### PR TITLE
chore(lint): re-enable redundant_nil_coalescing (#262)

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -29,10 +29,6 @@ disabled_rules:
   - sorted_imports
   # Autocorrect produces invalid code for our codebase. Tracked in tech-debt
   # issues; revisit once a safer fix strategy exists.
-  # TODO(#262): re-enable redundant_nil_coalescing — autofix removes `?? nil`
-  # on dictionary subscripts of optional values, producing Int?? where Int? is
-  # required. Broke TransactionDetailView.swift (legCategoryHighlightedIndex).
-  - redundant_nil_coalescing
   # TODO(#263): re-enable redundant_discardable_let — autofix rewrites
   # `let _ = foo()` to `_ = foo()` inside SwiftUI @ViewBuilder bodies, which
   # changes semantics (view builders accept `let _`, not bare assignments).

--- a/Features/Transactions/Views/TransactionDetailView.swift
+++ b/Features/Transactions/Views/TransactionDetailView.swift
@@ -30,7 +30,7 @@ struct TransactionDetailView: View {
   @State private var legPendingDeletion: Int?
   @State private var legCategoryJustSelected: [Int: Bool] = [:]
   @State private var showLegCategorySuggestions: [Int: Bool] = [:]
-  @State private var legCategoryHighlightedIndex: [Int: Int?] = [:]
+  @State private var legCategoryHighlightedIndex: [Int: Int] = [:]
   /// Snapshot of whether the transaction was a blank/new draft at open
   /// time (empty payee + all-zero legs). Captured once at init so that
   /// `autofillFromPayee` only copies fields from a matched transaction
@@ -627,7 +627,7 @@ struct TransactionDetailView: View {
           legIndex: index,
           text: $draft.legDrafts[index].categoryText,
           highlightedIndex: Binding(
-            get: { legCategoryHighlightedIndex[index] ?? nil },
+            get: { legCategoryHighlightedIndex[index] },
             set: { legCategoryHighlightedIndex[index] = $0 }
           ),
           suggestionCount: legCategoryVisibleSuggestions(for: index).count,
@@ -928,7 +928,7 @@ struct TransactionDetailView: View {
 
   private func acceptHighlightedLegCategory(at index: Int) {
     let suggestions = legCategoryVisibleSuggestions(for: index)
-    guard let highlighted = legCategoryHighlightedIndex[index] ?? nil,
+    guard let highlighted = legCategoryHighlightedIndex[index],
       highlighted < suggestions.count
     else { return }
     let selected = suggestions[highlighted]
@@ -951,7 +951,7 @@ struct TransactionDetailView: View {
           suggestions: legCategoryVisibleSuggestions(for: activeIndex),
           searchText: draft.legDrafts[activeIndex].categoryText,
           highlightedIndex: Binding(
-            get: { legCategoryHighlightedIndex[activeIndex] ?? nil },
+            get: { legCategoryHighlightedIndex[activeIndex] },
             set: { legCategoryHighlightedIndex[activeIndex] = $0 }
           ),
           onSelect: { selected in


### PR DESCRIPTION
## Summary
- Change `legCategoryHighlightedIndex` in `TransactionDetailView` from `[Int: Int?]` to `[Int: Int]` so dictionary subscript returns `Int?` directly. The three `?? nil` flattens collapse to plain lookups, and the SwiftLint autofix that previously broke this pattern (by turning `Int?` into `Int??`) no longer has a pattern to mis-transform.
- Remove `redundant_nil_coalescing` from `disabled_rules:` in `.swiftlint.yml`. Baseline unchanged; `just format-check` passes.
- Assigning `nil` to the `[Int: Int]` subscript still removes the entry, so Binding set semantics are preserved.

Fixes #262.

## Test plan
- [x] `just format-check` — passes with no new baseline entries.
- [x] `just test-mac` — 1473 tests in 185 suites pass.
- [x] `just test-ios` — 1452 tests in 181 suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)