### PR TITLE
fix: reload accounts and earmarks on TransactionLegRecord sync

### DIFF
--- a/App/ProfileSession.swift
+++ b/App/ProfileSession.swift
@@ -257,20 +257,54 @@ final class ProfileSession: Identifiable {
 
       let reloadStart = ContinuousClock.now
       logger.debug("Reloading stores after CloudKit sync: \(types)")
-      if types.contains(AccountRecord.recordType) || types.contains(TransactionRecord.recordType) {
+      let plan = Self.storesToReload(for: types)
+      if plan.contains(.accounts) {
         await accountStore.reloadFromSync()
       }
-      if types.contains(CategoryRecord.recordType) {
+      if plan.contains(.categories) {
         await categoryStore.reloadFromSync()
       }
-      if types.contains(EarmarkRecord.recordType)
-        || types.contains(EarmarkBudgetItemRecord.recordType)
-      {
+      if plan.contains(.earmarks) {
         await earmarkStore.reloadFromSync()
       }
       let reloadMs = (ContinuousClock.now - reloadStart).inMilliseconds
       logger.info("📊 Store reloads after sync completed in \(reloadMs)ms for types: \(types)")
     }
+  }
+
+  /// Which stores should be reloaded for a given set of changed record types.
+  /// Exposed as a pure static function so the reload-mapping policy can be
+  /// unit-tested without driving the debounced async task.
+  ///
+  /// `TransactionLegRecord` drives both account balances and earmark positions,
+  /// so a remote leg-only change (e.g. category/earmark reassignment performed
+  /// on another device) must reload both stores even if the parent
+  /// `TransactionRecord` did not change in this batch.
+  struct StoreReloadPlan: OptionSet, Sendable, Equatable {
+    let rawValue: Int
+    static let accounts = StoreReloadPlan(rawValue: 1 << 0)
+    static let categories = StoreReloadPlan(rawValue: 1 << 1)
+    static let earmarks = StoreReloadPlan(rawValue: 1 << 2)
+  }
+
+  static func storesToReload(for changedTypes: Set<String>) -> StoreReloadPlan {
+    var plan: StoreReloadPlan = []
+    if changedTypes.contains(AccountRecord.recordType)
+      || changedTypes.contains(TransactionRecord.recordType)
+      || changedTypes.contains(TransactionLegRecord.recordType)
+    {
+      plan.insert(.accounts)
+    }
+    if changedTypes.contains(CategoryRecord.recordType) {
+      plan.insert(.categories)
+    }
+    if changedTypes.contains(EarmarkRecord.recordType)
+      || changedTypes.contains(EarmarkBudgetItemRecord.recordType)
+      || changedTypes.contains(TransactionLegRecord.recordType)
+    {
+      plan.insert(.earmarks)
+    }
+    return plan
   }
 
   // MARK: - Sync Cleanup

--- a/MoolahTests/App/ProfileSessionTests.swift
+++ b/MoolahTests/App/ProfileSessionTests.swift
@@ -78,4 +78,72 @@ struct ProfileSessionTests {
     // Store exists and starts empty (registrations load on demand).
     #expect(session.cryptoTokenStore.registrations.isEmpty)
   }
+
+  // MARK: - storesToReload (sync reload dispatch policy)
+
+  @Test("AccountRecord change reloads the account store")
+  func accountRecordReloadsAccounts() {
+    let plan = ProfileSession.storesToReload(for: [AccountRecord.recordType])
+    #expect(plan == .accounts)
+  }
+
+  @Test("TransactionRecord change reloads the account store")
+  func transactionRecordReloadsAccounts() {
+    let plan = ProfileSession.storesToReload(for: [TransactionRecord.recordType])
+    #expect(plan == .accounts)
+  }
+
+  @Test("TransactionLegRecord change reloads both accounts and earmarks")
+  func transactionLegRecordReloadsAccountsAndEarmarks() {
+    // Regression for issue #76: leg-only remote changes (e.g. category or
+    // earmark reassignment on another device) must trigger reloads of both
+    // the account store and the earmark store, even when the parent
+    // TransactionRecord did not change in this batch.
+    let plan = ProfileSession.storesToReload(for: [TransactionLegRecord.recordType])
+    #expect(plan.contains(.accounts))
+    #expect(plan.contains(.earmarks))
+    #expect(!plan.contains(.categories))
+  }
+
+  @Test("CategoryRecord change reloads only the category store")
+  func categoryRecordReloadsCategories() {
+    let plan = ProfileSession.storesToReload(for: [CategoryRecord.recordType])
+    #expect(plan == .categories)
+  }
+
+  @Test("EarmarkRecord change reloads the earmark store")
+  func earmarkRecordReloadsEarmarks() {
+    let plan = ProfileSession.storesToReload(for: [EarmarkRecord.recordType])
+    #expect(plan == .earmarks)
+  }
+
+  @Test("EarmarkBudgetItemRecord change reloads the earmark store")
+  func earmarkBudgetItemRecordReloadsEarmarks() {
+    let plan = ProfileSession.storesToReload(for: [EarmarkBudgetItemRecord.recordType])
+    #expect(plan == .earmarks)
+  }
+
+  @Test("Unknown record types do not trigger any reload")
+  func unknownRecordTypesDoNotReload() {
+    let plan = ProfileSession.storesToReload(for: ["CD_SomethingElse"])
+    #expect(plan.isEmpty)
+  }
+
+  @Test("Empty changed types produces an empty plan")
+  func emptyChangedTypesProducesEmptyPlan() {
+    let plan = ProfileSession.storesToReload(for: [])
+    #expect(plan.isEmpty)
+  }
+
+  @Test("Mixed record types combine reload plans")
+  func mixedRecordTypesCombineReloadPlans() {
+    let plan = ProfileSession.storesToReload(
+      for: [
+        TransactionLegRecord.recordType,
+        CategoryRecord.recordType,
+      ])
+    #expect(plan.contains(.accounts))
+    #expect(plan.contains(.earmarks))
+    #expect(plan.contains(.categories))
+  }
 }


### PR DESCRIPTION
## Summary

Fixes #76.

`ProfileSession.scheduleReloadFromSync` reloaded `accountStore` only when `AccountRecord` or `TransactionRecord` changed, and `earmarkStore` only on earmark-related records. Leg-only remote changes (category or earmark reassignment from another device) push `TransactionLegRecord` without touching the parent `TransactionRecord`, so both stores stayed stale until the next manual refresh.

- Extract the record-type-to-store mapping into a pure static `storesToReload(for:) -> StoreReloadPlan` on `ProfileSession`.
- Include `TransactionLegRecord.recordType` in both the account and earmark reload conditions, matching the record's role as the source of truth for both account balances and earmark positions.
- The OptionSet-based plan makes the debounced reload dispatch trivial and unit-testable without driving the async Task.

## Judgment calls

- Refactored the inline `if types.contains(...)` checks into a static function rather than patching the two conditions in place. The policy is load-bearing and was previously untested; this lets the tests assert behaviour directly without exercising the 500ms/2s debounce.

## Test plan

- [x] Added `ProfileSessionTests` covering each record-type-to-store mapping, including the #76 regression (leg-only change reloads both accounts and earmarks), empty/unknown inputs, and combined plans.
- [ ] CI macOS build + tests (Linux sandbox has no Xcode, relying on CI).

https://claude.ai/code/session_01DB7AH6JLVvckAp6LPsxBEM