### PR TITLE
chore(lint): extract helpers to drop cyclomatic complexity (#275, partial)

### DIFF
--- a/Automation/AppleScript/Commands/DeleteCommand.swift
+++ b/Automation/AppleScript/Commands/DeleteCommand.swift
@@ -14,86 +14,100 @@
         scriptErrorString = "Missing object specifier for delete"
         return nil
       }
-
-      // Walk up the specifier chain to find the profile name
-      let profileName: String
-      let objectKey = specifier.key
-      let container = specifier.container
-
-      // The specifier should be: object of profile "X"
-      if let nameSpec = container as? NSNameSpecifier {
-        profileName = nameSpec.name
-      } else {
+      guard let profileName = (specifier.container as? NSNameSpecifier)?.name else {
         scriptErrorNumber = -10000
         scriptErrorString = "Cannot determine profile for delete operation"
         return nil
       }
-
-      // Determine what we're deleting based on the key
-      let objectName: String?
-      let objectID: String?
-
-      if let nameSpec = specifier as? NSNameSpecifier {
-        objectName = nameSpec.name
-        objectID = nil
-      } else if let idSpec = specifier as? NSUniqueIDSpecifier {
-        objectName = nil
-        objectID = idSpec.uniqueID as? String
-      } else {
+      guard let target = resolveTarget(specifier) else {
         scriptErrorNumber = -10000
         scriptErrorString = "Cannot identify object to delete"
         return nil
       }
-
+      let objectKey = specifier.key
       let result: Bool? = runBlockingWithError { @MainActor () async throws -> Bool in
         guard let service = ScriptingContext.automationService else {
           throw AutomationError.operationFailed("Scripting not configured")
         }
-
-        switch objectKey {
-        case "scriptableAccounts":
-          let account: Account
-          if let objectName {
-            account = try service.resolveAccount(named: objectName, profileIdentifier: profileName)
-          } else if let objectID, let uuid = UUID(uuidString: objectID) {
-            account = try service.resolveAccount(id: uuid, profileIdentifier: profileName)
-          } else {
-            throw AutomationError.accountNotFound("unknown")
-          }
-          try await service.deleteAccount(profileIdentifier: profileName, accountId: account.id)
-
-        case "scriptableTransactions":
-          guard let objectID, let uuid = UUID(uuidString: objectID) else {
-            throw AutomationError.transactionNotFound("unknown")
-          }
-          try await service.deleteTransaction(profileIdentifier: profileName, transactionId: uuid)
-
-        case "scriptableEarmarks":
-          let earmark: Earmark
-          if let objectName {
-            earmark = try service.resolveEarmark(named: objectName, profileIdentifier: profileName)
-          } else {
-            throw AutomationError.earmarkNotFound("unknown")
-          }
-          try await service.deleteEarmark(profileIdentifier: profileName, earmarkId: earmark.id)
-
-        case "scriptableCategories":
-          let category: Category
-          if let objectName {
-            category = try service.resolveCategory(
-              named: objectName, profileIdentifier: profileName)
-          } else {
-            throw AutomationError.categoryNotFound("unknown")
-          }
-          try await service.deleteCategory(profileIdentifier: profileName, categoryId: category.id)
-
-        default:
-          throw AutomationError.operationFailed("Cannot delete objects of type '\(objectKey)'")
-        }
-
+        try await Self.performDelete(
+          objectKey: objectKey, target: target,
+          profileName: profileName, service: service)
         return true
       }
       return result
+    }
+
+    /// Identifies the object the user wants to delete by name or unique ID.
+    private struct DeleteTarget: Sendable {
+      let name: String?
+      let id: String?
+    }
+
+    private func resolveTarget(_ specifier: NSScriptObjectSpecifier) -> DeleteTarget? {
+      if let nameSpec = specifier as? NSNameSpecifier {
+        return DeleteTarget(name: nameSpec.name, id: nil)
+      }
+      if let idSpec = specifier as? NSUniqueIDSpecifier {
+        return DeleteTarget(name: nil, id: idSpec.uniqueID as? String)
+      }
+      return nil
+    }
+
+    @MainActor
+    private static func performDelete(
+      objectKey: String,
+      target: DeleteTarget,
+      profileName: String,
+      service: AutomationService
+    ) async throws {
+      switch objectKey {
+      case "scriptableAccounts":
+        try await deleteAccount(target: target, profileName: profileName, service: service)
+      case "scriptableTransactions":
+        guard let objectID = target.id, let uuid = UUID(uuidString: objectID) else {
+          throw AutomationError.transactionNotFound("unknown")
+        }
+        try await service.deleteTransaction(profileIdentifier: profileName, transactionId: uuid)
+      case "scriptableEarmarks":
+        try await deleteEarmark(target: target, profileName: profileName, service: service)
+      case "scriptableCategories":
+        try await deleteCategory(target: target, profileName: profileName, service: service)
+      default:
+        throw AutomationError.operationFailed("Cannot delete objects of type '\(objectKey)'")
+      }
+    }
+
+    @MainActor
+    private static func deleteAccount(
+      target: DeleteTarget, profileName: String, service: AutomationService
+    ) async throws {
+      let account: Account
+      if let name = target.name {
+        account = try service.resolveAccount(named: name, profileIdentifier: profileName)
+      } else if let objectID = target.id, let uuid = UUID(uuidString: objectID) {
+        account = try service.resolveAccount(id: uuid, profileIdentifier: profileName)
+      } else {
+        throw AutomationError.accountNotFound("unknown")
+      }
+      try await service.deleteAccount(profileIdentifier: profileName, accountId: account.id)
+    }
+
+    @MainActor
+    private static func deleteEarmark(
+      target: DeleteTarget, profileName: String, service: AutomationService
+    ) async throws {
+      guard let name = target.name else { throw AutomationError.earmarkNotFound("unknown") }
+      let earmark = try service.resolveEarmark(named: name, profileIdentifier: profileName)
+      try await service.deleteEarmark(profileIdentifier: profileName, earmarkId: earmark.id)
+    }
+
+    @MainActor
+    private static func deleteCategory(
+      target: DeleteTarget, profileName: String, service: AutomationService
+    ) async throws {
+      guard let name = target.name else { throw AutomationError.categoryNotFound("unknown") }
+      let category = try service.resolveCategory(named: name, profileIdentifier: profileName)
+      try await service.deleteCategory(profileIdentifier: profileName, categoryId: category.id)
     }
   }
 #endif

