### PR TITLE
test: expand multi-instrument coverage across domain, repos, and stores

### DIFF
--- a/MoolahTests/Domain/AccountRepositoryContractTests.swift
+++ b/MoolahTests/Domain/AccountRepositoryContractTests.swift
@@ -167,6 +167,119 @@ struct AccountRepositoryContractTests {
 
   // MARK: - REORDERING TESTS
 
+  // MARK: - Multi-instrument persistence
+
+  @Test("round-trips a USD fiat account with USD opening balance")
+  func testRoundTripUSDFiatAccount() async throws {
+    let repository = makeCloudKitAccountRepository()
+    let account = Account(name: "US Checking", type: .bank, instrument: .USD)
+    let openingBalance = InstrumentAmount(
+      quantity: Decimal(string: "750.00")!, instrument: .USD)
+
+    _ = try await repository.create(account, openingBalance: openingBalance)
+
+    let all = try await repository.fetchAll()
+    let fetched = try #require(all.first { $0.id == account.id })
+    #expect(fetched.instrument == .USD)
+    #expect(fetched.instrument.id == "USD")
+    #expect(fetched.instrument.kind == .fiatCurrency)
+    let usdPosition = fetched.positions.first { $0.instrument == .USD }
+    #expect(usdPosition?.quantity == Decimal(string: "750.00")!)
+  }
+
+  @Test("round-trips a stock account preserving exchange and ticker")
+  func testRoundTripStockAccount() async throws {
+    let repository = makeCloudKitAccountRepository()
+    let bhp = Instrument.stock(ticker: "BHP.AX", exchange: "ASX", name: "BHP")
+    let account = Account(name: "BHP Shares", type: .investment, instrument: bhp)
+    let openingBalance = InstrumentAmount(quantity: Decimal(150), instrument: bhp)
+
+    _ = try await repository.create(account, openingBalance: openingBalance)
+
+    let all = try await repository.fetchAll()
+    let fetched = try #require(all.first { $0.id == account.id })
+    #expect(fetched.instrument == bhp)
+    #expect(fetched.instrument.id == "ASX:BHP")
+    #expect(fetched.instrument.kind == .stock)
+    #expect(fetched.instrument.ticker == "BHP.AX")
+    #expect(fetched.instrument.exchange == "ASX")
+    let bhpPosition = fetched.positions.first { $0.instrument == bhp }
+    #expect(bhpPosition?.quantity == Decimal(150))
+  }
+
+  @Test("round-trips a crypto account preserving chainId and contractAddress")
+  func testRoundTripCryptoAccount() async throws {
+    let repository = makeCloudKitAccountRepository()
+    let usdc = Instrument.crypto(
+      chainId: 1,
+      contractAddress: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+      symbol: "USDC", name: "USD Coin", decimals: 6
+    )
+    let account = Account(name: "Wallet", type: .investment, instrument: usdc)
+    let openingBalance = InstrumentAmount(
+      quantity: Decimal(string: "2500.000000")!, instrument: usdc)
+
+    _ = try await repository.create(account, openingBalance: openingBalance)
+
+    let all = try await repository.fetchAll()
+    let fetched = try #require(all.first { $0.id == account.id })
+    #expect(fetched.instrument == usdc)
+    #expect(fetched.instrument.kind == .cryptoToken)
+    #expect(fetched.instrument.chainId == 1)
+    #expect(fetched.instrument.contractAddress == "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48")
+    #expect(fetched.instrument.decimals == 6)
+    let position = fetched.positions.first { $0.instrument == usdc }
+    #expect(position?.quantity == Decimal(string: "2500.000000")!)
+  }
+
+  @Test("accounts with distinct instruments coexist and keep their own instrument")
+  func testMultipleAccountsWithDifferentInstruments() async throws {
+    let repository = makeCloudKitAccountRepository()
+    let audAccount = Account(
+      id: UUID(), name: "AUD Bank", type: .bank, instrument: .AUD)
+    let usdAccount = Account(
+      id: UUID(), name: "USD Bank", type: .bank, instrument: .USD)
+    let bhp = Instrument.stock(ticker: "BHP.AX", exchange: "ASX", name: "BHP")
+    let stockAccount = Account(
+      id: UUID(), name: "Brokerage", type: .investment, instrument: bhp)
+
+    _ = try await repository.create(
+      audAccount, openingBalance: InstrumentAmount(quantity: Decimal(1), instrument: .AUD))
+    _ = try await repository.create(
+      usdAccount, openingBalance: InstrumentAmount(quantity: Decimal(1), instrument: .USD))
+    _ = try await repository.create(
+      stockAccount, openingBalance: InstrumentAmount(quantity: Decimal(1), instrument: bhp))
+
+    let all = try await repository.fetchAll()
+    let aud = try #require(all.first { $0.id == audAccount.id })
+    let usd = try #require(all.first { $0.id == usdAccount.id })
+    let stock = try #require(all.first { $0.id == stockAccount.id })
+    #expect(aud.instrument == .AUD)
+    #expect(usd.instrument == .USD)
+    #expect(stock.instrument == bhp)
+    // Distinct instrument ids ensure records didn't collapse together.
+    #expect(Set([aud.instrument.id, usd.instrument.id, stock.instrument.id]).count == 3)
+  }
+
+  @Test("updates preserve non-default instrument")
+  func testUpdatePreservesNonDefaultInstrument() async throws {
+    let repository = makeCloudKitAccountRepository()
+    let account = Account(name: "EUR Wallet", type: .bank, instrument: .fiat(code: "EUR"))
+    _ = try await repository.create(account, openingBalance: nil)
+
+    let accounts = try await repository.fetchAll()
+    var toUpdate = try #require(accounts.first { $0.id == account.id })
+    toUpdate.name = "Renamed EUR Wallet"
+    let updated = try await repository.update(toUpdate)
+
+    #expect(updated.instrument.id == "EUR")
+    #expect(updated.instrument.kind == .fiatCurrency)
+    let refetched = try await repository.fetchAll()
+    let final = try #require(refetched.first { $0.id == account.id })
+    #expect(final.instrument.id == "EUR")
+    #expect(final.name == "Renamed EUR Wallet")
+  }
+
   @Test("updates positions")
   func testUpdatesPositions() async throws {
     let repository = makeCloudKitWithPositionedAccounts()

--- a/MoolahTests/Domain/CryptoTokenRepositoryTests.swift
+++ b/MoolahTests/Domain/CryptoTokenRepositoryTests.swift
@@ -33,4 +33,82 @@ struct CryptoTokenRepositoryTests {
     let loaded = try await repo.loadRegistrations()
     #expect(loaded.count == 1)
   }
+
+  @Test func registrationsOnDifferentChainsAreDistinct() async throws {
+    // Same-symbol tokens on different chains (USDC-Ethereum vs hypothetical USDC-Polygon)
+    // must be preserved as independent registrations — the chainId is part of the identity.
+    let ethUsdc = CryptoRegistration(
+      instrument: .crypto(
+        chainId: 1,
+        contractAddress: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+        symbol: "USDC", name: "USD Coin (Ethereum)", decimals: 6
+      ),
+      mapping: CryptoProviderMapping(
+        instrumentId: "1:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+        coingeckoId: "usd-coin",
+        cryptocompareSymbol: "USDC",
+        binanceSymbol: nil
+      )
+    )
+    let polyUsdc = CryptoRegistration(
+      instrument: .crypto(
+        chainId: 137,
+        contractAddress: "0x2791bca1f2de4661ed88a30c99a7a9449aa84174",
+        symbol: "USDC", name: "USD Coin (Polygon)", decimals: 6
+      ),
+      mapping: CryptoProviderMapping(
+        instrumentId: "137:0x2791bca1f2de4661ed88a30c99a7a9449aa84174",
+        coingeckoId: "usd-coin",
+        cryptocompareSymbol: "USDC",
+        binanceSymbol: nil
+      )
+    )
+    let repo = makeRepository()
+    try await repo.saveRegistrations([ethUsdc, polyUsdc])
+
+    let loaded = try await repo.loadRegistrations()
+    #expect(loaded.count == 2)
+    let ids = Set(loaded.map(\.id))
+    #expect(ids.contains(ethUsdc.id))
+    #expect(ids.contains(polyUsdc.id))
+    #expect(ethUsdc.id != polyUsdc.id)
+  }
+
+  @Test func nativeAndErc20OnSameChainAreDistinct() async throws {
+    // Native ETH (chainId:1, no contract) vs ERC20 on chain 1 must be distinct registrations.
+    let eth = CryptoRegistration(
+      instrument: .crypto(
+        chainId: 1, contractAddress: nil,
+        symbol: "ETH", name: "Ethereum", decimals: 18
+      ),
+      mapping: CryptoProviderMapping(
+        instrumentId: "1:native",
+        coingeckoId: "ethereum",
+        cryptocompareSymbol: "ETH",
+        binanceSymbol: "ETHUSDT"
+      )
+    )
+    let uni = CryptoRegistration(
+      instrument: .crypto(
+        chainId: 1,
+        contractAddress: "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
+        symbol: "UNI", name: "Uniswap", decimals: 18
+      ),
+      mapping: CryptoProviderMapping(
+        instrumentId: "1:0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
+        coingeckoId: "uniswap",
+        cryptocompareSymbol: "UNI",
+        binanceSymbol: "UNIUSDT"
+      )
+    )
+    let repo = makeRepository()
+    try await repo.saveRegistrations([eth, uni])
+
+    let loaded = try await repo.loadRegistrations()
+    #expect(loaded.count == 2)
+    let ethLoaded = try #require(loaded.first { $0.instrument.ticker == "ETH" })
+    let uniLoaded = try #require(loaded.first { $0.instrument.ticker == "UNI" })
+    #expect(ethLoaded.instrument.contractAddress == nil)
+    #expect(uniLoaded.instrument.contractAddress != nil)
+  }
 }

--- a/MoolahTests/Domain/EarmarkRepositoryContractTests.swift
+++ b/MoolahTests/Domain/EarmarkRepositoryContractTests.swift
@@ -100,6 +100,78 @@ struct EarmarkRepositoryContractTests {
     }
   }
 
