### PR TITLE
fix: set CLOUDKIT_ENABLED in Release config (#84)

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -59,6 +59,9 @@ targets:
         PRODUCT_MODULE_NAME: Moolah
         INFOPLIST_FILE: App/Info.plist
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
+      configs:
+        Release:
+          SWIFT_ACTIVE_COMPILATION_CONDITIONS: "$(inherited) CLOUDKIT_ENABLED"
 
   Moolah_macOS:
     type: application
@@ -83,6 +86,7 @@ targets:
       configs:
         Release:
           ENABLE_HARDENED_RUNTIME: YES
+          SWIFT_ACTIVE_COMPILATION_CONDITIONS: "$(inherited) CLOUDKIT_ENABLED"
 
   MoolahTests_iOS:
     type: bundle.unit-test


### PR DESCRIPTION
## Summary
- Bakes `SWIFT_ACTIVE_COMPILATION_CONDITIONS=CLOUDKIT_ENABLED` into the Release config of `Moolah_iOS` and `Moolah_macOS` in `project.yml`.
- Previously the flag was only injected via the Fastfile's ad-hoc `xcargs`, so any Release archive produced via Xcode's Organizer or `just install-mac` silently dropped CloudKit and fell back to the local-stub `AuthProvider`.
- Debug configs are unchanged (tests still build without the flag, as before). Fastlane's redundant `xcargs` override still works.

Closes #84.

## Test plan
- [x] `just generate` (no `ENABLE_ENTITLEMENTS`) — pbxproj contains `CLOUDKIT_ENABLED` only in Release configs for both app targets; Debug configs are unchanged.
- [x] `xcodebuild -showBuildSettings` confirms: Debug → `DEBUG`, Release → `CLOUDKIT_ENABLED` (iOS + macOS).
- [x] `xcodebuild -configuration Release -scheme Moolah-macOS build` succeeds.
- [ ] CI test suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)