### PR TITLE
Phase 7: ShowHiddenCommands verb-pair fix

### DIFF
--- a/App/MoolahApp.swift
+++ b/App/MoolahApp.swift
@@ -43,16 +43,21 @@ struct RefreshCommands: Commands {
   }
 }
 
-/// View menu toggle for showing hidden accounts and earmarks
+/// View menu verb-pair for showing / hiding hidden accounts and earmarks.
+/// Uses a Button with a flipped label (per §14 "Toggle State") and stays
+/// visible when no window is focused — disabled per §14 "Disable, don't hide".
 struct ShowHiddenCommands: Commands {
   @FocusedValue(\.showHiddenAccounts) private var showHidden
 
   var body: some Commands {
     CommandGroup(after: .sidebar) {
-      if let showHidden {
-        Toggle("Show Hidden Accounts", isOn: showHidden)
-          .keyboardShortcut("h", modifiers: [.command, .shift])
+      Button(
+        showHidden?.wrappedValue == true ? "Hide Hidden Accounts" : "Show Hidden Accounts"
+      ) {
+        showHidden?.wrappedValue.toggle()
       }
+      .keyboardShortcut("h", modifiers: [.command, .shift])
+      .disabled(showHidden == nil)
     }
   }
 }


### PR DESCRIPTION
## Summary

Phase 7 of `plans/2026-04-17-menu-bar-compliance-plan.md`. Stacked on #187.

Replaces the `Toggle` in `ShowHiddenCommands` with a `Button` whose label flips between **Show Hidden Accounts** and **Hide Hidden Accounts**. The button is always registered; when no window is focused it's disabled instead of hidden, so the View menu layout doesn't shift and the ⇧⌘H shortcut namespace is preserved.

Closes findings **3.1, 8.3**.

## Test plan

- [ ] CI build passes
- [ ] View menu always contains the item (disabled when no window focused)
- [ ] Label flips with state
- [ ] ⇧⌘H toggles

https://claude.ai/code/session_015qvTebgEgfxLCXs1GTkzsh