### PR TITLE
docs: sync plans with current code state

### DIFF
--- a/plans/2026-04-17-menu-bar-compliance-plan.md
+++ b/plans/2026-04-17-menu-bar-compliance-plan.md
@@ -164,16 +164,21 @@ git commit -m "docs: remove single-key shortcut annotations from Transaction men
 
 ---
 
-## Phase 1: Focused Value Foundation
+## Phase 1: Focused Value Foundation ✅ Complete
 
 All subsequent menu-bar commands operate on selection. Centralize the selection state via `@FocusedValue` first so later phases can consume it without circular changes.
+
+Status verified 2026-04-18:
+- `Shared/FocusedValues.swift` contains all eleven focused value keys listed in Task 1.1.
+- `TransactionListView.swift:105` and `UpcomingView.swift:24` publish `selectedTransaction`.
+- `SidebarView.swift:187–188` publish `sidebarSelection` and `selectedAccount`; `EarmarksView.swift:97` publishes `selectedEarmark`; `CategoriesView.swift:99` publishes `selectedCategory`.
 
 ### Task 1.1: Add focused value keys for selection state
 
 **Files:**
 - Modify: `Shared/FocusedValues.swift`
 
-- [ ] **Step 1: Add new focused value keys**
+- [x] **Step 1: Add new focused value keys**
 
 Replace the contents of `Shared/FocusedValues.swift` with:
 
@@ -292,7 +297,7 @@ extension FocusedValues {
 }
 ```
 
-- [ ] **Step 2: Build — verify warning-free compile**
+- [x] **Step 2: Build — verify warning-free compile**
 
 ```bash
 just build-mac 2>&1 | tee .agent-tmp/phase1-build.txt
@@ -300,7 +305,7 @@ grep -i 'warning\|error' .agent-tmp/phase1-build.txt
 ```
 Expected: No warnings, no errors.
 
-- [ ] **Step 3: Commit**
+- [x] **Step 3: Commit**
 
 ```bash
 git add Shared/FocusedValues.swift
@@ -311,13 +316,13 @@ git commit -m "feat: add focused value keys for menu selection state"
 
 **Files:**
 - Modify: `Features/Transactions/Views/TransactionListView.swift:104`
-- Modify: `Features/Upcoming/Views/UpcomingView.swift` (wherever list selection is owned)
+- Modify: `Features/Transactions/Views/UpcomingView.swift` (wherever list selection is owned)
 
-- [ ] **Step 1: Find the selection binding in TransactionListView**
+- [x] **Step 1: Find the selection binding in TransactionListView**
 
 Read `Features/Transactions/Views/TransactionListView.swift` and locate `selectedTransactionBinding` (used on line 182 `List(selection: selectedTransactionBinding)`).
 
-- [ ] **Step 2: Publish the binding alongside the existing `newTransactionAction` publication**
+- [x] **Step 2: Publish the binding alongside the existing `newTransactionAction` publication**
 
 At line 104, change:
 
@@ -332,15 +337,15 @@ to:
 .focusedSceneValue(\.selectedTransaction, selectedTransactionBinding)
 ```
 
-- [ ] **Step 3: Same publication for UpcomingView**
+- [x] **Step 3: Same publication for UpcomingView**
 
-Read `Features/Upcoming/Views/UpcomingView.swift`. Locate its selection state (likely `@State private var selectedTransaction: Transaction?` and a `List(selection:)`). Append to its root view modifier:
+Read `Features/Transactions/Views/UpcomingView.swift`. Locate its selection state (`@State private var selectedTransaction: Transaction?` and a `List(selection:)`). Append to its root view modifier:
 
 ```swift
 .focusedSceneValue(\.selectedTransaction, $selectedTransaction)
 ```
 
-- [ ] **Step 4: Build**
+- [x] **Step 4: Build**
 
 ```bash
 just build-mac 2>&1 | tee .agent-tmp/phase1-build.txt
@@ -348,10 +353,10 @@ grep -i 'warning\|error' .agent-tmp/phase1-build.txt
 ```
 Expected: clean.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
-git add Features/Transactions/Views/TransactionListView.swift Features/Upcoming/Views/UpcomingView.swift
+git add Features/Transactions/Views/TransactionListView.swift Features/Transactions/Views/UpcomingView.swift
 git commit -m "feat: publish selectedTransaction focused value from list views"
 ```
 
@@ -362,7 +367,7 @@ git commit -m "feat: publish selectedTransaction focused value from list views"
 - Modify: `Features/Earmarks/Views/EarmarksView.swift`
 - Modify: `Features/Categories/Views/CategoriesView.swift`
 
-- [ ] **Step 1: Publish `sidebarSelection` and `selectedAccount` from SidebarView**
+- [x] **Step 1: Publish `sidebarSelection` and `selectedAccount` from SidebarView**
 
 Read `Features/Navigation/SidebarView.swift`. Near the existing `.focusedSceneValue(\.showHiddenAccounts, $showHidden)` at line 181, add:
 
