### PR TITLE
style: add missing #Preview blocks and .monospacedDigit() modifiers

### DIFF
--- a/Features/Analysis/Views/IncomeExpenseTableCard.swift
+++ b/Features/Analysis/Views/IncomeExpenseTableCard.swift
@@ -78,9 +78,11 @@ struct IncomeExpenseTableCard: View {
                 VStack(alignment: .leading, spacing: 2) {
                   Text(monthLabel(for: item))
                     .font(.body)
+                    .monospacedDigit()
                   Text(monthsAgoLabel(for: item))
                     .font(.caption)
                     .foregroundStyle(.secondary)
+                    .monospacedDigit()
                 }
                 .frame(minWidth: 120, alignment: .leading)
 

--- a/Features/Earmarks/Views/AddBudgetLineItemSheet.swift
+++ b/Features/Earmarks/Views/AddBudgetLineItemSheet.swift
@@ -52,6 +52,7 @@ struct AddBudgetLineItemSheet: View {
             Text(earmark.instrument.currencySymbol ?? earmark.instrument.id)
               .foregroundStyle(.secondary)
             TextField("Amount", text: $amountText)
+              .monospacedDigit()
               #if os(iOS)
                 .keyboardType(.decimalPad)
               #endif

--- a/Features/Earmarks/Views/EditBudgetAmountSheet.swift
+++ b/Features/Earmarks/Views/EditBudgetAmountSheet.swift
@@ -21,6 +21,7 @@ struct EditBudgetAmountSheet: View {
             Text(lineItem.budgeted.instrument.currencySymbol ?? lineItem.budgeted.instrument.id)
               .foregroundStyle(.secondary)
             TextField("Amount", text: $amountText)
+              .monospacedDigit()
               #if os(iOS)
                 .keyboardType(.decimalPad)
               #endif

--- a/Features/Investments/Views/AddInvestmentValueView.swift
+++ b/Features/Investments/Views/AddInvestmentValueView.swift
@@ -31,6 +31,7 @@ struct AddInvestmentValueView: View {
               .foregroundStyle(.secondary)
             TextField("Value", text: $valueString)
               .focused($isValueFieldFocused)
+              .monospacedDigit()
               #if os(iOS)
                 .keyboardType(.decimalPad)
               #endif
@@ -76,4 +77,18 @@ struct AddInvestmentValueView: View {
     isSubmitting = false
     dismiss()
   }
+}
+
+#Preview {
+  let (backend, _) = PreviewBackend.create()
+  let store = InvestmentStore(
+    repository: backend.investments,
+    transactionRepository: backend.transactions,
+    conversionService: backend.conversionService
+  )
+  AddInvestmentValueView(
+    accountId: UUID(),
+    instrument: .AUD,
+    store: store
+  )
 }

--- a/Features/Investments/Views/InvestmentAccountView.swift
+++ b/Features/Investments/Views/InvestmentAccountView.swift
@@ -238,3 +238,52 @@ struct InvestmentAccountView: View {
     }
   }
 }
+
+#Preview {
+  let (backend, _) = PreviewBackend.create()
+  let investmentStore = InvestmentStore(
+    repository: backend.investments,
+    transactionRepository: backend.transactions,
+    conversionService: backend.conversionService
+  )
+  let transactionStore = TransactionStore(
+    repository: backend.transactions,
+    conversionService: backend.conversionService,
+    targetInstrument: .AUD
+  )
+  let tradeStore = TradeStore(transactions: backend.transactions)
+  let session = ProfileSession(profile: Profile(label: "Preview", backendType: .moolah))
+  let account = Account(
+    name: "Brokerage",
+    type: .investment,
+    instrument: .AUD
+  )
+
+  NavigationStack {
+    InvestmentAccountView(
+      account: account,
+      accounts: Accounts(from: [account]),
+      categories: Categories(from: []),
+      earmarks: Earmarks(from: []),
+      investmentStore: investmentStore,
+      transactionStore: transactionStore,
+      tradeStore: tradeStore
+    )
+    .environment(session)
+  }
+  .frame(width: 720, height: 560)
+  .task {
+    _ = try? await backend.accounts.create(
+      account, openingBalance: InstrumentAmount(quantity: 10_000, instrument: .AUD))
+    let calendar = Calendar.current
+    for monthsAgo in (0..<6).reversed() {
+      let date = calendar.date(byAdding: .month, value: -monthsAgo, to: Date())!
+      let quantity: Decimal = 9_500 + Decimal(6 - monthsAgo) * 400
+      await investmentStore.setValue(
+        accountId: account.id,
+        date: date,
+        value: InstrumentAmount(quantity: quantity, instrument: .AUD)
+      )
+    }
+  }
+}

