### PR TITLE
fix: partition CKSyncEngine batches by zone-kind for atomicByZone (#61)

### DIFF
--- a/Backends/CloudKit/Sync/SyncCoordinator.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator.swift
@@ -38,6 +38,69 @@ final class SyncCoordinator: Sendable {
     return .unknown
   }
 
+  // MARK: - Batch Kind
+
+  /// Zone-kind bucket for a single `RecordZoneChangeBatch`.
+  ///
+  /// `nextRecordZoneChangeBatch` emits one bucket per call so `atomicByZone` can
+  /// be set per-kind: profile-index records are independent (no cascade on conflict),
+  /// while profile-data records within a zone must commit together.
+  /// See issue #61.
+  enum BatchKind: Equatable {
+    case profileIndex
+    case profileData
+
+    var atomicByZone: Bool {
+      switch self {
+      case .profileIndex: return false
+      case .profileData: return true
+      }
+    }
+  }
+
+  /// Picks the next batch kind to emit from a list of pending changes.
+  /// Profile-index wins when both kinds are pending so index conflicts drain first.
+  /// Returns `nil` if no changes belong to a known zone kind.
+  nonisolated static func selectBatchKind(
+    from changes: some Sequence<CKSyncEngine.PendingRecordZoneChange>
+  ) -> BatchKind? {
+    var sawData = false
+    for change in changes {
+      let zoneID: CKRecordZone.ID
+      switch change {
+      case .saveRecord(let id): zoneID = id.zoneID
+      case .deleteRecord(let id): zoneID = id.zoneID
+      @unknown default: continue
+      }
+      switch parseZone(zoneID) {
+      case .profileIndex: return .profileIndex
+      case .profileData: sawData = true
+      case .unknown: continue
+      }
+    }
+    return sawData ? .profileData : nil
+  }
+
+  /// Filters pending changes to those matching the given batch kind, preserving order.
+  nonisolated static func filterChanges(
+    _ changes: [CKSyncEngine.PendingRecordZoneChange],
+    matching kind: BatchKind
+  ) -> [CKSyncEngine.PendingRecordZoneChange] {
+    changes.filter { change in
+      let zoneID: CKRecordZone.ID
+      switch change {
+      case .saveRecord(let id): zoneID = id.zoneID
+      case .deleteRecord(let id): zoneID = id.zoneID
+      @unknown default: return false
+      }
+      switch (parseZone(zoneID), kind) {
+      case (.profileIndex, .profileIndex): return true
+      case (.profileData, .profileData): return true
+      default: return false
+      }
+    }
+  }
+
   // MARK: - Observer Pattern
 
   struct ObserverToken: Equatable {
@@ -840,8 +903,14 @@ extension SyncCoordinator: CKSyncEngineDelegate {
 
     guard !pendingChanges.isEmpty else { return nil }
 
+    // Partition by zone-kind so atomicByZone can be set correctly per kind.
+    // Profile-index records are independent (atomicByZone: false); profile-data
+    // records within a zone must commit together (atomicByZone: true). See issue #61.
+    guard let batchKind = Self.selectBatchKind(from: pendingChanges) else { return nil }
+    let kindChanges = Self.filterChanges(pendingChanges, matching: batchKind)
+
     let batchLimit = 400
-    let batch = Array(pendingChanges.prefix(batchLimit))
+    let batch = Array(kindChanges.prefix(batchLimit))
 
     // Group saves by zone for efficient batch lookup
     var savesByZone: [CKRecordZone.ID: [CKRecord.ID]] = [:]
@@ -928,7 +997,7 @@ extension SyncCoordinator: CKSyncEngineDelegate {
     return CKSyncEngine.RecordZoneChangeBatch(
       recordsToSave: recordsToSave,
       recordIDsToDelete: deletesByBatch,
-      atomicByZone: false
+      atomicByZone: batchKind.atomicByZone
     )
   }
 

--- a/MoolahTests/Sync/SyncCoordinatorTests.swift
+++ b/MoolahTests/Sync/SyncCoordinatorTests.swift
@@ -284,4 +284,89 @@ struct SyncCoordinatorTests {
     #expect(handler.profileId == profileId)
     #expect(handler.zoneID == zoneID)
   }
+
+  // MARK: - Batch Kind Selection (issue #61)
+
+  @Test func batchKindAtomicByZoneIsFalseForProfileIndex() {
+    #expect(SyncCoordinator.BatchKind.profileIndex.atomicByZone == false)
+  }
+
+  @Test func batchKindAtomicByZoneIsTrueForProfileData() {
+    #expect(SyncCoordinator.BatchKind.profileData.atomicByZone == true)
+  }
+
+  @Test func selectBatchKindReturnsNilWhenNoChanges() {
+    let kind = SyncCoordinator.selectBatchKind(from: [])
+    #expect(kind == nil)
+  }
+
+  @Test func selectBatchKindPrefersProfileIndexWhenMixed() {
+    let indexZone = CKRecordZone.ID(
+      zoneName: "profile-index", ownerName: CKCurrentUserDefaultName)
+    let dataZone = CKRecordZone.ID(
+      zoneName: "profile-\(UUID().uuidString)", ownerName: CKCurrentUserDefaultName)
+    let changes: [CKSyncEngine.PendingRecordZoneChange] = [
+      .saveRecord(CKRecord.ID(recordName: UUID().uuidString, zoneID: dataZone)),
+      .saveRecord(CKRecord.ID(recordName: UUID().uuidString, zoneID: indexZone)),
+      .deleteRecord(CKRecord.ID(recordName: UUID().uuidString, zoneID: dataZone)),
+    ]
+    let kind = SyncCoordinator.selectBatchKind(from: changes)
+    #expect(kind == .profileIndex)
+  }
+
+  @Test func selectBatchKindReturnsProfileDataWhenOnlyDataZoneChanges() {
+    let dataZone1 = CKRecordZone.ID(
+      zoneName: "profile-\(UUID().uuidString)", ownerName: CKCurrentUserDefaultName)
+    let dataZone2 = CKRecordZone.ID(
+      zoneName: "profile-\(UUID().uuidString)", ownerName: CKCurrentUserDefaultName)
+    let changes: [CKSyncEngine.PendingRecordZoneChange] = [
+      .saveRecord(CKRecord.ID(recordName: UUID().uuidString, zoneID: dataZone1)),
+      .saveRecord(CKRecord.ID(recordName: UUID().uuidString, zoneID: dataZone2)),
+    ]
+    let kind = SyncCoordinator.selectBatchKind(from: changes)
+    #expect(kind == .profileData)
+  }
+
+  @Test func selectBatchKindIgnoresUnknownZones() {
+    let unknownZone = CKRecordZone.ID(
+      zoneName: "some-other-zone", ownerName: CKCurrentUserDefaultName)
+    let changes: [CKSyncEngine.PendingRecordZoneChange] = [
+      .saveRecord(CKRecord.ID(recordName: UUID().uuidString, zoneID: unknownZone))
+    ]
+    let kind = SyncCoordinator.selectBatchKind(from: changes)
+    #expect(kind == nil)
+  }
+
+  @Test func filterChangesMatchingProfileIndexKeepsOnlyIndexZone() {
+    let indexZone = CKRecordZone.ID(
+      zoneName: "profile-index", ownerName: CKCurrentUserDefaultName)
+    let dataZone = CKRecordZone.ID(
+      zoneName: "profile-\(UUID().uuidString)", ownerName: CKCurrentUserDefaultName)
+    let indexChange: CKSyncEngine.PendingRecordZoneChange =
+      .saveRecord(CKRecord.ID(recordName: UUID().uuidString, zoneID: indexZone))
+    let dataChange: CKSyncEngine.PendingRecordZoneChange =
+      .saveRecord(CKRecord.ID(recordName: UUID().uuidString, zoneID: dataZone))
+    let filtered = SyncCoordinator.filterChanges(
+      [dataChange, indexChange], matching: .profileIndex)
+    #expect(filtered.count == 1)
+    #expect(filtered.first == indexChange)
+  }
+
+  @Test func filterChangesMatchingProfileDataKeepsOnlyDataZones() {
+    let indexZone = CKRecordZone.ID(
+      zoneName: "profile-index", ownerName: CKCurrentUserDefaultName)
+    let dataZoneA = CKRecordZone.ID(
+      zoneName: "profile-\(UUID().uuidString)", ownerName: CKCurrentUserDefaultName)
+    let dataZoneB = CKRecordZone.ID(
+      zoneName: "profile-\(UUID().uuidString)", ownerName: CKCurrentUserDefaultName)
+    let indexChange: CKSyncEngine.PendingRecordZoneChange =
+      .saveRecord(CKRecord.ID(recordName: UUID().uuidString, zoneID: indexZone))
+    let dataChangeA: CKSyncEngine.PendingRecordZoneChange =
+      .saveRecord(CKRecord.ID(recordName: UUID().uuidString, zoneID: dataZoneA))
+    let dataChangeB: CKSyncEngine.PendingRecordZoneChange =
+      .deleteRecord(CKRecord.ID(recordName: UUID().uuidString, zoneID: dataZoneB))
+    let filtered = SyncCoordinator.filterChanges(
+      [indexChange, dataChangeA, dataChangeB], matching: .profileData)
+    #expect(filtered == [dataChangeA, dataChangeB])
+  }
 }


### PR DESCRIPTION
## Summary
- Split `nextRecordZoneChangeBatch` emission by zone-kind so `atomicByZone` is set correctly per kind: profile-index batches use `atomicByZone: false` (records are independent, no cascade on conflict — per commit 7c6648f), profile-data batches use `atomicByZone: true` (records within a zone must commit together).
- Previously a single mixed batch was emitted with `atomicByZone: false`, silently weakening atomicity for profile-data zones.
- Profile-index is drained first when both are pending so index conflicts don't block data traffic.

Fixes #61.

## Test plan
- [x] New unit tests in `SyncCoordinatorTests` cover `BatchKind.atomicByZone`, `selectBatchKind` (empty/mixed/data-only/unknown), and `filterChanges` (index and data)
- [x] `just test` — all 1178 tests pass on macOS and iOS
- [x] `@sync-review` clean against `guides/SYNC_GUIDE.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)