### PR TITLE
docs(testing): add writing-ui-tests skill (PR #3 of UI testing rollout)

### DIFF
--- a/.claude/skills/writing-ui-tests/SKILL.md
+++ b/.claude/skills/writing-ui-tests/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: writing-ui-tests
+description: Use when adding a UI test to MoolahUITests_macOS, extending a screen driver, adding a new test seed or identifier, or fixing a failing UI test. Guides the test-type decision, driver extension rules, seed reuse, user-story test style, the 20-run stability gate, and running the @ui-test-review agent before opening a PR.
+---
+
+# Writing a UI Test
+
+Follow this checklist when adding or modifying a UI test. The guides are the source of truth — this skill orders the work and flags the cheap mistakes. Read `guides/TEST_GUIDE.md` and `guides/UI_TEST_GUIDE.md` in full before making changes; the details below assume you have.
+
+## Before Writing
+
+1. **Confirm a UI test is warranted.**
+   - Can the behaviour be proven with a store test against `TestBackend`? Almost always, yes. If so, write the store test instead and stop.
+   - UI tests earn their slot only when the failure class requires the real SwiftUI event loop: `@FocusState`, autocomplete/overlay show/hide timing, real keyboard events, multi-leg form reveal. Anything else is cheaper to cover elsewhere.
+   - See `UI_TEST_GUIDE.md` §1 for the full decision table.
+
+2. **Map the test to drivers.**
+   - Sketch the test as a short user story: launch → sidebar action → list action → detail action → assertion.
+   - For each step, identify the driver that owns it (`app.sidebar`, `app.transactionList`, `app.transactionDetail`, `app.dialogs`, field drivers like `AutocompleteFieldDriver`).
+   - If a driver method you need does not exist, you extend the driver *first* — not the test. A test that inlines XCUI primitives to "work around a missing driver method" is wrong and the reviewer agent flags it.
+
+3. **Pick the seed.**
+   - Scan `UITestSupport/UITestSeeds.swift` for an existing seed that fits the scenario. Reuse it.
+   - Only add a new seed when no existing one covers the shape (e.g., multi-leg trade baseline vs. single-leg expense baseline). New seeds use hard-coded `UUID(uuidString:)!` literals — never `UUID()`. Document the entities inline so `seed.txt` failure artefacts remain readable.
+
+## Writing the Test
+
+### Test file
+
+- Location: `MoolahUITests_macOS/Tests/<Area>/<BehaviourClass>Tests.swift`.
+- Class name: `<BehaviourClass>Tests` — camel-case, describes the behaviour area (e.g. `TransactionDetailFocusTests`).
+- Inherits `MoolahUITestCase` — never `XCTestCase` directly. The base class wires up the four failure artefacts (`tree.txt`, `screenshot.png`, `seed.txt`, `trace.txt`).
+- Imports: only `XCTest`. No `XCUIApplication`, `XCUIElement`, `XCUIElementQuery`.
+
+### Test method
+
+- Name: `test<BehaviourInPlainEnglish>` — `testOpeningTradeFocusesPayee`, not `test_TDV_focus_init_v2`.
+- One behaviour per test. If the name needs an "and", split into two tests.
+- Shape:
+
+  ```swift
+  func testOpeningTradeFocusesPayee() {
+      let app = MoolahApp.launch(seed: .tradeBaseline)
+      app.sidebar.switchToAccount(.checking)
+      app.transactionList.openTransaction(.coffeeShop)
+
+      app.transactionDetail.payee.expectFocused()
+  }
+  ```
+
+- Body = sequence of driver actions, then driver expectations. No raw identifier strings, no `waitForExistence`, no `MoolahUITestCase` low-level primitives (`waitForIdentifier`, `typeInto`, `pressKey`).
+
+### Extending a driver (when needed)
+
+Each new or modified action method must:
+
+1. Start with `Trace.record(#function, ...)` on its first line — without it, `trace.txt` cannot locate the failing step.
+2. Wait for a real post-condition (an element existing, a value propagating, a focus state changing) with a bounded timeout (default 3 s). No `Thread.sleep`, no `DispatchQueue.main.asyncAfter`, no unbounded waits.
+3. Fail loudly on a precondition violation (`XCTFail(...)` with the failure artefacts attached) — never silent no-ops or swallowed throws.
+4. Look up elements via `MoolahApp.element(for:)` — never `app.buttons[...]`, `app.textFields[...]`, etc.
+5. Reference identifiers via `UITestIdentifiers` constants — never inline string literals.
+6. Not cache `XCUIElement` references on stored properties — re-resolve each call.
+
+Expectation methods (`expect…`) never mutate state and do not call `Trace.record`.
+
+### Adding identifiers
+
+Add the identifier constants to `UITestSupport/UITestIdentifiers.swift` using the existing `area.element[.qualifier]` namespace, and add `.accessibilityIdentifier(UITestIdentifiers.…)` to the targeted view. Identifier additions are incremental — only what this test needs, not a bulk pass.
+
+
+## After Writing
+
+1. **Run the test in isolation**:
+
+   ```bash
+   mkdir -p .agent-tmp
+   just test-ui <ClassName>/<testName> 2>&1 | tee .agent-tmp/test-ui.txt
+   ```
+
+2. **On failure, read artefacts before editing anything**:
+
+   ```bash
+   ls .agent-tmp/ui-fail-<TestName>/
+   #   tree.txt  screenshot.png  seed.txt  trace.txt
+   ```
+
+   - `trace.txt` → find the first failing action.
+   - `tree.txt` → see which identifiers actually exist at that point in the UI.
+   - Fix at the right layer: missing identifier (add it), wrong seed (fix the seed), wrong driver post-condition (fix the wait), genuine product change (update the driver).
+   - **Never modify the test to make a failure go away.** The test describes intended behaviour; only drivers, identifiers, and seeds change to reflect product changes.
+
+3. **Iteration check** (a fast-feedback heuristic during driver/test iteration, *not* a substitute for the gate in step 5) — run the test three times locally:
+
+   ```bash
+   for i in 1 2 3; do
+     just test-ui <ClassName>/<testName> 2>&1 \
+       | tee .agent-tmp/test-ui-iter-$i.txt \
+       || break
+   done
+   ```
+
+   Divergence within three runs usually reveals a driver post-condition bug. Fix it before continuing.
+
+4. **Run the `@ui-test-review` agent** on every changed file. Cheap to run; will reject things the 20-run gate would burn 20 minutes discovering. Address every finding before continuing — exceptions require a `// ui-test-review: allow <rule> — <reason>` comment with real justification.
+
+5. **The 20-run stability gate before opening the PR** — this is the gate, not an option:
+
+   ```bash
+   for i in $(seq 1 20); do
+     just test-ui <ClassName>/<testName> 2>&1 \
+       | tee .agent-tmp/test-ui-run-$i.txt \
+       || break
+   done
+   ```
+
+   All 20 must pass. A test that fails 1-in-20 is broken, not flaky — the driver's post-condition wait is wrong. Fix it and run all 20 again from scratch. Do not open the PR with anything less than a clean 20.
+
+## Common Mistakes
+
+- **Writing the test first, then inlining XCUI primitives to make it compile.** Extend the driver first, always.
+- **Reaching into `app.buttons[...]` because it's faster than adding a driver method.** The reviewer will flag it. So will the next test that breaks when the view restructures.
+- **Bulk-adding identifiers to dozens of views "just in case".** Add only what the current test needs. Dead identifiers are a maintenance tax on everyone who comes after.
+- **Catching a flake by adding a `Thread.sleep(0.5)`.** The flake is a missing post-condition wait. Find the real signal and wait on that.
+- **Asserting a post-condition the driver action already owns.** `switchToAccount` returns only after the list re-rendered — the test doesn't need to re-check it. Tests assert scenario-specific outcomes, not driver contract.


### PR DESCRIPTION
## Summary

PR #3 of the UI-testing rollout. Adds the `writing-ui-tests` skill under `.claude/skills/writing-ui-tests/SKILL.md`.

The skill sequences the work for any agent adding or modifying a UI test; it defers rationale to `guides/TEST_GUIDE.md` and `guides/UI_TEST_GUIDE.md` and covers order-of-operations only.

**Before** — confirm a UI test is warranted (store test first), map to drivers, pick or add a seed.
**Writing** — test file location, class inherits `MoolahUITestCase`, imports only `XCTest`; six driver invariants (trace first line, bounded wait, loud failure, single resolver, no caching, constants not literals); expectation purity; identifier additions.
**After** — run in isolation; on failure read `.agent-tmp/ui-fail-<TestName>/` artefacts and fix drivers/seeds/identifiers (never the test); three-run iteration check for fast feedback; `@ui-test-review` agent run before the 20-run gate; 20 consecutive green runs before opening the PR.

Closes with a "Common Mistakes" section enumerating the failure modes the reviewer agent flags repeatedly — XCUI primitives as a shortcut, bulk-identifier passes, `Thread.sleep` band-aids, redundant post-condition assertions.

## Test plan

- [x] Skill file present at `.claude/skills/writing-ui-tests/SKILL.md`.
- [x] Frontmatter `name` and `description` match the existing-skill pattern (`write-benchmark`, `automate-app`).
- [x] Skill cross-references both guides (PR #1) and the `@ui-test-review` agent (PR #2).
- [x] Cross-references resolve once the prior PRs in the rollout merge.

Depends conceptually on PRs #1 and #2 but does not block on them for merge — references become live once the full rollout lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)