### PR TITLE
Replace @unchecked Sendable with safe Sendable on AppleScript wrappers

### DIFF
--- a/Automation/AppleScript/ScriptableAccount.swift
+++ b/Automation/AppleScript/ScriptableAccount.swift
@@ -5,7 +5,7 @@
   /// AppleScript wrapper for an Account domain model.
   /// Data captured at construction time; all properties are nonisolated.
   @objc(ScriptableAccount)
-  class ScriptableAccount: NSObject, @unchecked Sendable {
+  final class ScriptableAccount: NSObject, Sendable {
     private let _uniqueID: String
     private let _name: String
     private let _accountType: String

--- a/Automation/AppleScript/ScriptableCategory.swift
+++ b/Automation/AppleScript/ScriptableCategory.swift
@@ -5,7 +5,7 @@
   /// AppleScript wrapper for a Category domain model.
   /// Data captured at construction time; all properties are nonisolated.
   @objc(ScriptableCategory)
-  class ScriptableCategory: NSObject, @unchecked Sendable {
+  final class ScriptableCategory: NSObject, Sendable {
     private let _uniqueID: String
     private let _name: String
     private let _parentName: String

--- a/Automation/AppleScript/ScriptableEarmark.swift
+++ b/Automation/AppleScript/ScriptableEarmark.swift
@@ -5,7 +5,7 @@
   /// AppleScript wrapper for an Earmark domain model.
   /// Data captured at construction time; all properties are nonisolated.
   @objc(ScriptableEarmark)
-  class ScriptableEarmark: NSObject, @unchecked Sendable {
+  final class ScriptableEarmark: NSObject, Sendable {
     private let _uniqueID: String
     private let _name: String
     private let _balance: Double

--- a/Automation/AppleScript/ScriptableProfile.swift
+++ b/Automation/AppleScript/ScriptableProfile.swift
@@ -8,7 +8,7 @@
   /// Data is captured at construction time (on MainActor) and stored as plain values.
   /// The object specifier methods are nonisolated so NSScripting can call them freely.
   @objc(ScriptableProfile)
-  class ScriptableProfile: NSObject, @unchecked Sendable {
+  final class ScriptableProfile: NSObject, Sendable {
     private let _uniqueID: String
     private let _name: String
     private let _currencyCode: String

--- a/Automation/AppleScript/ScriptableTransaction.swift
+++ b/Automation/AppleScript/ScriptableTransaction.swift
@@ -5,7 +5,7 @@
   /// AppleScript wrapper for a Transaction domain model.
   /// Data captured at construction time; all properties are nonisolated.
   @objc(ScriptableTransaction)
-  class ScriptableTransaction: NSObject, @unchecked Sendable {
+  final class ScriptableTransaction: NSObject, Sendable {
     private let _uniqueID: String
     private let _date: Date
     private let _payee: String
@@ -94,7 +94,7 @@
   /// AppleScript wrapper for a TransactionLeg.
   /// Data captured at construction time; all properties are nonisolated.
   @objc(ScriptableLeg)
-  class ScriptableLeg: NSObject, @unchecked Sendable {
+  final class ScriptableLeg: NSObject, Sendable {
     private let _accountName: String
     private let _amount: Double
     private let _categoryName: String


### PR DESCRIPTION
## Summary

- Marks `ScriptableAccount`, `ScriptableCategory`, `ScriptableEarmark`, `ScriptableProfile`, `ScriptableTransaction`, and `ScriptableLeg` as `final class` and replaces `@unchecked Sendable` with plain `Sendable`.
- Each type stores only `let` properties of Sendable types, so the compiler can synthesize safe Sendable conformance with no runtime behaviour change.
- Aligns these types with `guides/CONCURRENCY_GUIDE.md`: "Do not use @unchecked Sendable in production code."

## Judgment calls

- `ResultBox` in `ScriptingBridge.swift` and `ScriptResultBox` in `ScriptCommandHelpers.swift` still use `@unchecked Sendable` because they intentionally hold `var` state for cross-thread transfer via `DispatchSemaphore`. Those are outside the scope of this issue, which explicitly lists the six `Scriptable*` domain wrappers.
- `@MainActor`-isolated initializers are retained; isolation only applies during construction, and the resulting instance (all `let` stored Sendable properties) is safe to cross actor boundaries.

## Test plan

- [ ] macOS CI build succeeds (Swift treats warnings as errors; any Sendable regression would fail the build).
- [ ] Full test suite passes on macOS and iOS.

Fixes #68

https://claude.ai/code/session_01DB7AH6JLVvckAp6LPsxBEM