--- a/Automation/AppleScript/Commands/NavigateCommand.swift
+++ b/Automation/AppleScript/Commands/NavigateCommand.swift
@@ -15,60 +15,59 @@
         return nil
       }
 
-      let objectKey = specifier.key
-
-      // Walk up to find the profile name
       guard let profileSpec = specifier.container as? NSNameSpecifier else {
-        // Maybe the specifier IS a profile
-        if let nameSpec = specifier as? NSNameSpecifier, specifier.key == "scriptableProfiles" {
-          // Navigate to profile root — just open the window
-          let profileName = nameSpec.name
-          let urlString =
-            "moolah://\(profileName.addingPercentEncoding(withAllowedCharacters: .urlHostAllowed) ?? profileName)"
-          if let url = URL(string: urlString) {
-            NSWorkspace.shared.open(url)
-          }
-          return nil
-        }
-        scriptErrorNumber = -10000
-        scriptErrorString = "Cannot determine profile for navigation"
-        return nil
-      }
-      let profileName = profileSpec.name
-
-      // Build a moolah:// URL based on the object type
-      let destination: String
-      switch objectKey {
-      case "scriptableAccounts":
-        if let nameSpec = specifier as? NSNameSpecifier {
-          destination =
-            "accounts/\(nameSpec.name.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? nameSpec.name)"
-        } else {
-          destination = "accounts"
-        }
-      case "scriptableTransactions":
-        destination = "transactions"
-      case "scriptableEarmarks":
-        if let nameSpec = specifier as? NSNameSpecifier {
-          destination =
-            "earmarks/\(nameSpec.name.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? nameSpec.name)"
-        } else {
-          destination = "earmarks"
-        }
-      case "scriptableCategories":
-        destination = "categories"
-      default:
-        destination = ""
+        return openProfileRoot(specifier: specifier)
       }
 
       let host =
-        profileName.addingPercentEncoding(withAllowedCharacters: .urlHostAllowed) ?? profileName
+        profileSpec.name.addingPercentEncoding(withAllowedCharacters: .urlHostAllowed)
+        ?? profileSpec.name
+      let destination = destinationPath(for: specifier)
       let urlString = destination.isEmpty ? "moolah://\(host)" : "moolah://\(host)/\(destination)"
-      if let url = URL(string: urlString) {
-        NSWorkspace.shared.open(url)
-      }
-
+      if let url = URL(string: urlString) { NSWorkspace.shared.open(url) }
       return nil
+    }
+
+    /// Open the top-level window for a profile specifier with no container,
+    /// or record an error when the specifier can't be resolved to a profile.
+    private func openProfileRoot(specifier: NSScriptObjectSpecifier) -> Any? {
+      if let nameSpec = specifier as? NSNameSpecifier, specifier.key == "scriptableProfiles" {
+        let encoded =
+          nameSpec.name.addingPercentEncoding(withAllowedCharacters: .urlHostAllowed)
+          ?? nameSpec.name
+        if let url = URL(string: "moolah://\(encoded)") { NSWorkspace.shared.open(url) }
+        return nil
+      }
+      scriptErrorNumber = -10000
+      scriptErrorString = "Cannot determine profile for navigation"
+      return nil
+    }
+
+    /// Map an object specifier (accounts / transactions / earmarks / categories)
+    /// to the tail of the `moolah://` URL.
+    private func destinationPath(for specifier: NSScriptObjectSpecifier) -> String {
+      switch specifier.key {
+      case "scriptableAccounts":
+        return namedPath(prefix: "accounts", specifier: specifier)
+      case "scriptableTransactions":
+        return "transactions"
+      case "scriptableEarmarks":
+        return namedPath(prefix: "earmarks", specifier: specifier)
+      case "scriptableCategories":
+        return "categories"
+      default:
+        return ""
+      }
+    }
+
+    /// Append the specifier's name to `prefix` (if the specifier is a name
+    /// specifier) or return just the prefix otherwise.
+    private func namedPath(prefix: String, specifier: NSScriptObjectSpecifier) -> String {
+      guard let nameSpec = specifier as? NSNameSpecifier else { return prefix }
+      let encoded =
+        nameSpec.name.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed)
+        ?? nameSpec.name
+      return "\(prefix)/\(encoded)"
     }
   }
 #endif

