### PR TITLE
fix: enforce earmark/budget instrument parity and earmark-targeted balances

### DIFF
--- a/Backends/CloudKit/Models/EarmarkBudgetItemRecord.swift
+++ b/Backends/CloudKit/Models/EarmarkBudgetItemRecord.swift
@@ -27,8 +27,15 @@ final class EarmarkBudgetItemRecord {
     self.instrumentId = instrumentId
   }
 
-  func toDomain() -> EarmarkBudgetItem {
-    let instrument = Instrument.fiat(code: instrumentId)
+  /// Domain conversion keyed to the owning earmark's instrument.
+  /// Budget items must always share their earmark's instrument (see
+  /// `guides/INSTRUMENT_CONVERSION_GUIDE.md` Rule 1/2). The stored
+  /// `instrumentId` is preserved for backwards compatibility but any drift
+  /// is resolved here — the quantity is kept, the instrument is the
+  /// earmark's. Pass `nil` to fall back to the stored `instrumentId` (used
+  /// only by code paths that cannot resolve the earmark).
+  func toDomain(earmarkInstrument: Instrument? = nil) -> EarmarkBudgetItem {
+    let instrument = earmarkInstrument ?? Instrument.fiat(code: instrumentId)
     return EarmarkBudgetItem(
       id: id, categoryId: categoryId,
       amount: InstrumentAmount(storageValue: amount, instrument: instrument))

--- a/Backends/CloudKit/Models/EarmarkRecord.swift
+++ b/Backends/CloudKit/Models/EarmarkRecord.swift
@@ -44,10 +44,12 @@ final class EarmarkRecord {
     positions: [Position] = [], savedPositions: [Position] = [], spentPositions: [Position] = []
   ) -> Earmark {
     let instrument = instrumentId.map { Instrument.fiat(code: $0) } ?? defaultInstrument
-    let savingsGoal: InstrumentAmount? = savingsTarget.flatMap { target in
-      guard let instrumentId = savingsTargetInstrumentId else { return nil }
-      let inst = Instrument.fiat(code: instrumentId)
-      return InstrumentAmount(storageValue: target, instrument: inst)
+    // Savings goal is always expressed in the earmark's own instrument. The
+    // `savingsTargetInstrumentId` column is preserved for backwards
+    // compatibility with older records but any drift is resolved here — the
+    // quantity is kept, the label is the earmark's instrument.
+    let savingsGoal: InstrumentAmount? = savingsTarget.map { target in
+      InstrumentAmount(storageValue: target, instrument: instrument)
     }
     return Earmark(
       id: id,

--- a/Backends/CloudKit/Repositories/CloudKitAnalysisRepository.swift
+++ b/Backends/CloudKit/Repositories/CloudKitAnalysisRepository.swift
@@ -356,7 +356,8 @@ final class CloudKitAnalysisRepository: AnalysisRepository, @unchecked Sendable 
   func fetchCategoryBalances(
     dateRange: ClosedRange<Date>,
     transactionType: TransactionType,
-    filters: TransactionFilter?
+    filters: TransactionFilter?,
+    targetInstrument: Instrument
   ) async throws -> [UUID: InstrumentAmount] {
     // 1. Fetch all transactions
     let allTransactions = try await fetchTransactions()
@@ -387,8 +388,8 @@ final class CloudKitAnalysisRepository: AnalysisRepository, @unchecked Sendable 
         }
 
         let amount = try await Self.convertedAmount(
-          leg, to: instrument, on: tx.date, conversionService: conversionService)
-        balances[categoryId, default: .zero(instrument: instrument)] += amount
+          leg, to: targetInstrument, on: tx.date, conversionService: conversionService)
+        balances[categoryId, default: .zero(instrument: targetInstrument)] += amount
       }
     }
 

--- a/Backends/CloudKit/Repositories/CloudKitEarmarkRepository.swift
+++ b/Backends/CloudKit/Repositories/CloudKitEarmarkRepository.swift
@@ -96,12 +96,20 @@ final class CloudKitEarmarkRepository: EarmarkRepository, @unchecked Sendable {
       os_signpost(
         .end, log: Signposts.repository, name: "EarmarkRepo.fetchBudget", signpostID: signpostID)
     }
-    let descriptor = FetchDescriptor<EarmarkBudgetItemRecord>(
+    let budgetDescriptor = FetchDescriptor<EarmarkBudgetItemRecord>(
       predicate: #Predicate { $0.earmarkId == earmarkId }
     )
+    let earmarkDescriptor = FetchDescriptor<EarmarkRecord>(
+      predicate: #Predicate { $0.id == earmarkId }
+    )
+    let defaultInstrument = self.instrument
     return try await MainActor.run {
-      let records = try context.fetch(descriptor)
-      return records.map { $0.toDomain() }
+      let earmarkInstrument =
+        try context.fetch(earmarkDescriptor).first
+        .flatMap { $0.instrumentId.map { Instrument.fiat(code: $0) } }
+        ?? defaultInstrument
+      let records = try context.fetch(budgetDescriptor)
+      return records.map { $0.toDomain(earmarkInstrument: earmarkInstrument) }
     }
   }
 
@@ -116,10 +124,23 @@ final class CloudKitEarmarkRepository: EarmarkRepository, @unchecked Sendable {
     let earmarkDescriptor = FetchDescriptor<EarmarkRecord>(
       predicate: #Predicate { $0.id == earmarkId }
     )
+    let defaultInstrument = self.instrument
 
     try await MainActor.run {
-      guard try context.fetch(earmarkDescriptor).first != nil else {
+      guard let earmarkRecord = try context.fetch(earmarkDescriptor).first else {
         throw BackendError.serverError(404)
+      }
+      // Budget items must match the earmark's instrument. Zero-amount writes
+      // (used to remove an entry) are always accepted — the value has no
+      // instrument meaning. See `guides/INSTRUMENT_CONVERSION_GUIDE.md` Rule 1/2.
+      let earmarkInstrument =
+        earmarkRecord.instrumentId
+        .map { Instrument.fiat(code: $0) } ?? defaultInstrument
+      if !amount.isZero, amount.instrument != earmarkInstrument {
+        throw BackendError.unsupportedInstrument(
+          "Budget amount uses \(amount.instrument.id); earmark uses \(earmarkInstrument.id). "
+            + "Budget items must share the earmark's instrument."
+        )
       }
 
       let budgetDescriptor = FetchDescriptor<EarmarkBudgetItemRecord>(

--- a/Backends/Remote/Repositories/RemoteAnalysisRepository.swift
+++ b/Backends/Remote/Repositories/RemoteAnalysisRepository.swift
@@ -71,8 +71,13 @@ final class RemoteAnalysisRepository: AnalysisRepository, Sendable {
   func fetchCategoryBalances(
     dateRange: ClosedRange<Date>,
     transactionType: TransactionType,
-    filters: TransactionFilter?
+    filters: TransactionFilter?,
+    targetInstrument: Instrument
   ) async throws -> [UUID: InstrumentAmount] {
+    // Remote is single-instrument; callers must request the profile instrument.
+    // See `guides/INSTRUMENT_CONVERSION_GUIDE.md` Rule 11a.
+    try requireMatchesProfileInstrument(
+      targetInstrument, profile: instrument, entity: "Category balances target instrument")
     var queryItems: [URLQueryItem] = [
       URLQueryItem(name: "from", value: BackendDateFormatter.string(from: dateRange.lowerBound)),
       URLQueryItem(name: "to", value: BackendDateFormatter.string(from: dateRange.upperBound)),

--- a/Domain/Models/BudgetLineItem.swift
+++ b/Domain/Models/BudgetLineItem.swift
@@ -9,25 +9,33 @@ struct BudgetLineItem: Identifiable, Sendable {
   var remaining: InstrumentAmount { budgeted + actual }
 
   /// Merges budget items with category expense balances into a sorted list of line items.
+  ///
+  /// All amounts must be expressed in `earmarkInstrument`. `buildLineItems` enforces
+  /// this by coercing budget items and category balances onto the earmark's instrument,
+  /// which is the required common denominator for sums across the list (see
+  /// `guides/INSTRUMENT_CONVERSION_GUIDE.md` Rule 1/2).
   static func buildLineItems(
     budgetItems: [EarmarkBudgetItem],
     categoryBalances: [UUID: InstrumentAmount],
-    categories: Categories
+    categories: Categories,
+    earmarkInstrument: Instrument
   ) -> [BudgetLineItem] {
     var seen = Set<UUID>()
     var result: [BudgetLineItem] = []
+    let zero = InstrumentAmount.zero(instrument: earmarkInstrument)
 
     // Add all budgeted categories
     for item in budgetItems {
       seen.insert(item.categoryId)
       let name = categories.by(id: item.categoryId)?.name ?? "Unknown"
-      let actual = categoryBalances[item.categoryId] ?? .zero(instrument: item.amount.instrument)
+      let budgeted = item.inInstrument(earmarkInstrument).amount
+      let actual = categoryBalances[item.categoryId] ?? zero
       result.append(
         BudgetLineItem(
           id: item.categoryId,
           categoryName: name,
           actual: actual,
-          budgeted: item.amount
+          budgeted: budgeted
         ))
     }
 
@@ -39,7 +47,7 @@ struct BudgetLineItem: Identifiable, Sendable {
           id: categoryId,
           categoryName: name,
           actual: actual,
-          budgeted: .zero(instrument: actual.instrument)
+          budgeted: zero
         ))
     }
 
@@ -48,14 +56,19 @@ struct BudgetLineItem: Identifiable, Sendable {
 
   /// Calculates the unallocated portion of a savings goal.
   /// Returns nil if there is no savings goal.
+  ///
+  /// `Earmark.init` guarantees `savingsGoal.instrument == earmark.instrument`, and every
+  /// `EarmarkBudgetItem` is stored in the earmark's instrument. Those invariants keep the
+  /// reduction below instrument-safe (see `guides/INSTRUMENT_CONVERSION_GUIDE.md` Rule 1/2).
   static func unallocatedAmount(
     budgetItems: [EarmarkBudgetItem],
     savingsGoal: InstrumentAmount?
   ) -> InstrumentAmount? {
     guard let goal = savingsGoal, goal.isPositive else { return nil }
-    let totalBudget = budgetItems.reduce(InstrumentAmount.zero(instrument: goal.instrument)) {
-      $0 + $1.amount
-    }
+    let totalBudget =
+      budgetItems
+      .map { $0.inInstrument(goal.instrument).amount }
+      .reduce(InstrumentAmount.zero(instrument: goal.instrument)) { $0 + $1 }
     return goal - totalBudget
   }
 }

--- a/Domain/Models/Earmark.swift
+++ b/Domain/Models/Earmark.swift
@@ -12,6 +12,23 @@ struct EarmarkBudgetItem: Codable, Sendable, Identifiable, Hashable {
   }
 }
 
+extension EarmarkBudgetItem {
+  /// Coerces the budget item's amount to the earmark's instrument. Budget items
+  /// must always share the earmark's instrument (see `guides/INSTRUMENT_CONVERSION_GUIDE.md`
+  /// Rule 1/2: arithmetic across instruments traps). Use this when constructing a
+  /// budget item from storage whose instrument label may have drifted from the
+  /// owning earmark's instrument — the quantity is preserved, the instrument is
+  /// relabelled so sums against the earmark's other budgeted amounts are safe.
+  func inInstrument(_ instrument: Instrument) -> EarmarkBudgetItem {
+    guard amount.instrument != instrument else { return self }
+    return EarmarkBudgetItem(
+      id: id,
+      categoryId: categoryId,
+      amount: InstrumentAmount(quantity: amount.quantity, instrument: instrument)
+    )
+  }
+}
+
 struct Earmark: Codable, Sendable, Identifiable, Hashable, Comparable {
   let id: UUID
   var name: String
@@ -46,7 +63,14 @@ struct Earmark: Codable, Sendable, Identifiable, Hashable, Comparable {
     self.spentPositions = spentPositions
     self.isHidden = isHidden
     self.position = position
-    self.savingsGoal = savingsGoal
+    // Savings goal must share the earmark's instrument. See
+    // `guides/INSTRUMENT_CONVERSION_GUIDE.md` Rule 1 — progress / remaining
+    // math would otherwise trap or silently compare raw quantities.
+    self.savingsGoal = savingsGoal.map { goal in
+      goal.instrument == instrument
+        ? goal
+        : InstrumentAmount(quantity: goal.quantity, instrument: instrument)
+    }
     self.savingsStartDate = savingsStartDate
     self.savingsEndDate = savingsEndDate
   }
@@ -66,14 +90,22 @@ struct Earmark: Codable, Sendable, Identifiable, Hashable, Comparable {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     id = try container.decode(UUID.self, forKey: .id)
     name = try container.decode(String.self, forKey: .name)
-    instrument =
+    let decodedInstrument =
       try container.decodeIfPresent(Instrument.self, forKey: .instrument) ?? .AUD
+    instrument = decodedInstrument
     positions = []
     savedPositions = []
     spentPositions = []
     isHidden = try container.decode(Bool.self, forKey: .isHidden)
     position = try container.decode(Int.self, forKey: .position)
+    // Coerce any decoded savings goal to the earmark's instrument; the two
+    // must always match (see `guides/INSTRUMENT_CONVERSION_GUIDE.md` Rule 1).
     savingsGoal = try container.decodeIfPresent(InstrumentAmount.self, forKey: .savingsGoal)
+      .map { goal in
+        goal.instrument == decodedInstrument
+          ? goal
+          : InstrumentAmount(quantity: goal.quantity, instrument: decodedInstrument)
+      }
     savingsStartDate = try container.decodeIfPresent(Date.self, forKey: .savingsStartDate)
     savingsEndDate = try container.decodeIfPresent(Date.self, forKey: .savingsEndDate)
   }

--- a/Domain/Repositories/AnalysisRepository.swift
+++ b/Domain/Repositories/AnalysisRepository.swift
@@ -47,12 +47,19 @@ protocol AnalysisRepository: Sendable {
   ///   - dateRange: Date range to analyze (inclusive on both ends).
   ///   - transactionType: Filter to 'income' or 'expense' transactions.
   ///   - filters: Optional additional filters (account, earmark, payee, etc.).
-  /// - Returns: Dictionary where keys are category UUIDs and values are total InstrumentAmounts.
+  ///   - targetInstrument: Instrument to convert the aggregated amounts into. Callers that
+  ///     filter by earmark should pass the earmark's instrument so the totals are directly
+  ///     comparable to the earmark's budget items (see
+  ///     `guides/INSTRUMENT_CONVERSION_GUIDE.md` Rule 1/2). Single-instrument backends
+  ///     require this to match the profile instrument.
+  /// - Returns: Dictionary where keys are category UUIDs and values are total
+  ///   `InstrumentAmount`s in `targetInstrument`.
   /// - Throws: BackendError on network/auth failure.
   func fetchCategoryBalances(
     dateRange: ClosedRange<Date>,
     transactionType: TransactionType,
-    filters: TransactionFilter?
+    filters: TransactionFilter?,
+    targetInstrument: Instrument
   ) async throws -> [UUID: InstrumentAmount]
 
   /// Fetch category balances for both income and expense in a single pass.
@@ -63,11 +70,13 @@ protocol AnalysisRepository: Sendable {
   /// - Parameters:
   ///   - dateRange: Date range to analyze (inclusive on both ends).
   ///   - filters: Optional additional filters (account, earmark, payee, etc.).
+  ///   - targetInstrument: Instrument the aggregated amounts are expressed in.
   /// - Returns: Tuple of income and expense dictionaries mapping category UUIDs to totals.
   /// - Throws: BackendError on network/auth failure.
   func fetchCategoryBalancesByType(
     dateRange: ClosedRange<Date>,
-    filters: TransactionFilter?
+    filters: TransactionFilter?,
+    targetInstrument: Instrument
   ) async throws -> (income: [UUID: InstrumentAmount], expense: [UUID: InstrumentAmount])
 
   /// Load all analysis data in a single batch, avoiding redundant fetches.
@@ -92,12 +101,15 @@ struct AnalysisData: Sendable {
 extension AnalysisRepository {
   func fetchCategoryBalancesByType(
     dateRange: ClosedRange<Date>,
-    filters: TransactionFilter?
+    filters: TransactionFilter?,
+    targetInstrument: Instrument
   ) async throws -> (income: [UUID: InstrumentAmount], expense: [UUID: InstrumentAmount]) {
     async let incomeResult = fetchCategoryBalances(
-      dateRange: dateRange, transactionType: .income, filters: filters)
+      dateRange: dateRange, transactionType: .income, filters: filters,
+      targetInstrument: targetInstrument)
     async let expenseResult = fetchCategoryBalances(
-      dateRange: dateRange, transactionType: .expense, filters: filters)
+      dateRange: dateRange, transactionType: .expense, filters: filters,
+      targetInstrument: targetInstrument)
     return try await (income: incomeResult, expense: expenseResult)
   }
 

--- a/Features/Earmarks/EarmarkStore.swift
+++ b/Features/Earmarks/EarmarkStore.swift
@@ -312,10 +312,13 @@ final class EarmarkStore {
     let oldItems = budgetItems
     budgetItems.removeAll { $0.categoryId == categoryId }
 
+    // Setting amount to 0 removes the budget entry on the server. Use the
+    // earmark's own instrument so the repository's instrument-parity guard
+    // doesn't reject the zero write on a multi-currency profile.
+    let zeroInstrument = earmarks.by(id: earmarkId)?.instrument ?? targetInstrument
     do {
-      // Setting amount to 0 removes the budget entry on the server
       try await repository.setBudget(
-        earmarkId: earmarkId, categoryId: categoryId, amount: .zero(instrument: targetInstrument))
+        earmarkId: earmarkId, categoryId: categoryId, amount: .zero(instrument: zeroInstrument))
     } catch {
       logger.error("Failed to remove budget item: \(error.localizedDescription)")
       budgetItems = oldItems

--- a/Features/Earmarks/Views/EarmarkBudgetSectionView.swift
+++ b/Features/Earmarks/Views/EarmarkBudgetSectionView.swift
@@ -80,20 +80,21 @@ struct EarmarkBudgetSectionView: View {
     BudgetLineItem.buildLineItems(
       budgetItems: earmarkStore.budgetItems,
       categoryBalances: categoryBalances,
-      categories: categories
+      categories: categories,
+      earmarkInstrument: earmark.instrument
     )
   }
 
   private var totalActual: InstrumentAmount {
-    lineItems.reduce(.zero(instrument: lineItems.first?.actual.instrument ?? .AUD)) {
-      $0 + $1.actual
-    }
+    // All line items share the earmark's instrument (see
+    // `guides/INSTRUMENT_CONVERSION_GUIDE.md` Rule 1/2). Budget items are
+    // stored in the earmark's instrument; category balances are fetched
+    // with `targetInstrument: earmark.instrument` below.
+    lineItems.reduce(.zero(instrument: earmark.instrument)) { $0 + $1.actual }
   }
 
   private var totalBudgeted: InstrumentAmount {
-    lineItems.reduce(.zero(instrument: lineItems.first?.budgeted.instrument ?? .AUD)) {
-      $0 + $1.budgeted
-    }
+    lineItems.reduce(.zero(instrument: earmark.instrument)) { $0 + $1.budgeted }
   }
 
   private var totalRemaining: InstrumentAmount {
@@ -243,7 +244,8 @@ struct EarmarkBudgetSectionView: View {
       categoryBalances = try await analysisRepository.fetchCategoryBalances(
         dateRange: distantPast...now,
         transactionType: .expense,
-        filters: TransactionFilter(earmarkId: earmark.id)
+        filters: TransactionFilter(earmarkId: earmark.id),
+        targetInstrument: earmark.instrument
       )
     } catch {
       categoryBalances = [:]

--- a/Features/Reports/ReportingStore.swift
+++ b/Features/Reports/ReportingStore.swift
@@ -95,7 +95,8 @@ final class ReportingStore {
     do {
       let result = try await analysisRepository.fetchCategoryBalancesByType(
         dateRange: dateRange,
-        filters: TransactionFilter()
+        filters: TransactionFilter(),
+        targetInstrument: profileCurrency
       )
       incomeBalances = result.income
       expenseBalances = result.expense

--- a/MoolahBenchmarks/AnalysisBenchmarks.swift
+++ b/MoolahBenchmarks/AnalysisBenchmarks.swift
@@ -74,7 +74,8 @@ final class AnalysisBenchmarks: XCTestCase {
     measure(metrics: metrics, options: options) {
       _ = try! awaitSync {
         try await repo.fetchCategoryBalances(
-          dateRange: dateRange, transactionType: .expense, filters: nil)
+          dateRange: dateRange, transactionType: .expense, filters: nil,
+          targetInstrument: .defaultTestInstrument)
       }
     }
   }
@@ -88,7 +89,9 @@ final class AnalysisBenchmarks: XCTestCase {
     let dateRange = start...end
     measure(metrics: metrics, options: options) {
       _ = try! awaitSync {
-        try await repo.fetchCategoryBalancesByType(dateRange: dateRange, filters: nil)
+        try await repo.fetchCategoryBalancesByType(
+          dateRange: dateRange, filters: nil,
+          targetInstrument: .defaultTestInstrument)
       }
     }
   }

--- a/MoolahTests/Domain/AnalysisRepositoryContractTests.swift
+++ b/MoolahTests/Domain/AnalysisRepositoryContractTests.swift
@@ -1080,7 +1080,8 @@ struct AnalysisRepositoryContractTests {
     let balances = try await backend.analysis.fetchCategoryBalances(
       dateRange: dateRange,
       transactionType: .expense,
-      filters: nil
+      filters: nil,
+      targetInstrument: .defaultTestInstrument
     )
 
     // Verify totals are correct
@@ -1137,7 +1138,8 @@ struct AnalysisRepositoryContractTests {
     let balances = try await backend.analysis.fetchCategoryBalances(
       dateRange: dateRange,
       transactionType: .expense,
-      filters: nil
+      filters: nil,
+      targetInstrument: .defaultTestInstrument
     )
 
     // Only completed transaction counted
@@ -1189,7 +1191,8 @@ struct AnalysisRepositoryContractTests {
     let incomeBalances = try await backend.analysis.fetchCategoryBalances(
       dateRange: dateRange,
       transactionType: .income,
-      filters: nil
+      filters: nil,
+      targetInstrument: .defaultTestInstrument
     )
 
     // Only income counted
@@ -1200,7 +1203,8 @@ struct AnalysisRepositoryContractTests {
     let expenseBalances = try await backend.analysis.fetchCategoryBalances(
       dateRange: dateRange,
       transactionType: .expense,
-      filters: nil
+      filters: nil,
+      targetInstrument: .defaultTestInstrument
     )
 
     // Only expense counted
@@ -1253,7 +1257,8 @@ struct AnalysisRepositoryContractTests {
     let balances = try await backend.analysis.fetchCategoryBalances(
       dateRange: yesterday...today,
       transactionType: .expense,
-      filters: nil
+      filters: nil,
+      targetInstrument: .defaultTestInstrument
     )
 
     // Only yesterday's transaction counted
@@ -1313,7 +1318,8 @@ struct AnalysisRepositoryContractTests {
     let balances = try await backend.analysis.fetchCategoryBalances(
       dateRange: dateRange,
       transactionType: .expense,
-      filters: TransactionFilter(accountId: account1.id)
+      filters: TransactionFilter(accountId: account1.id),
+      targetInstrument: .defaultTestInstrument
     )
 
     // Only account1 transaction counted
@@ -1364,7 +1370,8 @@ struct AnalysisRepositoryContractTests {
     let balances = try await backend.analysis.fetchCategoryBalances(
       dateRange: dateRange,
       transactionType: .expense,
-      filters: nil
+      filters: nil,
+      targetInstrument: .defaultTestInstrument
     )
 
     #expect(balances.count == 1)
@@ -1383,7 +1390,8 @@ struct AnalysisRepositoryContractTests {
     let balances = try await backend.analysis.fetchCategoryBalances(
       dateRange: dateRange,
       transactionType: .expense,
-      filters: nil
+      filters: nil,
+      targetInstrument: .defaultTestInstrument
     )
 
     #expect(balances.isEmpty)
@@ -2005,7 +2013,8 @@ struct AnalysisRepositoryContractTests {
     let balances = try await backend.analysis.fetchCategoryBalances(
       dateRange: today...today,
       transactionType: .expense,
-      filters: nil
+      filters: nil,
+      targetInstrument: .defaultTestInstrument
     )
 
     // -40 USD * 1.5 = -60 AUD
@@ -2650,12 +2659,62 @@ struct AnalysisRepositoryContractTests {
     let balances = try await backend.analysis.fetchCategoryBalances(
       dateRange: day1...day10,
       transactionType: .expense,
-      filters: nil
+      filters: nil,
+      targetInstrument: .defaultTestInstrument
     )
 
     #expect(balances[food.id]?.quantity == -190)
     #expect(balances[travel.id]?.quantity == -52)
     #expect(balances[food.id]?.instrument == .defaultTestInstrument)
+  }
+
+  @Test("category balances convert to the requested target instrument")
+  func categoryBalancesHonourTargetInstrument() async throws {
+    // Profile is AUD but the caller (an earmark detail view) requests
+    // totals in USD so they can be summed against USD-denominated budget
+    // items. The repository must convert to USD rather than the profile
+    // instrument. USD -> USD leg passes through; AUD -> USD is converted.
+    let usd = Instrument.fiat(code: "USD")
+    // `FixedConversionService` keys by the `from` instrument only. Using AUD
+    // → 0.5 means `-40 AUD -> -40 * 0.5 = -20 USD` below.
+    let conversion = FixedConversionService(rates: [
+      "AUD": Decimal(string: "0.5")!
+    ])
+    let backend = CloudKitAnalysisTestBackend(conversionService: conversion)
+    let account = Account(
+      id: UUID(), name: "Bank", type: .bank, instrument: .defaultTestInstrument)
+    _ = try await backend.accounts.create(account)
+
+    let category = Category(id: UUID(), name: "Food")
+    _ = try await backend.categories.create(category)
+
+    let today = Calendar.current.startOfDay(for: Date())
+    _ = try await backend.transactions.create(
+      Transaction(
+        date: today, payee: "AUD Store",
+        legs: [
+          TransactionLeg(
+            accountId: account.id, instrument: .defaultTestInstrument,
+            quantity: -40, type: .expense, categoryId: category.id)
+        ]))
+    _ = try await backend.transactions.create(
+      Transaction(
+        date: today, payee: "US Store",
+        legs: [
+          TransactionLeg(
+            accountId: account.id, instrument: usd,
+            quantity: -30, type: .expense, categoryId: category.id)
+        ]))
+
+    let balances = try await backend.analysis.fetchCategoryBalances(
+      dateRange: today...today,
+      transactionType: .expense,
+      filters: nil,
+      targetInstrument: usd
+    )
+
+    // -40 AUD * 0.5 = -20 USD; -30 USD passes through. Sum = -50 USD.
+    #expect(balances[category.id] == InstrumentAmount(quantity: -50, instrument: usd))
   }
 
   @Test("mixed bank + investment + earmark + multi-currency + rate-varying")

--- a/MoolahTests/Domain/EarmarkRepositoryContractTests.swift
+++ b/MoolahTests/Domain/EarmarkRepositoryContractTests.swift
@@ -118,38 +118,53 @@ struct EarmarkRepositoryContractTests {
     #expect(fetched.savingsGoal?.quantity == Decimal(string: "5000.00")!)
   }
 
-  @Test("budget items preserve their own instrument distinct from earmark instrument")
-  func testBudgetItemsPreserveInstrumentDistinctFromEarmark() async throws {
+  @Test("budget items adopt the earmark's instrument")
+  func testBudgetItemsUseEarmarkInstrument() async throws {
     let repository = makeCloudKitEarmarkRepository(initialEarmarks: [
-      Earmark(name: "Mixed Fund", instrument: .AUD)
+      Earmark(name: "AUD Fund", instrument: .AUD)
     ])
     let earmarks = try await repository.fetchAll()
     let earmarkId = earmarks[0].id
-    let audCategory = UUID()
-    let usdCategory = UUID()
+    let categoryA = UUID()
+    let categoryB = UUID()
 
-    let audAmount = InstrumentAmount(
+    let amountA = InstrumentAmount(
       quantity: Decimal(string: "100.00")!, instrument: .AUD)
-    let usdAmount = InstrumentAmount(
-      quantity: Decimal(string: "80.00")!, instrument: .USD)
+    let amountB = InstrumentAmount(
+      quantity: Decimal(string: "80.00")!, instrument: .AUD)
 
     try await repository.setBudget(
-      earmarkId: earmarkId, categoryId: audCategory, amount: audAmount)
+      earmarkId: earmarkId, categoryId: categoryA, amount: amountA)
     try await repository.setBudget(
-      earmarkId: earmarkId, categoryId: usdCategory, amount: usdAmount)
+      earmarkId: earmarkId, categoryId: categoryB, amount: amountB)
 
     let fetched = try await repository.fetchBudget(earmarkId: earmarkId)
     #expect(fetched.count == 2)
-    let audItem = try #require(fetched.first { $0.categoryId == audCategory })
-    let usdItem = try #require(fetched.first { $0.categoryId == usdCategory })
-    #expect(audItem.amount.instrument == .AUD)
-    #expect(audItem.amount.quantity == Decimal(string: "100.00")!)
-    #expect(usdItem.amount.instrument == .USD)
-    #expect(usdItem.amount.quantity == Decimal(string: "80.00")!)
+    for item in fetched {
+      #expect(item.amount.instrument == .AUD)
+    }
   }
 
-  @Test("updating budget item changes amount without changing instrument")
-  func testUpdatingBudgetItemPreservesInstrument() async throws {
+  @Test("setBudget rejects amounts in a different instrument from the earmark")
+  func testSetBudgetRejectsForeignInstrument() async throws {
+    let repository = makeCloudKitEarmarkRepository(initialEarmarks: [
+      Earmark(name: "AUD Fund", instrument: .AUD)
+    ])
+    let earmarks = try await repository.fetchAll()
+    let earmarkId = earmarks[0].id
+    let categoryId = UUID()
+
+    let foreign = InstrumentAmount(
+      quantity: Decimal(string: "80.00")!, instrument: .USD)
+
+    await #expect(throws: BackendError.self) {
+      try await repository.setBudget(
+        earmarkId: earmarkId, categoryId: categoryId, amount: foreign)
+    }
+  }
+
+  @Test("updating budget item changes amount and keeps the earmark's instrument")
+  func testUpdatingBudgetItemKeepsEarmarkInstrument() async throws {
     let repository = makeCloudKitEarmarkRepository(initialEarmarks: [
       Earmark(name: "Travel", instrument: .AUD)
     ])
@@ -157,18 +172,18 @@ struct EarmarkRepositoryContractTests {
     let earmarkId = earmarks[0].id
     let categoryId = UUID()
 
-    let usdFirst = InstrumentAmount(
-      quantity: Decimal(string: "100.00")!, instrument: .USD)
-    let usdSecond = InstrumentAmount(
-      quantity: Decimal(string: "250.00")!, instrument: .USD)
+    let first = InstrumentAmount(
+      quantity: Decimal(string: "100.00")!, instrument: .AUD)
+    let second = InstrumentAmount(
+      quantity: Decimal(string: "250.00")!, instrument: .AUD)
 
-    try await repository.setBudget(earmarkId: earmarkId, categoryId: categoryId, amount: usdFirst)
-    try await repository.setBudget(earmarkId: earmarkId, categoryId: categoryId, amount: usdSecond)
+    try await repository.setBudget(earmarkId: earmarkId, categoryId: categoryId, amount: first)
+    try await repository.setBudget(earmarkId: earmarkId, categoryId: categoryId, amount: second)
 
     let fetched = try await repository.fetchBudget(earmarkId: earmarkId)
     let entries = fetched.filter { $0.categoryId == categoryId }
     #expect(entries.count == 1)
-    #expect(entries[0].amount.instrument == .USD)
+    #expect(entries[0].amount.instrument == .AUD)
     #expect(entries[0].amount.quantity == Decimal(string: "250.00")!)
   }
 

--- a/MoolahTests/Features/EarmarkBudgetTests.swift
+++ b/MoolahTests/Features/EarmarkBudgetTests.swift
@@ -219,7 +219,8 @@ struct BudgetLineItemMergeTests {
     let result = BudgetLineItem.buildLineItems(
       budgetItems: budgetItems,
       categoryBalances: categoryBalances,
-      categories: categories
+      categories: categories,
+      earmarkInstrument: .defaultTestInstrument
     )
 
     #expect(result.count == 1)
@@ -243,7 +244,8 @@ struct BudgetLineItemMergeTests {
     let result = BudgetLineItem.buildLineItems(
       budgetItems: budgetItems,
       categoryBalances: categoryBalances,
-      categories: categories
+      categories: categories,
+      earmarkInstrument: .defaultTestInstrument
     )
 
     #expect(result.count == 1)
@@ -263,7 +265,8 @@ struct BudgetLineItemMergeTests {
     let result = BudgetLineItem.buildLineItems(
       budgetItems: budgetItems,
       categoryBalances: categoryBalances,
-      categories: categories
+      categories: categories,
+      earmarkInstrument: .defaultTestInstrument
     )
 
     #expect(result.count == 1)
@@ -289,7 +292,8 @@ struct BudgetLineItemMergeTests {
     let result = BudgetLineItem.buildLineItems(
       budgetItems: budgetItems,
       categoryBalances: categoryBalances,
-      categories: categories
+      categories: categories,
+      earmarkInstrument: .defaultTestInstrument
     )
 
     // remaining = budget + actual = 60000 + (-70000) = -10000 (over budget)
@@ -319,7 +323,8 @@ struct BudgetLineItemMergeTests {
     let result = BudgetLineItem.buildLineItems(
       budgetItems: budgetItems,
       categoryBalances: [:],
-      categories: categories
+      categories: categories,
+      earmarkInstrument: .defaultTestInstrument
     )
 
     #expect(result.map(\.categoryName) == ["Alpha", "Middle", "Zebra"])
@@ -386,15 +391,19 @@ struct BudgetLineItemMergeTests {
     let result = BudgetLineItem.buildLineItems(
       budgetItems: budgetItems,
       categoryBalances: [:],
-      categories: categories
+      categories: categories,
+      earmarkInstrument: .defaultTestInstrument
     )
 
     #expect(result.first?.categoryName == "Unknown")
   }
 
-  // MARK: - Multi-instrument budget items
+  // MARK: - Budget item instrument parity
 
-  @Test func budgetItemInForeignInstrumentPreservesInstrumentInLineItem() {
+  @Test func budgetItemIsCoercedToEarmarkInstrumentInLineItem() {
+    // Budget items stored with a mismatched instrument label (e.g. from stale
+    // CloudKit data) are re-expressed in the earmark's instrument so sums
+    // across the list are instrument-safe.
     let catId = UUID()
     let categories = Categories(from: [Category(id: catId, name: "Travel")])
     let budgetItems = [
@@ -406,21 +415,24 @@ struct BudgetLineItemMergeTests {
     let result = BudgetLineItem.buildLineItems(
       budgetItems: budgetItems,
       categoryBalances: [:],
-      categories: categories
+      categories: categories,
+      earmarkInstrument: .AUD
     )
 
     #expect(result.count == 1)
-    #expect(result[0].budgeted.instrument == .USD)
+    #expect(result[0].budgeted.instrument == .AUD)
     #expect(result[0].budgeted.quantity == Decimal(500))
   }
 
-  @Test func multipleBudgetItemsAcrossInstrumentsEachRetainTheirOwnInstrument() {
+  @Test func allLineItemsShareEarmarkInstrument() {
     let audCat = UUID()
     let usdCat = UUID()
     let categories = Categories(from: [
       Category(id: audCat, name: "Groceries"),
       Category(id: usdCat, name: "Subscriptions"),
     ])
+    // Both budget items should land in the earmark's instrument even if the
+    // records drifted in storage.
     let budgetItems = [
       EarmarkBudgetItem(
         categoryId: audCat,
@@ -433,13 +445,14 @@ struct BudgetLineItemMergeTests {
     let result = BudgetLineItem.buildLineItems(
       budgetItems: budgetItems,
       categoryBalances: [:],
-      categories: categories
+      categories: categories,
+      earmarkInstrument: .AUD
     )
 
     #expect(result.count == 2)
     let audLine = result.first { $0.id == audCat }
     let usdLine = result.first { $0.id == usdCat }
     #expect(audLine?.budgeted.instrument == .AUD)
-    #expect(usdLine?.budgeted.instrument == .USD)
+    #expect(usdLine?.budgeted.instrument == .AUD)
   }
 }


### PR DESCRIPTION
## Summary
- `Earmark.savingsGoal` is now always expressed in the earmark's own instrument — coerced at `init`, decoder, and `EarmarkRecord.toDomain` boundaries. Fixes the nonsense `balance / goal` ratio in `EarmarkDetailView`.
- `EarmarkBudgetItem.amount` must match the earmark's instrument. CloudKit `setBudget` rejects foreign-instrument writes; `fetchBudget` re-labels stored records to the earmark's instrument. Fixes the trap risk in `BudgetLineItem.unallocatedAmount` / reductions.
- `AnalysisRepository.fetchCategoryBalances` gains an explicit `targetInstrument` parameter. `EarmarkBudgetSectionView` now requests the earmark's instrument, so actual and budgeted totals share an instrument before summing. `ReportsView` passes the profile instrument. Remote backend guards that the target matches profile (single-instrument rule).

Closes #80, #81, #82.

## Test plan
- [x] `just test-mac` — 1172 passing, 0 failing
- [x] `just test-ios` — 1156 passing, 0 failing
- [x] New test: `categoryBalancesHonourTargetInstrument` (Analysis contract) verifies a non-profile target instrument converts correctly.
- [x] Updated test: `setBudget rejects amounts in a different instrument from the earmark` (Earmark contract).
- [x] Updated `BudgetLineItem.buildLineItems` tests to pass `earmarkInstrument:` and verify items are coerced to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)