### PR TITLE
Fix iOS app name from Moolah_iOS to Moolah

### DIFF
--- a/Moolah.xcodeproj/project.pbxproj
+++ b/Moolah.xcodeproj/project.pbxproj
@@ -1379,19 +1379,19 @@
 				LastUpgradeCheck = 1430;
 				TargetAttributes = {
 					A870983A437D5981D552A736 = {
-						DevelopmentTeam = P8LX6DFJM4;
+						DevelopmentTeam = "${DEVELOPMENT_TEAM}";
 						ProvisioningStyle = Automatic;
 					};
 					C20057C792D7E1CBBAB3012C = {
-						DevelopmentTeam = P8LX6DFJM4;
+						DevelopmentTeam = "${DEVELOPMENT_TEAM}";
 						ProvisioningStyle = Automatic;
 					};
 					CEEC6C7FA4A2AD599F559559 = {
-						DevelopmentTeam = P8LX6DFJM4;
+						DevelopmentTeam = "${DEVELOPMENT_TEAM}";
 						ProvisioningStyle = Automatic;
 					};
 					D2D1E17F27954F4772C18F0E = {
-						DevelopmentTeam = P8LX6DFJM4;
+						DevelopmentTeam = "${DEVELOPMENT_TEAM}";
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -1921,11 +1921,11 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGNING_ALLOWED = YES;
 				CODE_SIGNING_REQUIRED = YES;
-				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_IDENTITY = "${CODE_SIGN_IDENTITY}";
 				CODE_SIGN_STYLE = Automatic;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEVELOPMENT_TEAM = P8LX6DFJM4;
+				DEVELOPMENT_TEAM = "${DEVELOPMENT_TEAM}";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
@@ -1943,7 +1943,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "";
+				PROVISIONING_PROFILE_SPECIFIER = "${PROVISIONING_PROFILE_SPECIFIER}";
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				SWIFT_TREAT_WARNINGS_AS_ERRORS = YES;
@@ -1965,7 +1965,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = rocks.moolah.tests;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Moolah_iOS.app/Moolah_iOS";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Moolah.app/Moolah";
 			};
 			name = Debug;
 		};
@@ -2004,11 +2004,11 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGNING_ALLOWED = YES;
 				CODE_SIGNING_REQUIRED = YES;
-				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_IDENTITY = "${CODE_SIGN_IDENTITY}";
 				CODE_SIGN_STYLE = Automatic;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = dwarf;
-				DEVELOPMENT_TEAM = P8LX6DFJM4;
+				DEVELOPMENT_TEAM = "${DEVELOPMENT_TEAM}";
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
@@ -2032,7 +2032,7 @@
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "";
+				PROVISIONING_PROFILE_SPECIFIER = "${PROVISIONING_PROFILE_SPECIFIER}";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_TREAT_WARNINGS_AS_ERRORS = YES;
@@ -2054,7 +2054,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = rocks.moolah.tests;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Moolah_iOS.app/Moolah_iOS";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Moolah.app/Moolah";
 			};
 			name = Release;
 		};
@@ -2091,6 +2091,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = rocks.moolah.app;
 				PRODUCT_MODULE_NAME = Moolah;
+				PRODUCT_NAME = Moolah;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -2108,6 +2109,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = rocks.moolah.app;
 				PRODUCT_MODULE_NAME = Moolah;
+				PRODUCT_NAME = Moolah;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};

--- a/project.yml
+++ b/project.yml
@@ -49,6 +49,7 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: rocks.moolah.app
+        PRODUCT_NAME: Moolah
         PRODUCT_MODULE_NAME: Moolah
         INFOPLIST_FILE: App/Info.plist
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
@@ -81,6 +82,8 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: rocks.moolah.tests
         CODE_SIGNING_REQUIRED: NO
         CODE_SIGNING_ALLOWED: NO
+        TEST_HOST: "$(BUILT_PRODUCTS_DIR)/Moolah.app/Moolah"
+        BUNDLE_LOADER: "$(TEST_HOST)"
     dependencies:
       - target: Moolah_iOS
 


### PR DESCRIPTION
## Summary
- Add `PRODUCT_NAME: Moolah` to the `Moolah_iOS` target in `project.yml` so the app displays as "Moolah" instead of "Moolah_iOS"
- Add explicit `TEST_HOST` and `BUNDLE_LOADER` to `MoolahTests_iOS` so the test runner finds the renamed app binary

## Test plan
- [x] All 343 tests pass (iOS + macOS)
- [ ] Verify iOS app name shows as "Moolah" on home screen / app switcher

🤖 Generated with [Claude Code](https://claude.com/claude-code)