### PR TITLE
Add comprehensive app automation (AppleScript, Shortcuts, URL scheme)

### DIFF
--- a/.claude/skills/automate-app/SKILL.md
+++ b/.claude/skills/automate-app/SKILL.md
@@ -1,0 +1,244 @@
+---
+name: automate-app
+description: Use when you need to interact with the running Moolah app — testing UI changes, verifying data, creating test fixtures, or navigating to specific views via AppleScript or URL scheme
+---
+
+# Automating the Moolah App
+
+Drive the running Moolah macOS app via AppleScript (`osascript`) for data operations and `moolah://` URLs for navigation.
+
+## CRITICAL: Profile Safety
+
+**Before taking ANY automation action, you MUST confirm with the user which profile to use.** Never assume a profile. Never default to the first profile. Ask explicitly, every time, even if there's only one profile open. This is real financial data — testing operations must not be performed on important profiles.
+
+**Recommended first step for testing:** Suggest creating a dedicated test profile via the app's UI or AppleScript.
+
+## Prerequisites
+
+The app must be running. Use `just run-mac` to build and launch, or `just run-mac-with-logs` to also capture logs.
+
+## AppleScript Reference
+
+All commands use `osascript -e '...'` from the terminal. The app must be running and the target profile must be open in a window.
+
+### Profile Operations
+
+```bash
+# List all open profiles
+osascript -e 'tell application "Moolah" to get name of every profile'
+
+# Get profile currency
+osascript -e 'tell application "Moolah" to get currency of profile "Test"'
+
+# Count profiles
+osascript -e 'tell application "Moolah" to count profiles'
+```
+
+### Account Operations
+
+```bash
+# List all accounts
+osascript -e 'tell application "Moolah" to get name of every account of profile "Test"'
+
+# Get account balance
+osascript -e 'tell application "Moolah" to get balance of account "Savings" of profile "Test"'
+
+# Get all account names and balances
+osascript -e 'tell application "Moolah" to get {name, balance} of every account of profile "Test"'
+
+# Get net worth
+osascript -e 'tell application "Moolah" to net worth of profile "Test"'
+
+# Create account
+osascript -e 'tell application "Moolah" to tell profile "Test" to create account name "New Account" type "bank"'
+# Types: bank, cc, asset, investment
+
+# Delete account
+osascript -e 'tell application "Moolah" to delete account "New Account" of profile "Test"'
+```
+
+### Transaction Operations
+
+```bash
+# Create a simple expense
+osascript -e 'tell application "Moolah" to tell profile "Test" to create transaction with payee "Woolworths" amount -42.50 account "Everyday" category "Groceries"'
+
+# Create with date and notes
+osascript -e 'tell application "Moolah" to tell profile "Test" to create transaction with payee "Rent" amount -2000.00 account "Everyday" date (date "2026-04-01") notes "April rent"'
+
+# Create income
+osascript -e 'tell application "Moolah" to tell profile "Test" to create transaction with payee "Employer" amount 5000.00 account "Everyday" category "Salary"'
+
+# List transactions (payee and amount)
+osascript -e 'tell application "Moolah" to get {payee, amount} of every transaction of profile "Test"'
+
+# Get transaction details
+osascript -e 'tell application "Moolah" to get {payee, date, amount, transaction type} of every transaction of profile "Test"'
+
+# Delete a transaction
+osascript -e 'tell application "Moolah" to delete transaction id "UUID-HERE" of profile "Test"'
+
+# Pay a scheduled transaction
+osascript -e 'tell application "Moolah" to pay transaction id "UUID-HERE" of profile "Test"'
+```
+
+### Earmark Operations
+
+```bash
+# List earmarks
+osascript -e 'tell application "Moolah" to get {name, balance} of every earmark of profile "Test"'
+
+# Create earmark with target
+osascript -e 'tell application "Moolah" to tell profile "Test" to create earmark name "Holiday" target 5000.00'
+
+# Create earmark without target
+osascript -e 'tell application "Moolah" to tell profile "Test" to create earmark name "Emergency Fund"'
+
+# Get earmark balance
+osascript -e 'tell application "Moolah" to get balance of earmark "Holiday" of profile "Test"'
+```
+
+### Category Operations
+
+```bash
+# List categories
+osascript -e 'tell application "Moolah" to get name of every category of profile "Test"'
+
+# Create category
+osascript -e 'tell application "Moolah" to tell profile "Test" to create category name "Groceries"'
+
+# Create subcategory
+osascript -e 'tell application "Moolah" to tell profile "Test" to create category name "Fruit" parent "Groceries"'
+```
+
+### Refresh and Navigation
+
+```bash
+# Refresh data from backend
+osascript -e 'tell application "Moolah" to refresh profile "Test"'
+
+# Navigate to a specific account
+osascript -e 'tell application "Moolah" to navigate to account "Savings" of profile "Test"'
+```
+
+## URL Scheme Reference
+
+Use `open` command to trigger navigation. The app opens/focuses the profile window and navigates to the destination.
+
+```bash
+# Open a profile window
+open "moolah://Test"
+
+# Navigate to a specific account
+open "moolah://Test/account/ACCOUNT-UUID-HERE"
+
+# Navigate to a specific transaction (opens in first leg's account context)
+open "moolah://Test/transaction/TRANSACTION-UUID-HERE"
+
+# Navigate to analysis with custom periods
+open "moolah://Test/analysis?history=12&forecast=3"
+
+# Navigate to reports with date range
+open "moolah://Test/reports?from=2026-01-01&to=2026-03-31"
+
+# Navigate to specific views
+open "moolah://Test/categories"
+open "moolah://Test/upcoming"
+open "moolah://Test/earmarks"
+open "moolah://Test/earmark/EARMARK-UUID-HERE"
+open "moolah://Test/accounts"
+
+# URL-encode profile names with spaces
+open "moolah://My%20Finances/analysis"
+```
+
+**Profile resolution:** Tries name match (case-insensitive) first, then UUID. If the profile isn't open, a new window opens for it.
+
+## Common Test Workflows
+
+### Verify account balance updates after transaction
+
+```bash
+# 1. Check initial balance
+osascript -e 'tell application "Moolah" to get balance of account "Everyday" of profile "Test"'
+
+# 2. Create a transaction
+osascript -e 'tell application "Moolah" to tell profile "Test" to create transaction with payee "Test Purchase" amount -25.00 account "Everyday"'
+
+# 3. Verify balance changed
+osascript -e 'tell application "Moolah" to get balance of account "Everyday" of profile "Test"'
+```
+
+### Verify UI navigation
+
+```bash
+# Navigate to analysis view and verify visually
+open "moolah://Test/analysis?history=6&forecast=3"
+
+# Navigate to specific account
+open "moolah://Test/account/ACCOUNT-UUID"
+```
+
+### Create a full test environment
+
+```bash
+osascript -e '
+tell application "Moolah"
+  tell profile "AI Test"
+    create account name "Checking" type "bank"
+    create account name "Savings" type "bank"
+    create account name "Credit Card" type "cc"
+    create category name "Food"
+    create category name "Transport"
+    create category name "Salary"
+    create earmark name "Emergency Fund" target 10000.00
+    create transaction with payee "Employer" amount 5000.00 account "Checking" category "Salary"
+    create transaction with payee "Groceries" amount -150.00 account "Checking" category "Food"
+    create transaction with payee "Gas" amount -60.00 account "Credit Card" category "Transport"
+  end tell
+end tell
+'
+```
+
+### Verify data integrity after code changes
+
+```bash
+# Get a snapshot of all state
+osascript -e '
+tell application "Moolah"
+  tell profile "AI Test"
+    set accts to {name, balance} of every account
+    set cats to name of every category
+    set earmarks to {name, balance} of every earmark
+    return {accts, cats, earmarks}
+  end tell
+end tell
+'
+```
+
+## Error Handling
+
+```bash
+# Wrap in try block to capture errors
+osascript -e '
+try
+  tell application "Moolah" to get balance of account "Nonexistent" of profile "Test"
+on error errMsg
+  return "ERROR: " & errMsg
+end try
+'
+```
+
+Common errors:
+- **"Profile not found"** — profile isn't open or name is misspelled
+- **"Account not found"** — account name doesn't match (matching is case-insensitive)
+- **"Operation failed"** — backend error, check app logs with `run-mac-app-with-logs` skill
+
+## Tips
+
+- **Use AppleScript for data operations** (CRUD, balance checks, queries)
+- **Use URL scheme for navigation** (opening views, navigating to specific entities)
+- **Always verify state after mutations** — read back the value you just changed
+- **Use `run-mac-app-with-logs` skill** to capture app logs while running automation for debugging
+- **Amounts are Decimal** — expenses are negative, income is positive. Don't use `abs()`.
+- **Profile must be open** — the profile needs to be open in a window for AppleScript to work with it

--- a/App/ContentView.swift
+++ b/App/ContentView.swift
@@ -12,6 +12,7 @@ struct ContentView: View {
   @Environment(TradeStore.self) private var tradeStore
   @State private var selection: SidebarSelection? = .analysis
 
+  @Environment(\.pendingNavigation) private var pendingNavigationBinding
   @State private var showCreateEarmarkSheet = false
 
   var body: some View {
@@ -124,6 +125,22 @@ struct ContentView: View {
           }
         }
       )
+    }
+    .onChange(of: pendingNavigationBinding?.wrappedValue) { _, newValue in
+      if let navigation = newValue {
+        applyNavigation(navigation.destination)
+        pendingNavigationBinding?.wrappedValue = nil
+      }
+    }
+  }
+
+  private func applyNavigation(_ destination: URLSchemeHandler.Destination) {
+    if let sidebarSelection = URLSchemeHandler.toSidebarSelection(destination) {
+      selection = sidebarSelection
+    }
+    if case .analysis(let history, let forecast) = destination {
+      if let history { analysisStore.historyMonths = history }
+      if let forecast { analysisStore.forecastMonths = forecast }
     }
   }
 }

--- a/App/Info.plist
+++ b/App/Info.plist
@@ -29,6 +29,10 @@
             </array>
         </dict>
     </array>
+    <key>NSAppleScriptEnabled</key>
+    <true/>
+    <key>OSAScriptingDefinition</key>
+    <string>Moolah.sdef</string>
     <key>LSMinimumSystemVersion</key>
     <string>$(MACOSX_DEPLOYMENT_TARGET)</string>
     <key>ITSAppUsesNonExemptEncryption</key>

--- a/App/MoolahApp.swift
+++ b/App/MoolahApp.swift
@@ -71,7 +71,9 @@ struct MoolahApp: App {
   private let syncCoordinator: SyncCoordinator
   @State private var profileStore: ProfileStore
   private let logger = Logger(subsystem: "com.moolah.app", category: "BackgroundSync")
+  @State private var pendingNavigation: PendingNavigation?
   #if os(macOS)
+    @Environment(\.openWindow) private var openWindow
     private let backupManager: StoreBackupManager
     @State private var sessionManager: SessionManager
   #else
@@ -161,6 +163,8 @@ struct MoolahApp: App {
           .environment(sessionManager)
           .environment(containerManager)
           .environment(syncCoordinator)
+          .environment(\.pendingNavigation, $pendingNavigation)
+          .onOpenURL { url in handleURL(url) }
           .task {
             backupManager.performDailyBackup(
               profiles: profileStore.profiles,
@@ -203,6 +207,8 @@ struct MoolahApp: App {
           .environment(profileStore)
           .environment(containerManager)
           .environment(syncCoordinator)
+          .environment(\.pendingNavigation, $pendingNavigation)
+          .onOpenURL { url in handleURL(url) }
       }
       .modelContainer(containerManager.indexContainer)
       .onChange(of: scenePhase) { _, newPhase in
@@ -259,5 +265,36 @@ struct MoolahApp: App {
   private func fetchRemoteChanges() async {
     logger.info("Fetching remote changes on foreground entry")
     await syncCoordinator.fetchChanges()
+  }
+
+  // MARK: - URL Scheme Handling
+
+  private func handleURL(_ url: URL) {
+    do {
+      let route = try URLSchemeHandler.parse(url)
+      // Find profile by name (case-insensitive) then by UUID
+      if let profile = profileStore.profiles.first(where: {
+        $0.label.lowercased() == route.profileIdentifier.lowercased()
+      })
+        ?? profileStore.profiles.first(where: {
+          $0.id.uuidString.lowercased() == route.profileIdentifier.lowercased()
+        })
+      {
+        #if os(macOS)
+          openWindow(value: profile.id)
+        #else
+          profileStore.setActiveProfile(profile.id)
+        #endif
+        if let destination = route.destination {
+          pendingNavigation = PendingNavigation(
+            profileId: profile.id, destination: destination)
+        }
+      } else {
+        logger.warning(
+          "No profile found matching '\(route.profileIdentifier, privacy: .public)'")
+      }
+    } catch {
+      logger.error("Failed to parse URL: \(error.localizedDescription, privacy: .public)")
+    }
   }
 }

--- a/App/MoolahApp.swift
+++ b/App/MoolahApp.swift
@@ -73,6 +73,7 @@ struct MoolahApp: App {
   private let logger = Logger(subsystem: "com.moolah.app", category: "BackgroundSync")
   @State private var pendingNavigation: PendingNavigation?
   #if os(macOS)
+    @NSApplicationDelegateAdaptor(ScriptingBridge.self) var scriptingBridge
     @Environment(\.openWindow) private var openWindow
     private let backupManager: StoreBackupManager
     @State private var sessionManager: SessionManager
@@ -152,6 +153,11 @@ struct MoolahApp: App {
       store.onProfileRemoved = { [weak sessionManager] profileID in
         sessionManager?.removeSession(for: profileID)
       }
+
+      // Configure AppleScript scripting context
+      let automationService = AutomationService(sessionManager: sessionManager)
+      ScriptingContext.automationService = automationService
+      ScriptingContext.sessionManager = sessionManager
     #endif
   }
 

--- a/App/MoolahApp.swift
+++ b/App/MoolahApp.swift
@@ -79,6 +79,7 @@ struct MoolahApp: App {
     @State private var sessionManager: SessionManager
   #else
     @State private var activeSession: ProfileSession?
+    @State private var sessionManager: SessionManager
   #endif
 
   init() {
@@ -159,6 +160,19 @@ struct MoolahApp: App {
       ScriptingContext.automationService = automationService
       ScriptingContext.sessionManager = sessionManager
       AutomationServiceLocator.shared.service = automationService
+    #else
+      let sessionManager = SessionManager(
+        containerManager: containerManager, syncCoordinator: coordinator)
+      _sessionManager = State(initialValue: sessionManager)
+
+      // Clean up cached sessions when a profile is removed (locally or via remote sync)
+      store.onProfileRemoved = { [weak sessionManager] profileID in
+        sessionManager?.removeSession(for: profileID)
+      }
+
+      // Configure App Intents service locator
+      let automationService = AutomationService(sessionManager: sessionManager)
+      AutomationServiceLocator.shared.service = automationService
     #endif
   }
 
@@ -212,6 +226,7 @@ struct MoolahApp: App {
       WindowGroup {
         ProfileRootView(activeSession: $activeSession)
           .environment(profileStore)
+          .environment(sessionManager)
           .environment(containerManager)
           .environment(syncCoordinator)
           .environment(\.pendingNavigation, $pendingNavigation)

--- a/App/MoolahApp.swift
+++ b/App/MoolahApp.swift
@@ -154,10 +154,11 @@ struct MoolahApp: App {
         sessionManager?.removeSession(for: profileID)
       }
 
-      // Configure AppleScript scripting context
+      // Configure AppleScript scripting context and App Intents service locator
       let automationService = AutomationService(sessionManager: sessionManager)
       ScriptingContext.automationService = automationService
       ScriptingContext.sessionManager = sessionManager
+      AutomationServiceLocator.shared.service = automationService
     #endif
   }
 

--- a/App/ProfileRootView.swift
+++ b/App/ProfileRootView.swift
@@ -9,6 +9,7 @@
   /// On macOS, ProfileWindowView handles this role.
   struct ProfileRootView: View {
     @Environment(ProfileStore.self) private var profileStore
+    @Environment(SessionManager.self) private var sessionManager
     @Environment(ProfileContainerManager.self) private var containerManager
     @Environment(SyncCoordinator.self) private var syncCoordinator
     @Binding var activeSession: ProfileSession?
@@ -61,11 +62,7 @@
 
       // Only create a new session if profile changed
       if activeSession?.profile.id != profileID {
-        activeSession = ProfileSession(
-          profile: profile,
-          containerManager: containerManager,
-          syncCoordinator: syncCoordinator
-        )
+        activeSession = sessionManager.session(for: profile)
       }
     }
 
@@ -76,11 +73,8 @@
       if let session = activeSession,
         session.profile.resolvedServerURL != profile.resolvedServerURL
       {
-        activeSession = ProfileSession(
-          profile: profile,
-          containerManager: containerManager,
-          syncCoordinator: syncCoordinator
-        )
+        sessionManager.rebuildSession(for: profile)
+        activeSession = sessionManager.session(for: profile)
       }
     }
 

--- a/App/SessionManager.swift
+++ b/App/SessionManager.swift
@@ -32,6 +32,24 @@ final class SessionManager {
     }
   }
 
+  // MARK: - Automation Lookup
+
+  /// Find an open session by profile name (case-insensitive).
+  func session(named name: String) -> ProfileSession? {
+    let lowered = name.lowercased()
+    return sessions.values.first { $0.profile.label.lowercased() == lowered }
+  }
+
+  /// Find an open session by profile UUID.
+  func session(forID id: UUID) -> ProfileSession? {
+    sessions[id]
+  }
+
+  /// All currently open profile sessions.
+  var openProfiles: [ProfileSession] {
+    Array(sessions.values)
+  }
+
   /// Replaces the session for a profile with a fresh instance
   /// (e.g. when the profile's server URL changes).
   func rebuildSession(for profile: Profile) {

--- a/Automation/AppleScript/Commands/CreateAccountCommand.swift
+++ b/Automation/AppleScript/Commands/CreateAccountCommand.swift
@@ -1,0 +1,46 @@
+#if os(macOS)
+  import AppKit
+  import Foundation
+  import OSLog
+
+  private let logger = Logger(subsystem: "com.moolah.app", category: "CreateAccountCommand")
+
+  /// Handles: `create account profile "X" name "Checking" type "bank"`
+  class CreateAccountCommand: NSScriptCommand {
+    override func performDefaultImplementation() -> Any? {
+      guard let profileName = resolveProfileName() else {
+        scriptErrorNumber = -10000
+        scriptErrorString = "Missing profile specifier"
+        return nil
+      }
+      guard let args = evaluatedArguments,
+        let name = args["name"] as? String,
+        let typeString = args["type"] as? String
+      else {
+        scriptErrorNumber = -10000
+        scriptErrorString = "Missing required parameters: name and type"
+        return nil
+      }
+
+      guard let accountType = AccountType(rawValue: typeString) else {
+        scriptErrorNumber = -10000
+        scriptErrorString =
+          "Invalid account type '\(typeString)'. Use: bank, cc, asset, or investment"
+        return nil
+      }
+
+      let profName = profileName
+      return runBlockingWithError { @MainActor in
+        guard let service = ScriptingContext.automationService else {
+          throw AutomationError.operationFailed("Scripting not configured")
+        }
+        let account = try await service.createAccount(
+          profileIdentifier: profName,
+          name: name,
+          type: accountType
+        )
+        return ScriptableAccount(account: account, profileName: profName)
+      }
+    }
+  }
+#endif

--- a/Automation/AppleScript/Commands/CreateAccountCommand.swift
+++ b/Automation/AppleScript/Commands/CreateAccountCommand.swift
@@ -30,7 +30,8 @@
       }
 
       let profName = profileName
-      return runBlockingWithError { @MainActor in
+      let result: ScriptableAccount? = runBlockingWithError {
+        @MainActor () async throws -> ScriptableAccount in
         guard let service = ScriptingContext.automationService else {
           throw AutomationError.operationFailed("Scripting not configured")
         }
@@ -41,6 +42,7 @@
         )
         return ScriptableAccount(account: account, profileName: profName)
       }
+      return result
     }
   }
 #endif

--- a/Automation/AppleScript/Commands/CreateCategoryCommand.swift
+++ b/Automation/AppleScript/Commands/CreateCategoryCommand.swift
@@ -24,7 +24,8 @@
       let parentName = args["parent"] as? String
       let profName = profileName
 
-      return runBlockingWithError { @MainActor in
+      let result: ScriptableCategory? = runBlockingWithError {
+        @MainActor () async throws -> ScriptableCategory in
         guard let service = ScriptingContext.automationService else {
           throw AutomationError.operationFailed("Scripting not configured")
         }
@@ -45,6 +46,7 @@
         return ScriptableCategory(
           category: category, parentName: parentDisplay, profileName: profName)
       }
+      return result
     }
   }
 #endif

--- a/Automation/AppleScript/Commands/CreateCategoryCommand.swift
+++ b/Automation/AppleScript/Commands/CreateCategoryCommand.swift
@@ -1,0 +1,50 @@
+#if os(macOS)
+  import AppKit
+  import Foundation
+  import OSLog
+
+  private let logger = Logger(subsystem: "com.moolah.app", category: "CreateCategoryCommand")
+
+  /// Handles: `create category profile "X" name "Groceries" parent "Food"`
+  class CreateCategoryCommand: NSScriptCommand {
+    override func performDefaultImplementation() -> Any? {
+      guard let profileName = resolveProfileName() else {
+        scriptErrorNumber = -10000
+        scriptErrorString = "Missing profile specifier"
+        return nil
+      }
+      guard let args = evaluatedArguments,
+        let name = args["name"] as? String
+      else {
+        scriptErrorNumber = -10000
+        scriptErrorString = "Missing required parameter: name"
+        return nil
+      }
+
+      let parentName = args["parent"] as? String
+      let profName = profileName
+
+      return runBlockingWithError { @MainActor in
+        guard let service = ScriptingContext.automationService else {
+          throw AutomationError.operationFailed("Scripting not configured")
+        }
+        let category = try await service.createCategory(
+          profileIdentifier: profName,
+          name: name,
+          parentName: parentName
+        )
+        let session = try service.resolveSession(for: profName)
+        let parentDisplay: String
+        if let parentId = category.parentId,
+          let parent = session.categoryStore.categories.by(id: parentId)
+        {
+          parentDisplay = parent.name
+        } else {
+          parentDisplay = ""
+        }
+        return ScriptableCategory(
+          category: category, parentName: parentDisplay, profileName: profName)
+      }
+    }
+  }
+#endif

--- a/Automation/AppleScript/Commands/CreateEarmarkCommand.swift
+++ b/Automation/AppleScript/Commands/CreateEarmarkCommand.swift
@@ -24,7 +24,8 @@
       let target = args["target"] as? Double
       let profName = profileName
 
-      return runBlockingWithError { @MainActor in
+      let result: ScriptableEarmark? = runBlockingWithError {
+        @MainActor () async throws -> ScriptableEarmark in
         guard let service = ScriptingContext.automationService else {
           throw AutomationError.operationFailed("Scripting not configured")
         }
@@ -35,6 +36,7 @@
         )
         return ScriptableEarmark(earmark: earmark, profileName: profName)
       }
+      return result
     }
   }
 #endif

--- a/Automation/AppleScript/Commands/CreateEarmarkCommand.swift
+++ b/Automation/AppleScript/Commands/CreateEarmarkCommand.swift
@@ -1,0 +1,40 @@
+#if os(macOS)
+  import AppKit
+  import Foundation
+  import OSLog
+
+  private let logger = Logger(subsystem: "com.moolah.app", category: "CreateEarmarkCommand")
+
+  /// Handles: `create earmark profile "X" name "Holiday" target 5000.0`
+  class CreateEarmarkCommand: NSScriptCommand {
+    override func performDefaultImplementation() -> Any? {
+      guard let profileName = resolveProfileName() else {
+        scriptErrorNumber = -10000
+        scriptErrorString = "Missing profile specifier"
+        return nil
+      }
+      guard let args = evaluatedArguments,
+        let name = args["name"] as? String
+      else {
+        scriptErrorNumber = -10000
+        scriptErrorString = "Missing required parameter: name"
+        return nil
+      }
+
+      let target = args["target"] as? Double
+      let profName = profileName
+
+      return runBlockingWithError { @MainActor in
+        guard let service = ScriptingContext.automationService else {
+          throw AutomationError.operationFailed("Scripting not configured")
+        }
+        let earmark = try await service.createEarmark(
+          profileIdentifier: profName,
+          name: name,
+          targetAmount: target.map { Decimal($0) }
+        )
+        return ScriptableEarmark(earmark: earmark, profileName: profName)
+      }
+    }
+  }
+#endif

--- a/Automation/AppleScript/Commands/CreateTransactionCommand.swift
+++ b/Automation/AppleScript/Commands/CreateTransactionCommand.swift
@@ -28,7 +28,8 @@
       let notes = args["notes"] as? String
       let profName = profileName
 
-      return runBlockingWithError { @MainActor in
+      let result: ScriptableTransaction? = runBlockingWithError {
+        @MainActor () async throws -> ScriptableTransaction in
         guard let service = ScriptingContext.automationService else {
           throw AutomationError.operationFailed("Scripting not configured")
         }
@@ -55,6 +56,7 @@
           categoryStore: session.categoryStore
         )
       }
+      return result
     }
   }
 #endif

