### PR TITLE
fix: remove "Tap +" from InvestmentValuesView empty state

### DIFF
--- a/Features/Investments/Views/InvestmentValuesView.swift
+++ b/Features/Investments/Views/InvestmentValuesView.swift
@@ -12,7 +12,7 @@ struct InvestmentValuesView: View {
         ContentUnavailableView(
           "No Values Recorded",
           systemImage: "chart.line.uptrend.xyaxis",
-          description: Text("Tap + to record your first investment value")
+          description: Text("Record a value to start tracking this investment over time.")
         )
       } else {
         if store.values.count > 1 {


### PR DESCRIPTION
## Summary

- The empty-state description in `InvestmentValuesView` said "Tap + to record your first investment value", which violates STYLE_GUIDE.md §1 macOS-First (users click, not tap, on macOS).
- Rather than adding an `#if os` conditional for a user-visible string, rephrased to an action-focused sentence that reads naturally on both platforms and matches the tone used in other empty states (e.g. "Create an earmark to start tracking savings goals.").

## Judgment call

Chose rephrasing over platform-conditional copy because:
- It avoids scattering `#if os(macOS)` through user-facing strings.
- It matches the pattern already used by sibling empty states in the app.
- The new wording ("Record a value to start tracking this investment over time.") is action-focused and platform-neutral.

## Test plan

- [x] Visually reviewed the diff; single one-line string change.
- [ ] `just build-mac` — cannot run in this sandboxed environment (no Xcode); change is a string literal only, so risk is confined to spelling/compile of a `Text(_:)` initializer.
- [ ] `just test` — not required; no behavioural change.

Fixes #121

https://claude.ai/code/session_01DB7AH6JLVvckAp6LPsxBEM