### PR TITLE
test: date-sensitive routing tests for P&L and capital gains (#127)

### DIFF
--- a/MoolahTests/Shared/CapitalGainsCalculatorTests.swift
+++ b/MoolahTests/Shared/CapitalGainsCalculatorTests.swift
@@ -357,6 +357,70 @@ struct CapitalGainsCalculatorTests {
     #expect(result.events[0].gain == 1500)
   }
 
+  // MARK: - Date-sensitive routing
+  //
+  // `computeWithConversion` must convert every fiat or non-fiat-swap leg
+  // on the transaction's date (Rule 5). The rate-ignoring
+  // `FixedConversionService` would not detect a regression that swapped
+  // `tx.date` for `Date()` or another date; this test uses
+  // `DateBasedFixedConversionService` to make that observable.
+
+  /// Crypto-to-crypto swap: both legs are valued via the conversion
+  /// service. The rate schedule below has a different rate effective at
+  /// the swap date than would be returned for "today" (`Date()`), so a
+  /// regression that misrouted the lookup date would yield a different
+  /// gain than the assertion permits.
+  @Test func cryptoSwap_conversionUsesTransactionDate() async throws {
+    let eth = cryptoInstrument("ETH")
+    let uni = cryptoInstrument("UNI")
+    let accountId = UUID()
+
+    let buyTx = LegTransaction(
+      date: date(0),
+      legs: [
+        TransactionLeg(
+          accountId: accountId, instrument: aud, quantity: -3000, type: .transfer,
+          categoryId: nil, earmarkId: nil),
+        TransactionLeg(
+          accountId: accountId, instrument: eth, quantity: 1, type: .transfer,
+          categoryId: nil, earmarkId: nil),
+      ])
+
+    let swapTx = LegTransaction(
+      date: date(200),
+      legs: [
+        TransactionLeg(
+          accountId: accountId, instrument: eth, quantity: -1, type: .transfer,
+          categoryId: nil, earmarkId: nil),
+        TransactionLeg(
+          accountId: accountId, instrument: uni, quantity: 500, type: .transfer,
+          categoryId: nil, earmarkId: nil),
+      ])
+
+    // Rate schedule:
+    //   pre-date(100): no rates (1:1 fallback)
+    //   date(100)..<date(365): ETH=4000 AUD, UNI=8 AUD  ← effective on swap date(200)
+    //   date(365) onward:      ETH=10 AUD,   UNI=0.01 AUD  ← what `Date()` would resolve to
+    //
+    // Correct routing (tx.date=swap date(200)) → ETH proceeds 4000 AUD,
+    // gain = 4000 − 3000 = 1000.
+    // Mistake (`Date()` ≈ today, > date(365)) → proceeds 10 AUD, gain ≈ −2990.
+    // Mistake (`buyTx.date`=date(0)) → 1:1 fallback, proceeds 1 AUD, gain = −2999.
+    let service = DateBasedFixedConversionService(rates: [
+      date(100): [eth.id: 4000, uni.id: 8],
+      date(365): [eth.id: 10, uni.id: Decimal(string: "0.01")!],
+    ])
+    let result = try await CapitalGainsCalculator.computeWithConversion(
+      transactions: [buyTx, swapTx],
+      profileCurrency: aud,
+      conversionService: service
+    )
+
+    #expect(result.events.count == 1)
+    #expect(result.events[0].instrument.id == eth.id)
+    #expect(result.events[0].gain == 1000)
+  }
+
   // MARK: - Helpers
 
   private func stockInstrument(_ name: String) -> Instrument {

--- a/MoolahTests/Shared/ProfitLossCalculatorTests.swift
+++ b/MoolahTests/Shared/ProfitLossCalculatorTests.swift
@@ -283,6 +283,57 @@ struct ProfitLossCalculatorTests {
     #expect(results[0].unrealizedGain == 1900)
   }
 
+  // MARK: - Date-sensitive routing
+  //
+  // These tests use `DateBasedFixedConversionService` to verify that
+  // `compute` routes its two conversion calls to the correct dates:
+  // historic cost basis (`tx.date`, Rule 5) and current valuation
+  // (`asOfDate`, Rule 6). The rate-ignoring `FixedConversionService`
+  // would pass even if production code swapped the dates.
+
+  /// Cost basis must convert each fiat outflow leg on `tx.date` while
+  /// `currentValue` must convert the open position on `asOfDate`. The
+  /// rate schedule below makes both choices observable: swapping the
+  /// dates would yield different totals.
+  @Test func datesRouteCorrectly_costBasisOnTxDate_currentValueOnAsOfDate() async throws {
+    let bhp = stockInstrument("BHP")
+    let usd = Instrument.fiat(code: "USD")
+    let accountId = UUID()
+
+    let buyTx = LegTransaction(
+      date: date(0),
+      legs: [
+        TransactionLeg(
+          accountId: accountId, instrument: usd, quantity: -2000, type: .transfer,
+          categoryId: nil, earmarkId: nil),
+        TransactionLeg(
+          accountId: accountId, instrument: bhp, quantity: 100, type: .transfer,
+          categoryId: nil, earmarkId: nil),
+      ])
+
+    // date(0):   USD→AUD 1.5,  BHP→AUD 30   (cost basis must use these)
+    // date(365): USD→AUD 2.0,  BHP→AUD 50   (current valuation must use these)
+    //
+    // Correct routing: totalInvested = 2000 × 1.5 = 3000; currentValue = 100 × 50 = 5000.
+    // If dates were swapped: totalInvested = 2000 × 2.0 = 4000; currentValue = 100 × 30 = 3000.
+    let service = DateBasedFixedConversionService(rates: [
+      date(0): ["USD": Decimal(string: "1.5")!, "ASX:BHP": 30],
+      date(365): ["USD": Decimal(string: "2.0")!, "ASX:BHP": 50],
+    ])
+    let results = try await ProfitLossCalculator.compute(
+      transactions: [buyTx],
+      profileCurrency: aud,
+      conversionService: service,
+      asOfDate: date(365)
+    )
+
+    #expect(results.count == 1)
+    let pl = results[0]
+    #expect(pl.totalInvested == 3000)
+    #expect(pl.currentValue == 5000)
+    #expect(pl.unrealizedGain == 2000)
+  }
+
   // MARK: - Helpers
 
   private func stockInstrument(_ name: String) -> Instrument {


### PR DESCRIPTION
## Summary

Closes #127. Adds `DateBasedFixedConversionService` coverage to two date-sensitive code paths so a regression that swapped `tx.date` for `asOfDate` (or `Date()`) would now fail a test instead of silently passing.

- `ProfitLossCalculatorTests.datesRouteCorrectly_costBasisOnTxDate_currentValueOnAsOfDate` — exercises both routing decisions in `ProfitLossCalculator.compute`. The rate schedule is intentionally different at `date(0)` and `date(365)`, so swapping them changes `totalInvested` (must use `tx.date`, Rule 5) and `currentValue` (must use `asOfDate`, Rule 6).
- `CapitalGainsCalculatorTests.cryptoSwap_conversionUsesTransactionDate` — exercises the non-fiat-swap path of `computeWithConversion`. The rate schedule has a later entry that `Date()` (today) would resolve to, so a regression using "now" instead of `tx.date` would yield a different gain.

Mutation-verified: temporarily swapping `tx.date` → `asOfDate` in `ProfitLossCalculator` makes the new P&L test fail at the `totalInvested` assertion as expected.

## Test plan

- [x] `just test ProfitLossCalculatorTests CapitalGainsCalculatorTests` passes on iOS Simulator and macOS (17 tests, 0 failures)
- [x] Mutation test: swap `on: tx.date` → `on: asOfDate` in `ProfitLossCalculator`; the new test fails with `pl.totalInvested → 4000) == 3000`

🤖 Generated with [Claude Code](https://claude.com/claude-code)