--- a/Features/Investments/Views/InvestmentChartView.swift
+++ b/Features/Investments/Views/InvestmentChartView.swift
@@ -176,3 +176,27 @@ struct InvestmentChartView: View {
     })
   }
 }
+
+#Preview {
+  let calendar = Calendar.current
+  let points: [InvestmentChartDataPoint] = (0..<12).reversed().map { monthsAgo in
+    let date = calendar.date(byAdding: .month, value: -monthsAgo, to: Date())!
+    let balance: Decimal = 10_000 + Decimal(12 - monthsAgo) * 500
+    let value: Decimal = balance + Decimal(Double.random(in: -1_000...2_500))
+    return InvestmentChartDataPoint(
+      date: date,
+      value: value,
+      balance: balance,
+      profitLoss: value - balance
+    )
+  }
+  InvestmentChartView(dataPoints: points, instrument: .AUD)
+    .frame(width: 560, height: 320)
+    .padding()
+}
+
+#Preview("Empty") {
+  InvestmentChartView(dataPoints: [], instrument: .AUD)
+    .frame(width: 560, height: 320)
+    .padding()
+}

--- a/Features/Investments/Views/InvestmentSummaryView.swift
+++ b/Features/Investments/Views/InvestmentSummaryView.swift
@@ -104,3 +104,35 @@ private struct SummaryPanel: View {
     .accessibilityElement(children: .combine)
   }
 }
+
+#Preview {
+  let (backend, _) = PreviewBackend.create()
+  let store = InvestmentStore(
+    repository: backend.investments,
+    transactionRepository: backend.transactions,
+    conversionService: backend.conversionService
+  )
+  InvestmentSummaryView(
+    investedAmount: InstrumentAmount(quantity: 10_000, instrument: .AUD),
+    currentValue: InstrumentAmount(quantity: 12_500, instrument: .AUD),
+    store: store
+  )
+  .frame(width: 560)
+  .padding()
+}
+
+#Preview("At cost") {
+  let (backend, _) = PreviewBackend.create()
+  let store = InvestmentStore(
+    repository: backend.investments,
+    transactionRepository: backend.transactions,
+    conversionService: backend.conversionService
+  )
+  InvestmentSummaryView(
+    investedAmount: InstrumentAmount(quantity: 10_000, instrument: .AUD),
+    currentValue: nil,
+    store: store
+  )
+  .frame(width: 560)
+  .padding()
+}

--- a/Features/Investments/Views/InvestmentValueRow.swift
+++ b/Features/Investments/Views/InvestmentValueRow.swift
@@ -32,3 +32,23 @@ struct InvestmentValueRow: View {
     }
   }
 }
+
+#Preview {
+  List {
+    InvestmentValueRow(
+      value: InvestmentValue(
+        date: Date(),
+        value: InstrumentAmount(quantity: 5432, instrument: .AUD)
+      ),
+      onDelete: {}
+    )
+    InvestmentValueRow(
+      value: InvestmentValue(
+        date: Calendar.current.date(byAdding: .month, value: -1, to: Date())!,
+        value: InstrumentAmount(quantity: 5010, instrument: .AUD)
+      ),
+      onDelete: {}
+    )
+  }
+  .frame(width: 320)
+}

--- a/Features/Investments/Views/InvestmentValuesView.swift
+++ b/Features/Investments/Views/InvestmentValuesView.swift
@@ -103,3 +103,35 @@ struct InvestmentValuesView: View {
     .accessibilityLabel("Investment value over time")
   }
 }
+
+#Preview {
+  let (backend, _) = PreviewBackend.create()
+  let store = InvestmentStore(
+    repository: backend.investments,
+    transactionRepository: backend.transactions,
+    conversionService: backend.conversionService
+  )
+  let account = Account(
+    name: "Brokerage",
+    type: .investment,
+    instrument: .AUD
+  )
+  NavigationStack {
+    InvestmentValuesView(account: account, store: store)
+  }
+  .frame(width: 560, height: 480)
+  .task {
+    _ = try? await backend.accounts.create(account, openingBalance: .zero(instrument: .AUD))
+    let calendar = Calendar.current
+    for monthsAgo in (0..<6).reversed() {
+      let date = calendar.date(byAdding: .month, value: -monthsAgo, to: Date())!
+      let quantity: Decimal = 9_000 + Decimal(6 - monthsAgo) * 350
+      await store.setValue(
+        accountId: account.id,
+        date: date,
+        value: InstrumentAmount(quantity: quantity, instrument: .AUD)
+      )
+    }
+    await store.loadValues(accountId: account.id)
+  }
+}

