### PR TITLE
Unify analysis daily-balance accumulator on PositionBook

### DIFF
--- a/Backends/CloudKit/Repositories/CloudKitAnalysisRepository.swift
+++ b/Backends/CloudKit/Repositories/CloudKitAnalysisRepository.swift
@@ -233,14 +233,33 @@ final class CloudKitAnalysisRepository: AnalysisRepository, @unchecked Sendable 
       let scheduledTransactions = try await fetchTransactions(scheduled: true)
       // transactions is sorted chronologically, so .last is the most recent date
       let lastDate = transactions.last?.date ?? Date()
+
+      // Build the starting PositionBook from the same transactions that fed
+      // the legacy accumulator (currentBalance/currentInvestments/perEarmarkAmounts).
+      // PositionBook.apply tracks per-instrument positions correctly without
+      // needing to be told which rule will be used at read time — the rule
+      // controls READS via dailyBalance, not WRITES via apply.
+      var startingBook = PositionBook.empty
+      if let after {
+        let priorTransactions =
+          allTransactions
+          .filter { $0.date < after }
+          .sorted(by: { $0.date < $1.date })
+        for txn in priorTransactions {
+          startingBook.apply(txn, investmentAccountIds: investmentAccountIds)
+        }
+      }
+      for txn in transactions {
+        startingBook.apply(txn, investmentAccountIds: investmentAccountIds)
+      }
+
       scheduledBalances = try await Self.generateForecast(
         scheduled: scheduledTransactions,
+        startingBook: startingBook,
         startDate: lastDate,
         endDate: forecastUntil,
-        startingBalance: currentBalance,
-        startingPerEarmarkAmounts: perEarmarkAmounts,
-        startingInvestments: currentInvestments,
         investmentAccountIds: investmentAccountIds,
+        profileInstrument: instrument,
         conversionService: conversionService
       )
     }
@@ -656,14 +675,33 @@ final class CloudKitAnalysisRepository: AnalysisRepository, @unchecked Sendable 
     if let forecastUntil {
       // transactions is sorted chronologically, so .last is the most recent date
       let lastDate = transactions.last?.date ?? Date()
+
+      // Build the starting PositionBook from the same transactions that fed
+      // the legacy accumulator (currentBalance/currentInvestments/perEarmarkAmounts).
+      // PositionBook.apply tracks per-instrument positions correctly without
+      // needing to be told which rule will be used at read time — the rule
+      // controls READS via dailyBalance, not WRITES via apply.
+      var startingBook = PositionBook.empty
+      if let after {
+        let priorTransactions =
+          nonScheduled
+          .filter { $0.date < after }
+          .sorted(by: { $0.date < $1.date })
+        for txn in priorTransactions {
+          startingBook.apply(txn, investmentAccountIds: investmentAccountIds)
+        }
+      }
+      for txn in transactions {
+        startingBook.apply(txn, investmentAccountIds: investmentAccountIds)
+      }
+
       forecastBalances = try await generateForecast(
         scheduled: scheduled,
+        startingBook: startingBook,
         startDate: lastDate,
         endDate: forecastUntil,
-        startingBalance: currentBalance,
-        startingPerEarmarkAmounts: perEarmarkAmounts,
-        startingInvestments: currentInvestments,
         investmentAccountIds: investmentAccountIds,
+        profileInstrument: instrument,
         conversionService: conversionService
       )
     }
@@ -1087,12 +1125,11 @@ final class CloudKitAnalysisRepository: AnalysisRepository, @unchecked Sendable 
 
   private static func generateForecast(
     scheduled: [Transaction],
+    startingBook: PositionBook,
     startDate: Date,
     endDate: Date,
-    startingBalance: InstrumentAmount,
-    startingPerEarmarkAmounts: [UUID: InstrumentAmount],
-    startingInvestments: InstrumentAmount,
     investmentAccountIds: Set<UUID>,
+    profileInstrument: Instrument,
     conversionService: any InstrumentConversionService
   ) async throws -> [DailyBalance] {
     // Extrapolate instances up to endDate
@@ -1103,10 +1140,8 @@ final class CloudKitAnalysisRepository: AnalysisRepository, @unchecked Sendable 
 
     // Sort by date and apply to running balances
     instances.sort { $0.date < $1.date }
-    var balance = startingBalance
-    var perEarmarkAmounts = startingPerEarmarkAmounts
-    var investments = startingInvestments
-    let instrument = startingBalance.instrument
+    var book = startingBook
+    let instrument = profileInstrument
 
     // Scheduled transactions live in the future; exchange-rate sources can't return
     // future rates. Use today's rate as the best available estimate for forecast
@@ -1117,6 +1152,11 @@ final class CloudKitAnalysisRepository: AnalysisRepository, @unchecked Sendable 
     // The accumulator that follows is inherently sequential (each iteration
     // depends on the previous running totals), so we can't parallelise it.
     // See guides/CONCURRENCY_GUIDE.md: dynamic count → TaskGroup.
+    //
+    // After pre-conversion, every leg's instrument == profileInstrument, so
+    // `book.dailyBalance` will hit the single-instrument fast path on every
+    // call below — no extra conversion cost from the multi-instrument
+    // accumulator.
     let converted: [Transaction]
     if instances.isEmpty {
       converted = []
@@ -1140,27 +1180,15 @@ final class CloudKitAnalysisRepository: AnalysisRepository, @unchecked Sendable 
 
     var forecastBalances: [Date: DailyBalance] = [:]
     for instance in converted {
-      applyTransaction(
-        instance,
-        to: &balance,
-        investments: &investments,
-        perEarmarkAmounts: &perEarmarkAmounts,
-        instrument: instrument,
-        investmentAccountIds: investmentAccountIds,
-        investmentTransfersOnly: true
-      )
+      book.apply(instance, investmentAccountIds: investmentAccountIds)
 
       let dayKey = Calendar.current.startOfDay(for: instance.date)
-      let earmarks = clampedEarmarkTotal(perEarmarkAmounts, instrument: instrument)
-      forecastBalances[dayKey] = DailyBalance(
-        date: dayKey,
-        balance: balance,
-        earmarked: earmarks,
-        availableFunds: balance - earmarks,
-        investments: investments,
-        investmentValue: nil,
-        netWorth: balance + investments,
-        bestFit: nil,
+      forecastBalances[dayKey] = try await book.dailyBalance(
+        on: instance.date,
+        investmentAccountIds: investmentAccountIds,
+        profileInstrument: instrument,
+        rule: .investmentTransfersOnly,
+        conversionService: conversionService,
         isForecast: true
       )
     }

--- a/Backends/CloudKit/Repositories/CloudKitAnalysisRepository.swift
+++ b/Backends/CloudKit/Repositories/CloudKitAnalysisRepository.swift
@@ -415,8 +415,9 @@ final class CloudKitAnalysisRepository: AnalysisRepository, @unchecked Sendable 
 
   /// Return a copy of the transaction with every leg's quantity/instrument rewritten
   /// into the profile instrument. Used before feeding scheduled-transaction instances
-  /// into the forecast accumulator so the synchronous `applyTransaction` can assume
-  /// all legs share the profile instrument.
+  /// into the forecast accumulator so every leg already shares the profile instrument
+  /// when `PositionBook.dailyBalance` is queried (skipping the multi-instrument
+  /// conversion path on every forecast day).
   ///
   /// - Parameter date: date passed to the conversion service. For forecast use, this
   ///   is `Date()` — the current rate — because scheduled transactions have future
@@ -506,25 +507,6 @@ final class CloudKitAnalysisRepository: AnalysisRepository, @unchecked Sendable 
       investmentValues, to: &dailyBalances,
       instrument: instrument, conversionService: conversionService)
 
-    // Equivalence check (debug only, single-currency only).
-    // Multi-currency divergence is by design (Option A unifies behaviour).
-    #if DEBUG
-      let hasMultiInstrument = nonScheduled.contains { txn in
-        txn.legs.contains { $0.instrument.id != instrument.id }
-      }
-      if !hasMultiInstrument {
-        let legacy = try await computeDailyBalancesLegacy(
-          nonScheduled: nonScheduled,
-          accounts: accounts,
-          investmentValues: investmentValues,
-          after: after,
-          instrument: instrument,
-          conversionService: conversionService
-        )
-        assertDailyBalanceDictsEquivalent(new: dailyBalances, legacy: legacy)
-      }
-    #endif
-
     // Compute bestFit
     var actualBalances = dailyBalances.values.sorted { $0.date < $1.date }
     CloudKitAnalysisRepository.applyBestFit(to: &actualBalances, instrument: instrument)
@@ -550,115 +532,6 @@ final class CloudKitAnalysisRepository: AnalysisRepository, @unchecked Sendable 
 
     return actualBalances + forecastBalances
   }
-
-  #if DEBUG
-    /// Legacy implementation of the daily-balance accumulator, kept as a
-    /// correctness oracle for the PositionBook-based `computeDailyBalances`
-    /// during the migration. Single-currency only — multi-currency semantics
-    /// intentionally diverge under Option A.
-    @concurrent
-    private static func computeDailyBalancesLegacy(
-      nonScheduled: [Transaction],
-      accounts: [Account],
-      investmentValues: [(accountId: UUID, date: Date, value: InstrumentAmount)],
-      after: Date?,
-      instrument: Instrument,
-      conversionService: any InstrumentConversionService
-    ) async throws -> [Date: DailyBalance] {
-      let investmentAccountIds = Set(accounts.filter { $0.type == .investment }.map(\.id))
-      let transactions: [Transaction]
-      if let after {
-        transactions = nonScheduled.filter { $0.date >= after }.sorted(by: { $0.date < $1.date })
-      } else {
-        transactions = nonScheduled.sorted(by: { $0.date < $1.date })
-      }
-
-      var dailyBalances: [Date: DailyBalance] = [:]
-      var currentBalance: InstrumentAmount = .zero(instrument: instrument)
-      var currentInvestments: InstrumentAmount = .zero(instrument: instrument)
-      var perEarmarkAmounts: [UUID: InstrumentAmount] = [:]
-
-      if let after {
-        let priorTransactions = nonScheduled.filter { $0.date < after }
-        for txn in priorTransactions.sorted(by: { $0.date < $1.date }) {
-          applyTransaction(
-            txn,
-            to: &currentBalance,
-            investments: &currentInvestments,
-            perEarmarkAmounts: &perEarmarkAmounts,
-            instrument: instrument,
-            investmentAccountIds: investmentAccountIds,
-            investmentTransfersOnly: false
-          )
-        }
-      }
-
-      for txn in transactions {
-        applyTransaction(
-          txn,
-          to: &currentBalance,
-          investments: &currentInvestments,
-          perEarmarkAmounts: &perEarmarkAmounts,
-          instrument: instrument,
-          investmentAccountIds: investmentAccountIds,
-          investmentTransfersOnly: true
-        )
-        let dayKey = Calendar.current.startOfDay(for: txn.date)
-        let currentEarmarks = clampedEarmarkTotal(perEarmarkAmounts, instrument: instrument)
-        dailyBalances[dayKey] = DailyBalance(
-          date: dayKey,
-          balance: currentBalance,
-          earmarked: currentEarmarks,
-          availableFunds: currentBalance - currentEarmarks,
-          investments: currentInvestments,
-          investmentValue: nil,
-          netWorth: currentBalance + currentInvestments,
-          bestFit: nil,
-          isForecast: false
-        )
-      }
-
-      try await applyMultiInstrumentConversion(
-        to: &dailyBalances,
-        allTransactions: nonScheduled,
-        investmentAccountIds: investmentAccountIds,
-        instrument: instrument,
-        conversionService: conversionService
-      )
-      try await applyInvestmentValues(
-        investmentValues, to: &dailyBalances,
-        instrument: instrument, conversionService: conversionService)
-      return dailyBalances
-    }
-
-    private static func assertDailyBalanceDictsEquivalent(
-      new: [Date: DailyBalance],
-      legacy: [Date: DailyBalance],
-      file: StaticString = #file,
-      line: UInt = #line
-    ) {
-      if new.keys.sorted() != legacy.keys.sorted() {
-        assertionFailure(
-          "PositionBook daily-balance keys differ from legacy: \(new.keys.sorted().count) vs \(legacy.keys.sorted().count)",
-          file: file, line: line
-        )
-        return
-      }
-      for date in new.keys.sorted() {
-        let n = new[date]!
-        let l = legacy[date]!
-        if n.balance != l.balance || n.earmarked != l.earmarked
-          || n.availableFunds != l.availableFunds || n.investments != l.investments
-          || n.investmentValue != l.investmentValue || n.netWorth != l.netWorth
-        {
-          assertionFailure(
-            "PositionBook daily-balance diverges from legacy on \(date)\n  new: balance=\(n.balance) earmarked=\(n.earmarked) avail=\(n.availableFunds) invest=\(n.investments) value=\(String(describing: n.investmentValue)) net=\(n.netWorth)\n  legacy: balance=\(l.balance) earmarked=\(l.earmarked) avail=\(l.availableFunds) invest=\(l.investments) value=\(String(describing: l.investmentValue)) net=\(l.netWorth)",
-            file: file, line: line
-          )
-        }
-      }
-    }
-  #endif
 
   @concurrent
   private static func computeExpenseBreakdown(
@@ -815,165 +688,7 @@ final class CloudKitAnalysisRepository: AnalysisRepository, @unchecked Sendable 
     }.sorted { $0.month > $1.month }
   }
 
-  // MARK: - Multi-Instrument Net Worth
-
-  /// Recomputes daily balances using currency conversion for multi-instrument positions.
-  /// Accumulates positions per instrument, converts each to profile currency per day,
-  /// then splits into balance (bank accounts) and investments (investment accounts).
-  /// Preserves the invariant: netWorth == balance + investmentValue (or balance + investments).
-  private static func applyMultiInstrumentConversion(
-    to dailyBalances: inout [Date: DailyBalance],
-    allTransactions: [Transaction],
-    investmentAccountIds: Set<UUID>,
-    instrument: Instrument,
-    conversionService: any InstrumentConversionService
-  ) async throws {
-    guard !dailyBalances.isEmpty else { return }
-
-    // Check if any legs use a non-profile instrument; skip if single-instrument
-    let hasMultiInstrument = allTransactions.contains { txn in
-      txn.legs.contains { $0.instrument.id != instrument.id }
-    }
-    guard hasMultiInstrument else { return }
-
-    // Sort transactions chronologically
-    let sorted = allTransactions.sorted { $0.date < $1.date }
-    let calendar = Calendar(identifier: .gregorian)
-
-    // Track positions by instrument, split by bank vs investment
-    var bankPositions: [String: (quantity: Decimal, instrument: Instrument)] = [:]
-    var investmentPositions: [String: (quantity: Decimal, instrument: Instrument)] = [:]
-    var earmarkPositions: [UUID: [String: (quantity: Decimal, instrument: Instrument)]] = [:]
-
-    for txn in sorted {
-      let dayKey = calendar.startOfDay(for: txn.date)
-
-      for leg in txn.legs {
-        let isInvestment = leg.accountId.map(investmentAccountIds.contains) ?? false
-        let key = leg.instrument.id
-
-        if isInvestment {
-          investmentPositions[key, default: (0, leg.instrument)].quantity += leg.quantity
-        } else {
-          bankPositions[key, default: (0, leg.instrument)].quantity += leg.quantity
-        }
-
-        if let earmarkId = leg.earmarkId {
-          earmarkPositions[earmarkId, default: [:]][key, default: (0, leg.instrument)].quantity +=
-            leg.quantity
-        }
-      }
-
-      // Only update days that have a balance entry
-      guard dailyBalances[dayKey] != nil else { continue }
-
-      // Convert all positions to profile currency
-      var bankTotal: Decimal = 0
-      for (_, pos) in bankPositions where pos.quantity != 0 {
-        if pos.instrument.id == instrument.id {
-          bankTotal += pos.quantity
-        } else {
-          bankTotal += try await conversionService.convert(
-            pos.quantity, from: pos.instrument, to: instrument, on: txn.date)
-        }
-      }
-
-      var investTotal: Decimal = 0
-      for (_, pos) in investmentPositions where pos.quantity != 0 {
-        if pos.instrument.id == instrument.id {
-          investTotal += pos.quantity
-        } else {
-          investTotal += try await conversionService.convert(
-            pos.quantity, from: pos.instrument, to: instrument, on: txn.date)
-        }
-      }
-
-      var earmarkTotal: Decimal = 0
-      for (_, positions) in earmarkPositions {
-        var perEarmarkTotal: Decimal = 0
-        for (_, pos) in positions where pos.quantity != 0 {
-          if pos.instrument.id == instrument.id {
-            perEarmarkTotal += pos.quantity
-          } else {
-            perEarmarkTotal += try await conversionService.convert(
-              pos.quantity, from: pos.instrument, to: instrument, on: txn.date)
-          }
-        }
-        earmarkTotal += max(perEarmarkTotal, 0)
-      }
-
-      let balance = InstrumentAmount(quantity: bankTotal, instrument: instrument)
-      let investments = InstrumentAmount(quantity: investTotal, instrument: instrument)
-      let earmarked = InstrumentAmount(quantity: earmarkTotal, instrument: instrument)
-      let existing = dailyBalances[dayKey]!
-
-      dailyBalances[dayKey] = DailyBalance(
-        date: existing.date,
-        balance: balance,
-        earmarked: earmarked,
-        availableFunds: balance - earmarked,
-        investments: investments,
-        investmentValue: existing.investmentValue,
-        netWorth: balance + (existing.investmentValue ?? investments),
-        bestFit: existing.bestFit,
-        isForecast: existing.isForecast
-      )
-    }
-  }
-
   // MARK: - Static Helper Methods
