### PR TITLE
feat(ui-testing): leg category + cross-currency tests, autofill-on-edit fix

### DIFF
--- a/App/UITestSeedHydrator.swift
+++ b/App/UITestSeedHydrator.swift
@@ -71,6 +71,19 @@ enum UITestSeedHydrator {
       in: context
     )
 
+    // USD account lets the cross-currency test switch a transfer's
+    // counterpart to a different instrument.
+    let usd = Instrument.USD
+    try upsertInstrument(usd, in: context)
+    try upsertAccount(
+      id: fixtures.usdAccountId,
+      name: fixtures.usdAccountName,
+      type: .bank,
+      instrumentId: usd.id,
+      position: 2,
+      in: context
+    )
+
     try upsertTrade(
       id: fixtures.bhpPurchaseId,
       payee: fixtures.bhpPurchasePayee,
@@ -98,6 +111,27 @@ enum UITestSeedHydrator {
         in: context
       )
     }
+
+    try upsertCategory(
+      id: fixtures.groceriesCategoryId, name: fixtures.groceriesCategoryName, in: context)
+    try upsertCategory(
+      id: fixtures.gymCategoryId, name: fixtures.gymCategoryName, in: context)
+
+    try upsertCustomExpenseSplit(
+      id: fixtures.splitShopId,
+      payee: fixtures.splitShopPayee,
+      date: fixtures.splitShopDate,
+      legAAmount: InstrumentAmount(
+        quantity: Decimal(fixtures.splitShopLegAAmountCents) / 100,
+        instrument: instrument
+      ),
+      legBAmount: InstrumentAmount(
+        quantity: Decimal(fixtures.splitShopLegBAmountCents) / 100,
+        instrument: instrument
+      ),
+      accountId: fixtures.checkingAccountId,
+      in: context
+    )
 
     try context.save()
     return profile
@@ -230,6 +264,69 @@ enum UITestSeedHydrator {
         quantity: outgoing.storageValue,
         type: TransactionType.expense.rawValue,
         sortOrder: 0
+      )
+    )
+  }
+
+  private static func upsertCategory(
+    id: UUID,
+    name: String,
+    in context: ModelContext
+  ) throws {
+    let targetId = id
+    let descriptor = FetchDescriptor<CategoryRecord>(
+      predicate: #Predicate { $0.id == targetId }
+    )
+    if try context.fetch(descriptor).first != nil { return }
+    context.insert(CategoryRecord(id: id, name: name))
+  }
+
+  /// Inserts a two-leg expense split on the same account. Both legs share
+  /// `accountId`, which makes `Transaction.isSimple` false (it requires
+  /// `a.accountId != b.accountId`) and flips `TransactionDraft.isCustom`
+  /// to true. Categories are left nil on both legs so the test can type
+  /// into an empty category field and observe autocomplete behaviour.
+  private static func upsertCustomExpenseSplit(
+    id: UUID,
+    payee: String,
+    date: Date,
+    legAAmount: InstrumentAmount,
+    legBAmount: InstrumentAmount,
+    accountId: UUID,
+    in context: ModelContext
+  ) throws {
+    let targetId = id
+    let descriptor = FetchDescriptor<TransactionRecord>(
+      predicate: #Predicate { $0.id == targetId }
+    )
+    if try context.fetch(descriptor).first != nil { return }
+
+    let txn = TransactionRecord(id: id, date: date, payee: payee)
+    context.insert(txn)
+
+    let outgoingA = InstrumentAmount(
+      quantity: -legAAmount.quantity, instrument: legAAmount.instrument)
+    let outgoingB = InstrumentAmount(
+      quantity: -legBAmount.quantity, instrument: legBAmount.instrument)
+
+    context.insert(
+      TransactionLegRecord(
+        transactionId: id,
+        accountId: accountId,
+        instrumentId: legAAmount.instrument.id,
+        quantity: outgoingA.storageValue,
+        type: TransactionType.expense.rawValue,
+        sortOrder: 0
+      )
+    )
+    context.insert(
+      TransactionLegRecord(
+        transactionId: id,
+        accountId: accountId,
+        instrumentId: legBAmount.instrument.id,
+        quantity: outgoingB.storageValue,
+        type: TransactionType.expense.rawValue,
+        sortOrder: 1
       )
     )
   }

--- a/BUGS.md
+++ b/BUGS.md
@@ -13,3 +13,4 @@ can start typing.
 The first UI test (`TransactionDetailFocusTests.testOpeningTradeFocusesPayee`)
 works around this by tapping the payee field explicitly before asserting
 focus. When this bug is fixed, that `.tap()` step can be deleted.
+

