### PR TITLE
feat(csv-import): Phase H — setup form, rules UI, folder watch, paste, settings

### DIFF
--- a/App/ContentView.swift
+++ b/App/ContentView.swift
@@ -1,5 +1,11 @@
 import SwiftUI
 
+#if os(macOS)
+  import AppKit
+#else
+  import UIKit
+#endif
+
 /// Placeholder main content shown after sign-in. Replaced step-by-step with real screens.
 struct ContentView: View {
   @Environment(AuthStore.self) private var authStore
@@ -122,6 +128,9 @@ struct ContentView: View {
     .focusedSceneValue(\.importCSVAction) {
       showImportCSVPicker = true
     }
+    .focusedSceneValue(\.pasteCSVAction) {
+      Task { await pasteCSVFromClipboard() }
+    }
     .focusedSceneValue(\.refreshAction) {
       Task {
         async let a: Void = accountStore.load()
@@ -167,6 +176,25 @@ struct ContentView: View {
     } message: {
       Text(importError ?? "")
     }
+  }
+
+  private func pasteCSVFromClipboard() async {
+    #if os(macOS)
+      guard let text = NSPasteboard.general.string(forType: .string), !text.isEmpty else {
+        importError = "Nothing to paste."
+        return
+      }
+    #else
+      guard let text = UIPasteboard.general.string, !text.isEmpty else {
+        importError = "Nothing to paste."
+        return
+      }
+    #endif
+    let data = Data(text.utf8)
+    _ = await importStore.ingest(
+      data: data,
+      source: .paste(text: text, label: "Pasted CSV"))
+    selection = .recentlyAdded
   }
 
   private func handleImportPickerResult(_ result: Result<[URL], Error>) async {

--- a/App/MoolahApp.swift
+++ b/App/MoolahApp.swift
@@ -270,6 +270,10 @@ struct MoolahApp: App {
   @Environment(\.scenePhase) private var scenePhase
   private let containerManager: ProfileContainerManager
   private let syncCoordinator: SyncCoordinator
+  /// The seeded profile ID under `--ui-testing`, or `nil` for production
+  /// launches. Stored as `let` because `MoolahApp.init` runs once per
+  /// process; the value is decided at launch and never changes.
+  private let uiTestingProfileId: UUID?
   @State private var profileStore: ProfileStore
   private let logger = Logger(subsystem: "com.moolah.app", category: "BackgroundSync")
   @State private var pendingNavigation: PendingNavigation?
@@ -283,35 +287,69 @@ struct MoolahApp: App {
     @State private var sessionManager: SessionManager
   #endif
 
+  /// Returns the `UITestSeed` to hydrate from when the process was launched
+  /// with `--ui-testing`, or `nil` for normal launches. An unset or unknown
+  /// `UI_TESTING_SEED` is a fatal error so test runs cannot silently fall
+  /// back to an unrelated seed when the environment fails to propagate.
+  private static func uiTestingSeed(from arguments: [String]) -> UITestSeed? {
+    guard arguments.contains("--ui-testing") else { return nil }
+    guard let raw = ProcessInfo.processInfo.environment["UI_TESTING_SEED"] else {
+      fatalError(
+        "--ui-testing launched without UI_TESTING_SEED — set the env var via MoolahApp.launch(seed:)."
+      )
+    }
+    guard let seed = UITestSeed(rawValue: raw) else {
+      fatalError("Unknown UI test seed '\(raw)' — extend UITestSeed in UITestSupport.")
+    }
+    return seed
+  }
+
   init() {
+    // UI-testing launch mode: swap the on-disk profile index for an
+    // in-memory one and hydrate it from UI_TESTING_SEED. CloudKit sync and
+    // telemetry are skipped entirely — the app runs against `TestBackend`
+    // shaped storage (in-memory `CloudKitBackend`) so XCUITest flows never
+    // touch the user's iCloud. See guides/UI_TEST_GUIDE.md §6.
+    let uiTestingSeed = Self.uiTestingSeed(from: CommandLine.arguments)
+    var uiTestingProfileId: UUID? = nil
+
     do {
-      let profileSchema = Schema([ProfileRecord.self])
-      let profileStoreURL = URL.applicationSupportDirectory.appending(path: "Moolah-v2.store")
-      let profileConfig = ModelConfiguration(
-        url: profileStoreURL,
-        cloudKitDatabase: .none
-      )
-      let indexContainer = try ModelContainer(for: profileSchema, configurations: [profileConfig])
+      let manager: ProfileContainerManager
+      if let seed = uiTestingSeed {
+        manager = try ProfileContainerManager.forTesting()
+        let profile = try UITestSeedHydrator.hydrate(seed, into: manager)
+        uiTestingProfileId = profile.id
+      } else {
+        let profileSchema = Schema([ProfileRecord.self])
+        let profileStoreURL = URL.applicationSupportDirectory.appending(path: "Moolah-v2.store")
+        let profileConfig = ModelConfiguration(
+          url: profileStoreURL,
+          cloudKitDatabase: .none
+        )
+        let indexContainer = try ModelContainer(
+          for: profileSchema, configurations: [profileConfig])
 
-      let dataSchema = Schema([
-        AccountRecord.self,
-        TransactionRecord.self,
-        TransactionLegRecord.self,
-        InstrumentRecord.self,
-        CategoryRecord.self,
-        EarmarkRecord.self,
-        EarmarkBudgetItemRecord.self,
-        InvestmentValueRecord.self,
-        CSVImportProfileRecord.self,
-        ImportRuleRecord.self,
-      ])
+        let dataSchema = Schema([
+          AccountRecord.self,
+          TransactionRecord.self,
+          TransactionLegRecord.self,
+          InstrumentRecord.self,
+          CategoryRecord.self,
+          EarmarkRecord.self,
+          EarmarkBudgetItemRecord.self,
+          InvestmentValueRecord.self,
+          CSVImportProfileRecord.self,
+          ImportRuleRecord.self,
+        ])
 
-      let manager = ProfileContainerManager(
-        indexContainer: indexContainer,
-        dataSchema: dataSchema
-      )
+        manager = ProfileContainerManager(
+          indexContainer: indexContainer,
+          dataSchema: dataSchema
+        )
+      }
       containerManager = manager
       syncCoordinator = SyncCoordinator(containerManager: manager)
+      self.uiTestingProfileId = uiTestingProfileId
     } catch {
       fatalError("Failed to initialize ModelContainer: \(error)")
     }
@@ -321,13 +359,23 @@ struct MoolahApp: App {
 
     let coordinator = syncCoordinator
 
-    // Wire sync coordinator to reload profiles on remote changes (only when CloudKit is available)
-    // Never start CloudKit sync under XCTest: the test binary is signed with the production
-    // iCloud entitlement, so the coordinator would fetch real records from the user's iCloud
-    // into on-disk profile stores; those records have bled into tests' in-memory containers
-    // via SwiftData's shared process state and caused intermittent balance failures.
+    // Wire sync coordinator to reload profiles on remote changes only for
+    // production launches. Test contexts must not reach for real iCloud:
+    //   - XCTest: the test binary is signed with the production iCloud
+    //     entitlement, so the coordinator would fetch real records from the
+    //     user's iCloud into on-disk profile stores; those records have bled
+    //     into tests' in-memory containers via SwiftData's shared process
+    //     state and caused intermittent balance failures.
+    //   - --ui-testing: the app is running against in-memory `TestBackend`-
+    //     shaped storage and must not reach for real iCloud. See
+    //     guides/UI_TEST_GUIDE.md §6.
     let isRunningTests = NSClassFromString("XCTestCase") != nil
-    if CloudKitAuthProvider.isCloudKitAvailable && !isRunningTests {
+    let isUITesting = uiTestingProfileId != nil
+    if isUITesting {
+      logger.info("Running under --ui-testing — skipping CloudKit sync coordinator")
+    } else if isRunningTests {
+      logger.info("Running under XCTest — skipping CloudKit sync coordinator")
+    } else if CloudKitAuthProvider.isCloudKitAvailable {
       logger.info("CloudKit available — starting sync coordinator")
       _ = coordinator.addIndexObserver { [weak store] in
         store?.loadCloudProfiles()
@@ -346,8 +394,6 @@ struct MoolahApp: App {
 
       // Clean up the legacy CloudKit zone from SwiftData's automatic sync
       LegacyZoneCleanup.performIfNeeded()
-    } else if isRunningTests {
-      logger.info("Running under XCTest — skipping CloudKit sync coordinator")
     } else {
       logger.warning(
         "CloudKit not available — profile sync disabled (NSUbiquitousContainers missing from Info.plist)"
@@ -389,7 +435,9 @@ struct MoolahApp: App {
   var body: some Scene {
     #if os(macOS)
       WindowGroup(for: Profile.ID.self) { $profileID in
-        ProfileWindowView(profileID: profileID)
+        // UI-testing mode pins the window to the seeded profile; the
+        // per-window binding is used only in production launches.
+        ProfileWindowView(profileID: uiTestingProfileId ?? profileID)
           .environment(profileStore)
           .environment(sessionManager)
           .environment(containerManager)
@@ -397,6 +445,10 @@ struct MoolahApp: App {
           .environment(\.pendingNavigation, $pendingNavigation)
           .onOpenURL { url in handleURL(url) }
           .task {
+            // Daily backup runs in production launches only; under UI
+            // testing the fixture container is ephemeral, so there is
+            // nothing meaningful to back up.
+            guard uiTestingProfileId == nil else { return }
             backupManager.performDailyBackup(
               profiles: profileStore.profiles,
               containerManager: containerManager

--- a/App/ProfileSession.swift
+++ b/App/ProfileSession.swift
@@ -197,6 +197,12 @@ final class ProfileSession: Identifiable {
       importStore: self.importStore,
       preferences: preferences,
       scanner: scanner)
+    // Wire the folder-watch delete-after-import default into ImportStore so a
+    // `.folderWatch` ingest honours it even when the matched profile's own
+    // `deleteAfterImport` is off.
+    self.importStore.folderWatchDeleteAfterImport = { [preferences] in
+      preferences.deleteAfterImportFolderDefault
+    }
 
     // Wire up cross-store side effects. The callback is fire-and-forget in
     // production; `updateInvestmentValue` awaits its own first conversion

--- a/App/ProfileSession.swift
+++ b/App/ProfileSession.swift
@@ -24,6 +24,9 @@ final class ProfileSession: Identifiable {
   let cryptoTokenStore: CryptoTokenStore
   let importStore: ImportStore
   let importRuleStore: ImportRuleStore
+  let importPreferences: ImportPreferences
+  private let folderScanner: FolderScanService
+  private let folderWatcher: FolderWatchService
 
   /// Observer token for sync coordinator notifications (nil for remote profiles).
   private var syncObserverToken: SyncCoordinator.ObserverToken?
@@ -182,6 +185,18 @@ final class ProfileSession: Identifiable {
       )
     }
     self.importRuleStore = ImportRuleStore(repository: backend.importRules)
+    let preferencesDirectory = stagingDirectory.deletingLastPathComponent()
+    let preferences = ImportPreferences(directory: preferencesDirectory)
+    self.importPreferences = preferences
+    let scanner = FolderScanService(
+      profileId: profile.id,
+      importStore: self.importStore,
+      preferences: preferences)
+    self.folderScanner = scanner
+    self.folderWatcher = FolderWatchService(
+      importStore: self.importStore,
+      preferences: preferences,
+      scanner: scanner)
 
     // Wire up cross-store side effects. The callback is fire-and-forget in
     // production; `updateInvestmentValue` awaits its own first conversion
@@ -376,6 +391,27 @@ final class ProfileSession: Identifiable {
     }
     syncReloadTask?.cancel()
     syncReloadTask = nil
+  }
+
+  // MARK: - Folder watch
+
+  /// Kick off the folder watch: catches up on any files added while the app
+  /// was closed and (on macOS) opens an FSEvents stream for live updates.
+  /// Safe to call repeatedly; stop() must be paired with start() for state
+  /// hygiene.
+  func startFolderWatch() async {
+    await folderWatcher.start()
+  }
+
+  /// Stop the folder watch and release the security-scoped resource.
+  func stopFolderWatch() {
+    folderWatcher.stop()
+  }
+
+  /// Catch-up scan — used at launch / foreground on iOS where the live
+  /// watch isn't available.
+  func scanWatchedFolder() async {
+    await folderScanner.scanForNewFiles()
   }
 
   /// Per-profile directory under Application Support where CSV import staging

--- a/App/UITestSeedHydrator.swift
+++ b/App/UITestSeedHydrator.swift
@@ -1,0 +1,184 @@
+import Foundation
+import SwiftData
+
+/// Populates an in-memory `ProfileContainerManager` from a named `UITestSeed`.
+///
+/// Called during `MoolahApp.init` when the process was launched with
+/// `--ui-testing`. Deterministic by contract: every invocation produces
+/// records with the UUIDs and values declared in `UITestFixtures`, so drivers
+/// can reference entities symbolically.
+///
+/// Idempotent: running twice on the same manager does not double-insert,
+/// which keeps re-launches during driver iteration robust.
+@MainActor
+enum UITestSeedHydrator {
+  /// Seeds `manager` from the given seed and returns the resulting `Profile`.
+  ///
+  /// - Parameter seed: the named data set to hydrate.
+  /// - Parameter manager: an in-memory `ProfileContainerManager` (see
+  ///   `ProfileContainerManager.forTesting()`).
+  /// - Returns: the seeded profile, ready to drive a window.
+  @discardableResult
+  static func hydrate(
+    _ seed: UITestSeed,
+    into manager: ProfileContainerManager
+  ) throws -> Profile {
+    switch seed {
+    case .tradeBaseline:
+      return try hydrateTradeBaseline(into: manager)
+    }
+  }
+
+  // MARK: - Seeds
+
+  private static func hydrateTradeBaseline(
+    into manager: ProfileContainerManager
+  ) throws -> Profile {
+    let fixtures = UITestFixtures.TradeBaseline.self
+
+    let profile = Profile(
+      id: fixtures.profileId,
+      label: fixtures.profileLabel,
+      backendType: .cloudKit,
+      currencyCode: fixtures.profileCurrencyCode,
+      financialYearStartMonth: 7,
+      createdAt: Date(timeIntervalSince1970: 1_700_000_000)
+    )
+
+    try upsertProfile(profile, into: manager)
+
+    let container = try manager.container(for: profile.id)
+    let context = ModelContext(container)
+    let instrument = profile.instrument
+
+    try upsertInstrument(instrument, in: context)
+
+    try upsertAccount(
+      id: fixtures.checkingAccountId,
+      name: fixtures.checkingAccountName,
+      type: .bank,
+      instrumentId: instrument.id,
+      position: 0,
+      in: context
+    )
+
+    try upsertAccount(
+      id: fixtures.brokerageAccountId,
+      name: fixtures.brokerageAccountName,
+      type: .investment,
+      instrumentId: instrument.id,
+      position: 1,
+      in: context
+    )
+
+    try upsertTrade(
+      id: fixtures.bhpPurchaseId,
+      payee: fixtures.bhpPurchasePayee,
+      date: fixtures.bhpPurchaseDate,
+      amount: InstrumentAmount(
+        quantity: Decimal(fixtures.bhpPurchaseAmountCents) / 100,
+        instrument: instrument
+      ),
+      fromAccountId: fixtures.checkingAccountId,
+      toAccountId: fixtures.brokerageAccountId,
+      in: context
+    )
+
+    try context.save()
+    return profile
+  }
+
+  // MARK: - Upsert helpers
+
+  private static func upsertProfile(
+    _ profile: Profile,
+    into manager: ProfileContainerManager
+  ) throws {
+    let context = ModelContext(manager.indexContainer)
+    let targetId = profile.id
+    let descriptor = FetchDescriptor<ProfileRecord>(
+      predicate: #Predicate { $0.id == targetId }
+    )
+    if try context.fetch(descriptor).first != nil { return }
+    context.insert(ProfileRecord.from(profile: profile))
+    try context.save()
+  }
+
+  private static func upsertInstrument(
+    _ instrument: Instrument,
+    in context: ModelContext
+  ) throws {
+    let targetId = instrument.id
+    let descriptor = FetchDescriptor<InstrumentRecord>(
+      predicate: #Predicate { $0.id == targetId }
+    )
+    if try context.fetch(descriptor).first != nil { return }
+    context.insert(InstrumentRecord.from(instrument))
+  }
+
+  private static func upsertAccount(
+    id: UUID,
+    name: String,
+    type: AccountType,
+    instrumentId: String,
+    position: Int,
+    in context: ModelContext
+  ) throws {
+    let targetId = id
+    let descriptor = FetchDescriptor<AccountRecord>(
+      predicate: #Predicate { $0.id == targetId }
+    )
+    if try context.fetch(descriptor).first != nil { return }
+    context.insert(
+      AccountRecord(
+        id: id,
+        name: name,
+        type: type.rawValue,
+        instrumentId: instrumentId,
+        position: position
+      )
+    )
+  }
+
+  private static func upsertTrade(
+    id: UUID,
+    payee: String,
+    date: Date,
+    amount: InstrumentAmount,
+    fromAccountId: UUID,
+    toAccountId: UUID,
+    in context: ModelContext
+  ) throws {
+    let targetId = id
+    let descriptor = FetchDescriptor<TransactionRecord>(
+      predicate: #Predicate { $0.id == targetId }
+    )
+    if try context.fetch(descriptor).first != nil { return }
+
+    let txn = TransactionRecord(id: id, date: date, payee: payee)
+    context.insert(txn)
+
+    let outgoing = InstrumentAmount(quantity: -amount.quantity, instrument: amount.instrument)
+
+    context.insert(
+      TransactionLegRecord(
+        transactionId: id,
+        accountId: fromAccountId,
+        instrumentId: amount.instrument.id,
+        quantity: outgoing.storageValue,
+        type: TransactionType.expense.rawValue,
+        sortOrder: 0
+      )
+    )
+    context.insert(
+      TransactionLegRecord(
+        transactionId: id,
+        accountId: toAccountId,
+        instrumentId: amount.instrument.id,
+        quantity: amount.storageValue,
+        type: TransactionType.income.rawValue,
+        sortOrder: 1
+      )
+    )
+  }
+}

--- a/Backends/CloudKit/Models/CSVImportProfileRecord.swift
+++ b/Backends/CloudKit/Models/CSVImportProfileRecord.swift
@@ -17,6 +17,8 @@ final class CSVImportProfileRecord {
   var deleteAfterImport: Bool = false
   var createdAt: Date = Date()
   var lastUsedAt: Date?
+  /// Persisted user-confirmed date format (see CSVImportProfile).
+  var dateFormatRawValue: String?
   var encodedSystemFields: Data?
 
   init(
@@ -27,7 +29,8 @@ final class CSVImportProfileRecord {
     filenamePattern: String? = nil,
     deleteAfterImport: Bool = false,
     createdAt: Date = Date(),
-    lastUsedAt: Date? = nil
+    lastUsedAt: Date? = nil,
+    dateFormatRawValue: String? = nil
   ) {
     self.id = id
     self.accountId = accountId
@@ -37,6 +40,7 @@ final class CSVImportProfileRecord {
     self.deleteAfterImport = deleteAfterImport
     self.createdAt = createdAt
     self.lastUsedAt = lastUsedAt
+    self.dateFormatRawValue = dateFormatRawValue
   }
 
   /// Unit-separator (U+001F). Chosen because the CSV tokenizer never produces
@@ -54,7 +58,8 @@ final class CSVImportProfileRecord {
       filenamePattern: filenamePattern,
       deleteAfterImport: deleteAfterImport,
       createdAt: createdAt,
-      lastUsedAt: lastUsedAt)
+      lastUsedAt: lastUsedAt,
+      dateFormatRawValue: dateFormatRawValue)
   }
 
   static func from(_ profile: CSVImportProfile) -> CSVImportProfileRecord {
@@ -66,6 +71,7 @@ final class CSVImportProfileRecord {
       filenamePattern: profile.filenamePattern,
       deleteAfterImport: profile.deleteAfterImport,
       createdAt: profile.createdAt,
-      lastUsedAt: profile.lastUsedAt)
+      lastUsedAt: profile.lastUsedAt,
+      dateFormatRawValue: profile.dateFormatRawValue)
   }
 }

--- a/Backends/CloudKit/Repositories/CloudKitCSVImportProfileRepository.swift
+++ b/Backends/CloudKit/Repositories/CloudKitCSVImportProfileRepository.swift
@@ -46,6 +46,7 @@ final class CloudKitCSVImportProfileRepository: CSVImportProfileRepository, @unc
       record.filenamePattern = profile.filenamePattern
       record.deleteAfterImport = profile.deleteAfterImport
       record.lastUsedAt = profile.lastUsedAt
+      record.dateFormatRawValue = profile.dateFormatRawValue
       try context.save()
       onRecordChanged(profile.id)
       return record.toDomain()

--- a/Backends/CloudKit/Sync/ProfileDataSyncHandler.swift
+++ b/Backends/CloudKit/Sync/ProfileDataSyncHandler.swift
@@ -1129,6 +1129,7 @@ final class ProfileDataSyncHandler: Sendable {
         existing.deleteAfterImport = values.deleteAfterImport
         existing.createdAt = values.createdAt
         existing.lastUsedAt = values.lastUsedAt
+        existing.dateFormatRawValue = values.dateFormatRawValue
         existing.encodedSystemFields = systemFields[id.uuidString]
       } else {
         values.encodedSystemFields = systemFields[id.uuidString]

--- a/Backends/CloudKit/Sync/RecordMapping.swift
+++ b/Backends/CloudKit/Sync/RecordMapping.swift
@@ -376,6 +376,7 @@ extension CSVImportProfileRecord: CloudKitRecordConvertible {
     record["deleteAfterImport"] = (deleteAfterImport ? 1 : 0) as CKRecordValue
     record["createdAt"] = createdAt as CKRecordValue
     if let v = lastUsedAt { record["lastUsedAt"] = v as CKRecordValue }
+    if let v = dateFormatRawValue { record["dateFormatRawValue"] = v as CKRecordValue }
     return record
   }
 
@@ -388,7 +389,8 @@ extension CSVImportProfileRecord: CloudKitRecordConvertible {
       filenamePattern: ckRecord["filenamePattern"] as? String,
       deleteAfterImport: (ckRecord["deleteAfterImport"] as? Int ?? 0) != 0,
       createdAt: ckRecord["createdAt"] as? Date ?? Date(),
-      lastUsedAt: ckRecord["lastUsedAt"] as? Date)
+      lastUsedAt: ckRecord["lastUsedAt"] as? Date,
+      dateFormatRawValue: ckRecord["dateFormatRawValue"] as? String)
     // Store the joined headerSignature directly (init normalises via joining,
     // but the CK value already arrives pre-joined).
     record.headerSignature = ckRecord["headerSignature"] as? String ?? ""

--- a/Domain/Models/CSVImport/CSVImportProfile.swift
+++ b/Domain/Models/CSVImport/CSVImportProfile.swift
@@ -16,6 +16,12 @@ struct CSVImportProfile: Codable, Sendable, Identifiable, Hashable {
   var deleteAfterImport: Bool
   let createdAt: Date
   var lastUsedAt: Date?
+  /// User-confirmed date format for ambiguous generic-bank exports. `nil`
+  /// means "auto-detect". Stored as the raw-value string form of
+  /// `GenericBankCSVParser.DateFormat` so the domain layer doesn't depend
+  /// on Shared/. Format strings follow `DateFormatter` conventions (e.g.
+  /// `"dd/MM/yyyy"`, `"MM/dd/yyyy"`, `"yyyy-MM-dd"`).
+  var dateFormatRawValue: String?
 
   init(
     id: UUID = UUID(),
@@ -25,7 +31,8 @@ struct CSVImportProfile: Codable, Sendable, Identifiable, Hashable {
     filenamePattern: String? = nil,
     deleteAfterImport: Bool = false,
     createdAt: Date = Date(),
-    lastUsedAt: Date? = nil
+    lastUsedAt: Date? = nil,
+    dateFormatRawValue: String? = nil
   ) {
     self.id = id
     self.accountId = accountId
@@ -35,6 +42,7 @@ struct CSVImportProfile: Codable, Sendable, Identifiable, Hashable {
     self.deleteAfterImport = deleteAfterImport
     self.createdAt = createdAt
     self.lastUsedAt = lastUsedAt
+    self.dateFormatRawValue = dateFormatRawValue
   }
 
   /// Canonical header form: trimmed + lowercased. This is what both the

--- a/Domain/Models/CSVImport/ParsedTransaction.swift
+++ b/Domain/Models/CSVImport/ParsedTransaction.swift
@@ -3,11 +3,32 @@ import Foundation
 /// One leg of a parsed CSV row. `accountId` is `nil` at parse time for cash
 /// legs — the profile-routing step fills it in. Position legs (e.g. brokerage
 /// trades) reference their target account directly.
+///
+/// `isInstrumentPlaceholder` signals that the leg's `instrument` is a
+/// pipeline-placeholder (typically `.AUD`) that the orchestrator should
+/// rewrite to the routed account's actual instrument before persisting.
+/// Parsers set this to `true` on cash legs and `false` on position legs
+/// (e.g. stock tickers) where the instrument is the real one already.
 struct ParsedLeg: Sendable, Hashable {
   var accountId: UUID?
   var instrument: Instrument
   var quantity: Decimal
   var type: TransactionType
+  var isInstrumentPlaceholder: Bool
+
+  init(
+    accountId: UUID?,
+    instrument: Instrument,
+    quantity: Decimal,
+    type: TransactionType,
+    isInstrumentPlaceholder: Bool = false
+  ) {
+    self.accountId = accountId
+    self.instrument = instrument
+    self.quantity = quantity
+    self.type = type
+    self.isInstrumentPlaceholder = isInstrumentPlaceholder
+  }
 }
 
 /// The ephemeral output of a `CSVParser`. Never persisted directly — the

--- a/Features/Import/CSVImportSetupStore.swift
+++ b/Features/Import/CSVImportSetupStore.swift
@@ -1,0 +1,137 @@
+import Foundation
+import OSLog
+import Observation
+
+/// Thin drives the CSVImportSetupView. Loads the staged bytes, builds a
+/// preview, and on Save & Import persists a `CSVImportProfile` and re-enters
+/// the pipeline via `ImportStore.finishSetup(pendingId:profile:)`.
+///
+/// @Observable @MainActor because it binds to a SwiftUI form.
+@Observable
+@MainActor
+final class CSVImportSetupStore {
+
+  /// The pending file this setup form is resolving.
+  let pending: PendingSetupFile
+
+  /// Editable fields.
+  var targetAccountId: UUID?
+  var filenamePattern: String
+  var deleteAfterImport: Bool = false
+  /// Override date-format detection when the user disagrees.
+  var dateFormatOverride: GenericBankCSVParser.DateFormat?
+
+  /// Computed read-only state for the view.
+  private(set) var detectedParserIdentifier: String
+  private(set) var detectedHeaders: [String]
+  private(set) var detectedMapping: GenericBankCSVParser.ColumnMapping?
+  private(set) var rowCount: Int = 0
+  private(set) var preview: [ParsedTransaction] = []
+  private(set) var saveError: String?
+  private(set) var isSaving: Bool = false
+
+  /// Is the detected parser the fallback generic one (column-mapping UI shown),
+  /// or a source-specific parser (mapping hidden).
+  var isGenericParser: Bool { detectedParserIdentifier == "generic-bank" }
+
+  private let backend: any BackendProvider
+  private let importStore: ImportStore
+  private let staging: ImportStagingStore
+  private let registry: CSVParserRegistry
+  private let logger = Logger(subsystem: "com.moolah.app", category: "CSVImportSetupStore")
+
+  init(
+    pending: PendingSetupFile,
+    backend: any BackendProvider,
+    importStore: ImportStore,
+    staging: ImportStagingStore,
+    registry: CSVParserRegistry = .default
+  ) {
+    self.pending = pending
+    self.backend = backend
+    self.importStore = importStore
+    self.staging = staging
+    self.registry = registry
+    self.detectedParserIdentifier = pending.detectedParserIdentifier ?? "generic-bank"
+    self.detectedHeaders = pending.detectedHeaders
+    self.filenamePattern = Self.suggestedFilenamePattern(from: pending.originalFilename)
+  }
+
+  /// Parse the staged bytes with the current settings, populate the preview.
+  func regeneratePreview() async {
+    do {
+      let data = try await staging.data(for: pending.id)
+      let rows = try CSVTokenizer.parse(data)
+      rowCount = max(0, rows.count - 1)
+      let parser = registry.select(for: rows.first ?? [])
+      detectedParserIdentifier = parser.identifier
+      if let generic = parser as? GenericBankCSVParser {
+        detectedMapping = generic.inferMapping(
+          from: rows.first ?? [], sampleRows: Array(rows.dropFirst().prefix(5)))
+      } else {
+        detectedMapping = nil
+      }
+      let records = try parser.parse(rows: rows)
+      preview = Array(
+        records.compactMap { rec -> ParsedTransaction? in
+          if case .transaction(let tx) = rec { return tx } else { return nil }
+        }
+        .prefix(5)
+      )
+      saveError = nil
+    } catch {
+      preview = []
+      saveError = error.localizedDescription
+      logger.error(
+        "Preview failed: \(error.localizedDescription, privacy: .public)")
+    }
+  }
+
+  /// Build the profile, persist it, and re-enter the pipeline. Returns the
+  /// `ImportSessionResult` from `ImportStore.finishSetup`.
+  @discardableResult
+  func saveAndImport() async -> ImportSessionResult {
+    guard let accountId = targetAccountId else {
+      let message = "Pick a target account before saving."
+      saveError = message
+      return .failed(message: message)
+    }
+    isSaving = true
+    defer { isSaving = false }
+    saveError = nil
+    let profile = CSVImportProfile(
+      accountId: accountId,
+      parserIdentifier: detectedParserIdentifier,
+      headerSignature: detectedHeaders,
+      filenamePattern: filenamePattern.isEmpty ? nil : filenamePattern,
+      deleteAfterImport: deleteAfterImport)
+    return await importStore.finishSetup(pendingId: pending.id, profile: profile)
+  }
+
+  /// Leave the pending file where it is; just dismiss the sheet.
+  func cancel() {
+    saveError = nil
+  }
+
+  /// Permanently drop the staged file (user decided they don't want it).
+  func deletePending() async {
+    await importStore.dismissPending(id: pending.id)
+  }
+
+  // MARK: - Helpers
+
+  /// Turn `cba-april-2026.csv` into `cba-*.csv`. The rule: lower-case,
+  /// everything up to the first dash stays literal, then `*` then the
+  /// extension.
+  static func suggestedFilenamePattern(from filename: String) -> String {
+    let lower = filename.lowercased()
+    let ext = (lower as NSString).pathExtension
+    let stem = (lower as NSString).deletingPathExtension
+    let components = stem.split(separator: "-", omittingEmptySubsequences: true)
+    if components.count >= 2 {
+      let head = components[0]
+      return ext.isEmpty ? "\(head)-*" : "\(head)-*.\(ext)"
+    }
+    return ext.isEmpty ? "\(stem)*" : "\(stem)*.\(ext)"
+  }
+}

--- a/Features/Import/CSVImportSetupStore.swift
+++ b/Features/Import/CSVImportSetupStore.swift
@@ -20,6 +20,9 @@ final class CSVImportSetupStore {
   var deleteAfterImport: Bool = false
   /// Override date-format detection when the user disagrees.
   var dateFormatOverride: GenericBankCSVParser.DateFormat?
+  /// Per-column role overrides keyed by header index. `.ignore` means the
+  /// column won't be used. See `ColumnRole`.
+  var columnRoles: [ColumnRole?] = []
 
   /// Computed read-only state for the view.
   private(set) var detectedParserIdentifier: String
@@ -33,6 +36,80 @@ final class CSVImportSetupStore {
   /// Is the detected parser the fallback generic one (column-mapping UI shown),
   /// or a source-specific parser (mapping hidden).
   var isGenericParser: Bool { detectedParserIdentifier == "generic-bank" }
+
+  /// The role a column has been assigned by the user or by the detector.
+  enum ColumnRole: String, CaseIterable, Identifiable, Sendable {
+    case date, description, amount, debit, credit, balance, reference, ignore
+    var id: String { rawValue }
+    var label: String {
+      switch self {
+      case .date: return "Date"
+      case .description: return "Description"
+      case .amount: return "Amount"
+      case .debit: return "Debit"
+      case .credit: return "Credit"
+      case .balance: return "Balance"
+      case .reference: return "Reference"
+      case .ignore: return "Ignore"
+      }
+    }
+  }
+
+  /// Compose a `ColumnMapping` from the user's current role assignments.
+  /// `columnRoles` is seeded from the detected mapping in `regeneratePreview`,
+  /// so this function derives the mapping purely from the roles array — a
+  /// role set to `.ignore` (or simply left `nil`) means the column is unused,
+  /// even if the detector had originally picked it.
+  ///
+  /// Missing `.date` / `.description` columns resolve to `-1`; the parser's
+  /// `safe(row:_:)` helper returns `""` for out-of-bounds indices, which is
+  /// the intended "not mapped" behaviour.
+  func effectiveMapping() -> GenericBankCSVParser.ColumnMapping? {
+    guard let base = detectedMapping else { return nil }
+    // If columnRoles hasn't been seeded yet (no regeneratePreview run),
+    // ship the detected mapping with the date-format override applied.
+    guard columnRoles.count == detectedHeaders.count else {
+      var mapping = base
+      if let override = dateFormatOverride {
+        mapping.dateFormat = override
+        mapping.dateFormatAmbiguous = false
+      }
+      return mapping
+    }
+    var mapping = base
+    mapping.date = columnRoles.firstIndex(of: .date) ?? -1
+    mapping.description = columnRoles.firstIndex(of: .description) ?? -1
+    mapping.amount = columnRoles.firstIndex(of: .amount)
+    mapping.debit = columnRoles.firstIndex(of: .debit)
+    mapping.credit = columnRoles.firstIndex(of: .credit)
+    mapping.balance = columnRoles.firstIndex(of: .balance)
+    mapping.reference = columnRoles.firstIndex(of: .reference)
+    if let override = dateFormatOverride {
+      mapping.dateFormat = override
+      mapping.dateFormatAmbiguous = false
+    }
+    return mapping
+  }
+
+  /// Re-read the preview after a role change.
+  func applyColumnRole(_ role: ColumnRole?, forColumn index: Int) async {
+    while columnRoles.count < detectedHeaders.count {
+      columnRoles.append(nil)
+    }
+    // Single-value roles (date / description / amount / debit / credit /
+    // balance / reference) map to exactly one column — reassigning them
+    // clears the previous column. `.ignore` is deliberately excluded from
+    // this rule because multiple columns can legitimately be ignored.
+    if let role, role != .ignore {
+      for otherIndex in columnRoles.indices
+      where otherIndex != index && columnRoles[otherIndex] == role {
+        columnRoles[otherIndex] = nil
+      }
+    }
+    guard columnRoles.indices.contains(index) else { return }
+    columnRoles[index] = role
+    await regeneratePreview()
+  }
 
   private let backend: any BackendProvider
   private let importStore: ImportStore
@@ -57,21 +134,69 @@ final class CSVImportSetupStore {
     self.filenamePattern = Self.suggestedFilenamePattern(from: pending.originalFilename)
   }
 
+  /// Update the date-format override and regenerate the preview in one
+  /// atomic step. Called by the view's `onChange` so the mutation and the
+  /// async reload stay together inside the store.
+  func applyDateFormatOverride(
+    _ override: GenericBankCSVParser.DateFormat?
+  ) async {
+    dateFormatOverride = override
+    await regeneratePreview()
+  }
+
   /// Parse the staged bytes with the current settings, populate the preview.
   func regeneratePreview() async {
     do {
       let data = try await staging.data(for: pending.id)
       let rows = try CSVTokenizer.parse(data)
       rowCount = max(0, rows.count - 1)
-      let parser = registry.select(for: rows.first ?? [])
+      let headers = rows.first ?? []
+      detectedHeaders = headers
+      let parser = registry.select(for: headers)
       detectedParserIdentifier = parser.identifier
       if let generic = parser as? GenericBankCSVParser {
         detectedMapping = generic.inferMapping(
-          from: rows.first ?? [], sampleRows: Array(rows.dropFirst().prefix(5)))
+          from: headers, sampleRows: Array(rows.dropFirst().prefix(5)))
       } else {
         detectedMapping = nil
       }
-      let records = try parser.parse(rows: rows)
+      // Seed columnRoles from the detected mapping on first run so the UI
+      // picker starts at the detector's choice AND so the mapping can be
+      // derived purely from `columnRoles` from here on (a `.ignore` or
+      // `nil` entry means the column is unused — the detector's original
+      // pick does not "leak through").
+      if columnRoles.count != headers.count {
+        columnRoles = Array(repeating: nil, count: headers.count)
+        if let detected = detectedMapping {
+          if columnRoles.indices.contains(detected.date) {
+            columnRoles[detected.date] = .date
+          }
+          if columnRoles.indices.contains(detected.description) {
+            columnRoles[detected.description] = .description
+          }
+          if let idx = detected.amount, columnRoles.indices.contains(idx) {
+            columnRoles[idx] = .amount
+          }
+          if let idx = detected.debit, columnRoles.indices.contains(idx) {
+            columnRoles[idx] = .debit
+          }
+          if let idx = detected.credit, columnRoles.indices.contains(idx) {
+            columnRoles[idx] = .credit
+          }
+          if let idx = detected.balance, columnRoles.indices.contains(idx) {
+            columnRoles[idx] = .balance
+          }
+          if let idx = detected.reference, columnRoles.indices.contains(idx) {
+            columnRoles[idx] = .reference
+          }
+        }
+      }
+      let records: [ParsedRecord]
+      if parser is GenericBankCSVParser, let mapping = effectiveMapping() {
+        records = try parseGenericWith(mapping: mapping, rows: rows)
+      } else {
+        records = try parser.parse(rows: rows)
+      }
       preview = Array(
         records.compactMap { rec -> ParsedTransaction? in
           if case .transaction(let tx) = rec { return tx } else { return nil }
@@ -85,6 +210,16 @@ final class CSVImportSetupStore {
       logger.error(
         "Preview failed: \(error.localizedDescription, privacy: .public)")
     }
+  }
+
+  /// Parse the rows with an explicit mapping. Bypasses the detector so the
+  /// user's role assignments take effect immediately in the preview.
+  private func parseGenericWith(
+    mapping: GenericBankCSVParser.ColumnMapping, rows: [[String]]
+  ) throws -> [ParsedRecord] {
+    let parser = GenericBankCSVParser()
+    return try parser.parse(
+      rows: rows, overrideMapping: mapping)
   }
 
   /// Build the profile, persist it, and re-enter the pipeline. Returns the
@@ -104,7 +239,8 @@ final class CSVImportSetupStore {
       parserIdentifier: detectedParserIdentifier,
       headerSignature: detectedHeaders,
       filenamePattern: filenamePattern.isEmpty ? nil : filenamePattern,
-      deleteAfterImport: deleteAfterImport)
+      deleteAfterImport: deleteAfterImport,
+      dateFormatRawValue: dateFormatOverride?.rawValue)
     return await importStore.finishSetup(pendingId: pending.id, profile: profile)
   }
 

--- a/Features/Import/FolderScanService.swift
+++ b/Features/Import/FolderScanService.swift
@@ -1,0 +1,102 @@
+import Foundation
+import OSLog
+
+/// Scans a folder for new / changed CSV files and feeds them into
+/// `ImportStore.ingest(source: .folderWatch)`. Used on both platforms:
+/// - iOS: at launch and scene-foreground (no live watch).
+/// - macOS: for the catch-up scan on app launch, before `FolderWatchService`
+///   takes over for live changes.
+///
+/// Tracks the last-seen modification date per profile in UserDefaults so
+/// subsequent scans only ingest files newer than the cursor.
+@MainActor
+final class FolderScanService {
+
+  private let defaults: UserDefaults
+  private let importStore: ImportStore
+  private let preferences: ImportPreferences
+  private let profileId: UUID
+  private let fileManager: FileManager
+  private let logger = Logger(
+    subsystem: "com.moolah.app", category: "FolderScanService")
+
+  init(
+    profileId: UUID,
+    importStore: ImportStore,
+    preferences: ImportPreferences,
+    defaults: UserDefaults = .standard,
+    fileManager: FileManager = .default
+  ) {
+    self.profileId = profileId
+    self.importStore = importStore
+    self.preferences = preferences
+    self.defaults = defaults
+    self.fileManager = fileManager
+  }
+
+  /// Scan the watched folder (if configured) and ingest every `.csv` file
+  /// whose modification date is newer than the last-seen cursor. Updates
+  /// the cursor at the end.
+  func scanForNewFiles() async {
+    guard let resolved = preferences.resolveWatchedFolder() else { return }
+    defer {
+      if resolved.startedAccess {
+        resolved.url.stopAccessingSecurityScopedResource()
+      }
+    }
+    let folder = resolved.url
+    let lastSeen = lastSeenDate()
+    let urls: [URL]
+    do {
+      urls = try fileManager.contentsOfDirectory(
+        at: folder,
+        includingPropertiesForKeys: [.contentModificationDateKey, .isRegularFileKey],
+        options: [.skipsHiddenFiles])
+    } catch {
+      let folderPath = folder.path
+      let errDesc = error.localizedDescription
+      logger.error(
+        "Failed to list \(folderPath, privacy: .public): \(errDesc, privacy: .public)"
+      )
+      return
+    }
+
+    var newestSeen = lastSeen
+    for url in urls where url.pathExtension.lowercased() == "csv" {
+      guard
+        let values = try? url.resourceValues(forKeys: [
+          .contentModificationDateKey, .isRegularFileKey,
+        ]),
+        values.isRegularFile == true,
+        let modified = values.contentModificationDate
+      else { continue }
+      if modified <= lastSeen { continue }
+      guard let data = try? Data(contentsOf: url) else { continue }
+      // Read the security-scoped bookmark from preferences rather than
+      // re-bookmarking each file; the parent folder's scope covers this.
+      let bookmark = preferences.watchedFolderBookmark
+      _ = await importStore.ingest(
+        data: data,
+        source: .folderWatch(url: url, bookmark: bookmark))
+      if modified > newestSeen { newestSeen = modified }
+    }
+
+    if newestSeen > lastSeen {
+      setLastSeenDate(newestSeen)
+    }
+  }
+
+  // MARK: - Cursor
+
+  private var cursorKey: String { "csvImport.folderScan.lastSeen.\(profileId.uuidString)" }
+
+  private func lastSeenDate() -> Date {
+    let interval = defaults.double(forKey: cursorKey)
+    if interval > 0 { return Date(timeIntervalSince1970: interval) }
+    return .distantPast
+  }
+
+  private func setLastSeenDate(_ date: Date) {
+    defaults.set(date.timeIntervalSince1970, forKey: cursorKey)
+  }
+}

--- a/Features/Import/FolderWatchService.swift
+++ b/Features/Import/FolderWatchService.swift
@@ -24,6 +24,9 @@
     private var stream: FSEventStreamRef?
     private var watchedURL: URL?
     private var didStartAccess: Bool = false
+    /// Held across the stream's lifetime and deallocated in `stop()` so the
+    /// FSEventStreamContext isn't leaked when we drop the stream.
+    private var contextPointer: UnsafeMutablePointer<FSEventStreamContext>?
 
     init(
       importStore: ImportStore,
@@ -93,6 +96,7 @@
         return
       }
       stream = newStream
+      contextPointer = context
       FSEventStreamSetDispatchQueue(newStream, .main)
       FSEventStreamStart(newStream)
       let folderPath = resolved.url.path
@@ -107,6 +111,11 @@
         FSEventStreamRelease(stream)
       }
       stream = nil
+      if let contextPointer {
+        contextPointer.deinitialize(count: 1)
+        contextPointer.deallocate()
+      }
+      contextPointer = nil
       if didStartAccess, let watchedURL {
         watchedURL.stopAccessingSecurityScopedResource()
       }

--- a/Features/Import/FolderWatchService.swift
+++ b/Features/Import/FolderWatchService.swift
@@ -1,0 +1,153 @@
+#if os(macOS)
+  import CoreServices
+  import Foundation
+  import OSLog
+
+  /// Live folder-watch service using FSEvents (macOS only). On iOS, the
+  /// system doesn't grant a live background watch on a user folder, so
+  /// `FolderScanService` runs on launch and scene-foreground instead.
+  ///
+  /// Lifecycle: `start()` resolves the security-scoped bookmark, opens an
+  /// FSEvents stream, and forwards every `.csv` appearance / change to
+  /// `ImportStore` via a delegating callback. `stop()` tears down the
+  /// stream and releases the security-scoped resource.
+  @MainActor
+  final class FolderWatchService {
+
+    private let importStore: ImportStore
+    private let preferences: ImportPreferences
+    private let scanner: FolderScanService
+    private let fileManager: FileManager
+    private let logger = Logger(
+      subsystem: "com.moolah.app", category: "FolderWatchService")
+
+    private var stream: FSEventStreamRef?
+    private var watchedURL: URL?
+    private var didStartAccess: Bool = false
+
+    init(
+      importStore: ImportStore,
+      preferences: ImportPreferences,
+      scanner: FolderScanService,
+      fileManager: FileManager = .default
+    ) {
+      self.importStore = importStore
+      self.preferences = preferences
+      self.scanner = scanner
+      self.fileManager = fileManager
+    }
+
+    /// Start watching. Runs a catch-up scan first (delegated to
+    /// `FolderScanService`) so files added while the app was closed are
+    /// picked up.
+    func start() async {
+      guard stream == nil else { return }
+      await scanner.scanForNewFiles()
+      guard let resolved = preferences.resolveWatchedFolder() else { return }
+      watchedURL = resolved.url
+      didStartAccess = resolved.startedAccess
+
+      let context = UnsafeMutablePointer<FSEventStreamContext>.allocate(capacity: 1)
+      context.initialize(
+        to: FSEventStreamContext(
+          version: 0,
+          info: Unmanaged<FolderWatchService>.passUnretained(self).toOpaque(),
+          retain: nil,
+          release: nil,
+          copyDescription: nil))
+
+      let callback: FSEventStreamCallback = { _, info, count, pathsRaw, _, _ in
+        guard let info else { return }
+        let unmanaged = Unmanaged<FolderWatchService>.fromOpaque(info)
+        let service = unmanaged.takeUnretainedValue()
+        let cfArray = unsafeBitCast(pathsRaw, to: CFArray.self)
+        let pathCount = CFArrayGetCount(cfArray)
+        var paths: [String] = []
+        paths.reserveCapacity(pathCount)
+        for i in 0..<min(pathCount, count) {
+          let ptr = CFArrayGetValueAtIndex(cfArray, i)
+          if let ptr {
+            let cfString = unsafeBitCast(ptr, to: CFString.self)
+            paths.append(cfString as String)
+          }
+        }
+        Task { @MainActor in
+          await service.handleEvents(paths: paths)
+        }
+      }
+
+      let flags = UInt32(kFSEventStreamCreateFlagUseCFTypes | kFSEventStreamCreateFlagFileEvents)
+      guard
+        let newStream = FSEventStreamCreate(
+          kCFAllocatorDefault,
+          callback,
+          context,
+          [resolved.url.path] as CFArray,
+          FSEventStreamEventId(kFSEventStreamEventIdSinceNow),
+          1.0,
+          flags)
+      else {
+        context.deinitialize(count: 1)
+        context.deallocate()
+        logger.error("FSEventStreamCreate failed")
+        return
+      }
+      stream = newStream
+      FSEventStreamSetDispatchQueue(newStream, .main)
+      FSEventStreamStart(newStream)
+      let folderPath = resolved.url.path
+      logger.info("Watching \(folderPath, privacy: .public) via FSEvents")
+    }
+
+    /// Stop watching and release the security-scoped resource.
+    func stop() {
+      if let stream {
+        FSEventStreamStop(stream)
+        FSEventStreamInvalidate(stream)
+        FSEventStreamRelease(stream)
+      }
+      stream = nil
+      if didStartAccess, let watchedURL {
+        watchedURL.stopAccessingSecurityScopedResource()
+      }
+      watchedURL = nil
+      didStartAccess = false
+    }
+
+    // MARK: - Event handling
+
+    fileprivate func handleEvents(paths: [String]) async {
+      for path in paths {
+        let url = URL(fileURLWithPath: path)
+        guard url.pathExtension.lowercased() == "csv" else { continue }
+        guard fileManager.fileExists(atPath: url.path) else { continue }
+        guard let data = try? Data(contentsOf: url) else { continue }
+        _ = await importStore.ingest(
+          data: data,
+          source: .folderWatch(url: url, bookmark: preferences.watchedFolderBookmark))
+      }
+    }
+  }
+#else
+  // iOS — no live watch. `FolderScanService` handles launch / foreground
+  // polls. This empty shim keeps call sites compiling.
+  import Foundation
+
+  @MainActor
+  final class FolderWatchService {
+    init(
+      importStore: ImportStore,
+      preferences: ImportPreferences,
+      scanner: FolderScanService,
+      fileManager: FileManager = .default
+    ) {
+      _ = importStore
+      _ = preferences
+      _ = scanner
+      _ = fileManager
+    }
+
+    func start() async {}
+    func stop() {}
+  }
+#endif

--- a/Features/Import/ImportCommands.swift
+++ b/Features/Import/ImportCommands.swift
@@ -1,10 +1,10 @@
 import SwiftUI
 
-/// File > Import CSV… menu item. The actual `.fileImporter` sheet lives in
-/// the focused window's view; this command triggers the focused-value action
-/// that opens it.
+/// File > Import CSV… menu item plus Paste CSV. The actual handlers live in
+/// the focused window's view; the commands trigger focused-value actions.
 struct ImportCSVCommands: Commands {
   @FocusedValue(\.importCSVAction) private var importCSVAction
+  @FocusedValue(\.pasteCSVAction) private var pasteCSVAction
 
   var body: some Commands {
     CommandGroup(replacing: .importExport) {
@@ -13,6 +13,12 @@ struct ImportCSVCommands: Commands {
       }
       .keyboardShortcut("i", modifiers: [.command, .shift])
       .disabled(importCSVAction == nil)
+
+      Button("Paste CSV") {
+        pasteCSVAction?()
+      }
+      .keyboardShortcut("v", modifiers: [.command, .shift, .option])
+      .disabled(pasteCSVAction == nil)
     }
   }
 }

--- a/Features/Import/ImportPreferences.swift
+++ b/Features/Import/ImportPreferences.swift
@@ -1,0 +1,153 @@
+import Foundation
+import OSLog
+import Observation
+
+/// Per-profile CSV-import settings. Persisted as a small JSON file next to
+/// the staging store. Not synced — security-scoped bookmarks are per-device.
+struct ImportPreferencesRecord: Codable, Sendable, Equatable {
+  /// Security-scoped bookmark to the user's watched folder. `nil` when folder
+  /// watching is disabled.
+  var watchedFolderBookmark: Data?
+  /// The folder's display path at the time it was picked, for UI display
+  /// only. The bookmark is authoritative.
+  var watchedFolderDisplayPath: String?
+  /// Delete CSVs after successful import (folder-watch only). Per-profile
+  /// default; can be overridden per profile via `CSVImportProfile.deleteAfterImport`.
+  var deleteAfterImportFolderDefault: Bool = false
+}
+
+/// `@Observable @MainActor` store for folder-watch preferences. Backs the
+/// Settings → Import panel.
+@Observable
+@MainActor
+final class ImportPreferences {
+
+  private(set) var record: ImportPreferencesRecord = ImportPreferencesRecord()
+  private let url: URL
+  private let fileManager: FileManager
+  private let logger = Logger(subsystem: "com.moolah.app", category: "ImportPreferences")
+
+  init(directory: URL, fileManager: FileManager = .default) {
+    self.url = directory.appendingPathComponent("import-preferences.json")
+    self.fileManager = fileManager
+    do {
+      try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+    } catch {
+      let dirPath = directory.path
+      let errDesc = error.localizedDescription
+      logger.error(
+        "Could not create preferences directory at \(dirPath, privacy: .public): \(errDesc, privacy: .public)"
+      )
+    }
+    load()
+  }
+
+  // MARK: - Public API
+
+  var watchedFolderDisplayPath: String? {
+    record.watchedFolderDisplayPath
+  }
+
+  var watchedFolderBookmark: Data? {
+    record.watchedFolderBookmark
+  }
+
+  var deleteAfterImportFolderDefault: Bool {
+    get { record.deleteAfterImportFolderDefault }
+    set {
+      record.deleteAfterImportFolderDefault = newValue
+      save()
+    }
+  }
+
+  /// Resolve the stored bookmark to a URL, starting security-scoped access.
+  /// Caller is responsible for calling `stopAccessingSecurityScopedResource`
+  /// when done.
+  func resolveWatchedFolder() -> (url: URL, startedAccess: Bool)? {
+    guard let bookmark = record.watchedFolderBookmark else { return nil }
+    var isStale = false
+    do {
+      let url = try URL(
+        resolvingBookmarkData: bookmark,
+        options: Self.bookmarkOptions,
+        relativeTo: nil,
+        bookmarkDataIsStale: &isStale)
+      if isStale {
+        // Re-make the bookmark so subsequent resolves are fast.
+        if let refreshed = try? url.bookmarkData(options: Self.bookmarkCreateOptions) {
+          record.watchedFolderBookmark = refreshed
+          save()
+        }
+      }
+      let started = url.startAccessingSecurityScopedResource()
+      return (url, started)
+    } catch {
+      logger.error(
+        "Failed to resolve bookmark: \(error.localizedDescription, privacy: .public)")
+      return nil
+    }
+  }
+
+  /// Persist a new watched folder.
+  func setWatchedFolder(_ url: URL) {
+    do {
+      let bookmark = try url.bookmarkData(options: Self.bookmarkCreateOptions)
+      record.watchedFolderBookmark = bookmark
+      record.watchedFolderDisplayPath = url.path
+      save()
+    } catch {
+      let urlPath = url.path
+      let errDesc = error.localizedDescription
+      logger.error(
+        "Failed to create bookmark for \(urlPath, privacy: .public): \(errDesc, privacy: .public)"
+      )
+    }
+  }
+
+  func clearWatchedFolder() {
+    record.watchedFolderBookmark = nil
+    record.watchedFolderDisplayPath = nil
+    save()
+  }
+
+  // MARK: - Persistence
+
+  private func load() {
+    guard fileManager.fileExists(atPath: url.path) else { return }
+    do {
+      let data = try Data(contentsOf: url)
+      record = try JSONDecoder().decode(ImportPreferencesRecord.self, from: data)
+    } catch {
+      logger.error(
+        "Failed to load preferences: \(error.localizedDescription, privacy: .public)")
+    }
+  }
+
+  private func save() {
+    do {
+      let data = try JSONEncoder().encode(record)
+      try data.write(to: url, options: .atomic)
+    } catch {
+      logger.error(
+        "Failed to save preferences: \(error.localizedDescription, privacy: .public)")
+    }
+  }
+
+  // MARK: - Bookmark options
+
+  private static var bookmarkCreateOptions: URL.BookmarkCreationOptions {
+    #if os(macOS)
+      return [.withSecurityScope]
+    #else
+      return []
+    #endif
+  }
+
+  private static var bookmarkOptions: URL.BookmarkResolutionOptions {
+    #if os(macOS)
+      return [.withSecurityScope]
+    #else
+      return []
+    #endif
+  }
+}

--- a/Features/Import/ImportStore.swift
+++ b/Features/Import/ImportStore.swift
@@ -83,6 +83,11 @@ final class ImportStore {
   /// `CSVImportSetupStore`. Mutations still flow through the `ImportStore`
   /// public API; external callers should only read.
   let staging: ImportStagingStore
+  /// Optional resolver for the folder-watch "delete after import" default.
+  /// `ProfileSession` wires this to `ImportPreferences.deleteAfterImportFolderDefault`
+  /// so `.folderWatch` ingests honour the setting even when the matched
+  /// profile's own `deleteAfterImport` is false.
+  var folderWatchDeleteAfterImport: (@MainActor () -> Bool)?
   private let logger = Logger(subsystem: "com.moolah.app", category: "ImportStore")
 
   init(
@@ -170,13 +175,35 @@ final class ImportStore {
   @discardableResult
   func finishSetup(pendingId: UUID, profile: CSVImportProfile) async -> ImportSessionResult {
     do {
+      let pendingRecord = try await staging.pendingFiles().first {
+        $0.id == pendingId
+      }
+      let originalFilename = pendingRecord?.originalFilename ?? "setup-\(pendingId.uuidString)"
+      // Resolve the source bookmark (if any) so delete-after-import still
+      // works on the file the user originally picked.
+      let bookmark = pendingRecord?.sourceBookmark
+      let sourceURL: URL? = {
+        guard let bookmark else { return nil }
+        var isStale = false
+        #if os(macOS)
+          let options: URL.BookmarkResolutionOptions = [.withSecurityScope]
+        #else
+          let options: URL.BookmarkResolutionOptions = []
+        #endif
+        return try? URL(
+          resolvingBookmarkData: bookmark,
+          options: options,
+          relativeTo: nil,
+          bookmarkDataIsStale: &isStale)
+      }()
       let bytes = try await staging.data(for: pendingId)
       _ = try await backend.csvImportProfiles.create(profile)
       try await staging.dismiss(pendingId: pendingId)
       await reloadStagingLists()
       return await ingest(
         data: bytes,
-        source: .paste(text: "", label: "setup-\(pendingId.uuidString)"))
+        source: .reingestFromSetup(
+          filename: originalFilename, sourceURL: sourceURL))
     } catch {
       logger.error("finishSetup failed: \(error.localizedDescription)")
       return .failed(message: error.localizedDescription)
@@ -215,14 +242,27 @@ final class ImportStore {
       signpostID: tokenizeSignpost)
     guard let headers = rows.first else { throw IngestError.empty }
 
-    // 2. Select parser + parse.
+    // 2. Select parser. We do profile lookup first (when possible) so a
+    // saved `dateFormatRawValue` override can be threaded into the parser.
+    let parser = registry.select(for: headers)
+    let profileForOverride = try? await preExistingProfile(
+      parserIdentifier: parser.identifier, headers: headers,
+      forcedAccountId: source.forcedAccountId)
+    let dateFormatOverride = profileForOverride?.dateFormatRawValue
+      .flatMap(GenericBankCSVParser.DateFormat.fromRawValue)
+
+    // 3. Parse.
     let parseSignpost = OSSignpostID(log: Signposts.importPipeline)
     os_signpost(
       .begin, log: Signposts.importPipeline, name: "parse", signpostID: parseSignpost)
-    let parser = registry.select(for: headers)
     let records: [ParsedRecord]
     do {
-      records = try parser.parse(rows: rows)
+      if let genericParser = parser as? GenericBankCSVParser {
+        records = try genericParser.parse(
+          rows: rows, overrideDateFormat: dateFormatOverride)
+      } else {
+        records = try parser.parse(rows: rows)
+      }
     } catch let error as CSVParserError {
       os_signpost(
         .end, log: Signposts.importPipeline, name: "parse", signpostID: parseSignpost)
@@ -273,8 +313,19 @@ final class ImportStore {
     os_signpost(
       .begin, log: Signposts.importPipeline, name: "rules", signpostID: rulesSignpost)
     let rules = try await backend.importRules.fetchAll()
-    let accountInstrument = try await resolveInstrument(
-      for: resolvedProfile.accountId)
+    // Fetch every account once and build a { id → instrument } map so
+    // `buildTransaction` can stamp each leg with its own account's
+    // instrument — in particular the destination leg of a `.markAsTransfer`
+    // rule, which may target an account in a different instrument than the
+    // source (Rule 11a — never write a leg with the wrong instrument).
+    let allAccounts = try await backend.accounts.fetchAll()
+    let accountInstruments: [UUID: Instrument] = Dictionary(
+      uniqueKeysWithValues: allAccounts.map { ($0.id, $0.instrument) })
+    guard let routedInstrument = accountInstruments[resolvedProfile.accountId]
+    else {
+      throw IngestError.other(
+        "Account \(resolvedProfile.accountId) not found; cannot resolve its instrument.")
+    }
     var persisted: [Transaction] = []
     for candidate in dedup.kept {
       let evaluation = ImportRulesEngine.evaluate(
@@ -283,7 +334,8 @@ final class ImportStore {
       let transaction = buildTransaction(
         from: evaluation,
         routedAccountId: resolvedProfile.accountId,
-        accountInstrument: accountInstrument,
+        accountInstrument: routedInstrument,
+        accountInstruments: accountInstruments,
         sessionId: sessionId,
         source: source,
         parserIdentifier: parser.identifier)
@@ -297,13 +349,29 @@ final class ImportStore {
     os_signpost(
       .end, log: Signposts.importPipeline, name: "rules", signpostID: rulesSignpost)
 
-    // 6. Update profile lastUsedAt (best-effort).
+    // 6. Update profile lastUsedAt (best-effort — log on failure rather than
+    // silently swallow so a backend hiccup isn't invisible).
     var updatedProfile = resolvedProfile
     updatedProfile.lastUsedAt = Date()
-    _ = try? await backend.csvImportProfiles.update(updatedProfile)
+    do {
+      _ = try await backend.csvImportProfiles.update(updatedProfile)
+    } catch {
+      logger.warning(
+        "Profile lastUsedAt update failed (non-critical): \(error.localizedDescription, privacy: .public)"
+      )
+    }
 
-    // 7. Optional delete source.
-    if resolvedProfile.deleteAfterImport, let url = source.sourceURL {
+    // 7. Optional delete source. Honour either the profile-level flag or
+    // (for folder-watched files) the folder-level default.
+    let folderDefaultDelete: Bool = {
+      if case .folderWatch = source {
+        return folderWatchDeleteAfterImport?() ?? false
+      }
+      return false
+    }()
+    if resolvedProfile.deleteAfterImport || folderDefaultDelete,
+      let url = source.sourceURL
+    {
       await Self.deleteSourceInBackground(at: url)
     }
 
@@ -318,6 +386,31 @@ final class ImportStore {
   private enum ProfileResolution {
     case routed(CSVImportProfile)
     case needsSetup(pendingId: UUID)
+  }
+
+  /// Cheap lookup used to pre-fetch a profile before parsing, so parser
+  /// overrides like `dateFormatRawValue` can be threaded into the parse
+  /// step. Returns nil when zero / multiple profiles match — the pipeline
+  /// then falls back to auto-detect.
+  private func preExistingProfile(
+    parserIdentifier: String,
+    headers: [String],
+    forcedAccountId: UUID?
+  ) async throws -> CSVImportProfile? {
+    let profiles = try await backend.csvImportProfiles.fetchAll()
+    let normalisedHeaders = headers.map { CSVImportProfile.normalise($0) }
+    if let forcedAccountId {
+      return profiles.first(where: {
+        $0.accountId == forcedAccountId
+          && $0.parserIdentifier == parserIdentifier
+          && $0.headerSignature == normalisedHeaders
+      })
+    }
+    let matching = profiles.filter {
+      $0.parserIdentifier == parserIdentifier
+        && $0.headerSignature == normalisedHeaders
+    }
+    return matching.count == 1 ? matching[0] : nil
   }
 
   private func resolveProfile(
@@ -385,6 +478,7 @@ final class ImportStore {
     from evaluation: RuleEvaluation,
     routedAccountId: UUID,
     accountInstrument: Instrument,
+    accountInstruments: [UUID: Instrument],
     sessionId: UUID,
     source: ImportSource,
     parserIdentifier: String
@@ -416,6 +510,11 @@ final class ImportStore {
     if let toId = evaluation.transferTargetAccountId,
       let cash = legs.first
     {
+      // Each side of a transfer carries ITS OWN account's instrument
+      // (Rule 11a). Fall back to the source leg's instrument if the
+      // destination account isn't in the lookup — that's a same-instrument
+      // transfer, which is the safe default when the map is incomplete.
+      let destinationInstrument = accountInstruments[toId] ?? cash.instrument
       legs = [
         TransactionLeg(
           accountId: routedAccountId,
@@ -425,7 +524,7 @@ final class ImportStore {
           categoryId: nil, earmarkId: nil),
         TransactionLeg(
           accountId: toId,
-          instrument: cash.instrument,
+          instrument: destinationInstrument,
           quantity: abs(cash.quantity),
           type: .transfer,
           categoryId: nil, earmarkId: nil),
@@ -447,20 +546,6 @@ final class ImportStore {
       notes: evaluation.appendedNotes,
       legs: legs,
       importOrigin: origin)
-  }
-
-  private func resolveInstrument(for accountId: UUID) async throws -> Instrument {
-    let accounts = try await backend.accounts.fetchAll()
-    guard let account = accounts.first(where: { $0.id == accountId }) else {
-      // At this point in the pipeline the account must exist — profile
-      // routing already validated it. A miss here means the account was
-      // deleted between fetches. Throw rather than fall back to AUD (which
-      // would silently persist rows with the wrong instrument on non-AUD
-      // accounts — Rule 11 violation).
-      throw IngestError.other(
-        "Account \(accountId) not found; cannot resolve its instrument.")
-    }
-    return account.instrument
   }
 
   // MARK: - Staging helpers
@@ -508,22 +593,22 @@ final class ImportStore {
     return id
   }
 
-  /// File delete runs on a detached background task so the main actor isn't
-  /// blocked waiting on a (potentially slow) filesystem call — network-share
-  /// volumes, security-scoped resource locks, and iCloud Drive materialisation
-  /// can all push `removeItem` into the hundreds-of-ms range.
+  /// File delete runs off the main actor so the UI isn't blocked on a slow
+  /// filesystem call — network-share volumes, security-scoped resource
+  /// locks, and iCloud Drive materialisation can all push `removeItem` into
+  /// the hundreds-of-ms range. As a `nonisolated` async function called via
+  /// `await` from the main actor, Swift's concurrency runtime schedules
+  /// the body on a cooperative pool thread automatically — no
+  /// `Task.detached` needed.
   nonisolated private static func deleteSourceInBackground(at url: URL) async {
-    let task = Task.detached(priority: .utility) {
-      do {
-        try FileManager.default.removeItem(at: url)
-      } catch {
-        let path = url.path
-        let description = error.localizedDescription
-        importStoreBackgroundLogger.warning(
-          "Could not delete source file at \(path, privacy: .public): \(description, privacy: .public)"
-        )
-      }
+    do {
+      try FileManager.default.removeItem(at: url)
+    } catch {
+      let path = url.path
+      let description = error.localizedDescription
+      importStoreBackgroundLogger.warning(
+        "Could not delete source file at \(path, privacy: .public): \(description, privacy: .public)"
+      )
     }
-    await task.value
   }
 }

--- a/Features/Import/ImportStore.swift
+++ b/Features/Import/ImportStore.swift
@@ -353,11 +353,13 @@ final class ImportStore {
   ) -> Transaction {
     var legs = evaluation.transaction.legs.map { leg -> TransactionLeg in
       let resolvedAccount = leg.accountId ?? routedAccountId
-      // Rewrite the placeholder AUD on cash-side legs to match the account's
-      // actual instrument. Position legs (non-AUD) are left alone.
+      // Rewrite placeholder-instrument legs (cash legs from parsers) to the
+      // routed account's actual instrument. Explicit instrument legs (e.g.
+      // SelfWealth's ASX:BHP position leg) are left alone. The flag is set
+      // by the parser at the leg's point-of-origin, replacing the earlier
+      // fragile "is it AUD?" heuristic.
       let resolvedInstrument =
-        (leg.instrument == .AUD && accountInstrument != .AUD)
-        ? accountInstrument : leg.instrument
+        leg.isInstrumentPlaceholder ? accountInstrument : leg.instrument
       return TransactionLeg(
         accountId: resolvedAccount,
         instrument: resolvedInstrument,

--- a/Features/Import/ImportStore.swift
+++ b/Features/Import/ImportStore.swift
@@ -78,7 +78,10 @@ final class ImportStore {
 
   private let backend: any BackendProvider
   private let registry: CSVParserRegistry
-  private let staging: ImportStagingStore
+  /// Exposed so the Needs Setup sheet can re-read staged bytes via its own
+  /// `CSVImportSetupStore`. Mutations still flow through the `ImportStore`
+  /// public API; external callers should only read.
+  let staging: ImportStagingStore
   private let logger = Logger(subsystem: "com.moolah.app", category: "ImportStore")
 
   init(

--- a/Features/Import/ImportStore.swift
+++ b/Features/Import/ImportStore.swift
@@ -1,6 +1,7 @@
 import Foundation
 import OSLog
 import Observation
+import os
 
 private let importStoreBackgroundLogger = Logger(
   subsystem: "com.moolah.app", category: "ImportStore.Background")
@@ -187,24 +188,48 @@ final class ImportStore {
   private func runPipeline(
     data: Data, source: ImportSource, sessionId: UUID
   ) async throws -> ImportSessionResult {
+    let pipelineSignpost = OSSignpostID(log: Signposts.importPipeline)
+    os_signpost(
+      .begin, log: Signposts.importPipeline, name: "ingest", signpostID: pipelineSignpost)
+    defer {
+      os_signpost(
+        .end, log: Signposts.importPipeline, name: "ingest", signpostID: pipelineSignpost)
+    }
 
     // 1. Decode + tokenize.
+    let tokenizeSignpost = OSSignpostID(log: Signposts.importPipeline)
+    os_signpost(
+      .begin, log: Signposts.importPipeline, name: "tokenize",
+      signpostID: tokenizeSignpost)
     let rows: [[String]]
     do {
       rows = try CSVTokenizer.parse(data)
     } catch {
+      os_signpost(
+        .end, log: Signposts.importPipeline, name: "tokenize",
+        signpostID: tokenizeSignpost)
       throw IngestError.decode(error.localizedDescription)
     }
+    os_signpost(
+      .end, log: Signposts.importPipeline, name: "tokenize",
+      signpostID: tokenizeSignpost)
     guard let headers = rows.first else { throw IngestError.empty }
 
     // 2. Select parser + parse.
+    let parseSignpost = OSSignpostID(log: Signposts.importPipeline)
+    os_signpost(
+      .begin, log: Signposts.importPipeline, name: "parse", signpostID: parseSignpost)
     let parser = registry.select(for: headers)
     let records: [ParsedRecord]
     do {
       records = try parser.parse(rows: rows)
     } catch let error as CSVParserError {
+      os_signpost(
+        .end, log: Signposts.importPipeline, name: "parse", signpostID: parseSignpost)
       throw IngestError.parse(error)
     }
+    os_signpost(
+      .end, log: Signposts.importPipeline, name: "parse", signpostID: parseSignpost)
     let candidates = records.compactMap { record -> ParsedTransaction? in
       if case .transaction(let tx) = record { return tx } else { return nil }
     }
@@ -230,6 +255,9 @@ final class ImportStore {
     }
 
     // 4. Dedup.
+    let dedupSignpost = OSSignpostID(log: Signposts.importPipeline)
+    os_signpost(
+      .begin, log: Signposts.importPipeline, name: "dedup", signpostID: dedupSignpost)
     let existingPage = try await backend.transactions.fetch(
       filter: TransactionFilter(accountId: resolvedProfile.accountId),
       page: 0, pageSize: 1000)
@@ -237,8 +265,13 @@ final class ImportStore {
       candidates,
       against: existingPage.transactions,
       accountId: resolvedProfile.accountId)
+    os_signpost(
+      .end, log: Signposts.importPipeline, name: "dedup", signpostID: dedupSignpost)
 
     // 5. Rules engine + persist.
+    let rulesSignpost = OSSignpostID(log: Signposts.importPipeline)
+    os_signpost(
+      .begin, log: Signposts.importPipeline, name: "rules", signpostID: rulesSignpost)
     let rules = try await backend.importRules.fetchAll()
     let accountInstrument = try await resolveInstrument(
       for: resolvedProfile.accountId)
@@ -261,6 +294,8 @@ final class ImportStore {
           "Create failed for candidate at \(candidate.date): \(error.localizedDescription)")
       }
     }
+    os_signpost(
+      .end, log: Signposts.importPipeline, name: "rules", signpostID: rulesSignpost)
 
     // 6. Update profile lastUsedAt (best-effort).
     var updatedProfile = resolvedProfile

--- a/Features/Import/Views/CSVImportSetupView.swift
+++ b/Features/Import/Views/CSVImportSetupView.swift
@@ -1,0 +1,204 @@
+import SwiftUI
+
+/// One-screen Needs Setup form per the design doc. Presented as a sheet from
+/// `NeedsSetupAndFailedPanel`. Lets the user pick the target account, review
+/// the detected parser / mapping, preview the first five rows, set a
+/// filename pattern, and toggle delete-after-import.
+struct CSVImportSetupView: View {
+  let store: CSVImportSetupStore
+  @Environment(AccountStore.self) private var accountStore
+  @Environment(\.dismiss) private var dismiss
+
+  @State private var dateFormatChoice: DateFormatChoice = .auto
+
+  enum DateFormatChoice: String, Hashable, CaseIterable, Identifiable {
+    case auto
+    case ddMMYYYY
+    case mmDDYYYY
+    case iso
+    var id: String { rawValue }
+    var label: String {
+      switch self {
+      case .auto: return "Auto-detect"
+      case .ddMMYYYY: return "DD/MM/YYYY"
+      case .mmDDYYYY: return "MM/DD/YYYY"
+      case .iso: return "YYYY-MM-DD"
+      }
+    }
+  }
+
+  var body: some View {
+    NavigationStack {
+      Form {
+        Section(header: Text("File")) {
+          LabeledContent("Filename", value: store.pending.originalFilename)
+          LabeledContent("Parser", value: store.detectedParserIdentifier)
+          LabeledContent("Rows") {
+            Text("\(store.rowCount)").monospacedDigit()
+          }
+        }
+
+        Section(header: Text("Target account")) {
+          Picker(
+            "Account",
+            selection: Binding(
+              get: { store.targetAccountId },
+              set: { store.targetAccountId = $0 }
+            )
+          ) {
+            Text("Select…").tag(UUID?.none)
+            ForEach(availableAccounts, id: \.id) { account in
+              Text(account.name).tag(UUID?.some(account.id))
+            }
+          }
+        }
+
+        if store.isGenericParser, let mapping = store.detectedMapping {
+          Section(header: Text("Column mapping")) {
+            columnMappingRows(mapping: mapping)
+            Picker("Date format", selection: $dateFormatChoice) {
+              ForEach(DateFormatChoice.allCases) { choice in
+                Text(choice.label).tag(choice)
+              }
+            }
+            if mapping.dateFormatAmbiguous {
+              Label(
+                "Dates are ambiguous — pick the format to match your file.",
+                systemImage: "exclamationmark.triangle"
+              )
+              .foregroundStyle(.orange)
+              .font(.caption)
+            }
+          }
+        }
+
+        if !store.preview.isEmpty {
+          Section(header: Text("Preview (first 5 rows)")) {
+            ForEach(Array(store.preview.enumerated()), id: \.offset) { _, tx in
+              PreviewRow(transaction: tx)
+            }
+          }
+        }
+
+        Section(header: Text("Options")) {
+          TextField(
+            "Filename pattern",
+            text: Binding(
+              get: { store.filenamePattern },
+              set: { store.filenamePattern = $0 })
+          )
+          .textFieldStyle(.roundedBorder)
+          Toggle(
+            "Delete CSV after import",
+            isOn: Binding(
+              get: { store.deleteAfterImport },
+              set: { store.deleteAfterImport = $0 }))
+        }
+
+        if let error = store.saveError {
+          Label(error, systemImage: "exclamationmark.circle")
+            .foregroundStyle(.red)
+        }
+      }
+      .formStyle(.grouped)
+      .navigationTitle("Set up CSV import")
+      .toolbar {
+        ToolbarItem(placement: .cancellationAction) {
+          Button("Cancel") {
+            store.cancel()
+            dismiss()
+          }
+        }
+        ToolbarItem(placement: .destructiveAction) {
+          Button("Delete", role: .destructive) {
+            Task {
+              await store.deletePending()
+              dismiss()
+            }
+          }
+        }
+        ToolbarItem(placement: .confirmationAction) {
+          Button("Save & Import") {
+            Task {
+              _ = await store.saveAndImport()
+              if store.saveError == nil {
+                dismiss()
+              }
+            }
+          }
+          .disabled(store.targetAccountId == nil || store.isSaving)
+        }
+      }
+      .task {
+        await store.regeneratePreview()
+      }
+      .onChange(of: dateFormatChoice) { _, newValue in
+        store.dateFormatOverride = newValue.resolved
+        Task { await store.regeneratePreview() }
+      }
+    }
+  }
+
+  private var availableAccounts: [Account] {
+    accountStore.accounts.ordered.filter { !$0.isHidden }
+  }
+
+  @ViewBuilder
+  private func columnMappingRows(
+    mapping: GenericBankCSVParser.ColumnMapping
+  ) -> some View {
+    let entries: [(label: String, index: Int?)] = [
+      ("Date", mapping.date),
+      ("Description", mapping.description),
+      ("Amount", mapping.amount),
+      ("Debit", mapping.debit),
+      ("Credit", mapping.credit),
+      ("Balance", mapping.balance),
+      ("Reference", mapping.reference),
+    ]
+    ForEach(entries, id: \.label) { entry in
+      HStack {
+        Text(entry.label)
+        Spacer()
+        if let index = entry.index, index < store.detectedHeaders.count {
+          Text(store.detectedHeaders[index])
+            .foregroundStyle(.secondary)
+            .monospacedDigit()
+        } else {
+          Text("—").foregroundStyle(.secondary)
+        }
+      }
+    }
+  }
+}
+
+extension CSVImportSetupView.DateFormatChoice {
+  /// Resolve to a concrete `GenericBankCSVParser.DateFormat` when the user
+  /// overrides detection. `nil` means "use the detector's pick".
+  var resolved: GenericBankCSVParser.DateFormat? {
+    switch self {
+    case .auto: return nil
+    case .ddMMYYYY: return .ddMMyyyy(separator: "/")
+    case .mmDDYYYY: return .mmDDyyyy(separator: "/")
+    case .iso: return .iso
+    }
+  }
+}
+
+/// Renders one preview row using the parsed payee/amount/date — the rules
+/// engine hasn't run yet so the payee is the raw description.
+private struct PreviewRow: View {
+  let transaction: ParsedTransaction
+  var body: some View {
+    HStack(spacing: 12) {
+      VStack(alignment: .leading, spacing: 2) {
+        Text(transaction.rawDescription).lineLimit(1)
+        Text(transaction.date, format: .dateTime.day().month().year())
+          .font(.caption).foregroundStyle(.secondary).monospacedDigit()
+      }
+      Spacer()
+      Text(transaction.rawAmount, format: .number.precision(.fractionLength(2)))
+        .monospacedDigit()
+    }
+  }
+}

--- a/Features/Import/Views/CSVImportSetupView.swift
+++ b/Features/Import/Views/CSVImportSetupView.swift
@@ -99,6 +99,18 @@ struct CSVImportSetupView: View {
           Label(error, systemImage: "exclamationmark.circle")
             .foregroundStyle(.red)
         }
+
+        // Destructive action lives in the form body, not the toolbar, so
+        // it doesn't sit alongside Cancel / Save & Import where users
+        // might tap it by accident. See Apple HIG "Destructive actions".
+        Section {
+          Button("Delete staged file", role: .destructive) {
+            Task {
+              await store.deletePending()
+              dismiss()
+            }
+          }
+        }
       }
       .formStyle(.grouped)
       .navigationTitle("Set up CSV import")
@@ -107,14 +119,6 @@ struct CSVImportSetupView: View {
           Button("Cancel") {
             store.cancel()
             dismiss()
-          }
-        }
-        ToolbarItem(placement: .destructiveAction) {
-          Button("Delete", role: .destructive) {
-            Task {
-              await store.deletePending()
-              dismiss()
-            }
           }
         }
         ToolbarItem(placement: .confirmationAction) {
@@ -133,9 +137,11 @@ struct CSVImportSetupView: View {
         await store.regeneratePreview()
       }
       .onChange(of: dateFormatChoice) { _, newValue in
-        store.dateFormatOverride = newValue.resolved
-        Task { await store.regeneratePreview() }
+        Task { await store.applyDateFormatOverride(newValue.resolved) }
       }
+      #if os(macOS)
+        .frame(minWidth: 520, minHeight: 480)
+      #endif
     }
   }
 
@@ -147,28 +153,49 @@ struct CSVImportSetupView: View {
   private func columnMappingRows(
     mapping: GenericBankCSVParser.ColumnMapping
   ) -> some View {
-    let entries: [(label: String, index: Int?)] = [
-      ("Date", mapping.date),
-      ("Description", mapping.description),
-      ("Amount", mapping.amount),
-      ("Debit", mapping.debit),
-      ("Credit", mapping.credit),
-      ("Balance", mapping.balance),
-      ("Reference", mapping.reference),
-    ]
-    ForEach(entries, id: \.label) { entry in
+    // Editable: one row per CSV column, dropdown picks the role. Default
+    // reflects the detector's mapping; user overrides flow through
+    // `store.applyColumnRole(_:forColumn:)` which regenerates the preview.
+    ForEach(Array(store.detectedHeaders.enumerated()), id: \.offset) { index, header in
       HStack {
-        Text(entry.label)
+        Text(header).lineLimit(1)
         Spacer()
-        if let index = entry.index, index < store.detectedHeaders.count {
-          Text(store.detectedHeaders[index])
-            .foregroundStyle(.secondary)
-            .monospacedDigit()
-        } else {
-          Text("—").foregroundStyle(.secondary)
+        Picker(
+          "Role",
+          selection: Binding(
+            get: { roleForColumn(index: index, mapping: mapping) },
+            set: { newRole in
+              let effectiveRole: CSVImportSetupStore.ColumnRole? =
+                (newRole == .ignore) ? nil : newRole
+              Task { await store.applyColumnRole(effectiveRole, forColumn: index) }
+            })
+        ) {
+          ForEach(CSVImportSetupStore.ColumnRole.allCases) { role in
+            Text(role.label).tag(role)
+          }
         }
+        .labelsHidden()
       }
     }
+  }
+
+  /// Returns the user's chosen role for this column index if set; otherwise
+  /// derives the role from the detected mapping. `.ignore` is the displayed
+  /// role for any column whose index isn't used by the mapping.
+  private func roleForColumn(
+    index: Int, mapping: GenericBankCSVParser.ColumnMapping
+  ) -> CSVImportSetupStore.ColumnRole {
+    if index < store.columnRoles.count, let override = store.columnRoles[index] {
+      return override
+    }
+    if mapping.date == index { return .date }
+    if mapping.description == index { return .description }
+    if mapping.amount == index { return .amount }
+    if mapping.debit == index { return .debit }
+    if mapping.credit == index { return .credit }
+    if mapping.balance == index { return .balance }
+    if mapping.reference == index { return .reference }
+    return .ignore
   }
 }
 

--- a/Features/Import/Views/CreateRuleFromTransactionSheet.swift
+++ b/Features/Import/Views/CreateRuleFromTransactionSheet.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+
+/// "Create a rule from this…" affordance. Pre-fills a new `ImportRule` with
+/// `descriptionContains([distinguishingTokens])` extracted from the source
+/// transaction's raw description + the user's currently-assigned payee /
+/// category actions. Hands off to `RuleEditorView` for final review.
+struct CreateRuleFromTransactionSheet: View {
+  let transaction: Transaction
+  let corpus: [String]
+  @Environment(ImportRuleStore.self) private var ruleStore
+
+  var body: some View {
+    RuleEditorView(
+      initialRule: prefilledRule(),
+      onSave: { rule in
+        Task { await ruleStore.create(rule) }
+      })
+  }
+
+  private func prefilledRule() -> ImportRule {
+    let rawDescription = transaction.importOrigin?.rawDescription ?? ""
+    let tokens = DistinguishingTokens.extract(
+      from: rawDescription, corpus: corpus, limit: 3)
+    var actions: [RuleAction] = []
+    if let payee = transaction.payee, !payee.isEmpty {
+      actions.append(.setPayee(payee))
+    }
+    if let firstCategoryId = transaction.legs.compactMap(\.categoryId).first {
+      actions.append(.setCategory(firstCategoryId))
+    }
+    if actions.isEmpty {
+      // Default: just describe the match; user fills in the action in the editor.
+      actions = [.appendNote("")]
+    }
+    return ImportRule(
+      name: "Rule from \(rawDescription.prefix(20))",
+      position: ruleStore.rules.count,
+      conditions: [.descriptionContains(tokens.isEmpty ? [rawDescription] : tokens)],
+      actions: actions)
+  }
+}

--- a/Features/Import/Views/ImportRulesSettingsView.swift
+++ b/Features/Import/Views/ImportRulesSettingsView.swift
@@ -1,0 +1,144 @@
+import SwiftUI
+
+/// Settings → Import Rules list. Mail.app-shaped: ordered list, drag to
+/// reorder, enable toggle per row, Add button to create a new rule.
+struct ImportRulesSettingsView: View {
+  @Environment(ImportRuleStore.self) private var ruleStore
+  @Environment(CategoryStore.self) private var categoryStore
+  @State private var editingRule: ImportRule?
+  @State private var showingAddSheet = false
+
+  var body: some View {
+    List {
+      if ruleStore.rules.isEmpty {
+        ContentUnavailableView(
+          "No rules yet",
+          systemImage: "list.bullet.rectangle",
+          description: Text(
+            "Rules run at CSV import time to set the payee, category, "
+              + "notes, or to mark a row as a transfer."))
+      } else {
+        ForEach(ruleStore.rules) { rule in
+          RuleRow(rule: rule) { editingRule = rule }
+        }
+        .onMove { source, destination in
+          var ids = ruleStore.rules.map(\.id)
+          ids.move(fromOffsets: source, toOffset: destination)
+          Task { await ruleStore.reorder(ids) }
+        }
+        .onDelete { offsets in
+          let ids = offsets.map { ruleStore.rules[$0].id }
+          for id in ids {
+            Task { await ruleStore.delete(id: id) }
+          }
+        }
+      }
+    }
+    .navigationTitle("Import Rules")
+    .toolbar {
+      ToolbarItem(placement: .primaryAction) {
+        Button {
+          showingAddSheet = true
+        } label: {
+          Label("Add Rule", systemImage: "plus")
+        }
+        .accessibilityLabel("Add Rule")
+      }
+      #if !os(macOS)
+        ToolbarItem(placement: .navigationBarTrailing) {
+          EditButton()
+        }
+      #endif
+    }
+    .task { await ruleStore.load() }
+    .sheet(isPresented: $showingAddSheet) {
+      RuleEditorView(
+        initialRule: ImportRule(
+          name: "New Rule",
+          position: ruleStore.rules.count,
+          conditions: [],
+          actions: []),
+        onSave: { newRule in
+          Task { await ruleStore.create(newRule) }
+        })
+    }
+    .sheet(item: $editingRule) { rule in
+      RuleEditorView(
+        initialRule: rule,
+        onSave: { updated in
+          Task { await ruleStore.update(updated) }
+        })
+    }
+  }
+}
+
+private struct RuleRow: View {
+  let rule: ImportRule
+  let onEdit: () -> Void
+  @Environment(ImportRuleStore.self) private var ruleStore
+
+  var body: some View {
+    HStack {
+      Toggle(
+        "",
+        isOn: Binding(
+          get: { rule.enabled },
+          set: { newValue in
+            var copy = rule
+            copy.enabled = newValue
+            Task { await ruleStore.update(copy) }
+          })
+      )
+      .labelsHidden()
+      .accessibilityLabel(rule.enabled ? "Disable \(rule.name)" : "Enable \(rule.name)")
+
+      VStack(alignment: .leading, spacing: 2) {
+        Text(rule.name)
+        Text(summarise(rule))
+          .font(.caption)
+          .foregroundStyle(.secondary)
+          .lineLimit(1)
+      }
+      .onTapGesture { onEdit() }
+      Spacer()
+      Button("Edit") { onEdit() }
+        .buttonStyle(.borderless)
+    }
+    .contentShape(Rectangle())
+  }
+
+  private func summarise(_ rule: ImportRule) -> String {
+    let conditionSummary =
+      rule.conditions.isEmpty
+      ? "matches every row"
+      : rule.conditions.map(Self.describe).joined(separator: " · ")
+    let actionSummary =
+      rule.actions.isEmpty
+      ? "(no actions)"
+      : rule.actions.map(Self.describe).joined(separator: " · ")
+    return "\(conditionSummary) → \(actionSummary)"
+  }
+
+  private static func describe(_ condition: RuleCondition) -> String {
+    switch condition {
+    case .descriptionContains(let tokens): return "contains \(tokens.joined(separator: ","))"
+    case .descriptionDoesNotContain(let tokens):
+      return "excludes \(tokens.joined(separator: ","))"
+    case .descriptionBeginsWith(let prefix): return "starts \(prefix)"
+    case .amountIsPositive: return "income"
+    case .amountIsNegative: return "expense"
+    case .amountBetween(let min, let max): return "between \(min) and \(max)"
+    case .sourceAccountIs: return "on one account"
+    }
+  }
+
+  private static func describe(_ action: RuleAction) -> String {
+    switch action {
+    case .setPayee(let p): return "payee=\(p)"
+    case .setCategory: return "set category"
+    case .appendNote(let n): return "note=\(n)"
+    case .markAsTransfer: return "mark as transfer"
+    case .skip: return "skip"
+    }
+  }
+}

--- a/Features/Import/Views/ImportRulesSettingsView.swift
+++ b/Features/Import/Views/ImportRulesSettingsView.swift
@@ -10,6 +10,22 @@ struct ImportRulesSettingsView: View {
 
   var body: some View {
     List {
+      ForEach(ruleStore.rules) { rule in
+        RuleRow(rule: rule) { editingRule = rule }
+      }
+      .onMove { source, destination in
+        var ids = ruleStore.rules.map(\.id)
+        ids.move(fromOffsets: source, toOffset: destination)
+        Task { await ruleStore.reorder(ids) }
+      }
+      .onDelete { offsets in
+        let ids = offsets.map { ruleStore.rules[$0].id }
+        for id in ids {
+          Task { await ruleStore.delete(id: id) }
+        }
+      }
+    }
+    .overlay {
       if ruleStore.rules.isEmpty {
         ContentUnavailableView(
           "No rules yet",
@@ -17,32 +33,18 @@ struct ImportRulesSettingsView: View {
           description: Text(
             "Rules run at CSV import time to set the payee, category, "
               + "notes, or to mark a row as a transfer."))
-      } else {
-        ForEach(ruleStore.rules) { rule in
-          RuleRow(rule: rule) { editingRule = rule }
-        }
-        .onMove { source, destination in
-          var ids = ruleStore.rules.map(\.id)
-          ids.move(fromOffsets: source, toOffset: destination)
-          Task { await ruleStore.reorder(ids) }
-        }
-        .onDelete { offsets in
-          let ids = offsets.map { ruleStore.rules[$0].id }
-          for id in ids {
-            Task { await ruleStore.delete(id: id) }
-          }
-        }
       }
     }
     .navigationTitle("Import Rules")
     .toolbar {
       ToolbarItem(placement: .primaryAction) {
+        // `Label("Add Rule", …)` already carries "Add Rule" as the
+        // VoiceOver label; no explicit `.accessibilityLabel` needed.
         Button {
           showingAddSheet = true
         } label: {
           Label("Add Rule", systemImage: "plus")
         }
-        .accessibilityLabel("Add Rule")
       }
       #if !os(macOS)
         ToolbarItem(placement: .navigationBarTrailing) {
@@ -99,12 +101,18 @@ private struct RuleRow: View {
           .foregroundStyle(.secondary)
           .lineLimit(1)
       }
-      .onTapGesture { onEdit() }
       Spacer()
+      // Tab-reachable keyboard path for macOS users; redundant with the
+      // whole-row tap on mouse/touch.
       Button("Edit") { onEdit() }
         .buttonStyle(.borderless)
     }
+    // Whole-row click target: a bare `.onTapGesture` on the VStack only
+    // responded to taps on the label text, which left most of the row
+    // dead. `.contentShape(Rectangle())` + row-level tap routes every
+    // click — including on the trailing `Spacer()` — to the editor.
     .contentShape(Rectangle())
+    .onTapGesture { onEdit() }
   }
 
   private func summarise(_ rule: ImportRule) -> String {

--- a/Features/Import/Views/ImportSettingsView.swift
+++ b/Features/Import/Views/ImportSettingsView.swift
@@ -1,5 +1,9 @@
+import OSLog
 import SwiftUI
 import UniformTypeIdentifiers
+
+private let importSettingsLogger = Logger(
+  subsystem: "com.moolah.app", category: "ImportSettingsView")
 
 /// Settings → Import: pick a folder to watch, toggle delete-after-import,
 /// and browse import profiles. Device-local settings — not synced.
@@ -40,8 +44,8 @@ struct ImportSettingsView: View {
       Section("Import profiles") {
         if profiles.isEmpty {
           Text(
-            "No profiles yet. Profiles are created automatically when you "
-              + "import a CSV into an account."
+            "No profiles yet. Moolah saves one the first time you "
+              + "complete a CSV import into an account."
           )
           .font(.caption)
           .foregroundStyle(.secondary)
@@ -55,6 +59,7 @@ struct ImportSettingsView: View {
               if let lastUsedAt = profile.lastUsedAt {
                 Text("Last used \(lastUsedAt, style: .relative) ago")
                   .font(.caption2).foregroundStyle(.secondary)
+                  .monospacedDigit()
               }
             }
             .swipeActions(edge: .trailing) {
@@ -86,7 +91,9 @@ struct ImportSettingsView: View {
     do {
       profiles = try await session.backend.csvImportProfiles.fetchAll()
     } catch {
-      // Silent log; UI shows empty list.
+      importSettingsLogger.error(
+        "Failed to reload import profiles: \(error.localizedDescription, privacy: .public)"
+      )
     }
   }
 
@@ -99,11 +106,12 @@ struct ImportSettingsView: View {
     switch result {
     case .success(let urls):
       guard let url = urls.first else { return }
+      // Ordering: take security-scoped access, persist the bookmark
+      // (needs active scope), then release our scope. `startFolderWatch`
+      // re-resolves the bookmark and acquires its own long-lived scope.
       let didStart = url.startAccessingSecurityScopedResource()
-      defer {
-        if didStart { url.stopAccessingSecurityScopedResource() }
-      }
       session.importPreferences.setWatchedFolder(url)
+      if didStart { url.stopAccessingSecurityScopedResource() }
       Task { await session.startFolderWatch() }
     case .failure:
       break

--- a/Features/Import/Views/ImportSettingsView.swift
+++ b/Features/Import/Views/ImportSettingsView.swift
@@ -1,0 +1,112 @@
+import SwiftUI
+import UniformTypeIdentifiers
+
+/// Settings → Import: pick a folder to watch, toggle delete-after-import,
+/// and browse import profiles. Device-local settings — not synced.
+struct ImportSettingsView: View {
+  @Environment(ProfileSession.self) private var session
+  @State private var profiles: [CSVImportProfile] = []
+  @State private var showFolderPicker = false
+  @State private var isReloadingProfiles = false
+
+  var body: some View {
+    Form {
+      Section("Folder watch") {
+        if let path = session.importPreferences.watchedFolderDisplayPath {
+          LabeledContent("Watching") {
+            Text(path).foregroundStyle(.secondary).lineLimit(2)
+          }
+          Button("Change folder…") { showFolderPicker = true }
+          Button("Stop watching", role: .destructive) {
+            session.stopFolderWatch()
+          }
+        } else {
+          Button("Pick folder…") { showFolderPicker = true }
+          Text(
+            "Pick a folder (usually Downloads) and Moolah will scan it for "
+              + "new CSV files at launch, and on macOS watch it live."
+          )
+          .font(.caption)
+          .foregroundStyle(.secondary)
+        }
+
+        Toggle(
+          "Delete CSVs after import",
+          isOn: Binding(
+            get: { session.importPreferences.deleteAfterImportFolderDefault },
+            set: { session.importPreferences.deleteAfterImportFolderDefault = $0 }))
+      }
+
+      Section("Import profiles") {
+        if profiles.isEmpty {
+          Text(
+            "No profiles yet. Profiles are created automatically when you "
+              + "import a CSV into an account."
+          )
+          .font(.caption)
+          .foregroundStyle(.secondary)
+        } else {
+          ForEach(profiles) { profile in
+            VStack(alignment: .leading, spacing: 2) {
+              Text(profile.filenamePattern ?? profile.parserIdentifier)
+                .font(.subheadline)
+              Text(profile.headerSignature.joined(separator: " · "))
+                .font(.caption).foregroundStyle(.secondary).lineLimit(1)
+              if let lastUsedAt = profile.lastUsedAt {
+                Text("Last used \(lastUsedAt, style: .relative) ago")
+                  .font(.caption2).foregroundStyle(.secondary)
+              }
+            }
+            .swipeActions(edge: .trailing) {
+              Button(role: .destructive) {
+                Task { await deleteProfile(profile) }
+              } label: {
+                Label("Delete", systemImage: "trash")
+              }
+            }
+          }
+        }
+      }
+    }
+    .formStyle(.grouped)
+    .navigationTitle("CSV Import")
+    .task { await reloadProfiles() }
+    .fileImporter(
+      isPresented: $showFolderPicker,
+      allowedContentTypes: [.folder],
+      allowsMultipleSelection: false
+    ) { result in
+      handleFolderPick(result)
+    }
+  }
+
+  private func reloadProfiles() async {
+    isReloadingProfiles = true
+    defer { isReloadingProfiles = false }
+    do {
+      profiles = try await session.backend.csvImportProfiles.fetchAll()
+    } catch {
+      // Silent log; UI shows empty list.
+    }
+  }
+
+  private func deleteProfile(_ profile: CSVImportProfile) async {
+    try? await session.backend.csvImportProfiles.delete(id: profile.id)
+    await reloadProfiles()
+  }
+
+  private func handleFolderPick(_ result: Result<[URL], Error>) {
+    switch result {
+    case .success(let urls):
+      guard let url = urls.first else { return }
+      let didStart = url.startAccessingSecurityScopedResource()
+      defer {
+        if didStart { url.stopAccessingSecurityScopedResource() }
+      }
+      session.importPreferences.setWatchedFolder(url)
+      Task { await session.startFolderWatch() }
+    case .failure:
+      break
+    }
+  }
+}

--- a/Features/Import/Views/RecentlyAddedView.swift
+++ b/Features/Import/Views/RecentlyAddedView.swift
@@ -11,7 +11,7 @@ struct RecentlyAddedView: View {
 
   var body: some View {
     VStack(alignment: .leading, spacing: 0) {
-      NeedsSetupAndFailedPanel()
+      NeedsSetupAndFailedPanel(backend: backend, staging: importStore.staging)
       if let viewModel {
         if viewModel.isLoading && viewModel.sessions.isEmpty {
           ProgressView().frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -163,6 +163,8 @@ private struct RecentlyAddedRow: View {
 /// Needs Setup / Failed Files panel. Shown above the session list when either
 /// list is non-empty; fully hidden when both are empty.
 private struct NeedsSetupAndFailedPanel: View {
+  let backend: any BackendProvider
+  let staging: ImportStagingStore
   @Environment(ImportStore.self) private var importStore
 
   var body: some View {
@@ -173,7 +175,7 @@ private struct NeedsSetupAndFailedPanel: View {
         if !importStore.pendingSetup.isEmpty {
           Text("Needs Setup").font(.headline)
           ForEach(importStore.pendingSetup) { file in
-            PendingRow(file: file)
+            PendingRow(file: file, backend: backend, staging: staging)
           }
         }
         if !importStore.failedFiles.isEmpty {
@@ -193,7 +195,10 @@ private struct NeedsSetupAndFailedPanel: View {
 
 private struct PendingRow: View {
   let file: PendingSetupFile
+  let backend: any BackendProvider
+  let staging: ImportStagingStore
   @Environment(ImportStore.self) private var importStore
+  @State private var showingSetup = false
 
   var body: some View {
     HStack {
@@ -204,10 +209,18 @@ private struct PendingRow: View {
           .font(.caption).foregroundStyle(.secondary)
       }
       Spacer()
+      Button("Set up\u{2026}") { showingSetup = true }
+        .buttonStyle(.borderless)
       Button("Dismiss") {
         Task { await importStore.dismissPending(id: file.id) }
       }
       .buttonStyle(.borderless)
+    }
+    .sheet(isPresented: $showingSetup) {
+      CSVImportSetupView(
+        store: CSVImportSetupStore(
+          pending: file, backend: backend,
+          importStore: importStore, staging: staging))
     }
   }
 }

--- a/Features/Import/Views/RecentlyAddedView.swift
+++ b/Features/Import/Views/RecentlyAddedView.swift
@@ -19,9 +19,7 @@ struct RecentlyAddedView: View {
           ContentUnavailableView(
             "Nothing imported yet",
             systemImage: "tray",
-            description: Text(
-              "Drop a CSV onto the app, use the Import CSV menu item, "
-                + "or paste tabular text to get started."))
+            description: Text(emptyStatePrompt))
         } else {
           List {
             ForEach(viewModel.sessions) { session in
@@ -56,6 +54,27 @@ struct RecentlyAddedView: View {
     // .task(id: window) fires on first appearance and re-fires (auto-cancelling
     // any in-flight load) whenever `window` changes.
     .task(id: window) { await reload() }
+    // After a successful ingest (including `finishSetup` completing a
+    // Needs Setup file) `ImportStore.recentSessions` grows. Use that as
+    // the signal to re-query the backend so the new transactions appear
+    // in the session list without the user having to switch the window.
+    .onChange(of: importStore.recentSessions.count) { _, _ in
+      Task { await reload() }
+    }
+  }
+
+  /// Platform-specific empty-state copy: macOS users drag files and use
+  /// menu items; iOS users share or paste.
+  private var emptyStatePrompt: String {
+    #if os(macOS)
+      return
+        "Drop a CSV onto the app, use the Import CSV menu item, "
+        + "or paste tabular text to get started."
+    #else
+      return
+        "Use the Share sheet from Files to open a CSV, "
+        + "or paste tabular text to get started."
+    #endif
   }
 
   private func sessionHeader(_ session: RecentlyAddedViewModel.SessionGroup) -> some View {
@@ -78,6 +97,7 @@ struct RecentlyAddedView: View {
         .foregroundStyle(.secondary)
         .monospacedDigit()
     }
+    .accessibilityElement(children: .combine)
   }
 
   private func reload() async {
@@ -121,6 +141,9 @@ private struct RecentlyAddedRow: View {
       Rectangle()
         .fill(needsReview ? Color.orange : Color.clear)
         .frame(width: 3)
+        // Purely decorative — the "Needs review" badge carries the
+        // screen-reader signal.
+        .accessibilityHidden(true)
       VStack(alignment: .leading, spacing: 2) {
         Text(transaction.payee ?? transaction.importOrigin?.rawDescription ?? "")
           .lineLimit(1)
@@ -130,8 +153,9 @@ private struct RecentlyAddedRow: View {
           .monospacedDigit()
       }
       Spacer()
-      Text(amountText)
-        .monospacedDigit()
+      if let primary = displayAmount {
+        InstrumentAmountView(amount: primary, font: .body)
+      }
       if needsReview {
         Text("Needs review")
           .font(.caption2)
@@ -149,14 +173,14 @@ private struct RecentlyAddedRow: View {
     transaction.legs.allSatisfy { $0.categoryId == nil }
   }
 
-  private var amountText: String {
-    let total = transaction.legs.reduce(Decimal(0)) { $0 + $1.quantity }
-    let formatter = NumberFormatter()
-    formatter.numberStyle = .currency
-    formatter.maximumFractionDigits = 2
-    formatter.minimumFractionDigits = 2
-    formatter.currencyCode = transaction.legs.first?.instrument.id ?? "AUD"
-    return formatter.string(from: total as NSDecimalNumber) ?? "\(total)"
+  /// Pick the first leg (the source/cash leg from the importer) and build
+  /// an `InstrumentAmount` so colour coding + per-instrument formatting
+  /// come straight from `InstrumentAmountView`. Cross-instrument transfers
+  /// intentionally show only the source-side amount here; the detail view
+  /// lists both legs.
+  private var displayAmount: InstrumentAmount? {
+    guard let leg = transaction.legs.first else { return nil }
+    return InstrumentAmount(quantity: leg.quantity, instrument: leg.instrument)
   }
 }
 
@@ -198,29 +222,43 @@ private struct PendingRow: View {
   let backend: any BackendProvider
   let staging: ImportStagingStore
   @Environment(ImportStore.self) private var importStore
-  @State private var showingSetup = false
+  @State private var setupStore: CSVImportSetupStore?
 
   var body: some View {
     HStack {
-      Image(systemName: "doc.badge.ellipsis").foregroundStyle(.secondary)
+      Image(systemName: "doc.badge.ellipsis")
+        .foregroundStyle(.secondary)
+        .accessibilityHidden(true)
       VStack(alignment: .leading) {
         Text(file.originalFilename).font(.subheadline)
         Text(file.detectedParserIdentifier ?? "Unknown parser")
           .font(.caption).foregroundStyle(.secondary)
       }
+      .accessibilityElement(children: .combine)
+      .accessibilityLabel("\(file.originalFilename), needs setup")
       Spacer()
-      Button("Set up\u{2026}") { showingSetup = true }
-        .buttonStyle(.borderless)
+      Button("Set up\u{2026}") {
+        // Build the store lazily on first open so re-renders of the parent
+        // don't wipe user-entered form state. Held in @State for stability
+        // across sheet dismiss/show cycles.
+        setupStore = CSVImportSetupStore(
+          pending: file, backend: backend,
+          importStore: importStore, staging: staging)
+      }
+      .buttonStyle(.borderless)
       Button("Dismiss") {
         Task { await importStore.dismissPending(id: file.id) }
       }
       .buttonStyle(.borderless)
     }
-    .sheet(isPresented: $showingSetup) {
-      CSVImportSetupView(
-        store: CSVImportSetupStore(
-          pending: file, backend: backend,
-          importStore: importStore, staging: staging))
+    .sheet(
+      isPresented: Binding(
+        get: { setupStore != nil },
+        set: { if !$0 { setupStore = nil } })
+    ) {
+      if let setupStore {
+        CSVImportSetupView(store: setupStore)
+      }
     }
   }
 }
@@ -231,7 +269,9 @@ private struct FailedRow: View {
 
   var body: some View {
     HStack {
-      Image(systemName: "exclamationmark.triangle").foregroundStyle(.red)
+      Image(systemName: "exclamationmark.triangle")
+        .foregroundStyle(.red)
+        .accessibilityHidden(true)
       VStack(alignment: .leading) {
         Text(file.originalFilename).font(.subheadline)
         Text(file.error)
@@ -239,6 +279,8 @@ private struct FailedRow: View {
           .foregroundStyle(.secondary)
           .lineLimit(2)
       }
+      .accessibilityElement(children: .combine)
+      .accessibilityLabel("\(file.originalFilename) failed: \(file.error)")
       Spacer()
       Button("Dismiss") {
         Task { await importStore.dismissFailed(id: file.id) }

--- a/Features/Import/Views/RuleEditorView.swift
+++ b/Features/Import/Views/RuleEditorView.swift
@@ -1,0 +1,363 @@
+import SwiftUI
+
+/// Rule editor sheet. Two sections — Conditions (If any/all of these are
+/// true) and Actions (Perform these). Each row has a field/operator/value
+/// dropdown. Save writes back through the `onSave` closure; Cancel throws
+/// the draft away.
+struct RuleEditorView: View {
+  @State private var rule: ImportRule
+  let onSave: (ImportRule) -> Void
+  @Environment(\.dismiss) private var dismiss
+  @Environment(CategoryStore.self) private var categoryStore
+  @Environment(AccountStore.self) private var accountStore
+
+  init(initialRule: ImportRule, onSave: @escaping (ImportRule) -> Void) {
+    _rule = State(initialValue: initialRule)
+    self.onSave = onSave
+  }
+
+  var body: some View {
+    NavigationStack {
+      Form {
+        Section(header: Text("Rule")) {
+          TextField("Name", text: $rule.name)
+          Toggle("Enabled", isOn: $rule.enabled)
+        }
+
+        Section(header: Text("If \(matchModeLabel) of these are true")) {
+          Picker("Match mode", selection: $rule.matchMode) {
+            Text("All").tag(MatchMode.all)
+            Text("Any").tag(MatchMode.any)
+          }
+          .pickerStyle(.segmented)
+          ForEach(Array(rule.conditions.enumerated()), id: \.offset) { index, _ in
+            ConditionRow(
+              condition: Binding(
+                get: { rule.conditions[index] },
+                set: { rule.conditions[index] = $0 }),
+              onDelete: { rule.conditions.remove(at: index) })
+          }
+          Button {
+            rule.conditions.append(.descriptionContains([""]))
+          } label: {
+            Label("Add Condition", systemImage: "plus.circle")
+          }
+        }
+
+        Section(header: Text("Perform these actions")) {
+          ForEach(Array(rule.actions.enumerated()), id: \.offset) { index, _ in
+            ActionRow(
+              action: Binding(
+                get: { rule.actions[index] },
+                set: { rule.actions[index] = $0 }),
+              categories: categoryStore.categories,
+              accounts: accountStore.accounts,
+              onDelete: { rule.actions.remove(at: index) })
+          }
+          Menu {
+            Button("Set Payee") { rule.actions.append(.setPayee("")) }
+            Button("Set Category") {
+              if let firstCategory = categoryStore.categories.flattenedByPath().first?.category {
+                rule.actions.append(.setCategory(firstCategory.id))
+              } else {
+                rule.actions.append(.setCategory(UUID()))
+              }
+            }
+            Button("Append Note") { rule.actions.append(.appendNote("")) }
+            if let firstAccount = accountStore.accounts.ordered.first {
+              Button("Mark as Transfer") {
+                rule.actions.append(.markAsTransfer(toAccountId: firstAccount.id))
+              }
+            }
+            Button("Skip Row") { rule.actions.append(.skip) }
+          } label: {
+            Label("Add Action", systemImage: "plus.circle")
+          }
+        }
+      }
+      .formStyle(.grouped)
+      .navigationTitle(rule.name.isEmpty ? "New Rule" : rule.name)
+      .toolbar {
+        ToolbarItem(placement: .cancellationAction) {
+          Button("Cancel") { dismiss() }
+        }
+        ToolbarItem(placement: .confirmationAction) {
+          Button("Save") {
+            onSave(rule)
+            dismiss()
+          }
+          .disabled(rule.name.isEmpty)
+        }
+      }
+    }
+  }
+
+  private var matchModeLabel: String {
+    rule.matchMode == .all ? "all" : "any"
+  }
+}
+
+// MARK: - Condition editor row
+
+private struct ConditionRow: View {
+  @Binding var condition: RuleCondition
+  let onDelete: () -> Void
+
+  var body: some View {
+    HStack {
+      Picker("", selection: conditionKindBinding) {
+        ForEach(ConditionKind.allCases, id: \.self) { kind in
+          Text(kind.label).tag(kind)
+        }
+      }
+      .labelsHidden()
+
+      switch condition {
+      case .descriptionContains(let tokens), .descriptionDoesNotContain(let tokens):
+        TextField(
+          "tokens, comma separated",
+          text: Binding(
+            get: { tokens.joined(separator: ", ") },
+            set: { newValue in
+              let parts =
+                newValue
+                .split(separator: ",")
+                .map { $0.trimmingCharacters(in: .whitespaces) }
+                .filter { !$0.isEmpty }
+              switch condition {
+              case .descriptionContains: condition = .descriptionContains(parts)
+              case .descriptionDoesNotContain: condition = .descriptionDoesNotContain(parts)
+              default: break
+              }
+            }))
+      case .descriptionBeginsWith(let prefix):
+        TextField(
+          "prefix",
+          text: Binding(
+            get: { prefix },
+            set: { condition = .descriptionBeginsWith($0) }))
+      case .amountIsPositive, .amountIsNegative:
+        EmptyView()
+      case .amountBetween(let min, let max):
+        TextField(
+          "min",
+          value: Binding(
+            get: { min },
+            set: { condition = .amountBetween(min: $0, max: max) }),
+          format: .number)
+        TextField(
+          "max",
+          value: Binding(
+            get: { max },
+            set: { condition = .amountBetween(min: min, max: $0) }),
+          format: .number)
+      case .sourceAccountIs:
+        Text("(on routed account)")
+          .font(.caption)
+          .foregroundStyle(.secondary)
+      }
+
+      Button(role: .destructive) {
+        onDelete()
+      } label: {
+        Image(systemName: "minus.circle")
+      }
+      .buttonStyle(.borderless)
+      .accessibilityLabel("Remove condition")
+    }
+  }
+
+  // MARK: - Condition kind picker
+
+  private var conditionKindBinding: Binding<ConditionKind> {
+    Binding(
+      get: { ConditionKind.from(condition) },
+      set: { newKind in
+        condition = newKind.defaultCondition(from: condition)
+      })
+  }
+}
+
+private enum ConditionKind: String, CaseIterable, Hashable {
+  case contains, doesNotContain, beginsWith
+  case amountPositive, amountNegative, amountBetween
+  case sourceAccount
+
+  var label: String {
+    switch self {
+    case .contains: return "Contains"
+    case .doesNotContain: return "Does not contain"
+    case .beginsWith: return "Begins with"
+    case .amountPositive: return "Amount is income"
+    case .amountNegative: return "Amount is expense"
+    case .amountBetween: return "Amount between"
+    case .sourceAccount: return "Source is routed account"
+    }
+  }
+
+  static func from(_ condition: RuleCondition) -> ConditionKind {
+    switch condition {
+    case .descriptionContains: return .contains
+    case .descriptionDoesNotContain: return .doesNotContain
+    case .descriptionBeginsWith: return .beginsWith
+    case .amountIsPositive: return .amountPositive
+    case .amountIsNegative: return .amountNegative
+    case .amountBetween: return .amountBetween
+    case .sourceAccountIs: return .sourceAccount
+    }
+  }
+
+  /// Transition to the new kind, carrying forward tokens/prefix/min+max if
+  /// shapes overlap.
+  func defaultCondition(from existing: RuleCondition) -> RuleCondition {
+    switch self {
+    case .contains:
+      if case .descriptionContains(let t) = existing { return .descriptionContains(t) }
+      if case .descriptionDoesNotContain(let t) = existing { return .descriptionContains(t) }
+      return .descriptionContains([""])
+    case .doesNotContain:
+      if case .descriptionContains(let t) = existing { return .descriptionDoesNotContain(t) }
+      if case .descriptionDoesNotContain(let t) = existing { return .descriptionDoesNotContain(t) }
+      return .descriptionDoesNotContain([""])
+    case .beginsWith:
+      if case .descriptionBeginsWith(let p) = existing { return .descriptionBeginsWith(p) }
+      return .descriptionBeginsWith("")
+    case .amountPositive: return .amountIsPositive
+    case .amountNegative: return .amountIsNegative
+    case .amountBetween:
+      if case .amountBetween(let min, let max) = existing {
+        return .amountBetween(min: min, max: max)
+      }
+      return .amountBetween(min: 0, max: 0)
+    case .sourceAccount:
+      if case .sourceAccountIs(let id) = existing { return .sourceAccountIs(id) }
+      return .sourceAccountIs(UUID())
+    }
+  }
+}
+
+// MARK: - Action editor row
+
+private struct ActionRow: View {
+  @Binding var action: RuleAction
+  let categories: Categories
+  let accounts: Accounts
+  let onDelete: () -> Void
+
+  var body: some View {
+    HStack {
+      Picker("", selection: actionKindBinding) {
+        ForEach(ActionKind.allCases, id: \.self) { kind in
+          Text(kind.label).tag(kind)
+        }
+      }
+      .labelsHidden()
+
+      switch action {
+      case .setPayee(let payee):
+        TextField(
+          "payee",
+          text: Binding(get: { payee }, set: { action = .setPayee($0) }))
+      case .setCategory(let id):
+        Picker(
+          "Category",
+          selection: Binding(
+            get: { id },
+            set: { action = .setCategory($0) })
+        ) {
+          ForEach(flatCategories, id: \.id) { category in
+            Text(category.name).tag(category.id)
+          }
+        }
+        .labelsHidden()
+      case .appendNote(let note):
+        TextField(
+          "note",
+          text: Binding(get: { note }, set: { action = .appendNote($0) }))
+      case .markAsTransfer(let accountId):
+        Picker(
+          "To account",
+          selection: Binding(
+            get: { accountId },
+            set: { action = .markAsTransfer(toAccountId: $0) })
+        ) {
+          ForEach(accounts.ordered, id: \.id) { account in
+            Text(account.name).tag(account.id)
+          }
+        }
+        .labelsHidden()
+      case .skip:
+        Text("(drops the row)")
+          .font(.caption)
+          .foregroundStyle(.secondary)
+      }
+
+      Button(role: .destructive) {
+        onDelete()
+      } label: {
+        Image(systemName: "minus.circle")
+      }
+      .buttonStyle(.borderless)
+      .accessibilityLabel("Remove action")
+    }
+  }
+
+  private var flatCategories: [Category] {
+    categories.flattenedByPath().map(\.category)
+  }
+
+  private var actionKindBinding: Binding<ActionKind> {
+    Binding(
+      get: { ActionKind.from(action) },
+      set: { newKind in
+        action = newKind.defaultAction(
+          from: action, categories: categories, accounts: accounts)
+      })
+  }
+}
+
+private enum ActionKind: String, CaseIterable, Hashable {
+  case setPayee, setCategory, appendNote, markAsTransfer, skip
+
+  var label: String {
+    switch self {
+    case .setPayee: return "Set payee"
+    case .setCategory: return "Set category"
+    case .appendNote: return "Append note"
+    case .markAsTransfer: return "Mark as transfer"
+    case .skip: return "Skip row"
+    }
+  }
+
+  static func from(_ action: RuleAction) -> ActionKind {
+    switch action {
+    case .setPayee: return .setPayee
+    case .setCategory: return .setCategory
+    case .appendNote: return .appendNote
+    case .markAsTransfer: return .markAsTransfer
+    case .skip: return .skip
+    }
+  }
+
+  func defaultAction(
+    from existing: RuleAction, categories: Categories, accounts: Accounts
+  ) -> RuleAction {
+    switch self {
+    case .setPayee:
+      if case .setPayee(let p) = existing { return .setPayee(p) }
+      return .setPayee("")
+    case .setCategory:
+      if case .setCategory(let id) = existing { return .setCategory(id) }
+      let first = categories.flattenedByPath().first?.category.id ?? UUID()
+      return .setCategory(first)
+    case .appendNote:
+      if case .appendNote(let n) = existing { return .appendNote(n) }
+      return .appendNote("")
+    case .markAsTransfer:
+      if case .markAsTransfer(let id) = existing { return .markAsTransfer(toAccountId: id) }
+      let first = accounts.ordered.first?.id ?? UUID()
+      return .markAsTransfer(toAccountId: first)
+    case .skip: return .skip
+    }
+  }
+}

--- a/Features/Import/Views/RuleEditorView.swift
+++ b/Features/Import/Views/RuleEditorView.swift
@@ -6,13 +6,31 @@ import SwiftUI
 /// the draft away.
 struct RuleEditorView: View {
   @State private var rule: ImportRule
+  /// UUID-keyed view-state wrappers around each condition / action. Using
+  /// stable IDs (rather than `Array.Index` offsets) keeps SwiftUI's view
+  /// identity pinned to the same row after a mid-list delete, so focus,
+  /// in-flight text edits, and Binding reads don't jump to a stale index.
+  @State private var identifiedConditions: [IdentifiedCondition]
+  @State private var identifiedActions: [IdentifiedAction]
+  @State private var affectedCount: Int?
+  @State private var countingTask: Task<Void, Never>?
   let onSave: (ImportRule) -> Void
   @Environment(\.dismiss) private var dismiss
   @Environment(CategoryStore.self) private var categoryStore
   @Environment(AccountStore.self) private var accountStore
+  @Environment(ImportRuleStore.self) private var ruleStore
+  @Environment(ProfileSession.self) private var session
 
   init(initialRule: ImportRule, onSave: @escaping (ImportRule) -> Void) {
     _rule = State(initialValue: initialRule)
+    _identifiedConditions = State(
+      initialValue: initialRule.conditions.map {
+        IdentifiedCondition(id: UUID(), condition: $0)
+      })
+    _identifiedActions = State(
+      initialValue: initialRule.actions.map {
+        IdentifiedAction(id: UUID(), action: $0)
+      })
     self.onSave = onSave
   }
 
@@ -22,6 +40,17 @@ struct RuleEditorView: View {
         Section(header: Text("Rule")) {
           TextField("Name", text: $rule.name)
           Toggle("Enabled", isOn: $rule.enabled)
+          Picker(
+            "Applies to",
+            selection: Binding(
+              get: { rule.accountScope },
+              set: { rule.accountScope = $0 })
+          ) {
+            Text("All accounts").tag(UUID?.none)
+            ForEach(accountStore.accounts.ordered, id: \.id) { account in
+              Text(account.name).tag(UUID?.some(account.id))
+            }
+          }
         }
 
         Section(header: Text("If \(matchModeLabel) of these are true")) {
@@ -30,48 +59,73 @@ struct RuleEditorView: View {
             Text("Any").tag(MatchMode.any)
           }
           .pickerStyle(.segmented)
-          ForEach(Array(rule.conditions.enumerated()), id: \.offset) { index, _ in
+          ForEach($identifiedConditions) { $item in
             ConditionRow(
-              condition: Binding(
-                get: { rule.conditions[index] },
-                set: { rule.conditions[index] = $0 }),
-              onDelete: { rule.conditions.remove(at: index) })
+              condition: $item.condition,
+              onDelete: {
+                identifiedConditions.removeAll { $0.id == item.id }
+              })
           }
           Button {
-            rule.conditions.append(.descriptionContains([""]))
+            identifiedConditions.append(
+              IdentifiedCondition(id: UUID(), condition: .descriptionContains([""])))
           } label: {
             Label("Add Condition", systemImage: "plus.circle")
           }
         }
 
         Section(header: Text("Perform these actions")) {
-          ForEach(Array(rule.actions.enumerated()), id: \.offset) { index, _ in
+          ForEach($identifiedActions) { $item in
             ActionRow(
-              action: Binding(
-                get: { rule.actions[index] },
-                set: { rule.actions[index] = $0 }),
+              action: $item.action,
               categories: categoryStore.categories,
               accounts: accountStore.accounts,
-              onDelete: { rule.actions.remove(at: index) })
+              onDelete: {
+                identifiedActions.removeAll { $0.id == item.id }
+              })
           }
           Menu {
-            Button("Set Payee") { rule.actions.append(.setPayee("")) }
-            Button("Set Category") {
-              if let firstCategory = categoryStore.categories.flattenedByPath().first?.category {
-                rule.actions.append(.setCategory(firstCategory.id))
-              } else {
-                rule.actions.append(.setCategory(UUID()))
+            Button("Set Payee") {
+              identifiedActions.append(
+                IdentifiedAction(id: UUID(), action: .setPayee("")))
+            }
+            // Only offer Set Category when categories exist — spec forbids
+            // rules referencing invented category UUIDs.
+            if let firstCategory = categoryStore.categories.flattenedByPath().first?.category {
+              Button("Set Category") {
+                identifiedActions.append(
+                  IdentifiedAction(id: UUID(), action: .setCategory(firstCategory.id)))
               }
             }
-            Button("Append Note") { rule.actions.append(.appendNote("")) }
+            Button("Append Note") {
+              identifiedActions.append(
+                IdentifiedAction(id: UUID(), action: .appendNote("")))
+            }
             if let firstAccount = accountStore.accounts.ordered.first {
               Button("Mark as Transfer") {
-                rule.actions.append(.markAsTransfer(toAccountId: firstAccount.id))
+                identifiedActions.append(
+                  IdentifiedAction(
+                    id: UUID(),
+                    action: .markAsTransfer(toAccountId: firstAccount.id)))
               }
             }
-            Button("Skip Row") { rule.actions.append(.skip) }
+            Button("Skip Row") {
+              identifiedActions.append(
+                IdentifiedAction(id: UUID(), action: .skip))
+            }
           } label: {
             Label("Add Action", systemImage: "plus.circle")
+          }
+        }
+
+        Section(header: Text("Preview")) {
+          HStack(spacing: 6) {
+            if affectedCount == nil {
+              ProgressView().controlSize(.small)
+            }
+            Text(previewText)
+              .font(.subheadline)
+              .foregroundStyle(affectedCount == nil ? .secondary : .primary)
           }
         }
       }
@@ -83,18 +137,83 @@ struct RuleEditorView: View {
         }
         ToolbarItem(placement: .confirmationAction) {
           Button("Save") {
-            onSave(rule)
+            var out = rule
+            out.conditions = identifiedConditions.map(\.condition)
+            out.actions = identifiedActions.map(\.action)
+            onSave(out)
             dismiss()
           }
           .disabled(rule.name.isEmpty)
         }
       }
+      .task(id: previewKey) {
+        await schedulePreview()
+      }
+      #if os(macOS)
+        .frame(minWidth: 540, minHeight: 520)
+      #endif
     }
+  }
+
+  /// Serialises the conditions + matchMode + accountScope so the preview
+  /// task cancels and re-runs on any change, but not on name / action edits
+  /// (which don't affect the match set).
+  private var previewKey: String {
+    var bits: [String] = [rule.matchMode.rawValue]
+    for item in identifiedConditions {
+      bits.append(String(describing: item.condition))
+    }
+    if let scope = rule.accountScope {
+      bits.append("scope:\(scope.uuidString)")
+    }
+    return bits.joined(separator: "|")
+  }
+
+  private var previewText: String {
+    guard let count = affectedCount else {
+      return "Counting past transactions…"
+    }
+    switch count {
+    case 0: return "No past transactions would match this rule."
+    case 1: return "1 past transaction would match this rule."
+    default: return "\(count) past transactions would match this rule."
+    }
+  }
+
+  /// Wait a short debounce before re-counting so typing in the token
+  /// editor doesn't hammer the backend.
+  private func schedulePreview() async {
+    affectedCount = nil
+    try? await Task.sleep(nanoseconds: 500_000_000)
+    if Task.isCancelled { return }
+    let count = await ruleStore.countAffected(
+      conditions: identifiedConditions.map(\.condition),
+      matchMode: rule.matchMode,
+      accountScope: rule.accountScope,
+      backend: session.backend)
+    if Task.isCancelled { return }
+    affectedCount = count
   }
 
   private var matchModeLabel: String {
     rule.matchMode == .all ? "all" : "any"
   }
+}
+
+// MARK: - UUID-keyed view-state wrappers
+
+/// Wraps a `RuleCondition` with a persistent UUID so SwiftUI `ForEach` can
+/// keep view identity stable across mid-list deletes. Mirrors into
+/// `rule.conditions` on Save.
+private struct IdentifiedCondition: Identifiable {
+  let id: UUID
+  var condition: RuleCondition
+}
+
+/// Wraps a `RuleAction` with a persistent UUID for the same reason.
+private struct IdentifiedAction: Identifiable {
+  let id: UUID
+  var action: RuleAction
 }
 
 // MARK: - Condition editor row
@@ -105,7 +224,7 @@ private struct ConditionRow: View {
 
   var body: some View {
     HStack {
-      Picker("", selection: conditionKindBinding) {
+      Picker("Condition type", selection: conditionKindBinding) {
         ForEach(ConditionKind.allCases, id: \.self) { kind in
           Text(kind.label).tag(kind)
         }
@@ -144,13 +263,19 @@ private struct ConditionRow: View {
           value: Binding(
             get: { min },
             set: { condition = .amountBetween(min: $0, max: max) }),
-          format: .number)
+          format: .number
+        )
+        .monospacedDigit()
+        .accessibilityLabel("Minimum amount")
         TextField(
           "max",
           value: Binding(
             get: { max },
             set: { condition = .amountBetween(min: min, max: $0) }),
-          format: .number)
+          format: .number
+        )
+        .monospacedDigit()
+        .accessibilityLabel("Maximum amount")
       case .sourceAccountIs:
         Text("(on routed account)")
           .font(.caption)
@@ -246,7 +371,7 @@ private struct ActionRow: View {
 
   var body: some View {
     HStack {
-      Picker("", selection: actionKindBinding) {
+      Picker("Action type", selection: actionKindBinding) {
         ForEach(ActionKind.allCases, id: \.self) { kind in
           Text(kind.label).tag(kind)
         }
@@ -348,6 +473,10 @@ private enum ActionKind: String, CaseIterable, Hashable {
       return .setPayee("")
     case .setCategory:
       if case .setCategory(let id) = existing { return .setCategory(id) }
+      // Prefer an existing category; if none exist the caller shouldn't
+      // have offered this option in the picker, so the fallback is
+      // defensive. The rule editor's "Add Action" menu hides Set Category
+      // entirely when categories are empty.
       let first = categories.flattenedByPath().first?.category.id ?? UUID()
       return .setCategory(first)
     case .appendNote:

--- a/Features/Navigation/SidebarView.swift
+++ b/Features/Navigation/SidebarView.swift
@@ -15,6 +15,7 @@ struct SidebarView: View {
   @Environment(AccountStore.self) private var accountStore
   @Environment(EarmarkStore.self) private var earmarkStore
   @Environment(ProfileSession.self) private var session
+  @Environment(ImportStore.self) private var importStore
   @Binding var selection: SidebarSelection?
   @State private var showCreateEarmarkSheet = false
   @State private var showCreateAccountSheet = false
@@ -42,6 +43,10 @@ struct SidebarView: View {
         ForEach(accountStore.currentAccounts) { account in
           NavigationLink(value: SidebarSelection.account(account.id)) {
             AccountSidebarRow(account: account, isSelected: selection == .account(account.id))
+          }
+          .dropDestination(for: URL.self) { urls, _ in
+            Task { await ingestDroppedURLs(urls, forcedAccountId: account.id) }
+            return !urls.isEmpty
           }
           .contextMenu {
             Button("Edit Account\u{2026}", systemImage: "pencil") {
@@ -277,6 +282,24 @@ struct SidebarView: View {
     var accounts = accountStore.currentAccounts
     accounts.move(fromOffsets: source, toOffset: destination)
     await accountStore.reorderAccounts(accounts)
+  }
+
+  /// Dropped CSV onto a sidebar account row: force the import onto that
+  /// account, bypassing profile matching. A profile is created on success.
+  private func ingestDroppedURLs(_ urls: [URL], forcedAccountId: UUID) async {
+    for url in urls
+    where url.pathExtension.lowercased() == "csv"
+      || url.pathExtension.isEmpty
+    {
+      let didStart = url.startAccessingSecurityScopedResource()
+      defer {
+        if didStart { url.stopAccessingSecurityScopedResource() }
+      }
+      guard let data = try? Data(contentsOf: url) else { continue }
+      _ = await importStore.ingest(
+        data: data,
+        source: .droppedFile(url: url, forcedAccountId: forcedAccountId))
+    }
   }
 
   private func reorderInvestmentAccounts(from source: IndexSet, to destination: Int) async {

--- a/Features/Settings/SettingsView.swift
+++ b/Features/Settings/SettingsView.swift
@@ -64,6 +64,15 @@ struct SettingsView: View {
         Tab("Crypto", systemImage: "bitcoinsign.circle") {
           CryptoSettingsView(store: cryptoTokenStoreForSettings)
         }
+        // macOS Settings tabs host the Form / List directly — the window
+        // already supplies chrome and a title, so wrapping in a second
+        // `NavigationStack` would produce a duplicate navigation bar.
+        Tab("Import", systemImage: "tray.and.arrow.down") {
+          ImportSettingsView()
+        }
+        Tab("Rules", systemImage: "list.bullet.rectangle") {
+          ImportRulesSettingsView()
+        }
       }
       .frame(minWidth: 600, minHeight: 400)
       .sheet(isPresented: $showAddProfile) {

--- a/Features/Settings/SettingsView.swift
+++ b/Features/Settings/SettingsView.swift
@@ -199,6 +199,19 @@ struct SettingsView: View {
             Label("Crypto Tokens", systemImage: "bitcoinsign.circle")
           }
         }
+
+        Section("Import") {
+          NavigationLink {
+            ImportSettingsView()
+          } label: {
+            Label("CSV Import", systemImage: "tray.and.arrow.down")
+          }
+          NavigationLink {
+            ImportRulesSettingsView()
+          } label: {
+            Label("Import Rules", systemImage: "list.bullet.rectangle")
+          }
+        }
       }
       .navigationTitle("Settings")
       .overlay {

--- a/MoolahBenchmarks/ImportPipelineBenchmarks.swift
+++ b/MoolahBenchmarks/ImportPipelineBenchmarks.swift
@@ -49,7 +49,7 @@ final class ImportPipelineBenchmarks: XCTestCase {
   private var metrics: [XCTMetric] { [XCTClockMetric(), XCTMemoryMetric()] }
   private var options: XCTMeasureOptions {
     let opts = XCTMeasureOptions()
-    opts.iterationCount = 5
+    opts.iterationCount = 10
     return opts
   }
 
@@ -173,19 +173,33 @@ final class ImportPipelineBenchmarks: XCTestCase {
     }
   }
 
-  /// End-to-end: 10 files × 1 000 rows each against the seeded TestBackend.
+  /// End-to-end: 10 files × 1 000 rows each against a fresh TestBackend per
+  /// iteration so numbers are comparable (earlier versions accumulated
+  /// transactions across iterations, inflating dedup cost).
   /// Measures tokenize + parse + profile match + dedup + rules + persist +
   /// the cleanup steps. One of the most realistic benchmarks.
   func testImportPipelineEndToEnd10Files1000RowsEach() throws {
-    let importStore = try awaitSync { @MainActor in
-      let dir = FileManager.default.temporaryDirectory
-        .appendingPathComponent("bench-\(UUID().uuidString)")
-      let staging = try ImportStagingStore(directory: dir)
-      return ImportStore(backend: Self._backend, staging: staging)
-    }
     let data = Self.makeCBAData(rowCount: 1000)
     measure(metrics: metrics, options: options) {
       try! awaitSync { @MainActor in
+        // Fresh backend + staging per iteration — no state leaks between
+        // runs so the reported time measures a clean 10-file ingest.
+        let (backend, _) = try TestBackend.create()
+        let accountId = UUID()
+        _ = try await backend.accounts.create(
+          Account(
+            id: accountId, name: "Bench", type: .bank, instrument: .AUD,
+            positions: [], position: 0, isHidden: false),
+          openingBalance: nil)
+        _ = try await backend.csvImportProfiles.create(
+          CSVImportProfile(
+            accountId: accountId,
+            parserIdentifier: "generic-bank",
+            headerSignature: ["date", "description", "debit", "credit", "balance"]))
+        let dir = FileManager.default.temporaryDirectory
+          .appendingPathComponent("bench-\(UUID().uuidString)")
+        let staging = try ImportStagingStore(directory: dir)
+        let importStore = ImportStore(backend: backend, staging: staging)
         for _ in 0..<10 {
           _ = await importStore.ingest(
             data: data,

--- a/MoolahBenchmarks/ImportPipelineBenchmarks.swift
+++ b/MoolahBenchmarks/ImportPipelineBenchmarks.swift
@@ -1,0 +1,199 @@
+import Foundation
+import SwiftData
+import XCTest
+
+@testable import Moolah
+
+/// Benchmarks for the CSV import pipeline per `plans/2026-04-18-csv-import-design.md`
+/// § Benchmarks. Each test isolates one stage so regressions in parse vs dedup
+/// vs rules vs end-to-end can be pinpointed by xctest output.
+///
+/// Fixtures are synthesised in-memory (no file I/O) so the benchmarks measure
+/// Swift work rather than filesystem variance.
+final class ImportPipelineBenchmarks: XCTestCase {
+
+  nonisolated(unsafe) private static var _backend: CloudKitBackend!
+  nonisolated(unsafe) private static var _container: ModelContainer!
+  nonisolated(unsafe) private static var _accountId: UUID!
+
+  override class func setUp() {
+    super.setUp()
+    let result = try! TestBackend.create()
+    _backend = result.backend
+    _container = result.container
+    _accountId = UUID()
+    try! awaitSync { @MainActor in
+      _ = try await result.backend.accounts.create(
+        Account(
+          id: _accountId, name: "Bench", type: .bank, instrument: .AUD,
+          positions: [], position: 0, isHidden: false),
+        openingBalance: nil)
+      _ = try await result.backend.csvImportProfiles.create(
+        CSVImportProfile(
+          accountId: _accountId,
+          parserIdentifier: "generic-bank",
+          headerSignature: ["date", "description", "debit", "credit", "balance"]))
+    }
+  }
+
+  override class func tearDown() {
+    _backend = nil
+    _container = nil
+    _accountId = nil
+    super.tearDown()
+  }
+
+  private var backend: CloudKitBackend { Self._backend }
+  private var accountId: UUID { Self._accountId }
+
+  private var metrics: [XCTMetric] { [XCTClockMetric(), XCTMemoryMetric()] }
+  private var options: XCTMeasureOptions {
+    let opts = XCTMeasureOptions()
+    opts.iterationCount = 5
+    return opts
+  }
+
+  // MARK: - Synthetic CSV
+
+  /// A valid CBA-style CSV with `rowCount` data rows plus a header.
+  private static func makeCBAData(rowCount: Int) -> Data {
+    var lines: [String] = ["Date,Description,Debit,Credit,Balance"]
+    lines.reserveCapacity(rowCount + 1)
+    var balance = Decimal(1000)
+    for i in 0..<rowCount {
+      let amount = Decimal(-5) - Decimal(i % 7)
+      balance += amount
+      let day = (i % 28) + 1
+      let dd = String(format: "%02d", day)
+      let description = "MERCHANT \(i % 50) SYDNEY"
+      let amountStr = "\(amount)"
+      let balStr = "\(balance)"
+      lines.append("\(dd)/04/2024,\(description),\(amountStr),,\(balStr)")
+    }
+    return Data(lines.joined(separator: "\n").utf8)
+  }
+
+  private static func makeExisting(count: Int, accountId: UUID) -> [Transaction] {
+    var out: [Transaction] = []
+    out.reserveCapacity(count)
+    let sessionId = UUID()
+    for i in 0..<count {
+      let origin = ImportOrigin(
+        rawDescription: "MERCHANT \(i % 50) SYDNEY",
+        bankReference: "REF-\(i)",
+        rawAmount: Decimal(-5),
+        rawBalance: nil,
+        importedAt: Date(),
+        importSessionId: sessionId,
+        sourceFilename: "bulk.csv",
+        parserIdentifier: "generic-bank")
+      out.append(
+        Transaction(
+          date: Date(timeIntervalSince1970: Double(i * 86_400)),
+          legs: [
+            TransactionLeg(
+              accountId: accountId, instrument: .AUD,
+              quantity: Decimal(-5), type: .expense,
+              categoryId: nil, earmarkId: nil)
+          ],
+          importOrigin: origin))
+    }
+    return out
+  }
+
+  private static func makeCandidates(count: Int) -> [ParsedTransaction] {
+    var out: [ParsedTransaction] = []
+    out.reserveCapacity(count)
+    for i in 0..<count {
+      out.append(
+        ParsedTransaction(
+          date: Date(timeIntervalSince1970: Double(i * 86_400)),
+          legs: [
+            ParsedLeg(
+              accountId: nil, instrument: .AUD,
+              quantity: Decimal(-5), type: .expense,
+              isInstrumentPlaceholder: true)
+          ],
+          rawRow: [],
+          rawDescription: "MERCHANT \(i % 50) SYDNEY",
+          rawAmount: Decimal(-5),
+          rawBalance: Decimal(1000),
+          bankReference: "REF-\(i)"))
+    }
+    return out
+  }
+
+  private static func makeRules(count: Int) -> [ImportRule] {
+    var out: [ImportRule] = []
+    for i in 0..<count {
+      out.append(
+        ImportRule(
+          name: "rule-\(i)",
+          position: i,
+          matchMode: .any,
+          conditions: [.descriptionContains(["MERCHANT \(i % 50)"])],
+          actions: [.setPayee("Payee \(i % 50)"), .appendNote("note-\(i)")]))
+    }
+    return out
+  }
+
+  // MARK: - Stage benchmarks
+
+  /// Parse 1 000 rows of generic-bank CSV (tokenize + parse, no I/O).
+  func testImportPipelineParse1000Rows() {
+    let data = Self.makeCBAData(rowCount: 1000)
+    let parser = GenericBankCSVParser()
+    measure(metrics: metrics, options: options) {
+      let rows = (try? CSVTokenizer.parse(data)) ?? []
+      _ = (try? parser.parse(rows: rows)) ?? []
+    }
+  }
+
+  /// Dedup 1 000 candidates against 10 000 existing transactions.
+  func testImportPipelineDedup1000Against10000Existing() {
+    let accountId = self.accountId
+    let candidates = Self.makeCandidates(count: 1_000)
+    let existing = Self.makeExisting(count: 10_000, accountId: accountId)
+    measure(metrics: metrics, options: options) {
+      _ = CSVDeduplicator.filter(
+        candidates, against: existing, accountId: accountId)
+    }
+  }
+
+  /// Run 20 rules against 1 000 candidates.
+  func testImportPipelineRules1000RowsWith20Rules() {
+    let accountId = self.accountId
+    let candidates = Self.makeCandidates(count: 1_000)
+    let rules = Self.makeRules(count: 20)
+    measure(metrics: metrics, options: options) {
+      for candidate in candidates {
+        _ = ImportRulesEngine.evaluate(
+          candidate, routedAccountId: accountId, rules: rules)
+      }
+    }
+  }
+
+  /// End-to-end: 10 files × 1 000 rows each against the seeded TestBackend.
+  /// Measures tokenize + parse + profile match + dedup + rules + persist +
+  /// the cleanup steps. One of the most realistic benchmarks.
+  func testImportPipelineEndToEnd10Files1000RowsEach() throws {
+    let importStore = try awaitSync { @MainActor in
+      let dir = FileManager.default.temporaryDirectory
+        .appendingPathComponent("bench-\(UUID().uuidString)")
+      let staging = try ImportStagingStore(directory: dir)
+      return ImportStore(backend: Self._backend, staging: staging)
+    }
+    let data = Self.makeCBAData(rowCount: 1000)
+    measure(metrics: metrics, options: options) {
+      try! awaitSync { @MainActor in
+        for _ in 0..<10 {
+          _ = await importStore.ingest(
+            data: data,
+            source: .pickedFile(
+              url: URL(fileURLWithPath: "/tmp/bench.csv"),
+              securityScoped: false))
+        }
+      }
+    }
+  }
+}

--- a/MoolahTests/Features/Import/CSVImportSetupStoreTests.swift
+++ b/MoolahTests/Features/Import/CSVImportSetupStoreTests.swift
@@ -127,6 +127,49 @@ struct CSVImportSetupStoreTests {
         == "anz-*.txt")
   }
 
+  @Test("preview applies the detected column mapping to real rows")
+  func previewAppliesColumnMapping() async throws {
+    let (backend, _) = try TestBackend.create()
+    let dir = tempDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let staging = try ImportStagingStore(directory: dir)
+    let importStore = ImportStore(backend: backend, staging: staging)
+    let bytes = try CSVFixtureLoader.data("cba-everyday-standard")
+    let pending = try await seedPending(staging, bytes: bytes)
+
+    let store = CSVImportSetupStore(
+      pending: pending, backend: backend,
+      importStore: importStore, staging: staging)
+    await store.regeneratePreview()
+
+    let coffee = store.preview.first(where: {
+      $0.rawDescription == "COFFEE HUT SYDNEY"
+    })
+    #expect(coffee != nil)
+    #expect(coffee?.rawAmount == Decimal(string: "-5.50"))
+    #expect(coffee?.rawBalance == Decimal(string: "994.50"))
+  }
+
+  @Test("user column-role overrides flow through to preview")
+  func columnRoleOverridesApplied() async throws {
+    let (backend, _) = try TestBackend.create()
+    let dir = tempDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let staging = try ImportStagingStore(directory: dir)
+    let importStore = ImportStore(backend: backend, staging: staging)
+    let bytes = try CSVFixtureLoader.data("cba-everyday-standard")
+    let pending = try await seedPending(staging, bytes: bytes)
+    let store = CSVImportSetupStore(
+      pending: pending, backend: backend,
+      importStore: importStore, staging: staging)
+    await store.regeneratePreview()
+    // Detected mapping puts Description at column 1. Overriding it to
+    // .ignore should route the raw description to an empty value.
+    await store.applyColumnRole(.ignore, forColumn: 1)
+    let firstTx = store.preview.first
+    #expect(firstTx?.rawDescription == "")
+  }
+
   @Test("deletePending removes the staged pending file")
   func deletePendingClears() async throws {
     let (backend, _) = try TestBackend.create()

--- a/MoolahTests/Features/Import/CSVImportSetupStoreTests.swift
+++ b/MoolahTests/Features/Import/CSVImportSetupStoreTests.swift
@@ -1,0 +1,147 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("CSVImportSetupStore")
+@MainActor
+struct CSVImportSetupStoreTests {
+
+  private func tempDirectory() -> URL {
+    FileManager.default.temporaryDirectory
+      .appendingPathComponent("setup-store-\(UUID().uuidString)")
+  }
+
+  private func seedPending(
+    _ staging: ImportStagingStore,
+    filename: String = "cba-march.csv",
+    bytes: Data
+  ) async throws -> PendingSetupFile {
+    let id = UUID()
+    let path = await staging.stagingPath(for: id)
+    let file = PendingSetupFile(
+      id: id,
+      originalFilename: filename,
+      stagingPath: path,
+      securityScopedBookmark: nil,
+      detectedParserIdentifier: "generic-bank",
+      detectedHeaders: ["date", "description", "debit", "credit", "balance"],
+      parsedAt: Date(),
+      sourceBookmark: nil)
+    try await staging.stagePending(file, data: bytes)
+    return file
+  }
+
+  @Test("regeneratePreview populates row count + preview for generic CBA file")
+  func previewPopulatesForGeneric() async throws {
+    let (backend, _) = try TestBackend.create()
+    let dir = tempDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let staging = try ImportStagingStore(directory: dir)
+    let importStore = ImportStore(backend: backend, staging: staging)
+    let bytes = try CSVFixtureLoader.data("cba-everyday-standard")
+    let pending = try await seedPending(staging, bytes: bytes)
+
+    let store = CSVImportSetupStore(
+      pending: pending, backend: backend,
+      importStore: importStore, staging: staging)
+    await store.regeneratePreview()
+
+    #expect(store.rowCount == 5)
+    #expect(store.detectedParserIdentifier == "generic-bank")
+    #expect(store.isGenericParser == true)
+    #expect(store.detectedMapping != nil)
+    // Preview takes the first 5 parsed transactions; the opening balance row
+    // skips, so we get up to 4.
+    #expect(store.preview.count >= 3)
+  }
+
+  @Test("saveAndImport requires a target account")
+  func saveRequiresTargetAccount() async throws {
+    let (backend, _) = try TestBackend.create()
+    let dir = tempDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let staging = try ImportStagingStore(directory: dir)
+    let importStore = ImportStore(backend: backend, staging: staging)
+    let bytes = try CSVFixtureLoader.data("cba-everyday-standard")
+    let pending = try await seedPending(staging, bytes: bytes)
+    let store = CSVImportSetupStore(
+      pending: pending, backend: backend,
+      importStore: importStore, staging: staging)
+
+    let result = await store.saveAndImport()
+    if case .failed = result {
+      #expect(store.saveError != nil)
+    } else {
+      Issue.record("expected .failed without target account; got \(result)")
+    }
+  }
+
+  @Test("saveAndImport creates the profile and imports")
+  func saveAndImportPersistsProfileAndImports() async throws {
+    let (backend, _) = try TestBackend.create()
+    let accountId = UUID()
+    _ = try await backend.accounts.create(
+      Account(
+        id: accountId, name: "Cash", type: .bank, instrument: .AUD,
+        positions: [], position: 0, isHidden: false),
+      openingBalance: nil)
+    let dir = tempDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let staging = try ImportStagingStore(directory: dir)
+    let importStore = ImportStore(backend: backend, staging: staging)
+    let bytes = try CSVFixtureLoader.data("cba-everyday-standard")
+    let pending = try await seedPending(staging, bytes: bytes)
+    let store = CSVImportSetupStore(
+      pending: pending, backend: backend,
+      importStore: importStore, staging: staging)
+    store.targetAccountId = accountId
+    store.filenamePattern = "cba-*.csv"
+    store.deleteAfterImport = true
+
+    let result = await store.saveAndImport()
+    if case .imported = result {
+      let profiles = try await backend.csvImportProfiles.fetchAll()
+      #expect(profiles.count == 1)
+      #expect(profiles[0].accountId == accountId)
+      #expect(profiles[0].filenamePattern == "cba-*.csv")
+      #expect(profiles[0].deleteAfterImport == true)
+      // Pending was cleared (importStore.finishSetup dismisses it).
+      await importStore.reloadStagingLists()
+      #expect(importStore.pendingSetup.isEmpty)
+    } else {
+      Issue.record("expected .imported; got \(result)")
+    }
+  }
+
+  @Test("suggestedFilenamePattern turns stem-prefix into glob")
+  func suggestedFilenamePatternBuildsGlob() {
+    #expect(
+      CSVImportSetupStore.suggestedFilenamePattern(from: "cba-april-2026.csv")
+        == "cba-*.csv")
+    #expect(
+      CSVImportSetupStore.suggestedFilenamePattern(from: "Statement.csv")
+        == "statement*.csv")
+    #expect(
+      CSVImportSetupStore.suggestedFilenamePattern(from: "anz-march-2026.txt")
+        == "anz-*.txt")
+  }
+
+  @Test("deletePending removes the staged pending file")
+  func deletePendingClears() async throws {
+    let (backend, _) = try TestBackend.create()
+    let dir = tempDirectory()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let staging = try ImportStagingStore(directory: dir)
+    let importStore = ImportStore(backend: backend, staging: staging)
+    let bytes = try CSVFixtureLoader.data("cba-everyday-standard")
+    let pending = try await seedPending(staging, bytes: bytes)
+    let store = CSVImportSetupStore(
+      pending: pending, backend: backend,
+      importStore: importStore, staging: staging)
+
+    await store.deletePending()
+    let remaining = try await staging.pendingFiles()
+    #expect(remaining.isEmpty)
+  }
+}

--- a/MoolahTests/Features/Import/FolderScanServiceTests.swift
+++ b/MoolahTests/Features/Import/FolderScanServiceTests.swift
@@ -1,0 +1,190 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("FolderScanService")
+@MainActor
+struct FolderScanServiceTests {
+
+  private func tempDirectory() -> URL {
+    FileManager.default.temporaryDirectory
+      .appendingPathComponent("scan-\(UUID().uuidString)", isDirectory: true)
+  }
+
+  /// Build an ImportStore wired to an in-memory TestBackend with one account
+  /// + one profile. Lets us count how many ingests happen by querying the
+  /// transactions repository.
+  private func makeStack(
+    watchedFolder: URL,
+    defaults: UserDefaults,
+    profileId: UUID = UUID()
+  ) async throws -> (
+    store: ImportStore, accountId: UUID, scanner: FolderScanService, backend: CloudKitBackend
+  ) {
+    let (backend, _) = try TestBackend.create()
+    let accountId = UUID()
+    _ = try await backend.accounts.create(
+      Account(
+        id: accountId, name: "Scan", type: .bank, instrument: .AUD,
+        positions: [], position: 0, isHidden: false),
+      openingBalance: nil)
+    _ = try await backend.csvImportProfiles.create(
+      CSVImportProfile(
+        accountId: accountId,
+        parserIdentifier: "generic-bank",
+        headerSignature: ["date", "description", "debit", "credit", "balance"]))
+    let stagingDirectory = tempDirectory()
+    let staging = try ImportStagingStore(directory: stagingDirectory)
+    let store = ImportStore(backend: backend, staging: staging)
+    let preferences = ImportPreferences(directory: tempDirectory())
+    preferences.setWatchedFolder(watchedFolder)
+    let scanner = FolderScanService(
+      profileId: profileId,
+      importStore: store,
+      preferences: preferences,
+      defaults: defaults)
+    return (store, accountId, scanner, backend)
+  }
+
+  private func writeCSV(at url: URL, lines: [String], modified: Date) throws {
+    try lines.joined(separator: "\n").write(to: url, atomically: true, encoding: .utf8)
+    try FileManager.default.setAttributes(
+      [.modificationDate: modified], ofItemAtPath: url.path)
+  }
+
+  private func cbaLines(startBalance: Decimal = 1000) -> [String] {
+    return [
+      "Date,Description,Debit,Credit,Balance",
+      "02/04/2024,COFFEE HUT SYDNEY,-5.50,,\(startBalance - 5.50)",
+      "03/04/2024,PAY NET,,3000.00,\(startBalance + 2994.50)",
+    ]
+  }
+
+  @Test("scanForNewFiles ingests each CSV the first time it sees it")
+  func firstRunIngestsEachCSV() async throws {
+    let folder = tempDirectory()
+    try FileManager.default.createDirectory(
+      at: folder, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: folder) }
+    let defaults = UserDefaults(suiteName: "csvscan-\(UUID().uuidString)")!
+    let (_, accountId, scanner, backend) = try await makeStack(
+      watchedFolder: folder, defaults: defaults)
+    let a = folder.appendingPathComponent("one.csv")
+    let b = folder.appendingPathComponent("two.csv")
+    try writeCSV(at: a, lines: cbaLines(), modified: Date(timeIntervalSinceNow: -30))
+    try writeCSV(at: b, lines: cbaLines(), modified: Date(timeIntervalSinceNow: -10))
+
+    await scanner.scanForNewFiles()
+
+    let page = try await backend.transactions.fetch(
+      filter: TransactionFilter(accountId: accountId), page: 0, pageSize: 50)
+    // Each CSV yields 2 candidates → dedup drops second-run duplicates but
+    // first run should land 2 for `a` and 0/2 for `b` depending on dedup.
+    // Two distinct files with identical bank references/descriptions →
+    // second file dedup's against first. Expect at least 2 transactions.
+    #expect(page.transactions.count >= 2)
+  }
+
+  @Test("scanForNewFiles skips files already seen on the previous run")
+  func subsequentRunSkipsSeen() async throws {
+    let folder = tempDirectory()
+    try FileManager.default.createDirectory(
+      at: folder, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: folder) }
+    let defaults = UserDefaults(suiteName: "csvscan-\(UUID().uuidString)")!
+    let (_, accountId, scanner, backend) = try await makeStack(
+      watchedFolder: folder, defaults: defaults)
+    let a = folder.appendingPathComponent("one.csv")
+    let oldTime = Date(timeIntervalSinceNow: -300)
+    try writeCSV(at: a, lines: cbaLines(), modified: oldTime)
+
+    await scanner.scanForNewFiles()
+    let firstPage = try await backend.transactions.fetch(
+      filter: TransactionFilter(accountId: accountId), page: 0, pageSize: 50)
+    let firstCount = firstPage.transactions.count
+
+    // Second scan with no new files → nothing changes. Cursor prevents
+    // re-ingest even though dedup would also catch it.
+    await scanner.scanForNewFiles()
+    let secondPage = try await backend.transactions.fetch(
+      filter: TransactionFilter(accountId: accountId), page: 0, pageSize: 50)
+    #expect(secondPage.transactions.count == firstCount)
+  }
+
+  @Test("scanForNewFiles picks up files newer than the cursor")
+  func newerFilesIngested() async throws {
+    let folder = tempDirectory()
+    try FileManager.default.createDirectory(
+      at: folder, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: folder) }
+    let defaults = UserDefaults(suiteName: "csvscan-\(UUID().uuidString)")!
+    let (_, accountId, scanner, backend) = try await makeStack(
+      watchedFolder: folder, defaults: defaults)
+    let a = folder.appendingPathComponent("a.csv")
+    try writeCSV(at: a, lines: cbaLines(), modified: Date(timeIntervalSinceNow: -600))
+    await scanner.scanForNewFiles()
+    let firstPage = try await backend.transactions.fetch(
+      filter: TransactionFilter(accountId: accountId), page: 0, pageSize: 50)
+    let first = firstPage.transactions.count
+
+    // Drop a second file with a strictly newer mtime + distinct data so dedup
+    // doesn't drop it.
+    let b = folder.appendingPathComponent("b.csv")
+    try writeCSV(
+      at: b,
+      lines: [
+        "Date,Description,Debit,Credit,Balance",
+        "04/04/2024,TAXI SYDNEY,-20.00,,950.00",
+      ],
+      modified: Date(timeIntervalSinceNow: -10))
+    await scanner.scanForNewFiles()
+    let secondPage = try await backend.transactions.fetch(
+      filter: TransactionFilter(accountId: accountId), page: 0, pageSize: 50)
+    #expect(secondPage.transactions.count > first)
+  }
+
+  @Test("non-CSV files in the folder are ignored")
+  func nonCSVFilesIgnored() async throws {
+    let folder = tempDirectory()
+    try FileManager.default.createDirectory(
+      at: folder, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: folder) }
+    let defaults = UserDefaults(suiteName: "csvscan-\(UUID().uuidString)")!
+    let (_, accountId, scanner, backend) = try await makeStack(
+      watchedFolder: folder, defaults: defaults)
+    let txt = folder.appendingPathComponent("notes.txt")
+    try writeCSV(
+      at: txt, lines: ["hello"],
+      modified: Date(timeIntervalSinceNow: -10))
+    await scanner.scanForNewFiles()
+    let page = try await backend.transactions.fetch(
+      filter: TransactionFilter(accountId: accountId), page: 0, pageSize: 50)
+    #expect(page.transactions.isEmpty)
+  }
+
+  @Test("scanForNewFiles without a watched folder is a no-op")
+  func noWatchedFolderIsNoOp() async throws {
+    let defaults = UserDefaults(suiteName: "csvscan-\(UUID().uuidString)")!
+    let (backend, _) = try TestBackend.create()
+    let accountId = UUID()
+    _ = try await backend.accounts.create(
+      Account(
+        id: accountId, name: "Scan", type: .bank, instrument: .AUD,
+        positions: [], position: 0, isHidden: false),
+      openingBalance: nil)
+    let staging = try ImportStagingStore(directory: tempDirectory())
+    let store = ImportStore(backend: backend, staging: staging)
+    let preferences = ImportPreferences(directory: tempDirectory())
+    // No setWatchedFolder → nothing to scan.
+    let scanner = FolderScanService(
+      profileId: UUID(),
+      importStore: store,
+      preferences: preferences,
+      defaults: defaults)
+    await scanner.scanForNewFiles()
+    let page = try await backend.transactions.fetch(
+      filter: TransactionFilter(accountId: accountId), page: 0, pageSize: 50)
+    #expect(page.transactions.isEmpty)
+  }
+}

--- a/MoolahTests/Features/Import/ImportStoreTests.swift
+++ b/MoolahTests/Features/Import/ImportStoreTests.swift
@@ -426,6 +426,65 @@ struct ImportStoreTests {
     #expect(FileManager.default.fileExists(atPath: tmp.path) == false)
   }
 
+  @Test("SelfWealth fixture creates two-leg trade transactions end-to-end")
+  func selfWealthFixtureCreatesTwoLegTrades() async throws {
+    let (backend, _) = try TestBackend.create()
+    let accountId = UUID()
+    try await seedAccount(backend, id: accountId, name: "Brokerage")
+    _ = try await seedProfile(
+      backend,
+      accountId: accountId,
+      parser: "selfwealth",
+      signature: ["date", "type", "description", "debit", "credit", "balance"])
+    let (store, dir) = try makeStore(backend: backend)
+    defer { try? FileManager.default.removeItem(at: dir) }
+
+    let data = try CSVFixtureLoader.data("selfwealth-trades")
+    let result = await store.ingest(
+      data: data,
+      source: .pickedFile(
+        url: URL(fileURLWithPath: "/tmp/selfwealth.csv"), securityScoped: false))
+    guard case .imported(_, let imported, _) = result else {
+      Issue.record("expected .imported; got \(result)")
+      return
+    }
+
+    // BHP buy: 2-leg transaction, cash AUD leg -4550.00, position ASX:BHP +100.
+    let bhp = imported.first(where: {
+      $0.importOrigin?.rawDescription.contains("BHP") == true
+        && $0.legs.count == 2
+    })
+    #expect(bhp != nil)
+    if let bhp {
+      let cashLeg = bhp.legs.first(where: { $0.instrument == .AUD })
+      #expect(cashLeg?.quantity == Decimal(string: "-4550.00"))
+      #expect(cashLeg?.type == .expense)
+      let positionLeg = bhp.legs.first(where: { $0.instrument.id == "ASX:BHP" })
+      #expect(positionLeg?.quantity == 100)
+      #expect(positionLeg?.type == .income)
+      #expect(positionLeg?.instrument.kind == .stock)
+    }
+
+    // CBA sell: cash AUD +5512.50, position ASX:CBA -50.
+    let cba = imported.first(where: {
+      $0.importOrigin?.rawDescription.contains("CBA") == true
+    })
+    #expect(cba != nil)
+    if let cba {
+      let cashLeg = cba.legs.first(where: { $0.instrument == .AUD })
+      #expect(cashLeg?.quantity == Decimal(string: "5512.50"))
+      let positionLeg = cba.legs.first(where: { $0.instrument.id == "ASX:CBA" })
+      #expect(positionLeg?.quantity == -50)
+    }
+
+    // Dividend is single-leg AUD income with SW-DIV-<ticker> bank reference.
+    let dividend = imported.first(where: {
+      $0.importOrigin?.rawDescription.contains("DIVIDEND") == true
+    })
+    #expect(dividend?.legs.count == 1)
+    #expect(dividend?.importOrigin?.bankReference == "SW-DIV-BHP")
+  }
+
   @Test("recentSessions carries one entry per successful ingest")
   func recentSessionsPopulated() async throws {
     let (backend, _) = try TestBackend.create()

--- a/MoolahTests/Features/Import/ImportStoreTests.swift
+++ b/MoolahTests/Features/Import/ImportStoreTests.swift
@@ -218,6 +218,72 @@ struct ImportStoreTests {
     #expect(sum == 0)
   }
 
+  // MARK: - Instrument correctness (Rule 11 / Rule 11a)
+
+  @Test("placeholder cash legs are rewritten to the non-AUD target account's instrument")
+  func placeholderLegRewriteNonAUD() async throws {
+    let (backend, _) = try TestBackend.create()
+    let eurAccount = UUID()
+    let eur = Instrument.fiat(code: "EUR")
+    try await seedAccount(backend, id: eurAccount, name: "EUR Bank", instrument: eur)
+    _ = try await seedProfile(backend, accountId: eurAccount)
+
+    let (store, dir) = try makeStore(backend: backend)
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let data = try cbaFixtureBytes()
+    _ = await store.ingest(
+      data: data,
+      source: .pickedFile(url: URL(fileURLWithPath: "/tmp/cba.csv"), securityScoped: false))
+
+    let page = try await backend.transactions.fetch(
+      filter: TransactionFilter(accountId: eurAccount), page: 0, pageSize: 50)
+    #expect(!page.transactions.isEmpty)
+    // Every persisted leg must carry the target account's instrument —
+    // the parser's placeholder .AUD must never survive into persistence.
+    for tx in page.transactions {
+      for leg in tx.legs {
+        #expect(leg.instrument == eur)
+      }
+    }
+  }
+
+  @Test("markAsTransfer across instruments stamps each leg with its own account's instrument")
+  func markAsTransferCrossInstrument() async throws {
+    let (backend, _) = try TestBackend.create()
+    let audSource = UUID()
+    let usdTarget = UUID()
+    try await seedAccount(backend, id: audSource, name: "AUD Source", instrument: .AUD)
+    try await seedAccount(backend, id: usdTarget, name: "USD Target", instrument: .USD)
+    _ = try await seedProfile(backend, accountId: audSource)
+    let rule = ImportRule(
+      name: "Cross-currency transfer",
+      position: 0,
+      conditions: [.descriptionContains(["COFFEE"])],
+      actions: [.markAsTransfer(toAccountId: usdTarget)])
+    _ = try await backend.importRules.create(rule)
+
+    let (store, dir) = try makeStore(backend: backend)
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let data = try cbaFixtureBytes()
+    _ = await store.ingest(
+      data: data,
+      source: .pickedFile(url: URL(fileURLWithPath: "/tmp/cba.csv"), securityScoped: false))
+
+    let page = try await backend.transactions.fetch(
+      filter: TransactionFilter(accountId: audSource), page: 0, pageSize: 50)
+    let coffee = page.transactions.first(where: {
+      $0.importOrigin?.rawDescription == "COFFEE HUT SYDNEY"
+    })!
+    #expect(coffee.legs.count == 2)
+    let sourceLeg = coffee.legs.first(where: { $0.accountId == audSource })!
+    let destinationLeg = coffee.legs.first(where: { $0.accountId == usdTarget })!
+    #expect(sourceLeg.instrument == .AUD)
+    // Rule 11a: destination leg carries the destination account's
+    // instrument, NOT the source's. Without this fix, both legs would
+    // be .AUD and the USD-target account would silently gain an AUD leg.
+    #expect(destinationLeg.instrument == .USD)
+  }
+
   @Test("skip rule drops rows from persistence")
   func rulesSkipDropsRows() async throws {
     let (backend, _) = try TestBackend.create()

--- a/MoolahTests/UITestSupport/UITestSeedHydratorTests.swift
+++ b/MoolahTests/UITestSupport/UITestSeedHydratorTests.swift
@@ -1,0 +1,108 @@
+import Foundation
+import SwiftData
+import XCTest
+
+@testable import Moolah
+
+/// Contract tests for `UITestSeedHydrator` — the code path that
+/// `MoolahApp` uses when launched with `--ui-testing` to populate an
+/// in-memory `ProfileContainerManager` from a named `UITestSeed`.
+///
+/// Hydration logic is deterministic: every call produces records with the
+/// same UUIDs and values taken from `UITestFixtures`, regardless of when it
+/// runs. These tests guard that contract so UI tests can reference fixtures
+/// symbolically without worrying about non-determinism.
+@MainActor
+final class UITestSeedHydratorTests: XCTestCase {
+  private var containerManager: ProfileContainerManager!
+
+  override func setUp() async throws {
+    try await super.setUp()
+    containerManager = try ProfileContainerManager.forTesting()
+  }
+
+  override func tearDown() async throws {
+    containerManager = nil
+    try await super.tearDown()
+  }
+
+  // MARK: - Profile index
+
+  func testHydrateTradeBaselineSeedsTheProfile() throws {
+    _ = try UITestSeedHydrator.hydrate(.tradeBaseline, into: containerManager)
+
+    let context = ModelContext(containerManager.indexContainer)
+    let profiles = try context.fetch(FetchDescriptor<ProfileRecord>())
+    XCTAssertEqual(profiles.count, 1, "expected exactly one seeded profile")
+    let profile = try XCTUnwrap(profiles.first)
+    XCTAssertEqual(profile.id, UITestFixtures.TradeBaseline.profileId)
+    XCTAssertEqual(profile.label, UITestFixtures.TradeBaseline.profileLabel)
+    XCTAssertEqual(profile.currencyCode, UITestFixtures.TradeBaseline.profileCurrencyCode)
+  }
+
+  func testHydrateReturnsSeededProfile() throws {
+    let profile = try UITestSeedHydrator.hydrate(.tradeBaseline, into: containerManager)
+
+    XCTAssertEqual(profile.id, UITestFixtures.TradeBaseline.profileId)
+    XCTAssertEqual(profile.backendType, .cloudKit)
+    XCTAssertEqual(profile.currencyCode, UITestFixtures.TradeBaseline.profileCurrencyCode)
+  }
+
+  // MARK: - Per-profile data
+
+  func testHydrateTradeBaselineSeedsTheAccounts() throws {
+    let profile = try UITestSeedHydrator.hydrate(.tradeBaseline, into: containerManager)
+    let container = try containerManager.container(for: profile.id)
+
+    let context = ModelContext(container)
+    let accounts = try context.fetch(FetchDescriptor<AccountRecord>())
+    XCTAssertEqual(accounts.count, 2, "expected checking + brokerage accounts")
+    let ids = Set(accounts.map(\.id))
+    XCTAssertEqual(
+      ids,
+      [
+        UITestFixtures.TradeBaseline.checkingAccountId,
+        UITestFixtures.TradeBaseline.brokerageAccountId,
+      ]
+    )
+  }
+
+  func testHydrateTradeBaselineSeedsTheTradeTransaction() throws {
+    let profile = try UITestSeedHydrator.hydrate(.tradeBaseline, into: containerManager)
+    let container = try containerManager.container(for: profile.id)
+
+    let context = ModelContext(container)
+    let transactions = try context.fetch(FetchDescriptor<TransactionRecord>())
+    XCTAssertEqual(transactions.count, 1, "expected exactly one seeded transaction")
+    let txn = try XCTUnwrap(transactions.first)
+    XCTAssertEqual(txn.id, UITestFixtures.TradeBaseline.bhpPurchaseId)
+    XCTAssertEqual(txn.payee, UITestFixtures.TradeBaseline.bhpPurchasePayee)
+
+    let legs = try context.fetch(FetchDescriptor<TransactionLegRecord>())
+    XCTAssertEqual(legs.count, 2, "expected two legs on the trade transaction")
+    let accountIds = Set(legs.compactMap(\.accountId))
+    XCTAssertEqual(
+      accountIds,
+      [
+        UITestFixtures.TradeBaseline.checkingAccountId,
+        UITestFixtures.TradeBaseline.brokerageAccountId,
+      ]
+    )
+  }
+
+  // MARK: - Determinism
+
+  func testHydrateIsIdempotentWhenRunTwice() throws {
+    _ = try UITestSeedHydrator.hydrate(.tradeBaseline, into: containerManager)
+    let first = try containerManager.container(for: UITestFixtures.TradeBaseline.profileId)
+    let firstTxnCount = try ModelContext(first).fetch(FetchDescriptor<TransactionRecord>()).count
+
+    // Running hydration again on the same manager should not double-insert.
+    _ = try UITestSeedHydrator.hydrate(.tradeBaseline, into: containerManager)
+    let second = try containerManager.container(for: UITestFixtures.TradeBaseline.profileId)
+    let secondTxnCount = try ModelContext(second).fetch(FetchDescriptor<TransactionRecord>()).count
+
+    XCTAssertEqual(firstTxnCount, 1)
+    XCTAssertEqual(secondTxnCount, 1, "hydration must be idempotent for robust relaunches")
+  }
+}

--- a/MoolahUITests_macOS/SmokeTests.swift
+++ b/MoolahUITests_macOS/SmokeTests.swift
@@ -1,0 +1,32 @@
+import XCTest
+
+/// The first UI test in the new `MoolahUITests_macOS` target: proves the app
+/// can launch with `--ui-testing` and the `UI_TESTING_SEED=tradeBaseline`
+/// environment variable, i.e. the whole PR #4 scaffolding works end-to-end.
+///
+/// Intentionally bare. The proper test-case base class (`MoolahUITestCase`
+/// with failure artefacts and screen drivers) lands in PR #5; real behaviour
+/// tests land in PR #6 and beyond. Keeping the smoke test here gives CI
+/// something to run before the richer infrastructure is in place.
+@MainActor
+final class UITestingLaunchSmokeTests: XCTestCase {
+  override func setUp() async throws {
+    try await super.setUp()
+    continueAfterFailure = false
+  }
+
+  func testAppLaunchesWithTradeBaselineSeed() throws {
+    let app = XCUIApplication()
+    app.launchArguments = ["--ui-testing"]
+    app.launchEnvironment = ["UI_TESTING_SEED": UITestSeed.tradeBaseline.rawValue]
+    app.launch()
+
+    XCTAssertTrue(
+      app.wait(for: .runningForeground, timeout: 10),
+      "Moolah did not reach runningForeground within 10 s of launch"
+    )
+
+    // Terminate cleanly so the next test in the queue gets a fresh process.
+    app.terminate()
+  }
+}

--- a/Shared/CSVImport/GenericBankCSVParser.swift
+++ b/Shared/CSVImport/GenericBankCSVParser.swift
@@ -104,7 +104,8 @@ struct GenericBankCSVParser: CSVParser, Sendable {
         accountId: nil,
         instrument: .AUD,
         quantity: amount,
-        type: amount >= 0 ? .income : .expense)
+        type: amount >= 0 ? .income : .expense,
+        isInstrumentPlaceholder: true)
       let tx = ParsedTransaction(
         date: date,
         legs: [leg],

--- a/Shared/CSVImport/GenericBankCSVParser.swift
+++ b/Shared/CSVImport/GenericBankCSVParser.swift
@@ -43,6 +43,24 @@ struct GenericBankCSVParser: CSVParser, Sendable {
       case .iso: return "yyyy-MM-dd"
       }
     }
+
+    /// Stable string form used to persist the user's override on
+    /// `CSVImportProfile.dateFormatRawValue`. The shape is the
+    /// `DateFormatter` pattern so round-tripping is lossless.
+    var rawValue: String { formatString }
+
+    /// Parse a persisted `dateFormatRawValue` back into a concrete case.
+    /// Returns nil for unknown patterns — callers fall back to auto-detect.
+    static func fromRawValue(_ value: String) -> DateFormat? {
+      switch value {
+      case "dd/MM/yyyy": return .ddMMyyyy(separator: "/")
+      case "dd-MM-yyyy": return .ddMMyyyy(separator: "-")
+      case "MM/dd/yyyy": return .mmDDyyyy(separator: "/")
+      case "MM-dd-yyyy": return .mmDDyyyy(separator: "-")
+      case "yyyy-MM-dd": return .iso
+      default: return nil
+      }
+    }
   }
 
   func recognizes(headers: [String]) -> Bool {
@@ -50,11 +68,40 @@ struct GenericBankCSVParser: CSVParser, Sendable {
   }
 
   func parse(rows: [[String]]) throws -> [ParsedRecord] {
-    guard let headers = rows.first else { throw CSVParserError.emptyFile }
+    try parse(rows: rows, overrideDateFormat: nil)
+  }
+
+  /// Parse variant that lets the caller force the date format (Needs Setup
+  /// form on an ambiguous file). `nil` = auto-detect as normal.
+  func parse(
+    rows: [[String]], overrideDateFormat: DateFormat?
+  ) throws -> [ParsedRecord] {
+    guard !rows.isEmpty, let headers = rows.first else { throw CSVParserError.emptyFile }
     let sample = Array(rows.dropFirst().prefix(5))
-    guard let mapping = inferMapping(from: headers, sampleRows: sample) else {
+    guard var mapping = inferMapping(from: headers, sampleRows: sample) else {
       throw CSVParserError.headerMismatch
     }
+    if let override = overrideDateFormat {
+      mapping.dateFormat = override
+      mapping.dateFormatAmbiguous = false
+    }
+    return try parseRows(rows, with: mapping)
+  }
+
+  /// Parse variant that takes a fully-formed `ColumnMapping` from the Needs
+  /// Setup form — bypasses the detector so the user's role overrides are
+  /// authoritative.
+  func parse(
+    rows: [[String]], overrideMapping: ColumnMapping
+  ) throws -> [ParsedRecord] {
+    guard !rows.isEmpty else { throw CSVParserError.emptyFile }
+    return try parseRows(rows, with: overrideMapping)
+  }
+
+  /// Shared row-loop implementation used by all `parse` variants.
+  private func parseRows(
+    _ rows: [[String]], with mapping: ColumnMapping
+  ) throws -> [ParsedRecord] {
     var results: [ParsedRecord] = []
     for (offset, row) in rows.dropFirst().enumerated() {
       let rowIndex = offset + 1  // 1-based for user-facing error messages

--- a/Shared/CSVImport/ImportSource.swift
+++ b/Shared/CSVImport/ImportSource.swift
@@ -22,6 +22,12 @@ enum ImportSource: Sendable {
   /// name for surfaces like the failed-files panel.
   case paste(text: String, label: String?)
 
+  /// Re-entry for the Needs Setup flow. Preserves the original filename and
+  /// (optional) source URL so `ImportOrigin.sourceFilename` carries the real
+  /// name and `profile.deleteAfterImport` can still honour the toggle after
+  /// the user completes setup.
+  case reingestFromSetup(filename: String, sourceURL: URL?)
+
   /// User-visible filename or paste label for diagnostics and the
   /// `ImportOrigin.sourceFilename` field.
   var filename: String? {
@@ -32,6 +38,8 @@ enum ImportSource: Sendable {
       return url.lastPathComponent
     case .paste(_, let label):
       return label
+    case .reingestFromSetup(let filename, _):
+      return filename
     }
   }
 
@@ -48,6 +56,8 @@ enum ImportSource: Sendable {
     case .pickedFile(let url, _),
       .folderWatch(let url, _),
       .droppedFile(let url, _):
+      return url
+    case .reingestFromSetup(_, let url):
       return url
     case .paste:
       return nil

--- a/Shared/CSVImport/SelfWealthParser.swift
+++ b/Shared/CSVImport/SelfWealthParser.swift
@@ -63,7 +63,8 @@ struct SelfWealthParser: CSVParser, Sendable {
           accountId: nil,
           instrument: .AUD,
           quantity: cashAmount,
-          type: .income)
+          type: .income,
+          isInstrumentPlaceholder: true)
         results.append(
           .transaction(
             ParsedTransaction(
@@ -79,7 +80,8 @@ struct SelfWealthParser: CSVParser, Sendable {
           accountId: nil,
           instrument: .AUD,
           quantity: cashAmount,
-          type: .expense)
+          type: .expense,
+          isInstrumentPlaceholder: true)
         results.append(
           .transaction(
             ParsedTransaction(
@@ -95,7 +97,8 @@ struct SelfWealthParser: CSVParser, Sendable {
           accountId: nil,
           instrument: .AUD,
           quantity: cashAmount,
-          type: cashAmount >= 0 ? .income : .expense)
+          type: cashAmount >= 0 ? .income : .expense,
+          isInstrumentPlaceholder: true)
         results.append(
           .transaction(
             ParsedTransaction(
@@ -215,12 +218,14 @@ struct SelfWealthParser: CSVParser, Sendable {
       accountId: nil,
       instrument: .AUD,
       quantity: cashAmount,
-      type: kind == "BUY" ? .expense : .income)
+      type: kind == "BUY" ? .expense : .income,
+      isInstrumentPlaceholder: true)
     let positionLeg = ParsedLeg(
       accountId: nil,
       instrument: stockInstrument,
       quantity: kind == "BUY" ? quantity : -quantity,
-      type: kind == "BUY" ? .income : .expense)
+      type: kind == "BUY" ? .income : .expense,
+      isInstrumentPlaceholder: false)
     return .transaction(
       ParsedTransaction(
         date: date,

--- a/Shared/FocusedValues.swift
+++ b/Shared/FocusedValues.swift
@@ -66,6 +66,12 @@ struct ImportCSVActionKey: FocusedValueKey {
   typealias Value = () -> Void
 }
 
+/// Trigger action for Edit > Paste CSV (⌥⇧⌘V). Reads tabular text from
+/// the pasteboard and runs it through the ImportStore pipeline.
+struct PasteCSVActionKey: FocusedValueKey {
+  typealias Value = () -> Void
+}
+
 extension FocusedValues {
   var newTransactionAction: NewTransactionActionKey.Value? {
     get { self[NewTransactionActionKey.self] }
@@ -118,5 +124,9 @@ extension FocusedValues {
   var importCSVAction: ImportCSVActionKey.Value? {
     get { self[ImportCSVActionKey.self] }
     set { self[ImportCSVActionKey.self] = newValue }
+  }
+  var pasteCSVAction: PasteCSVActionKey.Value? {
+    get { self[PasteCSVActionKey.self] }
+    set { self[PasteCSVActionKey.self] = newValue }
   }
 }

--- a/Shared/Signposts.swift
+++ b/Shared/Signposts.swift
@@ -4,6 +4,10 @@ enum Signposts {
   static let repository = OSLog(subsystem: "com.moolah.app", category: "Repository")
   static let sync = OSLog(subsystem: "com.moolah.app", category: "Sync")
   static let balance = OSLog(subsystem: "com.moolah.app", category: "Balance")
+  /// Per-stage boundaries for the CSV import pipeline. Instruments traces
+  /// attribute time to `tokenize`, `parse`, `dedup`, `rules`, and the outer
+  /// `ingest` range. See `guides/BENCHMARKING_GUIDE.md`.
+  static let importPipeline = OSLog(subsystem: "com.moolah.app", category: "ImportPipeline")
 }
 
 extension Duration {

--- a/UITestSupport/UITestIdentifiers.swift
+++ b/UITestSupport/UITestIdentifiers.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+/// String identifiers applied via `.accessibilityIdentifier(_:)` in views and
+/// looked up by UI-test drivers via `MoolahApp.element(for:)`.
+///
+/// Compiled into both the main app and the `MoolahUITests_macOS` target so
+/// the two sides reference the same constants — edit in one place.
+///
+/// Naming format: `area.element[.qualifier]`. Lowercase, dot-separated. New
+/// areas extend this enum rather than introducing parallel naming schemes.
+///
+/// Identifiers are added incrementally as drivers and tests need them — see
+/// `guides/UI_TEST_GUIDE.md` §4. The namespaces below are stubs awaiting
+/// entries from the first driver PR.
+public enum UITestIdentifiers {
+  public enum Sidebar {
+    /// Sidebar row for a specific account. `id` is the account's UUID, lowercased.
+    public static func account(_ id: UUID) -> String {
+      "sidebar.account.\(id.uuidString.lowercased())"
+    }
+
+    /// Sidebar row for a named top-level view (e.g. `"upcoming"`, `"analysis"`).
+    public static func view(_ name: String) -> String {
+      "sidebar.view.\(name)"
+    }
+  }
+
+  public enum Detail {
+    // Intentionally empty — populated when TransactionDetailScreen lands.
+  }
+
+  public enum Autocomplete {
+    // Intentionally empty — populated when AutocompleteFieldDriver lands.
+  }
+}

--- a/UITestSupport/UITestSeeds.swift
+++ b/UITestSupport/UITestSeeds.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+/// Named deterministic data sets that the app hydrates from when launched
+/// with the `--ui-testing` argument and `UI_TESTING_SEED` set to the seed's
+/// raw value.
+///
+/// Compiled into both the main app and `MoolahUITests_macOS` so:
+///   - tests select a seed symbolically via `MoolahApp.launch(seed: .tradeBaseline)`,
+///   - the app reads `UI_TESTING_SEED` and hydrates from the matching case,
+///   - drivers reference fixtures (e.g. `UITestFixtures.TradeBaseline.checkingAccountId`)
+///     by the same UUID the app wrote.
+///
+/// Every seed is deterministic: all UUIDs are hard-coded literals and every
+/// entity's name, amount, and date is a constant. The `seed.txt` failure
+/// artefact is generated from this metadata.
+public enum UITestSeed: String, CaseIterable, Sendable {
+  /// A CloudKit-backed profile with a checking account, a brokerage
+  /// investment account, and one trade transaction with two legs. The
+  /// baseline for `TransactionDetailView` tests involving trades.
+  case tradeBaseline
+}
+
+/// Fixed-UUID fixtures used by both the app (when seeding) and UI-test
+/// drivers (when resolving identifiers). Grouping constants by seed family
+/// keeps fixtures local to the scenario that needs them.
+public enum UITestFixtures {
+  /// Fixtures for the `.tradeBaseline` seed.
+  ///
+  /// Entities (all fixed, deterministic):
+  ///   - Profile `personal` — label "Personal", currency AUD, CloudKit-backed.
+  ///   - Account `checking` — "Checking", bank, AUD.
+  ///   - Account `brokerage` — "Brokerage", investment, AUD.
+  ///   - Transaction `bhpPurchase` — trade on 2026-04-01 UTC, payee
+  ///     "BHP Purchase". Two legs in the profile instrument: −5,000.00 AUD
+  ///     from `checking` (expense) and +5,000.00 AUD into `brokerage`
+  ///     (income). A simplified stand-in until cross-instrument trades land.
+  public enum TradeBaseline {
+    public static let profileId = UUID(uuidString: "A1000000-0000-0000-0000-000000000001")!
+    public static let profileLabel = "Personal"
+    public static let profileCurrencyCode = "AUD"
+
+    public static let checkingAccountId = UUID(uuidString: "A1000000-0000-0000-0000-000000000010")!
+    public static let checkingAccountName = "Checking"
+
+    public static let brokerageAccountId = UUID(uuidString: "A1000000-0000-0000-0000-000000000011")!
+    public static let brokerageAccountName = "Brokerage"
+
+    public static let bhpPurchaseId = UUID(uuidString: "A1000000-0000-0000-0000-000000000020")!
+    public static let bhpPurchasePayee = "BHP Purchase"
+    public static let bhpPurchaseAmountCents = 500_000  // 5,000.00 AUD
+    /// 2026-04-01 00:00:00 UTC.
+    public static let bhpPurchaseDate = Date(timeIntervalSince1970: 1_775_001_600)
+  }
+}

--- a/justfile
+++ b/justfile
@@ -67,6 +67,12 @@ test-ios *FILTERS: generate
 benchmark *FILTER: generate
     bash scripts/benchmark.sh {{ FILTER }}
 
+# Run UI tests on native macOS (no simulator). FILTERS work like `test`:
+# pass a class name (e.g. `UITestingLaunchSmokeTests`) or class/method to
+# narrow the run. The MoolahUITests_macOS prefix is added automatically.
+test-ui *FILTERS: generate
+    bash scripts/test-ui.sh {{ FILTERS }}
+
 # Build the app for macOS
 build-mac: generate
     #!/usr/bin/env bash

--- a/project.yml
+++ b/project.yml
@@ -60,6 +60,7 @@ targets:
       - path: Features
       - path: Shared
       - path: Automation
+      - path: UITestSupport
     dependencies:
       - sdk: AppIntents.framework
     settings:
@@ -90,6 +91,7 @@ targets:
       - path: Features
       - path: Shared
       - path: Automation
+      - path: UITestSupport
     dependencies:
       - sdk: AppIntents.framework
     settings:
@@ -161,6 +163,24 @@ targets:
     dependencies:
       - target: Moolah_macOS
 
+  MoolahUITests_macOS:
+    type: bundle.ui-testing
+    platform: macOS
+    sources:
+      - path: MoolahUITests_macOS
+      - path: UITestSupport
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: rocks.moolah.uitests
+        GENERATE_INFOPLIST_FILE: YES
+        CODE_SIGN_IDENTITY: "-"
+        CODE_SIGNING_REQUIRED: YES
+        CODE_SIGNING_ALLOWED: YES
+        ENABLE_HARDENED_RUNTIME: NO
+        TEST_TARGET_NAME: Moolah_macOS
+    dependencies:
+      - target: Moolah_macOS
+
 schemes:
   Moolah:
     build:
@@ -197,3 +217,13 @@ schemes:
       config: Debug-Tests
       targets:
         - MoolahBenchmarks_macOS
+
+  Moolah-macOS-UITests:
+    build:
+      targets:
+        Moolah_macOS: all
+        MoolahUITests_macOS: [test]
+    test:
+      config: Debug-Tests
+      targets:
+        - MoolahUITests_macOS

--- a/scripts/test-ui.sh
+++ b/scripts/test-ui.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Run XCUITest UI tests on native macOS (no simulator).
+#
+# Usage: test-ui.sh [FILTER ...]
+#   FILTERs follow the same convention as scripts/test.sh: pass a class name
+#   (`UITestingLaunchSmokeTests`) or class/method
+#   (`UITestingLaunchSmokeTests/testAppLaunchesWithTradeBaselineSeed`) to
+#   narrow the run. The `MoolahUITests_macOS` prefix is added automatically;
+#   pass a fully-qualified `MoolahUITests_macOS/Class[/method]` form to skip
+#   the prefix.
+#
+# UI tests are macOS-only (see guides/UI_TEST_GUIDE.md §1) and run through
+# the dedicated `Moolah-macOS-UITests` scheme. Output flows directly to the
+# terminal; tee it to `.agent-tmp/test-ui.txt` from the caller if you want to
+# inspect failures without re-running.
+set -euo pipefail
+
+# Disable nested sandboxing when running inside sandvault; xcodebuild creates
+# its own sandbox and fails when already running inside one.
+export SWIFTPM_DISABLE_SANDBOX=1
+export SWIFT_BUILD_USE_SANDBOX=0
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+COMMON_ARGS=(
+    -IDEPackageSupportDisableManifestSandbox=1
+    -IDEPackageSupportDisablePackageSandbox=1
+    'OTHER_SWIFT_FLAGS=$(inherited) -disable-sandbox'
+)
+
+FILTERS=("$@")
+
+filter_flags=()
+for f in ${FILTERS[@]+"${FILTERS[@]}"}; do
+    if [[ "$f" == MoolahUITests_macOS/* ]]; then
+        filter_flags+=("-only-testing:$f")
+    else
+        filter_flags+=("-only-testing:MoolahUITests_macOS/$f")
+    fi
+done
+
+echo "==> Running UI tests on native macOS…"
+xcodebuild test "${COMMON_ARGS[@]}" \
+    -derivedDataPath "$REPO_ROOT/.DerivedData-mac-ui" \
+    -scheme Moolah-macOS-UITests \
+    -destination "platform=macOS" \
+    ${filter_flags[@]+"${filter_flags[@]}"}
+
+echo ""
+echo "==> UI tests passed."


### PR DESCRIPTION
## Summary
- Needs Setup sheet (`CSVImportSetupView` + `CSVImportSetupStore`) with per-column role pickers, date-format override, and live preview.
- Full rules UI — Mail.app-shaped rules list, rule editor with UUID-keyed Condition/Action rows, "Create rule from this transaction" sheet with distinguishing tokens, live-preview count.
- macOS folder watch (FSEvents + security-scoped bookmark) + iOS launch/foreground scan with per-profile cursor.
- Paste CSV menu item (⌥⇧⌘V) + account-row drop destination for forced routing.
- Settings → Import and Settings → Rules tabs.
- Import pipeline benchmarks.

## Fixes flowing out of sync-review / instrument-conversion-review / ui-review
- Rule 11a: `markAsTransfer` destination leg now stamped with the destination account's instrument, not the source's.
- Placeholder-instrument rewrite verified against non-AUD accounts (new tests).
- `CSVImportSetupStore` seeds `columnRoles` from the detected mapping and derives `effectiveMapping()` purely from roles; `.ignore` on a detector-picked column actually unmaps it, and multiple `.ignore` columns are allowed.
- `RecentlyAddedView` auto-refreshes after `finishSetup`.
- UUID-keyed Condition/Action rows in `RuleEditorView` eliminate index-drift bugs on mid-list delete.
- Accessibility + monospacedDigit pass on Recently Added, rules editor, folder settings.
- macOS minimum frames on setup + rule editor sheets; destructive Delete moved out of the toolbar.
- Settings tabs drop the double `NavigationStack` wrapper.

## Test plan
- [x] `just test` — iOS 1433 tests, macOS 1449 tests, all green.
- [x] `just format-check` — all Swift files correctly formatted.
- [x] New tests cover placeholder rewrite into a non-AUD account and cross-instrument `markAsTransfer`.
- [x] CSVImportSetupStore role-override + preview regression test in place.
- [ ] Smoke-test the Needs Setup sheet in the macOS app with a real CBA CSV.
- [ ] Smoke-test folder watch on macOS (Downloads) with delete-after-import.
- [ ] Smoke-test Paste CSV from clipboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)