### PR TITLE
fix: avoid disruptive reload on scenePhase active

### DIFF
--- a/Features/Analysis/AnalysisStore.swift
+++ b/Features/Analysis/AnalysisStore.swift
@@ -19,6 +19,11 @@ final class AnalysisStore {
     cachedHistoryMonths != nil && !dailyBalances.isEmpty
   }
 
+  /// Timestamp of the last successful `loadAll()`. Used by `refreshIfStale` to
+  /// avoid reloading when data was recently fetched (e.g. the app briefly
+  /// becomes inactive returning from a share sheet or system dialog).
+  private(set) var lastLoadedAt: Date?
+
   // Filters (persisted across launches)
   var historyMonths: Int {
     didSet { defaults.set(historyMonths, forKey: "analysisHistoryMonths") }
@@ -86,12 +91,34 @@ final class AnalysisStore {
 
       cachedHistoryMonths = historyMonths
       cachedForecastMonths = forecastMonths
+      lastLoadedAt = Date()
     } catch {
       logger.error("Failed to load analysis data: \(error)")
       self.error = error
     }
 
     isLoading = false
+  }
+
+  /// Reloads analysis data only if it has been at least `minimumInterval` seconds since
+  /// the last successful `loadAll()`. Called on scene phase transitions from background
+  /// to active — the app briefly going inactive (share sheet, Command-Tab, notification
+  /// banner) should not trigger a disruptive reload.
+  ///
+  /// Always loads if no data has been loaded yet.
+  func refreshIfStale(minimumInterval: TimeInterval) async {
+    if let last = lastLoadedAt,
+      Date().timeIntervalSince(last) < minimumInterval
+    {
+      return
+    }
+    await loadAll()
+  }
+
+  /// Test hook: allows tests to rewind `lastLoadedAt` to simulate staleness without
+  /// waiting real time. Not intended for production use.
+  func overrideLastLoadedAtForTesting(_ date: Date?) {
+    lastLoadedAt = date
   }
 
   /// Extends balance data to fill gaps, matching the web app's extrapolateBalances logic:

--- a/Features/Analysis/Views/AnalysisView.swift
+++ b/Features/Analysis/Views/AnalysisView.swift
@@ -68,9 +68,12 @@ struct AnalysisView: View {
     .onChange(of: store.forecastMonths) { _, _ in
       Task { await store.loadAll() }
     }
-    .onChange(of: scenePhase) { _, newPhase in
-      if newPhase == .active {
-        Task { await store.loadAll() }
+    .onChange(of: scenePhase) { oldPhase, newPhase in
+      // Only refresh when returning from the background (not from brief inactive
+      // states like share sheets, system dialogs, or Command-Tab). Use a staleness
+      // threshold to avoid disruptive reloads when the app has just been loaded.
+      if oldPhase == .background && newPhase == .active {
+        Task { await store.refreshIfStale(minimumInterval: 60) }
       }
     }
   }

--- a/MoolahTests/Features/AnalysisStoreTests.swift
+++ b/MoolahTests/Features/AnalysisStoreTests.swift
@@ -70,6 +70,74 @@ struct AnalysisStoreFilterPersistenceTests {
   }
 }
 
+@Suite("AnalysisStore — refreshIfStale")
+@MainActor
+struct AnalysisStoreRefreshIfStaleTests {
+
+  private func makeDefaults() -> UserDefaults {
+    let suiteName = "com.moolah.test.\(UUID().uuidString)"
+    let defaults = UserDefaults(suiteName: suiteName)!
+    defaults.removePersistentDomain(forName: suiteName)
+    return defaults
+  }
+
+  @Test("loads when no data has been loaded yet")
+  func loadsWhenNoDataLoaded() async throws {
+    let (backend, _) = try TestBackend.create()
+    let store = AnalysisStore(
+      repository: backend.analysis, defaults: makeDefaults())
+
+    #expect(store.lastLoadedAt == nil)
+    await store.refreshIfStale(minimumInterval: 60)
+    #expect(store.lastLoadedAt != nil)
+  }
+
+  @Test("reloads when elapsed time exceeds minimum interval")
+  func reloadsWhenStale() async throws {
+    let (backend, _) = try TestBackend.create()
+    let store = AnalysisStore(
+      repository: backend.analysis, defaults: makeDefaults())
+
+    await store.loadAll()
+    let firstLoad = store.lastLoadedAt
+    #expect(firstLoad != nil)
+
+    // Simulate a stale load by rewinding lastLoadedAt.
+    let staleDate = Date().addingTimeInterval(-120)
+    store.overrideLastLoadedAtForTesting(staleDate)
+
+    await store.refreshIfStale(minimumInterval: 60)
+    #expect(store.lastLoadedAt != nil)
+    #expect(store.lastLoadedAt! > staleDate)
+  }
+
+  @Test("skips reload when elapsed time is within minimum interval")
+  func skipsReloadWhenFresh() async throws {
+    let (backend, _) = try TestBackend.create()
+    let store = AnalysisStore(
+      repository: backend.analysis, defaults: makeDefaults())
+
+    await store.loadAll()
+    let firstLoad = store.lastLoadedAt
+    #expect(firstLoad != nil)
+
+    await store.refreshIfStale(minimumInterval: 60)
+    // Should NOT have reloaded — timestamp unchanged.
+    #expect(store.lastLoadedAt == firstLoad)
+  }
+
+  @Test("loadAll updates lastLoadedAt on success")
+  func loadAllUpdatesTimestampOnSuccess() async throws {
+    let (backend, _) = try TestBackend.create()
+    let store = AnalysisStore(
+      repository: backend.analysis, defaults: makeDefaults())
+
+    #expect(store.lastLoadedAt == nil)
+    await store.loadAll()
+    #expect(store.lastLoadedAt != nil)
+  }
+}
+
 @Suite("AnalysisStore — categoriesOverTime")
 @MainActor
 struct AnalysisStoreCategoriesOverTimeTests {


### PR DESCRIPTION
Fixes #124.

## Summary
- `AnalysisView` previously reloaded on every `scenePhase == .active` transition, which fires when returning from share sheets, system dialogs, notification banners, or Command-Tab. The result was a disruptive loading flash.
- Restrict the reload to genuine `background → active` transitions.
- Add `AnalysisStore.refreshIfStale(minimumInterval:)` gated behind a 60s staleness window so even a real background→active reload is skipped if data was just fetched.

## Judgment calls
- Chose **both** guards from the issue ("only reload on background→active" AND "staleness threshold") — either alone has edge cases (the former still reloads the full screen even if the user backgrounded for 2 seconds; the latter alone does unnecessary work comparing timestamps on every .inactive → .active transition).
- 60s threshold chosen to balance "user has been away long enough to want fresh data" against "avoid reload storms when foregrounding briefly." Easy to tune later.
- `overrideLastLoadedAtForTesting(_:)` rather than injecting a clock — consistent with how the existing tests in this file use direct UserDefaults manipulation rather than abstraction.

## Test plan
- [x] `AnalysisStoreRefreshIfStaleTests` — new suite covering: loads when no prior data, reloads when stale, skips when fresh, `loadAll` updates timestamp on success.
- [ ] CI: `just test` on macOS + iOS.

https://claude.ai/code/session_01DB7AH6JLVvckAp6LPsxBEM