### PR TITLE
feat(ui-testing): payee autocomplete test suite

### DIFF
--- a/App/UITestSeedHydrator.swift
+++ b/App/UITestSeedHydrator.swift
@@ -84,6 +84,21 @@ enum UITestSeedHydrator {
       in: context
     )
 
+    let historicalAmount = InstrumentAmount(
+      quantity: Decimal(fixtures.historicalExpenseAmountCents) / 100,
+      instrument: instrument
+    )
+    for historical in fixtures.historicalPayees {
+      try upsertHistoricalExpense(
+        id: historical.id,
+        payee: historical.payee,
+        date: historical.date,
+        amount: historicalAmount,
+        accountId: fixtures.checkingAccountId,
+        in: context
+      )
+    }
+
     try context.save()
     return profile
   }
@@ -185,6 +200,36 @@ enum UITestSeedHydrator {
         quantity: amount.storageValue,
         type: TransactionType.transfer.rawValue,
         sortOrder: 1
+      )
+    )
+  }
+
+  private static func upsertHistoricalExpense(
+    id: UUID,
+    payee: String,
+    date: Date,
+    amount: InstrumentAmount,
+    accountId: UUID,
+    in context: ModelContext
+  ) throws {
+    let targetId = id
+    let descriptor = FetchDescriptor<TransactionRecord>(
+      predicate: #Predicate { $0.id == targetId }
+    )
+    if try context.fetch(descriptor).first != nil { return }
+
+    let txn = TransactionRecord(id: id, date: date, payee: payee)
+    context.insert(txn)
+
+    let outgoing = InstrumentAmount(quantity: -amount.quantity, instrument: amount.instrument)
+    context.insert(
+      TransactionLegRecord(
+        transactionId: id,
+        accountId: accountId,
+        instrumentId: amount.instrument.id,
+        quantity: outgoing.storageValue,
+        type: TransactionType.expense.rawValue,
+        sortOrder: 0
       )
     )
   }

