### PR TITLE
fix(transactions): restore Custom mode for iCloud in account/all/reports lists

### DIFF
--- a/App/ContentView.swift
+++ b/App/ContentView.swift
@@ -94,7 +94,8 @@ struct ContentView: View {
               positions: accountStore.positions(for: account.id),
               positionsHostCurrency: account.instrument,
               positionsTitle: account.name,
-              conversionService: session.backend.conversionService)
+              conversionService: session.backend.conversionService,
+              supportsComplexTransactions: session.profile.supportsComplexTransactions)
           }
         }
       case .earmark(let id):
@@ -116,7 +117,8 @@ struct ContentView: View {
           accounts: accountStore.accounts,
           categories: categoryStore.categories,
           earmarks: earmarkStore.earmarks,
-          transactionStore: transactionStore)
+          transactionStore: transactionStore,
+          supportsComplexTransactions: session.profile.supportsComplexTransactions)
       case .upcomingTransactions:
         UpcomingView(
           accounts: accountStore.accounts,

--- a/Features/Reports/Views/ReportsView.swift
+++ b/Features/Reports/Views/ReportsView.swift
@@ -8,6 +8,8 @@ struct ReportsView: View {
   let earmarks: Earmarks
   let transactionStore: TransactionStore
 
+  @Environment(ProfileSession.self) private var session
+
   @State private var dateRange: DateRange = .last12Months
   @State private var customFrom: Date = Calendar.current.date(
     byAdding: .year, value: -1, to: Date())!
@@ -98,7 +100,8 @@ struct ReportsView: View {
           accounts: accounts,
           categories: categories,
           earmarks: earmarks,
-          transactionStore: transactionStore
+          transactionStore: transactionStore,
+          supportsComplexTransactions: session.profile.supportsComplexTransactions
         )
       }
     }
@@ -176,6 +179,7 @@ struct ReportsView: View {
     Category(id: rentId, name: "Rent"),
   ])
   let account = Account(name: "Checking", type: .bank, instrument: .AUD)
+  let session = ProfileSession(profile: Profile(label: "Preview", backendType: .moolah))
 
   ReportsView(
     reportingStore: reportingStore,
@@ -184,6 +188,7 @@ struct ReportsView: View {
     earmarks: Earmarks(from: []),
     transactionStore: transactionStore
   )
+  .environment(session)
   .frame(width: 900, height: 600)
   .task {
     _ = try? await backend.accounts.create(

--- a/Features/Transactions/Views/TransactionListView.swift
+++ b/Features/Transactions/Views/TransactionListView.swift
@@ -13,6 +13,7 @@ struct TransactionListView: View {
   var positionsHostCurrency: Instrument = .AUD
   var positionsTitle: String = "Balances"
   var conversionService: (any InstrumentConversionService)?
+  var supportsComplexTransactions: Bool = false
 
   /// When non-nil, the parent owns the selection and handles the inspector.
   /// When nil, TransactionListView manages its own selection and inspector.
@@ -59,7 +60,8 @@ struct TransactionListView: View {
     positions: [Position] = [],
     positionsHostCurrency: Instrument = .AUD,
     positionsTitle: String = "Balances",
-    conversionService: (any InstrumentConversionService)? = nil
+    conversionService: (any InstrumentConversionService)? = nil,
+    supportsComplexTransactions: Bool = false
   ) {
     self.title = title
     self.baseFilter = filter
@@ -71,6 +73,7 @@ struct TransactionListView: View {
     self.positionsHostCurrency = positionsHostCurrency
     self.positionsTitle = positionsTitle
     self.conversionService = conversionService
+    self.supportsComplexTransactions = supportsComplexTransactions
     self._externalSelection = nil
     self._activeFilter = State(initialValue: filter)
   }
@@ -120,7 +123,8 @@ struct TransactionListView: View {
           categories: categories,
           earmarks: earmarks,
           transactionStore: transactionStore,
-          viewingAccountId: filter.accountId
+          viewingAccountId: filter.accountId,
+          supportsComplexTransactions: supportsComplexTransactions
         )
       )
       .focusedSceneValue(\.newTransactionAction, createNewTransaction)


### PR DESCRIPTION
## Summary

`TransactionListView` owns its own inspector by default but wasn't forwarding `supportsComplexTransactions`, so the "Custom" segment never rendered in:

- the **account transactions** view (sidebar → account)
- the **All Transactions** view
- the **Reports** category drill-down

Even on iCloud profiles where `Profile.supportsComplexTransactions == true`, the view always fell back to the modifier's default of `false`. The other inspector hosts (Investments, Earmark detail, Upcoming, Analysis) already thread the flag; this fix brings `TransactionListView` in line.

## Changes

- `TransactionListView`: accepts `supportsComplexTransactions` on the default (non-embedded) init and forwards it to `OptionalTransactionInspector`. The embedded init is unaffected — its parent owns the inspector and already threads the flag.
- `ContentView`: passes `session.profile.supportsComplexTransactions` for both the per-account view and All Transactions.
- `ReportsView`: adds `@Environment(ProfileSession.self)` and passes the flag for the drill-down list. Preview updated with a preview `ProfileSession`.

Remote / moolah profiles are unaffected (flag remains `false` per `Profile.supportsComplexTransactions`).

## Test plan

- [x] `just format-check` clean
- [x] `just test-mac` — all 1451 tests pass
- [ ] Manual: open an iCloud profile → account view shows Income/Expense/Transfer/**Custom** in the transaction detail picker
- [ ] Manual: Remote profile shows only Income/Expense/Transfer