--- a/Backends/CloudKit/Sync/ProfileIndexSyncHandler.swift
+++ b/Backends/CloudKit/Sync/ProfileIndexSyncHandler.swift
@@ -221,59 +221,72 @@ final class ProfileIndexSyncHandler {
     failedSaves: [CKSyncEngine.Event.SentRecordZoneChanges.FailedRecordSave],
     failedDeletes: [(CKRecord.ID, CKError)]
   ) -> SyncErrorRecovery.ClassifiedFailures {
-    // Update system fields on model records after successful upload.
-    if !savedRecords.isEmpty {
-      let context = ModelContext(modelContainer)
-      for saved in savedRecords {
-        guard let profileId = UUID(uuidString: saved.recordID.recordName) else { continue }
-        let descriptor = FetchDescriptor<ProfileRecord>(
-          predicate: #Predicate { $0.id == profileId }
-        )
-        if let record = fetchOrLog(descriptor, context: context).first {
-          record.encodedSystemFields = saved.encodedSystemFields
-        }
-      }
-      do {
-        try context.save()
-      } catch {
-        logger.error("Failed to save system fields after upload: \(error)")
-      }
-    }
-
-    // Classify failures
+    persistSystemFields(for: savedRecords)
     let failures = SyncErrorRecovery.classify(
       failedSaves: failedSaves,
       failedDeletes: failedDeletes,
       logger: logger)
-
-    // Update system fields from server records on conflict, clear on unknownItem
-    if !failures.conflicts.isEmpty || !failures.unknownItems.isEmpty {
-      let context = ModelContext(modelContainer)
-      for (_, serverRecord) in failures.conflicts {
-        guard let profileId = UUID(uuidString: serverRecord.recordID.recordName) else { continue }
-        let descriptor = FetchDescriptor<ProfileRecord>(
-          predicate: #Predicate { $0.id == profileId }
-        )
-        if let record = fetchOrLog(descriptor, context: context).first {
-          record.encodedSystemFields = serverRecord.encodedSystemFields
-        }
-      }
-      for (recordID, _) in failures.unknownItems {
-        guard let profileId = UUID(uuidString: recordID.recordName) else { continue }
-        let descriptor = FetchDescriptor<ProfileRecord>(
-          predicate: #Predicate { $0.id == profileId }
-        )
-        if let record = fetchOrLog(descriptor, context: context).first {
-          record.encodedSystemFields = nil
-        }
-      }
-      do {
-        try context.save()
-      } catch {
-        logger.error("Failed to save system fields after conflict resolution: \(error)")
-      }
-    }
-
+    resolveSystemFields(for: failures)
     return failures
+  }
+
+  /// Persist updated CKRecord system fields onto matching `ProfileRecord` rows
+  /// after a successful upload.
+  private func persistSystemFields(for savedRecords: [CKRecord]) {
+    guard !savedRecords.isEmpty else { return }
+    let context = ModelContext(modelContainer)
+    for saved in savedRecords {
+      updateSystemFields(
+        forProfileId: saved.recordID.recordName,
+        context: context,
+        to: saved.encodedSystemFields
+      )
+    }
+    do {
+      try context.save()
+    } catch {
+      logger.error("Failed to save system fields after upload: \(error)")
+    }
+  }
+
+  /// Apply server-side system fields from conflicts, and clear system fields for
+  /// records the server has already deleted.
+  private func resolveSystemFields(for failures: SyncErrorRecovery.ClassifiedFailures) {
+    guard !failures.conflicts.isEmpty || !failures.unknownItems.isEmpty else { return }
+    let context = ModelContext(modelContainer)
+    for (_, serverRecord) in failures.conflicts {
+      updateSystemFields(
+        forProfileId: serverRecord.recordID.recordName,
+        context: context,
+        to: serverRecord.encodedSystemFields
+      )
+    }
+    for (recordID, _) in failures.unknownItems {
+      updateSystemFields(
+        forProfileId: recordID.recordName,
+        context: context,
+        to: nil
+      )
+    }
+    do {
+      try context.save()
+    } catch {
+      logger.error("Failed to save system fields after conflict resolution: \(error)")
+    }
+  }
+
+  /// Look up a `ProfileRecord` by id string and replace its cached system fields.
+  private func updateSystemFields(
+    forProfileId recordName: String,
+    context: ModelContext,
+    to data: Data?
+  ) {
+    guard let profileId = UUID(uuidString: recordName) else { return }
+    let descriptor = FetchDescriptor<ProfileRecord>(
+      predicate: #Predicate { $0.id == profileId }
+    )
+    if let record = fetchOrLog(descriptor, context: context).first {
+      record.encodedSystemFields = data
+    }
   }
 }

