### PR TITLE
fix: drop ENABLE_HARDENED_RUNTIME=NO from macOS base config

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -82,7 +82,6 @@ targets:
         PRODUCT_MODULE_NAME: Moolah
         INFOPLIST_FILE: App/Info.plist
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
-        ENABLE_HARDENED_RUNTIME: NO
       configs:
         Release:
           ENABLE_HARDENED_RUNTIME: YES


### PR DESCRIPTION
## Summary
- Closes #83. Removes `ENABLE_HARDENED_RUNTIME: NO` from the `Moolah_macOS` base settings so a Release archive cannot silently inherit Hardened Runtime disabled. Release still explicitly sets `YES`; Debug continues to resolve to `NO` via Xcode's default.

## Test plan
- [x] `just generate` succeeds
- [x] `xcodebuild -target Moolah_macOS -configuration Release` resolves `ENABLE_HARDENED_RUNTIME = YES`
- [x] `xcodebuild -target Moolah_macOS -configuration Debug` resolves `ENABLE_HARDENED_RUNTIME = NO`
- [x] Debug macOS build succeeds
- [x] Release macOS build succeeds (unsigned)

🤖 Generated with [Claude Code](https://claude.com/claude-code)