--- a/Features/Transactions/Views/TransactionDetailView.swift
+++ b/Features/Transactions/Views/TransactionDetailView.swift
@@ -28,6 +28,14 @@ struct TransactionDetailView: View {
   @State private var legCategoryJustSelected: [Int: Bool] = [:]
   @State private var showLegCategorySuggestions: [Int: Bool] = [:]
   @State private var legCategoryHighlightedIndex: [Int: Int?] = [:]
+  /// Snapshot of whether the transaction was a blank/new draft at open
+  /// time (empty payee + all-zero legs). Captured once at init so that
+  /// `autofillFromPayee` only copies fields from a matched transaction
+  /// when the user is filling in a fresh transaction — never when they
+  /// are editing an existing one. Without this guard, selecting a payee
+  /// from the dropdown while editing a $5,000 transfer would clobber the
+  /// amount, type, and category.
+  @State private var openedAsNewTransaction: Bool
   @FocusState private var focusedField: Field?
 
   private enum Field: Hashable {
@@ -138,6 +146,10 @@ struct TransactionDetailView: View {
       }
     }
     _draft = State(initialValue: initialDraft)
+
+    let payeeEmpty = (transaction.payee?.isEmpty ?? true)
+    let allLegsZero = transaction.legs.allSatisfy { $0.quantity == .zero }
+    _openedAsNewTransaction = State(initialValue: payeeEmpty && allLegsZero)
   }
 
   private var sortedAccounts: [Account] {
@@ -437,6 +449,7 @@ struct TransactionDetailView: View {
             Text(account.name).tag(UUID?.some(account.id))
           }
         }
+        .accessibilityIdentifier(UITestIdentifiers.Detail.toAccountPicker)
         .onChange(of: draft.legDrafts[counterpartIndex].accountId) { _, _ in
           draft.snapToSameCurrencyIfNeeded(accounts: accounts)
         }
