### PR TITLE
fix: surface crypto valuation errors instead of swallowing them

### DIFF
--- a/Features/Accounts/CryptoPositionsSectionView.swift
+++ b/Features/Accounts/CryptoPositionsSectionView.swift
@@ -1,13 +1,66 @@
 // Features/Accounts/CryptoPositionsSectionView.swift
+import Foundation
+import OSLog
 import SwiftUI
 
+/// Valuates crypto positions against the profile currency.
+///
+/// Pulled out of the view so the per-position conversion loop is unit-testable
+/// and so failures are handled uniformly: on a throwing conversion we log via
+/// `os.Logger` and surface a `.failure` result for the affected position. Per
+/// Rule 11 in `guides/INSTRUMENT_CONVERSION_GUIDE.md`, the view must render
+/// the failing row as "unavailable" with a retry affordance — never silently
+/// drop it, substitute zero, or fall back to the native instrument.
+struct CryptoPositionValuator {
+  let conversionService: any InstrumentConversionService
+  private let logger = Logger(
+    subsystem: "com.moolah.app", category: "CryptoPositionValuator")
+
+  /// Returns a per-position result keyed by instrument id.
+  /// Single-instrument fast path: positions whose instrument matches the profile
+  /// currency skip the conversion service entirely (Rule 8).
+  func valuate(
+    positions: [Position],
+    profileCurrency: Instrument,
+    on date: Date
+  ) async -> [String: Result<Decimal, any Error>] {
+    var results: [String: Result<Decimal, any Error>] = [:]
+    for position in positions {
+      if position.instrument.id == profileCurrency.id {
+        results[position.instrument.id] = .success(position.quantity)
+        continue
+      }
+      do {
+        let value = try await conversionService.convert(
+          position.quantity,
+          from: position.instrument,
+          to: profileCurrency,
+          on: date
+        )
+        results[position.instrument.id] = .success(value)
+      } catch {
+        logger.warning(
+          "Failed to valuate crypto position \(position.instrument.id, privacy: .public): \(error.localizedDescription, privacy: .public)"
+        )
+        results[position.instrument.id] = .failure(error)
+      }
+    }
+    return results
+  }
+}
+
 /// Displays crypto token positions for an account with current fiat values.
