### PR TITLE
fix: proactively create profile-data zones on sync start (closes #66)

### DIFF
--- a/Backends/CloudKit/Sync/SyncCoordinator.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator.swift
@@ -260,11 +260,20 @@ final class SyncCoordinator: Sendable {
       queueAllExistingRecordsForAllZones()
     }
 
-    // Eagerly create the profile-index zone, then send if needed
+    // Eagerly create the profile-index zone and all known profile-data zones,
+    // then send if needed. Reactive creation in `handleSentRecordZoneChanges`
+    // remains as a fallback per SYNC_GUIDE Rule 3.
+    let profileIds = containerManager.allProfileIds()
     zoneSetupTask = Task {
       await self.ensureZoneExists(self.profileIndexHandler.zoneID)
+      for profileId in profileIds {
+        let zoneID = CKRecordZone.ID(
+          zoneName: "profile-\(profileId.uuidString)",
+          ownerName: CKCurrentUserDefaultName)
+        await self.ensureZoneExists(zoneID)
+      }
       if self.hasPendingChanges {
-        self.logger.info("Profile-index zone ready — sending pending changes")
+        self.logger.info("Zones ready — sending pending changes")
         await self.sendChanges()
       }
     }


### PR DESCRIPTION
## Summary
- \`SyncCoordinator.start()\` only ensured the \`profile-index\` zone; per-profile data zones were created reactively on \`.zoneNotFound\` send failures.
- This was a regression from commit \`4c6d853\` (unified \`SyncCoordinator\`) which dropped the proactive \`ensureZoneExists()\` that the prior per-profile \`ProfileSyncEngine.start()\` had. The profile-index zone kept that pattern — profile-data zones didn't.
- Per \`guides/SYNC_GUIDE.md\` §4 Rule 3, reactive-only creation is unreliable: error codes vary (\`.zoneNotFound\`, \`.limitExceeded\`, \`.userDeletedZone\`, \`.invalidArguments\`) and batch failures may stop retrying.
- Fix: iterate \`containerManager.allProfileIds()\` in \`start()\` and \`ensureZoneExists\` for each \`profile-<uuid>\` zone alongside the existing profile-index call. Reactive \`ensureProfileZone\` in \`handleSentRecordZoneChanges\` stays as the defense-in-depth fallback the guide requires.

## Test plan
- [x] \`just build-mac\` — succeeds, no new warnings
- [x] \`just test SyncCoordinatorTests\` — all pass
- [ ] CI (iOS + macOS test suite) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)