@@ -455,9 +468,11 @@ struct TransactionDetailView: View {
               #endif
               .focused($focusedField, equals: .counterpartAmount)
               .onSubmit { focusedField = nil }
+              .accessibilityIdentifier(UITestIdentifiers.Detail.counterpartAmount)
             Text(counterpartInstrument?.id ?? "")
               .foregroundStyle(.secondary)
               .monospacedDigit()
+              .accessibilityIdentifier(UITestIdentifiers.Detail.counterpartAmountInstrument)
           }
 
           if let rate = derivedRate {
@@ -616,6 +631,7 @@ struct TransactionDetailView: View {
           onAcceptHighlighted: { acceptHighlightedLegCategory(at: index) }
         )
         .focused($legCategoryFieldFocused, equals: index)
+        .accessibilityIdentifier(UITestIdentifiers.Detail.Leg.category(index))
       }
 
       Picker("Earmark", selection: $draft.legDrafts[index].earmarkId) {
@@ -817,6 +833,11 @@ struct TransactionDetailView: View {
   }
 
   private func autofillFromPayee(_ selectedPayee: String) {
+    // Only auto-copy amount/type/category from a past transaction when
+    // the user is filling in a fresh draft. Editing an existing
+    // transaction's payee must never rewrite other fields — see BUGS.md
+    // before removing this guard.
+    guard openedAsNewTransaction else { return }
     Task {
       guard let match = await transactionStore.fetchTransactionForAutofill(payee: selectedPayee)
       else { return }
@@ -926,6 +947,10 @@ struct TransactionDetailView: View {
             draft.legDrafts[activeIndex].categoryText = selected.path
             showLegCategorySuggestions[activeIndex] = false
             legCategoryHighlightedIndex[activeIndex] = nil
+          },
+          identifier: UITestIdentifiers.Autocomplete.Leg.category(activeIndex),
+          rowIdentifier: { rowIndex in
+            UITestIdentifiers.Autocomplete.Leg.categorySuggestion(activeIndex, rowIndex)
           }
         )
         .frame(width: rect.width)

--- a/MoolahTests/UITestSupport/UITestSeedHydratorTests.swift
+++ b/MoolahTests/UITestSupport/UITestSeedHydratorTests.swift
@@ -56,15 +56,20 @@ final class UITestSeedHydratorTests: XCTestCase {
 
     let context = ModelContext(container)
     let accounts = try context.fetch(FetchDescriptor<AccountRecord>())
-    XCTAssertEqual(accounts.count, 2, "expected checking + brokerage accounts")
+    XCTAssertEqual(accounts.count, 3, "expected checking + brokerage + USD accounts")
     let ids = Set(accounts.map(\.id))
     XCTAssertEqual(
       ids,
       [
         UITestFixtures.TradeBaseline.checkingAccountId,
         UITestFixtures.TradeBaseline.brokerageAccountId,
+        UITestFixtures.TradeBaseline.usdAccountId,
       ]
     )
+    let usd = try XCTUnwrap(
+      accounts.first { $0.id == UITestFixtures.TradeBaseline.usdAccountId }
+    )
+    XCTAssertEqual(usd.instrumentId, UITestFixtures.TradeBaseline.usdAccountInstrumentCode)
   }
 
   func testHydrateTradeBaselineSeedsTheTradeTransaction() throws {
@@ -96,6 +101,55 @@ final class UITestSeedHydratorTests: XCTestCase {
         UITestFixtures.TradeBaseline.checkingAccountId,
         UITestFixtures.TradeBaseline.brokerageAccountId,
       ]
+    )
+  }
+
+  func testHydrateTradeBaselineSeedsTheCategories() throws {
+    let profile = try UITestSeedHydrator.hydrate(.tradeBaseline, into: containerManager)
+    let container = try containerManager.container(for: profile.id)
+
+    let context = ModelContext(container)
+    let categories = try context.fetch(FetchDescriptor<CategoryRecord>())
+    let byId = Dictionary(uniqueKeysWithValues: categories.map { ($0.id, $0) })
+    XCTAssertEqual(
+      byId[UITestFixtures.TradeBaseline.groceriesCategoryId]?.name,
+      UITestFixtures.TradeBaseline.groceriesCategoryName)
+    XCTAssertEqual(
+      byId[UITestFixtures.TradeBaseline.gymCategoryId]?.name,
+      UITestFixtures.TradeBaseline.gymCategoryName)
+  }
+
+  func testHydrateTradeBaselineSeedsTheCustomSplitTransaction() throws {
+    let profile = try UITestSeedHydrator.hydrate(.tradeBaseline, into: containerManager)
+    let container = try containerManager.container(for: profile.id)
+
+    let context = ModelContext(container)
+    let splitId = UITestFixtures.TradeBaseline.splitShopId
+    let split = try XCTUnwrap(
+      try context.fetch(
+        FetchDescriptor<TransactionRecord>(
+          predicate: #Predicate { $0.id == splitId }
+        )
+      ).first,
+      "custom split transaction must exist"
+    )
+    XCTAssertEqual(split.payee, UITestFixtures.TradeBaseline.splitShopPayee)
+
+    let legs = try context.fetch(
+      FetchDescriptor<TransactionLegRecord>(
+        predicate: #Predicate { $0.transactionId == splitId }
+      )
+    )
+    XCTAssertEqual(legs.count, 2, "split has two legs")
+    let accountIds = Set(legs.compactMap(\.accountId))
+    XCTAssertEqual(
+      accountIds,
+      [UITestFixtures.TradeBaseline.checkingAccountId],
+      "both legs share Checking — drives isCustom == true"
+    )
+    XCTAssertTrue(
+      legs.allSatisfy { $0.type == TransactionType.expense.rawValue },
+      "both legs are expense"
     )
   }
 
@@ -146,7 +200,8 @@ final class UITestSeedHydratorTests: XCTestCase {
     let second = try containerManager.container(for: UITestFixtures.TradeBaseline.profileId)
     let secondTxnCount = try ModelContext(second).fetch(FetchDescriptor<TransactionRecord>()).count
 
-    let expected = 1 + UITestFixtures.TradeBaseline.historicalPayees.count
+    // 1 trade + N historical single-leg expenses + 1 custom multi-leg split.
+    let expected = 1 + UITestFixtures.TradeBaseline.historicalPayees.count + 1
     XCTAssertEqual(firstTxnCount, expected)
     XCTAssertEqual(secondTxnCount, expected, "hydration must be idempotent for robust relaunches")
   }

--- a/MoolahUITests_macOS/Helpers/Fields/CounterpartAmountDriver.swift
+++ b/MoolahUITests_macOS/Helpers/Fields/CounterpartAmountDriver.swift
@@ -1,0 +1,60 @@
+import XCTest
+
+/// Read-only driver for the counterpart amount field that only renders
+/// when a transfer is cross-currency. Exposes visibility and
+/// instrument-label expectations — no typing action is needed by the
+/// v1 test suite.
+@MainActor
+struct CounterpartAmountDriver {
+  let app: MoolahApp
+
+  /// Waits up to `timeout` seconds for the counterpart amount field to
+  /// appear, then asserts the adjacent instrument label matches.
+  func expectVisible(instrumentCode: String, timeout: TimeInterval = 3) {
+    let field = app.element(for: UITestIdentifiers.Detail.counterpartAmount)
+    if !field.waitForExistence(timeout: timeout) {
+      Trace.recordFailure("counterpart amount field did not appear")
+      XCTFail(
+        "Counterpart amount field '\(UITestIdentifiers.Detail.counterpartAmount)' "
+          + "did not appear within \(timeout)s")
+      return
+    }
+    let instrumentLabel = app.element(
+      for: UITestIdentifiers.Detail.counterpartAmountInstrument)
+    if !instrumentLabel.waitForExistence(timeout: timeout) {
+      Trace.recordFailure("counterpart instrument label did not appear")
+      XCTFail(
+        "Counterpart instrument label '\(UITestIdentifiers.Detail.counterpartAmountInstrument)' "
+          + "did not appear within \(timeout)s")
+      return
+    }
+    // Poll — the Text's content is exposed via `value` (not `label`) once
+    // an `.accessibilityIdentifier` is attached, and it updates via
+    // `.onChange` after the account picker selection propagates.
+    let deadline = Date().addingTimeInterval(timeout)
+    var lastValue = ""
+    while Date() < deadline {
+      lastValue = (instrumentLabel.value as? String) ?? ""
+      if lastValue == instrumentCode { return }
+      RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+    }
+    Trace.recordFailure(
+      "counterpart instrument label was '\(lastValue)' (expected '\(instrumentCode)')")
+    XCTFail(
+      "Counterpart instrument label expected '\(instrumentCode)', got '\(lastValue)' within \(timeout)s"
+    )
+  }
+
+  /// Asserts the counterpart amount field is not in the accessibility
+  /// tree (same-currency transfer — field is conditionally compiled out).
+  func expectHidden(timeout: TimeInterval = 3) {
+    let field = app.element(for: UITestIdentifiers.Detail.counterpartAmount)
+    let deadline = Date().addingTimeInterval(timeout)
+    while Date() < deadline {
+      if !field.exists { return }
+      RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+    }
+    Trace.recordFailure("counterpart amount field still visible after \(timeout)s")
+    XCTFail("Counterpart amount field should be hidden but was visible within \(timeout)s")
+  }
+}

--- a/MoolahUITests_macOS/Helpers/MoolahUITestCase.swift
+++ b/MoolahUITests_macOS/Helpers/MoolahUITestCase.swift
@@ -241,6 +241,9 @@ class MoolahUITestCase: XCTestCase {
       lines.append("checking.name   = \(f.checkingAccountName)")
       lines.append("brokerage.id    = \(f.brokerageAccountId)")
       lines.append("brokerage.name  = \(f.brokerageAccountName)")
+      lines.append("usdSavings.id   = \(f.usdAccountId)")
+      lines.append("usdSavings.name = \(f.usdAccountName)")
+      lines.append("usdSavings.instrument = \(f.usdAccountInstrumentCode)")
       lines.append("trade.id        = \(f.bhpPurchaseId)")
       lines.append("trade.payee     = \(f.bhpPurchasePayee)")
       lines.append("trade.cents     = \(f.bhpPurchaseAmountCents)")
@@ -252,6 +255,15 @@ class MoolahUITestCase: XCTestCase {
             + "\(historical.id) / \(historical.payee) / \(historical.date)"
         )
       }
+      lines.append(
+        "category.groceries.id/name = \(f.groceriesCategoryId) / \(f.groceriesCategoryName)")
+      lines.append("category.gym.id/name = \(f.gymCategoryId) / \(f.gymCategoryName)")
+      lines.append(
+        "splitShop.id/payee/date = \(f.splitShopId) / \(f.splitShopPayee) / \(f.splitShopDate)")
+      lines.append(
+        "splitShop.legA.cents / legB.cents = "
+          + "\(f.splitShopLegAAmountCents) / \(f.splitShopLegBAmountCents)"
+      )
     }
     return lines.joined(separator: "\n") + "\n"
   }

