### PR TITLE
chore(lint): drop IUO from AnalysisBenchmarks _backend (#277)

### DIFF
--- a/MoolahBenchmarks/AnalysisBenchmarks.swift
+++ b/MoolahBenchmarks/AnalysisBenchmarks.swift
@@ -7,7 +7,7 @@ import XCTest
 /// on a realistic x2-scale dataset (37k transactions, 62 accounts, 5k investment values).
 final class AnalysisBenchmarks: XCTestCase {
 
-  nonisolated(unsafe) private static var _backend: CloudKitBackend!
+  nonisolated(unsafe) private static var _backend: CloudKitBackend?
   nonisolated(unsafe) private static var _container: ModelContainer?
 
   override static func setUp() {
@@ -26,11 +26,18 @@ final class AnalysisBenchmarks: XCTestCase {
     super.tearDown()
   }
 
+  private var backend: CloudKitBackend {
+    guard let backend = Self._backend else {
+      fatalError("setUp must initialise _backend before tests run")
+    }
+    return backend
+  }
+
   private var repo: CloudKitAnalysisRepository {
-    guard let repo = Self._backend.analysis as? CloudKitAnalysisRepository else {
+    guard let repo = backend.analysis as? CloudKitAnalysisRepository else {
       fatalError(
         "AnalysisBenchmarks requires CloudKitAnalysisRepository; "
-          + "got \(type(of: Self._backend.analysis))")
+          + "got \(type(of: backend.analysis))")
     }
     return repo
   }


### PR DESCRIPTION
## Summary

Migrate `AnalysisBenchmarks._backend` off an implicitly-unwrapped `CloudKitBackend!` to a `CloudKitBackend?` + `guard let` accessor, mirroring the existing `PriorBalanceBenchmarks` precedent in `MoolahBenchmarks/BalanceBenchmarks.swift`. Clears the last non-baselined `implicitly_unwrapped_optional` violation; baseline is untouched.

## Test plan
- [x] \`just format-check\` clean
- [x] \`just build-mac\` succeeds (no user-code warnings)
- [x] \`just test-mac\` passes
- [x] \`xcodebuild build-for-testing\` on the Moolah-Benchmarks scheme succeeds (benchmarks aren't in \`just test-mac\`; verified the file still compiles)
- [x] \`swiftlint lint --only-rule implicitly_unwrapped_optional --quiet\` returns no output