### PR TITLE
fix: differentiate empty states in transaction list (#119)

### DIFF
--- a/Features/Transactions/Views/TransactionListView.swift
+++ b/Features/Transactions/Views/TransactionListView.swift
@@ -337,11 +337,51 @@ struct TransactionListView: View {
     }
     .searchable(text: $searchText, prompt: "Search payee")
     .overlay {
-      if !transactionStore.isLoading && transactionStore.transactions.isEmpty {
+      emptyStateOverlay
+    }
+  }
+
+  /// Empty-state overlay, differentiated by context:
+  /// - Active search with no matches → system search empty state.
+  /// - Loaded transactions exist but none match the current (filter + search) → hint to
+  ///   clear filters/search.
+  /// - No transactions loaded at all with an active filter → filter excludes everything.
+  /// - Otherwise (new / empty account) → encourage adding the first transaction.
+  @ViewBuilder
+  private var emptyStateOverlay: some View {
+    if transactionStore.isLoading {
+      EmptyView()
+    } else if filteredTransactions.isEmpty {
+      let hasSearch = !searchText.isEmpty
+      let hasFilter = activeFilter != baseFilter
+      let hasAnyLoaded = !transactionStore.transactions.isEmpty
+
+      if hasSearch && hasAnyLoaded {
+        // Some transactions are loaded; the search is narrowing them to zero.
+        ContentUnavailableView.search(text: searchText)
+      } else if hasFilter {
+        ContentUnavailableView {
+          Label("No Matches", systemImage: "line.3.horizontal.decrease.circle")
+        } description: {
+          Text("No transactions match the current filter.")
+        } actions: {
+          Button("Clear Filter") {
+            activeFilter = baseFilter
+          }
+        }
+      } else if hasSearch {
+        // No transactions are loaded at all, but a search term is present.
+        ContentUnavailableView.search(text: searchText)
+      } else {
         ContentUnavailableView(
           "No Transactions",
           systemImage: "tray",
-          description: Text("No transactions found.")
+          description: Text(
+            PlatformActionVerb.emptyStatePrompt(
+              buttonLabel: "+",
+              suffix: "to add your first transaction."
+            )
+          )
         )
       }
     }


### PR DESCRIPTION
## Summary

Fixes #119. The `ContentUnavailableView` in `TransactionListView` previously rendered a generic "No transactions found." description, which violated STYLE_GUIDE.md §6 (Empty States) and BRAND_GUIDE.md §2 (plain-spoken, permission-giving voice) and gave users no guidance on what to do next.

The overlay now branches on four distinct contexts:

- **Search with no matches against loaded rows** - uses the built-in `ContentUnavailableView.search(text:)`, matching Apple HIG.
- **Active filter excluding everything** - shows "No Matches" with a **Clear Filter** button so users can escape a too-narrow filter without having to re-open the filter sheet.
- **Search term with no underlying data** - system search empty state.
- **New / empty account** - "Tap + to add your first transaction.", matching the exact STYLE_GUIDE §6 example copy.

Logic lives inline as a `@ViewBuilder` computed property in the view because it is pure presentation (no async orchestration, no state mutation beyond the local `activeFilter` reset that already lives in this view).

## Judgment calls

- Kept the empty-state view local rather than extracting to a separate type. It is under 40 lines, touches only view-local state (`activeFilter`, `searchText`), and pulling it out would require threading those bindings without any test or reuse benefit.
- Used `ContentUnavailableView.search(text:)` for both "search with data" and "search without data" paths - the built-in variant is identical for users and keeps the HIG-native copy.
- The `Clear Filter` button resets `activeFilter` to `baseFilter`, which already triggers the existing `.task(id: activeFilter)` reload path.

## Test plan

- [ ] CI: macOS + iOS builds with `SWIFT_TREAT_WARNINGS_AS_ERRORS: YES`.
- [ ] CI: existing test suites still pass (no test touches this view today).
- [ ] Manual: open an empty account → see "Tap + to add your first transaction."
- [ ] Manual: apply a filter that excludes everything → see "No Matches" with working **Clear Filter** button.
- [ ] Manual: type a search string with no matches → see the system search empty state.

https://claude.ai/code/session_01DB7AH6JLVvckAp6LPsxBEM