### PR TITLE
Queue records for sync after iCloud migration/import

### DIFF
--- a/App/MoolahApp.swift
+++ b/App/MoolahApp.swift
@@ -410,7 +410,7 @@ struct MoolahApp: App {
         AboutCommands()
         ProfileCommands(
           profileStore: profileStore, sessionManager: sessionManager,
-          containerManager: containerManager)
+          containerManager: containerManager, syncCoordinator: syncCoordinator)
         NewItemCommands()
         RefreshCommands()
         SidebarCommands()
@@ -436,6 +436,7 @@ struct MoolahApp: App {
           .environment(profileStore)
           .environment(sessionManager)
           .environment(containerManager)
+          .environment(syncCoordinator)
           .modelContainer(containerManager.indexContainer)
       }
     #else

--- a/Backends/CloudKit/Migration/MigrationCoordinator.swift
+++ b/Backends/CloudKit/Migration/MigrationCoordinator.swift
@@ -1,3 +1,4 @@
+@preconcurrency import CloudKit
 import Foundation
 import OSLog
 import Observation
@@ -81,6 +82,12 @@ final class MigrationCoordinator {
   }
 
   private(set) var state: State = .idle
+
+  /// Record IDs queued with the sync coordinator by the most recent successful
+  /// `migrate(...)` call. Empty if no sync coordinator was provided, the migration
+  /// failed, or the profile had no records to queue. Exposed for test verification.
+  private(set) var lastRecordIDsQueuedForUpload: [CKRecord.ID] = []
+
   private let logger = Logger(subsystem: "com.moolah.app", category: "Migration")
 
   /// Migrates data from a remote profile to a new iCloud profile.
