### PR TITLE
Enforce single-instrument constraint on Remote backend + close Phase 6

### DIFF
--- a/Backends/Remote/Repositories/RemoteAccountRepository.swift
+++ b/Backends/Remote/Repositories/RemoteAccountRepository.swift
@@ -49,6 +49,13 @@ final class RemoteAccountRepository: AccountRepository, Sendable {
     guard !account.name.trimmingCharacters(in: .whitespaces).isEmpty else {
       throw BackendError.validationFailed("Account name cannot be empty")
     }
+    try requireMatchesProfileInstrument(
+      account.instrument, profile: instrument, entity: "Account \"\(account.name)\"")
+    if let openingBalance {
+      try requireMatchesProfileInstrument(
+        openingBalance.instrument, profile: instrument,
+        entity: "Opening balance for \"\(account.name)\"")
+    }
 
     let cents: Int
     if let openingBalance {
@@ -85,6 +92,8 @@ final class RemoteAccountRepository: AccountRepository, Sendable {
     guard !account.name.trimmingCharacters(in: .whitespaces).isEmpty else {
       throw BackendError.validationFailed("Account name cannot be empty")
     }
+    try requireMatchesProfileInstrument(
+      account.instrument, profile: instrument, entity: "Account \"\(account.name)\"")
 
     let dto = UpdateAccountDTO(
       id: account.id.apiString,

--- a/Backends/Remote/Repositories/RemoteEarmarkRepository.swift
+++ b/Backends/Remote/Repositories/RemoteEarmarkRepository.swift
@@ -25,6 +25,8 @@ final class RemoteEarmarkRepository: EarmarkRepository, Sendable {
   }
 
   func create(_ earmark: Earmark) async throws -> Earmark {
+    try requireMatchesProfileInstrument(
+      earmark.instrument, profile: instrument, entity: "Earmark \"\(earmark.name)\"")
     let dto = CreateEarmarkDTO(from: earmark)
     let data = try await client.post("earmarks/", body: dto)
     let responseDTO = try JSONDecoder().decode(EarmarkDTO.self, from: data)
@@ -32,6 +34,8 @@ final class RemoteEarmarkRepository: EarmarkRepository, Sendable {
   }
 
   func update(_ earmark: Earmark) async throws -> Earmark {
+    try requireMatchesProfileInstrument(
+      earmark.instrument, profile: instrument, entity: "Earmark \"\(earmark.name)\"")
     let dto = EarmarkDTO.fromDomain(earmark)
     let data = try await client.put("earmarks/\(earmark.id.apiString)/", body: dto)
     let responseDTO = try JSONDecoder().decode(EarmarkDTO.self, from: data)
@@ -59,6 +63,8 @@ final class RemoteEarmarkRepository: EarmarkRepository, Sendable {
   }
 
   func setBudget(earmarkId: UUID, categoryId: UUID, amount: InstrumentAmount) async throws {
+    try requireMatchesProfileInstrument(
+      amount.instrument, profile: instrument, entity: "Budget amount")
     let cents = Int(truncating: (amount.quantity * 100) as NSDecimalNumber)
     let body = SetBudgetDTO(amount: cents)
     _ = try await client.put(

--- a/Backends/Remote/Repositories/RemoteTransactionRepository.swift
+++ b/Backends/Remote/Repositories/RemoteTransactionRepository.swift
@@ -66,6 +66,7 @@ final class RemoteTransactionRepository: TransactionRepository, Sendable {
   }
 
   func create(_ transaction: Transaction) async throws -> Transaction {
+    try requireAllLegsMatchProfile(transaction)
     let dto = try CreateTransactionDTO.fromDomain(transaction)
     let data = try await client.post("transactions/", body: dto)
     let responseDTO = try JSONDecoder().decode(TransactionDTO.self, from: data)
@@ -73,10 +74,19 @@ final class RemoteTransactionRepository: TransactionRepository, Sendable {
   }
 
   func update(_ transaction: Transaction) async throws -> Transaction {
+    try requireAllLegsMatchProfile(transaction)
     let dto = try TransactionDTO.fromDomain(transaction)
     let data = try await client.put("transactions/\(transaction.id.apiString)/", body: dto)
     let responseDTO = try JSONDecoder().decode(TransactionDTO.self, from: data)
     return responseDTO.toDomain(instrument: instrument)
+  }
+
+  private func requireAllLegsMatchProfile(_ transaction: Transaction) throws {
+    for (index, leg) in transaction.legs.enumerated() {
+      try requireMatchesProfileInstrument(
+        leg.instrument, profile: instrument,
+        entity: "Transaction leg \(index + 1)")
+    }
   }
 
   func delete(id: UUID) async throws {

--- a/Backends/Remote/SingleInstrumentGuard.swift
+++ b/Backends/Remote/SingleInstrumentGuard.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+/// Throws `BackendError.unsupportedInstrument` when an entity's instrument
+/// does not match the profile currency of a single-instrument backend
+/// (Remote, moolah).
+///
+/// Defence in depth against a UI gating bug: the currency pickers are hidden
+/// when `Profile.supportsComplexTransactions` is false (Remote / moolah),
+/// so in correct use this guard never fires. If it does, a code path has
+/// slipped past the gating — surface as an error rather than silently writing
+/// data the backend cannot represent.
+func requireMatchesProfileInstrument(
+  _ instrument: Instrument,
+  profile: Instrument,
+  entity: String
+) throws {
+  guard instrument.id == profile.id else {
+    throw BackendError.unsupportedInstrument(
+      "\(entity) uses \(instrument.id); this backend only supports \(profile.id). "
+        + "UI should gate on Profile.supportsComplexTransactions."
+    )
+  }
+}

--- a/Domain/Models/BackendError.swift
+++ b/Domain/Models/BackendError.swift
@@ -5,6 +5,10 @@ enum BackendError: Error, Sendable, Equatable {
   case networkUnavailable
   case validationFailed(String)
   case notFound(String)
+  /// Thrown by single-instrument backends (Remote, moolah) when a write carries
+  /// an instrument other than the profile's currency. Indicates a programmer
+  /// error — the UI should have gated the write on `Profile.supportsComplexTransactions`.
+  case unsupportedInstrument(String)
 }
 
 extension BackendError {
@@ -19,6 +23,8 @@ extension BackendError {
     case .validationFailed(let message):
       return message
     case .notFound(let message):
+      return message
+    case .unsupportedInstrument(let message):
       return message
     }
   }

--- a/Domain/Models/Profile.swift
+++ b/Domain/Models/Profile.swift
@@ -45,6 +45,16 @@ struct Profile: Identifiable, Codable, Sendable, Equatable {
     Instrument.fiat(code: currencyCode)
   }
 
+  /// Whether this profile's backend supports multi-instrument data:
+  /// per-account currencies, per-earmark currencies, cross-currency transfers,
+  /// and the custom transaction editor with per-leg instrument overrides.
+  ///
+  /// `true` only for `.cloudKit`. `Remote` and `moolah` backends are
+  /// single-instrument — every account, earmark, and transaction leg must be
+  /// in `profile.currencyCode`. UI must gate currency pickers and custom mode
+  /// on this flag; `Remote*Repository` write paths enforce the constraint via
+  /// `requireMatchesProfileInstrument(...)` (see
+  /// `guides/INSTRUMENT_CONVERSION_GUIDE.md` Rule 11a).
   var supportsComplexTransactions: Bool {
     backendType == .cloudKit
   }

--- a/MoolahTests/Backends/RemoteAccountRepositoryTests.swift
+++ b/MoolahTests/Backends/RemoteAccountRepositoryTests.swift
@@ -5,6 +5,49 @@ import Testing
 
 @Suite("RemoteAccountRepository")
 struct RemoteAccountRepositoryTests {
+  private func makeRepository(instrument: Instrument = .defaultTestInstrument)
+    -> RemoteAccountRepository
+  {
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [URLProtocolStub.self]
+    let session = URLSession(configuration: config)
+    let client = APIClient(baseURL: URL(string: "https://api.example.com")!, session: session)
+    // Fail the test if the guard doesn't short-circuit before the network call.
+    URLProtocolStub.requestHandler = { _ in
+      Issue.record("Network request should not be made when instrument guard fires")
+      let response = HTTPURLResponse(
+        url: URL(string: "https://api.example.com")!, statusCode: 500, httpVersion: nil,
+        headerFields: nil)!
+      return (response, Data())
+    }
+    return RemoteAccountRepository(client: client, instrument: instrument)
+  }
+
+  @Test func createRejectsAccountWithNonProfileInstrument() async throws {
+    let repo = makeRepository(instrument: .AUD)
+    let account = Account(name: "USD Savings", type: .bank, instrument: .USD)
+    await #expect(throws: BackendError.self) {
+      _ = try await repo.create(account)
+    }
+  }
+
+  @Test func createRejectsOpeningBalanceInForeignInstrument() async throws {
+    let repo = makeRepository(instrument: .AUD)
+    let account = Account(name: "AUD Savings", type: .bank, instrument: .AUD)
+    let foreignOpening = InstrumentAmount(quantity: 100, instrument: .USD)
+    await #expect(throws: BackendError.self) {
+      _ = try await repo.create(account, openingBalance: foreignOpening)
+    }
+  }
+
+  @Test func updateRejectsAccountWithNonProfileInstrument() async throws {
+    let repo = makeRepository(instrument: .AUD)
+    let account = Account(name: "USD Savings", type: .bank, instrument: .USD)
+    await #expect(throws: BackendError.self) {
+      _ = try await repo.update(account)
+    }
+  }
+
   @Test func testDecodesFixtureJSON() async throws {
     // Given
     let bundle = Bundle(for: TestBundleMarker.self)

--- a/MoolahTests/Backends/RemoteEarmarkRepositoryTests.swift
+++ b/MoolahTests/Backends/RemoteEarmarkRepositoryTests.swift
@@ -5,6 +5,45 @@ import Testing
 
 @Suite("RemoteEarmarkRepository")
 struct RemoteEarmarkRepositoryTests {
+  private func makeGuardOnlyRepository(instrument: Instrument) -> RemoteEarmarkRepository {
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [URLProtocolStub.self]
+    let session = URLSession(configuration: config)
+    let client = APIClient(baseURL: URL(string: "https://api.example.com")!, session: session)
+    URLProtocolStub.requestHandler = { _ in
+      Issue.record("Network request should not be made when instrument guard fires")
+      let response = HTTPURLResponse(
+        url: URL(string: "https://api.example.com")!, statusCode: 500, httpVersion: nil,
+        headerFields: nil)!
+      return (response, Data())
+    }
+    return RemoteEarmarkRepository(client: client, instrument: instrument)
+  }
+
+  @Test func createRejectsEarmarkWithNonProfileInstrument() async throws {
+    let repo = makeGuardOnlyRepository(instrument: .AUD)
+    let earmark = Earmark(name: "USD Holiday", instrument: .USD)
+    await #expect(throws: BackendError.self) {
+      _ = try await repo.create(earmark)
+    }
+  }
+
+  @Test func updateRejectsEarmarkWithNonProfileInstrument() async throws {
+    let repo = makeGuardOnlyRepository(instrument: .AUD)
+    let earmark = Earmark(name: "USD Holiday", instrument: .USD)
+    await #expect(throws: BackendError.self) {
+      _ = try await repo.update(earmark)
+    }
+  }
+
+  @Test func setBudgetRejectsAmountInForeignInstrument() async throws {
+    let repo = makeGuardOnlyRepository(instrument: .AUD)
+    let foreignAmount = InstrumentAmount(quantity: 50, instrument: .USD)
+    await #expect(throws: BackendError.self) {
+      try await repo.setBudget(earmarkId: UUID(), categoryId: UUID(), amount: foreignAmount)
+    }
+  }
+
   @Test func testDecodesFixtureJSON() async throws {
     // Given
     let bundle = Bundle(for: TestBundleMarker.self)

--- a/MoolahTests/Backends/RemoteTransactionRepositoryTests.swift
+++ b/MoolahTests/Backends/RemoteTransactionRepositoryTests.swift
@@ -13,6 +13,45 @@ struct RemoteTransactionRepositoryTests {
     return (session, client)
   }
 
+  private func makeGuardOnlyRepository(instrument: Instrument)
+    -> RemoteTransactionRepository
+  {
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [TransactionURLProtocolStub.self]
+    let session = URLSession(configuration: config)
+    let client = APIClient(baseURL: URL(string: "https://api.example.com/api/")!, session: session)
+    TransactionURLProtocolStub.requestHandler = { _ in
+      Issue.record("Network request should not be made when instrument guard fires")
+      let response = HTTPURLResponse(
+        url: URL(string: "https://api.example.com")!, statusCode: 500, httpVersion: nil,
+        headerFields: nil)!
+      return (response, Data())
+    }
+    return RemoteTransactionRepository(client: client, instrument: instrument)
+  }
+
+  @Test func createRejectsTransactionWithForeignLeg() async throws {
+    let repo = makeGuardOnlyRepository(instrument: .AUD)
+    let leg = TransactionLeg(
+      accountId: UUID(), instrument: .USD, quantity: 50, type: .expense)
+    let txn = Transaction(date: Date(), legs: [leg])
+    await #expect(throws: BackendError.self) {
+      _ = try await repo.create(txn)
+    }
+  }
+
+  @Test func updateRejectsTransactionWhereAnyLegIsForeign() async throws {
+    let repo = makeGuardOnlyRepository(instrument: .AUD)
+    let nativeLeg = TransactionLeg(
+      accountId: UUID(), instrument: .AUD, quantity: 100, type: .income)
+    let foreignLeg = TransactionLeg(
+      accountId: UUID(), instrument: .USD, quantity: -100, type: .expense)
+    let txn = Transaction(date: Date(), legs: [nativeLeg, foreignLeg])
+    await #expect(throws: BackendError.self) {
+      _ = try await repo.update(txn)
+    }
+  }
+
   @Test func testDecodesFixtureJSON() async throws {
     let bundle = Bundle(for: TestBundleMarker.self)
     guard let url = bundle.url(forResource: "transactions", withExtension: "json") else {

--- a/guides/INSTRUMENT_CONVERSION_GUIDE.md
+++ b/guides/INSTRUMENT_CONVERSION_GUIDE.md
@@ -1,6 +1,6 @@
 # Instrument Conversion Guide
 
-**Version:** 1.0
+**Version:** 1.1
 **Platform targets:** macOS 26+ (primary), iOS 26+ (secondary)
 
 ---
@@ -137,6 +137,21 @@ Use `transaction.date`, `dailyBalance.date`, `snapshot.date`, or the explicit pa
 
 The date used to key a balance and the date supplied to the conversion service must both be normalized the same way (usually `Calendar(identifier: .gregorian).startOfDay(for:)`). Mismatches can cross timezone boundaries and return yesterday's rate for today's value.
 
+### Rule 11a: Single-instrument backends reject foreign-instrument writes
+
+Not every backend supports multi-currency. Only `CloudKitBackend` is multi-instrument; `RemoteBackend` and the hosted `moolah` backend are **single-instrument**. All accounts, earmarks, transaction legs, and budget amounts on those backends must be in the profile's currency.
+
+`Profile.supportsComplexTransactions` is the single source of truth:
+
+- `true` → CloudKit. Per-account currencies, per-earmark currencies, cross-currency transfers, and the custom transaction editor are available.
+- `false` → Remote / moolah. The UI hides currency pickers and the "Custom" transaction mode; sheets default to `profile.instrument`.
+
+**UI layer** — every currency picker (create/edit account, create/edit earmark, per-leg currency in `TransactionDetailView`) must be gated on `supportsComplexTransactions` and omitted when the flag is false. `TransactionDetailView.availableModes` must omit `.custom` for single-instrument profiles.
+
+**Backend layer** — the three `Remote*Repository` write paths (`RemoteAccountRepository.create/update`, `RemoteEarmarkRepository.create/update/setBudget`, `RemoteTransactionRepository.create/update`) call `requireMatchesProfileInstrument(...)` before any HTTP call and throw `BackendError.unsupportedInstrument(...)` on mismatch. This is defence in depth — a gating bug in the UI surfaces as an error, never as silent data that the backend cannot represent.
+
+If you add a new write path on a single-instrument backend (or a new single-instrument backend), it **must** call the guard on every instrument-bearing field — account instrument, opening balance, every transaction leg, earmark instrument, budget amount.
+
 ### Rule 11: Degrade gracefully; never display incorrect or confusing data
 
 Conversion can fail in production — no network, no cached fallback, unsupported pair, missing provider mapping. The system must degrade as gracefully as it can, but it **must never present an incorrect, partial, or mixed-instrument number as if it were the answer the user asked for**.
@@ -201,6 +216,8 @@ See Rule 8. Applies to both `convert(_:from:to:on:)` and `convertAmount(_:to:on:
 | Replacing a failed conversion with `0` / `.zero(instrument:)` in the running sum | A wrong total rendered as authoritative | Mark the affected total unavailable; never substitute zero (Rule 11) |
 | Wrapping all totals in one outer `do { ... } catch { total = nil }` | One bad position blanks sibling totals too — sidebar spinner forever | Scope the catch to the individual failing total; keep siblings rendering (Rule 11) |
 | `try?` on a conversion without logging or surfacing an error | Silent failure, invisible in production | Log via `os.Logger` and surface a retryable error to the user (Rule 11) |
+| Skipping the `supportsComplexTransactions` gate on a currency picker or custom-mode toggle | Lets a Remote / moolah user enter foreign-instrument data that the backend cannot represent | Gate every currency / custom-mode UI on `Profile.supportsComplexTransactions` (Rule 11a) |
+| Adding a write path on a single-instrument backend without calling `requireMatchesProfileInstrument` | Silent corruption — backend receives data it cannot represent | Call the guard on every instrument-bearing field before the HTTP call (Rule 11a) |
 
 ---
 
@@ -242,5 +259,6 @@ See Rule 8. Applies to both `convert(_:from:to:on:)` and `convertAmount(_:to:on:
 
 ## Version History
 
+- **1.1** (2026-04-17): Adds Rule 11a — single-instrument backends (Remote, moolah) reject foreign-instrument writes. Documents the UI gating (`Profile.supportsComplexTransactions`) and the `requireMatchesProfileInstrument` guard in the `Remote*Repository` write paths.
 - **1.0** (2026-04-17): Initial guide. Consolidates instrument-safe-arithmetic and conversion-date rules previously spread across `plans/ROADMAP.md`, `plans/2026-04-17-forecast-currency-conversion-plan.md`, and the `PositionBook` / `InstrumentAmount` source files. Adds Rule 11: on conversion failure, mark the affected total unavailable — never display the convertible portion as the total, never display the unconverted amount in its native instrument, and never substitute zero. Independently-scoped sibling totals must keep rendering.
 - **1.1** (2026-04-17): Rule 7 moved from a call-site obligation to a service-level guarantee — `FiatConversionService` and `FullConversionService` now clamp any future date to `Date()` before rate lookup, so forecast and scheduled call sites can pass `transaction.date` directly.

--- a/plans/ROADMAP.md
+++ b/plans/ROADMAP.md
@@ -75,25 +75,30 @@ CloudKit compatibility required: removing `#Unique` constraints, adding default 
 
 ---
 
-## Phase 6: Multi-Currency Support
+## Phase 6: Multi-Currency Support — Done
 
-Full per-account currency support, building on the exchange rate infrastructure from Phase 4 and multi-instrument foundation from Phase 8. Accounts can have a currency different from the profile's base currency, and all aggregation (totals, net worth, available funds) converts to the profile currency.
+Full per-account / per-earmark / per-leg currency support, building on the exchange rate infrastructure from Phase 4 and multi-instrument foundation from Phase 8. All aggregation (totals, net worth, available funds, forecast, analysis) converts to the profile currency at read time.
 
 ### Done
 
-- `Instrument` model, `Position` type, `TransactionLeg` with per-leg instruments
-- `ExchangeRateService` — Frankfurter API with caching, offline fallback, date-range queries
-- `InstrumentConversionService` protocol with `FiatConversionService` and `FullConversionService`
+- `Instrument` model, `Position` type, `TransactionLeg` with per-leg instruments.
+- `ExchangeRateService` — Frankfurter API with caching, offline fallback, date-range queries.
+- `InstrumentConversionService` protocol with `FiatConversionService` and `FullConversionService`.
 - `Account.instrument` field and `AccountRecord.instrumentId` storage — persisted and read back from SwiftData. Legacy `balance`/`investmentValue` fields removed; accounts are fully position-based.
-- Aggregation — `AccountStore` converts foreign-currency accounts to profile currency for sidebar totals, net worth, and available funds
-- Per-account currency picker in create/edit account UI (gated on `supportsComplexTransactions`)
-- Cross-currency transfers — `TransactionDetailView` shows independent Sent/Received amount fields with a derived exchange-rate hint
-- Analysis views — `CloudKitAnalysisRepository` converts every leg at the transaction's date before aggregating expense breakdown, income/expense totals, and daily balances
+- Aggregation — `AccountStore` converts foreign-currency accounts to profile currency for sidebar totals, net worth, and available funds. `displayBalance` replaces the old sync `balance(for:)`.
+- Per-account currency picker in create/edit account UI (gated on `supportsComplexTransactions`).
+- Per-earmark currency picker in create/edit earmark UI (`c6eda0d`), with `EarmarkStore` re-running `recomputeConvertedTotals` when the instrument changes.
+- Cross-currency transfers — `TransactionDetailView` shows independent Sent/Received amount fields with a derived exchange-rate hint; `TransactionDraft` supports per-leg instrument overrides.
+- Analysis views — `CloudKitAnalysisRepository` converts every leg at the transaction's date before aggregating expense breakdown, income/expense totals, and daily balances.
+- Forecast — scheduled foreign-currency transactions are pre-converted on `Date()` before entering the forecast accumulator (`c31b6af`).
+- Graceful degradation — per-unit isolation + retry for sidebar conversion failures (`61460a1`), transactions still display when conversion fails (`1dc622a`), per-account sidebar rows show the converted balance (`2331571`), `ExchangeRateService` falls back for missing dates and cold caches (`704825b`). Codified as Rule 11 in `guides/INSTRUMENT_CONVERSION_GUIDE.md`.
+- Import / export round-trip preserves earmark instrument (`b9a084f`).
+- Single-instrument backend enforcement — `Remote*Repository` write paths reject foreign-instrument writes with `BackendError.unsupportedInstrument`; UI gates currency pickers and the custom transaction mode on `Profile.supportsComplexTransactions`. Codified as Rule 11a in the guide.
 
-### Remaining
+### Known minor follow-ups (not blockers, not in BUGS.md)
 
-- Fix the multi-currency bugs tracked in `BUGS.md`: sync `AccountStore` totals trap for foreign-currency accounts, a single exchange-rate failure blanks the sidebar forever, `balance(for:)` hides non-primary positions, and there's no export/import round-trip test for multi-currency data.
-- Earmark currency picker — plan in `2026-04-17-earmark-currency-picker-plan.md`.
+- **Instrument override lost on account change** — `TransactionDetailView.swift:561` clears `draft.legDrafts[index].instrumentId` whenever the leg's account changes. If a user explicitly picked a non-account currency for a leg and then switches account, the override is silently dropped (the leg falls back to the new account's instrument via `TransactionDraft.toTransaction`). The resulting transaction is still valid data — UX regression, not a correctness bug.
+- **Profile currency change has no migration UX** — `SettingsView` lets a user change `profile.currencyCode` on a live profile with no warning. The conversion pipeline continues to work (existing accounts/earmarks keep their own instruments and are converted to the new profile currency at display time), but there's no confirmation dialog explaining the change or its effect on existing reports. Out of Phase 6 scope; revisit if users hit it.
 
 ---
 


### PR DESCRIPTION
## Summary
Belt-and-braces enforcement of the *Remote / moolah backend is single-currency* rule, plus documentation closing out Phase 6 (Multi-Currency Support).

### Code
- **New error** `BackendError.unsupportedInstrument(String)` with a user-facing message.
- **New helper** `requireMatchesProfileInstrument(_:profile:entity:)` in `Backends/Remote/SingleInstrumentGuard.swift`.
- **Guards on every Remote write path** — rejected before the HTTP call:
  - `RemoteAccountRepository.create/update` — account instrument + opening balance.
  - `RemoteTransactionRepository.create/update` — every leg instrument.
  - `RemoteEarmarkRepository.create/update/setBudget` — earmark instrument, budget amount.
- Currency pickers and the "Custom" transaction mode are already hidden when `Profile.supportsComplexTransactions` is `false`; the repository guard turns a future UI gating bug into an explicit error instead of silent corrupt data.

### Docs
- `guides/INSTRUMENT_CONVERSION_GUIDE.md` — new **Rule 11a**: single-instrument backends; UI must gate on `supportsComplexTransactions`; repositories enforce via the guard. Anti-patterns table and version history updated (v1.1).
- `Domain/Models/Profile.swift` — docstring on `supportsComplexTransactions` explaining the flag's contract and pointing at the guide rule.
- `plans/ROADMAP.md` — Phase 6 marked **Done**. Cites the commits that closed the old "Remaining" list (earmark picker, forecast conversion, graceful degradation, import/export round-trip, this PR's single-instrument enforcement). Two minor non-blocker follow-ups noted.

## Test plan
- [x] 8 new tests (`RemoteAccountRepository`, `RemoteTransactionRepository`, `RemoteEarmarkRepository`) assert each guard throws `BackendError` on a foreign-instrument write and that no HTTP request is made.
- [x] Full suite `just test` passes on macOS (1163 tests) and iOS simulator (1147 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)