### PR TITLE
fix: re-queue failed CloudKit deletes (issue #63)

### DIFF
--- a/Backends/CloudKit/Sync/SyncErrorRecovery.swift
+++ b/Backends/CloudKit/Sync/SyncErrorRecovery.swift
@@ -22,6 +22,10 @@ enum SyncErrorRecovery {
     var quotaExceeded: [CKRecord.ID] = []
     /// All other re-queueable failures (limitExceeded, unexpected errors).
     var requeue: [CKRecord.ID] = []
+    /// Failed deletes that should be re-queued (conflicts, limitExceeded, unexpected errors).
+    /// CKSyncEngine drops failed deletes from its queue; re-queuing prevents permanent
+    /// server-side orphans.
+    var requeueDeletes: [CKRecord.ID] = []
   }
 
   /// Classifies all failed saves and deletes from a sent-changes event.
@@ -72,10 +76,26 @@ enum SyncErrorRecovery {
     }
 
     for (recordID, error) in failedDeletes {
-      if error.code == .zoneNotFound || error.code == .userDeletedZone {
+      switch error.code {
+      case .zoneNotFound, .userDeletedZone:
         result.zoneNotFoundDeletes.append(recordID)
-      } else {
-        logger.error("Failed to delete record \(recordID.recordName): \(error)")
+
+      case .unknownItem:
+        // Record is already gone from the server — the delete has effectively
+        // succeeded. Don't re-queue (would loop forever) and don't treat as a
+        // failure. CKSyncEngine has already removed it from its pending queue.
+        logger.info(
+          "Delete returned unknownItem for \(recordID.recordName) — record already gone, treating as success"
+        )
+
+      default:
+        // Re-queue any other delete failure (serverRecordChanged, limitExceeded,
+        // unexpected errors). CKSyncEngine drops failed items from its queue, so
+        // not re-queuing would leave the record on the server permanently.
+        logger.error(
+          "Delete error (code=\(error.code.rawValue)) for \(recordID.recordName): \(error) — re-queuing"
+        )
+        result.requeueDeletes.append(recordID)
       }
     }
 
@@ -90,21 +110,24 @@ enum SyncErrorRecovery {
     logger: Logger
   ) -> (zoneNotFoundSaves: [CKRecord.ID], zoneNotFoundDeletes: [CKRecord.ID]) {
     // Re-queue conflicts, unknownItems, and other failures (same logic as current recover())
-    var pendingSaves: [CKSyncEngine.PendingRecordZoneChange] = []
+    var pendingChanges: [CKSyncEngine.PendingRecordZoneChange] = []
     for (recordID, _) in failures.conflicts {
-      pendingSaves.append(.saveRecord(recordID))
+      pendingChanges.append(.saveRecord(recordID))
     }
     for (recordID, _) in failures.unknownItems {
-      pendingSaves.append(.saveRecord(recordID))
+      pendingChanges.append(.saveRecord(recordID))
     }
     for recordID in failures.requeue {
-      pendingSaves.append(.saveRecord(recordID))
+      pendingChanges.append(.saveRecord(recordID))
     }
     for recordID in failures.quotaExceeded {
-      pendingSaves.append(.saveRecord(recordID))
+      pendingChanges.append(.saveRecord(recordID))
     }
-    if !pendingSaves.isEmpty {
-      syncEngine?.state.add(pendingRecordZoneChanges: pendingSaves)
+    for recordID in failures.requeueDeletes {
+      pendingChanges.append(.deleteRecord(recordID))
+    }
+    if !pendingChanges.isEmpty {
+      syncEngine?.state.add(pendingRecordZoneChanges: pendingChanges)
     }
 
     return (failures.zoneNotFoundSaves, failures.zoneNotFoundDeletes)

--- a/MoolahTests/Sync/SyncErrorRecoveryTests.swift
+++ b/MoolahTests/Sync/SyncErrorRecoveryTests.swift
@@ -1,0 +1,112 @@
+import CloudKit
+import Foundation
+import Testing
+import os
+
+@testable import Moolah
+
+@Suite("SyncErrorRecovery")
+struct SyncErrorRecoveryTests {
+
+  private static let logger = Logger(subsystem: "moolah.tests", category: "SyncErrorRecovery")
+
+  private static let zoneID = CKRecordZone.ID(
+    zoneName: "profile-\(UUID().uuidString)", ownerName: CKCurrentUserDefaultName)
+
+  private static func makeRecordID(_ name: String = UUID().uuidString) -> CKRecord.ID {
+    CKRecord.ID(recordName: name, zoneID: zoneID)
+  }
+
+  private static func makeCKError(_ code: CKError.Code) -> CKError {
+    CKError(_nsError: NSError(domain: CKErrorDomain, code: code.rawValue))
+  }
+
+  // MARK: - Failed delete classification
+
+  @Test func zoneNotFoundDeleteIsClassifiedForZoneCreation() {
+    let recordID = Self.makeRecordID()
+    let failures = SyncErrorRecovery.classify(
+      failedSaves: [],
+      failedDeletes: [(recordID, Self.makeCKError(.zoneNotFound))],
+      logger: Self.logger)
+
+    #expect(failures.zoneNotFoundDeletes == [recordID])
+    #expect(failures.requeueDeletes.isEmpty)
+  }
+
+  @Test func userDeletedZoneDeleteIsClassifiedForZoneCreation() {
+    let recordID = Self.makeRecordID()
+    let failures = SyncErrorRecovery.classify(
+      failedSaves: [],
+      failedDeletes: [(recordID, Self.makeCKError(.userDeletedZone))],
+      logger: Self.logger)
+
+    #expect(failures.zoneNotFoundDeletes == [recordID])
+    #expect(failures.requeueDeletes.isEmpty)
+  }
+
+  @Test func unknownItemDeleteIsTreatedAsSuccess() {
+    // The record is already gone on the server — delete succeeded in effect.
+    // It must NOT be re-queued (infinite loop) and NOT classified as zone-not-found.
+    let recordID = Self.makeRecordID()
+    let failures = SyncErrorRecovery.classify(
+      failedSaves: [],
+      failedDeletes: [(recordID, Self.makeCKError(.unknownItem))],
+      logger: Self.logger)
+
+    #expect(failures.zoneNotFoundDeletes.isEmpty)
+    #expect(failures.requeueDeletes.isEmpty)
+  }
+
+  @Test func serverRecordChangedDeleteIsRequeued() {
+    let recordID = Self.makeRecordID()
+    let failures = SyncErrorRecovery.classify(
+      failedSaves: [],
+      failedDeletes: [(recordID, Self.makeCKError(.serverRecordChanged))],
+      logger: Self.logger)
+
+    #expect(failures.requeueDeletes == [recordID])
+    #expect(failures.zoneNotFoundDeletes.isEmpty)
+  }
+
+  @Test func limitExceededDeleteIsRequeued() {
+    let recordID = Self.makeRecordID()
+    let failures = SyncErrorRecovery.classify(
+      failedSaves: [],
+      failedDeletes: [(recordID, Self.makeCKError(.limitExceeded))],
+      logger: Self.logger)
+
+    #expect(failures.requeueDeletes == [recordID])
+  }
+
+  @Test func unexpectedDeleteErrorIsRequeued() {
+    let recordID = Self.makeRecordID()
+    let failures = SyncErrorRecovery.classify(
+      failedSaves: [],
+      failedDeletes: [(recordID, Self.makeCKError(.internalError))],
+      logger: Self.logger)
+
+    #expect(failures.requeueDeletes == [recordID])
+    #expect(failures.zoneNotFoundDeletes.isEmpty)
+  }
+
+  @Test func mixedDeleteFailuresAreRoutedIndependently() {
+    let zoneMissing = Self.makeRecordID("zone-missing")
+    let alreadyGone = Self.makeRecordID("already-gone")
+    let conflict = Self.makeRecordID("conflict")
+    let unexpected = Self.makeRecordID("unexpected")
+
+    let failures = SyncErrorRecovery.classify(
+      failedSaves: [],
+      failedDeletes: [
+        (zoneMissing, Self.makeCKError(.zoneNotFound)),
+        (alreadyGone, Self.makeCKError(.unknownItem)),
+        (conflict, Self.makeCKError(.serverRecordChanged)),
+        (unexpected, Self.makeCKError(.internalError)),
+      ],
+      logger: Self.logger)
+
+    #expect(failures.zoneNotFoundDeletes == [zoneMissing])
+    #expect(Set(failures.requeueDeletes) == [conflict, unexpected])
+  }
+}


### PR DESCRIPTION
## Summary

- `SyncErrorRecovery.classify` now switches over every failed-delete error code instead of silently dropping anything that wasn't `.zoneNotFound`/`.userDeletedZone`. `.unknownItem` is treated as success (record already gone; re-queuing would loop forever); every other error goes into a new `requeueDeletes` list.
- `SyncErrorRecovery.requeueFailures` appends `.deleteRecord(recordID)` to the pending changes for each `requeueDeletes` entry, so CKSyncEngine retries the delete on the next send pass.
- Adds `MoolahTests/Sync/SyncErrorRecoveryTests.swift` covering zone-missing, `.unknownItem`, `.serverRecordChanged`, `.limitExceeded`, an unexpected error, and a mixed-input test that verifies independent routing.

Closes #63. Satisfies Rule 9 of `guides/SYNC_GUIDE.md`.

## Test plan

- [x] `just test SyncErrorRecoveryTests` — 7/7 passing
- [x] `just test-mac ProfileDataSyncHandlerTests ProfileIndexSyncHandlerTests SyncCoordinatorTests` — 46/46 passing
- [x] `sync-review` agent pass (clean, no violations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)