### PR TITLE
fix(transactions): focus payee after ⌘N (placeholder-swap race)

### DIFF
--- a/Features/Transactions/Views/TransactionDetailView.swift
+++ b/Features/Transactions/Views/TransactionDetailView.swift
@@ -250,9 +250,23 @@ struct TransactionDetailView: View {
         // `.searchable` toolbar field). `.task(id:)` runs after the view is in
         // the window hierarchy and imperatively claims focus on the expected
         // field, re-firing whenever the selected transaction changes.
+        //
+        // Assign once immediately (fast path — clicking a list row) and
+        // re-assert briefly afterwards. Some flows (⌘N menu events and
+        // the placeholder → persisted-transaction swap during creation)
+        // have AppKit restore first-responder to the window's default
+        // responder after our initial assignment; the re-assertion wins
+        // that race. We only re-assert when focus is nil so we don't
+        // steal focus from a Tab'd-to field.
         .defaultFocus($focusedField, isSimpleEarmarkOnly ? .amount : .payee)
         .task(id: transaction.id) {
-          focusedField = isSimpleEarmarkOnly ? .amount : .payee
+          let target: Field = isSimpleEarmarkOnly ? .amount : .payee
+          focusedField = target
+          for delayMs: UInt64 in [50, 150] {
+            try? await Task.sleep(nanoseconds: delayMs * 1_000_000)
+            if Task.isCancelled { return }
+            if focusedField == nil { focusedField = target }
+          }
         }
       #endif
       .onChange(of: draft) { _, _ in debouncedSave() }

--- a/MoolahUITests_macOS/Helpers/MoolahApp.swift
+++ b/MoolahUITests_macOS/Helpers/MoolahApp.swift
@@ -57,6 +57,14 @@ final class MoolahApp {
     application.descendants(matching: .any).matching(identifier: identifier).firstMatch
   }
 
+  /// Keyboard shortcut entrypoint for drivers. Drivers must route keyboard
+  /// events through this method rather than reaching into `application`
+  /// directly — the single seam keeps `MoolahApp` as the only surface the
+  /// driver layer talks to (mirrors `element(for:)`).
+  func pressKeyboardShortcut(_ key: String, modifiers: XCUIElement.KeyModifierFlags = []) {
+    application.typeKey(key, modifierFlags: modifiers)
+  }
+
   // MARK: - Helpers used by drivers and `MoolahUITestCase`
 
   /// Bounded wait for an element with the given identifier to exist. Used

--- a/MoolahUITests_macOS/Helpers/Screens/TransactionListScreen.swift
+++ b/MoolahUITests_macOS/Helpers/Screens/TransactionListScreen.swift
@@ -27,7 +27,7 @@ struct TransactionListScreen {
   /// detail surface for that transaction is visible (i.e. the payee field
   /// has been added to the accessibility tree).
   func openTransaction(_ entry: TransactionListEntry) {
-    Trace.record(detail: "entry=\(entry)")
+    Trace.record(#function, detail: "entry=\(entry)")
     let identifier = UITestIdentifiers.TransactionList.transaction(entry.id)
     let row = app.element(for: identifier)
     if !row.waitForExistence(timeout: 3) {
@@ -40,6 +40,21 @@ struct TransactionListScreen {
     if !payee.waitForExistence(timeout: 3) {
       Trace.recordFailure("detail.payee did not appear after opening \(entry)")
       XCTFail("Transaction detail did not surface payee field after opening \(entry)")
+    }
+  }
+
+  /// Triggers the "New Transaction" menu command (⌘N) and returns once
+  /// the detail surface for the new transaction is visible (i.e. the
+  /// payee field exists in the accessibility tree). The caller is
+  /// responsible for focus assertions — this method does not assume the
+  /// field has been auto-focused.
+  func createTransaction() {
+    Trace.record(#function)
+    app.pressKeyboardShortcut("n", modifiers: .command)
+    let payee = app.element(for: UITestIdentifiers.Detail.payee)
+    if !payee.waitForExistence(timeout: 3) {
+      Trace.recordFailure("detail.payee did not appear after ⌘N")
+      XCTFail("Transaction detail did not surface payee field after ⌘N")
     }
   }
 }

--- a/MoolahUITests_macOS/Tests/TransactionDetail/TransactionDetailFocusTests.swift
+++ b/MoolahUITests_macOS/Tests/TransactionDetail/TransactionDetailFocusTests.swift
@@ -11,4 +11,16 @@ final class TransactionDetailFocusTests: MoolahUITestCase {
 
     app.transactionDetail.payee.expectFocused()
   }
+
+  /// ⌘N is the keyboard entry-point for new transactions. The detail
+  /// inspector must land first-responder on the payee field so the user
+  /// can start typing immediately without clicking.
+  func testCreatingTransactionFocusesPayee() {
+    let app = launch(seed: .tradeBaseline)
+
+    app.sidebar.switchToAccount(.checking)
+    app.transactionList.createTransaction()
+
+    app.transactionDetail.payee.expectFocused()
+  }
 }


### PR DESCRIPTION
## Summary

PR #240 fixed focus for *existing*-transaction opens but not for the ⌘N path. ⌘N follows a different flow:

1. `selectedTransaction = placeholder` (fresh UUID A) — inspector opens.
2. Async `Task { createDefault() }` runs; `selectedTransaction = created` (UUID B).
3. `.id(selected.id)` sees B ≠ A and destroys + recreates the detail view.
4. AppKit's menu-event first-responder restoration lands during that window and overrides our `.task` focus assignment.

The `.task(id: transaction.id)` set `focusedField = .payee` once — the set was lost during the recreation / first-responder race, leaving no field focused.

## Fix (pragmatic)

After the immediate `focusedField = target` assignment, re-assert at 50 ms and 150 ms if focus is still nil (i.e. landed outside the inspector's focus region — e.g. on the `.searchable` toolbar field AppKit restored). The `focusedField == nil` guard prevents stealing focus if the user has Tab'd to another field in the inspector.

## This is hacky — follow-up worth doing

Timer-driven focus shifting is a workaround, not a principled fix. The cleaner approach:

- Preserve the placeholder's UUID through `TransactionStore.createDefault` so the persisted transaction lands with the *same* id as the optimistic placeholder. `.id(selected.id)` would no longer trigger a view recreation, so the inspector's `@FocusState` would survive the placeholder → persisted swap.
- That still leaves the "AppKit restores to search field after ⌘N" race, which needs separate investigation (likely involving `.focusedSceneValue` coordination or explicitly blurring `searchFieldFocused` when the inspector opens).

I left that out to keep this PR minimal and recover working keyboard-entry behaviour now.

## Test

New UI test `TransactionDetailFocusTests.testCreatingTransactionFocusesPayee` reliably reproduces the bug (fails without the fix) and gates the regression.

Driver additions:
- `TransactionListScreen.createTransaction()` — triggers ⌘N and waits for the payee field to appear.
- `MoolahApp.pressKeyboardShortcut(_:modifiers:)` — the single seam drivers go through for keyboard events (mirrors `element(for:)`). Fixes a `ui-test-review` finding about `typeKey` bypassing the seam.
- Filled in a pre-existing missing `#function` in `openTransaction`'s trace call while in the area.

## Test plan

- [x] `just test-ui TransactionDetailFocusTests` — 20/20 passing (stability gate).
- [x] `just test-mac` — full non-UI suite passes (1450 tests).
- [x] `just format-check` — clean.
- [ ] Manual: ⌘N in the running app focuses payee immediately without a visible lag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)