--- a/Features/Transactions/Views/TransactionDetailView.swift
+++ b/Features/Transactions/Views/TransactionDetailView.swift
@@ -17,6 +17,10 @@ struct TransactionDetailView: View {
   @State private var showDeleteConfirmation = false
   @State private var showPayeeSuggestions = false
   @State private var payeeHighlightedIndex: Int?
+  /// Mirrors `categoryJustSelected` — set when a payee is accepted so the
+  /// resulting `onTextChange` (from binding update) does not immediately
+  /// re-open the dropdown and re-trigger a prefix fetch.
+  @State private var payeeJustSelected = false
   @State private var showCategorySuggestions = false
   @State private var categoryHighlightedIndex: Int?
   @State private var categoryJustSelected = false
@@ -328,6 +332,7 @@ struct TransactionDetailView: View {
           searchText: draft.payee,
           highlightedIndex: $payeeHighlightedIndex,
           onSelect: { selected in
+            payeeJustSelected = true
             showPayeeSuggestions = false
             payeeHighlightedIndex = nil
             draft.payee = selected
@@ -378,8 +383,12 @@ struct TransactionDetailView: View {
         highlightedIndex: $payeeHighlightedIndex,
         suggestionCount: payeeVisibleSuggestionCount,
         onTextChange: { newValue in
-          showPayeeSuggestions = !newValue.isEmpty
-          transactionStore.fetchPayeeSuggestions(prefix: newValue)
+          if payeeJustSelected {
+            payeeJustSelected = false
+          } else {
+            showPayeeSuggestions = !newValue.isEmpty
+            transactionStore.fetchPayeeSuggestions(prefix: newValue)
+          }
         },
         onAcceptHighlighted: acceptHighlightedPayee
       )
@@ -515,8 +524,12 @@ struct TransactionDetailView: View {
         highlightedIndex: $payeeHighlightedIndex,
         suggestionCount: payeeVisibleSuggestionCount,
         onTextChange: { newValue in
-          showPayeeSuggestions = !newValue.isEmpty
-          transactionStore.fetchPayeeSuggestions(prefix: newValue)
+          if payeeJustSelected {
+            payeeJustSelected = false
+          } else {
+            showPayeeSuggestions = !newValue.isEmpty
+            transactionStore.fetchPayeeSuggestions(prefix: newValue)
+          }
         },
         onAcceptHighlighted: acceptHighlightedPayee
       )
@@ -795,6 +808,7 @@ struct TransactionDetailView: View {
   private func acceptHighlightedPayee() {
     guard let index = payeeHighlightedIndex, index < payeeVisibleSuggestions.count else { return }
     let selected = payeeVisibleSuggestions[index]
+    payeeJustSelected = true
     showPayeeSuggestions = false
     payeeHighlightedIndex = nil
     draft.payee = selected

--- a/MoolahTests/UITestSupport/UITestSeedHydratorTests.swift
+++ b/MoolahTests/UITestSupport/UITestSeedHydratorTests.swift
@@ -72,13 +72,22 @@ final class UITestSeedHydratorTests: XCTestCase {
     let container = try containerManager.container(for: profile.id)
 
     let context = ModelContext(container)
-    let transactions = try context.fetch(FetchDescriptor<TransactionRecord>())
-    XCTAssertEqual(transactions.count, 1, "expected exactly one seeded transaction")
-    let txn = try XCTUnwrap(transactions.first)
-    XCTAssertEqual(txn.id, UITestFixtures.TradeBaseline.bhpPurchaseId)
-    XCTAssertEqual(txn.payee, UITestFixtures.TradeBaseline.bhpPurchasePayee)
+    let tradeId = UITestFixtures.TradeBaseline.bhpPurchaseId
+    let trade = try XCTUnwrap(
+      try context.fetch(
+        FetchDescriptor<TransactionRecord>(
+          predicate: #Predicate { $0.id == tradeId }
+        )
+      ).first,
+      "trade transaction must exist"
+    )
+    XCTAssertEqual(trade.payee, UITestFixtures.TradeBaseline.bhpPurchasePayee)
 
-    let legs = try context.fetch(FetchDescriptor<TransactionLegRecord>())
+    let legs = try context.fetch(
+      FetchDescriptor<TransactionLegRecord>(
+        predicate: #Predicate { $0.transactionId == tradeId }
+      )
+    )
     XCTAssertEqual(legs.count, 2, "expected two legs on the trade transaction")
     let accountIds = Set(legs.compactMap(\.accountId))
     XCTAssertEqual(
@@ -88,6 +97,41 @@ final class UITestSeedHydratorTests: XCTestCase {
         UITestFixtures.TradeBaseline.brokerageAccountId,
       ]
     )
+  }
+
+  func testHydrateTradeBaselineSeedsTheHistoricalPayees() throws {
+    let profile = try UITestSeedHydrator.hydrate(.tradeBaseline, into: containerManager)
+    let container = try containerManager.container(for: profile.id)
+
+    let context = ModelContext(container)
+    let historicalIds = Set(UITestFixtures.TradeBaseline.historicalPayees.map(\.id))
+    let allTransactions = try context.fetch(FetchDescriptor<TransactionRecord>())
+    let historicals = allTransactions.filter { historicalIds.contains($0.id) }
+    XCTAssertEqual(
+      historicals.count,
+      UITestFixtures.TradeBaseline.historicalPayees.count,
+      "expected every historical payee to be seeded"
+    )
+
+    let payees = historicals.compactMap(\.payee).sorted()
+    XCTAssertEqual(
+      payees,
+      ["Coles", "Woolworths", "Woolworths", "Woolworths Metro"],
+      "historical payees must match fixture list exactly"
+    )
+
+    // Each historical has exactly one expense leg on Checking.
+    for historical in historicals {
+      let txnId = historical.id
+      let legs = try context.fetch(
+        FetchDescriptor<TransactionLegRecord>(
+          predicate: #Predicate { $0.transactionId == txnId }
+        )
+      )
+      XCTAssertEqual(legs.count, 1, "historical \(historical.payee ?? "?") should have 1 leg")
+      XCTAssertEqual(legs.first?.accountId, UITestFixtures.TradeBaseline.checkingAccountId)
+      XCTAssertEqual(legs.first?.type, TransactionType.expense.rawValue)
+    }
   }
 
   // MARK: - Determinism
@@ -102,7 +146,8 @@ final class UITestSeedHydratorTests: XCTestCase {
     let second = try containerManager.container(for: UITestFixtures.TradeBaseline.profileId)
     let secondTxnCount = try ModelContext(second).fetch(FetchDescriptor<TransactionRecord>()).count
 
-    XCTAssertEqual(firstTxnCount, 1)
-    XCTAssertEqual(secondTxnCount, 1, "hydration must be idempotent for robust relaunches")
+    let expected = 1 + UITestFixtures.TradeBaseline.historicalPayees.count
+    XCTAssertEqual(firstTxnCount, expected)
+    XCTAssertEqual(secondTxnCount, expected, "hydration must be idempotent for robust relaunches")
   }
 }

--- a/MoolahUITests_macOS/Helpers/Fields/AutocompleteFieldDriver.swift
+++ b/MoolahUITests_macOS/Helpers/Fields/AutocompleteFieldDriver.swift
@@ -64,22 +64,98 @@ struct AutocompleteFieldDriver {
     XCTFail("Autocomplete field value did not contain '\(text)' within 3s")
   }
 
-  /// Sends a single arrow-down key press to the field.
+  /// Clears any existing text in the field via Cmd+A then backspace.
+  /// Returns once the field's reported value is empty. Use before `type`
+  /// when the field was pre-populated (e.g. editing an existing payee) or
+  /// inside a test that asserts "clearing hides the dropdown".
+  func clear() {
+    Trace.record(detail: "field=\(fieldIdentifier)")
+    let field = app.element(for: fieldIdentifier)
+    if !field.waitForExistence(timeout: 3) {
+      Trace.recordFailure("field '\(fieldIdentifier)' did not appear for clear")
+      XCTFail("Autocomplete field '\(fieldIdentifier)' did not appear within 3s")
+      return
+    }
+    field.click()
+    app.application.typeKey("a", modifierFlags: .command)
+    app.application.typeKey(XCUIKeyboardKey.delete, modifierFlags: [])
+
+    let deadline = Date().addingTimeInterval(3)
+    while Date() < deadline {
+      if let value = field.value as? String, value.isEmpty { return }
+      RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+    }
+    Trace.recordFailure("field did not empty after clear")
+    XCTFail("Autocomplete field '\(fieldIdentifier)' did not clear within 3s")
+  }
+
+  /// Sends a single arrow-down key press to the field. Returns once the
+  /// dropdown reports a highlighted row (any suggestion with `isSelected`).
+  /// Caller is expected to ensure the dropdown is visible — the
+  /// `.downArrow` handler in `AutocompleteField` is guarded on
+  /// `suggestionCount > 0`, so arrow-down with no suggestions is a no-op.
   func pressArrowDown() {
     Trace.record(detail: "field=\(fieldIdentifier)")
     app.application.typeKey(.downArrow, modifierFlags: [])
+    if !waitUntilAnySuggestionSelected(timeout: 3) {
+      Trace.recordFailure("arrow-down did not produce any highlighted suggestion")
+      XCTFail(
+        "Autocomplete dropdown '\(dropdownIdentifier)' had no highlighted suggestion "
+          + "within 3s of arrow-down")
+    }
   }
 
-  /// Sends a single Return key press to the field.
+  /// Sends a single Return key press to the field. Returns once the
+  /// dropdown has hidden (the selection was committed and the overlay
+  /// dismissed).
   func pressEnter() {
     Trace.record(detail: "field=\(fieldIdentifier)")
     app.application.typeKey(.return, modifierFlags: [])
+    if !waitUntilDropdownHidden(timeout: 3) {
+      Trace.recordFailure("dropdown '\(dropdownIdentifier)' did not hide after Return")
+      XCTFail(
+        "Autocomplete dropdown '\(dropdownIdentifier)' did not hide within 3s of Return")
+    }
   }
 
-  /// Sends a single Escape key press to the field.
+  /// Sends a single Escape key press to the field. Returns once the
+  /// dropdown has hidden. `AutocompleteField`'s escape handler also clears
+  /// the field binding — tests that care assert the value separately.
   func pressEscape() {
     Trace.record(detail: "field=\(fieldIdentifier)")
     app.application.typeKey(.escape, modifierFlags: [])
+    if !waitUntilDropdownHidden(timeout: 3) {
+      Trace.recordFailure("dropdown '\(dropdownIdentifier)' did not hide after Escape")
+      XCTFail(
+        "Autocomplete dropdown '\(dropdownIdentifier)' did not hide within 3s of Escape")
+    }
+  }
+
+  // MARK: - Internal: post-condition waits
+
+  private func waitUntilDropdownHidden(timeout: TimeInterval) -> Bool {
+    let dropdown = app.element(for: dropdownIdentifier)
+    let deadline = Date().addingTimeInterval(timeout)
+    while Date() < deadline {
+      if !dropdown.exists { return true }
+      RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+    }
+    return false
+  }
+
+  private func waitUntilAnySuggestionSelected(timeout: TimeInterval) -> Bool {
+    let deadline = Date().addingTimeInterval(timeout)
+    while Date() < deadline {
+      var index = 0
+      while app.element(for: suggestionIdentifier(index)).exists {
+        let suggestion = app.element(for: suggestionIdentifier(index))
+        if (suggestion.value(forKey: "isSelected") as? Bool) ?? false { return true }
+        index += 1
+        if index > 200 { break }
+      }
+      RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+    }
+    return false
   }
 
   // MARK: - Expectations (read-only)
@@ -99,7 +175,9 @@ struct AutocompleteFieldDriver {
     }
   }
 
-  /// Asserts the field's current value equals `expected`.
+  /// Asserts the field's current value equals `expected`. Polls for up
+  /// to 3 s — bindings from `onChange(of: text)` can lag a frame behind
+  /// the key event that triggered them.
   func expectValue(_ expected: String) {
     let field = app.element(for: fieldIdentifier)
     if !field.waitForExistence(timeout: 3) {
@@ -107,11 +185,15 @@ struct AutocompleteFieldDriver {
       XCTFail("Autocomplete field '\(fieldIdentifier)' did not appear within 3s")
       return
     }
-    let actual = (field.value as? String) ?? ""
-    if actual != expected {
-      Trace.recordFailure("field value '\(actual)' != '\(expected)'")
-      XCTFail("Autocomplete field expected value '\(expected)', got '\(actual)'")
+    let deadline = Date().addingTimeInterval(3)
+    var lastActual = ""
+    while Date() < deadline {
+      lastActual = (field.value as? String) ?? ""
+      if lastActual == expected { return }
+      RunLoop.current.run(until: Date().addingTimeInterval(0.05))
     }
+    Trace.recordFailure("field value '\(lastActual)' != '\(expected)'")
+    XCTFail("Autocomplete field expected value '\(expected)', got '\(lastActual)'")
   }
 
   /// Asserts the autocomplete dropdown is currently visible and contains
@@ -154,7 +236,9 @@ struct AutocompleteFieldDriver {
     XCTFail("Autocomplete dropdown '\(dropdownIdentifier)' did not hide within 3s")
   }
 
-  /// Asserts the suggestion at `index` is currently highlighted.
+  /// Asserts the suggestion at `index` is currently highlighted. Polls
+  /// for up to 3 s so the assertion tolerates a frame of lag between the
+  /// key event and SwiftUI's `highlightedIndex` update.
   func expectHighlightedSuggestion(at index: Int) {
     let identifier = suggestionIdentifier(index)
     let suggestion = app.element(for: identifier)
@@ -163,10 +247,12 @@ struct AutocompleteFieldDriver {
       XCTFail("Autocomplete suggestion at index \(index) did not appear within 3s")
       return
     }
-    let isSelected = (suggestion.value(forKey: "isSelected") as? Bool) ?? false
-    if !isSelected {
-      Trace.recordFailure("suggestion '\(identifier)' is not highlighted")
-      XCTFail("Autocomplete suggestion at index \(index) is not highlighted")
+    let deadline = Date().addingTimeInterval(3)
+    while Date() < deadline {
+      if (suggestion.value(forKey: "isSelected") as? Bool) ?? false { return }
+      RunLoop.current.run(until: Date().addingTimeInterval(0.05))
     }
+    Trace.recordFailure("suggestion '\(identifier)' is not highlighted")
+    XCTFail("Autocomplete suggestion at index \(index) is not highlighted within 3s")
   }
 }

--- a/MoolahUITests_macOS/Helpers/MoolahUITestCase.swift
+++ b/MoolahUITests_macOS/Helpers/MoolahUITestCase.swift
@@ -152,17 +152,17 @@ class MoolahUITestCase: XCTestCase {
     attachArtefacts(in: dir)
   }
 
-  /// Resolves `/private/tmp/MoolahUITests/ui-fail-<TestName>/`.
+  /// Resolves `<runner tmpdir>/MoolahUITests/ui-fail-<TestName>/`.
   ///
-  /// The XCUITest runner is sandboxed and cannot write to the developer's
-  /// `Documents` folder; `NSTemporaryDirectory()` returns the runner's
-  /// container-private tmp dir, which the host shell can only read with
-  /// extra TCC prompts. `/private/tmp/` is the system-wide tmp folder,
-  /// readable and writable by both the sandboxed runner and the host
-  /// shell without any TCC interaction. `scripts/test-ui.sh` greps the
-  /// `[MoolahUITestCase] ARTEFACT_DIR` lines out of xcodebuild's stdout
-  /// and copies each artefact dir back into `<repo-root>/.agent-tmp/`
-  /// after `xcodebuild test` exits.
+  /// The XCUITest runner runs in a stricter sandbox than the app: writes
+  /// to `/private/tmp/` fail with "Operation not permitted" on current
+  /// macOS. `FileManager.default.temporaryDirectory` resolves to the
+  /// runner's own per-process tmpdir under `/var/folders/.../T/` which
+  /// the runner can freely create inside and the developer's shell can
+  /// still read (same uid) without TCC prompts. `scripts/test-ui.sh`
+  /// greps the `[MoolahUITestCase] ARTEFACT_DIR` lines out of
+  /// xcodebuild's stdout and copies each artefact dir back into
+  /// `<repo-root>/.agent-tmp/` after `xcodebuild test` exits.
   private func artefactDirectory(for testName: String) -> URL {
     let cleanName =
       testName
@@ -170,7 +170,7 @@ class MoolahUITestCase: XCTestCase {
       .replacingOccurrences(of: "[", with: "")
       .replacingOccurrences(of: "]", with: "")
       .replacingOccurrences(of: " ", with: "_")
-    return URL(fileURLWithPath: "/private/tmp", isDirectory: true)
+    return FileManager.default.temporaryDirectory
       .appendingPathComponent("MoolahUITests", isDirectory: true)
       .appendingPathComponent("ui-fail-\(cleanName)", isDirectory: true)
   }
@@ -245,6 +245,13 @@ class MoolahUITestCase: XCTestCase {
       lines.append("trade.payee     = \(f.bhpPurchasePayee)")
       lines.append("trade.cents     = \(f.bhpPurchaseAmountCents)")
       lines.append("trade.date      = \(f.bhpPurchaseDate)")
+      lines.append("historical.amount.cents = \(f.historicalExpenseAmountCents)")
+      for (index, historical) in f.historicalPayees.enumerated() {
+        lines.append(
+          "historical[\(index)].id/payee/date = "
+            + "\(historical.id) / \(historical.payee) / \(historical.date)"
+        )
+      }
     }
     return lines.joined(separator: "\n") + "\n"
   }

--- a/MoolahUITests_macOS/Tests/TransactionDetail/TransactionDetailPayeeAutocompleteTests.swift
+++ b/MoolahUITests_macOS/Tests/TransactionDetail/TransactionDetailPayeeAutocompleteTests.swift
@@ -1,0 +1,71 @@
+import XCTest
+
+/// Behaviour tests for the payee autocomplete dropdown on
+/// `TransactionDetailView`. Covers: show on typing, hide on clearing,
+/// arrow-key highlight + Return commit, and Escape reset. The `.tradeBaseline`
+/// seed includes historical expenses with prefix "Wool" (Woolworths ×2,
+/// Woolworths Metro ×1) plus a Coles expense and the BHP trade so every
+/// prefix has a deterministic result set.
+@MainActor
+final class TransactionDetailPayeeAutocompleteTests: MoolahUITestCase {
+  func testTypingPrefixShowsDropdown() {
+    let app = launch(seed: .tradeBaseline)
+
+    app.sidebar.switchToAccount(.checking)
+    app.transactionList.openTransaction(.bhpPurchase)
+    app.transactionDetail.payee.tap()
+    app.transactionDetail.payee.clear()
+    app.transactionDetail.payee.type("Wool")
+
+    app.transactionDetail.payee.expectSuggestionsVisible(count: 2)
+  }
+
+  func testClearingFieldHidesDropdown() {
+    let app = launch(seed: .tradeBaseline)
+
+    app.sidebar.switchToAccount(.checking)
+    app.transactionList.openTransaction(.bhpPurchase)
+    app.transactionDetail.payee.tap()
+    app.transactionDetail.payee.clear()
+    app.transactionDetail.payee.type("Wool")
+    app.transactionDetail.payee.expectSuggestionsVisible(count: 2)
+
+    app.transactionDetail.payee.clear()
+
+    app.transactionDetail.payee.expectSuggestionsHidden()
+  }
+
+  func testArrowDownThenReturnSelectsFirstSuggestion() {
+    let app = launch(seed: .tradeBaseline)
+
+    app.sidebar.switchToAccount(.checking)
+    app.transactionList.openTransaction(.bhpPurchase)
+    app.transactionDetail.payee.tap()
+    app.transactionDetail.payee.clear()
+    app.transactionDetail.payee.type("Wool")
+    app.transactionDetail.payee.expectSuggestionsVisible(count: 2)
+
+    app.transactionDetail.payee.pressArrowDown()
+    app.transactionDetail.payee.expectHighlightedSuggestion(at: 0)
+    app.transactionDetail.payee.pressEnter()
+
+    app.transactionDetail.payee.expectValue("Woolworths")
+    app.transactionDetail.payee.expectSuggestionsHidden()
+  }
+
+  func testEscapeClearsPayeeAndClosesDropdown() {
+    let app = launch(seed: .tradeBaseline)
+
+    app.sidebar.switchToAccount(.checking)
+    app.transactionList.openTransaction(.bhpPurchase)
+    app.transactionDetail.payee.tap()
+    app.transactionDetail.payee.clear()
+    app.transactionDetail.payee.type("Wool")
+    app.transactionDetail.payee.expectSuggestionsVisible(count: 2)
+
+    app.transactionDetail.payee.pressEscape()
+
+    app.transactionDetail.payee.expectValue("")
+    app.transactionDetail.payee.expectSuggestionsHidden()
+  }
+}

--- a/Shared/Views/AutocompleteField.swift
+++ b/Shared/Views/AutocompleteField.swift
@@ -43,7 +43,10 @@ struct AutocompleteField: View {
         .onKeyPress(.escape) {
           guard suggestionCount > 0 else { return .ignored }
           highlightedIndex = nil
-          onTextChange("")
+          // Clear the binding directly — `.onChange(of: text)` will fire
+          // `onTextChange("")` as a side effect, propagating dropdown
+          // dismissal to the consumer.
+          text = ""
           return .handled
         }
       #endif
@@ -109,6 +112,12 @@ struct AutocompleteSuggestionDropdown<Item: Identifiable>: View {
         .stroke(.separator, lineWidth: 0.5)
     )
     .compositingGroup()
+    // `children: .contain` keeps the container addressable (with its
+    // suggestion-count label for VoiceOver and its wrapper identifier for
+    // UI tests) while still exposing each row as its own accessibility
+    // element. Without this, SwiftUI flattens the VStack into a single
+    // leaf when a label is attached, hiding the rows.
+    .accessibilityElement(children: .contain)
     .accessibilityLabel("\(min(items.count, 8)) suggestions")
   }
 
@@ -143,6 +152,7 @@ struct AutocompleteSuggestionDropdown<Item: Identifiable>: View {
       }
     #endif
     .accessibilityLabel("Suggestion: \(label(item))")
+    .accessibilityAddTraits(highlightedIndex == index ? [.isSelected] : [])
     .accessibilityIdentifier(rowIdentifier?(index) ?? "")
   }
 

--- a/UITestSupport/UITestSeeds.swift
+++ b/UITestSupport/UITestSeeds.swift
@@ -15,9 +15,24 @@ import Foundation
 /// artefact is generated from this metadata.
 public enum UITestSeed: String, CaseIterable, Sendable {
   /// A CloudKit-backed profile with a checking account, a brokerage
-  /// investment account, and one trade transaction with two legs. The
-  /// baseline for `TransactionDetailView` tests involving trades.
+  /// investment account, one trade transaction with two legs, and a
+  /// handful of historical expenses with repeated payees. The baseline
+  /// for `TransactionDetailView` tests covering focus, payee
+  /// autocomplete, and cross-currency.
   case tradeBaseline
+}
+
+/// A past single-leg expense used to seed payee suggestions.
+public struct UITestHistoricalExpense: Sendable {
+  public let id: UUID
+  public let payee: String
+  public let date: Date
+
+  public init(id: UUID, payee: String, date: Date) {
+    self.id = id
+    self.payee = payee
+    self.date = date
+  }
 }
 
 /// Fixed-UUID fixtures used by both the app (when seeding) and UI-test
@@ -34,6 +49,10 @@ public enum UITestFixtures {
   ///     "BHP Purchase". Two legs in the profile instrument: −5,000.00 AUD
   ///     from `checking` (expense) and +5,000.00 AUD into `brokerage`
   ///     (income). A simplified stand-in until cross-instrument trades land.
+  ///   - `historicalPayees` — four single-leg expenses from `checking` that
+  ///     give `fetchPayeeSuggestions` something to match against. "Woolworths"
+  ///     occurs twice so it sorts strictly above single-occurrence payees
+  ///     regardless of dictionary iteration order.
   public enum TradeBaseline {
     public static let profileId = UUID(uuidString: "A1000000-0000-0000-0000-000000000001")!
     public static let profileLabel = "Personal"
@@ -50,5 +69,36 @@ public enum UITestFixtures {
     public static let bhpPurchaseAmountCents = 500_000  // 5,000.00 AUD
     /// 2026-04-01 00:00:00 UTC.
     public static let bhpPurchaseDate = Date(timeIntervalSince1970: 1_775_001_600)
+
+    /// Cents moved by every historical expense. Kept identical across the
+    /// list so tests that care only about payee text don't encode amounts.
+    public static let historicalExpenseAmountCents = 5_000  // 50.00 AUD
+
+    /// Four historical expense transactions from `checking`, ordered by
+    /// date. Payee frequency is the only axis `fetchPayeeSuggestions` sorts
+    /// on; "Woolworths" appears twice so it ranks strictly above
+    /// "Woolworths Metro" for the prefix "Wool".
+    public static let historicalPayees: [UITestHistoricalExpense] = [
+      UITestHistoricalExpense(
+        id: UUID(uuidString: "A1000000-0000-0000-0000-000000000030")!,
+        payee: "Coles",
+        date: Date(timeIntervalSince1970: 1_772_668_800)  // 2026-03-05 UTC
+      ),
+      UITestHistoricalExpense(
+        id: UUID(uuidString: "A1000000-0000-0000-0000-000000000031")!,
+        payee: "Woolworths",
+        date: Date(timeIntervalSince1970: 1_773_100_800)  // 2026-03-10 UTC
+      ),
+      UITestHistoricalExpense(
+        id: UUID(uuidString: "A1000000-0000-0000-0000-000000000032")!,
+        payee: "Woolworths Metro",
+        date: Date(timeIntervalSince1970: 1_773_532_800)  // 2026-03-15 UTC
+      ),
+      UITestHistoricalExpense(
+        id: UUID(uuidString: "A1000000-0000-0000-0000-000000000033")!,
+        payee: "Woolworths",
+        date: Date(timeIntervalSince1970: 1_773_964_800)  // 2026-03-20 UTC
+      ),
+    ]
   }
 }


### PR DESCRIPTION
## Summary

Adds the four remaining `TransactionDetailView` behaviour tests from the v1 UI-testing spec (`plans/2026-04-20-ui-testing-strategy-design.md` § Scope):

1. Typing a prefix into payee shows the autocomplete dropdown.
2. Clearing the field hides the dropdown.
3. Arrow-down + Return commits the highlighted suggestion.
4. Escape clears the payee text and closes the dropdown.

Along with the test-infrastructure and product-side observability fixes needed to make those tests reliable.

### Seed + driver

- `.tradeBaseline` gains four fixed-UUID historical expenses (Coles, Woolworths ×2, Woolworths Metro) so `fetchPayeeSuggestions` has matching prefix data. "Woolworths" appears twice so it sorts strictly above "Woolworths Metro" regardless of dictionary iteration order. `seed.txt` enumerates the historicals for failure artefacts.
- `AutocompleteFieldDriver` gains `clear()` and bounded post-condition waits on `pressArrowDown` / `pressEnter` / `pressEscape`. `expectValue` and `expectHighlightedSuggestion` poll instead of reading once, so a one-frame SwiftUI update lag no longer races the assertion.

### Artefact path fix

- Artefact directory switched from `/private/tmp/MoolahUITests/...` to `FileManager.default.temporaryDirectory`. The xctest runner's sandbox denies writes to `/private/tmp` on current macOS ("Operation not permitted" — confirmed via xcresult attachment); the per-process tmpdir under `/var/folders/…/T/` is runner-writable and developer-shell readable without TCC prompts.

### Product-side observability / behaviour fixes

- `AutocompleteSuggestionDropdown` — `.accessibilityElement(children: .contain)` above the "N suggestions" label so SwiftUI doesn't flatten the VStack into a single leaf and hide the individual `autocomplete.payee.suggestion.<n>` rows from XCUITest.
- `suggestionRow` — `.accessibilityAddTraits([.isSelected])` on the highlighted row so the driver's `isSelected` read works (and VoiceOver announces selection).
- `AutocompleteField` Escape handler now sets `text = ""` directly. The previous `onTextChange("")` call never propagated to the binding, leaving typed text in place contrary to the spec.
- `TransactionDetailView` — adds `payeeJustSelected` state mirroring the existing `categoryJustSelected` pattern. Without it, committing a suggestion (`draft.payee = selected`) retriggered `.onChange(of: text)` → fetched suggestions again → dropdown re-opened 200 ms after commit.

### Note on dependency

This branch currently also carries commit `9af10b8` (the `fix/ui-test-tcc-derived-data` PR [#237](https://github.com/ajsutton/moolah-native/pull/237)), which is required for local and CI UI test runs to avoid the Documents-folder TCC prompt. If #237 lands first, the merge queue will dedupe cleanly.

## Test plan

- [x] `just test-mac UITestSeedHydratorTests` — 6 / 6
- [x] `just test-mac TransactionDraftTests TransactionStoreTests` — 150 / 150
- [x] `just test-ui TransactionDetailFocusTests` — 1 / 1 (pre-existing, confirmed unaffected)
- [x] `just test-ui TransactionDetailPayeeAutocompleteTests` — 4 / 4
- [x] **20 consecutive `just test-ui TransactionDetailPayeeAutocompleteTests` runs, all green** (~30 minutes wall time, see `guides/UI_TEST_GUIDE.md` § 8)
- [x] `@ui-test-review` — findings addressed: post-condition waits on `press*` actions, split `testTypingShowsDropdownAndClearingHidesIt` into two single-behaviour tests.
- [x] `just format-check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)