--- a/Backends/CloudKit/Sync/SyncErrorRecovery.swift
+++ b/Backends/CloudKit/Sync/SyncErrorRecovery.swift
@@ -35,71 +35,87 @@ enum SyncErrorRecovery {
     logger: Logger
   ) -> ClassifiedFailures {
     var result = ClassifiedFailures()
-
     for failure in failedSaves {
-      let recordID = failure.record.recordID
-
-      switch failure.error.code {
-      case .zoneNotFound, .userDeletedZone:
-        result.zoneNotFoundSaves.append(recordID)
-
-      case .serverRecordChanged:
-        if let serverRecord = failure.error.serverRecord {
-          result.conflicts.append((recordID: recordID, serverRecord: serverRecord))
-        } else {
-          // Server record unavailable — re-queue so the record isn't silently lost
-          logger.warning(
-            "serverRecordChanged with no serverRecord for \(recordID.recordName) — re-queuing")
-          result.requeue.append(recordID)
-        }
-
-      case .unknownItem:
-        result.unknownItems.append((recordID: recordID, recordType: failure.record.recordType))
-
-      case .quotaExceeded:
-        logger.error(
-          "iCloud quota exceeded — sync paused for record \(recordID.recordName)")
-        result.quotaExceeded.append(recordID)
-
-      case .limitExceeded, .batchRequestFailed:
-        result.requeue.append(recordID)
-
-      default:
-        // Re-queue unexpected errors. CKSyncEngine handles transient errors
-        // (network, rate limiting) automatically, but other errors drop the
-        // record from the queue. Re-queuing ensures we don't silently lose data.
-        logger.error(
-          "Save error (code=\(failure.error.code.rawValue)) for \(recordID.recordName): \(failure.error) — re-queuing"
-        )
-        result.requeue.append(recordID)
-      }
+      classifySaveFailure(failure, into: &result, logger: logger)
     }
-
     for (recordID, error) in failedDeletes {
-      switch error.code {
-      case .zoneNotFound, .userDeletedZone:
-        result.zoneNotFoundDeletes.append(recordID)
-
-      case .unknownItem:
-        // Record is already gone from the server — the delete has effectively
-        // succeeded. Don't re-queue (would loop forever) and don't treat as a
-        // failure. CKSyncEngine has already removed it from its pending queue.
-        logger.info(
-          "Delete returned unknownItem for \(recordID.recordName) — record already gone, treating as success"
-        )
-
-      default:
-        // Re-queue any other delete failure (serverRecordChanged, limitExceeded,
-        // unexpected errors). CKSyncEngine drops failed items from its queue, so
-        // not re-queuing would leave the record on the server permanently.
-        logger.error(
-          "Delete error (code=\(error.code.rawValue)) for \(recordID.recordName): \(error) — re-queuing"
-        )
-        result.requeueDeletes.append(recordID)
-      }
+      classifyDeleteFailure(recordID: recordID, error: error, into: &result, logger: logger)
     }
-
     return result
+  }
+
+  /// Route one failed save into the appropriate `ClassifiedFailures` bucket.
+  /// Kept separate so `classify` stays below the cyclomatic-complexity threshold.
+  private static func classifySaveFailure(
+    _ failure: CKSyncEngine.Event.SentRecordZoneChanges.FailedRecordSave,
+    into result: inout ClassifiedFailures,
+    logger: Logger
+  ) {
+    let recordID = failure.record.recordID
+    switch failure.error.code {
+    case .zoneNotFound, .userDeletedZone:
+      result.zoneNotFoundSaves.append(recordID)
+
+    case .serverRecordChanged:
+      if let serverRecord = failure.error.serverRecord {
+        result.conflicts.append((recordID: recordID, serverRecord: serverRecord))
+      } else {
+        // Server record unavailable — re-queue so the record isn't silently lost
+        logger.warning(
+          "serverRecordChanged with no serverRecord for \(recordID.recordName) — re-queuing")
+        result.requeue.append(recordID)
+      }
+
+    case .unknownItem:
+      result.unknownItems.append((recordID: recordID, recordType: failure.record.recordType))
+
+    case .quotaExceeded:
+      logger.error(
+        "iCloud quota exceeded — sync paused for record \(recordID.recordName)")
+      result.quotaExceeded.append(recordID)
+
+    case .limitExceeded, .batchRequestFailed:
+      result.requeue.append(recordID)
+
+    default:
+      // Re-queue unexpected errors. CKSyncEngine handles transient errors
+      // (network, rate limiting) automatically, but other errors drop the
+      // record from the queue. Re-queuing ensures we don't silently lose data.
+      logger.error(
+        "Save error (code=\(failure.error.code.rawValue)) for \(recordID.recordName): \(failure.error) — re-queuing"
+      )
+      result.requeue.append(recordID)
+    }
+  }
+
+  /// Route one failed delete into the appropriate `ClassifiedFailures` bucket.
+  private static func classifyDeleteFailure(
+    recordID: CKRecord.ID,
+    error: CKError,
+    into result: inout ClassifiedFailures,
+    logger: Logger
+  ) {
+    switch error.code {
+    case .zoneNotFound, .userDeletedZone:
+      result.zoneNotFoundDeletes.append(recordID)
+
+    case .unknownItem:
+      // Record is already gone from the server — the delete has effectively
+      // succeeded. Don't re-queue (would loop forever) and don't treat as a
+      // failure. CKSyncEngine has already removed it from its pending queue.
+      logger.info(
+        "Delete returned unknownItem for \(recordID.recordName) — record already gone, treating as success"
+      )
+
+    default:
+      // Re-queue any other delete failure (serverRecordChanged, limitExceeded,
+      // unexpected errors). CKSyncEngine drops failed items from its queue, so
+      // not re-queuing would leave the record on the server permanently.
+      logger.error(
+        "Delete error (code=\(error.code.rawValue)) for \(recordID.recordName): \(error) — re-queuing"
+      )
+      result.requeueDeletes.append(recordID)
+    }
   }
 
   /// Re-queues all classified failures except zone-not-found records.

