### PR TITLE
fix: wire FullConversionService into CloudKit profiles (#102)

### DIFF
--- a/App/ProfileSession.swift
+++ b/App/ProfileSession.swift
@@ -22,6 +22,7 @@ final class ProfileSession: Identifiable {
   let exchangeRateService: ExchangeRateService
   let stockPriceService: StockPriceService
   let cryptoPriceService: CryptoPriceService
+  let cryptoTokenStore: CryptoTokenStore
 
   /// Observer token for sync coordinator notifications (nil for remote profiles).
   private var syncObserverToken: SyncCoordinator.ObserverToken?
@@ -42,41 +43,9 @@ final class ProfileSession: Identifiable {
     let exchangeRateService = ExchangeRateService(client: FrankfurterClient())
     self.exchangeRateService = exchangeRateService
 
-    let backend: BackendProvider
-    switch profile.backendType {
-    case .remote, .moolah:
-      // Each profile gets its own cookie storage and URLSession.
-      // Ephemeral config provides an isolated cookie storage that URLSession
-      // actually integrates with for automatic Set-Cookie handling.
-      let config = URLSessionConfiguration.ephemeral
-      let cookieStorage = config.httpCookieStorage!
-      let session = URLSession(configuration: config)
+    let stockPriceService = StockPriceService(client: YahooFinanceClient())
+    self.stockPriceService = stockPriceService
 
-      // Each profile gets its own keychain entry keyed by profile ID
-      let cookieKeychain = CookieKeychain(account: profile.id.uuidString)
-
-      backend = RemoteBackend(
-        baseURL: profile.resolvedServerURL,
-        instrument: profile.instrument,
-        session: session,
-        cookieKeychain: cookieKeychain,
-        cookieStorage: cookieStorage
-      )
-
-    case .cloudKit:
-      guard let containerManager else {
-        fatalError("ProfileContainerManager is required for CloudKit profiles")
-      }
-      let profileContainer = try! containerManager.container(for: profile.id)
-      backend = CloudKitBackend(
-        modelContainer: profileContainer,
-        instrument: profile.instrument,
-        profileLabel: profile.label,
-        conversionService: FiatConversionService(exchangeRates: exchangeRateService)
-      )
-    }
-    self.backend = backend
-    self.stockPriceService = StockPriceService(client: YahooFinanceClient())
     let cryptoCompareClient = CryptoCompareClient()
     let binanceClient = BinanceClient { date in
       let usdtMapping = CryptoProviderMapping(
@@ -102,11 +71,63 @@ final class ProfileSession: Identifiable {
     priceClients.append(cryptoCompareClient)
     priceClients.append(binanceClient)
 
-    self.cryptoPriceService = CryptoPriceService(
+    let cryptoPriceService = CryptoPriceService(
       clients: priceClients,
       tokenRepository: ICloudTokenRepository(),
       resolutionClient: CompositeTokenResolutionClient(coinGeckoApiKey: coinGeckoApiKey)
     )
+    self.cryptoPriceService = cryptoPriceService
+    self.cryptoTokenStore = CryptoTokenStore(cryptoPriceService: cryptoPriceService)
+
+    let backend: BackendProvider
+    switch profile.backendType {
+    case .remote, .moolah:
+      // Each profile gets its own cookie storage and URLSession.
+      // Ephemeral config provides an isolated cookie storage that URLSession
+      // actually integrates with for automatic Set-Cookie handling.
+      let config = URLSessionConfiguration.ephemeral
+      let cookieStorage = config.httpCookieStorage!
+      let session = URLSession(configuration: config)
+
+      // Each profile gets its own keychain entry keyed by profile ID
+      let cookieKeychain = CookieKeychain(account: profile.id.uuidString)
+
+      // RemoteBackend uses its own FiatConversionService internally;
+      // moolah-server is fiat-only so stock/crypto conversion via remote is
+      // out of scope. See issue #102 for the CloudKit fix.
+      backend = RemoteBackend(
+        baseURL: profile.resolvedServerURL,
+        instrument: profile.instrument,
+        session: session,
+        cookieKeychain: cookieKeychain,
+        cookieStorage: cookieStorage
+      )
+
+    case .cloudKit:
+      guard let containerManager else {
+        fatalError("ProfileContainerManager is required for CloudKit profiles")
+      }
+      let profileContainer = try! containerManager.container(for: profile.id)
+      // CloudKit profiles need full stock+crypto conversion support. The
+      // closure reads registered tokens from CryptoPriceService on each
+      // conversion so registrations added at runtime become usable without
+      // rebuilding the service. See issue #102.
+      let conversionService = FullConversionService(
+        exchangeRates: exchangeRateService,
+        stockPrices: stockPriceService,
+        cryptoPrices: cryptoPriceService,
+        providerMappings: {
+          await cryptoPriceService.registeredItems().map(\.mapping)
+        }
+      )
+      backend = CloudKitBackend(
+        modelContainer: profileContainer,
+        instrument: profile.instrument,
+        profileLabel: profile.label,
+        conversionService: conversionService
+      )
+    }
+    self.backend = backend
     self.authStore = AuthStore(backend: backend)
     self.accountStore = AccountStore(
       repository: backend.accounts, conversionService: backend.conversionService,

--- a/Features/Settings/CryptoSettingsView.swift
+++ b/Features/Settings/CryptoSettingsView.swift
@@ -2,13 +2,9 @@
 import SwiftUI
 
 struct CryptoSettingsView: View {
-  @State private var store: CryptoTokenStore
+  @Bindable var store: CryptoTokenStore
   @State private var showAddToken = false
   @State private var apiKeyInput = ""
-
-  init(cryptoPriceService: CryptoPriceService) {
-    _store = State(initialValue: CryptoTokenStore(cryptoPriceService: cryptoPriceService))
-  }
 
   var body: some View {
     Form {

--- a/Features/Settings/SettingsView.swift
+++ b/Features/Settings/SettingsView.swift
@@ -43,15 +43,16 @@ struct SettingsView: View {
   // MARK: - macOS: HSplitView layout
 
   #if os(macOS)
-    private var cryptoPriceServiceForSettings: CryptoPriceService {
+    private var cryptoTokenStoreForSettings: CryptoTokenStore {
       if let session = sessionManager.sessions.values.first {
-        return session.cryptoPriceService
+        return session.cryptoTokenStore
       }
-      return CryptoPriceService(
+      let fallbackService = CryptoPriceService(
         clients: [CryptoCompareClient(), BinanceClient()],
         tokenRepository: ICloudTokenRepository(),
         resolutionClient: CompositeTokenResolutionClient()
       )
+      return CryptoTokenStore(cryptoPriceService: fallbackService)
     }
 
     private var macOSLayout: some View {
@@ -60,7 +61,7 @@ struct SettingsView: View {
           profilesContent
         }
         Tab("Crypto", systemImage: "bitcoinsign.circle") {
-          CryptoSettingsView(cryptoPriceService: cryptoPriceServiceForSettings)
+          CryptoSettingsView(store: cryptoTokenStoreForSettings)
         }
       }
       .frame(minWidth: 600, minHeight: 400)
@@ -133,15 +134,16 @@ struct SettingsView: View {
   // MARK: - iOS: NavigationStack layout
 
   #if os(iOS)
-    private var cryptoPriceServiceForSettings: CryptoPriceService {
+    private var cryptoTokenStoreForSettings: CryptoTokenStore {
       if let session = activeSession {
-        return session.cryptoPriceService
+        return session.cryptoTokenStore
       }
-      return CryptoPriceService(
+      let fallbackService = CryptoPriceService(
         clients: [CryptoCompareClient(), BinanceClient()],
         tokenRepository: ICloudTokenRepository(),
         resolutionClient: CompositeTokenResolutionClient()
       )
+      return CryptoTokenStore(cryptoPriceService: fallbackService)
     }
 
     private var iOSLayout: some View {
@@ -191,7 +193,7 @@ struct SettingsView: View {
 
         Section {
           NavigationLink {
-            CryptoSettingsView(cryptoPriceService: cryptoPriceServiceForSettings)
+            CryptoSettingsView(store: cryptoTokenStoreForSettings)
           } label: {
             Label("Crypto Tokens", systemImage: "bitcoinsign.circle")
           }

--- a/MoolahTests/App/ProfileSessionTests.swift
+++ b/MoolahTests/App/ProfileSessionTests.swift
@@ -49,4 +49,33 @@ struct ProfileSessionTests {
 
     #expect(session.investmentStore.onInvestmentValueChanged != nil)
   }
+
+  /// Regression for #102: a CloudKit profile must use `FullConversionService`,
+  /// not `FiatConversionService`, so stock and crypto positions can be
+  /// converted. `FiatConversionService` throws `unsupportedInstrumentKind`
+  /// for any non-fiat input which (via Rule 11) blanks aggregates.
+  @Test("CloudKit profile uses FullConversionService")
+  func cloudKitProfileUsesFullConversionService() throws {
+    let containerManager = try ProfileContainerManager.forTesting()
+    let profile = Profile(
+      label: "iCloud", backendType: .cloudKit,
+      currencyCode: "AUD", financialYearStartMonth: 7
+    )
+    let session = ProfileSession(profile: profile, containerManager: containerManager)
+
+    #expect(session.backend.conversionService is FullConversionService)
+  }
+
+  @Test("CloudKit profile exposes cryptoTokenStore on session")
+  func cloudKitProfileExposesCryptoTokenStore() throws {
+    let containerManager = try ProfileContainerManager.forTesting()
+    let profile = Profile(
+      label: "iCloud", backendType: .cloudKit,
+      currencyCode: "AUD", financialYearStartMonth: 7
+    )
+    let session = ProfileSession(profile: profile, containerManager: containerManager)
+
+    // Store exists and starts empty (registrations load on demand).
+    #expect(session.cryptoTokenStore.registrations.isEmpty)
+  }
 }

--- a/MoolahTests/Shared/InstrumentConversionServiceCryptoTests.swift
+++ b/MoolahTests/Shared/InstrumentConversionServiceCryptoTests.swift
@@ -42,7 +42,7 @@ struct InstrumentConversionServiceCryptoTests {
       exchangeRates: exchangeService,
       stockPrices: stockService,
       cryptoPrices: cryptoService,
-      providerMappings: providerMappings
+      providerMappings: { providerMappings }
     )
   }
 
@@ -198,4 +198,57 @@ struct InstrumentConversionServiceCryptoTests {
     }
   }
 
+  /// The conversion service must consult its provider-mappings source on every
+  /// conversion so tokens registered after construction become resolvable
+  /// without rebuilding the service. `ProfileSession` wires the closure to the
+  /// `CryptoPriceService`, which persists registrations to the token
+  /// repository; newly-added tokens must flow through without app restart.
+  @Test func providerMappingsClosureIsQueriedPerConversion() async throws {
+    let cryptoClient = FixedCryptoPriceClient(
+      prices: ["1:native": ["2026-04-10": Decimal(string: "1623.45")!]]
+    )
+    let cryptoService = CryptoPriceService(
+      clients: [cryptoClient],
+      cacheDirectory: FileManager.default.temporaryDirectory
+        .appendingPathComponent(UUID().uuidString)
+    )
+    let exchangeService = ExchangeRateService(
+      client: FixedRateClient(rates: [:]),
+      cacheDirectory: FileManager.default.temporaryDirectory
+        .appendingPathComponent(UUID().uuidString)
+    )
+    let stockService = StockPriceService(client: FixedStockPriceClient())
+    let source = MutableMappingsSource()
+
+    let service = FullConversionService(
+      exchangeRates: exchangeService,
+      stockPrices: stockService,
+      cryptoPrices: cryptoService,
+      providerMappings: { await source.current() }
+    )
+
+    await #expect(throws: (any Error).self) {
+      _ = try await service.convert(Decimal(1), from: eth, to: usd, on: date("2026-04-10"))
+    }
+
+    await source.set([
+      CryptoProviderMapping(
+        instrumentId: "1:native", coingeckoId: "ethereum",
+        cryptocompareSymbol: "ETH", binanceSymbol: "ETHUSDT"
+      )
+    ])
+
+    let result = try await service.convert(
+      Decimal(1), from: eth, to: usd, on: date("2026-04-10")
+    )
+    #expect(result == Decimal(string: "1623.45")!)
+  }
+}
+
+private actor MutableMappingsSource {
+  private var mappings: [CryptoProviderMapping] = []
+
+  func current() -> [CryptoProviderMapping] { mappings }
+
+  func set(_ new: [CryptoProviderMapping]) { mappings = new }
 }

--- a/Shared/FullConversionService.swift
+++ b/Shared/FullConversionService.swift
@@ -9,22 +9,23 @@ actor FullConversionService: InstrumentConversionService {
   private let exchangeRates: ExchangeRateService
   private let stockPrices: StockPriceService
   private let cryptoPrices: CryptoPriceService?
-  private let providerMappingsByInstrumentId: [String: CryptoProviderMapping]
+  private let providerMappings: @Sendable () async -> [CryptoProviderMapping]
   private let logger = Logger(subsystem: "com.moolah.app", category: "CurrencyConversion")
 
+  /// - Parameter providerMappings: Closure invoked on each crypto conversion
+  ///   to obtain the current set of provider mappings. Tokens registered via
+  ///   `CryptoPriceService` after service construction become resolvable on
+  ///   the next conversion without rebuilding the service.
   init(
     exchangeRates: ExchangeRateService,
     stockPrices: StockPriceService,
     cryptoPrices: CryptoPriceService? = nil,
-    providerMappings: [CryptoProviderMapping] = []
+    providerMappings: @Sendable @escaping () async -> [CryptoProviderMapping] = { [] }
   ) {
     self.exchangeRates = exchangeRates
     self.stockPrices = stockPrices
     self.cryptoPrices = cryptoPrices
-    self.providerMappingsByInstrumentId = Dictionary(
-      providerMappings.map { ($0.instrumentId, $0) },
-      uniquingKeysWith: { _, last in last }
-    )
+    self.providerMappings = providerMappings
   }
 
   func convert(
@@ -133,7 +134,8 @@ actor FullConversionService: InstrumentConversionService {
     guard let cryptoPrices else {
       throw ConversionError.noCryptoPriceService
     }
-    guard let mapping = providerMappingsByInstrumentId[instrument.id] else {
+    let mappings = await providerMappings()
+    guard let mapping = mappings.first(where: { $0.instrumentId == instrument.id }) else {
       throw ConversionError.noProviderMapping(instrumentId: instrument.id)
     }
     return try await cryptoPrices.price(for: instrument, mapping: mapping, on: date)


### PR DESCRIPTION
## Summary
- CloudKit profiles were wired with `FiatConversionService`, which throws `unsupportedInstrumentKind` for stock/crypto instruments. Under Rule 11 this blanks aggregates on any account or earmark holding a non-fiat position — even though `InvestmentStore` is supposed to valuate those positions.
- Reorder `ProfileSession.init` so the stock/crypto price services are built before the backend, then pass a `FullConversionService` into `CloudKitBackend`. Provider mappings are resolved dynamically via an async closure reading `cryptoPriceService.registeredItems()`, so tokens registered at runtime become resolvable without rebuilding the service.
- Move `CryptoTokenStore` ownership onto the session alongside the other stores, and have `CryptoSettingsView` take the store directly.
- `RemoteBackend` remains fiat-only (moolah-server is fiat-only today).

Closes #102.

## Test plan
- [x] `just test` (1192 tests pass on iOS Simulator + macOS; +3 new tests from baseline)
- [x] New test: `FullConversionService` closure is queried per conversion — tokens registered after service construction are usable immediately
- [x] New test: CloudKit profile uses `FullConversionService` (regression guard)
- [x] New test: CloudKit profile exposes `cryptoTokenStore` on session
- [x] `instrument-conversion-review` agent run — no blockers or majors

🤖 Generated with [Claude Code](https://claude.com/claude-code)