### PR TITLE
Add master iCloud migration plan

### DIFF
--- a/plans/ICLOUD_ACCOUNTS_PLAN.md
+++ b/plans/ICLOUD_ACCOUNTS_PLAN.md
@@ -1,0 +1,365 @@
+# iCloud Migration — Accounts
+
+**Date:** 2026-04-08
+**Component:** Accounts (read, balance computation, ordering)
+**Parent plan:** [ICLOUD_MIGRATION_PLAN.md](./ICLOUD_MIGRATION_PLAN.md)
+
+## Overview
+
+Accounts are relatively simple in terms of CRUD (currently read-only via `AccountRepository`), but the key challenge is **balance computation**. The server computes account balances from the sum of transactions. In the iCloud backend, this must be done locally.
+
+---
+
+## Current Implementation
+
+### AccountRepository Protocol (`Domain/Repositories/AccountRepository.swift`)
+```swift
+protocol AccountRepository: Sendable {
+  func fetchAll() async throws -> [Account]
+}
+```
+
+Currently read-only. The `NATIVE_APP_PLAN.md` Step 13 plans to add `create`, `update`, and `delete` methods.
+
+### Account Domain Model (`Domain/Models/Account.swift`)
+```swift
+struct Account: Codable, Sendable, Identifiable, Hashable, Comparable {
+  let id: UUID
+  var name: String
+  var type: AccountType        // bank, creditCard, asset, investment
+  var balance: MonetaryAmount  // computed from transactions on server
+  var position: Int            // sort order
+  var isHidden: Bool
+}
+```
+
+### Server Behavior
+- `GET /api/accounts/` returns all accounts with pre-computed `balance`
+- Balance = sum of all non-scheduled transaction amounts for that account
+- For investments, server also returns `value` (latest market valuation); the DTO uses `value` if present, otherwise falls back to `balance`
+- Sorted by `position` ascending
+
+### AccountStore (`Features/Accounts/AccountStore.swift`)
+- Loads accounts via `repository.fetchAll()`
+- Provides computed properties: `currentAccounts`, `investmentAccounts`, `currentTotal`, `investmentTotal`, `netWorth`
+- `applyTransactionDelta(old:new:)` — optimistically adjusts balances locally when transactions change
+
+### Balance Computation Logic (from AccountStore)
+- Income: `accountId` balance += amount (amount is positive)
+- Expense: `accountId` balance += amount (amount is negative)
+- Transfer: `accountId` balance += amount (negative), `toAccountId` balance -= amount (positive effect)
+
+---
+
+## SwiftData Model
+
+### File: `Backends/CloudKit/Models/AccountRecord.swift`
+
+```swift
+import Foundation
+import SwiftData
+
+@Model
+final class AccountRecord {
+  #Unique<AccountRecord>([\.id])
+
+  @Attribute(.preserveValueOnDeletion)
+  var id: UUID
+
+  var name: String
+  var type: String       // raw value: "bank", "cc", "asset", "investment"
+  var position: Int
+  var isHidden: Bool
+
+  init(id: UUID, name: String, type: String, position: Int, isHidden: Bool) {
+    self.id = id
+    self.name = name
+    self.type = type
+    self.position = position
+    self.isHidden = isHidden
+  }
+}
+```
+
+### Key Decision: No Stored Balance
+
+The `AccountRecord` does **not** store `balance`. Rationale:
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **A: Compute on fetch** | Always correct; no sync issues | Slower — requires transaction query per account |
+| **B: Denormalized field** | Fast reads | Can become stale; sync conflicts; must update on every transaction change |
+
+**Recommendation: Option A (compute on fetch)** for correctness, with caching optimization if needed.
+
+- Balance is computed by summing `TransactionRecord` amounts where `accountId` or `toAccountId` matches
+- Only non-scheduled transactions contribute to balance (`recurPeriod == nil`)
+- This matches the server behavior exactly
+
+---
+
+## CloudKitAccountRepository
+
+### File: `Backends/CloudKit/Repositories/CloudKitAccountRepository.swift`
+
+```swift
+import Foundation
+import SwiftData
+import OSLog
+
+@ModelActor
+actor CloudKitAccountRepository: AccountRepository {
+  private let logger = Logger(subsystem: "com.moolah.app", category: "CloudKitAccountRepo")
+
+  func fetchAll() async throws -> [Account] {
+    // 1. Fetch all account records, sorted by position
+    var descriptor = FetchDescriptor<AccountRecord>(
+      sortBy: [SortDescriptor(\.position, order: .forward)]
+    )
+    let accountRecords = try modelContext.fetch(descriptor)
+
+    // 2. Fetch all non-scheduled transactions for balance computation
+    let txnDescriptor = FetchDescriptor<TransactionRecord>(
+      predicate: #Predicate<TransactionRecord> { $0.recurPeriod == nil }
+    )
+    let transactions = try modelContext.fetch(txnDescriptor)
+
+    // 3. Pre-compute balances by account ID
+    var balances: [UUID: Int] = [:]
+    for txn in transactions {
+      if let accountId = txn.accountId {
+        balances[accountId, default: 0] += txn.amount
+      }
+      if let toAccountId = txn.toAccountId {
+        // Transfers: the amount on the transaction is negative (debit from source).
+        // The destination receives the negated amount (credit).
+        balances[toAccountId, default: 0] -= txn.amount
+      }
+    }
+
+    // 4. Map to domain models with computed balances
+    return accountRecords.map { record in
+      let balanceCents = balances[record.id] ?? 0
+      return Account(
+        id: record.id,
+        name: record.name,
+        type: AccountType(rawValue: record.type) ?? .asset,
+        balance: MonetaryAmount(cents: balanceCents, currency: .defaultCurrency),
+        position: record.position,
+        isHidden: record.isHidden
+      )
+    }
+  }
+}
+```
+
+### Balance Computation Detail
+
+The balance calculation must match the server precisely. Based on the `AccountStore.applyTransactionDelta` logic:
+
+| Transaction Type | accountId Effect | toAccountId Effect |
+|-----------------|-----------------|-------------------|
+| Income | `+= amount` (positive) | N/A |
+| Expense | `+= amount` (negative) | N/A |
+| Transfer | `+= amount` (negative, debit) | `-= amount` (positive, credit) |
+
+The key insight: the `amount` field on a transaction already has the correct sign for the `accountId`. For `toAccountId` (transfer destination), negate the amount.
+
+### Excluding Scheduled Transactions
+
+Only non-scheduled transactions (where `recurPeriod == nil`) contribute to the actual balance. Scheduled transactions are future/projected and should not affect the current balance. The predicate `$0.recurPeriod == nil` handles this.
+
+---
+
+## Future CRUD Operations
+
+When Step 13 of `NATIVE_APP_PLAN.md` adds account management, the repository protocol will grow:
+
+```swift
+protocol AccountRepository: Sendable {
+  func fetchAll() async throws -> [Account]
+  func create(_ account: Account) async throws -> Account
+  func update(_ account: Account) async throws -> Account
+  func delete(id: UUID) async throws
+}
+```
+
+The CloudKit implementation is straightforward:
+
+```swift
+func create(_ account: Account) async throws -> Account {
+  let record = AccountRecord(
+    id: account.id,
+    name: account.name,
+    type: account.type.rawValue,
+    position: account.position,
+    isHidden: account.isHidden
+  )
+  modelContext.insert(record)
+  try modelContext.save()
+  return account  // balance will be 0 for new accounts
+}
+
+func update(_ account: Account) async throws -> Account {
+  let id = account.id
+  let descriptor = FetchDescriptor<AccountRecord>(
+    predicate: #Predicate { $0.id == id }
+  )
+  guard let record = try modelContext.fetch(descriptor).first else {
+    throw BackendError.serverError(404)
+  }
+  record.name = account.name
+  record.type = account.type.rawValue
+  record.position = account.position
+  record.isHidden = account.isHidden
+  try modelContext.save()
+  return account
+}
+
+func delete(id: UUID) async throws {
+  let descriptor = FetchDescriptor<AccountRecord>(
+    predicate: #Predicate { $0.id == id }
+  )
+  guard let record = try modelContext.fetch(descriptor).first else {
+    throw BackendError.serverError(404)
+  }
+  modelContext.delete(record)
+  try modelContext.save()
+}
+```
+
+---
+
+## CloudKit Sync Considerations
+
+### Conflict Resolution
+- Account metadata (name, type, position, hidden) uses last-writer-wins
+- This is acceptable — users rarely edit account properties simultaneously from multiple devices
+- Balance is not stored, so there's no balance conflict
+
+### Eventual Consistency
+- If a transaction syncs before an account record, the balance computation will include a transaction for a non-existent account — this is harmless (the balance entry is computed but no account displays it)
+- If an account syncs before its transactions, the account will show balance = 0 until transactions arrive — this is temporary and self-correcting
+
+### Position Reordering
+- If two devices reorder accounts simultaneously, last-writer-wins applies to each account's `position` field independently
+- This could result in duplicate positions — the sort is stable so no crash, but order may be surprising
+- Low-risk: simultaneous reordering from two devices is extremely unlikely for a single-user app
+
+---
+
+## Performance Considerations
+
+### Balance Computation Cost
+- Fetching ALL non-scheduled transactions on every `fetchAll()` is O(n) where n = total transaction count
+- For 10,000 transactions, this is a scan of ~10,000 records + integer summation — fast on modern hardware
+- SwiftData keeps an in-memory cache, so repeated fetches are fast
+
+### Optimization Strategies (if needed)
+1. **Cached balances:** Compute balances once on app launch, then update incrementally via `applyTransactionDelta()` (already done in `AccountStore`)
+2. **Denormalized balance field:** Store balance on `AccountRecord`, update on transaction changes. Adds complexity but eliminates the full-table scan.
+3. **Background computation:** Compute balances off the main actor, update UI when ready.
+
+**Recommendation:** Start with the simple approach. The `AccountStore` already caches balances and updates them incrementally — the full computation only happens on `load()` (app launch / pull-to-refresh).
+
+---
+
+## Domain Model Mapping
+
+### AccountRecord → Account
+```swift
+extension AccountRecord {
+  func toDomain(balanceCents: Int) -> Account {
+    Account(
+      id: id,
+      name: name,
+      type: AccountType(rawValue: type) ?? .asset,
+      balance: MonetaryAmount(cents: balanceCents, currency: .defaultCurrency),
+      position: position,
+      isHidden: isHidden
+    )
+  }
+}
+```
+
+### Account → AccountRecord
+```swift
+extension AccountRecord {
+  convenience init(from domain: Account) {
+    self.init(
+      id: domain.id,
+      name: domain.name,
+      type: domain.type.rawValue,
+      position: domain.position,
+      isHidden: domain.isHidden
+    )
+  }
+}
+```
+
+---
+
+## Testing Strategy
+
+### Contract Tests
+Run existing contract tests against `CloudKitAccountRepository` with an in-memory `ModelContainer`:
+
+```swift
+@Suite("CloudKitAccountRepository contract")
+struct CloudKitAccountRepositoryContractTests {
+  private func makeRepository() throws -> (
+    CloudKitAccountRepository, ModelContainer
+  ) {
+    let config = ModelConfiguration(isStoredInMemoryOnly: true)
+    let container = try ModelContainer(
+      for: AccountRecord.self, TransactionRecord.self,
+      configurations: config
+    )
+    return (CloudKitAccountRepository(modelContainer: container), container)
+  }
+
+  @Test("fetches accounts sorted by position")
+  func fetchSortedByPosition() async throws { ... }
+
+  @Test("computes balance from transactions")
+  func computesBalance() async throws { ... }
+
+  @Test("excludes scheduled transactions from balance")
+  func excludesScheduledFromBalance() async throws { ... }
+
+  @Test("transfer affects both accounts")
+  func transferAffectsBothAccounts() async throws { ... }
+}
+```
+
+### Specific Test Cases
+1. Empty accounts list returns `[]`
+2. Accounts sorted by position ascending
+3. Balance computed correctly for income, expense, and transfer transactions
+4. Scheduled transactions excluded from balance
+5. Account with no transactions has balance = 0
+6. Transfer transaction affects both source and destination balances
+7. Hidden accounts are still returned (UI filters them)
+
+---
+
+## Files to Create
+
+| File | Purpose |
+|------|---------|
+| `Backends/CloudKit/Models/AccountRecord.swift` | SwiftData `@Model` |
+| `Backends/CloudKit/Repositories/CloudKitAccountRepository.swift` | Repository implementation |
+| `MoolahTests/Backends/CloudKitAccountRepositoryTests.swift` | Contract + balance tests |
+
+---
+
+## Estimated Effort
+
+| Task | Estimate |
+|------|----------|
+| `AccountRecord` model | 30 minutes |
+| Domain ↔ Record mapping | 30 minutes |
+| `fetchAll()` with balance computation | 2 hours |
+| Future CRUD stubs | 1 hour |
+| Tests | 2 hours |
+| **Total** | **~6 hours** |