--- a/MoolahUITests_macOS/Helpers/Screens/LegSectionDriver.swift
+++ b/MoolahUITests_macOS/Helpers/Screens/LegSectionDriver.swift
@@ -1,0 +1,25 @@
+import XCTest
+
+/// Driver for a single sub-transaction (leg) section inside the
+/// multi-leg (`isCustom`) transaction detail view. Returned from
+/// `TransactionDetailScreen.leg(_:)` — see `guides/UI_TEST_GUIDE.md` §7.
+@MainActor
+struct LegSectionDriver {
+  let app: MoolahApp
+  let legIndex: Int
+
+  /// Category autocomplete field for this leg. Identifiers follow the
+  /// `detail.leg.<index>.category` / `autocomplete.leg.<index>.category`
+  /// naming — the dropdown identifier reflects whichever leg is active
+  /// because `legCategoryOverlay` only renders one dropdown at a time.
+  var category: AutocompleteFieldDriver {
+    AutocompleteFieldDriver(
+      app: app,
+      fieldIdentifier: UITestIdentifiers.Detail.Leg.category(legIndex),
+      dropdownIdentifier: UITestIdentifiers.Autocomplete.Leg.category(legIndex),
+      suggestionIdentifier: { rowIndex in
+        UITestIdentifiers.Autocomplete.Leg.categorySuggestion(legIndex, rowIndex)
+      }
+    )
+  }
+}

