### PR TITLE
fix(positions): make all 6 table columns sortable

### DIFF
--- a/Domain/Models/ValuedPosition+Display.swift
+++ b/Domain/Models/ValuedPosition+Display.swift
@@ -55,3 +55,24 @@ extension InstrumentAmount {
     return "\(sign)\(formatted)"
   }
 }
+
+// MARK: - Sortable accessors
+
+extension ValuedPosition {
+  /// Non-optional `Decimal` view of `unitPrice` for sortable Table columns.
+  /// Missing values sort as zero — paired with the `—` placeholder rendered
+  /// in the cell, this groups failed/unknown rows together at one end.
+  var unitPriceQuantity: Decimal { unitPrice?.quantity ?? 0 }
+
+  /// Non-optional `Decimal` view of `costBasis` for sortable Table columns.
+  /// Missing values sort as zero (see `unitPriceQuantity`).
+  var costBasisQuantity: Decimal { costBasis?.quantity ?? 0 }
+
+  /// Non-optional `Decimal` view of `value` for sortable Table columns.
+  /// Missing values sort as zero (see `unitPriceQuantity`).
+  var valueQuantity: Decimal { value?.quantity ?? 0 }
+
+  /// Non-optional `Decimal` view of `gainLoss` for sortable Table columns.
+  /// Missing values sort as zero (see `unitPriceQuantity`).
+  var gainQuantity: Decimal { gainLoss?.quantity ?? 0 }
+}

--- a/Shared/Views/Positions/PositionsTable.swift
+++ b/Shared/Views/Positions/PositionsTable.swift
@@ -13,7 +13,7 @@ struct PositionsTable: View {
   @Environment(\.horizontalSizeClass) private var sizeClass
 
   @State private var sortOrder: [KeyPathComparator<ValuedPosition>] = [
-    .init(\.quantity, order: .reverse)
+    .init(\.valueQuantity, order: .reverse)
   ]
 
   var body: some View {
@@ -57,28 +57,28 @@ struct PositionsTable: View {
         Text(row.quantityFormatted)
           .monospacedDigit()
       }
-      TableColumn("Unit Price") { row in
+      TableColumn("Unit Price", value: \.unitPriceQuantity) { row in
         if let unit = row.unitPrice {
           Text(unit.formatted).monospacedDigit()
         } else {
           Text("—").foregroundStyle(.tertiary)
         }
       }
-      TableColumn("Cost") { row in
+      TableColumn("Cost", value: \.costBasisQuantity) { row in
         if let cost = row.costBasis {
           Text(cost.formatted).monospacedDigit()
         } else {
           Text("—").foregroundStyle(.tertiary)
         }
       }
-      TableColumn("Value") { row in
+      TableColumn("Value", value: \.valueQuantity) { row in
         if let value = row.value {
           Text(value.formatted).monospacedDigit()
         } else {
           Text("—").foregroundStyle(.tertiary)
         }
       }
-      TableColumn("Gain") { row in
+      TableColumn("Gain", value: \.gainQuantity) { row in
         if let gain = row.gainLoss {
           Text(gain.signedFormatted)
             .monospacedDigit()


### PR DESCRIPTION
## Summary

Followup to #205. The wide-layout `Table` in `PositionsView` only had sortable headers on Instrument and Qty — the four monetary columns (Unit Price, Cost, Value, Gain) silently no-op'd on click because their underlying values are `InstrumentAmount?` and `KeyPathComparator` over an optional doesn't compile cleanly.

Fix: add four non-optional `Decimal` accessors on `ValuedPosition` (`unitPriceQuantity`, `costBasisQuantity`, `valueQuantity`, `gainQuantity`) that surface `nil` as `0`. The cells still render `—` for nil (so failed/unknown values are visually distinct), but they now sort consistently — grouping nil rows at one end of the column.

Also flips the default sort to **Value descending** (matches the design spec's "Default sort: value descending"). Was previously `quantity descending`.

## Test plan
- [x] `just build-mac` clean
- [x] `just build-ios` clean
- [x] `just format-check` clean
- [ ] Click each of the 6 column headers in turn — each cycles between ascending and descending.
- [ ] Default sort on first open is highest-value first.
- [ ] Failed-conversion rows (with `—` cells) sort consistently when their column is the sort axis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)