### PR TITLE
chore(lint): fix convenience_type in AuthContractTests (#300)

### DIFF
--- a/MoolahTests/Domain/AuthContractTests.swift
+++ b/MoolahTests/Domain/AuthContractTests.swift
@@ -6,7 +6,7 @@ import Testing
 /// Both InMemoryAuthProvider and RemoteAuthProvider must pass these tests
 /// to prove substitutability per the architecture contract.
 @Suite("AuthProvider contract")
-struct AuthContractTests {
+enum AuthContractTests {
   // MARK: - InMemoryAuthProvider
 
   @Suite("InMemoryAuthProvider")


### PR DESCRIPTION
## Summary

Fixes SwiftLint `convenience_type` violation in `MoolahTests/Domain/AuthContractTests.swift`.

The outer `AuthContractTests` type only hosts two nested `@Suite` test types and never needs to be instantiated, so it's a namespace — the `convenience_type` rule's recommendation is a caseless `enum`. Changed `struct` → `enum`; no behavioural change.

The `.swiftlint-baseline.yml` still contains the stale entry for this violation (baseline is a one-way ratchet and must not be regenerated per CLAUDE.md); `just format-check` still passes because no new violations are introduced.

Refs #300.

## Test plan

- [x] `just format-check` passes.
- [x] `just test-mac AuthContractTests` — all 7 tests pass (3 suites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)