### PR TITLE
fix: surface balance conversion failures in EditAccountView

### DIFF
--- a/Features/Accounts/Views/EditAccountView.swift
+++ b/Features/Accounts/Views/EditAccountView.swift
@@ -9,7 +9,6 @@ struct EditAccountView: View {
   @State private var isSubmitting = false
   @State private var errorMessage: String?
   @State private var showingHideConfirmation = false
-  @State private var displayBalance: InstrumentAmount?
   @FocusState private var focusedField: Field?
 
   let account: Account
@@ -52,6 +51,10 @@ struct EditAccountView: View {
             if let displayBalance {
               InstrumentAmountView(amount: displayBalance)
                 .foregroundStyle(.secondary)
+            } else if isBalanceUnavailable {
+              Text("Unavailable")
+                .foregroundStyle(.secondary)
+                .accessibilityLabel("Current balance unavailable")
             } else {
               ProgressView()
                 .controlSize(.small)
@@ -59,7 +62,7 @@ struct EditAccountView: View {
             }
           }
           .accessibilityLabel("Current balance, read-only")
-          .accessibilityValue(displayBalance?.formatted ?? "Loading")
+          .accessibilityValue(balanceAccessibilityValue)
         }
 
         PositionListView(positions: accountStore.positions(for: account.id))
@@ -93,9 +96,6 @@ struct EditAccountView: View {
               : ""
           )
         }
-      }
-      .task(id: balanceInputs) {
-        displayBalance = try? await accountStore.displayBalance(for: account.id)
       }
       .navigationTitle("Edit Account")
       #if os(iOS)
@@ -132,16 +132,26 @@ struct EditAccountView: View {
     !name.trimmingCharacters(in: .whitespaces).isEmpty
   }
 
-  private var balanceInputs: BalanceInputs {
-    BalanceInputs(
-      positions: accountStore.positions(for: account.id),
-      investmentValue: accountStore.investmentValues[account.id]
-    )
+  /// Reads the converted balance published by `AccountStore`, which handles
+  /// retries and logging for conversion failures. `nil` means either no
+  /// conversion pass has run yet (loading) or the conversion failed
+  /// (unavailable) — `isBalanceUnavailable` distinguishes the two.
+  private var displayBalance: InstrumentAmount? {
+    accountStore.convertedBalances[account.id]
   }
 
-  private struct BalanceInputs: Equatable {
-    let positions: [Position]
-    let investmentValue: InstrumentAmount?
+  /// True when a conversion attempt has completed but no balance is
+  /// available — i.e. conversion failed. Distinct from the initial
+  /// "still loading" state before the first attempt.
+  private var isBalanceUnavailable: Bool {
+    accountStore.conversionAttemptsCompleted > 0 && displayBalance == nil
+  }
+
+  private var balanceAccessibilityValue: String {
+    if let displayBalance {
+      return displayBalance.formatted
+    }
+    return isBalanceUnavailable ? "Unavailable" : "Loading"
   }
 
   private func save() async {


### PR DESCRIPTION
## Summary

Fixes #75 — `EditAccountView` was calling `accountStore.displayBalance(for:)` inside a `.task` wrapped in `try?`, silently swallowing conversion errors. Per `guides/INSTRUMENT_CONVERSION_GUIDE.md` Rule 11, a failed conversion must be logged and surfaced to the user, not swallowed.

## Fix

- Removed the local `.task(id: balanceInputs)` + `try?` pattern entirely, along with the `@State displayBalance` and the internal `BalanceInputs` struct.
- The view now reads `accountStore.convertedBalances[account.id]` directly. `AccountStore.recomputeConvertedTotals()` already logs every failure via `os.Logger`, retries on a timer, and leaves the entry absent when conversion fails — so there is no need for the view to do its own conversion + error handling.
- Added an `isBalanceUnavailable` computed property (`conversionAttemptsCompleted > 0 && balance == nil`) that distinguishes "not yet loaded" from "conversion failed". When unavailable, the view renders "Unavailable" (matching the existing `StockPositionsView` convention) with an appropriate accessibility label instead of a perpetual spinner + "Loading" VoiceOver value.

## Judgment calls

- Chose `"Unavailable"` text over an error banner / retry button. The store already retries automatically, and this matches the pattern already established in `StockPositionsView` for the same class of failure.
- Did not add a new unit test — the change is purely a consumer of state that is already covered by `AccountStoreConversionTests.perAccountBalancePopulatesEvenWhenAnotherAccountFails` and `conversionFailuresAreRetriedAfterDelay`. The view no longer has any branch-worthy logic of its own.

## Test plan

- [ ] `just build-mac` passes (warnings-as-errors).
- [ ] `just build-ios` passes.
- [ ] `just test AccountStoreConversionTests` continues to pass.
- [ ] Manual: open Edit Account with a multi-currency account while offline → "Unavailable" appears, `os.Logger` emits a warning.

Fixes #75

https://claude.ai/code/session_01DB7AH6JLVvckAp6LPsxBEM