### PR TITLE
chore(lint): replace large tuples with named structs (#287)

### DIFF
--- a/Backends/CloudKit/Repositories/CloudKitAnalysisRepository.swift
+++ b/Backends/CloudKit/Repositories/CloudKitAnalysisRepository.swift
@@ -165,7 +165,7 @@ final class CloudKitAnalysisRepository: AnalysisRepository, @unchecked Sendable 
   /// Fetch all investment values for the given accounts from SwiftData, sorted by date ascending.
   private func fetchAllInvestmentValues(
     investmentAccountIds: Set<UUID>
-  ) async throws -> [(accountId: UUID, date: Date, value: InstrumentAmount)] {
+  ) async throws -> [InvestmentValueSnapshot] {
     guard !investmentAccountIds.isEmpty else { return [] }
     let descriptor = FetchDescriptor<InvestmentValueRecord>()
     return try await MainActor.run {
@@ -173,7 +173,7 @@ final class CloudKitAnalysisRepository: AnalysisRepository, @unchecked Sendable 
       return
         records
         .filter { investmentAccountIds.contains($0.accountId) }
-        .map { (accountId: $0.accountId, date: $0.date, value: $0.toDomain().value) }
+        .map(InvestmentValueSnapshot.init(record:))
         .sorted { $0.date < $1.date }
     }
   }
@@ -468,7 +468,7 @@ final class CloudKitAnalysisRepository: AnalysisRepository, @unchecked Sendable 
     nonScheduled: [Transaction],
     scheduled: [Transaction],
     accounts: [Account],
-    investmentValues: [(accountId: UUID, date: Date, value: InstrumentAmount)],
+    investmentValues: [InvestmentValueSnapshot],
     after: Date?,
     forecastUntil: Date?,
     instrument: Instrument,
@@ -715,7 +715,7 @@ final class CloudKitAnalysisRepository: AnalysisRepository, @unchecked Sendable 
   // MARK: - Static Helper Methods
 
   private static func applyInvestmentValues(
-    _ investmentValues: [(accountId: UUID, date: Date, value: InstrumentAmount)],
+    _ investmentValues: [InvestmentValueSnapshot],
     to dailyBalances: inout [Date: DailyBalance],
     instrument: Instrument,
     conversionService: any InstrumentConversionService

--- a/Backends/CloudKit/Repositories/InvestmentValueSnapshot.swift
+++ b/Backends/CloudKit/Repositories/InvestmentValueSnapshot.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// One investment value snapshot: an amount recorded for an account on a
+/// specific date. Used by `CloudKitAnalysisRepository` to pass investment
+/// positions between its SwiftData fetch and its off-main computations
+/// without a 3-member tuple.
+struct InvestmentValueSnapshot: Sendable {
+  let accountId: UUID
+  let date: Date
+  let value: InstrumentAmount
+
+  /// Bridges a SwiftData record into a Sendable snapshot. Provided so the
+  /// call site in `CloudKitAnalysisRepository` can pass
+  /// `InvestmentValueSnapshot.init(record:)` straight to `Array.map`.
+  init(record: InvestmentValueRecord) {
+    self.accountId = record.accountId
+    self.date = record.date
+    self.value = record.toDomain().value
+  }
+}

--- a/Features/Earmarks/EarmarkStore.swift
+++ b/Features/Earmarks/EarmarkStore.swift
@@ -171,17 +171,16 @@ final class EarmarkStore {
 
     for earmark in visibleEarmarks {
       do {
-        let (earmarkBalance, earmarkSaved, earmarkSpent) =
-          try await convertEarmarkPositions(earmark)
+        let totals = try await convertEarmarkPositions(earmark)
         guard !Task.isCancelled else { return false }
-        balances[earmark.id] = earmarkBalance
-        saved[earmark.id] = earmarkSaved
-        spent[earmark.id] = earmarkSpent
+        balances[earmark.id] = totals.balance
+        saved[earmark.id] = totals.saved
+        spent[earmark.id] = totals.spent
 
         // Convert earmark balance to target instrument for grand total.
         // Clamp negative balances to zero so they don't reduce the total.
         let convertedToTarget = try await conversionService.convertAmount(
-          earmarkBalance, to: targetInstrument, on: Date())
+          totals.balance, to: targetInstrument, on: Date())
         guard !Task.isCancelled else { return false }
         if grandTotalValid {
           grandTotal += max(convertedToTarget, zeroInTarget)
@@ -204,16 +203,20 @@ final class EarmarkStore {
     return anyFailed
   }
 
+  /// Per-earmark conversion result: the three position-list totals,
+  /// each expressed in the earmark's own instrument.
+  private struct ConvertedEarmarkTotals {
+    let balance: InstrumentAmount
+    let saved: InstrumentAmount
+    let spent: InstrumentAmount
+  }
+
   /// Sums an earmark's three position lists, each converted to the
   /// earmark's own instrument. Throws if any conversion fails so the
   /// caller treats the whole earmark as failed (we never display a
   /// partial earmark balance).
   private func convertEarmarkPositions(_ earmark: Earmark) async throws
-    -> (
-      balance: InstrumentAmount,
-      saved: InstrumentAmount,
-      spent: InstrumentAmount
-    )
+    -> ConvertedEarmarkTotals
   {
     let date = Date()
     var balance = InstrumentAmount.zero(instrument: earmark.instrument)
@@ -231,7 +234,7 @@ final class EarmarkStore {
       spent += try await conversionService.convertAmount(
         position.amount, to: earmark.instrument, on: date)
     }
-    return (balance, saved, spent)
+    return ConvertedEarmarkTotals(balance: balance, saved: saved, spent: spent)
   }
 
   /// Reorders the visible earmarks, persisting each new position to the

--- a/MoolahTests/Features/Import/FolderScanServiceTests.swift
+++ b/MoolahTests/Features/Import/FolderScanServiceTests.swift
@@ -7,6 +7,15 @@ import Testing
 @MainActor
 struct FolderScanServiceTests {
 
+  /// Bundle of objects returned by `makeStack`, replacing a 4-element
+  /// tuple. Members read clearly at the call site (e.g. `stack.scanner`).
+  private struct Stack {
+    let store: ImportStore
+    let accountId: UUID
+    let scanner: FolderScanService
+    let backend: CloudKitBackend
+  }
+
   private func tempDirectory() -> URL {
     FileManager.default.temporaryDirectory
       .appendingPathComponent("scan-\(UUID().uuidString)", isDirectory: true)
@@ -19,9 +28,7 @@ struct FolderScanServiceTests {
     watchedFolder: URL,
     defaults: UserDefaults,
     profileId: UUID = UUID()
-  ) async throws -> (
-    store: ImportStore, accountId: UUID, scanner: FolderScanService, backend: CloudKitBackend
-  ) {
+  ) async throws -> Stack {
     let (backend, _) = try TestBackend.create()
     let accountId = UUID()
     _ = try await backend.accounts.create(
@@ -44,7 +51,7 @@ struct FolderScanServiceTests {
       importStore: store,
       preferences: preferences,
       defaults: defaults)
-    return (store, accountId, scanner, backend)
+    return Stack(store: store, accountId: accountId, scanner: scanner, backend: backend)
   }
 
   private func writeCSV(at url: URL, lines: [String], modified: Date) throws {
@@ -68,17 +75,16 @@ struct FolderScanServiceTests {
       at: folder, withIntermediateDirectories: true)
     defer { try? FileManager.default.removeItem(at: folder) }
     let defaults = UserDefaults(suiteName: "csvscan-\(UUID().uuidString)")!
-    let (_, accountId, scanner, backend) = try await makeStack(
-      watchedFolder: folder, defaults: defaults)
+    let stack = try await makeStack(watchedFolder: folder, defaults: defaults)
     let a = folder.appendingPathComponent("one.csv")
     let b = folder.appendingPathComponent("two.csv")
     try writeCSV(at: a, lines: cbaLines(), modified: Date(timeIntervalSinceNow: -30))
     try writeCSV(at: b, lines: cbaLines(), modified: Date(timeIntervalSinceNow: -10))
 
-    await scanner.scanForNewFiles()
+    await stack.scanner.scanForNewFiles()
 
-    let page = try await backend.transactions.fetch(
-      filter: TransactionFilter(accountId: accountId), page: 0, pageSize: 50)
+    let page = try await stack.backend.transactions.fetch(
+      filter: TransactionFilter(accountId: stack.accountId), page: 0, pageSize: 50)
     // Each CSV yields 2 candidates → dedup drops second-run duplicates but
     // first run should land 2 for `a` and 0/2 for `b` depending on dedup.
     // Two distinct files with identical bank references/descriptions →
@@ -93,22 +99,21 @@ struct FolderScanServiceTests {
       at: folder, withIntermediateDirectories: true)
     defer { try? FileManager.default.removeItem(at: folder) }
     let defaults = UserDefaults(suiteName: "csvscan-\(UUID().uuidString)")!
-    let (_, accountId, scanner, backend) = try await makeStack(
-      watchedFolder: folder, defaults: defaults)
+    let stack = try await makeStack(watchedFolder: folder, defaults: defaults)
     let a = folder.appendingPathComponent("one.csv")
     let oldTime = Date(timeIntervalSinceNow: -300)
     try writeCSV(at: a, lines: cbaLines(), modified: oldTime)
 
-    await scanner.scanForNewFiles()
-    let firstPage = try await backend.transactions.fetch(
-      filter: TransactionFilter(accountId: accountId), page: 0, pageSize: 50)
+    await stack.scanner.scanForNewFiles()
+    let firstPage = try await stack.backend.transactions.fetch(
+      filter: TransactionFilter(accountId: stack.accountId), page: 0, pageSize: 50)
     let firstCount = firstPage.transactions.count
 
     // Second scan with no new files → nothing changes. Cursor prevents
     // re-ingest even though dedup would also catch it.
-    await scanner.scanForNewFiles()
-    let secondPage = try await backend.transactions.fetch(
-      filter: TransactionFilter(accountId: accountId), page: 0, pageSize: 50)
+    await stack.scanner.scanForNewFiles()
+    let secondPage = try await stack.backend.transactions.fetch(
+      filter: TransactionFilter(accountId: stack.accountId), page: 0, pageSize: 50)
     #expect(secondPage.transactions.count == firstCount)
   }
 
@@ -119,13 +124,12 @@ struct FolderScanServiceTests {
       at: folder, withIntermediateDirectories: true)
     defer { try? FileManager.default.removeItem(at: folder) }
     let defaults = UserDefaults(suiteName: "csvscan-\(UUID().uuidString)")!
-    let (_, accountId, scanner, backend) = try await makeStack(
-      watchedFolder: folder, defaults: defaults)
+    let stack = try await makeStack(watchedFolder: folder, defaults: defaults)
     let a = folder.appendingPathComponent("a.csv")
     try writeCSV(at: a, lines: cbaLines(), modified: Date(timeIntervalSinceNow: -600))
-    await scanner.scanForNewFiles()
-    let firstPage = try await backend.transactions.fetch(
-      filter: TransactionFilter(accountId: accountId), page: 0, pageSize: 50)
+    await stack.scanner.scanForNewFiles()
+    let firstPage = try await stack.backend.transactions.fetch(
+      filter: TransactionFilter(accountId: stack.accountId), page: 0, pageSize: 50)
     let first = firstPage.transactions.count
 
     // Drop a second file with a strictly newer mtime + distinct data so dedup
@@ -138,9 +142,9 @@ struct FolderScanServiceTests {
         "04/04/2024,TAXI SYDNEY,-20.00,,950.00",
       ],
       modified: Date(timeIntervalSinceNow: -10))
-    await scanner.scanForNewFiles()
-    let secondPage = try await backend.transactions.fetch(
-      filter: TransactionFilter(accountId: accountId), page: 0, pageSize: 50)
+    await stack.scanner.scanForNewFiles()
+    let secondPage = try await stack.backend.transactions.fetch(
+      filter: TransactionFilter(accountId: stack.accountId), page: 0, pageSize: 50)
     #expect(secondPage.transactions.count > first)
   }
 
@@ -151,15 +155,14 @@ struct FolderScanServiceTests {
       at: folder, withIntermediateDirectories: true)
     defer { try? FileManager.default.removeItem(at: folder) }
     let defaults = UserDefaults(suiteName: "csvscan-\(UUID().uuidString)")!
-    let (_, accountId, scanner, backend) = try await makeStack(
-      watchedFolder: folder, defaults: defaults)
+    let stack = try await makeStack(watchedFolder: folder, defaults: defaults)
     let txt = folder.appendingPathComponent("notes.txt")
     try writeCSV(
       at: txt, lines: ["hello"],
       modified: Date(timeIntervalSinceNow: -10))
-    await scanner.scanForNewFiles()
-    let page = try await backend.transactions.fetch(
-      filter: TransactionFilter(accountId: accountId), page: 0, pageSize: 50)
+    await stack.scanner.scanForNewFiles()
+    let page = try await stack.backend.transactions.fetch(
+      filter: TransactionFilter(accountId: stack.accountId), page: 0, pageSize: 50)
     #expect(page.transactions.isEmpty)
   }
 


### PR DESCRIPTION
## Summary

Convert all 5 non-baselined `large_tuple` violations (3+ member tuples) to small named structs that read clearly at the call sites.

- **CloudKitAnalysisRepository** (3 sites): extract `InvestmentValueSnapshot` (accountId + date + amount) into a sibling file `Backends/CloudKit/Repositories/InvestmentValueSnapshot.swift`. All three sites have the same shape, so one shared type is appropriate. Sibling-file placement keeps the repository at its existing `file_length` / `type_body_length` baseline values.
- **EarmarkStore**: private `ConvertedEarmarkTotals` for the triple-amount accumulator in `refreshTotals()`.
- **FolderScanServiceTests**: private `Stack` for the triple-value test fixture.

No baseline changes; no behavioural change.

## Test plan
- [x] \`just format-check\` clean
- [x] \`just build-mac\` succeeds (no user-code warnings)
- [x] \`just test-mac\` passes (1462 tests across 146 suites)
- [x] \`swiftlint lint --only-rule large_tuple --quiet\` returns no output