--- a/MoolahUITests_macOS/Helpers/Screens/TransactionDetailScreen.swift
+++ b/MoolahUITests_macOS/Helpers/Screens/TransactionDetailScreen.swift
@@ -17,4 +17,68 @@ struct TransactionDetailScreen {
       suggestionIdentifier: UITestIdentifiers.Autocomplete.payeeSuggestion(_:)
     )
   }
+
+  /// Driver for a single sub-transaction (leg) section in a multi-leg
+  /// (`isCustom`) transaction. Legs are ordered by `sortOrder`; index 0
+  /// is the first leg the user sees.
+  func leg(_ index: Int) -> LegSectionDriver {
+    LegSectionDriver(app: app, legIndex: index)
+  }
+
+  /// Counterpart amount field that is rendered only for cross-currency
+  /// transfers.
+  var counterpartAmount: CounterpartAmountDriver {
+    CounterpartAmountDriver(app: app)
+  }
+
+  /// Selects a new "To Account" (counterpart account) for a transfer via
+  /// the transfer account picker. Clicks the picker to open its menu,
+  /// clicks the menu item with the given display name, and returns once
+  /// the picker's displayed title reflects the selection — proving the
+  /// SwiftUI state binding (`draft.legDrafts[counterpartIndex].accountId`)
+  /// has propagated. The menu-dismissal signal on its own is not a
+  /// sufficient post-condition; it can fire before the picker re-renders.
+  func selectToAccount(named name: String) {
+    Trace.record(detail: "toAccount=\(name)")
+    let picker = app.element(for: UITestIdentifiers.Detail.toAccountPicker)
+    if !picker.waitForExistence(timeout: 3) {
+      Trace.recordFailure("to-account picker did not appear")
+      XCTFail(
+        "To-account picker '\(UITestIdentifiers.Detail.toAccountPicker)' "
+          + "did not appear within 3s")
+      return
+    }
+    picker.click()
+
+    // ui-test-review: allow single-resolver — on macOS, SwiftUI Pickers
+    // open a native NSMenu whose items attach to the application's menu
+    // hierarchy at runtime. `.accessibilityIdentifier(_:)` on the inline
+    // `Text(account.name)` inside the `ForEach` does not propagate to the
+    // NSMenuItem, so querying by label via `menuItems[name]` is the only
+    // viable resolution path here.
+    let menuItem = app.application.menuItems[name]
+    if !menuItem.waitForExistence(timeout: 3) {
+      Trace.recordFailure("menu item '\(name)' did not appear")
+      XCTFail("Picker menu item '\(name)' did not appear within 3s")
+      return
+    }
+    menuItem.click()
+
+    // Post-condition: the picker's displayed selection updates to the new
+    // value — a more reliable signal than menu dismissal because it
+    // proves the SwiftUI binding flowed through, not just that the popup
+    // closed. macOS pop-up buttons expose the selection via `value`, not
+    // `title`; the latter is empty.
+    let deadline = Date().addingTimeInterval(3)
+    var lastValue = ""
+    while Date() < deadline {
+      lastValue = (picker.value as? String) ?? ""
+      if lastValue == name { return }
+      RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+    }
+    Trace.recordFailure(
+      "picker value was '\(lastValue)' after selecting '\(name)'")
+    XCTFail(
+      "To-account picker did not show '\(name)' within 3s of selection (was '\(lastValue)')")
+  }
 }

--- a/MoolahUITests_macOS/Helpers/Screens/TransactionListScreen.swift
+++ b/MoolahUITests_macOS/Helpers/Screens/TransactionListScreen.swift
@@ -5,12 +5,14 @@ import XCTest
 /// seeded UUID.
 enum TransactionListEntry {
   case bhpPurchase
+  case splitShop
 
   /// The fixed UUID written to the seeded `ProfileContainerManager` by
   /// `UITestSeedHydrator`.
   var id: UUID {
     switch self {
     case .bhpPurchase: return UITestFixtures.TradeBaseline.bhpPurchaseId
+    case .splitShop: return UITestFixtures.TradeBaseline.splitShopId
     }
   }
 }