@@ -90,13 +97,19 @@ final class MigrationCoordinator {
   ///   - backend: The backend for the source profile (provides repositories)
   ///   - containerManager: The per-profile container manager used to create the target store
   ///   - profileStore: The profile store for creating the new profile and renaming the old one
+  ///   - syncCoordinator: Optional sync coordinator. When provided, the newly-imported
+  ///     profile's zone is created on CloudKit and every imported record is queued for
+  ///     upload so other devices receive the migrated data. Pass `nil` for tests that
+  ///     don't exercise sync.
   func migrate(
     sourceProfile: Profile,
     from backend: any BackendProvider,
     to containerManager: ProfileContainerManager,
-    profileStore: ProfileStore
+    profileStore: ProfileStore,
+    syncCoordinator: SyncCoordinator? = nil
   ) async {
     state = .exporting(step: "Starting...")
+    lastRecordIDsQueuedForUpload = []
 
     do {
       // 1. Export all data from the source backend
@@ -188,6 +201,19 @@ final class MigrationCoordinator {
       // 6. Switch to the new iCloud profile
       profileStore.setActiveProfile(newProfileId)
 
+      // 7. Queue the imported records with the sync coordinator so they upload to
+      // CloudKit and propagate to other devices. `CloudKitDataImporter` writes records
+      // directly to SwiftData and so bypasses the repository `onRecordChanged` hooks —
+      // without this step the new profile's data would only ever exist on the device
+      // that performed the migration.
+      if let syncCoordinator {
+        let queued = await syncCoordinator.queueAllRecordsAfterImport(for: newProfileId)
+        lastRecordIDsQueuedForUpload = queued
+        if !queued.isEmpty {
+          await syncCoordinator.sendChanges()
+        }
+      }
+
       state = .succeeded(
         result, newProfileId: newProfileId, balanceWarnings: verification.balanceMismatches)
 
@@ -234,10 +260,16 @@ final class MigrationCoordinator {
   /// - Parameters:
   ///   - url: The file URL to read the exported JSON from
   ///   - modelContainer: The target container to import data into
+  ///   - profileId: The UUID of the new profile that owns `modelContainer`. Required
+  ///     when `syncCoordinator` is non-nil so imported records can be queued for upload.
+  ///   - syncCoordinator: Optional sync coordinator. When provided, all imported records
+  ///     are queued for upload so the profile syncs to CloudKit and other devices.
   /// - Returns: The import result with counts of imported records
   func importFromFile(
     url: URL,
-    modelContainer: ModelContainer
+    modelContainer: ModelContainer,
+    profileId: UUID? = nil,
+    syncCoordinator: SyncCoordinator? = nil
   ) async throws -> ImportResult {
     state = .importing(step: "reading file", progress: 0)
 
@@ -283,6 +315,17 @@ final class MigrationCoordinator {
     if !verification.countMatch {
       state = .idle
       throw MigrationError.verificationFailed(verification)
+    }
+
+    // Queue every imported record for upload so the new profile actually syncs to
+    // CloudKit. Without this the container has data but CKSyncEngine never hears
+    // about it — the profile would be iCloud-backed in name only.
+    if let syncCoordinator, let profileId {
+      let queued = await syncCoordinator.queueAllRecordsAfterImport(for: profileId)
+      lastRecordIDsQueuedForUpload = queued
+      if !queued.isEmpty {
+        await syncCoordinator.sendChanges()
+      }
     }
 
     state = .idle

--- a/Backends/CloudKit/Sync/ProfileDataSyncHandler.swift
+++ b/Backends/CloudKit/Sync/ProfileDataSyncHandler.swift
@@ -347,6 +347,48 @@ final class ProfileDataSyncHandler: Sendable {
     return recordIDs
   }
 
+  /// Scans all record types and returns CKRecord.IDs for records that have never been
+  /// successfully sent to CloudKit (i.e. `encodedSystemFields == nil`). Used on startup
+  /// to backfill uploads for profiles whose data landed via migration or any other path
+  /// that bypassed the repository `onRecordChanged` hooks.
+  func queueUnsyncedRecords() -> [CKRecord.ID] {
+    let signpostID = OSSignpostID(log: Signposts.sync)
+    os_signpost(
+      .begin, log: Signposts.sync, name: "queueUnsyncedRecords", signpostID: signpostID)
+    defer {
+      os_signpost(
+        .end, log: Signposts.sync, name: "queueUnsyncedRecords", signpostID: signpostID)
+    }
+
+    var recordIDs: [CKRecord.ID] = []
+
+    func collectUnsynced<T: PersistentModel & SystemFieldsCacheable>(
+      _ type: T.Type, extract: (T) -> String
+    ) {
+      let context = ModelContext(modelContainer)
+      let records = fetchOrLog(FetchDescriptor<T>(), context: context)
+      for r in records where r.encodedSystemFields == nil {
+        recordIDs.append(CKRecord.ID(recordName: extract(r), zoneID: zoneID))
+      }
+    }
+
+    // Same dependency order as queueAllExistingRecords.
+    collectUnsynced(InstrumentRecord.self) { $0.id }
+    collectUnsynced(CategoryRecord.self) { $0.id.uuidString }
+    collectUnsynced(AccountRecord.self) { $0.id.uuidString }
+    collectUnsynced(EarmarkRecord.self) { $0.id.uuidString }
+    collectUnsynced(EarmarkBudgetItemRecord.self) { $0.id.uuidString }
+    collectUnsynced(InvestmentValueRecord.self) { $0.id.uuidString }
+    collectUnsynced(TransactionRecord.self) { $0.id.uuidString }
+    collectUnsynced(TransactionLegRecord.self) { $0.id.uuidString }
+
+    if !recordIDs.isEmpty {
+      logger.info("Collected \(recordIDs.count) unsynced records for upload")
+    }
+
+    return recordIDs
+  }
+
   // MARK: - Local Data Deletion
 
   /// Deletes all local records for this profile's zone.

--- a/Backends/CloudKit/Sync/SyncCoordinator.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator.swift
@@ -170,6 +170,14 @@ final class SyncCoordinator: Sendable {
   let containerManager: ProfileContainerManager
   let profileIndexHandler: ProfileIndexSyncHandler
 
+  /// User defaults used to persist per-profile "backfill scan complete" flags so the
+  /// scan runs at most once per profile across app launches. Injected for testing.
+  private let userDefaults: UserDefaults
+
+  /// Key prefix for the per-profile backfill-scan-completed flag. The full key is
+  /// `"\(backfillScanCompleteKeyPrefix).\(profileId.uuidString)"`.
+  private static let backfillScanCompleteKeyPrefix = "com.moolah.sync.backfillScanComplete"
+
   private let logger = Logger(subsystem: "com.moolah.app", category: "SyncCoordinator")
   private var syncEngine: CKSyncEngine?
   private(set) var isRunning = false
@@ -244,8 +252,12 @@ final class SyncCoordinator: Sendable {
 
   // MARK: - Init
 
-  init(containerManager: ProfileContainerManager) {
+  init(
+    containerManager: ProfileContainerManager,
+    userDefaults: UserDefaults = .standard
+  ) {
     self.containerManager = containerManager
+    self.userDefaults = userDefaults
     self.profileIndexHandler = ProfileIndexSyncHandler(
       modelContainer: containerManager.indexContainer)
   }
@@ -300,6 +312,7 @@ final class SyncCoordinator: Sendable {
     // then send if needed. Reactive creation in `handleSentRecordZoneChanges`
     // remains as a fallback per SYNC_GUIDE Rule 3.
     let profileIds = containerManager.allProfileIds()
+    let shouldBackfillUnsynced = !isFirstLaunch
     zoneSetupTask = Task {
       await self.ensureZoneExists(self.profileIndexHandler.zoneID)
       for profileId in profileIds {
@@ -307,6 +320,14 @@ final class SyncCoordinator: Sendable {
           zoneName: "profile-\(profileId.uuidString)",
           ownerName: CKCurrentUserDefaultName)
         await self.ensureZoneExists(zoneID)
+      }
+      // After zones are confirmed, backfill any records that never got queued for upload
+      // (e.g. data imported by migration on a build that predated the migration→sync fix,
+      // or a previous run that crashed between the SwiftData write and the sync-engine
+      // queue). Skipped on first launch because `queueAllExistingRecordsForAllZones`
+      // has already queued everything.
+      if shouldBackfillUnsynced {
+        _ = self.queueUnsyncedRecordsForAllProfiles()
       }
       if self.hasPendingChanges {
         self.logger.info("Zones ready — sending pending changes")
@@ -516,6 +537,142 @@ final class SyncCoordinator: Sendable {
 
   // MARK: - Queue All Existing Records
 
+  /// Ensures the given profile's zone exists on CloudKit, then queues every record in
+  /// that profile's local SwiftData store for upload. Called by `MigrationCoordinator`
+  /// after a migration import, which writes records directly to SwiftData and so
+  /// bypasses the repository `onRecordChanged` hooks that normally feed the sync engine.
+  ///
+  /// The zone is created first so the initial send does not have to round-trip through
+  /// `.zoneNotFound` and `pendingZoneCreation`.
+  ///
+  /// Returns the record IDs that were queued (empty if the profile has no records or
+  /// its handler couldn't be resolved). The caller is responsible for invoking
+  /// `sendChanges()` afterwards if an immediate upload is desired.
+  @discardableResult
+  func queueAllRecordsAfterImport(for profileId: UUID) async -> [CKRecord.ID] {
+    let zoneID = CKRecordZone.ID(
+      zoneName: "profile-\(profileId.uuidString)",
+      ownerName: CKCurrentUserDefaultName)
+
+    // Only hit CloudKit when the coordinator is actually running; tests never start
+    // the engine and should not make network calls for zone creation.
+    if isRunning {
+      await ensureZoneExists(zoneID)
+    }
+
+    guard let handler = try? handlerForProfileZone(profileId: profileId, zoneID: zoneID) else {
+      logger.error("Failed to get handler for post-import queueing, profile \(profileId)")
+      return []
+    }
+    let recordIDs = handler.queueAllExistingRecords()
+    if !recordIDs.isEmpty {
+      syncEngine?.state.add(
+        pendingRecordZoneChanges: recordIDs.map { .saveRecord($0) })
+      logger.info(
+        "Queued \(recordIDs.count) records for upload after import, profile \(profileId)")
+    }
+    // Mark the profile as backfill-scanned: we've just queued every record, which is
+    // a strict superset of what the startup backfill scan would do. Prevents the next
+    // launch from re-scanning this profile's SwiftData store for nothing.
+    markBackfillScanComplete(for: profileId)
+    return recordIDs
+  }
+
+  /// Scans every known cloud profile for records that have never been successfully
+  /// synced (i.e. `encodedSystemFields == nil`) and queues them for upload. Called on
+  /// coordinator start so users whose profiles were migrated on a previous build — where
+  /// migration did not queue imported records — still end up with their data uploaded
+  /// on the next launch.
+  ///
+  /// Idempotent: records that already have system fields are skipped, and CKSyncEngine's
+  /// pending list dedupes against any other queued changes.
+  @discardableResult
+  func queueUnsyncedRecordsForAllProfiles() -> [CKRecord.ID] {
+    var queued: [CKRecord.ID] = []
+    for profileId in containerManager.allProfileIds() {
+      // Skip profiles whose backfill scan has already run — the only work left for
+      // those is normal sync traffic. This keeps the startup scan O(1) on the happy
+      // path: after the first run per profile we never touch its SwiftData store again.
+      if hasCompletedBackfillScan(for: profileId) {
+        continue
+      }
+      let zoneID = CKRecordZone.ID(
+        zoneName: "profile-\(profileId.uuidString)",
+        ownerName: CKCurrentUserDefaultName)
+      guard let handler = try? handlerForProfileZone(profileId: profileId, zoneID: zoneID)
+      else {
+        logger.error("Failed to get handler for backfill queueing, profile \(profileId)")
+        continue
+      }
+      let recordIDs = handler.queueUnsyncedRecords()
+      if !recordIDs.isEmpty {
+        syncEngine?.state.add(
+          pendingRecordZoneChanges: recordIDs.map { .saveRecord($0) })
+        queued.append(contentsOf: recordIDs)
+      }
+      markBackfillScanComplete(for: profileId)
+    }
+    if !queued.isEmpty {
+      logger.info(
+        "Queued \(queued.count) previously-unsynced records for upload across all profiles")
+    }
+    return queued
+  }
+
+  private func hasCompletedBackfillScan(for profileId: UUID) -> Bool {
+    userDefaults.bool(forKey: backfillScanCompleteKey(for: profileId))
+  }
+
+  private func markBackfillScanComplete(for profileId: UUID) {
+    userDefaults.set(true, forKey: backfillScanCompleteKey(for: profileId))
+  }
+
+  /// Clears the backfill-scan flag for one profile — called whenever the profile's
+  /// local data is destroyed or its system fields are reset (zone deletion,
+  /// encrypted data reset), so the next scan re-examines it instead of skipping
+  /// based on stale state.
+  private func clearBackfillScanFlag(for profileId: UUID) {
+    userDefaults.removeObject(forKey: backfillScanCompleteKey(for: profileId))
+  }
+
+  /// Clears every backfill-scan flag. Called on sign-out/switch-accounts, where
+  /// the set of valid profiles may change entirely before the next scan runs.
+  private func clearAllBackfillScanFlags() {
+    let prefix = Self.backfillScanCompleteKeyPrefix + "."
+    for key in userDefaults.dictionaryRepresentation().keys where key.hasPrefix(prefix) {
+      userDefaults.removeObject(forKey: key)
+    }
+  }
+
+  private func backfillScanCompleteKey(for profileId: UUID) -> String {
+    "\(Self.backfillScanCompleteKeyPrefix).\(profileId.uuidString)"
+  }
+
+  // MARK: - Test Hooks
+
+  /// Test-only: runs the same bookkeeping as a CloudKit `.signOut` account event, so
+  /// unit tests can verify backfill-flag cleanup without a real CKSyncEngine.
+  func handleSignOutForTesting() {
+    deleteAllLocalData()
+    deleteStateSerialization()
+    clearAllBackfillScanFlags()
+    isFetchingChanges = false
+  }
+
+  /// Test-only: runs the same bookkeeping as a `.deleted` zone deletion for the given
+  /// zone, so unit tests can verify backfill-flag cleanup without dispatching a real
+  /// sync event.
+  func handleZoneDeletedForTesting(zoneID: CKRecordZone.ID) {
+    handleZoneDeleted(zoneID, zoneType: Self.parseZone(zoneID))
+  }
+
+  /// Test-only: runs the same bookkeeping as an `.encryptedDataReset` zone deletion,
+  /// so unit tests can verify backfill-flag cleanup without dispatching a real sync
+  /// event.
+  func handleEncryptedDataResetForTesting(zoneID: CKRecordZone.ID) {
+    handleEncryptedDataReset(zoneID, zoneType: Self.parseZone(zoneID))
+  }
+
   private func queueAllExistingRecordsForAllZones() {
     // Queue profile-index records
     let indexRecordIDs = profileIndexHandler.queueAllExistingRecords()
@@ -539,6 +696,9 @@ final class SyncCoordinator: Sendable {
       } catch {
         logger.error("Failed to queue records for profile \(profileId): \(error)")
       }
+      // This path queued every record for the profile, so there is nothing left for
+      // the per-launch backfill scan to find.
+      markBackfillScanComplete(for: profileId)
     }
   }
 
@@ -579,12 +739,14 @@ final class SyncCoordinator: Sendable {
       logger.info("Account signed out — deleting all local data and sync state")
       deleteAllLocalData()
       deleteStateSerialization()
+      clearAllBackfillScanFlags()
       isFetchingChanges = false
 
     case .switchAccounts:
       logger.info("Account switched — full reset")
       deleteAllLocalData()
       deleteStateSerialization()
+      clearAllBackfillScanFlags()
       isFetchingChanges = false
 
     @unknown default:
@@ -651,6 +813,9 @@ final class SyncCoordinator: Sendable {
           notifyObservers(for: profileId, changedTypes: changedTypes)
         }
       }
+      // Records have been wiped; any re-created zone starts with no system fields and
+      // must be re-scanned. Clear the flag so the next backfill pass picks it up.
+      clearBackfillScanFlag(for: profileId)
 
     case .unknown:
       break
@@ -673,6 +838,7 @@ final class SyncCoordinator: Sendable {
           notifyObservers(for: profileId, changedTypes: changedTypes)
         }
       }
+      clearBackfillScanFlag(for: profileId)
 
     case .unknown:
       break
@@ -705,6 +871,10 @@ final class SyncCoordinator: Sendable {
             pendingRecordZoneChanges: recordIDs.map { .saveRecord($0) })
         }
       }
+      // System fields were cleared; if a later crash happens before the re-upload
+      // persists, the next backfill scan must revisit this profile instead of
+      // trusting a stale "complete" flag from before the reset.
+      clearBackfillScanFlag(for: profileId)
 
     case .unknown:
       break

--- a/Backends/CloudKit/Sync/SyncCoordinator.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator.swift
@@ -589,11 +589,15 @@ final class SyncCoordinator: Sendable {
   @discardableResult
   func queueUnsyncedRecordsForAllProfiles() -> [CKRecord.ID] {
     var queued: [CKRecord.ID] = []
-    for profileId in containerManager.allProfileIds() {
+    var scannedProfiles = 0
+    var skippedProfiles = 0
+    let allProfiles = containerManager.allProfileIds()
+    for profileId in allProfiles {
       // Skip profiles whose backfill scan has already run — the only work left for
       // those is normal sync traffic. This keeps the startup scan O(1) on the happy
       // path: after the first run per profile we never touch its SwiftData store again.
       if hasCompletedBackfillScan(for: profileId) {
+        skippedProfiles += 1
         continue
       }
       let zoneID = CKRecordZone.ID(
@@ -605,6 +609,7 @@ final class SyncCoordinator: Sendable {
         continue
       }
       let recordIDs = handler.queueUnsyncedRecords()
+      scannedProfiles += 1
       if !recordIDs.isEmpty {
         syncEngine?.state.add(
           pendingRecordZoneChanges: recordIDs.map { .saveRecord($0) })
@@ -612,10 +617,12 @@ final class SyncCoordinator: Sendable {
       }
       markBackfillScanComplete(for: profileId)
     }
-    if !queued.isEmpty {
-      logger.info(
-        "Queued \(queued.count) previously-unsynced records for upload across all profiles")
-    }
+    logger.info(
+      """
+      Backfill scan complete: \(allProfiles.count) profiles total, \
+      \(scannedProfiles) scanned, \(skippedProfiles) skipped (already flagged), \
+      \(queued.count) unsynced records queued for upload
+      """)
     return queued
   }
 

--- a/Features/Export/ExportImportCommands.swift
+++ b/Features/Export/ExportImportCommands.swift
@@ -7,6 +7,7 @@
   struct ExportImportButtons: View {
     let profileStore: ProfileStore
     let containerManager: ProfileContainerManager
+    let syncCoordinator: SyncCoordinator
     let session: ProfileSession?
 
     @Environment(\.openWindow) private var openWindow
@@ -97,7 +98,9 @@
         let coordinator = MigrationCoordinator()
         _ = try await coordinator.importFromFile(
           url: url,
-          modelContainer: container
+          modelContainer: container,
+          profileId: newProfile.id,
+          syncCoordinator: syncCoordinator
         )
         openWindow(value: newProfile.id)
       } catch {

--- a/Features/Migration/MigrationView.swift
+++ b/Features/Migration/MigrationView.swift
@@ -7,6 +7,7 @@ struct MigrationView: View {
 
   @Environment(ProfileStore.self) private var profileStore
   @Environment(ProfileContainerManager.self) private var containerManager
+  @Environment(SyncCoordinator.self) private var syncCoordinator
   @Environment(\.dismiss) private var dismiss
   #if os(macOS)
     @Environment(\.openWindow) private var openWindow
@@ -61,7 +62,8 @@ struct MigrationView: View {
             sourceProfile: sourceProfile,
             from: backend,
             to: containerManager,
-            profileStore: profileStore
+            profileStore: profileStore,
+            syncCoordinator: syncCoordinator
           )
         }
       }

--- a/Features/Profiles/ProfileCommands.swift
+++ b/Features/Profiles/ProfileCommands.swift
@@ -6,6 +6,7 @@
     let profileStore: ProfileStore
     let sessionManager: SessionManager
     let containerManager: ProfileContainerManager
+    let syncCoordinator: SyncCoordinator
 
     @FocusedValue(\.authStore) private var authStore
     @FocusedValue(\.activeProfileSession) private var session
@@ -19,6 +20,7 @@
         ExportImportButtons(
           profileStore: profileStore,
           containerManager: containerManager,
+          syncCoordinator: syncCoordinator,
           session: session
         )
       }

--- a/Features/Settings/SettingsView.swift
+++ b/Features/Settings/SettingsView.swift
@@ -6,6 +6,7 @@ import UniformTypeIdentifiers
 struct SettingsView: View {
   @Environment(ProfileStore.self) private var profileStore
   @Environment(ProfileContainerManager.self) private var containerManager
+  @Environment(SyncCoordinator.self) private var syncCoordinator
 
   #if os(macOS)
     @Environment(SessionManager.self) private var sessionManager
@@ -393,7 +394,9 @@ struct SettingsView: View {
         let coordinator = MigrationCoordinator()
         _ = try await coordinator.importFromFile(
           url: url,
-          modelContainer: container
+          modelContainer: container,
+          profileId: newProfile.id,
+          syncCoordinator: syncCoordinator
         )
         profileStore.setActiveProfile(newProfile.id)
       } catch {

--- a/MoolahTests/Migration/MigrationIntegrationTests.swift
+++ b/MoolahTests/Migration/MigrationIntegrationTests.swift
@@ -1,3 +1,4 @@
+import CloudKit
 import Foundation
 import SwiftData
 import Testing
@@ -219,5 +220,66 @@ struct MigrationIntegrationTests {
     let budgetItems = try await cloudBackend.earmarks.fetchBudget(earmarkId: holiday!.id)
     #expect(budgetItems.count == 1)
     #expect(budgetItems.first?.amount.quantity == Decimal(string: "50.00")!)
+  }
+
+  @Test(
+    "MigrationCoordinator.migrate queues imported records with SyncCoordinator for upload"
+  )
+  func migrateQueuesRecordsForSync() async throws {
+    let backend = try await makeSeededBackend()
+    let manager = try ProfileContainerManager.forTesting()
+    let profileStore = ProfileStore(
+      defaults: UserDefaults(suiteName: "migrate-queues-\(UUID().uuidString)")!,
+      containerManager: manager
+    )
+    let syncCoordinator = SyncCoordinator(containerManager: manager)
+
+    let sourceProfile = Profile(
+      id: UUID(),
+      label: "Source",
+      backendType: .remote,
+      currencyCode: instrument.id,
+      financialYearStartMonth: 7
+    )
+
+    let coordinator = MigrationCoordinator()
+    await coordinator.migrate(
+      sourceProfile: sourceProfile,
+      from: backend,
+      to: manager,
+      profileStore: profileStore,
+      syncCoordinator: syncCoordinator
+    )
+
+    guard case .succeeded(_, let newProfileId, _) = coordinator.state else {
+      Issue.record("Expected .succeeded state, got \(coordinator.state)")
+      return
+    }
+
+    // The migration must have queued the new profile's records with the sync coordinator
+    // so they get uploaded to CloudKit. Otherwise other devices never see the migrated data.
+    let queued = coordinator.lastRecordIDsQueuedForUpload
+    #expect(!queued.isEmpty)
+    let zoneName = "profile-\(newProfileId.uuidString)"
+    for recordID in queued {
+      #expect(recordID.zoneID.zoneName == zoneName)
+    }
+
+    // Sanity: the queued record set should at least cover every account/transaction/category
+    // that was seeded.
+    let recordNames = Set(queued.map(\.recordName))
+    let container = try manager.container(for: newProfileId)
+    let context = ModelContext(container)
+    let importedAccounts = try context.fetch(FetchDescriptor<AccountRecord>())
+    for account in importedAccounts {
+      #expect(recordNames.contains(account.id.uuidString))
+    }
+
+    // The startup backfill scan must skip this profile — migration has already queued
+    // everything and flagged the profile as backfilled. Re-scanning would do pointless
+    // SwiftData iteration on every launch.
+    let leftover = syncCoordinator.queueUnsyncedRecordsForAllProfiles()
+      .filter { $0.zoneID.zoneName == zoneName }
+    #expect(leftover.isEmpty)
   }
 }

--- a/MoolahTests/Sync/ProfileDataSyncHandlerTests.swift
+++ b/MoolahTests/Sync/ProfileDataSyncHandlerTests.swift
@@ -239,6 +239,123 @@ struct ProfileDataSyncHandlerTests {
     }
   }
 
+  // MARK: - queueUnsyncedRecords
+
+  @Test func queueUnsyncedRecordsReturnsRecordsWithNilSystemFields() throws {
+    let (handler, container) = try makeHandler()
+
+    let unsyncedAccountId = UUID()
+    let syncedAccountId = UUID()
+    let unsyncedInstrumentId = "AUD"
+    let syncedInstrumentId = "USD"
+
+    let context = ModelContext(container)
+
+    // Record without system fields (never synced, e.g. just migrated)
+    context.insert(
+      AccountRecord(
+        id: unsyncedAccountId, name: "Unsynced", type: "bank", position: 0,
+        isHidden: false))
+
+    // Record with system fields (already synced)
+    let synced = AccountRecord(
+      id: syncedAccountId, name: "Synced", type: "bank", position: 1,
+      isHidden: false)
+    synced.encodedSystemFields = Data([0x01, 0x02, 0x03])
+    context.insert(synced)
+
+    // Instruments follow the same rule (string-keyed)
+    context.insert(
+      InstrumentRecord(
+        id: unsyncedInstrumentId, kind: "fiatCurrency",
+        name: "Australian Dollar", decimals: 2))
+    let syncedInstrument = InstrumentRecord(
+      id: syncedInstrumentId, kind: "fiatCurrency",
+      name: "US Dollar", decimals: 2)
+    syncedInstrument.encodedSystemFields = Data([0x04, 0x05])
+    context.insert(syncedInstrument)
+
+    try context.save()
+
+    let recordIDs = handler.queueUnsyncedRecords()
+    let recordNames = Set(recordIDs.map(\.recordName))
+
+    #expect(recordNames.contains(unsyncedAccountId.uuidString))
+    #expect(recordNames.contains(unsyncedInstrumentId))
+    #expect(!recordNames.contains(syncedAccountId.uuidString))
+    #expect(!recordNames.contains(syncedInstrumentId))
+  }
+
+  @Test func queueUnsyncedRecordsReturnsEmptyWhenAllSynced() throws {
+    let (handler, container) = try makeHandler()
+
+    let context = ModelContext(container)
+    let account = AccountRecord(
+      id: UUID(), name: "Acc", type: "bank", position: 0, isHidden: false)
+    account.encodedSystemFields = Data([0x01])
+    context.insert(account)
+    try context.save()
+
+    let recordIDs = handler.queueUnsyncedRecords()
+    #expect(recordIDs.isEmpty)
+  }
+
+  @Test func queueUnsyncedRecordsReturnsAllWhenNoneSynced() throws {
+    let (handler, container) = try makeHandler()
+
+    let accountId = UUID()
+    let txnId = UUID()
+    let legId = UUID()
+    let categoryId = UUID()
+    let earmarkId = UUID()
+    let budgetItemId = UUID()
+    let investmentValueId = UUID()
+    let instrumentId = "AUD"
+
+    let context = ModelContext(container)
+    context.insert(
+      InstrumentRecord(
+        id: instrumentId, kind: "fiatCurrency",
+        name: "Australian Dollar", decimals: 2))
+    context.insert(
+      AccountRecord(id: accountId, name: "Acc", type: "bank", position: 0, isHidden: false))
+    context.insert(
+      CategoryRecord(id: categoryId, name: "Food", parentId: nil))
+    context.insert(
+      EarmarkRecord(id: earmarkId, name: "Holiday", instrumentId: instrumentId))
+    context.insert(
+      EarmarkBudgetItemRecord(
+        id: budgetItemId, earmarkId: earmarkId, categoryId: categoryId,
+        amount: 0, instrumentId: instrumentId))
+    context.insert(
+      InvestmentValueRecord(
+        id: investmentValueId, accountId: accountId, date: Date(),
+        value: 0, instrumentId: instrumentId))
+    context.insert(TransactionRecord(id: txnId, date: Date(), payee: "Test"))
+    context.insert(
+      TransactionLegRecord(
+        id: legId, transactionId: txnId, accountId: accountId,
+        instrumentId: instrumentId, quantity: 0, type: "income", sortOrder: 0))
+    try context.save()
+
+    let recordIDs = handler.queueUnsyncedRecords()
+    let recordNames = Set(recordIDs.map(\.recordName))
+
+    #expect(recordNames.count == 8)
+    #expect(recordNames.contains(instrumentId))
+    #expect(recordNames.contains(accountId.uuidString))
+    #expect(recordNames.contains(categoryId.uuidString))
+    #expect(recordNames.contains(earmarkId.uuidString))
+    #expect(recordNames.contains(budgetItemId.uuidString))
+    #expect(recordNames.contains(investmentValueId.uuidString))
+    #expect(recordNames.contains(txnId.uuidString))
+    #expect(recordNames.contains(legId.uuidString))
+
+    for recordID in recordIDs {
+      #expect(recordID.zoneID == handler.zoneID)
+    }
+  }
+
   // MARK: - buildBatchRecordLookup
 
   @Test func buildBatchRecordLookupFindsRecordsByUUID() throws {

--- a/MoolahTests/Sync/SyncCoordinatorTests.swift
+++ b/MoolahTests/Sync/SyncCoordinatorTests.swift
@@ -234,6 +234,281 @@ struct SyncCoordinatorTests {
     coordinator.queueDeletion(id: id, zoneID: zoneID)
   }
 
+  // MARK: - Post-Migration / Import Record Queueing
+
+  @Test func queueAllRecordsAfterImportReturnsAllRecordsInProfileZone() async throws {
+    let manager = try ProfileContainerManager.forTesting()
+    let coordinator = SyncCoordinator(containerManager: manager)
+    let profileId = UUID()
+
+    // Seed the new profile's data container (as a migration import would).
+    let dataContainer = try manager.container(for: profileId)
+    let context = ModelContext(dataContainer)
+    let accountId = UUID()
+    let txnId = UUID()
+    context.insert(
+      AccountRecord(id: accountId, name: "Imported", type: "bank", position: 0, isHidden: false))
+    context.insert(TransactionRecord(id: txnId, date: Date(), payee: "Imported"))
+    context.insert(
+      InstrumentRecord(
+        id: "AUD", kind: "fiatCurrency", name: "Australian Dollar", decimals: 2))
+    try context.save()
+
+    let queued = await coordinator.queueAllRecordsAfterImport(for: profileId)
+    let names = Set(queued.map(\.recordName))
+
+    #expect(names == Set([accountId.uuidString, txnId.uuidString, "AUD"]))
+    for recordID in queued {
+      #expect(recordID.zoneID.zoneName == "profile-\(profileId.uuidString)")
+    }
+  }
+
+  @Test func queueAllRecordsAfterImportReturnsEmptyForProfileWithNoData() async throws {
+    let manager = try ProfileContainerManager.forTesting()
+    let coordinator = SyncCoordinator(containerManager: manager)
+    let profileId = UUID()
+
+    // Initialize the data container so the handler can be resolved,
+    // but leave it empty.
+    _ = try manager.container(for: profileId)
+
+    let queued = await coordinator.queueAllRecordsAfterImport(for: profileId)
+    #expect(queued.isEmpty)
+  }
+
+  // MARK: - Startup Backfill of Unsynced Records
+
+  private func makeDefaults() -> UserDefaults {
+    UserDefaults(suiteName: "sync-coordinator-test-\(UUID().uuidString)")!
+  }
+
+  @Test func queueUnsyncedRecordsForAllProfilesSkipsSyncedRecords() throws {
+    let manager = try ProfileContainerManager.forTesting()
+    let coordinator = SyncCoordinator(
+      containerManager: manager, userDefaults: makeDefaults())
+
+    // Register two profiles in the index.
+    let profileA = UUID()
+    let profileB = UUID()
+    let indexContext = ModelContext(manager.indexContainer)
+    indexContext.insert(
+      ProfileRecord(
+        id: profileA, label: "A", currencyCode: "AUD",
+        financialYearStartMonth: 7, createdAt: Date()))
+    indexContext.insert(
+      ProfileRecord(
+        id: profileB, label: "B", currencyCode: "USD",
+        financialYearStartMonth: 1, createdAt: Date()))
+    try indexContext.save()
+
+    // Profile A: one unsynced account and one synced account.
+    let unsyncedA = UUID()
+    let syncedA = UUID()
+    let contextA = ModelContext(try manager.container(for: profileA))
+    contextA.insert(
+      AccountRecord(id: unsyncedA, name: "A-unsynced", type: "bank", position: 0, isHidden: false))
+    let syncedRecord = AccountRecord(
+      id: syncedA, name: "A-synced", type: "bank", position: 1, isHidden: false)
+    syncedRecord.encodedSystemFields = Data([0x01])
+    contextA.insert(syncedRecord)
+    try contextA.save()
+
+    // Profile B: one unsynced transaction.
+    let unsyncedB = UUID()
+    let contextB = ModelContext(try manager.container(for: profileB))
+    contextB.insert(TransactionRecord(id: unsyncedB, date: Date(), payee: "B-unsynced"))
+    try contextB.save()
+
+    let queued = coordinator.queueUnsyncedRecordsForAllProfiles()
+    let names = Set(queued.map(\.recordName))
+
+    #expect(names == Set([unsyncedA.uuidString, unsyncedB.uuidString]))
+
+    // Each record went to the matching profile's zone.
+    let aZone = "profile-\(profileA.uuidString)"
+    let bZone = "profile-\(profileB.uuidString)"
+    for recordID in queued {
+      if recordID.recordName == unsyncedA.uuidString {
+        #expect(recordID.zoneID.zoneName == aZone)
+      }
+      if recordID.recordName == unsyncedB.uuidString {
+        #expect(recordID.zoneID.zoneName == bZone)
+      }
+    }
+  }
+
+  @Test func queueUnsyncedRecordsForAllProfilesReturnsEmptyWhenNoProfiles() throws {
+    let manager = try ProfileContainerManager.forTesting()
+    let coordinator = SyncCoordinator(
+      containerManager: manager, userDefaults: makeDefaults())
+
+    let queued = coordinator.queueUnsyncedRecordsForAllProfiles()
+    #expect(queued.isEmpty)
+  }
+
+  @Test(
+    "queueUnsyncedRecordsForAllProfiles skips profiles whose backfill scan has already run"
+  )
+  func queueUnsyncedRecordsForAllProfilesSkipsProfilesAlreadyScanned() throws {
+    let manager = try ProfileContainerManager.forTesting()
+    let defaults = makeDefaults()
+    let coordinator = SyncCoordinator(containerManager: manager, userDefaults: defaults)
+
+    let profileId = UUID()
+    let indexContext = ModelContext(manager.indexContainer)
+    indexContext.insert(
+      ProfileRecord(
+        id: profileId, label: "A", currencyCode: "AUD",
+        financialYearStartMonth: 7, createdAt: Date()))
+    try indexContext.save()
+
+    // Seed an unsynced record (nil encodedSystemFields) for this profile.
+    let accountId = UUID()
+    let context = ModelContext(try manager.container(for: profileId))
+    context.insert(
+      AccountRecord(id: accountId, name: "Unsynced", type: "bank", position: 0, isHidden: false))
+    try context.save()
+
+    // First scan should find and queue the unsynced record.
+    let first = coordinator.queueUnsyncedRecordsForAllProfiles()
+    #expect(first.map(\.recordName) == [accountId.uuidString])
+
+    // Second scan must NOT re-queue the same record — the profile has been marked
+    // as scanned and is skipped. Avoids doing a SwiftData pass on every app launch.
+    let second = coordinator.queueUnsyncedRecordsForAllProfiles()
+    #expect(second.isEmpty)
+  }
+
+  @Test(
+    "Sign-out clears all backfill-scan flags so the next sign-in can rescan"
+  )
+  func signOutClearsBackfillFlags() async throws {
+    let manager = try ProfileContainerManager.forTesting()
+    let defaults = makeDefaults()
+    let coordinator = SyncCoordinator(containerManager: manager, userDefaults: defaults)
+
+    let profileId = UUID()
+    let indexContext = ModelContext(manager.indexContainer)
+    indexContext.insert(
+      ProfileRecord(
+        id: profileId, label: "A", currencyCode: "AUD",
+        financialYearStartMonth: 7, createdAt: Date()))
+    try indexContext.save()
+
+    // Seed an unsynced record and scan so the flag is set.
+    let accountId = UUID()
+    let context = ModelContext(try manager.container(for: profileId))
+    context.insert(
+      AccountRecord(id: accountId, name: "A1", type: "bank", position: 0, isHidden: false))
+    try context.save()
+    _ = coordinator.queueUnsyncedRecordsForAllProfiles()
+
+    // Simulate the sign-out handler firing.
+    coordinator.handleSignOutForTesting()
+
+    // After sign-out, backfill state is gone — a future scan would rerun for the profile.
+    // We can't directly seed a profile back (deleteAllLocalData removed it), but we can
+    // observe the UserDefaults flag is cleared.
+    let key = "com.moolah.sync.backfillScanComplete.\(profileId.uuidString)"
+    #expect(defaults.bool(forKey: key) == false)
+  }
+
+  @Test(
+    "encryptedDataReset on a profile zone clears its backfill flag so re-queued records get tracked afresh"
+  )
+  func encryptedDataResetClearsBackfillFlag() async throws {
+    let manager = try ProfileContainerManager.forTesting()
+    let defaults = makeDefaults()
+    let coordinator = SyncCoordinator(containerManager: manager, userDefaults: defaults)
+
+    let profileId = UUID()
+    let indexContext = ModelContext(manager.indexContainer)
+    indexContext.insert(
+      ProfileRecord(
+        id: profileId, label: "A", currencyCode: "AUD",
+        financialYearStartMonth: 7, createdAt: Date()))
+    try indexContext.save()
+
+    let accountId = UUID()
+    let context = ModelContext(try manager.container(for: profileId))
+    context.insert(
+      AccountRecord(id: accountId, name: "A1", type: "bank", position: 0, isHidden: false))
+    try context.save()
+    _ = coordinator.queueUnsyncedRecordsForAllProfiles()
+
+    let zoneID = CKRecordZone.ID(
+      zoneName: "profile-\(profileId.uuidString)",
+      ownerName: CKCurrentUserDefaultName)
+    coordinator.handleEncryptedDataResetForTesting(zoneID: zoneID)
+
+    let key = "com.moolah.sync.backfillScanComplete.\(profileId.uuidString)"
+    #expect(defaults.bool(forKey: key) == false)
+  }
+
+  @Test(
+    "Server-side profile zone deletion clears the backfill flag so a re-created zone rescans"
+  )
+  func zoneDeletionClearsBackfillFlag() async throws {
+    let manager = try ProfileContainerManager.forTesting()
+    let defaults = makeDefaults()
+    let coordinator = SyncCoordinator(containerManager: manager, userDefaults: defaults)
+
+    let profileId = UUID()
+    let indexContext = ModelContext(manager.indexContainer)
+    indexContext.insert(
+      ProfileRecord(
+        id: profileId, label: "A", currencyCode: "AUD",
+        financialYearStartMonth: 7, createdAt: Date()))
+    try indexContext.save()
+
+    let context = ModelContext(try manager.container(for: profileId))
+    context.insert(
+      AccountRecord(id: UUID(), name: "A1", type: "bank", position: 0, isHidden: false))
+    try context.save()
+    _ = coordinator.queueUnsyncedRecordsForAllProfiles()
+
+    let zoneID = CKRecordZone.ID(
+      zoneName: "profile-\(profileId.uuidString)",
+      ownerName: CKCurrentUserDefaultName)
+    coordinator.handleZoneDeletedForTesting(zoneID: zoneID)
+
+    let key = "com.moolah.sync.backfillScanComplete.\(profileId.uuidString)"
+    #expect(defaults.bool(forKey: key) == false)
+  }
+
+  @Test(
+    "queueAllRecordsAfterImport marks the profile as backfilled so the startup scan skips it"
+  )
+  func queueAllRecordsAfterImportMarksBackfillComplete() async throws {
+    let manager = try ProfileContainerManager.forTesting()
+    let defaults = makeDefaults()
+    let coordinator = SyncCoordinator(containerManager: manager, userDefaults: defaults)
+
+    let profileId = UUID()
+    let indexContext = ModelContext(manager.indexContainer)
+    indexContext.insert(
+      ProfileRecord(
+        id: profileId, label: "Migrated", currencyCode: "AUD",
+        financialYearStartMonth: 7, createdAt: Date()))
+    try indexContext.save()
+
+    // Simulate what CloudKitDataImporter produces: records with nil system fields.
+    let accountId = UUID()
+    let context = ModelContext(try manager.container(for: profileId))
+    context.insert(
+      AccountRecord(id: accountId, name: "Migrated", type: "bank", position: 0, isHidden: false))
+    try context.save()
+
+    // Migration queues all records up front.
+    let queued = await coordinator.queueAllRecordsAfterImport(for: profileId)
+    #expect(queued.map(\.recordName) == [accountId.uuidString])
+
+    // A subsequent startup scan must skip this profile — migration has already done
+    // the equivalent work, and re-scanning would just do a pointless SwiftData pass.
+    let rescan = coordinator.queueUnsyncedRecordsForAllProfiles()
+    #expect(rescan.isEmpty)
+  }
+
   // MARK: - ProfileContainerManager Extensions
 
   @Test func allProfileIdsReturnsKnownProfiles() throws {


### PR DESCRIPTION
## Summary

- Migration writes records to SwiftData directly via `CloudKitDataImporter`, bypassing the repository `onRecordChanged` hooks that normally enqueue records with `CKSyncEngine`. The profile itself synced, so other devices saw it appear, but its zone was empty — only post-migration edits propagated. Fix: after a successful import, ensure the new profile's zone exists and queue every imported record, then call `sendChanges()`. Applies to `MigrationCoordinator.migrate(...)` and `.importFromFile(...)`.
- Added a startup backfill for users who migrated on earlier builds: scans each cloud profile for records whose `encodedSystemFields` is `nil` and queues them. Gated by a per-profile UserDefaults flag so the scan runs at most once per profile. The flag is cleared on sign-out, account switch, zone deletion/purge, and encrypted-data-reset so stale state can't wedge a recovery.
- Verified in the running macOS app: after clearing the backfill flag for two existing cloudKit profiles, the next launch found and queued **47,603 previously-unsynced records** for upload; `CKModifyRecordsOperation` uploads followed.

## Test plan

- [x] `just test` — 2,538 tests pass across iOS and macOS (added 9 new tests across `ProfileDataSyncHandlerTests`, `SyncCoordinatorTests`, `MigrationIntegrationTests`).
- [x] `just format-check` — clean.
- [x] `just build-mac` — no warnings in user code.
- [x] Ran the Mac app; confirmed `Backfill scan complete: N profiles total, M scanned, ... unsynced records queued` log fires at startup; CKSyncEngine begins `CKModifyRecordsOperation` uploads.
- [x] `concurrency-review` + `sync-review` + `ui-review` agents run; all findings addressed (backfill flag now cleared on sign-out / `switchAccounts` / `zoneDeleted` / `zonePurged` / `encryptedDataReset`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)