### PR TITLE
fix: use InstrumentAmountView in upcoming transactions row

### DIFF
--- a/Features/Analysis/Views/UpcomingTransactionsCard.swift
+++ b/Features/Analysis/Views/UpcomingTransactionsCard.swift
@@ -143,13 +143,7 @@ private struct SimpleTransactionRow: View {
       Spacer()
 
       if let displayAmount {
-        Text(
-          displayAmount.quantity,
-          format: .currency(code: displayAmount.instrument.id)
-        )
-        .font(.body)
-        .monospacedDigit()
-        .foregroundStyle(displayAmount.quantity >= 0 ? .green : .red)
+        InstrumentAmountView(amount: displayAmount, font: .body)
       } else {
         Text("—")
           .font(.body)


### PR DESCRIPTION
## Summary
- `SimpleTransactionRow` in `UpcomingTransactionsCard` manually formatted the display amount with `Text(...).foregroundStyle(displayAmount.quantity >= 0 ? .green : .red)`, which duplicated `InstrumentAmountView` and incorrectly coloured zero-valued amounts green.
- Replaced the hand-rolled currency/colour logic with `InstrumentAmountView(amount:font:)` so zero renders as `.primary` and currency formatting / `.monospacedDigit()` stay in a single source of truth.

## Notes
- Non-nil placeholder ("—") branch is kept unchanged because `InstrumentAmountView` requires a non-optional `InstrumentAmount`.
- Could not run `just build-mac` / `just test` in this sandbox (no `xcodebuild`/`just`); relying on CI for verification. The change is a pure view-composition swap with no behaviour change beyond the zero-colour fix.

## Test plan
- [ ] CI build (macOS + iOS) passes
- [ ] CI test suite passes

Fixes #108

https://claude.ai/code/session_01DB7AH6JLVvckAp6LPsxBEM