--- a/Features/Investments/Views/RecordTradeView.swift
+++ b/Features/Investments/Views/RecordTradeView.swift
@@ -145,3 +145,18 @@ struct RecordTradeView: View {
     // TODO: Replace with full instrument picker sheet in Phase 5
   }
 }
+
+#Preview {
+  let (backend, _) = PreviewBackend.create()
+  let tradeStore = TradeStore(transactions: backend.transactions)
+  let feeId = UUID()
+  let categories = Categories(from: [
+    Category(id: feeId, name: "Fees")
+  ])
+  RecordTradeView(
+    accountId: UUID(),
+    profileCurrency: .AUD,
+    categories: categories,
+    tradeStore: tradeStore
+  )
+}

--- a/Features/Investments/Views/StockPositionRow.swift
+++ b/Features/Investments/Views/StockPositionRow.swift
@@ -59,3 +59,25 @@ struct StockPositionRow: View {
     return "\(name), \(quantityText), value unavailable"
   }
 }
+
+#Preview {
+  let bhp = Instrument.stock(ticker: "BHP.AX", exchange: "ASX", name: "BHP")
+  let apple = Instrument.stock(ticker: "AAPL", exchange: "NASDAQ", name: "Apple")
+  List {
+    StockPositionRow(
+      valuedPosition: ValuedPosition(
+        position: Position(instrument: bhp, quantity: 250),
+        marketValue: 11_325
+      ),
+      profileCurrency: .AUD
+    )
+    StockPositionRow(
+      valuedPosition: ValuedPosition(
+        position: Position(instrument: apple, quantity: 40),
+        marketValue: nil
+      ),
+      profileCurrency: .AUD
+    )
+  }
+  .frame(width: 380)
+}

--- a/Features/Investments/Views/StockPositionsView.swift
+++ b/Features/Investments/Views/StockPositionsView.swift
@@ -63,3 +63,39 @@ struct StockPositionsView: View {
     valuedPositions.filter { $0.position.instrument.kind == .fiatCurrency }
   }
 }
+
+#Preview {
+  let bhp = Instrument.stock(ticker: "BHP.AX", exchange: "ASX", name: "BHP")
+  let cba = Instrument.stock(ticker: "CBA.AX", exchange: "ASX", name: "CBA")
+  StockPositionsView(
+    valuedPositions: [
+      ValuedPosition(position: Position(instrument: bhp, quantity: 250), marketValue: 11_325),
+      ValuedPosition(position: Position(instrument: cba, quantity: 80), marketValue: 9_600),
+      ValuedPosition(position: Position(instrument: .AUD, quantity: 2_480), marketValue: 2_480),
+    ],
+    totalValue: 23_405,
+    profileCurrency: .AUD
+  )
+  .frame(width: 400, height: 360)
+}
+
+#Preview("Unavailable total") {
+  let bhp = Instrument.stock(ticker: "BHP.AX", exchange: "ASX", name: "BHP")
+  StockPositionsView(
+    valuedPositions: [
+      ValuedPosition(position: Position(instrument: bhp, quantity: 250), marketValue: nil)
+    ],
+    totalValue: nil,
+    profileCurrency: .AUD
+  )
+  .frame(width: 400, height: 240)
+}
+
+#Preview("Empty") {
+  StockPositionsView(
+    valuedPositions: [],
+    totalValue: nil,
+    profileCurrency: .AUD
+  )
+  .frame(width: 400, height: 240)
+}

--- a/Features/Reports/Views/CategoryBalanceTable.swift
+++ b/Features/Reports/Views/CategoryBalanceTable.swift
@@ -161,3 +161,32 @@ struct CategoryDrillDown: Hashable {
   let categoryId: UUID
   let dateRange: ClosedRange<Date>
 }