+  // MARK: - Multi-instrument persistence
+
+  @Test("round-trips earmark with USD savings goal")
+  func testRoundTripEarmarkWithUSDSavingsGoal() async throws {
+    let repository = makeCloudKitEarmarkRepository()
+    var earmark = Earmark(name: "US Travel Fund", instrument: .USD)
+    earmark.savingsGoal = InstrumentAmount(
+      quantity: Decimal(string: "5000.00")!, instrument: .USD)
+
+    _ = try await repository.create(earmark)
+
+    let all = try await repository.fetchAll()
+    let fetched = try #require(all.first { $0.id == earmark.id })
+    #expect(fetched.instrument == .USD)
+    #expect(fetched.savingsGoal?.instrument == .USD)
+    #expect(fetched.savingsGoal?.quantity == Decimal(string: "5000.00")!)
+  }
+
+  @Test("budget items preserve their own instrument distinct from earmark instrument")
+  func testBudgetItemsPreserveInstrumentDistinctFromEarmark() async throws {
+    let repository = makeCloudKitEarmarkRepository(initialEarmarks: [
+      Earmark(name: "Mixed Fund", instrument: .AUD)
+    ])
+    let earmarks = try await repository.fetchAll()
+    let earmarkId = earmarks[0].id
+    let audCategory = UUID()
+    let usdCategory = UUID()
+
+    let audAmount = InstrumentAmount(
+      quantity: Decimal(string: "100.00")!, instrument: .AUD)
+    let usdAmount = InstrumentAmount(
+      quantity: Decimal(string: "80.00")!, instrument: .USD)
+
+    try await repository.setBudget(
+      earmarkId: earmarkId, categoryId: audCategory, amount: audAmount)
+    try await repository.setBudget(
+      earmarkId: earmarkId, categoryId: usdCategory, amount: usdAmount)
+
+    let fetched = try await repository.fetchBudget(earmarkId: earmarkId)
+    #expect(fetched.count == 2)
+    let audItem = try #require(fetched.first { $0.categoryId == audCategory })
+    let usdItem = try #require(fetched.first { $0.categoryId == usdCategory })
+    #expect(audItem.amount.instrument == .AUD)
+    #expect(audItem.amount.quantity == Decimal(string: "100.00")!)
+    #expect(usdItem.amount.instrument == .USD)
+    #expect(usdItem.amount.quantity == Decimal(string: "80.00")!)
+  }
+
+  @Test("updating budget item changes amount without changing instrument")
+  func testUpdatingBudgetItemPreservesInstrument() async throws {
+    let repository = makeCloudKitEarmarkRepository(initialEarmarks: [
+      Earmark(name: "Travel", instrument: .AUD)
+    ])
+    let earmarks = try await repository.fetchAll()
+    let earmarkId = earmarks[0].id
+    let categoryId = UUID()
+
+    let usdFirst = InstrumentAmount(
+      quantity: Decimal(string: "100.00")!, instrument: .USD)
+    let usdSecond = InstrumentAmount(
+      quantity: Decimal(string: "250.00")!, instrument: .USD)
+
+    try await repository.setBudget(earmarkId: earmarkId, categoryId: categoryId, amount: usdFirst)
+    try await repository.setBudget(earmarkId: earmarkId, categoryId: categoryId, amount: usdSecond)
+
+    let fetched = try await repository.fetchBudget(earmarkId: earmarkId)
+    let entries = fetched.filter { $0.categoryId == categoryId }
+    #expect(entries.count == 1)
+    #expect(entries[0].amount.instrument == .USD)
+    #expect(entries[0].amount.quantity == Decimal(string: "250.00")!)
+  }
+
   @Test("setBudget twice updates existing entry, not creates duplicate")
   func testBudgetUpsertSemantics() async throws {
     let repository = makeCloudKitEarmarkRepository(initialEarmarks: [

--- a/MoolahTests/Domain/InstrumentAmountTests.swift
+++ b/MoolahTests/Domain/InstrumentAmountTests.swift
@@ -220,4 +220,116 @@ struct InstrumentAmountTests {
     let result = InstrumentAmount.parseQuantity(from: "", decimals: 2)
     #expect(result == nil)
   }
+
+  // MARK: - Multi-instrument storage scaling
+
+  @Test func storageRoundTripForCryptoEightDecimals() {
+    let btc = Instrument.crypto(
+      chainId: 0, contractAddress: nil, symbol: "BTC", name: "Bitcoin", decimals: 8
+    )
+    let original = InstrumentAmount(quantity: Decimal(string: "0.12345678")!, instrument: btc)
+    #expect(original.storageValue == 12_345_678)
+    let restored = InstrumentAmount(storageValue: original.storageValue, instrument: btc)
+    #expect(restored.quantity == Decimal(string: "0.12345678")!)
+    #expect(restored.instrument == btc)
+  }
+
+  @Test func storageRoundTripForCryptoSubSatoshiTruncates() {
+    // 10^8 storage scale means anything below 8 decimals of precision is lost.
+    // ETH declares 18 decimals but storage only preserves 8 — truncation is expected.
+    let eth = Instrument.crypto(
+      chainId: 1, contractAddress: nil, symbol: "ETH", name: "Ethereum", decimals: 18
+    )
+    let original = InstrumentAmount(
+      quantity: Decimal(string: "0.123456789012345678")!, instrument: eth)
+    // Only first 8 decimals survive Int64 × 10^8 storage scaling.
+    let restored = InstrumentAmount(storageValue: original.storageValue, instrument: eth)
+    #expect(restored.quantity == Decimal(string: "0.12345678")!)
+  }
+
+  @Test func storageRoundTripForStockWholeShares() {
+    let bhp = Instrument.stock(ticker: "BHP.AX", exchange: "ASX", name: "BHP")
+    let amount = InstrumentAmount(quantity: Decimal(150), instrument: bhp)
+    #expect(amount.storageValue == 15_000_000_000)
+    let restored = InstrumentAmount(storageValue: amount.storageValue, instrument: bhp)
+    #expect(restored.quantity == Decimal(150))
+    #expect(restored.instrument == bhp)
+  }
+
+  @Test func storageRoundTripForZeroDecimalFiat() {
+    let jpy = Instrument.fiat(code: "JPY")
+    let amount = InstrumentAmount(quantity: Decimal(12345), instrument: jpy)
+    #expect(amount.storageValue == 1_234_500_000_000)
+    let restored = InstrumentAmount(storageValue: amount.storageValue, instrument: jpy)
+    #expect(restored.quantity == Decimal(12345))
+  }
+
+  @Test func storageRoundTripForLargeCryptoQuantity() {
+    // Simulate a wallet holding a large whole-token quantity; must survive Int64 bounds.
+    let eth = Instrument.crypto(
+      chainId: 1, contractAddress: nil, symbol: "ETH", name: "Ethereum", decimals: 18
+    )
+    let original = InstrumentAmount(quantity: Decimal(string: "1234567.89012345")!, instrument: eth)
+    let restored = InstrumentAmount(storageValue: original.storageValue, instrument: eth)
+    #expect(restored.quantity == Decimal(string: "1234567.89012345")!)
+  }
+
+  // MARK: - Formatting across instrument kinds
+
+  @Test func formattedZeroDecimalFiatHasNoFractionPart() {
+    // JPY is zero-decimal; formatting must not introduce decimals.
+    let jpy = Instrument.fiat(code: "JPY")
+    let amount = InstrumentAmount(quantity: Decimal(500), instrument: jpy)
+    #expect(!amount.formatted.contains("."))
+    #expect(amount.formatted.contains("500"))
+  }
+
+  @Test func formatNoSymbolRespectsCryptoDecimals() {
+    let btc = Instrument.crypto(
+      chainId: 0, contractAddress: nil, symbol: "BTC", name: "Bitcoin", decimals: 8
+    )
+    let amount = InstrumentAmount(quantity: Decimal(string: "0.5")!, instrument: btc)
+    #expect(amount.formatNoSymbol == "0.50000000")
+  }
+
+  @Test func formatNoSymbolZeroDecimalFiatHasNoDecimals() {
+    let jpy = Instrument.fiat(code: "JPY")
+    let amount = InstrumentAmount(quantity: Decimal(500), instrument: jpy)
+    #expect(amount.formatNoSymbol == "500")
+  }
+
+  // MARK: - Equality discriminates by instrument kind
+
+  @Test func equalityDistinguishesBetweenKindsWithSameId() {
+    // Hypothetical: a fiat code that collides with a stock ticker should be distinct.
+    // This exercises the Hashable/Equatable contract on the full Instrument record, not just id.
+    let fiat = Instrument.fiat(code: "USD")
+    let stock = Instrument.stock(ticker: "USD.X", exchange: "USD", name: "USD")
+    let a = InstrumentAmount(quantity: Decimal(10), instrument: fiat)
+    let b = InstrumentAmount(quantity: Decimal(10), instrument: stock)
+    #expect(a != b)
+  }
+
+  @Test func negationPreservesInstrumentAcrossKinds() {
+    let eth = Instrument.crypto(
+      chainId: 1, contractAddress: nil, symbol: "ETH", name: "Ethereum", decimals: 18
+    )
+    let amount = InstrumentAmount(quantity: Decimal(string: "0.5")!, instrument: eth)
+    let negated = -amount
+    #expect(negated.instrument == eth)
+    #expect(negated.quantity == Decimal(string: "-0.5")!)
+  }
+
+  @Test func reduceForSummingCryptoPreservesPrecision() {
+    let btc = Instrument.crypto(
+      chainId: 0, contractAddress: nil, symbol: "BTC", name: "Bitcoin", decimals: 8
+    )
+    let amounts = [
+      InstrumentAmount(quantity: Decimal(string: "0.00000001")!, instrument: btc),
+      InstrumentAmount(quantity: Decimal(string: "0.00000002")!, instrument: btc),
+      InstrumentAmount(quantity: Decimal(string: "0.00000003")!, instrument: btc),
+    ]
+    let total = amounts.reduce(.zero(instrument: btc)) { $0 + $1 }
+    #expect(total.quantity == Decimal(string: "0.00000006")!)
+  }
 }

--- a/MoolahTests/Domain/InstrumentCryptoTests.swift
+++ b/MoolahTests/Domain/InstrumentCryptoTests.swift
@@ -99,4 +99,60 @@ struct InstrumentCryptoTests {
       chainId: 1, contractAddress: nil, symbol: "ETH", name: "Ethereum", decimals: 18)
     #expect(eth.displaySymbol == "ETH")
   }
+
+  // MARK: - Cross-chain / multi-chain edge cases
+
+  @Test func sameSymbolOnDifferentChainsAreDistinctInstruments() {
+    // USDC on Ethereum (chainId 1) vs USDC on Polygon (chainId 137) — different ids.
+    let ethUsdc = Instrument.crypto(
+      chainId: 1,
+      contractAddress: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+      symbol: "USDC", name: "USD Coin", decimals: 6
+    )
+    let polyUsdc = Instrument.crypto(
+      chainId: 137,
+      contractAddress: "0x2791bca1f2de4661ed88a30c99a7a9449aa84174",
+      symbol: "USDC", name: "USD Coin", decimals: 6
+    )
+    #expect(ethUsdc.id != polyUsdc.id)
+    #expect(ethUsdc != polyUsdc)
+  }
+
+  @Test func nativeAndErc20OnSameChainAreDistinct() {
+    // Native ETH on chain 1 vs a ERC20 on chain 1 must be different.
+    let eth = Instrument.crypto(
+      chainId: 1, contractAddress: nil,
+      symbol: "ETH", name: "Ethereum", decimals: 18
+    )
+    let weth = Instrument.crypto(
+      chainId: 1,
+      contractAddress: "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+      symbol: "WETH", name: "Wrapped Ether", decimals: 18
+    )
+    #expect(eth.id == "1:native")
+    #expect(weth.id == "1:0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2")
+    #expect(eth != weth)
+  }
+
+  @Test func optimismChainIdPersistedInInstrumentId() {
+    let op = Instrument.crypto(
+      chainId: 10,
+      contractAddress: "0x4200000000000000000000000000000000000042",
+      symbol: "OP", name: "Optimism", decimals: 18
+    )
+    #expect(op.id.hasPrefix("10:"))
+    #expect(op.chainId == 10)
+  }
+
+  @Test func cryptoDecimalsDifferenceMakesInstrumentsNotEqual() {
+    // Two instruments with the same id+address but different stated decimals must still
+    // be considered unequal under Hashable/Equatable (all fields matter).
+    let a = Instrument.crypto(
+      chainId: 1, contractAddress: nil, symbol: "ETH", name: "Ethereum", decimals: 18
+    )
+    let b = Instrument.crypto(
+      chainId: 1, contractAddress: nil, symbol: "ETH", name: "Ethereum", decimals: 8
+    )
+    #expect(a != b)
+  }
 }

--- a/MoolahTests/Domain/InstrumentStockTests.swift
+++ b/MoolahTests/Domain/InstrumentStockTests.swift
@@ -60,4 +60,34 @@ struct InstrumentStockTests {
     let b = Instrument.stock(ticker: "BHP.AX", exchange: "ASX", name: "BHP")
     #expect(a.hashValue == b.hashValue)
   }
+
+  // MARK: - Edge-case ticker formats
+
+  @Test func stockWithDottedTicker() {
+    // Berkshire Hathaway Class B — ticker contains dot.
+    let brkB = Instrument.stock(ticker: "BRK.B", exchange: "NYSE", name: "BRK-B")
+    #expect(brkB.ticker == "BRK.B")
+    #expect(brkB.id == "NYSE:BRK-B")
+  }
+
+  @Test func stockWithHyphenatedTicker() {
+    // BRK-A on some feeds uses hyphen.
+    let brkA = Instrument.stock(ticker: "BRK-A", exchange: "NYSE", name: "BRK-A")
+    #expect(brkA.ticker == "BRK-A")
+  }
+
+  @Test func stocksOnSameExchangeDifferByName() {
+    let bhp = Instrument.stock(ticker: "BHP.AX", exchange: "ASX", name: "BHP")
+    let cba = Instrument.stock(ticker: "CBA.AX", exchange: "ASX", name: "CBA")
+    #expect(bhp.id != cba.id)
+    #expect(bhp != cba)
+  }
+
+  @Test func stockOnDifferentExchangesWithSameNameAreDistinct() {
+    // Same name on two exchanges must have distinct ids — the exchange is part of identity.
+    let aud = Instrument.stock(ticker: "BHP.AX", exchange: "ASX", name: "BHP")
+    let lon = Instrument.stock(ticker: "BHP.L", exchange: "LSE", name: "BHP")
+    #expect(aud.id != lon.id)
+    #expect(aud != lon)
+  }
 }

--- a/MoolahTests/Domain/InvestmentRepositoryContractTests.swift
+++ b/MoolahTests/Domain/InvestmentRepositoryContractTests.swift
@@ -407,6 +407,43 @@ struct InvestmentRepositoryContractTests {
     #expect(result.count == 1)
     #expect(result[0].balance.quantity == Decimal(string: "1500.00")!)
   }
+
+  // MARK: - Multi-instrument investment values
+
+  @Test("Investment values preserve USD instrument through round-trip")
+  func testSetAndFetchValueInUSD() async throws {
+    let repo = makeCloudKitInvestmentRepository(instrument: .USD)
+    let date = makeDate(year: 2024, month: 3, day: 15)
+    let accountId = UUID()
+    let amount = InstrumentAmount(quantity: Decimal(5000), instrument: .USD)
+    try await repo.setValue(accountId: accountId, date: date, value: amount)
+
+    let page = try await repo.fetchValues(accountId: accountId, page: 0, pageSize: 10)
+    #expect(page.values.count == 1)
+    #expect(page.values[0].value.instrument == .USD)
+    #expect(page.values[0].value.quantity == Decimal(5000))
+  }
+
+  @Test("Setting values on separate repositories with different instruments does not conflate them")
+  func testDistinctInstrumentsAcrossRepositories() async throws {
+    let audRepo = makeCloudKitInvestmentRepository(instrument: .AUD)
+    let usdRepo = makeCloudKitInvestmentRepository(instrument: .USD)
+    let date = makeDate(year: 2024, month: 3, day: 15)
+    let audAccount = UUID()
+    let usdAccount = UUID()
+
+    try await audRepo.setValue(
+      accountId: audAccount, date: date,
+      value: InstrumentAmount(quantity: Decimal(1000), instrument: .AUD))
+    try await usdRepo.setValue(
+      accountId: usdAccount, date: date,
+      value: InstrumentAmount(quantity: Decimal(650), instrument: .USD))
+
+    let audPage = try await audRepo.fetchValues(accountId: audAccount, page: 0, pageSize: 10)
+    let usdPage = try await usdRepo.fetchValues(accountId: usdAccount, page: 0, pageSize: 10)
+    #expect(audPage.values.first?.value.instrument == .AUD)
+    #expect(usdPage.values.first?.value.instrument == .USD)
+  }
 }
 
 // MARK: - Factory Helpers

--- a/MoolahTests/Domain/PositionTests.swift
+++ b/MoolahTests/Domain/PositionTests.swift
@@ -161,4 +161,118 @@ struct PositionTests {
     #expect(result[0].instrument == aud)
     #expect(result[1].instrument == usd)
   }
+
+  // MARK: - Multi-kind positions (fiat + stock + crypto)
+
+  @Test func computeForAccountAggregatesAcrossInstrumentKinds() {
+    // Account holds fiat, stock, and crypto simultaneously.
+    let bhp = Instrument.stock(ticker: "BHP.AX", exchange: "ASX", name: "BHP")
+    let eth = Instrument.crypto(
+      chainId: 1, contractAddress: nil, symbol: "ETH", name: "Ethereum", decimals: 18
+    )
+    let legs = [
+      TransactionLeg(
+        accountId: accountId, instrument: aud,
+        quantity: Decimal(string: "1000.00")!, type: .openingBalance),
+      TransactionLeg(
+        accountId: accountId, instrument: bhp, quantity: Decimal(150), type: .transfer),
+      TransactionLeg(
+        accountId: accountId, instrument: eth,
+        quantity: Decimal(string: "0.5")!, type: .transfer),
+    ]
+    let positions = Position.computeForAccount(accountId, from: legs)
+    #expect(positions.count == 3)
+
+    let audPos = positions.first(where: { $0.instrument == aud })
+    let bhpPos = positions.first(where: { $0.instrument == bhp })
+    let ethPos = positions.first(where: { $0.instrument == eth })
+    #expect(audPos?.quantity == Decimal(string: "1000.00")!)
+    #expect(bhpPos?.quantity == Decimal(150))
+    #expect(ethPos?.quantity == Decimal(string: "0.5")!)
+  }
+
+  @Test func computeForAccountSortsByInstrumentIdAcrossKinds() {
+    // Sort is lexicographic over instrument.id — "0:native" (BTC), "1:native" (ETH),
+    // "ASX:BHP", "AUD", "JPY", "NASDAQ:AAPL", "USD" under ASCII ordering.
+    let btc = Instrument.crypto(
+      chainId: 0, contractAddress: nil, symbol: "BTC", name: "Bitcoin", decimals: 8
+    )
+    let eth = Instrument.crypto(
+      chainId: 1, contractAddress: nil, symbol: "ETH", name: "Ethereum", decimals: 18
+    )
+    let bhp = Instrument.stock(ticker: "BHP.AX", exchange: "ASX", name: "BHP")
+    let aapl = Instrument.stock(ticker: "AAPL", exchange: "NASDAQ", name: "AAPL")
+    let jpy = Instrument.fiat(code: "JPY")
+
+    let legs = [
+      TransactionLeg(accountId: accountId, instrument: usd, quantity: Decimal(1), type: .income),
+      TransactionLeg(
+        accountId: accountId, instrument: bhp, quantity: Decimal(1), type: .transfer),
+      TransactionLeg(accountId: accountId, instrument: btc, quantity: Decimal(1), type: .transfer),
+      TransactionLeg(accountId: accountId, instrument: aud, quantity: Decimal(1), type: .income),
+      TransactionLeg(accountId: accountId, instrument: jpy, quantity: Decimal(1), type: .income),
+      TransactionLeg(accountId: accountId, instrument: eth, quantity: Decimal(1), type: .transfer),
+      TransactionLeg(
+        accountId: accountId, instrument: aapl, quantity: Decimal(1), type: .transfer),
+    ]
+    let positions = Position.computeForAccount(accountId, from: legs)
+    #expect(positions.count == 7)
+    let ids = positions.map { $0.instrument.id }
+    #expect(ids == ids.sorted())
+  }
+
+  @Test func computeForAccountDoesNotMergeDifferentKindsWithSameSymbol() {
+    // Guard: a fiat "USD" and a crypto with id "1:usdc" must be distinct positions.
+    let usdc = Instrument.crypto(
+      chainId: 1,
+      contractAddress: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+      symbol: "USDC", name: "USD Coin", decimals: 6
+    )
+    let legs = [
+      TransactionLeg(
+        accountId: accountId, instrument: usd,
+        quantity: Decimal(string: "100.00")!, type: .income),
+      TransactionLeg(
+        accountId: accountId, instrument: usdc,
+        quantity: Decimal(string: "100.00")!, type: .transfer),
+    ]
+    let positions = Position.computeForAccount(accountId, from: legs)
+    #expect(positions.count == 2)
+    #expect(positions.contains(where: { $0.instrument == usd }))
+    #expect(positions.contains(where: { $0.instrument == usdc }))
+  }
+
+  @Test func applyingDeltasWithMixedKindsKeepsPositionsDistinct() {
+    let bhp = Instrument.stock(ticker: "BHP.AX", exchange: "ASX", name: "BHP")
+    let btc = Instrument.crypto(
+      chainId: 0, contractAddress: nil, symbol: "BTC", name: "Bitcoin", decimals: 8
+    )
+    let positions = [
+      Position(instrument: aud, quantity: Decimal(string: "1000.00")!)
+    ]
+    let result = positions.applying(deltas: [
+      bhp: Decimal(100),
+      btc: Decimal(string: "0.1")!,
+    ])
+    #expect(result.count == 3)
+    #expect(result.map { $0.instrument.id } == ["0:native", "ASX:BHP", "AUD"])
+  }
+
+  @Test func zeroOutOneKindDoesNotRemoveOthers() {
+    let bhp = Instrument.stock(ticker: "BHP.AX", exchange: "ASX", name: "BHP")
+    // Sell entire BHP position while leaving AUD cash intact.
+    let legs = [
+      TransactionLeg(
+        accountId: accountId, instrument: aud,
+        quantity: Decimal(string: "2000.00")!, type: .openingBalance),
+      TransactionLeg(
+        accountId: accountId, instrument: bhp, quantity: Decimal(100), type: .transfer),
+      TransactionLeg(
+        accountId: accountId, instrument: bhp, quantity: Decimal(-100), type: .transfer),
+    ]
+    let positions = Position.computeForAccount(accountId, from: legs)
+    #expect(positions.count == 1)
+    #expect(positions.first?.instrument == aud)
+    #expect(positions.first?.quantity == Decimal(string: "2000.00")!)
+  }
 }

