### PR TITLE
fix: drop AccountStore sync totals that trap on mixed instruments

### DIFF
--- a/App/ContentView.swift
+++ b/App/ContentView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 /// Placeholder main content shown after sign-in. Replaced step-by-step with real screens.
 struct ContentView: View {
   @Environment(AuthStore.self) private var authStore
+  @Environment(ProfileSession.self) private var session
   @Environment(AccountStore.self) private var accountStore
   @Environment(TransactionStore.self) private var transactionStore
   @Environment(CategoryStore.self) private var categoryStore
@@ -121,7 +122,7 @@ struct ContentView: View {
     }
     .sheet(isPresented: $showCreateEarmarkSheet) {
       CreateEarmarkSheet(
-        instrument: accountStore.currentTotal.instrument,
+        instrument: session.profile.instrument,
         onCreate: { newEarmark in
           Task {
             _ = await earmarkStore.create(newEarmark)

--- a/Automation/AppleScript/Commands/NetWorthCommand.swift
+++ b/Automation/AppleScript/Commands/NetWorthCommand.swift
@@ -18,7 +18,7 @@
         guard let service = ScriptingContext.automationService else {
           throw AutomationError.operationFailed("Scripting not configured")
         }
-        let netWorth = try service.getNetWorth(profileIdentifier: profileName)
+        let netWorth = try await service.getNetWorth(profileIdentifier: profileName)
         return netWorth.doubleValue as NSNumber
       }
       return result

--- a/Automation/AutomationService.swift
+++ b/Automation/AutomationService.swift
@@ -56,10 +56,17 @@ final class AutomationService {
     return account
   }
 
-  /// Returns the net worth (current + investment totals) for the given profile.
-  func getNetWorth(profileIdentifier: String) throws -> InstrumentAmount {
+  /// Returns the net worth (current + investment totals) for the given profile,
+  /// converted into the profile's instrument.
+  func getNetWorth(profileIdentifier: String) async throws -> InstrumentAmount {
     let session = try resolveSession(for: profileIdentifier)
-    return session.accountStore.netWorth
+    do {
+      return try await session.accountStore.computeConvertedNetWorth(
+        in: session.profile.instrument)
+    } catch {
+      throw AutomationError.operationFailed(
+        "Failed to compute net worth: \(error.localizedDescription)")
+    }
   }
 
   /// Creates a new account in the given profile.

--- a/Automation/Intents/GetNetWorthIntent.swift
+++ b/Automation/Intents/GetNetWorthIntent.swift
@@ -14,7 +14,7 @@ struct GetNetWorthIntent: AppIntent {
     guard let service = AutomationServiceLocator.shared.service else {
       throw AutomationError.operationFailed("App not ready")
     }
-    let netWorth = try service.getNetWorth(profileIdentifier: profile.id.uuidString)
+    let netWorth = try await service.getNetWorth(profileIdentifier: profile.id.uuidString)
     return .result(value: netWorth.formatted)
   }
 }

--- a/BUGS.md
+++ b/BUGS.md
@@ -4,15 +4,6 @@
 
 In `CloudKitAnalysisRepository.fetchDailyBalances` / `computeDailyBalances`, the starting-balance phase (transactions with `date < after`) calls `applyTransaction` with `investmentTransfersOnly: false` — so every leg type on an investment account bumps the `investments` running total. The daily-delta phase (transactions with `date >= after`) calls it with `investmentTransfersOnly: true` — so only `.transfer` legs on investment accounts bump `investments`. This means the balance at the `after` boundary can jump when a non-transfer leg on an investment account flips sides: it counted on day `after - 1` but is ignored on day `after`. The rule was imported from the server's `selectBalance` vs `dailyProfitAndLoss` split; unclear whether the discontinuity is intentional. Decide once and apply consistently across both phases.
 
-## `AccountStore` sync totals trap for multi-currency profiles
-
-`AccountStore.currentTotal`, `investmentTotal`, and `netWorth` (`Features/Accounts/AccountStore.swift:112-126`) reduce with `InstrumentAmount.+`, whose precondition traps when any account's instrument differs from `targetInstrument`. The sidebar uses the async `convertedCurrentTotal` / `convertedNetWorth` properties and is safe, but the following call sites still hit the sync properties and will crash as soon as a profile holds any foreign-currency account:
-
-- `Automation/AutomationService.swift:62` — `getNetWorth` (the "Get Net Worth" App Intent / Shortcut).
-- `Features/Navigation/SidebarView.swift:226` and `App/ContentView.swift:124` — both read `accountStore.currentTotal.instrument` when opening the Create Account / Create Earmark sheets.
-
-Fix by removing the sync aggregates (use the async converted properties everywhere) or guarding them against mixed instruments.
-
 ## Exchange-rate failure leaves sidebar totals permanently blank
 
 `AccountStore.recomputeConvertedTotals` (`Features/Accounts/AccountStore.swift:168-184`) and the equivalent in `EarmarkStore` (`Features/Earmarks/EarmarkStore.swift:114-168`) wrap the full loop in one `Task { do … catch }`. If a single conversion throws (e.g. `ExchangeRateService` can't reach Frankfurter and has no cached fallback for the requested currency), the whole task aborts and `convertedCurrentTotal` / `convertedNetWorth` / `convertedTotalBalance` stay `nil`, so the sidebar rows render spinners forever. Should degrade per-position: catch inside the inner loop, skip or zero the failed position, surface a warning to the user, and keep the rest of the totals.

--- a/Features/Accounts/AccountStore.swift
+++ b/Features/Accounts/AccountStore.swift
@@ -109,22 +109,6 @@ final class AccountStore {
     return account.positions.isEmpty || account.positions.allSatisfy { $0.quantity == 0 }
   }
 
-  var currentTotal: InstrumentAmount {
-    currentAccounts.reduce(.zero(instrument: targetInstrument)) {
-      $0 + balance(for: $1.id)
-    }
-  }
-
-  var investmentTotal: InstrumentAmount {
-    investmentAccounts.reduce(
-      .zero(instrument: targetInstrument)
-    ) { $0 + displayBalance(for: $1.id) }
-  }
-
-  var netWorth: InstrumentAmount {
-    currentTotal + investmentTotal
-  }
-
   /// Positions for a given account. Returns empty array if not loaded.
   func positions(for accountId: UUID) -> [Position] {
     accounts.by(id: accountId)?.positions ?? []
@@ -165,6 +149,13 @@ final class AccountStore {
     return total
   }
 
+  /// Compute converted net worth (current + investment totals) in a target instrument.
+  func computeConvertedNetWorth(in target: Instrument) async throws -> InstrumentAmount {
+    let current = try await computeConvertedCurrentTotal(in: target)
+    let investment = try await computeConvertedInvestmentTotal(in: target)
+    return current + investment
+  }
+
   private func recomputeConvertedTotals() {
     conversionTask?.cancel()
     conversionTask = Task {
@@ -181,6 +172,14 @@ final class AccountStore {
         logger.error("Failed to compute converted totals: \(error.localizedDescription)")
       }
     }
+  }
+
+  /// Awaits any in-flight converted-totals recomputation. Intended for tests
+  /// that need deterministic synchronisation after `load()` / `applyDelta` /
+  /// `updateInvestmentValue` kick off `recomputeConvertedTotals()`.
+  func waitForPendingConversions() async {
+    guard let task = conversionTask else { return }
+    await task.value
   }
 
   /// Updates the investment value for a specific account locally.

--- a/Features/Navigation/SidebarView.swift
+++ b/Features/Navigation/SidebarView.swift
@@ -237,7 +237,7 @@ struct SidebarView: View {
     }
     .sheet(isPresented: $showCreateAccountSheet) {
       CreateAccountView(
-        instrument: accountStore.currentTotal.instrument, accountStore: accountStore,
+        instrument: session.profile.instrument, accountStore: accountStore,
         supportsComplexTransactions: session.profile.supportsComplexTransactions)
     }
     .sheet(item: $accountToEdit) { account in

--- a/MoolahTests/Automation/AutomationServiceTests.swift
+++ b/MoolahTests/Automation/AutomationServiceTests.swift
@@ -252,7 +252,7 @@ struct AutomationServiceAccountTests {
     // Reload to pick up positions computed from the opening balance transaction
     await session.accountStore.load()
 
-    let netWorth = try service.getNetWorth(profileIdentifier: "Test")
+    let netWorth = try await service.getNetWorth(profileIdentifier: "Test")
     #expect(netWorth.quantity == 1000)
   }
 

--- a/MoolahTests/Features/AccountStoreTests.swift
+++ b/MoolahTests/Features/AccountStoreTests.swift
@@ -75,20 +75,49 @@ struct AccountStoreTests {
       targetInstrument: .defaultTestInstrument)
 
     await store.load()
+    await store.waitForPendingConversions()
 
     #expect(
-      store.currentTotal
+      store.convertedCurrentTotal
         == InstrumentAmount(
           quantity: Decimal(550000) / 100, instrument: Instrument.defaultTestInstrument))  // 100000 + 500000 - 50000
     #expect(
-      store.investmentTotal
+      store.convertedInvestmentTotal
         == InstrumentAmount(
           quantity: Decimal(2_000_000) / 100, instrument: Instrument.defaultTestInstrument))
     #expect(
-      store.netWorth
+      store.convertedNetWorth
         == InstrumentAmount(
           quantity: Decimal(2_550_000) / 100, instrument: Instrument.defaultTestInstrument)
     )
+  }
+
+  @Test func testConvertedTotalsHandleMixedInstruments() async throws {
+    let aud = Instrument.defaultTestInstrument  // AUD in tests
+    let usd = Instrument.fiat(code: "USD")
+    let (backend, container) = try TestBackend.create()
+    _ = seedAccount(name: "AUD Bank", balance: Decimal(100000) / 100, in: container)
+    _ = seedAccount(
+      name: "USD Bank", instrument: usd, balance: Decimal(50000) / 100, in: container)
+    _ = seedAccount(
+      name: "USD Asset", type: .asset, instrument: usd, balance: Decimal(20000) / 100,
+      in: container)
+
+    // 1 USD = 2 AUD — simple test rate
+    let conversion = FixedConversionService(rates: ["USD": 2])
+    let store = AccountStore(
+      repository: backend.accounts, conversionService: conversion, targetInstrument: aud)
+
+    await store.load()
+    await store.waitForPendingConversions()
+
+    // 1_000.00 AUD + (500.00 USD * 2) + (200.00 USD * 2) = 1_000 + 1_000 + 400 = 2_400.00
+    #expect(
+      store.convertedCurrentTotal
+        == InstrumentAmount(quantity: Decimal(240_000) / 100, instrument: aud))
+    #expect(
+      store.convertedNetWorth
+        == InstrumentAmount(quantity: Decimal(240_000) / 100, instrument: aud))
   }
 
   // MARK: - updateInvestmentValue
@@ -275,14 +304,16 @@ struct AccountStoreTests {
       repository: backend.accounts, conversionService: FixedConversionService(),
       targetInstrument: .defaultTestInstrument)
     await store.load()
+    await store.waitForPendingConversions()
 
-    #expect(store.currentTotal.quantity == Decimal(100000) / 100)
+    #expect(store.convertedCurrentTotal?.quantity == Decimal(100000) / 100)
 
     let deltas: PositionDeltas = [checkingId: [instrument: Decimal(-5000) / 100]]
     store.applyDelta(deltas)
+    await store.waitForPendingConversions()
 
-    #expect(store.currentTotal.quantity == Decimal(95000) / 100)
-    #expect(store.netWorth.quantity == Decimal(95000) / 100)
+    #expect(store.convertedCurrentTotal?.quantity == Decimal(95000) / 100)
+    #expect(store.convertedNetWorth?.quantity == Decimal(95000) / 100)
   }
 
   @Test func testApplyDeltaViaBalanceDeltaCalculator() async throws {
@@ -357,7 +388,7 @@ struct AccountStoreTests {
 
     await store.load()
     // Wait for async conversion task to complete
-    try await Task.sleep(for: .milliseconds(100))
+    await store.waitForPendingConversions()
 
     #expect(store.convertedCurrentTotal != nil)
     #expect(store.convertedCurrentTotal?.quantity == Decimal(100000) / 100)
@@ -377,13 +408,13 @@ struct AccountStoreTests {
     )
 
     await store.load()
-    try await Task.sleep(for: .milliseconds(100))
+    await store.waitForPendingConversions()
 
     #expect(store.convertedCurrentTotal?.quantity == Decimal(100000) / 100)
 
     let deltas: PositionDeltas = [acctId: [instrument: Decimal(-5000) / 100]]
     store.applyDelta(deltas)
-    try await Task.sleep(for: .milliseconds(100))
+    await store.waitForPendingConversions()
 
     #expect(store.convertedCurrentTotal?.quantity == Decimal(95000) / 100)
     #expect(store.convertedNetWorth?.quantity == Decimal(95000) / 100)


### PR DESCRIPTION
## Summary

- `AccountStore.currentTotal` / `investmentTotal` / `netWorth` summed amounts using `InstrumentAmount.+`, whose precondition traps when any account's instrument differs from the profile's. Any foreign-currency account would crash `getNetWorth` (App Intent / AppleScript) and the Create Account / Create Earmark sheets that read `currentTotal.instrument`.
- Remove the sync aggregates entirely. Migrate callers: `AutomationService.getNetWorth` is now `async` and goes through `computeConvertedCurrentTotal` + `computeConvertedInvestmentTotal`; sidebar / ContentView sheet presenters read `session.profile.instrument`.
- Tests updated to the converted totals, plus a new `testConvertedTotalsHandleMixedInstruments` that seeds an AUD + USD profile and verifies conversion lands.
- `BUGS.md` entry removed.

## Test plan

- [x] `just test` — 1106 iOS + 1122 macOS tests pass
- [x] New `testConvertedTotalsHandleMixedInstruments` passes
- [x] Updated `testCalculatesTotals` / `testApplyDeltaUpdatesTotals` / `getNetWorth` automation test still pass