### PR TITLE
chore(lint): use isEmpty over == "" (#285)

### DIFF
--- a/MoolahTests/Domain/CSVImportProfileTests.swift
+++ b/MoolahTests/Domain/CSVImportProfileTests.swift
@@ -35,6 +35,6 @@ struct CSVImportProfileTests {
   func normaliseHelper() {
     #expect(CSVImportProfile.normalise("  Date  ") == "date")
     #expect(CSVImportProfile.normalise("Amount (AUD)") == "amount (aud)")
-    #expect(CSVImportProfile.normalise("") == "")
+    #expect(CSVImportProfile.normalise("").isEmpty)
   }
 }

--- a/MoolahTests/Export/ExportedDataTests.swift
+++ b/MoolahTests/Export/ExportedDataTests.swift
@@ -117,8 +117,8 @@ struct ExportedDataTests {
     )
 
     #expect(exported.version == 1)
-    #expect(exported.profileLabel == "")
-    #expect(exported.currencyCode == "")
+    #expect(exported.profileLabel.isEmpty)
+    #expect(exported.currencyCode.isEmpty)
     #expect(exported.financialYearStartMonth == 1)
   }
 

--- a/MoolahTests/Features/Import/CSVImportSetupStoreTests.swift
+++ b/MoolahTests/Features/Import/CSVImportSetupStoreTests.swift
@@ -167,7 +167,7 @@ struct CSVImportSetupStoreTests {
     // .ignore should route the raw description to an empty value.
     await store.applyColumnRole(.ignore, forColumn: 1)
     let firstTx = store.preview.first
-    #expect(firstTx?.rawDescription == "")
+    #expect(firstTx?.rawDescription.isEmpty == true)
   }
 
   @Test("saveAndImport persists column-role overrides on the profile")

--- a/MoolahTests/Shared/TransactionDraftTests.swift
+++ b/MoolahTests/Shared/TransactionDraftTests.swift
@@ -258,8 +258,8 @@ struct TransactionDraftTests {
     #expect(draft.legDrafts[0].type == .expense)
     #expect(draft.legDrafts[0].accountId == accountA)
     #expect(draft.legDrafts[0].amountText == "0")
-    #expect(draft.payee == "")
-    #expect(draft.notes == "")
+    #expect(draft.payee.isEmpty)
+    #expect(draft.notes.isEmpty)
     #expect(draft.isRepeating == false)
   }
 
@@ -439,7 +439,7 @@ struct TransactionDraftTests {
     draft.setAmount("abc")
     #expect(draft.legDrafts[draft.relevantLegIndex].amountText == "abc")
     let counterIdx = draft.relevantLegIndex == 0 ? 1 : 0
-    #expect(draft.legDrafts[counterIdx].amountText == "")
+    #expect(draft.legDrafts[counterIdx].amountText.isEmpty)
   }
 
   @Test func setAmountZeroIsValid() {
@@ -1439,7 +1439,7 @@ struct TransactionDraftTests {
     draft.enforceEarmarkOnlyInvariants(at: 0)
     #expect(draft.legDrafts[0].type == .income)
     #expect(draft.legDrafts[0].categoryId == nil)
-    #expect(draft.legDrafts[0].categoryText == "")
+    #expect(draft.legDrafts[0].categoryText.isEmpty)
   }
 
   @Test func earmarkOnlyInvariantsNoOpWhenNotEarmarkOnly() {


### PR DESCRIPTION
## Summary

Fixes all current SwiftLint `empty_string` violations. Rewrote 8 `== ""` sites to `.isEmpty`, covering every violation in:

- `MoolahTests/Domain/CSVImportProfileTests.swift`
- `MoolahTests/Export/ExportedDataTests.swift`
- `MoolahTests/Features/Import/CSVImportSetupStoreTests.swift` (optional-chain case uses `.isEmpty == true`)
- `MoolahTests/Shared/TransactionDraftTests.swift`

The baseline lists 10 violations (2 in the old `MoolahTests/Features/TransactionStoreTests.swift`) — those 2 moved with the file-split refactor in [#307](https://github.com/ajsutton/moolah-native/pull/307) and aren't current violations, so nothing to edit there.

Baseline unchanged.

**Stacked on [#325](https://github.com/ajsutton/moolah-native/pull/325).**

Fixes #285.

## Test plan

- [x] `just format-check` passes.
- [x] `just test-mac CSVImportProfileTests ExportedDataTests CSVImportSetupStoreTests TransactionDraftTests` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)