### PR TITLE
chore(lint): drop optional wrapper on categoryIds + URL queryItems (#276, partial)

### DIFF
--- a/Automation/URLScheme/URLSchemeHandler.swift
+++ b/Automation/URLScheme/URLSchemeHandler.swift
@@ -56,7 +56,7 @@ enum URLSchemeHandler {
     let destination = try parseDestination(
       firstComponent.lowercased(),
       pathComponents: pathComponents,
-      queryItems: URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems
+      queryItems: URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems ?? []
     )
 
     return Route(profileIdentifier: profileIdentifier, destination: destination)
@@ -65,7 +65,7 @@ enum URLSchemeHandler {
   private static func parseDestination(
     _ name: String,
     pathComponents: [String],
-    queryItems: [URLQueryItem]?
+    queryItems: [URLQueryItem]
   ) throws -> Destination {
     switch name {
     case "accounts":
@@ -82,15 +82,15 @@ enum URLSchemeHandler {
       let id = try requireUUID(from: pathComponents, at: 1)
       return .earmark(id)
     case "analysis":
-      let history = queryItems?.first(where: { $0.name == "history" })?.value.flatMap(Int.init)
-      let forecast = queryItems?.first(where: { $0.name == "forecast" })?.value.flatMap(Int.init)
+      let history = queryItems.first(where: { $0.name == "history" })?.value.flatMap(Int.init)
+      let forecast = queryItems.first(where: { $0.name == "forecast" })?.value.flatMap(Int.init)
       return .analysis(history: history, forecast: forecast)
     case "reports":
       let dateFormatter = ISO8601DateFormatter()
       dateFormatter.formatOptions = [.withFullDate]
-      let from = queryItems?.first(where: { $0.name == "from" })?.value.flatMap(
+      let from = queryItems.first(where: { $0.name == "from" })?.value.flatMap(
         dateFormatter.date(from:))
-      let to = queryItems?.first(where: { $0.name == "to" })?.value.flatMap(
+      let to = queryItems.first(where: { $0.name == "to" })?.value.flatMap(
         dateFormatter.date(from:))
       return .reports(from: from, to: to)
     case "categories":

--- a/Backends/CloudKit/Repositories/CloudKitAnalysisRepository.swift
+++ b/Backends/CloudKit/Repositories/CloudKitAnalysisRepository.swift
@@ -373,9 +373,7 @@ final class CloudKitAnalysisRepository: AnalysisRepository, @unchecked Sendable 
       guard dateRange.contains(tx.date) else { continue }
       guard tx.recurPeriod == nil else { continue }
 
-      if let accountId = filters?.accountId {
-        guard tx.accountIds.contains(accountId) else { continue }
-      }
+      if let accountId = filters?.accountId, !tx.accountIds.contains(accountId) { continue }
       if let payee = filters?.payee, tx.payee != payee {
         continue
       }
@@ -387,7 +385,9 @@ final class CloudKitAnalysisRepository: AnalysisRepository, @unchecked Sendable 
         if let earmarkId = filters?.earmarkId, leg.earmarkId != earmarkId {
           continue
         }
-        if let categoryIds = filters?.categoryIds, !categoryIds.contains(categoryId) {
+        if let categoryIds = filters?.categoryIds, !categoryIds.isEmpty,
+          !categoryIds.contains(categoryId)
+        {
           continue
         }
 

--- a/Backends/CloudKit/Repositories/CloudKitTransactionRepository.swift
+++ b/Backends/CloudKit/Repositories/CloudKitTransactionRepository.swift
@@ -191,7 +191,7 @@ final class CloudKitTransactionRepository: TransactionRepository, @unchecked Sen
       }
 
       // categoryIds filter: need to check legs
-      if let categoryIds = filter.categoryIds, !categoryIds.isEmpty {
+      if !filter.categoryIds.isEmpty {
         // Fetch all leg records and find transactions with matching categories
         let allLegs = try fetchAllLegRecords()
         let legsByTxnId = Dictionary(grouping: allLegs, by: \.transactionId)
@@ -199,7 +199,7 @@ final class CloudKitTransactionRepository: TransactionRepository, @unchecked Sen
           guard let legs = legsByTxnId[record.id] else { return false }
           return legs.contains { leg in
             guard let catId = leg.categoryId else { return false }
-            return categoryIds.contains(catId)
+            return filter.categoryIds.contains(catId)
           }
         }
       }

--- a/Backends/Remote/Repositories/RemoteAnalysisRepository.swift
+++ b/Backends/Remote/Repositories/RemoteAnalysisRepository.swift
@@ -91,7 +91,7 @@ final class RemoteAnalysisRepository: AnalysisRepository, Sendable {
     if let earmarkId = filters?.earmarkId {
       queryItems.append(URLQueryItem(name: "earmark", value: earmarkId.apiString))
     }
-    if let categoryIds = filters?.categoryIds {
+    if let categoryIds = filters?.categoryIds, !categoryIds.isEmpty {
       queryItems.append(
         contentsOf: categoryIds.map {
           URLQueryItem(name: "category", value: $0.apiString)

--- a/Backends/Remote/Repositories/RemoteTransactionRepository.swift
+++ b/Backends/Remote/Repositories/RemoteTransactionRepository.swift
@@ -38,8 +38,8 @@ final class RemoteTransactionRepository: TransactionRepository, Sendable {
           name: "to", value: BackendDateFormatter.string(from: dateRange.upperBound)))
     }
 
-    if let categoryIds = filter.categoryIds, !categoryIds.isEmpty {
-      for categoryId in categoryIds {
+    if !filter.categoryIds.isEmpty {
+      for categoryId in filter.categoryIds {
         queryItems.append(URLQueryItem(name: "category", value: categoryId.apiString))
       }
     }

--- a/Domain/Models/Transaction.swift
+++ b/Domain/Models/Transaction.swift
@@ -223,7 +223,7 @@ struct TransactionFilter: Sendable, Equatable {
   var earmarkId: UUID?
   var scheduled: Bool?
   var dateRange: ClosedRange<Date>?
-  var categoryIds: Set<UUID>?
+  var categoryIds: Set<UUID>
   var payee: String?
 
   init(
@@ -231,7 +231,7 @@ struct TransactionFilter: Sendable, Equatable {
     earmarkId: UUID? = nil,
     scheduled: Bool? = nil,
     dateRange: ClosedRange<Date>? = nil,
-    categoryIds: Set<UUID>? = nil,
+    categoryIds: Set<UUID> = [],
     payee: String? = nil
   ) {
     self.accountId = accountId
@@ -246,7 +246,7 @@ struct TransactionFilter: Sendable, Equatable {
 extension TransactionFilter {
   var hasActiveFilters: Bool {
     accountId != nil || earmarkId != nil || scheduled != nil
-      || dateRange != nil || categoryIds != nil || payee != nil
+      || dateRange != nil || !categoryIds.isEmpty || payee != nil
   }
 }
 

--- a/Features/Transactions/Views/TransactionFilterView.swift
+++ b/Features/Transactions/Views/TransactionFilterView.swift
@@ -35,7 +35,7 @@ struct TransactionFilterView: View {
     _selectedScheduled = State(initialValue: filter.scheduled)
     _dateRangeLowerBound = State(initialValue: filter.dateRange?.lowerBound)
     _dateRangeUpperBound = State(initialValue: filter.dateRange?.upperBound)
-    _selectedCategoryIds = State(initialValue: filter.categoryIds ?? [])
+    _selectedCategoryIds = State(initialValue: filter.categoryIds)
     _payeeText = State(initialValue: filter.payee ?? "")
   }
 
@@ -190,7 +190,7 @@ struct TransactionFilterView: View {
       earmarkId: selectedEarmarkId,
       scheduled: selectedScheduled,
       dateRange: dateRange,
-      categoryIds: selectedCategoryIds.isEmpty ? nil : selectedCategoryIds,
+      categoryIds: selectedCategoryIds,
       payee: payeeText.isEmpty ? nil : payeeText
     )
 


### PR DESCRIPTION
## Summary

Three sites where `nil` and `[]` carried the same meaning:

- `URLSchemeHandler.queryItems` — caller already coalesced with `?? []`.
- `Transaction.categoryIds` — Domain model now a `Set<UUID>`, default `[]`. Ripple: `TransactionFilter.categoryIds` ditto; repositories and filter view branch on `.isEmpty` instead of `nil`.

Fixes 3 of 22 sites. The remaining 19 all rely on the nil-vs-empty distinction for a real reason:

- Codable wire format (server JSON and CloudKit round-trip — `nil` = field absent, `[]` = explicit empty).
- `CookieKeychain.restore` — `nil` = nothing stored, `[]` = stored empty.
- CSV parser `malformedRow(row: [String]?)` — `nil` = parser couldn't identify offending row.
- Repository fetches (`subtotalsToConvert`, `accountTransactionIds`) — `nil` = no account filter active, `[]` = filter active with zero matches (opposite semantics).
- Test sentinels for "callback hasn't fired yet" vs "callback fired with empty payload".

Each remaining site needs its own API redesign — out of scope for a lint pass.

Refs #276 (3 of 22 sites)

## Test plan
- [x] `just format-check` clean
- [x] `just build-mac` no user-code warnings
- [x] `just test-mac` — 1462 tests pass
- [ ] CI green