### PR TITLE
docs: remove fixed investment-balance discontinuity bug

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -1,9 +1,5 @@
 # Known Bugs
 
-## Analysis starting balance vs. daily deltas use different rules for investment accounts
-
-In `CloudKitAnalysisRepository.fetchDailyBalances` / `computeDailyBalances`, the starting-balance phase (transactions with `date < after`) calls `applyTransaction` with `investmentTransfersOnly: false` — so every leg type on an investment account bumps the `investments` running total. The daily-delta phase (transactions with `date >= after`) calls it with `investmentTransfersOnly: true` — so only `.transfer` legs on investment accounts bump `investments`. This means the balance at the `after` boundary can jump when a non-transfer leg on an investment account flips sides: it counted on day `after - 1` but is ignored on day `after`. The rule was imported from the server's `selectBalance` vs `dailyProfitAndLoss` split; unclear whether the discontinuity is intentional. Decide once and apply consistently across both phases.
-
 ## Exchange-rate failure leaves sidebar totals permanently blank
 
 `AccountStore.recomputeConvertedTotals` (`Features/Accounts/AccountStore.swift:168-184`) and the equivalent in `EarmarkStore` (`Features/Earmarks/EarmarkStore.swift:114-168`) wrap the full loop in one `Task { do … catch }`. If a single conversion throws (e.g. `ExchangeRateService` can't reach Frankfurter and has no cached fallback for the requested currency), the whole task aborts and `convertedCurrentTotal` / `convertedNetWorth` / `convertedTotalBalance` stay `nil`, so the sidebar rows render spinners forever. Should degrade per-position: catch inside the inner loop, skip or zero the failed position, surface a warning to the user, and keep the rest of the totals.


### PR DESCRIPTION
## Summary
- Removes the \"Analysis starting balance vs. daily deltas use different rules for investment accounts\" entry from `BUGS.md`.
- Verified fixed: `CloudKitAnalysisRepository` now uses `PositionBook.apply(asStartingBalance:)`; both the pre-`after` starting-balance phase and the post-`after` daily-delta phase read investments via `accountsFromTransfers` (`rule: .investmentTransfersOnly`), so there is no longer a discontinuity at the boundary.

## Test plan
- [x] Docs-only change; no code paths modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)