### PR TITLE
docs: menu bar compliance plan — Phase 0 (style guide refinement)

### DIFF
--- a/guides/STYLE_GUIDE.md
+++ b/guides/STYLE_GUIDE.md
@@ -1022,7 +1022,7 @@ The primary domain menu. Named for the noun the commands act on (Apple's Mail ha
 
 ```
 Transaction
-  Edit Transaction…            ↩       (primary action on selection)
+  Edit Transaction…                    (opens inspector; fires on list double-click / Return)
   Duplicate Transaction        ⌘D
   —
   Mark as Cleared              ⌘K
@@ -1034,7 +1034,7 @@ Transaction
   Reveal in Account
   Copy Transaction Link        ⌃⌘C
   —
-  Delete Transaction           ⌫        (on menu; fires via Delete key on selection)
+  Delete Transaction…                  (ellipsis — confirmation alert; Delete key fires on list focus)
 ```
 
 Pay Scheduled Transaction is intentionally shortcut-less: ⌘P is a universal Mac shortcut for Print and must not be reassigned, even in apps without a Print command — users hit it reflexively and expect nothing bad to happen. The action is reachable from the Transaction menu, the inline Pay button on upcoming rows, and the context menu.
@@ -1214,7 +1214,8 @@ Assign shortcuts only when the action is **frequent** (used more than a few time
 | Duplicate Transaction | ⌘D | Transaction |
 | Mark as Cleared / All | ⌘K / ⇧⌘K | Transaction |
 | Pay Scheduled Transaction | — | Transaction (⌘P reserved for Print) |
-| Delete Transaction | ⌫ | Transaction (fires on selection) |
+| Edit Transaction… | — | Transaction (list primaryAction on Return/double-click) |
+| Delete Transaction… | — | Transaction (Delete key on list focus via onDeleteCommand) |
 | Refresh | ⌘R | (no menu item — handled by `.refreshable`; see note) |
 | Moolah Help | ⌘? | Help |
 | Keyboard Shortcuts | ⇧⌘/ | Help |
@@ -1355,11 +1356,11 @@ Every context menu item (right-click on a list row) should have a matching top-l
 
 // Must be mirrored by:
 CommandMenu("Transaction") {
-    Button("Edit Transaction…") { … }.keyboardShortcut(.return, modifiers: [])
+    Button("Edit Transaction…") { … }                  // no menu shortcut — fires on list focus
     Button("Duplicate Transaction") { … }.keyboardShortcut("d")
     Button("Mark as Cleared") { … }.keyboardShortcut("k")
     Divider()
-    Button("Delete Transaction", role: .destructive) { … }
+    Button("Delete Transaction…", role: .destructive) { … }   // ellipsis for confirmation
 }
 ```
 

--- a/guides/STYLE_GUIDE.md
+++ b/guides/STYLE_GUIDE.md
@@ -1233,6 +1233,8 @@ Acceptable uses:
 - **Recent Items submenu** — file-type icon for each entry.
 - **Items that mirror a toolbar button** where the toolbar's SF Symbol is the recognized shorthand for the action (e.g., `Reveal in Finder` with `magnifyingglass`). Use sparingly.
 
+**Context menus (right-click / long-press) are a separate case.** iOS renders contextual menus with leading icons by convention, and macOS 26 does the same. Keep `systemImage:` on context-menu `Button`s — they read as system-native on iOS and provide visual affordance on macOS. The "no icons by default" rule applies to **the menu bar only** (`CommandMenu`, `CommandGroup`).
+
 Unacceptable:
 
 - Icons on every item in File/Edit/View.

--- a/guides/STYLE_GUIDE.md
+++ b/guides/STYLE_GUIDE.md
@@ -1043,6 +1043,18 @@ Every item here **must** be disabled (not hidden) when no transaction is selecte
 
 Labels match the selection count: `Delete Transaction` with one selected, `Delete 3 Transactions` with many. Prefer the singular when it reads naturally either way.
 
+#### Additional Domain Menus (Account, Earmark)
+
+When the app has more than one primary noun the user acts on, each gets its own domain menu positioned between `Transaction` and `Window`:
+
+```
+… View · Go · Transaction · Account · Earmark · Window · Help
+```
+
+Each domain menu follows the same rules as `Transaction` — verb-phrase items, operate on the focused window's selection via `@FocusedValue`, disabled (not hidden) when no selection is present. Keep each menu short (3–6 items). If a domain has only one or two menu-worthy actions, inline them into `Transaction` under a noun prefix (`Edit Account…`, `View Account Transactions`) instead of creating a dedicated menu.
+
+Do not create a domain menu just to host a single command. And do not invent a generic `Domain` or `Items` menu that covers multiple nouns — each menu owns exactly one noun.
+
 #### Window
 
 Mostly SwiftUI-provided via `.windowSize`, `.windowArrangement`, `.singleWindowList`:

--- a/plans/2026-04-17-menu-bar-compliance-plan.md
+++ b/plans/2026-04-17-menu-bar-compliance-plan.md
@@ -37,7 +37,7 @@ Each phase closes specific findings from the 2026-04-17 review:
 
 ---
 
-## Phase 0: Style Guide Refinement
+## Phase 0: Style Guide Refinement ✅ Complete
 
 Before touching code, clarify two points in `guides/STYLE_GUIDE.md` §14 that the current text leaves ambiguous. These are guide-only changes and committed separately.
 
@@ -46,7 +46,7 @@ Before touching code, clarify two points in `guides/STYLE_GUIDE.md` §14 that th
 **Files:**
 - Modify: `guides/STYLE_GUIDE.md` — Section 14 "Icons in Menu Items"
 
-- [ ] **Step 1: Add a "Context menus vs menu bar" clarification**
+- [x] **Step 1: Add a "Context menus vs menu bar" clarification**
 
 In the "Icons in Menu Items" subsection, after the "Acceptable uses" list and before "Unacceptable", insert:
 
@@ -54,7 +54,7 @@ In the "Icons in Menu Items" subsection, after the "Acceptable uses" list and be
 **Context menus (right-click / long-press) are a separate case.** iOS renders contextual menus with leading icons by convention, and macOS 26 does the same. Keep `systemImage:` on context-menu `Button`s — they read as system-native on iOS and provide visual affordance on macOS. The "no icons by default" rule applies to **the menu bar only** (`CommandMenu`, `CommandGroup`).
 ```
 
-- [ ] **Step 2: Commit**
+- [x] **Step 2: Commit**
 
 ```bash
 git add guides/STYLE_GUIDE.md
@@ -66,7 +66,7 @@ git commit -m "docs: clarify style guide — context menu icons are permitted"
 **Files:**
 - Modify: `guides/STYLE_GUIDE.md` — Section 14 "Top-Level Menu Structure"
 
-- [ ] **Step 1: Allow additional domain menus alongside Transaction**
+- [x] **Step 1: Allow additional domain menus alongside Transaction**
 
 After the "Transaction" subsection and before "Window", insert a new subsection:
 
@@ -84,7 +84,7 @@ Each domain menu follows the same rules as `Transaction` — verb-phrase items, 
 Do not create a domain menu just to host a single command. And do not invent a generic `Domain` or `Items` menu that covers multiple nouns — each menu owns exactly one noun.
 ```
 
-- [ ] **Step 2: Commit**
+- [x] **Step 2: Commit**
 
 ```bash
 git add guides/STYLE_GUIDE.md
@@ -98,7 +98,7 @@ git commit -m "docs: permit Account and Earmark domain menus alongside Transacti
 
 The §14 Transaction menu outline currently shows `Edit Transaction…  ↩` and `Delete Transaction ⌫`, which creates a tension with §14's Philosophy: "Menus are for ⌘-modified commands. Single-key shortcuts … do not belong in the menu bar." The Return and Delete keys fire via List row focus (list primaryAction / onDeleteCommand), not via menu-registered shortcuts.
 
-- [ ] **Step 1: Update the Transaction menu code block**
+- [x] **Step 1: Update the Transaction menu code block**
 
 In §14's Transaction menu code block, change:
 ```
@@ -118,7 +118,7 @@ to:
 Delete Transaction…                  (ellipsis — confirmation alert; Delete key fires on list focus)
 ```
 
-- [ ] **Step 2: Update the Moolah-Specific Shortcut Map**
+- [x] **Step 2: Update the Moolah-Specific Shortcut Map**
 
 Change:
 ```
@@ -132,7 +132,7 @@ to:
 | Delete Transaction… | — | Transaction (Delete key on list focus via onDeleteCommand) |
 ```
 
-- [ ] **Step 3: Update the "Context Menu ↔ Menu Bar Parity" code example**
+- [x] **Step 3: Update the "Context Menu ↔ Menu Bar Parity" code example**
 
 Find the code block under "Context Menu ↔ Menu Bar Parity" that shows:
 ```swift
@@ -155,7 +155,7 @@ CommandMenu("Transaction") {
 }
 ```
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```bash
 git add guides/STYLE_GUIDE.md


### PR DESCRIPTION
## Summary
- Clarify §14 icon policy so context-menu `Button`s keep their `systemImage:` — the no-icons rule applies to the menu bar only.
- Sanction Account and Earmark as additional domain menus alongside Transaction, with the same selection-driven rules.
- Drop the ambiguous single-key shortcut annotations from the Transaction menu outline, shortcut map, and Context ↔ Menu parity example; Return/Delete fire via list focus, not menu-registered shortcuts.
- Mark Phase 0 checkboxes complete in \`plans/2026-04-17-menu-bar-compliance-plan.md\`.

## Test plan
- [x] Docs-only change — no build/tests required.
- [x] Reviewed diff for consistency across Transaction menu block, shortcut map, and code example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)