### PR TITLE
fix: preserve earmark instrument across export/import round-trip

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -12,7 +12,3 @@ In `CloudKitAnalysisRepository.fetchDailyBalances` / `computeDailyBalances`, the
 
 `AccountStore.balance(for:)` (`Features/Accounts/AccountStore.swift:102-103`) returns only the position whose instrument matches `account.instrument`. If an account accumulates a position in any other instrument (e.g. a cross-currency transfer into it, or a stray crypto position), that value is invisible in the per-account sidebar row and in `canDelete` (line 109), even though the converted sidebar totals still include it. Show the full position list, or at least surface a badge / warning when an account holds off-primary positions.
 
-## No test round-trip for multi-currency export/import
-
-`ExportedData` serialises `instruments` alongside accounts, earmarks, and legs, but no test asserts that a profile containing mixed-currency accounts and earmarks survives an export → import cycle with instruments intact. Add a JSON round-trip test (ideally covering fiat, stock, and crypto instruments on both accounts and legs) to lock this in before Phase 9's CSV importer starts producing more multi-currency data.
-

--- a/Backends/CloudKit/Migration/CloudKitDataImporter.swift
+++ b/Backends/CloudKit/Migration/CloudKitDataImporter.swift
@@ -76,17 +76,7 @@ struct CloudKitDataImporter {
     // 3. Earmarks (no dependencies)
     progress?("earmarks", step / totalSteps)
     for earmark in data.earmarks {
-      let record = EarmarkRecord(
-        id: earmark.id,
-        name: earmark.name,
-        position: earmark.position,
-        isHidden: earmark.isHidden,
-        savingsTarget: earmark.savingsGoal?.storageValue,
-        savingsTargetInstrumentId: earmark.savingsGoal?.instrument.id,
-        savingsStartDate: earmark.savingsStartDate,
-        savingsEndDate: earmark.savingsEndDate
-      )
-      context.insert(record)
+      context.insert(EarmarkRecord.from(earmark))
     }
     step += 1
     await Task.yield()

--- a/MoolahTests/Export/ExportImportIntegrationTests.swift
+++ b/MoolahTests/Export/ExportImportIntegrationTests.swift
@@ -221,4 +221,175 @@ struct ExportImportIntegrationTests {
       _ = try await coordinator.importFromFile(url: fakeURL, modelContainer: container)
     }
   }
