### PR TITLE
ci: enforce swift-format on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,8 @@ jobs:
       - name: Validate App Store requirements
         run: just validate-appstore
 
-      - name: Format
-        run: just lint
+      - name: Format check
+        run: just format-check
 
       - name: Test
         run: just test

--- a/Automation/Intents/GetExpenseBreakdownIntent.swift
+++ b/Automation/Intents/GetExpenseBreakdownIntent.swift
@@ -60,11 +60,10 @@ enum ExpensePeriod: String, AppEnum {
   static let typeDisplayRepresentation = TypeDisplayRepresentation(
     name: "Period")
 
-  static let caseDisplayRepresentations:
-    [ExpensePeriod: DisplayRepresentation] = [
-      .thisMonth: "This Month",
-      .lastMonth: "Last Month",
-    ]
+  static let caseDisplayRepresentations: [ExpensePeriod: DisplayRepresentation] = [
+    .thisMonth: "This Month",
+    .lastMonth: "Last Month",
+  ]
 
   var displayLabel: String {
     switch self {

--- a/Automation/Intents/ListAccountsIntent.swift
+++ b/Automation/Intents/ListAccountsIntent.swift
@@ -47,13 +47,12 @@ enum AccountTypeEnum: String, AppEnum {
   static let typeDisplayRepresentation = TypeDisplayRepresentation(
     name: "Account Type")
 
-  static let caseDisplayRepresentations:
-    [AccountTypeEnum: DisplayRepresentation] = [
-      .bank: "Bank Account",
-      .creditCard: "Credit Card",
-      .asset: "Asset",
-      .investment: "Investment",
-    ]
+  static let caseDisplayRepresentations: [AccountTypeEnum: DisplayRepresentation] = [
+    .bank: "Bank Account",
+    .creditCard: "Credit Card",
+    .asset: "Asset",
+    .investment: "Investment",
+  ]
 
   var toDomainType: AccountType {
     switch self {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,12 @@ just build-ios
 
 # Regenerate Moolah.xcodeproj from project.yml (run after editing project.yml)
 just generate
+
+# Apply swift-format to the repo (run before every commit)
+just format
+
+# Verify formatting (non-destructive; exits non-zero on any diff; used by CI)
+just format-check
 ```
 
 ### Capturing Test Output
@@ -116,12 +122,18 @@ Views must be thin wrappers that bind state, dispatch actions, and render. **All
 
 **Before committing any code, you MUST:**
 
-1. **Check for Compiler Warnings**
+1. **Format Swift files**
+   - Run `just format` to apply `swift-format` across the repo (uses `.swift-format` config)
+   - CI runs `just format-check` and **will fail** if any tracked `.swift` file is not in formatted form
+   - `just format-check` is non-destructive — run it locally to preview CI's result without mutating files
+   - Xcode's editor / format-on-save can silently reformat files to a layout that disagrees with `swift-format`. Always run `just format` immediately before `git commit` so CI doesn't kick the PR back.
+
+2. **Check for Compiler Warnings**
    - Use Xcode MCP: `mcp__xcode__XcodeListNavigatorIssues` with `severity: "warning"`
    - Or run `xcodebuild` and check for warnings
    - **ALL warnings in user code must be fixed.** (Preview macro warnings from `#Preview` can be ignored.)
 
-2. **Common Warning Fixes:**
+3. **Common Warning Fixes:**
    - **"Result of call to X is unused"**: Add `_ = ` before the call to explicitly discard the result
      ```swift
      // Before
@@ -133,7 +145,7 @@ Views must be thin wrappers that bind state, dispatch actions, and render. **All
    - **"Variable 'x' was never mutated"**: Change `var` to `let`
    - **"Initialization of immutable value 'x' was never used"**: Remove unused variables
 
-3. **Build Configuration**
+4. **Build Configuration**
    - The project is configured with `SWIFT_TREAT_WARNINGS_AS_ERRORS: YES`
    - Builds will fail if there are any warnings in user code
    - This ensures warning-free commits at all times

--- a/justfile
+++ b/justfile
@@ -8,11 +8,43 @@ set dotenv-load := true
 default:
     @just --list
 
+# Run swift-format style lint (prints warnings; does not exit non-zero for
+# pre-existing advisory violations). Use `format-check` in CI and pre-commit
+# to enforce actual formatting.
 lint:
     swift-format lint -r . --configuration .swift-format
 
-lint-fix:
+# Apply swift-format formatting in place across the repo. Run this before
+# committing; CI rejects changes that are not in formatted form.
+format:
     swift-format format -i -r . --configuration .swift-format
+
+# Back-compat alias for `format`.
+lint-fix: format
+
+# Verify that every tracked Swift file is already in formatted form.
+# Non-destructive: does not modify any files. Exits non-zero on any diff.
+# Used by CI; run locally before committing if you want to preview failures
+# without applying changes.
+format-check:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    fail=0
+    while IFS= read -r file; do
+        if ! cmp -s "$file" <(swift-format format --configuration .swift-format "$file"); then
+            echo "::error file=$file::Not formatted; run 'just format' to fix"
+            diff -u --label "$file" --label "$file (formatted)" \
+                "$file" <(swift-format format --configuration .swift-format "$file") || true
+            fail=1
+        fi
+    done < <(git ls-files '*.swift')
+    if [ "$fail" -ne 0 ]; then
+        echo
+        echo "One or more files are not formatted correctly."
+        echo "Run 'just format' and commit the result."
+        exit 1
+    fi
+    echo "All Swift files are correctly formatted."
 
 # FILTERS restrict the run to specific tests: each is a class (e.g.
 # TransactionStoreTests) or class/method (e.g. TransactionStoreTests/testFoo);


### PR DESCRIPTION
## Summary

- Adds `just format` (apply) and `just format-check` (non-destructive verify) targets
- Replaces CI's advisory `just lint` step with `just format-check` — PRs now fail CI when any tracked `.swift` file is not in the canonical `swift-format` layout
- Applies the formatter to two `Automation/Intents` files that had real violations (`[RemoveLine]` + `[Indentation]`). These were the phantom uncommitted changes that appeared in every worktree whenever Xcode's editor opened them
- Updates CLAUDE.md's pre-commit checklist so agents run `just format` before every commit

## Why

The existing `just lint` step ran `swift-format lint`, which only prints warnings and exits 0 — CI silently accepted unformatted files. Xcode reformats the affected files on save, producing phantom diffs that show up in every worktree.

## Test plan

- [x] `just format-check` passes locally after the fix
- [ ] CI's new \`Format check\` step passes on the PR branch
- [ ] Deliberately un-format a file locally, confirm \`just format-check\` exits non-zero and prints the diff