--- a/MoolahUITests_macOS/Tests/TransactionDetail/TransactionDetailCrossCurrencyTests.swift
+++ b/MoolahUITests_macOS/Tests/TransactionDetail/TransactionDetailCrossCurrencyTests.swift
@@ -1,0 +1,23 @@
+import XCTest
+
+/// Behaviour test for the cross-currency branch of the transfer detail
+/// view. Switching the "To Account" picker to an account in a different
+/// instrument flips `isCrossCurrency` to true, which reveals the
+/// counterpart amount field and its instrument label. The
+/// `.tradeBaseline` seed provides an AUD transfer (BHP Purchase:
+/// Checking → Brokerage) and a USD Savings account the picker can
+/// switch to.
+@MainActor
+final class TransactionDetailCrossCurrencyTests: MoolahUITestCase {
+  func testSwitchingTransferToCrossCurrencyRevealsCounterpartField() {
+    let app = launch(seed: .tradeBaseline)
+
+    app.sidebar.switchToAccount(.checking)
+    app.transactionList.openTransaction(.bhpPurchase)
+    app.transactionDetail.counterpartAmount.expectHidden()
+
+    app.transactionDetail.selectToAccount(named: "USD Savings")
+
+    app.transactionDetail.counterpartAmount.expectVisible(instrumentCode: "USD")
+  }
+}

--- a/MoolahUITests_macOS/Tests/TransactionDetail/TransactionDetailLegCategoryTests.swift
+++ b/MoolahUITests_macOS/Tests/TransactionDetail/TransactionDetailLegCategoryTests.swift
@@ -1,0 +1,29 @@
+import XCTest
+
+/// Behaviour tests for the per-leg category autocomplete dropdown on
+/// `TransactionDetailView` in multi-leg (`isCustom`) mode. The view must
+/// keep each leg's dropdown isolated: typing in one leg only ever shows
+/// that leg's dropdown — never another leg's — even when focus moves
+/// between fields. The `.tradeBaseline` seed provides a two-leg expense
+/// split ("Split Shop") from a single Checking account, plus two
+/// categories ("Groceries", "Gym") so the prefix "G" yields two matches.
+@MainActor
+final class TransactionDetailLegCategoryTests: MoolahUITestCase {
+  func testTypingInLegOneHidesLegZeroDropdown() {
+    let app = launch(seed: .tradeBaseline)
+
+    app.sidebar.switchToAccount(.checking)
+    app.transactionList.openTransaction(.splitShop)
+
+    app.transactionDetail.leg(0).category.tap()
+    app.transactionDetail.leg(0).category.type("G")
+    app.transactionDetail.leg(0).category.expectSuggestionsVisible(count: 2)
+
+    app.transactionDetail.leg(1).category.tap()
+    app.transactionDetail.leg(0).category.expectSuggestionsHidden()
+
+    app.transactionDetail.leg(1).category.type("G")
+    app.transactionDetail.leg(1).category.expectSuggestionsVisible(count: 2)
+    app.transactionDetail.leg(0).category.expectSuggestionsHidden()
+  }
+}

--- a/Shared/Views/CategoryPicker.swift
+++ b/Shared/Views/CategoryPicker.swift
@@ -40,20 +40,50 @@ struct CategoryAutocompleteField: View {
 }
 
 /// The floating dropdown for category suggestions — mirrors PayeeSuggestionDropdown.