+
+  @Test("round-trip preserves fiat, stock, and crypto instruments across accounts, legs, earmarks")
+  func multiCurrencyRoundTrip() async throws {
+    let aud = Instrument.AUD
+    let usd = Instrument.USD
+    let bhp = Instrument.stock(ticker: "BHP.AX", exchange: "ASX", name: "BHP")
+    let eth = Instrument.crypto(
+      chainId: 1, contractAddress: nil, symbol: "ETH", name: "Ethereum", decimals: 18)
+
+    let (backend, _) = try TestBackend.create(instrument: aud)
+
+    let audAccount = try await backend.accounts.create(
+      Account(name: "Checking AUD", type: .bank, instrument: aud),
+      openingBalance: InstrumentAmount(quantity: Decimal(string: "1000.00")!, instrument: aud)
+    )
+    let usdAccount = try await backend.accounts.create(
+      Account(name: "USD Travel", type: .bank, instrument: usd),
+      openingBalance: InstrumentAmount(quantity: Decimal(string: "200.00")!, instrument: usd)
+    )
+    let stockAccount = try await backend.accounts.create(
+      Account(name: "Brokerage", type: .investment, instrument: bhp),
+      openingBalance: InstrumentAmount(quantity: Decimal(string: "10")!, instrument: bhp)
+    )
+    let cryptoAccount = try await backend.accounts.create(
+      Account(name: "Crypto Wallet", type: .asset, instrument: eth),
+      openingBalance: InstrumentAmount(quantity: Decimal(string: "0.5")!, instrument: eth)
+    )
+
+    let food = try await backend.categories.create(Category(name: "Food"))
+
+    let usdEarmark = try await backend.earmarks.create(
+      Earmark(
+        name: "US Trip", instrument: usd,
+        savingsGoal: InstrumentAmount(quantity: Decimal(string: "500.00")!, instrument: usd)
+      )
+    )
+    try await backend.earmarks.setBudget(
+      earmarkId: usdEarmark.id,
+      categoryId: food.id,
+      amount: InstrumentAmount(quantity: Decimal(string: "50.00")!, instrument: usd)
+    )
+
+    // Expense in USD, tagged to the USD earmark
+    _ = try await backend.transactions.create(
+      Transaction(
+        date: Date(),
+        payee: "NYC coffee",
+        legs: [
+          TransactionLeg(
+            accountId: usdAccount.id, instrument: usd,
+            quantity: Decimal(string: "-4.50")!, type: .expense,
+            categoryId: food.id, earmarkId: usdEarmark.id
+          )
+        ]
+      )
+    )
+
+    // Cross-instrument investment transfer (AUD -> BHP.AX)
+    _ = try await backend.transactions.create(
+      Transaction(
+        date: Date(),
+        payee: "Stock purchase",
+        legs: [
+          TransactionLeg(
+            accountId: audAccount.id, instrument: aud,
+            quantity: Decimal(string: "-500.00")!, type: .transfer
+          ),
+          TransactionLeg(
+            accountId: stockAccount.id, instrument: bhp,
+            quantity: Decimal(string: "5")!, type: .transfer
+          ),
+        ]
+      )
+    )
+
+    // Crypto income
+    _ = try await backend.transactions.create(
+      Transaction(
+        date: Date(),
+        payee: "Staking reward",
+        legs: [
+          TransactionLeg(
+            accountId: cryptoAccount.id, instrument: eth,
+            quantity: Decimal(string: "0.05")!, type: .income
+          )
+        ]
+      )
+    )
+
+    // Export via coordinator to a temporary JSON file
+    let tempURL = makeTempFileURL()
+    defer { try? FileManager.default.removeItem(at: tempURL) }
+
+    let profile = Profile(
+      label: "Multi-Currency Profile",
+      backendType: .cloudKit,
+      currencyCode: aud.id,
+      financialYearStartMonth: 7
+    )
+    let coordinator = MigrationCoordinator()
+    try await coordinator.exportToFile(url: tempURL, backend: backend, profile: profile)
+
+    // Serialized JSON must list all four instruments for the importer to rehydrate them
+    let exportedJSON = try Data(contentsOf: tempURL)
+    let decoded = try JSONDecoder.exportDecoder.decode(ExportedData.self, from: exportedJSON)
+    let exportedInstrumentIds = Set(decoded.instruments.map(\.id))
+    #expect(exportedInstrumentIds == [aud.id, usd.id, bhp.id, eth.id])
+
+    // Import into a fresh container and fetch everything back
+    let freshContainer = try TestModelContainer.create()
+    _ = try await coordinator.importFromFile(url: tempURL, modelContainer: freshContainer)
+
+    let freshBackend = CloudKitBackend(
+      modelContainer: freshContainer,
+      instrument: aud,
+      profileLabel: profile.label,
+      conversionService: FixedConversionService()
+    )
+
+    // Accounts: each should come back on its original instrument, with its primary position
+    let accounts = try await freshBackend.accounts.fetchAll()
+    let accountById = Dictionary(uniqueKeysWithValues: accounts.map { ($0.id, $0) })
+
+    let fetchedAud = try #require(accountById[audAccount.id])
+    #expect(fetchedAud.instrument == aud)
+    #expect(fetchedAud.positions.contains { $0.instrument == aud })
+
+    let fetchedUsd = try #require(accountById[usdAccount.id])
+    #expect(fetchedUsd.instrument == usd)
+    #expect(fetchedUsd.positions.contains { $0.instrument == usd })
+
+    let fetchedStock = try #require(accountById[stockAccount.id])
+    #expect(fetchedStock.instrument == bhp)
+    let bhpPosition = fetchedStock.positions.first { $0.instrument == bhp }
+    #expect(bhpPosition?.instrument.kind == .stock)
+    #expect(bhpPosition?.instrument.exchange == "ASX")
+    #expect(bhpPosition?.instrument.ticker == "BHP.AX")
+
+    let fetchedCrypto = try #require(accountById[cryptoAccount.id])
+    #expect(fetchedCrypto.instrument == eth)
+    let ethPosition = fetchedCrypto.positions.first { $0.instrument == eth }
+    #expect(ethPosition?.instrument.kind == .cryptoToken)
+    #expect(ethPosition?.instrument.chainId == 1)
+    #expect(ethPosition?.instrument.decimals == 18)
+
+    // Earmarks: USD earmark must stay on USD, not collapse to profile AUD
+    let earmarks = try await freshBackend.earmarks.fetchAll()
+    let fetchedEarmark = try #require(earmarks.first { $0.id == usdEarmark.id })
+    #expect(fetchedEarmark.instrument == usd)
+    #expect(fetchedEarmark.savingsGoal?.instrument == usd)
+
+    let budgetItems = try await freshBackend.earmarks.fetchBudget(earmarkId: usdEarmark.id)
+    #expect(budgetItems.first?.amount.instrument == usd)
+
+    // Transaction legs: each leg must retain its own instrument (fiat, stock, or crypto)
+    let txnPage = try await freshBackend.transactions.fetch(
+      filter: TransactionFilter(), page: 0, pageSize: 100)
+    let legInstruments = Set(txnPage.transactions.flatMap { $0.legs.map(\.instrument) })
+    #expect(legInstruments == [aud, usd, bhp, eth])
+
+    let stockLeg = txnPage.transactions
+      .flatMap(\.legs)
+      .first { $0.instrument.kind == .stock }
+    #expect(stockLeg?.instrument.ticker == "BHP.AX")
+
+    let cryptoLeg = txnPage.transactions
+      .flatMap(\.legs)
+      .first { $0.instrument.kind == .cryptoToken }
+    #expect(cryptoLeg?.instrument.chainId == 1)
+    #expect(cryptoLeg?.instrument.decimals == 18)
+  }
 }

