### PR TITLE
Fix all four tracked bugs

### DIFF
--- a/App/ProfileWindowView.swift
+++ b/App/ProfileWindowView.swift
@@ -9,6 +9,8 @@
     @Environment(SessionManager.self) private var sessionManager
     @Environment(\.openWindow) private var openWindow
 
+    @Environment(\.dismiss) private var dismiss
+
     var body: some View {
       Group {
         if let profileID,
@@ -30,12 +32,14 @@
                 openWindow(value: first.id)
               }
             }
+        } else if profileStore.isCloudLoadPending {
+          ProgressView()
         } else {
-          ContentUnavailableView(
-            "Profile Not Found",
-            systemImage: "person.crop.circle.badge.xmark",
-            description: Text("This profile has been removed.")
-          )
+          // Profile is genuinely gone — close this window
+          Color.clear
+            .onAppear {
+              dismiss()
+            }
         }
       }
     }

--- a/BUGS.md
+++ b/BUGS.md
@@ -1,18 +1,2 @@
 # Known Bugs
 
-## Windows flash "profile removed" on app launch
-
-When the app first loads, all existing windows briefly show a "profile removed" message before updating to show the actual profile data. This happens because the profile list hasn't loaded yet when the windows render, so they can't find their profile and assume it was removed. Don't show the window content until profiles are loaded. Once profiles are loaded, if a window's profile is genuinely gone, close the window rather than showing a "removed" message.
-
-## iOS login page should allow changing profile without logging in
-
-On iOS, the login page shows the currently selected remote profile but doesn't offer a way to switch to a different profile. The user should be able to change to another profile from the profile selector without having to log into the one that happens to be selected.
-
-## macOS sidebar: account balance lacks contrast against selection highlight
-
-During recent UI review fixes, the fix ensuring sufficient contrast between the account balance text and the sidebar selection colour on macOS was lost. The balance text becomes hard to read when its row is selected.
-
-## Upcoming transactions analysis panel flashes on pay
-
-When paying a transaction, the upcoming transactions analysis panel flashes its content as if doing a full reload. It should update incrementally without a visible flash.
-

