### PR TITLE
Require worktree + PR workflow; unify currency prefix label via displayLabel

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,13 @@
 # Claude Code Instructions — moolah-native
 
+## Git Workflow
+
+**`main` is protected and does not accept direct pushes.** All changes must land via a pull request.
+
+- **Default to a worktree.** Never make changes directly on the `main` checkout. At the start of any task that modifies files, create a git worktree on a feature branch (see the `superpowers:using-git-worktrees` skill). `.worktrees/` is gitignored.
+- **Ship via PR.** Push the feature branch and open a pull request with `gh pr create`. Do not attempt `git push origin main` — it will be rejected by branch protection.
+- **Exceptions:** Read-only inspection and investigation can happen on the `main` checkout without a worktree. If you're unsure whether a task will require edits, create the worktree up front.
+
 ## Build & Test
 
 Always use `just` targets to ensure consistent builds and test runs:

--- a/Domain/Models/Instrument.swift
+++ b/Domain/Models/Instrument.swift
@@ -71,6 +71,21 @@ struct Instrument: Codable, Sendable, Hashable, Identifiable {
     ticker
   }
 
+  /// Best user-facing short label for this instrument, suitable as a prefix next to a
+  /// numeric input field or row label.
+  /// - Fiat: the OS-localised currency symbol (e.g., "£", "$", or the ISO code on locales
+  ///   that don't define a narrow symbol for the currency).
+  /// - Stock/crypto: the ticker (e.g., "BHP.AX", "ETH").
+  /// Falls back to `id`/`name` if neither is available.
+  var displayLabel: String {
+    switch kind {
+    case .fiatCurrency:
+      return currencySymbol ?? id
+    case .stock, .cryptoToken:
+      return ticker ?? name
+    }
+  }
+
   // Convenience constants
   static let AUD = Instrument.fiat(code: "AUD")
   static let USD = Instrument.fiat(code: "USD")

--- a/Domain/Models/InstrumentAmount.swift
+++ b/Domain/Models/InstrumentAmount.swift
@@ -26,7 +26,7 @@ struct InstrumentAmount: Codable, Sendable, Hashable, Comparable {
       return quantity.formatted(.currency(code: instrument.id))
     case .stock, .cryptoToken:
       let number = quantity.formatted(.number.precision(.fractionLength(0...instrument.decimals)))
-      return "\(number) \(instrument.displaySymbol ?? instrument.name)"
+      return "\(number) \(instrument.displayLabel)"
     }
   }
 

--- a/Features/Accounts/CryptoPositionsSectionView.swift
+++ b/Features/Accounts/CryptoPositionsSectionView.swift
@@ -21,7 +21,7 @@ struct CryptoPositionsSectionView: View {
         ForEach(cryptoPositions, id: \.instrument.id) { position in
           HStack {
             VStack(alignment: .leading) {
-              Text(position.instrument.displaySymbol ?? position.instrument.name)
+              Text(position.instrument.displayLabel)
                 .font(.headline)
               Text(position.instrument.name)
                 .font(.caption)
@@ -80,9 +80,8 @@ struct CryptoPositionsSectionView: View {
     formatter.numberStyle = .decimal
     formatter.maximumFractionDigits = min(instrument.decimals, 8)
     formatter.minimumFractionDigits = 0
-    let symbol = instrument.displaySymbol ?? ""
     let number = formatter.string(from: quantity as NSDecimalNumber) ?? "\(quantity)"
-    return "\(number) \(symbol)"
+    return "\(number) \(instrument.displayLabel)"
   }
 
   private func accessibilityLabel(for position: Position) -> String {

--- a/Features/Earmarks/Views/EarmarkFormSheet.swift
+++ b/Features/Earmarks/Views/EarmarkFormSheet.swift
@@ -20,7 +20,7 @@ struct CreateEarmarkSheet: View {
 
         Section("Savings Goal") {
           HStack {
-            Text(instrument.id)
+            Text(instrument.displayLabel)
               .foregroundStyle(.secondary)
             TextField("Amount", text: $savingsGoal)
               #if os(iOS)

--- a/Features/Investments/Views/AddInvestmentValueView.swift
+++ b/Features/Investments/Views/AddInvestmentValueView.swift
@@ -27,7 +27,7 @@ struct AddInvestmentValueView: View {
           DatePicker("Date", selection: $date, displayedComponents: .date)
 
           HStack {
-            Text(instrument.id)
+            Text(instrument.displayLabel)
               .foregroundStyle(.secondary)
             TextField("Value", text: $valueString)
               .focused($isValueFieldFocused)

--- a/Features/Transactions/TokenSwapView.swift
+++ b/Features/Transactions/TokenSwapView.swift
@@ -133,7 +133,7 @@ struct TokenSwapView: View {
       Text(label)
       Spacer()
       if let inst = instrument {
-        Text(inst.displaySymbol ?? inst.name)
+        Text(inst.displayLabel)
           .foregroundStyle(.secondary)
       } else {
         Text("Select")

--- a/MoolahTests/Domain/InstrumentTests.swift
+++ b/MoolahTests/Domain/InstrumentTests.swift
@@ -46,4 +46,23 @@ struct InstrumentTests {
     #expect(symbol != nil)
     #expect(!symbol!.isEmpty)
   }
+
+  @Test func displayLabelForFiatUsesLocalisedCurrencySymbol() {
+    let aud = Instrument.fiat(code: "AUD")
+    // Whatever the host locale produces for this currency — must match the
+    // OS-provided symbol, not the raw ISO code when a symbol exists.
+    #expect(aud.displayLabel == (aud.currencySymbol ?? aud.id))
+    #expect(!aud.displayLabel.isEmpty)
+  }
+
+  @Test func displayLabelForStockUsesTicker() {
+    let bhp = Instrument.stock(ticker: "BHP.AX", exchange: "ASX", name: "BHP")
+    #expect(bhp.displayLabel == "BHP.AX")
+  }
+
+  @Test func displayLabelForCryptoUsesTicker() {
+    let eth = Instrument.crypto(
+      chainId: 1, contractAddress: nil, symbol: "ETH", name: "Ethereum", decimals: 18)
+    #expect(eth.displayLabel == "ETH")
+  }
 }


### PR DESCRIPTION
## Summary
- Document that `main` is branch-protected: all changes must go through a worktree + PR. Direct commits to `main` are disallowed.
- Introduce `Instrument.displayLabel` as the single source of truth for the short prefix label shown next to an amount field (or in a row's title position).
  - Fiat → OS-localised currency symbol (e.g. `£` on `en_GB`, `$` on `en_US` for USD, or the ISO code on locales without a narrow symbol for that currency — we intentionally respect the OS's choice).
  - Stock / crypto → ticker.
- Replace `Text(instrument.id)` (raw ISO code) in the add-investment-value form and the create-earmark form with `displayLabel`. These were the two places that printed "GBP", "USD" etc. directly.
- Route existing `displaySymbol ?? name` sites (`InstrumentAmount.formatted`, `TokenSwapView`, `CryptoPositionsSectionView`) through `displayLabel` so the policy lives in one place.

## Test plan
- [x] `just test` — 1139 tests pass on macOS and iOS Simulator.
- [x] New unit tests in `MoolahTests/Domain/InstrumentTests.swift` cover `displayLabel` for fiat, stock, and crypto.
- [ ] Manual check: Add Investment Value and Create Earmark forms show `£` / `$` / etc. (not "GBP") on locales where the OS provides a narrow symbol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)