### PR TITLE
test: fix flaky AccountStore conversion tests with deterministic signal

### DIFF
--- a/Features/Accounts/AccountStore.swift
+++ b/Features/Accounts/AccountStore.swift
@@ -22,6 +22,12 @@ final class AccountStore {
   /// Investment values keyed by account ID, updated by InvestmentStore.
   private(set) var investmentValues: [UUID: InstrumentAmount] = [:]
 
+  /// Number of conversion passes that have completed since the store was
+  /// created. Incremented after every `runConversionAttempt`, whether the
+  /// pass succeeded or scheduled a retry. Tests wait on this to know the
+  /// store has published the results of at least one pass.
+  private(set) var conversionAttemptsCompleted: Int = 0
+
   private let repository: AccountRepository
   private let conversionService: any InstrumentConversionService
   private let targetInstrument: Instrument
@@ -228,6 +234,7 @@ final class AccountStore {
     convertedInvestmentTotal = investmentValid ? investmentTotal : nil
     convertedNetWorth =
       (currentValid && investmentValid) ? (currentTotal + investmentTotal) : nil
+    conversionAttemptsCompleted += 1
 
     return anyFailed
   }

--- a/MoolahTests/Features/AccountStoreConversionTests.swift
+++ b/MoolahTests/Features/AccountStoreConversionTests.swift
@@ -407,11 +407,12 @@ struct AccountStoreConversionTests {
       retryDelay: .seconds(60))
 
     await store.load()
-    // Conversion runs off the main actor; wait for the first recompute to
-    // land before asserting. Poll rather than sleeping a fixed interval to
-    // stay robust on busy CI runners.
-    try await waitForCondition(timeout: .seconds(2)) {
-      store.convertedBalances[bankAud.id] != nil
+    // Wait for the first conversion attempt to publish before asserting.
+    // Waiting on `conversionAttemptsCompleted` is deterministic — it increments
+    // exactly once per pass regardless of success — whereas polling for a
+    // specific output value races on busy CI runners.
+    try await waitForCondition(timeout: .seconds(10)) {
+      store.conversionAttemptsCompleted >= 1
     }
 
     // AUD bank: only AUD positions → succeeds.
@@ -457,7 +458,10 @@ struct AccountStoreConversionTests {
       retryDelay: .milliseconds(20))
 
     await store.load()
-    try await Task.sleep(for: .milliseconds(50))
+    // Wait for the first attempt to publish, deterministically.
+    try await waitForCondition(timeout: .seconds(10)) {
+      store.conversionAttemptsCompleted >= 1
+    }
 
     // Initial state: EUR bank can't be converted to AUD aggregate target → aggregate nil.
     #expect(store.convertedCurrentTotal == nil)
@@ -466,7 +470,7 @@ struct AccountStoreConversionTests {
     await conversion.setFailing([])
 
     // Retry should fire within retryDelay × a few attempts.
-    try await waitForCondition(timeout: .seconds(2)) {
+    try await waitForCondition(timeout: .seconds(10)) {
       store.convertedCurrentTotal != nil
     }
 


### PR DESCRIPTION
## Summary
The previous de-flake (966255b) replaced a fixed 50ms sleep with a 2s poll on `convertedBalances[bankAud.id] != nil`, but `perAccountBalancePopulatesEvenWhenAnotherAccountFails` still flaked on CI — observed twice in ~15 recent main builds (runs [24561532627](https://github.com/ajsutton/moolah-native/actions/runs/24561532627) and [24548964657](https://github.com/ajsutton/moolah-native/actions/runs/24548964657)). Polling for a specific output value races on slow runners because the first conversion pass may take longer than the polling window to publish.

## Fix
Expose `AccountStore.conversionAttemptsCompleted`, an integer counter incremented at the end of every `runConversionAttempt`. Tests wait for the counter to advance rather than for a specific output value — deterministic regardless of which instruments fail or how long actor hops take. Production behaviour is unchanged (the counter is write-only for the store, read-only outside).

Also applied the same fix to `conversionFailuresAreRetriedAfterDelay`, which still had a raw 50ms sleep for the same reason. Timeout bumped to 10s as a belt-and-braces guard.

## Test plan
- [x] `just build-mac` succeeds (warnings-as-errors on)
- [x] `just test AccountStoreConversionTests` passed 8× in a row locally
- [x] `just test` passes the full 1170-test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)