### PR TITLE
fix: roll up descendant totals in expense breakdown

### DIFF
--- a/Features/Analysis/AnalysisStore.swift
+++ b/Features/Analysis/AnalysisStore.swift
@@ -190,6 +190,69 @@ final class AnalysisStore {
     return id
   }
 
+  /// Builds the pie-chart breakdown shown in `ExpenseBreakdownCard`.
+  ///
+  /// At the top level (`selectedCategoryId == nil`), each root category's total rolls up all
+  /// descendants' expenses. When drilled into a parent, each direct child's total rolls up its
+  /// own subtree; transactions directly on the drilled-into parent, or outside its subtree, are
+  /// excluded.
+  static func buildExpenseBreakdown(
+    from breakdown: [ExpenseBreakdown],
+    categories: Categories,
+    selectedCategoryId: UUID?
+  ) -> [ExpenseBreakdownWithPercentage] {
+    guard let instrument = breakdown.first?.totalExpenses.instrument else { return [] }
+
+    var totals: [UUID?: Decimal] = [:]
+    for item in breakdown {
+      let targetId: UUID?
+      if let selected = selectedCategoryId {
+        guard
+          let child = childOfAncestor(
+            for: item.categoryId, ancestor: selected, categories: categories)
+        else { continue }
+        targetId = child
+      } else {
+        targetId = rootCategoryId(for: item.categoryId, categories: categories)
+      }
+      totals[targetId, default: 0] += -item.totalExpenses.quantity
+    }
+
+    let grandTotal = totals.values.reduce(Decimal(0)) { $0 + max(0, $1) }
+
+    return
+      totals
+      .map { id, amount -> ExpenseBreakdownWithPercentage in
+        let clamped = max(0, amount)
+        let percentage =
+          grandTotal > 0
+          ? Double(truncating: (clamped / grandTotal * 100) as NSDecimalNumber) : 0
+        return ExpenseBreakdownWithPercentage(
+          categoryId: id,
+          totalExpenses: InstrumentAmount(quantity: clamped, instrument: instrument),
+          percentage: percentage
+        )
+      }
+      .sorted { $0.totalExpenses.quantity > $1.totalExpenses.quantity }
+  }
+
+  /// Returns the id of the node in `ancestor`'s direct children that is an ancestor of (or equal
+  /// to) `categoryId`, or nil if `categoryId` is outside `ancestor`'s subtree or is `ancestor`
+  /// itself.
+  private static func childOfAncestor(
+    for categoryId: UUID?, ancestor: UUID, categories: Categories
+  ) -> UUID? {
+    guard var id = categoryId else { return nil }
+    while let category = categories.by(id: id) {
+      if category.parentId == ancestor {
+        return id
+      }
+      guard let parentId = category.parentId else { return nil }
+      id = parentId
+    }
+    return nil
+  }
+
   private static func parseMonth(_ month: String) -> Date {
     let formatter = DateFormatter()
     formatter.dateFormat = "yyyyMM"

--- a/Features/Analysis/Views/ExpenseBreakdownCard.swift
+++ b/Features/Analysis/Views/ExpenseBreakdownCard.swift
@@ -101,46 +101,8 @@ struct ExpenseBreakdownCard: View {
   }
 
   private var filteredBreakdown: [ExpenseBreakdownWithPercentage] {
-    // Sum all expenses for this category level, negated to positive for display
-    // (server returns negative amounts for expenses)
-    let categoryTotals = Dictionary(grouping: breakdown) { $0.categoryId }
-      .mapValues { items -> InstrumentAmount in
-        let sum = items.reduce(
-          InstrumentAmount.zero(instrument: items.first!.totalExpenses.instrument)
-        ) {
-          $0 + $1.totalExpenses
-        }
-        let negated = InstrumentAmount(quantity: max(0, -sum.quantity), instrument: sum.instrument)
-        return negated
-      }
-
-    // Filter by selectedCategoryId (show only children if drill-down active)
-    let visibleCategories: [UUID?]
-    if let selectedId = selectedCategoryId {
-      let children = categories.children(of: selectedId)
-        .map { $0.id as UUID? }
-      visibleCategories = children
-    } else {
-      // Show top-level categories (no parent)
-      visibleCategories =
-        categories.roots
-        .map { $0.id as UUID? }
-        + [nil]  // Include uncategorized
-    }
-
-    let filtered = categoryTotals.filter { visibleCategories.contains($0.key) }
-    let total = filtered.values.reduce(
-      .zero(instrument: filtered.values.first?.instrument ?? .AUD), +)
-
-    return filtered.map { categoryId, amount in
-      ExpenseBreakdownWithPercentage(
-        categoryId: categoryId,
-        totalExpenses: amount,
-        percentage: total.quantity > 0
-          ? Double(truncating: (amount.quantity / total.quantity * 100) as NSDecimalNumber) : 0
-      )
-    }
-    .sorted { $0.totalExpenses.quantity > $1.totalExpenses.quantity }
+    AnalysisStore.buildExpenseBreakdown(
+      from: breakdown, categories: categories, selectedCategoryId: selectedCategoryId)
   }
 
   private func categoryName(for id: UUID?) -> String {

--- a/MoolahTests/Features/AnalysisStoreTests.swift
+++ b/MoolahTests/Features/AnalysisStoreTests.swift
@@ -237,6 +237,236 @@ struct AnalysisStoreCategoriesOverTimeTests {
   }
 }
 
+// MARK: - AnalysisStore.buildExpenseBreakdown
+
+@Suite("AnalysisStore — buildExpenseBreakdown")
+@MainActor
+struct AnalysisStoreBuildExpenseBreakdownTests {
+
+  private func amt(_ quantity: Decimal) -> InstrumentAmount {
+    InstrumentAmount(quantity: quantity, instrument: .defaultTestInstrument)
+  }
+
+  @Test func emptyBreakdownReturnsNoEntries() {
+    let result = AnalysisStore.buildExpenseBreakdown(
+      from: [], categories: Categories(from: []), selectedCategoryId: nil)
+    #expect(result.isEmpty)
+  }
+
+  @Test func topLevelRollsUpChildIntoRoot() {
+    // Repro: user reports a root category total does not include descendants.
+    let foodId = UUID()
+    let groceriesId = UUID()
+    let breakdown = [
+      ExpenseBreakdown(
+        categoryId: foodId, month: "202604",
+        totalExpenses: amt(Decimal(string: "-100.00")!)),
+      ExpenseBreakdown(
+        categoryId: groceriesId, month: "202604",
+        totalExpenses: amt(Decimal(string: "-300.00")!)),
+    ]
+    let categories = Categories(from: [
+      Category(id: foodId, name: "Food"),
+      Category(id: groceriesId, name: "Groceries", parentId: foodId),
+    ])
+
+    let result = AnalysisStore.buildExpenseBreakdown(
+      from: breakdown, categories: categories, selectedCategoryId: nil)
+
+    #expect(result.count == 1)
+    #expect(result[0].categoryId == foodId)
+    #expect(result[0].totalExpenses.quantity == Decimal(string: "400.00")!)
+    #expect(result[0].percentage == 100.0)
+  }
+
+  @Test func topLevelRollsUpMultipleLevelsOfDescendants() {
+    let foodId = UUID()
+    let groceriesId = UUID()
+    let organicId = UUID()
+    let breakdown = [
+      ExpenseBreakdown(
+        categoryId: foodId, month: "202604",
+        totalExpenses: amt(Decimal(string: "-10.00")!)),
+      ExpenseBreakdown(
+        categoryId: groceriesId, month: "202604",
+        totalExpenses: amt(Decimal(string: "-20.00")!)),
+      ExpenseBreakdown(
+        categoryId: organicId, month: "202604",
+        totalExpenses: amt(Decimal(string: "-30.00")!)),
+    ]
+    let categories = Categories(from: [
+      Category(id: foodId, name: "Food"),
+      Category(id: groceriesId, name: "Groceries", parentId: foodId),
+      Category(id: organicId, name: "Organic", parentId: groceriesId),
+    ])
+
+    let result = AnalysisStore.buildExpenseBreakdown(
+      from: breakdown, categories: categories, selectedCategoryId: nil)
+
+    #expect(result.count == 1)
+    #expect(result[0].categoryId == foodId)
+    #expect(result[0].totalExpenses.quantity == Decimal(string: "60.00")!)
+  }
+
+  @Test func topLevelSortsByTotalDescending() {
+    let foodId = UUID()
+    let transportId = UUID()
+    let breakdown = [
+      ExpenseBreakdown(
+        categoryId: foodId, month: "202604",
+        totalExpenses: amt(Decimal(string: "-200.00")!)),
+      ExpenseBreakdown(
+        categoryId: transportId, month: "202604",
+        totalExpenses: amt(Decimal(string: "-600.00")!)),
+    ]
+    let categories = Categories(from: [
+      Category(id: foodId, name: "Food"),
+      Category(id: transportId, name: "Transport"),
+    ])
+
+    let result = AnalysisStore.buildExpenseBreakdown(
+      from: breakdown, categories: categories, selectedCategoryId: nil)
+
+    #expect(result.count == 2)
+    #expect(result[0].categoryId == transportId)
+    #expect(result[0].percentage == 75.0)
+    #expect(result[1].categoryId == foodId)
+    #expect(result[1].percentage == 25.0)
+  }
+
+  @Test func topLevelIncludesUncategorized() {
+    let foodId = UUID()
+    let breakdown = [
+      ExpenseBreakdown(
+        categoryId: foodId, month: "202604",
+        totalExpenses: amt(Decimal(string: "-300.00")!)),
+      ExpenseBreakdown(
+        categoryId: nil, month: "202604",
+        totalExpenses: amt(Decimal(string: "-100.00")!)),
+    ]
+    let categories = Categories(from: [Category(id: foodId, name: "Food")])
+
+    let result = AnalysisStore.buildExpenseBreakdown(
+      from: breakdown, categories: categories, selectedCategoryId: nil)
+
+    #expect(result.count == 2)
+    let food = result.first { $0.categoryId == foodId }
+    #expect(food?.totalExpenses.quantity == Decimal(string: "300.00")!)
+    let uncategorized = result.first { $0.categoryId == nil }
+    #expect(uncategorized?.totalExpenses.quantity == Decimal(string: "100.00")!)
+  }
+
+  @Test func drilledInShowsChildrenWithDescendantsRolledUp() {
+    let foodId = UUID()
+    let groceriesId = UUID()
+    let organicId = UUID()
+    let restaurantsId = UUID()
+    let breakdown = [
+      ExpenseBreakdown(
+        categoryId: foodId, month: "202604",
+        totalExpenses: amt(Decimal(string: "-10.00")!)),
+      ExpenseBreakdown(
+        categoryId: groceriesId, month: "202604",
+        totalExpenses: amt(Decimal(string: "-20.00")!)),
+      ExpenseBreakdown(
+        categoryId: organicId, month: "202604",
+        totalExpenses: amt(Decimal(string: "-30.00")!)),
+      ExpenseBreakdown(
+        categoryId: restaurantsId, month: "202604",
+        totalExpenses: amt(Decimal(string: "-40.00")!)),
+    ]
+    let categories = Categories(from: [
+      Category(id: foodId, name: "Food"),
+      Category(id: groceriesId, name: "Groceries", parentId: foodId),
+      Category(id: organicId, name: "Organic", parentId: groceriesId),
+      Category(id: restaurantsId, name: "Restaurants", parentId: foodId),
+    ])
+
+    let result = AnalysisStore.buildExpenseBreakdown(
+      from: breakdown, categories: categories, selectedCategoryId: foodId)
+
+    // Groceries direct (20) + Organic (30) = 50; Restaurants = 40. Food-direct (10) excluded.
+    #expect(result.count == 2)
+    let groceries = result.first { $0.categoryId == groceriesId }
+    #expect(groceries?.totalExpenses.quantity == Decimal(string: "50.00")!)
+    let restaurants = result.first { $0.categoryId == restaurantsId }
+    #expect(restaurants?.totalExpenses.quantity == Decimal(string: "40.00")!)
+  }
+
+  @Test func drilledInExcludesItemsOutsideSubtree() {
+    let foodId = UUID()
+    let groceriesId = UUID()
+    let transportId = UUID()
+    let breakdown = [
+      ExpenseBreakdown(
+        categoryId: groceriesId, month: "202604",
+        totalExpenses: amt(Decimal(string: "-100.00")!)),
+      ExpenseBreakdown(
+        categoryId: transportId, month: "202604",
+        totalExpenses: amt(Decimal(string: "-200.00")!)),
+    ]
+    let categories = Categories(from: [
+      Category(id: foodId, name: "Food"),
+      Category(id: groceriesId, name: "Groceries", parentId: foodId),
+      Category(id: transportId, name: "Transport"),
+    ])
+
+    let result = AnalysisStore.buildExpenseBreakdown(
+      from: breakdown, categories: categories, selectedCategoryId: foodId)
+
+    #expect(result.count == 1)
+    #expect(result[0].categoryId == groceriesId)
+    #expect(result[0].totalExpenses.quantity == Decimal(string: "100.00")!)
+    #expect(result[0].percentage == 100.0)
+  }
+
+  @Test func multipleMonthsAccumulateIntoSameRollupTarget() {
+    let foodId = UUID()
+    let groceriesId = UUID()
+    let breakdown = [
+      ExpenseBreakdown(
+        categoryId: groceriesId, month: "202604",
+        totalExpenses: amt(Decimal(string: "-100.00")!)),
+      ExpenseBreakdown(
+        categoryId: groceriesId, month: "202605",
+        totalExpenses: amt(Decimal(string: "-200.00")!)),
+      ExpenseBreakdown(
+        categoryId: foodId, month: "202605",
+        totalExpenses: amt(Decimal(string: "-50.00")!)),
+    ]
+    let categories = Categories(from: [
+      Category(id: foodId, name: "Food"),
+      Category(id: groceriesId, name: "Groceries", parentId: foodId),
+    ])
+
+    let result = AnalysisStore.buildExpenseBreakdown(
+      from: breakdown, categories: categories, selectedCategoryId: nil)
+
+    #expect(result.count == 1)
+    #expect(result[0].categoryId == foodId)
+    #expect(result[0].totalExpenses.quantity == Decimal(string: "350.00")!)
+  }
+
+  @Test func positiveExpensesClampToZero() {
+    // Server returns negative for expenses; positive values are refunds.
+    // Matching web app's Math.max(0, ...) behavior, net-positive rollups clamp to zero.
+    let foodId = UUID()
+    let breakdown = [
+      ExpenseBreakdown(
+        categoryId: foodId, month: "202604",
+        totalExpenses: amt(Decimal(string: "100.00")!))
+    ]
+    let categories = Categories(from: [Category(id: foodId, name: "Food")])
+
+    let result = AnalysisStore.buildExpenseBreakdown(
+      from: breakdown, categories: categories, selectedCategoryId: nil)
+
+    #expect(result.count == 1)
+    #expect(result[0].totalExpenses.quantity == 0)
+    #expect(result[0].percentage == 0)
+  }
+}
+
 // MARK: - IncomeExpenseTableCard.cumulativeSavings
 
 @Suite("IncomeExpenseTableCard — cumulativeSavings")


### PR DESCRIPTION
## Summary
- The Expenses by Category legend grouped transactions by exact category id, so a root like "Food" didn't include descendants such as Groceries. The pie chart read the same data, so sector sizes were wrong too — proportions only looked plausible by coincidence.
- Adds `AnalysisStore.buildExpenseBreakdown(from:categories:selectedCategoryId:)` which rolls up each expense item to its root (top-level view) or to the direct child of the drilled-into parent (drill-down). Transactions outside the drilled subtree, or directly on the drill-down parent itself, remain excluded.
- `ExpenseBreakdownCard.filteredBreakdown` now delegates to the store — keeping the view thin and the rollup testable.

## Test plan
- [x] `just test` (1136 tests pass)
- [x] 9 new tests in `AnalysisStoreBuildExpenseBreakdownTests` covering top-level rollup, multi-level descendants, sort order, uncategorized, drill-down child rollup, subtree exclusion, multi-month accumulation, and the positive-clamp edge case.
- [ ] Manual: open Analysis, confirm a root category total in the legend now matches the sum of its subtree; drill into a parent, confirm each child row sums its own subtree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)