### PR TITLE
fix: share distribution entitlements between validate and beta lanes

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -40,24 +40,12 @@ platform :ios do
 
     profile_name = ENV["sigh_rocks.moolah.app_appstore_profile-name"]
 
-    entitlements_path = "build/Moolah.entitlements"
-    FileUtils.mkdir_p("build")
-    File.write(entitlements_path, <<~PLIST)
-      <?xml version="1.0" encoding="UTF-8"?>
-      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-      <plist version="1.0">
-      <dict>
-        <key>com.apple.developer.icloud-container-identifiers</key>
-        <array><string>iCloud.rocks.moolah.app.v2</string></array>
-        <key>com.apple.developer.icloud-services</key>
-        <array><string>CloudKit</string></array>
-        <key>com.apple.security.app-sandbox</key>
-        <true/>
-        <key>com.apple.security.network.client</key>
-        <true/>
-      </dict>
-      </plist>
-    PLIST
+    # Distribution entitlements live in fastlane/Moolah.entitlements and are
+    # shared by both `validate` and `beta` lanes so they can never diverge.
+    # The file is intentionally kept outside any XcodeGen source path; XcodeGen
+    # auto-discovers .entitlements files in source directories and would apply
+    # them to all builds, breaking CI simulator tests without CloudKit.
+    entitlements_path = File.expand_path("Moolah.entitlements", __dir__)
 
     build_app(
       scheme: "Moolah-iOS",
@@ -106,27 +94,10 @@ platform :ios do
 
     profile_name = ENV["sigh_rocks.moolah.app_appstore_profile-name"]
 
-    # Generate entitlements file for distribution builds.
-    # Not checked into the repo because XcodeGen auto-discovers .entitlements
-    # files and applies them to all builds, breaking CI simulator tests.
-    entitlements_path = "build/Moolah.entitlements"
-    FileUtils.mkdir_p("build")
-    File.write(entitlements_path, <<~PLIST)
-      <?xml version="1.0" encoding="UTF-8"?>
-      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-      <plist version="1.0">
-      <dict>
-        <key>com.apple.developer.icloud-container-identifiers</key>
-        <array><string>iCloud.rocks.moolah.app.v2</string></array>
-        <key>com.apple.developer.icloud-services</key>
-        <array><string>CloudKit</string></array>
-        <key>com.apple.security.app-sandbox</key>
-        <true/>
-        <key>com.apple.security.network.client</key>
-        <true/>
-      </dict>
-      </plist>
-    PLIST
+    # Share the entitlements file with the `validate` lane so the IPA we upload
+    # to TestFlight always matches what validate inspected. See the comment in
+    # `validate` for why this file is kept in fastlane/ rather than App/.
+    entitlements_path = File.expand_path("Moolah.entitlements", __dir__)
 
     build_app(
       scheme: "Moolah-iOS",

--- a/fastlane/Moolah.entitlements
+++ b/fastlane/Moolah.entitlements
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.developer.icloud-container-identifiers</key>
+  <array><string>iCloud.rocks.moolah.app.v2</string></array>
+  <key>com.apple.developer.icloud-services</key>
+  <array><string>CloudKit</string></array>
+  <key>com.apple.security.app-sandbox</key>
+  <true/>
+  <key>com.apple.security.network.client</key>
+  <true/>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- `fastlane/Fastfile` had two hardcoded copies of the same distribution entitlements plist, one in `validate` and one in `beta`. If either drifted, the validated IPA would no longer match the uploaded IPA.
- Commit a single `fastlane/Moolah.entitlements` and reference it via `File.expand_path("Moolah.entitlements", __dir__)` from both lanes.
- Location decision: the issue suggested `App/Moolah.entitlements`, but a comment in the original Fastfile explicitly calls out that XcodeGen auto-discovers `.entitlements` files inside source directories and would apply CloudKit entitlements to all builds, breaking CI simulator tests. `fastlane/` is not listed as a source path in `project.yml`, so keeping the file there preserves the existing CI behaviour while still giving both lanes a single source of truth.

Fixes #95

## Test plan
- [x] `ruby -c fastlane/Fastfile` passes
- [x] `python3 -c "import plistlib; plistlib.load(...)"` parses `fastlane/Moolah.entitlements`
- [ ] CI (GitHub Actions) green

https://claude.ai/code/session_01DB7AH6JLVvckAp6LPsxBEM