### PR TITLE
feat(csv-import): Phase F — Recently Added view + rules store

### DIFF
--- a/App/ContentView.swift
+++ b/App/ContentView.swift
@@ -76,6 +76,8 @@ struct ContentView: View {
             transactionStore: transactionStore,
             analysisRepository: analysisStore.repository)
         }
+      case .recentlyAdded:
+        RecentlyAddedView(backend: session.backend)
       case .allTransactions:
         TransactionListView(
           title: "All Transactions",

--- a/App/ProfileSession.swift
+++ b/App/ProfileSession.swift
@@ -23,6 +23,7 @@ final class ProfileSession: Identifiable {
   let cryptoPriceService: CryptoPriceService
   let cryptoTokenStore: CryptoTokenStore
   let importStore: ImportStore
+  let importRuleStore: ImportRuleStore
 
   /// Observer token for sync coordinator notifications (nil for remote profiles).
   private var syncObserverToken: SyncCoordinator.ObserverToken?
@@ -180,6 +181,7 @@ final class ProfileSession: Identifiable {
         "Failed to open CSV import staging at \(stagingPath, privacy: .public): \(errDesc, privacy: .public). Falling back to tmp."
       )
     }
+    self.importRuleStore = ImportRuleStore(repository: backend.importRules)
 
     // Wire up cross-store side effects. The callback is fire-and-forget in
     // production; `updateInvestmentValue` awaits its own first conversion
@@ -312,6 +314,9 @@ final class ProfileSession: Identifiable {
       if plan.contains(.earmarks) {
         await earmarkStore.reloadFromSync()
       }
+      if plan.contains(.importRules) {
+        await importRuleStore.reloadFromSync()
+      }
       let reloadMs = (ContinuousClock.now - reloadStart).inMilliseconds
       logger.info("📊 Store reloads after sync completed in \(reloadMs)ms for types: \(types)")
     }
@@ -325,11 +330,13 @@ final class ProfileSession: Identifiable {
   /// so a remote leg-only change (e.g. category/earmark reassignment performed
   /// on another device) must reload both stores even if the parent
   /// `TransactionRecord` did not change in this batch.
+  // StoreReloadPlan follows the OptionSet pattern for coalesced sync reloads.
   struct StoreReloadPlan: OptionSet, Sendable, Equatable {
     let rawValue: Int
     static let accounts = StoreReloadPlan(rawValue: 1 << 0)
     static let categories = StoreReloadPlan(rawValue: 1 << 1)
     static let earmarks = StoreReloadPlan(rawValue: 1 << 2)
+    static let importRules = StoreReloadPlan(rawValue: 1 << 3)
   }
 
   static func storesToReload(for changedTypes: Set<String>) -> StoreReloadPlan {
@@ -349,12 +356,13 @@ final class ProfileSession: Identifiable {
     {
       plan.insert(.earmarks)
     }
-    // NOTE: CSVImportProfileRecord and ImportRuleRecord arrive through sync but
-    // have no dedicated stores yet. Phase F of the CSV import feature will add
-    // CSVImportProfileStore and ImportRuleStore; this function will need
-    // corresponding `plan.insert(…)` entries at that point. Until then, remote
-    // changes land in SwiftData but no observer is notified — acceptable because
-    // there's no UI consuming them yet.
+    if changedTypes.contains(ImportRuleRecord.recordType) {
+      plan.insert(.importRules)
+    }
+    // NOTE: CSVImportProfileRecord has no dedicated store — the setup form
+    // fetches profiles directly via `backend.csvImportProfiles`. Remote
+    // changes land in SwiftData; the setup form reads through to the fresh
+    // values on its own `task`.
     return plan
   }
 

--- a/App/ProfileSession.swift
+++ b/App/ProfileSession.swift
@@ -22,6 +22,7 @@ final class ProfileSession: Identifiable {
   let stockPriceService: StockPriceService
   let cryptoPriceService: CryptoPriceService
   let cryptoTokenStore: CryptoTokenStore
+  let importStore: ImportStore
 
   /// Observer token for sync coordinator notifications (nil for remote profiles).
   private var syncObserverToken: SyncCoordinator.ObserverToken?
@@ -154,6 +155,31 @@ final class ProfileSession: Identifiable {
       conversionService: backend.conversionService,
       profileCurrency: profile.instrument
     )
+
+    // CSV import: ImportStore owns the pipeline orchestration; the staging
+    // store lives per-profile on disk so pending/failed files follow the
+    // profile across app restarts.
+    let stagingDirectory = ProfileSession.importStagingDirectory(for: profile.id)
+    do {
+      let staging = try ImportStagingStore(directory: stagingDirectory)
+      self.importStore = ImportStore(backend: backend, staging: staging)
+    } catch {
+      // Fall back to a scratch staging store in a temporary directory. This
+      // keeps the store non-optional — pending/failed files won't persist
+      // across app restarts in this degraded mode but the pipeline still
+      // works.
+      let fallback = FileManager.default.temporaryDirectory
+        .appendingPathComponent("csv-staging-fallback-\(profile.id.uuidString)")
+      // swiftlint:disable:next force_try — fallback in a tmp dir cannot fail
+      // in practice on Apple platforms.
+      let staging = try! ImportStagingStore(directory: fallback)
+      self.importStore = ImportStore(backend: backend, staging: staging)
+      let errDesc = error.localizedDescription
+      let stagingPath = stagingDirectory.path
+      logger.error(
+        "Failed to open CSV import staging at \(stagingPath, privacy: .public): \(errDesc, privacy: .public). Falling back to tmp."
+      )
+    }
 
     // Wire up cross-store side effects. The callback is fire-and-forget in
     // production; `updateInvestmentValue` awaits its own first conversion
@@ -342,5 +368,23 @@ final class ProfileSession: Identifiable {
     }
     syncReloadTask?.cancel()
     syncReloadTask = nil
+  }
+
+  /// Per-profile directory under Application Support where CSV import staging
+  /// lives. Not part of the SwiftData store because staging is device-local
+  /// and doesn't sync.
+  nonisolated static func importStagingDirectory(for profileId: UUID) -> URL {
+    let base =
+      (try? FileManager.default.url(
+        for: .applicationSupportDirectory,
+        in: .userDomainMask,
+        appropriateFor: nil,
+        create: true))
+      ?? FileManager.default.temporaryDirectory
+    return
+      base
+      .appendingPathComponent("Moolah", isDirectory: true)
+      .appendingPathComponent("csv-staging", isDirectory: true)
+      .appendingPathComponent(profileId.uuidString, isDirectory: true)
   }
 }

--- a/App/SessionRootView.swift
+++ b/App/SessionRootView.swift
@@ -17,6 +17,7 @@ struct SessionRootView: View {
       .environment(session.analysisStore)
       .environment(session.investmentStore)
       .environment(session.reportingStore)
+      .environment(session.importStore)
       .focusedSceneValue(\.authStore, session.authStore)
       .focusedSceneValue(\.activeProfileSession, session)
   }

--- a/App/SessionRootView.swift
+++ b/App/SessionRootView.swift
@@ -18,6 +18,7 @@ struct SessionRootView: View {
       .environment(session.investmentStore)
       .environment(session.reportingStore)
       .environment(session.importStore)
+      .environment(session.importRuleStore)
       .focusedSceneValue(\.authStore, session.authStore)
       .focusedSceneValue(\.activeProfileSession, session)
   }

--- a/Features/Import/ImportRuleStore.swift
+++ b/Features/Import/ImportRuleStore.swift
@@ -34,6 +34,20 @@ final class ImportRuleStore {
     }
   }
 
+  /// Re-fetch rules without flipping `isLoading` or clearing `error`. Called
+  /// when CloudKit delivers a remote change to an `ImportRuleRecord`. Replaces
+  /// `rules` only when the fetched list differs so observers don't churn on
+  /// no-op syncs.
+  func reloadFromSync() async {
+    do {
+      let fresh = try await repository.fetchAll().sorted { $0.position < $1.position }
+      if fresh != rules { rules = fresh }
+    } catch {
+      logger.error(
+        "Sync reload of rules failed: \(error.localizedDescription, privacy: .public)")
+    }
+  }
+
   @discardableResult
   func create(_ rule: ImportRule) async -> ImportRule? {
     do {

--- a/Features/Import/ImportRuleStore.swift
+++ b/Features/Import/ImportRuleStore.swift
@@ -1,0 +1,140 @@
+import Foundation
+import OSLog
+import Observation
+
+/// Thin wrapper around `ImportRuleRepository`. Exposes an ordered `rules`
+/// list for the rules settings view and a helper that counts how many
+/// already-imported transactions would match a candidate rule (live preview).
+@Observable
+@MainActor
+final class ImportRuleStore {
+
+  private(set) var rules: [ImportRule] = []
+  private(set) var isLoading = false
+  private(set) var error: String?
+
+  private let repository: any ImportRuleRepository
+  private let logger = Logger(subsystem: "com.moolah.app", category: "ImportRuleStore")
+
+  init(repository: any ImportRuleRepository) {
+    self.repository = repository
+  }
+
+  func load() async {
+    guard !isLoading else { return }
+    isLoading = true
+    defer { isLoading = false }
+    error = nil
+    do {
+      let all = try await repository.fetchAll()
+      rules = all.sorted { $0.position < $1.position }
+    } catch {
+      self.error = error.localizedDescription
+      logger.error("Load rules failed: \(error.localizedDescription, privacy: .public)")
+    }
+  }
+
+  @discardableResult
+  func create(_ rule: ImportRule) async -> ImportRule? {
+    do {
+      let saved = try await repository.create(rule)
+      rules.append(saved)
+      rules.sort { $0.position < $1.position }
+      return saved
+    } catch {
+      self.error = error.localizedDescription
+      logger.error("Create rule failed: \(error.localizedDescription, privacy: .public)")
+      return nil
+    }
+  }
+
+  @discardableResult
+  func update(_ rule: ImportRule) async -> ImportRule? {
+    do {
+      let saved = try await repository.update(rule)
+      if let index = rules.firstIndex(where: { $0.id == saved.id }) {
+        rules[index] = saved
+      }
+      rules.sort { $0.position < $1.position }
+      return saved
+    } catch {
+      self.error = error.localizedDescription
+      logger.error("Update rule failed: \(error.localizedDescription, privacy: .public)")
+      return nil
+    }
+  }
+
+  func delete(id: UUID) async {
+    do {
+      try await repository.delete(id: id)
+      rules.removeAll { $0.id == id }
+    } catch {
+      self.error = error.localizedDescription
+      logger.error("Delete rule failed: \(error.localizedDescription, privacy: .public)")
+    }
+  }
+
+  func reorder(_ orderedIds: [UUID]) async {
+    do {
+      try await repository.reorder(orderedIds)
+      let indexById = Dictionary(
+        uniqueKeysWithValues: orderedIds.enumerated().map { ($1, $0) })
+      for index in rules.indices {
+        rules[index].position = indexById[rules[index].id] ?? rules[index].position
+      }
+      rules.sort { $0.position < $1.position }
+    } catch {
+      self.error = error.localizedDescription
+      logger.error("Reorder rules failed: \(error.localizedDescription, privacy: .public)")
+    }
+  }
+
+  /// Live preview: given a candidate set of conditions + match mode, count
+  /// how many already-imported transactions would match. The rule-editor
+  /// view debounces before calling so we don't hammer the backend on every
+  /// keystroke.
+  func countAffected(
+    conditions: [RuleCondition],
+    matchMode: MatchMode,
+    accountScope: UUID?,
+    backend: any BackendProvider
+  ) async -> Int {
+    do {
+      let page = try await backend.transactions.fetch(
+        filter: TransactionFilter(), page: 0, pageSize: 2000)
+      let candidate = ImportRule(
+        name: "preview",
+        position: 0,
+        matchMode: matchMode,
+        conditions: conditions,
+        actions: [],
+        accountScope: accountScope)
+      return page.transactions.reduce(0) { count, tx in
+        guard let origin = tx.importOrigin,
+          let routingAccount = tx.legs.first?.accountId
+        else {
+          return count
+        }
+        let parsed = ParsedTransaction(
+          date: tx.date,
+          legs: tx.legs.map {
+            ParsedLeg(
+              accountId: $0.accountId, instrument: $0.instrument,
+              quantity: $0.quantity, type: $0.type)
+          },
+          rawRow: [],
+          rawDescription: origin.rawDescription,
+          rawAmount: origin.rawAmount,
+          rawBalance: origin.rawBalance,
+          bankReference: origin.bankReference)
+        let eval = ImportRulesEngine.evaluate(
+          parsed, routedAccountId: routingAccount, rules: [candidate])
+        return count + (eval.matchedRuleIds.isEmpty ? 0 : 1)
+      }
+    } catch {
+      logger.error(
+        "countAffected failed: \(error.localizedDescription, privacy: .public)")
+      return 0
+    }
+  }
+}

--- a/Features/Import/RecentlyAddedViewModel.swift
+++ b/Features/Import/RecentlyAddedViewModel.swift
@@ -1,0 +1,141 @@
+import Foundation
+import OSLog
+import Observation
+
+/// Drives the Recently Added view. Thin wrapper around the transactions
+/// repository that filters by `ImportOrigin.importedAt` within the chosen
+/// window and groups by `importSessionId`.
+@Observable
+@MainActor
+final class RecentlyAddedViewModel {
+
+  enum Window: String, CaseIterable, Identifiable, Sendable {
+    case last24Hours
+    case last3Days
+    case lastWeek
+    case last2Weeks
+    case lastMonth
+    case all
+
+    var id: String { rawValue }
+
+    var label: String {
+      switch self {
+      case .last24Hours: return "Last 24 hours"
+      case .last3Days: return "Last 3 days"
+      case .lastWeek: return "Last week"
+      case .last2Weeks: return "Last 2 weeks"
+      case .lastMonth: return "Last month"
+      case .all: return "All"
+      }
+    }
+
+    func dateRange(now: Date = Date()) -> ClosedRange<Date>? {
+      let day: TimeInterval = 86_400
+      switch self {
+      case .last24Hours: return (now.addingTimeInterval(-day))...now
+      case .last3Days: return (now.addingTimeInterval(-3 * day))...now
+      case .lastWeek: return (now.addingTimeInterval(-7 * day))...now
+      case .last2Weeks: return (now.addingTimeInterval(-14 * day))...now
+      case .lastMonth: return (now.addingTimeInterval(-30 * day))...now
+      case .all: return nil
+      }
+    }
+  }
+
+  /// A group of transactions imported in the same session.
+  struct SessionGroup: Identifiable, Sendable {
+    let id: UUID
+    let importedAt: Date
+    let filenames: [String]
+    let transactions: [Transaction]
+
+    /// v1 proxy for "needs review": any transaction whose legs all lack a
+    /// category. See the design doc.
+    var needsReviewCount: Int {
+      transactions.filter { tx in tx.legs.allSatisfy { $0.categoryId == nil } }.count
+    }
+  }
+
+  private(set) var window: Window = .last24Hours
+  private(set) var sessions: [SessionGroup] = []
+  private(set) var badgeCount: Int = 0
+  private(set) var isLoading = false
+
+  private let backend: any BackendProvider
+  private let logger = Logger(
+    subsystem: "com.moolah.app", category: "RecentlyAddedViewModel")
+
+  init(backend: any BackendProvider) {
+    self.backend = backend
+  }
+
+  func load(window: Window, now: Date = Date()) async {
+    self.window = window
+    isLoading = true
+    defer { isLoading = false }
+    let pageSize = 500
+    var all: [Transaction] = []
+    do {
+      var page = 0
+      while true {
+        let result = try await backend.transactions.fetch(
+          filter: TransactionFilter(),
+          page: page,
+          pageSize: pageSize)
+        if result.transactions.isEmpty { break }
+        all.append(contentsOf: result.transactions)
+        if result.transactions.count < pageSize { break }
+        page += 1
+        // Safety cap: don't fetch more than 5 pages to keep the view snappy
+        // (2500 transactions max). Windowed recent views never need more.
+        if page >= 5 { break }
+      }
+    } catch {
+      logger.error("load failed: \(error.localizedDescription, privacy: .public)")
+    }
+
+    let filtered = Self.filter(all, window: window, now: now)
+    sessions = Self.group(filtered)
+    badgeCount =
+      filtered.filter { tx in
+        tx.legs.allSatisfy { $0.categoryId == nil }
+      }.count
+  }
+
+  /// Exposed for tests and for the sidebar badge lookup — given a fully-fetched
+  /// transaction list, return only those with an ImportOrigin within the
+  /// window.
+  static func filter(
+    _ transactions: [Transaction],
+    window: Window,
+    now: Date = Date()
+  ) -> [Transaction] {
+    transactions.filter { tx in
+      guard let origin = tx.importOrigin else { return false }
+      if let range = window.dateRange(now: now) {
+        return range.contains(origin.importedAt)
+      }
+      return true
+    }
+  }
+
+  static func group(_ transactions: [Transaction]) -> [SessionGroup] {
+    let dict = Dictionary(
+      grouping: transactions,
+      by: { $0.importOrigin?.importSessionId ?? UUID() })
+    return dict.map { (id, txs) in
+      let filenames = Array(
+        Set(txs.compactMap { $0.importOrigin?.sourceFilename })
+      ).sorted()
+      let importedAt =
+        txs.map { $0.importOrigin?.importedAt ?? .distantPast }.max()
+        ?? .distantPast
+      return SessionGroup(
+        id: id,
+        importedAt: importedAt,
+        filenames: filenames,
+        transactions: txs.sorted { $0.date > $1.date })
+    }.sorted { $0.importedAt > $1.importedAt }
+  }
+}

--- a/Features/Import/RecentlyAddedViewModel.swift
+++ b/Features/Import/RecentlyAddedViewModel.swift
@@ -71,6 +71,7 @@ final class RecentlyAddedViewModel {
   }
 
   func load(window: Window, now: Date = Date()) async {
+    guard !isLoading else { return }
     self.window = window
     isLoading = true
     defer { isLoading = false }

--- a/Features/Import/Views/RecentlyAddedView.swift
+++ b/Features/Import/Views/RecentlyAddedView.swift
@@ -1,0 +1,209 @@
+import SwiftUI
+
+/// Recently Added — landing page for CSV imports. Shows the Needs Setup /
+/// Failed Files panel at the top and a session-grouped list of recently
+/// imported transactions below. The time window picker is in the toolbar.
+struct RecentlyAddedView: View {
+  let backend: any BackendProvider
+  @Environment(ImportStore.self) private var importStore
+  @State private var viewModel: RecentlyAddedViewModel?
+  @State private var window: RecentlyAddedViewModel.Window = .last24Hours
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 0) {
+      NeedsSetupAndFailedPanel()
+      if let viewModel {
+        if viewModel.isLoading && viewModel.sessions.isEmpty {
+          ProgressView().frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if viewModel.sessions.isEmpty {
+          ContentUnavailableView(
+            "Nothing imported yet",
+            systemImage: "tray",
+            description: Text(
+              "Drop a CSV onto the app, use the Import CSV menu item, "
+                + "or paste tabular text to get started."))
+        } else {
+          List {
+            ForEach(viewModel.sessions) { session in
+              Section(header: sessionHeader(session)) {
+                ForEach(session.transactions, id: \.id) { tx in
+                  RecentlyAddedRow(transaction: tx)
+                }
+              }
+            }
+          }
+        }
+      } else {
+        ProgressView().frame(maxWidth: .infinity, maxHeight: .infinity)
+      }
+    }
+    .navigationTitle("Recently Added")
+    .toolbar {
+      ToolbarItem(placement: .automatic) {
+        Picker("Time window", selection: $window) {
+          ForEach(RecentlyAddedViewModel.Window.allCases) { w in
+            Text(w.label).tag(w)
+          }
+        }
+        .pickerStyle(.menu)
+        .accessibilityLabel("Time window")
+      }
+    }
+    .task { await reload() }
+    .onChange(of: window) { _, _ in Task { await reload() } }
+  }
+
+  private func sessionHeader(_ session: RecentlyAddedViewModel.SessionGroup) -> some View {
+    HStack {
+      Text(session.importedAt, format: .dateTime.day().month().year().hour().minute())
+        .font(.subheadline)
+        .monospacedDigit()
+      Spacer()
+      if !session.filenames.isEmpty {
+        Text(session.filenames.joined(separator: ", "))
+          .font(.caption)
+          .foregroundStyle(.secondary)
+          .lineLimit(1)
+      }
+      let counts = "\(session.transactions.count) imported"
+      let needs =
+        session.needsReviewCount > 0 ? " · \(session.needsReviewCount) need review" : ""
+      Text(counts + needs)
+        .font(.caption)
+        .foregroundStyle(.secondary)
+        .monospacedDigit()
+    }
+  }
+
+  private func reload() async {
+    if viewModel == nil {
+      viewModel = RecentlyAddedViewModel(backend: backend)
+    }
+    await viewModel?.load(window: window)
+    await importStore.reloadStagingLists()
+  }
+}
+
+/// Row for one imported transaction. Shows date, description, amount, and a
+/// left-edge accent stripe when the row needs review (all legs uncategorised).
+private struct RecentlyAddedRow: View {
+  let transaction: Transaction
+
+  var body: some View {
+    HStack(spacing: 12) {
+      Rectangle()
+        .fill(needsReview ? Color.orange : Color.clear)
+        .frame(width: 3)
+      VStack(alignment: .leading, spacing: 2) {
+        Text(transaction.payee ?? transaction.importOrigin?.rawDescription ?? "")
+          .lineLimit(1)
+        Text(transaction.date, format: .dateTime.day().month().year())
+          .font(.caption)
+          .foregroundStyle(.secondary)
+          .monospacedDigit()
+      }
+      Spacer()
+      Text(amountText)
+        .monospacedDigit()
+      if needsReview {
+        Text("Needs review")
+          .font(.caption2)
+          .padding(.horizontal, 6)
+          .padding(.vertical, 2)
+          .background(Color.orange.opacity(0.15), in: Capsule())
+          .foregroundStyle(Color.orange)
+          .accessibilityLabel("Needs review")
+      }
+    }
+    .padding(.vertical, 2)
+  }
+
+  private var needsReview: Bool {
+    transaction.legs.allSatisfy { $0.categoryId == nil }
+  }
+
+  private var amountText: String {
+    let total = transaction.legs.reduce(Decimal(0)) { $0 + $1.quantity }
+    let formatter = NumberFormatter()
+    formatter.numberStyle = .currency
+    formatter.maximumFractionDigits = 2
+    formatter.minimumFractionDigits = 2
+    formatter.currencyCode = transaction.legs.first?.instrument.id ?? "AUD"
+    return formatter.string(from: total as NSDecimalNumber) ?? "\(total)"
+  }
+}
+
+/// Needs Setup / Failed Files panel. Shown above the session list when either
+/// list is non-empty; fully hidden when both are empty.
+private struct NeedsSetupAndFailedPanel: View {
+  @Environment(ImportStore.self) private var importStore
+
+  var body: some View {
+    if importStore.pendingSetup.isEmpty && importStore.failedFiles.isEmpty {
+      EmptyView()
+    } else {
+      VStack(alignment: .leading, spacing: 8) {
+        if !importStore.pendingSetup.isEmpty {
+          Text("Needs Setup").font(.headline)
+          ForEach(importStore.pendingSetup) { file in
+            PendingRow(file: file)
+          }
+        }
+        if !importStore.failedFiles.isEmpty {
+          Text("Failed Files").font(.headline)
+          ForEach(importStore.failedFiles) { file in
+            FailedRow(file: file)
+          }
+        }
+      }
+      .padding()
+      .background(Color.secondary.opacity(0.1), in: RoundedRectangle(cornerRadius: 8))
+      .padding(.horizontal)
+      .padding(.top)
+    }
+  }
+}
+
+private struct PendingRow: View {
+  let file: PendingSetupFile
+  @Environment(ImportStore.self) private var importStore
+
+  var body: some View {
+    HStack {
+      Image(systemName: "doc.badge.ellipsis").foregroundStyle(.secondary)
+      VStack(alignment: .leading) {
+        Text(file.originalFilename).font(.subheadline)
+        Text(file.detectedParserIdentifier ?? "Unknown parser")
+          .font(.caption).foregroundStyle(.secondary)
+      }
+      Spacer()
+      Button("Dismiss") {
+        Task { await importStore.dismissPending(id: file.id) }
+      }
+      .buttonStyle(.borderless)
+    }
+  }
+}
+
+private struct FailedRow: View {
+  let file: FailedImportFile
+  @Environment(ImportStore.self) private var importStore
+
+  var body: some View {
+    HStack {
+      Image(systemName: "exclamationmark.triangle").foregroundStyle(.red)
+      VStack(alignment: .leading) {
+        Text(file.originalFilename).font(.subheadline)
+        Text(file.error)
+          .font(.caption)
+          .foregroundStyle(.secondary)
+          .lineLimit(2)
+      }
+      Spacer()
+      Button("Dismiss") {
+        Task { await importStore.dismissFailed(id: file.id) }
+      }
+      .buttonStyle(.borderless)
+    }
+  }
+}

--- a/Features/Import/Views/RecentlyAddedView.swift
+++ b/Features/Import/Views/RecentlyAddedView.swift
@@ -49,8 +49,9 @@ struct RecentlyAddedView: View {
         .accessibilityLabel("Time window")
       }
     }
-    .task { await reload() }
-    .onChange(of: window) { _, _ in Task { await reload() } }
+    // .task(id: window) fires on first appearance and re-fires (auto-cancelling
+    // any in-flight load) whenever `window` changes.
+    .task(id: window) { await reload() }
   }
 
   private func sessionHeader(_ session: RecentlyAddedViewModel.SessionGroup) -> some View {

--- a/Features/Navigation/SidebarView.swift
+++ b/Features/Navigation/SidebarView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 enum SidebarSelection: Hashable {
   case account(UUID)
   case earmark(UUID)
+  case recentlyAdded
   case allTransactions
   case upcomingTransactions
   case categories
@@ -168,6 +169,10 @@ struct SidebarView: View {
 
         NavigationLink(value: SidebarSelection.upcomingTransactions) {
           Label("Upcoming", systemImage: "calendar")
+        }
+
+        NavigationLink(value: SidebarSelection.recentlyAdded) {
+          Label("Recently Added", systemImage: "tray.full")
         }
 
         NavigationLink(value: SidebarSelection.allTransactions) {

--- a/MoolahTests/Features/Import/ImportRuleStoreTests.swift
+++ b/MoolahTests/Features/Import/ImportRuleStoreTests.swift
@@ -1,0 +1,176 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("ImportRuleStore")
+@MainActor
+struct ImportRuleStoreTests {
+
+  private func rule(
+    name: String = "r",
+    position: Int = 0,
+    conditions: [RuleCondition] = [],
+    actions: [RuleAction] = []
+  ) -> ImportRule {
+    ImportRule(
+      name: name, position: position,
+      conditions: conditions, actions: actions)
+  }
+
+  @Test("load sorts rules by position")
+  func loadSortsByPosition() async throws {
+    let (backend, _) = try TestBackend.create()
+    _ = try await backend.importRules.create(rule(name: "c", position: 5))
+    _ = try await backend.importRules.create(rule(name: "a", position: 1))
+    _ = try await backend.importRules.create(rule(name: "b", position: 3))
+    let store = ImportRuleStore(repository: backend.importRules)
+    await store.load()
+    #expect(store.rules.map(\.name) == ["a", "b", "c"])
+  }
+
+  @Test("create appends the new rule and keeps sorted")
+  func createAppends() async throws {
+    let (backend, _) = try TestBackend.create()
+    let store = ImportRuleStore(repository: backend.importRules)
+    await store.load()
+    await store.create(rule(name: "alpha", position: 0))
+    await store.create(rule(name: "beta", position: 1))
+    #expect(store.rules.map(\.name) == ["alpha", "beta"])
+  }
+
+  @Test("update replaces the existing rule")
+  func updateReplaces() async throws {
+    let (backend, _) = try TestBackend.create()
+    let store = ImportRuleStore(repository: backend.importRules)
+    guard let created = await store.create(rule(name: "original", position: 0)) else {
+      Issue.record("create returned nil")
+      return
+    }
+    var edited = created
+    edited.name = "renamed"
+    edited.conditions = [.descriptionContains(["FOO"])]
+    await store.update(edited)
+    #expect(store.rules.first?.name == "renamed")
+    #expect(store.rules.first?.conditions == [.descriptionContains(["FOO"])])
+  }
+
+  @Test("delete removes from the list")
+  func deleteRemoves() async throws {
+    let (backend, _) = try TestBackend.create()
+    let store = ImportRuleStore(repository: backend.importRules)
+    guard let created = await store.create(rule(name: "x", position: 0)) else {
+      Issue.record("create failed")
+      return
+    }
+    await store.delete(id: created.id)
+    #expect(store.rules.isEmpty)
+  }
+
+  @Test("reorder atomically updates positions and re-sorts")
+  func reorderUpdatesPositions() async throws {
+    let (backend, _) = try TestBackend.create()
+    let store = ImportRuleStore(repository: backend.importRules)
+    let a = await store.create(rule(name: "a", position: 0))!
+    let b = await store.create(rule(name: "b", position: 1))!
+    let c = await store.create(rule(name: "c", position: 2))!
+    await store.reorder([c.id, a.id, b.id])
+    #expect(store.rules.map(\.name) == ["c", "a", "b"])
+    #expect(store.rules.map(\.position) == [0, 1, 2])
+  }
+
+  @Test("countAffected counts matching imported transactions")
+  func countAffectedMatchesRules() async throws {
+    let (backend, container) = try TestBackend.create()
+    let accountId = UUID()
+    _ = try await backend.accounts.create(
+      Account(
+        id: accountId, name: "Cash", type: .bank, instrument: .AUD,
+        positions: [], position: 0, isHidden: false),
+      openingBalance: nil)
+    let origin = ImportOrigin(
+      rawDescription: "COFFEE HUT",
+      bankReference: nil,
+      rawAmount: -5,
+      rawBalance: nil,
+      importedAt: Date(),
+      importSessionId: UUID(),
+      sourceFilename: "cba.csv",
+      parserIdentifier: "generic-bank")
+    let seededTxs = (0..<3).map { _ in
+      Transaction(
+        date: Date(),
+        legs: [
+          TransactionLeg(
+            accountId: accountId, instrument: .AUD, quantity: -5, type: .expense,
+            categoryId: nil, earmarkId: nil)
+        ],
+        importOrigin: origin)
+    }
+    let unrelated = Transaction(
+      date: Date(),
+      legs: [
+        TransactionLeg(
+          accountId: accountId, instrument: .AUD, quantity: -10, type: .expense,
+          categoryId: nil, earmarkId: nil)
+      ],
+      importOrigin: ImportOrigin(
+        rawDescription: "AMAZON", bankReference: nil,
+        rawAmount: -10, rawBalance: nil, importedAt: Date(),
+        importSessionId: UUID(), sourceFilename: nil,
+        parserIdentifier: "generic-bank"))
+    TestBackend.seed(transactions: seededTxs + [unrelated], in: container)
+    let store = ImportRuleStore(repository: backend.importRules)
+    let count = await store.countAffected(
+      conditions: [.descriptionContains(["COFFEE"])],
+      matchMode: .all,
+      accountScope: nil,
+      backend: backend)
+    #expect(count == 3)
+  }
+}
+
+@Suite("DistinguishingTokens")
+struct DistinguishingTokensTests {
+
+  @Test("extract picks rare tokens first")
+  func picksRareTokens() {
+    let description = "EFTPOS AMAZON PURCHASE AUD"
+    let corpus = [
+      "EFTPOS WOOLWORTHS AUD",
+      "EFTPOS COLES AUD",
+      "EFTPOS COFFEE AUD",
+      "EFTPOS AMAZON AUD",  // contains AMAZON once — still rarer than EFTPOS
+      "EFTPOS PURCHASE AUD",
+    ]
+    let tokens = DistinguishingTokens.extract(from: description, corpus: corpus, limit: 2)
+    // EFTPOS and AUD and PURCHASE are common; AMAZON appears only once → rarer.
+    #expect(tokens.contains("AMAZON"))
+  }
+
+  @Test("extract filters out numeric-only and one-char tokens")
+  func filtersNoiseTokens() {
+    let tokens = DistinguishingTokens.extract(
+      from: "A 12345 COFFEE", corpus: ["B 67890 COFFEE"])
+    #expect(tokens.contains("A") == false)
+    #expect(tokens.contains("12345") == false)
+    #expect(tokens.contains("COFFEE"))
+  }
+
+  @Test("empty description returns empty list")
+  func emptyDescription() {
+    let tokens = DistinguishingTokens.extract(from: "", corpus: ["foo"])
+    #expect(tokens.isEmpty)
+  }
+
+  @Test("extract returns tokens in frequency-then-first-appearance order")
+  func stableOrdering() {
+    let tokens = DistinguishingTokens.extract(
+      from: "RARE COMMON RARE MIDDLE",
+      corpus: ["COMMON COMMON COMMON", "MIDDLE MIDDLE"],
+      limit: 3)
+    // RARE appears 0 times in corpus; MIDDLE 1; COMMON 1 (set-deduped per item).
+    // Order rarest-first, ties broken by first appearance in description.
+    #expect(tokens.first == "RARE")
+  }
+}

--- a/MoolahTests/Features/Import/RecentlyAddedViewModelTests.swift
+++ b/MoolahTests/Features/Import/RecentlyAddedViewModelTests.swift
@@ -1,0 +1,158 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("RecentlyAddedViewModel")
+@MainActor
+struct RecentlyAddedViewModelTests {
+
+  private func date(offsetHours: Int, from now: Date = Date()) -> Date {
+    now.addingTimeInterval(Double(offsetHours) * 3_600)
+  }
+
+  private func stamped(
+    origin: ImportOrigin?,
+    legs: [TransactionLeg] = [],
+    date: Date = Date()
+  ) -> Transaction {
+    Transaction(date: date, legs: legs, importOrigin: origin)
+  }
+
+  private func origin(
+    sessionId: UUID,
+    importedAt: Date,
+    filename: String? = nil
+  ) -> ImportOrigin {
+    ImportOrigin(
+      rawDescription: "x",
+      bankReference: nil,
+      rawAmount: 0,
+      rawBalance: nil,
+      importedAt: importedAt,
+      importSessionId: sessionId,
+      sourceFilename: filename,
+      parserIdentifier: "generic-bank")
+  }
+
+  @Test("filter keeps only transactions whose importedAt falls within the window")
+  func filterWindow() {
+    let now = Date(timeIntervalSince1970: 1_700_000_000)
+    let session = UUID()
+    let inside = stamped(
+      origin: origin(sessionId: session, importedAt: now.addingTimeInterval(-3_600)))
+    let outside = stamped(
+      origin: origin(sessionId: session, importedAt: now.addingTimeInterval(-86_400 * 2)))
+    let noOrigin = stamped(origin: nil)
+    let kept = RecentlyAddedViewModel.filter(
+      [inside, outside, noOrigin], window: .last24Hours, now: now)
+    #expect(kept.count == 1)
+    #expect(kept[0] == inside)
+  }
+
+  @Test("group bundles transactions by importSessionId and sorts newest-first")
+  func groupBySession() {
+    let sessionA = UUID()
+    let sessionB = UUID()
+    let now = Date(timeIntervalSince1970: 1_700_000_000)
+    let olderA = stamped(
+      origin: origin(
+        sessionId: sessionA, importedAt: now.addingTimeInterval(-3_600),
+        filename: "a.csv"))
+    let newerA = stamped(
+      origin: origin(sessionId: sessionA, importedAt: now, filename: "a.csv"))
+    let newerB = stamped(
+      origin: origin(
+        sessionId: sessionB, importedAt: now.addingTimeInterval(-60),
+        filename: "b.csv"))
+    let groups = RecentlyAddedViewModel.group([olderA, newerA, newerB])
+    #expect(groups.count == 2)
+    // Session A is newest because its most-recent tx is at `now`.
+    #expect(groups[0].id == sessionA)
+    #expect(groups[0].filenames == ["a.csv"])
+    #expect(groups[0].transactions.count == 2)
+    #expect(groups[1].id == sessionB)
+  }
+
+  @Test("badge count + session load against TestBackend")
+  func loadViaBackend() async throws {
+    let (backend, container) = try TestBackend.create()
+    let accountId = UUID()
+    _ = try await backend.accounts.create(
+      Account(
+        id: accountId, name: "Cash", type: .bank, instrument: .AUD,
+        positions: [], position: 0, isHidden: false),
+      openingBalance: nil)
+
+    let now = Date()
+    let sessionId = UUID()
+    let categorisedOrigin = origin(
+      sessionId: sessionId, importedAt: now.addingTimeInterval(-60), filename: "cba.csv")
+    let uncategorisedOrigin = origin(
+      sessionId: sessionId, importedAt: now.addingTimeInterval(-30), filename: "cba.csv")
+    let outsideOrigin = origin(
+      sessionId: sessionId, importedAt: now.addingTimeInterval(-86_400 * 2),
+      filename: "old.csv")
+
+    let categorisedTxs = [
+      Transaction(
+        date: now,
+        legs: [
+          TransactionLeg(
+            accountId: accountId, instrument: .AUD, quantity: -5, type: .expense,
+            categoryId: UUID(), earmarkId: nil)
+        ],
+        importOrigin: categorisedOrigin),
+      Transaction(
+        date: now,
+        legs: [
+          TransactionLeg(
+            accountId: accountId, instrument: .AUD, quantity: -10, type: .expense,
+            categoryId: UUID(), earmarkId: nil)
+        ],
+        importOrigin: categorisedOrigin),
+    ]
+    let uncategorisedTxs = [
+      Transaction(
+        date: now,
+        legs: [
+          TransactionLeg(
+            accountId: accountId, instrument: .AUD, quantity: -3, type: .expense,
+            categoryId: nil, earmarkId: nil)
+        ],
+        importOrigin: uncategorisedOrigin),
+      Transaction(
+        date: now,
+        legs: [
+          TransactionLeg(
+            accountId: accountId, instrument: .AUD, quantity: -4, type: .expense,
+            categoryId: nil, earmarkId: nil)
+        ],
+        importOrigin: uncategorisedOrigin),
+      Transaction(
+        date: now,
+        legs: [
+          TransactionLeg(
+            accountId: accountId, instrument: .AUD, quantity: -2, type: .expense,
+            categoryId: nil, earmarkId: nil)
+        ],
+        importOrigin: uncategorisedOrigin),
+    ]
+    let outsideTx = Transaction(
+      date: now.addingTimeInterval(-86_400 * 2),
+      legs: [
+        TransactionLeg(
+          accountId: accountId, instrument: .AUD, quantity: -1, type: .expense,
+          categoryId: nil, earmarkId: nil)
+      ],
+      importOrigin: outsideOrigin)
+    TestBackend.seed(
+      transactions: categorisedTxs + uncategorisedTxs + [outsideTx], in: container)
+
+    let vm = RecentlyAddedViewModel(backend: backend)
+    await vm.load(window: .last24Hours, now: now)
+    #expect(vm.badgeCount == 3)
+    #expect(vm.sessions.count == 1)
+    #expect(vm.sessions[0].transactions.count == 5)
+  }
+}

--- a/Shared/CSVImport/DistinguishingTokens.swift
+++ b/Shared/CSVImport/DistinguishingTokens.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// Token distinctiveness helper for the "Create a rule from this…"
+/// affordance. Given a single `description`, pick the tokens that appear
+/// in it but are rare across the user's full corpus of raw descriptions.
+/// Rare tokens are high-signal — "AMAZON", "NETFLIX" — whereas common
+/// tokens like "EFTPOS" or "PURCHASE" aren't.
+enum DistinguishingTokens {
+
+  /// Up to `limit` tokens from `description` ranked by rarity in `corpus`.
+  /// Numeric-only and single-character tokens are always filtered out.
+  static func extract(
+    from description: String, corpus: [String], limit: Int = 3
+  ) -> [String] {
+    let tokens = normalise(description)
+    guard !tokens.isEmpty else { return [] }
+    var frequency: [String: Int] = [:]
+    for item in corpus {
+      for token in Set(normalise(item)) {
+        frequency[token, default: 0] += 1
+      }
+    }
+    // Sort rarest first; stable on the original order from `description` so
+    // two tokens tied on rarity pick the one that appeared first.
+    let distinctTokens = Array(Set(tokens))
+    let scored = distinctTokens.map { (token: $0, frequency: frequency[$0, default: 0]) }
+    let sorted = scored.sorted { lhs, rhs in
+      if lhs.frequency != rhs.frequency { return lhs.frequency < rhs.frequency }
+      let lhsIndex = tokens.firstIndex(of: lhs.token) ?? Int.max
+      let rhsIndex = tokens.firstIndex(of: rhs.token) ?? Int.max
+      return lhsIndex < rhsIndex
+    }
+    return Array(sorted.prefix(limit).map { $0.token })
+  }
+
+  static func normalise(_ value: String) -> [String] {
+    value.uppercased()
+      .components(separatedBy: CharacterSet.alphanumerics.inverted)
+      .filter { $0.count > 1 && !$0.allSatisfy(\.isNumber) }
+  }
+}


### PR DESCRIPTION
## Summary

Phase F of the CSV transaction import feature — the Recently Added sidebar entry and the foundational rules store. A minimum viable UI so users can see imported transactions and queue Needs Setup files; the full rule editor and import setup form are follow-ups.

Follow-up to Phase E ([#226](https://github.com/ajsutton/moolah-native/pull/226)).

### What shipped

- **Task 16 — Recently Added sidebar + view.** `RecentlyAddedViewModel` (`@Observable @MainActor`) exposes a windowed session list grouped by `importOrigin.importSessionId`, a badge count of uncategorised imports, and pure `filter()` / `group()` helpers for unit tests. `RecentlyAddedView` renders the session list with a window picker in the toolbar, a left-edge orange accent + "Needs review" chip on uncategorised rows, and a Needs Setup / Failed Files panel at the top that drives `ImportStore.dismissPending/Failed`. New `.recentlyAdded` sidebar entry above "All Transactions"; `ContentView` routes to the view. `ProfileSession` gains `importStore` wired to a per-profile `ImportStagingStore` under Application Support/Moolah/csv-staging/<profileId>/.
- **Task 18 — ImportRuleStore + DistinguishingTokens.** Thin `@Observable @MainActor` wrapper around `ImportRuleRepository` with load/create/update/delete/reorder, a `countAffected(…)` live-preview helper that runs rules through the existing `ImportRulesEngine`, and `reloadFromSync()` for CloudKit notifications. `DistinguishingTokens` picks the rarest tokens from a description relative to the corpus for the "Create a rule from this…" affordance. Wired into `ProfileSession` + `SessionRootView`; `StoreReloadPlan` gets a `.importRules` bit so remote rule changes propagate without an app restart.

### Deferred to follow-up PR

- **Task 17 — CSVImportSetupView.** The one-screen first-time-setup form (target account + column mapping + date format picker + preview + Save & Import) is substantial SwiftUI work; the Needs Setup panel surfaces pending files in the view with a Dismiss option, and users can still use the drag-to-account bypass. The form itself lands as a standalone PR.
- **Full rule editor + settings views.** `ImportRuleStore` is ready; the list + editor SwiftUI is a follow-up.

### Review feedback incorporated

`@concurrency-review` agent ran on the first two commits; the final commit addresses the findings:

- `RecentlyAddedViewModel.load` now guards with `guard !isLoading else { return }` (matches every other store in the repo; previously two concurrent calls could race).
- `RecentlyAddedView` swaps `.onChange(of:) { Task { … } }` for `.task(id: window)` so a rapid picker change auto-cancels the previous load.
- `ImportRuleStore.reloadFromSync()` added and wired through `StoreReloadPlan.importRules` so CloudKit rule changes update the UI.
- `Task.detached` in `ImportStore.deleteSourceInBackground` kept — it's the correct tool to escape `@MainActor` isolation for blocking I/O.

### Design / plan refs

- `plans/2026-04-18-csv-import-design.md`
- `plans/2026-04-19-csv-import-implementation-plan.md` (Tasks 16, 18)
- `guides/CONCURRENCY_GUIDE.md`

## Test plan

- [x] `just test` — iOS: 1418 tests pass (128 suites). macOS: 1434 tests pass (131 suites). 13 new tests across `RecentlyAddedViewModelTests` (3), `ImportRuleStoreTests` (6), `DistinguishingTokensTests` (4).
- [x] `just format-check` clean.
- [x] `SWIFT_TREAT_WARNINGS_AS_ERRORS` stays on — build is warning-free.
- [x] `@concurrency-review` agent clean after the review-feedback commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)