### PR TITLE
fix(build): inject iCloud entitlements into Release for install-mac

### DIFF
--- a/justfile
+++ b/justfile
@@ -94,10 +94,14 @@ run-mac: generate
     xcodebuild build "${args[@]}"
     open .build/Build/Products/Debug/Moolah.app
 
-# Build a Release macOS app and install to /Applications
-install-mac: generate
+# Build a Release macOS app and install to /Applications.
+# Forces ENABLE_ENTITLEMENTS=1 for the regenerate: Release bakes in
+# CLOUDKIT_ENABLED, so an un-entitled binary is killed silently at launch
+# by the hardened runtime when it calls CKContainer.default().
+install-mac:
     #!/usr/bin/env bash
     set -euo pipefail
+    ENABLE_ENTITLEMENTS=1 just generate
     xcodebuild build \
         -scheme Moolah-macOS \
         -destination 'platform=macOS' \

--- a/scripts/inject-entitlements.sh
+++ b/scripts/inject-entitlements.sh
@@ -2,9 +2,14 @@
 # Prepares the build tree for local CloudKit development.
 #
 # 1. Writes .build/Moolah.entitlements with the full sandbox + CloudKit keys.
-# 2. Produces project-entitlements.yml — a copy of project.yml with a
-#    Debug-only settings block added to each app target that wires in
-#    CODE_SIGN_ENTITLEMENTS and the CLOUDKIT_ENABLED compilation condition.
+# 2. Produces project-entitlements.yml — a copy of project.yml that:
+#    - Adds a Debug-only block to each app target wiring in
+#      CODE_SIGN_ENTITLEMENTS and the CLOUDKIT_ENABLED compilation condition.
+#    - Appends CODE_SIGN_ENTITLEMENTS to each target's existing Release block.
+#      Release already bakes in CLOUDKIT_ENABLED via project.yml; without the
+#      matching entitlements file the signed binary calls CKContainer.default()
+#      without the required capability and is killed silently by the hardened
+#      runtime at launch — which is what breaks `just install-mac`.
 #
 # The Debug-Tests configuration deliberately does NOT get these, so
 # `just test` never signs the test host with iCloud entitlements. See
@@ -55,6 +60,10 @@ debug_block = "\n".join([
     "",
 ])
 
+release_entitlements_line = (
+    f"          CODE_SIGN_ENTITLEMENTS: {entitlements_path}\n"
+)
+
 for target in ("Moolah_iOS", "Moolah_macOS"):
     target_header = f"  {target}:\n    type: application\n"
     target_start = content.find(target_header)
@@ -71,12 +80,35 @@ for target in ("Moolah_iOS", "Moolah_macOS"):
     insert_at = configs_pos + len(configs_marker)
     content = content[:insert_at] + debug_block + content[insert_at:]
 
-# Sanity check — both app targets now carry a Debug-scoped entitlement block.
-marker = "        Debug:\n          CODE_SIGN_ENTITLEMENTS:"
-if content.count(marker) != 2:
+    # Append CODE_SIGN_ENTITLEMENTS to this target's existing Release: block.
+    # Search forward from the Debug block we just inserted so we stay inside
+    # this target's configs: section.
+    release_header = "        Release:\n"
+    release_pos = content.find(release_header, insert_at)
+    if release_pos == -1:
+        raise SystemExit(
+            f"inject-entitlements: could not find Release: block for {target}"
+        )
+    release_insert_at = release_pos + len(release_header)
+    content = (
+        content[:release_insert_at]
+        + release_entitlements_line
+        + content[release_insert_at:]
+    )
+
+# Sanity check — both app targets now carry a Debug-scoped entitlement block
+# and a CODE_SIGN_ENTITLEMENTS line at the top of their Release block.
+debug_marker = "        Debug:\n          CODE_SIGN_ENTITLEMENTS:"
+if content.count(debug_marker) != 2:
     raise SystemExit(
         "inject-entitlements: expected 2 Debug entitlement blocks, "
-        f"found {content.count(marker)}"
+        f"found {content.count(debug_marker)}"
+    )
+release_marker = "        Release:\n          CODE_SIGN_ENTITLEMENTS:"
+if content.count(release_marker) != 2:
+    raise SystemExit(
+        "inject-entitlements: expected 2 Release entitlement lines, "
+        f"found {content.count(release_marker)}"
     )
 
 with open(os.environ["OUTFILE"], "w") as f:


### PR DESCRIPTION
## Summary

- `just install-mac` produced a Release binary that died silently at launch.
- Root cause: `project.yml` bakes `CLOUDKIT_ENABLED` into Release unconditionally (commit `f72d9fd`), but `scripts/inject-entitlements.sh` only added the matching `CODE_SIGN_ENTITLEMENTS` line to the `Debug:` block. The signed Release app therefore called `CKContainer.default()` on startup without the iCloud capability, and the hardened runtime killed it with an uncatchable `NSException` before any UI rendered. `just run-mac` (Debug) was unaffected because Debug only gets `CLOUDKIT_ENABLED` when entitlements are also injected — flag and capability stay aligned.
- `scripts/inject-entitlements.sh` now also prepends `CODE_SIGN_ENTITLEMENTS` to each target's existing `Release:` config block in place, so there's no duplicate YAML key against the block that already carries `ENABLE_HARDENED_RUNTIME` / `SWIFT_ACTIVE_COMPILATION_CONDITIONS`.
- `install-mac` now forces `ENABLE_ENTITLEMENTS=1` for its `just generate` step so the fix applies regardless of the dev's local `.env`.

## Test plan

- [x] `just install-mac` builds & installs without errors
- [x] `codesign -d --entitlements :- /Applications/Moolah.app` shows `com.apple.developer.icloud-container-identifiers` = `iCloud.rocks.moolah.app.v2` and `CloudKit` service
- [x] Installed app launches and stays running (was dying silently before)
- [x] `just format-check` clean
- [ ] `just test` on CI (unchanged — inject script still leaves `Debug-Tests` entitlements-free)

🤖 Generated with [Claude Code](https://claude.com/claude-code)