--- a/Automation/AppleScript/Commands/CreateTransactionCommand.swift
+++ b/Automation/AppleScript/Commands/CreateTransactionCommand.swift
@@ -1,0 +1,60 @@
+#if os(macOS)
+  import AppKit
+  import Foundation
+  import OSLog
+
+  private let logger = Logger(subsystem: "com.moolah.app", category: "CreateTransactionCommand")
+
+  /// Handles: `create transaction profile "X" with payee "Store" amount -42.50 account "Checking"`
+  class CreateTransactionCommand: NSScriptCommand {
+    override func performDefaultImplementation() -> Any? {
+      guard let profileName = resolveProfileName() else {
+        scriptErrorNumber = -10000
+        scriptErrorString = "Missing profile specifier"
+        return nil
+      }
+      guard let args = evaluatedArguments,
+        let payee = args["withPayee"] as? String,
+        let amount = args["amount"] as? Double,
+        let accountName = args["account"] as? String
+      else {
+        scriptErrorNumber = -10000
+        scriptErrorString = "Missing required parameters: with payee, amount, and account"
+        return nil
+      }
+
+      let categoryName = args["category"] as? String
+      let date = args["onDate"] as? Date ?? Date()
+      let notes = args["notes"] as? String
+      let profName = profileName
+
+      return runBlockingWithError { @MainActor in
+        guard let service = ScriptingContext.automationService else {
+          throw AutomationError.operationFailed("Scripting not configured")
+        }
+
+        let leg = AutomationService.LegSpec(
+          accountName: accountName,
+          amount: Decimal(amount),
+          categoryName: categoryName,
+          earmarkName: nil
+        )
+
+        let transaction = try await service.createTransaction(
+          profileIdentifier: profName,
+          payee: payee,
+          date: date,
+          legs: [leg],
+          notes: notes
+        )
+        let session = try service.resolveSession(for: profName)
+        return ScriptableTransaction(
+          transaction: transaction,
+          profileName: profName,
+          accountStore: session.accountStore,
+          categoryStore: session.categoryStore
+        )
+      }
+    }
+  }
+#endif

--- a/Automation/AppleScript/Commands/DeleteCommand.swift
+++ b/Automation/AppleScript/Commands/DeleteCommand.swift
@@ -1,0 +1,98 @@
+#if os(macOS)
+  import AppKit
+  import Foundation
+  import OSLog
+
+  private let logger = Logger(subsystem: "com.moolah.app", category: "DeleteCommand")
+
+  /// Handles: `delete account "Checking" of profile "X"`
+  /// Works for accounts, transactions, earmarks, and categories.
+  class DeleteCommand: NSScriptCommand {
+    override func performDefaultImplementation() -> Any? {
+      guard let specifier = directParameter as? NSScriptObjectSpecifier else {
+        scriptErrorNumber = -10000
+        scriptErrorString = "Missing object specifier for delete"
+        return nil
+      }
+
+      // Walk up the specifier chain to find the profile name
+      let profileName: String
+      let objectKey = specifier.key
+      let container = specifier.container
+
+      // The specifier should be: object of profile "X"
+      if let nameSpec = container as? NSNameSpecifier {
+        profileName = nameSpec.name
+      } else {
+        scriptErrorNumber = -10000
+        scriptErrorString = "Cannot determine profile for delete operation"
+        return nil
+      }
+
+      // Determine what we're deleting based on the key
+      let objectName: String?
+      let objectID: String?
+
+      if let nameSpec = specifier as? NSNameSpecifier {
+        objectName = nameSpec.name
+        objectID = nil
+      } else if let idSpec = specifier as? NSUniqueIDSpecifier {
+        objectName = nil
+        objectID = idSpec.uniqueID as? String
+      } else {
+        scriptErrorNumber = -10000
+        scriptErrorString = "Cannot identify object to delete"
+        return nil
+      }
+
+      return runBlockingWithError { @MainActor in
+        guard let service = ScriptingContext.automationService else {
+          throw AutomationError.operationFailed("Scripting not configured")
+        }
+
+        switch objectKey {
+        case "scriptableAccounts":
+          let account: Account
+          if let objectName {
+            account = try service.resolveAccount(named: objectName, profileIdentifier: profileName)
+          } else if let objectID, let uuid = UUID(uuidString: objectID) {
+            account = try service.resolveAccount(id: uuid, profileIdentifier: profileName)
+          } else {
+            throw AutomationError.accountNotFound("unknown")
+          }
+          try await service.deleteAccount(profileIdentifier: profileName, accountId: account.id)
+
+        case "scriptableTransactions":
+          guard let objectID, let uuid = UUID(uuidString: objectID) else {
+            throw AutomationError.transactionNotFound("unknown")
+          }
+          try await service.deleteTransaction(profileIdentifier: profileName, transactionId: uuid)
+
+        case "scriptableEarmarks":
+          let earmark: Earmark
+          if let objectName {
+            earmark = try service.resolveEarmark(named: objectName, profileIdentifier: profileName)
+          } else {
+            throw AutomationError.earmarkNotFound("unknown")
+          }
+          try await service.deleteEarmark(profileIdentifier: profileName, earmarkId: earmark.id)
+
+        case "scriptableCategories":
+          let category: Category
+          if let objectName {
+            category = try service.resolveCategory(
+              named: objectName, profileIdentifier: profileName)
+          } else {
+            throw AutomationError.categoryNotFound("unknown")
+          }
+          try await service.deleteCategory(profileIdentifier: profileName, categoryId: category.id)
+
+        default:
+          throw AutomationError.operationFailed("Cannot delete objects of type '\(objectKey)'")
+        }
+
+        return true
+      }
+    }
+  }
+#endif

--- a/Automation/AppleScript/Commands/DeleteCommand.swift
+++ b/Automation/AppleScript/Commands/DeleteCommand.swift
@@ -45,7 +45,7 @@
         return nil
       }
 
-      return runBlockingWithError { @MainActor in
+      let result: Bool? = runBlockingWithError { @MainActor () async throws -> Bool in
         guard let service = ScriptingContext.automationService else {
           throw AutomationError.operationFailed("Scripting not configured")
         }
@@ -93,6 +93,7 @@
 
         return true
       }
+      return result
     }
   }
 #endif

--- a/Automation/AppleScript/Commands/NavigateCommand.swift
+++ b/Automation/AppleScript/Commands/NavigateCommand.swift
@@ -1,0 +1,74 @@
+#if os(macOS)
+  import AppKit
+  import Foundation
+  import OSLog
+
+  private let logger = Logger(subsystem: "com.moolah.app", category: "NavigateCommand")
+
+  /// Handles: `navigate to account "Checking" of profile "X"`
+  /// Uses the URL scheme handler to trigger navigation in the UI.
+  class NavigateCommand: NSScriptCommand {
+    override func performDefaultImplementation() -> Any? {
+      guard let specifier = directParameter as? NSScriptObjectSpecifier else {
+        scriptErrorNumber = -10000
+        scriptErrorString = "Missing object specifier for navigation"
+        return nil
+      }
+
+      let objectKey = specifier.key
+
+      // Walk up to find the profile name
+      guard let profileSpec = specifier.container as? NSNameSpecifier else {
+        // Maybe the specifier IS a profile
+        if let nameSpec = specifier as? NSNameSpecifier, specifier.key == "scriptableProfiles" {
+          // Navigate to profile root — just open the window
+          let profileName = nameSpec.name
+          let urlString =
+            "moolah://\(profileName.addingPercentEncoding(withAllowedCharacters: .urlHostAllowed) ?? profileName)"
+          if let url = URL(string: urlString) {
+            NSWorkspace.shared.open(url)
+          }
+          return nil
+        }
+        scriptErrorNumber = -10000
+        scriptErrorString = "Cannot determine profile for navigation"
+        return nil
+      }
+      let profileName = profileSpec.name
+
+      // Build a moolah:// URL based on the object type
+      let destination: String
+      switch objectKey {
+      case "scriptableAccounts":
+        if let nameSpec = specifier as? NSNameSpecifier {
+          destination =
+            "accounts/\(nameSpec.name.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? nameSpec.name)"
+        } else {
+          destination = "accounts"
+        }
+      case "scriptableTransactions":
+        destination = "transactions"
+      case "scriptableEarmarks":
+        if let nameSpec = specifier as? NSNameSpecifier {
+          destination =
+            "earmarks/\(nameSpec.name.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? nameSpec.name)"
+        } else {
+          destination = "earmarks"
+        }
+      case "scriptableCategories":
+        destination = "categories"
+      default:
+        destination = ""
+      }
+
+      let host =
+        profileName.addingPercentEncoding(withAllowedCharacters: .urlHostAllowed) ?? profileName
+      let urlString = destination.isEmpty ? "moolah://\(host)" : "moolah://\(host)/\(destination)"
+      if let url = URL(string: urlString) {
+        NSWorkspace.shared.open(url)
+      }
+
+      return nil
+    }
+  }
+#endif

--- a/Automation/AppleScript/Commands/NetWorthCommand.swift
+++ b/Automation/AppleScript/Commands/NetWorthCommand.swift
@@ -1,0 +1,26 @@
+#if os(macOS)
+  import AppKit
+  import Foundation
+  import OSLog
+
+  private let logger = Logger(subsystem: "com.moolah.app", category: "NetWorthCommand")
+
+  /// Handles: `net worth profile "X"` → returns a real number
+  class NetWorthCommand: NSScriptCommand {
+    override func performDefaultImplementation() -> Any? {
+      guard let profileName = resolveProfileName() else {
+        scriptErrorNumber = -10000
+        scriptErrorString = "Missing profile specifier"
+        return nil
+      }
+
+      return runBlockingWithError { @MainActor in
+        guard let service = ScriptingContext.automationService else {
+          throw AutomationError.operationFailed("Scripting not configured")
+        }
+        let netWorth = try service.getNetWorth(profileIdentifier: profileName)
+        return netWorth.doubleValue as NSNumber
+      }
+    }
+  }
+#endif

--- a/Automation/AppleScript/Commands/NetWorthCommand.swift
+++ b/Automation/AppleScript/Commands/NetWorthCommand.swift
@@ -14,13 +14,14 @@
         return nil
       }
 
-      return runBlockingWithError { @MainActor in
+      let result: NSNumber? = runBlockingWithError { @MainActor () async throws -> NSNumber in
         guard let service = ScriptingContext.automationService else {
           throw AutomationError.operationFailed("Scripting not configured")
         }
         let netWorth = try service.getNetWorth(profileIdentifier: profileName)
         return netWorth.doubleValue as NSNumber
       }
+      return result
     }
   }
 #endif

--- a/Automation/AppleScript/Commands/PayScheduledCommand.swift
+++ b/Automation/AppleScript/Commands/PayScheduledCommand.swift
@@ -1,0 +1,64 @@
+#if os(macOS)
+  import AppKit
+  import Foundation
+  import OSLog
+
+  private let logger = Logger(subsystem: "com.moolah.app", category: "PayScheduledCommand")
+
+  /// Handles: `pay transaction id "uuid" of profile "X"`
+  class PayScheduledCommand: NSScriptCommand {
+    override func performDefaultImplementation() -> Any? {
+      guard let specifier = directParameter as? NSScriptObjectSpecifier else {
+        scriptErrorNumber = -10000
+        scriptErrorString = "Missing transaction specifier"
+        return nil
+      }
+
+      // Get the transaction ID from the specifier
+      guard let idSpec = specifier as? NSUniqueIDSpecifier,
+        let transactionID = idSpec.uniqueID as? String,
+        let uuid = UUID(uuidString: transactionID)
+      else {
+        scriptErrorNumber = -10000
+        scriptErrorString = "Pay command requires a transaction specifier with an ID"
+        return nil
+      }
+
+      // Get the profile from the container
+      guard let profileSpec = specifier.container as? NSNameSpecifier else {
+        scriptErrorNumber = -10000
+        scriptErrorString = "Cannot determine profile for pay command"
+        return nil
+      }
+      let profName = profileSpec.name
+
+      return runBlockingWithError { @MainActor () async throws -> ScriptableTransaction in
+        guard let service = ScriptingContext.automationService else {
+          throw AutomationError.operationFailed("Scripting not configured")
+        }
+        let payResult = try await service.payScheduledTransaction(
+          profileIdentifier: profName,
+          transactionId: uuid
+        )
+        let session = try service.resolveSession(for: profName)
+        switch payResult {
+        case .paid(let updatedScheduled):
+          if let updated = updatedScheduled {
+            return ScriptableTransaction(
+              transaction: updated,
+              profileName: profName,
+              accountStore: session.accountStore,
+              categoryStore: session.categoryStore
+            )
+          }
+          throw AutomationError.operationFailed(
+            "Transaction was paid but no updated version returned")
+        case .deleted:
+          throw AutomationError.operationFailed("Scheduled transaction was deleted after payment")
+        case .failed:
+          throw AutomationError.operationFailed("Failed to pay scheduled transaction")
+        }
+      }
+    }
+  }
+#endif

--- a/Automation/AppleScript/Commands/PayScheduledCommand.swift
+++ b/Automation/AppleScript/Commands/PayScheduledCommand.swift
@@ -32,7 +32,8 @@
       }
       let profName = profileSpec.name
 
-      return runBlockingWithError { @MainActor () async throws -> ScriptableTransaction in
+      let result: ScriptableTransaction? = runBlockingWithError {
+        @MainActor () async throws -> ScriptableTransaction in
         guard let service = ScriptingContext.automationService else {
           throw AutomationError.operationFailed("Scripting not configured")
         }
@@ -59,6 +60,7 @@
           throw AutomationError.operationFailed("Failed to pay scheduled transaction")
         }
       }
+      return result
     }
   }
 #endif

