### PR TITLE
ci: trigger CI on mq-spec-* branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,10 @@ name: CI
 
 on:
   push:
-    branches: ["master", "main"]
+    branches:
+      - master
+      - main
+      - 'mq-spec-*'   # speculative merge-queue branches; CI runs without a PR
   pull_request:
 
 jobs:


### PR DESCRIPTION
## Summary

Adds `mq-spec-*` to the push triggers in `.github/workflows/ci.yml` so the merge-queue daemon's speculative branches get a CI run automatically (no PR required for them).

This is **Phase 0** of the merge-train rework (see `plans/MERGE_TRAIN_PLAN.md`). Without this trigger, speculative train branches would have no CI, and the train's "promote-by-force-pushing-the-spec-SHA-to-the-PR-head" fast path can't satisfy branch protection.

## Test plan

- [ ] CI runs on this PR (push event from a regular branch).
- [ ] After merge, push a `mq-spec-test-0` branch with any commit and confirm CI fires as a push event without an associated PR.