--- a/MoolahTests/Domain/ScheduledTransactionTests.swift
+++ b/MoolahTests/Domain/ScheduledTransactionTests.swift
@@ -36,6 +36,47 @@ private func makeTxn(
 
 @Suite("Scheduled Transactions")
 struct ScheduledTransactionTests {
+  @Test("isScheduled preserves instrument across recurrence")
+  func testIsScheduledWithForeignCurrencyRecurrence() {
+    // A monthly USD subscription paid from a USD account.
+    let usd = Instrument.USD
+    let tx = Transaction(
+      date: Date(),
+      recurPeriod: .month,
+      recurEvery: 1,
+      legs: [
+        TransactionLeg(
+          accountId: UUID(), instrument: usd,
+          quantity: Decimal(string: "-9.99")!, type: .expense)
+      ]
+    )
+    #expect(tx.isScheduled)
+    #expect(tx.legs[0].instrument == usd)
+  }
+
+  @Test("Scheduled cross-currency transfer retains both instruments")
+  func testScheduledCrossCurrencyTransferLegsInstruments() {
+    // A weekly currency conversion: 1000 AUD becomes 650 USD every week.
+    let tx = Transaction(
+      date: Date(),
+      payee: "Weekly FX",
+      recurPeriod: .week,
+      recurEvery: 1,
+      legs: [
+        TransactionLeg(
+          accountId: UUID(), instrument: .AUD,
+          quantity: Decimal(string: "-1000.00")!, type: .transfer),
+        TransactionLeg(
+          accountId: UUID(), instrument: .USD,
+          quantity: Decimal(string: "650.00")!, type: .transfer),
+      ]
+    )
+    #expect(tx.isScheduled)
+    #expect(tx.isTransfer)
+    #expect(tx.legs[0].instrument == .AUD)
+    #expect(tx.legs[1].instrument == .USD)
+  }
+
   @Test("isScheduled returns true when recurPeriod is set")
   func testIsScheduledWithRecurrence() {
     let transaction = makeTxn(recurPeriod: .month, recurEvery: 1)

--- a/MoolahTests/Domain/TransactionIsSimpleTests.swift
+++ b/MoolahTests/Domain/TransactionIsSimpleTests.swift
@@ -126,4 +126,80 @@ struct TransactionIsSimpleTests {
     ])
     #expect(tx.isSimple == false)
   }
+
+  // MARK: - Multi-instrument edge cases
+
+  @Test("Cross-currency transfer is NOT simple (quantities don't negate)")
+  func crossCurrencyTransferNotSimple() {
+    // Currency conversion: 1000 AUD -> 650 USD. Quantities don't negate,
+    // so isSimple must be false even though structurally a 2-leg transfer.
+    let fromAccount = UUID()
+    let toAccount = UUID()
+    let aud100 = TransactionLeg(
+      accountId: fromAccount, instrument: Instrument.AUD,
+      quantity: Decimal(-1000), type: .transfer)
+    let usd65 = TransactionLeg(
+      accountId: toAccount, instrument: Instrument.USD,
+      quantity: Decimal(650), type: .transfer)
+    let tx = makeTransaction(legs: [aud100, usd65])
+    #expect(tx.isSimple == false)
+  }
+
+  @Test("Single-account cross-instrument swap is a transfer")
+  func singleAccountMultiInstrumentIsTransfer() {
+    // A single-account conversion (e.g., AUD→USD within Revolut) counts as a transfer
+    // per Transaction.isTransfer: uniqueness across instruments triggers transfer.
+    let accountId = UUID()
+    let legs = [
+      TransactionLeg(
+        accountId: accountId, instrument: Instrument.AUD,
+        quantity: Decimal(-1000), type: .transfer),
+      TransactionLeg(
+        accountId: accountId, instrument: Instrument.USD,
+        quantity: Decimal(650), type: .transfer),
+    ]
+    let tx = makeTransaction(legs: legs)
+    #expect(tx.isTransfer == true)
+  }
+
+  @Test("Single-account same-instrument legs are NOT a transfer")
+  func singleAccountSameInstrumentNotTransfer() {
+    // Same account + same instrument means there's no source→destination movement.
+    let accountId = UUID()
+    let legs = [
+      TransactionLeg(
+        accountId: accountId, instrument: aud, quantity: Decimal(-100), type: .transfer),
+      TransactionLeg(
+        accountId: accountId, instrument: aud, quantity: Decimal(100), type: .transfer),
+    ]
+    let tx = makeTransaction(legs: legs)
+    #expect(tx.isTransfer == false)
+  }
+
+  @Test("Cross-account same-instrument legs are a transfer")
+  func crossAccountSameInstrumentIsTransfer() {
+    let legs = [
+      TransactionLeg(
+        accountId: UUID(), instrument: aud, quantity: Decimal(-100), type: .transfer),
+      TransactionLeg(
+        accountId: UUID(), instrument: aud, quantity: Decimal(100), type: .transfer),
+    ]
+    let tx = makeTransaction(legs: legs)
+    #expect(tx.isTransfer == true)
+  }
+
+  @Test("Stock trade (fiat out, stock in) is a transfer")
+  func stockTradeIsTransfer() {
+    let accountId = UUID()
+    let bhp = Instrument.stock(ticker: "BHP.AX", exchange: "ASX", name: "BHP")
+    let legs = [
+      TransactionLeg(
+        accountId: accountId, instrument: Instrument.AUD,
+        quantity: Decimal(-6345), type: .transfer),
+      TransactionLeg(
+        accountId: accountId, instrument: bhp, quantity: Decimal(150), type: .transfer),
+    ]
+    let tx = makeTransaction(legs: legs)
+    #expect(tx.isTransfer == true)
+  }
 }

--- a/MoolahTests/Domain/TransactionLegTests.swift
+++ b/MoolahTests/Domain/TransactionLegTests.swift
@@ -88,4 +88,73 @@ struct TransactionLegTests {
     #expect(decoded == leg)
     #expect(decoded.accountId == nil)
   }
+
+  // MARK: - Multi-instrument leg behavior
+
+  @Test func stockLegCodableRoundTripPreservesInstrumentMetadata() throws {
+    let bhp = Instrument.stock(ticker: "BHP.AX", exchange: "ASX", name: "BHP")
+    let leg = TransactionLeg(
+      accountId: accountId,
+      instrument: bhp,
+      quantity: Decimal(150),
+      type: .transfer
+    )
+    let data = try JSONEncoder().encode(leg)
+    let decoded = try JSONDecoder().decode(TransactionLeg.self, from: data)
+    #expect(decoded == leg)
+    #expect(decoded.instrument.kind == .stock)
+    #expect(decoded.instrument.ticker == "BHP.AX")
+    #expect(decoded.instrument.exchange == "ASX")
+    #expect(decoded.quantity == Decimal(150))
+  }
+
+  @Test func cryptoLegCodableRoundTripPreservesChainMetadata() throws {
+    let usdc = Instrument.crypto(
+      chainId: 1,
+      contractAddress: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+      symbol: "USDC", name: "USD Coin", decimals: 6
+    )
+    let leg = TransactionLeg(
+      accountId: accountId,
+      instrument: usdc,
+      quantity: Decimal(string: "1234.567890")!,
+      type: .transfer
+    )
+    let data = try JSONEncoder().encode(leg)
+    let decoded = try JSONDecoder().decode(TransactionLeg.self, from: data)
+    #expect(decoded == leg)
+    #expect(decoded.instrument.kind == .cryptoToken)
+    #expect(decoded.instrument.chainId == 1)
+    #expect(
+      decoded.instrument.contractAddress == "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48")
+    #expect(decoded.instrument.decimals == 6)
+    #expect(decoded.quantity == Decimal(string: "1234.567890")!)
+  }
+
+  @Test func amountPropertyReturnsInstrumentAmountForStock() {
+    let bhp = Instrument.stock(ticker: "BHP.AX", exchange: "ASX", name: "BHP")
+    let leg = TransactionLeg(
+      accountId: accountId,
+      instrument: bhp,
+      quantity: Decimal(-50),
+      type: .transfer
+    )
+    let expected = InstrumentAmount(quantity: Decimal(-50), instrument: bhp)
+    #expect(leg.amount == expected)
+    #expect(leg.amount.instrument.kind == .stock)
+  }
+
+  @Test func amountPropertyReturnsInstrumentAmountForCrypto() {
+    let eth = Instrument.crypto(
+      chainId: 1, contractAddress: nil, symbol: "ETH", name: "Ethereum", decimals: 18
+    )
+    let leg = TransactionLeg(
+      accountId: accountId,
+      instrument: eth,
+      quantity: Decimal(string: "0.12345678")!,
+      type: .transfer
+    )
+    #expect(leg.amount.instrument == eth)
+    #expect(leg.amount.quantity == Decimal(string: "0.12345678")!)
+  }
 }

--- a/MoolahTests/Domain/TransactionRepositoryContractTests.swift
+++ b/MoolahTests/Domain/TransactionRepositoryContractTests.swift
@@ -266,6 +266,165 @@ struct TransactionRepositoryContractTests {
     #expect(created.isTransfer)
   }
 
