### PR TITLE
fix: address instrument-conversion minor issues

### DIFF
--- a/Features/Reports/ReportingStore.swift
+++ b/Features/Reports/ReportingStore.swift
@@ -67,7 +67,7 @@ final class ReportingStore {
   private let transactionRepository: TransactionRepository
   private let analysisRepository: AnalysisRepository?
   private let conversionService: InstrumentConversionService
-  private let profileCurrency: Instrument
+  private(set) var profileCurrency: Instrument
   private let logger = Logger(subsystem: "com.moolah.app", category: "ReportingStore")
 
   init(

--- a/Features/Reports/Views/CategoryBalanceTable.swift
+++ b/Features/Reports/Views/CategoryBalanceTable.swift
@@ -7,6 +7,7 @@ struct CategoryBalanceTable: View {
   let balances: [UUID: InstrumentAmount]
   let categories: Categories
   let dateRange: ClosedRange<Date>
+  let profileInstrument: Instrument
 
   private var reportData: [CategoryGroup] {
     // Group subcategories under roots
@@ -55,8 +56,12 @@ struct CategoryBalanceTable: View {
       .sorted { $0.totalAmount.quantity.magnitude > $1.totalAmount.quantity.magnitude }
   }
 
+  /// Seed the reduce with a zero in the profile instrument so empty balances
+  /// render as the right currency. All `balances` entries come from the
+  /// repository's `fetchCategoryBalancesByType` which returns values in the
+  /// profile instrument, so instrument parity with the seed holds.
   private var grandTotal: InstrumentAmount {
-    balances.values.reduce(.zero(instrument: balances.values.first?.instrument ?? .AUD), +)
+    balances.values.reduce(.zero(instrument: profileInstrument), +)
   }
 
   var body: some View {
@@ -186,7 +191,8 @@ struct CategoryDrillDown: Hashable {
     title: "Income",
     balances: balances,
     categories: categories,
-    dateRange: start...Date()
+    dateRange: start...Date(),
+    profileInstrument: .AUD
   )
   .frame(width: 500, height: 400)
 }

--- a/Features/Reports/Views/ReportsView.swift
+++ b/Features/Reports/Views/ReportsView.swift
@@ -49,7 +49,8 @@ struct ReportsView: View {
                 title: "Income",
                 balances: reportingStore.incomeBalances,
                 categories: categories,
-                dateRange: resolvedFrom...resolvedTo
+                dateRange: resolvedFrom...resolvedTo,
+                profileInstrument: reportingStore.profileCurrency
               )
 
               Divider()
@@ -58,7 +59,8 @@ struct ReportsView: View {
                 title: "Expenses",
                 balances: reportingStore.expenseBalances,
                 categories: categories,
-                dateRange: resolvedFrom...resolvedTo
+                dateRange: resolvedFrom...resolvedTo,
+                profileInstrument: reportingStore.profileCurrency
               )
             }
           #else
@@ -67,7 +69,8 @@ struct ReportsView: View {
                 title: "Income",
                 balances: reportingStore.incomeBalances,
                 categories: categories,
-                dateRange: resolvedFrom...resolvedTo
+                dateRange: resolvedFrom...resolvedTo,
+                profileInstrument: reportingStore.profileCurrency
               )
 
               Divider()
@@ -76,7 +79,8 @@ struct ReportsView: View {
                 title: "Expenses",
                 balances: reportingStore.expenseBalances,
                 categories: categories,
-                dateRange: resolvedFrom...resolvedTo
+                dateRange: resolvedFrom...resolvedTo,
+                profileInstrument: reportingStore.profileCurrency
               )
             }
           #endif

--- a/Shared/PositionBook.swift
+++ b/Shared/PositionBook.swift
@@ -1,4 +1,7 @@
 import Foundation
+import OSLog
+
+private let logger = Logger(subsystem: "com.moolah.app", category: "PositionBook")
 
 /// Per-entity, per-instrument position state. The single place where position
 /// math for transactions and legs lives.
@@ -242,6 +245,11 @@ struct PositionBook: Equatable, Sendable {
   /// Sum a per-instrument position dict into a single `Decimal` in `target`,
   /// using the conversion service for non-target instruments. Single-instrument
   /// positions skip the conversion call.
+  ///
+  /// Per-failure diagnostics: callers that swallow the thrown error (e.g. the
+  /// analysis pipeline skipping a day's balance) leave no trail of which
+  /// instrument/date failed. Log here so production diagnosis can identify
+  /// the offending conversion before re-throwing.
   private func convert(
     _ positions: [Instrument: Decimal],
     to target: Instrument,
@@ -253,7 +261,19 @@ struct PositionBook: Equatable, Sendable {
       if instrument == target {
         total += quantity
       } else {
-        total += try await service.convert(quantity, from: instrument, to: target, on: date)
+        do {
+          total += try await service.convert(quantity, from: instrument, to: target, on: date)
+        } catch {
+          logger.warning(
+            """
+            PositionBook conversion failed: \
+            \(quantity, privacy: .public) \(instrument.id, privacy: .public) \
+            → \(target.id, privacy: .public) on \(date, privacy: .public): \
+            \(error.localizedDescription, privacy: .public)
+            """
+          )
+          throw error
+        }
       }
     }
     return total


### PR DESCRIPTION
## Summary

Addresses several instrument-conversion minor issues flagged by review.

**Fixed in this PR:**
- **#92** — `CategoryBalanceTable` no longer falls back to `.AUD` when balances are empty. Profile instrument is now threaded through explicitly via `ReportingStore.profileCurrency`.
- **#126** — `PositionBook.convert` now logs the failing instrument/date before rethrowing. Callers that swallow the thrown error (e.g. `CloudKitAnalysisRepository.computeDailyBalances` skipping a day's balance) now leave a trail for production diagnosis.

**Already resolved (will close with pointer):**
- **#98** — `InvestmentStore.valuatePositions` already has a single-instrument fast path (line 198).
- **#109** — `EarmarkStore.removeBudgetItem` already uses the earmark's own instrument (fixed in 17690c9).

**Skipped as too involved for a batch fix (will comment on issues):**
- **#102** — Wiring `FullConversionService` into CloudKit backend requires restructuring `ProfileSession` init so price services are constructed before the backend.
- **#118** — Scoping `dailyBalance` errors per-account requires an API change to `DailyBalance` (optional fields) and downstream callers.
- **#125** — Theoretical fragility; the stated race isn't reproducible — `priorBalance.instrument` and `currentTargetInstrument` are updated in lockstep at every state transition.
- **#127** — Substantial test rewrite across multiple `*CalculatorTests` files. Better as a dedicated effort.

## Test plan

- [x] `just test-mac` — 1189 tests pass
- [x] `just build-mac` — clean build, no warnings