--- a/Shared/CSVImport/CSVTokenizer.swift
+++ b/Shared/CSVImport/CSVTokenizer.swift
@@ -10,62 +10,87 @@ enum CSVTokenizer: Sendable {
 
   /// Parse CSV text into rows. See type docs for handled edge cases.
   static func parse(_ text: String) -> [[String]] {
-    var rows: [[String]] = []
-    var field = ""
-    var row: [String] = []
-    var inQuotes = false
+    var state = ParseState()
     var scalars = Substring(text).unicodeScalars[...]
     if scalars.first == "\u{FEFF}" { scalars = scalars.dropFirst() }
     var i = scalars.startIndex
     while i < scalars.endIndex {
       let c = scalars[i]
-      if inQuotes {
-        if c == "\"" {
-          let next = scalars.index(after: i)
-          if next < scalars.endIndex && scalars[next] == "\"" {
-            field.append("\"")
-            i = scalars.index(after: next)
-            continue
-          } else {
-            inQuotes = false
-            i = scalars.index(after: i)
-            continue
-          }
-        }
-        field.unicodeScalars.append(c)
-        i = scalars.index(after: i)
-        continue
+      if state.inQuotes {
+        i = handleQuoted(c, at: i, in: scalars, state: &state)
+      } else {
+        i = handleUnquoted(c, at: i, in: scalars, state: &state)
       }
-      switch c {
-      case "\"":
-        inQuotes = true
-      case ",":
-        row.append(field)
-        field = ""
-      case "\r":
-        row.append(field)
-        field = ""
-        rows.append(row)
-        row = []
-        let next = scalars.index(after: i)
-        if next < scalars.endIndex && scalars[next] == "\n" {
-          i = next
-        }
-      case "\n":
-        row.append(field)
-        field = ""
-        rows.append(row)
-        row = []
-      default:
-        field.unicodeScalars.append(c)
+    }
+    if !state.field.isEmpty || !state.row.isEmpty {
+      state.row.append(state.field)
+      state.rows.append(state.row)
+    }
+    return state.rows.filter { !($0.count == 1 && $0[0].isEmpty) }
+  }
+
+  /// Mutable parser state — kept together so the per-scalar helpers can thread
+  /// it via a single `inout` parameter.
+  private struct ParseState {
+    var rows: [[String]] = []
+    var field = ""
+    var row: [String] = []
+    var inQuotes = false
+  }
+
+  /// Handle one scalar inside a quoted field; returns the next scanner index.
+  private static func handleQuoted(
+    _ scalar: Unicode.Scalar,
+    at i: String.UnicodeScalarView.SubSequence.Index,
+    in scalars: Substring.UnicodeScalarView.SubSequence,
+    state: inout ParseState
+  ) -> String.UnicodeScalarView.SubSequence.Index {
+    if scalar == "\"" {
+      let next = scalars.index(after: i)
+      if next < scalars.endIndex && scalars[next] == "\"" {
+        state.field.append("\"")
+        return scalars.index(after: next)
       }
-      i = scalars.index(after: i)
+      state.inQuotes = false
+      return scalars.index(after: i)
     }
-    if !field.isEmpty || !row.isEmpty {
-      row.append(field)
-      rows.append(row)
+    state.field.unicodeScalars.append(scalar)
+    return scalars.index(after: i)
+  }
+
+  /// Handle one scalar outside a quoted field; returns the next scanner index.
+  private static func handleUnquoted(
+    _ scalar: Unicode.Scalar,
+    at i: String.UnicodeScalarView.SubSequence.Index,
+    in scalars: Substring.UnicodeScalarView.SubSequence,
+    state: inout ParseState
+  ) -> String.UnicodeScalarView.SubSequence.Index {
+    var i = i
+    switch scalar {
+    case "\"":
+      state.inQuotes = true
+    case ",":
+      state.row.append(state.field)
+      state.field = ""
+    case "\r":
+      finishRow(state: &state)
+      let next = scalars.index(after: i)
+      if next < scalars.endIndex && scalars[next] == "\n" {
+        i = next
+      }
+    case "\n":
+      finishRow(state: &state)
+    default:
+      state.field.unicodeScalars.append(scalar)
     }
-    return rows.filter { !($0.count == 1 && $0[0].isEmpty) }
+    return scalars.index(after: i)
+  }
+
+  private static func finishRow(state: inout ParseState) {
+    state.row.append(state.field)
+    state.field = ""
+    state.rows.append(state.row)
+    state.row = []
   }
 
   /// Parse raw bytes: detect encoding via `CSVIngestionText.decode(_:)`, then tokenize.

--- a/Shared/CSVImport/GenericBankCSVParser.swift
+++ b/Shared/CSVImport/GenericBankCSVParser.swift
@@ -229,49 +229,62 @@ struct GenericBankCSVParser: CSVParser, Sendable {
   private func detectDateFormat(
     columnIndex: Int, sampleRows: [[String]]
   ) -> (DateFormat, Bool) {
+    let signals = scanDateSignals(columnIndex: columnIndex, sampleRows: sampleRows)
+    return decideDateFormat(signals: signals)
+  }
+
+  /// Signals gathered from a single pass over sample date cells.
+  private struct DateFormatSignals {
     var separator: Character = "/"
     var sawSeparator = false
     var firstGreaterThan12 = false
     var secondGreaterThan12 = false
     var anyIsoShaped = false
+  }
 
+  private func scanDateSignals(
+    columnIndex: Int, sampleRows: [[String]]
+  ) -> DateFormatSignals {
+    var signals = DateFormatSignals()
     for row in sampleRows {
       guard columnIndex >= 0, columnIndex < row.count else { continue }
       let value = row[columnIndex].trimmingCharacters(in: .whitespaces)
       if value.isEmpty { continue }
       if isISOShaped(value) {
-        anyIsoShaped = true
+        signals.anyIsoShaped = true
         continue
       }
       let chosen: Character? = value.contains("/") ? "/" : (value.contains("-") ? "-" : nil)
       guard let sep = chosen else { continue }
-      if !sawSeparator {
-        separator = sep
-        sawSeparator = true
+      if !signals.sawSeparator {
+        signals.separator = sep
+        signals.sawSeparator = true
       }
       let components = value.split(separator: sep)
       guard components.count == 3,
         let first = Int(components[0]),
         let second = Int(components[1])
       else { continue }
-      if first > 12 { firstGreaterThan12 = true }
-      if second > 12 { secondGreaterThan12 = true }
+      if first > 12 { signals.firstGreaterThan12 = true }
+      if second > 12 { signals.secondGreaterThan12 = true }
     }
+    return signals
+  }
 
-    if anyIsoShaped {
-      return (.iso, false)
-    }
-    if firstGreaterThan12 && !secondGreaterThan12 {
-      return (.ddMMyyyy(separator: separator), false)
-    }
-    if secondGreaterThan12 && !firstGreaterThan12 {
-      return (.mmDDyyyy(separator: separator), false)
-    }
-    if firstGreaterThan12 && secondGreaterThan12 {
+  private func decideDateFormat(signals: DateFormatSignals) -> (DateFormat, Bool) {
+    if signals.anyIsoShaped { return (.iso, false) }
+    let sep = signals.separator
+    switch (signals.firstGreaterThan12, signals.secondGreaterThan12) {
+    case (true, false):
+      return (.ddMMyyyy(separator: sep), false)
+    case (false, true):
+      return (.mmDDyyyy(separator: sep), false)
+    case (true, true):
       // Both invalid — caller's parse step will throw on the first row.
-      return (.ddMMyyyy(separator: separator), false)
+      return (.ddMMyyyy(separator: sep), false)
+    case (false, false):
+      return (.ddMMyyyy(separator: sep), true)
     }
-    return (.ddMMyyyy(separator: separator), true)
   }
 
   private func isISOShaped(_ value: String) -> Bool {

--- a/Shared/Models/DateRange.swift
+++ b/Shared/Models/DateRange.swift
@@ -27,22 +27,22 @@ enum DateRange: String, CaseIterable, Identifiable, Sendable {
   func startDate(today: Date, financialYearStartMonth: Int = 7) -> Date {
     let calendar = Calendar.current
 
+    // Fixed-rolling-window cases share one `date(byAdding:)` call shape, so
+    // collapsing them to a single branch keeps the remaining `switch` below
+    // the cyclomatic-complexity threshold.
+    if let monthsAgo = rollingWindowMonthsAgo {
+      guard let date = calendar.date(byAdding: .month, value: -monthsAgo, to: today) else {
+        return today
+      }
+      return date
+    }
+
     switch self {
     case .thisFinancialYear:
       return financialYear(for: today, startMonth: financialYearStartMonth).start
     case .lastFinancialYear:
       let lastYear = calendar.date(byAdding: .year, value: -1, to: today)!
       return financialYear(for: lastYear, startMonth: financialYearStartMonth).start
-    case .lastMonth:
-      return calendar.date(byAdding: .month, value: -1, to: today)!
-    case .last3Months:
-      return calendar.date(byAdding: .month, value: -3, to: today)!
-    case .last6Months:
-      return calendar.date(byAdding: .month, value: -6, to: today)!
-    case .last9Months:
-      return calendar.date(byAdding: .month, value: -9, to: today)!
-    case .last12Months:
-      return calendar.date(byAdding: .month, value: -12, to: today)!
     case .monthToDate:
       return calendar.date(from: calendar.dateComponents([.year, .month], from: today))!
     case .quarterToDate:
@@ -59,6 +59,23 @@ enum DateRange: String, CaseIterable, Identifiable, Sendable {
     case .custom:
       // Default for custom: 1 year ago
       return calendar.date(byAdding: .year, value: -1, to: today)!
+    default:
+      // Handled by the `rollingWindowMonthsAgo` early-return above; the
+      // compiler can't prove exhaustiveness once that branch is lifted out.
+      return today
+    }
+  }
+
+  /// Offset in months for the fixed-window rolling cases (`lastMonth`,
+  /// `last3Months`, etc.); `nil` for everything else.
+  private var rollingWindowMonthsAgo: Int? {
+    switch self {
+    case .lastMonth: return 1
+    case .last3Months: return 3
+    case .last6Months: return 6
+    case .last9Months: return 9
+    case .last12Months: return 12
+    default: return nil
     }
   }
 

--- a/Shared/PositionsHistoryBuilder.swift
+++ b/Shared/PositionsHistoryBuilder.swift
@@ -51,7 +51,6 @@ struct PositionsHistoryBuilder: Sendable {
         hostCurrency: hostCurrency, total: [], perInstrument: [:])
     }
 
-    // Range start: max of (cutoff for selected range, first holding date).
     let cutoff = range.cutoff(from: now) ?? firstTxnDate
     let start = calendar.startOfDay(for: max(cutoff, firstTxnDate))
     let endDay = calendar.startOfDay(for: now)
@@ -60,97 +59,139 @@ struct PositionsHistoryBuilder: Sendable {
         hostCurrency: hostCurrency, total: [], perInstrument: [:])
     }
 
-    // Pre-compute per-day snapshots in one pass over transactions. We fold
-    // each transaction into a running snapshot, then on every distinct
-    // event date emit "the snapshot as of end-of-that-day". Days in between
-    // events carry the prior snapshot forward.
-    var quantities: [Instrument: Decimal] = [:]
-    var engine = CostBasisEngine()
-    var txnIndex = 0
-
-    var perInstrument: [String: [HistoricalValueSeries.Point]] = [:]
-    var total: [HistoricalValueSeries.Point] = []
-
-    // Pre-fold any transactions strictly before `start` so the snapshot at
-    // `start` already reflects historical buys.
-    while txnIndex < sortedTxns.count
-      && calendar.startOfDay(for: sortedTxns[txnIndex].date) < start
-    {
-      await apply(
-        transaction: sortedTxns[txnIndex], accountId: accountId,
-        hostCurrency: hostCurrency,
-        quantities: &quantities, engine: &engine
-      )
-      txnIndex += 1
-    }
+    let context = BuildContext(
+      sortedTxns: sortedTxns, accountId: accountId,
+      hostCurrency: hostCurrency, calendar: calendar)
+    var state = BuildState()
+    await preFoldHistory(before: start, context: context, state: &state)
 
     var day = start
     while day <= endDay {
-      if Task.isCancelled {
-        return HistoricalValueSeries(
-          hostCurrency: hostCurrency, total: total, perInstrument: perInstrument)
-      }
-
-      // Apply every transaction whose start-of-day is `day`.
-      while txnIndex < sortedTxns.count
-        && calendar.startOfDay(for: sortedTxns[txnIndex].date) == day
-      {
-        await apply(
-          transaction: sortedTxns[txnIndex], accountId: accountId,
-          hostCurrency: hostCurrency,
-          quantities: &quantities, engine: &engine
-        )
-        txnIndex += 1
-      }
-
-      // Emit a point per held instrument + an aggregate (when complete).
-      var aggValue: Decimal = 0
-      var aggCost: Decimal = 0
-      var aggOK = true
-      var anyHeld = false
-
-      // Note: host-currency legs are excluded from `quantities` in `apply()`, so
-      // every instrument here is a non-host investment instrument and always
-      // requires a conversion call.
-      for (instrument, qty) in quantities where qty != 0 {
-        if Task.isCancelled {
-          return HistoricalValueSeries(
-            hostCurrency: hostCurrency, total: total, perInstrument: perInstrument)
-        }
-        anyHeld = true
-        let cost = engine.openLots(for: instrument)
-          .reduce(Decimal(0)) { $0 + $1.remainingCost }
-
-        let value: Decimal?
-        do {
-          value = try await conversionService.convert(
-            qty, from: instrument, to: hostCurrency, on: day)
-        } catch {
-          logger.warning(
-            "history conversion failed for \(instrument.id, privacy: .public) on \(day, privacy: .public): \(error.localizedDescription, privacy: .public)"
-          )
-          value = nil
-          aggOK = false
-        }
-
-        if let value {
-          perInstrument[instrument.id, default: []].append(
-            HistoricalValueSeries.Point(date: day, value: value, cost: cost))
-          aggValue += value
-          aggCost += cost
-        }
-      }
-
-      if anyHeld && aggOK {
-        total.append(HistoricalValueSeries.Point(date: day, value: aggValue, cost: aggCost))
-      }
-
+      if Task.isCancelled { return state.series(hostCurrency: hostCurrency) }
+      await applyTransactions(on: day, context: context, state: &state)
+      let cancelled = await emitDailyPoints(
+        for: day, hostCurrency: hostCurrency, state: &state)
+      if cancelled { return state.series(hostCurrency: hostCurrency) }
       guard let next = calendar.date(byAdding: .day, value: 1, to: day) else { break }
       day = next
     }
 
-    return HistoricalValueSeries(
-      hostCurrency: hostCurrency, total: total, perInstrument: perInstrument)
+    return state.series(hostCurrency: hostCurrency)
+  }
+
+  /// Pre-fold any transactions strictly before `start` so the snapshot at
+  /// `start` already reflects historical buys.
+  private func preFoldHistory(
+    before start: Date,
+    context: BuildContext,
+    state: inout BuildState
+  ) async {
+    while state.txnIndex < context.sortedTxns.count
+      && context.calendar.startOfDay(for: context.sortedTxns[state.txnIndex].date) < start
+    {
+      await apply(
+        transaction: context.sortedTxns[state.txnIndex], accountId: context.accountId,
+        hostCurrency: context.hostCurrency,
+        quantities: &state.quantities, engine: &state.engine
+      )
+      state.txnIndex += 1
+    }
+  }
+
+  /// Fold every transaction whose start-of-day is `day` into the running state.
+  private func applyTransactions(
+    on day: Date,
+    context: BuildContext,
+    state: inout BuildState
+  ) async {
+    while state.txnIndex < context.sortedTxns.count
+      && context.calendar.startOfDay(for: context.sortedTxns[state.txnIndex].date) == day
+    {
+      await apply(
+        transaction: context.sortedTxns[state.txnIndex], accountId: context.accountId,
+        hostCurrency: context.hostCurrency,
+        quantities: &state.quantities, engine: &state.engine
+      )
+      state.txnIndex += 1
+    }
+  }
+
+  /// Immutable inputs threaded through `build`'s per-day loop.
+  private struct BuildContext {
+    let sortedTxns: [Transaction]
+    let accountId: UUID
+    let hostCurrency: Instrument
+    let calendar: Calendar
+  }
+
+  /// Emit one point per held instrument on `day` and, when every conversion
+  /// succeeds, one aggregate point. Returns `true` if cancellation was observed
+  /// so the caller can bail.
+  private func emitDailyPoints(
+    for day: Date,
+    hostCurrency: Instrument,
+    state: inout BuildState
+  ) async -> Bool {
+    var aggValue: Decimal = 0
+    var aggCost: Decimal = 0
+    var aggOK = true
+    var anyHeld = false
+
+    // Host-currency legs are excluded from `quantities` in `apply()`, so every
+    // instrument here is a non-host investment instrument and always requires
+    // a conversion call.
+    for (instrument, qty) in state.quantities where qty != 0 {
+      if Task.isCancelled { return true }
+      anyHeld = true
+      let cost = state.engine.openLots(for: instrument)
+        .reduce(Decimal(0)) { $0 + $1.remainingCost }
+      let value = await convertValue(
+        qty: qty, instrument: instrument, hostCurrency: hostCurrency, on: day)
+      if let value {
+        state.perInstrument[instrument.id, default: []].append(
+          HistoricalValueSeries.Point(date: day, value: value, cost: cost))
+        aggValue += value
+        aggCost += cost
+      } else {
+        aggOK = false
+      }
+    }
+
+    if anyHeld && aggOK {
+      state.total.append(
+        HistoricalValueSeries.Point(date: day, value: aggValue, cost: aggCost))
+    }
+    return false
+  }
+
+  /// Convert `qty` of `instrument` to `hostCurrency` on `day`, logging and
+  /// returning `nil` on failure so the caller can mark the day incomplete.
+  private func convertValue(
+    qty: Decimal, instrument: Instrument, hostCurrency: Instrument, on day: Date
+  ) async -> Decimal? {
+    do {
+      return try await conversionService.convert(
+        qty, from: instrument, to: hostCurrency, on: day)
+    } catch {
+      logger.warning(
+        "history conversion failed for \(instrument.id, privacy: .public) on \(day, privacy: .public): \(error.localizedDescription, privacy: .public)"
+      )
+      return nil
+    }
+  }
+
+  /// Mutable running state threaded through `build`'s per-day loop.
+  private struct BuildState {
+    var quantities: [Instrument: Decimal] = [:]
+    var engine = CostBasisEngine()
+    var txnIndex = 0
+    var perInstrument: [String: [HistoricalValueSeries.Point]] = [:]
+    var total: [HistoricalValueSeries.Point] = []
+
+    func series(hostCurrency: Instrument) -> HistoricalValueSeries {
+      HistoricalValueSeries(
+        hostCurrency: hostCurrency, total: total, perInstrument: perInstrument)
+    }
   }
 
   /// Fold one transaction into the running quantity dict and FIFO engine.


### PR DESCRIPTION
## Summary

Reduce complexity below the threshold in eight functions by extracting cohesive handlers / lifting dispatch into data structures:

- `SyncErrorRecovery`: per-case `classify*` helpers.
- `DateRange`: `rollingWindowMonthsAgo` + smaller quarter/year branches.
- `CSVTokenizer`: `handleQuoted` / `handleUnquoted` / `finishRow` around a `ParseState` struct.
- `ProfileIndexSyncHandler`: persist/resolve/update system-fields helpers.
- `PositionsHistoryBuilder`: pipeline stages over `BuildContext` / `BuildState`.
- `GenericBankCSVParser`: `scanDateSignals` → `DateFormatSignals`, then `decideDateFormat`.
- `NavigateCommand`: `openProfileRoot` / `destinationPath` / `namedPath`.
- `DeleteCommand`: `Sendable DeleteTarget`, dispatch through `performDelete`, per-kind `deleteAccount`/`Earmark`/`Category`.

Fixes 8 of 20 sites. The remaining 12 all sit in files whose `function_body_length`, `type_body_length` or `file_length` baseline entries would re-key on any structural edit (reason strings embed line counts). Those sites are `CloudKitAnalysisRepository:238/611`, `CloudKitTransactionRepository:120`, `SyncCoordinator:960/1074/1219`, `RecordMapping:130`, `ImportStore:266`, `RuleEditorView:337`, `InvestmentStore:414/486`, and `BenchmarkFixtures:219` — each needs the enclosing file shrunk (a separate refactor) before its complexity can be reduced.

Refs #275 (8 of 20 sites)

## Test plan
- [x] `just format-check` clean
- [x] `just build-mac` no user-code warnings
- [x] `just test-mac` — 1462 tests pass
- [ ] CI green