### PR TITLE
docs: mark Phase 6 done and log remaining multi-currency gaps

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -4,3 +4,24 @@
 
 In `CloudKitAnalysisRepository.fetchDailyBalances` / `computeDailyBalances`, the starting-balance phase (transactions with `date < after`) calls `applyTransaction` with `investmentTransfersOnly: false` — so every leg type on an investment account bumps the `investments` running total. The daily-delta phase (transactions with `date >= after`) calls it with `investmentTransfersOnly: true` — so only `.transfer` legs on investment accounts bump `investments`. This means the balance at the `after` boundary can jump when a non-transfer leg on an investment account flips sides: it counted on day `after - 1` but is ignored on day `after`. The rule was imported from the server's `selectBalance` vs `dailyProfitAndLoss` split; unclear whether the discontinuity is intentional. Decide once and apply consistently across both phases.
 
+## `AccountStore` sync totals trap for multi-currency profiles
+
+`AccountStore.currentTotal`, `investmentTotal`, and `netWorth` (`Features/Accounts/AccountStore.swift:112-126`) reduce with `InstrumentAmount.+`, whose precondition traps when any account's instrument differs from `targetInstrument`. The sidebar uses the async `convertedCurrentTotal` / `convertedNetWorth` properties and is safe, but the following call sites still hit the sync properties and will crash as soon as a profile holds any foreign-currency account:
+
+- `Automation/AutomationService.swift:62` — `getNetWorth` (the "Get Net Worth" App Intent / Shortcut).
+- `Features/Navigation/SidebarView.swift:226` and `App/ContentView.swift:124` — both read `accountStore.currentTotal.instrument` when opening the Create Account / Create Earmark sheets.
+
+Fix by removing the sync aggregates (use the async converted properties everywhere) or guarding them against mixed instruments.
+
+## Exchange-rate failure leaves sidebar totals permanently blank
+
+`AccountStore.recomputeConvertedTotals` (`Features/Accounts/AccountStore.swift:168-184`) and the equivalent in `EarmarkStore` (`Features/Earmarks/EarmarkStore.swift:114-168`) wrap the full loop in one `Task { do … catch }`. If a single conversion throws (e.g. `ExchangeRateService` can't reach Frankfurter and has no cached fallback for the requested currency), the whole task aborts and `convertedCurrentTotal` / `convertedNetWorth` / `convertedTotalBalance` stay `nil`, so the sidebar rows render spinners forever. Should degrade per-position: catch inside the inner loop, skip or zero the failed position, surface a warning to the user, and keep the rest of the totals.
+
+## `AccountStore.balance(for:)` hides non-primary positions
+
+`AccountStore.balance(for:)` (`Features/Accounts/AccountStore.swift:102-103`) returns only the position whose instrument matches `account.instrument`. If an account accumulates a position in any other instrument (e.g. a cross-currency transfer into it, or a stray crypto position), that value is invisible in the per-account sidebar row and in `canDelete` (line 109), even though the converted sidebar totals still include it. Show the full position list, or at least surface a badge / warning when an account holds off-primary positions.
+
+## No test round-trip for multi-currency export/import
+
+`ExportedData` serialises `instruments` alongside accounts, earmarks, and legs, but no test asserts that a profile containing mixed-currency accounts and earmarks survives an export → import cycle with instruments intact. Add a JSON round-trip test (ideally covering fiat, stock, and crypto instruments on both accounts and legs) to lock this in before Phase 9's CSV importer starts producing more multi-currency data.
+

--- a/plans/2026-04-17-earmark-currency-picker-plan.md
+++ b/plans/2026-04-17-earmark-currency-picker-plan.md
@@ -1,0 +1,68 @@
+# Earmark Currency Picker — Plan
+
+**Date:** 2026-04-17
+
+## Goal
+
+Let users create earmarks in a currency other than the profile's base currency, mirroring the per-account currency picker added in `2026-04-16-account-currency-picker-design.md`. Today the earmark UI hardcodes the profile currency even though `Earmark.instrument` is already persisted per-earmark and `EarmarkStore` already converts foreign-currency positions back to `earmark.instrument` for display.
+
+## Context
+
+- `Earmark.instrument` and `EarmarkRecord.instrumentId` already exist and persist through CloudKit sync.
+- `EarmarkStore.recomputeConvertedTotals` (`Features/Earmarks/EarmarkStore.swift:114-168`) iterates each earmark's positions, converts them to `earmark.instrument`, then converts the earmark's balance a second time into `targetInstrument` (profile currency) for the sidebar grand total. Multi-instrument positions therefore already work at the data layer — only the UI is missing.
+- `CreateEarmarkSheet` / `EditEarmarkSheet` live in `Features/Earmarks/Views/EarmarkFormSheet.swift`. The create sheet takes an `instrument: Instrument` parameter and uses it directly; the edit sheet renders `earmark.instrument.id` as a read-only label.
+- Call sites that present the create sheet:
+  - `Features/Navigation/SidebarView.swift:213-223` — passes `earmarkStore.targetInstrument`.
+  - `App/ContentView.swift:122-132` — passes `accountStore.currentTotal.instrument` (this call is also affected by the sync-total crash logged in `BUGS.md`; once that bug is fixed the site will read the profile instrument directly).
+  - `Features/Earmarks/Views/EarmarksView.swift:71-81` — passes `earmarkStore.targetInstrument`.
+- Remote backends don't support per-earmark currencies. Like the account picker, the earmark picker must be gated on `profile.supportsComplexTransactions` (true only for CloudKit).
+- The reusable `CurrencyPicker` already exists at `Shared/Views/CurrencyPicker.swift`.
+
+## Design
+
+### `CreateEarmarkSheet`
+
+- Add a `supportsComplexTransactions: Bool` parameter (default `false` to keep existing previews happy).
+- Add `@State private var currencyCode: String`, initialised from the injected `instrument.id`.
+- When `supportsComplexTransactions` is true, render `CurrencyPicker(selection: $currencyCode)` in the "Details" section above the savings-goal field. The savings-goal row's leading `Text(instrument.id)` becomes `Text(currencyCode)` so the symbol follows the picker.
+- In `createEarmark()`, resolve `let selected = supportsComplexTransactions ? Instrument.fiat(code: currencyCode) : instrument` and use `selected` for both the goal amount and the earmark's `instrument` field.
+
+### `EditEarmarkSheet`
+
+- Also accept `supportsComplexTransactions: Bool`.
+- Add `@State private var currencyCode: String` initialised from `earmark.instrument.id`.
+- When `supportsComplexTransactions` is true, render `CurrencyPicker(selection: $currencyCode)`; otherwise keep the existing read-only label.
+- In `saveChanges()`, only update `earmark.instrument` when `supportsComplexTransactions` is true. Build the new goal `InstrumentAmount` in the selected instrument so the goal, balance, and display stay aligned.
+- Leave existing `positions` / `savedPositions` / `spentPositions` untouched. Because `EarmarkStore.recomputeConvertedTotals` converts every position to `earmark.instrument` on each recompute, changing the earmark's instrument simply re-reports the same underlying value in a new currency — no data migration is required (parallel to the account case).
+
+### Call sites
+
+- `SidebarView.swift` and `EarmarksView.swift` both already have `session.profile`; pass `supportsComplexTransactions: session.profile.supportsComplexTransactions` into `CreateEarmarkSheet`. Do the same for `EditEarmarkSheet` wherever it's presented (`EarmarksView`, `EarmarkDetailView`).
+- `ContentView.swift:124` keeps its call site shape but should receive the profile instrument + `supportsComplexTransactions` after the sync-total crash bug (see `BUGS.md`) is resolved. If that fix lands first, just wire the flag through; otherwise this plan can fix the call site inline by reading `session.profile.instrument` / `session.profile.supportsComplexTransactions` directly.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `Features/Earmarks/Views/EarmarkFormSheet.swift` | Add picker + `supportsComplexTransactions` param to both `CreateEarmarkSheet` and `EditEarmarkSheet`; drive goal/instrument from the selected code. |
+| `Features/Navigation/SidebarView.swift` | Pass `supportsComplexTransactions` into `CreateEarmarkSheet`. |
+| `Features/Earmarks/Views/EarmarksView.swift` | Pass `supportsComplexTransactions` into `CreateEarmarkSheet` and `EditEarmarkSheet`. |
+| `Features/Earmarks/Views/EarmarkDetailView.swift` | Pass `supportsComplexTransactions` into `EditEarmarkSheet` if it is presented from here. |
+| `App/ContentView.swift` | Pass `supportsComplexTransactions` into `CreateEarmarkSheet` (and use the profile instrument instead of the sync-total instrument — aligns with the sidebar-totals crash fix). |
+
+## Testing
+
+Follow TDD — tests first, then code.
+
+- **Domain round-trip (contract):** extend the earmark repository contract test with a case that creates an earmark in a non-profile currency, reloads, and asserts `instrument.id` is preserved. One test on `CloudKitBackend` + in-memory SwiftData is enough; the remote backend doesn't support this path.
+- **Store:** extend `EarmarkStoreTests` to cover
+  - Creating an earmark in a currency different from the profile and confirming `EarmarkStore.convertedBalance(for:)` converts positions from the underlying account currency to the earmark currency.
+  - Updating an earmark's instrument on an earmark with existing positions and asserting the converted balance is re-expressed in the new currency (no crash, no data loss).
+- **Sheet wiring:** no new UI tests — the picker is the same control already covered by the account currency picker work; snapshot/preview the new sheet to sanity-check layout on macOS and iOS.
+
+## Out of Scope
+
+- Expanding the currency list beyond the 17 shared with the account picker.
+- Letting earmark budget-line items pick a different currency from the earmark (they inherit `earmark.instrument`).
+- Backfilling or re-denominating historical positions — not required, since the store already converts per-position on every recompute.
+- Fixing the sync-totals crash or the permanent-spinner behaviour on exchange-rate failure — tracked separately in `BUGS.md`.

--- a/plans/ROADMAP.md
+++ b/plans/ROADMAP.md
@@ -75,25 +75,20 @@ CloudKit compatibility required: removing `#Unique` constraints, adding default 
 
 ---
 
-## Phase 6: Multi-Currency Support
+## Phase 6: Multi-Currency Support — Done
 
 Full per-account currency support, building on the exchange rate infrastructure from Phase 4 and multi-instrument foundation from Phase 8. Accounts can have a currency different from the profile's base currency, and all aggregation (totals, net worth, available funds) converts to the profile currency.
-
-**Why now:** Phases 7 and 9 (tax reporting, stock import) are only useful if the app can aggregate values across currencies. The infrastructure is already done — this phase wires it into the data layer and UI.
-
-### Done
 
 - `Instrument` model, `Position` type, `TransactionLeg` with per-leg instruments
 - `ExchangeRateService` — Frankfurter API with caching, offline fallback, date-range queries
 - `InstrumentConversionService` protocol with `FiatConversionService` and `FullConversionService`
 - `Account.instrument` field and `AccountRecord.instrumentId` storage — persisted and read back from SwiftData. Legacy `balance`/`investmentValue` fields removed; accounts are fully position-based.
 - Aggregation — `AccountStore` converts foreign-currency accounts to profile currency for sidebar totals, net worth, and available funds
+- Per-account currency picker in create/edit account UI (gated on `supportsComplexTransactions`)
+- Cross-currency transfers — `TransactionDetailView` shows independent Sent/Received amount fields with a derived exchange-rate hint
+- Analysis views — `CloudKitAnalysisRepository` converts every leg at the transaction's date before aggregating expense breakdown, income/expense totals, and daily balances
 
-### Remaining
-
-- Per-account currency picker in create/edit account UI
-- Cross-currency transfers: UI for exchange rate input or market rate selection when transferring between accounts with different currencies
-- Analysis views: expense breakdown and income/expense tables sum foreign-currency legs without converting to profile currency (net worth graph already handles this via `applyMultiInstrumentConversion`)
+Remaining multi-currency work (UI polish, earmark currency picker, etc.) is tracked in `BUGS.md` and individual plans.
 
 ---
 
@@ -117,7 +112,7 @@ Cryptocurrency price fetching, caching, and conversion using CryptoCompare, Bina
 
 ## Phase 9: CSV Import (SelfWealth)
 
-Import Australian stock holdings and trade history from SelfWealth CSV exports. SelfWealth has no API, so CSV is the only reliable data path.
+Import Australian stock holdings and trade history from SelfWealth CSV exports. SelfWealth has no API, so CSV is the only reliable data path. Imported holdings and trades preserve the source currency (typically AUD for SelfWealth, but the importer and resulting legs use per-row instruments so non-AUD-denominated trades import correctly and flow through Phase 6's conversion pipeline).
 
 **Why now:** This unlocks investment tracking for real-world use. The Sharesight API was evaluated (`sharesight-api-research.md`) but requires a paid subscription — CSV import works for any SelfWealth user with zero external dependencies.
 


### PR DESCRIPTION
## Summary
- Rewrite the Phase 6 section of `plans/ROADMAP.md` as Done — the account currency picker, cross-currency transfer UI, and per-leg conversion in analysis all shipped, so the Done/Remaining split no longer matched reality. Also added a one-line note to Phase 9 that CSV-imported rows preserve per-row instruments so they flow through Phase 6's conversion pipeline.
- Log four multi-currency bugs surfaced while auditing Phase 6 in `BUGS.md`: sync `AccountStore` totals trap for foreign-currency accounts (also trips the "Get Net Worth" Shortcut and the Create sheets); a single exchange-rate failure leaves the sidebar stuck on a spinner; `balance(for:)` hides non-primary positions; no export/import round-trip test for multi-currency data.
- Add `plans/2026-04-17-earmark-currency-picker-plan.md` — plan to close the last UI asymmetry between accounts and earmarks by putting the shared `CurrencyPicker` behind `supportsComplexTransactions` in `CreateEarmarkSheet` / `EditEarmarkSheet`. No data migration required because `EarmarkStore` already reconverts positions to `earmark.instrument` on every recompute.

## Test plan
- [ ] Docs-only change; no code touched, no tests required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)