--- a/plans/ICLOUD_AUTH_PLAN.md
+++ b/plans/ICLOUD_AUTH_PLAN.md
@@ -1,0 +1,325 @@
+# iCloud Migration — Authentication & User Identity
+
+**Date:** 2026-04-08
+**Component:** Authentication
+**Parent plan:** [ICLOUD_MIGRATION_PLAN.md](./ICLOUD_MIGRATION_PLAN.md)
+
+## Overview
+
+Replace Google OAuth (via `RemoteAuthProvider`) with implicit iCloud identity (via `CloudKitAuthProvider`). This is the simplest component in the migration — iCloud authentication is handled at the OS level, so the app just needs to verify iCloud availability and retrieve user identity.
+
+---
+
+## Current Implementation
+
+### RemoteAuthProvider (`Backends/Remote/Auth/RemoteAuthProvider.swift`)
+- `requiresExplicitSignIn = true` — user must tap "Sign in with Google"
+- `currentUser()` — calls `GET /api/auth/`, restores session cookies from Keychain
+- `signIn()` — opens Google OAuth URL in browser, polls `POST /api/auth/token` every 2s for up to 5 minutes
+- `signOut()` — calls `DELETE /api/auth/`, clears cookies from Keychain and HTTPCookieStorage
+
+### AuthProvider Protocol (`Domain/Repositories/AuthProvider.swift`)
+```swift
+protocol AuthProvider: Sendable {
+  var requiresExplicitSignIn: Bool { get }
+  func currentUser() async throws -> UserProfile?
+  func signIn() async throws -> UserProfile
+  func signOut() async throws
+}
+```
+
+### UserProfile (`Domain/Models/UserProfile.swift`)
+```swift
+struct UserProfile: Codable, Sendable, Equatable {
+  let id: String          // "google-{google_id}" in current impl
+  let givenName: String
+  let familyName: String
+  let pictureURL: URL?
+}
+```
+
+### UI Behavior
+- `WelcomeView` checks `requiresExplicitSignIn` — if `false`, it skips the sign-in button entirely
+- `AuthStore` calls `currentUser()` on launch → routes to `.signedIn` or `.signedOut`
+- `AppRootView` switches on auth state
+
+---
+
+## CloudKitAuthProvider Design
+
+### File Location
+`Backends/CloudKit/Auth/CloudKitAuthProvider.swift`
+
+### Implementation
+
+```swift
+import CloudKit
+import Foundation
+import OSLog
+
+final class CloudKitAuthProvider: AuthProvider, @unchecked Sendable {
+  nonisolated let requiresExplicitSignIn = false
+
+  private let container: CKContainer
+  private let logger = Logger(subsystem: "com.moolah.app", category: "CloudKitAuth")
+
+  init(container: CKContainer = .default()) {
+    self.container = container
+  }
+
+  func currentUser() async throws -> UserProfile? {
+    // Check if iCloud is available
+    guard FileManager.default.ubiquityIdentityToken != nil else {
+      logger.info("iCloud not available")
+      return nil
+    }
+
+    do {
+      let userRecordID = try await container.userRecordID()
+      return UserProfile(
+        id: "icloud-\(userRecordID.recordName)",
+        givenName: "iCloud",
+        familyName: "User",
+        pictureURL: nil
+      )
+    } catch {
+      logger.error("Failed to get iCloud user record: \(error.localizedDescription)")
+      return nil
+    }
+  }
+
+  func signIn() async throws -> UserProfile {
+    guard FileManager.default.ubiquityIdentityToken != nil else {
+      throw BackendError.unauthenticated
+    }
+
+    do {
+      let userRecordID = try await container.userRecordID()
+      return UserProfile(
+        id: "icloud-\(userRecordID.recordName)",
+        givenName: "iCloud",
+        familyName: "User",
+        pictureURL: nil
+      )
+    } catch {
+      logger.error("iCloud sign-in failed: \(error.localizedDescription)")
+      throw BackendError.unauthenticated
+    }
+  }
+
+  func signOut() async throws {
+    // No-op: iCloud sign-out is managed at the OS level (Settings > Apple ID).
+    // The app cannot programmatically sign the user out of iCloud.
+    logger.info("signOut called — no-op for iCloud auth")
+  }
+}
+```
+
+### Key Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| `requiresExplicitSignIn` | `false` | iCloud is always available if signed in at OS level |
+| User identity | `CKContainer.userRecordID()` | Stable per-user identifier across devices |
+| Profile name | "iCloud User" (placeholder) | CloudKit doesn't expose the user's real name without `discoverUserIdentity` permission |
+| Sign out | No-op | Cannot sign out of iCloud programmatically |
+| Error handling | Return `nil` from `currentUser()` | If iCloud is unavailable, treat as signed out |
+
+---
+
+## User Profile Considerations
+
+### The Name Problem
+
+CloudKit does not freely expose the iCloud user's real name. Options:
+
+1. **Use `CKContainer.discoverUserIdentity(byUserRecordID:)`** — requires the user to grant "Look Me Up" permission in iCloud settings. May return the name but is not guaranteed.
+
+2. **Use device owner name** — `UIDevice.current.name` (iOS) contains the device name (e.g., "Adrian's iPhone"), not reliably the user's name.
+
+3. **Use a hardcoded placeholder** — "iCloud User" or similar. Since this is a single-user app, the name is only displayed in the user menu.
+
+4. **Store a user-editable display name** — let the user set their name once in app settings, store it in SwiftData.
+
+**Recommendation:** Option 4 (user-editable name) with Option 3 as default. The `UserProfile` returned by `currentUser()` uses "iCloud User" initially. A future settings screen can let the user customize their display name.
+
+### Profile Picture
+
+CloudKit does not provide a user profile picture. Options:
+- Set `pictureURL` to `nil` (current `UserMenuView` already handles this with a fallback icon)
+- Use SF Symbols person icon (already the fallback)
+
+**Recommendation:** `pictureURL = nil`. The UI already handles this gracefully.
+
+---
+
+## iCloud Availability Checking
+
+### Primary Check: `FileManager.default.ubiquityIdentityToken`
+- Returns a non-nil opaque token if the user is signed into iCloud
+- Fast, synchronous check
+- Does not require CloudKit entitlements for the check itself
+
+### Secondary Check: `CKContainer.accountStatus()`
+- Returns `.available`, `.noAccount`, `.restricted`, `.couldNotDetermine`, `.temporarilyUnavailable`
+- Async call
+- More detailed than `ubiquityIdentityToken`
+
+### Notification: `NSUbiquityIdentityDidChange`
+- Posted when the user signs in/out of iCloud while the app is running
+- `AuthStore` should observe this to update auth state reactively
+
+### Implementation Strategy
+
+```swift
+// In CloudKitAuthProvider
+func currentUser() async throws -> UserProfile? {
+  // Fast check first
+  guard FileManager.default.ubiquityIdentityToken != nil else { return nil }
+
+  // Verify CloudKit container access
+  let status = try await container.accountStatus()
+  guard status == .available else {
+    logger.warning("iCloud account status: \(String(describing: status))")
+    return nil
+  }
+
+  let userRecordID = try await container.userRecordID()
+  return makeProfile(from: userRecordID)
+}
+```
+
+### Error States
+
+| Condition | Behavior |
+|-----------|----------|
+| iCloud not signed in | `currentUser()` returns `nil` → AuthStore shows error prompt |
+| iCloud restricted (parental controls) | `currentUser()` returns `nil` → show specific error |
+| Network unavailable | `userRecordID()` may throw → return cached profile or nil |
+| iCloud temporarily unavailable | Return cached profile if available |
+
+---
+
+## UI Changes
+
+### WelcomeView
+No changes needed. The view already checks `requiresExplicitSignIn`:
+- When `false`, it auto-attempts sign-in without showing a button
+- The `AuthStore.checkAuthState()` flow calls `currentUser()` on launch
+
+### UserMenuView
+Minor change needed:
+- Currently shows "Sign Out" button
+- For iCloud auth, either hide the sign-out button or show "Manage in Settings" since sign-out is a no-op
+- Check `backend.auth.requiresExplicitSignIn` — if `false`, hide sign-out action
+
+### AppRootView
+No changes needed — already switches on `AuthStore.state`.
+
+### New: iCloud Unavailable View
+Create a view shown when iCloud is not available:
+```swift
+struct ICloudUnavailableView: View {
+  var body: some View {
+    ContentUnavailableView(
+      "iCloud Required",
+      systemImage: "icloud.slash",
+      description: Text("Sign in to iCloud in Settings to use Moolah.")
+    )
+  }
+}
+```
+
+---
+
+## Testing Strategy
+
+### Contract Tests
+The existing `AuthContractTests` test `InMemoryAuthProvider`. Add a new suite for `CloudKitAuthProvider`:
+
+```swift
+@Suite("CloudKitAuthProvider")
+struct CloudKitAuthProviderTests {
+  @Test("requiresExplicitSignIn is false")
+  func requiresExplicit() {
+    let provider = CloudKitAuthProvider()
+    #expect(provider.requiresExplicitSignIn == false)
+  }
+
+  @Test("signOut is a no-op")
+  func signOutNoOp() async throws {
+    let provider = CloudKitAuthProvider()
+    // Should not throw
+    try await provider.signOut()
+  }
+}
+```
+
+### Testability Challenge
+`CKContainer` is not easily mockable. Options:
+1. **Protocol wrapper** — define `CloudKitContainerProtocol` with `userRecordID()` and `accountStatus()`, make `CKContainer` conform via extension, inject mock in tests
+2. **Integration tests only** — test against real CloudKit in CI (requires iCloud-signed-in Mac)
+3. **Test via InMemoryAuthProvider** — the contract tests already validate behavior; CloudKitAuthProvider is thin enough to verify manually
+
+**Recommendation:** Option 1 for unit tests. The protocol wrapper is small:
+
+```swift
+protocol CloudKitContainerProtocol: Sendable {
+  func userRecordID() async throws -> CKRecord.ID
+  func accountStatus() async throws -> CKAccountStatus
+}
+
+extension CKContainer: CloudKitContainerProtocol {}
+```
+
+---
+
+## Migration Considerations
+
+### Identity Transition
+- The user's `UserProfile.id` changes from `"google-{id}"` to `"icloud-{recordName}"`
+- This is acceptable because the user ID is only used for display, not as a foreign key in data models
+- Transactions, accounts, etc. do not reference the user ID — they're implicitly scoped to the CloudKit private database
+
+### Session Cleanup
+During migration:
+1. Export data from server (while still authenticated with Google OAuth)
+2. Import data to SwiftData/CloudKit
+3. Switch `BackendProvider` to `CloudKitBackend`
+4. Clear Google OAuth cookies from Keychain (`CookieKeychain.clear()`)
+5. Old `RemoteAuthProvider` code can be removed once migration is complete
+
+### No Dual-Auth Period
+The migration is a one-shot operation. The user is either on RemoteBackend or CloudKitBackend, never both simultaneously.
+
+---
+
+## Files to Create
+
+| File | Purpose |
+|------|---------|
+| `Backends/CloudKit/Auth/CloudKitAuthProvider.swift` | AuthProvider implementation |
+| `Backends/CloudKit/Auth/CloudKitContainerProtocol.swift` | Testability protocol wrapper |
+| `Features/Auth/ICloudUnavailableView.swift` | Error view when iCloud is not available |
+| `MoolahTests/Backends/CloudKitAuthProviderTests.swift` | Unit tests |
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `Features/Auth/UserMenuView.swift` | Hide sign-out when `requiresExplicitSignIn == false` |
+| `Features/Auth/AuthStore.swift` | Observe `NSUbiquityIdentityDidChange` notification |
+
+---
+
+## Estimated Effort
+
+| Task | Estimate |
+|------|----------|
+| `CloudKitAuthProvider` implementation | 2 hours |
+| Protocol wrapper for testability | 1 hour |
+| `ICloudUnavailableView` | 30 minutes |
+| `UserMenuView` sign-out hiding | 30 minutes |
+| `AuthStore` iCloud notification observer | 1 hour |
+| Tests | 1 hour |
+| **Total** | **~6 hours** |

