### PR TITLE
test: replace fixed-duration sleeps with deadline-based polling

### DIFF
--- a/MoolahTests/Features/AccountStoreConversionTests.swift
+++ b/MoolahTests/Features/AccountStoreConversionTests.swift
@@ -407,12 +407,14 @@ struct AccountStoreConversionTests {
       retryDelay: .seconds(60))
 
     await store.load()
-    // Wait for the first conversion attempt to publish before asserting.
-    // Waiting on `conversionAttemptsCompleted` is deterministic — it increments
-    // exactly once per pass regardless of success — whereas polling for a
-    // specific output value races on busy CI runners.
-    try await waitForCondition(timeout: .seconds(10)) {
-      store.conversionAttemptsCompleted >= 1
+    // Wait for the first conversion pass to publish bankAud's balance. We
+    // poll the observable we actually assert on: when bankAud is present,
+    // the pass has written the whole `newBalances` / totals set atomically
+    // within a single MainActor tick, so the other invariants below hold.
+    // Timeout is generous because iOS simulator CI has been observed to
+    // take >10s for the first pass under CoreData/SwiftData setup load.
+    try await waitForCondition(timeout: .seconds(30)) {
+      store.convertedBalances[bankAud.id] != nil
     }
 
     // AUD bank: only AUD positions → succeeds.
@@ -458,9 +460,11 @@ struct AccountStoreConversionTests {
       retryDelay: .milliseconds(20))
 
     await store.load()
-    // Wait for the first attempt to publish, deterministically.
-    try await waitForCondition(timeout: .seconds(10)) {
-      store.conversionAttemptsCompleted >= 1
+    // Wait for the first pass to publish the succeeding account's balance
+    // before probing the partial-failure state. Polling an observable we
+    // actually care about keeps this robust on slow iOS simulator CI.
+    try await waitForCondition(timeout: .seconds(30)) {
+      store.convertedBalances[bankAud.id] != nil
     }
 
     // Initial state: EUR bank can't be converted to AUD aggregate target → aggregate nil.
@@ -470,7 +474,7 @@ struct AccountStoreConversionTests {
     await conversion.setFailing([])
 
     // Retry should fire within retryDelay × a few attempts.
-    try await waitForCondition(timeout: .seconds(10)) {
+    try await waitForCondition(timeout: .seconds(30)) {
       store.convertedCurrentTotal != nil
     }
 

--- a/MoolahTests/Features/EarmarkStoreTests.swift
+++ b/MoolahTests/Features/EarmarkStoreTests.swift
@@ -208,9 +208,10 @@ struct EarmarkStoreTests {
       targetInstrument: .defaultTestInstrument)
 
     await store.load()
-    try await Task.sleep(for: .milliseconds(50))
+    try await waitForCondition(timeout: .seconds(30)) {
+      store.convertedTotalBalance != nil
+    }
 
-    #expect(store.convertedTotalBalance != nil)
     #expect(store.convertedTotalBalance?.quantity == 500)
   }
 
@@ -240,7 +241,9 @@ struct EarmarkStoreTests {
       targetInstrument: .defaultTestInstrument)
 
     await store.load()
-    try await Task.sleep(for: .milliseconds(50))
+    try await waitForCondition(timeout: .seconds(30)) {
+      store.convertedTotalBalance != nil
+    }
 
     // Individual balances should reflect true values
     #expect(store.convertedBalance(for: positiveId)?.quantity == 500)
@@ -268,15 +271,18 @@ struct EarmarkStoreTests {
       repository: backend.earmarks, conversionService: FixedConversionService(),
       targetInstrument: .defaultTestInstrument)
     await store.load()
-    try await Task.sleep(for: .milliseconds(50))
-    #expect(store.convertedTotalBalance?.quantity == 500)
+    try await waitForCondition(timeout: .seconds(30)) {
+      store.convertedTotalBalance?.quantity == 500
+    }
 
     store.applyDelta(
       earmarkDeltas: [earmarkId: [instrument: -100]],
       savedDeltas: [:],
       spentDeltas: [earmarkId: [instrument: 100]]
     )
-    try await Task.sleep(for: .milliseconds(50))
+    try await waitForCondition(timeout: .seconds(30)) {
+      store.convertedTotalBalance?.quantity == 400
+    }
 
     #expect(store.convertedTotalBalance?.quantity == 400)
   }
@@ -302,7 +308,9 @@ struct EarmarkStoreTests {
       targetInstrument: .defaultTestInstrument)
 
     await store.load()
-    try await Task.sleep(for: .milliseconds(50))
+    try await waitForCondition(timeout: .seconds(30)) {
+      store.convertedBalance(for: earmarkId) != nil
+    }
 
     #expect(store.convertedBalance(for: earmarkId)?.quantity == 500)
     #expect(store.convertedSaved(for: earmarkId)?.quantity == 500)
@@ -327,14 +335,18 @@ struct EarmarkStoreTests {
       repository: backend.earmarks, conversionService: FixedConversionService(),
       targetInstrument: .defaultTestInstrument)
     await store.load()
-    try await Task.sleep(for: .milliseconds(50))
+    try await waitForCondition(timeout: .seconds(30)) {
+      store.convertedBalance(for: earmarkId)?.quantity == 500
+    }
 
     store.applyDelta(
       earmarkDeltas: [earmarkId: [instrument: -100]],
       savedDeltas: [:],
       spentDeltas: [earmarkId: [instrument: 100]]
     )
-    try await Task.sleep(for: .milliseconds(50))
+    try await waitForCondition(timeout: .seconds(30)) {
+      store.convertedBalance(for: earmarkId)?.quantity == 400
+    }
 
     #expect(store.convertedBalance(for: earmarkId)?.quantity == 400)
     #expect(store.convertedSpent(for: earmarkId)?.quantity == 100)
@@ -693,7 +705,9 @@ struct EarmarkStoreTests {
       targetInstrument: aud)
 
     await store.load()
-    try await Task.sleep(for: .milliseconds(50))
+    try await waitForCondition(timeout: .seconds(30)) {
+      store.convertedBalance(for: earmarkId) != nil
+    }
 
     let balance = try #require(store.convertedBalance(for: earmarkId))
     #expect(balance.instrument == usd)
@@ -722,7 +736,9 @@ struct EarmarkStoreTests {
       conversionService: FixedConversionService(rates: ["AUD": 2]),
       targetInstrument: aud)
     await store.load()
-    try await Task.sleep(for: .milliseconds(50))
+    try await waitForCondition(timeout: .seconds(30)) {
+      store.convertedBalance(for: earmarkId)?.instrument == aud
+    }
 
     let before = try #require(store.convertedBalance(for: earmarkId))
     #expect(before.instrument == aud)
@@ -733,7 +749,9 @@ struct EarmarkStoreTests {
     changed.instrument = usd
     let updated = await store.update(changed)
     #expect(updated?.instrument == usd)
-    try await Task.sleep(for: .milliseconds(50))
+    try await waitForCondition(timeout: .seconds(30)) {
+      store.convertedBalance(for: earmarkId)?.instrument == usd
+    }
 
     let after = try #require(store.convertedBalance(for: earmarkId))
     #expect(after.instrument == usd)
@@ -798,7 +816,12 @@ struct EarmarkStorePartialConversionTests {
       retryDelay: .seconds(60))
 
     await store.load()
-    try await Task.sleep(for: .milliseconds(50))
+    // Poll the observable we actually assert on. When the healthy earmark's
+    // balance is published, the first conversion pass has written all per-
+    // earmark state atomically within one MainActor tick.
+    try await waitForCondition(timeout: .seconds(30)) {
+      store.convertedBalance(for: healthyEarmark.id) != nil
+    }
 
     #expect(store.convertedBalance(for: healthyEarmark.id)?.quantity == 300)
     #expect(store.convertedBalance(for: mixedEarmark.id) == nil)
@@ -844,7 +867,11 @@ struct EarmarkStorePartialConversionTests {
       retryDelay: .milliseconds(20))
 
     await store.load()
-    try await Task.sleep(for: .milliseconds(50))
+    // Wait for the first pass to publish the succeeding earmark before
+    // probing the partial-failure state.
+    try await waitForCondition(timeout: .seconds(30)) {
+      store.convertedBalance(for: audEarmark.id) != nil
+    }
 
     // Aggregate cannot be computed (EUR → AUD fails). Per-earmark balances
     // are still displayed in their own currency where no conversion is
@@ -853,7 +880,7 @@ struct EarmarkStorePartialConversionTests {
 
     await conversion.setFailing([])
 
-    try await waitForCondition(timeout: .seconds(2)) {
+    try await waitForCondition(timeout: .seconds(30)) {
       store.convertedTotalBalance != nil
     }
 


### PR DESCRIPTION
## Summary

- Fixes a flake exposed by #162's CI run at [runs/24613924312](https://github.com/ajsutton/moolah-native/actions/runs/24613924312).
- Root cause: `AccountStoreConversionTests.perAccountBalancePopulatesEvenWhenAnotherAccountFails` timed out after 10s waiting on `store.conversionAttemptsCompleted >= 1`. On iOS simulator CI, the first conversion pass sometimes takes longer than 10s under CoreData/SwiftData setup contention. The wait was also polling an indirection (the pass-counter) instead of the observable value the test actually asserts on.
- Fix in `AccountStoreConversionTests`: poll `convertedBalances[bankAud.id] != nil` directly and raise timeout to 30s. When the per-account balance appears, the store has atomically written the whole `newBalances`/totals set in one MainActor tick, so polling that value is strictly closer to the invariant being asserted.
- Audited `MoolahTests/` for other `Task.sleep`/`Thread.sleep`/`sleep(` usages. Converted the 12 pre-existing `Task.sleep(for: .milliseconds(50))` "wait for async conversion to publish" instances in `EarmarkStoreTests` / `EarmarkStorePartialConversionTests` to `waitForCondition` polls on the actual observables. Also bumped an existing 2s retry-wait in the same file up to 30s for the same slow-CI reason.
- Left alone: `TransactionStoreTests.testDebouncedSaveOnlyCallsLastAction`'s `Task.sleep(nanoseconds: 500_000_000)` — that's genuinely verifying a 300ms debounce timer fires exactly once (rate-limit-like behaviour), not waiting for async work.

## Test plan

- [ ] CI (iOS + macOS) passes, including `AccountStoreConversionTests` and `EarmarkStoreTests` / `EarmarkStorePartialConversionTests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)