+  // MARK: - Multi-instrument persistence
+
+  @Test("currency conversion transfer persists legs in distinct instruments")
+  func testCurrencyConversionPersistsLegsInDistinctInstruments() async throws {
+    let repository = makeCloudKitTransactionRepository()
+    let accountId = UUID()
+    let date = Calendar.current.date(from: DateComponents(year: 2026, month: 3, day: 15))!
+    let conversion = Transaction(
+      date: date,
+      payee: "FX",
+      legs: [
+        TransactionLeg(
+          accountId: accountId, instrument: .AUD,
+          quantity: Decimal(string: "-1000.00")!, type: .transfer),
+        TransactionLeg(
+          accountId: accountId, instrument: .USD,
+          quantity: Decimal(string: "650.00")!, type: .transfer),
+      ]
+    )
+
+    let created = try await repository.create(conversion)
+    #expect(created.legs.count == 2)
+
+    let page = try await repository.fetch(
+      filter: TransactionFilter(accountId: accountId),
+      page: 0,
+      pageSize: 10
+    )
+    let fetched = try #require(page.transactions.first(where: { $0.id == created.id }))
+    #expect(fetched.legs.count == 2)
+    let audLeg = try #require(fetched.legs.first(where: { $0.instrument == .AUD }))
+    let usdLeg = try #require(fetched.legs.first(where: { $0.instrument == .USD }))
+    #expect(audLeg.quantity == Decimal(string: "-1000.00")!)
+    #expect(usdLeg.quantity == Decimal(string: "650.00")!)
+  }
+
+  @Test("stock trade transaction persists fiat and stock legs")
+  func testStockTradePersistsFiatAndStockLegs() async throws {
+    let repository = makeCloudKitTransactionRepository()
+    let accountId = UUID()
+    let bhp = Instrument.stock(ticker: "BHP.AX", exchange: "ASX", name: "BHP")
+    let trade = Transaction(
+      date: Date(),
+      payee: "Buy 150 BHP",
+      legs: [
+        TransactionLeg(
+          accountId: accountId, instrument: .AUD,
+          quantity: Decimal(string: "-6345.00")!, type: .transfer),
+        TransactionLeg(
+          accountId: accountId, instrument: bhp, quantity: Decimal(150), type: .transfer),
+      ]
+    )
+
+    let created = try await repository.create(trade)
+    #expect(created.legs.count == 2)
+
+    let page = try await repository.fetch(
+      filter: TransactionFilter(accountId: accountId),
+      page: 0,
+      pageSize: 10
+    )
+    let fetched = try #require(page.transactions.first(where: { $0.id == created.id }))
+    let audLeg = try #require(fetched.legs.first(where: { $0.instrument == .AUD }))
+    let stockLeg = try #require(fetched.legs.first(where: { $0.instrument.kind == .stock }))
+    #expect(audLeg.quantity == Decimal(string: "-6345.00")!)
+    #expect(stockLeg.instrument == bhp)
+    #expect(stockLeg.quantity == Decimal(150))
+  }
+
+  @Test("three-leg trade with fee in third instrument persists each leg")
+  func testThreeLegTradeWithForeignFeePersistsAllLegs() async throws {
+    let repository = makeCloudKitTransactionRepository()
+    let accountId = UUID()
+    let feeCategoryId = UUID()
+    let aapl = Instrument.stock(ticker: "AAPL", exchange: "NASDAQ", name: "Apple")
+    // Sell USD, buy AAPL, fee in AUD — three distinct instruments across legs.
+    let trade = Transaction(
+      date: Date(),
+      payee: "Buy 10 Apple",
+      legs: [
+        TransactionLeg(
+          accountId: accountId, instrument: .USD,
+          quantity: Decimal(string: "-1855.00")!, type: .transfer),
+        TransactionLeg(
+          accountId: accountId, instrument: aapl, quantity: Decimal(10), type: .transfer),
+        TransactionLeg(
+          accountId: accountId, instrument: .AUD,
+          quantity: Decimal(string: "-7.50")!, type: .expense,
+          categoryId: feeCategoryId),
+      ]
+    )
+
+    let created = try await repository.create(trade)
+    #expect(created.legs.count == 3)
+
+    let page = try await repository.fetch(
+      filter: TransactionFilter(accountId: accountId),
+      page: 0,
+      pageSize: 10
+    )
+    let fetched = try #require(page.transactions.first(where: { $0.id == created.id }))
+    #expect(fetched.legs.count == 3)
+    let instrumentIds = Set(fetched.legs.map { $0.instrument.id })
+    #expect(instrumentIds == [Instrument.USD.id, aapl.id, Instrument.AUD.id])
+    let feeLeg = try #require(fetched.legs.first(where: { $0.type == .expense }))
+    #expect(feeLeg.instrument == .AUD)
+    #expect(feeLeg.categoryId == feeCategoryId)
+  }
+
+  @Test("filter by accountId returns transactions regardless of leg instrument")
+  func testFilterByAccountReturnsMultiInstrumentTransactions() async throws {
+    let accountId = UUID()
+    let bhp = Instrument.stock(ticker: "BHP.AX", exchange: "ASX", name: "BHP")
+    let initial: [Transaction] = [
+      Transaction(
+        date: Calendar.current.date(from: DateComponents(year: 2026, month: 1, day: 5))!,
+        payee: "Opening AUD",
+        legs: [
+          TransactionLeg(
+            accountId: accountId, instrument: .AUD,
+            quantity: Decimal(string: "10000.00")!, type: .openingBalance)
+        ]),
+      Transaction(
+        date: Calendar.current.date(from: DateComponents(year: 2026, month: 1, day: 10))!,
+        payee: "FX",
+        legs: [
+          TransactionLeg(
+            accountId: accountId, instrument: .AUD,
+            quantity: Decimal(string: "-1000.00")!, type: .transfer),
+          TransactionLeg(
+            accountId: accountId, instrument: .USD,
+            quantity: Decimal(string: "650.00")!, type: .transfer),
+        ]),
+      Transaction(
+        date: Calendar.current.date(from: DateComponents(year: 2026, month: 1, day: 15))!,
+        payee: "Buy 100 BHP",
+        legs: [
+          TransactionLeg(
+            accountId: accountId, instrument: .AUD,
+            quantity: Decimal(string: "-4230.00")!, type: .transfer),
+          TransactionLeg(
+            accountId: accountId, instrument: bhp, quantity: Decimal(100), type: .transfer),
+        ]),
+    ]
+    let repository = makeCloudKitTransactionRepository(initialTransactions: initial)
+
+    let page = try await repository.fetch(
+      filter: TransactionFilter(accountId: accountId),
+      page: 0,
+      pageSize: 50
+    )
+    #expect(page.transactions.count == 3)
+    // Union of instruments across all legs on this account must include fiat + stock.
+    let allInstruments = Set(page.transactions.flatMap { $0.legs.map(\.instrument.id) })
+    #expect(allInstruments.contains(Instrument.AUD.id))
+    #expect(allInstruments.contains(Instrument.USD.id))
+    #expect(allInstruments.contains(bhp.id))
+  }
+
   @Test("transactions are sorted by date descending")
   func testTransactionsSortedByDateDesc() async throws {
     let repository = makeCloudKitTransactionRepository(initialTransactions: makeTestTransactions())

--- a/MoolahTests/Features/AccountStoreConversionTests.swift
+++ b/MoolahTests/Features/AccountStoreConversionTests.swift
@@ -156,4 +156,94 @@ struct AccountStoreConversionTests {
     await store.load()
     #expect(store.positions(for: UUID()).isEmpty)
   }
+
+  @Test func mixedKindAccountShowsFiatAndStockPositions() async throws {
+    let accountId = UUID()
+    let bhp = Instrument.stock(ticker: "BHP.AX", exchange: "ASX", name: "BHP")
+    let account = Account(
+      id: accountId, name: "Sharesight", type: .investment,
+      instrument: .defaultTestInstrument)
+    let (backend, container) = try TestBackend.create()
+    TestBackend.seed(accounts: [account], in: container)
+
+    let audTx = Transaction(
+      date: Date(),
+      legs: [
+        TransactionLeg(
+          accountId: accountId, instrument: .AUD,
+          quantity: Decimal(string: "5000.00")!, type: .openingBalance)
+      ]
+    )
+    let stockTx = Transaction(
+      date: Date(),
+      legs: [
+        TransactionLeg(
+          accountId: accountId, instrument: bhp, quantity: Decimal(100),
+          type: .transfer)
+      ]
+    )
+    TestBackend.seed(transactions: [audTx, stockTx], in: container)
+
+    let store = AccountStore(
+      repository: backend.accounts,
+      conversionService: backend.conversionService,
+      targetInstrument: .defaultTestInstrument
+    )
+    await store.load()
+
+    let positions = store.positions(for: accountId)
+    #expect(positions.count == 2)
+    #expect(positions.contains { $0.instrument == .AUD })
+    #expect(positions.contains { $0.instrument == bhp })
+  }
+
+  @Test func mixedKindAccountShowsFiatStockAndCryptoPositions() async throws {
+    let accountId = UUID()
+    let bhp = Instrument.stock(ticker: "BHP.AX", exchange: "ASX", name: "BHP")
+    let eth = Instrument.crypto(
+      chainId: 1, contractAddress: nil, symbol: "ETH", name: "Ethereum", decimals: 18
+    )
+    let account = Account(
+      id: accountId, name: "Portfolio", type: .investment,
+      instrument: .defaultTestInstrument)
+    let (backend, container) = try TestBackend.create()
+    TestBackend.seed(accounts: [account], in: container)
+
+    let txns = [
+      Transaction(
+        date: Date(),
+        legs: [
+          TransactionLeg(
+            accountId: accountId, instrument: .AUD,
+            quantity: Decimal(string: "1000.00")!, type: .openingBalance)
+        ]),
+      Transaction(
+        date: Date(),
+        legs: [
+          TransactionLeg(
+            accountId: accountId, instrument: bhp, quantity: Decimal(100),
+            type: .transfer)
+        ]),
+      Transaction(
+        date: Date(),
+        legs: [
+          TransactionLeg(
+            accountId: accountId, instrument: eth,
+            quantity: Decimal(string: "0.5")!, type: .transfer)
+        ]),
+    ]
+    TestBackend.seed(transactions: txns, in: container)
+
+    let store = AccountStore(
+      repository: backend.accounts,
+      conversionService: backend.conversionService,
+      targetInstrument: .defaultTestInstrument
+    )
+    await store.load()
+
+    let positions = store.positions(for: accountId)
+    #expect(positions.count == 3)
+    let kinds = Set(positions.map(\.instrument.kind))
+    #expect(kinds == [.fiatCurrency, .stock, .cryptoToken])
+  }
 }

--- a/MoolahTests/Features/CryptoTokenStoreTests.swift
+++ b/MoolahTests/Features/CryptoTokenStoreTests.swift
@@ -143,4 +143,30 @@ struct CryptoTokenStoreTests {
     #expect(store.instruments.count == 1)
     #expect(store.resolvedRegistration == nil)
   }
+
+  // MARK: - Multi-instrument / cross-chain
+
+  @Test func loadRegistrations_preservesMultipleChainsWithSamePrefix() async {
+    // All presets should load — presets include Bitcoin (chainId 0), Ethereum (1),
+    // Optimism (10), and ERC20s on Ethereum. Store keeps them distinct.
+    let store = await makeStore(registrations: CryptoRegistration.builtInPresets)
+    await store.loadRegistrations()
+    #expect(store.registrations.count == CryptoRegistration.builtInPresets.count)
+    let chainIds = Set(store.instruments.compactMap(\.chainId))
+    // Presets span at least chain 0 (BTC), 1 (ETH/UNI/ENS), 10 (OP).
+    #expect(chainIds.contains(0))
+    #expect(chainIds.contains(1))
+    #expect(chainIds.contains(10))
+  }
+
+  @Test func loadRegistrations_keepsNativeAndErc20OnSameChainDistinct() async {
+    // builtInPresets contains ETH (chainId 1, native) and UNI/ENS (chainId 1, ERC20).
+    let store = await makeStore(registrations: CryptoRegistration.builtInPresets)
+    await store.loadRegistrations()
+    let chain1 = store.instruments.filter { $0.chainId == 1 }
+    let natives = chain1.filter { $0.contractAddress == nil }
+    let erc20s = chain1.filter { $0.contractAddress != nil }
+    #expect(!natives.isEmpty)
+    #expect(!erc20s.isEmpty)
+  }
 }

--- a/MoolahTests/Features/EarmarkBudgetTests.swift
+++ b/MoolahTests/Features/EarmarkBudgetTests.swift
@@ -387,4 +387,55 @@ struct BudgetLineItemMergeTests {
 
     #expect(result.first?.categoryName == "Unknown")
   }
+
+  // MARK: - Multi-instrument budget items
+
+  @Test func budgetItemInForeignInstrumentPreservesInstrumentInLineItem() {
+    let catId = UUID()
+    let categories = Categories(from: [Category(id: catId, name: "Travel")])
+    let budgetItems = [
+      EarmarkBudgetItem(
+        categoryId: catId,
+        amount: InstrumentAmount(quantity: Decimal(500), instrument: .USD))
+    ]
+
+    let result = BudgetLineItem.buildLineItems(
+      budgetItems: budgetItems,
+      categoryBalances: [:],
+      categories: categories
+    )
+
+    #expect(result.count == 1)
+    #expect(result[0].budgeted.instrument == .USD)
+    #expect(result[0].budgeted.quantity == Decimal(500))
+  }
+
+  @Test func multipleBudgetItemsAcrossInstrumentsEachRetainTheirOwnInstrument() {
+    let audCat = UUID()
+    let usdCat = UUID()
+    let categories = Categories(from: [
+      Category(id: audCat, name: "Groceries"),
+      Category(id: usdCat, name: "Subscriptions"),
+    ])
+    let budgetItems = [
+      EarmarkBudgetItem(
+        categoryId: audCat,
+        amount: InstrumentAmount(quantity: Decimal(200), instrument: .AUD)),
+      EarmarkBudgetItem(
+        categoryId: usdCat,
+        amount: InstrumentAmount(quantity: Decimal(50), instrument: .USD)),
+    ]
+
+    let result = BudgetLineItem.buildLineItems(
+      budgetItems: budgetItems,
+      categoryBalances: [:],
+      categories: categories
+    )
+
+    #expect(result.count == 2)
+    let audLine = result.first { $0.id == audCat }
+    let usdLine = result.first { $0.id == usdCat }
+    #expect(audLine?.budgeted.instrument == .AUD)
+    #expect(usdLine?.budgeted.instrument == .USD)
+  }
 }

--- a/MoolahTests/Features/EarmarkStoreTests.swift
+++ b/MoolahTests/Features/EarmarkStoreTests.swift
@@ -519,6 +519,46 @@ struct EarmarkStoreTests {
 
     #expect(store.visibleEarmarks.count == 2)
   }
+
+  // MARK: - Multi-instrument earmarks
+
+  @Test("USD earmark is loaded with USD instrument intact")
+  func loadEarmarkWithUSDInstrument() async throws {
+    let usdEarmark = Earmark(name: "US Travel", instrument: .USD)
+    let accountId = UUID()
+    let (backend, container) = try TestBackend.create()
+    TestBackend.seed(
+      accounts: [
+        Account(id: accountId, name: "Test", type: .bank, instrument: .USD)
+      ], in: container)
+    TestBackend.seedWithTransactions(
+      earmarks: [usdEarmark],
+      amounts: [usdEarmark.id: (saved: 500, spent: 0)],
+      accountId: accountId, in: container, instrument: .USD)
+    let store = EarmarkStore(repository: backend.earmarks, targetInstrument: .USD)
+
+    await store.load()
+    #expect(store.earmarks.count == 1)
+    #expect(store.earmarks.first?.instrument == .USD)
+  }
+
+  @Test("Earmarks created with different instruments round-trip through repository")
+  func multipleEarmarksWithDifferentInstruments() async throws {
+    // Direct repository check — avoids triggering store-level aggregation that presumes
+    // a single profile currency.
+    let audEm = Earmark(name: "AUD Fund", instrument: .AUD)
+    let usdEm = Earmark(name: "USD Fund", instrument: .USD)
+    let (backend, _) = try TestBackend.create()
+    _ = try await backend.earmarks.create(audEm)
+    _ = try await backend.earmarks.create(usdEm)
+
+    let all = try await backend.earmarks.fetchAll()
+    #expect(all.count == 2)
+    let aud = try #require(all.first { $0.id == audEm.id })
+    let usd = try #require(all.first { $0.id == usdEm.id })
+    #expect(aud.instrument == .AUD)
+    #expect(usd.instrument == .USD)
+  }
 }
 
 // MARK: - Test helpers

--- a/MoolahTests/Features/InvestmentStoreTests.swift
+++ b/MoolahTests/Features/InvestmentStoreTests.swift
@@ -466,4 +466,60 @@ struct InvestmentStoreTests {
     let result = mergeChartData(values: [], balances: [], period: .all)
     #expect(result.isEmpty)
   }
+
+  // MARK: - Multi-instrument manual investment values
+
+  @Test("Set value preserves USD instrument through store round-trip")
+  func testSetValueWithUSDInstrument() async throws {
+    let accountId = UUID()
+    let (backend, _) = try TestBackend.create()
+    let store = InvestmentStore(repository: backend.investments)
+    let date = makeDate(year: 2024, month: 3, day: 15)
+    let amount = InstrumentAmount(quantity: Decimal(5000), instrument: .USD)
+
+    await store.setValue(accountId: accountId, date: date, value: amount)
+
+    #expect(store.values.count == 1)
+    #expect(store.values[0].value.instrument == .USD)
+    #expect(store.values[0].value.quantity == Decimal(5000))
+  }
+
+  @Test("Different accounts can have values in different instruments")
+  func testValuesWithDifferentInstrumentsPerAccount() async throws {
+    let audAccount = UUID()
+    let usdAccount = UUID()
+    let (backend, container) = try TestBackend.create()
+    let date = makeDate(year: 2024, month: 3, day: 15)
+    // seed(investmentValues:) uses a single instrument per call, so seed each account separately
+    // with its own instrument so the stored records retain the account's real currency.
+    TestBackend.seed(
+      investmentValues: [
+        audAccount: [
+          InvestmentValue(
+            date: date,
+            value: InstrumentAmount(quantity: Decimal(1000), instrument: .AUD))
+        ]
+      ],
+      in: container,
+      instrument: .AUD)
+    TestBackend.seed(
+      investmentValues: [
+        usdAccount: [
+          InvestmentValue(
+            date: date,
+            value: InstrumentAmount(quantity: Decimal(650), instrument: .USD))
+        ]
+      ],
+      in: container,
+      instrument: .USD)
+    let store = InvestmentStore(repository: backend.investments)
+
+    await store.loadValues(accountId: audAccount)
+    #expect(store.values.count == 1)
+    #expect(store.values[0].value.instrument == .AUD)
+
+    await store.loadValues(accountId: usdAccount)
+    #expect(store.values.count == 1)
+    #expect(store.values[0].value.instrument == .USD)
+  }
 }

--- a/MoolahTests/Features/ReportingStoreTests.swift
+++ b/MoolahTests/Features/ReportingStoreTests.swift
@@ -225,4 +225,112 @@ struct ReportingStoreTests {
     #expect(summary.discountedLongTermGain == 500)
     #expect(summary.netCapitalGain == 500)
   }