+///
+/// `identifier` + `rowIdentifier` are optional so the simple-mode call site
+/// (which doesn't need UI-test targeting today) can keep calling the struct
+/// without extra arguments. The multi-leg call site passes both so each
+/// leg's dropdown surfaces in the accessibility tree with a distinct
+/// identifier (`autocomplete.leg.<legIndex>.category[.suggestion.N]`).
 struct CategorySuggestionDropdown: View {
   let suggestions: [CategorySuggestion]
   let searchText: String
   @Binding var highlightedIndex: Int?
   let onSelect: (CategorySuggestion) -> Void
+  let identifier: String?
+  let rowIdentifier: ((Int) -> String)?
+
+  init(
+    suggestions: [CategorySuggestion],
+    searchText: String,
+    highlightedIndex: Binding<Int?>,
+    onSelect: @escaping (CategorySuggestion) -> Void,
+    identifier: String? = nil,
+    rowIdentifier: ((Int) -> String)? = nil
+  ) {
+    self.suggestions = suggestions
+    self.searchText = searchText
+    self._highlightedIndex = highlightedIndex
+    self.onSelect = onSelect
+    self.identifier = identifier
+    self.rowIdentifier = rowIdentifier
+  }
 
   var body: some View {
-    AutocompleteSuggestionDropdown(
+    let dropdown = AutocompleteSuggestionDropdown(
       items: suggestions,
       searchText: searchText,
       label: { $0.path },
       highlightedIndex: $highlightedIndex,
-      onSelect: { onSelect($0) }
+      onSelect: { onSelect($0) },
+      rowIdentifier: rowIdentifier
     )
+    if let identifier {
+      dropdown.accessibilityIdentifier(identifier)
+    } else {
+      dropdown
+    }
   }
 }
 

--- a/UITestSupport/UITestIdentifiers.swift
+++ b/UITestSupport/UITestIdentifiers.swift
@@ -43,6 +43,29 @@ public enum UITestIdentifiers {
   public enum Detail {
     /// Payee text field on the transaction detail surface.
     public static let payee = "detail.payee"
+
+    /// Picker that sets the counterpart account for a transfer (the "To
+    /// Account" or "From Account" picker depending on `showFromAccount`).
+    /// Only rendered when `draft.type == .transfer`.
+    public static let toAccountPicker = "detail.toAccountPicker"
+
+    /// Counterpart amount text field. Only rendered when the transfer is
+    /// cross-currency (primary and counterpart legs' accounts have
+    /// different instruments).
+    public static let counterpartAmount = "detail.counterpartAmount"
+
+    /// Instrument code label next to the counterpart amount field (e.g.
+    /// "USD"). Rendered in the same row as `counterpartAmount`.
+    public static let counterpartAmountInstrument = "detail.counterpartAmount.instrument"
+
+    /// Identifiers for elements that only appear when the transaction is
+    /// rendered in multi-leg (`isCustom`) mode.
+    public enum Leg {
+      /// Category text field inside the given leg section.
+      public static func category(_ index: Int) -> String {
+        "detail.leg.\(index).category"
+      }
+    }
   }
 
   public enum Autocomplete {
@@ -52,6 +75,22 @@ public enum UITestIdentifiers {
     /// Indexed payee suggestion row inside the dropdown.
     public static func payeeSuggestion(_ index: Int) -> String {
       "autocomplete.payee.suggestion.\(index)"
+    }
+
+    /// Identifiers for per-leg autocomplete dropdowns (multi-leg `isCustom`
+    /// transactions render one category field per leg).
+    public enum Leg {
+      /// Container element of the category autocomplete dropdown for the
+      /// given leg. Only one leg's category dropdown is visible at a time;
+      /// the identifier reflects whichever leg is active.
+      public static func category(_ legIndex: Int) -> String {
+        "autocomplete.leg.\(legIndex).category"
+      }
+
+      /// Indexed category suggestion row inside the given leg's dropdown.
+      public static func categorySuggestion(_ legIndex: Int, _ rowIndex: Int) -> String {
+        "autocomplete.leg.\(legIndex).category.suggestion.\(rowIndex)"
+      }
     }
   }
 }

--- a/UITestSupport/UITestSeeds.swift
+++ b/UITestSupport/UITestSeeds.swift
@@ -64,6 +64,12 @@ public enum UITestFixtures {
     public static let brokerageAccountId = UUID(uuidString: "A1000000-0000-0000-0000-000000000011")!
     public static let brokerageAccountName = "Brokerage"
 
+    /// A USD-denominated account so the cross-currency test can switch a
+    /// transfer's counterpart leg to a different instrument.
+    public static let usdAccountId = UUID(uuidString: "A1000000-0000-0000-0000-000000000012")!
+    public static let usdAccountName = "USD Savings"
+    public static let usdAccountInstrumentCode = "USD"
+
     public static let bhpPurchaseId = UUID(uuidString: "A1000000-0000-0000-0000-000000000020")!
     public static let bhpPurchasePayee = "BHP Purchase"
     public static let bhpPurchaseAmountCents = 500_000  // 5,000.00 AUD
@@ -73,6 +79,37 @@ public enum UITestFixtures {
     /// Cents moved by every historical expense. Kept identical across the
     /// list so tests that care only about payee text don't encode amounts.
     public static let historicalExpenseAmountCents = 5_000  // 50.00 AUD
+
+    // MARK: - Categories
+    //
+    // A minimal category set that gives the autocomplete dropdown
+    // matches for the prefixes exercised by the multi-leg isolation test:
+    //
+    //   "G" → [Groceries, Gym]           (count = 2)
+    //   "Gr" → [Groceries]                (count = 1)
+    //
+    // Seeded flat — no parent hierarchy — because the test only asserts
+    // dropdown visibility, not label formatting.
+    public static let groceriesCategoryId =
+      UUID(uuidString: "A1000000-0000-0000-0000-000000000040")!
+    public static let groceriesCategoryName = "Groceries"
+    public static let gymCategoryId =
+      UUID(uuidString: "A1000000-0000-0000-0000-000000000041")!
+    public static let gymCategoryName = "Gym"
+
+    // MARK: - Custom (multi-leg) transaction
+    //
+    // A two-leg expense split from `checking`, both legs with the same
+    // account so `Transaction.isSimple == false` → `TransactionDraft.isCustom
+    // == true` → the detail view renders per-leg sections with category
+    // autocomplete fields.
+    public static let splitShopId = UUID(uuidString: "A1000000-0000-0000-0000-000000000050")!
+    public static let splitShopPayee = "Split Shop"
+    /// 2026-03-23 00:00:00 UTC — between the historical expenses and the
+    /// BHP trade.
+    public static let splitShopDate = Date(timeIntervalSince1970: 1_774_224_000)
+    public static let splitShopLegAAmountCents = 3_000  // 30.00 AUD
+    public static let splitShopLegBAmountCents = 2_000  // 20.00 AUD
 
     /// Four historical expense transactions from `checking`, ordered by
     /// date. Payee frequency is the only axis `fetchPayeeSuggestions` sorts


### PR DESCRIPTION
## Summary

Follows [#238](https://github.com/ajsutton/moolah-native/pull/238) and completes the v1 UI test suite from `plans/2026-04-20-ui-testing-strategy-design.md` § Scope:

- **Test 5** — multi-leg category dropdown isolation: typing in one leg's category field shows only that leg's dropdown; focus moves hide the previous one.
- **Test 6** — switching a transfer to cross-currency reveals the counterpart amount field and its instrument label.

### Seed additions (`.tradeBaseline`)

- **USD Savings** account (instrument USD) so the cross-currency test has a different-currency target.
- Two categories — **Groceries**, **Gym** — so prefix `"G"` yields a deterministic 2-suggestion dropdown.
- **Split Shop** two-leg expense split (both legs on Checking) — drives `Transaction.isSimple == false` → `TransactionDraft.isCustom == true`, so the detail view renders sub-transaction sections with per-leg category autocomplete fields.

### Infrastructure

- New `LegSectionDriver` returning a per-leg `AutocompleteFieldDriver` for category.
- New `CounterpartAmountDriver` with `expectVisible(instrumentCode:)` / `expectHidden()`. Reads the instrument label via `.value` (SwiftUI `Text` with `accessibilityIdentifier` routes content into `value`, not `label`).
- `TransactionDetailScreen.selectToAccount(named:)` drives the macOS Picker: clicks the pop-up, resolves the NSMenuItem by label (ui-test-review allowance — menu items have no stable identifier), and returns once the picker's displayed `value` reflects the selection (the real SwiftUI-state propagation signal, not menu dismissal).
- New identifiers: `detail.toAccountPicker`, `detail.counterpartAmount`, `detail.counterpartAmount.instrument`, `detail.leg.<i>.category`, `autocomplete.leg.<i>.category[.suggestion.<n>]`.
- Leg category overlay passes per-leg identifiers to `CategorySuggestionDropdown`; simple-mode call sites pass nil and the modifier is skipped conditionally.

### Product fix — autofill-on-edit

Editing an existing transaction's payee previously clobbered the amount, type, category, and earmark via `autofillFromPayee`. Observed during test 3 development: opening a $5,000 transfer named "BHP Purchase", clearing the payee, and selecting "Woolworths" rewrote the transaction as a $50 expense. The view now snapshots `openedAsNewTransaction` at init (empty payee + all-zero legs) and guards `autofillFromPayee` on it — existing edits are safe, freshly created transactions still autofill.

## Test plan

- [x] `just test-mac UITestSeedHydratorTests` — 8/8 (two new: categories + custom split)
- [x] `just test-mac TransactionDraftTests TransactionStoreTests` — 150/150
- [x] `just test-ui TransactionDetailPayeeAutocompleteTests TransactionDetailLegCategoryTests TransactionDetailCrossCurrencyTests TransactionDetailFocusTests` — 7/7 in ~136 s
- [x] **20 consecutive full-suite runs locally**, all green (`guides/UI_TEST_GUIDE.md` § 8)
- [x] `@ui-test-review` run; findings addressed:
  - escape-hatch comment on `menuItems[name]` lookup (single-resolver rule)
  - stronger post-condition in `selectToAccount` (polls `picker.value`, not menu dismissal)
  - USD account added to `seed.txt` output
  - conditional identifier modifier on `CategorySuggestionDropdown` (no empty-string literal)
- [x] `just format-check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)