### PR TITLE
fix: require conversionService on stores to prevent mixed-instrument crash

### DIFF
--- a/App/ProfileSession.swift
+++ b/App/ProfileSession.swift
@@ -38,6 +38,9 @@ final class ProfileSession: Identifiable {
   ) {
     self.profile = profile
 
+    let exchangeRateService = ExchangeRateService(client: FrankfurterClient())
+    self.exchangeRateService = exchangeRateService
+
     let backend: BackendProvider
     switch profile.backendType {
     case .remote, .moolah:
@@ -67,11 +70,11 @@ final class ProfileSession: Identifiable {
       backend = CloudKitBackend(
         modelContainer: profileContainer,
         instrument: profile.instrument,
-        profileLabel: profile.label
+        profileLabel: profile.label,
+        conversionService: FiatConversionService(exchangeRates: exchangeRateService)
       )
     }
     self.backend = backend
-    self.exchangeRateService = ExchangeRateService(client: FrankfurterClient())
     self.stockPriceService = StockPriceService(client: YahooFinanceClient())
     let cryptoCompareClient = CryptoCompareClient()
     let binanceClient = BinanceClient { date in
@@ -121,7 +124,8 @@ final class ProfileSession: Identifiable {
     self.analysisStore = AnalysisStore(repository: backend.analysis)
     self.investmentStore = InvestmentStore(
       repository: backend.investments,
-      transactionRepository: backend.transactions
+      transactionRepository: backend.transactions,
+      conversionService: backend.conversionService
     )
     self.tradeStore = TradeStore(transactions: backend.transactions)
 

--- a/Backends/CloudKit/CloudKitBackend.swift
+++ b/Backends/CloudKit/CloudKitBackend.swift
@@ -15,17 +15,8 @@ final class CloudKitBackend: BackendProvider, @unchecked Sendable {
     modelContainer: ModelContainer,
     instrument: Instrument,
     profileLabel: String,
-    conversionService: (any InstrumentConversionService)? = nil
+    conversionService: any InstrumentConversionService
   ) {
-    let resolvedConversion: any InstrumentConversionService
-    if let conversionService {
-      resolvedConversion = conversionService
-    } else {
-      let client = FrankfurterClient()
-      let exchangeRates = ExchangeRateService(client: client)
-      resolvedConversion = FiatConversionService(exchangeRates: exchangeRates)
-    }
-
     self.auth = CloudKitAuthProvider(profileLabel: profileLabel)
     self.accounts = CloudKitAccountRepository(
       modelContainer: modelContainer)
@@ -36,9 +27,9 @@ final class CloudKitBackend: BackendProvider, @unchecked Sendable {
       modelContainer: modelContainer, instrument: instrument)
     self.analysis = CloudKitAnalysisRepository(
       modelContainer: modelContainer, instrument: instrument,
-      conversionService: resolvedConversion)
+      conversionService: conversionService)
     self.investments = CloudKitInvestmentRepository(
       modelContainer: modelContainer, instrument: instrument)
-    self.conversionService = resolvedConversion
+    self.conversionService = conversionService
   }
 }

--- a/Features/Accounts/AccountStore.swift
+++ b/Features/Accounts/AccountStore.swift
@@ -17,14 +17,14 @@ final class AccountStore {
   private(set) var investmentValues: [UUID: InstrumentAmount] = [:]
 
   private let repository: AccountRepository
-  private let conversionService: (any InstrumentConversionService)?
+  private let conversionService: any InstrumentConversionService
   private let targetInstrument: Instrument
   private let logger = Logger(subsystem: "com.moolah.app", category: "AccountStore")
   private var conversionTask: Task<Void, Never>?
 
   init(
     repository: AccountRepository,
-    conversionService: (any InstrumentConversionService)? = nil,
+    conversionService: any InstrumentConversionService,
     targetInstrument: Instrument
   ) {
     self.repository = repository
@@ -135,10 +135,6 @@ final class AccountStore {
   func computeConvertedTotal(for accountList: [Account], in target: Instrument) async throws
     -> InstrumentAmount
   {
-    guard let conversionService else {
-      return accountList.reduce(.zero(instrument: target)) { $0 + balance(for: $1.id) }
-    }
-
     var total = InstrumentAmount.zero(instrument: target)
     let date = Date()
 
@@ -159,9 +155,6 @@ final class AccountStore {
 
   /// Compute converted total for investment accounts.
   func computeConvertedInvestmentTotal(in target: Instrument) async throws -> InstrumentAmount {
-    guard let conversionService else {
-      return investmentTotal
-    }
     var total = InstrumentAmount.zero(instrument: target)
     let date = Date()
     for account in investmentAccounts {

--- a/Features/Accounts/Views/CreateAccountView.swift
+++ b/Features/Accounts/Views/CreateAccountView.swift
@@ -129,7 +129,10 @@ struct CreateAccountView: View {
 
 #Preview {
   let (backend, _) = PreviewBackend.create()
-  let accountStore = AccountStore(repository: backend.accounts, targetInstrument: .AUD)
+  let accountStore = AccountStore(
+    repository: backend.accounts,
+    conversionService: backend.conversionService,
+    targetInstrument: .AUD)
 
   CreateAccountView(
     instrument: .AUD, accountStore: accountStore,

--- a/Features/Accounts/Views/EditAccountView.swift
+++ b/Features/Accounts/Views/EditAccountView.swift
@@ -158,7 +158,10 @@ struct EditAccountView: View {
 
 #Preview {
   let (backend, _) = PreviewBackend.create()
-  let accountStore = AccountStore(repository: backend.accounts, targetInstrument: .AUD)
+  let accountStore = AccountStore(
+    repository: backend.accounts,
+    conversionService: backend.conversionService,
+    targetInstrument: .AUD)
 
   EditAccountView(
     account: Account(name: "Checking", type: .bank, instrument: .AUD),

--- a/Features/Analysis/Views/AnalysisView.swift
+++ b/Features/Analysis/Views/AnalysisView.swift
@@ -153,9 +153,15 @@ struct ForecastPicker: View {
 
 #Preview {
   let (backend, _) = PreviewBackend.create()
-  let accountStore = AccountStore(repository: backend.accounts, targetInstrument: .AUD)
+  let accountStore = AccountStore(
+    repository: backend.accounts,
+    conversionService: backend.conversionService,
+    targetInstrument: .AUD)
   let categoryStore = CategoryStore(repository: backend.categories)
-  let earmarkStore = EarmarkStore(repository: backend.earmarks, targetInstrument: .AUD)
+  let earmarkStore = EarmarkStore(
+    repository: backend.earmarks,
+    conversionService: backend.conversionService,
+    targetInstrument: .AUD)
   let transactionStore = TransactionStore(
     repository: backend.transactions,
     conversionService: backend.conversionService,

--- a/Features/Earmarks/EarmarkStore.swift
+++ b/Features/Earmarks/EarmarkStore.swift
@@ -19,14 +19,14 @@ final class EarmarkStore {
   private(set) var convertedSpentAmounts: [UUID: InstrumentAmount] = [:]
 
   private let repository: EarmarkRepository
-  private let conversionService: (any InstrumentConversionService)?
+  private let conversionService: any InstrumentConversionService
   let targetInstrument: Instrument
   private let logger = Logger(subsystem: "com.moolah.app", category: "EarmarkStore")
   private var conversionTask: Task<Void, Never>?
 
   init(
     repository: EarmarkRepository,
-    conversionService: (any InstrumentConversionService)? = nil,
+    conversionService: any InstrumentConversionService,
     targetInstrument: Instrument
   ) {
     self.repository = repository
@@ -126,30 +126,18 @@ final class EarmarkStore {
           var earmarkSpent = InstrumentAmount.zero(instrument: earmark.instrument)
 
           for position in earmark.positions {
-            guard let conversionService else {
-              earmarkBalance += position.amount
-              continue
-            }
             let converted = try await conversionService.convertAmount(
               position.amount, to: earmark.instrument, on: Date())
             guard !Task.isCancelled else { return }
             earmarkBalance += converted
           }
           for position in earmark.savedPositions {
-            guard let conversionService else {
-              earmarkSaved += position.amount
-              continue
-            }
             let converted = try await conversionService.convertAmount(
               position.amount, to: earmark.instrument, on: Date())
             guard !Task.isCancelled else { return }
             earmarkSaved += converted
           }
           for position in earmark.spentPositions {
-            guard let conversionService else {
-              earmarkSpent += position.amount
-              continue
-            }
             let converted = try await conversionService.convertAmount(
               position.amount, to: earmark.instrument, on: Date())
             guard !Task.isCancelled else { return }
@@ -163,14 +151,10 @@ final class EarmarkStore {
           // Convert earmark balance to target instrument for grand total.
           // Clamp negative balances to zero so they don't reduce the total.
           let zeroInTarget = InstrumentAmount.zero(instrument: targetInstrument)
-          if let conversionService {
-            let convertedToTarget = try await conversionService.convertAmount(
-              earmarkBalance, to: targetInstrument, on: Date())
-            guard !Task.isCancelled else { return }
-            grandTotal += max(convertedToTarget, zeroInTarget)
-          } else {
-            grandTotal += max(earmarkBalance, zeroInTarget)
-          }
+          let convertedToTarget = try await conversionService.convertAmount(
+            earmarkBalance, to: targetInstrument, on: Date())
+          guard !Task.isCancelled else { return }
+          grandTotal += max(convertedToTarget, zeroInTarget)
         }
 
         convertedBalances = balances

--- a/Features/Earmarks/Views/EarmarkDetailView.swift
+++ b/Features/Earmarks/Views/EarmarkDetailView.swift
@@ -212,7 +212,10 @@ struct EarmarkDetailView: View {
     savingsEndDate: Calendar.current.date(from: DateComponents(year: 2026, month: 12, day: 31))
   )
   let (backend, _) = PreviewBackend.create()
-  let earmarkStore = EarmarkStore(repository: backend.earmarks, targetInstrument: .AUD)
+  let earmarkStore = EarmarkStore(
+    repository: backend.earmarks,
+    conversionService: backend.conversionService,
+    targetInstrument: .AUD)
   let store = TransactionStore(
     repository: backend.transactions,
     conversionService: backend.conversionService,

--- a/Features/Earmarks/Views/EarmarkRowView.swift
+++ b/Features/Earmarks/Views/EarmarkRowView.swift
@@ -16,7 +16,10 @@ struct EarmarkRowView: View {
 
 #Preview {
   let (backend, _) = PreviewBackend.create()
-  let earmarkStore = EarmarkStore(repository: backend.earmarks, targetInstrument: .AUD)
+  let earmarkStore = EarmarkStore(
+    repository: backend.earmarks,
+    conversionService: backend.conversionService,
+    targetInstrument: .AUD)
 
   List {
     EarmarkRowView(

--- a/Features/Earmarks/Views/EarmarksView.swift
+++ b/Features/Earmarks/Views/EarmarksView.swift
@@ -214,7 +214,10 @@ struct EarmarksView: View {
 
 #Preview {
   let (backend, _) = PreviewBackend.create()
-  let earmarkStore = EarmarkStore(repository: backend.earmarks, targetInstrument: .AUD)
+  let earmarkStore = EarmarkStore(
+    repository: backend.earmarks,
+    conversionService: backend.conversionService,
+    targetInstrument: .AUD)
   let transactionStore = TransactionStore(
     repository: backend.transactions,
     conversionService: backend.conversionService,

--- a/Features/Investments/InvestmentStore.swift
+++ b/Features/Investments/InvestmentStore.swift
@@ -31,13 +31,13 @@ final class InvestmentStore {
 
   private let repository: InvestmentRepository
   private let transactionRepository: TransactionRepository?
-  private let conversionService: (any InstrumentConversionService)?
+  private let conversionService: any InstrumentConversionService
   private let logger = Logger(subsystem: "com.moolah.app", category: "InvestmentStore")
 
   init(
     repository: InvestmentRepository,
     transactionRepository: TransactionRepository? = nil,
-    conversionService: (any InstrumentConversionService)? = nil
+    conversionService: any InstrumentConversionService
   ) {
     self.repository = repository
     self.transactionRepository = transactionRepository
@@ -157,11 +157,6 @@ final class InvestmentStore {
 
   /// Valuate all loaded positions using current market prices.
   func valuatePositions(profileCurrency: Instrument, on date: Date) async {
-    guard let conversionService else {
-      valuedPositions = positions.map { ValuedPosition(position: $0, marketValue: nil) }
-      return
-    }
-
     var valued: [ValuedPosition] = []
     var total: Decimal = 0
 

--- a/Features/Navigation/SidebarView.swift
+++ b/Features/Navigation/SidebarView.swift
@@ -262,8 +262,14 @@ struct SidebarView: View {
 
 #Preview {
   let (backend, _) = PreviewBackend.create()
-  let accountStore = AccountStore(repository: backend.accounts, targetInstrument: .AUD)
-  let earmarkStore = EarmarkStore(repository: backend.earmarks, targetInstrument: .AUD)
+  let accountStore = AccountStore(
+    repository: backend.accounts,
+    conversionService: backend.conversionService,
+    targetInstrument: .AUD)
+  let earmarkStore = EarmarkStore(
+    repository: backend.earmarks,
+    conversionService: backend.conversionService,
+    targetInstrument: .AUD)
   let session = ProfileSession(profile: Profile(label: "Preview", backendType: .moolah))
 
   NavigationSplitView {

--- a/MoolahBenchmarks/BalanceDeltaBenchmarks.swift
+++ b/MoolahBenchmarks/BalanceDeltaBenchmarks.swift
@@ -124,7 +124,10 @@ final class BalanceDeltaBenchmarks: XCTestCase {
   /// Applies a single-account, single-instrument delta 100 times per iteration.
   func testAccountStoreApplyDelta() {
     let accountStore = try! awaitSync { @MainActor in
-      let store = AccountStore(repository: Self._backend.accounts, targetInstrument: .AUD)
+      let store = AccountStore(
+        repository: Self._backend.accounts,
+        conversionService: Self._backend.conversionService,
+        targetInstrument: .AUD)
       await store.load()
       return store
     }
@@ -145,7 +148,10 @@ final class BalanceDeltaBenchmarks: XCTestCase {
   /// re-fetches everything. This is the baseline we're trying to avoid.
   func testAccountReloadFromSync() {
     let accountStore = try! awaitSync { @MainActor in
-      let store = AccountStore(repository: Self._backend.accounts, targetInstrument: .AUD)
+      let store = AccountStore(
+        repository: Self._backend.accounts,
+        conversionService: Self._backend.conversionService,
+        targetInstrument: .AUD)
       await store.load()
       return store
     }
@@ -161,7 +167,10 @@ final class BalanceDeltaBenchmarks: XCTestCase {
   /// Measures reloadFromSync on EarmarkStore — how expensive the earmark reload is.
   func testEarmarkReloadFromSync() {
     let earmarkStore = try! awaitSync { @MainActor in
-      let store = EarmarkStore(repository: Self._backend.earmarks, targetInstrument: .AUD)
+      let store = EarmarkStore(
+        repository: Self._backend.earmarks,
+        conversionService: Self._backend.conversionService,
+        targetInstrument: .AUD)
       await store.load()
       return store
     }

--- a/MoolahTests/CloudKit/MultiProfileIsolationTests.swift
+++ b/MoolahTests/CloudKit/MultiProfileIsolationTests.swift
@@ -35,9 +35,11 @@ struct MultiProfileIsolationTests {
     let containerB = try manager.container(for: profileB)
 
     let backendA = CloudKitBackend(
-      modelContainer: containerA, instrument: .defaultTestInstrument, profileLabel: "A")
+      modelContainer: containerA, instrument: .defaultTestInstrument, profileLabel: "A",
+      conversionService: FixedConversionService())
     let backendB = CloudKitBackend(
-      modelContainer: containerB, instrument: .defaultTestInstrument, profileLabel: "B")
+      modelContainer: containerB, instrument: .defaultTestInstrument, profileLabel: "B",
+      conversionService: FixedConversionService())
 
     _ = try await backendA.categories.create(Moolah.Category(name: "A-Cat"))
     _ = try await backendB.categories.create(Moolah.Category(name: "B-Cat"))

--- a/MoolahTests/Export/ExportImportIntegrationTests.swift
+++ b/MoolahTests/Export/ExportImportIntegrationTests.swift
@@ -148,7 +148,8 @@ struct ExportImportIntegrationTests {
     let cloudBackend = CloudKitBackend(
       modelContainer: freshContainer,
       instrument: instrument,
-      profileLabel: "Test Profile"
+      profileLabel: "Test Profile",
+      conversionService: FixedConversionService()
     )
 
     let accounts = try await cloudBackend.accounts.fetchAll()

--- a/MoolahTests/Features/AccountStoreTests.swift
+++ b/MoolahTests/Features/AccountStoreTests.swift
@@ -32,7 +32,9 @@ struct AccountStoreTests {
   @Test func testPopulatesFromRepository() async throws {
     let (backend, container) = try TestBackend.create()
     _ = seedAccount(name: "Checking", balance: Decimal(100000) / 100, in: container)
-    let store = AccountStore(repository: backend.accounts, targetInstrument: .defaultTestInstrument)
+    let store = AccountStore(
+      repository: backend.accounts, conversionService: FixedConversionService(),
+      targetInstrument: .defaultTestInstrument)
 
     await store.load()
 
@@ -45,7 +47,9 @@ struct AccountStoreTests {
     _ = seedAccount(name: "A1", balance: Decimal(10000) / 100, position: 2, in: container)
     _ = seedAccount(
       name: "A2", type: .asset, balance: Decimal(20000) / 100, position: 1, in: container)
-    let store = AccountStore(repository: backend.accounts, targetInstrument: .defaultTestInstrument)
+    let store = AccountStore(
+      repository: backend.accounts, conversionService: FixedConversionService(),
+      targetInstrument: .defaultTestInstrument)
 
     await store.load()
 
@@ -66,7 +70,9 @@ struct AccountStoreTests {
       name: "Hidden", type: .asset, balance: Decimal(100_000_000) / 100, isHidden: true,
       in: container)
 
-    let store = AccountStore(repository: backend.accounts, targetInstrument: .defaultTestInstrument)
+    let store = AccountStore(
+      repository: backend.accounts, conversionService: FixedConversionService(),
+      targetInstrument: .defaultTestInstrument)
 
     await store.load()
 
@@ -91,7 +97,9 @@ struct AccountStoreTests {
     let (backend, container) = try TestBackend.create()
     _ = seedAccount(
       name: "Invest", type: .investment, balance: Decimal(100000) / 100, in: container)
-    let store = AccountStore(repository: backend.accounts, targetInstrument: .defaultTestInstrument)
+    let store = AccountStore(
+      repository: backend.accounts, conversionService: FixedConversionService(),
+      targetInstrument: .defaultTestInstrument)
     await store.load()
 
     let newValue = InstrumentAmount(
@@ -107,7 +115,9 @@ struct AccountStoreTests {
     let (backend, container) = try TestBackend.create()
     _ = seedAccount(
       name: "Invest", type: .investment, balance: Decimal(100000) / 100, in: container)
-    let store = AccountStore(repository: backend.accounts, targetInstrument: .defaultTestInstrument)
+    let store = AccountStore(
+      repository: backend.accounts, conversionService: FixedConversionService(),
+      targetInstrument: .defaultTestInstrument)
     await store.load()
 
     let account = store.accounts.first!
@@ -128,7 +138,9 @@ struct AccountStoreTests {
     let (backend, container) = try TestBackend.create()
     _ = seedAccount(
       name: "Invest", type: .investment, balance: Decimal(100000) / 100, in: container)
-    let store = AccountStore(repository: backend.accounts, targetInstrument: .defaultTestInstrument)
+    let store = AccountStore(
+      repository: backend.accounts, conversionService: FixedConversionService(),
+      targetInstrument: .defaultTestInstrument)
     await store.load()
 
     let newValue = InstrumentAmount(
@@ -148,7 +160,9 @@ struct AccountStoreTests {
     _ = seedAccount(name: "Visible", balance: Decimal(100000) / 100, in: container)
     _ = seedAccount(
       name: "Hidden", balance: Decimal(50000) / 100, isHidden: true, in: container)
-    let store = AccountStore(repository: backend.accounts, targetInstrument: .defaultTestInstrument)
+    let store = AccountStore(
+      repository: backend.accounts, conversionService: FixedConversionService(),
+      targetInstrument: .defaultTestInstrument)
 
     await store.load()
 
@@ -162,7 +176,9 @@ struct AccountStoreTests {
     _ = seedAccount(name: "Visible", balance: Decimal(100000) / 100, in: container)
     _ = seedAccount(
       name: "Hidden", balance: Decimal(50000) / 100, isHidden: true, in: container)
-    let store = AccountStore(repository: backend.accounts, targetInstrument: .defaultTestInstrument)
+    let store = AccountStore(
+      repository: backend.accounts, conversionService: FixedConversionService(),
+      targetInstrument: .defaultTestInstrument)
 
     await store.load()
     store.showHidden = true
@@ -178,7 +194,9 @@ struct AccountStoreTests {
     _ = seedAccount(
       name: "Hidden", type: .investment, balance: Decimal(50000) / 100, isHidden: true,
       in: container)
-    let store = AccountStore(repository: backend.accounts, targetInstrument: .defaultTestInstrument)
+    let store = AccountStore(
+      repository: backend.accounts, conversionService: FixedConversionService(),
+      targetInstrument: .defaultTestInstrument)
 
     await store.load()
 
@@ -195,7 +213,9 @@ struct AccountStoreTests {
     let (backend, container) = try TestBackend.create()
     _ = seedAccount(
       id: acctId, name: "Checking", balance: Decimal(100000) / 100, in: container)
-    let store = AccountStore(repository: backend.accounts, targetInstrument: .defaultTestInstrument)
+    let store = AccountStore(
+      repository: backend.accounts, conversionService: FixedConversionService(),
+      targetInstrument: .defaultTestInstrument)
     await store.load()
 
     let deltas: PositionDeltas = [acctId: [instrument: Decimal(-5000) / 100]]
@@ -210,7 +230,9 @@ struct AccountStoreTests {
     let (backend, container) = try TestBackend.create()
     _ = seedAccount(
       id: acctId, name: "Checking", balance: Decimal(100000) / 100, in: container)
-    let store = AccountStore(repository: backend.accounts, targetInstrument: .defaultTestInstrument)
+    let store = AccountStore(
+      repository: backend.accounts, conversionService: FixedConversionService(),
+      targetInstrument: .defaultTestInstrument)
     await store.load()
 
     let deltas: PositionDeltas = [acctId: [instrument: Decimal(50000) / 100]]
@@ -228,7 +250,9 @@ struct AccountStoreTests {
       id: checkingId, name: "Checking", balance: Decimal(100000) / 100, in: container)
     _ = seedAccount(
       id: savingsId, name: "Savings", balance: Decimal(200000) / 100, in: container)
-    let store = AccountStore(repository: backend.accounts, targetInstrument: .defaultTestInstrument)
+    let store = AccountStore(
+      repository: backend.accounts, conversionService: FixedConversionService(),
+      targetInstrument: .defaultTestInstrument)
     await store.load()
 
     let deltas: PositionDeltas = [
@@ -247,7 +271,9 @@ struct AccountStoreTests {
     let (backend, container) = try TestBackend.create()
     _ = seedAccount(
       id: checkingId, name: "Checking", balance: Decimal(100000) / 100, in: container)
-    let store = AccountStore(repository: backend.accounts, targetInstrument: .defaultTestInstrument)
+    let store = AccountStore(
+      repository: backend.accounts, conversionService: FixedConversionService(),
+      targetInstrument: .defaultTestInstrument)
     await store.load()
 
     #expect(store.currentTotal.quantity == Decimal(100000) / 100)
@@ -265,7 +291,9 @@ struct AccountStoreTests {
     let (backend, container) = try TestBackend.create()
     _ = seedAccount(
       id: acctId, name: "Checking", balance: Decimal(100000) / 100, in: container)
-    let store = AccountStore(repository: backend.accounts, targetInstrument: .defaultTestInstrument)
+    let store = AccountStore(
+      repository: backend.accounts, conversionService: FixedConversionService(),
+      targetInstrument: .defaultTestInstrument)
     await store.load()
 
     let tx = Transaction(
@@ -290,7 +318,9 @@ struct AccountStoreTests {
     let (backend, container) = try TestBackend.create()
     _ = seedAccount(
       id: acctId, name: "Checking", balance: Decimal(100000) / 100, in: container)
-    let store = AccountStore(repository: backend.accounts, targetInstrument: .defaultTestInstrument)
+    let store = AccountStore(
+      repository: backend.accounts, conversionService: FixedConversionService(),
+      targetInstrument: .defaultTestInstrument)
     await store.load()
 
     let deltas: PositionDeltas = [unknownId: [instrument: Decimal(-5000) / 100]]
@@ -366,7 +396,9 @@ struct AccountStoreTests {
     let (backend, container) = try TestBackend.create()
     _ = seedAccount(
       id: acctId, name: "Checking", balance: Decimal(100000) / 100, in: container)
-    let store = AccountStore(repository: backend.accounts, targetInstrument: .defaultTestInstrument)
+    let store = AccountStore(
+      repository: backend.accounts, conversionService: FixedConversionService(),
+      targetInstrument: .defaultTestInstrument)
     await store.load()
 
     #expect(store.balance(for: acctId).quantity == Decimal(100000) / 100)
@@ -378,7 +410,9 @@ struct AccountStoreTests {
     _ = seedAccount(
       id: acctId, name: "Invest", type: .investment, balance: Decimal(100000) / 100,
       in: container)
-    let store = AccountStore(repository: backend.accounts, targetInstrument: .defaultTestInstrument)
+    let store = AccountStore(
+      repository: backend.accounts, conversionService: FixedConversionService(),
+      targetInstrument: .defaultTestInstrument)
     await store.load()
 
     let investmentValue = InstrumentAmount(
@@ -392,7 +426,9 @@ struct AccountStoreTests {
     let acctId = UUID()
     let (backend, container) = try TestBackend.create()
     _ = seedAccount(id: acctId, name: "Empty", in: container)
-    let store = AccountStore(repository: backend.accounts, targetInstrument: .defaultTestInstrument)
+    let store = AccountStore(
+      repository: backend.accounts, conversionService: FixedConversionService(),
+      targetInstrument: .defaultTestInstrument)
     await store.load()
 
     #expect(store.canDelete(acctId))
@@ -403,7 +439,9 @@ struct AccountStoreTests {
     let (backend, container) = try TestBackend.create()
     _ = seedAccount(
       id: acctId, name: "Active", balance: Decimal(100000) / 100, in: container)
-    let store = AccountStore(repository: backend.accounts, targetInstrument: .defaultTestInstrument)
+    let store = AccountStore(
+      repository: backend.accounts, conversionService: FixedConversionService(),
+      targetInstrument: .defaultTestInstrument)
     await store.load()
 
     #expect(!store.canDelete(acctId))
@@ -413,7 +451,9 @@ struct AccountStoreTests {
 
   @Test func testCreatePersistsInstrument() async throws {
     let (backend, _) = try TestBackend.create()
-    let store = AccountStore(repository: backend.accounts, targetInstrument: .defaultTestInstrument)
+    let store = AccountStore(
+      repository: backend.accounts, conversionService: FixedConversionService(),
+      targetInstrument: .defaultTestInstrument)
     let usdInstrument = Instrument.fiat(code: "USD")
     let account = Account(
       id: UUID(), name: "USD Checking", type: .bank, instrument: usdInstrument, position: 0,
@@ -431,7 +471,9 @@ struct AccountStoreTests {
   @Test func testUpdatePersistsChangedInstrument() async throws {
     let (backend, container) = try TestBackend.create()
     let original = seedAccount(name: "Savings", in: container)
-    let store = AccountStore(repository: backend.accounts, targetInstrument: .defaultTestInstrument)
+    let store = AccountStore(
+      repository: backend.accounts, conversionService: FixedConversionService(),
+      targetInstrument: .defaultTestInstrument)
 
     let eurInstrument = Instrument.fiat(code: "EUR")
     var modified = original

--- a/MoolahTests/Features/EarmarkBudgetTests.swift
+++ b/MoolahTests/Features/EarmarkBudgetTests.swift
@@ -17,7 +17,9 @@ struct EarmarkBudgetTests {
       TestBackend.seedBudget(
         earmarkId: earmarkId, items: items, in: container)
     }
-    let store = EarmarkStore(repository: backend.earmarks, targetInstrument: .defaultTestInstrument)
+    let store = EarmarkStore(
+      repository: backend.earmarks, conversionService: FixedConversionService(),
+      targetInstrument: .defaultTestInstrument)
     await store.load()
     return (store, backend)
   }
@@ -47,7 +49,9 @@ struct EarmarkBudgetTests {
 
   @Test func testLoadBudgetHandlesError() async throws {
     let (backend, _) = try TestBackend.create()
-    let store = EarmarkStore(repository: backend.earmarks, targetInstrument: .defaultTestInstrument)
+    let store = EarmarkStore(
+      repository: backend.earmarks, conversionService: FixedConversionService(),
+      targetInstrument: .defaultTestInstrument)
     // Loading budget for nonexistent earmark still returns empty
     await store.loadBudget(earmarkId: UUID())
     #expect(store.budgetItems.isEmpty)

--- a/MoolahTests/Features/EarmarkStoreTests.swift
+++ b/MoolahTests/Features/EarmarkStoreTests.swift
@@ -15,7 +15,9 @@ struct EarmarkStoreTests {
       earmarks: [earmark],
       amounts: [earmark.id: (saved: 500, spent: 0)],
       accountId: accountId, in: container)
-    let store = EarmarkStore(repository: backend.earmarks, targetInstrument: .defaultTestInstrument)
+    let store = EarmarkStore(
+      repository: backend.earmarks, conversionService: FixedConversionService(),
+      targetInstrument: .defaultTestInstrument)
 
     await store.load()
 
@@ -35,7 +37,9 @@ struct EarmarkStoreTests {
         e2.id: (saved: 200, spent: 0),
       ],
       accountId: accountId, in: container)
-    let store = EarmarkStore(repository: backend.earmarks, targetInstrument: .defaultTestInstrument)
+    let store = EarmarkStore(
+      repository: backend.earmarks, conversionService: FixedConversionService(),
+      targetInstrument: .defaultTestInstrument)
 
     await store.load()
 
@@ -61,7 +65,9 @@ struct EarmarkStoreTests {
         e2.id: (saved: 300, spent: 0),
       ],
       accountId: accountId, in: container)
-    let store = EarmarkStore(repository: backend.earmarks, targetInstrument: .defaultTestInstrument)
+    let store = EarmarkStore(
+      repository: backend.earmarks, conversionService: FixedConversionService(),
+      targetInstrument: .defaultTestInstrument)
 
     await store.load()
 
@@ -86,7 +92,9 @@ struct EarmarkStoreTests {
       earmarks: [Earmark(id: earmarkId, name: "Holiday Fund", instrument: instrument)],
       amounts: [earmarkId: (saved: 500, spent: 0)],
       accountId: accountId, in: container)
-    let store = EarmarkStore(repository: backend.earmarks, targetInstrument: .defaultTestInstrument)
+    let store = EarmarkStore(
+      repository: backend.earmarks, conversionService: FixedConversionService(),
+      targetInstrument: .defaultTestInstrument)
     await store.load()
 
     store.applyDelta(
@@ -114,7 +122,9 @@ struct EarmarkStoreTests {
       earmarks: [Earmark(id: earmarkId, name: "Holiday Fund", instrument: instrument)],
       amounts: [earmarkId: (saved: 500, spent: 0)],
       accountId: accountId, in: container)
-    let store = EarmarkStore(repository: backend.earmarks, targetInstrument: .defaultTestInstrument)
+    let store = EarmarkStore(
+      repository: backend.earmarks, conversionService: FixedConversionService(),
+      targetInstrument: .defaultTestInstrument)
     await store.load()
 
     store.applyDelta(
@@ -148,7 +158,9 @@ struct EarmarkStoreTests {
         earmark2Id: (saved: 300, spent: 0),
       ],
       accountId: accountId, in: container)
-    let store = EarmarkStore(repository: backend.earmarks, targetInstrument: .defaultTestInstrument)
+    let store = EarmarkStore(
+      repository: backend.earmarks, conversionService: FixedConversionService(),
+      targetInstrument: .defaultTestInstrument)
     await store.load()
 
     store.applyDelta(
@@ -170,7 +182,9 @@ struct EarmarkStoreTests {
 
   @Test func testConvertedTotalBalanceNilBeforeLoad() async throws {
     let (backend, _) = try TestBackend.create()
-    let store = EarmarkStore(repository: backend.earmarks, targetInstrument: .defaultTestInstrument)
+    let store = EarmarkStore(
+      repository: backend.earmarks, conversionService: FixedConversionService(),
+      targetInstrument: .defaultTestInstrument)
 
     #expect(store.convertedTotalBalance == nil)
   }
@@ -189,7 +203,9 @@ struct EarmarkStoreTests {
       earmarks: [Earmark(id: earmarkId, name: "Holiday Fund", instrument: instrument)],
       amounts: [earmarkId: (saved: 500, spent: 0)],
       accountId: accountId, in: container)
-    let store = EarmarkStore(repository: backend.earmarks, targetInstrument: .defaultTestInstrument)
+    let store = EarmarkStore(
+      repository: backend.earmarks, conversionService: FixedConversionService(),
+      targetInstrument: .defaultTestInstrument)
 
     await store.load()
     try await Task.sleep(for: .milliseconds(50))
@@ -219,7 +235,9 @@ struct EarmarkStoreTests {
         negativeId: (saved: -18950, spent: 0),
       ],
       accountId: accountId, in: container)
-    let store = EarmarkStore(repository: backend.earmarks, targetInstrument: .defaultTestInstrument)
+    let store = EarmarkStore(
+      repository: backend.earmarks, conversionService: FixedConversionService(),
+      targetInstrument: .defaultTestInstrument)
 
     await store.load()
     try await Task.sleep(for: .milliseconds(50))
@@ -246,7 +264,9 @@ struct EarmarkStoreTests {
       earmarks: [Earmark(id: earmarkId, name: "Holiday Fund", instrument: instrument)],
       amounts: [earmarkId: (saved: 500, spent: 0)],
       accountId: accountId, in: container)
-    let store = EarmarkStore(repository: backend.earmarks, targetInstrument: .defaultTestInstrument)
+    let store = EarmarkStore(
+      repository: backend.earmarks, conversionService: FixedConversionService(),
+      targetInstrument: .defaultTestInstrument)
     await store.load()
     try await Task.sleep(for: .milliseconds(50))
     #expect(store.convertedTotalBalance?.quantity == 500)
@@ -277,7 +297,9 @@ struct EarmarkStoreTests {
       earmarks: [Earmark(id: earmarkId, name: "Holiday Fund", instrument: instrument)],
       amounts: [earmarkId: (saved: 500, spent: 0)],
       accountId: accountId, in: container)
-    let store = EarmarkStore(repository: backend.earmarks, targetInstrument: .defaultTestInstrument)
+    let store = EarmarkStore(
+      repository: backend.earmarks, conversionService: FixedConversionService(),
+      targetInstrument: .defaultTestInstrument)
 
     await store.load()
     try await Task.sleep(for: .milliseconds(50))
@@ -301,7 +323,9 @@ struct EarmarkStoreTests {
       earmarks: [Earmark(id: earmarkId, name: "Holiday Fund", instrument: instrument)],
       amounts: [earmarkId: (saved: 500, spent: 0)],
       accountId: accountId, in: container)
-    let store = EarmarkStore(repository: backend.earmarks, targetInstrument: .defaultTestInstrument)
+    let store = EarmarkStore(
+      repository: backend.earmarks, conversionService: FixedConversionService(),
+      targetInstrument: .defaultTestInstrument)
     await store.load()
     try await Task.sleep(for: .milliseconds(50))
 
@@ -324,7 +348,9 @@ struct EarmarkStoreTests {
     let e2 = Earmark(name: "Third", instrument: .defaultTestInstrument, position: 2)
     let (backend, container) = try TestBackend.create()
     TestBackend.seed(earmarks: [e0, e1, e2], in: container)
-    let store = EarmarkStore(repository: backend.earmarks, targetInstrument: .defaultTestInstrument)
+    let store = EarmarkStore(
+      repository: backend.earmarks, conversionService: FixedConversionService(),
+      targetInstrument: .defaultTestInstrument)
     await store.load()
 
     await store.reorderEarmarks(from: IndexSet(integer: 2), to: 0)
@@ -344,7 +370,9 @@ struct EarmarkStoreTests {
     let e2 = Earmark(name: "Visible2", instrument: .defaultTestInstrument, position: 2)
     let (backend, container) = try TestBackend.create()
     TestBackend.seed(earmarks: [e0, e1, e2], in: container)
-    let store = EarmarkStore(repository: backend.earmarks, targetInstrument: .defaultTestInstrument)
+    let store = EarmarkStore(
+      repository: backend.earmarks, conversionService: FixedConversionService(),
+      targetInstrument: .defaultTestInstrument)
     await store.load()
 
     await store.reorderEarmarks(from: IndexSet(integer: 1), to: 0)
@@ -359,7 +387,9 @@ struct EarmarkStoreTests {
     let e0 = Earmark(name: "Only", instrument: .defaultTestInstrument, position: 0)
     let (backend, container) = try TestBackend.create()
     TestBackend.seed(earmarks: [e0], in: container)
-    let store = EarmarkStore(repository: backend.earmarks, targetInstrument: .defaultTestInstrument)
+    let store = EarmarkStore(
+      repository: backend.earmarks, conversionService: FixedConversionService(),
+      targetInstrument: .defaultTestInstrument)
     await store.load()
 
     await store.reorderEarmarks(from: IndexSet(integer: 0), to: 0)
@@ -371,7 +401,9 @@ struct EarmarkStoreTests {
   @Test func testReorderEmptyListIsNoOp() async throws {
     let (backend, container) = try TestBackend.create()
     TestBackend.seed(earmarks: [], in: container)
-    let store = EarmarkStore(repository: backend.earmarks, targetInstrument: .defaultTestInstrument)
+    let store = EarmarkStore(
+      repository: backend.earmarks, conversionService: FixedConversionService(),
+      targetInstrument: .defaultTestInstrument)
     await store.load()
 
     await store.reorderEarmarks(from: IndexSet(integer: 0), to: 0)
@@ -385,7 +417,9 @@ struct EarmarkStoreTests {
     let e2 = Earmark(name: "Third", instrument: .defaultTestInstrument, position: 2)
     let (backend, container) = try TestBackend.create()
     TestBackend.seed(earmarks: [e0, e1, e2], in: container)
-    let store = EarmarkStore(repository: backend.earmarks, targetInstrument: .defaultTestInstrument)
+    let store = EarmarkStore(
+      repository: backend.earmarks, conversionService: FixedConversionService(),
+      targetInstrument: .defaultTestInstrument)
     await store.load()
 
     await store.reorderEarmarks(from: IndexSet(integer: 2), to: 0)
@@ -403,7 +437,9 @@ struct EarmarkStoreTests {
 
   @Test func testCreateAddsEarmark() async throws {
     let (backend, _) = try TestBackend.create()
-    let store = EarmarkStore(repository: backend.earmarks, targetInstrument: .defaultTestInstrument)
+    let store = EarmarkStore(
+      repository: backend.earmarks, conversionService: FixedConversionService(),
+      targetInstrument: .defaultTestInstrument)
 
     let earmark = Earmark(name: "New Fund", instrument: .defaultTestInstrument)
     let created = await store.create(earmark)
@@ -416,7 +452,9 @@ struct EarmarkStoreTests {
 
   @Test func testCreateReturnsNilOnFailure() async throws {
     let store = EarmarkStore(
-      repository: FailingEarmarkRepository(), targetInstrument: .defaultTestInstrument)
+      repository: FailingEarmarkRepository(),
+      conversionService: FixedConversionService(),
+      targetInstrument: .defaultTestInstrument)
 
     let result = await store.create(Earmark(name: "Fails", instrument: .defaultTestInstrument))
 
@@ -426,7 +464,9 @@ struct EarmarkStoreTests {
 
   @Test func testCreateReloadsAfterSuccess() async throws {
     let (backend, _) = try TestBackend.create()
-    let store = EarmarkStore(repository: backend.earmarks, targetInstrument: .defaultTestInstrument)
+    let store = EarmarkStore(
+      repository: backend.earmarks, conversionService: FixedConversionService(),
+      targetInstrument: .defaultTestInstrument)
 
     let e1 = Earmark(name: "First", instrument: .defaultTestInstrument)
     _ = await store.create(e1)
@@ -442,7 +482,9 @@ struct EarmarkStoreTests {
     let earmark = Earmark(name: "Holiday Fund", instrument: .defaultTestInstrument)
     let (backend, container) = try TestBackend.create()
     TestBackend.seed(earmarks: [earmark], in: container)
-    let store = EarmarkStore(repository: backend.earmarks, targetInstrument: .defaultTestInstrument)
+    let store = EarmarkStore(
+      repository: backend.earmarks, conversionService: FixedConversionService(),
+      targetInstrument: .defaultTestInstrument)
     await store.load()
 
     var modified = earmark
@@ -456,7 +498,9 @@ struct EarmarkStoreTests {
 
   @Test func testUpdateReturnsNilOnFailure() async throws {
     let store = EarmarkStore(
-      repository: FailingEarmarkRepository(), targetInstrument: .defaultTestInstrument)
+      repository: FailingEarmarkRepository(),
+      conversionService: FixedConversionService(),
+      targetInstrument: .defaultTestInstrument)
 
     let result = await store.update(Earmark(name: "Fails", instrument: .defaultTestInstrument))
 
@@ -485,7 +529,9 @@ struct EarmarkStoreTests {
         hidden.id: (saved: 300, spent: 0),
       ],
       accountId: accountId, in: container)
-    let store = EarmarkStore(repository: backend.earmarks, targetInstrument: .defaultTestInstrument)
+    let store = EarmarkStore(
+      repository: backend.earmarks, conversionService: FixedConversionService(),
+      targetInstrument: .defaultTestInstrument)
 
     await store.load()
 
@@ -512,7 +558,9 @@ struct EarmarkStoreTests {
         hidden.id: (saved: 300, spent: 0),
       ],
       accountId: accountId, in: container)
-    let store = EarmarkStore(repository: backend.earmarks, targetInstrument: .defaultTestInstrument)
+    let store = EarmarkStore(
+      repository: backend.earmarks, conversionService: FixedConversionService(),
+      targetInstrument: .defaultTestInstrument)
 
     await store.load()
     store.showHidden = true
@@ -535,7 +583,9 @@ struct EarmarkStoreTests {
       earmarks: [usdEarmark],
       amounts: [usdEarmark.id: (saved: 500, spent: 0)],
       accountId: accountId, in: container, instrument: .USD)
-    let store = EarmarkStore(repository: backend.earmarks, targetInstrument: .USD)
+    let store = EarmarkStore(
+      repository: backend.earmarks, conversionService: FixedConversionService(),
+      targetInstrument: .USD)
 
     await store.load()
     #expect(store.earmarks.count == 1)

--- a/MoolahTests/Features/InvestmentStoreTests.swift
+++ b/MoolahTests/Features/InvestmentStoreTests.swift
@@ -30,7 +30,8 @@ struct InvestmentStoreTests {
     TestBackend.seed(
       investmentValues: makeValues(accountId: accountId, count: 3), in: container
     )
-    let store = InvestmentStore(repository: backend.investments)
+    let store = InvestmentStore(
+      repository: backend.investments, conversionService: FixedConversionService())
 
     await store.loadValues(accountId: accountId)
 
@@ -46,7 +47,8 @@ struct InvestmentStoreTests {
     TestBackend.seed(
       investmentValues: makeValues(accountId: accountId, count: 5), in: container
     )
-    let store = InvestmentStore(repository: backend.investments)
+    let store = InvestmentStore(
+      repository: backend.investments, conversionService: FixedConversionService())
 
     await store.loadValues(accountId: accountId)
     #expect(store.values.count == 5)
@@ -60,7 +62,8 @@ struct InvestmentStoreTests {
   func testSetValue() async throws {
     let accountId = UUID()
     let (backend, _) = try TestBackend.create()
-    let store = InvestmentStore(repository: backend.investments)
+    let store = InvestmentStore(
+      repository: backend.investments, conversionService: FixedConversionService())
 
     let date = makeDate(year: 2024, month: 3, day: 15)
     let amount = InstrumentAmount(
@@ -87,7 +90,8 @@ struct InvestmentStoreTests {
     ]
     let (backend, container) = try TestBackend.create()
     TestBackend.seed(investmentValues: initialValues, in: container)
-    let store = InvestmentStore(repository: backend.investments)
+    let store = InvestmentStore(
+      repository: backend.investments, conversionService: FixedConversionService())
 
     await store.loadValues(accountId: accountId)
     #expect(store.values.count == 1)
@@ -115,7 +119,8 @@ struct InvestmentStoreTests {
     ]
     let (backend, container) = try TestBackend.create()
     TestBackend.seed(investmentValues: initialValues, in: container)
-    let store = InvestmentStore(repository: backend.investments)
+    let store = InvestmentStore(
+      repository: backend.investments, conversionService: FixedConversionService())
 
     await store.loadValues(accountId: accountId)
     #expect(store.values.count == 1)
@@ -144,7 +149,8 @@ struct InvestmentStoreTests {
     ]
     let (backend, container) = try TestBackend.create()
     TestBackend.seed(investmentValues: initialValues, in: container)
-    let store = InvestmentStore(repository: backend.investments)
+    let store = InvestmentStore(
+      repository: backend.investments, conversionService: FixedConversionService())
 
     await store.loadValues(accountId: accountId)
     #expect(store.values.count == 1)
@@ -156,7 +162,8 @@ struct InvestmentStoreTests {
   @Test("Remove value handles error gracefully")
   func testRemoveNonExistent() async throws {
     let (backend, _) = try TestBackend.create()
-    let store = InvestmentStore(repository: backend.investments)
+    let store = InvestmentStore(
+      repository: backend.investments, conversionService: FixedConversionService())
 
     await store.removeValue(accountId: UUID(), date: Date())
 
@@ -169,7 +176,8 @@ struct InvestmentStoreTests {
   func testSetValueFiresCallback() async throws {
     let accountId = UUID()
     let (backend, _) = try TestBackend.create()
-    let store = InvestmentStore(repository: backend.investments)
+    let store = InvestmentStore(
+      repository: backend.investments, conversionService: FixedConversionService())
 
     var receivedAccountId: UUID?
     var receivedValue: InstrumentAmount?
@@ -203,7 +211,8 @@ struct InvestmentStoreTests {
     ]
     let (backend, container) = try TestBackend.create()
     TestBackend.seed(investmentValues: initialValues, in: container)
-    let store = InvestmentStore(repository: backend.investments)
+    let store = InvestmentStore(
+      repository: backend.investments, conversionService: FixedConversionService())
     await store.loadValues(accountId: accountId)
 
     var receivedValue: InstrumentAmount?
@@ -240,7 +249,8 @@ struct InvestmentStoreTests {
     ]
     let (backend, container) = try TestBackend.create()
     TestBackend.seed(investmentValues: initialValues, in: container)
-    let store = InvestmentStore(repository: backend.investments)
+    let store = InvestmentStore(
+      repository: backend.investments, conversionService: FixedConversionService())
     await store.loadValues(accountId: accountId)
 
     var receivedValue: InstrumentAmount?? = .none
@@ -270,7 +280,8 @@ struct InvestmentStoreTests {
     ]
     let (backend, container) = try TestBackend.create()
     TestBackend.seed(investmentValues: initialValues, in: container)
-    let store = InvestmentStore(repository: backend.investments)
+    let store = InvestmentStore(
+      repository: backend.investments, conversionService: FixedConversionService())
     await store.loadValues(accountId: accountId)
 
     var receivedValue: InstrumentAmount?? = .none
@@ -307,7 +318,8 @@ struct InvestmentStoreTests {
           ]),
       ], in: container)
 
-    let store = InvestmentStore(repository: backend.investments)
+    let store = InvestmentStore(
+      repository: backend.investments, conversionService: FixedConversionService())
     await store.loadDailyBalances(accountId: accountId)
 
     #expect(store.dailyBalances.count == 2)
@@ -324,7 +336,8 @@ struct InvestmentStoreTests {
     TestBackend.seed(
       investmentValues: makeValues(accountId: accountId, count: 3), in: container
     )
-    let store = InvestmentStore(repository: backend.investments)
+    let store = InvestmentStore(
+      repository: backend.investments, conversionService: FixedConversionService())
 
     await store.loadValues(accountId: accountId)
     store.selectedPeriod = .all
@@ -473,7 +486,8 @@ struct InvestmentStoreTests {
   func testSetValueWithUSDInstrument() async throws {
     let accountId = UUID()
     let (backend, _) = try TestBackend.create()
-    let store = InvestmentStore(repository: backend.investments)
+    let store = InvestmentStore(
+      repository: backend.investments, conversionService: FixedConversionService())
     let date = makeDate(year: 2024, month: 3, day: 15)
     let amount = InstrumentAmount(quantity: Decimal(5000), instrument: .USD)
 
@@ -512,7 +526,8 @@ struct InvestmentStoreTests {
       ],
       in: container,
       instrument: .USD)
-    let store = InvestmentStore(repository: backend.investments)
+    let store = InvestmentStore(
+      repository: backend.investments, conversionService: FixedConversionService())
 
     await store.loadValues(accountId: audAccount)
     #expect(store.values.count == 1)

--- a/MoolahTests/Features/StockPositionDisplayTests.swift
+++ b/MoolahTests/Features/StockPositionDisplayTests.swift
@@ -46,7 +46,7 @@ struct StockPositionDisplayTests {
     let store = InvestmentStore(
       repository: backend.investments,
       transactionRepository: backend.transactions,
-      conversionService: nil
+      conversionService: FixedConversionService()
     )
     await store.loadPositions(accountId: accountId)
 

--- a/MoolahTests/Features/TradeFlowIntegrationTests.swift
+++ b/MoolahTests/Features/TradeFlowIntegrationTests.swift
@@ -110,7 +110,7 @@ struct TradeFlowIntegrationTests {
     let investmentStore = InvestmentStore(
       repository: backend.investments,
       transactionRepository: backend.transactions,
-      conversionService: nil
+      conversionService: FixedConversionService()
     )
 
     var draft = TradeDraft(accountId: accountId)

--- a/MoolahTests/Migration/MigrationIntegrationTests.swift
+++ b/MoolahTests/Migration/MigrationIntegrationTests.swift
@@ -128,7 +128,8 @@ struct MigrationIntegrationTests {
     let cloudBackend = CloudKitBackend(
       modelContainer: container,
       instrument: instrument,
-      profileLabel: "Test"
+      profileLabel: "Test",
+      conversionService: FixedConversionService()
     )
     let cloudAccounts = try await cloudBackend.accounts.fetchAll()
     #expect(cloudAccounts.count == exported.accounts.count)
@@ -174,7 +175,8 @@ struct MigrationIntegrationTests {
     let cloudBackend = CloudKitBackend(
       modelContainer: container,
       instrument: instrument,
-      profileLabel: "Test"
+      profileLabel: "Test",
+      conversionService: FixedConversionService()
     )
     let categories = try await cloudBackend.categories.fetchAll()
     let groceries = categories.first { $0.name == "Groceries" }
@@ -207,7 +209,8 @@ struct MigrationIntegrationTests {
     let cloudBackend = CloudKitBackend(
       modelContainer: container,
       instrument: instrument,
-      profileLabel: "Test"
+      profileLabel: "Test",
+      conversionService: FixedConversionService()
     )
     let earmarks = try await cloudBackend.earmarks.fetchAll()
     let holiday = earmarks.first { $0.name == "Holiday" }


### PR DESCRIPTION
## Summary

- `EarmarkStore.recomputeConvertedTotals()` had a `guard let conversionService else { earmarkBalance += position.amount }` fallback that crashed `InstrumentAmount.+` whenever an earmark position's instrument didn't match the earmark's. Because `MoolahTests` is app-hosted, the Swift precondition took down the whole process — what appeared as a mysterious "Moolah crashed" dialog and lingering dock icon during `just test`.
- Made `conversionService` a required, non-optional parameter on `EarmarkStore`, `AccountStore`, `InvestmentStore`, and `CloudKitBackend`. Deleted every `guard let conversionService else { ... }` branch. `AccountStore` had the same latent crash; `InvestmentStore` and `CloudKitBackend` had less-dangerous but equally confusing fallbacks (silent nil valuations / implicit network-backed `FiatConversionService` in tests).
- Updated all call sites — `ProfileSession`, previews (Analysis/Sidebar/Earmark/Account views), migration/export/multi-profile integration tests, benchmarks — to pass a conversion service explicitly. Tests use `FixedConversionService()` so they don't hit the network.

## Test plan

- [x] `just build-mac` succeeds
- [x] `just test` passes (1094 tests across macOS and iOS)
- [x] No new `~/Library/Logs/DiagnosticReports/Moolah-*.ips` crash reports generated during test runs