### PR TITLE
chore(lint): split multi-param signatures one per line (#284, partial)

### DIFF
--- a/Backends/CloudKit/Models/EarmarkRecord.swift
+++ b/Backends/CloudKit/Models/EarmarkRecord.swift
@@ -41,7 +41,9 @@ final class EarmarkRecord {
 
   func toDomain(
     defaultInstrument: Instrument,
-    positions: [Position] = [], savedPositions: [Position] = [], spentPositions: [Position] = []
+    positions: [Position] = [],
+    savedPositions: [Position] = [],
+    spentPositions: [Position] = []
   ) -> Earmark {
     let instrument = instrumentId.map { Instrument.fiat(code: $0) } ?? defaultInstrument
     // Savings goal is always expressed in the earmark's own instrument. The

--- a/Features/Accounts/Views/CreateAccountView.swift
+++ b/Features/Accounts/Views/CreateAccountView.swift
@@ -22,7 +22,8 @@ struct CreateAccountView: View {
   }
 
   init(
-    instrument: Instrument, accountStore: AccountStore,
+    instrument: Instrument,
+    accountStore: AccountStore,
     supportsComplexTransactions: Bool = false
   ) {
     self.instrument = instrument

--- a/MoolahTests/Shared/CSVImport/CSVImportProfileMatcherTests.swift
+++ b/MoolahTests/Shared/CSVImport/CSVImportProfileMatcherTests.swift
@@ -53,7 +53,10 @@ struct CSVImportProfileMatcherTests {
   }
 
   private func existing(
-    accountId: UUID, date: Date, description: String, amount: Decimal,
+    accountId: UUID,
+    date: Date,
+    description: String,
+    amount: Decimal,
     bankRef: String? = nil
   ) -> Transaction {
     Transaction(


### PR DESCRIPTION
## Summary

Fixes 3 of 9 SwiftLint `multiline_parameters` violations — split each signature so every parameter sits on its own line:

- `Backends/CloudKit/Models/EarmarkRecord.swift`'s `toDomain(...)`
- `Features/Accounts/Views/CreateAccountView.swift`'s `init(...)`
- `MoolahTests/Shared/CSVImport/CSVImportProfileMatcherTests.swift`'s `existing(...)` helper

### Deferred (6 of 9)

The other 6 sites all live in files whose `file_length`, `type_body_length`, or `function_body_length` baseline entry is already keyed to the current line count. Splitting parameters one-per-line adds lines and re-keys those entries:

| File | Current | Threshold |
|---|---|---|
| `App/ProfileSession.swift` | 440 | 400 |
| `Features/Transactions/Views/TransactionListView.swift` | 553 | 400 |
| `Shared/Models/TransactionDraft.swift` | 586 | 400 |
| `Shared/CryptoPriceService.swift` (actor) | 285 | 250 |
| `MoolahTests/Features/AnalysisStoreTests.swift` | 926 | 400 |

These unblock once [#272](https://github.com/ajsutton/moolah-native/issues/272) / [#271](https://github.com/ajsutton/moolah-native/issues/271) / [#269](https://github.com/ajsutton/moolah-native/issues/269) land.

Baseline unchanged.

**Stacked on [#326](https://github.com/ajsutton/moolah-native/pull/326).**

Refs #284 (3 of 9 sites).

## Test plan

- [x] `just format-check` passes.
- [x] `just build-mac` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)