### PR TITLE
fix: surface reorderEarmarks errors and roll back on failure

### DIFF
--- a/Features/Earmarks/EarmarkStore.swift
+++ b/Features/Earmarks/EarmarkStore.swift
@@ -215,21 +215,39 @@ final class EarmarkStore {
     return (balance, saved, spent)
   }
 
+  /// Reorders the visible earmarks, persisting each new position to the
+  /// repository. On any failure, rolls back local state, reloads from the
+  /// repository to reconcile partial writes, and surfaces the error via
+  /// `self.error`. Hidden earmarks keep their existing positions.
   func reorderEarmarks(from source: IndexSet, to destination: Int) async {
+    // Save old state for rollback.
+    let previousEarmarks = earmarks
+    error = nil
+
     var visible = visibleEarmarks
     visible.move(fromOffsets: source, toOffset: destination)
-
     for index in visible.indices {
       visible[index].position = index
-      do {
-        _ = try await repository.update(visible[index])
-      } catch {
-        logger.error("Failed to persist earmark reorder for \(visible[index].id): \(error)")
-      }
     }
 
+    // Apply optimistic update so the UI reflects the new order immediately.
     let hiddenEarmarks = earmarks.ordered.filter { $0.isHidden }
     earmarks = Earmarks(from: visible + hiddenEarmarks)
+
+    for earmark in visible {
+      do {
+        _ = try await repository.update(earmark)
+      } catch {
+        logger.error("Failed to persist earmark reorder for \(earmark.id): \(error)")
+        // Rollback local state, then reload to reconcile any partial writes
+        // already persisted to the backend before the failure. Use
+        // `reloadFromSync` so it preserves `self.error` set below.
+        earmarks = previousEarmarks
+        await reloadFromSync()
+        self.error = error
+        return
+      }
+    }
   }
 
   func create(_ earmark: Earmark) async -> Earmark? {

--- a/MoolahTests/Features/EarmarkStoreTests.swift
+++ b/MoolahTests/Features/EarmarkStoreTests.swift
@@ -433,6 +433,50 @@ struct EarmarkStoreTests {
     #expect(persisted[2].position == 2)
   }
 
+  @Test func testReorderSurfacesErrorOnFailure() async throws {
+    let e0 = Earmark(name: "First", instrument: .defaultTestInstrument, position: 0)
+    let e1 = Earmark(name: "Second", instrument: .defaultTestInstrument, position: 1)
+    let e2 = Earmark(name: "Third", instrument: .defaultTestInstrument, position: 2)
+    let (backend, container) = try TestBackend.create()
+    TestBackend.seed(earmarks: [e0, e1, e2], in: container)
+    let failing = UpdateFailingEarmarkRepository(wrapping: backend.earmarks)
+    let store = EarmarkStore(
+      repository: failing, conversionService: FixedConversionService(),
+      targetInstrument: .defaultTestInstrument)
+    await store.load()
+
+    failing.failUpdates = true
+    await store.reorderEarmarks(from: IndexSet(integer: 2), to: 0)
+
+    #expect(store.error != nil)
+  }
+
+  @Test func testReorderRollsBackOnFailure() async throws {
+    let e0 = Earmark(name: "First", instrument: .defaultTestInstrument, position: 0)
+    let e1 = Earmark(name: "Second", instrument: .defaultTestInstrument, position: 1)
+    let e2 = Earmark(name: "Third", instrument: .defaultTestInstrument, position: 2)
+    let (backend, container) = try TestBackend.create()
+    TestBackend.seed(earmarks: [e0, e1, e2], in: container)
+    let failing = UpdateFailingEarmarkRepository(wrapping: backend.earmarks)
+    let store = EarmarkStore(
+      repository: failing, conversionService: FixedConversionService(),
+      targetInstrument: .defaultTestInstrument)
+    await store.load()
+
+    // First update succeeds (persists partial reorder on the server), second
+    // update throws — exercises the reconcile-after-partial-write path.
+    failing.failAfter = 1
+    await store.reorderEarmarks(from: IndexSet(integer: 2), to: 0)
+
+    // Local store state is reconciled with the repository (not the stale
+    // pre-reorder snapshot, since one write landed).
+    let persisted = try await backend.earmarks.fetchAll().sorted { $0.position < $1.position }
+    let storeOrdered = store.earmarks.ordered.sorted { $0.position < $1.position }
+    #expect(storeOrdered.map(\.id) == persisted.map(\.id))
+    #expect(storeOrdered.map(\.position) == persisted.map(\.position))
+    #expect(store.error != nil)
+  }
+
   // MARK: - create / update
 
   @Test func testCreateAddsEarmark() async throws {
@@ -854,5 +898,49 @@ private struct FailingEarmarkRepository: EarmarkRepository {
 
   func setBudget(earmarkId: UUID, categoryId: UUID, amount: InstrumentAmount) async throws {
     throw BackendError.networkUnavailable
+  }
+}
+
+/// Wraps a real repository but can be configured to fail `update` calls so
+/// tests can exercise error paths without mocking.
+@MainActor
+private final class UpdateFailingEarmarkRepository: EarmarkRepository {
+  private let wrapped: any EarmarkRepository
+  /// When `true`, every `update` call throws immediately.
+  var failUpdates: Bool = false
+  /// When non-nil, the first `failAfter` calls succeed; subsequent calls
+  /// throw. Useful for simulating partial writes.
+  var failAfter: Int?
+  private var updateCount: Int = 0
+
+  init(wrapping repository: any EarmarkRepository) {
+    self.wrapped = repository
+  }
+
+  func fetchAll() async throws -> [Earmark] {
+    try await wrapped.fetchAll()
+  }
+
+  func create(_ earmark: Earmark) async throws -> Earmark {
+    try await wrapped.create(earmark)
+  }
+
+  func update(_ earmark: Earmark) async throws -> Earmark {
+    if failUpdates {
+      throw BackendError.networkUnavailable
+    }
+    if let threshold = failAfter, updateCount >= threshold {
+      throw BackendError.networkUnavailable
+    }
+    updateCount += 1
+    return try await wrapped.update(earmark)
+  }
+
+  func fetchBudget(earmarkId: UUID) async throws -> [EarmarkBudgetItem] {
+    try await wrapped.fetchBudget(earmarkId: earmarkId)
+  }
+
+  func setBudget(earmarkId: UUID, categoryId: UUID, amount: InstrumentAmount) async throws {
+    try await wrapped.setBudget(earmarkId: earmarkId, categoryId: categoryId, amount: amount)
   }
 }


### PR DESCRIPTION
## Summary

Fixes #60.

`EarmarkStore.reorderEarmarks(from:to:)` previously logged per-item update failures and unconditionally applied the reordered state locally, leaving UI state inconsistent with the server and providing no indication to the user that anything went wrong.

This change adopts the optimistic-update-with-rollback pattern from `guides/CONCURRENCY_GUIDE.md`:

1. Snapshot the current `earmarks` for rollback.
2. Apply the reordered state locally so the UI feels instant.
3. Persist each earmark. On the first failure:
   - Roll back local state to the snapshot.
   - Call `reloadFromSync()` to reconcile any partial writes that already landed on the backend (it deliberately preserves `self.error`, unlike `load()` which resets it).
   - Set `self.error` so any subscriber can react / display the failure.
   - Return (stop attempting further writes for this reorder).

Hidden earmarks continue to keep their positions; they aren't re-indexed.

## Judgment calls

- **Reload path uses `reloadFromSync()` instead of `load()`** because `load()` clears `error` at the top, which would wipe out the error we're trying to surface. `reloadFromSync` already exists precisely for "reconcile from backend without touching loading/error UI flicker" scenarios, which is the right semantics here.
- **Bail on first failure** (rather than attempting remaining writes). Continuing would only widen the partial-state window; the server reconciliation handles whatever did land.
- **Test helper `UpdateFailingEarmarkRepository`** wraps the real `TestBackend` repository so we can simulate both total and partial failure without mocking (consistent with CLAUDE.md's "never mock the repository" rule).

Issue #59 flags the same pattern in `reorderAccounts` and is being handled in a parallel branch.

## Test plan
- [x] New test: `testReorderSurfacesErrorOnFailure` — when every `update` throws, `store.error` is non-nil afterwards.
- [x] New test: `testReorderRollsBackOnFailure` — when only the second `update` throws (simulating a partial write), the store's local state matches the persisted repository state and `store.error` is surfaced.
- [ ] CI runs the full `MoolahTests_macOS` + `MoolahTests_iOS` suites.

https://claude.ai/code/session_01DB7AH6JLVvckAp6LPsxBEM