+
+#Preview {
+  let salaryId = UUID()
+  let bonusId = UUID()
+  let contractingId = UUID()
+  let incomeId = UUID()
+  let interestId = UUID()
+  let categories = Categories(from: [
+    Category(id: incomeId, name: "Income"),
+    Category(id: salaryId, name: "Salary", parentId: incomeId),
+    Category(id: bonusId, name: "Bonus", parentId: incomeId),
+    Category(id: contractingId, name: "Contracting", parentId: incomeId),
+    Category(id: interestId, name: "Interest"),
+  ])
+  let balances: [UUID: InstrumentAmount] = [
+    salaryId: InstrumentAmount(quantity: 4200, instrument: .AUD),
+    bonusId: InstrumentAmount(quantity: 1500, instrument: .AUD),
+    contractingId: InstrumentAmount(quantity: 800, instrument: .AUD),
+    interestId: InstrumentAmount(quantity: 120, instrument: .AUD),
+  ]
+  let start = Calendar.current.date(byAdding: .month, value: -1, to: Date())!
+  CategoryBalanceTable(
+    title: "Income",
+    balances: balances,
+    categories: categories,
+    dateRange: start...Date()
+  )
+  .frame(width: 500, height: 400)
+}

--- a/Features/Reports/Views/ReportsView.swift
+++ b/Features/Reports/Views/ReportsView.swift
@@ -167,3 +167,64 @@ struct ReportsView: View {
     isLoading = false
   }
 }
+
+#Preview {
+  let (backend, _) = PreviewBackend.create()
+  let transactionStore = TransactionStore(
+    repository: backend.transactions,
+    conversionService: backend.conversionService,
+    targetInstrument: .AUD
+  )
+  let salaryId = UUID()
+  let groceriesId = UUID()
+  let rentId = UUID()
+  let categories = Categories(from: [
+    Category(id: salaryId, name: "Salary"),
+    Category(id: groceriesId, name: "Groceries"),
+    Category(id: rentId, name: "Rent"),
+  ])
+  let account = Account(name: "Checking", type: .bank, instrument: .AUD)
+
+  ReportsView(
+    analysisRepository: backend.analysis,
+    categories: categories,
+    accounts: Accounts(from: [account]),
+    earmarks: Earmarks(from: []),
+    transactionStore: transactionStore
+  )
+  .frame(width: 900, height: 600)
+  .task {
+    _ = try? await backend.accounts.create(
+      account, openingBalance: InstrumentAmount(quantity: 5_000, instrument: .AUD))
+    _ = try? await backend.categories.create(
+      Category(id: salaryId, name: "Salary"))
+    _ = try? await backend.categories.create(
+      Category(id: groceriesId, name: "Groceries"))
+    _ = try? await backend.categories.create(
+      Category(id: rentId, name: "Rent"))
+    _ = try? await backend.transactions.create(
+      Transaction(
+        date: Date(), payee: "Employer",
+        legs: [
+          TransactionLeg(
+            accountId: account.id, instrument: .AUD, quantity: 4500, type: .income,
+            categoryId: salaryId)
+        ]))
+    _ = try? await backend.transactions.create(
+      Transaction(
+        date: Date().addingTimeInterval(-86400), payee: "Supermarket",
+        legs: [
+          TransactionLeg(
+            accountId: account.id, instrument: .AUD, quantity: -220, type: .expense,
+            categoryId: groceriesId)
+        ]))
+    _ = try? await backend.transactions.create(
+      Transaction(
+        date: Date().addingTimeInterval(-2 * 86400), payee: "Landlord",
+        legs: [
+          TransactionLeg(
+            accountId: account.id, instrument: .AUD, quantity: -1800, type: .expense,
+            categoryId: rentId)
+        ]))
+  }
+}


### PR DESCRIPTION
## Summary
Fixes seven ui-review issues flagged against `guides/STYLE_GUIDE.md`.

**Missing `.monospacedDigit()`** on numeric text fields and labels:
- #101 `IncomeExpenseTableCard` month labels
- #114 `AddBudgetLineItemSheet` and `EditBudgetAmountSheet` amount fields
- #115 `AddInvestmentValueView` value field

**Missing `#Preview` blocks** (using `PreviewBackend.create()` where stores are required):
- #117 `CategoryBalanceTable`
- #105 `ReportsView`, `InvestmentAccountView`, `InvestmentSummaryView`, `InvestmentChartView`, `InvestmentValuesView`, `StockPositionsView`, `StockPositionRow`, `InvestmentValueRow`, `AddInvestmentValueView`, `RecordTradeView`

Issues #113 and #123 were already resolved in the current code but remained open — the matching files already have `#Preview` blocks and `.monospacedDigit()` applied.

Closes #101, #105, #113, #114, #115, #117, #123.

## Test plan
- [x] `just build-mac` succeeds with no new warnings (warnings-as-errors is on)
- [x] `just test` passes (1170 tests, both iOS and macOS)
- [ ] Spot-render a few of the new previews in Xcode Canvas to confirm they render

🤖 Generated with [Claude Code](https://claude.com/claude-code)