### PR TITLE
refactor: move async business logic out of views (concurrency review fixes)

### DIFF
--- a/App/ContentView.swift
+++ b/App/ContentView.swift
@@ -11,6 +11,7 @@ struct ContentView: View {
   @Environment(AnalysisStore.self) private var analysisStore
   @Environment(InvestmentStore.self) private var investmentStore
   @Environment(TradeStore.self) private var tradeStore
+  @Environment(ReportingStore.self) private var reportingStore
   #if os(macOS)
     @State private var selection: SidebarSelection? = .analysis
   #else
@@ -92,7 +93,7 @@ struct ContentView: View {
         CategoriesView(categoryStore: categoryStore)
       case .reports:
         ReportsView(
-          analysisRepository: analysisStore.repository,
+          reportingStore: reportingStore,
           categories: categoryStore.categories,
           accounts: accountStore.accounts,
           earmarks: earmarkStore.earmarks,

--- a/App/ProfileSession.swift
+++ b/App/ProfileSession.swift
@@ -18,6 +18,7 @@ final class ProfileSession: Identifiable {
   let analysisStore: AnalysisStore
   let investmentStore: InvestmentStore
   let tradeStore: TradeStore
+  let reportingStore: ReportingStore
   let exchangeRateService: ExchangeRateService
   let stockPriceService: StockPriceService
   let cryptoPriceService: CryptoPriceService
@@ -128,6 +129,12 @@ final class ProfileSession: Identifiable {
       conversionService: backend.conversionService
     )
     self.tradeStore = TradeStore(transactions: backend.transactions)
+    self.reportingStore = ReportingStore(
+      transactionRepository: backend.transactions,
+      analysisRepository: backend.analysis,
+      conversionService: backend.conversionService,
+      profileCurrency: profile.instrument
+    )
 
     // Wire up cross-store side effects
     let accountStore = self.accountStore

--- a/App/SessionRootView.swift
+++ b/App/SessionRootView.swift
@@ -17,6 +17,7 @@ struct SessionRootView: View {
       .environment(session.analysisStore)
       .environment(session.investmentStore)
       .environment(session.tradeStore)
+      .environment(session.reportingStore)
       .focusedSceneValue(\.authStore, session.authStore)
       .focusedSceneValue(\.activeProfileSession, session)
   }

--- a/Features/Earmarks/EarmarkStore.swift
+++ b/Features/Earmarks/EarmarkStore.swift
@@ -323,6 +323,14 @@ final class EarmarkStore {
     }
   }
 
+  /// Marks an earmark as hidden so it no longer appears in default lists.
+  @discardableResult
+  func hide(_ earmark: Earmark) async -> Earmark? {
+    var hidden = earmark
+    hidden.isHidden = true
+    return await update(hidden)
+  }
+
   func update(_ earmark: Earmark) async -> Earmark? {
     logger.debug("Updating earmark: \(earmark.name)")
     error = nil

--- a/Features/Earmarks/Views/EarmarksView.swift
+++ b/Features/Earmarks/Views/EarmarksView.swift
@@ -152,20 +152,12 @@ struct EarmarksView: View {
           }
           Divider()
           Button("Hide", systemImage: "eye.slash", role: .destructive) {
-            Task {
-              var hidden = earmark
-              hidden.isHidden = true
-              _ = await earmarkStore.update(hidden)
-            }
+            Task { await earmarkStore.hide(earmark) }
           }
         }
         .swipeActions(edge: .trailing) {
           Button(role: .destructive) {
-            Task {
-              var hidden = earmark
-              hidden.isHidden = true
-              _ = await earmarkStore.update(hidden)
-            }
+            Task { await earmarkStore.hide(earmark) }
           } label: {
             Label("Hide", systemImage: "eye.slash")
           }

--- a/Features/Investments/InvestmentStore.swift
+++ b/Features/Investments/InvestmentStore.swift
@@ -87,6 +87,28 @@ final class InvestmentStore {
     isLoading = false
   }
 
+  /// Loads the full dataset required by `InvestmentAccountView`, branching on
+  /// whether the account uses legacy manual valuations or position tracking.
+  /// Keeps the branching logic out of the view so `.task`/`.refreshable`
+  /// blocks stay one-liners.
+  func loadAllData(accountId: UUID, profileCurrency: Instrument) async {
+    await loadValues(accountId: accountId)
+    if hasLegacyValuations {
+      await loadDailyBalances(accountId: accountId)
+    } else {
+      await loadPositions(accountId: accountId)
+      await valuatePositions(profileCurrency: profileCurrency, on: Date())
+    }
+  }
+
+  /// Refreshes position data after a trade is recorded. Used from
+  /// `.onChange` where we only care about position-tracked accounts.
+  func reloadPositionsIfNeeded(accountId: UUID, profileCurrency: Instrument) async {
+    guard !hasLegacyValuations else { return }
+    await loadPositions(accountId: accountId)
+    await valuatePositions(profileCurrency: profileCurrency, on: Date())
+  }
+
   func setValue(accountId: UUID, date: Date, value: InstrumentAmount) async {
     error = nil
     do {

--- a/Features/Investments/Views/InvestmentAccountView.swift
+++ b/Features/Investments/Views/InvestmentAccountView.swift
@@ -135,34 +135,19 @@ struct InvestmentAccountView: View {
       }
     }
     .task(id: account.id) {
-      // Always load values first to determine which mode to use
-      await investmentStore.loadValues(accountId: account.id)
-      if investmentStore.hasLegacyValuations {
-        await investmentStore.loadDailyBalances(accountId: account.id)
-      } else {
-        await investmentStore.loadPositions(accountId: account.id)
-        await investmentStore.valuatePositions(
-          profileCurrency: profileCurrencyInstrument, on: Date())
-      }
+      await investmentStore.loadAllData(
+        accountId: account.id, profileCurrency: profileCurrencyInstrument)
     }
     .onChange(of: showingRecordTrade) { _, showing in
-      if !showing && !investmentStore.hasLegacyValuations {
-        Task {
-          await investmentStore.loadPositions(accountId: account.id)
-          await investmentStore.valuatePositions(
-            profileCurrency: profileCurrencyInstrument, on: Date())
-        }
+      guard !showing else { return }
+      Task {
+        await investmentStore.reloadPositionsIfNeeded(
+          accountId: account.id, profileCurrency: profileCurrencyInstrument)
       }
     }
     .refreshable {
-      await investmentStore.loadValues(accountId: account.id)
-      if investmentStore.hasLegacyValuations {
-        await investmentStore.loadDailyBalances(accountId: account.id)
-      } else {
-        await investmentStore.loadPositions(accountId: account.id)
-        await investmentStore.valuatePositions(
-          profileCurrency: profileCurrencyInstrument, on: Date())
-      }
+      await investmentStore.loadAllData(
+        accountId: account.id, profileCurrency: profileCurrencyInstrument)
     }
   }
 

--- a/Features/Reports/ReportingStore.swift
+++ b/Features/Reports/ReportingStore.swift
@@ -58,19 +58,52 @@ final class ReportingStore {
   private(set) var isLoading = false
   private(set) var error: Error?
 
+  /// Category balances for the Reports view, bucketed by transaction type.
+  private(set) var incomeBalances: [UUID: InstrumentAmount] = [:]
+  private(set) var expenseBalances: [UUID: InstrumentAmount] = [:]
+  private(set) var isLoadingCategoryBalances = false
+  private(set) var categoryBalancesError: Error?
+
   private let transactionRepository: TransactionRepository
+  private let analysisRepository: AnalysisRepository?
   private let conversionService: InstrumentConversionService
   private let profileCurrency: Instrument
   private let logger = Logger(subsystem: "com.moolah.app", category: "ReportingStore")
 
   init(
     transactionRepository: TransactionRepository,
+    analysisRepository: AnalysisRepository? = nil,
     conversionService: InstrumentConversionService,
     profileCurrency: Instrument
   ) {
     self.transactionRepository = transactionRepository
+    self.analysisRepository = analysisRepository
     self.conversionService = conversionService
     self.profileCurrency = profileCurrency
+  }
+
+  /// Loads income + expense category balances for a date range. Results are
+  /// published to `incomeBalances` / `expenseBalances`; failures land on
+  /// `categoryBalancesError`.
+  func loadCategoryBalances(dateRange: ClosedRange<Date>) async {
+    guard let analysisRepository else {
+      logger.error("loadCategoryBalances called without analysisRepository")
+      return
+    }
+    isLoadingCategoryBalances = true
+    categoryBalancesError = nil
+    do {
+      let result = try await analysisRepository.fetchCategoryBalancesByType(
+        dateRange: dateRange,
+        filters: TransactionFilter()
+      )
+      incomeBalances = result.income
+      expenseBalances = result.expense
+    } catch {
+      logger.error("Failed to load category balances: \(error)")
+      categoryBalancesError = error
+    }
+    isLoadingCategoryBalances = false
   }
 
   func loadProfitLoss() async {

--- a/Features/Reports/Views/ReportsView.swift
+++ b/Features/Reports/Views/ReportsView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 /// Main Reports view displaying income and expense breakdown by category.
 struct ReportsView: View {
-  let analysisRepository: AnalysisRepository
+  let reportingStore: ReportingStore
   let categories: Categories
   let accounts: Accounts
   let earmarks: Earmarks
@@ -18,11 +18,6 @@ struct ReportsView: View {
   @State private var resolvedFrom: Date = DateRange.last12Months.startDate()
   @State private var resolvedTo: Date = DateRange.last12Months.endDate()
 
-  @State private var incomeBalances: [UUID: InstrumentAmount] = [:]
-  @State private var expenseBalances: [UUID: InstrumentAmount] = [:]
-  @State private var isLoading = false
-  @State private var error: Error?
-
   var body: some View {
     NavigationStack {
       VStack(spacing: 0) {
@@ -31,17 +26,19 @@ struct ReportsView: View {
 
         Divider()
 
-        if isLoading {
+        if reportingStore.isLoadingCategoryBalances {
           ProgressView("Loading report...")
             .frame(maxWidth: .infinity, maxHeight: .infinity)
-        } else if let error {
+        } else if let error = reportingStore.categoryBalancesError {
           ContentUnavailableView {
             Label("Error Loading Report", systemImage: "exclamationmark.triangle")
           } description: {
             Text(error.localizedDescription)
           } actions: {
             Button("Try Again") {
-              Task { await loadData() }
+              Task {
+                await reportingStore.loadCategoryBalances(dateRange: resolvedFrom...resolvedTo)
+              }
             }
           }
         } else {
@@ -50,7 +47,7 @@ struct ReportsView: View {
             HStack(spacing: 0) {
               CategoryBalanceTable(
                 title: "Income",
-                balances: incomeBalances,
+                balances: reportingStore.incomeBalances,
                 categories: categories,
                 dateRange: resolvedFrom...resolvedTo
               )
@@ -59,7 +56,7 @@ struct ReportsView: View {
 
               CategoryBalanceTable(
                 title: "Expenses",
-                balances: expenseBalances,
+                balances: reportingStore.expenseBalances,
                 categories: categories,
                 dateRange: resolvedFrom...resolvedTo
               )
@@ -68,7 +65,7 @@ struct ReportsView: View {
             VStack(spacing: 0) {
               CategoryBalanceTable(
                 title: "Income",
-                balances: incomeBalances,
+                balances: reportingStore.incomeBalances,
                 categories: categories,
                 dateRange: resolvedFrom...resolvedTo
               )
@@ -77,7 +74,7 @@ struct ReportsView: View {
 
               CategoryBalanceTable(
                 title: "Expenses",
-                balances: expenseBalances,
+                balances: reportingStore.expenseBalances,
                 categories: categories,
                 dateRange: resolvedFrom...resolvedTo
               )
@@ -101,26 +98,30 @@ struct ReportsView: View {
         )
       }
     }
-    .task {
-      await loadData()
+    .task(id: DateRangeKey(from: resolvedFrom, to: resolvedTo)) {
+      await reportingStore.loadCategoryBalances(dateRange: resolvedFrom...resolvedTo)
     }
     .onChange(of: dateRange) { _, newValue in
-      if newValue != .custom {
-        resolvedFrom = newValue.startDate()
-        resolvedTo = newValue.endDate()
-      }
-      Task { await loadData() }
+      guard newValue != .custom else { return }
+      resolvedFrom = newValue.startDate()
+      resolvedTo = newValue.endDate()
     }
     .onChange(of: customFrom) { _, newValue in
       guard dateRange == .custom else { return }
       resolvedFrom = newValue
-      Task { await loadData() }
     }
     .onChange(of: customTo) { _, newValue in
       guard dateRange == .custom else { return }
       resolvedTo = newValue
-      Task { await loadData() }
     }
+  }
+
+  /// Stable identity for the `.task(id:)` trigger — re-running the load
+  /// whenever either endpoint changes while letting SwiftUI cancel any
+  /// in-flight request when the view disappears.
+  private struct DateRangeKey: Hashable {
+    let from: Date
+    let to: Date
   }
 
   private var dateRangeSelector: some View {
@@ -146,25 +147,6 @@ struct ReportsView: View {
       Spacer()
     }
     .padding()
-  }
-
-  private func loadData() async {
-    isLoading = true
-    error = nil
-
-    do {
-      let range = resolvedFrom...resolvedTo
-      let result = try await analysisRepository.fetchCategoryBalancesByType(
-        dateRange: range,
-        filters: TransactionFilter()
-      )
-      incomeBalances = result.income
-      expenseBalances = result.expense
-    } catch {
-      self.error = error
-    }
-
-    isLoading = false
   }
 }
 

--- a/Features/Reports/Views/ReportsView.swift
+++ b/Features/Reports/Views/ReportsView.swift
@@ -157,6 +157,12 @@ struct ReportsView: View {
     conversionService: backend.conversionService,
     targetInstrument: .AUD
   )
+  let reportingStore = ReportingStore(
+    transactionRepository: backend.transactions,
+    analysisRepository: backend.analysis,
+    conversionService: backend.conversionService,
+    profileCurrency: .AUD
+  )
   let salaryId = UUID()
   let groceriesId = UUID()
   let rentId = UUID()
@@ -168,7 +174,7 @@ struct ReportsView: View {
   let account = Account(name: "Checking", type: .bank, instrument: .AUD)
 
   ReportsView(
-    analysisRepository: backend.analysis,
+    reportingStore: reportingStore,
     categories: categories,
     accounts: Accounts(from: [account]),
     earmarks: Earmarks(from: []),

--- a/Features/Transactions/TransactionStore.swift
+++ b/Features/Transactions/TransactionStore.swift
@@ -11,6 +11,9 @@ final class TransactionStore {
   private(set) var error: Error?
   private(set) var loadedCount = 0
   private(set) var totalCount: Int?
+  /// True while a `payScheduledTransaction` call is in flight. Views observe
+  /// this to show a progress indicator on the Pay button.
+  private(set) var isPayingScheduled = false
 
   private let repository: TransactionRepository
   private let conversionService: InstrumentConversionService
@@ -154,6 +157,8 @@ final class TransactionStore {
   /// or deletes it (one-time). Reloads with the scheduled filter afterward.
   /// Returns the updated scheduled transaction if recurring, nil if deleted or failed.
   func payScheduledTransaction(_ scheduledTransaction: Transaction) async -> PayResult {
+    isPayingScheduled = true
+    defer { isPayingScheduled = false }
     // Create a non-scheduled copy with today's date
     let paidTransaction = Transaction(
       id: UUID(),

--- a/Features/Transactions/Views/TransactionDetailView.swift
+++ b/Features/Transactions/Views/TransactionDetailView.swift
@@ -700,8 +700,6 @@ struct TransactionDetailView: View {
     }
   }
 
-  @State private var isPaying = false
-
   private var isScheduled: Bool {
     showRecurrence && transaction.recurPeriod != nil
   }
@@ -710,26 +708,16 @@ struct TransactionDetailView: View {
     Section {
       Button {
         Task {
-          isPaying = true
-          let result = await transactionStore.payScheduledTransaction(transaction)
-          isPaying = false
-          switch result {
-          case .paid(let updated):
-            if let updated {
-              onUpdate(updated)
-            } else {
-              onDelete(transaction.id)
-            }
-          case .deleted:
-            onDelete(transaction.id)
-          case .failed:
-            break
+          switch await transactionStore.payScheduledTransaction(transaction) {
+          case .paid(let updated?): onUpdate(updated)
+          case .paid(.none), .deleted: onDelete(transaction.id)
+          case .failed: break
           }
         }
       } label: {
         HStack {
           Spacer()
-          if isPaying {
+          if transactionStore.isPayingScheduled {
             ProgressView()
               .controlSize(.small)
           } else {
@@ -738,7 +726,7 @@ struct TransactionDetailView: View {
           Spacer()
         }
       }
-      .disabled(isPaying)
+      .disabled(transactionStore.isPayingScheduled)
       .accessibilityLabel("Pay \(transaction.payee ?? "transaction") now")
     }
   }

--- a/Features/Transactions/Views/TransactionListView.swift
+++ b/Features/Transactions/Views/TransactionListView.swift
@@ -211,11 +211,9 @@ struct TransactionListView: View {
             Label("Delete", systemImage: "trash")
           }
         }
-        .onAppear {
+        .task {
           if entry.id == transactionStore.transactions.last?.id {
-            Task {
-              await transactionStore.loadMore()
-            }
+            await transactionStore.loadMore()
           }
         }
       }

--- a/MoolahTests/Features/EarmarkStoreTests.swift
+++ b/MoolahTests/Features/EarmarkStoreTests.swift
@@ -508,6 +508,22 @@ struct EarmarkStoreTests {
     #expect(store.error != nil)
   }
 
+  @Test func testHideMarksEarmarkHidden() async throws {
+    let earmark = Earmark(name: "Vacation", instrument: .defaultTestInstrument)
+    let (backend, container) = try TestBackend.create()
+    TestBackend.seed(earmarks: [earmark], in: container)
+    let store = EarmarkStore(
+      repository: backend.earmarks, conversionService: FixedConversionService(),
+      targetInstrument: .defaultTestInstrument)
+    await store.load()
+
+    let result = await store.hide(earmark)
+
+    #expect(result?.isHidden == true)
+    #expect(store.earmarks.by(id: earmark.id)?.isHidden == true)
+    #expect(store.visibleEarmarks.contains(where: { $0.id == earmark.id }) == false)
+  }
+
   // MARK: - Show Hidden
 
   @Test("visibleEarmarks excludes hidden earmarks by default")

--- a/MoolahTests/Features/ReportingStoreTests.swift
+++ b/MoolahTests/Features/ReportingStoreTests.swift
@@ -333,4 +333,56 @@ struct ReportingStoreTests {
     let kinds = Set(store.profitLoss.map { $0.instrument.kind })
     #expect(kinds == [.stock, .cryptoToken])
   }
+
+  @Test @MainActor func loadCategoryBalances_populatesIncomeAndExpense() async throws {
+    let (backend, container) = try TestBackend.create()
+    let account = Account(
+      id: UUID(), name: "Checking", type: .bank, instrument: .defaultTestInstrument
+    )
+    let incomeCategory = Moolah.Category(id: UUID(), name: "Salary")
+    let expenseCategory = Moolah.Category(id: UUID(), name: "Groceries")
+    TestBackend.seed(accounts: [account], in: container)
+    TestBackend.seed(categories: [incomeCategory, expenseCategory], in: container)
+
+    let today = Date()
+    TestBackend.seed(
+      transactions: [
+        Transaction(
+          date: today,
+          payee: "Employer",
+          legs: [
+            TransactionLeg(
+              accountId: account.id, instrument: .defaultTestInstrument,
+              quantity: 1000, type: .income, categoryId: incomeCategory.id)
+          ]
+        ),
+        Transaction(
+          date: today,
+          payee: "Store",
+          legs: [
+            TransactionLeg(
+              accountId: account.id, instrument: .defaultTestInstrument,
+              quantity: -50, type: .expense, categoryId: expenseCategory.id)
+          ]
+        ),
+      ],
+      in: container
+    )
+
+    let store = ReportingStore(
+      transactionRepository: backend.transactions,
+      analysisRepository: backend.analysis,
+      conversionService: FixedConversionService(),
+      profileCurrency: .defaultTestInstrument
+    )
+
+    let from = Calendar.current.date(byAdding: .day, value: -1, to: today)!
+    let to = Calendar.current.date(byAdding: .day, value: 1, to: today)!
+    await store.loadCategoryBalances(dateRange: from...to)
+
+    #expect(!store.isLoadingCategoryBalances)
+    #expect(store.categoryBalancesError == nil)
+    #expect(store.incomeBalances[incomeCategory.id]?.quantity == 1000)
+    #expect(store.expenseBalances[expenseCategory.id]?.quantity == -50)
+  }
 }


### PR DESCRIPTION
## Summary

Closes #51, #52, #53, #55, #56 — all five `review:concurrency` / `severity:important` findings.

Each view no longer owns the state or orchestration the concurrency guide says belongs in a store:

- **#51 TransactionListView** — pagination trigger uses `.task` (auto-cancels on disappear) instead of `Task {}` in `.onAppear`.
- **#52 TransactionDetailView** — `isPaying` moved to `TransactionStore.isPayingScheduled` (guarded by `defer`); Pay button body is a single dispatch.
- **#53 InvestmentAccountView** — `InvestmentStore.loadAllData(accountId:profileCurrency:)` and `reloadPositionsIfNeeded(...)` fold the legacy-vs-positions branch into the store.
- **#55 ReportsView** — category-balance state + repository call moved to `ReportingStore.loadCategoryBalances(dateRange:)`; view uses `.task(id:)` with a composite `DateRangeKey` so SwiftUI re-runs and cancels the load as the resolved range changes.
- **#56 EarmarksView** — `EarmarkStore.hide(_:)` replaces the 4-line mutate-then-update `Task {}` in context menu / swipe action.

Store tests added for `EarmarkStore.hide` and `ReportingStore.loadCategoryBalances`.

## Test plan

- [x] `just test` (macOS + iOS) — all 1172 tests pass
- [x] `just build-mac` — warning-free build
- [x] `@concurrency-review` agent re-run; remaining findings addressed in a follow-up commit