+
+  // MARK: - Multi-instrument profit/loss
+
+  @Test @MainActor func loadProfitLoss_aggregatesMultipleStockInstruments() async throws {
+    let (backend, container) = try TestBackend.create()
+    let account = Account(
+      id: UUID(), name: "Brokerage", type: .bank, instrument: .defaultTestInstrument
+    )
+    TestBackend.seed(accounts: [account], in: container)
+
+    let bhp = Instrument(
+      id: "ASX:BHP", kind: .stock, name: "BHP", decimals: 0,
+      ticker: "BHP.AX", exchange: "ASX", chainId: nil, contractAddress: nil)
+    let cba = Instrument(
+      id: "ASX:CBA", kind: .stock, name: "CBA", decimals: 0,
+      ticker: "CBA.AX", exchange: "ASX", chainId: nil, contractAddress: nil)
+
+    let buyBHP = Transaction(
+      date: Date(),
+      payee: "Buy BHP",
+      legs: [
+        TransactionLeg(
+          accountId: account.id, instrument: aud, quantity: -4000, type: .transfer),
+        TransactionLeg(
+          accountId: account.id, instrument: bhp, quantity: 100, type: .transfer),
+      ]
+    )
+    let buyCBA = Transaction(
+      date: Date(),
+      payee: "Buy CBA",
+      legs: [
+        TransactionLeg(
+          accountId: account.id, instrument: aud, quantity: -5000, type: .transfer),
+        TransactionLeg(
+          accountId: account.id, instrument: cba, quantity: 50, type: .transfer),
+      ]
+    )
+    TestBackend.seed(transactions: [buyBHP, buyCBA], in: container)
+
+    // BHP worth $50/share → 5000, CBA worth $120/share → 6000
+    let service = FixedConversionService(rates: ["ASX:BHP": 50, "ASX:CBA": 120])
+    let store = ReportingStore(
+      transactionRepository: backend.transactions,
+      conversionService: service,
+      profileCurrency: aud
+    )
+
+    await store.loadProfitLoss()
+
+    #expect(store.profitLoss.count == 2)
+    let bhpPL = try #require(store.profitLoss.first { $0.instrument.id == "ASX:BHP" })
+    let cbaPL = try #require(store.profitLoss.first { $0.instrument.id == "ASX:CBA" })
+    #expect(bhpPL.totalInvested == 4000)
+    #expect(bhpPL.currentValue == 5000)
+    #expect(cbaPL.totalInvested == 5000)
+    #expect(cbaPL.currentValue == 6000)
+  }
+
+  @Test @MainActor func loadProfitLoss_tracksStockAndCryptoInSamePortfolio() async throws {
+    let (backend, container) = try TestBackend.create()
+    let account = Account(
+      id: UUID(), name: "Hybrid", type: .bank, instrument: .defaultTestInstrument
+    )
+    TestBackend.seed(accounts: [account], in: container)
+
+    let bhp = Instrument(
+      id: "ASX:BHP", kind: .stock, name: "BHP", decimals: 0,
+      ticker: "BHP.AX", exchange: "ASX", chainId: nil, contractAddress: nil)
+    let eth = Instrument.crypto(
+      chainId: 1, contractAddress: nil, symbol: "ETH", name: "Ethereum", decimals: 18
+    )
+
+    let txns = [
+      Transaction(
+        date: Date(),
+        payee: "Buy BHP",
+        legs: [
+          TransactionLeg(
+            accountId: account.id, instrument: aud, quantity: -4000, type: .transfer),
+          TransactionLeg(
+            accountId: account.id, instrument: bhp, quantity: 100, type: .transfer),
+        ]),
+      Transaction(
+        date: Date(),
+        payee: "Buy ETH",
+        legs: [
+          TransactionLeg(
+            accountId: account.id, instrument: aud, quantity: -2000, type: .transfer),
+          TransactionLeg(
+            accountId: account.id, instrument: eth,
+            quantity: Decimal(string: "1.0")!, type: .transfer),
+        ]),
+    ]
+    TestBackend.seed(transactions: txns, in: container)
+
+    let service = FixedConversionService(rates: ["ASX:BHP": 50, eth.id: 2500])
+    let store = ReportingStore(
+      transactionRepository: backend.transactions,
+      conversionService: service,
+      profileCurrency: aud
+    )
+
+    await store.loadProfitLoss()
+
+    #expect(store.profitLoss.count == 2)
+    let kinds = Set(store.profitLoss.map { $0.instrument.kind })
+    #expect(kinds == [.stock, .cryptoToken])
+  }
 }

--- a/MoolahTests/Features/TokenSwapDraftTests.swift
+++ b/MoolahTests/Features/TokenSwapDraftTests.swift
@@ -114,4 +114,75 @@ struct TokenSwapDraftTests {
     #expect(transaction.notes == "Uniswap swap")
     #expect(transaction.payee == nil)
   }
+
+  // MARK: - Multi-instrument swap scenarios
+
+  @Test func crossChainSwapPreservesChainIdsOnEachLeg() {
+    // ETH on chain 1 swapped for a token on chain 137 (Polygon).
+    let polyUsdc = Instrument.crypto(
+      chainId: 137,
+      contractAddress: "0x2791bca1f2de4661ed88a30c99a7a9449aa84174",
+      symbol: "USDC", name: "USD Coin", decimals: 6
+    )
+    var draft = TokenSwapDraft(accountId: accountId)
+    draft.sourceInstrument = eth
+    draft.sourceQuantity = Decimal(string: "0.5")!
+    draft.destinationInstrument = polyUsdc
+    draft.destinationQuantity = Decimal(string: "800")!
+    draft.date = Date()
+
+    let legs = draft.buildLegs()
+    #expect(legs.count == 2)
+    #expect(legs[0].instrument.chainId == 1)
+    #expect(legs[1].instrument.chainId == 137)
+    #expect(legs[0].instrument.contractAddress == nil)
+    #expect(legs[1].instrument.contractAddress != nil)
+  }
+
+  @Test func gasFeeInInstrumentDifferentFromSourceAndDestinationIsLegged() {
+    // Swap UNI for a hypothetical token on chain 1, fee in ETH (native gas).
+    let dai = Instrument.crypto(
+      chainId: 1,
+      contractAddress: "0x6b175474e89094c44da98b954eedeac495271d0f",
+      symbol: "DAI", name: "Dai", decimals: 18
+    )
+    var draft = TokenSwapDraft(accountId: accountId)
+    draft.sourceInstrument = uni
+    draft.sourceQuantity = Decimal(string: "100")!
+    draft.destinationInstrument = dai
+    draft.destinationQuantity = Decimal(string: "600")!
+    draft.gasFeeInstrument = eth
+    draft.gasFeeQuantity = Decimal(string: "0.003")!
+    draft.date = Date()
+
+    let legs = draft.buildLegs()
+    #expect(legs.count == 3)
+    let instruments = Set(legs.map { $0.instrument.id })
+    #expect(instruments.count == 3)
+    let feeLeg = legs[2]
+    #expect(feeLeg.instrument == eth)
+    #expect(feeLeg.quantity == Decimal(string: "-0.003")!)
+    #expect(feeLeg.type == .expense)
+  }
+
+  @Test func swapPreservesHighDecimalPrecisionOnBothSides() {
+    // Source has 18-decimal ETH, destination has 6-decimal USDC.
+    let usdc = Instrument.crypto(
+      chainId: 1,
+      contractAddress: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+      symbol: "USDC", name: "USD Coin", decimals: 6
+    )
+    var draft = TokenSwapDraft(accountId: accountId)
+    draft.sourceInstrument = eth
+    draft.sourceQuantity = Decimal(string: "0.12345678")!
+    draft.destinationInstrument = usdc
+    draft.destinationQuantity = Decimal(string: "200.001234")!
+    draft.date = Date()
+
+    let legs = draft.buildLegs()
+    #expect(legs[0].instrument.decimals == 18)
+    #expect(legs[0].quantity == Decimal(string: "-0.12345678")!)
+    #expect(legs[1].instrument.decimals == 6)
+    #expect(legs[1].quantity == Decimal(string: "200.001234")!)
+  }
 }

--- a/MoolahTests/Features/TradeStoreTests.swift
+++ b/MoolahTests/Features/TradeStoreTests.swift
@@ -95,4 +95,126 @@ struct TradeStoreTests {
       #expect(store.error != nil)
     }
   }
+
+  // MARK: - Multi-instrument persistence
+
+  @Test func executeTradePersistsLegInstrumentsExactly() async throws {
+    // Verify each leg's instrument survives a round-trip through CloudKitBackend storage —
+    // not just leg count. Stock trades span fiat + stock kinds.
+    let accountId = UUID()
+    let (backend, container) = try TestBackend.create()
+    TestBackend.seed(
+      accounts: [
+        Account(
+          id: accountId, name: "Sharesight", type: .investment, instrument: .defaultTestInstrument)
+      ], in: container)
+
+    let store = TradeStore(transactions: backend.transactions)
+
+    var draft = TradeDraft(accountId: accountId)
+    draft.soldInstrument = aud
+    draft.soldQuantityText = "6345.00"
+    draft.boughtInstrument = bhp
+    draft.boughtQuantityText = "150"
+    draft.date = makeDate(year: 2024, month: 6, day: 15)
+
+    _ = try await store.executeTrade(draft)
+
+    let page = try await backend.transactions.fetch(
+      filter: TransactionFilter(accountId: accountId),
+      page: 0,
+      pageSize: 10
+    )
+    let fetched = try #require(page.transactions.first)
+    #expect(fetched.legs.count == 2)
+    let audLeg = try #require(fetched.legs.first(where: { $0.instrument == aud }))
+    let stockLeg = try #require(fetched.legs.first(where: { $0.instrument.kind == .stock }))
+    #expect(audLeg.quantity == Decimal(string: "-6345.00")!)
+    #expect(stockLeg.instrument == bhp)
+    #expect(stockLeg.quantity == Decimal(150))
+  }
+
+  @Test func executeTradeWithFeeInThirdInstrumentPersistsThreeDistinctInstruments() async throws {
+    let accountId = UUID()
+    let feeCategoryId = UUID()
+    let usd = Instrument.fiat(code: "USD")
+    let aapl = Instrument.stock(ticker: "AAPL", exchange: "NASDAQ", name: "Apple")
+    let (backend, container) = try TestBackend.create()
+    TestBackend.seed(
+      accounts: [
+        Account(
+          id: accountId, name: "Interactive Brokers", type: .investment,
+          instrument: .defaultTestInstrument)
+      ], in: container)
+
+    let store = TradeStore(transactions: backend.transactions)
+
+    // Sell USD, buy AAPL, fee in AUD — three different instruments on the same trade.
+    var draft = TradeDraft(accountId: accountId)
+    draft.soldInstrument = usd
+    draft.soldQuantityText = "1855.00"
+    draft.boughtInstrument = aapl
+    draft.boughtQuantityText = "10"
+    draft.feeAmountText = "7.50"
+    draft.feeInstrument = aud
+    draft.feeCategoryId = feeCategoryId
+    draft.date = makeDate(year: 2024, month: 6, day: 15)
+
+    _ = try await store.executeTrade(draft)
+
+    let page = try await backend.transactions.fetch(
+      filter: TransactionFilter(accountId: accountId),
+      page: 0,
+      pageSize: 10
+    )
+    let fetched = try #require(page.transactions.first)
+    #expect(fetched.legs.count == 3)
+    let instrumentIds = Set(fetched.legs.map { $0.instrument.id })
+    #expect(instrumentIds == [usd.id, aapl.id, aud.id])
+    let feeLeg = try #require(fetched.legs.first(where: { $0.type == .expense }))
+    #expect(feeLeg.instrument == aud)
+    #expect(feeLeg.categoryId == feeCategoryId)
+  }
+
+  @Test func executeCryptoSwapPersistsBothLegsWithCorrectInstruments() async throws {
+    let accountId = UUID()
+    let eth = Instrument.crypto(
+      chainId: 1, contractAddress: nil, symbol: "ETH", name: "Ethereum", decimals: 18
+    )
+    let uni = Instrument.crypto(
+      chainId: 1,
+      contractAddress: "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
+      symbol: "UNI", name: "Uniswap", decimals: 18
+    )
+    let (backend, container) = try TestBackend.create()
+    TestBackend.seed(
+      accounts: [
+        Account(
+          id: accountId, name: "Wallet", type: .investment, instrument: .defaultTestInstrument)
+      ], in: container)
+
+    let store = TradeStore(transactions: backend.transactions)
+
+    var draft = TradeDraft(accountId: accountId)
+    draft.soldInstrument = eth
+    draft.soldQuantityText = "0.5"
+    draft.boughtInstrument = uni
+    draft.boughtQuantityText = "1234.56"
+    draft.date = makeDate(year: 2024, month: 6, day: 15)
+
+    _ = try await store.executeTrade(draft)
+
+    let page = try await backend.transactions.fetch(
+      filter: TransactionFilter(accountId: accountId),
+      page: 0,
+      pageSize: 10
+    )
+    let fetched = try #require(page.transactions.first)
+    let soldLeg = try #require(fetched.legs.first(where: { $0.instrument == eth }))
+    let boughtLeg = try #require(fetched.legs.first(where: { $0.instrument == uni }))
+    #expect(soldLeg.quantity == Decimal(string: "-0.5")!)
+    #expect(boughtLeg.quantity == Decimal(string: "1234.56")!)
+    #expect(soldLeg.type == .transfer)
+    #expect(boughtLeg.type == .transfer)
+  }
 }

--- a/MoolahTests/Features/TransactionStoreTests.swift
+++ b/MoolahTests/Features/TransactionStoreTests.swift
@@ -1540,6 +1540,83 @@ struct TransactionStoreTests {
     let suggestions = try await backend.transactions.fetchPayeeSuggestions(prefix: "")
     #expect(suggestions.isEmpty)
   }