--- a/plans/ICLOUD_CATEGORIES_PLAN.md
+++ b/plans/ICLOUD_CATEGORIES_PLAN.md
@@ -1,0 +1,265 @@
+# iCloud Migration — Categories
+
+**Date:** 2026-04-08
+**Component:** Categories (hierarchical CRUD)
+**Parent plan:** [ICLOUD_MIGRATION_PLAN.md](./ICLOUD_MIGRATION_PLAN.md)
+
+## Overview
+
+Categories are the simplest data component — flat records with an optional `parentId` for hierarchy, and straightforward CRUD. The main complexity is deletion with replacement (re-parenting children).
+
+---
+
+## Current Implementation
+
+### CategoryRepository Protocol (`Domain/Repositories/CategoryRepository.swift`)
+```swift
+protocol CategoryRepository: Sendable {
+  func fetchAll() async throws -> [Category]
+  func create(_ category: Category) async throws -> Category
+  func update(_ category: Category) async throws -> Category
+  func delete(id: UUID, withReplacement replacementId: UUID?) async throws
+}
+```
+
+### Category Domain Model (`Domain/Models/Category.swift`)
+```swift
+struct Category: Codable, Sendable, Identifiable, Hashable {
+  let id: UUID
+  var name: String
+  var parentId: UUID?
+}
+```
+
+### Categories Lookup Structure
+```swift
+struct Categories: Sendable {
+  var roots: [Category]                     // top-level (parentId == nil), sorted by name
+  func children(of parentId: UUID) -> [Category]  // children of a parent, sorted by name
+  func by(id: UUID) -> Category?
+}
+```
+
+### Server Behavior (from InMemoryCategoryRepository)
+- `fetchAll()` — returns all categories sorted by name
+- `create(_:)` — inserts category (client generates UUID)
+- `update(_:)` — updates name and/or parentId
+- `delete(id:withReplacement:)`:
+  - If `replacementId` is provided: re-parent all children to `replacementId`
+  - If `nil`: orphan all children (set their `parentId` to `nil`)
+  - Then delete the category itself
+
+---
+
+## SwiftData Model
+
+### File: `Backends/CloudKit/Models/CategoryRecord.swift`
+
+```swift
+import Foundation
+import SwiftData
+
+@Model
+final class CategoryRecord {
+  #Unique<CategoryRecord>([\.id])
+
+  @Attribute(.preserveValueOnDeletion)
+  var id: UUID
+
+  var name: String
+  var parentId: UUID?
+
+  init(id: UUID, name: String, parentId: UUID? = nil) {
+    self.id = id
+    self.name = name
+    self.parentId = parentId
+  }
+}
+```
+
+### Design Decision: UUID FK vs SwiftData Relationship
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **UUID `parentId`** | Simple, CloudKit-friendly, matches domain model | No cascade delete, manual orphan logic |
+| **SwiftData `@Relationship`** | Automatic cascade, type-safe navigation | CloudKit sync complications, self-referencing relationships are tricky |
+
+**Recommendation: UUID `parentId`** — matches the domain model exactly, avoids CloudKit relationship sync issues, and the orphan/re-parent logic is simple (4 lines of code in `InMemoryCategoryRepository`).
+
+---
+
+## CloudKitCategoryRepository
+
+### File: `Backends/CloudKit/Repositories/CloudKitCategoryRepository.swift`
+
+```swift
+import Foundation
+import SwiftData
+import OSLog
+
+@ModelActor
+actor CloudKitCategoryRepository: CategoryRepository {
+  private let logger = Logger(subsystem: "com.moolah.app", category: "CloudKitCategoryRepo")
+
+  func fetchAll() async throws -> [Category] {
+    let descriptor = FetchDescriptor<CategoryRecord>(
+      sortBy: [SortDescriptor(\.name, order: .forward)]
+    )
+    let records = try modelContext.fetch(descriptor)
+    return records.map { $0.toDomain() }
+  }
+
+  func create(_ category: Category) async throws -> Category {
+    let record = CategoryRecord(
+      id: category.id,
+      name: category.name,
+      parentId: category.parentId
+    )
+    modelContext.insert(record)
+    try modelContext.save()
+    return category
+  }
+
+  func update(_ category: Category) async throws -> Category {
+    let id = category.id
+    let descriptor = FetchDescriptor<CategoryRecord>(
+      predicate: #Predicate { $0.id == id }
+    )
+    guard let record = try modelContext.fetch(descriptor).first else {
+      throw BackendError.serverError(404)
+    }
+    record.name = category.name
+    record.parentId = category.parentId
+    try modelContext.save()
+    return category
+  }
+
+  func delete(id: UUID, withReplacement replacementId: UUID?) async throws {
+    // Find the category to delete
+    let descriptor = FetchDescriptor<CategoryRecord>(
+      predicate: #Predicate { $0.id == id }
+    )
+    guard let record = try modelContext.fetch(descriptor).first else {
+      throw BackendError.serverError(404)
+    }
+
+    // Re-parent children
+    let childDescriptor = FetchDescriptor<CategoryRecord>(
+      predicate: #Predicate<CategoryRecord> { $0.parentId == id }
+    )
+    let children = try modelContext.fetch(childDescriptor)
+    for child in children {
+      child.parentId = replacementId
+    }
+
+    // Delete the category
+    modelContext.delete(record)
+    try modelContext.save()
+  }
+}
+```
+
+---
+
+## Domain Model Mapping
+
+```swift
+extension CategoryRecord {
+  func toDomain() -> Category {
+    Category(id: id, name: name, parentId: parentId)
+  }
+}
+```
+
+---
+
+## Hierarchy Handling
+
+The `Categories` struct (in `Domain/Models/Category.swift`) builds the tree from a flat list. This is already implemented in the domain layer and works with any flat `[Category]` array. No changes needed.
+
+### Edge Case: Partial Sync
+
+If CloudKit syncs a child category before its parent:
+- The child's `parentId` references a UUID that doesn't exist locally yet
+- `Categories.children(of:)` will not find the child (it's looking under the parent)
+- `Categories.roots` will not include it (its `parentId` is not nil)
+- **Result:** The category is temporarily invisible
+
+**Mitigation options:**
+1. **Treat orphaned children as roots** — if `parentId` is set but the parent doesn't exist in the local set, treat as a root. This requires a small change to `Categories.init(from:)`.
+2. **Accept temporary invisibility** — CloudKit sync is typically fast; the category will appear once the parent syncs.
+
+**Recommendation:** Option 2 for now (keep it simple). Option 1 can be added if users report issues.
+
+---
+
+## CloudKit Sync Considerations
+
+### Conflicts
+- Name change from two devices: last-writer-wins, acceptable
+- Parent change from two devices: last-writer-wins, acceptable
+- Simultaneous create: both categories will sync (different UUIDs), no conflict
+
+### Deletion
+- If device A deletes a category while device B creates a child under it:
+  - Device A's delete syncs, removing the parent
+  - Device B's child has a dangling `parentId`
+  - This is the same "orphaned child" case as partial sync — handled identically
+
+### Transactions Referencing Deleted Categories
+- Transactions have a `categoryId` field. If a category is deleted, transactions still reference the old UUID.
+- The server handles this by simply leaving the reference dangling (the web app shows "Uncategorized" if the categoryId doesn't resolve).
+- The native app should do the same — `Categories.by(id:)` returns `nil` for deleted categories, and the UI already handles this.
+
+---
+
+## Testing Strategy
+
+### Contract Tests
+Run existing `CategoryRepositoryContractTests` against `CloudKitCategoryRepository`:
+
+```swift
+@Suite("CloudKitCategoryRepository contract")
+struct CloudKitCategoryRepositoryContractTests {
+  private func makeRepository() throws -> CloudKitCategoryRepository {
+    let config = ModelConfiguration(isStoredInMemoryOnly: true)
+    let container = try ModelContainer(
+      for: CategoryRecord.self,
+      configurations: config
+    )
+    return CloudKitCategoryRepository(modelContainer: container)
+  }
+}
+```
+
+### Test Cases
+1. `fetchAll()` returns categories sorted by name
+2. `create()` inserts and returns the category
+3. `update()` changes name and/or parentId
+4. `delete()` with no replacement orphans children (parentId → nil)
+5. `delete()` with replacement re-parents children
+6. `delete()` throws 404 for non-existent category
+7. `update()` throws 404 for non-existent category
+8. Hierarchy: parent-child relationships preserved through CRUD cycle
+
+---
+
+## Files to Create
+
+| File | Purpose |
+|------|---------|
+| `Backends/CloudKit/Models/CategoryRecord.swift` | SwiftData `@Model` |
+| `Backends/CloudKit/Repositories/CloudKitCategoryRepository.swift` | Repository implementation |
+| `MoolahTests/Backends/CloudKitCategoryRepositoryTests.swift` | Contract tests |
+
+---
+
+## Estimated Effort
+
+| Task | Estimate |
+|------|----------|
+| `CategoryRecord` model | 30 minutes |
+| `CloudKitCategoryRepository` full CRUD | 2 hours |
+| Deletion with replacement logic | 30 minutes |
+| Tests | 1.5 hours |
+| **Total** | **~4.5 hours** |

--- a/plans/ICLOUD_DATA_MIGRATION_PLAN.md
+++ b/plans/ICLOUD_DATA_MIGRATION_PLAN.md
@@ -1,0 +1,798 @@
+# iCloud Migration — Data Migration from moolah-server
+
+**Date:** 2026-04-08
+**Component:** Data Migration
+**Parent plan:** [ICLOUD_MIGRATION_PLAN.md](./ICLOUD_MIGRATION_PLAN.md)
+
+## Overview
+
+This plan describes the one-time migration of existing user data from the moolah-server REST API to the local SwiftData/CloudKit storage. This is the **highest-risk** part of the iCloud migration — data loss or corruption during migration would be unacceptable for a financial application.
+
+---
+
+## User Experience Flow
+
+### Happy Path
+1. User opens the app (currently signed in via Google OAuth to moolah-server)
+2. App detects this is the first launch with iCloud backend available
+3. App shows **"Migrate to iCloud"** screen explaining the change
+4. User taps **"Start Migration"**
+5. Progress indicator shows: "Downloading accounts... categories... earmarks... transactions (page 1 of N)..."
+6. Progress indicator shows: "Saving to iCloud..."
+7. **"Migration Complete"** screen with summary (X accounts, Y transactions, etc.)
+8. User taps **"Continue"** → app switches to CloudKit backend
+9. Old session cookies are cleared
+
+### Error Path
+1. Migration fails at any step → error screen with details
+2. User can tap **"Retry"** to restart from the beginning
+3. All partial imports are rolled back (SwiftData context discarded without saving)
+4. User can also tap **"Skip for Now"** to continue using the server backend
+
+### No Data Path
+- User has no data on the server (fresh account)
+- Migration completes instantly with "0 items migrated"
+- App switches to CloudKit backend
+
+---
+
+## Architecture
+
+### Code Structure
+
+```
+Backends/CloudKit/Migration/
+├── ServerDataExporter.swift      # Fetches all data from REST API
+├── CloudKitDataImporter.swift    # Writes data to SwiftData
+└── MigrationCoordinator.swift    # Orchestrates the full flow
+
+Features/Migration/
+├── MigrationView.swift           # Migration UI
+└── MigrationStore.swift          # @Observable state management
+```
+
+### Component Responsibilities
+
+| Component | Input | Output |
+|-----------|-------|--------|
+| `ServerDataExporter` | Authenticated `APIClient` | `ExportedData` struct |
+| `CloudKitDataImporter` | `ExportedData` + `ModelContext` | Imported record counts |
+| `MigrationCoordinator` | Both of the above | Success/failure result |
+
+---
+
+## Phase 1: Export from Server
+
+### ServerDataExporter
+
+```swift
+struct ExportedData: Sendable {
+  let accounts: [Account]
+  let categories: [Category]
+  let earmarks: [Earmark]
+  let earmarkBudgets: [UUID: [EarmarkBudgetItem]]  // keyed by earmarkId
+  let transactions: [Transaction]
+}
+
+actor ServerDataExporter {
+  private let accountRepo: AccountRepository
+  private let categoryRepo: CategoryRepository
+  private let earmarkRepo: EarmarkRepository
+  private let transactionRepo: TransactionRepository
+
+  enum ExportProgress: Sendable {
+    case downloading(step: String)
+    case downloadComplete(ExportedData)
+    case failed(Error)
+  }
+
+  func export(
+    progress: @escaping @Sendable (ExportProgress) -> Void
+  ) async throws -> ExportedData {
+    // 1. Accounts (single request)
+    progress(.downloading(step: "accounts"))
+    let accounts = try await accountRepo.fetchAll()
+
+    // 2. Categories (single request)
+    progress(.downloading(step: "categories"))
+    let categories = try await categoryRepo.fetchAll()
+
+    // 3. Earmarks + budgets
+    progress(.downloading(step: "earmarks"))
+    let earmarks = try await earmarkRepo.fetchAll()
+    var budgets: [UUID: [EarmarkBudgetItem]] = [:]
+    for earmark in earmarks {
+      budgets[earmark.id] = try await earmarkRepo.fetchBudget(earmarkId: earmark.id)
+    }
+
+    // 4. Transactions (paginated — may require many requests)
+    progress(.downloading(step: "transactions"))
+    let transactions = try await fetchAllTransactions()
+
+    let data = ExportedData(
+      accounts: accounts,
+      categories: categories,
+      earmarks: earmarks,
+      earmarkBudgets: budgets,
+      transactions: transactions
+    )
+    progress(.downloadComplete(data))
+    return data
+  }
+
+  private func fetchAllTransactions() async throws -> [Transaction] {
+    var allTransactions: [Transaction] = []
+    var page = 0
+    let pageSize = 200  // larger pages for bulk export
+
+    while true {
+      // Fetch ALL transactions (no filter) including scheduled
+      let result = try await transactionRepo.fetch(
+        filter: TransactionFilter(),
+        page: page,
+        pageSize: pageSize
+      )
+      allTransactions.append(contentsOf: result.transactions)
+
+      if result.transactions.count < pageSize {
+        break  // last page
+      }
+      page += 1
+    }
+
+    // Also fetch scheduled transactions explicitly
+    // (the default filter may exclude them)
+    var scheduledPage = 0
+    while true {
+      let result = try await transactionRepo.fetch(
+        filter: TransactionFilter(scheduled: true),
+        page: scheduledPage,
+        pageSize: pageSize
+      )
+
+      // Add only transactions we haven't seen
+      let existingIds = Set(allTransactions.map(\.id))
+      let newTransactions = result.transactions.filter { !existingIds.contains($0.id) }
+      allTransactions.append(contentsOf: newTransactions)
+
+      if result.transactions.count < pageSize {
+        break
+      }
+      scheduledPage += 1
+    }
+
+    return allTransactions
+  }
+}
+```
+
+### Pagination Handling
+
+The server returns transactions in pages. A user with thousands of transactions may require dozens of requests. Key considerations:
+
+- **Page size:** Use 200 (larger than the default 50) to minimize round-trips
+- **Completeness check:** `transactions.count < pageSize` indicates the last page
+- **Scheduled transactions:** Fetch separately with `scheduled: true` filter to ensure none are missed (the default fetch without `scheduled` filter returns all transactions on the server, but verify this)
+- **Deduplication:** Use a `Set<UUID>` to avoid duplicates if both fetches return the same transactions
+
+### Error Handling During Export
+
+- **Network error on any request:** Throw `MigrationError.exportFailed(step, underlyingError)`
+- **Authentication error:** User's Google session may have expired — show re-auth prompt
+- **Retry logic:** The coordinator handles retry at the top level; individual requests use the existing `APIClient` error handling
+
+---
+
+## Phase 2: Import to SwiftData
+
+### CloudKitDataImporter
+
+```swift
+struct ImportResult: Sendable {
+  let accountCount: Int
+  let categoryCount: Int
+  let earmarkCount: Int
+  let budgetItemCount: Int
+  let transactionCount: Int
+}
+
+actor CloudKitDataImporter {
+  private let modelContainer: ModelContainer
+
+  enum ImportProgress: Sendable {
+    case importing(step: String, current: Int, total: Int)
+    case importComplete(ImportResult)
+    case failed(Error)
+  }
+
+  func importData(
+    _ data: ExportedData,
+    progress: @escaping @Sendable (ImportProgress) -> Void
+  ) async throws -> ImportResult {
+    let context = ModelContext(modelContainer)
+
+    // Order matters for referential integrity (though we use UUIDs, not relationships)
+
+    // 1. Categories (no dependencies)
+    progress(.importing(step: "categories", current: 0, total: data.categories.count))
+    for (i, category) in data.categories.enumerated() {
+      let record = CategoryRecord(
+        id: category.id,
+        name: category.name,
+        parentId: category.parentId
+      )
+      context.insert(record)
+      if i % 50 == 0 {
+        progress(.importing(step: "categories", current: i, total: data.categories.count))
+      }
+    }
+
+    // 2. Accounts (no dependencies)
+    progress(.importing(step: "accounts", current: 0, total: data.accounts.count))
+    for account in data.accounts {
+      let record = AccountRecord(
+        id: account.id,
+        name: account.name,
+        type: account.type.rawValue,
+        position: account.position,
+        isHidden: account.isHidden
+      )
+      context.insert(record)
+    }
+
+    // 3. Earmarks (no dependencies)
+    progress(.importing(step: "earmarks", current: 0, total: data.earmarks.count))
+    for earmark in data.earmarks {
+      let record = EarmarkRecord(
+        id: earmark.id,
+        name: earmark.name,
+        position: earmark.position,
+        isHidden: earmark.isHidden,
+        savingsTarget: earmark.savingsGoal?.cents,
+        savingsStartDate: earmark.savingsStartDate,
+        savingsEndDate: earmark.savingsEndDate
+      )
+      context.insert(record)
+    }
+
+    // 4. Earmark budget items
+    var budgetItemCount = 0
+    for (earmarkId, items) in data.earmarkBudgets {
+      for item in items {
+        let record = EarmarkBudgetItemRecord(
+          id: item.id,
+          earmarkId: earmarkId,
+          categoryId: item.categoryId,
+          amount: item.amount.cents
+        )
+        context.insert(record)
+        budgetItemCount += 1
+      }
+    }
+
+    // 5. Transactions (largest dataset — batch insert with progress)
+    let totalTxns = data.transactions.count
+    progress(.importing(step: "transactions", current: 0, total: totalTxns))
+    for (i, txn) in data.transactions.enumerated() {
+      let record = TransactionRecord(
+        id: txn.id,
+        type: txn.type.rawValue,
+        date: txn.date,
+        accountId: txn.accountId,
+        toAccountId: txn.toAccountId,
+        amount: txn.amount.cents,
+        payee: txn.payee,
+        notes: txn.notes,
+        categoryId: txn.categoryId,
+        earmarkId: txn.earmarkId,
+        recurPeriod: txn.recurPeriod?.rawValue,
+        recurEvery: txn.recurEvery
+      )
+      context.insert(record)
+
+      if i % 100 == 0 {
+        progress(.importing(step: "transactions", current: i, total: totalTxns))
+      }
+    }
+
+    // 6. Save all at once (atomic)
+    progress(.importing(step: "saving", current: 0, total: 1))
+    try context.save()
+
+    let result = ImportResult(
+      accountCount: data.accounts.count,
+      categoryCount: data.categories.count,
+      earmarkCount: data.earmarks.count,
+      budgetItemCount: budgetItemCount,
+      transactionCount: data.transactions.count
+    )
+    progress(.importComplete(result))
+    return result
+  }
+}
+```
+
+### Import Order
+
+```
+1. Categories    (referenced by transactions, earmark budgets)
+2. Accounts      (referenced by transactions)
+3. Earmarks      (referenced by transactions, budget items)
+4. Budget Items  (references earmarks + categories)
+5. Transactions  (references accounts, categories, earmarks)
+```
+
+Since we use UUID foreign keys (not SwiftData relationships), the order is technically irrelevant — but importing in dependency order makes verification easier.
+
+### Preserving UUIDs
+
+**Critical:** All UUIDs from the server must be preserved exactly. The `id` fields on imported records must match the server's `id` values. This ensures:
+- Transaction → Account references remain valid
+- Transaction → Category references remain valid
+- Transaction → Earmark references remain valid
+- Category parent → child references remain valid
+- Earmark → Budget item references remain valid
+
+The domain models already use `UUID` for IDs, and the import code passes them through directly.
+
+### Batch Saving
+
+All records are inserted into a single `ModelContext` and saved once at the end. This is:
+- **Atomic:** Either all data is saved or none is
+- **Efficient:** Single write transaction to SQLite
+- **Safe:** If any insertion fails, nothing is persisted
+
+For very large datasets (10,000+ transactions), memory usage during the batch insert may be a concern. If needed, batch in groups of 1,000 with intermediate saves — but this sacrifices atomicity.
+
+---
+
+## Phase 3: Verification
+
+### Post-Migration Checks
+
+```swift
+struct MigrationVerifier {
+  func verify(
+    exported: ExportedData,
+    modelContainer: ModelContainer
+  ) async throws -> VerificationResult {
+    let context = ModelContext(modelContainer)
+
+    // 1. Record counts
+    let accountCount = try context.fetchCount(FetchDescriptor<AccountRecord>())
+    let categoryCount = try context.fetchCount(FetchDescriptor<CategoryRecord>())
+    let earmarkCount = try context.fetchCount(FetchDescriptor<EarmarkRecord>())
+    let txnCount = try context.fetchCount(FetchDescriptor<TransactionRecord>())
+
+    let countMatch = accountCount == exported.accounts.count
+      && categoryCount == exported.categories.count
+      && earmarkCount == exported.earmarks.count
+      && txnCount == exported.transactions.count
+
+    // 2. Account balance verification
+    // Compute balances locally and compare with server-provided balances
+    var balanceMismatches: [(accountName: String, serverBalance: Int, localBalance: Int)] = []
+    let allTxns = try context.fetch(FetchDescriptor<TransactionRecord>())
+
+    for account in exported.accounts {
+      let localBalance = allTxns
+        .filter { $0.recurPeriod == nil }  // exclude scheduled
+        .reduce(0) { sum, txn in
+          var delta = 0
+          if txn.accountId == account.id { delta += txn.amount }
+          if txn.toAccountId == account.id { delta -= txn.amount }
+          return sum + delta
+        }
+
+      if localBalance != account.balance.cents {
+        balanceMismatches.append((
+          accountName: account.name,
+          serverBalance: account.balance.cents,
+          localBalance: localBalance
+        ))
+      }
+    }
+
+    return VerificationResult(
+      countMatch: countMatch,
+      expectedCounts: (
+        accounts: exported.accounts.count,
+        categories: exported.categories.count,
+        earmarks: exported.earmarks.count,
+        transactions: exported.transactions.count
+      ),
+      actualCounts: (
+        accounts: accountCount,
+        categories: categoryCount,
+        earmarks: earmarkCount,
+        transactions: txnCount
+      ),
+      balanceMismatches: balanceMismatches
+    )
+  }
+}
+```
+
+### What to Verify
+
+| Check | How | Acceptable Difference |
+|-------|-----|----------------------|
+| Account count | `fetchCount` vs exported count | Must match exactly |
+| Category count | `fetchCount` vs exported count | Must match exactly |
+| Earmark count | `fetchCount` vs exported count | Must match exactly |
+| Transaction count | `fetchCount` vs exported count | Must match exactly |
+| Account balances | Local computation vs server balance | Must match exactly |
+| Earmark balances | Local computation vs server balance | Must match (within rounding) |
+
+### Balance Mismatch Handling
+
+If balances don't match:
+- Log the mismatches for debugging
+- Show a warning to the user (not a blocker)
+- Likely causes: scheduled transaction inclusion/exclusion differences, or transfer amount sign conventions
+- The local computation is authoritative going forward — the server balance is just a verification check
+
+---
+
+## Phase 4: Switchover
+
+### MigrationCoordinator
+
+```swift
+@Observable
+@MainActor
+final class MigrationCoordinator {
+  enum State: Sendable {
+    case idle
+    case exporting(step: String)
+    case importing(step: String, progress: Double)
+    case verifying
+    case succeeded(ImportResult)
+    case failed(MigrationError)
+  }
+
+  private(set) var state: State = .idle
+
+  func migrate(
+    from remoteBackend: RemoteBackend,
+    to modelContainer: ModelContainer
+  ) async {
+    state = .exporting(step: "Starting...")
+
+    do {
+      // 1. Export
+      let exporter = ServerDataExporter(
+        accountRepo: remoteBackend.accounts,
+        categoryRepo: remoteBackend.categories,
+        earmarkRepo: remoteBackend.earmarks,
+        transactionRepo: remoteBackend.transactions
+      )
+      let exported = try await exporter.export { [weak self] progress in
+        Task { @MainActor in
+          switch progress {
+          case .downloading(let step):
+            self?.state = .exporting(step: step)
+          default: break
+          }
+        }
+      }
+
+      // 2. Import
+      let importer = CloudKitDataImporter(modelContainer: modelContainer)
+      let result = try await importer.importData(exported) { [weak self] progress in
+        Task { @MainActor in
+          switch progress {
+          case .importing(let step, let current, let total):
+            let pct = total > 0 ? Double(current) / Double(total) : 0
+            self?.state = .importing(step: step, progress: pct)
+          default: break
+          }
+        }
+      }
+
+      // 3. Verify
+      state = .verifying
+      let verifier = MigrationVerifier()
+      let verification = try await verifier.verify(
+        exported: exported,
+        modelContainer: modelContainer
+      )
+
+      if !verification.countMatch {
+        throw MigrationError.verificationFailed(verification)
+      }
+
+      // 4. Cleanup
+      CookieKeychain().clear()  // Remove Google OAuth cookies
+
+      state = .succeeded(result)
+
+    } catch {
+      state = .failed(error as? MigrationError ?? .unexpected(error))
+    }
+  }
+}
+```
+
+### Backend Switching
+
+After successful migration:
+1. Store a flag in `UserDefaults`: `iCloudMigrationCompleted = true`
+2. On next app launch, the composition root checks this flag
+3. If `true`: create `CloudKitBackend` instead of `RemoteBackend`
+4. If `false`: create `RemoteBackend` (or show migration prompt)
+
+```swift
+// In MoolahApp.swift (composition root)
+@main
+struct MoolahApp: App {
+  var body: some Scene {
+    WindowGroup {
+      ContentView()
+        .environment(backend)
+    }
+  }
+
+  var backend: any BackendProvider {
+    if UserDefaults.standard.bool(forKey: "iCloudMigrationCompleted") {
+      return CloudKitBackend()
+    } else {
+      return RemoteBackend(baseURL: serverURL)
+    }
+  }
+}
+```
+
+---
+
+## Error Handling & Rollback
+
+### Error Types
+
+```swift
+enum MigrationError: Error, Sendable {
+  case exportFailed(step: String, underlying: Error)
+  case importFailed(underlying: Error)
+  case verificationFailed(VerificationResult)
+  case iCloudUnavailable
+  case unexpected(Error)
+}
+```
+
+### Rollback Strategy
+
+- **Export failure:** No data has been written locally. Simply show error and allow retry.
+- **Import failure:** The `ModelContext` is discarded without calling `save()`. No data persists. Clean rollback.
+- **Verification failure:** Data was saved but counts don't match. Two options:
+  1. Delete all imported records and retry
+  2. Show warning but allow user to proceed (balances may differ slightly)
+- **Post-switchover issues:** Keep the `RemoteBackend` code available for a transition period. Add a "Switch back to server" option in settings.
+
+### Retry
+
+The migration can be retried from scratch at any time. Before retrying:
+1. Delete all existing records from the SwiftData container (clean slate)
+2. Re-run the full export → import → verify cycle
+
+---
+
+## Edge Cases
+
+### User with No Data
+- Export returns empty arrays for all entities
+- Import inserts nothing
+- Verification passes (0 == 0)
+- Migration completes instantly
+
+### User with Thousands of Transactions
+- Export paginates through all transactions (200 per page)
+- For 10,000 transactions: ~50 requests
+- Progress indicator shows page count
+- Import inserts all 10,000 in a single batch
+- Memory usage: ~10,000 `TransactionRecord` objects in memory — acceptable (~1-2 MB)
+
+### Scheduled Transactions
+- Exported like any other transaction (they have `recurPeriod != nil`)
+- Imported into the same `TransactionRecord` table
+- No special handling needed
+
+### Earmark Budgets
+- Fetched per-earmark (one request each)
+- For 10 earmarks: 10 additional requests
+- Budget items imported as `EarmarkBudgetItemRecord`
+
+### Categories with Parent-Child Relationships
+- Parent and child categories are both in the exported flat list
+- `parentId` references are preserved by UUID
+- Import order doesn't matter (UUID foreign keys, not SwiftData relationships)
+
+### Session Expiry During Migration
+- If the Google OAuth session expires mid-export, `APIClient` throws `BackendError.unauthenticated`
+- Show "Session expired. Please sign in again to continue migration."
+- After re-auth, retry the migration from the beginning
+
+---
+
+## UI Design
+
+### MigrationView
+
+```swift
+struct MigrationView: View {
+  @State private var coordinator = MigrationCoordinator()
+
+  var body: some View {
+    VStack(spacing: 24) {
+      switch coordinator.state {
+      case .idle:
+        migrationPrompt
+      case .exporting(let step):
+        ProgressView("Downloading \(step)...")
+      case .importing(let step, let progress):
+        ProgressView("Importing \(step)...", value: progress)
+      case .verifying:
+        ProgressView("Verifying data integrity...")
+      case .succeeded(let result):
+        migrationSuccess(result)
+      case .failed(let error):
+        migrationFailure(error)
+      }
+    }
+    .padding()
+  }
+
+  private var migrationPrompt: some View {
+    VStack(spacing: 16) {
+      Image(systemName: "icloud.and.arrow.up")
+        .font(.system(size: 48))
+        .foregroundStyle(.tint)
+      Text("Migrate to iCloud")
+        .font(.title)
+      Text("Your data will be moved from the Moolah server to iCloud. This enables offline access and removes the dependency on the server.")
+        .multilineTextAlignment(.center)
+        .foregroundStyle(.secondary)
+      Button("Start Migration") {
+        Task { await coordinator.migrate(...) }
+      }
+      .buttonStyle(.borderedProminent)
+    }
+  }
+}
+```
+
+### Settings Integration
+- Add "Data Migration" section in settings
+- Show migration status (completed / not started)
+- Allow re-triggering migration if needed
+- Show "Switch back to server" option during transition period
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+
+```swift
+@Suite("ServerDataExporter")
+struct ServerDataExporterTests {
+  @Test("exports all data from InMemory backend")
+  func exportAll() async throws {
+    let backend = InMemoryBackend(/* seeded with test data */)
+    let exporter = ServerDataExporter(
+      accountRepo: backend.accounts,
+      categoryRepo: backend.categories,
+      earmarkRepo: backend.earmarks,
+      transactionRepo: backend.transactions
+    )
+    let data = try await exporter.export { _ in }
+    #expect(data.accounts.count == expectedAccountCount)
+    #expect(data.transactions.count == expectedTransactionCount)
+  }
+}
+
+@Suite("CloudKitDataImporter")
+struct CloudKitDataImporterTests {
+  @Test("imports exported data preserving all UUIDs")
+  func importPreservesIds() async throws {
+    let config = ModelConfiguration(isStoredInMemoryOnly: true)
+    let container = try ModelContainer(for: allModelTypes, configurations: config)
+    let importer = CloudKitDataImporter(modelContainer: container)
+
+    let exported = ExportedData(/* test data */)
+    let result = try await importer.importData(exported) { _ in }
+
+    #expect(result.transactionCount == exported.transactions.count)
+    // Verify UUIDs match
+  }
+}
+
+@Suite("MigrationVerifier")
+struct MigrationVerifierTests {
+  @Test("verification passes when counts match")
+  func countsMatch() async throws { ... }
+
+  @Test("verification fails when transaction count mismatches")
+  func countMismatch() async throws { ... }
+
+  @Test("balance verification catches mismatches")
+  func balanceMismatch() async throws { ... }
+}
+```
+
+### Integration Test
+
+```swift
+@Test("full migration round-trip: InMemory → SwiftData → verify")
+func fullMigration() async throws {
+  // 1. Seed InMemoryBackend with realistic data
+  let backend = InMemoryBackend(/* accounts, categories, earmarks, transactions */)
+
+  // 2. Export
+  let exporter = ServerDataExporter(backend: backend)
+  let exported = try await exporter.export { _ in }
+
+  // 3. Import to in-memory SwiftData
+  let config = ModelConfiguration(isStoredInMemoryOnly: true)
+  let container = try ModelContainer(for: allModelTypes, configurations: config)
+  let importer = CloudKitDataImporter(modelContainer: container)
+  let result = try await importer.importData(exported) { _ in }
+
+  // 4. Verify
+  let verifier = MigrationVerifier()
+  let verification = try await verifier.verify(exported: exported, modelContainer: container)
+  #expect(verification.countMatch == true)
+  #expect(verification.balanceMismatches.isEmpty)
+
+  // 5. Read back through CloudKit repositories and compare
+  let cloudAccounts = CloudKitAccountRepository(modelContainer: container)
+  let accounts = try await cloudAccounts.fetchAll()
+  #expect(accounts.count == exported.accounts.count)
+}
+```
+
+---
+
+## Files to Create
+
+| File | Purpose |
+|------|---------|
+| `Backends/CloudKit/Migration/ServerDataExporter.swift` | Export from REST API |
+| `Backends/CloudKit/Migration/CloudKitDataImporter.swift` | Import to SwiftData |
+| `Backends/CloudKit/Migration/MigrationCoordinator.swift` | Orchestration |
+| `Backends/CloudKit/Migration/MigrationVerifier.swift` | Post-import verification |
+| `Backends/CloudKit/Migration/MigrationError.swift` | Error types |
+| `Features/Migration/MigrationView.swift` | Migration UI |
+| `Features/Migration/MigrationStore.swift` | UI state (or use coordinator directly) |
+| `MoolahTests/Migration/ServerDataExporterTests.swift` | Export tests |
+| `MoolahTests/Migration/CloudKitDataImporterTests.swift` | Import tests |
+| `MoolahTests/Migration/MigrationVerifierTests.swift` | Verification tests |
+| `MoolahTests/Migration/MigrationIntegrationTests.swift` | End-to-end test |
+
+---
+
+## Estimated Effort
+
+| Task | Estimate |
+|------|----------|
+| `ServerDataExporter` (with pagination) | 3 hours |
+| `CloudKitDataImporter` (batch insert) | 3 hours |
+| `MigrationVerifier` (counts + balances) | 2 hours |
+| `MigrationCoordinator` (orchestration) | 2 hours |
+| `MigrationView` UI | 2 hours |
+| Backend switching in composition root | 1 hour |
+| Unit tests | 3 hours |
+| Integration tests | 2 hours |
+| **Total** | **~18 hours** |
+
+---
+
+## Risks
+
+| Risk | Impact | Likelihood | Mitigation |
+|------|--------|------------|------------|
+| Data loss during migration | Critical | Low | Atomic save, verification, retry capability |
+| Session expires mid-export | Medium | Medium | Detect and prompt re-auth |
+| Very large datasets (50K+ txns) | Medium | Low | Pagination, progress reporting, memory management |
+| Balance mismatch after migration | Medium | Low | Detailed verification logging; local computation is authoritative |
+| User declines migration | Low | Medium | Keep RemoteBackend working; prompt again later |
+| CloudKit unavailable during import | Medium | Low | Check iCloud availability before starting |

--- a/plans/ICLOUD_EARMARKS_PLAN.md
+++ b/plans/ICLOUD_EARMARKS_PLAN.md
@@ -1,0 +1,405 @@
+# iCloud Migration — Earmarks / Savings Goals
+
+**Date:** 2026-04-08
+**Component:** Earmarks (CRUD, budgets, computed balances)
+**Parent plan:** [ICLOUD_MIGRATION_PLAN.md](./ICLOUD_MIGRATION_PLAN.md)
+
+## Overview
+
+Earmarks (savings goals) have two key challenges: (1) **computed values** — balance, saved, and spent are derived from transactions, not stored; and (2) **budget items** — a separate sub-collection per earmark.
+
+---
+
+## Current Implementation
+
+### EarmarkRepository Protocol (`Domain/Repositories/EarmarkRepository.swift`)
+```swift
+protocol EarmarkRepository: Sendable {
+  func fetchAll() async throws -> [Earmark]
+  func create(_ earmark: Earmark) async throws -> Earmark
+  func update(_ earmark: Earmark) async throws -> Earmark
+  func fetchBudget(earmarkId: UUID) async throws -> [EarmarkBudgetItem]
+  func updateBudget(earmarkId: UUID, items: [EarmarkBudgetItem]) async throws
+}
+```
+
+### Earmark Domain Model (`Domain/Models/Earmark.swift`)
+```swift
+struct Earmark: Codable, Sendable, Identifiable, Hashable, Comparable {
+  let id: UUID
+  var name: String
+  var balance: MonetaryAmount    // computed: sum of all earmark transactions
+  var saved: MonetaryAmount      // computed: sum of positive amounts
+  var spent: MonetaryAmount      // computed: sum of abs(negative amounts)
+  var isHidden: Bool
+  var position: Int
+  var savingsGoal: MonetaryAmount?
+  var savingsStartDate: Date?
+  var savingsEndDate: Date?
+}
+```
+
+### EarmarkBudgetItem
+```swift
+struct EarmarkBudgetItem: Codable, Sendable, Identifiable, Hashable {
+  let id: UUID
+  var categoryId: UUID
+  var amount: MonetaryAmount
+}
+```
+
+### Server Behavior
+- `balance` = sum of ALL transaction amounts where `earmarkId` matches
+- `saved` = sum of POSITIVE transaction amounts (income into earmark)
+- `spent` = sum of absolute values of NEGATIVE transaction amounts (expenses from earmark)
+- Budgets are a separate sub-resource: `GET/PUT /api/earmarks/{id}/budget/`
+- Budget `updateBudget` replaces the entire budget array (not incremental)
+
+### Field Name Mapping
+- Domain `savingsGoal` ↔ Server `savingsTarget` (handled by `CodingKeys`)
+
+---
+
+## SwiftData Models
+
+### File: `Backends/CloudKit/Models/EarmarkRecord.swift`
+
+```swift
+import Foundation
+import SwiftData
+
+@Model
+final class EarmarkRecord {
+  #Unique<EarmarkRecord>([\.id])
+
+  @Attribute(.preserveValueOnDeletion)
+  var id: UUID
+
+  var name: String
+  var position: Int
+  var isHidden: Bool
+  var savingsTarget: Int?   // cents (nil = no savings goal)
+  var savingsStartDate: Date?
+  var savingsEndDate: Date?
+
+  init(
+    id: UUID,
+    name: String,
+    position: Int = 0,
+    isHidden: Bool = false,
+    savingsTarget: Int? = nil,
+    savingsStartDate: Date? = nil,
+    savingsEndDate: Date? = nil
+  ) {
+    self.id = id
+    self.name = name
+    self.position = position
+    self.isHidden = isHidden
+    self.savingsTarget = savingsTarget
+    self.savingsStartDate = savingsStartDate
+    self.savingsEndDate = savingsEndDate
+  }
+}
+```
+
+**Note:** `balance`, `saved`, and `spent` are NOT stored — they are computed from `TransactionRecord` data at fetch time.
+
+### File: `Backends/CloudKit/Models/EarmarkBudgetItemRecord.swift`
+
+```swift
+import Foundation
+import SwiftData
+
+@Model
+final class EarmarkBudgetItemRecord {
+  #Unique<EarmarkBudgetItemRecord>([\.id])
+
+  @Attribute(.preserveValueOnDeletion)
+  var id: UUID
+
+  var earmarkId: UUID
+  var categoryId: UUID
+  var amount: Int   // cents
+
+  init(id: UUID, earmarkId: UUID, categoryId: UUID, amount: Int) {
+    self.id = id
+    self.earmarkId = earmarkId
+    self.categoryId = categoryId
+    self.amount = amount
+  }
+}
+```
+
+---
+
+## CloudKitEarmarkRepository
+
+### File: `Backends/CloudKit/Repositories/CloudKitEarmarkRepository.swift`
+
+```swift
+import Foundation
+import SwiftData
+import OSLog
+
+@ModelActor
+actor CloudKitEarmarkRepository: EarmarkRepository {
+  private let logger = Logger(subsystem: "com.moolah.app", category: "CloudKitEarmarkRepo")
+
+  func fetchAll() async throws -> [Earmark] {
+    // 1. Fetch all earmark records
+    let descriptor = FetchDescriptor<EarmarkRecord>(
+      sortBy: [SortDescriptor(\.position, order: .forward)]
+    )
+    let earmarkRecords = try modelContext.fetch(descriptor)
+
+    // 2. Fetch all non-scheduled transactions with earmarkIds
+    let txnDescriptor = FetchDescriptor<TransactionRecord>(
+      predicate: #Predicate<TransactionRecord> {
+        $0.earmarkId != nil && $0.recurPeriod == nil
+      }
+    )
+    let transactions = try modelContext.fetch(txnDescriptor)
+
+    // 3. Group transactions by earmarkId and compute totals
+    var balances: [UUID: Int] = [:]
+    var savedAmounts: [UUID: Int] = [:]
+    var spentAmounts: [UUID: Int] = [:]
+
+    for txn in transactions {
+      guard let earmarkId = txn.earmarkId else { continue }
+      balances[earmarkId, default: 0] += txn.amount
+      if txn.amount > 0 {
+        savedAmounts[earmarkId, default: 0] += txn.amount
+      } else if txn.amount < 0 {
+        spentAmounts[earmarkId, default: 0] += abs(txn.amount)
+      }
+    }
+
+    // 4. Map to domain models
+    return earmarkRecords.map { record in
+      Earmark(
+        id: record.id,
+        name: record.name,
+        balance: MonetaryAmount(
+          cents: balances[record.id] ?? 0, currency: .defaultCurrency),
+        saved: MonetaryAmount(
+          cents: savedAmounts[record.id] ?? 0, currency: .defaultCurrency),
+        spent: MonetaryAmount(
+          cents: spentAmounts[record.id] ?? 0, currency: .defaultCurrency),
+        isHidden: record.isHidden,
+        position: record.position,
+        savingsGoal: record.savingsTarget.map {
+          MonetaryAmount(cents: $0, currency: .defaultCurrency)
+        },
+        savingsStartDate: record.savingsStartDate,
+        savingsEndDate: record.savingsEndDate
+      )
+    }
+  }
+
+  func create(_ earmark: Earmark) async throws -> Earmark {
+    let record = EarmarkRecord(
+      id: earmark.id,
+      name: earmark.name,
+      position: earmark.position,
+      isHidden: earmark.isHidden,
+      savingsTarget: earmark.savingsGoal?.cents,
+      savingsStartDate: earmark.savingsStartDate,
+      savingsEndDate: earmark.savingsEndDate
+    )
+    modelContext.insert(record)
+    try modelContext.save()
+    // Return with zero computed values (new earmark has no transactions)
+    return Earmark(
+      id: earmark.id,
+      name: earmark.name,
+      balance: .zero,
+      saved: .zero,
+      spent: .zero,
+      isHidden: earmark.isHidden,
+      position: earmark.position,
+      savingsGoal: earmark.savingsGoal,
+      savingsStartDate: earmark.savingsStartDate,
+      savingsEndDate: earmark.savingsEndDate
+    )
+  }
+
+  func update(_ earmark: Earmark) async throws -> Earmark {
+    let id = earmark.id
+    let descriptor = FetchDescriptor<EarmarkRecord>(
+      predicate: #Predicate { $0.id == id }
+    )
+    guard let record = try modelContext.fetch(descriptor).first else {
+      throw BackendError.serverError(404)
+    }
+    record.name = earmark.name
+    record.position = earmark.position
+    record.isHidden = earmark.isHidden
+    record.savingsTarget = earmark.savingsGoal?.cents
+    record.savingsStartDate = earmark.savingsStartDate
+    record.savingsEndDate = earmark.savingsEndDate
+    try modelContext.save()
+    return earmark
+  }
+
+  func fetchBudget(earmarkId: UUID) async throws -> [EarmarkBudgetItem] {
+    let descriptor = FetchDescriptor<EarmarkBudgetItemRecord>(
+      predicate: #Predicate<EarmarkBudgetItemRecord> { $0.earmarkId == earmarkId }
+    )
+    let records = try modelContext.fetch(descriptor)
+    return records.map { record in
+      EarmarkBudgetItem(
+        id: record.id,
+        categoryId: record.categoryId,
+        amount: MonetaryAmount(cents: record.amount, currency: .defaultCurrency)
+      )
+    }
+  }
+
+  func updateBudget(earmarkId: UUID, items: [EarmarkBudgetItem]) async throws {
+    // Verify earmark exists
+    let earmarkDescriptor = FetchDescriptor<EarmarkRecord>(
+      predicate: #Predicate<EarmarkRecord> { $0.id == earmarkId }
+    )
+    guard try modelContext.fetch(earmarkDescriptor).first != nil else {
+      throw BackendError.serverError(404)
+    }
+
+    // Delete existing budget items for this earmark
+    let existingDescriptor = FetchDescriptor<EarmarkBudgetItemRecord>(
+      predicate: #Predicate<EarmarkBudgetItemRecord> { $0.earmarkId == earmarkId }
+    )
+    let existing = try modelContext.fetch(existingDescriptor)
+    for item in existing {
+      modelContext.delete(item)
+    }
+
+    // Insert new budget items
+    for item in items {
+      let record = EarmarkBudgetItemRecord(
+        id: item.id,
+        earmarkId: earmarkId,
+        categoryId: item.categoryId,
+        amount: item.amount.cents
+      )
+      modelContext.insert(record)
+    }
+
+    try modelContext.save()
+  }
+}
+```
+
+---
+
+## Balance Computation Details
+
+### Matching Server Behavior
+
+The server computes earmark totals from all transactions where `earmarkId` matches:
+
+| Metric | Computation |
+|--------|-------------|
+| `balance` | `SUM(amount)` for all matching transactions |
+| `saved` | `SUM(amount)` where `amount > 0` |
+| `spent` | `SUM(ABS(amount))` where `amount < 0` |
+
+### Relationship: `balance = saved - spent`
+
+This is always true by construction:
+- `balance = sum_positive + sum_negative = saved - spent`
+
+### Excluding Scheduled Transactions
+
+Like account balances, only non-scheduled transactions contribute to earmark totals. The predicate filters `recurPeriod == nil`.
+
+---
+
+## CloudKit Sync Considerations
+
+### Computed Values
+- `balance`, `saved`, `spent` are always recomputed from local transactions
+- If transactions sync before the earmark, the values are computed for a non-existent earmark (harmless — no UI shows them)
+- If the earmark syncs before its transactions, it shows zero values temporarily
+
+### Budget Items
+- Budget items reference `earmarkId` via UUID
+- `updateBudget` is a replace-all operation — if two devices update budgets simultaneously, last-writer-wins applies to each `EarmarkBudgetItemRecord` independently
+- This could result in a merged set of budget items from both devices — which may be incorrect
+- **Mitigation:** Budget editing is rare; accept the risk for now
+
+### Position Conflicts
+- Same considerations as accounts — last-writer-wins on position field
+
+---
+
+## Performance Considerations
+
+### Batch Transaction Fetch
+`fetchAll()` fetches all earmarked transactions once, then groups by earmarkId. This is efficient:
+- Single SwiftData fetch for all earmarked transactions
+- O(n) grouping and summation
+- For 1,000 earmarked transactions across 10 earmarks, this is trivial
+
+### Budget Items
+- Budget items are few per earmark (typically 5-20 categories)
+- `updateBudget` deletes and re-inserts, which is fine for small sets
+- No performance concern
+
+---
+
+## Testing Strategy
+
+### Contract Tests
+```swift
+@Suite("CloudKitEarmarkRepository contract")
+struct CloudKitEarmarkRepositoryContractTests {
+  private func makeRepository() throws -> (
+    CloudKitEarmarkRepository, ModelContainer
+  ) {
+    let config = ModelConfiguration(isStoredInMemoryOnly: true)
+    let container = try ModelContainer(
+      for: EarmarkRecord.self, EarmarkBudgetItemRecord.self, TransactionRecord.self,
+      configurations: config
+    )
+    return (CloudKitEarmarkRepository(modelContainer: container), container)
+  }
+}
+```
+
+### Test Cases
+1. `fetchAll()` returns earmarks sorted by position
+2. `fetchAll()` computes balance from positive + negative transactions
+3. `fetchAll()` computes saved (positive only) and spent (abs negative only)
+4. `create()` returns earmark with zero computed values
+5. `update()` changes metadata without affecting computed values
+6. `update()` throws 404 for non-existent earmark
+7. `fetchBudget()` returns items for specific earmark
+8. `updateBudget()` replaces entire budget
+9. `updateBudget()` throws 404 for non-existent earmark
+10. Earmark with no transactions has all-zero computed values
+11. Scheduled transactions excluded from computed values
+
+---
+
+## Files to Create
+
+| File | Purpose |
+|------|---------|
+| `Backends/CloudKit/Models/EarmarkRecord.swift` | SwiftData `@Model` |
+| `Backends/CloudKit/Models/EarmarkBudgetItemRecord.swift` | SwiftData `@Model` |
+| `Backends/CloudKit/Repositories/CloudKitEarmarkRepository.swift` | Repository implementation |
+| `MoolahTests/Backends/CloudKitEarmarkRepositoryTests.swift` | Contract tests |
+
+---
+
+## Estimated Effort
+
+| Task | Estimate |
+|------|----------|
+| `EarmarkRecord` + `EarmarkBudgetItemRecord` models | 1 hour |
+| `fetchAll()` with balance computation | 2 hours |
+| CRUD operations | 1 hour |
+| Budget fetch/update | 1.5 hours |
+| Tests | 2.5 hours |
+| **Total** | **~8 hours** |

--- a/plans/ICLOUD_MIGRATION_PLAN.md
+++ b/plans/ICLOUD_MIGRATION_PLAN.md
@@ -1,0 +1,350 @@
+# Moolah — iCloud Migration Plan
+
+**Date:** 2026-04-08
+**Status:** Draft
+
+## Executive Summary
+
+This plan describes how to migrate moolah-native from the current `RemoteBackend` (REST API talking to moolah-server) to a fully local-first architecture using **SwiftData with CloudKit syncing**. The existing `BackendProvider` abstraction means the migration is a matter of creating a new `CloudKitBackend` implementation — no UI or feature code needs to change.
+
+The moolah-server provides six major components that must be replicated locally:
+
+1. **Authentication & User Identity**
+2. **Accounts**
+3. **Transactions** (including filtering, pagination, and balance computation)
+4. **Categories** (including hierarchy)
+5. **Earmarks / Savings Goals** (including budgets and computed balances)
+6. **Scheduled Transactions & Forecasting**
+
+Each component has a dedicated detailed plan in this directory.
+
+---
+
+## Architecture Overview
+
+### Current Architecture (Remote Backend)
+
+```
+┌──────────────────────────┐
+│     Views / Features     │
+└────────────┬─────────────┘
+             │ @Observable Stores
+┌────────────▼─────────────┐
+│   Repository Protocols   │  ← Domain layer
+└──────┬───────────────────┘
+       │
+┌──────▼──────────────────┐
+│   RemoteBackend         │
+│   ├── APIClient         │  URLSession → moolah-server
+│   ├── DTOs              │  JSON ↔ Domain models
+│   └── Remote Repos      │  REST endpoints
+└─────────────────────────┘
+```
+
+### Target Architecture (CloudKit Backend)
+
+```
+┌──────────────────────────┐
+│     Views / Features     │  ← NO CHANGES
+└────────────┬─────────────┘
+             │ @Observable Stores
+┌────────────▼─────────────┐
+│   Repository Protocols   │  ← NO CHANGES
+└──────┬───────────────────┘
+       │
+┌──────▼──────────────────┐
+│   CloudKitBackend       │
+│   ├── SwiftData Models  │  @Model classes with CloudKit sync
+│   ├── Model Container   │  CloudKit-enabled ModelContainer
+│   └── CloudKit Repos    │  SwiftData queries → Domain models
+└──────┬──────────────────┘
+       │ automatic sync
+┌──────▼──────────────────┐
+│   iCloud (CloudKit)     │  Private database, auto-sync
+└─────────────────────────┘
+```
+
+### Key Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Persistence | SwiftData with CloudKit | First-party, automatic sync, no server to maintain |
+| CloudKit Database | Private | User's own data, no sharing needed |
+| Sync Strategy | Automatic (SwiftData handles it) | Minimal code, Apple-managed conflict resolution |
+| Auth | Implicit iCloud account | No sign-in UI needed; `requiresExplicitSignIn = false` |
+| Computed Values | Local computation | Balances, earmark totals computed from local transactions |
+| Conflict Resolution | Last-writer-wins (CloudKit default) | Acceptable for single-user financial data |
+| Migration | Export/import via REST API | One-time data transfer from server to iCloud |
+
+---
+
+## Major Components
+
+### 1. Authentication & User Identity
+
+**Server functionality being replaced:**
+- Google OAuth sign-in flow
+- Session cookie management
+- User profile retrieval
+
+**iCloud approach:**
+- Use implicit Apple ID via `CKContainer.default().userRecordID()`
+- `requiresExplicitSignIn = false` — no login screen needed
+- User profile from `CKContainer.default().fetchShareParticipants()` or device owner info
+- `CloudKitAuthProvider` implements existing `AuthProvider` protocol
+
+**Detailed plan:** [`ICLOUD_AUTH_PLAN.md`](./ICLOUD_AUTH_PLAN.md)
+
+---
+
+### 2. Accounts
+
+**Server functionality being replaced:**
+- `GET /api/accounts/` — fetch all accounts
+- Account balance computed from sum of transactions
+- Sorting by position
+- Account types: bank, cc, asset, investment
+
+**iCloud approach:**
+- `AccountRecord` SwiftData `@Model` class
+- Balance computed locally from `TransactionRecord` queries
+- Position-based ordering stored in the model
+- `CloudKitAccountRepository` implements `AccountRepository` protocol
+
+**Detailed plan:** [`ICLOUD_ACCOUNTS_PLAN.md`](./ICLOUD_ACCOUNTS_PLAN.md)
+
+---
+
+### 3. Transactions
+
+**Server functionality being replaced:**
+- `GET /api/transactions/` — paginated, filtered fetch
+- `POST /PUT /DELETE /api/transactions/` — CRUD
+- Complex filtering (account, earmark, scheduled, date range, category, payee)
+- Pagination with offset/pageSize
+- `priorBalance` computation
+- Payee suggestions
+
+**iCloud approach:**
+- `TransactionRecord` SwiftData `@Model` class
+- SwiftData `#Predicate` for filtering
+- `FetchDescriptor` with sort and pagination
+- `priorBalance` computed via aggregate query on older transactions
+- Payee suggestions via distinct query on payee field
+- `CloudKitTransactionRepository` implements `TransactionRepository` protocol
+
+**Detailed plan:** [`ICLOUD_TRANSACTIONS_PLAN.md`](./ICLOUD_TRANSACTIONS_PLAN.md)
+
+---
+
+### 4. Categories
+
+**Server functionality being replaced:**
+- `GET /api/categories/` — fetch all categories
+- `POST /PUT /DELETE /api/categories/` — CRUD
+- Hierarchical parent-child relationships via `parentId`
+- Deletion with replacement (re-parent children)
+
+**iCloud approach:**
+- `CategoryRecord` SwiftData `@Model` class
+- Parent-child relationship modeled via optional `parentId` (or SwiftData relationship)
+- Deletion with replacement logic in repository
+- `CloudKitCategoryRepository` implements `CategoryRepository` protocol
+
+**Detailed plan:** [`ICLOUD_CATEGORIES_PLAN.md`](./ICLOUD_CATEGORIES_PLAN.md)
+
+---
+
+### 5. Earmarks / Savings Goals
+
+**Server functionality being replaced:**
+- `GET /api/earmarks/` — fetch all with computed balance/saved/spent
+- `POST /PUT /api/earmarks/` — CRUD
+- `GET /PUT /api/earmarks/{id}/budget/` — budget management
+- Balance = sum of transactions with this earmarkId
+- Saved = sum of positive transaction amounts
+- Spent = sum of absolute negative transaction amounts
+
+**iCloud approach:**
+- `EarmarkRecord` SwiftData `@Model` class
+- `EarmarkBudgetItemRecord` SwiftData `@Model` class
+- Balance/saved/spent computed locally from transactions at fetch time
+- `CloudKitEarmarkRepository` implements `EarmarkRepository` protocol
+
+**Detailed plan:** [`ICLOUD_EARMARKS_PLAN.md`](./ICLOUD_EARMARKS_PLAN.md)
+
+---
+
+### 6. Scheduled Transactions & Forecasting
+
+**Server functionality being replaced:**
+- Scheduled transaction filtering (`scheduled=true/false`)
+- Next due date calculation
+- Pay action orchestration (create paid copy + update/delete original)
+- Transaction forecasting for analysis graphs
+
+**iCloud approach:**
+- Scheduled transactions are just `TransactionRecord` entries with `recurPeriod != nil`
+- All recurrence logic already exists in `Domain/Models/Transaction.swift`
+- Pay action orchestrated locally (same as current InMemoryBackend behavior)
+- Forecasting computed locally from scheduled transactions
+- No separate component needed — handled within `CloudKitTransactionRepository`
+
+**Detailed plan:** [`ICLOUD_SCHEDULED_TRANSACTIONS_PLAN.md`](./ICLOUD_SCHEDULED_TRANSACTIONS_PLAN.md)
+
+---
+
+## Data Migration
+
+Existing users with data on moolah-server need a one-time migration path to move their data into iCloud.
+
+**Detailed plan:** [`ICLOUD_DATA_MIGRATION_PLAN.md`](./ICLOUD_DATA_MIGRATION_PLAN.md)
+
+---
+
+## SwiftData Model Design
+
+All SwiftData `@Model` classes live in `Backends/CloudKit/Models/`. They are internal to the CloudKit backend — features never see them. Each repository maps between SwiftData models and domain models.
+
+### Model Relationships
+
+```
+AccountRecord
+  ├── id: UUID (unique)
+  ├── name: String
+  ├── type: String (raw value of AccountType)
+  ├── position: Int
+  ├── isHidden: Bool
+  └── ← TransactionRecord.accountId / toAccountId (implicit)
+
+TransactionRecord
+  ├── id: UUID (unique)
+  ├── type: String (raw value of TransactionType)
+  ├── date: Date
+  ├── accountId: UUID?
+  ├── toAccountId: UUID?
+  ├── amount: Int (cents)
+  ├── payee: String?
+  ├── notes: String?
+  ├── categoryId: UUID?
+  ├── earmarkId: UUID?
+  ├── recurPeriod: String? (raw value of RecurPeriod)
+  └── recurEvery: Int?
+
+CategoryRecord
+  ├── id: UUID (unique)
+  ├── name: String
+  └── parentId: UUID?
+
+EarmarkRecord
+  ├── id: UUID (unique)
+  ├── name: String
+  ├── position: Int
+  ├── isHidden: Bool
+  ├── savingsTarget: Int? (cents)
+  ├── savingsStartDate: Date?
+  └── savingsEndDate: Date?
+
+EarmarkBudgetItemRecord
+  ├── id: UUID (unique)
+  ├── earmarkId: UUID
+  ├── categoryId: UUID
+  └── amount: Int (cents)
+```
+
+### CloudKit Considerations
+
+- **Container:** Use the app's default CloudKit container
+- **Database:** Private database only (no public or shared)
+- **Record Zone:** Default zone (SwiftData manages this)
+- **Indexes:** SwiftData automatically creates CloudKit indexes for `@Attribute` properties used in predicates
+- **Size Limits:** CloudKit record size limit is 1MB — financial records are well within this
+- **Rate Limits:** CloudKit has per-user rate limits; batch operations should be chunked appropriately during migration
+
+---
+
+## Implementation Order
+
+The recommended implementation order minimizes risk and allows incremental testing:
+
+### Phase 1: Foundation
+1. **SwiftData Models** — Define all `@Model` classes
+2. **CloudKit ModelContainer** — Configure CloudKit-enabled container
+3. **CloudKitAuthProvider** — Simplest component; validates iCloud availability
+
+### Phase 2: Core Repositories (order matters — transactions depend on accounts)
+4. **CloudKitCategoryRepository** — No computed values, straightforward CRUD
+5. **CloudKitAccountRepository** — Read-only initially (balance computed from transactions)
+6. **CloudKitTransactionRepository** — Most complex; filtering, pagination, balance computation
+7. **CloudKitEarmarkRepository** — Depends on transactions for computed values
+
+### Phase 3: Assembly & Testing
+8. **CloudKitBackend** — Wire all repositories into `BackendProvider`
+9. **Contract Tests** — Run existing contract test suites against CloudKit backend
+10. **Composition Root** — Add toggle to switch between Remote and CloudKit backends
+
+### Phase 4: Migration
+11. **Data Migration Tool** — Export from server, import to iCloud
+12. **Migration UI** — In-app flow for existing users
+
+### Phase 5: Cleanup
+13. **Remove RemoteBackend** — Once migration is complete and stable
+14. **Remove Google Sign-In dependency** — No longer needed
+
+---
+
+## Risk Assessment
+
+| Risk | Impact | Likelihood | Mitigation |
+|------|--------|------------|------------|
+| CloudKit sync delays | Medium | Medium | Show sync status indicator; local-first means app always works |
+| CloudKit quota limits | Low | Low | Financial data is small; well within free tier |
+| Conflict resolution errors | Medium | Low | Last-writer-wins is acceptable; single user typically uses one device at a time |
+| SwiftData/CloudKit bugs | High | Medium | Use latest iOS/macOS 26 APIs; file radars; keep RemoteBackend as fallback |
+| Migration data loss | Critical | Low | Verify migration with checksums; keep server running during transition period |
+| iCloud account not available | Medium | Low | Show clear error; require iCloud sign-in |
+
+---
+
+## Testing Strategy
+
+- **All existing contract tests** must pass against `CloudKitBackend`
+- **Use in-memory SwiftData container** (without CloudKit) for unit tests
+- **Integration tests** with actual CloudKit container for sync verification
+- **Migration tests** comparing exported server data with imported iCloud data
+- **Multi-device sync tests** (manual) to verify eventual consistency
+
+---
+
+## Files to Create
+
+```
+Backends/CloudKit/
+├── CloudKitBackend.swift              # BackendProvider implementation
+├── Auth/
+│   └── CloudKitAuthProvider.swift     # Implicit iCloud auth
+├── Models/
+│   ├── AccountRecord.swift            # @Model for accounts
+│   ├── TransactionRecord.swift        # @Model for transactions
+│   ├── CategoryRecord.swift           # @Model for categories
+│   ├── EarmarkRecord.swift            # @Model for earmarks
+│   └── EarmarkBudgetItemRecord.swift  # @Model for earmark budgets
+├── Repositories/
+│   ├── CloudKitAccountRepository.swift
+│   ├── CloudKitTransactionRepository.swift
+│   ├── CloudKitCategoryRepository.swift
+│   └── CloudKitEarmarkRepository.swift
+└── Migration/
+    ├── ServerDataExporter.swift        # Fetches all data from REST API
+    └── CloudKitDataImporter.swift      # Writes data to SwiftData/CloudKit
+```
+
+---
+
+## Out of Scope
+
+- Shared databases / multi-user collaboration
+- CloudKit subscriptions / push notifications for sync
+- Offline write queue (SwiftData handles this automatically)
+- Server-side changes to moolah-server
+- Web app migration (web app continues to use moolah-server)

--- a/plans/ICLOUD_SCHEDULED_TRANSACTIONS_PLAN.md
+++ b/plans/ICLOUD_SCHEDULED_TRANSACTIONS_PLAN.md
@@ -1,0 +1,337 @@
+# iCloud Migration — Scheduled Transactions & Forecasting
+
+**Date:** 2026-04-08
+**Component:** Scheduled Transactions (recurrence, pay action, forecasting)
+**Parent plan:** [ICLOUD_MIGRATION_PLAN.md](./ICLOUD_MIGRATION_PLAN.md)
+
+## Overview
+
+Scheduled transactions are stored as regular transactions with `recurPeriod != nil`. Moving to iCloud actually **simplifies** this component — the pay action orchestration and forecasting that the server handles can now be done locally in a single SwiftData context, making atomic operations trivial.
+
+---
+
+## Current State
+
+### What Exists (from SCHEDULED_TRANSACTIONS_GAP_ANALYSIS.md)
+
+**Domain Layer (complete):**
+- `RecurPeriod` enum: `.once`, `.day`, `.week`, `.month`, `.year`
+- `Transaction.isScheduled` / `Transaction.isRecurring` computed properties
+- `Transaction.nextDueDate()` — calculates next occurrence using `Calendar`
+- `Transaction.validate()` — ensures `recurPeriod` and `recurEvery` are both set or both nil
+- `TransactionFilter.scheduled: Bool?` — filter by scheduled status
+
+**Backend Layer (complete):**
+- `InMemoryTransactionRepository` filters by `scheduled` correctly
+- `RemoteTransactionRepository` passes `scheduled` query param
+- `TransactionDTO` includes `recurPeriod` and `recurEvery`
+
+**UI (partially complete):**
+- `UpcomingView` — displays overdue and upcoming scheduled transactions
+- Pay button on each row
+- Recurrence description display
+
+### What's Missing (gaps from analysis)
+
+1. Recurrence UI in TransactionFormView (creating/editing scheduled txns)
+2. Pay action doesn't update/delete the original scheduled transaction
+3. Forecasting for analysis graphs
+4. Short-term upcoming widget on dashboard
+
+---
+
+## How Scheduled Transactions Work in CloudKit Backend
+
+### Storage
+
+Scheduled transactions are stored as regular `TransactionRecord` entries in SwiftData. The only difference is `recurPeriod != nil`. No separate model or table needed.
+
+### Filtering
+
+The `CloudKitTransactionRepository` already handles the `scheduled` filter (see Transactions plan):
+```swift
+if let scheduled = filter.scheduled {
+  result = result.filter { ($0.recurPeriod != nil) == scheduled }
+}
+```
+
+### Balance Exclusion
+
+Scheduled transactions are excluded from account and earmark balance computations:
+```swift
+// In CloudKitAccountRepository.fetchAll()
+predicate: #Predicate<TransactionRecord> { $0.recurPeriod == nil }
+```
+
+This matches the server behavior — scheduled transactions represent future/projected amounts, not actual balances.
+
+---
+
+## Pay Action Implementation
+
+The pay action is currently orchestrated in `TransactionStore`. With iCloud, this becomes simpler because everything happens in a single SwiftData context.
+
+### Current Flow (from SCHEDULED_TRANSACTIONS_GAP_ANALYSIS.md)
+
+1. Create a non-scheduled copy with today's date
+2. If `recurPeriod == .once`: delete the original
+3. If recurring: update the original's `date` to `nextDueDate()`
+
+### CloudKit Implementation
+
+With SwiftData, all three operations happen in a single `modelContext.save()`:
+
+```swift
+// In CloudKitTransactionRepository or a dedicated method
+func payScheduledTransaction(_ transaction: Transaction) async throws -> Transaction {
+  // 1. Create paid (non-scheduled) copy
+  let paidTransaction = Transaction(
+    id: UUID(),
+    type: transaction.type,
+    date: Date(),  // today
+    accountId: transaction.accountId,
+    toAccountId: transaction.toAccountId,
+    amount: transaction.amount,
+    payee: transaction.payee,
+    notes: transaction.notes,
+    categoryId: transaction.categoryId,
+    earmarkId: transaction.earmarkId,
+    recurPeriod: nil,    // non-scheduled
+    recurEvery: nil
+  )
+  let paidRecord = TransactionRecord(from: paidTransaction)
+  modelContext.insert(paidRecord)
+
+  // 2. Handle the original scheduled transaction
+  let originalId = transaction.id
+  let descriptor = FetchDescriptor<TransactionRecord>(
+    predicate: #Predicate { $0.id == originalId }
+  )
+  guard let originalRecord = try modelContext.fetch(descriptor).first else {
+    throw BackendError.serverError(404)
+  }
+
+  if transaction.recurPeriod == .once {
+    // One-time: delete the original
+    modelContext.delete(originalRecord)
+  } else if let nextDate = transaction.nextDueDate() {
+    // Recurring: advance to next due date
+    originalRecord.date = nextDate
+  }
+
+  // 3. Single atomic save
+  try modelContext.save()
+
+  return paidTransaction
+}
+```
+
+### Advantages Over Server Approach
+
+| Aspect | Server (current) | CloudKit (new) |
+|--------|-----------------|----------------|
+| Atomicity | Two separate HTTP requests (create + update/delete) — not atomic | Single `modelContext.save()` — fully atomic |
+| Latency | Two round trips | Instant (local write) |
+| Error handling | Partial failure possible (paid txn created but original not updated) | All-or-nothing |
+| Offline support | Fails without network | Works offline, syncs later |
+
+---
+
+## Gap Resolution
+
+### Gap 1: Recurrence UI in TransactionFormView
+**Status:** Not affected by backend migration — this is a pure UI change.
+**Action:** Implement as described in `SCHEDULED_TRANSACTIONS_GAP_ANALYSIS.md` Phase 1, item 3. No backend-specific work needed.
+
+### Gap 2: Pay Action Doesn't Update Original
+**Status:** Resolved by the `payScheduledTransaction` method above.
+**Action:** Wire `TransactionStore.payTransaction()` to call the repository's pay method (or orchestrate create + update/delete using existing CRUD methods).
+
+### Gap 3: Forecasting
+**Status:** Becomes a local computation. See Forecasting section below.
+
+### Gap 4: RecurPeriod Enum
+**Status:** Already resolved — `RecurPeriod` enum exists in `Domain/Models/Transaction.swift`.
+
+### Gap 5: Short-Term Upcoming Widget
+**Status:** Pure UI — not affected by backend migration.
+
+### Gap 6: Validation
+**Status:** `Transaction.validate()` already exists in the domain layer.
+
+---
+
+## Forecasting
+
+### Purpose
+Project future balances based on scheduled transactions for the analysis/net-worth graph.
+
+### Implementation: Local Computation
+
+With all data local, forecasting is a straightforward computation:
+
+```swift
+/// Generates all future instances of a scheduled transaction up to a date.
+func extrapolateScheduledTransaction(
+  _ transaction: Transaction,
+  until forecastEnd: Date
+) -> [Transaction] {
+  guard transaction.isRecurring else {
+    // One-time scheduled: just return it if it's before forecastEnd
+    if transaction.date <= forecastEnd {
+      return [transaction]
+    }
+    return []
+  }
+
+  var instances: [Transaction] = []
+  var currentDate = transaction.date
+  let calendar = Calendar.current
+
+  while currentDate <= forecastEnd {
+    // Create a projected instance
+    let instance = Transaction(
+      id: UUID(),
+      type: transaction.type,
+      date: currentDate,
+      accountId: transaction.accountId,
+      toAccountId: transaction.toAccountId,
+      amount: transaction.amount,
+      payee: transaction.payee,
+      categoryId: transaction.categoryId,
+      earmarkId: transaction.earmarkId,
+      recurPeriod: nil,  // projected instances are non-scheduled
+      recurEvery: nil
+    )
+    instances.append(instance)
+
+    // Advance to next occurrence
+    guard let period = transaction.recurPeriod,
+          let every = transaction.recurEvery else { break }
+
+    var components = DateComponents()
+    switch period {
+    case .day: components.day = every
+    case .week: components.weekOfYear = every
+    case .month: components.month = every
+    case .year: components.year = every
+    case .once: break
+    }
+
+    guard let nextDate = calendar.date(byAdding: components, to: currentDate) else { break }
+    currentDate = nextDate
+  }
+
+  return instances
+}
+
+/// Projects daily balances forward from a starting balance.
+func forecastBalances(
+  scheduledTransactions: [Transaction],
+  currentNetWorth: MonetaryAmount,
+  until forecastEnd: Date
+) -> [DailyBalance] {
+  // 1. Extrapolate all scheduled transactions
+  let allProjected = scheduledTransactions
+    .flatMap { extrapolateScheduledTransaction($0, until: forecastEnd) }
+    .sorted { $0.date < $1.date }
+
+  // 2. Walk forward, computing running balance
+  var balance = currentNetWorth
+  var result: [DailyBalance] = []
+
+  for txn in allProjected {
+    balance += txn.amount
+    result.append(DailyBalance(
+      date: txn.date,
+      balance: balance,
+      isForecast: true
+    ))
+  }
+
+  return result
+}
+```
+
+### Where This Lives
+
+This computation belongs in the domain layer or in an `AnalysisRepository` implementation — it's pure business logic with no backend dependency.
+
+**Recommended location:** `Domain/Models/TransactionForecasting.swift` or within `CloudKitAnalysisRepository` (when Step 10 is implemented).
+
+---
+
+## Testing Strategy
+
+### Existing Tests
+`MoolahTests/Domain/ScheduledTransactionTests.swift` already covers:
+- `isScheduled` property
+- Creating a paid copy
+- Filtering scheduled transactions
+- Overdue classification
+- Recurrence period values
+
+### Additional Tests for CloudKit Backend
+
+```swift
+@Suite("Scheduled transactions in CloudKit")
+struct CloudKitScheduledTransactionTests {
+  @Test("Pay one-time scheduled transaction deletes original")
+  func payOnce() async throws { ... }
+
+  @Test("Pay recurring transaction advances date")
+  func payRecurring() async throws { ... }
+
+  @Test("Scheduled transactions excluded from account balance")
+  func excludedFromBalance() async throws { ... }
+
+  @Test("Scheduled transactions excluded from earmark balance")
+  func excludedFromEarmarkBalance() async throws { ... }
+
+  @Test("Pay action is atomic — both operations succeed or both fail")
+  func payAtomic() async throws { ... }
+}
+```
+
+### Forecasting Tests
+```swift
+@Suite("Transaction forecasting")
+struct TransactionForecastingTests {
+  @Test("Extrapolates monthly transaction")
+  func monthlyExtrapolation() { ... }
+
+  @Test("One-time scheduled returns single instance")
+  func onceExtrapolation() { ... }
+
+  @Test("Forecast balances accumulate correctly")
+  func forecastBalances() { ... }
+
+  @Test("Empty scheduled transactions produce no forecast")
+  func emptyForecast() { ... }
+}
+```
+
+---
+
+## Files to Create
+
+| File | Purpose |
+|------|---------|
+| `Domain/Models/TransactionForecasting.swift` | Extrapolation and forecasting logic |
+| `MoolahTests/Domain/TransactionForecastingTests.swift` | Forecasting tests |
+
+No new backend files needed — scheduled transactions use `TransactionRecord` and `CloudKitTransactionRepository`.
+
+---
+
+## Estimated Effort
+
+| Task | Estimate |
+|------|----------|
+| Pay action in repository | 1.5 hours |
+| Forecasting logic | 2 hours |
+| Forecasting tests | 1.5 hours |
+| Pay action tests | 1 hour |
+| **Total** | **~6 hours** |
+
+Note: The recurrence UI gaps identified in `SCHEDULED_TRANSACTIONS_GAP_ANALYSIS.md` are UI-only work and are not affected by the backend migration. They are estimated at ~11 hours separately.

--- a/plans/ICLOUD_TRANSACTIONS_PLAN.md
+++ b/plans/ICLOUD_TRANSACTIONS_PLAN.md
@@ -1,0 +1,548 @@
+# iCloud Migration — Transactions
+
+**Date:** 2026-04-08
+**Component:** Transactions (CRUD, filtering, pagination, balance computation)
+**Parent plan:** [ICLOUD_MIGRATION_PLAN.md](./ICLOUD_MIGRATION_PLAN.md)
+
+## Overview
+
+Transactions are the most complex component of the migration. The server currently handles paginated queries with multi-field filtering, sort ordering, `priorBalance` computation, and payee suggestions — all of which must be reimplemented locally using SwiftData queries.
+
+---
+
+## Current Implementation
+
+### TransactionRepository Protocol (`Domain/Repositories/TransactionRepository.swift`)
+```swift
+protocol TransactionRepository: Sendable {
+  func fetch(filter: TransactionFilter, page: Int, pageSize: Int) async throws -> TransactionPage
+  func create(_ transaction: Transaction) async throws -> Transaction
+  func update(_ transaction: Transaction) async throws -> Transaction
+  func delete(id: UUID) async throws
+  func fetchPayeeSuggestions(prefix: String) async throws -> [String]
+}
+```
+
+### TransactionFilter (`Domain/Models/Transaction.swift`)
+```swift
+struct TransactionFilter: Sendable, Equatable {
+  var accountId: UUID?
+  var earmarkId: UUID?
+  var scheduled: Bool?
+  var dateRange: ClosedRange<Date>?
+  var categoryIds: Set<UUID>?
+  var payee: String?
+}
+```
+
+### TransactionPage
+```swift
+struct TransactionPage: Sendable {
+  let transactions: [Transaction]
+  let priorBalance: MonetaryAmount  // balance before the oldest txn in this page
+}
+```
+
+### Server Behavior (from InMemoryTransactionRepository)
+- **Account filter:** matches `accountId == X` OR `toAccountId == X` (transfers appear in both accounts)
+- **Earmark filter:** matches `earmarkId == X`
+- **Scheduled filter:** `true` = `recurPeriod != nil`, `false` = `recurPeriod == nil`
+- **Date range:** inclusive on both ends
+- **Category filter:** OR logic — transaction matches ANY of the category IDs
+- **Payee filter:** case-insensitive substring match
+- **All filters combine with AND logic**
+- **Sort:** date DESC, then id ASC (stable ordering)
+- **Pagination:** offset-based (`page * pageSize`)
+- **priorBalance:** sum of all transaction amounts AFTER the current page (older transactions)
+
+---
+
+## SwiftData Model
+
+### File: `Backends/CloudKit/Models/TransactionRecord.swift`
+
+```swift
+import Foundation
+import SwiftData
+
+@Model
+final class TransactionRecord {
+  #Unique<TransactionRecord>([\.id])
+
+  @Attribute(.preserveValueOnDeletion)
+  var id: UUID
+
+  var type: String          // "income", "expense", "transfer"
+  var date: Date
+  var accountId: UUID?
+  var toAccountId: UUID?
+  var amount: Int           // cents
+  var payee: String?
+  var notes: String?
+  var categoryId: UUID?
+  var earmarkId: UUID?
+  var recurPeriod: String?  // "ONCE", "DAY", "WEEK", "MONTH", "YEAR"
+  var recurEvery: Int?
+
+  // Denormalized lowercase payee for case-insensitive search
+  var payeeLower: String?
+
+  init(
+    id: UUID,
+    type: String,
+    date: Date,
+    accountId: UUID? = nil,
+    toAccountId: UUID? = nil,
+    amount: Int,
+    payee: String? = nil,
+    notes: String? = nil,
+    categoryId: UUID? = nil,
+    earmarkId: UUID? = nil,
+    recurPeriod: String? = nil,
+    recurEvery: Int? = nil
+  ) {
+    self.id = id
+    self.type = type
+    self.date = date
+    self.accountId = accountId
+    self.toAccountId = toAccountId
+    self.amount = amount
+    self.payee = payee
+    self.notes = notes
+    self.categoryId = categoryId
+    self.earmarkId = earmarkId
+    self.recurPeriod = recurPeriod
+    self.recurEvery = recurEvery
+    self.payeeLower = payee?.lowercased()
+  }
+}
+```
+
+### Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Store `type` as `String` | Yes | CloudKit doesn't support custom enums; raw values work |
+| Store `recurPeriod` as `String?` | Yes | Same reason; map to `RecurPeriod` enum in domain layer |
+| Store `amount` as `Int` | Yes | Cents, matches domain model |
+| Denormalized `payeeLower` | Yes | SwiftData `#Predicate` doesn't support `.lowercased()` calls |
+| No SwiftData relationships | Yes | Use UUID foreign keys; relationships complicate CloudKit sync |
+| `@Attribute(.preserveValueOnDeletion)` on `id` | Yes | Helps CloudKit tombstone tracking |
+
+---
+
+## CloudKitTransactionRepository
+
+### File: `Backends/CloudKit/Repositories/CloudKitTransactionRepository.swift`
+
+### Filtering Strategy
+
+SwiftData `#Predicate` with CloudKit has significant limitations:
+- No `.lowercased()` or `.localizedCaseInsensitiveContains()` in predicates
+- No OR logic across different fields in a single predicate
+- Limited compound predicate support
+- No aggregate functions in predicates
+
+**Approach: Build predicate dynamically + post-filter for unsupported operations.**
+
+```swift
+@ModelActor
+actor CloudKitTransactionRepository: TransactionRepository {
+  func fetch(
+    filter: TransactionFilter, page: Int, pageSize: Int
+  ) async throws -> TransactionPage {
+
+    // Phase 1: SwiftData predicate for filters it CAN handle
+    var descriptor = FetchDescriptor<TransactionRecord>(
+      sortBy: [
+        SortDescriptor(\.date, order: .reverse),
+        SortDescriptor(\.id, order: .forward)
+      ]
+    )
+
+    // Phase 2: Fetch all matching, then post-filter for complex conditions
+    let allRecords = try modelContext.fetch(descriptor)
+    let filtered = applyFilters(allRecords, filter: filter)
+
+    // Phase 3: Paginate
+    let offset = page * pageSize
+    guard offset < filtered.count else {
+      return TransactionPage(transactions: [], priorBalance: .zero)
+    }
+    let end = min(offset + pageSize, filtered.count)
+    let pageRecords = Array(filtered[offset..<end])
+
+    // Phase 4: Compute priorBalance (sum of transactions after this page)
+    let priorCents = filtered[end...].reduce(0) { $0 + $1.amount }
+    let priorBalance = MonetaryAmount(cents: priorCents, currency: .defaultCurrency)
+
+    // Phase 5: Map to domain models
+    let transactions = pageRecords.map { $0.toDomain() }
+    return TransactionPage(transactions: transactions, priorBalance: priorBalance)
+  }
+}
+```
+
+### Filter Implementation
+
+Because SwiftData predicates have limited expressiveness (especially with CloudKit), the safest approach is predicate for simple filters + in-memory post-filtering for complex ones:
+
+```swift
+private func applyFilters(
+  _ records: [TransactionRecord],
+  filter: TransactionFilter
+) -> [TransactionRecord] {
+  var result = records
+
+  // Account filter: matches accountId OR toAccountId
+  if let accountId = filter.accountId {
+    result = result.filter { $0.accountId == accountId || $0.toAccountId == accountId }
+  }
+
+  // Earmark filter
+  if let earmarkId = filter.earmarkId {
+    result = result.filter { $0.earmarkId == earmarkId }
+  }
+
+  // Scheduled filter
+  if let scheduled = filter.scheduled {
+    result = result.filter { ($0.recurPeriod != nil) == scheduled }
+  }
+
+  // Date range filter
+  if let dateRange = filter.dateRange {
+    result = result.filter { dateRange.contains($0.date) }
+  }
+
+  // Category filter (OR logic across multiple categories)
+  if let categoryIds = filter.categoryIds, !categoryIds.isEmpty {
+    result = result.filter { record in
+      guard let catId = record.categoryId else { return false }
+      return categoryIds.contains(catId)
+    }
+  }
+
+  // Payee filter (case-insensitive contains)
+  if let payee = filter.payee, !payee.isEmpty {
+    let lowered = payee.lowercased()
+    result = result.filter { record in
+      guard let p = record.payeeLower else { return false }
+      return p.contains(lowered)
+    }
+  }
+
+  return result
+}
+```
+
+### Performance Optimization: Predicate Push-Down
+
+For large datasets, loading all transactions into memory for filtering is expensive. As an optimization, push simple filters into the SwiftData predicate when possible:
+
+```swift
+// When only earmarkId filter is set (common case)
+if let earmarkId = filter.earmarkId,
+   filter.accountId == nil, filter.scheduled == nil,
+   filter.dateRange == nil, filter.categoryIds == nil, filter.payee == nil {
+  descriptor.predicate = #Predicate<TransactionRecord> { record in
+    record.earmarkId == earmarkId
+  }
+}
+
+// When only scheduled filter is set
+if let scheduled = filter.scheduled,
+   filter.accountId == nil, filter.earmarkId == nil,
+   filter.dateRange == nil, filter.categoryIds == nil, filter.payee == nil {
+  if scheduled {
+    descriptor.predicate = #Predicate<TransactionRecord> { $0.recurPeriod != nil }
+  } else {
+    descriptor.predicate = #Predicate<TransactionRecord> { $0.recurPeriod == nil }
+  }
+}
+```
+
+A more complete optimization can build compound predicates for filter combinations that SwiftData supports. The post-filter approach is the safe fallback that guarantees correctness.
+
+### CRUD Operations
+
+```swift
+func create(_ transaction: Transaction) async throws -> Transaction {
+  let record = TransactionRecord(from: transaction)
+  modelContext.insert(record)
+  try modelContext.save()
+  return transaction
+}
+
+func update(_ transaction: Transaction) async throws -> Transaction {
+  let id = transaction.id
+  let descriptor = FetchDescriptor<TransactionRecord>(
+    predicate: #Predicate { $0.id == id }
+  )
+  guard let record = try modelContext.fetch(descriptor).first else {
+    throw BackendError.serverError(404)
+  }
+  record.update(from: transaction)
+  try modelContext.save()
+  return transaction
+}
+
+func delete(id: UUID) async throws {
+  let descriptor = FetchDescriptor<TransactionRecord>(
+    predicate: #Predicate { $0.id == id }
+  )
+  guard let record = try modelContext.fetch(descriptor).first else {
+    throw BackendError.serverError(404)
+  }
+  modelContext.delete(record)
+  try modelContext.save()
+}
+```
+
+### Payee Suggestions
+
+```swift
+func fetchPayeeSuggestions(prefix: String) async throws -> [String] {
+  let lowered = prefix.lowercased()
+  let descriptor = FetchDescriptor<TransactionRecord>()
+  let records = try modelContext.fetch(descriptor)
+
+  let payees = Set(
+    records
+      .compactMap(\.payee)
+      .filter { !$0.isEmpty && $0.lowercased().hasPrefix(lowered) }
+  )
+  return payees.sorted()
+}
+```
+
+**Optimization:** If performance is an issue, maintain a separate `PayeeRecord` model that stores distinct payees, updated on transaction create/update.
+
+---
+
+## Domain Model Mapping
+
+### TransactionRecord → Transaction
+
+```swift
+extension TransactionRecord {
+  func toDomain() -> Transaction {
+    Transaction(
+      id: id,
+      type: TransactionType(rawValue: type) ?? .expense,
+      date: date,
+      accountId: accountId,
+      toAccountId: toAccountId,
+      amount: MonetaryAmount(cents: amount, currency: .defaultCurrency),
+      payee: payee,
+      notes: notes,
+      categoryId: categoryId,
+      earmarkId: earmarkId,
+      recurPeriod: recurPeriod.flatMap { RecurPeriod(rawValue: $0) },
+      recurEvery: recurEvery
+    )
+  }
+}
+```
+
+### Transaction → TransactionRecord
+
+```swift
+extension TransactionRecord {
+  convenience init(from domain: Transaction) {
+    self.init(
+      id: domain.id,
+      type: domain.type.rawValue,
+      date: domain.date,
+      accountId: domain.accountId,
+      toAccountId: domain.toAccountId,
+      amount: domain.amount.cents,
+      payee: domain.payee,
+      notes: domain.notes,
+      categoryId: domain.categoryId,
+      earmarkId: domain.earmarkId,
+      recurPeriod: domain.recurPeriod?.rawValue,
+      recurEvery: domain.recurEvery
+    )
+  }
+
+  func update(from domain: Transaction) {
+    type = domain.type.rawValue
+    date = domain.date
+    accountId = domain.accountId
+    toAccountId = domain.toAccountId
+    amount = domain.amount.cents
+    payee = domain.payee
+    payeeLower = domain.payee?.lowercased()
+    notes = domain.notes
+    categoryId = domain.categoryId
+    earmarkId = domain.earmarkId
+    recurPeriod = domain.recurPeriod?.rawValue
+    recurEvery = domain.recurEvery
+  }
+}
+```
+
+---
+
+## priorBalance Computation
+
+The `priorBalance` represents the sum of all transaction amounts that are older than the current page. This is used to compute running balances in the transaction list.
+
+### Approach
+
+After filtering and sorting, the transactions older than the current page are at indices `[end...]`. Sum their amounts:
+
+```swift
+let priorCents = filtered[end...].reduce(0) { $0 + $1.amount }
+```
+
+### Performance Note
+
+For an account with 10,000 transactions viewing page 1 (50 items), this sums 9,950 values. This is O(n) but integer addition is fast. If it becomes a bottleneck:
+- Cache cumulative balance per account
+- Use a denormalized running balance field
+- Compute incrementally on insert/delete
+
+For now, the simple approach matches the InMemoryBackend exactly and is correct.
+
+---
+
+## Account Balance Computation
+
+Account balances are not stored on the `AccountRecord` — they're computed by summing transactions. This query is needed by `CloudKitAccountRepository.fetchAll()`:
+
+```swift
+func computeBalance(for accountId: UUID) throws -> Int {
+  let descriptor = FetchDescriptor<TransactionRecord>()
+  let allTransactions = try modelContext.fetch(descriptor)
+
+  return allTransactions
+    .filter { $0.accountId == accountId || $0.toAccountId == accountId }
+    .reduce(0) { sum, txn in
+      if txn.accountId == accountId {
+        return sum + txn.amount
+      } else {
+        // Transfer TO this account — amount is the transfer amount (positive)
+        return sum + txn.amount
+      }
+    }
+}
+```
+
+Note: The actual balance logic depends on the transaction type and whether this is the source or destination account. The exact semantics should match the server's computation. See the Accounts plan for details.
+
+---
+
+## SwiftData / CloudKit Limitations & Workarounds
+
+### 1. Case-Insensitive String Matching
+**Problem:** `#Predicate` doesn't support `.lowercased()` or `.localizedCaseInsensitiveContains()`
+**Workaround:** Store denormalized `payeeLower` field, keep it in sync on create/update
+
+### 2. OR Logic Across Fields
+**Problem:** Account filter needs `accountId == X || toAccountId == X`
+**Workaround:** Post-filter in memory after fetching. For the common case of filtering by one account, this is acceptable — most transactions don't match, so the filtered set is small.
+
+### 3. Aggregate Queries
+**Problem:** SwiftData doesn't support `SUM()`, `COUNT()`, or `DISTINCT` in predicates
+**Workaround:** Fetch records and compute in memory. For balance computation, this is unavoidable with SwiftData.
+
+### 4. Compound Predicates with Optional Fields
+**Problem:** Predicates on optional fields can be tricky with CloudKit
+**Workaround:** Use post-filtering for optional field comparisons
+
+### 5. CloudKit Sync Latency
+**Problem:** A transaction created on device A may not appear on device B immediately
+**Workaround:** Accept eventual consistency. The UI should show local data immediately. CloudKit will sync in the background.
+
+---
+
+## Indexing Strategy
+
+SwiftData automatically indexes `@Attribute` properties used in `#Predicate`. Ensure these fields are used in predicates to get automatic indexing:
+
+| Field | Used In | Index Priority |
+|-------|---------|---------------|
+| `id` | Lookups, updates, deletes | High (unique constraint) |
+| `date` | Date range filter, sorting | High |
+| `accountId` | Account filter | High |
+| `earmarkId` | Earmark filter | Medium |
+| `recurPeriod` | Scheduled filter | Medium |
+| `categoryId` | Category filter | Medium |
+| `payeeLower` | Payee search | Low |
+
+---
+
+## Testing Strategy
+
+### Contract Tests
+The existing `TransactionRepositoryContractTests` should be runnable against `CloudKitTransactionRepository` using an in-memory SwiftData `ModelContainer` (no CloudKit):
+
+```swift
+@Suite("CloudKitTransactionRepository contract")
+struct CloudKitTransactionRepositoryContractTests {
+  private func makeRepository() -> CloudKitTransactionRepository {
+    let config = ModelConfiguration(isStoredInMemoryOnly: true)
+    let container = try! ModelContainer(
+      for: TransactionRecord.self,
+      configurations: config
+    )
+    return CloudKitTransactionRepository(modelContainer: container)
+  }
+
+  // Run all contract tests against this repository...
+}
+```
+
+### Specific Test Cases
+1. **Filtering:** Each filter in isolation and in combination (mirrors InMemory tests)
+2. **Pagination:** First page, subsequent pages, empty page, single item
+3. **priorBalance:** Correct for each page
+4. **CRUD:** Create → fetch → update → fetch → delete → fetch
+5. **Payee suggestions:** Prefix matching, case-insensitive, distinct values
+6. **Sort order:** Date DESC, ID ASC
+7. **Account filter:** Matches both accountId and toAccountId for transfers
+8. **Scheduled filter:** Correctly distinguishes scheduled from non-scheduled
+
+### Performance Tests
+- Fetch with 10,000 transactions (baseline)
+- Filter by account with 10,000 transactions
+- Payee suggestions with 1,000 unique payees
+- priorBalance computation at various page depths
+
+---
+
+## Files to Create
+
+| File | Purpose |
+|------|---------|
+| `Backends/CloudKit/Models/TransactionRecord.swift` | SwiftData `@Model` |
+| `Backends/CloudKit/Repositories/CloudKitTransactionRepository.swift` | Repository implementation |
+| `MoolahTests/Backends/CloudKitTransactionRepositoryTests.swift` | Contract + specific tests |
+
+---
+
+## Estimated Effort
+
+| Task | Estimate |
+|------|----------|
+| `TransactionRecord` model | 1 hour |
+| Domain ↔ Record mapping | 1 hour |
+| `fetch()` with filtering & pagination | 4 hours |
+| `priorBalance` computation | 1 hour |
+| CRUD operations | 1 hour |
+| Payee suggestions | 1 hour |
+| Predicate optimization | 2 hours |
+| Tests | 3 hours |
+| **Total** | **~14 hours** |
+
+---
+
+## Risks
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Post-filter performance with many transactions | Medium | Predicate push-down for common single-filter cases |
+| `payeeLower` getting out of sync | Low | Always update in `create()` and `update()` |
+| CloudKit sync conflicts on rapid edits | Low | Last-writer-wins is acceptable for single-user |
+| SwiftData predicate limitations change in future OS | Low | Post-filter is always correct; predicates are optimizations |


### PR DESCRIPTION
Identifies the 6 major moolah-server components (auth, accounts,
transactions, categories, earmarks, scheduled transactions) and
documents the architecture for replacing the REST backend with
SwiftData + CloudKit syncing. Detailed component plans are being
generated separately.

https://claude.ai/code/session_01D2yfYY4EPnoA29HvKD4rmp