### PR TITLE
fix(ui-testing): keep derived data out of Documents to silence TCC prompts

### DIFF
--- a/scripts/test-ui.sh
+++ b/scripts/test-ui.sh
@@ -40,18 +40,21 @@ for f in ${FILTERS[@]+"${FILTERS[@]}"}; do
 done
 
 echo "==> Running UI tests on native macOS…"
-# Capture xcodebuild output in a tmpfile so we can both print it live and
-# scan it afterwards for ARTEFACT_DIR lines emitted by MoolahUITestCase
-# when a test fails. The runner is sandboxed and cannot write directly to
-# the worktree's `.agent-tmp/`, so artefacts land under
-# `$TMPDIR/MoolahUITests/`. We copy them back here so subsequent agent
-# inspection (and CI uploads) can find them in the conventional location.
+# Use derived data outside the developer's Documents folder so xcodebuild
+# does not re-trigger the macOS TCC Documents-access prompt on every
+# binary re-sign. CI overrides via the DERIVED_DATA_PATH env var.
+DERIVED_DATA_PATH="${DERIVED_DATA_PATH:-/tmp/moolah-derived-data-ui}"
+mkdir -p "$DERIVED_DATA_PATH"
+
+# Capture xcodebuild output so we can both print it live and scan it for
+# `[MoolahUITestCase] ARTEFACT_DIR` lines on failure (the runner is
+# sandboxed and writes artefacts to /private/tmp/MoolahUITests/...).
 LOG_FILE="$(mktemp)"
 trap 'rm -f "$LOG_FILE"' EXIT
 
 set +e
 xcodebuild test "${COMMON_ARGS[@]}" \
-    -derivedDataPath "$REPO_ROOT/.DerivedData-mac-ui" \
+    -derivedDataPath "$DERIVED_DATA_PATH" \
     -scheme Moolah-macOS-UITests \
     -destination "platform=macOS" \
     ${filter_flags[@]+"${filter_flags[@]}"} \


### PR DESCRIPTION
## Summary

Every binary re-sign by `xcodebuild` was re-triggering the macOS TCC prompt for Documents-folder access because `scripts/test-ui.sh` was passing `<worktree>/.DerivedData-mac-ui` as the derived-data path — and the worktree lives inside the developer's Documents tree.

Move the default to `/tmp/moolah-derived-data-ui/` so prompts stop. CI overrides via the `DERIVED_DATA_PATH` env var if it wants the data inside the workspace.

This complements PR #8's `ui-test` job — together they make `just test-ui` survivable both locally (no per-binary TCC prompts) and in CI (own derived-data path).

## Test plan

- [x] `just test-ui TransactionDetailFocusTests` passes (~14 s) using the new path.
- [x] `just format-check` clean.
- [ ] After merge: confirm Documents prompts stop on subsequent local UI test runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)