+
+  // MARK: - Multi-instrument loading
+
+  @Test func testLoadsUSDAccountTransactionsInUSDInstrument() async throws {
+    // A USD-denominated account should load expense/income legs with USD instrument intact.
+    let usdAccountId = UUID()
+    let transactions = [
+      Transaction(
+        date: makeDate("2024-06-15"),
+        payee: "Starbucks",
+        legs: [
+          TransactionLeg(
+            accountId: usdAccountId,
+            instrument: .USD,
+            quantity: Decimal(string: "-4.50")!,
+            type: .expense)
+        ]
+      )
+    ]
+    let (backend, container) = try TestBackend.create()
+    TestBackend.seed(
+      accounts: [
+        Account(id: usdAccountId, name: "US Checking", type: .bank, instrument: .USD)
+      ], in: container)
+    TestBackend.seed(transactions: transactions, in: container)
+
+    let store = TransactionStore(
+      repository: backend.transactions,
+      conversionService: FixedConversionService(),
+      targetInstrument: .defaultTestInstrument
+    )
+    await store.load(filter: TransactionFilter(accountId: usdAccountId))
+
+    #expect(store.transactions.count == 1)
+    let tx = store.transactions[0].transaction
+    #expect(tx.legs[0].instrument == .USD)
+    #expect(tx.legs[0].quantity == Decimal(string: "-4.50")!)
+  }
+
+  @Test func testLoadsTransactionSpanningMultipleInstruments() async throws {
+    // Currency conversion transaction on the same account — leg instruments must be preserved.
+    let revolutId = UUID()
+    let tx = Transaction(
+      date: makeDate("2024-06-15"),
+      payee: "FX",
+      legs: [
+        TransactionLeg(
+          accountId: revolutId, instrument: .AUD,
+          quantity: Decimal(string: "-1000.00")!, type: .transfer),
+        TransactionLeg(
+          accountId: revolutId, instrument: .USD,
+          quantity: Decimal(string: "650.00")!, type: .transfer),
+      ]
+    )
+    let (backend, container) = try TestBackend.create()
+    TestBackend.seed(
+      accounts: [
+        Account(id: revolutId, name: "Revolut", type: .bank, instrument: .AUD)
+      ], in: container)
+    TestBackend.seed(transactions: [tx], in: container)
+
+    let store = TransactionStore(
+      repository: backend.transactions,
+      conversionService: FixedConversionService(),
+      targetInstrument: .defaultTestInstrument
+    )
+    await store.load(filter: TransactionFilter(accountId: revolutId))
+
+    #expect(store.transactions.count == 1)
+    let fetched = store.transactions[0].transaction
+    #expect(fetched.legs.count == 2)
+    let audLeg = try #require(fetched.legs.first(where: { $0.instrument == .AUD }))
+    let usdLeg = try #require(fetched.legs.first(where: { $0.instrument == .USD }))
+    #expect(audLeg.quantity == Decimal(string: "-1000.00")!)
+    #expect(usdLeg.quantity == Decimal(string: "650.00")!)
+    #expect(fetched.isTransfer)
+  }
 }
 
 // MARK: - Test helpers

--- a/MoolahTests/Shared/BalanceDeltaCalculatorTests.swift
+++ b/MoolahTests/Shared/BalanceDeltaCalculatorTests.swift
@@ -134,6 +134,57 @@ struct BalanceDeltaCalculatorTests {
     #expect(result.accountDeltas[accountA]?[usd] == -30)
   }
 
+  @Test("Three-kind transaction tracks fiat, stock, and crypto deltas separately")
+  func threeKindTransactionSeparateDeltas() {
+    let bhp = Instrument.stock(ticker: "BHP.AX", exchange: "ASX", name: "BHP")
+    let eth = Instrument.crypto(
+      chainId: 1, contractAddress: nil, symbol: "ETH", name: "Ethereum", decimals: 18
+    )
+    // Single transaction spanning three instrument kinds.
+    let tx = transaction(legs: [
+      TransactionLeg(accountId: accountA, instrument: aud, quantity: -1000, type: .transfer),
+      TransactionLeg(accountId: accountA, instrument: bhp, quantity: 100, type: .transfer),
+      TransactionLeg(
+        accountId: accountA, instrument: eth,
+        quantity: Decimal(string: "-0.005")!, type: .expense),
+    ])
+    let result = BalanceDeltaCalculator.deltas(old: nil, new: tx)
+    #expect(result.accountDeltas[accountA]?[aud] == -1000)
+    #expect(result.accountDeltas[accountA]?[bhp] == 100)
+    #expect(result.accountDeltas[accountA]?[eth] == Decimal(string: "-0.005")!)
+  }
+
+  @Test("Cross-currency transfer produces deltas in different instruments on different accounts")
+  func crossCurrencyTransferDeltasAcrossAccounts() {
+    let tx = transaction(legs: [
+      TransactionLeg(accountId: accountA, instrument: aud, quantity: -1000, type: .transfer),
+      TransactionLeg(accountId: accountB, instrument: usd, quantity: 650, type: .transfer),
+    ])
+    let result = BalanceDeltaCalculator.deltas(old: nil, new: tx)
+    #expect(result.accountDeltas[accountA]?[aud] == -1000)
+    #expect(result.accountDeltas[accountB]?[usd] == 650)
+    #expect(result.accountDeltas[accountA]?[usd] == nil)
+    #expect(result.accountDeltas[accountB]?[aud] == nil)
+  }
+
+  @Test("Updating leg instrument reverses old instrument and applies new instrument")
+  func updateChangesInstrument() {
+    let txId = UUID()
+    let oldTx = transaction(
+      id: txId,
+      legs: [
+        TransactionLeg(accountId: accountA, instrument: aud, quantity: -50, type: .expense)
+      ])
+    let newTx = transaction(
+      id: txId,
+      legs: [
+        TransactionLeg(accountId: accountA, instrument: usd, quantity: -50, type: .expense)
+      ])
+    let result = BalanceDeltaCalculator.deltas(old: oldTx, new: newTx)
+    #expect(result.accountDeltas[accountA]?[aud] == 50)
+    #expect(result.accountDeltas[accountA]?[usd] == -50)
+  }
+
   // MARK: - Earmark Deltas
 
   @Test("Expense with earmark produces earmark delta and spent delta")

--- a/MoolahTests/Shared/CapitalGainsCalculatorTests.swift
+++ b/MoolahTests/Shared/CapitalGainsCalculatorTests.swift
@@ -154,6 +154,115 @@ struct CapitalGainsCalculatorTests {
     #expect(earlyResult.events.isEmpty)
   }
 
+  // MARK: - Multi-instrument scenarios
+
+  @Test func multipleStocks_produceIndependentGainEvents() {
+    let bhp = stockInstrument("BHP")
+    let cba = stockInstrument("CBA")
+    let accountId = UUID()
+
+    let buyBHP = LegTransaction(
+      date: date(0),
+      legs: [
+        TransactionLeg(
+          accountId: accountId, instrument: aud, quantity: -4000, type: .transfer,
+          categoryId: nil, earmarkId: nil),
+        TransactionLeg(
+          accountId: accountId, instrument: bhp, quantity: 100, type: .transfer,
+          categoryId: nil, earmarkId: nil),
+      ])
+    let sellBHP = LegTransaction(
+      date: date(400),
+      legs: [
+        TransactionLeg(
+          accountId: accountId, instrument: bhp, quantity: -100, type: .transfer,
+          categoryId: nil, earmarkId: nil),
+        TransactionLeg(
+          accountId: accountId, instrument: aud, quantity: 5000, type: .transfer,
+          categoryId: nil, earmarkId: nil),
+      ])
+    let buyCBA = LegTransaction(
+      date: date(50),
+      legs: [
+        TransactionLeg(
+          accountId: accountId, instrument: aud, quantity: -5000, type: .transfer,
+          categoryId: nil, earmarkId: nil),
+        TransactionLeg(
+          accountId: accountId, instrument: cba, quantity: 50, type: .transfer,
+          categoryId: nil, earmarkId: nil),
+      ])
+    let sellCBA = LegTransaction(
+      date: date(500),
+      legs: [
+        TransactionLeg(
+          accountId: accountId, instrument: cba, quantity: -50, type: .transfer,
+          categoryId: nil, earmarkId: nil),
+        TransactionLeg(
+          accountId: accountId, instrument: aud, quantity: 7000, type: .transfer,
+          categoryId: nil, earmarkId: nil),
+      ])
+
+    let result = CapitalGainsCalculator.compute(
+      transactions: [buyBHP, buyCBA, sellBHP, sellCBA],
+      profileCurrency: aud
+    )
+
+    #expect(result.events.count == 2)
+    let bhpGain = result.events.first { $0.instrument.id == "ASX:BHP" }?.gain
+    let cbaGain = result.events.first { $0.instrument.id == "ASX:CBA" }?.gain
+    #expect(bhpGain == 1000)
+    #expect(cbaGain == 2000)
+    #expect(result.totalRealizedGain == 3000)
+  }
+
+  @Test func sellingOneInstrumentDoesNotTouchCostBasisOfAnother() {
+    // If a user sells BHP, CBA cost basis must not change.
+    let bhp = stockInstrument("BHP")
+    let cba = stockInstrument("CBA")
+    let accountId = UUID()
+
+    let buyBHP = LegTransaction(
+      date: date(0),
+      legs: [
+        TransactionLeg(
+          accountId: accountId, instrument: aud, quantity: -4000, type: .transfer,
+          categoryId: nil, earmarkId: nil),
+        TransactionLeg(
+          accountId: accountId, instrument: bhp, quantity: 100, type: .transfer,
+          categoryId: nil, earmarkId: nil),
+      ])
+    let buyCBA = LegTransaction(
+      date: date(50),
+      legs: [
+        TransactionLeg(
+          accountId: accountId, instrument: aud, quantity: -5000, type: .transfer,
+          categoryId: nil, earmarkId: nil),
+        TransactionLeg(
+          accountId: accountId, instrument: cba, quantity: 50, type: .transfer,
+          categoryId: nil, earmarkId: nil),
+      ])
+    let sellAllBHP = LegTransaction(
+      date: date(400),
+      legs: [
+        TransactionLeg(
+          accountId: accountId, instrument: bhp, quantity: -100, type: .transfer,
+          categoryId: nil, earmarkId: nil),
+        TransactionLeg(
+          accountId: accountId, instrument: aud, quantity: 5000, type: .transfer,
+          categoryId: nil, earmarkId: nil),
+      ])
+
+    let result = CapitalGainsCalculator.compute(
+      transactions: [buyBHP, buyCBA, sellAllBHP],
+      profileCurrency: aud
+    )
+
+    // Only BHP sale produces an event; CBA is still held.
+    #expect(result.events.count == 1)
+    #expect(result.events[0].instrument.id == "ASX:BHP")
+    #expect(result.events[0].gain == 1000)
+  }
+
   // MARK: - Helpers
 
   private func stockInstrument(_ name: String) -> Instrument {

--- a/MoolahTests/Shared/CompositeTokenResolutionClientTests.swift
+++ b/MoolahTests/Shared/CompositeTokenResolutionClientTests.swift
@@ -97,4 +97,69 @@ struct CompositeTokenResolutionClientTests {
     #expect(result.binanceSymbol == nil)
     #expect(result.coingeckoId == nil)
   }
+
+  @Test func resolve_matchesContractAddressRegardlessOfCase() async throws {
+    // CoinList uses lowercase addresses; callers may pass checksummed (mixed-case).
+    let ccCoinList = """
+      {
+          "Data": {
+              "UNI": {
+                  "Symbol": "UNI",
+                  "CoinName": "Uniswap",
+                  "SmartContractAddress": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984"
+              }
+          }
+      }
+      """.data(using: .utf8)!
+
+    let binanceInfo = """
+      { "symbols": [] }
+      """.data(using: .utf8)!
+
+    let client = CompositeTokenResolutionClient(
+      coinListData: ccCoinList,
+      exchangeInfoData: binanceInfo,
+      coinGeckoApiKey: nil
+    )
+
+    let result = try await client.resolve(
+      chainId: 1,
+      contractAddress: "0x1F9840A85D5AF5BF1D1762F925BDADDC4201F984",
+      symbol: nil,
+      isNative: false
+    )
+    #expect(result.cryptocompareSymbol == "UNI")
+  }
+
+  @Test func resolve_nativeOnDifferentChainsAreDistinct() async throws {
+    // Resolving native tokens on two different chainIds should not conflate them —
+    // the chainId combined with symbol scopes the lookup.
+    let ccCoinList = """
+      {
+          "Data": {
+              "ETH": { "Symbol": "ETH", "CoinName": "Ethereum", "SmartContractAddress": "N/A" },
+              "MATIC": { "Symbol": "MATIC", "CoinName": "Polygon", "SmartContractAddress": "N/A" }
+          }
+      }
+      """.data(using: .utf8)!
+
+    let binanceInfo = """
+      { "symbols": [] }
+      """.data(using: .utf8)!
+
+    let client = CompositeTokenResolutionClient(
+      coinListData: ccCoinList,
+      exchangeInfoData: binanceInfo,
+      coinGeckoApiKey: nil
+    )
+
+    let eth = try await client.resolve(
+      chainId: 1, contractAddress: nil, symbol: "ETH", isNative: true
+    )
+    let matic = try await client.resolve(
+      chainId: 137, contractAddress: nil, symbol: "MATIC", isNative: true
+    )
+    #expect(eth.cryptocompareSymbol == "ETH")
+    #expect(matic.cryptocompareSymbol == "MATIC")
+  }
 }

--- a/MoolahTests/Shared/CostBasisEngineTests.swift
+++ b/MoolahTests/Shared/CostBasisEngineTests.swift
@@ -146,12 +146,76 @@ struct CostBasisEngineTests {
     #expect(engine.openLots(for: bhp).isEmpty)
   }
 
