### PR TITLE
fix(tests): strip iCloud entitlements from the test host (#206)

### DIFF
--- a/plans/2026-04-20-strip-icloud-from-tests-design.md
+++ b/plans/2026-04-20-strip-icloud-from-tests-design.md
@@ -1,0 +1,204 @@
+# Strip iCloud Entitlements From Test Builds — Design
+
+Resolves: [#206](https://github.com/ajsutton/moolah-native/issues/206).
+
+## Background
+
+The flaky `AnalysisRepositoryContractTests/holding revalues daily as exchange rate changes` failure was traced to the test process booting the real `SyncCoordinator` against the developer's iCloud account. Via SwiftData's shared process state, those records bled into the test's in-memory `ModelContainer` and surfaced as a ~3272.77 AUD phantom offset.
+
+A first fix (commit `4194767`) added two runtime guards in `App/MoolahApp.swift` and `MoolahTests/Support/TestModelContainer.swift`:
+
+- `SyncCoordinator.start()` is skipped when `NSClassFromString("XCTestCase") != nil`.
+- The test container sets `cloudKitDatabase: .none` to block SwiftData automatic mirroring.
+
+That made the tests pass, but left the structural hole open: the test host binary is still signed with iCloud entitlements when `ENABLE_ENTITLEMENTS=1` is set locally. Any new test that directly calls `CKContainer.default()` / `CKSyncEngine` would quietly succeed against real iCloud.
+
+### How entitlements reach the test host today
+
+Three build paths:
+
+1. **Default (`ENABLE_ENTITLEMENTS=0`, CI and most local dev)** — committed `project.yml` contains no entitlements. `CLOUDKIT_ENABLED` is only set for the `Release` config. Test host has no iCloud capability. *Safe.*
+2. **Local CloudKit dev (`ENABLE_ENTITLEMENTS=1`)** — `scripts/inject-entitlements.sh` writes a temporary `project-entitlements.yml` that (a) adds an `entitlements:` block with iCloud container + CloudKit services to each app target, applied across **every configuration**, and (b) adds `CLOUDKIT_ENABLED` to `settings.base`, again across every configuration. `just test` uses the Debug config, so it inherits both. *Leaks iCloud into tests.*
+3. **`fastlane` distribution (TestFlight / validate)** — the `Fastfile` passes `CODE_SIGN_ENTITLEMENTS=fastlane/Moolah.entitlements` to the archive build. Tests are not executed. *Out of scope.*
+
+Only path 2 is the target. But the fix must be structural enough that path 1 stays safe even if someone later commits iCloud entitlements directly into `project.yml`.
+
+## Goal
+
+Repeat from the issue:
+
+1. The binary used as the test host must not be signed with any `iCloud.*` entitlement.
+2. `CKContainer.default()` / `CKSyncEngine` calls from test code should fail cleanly rather than succeed silently against the developer's iCloud.
+
+And the acceptance criteria:
+
+- `just test` on macOS and iOS still passes on a machine signed into iCloud.
+- No `iCloud.rocks.moolah.app.v2` entitlement on the binary used by `xcodebuild test` (verified with `codesign -d --entitlements :-`).
+- `[BackgroundSync] CloudKit available — starting sync coordinator` never logs during `just test`.
+- CI stays green (no new signing / provisioning requirements).
+
+## Non-goals
+
+- Restructuring app sources into a framework for host-less testing.
+- Changing `fastlane` distribution flow.
+- Removing runtime defence (the `NSClassFromString("XCTestCase")` gate and `cloudKitDatabase: .none` stay).
+
+## Approach
+
+A dedicated `Debug-Tests` build configuration, selected by the test action of every scheme, that cannot receive iCloud entitlements regardless of what else happens to the Debug config.
+
+The scheme's test action is what `xcodebuild test -scheme …` runs, so `just test`, `just test-ios`, `just test-mac`, and `just benchmark` all pick up the new config automatically. The run action stays on Debug, so local `just run-mac` keeps iCloud.
+
+### Why not options B or C
+
+- **Separate `Moolah_*_TestHost` app targets (B)** — strongest isolation but doubles target surface. Every future change to `Moolah_iOS` / `Moolah_macOS` (new framework dep, new source directory, new Info.plist key) has to be mirrored. Option A gets the same default-safety from one new config.
+- **Host-less test target (C)** — requires extracting app sources into a framework. Breaks `@main` assumptions and anything reading `Bundle.main`. Worth considering for a broader test-architecture refactor, but not for this issue.
+
+## Changes
+
+### 1. Declare the configurations (`project.yml`)
+
+Add a top-level `configs:` block (currently missing — xcodegen uses its defaults of Debug/Release):
+
+```yaml
+configs:
+  Debug: debug
+  Debug-Tests: debug
+  Release: release
+```
+
+`Debug-Tests` inherits all Debug behaviour (optimisation off, debug symbols, assertions on) but is a distinct named config that per-target overrides and per-scheme selection can target.
+
+### 2. Per-target overrides (`project.yml`)
+
+For both `Moolah_iOS` and `Moolah_macOS`, add a `Debug-Tests` override that explicitly clears iCloud:
+
+```yaml
+    configs:
+      Debug-Tests:
+        CODE_SIGN_ENTITLEMENTS: ""
+        SWIFT_ACTIVE_COMPILATION_CONDITIONS: "$(inherited)"
+      Release:
+        # existing Release block stays unchanged
+```
+
+`CODE_SIGN_ENTITLEMENTS: ""` overrides any entitlements file set at target scope by the inject script — so even if `Debug` later gets iCloud pinned into `project.yml` directly, `Debug-Tests` still signs with no entitlements file. The `SWIFT_ACTIVE_COMPILATION_CONDITIONS: "$(inherited)"` line ensures `CLOUDKIT_ENABLED` does not leak in through base settings; `$(inherited)` here deliberately drops any condition that only exists at base scope and is not otherwise re-added.
+
+No changes needed on `MoolahTests_iOS`, `MoolahTests_macOS`, `MoolahBenchmarks_macOS` — they already have `CODE_SIGNING_REQUIRED: NO` / ad-hoc signing, and inherit host config from the scheme.
+
+### 3. Point each test scheme at `Debug-Tests` (`project.yml`)
+
+Update the `test:` action of every scheme:
+
+```yaml
+schemes:
+  Moolah-iOS:
+    build:
+      targets:
+        Moolah_iOS: all
+    test:
+      config: Debug-Tests
+      targets:
+        - MoolahTests_iOS
+
+  Moolah-macOS:
+    build:
+      targets:
+        Moolah_macOS: all
+    test:
+      config: Debug-Tests
+      targets:
+        - MoolahTests_macOS
+
+  Moolah-Benchmarks:
+    build:
+      targets:
+        Moolah_macOS: all
+        MoolahBenchmarks_macOS: [test]
+    test:
+      config: Debug-Tests
+      targets:
+        - MoolahBenchmarks_macOS
+```
+
+The default `Moolah` scheme (run-only, no test action) stays on Debug — it's what `just run-mac` uses.
+
+### 4. Scope injected entitlements to `Debug` (`scripts/inject-entitlements.sh`)
+
+Rewrite the script so that when `ENABLE_ENTITLEMENTS=1`:
+
+- The entitlements block is nested under `configs.Debug:` on each app target (not at target scope).
+- `CLOUDKIT_ENABLED` is added under `settings.configs.Debug:` (not `settings.base:`).
+
+After the change, with `ENABLE_ENTITLEMENTS=1`:
+
+| Config       | Entitlements file                    | `CLOUDKIT_ENABLED` |
+|--------------|--------------------------------------|--------------------|
+| Debug        | `.build/Moolah.entitlements` (full)  | Yes                |
+| Debug-Tests  | none (explicitly empty)              | No                 |
+| Release      | (fastlane xcargs)                    | Yes (committed)    |
+
+With `ENABLE_ENTITLEMENTS=0` (CI default), no injection happens; Debug-Tests still resolves to "no entitlements" and carries no `CLOUDKIT_ENABLED`.
+
+### 5. Post-build verification (`scripts/test.sh`)
+
+After the `xcodebuild test` run completes on each platform, assert the test host binary was not signed with any iCloud entitlement. This catches regressions in the config wiring even when no test explicitly triggers sync.
+
+A new script `scripts/assert-no-icloud-in-test-host.sh`:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+HOST="$1"
+if codesign -d --entitlements :- "$HOST" 2>&1 | grep -qi 'icloud'; then
+  echo "ERROR: test host $HOST is signed with iCloud entitlements" >&2
+  codesign -d --entitlements :- "$HOST" >&2 || true
+  exit 1
+fi
+```
+
+`scripts/test.sh` calls it at the end of `run_mac` / `run_ios` with the appropriate derived-data path. On macOS the target is `…/Debug-Tests/Moolah.app/Contents/MacOS/Moolah`; on iOS Simulator it is `…/Debug-Tests-iphonesimulator/Moolah.app`.
+
+The check is cheap (one `codesign` spawn per platform) and runs on every `just test`. If it fires, the test run exits non-zero and CI fails.
+
+### 6. Runtime defence stays in place
+
+Per the decision made during brainstorming, the `NSClassFromString("XCTestCase")` gate in `App/MoolahApp.swift` and the `cloudKitDatabase: .none` setting in `MoolahTests/Support/TestModelContainer.swift` remain as belt-and-braces. They protect against any future path that reintroduces iCloud access to the test host (e.g. someone explicitly running the test scheme with `-configuration Debug`).
+
+## Verification plan
+
+Manual checks before landing:
+
+1. `ENABLE_ENTITLEMENTS=1 just test` on macOS signed into iCloud — passes.
+2. `codesign -d --entitlements :- .DerivedData-mac/Build/Products/Debug-Tests/Moolah.app/Contents/MacOS/Moolah` — no `iCloud.*` keys.
+3. `ENABLE_ENTITLEMENTS=1 just run-mac` — app launches with iCloud working (sync coordinator starts, profiles load).
+4. `codesign -d --entitlements :- .build/Build/Products/Debug/Moolah.app/Contents/MacOS/Moolah` — includes `com.apple.developer.icloud-container-identifiers`.
+5. `just test` with `ENABLE_ENTITLEMENTS=0` — passes on both platforms.
+6. `just benchmark` — still runs.
+7. `just generate` in both modes — produces a valid project.
+8. `ENABLE_ENTITLEMENTS=1 just test` filtering log output for `CloudKit available — starting sync coordinator` — zero occurrences.
+
+Automated: `scripts/assert-no-icloud-in-test-host.sh` runs every test invocation, including CI.
+
+## Risks and trade-offs
+
+- **Extra config dimension.** Devs opening the project in Xcode will see `Debug-Tests` in the configuration dropdown. Benign; `Debug` stays the default for Run. Documented in `justfile` comments for discoverability.
+- **xcodegen scheme regeneration.** The test config must be written into the generated `.xcscheme` XML. xcodegen supports `test.config:` — verify during implementation (fall back to `test.configuration:` key if the former doesn't apply).
+- **Inject-script regex fragility.** `scripts/inject-entitlements.sh` currently pattern-matches target headers with a regex. Scoping under `configs.Debug:` means it has to find or create that nested block on each target. The rewrite is small but the script becomes slightly more coupled to `project.yml` layout. Mitigation: add a sanity assertion at the end that both `Debug` entitlements blocks exist in the generated file, and bail if not.
+- **Partial fastlane coverage.** This design does nothing for `fastlane` because fastlane uses `-configuration Release` and does not run tests. If that ever changes (e.g. UI tests on TestFlight), the new scheme-based wiring must be revisited.
+
+## Out of scope
+
+- Removing the `ENABLE_ENTITLEMENTS=1` flow in favour of committing entitlements directly to `project.yml`. Would require provisioning-profile changes on CI and is a separate conversation.
+- Converting test targets to host-less bundles (Option C).
+- Replacing runtime XCTest gate with environment-variable gate (orthogonal; a later cleanup if desired).
+
+## Acceptance criteria checklist
+
+- [ ] `just test` (iOS + macOS) passes on a machine signed into iCloud with `ENABLE_ENTITLEMENTS=1`.
+- [ ] `just test` passes on CI with `ENABLE_ENTITLEMENTS=0`.
+- [ ] `codesign -d --entitlements :-` on the Debug-Tests host shows no `iCloud.*` keys.
+- [ ] `[BackgroundSync] CloudKit available — starting sync coordinator` never logs during `just test`.
+- [ ] `just run-mac` with `ENABLE_ENTITLEMENTS=1` still starts the sync coordinator and reaches iCloud.
+- [ ] `scripts/assert-no-icloud-in-test-host.sh` invoked by `scripts/test.sh` on both platforms.
+- [ ] Runtime XCTest gate in `MoolahApp.init()` and `cloudKitDatabase: .none` in `TestModelContainer` preserved.

--- a/project.yml
+++ b/project.yml
@@ -6,6 +6,14 @@ options:
   defaultConfig: Debug
   bundleIdPrefix: rocks.moolah
 
+# Debug-Tests is an iCloud-free variant of Debug used by every scheme's test
+# action. Keeps local `ENABLE_ENTITLEMENTS=1` dev flows (run on Debug) isolated
+# from `just test` — see plans/2026-04-20-strip-icloud-from-tests-design.md.
+configs:
+  Debug: debug
+  Debug-Tests: debug
+  Release: release
+
 settings:
   base:
     SWIFT_VERSION: "6.0"
@@ -62,6 +70,11 @@ targets:
         INFOPLIST_FILE: App/Info-iOS.plist
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
       configs:
+        Debug-Tests:
+          # Tests must never pick up iCloud entitlements, even when a dev
+          # runs `ENABLE_ENTITLEMENTS=1 just generate` to inject them into Debug.
+          CODE_SIGN_ENTITLEMENTS: ""
+          SWIFT_ACTIVE_COMPILATION_CONDITIONS: "$(inherited)"
         Release:
           SWIFT_ACTIVE_COMPILATION_CONDITIONS: "$(inherited) CLOUDKIT_ENABLED"
 
@@ -87,6 +100,11 @@ targets:
         INFOPLIST_FILE: App/Info-macOS.plist
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
       configs:
+        Debug-Tests:
+          # Tests must never pick up iCloud entitlements, even when a dev
+          # runs `ENABLE_ENTITLEMENTS=1 just generate` to inject them into Debug.
+          CODE_SIGN_ENTITLEMENTS: ""
+          SWIFT_ACTIVE_COMPILATION_CONDITIONS: "$(inherited)"
         Release:
           ENABLE_HARDENED_RUNTIME: YES
           SWIFT_ACTIVE_COMPILATION_CONDITIONS: "$(inherited) CLOUDKIT_ENABLED"
@@ -157,6 +175,7 @@ schemes:
       targets:
         Moolah_iOS: all
     test:
+      config: Debug-Tests
       targets:
         - MoolahTests_iOS
 
@@ -165,6 +184,7 @@ schemes:
       targets:
         Moolah_macOS: all
     test:
+      config: Debug-Tests
       targets:
         - MoolahTests_macOS
 
@@ -174,5 +194,6 @@ schemes:
         Moolah_macOS: all
         MoolahBenchmarks_macOS: [test]
     test:
+      config: Debug-Tests
       targets:
         - MoolahBenchmarks_macOS

--- a/scripts/assert-no-icloud-in-test-host.sh
+++ b/scripts/assert-no-icloud-in-test-host.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Verifies that the binary used as test host is not signed with any iCloud
+# entitlement. Fails the test run if one is found. Called by scripts/test.sh
+# after a platform's test action completes. See
+# plans/2026-04-20-strip-icloud-from-tests-design.md.
+set -euo pipefail
+
+HOST="${1:-}"
+if [[ -z "$HOST" ]]; then
+    echo "usage: $0 <path-to-host-binary>" >&2
+    exit 2
+fi
+
+if [[ ! -e "$HOST" ]]; then
+    # Missing binary is not itself a leak, but indicates the caller passed the
+    # wrong path — surface it rather than silently "pass".
+    echo "ERROR: test host binary not found at $HOST" >&2
+    exit 2
+fi
+
+# `codesign -d --entitlements :-` writes the entitlements plist to stdout and
+# logs framing like `Executable=...` to stderr. Grep stdout only.
+entitlements="$(codesign -d --entitlements :- "$HOST" 2>/dev/null || true)"
+
+if printf '%s' "$entitlements" | grep -qi 'icloud'; then
+    echo "ERROR: test host $HOST is signed with iCloud entitlements:" >&2
+    printf '%s\n' "$entitlements" >&2
+    exit 1
+fi

--- a/scripts/inject-entitlements.sh
+++ b/scripts/inject-entitlements.sh
@@ -1,43 +1,86 @@
 #!/usr/bin/env bash
-# Creates a temporary project.yml with entitlements in the project directory.
-# Prints the path to the temp file. Caller cleans up.
+# Prepares the build tree for local CloudKit development.
+#
+# 1. Writes .build/Moolah.entitlements with the full sandbox + CloudKit keys.
+# 2. Produces project-entitlements.yml — a copy of project.yml with a
+#    Debug-only settings block added to each app target that wires in
+#    CODE_SIGN_ENTITLEMENTS and the CLOUDKIT_ENABLED compilation condition.
+#
+# The Debug-Tests configuration deliberately does NOT get these, so
+# `just test` never signs the test host with iCloud entitlements. See
+# plans/2026-04-20-strip-icloud-from-tests-design.md.
+#
+# Prints the path to the temp project file. Caller cleans up.
 set -euo pipefail
 
 TEMP_FILE="project-entitlements.yml"
+ENTITLEMENTS_FILE=".build/Moolah.entitlements"
 
-OUTFILE="$TEMP_FILE" python3 << 'EOF'
-import re, os
+mkdir -p "$(dirname "$ENTITLEMENTS_FILE")"
+cat > "$ENTITLEMENTS_FILE" <<'PLIST'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.app-sandbox</key>
+    <true/>
+    <key>com.apple.security.network.client</key>
+    <true/>
+    <key>com.apple.security.files.user-selected.read-write</key>
+    <true/>
+    <key>com.apple.developer.icloud-services</key>
+    <array>
+        <string>CloudKit</string>
+    </array>
+    <key>com.apple.developer.icloud-container-identifiers</key>
+    <array>
+        <string>iCloud.rocks.moolah.app.v2</string>
+    </array>
+</dict>
+</plist>
+PLIST
+
+OUTFILE="$TEMP_FILE" ENTITLEMENTS_FILE="$ENTITLEMENTS_FILE" python3 << 'PY'
+import os
 
 with open("project.yml") as f:
     content = f.read()
 
-entitlements_block = "\n".join([
-    "    entitlements:",
-    "      path: .build/Moolah.entitlements",
-    "      properties:",
-    "        com.apple.security.app-sandbox: true",
-    "        com.apple.security.network.client: true",
-    "        com.apple.security.files.user-selected.read-write: true",
-    "        com.apple.developer.icloud-services:",
-    "          - CloudKit",
-    "        com.apple.developer.icloud-container-identifiers:",
-    "          - iCloud.rocks.moolah.app.v2",
+entitlements_path = os.environ["ENTITLEMENTS_FILE"]
+
+debug_block = "\n".join([
+    "        Debug:",
+    f"          CODE_SIGN_ENTITLEMENTS: {entitlements_path}",
+    '          SWIFT_ACTIVE_COMPILATION_CONDITIONS: "$(inherited) CLOUDKIT_ENABLED"',
+    "",
 ])
 
-for target in ["Moolah_iOS", "Moolah_macOS"]:
-    pattern = rf"(  {target}:\n    type: application\n    platform: (?:iOS|macOS)\n)"
-    content = re.sub(pattern, lambda m: m.group(0) + entitlements_block + "\n", content)
+for target in ("Moolah_iOS", "Moolah_macOS"):
+    target_header = f"  {target}:\n    type: application\n"
+    target_start = content.find(target_header)
+    if target_start == -1:
+        raise SystemExit(f"inject-entitlements: could not find target {target}")
 
-# Add CLOUDKIT_ENABLED Swift compilation condition so isCloudKitAvailable
-# can gate CKContainer usage at compile time (prevents NSException crash
-# in builds without CloudKit entitlements).
-content = content.replace(
-    'SWIFT_TREAT_WARNINGS_AS_ERRORS: YES',
-    'SWIFT_TREAT_WARNINGS_AS_ERRORS: YES\n    SWIFT_ACTIVE_COMPILATION_CONDITIONS: "$(inherited) CLOUDKIT_ENABLED"'
-)
+    configs_marker = "      configs:\n"
+    configs_pos = content.find(configs_marker, target_start)
+    if configs_pos == -1:
+        raise SystemExit(
+            f"inject-entitlements: could not find configs: block for {target}"
+        )
+
+    insert_at = configs_pos + len(configs_marker)
+    content = content[:insert_at] + debug_block + content[insert_at:]
+
+# Sanity check — both app targets now carry a Debug-scoped entitlement block.
+marker = "        Debug:\n          CODE_SIGN_ENTITLEMENTS:"
+if content.count(marker) != 2:
+    raise SystemExit(
+        "inject-entitlements: expected 2 Debug entitlement blocks, "
+        f"found {content.count(marker)}"
+    )
 
 with open(os.environ["OUTFILE"], "w") as f:
     f.write(content)
-EOF
+PY
 
 echo "$TEMP_FILE"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -58,6 +58,8 @@ run_ios() {
         -scheme Moolah-iOS \
         -destination "platform=iOS Simulator,name=$IOS_SIMULATOR" \
         ${filter_flags[@]+"${filter_flags[@]}"}
+    bash "$REPO_ROOT/scripts/assert-no-icloud-in-test-host.sh" \
+        "$REPO_ROOT/.DerivedData-ios/Build/Products/Debug-Tests-iphonesimulator/Moolah.app/Moolah"
 }
 
 run_mac() {
@@ -71,6 +73,8 @@ run_mac() {
         -scheme Moolah-macOS \
         -destination "platform=macOS" \
         ${filter_flags[@]+"${filter_flags[@]}"}
+    bash "$REPO_ROOT/scripts/assert-no-icloud-in-test-host.sh" \
+        "$REPO_ROOT/.DerivedData-mac/Build/Products/Debug-Tests/Moolah.app/Contents/MacOS/Moolah"
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Resolves [#206](https://github.com/ajsutton/moolah-native/issues/206). Adds a dedicated `Debug-Tests` build configuration that every scheme's test action selects, so the host binary running `xcodebuild test` is never signed with iCloud entitlements — even when a dev has `ENABLE_ENTITLEMENTS=1` set for local CloudKit work on the Debug config.

- New `Debug-Tests` config in `project.yml`; both app targets override it to set `CODE_SIGN_ENTITLEMENTS=""` and keep `SWIFT_ACTIVE_COMPILATION_CONDITIONS` at `$(inherited)` (no `CLOUDKIT_ENABLED`).
- `Moolah-iOS`, `Moolah-macOS`, and `Moolah-Benchmarks` scheme test actions now use `Debug-Tests`.
- `scripts/inject-entitlements.sh` rewritten to scope injections to `Debug` only: writes `.build/Moolah.entitlements` directly, then adds `CODE_SIGN_ENTITLEMENTS` + `CLOUDKIT_ENABLED` inside each app target's `settings.configs.Debug` block. `Release` is untouched.
- New `scripts/assert-no-icloud-in-test-host.sh` runs after every `xcodebuild test` and fails the run if the host binary contains any `iCloud` key.
- Runtime `NSClassFromString("XCTestCase")` gate and `cloudKitDatabase: .none` stay in place as defence in depth.

Full design in `plans/2026-04-20-strip-icloud-from-tests-design.md`.

## Test plan

Verified locally with `ENABLE_ENTITLEMENTS=1`:

- [x] `just test` passes on iOS Simulator + macOS (1319 tests).
- [x] `codesign -d --entitlements :-` on the macOS Debug-Tests host shows no `iCloud.*` keys (only `get-task-allow` and testmanagerd lookups).
- [x] iOS Debug-Tests host carries no entitlements (simulator, unsigned).
- [x] `codesign -d --entitlements :-` on the Debug (run) host still shows `com.apple.developer.icloud-container-identifiers` — so `just run-mac` keeps working with real iCloud.
- [x] No `CloudKit available — starting sync coordinator` log during `just test`.
- [x] `scripts/assert-no-icloud-in-test-host.sh` fires (exit 1) when pointed at the leaky Debug host — negative case works.
- [x] `just generate` works in both `ENABLE_ENTITLEMENTS=0` and `ENABLE_ENTITLEMENTS=1` modes.
- [x] `just format-check` clean.

## Test plan for reviewer

- [ ] CI green on `fix/strip-icloud-from-tests`.
- [ ] After merge, run `just test` with `ENABLE_ENTITLEMENTS=1` locally — still passes; no iCloud on the Debug-Tests host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)