### PR TITLE
feat: support test filters in just targets

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,12 @@ just
 # Run the full test suite on iOS Simulator and macOS
 just test
 
+# Run a subset of tests (class or class/method); prefix is added per platform.
+# Works for `just test`, `just test-mac`, and `just test-ios`.
+just test TransactionStoreTests
+just test TransactionStoreTests/testPayScheduledTransaction
+just test-mac TransactionStoreTests AccountStoreTests  # multiple filters
+
 # Build the app for macOS
 just build-mac
 
@@ -34,6 +40,9 @@ mkdir -p .agent-tmp
 
 # Run tests and capture output
 just test 2>&1 | tee .agent-tmp/test-output.txt
+
+# Re-run only the failing class to iterate faster
+just test TransactionStoreTests 2>&1 | tee .agent-tmp/test-output.txt
 
 # Check for failures
 grep -i 'failed\|error:' .agent-tmp/test-output.txt

--- a/justfile
+++ b/justfile
@@ -14,17 +14,22 @@ lint:
 lint-fix:
     swift-format format -i -r . --configuration .swift-format
 
-# Run the full test suite on iOS Simulator and macOS (in parallel)
-test: generate
-    bash scripts/test.sh
+# FILTERS restrict the run to specific tests: each is a class (e.g.
+# TransactionStoreTests) or class/method (e.g. TransactionStoreTests/testFoo);
+# the platform's test target prefix (MoolahTests_iOS or MoolahTests_macOS) is
+# added automatically. Pass a fully-qualified TestTarget/Class form to pin a
+# filter to one platform's target.
+# Run the test suite on iOS Simulator and macOS in parallel (optional FILTERS).
+test *FILTERS: generate
+    bash scripts/test.sh all {{ FILTERS }}
 
-# Run tests on macOS only
-test-mac: generate
-    bash scripts/test.sh mac
+# Run tests on macOS only. See `test` for FILTERS syntax.
+test-mac *FILTERS: generate
+    bash scripts/test.sh mac {{ FILTERS }}
 
-# Run tests on iOS Simulator only
-test-ios: generate
-    bash scripts/test.sh ios
+# Run tests on iOS Simulator only. See `test` for FILTERS syntax.
+test-ios *FILTERS: generate
+    bash scripts/test.sh ios {{ FILTERS }}
 
 # Run performance benchmarks (macOS only)
 benchmark *FILTER: generate

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -15,8 +15,17 @@ COMMON_ARGS=(
     'OTHER_SWIFT_FLAGS=$(inherited) -disable-sandbox'
 )
 
-# Which platforms to test: "all" (default), "ios", or "mac"
+# Usage: test.sh [all|ios|mac] [FILTER ...]
+# FILTERs are passed to xcodebuild as -only-testing: flags. Each filter may be:
+#   - A class name or class/method, e.g. "TransactionStoreTests" or
+#     "TransactionStoreTests/testFoo". The platform's test target prefix
+#     ("MoolahTests_iOS" or "MoolahTests_macOS") is added automatically.
+#   - A fully-qualified "TestTarget/Class[/method]" form (starting with
+#     "MoolahTests_"), which is passed through unchanged. Use this to pin a
+#     filter to a specific platform's target when running both platforms.
 PLATFORM="${1:-all}"
+shift || true
+FILTERS=("$@")
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -24,20 +33,44 @@ PLATFORM="${1:-all}"
 
 IOS_SIMULATOR="$(bash "$REPO_ROOT/scripts/find-simulator.sh")"
 
+# Print the -only-testing: flags for the given platform's test target, one per
+# line, honouring the global FILTERS array. Prints nothing when FILTERS is empty.
+print_filter_flags() {
+    local target="$1"
+    local f
+    for f in ${FILTERS[@]+"${FILTERS[@]}"}; do
+        if [[ "$f" == MoolahTests_* ]]; then
+            printf -- '-only-testing:%s\n' "$f"
+        else
+            printf -- '-only-testing:%s/%s\n' "$target" "$f"
+        fi
+    done
+}
+
 run_ios() {
     echo "==> Testing iOS Simulator ($IOS_SIMULATOR)…"
+    local filter_flags=()
+    while IFS= read -r line; do
+        filter_flags+=("$line")
+    done < <(print_filter_flags "MoolahTests_iOS")
     xcodebuild test "${COMMON_ARGS[@]}" \
         -derivedDataPath "$REPO_ROOT/.DerivedData-ios" \
         -scheme Moolah-iOS \
-        -destination "platform=iOS Simulator,name=$IOS_SIMULATOR"
+        -destination "platform=iOS Simulator,name=$IOS_SIMULATOR" \
+        ${filter_flags[@]+"${filter_flags[@]}"}
 }
 
 run_mac() {
     echo "==> Testing macOS…"
+    local filter_flags=()
+    while IFS= read -r line; do
+        filter_flags+=("$line")
+    done < <(print_filter_flags "MoolahTests_macOS")
     xcodebuild test "${COMMON_ARGS[@]}" \
         -derivedDataPath "$REPO_ROOT/.DerivedData-mac" \
         -scheme Moolah-macOS \
-        -destination "platform=macOS"
+        -destination "platform=macOS" \
+        ${filter_flags[@]+"${filter_flags[@]}"}
 }
 
 # ---------------------------------------------------------------------------
@@ -87,7 +120,7 @@ case "$PLATFORM" in
         fi
         ;;
     *)
-        echo "Usage: $0 [all|ios|mac]" >&2
+        echo "Usage: $0 [all|ios|mac] [FILTER ...]" >&2
         exit 1
         ;;
 esac


### PR DESCRIPTION
## Summary
- `just test`, `just test-mac`, `just test-ios` now accept variadic `*FILTERS` that are forwarded to `xcodebuild` as `-only-testing:` flags.
- Bare `ClassName` or `ClassName/testMethod` filters get the platform's test target prefix (`MoolahTests_iOS` / `MoolahTests_macOS`) added automatically, so the same filter works on both platforms; fully-qualified forms (starting with `MoolahTests_`) pass through unchanged for pinning.
- Documented the new syntax in CLAUDE.md (Build & Test and Capturing Test Output sections).

Motivation: working in worktrees means the Xcode MCP isn't available and raw `xcodebuild` uses different derived-data dirs than `just`, so there was no quick way to iterate on a single failing test without running the full suite.

## Test plan
- [x] `just --list` still renders sensible summaries for the three recipes
- [x] `just test-mac BackendErrorTests` runs only the 4 tests in that suite
- [x] Empty-filter path verified (pattern: `${arr[@]+"${arr[@]}"}` under `set -euo pipefail`)
- [ ] CI passes on both iOS and macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)