### PR TITLE
Fix: transactions vanish when currency conversion fails

### DIFF
--- a/Backends/CloudKit/Repositories/CloudKitTransactionRepository.swift
+++ b/Backends/CloudKit/Repositories/CloudKitTransactionRepository.swift
@@ -49,6 +49,17 @@ final class CloudKitTransactionRepository: TransactionRepository, @unchecked Sen
     instrumentCache[instrument.id] = instrument
   }
 
+  /// Returns the instrument associated with the given account, falling back
+  /// to the profile instrument if the account isn't found.
+  @MainActor
+  private func accountInstrument(id: UUID) throws -> Instrument {
+    let accountDescriptor = FetchDescriptor<AccountRecord>(predicate: #Predicate { $0.id == id })
+    guard let record = try context.fetch(accountDescriptor).first else {
+      return self.instrument
+    }
+    return try resolveInstrument(id: record.instrumentId)
+  }
+
   // MARK: - Fetch Legs for Transactions
 
   @MainActor
@@ -180,9 +191,17 @@ final class CloudKitTransactionRepository: TransactionRepository, @unchecked Sen
       // --- Paginate ---
       let offset = page * pageSize
       guard offset < filteredRecords.count else {
+        // Empty page — priorBalance is zero in whichever instrument best
+        // matches the filter context.
+        let emptyInstrument: Instrument
+        if let filterAccountId = filter.accountId {
+          emptyInstrument = (try? accountInstrument(id: filterAccountId)) ?? self.instrument
+        } else {
+          emptyInstrument = self.instrument
+        }
         return TransactionPage(
           transactions: [],
-          priorBalance: InstrumentAmount.zero(instrument: self.instrument),
+          priorBalance: InstrumentAmount.zero(instrument: emptyInstrument),
           totalCount: filteredRecords.count)
       }
       let totalCount = filteredRecords.count
@@ -197,7 +216,9 @@ final class CloudKitTransactionRepository: TransactionRepository, @unchecked Sen
       }
       os_signpost(.end, log: Signposts.repository, name: "fetch.toDomain", signpostID: signpostID)
 
-      // priorBalance = sum of leg quantities for the filtered account for records after the page
+      // priorBalance = sum of leg quantities for the filtered account for records after the page.
+      // Account balances are tracked in the account's own instrument (legs of
+      // an account share its instrument), not the profile instrument.
       os_signpost(
         .begin, log: Signposts.balance, name: "fetch.priorBalance", signpostID: signpostID)
       let priorBalance: InstrumentAmount
@@ -212,8 +233,9 @@ final class CloudKitTransactionRepository: TransactionRepository, @unchecked Sen
         for leg in allAccountLegs where afterPageRecordIds.contains(leg.transactionId) {
           totalStorageValue += leg.quantity
         }
+        let accountInstrument = try accountInstrument(id: filterAccountId)
         priorBalance = InstrumentAmount(
-          storageValue: totalStorageValue, instrument: self.instrument)
+          storageValue: totalStorageValue, instrument: accountInstrument)
       } else {
         priorBalance = InstrumentAmount.zero(instrument: self.instrument)
       }

--- a/Backends/Frankfurter/FrankfurterClient.swift
+++ b/Backends/Frankfurter/FrankfurterClient.swift
@@ -2,8 +2,14 @@
 import Foundation
 import OSLog
 
+/// Client for the public Frankfurter exchange-rate API.
+/// Uses the range endpoint `<from>..<to>?base=<code>` which returns rates
+/// keyed by trading date. When the requested range has no trading data
+/// (weekends/holidays/today before the daily post), Frankfurter shifts the
+/// response to the nearest available trading day; 404 is returned only when
+/// the requested dates are wholly outside coverage (e.g. far-future).
 struct FrankfurterClient: ExchangeRateClient, Sendable {
-  private static let baseURL = URL(string: "https://api.frankfurter.dev/v2/")!
+  private static let baseURL = URL(string: "https://api.frankfurter.app/")!
   private static let logger = Logger(subsystem: "com.moolah.app", category: "FrankfurterClient")
   private let session: URLSession
 
@@ -42,19 +48,14 @@ struct FrankfurterClient: ExchangeRateClient, Sendable {
     return try Self.parseResponse(data)
   }
 
+  /// Parses the Frankfurter range response. Shape:
+  /// `{"amount":1.0,"base":"GBP","start_date":"...","end_date":"...","rates":{"2026-04-10":{"AUD":1.9,...}}}`
   static func parseResponse(_ data: Data) throws -> [String: [String: Decimal]] {
-    let entries = try JSONDecoder().decode([FrankfurterEntry].self, from: data)
-    var result: [String: [String: Decimal]] = [:]
-    for entry in entries {
-      result[entry.date, default: [:]][entry.quote] = entry.rate
-    }
-    return result
+    let response = try JSONDecoder().decode(FrankfurterRangeResponse.self, from: data)
+    return response.rates
   }
 }
 