+  // MARK: - Mixed kinds (stock + crypto)
+
+  @Test func stockAndCryptoLotsTrackedSeparately() {
+    let bhp = stockInstrument("BHP")
+    let eth = cryptoInstrument("ETH")
+    var engine = CostBasisEngine()
+    engine.processBuy(instrument: bhp, quantity: 100, costPerUnit: 40, date: date(0))
+    engine.processBuy(
+      instrument: eth, quantity: Decimal(string: "1.0")!, costPerUnit: 2000, date: date(0))
+
+    // Sell only stock — crypto untouched
+    _ = engine.processSell(instrument: bhp, quantity: 100, proceedsPerUnit: 50, date: date(365))
+    #expect(engine.openLots(for: bhp).isEmpty)
+    let ethLots = engine.openLots(for: eth)
+    #expect(ethLots.count == 1)
+    #expect(ethLots[0].remainingQuantity == Decimal(string: "1.0")!)
+  }
+
+  @Test func cryptoPartialSellProducesFractionalEvents() {
+    let eth = cryptoInstrument("ETH")
+    var engine = CostBasisEngine()
+    engine.processBuy(
+      instrument: eth, quantity: Decimal(string: "2.0")!, costPerUnit: 2000, date: date(0))
+
+    let events = engine.processSell(
+      instrument: eth, quantity: Decimal(string: "0.5")!, proceedsPerUnit: 2500, date: date(100))
+
+    #expect(events.count == 1)
+    #expect(events[0].quantity == Decimal(string: "0.5")!)
+    let remaining = engine.openLots(for: eth)
+    #expect(remaining.count == 1)
+    #expect(remaining[0].remainingQuantity == Decimal(string: "1.5")!)
+  }
+
+  @Test func sameSymbolOnDifferentChainsTrackedSeparately() {
+    // USDC-Ethereum and USDC-Polygon are different instruments.
+    let ethUsdc = Instrument.crypto(
+      chainId: 1,
+      contractAddress: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+      symbol: "USDC", name: "USDC", decimals: 6
+    )
+    let polyUsdc = Instrument.crypto(
+      chainId: 137,
+      contractAddress: "0x2791bca1f2de4661ed88a30c99a7a9449aa84174",
+      symbol: "USDC", name: "USDC", decimals: 6
+    )
+    var engine = CostBasisEngine()
+    engine.processBuy(instrument: ethUsdc, quantity: 100, costPerUnit: 1, date: date(0))
+    engine.processBuy(instrument: polyUsdc, quantity: 200, costPerUnit: 1, date: date(0))
+
+    // Selling from one chain should not touch the other.
+    _ = engine.processSell(
+      instrument: ethUsdc, quantity: 100, proceedsPerUnit: 1, date: date(100))
+    #expect(engine.openLots(for: ethUsdc).isEmpty)
+    #expect(engine.openLots(for: polyUsdc).count == 1)
+    #expect(engine.openLots(for: polyUsdc)[0].remainingQuantity == 200)
+  }
+
   // MARK: - Helpers
 
   private func stockInstrument(_ name: String) -> Instrument {
     Instrument(
       id: "ASX:\(name)", kind: .stock, name: name, decimals: 0,
       ticker: "\(name).AX", exchange: "ASX", chainId: nil, contractAddress: nil)
+  }
+
+  private func cryptoInstrument(_ symbol: String) -> Instrument {
+    Instrument(
+      id: "1:\(symbol.lowercased())", kind: .cryptoToken, name: symbol, decimals: 18,
+      ticker: symbol, exchange: nil, chainId: 1, contractAddress: nil)
   }
 
   private func date(_ daysFromBase: Int) -> Date {

--- a/MoolahTests/Shared/InstrumentConversionServiceCryptoTests.swift
+++ b/MoolahTests/Shared/InstrumentConversionServiceCryptoTests.swift
@@ -143,4 +143,59 @@ struct InstrumentConversionServiceCryptoTests {
     #expect(result == expected)
   }
 
+  // MARK: - Precision across kinds
+
+  @Test func cryptoToFiatPreservesHighPrecisionMultiplication() async throws {
+    // Verify that high-decimal crypto quantities preserve precision through conversion.
+    let service = makeService(
+      cryptoPrices: ["1:native": ["2026-04-10": Decimal(string: "1623.45")!]],
+      providerMappings: [
+        CryptoProviderMapping(
+          instrumentId: "1:native", coingeckoId: "ethereum",
+          cryptocompareSymbol: "ETH", binanceSymbol: "ETHUSDT"
+        )
+      ]
+    )
+    let result = try await service.convert(
+      Decimal(string: "0.00012345")!, from: eth, to: usd, on: date("2026-04-10")
+    )
+    let expected = Decimal(string: "0.00012345")! * Decimal(string: "1623.45")!
+    #expect(result == expected)
+  }
+
+  @Test func zeroDecimalFiatToCryptoGoesThroughUsd() async throws {
+    // JPY has 0 decimals; route JPY → USD → ETH should not throw for fiat bridging.
+    let jpy = Instrument.fiat(code: "JPY")
+    let service = makeService(
+      cryptoPrices: ["1:native": ["2026-04-10": Decimal(string: "2000.00")!]],
+      exchangeRates: ["2026-04-10": ["JPY": Decimal(string: "150.00")!]],
+      providerMappings: [
+        CryptoProviderMapping(
+          instrumentId: "1:native", coingeckoId: "ethereum",
+          cryptocompareSymbol: "ETH", binanceSymbol: "ETHUSDT"
+        )
+      ]
+    )
+    // 300000 JPY → USD → ETH. 1 USD = 150 JPY, so 300000 JPY = 2000 USD; 1 ETH = 2000 USD → 1 ETH.
+    let result = try await service.convert(
+      Decimal(300_000), from: jpy, to: eth, on: date("2026-04-10")
+    )
+    #expect(result == Decimal(1))
+  }
+
+  @Test func missingCryptoPriceThrows() async throws {
+    let service = makeService(
+      cryptoPrices: [:],
+      providerMappings: [
+        CryptoProviderMapping(
+          instrumentId: "1:native", coingeckoId: "ethereum",
+          cryptocompareSymbol: "ETH", binanceSymbol: "ETHUSDT"
+        )
+      ]
+    )
+    await #expect(throws: (any Error).self) {
+      _ = try await service.convert(Decimal(1), from: eth, to: usd, on: date("2026-04-10"))
+    }
+  }
+
 }

--- a/MoolahTests/Shared/InstrumentConversionServiceStockTests.swift
+++ b/MoolahTests/Shared/InstrumentConversionServiceStockTests.swift
@@ -87,6 +87,41 @@ struct InstrumentConversionServiceStockTests {
     }
   }
 
+  @Test func foreignFiatToStockListedInDifferentFiatThrowsSymmetrically() async throws {
+    // fiatToStock is not a supported conversion direction regardless of source fiat.
+    let today = Date()
+    let service = makeService()
+
+    await #expect(throws: (any Error).self) {
+      _ = try await service.convert(Decimal(1000), from: usd, to: bhp, on: today)
+    }
+  }
+
+  @Test func stockInNonPrimaryFiatConvertsViaIntermediate() async throws {
+    // Simulate a USD-listed stock converting to USD directly (no FX required).
+    let today = Date()
+    let ds = dateString(today)
+    let service = makeService(
+      stockPrices: [
+        "AAPL": StockPriceResponse(instrument: .USD, prices: [ds: Decimal(string: "185.50")!])
+      ]
+    )
+
+    let result = try await service.convert(Decimal(10), from: aapl, to: usd, on: today)
+    #expect(result == Decimal(string: "1855.00")!)
+  }
+
+  @Test func zeroDecimalFiatToStockAlsoRejected() async throws {
+    // JPY has 0 decimals; request still throws (direction not supported) without crashing.
+    let today = Date()
+    let jpy = Instrument.fiat(code: "JPY")
+    let service = makeService()
+
+    await #expect(throws: (any Error).self) {
+      _ = try await service.convert(Decimal(100000), from: jpy, to: bhp, on: today)
+    }
+  }
+
   @Test func stockPriceFetchFailureThrows() async throws {
     let today = Date()
     let stockClient = FixedStockPriceClient(shouldFail: true)

--- a/MoolahTests/Shared/MonetaryAmountConversionTests.swift
+++ b/MoolahTests/Shared/MonetaryAmountConversionTests.swift
@@ -36,4 +36,33 @@ struct InstrumentAmountConversionTests {
     #expect(result.quantity == Decimal(string: "123.45")!)
     #expect(result.instrument == .AUD)
   }
+
+  @Test func convertZeroDecimalFiatPreservesPrecision() async throws {
+    // JPY has 0 decimals; converting yields a multiplied quantity with normal Decimal precision.
+    let client = FixedRateClient(rates: [
+      "2026-04-11": ["JPY": Decimal(string: "95.50")!]
+    ])
+    let service = ExchangeRateService(client: client)
+    let amount = InstrumentAmount(quantity: Decimal(100), instrument: .AUD)
+
+    let result = try await service.convert(
+      amount, to: Instrument.fiat(code: "JPY"), on: date("2026-04-11"))
+
+    #expect(result.quantity == Decimal(9550))
+    #expect(result.instrument.id == "JPY")
+  }
+
+  @Test func convertRespectsSourceQuantitySign() async throws {
+    let client = FixedRateClient(rates: [
+      "2026-04-11": ["USD": Decimal(string: "0.65")!]
+    ])
+    let service = ExchangeRateService(client: client)
+    let amount = InstrumentAmount(quantity: Decimal(string: "-200.00")!, instrument: .AUD)
+
+    let result = try await service.convert(
+      amount, to: .USD, on: date("2026-04-11"))
+
+    #expect(result.quantity == Decimal(string: "-130.00")!)
+    #expect(result.isNegative)
+  }
 }

--- a/MoolahTests/Shared/ProfitLossCalculatorTests.swift
+++ b/MoolahTests/Shared/ProfitLossCalculatorTests.swift
@@ -148,6 +148,97 @@ struct ProfitLossCalculatorTests {
     #expect(results.isEmpty)
   }
 
+  // MARK: - Multi-instrument portfolios
+
+  @Test func multipleStocks_eachGetsOwnRow() async throws {
+    let bhp = stockInstrument("BHP")
+    let cba = stockInstrument("CBA")
+    let accountId = UUID()
+
+    let buyBHP = LegTransaction(
+      date: date(0),
+      legs: [
+        TransactionLeg(
+          accountId: accountId, instrument: aud, quantity: -4000, type: .transfer,
+          categoryId: nil, earmarkId: nil),
+        TransactionLeg(
+          accountId: accountId, instrument: bhp, quantity: 100, type: .transfer,
+          categoryId: nil, earmarkId: nil),
+      ])
+    let buyCBA = LegTransaction(
+      date: date(0),
+      legs: [
+        TransactionLeg(
+          accountId: accountId, instrument: aud, quantity: -5000, type: .transfer,
+          categoryId: nil, earmarkId: nil),
+        TransactionLeg(
+          accountId: accountId, instrument: cba, quantity: 50, type: .transfer,
+          categoryId: nil, earmarkId: nil),
+      ])
+
+    // BHP $50/share (100 * 50 = 5000). CBA $120/share (50 * 120 = 6000).
+    let service = FixedConversionService(rates: ["ASX:BHP": 50, "ASX:CBA": 120])
+    let results = try await ProfitLossCalculator.compute(
+      transactions: [buyBHP, buyCBA],
+      profileCurrency: aud,
+      conversionService: service,
+      asOfDate: date(365)
+    )
+
+    #expect(results.count == 2)
+    let bhpPL = results.first { $0.instrument.id == "ASX:BHP" }
+    let cbaPL = results.first { $0.instrument.id == "ASX:CBA" }
+    #expect(bhpPL?.unrealizedGain == 1000)
+    #expect(cbaPL?.unrealizedGain == 1000)
+  }
+
+  @Test func portfolioMixesStockAndCrypto() async throws {
+    let bhp = stockInstrument("BHP")
+    let eth = Instrument.crypto(
+      chainId: 1, contractAddress: nil, symbol: "ETH", name: "Ethereum", decimals: 18
+    )
+    let accountId = UUID()
+
+    let buyBHP = LegTransaction(
+      date: date(0),
+      legs: [
+        TransactionLeg(
+          accountId: accountId, instrument: aud, quantity: -4000, type: .transfer,
+          categoryId: nil, earmarkId: nil),
+        TransactionLeg(
+          accountId: accountId, instrument: bhp, quantity: 100, type: .transfer,
+          categoryId: nil, earmarkId: nil),
+      ])
+    let buyETH = LegTransaction(
+      date: date(0),
+      legs: [
+        TransactionLeg(
+          accountId: accountId, instrument: aud, quantity: -2000, type: .transfer,
+          categoryId: nil, earmarkId: nil),
+        TransactionLeg(
+          accountId: accountId, instrument: eth,
+          quantity: Decimal(string: "1.0")!, type: .transfer,
+          categoryId: nil, earmarkId: nil),
+      ])
+
+    let service = FixedConversionService(rates: ["ASX:BHP": 50, eth.id: 2500])
+    let results = try await ProfitLossCalculator.compute(
+      transactions: [buyBHP, buyETH],
+      profileCurrency: aud,
+      conversionService: service,
+      asOfDate: date(365)
+    )
+
+    #expect(results.count == 2)
+    let kinds = Set(results.map { $0.instrument.kind })
+    #expect(kinds == [.stock, .cryptoToken])
+    // Each row is independent; gains aggregate separately.
+    let bhpPL = results.first { $0.instrument.kind == .stock }
+    let ethPL = results.first { $0.instrument.kind == .cryptoToken }
+    #expect(bhpPL?.unrealizedGain == 1000)
+    #expect(ethPL?.unrealizedGain == 500)
+  }
+
   // MARK: - Helpers
 
   private func stockInstrument(_ name: String) -> Instrument {

--- a/MoolahTests/Shared/TradeDraftTests.swift
+++ b/MoolahTests/Shared/TradeDraftTests.swift
@@ -174,4 +174,142 @@ struct TradeDraftTests {
     #expect(transaction != nil)
     #expect(transaction!.legs[0].quantity == Decimal(string: "-1234.56")!)
   }
+
+  // MARK: - Cross-instrument trades
+
+  @Test func stockToStockTradeProducesTwoStockLegsAndTradePayee() throws {
+    let aapl = Instrument.stock(ticker: "AAPL", exchange: "NASDAQ", name: "Apple")
+    var draft = TradeDraft(accountId: accountId)
+    draft.soldInstrument = bhp
+    draft.soldQuantityText = "100"
+    draft.boughtInstrument = aapl
+    draft.boughtQuantityText = "25"
+    draft.date = Date()
+
+    let transaction = try #require(draft.toTransaction(id: UUID()))
+    #expect(transaction.legs.count == 2)
+    #expect(transaction.legs[0].instrument == bhp)
+    #expect(transaction.legs[0].quantity == Decimal(-100))
+    #expect(transaction.legs[1].instrument == aapl)
+    #expect(transaction.legs[1].quantity == Decimal(25))
+    #expect(transaction.payee == "Trade BHP for Apple")
+  }
+
+  @Test func cryptoToCryptoSwapProducesTwoCryptoLegs() throws {
+    let eth = Instrument.crypto(
+      chainId: 1, contractAddress: nil, symbol: "ETH", name: "Ethereum", decimals: 18
+    )
+    let uni = Instrument.crypto(
+      chainId: 1,
+      contractAddress: "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
+      symbol: "UNI", name: "Uniswap", decimals: 18
+    )
+    var draft = TradeDraft(accountId: accountId)
+    draft.soldInstrument = eth
+    draft.soldQuantityText = "0.5"
+    draft.boughtInstrument = uni
+    draft.boughtQuantityText = "1234.56"
+    draft.date = Date()
+
+    let transaction = try #require(draft.toTransaction(id: UUID()))
+    #expect(transaction.legs.count == 2)
+    #expect(transaction.legs[0].instrument == eth)
+    #expect(transaction.legs[0].quantity == Decimal(string: "-0.5")!)
+    #expect(transaction.legs[1].instrument == uni)
+    #expect(transaction.legs[1].quantity == Decimal(string: "1234.56")!)
+    #expect(transaction.payee == "Trade Ethereum for Uniswap")
+  }
+
+  @Test func crossCurrencyFiatTradeProducesTwoFiatLegs() throws {
+    let usd = Instrument.fiat(code: "USD")
+    var draft = TradeDraft(accountId: accountId)
+    draft.soldInstrument = aud
+    draft.soldQuantityText = "1000.00"
+    draft.boughtInstrument = usd
+    draft.boughtQuantityText = "650.00"
+    draft.date = Date()
+
+    let transaction = try #require(draft.toTransaction(id: UUID()))
+    #expect(transaction.legs.count == 2)
+    #expect(transaction.legs[0].instrument == aud)
+    #expect(transaction.legs[0].quantity == Decimal(string: "-1000.00")!)
+    #expect(transaction.legs[1].instrument == usd)
+    #expect(transaction.legs[1].quantity == Decimal(string: "650.00")!)
+    #expect(transaction.legs[0].type == .transfer)
+    #expect(transaction.legs[1].type == .transfer)
+    #expect(transaction.payee == "Trade AUD for USD")
+  }
+
+  @Test func feeDefaultsToSoldInstrumentWhenFeeInstrumentIsNil() throws {
+    var draft = TradeDraft(accountId: accountId)
+    draft.soldInstrument = aud
+    draft.soldQuantityText = "6345.00"
+    draft.boughtInstrument = bhp
+    draft.boughtQuantityText = "150"
+    draft.feeAmountText = "9.50"
+    draft.feeInstrument = nil
+    draft.date = Date()
+
+    let transaction = try #require(draft.toTransaction(id: UUID()))
+    #expect(transaction.legs.count == 3)
+    #expect(transaction.legs[2].instrument == aud)
+    #expect(transaction.legs[2].quantity == Decimal(string: "-9.50")!)
+    #expect(transaction.legs[2].type == .expense)
+  }
+
+  @Test func feeInThirdInstrumentPersistsOnLeg() throws {
+    // Sell USD, buy BHP, fee in AUD — three distinct instruments.
+    let usd = Instrument.fiat(code: "USD")
+    var draft = TradeDraft(accountId: accountId)
+    draft.soldInstrument = usd
+    draft.soldQuantityText = "4200.00"
+    draft.boughtInstrument = bhp
+    draft.boughtQuantityText = "150"
+    draft.feeAmountText = "12.00"
+    draft.feeInstrument = aud
+    draft.feeCategoryId = feeCategoryId
+    draft.date = Date()
+
+    let transaction = try #require(draft.toTransaction(id: UUID()))
+    #expect(transaction.legs.count == 3)
+    #expect(transaction.legs[0].instrument == usd)
+    #expect(transaction.legs[1].instrument == bhp)
+    #expect(transaction.legs[2].instrument == aud)
+    #expect(transaction.legs[2].quantity == Decimal(string: "-12.00")!)
+    #expect(transaction.legs[2].categoryId == feeCategoryId)
+    let instrumentIds = Set(transaction.legs.map { $0.instrument.id })
+    #expect(instrumentIds.count == 3)
+  }
+
+  @Test func cryptoTradeWithFeeInNativeGasToken() throws {
+    // Swap UNI for USDC, pay gas fee in ETH — fee in instrument different from both trade sides.
+    let eth = Instrument.crypto(
+      chainId: 1, contractAddress: nil, symbol: "ETH", name: "Ethereum", decimals: 18
+    )
+    let uni = Instrument.crypto(
+      chainId: 1,
+      contractAddress: "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
+      symbol: "UNI", name: "Uniswap", decimals: 18
+    )
+    let usdc = Instrument.crypto(
+      chainId: 1,
+      contractAddress: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+      symbol: "USDC", name: "USD Coin", decimals: 6
+    )
+    var draft = TradeDraft(accountId: accountId)
+    draft.soldInstrument = uni
+    draft.soldQuantityText = "100"
+    draft.boughtInstrument = usdc
+    draft.boughtQuantityText = "550.00"
+    draft.feeAmountText = "0.002"
+    draft.feeInstrument = eth
+    draft.feeCategoryId = feeCategoryId
+    draft.date = Date()
+
+    let transaction = try #require(draft.toTransaction(id: UUID()))
+    #expect(transaction.legs.count == 3)
+    #expect(transaction.legs[2].instrument == eth)
+    #expect(transaction.legs[2].quantity == Decimal(string: "-0.002")!)
+    #expect(transaction.legs[2].type == .expense)
+  }
 }

