### PR TITLE
chore(lint): add blank lines between decls and #if blocks (#280, partial)

### DIFF
--- a/App/ContentView.swift
+++ b/App/ContentView.swift
@@ -17,6 +17,7 @@ struct ContentView: View {
   @Environment(AnalysisStore.self) private var analysisStore
   @Environment(InvestmentStore.self) private var investmentStore
   @Environment(ReportingStore.self) private var reportingStore
+
   #if os(macOS)
     @State private var selection: SidebarSelection? = .analysis
   #else

--- a/Automation/Intents/AutomationServiceLocator.swift
+++ b/Automation/Intents/AutomationServiceLocator.swift
@@ -7,5 +7,6 @@ import Foundation
 final class AutomationServiceLocator {
   static let shared = AutomationServiceLocator()
   var service: AutomationService?
+
   private init() {}
 }

--- a/Features/Import/CSVImportSetupStore.swift
+++ b/Features/Import/CSVImportSetupStore.swift
@@ -40,6 +40,7 @@ final class CSVImportSetupStore {
   /// The role a column has been assigned by the user or by the detector.
   enum ColumnRole: String, CaseIterable, Identifiable, Sendable {
     case date, description, amount, debit, credit, balance, reference, ignore
+
     var id: String { rawValue }
     var label: String {
       switch self {

--- a/Features/Import/Views/CSVImportSetupView.swift
+++ b/Features/Import/Views/CSVImportSetupView.swift
@@ -16,6 +16,7 @@ struct CSVImportSetupView: View {
     case ddMMYYYY
     case mmDDYYYY
     case iso
+
     var id: String { rawValue }
     var label: String {
       switch self {

--- a/Features/Migration/MigrationView.swift
+++ b/Features/Migration/MigrationView.swift
@@ -9,9 +9,11 @@ struct MigrationView: View {
   @Environment(ProfileContainerManager.self) private var containerManager
   @Environment(SyncCoordinator.self) private var syncCoordinator
   @Environment(\.dismiss) private var dismiss
+
   #if os(macOS)
     @Environment(\.openWindow) private var openWindow
   #endif
+
   @State private var coordinator = MigrationCoordinator()
 
   var body: some View {

--- a/Features/Navigation/SidebarView.swift
+++ b/Features/Navigation/SidebarView.swift
@@ -21,6 +21,7 @@ struct SidebarView: View {
   @State private var showCreateAccountSheet = false
   @State private var accountToEdit: Account?
   @AppStorage("showHiddenAccounts") private var showHidden = false
+
   #if os(iOS)
     @State private var editMode: EditMode = .inactive
   #endif

--- a/Features/Profiles/Views/ProfileFormView.swift
+++ b/Features/Profiles/Views/ProfileFormView.swift
@@ -7,6 +7,7 @@ import SwiftUI
 struct ProfileFormView: View {
   @Environment(ProfileStore.self) private var profileStore
   @Environment(\.dismiss) private var dismiss
+
   #if os(macOS)
     @Environment(\.openWindow) private var openWindow
   #endif

--- a/Shared/Views/AutocompleteField.swift
+++ b/Shared/Views/AutocompleteField.swift
@@ -3,6 +3,7 @@ import SwiftUI
 /// Preference key to communicate an autocomplete field's bounds to the parent view for dropdown positioning.
 struct AutocompleteFieldAnchorKey: PreferenceKey {
   static let defaultValue: Anchor<CGRect>? = nil
+
   static func reduce(value: inout Anchor<CGRect>?, nextValue: () -> Anchor<CGRect>?) {
     value = value ?? nextValue()
   }

--- a/Shared/Views/CategoryPicker.swift
+++ b/Shared/Views/CategoryPicker.swift
@@ -3,6 +3,7 @@ import SwiftUI
 /// Preference key for positioning the category dropdown relative to the text field.
 struct CategoryPickerAnchorKey: PreferenceKey {
   static let defaultValue: Anchor<CGRect>? = nil
+
   static func reduce(value: inout Anchor<CGRect>?, nextValue: () -> Anchor<CGRect>?) {
     value = value ?? nextValue()
   }
@@ -91,6 +92,7 @@ struct CategorySuggestionDropdown: View {
 /// Stores anchors keyed by leg index so multiple fields can coexist.
 struct LegCategoryPickerAnchorKey: PreferenceKey {
   static let defaultValue: [Int: Anchor<CGRect>] = [:]
+
   static func reduce(value: inout [Int: Anchor<CGRect>], nextValue: () -> [Int: Anchor<CGRect>]) {
     value.merge(nextValue()) { _, new in new }
   }

--- a/Shared/Views/Positions/PositionsTable.swift
+++ b/Shared/Views/Positions/PositionsTable.swift
@@ -176,6 +176,7 @@ struct PositionsTable: View {
 /// in spec order. Each group is empty if no row of that kind appears.
 struct InstrumentGroup: Identifiable {
   enum Kind { case stocks, crypto, cash }
+
   let kind: Kind
   let rows: [ValuedPosition]
   var id: String {


### PR DESCRIPTION
## Summary

Insert blank lines between a `@State`/`@Environment`/`@AppStorage` declaration and the next `#if os(...)`-guarded declaration, and between protocol/static members that the `let_var_whitespace` rule flags.

Fixes 12 of 14 violations. Deferred sites:

- `App/MoolahApp.swift` (currently 621 / limit 400 — adding the blank line would push it to 622 and re-key the `file_length` baseline entry).
- `Features/Import/Views/RecentlyAddedView.swift` (currently 486 / limit 400 — same class of problem).

Those close out once the enclosing files are split.

Refs #280 (12 of 14 sites)

## Test plan
- [x] `just format-check` clean
- [x] `just build-mac` succeeds with no warnings
- [ ] CI green