@@ -389,7 +394,7 @@ private var selectedAccountBinding: Binding<Account?> {
 
 Adjust the case matching to match the actual `SidebarSelection` enum shape in the codebase.
 
-- [ ] **Step 2: Publish `selectedEarmark` from EarmarksView**
+- [x] **Step 2: Publish `selectedEarmark` from EarmarksView**
 
 Read `Features/Earmarks/Views/EarmarksView.swift`. Locate its list selection. Add to its root view modifier:
 
@@ -397,7 +402,7 @@ Read `Features/Earmarks/Views/EarmarksView.swift`. Locate its list selection. Ad
 .focusedSceneValue(\.selectedEarmark, $selectedEarmark)
 ```
 
-- [ ] **Step 3: Publish `selectedCategory` from CategoriesView**
+- [x] **Step 3: Publish `selectedCategory` from CategoriesView**
 
 Read `Features/Categories/Views/CategoriesView.swift`. Locate its list selection. Add:
 
@@ -405,7 +410,7 @@ Read `Features/Categories/Views/CategoriesView.swift`. Locate its list selection
 .focusedSceneValue(\.selectedCategory, $selectedCategory)
 ```
 
-- [ ] **Step 4: Build**
+- [x] **Step 4: Build**
 
 ```bash
 just build-mac 2>&1 | tee .agent-tmp/phase1-build.txt
@@ -413,7 +418,7 @@ grep -i 'warning\|error' .agent-tmp/phase1-build.txt
 ```
 Expected: clean.
 
-- [ ] **Step 5: Run tests**
+- [x] **Step 5: Run tests**
 
 ```bash
 just test 2>&1 | tee .agent-tmp/phase1-test.txt
@@ -421,7 +426,7 @@ grep -i 'failed\|error:' .agent-tmp/phase1-test.txt
 ```
 Expected: no new failures.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add Features/Navigation/SidebarView.swift Features/Earmarks/Views/EarmarksView.swift Features/Categories/Views/CategoriesView.swift

--- a/plans/ui-review-remaining-issues.md
+++ b/plans/ui-review-remaining-issues.md
@@ -22,10 +22,6 @@ Metadata row uses `.caption` instead of `.subheadline` per style guide.
 **File:** `Features/Analysis/Views/NetWorthGraphCard.swift`
 Chart Y-axis labels have no currency unit indicator.
 
-### S7. InvestmentAccountView time period picker accessibility
-**File:** `Features/Investments/Views/InvestmentAccountView.swift:193-217`
-Time period picker buttons lack `.accessibilityValue("Selected")`.
-
 ### S8. TransactionListView punctuation inconsistency
 **File:** `Features/Transactions/Views/TransactionListView.swift:282`
 Empty state description punctuation style differs from other views.


### PR DESCRIPTION
## Summary

Review of every document in `plans/` against the current codebase. No
plan has advanced to fully complete since the last sweep (menu-bar
Phase 0 was already marked complete on April 17), so nothing moves to
`plans/completed/`. Two sync fixes land in this PR:

- **Menu-bar compliance plan**: Phase 1 ("Focused Value Foundation") is
  in the code but the checkboxes were unchecked. Marked Phase 1 header
  as ✅ Complete and ticked every `- [ ]` in Tasks 1.1, 1.2, 1.3. Also
  corrected the `UpcomingView.swift` path (it lives in
  `Features/Transactions/Views`, not `Features/Upcoming/Views`).
- **UI review remaining issues**: Removed S7 — `InvestmentAccountView`
  time-period buttons already publish `.accessibilityAddTraits(... .isSelected ...)`
  at lines 218–220. Twelve other findings remain and still match the
  code.

### Plans audited

| File | State | Verdict |
|---|---|---|
| ROADMAP.md | Phases 1–6, 8 done; 7, 9, 10 pending | Accurate — spot-checked Phase 6 follow-ups (instrument override at `TransactionDetailView.swift:561`; no migration UX for profile currency in `SettingsView`) |
| FEATURE_IDEAS.md | Unimplemented ideas | Keep |
| APP_STORE_READINESS.md | All blockers pending | Keep |
| IOS_RELEASE_AUTOMATION_PLAN.md | Milestone 1 ✅, Milestone 2 pending | Accurate — no `APPSTORE_BUILD` gate yet, fastlane + workflows live |
| 2026-04-17-menu-bar-compliance-plan.md | Phase 0 + Phase 1 done | **Updated** to reflect Phase 1 done |
| ui-review-remaining-issues.md | 12 of 13 still present | **Updated** — S7 fixed |
| 2026-04-11-australian-tax-reporting-design.md | Design only | Needs implementation plan (follow-up PR) |
| 2026-04-11-crypto-tracking-design.md | Design only | Needs implementation plan (follow-up PR) |
| csv-import-design.md | Design only | Needs implementation plan (follow-up PR) |

## Test plan

- [ ] Confirm `Shared/FocusedValues.swift` still declares all eleven keys
- [ ] Confirm `SelectedTransaction`, `SelectedAccount`, `SelectedEarmark`, `SelectedCategory`, and `SidebarSelection` are still published from the five listed views
- [ ] Confirm `InvestmentAccountView` still sets `.accessibilityAddTraits(... .isSelected ...)` on time-period buttons

https://claude.ai/code/session_016eyszazsmhrfQLiDgo8Q8M