-private struct FrankfurterEntry: Decodable {
-  let date: String
-  let base: String
-  let quote: String
-  let rate: Decimal
+private struct FrankfurterRangeResponse: Decodable {
+  let rates: [String: [String: Decimal]]
 }

--- a/Domain/Models/Transaction.swift
+++ b/Domain/Models/Transaction.swift
@@ -254,6 +254,12 @@ struct TransactionPage: Sendable {
   /// to the target instrument and computing a display amount per transaction.
   /// Transactions must be ordered newest-first (as returned by the repository).
   /// `priorBalance` is the account balance before the oldest transaction in the list.
+  ///
+  /// Graceful degradation: when a leg cannot be converted (e.g. exchange rate
+  /// unavailable), that transaction is returned with `displayAmount == nil` and
+  /// `balance == nil`, and every subsequent (newer) transaction also has
+  /// `balance == nil` since the running total can no longer be tracked.
+  /// The transactions themselves are always returned.
   static func withRunningBalances(
     transactions: [Transaction],
     priorBalance: InstrumentAmount,
@@ -261,54 +267,73 @@ struct TransactionPage: Sendable {
     earmarkId: UUID? = nil,
     targetInstrument: Instrument,
     conversionService: InstrumentConversionService
-  ) async throws -> [TransactionWithBalance] {
-    var balance = priorBalance
+  ) async -> [TransactionWithBalance] {
+    var balance: InstrumentAmount? = priorBalance
     var result: [TransactionWithBalance] = []
     result.reserveCapacity(transactions.count)
 
     for transaction in transactions.reversed() {
-      var convertedLegs: [ConvertedTransactionLeg] = []
-      for leg in transaction.legs {
-        if leg.instrument == targetInstrument {
-          convertedLegs.append(ConvertedTransactionLeg(leg: leg, convertedAmount: leg.amount))
-        } else {
-          let converted = try await conversionService.convertAmount(
-            leg.amount, to: targetInstrument, on: transaction.date)
-          convertedLegs.append(ConvertedTransactionLeg(leg: leg, convertedAmount: converted))
+      let convertedLegs: [ConvertedTransactionLeg]?
+      do {
+        var legs: [ConvertedTransactionLeg] = []
+        legs.reserveCapacity(transaction.legs.count)
+        for leg in transaction.legs {
+          if leg.instrument == targetInstrument {
+            legs.append(ConvertedTransactionLeg(leg: leg, convertedAmount: leg.amount))
+          } else {
+            let converted = try await conversionService.convertAmount(
+              leg.amount, to: targetInstrument, on: transaction.date)
+            legs.append(ConvertedTransactionLeg(leg: leg, convertedAmount: converted))
+          }
         }
+        convertedLegs = legs
+      } catch {
+        convertedLegs = nil
       }
 
-      let displayAmount: InstrumentAmount
-      if let accountId {
-        displayAmount =
-          convertedLegs
-          .filter { $0.leg.accountId == accountId }
-          .reduce(InstrumentAmount.zero(instrument: targetInstrument)) { $0 + $1.convertedAmount }
-      } else if let earmarkId {
-        // Earmark context (no account): sum legs matching the viewing earmark
-        displayAmount =
-          convertedLegs
-          .filter { $0.leg.earmarkId == earmarkId }
-          .reduce(InstrumentAmount.zero(instrument: targetInstrument)) { $0 + $1.convertedAmount }
-      } else {
-        // No account context (scheduled view): use negative-quantity leg for transfers,
-        // otherwise sum all legs
-        let isTransfer = transaction.legs.contains { $0.type == .transfer }
-        if isTransfer {
-          let negativeLeg = convertedLegs.first { $0.leg.quantity < 0 }
-          displayAmount = negativeLeg?.convertedAmount ?? .zero(instrument: targetInstrument)
-        } else {
+      let displayAmount: InstrumentAmount?
+      if let convertedLegs {
+        if let accountId {
           displayAmount =
             convertedLegs
+            .filter { $0.leg.accountId == accountId }
             .reduce(InstrumentAmount.zero(instrument: targetInstrument)) { $0 + $1.convertedAmount }
+        } else if let earmarkId {
+          // Earmark context (no account): sum legs matching the viewing earmark
+          displayAmount =
+            convertedLegs
+            .filter { $0.leg.earmarkId == earmarkId }
+            .reduce(InstrumentAmount.zero(instrument: targetInstrument)) { $0 + $1.convertedAmount }
+        } else {
+          // No account context (scheduled view): use negative-quantity leg for transfers,
+          // otherwise sum all legs
+          let isTransfer = transaction.legs.contains { $0.type == .transfer }
+          if isTransfer {
+            let negativeLeg = convertedLegs.first { $0.leg.quantity < 0 }
+            displayAmount = negativeLeg?.convertedAmount ?? .zero(instrument: targetInstrument)
+          } else {
+            displayAmount =
+              convertedLegs
+              .reduce(InstrumentAmount.zero(instrument: targetInstrument)) {
+                $0 + $1.convertedAmount
+              }
+          }
         }
+      } else {
+        displayAmount = nil
       }
 
-      balance += displayAmount
+      if let displayAmount, var runningBalance = balance {
+        runningBalance += displayAmount
+        balance = runningBalance
+      } else {
+        balance = nil
+      }
+
       result.append(
         TransactionWithBalance(
           transaction: transaction,
-          convertedLegs: convertedLegs,
+          convertedLegs: convertedLegs ?? [],
           displayAmount: displayAmount,
           balance: balance
         ))
@@ -320,11 +345,15 @@ struct TransactionPage: Sendable {
 }
 
 /// A transaction paired with converted leg amounts and the account balance after it was applied.
+///
+/// `displayAmount` and `balance` are `nil` when conversion failed — either for
+/// this transaction's legs or for an earlier transaction in the running-balance
+/// chain. `convertedLegs` is empty in the same case.
 struct TransactionWithBalance: Sendable, Identifiable {
   let transaction: Transaction
   let convertedLegs: [ConvertedTransactionLeg]
-  let displayAmount: InstrumentAmount
-  let balance: InstrumentAmount
+  let displayAmount: InstrumentAmount?
+  let balance: InstrumentAmount?
 
   var id: UUID { transaction.id }
 

--- a/Features/Analysis/Views/UpcomingTransactionsCard.swift
+++ b/Features/Analysis/Views/UpcomingTransactionsCard.swift
@@ -95,7 +95,7 @@ private struct SimpleTransactionRow: View {
   let transaction: Transaction
   let accounts: Accounts
   let earmarks: Earmarks
-  let displayAmount: InstrumentAmount
+  let displayAmount: InstrumentAmount?
   let isOverdue: Bool
   let isDueToday: Bool
   let onPay: () async -> Void
@@ -142,13 +142,20 @@ private struct SimpleTransactionRow: View {
 
       Spacer()
 
-      Text(
-        displayAmount.quantity,
-        format: .currency(code: displayAmount.instrument.id)
-      )
-      .font(.body)
-      .monospacedDigit()
-      .foregroundStyle(displayAmount.quantity >= 0 ? .green : .red)
+      if let displayAmount {
+        Text(
+          displayAmount.quantity,
+          format: .currency(code: displayAmount.instrument.id)
+        )
+        .font(.body)
+        .monospacedDigit()
+        .foregroundStyle(displayAmount.quantity >= 0 ? .green : .red)
+      } else {
+        Text("—")
+          .font(.body)
+          .monospacedDigit()
+          .foregroundStyle(.secondary)
+      }
 
       Button {
         Task {

--- a/Features/Transactions/TransactionStore.swift
+++ b/Features/Transactions/TransactionStore.swift
@@ -14,7 +14,15 @@ final class TransactionStore {
 
   private let repository: TransactionRepository
   private let conversionService: InstrumentConversionService
+  /// The default target instrument (profile currency). Used when `load` is
+  /// called without an explicit override — e.g. scheduled/upcoming views
+  /// where no account context narrows the display currency.
   private(set) var targetInstrument: Instrument
+  /// The instrument used for the currently-loaded view — either the override
+  /// passed to `load(filter:targetInstrument:)` or `targetInstrument`.
+  /// Account-scoped views display balances in the account's own currency so
+  /// legs native to that account never require conversion.
+  private(set) var currentTargetInstrument: Instrument
   private let pageSize: Int
   private let accountStore: AccountStore?
   private let earmarkStore: EarmarkStore?
@@ -35,16 +43,25 @@ final class TransactionStore {
     self.repository = repository
     self.conversionService = conversionService
     self.targetInstrument = targetInstrument
+    self.currentTargetInstrument = targetInstrument
     self.pageSize = pageSize
     self.accountStore = accountStore
     self.earmarkStore = earmarkStore
   }
 
-  func load(filter: TransactionFilter) async {
+  /// Loads transactions matching `filter`.
+  ///
+  /// When `targetInstrument` is supplied it overrides the store's default
+  /// (profile) instrument for this load — used by account-scoped views so
+  /// the display currency matches the viewing account. Pass `nil` for global
+  /// views (scheduled, upcoming, analysis) that should display in the
+  /// profile currency.
+  func load(filter: TransactionFilter, targetInstrument: Instrument? = nil) async {
     currentFilter = filter
+    currentTargetInstrument = targetInstrument ?? self.targetInstrument
     currentPage = 0
     rawTransactions = []
-    priorBalance = .zero(instrument: targetInstrument)
+    priorBalance = .zero(instrument: currentTargetInstrument)
     transactions = []
     hasMore = true
     error = nil
@@ -320,17 +337,13 @@ final class TransactionStore {
       if a.date != b.date { return a.date > b.date }
       return a.id.uuidString < b.id.uuidString
     }
-    do {
-      transactions = try await TransactionPage.withRunningBalances(
-        transactions: rawTransactions,
-        priorBalance: priorBalance,
-        accountId: currentFilter.accountId,
-        earmarkId: currentFilter.earmarkId,
-        targetInstrument: targetInstrument,
-        conversionService: conversionService
-      )
-    } catch {
-      logger.error("Failed to compute balances: \(error.localizedDescription)")
-    }
+    transactions = await TransactionPage.withRunningBalances(
+      transactions: rawTransactions,
+      priorBalance: priorBalance,
+      accountId: currentFilter.accountId,
+      earmarkId: currentFilter.earmarkId,
+      targetInstrument: currentTargetInstrument,
+      conversionService: conversionService
+    )
   }
 }

--- a/Features/Transactions/TransactionStore.swift
+++ b/Features/Transactions/TransactionStore.swift
@@ -14,14 +14,14 @@ final class TransactionStore {
 
   private let repository: TransactionRepository
   private let conversionService: InstrumentConversionService
-  /// The default target instrument (profile currency). Used when `load` is
-  /// called without an explicit override — e.g. scheduled/upcoming views
-  /// where no account context narrows the display currency.
+  /// The store's default target instrument (profile currency). Used for views
+  /// that don't narrow to a single account — scheduled, upcoming, analysis.
   private(set) var targetInstrument: Instrument
-  /// The instrument used for the currently-loaded view — either the override
-  /// passed to `load(filter:targetInstrument:)` or `targetInstrument`.
+  /// The instrument used for the currently-loaded view.
   /// Account-scoped views display balances in the account's own currency so
-  /// legs native to that account never require conversion.
+  /// native legs don't require conversion. The repository reports the
+  /// account's instrument via `TransactionPage.priorBalance.instrument`, and
+  /// the store aligns to it on the first page fetch.
   private(set) var currentTargetInstrument: Instrument
   private let pageSize: Int
   private let accountStore: AccountStore?
@@ -49,16 +49,9 @@ final class TransactionStore {
     self.earmarkStore = earmarkStore
   }
 
-  /// Loads transactions matching `filter`.
-  ///
-  /// When `targetInstrument` is supplied it overrides the store's default
-  /// (profile) instrument for this load — used by account-scoped views so
-  /// the display currency matches the viewing account. Pass `nil` for global
-  /// views (scheduled, upcoming, analysis) that should display in the
-  /// profile currency.
-  func load(filter: TransactionFilter, targetInstrument: Instrument? = nil) async {
+  func load(filter: TransactionFilter) async {
     currentFilter = filter
-    currentTargetInstrument = targetInstrument ?? self.targetInstrument
+    currentTargetInstrument = targetInstrument
     currentPage = 0
     rawTransactions = []
     priorBalance = .zero(instrument: currentTargetInstrument)
@@ -247,6 +240,13 @@ final class TransactionStore {
       )
       rawTransactions.append(contentsOf: page.transactions)
       priorBalance = page.priorBalance
+      // Adopt the repository's instrument for the display currency. For
+      // single-account views the repo returns the account's instrument so
+      // native legs never need conversion; for global views it's the profile
+      // instrument. This only changes on the first page load.
+      if currentPage == 0 {
+        currentTargetInstrument = page.priorBalance.instrument
+      }
       hasMore = page.transactions.count >= pageSize
       currentPage += 1
       loadedCount = rawTransactions.count

--- a/Features/Transactions/Views/TransactionListView.swift
+++ b/Features/Transactions/Views/TransactionListView.swift
@@ -179,13 +179,6 @@ struct TransactionListView: View {
     }
   }
 
-  /// For account-scoped views, display balances in the viewing account's own
-  /// currency so native legs never require conversion. Otherwise fall back to
-  /// the store's default (profile) instrument.
-  private func targetInstrumentForFilter(_ filter: TransactionFilter) -> Instrument? {
-    filter.accountId.flatMap { accounts.by(id: $0)?.instrument }
-  }
-
   private var listView: some View {
     List(selection: selectedTransactionBinding) {
       PositionListView(positions: positions)
@@ -270,7 +263,7 @@ struct TransactionListView: View {
         Button {
           Task {
             await transactionStore.load(
-              filter: filter, targetInstrument: targetInstrumentForFilter(filter))
+              filter: filter)
           }
         } label: {
           Label("Refresh", systemImage: "arrow.clockwise")
@@ -304,18 +297,18 @@ struct TransactionListView: View {
       activeFilter = baseFilter
       selectedTransaction = nil
       await transactionStore.load(
-        filter: baseFilter, targetInstrument: targetInstrumentForFilter(baseFilter))
+        filter: baseFilter)
     }
     .task(id: activeFilter) {
       // Reload when user applies a filter
       if activeFilter != baseFilter {
         await transactionStore.load(
-          filter: activeFilter, targetInstrument: targetInstrumentForFilter(activeFilter))
+          filter: activeFilter)
       }
     }
     .refreshable {
       await transactionStore.load(
-        filter: filter, targetInstrument: targetInstrumentForFilter(filter))
+        filter: filter)
     }
     .searchable(text: $searchText, prompt: "Search payee")
     .overlay {

--- a/Features/Transactions/Views/TransactionListView.swift
+++ b/Features/Transactions/Views/TransactionListView.swift
@@ -179,6 +179,13 @@ struct TransactionListView: View {
     }
   }
 
+  /// For account-scoped views, display balances in the viewing account's own
+  /// currency so native legs never require conversion. Otherwise fall back to
+  /// the store's default (profile) instrument.
+  private func targetInstrumentForFilter(_ filter: TransactionFilter) -> Instrument? {
+    filter.accountId.flatMap { accounts.by(id: $0)?.instrument }
+  }
+
   private var listView: some View {
     List(selection: selectedTransactionBinding) {
       PositionListView(positions: positions)
@@ -262,7 +269,8 @@ struct TransactionListView: View {
       ToolbarItem(placement: .automatic) {
         Button {
           Task {
-            await transactionStore.load(filter: filter)
+            await transactionStore.load(
+              filter: filter, targetInstrument: targetInstrumentForFilter(filter))
           }
         } label: {
           Label("Refresh", systemImage: "arrow.clockwise")
@@ -295,16 +303,19 @@ struct TransactionListView: View {
       // Reset filter and selection when switching accounts/contexts
       activeFilter = baseFilter
       selectedTransaction = nil
-      await transactionStore.load(filter: baseFilter)
+      await transactionStore.load(
+        filter: baseFilter, targetInstrument: targetInstrumentForFilter(baseFilter))
     }
     .task(id: activeFilter) {
       // Reload when user applies a filter
       if activeFilter != baseFilter {
-        await transactionStore.load(filter: activeFilter)
+        await transactionStore.load(
+          filter: activeFilter, targetInstrument: targetInstrumentForFilter(activeFilter))
       }
     }
     .refreshable {
-      await transactionStore.load(filter: filter)
+      await transactionStore.load(
+        filter: filter, targetInstrument: targetInstrumentForFilter(filter))
     }
     .searchable(text: $searchText, prompt: "Search payee")
     .overlay {

--- a/Features/Transactions/Views/TransactionRowView.swift
+++ b/Features/Transactions/Views/TransactionRowView.swift
@@ -5,8 +5,8 @@ struct TransactionRowView: View {
   let accounts: Accounts
   let categories: Categories
   let earmarks: Earmarks
-  let displayAmount: InstrumentAmount
-  let balance: InstrumentAmount
+  let displayAmount: InstrumentAmount?
+  let balance: InstrumentAmount?
   var hideEarmark: Bool = false
   var viewingAccountId: UUID? = nil
 
@@ -56,9 +56,18 @@ struct TransactionRowView: View {
       Spacer()
 
       VStack(alignment: .trailing, spacing: 2) {
-        InstrumentAmountView(amount: displayAmount, font: .body)
+        if let displayAmount {
+          InstrumentAmountView(amount: displayAmount, font: .body)
+        } else {
+          Text("—")
+            .font(.body)
+            .foregroundStyle(.secondary)
+            .monospacedDigit()
+        }
 
-        InstrumentAmountView(amount: balance, font: .caption)
+        if let balance {
+          InstrumentAmountView(amount: balance, font: .caption)
+        }
       }
     }
     .padding(.vertical, verticalPadding)
@@ -68,15 +77,19 @@ struct TransactionRowView: View {
 
   private var accessibilityDescription: String {
     let dateStr = transaction.date.formatted(date: .abbreviated, time: .omitted)
-    let amountStr = displayAmount.formatted
-    let balanceStr = balance.formatted
+    let amountStr = displayAmount?.formatted ?? "amount unavailable"
     let typeStr: String
     if transaction.isSimple, let type = transaction.legs.first?.type {
       typeStr = type.displayName
     } else {
       typeStr = "Custom transaction"
     }
-    return "\(typeStr), \(displayPayee), \(amountStr), \(dateStr), balance \(balanceStr)"
+    if let balance {
+      return
+        "\(typeStr), \(displayPayee), \(amountStr), \(dateStr), balance \(balance.formatted)"
+    } else {
+      return "\(typeStr), \(displayPayee), \(amountStr), \(dateStr)"
+    }
   }
 
   private var iconName: String {

--- a/Features/Transactions/Views/UpcomingView.swift
+++ b/Features/Transactions/Views/UpcomingView.swift
@@ -179,7 +179,7 @@ struct UpcomingTransactionRow: View {
   let accounts: Accounts
   let categories: Categories
   let earmarks: Earmarks
-  let displayAmount: InstrumentAmount
+  let displayAmount: InstrumentAmount?
   let isOverdue: Bool
   var isDueToday: Bool = false
   let onPay: () -> Void
@@ -239,7 +239,14 @@ struct UpcomingTransactionRow: View {
 
       Spacer()
 
-      InstrumentAmountView(amount: displayAmount, font: .body)
+      if let displayAmount {
+        InstrumentAmountView(amount: displayAmount, font: .body)
+      } else {
+        Text("—")
+          .font(.body)
+          .foregroundStyle(.secondary)
+          .monospacedDigit()
+      }
 
       Button("Pay") {
         onPay()

--- a/MoolahTests/Backends/FrankfurterClientTests.swift
+++ b/MoolahTests/Backends/FrankfurterClientTests.swift
@@ -6,13 +6,20 @@ import Testing
 
 @Suite("FrankfurterClient")
 struct FrankfurterClientTests {
-  @Test func parsesV2ResponseFormat() throws {
+  @Test func parsesRangeResponseFormat() throws {
+    // Shape returned by the real Frankfurter range endpoint
+    // (api.frankfurter.app/<from>..<to>?base=<code>).
     let json = """
-      [
-        {"date": "2026-04-11", "base": "AUD", "quote": "USD", "rate": 0.632},
-        {"date": "2026-04-11", "base": "AUD", "quote": "EUR", "rate": 0.581},
-        {"date": "2026-04-10", "base": "AUD", "quote": "USD", "rate": 0.629}
-      ]
+      {
+        "amount": 1.0,
+        "base": "AUD",
+        "start_date": "2026-04-10",
+        "end_date": "2026-04-11",
+        "rates": {
+          "2026-04-10": {"USD": 0.629},
+          "2026-04-11": {"USD": 0.632, "EUR": 0.581}
+        }
+      }
       """
     let data = Data(json.utf8)
     let result = try FrankfurterClient.parseResponse(data)
@@ -23,8 +30,17 @@ struct FrankfurterClientTests {
     #expect(result["2026-04-10"]?["USD"] == Decimal(string: "0.629")!)
   }
 
-  @Test func parsesEmptyResponse() throws {
-    let data = Data("[]".utf8)
+  @Test func parsesEmptyRatesResponse() throws {
+    let json = """
+      {
+        "amount": 1.0,
+        "base": "AUD",
+        "start_date": "2026-04-10",
+        "end_date": "2026-04-10",
+        "rates": {}
+      }
+      """
+    let data = Data(json.utf8)
     let result = try FrankfurterClient.parseResponse(data)
     #expect(result.isEmpty)
   }

--- a/MoolahTests/Domain/TransactionRepositoryContractTests.swift
+++ b/MoolahTests/Domain/TransactionRepositoryContractTests.swift
@@ -243,6 +243,47 @@ struct TransactionRepositoryContractTests {
     #expect(page.priorBalance.isZero)
   }
 
+  @Test("priorBalance is labelled with the account's own instrument")
+  func testPriorBalanceUsesAccountInstrument() async throws {
+    // Non-profile instrument for the viewing account.
+    let accountInstrument = Instrument.USD
+    let accountId = UUID()
+    let (backend, container) = try TestBackend.create()
+    let account = Account(
+      id: accountId, name: "USD Account", type: .bank, instrument: accountInstrument)
+    TestBackend.seed(
+      accounts: [(account, InstrumentAmount.zero(instrument: accountInstrument))],
+      in: container)
+    // Two transactions in the USD account so we need a priorBalance across pages.
+    let tx1 = Transaction(
+      date: Date(timeIntervalSince1970: 1),
+      payee: "Older",
+      legs: [
+        TransactionLeg(
+          accountId: accountId, instrument: accountInstrument,
+          quantity: Decimal(string: "10")!, type: .income)
+      ])
+    let tx2 = Transaction(
+      date: Date(timeIntervalSince1970: 2),
+      payee: "Newer",
+      legs: [
+        TransactionLeg(
+          accountId: accountId, instrument: accountInstrument,
+          quantity: Decimal(string: "20")!, type: .income)
+      ])
+    TestBackend.seed(transactions: [tx1, tx2], in: container)
+
+    // Page size of 1 forces a non-zero priorBalance on page 0.
+    let page0 = try await backend.transactions.fetch(
+      filter: TransactionFilter(accountId: accountId), page: 0, pageSize: 1)
+    #expect(page0.priorBalance.instrument == accountInstrument)
+
+    // Empty paged-past-end response should also use the account's instrument.
+    let pageN = try await backend.transactions.fetch(
+      filter: TransactionFilter(accountId: accountId), page: 99, pageSize: 1)
+    #expect(pageN.priorBalance.instrument == accountInstrument)
+  }
+
   @Test("transfer creates with two legs")
   func testTransferCreatesTwoLegs() async throws {
     let repository = makeCloudKitTransactionRepository()

--- a/MoolahTests/Domain/TransactionRunningBalanceTests.swift
+++ b/MoolahTests/Domain/TransactionRunningBalanceTests.swift
@@ -1,0 +1,145 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("TransactionPage.withRunningBalances")
+struct TransactionRunningBalanceTests {
+  private let target = Instrument.defaultTestInstrument
+  private let foreign = Instrument.USD
+
+  private func date(_ days: Int) -> Date {
+    Calendar(identifier: .gregorian)
+      .date(byAdding: .day, value: days, to: Date(timeIntervalSince1970: 0))!
+  }
+
+  private func tx(
+    id: UUID = UUID(),
+    daysFromEpoch: Int,
+    accountId: UUID,
+    quantity: Decimal,
+    instrument: Instrument
+  ) -> Transaction {
+    Transaction(
+      id: id,
+      date: date(daysFromEpoch),
+      payee: "Payee",
+      legs: [
+        TransactionLeg(
+          accountId: accountId,
+          instrument: instrument,
+          quantity: quantity,
+          type: .expense
+        )
+      ]
+    )
+  }
+
+  /// All legs convert successfully — every transaction gets a valid balance.
+  @Test func allLegsConvertibleYieldsBalancesForEveryTransaction() async {
+    let accountId = UUID()
+    // Target instrument differs from the default test instrument so make sure
+    // we're using the ambient default.
+    let transactions = [
+      tx(daysFromEpoch: 3, accountId: accountId, quantity: -30, instrument: target),
+      tx(daysFromEpoch: 2, accountId: accountId, quantity: -20, instrument: target),
+      tx(daysFromEpoch: 1, accountId: accountId, quantity: -10, instrument: target),
+    ]
+
+    let result = await TransactionPage.withRunningBalances(
+      transactions: transactions,
+      priorBalance: .zero(instrument: target),
+      accountId: accountId,
+      targetInstrument: target,
+      conversionService: FixedConversionService()
+    )
+
+    #expect(result.count == 3)
+    #expect(result.allSatisfy { $0.balance != nil })
+    #expect(result.allSatisfy { $0.displayAmount != nil })
+  }
+
+  /// A transaction with an unconvertible leg still appears in the result,
+  /// but with a nil balance and nil displayAmount.
+  @Test func unconvertibleTransactionStillAppearsWithNilBalance() async {
+    let accountId = UUID()
+    let transactions = [
+      tx(daysFromEpoch: 1, accountId: accountId, quantity: -10, instrument: foreign)
+    ]
+
+    let result = await TransactionPage.withRunningBalances(
+      transactions: transactions,
+      priorBalance: .zero(instrument: target),
+      accountId: accountId,
+      targetInstrument: target,
+      conversionService: FailingConversionService(failingInstrumentIds: [foreign.id])
+    )
+
+    #expect(result.count == 1)
+    #expect(result[0].transaction.id == transactions[0].id)
+    #expect(result[0].balance == nil)
+    #expect(result[0].displayAmount == nil)
+  }
+
+  /// Earlier transactions (older — processed first in the reversed iteration)
+  /// keep their balances even when a later (newer) transaction can't convert.
+  /// Newer transactions after the failure point have nil balances.
+  @Test func conversionFailureBreaksBalanceChainForLaterTransactions() async {
+    let accountId = UUID()
+    // Oldest first in source → in the newest-first returned list this is
+    // the last entry. We list newest-first as the function expects.
+    let oldestId = UUID()
+    let middleId = UUID()
+    let newestId = UUID()
+    let transactions = [
+      // newest — unconvertible
+      tx(id: newestId, daysFromEpoch: 3, accountId: accountId, quantity: -30, instrument: foreign),
+      // middle — convertible
+      tx(id: middleId, daysFromEpoch: 2, accountId: accountId, quantity: -20, instrument: target),
+      // oldest — convertible
+      tx(id: oldestId, daysFromEpoch: 1, accountId: accountId, quantity: -10, instrument: target),
+    ]
+
+    let result = await TransactionPage.withRunningBalances(
+      transactions: transactions,
+      priorBalance: .zero(instrument: target),
+      accountId: accountId,
+      targetInstrument: target,
+      conversionService: FailingConversionService(failingInstrumentIds: [foreign.id])
+    )
+
+    #expect(result.count == 3)
+    // Result is newest-first. Oldest two (middle, oldest) keep their balances.
+    let byId = Dictionary(uniqueKeysWithValues: result.map { ($0.transaction.id, $0) })
+    #expect(byId[oldestId]?.balance != nil)
+    #expect(byId[middleId]?.balance != nil)
+    // The unconvertible newest transaction has nil balance.
+    #expect(byId[newestId]?.balance == nil)
+    #expect(byId[newestId]?.displayAmount == nil)
+  }
+
+  /// When the FIRST (oldest) transaction can't convert, every subsequent
+  /// (newer) transaction has nil balance — the running total is unrecoverable.
+  @Test func conversionFailureAtOldestBreaksAllBalances() async {
+    let accountId = UUID()
+    let oldestId = UUID()
+    let middleId = UUID()
+    let newestId = UUID()
+    let transactions = [
+      tx(id: newestId, daysFromEpoch: 3, accountId: accountId, quantity: -30, instrument: target),
+      tx(id: middleId, daysFromEpoch: 2, accountId: accountId, quantity: -20, instrument: target),
+      tx(id: oldestId, daysFromEpoch: 1, accountId: accountId, quantity: -10, instrument: foreign),
+    ]
+
+    let result = await TransactionPage.withRunningBalances(
+      transactions: transactions,
+      priorBalance: .zero(instrument: target),
+      accountId: accountId,
+      targetInstrument: target,
+      conversionService: FailingConversionService(failingInstrumentIds: [foreign.id])
+    )
+
+    #expect(result.count == 3)
+    #expect(result.allSatisfy { $0.balance == nil })
+  }
+}

--- a/MoolahTests/Features/TransactionStoreTests.swift
+++ b/MoolahTests/Features/TransactionStoreTests.swift
@@ -396,7 +396,7 @@ struct TransactionStoreTests {
 
     #expect(store.transactions.count == 1)
     #expect(store.transactions[0].transaction.payee == "Fancy Coffee")
-    #expect(store.transactions[0].displayAmount.quantity == Decimal(-7500) / 100)
+    #expect(store.transactions[0].displayAmount?.quantity == Decimal(-7500) / 100)
     #expect(store.error == nil)
   }
 
@@ -468,7 +468,7 @@ struct TransactionStoreTests {
     ]
     await store.update(modified)
     #expect(store.transactions.count == 1)
-    #expect(store.transactions[0].displayAmount.quantity == Decimal(110000) / 100)
+    #expect(store.transactions[0].displayAmount?.quantity == Decimal(110000) / 100)
 
     // Delete
     await store.delete(id: tx.id)
@@ -497,7 +497,7 @@ struct TransactionStoreTests {
     )
 
     await store.load(filter: TransactionFilter(accountId: accountId))
-    #expect(store.transactions[0].balance.quantity == Decimal(100000) / 100)
+    #expect(store.transactions[0].balance?.quantity == Decimal(100000) / 100)
 
     // Add a newer expense
     let expense = Transaction(
@@ -517,9 +517,9 @@ struct TransactionStoreTests {
     // Newest first: expense (balance 97000), then income (balance 100000)
     #expect(store.transactions.count == 2)
     #expect(store.transactions[0].transaction.payee == "Coffee")
-    #expect(store.transactions[0].balance.quantity == Decimal(97000) / 100)
+    #expect(store.transactions[0].balance?.quantity == Decimal(97000) / 100)
     #expect(store.transactions[1].transaction.payee == "Initial")
-    #expect(store.transactions[1].balance.quantity == Decimal(100000) / 100)
+    #expect(store.transactions[1].balance?.quantity == Decimal(100000) / 100)
   }
 
   @Test func testRunningBalancesUpdateAfterDelete() async throws {
@@ -557,12 +557,12 @@ struct TransactionStoreTests {
 
     await store.load(filter: TransactionFilter(accountId: accountId))
     #expect(store.transactions.count == 2)
-    #expect(store.transactions[0].balance.quantity == Decimal(97000) / 100)  // After Coffee
+    #expect(store.transactions[0].balance?.quantity == Decimal(97000) / 100)  // After Coffee
 
     // Delete the expense — balance should revert
     await store.delete(id: tx2.id)
     #expect(store.transactions.count == 1)
-    #expect(store.transactions[0].balance.quantity == Decimal(100000) / 100)  // Only Salary remains
+    #expect(store.transactions[0].balance?.quantity == Decimal(100000) / 100)  // Only Salary remains
   }
 
   // MARK: - Cross-Store Balance Updates
@@ -1034,8 +1034,8 @@ struct TransactionStoreTests {
 
     await store.load(filter: TransactionFilter(accountId: accountId))
     #expect(store.transactions.count == 2)
-    #expect(store.transactions[0].balance.quantity == Decimal(97000) / 100)  // After Coffee
-    #expect(store.transactions[1].balance.quantity == Decimal(100000) / 100)  // After Salary
+    #expect(store.transactions[0].balance?.quantity == Decimal(97000) / 100)  // After Coffee
+    #expect(store.transactions[1].balance?.quantity == Decimal(100000) / 100)  // After Salary
 
     // Update Coffee amount to -5000
     var updated = tx2
@@ -1050,8 +1050,8 @@ struct TransactionStoreTests {
     await store.update(updated)
 
     #expect(store.transactions.count == 2)
-    #expect(store.transactions[0].balance.quantity == Decimal(95000) / 100)  // After updated Coffee
-    #expect(store.transactions[1].balance.quantity == Decimal(100000) / 100)  // After Salary (unchanged)
+    #expect(store.transactions[0].balance?.quantity == Decimal(95000) / 100)  // After updated Coffee
+    #expect(store.transactions[1].balance?.quantity == Decimal(100000) / 100)  // After Salary (unchanged)
   }
 
   // MARK: - Pay Scheduled Transaction

--- a/MoolahTests/Shared/ExchangeRateServiceTests.swift
+++ b/MoolahTests/Shared/ExchangeRateServiceTests.swift
@@ -224,4 +224,92 @@ struct ExchangeRateServiceTests {
       try await service.rate(from: .AUD, to: .USD, on: date("2025-01-15"))
     }
   }
+
+  // MARK: - Cold cache surrounding fetch
+
+  /// When there is no cache for the base currency and the requested date is
+  /// missing from the client (weekend / holiday / today's rate not posted),
+  /// we still fetch a surrounding range wide enough to cover a recent trading
+  /// day and fall back to the most-recent prior cached rate.
+  @Test func coldCacheFallsBackToPriorTradingDayWhenRequestedDateMissing() async throws {
+    // Client has data for Jan 17 (Friday) but not Jan 18 (Saturday).
+    let service = makeService(rates: [
+      "2025-01-17": ["USD": Decimal(string: "0.6500")!]
+    ])
+
+    // First call with a cold cache on Saturday. The service should fetch a
+    // month-wide surrounding range, populate cache with Jan 17, and fall
+    // back to Jan 17's rate.
+    let saturdayRate = try await service.rate(from: .AUD, to: .USD, on: date("2025-01-18"))
+    #expect(saturdayRate == Decimal(string: "0.6500")!)
+  }
+
+  @Test func coldCacheWithNetworkErrorThrows() async throws {
+    // shouldFail simulates a network error. With no prior cache and a failing
+    // fetch we have nothing to fall back to, so we must throw.
+    let service = makeService(shouldFail: true)
+    await #expect(throws: (any Error).self) {
+      try await service.rate(from: .AUD, to: .USD, on: date("2025-01-15"))
+    }
+  }
+
+  // MARK: - Cache extension
+
+  /// After priming the cache, requesting a date after the latest cached date
+  /// should trigger a forward extension fetch. If the client returns no data
+  /// for the new range (e.g., today's rate not yet posted), we fall back to
+  /// the most-recent cached rate rather than throwing.
+  @Test func futureRequestExtendsForwardAndFallsBack() async throws {
+    let service = makeService(rates: [
+      "2025-01-10": ["USD": Decimal(string: "0.6400")!]
+    ])
+    // Prime the cache by fetching Jan 10.
+    _ = try await service.rate(from: .AUD, to: .USD, on: date("2025-01-10"))
+
+    // Request Jan 15 — client has no data for this date; forward extension
+    // of [Jan 11, Jan 15] returns empty. Should fall back to Jan 10's rate.
+    let rate = try await service.rate(from: .AUD, to: .USD, on: date("2025-01-15"))
+    #expect(rate == Decimal(string: "0.6400")!)
+  }
+
+  /// Requesting a date before the earliest cached date should trigger a
+  /// backward extension fetch and pull in data from the client for the
+  /// missing historical range.
+  @Test func pastRequestExtendsBackwardAndReturnsRate() async throws {
+    let service = makeService(rates: [
+      "2025-01-15": ["USD": Decimal(string: "0.6480")!],
+      "2025-01-25": ["USD": Decimal(string: "0.6600")!],
+    ])
+    // Prime cache with Jan 25 (earliest will be 2024-12-26 via surrounding fetch,
+    // but client has no data for those dates so cache contains only Jan 25).
+    _ = try await service.rate(from: .AUD, to: .USD, on: date("2025-01-25"))
+
+    // Request Jan 15 — backward extension fetch of [Jan 15, Jan 24] should
+    // pull in Jan 15.
+    let rate = try await service.rate(from: .AUD, to: .USD, on: date("2025-01-15"))
+    #expect(rate == Decimal(string: "0.6480")!)
+  }
+
+  /// Once the cache is primed, a network error on a subsequent extension
+  /// fetch should still fall back to cached data rather than propagate.
+  @Test func extensionFetchErrorFallsBackToCache() async throws {
+    // Step 1: populate cache with a successful fetch.
+    let primingClient = FixedRateClient(rates: [
+      "2025-01-10": ["USD": Decimal(string: "0.6400")!]
+    ])
+    let cacheDir = FileManager.default.temporaryDirectory
+      .appendingPathComponent("exchange-rate-tests")
+      .appendingPathComponent(UUID().uuidString)
+    let service = ExchangeRateService(client: primingClient, cacheDirectory: cacheDir)
+    _ = try await service.rate(from: .AUD, to: .USD, on: date("2025-01-10"))
+
+    // Step 2: new service using the same cache dir but with a failing client.
+    let failingClient = FixedRateClient(shouldFail: true)
+    let service2 = ExchangeRateService(client: failingClient, cacheDirectory: cacheDir)
+
+    // Requesting Jan 15 triggers a forward extension fetch that fails. Should
+    // still return the cached Jan 10 rate via fallback.
+    let rate = try await service2.rate(from: .AUD, to: .USD, on: date("2025-01-15"))
+    #expect(rate == Decimal(string: "0.6400")!)
+  }
 }

--- a/Shared/ExchangeRateService.swift
+++ b/Shared/ExchangeRateService.swift
@@ -44,21 +44,47 @@ actor ExchangeRateService {
       return cached
     }
 
-    // Fetch from client
+    // Determine what to fetch to cover the requested date.
+    // Frankfurter 404s for weekends, public holidays, and dates past its
+    // last-posted rate, so we always fetch a surrounding range and fall
+    // back to the most-recent prior cached rate when the exact date is
+    // missing.
+    let calendar = Calendar(identifier: .gregorian)
     do {
-      try await fetchAndMerge(base: base, from: date, to: date)
-      if let cached = lookupRate(base: base, quote: quote, dateString: dateString) {
-        return cached
+      if let cache = caches[base] {
+        if dateString > cache.latestDate {
+          let fetchStart = calendar.date(
+            byAdding: .day, value: 1,
+            to: dateFormatter.date(from: cache.latestDate)!)!
+          try await fetchInChunks(base: base, from: fetchStart, to: date)
+        } else if dateString < cache.earliestDate {
+          let fetchEnd = calendar.date(
+            byAdding: .day, value: -1,
+            to: dateFormatter.date(from: cache.earliestDate)!)!
+          try await fetchInChunks(base: base, from: date, to: fetchEnd)
+        } else {
+          // Requested date is inside the cached range but the specific
+          // quote is missing (or the whole date is missing) — we only
+          // reach here after the initial cache lookup returned nil, so
+          // attempt to fetch that single date.
+          try await fetchInChunks(base: base, from: date, to: date)
+        }
+      } else {
+        // Cold cache: fetch a month-wide surrounding range so we pick up
+        // at least one trading day alongside the requested date.
+        let fetchStart = calendar.date(byAdding: .day, value: -30, to: date)!
+        try await fetchInChunks(base: base, from: fetchStart, to: date)
       }
     } catch {
-      // Network failure — try fallback
-      if let fallback = fallbackRate(base: base, quote: quote, dateString: dateString) {
-        return fallback
-      }
-      throw error
+      // Fetch failed — proceed to fallback lookup.
     }
 
-    // Fetch succeeded but no rate for this date — try fallback
+    // Exact hit after fetch?
+    if let cached = lookupRate(base: base, quote: quote, dateString: dateString) {
+      return cached
+    }
+
+    // Fall back to the most-recent cached rate on or before the requested date.
     if let fallback = fallbackRate(base: base, quote: quote, dateString: dateString) {
       return fallback
     }


### PR DESCRIPTION
## Summary

Fixes a bug where creating a transaction in an account whose currency differs from the profile currency caused the whole transaction list to appear empty. Along the way, uncovered and fixed a latent bug in the Frankfurter client that had been 404ing every request.

Four commits, each independently reviewable:

- **`1eedc8d` — ExchangeRateService graceful fallback.** Rework `rate(from:to:on:)` to mirror the gap-filling logic of `rates()`: cold caches fetch a month-wide surrounding range; forward/backward extensions fetch only the gap; fetch errors fall through to the most-recent prior cached rate. Throws only when there's no cached data at all.

- **`9f0fa3f` — Frankfurter URL and response shape.** The client was pointed at `api.frankfurter.dev/v2/` (404s for every request) and parsed a JSON array the real API doesn't return. Point it at `api.frankfurter.app/` and decode the actual `{"rates": {"<date>": {...}}}` range response. The range endpoint already shifts weekends/holidays/today-before-daily-post to the nearest trading day, so 404s only happen for dates wholly outside coverage.

- **`384d664` — TransactionWithBalance graceful degradation.** `displayAmount` and `balance` are now optional. `withRunningBalances` no longer throws on conversion failure; instead the failing transaction and every newer one get `balance = nil`, but they always appear in the list. Views render `—` for a nil amount and hide the running-balance caption for a nil balance.

- **`0b84119` — account-scoped balances use the account's currency.** `CloudKitTransactionRepository` now labels the page's `priorBalance` with the viewing account's instrument (via a new `accountInstrument(id:)` lookup). `TransactionStore` adopts that instrument from the first page fetch, so single-account views never need to convert their own legs. The remote backend is single-currency and unaffected.

## Test plan

- [x] `just test` — 1134 iOS + 1150 macOS, all green. New tests:
  - `ExchangeRateServiceTests`: cold-cache fallback, forward/backward extension, extension fetch error with fallback.
  - `FrankfurterClientTests`: real range response shape.
  - `TransactionRunningBalanceTests`: all-convertible happy path, single unconvertible row, failure mid-list, failure at the oldest.
  - `TransactionRepositoryContractTests`: priorBalance labelled with the account's instrument (both populated and empty-page cases).
- [x] Run the macOS app with the fix and view a non-profile-currency account (GBP account on an AUD profile). Transactions appear with correct amounts and running balances in the account's currency. No `Failed to compute balances`, no `Exchange rate request failed`, no crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)