### PR TITLE
fix(transactions): focus detail view payee without timers

### DIFF
--- a/Features/Analysis/Views/AnalysisView.swift
+++ b/Features/Analysis/Views/AnalysisView.swift
@@ -92,6 +92,10 @@ struct AnalysisView: View {
     let instrument = accounts.ordered.first?.instrument ?? .AUD
     let fallbackAccountId = accounts.ordered.first?.id
 
+    // Persist the placeholder directly so the returned transaction carries
+    // the same UUID. The inspector's `.id(selected.id)` stays stable and
+    // the detail view's focus state survives the create (see
+    // `plans/2026-04-21-transaction-detail-focus-design.md`).
     let placeholder: Transaction? = fallbackAccountId.map { id in
       Transaction(
         date: Date(),
@@ -102,17 +106,9 @@ struct AnalysisView: View {
       )
     }
     selectedUpcomingTransaction = placeholder
-
+    guard let placeholder else { return }
     Task {
-      if let created = await transactionStore.createDefaultScheduled(
-        accountId: nil,
-        fallbackAccountId: fallbackAccountId,
-        instrument: instrument
-      ) {
-        if selectedUpcomingTransaction?.id == placeholder?.id {
-          selectedUpcomingTransaction = created
-        }
-      }
+      _ = await transactionStore.create(placeholder)
     }
   }
 

--- a/Features/Transactions/Views/TransactionDetailView.swift
+++ b/Features/Transactions/Views/TransactionDetailView.swift
@@ -246,27 +246,14 @@ struct TransactionDetailView: View {
       #endif
       #if os(macOS)
         // `defaultFocus` alone does not pull first-responder into the inspector
-        // when focus currently sits outside its region (e.g., the list's
-        // `.searchable` toolbar field). `.task(id:)` runs after the view is in
-        // the window hierarchy and imperatively claims focus on the expected
-        // field, re-firing whenever the selected transaction changes.
-        //
-        // Assign once immediately (fast path — clicking a list row) and
-        // re-assert briefly afterwards. Some flows (⌘N menu events and
-        // the placeholder → persisted-transaction swap during creation)
-        // have AppKit restore first-responder to the window's default
-        // responder after our initial assignment; the re-assertion wins
-        // that race. We only re-assert when focus is nil so we don't
-        // steal focus from a Tab'd-to field.
+        // when focus currently sits outside its region; `.task(id:)` runs
+        // after the view is in the window hierarchy and imperatively claims
+        // focus on the expected field. The list view cooperates by blurring
+        // the `.searchable` toolbar field when the inspector opens, so the
+        // responder chain's fallback doesn't steal our assignment.
         .defaultFocus($focusedField, isSimpleEarmarkOnly ? .amount : .payee)
         .task(id: transaction.id) {
-          let target: Field = isSimpleEarmarkOnly ? .amount : .payee
-          focusedField = target
-          for delayMs: UInt64 in [50, 150] {
-            try? await Task.sleep(nanoseconds: delayMs * 1_000_000)
-            if Task.isCancelled { return }
-            if focusedField == nil { focusedField = target }
-          }
+          focusedField = isSimpleEarmarkOnly ? .amount : .payee
         }
       #endif
       .onChange(of: draft) { _, _ in debouncedSave() }

--- a/Features/Transactions/Views/TransactionListView.swift
+++ b/Features/Transactions/Views/TransactionListView.swift
@@ -126,6 +126,14 @@ struct TransactionListView: View {
       .focusedSceneValue(\.newTransactionAction, createNewTransaction)
       .focusedSceneValue(\.findInListAction) { searchFieldFocused = true }
       .searchFocused($searchFieldFocused)
+      // When the inspector opens, release our claim on the `.searchable`
+      // first responder so focus can land on the detail view's payee/amount
+      // field (set imperatively by `TransactionDetailView.task(id:)`).
+      // Without this, AppKit's responder-chain fallback — reinforced after
+      // a ⌘N menu event — would restore focus to the search field.
+      .onChange(of: selectedTransaction) { _, new in
+        if new != nil { searchFieldFocused = false }
+      }
       .focusedSceneValue(\.selectedTransaction, selectedTransactionBinding)
       .alert("Error", isPresented: $showError) {
         Button("OK", role: .cancel) {}
@@ -203,9 +211,14 @@ struct TransactionListView: View {
   private func createNewTransaction() {
     let instrument = accounts.ordered.first?.instrument ?? .AUD
 
-    // When viewing from an earmark (no account in filter), create an earmark-only transaction
+    // Build the placeholder with its own UUID and send that exact
+    // transaction through `store.create`. CloudKit's repository echoes
+    // the input transaction, so `selectedTransaction.id` stays stable
+    // across the persist — the inspector's `.id(selected.id)` does not
+    // force a view recreation and the detail view's focus state survives.
+    let placeholder: Transaction?
     if let earmarkId = filter.earmarkId, filter.accountId == nil {
-      let placeholder = Transaction(
+      placeholder = Transaction(
         date: Date(),
         payee: "",
         legs: [
@@ -214,43 +227,22 @@ struct TransactionListView: View {
             earmarkId: earmarkId)
         ]
       )
-      selectedTransaction = placeholder
-      Task {
-        if let created = await transactionStore.createDefaultEarmark(
-          earmarkId: earmarkId,
-          instrument: instrument
-        ) {
-          if selectedTransaction?.id == placeholder.id {
-            selectedTransaction = created
-          }
-        }
-      }
-      return
-    }
-
-    let acctId = filter.accountId ?? accounts.ordered.first?.id
-
-    // Create a placeholder for optimistic selection while the store creates it
-    let placeholder: Transaction? = acctId.map { id in
-      Transaction(
+    } else if let acctId = filter.accountId ?? accounts.ordered.first?.id {
+      placeholder = Transaction(
         date: Date(),
         payee: "",
-        legs: [TransactionLeg(accountId: id, instrument: instrument, quantity: 0, type: .expense)]
+        legs: [
+          TransactionLeg(accountId: acctId, instrument: instrument, quantity: 0, type: .expense)
+        ]
       )
+    } else {
+      placeholder = nil
     }
-    selectedTransaction = placeholder
 
-    // Create the transaction in the store and update selection with server-confirmed version
+    selectedTransaction = placeholder
+    guard let placeholder else { return }
     Task {
-      if let created = await transactionStore.createDefault(
-        accountId: filter.accountId,
-        fallbackAccountId: accounts.ordered.first?.id,
-        instrument: instrument
-      ) {
-        if selectedTransaction?.id == placeholder?.id {
-          selectedTransaction = created
-        }
-      }
+      _ = await transactionStore.create(placeholder)
     }
   }
 

--- a/Features/Transactions/Views/UpcomingView.swift
+++ b/Features/Transactions/Views/UpcomingView.swift
@@ -197,6 +197,10 @@ struct UpcomingView: View {
     let instrument = accounts.ordered.first?.instrument ?? .AUD
     let fallbackAccountId = accounts.ordered.first?.id
 
+    // Build the placeholder with its own UUID and persist that exact
+    // transaction — CloudKit's repository echoes the input, so
+    // `selectedTransaction.id` stays stable through the create and the
+    // inspector doesn't recreate its detail view (preserves focus state).
     let placeholder: Transaction? = fallbackAccountId.map { id in
       Transaction(
         date: Date(),
@@ -207,17 +211,9 @@ struct UpcomingView: View {
       )
     }
     selectedTransaction = placeholder
-
+    guard let placeholder else { return }
     Task {
-      if let created = await transactionStore.createDefaultScheduled(
-        accountId: nil,
-        fallbackAccountId: fallbackAccountId,
-        instrument: instrument
-      ) {
-        if selectedTransaction?.id == placeholder?.id {
-          selectedTransaction = created
-        }
-      }
+      _ = await transactionStore.create(placeholder)
     }
   }
 

--- a/MoolahTests/Features/TransactionStoreTests.swift
+++ b/MoolahTests/Features/TransactionStoreTests.swift
@@ -358,6 +358,43 @@ struct TransactionStoreTests {
     #expect(store.error == nil)
   }
 
+  /// The placeholder-pass-through pattern in `TransactionListView.createNewTransaction`
+  /// (and the upcoming-view equivalent) relies on `store.create(placeholder)`
+  /// returning a transaction with the same UUID the caller passed in. The
+  /// inspector's `.id(selected.id)` otherwise forces a view recreation on
+  /// every create, which would drop focus state. See
+  /// `plans/2026-04-21-transaction-detail-focus-design.md`.
+  @Test func testCreatePreservesInputUUID() async throws {
+    let (backend, _) = try TestBackend.create()
+    let store = TransactionStore(
+      repository: backend.transactions,
+      conversionService: FixedConversionService(),
+      targetInstrument: .defaultTestInstrument
+    )
+    await store.load(filter: TransactionFilter(accountId: accountId))
+
+    let placeholderId = UUID()
+    let placeholder = Transaction(
+      id: placeholderId,
+      date: makeDate("2024-02-01"),
+      payee: "",
+      legs: [
+        TransactionLeg(
+          accountId: accountId,
+          instrument: Instrument.defaultTestInstrument,
+          quantity: 0,
+          type: .expense
+        )
+      ]
+    )
+
+    let created = await store.create(placeholder)
+
+    #expect(created?.id == placeholderId)
+    #expect(store.transactions.count == 1)
+    #expect(store.transactions[0].transaction.id == placeholderId)
+  }
+
   @Test func testUpdateModifiesTransaction() async throws {
     let tx = Transaction(
       date: makeDate("2024-01-15"),

--- a/guides/STYLE_GUIDE.md
+++ b/guides/STYLE_GUIDE.md
@@ -854,6 +854,9 @@ TextField("Notes", text: $notes, axis: .vertical)
   Form { ... }
       .defaultFocus($focusedField, .payee)
   ```
+- **Caveat — `defaultFocus` does not pull focus in from outside its region.** It picks the default target *within* a focus region once focus enters that region. If the form is presented alongside a scene-level focus claimant (a `.searchable` toolbar field is the usual culprit) the search field holds first-responder and `defaultFocus` silently does nothing. Two mitigations, applied at the surrounding view rather than the form:
+  1. Blur the claimant explicitly when the form presents — `.onChange(of: selected) { if $1 != nil { searchFieldFocused = false } }` on the list.
+  2. Back `defaultFocus` with an imperative `.task(id:)` on the form that sets `focusedField = .target` once the view is in the window hierarchy.
 - Advance focus on submit — when Return is pressed in a text field, move to the next logical field:
   ```swift
   TextField("Payee", text: $payee)


### PR DESCRIPTION
Replaces the timer-based retry loop from [#241](https://github.com/ajsutton/moolah-native/pull/241) with root-cause fixes for the two races that made the ⌘N create flow drop focus. Implements the design in `plans/2026-04-21-transaction-detail-focus-design.md` (PR [#242](https://github.com/ajsutton/moolah-native/pull/242)).

## Changes

**Change 1 — list view blurs `.searchable` on inspector open.** `TransactionListView.onChange(of: selectedTransaction)` sets `searchFieldFocused = false` when the inspector opens. AppKit's responder-chain fallback after a menu event no longer restores focus to the search field, so the detail view's `.task(id:)` assignment lands.

**Change 2 — creator routes placeholder through `store.create(_:)`.** `createNewTransaction` (both branches in `TransactionListView`, `UpcomingView.createNewScheduledTransaction`, `AnalysisView.createNewScheduledTransaction`) now builds the placeholder once and passes that exact transaction to `store.create(_:)`. CloudKit's repository echoes the input unchanged, so `selectedTransaction.id` stays stable and `.id(selected.id)` no longer forces a view recreation during the create. The `selectedTransaction = created` reassignment is gone.

**Change 3 — simplify `.task(id:)`.** Back to a single `focusedField = target` assignment. No retries, no `Task.sleep`.

## Extras

- `testCreatePreservesInputUUID` in `TransactionStoreTests` codifies the UUID-echo guarantee that Change 2 relies on.
- `STYLE_GUIDE.md §13` gains the `defaultFocus`/`.searchable` caveat so the next contributor doesn't repeat the trap.

## Scope

CloudKit only — per direction `moolah-server` isn't changing and `Remote` is being retired. On `Remote` the server still assigns a new UUID; acceptable during the sunset.

## Test plan

- [x] `just test-ui TransactionDetailFocusTests` — **20/20 stability gate**.
- [x] `just test-mac` — full non-UI suite (includes new `testCreatePreservesInputUUID`).
- [x] `just test-ios` — passes.
- [x] `just build-ios` — passes.
- [x] `just format-check` — clean.

## Follow-ups (not this PR)

- After merge, move `plans/2026-04-21-transaction-detail-focus-design.md` and `-implementation.md` (landing via [#242](https://github.com/ajsutton/moolah-native/pull/242)) into `plans/completed/`.
- Once `Remote` is retired, simplify `TransactionStore.create`'s optimistic-replace branch — the caller UUID is then always preserved end-to-end and the replace step becomes redundant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)