### PR TITLE
chore(lint): re-enable redundant_discardable_let (#263)

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -29,11 +29,6 @@ disabled_rules:
   - sorted_imports
   # Autocorrect produces invalid code for our codebase. Tracked in tech-debt
   # issues; revisit once a safer fix strategy exists.
-  # TODO(#263): re-enable redundant_discardable_let — autofix rewrites
-  # `let _ = foo()` to `_ = foo()` inside SwiftUI @ViewBuilder bodies, which
-  # changes semantics (view builders accept `let _`, not bare assignments).
-  # Broke ProfileWindowView.swift.
-  - redundant_discardable_let
   # TODO(#264): re-enable attributes — 903 baseline violations that fight
   # swift-format's chosen layout for `@State`, `@Binding`, etc. swift-format
   # owns layout; revisit once we decide whether to override the formatter.

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -29,10 +29,6 @@ disabled_rules:
   - sorted_imports
   # Autocorrect produces invalid code for our codebase. Tracked in tech-debt
   # issues; revisit once a safer fix strategy exists.
-  # TODO(#262): re-enable redundant_nil_coalescing — autofix removes `?? nil`
-  # on dictionary subscripts of optional values, producing Int?? where Int? is
-  # required. Broke TransactionDetailView.swift (legCategoryHighlightedIndex).
-  - redundant_nil_coalescing
   # TODO(#263): re-enable redundant_discardable_let — autofix rewrites
   # `let _ = foo()` to `_ = foo()` inside SwiftUI @ViewBuilder bodies, which
   # changes semantics (view builders accept `let _`, not bare assignments).

--- a/App/ProfileWindowView.swift
+++ b/App/ProfileWindowView.swift
@@ -50,11 +50,11 @@
           ProgressView()
         } else {
           // Profile is genuinely gone — close this window
-          let _ = logger.warning(
-            "Dismissing window — profile not found. profileID=\(profileID?.uuidString ?? "nil", privacy: .public), profileCount=\(profileStore.profiles.count), profileIDs=\(profileStore.profiles.map(\.id).map(\.uuidString).joined(separator: ","), privacy: .public)"
-          )
           Color.clear
             .onAppear {
+              logger.warning(
+                "Dismissing window — profile not found. profileID=\(profileID?.uuidString ?? "nil", privacy: .public), profileCount=\(profileStore.profiles.count), profileIDs=\(profileStore.profiles.map(\.id).map(\.uuidString).joined(separator: ","), privacy: .public)"
+              )
               dismiss()
             }
         }

--- a/Features/Transactions/Views/TransactionDetailView.swift
+++ b/Features/Transactions/Views/TransactionDetailView.swift
@@ -30,7 +30,7 @@ struct TransactionDetailView: View {
   @State private var legPendingDeletion: Int?
   @State private var legCategoryJustSelected: [Int: Bool] = [:]
   @State private var showLegCategorySuggestions: [Int: Bool] = [:]
-  @State private var legCategoryHighlightedIndex: [Int: Int?] = [:]
+  @State private var legCategoryHighlightedIndex: [Int: Int] = [:]
   /// Snapshot of whether the transaction was a blank/new draft at open
   /// time (empty payee + all-zero legs). Captured once at init so that
   /// `autofillFromPayee` only copies fields from a matched transaction
@@ -627,7 +627,7 @@ struct TransactionDetailView: View {
           legIndex: index,
           text: $draft.legDrafts[index].categoryText,
           highlightedIndex: Binding(
-            get: { legCategoryHighlightedIndex[index] ?? nil },
+            get: { legCategoryHighlightedIndex[index] },
             set: { legCategoryHighlightedIndex[index] = $0 }
           ),
           suggestionCount: legCategoryVisibleSuggestions(for: index).count,
@@ -928,7 +928,7 @@ struct TransactionDetailView: View {
 
   private func acceptHighlightedLegCategory(at index: Int) {
     let suggestions = legCategoryVisibleSuggestions(for: index)
-    guard let highlighted = legCategoryHighlightedIndex[index] ?? nil,
+    guard let highlighted = legCategoryHighlightedIndex[index],
       highlighted < suggestions.count
     else { return }
     let selected = suggestions[highlighted]
@@ -951,7 +951,7 @@ struct TransactionDetailView: View {
           suggestions: legCategoryVisibleSuggestions(for: activeIndex),
           searchText: draft.legDrafts[activeIndex].categoryText,
           highlightedIndex: Binding(
-            get: { legCategoryHighlightedIndex[activeIndex] ?? nil },
+            get: { legCategoryHighlightedIndex[activeIndex] },
             set: { legCategoryHighlightedIndex[activeIndex] = $0 }
           ),
           onSelect: { selected in


### PR DESCRIPTION
## Summary
- Move the sole `let _ = logger.warning(...)` in `ProfileWindowView`'s @ViewBuilder body into the existing `.onAppear` alongside `dismiss()`, so the log emits as a plain statement instead of a discardable expression. No more `let _ = ...` in the codebase, so SwiftLint's autofix has nothing to mis-transform inside a view builder.
- Remove `redundant_discardable_let` from `disabled_rules:` in `.swiftlint.yml`. Baseline unchanged; `just format-check` passes.
- Based on #363 so that when it merges, this rebases cleanly onto main.

Fixes #263.

## Test plan
- [x] `just format-check` — passes with no new baseline entries.
- [x] `just build-mac` — builds cleanly (no new warnings in user code).
- [x] `just test-mac` — 1473 tests in 185 suites pass.
- [x] `just test-ios` — tests pass.

Generated with [Claude Code](https://claude.com/claude-code)