-
-  /// Apply a transaction's legs to running balance totals.
-  /// Each leg is processed independently based on its type and account.
-  /// Apply a transaction's legs to running balance totals.
-  ///
-  /// - Parameter investmentTransfersOnly: When true, only `.transfer` legs on investment
-  ///   accounts affect the `investments` total (matching server's dailyProfitAndLoss
-  ///   which only counts transfers between investment/non-investment accounts).
-  ///   When false, all leg types on investment accounts count (matching server's
-  ///   selectBalance used for starting balances).
-  private static func applyTransaction(
-    _ txn: Transaction,
-    to balance: inout InstrumentAmount,
-    investments: inout InstrumentAmount,
-    perEarmarkAmounts: inout [UUID: InstrumentAmount],
-    instrument: Instrument,
-    investmentAccountIds: Set<UUID>,
-    investmentTransfersOnly: Bool = false
-  ) {
-    let zero = InstrumentAmount.zero(instrument: instrument)
-    for leg in txn.legs {
-      // Only legs with an accountId affect account balances
-      // (matching server's account_id IS NOT NULL requirement).
-      // Earmark-only legs (nil accountId) only affect the earmarked total.
-      if let accountId = leg.accountId {
-        if investmentAccountIds.contains(accountId) {
-          if !investmentTransfersOnly || leg.type == .transfer {
-            investments += leg.amount
-          }
-        } else {
-          balance += leg.amount
-        }
-      }
-      if let earmarkId = leg.earmarkId {
-        perEarmarkAmounts[earmarkId, default: zero] += leg.amount
-      }
-    }
-  }
-
-  /// Computes the earmarked total by clamping each earmark's balance to max(0).
-  /// Negative earmarks (e.g., investments) should not reduce the total.
-  private static func clampedEarmarkTotal(
-    _ perEarmark: [UUID: InstrumentAmount],
-    instrument: Instrument
-  ) -> InstrumentAmount {
-    var total = InstrumentAmount.zero(instrument: instrument)
-    let zero = InstrumentAmount.zero(instrument: instrument)
-    for (_, amount) in perEarmark {
-      total += max(amount, zero)
-    }
-    return total
-  }
 
   private static func applyInvestmentValues(
     _ investmentValues: [(accountId: UUID, date: Date, value: InstrumentAmount)],

--- a/Backends/CloudKit/Repositories/CloudKitAnalysisRepository.swift
+++ b/Backends/CloudKit/Repositories/CloudKitAnalysisRepository.swift
@@ -579,125 +579,77 @@ final class CloudKitAnalysisRepository: AnalysisRepository, @unchecked Sendable 
     conversionService: any InstrumentConversionService
   ) async throws -> [DailyBalance] {
     let investmentAccountIds = Set(accounts.filter { $0.type == .investment }.map(\.id))
+    let sorted = nonScheduled.sorted { $0.date < $1.date }
 
-    // Filter by date range and sort chronologically (sorted once, reused below)
-    let transactions: [Transaction]
-    if let after {
-      transactions = nonScheduled.filter { $0.date >= after }.sorted(by: { $0.date < $1.date })
-    } else {
-      transactions = nonScheduled.sorted(by: { $0.date < $1.date })
-    }
-
-    // Compute daily balances
+    var book = PositionBook.empty
     var dailyBalances: [Date: DailyBalance] = [:]
-    var currentBalance: InstrumentAmount = .zero(instrument: instrument)
-    var currentInvestments: InstrumentAmount = .zero(instrument: instrument)
-    var perEarmarkAmounts: [UUID: InstrumentAmount] = [:]
 
-    // If 'after' is provided, compute starting balances up to that date.
-    // Starting balance includes ALL leg types on investment accounts
-    // (matching server's selectBalance for hasInvestmentAccount).
+    // Pre-`after` priors: walk into the book with asStartingBalance: true so
+    // that non-transfer legs on investment accounts seed the transfers-only
+    // baseline. This preserves the legacy single-currency semantic:
+    // `investments` for each post-`after` day = snapshot at `after` +
+    // post-`after` transfers.
     if let after {
-      let priorTransactions = nonScheduled.filter { $0.date < after }
-      for txn in priorTransactions.sorted(by: { $0.date < $1.date }) {
-        applyTransaction(
-          txn,
-          to: &currentBalance,
-          investments: &currentInvestments,
-          perEarmarkAmounts: &perEarmarkAmounts,
-          instrument: instrument,
-          investmentAccountIds: investmentAccountIds,
-          investmentTransfersOnly: false
-        )
+      for txn in sorted where txn.date < after {
+        book.apply(
+          txn, investmentAccountIds: investmentAccountIds, asStartingBalance: true)
       }
     }
 
-    // Apply each transaction to running balances (transactions already sorted above).
-    // Only TRANSFER legs change the investment running total for daily deltas
-    // (matching server's dailyProfitAndLoss which only counts transfers
-    // between investment and non-investment accounts).
-    var lastComputeDayDate: Date?
-    var lastComputeDayKey: Date = .distantPast
-
-    for txn in transactions {
-      applyTransaction(
-        txn,
-        to: &currentBalance,
-        investments: &currentInvestments,
-        perEarmarkAmounts: &perEarmarkAmounts,
-        instrument: instrument,
+    // Post-`after` daily updates: normal accumulation. Only `.transfer` legs on
+    // investment accounts contribute to the transfers-only read.
+    for txn in sorted where after.map({ txn.date >= $0 }) ?? true {
+      book.apply(txn, investmentAccountIds: investmentAccountIds)
+      let dayKey = Calendar.current.startOfDay(for: txn.date)
+      dailyBalances[dayKey] = try await book.dailyBalance(
+        on: txn.date,
         investmentAccountIds: investmentAccountIds,
-        investmentTransfersOnly: true
-      )
-
-      let dayKey: Date
-      if let last = lastComputeDayDate, txn.date.isSameDay(as: last) {
-        dayKey = lastComputeDayKey
-      } else {
-        dayKey = Calendar.current.startOfDay(for: txn.date)
-        lastComputeDayKey = dayKey
-        lastComputeDayDate = txn.date
-      }
-      let currentEarmarks = clampedEarmarkTotal(perEarmarkAmounts, instrument: instrument)
-      dailyBalances[dayKey] = DailyBalance(
-        date: dayKey,
-        balance: currentBalance,
-        earmarked: currentEarmarks,
-        availableFunds: currentBalance - currentEarmarks,
-        investments: currentInvestments,
-        investmentValue: nil,
-        netWorth: currentBalance + currentInvestments,
-        bestFit: nil,
+        profileInstrument: instrument,
+        rule: .investmentTransfersOnly,
+        conversionService: conversionService,
         isForecast: false
       )
     }
 
-    // Convert multi-instrument positions to profile currency if needed
-    try await applyMultiInstrumentConversion(
-      to: &dailyBalances,
-      allTransactions: nonScheduled,
-      investmentAccountIds: investmentAccountIds,
-      instrument: instrument,
-      conversionService: conversionService
-    )
-
     // Apply investment values (overrides net worth with market values where available)
     try await applyInvestmentValues(
-      investmentValues, to: &dailyBalances, instrument: instrument,
-      conversionService: conversionService)
+      investmentValues, to: &dailyBalances,
+      instrument: instrument, conversionService: conversionService)
+
+    // Equivalence check (debug only, single-currency only).
+    // Multi-currency divergence is by design (Option A unifies behaviour).
+    #if DEBUG
+      let hasMultiInstrument = nonScheduled.contains { txn in
+        txn.legs.contains { $0.instrument.id != instrument.id }
+      }
+      if !hasMultiInstrument {
+        let legacy = try await computeDailyBalancesLegacy(
+          nonScheduled: nonScheduled,
+          accounts: accounts,
+          investmentValues: investmentValues,
+          after: after,
+          instrument: instrument,
+          conversionService: conversionService
+        )
+        assertDailyBalanceDictsEquivalent(new: dailyBalances, legacy: legacy)
+      }
+    #endif
 
     // Compute bestFit
     var actualBalances = dailyBalances.values.sorted { $0.date < $1.date }
     CloudKitAnalysisRepository.applyBestFit(to: &actualBalances, instrument: instrument)
 
-    // Generate forecasted balances if requested
+    // Generate forecasted balances if requested. The `book` above already
+    // holds the full position at the end of the in-window range, so we can
+    // pass it straight to `generateForecast` as the starting state.
     var forecastBalances: [DailyBalance] = []
     if let forecastUntil {
-      // transactions is sorted chronologically, so .last is the most recent date
-      let lastDate = transactions.last?.date ?? Date()
-
-      // Build the starting PositionBook from the same transactions that fed
-      // the legacy accumulator (currentBalance/currentInvestments/perEarmarkAmounts).
-      // PositionBook.apply tracks per-instrument positions correctly without
-      // needing to be told which rule will be used at read time — the rule
-      // controls READS via dailyBalance, not WRITES via apply.
-      var startingBook = PositionBook.empty
-      if let after {
-        let priorTransactions =
-          nonScheduled
-          .filter { $0.date < after }
-          .sorted(by: { $0.date < $1.date })
-        for txn in priorTransactions {
-          startingBook.apply(txn, investmentAccountIds: investmentAccountIds)
-        }
-      }
-      for txn in transactions {
-        startingBook.apply(txn, investmentAccountIds: investmentAccountIds)
-      }
-
+      let lastDate =
+        sorted.last(where: { txn in after.map({ txn.date >= $0 }) ?? true })?.date
+        ?? Date()
       forecastBalances = try await generateForecast(
         scheduled: scheduled,
-        startingBook: startingBook,
+        startingBook: book,
         startDate: lastDate,
         endDate: forecastUntil,
         investmentAccountIds: investmentAccountIds,
@@ -708,6 +660,115 @@ final class CloudKitAnalysisRepository: AnalysisRepository, @unchecked Sendable 
 
     return actualBalances + forecastBalances
   }
+
+  #if DEBUG
+    /// Legacy implementation of the daily-balance accumulator, kept as a
+    /// correctness oracle for the PositionBook-based `computeDailyBalances`
+    /// during the migration. Single-currency only — multi-currency semantics
+    /// intentionally diverge under Option A.
+    @concurrent
+    private static func computeDailyBalancesLegacy(
+      nonScheduled: [Transaction],
+      accounts: [Account],
+      investmentValues: [(accountId: UUID, date: Date, value: InstrumentAmount)],
+      after: Date?,
+      instrument: Instrument,
+      conversionService: any InstrumentConversionService
+    ) async throws -> [Date: DailyBalance] {
+      let investmentAccountIds = Set(accounts.filter { $0.type == .investment }.map(\.id))
+      let transactions: [Transaction]
+      if let after {
+        transactions = nonScheduled.filter { $0.date >= after }.sorted(by: { $0.date < $1.date })
+      } else {
+        transactions = nonScheduled.sorted(by: { $0.date < $1.date })
+      }
+
+      var dailyBalances: [Date: DailyBalance] = [:]
+      var currentBalance: InstrumentAmount = .zero(instrument: instrument)
+      var currentInvestments: InstrumentAmount = .zero(instrument: instrument)
+      var perEarmarkAmounts: [UUID: InstrumentAmount] = [:]
+
+      if let after {
+        let priorTransactions = nonScheduled.filter { $0.date < after }
+        for txn in priorTransactions.sorted(by: { $0.date < $1.date }) {
+          applyTransaction(
+            txn,
+            to: &currentBalance,
+            investments: &currentInvestments,
+            perEarmarkAmounts: &perEarmarkAmounts,
+            instrument: instrument,
+            investmentAccountIds: investmentAccountIds,
+            investmentTransfersOnly: false
+          )
+        }
+      }
+
+      for txn in transactions {
+        applyTransaction(
+          txn,
+          to: &currentBalance,
+          investments: &currentInvestments,
+          perEarmarkAmounts: &perEarmarkAmounts,
+          instrument: instrument,
+          investmentAccountIds: investmentAccountIds,
+          investmentTransfersOnly: true
+        )
+        let dayKey = Calendar.current.startOfDay(for: txn.date)
+        let currentEarmarks = clampedEarmarkTotal(perEarmarkAmounts, instrument: instrument)
+        dailyBalances[dayKey] = DailyBalance(
+          date: dayKey,
+          balance: currentBalance,
+          earmarked: currentEarmarks,
+          availableFunds: currentBalance - currentEarmarks,
+          investments: currentInvestments,
+          investmentValue: nil,
+          netWorth: currentBalance + currentInvestments,
+          bestFit: nil,
+          isForecast: false
+        )
+      }
+
+      try await applyMultiInstrumentConversion(
+        to: &dailyBalances,
+        allTransactions: nonScheduled,
+        investmentAccountIds: investmentAccountIds,
+        instrument: instrument,
+        conversionService: conversionService
+      )
+      try await applyInvestmentValues(
+        investmentValues, to: &dailyBalances,
+        instrument: instrument, conversionService: conversionService)
+      return dailyBalances
+    }
+
+    private static func assertDailyBalanceDictsEquivalent(
+      new: [Date: DailyBalance],
+      legacy: [Date: DailyBalance],
+      file: StaticString = #file,
+      line: UInt = #line
+    ) {
+      if new.keys.sorted() != legacy.keys.sorted() {
+        assertionFailure(
+          "PositionBook daily-balance keys differ from legacy: \(new.keys.sorted().count) vs \(legacy.keys.sorted().count)",
+          file: file, line: line
+        )
+        return
+      }
+      for date in new.keys.sorted() {
+        let n = new[date]!
+        let l = legacy[date]!
+        if n.balance != l.balance || n.earmarked != l.earmarked
+          || n.availableFunds != l.availableFunds || n.investments != l.investments
+          || n.investmentValue != l.investmentValue || n.netWorth != l.netWorth
+        {
+          assertionFailure(
+            "PositionBook daily-balance diverges from legacy on \(date)\n  new: balance=\(n.balance) earmarked=\(n.earmarked) avail=\(n.availableFunds) invest=\(n.investments) value=\(String(describing: n.investmentValue)) net=\(n.netWorth)\n  legacy: balance=\(l.balance) earmarked=\(l.earmarked) avail=\(l.availableFunds) invest=\(l.investments) value=\(String(describing: l.investmentValue)) net=\(l.netWorth)",
+            file: file, line: line
+          )
+        }
+      }
+    }
+  #endif
 
   @concurrent
   private static func computeExpenseBreakdown(

--- a/Backends/CloudKit/Repositories/CloudKitAnalysisRepository.swift
+++ b/Backends/CloudKit/Repositories/CloudKitAnalysisRepository.swift
@@ -134,138 +134,28 @@ final class CloudKitAnalysisRepository: AnalysisRepository, @unchecked Sendable 
     after: Date?,
     forecastUntil: Date?
   ) async throws -> [DailyBalance] {
-    // 1. Fetch all non-scheduled transactions
-    let allTransactions = try await fetchTransactions(scheduled: false)
-
-    // 2. Filter by date range and sort chronologically (sorted once, reused below)
-    let transactions = allTransactions.filter { txn in
-      guard let after else { return true }
-      return txn.date >= after
-    }.sorted(by: { $0.date < $1.date })
-
-    // 3. Get accounts to classify as current vs investment
+    // Fetch shared data on MainActor (SwiftData requirement) and split scheduled
+    // vs non-scheduled, then delegate to the off-main static computation path.
+    let allTransactions = try await fetchTransactions()
     let accounts = try await fetchAccounts()
+    let nonScheduled = allTransactions.filter { !$0.isScheduled }
+    let scheduled = allTransactions.filter { $0.isScheduled }
     let investmentAccountIds = Set(accounts.filter { $0.type == .investment }.map(\.id))
+    let investmentValues = try await fetchAllInvestmentValues(
+      investmentAccountIds: investmentAccountIds)
+    let instrument = self.instrument
+    let conversionService = self.conversionService
 
-    // 4. Compute daily balances
-    var dailyBalances: [Date: DailyBalance] = [:]
-    var currentBalance: InstrumentAmount = .zero(instrument: instrument)
-    var currentInvestments: InstrumentAmount = .zero(instrument: instrument)
-    var perEarmarkAmounts: [UUID: InstrumentAmount] = [:]
-
-    // If 'after' is provided, compute starting balances up to that date
-    if let after {
-      let priorTransactions = allTransactions.filter { $0.date < after }
-
-      for txn in priorTransactions.sorted(by: { $0.date < $1.date }) {
-        Self.applyTransaction(
-          txn,
-          to: &currentBalance,
-          investments: &currentInvestments,
-          perEarmarkAmounts: &perEarmarkAmounts,
-          instrument: instrument,
-          investmentAccountIds: investmentAccountIds,
-          investmentTransfersOnly: false
-        )
-      }
-    }
-
-    // Apply each transaction to running balances (transactions already sorted above)
-    var lastDayDate: Date?
-    var lastDayKey: Date = .distantPast
-
-    for txn in transactions {
-      Self.applyTransaction(
-        txn,
-        to: &currentBalance,
-        investments: &currentInvestments,
-        perEarmarkAmounts: &perEarmarkAmounts,
-        instrument: instrument,
-        investmentAccountIds: investmentAccountIds,
-        investmentTransfersOnly: true
-      )
-
-      let dayKey: Date
-      if let last = lastDayDate, txn.date.isSameDay(as: last) {
-        dayKey = lastDayKey
-      } else {
-        dayKey = Calendar.current.startOfDay(for: txn.date)
-        lastDayKey = dayKey
-        lastDayDate = txn.date
-      }
-      let currentEarmarks = Self.clampedEarmarkTotal(perEarmarkAmounts, instrument: instrument)
-      dailyBalances[dayKey] = DailyBalance(
-        date: dayKey,
-        balance: currentBalance,
-        earmarked: currentEarmarks,
-        availableFunds: currentBalance - currentEarmarks,
-        investments: currentInvestments,
-        investmentValue: nil,
-        netWorth: currentBalance + currentInvestments,
-        bestFit: nil,
-        isForecast: false
-      )
-    }
-
-    // 5. Convert multi-instrument positions to profile currency if needed
-    try await Self.applyMultiInstrumentConversion(
-      to: &dailyBalances,
-      allTransactions: allTransactions,
-      investmentAccountIds: investmentAccountIds,
+    return try await Self.computeDailyBalances(
+      nonScheduled: nonScheduled,
+      scheduled: scheduled,
+      accounts: accounts,
+      investmentValues: investmentValues,
+      after: after,
+      forecastUntil: forecastUntil,
       instrument: instrument,
       conversionService: conversionService
     )
-
-    // 6. Apply investment values (overrides net worth with market values where available)
-    let investmentValues = try await fetchAllInvestmentValues(
-      investmentAccountIds: investmentAccountIds)
-    try await Self.applyInvestmentValues(
-      investmentValues, to: &dailyBalances, instrument: instrument,
-      conversionService: conversionService)
-
-    // 6. Compute bestFit (linear regression on availableFunds)
-    var actualBalances = dailyBalances.values.sorted { $0.date < $1.date }
-    CloudKitAnalysisRepository.applyBestFit(to: &actualBalances, instrument: instrument)
-
-    // 7. Generate forecasted balances if requested
-    var scheduledBalances: [DailyBalance] = []
-    if let forecastUntil {
-      let scheduledTransactions = try await fetchTransactions(scheduled: true)
-      // transactions is sorted chronologically, so .last is the most recent date
-      let lastDate = transactions.last?.date ?? Date()
-
-      // Build the starting PositionBook from the same transactions that fed
-      // the legacy accumulator (currentBalance/currentInvestments/perEarmarkAmounts).
-      // PositionBook.apply tracks per-instrument positions correctly without
-      // needing to be told which rule will be used at read time — the rule
-      // controls READS via dailyBalance, not WRITES via apply.
-      var startingBook = PositionBook.empty
-      if let after {
-        let priorTransactions =
-          allTransactions
-          .filter { $0.date < after }
-          .sorted(by: { $0.date < $1.date })
-        for txn in priorTransactions {
-          startingBook.apply(txn, investmentAccountIds: investmentAccountIds)
-        }
-      }
-      for txn in transactions {
-        startingBook.apply(txn, investmentAccountIds: investmentAccountIds)
-      }
-
-      scheduledBalances = try await Self.generateForecast(
-        scheduled: scheduledTransactions,
-        startingBook: startingBook,
-        startDate: lastDate,
-        endDate: forecastUntil,
-        investmentAccountIds: investmentAccountIds,
-        profileInstrument: instrument,
-        conversionService: conversionService
-      )
-    }
-
-    // 8. Combine and return
-    return actualBalances + scheduledBalances
   }
 
   /// Fetch all investment values for the given accounts from SwiftData, sorted by date ascending.

--- a/MoolahTests/Domain/AnalysisRepositoryContractTests.swift
+++ b/MoolahTests/Domain/AnalysisRepositoryContractTests.swift
@@ -2153,6 +2153,794 @@ struct AnalysisRepositoryContractTests {
     #expect(data[0].expense.quantity == -25)
   }
 
+  // MARK: - Multi-Instrument PositionBook Coverage
+
+  @Test("holding revalues daily as exchange rate changes")
+  func holdingRevaluesDailyAsRateChanges() async throws {
+    // Profile is AUD. A USD bank account holds 100 USD from day 1 onward.
+    // The USD->AUD rate steps up across days; each day's balance.quantity
+    // must reflect the rate effective on that day.
+    let calendar = Calendar(identifier: .gregorian)
+    let day1 = calendar.date(from: DateComponents(year: 2025, month: 6, day: 1))!
+    let day2 = calendar.date(from: DateComponents(year: 2025, month: 6, day: 2))!
+    let day3 = calendar.date(from: DateComponents(year: 2025, month: 6, day: 3))!
+
+    let conversion = DateBasedFixedConversionService(rates: [
+      day1: ["USD": Decimal(string: "1.50")!],
+      day2: ["USD": Decimal(string: "1.60")!],
+      day3: ["USD": Decimal(string: "1.40")!],
+    ])
+    let backend = CloudKitAnalysisTestBackend(conversionService: conversion)
+
+    let usd = Instrument.fiat(code: "USD")
+    let usdAccount = Account(
+      id: UUID(), name: "USD Cash", type: .bank, instrument: usd)
+    _ = try await backend.accounts.create(usdAccount)
+
+    // Open the position on day1 and add small AUD-only legs on subsequent days
+    // so each day produces a daily balance entry. The USD position is unchanged
+    // across days; only the rate moves.
+    _ = try await backend.transactions.create(
+      Transaction(
+        date: day1, payee: "Open USD",
+        legs: [
+          TransactionLeg(
+            accountId: usdAccount.id, instrument: usd,
+            quantity: 100, type: .openingBalance)
+        ]))
+
+    // Touch each subsequent day with a separate (zero-impact) AUD account leg
+    // to force a daily-balance entry. Use 1c income on a separate AUD account so
+    // we don't confound the USD revaluation under test.
+    let audAccount = Account(
+      id: UUID(), name: "AUD Tip Jar", type: .bank, instrument: .defaultTestInstrument)
+    _ = try await backend.accounts.create(audAccount)
+
+    for date in [day2, day3] {
+      _ = try await backend.transactions.create(
+        Transaction(
+          date: date, payee: "Tick",
+          legs: [
+            TransactionLeg(
+              accountId: audAccount.id, instrument: .defaultTestInstrument,
+              quantity: Decimal(string: "0.01")!, type: .income)
+          ]))
+    }
+
+    let balances = try await backend.analysis.fetchDailyBalances(
+      after: nil, forecastUntil: nil)
+
+    let d1 = balances.first { $0.date == calendar.startOfDay(for: day1) }
+    let d2 = balances.first { $0.date == calendar.startOfDay(for: day2) }
+    let d3 = balances.first { $0.date == calendar.startOfDay(for: day3) }
+    #expect(d1 != nil)
+    #expect(d2 != nil)
+    #expect(d3 != nil)
+
+    // Day1: 100 USD * 1.50 = 150 AUD (no AUD leg yet)
+    #expect(d1?.balance.quantity == 150)
+    // Day2: 100 USD * 1.60 + 0.01 AUD = 160.01 AUD
+    #expect(d2?.balance.quantity == Decimal(string: "160.01"))
+    // Day3: 100 USD * 1.40 + 0.02 AUD (cumulative) = 140.02 AUD
+    #expect(d3?.balance.quantity == Decimal(string: "140.02"))
+
+    // Profile instrument throughout
+    #expect(d1?.balance.instrument == .defaultTestInstrument)
+  }
+
+  @Test("multi-currency starting balance before 'after' cutoff")
+  func multiCurrencyStartingBalanceBeforeAfter() async throws {
+    // Profile = AUD. Pre-`after` history seeds AUD/USD/EUR positions on a bank
+    // account and an investment account. After cutoff, no further activity
+    // except a single AUD leg to produce a daily-balance entry. The post-`after`
+    // balance must reflect the converted starting positions.
+    let usd = Instrument.fiat(code: "USD")
+    let eur = Instrument.fiat(code: "EUR")
+
+    let conversion = FixedConversionService(rates: [
+      "USD": Decimal(string: "1.5")!,
+      "EUR": Decimal(string: "1.7")!,
+    ])
+    let backend = CloudKitAnalysisTestBackend(conversionService: conversion)
+
+    let calendar = Calendar(identifier: .gregorian)
+    let day1 = calendar.date(from: DateComponents(year: 2025, month: 5, day: 1))!
+    let day5 = calendar.date(from: DateComponents(year: 2025, month: 5, day: 5))!
+    let day10 = calendar.date(from: DateComponents(year: 2025, month: 5, day: 10))!
+    let day15 = calendar.date(from: DateComponents(year: 2025, month: 5, day: 15))!
+    let after = calendar.date(from: DateComponents(year: 2025, month: 5, day: 30))!
+    let postCutoff = calendar.date(from: DateComponents(year: 2025, month: 5, day: 31))!
+
+    let bank = Account(
+      id: UUID(), name: "Multi Bank", type: .bank, instrument: .defaultTestInstrument)
+    _ = try await backend.accounts.create(bank)
+
+    let investment = Account(
+      id: UUID(), name: "Multi Investment", type: .investment, instrument: .defaultTestInstrument)
+    _ = try await backend.accounts.create(investment)
+
+    // Pre-`after` priors: AUD opening on bank, USD opening on investment, EUR income on bank.
+    _ = try await backend.transactions.create(
+      Transaction(
+        date: day1, payee: "AUD opening",
+        legs: [
+          TransactionLeg(
+            accountId: bank.id, instrument: .defaultTestInstrument,
+            quantity: 200, type: .openingBalance)
+        ]))
+    _ = try await backend.transactions.create(
+      Transaction(
+        date: day5, payee: "USD investment opening",
+        legs: [
+          TransactionLeg(
+            accountId: investment.id, instrument: usd,
+            quantity: 100, type: .openingBalance)
+        ]))
+    _ = try await backend.transactions.create(
+      Transaction(
+        date: day10, payee: "EUR side",
+        legs: [
+          TransactionLeg(
+            accountId: bank.id, instrument: eur,
+            quantity: 50, type: .income)
+        ]))
+    _ = try await backend.transactions.create(
+      Transaction(
+        date: day15, payee: "USD side income",
+        legs: [
+          TransactionLeg(
+            accountId: bank.id, instrument: usd,
+            quantity: 40, type: .income)
+        ]))
+
+    // Single post-`after` AUD leg so a daily balance is emitted.
+    _ = try await backend.transactions.create(
+      Transaction(
+        date: postCutoff, payee: "Tick",
+        legs: [
+          TransactionLeg(
+            accountId: bank.id, instrument: .defaultTestInstrument,
+            quantity: Decimal(string: "0.01")!, type: .income)
+        ]))
+
+    let balances = try await backend.analysis.fetchDailyBalances(
+      after: after, forecastUntil: nil)
+
+    let postKey = calendar.startOfDay(for: postCutoff)
+    let post = balances.first { $0.date == postKey }
+    #expect(post != nil)
+    // bank balance:
+    //   200 AUD + 50 EUR * 1.7 + 40 USD * 1.5 + 0.01 AUD
+    // = 200 + 85 + 60 + 0.01 = 345.01 AUD
+    #expect(post?.balance.quantity == Decimal(string: "345.01"))
+    // investments (Option A: pre-after non-transfer legs seed transfers-only):
+    //   100 USD * 1.5 = 150 AUD
+    #expect(post?.investments.quantity == 150)
+    #expect(post?.balance.instrument == .defaultTestInstrument)
+  }
+
+  @Test("multi-currency investment account with no market value record")
+  func multiCurrencyInvestmentNoMarketValue() async throws {
+    // USD-denominated investment account with deposits in USD; no market value
+    // overrides. Verify investmentValue == nil and `investments` reflects the
+    // position-tracking total (snapshot+transfer-deltas under Option A) at each
+    // day's rate.
+    let usd = Instrument.fiat(code: "USD")
+    let calendar = Calendar(identifier: .gregorian)
+    let day1 = calendar.date(from: DateComponents(year: 2025, month: 7, day: 1))!
+    let day2 = calendar.date(from: DateComponents(year: 2025, month: 7, day: 2))!
+    let day3 = calendar.date(from: DateComponents(year: 2025, month: 7, day: 3))!
+
+    let conversion = DateBasedFixedConversionService(rates: [
+      day1: ["USD": Decimal(string: "1.5")!],
+      day2: ["USD": Decimal(string: "1.6")!],
+      day3: ["USD": Decimal(string: "1.7")!],
+    ])
+    let backend = CloudKitAnalysisTestBackend(conversionService: conversion)
+
+    let bank = Account(
+      id: UUID(), name: "Bank", type: .bank, instrument: .defaultTestInstrument)
+    _ = try await backend.accounts.create(bank)
+    let investment = Account(
+      id: UUID(), name: "USD Brokerage", type: .investment, instrument: usd)
+    _ = try await backend.accounts.create(investment)
+
+    // Day1: transfer 100 AUD bank -> 100 USD investment.
+    _ = try await backend.transactions.create(
+      Transaction(
+        date: day1, payee: "Initial deposit",
+        legs: [
+          TransactionLeg(
+            accountId: bank.id, instrument: .defaultTestInstrument,
+            quantity: -100, type: .transfer),
+          TransactionLeg(
+            accountId: investment.id, instrument: usd,
+            quantity: 100, type: .transfer),
+        ]))
+    // Day2: transfer another 50 USD into the investment account.
+    _ = try await backend.transactions.create(
+      Transaction(
+        date: day2, payee: "Top up",
+        legs: [
+          TransactionLeg(
+            accountId: bank.id, instrument: .defaultTestInstrument,
+            quantity: -50, type: .transfer),
+          TransactionLeg(
+            accountId: investment.id, instrument: usd,
+            quantity: 50, type: .transfer),
+        ]))
+    // Day3: tiny AUD income to ensure a daily-balance entry on day3.
+    _ = try await backend.transactions.create(
+      Transaction(
+        date: day3, payee: "Tick",
+        legs: [
+          TransactionLeg(
+            accountId: bank.id, instrument: .defaultTestInstrument,
+            quantity: Decimal(string: "0.01")!, type: .income)
+        ]))
+
+    let balances = try await backend.analysis.fetchDailyBalances(
+      after: nil, forecastUntil: nil)
+
+    let d1 = balances.first { $0.date == calendar.startOfDay(for: day1) }
+    let d2 = balances.first { $0.date == calendar.startOfDay(for: day2) }
+    let d3 = balances.first { $0.date == calendar.startOfDay(for: day3) }
+    #expect(d1?.investmentValue == nil, "no market value records → investmentValue should be nil")
+    #expect(d2?.investmentValue == nil)
+    #expect(d3?.investmentValue == nil)
+
+    // investments converts the running USD position at each day's rate.
+    // Day1: 100 USD * 1.5 = 150 AUD; Day2: 150 USD * 1.6 = 240 AUD;
+    // Day3: 150 USD * 1.7 = 255 AUD.
+    #expect(d1?.investments.quantity == 150)
+    #expect(d2?.investments.quantity == 240)
+    #expect(d3?.investments.quantity == 255)
+
+    // netWorth uses `investments` (no override) — bank + investments.
+    // Day1: -100 AUD bank + 150 AUD investments = 50 AUD
+    #expect(d1?.netWorth.quantity == 50)
+  }
+
+  @Test("multi-currency earmark clamping")
+  func multiCurrencyEarmarkClamping() async throws {
+    // Two earmarks. Earmark A: AUD income +200, USD outflow -100. Per-earmark
+    // total = 200 AUD + (-100 USD * 1.5) = 200 - 150 = 50 AUD (positive,
+    // contributes 50 AUD to earmarkedTotal). Earmark B: USD outflow only,
+    // -50 USD * 1.5 = -75 AUD (negative, clamps to 0, does NOT subtract from
+    // total). Expected earmarkedTotal = 50 AUD (clamping is per-earmark, not
+    // global).
+    let usd = Instrument.fiat(code: "USD")
+    let conversion = FixedConversionService(rates: ["USD": Decimal(string: "1.5")!])
+    let backend = CloudKitAnalysisTestBackend(conversionService: conversion)
+
+    let bank = Account(
+      id: UUID(), name: "Bank", type: .bank, instrument: .defaultTestInstrument)
+    _ = try await backend.accounts.create(bank)
+
+    let earmarkA = Earmark(id: UUID(), name: "A", instrument: .defaultTestInstrument)
+    let earmarkB = Earmark(id: UUID(), name: "B", instrument: .defaultTestInstrument)
+    _ = try await backend.earmarks.create(earmarkA)
+    _ = try await backend.earmarks.create(earmarkB)
+
+    let calendar = Calendar(identifier: .gregorian)
+    let date = calendar.date(from: DateComponents(year: 2025, month: 8, day: 1))!
+
+    // Earmark A: AUD income 200 and USD expense -100.
+    _ = try await backend.transactions.create(
+      Transaction(
+        date: date, payee: "A: AUD income",
+        legs: [
+          TransactionLeg(
+            accountId: bank.id, instrument: .defaultTestInstrument,
+            quantity: 200, type: .income, earmarkId: earmarkA.id)
+        ]))
+    _ = try await backend.transactions.create(
+      Transaction(
+        date: date, payee: "A: USD expense",
+        legs: [
+          TransactionLeg(
+            accountId: bank.id, instrument: usd,
+            quantity: -100, type: .expense, earmarkId: earmarkA.id)
+        ]))
+    // Earmark B: USD expense only, -50 USD => -75 AUD per-earmark; clamps to 0.
+    _ = try await backend.transactions.create(
+      Transaction(
+        date: date, payee: "B: USD expense",
+        legs: [
+          TransactionLeg(
+            accountId: bank.id, instrument: usd,
+            quantity: -50, type: .expense, earmarkId: earmarkB.id)
+        ]))
+
+    let balances = try await backend.analysis.fetchDailyBalances(
+      after: nil, forecastUntil: nil)
+    let day = balances.first { $0.date == calendar.startOfDay(for: date) }
+    #expect(day != nil)
+    // Per-earmark clamping: A contributes 50, B clamps to 0. Total = 50.
+    #expect(day?.earmarked.quantity == 50)
+    #expect(day?.earmarked.instrument == .defaultTestInstrument)
+  }
+
+  @Test("multi-currency expense breakdown across months")
+  func multiCurrencyExpenseBreakdownAcrossMonths() async throws {
+    // Two categories, mixed currencies, across two financial months. Verify
+    // grouping by (categoryId, financialMonth) sums conversions correctly.
+    let usd = Instrument.fiat(code: "USD")
+    let conversion = FixedConversionService(rates: ["USD": Decimal(string: "1.5")!])
+    let backend = CloudKitAnalysisTestBackend(conversionService: conversion)
+
+    let account = Account(
+      id: UUID(), name: "Bank", type: .bank, instrument: .defaultTestInstrument)
+    _ = try await backend.accounts.create(account)
+
+    let groceries = Category(id: UUID(), name: "Groceries")
+    let transport = Category(id: UUID(), name: "Transport")
+    _ = try await backend.categories.create(groceries)
+    _ = try await backend.categories.create(transport)
+
+    let calendar = Calendar(identifier: .gregorian)
+    // monthEnd = 25 → month "202506" covers Jan 26..Feb 25 .. June covers May 26..Jun 25.
+    // Use clear non-boundary dates.
+    let mayDate = calendar.date(from: DateComponents(year: 2025, month: 5, day: 10))!  // 202505
+    let juneDate = calendar.date(from: DateComponents(year: 2025, month: 6, day: 10))!  // 202506
+
+    // May: groceries -100 USD => -150 AUD; transport -20 AUD.
+    _ = try await backend.transactions.create(
+      Transaction(
+        date: mayDate, payee: "May groc USD",
+        legs: [
+          TransactionLeg(
+            accountId: account.id, instrument: usd,
+            quantity: -100, type: .expense, categoryId: groceries.id)
+        ]))
+    _ = try await backend.transactions.create(
+      Transaction(
+        date: mayDate, payee: "May transit",
+        legs: [
+          TransactionLeg(
+            accountId: account.id, instrument: .defaultTestInstrument,
+            quantity: -20, type: .expense, categoryId: transport.id)
+        ]))
+    // June: groceries -40 AUD; transport -30 USD => -45 AUD.
+    _ = try await backend.transactions.create(
+      Transaction(
+        date: juneDate, payee: "June groc",
+        legs: [
+          TransactionLeg(
+            accountId: account.id, instrument: .defaultTestInstrument,
+            quantity: -40, type: .expense, categoryId: groceries.id)
+        ]))
+    _ = try await backend.transactions.create(
+      Transaction(
+        date: juneDate, payee: "June transit USD",
+        legs: [
+          TransactionLeg(
+            accountId: account.id, instrument: usd,
+            quantity: -30, type: .expense, categoryId: transport.id)
+        ]))
+
+    let breakdown = try await backend.analysis.fetchExpenseBreakdown(monthEnd: 25, after: nil)
+
+    // Expect 4 entries: (groceries, 202505), (transport, 202505), (groceries, 202506), (transport, 202506).
+    #expect(breakdown.count == 4)
+
+    func find(_ category: Moolah.Category, _ month: String) -> ExpenseBreakdown? {
+      breakdown.first { $0.categoryId == category.id && $0.month == month }
+    }
+
+    #expect(find(groceries, "202505")?.totalExpenses.quantity == -150)
+    #expect(find(transport, "202505")?.totalExpenses.quantity == -20)
+    #expect(find(groceries, "202506")?.totalExpenses.quantity == -40)
+    #expect(find(transport, "202506")?.totalExpenses.quantity == -45)
+    for entry in breakdown {
+      #expect(entry.totalExpenses.instrument == .defaultTestInstrument)
+    }
+  }
+
+  @Test("multi-currency income/expense with rate changes across months")
+  func multiCurrencyIncomeExpenseRateChangesAcrossMonths() async throws {
+    // Same income amount in USD on different months. Use date-based rates.
+    let usd = Instrument.fiat(code: "USD")
+    let calendar = Calendar(identifier: .gregorian)
+    let mayDate = calendar.date(from: DateComponents(year: 2025, month: 5, day: 10))!  // 202505
+    let juneDate = calendar.date(from: DateComponents(year: 2025, month: 6, day: 10))!  // 202506
+
+    let conversion = DateBasedFixedConversionService(rates: [
+      mayDate: ["USD": Decimal(string: "1.5")!],
+      juneDate: ["USD": Decimal(string: "2.0")!],
+    ])
+    let backend = CloudKitAnalysisTestBackend(conversionService: conversion)
+
+    let account = Account(
+      id: UUID(), name: "Bank", type: .bank, instrument: .defaultTestInstrument)
+    _ = try await backend.accounts.create(account)
+
+    // 100 USD income in May -> 150 AUD; 100 USD income in June -> 200 AUD.
+    _ = try await backend.transactions.create(
+      Transaction(
+        date: mayDate, payee: "May Pay USD",
+        legs: [
+          TransactionLeg(
+            accountId: account.id, instrument: usd,
+            quantity: 100, type: .income)
+        ]))
+    _ = try await backend.transactions.create(
+      Transaction(
+        date: juneDate, payee: "June Pay USD",
+        legs: [
+          TransactionLeg(
+            accountId: account.id, instrument: usd,
+            quantity: 100, type: .income)
+        ]))
+
+    let data = try await backend.analysis.fetchIncomeAndExpense(monthEnd: 25, after: nil)
+
+    let may = data.first { $0.month == "202505" }
+    let june = data.first { $0.month == "202506" }
+    #expect(may != nil)
+    #expect(june != nil)
+    #expect(may?.income.quantity == 150)
+    #expect(june?.income.quantity == 200)
+    #expect(may?.income.instrument == .defaultTestInstrument)
+    #expect(june?.income.instrument == .defaultTestInstrument)
+  }
+
+  @Test("category balances multi-currency")
+  func categoryBalancesMultiCurrencyExtended() async throws {
+    // Multiple categories with mixed currencies across a date range.
+    // Use date-based rates so different days give different conversions.
+    let usd = Instrument.fiat(code: "USD")
+    let eur = Instrument.fiat(code: "EUR")
+    let calendar = Calendar(identifier: .gregorian)
+    let day1 = calendar.date(from: DateComponents(year: 2025, month: 9, day: 1))!
+    let day5 = calendar.date(from: DateComponents(year: 2025, month: 9, day: 5))!
+    let day10 = calendar.date(from: DateComponents(year: 2025, month: 9, day: 10))!
+
+    let conversion = DateBasedFixedConversionService(rates: [
+      day1: ["USD": Decimal(string: "1.4")!, "EUR": Decimal(string: "1.6")!],
+      day5: ["USD": Decimal(string: "1.5")!, "EUR": Decimal(string: "1.7")!],
+      day10: ["USD": Decimal(string: "1.6")!, "EUR": Decimal(string: "1.8")!],
+    ])
+    let backend = CloudKitAnalysisTestBackend(conversionService: conversion)
+
+    let account = Account(
+      id: UUID(), name: "Bank", type: .bank, instrument: .defaultTestInstrument)
+    _ = try await backend.accounts.create(account)
+
+    let food = Category(id: UUID(), name: "Food")
+    let travel = Category(id: UUID(), name: "Travel")
+    _ = try await backend.categories.create(food)
+    _ = try await backend.categories.create(travel)
+
+    // Food: -100 USD on day1 (=> -140 AUD) + -50 AUD on day5 = -190 AUD.
+    _ = try await backend.transactions.create(
+      Transaction(
+        date: day1, payee: "Food USD",
+        legs: [
+          TransactionLeg(
+            accountId: account.id, instrument: usd,
+            quantity: -100, type: .expense, categoryId: food.id)
+        ]))
+    _ = try await backend.transactions.create(
+      Transaction(
+        date: day5, payee: "Food AUD",
+        legs: [
+          TransactionLeg(
+            accountId: account.id, instrument: .defaultTestInstrument,
+            quantity: -50, type: .expense, categoryId: food.id)
+        ]))
+    // Travel: -20 EUR on day5 (=> -34 AUD) + -10 EUR on day10 (=> -18 AUD) = -52 AUD.
+    _ = try await backend.transactions.create(
+      Transaction(
+        date: day5, payee: "Travel EUR",
+        legs: [
+          TransactionLeg(
+            accountId: account.id, instrument: eur,
+            quantity: -20, type: .expense, categoryId: travel.id)
+        ]))
+    _ = try await backend.transactions.create(
+      Transaction(
+        date: day10, payee: "Travel EUR",
+        legs: [
+          TransactionLeg(
+            accountId: account.id, instrument: eur,
+            quantity: -10, type: .expense, categoryId: travel.id)
+        ]))
+
+    let balances = try await backend.analysis.fetchCategoryBalances(
+      dateRange: day1...day10,
+      transactionType: .expense,
+      filters: nil
+    )
+
+    #expect(balances[food.id]?.quantity == -190)
+    #expect(balances[travel.id]?.quantity == -52)
+    #expect(balances[food.id]?.instrument == .defaultTestInstrument)
+  }
+
+  @Test("mixed bank + investment + earmark + multi-currency + rate-varying")
+  func mixedSmokeMultiCurrencyRateVarying() async throws {
+    // End-to-end smoke: combine bank + investment accounts, an earmark, USD
+    // legs, and rate variation across days. Verify per-day invariants:
+    //   netWorth = balance + (investmentValue ?? investments)
+    //   availableFunds = balance - earmarked
+    let usd = Instrument.fiat(code: "USD")
+    let calendar = Calendar(identifier: .gregorian)
+    let day1 = calendar.date(from: DateComponents(year: 2025, month: 10, day: 1))!
+    let day2 = calendar.date(from: DateComponents(year: 2025, month: 10, day: 2))!
+    let day3 = calendar.date(from: DateComponents(year: 2025, month: 10, day: 3))!
+
+    let conversion = DateBasedFixedConversionService(rates: [
+      day1: ["USD": Decimal(string: "1.4")!],
+      day2: ["USD": Decimal(string: "1.5")!],
+      day3: ["USD": Decimal(string: "1.6")!],
+    ])
+    let backend = CloudKitAnalysisTestBackend(conversionService: conversion)
+
+    let bank = Account(
+      id: UUID(), name: "Bank AUD", type: .bank, instrument: .defaultTestInstrument)
+    let investment = Account(
+      id: UUID(), name: "USD Stocks", type: .investment, instrument: usd)
+    _ = try await backend.accounts.create(bank)
+    _ = try await backend.accounts.create(investment)
+
+    let earmark = Earmark(id: UUID(), name: "Holiday", instrument: .defaultTestInstrument)
+    _ = try await backend.earmarks.create(earmark)
+
+    // Day1: Open AUD bank with 1000 AUD; +100 AUD income tagged earmark.
+    _ = try await backend.transactions.create(
+      Transaction(
+        date: day1, payee: "Open Bank",
+        legs: [
+          TransactionLeg(
+            accountId: bank.id, instrument: .defaultTestInstrument,
+            quantity: 1000, type: .openingBalance)
+        ]))
+    _ = try await backend.transactions.create(
+      Transaction(
+        date: day1, payee: "Holiday savings",
+        legs: [
+          TransactionLeg(
+            accountId: bank.id, instrument: .defaultTestInstrument,
+            quantity: 100, type: .income, earmarkId: earmark.id)
+        ]))
+    // Day2: Transfer -200 AUD to 200 USD investment.
+    _ = try await backend.transactions.create(
+      Transaction(
+        date: day2, payee: "Buy USD stocks",
+        legs: [
+          TransactionLeg(
+            accountId: bank.id, instrument: .defaultTestInstrument,
+            quantity: -200, type: .transfer),
+          TransactionLeg(
+            accountId: investment.id, instrument: usd,
+            quantity: 200, type: .transfer),
+        ]))
+    // Day3: USD expense -50 USD on bank account.
+    _ = try await backend.transactions.create(
+      Transaction(
+        date: day3, payee: "USD spend",
+        legs: [
+          TransactionLeg(
+            accountId: bank.id, instrument: usd,
+            quantity: -50, type: .expense)
+        ]))
+
+    let balances = try await backend.analysis.fetchDailyBalances(
+      after: nil, forecastUntil: nil)
+    #expect(balances.count >= 3)
+
+    // Internal consistency every day.
+    for entry in balances {
+      let expectedNet = entry.balance + (entry.investmentValue ?? entry.investments)
+      #expect(entry.netWorth == expectedNet, "netWorth invariant failed on \(entry.date)")
+      #expect(
+        entry.availableFunds == entry.balance - entry.earmarked,
+        "availableFunds invariant failed on \(entry.date)")
+      #expect(entry.balance.instrument == .defaultTestInstrument)
+    }
+
+    // Spot-check day3: bank = 1000 + 100 - 200 (AUD) + (-50 USD * 1.6 = -80 AUD)
+    //                = 820 AUD; investments (transfers-only) = 200 USD * 1.6 = 320 AUD.
+    let d3 = balances.first { $0.date == calendar.startOfDay(for: day3) }
+    #expect(d3?.balance.quantity == 820)
+    #expect(d3?.investments.quantity == 320)
+    // Earmark = 100 AUD (positive, never clamped).
+    #expect(d3?.earmarked.quantity == 100)
+  }
+
+  @Test("applyInvestmentValues override still wins on multi-currency investments")
+  func investmentValueOverrideWinsMultiCurrency() async throws {
+    // USD investment account with a USD market-value override. The override
+    // (converted to profile) must take precedence in netWorth over the
+    // position-tracking total.
+    let usd = Instrument.fiat(code: "USD")
+    let conversion = FixedConversionService(rates: ["USD": Decimal(string: "1.5")!])
+    let backend = CloudKitAnalysisTestBackend(conversionService: conversion)
+
+    let bank = Account(
+      id: UUID(), name: "Bank", type: .bank, instrument: .defaultTestInstrument)
+    let investment = Account(
+      id: UUID(), name: "USD Stocks", type: .investment, instrument: usd)
+    _ = try await backend.accounts.create(bank)
+    _ = try await backend.accounts.create(investment)
+
+    let calendar = Calendar(identifier: .gregorian)
+    let day1 = calendar.date(from: DateComponents(year: 2025, month: 11, day: 1))!
+    let day2 = calendar.date(from: DateComponents(year: 2025, month: 11, day: 2))!
+
+    // Day1 transfer -100 AUD bank -> 100 USD investment (positionTracking total
+    // for investments = 100 USD * 1.5 = 150 AUD).
+    _ = try await backend.transactions.create(
+      Transaction(
+        date: day1, payee: "Buy",
+        legs: [
+          TransactionLeg(
+            accountId: bank.id, instrument: .defaultTestInstrument,
+            quantity: -100, type: .transfer),
+          TransactionLeg(
+            accountId: investment.id, instrument: usd,
+            quantity: 100, type: .transfer),
+        ]))
+    // Day2: market value = 200 USD on investment account. Bank tick to ensure
+    // a daily-balance entry is emitted on day2.
+    try await backend.investments.setValue(
+      accountId: investment.id, date: day2,
+      value: InstrumentAmount(quantity: 200, instrument: usd)
+    )
+    _ = try await backend.transactions.create(
+      Transaction(
+        date: day2, payee: "Tick",
+        legs: [
+          TransactionLeg(
+            accountId: bank.id, instrument: .defaultTestInstrument,
+            quantity: Decimal(string: "0.01")!, type: .income)
+        ]))
+
+    let balances = try await backend.analysis.fetchDailyBalances(
+      after: nil, forecastUntil: nil)
+
+    let d2 = balances.first { $0.date == calendar.startOfDay(for: day2) }
+    #expect(d2 != nil)
+    // investmentValue override = 200 USD * 1.5 = 300 AUD.
+    #expect(d2?.investmentValue?.quantity == 300)
+    #expect(d2?.investmentValue?.instrument == .defaultTestInstrument)
+    // netWorth uses the override, NOT the position-tracking total.
+    // bank = -100 + 0.01 = -99.99 AUD; netWorth = -99.99 + 300 = 200.01 AUD.
+    #expect(d2?.netWorth.quantity == Decimal(string: "200.01"))
+    // The position-tracking total is also exposed via `investments`.
+    #expect(d2?.investments.quantity == 150)
+  }
+
+  @Test("forecast starting from multi-currency actuals")
+  func forecastFromMultiCurrencyActuals() async throws {
+    // Actuals leave a USD position on a USD investment account. A scheduled
+    // USD expense projects forward; the forecast must build from the
+    // per-instrument starting book and pre-convert the scheduled leg at Date().
+    let usd = Instrument.fiat(code: "USD")
+    let conversion = FixedConversionService(rates: ["USD": Decimal(string: "1.5")!])
+    let backend = CloudKitAnalysisTestBackend(conversionService: conversion)
+
+    let calendar = Calendar(identifier: .gregorian)
+    let today = calendar.startOfDay(for: Date())
+    let yesterday = calendar.date(byAdding: .day, value: -1, to: today)!
+    let tomorrow = calendar.date(byAdding: .day, value: 1, to: today)!
+    let nextWeek = calendar.date(byAdding: .day, value: 7, to: today)!
+
+    let bank = Account(
+      id: UUID(), name: "Bank AUD", type: .bank, instrument: .defaultTestInstrument)
+    let investment = Account(
+      id: UUID(), name: "USD Brokerage", type: .investment, instrument: usd)
+    _ = try await backend.accounts.create(bank)
+    _ = try await backend.accounts.create(investment)
+
+    // Yesterday: opening 800 AUD on bank, then transfer -300 AUD bank → 200 USD
+    // investment (rate 1.5: 300/1.5 = 200 USD). Bank ends at 500 AUD; investment
+    // holds 200 USD. The USD position is recorded in `accountsFromTransfers`
+    // so it survives into the transfers-only forecast view.
+    _ = try await backend.transactions.create(
+      Transaction(
+        date: yesterday, payee: "AUD opening",
+        legs: [
+          TransactionLeg(
+            accountId: bank.id, instrument: .defaultTestInstrument,
+            quantity: 800, type: .openingBalance)
+        ]))
+    _ = try await backend.transactions.create(
+      Transaction(
+        date: yesterday, payee: "Buy USD",
+        legs: [
+          TransactionLeg(
+            accountId: bank.id, instrument: .defaultTestInstrument,
+            quantity: -300, type: .transfer),
+          TransactionLeg(
+            accountId: investment.id, instrument: usd,
+            quantity: 200, type: .transfer),
+        ]))
+
+    // Scheduled (one-off): -50 USD expense tomorrow on the bank account.
+    _ = try await backend.transactions.create(
+      Transaction(
+        id: UUID(), date: tomorrow, payee: "USD scheduled",
+        recurPeriod: .once,
+        legs: [
+          TransactionLeg(
+            accountId: bank.id, instrument: usd,
+            quantity: -50, type: .expense)
+        ]))
+
+    let balances = try await backend.analysis.fetchDailyBalances(
+      after: nil, forecastUntil: nextWeek)
+
+    let forecastEntry = balances.first { $0.date == tomorrow && $0.isForecast }
+    #expect(forecastEntry != nil, "expected a forecast entry for tomorrow")
+    // Bank starts at 500 AUD; scheduled -50 USD is pre-converted at Date()
+    // (rate 1.5) → -75 AUD. Bank running = 500 - 75 = 425 AUD.
+    #expect(forecastEntry?.balance.quantity == 425)
+    // Investments carry the 200 USD opening from actuals: 200 USD * 1.5 = 300 AUD.
+    #expect(forecastEntry?.investments.quantity == 300)
+  }
+
+  @Test(
+    "single-currency starting balance includes pre-after non-transfer investment legs (Option A)")
+  func singleCurrencyOptionAStartingBalance() async throws {
+    // Pre-`after` non-transfer legs on an investment account (here: openingBalance
+    // and income) must seed the `investments` total, even after `after`. This
+    // pins the Option A semantic explicitly so future refactors don't break it.
+    let backend = CloudKitAnalysisTestBackend()  // single-currency (AUD only)
+
+    let bank = Account(
+      id: UUID(), name: "Bank", type: .bank, instrument: .defaultTestInstrument)
+    let investment = Account(
+      id: UUID(), name: "Investment", type: .investment, instrument: .defaultTestInstrument)
+    _ = try await backend.accounts.create(bank)
+    _ = try await backend.accounts.create(investment)
+
+    let calendar = Calendar(identifier: .gregorian)
+    let day1 = calendar.date(from: DateComponents(year: 2025, month: 12, day: 1))!
+    let day5 = calendar.date(from: DateComponents(year: 2025, month: 12, day: 5))!
+    let after = calendar.date(from: DateComponents(year: 2025, month: 12, day: 10))!
+    let day12 = calendar.date(from: DateComponents(year: 2025, month: 12, day: 12))!
+
+    // Pre-`after` non-transfer legs on the investment account: opening 500 + income 100.
+    _ = try await backend.transactions.create(
+      Transaction(
+        date: day1, payee: "Investment opening",
+        legs: [
+          TransactionLeg(
+            accountId: investment.id, instrument: .defaultTestInstrument,
+            quantity: 500, type: .openingBalance)
+        ]))
+    _ = try await backend.transactions.create(
+      Transaction(
+        date: day5, payee: "Investment dividend",
+        legs: [
+          TransactionLeg(
+            accountId: investment.id, instrument: .defaultTestInstrument,
+            quantity: 100, type: .income)
+        ]))
+    // Post-`after`: a single bank-account income on day12 to emit a daily entry.
+    _ = try await backend.transactions.create(
+      Transaction(
+        date: day12, payee: "Tick",
+        legs: [
+          TransactionLeg(
+            accountId: bank.id, instrument: .defaultTestInstrument,
+            quantity: 10, type: .income)
+        ]))
+
+    let balances = try await backend.analysis.fetchDailyBalances(
+      after: after, forecastUntil: nil)
+
+    let day = balances.first { $0.date == calendar.startOfDay(for: day12) }
+    #expect(day != nil)
+    // Option A: pre-after openingBalance + income on investment account
+    // contribute to the transfers-only baseline (snapshot at `after`).
+    // Expect investments == 600 (500 + 100), NOT 0.
+    #expect(day?.investments.quantity == 600)
+    #expect(day?.balance.quantity == 10)
+  }
+
   // MARK: - loadAll Tests
 
   @Test("loadAll returns combined results matching individual methods")

--- a/MoolahTests/Shared/PositionBookTests.swift
+++ b/MoolahTests/Shared/PositionBookTests.swift
@@ -336,6 +336,80 @@ struct PositionBookTests {
     #expect(book.accountsFromTransfers.isEmpty)
   }
 
+  // MARK: - apply(_:asStartingBalance:)
+
+  @Test("apply with asStartingBalance: true records non-transfer investment legs in transfers")
+  func startingBalanceRecordsNonTransferInvestmentLegs() async throws {
+    var book = PositionBook.empty
+    // Income on investment account, applied as a starting balance.
+    book.apply(
+      transaction(legs: [
+        TransactionLeg(
+          accountId: investmentAccount, instrument: aud, quantity: 700, type: .income)
+      ]),
+      investmentAccountIds: [investmentAccount],
+      asStartingBalance: true)
+    // Opening balance on investment account, applied as a starting balance.
+    book.apply(
+      transaction(legs: [
+        TransactionLeg(
+          accountId: investmentAccount, instrument: aud, quantity: 300,
+          type: .openingBalance)
+      ]),
+      investmentAccountIds: [investmentAccount],
+      asStartingBalance: true)
+
+    // Both legs land in `accountsFromTransfers` because asStartingBalance == true.
+    #expect(book.accountsFromTransfers[investmentAccount]?[aud] == 1_000)
+    #expect(book.accounts[investmentAccount]?[aud] == 1_000)
+
+    let conversion = FixedConversionService()
+    let result = try await book.dailyBalance(
+      on: date,
+      investmentAccountIds: [investmentAccount],
+      profileInstrument: aud,
+      rule: .investmentTransfersOnly,
+      conversionService: conversion,
+      isForecast: false
+    )
+    // .investmentTransfersOnly read sees the seeded baseline.
+    #expect(result.investments.quantity == 1_000)
+  }
+
+  @Test("apply with asStartingBalance: false (default) leaves non-transfer investment legs out")
+  func startingBalanceFalseExcludesNonTransferInvestmentLegs() {
+    var book = PositionBook.empty
+    // Default behaviour: only .transfer legs on investment accounts contribute
+    // to accountsFromTransfers. An income leg on the investment account must
+    // NOT appear in that dict.
+    book.apply(
+      transaction(legs: [
+        TransactionLeg(
+          accountId: investmentAccount, instrument: aud, quantity: 200, type: .income)
+      ]),
+      investmentAccountIds: [investmentAccount])
+
+    #expect(book.accounts[investmentAccount]?[aud] == 200)
+    #expect(book.accountsFromTransfers.isEmpty)
+  }
+
+  @Test(
+    "apply with asStartingBalance: true is a no-op for accountsFromTransfers when no investment accounts"
+  )
+  func startingBalanceNoInvestmentAccountsIsNoOp() {
+    var book = PositionBook.empty
+    // Bank-only transaction with no investment accounts at all.
+    book.apply(
+      transaction(legs: [
+        TransactionLeg(accountId: bankAccount, instrument: aud, quantity: 500, type: .income)
+      ]),
+      investmentAccountIds: [],
+      asStartingBalance: true)
+
+    #expect(book.accounts[bankAccount]?[aud] == 500)
+    #expect(book.accountsFromTransfers.isEmpty)
+  }
+
   @Test("investment-account transfer leg appears in both all-legs and transfers-only")
   func transferAppearsInBothRules() async throws {
     var book = PositionBook.empty

--- a/MoolahTests/Shared/PositionBookTests.swift
+++ b/MoolahTests/Shared/PositionBookTests.swift
@@ -1,0 +1,344 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("PositionBook Tests")
+struct PositionBookTests {
+
+  // MARK: - Test Helpers
+
+  private let bankAccount = UUID()
+  private let bankAccount2 = UUID()
+  private let investmentAccount = UUID()
+  private let earmarkA = UUID()
+  private let earmarkB = UUID()
+  private let aud = Instrument.AUD
+  private let usd = Instrument.USD
+  private let date = Date(timeIntervalSince1970: 1_700_000_000)
+
+  private func transaction(
+    id: UUID = UUID(),
+    date: Date? = nil,
+    legs: [TransactionLeg]
+  ) -> Transaction {
+    Transaction(id: id, date: date ?? self.date, legs: legs)
+  }
+
+  // MARK: - Empty / Apply
+
+  @Test("empty book has no positions")
+  func emptyBookHasNoPositions() {
+    let book = PositionBook.empty
+    #expect(book.accounts.isEmpty)
+    #expect(book.earmarks.isEmpty)
+    #expect(book.earmarksSaved.isEmpty)
+    #expect(book.earmarksSpent.isEmpty)
+    #expect(book.accountsFromTransfers.isEmpty)
+    #expect(book == PositionBook())
+  }
+
+  @Test("applying a single leg records the position")
+  func applySingleLegRecordsPosition() {
+    var book = PositionBook.empty
+    let leg = TransactionLeg(
+      accountId: bankAccount, instrument: aud, quantity: -50, type: .expense,
+      earmarkId: earmarkA)
+    book.apply(leg)
+
+    #expect(book.accounts[bankAccount]?[aud] == -50)
+    #expect(book.earmarks[earmarkA]?[aud] == -50)
+    #expect(book.earmarksSpent[earmarkA]?[aud] == 50)
+    #expect(book.earmarksSaved.isEmpty)
+    #expect(book.accountsFromTransfers.isEmpty)
+  }
+
+  @Test("applying a transaction records all its legs")
+  func applyTransactionRecordsAllLegs() {
+    var book = PositionBook.empty
+    let txn = transaction(legs: [
+      TransactionLeg(accountId: bankAccount, instrument: aud, quantity: -200, type: .transfer),
+      TransactionLeg(accountId: bankAccount2, instrument: aud, quantity: 200, type: .transfer),
+    ])
+    book.apply(txn)
+
+    #expect(book.accounts[bankAccount]?[aud] == -200)
+    #expect(book.accounts[bankAccount2]?[aud] == 200)
+  }
+
+  @Test("sign = -1 reverses an application")
+  func signMinusOneReverses() {
+    var book = PositionBook.empty
+    let leg = TransactionLeg(
+      accountId: bankAccount, instrument: aud, quantity: 100, type: .income,
+      earmarkId: earmarkA)
+    book.apply(leg, sign: 1)
+    book.apply(leg, sign: -1)
+    book.cleanZeros()
+
+    #expect(book == PositionBook.empty)
+  }
+
+  @Test("applying old-sign-negative then new-sign-positive matches BalanceDeltaCalculator")
+  func matchesBalanceDeltaCalculator() {
+    let txId = UUID()
+    let oldTxn = transaction(
+      id: txId,
+      legs: [
+        TransactionLeg(
+          accountId: bankAccount, instrument: aud, quantity: -50, type: .expense,
+          earmarkId: earmarkA)
+      ])
+    let newTxn = transaction(
+      id: txId,
+      legs: [
+        TransactionLeg(
+          accountId: bankAccount, instrument: aud, quantity: -80, type: .expense,
+          earmarkId: earmarkB),
+        TransactionLeg(
+          accountId: bankAccount2, instrument: usd, quantity: 30, type: .income,
+          earmarkId: earmarkA),
+      ])
+
+    var book = PositionBook.empty
+    book.apply(oldTxn, sign: -1)
+    book.apply(newTxn, sign: 1)
+    book.cleanZeros()
+
+    let delta = BalanceDeltaCalculator.deltas(old: oldTxn, new: newTxn)
+
+    #expect(book.accounts == delta.accountDeltas)
+    #expect(book.earmarks == delta.earmarkDeltas)
+    #expect(book.earmarksSaved == delta.earmarkSavedDeltas)
+    #expect(book.earmarksSpent == delta.earmarkSpentDeltas)
+  }
+
+  // MARK: - cleanZeros
+
+  @Test("cleanZeros removes zero-valued instruments and empty entities")
+  func cleanZerosRemovesEmpty() {
+    var book = PositionBook.empty
+    let leg = TransactionLeg(
+      accountId: bankAccount, instrument: aud, quantity: 100, type: .income)
+    book.apply(leg, sign: 1)
+    book.apply(leg, sign: -1)
+
+    // Pre-clean: zero entry exists.
+    #expect(book.accounts[bankAccount]?[aud] == 0)
+
+    book.cleanZeros()
+
+    #expect(book.accounts.isEmpty)
+  }
+
+  // MARK: - dailyBalance — single instrument
+
+  @Test("single-instrument dailyBalance returns raw quantities without conversion")
+  func singleInstrumentDailyBalanceSkipsConversion() async throws {
+    var book = PositionBook.empty
+    book.apply(
+      TransactionLeg(accountId: bankAccount, instrument: aud, quantity: 1_000, type: .income))
+    book.apply(
+      TransactionLeg(accountId: bankAccount, instrument: aud, quantity: -150, type: .expense))
+
+    // Tuned with a non-1 USD rate to prove the fast path is taken: if the
+    // conversion service were called, totals would change.
+    let conversion = FixedConversionService(rates: ["USD": 999])
+
+    let result = try await book.dailyBalance(
+      on: date,
+      investmentAccountIds: [],
+      profileInstrument: aud,
+      rule: .allLegs,
+      conversionService: conversion,
+      isForecast: false
+    )
+
+    #expect(result.balance.quantity == 850)
+    #expect(result.balance.instrument == aud)
+    #expect(result.investments.quantity == 0)
+    #expect(result.earmarked.quantity == 0)
+    #expect(result.availableFunds.quantity == 850)
+    #expect(result.netWorth.quantity == 850)
+    #expect(result.investmentValue == nil)
+    #expect(result.bestFit == nil)
+    #expect(result.isForecast == false)
+  }
+
+  // MARK: - dailyBalance — multi instrument
+
+  @Test("multi-instrument dailyBalance converts at the given date's rates")
+  func multiInstrumentDailyBalanceConverts() async throws {
+    var book = PositionBook.empty
+    // 100 AUD in bank account.
+    book.apply(
+      TransactionLeg(accountId: bankAccount, instrument: aud, quantity: 100, type: .income))
+    // 50 USD in another bank account — should be converted at 1.5 AUD/USD = 75 AUD.
+    book.apply(
+      TransactionLeg(accountId: bankAccount2, instrument: usd, quantity: 50, type: .income))
+
+    let conversion = FixedConversionService(rates: ["USD": 1.5])
+
+    let result = try await book.dailyBalance(
+      on: date,
+      investmentAccountIds: [],
+      profileInstrument: aud,
+      rule: .allLegs,
+      conversionService: conversion,
+      isForecast: false
+    )
+
+    // 100 AUD + (50 USD × 1.5) = 175 AUD
+    #expect(result.balance.quantity == 175)
+    #expect(result.balance.instrument == aud)
+  }
+
+  // MARK: - dailyBalance — earmarks
+
+  @Test("earmarks are per-earmark clamped to zero before summing")
+  func earmarksClampedPerEarmark() async throws {
+    var book = PositionBook.empty
+    // earmarkA: -200 (negative — should be clamped to 0).
+    book.apply(
+      TransactionLeg(
+        accountId: bankAccount, instrument: aud, quantity: -200, type: .expense,
+        earmarkId: earmarkA))
+    // earmarkB: +500 (positive — counted in full).
+    book.apply(
+      TransactionLeg(
+        accountId: bankAccount, instrument: aud, quantity: 500, type: .income,
+        earmarkId: earmarkB))
+
+    let conversion = FixedConversionService()
+
+    let result = try await book.dailyBalance(
+      on: date,
+      investmentAccountIds: [],
+      profileInstrument: aud,
+      rule: .allLegs,
+      conversionService: conversion,
+      isForecast: false
+    )
+
+    // earmarkA clamped to 0, earmarkB contributes 500, total = 500.
+    // (Naive sum without clamping would be -200 + 500 = 300.)
+    #expect(result.earmarked.quantity == 500)
+  }
+
+  // MARK: - dailyBalance — investment rules
+
+  @Test("allLegs rule sums all investment-account positions")
+  func allLegsRuleSumsAllInvestmentPositions() async throws {
+    var book = PositionBook.empty
+    // Transfer into investment account.
+    book.apply(
+      TransactionLeg(
+        accountId: investmentAccount, instrument: aud, quantity: 1_000, type: .transfer),
+      isInvestmentAccount: true)
+    // Expense (e.g. capital loss / fee) on investment account.
+    book.apply(
+      TransactionLeg(
+        accountId: investmentAccount, instrument: aud, quantity: -50, type: .expense),
+      isInvestmentAccount: true)
+
+    let conversion = FixedConversionService()
+
+    let result = try await book.dailyBalance(
+      on: date,
+      investmentAccountIds: [investmentAccount],
+      profileInstrument: aud,
+      rule: .allLegs,
+      conversionService: conversion,
+      isForecast: false
+    )
+
+    // .allLegs sees the full position: 1000 - 50 = 950.
+    #expect(result.investments.quantity == 950)
+    #expect(result.balance.quantity == 0)
+  }
+
+  @Test("investmentTransfersOnly rule sums only transfer-derived positions")
+  func investmentTransfersOnlyRule() async throws {
+    var book = PositionBook.empty
+    // Transfer into investment account: contributes to both dicts.
+    book.apply(
+      TransactionLeg(
+        accountId: investmentAccount, instrument: aud, quantity: 1_000, type: .transfer),
+      isInvestmentAccount: true)
+    // Income on investment account: contributes only to `accounts`.
+    book.apply(
+      TransactionLeg(
+        accountId: investmentAccount, instrument: aud, quantity: 200, type: .income),
+      isInvestmentAccount: true)
+
+    let conversion = FixedConversionService()
+
+    let result = try await book.dailyBalance(
+      on: date,
+      investmentAccountIds: [investmentAccount],
+      profileInstrument: aud,
+      rule: .investmentTransfersOnly,
+      conversionService: conversion,
+      isForecast: false
+    )
+
+    // Only the transfer counts: 1000.
+    #expect(result.investments.quantity == 1_000)
+  }
+
+  @Test("investment-account expense leg does not inflate transfers-only total")
+  func expenseDoesNotInflateTransfersOnly() async throws {
+    var book = PositionBook.empty
+    // No transfers — only an expense on the investment account.
+    book.apply(
+      TransactionLeg(
+        accountId: investmentAccount, instrument: aud, quantity: -100, type: .expense),
+      isInvestmentAccount: true)
+
+    let conversion = FixedConversionService()
+
+    let result = try await book.dailyBalance(
+      on: date,
+      investmentAccountIds: [investmentAccount],
+      profileInstrument: aud,
+      rule: .investmentTransfersOnly,
+      conversionService: conversion,
+      isForecast: false
+    )
+
+    // Expense leg never reaches accountsFromTransfers; investments total is 0.
+    #expect(result.investments.quantity == 0)
+    #expect(book.accountsFromTransfers.isEmpty)
+  }
+
+  @Test("investment-account transfer leg appears in both all-legs and transfers-only")
+  func transferAppearsInBothRules() async throws {
+    var book = PositionBook.empty
+    book.apply(
+      TransactionLeg(
+        accountId: investmentAccount, instrument: aud, quantity: 500, type: .transfer),
+      isInvestmentAccount: true)
+
+    let conversion = FixedConversionService()
+
+    let allLegs = try await book.dailyBalance(
+      on: date,
+      investmentAccountIds: [investmentAccount],
+      profileInstrument: aud,
+      rule: .allLegs,
+      conversionService: conversion,
+      isForecast: false
+    )
+    let transfersOnly = try await book.dailyBalance(
+      on: date,
+      investmentAccountIds: [investmentAccount],
+      profileInstrument: aud,
+      rule: .investmentTransfersOnly,
+      conversionService: conversion,
+      isForecast: false
+    )
+
+    #expect(allLegs.investments.quantity == 500)
+    #expect(transfersOnly.investments.quantity == 500)
+  }
+}

--- a/MoolahTests/Shared/PositionBookTests.swift
+++ b/MoolahTests/Shared/PositionBookTests.swift
@@ -38,13 +38,13 @@ struct PositionBookTests {
     #expect(book == PositionBook())
   }
 
-  @Test("applying a single leg records the position")
+  @Test("applying a single-leg transaction records the position")
   func applySingleLegRecordsPosition() {
     var book = PositionBook.empty
     let leg = TransactionLeg(
       accountId: bankAccount, instrument: aud, quantity: -50, type: .expense,
       earmarkId: earmarkA)
-    book.apply(leg)
+    book.apply(transaction(legs: [leg]))
 
     #expect(book.accounts[bankAccount]?[aud] == -50)
     #expect(book.earmarks[earmarkA]?[aud] == -50)
@@ -69,11 +69,13 @@ struct PositionBookTests {
   @Test("sign = -1 reverses an application")
   func signMinusOneReverses() {
     var book = PositionBook.empty
-    let leg = TransactionLeg(
-      accountId: bankAccount, instrument: aud, quantity: 100, type: .income,
-      earmarkId: earmarkA)
-    book.apply(leg, sign: 1)
-    book.apply(leg, sign: -1)
+    let txn = transaction(legs: [
+      TransactionLeg(
+        accountId: bankAccount, instrument: aud, quantity: 100, type: .income,
+        earmarkId: earmarkA)
+    ])
+    book.apply(txn, sign: 1)
+    book.apply(txn, sign: -1)
     book.cleanZeros()
 
     #expect(book == PositionBook.empty)
@@ -118,10 +120,11 @@ struct PositionBookTests {
   @Test("cleanZeros removes zero-valued instruments and empty entities")
   func cleanZerosRemovesEmpty() {
     var book = PositionBook.empty
-    let leg = TransactionLeg(
-      accountId: bankAccount, instrument: aud, quantity: 100, type: .income)
-    book.apply(leg, sign: 1)
-    book.apply(leg, sign: -1)
+    let txn = transaction(legs: [
+      TransactionLeg(accountId: bankAccount, instrument: aud, quantity: 100, type: .income)
+    ])
+    book.apply(txn, sign: 1)
+    book.apply(txn, sign: -1)
 
     // Pre-clean: zero entry exists.
     #expect(book.accounts[bankAccount]?[aud] == 0)
@@ -137,9 +140,13 @@ struct PositionBookTests {
   func singleInstrumentDailyBalanceSkipsConversion() async throws {
     var book = PositionBook.empty
     book.apply(
-      TransactionLeg(accountId: bankAccount, instrument: aud, quantity: 1_000, type: .income))
+      transaction(legs: [
+        TransactionLeg(accountId: bankAccount, instrument: aud, quantity: 1_000, type: .income)
+      ]))
     book.apply(
-      TransactionLeg(accountId: bankAccount, instrument: aud, quantity: -150, type: .expense))
+      transaction(legs: [
+        TransactionLeg(accountId: bankAccount, instrument: aud, quantity: -150, type: .expense)
+      ]))
 
     // Tuned with a non-1 USD rate to prove the fast path is taken: if the
     // conversion service were called, totals would change.
@@ -172,10 +179,14 @@ struct PositionBookTests {
     var book = PositionBook.empty
     // 100 AUD in bank account.
     book.apply(
-      TransactionLeg(accountId: bankAccount, instrument: aud, quantity: 100, type: .income))
+      transaction(legs: [
+        TransactionLeg(accountId: bankAccount, instrument: aud, quantity: 100, type: .income)
+      ]))
     // 50 USD in another bank account — should be converted at 1.5 AUD/USD = 75 AUD.
     book.apply(
-      TransactionLeg(accountId: bankAccount2, instrument: usd, quantity: 50, type: .income))
+      transaction(legs: [
+        TransactionLeg(accountId: bankAccount2, instrument: usd, quantity: 50, type: .income)
+      ]))
 
     let conversion = FixedConversionService(rates: ["USD": 1.5])
 
@@ -200,14 +211,18 @@ struct PositionBookTests {
     var book = PositionBook.empty
     // earmarkA: -200 (negative — should be clamped to 0).
     book.apply(
-      TransactionLeg(
-        accountId: bankAccount, instrument: aud, quantity: -200, type: .expense,
-        earmarkId: earmarkA))
+      transaction(legs: [
+        TransactionLeg(
+          accountId: bankAccount, instrument: aud, quantity: -200, type: .expense,
+          earmarkId: earmarkA)
+      ]))
     // earmarkB: +500 (positive — counted in full).
     book.apply(
-      TransactionLeg(
-        accountId: bankAccount, instrument: aud, quantity: 500, type: .income,
-        earmarkId: earmarkB))
+      transaction(legs: [
+        TransactionLeg(
+          accountId: bankAccount, instrument: aud, quantity: 500, type: .income,
+          earmarkId: earmarkB)
+      ]))
 
     let conversion = FixedConversionService()
 
@@ -232,14 +247,18 @@ struct PositionBookTests {
     var book = PositionBook.empty
     // Transfer into investment account.
     book.apply(
-      TransactionLeg(
-        accountId: investmentAccount, instrument: aud, quantity: 1_000, type: .transfer),
-      isInvestmentAccount: true)
+      transaction(legs: [
+        TransactionLeg(
+          accountId: investmentAccount, instrument: aud, quantity: 1_000, type: .transfer)
+      ]),
+      investmentAccountIds: [investmentAccount])
     // Expense (e.g. capital loss / fee) on investment account.
     book.apply(
-      TransactionLeg(
-        accountId: investmentAccount, instrument: aud, quantity: -50, type: .expense),
-      isInvestmentAccount: true)
+      transaction(legs: [
+        TransactionLeg(
+          accountId: investmentAccount, instrument: aud, quantity: -50, type: .expense)
+      ]),
+      investmentAccountIds: [investmentAccount])
 
     let conversion = FixedConversionService()
 
@@ -262,14 +281,18 @@ struct PositionBookTests {
     var book = PositionBook.empty
     // Transfer into investment account: contributes to both dicts.
     book.apply(
-      TransactionLeg(
-        accountId: investmentAccount, instrument: aud, quantity: 1_000, type: .transfer),
-      isInvestmentAccount: true)
+      transaction(legs: [
+        TransactionLeg(
+          accountId: investmentAccount, instrument: aud, quantity: 1_000, type: .transfer)
+      ]),
+      investmentAccountIds: [investmentAccount])
     // Income on investment account: contributes only to `accounts`.
     book.apply(
-      TransactionLeg(
-        accountId: investmentAccount, instrument: aud, quantity: 200, type: .income),
-      isInvestmentAccount: true)
+      transaction(legs: [
+        TransactionLeg(
+          accountId: investmentAccount, instrument: aud, quantity: 200, type: .income)
+      ]),
+      investmentAccountIds: [investmentAccount])
 
     let conversion = FixedConversionService()
 
@@ -291,9 +314,11 @@ struct PositionBookTests {
     var book = PositionBook.empty
     // No transfers — only an expense on the investment account.
     book.apply(
-      TransactionLeg(
-        accountId: investmentAccount, instrument: aud, quantity: -100, type: .expense),
-      isInvestmentAccount: true)
+      transaction(legs: [
+        TransactionLeg(
+          accountId: investmentAccount, instrument: aud, quantity: -100, type: .expense)
+      ]),
+      investmentAccountIds: [investmentAccount])
 
     let conversion = FixedConversionService()
 
@@ -315,9 +340,11 @@ struct PositionBookTests {
   func transferAppearsInBothRules() async throws {
     var book = PositionBook.empty
     book.apply(
-      TransactionLeg(
-        accountId: investmentAccount, instrument: aud, quantity: 500, type: .transfer),
-      isInvestmentAccount: true)
+      transaction(legs: [
+        TransactionLeg(
+          accountId: investmentAccount, instrument: aud, quantity: 500, type: .transfer)
+      ]),
+      investmentAccountIds: [investmentAccount])
 
     let conversion = FixedConversionService()
 

--- a/MoolahTests/Support/DateBasedFixedConversionService.swift
+++ b/MoolahTests/Support/DateBasedFixedConversionService.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+@testable import Moolah
+
+/// Test-only conversion service that returns date-aware fixed rates.
+///
+/// Unlike `FixedConversionService` (which is rate-per-currency only), this
+/// service maps a date to a per-currency rate dict. Lookup picks the entry
+/// whose date is the most recent date <= the requested date (i.e. the
+/// effective rate "as of" that date). Used by analysis tests that exercise
+/// "rate changes over time" scenarios.
+///
+/// Same-instrument conversions short-circuit to the input quantity.
+/// Currencies with no rate at the requested date fall back 1:1.
+struct DateBasedFixedConversionService: InstrumentConversionService {
+  /// (date → (currencyCode → rate)) where the rate converts FROM that
+  /// currency code TO the profile instrument.
+  let rates: [Date: [String: Decimal]]
+  private let sortedDates: [Date]
+
+  /// - Parameter rates: Map of effective-from date to currency-code rates.
+  init(rates: [Date: [String: Decimal]]) {
+    self.rates = rates
+    self.sortedDates = rates.keys.sorted(by: >)  // descending for fast lookup
+  }
+
+  /// Find the rate dict whose key is the most recent date <= the requested date.
+  private func ratesAsOf(_ date: Date) -> [String: Decimal] {
+    for d in sortedDates where d <= date {
+      return rates[d]!
+    }
+    return [:]
+  }
+
+  func convert(
+    _ quantity: Decimal, from: Instrument, to: Instrument, on date: Date
+  ) async throws -> Decimal {
+    if from.id == to.id { return quantity }
+    let asOf = ratesAsOf(date)
+    guard let rate = asOf[from.id] else {
+      return quantity  // 1:1 fallback when no rate found
+    }
+    return quantity * rate
+  }
+
+  func convertAmount(
+    _ amount: InstrumentAmount, to instrument: Instrument, on date: Date
+  ) async throws -> InstrumentAmount {
+    guard amount.instrument != instrument else { return amount }
+    let converted = try await convert(
+      amount.quantity, from: amount.instrument, to: instrument, on: date
+    )
+    return InstrumentAmount(quantity: converted, instrument: instrument)
+  }
+}

--- a/Shared/BalanceDeltaCalculator.swift
+++ b/Shared/BalanceDeltaCalculator.swift
@@ -19,6 +19,28 @@ struct BalanceDelta: Equatable, Sendable {
     accountDeltas.isEmpty && earmarkDeltas.isEmpty && earmarkSavedDeltas.isEmpty
       && earmarkSpentDeltas.isEmpty
   }
+
+  /// Project a `PositionBook` into the four delta dicts consumed by stores.
+  /// `accountsFromTransfers` is intentionally ignored — it's only used by the
+  /// analysis pipeline, never by delta consumers.
+  init(from book: PositionBook) {
+    self.accountDeltas = book.accounts
+    self.earmarkDeltas = book.earmarks
+    self.earmarkSavedDeltas = book.earmarksSaved
+    self.earmarkSpentDeltas = book.earmarksSpent
+  }
+
+  init(
+    accountDeltas: PositionDeltas,
+    earmarkDeltas: PositionDeltas,
+    earmarkSavedDeltas: PositionDeltas,
+    earmarkSpentDeltas: PositionDeltas
+  ) {
+    self.accountDeltas = accountDeltas
+    self.earmarkDeltas = earmarkDeltas
+    self.earmarkSavedDeltas = earmarkSavedDeltas
+    self.earmarkSpentDeltas = earmarkSpentDeltas
+  }
 }
 
 /// Computes all balance deltas from a transaction create, update, or delete in a single pass.
@@ -27,102 +49,17 @@ struct BalanceDelta: Equatable, Sendable {
 /// - `deltas(old: tx, new: nil)` — transaction deleted
 /// - `deltas(old: oldTx, new: newTx)` — transaction updated
 /// - `deltas(old: nil, new: nil)` — no-op, returns `.empty`
+///
+/// Thin wrapper over `PositionBook`: reverses the old transaction's legs,
+/// applies the new transaction's legs, and projects the resulting book into
+/// the delta shape. Scheduled transactions are skipped (they don't move money).
 enum BalanceDeltaCalculator {
 
   static func deltas(old: Transaction?, new: Transaction?) -> BalanceDelta {
-    var accountDeltas: [UUID: [Instrument: Decimal]] = [:]
-    var earmarkDeltas: [UUID: [Instrument: Decimal]] = [:]
-    var earmarkSavedDeltas: [UUID: [Instrument: Decimal]] = [:]
-    var earmarkSpentDeltas: [UUID: [Instrument: Decimal]] = [:]
-
-    // Reverse old legs (skip scheduled transactions)
-    if let old, !old.isScheduled {
-      for leg in old.legs {
-        applyLeg(
-          leg,
-          sign: -1,
-          accountDeltas: &accountDeltas,
-          earmarkDeltas: &earmarkDeltas,
-          earmarkSavedDeltas: &earmarkSavedDeltas,
-          earmarkSpentDeltas: &earmarkSpentDeltas
-        )
-      }
-    }
-
-    // Apply new legs (skip scheduled transactions)
-    if let new, !new.isScheduled {
-      for leg in new.legs {
-        applyLeg(
-          leg,
-          sign: 1,
-          accountDeltas: &accountDeltas,
-          earmarkDeltas: &earmarkDeltas,
-          earmarkSavedDeltas: &earmarkSavedDeltas,
-          earmarkSpentDeltas: &earmarkSpentDeltas
-        )
-      }
-    }
-
-    // Clean up zero entries
-    cleanZeros(&accountDeltas)
-    cleanZeros(&earmarkDeltas)
-    cleanZeros(&earmarkSavedDeltas)
-    cleanZeros(&earmarkSpentDeltas)
-
-    return BalanceDelta(
-      accountDeltas: accountDeltas,
-      earmarkDeltas: earmarkDeltas,
-      earmarkSavedDeltas: earmarkSavedDeltas,
-      earmarkSpentDeltas: earmarkSpentDeltas
-    )
-  }
-
-  // MARK: - Private
-
-  private static func applyLeg(
-    _ leg: TransactionLeg,
-    sign: Decimal,
-    accountDeltas: inout [UUID: [Instrument: Decimal]],
-    earmarkDeltas: inout [UUID: [Instrument: Decimal]],
-    earmarkSavedDeltas: inout [UUID: [Instrument: Decimal]],
-    earmarkSpentDeltas: inout [UUID: [Instrument: Decimal]]
-  ) {
-    let quantity = leg.quantity
-
-    if let accountId = leg.accountId {
-      accountDeltas[accountId, default: [:]][leg.instrument, default: 0] += sign * quantity
-    }
-
-    if let earmarkId = leg.earmarkId {
-      earmarkDeltas[earmarkId, default: [:]][leg.instrument, default: 0] += sign * quantity
-
-      switch leg.type {
-      case .income, .openingBalance:
-        // Saved delta tracks the change to the saved total.
-        // Income/openingBalance quantities are positive, so sign * quantity gives the right direction.
-        earmarkSavedDeltas[earmarkId, default: [:]][leg.instrument, default: 0] += sign * quantity
-
-      case .expense, .transfer:
-        // Spent delta tracks the change to the spent total (stored as positive quantities).
-        // Negate the quantity: expenses are typically negative (outflows), so negating gives
-        // a positive spent amount. Refunds (positive expense quantity) correctly reduce spent.
-        earmarkSpentDeltas[earmarkId, default: [:]][leg.instrument, default: 0] +=
-          sign * (-quantity)
-      }
-    }
-  }
-
-  private static func cleanZeros(_ deltas: inout [UUID: [Instrument: Decimal]]) {
-    for (entityId, instruments) in deltas {
-      var cleaned = instruments
-      for (instrument, value) in cleaned where value == 0 {
-        cleaned.removeValue(forKey: instrument)
-      }
-      if cleaned.isEmpty {
-        deltas.removeValue(forKey: entityId)
-      } else {
-        deltas[entityId] = cleaned
-      }
-    }
+    var book = PositionBook.empty
+    if let old, !old.isScheduled { book.apply(old, sign: -1) }
+    if let new, !new.isScheduled { book.apply(new, sign: 1) }
+    book.cleanZeros()
+    return BalanceDelta(from: book)
   }
 }

--- a/Shared/PositionBook.swift
+++ b/Shared/PositionBook.swift
@@ -43,30 +43,36 @@ struct PositionBook: Equatable, Sendable {
 
   /// The canonical per-leg math. Mutates the four position dicts based on the
   /// leg's account/earmark membership and type, plus `accountsFromTransfers`
-  /// when the leg targets an investment account via a `.transfer`.
+  /// when the leg targets an investment account via a `.transfer` (or, when
+  /// `asStartingBalance` is true, any leg type on an investment account).
   ///
   /// Private — callers should drive position math through the txn-level
-  /// `apply(_ txn:sign:investmentAccountIds:)` overload, which decides
-  /// investment-account membership once per transaction and avoids leaking
-  /// accumulator policy into the per-leg primitive.
+  /// `apply(_ txn:sign:investmentAccountIds:asStartingBalance:)` overload,
+  /// which decides investment-account membership once per transaction and
+  /// avoids leaking accumulator policy into the per-leg primitive.
   ///
   /// - Parameters:
   ///   - leg: The leg to apply.
   ///   - sign: +1 to apply the leg, -1 to reverse it (used by delta math).
   ///   - isInvestmentAccount: Whether `leg.accountId` corresponds to an
-  ///     investment account. When true and the leg is a transfer, the leg also
-  ///     contributes to `accountsFromTransfers`.
+  ///     investment account. When true and the leg is a transfer (or
+  ///     `asStartingBalance` is true), the leg also contributes to
+  ///     `accountsFromTransfers`.
+  ///   - asStartingBalance: When true, every leg on an investment account is
+  ///     written into `accountsFromTransfers`, regardless of leg type. See
+  ///     the public `apply` overload for the rationale.
   private mutating func apply(
     _ leg: TransactionLeg,
     sign: Decimal = 1,
-    isInvestmentAccount: Bool = false
+    isInvestmentAccount: Bool = false,
+    asStartingBalance: Bool = false
   ) {
     let quantity = leg.quantity
 
     if let accountId = leg.accountId {
       accounts[accountId, default: [:]][leg.instrument, default: 0] += sign * quantity
 
-      if isInvestmentAccount && leg.type == .transfer {
+      if isInvestmentAccount && (asStartingBalance || leg.type == .transfer) {
         accountsFromTransfers[accountId, default: [:]][leg.instrument, default: 0] +=
           sign * quantity
       }
@@ -95,16 +101,27 @@ struct PositionBook: Equatable, Sendable {
   /// `investmentAccountIds` so that investment-account membership is decided
   /// once per transaction.
   ///
+  /// - Parameter asStartingBalance: Pass `true` for transactions that predate
+  ///   the analysis window (`date < after`). This ensures the
+  ///   `.investmentTransfersOnly` read rule sees the historical position as a
+  ///   baseline, matching the legacy `investmentTransfersOnly: false` behaviour
+  ///   for pre-`after` priors. Use `false` (the default) for transactions
+  ///   inside the analysis window — only `.transfer` legs on investment
+  ///   accounts contribute to the transfers-only view.
+  ///
   /// - Note: Does NOT skip scheduled transactions — callers that need to
   ///   exclude scheduled flows must do so before calling.
   mutating func apply(
     _ txn: Transaction,
     sign: Decimal = 1,
-    investmentAccountIds: Set<UUID> = []
+    investmentAccountIds: Set<UUID> = [],
+    asStartingBalance: Bool = false
   ) {
     for leg in txn.legs {
       let isInvestment = leg.accountId.map(investmentAccountIds.contains) ?? false
-      apply(leg, sign: sign, isInvestmentAccount: isInvestment)
+      apply(
+        leg, sign: sign, isInvestmentAccount: isInvestment,
+        asStartingBalance: asStartingBalance)
     }
   }
 

--- a/Shared/PositionBook.swift
+++ b/Shared/PositionBook.swift
@@ -1,0 +1,239 @@
+import Foundation
+
+/// Per-entity, per-instrument position state. The single place where position
+/// math for transactions and legs lives.
+///
+/// `PositionBook` is the canonical primitive used by both:
+/// - `BalanceDeltaCalculator` (transaction create/update/delete deltas), and
+/// - the analysis pipeline (daily balance accumulation across ranges).
+///
+/// All math is multi-instrument by construction: positions are tracked as raw
+/// `Decimal` quantities keyed by `Instrument`. Conversion to a profile
+/// instrument happens only at read time via `dailyBalance(...)`.
+struct PositionBook: Equatable, Sendable {
+  /// Per-account positions across all leg types.
+  var accounts: [UUID: [Instrument: Decimal]] = [:]
+
+  /// Per-earmark net position (sum of all leg quantities tagged with the
+  /// earmark, signed as in the leg).
+  var earmarks: [UUID: [Instrument: Decimal]] = [:]
+
+  /// Per-earmark "saved" totals — sum of `.income` and `.openingBalance` legs.
+  /// Tracks the change to the saved-into-earmark total.
+  var earmarksSaved: [UUID: [Instrument: Decimal]] = [:]
+
+  /// Per-earmark "spent" totals — sum of `.expense` and `.transfer` legs,
+  /// stored as positive quantities (i.e. negated against the leg quantity).
+  /// Refunds (positive expense quantities) correctly reduce the spent total.
+  var earmarksSpent: [UUID: [Instrument: Decimal]] = [:]
+
+  /// Positions on investment accounts arising from `.transfer` legs only —
+  /// used to compute the `investments` total under the
+  /// `.investmentTransfersOnly` accumulation rule.
+  ///
+  /// Tracked in parallel with `accounts` so a single accumulator can serve both
+  /// `.allLegs` (starting balance) and `.investmentTransfersOnly` (post-cutoff
+  /// daily delta) reading rules without re-traversing transactions. For users
+  /// with no investment accounts this dict stays empty.
+  var accountsFromTransfers: [UUID: [Instrument: Decimal]] = [:]
+
+  static let empty = PositionBook()
+
+  // MARK: - Apply
+
+  /// The canonical per-leg math. Mutates the four position dicts based on the
+  /// leg's account/earmark membership and type, plus `accountsFromTransfers`
+  /// when the leg targets an investment account via a `.transfer`.
+  ///
+  /// - Parameters:
+  ///   - leg: The leg to apply.
+  ///   - sign: +1 to apply the leg, -1 to reverse it (used by delta math).
+  ///   - isInvestmentAccount: Whether `leg.accountId` corresponds to an
+  ///     investment account. When true and the leg is a transfer, the leg also
+  ///     contributes to `accountsFromTransfers`.
+  mutating func apply(
+    _ leg: TransactionLeg,
+    sign: Decimal = 1,
+    isInvestmentAccount: Bool = false
+  ) {
+    let quantity = leg.quantity
+
+    if let accountId = leg.accountId {
+      accounts[accountId, default: [:]][leg.instrument, default: 0] += sign * quantity
+
+      if isInvestmentAccount && leg.type == .transfer {
+        accountsFromTransfers[accountId, default: [:]][leg.instrument, default: 0] +=
+          sign * quantity
+      }
+    }
+
+    if let earmarkId = leg.earmarkId {
+      earmarks[earmarkId, default: [:]][leg.instrument, default: 0] += sign * quantity
+
+      switch leg.type {
+      case .income, .openingBalance:
+        // Saved tracks the change to the saved total. Income/openingBalance
+        // quantities are positive, so sign * quantity gives the right direction.
+        earmarksSaved[earmarkId, default: [:]][leg.instrument, default: 0] += sign * quantity
+
+      case .expense, .transfer:
+        // Spent tracks the change to the spent total (stored as positive
+        // quantities). Negate the leg quantity: expenses are typically negative
+        // (outflows), so negating gives a positive spent amount. Refunds
+        // (positive expense quantity) correctly reduce spent.
+        earmarksSpent[earmarkId, default: [:]][leg.instrument, default: 0] += sign * (-quantity)
+      }
+    }
+  }
+
+  /// Apply (or reverse) every leg of `txn`. The caller supplies
+  /// `investmentAccountIds` so that investment-account membership is decided
+  /// once per transaction.
+  ///
+  /// - Note: Does NOT skip scheduled transactions — callers that need to
+  ///   exclude scheduled flows must do so before calling.
+  mutating func apply(
+    _ txn: Transaction,
+    sign: Decimal = 1,
+    investmentAccountIds: Set<UUID> = []
+  ) {
+    for leg in txn.legs {
+      let isInvestment = leg.accountId.map(investmentAccountIds.contains) ?? false
+      apply(leg, sign: sign, isInvestmentAccount: isInvestment)
+    }
+  }
+
+  /// Strip per-instrument entries whose value is exactly zero, and remove
+  /// outer entity entries whose inner dict becomes empty. Applied to all five
+  /// dicts. Match the cleanup `BalanceDeltaCalculator` performs before
+  /// publishing deltas.
+  mutating func cleanZeros() {
+    Self.cleanZeros(&accounts)
+    Self.cleanZeros(&earmarks)
+    Self.cleanZeros(&earmarksSaved)
+    Self.cleanZeros(&earmarksSpent)
+    Self.cleanZeros(&accountsFromTransfers)
+  }
+
+  private static func cleanZeros(_ dict: inout [UUID: [Instrument: Decimal]]) {
+    for (entityId, instruments) in dict {
+      var cleaned = instruments
+      for (instrument, value) in cleaned where value == 0 {
+        cleaned.removeValue(forKey: instrument)
+      }
+      if cleaned.isEmpty {
+        dict.removeValue(forKey: entityId)
+      } else {
+        dict[entityId] = cleaned
+      }
+    }
+  }
+
+  // MARK: - Daily Balance
+
+  /// Determines how the `investments` total is computed from the book.
+  enum AccumulationRule: Sendable {
+    /// All positions on investment accounts contribute to `investments`.
+    /// Use for starting-balance computations (pre-`after` cutoff).
+    case allLegs
+    /// Only positions arising from `.transfer` legs on investment accounts
+    /// contribute to `investments`. Use for post-`after` daily balances.
+    case investmentTransfersOnly
+  }
+
+  /// Build a `DailyBalance` snapshot from the current book state, converting
+  /// per-instrument positions to `profileInstrument` on `date`.
+  ///
+  /// Mirrors the semantics of the existing `applyMultiInstrumentConversion`:
+  /// - `balance` sums positions in non-investment accounts.
+  /// - `investments` sums positions in investment accounts under the chosen
+  ///   `rule` (either all positions or only transfer-derived positions).
+  /// - `earmarked` sums each earmark's positions converted to
+  ///   `profileInstrument`, then clamps each per-earmark sum to `>= 0`
+  ///   before adding to the overall total. Negative earmarks (e.g. those
+  ///   funding investments) do not reduce the total.
+  /// - `availableFunds = balance - earmarked`.
+  /// - `netWorth = balance + investments`.
+  /// - `investmentValue` and `bestFit` are left `nil`; callers fill them in.
+  ///
+  /// Single-instrument fast path: positions whose instrument equals
+  /// `profileInstrument` skip the conversion service entirely.
+  func dailyBalance(
+    on date: Date,
+    investmentAccountIds: Set<UUID>,
+    profileInstrument: Instrument,
+    rule: AccumulationRule,
+    conversionService: any InstrumentConversionService,
+    isForecast: Bool
+  ) async throws -> DailyBalance {
+    // Bank balance: all non-investment account positions.
+    var bankTotal: Decimal = 0
+    for (accountId, positions) in accounts where !investmentAccountIds.contains(accountId) {
+      bankTotal += try await convert(
+        positions, to: profileInstrument, on: date, using: conversionService)
+    }
+
+    // Investments: depending on rule.
+    var investmentsTotal: Decimal = 0
+    switch rule {
+    case .allLegs:
+      for (accountId, positions) in accounts where investmentAccountIds.contains(accountId) {
+        investmentsTotal += try await convert(
+          positions, to: profileInstrument, on: date, using: conversionService)
+      }
+    case .investmentTransfersOnly:
+      for (accountId, positions) in accountsFromTransfers
+      where investmentAccountIds.contains(accountId) {
+        investmentsTotal += try await convert(
+          positions, to: profileInstrument, on: date, using: conversionService)
+      }
+    }
+
+    // Earmarks: per-earmark sum, clamp each to >= 0, then total.
+    var earmarkedTotal: Decimal = 0
+    for (_, positions) in earmarks {
+      let perEarmark = try await convert(
+        positions, to: profileInstrument, on: date, using: conversionService)
+      earmarkedTotal += max(perEarmark, 0)
+    }
+
+    let balance = InstrumentAmount(quantity: bankTotal, instrument: profileInstrument)
+    let investments = InstrumentAmount(quantity: investmentsTotal, instrument: profileInstrument)
+    let earmarked = InstrumentAmount(quantity: earmarkedTotal, instrument: profileInstrument)
+
+    let calendar = Calendar(identifier: .gregorian)
+    let dayKey = calendar.startOfDay(for: date)
+
+    return DailyBalance(
+      date: dayKey,
+      balance: balance,
+      earmarked: earmarked,
+      availableFunds: balance - earmarked,
+      investments: investments,
+      investmentValue: nil,
+      netWorth: balance + investments,
+      bestFit: nil,
+      isForecast: isForecast
+    )
+  }
+
+  /// Sum a per-instrument position dict into a single `Decimal` in `target`,
+  /// using the conversion service for non-target instruments. Single-instrument
+  /// positions skip the conversion call.
+  private func convert(
+    _ positions: [Instrument: Decimal],
+    to target: Instrument,
+    on date: Date,
+    using service: any InstrumentConversionService
+  ) async throws -> Decimal {
+    var total: Decimal = 0
+    for (instrument, quantity) in positions {
+      if instrument == target {
+        total += quantity
+      } else {
+        total += try await service.convert(quantity, from: instrument, to: target, on: date)
+      }
+    }
+    return total
+  }
+}

--- a/Shared/PositionBook.swift
+++ b/Shared/PositionBook.swift
@@ -166,7 +166,7 @@ struct PositionBook: Equatable, Sendable {
   /// Build a `DailyBalance` snapshot from the current book state, converting
   /// per-instrument positions to `profileInstrument` on `date`.
   ///
-  /// Mirrors the semantics of the existing `applyMultiInstrumentConversion`:
+  /// Semantics:
   /// - `balance` sums positions in non-investment accounts.
   /// - `investments` sums positions in investment accounts under the chosen
   ///   `rule` (either all positions or only transfer-derived positions).

--- a/Shared/PositionBook.swift
+++ b/Shared/PositionBook.swift
@@ -45,13 +45,18 @@ struct PositionBook: Equatable, Sendable {
   /// leg's account/earmark membership and type, plus `accountsFromTransfers`
   /// when the leg targets an investment account via a `.transfer`.
   ///
+  /// Private — callers should drive position math through the txn-level
+  /// `apply(_ txn:sign:investmentAccountIds:)` overload, which decides
+  /// investment-account membership once per transaction and avoids leaking
+  /// accumulator policy into the per-leg primitive.
+  ///
   /// - Parameters:
   ///   - leg: The leg to apply.
   ///   - sign: +1 to apply the leg, -1 to reverse it (used by delta math).
   ///   - isInvestmentAccount: Whether `leg.accountId` corresponds to an
   ///     investment account. When true and the leg is a transfer, the leg also
   ///     contributes to `accountsFromTransfers`.
-  mutating func apply(
+  private mutating func apply(
     _ leg: TransactionLeg,
     sign: Decimal = 1,
     isInvestmentAccount: Bool = false


### PR DESCRIPTION
## Summary

- Introduces `PositionBook` (`Shared/PositionBook.swift`), a `Sendable` value type that owns per-entity, per-instrument position state and converts to a `DailyBalance` on demand.
- Routes `BalanceDeltaCalculator`, `generateForecast`, and `computeDailyBalances` through the same primitive — collapsing two near-duplicate accumulators (instance and `@concurrent` static) and eliminating the `InstrumentAmount.+=` precondition crash that was reachable for any user with multi-currency history.
- Picks **Option A** semantics for the "Invested Amount" chart series: `investments = (pre-after snapshot of all investment-account legs) + (post-after transfer-leg deltas)`. Matches legacy single-currency behaviour exactly; extends the same semantic to multi-currency users (whose previous `applyMultiInstrumentConversion` override used the inconsistent "all legs at every date" rule).
- Removes the legacy daily-balance accumulator (`applyTransaction`, `applyMultiInstrumentConversion`, `clampedEarmarkTotal`) and the migration-period debug equivalence oracle. `CloudKitAnalysisRepository.swift` shrinks from 1235 → 950 lines.

## Migration sequence

8 commits, each independently green:

1. Add `PositionBook` + 13 unit tests (dead code).
2. Switch `BalanceDeltaCalculator.deltas` to delegate to `PositionBook`; tighten visibility.
3. Port `generateForecast` to `PositionBook`.
4. Port `computeDailyBalances` to `PositionBook` (Option A); guard with `#if DEBUG` equivalence assertion against the legacy code.
5. Collapse instance `fetchDailyBalances` to a thin wrapper around the static path.
6. Add 11 multi-currency contract tests (and a `DateBasedFixedConversionService` test fixture) — pin the new behaviour.
7. Delete the legacy accumulator, comparator, and oracle.
8. Drop a stale doc reference.

## Behavioural notes

- **Single-currency users**: zero observable change. The debug equivalence oracle ran during migration and never fired.
- **Multi-currency users**: the "Invested Amount" line now uses snapshot+transfer-deltas semantics across all dates (consistent with what single-currency has always shown), instead of the previous "sum of all legs at each date" rule from `applyMultiInstrumentConversion`.
- The `investmentTransfersOnly` discontinuity tracked in `BUGS.md` is now resolved consistently — pre/post-`after` no longer use different rules.

## Plan

`plans/2026-04-17-analysis-unified-position-book-design.md` — full design including the Option A vs B rationale, test-coverage matrix, and risk analysis.

## Test plan

- [x] `just test-mac` — 1121/1121 passing
- [x] `AnalysisRepositoryContractTests` — 53/53 passing (42 existing + 11 new)
- [x] `BalanceDeltaCalculatorTests`, `AccountStoreTests`, `EarmarkStoreTests` — unchanged, all passing
- [x] `PositionBookTests` — 16/16 passing (13 + 3 added)
- [ ] Smoke-check the Net Worth chart on a multi-currency profile to confirm the "Invested Amount" line now shows expected values

🤖 Generated with [Claude Code](https://claude.com/claude-code)