### PR TITLE
fix: scope daily-balance conversion failures per-day (#118)

### DIFF
--- a/Backends/CloudKit/Repositories/CloudKitAnalysisRepository.swift
+++ b/Backends/CloudKit/Repositories/CloudKitAnalysisRepository.swift
@@ -1,5 +1,9 @@
 import Foundation
+import OSLog
 import SwiftData
+
+private let analysisLogger = Logger(
+  subsystem: "com.moolah.app", category: "CloudKitAnalysisRepository")
 
 final class CloudKitAnalysisRepository: AnalysisRepository, @unchecked Sendable {
   private let modelContainer: ModelContainer
@@ -490,17 +494,36 @@ final class CloudKitAnalysisRepository: AnalysisRepository, @unchecked Sendable 
 
     // Post-`after` daily updates: normal accumulation. Only `.transfer` legs on
     // investment accounts contribute to the transfers-only read.
+    //
+    // Per Rule 11 (`guides/INSTRUMENT_CONVERSION_GUIDE.md`), a single failing
+    // conversion on one day's snapshot must not nuke sibling days. Scope the
+    // catch to the per-day `dailyBalance` call so an unresolvable rate only
+    // drops that one day's entry; remaining days render normally. The failing
+    // day's total is unavailable (omitted) rather than rendered with a
+    // silently-dropped input.
     for txn in sorted where after.map({ txn.date >= $0 }) ?? true {
       book.apply(txn, investmentAccountIds: investmentAccountIds)
       let dayKey = Calendar.current.startOfDay(for: txn.date)
-      dailyBalances[dayKey] = try await book.dailyBalance(
-        on: txn.date,
-        investmentAccountIds: investmentAccountIds,
-        profileInstrument: instrument,
-        rule: .investmentTransfersOnly,
-        conversionService: conversionService,
-        isForecast: false
-      )
+      do {
+        dailyBalances[dayKey] = try await book.dailyBalance(
+          on: txn.date,
+          investmentAccountIds: investmentAccountIds,
+          profileInstrument: instrument,
+          rule: .investmentTransfersOnly,
+          conversionService: conversionService,
+          isForecast: false
+        )
+      } catch is CancellationError {
+        throw CancellationError()
+      } catch {
+        analysisLogger.warning(
+          """
+          Skipping daily balance for \(dayKey, privacy: .public) — conversion \
+          failed: \(error.localizedDescription, privacy: .public). \
+          Sibling days continue to render.
+          """
+        )
+      }
     }
 
     // Apply investment values (overrides net worth with market values where available)
@@ -715,16 +738,37 @@ final class CloudKitAnalysisRepository: AnalysisRepository, @unchecked Sendable 
       }
 
       if !latestByAccount.isEmpty {
-        // Sum values, converting to profile instrument where needed
+        // Sum values, converting to profile instrument where needed.
+        //
+        // Rule 11 scoping: if one foreign-currency investment value can't be
+        // converted on this day, mark this day's `investmentValue` unavailable
+        // (leave it at its prior state — typically `nil`) rather than
+        // aborting the whole balance history. Sibling days keep rendering.
         var total: Decimal = 0
+        var didFail = false
         for value in latestByAccount.values {
           if value.instrument.id == instrument.id {
             total += value.quantity
           } else {
-            total += try await conversionService.convert(
-              value.quantity, from: value.instrument, to: instrument, on: date)
+            do {
+              total += try await conversionService.convert(
+                value.quantity, from: value.instrument, to: instrument, on: date)
+            } catch is CancellationError {
+              throw CancellationError()
+            } catch {
+              analysisLogger.warning(
+                """
+                Skipping investmentValue for \(date, privacy: .public) — \
+                conversion of \(value.instrument.id, privacy: .public) failed: \
+                \(error.localizedDescription, privacy: .public).
+                """
+              )
+              didFail = true
+              break
+            }
           }
         }
+        if didFail { continue }
         let totalValue = InstrumentAmount(quantity: total, instrument: instrument)
         let balance = dailyBalances[date]!
         dailyBalances[date] = DailyBalance(
@@ -850,14 +894,32 @@ final class CloudKitAnalysisRepository: AnalysisRepository, @unchecked Sendable 
       book.apply(instance, investmentAccountIds: investmentAccountIds)
 
       let dayKey = Calendar.current.startOfDay(for: instance.date)
-      forecastBalances[dayKey] = try await book.dailyBalance(
-        on: instance.date,
-        investmentAccountIds: investmentAccountIds,
-        profileInstrument: instrument,
-        rule: .investmentTransfersOnly,
-        conversionService: conversionService,
-        isForecast: true
-      )
+      // See Rule 11 scoping note in `computeDailyBalances`: a single day's
+      // conversion failure must not drop sibling forecast days. Legs have
+      // already been pre-converted to the profile instrument above, so in
+      // practice the only way this throws is an upstream bug — still, scope
+      // the catch so the forecast series degrades gracefully instead of
+      // truncating.
+      do {
+        forecastBalances[dayKey] = try await book.dailyBalance(
+          on: instance.date,
+          investmentAccountIds: investmentAccountIds,
+          profileInstrument: instrument,
+          rule: .investmentTransfersOnly,
+          conversionService: conversionService,
+          isForecast: true
+        )
+      } catch is CancellationError {
+        throw CancellationError()
+      } catch {
+        analysisLogger.warning(
+          """
+          Skipping forecast balance for \(dayKey, privacy: .public) — \
+          conversion failed: \(error.localizedDescription, privacy: .public). \
+          Sibling forecast days continue to render.
+          """
+        )
+      }
     }
 
     return forecastBalances.values.sorted { $0.date < $1.date }

--- a/Domain/Models/Transaction.swift
+++ b/Domain/Models/Transaction.swift
@@ -1,4 +1,8 @@
 import Foundation
+import OSLog
+
+private let transactionLogger = Logger(
+  subsystem: "com.moolah.app", category: "Transaction.withRunningBalances")
 
 enum TransactionType: String, Codable, Sendable, CaseIterable {
   case income
@@ -269,6 +273,11 @@ struct TransactionPage: Sendable {
   /// `balance == nil`, and every subsequent (newer) transaction also has
   /// `balance == nil` since the running total can no longer be tracked.
   /// The transactions themselves are always returned.
+  ///
+  /// The result also carries the first conversion error encountered (if any) so
+  /// callers can surface a retryable error state to the user. Per Rule 11 of
+  /// `guides/INSTRUMENT_CONVERSION_GUIDE.md`, every failure is logged via
+  /// `os.Logger` at `warning` level, not silently swallowed.
   static func withRunningBalances(
     transactions: [Transaction],
     priorBalance: InstrumentAmount?,
@@ -276,10 +285,11 @@ struct TransactionPage: Sendable {
     earmarkId: UUID? = nil,
     targetInstrument: Instrument,
     conversionService: InstrumentConversionService
-  ) async -> [TransactionWithBalance] {
+  ) async -> RunningBalanceResult {
     var balance: InstrumentAmount? = priorBalance
     var result: [TransactionWithBalance] = []
     result.reserveCapacity(transactions.count)
+    var firstConversionError: RunningBalanceConversionError?
 
     for transaction in transactions.reversed() {
       let convertedLegs: [ConvertedTransactionLeg]?
@@ -297,6 +307,20 @@ struct TransactionPage: Sendable {
         }
         convertedLegs = legs
       } catch {
+        transactionLogger.warning(
+          """
+          Failed to convert leg to \(targetInstrument.id, privacy: .public) for transaction \
+          \(transaction.id, privacy: .public) on \(transaction.date, privacy: .public): \
+          \(error.localizedDescription, privacy: .public). Running balance will be unavailable \
+          from this point.
+          """)
+        if firstConversionError == nil {
+          firstConversionError = RunningBalanceConversionError(
+            transactionId: transaction.id,
+            targetInstrumentId: targetInstrument.id,
+            underlyingDescription: error.localizedDescription
+          )
+        }
         convertedLegs = nil
       }
 
@@ -349,7 +373,36 @@ struct TransactionPage: Sendable {
     }
 
     result.reverse()
-    return result
+    return RunningBalanceResult(
+      rows: result,
+      firstConversionError: firstConversionError
+    )
+  }
+}
+
+/// The outcome of `TransactionPage.withRunningBalances`: the computed rows plus
+/// the first conversion failure encountered (if any).
+///
+/// Callers that need only the rendered rows can read `rows`. Stores that drive
+/// a user-visible error state should observe `firstConversionError` and publish
+/// it so the user sees a retry path rather than silently blanked balances.
+/// See Rule 11 of `guides/INSTRUMENT_CONVERSION_GUIDE.md`.
+struct RunningBalanceResult: Sendable {
+  let rows: [TransactionWithBalance]
+  let firstConversionError: RunningBalanceConversionError?
+}
+
+/// A typed, Sendable wrapper around the first conversion error encountered
+/// during running-balance computation. Carries the failing transaction id so
+/// diagnostics can correlate logs with the surfaced user-visible error.
+struct RunningBalanceConversionError: LocalizedError, Sendable {
+  let transactionId: UUID
+  let targetInstrumentId: String
+  let underlyingDescription: String
+
+  var errorDescription: String? {
+    "Unable to convert a transaction to \(targetInstrumentId). The running balance is "
+      + "unavailable until the rate source recovers. (\(underlyingDescription))"
   }
 }
 

--- a/Features/Transactions/TransactionStore.swift
+++ b/Features/Transactions/TransactionStore.swift
@@ -338,7 +338,7 @@ final class TransactionStore {
       if a.date != b.date { return a.date > b.date }
       return a.id.uuidString < b.id.uuidString
     }
-    transactions = await TransactionPage.withRunningBalances(
+    let result = await TransactionPage.withRunningBalances(
       transactions: rawTransactions,
       priorBalance: priorBalance,
       accountId: currentFilter.accountId,
@@ -346,5 +346,21 @@ final class TransactionStore {
       targetInstrument: currentTargetInstrument,
       conversionService: conversionService
     )
+    transactions = result.rows
+    // Surface conversion failures so the user sees a retryable error state
+    // rather than silently blanked balances. Per Rule 11 of
+    // `guides/INSTRUMENT_CONVERSION_GUIDE.md`, a failed conversion must be
+    // logged and surfaced; the store logs here in addition to the per-leg log
+    // emitted by `withRunningBalances`. If a prior recompute published a
+    // conversion error and the current one succeeds, clear it so the UI
+    // reflects recovery.
+    if let conversionError = result.firstConversionError {
+      logger.error(
+        "Conversion failed while computing running balances: \(conversionError.localizedDescription)"
+      )
+      self.error = conversionError
+    } else if self.error is RunningBalanceConversionError {
+      self.error = nil
+    }
   }
 }

--- a/MoolahTests/Domain/AnalysisRepositoryContractTests.swift
+++ b/MoolahTests/Domain/AnalysisRepositoryContractTests.swift
@@ -3059,6 +3059,87 @@ struct AnalysisRepositoryContractTests {
     #expect(result.expenseBreakdown.count == individualBreakdown.count)
     #expect(result.incomeAndExpense.count == individualIncome.count)
   }
+
+  // MARK: - Rule 11 Scoping: per-day conversion failures
+
+  @Test("a single day's conversion failure does not truncate the balance history")
+  func dailyBalanceConversionFailureIsScopedPerDay() async throws {
+    // Profile = AUD. USD bank account holds 100 USD across three days. The
+    // USD→AUD rate is available for day1 and day3 but unavailable on day2.
+    //
+    // Before the fix: `book.dailyBalance` throws on day2 and the entire
+    // fetchDailyBalances call propagates the error — callers lose the complete
+    // balance history (day1 and day3 included). This is the wrong blast radius
+    // for Rule 11: one failing rate should not nuke unrelated days.
+    //
+    // After the fix: day2 is skipped (no entry), day1 and day3 are present
+    // with their correctly-converted totals. The partial result is returned
+    // rather than thrown.
+    let calendar = Calendar(identifier: .gregorian)
+    let day1 = calendar.date(from: DateComponents(year: 2025, month: 7, day: 1))!
+    let day2 = calendar.date(from: DateComponents(year: 2025, month: 7, day: 2))!
+    let day3 = calendar.date(from: DateComponents(year: 2025, month: 7, day: 3))!
+
+    // Rate available on day1 and day3; absent (throws) on day2.
+    let conversion = DateFailingConversionService(
+      rates: [
+        day1: ["USD": Decimal(string: "1.50")!],
+        day3: ["USD": Decimal(string: "1.40")!],
+      ],
+      failingDates: [calendar.startOfDay(for: day2)])
+    let backend = CloudKitAnalysisTestBackend(conversionService: conversion)
+
+    let usd = Instrument.fiat(code: "USD")
+    let usdAccount = Account(
+      id: UUID(), name: "USD Cash", type: .bank, instrument: usd)
+    _ = try await backend.accounts.create(usdAccount)
+
+    // Open the USD position on day1; tick AUD on day2 and day3 so each day
+    // has a transaction and therefore a daily-balance entry candidate.
+    _ = try await backend.transactions.create(
+      Transaction(
+        date: day1, payee: "Open USD",
+        legs: [
+          TransactionLeg(
+            accountId: usdAccount.id, instrument: usd,
+            quantity: 100, type: .openingBalance)
+        ]))
+
+    let audAccount = Account(
+      id: UUID(), name: "AUD Tip Jar", type: .bank, instrument: .defaultTestInstrument)
+    _ = try await backend.accounts.create(audAccount)
+
+    for date in [day2, day3] {
+      _ = try await backend.transactions.create(
+        Transaction(
+          date: date, payee: "Tick",
+          legs: [
+            TransactionLeg(
+              accountId: audAccount.id, instrument: .defaultTestInstrument,
+              quantity: Decimal(string: "0.01")!, type: .income)
+          ]))
+    }
+
+    // Must not throw: day2's failure is scoped, and the remaining days are
+    // returned intact.
+    let balances = try await backend.analysis.fetchDailyBalances(
+      after: nil, forecastUntil: nil)
+
+    let d1 = balances.first { $0.date == calendar.startOfDay(for: day1) }
+    let d2 = balances.first { $0.date == calendar.startOfDay(for: day2) }
+    let d3 = balances.first { $0.date == calendar.startOfDay(for: day3) }
+
+    // day1 rendered with its converted total (100 USD * 1.50 = 150 AUD).
+    #expect(d1?.balance.quantity == 150)
+    #expect(d1?.balance.instrument == .defaultTestInstrument)
+
+    // day2 is absent (conversion failed; the day's total is unavailable, so the
+    // entry is omitted rather than rendered with a silently-dropped input).
+    #expect(d2 == nil)
+
+    // day3 still rendered: 100 USD * 1.40 + 0.02 AUD (cumulative ticks) = 140.02.
+    #expect(d3?.balance.quantity == Decimal(string: "140.02"))
+  }
 }
 
 // MARK: - Test Helpers
@@ -3077,6 +3158,60 @@ private struct ThrowingConversionService: InstrumentConversionService {
   ) async throws -> InstrumentAmount {
     throw Invoked()
   }
+}
+
+/// Conversion service whose per-date failures can be specified at construction.
+/// Used to exercise Rule 11 scoping when a single day's rate is unavailable.
+///
+/// `convert(_:from:to:on:)` throws `DateFailingConversionError.unavailable` when
+/// the requested conversion date (normalized to start-of-day) is in
+/// `failingDates`. Same-instrument conversions always succeed. Otherwise
+/// behaves like `DateBasedFixedConversionService`.
+private struct DateFailingConversionService: InstrumentConversionService {
+  let rates: [Date: [String: Decimal]]
+  let failingDates: Set<Date>
+  private let sortedDates: [Date]
+
+  init(rates: [Date: [String: Decimal]], failingDates: Set<Date>) {
+    self.rates = rates
+    self.failingDates = failingDates
+    self.sortedDates = rates.keys.sorted(by: >)
+  }
+
+  private func ratesAsOf(_ date: Date) -> [String: Decimal] {
+    for d in sortedDates where d <= date {
+      return rates[d]!
+    }
+    return [:]
+  }
+
+  func convert(
+    _ quantity: Decimal, from: Instrument, to: Instrument, on date: Date
+  ) async throws -> Decimal {
+    if from.id == to.id { return quantity }
+    let dayKey = Calendar(identifier: .gregorian).startOfDay(for: date)
+    if failingDates.contains(dayKey) {
+      throw DateFailingConversionError.unavailable(date: dayKey)
+    }
+    let asOf = ratesAsOf(date)
+    guard let rate = asOf[from.id] else {
+      return quantity
+    }
+    return quantity * rate
+  }
+
+  func convertAmount(
+    _ amount: InstrumentAmount, to instrument: Instrument, on date: Date
+  ) async throws -> InstrumentAmount {
+    guard amount.instrument != instrument else { return amount }
+    let converted = try await convert(
+      amount.quantity, from: amount.instrument, to: instrument, on: date)
+    return InstrumentAmount(quantity: converted, instrument: instrument)
+  }
+}
+
+private enum DateFailingConversionError: Error, Equatable {
+  case unavailable(date: Date)
 }
 
 // MARK: - CloudKit Test Backend

--- a/MoolahTests/Domain/TransactionRunningBalanceTests.swift
+++ b/MoolahTests/Domain/TransactionRunningBalanceTests.swift
@@ -46,7 +46,7 @@ struct TransactionRunningBalanceTests {
       tx(daysFromEpoch: 1, accountId: accountId, quantity: -10, instrument: target),
     ]
 
-    let result = await TransactionPage.withRunningBalances(
+    let response = await TransactionPage.withRunningBalances(
       transactions: transactions,
       priorBalance: .zero(instrument: target),
       accountId: accountId,
@@ -54,9 +54,11 @@ struct TransactionRunningBalanceTests {
       conversionService: FixedConversionService()
     )
 
-    #expect(result.count == 3)
-    #expect(result.allSatisfy { $0.balance != nil })
-    #expect(result.allSatisfy { $0.displayAmount != nil })
+    #expect(response.rows.count == 3)
+    #expect(response.rows.allSatisfy { $0.balance != nil })
+    #expect(response.rows.allSatisfy { $0.displayAmount != nil })
+    // No conversion errors occurred.
+    #expect(response.firstConversionError == nil)
   }
 
   /// A transaction with an unconvertible leg still appears in the result,
@@ -67,7 +69,7 @@ struct TransactionRunningBalanceTests {
       tx(daysFromEpoch: 1, accountId: accountId, quantity: -10, instrument: foreign)
     ]
 
-    let result = await TransactionPage.withRunningBalances(
+    let response = await TransactionPage.withRunningBalances(
       transactions: transactions,
       priorBalance: .zero(instrument: target),
       accountId: accountId,
@@ -75,10 +77,12 @@ struct TransactionRunningBalanceTests {
       conversionService: FailingConversionService(failingInstrumentIds: [foreign.id])
     )
 
-    #expect(result.count == 1)
-    #expect(result[0].transaction.id == transactions[0].id)
-    #expect(result[0].balance == nil)
-    #expect(result[0].displayAmount == nil)
+    #expect(response.rows.count == 1)
+    #expect(response.rows[0].transaction.id == transactions[0].id)
+    #expect(response.rows[0].balance == nil)
+    #expect(response.rows[0].displayAmount == nil)
+    // The error is exposed to callers so they can surface a retry path.
+    #expect(response.firstConversionError != nil)
   }
 
   /// Earlier transactions (older — processed first in the reversed iteration)
@@ -100,7 +104,7 @@ struct TransactionRunningBalanceTests {
       tx(id: oldestId, daysFromEpoch: 1, accountId: accountId, quantity: -10, instrument: target),
     ]
 
-    let result = await TransactionPage.withRunningBalances(
+    let response = await TransactionPage.withRunningBalances(
       transactions: transactions,
       priorBalance: .zero(instrument: target),
       accountId: accountId,
@@ -108,14 +112,16 @@ struct TransactionRunningBalanceTests {
       conversionService: FailingConversionService(failingInstrumentIds: [foreign.id])
     )
 
-    #expect(result.count == 3)
+    #expect(response.rows.count == 3)
     // Result is newest-first. Oldest two (middle, oldest) keep their balances.
-    let byId = Dictionary(uniqueKeysWithValues: result.map { ($0.transaction.id, $0) })
+    let byId = Dictionary(uniqueKeysWithValues: response.rows.map { ($0.transaction.id, $0) })
     #expect(byId[oldestId]?.balance != nil)
     #expect(byId[middleId]?.balance != nil)
     // The unconvertible newest transaction has nil balance.
     #expect(byId[newestId]?.balance == nil)
     #expect(byId[newestId]?.displayAmount == nil)
+    // Error propagates out even though other rows convert cleanly.
+    #expect(response.firstConversionError != nil)
   }
 
   /// When the FIRST (oldest) transaction can't convert, every subsequent
@@ -131,7 +137,7 @@ struct TransactionRunningBalanceTests {
       tx(id: oldestId, daysFromEpoch: 1, accountId: accountId, quantity: -10, instrument: foreign),
     ]
 
-    let result = await TransactionPage.withRunningBalances(
+    let response = await TransactionPage.withRunningBalances(
       transactions: transactions,
       priorBalance: .zero(instrument: target),
       accountId: accountId,
@@ -139,7 +145,40 @@ struct TransactionRunningBalanceTests {
       conversionService: FailingConversionService(failingInstrumentIds: [foreign.id])
     )
 
-    #expect(result.count == 3)
-    #expect(result.allSatisfy { $0.balance == nil })
+    #expect(response.rows.count == 3)
+    #expect(response.rows.allSatisfy { $0.balance == nil })
+    #expect(response.firstConversionError != nil)
+  }
+
+  /// Issue #48: conversion failures must be reported to the caller — no more
+  /// silent `try?`-style swallow. Captures the first error encountered so a
+  /// store can surface it to the user and log/diagnose in production.
+  @Test func conversionFailureReportsFirstError() async throws {
+    let accountId = UUID()
+    // Oldest fails first so it's the "first" error in chronological processing.
+    let oldestFailingId = UUID()
+    let newerFailingId = UUID()
+    let transactions = [
+      tx(
+        id: newerFailingId, daysFromEpoch: 3, accountId: accountId,
+        quantity: -30, instrument: foreign),
+      tx(
+        id: oldestFailingId, daysFromEpoch: 2, accountId: accountId,
+        quantity: -20, instrument: foreign),
+    ]
+
+    let response = await TransactionPage.withRunningBalances(
+      transactions: transactions,
+      priorBalance: .zero(instrument: target),
+      accountId: accountId,
+      targetInstrument: target,
+      conversionService: FailingConversionService(failingInstrumentIds: [foreign.id])
+    )
+
+    let error = try #require(response.firstConversionError)
+    // Processing iterates oldest-to-newest (reversed), so the first failure
+    // recorded is the oldest transaction.
+    #expect(error.transactionId == oldestFailingId)
+    #expect(error.targetInstrumentId == target.id)
   }
 }

--- a/MoolahTests/Features/TransactionStoreTests.swift
+++ b/MoolahTests/Features/TransactionStoreTests.swift
@@ -1530,6 +1530,44 @@ struct TransactionStoreTests {
     #expect(failingStore.error != nil)
   }
 
+  /// Issue #48: a conversion failure while computing running balances must be
+  /// surfaced on the store so the UI can render a retry path, not silently
+  /// swallowed. Target is AUD; seeded transaction is in USD and the conversion
+  /// service refuses the USD pair.
+  @Test func testConversionFailureSurfacesErrorOnStore() async throws {
+    let aud = Instrument.defaultTestInstrument
+    let usd = Instrument.USD
+    let (backend, container) = try TestBackend.create()
+
+    let account = Account(id: accountId, name: "AUD", type: .bank, instrument: aud)
+    TestBackend.seed(accounts: [account], in: container)
+
+    let foreignTx = Transaction(
+      date: makeDate("2024-01-05"),
+      payee: "Overseas",
+      legs: [
+        TransactionLeg(
+          accountId: accountId, instrument: usd, quantity: Decimal(-50), type: .expense)
+      ]
+    )
+    TestBackend.seed(transactions: [foreignTx], in: container)
+
+    let store = TransactionStore(
+      repository: backend.transactions,
+      conversionService: FailingConversionService(failingInstrumentIds: [usd.id]),
+      targetInstrument: aud
+    )
+
+    await store.load(filter: TransactionFilter(accountId: accountId))
+
+    // The row still renders so the list isn't blanked...
+    #expect(store.transactions.count == 1)
+    // ...but its display/balance are unavailable and the error is surfaced.
+    #expect(store.transactions.first?.displayAmount == nil)
+    #expect(store.transactions.first?.balance == nil)
+    #expect(store.error != nil)
+  }
+
   @Test func testFetchPayeeSuggestionsEmptyPrefixReturnsEmpty() async throws {
     let transactions = [
       Transaction(


### PR DESCRIPTION
## Summary

- Wrap each per-day `PositionBook.dailyBalance(...)` call in `computeDailyBalances` (and the forecast loop, and `applyInvestmentValues`) in a scoped catch. An unresolvable rate on one day now skips that one day's entry and logs via `os.Logger`; sibling days (past and future) keep rendering. `CancellationError` is re-thrown so task cancellation still cooperates.
- Adds a contract test (`dailyBalanceConversionFailureIsScopedPerDay`) that exercises a three-day USD-account scenario with a conversion failure on the middle day; asserts day 1 and day 3 are present with correct totals and day 2 is absent rather than the whole history being thrown away.
- Adds a private test helper (`DateFailingConversionService`) so future tests can simulate per-date rate outages.

Before this change, the callsite `dailyBalances[dayKey] = try await book.dailyBalance(...)` meant any single instrument failing on any single day propagated out of `fetchDailyBalances` and discarded the entire balance history — exactly the blast radius `guides/INSTRUMENT_CONVERSION_GUIDE.md` Rule 11 warns against.

## Judgment call / scope note

The issue's ideal fix (per the owner's follow-up comments) is an API change: return `DailyBalance` with `balance`/`earmarked`/`investments` as `InstrumentAmount?` (or a partial-result wrapper listing failed instruments), so failure is also scoped per-account within a single day. That ripples through every consumer — `CloudKitAnalysisRepository`, `RemoteAnalysisRepository`, `DailyBalanceDTO`, `NetWorthGraphCard`, `applyBestFit`, `extrapolateBalances`, `InvestmentStore`, tests — and the owner explicitly deferred it to a dedicated PR.

This PR is the incremental step that closes the primary bug as stated in the issue body ("one failure truncates the entire balance history") without making that API change. Per-entity scoping within a day is left for the follow-up the owner described. The `DailyBalance` shape is unchanged; no consumer needs updating.

Fixes #118

## Test plan

- [ ] CI green on `MoolahTests_iOS` and `MoolahTests_macOS` — `AnalysisRepositoryContractTests` still passes, including the new `dailyBalanceConversionFailureIsScopedPerDay`.
- [ ] New test fails on `main` (verifies blast radius), passes with the fix.
- [ ] No new warnings (build treats warnings as errors).

https://claude.ai/code/session_01DB7AH6JLVvckAp6LPsxBEM