--- a/MoolahTests/Export/ExportedDataTests.swift
+++ b/MoolahTests/Export/ExportedDataTests.swift
@@ -120,4 +120,155 @@ struct ExportedDataTests {
     #expect(exported.currencyCode == "")
     #expect(exported.financialYearStartMonth == 1)
   }
+
+  @Test("JSON round-trip preserves mixed-currency instruments on accounts, legs, and earmarks")
+  func multiCurrencyRoundTrip() throws {
+    let aud = Instrument.AUD
+    let usd = Instrument.USD
+    let bhp = Instrument.stock(ticker: "BHP.AX", exchange: "ASX", name: "BHP")
+    let eth = Instrument.crypto(
+      chainId: 1, contractAddress: nil, symbol: "ETH", name: "Ethereum", decimals: 18)
+
+    let audAccountId = UUID()
+    let usdAccountId = UUID()
+    let investmentAccountId = UUID()
+    let cryptoEarmarkAccountId = UUID()
+    let earmarkId = UUID()
+    let foodCategoryId = UUID()
+
+    let original = ExportedData(
+      version: 1,
+      exportedAt: Date(timeIntervalSince1970: 1_700_000_000),
+      profileLabel: "Multi-currency profile",
+      currencyCode: aud.id,
+      financialYearStartMonth: 7,
+      instruments: [aud, usd, bhp, eth],
+      accounts: [
+        Account(id: audAccountId, name: "Checking AUD", type: .bank, instrument: aud),
+        Account(id: usdAccountId, name: "USD Travel", type: .bank, instrument: usd),
+        Account(
+          id: investmentAccountId, name: "Brokerage", type: .investment, instrument: bhp),
+        Account(id: cryptoEarmarkAccountId, name: "Crypto Wallet", type: .asset, instrument: eth),
+      ],
+      categories: [
+        Category(id: foodCategoryId, name: "Food")
+      ],
+      earmarks: [
+        Earmark(
+          id: earmarkId, name: "US Trip", instrument: usd,
+          savingsGoal: InstrumentAmount(quantity: Decimal(string: "500")!, instrument: usd)
+        )
+      ],
+      earmarkBudgets: [
+        earmarkId: [
+          EarmarkBudgetItem(
+            categoryId: foodCategoryId,
+            amount: InstrumentAmount(quantity: Decimal(string: "50")!, instrument: usd)
+          )
+        ]
+      ],
+      transactions: [
+        Transaction(
+          date: Date(timeIntervalSince1970: 1_700_100_000),
+          payee: "Coffee shop NYC",
+          legs: [
+            TransactionLeg(
+              accountId: usdAccountId, instrument: usd,
+              quantity: Decimal(string: "-4.50")!, type: .expense,
+              categoryId: foodCategoryId, earmarkId: earmarkId
+            )
+          ]
+        ),
+        Transaction(
+          date: Date(timeIntervalSince1970: 1_700_200_000),
+          payee: "Stock purchase",
+          legs: [
+            TransactionLeg(
+              accountId: audAccountId, instrument: aud,
+              quantity: Decimal(string: "-1500.00")!, type: .transfer
+            ),
+            TransactionLeg(
+              accountId: investmentAccountId, instrument: bhp,
+              quantity: Decimal(string: "10")!, type: .transfer
+            ),
+          ]
+        ),
+        Transaction(
+          date: Date(timeIntervalSince1970: 1_700_300_000),
+          payee: "Crypto swap",
+          legs: [
+            TransactionLeg(
+              accountId: cryptoEarmarkAccountId, instrument: eth,
+              quantity: Decimal(string: "0.25")!, type: .income
+            )
+          ]
+        ),
+      ],
+      investmentValues: [
+        investmentAccountId: [
+          InvestmentValue(
+            date: Date(timeIntervalSince1970: 1_700_400_000),
+            value: InstrumentAmount(quantity: Decimal(string: "10")!, instrument: bhp)
+          )
+        ],
+        cryptoEarmarkAccountId: [
+          InvestmentValue(
+            date: Date(timeIntervalSince1970: 1_700_500_000),
+            value: InstrumentAmount(quantity: Decimal(string: "0.25")!, instrument: eth)
+          )
+        ],
+      ]
+    )
+
+    let data = try JSONEncoder.exportEncoder.encode(original)
+    let decoded = try JSONDecoder.exportDecoder.decode(ExportedData.self, from: data)
+
+    // Instruments list preserved (all four kinds: two fiat, stock, crypto)
+    let decodedInstrumentsById = Dictionary(
+      uniqueKeysWithValues: decoded.instruments.map { ($0.id, $0) })
+    #expect(decoded.instruments.count == 4)
+    #expect(decodedInstrumentsById[aud.id] == aud)
+    #expect(decodedInstrumentsById[usd.id] == usd)
+    #expect(decodedInstrumentsById[bhp.id] == bhp)
+    #expect(decodedInstrumentsById[eth.id] == eth)
+
+    // Accounts keep their instruments (fiat, stock, and crypto)
+    let decodedAccountsById = Dictionary(uniqueKeysWithValues: decoded.accounts.map { ($0.id, $0) })
+    #expect(decodedAccountsById[audAccountId]?.instrument == aud)
+    #expect(decodedAccountsById[usdAccountId]?.instrument == usd)
+    #expect(decodedAccountsById[investmentAccountId]?.instrument == bhp)
+    #expect(decodedAccountsById[cryptoEarmarkAccountId]?.instrument == eth)
+
+    // Earmark and its savings goal stay on the foreign fiat
+    let decodedEarmark = decoded.earmarks.first { $0.id == earmarkId }
+    #expect(decodedEarmark?.instrument == usd)
+    #expect(decodedEarmark?.savingsGoal?.instrument == usd)
+
+    // Budget item stays on the earmark's instrument
+    let decodedBudget = decoded.earmarkBudgets[earmarkId]?.first
+    #expect(decodedBudget?.amount.instrument == usd)
+
+    // Legs carry through their full kind-specific metadata
+    let legInstruments = decoded.transactions.flatMap { $0.legs.map(\.instrument) }
+    #expect(Set(legInstruments) == Set([aud, usd, bhp, eth]))
+
+    let stockLeg = decoded.transactions
+      .flatMap { $0.legs }
+      .first { $0.instrument.kind == .stock }
+    #expect(stockLeg?.instrument.ticker == "BHP.AX")
+    #expect(stockLeg?.instrument.exchange == "ASX")
+
+    let cryptoLeg = decoded.transactions
+      .flatMap { $0.legs }
+      .first { $0.instrument.kind == .cryptoToken }
+    #expect(cryptoLeg?.instrument.chainId == 1)
+    #expect(cryptoLeg?.instrument.ticker == "ETH")
+    #expect(cryptoLeg?.instrument.decimals == 18)
+
+    // Investment values keep their instrument
+    let decodedStockValues = decoded.investmentValues[investmentAccountId]
+    #expect(decodedStockValues?.first?.value.instrument == bhp)
+    let decodedCryptoValues = decoded.investmentValues[cryptoEarmarkAccountId]
+    #expect(decodedCryptoValues?.first?.value.instrument == eth)
+  }
 }


### PR DESCRIPTION
## Summary
- Replaces the hand-rolled `EarmarkRecord` init in `CloudKitDataImporter` with `EarmarkRecord.from(_:)` so the earmark's `instrumentId` is actually written. Previously, any foreign-currency earmark collapsed to the profile's default instrument on import.
- Adds multi-currency JSON round-trip test in `ExportedDataTests` covering fiat, stock, and crypto instruments on accounts, legs, earmarks, budgets, and investment values.
- Adds end-to-end export → JSON → import → fetch integration test in `ExportImportIntegrationTests` that exercised the importer bug and locks the behaviour in.
- Removes the corresponding entry from `BUGS.md`.

## Test plan
- [x] `just test-mac ExportedDataTests ExportImportIntegrationTests CloudKitDataImporterTests MigrationIntegrationTests MigrationVerifierTests`
- [x] `just test-mac` (full suite: 1123 tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)