### PR TITLE
refactor(profile): split ProfileSession into factories + sync extensions (#272/#271/#269 partial)

### DIFF
--- a/App/ProfileSession+Factories.swift
+++ b/App/ProfileSession+Factories.swift
@@ -1,0 +1,238 @@
+import CloudKit
+import Foundation
+import OSLog
+import SwiftData
+
+extension ProfileSession {
+  /// Bundle of the external market-data services a profile session depends
+  /// on: fiat exchange rates, stock prices, and crypto prices. Returned
+  /// from `makeMarketDataServices` so `init` can assign each field in one
+  /// step.
+  struct MarketDataServices {
+    let exchangeRate: ExchangeRateService
+    let stockPrice: StockPriceService
+    let cryptoPrice: CryptoPriceService
+  }
+
+  /// Builds the fiat/stock/crypto market-data services used throughout the
+  /// profile session. Standalone helper so `ProfileSession.init` can build
+  /// and assign the trio in one step.
+  static func makeMarketDataServices() -> MarketDataServices {
+    MarketDataServices(
+      exchangeRate: ExchangeRateService(client: FrankfurterClient()),
+      stockPrice: StockPriceService(client: YahooFinanceClient()),
+      cryptoPrice: Self.makeCryptoPriceService()
+    )
+  }
+
+  /// Builds the crypto-price service with its configured clients
+  /// (CoinGecko when an API key is present in the keychain, plus
+  /// CryptoCompare and Binance as fallbacks) and the token resolver.
+  static func makeCryptoPriceService() -> CryptoPriceService {
+    let cryptoCompareClient = CryptoCompareClient()
+    let binanceClient = BinanceClient { date in
+      let usdtMapping = CryptoProviderMapping(
+        instrumentId: "1:0xdac17f958d2ee523a2206206994597c13d831ec7",
+        coingeckoId: "tether", cryptocompareSymbol: "USDT", binanceSymbol: nil
+      )
+      do {
+        return try await cryptoCompareClient.dailyPrice(for: usdtMapping, on: date)
+      } catch {
+        return Decimal(1)
+      }
+    }
+
+    let apiKeyStore = KeychainStore(
+      service: "com.moolah.api-keys", account: "coingecko", synchronizable: true
+    )
+    let coinGeckoApiKey = try? apiKeyStore.restoreString()
+
+    var priceClients: [CryptoPriceClient] = []
+    if let coinGeckoApiKey, !coinGeckoApiKey.isEmpty {
+      priceClients.append(CoinGeckoClient(apiKey: coinGeckoApiKey))
+    }
+    priceClients.append(cryptoCompareClient)
+    priceClients.append(binanceClient)
+
+    return CryptoPriceService(
+      clients: priceClients,
+      tokenRepository: ICloudTokenRepository(),
+      resolutionClient: CompositeTokenResolutionClient(coinGeckoApiKey: coinGeckoApiKey)
+    )
+  }
+
+  /// Builds the `BackendProvider` for the profile based on its backend type.
+  /// iCloud profiles get the full conversion service (stock + crypto + fiat);
+  /// remote profiles use their own internal fiat-only conversion.
+  static func makeBackend(
+    profile: Profile,
+    containerManager: ProfileContainerManager?,
+    exchangeRates: ExchangeRateService,
+    stockPrices: StockPriceService,
+    cryptoPrices: CryptoPriceService
+  ) -> BackendProvider {
+    switch profile.backendType {
+    case .remote, .moolah:
+      // Each profile gets its own cookie storage and URLSession.
+      // Ephemeral config provides an isolated cookie storage that URLSession
+      // actually integrates with for automatic Set-Cookie handling.
+      let config = URLSessionConfiguration.ephemeral
+      // URLSessionConfiguration.ephemeral always has a non-nil httpCookieStorage.
+      // swiftlint:disable:next force_unwrapping
+      let cookieStorage = config.httpCookieStorage!
+      let session = URLSession(configuration: config)
+      let cookieKeychain = CookieKeychain(account: profile.id.uuidString)
+      // RemoteBackend uses its own FiatConversionService internally;
+      // moolah-server is fiat-only so stock/crypto conversion via remote is
+      // out of scope. See issue #102 for the CloudKit fix.
+      return RemoteBackend(
+        baseURL: profile.resolvedServerURL,
+        instrument: profile.instrument,
+        session: session,
+        cookieKeychain: cookieKeychain,
+        cookieStorage: cookieStorage
+      )
+
+    case .cloudKit:
+      guard let containerManager else {
+        fatalError("ProfileContainerManager is required for CloudKit profiles")
+      }
+      // A missing container here means the profile can't be constructed;
+      // every call site depends on the session existing so there's no recovery.
+      // swiftlint:disable:next force_try
+      let profileContainer = try! containerManager.container(for: profile.id)
+      // CloudKit profiles need full stock+crypto conversion support. The
+      // closure reads registered tokens from CryptoPriceService on each
+      // conversion so registrations added at runtime become usable without
+      // rebuilding the service. See issue #102.
+      let conversionService = FullConversionService(
+        exchangeRates: exchangeRates,
+        stockPrices: stockPrices,
+        cryptoPrices: cryptoPrices,
+        providerMappings: {
+          await cryptoPrices.registeredItems().map(\.mapping)
+        }
+      )
+      return CloudKitBackend(
+        modelContainer: profileContainer,
+        instrument: profile.instrument,
+        profileLabel: profile.label,
+        conversionService: conversionService
+      )
+    }
+  }
+
+  /// Bundle of the per-profile domain stores. Returned from
+  /// `makeDomainStores` so `ProfileSession.init` can assign each stored
+  /// property in one step without inlining every constructor call.
+  struct DomainStores {
+    let auth: AuthStore
+    let account: AccountStore
+    let category: CategoryStore
+    let earmark: EarmarkStore
+    let transaction: TransactionStore
+    let analysis: AnalysisStore
+    let investment: InvestmentStore
+    let reporting: ReportingStore
+  }
+
+  /// Builds all of the domain stores for a profile against a shared
+  /// `BackendProvider`. The construction order (accounts + earmarks before
+  /// transactions) is preserved to match the previous inline init sequence.
+  static func makeDomainStores(
+    profile: Profile,
+    backend: BackendProvider
+  ) -> DomainStores {
+    let auth = AuthStore(backend: backend)
+    let account = AccountStore(
+      repository: backend.accounts, conversionService: backend.conversionService,
+      targetInstrument: profile.instrument, investmentRepository: backend.investments)
+    let category = CategoryStore(repository: backend.categories)
+    let earmark = EarmarkStore(
+      repository: backend.earmarks, conversionService: backend.conversionService,
+      targetInstrument: profile.instrument)
+    let transaction = TransactionStore(
+      repository: backend.transactions,
+      conversionService: backend.conversionService,
+      targetInstrument: profile.instrument,
+      accountStore: account,
+      earmarkStore: earmark
+    )
+    let analysis = AnalysisStore(repository: backend.analysis)
+    let investment = InvestmentStore(
+      repository: backend.investments,
+      transactionRepository: backend.transactions,
+      conversionService: backend.conversionService
+    )
+    let reporting = ReportingStore(
+      transactionRepository: backend.transactions,
+      analysisRepository: backend.analysis,
+      conversionService: backend.conversionService,
+      profileCurrency: profile.instrument
+    )
+    return DomainStores(
+      auth: auth, account: account, category: category, earmark: earmark,
+      transaction: transaction, analysis: analysis, investment: investment,
+      reporting: reporting
+    )
+  }
+
+  /// Bundle of the services that make up folder-watch ingestion for a
+  /// profile: the on-disk `ImportPreferences`, the catch-up `FolderScanService`,
+  /// and the live `FolderWatchService`. Returned from `makeFolderWatch` so
+  /// `ProfileSession.init` can assign each field in one step.
+  struct FolderWatchServices {
+    let preferences: ImportPreferences
+    let scanner: FolderScanService
+    let watcher: FolderWatchService
+  }
+
+  /// Builds the folder-watch bundle for a profile. `stagingDirectory` is the
+  /// per-profile CSV staging directory; preferences live in its parent so
+  /// they survive staging-store recreation.
+  static func makeFolderWatch(
+    stagingDirectory: URL,
+    profileId: UUID,
+    importStore: ImportStore
+  ) -> FolderWatchServices {
+    let preferencesDirectory = stagingDirectory.deletingLastPathComponent()
+    let preferences = ImportPreferences(directory: preferencesDirectory)
+    let scanner = FolderScanService(
+      profileId: profileId,
+      importStore: importStore,
+      preferences: preferences)
+    let watcher = FolderWatchService(
+      importStore: importStore,
+      preferences: preferences,
+      scanner: scanner)
+    return FolderWatchServices(preferences: preferences, scanner: scanner, watcher: watcher)
+  }
+
+  /// Opens the per-profile CSV import staging store. Falls back to a scratch
+  /// directory in the tmp dir (which cannot fail in practice on Apple
+  /// platforms) if the real directory can't be opened, so the pipeline
+  /// remains functional in the degraded mode.
+  static func makeImportStore(
+    backend: BackendProvider,
+    stagingDirectory: URL,
+    profileId: UUID,
+    logger: Logger
+  ) -> ImportStore {
+    do {
+      let staging = try ImportStagingStore(directory: stagingDirectory)
+      return ImportStore(backend: backend, staging: staging)
+    } catch {
+      let fallback = FileManager.default.temporaryDirectory
+        .appendingPathComponent("csv-staging-fallback-\(profileId.uuidString)")
+      // Fallback in a tmp dir cannot fail in practice on Apple platforms.
+      // swiftlint:disable:next force_try
+      let staging = try! ImportStagingStore(directory: fallback)
+      let errDesc = error.localizedDescription
+      let stagingPath = stagingDirectory.path
+      logger.error(
+        "Failed to open CSV import staging at \(stagingPath, privacy: .public): \(errDesc, privacy: .public). Falling back to tmp."
+      )
+      return ImportStore(backend: backend, staging: staging)
+    }
+  }
+}

--- a/App/ProfileSession+SyncWiring.swift
+++ b/App/ProfileSession+SyncWiring.swift
@@ -1,0 +1,133 @@
+import CloudKit
+import Foundation
+
+extension ProfileSession {
+  /// Wires each `CloudKit*Repository`'s change/delete callbacks to the
+  /// given sync coordinator so local mutations queue the corresponding
+  /// CloudKit send. Called from `init` for iCloud profiles.
+  func wireRepositorySync(coordinator: SyncCoordinator, zoneID: CKRecordZone.ID) {
+    wireAccountsAndTransactionsSync(coordinator: coordinator, zoneID: zoneID)
+    wireSimpleRepositorySync(coordinator: coordinator, zoneID: zoneID)
+  }
+
+  /// Wires repositories that additionally expose `onInstrumentChanged` —
+  /// accounts and transactions — to the sync coordinator.
+  private func wireAccountsAndTransactionsSync(
+    coordinator: SyncCoordinator, zoneID: CKRecordZone.ID
+  ) {
+    if let repo = backend.accounts as? CloudKitAccountRepository {
+      repo.onRecordChanged = { [weak coordinator] id in
+        coordinator?.queueSave(id: id, zoneID: zoneID)
+      }
+      repo.onRecordDeleted = { [weak coordinator] id in
+        coordinator?.queueDeletion(id: id, zoneID: zoneID)
+      }
+      repo.onInstrumentChanged = { [weak coordinator] id in
+        coordinator?.queueSave(recordName: id, zoneID: zoneID)
+      }
+    }
+    if let repo = backend.transactions as? CloudKitTransactionRepository {
+      repo.onRecordChanged = { [weak coordinator] id in
+        coordinator?.queueSave(id: id, zoneID: zoneID)
+      }
+      repo.onRecordDeleted = { [weak coordinator] id in
+        coordinator?.queueDeletion(id: id, zoneID: zoneID)
+      }
+      repo.onInstrumentChanged = { [weak coordinator] id in
+        coordinator?.queueSave(recordName: id, zoneID: zoneID)
+      }
+    }
+  }
+
+  /// Wires repositories that only need the `onRecordChanged` /
+  /// `onRecordDeleted` pair — categories, earmarks, investments,
+  /// csvImportProfiles, importRules — to the sync coordinator.
+  private func wireSimpleRepositorySync(
+    coordinator: SyncCoordinator, zoneID: CKRecordZone.ID
+  ) {
+    if let repo = backend.categories as? CloudKitCategoryRepository {
+      repo.onRecordChanged = { [weak coordinator] id in
+        coordinator?.queueSave(id: id, zoneID: zoneID)
+      }
+      repo.onRecordDeleted = { [weak coordinator] id in
+        coordinator?.queueDeletion(id: id, zoneID: zoneID)
+      }
+    }
+    if let repo = backend.earmarks as? CloudKitEarmarkRepository {
+      repo.onRecordChanged = { [weak coordinator] id in
+        coordinator?.queueSave(id: id, zoneID: zoneID)
+      }
+      repo.onRecordDeleted = { [weak coordinator] id in
+        coordinator?.queueDeletion(id: id, zoneID: zoneID)
+      }
+    }
+    if let repo = backend.investments as? CloudKitInvestmentRepository {
+      repo.onRecordChanged = { [weak coordinator] id in
+        coordinator?.queueSave(id: id, zoneID: zoneID)
+      }
+      repo.onRecordDeleted = { [weak coordinator] id in
+        coordinator?.queueDeletion(id: id, zoneID: zoneID)
+      }
+    }
+    if let repo = backend.csvImportProfiles as? CloudKitCSVImportProfileRepository {
+      repo.onRecordChanged = { [weak coordinator] id in
+        coordinator?.queueSave(id: id, zoneID: zoneID)
+      }
+      repo.onRecordDeleted = { [weak coordinator] id in
+        coordinator?.queueDeletion(id: id, zoneID: zoneID)
+      }
+    }
+    if let repo = backend.importRules as? CloudKitImportRuleRepository {
+      repo.onRecordChanged = { [weak coordinator] id in
+        coordinator?.queueSave(id: id, zoneID: zoneID)
+      }
+      repo.onRecordDeleted = { [weak coordinator] id in
+        coordinator?.queueDeletion(id: id, zoneID: zoneID)
+      }
+    }
+  }
+
+  /// OptionSet for coalesced store reloads after a sync batch.
+  struct StoreReloadPlan: OptionSet, Sendable, Equatable {
+    let rawValue: Int
+    static let accounts = StoreReloadPlan(rawValue: 1 << 0)
+    static let categories = StoreReloadPlan(rawValue: 1 << 1)
+    static let earmarks = StoreReloadPlan(rawValue: 1 << 2)
+    static let importRules = StoreReloadPlan(rawValue: 1 << 3)
+  }
+
+  /// Which stores should be reloaded for a given set of changed record types.
+  /// Exposed as a pure static function so the reload-mapping policy can be
+  /// unit-tested without driving the debounced async task.
+  ///
+  /// `TransactionLegRecord` drives both account balances and earmark positions,
+  /// so a remote leg-only change (e.g. category/earmark reassignment performed
+  /// on another device) must reload both stores even if the parent
+  /// `TransactionRecord` did not change in this batch.
+  static func storesToReload(for changedTypes: Set<String>) -> StoreReloadPlan {
+    var plan: StoreReloadPlan = []
+    if changedTypes.contains(AccountRecord.recordType)
+      || changedTypes.contains(TransactionRecord.recordType)
+      || changedTypes.contains(TransactionLegRecord.recordType)
+    {
+      plan.insert(.accounts)
+    }
+    if changedTypes.contains(CategoryRecord.recordType) {
+      plan.insert(.categories)
+    }
+    if changedTypes.contains(EarmarkRecord.recordType)
+      || changedTypes.contains(EarmarkBudgetItemRecord.recordType)
+      || changedTypes.contains(TransactionLegRecord.recordType)
+    {
+      plan.insert(.earmarks)
+    }
+    if changedTypes.contains(ImportRuleRecord.recordType) {
+      plan.insert(.importRules)
+    }
+    // NOTE: CSVImportProfileRecord has no dedicated store — the setup form
+    // fetches profiles directly via `backend.csvImportProfiles`. Remote
+    // changes land in SwiftData; the setup form reads through to the fresh
+    // values on its own `task`.
+    return plan
+  }
+}

--- a/App/ProfileSession.swift
+++ b/App/ProfileSession.swift
@@ -44,255 +44,95 @@ final class ProfileSession: Identifiable {
   ) {
     self.profile = profile
 
-    let exchangeRateService = ExchangeRateService(client: FrankfurterClient())
-    self.exchangeRateService = exchangeRateService
+    let services = Self.makeMarketDataServices()
+    self.exchangeRateService = services.exchangeRate
+    self.stockPriceService = services.stockPrice
+    self.cryptoPriceService = services.cryptoPrice
+    self.cryptoTokenStore = CryptoTokenStore(cryptoPriceService: services.cryptoPrice)
 
-    let stockPriceService = StockPriceService(client: YahooFinanceClient())
-    self.stockPriceService = stockPriceService
-
-    let cryptoCompareClient = CryptoCompareClient()
-    let binanceClient = BinanceClient { date in
-      let usdtMapping = CryptoProviderMapping(
-        instrumentId: "1:0xdac17f958d2ee523a2206206994597c13d831ec7",
-        coingeckoId: "tether", cryptocompareSymbol: "USDT", binanceSymbol: nil
-      )
-      do {
-        return try await cryptoCompareClient.dailyPrice(for: usdtMapping, on: date)
-      } catch {
-        return Decimal(1)
-      }
-    }
-
-    let apiKeyStore = KeychainStore(
-      service: "com.moolah.api-keys", account: "coingecko", synchronizable: true
+    let backend = Self.makeBackend(
+      profile: profile,
+      containerManager: containerManager,
+      exchangeRates: services.exchangeRate,
+      stockPrices: services.stockPrice,
+      cryptoPrices: services.cryptoPrice
     )
-    let coinGeckoApiKey = try? apiKeyStore.restoreString()
-
-    var priceClients: [CryptoPriceClient] = []
-    if let coinGeckoApiKey, !coinGeckoApiKey.isEmpty {
-      priceClients.append(CoinGeckoClient(apiKey: coinGeckoApiKey))
-    }
-    priceClients.append(cryptoCompareClient)
-    priceClients.append(binanceClient)
-
-    let cryptoPriceService = CryptoPriceService(
-      clients: priceClients,
-      tokenRepository: ICloudTokenRepository(),
-      resolutionClient: CompositeTokenResolutionClient(coinGeckoApiKey: coinGeckoApiKey)
-    )
-    self.cryptoPriceService = cryptoPriceService
-    self.cryptoTokenStore = CryptoTokenStore(cryptoPriceService: cryptoPriceService)
-
-    let backend: BackendProvider
-    switch profile.backendType {
-    case .remote, .moolah:
-      // Each profile gets its own cookie storage and URLSession.
-      // Ephemeral config provides an isolated cookie storage that URLSession
-      // actually integrates with for automatic Set-Cookie handling.
-      let config = URLSessionConfiguration.ephemeral
-      let cookieStorage = config.httpCookieStorage!
-      let session = URLSession(configuration: config)
-
-      // Each profile gets its own keychain entry keyed by profile ID
-      let cookieKeychain = CookieKeychain(account: profile.id.uuidString)
-
-      // RemoteBackend uses its own FiatConversionService internally;
-      // moolah-server is fiat-only so stock/crypto conversion via remote is
-      // out of scope. See issue #102 for the CloudKit fix.
-      backend = RemoteBackend(
-        baseURL: profile.resolvedServerURL,
-        instrument: profile.instrument,
-        session: session,
-        cookieKeychain: cookieKeychain,
-        cookieStorage: cookieStorage
-      )
-
-    case .cloudKit:
-      guard let containerManager else {
-        fatalError("ProfileContainerManager is required for CloudKit profiles")
-      }
-      let profileContainer = try! containerManager.container(for: profile.id)
-      // CloudKit profiles need full stock+crypto conversion support. The
-      // closure reads registered tokens from CryptoPriceService on each
-      // conversion so registrations added at runtime become usable without
-      // rebuilding the service. See issue #102.
-      let conversionService = FullConversionService(
-        exchangeRates: exchangeRateService,
-        stockPrices: stockPriceService,
-        cryptoPrices: cryptoPriceService,
-        providerMappings: {
-          await cryptoPriceService.registeredItems().map(\.mapping)
-        }
-      )
-      backend = CloudKitBackend(
-        modelContainer: profileContainer,
-        instrument: profile.instrument,
-        profileLabel: profile.label,
-        conversionService: conversionService
-      )
-    }
     self.backend = backend
-    self.authStore = AuthStore(backend: backend)
-    self.accountStore = AccountStore(
-      repository: backend.accounts, conversionService: backend.conversionService,
-      targetInstrument: profile.instrument, investmentRepository: backend.investments)
-    self.categoryStore = CategoryStore(repository: backend.categories)
-    self.earmarkStore = EarmarkStore(
-      repository: backend.earmarks, conversionService: backend.conversionService,
-      targetInstrument: profile.instrument)
-    self.transactionStore = TransactionStore(
-      repository: backend.transactions,
-      conversionService: backend.conversionService,
-      targetInstrument: profile.instrument,
-      accountStore: self.accountStore,
-      earmarkStore: self.earmarkStore
-    )
-    self.analysisStore = AnalysisStore(repository: backend.analysis)
-    self.investmentStore = InvestmentStore(
-      repository: backend.investments,
-      transactionRepository: backend.transactions,
-      conversionService: backend.conversionService
-    )
-    self.reportingStore = ReportingStore(
-      transactionRepository: backend.transactions,
-      analysisRepository: backend.analysis,
-      conversionService: backend.conversionService,
-      profileCurrency: profile.instrument
-    )
+    let stores = Self.makeDomainStores(profile: profile, backend: backend)
+    self.authStore = stores.auth
+    self.accountStore = stores.account
+    self.categoryStore = stores.category
+    self.earmarkStore = stores.earmark
+    self.transactionStore = stores.transaction
+    self.analysisStore = stores.analysis
+    self.investmentStore = stores.investment
+    self.reportingStore = stores.reporting
 
     // CSV import: ImportStore owns the pipeline orchestration; the staging
     // store lives per-profile on disk so pending/failed files follow the
     // profile across app restarts.
     let stagingDirectory = ProfileSession.importStagingDirectory(for: profile.id)
-    do {
-      let staging = try ImportStagingStore(directory: stagingDirectory)
-      self.importStore = ImportStore(backend: backend, staging: staging)
-    } catch {
-      // Fall back to a scratch staging store in a temporary directory. This
-      // keeps the store non-optional — pending/failed files won't persist
-      // across app restarts in this degraded mode but the pipeline still
-      // works.
-      let fallback = FileManager.default.temporaryDirectory
-        .appendingPathComponent("csv-staging-fallback-\(profile.id.uuidString)")
-      // Fallback in a tmp dir cannot fail in practice on Apple platforms.
-      // swiftlint:disable:next force_try
-      let staging = try! ImportStagingStore(directory: fallback)
-      self.importStore = ImportStore(backend: backend, staging: staging)
-      let errDesc = error.localizedDescription
-      let stagingPath = stagingDirectory.path
-      logger.error(
-        "Failed to open CSV import staging at \(stagingPath, privacy: .public): \(errDesc, privacy: .public). Falling back to tmp."
-      )
-    }
-    self.importRuleStore = ImportRuleStore(repository: backend.importRules)
-    let preferencesDirectory = stagingDirectory.deletingLastPathComponent()
-    let preferences = ImportPreferences(directory: preferencesDirectory)
-    self.importPreferences = preferences
-    let scanner = FolderScanService(
+    self.importStore = Self.makeImportStore(
+      backend: backend,
+      stagingDirectory: stagingDirectory,
       profileId: profile.id,
-      importStore: self.importStore,
-      preferences: preferences)
-    self.folderScanner = scanner
-    self.folderWatcher = FolderWatchService(
-      importStore: self.importStore,
-      preferences: preferences,
-      scanner: scanner)
+      logger: logger
+    )
+    self.importRuleStore = ImportRuleStore(repository: backend.importRules)
+    let folderWatch = Self.makeFolderWatch(
+      stagingDirectory: stagingDirectory,
+      profileId: profile.id,
+      importStore: self.importStore
+    )
+    self.importPreferences = folderWatch.preferences
+    self.folderScanner = folderWatch.scanner
+    self.folderWatcher = folderWatch.watcher
     // Wire the folder-watch delete-after-import default into ImportStore so a
     // `.folderWatch` ingest honours it even when the matched profile's own
     // `deleteAfterImport` is off.
+    let preferences = folderWatch.preferences
     self.importStore.folderWatchDeleteAfterImport = { [preferences] in
       preferences.deleteAfterImportFolderDefault
     }
 
-    // Wire up cross-store side effects. The callback is fire-and-forget in
-    // production; `updateInvestmentValue` awaits its own first conversion
-    // pass, so the sidebar reflects the new value once the Task completes
-    // on MainActor.
+    wireCrossStoreSideEffects()
+    registerWithSyncCoordinator(syncCoordinator)
+  }
+
+  /// Wires the investment-store -> account-store callback so the sidebar
+  /// total updates when a position revalues. The callback is fire-and-forget
+  /// in production; `updateInvestmentValue` awaits its own first conversion
+  /// pass, so the sidebar reflects the new value once the Task completes
+  /// on MainActor.
+  private func wireCrossStoreSideEffects() {
     let accountStore = self.accountStore
     self.investmentStore.onInvestmentValueChanged = { accountId, latestValue in
       Task {
         await accountStore.updateInvestmentValue(accountId: accountId, value: latestValue)
       }
     }
+  }
 
-    // Register with SyncCoordinator for iCloud profiles
-    if profile.backendType == .cloudKit, let syncCoordinator {
-      let zoneID = CKRecordZone.ID(
-        zoneName: "profile-\(profile.id.uuidString)",
-        ownerName: CKCurrentUserDefaultName)
-
-      logger.info("Registering profile \(profile.id) with sync coordinator")
-      self.syncObserverToken = syncCoordinator.addObserver(for: profile.id) {
-        [weak self] changedTypes in
-        self?.scheduleReloadFromSync(changedTypes: changedTypes)
-      }
-
-      // Wire repository sync closures to coordinator
-      if let repo = backend.accounts as? CloudKitAccountRepository {
-        repo.onRecordChanged = { [weak syncCoordinator] id in
-          syncCoordinator?.queueSave(id: id, zoneID: zoneID)
-        }
-        repo.onRecordDeleted = { [weak syncCoordinator] id in
-          syncCoordinator?.queueDeletion(id: id, zoneID: zoneID)
-        }
-        repo.onInstrumentChanged = { [weak syncCoordinator] id in
-          syncCoordinator?.queueSave(recordName: id, zoneID: zoneID)
-        }
-      }
-      if let repo = backend.transactions as? CloudKitTransactionRepository {
-        repo.onRecordChanged = { [weak syncCoordinator] id in
-          syncCoordinator?.queueSave(id: id, zoneID: zoneID)
-        }
-        repo.onRecordDeleted = { [weak syncCoordinator] id in
-          syncCoordinator?.queueDeletion(id: id, zoneID: zoneID)
-        }
-        repo.onInstrumentChanged = { [weak syncCoordinator] id in
-          syncCoordinator?.queueSave(recordName: id, zoneID: zoneID)
-        }
-      }
-      if let repo = backend.categories as? CloudKitCategoryRepository {
-        repo.onRecordChanged = { [weak syncCoordinator] id in
-          syncCoordinator?.queueSave(id: id, zoneID: zoneID)
-        }
-        repo.onRecordDeleted = { [weak syncCoordinator] id in
-          syncCoordinator?.queueDeletion(id: id, zoneID: zoneID)
-        }
-      }
-      if let repo = backend.earmarks as? CloudKitEarmarkRepository {
-        repo.onRecordChanged = { [weak syncCoordinator] id in
-          syncCoordinator?.queueSave(id: id, zoneID: zoneID)
-        }
-        repo.onRecordDeleted = { [weak syncCoordinator] id in
-          syncCoordinator?.queueDeletion(id: id, zoneID: zoneID)
-        }
-      }
-      if let repo = backend.investments as? CloudKitInvestmentRepository {
-        repo.onRecordChanged = { [weak syncCoordinator] id in
-          syncCoordinator?.queueSave(id: id, zoneID: zoneID)
-        }
-        repo.onRecordDeleted = { [weak syncCoordinator] id in
-          syncCoordinator?.queueDeletion(id: id, zoneID: zoneID)
-        }
-      }
-      if let repo = backend.csvImportProfiles as? CloudKitCSVImportProfileRepository {
-        repo.onRecordChanged = { [weak syncCoordinator] id in
-          syncCoordinator?.queueSave(id: id, zoneID: zoneID)
-        }
-        repo.onRecordDeleted = { [weak syncCoordinator] id in
-          syncCoordinator?.queueDeletion(id: id, zoneID: zoneID)
-        }
-      }
-      if let repo = backend.importRules as? CloudKitImportRuleRepository {
-        repo.onRecordChanged = { [weak syncCoordinator] id in
-          syncCoordinator?.queueSave(id: id, zoneID: zoneID)
-        }
-        repo.onRecordDeleted = { [weak syncCoordinator] id in
-          syncCoordinator?.queueDeletion(id: id, zoneID: zoneID)
-        }
-      }
-    } else if profile.backendType == .cloudKit {
-      logger.warning("CloudKit not available — profile sync disabled for \(profile.id)")
+  /// Registers the session with the `SyncCoordinator` for iCloud profiles:
+  /// installs the per-profile reload observer and wires the repository
+  /// sync callbacks for the profile's zone. No-op for non-CloudKit profiles;
+  /// logs a warning when the profile is CloudKit but the coordinator is
+  /// unavailable.
+  private func registerWithSyncCoordinator(_ coordinator: SyncCoordinator?) {
+    guard profile.backendType == .cloudKit else { return }
+    let profileId = profile.id
+    guard let coordinator else {
+      logger.warning("CloudKit not available — profile sync disabled for \(profileId)")
+      return
     }
+    let zoneID = CKRecordZone.ID(
+      zoneName: "profile-\(profileId.uuidString)",
+      ownerName: CKCurrentUserDefaultName)
+    logger.info("Registering profile \(profileId) with sync coordinator")
+    self.syncObserverToken = coordinator.addObserver(for: profileId) { [weak self] changedTypes in
+      self?.scheduleReloadFromSync(changedTypes: changedTypes)
+    }
+    wireRepositorySync(coordinator: coordinator, zoneID: zoneID)
   }
 
   // MARK: - CloudKit Sync
@@ -341,50 +181,6 @@ final class ProfileSession: Identifiable {
       let reloadMs = (ContinuousClock.now - reloadStart).inMilliseconds
       logger.info("📊 Store reloads after sync completed in \(reloadMs)ms for types: \(types)")
     }
-  }
-
-  /// OptionSet for coalesced store reloads after a sync batch.
-  struct StoreReloadPlan: OptionSet, Sendable, Equatable {
-    let rawValue: Int
-    static let accounts = StoreReloadPlan(rawValue: 1 << 0)
-    static let categories = StoreReloadPlan(rawValue: 1 << 1)
-    static let earmarks = StoreReloadPlan(rawValue: 1 << 2)
-    static let importRules = StoreReloadPlan(rawValue: 1 << 3)
-  }
-
-  /// Which stores should be reloaded for a given set of changed record types.
-  /// Exposed as a pure static function so the reload-mapping policy can be
-  /// unit-tested without driving the debounced async task.
-  ///
-  /// `TransactionLegRecord` drives both account balances and earmark positions,
-  /// so a remote leg-only change (e.g. category/earmark reassignment performed
-  /// on another device) must reload both stores even if the parent
-  /// `TransactionRecord` did not change in this batch.
-  static func storesToReload(for changedTypes: Set<String>) -> StoreReloadPlan {
-    var plan: StoreReloadPlan = []
-    if changedTypes.contains(AccountRecord.recordType)
-      || changedTypes.contains(TransactionRecord.recordType)
-      || changedTypes.contains(TransactionLegRecord.recordType)
-    {
-      plan.insert(.accounts)
-    }
-    if changedTypes.contains(CategoryRecord.recordType) {
-      plan.insert(.categories)
-    }
-    if changedTypes.contains(EarmarkRecord.recordType)
-      || changedTypes.contains(EarmarkBudgetItemRecord.recordType)
-      || changedTypes.contains(TransactionLegRecord.recordType)
-    {
-      plan.insert(.earmarks)
-    }
-    if changedTypes.contains(ImportRuleRecord.recordType) {
-      plan.insert(.importRules)
-    }
-    // NOTE: CSVImportProfileRecord has no dedicated store — the setup form
-    // fetches profiles directly via `backend.csvImportProfiles`. Remote
-    // changes land in SwiftData; the setup form reads through to the fresh
-    // values on its own `task`.
-    return plan
   }
 
   // MARK: - Sync Cleanup


### PR DESCRIPTION
## Summary

Brings `App/ProfileSession.swift` under all three threshold rules (`file_length`, `type_body_length`, `function_body_length`) by extracting cohesive chunks into two new file-scope extension files.

### New files

- **`App/ProfileSession+Factories.swift`** — static factories with small named bundle structs for the multi-value returns:
  - `makeMarketDataServices()` → `MarketDataServices` (exchangeRate / stockPrice / cryptoPrice)
  - `makeCryptoPriceService()` → `CryptoPriceService`
  - `makeBackend(profile:containerManager:exchangeRates:stockPrices:cryptoPrices:)` → `BackendProvider`
  - `makeDomainStores(profile:backend:)` → `DomainStores` (auth / account / category / earmark / transaction / analysis / investment / reporting)
  - `makeImportStore(backend:stagingDirectory:profileId:logger:)` → `ImportStore`
  - `makeFolderWatch(stagingDirectory:profileId:importStore:)` → `FolderWatchServices` (preferences / scanner / watcher)
- **`App/ProfileSession+SyncWiring.swift`** — sync-coordinator wiring:
  - `wireRepositorySync(coordinator:zoneID:)` delegates to `wireAccountsAndTransactionsSync` + `wireSimpleRepositorySync` (each ≤50 lines).
  - `StoreReloadPlan` OptionSet and `storesToReload(for:)` static function.

Two small instance helpers in `ProfileSession.swift` (`wireCrossStoreSideEffects()`, `registerWithSyncCoordinator(_:)`) let the init finish its wiring with two one-liners.

### Measurements (after)

| Metric | Before | After | Limit |
|---|---|---|---|
| `ProfileSession.swift` total lines | 440 | 236 | 400 |
| `init` body | 206 | 45 | 50 |
| `wireRepositorySync` body | 62 (inline-in-init block) | 2 (dispatches to two helpers) | 50 |
| Class body | 332 | 174 | 250 |

### Behaviour

Init sequence preserved exactly: market-data services → backend → domain stores → import store → import-rule store → folder watch → `folderWatchDeleteAfterImport` wiring → cross-store side effects → sync-coordinator registration.

### Pre-existing force_unwrap / force_try

The `config.httpCookieStorage!` and `try! containerManager.container(...)` sites moved from the old `ProfileSession.swift` to `+Factories.swift`; both carry explicit `// swiftlint:disable:next force_unwrapping` / `force_try` pragmas with a short reason.

### Unblocks

Deferred sites in [#290](https://github.com/ajsutton/moolah-native/pull/290), [#289](https://github.com/ajsutton/moolah-native/pull/322), and [#284](https://github.com/ajsutton/moolah-native/pull/327) that hit `ProfileSession.swift`'s old thresholds can now land.

Baseline unchanged (one-way ratchet per CLAUDE.md).

**Stacked on [#328](https://github.com/ajsutton/moolah-native/pull/328).**

Refs #272, #271, #269.

## Test plan

- [x] `just format-check` passes.
- [x] `just build-mac` succeeds.
- [x] `just test-mac ProfileSessionTests` — 15 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)