### PR TITLE
fix: stop double-converting investment total (#96)

### DIFF
--- a/Features/Accounts/AccountStore.swift
+++ b/Features/Accounts/AccountStore.swift
@@ -153,15 +153,24 @@ final class AccountStore {
     try await computeConvertedTotal(for: currentAccounts, in: target)
   }
 
-  /// Compute converted total for investment accounts.
+  /// Compute converted total for investment accounts. Sums each position
+  /// directly to `target` in one pass, mirroring `computeConvertedTotal`
+  /// (Rule 8 single-instrument fast path is handled inside the conversion
+  /// service). Accounts with an externally-provided `investmentValues`
+  /// entry skip position summing and convert that value once to `target`.
   func computeConvertedInvestmentTotal(in target: Instrument) async throws -> InstrumentAmount {
     var total = InstrumentAmount.zero(instrument: target)
     let date = Date()
     for account in investmentAccounts {
-      let accountBalance = try await displayBalance(for: account.id)
-      let converted = try await conversionService.convertAmount(
-        accountBalance, to: target, on: date)
-      total += converted
+      if let externalValue = investmentValues[account.id] {
+        total += try await conversionService.convertAmount(
+          externalValue, to: target, on: date)
+        continue
+      }
+      for position in account.positions {
+        total += try await conversionService.convertAmount(
+          position.amount, to: target, on: date)
+      }
     }
     return total
   }

--- a/MoolahTests/Features/AccountStoreConversionTests.swift
+++ b/MoolahTests/Features/AccountStoreConversionTests.swift
@@ -480,6 +480,68 @@ struct AccountStoreConversionTests {
     #expect(store.convertedBalances[bankAud.id]?.quantity == 1000)
     #expect(store.convertedBalances[bankEur.id]?.quantity == 500)
   }
+  /// Regression for #96: `computeConvertedInvestmentTotal` must not route
+  /// through `displayBalance` (which converts every position to the
+  /// account's instrument) and then convert the bottom line again to the
+  /// target. That extra hop doubles the round-trip through the conversion
+  /// actor and doubles the retry blast radius when the outer hop fails.
+  /// The implementation should mirror `computeConvertedCurrentTotal` and
+  /// convert each position directly to `target` in one pass.
+  @Test func computeConvertedInvestmentTotalDoesNotDoubleConvert() async throws {
+    let aud = Instrument.AUD
+    let usd = Instrument.USD
+    let eur = Instrument.fiat(code: "EUR")
+    let accountId = UUID()
+    let account = Account(
+      id: accountId, name: "Portfolio", type: .investment, instrument: aud)
+
+    let (backend, container) = try TestBackend.create()
+    TestBackend.seed(accounts: [account], in: container)
+
+    // Two foreign-currency positions in distinct instruments so the
+    // repository yields two `Position` entries.
+    let txns = [
+      Transaction(
+        date: Date(),
+        legs: [
+          TransactionLeg(
+            accountId: accountId, instrument: usd,
+            quantity: Decimal(100), type: .openingBalance)
+        ]),
+      Transaction(
+        date: Date(),
+        legs: [
+          TransactionLeg(
+            accountId: accountId, instrument: eur,
+            quantity: Decimal(50), type: .openingBalance)
+        ]),
+    ]
+    TestBackend.seed(transactions: txns, in: container)
+
+    let counter = CountingConversionService(rates: [
+      "USD": Decimal(string: "1.5")!,
+      "EUR": Decimal(string: "2.0")!,
+    ])
+    let store = AccountStore(
+      repository: backend.accounts,
+      conversionService: counter,
+      targetInstrument: aud)
+    await store.load()
+    // Wait for load's own convertedBalances pass to finish so the counter's
+    // baseline is stable before we measure this call.
+    await store.waitForPendingConversions()
+
+    let baseline = await counter.convertAmountCallCount
+    let total = try await store.computeConvertedInvestmentTotal(in: aud)
+    let delta = await counter.convertAmountCallCount - baseline
+
+    // 100 USD * 1.5 + 50 EUR * 2.0 = 150 + 100 = 250 AUD.
+    #expect(total == InstrumentAmount(quantity: Decimal(250), instrument: aud))
+    // One conversion per position (USD→AUD, EUR→AUD). The old implementation
+    // made 3 calls: 2 per-position (→ account.instrument AUD) plus 1 outer
+    // (accountBalance → target). New: 2 calls.
+    #expect(delta == 2)
+  }
 }
 
 @MainActor

--- a/MoolahTests/Support/CountingConversionService.swift
+++ b/MoolahTests/Support/CountingConversionService.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+@testable import Moolah
+
+/// Test conversion service that records every `convertAmount` call for
+/// assertions about how many round-trips a caller makes. Math behaves like
+/// `FixedConversionService` (rates keyed by source instrument id, 1:1
+/// fallback).
+actor CountingConversionService: InstrumentConversionService {
+  private let rates: [String: Decimal]
+  private(set) var convertAmountCallCount: Int = 0
+
+  init(rates: [String: Decimal] = [:]) {
+    self.rates = rates
+  }
+
+  func convert(
+    _ quantity: Decimal, from: Instrument, to: Instrument, on date: Date
+  ) async throws -> Decimal {
+    if from.id == to.id { return quantity }
+    guard let rate = rates[from.id] else { return quantity }
+    return quantity * rate
+  }
+
+  func convertAmount(
+    _ amount: InstrumentAmount, to instrument: Instrument, on date: Date
+  ) async throws -> InstrumentAmount {
+    convertAmountCallCount += 1
+    guard amount.instrument != instrument else { return amount }
+    let converted = try await convert(
+      amount.quantity, from: amount.instrument, to: instrument, on: date
+    )
+    return InstrumentAmount(quantity: converted, instrument: instrument)
+  }
+}


### PR DESCRIPTION
## Summary
- `AccountStore.computeConvertedInvestmentTotal` routed every investment account through `displayBalance`, which first converts each position to the account's own instrument, then converted that bottom line again to the target. The second hop added a round-trip through the conversion actor and doubled the retry blast radius — if the inner sum succeeded, the per-account balance was available but the aggregate was discarded.
- Sum each position directly to `target` in one pass, mirroring `computeConvertedCurrentTotal`. Accounts with an externally-provided `investmentValues` entry skip position summing and convert that value once to `target`.
- Adds a counting conversion-service test double and a regression test asserting one conversion per position (not one plus a trailing outer hop).

Closes #96.

## Test plan
- [x] `just test` — 1195 tests pass on macOS, 1179 on iOS; +1 new test from baseline
- [x] New regression test: `computeConvertedInvestmentTotalDoesNotDoubleConvert` — counts `convertAmount` calls and verifies the delta is 2 (one per position), where the old implementation made 3

## Related
- Siblings in this batch of `review:instrument-conversion`+`severity:minor`: #92 and #126 were already fixed upstream (closed); #118 needs a `DailyBalance` API change — skipped with a comment for a dedicated PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)