--- a/MoolahTests/Shared/TransactionDraftTests.swift
+++ b/MoolahTests/Shared/TransactionDraftTests.swift
@@ -976,6 +976,86 @@ struct TransactionDraftTests {
     #expect(draft.showFromAccount == false)
   }
 
+  // MARK: - Multi-instrument toTransaction
+
+  @Test func toTransactionExpenseUsesAccountInstrument() throws {
+    let usdAccount = makeAccount(id: accountA, instrument: .USD)
+    let accounts = makeAccounts([usdAccount])
+    let draft = TransactionDraft(
+      payee: "Coffee", date: Date(), notes: "",
+      isRepeating: false, recurPeriod: nil, recurEvery: 1, isCustom: false,
+      legDrafts: [
+        TransactionDraft.LegDraft(
+          type: .expense, accountId: accountA, amountText: "4.50",
+          categoryId: nil, categoryText: "", earmarkId: nil)
+      ],
+      relevantLegIndex: 0, viewingAccountId: nil
+    )
+
+    let tx = try #require(draft.toTransaction(id: UUID(), accounts: accounts))
+    #expect(tx.legs.count == 1)
+    #expect(tx.legs[0].instrument == .USD)
+    #expect(tx.legs[0].quantity == Decimal(string: "-4.50")!)
+  }
+
+  @Test func toTransactionCrossCurrencyTransferProducesMixedInstrumentLegs() throws {
+    // Transfer from AUD account to USD account — leg 0 is AUD, leg 1 is USD.
+    // Display convention negates transfer legs, so amountText is the negated quantity.
+    let audAccount = makeAccount(id: accountA, instrument: .AUD)
+    let usdAccount = makeAccount(id: accountB, instrument: .USD)
+    let accounts = makeAccounts([audAccount, usdAccount])
+    let draft = TransactionDraft(
+      payee: "FX", date: Date(), notes: "",
+      isRepeating: false, recurPeriod: nil, recurEvery: 1, isCustom: false,
+      legDrafts: [
+        TransactionDraft.LegDraft(
+          type: .transfer, accountId: accountA, amountText: "1000.00",
+          categoryId: nil, categoryText: "", earmarkId: nil),
+        TransactionDraft.LegDraft(
+          type: .transfer, accountId: accountB, amountText: "-650.00",
+          categoryId: nil, categoryText: "", earmarkId: nil),
+      ],
+      relevantLegIndex: 0, viewingAccountId: nil
+    )
+
+    let tx = try #require(draft.toTransaction(id: UUID(), accounts: accounts))
+    #expect(tx.legs.count == 2)
+    #expect(tx.legs[0].instrument == .AUD)
+    #expect(tx.legs[0].quantity == Decimal(string: "-1000.00")!)
+    #expect(tx.legs[1].instrument == .USD)
+    #expect(tx.legs[1].quantity == Decimal(string: "650.00")!)
+    #expect(tx.isTransfer)
+    // Cross-currency transfer quantities don't negate, so NOT isSimple.
+    #expect(!tx.isSimple)
+  }
+
+  @Test func toTransactionStockTradeLegHasStockInstrument() throws {
+    let bhp = Instrument.stock(ticker: "BHP.AX", exchange: "ASX", name: "BHP")
+    let audAccount = makeAccount(id: accountA, instrument: .AUD)
+    let stockAccount = makeAccount(id: accountB, instrument: bhp)
+    let accounts = makeAccounts([audAccount, stockAccount])
+    let draft = TransactionDraft(
+      payee: "Buy BHP", date: Date(), notes: "",
+      isRepeating: false, recurPeriod: nil, recurEvery: 1, isCustom: true,
+      legDrafts: [
+        TransactionDraft.LegDraft(
+          type: .transfer, accountId: accountA, amountText: "6345.00",
+          categoryId: nil, categoryText: "", earmarkId: nil),
+        TransactionDraft.LegDraft(
+          type: .transfer, accountId: accountB, amountText: "-150",
+          categoryId: nil, categoryText: "", earmarkId: nil),
+      ],
+      relevantLegIndex: 0, viewingAccountId: nil
+    )
+
+    let tx = try #require(draft.toTransaction(id: UUID(), accounts: accounts))
+    #expect(tx.legs.count == 2)
+    #expect(tx.legs[0].instrument == .AUD)
+    #expect(tx.legs[0].quantity == Decimal(string: "-6345.00")!)
+    #expect(tx.legs[1].instrument == bhp)
+    #expect(tx.legs[1].quantity == Decimal(150))
+  }
+
   // MARK: - eligibleToAccounts
 
   @Test func eligibleToAccountsFiltersByCurrency() {

--- a/MoolahTests/Sync/RecordMappingTests.swift
+++ b/MoolahTests/Sync/RecordMappingTests.swift
@@ -389,6 +389,215 @@ struct RecordMappingTests {
     #expect(restored.instrumentId == "AUD")
   }
 
+  // MARK: - Multi-instrument persistence
+
+  @Test func instrumentRecordCryptoFieldsRoundTrip() {
+    let instrument = InstrumentRecord(
+      id: "1:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+      kind: "cryptoToken",
+      name: "USD Coin",
+      decimals: 6,
+      ticker: "USDC",
+      exchange: nil,
+      chainId: 1,
+      contractAddress: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+    )
+
+    let ckRecord = instrument.toCKRecord(in: zoneID)
+    #expect(ckRecord["kind"] as? String == "cryptoToken")
+    #expect(ckRecord["ticker"] as? String == "USDC")
+    #expect(ckRecord["chainId"] as? Int == 1)
+    #expect(
+      ckRecord["contractAddress"] as? String == "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48")
+    #expect(ckRecord["exchange"] == nil)
+
+    let restored = InstrumentRecord.fieldValues(from: ckRecord)
+    #expect(restored.id == "1:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48")
+    #expect(restored.kind == "cryptoToken")
+    #expect(restored.decimals == 6)
+    #expect(restored.ticker == "USDC")
+    #expect(restored.chainId == 1)
+    #expect(restored.contractAddress == "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48")
+  }
+
+  @Test func instrumentRecordNativeCryptoHasNoContractAddress() {
+    // Bitcoin uses chainId = 0 and nil contractAddress; ETH native uses chainId = 1.
+    let btc = InstrumentRecord(
+      id: "0:native",
+      kind: "cryptoToken",
+      name: "Bitcoin",
+      decimals: 8,
+      ticker: "BTC",
+      chainId: 0,
+      contractAddress: nil
+    )
+
+    let ckRecord = btc.toCKRecord(in: zoneID)
+    #expect(ckRecord["chainId"] as? Int == 0)
+    #expect(ckRecord["contractAddress"] == nil)
+
+    let restored = InstrumentRecord.fieldValues(from: ckRecord)
+    #expect(restored.chainId == 0)
+    #expect(restored.contractAddress == nil)
+  }
+
+  @Test func instrumentRecordToDomainForStockAndCryptoKinds() {
+    let stock = InstrumentRecord(
+      id: "ASX:BHP",
+      kind: "stock",
+      name: "BHP",
+      decimals: 0,
+      ticker: "BHP.AX",
+      exchange: "ASX"
+    )
+    let stockDomain = stock.toDomain()
+    #expect(stockDomain.kind == .stock)
+    #expect(stockDomain.ticker == "BHP.AX")
+    #expect(stockDomain.exchange == "ASX")
+
+    let crypto = InstrumentRecord(
+      id: "1:native",
+      kind: "cryptoToken",
+      name: "Ethereum",
+      decimals: 18,
+      ticker: "ETH",
+      chainId: 1
+    )
+    let cryptoDomain = crypto.toDomain()
+    #expect(cryptoDomain.kind == .cryptoToken)
+    #expect(cryptoDomain.ticker == "ETH")
+    #expect(cryptoDomain.chainId == 1)
+  }
+
+  @Test func instrumentRecordUnknownKindFallsBackToFiat() {
+    // Defensive: if a future version writes an unknown kind, Record.toDomain should not crash.
+    let record = InstrumentRecord(
+      id: "XYZ",
+      kind: "notARealKind",
+      name: "Bogus",
+      decimals: 2
+    )
+    let domain = record.toDomain()
+    #expect(domain.kind == .fiatCurrency)
+  }
+
+  @Test func accountRecordRoundTripForStockInstrumentId() {
+    let account = AccountRecord(
+      id: UUID(),
+      name: "Sharesight",
+      type: "investment",
+      instrumentId: "ASX:BHP",
+      position: 0,
+      isHidden: false
+    )
+
+    let ckRecord = account.toCKRecord(in: zoneID)
+    #expect(ckRecord["instrumentId"] as? String == "ASX:BHP")
+
+    let restored = AccountRecord.fieldValues(from: ckRecord)
+    #expect(restored.instrumentId == "ASX:BHP")
+    #expect(restored.type == "investment")
+  }
+
+  @Test func accountRecordRoundTripForCryptoInstrumentId() {
+    let account = AccountRecord(
+      id: UUID(),
+      name: "Wallet",
+      type: "investment",
+      instrumentId: "1:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+      position: 0,
+      isHidden: false
+    )
+
+    let ckRecord = account.toCKRecord(in: zoneID)
+    #expect(
+      ckRecord["instrumentId"] as? String
+        == "1:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48")
+
+    let restored = AccountRecord.fieldValues(from: ckRecord)
+    #expect(restored.instrumentId == "1:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48")
+  }
+
+  @Test func transactionLegRecordRoundTripForStockInstrument() {
+    let leg = TransactionLegRecord(
+      id: UUID(),
+      transactionId: UUID(),
+      accountId: UUID(),
+      instrumentId: "ASX:BHP",
+      // 150 shares × 10^8 scale
+      quantity: 15_000_000_000,
+      type: "transfer",
+      sortOrder: 0
+    )
+
+    let ckRecord = leg.toCKRecord(in: zoneID)
+    #expect(ckRecord["instrumentId"] as? String == "ASX:BHP")
+    #expect(ckRecord["quantity"] as? Int64 == 15_000_000_000)
+
+    let restored = TransactionLegRecord.fieldValues(from: ckRecord)
+    #expect(restored.instrumentId == "ASX:BHP")
+    #expect(restored.quantity == 15_000_000_000)
+  }
+
+  @Test func transactionLegRecordRoundTripForCryptoInstrument() {
+    let leg = TransactionLegRecord(
+      id: UUID(),
+      transactionId: UUID(),
+      accountId: UUID(),
+      instrumentId: "1:native",
+      // 0.5 ETH × 10^8 scale
+      quantity: 50_000_000,
+      type: "transfer",
+      sortOrder: 0
+    )
+
+    let ckRecord = leg.toCKRecord(in: zoneID)
+    #expect(ckRecord["instrumentId"] as? String == "1:native")
+    #expect(ckRecord["quantity"] as? Int64 == 50_000_000)
+
+    let restored = TransactionLegRecord.fieldValues(from: ckRecord)
+    #expect(restored.instrumentId == "1:native")
+    #expect(restored.quantity == 50_000_000)
+  }
+
+  @Test func earmarkRecordRoundTripForNonFiatSavingsTarget() {
+    // Earmark tracking a stock or crypto target for goals like "own 100 BHP".
+    let earmark = EarmarkRecord(
+      id: UUID(),
+      name: "Stock Goal",
+      position: 0,
+      isHidden: false,
+      savingsTarget: 10_000_000_000,
+      savingsTargetInstrumentId: "ASX:BHP",
+      savingsStartDate: nil,
+      savingsEndDate: nil
+    )
+
+    let ckRecord = earmark.toCKRecord(in: zoneID)
+    #expect(ckRecord["savingsTargetInstrumentId"] as? String == "ASX:BHP")
+
+    let restored = EarmarkRecord.fieldValues(from: ckRecord)
+    #expect(restored.savingsTargetInstrumentId == "ASX:BHP")
+  }
+
+  @Test func earmarkBudgetItemRecordRoundTripForForeignInstrument() {
+    let item = EarmarkBudgetItemRecord(
+      id: UUID(),
+      earmarkId: UUID(),
+      categoryId: UUID(),
+      amount: 100_000_000_000,
+      instrumentId: "USD"
+    )
+
+    let ckRecord = item.toCKRecord(in: zoneID)
+    #expect(ckRecord["instrumentId"] as? String == "USD")
+    #expect(ckRecord["amount"] as? Int64 == 100_000_000_000)
+
+    let restored = EarmarkBudgetItemRecord.fieldValues(from: ckRecord)
+    #expect(restored.instrumentId == "USD")
+    #expect(restored.amount == 100_000_000_000)
+  }
+
   // MARK: - Record Type Strings
 
   @Test func recordTypeStrings() {


### PR DESCRIPTION
## Summary
- Fill gaps in multi-instrument test coverage where only `.defaultTestInstrument` (AUD) was exercised.
- Round-trip coverage for non-AUD accounts, earmarks, legs, and records (stock + crypto metadata).
- Cross-kind position aggregation and sort order, cross-currency transfers and swaps, cost-basis isolation per instrument.
- Conversion-service routing edge cases (JPY, high-decimal crypto, stock+crypto portfolios).
- Record mapping for crypto `chainId`/`contractAddress`, native vs ERC20, unknown-kind fallback.

## Test plan
- [x] `just test` passes locally (iOS 1078 tests / macOS 1094 tests, all green)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)