+///
+/// When a position's conversion fails the row renders an explicit
+/// "Value unavailable" label with a retry button, per Rule 11 in
+/// `guides/INSTRUMENT_CONVERSION_GUIDE.md`. Sibling rows keep rendering with
+/// their successful values — a single failure does not blank the section.
 struct CryptoPositionsSectionView: View {
   let positions: [Position]
   let profileCurrency: Instrument
   let conversionService: any InstrumentConversionService
 
-  @State private var valuations: [String: Decimal] = [:]
+  @State private var valuations: [String: Result<Decimal, any Error>] = [:]
   @State private var isLoading = true
 
   var body: some View {
@@ -19,31 +72,7 @@ struct CryptoPositionsSectionView: View {
           .foregroundStyle(.secondary)
       } else {
         ForEach(cryptoPositions, id: \.instrument.id) { position in
-          HStack {
-            VStack(alignment: .leading) {
-              Text(position.instrument.displayLabel)
-                .font(.headline)
-              Text(position.instrument.name)
-                .font(.caption)
-                .foregroundStyle(.secondary)
-            }
-
-            Spacer()
-
-            VStack(alignment: .trailing) {
-              Text(formatQuantity(position.quantity, instrument: position.instrument))
-                .monospacedDigit()
-              if let fiatValue = valuations[position.instrument.id] {
-                let amount = InstrumentAmount(quantity: fiatValue, instrument: profileCurrency)
-                Text(amount.formatted)
-                  .font(.caption)
-                  .foregroundStyle(.secondary)
-                  .monospacedDigit()
-              }
-            }
-          }
-          .accessibilityElement(children: .combine)
-          .accessibilityLabel(accessibilityLabel(for: position))
+          row(for: position)
         }
       }
     }
@@ -56,22 +85,78 @@ struct CryptoPositionsSectionView: View {
     positions.filter { $0.instrument.kind == .cryptoToken && !$0.quantity.isZero }
   }
 
+  @ViewBuilder
+  private func row(for position: Position) -> some View {
+    HStack {
+      VStack(alignment: .leading) {
+        Text(position.instrument.displayLabel)
+          .font(.headline)
+        Text(position.instrument.name)
+          .font(.caption)
+          .foregroundStyle(.secondary)
+      }
+
+      Spacer()
+
+      VStack(alignment: .trailing) {
+        Text(formatQuantity(position.quantity, instrument: position.instrument))
+          .monospacedDigit()
+        valuationLabel(for: position)
+      }
+    }
+    .accessibilityElement(children: .combine)
+    .accessibilityLabel(accessibilityLabel(for: position))
+  }
+
+  @ViewBuilder
+  private func valuationLabel(for position: Position) -> some View {
+    switch valuations[position.instrument.id] {
+    case .success(let quantity):
+      let amount = InstrumentAmount(quantity: quantity, instrument: profileCurrency)
+      Text(amount.formatted)
+        .font(.caption)
+        .foregroundStyle(.secondary)
+        .monospacedDigit()
+    case .failure:
+      HStack(spacing: 4) {
+        Text("Value unavailable")
+          .font(.caption)
+          .foregroundStyle(.secondary)
+        Button {
+          Task { await retry(position: position) }
+        } label: {
+          Label("Retry", systemImage: "arrow.clockwise")
+            .labelStyle(.iconOnly)
+        }
+        .buttonStyle(.borderless)
+        .font(.caption)
+        .accessibilityLabel("Retry valuation for \(position.instrument.name)")
+      }
+    case .none:
+      EmptyView()
+    }
+  }
+
   private func loadValuations() async {
     isLoading = true
     defer { isLoading = false }
+    let valuator = CryptoPositionValuator(conversionService: conversionService)
+    valuations = await valuator.valuate(
+      positions: cryptoPositions,
+      profileCurrency: profileCurrency,
+      on: Date()
+    )
+  }
 
-    for position in cryptoPositions {
-      do {
-        let fiatValue = try await conversionService.convert(
-          position.quantity,
-          from: position.instrument,
-          to: profileCurrency,
-          on: Date()
-        )
-        valuations[position.instrument.id] = fiatValue
-      } catch {
-        // Price unavailable -- show quantity without value
-      }
+  private func retry(position: Position) async {
+    let valuator = CryptoPositionValuator(conversionService: conversionService)
+    let results = await valuator.valuate(
+      positions: [position],
+      profileCurrency: profileCurrency,
+      on: Date()
+    )
+    if let result = results[position.instrument.id] {
+      valuations[position.instrument.id] = result
     }
   }
 
@@ -86,10 +171,14 @@ struct CryptoPositionsSectionView: View {
 
   private func accessibilityLabel(for position: Position) -> String {
     let qty = formatQuantity(position.quantity, instrument: position.instrument)
-    if let fiatValue = valuations[position.instrument.id] {
-      let amount = InstrumentAmount(quantity: fiatValue, instrument: profileCurrency)
+    switch valuations[position.instrument.id] {
+    case .success(let quantity):
+      let amount = InstrumentAmount(quantity: quantity, instrument: profileCurrency)
       return "\(qty), valued at \(amount.formatted)"
+    case .failure:
+      return "\(qty), value unavailable"
+    case .none:
+      return qty
     }
-    return qty
   }
 }

--- a/MoolahTests/Features/CryptoPositionValuatorTests.swift
+++ b/MoolahTests/Features/CryptoPositionValuatorTests.swift
@@ -1,0 +1,75 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+/// Covers the per-position valuation helper used by `CryptoPositionsSectionView`.
+///
+/// Per Rule 11 in `guides/INSTRUMENT_CONVERSION_GUIDE.md`: a conversion error
+/// on a single position must be (a) logged and (b) surfaced to the view as an
+/// explicit failure state so the row can render "Value unavailable" with a
+/// retry affordance. It must NOT be silently swallowed, nor substituted with
+/// zero, nor rendered in the native instrument as a fallback.
+@Suite("CryptoPositionValuator")
+struct CryptoPositionValuatorTests {
+  let aud = Instrument.fiat(code: "AUD")
+  let eth = Instrument.crypto(
+    chainId: 1, contractAddress: nil, symbol: "ETH", name: "Ethereum", decimals: 18)
+  let btc = Instrument.crypto(
+    chainId: 0, contractAddress: nil, symbol: "BTC", name: "Bitcoin", decimals: 8)
+
+  @Test func convertsEachPositionAndReturnsSuccessResults() async throws {
+    let positions = [
+      Position(instrument: eth, quantity: Decimal(2)),
+      Position(instrument: btc, quantity: Decimal(string: "0.5")!),
+    ]
+    let service = FixedConversionService(rates: [
+      eth.id: Decimal(3000),
+      btc.id: Decimal(60_000),
+    ])
+
+    let valuator = CryptoPositionValuator(conversionService: service)
+    let results = await valuator.valuate(
+      positions: positions, profileCurrency: aud, on: Date())
+
+    #expect(try results[eth.id]?.get() == Decimal(6000))
+    #expect(try results[btc.id]?.get() == Decimal(30_000))
+  }
+
+  @Test func surfacesFailureForPositionWhoseConversionThrows() async throws {
+    let positions = [
+      Position(instrument: eth, quantity: Decimal(2)),
+      Position(instrument: btc, quantity: Decimal(1)),
+    ]
+    let service = FailingConversionService(
+      rates: [eth.id: Decimal(3000)],
+      failingInstrumentIds: [btc.id]
+    )
+
+    let valuator = CryptoPositionValuator(conversionService: service)
+    let results = await valuator.valuate(
+      positions: positions, profileCurrency: aud, on: Date())
+
+    // Success row rendered normally.
+    #expect(try results[eth.id]?.get() == Decimal(6000))
+
+    // Failing row surfaces the failure — not silently dropped, not zeroed.
+    let btcResult = try #require(results[btc.id])
+    if case .success = btcResult {
+      Issue.record("Expected btc valuation to be a failure, got success")
+    }
+  }
+
+  @Test func sameInstrumentFastPathReturnsQuantityDirectly() async throws {
+    // A crypto "position" whose instrument equals the profile currency is a
+    // degenerate case, but the fast path guards against pointless async hops.
+    let positions = [Position(instrument: aud, quantity: Decimal(42))]
+    let service = FailingConversionService(failingInstrumentIds: [aud.id])
+
+    let valuator = CryptoPositionValuator(conversionService: service)
+    let results = await valuator.valuate(
+      positions: positions, profileCurrency: aud, on: Date())
+
+    #expect(try results[aud.id]?.get() == Decimal(42))
+  }
+}


### PR DESCRIPTION
## Summary

- `CryptoPositionsSectionView.loadValuations` caught conversion errors with nothing but a source-code comment — no `os.Logger`, no error state, so a permanent rate-source failure silently hid positions with no user-visible indication and no way to retry.
- Extracted the per-position valuation loop into a testable `CryptoPositionValuator` helper that logs failures via `os.Logger` and returns `Result<Decimal, any Error>` per instrument id. The view holds those results as its render state and shows an explicit "Value unavailable" label with a retry button on failing rows, while sibling rows continue to render their successful valuations — per Rule 11 in `guides/INSTRUMENT_CONVERSION_GUIDE.md`.
- Added unit tests covering the success, failure, and same-instrument fast-path branches using the existing `FixedConversionService` / `FailingConversionService` doubles.

## Judgment calls

- The view is currently unreferenced in-repo (no `AccountDetailView` imports it) but is a real source file the phase-4 crypto plan wires up, so I fixed it in place rather than deleting. Refactoring the loop into a standalone `CryptoPositionValuator` gives it a unit-testable seam without introducing a full store for a single presentation-only concern.
- Scope of failure is the individual row (this view renders no aggregate), so per Rule 11 the row is marked unavailable and siblings keep rendering; there is no dependent total to blank.

## Test plan

- [ ] `just test CryptoPositionValuatorTests`
- [ ] CI: `MoolahTests_iOS` + `MoolahTests_macOS` pass
- [ ] Manual: trigger a conversion failure path (e.g. unmapped crypto provider) and confirm the row shows "Value unavailable" with a working retry button

Fixes #65

https://claude.ai/code/session_01DB7AH6JLVvckAp6LPsxBEM