### PR TITLE
fix(transactions): auto-focus payee when inspector opens

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -1,16 +1,1 @@
 # Known Bugs
-
-## TransactionDetailView default focus on open
-
-When the user opens a transaction (or the inspector first appears), the
-payee field should receive keyboard focus per
-`defaultFocus($focusedField, isSimpleEarmarkOnly ? .amount : .payee)` in
-`TransactionDetailView`. Today the macOS first-responder grabs the
-transaction list's toolbar search field instead, leaving the payee field
-focusable but not focused. The user has to click into payee before they
-can start typing.
-
-The first UI test (`TransactionDetailFocusTests.testOpeningTradeFocusesPayee`)
-works around this by tapping the payee field explicitly before asserting
-focus. When this bug is fixed, that `.tap()` step can be deleted.
-

--- a/Features/Transactions/Views/TransactionDetailView.swift
+++ b/Features/Transactions/Views/TransactionDetailView.swift
@@ -245,7 +245,15 @@ struct TransactionDetailView: View {
         .navigationBarTitleDisplayMode(.inline)
       #endif
       #if os(macOS)
+        // `defaultFocus` alone does not pull first-responder into the inspector
+        // when focus currently sits outside its region (e.g., the list's
+        // `.searchable` toolbar field). `.task(id:)` runs after the view is in
+        // the window hierarchy and imperatively claims focus on the expected
+        // field, re-firing whenever the selected transaction changes.
         .defaultFocus($focusedField, isSimpleEarmarkOnly ? .amount : .payee)
+        .task(id: transaction.id) {
+          focusedField = isSimpleEarmarkOnly ? .amount : .payee
+        }
       #endif
       .onChange(of: draft) { _, _ in debouncedSave() }
       .onChange(of: legCategoryFieldFocused) { _, focused in

--- a/MoolahUITests_macOS/Tests/TransactionDetail/TransactionDetailFocusTests.swift
+++ b/MoolahUITests_macOS/Tests/TransactionDetail/TransactionDetailFocusTests.swift
@@ -1,17 +1,6 @@
 import XCTest
 
-/// Behaviour tests for keyboard focus on `TransactionDetailView`. The first
-/// test in the rollout — proves the entire driver and seed pipeline works
-/// end-to-end against a real SwiftUI event loop.
-///
-/// **Today's behaviour, scope of this test:** opening a transaction does
-/// not auto-focus the payee field — the macOS first-responder lands on
-/// the transaction list's search field instead, defeating the
-/// `defaultFocus(.payee)` modifier in the detail view. See `BUGS.md`
-/// (`TransactionDetailView default focus on open`). This test therefore
-/// covers what *can* be verified today: clicking the payee field gives
-/// it keyboard focus. When the auto-focus bug is fixed, the explicit
-/// `.tap()` step can be deleted.
+/// Behaviour tests for keyboard focus on `TransactionDetailView`.
 @MainActor
 final class TransactionDetailFocusTests: MoolahUITestCase {
   func testOpeningTradeFocusesPayee() {
@@ -19,7 +8,6 @@ final class TransactionDetailFocusTests: MoolahUITestCase {
 
     app.sidebar.switchToAccount(.checking)
     app.transactionList.openTransaction(.bhpPurchase)
-    app.transactionDetail.payee.tap()
 
     app.transactionDetail.payee.expectFocused()
   }


### PR DESCRIPTION
## Summary
- Closes the open `BUGS.md` entry: opening a transaction now lands first-responder on the payee field (or amount for earmark-only), as the `defaultFocus` modifier always intended.
- Root cause: `defaultFocus(_:_:)` only picks the default *within* its focus region — it does not pull focus in from outside. On app launch, the list's `.searchable` toolbar field claims first-responder, so when the inspector later opens, `defaultFocus` has no effect.
- Fix: keep `defaultFocus` (style-guide compliant) and add `.task(id: transaction.id)` that imperatively claims focus once the detail view is in the window hierarchy, re-firing whenever the selection changes.
- Cleanup: drop the `.tap()` workaround in `TransactionDetailFocusTests.testOpeningTradeFocusesPayee` plus the explanatory docstring, and remove the BUGS.md entry.

## Test plan
- [ ] `just test-mac` — full non-UI suite (local: 1450 tests passing).
- [ ] `just test-ui TransactionDetailFocusTests` — verifies focus lands on payee without the explicit tap (blocked locally by a stray macOS LocalAuthentication prompt; please re-run once the Touch ID/password dialog clears).
- [ ] Manual smoke: launch the macOS app, select any transaction in a list; the payee field should show the focus ring and accept typing without clicking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)