--- a/Automation/AppleScript/Commands/RefreshCommand.swift
+++ b/Automation/AppleScript/Commands/RefreshCommand.swift
@@ -10,7 +10,7 @@
     override func performDefaultImplementation() -> Any? {
       let profileName = resolveProfileName()
 
-      let _: Bool? = runBlockingWithError { @MainActor in
+      let _: Bool? = runBlockingWithError { @MainActor () async throws -> Bool in
         guard let service = ScriptingContext.automationService else {
           throw AutomationError.operationFailed("Scripting not configured")
         }

--- a/Automation/AppleScript/Commands/RefreshCommand.swift
+++ b/Automation/AppleScript/Commands/RefreshCommand.swift
@@ -1,0 +1,32 @@
+#if os(macOS)
+  import AppKit
+  import Foundation
+  import OSLog
+
+  private let logger = Logger(subsystem: "com.moolah.app", category: "RefreshCommand")
+
+  /// Handles: `refresh profile "X"` or `refresh`
+  class RefreshCommand: NSScriptCommand {
+    override func performDefaultImplementation() -> Any? {
+      let profileName = resolveProfileName()
+
+      let _: Bool? = runBlockingWithError { @MainActor in
+        guard let service = ScriptingContext.automationService else {
+          throw AutomationError.operationFailed("Scripting not configured")
+        }
+
+        if let profileName {
+          try await service.refresh(profileIdentifier: profileName)
+        } else {
+          // Refresh all open profiles
+          for session in service.sessionManager.openProfiles {
+            try await service.refresh(profileIdentifier: session.profile.label)
+          }
+        }
+
+        return true
+      }
+      return nil
+    }
+  }
+#endif

--- a/Automation/AppleScript/Commands/ScriptCommandHelpers.swift
+++ b/Automation/AppleScript/Commands/ScriptCommandHelpers.swift
@@ -5,6 +5,13 @@
 
   private let logger = Logger(subsystem: "com.moolah.app", category: "ScriptCommand")
 
+  /// Thread-safe box for transferring results across actor boundaries via semaphore.
+  /// The semaphore ensures happens-before ordering between write (in Task) and read (after wait).
+  final class ScriptResultBox<T: Sendable>: @unchecked Sendable {
+    var value: T?
+    var error: String?
+  }
+
   extension NSScriptCommand {
 
     /// Resolves the profile name from the direct parameter (an object specifier).
@@ -26,9 +33,9 @@
     /// Runs an async MainActor block synchronously, suitable for NSScriptCommand handlers.
     /// Uses a semaphore to bridge async/sync. This is safe because NSScriptCommand handlers
     /// run on a dedicated Apple Events thread, not the main thread.
-    func runBlockingWithError<T>(_ operation: @escaping @MainActor @Sendable () async throws -> T)
-      -> T?
-    {
+    func runBlockingWithError<T: Sendable>(
+      _ operation: @escaping @MainActor @Sendable () async throws -> sending T
+    ) -> T? {
       guard !Thread.isMainThread else {
         logger.error("runBlockingWithError called on main thread - would deadlock")
         scriptErrorNumber = errOSAGeneralError
@@ -36,29 +43,28 @@
         return nil
       }
 
-      nonisolated(unsafe) var result: T?
-      nonisolated(unsafe) var caughtError: String?
+      let box = ScriptResultBox<T>()
       let semaphore = DispatchSemaphore(value: 0)
 
       Task { @MainActor in
         do {
-          result = try await operation()
+          box.value = try await operation()
         } catch {
-          caughtError = error.localizedDescription
+          box.error = error.localizedDescription
         }
         semaphore.signal()
       }
 
       semaphore.wait()
 
-      if let errorMessage = caughtError {
+      if let errorMessage = box.error {
         logger.error("Script command failed: \(errorMessage)")
         scriptErrorNumber = errOSAGeneralError
         scriptErrorString = errorMessage
         return nil
       }
 
-      return result
+      return box.value
     }
   }
 

--- a/Automation/AppleScript/Commands/ScriptCommandHelpers.swift
+++ b/Automation/AppleScript/Commands/ScriptCommandHelpers.swift
@@ -1,0 +1,67 @@
+#if os(macOS)
+  import AppKit
+  import Foundation
+  import OSLog
+
+  private let logger = Logger(subsystem: "com.moolah.app", category: "ScriptCommand")
+
+  extension NSScriptCommand {
+
+    /// Resolves the profile name from the direct parameter (an object specifier).
+    /// AppleScript commands typically pass a specifier like `profile "MyProfile"`.
+    func resolveProfileName() -> String? {
+      if let specifier = directParameter as? NSScriptObjectSpecifier {
+        // NSNameSpecifier: `profile "MyProfile"`
+        if let nameSpec = specifier as? NSNameSpecifier {
+          return nameSpec.name
+        }
+      }
+      // Direct parameter might be a string
+      if let name = directParameter as? String {
+        return name
+      }
+      return nil
+    }
+
+    /// Runs an async MainActor block synchronously, suitable for NSScriptCommand handlers.
+    /// Uses a semaphore to bridge async/sync. This is safe because NSScriptCommand handlers
+    /// run on a dedicated Apple Events thread, not the main thread.
+    func runBlockingWithError<T>(_ operation: @escaping @MainActor @Sendable () async throws -> T)
+      -> T?
+    {
+      guard !Thread.isMainThread else {
+        logger.error("runBlockingWithError called on main thread - would deadlock")
+        scriptErrorNumber = errOSAGeneralError
+        scriptErrorString = "Internal error: scripting command ran on main thread"
+        return nil
+      }
+
+      nonisolated(unsafe) var result: T?
+      nonisolated(unsafe) var caughtError: String?
+      let semaphore = DispatchSemaphore(value: 0)
+
+      Task { @MainActor in
+        do {
+          result = try await operation()
+        } catch {
+          caughtError = error.localizedDescription
+        }
+        semaphore.signal()
+      }
+
+      semaphore.wait()
+
+      if let errorMessage = caughtError {
+        logger.error("Script command failed: \(errorMessage)")
+        scriptErrorNumber = errOSAGeneralError
+        scriptErrorString = errorMessage
+        return nil
+      }
+
+      return result
+    }
+  }
+
+  /// Error codes for AppleScript
+  private let errOSAGeneralError: Int = -10000
+#endif

--- a/Automation/AppleScript/Moolah.sdef
+++ b/Automation/AppleScript/Moolah.sdef
@@ -1,0 +1,248 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE dictionary SYSTEM "file://localhost/System/Library/DTDs/sdef.dtd">
+<dictionary title="Moolah Terminology">
+
+  <suite name="Standard Suite" code="????" description="Common classes and commands for all applications.">
+
+    <command name="count" code="corecnte" description="Return the number of elements of a particular type within an object.">
+      <cocoa class="NSCountCommand"/>
+      <access-group identifier="*"/>
+      <direct-parameter type="specifier" description="The objects to be counted."/>
+      <parameter name="each" code="kocl" type="type" optional="yes" description="The type of object to count.">
+        <cocoa key="ObjectClass"/>
+      </parameter>
+      <result type="integer" description="The count."/>
+    </command>
+
+    <command name="exists" code="coredoex" description="Verify that an object exists.">
+      <cocoa class="NSExistsCommand"/>
+      <access-group identifier="*"/>
+      <direct-parameter type="any" description="The object(s) to check."/>
+      <result type="boolean" description="Did the object(s) exist?"/>
+    </command>
+
+    <class name="application" code="capp" description="The Moolah application.">
+      <cocoa class="NSApplication"/>
+      <element type="profile" access="r">
+        <cocoa key="scriptableProfiles"/>
+      </element>
+    </class>
+
+  </suite>
+
+  <suite name="Moolah Suite" code="Mool" description="Moolah-specific classes and commands.">
+
+    <!-- MARK: - Classes -->
+
+    <class name="profile" code="Prof" description="A financial profile." plural="profiles">
+      <cocoa class="Moolah.ScriptableProfile"/>
+      <property name="id" code="ID  " type="text" access="r" description="The unique identifier of the profile.">
+        <cocoa key="uniqueID"/>
+      </property>
+      <property name="name" code="pnam" type="text" access="r" description="The name of the profile.">
+        <cocoa key="name"/>
+      </property>
+      <property name="currency" code="Mcur" type="text" access="r" description="The currency code of the profile.">
+        <cocoa key="currencyCode"/>
+      </property>
+      <element type="account" access="r">
+        <cocoa key="scriptableAccounts"/>
+      </element>
+      <element type="transaction" access="r">
+        <cocoa key="scriptableTransactions"/>
+      </element>
+      <element type="earmark" access="r">
+        <cocoa key="scriptableEarmarks"/>
+      </element>
+      <element type="category" access="r">
+        <cocoa key="scriptableCategories"/>
+      </element>
+    </class>
+
+    <class name="account" code="Acct" description="A financial account." plural="accounts">
+      <cocoa class="Moolah.ScriptableAccount"/>
+      <property name="id" code="ID  " type="text" access="r" description="The unique identifier of the account.">
+        <cocoa key="uniqueID"/>
+      </property>
+      <property name="name" code="pnam" type="text" access="r" description="The name of the account.">
+        <cocoa key="name"/>
+      </property>
+      <property name="account type" code="Maty" type="text" access="r" description="The type of account (bank, cc, asset, investment).">
+        <cocoa key="accountType"/>
+      </property>
+      <property name="balance" code="Mbal" type="real" access="r" description="The current balance of the account.">
+        <cocoa key="balance"/>
+      </property>
+      <property name="investment value" code="Mivl" type="real" access="r" description="The investment value of the account (0 if not an investment account).">
+        <cocoa key="investmentValue"/>
+      </property>
+      <property name="hidden" code="Mhid" type="boolean" access="r" description="Whether the account is hidden.">
+        <cocoa key="isHidden"/>
+      </property>
+    </class>
+
+    <class name="transaction" code="Txn " description="A financial transaction." plural="transactions">
+      <cocoa class="Moolah.ScriptableTransaction"/>
+      <property name="id" code="ID  " type="text" access="r" description="The unique identifier of the transaction.">
+        <cocoa key="uniqueID"/>
+      </property>
+      <property name="date" code="Mdat" type="date" access="r" description="The date of the transaction.">
+        <cocoa key="date"/>
+      </property>
+      <property name="payee" code="Mpay" type="text" access="r" description="The payee of the transaction.">
+        <cocoa key="payee"/>
+      </property>
+      <property name="notes" code="Mnot" type="text" access="r" description="Notes for the transaction.">
+        <cocoa key="notes"/>
+      </property>
+      <property name="transaction type" code="Mtty" type="text" access="r" description="The type of transaction (income, expense, transfer, openingBalance).">
+        <cocoa key="transactionType"/>
+      </property>
+      <property name="amount" code="Mamt" type="real" access="r" description="The total amount of the transaction.">
+        <cocoa key="amount"/>
+      </property>
+      <property name="scheduled" code="Msch" type="boolean" access="r" description="Whether the transaction is scheduled.">
+        <cocoa key="isScheduled"/>
+      </property>
+      <element type="leg" access="r">
+        <cocoa key="scriptableLegs"/>
+      </element>
+    </class>
+
+    <class name="leg" code="TLeg" description="A transaction leg." plural="legs">
+      <cocoa class="Moolah.ScriptableLeg"/>
+      <property name="account name" code="Mlan" type="text" access="r" description="The name of the account for this leg.">
+        <cocoa key="accountName"/>
+      </property>
+      <property name="amount" code="Mamt" type="real" access="r" description="The amount of this leg.">
+        <cocoa key="amount"/>
+      </property>
+      <property name="category name" code="Mlcn" type="text" access="r" description="The name of the category for this leg.">
+        <cocoa key="categoryName"/>
+      </property>
+      <property name="type" code="Mltp" type="text" access="r" description="The type of this leg (income, expense, transfer, openingBalance).">
+        <cocoa key="legType"/>
+      </property>
+    </class>
+
+    <class name="earmark" code="Emrk" description="An earmarked fund." plural="earmarks">
+      <cocoa class="Moolah.ScriptableEarmark"/>
+      <property name="id" code="ID  " type="text" access="r" description="The unique identifier of the earmark.">
+        <cocoa key="uniqueID"/>
+      </property>
+      <property name="name" code="pnam" type="text" access="r" description="The name of the earmark.">
+        <cocoa key="name"/>
+      </property>
+      <property name="balance" code="Mbal" type="real" access="r" description="The current balance of the earmark.">
+        <cocoa key="balance"/>
+      </property>
+      <property name="target amount" code="Mtgt" type="real" access="r" description="The savings target amount.">
+        <cocoa key="targetAmount"/>
+      </property>
+    </class>
+
+    <class name="category" code="Catg" description="A transaction category." plural="categories">
+      <cocoa class="Moolah.ScriptableCategory"/>
+      <property name="id" code="ID  " type="text" access="r" description="The unique identifier of the category.">
+        <cocoa key="uniqueID"/>
+      </property>
+      <property name="name" code="pnam" type="text" access="r" description="The name of the category.">
+        <cocoa key="name"/>
+      </property>
+      <property name="parent name" code="Mprn" type="text" access="r" description="The name of the parent category, or empty string if top-level.">
+        <cocoa key="parentName"/>
+      </property>
+    </class>
+
+    <!-- MARK: - Commands -->
+
+    <command name="create account" code="Moolcrac" description="Create a new account in a profile.">
+      <cocoa class="Moolah.CreateAccountCommand"/>
+      <direct-parameter type="specifier" description="The profile to create the account in."/>
+      <parameter name="name" code="Cnam" type="text" description="The name of the account.">
+        <cocoa key="name"/>
+      </parameter>
+      <parameter name="type" code="Ctyp" type="text" description="The account type (bank, cc, asset, investment).">
+        <cocoa key="type"/>
+      </parameter>
+      <result type="account" description="The created account."/>
+    </command>
+
+    <command name="create transaction" code="Moolcrtx" description="Create a new transaction in a profile.">
+      <cocoa class="Moolah.CreateTransactionCommand"/>
+      <direct-parameter type="specifier" description="The profile to create the transaction in."/>
+      <parameter name="with payee" code="Cpay" type="text" description="The payee for the transaction.">
+        <cocoa key="withPayee"/>
+      </parameter>
+      <parameter name="amount" code="Camt" type="real" description="The amount in the profile's currency.">
+        <cocoa key="amount"/>
+      </parameter>
+      <parameter name="account" code="Cacc" type="text" description="The account name for the transaction.">
+        <cocoa key="account"/>
+      </parameter>
+      <parameter name="category" code="Ccat" type="text" optional="yes" description="The category name for the transaction.">
+        <cocoa key="category"/>
+      </parameter>
+      <parameter name="on date" code="Cdte" type="date" optional="yes" description="The date of the transaction (defaults to today).">
+        <cocoa key="onDate"/>
+      </parameter>
+      <parameter name="notes" code="Cnts" type="text" optional="yes" description="Notes for the transaction.">
+        <cocoa key="notes"/>
+      </parameter>
+      <result type="transaction" description="The created transaction."/>
+    </command>
+
+    <command name="create earmark" code="Moolcrem" description="Create a new earmark in a profile.">
+      <cocoa class="Moolah.CreateEarmarkCommand"/>
+      <direct-parameter type="specifier" description="The profile to create the earmark in."/>
+      <parameter name="name" code="Cnam" type="text" description="The name of the earmark.">
+        <cocoa key="name"/>
+      </parameter>
+      <parameter name="target" code="Ctgt" type="real" optional="yes" description="The savings target amount.">
+        <cocoa key="target"/>
+      </parameter>
+      <result type="earmark" description="The created earmark."/>
+    </command>
+
+    <command name="create category" code="Moolcrca" description="Create a new category in a profile.">
+      <cocoa class="Moolah.CreateCategoryCommand"/>
+      <direct-parameter type="specifier" description="The profile to create the category in."/>
+      <parameter name="name" code="Cnam" type="text" description="The name of the category.">
+        <cocoa key="name"/>
+      </parameter>
+      <parameter name="parent" code="Cpar" type="text" optional="yes" description="The name of the parent category.">
+        <cocoa key="parent"/>
+      </parameter>
+      <result type="category" description="The created category."/>
+    </command>
+
+    <command name="delete" code="Mooldelt" description="Delete an account, transaction, earmark, or category.">
+      <cocoa class="Moolah.DeleteCommand"/>
+      <direct-parameter type="specifier" description="The object to delete."/>
+    </command>
+
+    <command name="pay" code="Moolpays" description="Pay a scheduled transaction.">
+      <cocoa class="Moolah.PayScheduledCommand"/>
+      <direct-parameter type="specifier" description="The scheduled transaction to pay."/>
+      <result type="transaction" description="The paid transaction."/>
+    </command>
+
+    <command name="refresh" code="Moolrefr" description="Refresh all data for a profile.">
+      <cocoa class="Moolah.RefreshCommand"/>
+      <direct-parameter type="specifier" optional="yes" description="The profile to refresh."/>
+    </command>
+
+    <command name="navigate to" code="Moolnavt" description="Navigate to an object in the UI.">
+      <cocoa class="Moolah.NavigateCommand"/>
+      <direct-parameter type="specifier" description="The object to navigate to."/>
+    </command>
+
+    <command name="net worth" code="Moolnetw" description="Get the net worth for a profile.">
+      <cocoa class="Moolah.NetWorthCommand"/>
+      <direct-parameter type="specifier" description="The profile."/>
+      <result type="real" description="The net worth value."/>
+    </command>
+
+  </suite>
+
+</dictionary>

--- a/Automation/AppleScript/ScriptableAccount.swift
+++ b/Automation/AppleScript/ScriptableAccount.swift
@@ -1,0 +1,67 @@
+#if os(macOS)
+  import AppKit
+  import Foundation
+
+  /// AppleScript wrapper for an Account domain model.
+  /// Data captured at construction time; all properties are nonisolated.
+  @objc(ScriptableAccount)
+  class ScriptableAccount: NSObject {
+    private let _uniqueID: String
+    private let _name: String
+    private let _accountType: String
+    private let _balance: Double
+    private let _investmentValue: Double
+    private let _isHidden: Bool
+    private let _profileName: String
+
+    @MainActor
+    init(account: Account, profileName: String) {
+      _uniqueID = account.id.uuidString
+      _name = account.name
+      _accountType = account.type.rawValue
+      _balance = account.balance.doubleValue
+      _investmentValue = account.investmentValue?.doubleValue ?? 0
+      _isHidden = account.isHidden
+      _profileName = profileName
+      super.init()
+    }
+
+    @objc var uniqueID: String { _uniqueID }
+    @objc var name: String { _name }
+    @objc var accountType: String { _accountType }
+    @objc var balance: Double { _balance }
+    @objc var investmentValue: Double { _investmentValue }
+    @objc var isHidden: Bool { _isHidden }
+
+    // MARK: - Object Specifier
+
+    override var objectSpecifier: NSScriptObjectSpecifier? {
+      guard
+        let appDescription = NSScriptSuiteRegistry.shared().classDescription(
+          withAppleEventCode: 0x6361_7070  // 'capp'
+        )
+      else {
+        return nil
+      }
+      let profileSpecifier = NSNameSpecifier(
+        containerClassDescription: appDescription,
+        containerSpecifier: nil,
+        key: "scriptableProfiles",
+        name: _profileName
+      )
+      guard
+        let profileDescription = NSScriptSuiteRegistry.shared().classDescription(
+          withAppleEventCode: 0x5072_6F66  // 'Prof'
+        )
+      else {
+        return nil
+      }
+      return NSNameSpecifier(
+        containerClassDescription: profileDescription,
+        containerSpecifier: profileSpecifier,
+        key: "scriptableAccounts",
+        name: _name
+      )
+    }
+  }
+#endif

--- a/Automation/AppleScript/ScriptableAccount.swift
+++ b/Automation/AppleScript/ScriptableAccount.swift
@@ -5,7 +5,7 @@
   /// AppleScript wrapper for an Account domain model.
   /// Data captured at construction time; all properties are nonisolated.
   @objc(ScriptableAccount)
-  class ScriptableAccount: NSObject {
+  class ScriptableAccount: NSObject, @unchecked Sendable {
     private let _uniqueID: String
     private let _name: String
     private let _accountType: String

--- a/Automation/AppleScript/ScriptableCategory.swift
+++ b/Automation/AppleScript/ScriptableCategory.swift
@@ -1,0 +1,58 @@
+#if os(macOS)
+  import AppKit
+  import Foundation
+
+  /// AppleScript wrapper for a Category domain model.
+  /// Data captured at construction time; all properties are nonisolated.
+  @objc(ScriptableCategory)
+  class ScriptableCategory: NSObject {
+    private let _uniqueID: String
+    private let _name: String
+    private let _parentName: String
+    private let _profileName: String
+
+    @MainActor
+    init(category: Category, parentName: String, profileName: String) {
+      _uniqueID = category.id.uuidString
+      _name = category.name
+      _parentName = parentName
+      _profileName = profileName
+      super.init()
+    }
+
+    @objc var uniqueID: String { _uniqueID }
+    @objc var name: String { _name }
+    @objc var parentName: String { _parentName }
+
+    // MARK: - Object Specifier
+
+    override var objectSpecifier: NSScriptObjectSpecifier? {
+      guard
+        let appDescription = NSScriptSuiteRegistry.shared().classDescription(
+          withAppleEventCode: 0x6361_7070  // 'capp'
+        )
+      else {
+        return nil
+      }
+      let profileSpecifier = NSNameSpecifier(
+        containerClassDescription: appDescription,
+        containerSpecifier: nil,
+        key: "scriptableProfiles",
+        name: _profileName
+      )
+      guard
+        let profileDescription = NSScriptSuiteRegistry.shared().classDescription(
+          withAppleEventCode: 0x5072_6F66  // 'Prof'
+        )
+      else {
+        return nil
+      }
+      return NSNameSpecifier(
+        containerClassDescription: profileDescription,
+        containerSpecifier: profileSpecifier,
+        key: "scriptableCategories",
+        name: _name
+      )
+    }
+  }
+#endif

--- a/Automation/AppleScript/ScriptableCategory.swift
+++ b/Automation/AppleScript/ScriptableCategory.swift
@@ -5,7 +5,7 @@
   /// AppleScript wrapper for a Category domain model.
   /// Data captured at construction time; all properties are nonisolated.
   @objc(ScriptableCategory)
-  class ScriptableCategory: NSObject {
+  class ScriptableCategory: NSObject, @unchecked Sendable {
     private let _uniqueID: String
     private let _name: String
     private let _parentName: String

--- a/Automation/AppleScript/ScriptableEarmark.swift
+++ b/Automation/AppleScript/ScriptableEarmark.swift
@@ -5,7 +5,7 @@
   /// AppleScript wrapper for an Earmark domain model.
   /// Data captured at construction time; all properties are nonisolated.
   @objc(ScriptableEarmark)
-  class ScriptableEarmark: NSObject {
+  class ScriptableEarmark: NSObject, @unchecked Sendable {
     private let _uniqueID: String
     private let _name: String
     private let _balance: Double

--- a/Automation/AppleScript/ScriptableEarmark.swift
+++ b/Automation/AppleScript/ScriptableEarmark.swift
@@ -1,0 +1,61 @@
+#if os(macOS)
+  import AppKit
+  import Foundation
+
+  /// AppleScript wrapper for an Earmark domain model.
+  /// Data captured at construction time; all properties are nonisolated.
+  @objc(ScriptableEarmark)
+  class ScriptableEarmark: NSObject {
+    private let _uniqueID: String
+    private let _name: String
+    private let _balance: Double
+    private let _targetAmount: Double
+    private let _profileName: String
+
+    @MainActor
+    init(earmark: Earmark, profileName: String) {
+      _uniqueID = earmark.id.uuidString
+      _name = earmark.name
+      _balance = earmark.balance.doubleValue
+      _targetAmount = earmark.savingsGoal?.doubleValue ?? 0
+      _profileName = profileName
+      super.init()
+    }
+
+    @objc var uniqueID: String { _uniqueID }
+    @objc var name: String { _name }
+    @objc var balance: Double { _balance }
+    @objc var targetAmount: Double { _targetAmount }
+
+    // MARK: - Object Specifier
+
+    override var objectSpecifier: NSScriptObjectSpecifier? {
+      guard
+        let appDescription = NSScriptSuiteRegistry.shared().classDescription(
+          withAppleEventCode: 0x6361_7070  // 'capp'
+        )
+      else {
+        return nil
+      }
+      let profileSpecifier = NSNameSpecifier(
+        containerClassDescription: appDescription,
+        containerSpecifier: nil,
+        key: "scriptableProfiles",
+        name: _profileName
+      )
+      guard
+        let profileDescription = NSScriptSuiteRegistry.shared().classDescription(
+          withAppleEventCode: 0x5072_6F66  // 'Prof'
+        )
+      else {
+        return nil
+      }
+      return NSNameSpecifier(
+        containerClassDescription: profileDescription,
+        containerSpecifier: profileSpecifier,
+        key: "scriptableEarmarks",
+        name: _name
+      )
+    }
+  }
+#endif

--- a/Automation/AppleScript/ScriptableProfile.swift
+++ b/Automation/AppleScript/ScriptableProfile.swift
@@ -1,0 +1,87 @@
+#if os(macOS)
+  import AppKit
+  import Foundation
+
+  /// AppleScript wrapper for a Profile / ProfileSession.
+  /// Serves as the container for accounts, transactions, earmarks, and categories.
+  ///
+  /// Data is captured at construction time (on MainActor) and stored as plain values.
+  /// The object specifier methods are nonisolated so NSScripting can call them freely.
+  @objc(ScriptableProfile)
+  class ScriptableProfile: NSObject {
+    private let _uniqueID: String
+    private let _name: String
+    private let _currencyCode: String
+    private let _accounts: [ScriptableAccount]
+    private let _transactions: [ScriptableTransaction]
+    private let _earmarks: [ScriptableEarmark]
+    private let _categories: [ScriptableCategory]
+
+    @MainActor
+    init(session: ProfileSession) {
+      _uniqueID = session.profile.id.uuidString
+      _name = session.profile.label
+      _currencyCode = session.profile.currencyCode
+
+      _accounts = session.accountStore.accounts.ordered.map {
+        ScriptableAccount(account: $0, profileName: session.profile.label)
+      }
+      _transactions = session.transactionStore.transactions.map {
+        ScriptableTransaction(
+          transaction: $0.transaction,
+          profileName: session.profile.label,
+          accountStore: session.accountStore,
+          categoryStore: session.categoryStore
+        )
+      }
+      _earmarks = session.earmarkStore.earmarks.ordered.map {
+        ScriptableEarmark(earmark: $0, profileName: session.profile.label)
+      }
+
+      let categories = session.categoryStore.categories
+      _categories = categories.flattenedByPath().map {
+        let parentName: String
+        if let parentId = $0.category.parentId,
+          let parent = categories.by(id: parentId)
+        {
+          parentName = parent.name
+        } else {
+          parentName = ""
+        }
+        return ScriptableCategory(
+          category: $0.category,
+          parentName: parentName,
+          profileName: session.profile.label
+        )
+      }
+
+      super.init()
+    }
+
+    @objc var uniqueID: String { _uniqueID }
+    @objc var name: String { _name }
+    @objc var currencyCode: String { _currencyCode }
+    @objc var scriptableAccounts: [ScriptableAccount] { _accounts }
+    @objc var scriptableTransactions: [ScriptableTransaction] { _transactions }
+    @objc var scriptableEarmarks: [ScriptableEarmark] { _earmarks }
+    @objc var scriptableCategories: [ScriptableCategory] { _categories }
+
+    // MARK: - Object Specifier
+
+    override var objectSpecifier: NSScriptObjectSpecifier? {
+      guard
+        let appDescription = NSScriptSuiteRegistry.shared().classDescription(
+          withAppleEventCode: 0x6361_7070  // 'capp'
+        )
+      else {
+        return nil
+      }
+      return NSNameSpecifier(
+        containerClassDescription: appDescription,
+        containerSpecifier: nil,
+        key: "scriptableProfiles",
+        name: _name
+      )
+    }
+  }
+#endif

--- a/Automation/AppleScript/ScriptableProfile.swift
+++ b/Automation/AppleScript/ScriptableProfile.swift
@@ -8,7 +8,7 @@
   /// Data is captured at construction time (on MainActor) and stored as plain values.
   /// The object specifier methods are nonisolated so NSScripting can call them freely.
   @objc(ScriptableProfile)
-  class ScriptableProfile: NSObject {
+  class ScriptableProfile: NSObject, @unchecked Sendable {
     private let _uniqueID: String
     private let _name: String
     private let _currencyCode: String

--- a/Automation/AppleScript/ScriptableTransaction.swift
+++ b/Automation/AppleScript/ScriptableTransaction.swift
@@ -5,7 +5,7 @@
   /// AppleScript wrapper for a Transaction domain model.
   /// Data captured at construction time; all properties are nonisolated.
   @objc(ScriptableTransaction)
-  class ScriptableTransaction: NSObject {
+  class ScriptableTransaction: NSObject, @unchecked Sendable {
     private let _uniqueID: String
     private let _date: Date
     private let _payee: String
@@ -94,7 +94,7 @@
   /// AppleScript wrapper for a TransactionLeg.
   /// Data captured at construction time; all properties are nonisolated.
   @objc(ScriptableLeg)
-  class ScriptableLeg: NSObject {
+  class ScriptableLeg: NSObject, @unchecked Sendable {
     private let _accountName: String
     private let _amount: Double
     private let _categoryName: String

--- a/Automation/AppleScript/ScriptableTransaction.swift
+++ b/Automation/AppleScript/ScriptableTransaction.swift
@@ -1,0 +1,174 @@
+#if os(macOS)
+  import AppKit
+  import Foundation
+
+  /// AppleScript wrapper for a Transaction domain model.
+  /// Data captured at construction time; all properties are nonisolated.
+  @objc(ScriptableTransaction)
+  class ScriptableTransaction: NSObject {
+    private let _uniqueID: String
+    private let _date: Date
+    private let _payee: String
+    private let _notes: String
+    private let _transactionType: String
+    private let _amount: Double
+    private let _isScheduled: Bool
+    private let _legs: [ScriptableLeg]
+    private let _profileName: String
+
+    @MainActor
+    init(
+      transaction: Transaction,
+      profileName: String,
+      accountStore: AccountStore,
+      categoryStore: CategoryStore
+    ) {
+      _uniqueID = transaction.id.uuidString
+      _date = transaction.date
+      _payee = transaction.payee ?? ""
+      _notes = transaction.notes ?? ""
+      _transactionType = transaction.legs.first?.type.rawValue ?? "expense"
+      _isScheduled = transaction.isScheduled
+      _profileName = profileName
+
+      let total = transaction.legs.reduce(Decimal(0)) { sum, leg in
+        sum + leg.quantity
+      }
+      _amount = Double(truncating: total as NSDecimalNumber)
+
+      _legs = transaction.legs.enumerated().map { index, leg in
+        ScriptableLeg(
+          leg: leg,
+          transactionID: transaction.id.uuidString,
+          profileName: profileName,
+          accountStore: accountStore,
+          categoryStore: categoryStore,
+          index: index
+        )
+      }
+
+      super.init()
+    }
+
+    @objc var uniqueID: String { _uniqueID }
+    @objc var date: Date { _date }
+    @objc var payee: String { _payee }
+    @objc var notes: String { _notes }
+    @objc var transactionType: String { _transactionType }
+    @objc var amount: Double { _amount }
+    @objc var isScheduled: Bool { _isScheduled }
+    @objc var scriptableLegs: [ScriptableLeg] { _legs }
+
+    // MARK: - Object Specifier
+
+    override var objectSpecifier: NSScriptObjectSpecifier? {
+      guard
+        let appDescription = NSScriptSuiteRegistry.shared().classDescription(
+          withAppleEventCode: 0x6361_7070  // 'capp'
+        )
+      else {
+        return nil
+      }
+      let profileSpecifier = NSNameSpecifier(
+        containerClassDescription: appDescription,
+        containerSpecifier: nil,
+        key: "scriptableProfiles",
+        name: _profileName
+      )
+      guard
+        let profileDescription = NSScriptSuiteRegistry.shared().classDescription(
+          withAppleEventCode: 0x5072_6F66  // 'Prof'
+        )
+      else {
+        return nil
+      }
+      return NSUniqueIDSpecifier(
+        containerClassDescription: profileDescription,
+        containerSpecifier: profileSpecifier,
+        key: "scriptableTransactions",
+        uniqueID: _uniqueID
+      )
+    }
+  }
+
+  /// AppleScript wrapper for a TransactionLeg.
+  /// Data captured at construction time; all properties are nonisolated.
+  @objc(ScriptableLeg)
+  class ScriptableLeg: NSObject {
+    private let _accountName: String
+    private let _amount: Double
+    private let _categoryName: String
+    private let _legType: String
+    private let _transactionID: String
+    private let _profileName: String
+    private let _index: Int
+
+    @MainActor
+    init(
+      leg: TransactionLeg,
+      transactionID: String,
+      profileName: String,
+      accountStore: AccountStore,
+      categoryStore: CategoryStore,
+      index: Int = 0
+    ) {
+      _accountName = leg.accountId.flatMap { accountStore.accounts.by(id: $0)?.name } ?? ""
+      _amount = leg.amount.doubleValue
+      _categoryName = leg.categoryId.flatMap { categoryStore.categories.by(id: $0)?.name } ?? ""
+      _legType = leg.type.rawValue
+      _transactionID = transactionID
+      _profileName = profileName
+      _index = index
+      super.init()
+    }
+
+    @objc var accountName: String { _accountName }
+    @objc var amount: Double { _amount }
+    @objc var categoryName: String { _categoryName }
+    @objc var legType: String { _legType }
+
+    // MARK: - Object Specifier
+
+    override var objectSpecifier: NSScriptObjectSpecifier? {
+      guard
+        let appDescription = NSScriptSuiteRegistry.shared().classDescription(
+          withAppleEventCode: 0x6361_7070  // 'capp'
+        )
+      else {
+        return nil
+      }
+      let profileSpecifier = NSNameSpecifier(
+        containerClassDescription: appDescription,
+        containerSpecifier: nil,
+        key: "scriptableProfiles",
+        name: _profileName
+      )
+      guard
+        let profileDescription = NSScriptSuiteRegistry.shared().classDescription(
+          withAppleEventCode: 0x5072_6F66  // 'Prof'
+        )
+      else {
+        return nil
+      }
+      let transactionSpecifier = NSUniqueIDSpecifier(
+        containerClassDescription: profileDescription,
+        containerSpecifier: profileSpecifier,
+        key: "scriptableTransactions",
+        uniqueID: _transactionID
+      )
+      guard
+        let transactionDescription = NSScriptSuiteRegistry.shared().classDescription(
+          withAppleEventCode: 0x5478_6E20  // 'Txn '
+        )
+      else {
+        return nil
+      }
+      return NSIndexSpecifier(
+        containerClassDescription: transactionDescription,
+        containerSpecifier: transactionSpecifier,
+        key: "scriptableLegs",
+        index: _index
+      )
+    }
+  }
+#endif

--- a/Automation/AppleScript/ScriptingBridge.swift
+++ b/Automation/AppleScript/ScriptingBridge.swift
@@ -27,27 +27,28 @@
     @objc var scriptableProfiles: [ScriptableProfile] {
       // This is called from the Apple Events thread. We need to hop to MainActor
       // to access the session manager safely.
-      nonisolated(unsafe) var result: [ScriptableProfile] = []
+      guard !Thread.isMainThread else {
+        logger.warning("scriptableProfiles accessed on main thread - returning empty")
+        return []
+      }
+
+      final class ResultBox: @unchecked Sendable {
+        var profiles: [ScriptableProfile] = []
+      }
+      let box = ResultBox()
       let semaphore = DispatchSemaphore(value: 0)
 
       Task { @MainActor in
         if let sessionManager = ScriptingContext.sessionManager {
-          result = sessionManager.openProfiles.map { ScriptableProfile(session: $0) }
+          box.profiles = sessionManager.openProfiles.map { ScriptableProfile(session: $0) }
         } else {
           logger.warning("ScriptingBridge accessed before configuration")
         }
         semaphore.signal()
       }
 
-      if Thread.isMainThread {
-        // If somehow called on main thread, we can't wait on the semaphore.
-        // Return empty and log a warning.
-        logger.warning("scriptableProfiles accessed on main thread - returning empty")
-        return []
-      }
-
       semaphore.wait()
-      return result
+      return box.profiles
     }
   }
 #endif

--- a/Automation/AppleScript/ScriptingBridge.swift
+++ b/Automation/AppleScript/ScriptingBridge.swift
@@ -1,0 +1,53 @@
+#if os(macOS)
+  import AppKit
+  import Foundation
+  import OSLog
+
+  private let logger = Logger(subsystem: "com.moolah.app", category: "ScriptingBridge")
+
+  /// Bridges the SwiftUI app to the AppleScript object model.
+  /// Registered as the NSApplicationDelegate via @NSApplicationDelegateAdaptor.
+  /// Exposes scriptableProfiles as the top-level element that NSApplication resolves
+  /// via KVC for the SDEF's application class.
+  class ScriptingBridge: NSObject, NSApplicationDelegate {
+
+    // MARK: - NSApplicationDelegate
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
+      logger.info("Scripting bridge ready")
+    }
+
+    /// Tells the scripting infrastructure which keys the application handles.
+    func application(_ sender: NSApplication, delegateHandlesKey key: String) -> Bool {
+      key == "scriptableProfiles"
+    }
+
+    /// The top-level scripting element: all open profiles.
+    /// Called by the scripting infrastructure when AppleScript accesses `profiles of application`.
+    @objc var scriptableProfiles: [ScriptableProfile] {
+      // This is called from the Apple Events thread. We need to hop to MainActor
+      // to access the session manager safely.
+      nonisolated(unsafe) var result: [ScriptableProfile] = []
+      let semaphore = DispatchSemaphore(value: 0)
+
+      Task { @MainActor in
+        if let sessionManager = ScriptingContext.sessionManager {
+          result = sessionManager.openProfiles.map { ScriptableProfile(session: $0) }
+        } else {
+          logger.warning("ScriptingBridge accessed before configuration")
+        }
+        semaphore.signal()
+      }
+
+      if Thread.isMainThread {
+        // If somehow called on main thread, we can't wait on the semaphore.
+        // Return empty and log a warning.
+        logger.warning("scriptableProfiles accessed on main thread - returning empty")
+        return []
+      }
+
+      semaphore.wait()
+      return result
+    }
+  }
+#endif

--- a/Automation/AppleScript/ScriptingContext.swift
+++ b/Automation/AppleScript/ScriptingContext.swift
@@ -1,0 +1,11 @@
+#if os(macOS)
+  import Foundation
+
+  /// Static accessor for AppleScript command handlers to reach the app's services.
+  /// Set during app initialization before any scripting commands can execute.
+  @MainActor
+  enum ScriptingContext {
+    static var automationService: AutomationService?
+    static var sessionManager: SessionManager?
+  }
+#endif

--- a/Automation/AutomationError.swift
+++ b/Automation/AutomationError.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+enum AutomationError: LocalizedError, Sendable {
+  case profileNotFound(String)
+  case profileNotOpen(String)
+  case accountNotFound(String)
+  case transactionNotFound(String)
+  case earmarkNotFound(String)
+  case categoryNotFound(String)
+  case invalidParameter(String)
+  case operationFailed(String)
+
+  var errorDescription: String? {
+    switch self {
+    case .profileNotFound(let name): "Profile not found: \(name)"
+    case .profileNotOpen(let name): "Profile not open: \(name)"
+    case .accountNotFound(let name): "Account not found: \(name)"
+    case .transactionNotFound(let id): "Transaction not found: \(id)"
+    case .earmarkNotFound(let name): "Earmark not found: \(name)"
+    case .categoryNotFound(let name): "Category not found: \(name)"
+    case .invalidParameter(let detail): "Invalid parameter: \(detail)"
+    case .operationFailed(let detail): "Operation failed: \(detail)"
+    }
+  }
+}

--- a/Automation/AutomationService.swift
+++ b/Automation/AutomationService.swift
@@ -165,12 +165,7 @@ final class AutomationService {
           nil
         }
 
-      let legType: TransactionType
-      if accountIds.count > 1 {
-        legType = .expense  // Transfer legs use expense sign convention
-      } else {
-        legType = spec.amount >= 0 ? .income : .expense
-      }
+      let legType: TransactionType = spec.amount >= 0 ? .income : .expense
 
       resolvedLegs.append(
         TransactionLeg(

--- a/Automation/AutomationService.swift
+++ b/Automation/AutomationService.swift
@@ -1,0 +1,29 @@
+import Foundation
+import OSLog
+
+private let logger = Logger(subsystem: "com.moolah.app", category: "AutomationService")
+
+@MainActor
+final class AutomationService {
+  let sessionManager: SessionManager
+
+  init(sessionManager: SessionManager) {
+    self.sessionManager = sessionManager
+  }
+
+  /// Resolves a profile session by name (case-insensitive) or UUID string.
+  func resolveSession(for identifier: String) throws -> ProfileSession {
+    if let session = sessionManager.session(named: identifier) { return session }
+    if let uuid = UUID(uuidString: identifier),
+      let session = sessionManager.session(forID: uuid)
+    {
+      return session
+    }
+    throw AutomationError.profileNotFound(identifier)
+  }
+
+  /// Returns all currently open profiles.
+  func listOpenProfiles() -> [Profile] {
+    sessionManager.openProfiles.map(\.profile)
+  }
+}

--- a/Automation/AutomationService.swift
+++ b/Automation/AutomationService.swift
@@ -26,4 +26,502 @@ final class AutomationService {
   func listOpenProfiles() -> [Profile] {
     sessionManager.openProfiles.map(\.profile)
   }
+
+  // MARK: - Account Operations
+
+  /// Returns all accounts for the given profile.
+  func listAccounts(profileIdentifier: String) throws -> [Account] {
+    let session = try resolveSession(for: profileIdentifier)
+    return Array(session.accountStore.accounts)
+  }
+
+  /// Resolves an account by name (case-insensitive) within a profile.
+  func resolveAccount(named name: String, profileIdentifier: String) throws -> Account {
+    let session = try resolveSession(for: profileIdentifier)
+    let lowered = name.lowercased()
+    guard
+      let account = session.accountStore.accounts.first(where: { $0.name.lowercased() == lowered })
+    else {
+      throw AutomationError.accountNotFound(name)
+    }
+    return account
+  }
+
+  /// Resolves an account by UUID within a profile.
+  func resolveAccount(id: UUID, profileIdentifier: String) throws -> Account {
+    let session = try resolveSession(for: profileIdentifier)
+    guard let account = session.accountStore.accounts.by(id: id) else {
+      throw AutomationError.accountNotFound(id.uuidString)
+    }
+    return account
+  }
+
+  /// Returns the net worth (current + investment totals) for the given profile.
+  func getNetWorth(profileIdentifier: String) throws -> InstrumentAmount {
+    let session = try resolveSession(for: profileIdentifier)
+    return session.accountStore.netWorth
+  }
+
+  /// Creates a new account in the given profile.
+  func createAccount(
+    profileIdentifier: String,
+    name: String,
+    type: AccountType,
+    isHidden: Bool = false
+  ) async throws -> Account {
+    let session = try resolveSession(for: profileIdentifier)
+    let instrument = session.profile.instrument
+    let account = Account(
+      id: UUID(),
+      name: name,
+      type: type,
+      balance: .zero(instrument: instrument),
+      investmentValue: nil,
+      positions: [],
+      usesPositionTracking: false,
+      position: session.accountStore.accounts.count,
+      isHidden: isHidden
+    )
+    do {
+      return try await session.accountStore.create(account)
+    } catch {
+      throw AutomationError.operationFailed(
+        "Failed to create account: \(error.localizedDescription)")
+    }
+  }
+
+  /// Updates an existing account's name and/or hidden status.
+  func updateAccount(
+    profileIdentifier: String,
+    accountId: UUID,
+    name: String? = nil,
+    isHidden: Bool? = nil
+  ) async throws -> Account {
+    let session = try resolveSession(for: profileIdentifier)
+    guard var account = session.accountStore.accounts.by(id: accountId) else {
+      throw AutomationError.accountNotFound(accountId.uuidString)
+    }
+    if let name { account.name = name }
+    if let isHidden { account.isHidden = isHidden }
+    do {
+      return try await session.accountStore.update(account)
+    } catch {
+      throw AutomationError.operationFailed(
+        "Failed to update account: \(error.localizedDescription)")
+    }
+  }
+
+  /// Deletes an account by UUID.
+  func deleteAccount(profileIdentifier: String, accountId: UUID) async throws {
+    let session = try resolveSession(for: profileIdentifier)
+    do {
+      try await session.accountStore.delete(id: accountId)
+    } catch {
+      throw AutomationError.operationFailed(
+        "Failed to delete account: \(error.localizedDescription)")
+    }
+  }
+
+  // MARK: - Transaction Operations
+
+  /// Describes a single leg of a transaction for creation.
+  struct LegSpec: Sendable {
+    let accountName: String
+    let amount: Decimal
+    let categoryName: String?
+    let earmarkName: String?
+  }
+
+  /// Creates a transaction with the specified legs.
+  func createTransaction(
+    profileIdentifier: String,
+    payee: String,
+    date: Date,
+    legs: [LegSpec],
+    notes: String? = nil
+  ) async throws -> Transaction {
+    let session = try resolveSession(for: profileIdentifier)
+    let instrument = session.profile.instrument
+
+    var resolvedLegs: [TransactionLeg] = []
+    var accountIds = Set<UUID>()
+
+    for spec in legs {
+      let account = try resolveAccount(
+        named: spec.accountName, profileIdentifier: profileIdentifier)
+      accountIds.insert(account.id)
+
+      let categoryId: UUID? =
+        if let categoryName = spec.categoryName {
+          try resolveCategory(named: categoryName, profileIdentifier: profileIdentifier).id
+        } else {
+          nil
+        }
+
+      let earmarkId: UUID? =
+        if let earmarkName = spec.earmarkName {
+          try resolveEarmark(named: earmarkName, profileIdentifier: profileIdentifier).id
+        } else {
+          nil
+        }
+
+      let legType: TransactionType
+      if accountIds.count > 1 {
+        legType = .expense  // Transfer legs use expense sign convention
+      } else {
+        legType = spec.amount >= 0 ? .income : .expense
+      }
+
+      resolvedLegs.append(
+        TransactionLeg(
+          accountId: account.id,
+          instrument: instrument,
+          quantity: spec.amount,
+          type: legType,
+          categoryId: categoryId,
+          earmarkId: earmarkId
+        ))
+    }
+
+    // Determine if this is a transfer (2+ legs with different account IDs)
+    let isTransfer = accountIds.count > 1
+    if isTransfer {
+      // All legs in a transfer use .expense type
+      resolvedLegs = resolvedLegs.map { leg in
+        var copy = leg
+        copy.type = .expense
+        return copy
+      }
+    }
+
+    let transaction = Transaction(
+      id: UUID(),
+      date: date,
+      payee: payee,
+      notes: notes,
+      recurPeriod: nil,
+      recurEvery: nil,
+      legs: resolvedLegs
+    )
+
+    guard let created = await session.transactionStore.create(transaction) else {
+      throw AutomationError.operationFailed("Failed to create transaction")
+    }
+    return created
+  }
+
+  /// Lists transactions, optionally filtered by account name and/or scheduled status.
+  func listTransactions(
+    profileIdentifier: String,
+    accountName: String? = nil,
+    scheduled: Bool? = nil
+  ) async throws -> [Transaction] {
+    let session = try resolveSession(for: profileIdentifier)
+
+    var filter = TransactionFilter()
+    if let accountName {
+      let account = try resolveAccount(named: accountName, profileIdentifier: profileIdentifier)
+      filter.accountId = account.id
+    }
+    filter.scheduled = scheduled
+
+    await session.transactionStore.load(filter: filter)
+    return session.transactionStore.transactions.map(\.transaction)
+  }
+
+  /// Updates an existing transaction's payee, date, or notes.
+  func updateTransaction(
+    profileIdentifier: String,
+    transactionId: UUID,
+    payee: String? = nil,
+    date: Date? = nil,
+    notes: String? = nil
+  ) async throws -> Transaction {
+    let session = try resolveSession(for: profileIdentifier)
+
+    // Find the transaction in the store
+    guard
+      let entry = session.transactionStore.transactions.first(where: {
+        $0.transaction.id == transactionId
+      })
+    else {
+      throw AutomationError.transactionNotFound(transactionId.uuidString)
+    }
+
+    var transaction = entry.transaction
+    if let payee { transaction.payee = payee }
+    if let date { transaction.date = date }
+    if let notes { transaction.notes = notes }
+
+    await session.transactionStore.update(transaction)
+
+    // Return the updated version from the store
+    guard
+      let updated = session.transactionStore.transactions.first(where: {
+        $0.transaction.id == transactionId
+      })
+    else {
+      throw AutomationError.operationFailed("Transaction update failed")
+    }
+    return updated.transaction
+  }
+
+  /// Deletes a transaction by UUID.
+  func deleteTransaction(profileIdentifier: String, transactionId: UUID) async throws {
+    let session = try resolveSession(for: profileIdentifier)
+    await session.transactionStore.delete(id: transactionId)
+  }
+
+  /// Pays a scheduled transaction (creates a non-scheduled copy with today's date).
+  func payScheduledTransaction(
+    profileIdentifier: String,
+    transactionId: UUID
+  ) async throws -> TransactionStore.PayResult {
+    let session = try resolveSession(for: profileIdentifier)
+
+    guard
+      let entry = session.transactionStore.transactions.first(where: {
+        $0.transaction.id == transactionId
+      })
+    else {
+      throw AutomationError.transactionNotFound(transactionId.uuidString)
+    }
+
+    return await session.transactionStore.payScheduledTransaction(entry.transaction)
+  }
+
+  // MARK: - Earmark Operations
+
+  /// Returns all earmarks for the given profile.
+  func listEarmarks(profileIdentifier: String) throws -> [Earmark] {
+    let session = try resolveSession(for: profileIdentifier)
+    return Array(session.earmarkStore.earmarks)
+  }
+
+  /// Resolves an earmark by name (case-insensitive) within a profile.
+  func resolveEarmark(named name: String, profileIdentifier: String) throws -> Earmark {
+    let session = try resolveSession(for: profileIdentifier)
+    let lowered = name.lowercased()
+    guard
+      let earmark = session.earmarkStore.earmarks.first(where: { $0.name.lowercased() == lowered })
+    else {
+      throw AutomationError.earmarkNotFound(name)
+    }
+    return earmark
+  }
+
+  /// Creates a new earmark in the given profile.
+  func createEarmark(
+    profileIdentifier: String,
+    name: String,
+    targetAmount: Decimal? = nil,
+    savingsEndDate: Date? = nil
+  ) async throws -> Earmark {
+    let session = try resolveSession(for: profileIdentifier)
+    let instrument = session.profile.instrument
+    let earmark = Earmark(
+      id: UUID(),
+      name: name,
+      balance: .zero(instrument: instrument),
+      saved: .zero(instrument: instrument),
+      spent: .zero(instrument: instrument),
+      isHidden: false,
+      position: session.earmarkStore.earmarks.count,
+      savingsGoal: targetAmount.map { InstrumentAmount(quantity: $0, instrument: instrument) },
+      savingsStartDate: savingsEndDate != nil ? Date() : nil,
+      savingsEndDate: savingsEndDate
+    )
+
+    guard let created = await session.earmarkStore.create(earmark) else {
+      throw AutomationError.operationFailed("Failed to create earmark")
+    }
+    return created
+  }
+
+  /// Updates an existing earmark.
+  func updateEarmark(
+    profileIdentifier: String,
+    earmarkId: UUID,
+    name: String? = nil,
+    targetAmount: Decimal? = nil,
+    savingsEndDate: Date? = nil
+  ) async throws -> Earmark {
+    let session = try resolveSession(for: profileIdentifier)
+    let instrument = session.profile.instrument
+    guard var earmark = session.earmarkStore.earmarks.by(id: earmarkId) else {
+      throw AutomationError.earmarkNotFound(earmarkId.uuidString)
+    }
+    if let name { earmark.name = name }
+    if let targetAmount {
+      earmark.savingsGoal = InstrumentAmount(quantity: targetAmount, instrument: instrument)
+    }
+    if let savingsEndDate {
+      earmark.savingsEndDate = savingsEndDate
+      if earmark.savingsStartDate == nil {
+        earmark.savingsStartDate = Date()
+      }
+    }
+
+    guard let updated = await session.earmarkStore.update(earmark) else {
+      throw AutomationError.operationFailed("Failed to update earmark")
+    }
+    return updated
+  }
+
+  /// Hides an earmark by UUID (earmarks cannot be deleted, only hidden).
+  func deleteEarmark(profileIdentifier: String, earmarkId: UUID) async throws {
+    let session = try resolveSession(for: profileIdentifier)
+    guard var earmark = session.earmarkStore.earmarks.by(id: earmarkId) else {
+      throw AutomationError.earmarkNotFound(earmarkId.uuidString)
+    }
+    earmark.isHidden = true
+    guard await session.earmarkStore.update(earmark) != nil else {
+      throw AutomationError.operationFailed("Failed to hide earmark")
+    }
+  }
+
+  // MARK: - Category Operations
+
+  /// Returns all categories for the given profile.
+  func listCategories(profileIdentifier: String) throws -> [Category] {
+    let session = try resolveSession(for: profileIdentifier)
+    return session.categoryStore.categories.flattenedByPath().map(\.category)
+  }
+
+  /// Resolves a category by name or path (case-insensitive) within a profile.
+  /// Matches either the category name or the full path (e.g., "Food:Groceries").
+  func resolveCategory(named name: String, profileIdentifier: String) throws -> Category {
+    let session = try resolveSession(for: profileIdentifier)
+    let lowered = name.lowercased()
+    let entries = session.categoryStore.categories.flattenedByPath()
+
+    // Try matching by path first, then by name
+    if let entry = entries.first(where: { $0.path.lowercased() == lowered }) {
+      return entry.category
+    }
+    if let entry = entries.first(where: { $0.category.name.lowercased() == lowered }) {
+      return entry.category
+    }
+
+    throw AutomationError.categoryNotFound(name)
+  }
+
+  /// Creates a new category, optionally under a parent.
+  func createCategory(
+    profileIdentifier: String,
+    name: String,
+    parentName: String? = nil
+  ) async throws -> Category {
+    let parentId: UUID?
+    if let parentName {
+      parentId = try resolveCategory(named: parentName, profileIdentifier: profileIdentifier).id
+    } else {
+      parentId = nil
+    }
+
+    let session = try resolveSession(for: profileIdentifier)
+    let category = Category(id: UUID(), name: name, parentId: parentId)
+
+    guard let created = await session.categoryStore.create(category) else {
+      throw AutomationError.operationFailed("Failed to create category")
+    }
+    return created
+  }
+
+  /// Deletes a category, optionally replacing it with another category.
+  func deleteCategory(
+    profileIdentifier: String,
+    categoryId: UUID,
+    replacementName: String? = nil
+  ) async throws {
+    let session = try resolveSession(for: profileIdentifier)
+
+    let replacementId: UUID?
+    if let replacementName {
+      replacementId = try resolveCategory(
+        named: replacementName, profileIdentifier: profileIdentifier
+      ).id
+    } else {
+      replacementId = nil
+    }
+
+    let success = await session.categoryStore.delete(id: categoryId, withReplacement: replacementId)
+    if !success {
+      throw AutomationError.operationFailed("Failed to delete category")
+    }
+  }
+
+  // MARK: - Investment Operations
+
+  /// Sets the investment value for an account on a given date.
+  func setInvestmentValue(
+    profileIdentifier: String,
+    accountName: String,
+    date: Date,
+    value: Decimal
+  ) async throws {
+    let session = try resolveSession(for: profileIdentifier)
+    let account = try resolveAccount(named: accountName, profileIdentifier: profileIdentifier)
+
+    guard account.type == .investment else {
+      throw AutomationError.invalidParameter(
+        "Account '\(accountName)' is not an investment account")
+    }
+
+    let instrument = session.profile.instrument
+    let amount = InstrumentAmount(quantity: value, instrument: instrument)
+    await session.investmentStore.setValue(accountId: account.id, date: date, value: amount)
+  }
+
+  /// Returns positions for a given investment account.
+  func getPositions(profileIdentifier: String, accountName: String) async throws -> [Position] {
+    let session = try resolveSession(for: profileIdentifier)
+    let account = try resolveAccount(named: accountName, profileIdentifier: profileIdentifier)
+    await session.investmentStore.loadPositions(accountId: account.id)
+    return session.investmentStore.positions
+  }
+
+  // MARK: - Analysis Operations
+
+  /// Loads analysis data (daily balances, expense breakdown, income/expense).
+  func loadAnalysis(
+    profileIdentifier: String,
+    historyMonths: Int? = nil,
+    forecastMonths: Int? = nil
+  ) async throws -> AnalysisData {
+    let session = try resolveSession(for: profileIdentifier)
+
+    if let historyMonths {
+      session.analysisStore.historyMonths = historyMonths
+    }
+    if let forecastMonths {
+      session.analysisStore.forecastMonths = forecastMonths
+    }
+
+    await session.analysisStore.loadAll()
+
+    if let error = session.analysisStore.error {
+      throw AutomationError.operationFailed(
+        "Failed to load analysis: \(error.localizedDescription)")
+    }
+
+    return AnalysisData(
+      dailyBalances: session.analysisStore.dailyBalances,
+      expenseBreakdown: session.analysisStore.expenseBreakdown,
+      incomeAndExpense: session.analysisStore.incomeAndExpense
+    )
+  }
+
+  // MARK: - Refresh
+
+  /// Refreshes all stores for the given profile concurrently.
+  func refresh(profileIdentifier: String) async throws {
+    let session = try resolveSession(for: profileIdentifier)
+
+    async let accountsLoad: Void = session.accountStore.load()
+    async let categoriesLoad: Void = session.categoryStore.load()
+    async let earmarksLoad: Void = session.earmarkStore.load()
+
+    _ = await (accountsLoad, categoriesLoad, earmarksLoad)
+  }
 }

--- a/Automation/Intents/AddInvestmentValueIntent.swift
+++ b/Automation/Intents/AddInvestmentValueIntent.swift
@@ -1,0 +1,33 @@
+import AppIntents
+import Foundation
+
+struct AddInvestmentValueIntent: AppIntent {
+  nonisolated(unsafe) static var title: LocalizedStringResource = "Set Investment Value"
+  nonisolated(unsafe) static var description = IntentDescription(
+    "Records the current market value for an investment account.")
+
+  @Parameter(title: "Profile")
+  var profile: ProfileEntity
+
+  @Parameter(title: "Account")
+  var account: AccountEntity
+
+  @Parameter(title: "Value")
+  var value: Double
+
+  @MainActor
+  func perform() async throws -> some IntentResult & ReturnsValue<String> {
+    guard let service = AutomationServiceLocator.shared.service else {
+      throw AutomationError.operationFailed("App not ready")
+    }
+
+    try await service.setInvestmentValue(
+      profileIdentifier: profile.id.uuidString,
+      accountName: account.name,
+      date: Date(),
+      value: Decimal(value)
+    )
+
+    return .result(value: "Updated investment value for \(account.name)")
+  }
+}

--- a/Automation/Intents/AutomationServiceLocator.swift
+++ b/Automation/Intents/AutomationServiceLocator.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+/// Static accessor for App Intents to reach the app's AutomationService.
+/// App Intents are instantiated by the system and cannot use dependency injection,
+/// so this service locator bridges the gap. Set during app initialization.
+@MainActor
+final class AutomationServiceLocator {
+  static let shared = AutomationServiceLocator()
+  var service: AutomationService?
+  private init() {}
+}

--- a/Automation/Intents/CreateEarmarkIntent.swift
+++ b/Automation/Intents/CreateEarmarkIntent.swift
@@ -1,0 +1,33 @@
+import AppIntents
+import Foundation
+
+struct CreateEarmarkIntent: AppIntent {
+  nonisolated(unsafe) static var title: LocalizedStringResource = "Create Earmark"
+  nonisolated(unsafe) static var description = IntentDescription(
+    "Creates a new earmark (savings goal).")
+
+  @Parameter(title: "Profile")
+  var profile: ProfileEntity
+
+  @Parameter(title: "Name")
+  var name: String
+
+  @Parameter(title: "Target Amount", default: nil)
+  var targetAmount: Double?
+
+  @MainActor
+  func perform() async throws -> some IntentResult & ReturnsValue<String> {
+    guard let service = AutomationServiceLocator.shared.service else {
+      throw AutomationError.operationFailed("App not ready")
+    }
+
+    let target = targetAmount.map { Decimal($0) }
+    let earmark = try await service.createEarmark(
+      profileIdentifier: profile.id.uuidString,
+      name: name,
+      targetAmount: target
+    )
+
+    return .result(value: "Created earmark: \(earmark.name)")
+  }
+}

--- a/Automation/Intents/CreateTransactionIntent.swift
+++ b/Automation/Intents/CreateTransactionIntent.swift
@@ -1,0 +1,59 @@
+import AppIntents
+import Foundation
+
+struct CreateTransactionIntent: AppIntent {
+  nonisolated(unsafe) static var title: LocalizedStringResource = "Add Transaction"
+  nonisolated(unsafe) static var description = IntentDescription(
+    "Creates a new transaction in the specified account.")
+
+  @Parameter(title: "Profile")
+  var profile: ProfileEntity
+
+  @Parameter(title: "Payee")
+  var payee: String
+
+  @Parameter(title: "Amount")
+  var amount: Double
+
+  @Parameter(title: "Account")
+  var account: AccountEntity
+
+  @Parameter(title: "Category", default: nil)
+  var category: CategoryEntity?
+
+  @Parameter(title: "Date", default: nil)
+  var date: Date?
+
+  @MainActor
+  func perform() async throws -> some IntentResult & ReturnsValue<String> {
+    guard let service = AutomationServiceLocator.shared.service else {
+      throw AutomationError.operationFailed("App not ready")
+    }
+
+    let transactionDate = date ?? Date()
+    let decimalAmount = Decimal(amount)
+
+    // Request confirmation before creating the transaction
+    let formattedAmount = String(format: "%.2f", amount)
+    try await requestConfirmation(
+      dialog: "Create transaction: \(payee) for \(formattedAmount) in \(account.name)?"
+    )
+
+    let leg = AutomationService.LegSpec(
+      accountName: account.name,
+      amount: decimalAmount,
+      categoryName: category?.name,
+      earmarkName: nil
+    )
+
+    let transaction = try await service.createTransaction(
+      profileIdentifier: profile.id.uuidString,
+      payee: payee,
+      date: transactionDate,
+      legs: [leg]
+    )
+
+    let displayPayee = transaction.payee ?? payee
+    return .result(value: "Created transaction: \(displayPayee)")
+  }
+}

--- a/Automation/Intents/Entities/AccountEntity.swift
+++ b/Automation/Intents/Entities/AccountEntity.swift
@@ -1,0 +1,55 @@
+import AppIntents
+import Foundation
+
+struct AccountEntity: AppEntity {
+  nonisolated(unsafe) static var typeDisplayRepresentation = TypeDisplayRepresentation(
+    name: "Account")
+  nonisolated(unsafe) static var defaultQuery = AccountQuery()
+
+  var id: UUID
+  var name: String
+  var accountType: String
+  var balance: Double
+
+  var displayRepresentation: DisplayRepresentation {
+    DisplayRepresentation(title: "\(name)", subtitle: "\(accountType)")
+  }
+
+  init(from account: Account) {
+    self.id = account.id
+    self.name = account.name
+    self.accountType = account.type.displayName
+    self.balance = account.displayBalance.doubleValue
+  }
+}
+
+struct AccountQuery: EntityQuery {
+  @IntentParameter(title: "Profile")
+  var profile: ProfileEntity?
+
+  @MainActor
+  func entities(for identifiers: [UUID]) async throws -> [AccountEntity] {
+    guard let service = AutomationServiceLocator.shared.service else { return [] }
+    guard let profile else { return [] }
+    let accounts = try service.listAccounts(profileIdentifier: profile.id.uuidString)
+    return
+      accounts
+      .filter { identifiers.contains($0.id) }
+      .map { AccountEntity(from: $0) }
+  }
+
+  @MainActor
+  func suggestedEntities() async throws -> [AccountEntity] {
+    guard let service = AutomationServiceLocator.shared.service else { return [] }
+    guard let profile else {
+      // If no profile specified, show accounts from all open profiles
+      let profiles = service.listOpenProfiles()
+      return try profiles.flatMap { profile in
+        try service.listAccounts(profileIdentifier: profile.id.uuidString)
+          .map { AccountEntity(from: $0) }
+      }
+    }
+    let accounts = try service.listAccounts(profileIdentifier: profile.id.uuidString)
+    return accounts.map { AccountEntity(from: $0) }
+  }
+}

--- a/Automation/Intents/Entities/CategoryEntity.swift
+++ b/Automation/Intents/Entities/CategoryEntity.swift
@@ -1,0 +1,50 @@
+import AppIntents
+import Foundation
+
+struct CategoryEntity: AppEntity {
+  nonisolated(unsafe) static var typeDisplayRepresentation = TypeDisplayRepresentation(
+    name: "Category")
+  nonisolated(unsafe) static var defaultQuery = CategoryQuery()
+
+  var id: UUID
+  var name: String
+
+  var displayRepresentation: DisplayRepresentation {
+    DisplayRepresentation(title: "\(name)")
+  }
+
+  init(from category: Category) {
+    self.id = category.id
+    self.name = category.name
+  }
+}
+
+struct CategoryQuery: EntityQuery {
+  @IntentParameter(title: "Profile")
+  var profile: ProfileEntity?
+
+  @MainActor
+  func entities(for identifiers: [UUID]) async throws -> [CategoryEntity] {
+    guard let service = AutomationServiceLocator.shared.service else { return [] }
+    guard let profile else { return [] }
+    let categories = try service.listCategories(profileIdentifier: profile.id.uuidString)
+    return
+      categories
+      .filter { identifiers.contains($0.id) }
+      .map { CategoryEntity(from: $0) }
+  }
+
+  @MainActor
+  func suggestedEntities() async throws -> [CategoryEntity] {
+    guard let service = AutomationServiceLocator.shared.service else { return [] }
+    guard let profile else {
+      let profiles = service.listOpenProfiles()
+      return try profiles.flatMap { profile in
+        try service.listCategories(profileIdentifier: profile.id.uuidString)
+          .map { CategoryEntity(from: $0) }
+      }
+    }
+    let categories = try service.listCategories(profileIdentifier: profile.id.uuidString)
+    return categories.map { CategoryEntity(from: $0) }
+  }
+}

--- a/Automation/Intents/Entities/EarmarkEntity.swift
+++ b/Automation/Intents/Entities/EarmarkEntity.swift
@@ -1,0 +1,54 @@
+import AppIntents
+import Foundation
+
+struct EarmarkEntity: AppEntity {
+  nonisolated(unsafe) static var typeDisplayRepresentation = TypeDisplayRepresentation(
+    name: "Earmark")
+  nonisolated(unsafe) static var defaultQuery = EarmarkQuery()
+
+  var id: UUID
+  var name: String
+  var balance: Double
+
+  var displayRepresentation: DisplayRepresentation {
+    DisplayRepresentation(title: "\(name)")
+  }
+
+  init(from earmark: Earmark) {
+    self.id = earmark.id
+    self.name = earmark.name
+    self.balance = earmark.balance.doubleValue
+  }
+}
+
+struct EarmarkQuery: EntityQuery {
+  @IntentParameter(title: "Profile")
+  var profile: ProfileEntity?
+
+  @MainActor
+  func entities(for identifiers: [UUID]) async throws -> [EarmarkEntity] {
+    guard let service = AutomationServiceLocator.shared.service else { return [] }
+    guard let profile else { return [] }
+    let earmarks = try service.listEarmarks(profileIdentifier: profile.id.uuidString)
+    return
+      earmarks
+      .filter { identifiers.contains($0.id) }
+      .filter { !$0.isHidden }
+      .map { EarmarkEntity(from: $0) }
+  }
+
+  @MainActor
+  func suggestedEntities() async throws -> [EarmarkEntity] {
+    guard let service = AutomationServiceLocator.shared.service else { return [] }
+    guard let profile else {
+      let profiles = service.listOpenProfiles()
+      return try profiles.flatMap { profile in
+        try service.listEarmarks(profileIdentifier: profile.id.uuidString)
+          .filter { !$0.isHidden }
+          .map { EarmarkEntity(from: $0) }
+      }
+    }
+    let earmarks = try service.listEarmarks(profileIdentifier: profile.id.uuidString)
+    return earmarks.filter { !$0.isHidden }.map { EarmarkEntity(from: $0) }
+  }
+}

--- a/Automation/Intents/Entities/ProfileEntity.swift
+++ b/Automation/Intents/Entities/ProfileEntity.swift
@@ -1,0 +1,38 @@
+import AppIntents
+import Foundation
+
+struct ProfileEntity: AppEntity {
+  nonisolated(unsafe) static var typeDisplayRepresentation = TypeDisplayRepresentation(
+    name: "Profile")
+  nonisolated(unsafe) static var defaultQuery = ProfileQuery()
+
+  var id: UUID
+  var name: String
+  var currency: String
+
+  var displayRepresentation: DisplayRepresentation {
+    DisplayRepresentation(title: "\(name)", subtitle: "\(currency)")
+  }
+
+  init(from profile: Profile) {
+    self.id = profile.id
+    self.name = profile.label
+    self.currency = profile.currencyCode
+  }
+}
+
+struct ProfileQuery: EntityQuery {
+  @MainActor
+  func entities(for identifiers: [UUID]) async throws -> [ProfileEntity] {
+    guard let service = AutomationServiceLocator.shared.service else { return [] }
+    return service.listOpenProfiles()
+      .filter { identifiers.contains($0.id) }
+      .map { ProfileEntity(from: $0) }
+  }
+
+  @MainActor
+  func suggestedEntities() async throws -> [ProfileEntity] {
+    guard let service = AutomationServiceLocator.shared.service else { return [] }
+    return service.listOpenProfiles().map { ProfileEntity(from: $0) }
+  }
+}

--- a/Automation/Intents/GetAccountBalanceIntent.swift
+++ b/Automation/Intents/GetAccountBalanceIntent.swift
@@ -1,0 +1,24 @@
+import AppIntents
+import Foundation
+
+struct GetAccountBalanceIntent: AppIntent {
+  nonisolated(unsafe) static var title: LocalizedStringResource = "Get Account Balance"
+  nonisolated(unsafe) static var description = IntentDescription(
+    "Returns the balance of a specific account.")
+
+  @Parameter(title: "Profile")
+  var profile: ProfileEntity
+
+  @Parameter(title: "Account")
+  var account: AccountEntity
+
+  @MainActor
+  func perform() async throws -> some IntentResult & ReturnsValue<String> {
+    guard let service = AutomationServiceLocator.shared.service else {
+      throw AutomationError.operationFailed("App not ready")
+    }
+    let resolved = try service.resolveAccount(
+      id: account.id, profileIdentifier: profile.id.uuidString)
+    return .result(value: resolved.displayBalance.formatted)
+  }
+}

--- a/Automation/Intents/GetEarmarkBalanceIntent.swift
+++ b/Automation/Intents/GetEarmarkBalanceIntent.swift
@@ -1,0 +1,24 @@
+import AppIntents
+import Foundation
+
+struct GetEarmarkBalanceIntent: AppIntent {
+  nonisolated(unsafe) static var title: LocalizedStringResource = "Get Earmark Balance"
+  nonisolated(unsafe) static var description = IntentDescription(
+    "Returns the balance of a specific earmark.")
+
+  @Parameter(title: "Profile")
+  var profile: ProfileEntity
+
+  @Parameter(title: "Earmark")
+  var earmark: EarmarkEntity
+
+  @MainActor
+  func perform() async throws -> some IntentResult & ReturnsValue<String> {
+    guard let service = AutomationServiceLocator.shared.service else {
+      throw AutomationError.operationFailed("App not ready")
+    }
+    let resolved = try service.resolveEarmark(
+      named: earmark.name, profileIdentifier: profile.id.uuidString)
+    return .result(value: resolved.balance.formatted)
+  }
+}

--- a/Automation/Intents/GetExpenseBreakdownIntent.swift
+++ b/Automation/Intents/GetExpenseBreakdownIntent.swift
@@ -1,0 +1,89 @@
+import AppIntents
+import Foundation
+
+struct GetExpenseBreakdownIntent: AppIntent {
+  nonisolated(unsafe) static var title: LocalizedStringResource = "Expense Breakdown"
+  nonisolated(unsafe) static var description = IntentDescription(
+    "Shows a breakdown of expenses by category for a given period.")
+
+  @Parameter(title: "Profile")
+  var profile: ProfileEntity
+
+  @Parameter(title: "Period", default: .thisMonth)
+  var period: ExpensePeriod
+
+  @MainActor
+  func perform() async throws -> some IntentResult & ReturnsValue<String> {
+    guard let service = AutomationServiceLocator.shared.service else {
+      throw AutomationError.operationFailed("App not ready")
+    }
+
+    let targetMonth = period.targetMonth
+    let analysisData = try await service.loadAnalysis(
+      profileIdentifier: profile.id.uuidString,
+      historyMonths: 2
+    )
+
+    let breakdown = analysisData.expenseBreakdown.filter { $0.month == targetMonth }
+
+    if breakdown.isEmpty {
+      return .result(value: "No expenses found for \(period.displayLabel).")
+    }
+
+    // Resolve category names
+    let categories = try service.listCategories(profileIdentifier: profile.id.uuidString)
+    let categoryLookup = Dictionary(uniqueKeysWithValues: categories.map { ($0.id, $0.name) })
+
+    let lines =
+      breakdown
+      .sorted { $0.totalExpenses > $1.totalExpenses }
+      .map { item in
+        let categoryName = item.categoryId.flatMap { categoryLookup[$0] } ?? "Uncategorized"
+        return "\(categoryName): \(item.totalExpenses.formatted)"
+      }
+
+    let total = breakdown.reduce(
+      InstrumentAmount.zero(instrument: breakdown[0].totalExpenses.instrument)
+    ) { $0 + $1.totalExpenses }
+
+    return .result(
+      value:
+        "\(period.displayLabel) expenses:\n\(lines.joined(separator: "\n"))\nTotal: \(total.formatted)"
+    )
+  }
+}
+
+enum ExpensePeriod: String, AppEnum {
+  case thisMonth
+  case lastMonth
+
+  nonisolated(unsafe) static var typeDisplayRepresentation = TypeDisplayRepresentation(
+    name: "Period")
+
+  nonisolated(unsafe) static var caseDisplayRepresentations:
+    [ExpensePeriod: DisplayRepresentation] = [
+      .thisMonth: "This Month",
+      .lastMonth: "Last Month",
+    ]
+
+  var displayLabel: String {
+    switch self {
+    case .thisMonth: "This month"
+    case .lastMonth: "Last month"
+    }
+  }
+
+  var targetMonth: String {
+    let calendar = Calendar.current
+    let date: Date
+    switch self {
+    case .thisMonth:
+      date = Date()
+    case .lastMonth:
+      date = calendar.date(byAdding: .month, value: -1, to: Date()) ?? Date()
+    }
+    let year = calendar.component(.year, from: date)
+    let month = calendar.component(.month, from: date)
+    return String(format: "%04d%02d", year, month)
+  }
+}

--- a/Automation/Intents/GetMonthlySummaryIntent.swift
+++ b/Automation/Intents/GetMonthlySummaryIntent.swift
@@ -1,0 +1,55 @@
+import AppIntents
+import Foundation
+
+struct GetMonthlySummaryIntent: AppIntent {
+  nonisolated(unsafe) static var title: LocalizedStringResource = "Monthly Summary"
+  nonisolated(unsafe) static var description = IntentDescription(
+    "Returns a summary of income, expenses, and net for a given month.")
+
+  @Parameter(title: "Profile")
+  var profile: ProfileEntity
+
+  @Parameter(title: "Month", default: 1)
+  var month: Int
+
+  @Parameter(title: "Year", default: 2026)
+  var year: Int
+
+  @MainActor
+  func perform() async throws -> some IntentResult & ReturnsValue<String> {
+    guard let service = AutomationServiceLocator.shared.service else {
+      throw AutomationError.operationFailed("App not ready")
+    }
+
+    let targetMonth = String(format: "%04d%02d", year, month)
+    let analysisData = try await service.loadAnalysis(
+      profileIdentifier: profile.id.uuidString,
+      historyMonths: 13
+    )
+
+    guard let summary = analysisData.incomeAndExpense.first(where: { $0.month == targetMonth })
+    else {
+      return .result(
+        value: "No data found for \(monthName(month)) \(year).")
+    }
+
+    return .result(
+      value: """
+        \(monthName(month)) \(year) Summary:
+        Income: \(summary.totalIncome.formatted)
+        Expenses: \(summary.totalExpense.formatted)
+        Net: \(summary.totalProfit.formatted)
+        """)
+  }
+
+  private func monthName(_ month: Int) -> String {
+    let formatter = DateFormatter()
+    formatter.dateFormat = "MMMM"
+    var components = DateComponents()
+    components.month = month
+    components.day = 1
+    components.year = 2026
+    guard let date = Calendar.current.date(from: components) else { return "Unknown" }
+    return formatter.string(from: date)
+  }
+}

--- a/Automation/Intents/GetMonthlySummaryIntent.swift
+++ b/Automation/Intents/GetMonthlySummaryIntent.swift
@@ -12,8 +12,8 @@ struct GetMonthlySummaryIntent: AppIntent {
   @Parameter(title: "Month", default: 1)
   var month: Int
 
-  @Parameter(title: "Year", default: 2026)
-  var year: Int
+  @Parameter(title: "Year")
+  var year: Int?
 
   @MainActor
   func perform() async throws -> some IntentResult & ReturnsValue<String> {
@@ -21,7 +21,8 @@ struct GetMonthlySummaryIntent: AppIntent {
       throw AutomationError.operationFailed("App not ready")
     }
 
-    let targetMonth = String(format: "%04d%02d", year, month)
+    let resolvedYear = year ?? Calendar.current.component(.year, from: Date())
+    let targetMonth = String(format: "%04d%02d", resolvedYear, month)
     let analysisData = try await service.loadAnalysis(
       profileIdentifier: profile.id.uuidString,
       historyMonths: 13
@@ -30,12 +31,12 @@ struct GetMonthlySummaryIntent: AppIntent {
     guard let summary = analysisData.incomeAndExpense.first(where: { $0.month == targetMonth })
     else {
       return .result(
-        value: "No data found for \(monthName(month)) \(year).")
+        value: "No data found for \(monthName(month)) \(resolvedYear).")
     }
 
     return .result(
       value: """
-        \(monthName(month)) \(year) Summary:
+        \(monthName(month)) \(resolvedYear) Summary:
         Income: \(summary.totalIncome.formatted)
         Expenses: \(summary.totalExpense.formatted)
         Net: \(summary.totalProfit.formatted)
@@ -48,7 +49,7 @@ struct GetMonthlySummaryIntent: AppIntent {
     var components = DateComponents()
     components.month = month
     components.day = 1
-    components.year = 2026
+    components.year = Calendar.current.component(.year, from: Date())
     guard let date = Calendar.current.date(from: components) else { return "Unknown" }
     return formatter.string(from: date)
   }

--- a/Automation/Intents/GetNetWorthIntent.swift
+++ b/Automation/Intents/GetNetWorthIntent.swift
@@ -1,0 +1,20 @@
+import AppIntents
+import Foundation
+
+struct GetNetWorthIntent: AppIntent {
+  nonisolated(unsafe) static var title: LocalizedStringResource = "Get Net Worth"
+  nonisolated(unsafe) static var description = IntentDescription(
+    "Returns the net worth for a profile.")
+
+  @Parameter(title: "Profile")
+  var profile: ProfileEntity
+
+  @MainActor
+  func perform() async throws -> some IntentResult & ReturnsValue<String> {
+    guard let service = AutomationServiceLocator.shared.service else {
+      throw AutomationError.operationFailed("App not ready")
+    }
+    let netWorth = try service.getNetWorth(profileIdentifier: profile.id.uuidString)
+    return .result(value: netWorth.formatted)
+  }
+}

--- a/Automation/Intents/GetRecentTransactionsIntent.swift
+++ b/Automation/Intents/GetRecentTransactionsIntent.swift
@@ -1,0 +1,51 @@
+import AppIntents
+import Foundation
+
+struct GetRecentTransactionsIntent: AppIntent {
+  nonisolated(unsafe) static var title: LocalizedStringResource = "Recent Transactions"
+  nonisolated(unsafe) static var description = IntentDescription(
+    "Shows recent transactions, optionally filtered by account.")
+
+  @Parameter(title: "Profile")
+  var profile: ProfileEntity
+
+  @Parameter(title: "Account", default: nil)
+  var account: AccountEntity?
+
+  @Parameter(title: "Count", default: 5)
+  var count: Int
+
+  @MainActor
+  func perform() async throws -> some IntentResult & ReturnsValue<String> {
+    guard let service = AutomationServiceLocator.shared.service else {
+      throw AutomationError.operationFailed("App not ready")
+    }
+
+    let transactions = try await service.listTransactions(
+      profileIdentifier: profile.id.uuidString,
+      accountName: account?.name,
+      scheduled: false
+    )
+
+    let recent = Array(transactions.prefix(count))
+
+    if recent.isEmpty {
+      return .result(value: "No recent transactions.")
+    }
+
+    let dateFormatter = DateFormatter()
+    dateFormatter.dateStyle = .short
+
+    let lines = recent.map { transaction in
+      let payee = transaction.payee ?? "Unknown"
+      let dateStr = dateFormatter.string(from: transaction.date)
+      let totalAmount = transaction.legs.reduce(Decimal.zero) { $0 + $1.quantity }
+      let amountStr =
+        transaction.legs.first.map { leg in
+          InstrumentAmount(quantity: totalAmount, instrument: leg.instrument).formatted
+        } ?? String(describing: totalAmount)
+      return "\(dateStr) \(payee): \(amountStr)"
+    }
+    return .result(value: lines.joined(separator: "\n"))
+  }
+}

--- a/Automation/Intents/ListAccountsIntent.swift
+++ b/Automation/Intents/ListAccountsIntent.swift
@@ -1,0 +1,63 @@
+import AppIntents
+import Foundation
+
+struct ListAccountsIntent: AppIntent {
+  nonisolated(unsafe) static var title: LocalizedStringResource = "List Accounts"
+  nonisolated(unsafe) static var description = IntentDescription(
+    "Lists accounts and their balances for a profile.")
+
+  @Parameter(title: "Profile")
+  var profile: ProfileEntity
+
+  @Parameter(title: "Account Type", default: nil)
+  var accountType: AccountTypeEnum?
+
+  @MainActor
+  func perform() async throws -> some IntentResult & ReturnsValue<String> {
+    guard let service = AutomationServiceLocator.shared.service else {
+      throw AutomationError.operationFailed("App not ready")
+    }
+    var accounts = try service.listAccounts(profileIdentifier: profile.id.uuidString)
+    accounts = accounts.filter { !$0.isHidden }
+
+    if let accountType {
+      accounts = accounts.filter { $0.type == accountType.toDomainType }
+    }
+
+    if accounts.isEmpty {
+      return .result(value: "No accounts found.")
+    }
+
+    let lines = accounts.map { account in
+      "\(account.name): \(account.displayBalance.formatted) (\(account.type.displayName))"
+    }
+    return .result(value: lines.joined(separator: "\n"))
+  }
+}
+
+enum AccountTypeEnum: String, AppEnum {
+  case bank
+  case creditCard
+  case asset
+  case investment
+
+  nonisolated(unsafe) static var typeDisplayRepresentation = TypeDisplayRepresentation(
+    name: "Account Type")
+
+  nonisolated(unsafe) static var caseDisplayRepresentations:
+    [AccountTypeEnum: DisplayRepresentation] = [
+      .bank: "Bank Account",
+      .creditCard: "Credit Card",
+      .asset: "Asset",
+      .investment: "Investment",
+    ]
+
+  var toDomainType: AccountType {
+    switch self {
+    case .bank: .bank
+    case .creditCard: .creditCard
+    case .asset: .asset
+    case .investment: .investment
+    }
+  }
+}

--- a/Automation/Intents/MoolahShortcuts.swift
+++ b/Automation/Intents/MoolahShortcuts.swift
@@ -1,0 +1,48 @@
+import AppIntents
+
+struct MoolahShortcuts: AppShortcutsProvider {
+  static var appShortcuts: [AppShortcut] {
+    AppShortcut(
+      intent: GetNetWorthIntent(),
+      phrases: ["What's my net worth in \(.applicationName)?"],
+      shortTitle: "Net Worth",
+      systemImageName: "chart.line.uptrend.xyaxis"
+    )
+    AppShortcut(
+      intent: ListAccountsIntent(),
+      phrases: ["Show my balances in \(.applicationName)"],
+      shortTitle: "Account Balances",
+      systemImageName: "list.bullet"
+    )
+    AppShortcut(
+      intent: CreateTransactionIntent(),
+      phrases: ["Add a transaction in \(.applicationName)"],
+      shortTitle: "Add Transaction",
+      systemImageName: "plus.circle"
+    )
+    AppShortcut(
+      intent: GetAccountBalanceIntent(),
+      phrases: ["What's my \(\.$account) balance in \(.applicationName)?"],
+      shortTitle: "Account Balance",
+      systemImageName: "dollarsign.circle"
+    )
+    AppShortcut(
+      intent: GetEarmarkBalanceIntent(),
+      phrases: ["How much is in \(\.$earmark) in \(.applicationName)?"],
+      shortTitle: "Earmark Balance",
+      systemImageName: "bookmark"
+    )
+    AppShortcut(
+      intent: GetExpenseBreakdownIntent(),
+      phrases: ["What did I spend this month in \(.applicationName)?"],
+      shortTitle: "Monthly Spending",
+      systemImageName: "chart.pie"
+    )
+    AppShortcut(
+      intent: GetRecentTransactionsIntent(),
+      phrases: ["Show my recent transactions in \(.applicationName)"],
+      shortTitle: "Recent Transactions",
+      systemImageName: "clock"
+    )
+  }
+}

--- a/Automation/Intents/OpenAccountIntent.swift
+++ b/Automation/Intents/OpenAccountIntent.swift
@@ -28,7 +28,7 @@ struct OpenAccountIntent: AppIntent {
 
     let profileEncoded =
       profile.name.addingPercentEncoding(withAllowedCharacters: .urlHostAllowed) ?? profile.name
-    let urlString = "moolah://\(profileEncoded)/accounts/\(account.id.uuidString)"
+    let urlString = "moolah://\(profileEncoded)/account/\(account.id.uuidString)"
     if let url = URL(string: urlString) {
       #if os(macOS)
         NSWorkspace.shared.open(url)

--- a/Automation/Intents/OpenAccountIntent.swift
+++ b/Automation/Intents/OpenAccountIntent.swift
@@ -1,0 +1,42 @@
+import AppIntents
+import Foundation
+
+#if os(macOS)
+  import AppKit
+#else
+  import UIKit
+#endif
+
+struct OpenAccountIntent: AppIntent {
+  nonisolated(unsafe) static var title: LocalizedStringResource = "Open Account"
+  nonisolated(unsafe) static var description = IntentDescription(
+    "Opens a specific account in the Moolah app.")
+
+  @Parameter(title: "Profile")
+  var profile: ProfileEntity
+
+  @Parameter(title: "Account")
+  var account: AccountEntity
+
+  nonisolated(unsafe) static var openAppWhenRun = true
+
+  @MainActor
+  func perform() async throws -> some IntentResult & ReturnsValue<String> {
+    guard AutomationServiceLocator.shared.service != nil else {
+      throw AutomationError.operationFailed("App not ready")
+    }
+
+    let profileEncoded =
+      profile.name.addingPercentEncoding(withAllowedCharacters: .urlHostAllowed) ?? profile.name
+    let urlString = "moolah://\(profileEncoded)/accounts/\(account.id.uuidString)"
+    if let url = URL(string: urlString) {
+      #if os(macOS)
+        NSWorkspace.shared.open(url)
+      #else
+        await UIApplication.shared.open(url)
+      #endif
+    }
+
+    return .result(value: "Opening \(account.name)")
+  }
+}

--- a/Automation/Intents/RefreshDataIntent.swift
+++ b/Automation/Intents/RefreshDataIntent.swift
@@ -1,0 +1,30 @@
+import AppIntents
+import Foundation
+
+struct RefreshDataIntent: AppIntent {
+  nonisolated(unsafe) static var title: LocalizedStringResource = "Refresh Data"
+  nonisolated(unsafe) static var description = IntentDescription(
+    "Refreshes all data from the server for a profile.")
+
+  @Parameter(title: "Profile", default: nil)
+  var profile: ProfileEntity?
+
+  @MainActor
+  func perform() async throws -> some IntentResult & ReturnsValue<String> {
+    guard let service = AutomationServiceLocator.shared.service else {
+      throw AutomationError.operationFailed("App not ready")
+    }
+
+    if let profile {
+      try await service.refresh(profileIdentifier: profile.id.uuidString)
+      return .result(value: "Refreshed data for \(profile.name)")
+    }
+
+    // Refresh all open profiles
+    let profiles = service.listOpenProfiles()
+    for openProfile in profiles {
+      try await service.refresh(profileIdentifier: openProfile.id.uuidString)
+    }
+    return .result(value: "Refreshed data for \(profiles.count) profile(s)")
+  }
+}

--- a/Automation/URLScheme/PendingNavigation.swift
+++ b/Automation/URLScheme/PendingNavigation.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+/// Represents a pending navigation request from a URL scheme.
+struct PendingNavigation: Equatable {
+  let profileId: UUID
+  let destination: URLSchemeHandler.Destination
+}
+
+// MARK: - Environment Key
+
+private struct PendingNavigationKey: EnvironmentKey {
+  static let defaultValue: Binding<PendingNavigation?>? = nil
+}
+
+extension EnvironmentValues {
+  var pendingNavigation: Binding<PendingNavigation?>? {
+    get { self[PendingNavigationKey.self] }
+    set { self[PendingNavigationKey.self] = newValue }
+  }
+}

--- a/Automation/URLScheme/URLSchemeHandler.swift
+++ b/Automation/URLScheme/URLSchemeHandler.swift
@@ -1,0 +1,135 @@
+import Foundation
+import OSLog
+
+private let logger = Logger(subsystem: "com.moolah.app", category: "URLScheme")
+
+enum URLSchemeHandler {
+  struct Route: Sendable {
+    let profileIdentifier: String
+    let destination: Destination?
+  }
+
+  enum Destination: Sendable, Equatable {
+    case accounts
+    case account(UUID)
+    case transaction(UUID)
+    case earmarks
+    case earmark(UUID)
+    case analysis(history: Int?, forecast: Int?)
+    case reports(from: Date?, to: Date?)
+    case categories
+    case upcoming
+  }
+
+  enum ParseError: LocalizedError, Sendable {
+    case invalidScheme(String)
+    case missingProfileName
+    case invalidUUID(String)
+    case unknownDestination(String)
+
+    var errorDescription: String? {
+      switch self {
+      case .invalidScheme(let scheme): "Invalid URL scheme: '\(scheme)' (expected 'moolah')"
+      case .missingProfileName: "URL must include a profile name as the host"
+      case .invalidUUID(let value): "Invalid UUID: '\(value)'"
+      case .unknownDestination(let path): "Unknown destination: '\(path)'"
+      }
+    }
+  }
+
+  static func parse(_ url: URL) throws -> Route {
+    guard url.scheme?.lowercased() == "moolah" else {
+      throw ParseError.invalidScheme(url.scheme ?? "<none>")
+    }
+
+    guard let profileIdentifier = url.host(percentEncoded: false), !profileIdentifier.isEmpty else {
+      throw ParseError.missingProfileName
+    }
+
+    // Extract path components (dropping the leading "/" empty component)
+    let pathComponents = url.pathComponents.filter { $0 != "/" }
+
+    guard let firstComponent = pathComponents.first else {
+      return Route(profileIdentifier: profileIdentifier, destination: nil)
+    }
+
+    let destination = try parseDestination(
+      firstComponent.lowercased(),
+      pathComponents: pathComponents,
+      queryItems: URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems
+    )
+
+    return Route(profileIdentifier: profileIdentifier, destination: destination)
+  }
+
+  private static func parseDestination(
+    _ name: String,
+    pathComponents: [String],
+    queryItems: [URLQueryItem]?
+  ) throws -> Destination {
+    switch name {
+    case "accounts":
+      return .accounts
+    case "account":
+      let id = try requireUUID(from: pathComponents, at: 1)
+      return .account(id)
+    case "transaction":
+      let id = try requireUUID(from: pathComponents, at: 1)
+      return .transaction(id)
+    case "earmarks":
+      return .earmarks
+    case "earmark":
+      let id = try requireUUID(from: pathComponents, at: 1)
+      return .earmark(id)
+    case "analysis":
+      let history = queryItems?.first(where: { $0.name == "history" })?.value.flatMap(Int.init)
+      let forecast = queryItems?.first(where: { $0.name == "forecast" })?.value.flatMap(Int.init)
+      return .analysis(history: history, forecast: forecast)
+    case "reports":
+      let dateFormatter = ISO8601DateFormatter()
+      dateFormatter.formatOptions = [.withFullDate]
+      let from = queryItems?.first(where: { $0.name == "from" })?.value.flatMap(
+        dateFormatter.date(from:))
+      let to = queryItems?.first(where: { $0.name == "to" })?.value.flatMap(
+        dateFormatter.date(from:))
+      return .reports(from: from, to: to)
+    case "categories":
+      return .categories
+    case "upcoming":
+      return .upcoming
+    default:
+      throw ParseError.unknownDestination(name)
+    }
+  }
+
+  private static func requireUUID(from components: [String], at index: Int) throws -> UUID {
+    guard index < components.count else {
+      throw ParseError.invalidUUID("<missing>")
+    }
+    guard let uuid = UUID(uuidString: components[index]) else {
+      throw ParseError.invalidUUID(components[index])
+    }
+    return uuid
+  }
+
+  // MARK: - Sidebar Mapping
+
+  static func toSidebarSelection(_ destination: Destination) -> SidebarSelection? {
+    switch destination {
+    case .account(let id):
+      return .account(id)
+    case .earmark(let id):
+      return .earmark(id)
+    case .analysis:
+      return .analysis
+    case .reports:
+      return .reports
+    case .categories:
+      return .categories
+    case .upcoming:
+      return .upcomingTransactions
+    case .accounts, .earmarks, .transaction:
+      return nil
+    }
+  }
+}

--- a/MoolahTests/Automation/AutomationServiceTests.swift
+++ b/MoolahTests/Automation/AutomationServiceTests.swift
@@ -1,0 +1,161 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("SessionManager Automation Extensions")
+@MainActor
+struct SessionManagerAutomationTests {
+  private func makeManager() throws -> SessionManager {
+    let containerManager = try ProfileContainerManager.forTesting()
+    return SessionManager(containerManager: containerManager)
+  }
+
+  private func makeProfile(label: String = "Personal") -> Profile {
+    Profile(
+      label: label,
+      backendType: .cloudKit,
+      currencyCode: "AUD",
+      financialYearStartMonth: 7
+    )
+  }
+
+  @Test("session(named:) finds session by exact profile name")
+  func findSessionByProfileName() throws {
+    let manager = try makeManager()
+    let profile = makeProfile(label: "Personal")
+    _ = manager.session(for: profile)
+
+    let found = manager.session(named: "Personal")
+
+    #expect(found != nil)
+    #expect(found?.profile.id == profile.id)
+  }
+
+  @Test("session(named:) finds session case-insensitively")
+  func findSessionByProfileNameCaseInsensitive() throws {
+    let manager = try makeManager()
+    let profile = makeProfile(label: "Personal")
+    _ = manager.session(for: profile)
+
+    let found = manager.session(named: "personal")
+
+    #expect(found != nil)
+    #expect(found?.profile.id == profile.id)
+  }
+
+  @Test("session(named:) returns nil when no session matches")
+  func findSessionByProfileNameReturnsNilWhenNotFound() throws {
+    let manager = try makeManager()
+    let profile = makeProfile(label: "Personal")
+    _ = manager.session(for: profile)
+
+    let found = manager.session(named: "Business")
+
+    #expect(found == nil)
+  }
+
+  @Test("session(forID:) finds session by UUID")
+  func findSessionByUUID() throws {
+    let manager = try makeManager()
+    let profile = makeProfile()
+    _ = manager.session(for: profile)
+
+    let found = manager.session(forID: profile.id)
+
+    #expect(found != nil)
+    #expect(found?.profile.id == profile.id)
+  }
+
+  @Test("session(forID:) returns nil for unknown UUID")
+  func findSessionByUUIDReturnsNilWhenNotFound() throws {
+    let manager = try makeManager()
+
+    let found = manager.session(forID: UUID())
+
+    #expect(found == nil)
+  }
+
+  @Test("openProfiles returns all sessions")
+  func openProfilesReturnsAllSessions() throws {
+    let manager = try makeManager()
+    let profile1 = makeProfile(label: "Personal")
+    let profile2 = makeProfile(label: "Business")
+    _ = manager.session(for: profile1)
+    _ = manager.session(for: profile2)
+
+    let open = manager.openProfiles
+
+    #expect(open.count == 2)
+    let ids = Set(open.map(\.profile.id))
+    #expect(ids.contains(profile1.id))
+    #expect(ids.contains(profile2.id))
+  }
+}
+
+@Suite("AutomationService Profile Operations")
+@MainActor
+struct AutomationServiceProfileTests {
+  private func makeService() throws -> (AutomationService, SessionManager) {
+    let containerManager = try ProfileContainerManager.forTesting()
+    let sessionManager = SessionManager(containerManager: containerManager)
+    let service = AutomationService(sessionManager: sessionManager)
+    return (service, sessionManager)
+  }
+
+  private func makeProfile(label: String = "Personal") -> Profile {
+    Profile(
+      label: label,
+      backendType: .cloudKit,
+      currencyCode: "AUD",
+      financialYearStartMonth: 7
+    )
+  }
+
+  @Test("resolveSession finds session by name")
+  func resolveByName() throws {
+    let (service, sessionManager) = try makeService()
+    let profile = makeProfile(label: "Personal")
+    _ = sessionManager.session(for: profile)
+
+    let session = try service.resolveSession(for: "Personal")
+
+    #expect(session.profile.id == profile.id)
+  }
+
+  @Test("resolveSession finds session by UUID string")
+  func resolveByUUID() throws {
+    let (service, sessionManager) = try makeService()
+    let profile = makeProfile(label: "Personal")
+    _ = sessionManager.session(for: profile)
+
+    let session = try service.resolveSession(for: profile.id.uuidString)
+
+    #expect(session.profile.id == profile.id)
+  }
+
+  @Test("resolveSession throws when profile not found")
+  func throwsWhenNotFound() throws {
+    let (service, _) = try makeService()
+
+    #expect(throws: AutomationError.self) {
+      try service.resolveSession(for: "NonExistent")
+    }
+  }
+
+  @Test("listOpenProfiles returns all open profiles")
+  func listOpenProfiles() throws {
+    let (service, sessionManager) = try makeService()
+    let profile1 = makeProfile(label: "Personal")
+    let profile2 = makeProfile(label: "Business")
+    _ = sessionManager.session(for: profile1)
+    _ = sessionManager.session(for: profile2)
+
+    let profiles = service.listOpenProfiles()
+
+    #expect(profiles.count == 2)
+    let labels = Set(profiles.map(\.label))
+    #expect(labels.contains("Personal"))
+    #expect(labels.contains("Business"))
+  }
+}

--- a/MoolahTests/Automation/AutomationServiceTests.swift
+++ b/MoolahTests/Automation/AutomationServiceTests.swift
@@ -159,3 +159,384 @@ struct AutomationServiceProfileTests {
     #expect(labels.contains("Business"))
   }
 }
+
+// MARK: - Account Operations
+
+@Suite("AutomationService Account Operations")
+@MainActor
+struct AutomationServiceAccountTests {
+  private func makeServiceWithSession() async throws -> (AutomationService, ProfileSession) {
+    let containerManager = try ProfileContainerManager.forTesting()
+    let sessionManager = SessionManager(containerManager: containerManager)
+    let profile = Profile(
+      label: "Test",
+      backendType: .cloudKit,
+      currencyCode: "AUD",
+      financialYearStartMonth: 7
+    )
+    let session = sessionManager.session(for: profile)
+    await session.accountStore.load()
+    let service = AutomationService(sessionManager: sessionManager)
+    return (service, session)
+  }
+
+  @Test("createAccount creates and lists accounts")
+  func createAndListAccounts() async throws {
+    let (service, _) = try await makeServiceWithSession()
+
+    let account = try await service.createAccount(
+      profileIdentifier: "Test",
+      name: "Savings",
+      type: .bank
+    )
+
+    #expect(account.name == "Savings")
+    #expect(account.type == .bank)
+    #expect(account.balance.quantity == 0)
+
+    let accounts = try service.listAccounts(profileIdentifier: "Test")
+    #expect(accounts.count == 1)
+    #expect(accounts.first?.name == "Savings")
+  }
+
+  @Test("resolveAccount finds account by name case-insensitively")
+  func resolveAccountByNameCaseInsensitive() async throws {
+    let (service, _) = try await makeServiceWithSession()
+    _ = try await service.createAccount(
+      profileIdentifier: "Test",
+      name: "My Savings",
+      type: .bank
+    )
+
+    let resolved = try service.resolveAccount(named: "my savings", profileIdentifier: "Test")
+    #expect(resolved.name == "My Savings")
+  }
+
+  @Test("resolveAccount throws when not found")
+  func resolveAccountNotFoundThrows() async throws {
+    let (service, _) = try await makeServiceWithSession()
+
+    #expect(throws: AutomationError.self) {
+      try service.resolveAccount(named: "NonExistent", profileIdentifier: "Test")
+    }
+  }
+
+  @Test("resolveAccount finds account by UUID")
+  func resolveAccountByUUID() async throws {
+    let (service, _) = try await makeServiceWithSession()
+    let created = try await service.createAccount(
+      profileIdentifier: "Test",
+      name: "Checking",
+      type: .bank
+    )
+
+    let resolved = try service.resolveAccount(id: created.id, profileIdentifier: "Test")
+    #expect(resolved.name == "Checking")
+  }
+
+  @Test("getNetWorth returns sum of current and investment accounts")
+  func getNetWorth() async throws {
+    let (service, session) = try await makeServiceWithSession()
+    let instrument = session.profile.instrument
+
+    // Create a bank account with a balance
+    let bankAccount = Account(
+      name: "Bank",
+      type: .bank,
+      balance: InstrumentAmount(quantity: 1000, instrument: instrument),
+      position: 0
+    )
+    _ = try await session.accountStore.create(bankAccount)
+
+    let netWorth = try service.getNetWorth(profileIdentifier: "Test")
+    #expect(netWorth.quantity == 1000)
+  }
+
+  @Test("updateAccount changes account name")
+  func updateAccountName() async throws {
+    let (service, _) = try await makeServiceWithSession()
+    let created = try await service.createAccount(
+      profileIdentifier: "Test",
+      name: "Old Name",
+      type: .bank
+    )
+
+    let updated = try await service.updateAccount(
+      profileIdentifier: "Test",
+      accountId: created.id,
+      name: "New Name"
+    )
+
+    #expect(updated.name == "New Name")
+  }
+
+  @Test("deleteAccount removes account")
+  func deleteAccount() async throws {
+    let (service, _) = try await makeServiceWithSession()
+    let created = try await service.createAccount(
+      profileIdentifier: "Test",
+      name: "ToDelete",
+      type: .bank
+    )
+
+    try await service.deleteAccount(profileIdentifier: "Test", accountId: created.id)
+
+    let accounts = try service.listAccounts(profileIdentifier: "Test")
+    #expect(accounts.isEmpty)
+  }
+}
+
+// MARK: - Transaction Operations
+
+@Suite("AutomationService Transaction Operations")
+@MainActor
+struct AutomationServiceTransactionTests {
+  private func makeServiceWithSession() async throws -> (AutomationService, ProfileSession) {
+    let containerManager = try ProfileContainerManager.forTesting()
+    let sessionManager = SessionManager(containerManager: containerManager)
+    let profile = Profile(
+      label: "Test",
+      backendType: .cloudKit,
+      currencyCode: "AUD",
+      financialYearStartMonth: 7
+    )
+    let session = sessionManager.session(for: profile)
+    await session.accountStore.load()
+    await session.categoryStore.load()
+    await session.earmarkStore.load()
+    let service = AutomationService(sessionManager: sessionManager)
+    return (service, session)
+  }
+
+  @Test("createTransaction creates a single-leg transaction")
+  func createSingleLegTransaction() async throws {
+    let (service, _) = try await makeServiceWithSession()
+
+    // Create an account first
+    _ = try await service.createAccount(
+      profileIdentifier: "Test",
+      name: "Checking",
+      type: .bank
+    )
+
+    let transaction = try await service.createTransaction(
+      profileIdentifier: "Test",
+      payee: "Grocery Store",
+      date: Date(),
+      legs: [
+        AutomationService.LegSpec(
+          accountName: "Checking",
+          amount: -50,
+          categoryName: nil,
+          earmarkName: nil
+        )
+      ],
+      notes: "Weekly shopping"
+    )
+
+    #expect(transaction.payee == "Grocery Store")
+    #expect(transaction.notes == "Weekly shopping")
+    #expect(transaction.legs.count == 1)
+    #expect(transaction.legs.first?.quantity == -50)
+    #expect(transaction.legs.first?.type == .expense)
+  }
+
+  @Test("listTransactions returns created transactions")
+  func listTransactions() async throws {
+    let (service, _) = try await makeServiceWithSession()
+
+    _ = try await service.createAccount(
+      profileIdentifier: "Test",
+      name: "Checking",
+      type: .bank
+    )
+
+    _ = try await service.createTransaction(
+      profileIdentifier: "Test",
+      payee: "Store A",
+      date: Date(),
+      legs: [
+        AutomationService.LegSpec(
+          accountName: "Checking",
+          amount: -25,
+          categoryName: nil,
+          earmarkName: nil
+        )
+      ]
+    )
+
+    let transactions = try await service.listTransactions(profileIdentifier: "Test")
+    #expect(transactions.count == 1)
+    #expect(transactions.first?.payee == "Store A")
+  }
+
+  @Test("createTransaction with positive amount creates income")
+  func createIncomeTransaction() async throws {
+    let (service, _) = try await makeServiceWithSession()
+
+    _ = try await service.createAccount(
+      profileIdentifier: "Test",
+      name: "Checking",
+      type: .bank
+    )
+
+    let transaction = try await service.createTransaction(
+      profileIdentifier: "Test",
+      payee: "Employer",
+      date: Date(),
+      legs: [
+        AutomationService.LegSpec(
+          accountName: "Checking",
+          amount: 3000,
+          categoryName: nil,
+          earmarkName: nil
+        )
+      ]
+    )
+
+    #expect(transaction.legs.first?.type == .income)
+    #expect(transaction.legs.first?.quantity == 3000)
+  }
+}
+
+// MARK: - Earmark Operations
+
+@Suite("AutomationService Earmark Operations")
+@MainActor
+struct AutomationServiceEarmarkTests {
+  private func makeServiceWithSession() async throws -> (AutomationService, ProfileSession) {
+    let containerManager = try ProfileContainerManager.forTesting()
+    let sessionManager = SessionManager(containerManager: containerManager)
+    let profile = Profile(
+      label: "Test",
+      backendType: .cloudKit,
+      currencyCode: "AUD",
+      financialYearStartMonth: 7
+    )
+    let session = sessionManager.session(for: profile)
+    await session.earmarkStore.load()
+    let service = AutomationService(sessionManager: sessionManager)
+    return (service, session)
+  }
+
+  @Test("createEarmark creates and lists earmarks")
+  func createAndListEarmarks() async throws {
+    let (service, _) = try await makeServiceWithSession()
+
+    let earmark = try await service.createEarmark(
+      profileIdentifier: "Test",
+      name: "Holiday Fund",
+      targetAmount: 5000
+    )
+
+    #expect(earmark.name == "Holiday Fund")
+    #expect(earmark.savingsGoal?.quantity == 5000)
+
+    let earmarks = try service.listEarmarks(profileIdentifier: "Test")
+    #expect(earmarks.count == 1)
+    #expect(earmarks.first?.name == "Holiday Fund")
+  }
+
+  @Test("resolveEarmark finds earmark case-insensitively")
+  func resolveEarmarkCaseInsensitive() async throws {
+    let (service, _) = try await makeServiceWithSession()
+
+    _ = try await service.createEarmark(
+      profileIdentifier: "Test",
+      name: "Emergency Fund"
+    )
+
+    let resolved = try service.resolveEarmark(named: "emergency fund", profileIdentifier: "Test")
+    #expect(resolved.name == "Emergency Fund")
+  }
+
+  @Test("resolveEarmark throws when not found")
+  func resolveEarmarkNotFound() async throws {
+    let (service, _) = try await makeServiceWithSession()
+
+    #expect(throws: AutomationError.self) {
+      try service.resolveEarmark(named: "NonExistent", profileIdentifier: "Test")
+    }
+  }
+}
+
+// MARK: - Category Operations
+
+@Suite("AutomationService Category Operations")
+@MainActor
+struct AutomationServiceCategoryTests {
+  private func makeServiceWithSession() async throws -> (AutomationService, ProfileSession) {
+    let containerManager = try ProfileContainerManager.forTesting()
+    let sessionManager = SessionManager(containerManager: containerManager)
+    let profile = Profile(
+      label: "Test",
+      backendType: .cloudKit,
+      currencyCode: "AUD",
+      financialYearStartMonth: 7
+    )
+    let session = sessionManager.session(for: profile)
+    await session.categoryStore.load()
+    let service = AutomationService(sessionManager: sessionManager)
+    return (service, session)
+  }
+
+  @Test("createCategory creates and lists categories")
+  func createAndListCategories() async throws {
+    let (service, _) = try await makeServiceWithSession()
+
+    let category = try await service.createCategory(
+      profileIdentifier: "Test",
+      name: "Food",
+      parentName: nil
+    )
+
+    #expect(category.name == "Food")
+    #expect(category.parentId == nil)
+
+    let categories = try service.listCategories(profileIdentifier: "Test")
+    #expect(categories.count == 1)
+    #expect(categories.first?.name == "Food")
+  }
+
+  @Test("resolveCategory finds category by name case-insensitively")
+  func resolveCategoryByName() async throws {
+    let (service, _) = try await makeServiceWithSession()
+
+    _ = try await service.createCategory(
+      profileIdentifier: "Test",
+      name: "Transport",
+      parentName: nil
+    )
+
+    let resolved = try service.resolveCategory(named: "transport", profileIdentifier: "Test")
+    #expect(resolved.name == "Transport")
+  }
+
+  @Test("resolveCategory throws when not found")
+  func resolveCategoryNotFound() async throws {
+    let (service, _) = try await makeServiceWithSession()
+
+    #expect(throws: AutomationError.self) {
+      try service.resolveCategory(named: "NonExistent", profileIdentifier: "Test")
+    }
+  }
+
+  @Test("createCategory with parent creates subcategory")
+  func createSubcategory() async throws {
+    let (service, _) = try await makeServiceWithSession()
+
+    let parent = try await service.createCategory(
+      profileIdentifier: "Test",
+      name: "Food",
+      parentName: nil
+    )
+
+    let child = try await service.createCategory(
+      profileIdentifier: "Test",
+      name: "Groceries",
+      parentName: "Food"
+    )
+
+    #expect(child.parentId == parent.id)
+  }
+}

--- a/MoolahTests/Automation/URLSchemeHandlerTests.swift
+++ b/MoolahTests/Automation/URLSchemeHandlerTests.swift
@@ -1,0 +1,217 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("URLSchemeHandler")
+struct URLSchemeHandlerTests {
+
+  // MARK: - Parsing
+
+  @Test("parses profile-only URL")
+  func parseProfileOnly() throws {
+    let url = URL(string: "moolah://Personal")!
+    let route = try URLSchemeHandler.parse(url)
+    #expect(route.profileIdentifier == "Personal")
+    #expect(route.destination == nil)
+  }
+
+  @Test("parses account route with UUID")
+  func parseAccountRoute() throws {
+    let id = UUID()
+    let url = URL(string: "moolah://Personal/account/\(id.uuidString)")!
+    let route = try URLSchemeHandler.parse(url)
+    #expect(route.profileIdentifier == "Personal")
+    #expect(route.destination == .account(id))
+  }
+
+  @Test("parses transaction route with UUID")
+  func parseTransactionRoute() throws {
+    let id = UUID()
+    let url = URL(string: "moolah://Personal/transaction/\(id.uuidString)")!
+    let route = try URLSchemeHandler.parse(url)
+    #expect(route.profileIdentifier == "Personal")
+    #expect(route.destination == .transaction(id))
+  }
+
+  @Test("parses analysis with query params")
+  func parseAnalysisWithParams() throws {
+    let url = URL(string: "moolah://Personal/analysis?history=12&forecast=3")!
+    let route = try URLSchemeHandler.parse(url)
+    #expect(route.profileIdentifier == "Personal")
+    #expect(route.destination == .analysis(history: 12, forecast: 3))
+  }
+
+  @Test("parses analysis without query params")
+  func parseAnalysisNoParams() throws {
+    let url = URL(string: "moolah://Personal/analysis")!
+    let route = try URLSchemeHandler.parse(url)
+    #expect(route.destination == .analysis(history: nil, forecast: nil))
+  }
+
+  @Test("parses reports with date range")
+  func parseReportsWithDates() throws {
+    let url = URL(string: "moolah://Personal/reports?from=2026-01-01&to=2026-03-31")!
+    let route = try URLSchemeHandler.parse(url)
+
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withFullDate]
+    let expectedFrom = formatter.date(from: "2026-01-01")!
+    let expectedTo = formatter.date(from: "2026-03-31")!
+
+    #expect(route.destination == .reports(from: expectedFrom, to: expectedTo))
+  }
+
+  @Test("parses reports without date range")
+  func parseReportsNoDates() throws {
+    let url = URL(string: "moolah://Personal/reports")!
+    let route = try URLSchemeHandler.parse(url)
+    #expect(route.destination == .reports(from: nil, to: nil))
+  }
+
+  @Test("parses percent-encoded profile name")
+  func parseEncodedProfileName() throws {
+    let url = URL(string: "moolah://My%20Finances/analysis")!
+    let route = try URLSchemeHandler.parse(url)
+    #expect(route.profileIdentifier == "My Finances")
+  }
+
+  @Test(
+    "parses simple destinations",
+    arguments: [
+      ("accounts", URLSchemeHandler.Destination.accounts),
+      ("earmarks", URLSchemeHandler.Destination.earmarks),
+      ("categories", URLSchemeHandler.Destination.categories),
+      ("upcoming", URLSchemeHandler.Destination.upcoming),
+    ]
+  )
+  func parseSimpleDestination(path: String, expected: URLSchemeHandler.Destination) throws {
+    let url = URL(string: "moolah://Test/\(path)")!
+    let route = try URLSchemeHandler.parse(url)
+    #expect(route.destination == expected)
+  }
+
+  @Test("parses earmark with UUID")
+  func parseEarmarkRoute() throws {
+    let id = UUID()
+    let url = URL(string: "moolah://Test/earmark/\(id.uuidString)")!
+    let route = try URLSchemeHandler.parse(url)
+    #expect(route.destination == .earmark(id))
+  }
+
+  @Test("case-insensitive path matching")
+  func caseInsensitivePath() throws {
+    let url = URL(string: "moolah://Test/Analysis")!
+    let route = try URLSchemeHandler.parse(url)
+    #expect(route.destination == .analysis(history: nil, forecast: nil))
+  }
+
+  @Test("case-insensitive UUID matching")
+  func caseInsensitiveUUID() throws {
+    let id = UUID()
+    let url = URL(string: "moolah://Test/account/\(id.uuidString.lowercased())")!
+    let route = try URLSchemeHandler.parse(url)
+    #expect(route.destination == .account(id))
+  }
+
+  // MARK: - Error Cases
+
+  @Test("throws for invalid scheme")
+  func invalidScheme() throws {
+    let url = URL(string: "https://Personal/accounts")!
+    #expect(throws: URLSchemeHandler.ParseError.self) {
+      try URLSchemeHandler.parse(url)
+    }
+  }
+
+  @Test("throws for missing profile name")
+  func missingProfileName() throws {
+    let url = URL(string: "moolah:///accounts")!
+    #expect(throws: URLSchemeHandler.ParseError.self) {
+      try URLSchemeHandler.parse(url)
+    }
+  }
+
+  @Test("throws for invalid UUID in account route")
+  func invalidUUIDAccount() throws {
+    let url = URL(string: "moolah://Test/account/not-a-uuid")!
+    #expect(throws: URLSchemeHandler.ParseError.self) {
+      try URLSchemeHandler.parse(url)
+    }
+  }
+
+  @Test("throws for invalid UUID in transaction route")
+  func invalidUUIDTransaction() throws {
+    let url = URL(string: "moolah://Test/transaction/bad")!
+    #expect(throws: URLSchemeHandler.ParseError.self) {
+      try URLSchemeHandler.parse(url)
+    }
+  }
+
+  @Test("throws for invalid UUID in earmark route")
+  func invalidUUIDEarmark() throws {
+    let url = URL(string: "moolah://Test/earmark/bad")!
+    #expect(throws: URLSchemeHandler.ParseError.self) {
+      try URLSchemeHandler.parse(url)
+    }
+  }
+
+  @Test("throws for unknown destination")
+  func unknownDestination() throws {
+    let url = URL(string: "moolah://Test/unknown")!
+    #expect(throws: URLSchemeHandler.ParseError.self) {
+      try URLSchemeHandler.parse(url)
+    }
+  }
+
+  // MARK: - toSidebarSelection
+
+  @Test("maps account to sidebar selection")
+  func sidebarAccount() {
+    let id = UUID()
+    #expect(URLSchemeHandler.toSidebarSelection(.account(id)) == .account(id))
+  }
+
+  @Test("maps earmark to sidebar selection")
+  func sidebarEarmark() {
+    let id = UUID()
+    #expect(URLSchemeHandler.toSidebarSelection(.earmark(id)) == .earmark(id))
+  }
+
+  @Test("maps analysis to sidebar selection")
+  func sidebarAnalysis() {
+    #expect(
+      URLSchemeHandler.toSidebarSelection(.analysis(history: nil, forecast: nil)) == .analysis)
+  }
+
+  @Test("maps reports to sidebar selection")
+  func sidebarReports() {
+    #expect(URLSchemeHandler.toSidebarSelection(.reports(from: nil, to: nil)) == .reports)
+  }
+
+  @Test("maps categories to sidebar selection")
+  func sidebarCategories() {
+    #expect(URLSchemeHandler.toSidebarSelection(.categories) == .categories)
+  }
+
+  @Test("maps upcoming to sidebar selection")
+  func sidebarUpcoming() {
+    #expect(URLSchemeHandler.toSidebarSelection(.upcoming) == .upcomingTransactions)
+  }
+
+  @Test("maps accounts to nil (handled differently)")
+  func sidebarAccounts() {
+    #expect(URLSchemeHandler.toSidebarSelection(.accounts) == nil)
+  }
+
+  @Test("maps earmarks to nil (handled differently)")
+  func sidebarEarmarks() {
+    #expect(URLSchemeHandler.toSidebarSelection(.earmarks) == nil)
+  }
+
+  @Test("maps transaction to nil (handled differently)")
+  func sidebarTransaction() {
+    let id = UUID()
+    #expect(URLSchemeHandler.toSidebarSelection(.transaction(id)) == nil)
+  }
+}

--- a/project.yml
+++ b/project.yml
@@ -49,6 +49,9 @@ targets:
       - path: Backends
       - path: Features
       - path: Shared
+      - path: Automation
+    dependencies:
+      - sdk: AppIntents.framework
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: rocks.moolah.app
@@ -66,6 +69,9 @@ targets:
       - path: Backends
       - path: Features
       - path: Shared
+      - path: Automation
+    dependencies:
+      - sdk: AppIntents.framework
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: rocks.moolah.app


### PR DESCRIPTION
## Summary

- **Shared AutomationService layer** — single operations layer for all automation surfaces, with full CRUD for accounts, transactions, earmarks, categories, investments, and analysis
- **AppleScript scripting** — complete SDEF scripting dictionary with scriptable object wrappers, 9 command handlers, and sync/async bridge for driving the app via `osascript`
- **App Intents / Shortcuts** — 12 intents with Siri phrases covering common workflows (net worth, balances, transactions, earmarks, expenses), plus `AppShortcutsProvider` for Shortcuts gallery
- **`moolah://` URL scheme** — deep linking to profiles, accounts, transactions, earmarks, analysis, reports, categories with query parameters for date ranges and analysis periods
- **AI automation skill** — `.claude/skills/automate-app/SKILL.md` teaching AI agents how to drive the app with profile safety requirements

## Test plan
- [ ] All 912 existing tests pass (verified)
- [ ] macOS and iOS builds succeed with no warnings (verified)
- [ ] Manual: `osascript -e 'tell application "Moolah" to get name of every profile'` returns profiles
- [ ] Manual: `open "moolah://ProfileName/analysis"` navigates to analysis view
- [ ] Manual: Create transaction via AppleScript, verify balance updates
- [ ] Manual: Test Shortcuts intents appear in Shortcuts app

🤖 Generated with [Claude Code](https://claude.com/claude-code)