--- a/Features/Accounts/Views/AccountRowView.swift
+++ b/Features/Accounts/Views/AccountRowView.swift
@@ -13,8 +13,8 @@ struct SidebarRowView: View {
   @Environment(\.backgroundProminence) private var backgroundProminence
 
   /// Bright green/red that contrast well against the blue selection highlight.
-  private static let selectedPositiveColor = Color.mint
-  private static let selectedNegativeColor = Color.pink
+  private static let selectedPositiveColor = Color(red: 0.55, green: 1.0, blue: 0.65)
+  private static let selectedNegativeColor = Color(red: 1.0, green: 0.6, blue: 0.6)
 
   private var amountColorOverride: Color? {
     // Only use bright overrides when the row has a prominent (blue) selection

--- a/Features/Auth/UserMenuView.swift
+++ b/Features/Auth/UserMenuView.swift
@@ -78,19 +78,7 @@ struct UserMenuView: View {
   #if os(iOS)
     @ViewBuilder
     private var profileSection: some View {
-      ForEach(profileStore.profiles) { profile in
-        Button {
-          profileStore.setActiveProfile(profile.id)
-        } label: {
-          HStack {
-            if profile.id == profileStore.activeProfileID {
-              Image(systemName: "checkmark")
-                .accessibilityHidden(true)
-            }
-            Text(profile.label)
-          }
-        }
-      }
+      ProfileMenuItems()
 
       Button(String(localized: "Manage Profiles...")) {
         showManageProfiles = true

--- a/Features/Auth/WelcomeView.swift
+++ b/Features/Auth/WelcomeView.swift
@@ -5,6 +5,12 @@ import SwiftUI
 /// (e.g. a future CloudKit backend that authenticates implicitly via Apple ID).
 struct WelcomeView: View {
   @Environment(AuthStore.self) private var authStore
+  @Environment(ProfileStore.self) private var profileStore
+
+  #if os(iOS)
+    @Environment(ProfileSession.self) private var session
+    @State private var showManageProfiles = false
+  #endif
 
   var body: some View {
     VStack(spacing: 32) {
@@ -14,6 +20,12 @@ struct WelcomeView: View {
         Text(String(localized: "Personal finance, your way."))
           .foregroundStyle(.secondary)
       }
+
+      #if os(iOS)
+        if profileStore.profiles.count > 1 {
+          profilePicker
+        }
+      #endif
 
       if authStore.requiresSignIn {
         Button {
@@ -38,5 +50,46 @@ struct WelcomeView: View {
       }
     }
     .padding()
+    #if os(iOS)
+      .sheet(isPresented: $showManageProfiles) {
+        NavigationStack {
+          SettingsView(activeSession: session)
+          .environment(profileStore)
+          .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+              Button("Done") { showManageProfiles = false }
+            }
+          }
+        }
+      }
+    #endif
   }
+
+  #if os(iOS)
+    private var profilePicker: some View {
+      Menu {
+        ProfileMenuItems()
+
+        Divider()
+
+        Button(String(localized: "Manage Profiles...")) {
+          showManageProfiles = true
+        }
+      } label: {
+        HStack(spacing: 6) {
+          Image(systemName: "person.crop.circle")
+            .foregroundStyle(.secondary)
+          Text(profileStore.activeProfile?.label ?? "")
+            .font(.subheadline)
+          Image(systemName: "chevron.up.chevron.down")
+            .font(.caption2)
+            .foregroundStyle(.secondary)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(.fill.tertiary, in: .capsule)
+      }
+      .accessibilityLabel("Switch profile")
+    }
+  #endif
 }

--- a/Features/Profiles/ProfileStore.swift
+++ b/Features/Profiles/ProfileStore.swift
@@ -19,6 +19,10 @@ final class ProfileStore {
   private(set) var isValidating = false
   private(set) var validationError: String?
 
+  /// True while the initial cloud profile load may still be retrying.
+  /// SwiftData with CloudKit may not have its store ready on the first fetch.
+  private(set) var isCloudLoadPending = false
+
   /// Called when a cloud profile is removed (locally or via remote sync).
   /// Used by SessionManager to tear down the corresponding ProfileSession.
   var onProfileRemoved: ((UUID) -> Void)?
@@ -61,6 +65,9 @@ final class ProfileStore {
     if containerManager != nil {
       loadCloudProfiles(isInitialLoad: true)
       scheduleRetryIfNeeded()
+    } else {
+      // No CloudKit — nothing pending
+      isCloudLoadPending = false
     }
   }
 
@@ -297,12 +304,17 @@ final class ProfileStore {
       !remoteProfiles.contains(where: { $0.id == activeProfileID })
     else { return }
 
+    isCloudLoadPending = true
     logger.debug("Cloud profiles empty on initial load, scheduling retry")
     Task { @MainActor [weak self] in
       try? await Task.sleep(for: .seconds(1))
-      guard let self, self.cloudProfiles.isEmpty else { return }
+      guard let self, self.cloudProfiles.isEmpty else {
+        self?.isCloudLoadPending = false
+        return
+      }
       self.logger.debug("Retrying cloud profile load")
       self.loadCloudProfiles()
+      self.isCloudLoadPending = false
     }
   }
 

--- a/Features/Profiles/Views/ProfileMenuItems.swift
+++ b/Features/Profiles/Views/ProfileMenuItems.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+
+/// Reusable menu content that lists all profiles with a checkmark on the active one.
+/// Use inside a `Menu` or as inline content in another menu.
+struct ProfileMenuItems: View {
+  @Environment(ProfileStore.self) private var profileStore
+
+  var body: some View {
+    ForEach(profileStore.profiles) { profile in
+      Button {
+        profileStore.setActiveProfile(profile.id)
+      } label: {
+        HStack {
+          if profile.id == profileStore.activeProfileID {
+            Image(systemName: "checkmark")
+              .accessibilityHidden(true)
+          }
+          Text(profile.label)
+        }
+      }
+    }
+  }
+}

--- a/Features/Transactions/TransactionStore.swift
+++ b/Features/Transactions/TransactionStore.swift
@@ -147,7 +147,10 @@ final class TransactionStore {
       await delete(id: scheduledTransaction.id)
     }
 
-    await load(filter: TransactionFilter(scheduled: true))
+    // Remove the non-scheduled paid transaction from the local list
+    // (it was added by create() but doesn't belong in the scheduled view).
+    rawTransactions.removeAll { $0.id == paidTransaction.id }
+    await recomputeBalances()
 
     if scheduledTransaction.isRecurring {
       let updated = transactions.first { $0.transaction.id == scheduledTransaction.id }?.transaction


### PR DESCRIPTION
## Summary

- **Profile removed flash on launch (macOS):** Added `isCloudLoadPending` flag to `ProfileStore` so windows show a `ProgressView` while SwiftData/CloudKit retries, then auto-dismiss if the profile is genuinely gone
- **iOS login profile switcher:** Extracted `ProfileMenuItems` shared component, added profile picker with "Manage Profiles..." to `WelcomeView` so users can switch profiles and add new ones without logging in first
- **Sidebar balance contrast (macOS):** Restored original bright RGB colors (`Color(red: 0.55, green: 1.0, blue: 0.65)` / `Color(red: 1.0, green: 0.6, blue: 0.6)`) that were incorrectly replaced with `.mint`/`.pink` in UI review commit 7b73e51
- **Analysis panel flash on pay:** Replaced full `load()` call in `payScheduledTransaction` with incremental removal of the non-scheduled paid transaction from `rawTransactions`, preserving the updated recurring transaction with its advanced date

## Test plan

- [x] All 800 tests pass on macOS
- [x] macOS build succeeds with no user code warnings
- [ ] Verify macOS windows no longer flash "profile removed" on launch with CloudKit profiles
- [ ] Verify iOS login page shows profile picker when multiple profiles exist
- [ ] Verify "Manage Profiles..." opens settings sheet from login page
- [ ] Verify sidebar balance text is readable when row is selected (green positive, red negative)
- [ ] Verify paying a scheduled transaction updates the analysis panel without flashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)