### PR TITLE
chore(lint): document named-struct preference for large_tuple (#287)

### DIFF
--- a/guides/CODE_GUIDE.md
+++ b/guides/CODE_GUIDE.md
@@ -181,6 +181,7 @@ Apple's [Swift API Design Guidelines](https://www.swift.org/documentation/api-de
 Apple's [Choosing Between Structures and Classes](https://developer.apple.com/documentation/swift/choosing-between-structures-and-classes) is the canonical decision guide.
 
 - **`struct` is the default for data.** Value semantics eliminate shared-mutable-state bugs and make types trivially `Sendable`.
+- **Prefer a named `struct` over a tuple with three or more elements.** Two-element tuples (e.g. `(Date, Amount)`) are fine locally; once a third field appears, field names at the call site stop being optional and a `struct` makes that explicit. Enforced by [`large_tuple`](https://realm.github.io/SwiftLint/large_tuple.html) (warn at 2, error at 3) — see §3. Scope the struct as narrowly as the use site allows (file-private helpers for single-file aggregations; sibling types when several files share the shape).
 - **`class` only for:**
   - Identity-driven state (two equal values are not interchangeable).
   - Shared mutable state with deliberately controlled access.


### PR DESCRIPTION
## Summary

The `large_tuple` rule is already at zero both live and in `.swiftlint-baseline.yml`. The original 9 violations were replaced with named structs in [#339](https://github.com/ajsutton/moolah-native/pull/339) (`InvestmentValueSnapshot` in `CloudKitAnalysisRepository`, `ConvertedEarmarkTotals` in `EarmarkStore`, plus the tuples in `CloudKitEarmarkRepository`, `AboutView`, `ReportingStore`, and `FolderScanServiceTests`), and every subsequent baseline regeneration has carried that 0 forward.

- Current live count: **0** `large_tuple` violations.
- Current baseline count: **0**.
- No code or baseline change is needed — the rule has already been at 0 since [#339](https://github.com/ajsutton/moolah-native/pull/339).

The only change in this PR is a `guides/CODE_GUIDE.md` §5 note pinning the named-struct-over-tuple convention alongside the existing `large_tuple` threshold in §3. Two-element tuples stay fine for local destructuring; three or more get a struct with named fields.

Fixes #287

## Test plan

- [x] `just format-check` clean
- [x] `swiftlint lint --quiet | grep -i 'Large Tuple'` returns zero matches
- [x] `grep -i 'large_tuple' .swiftlint-baseline.yml` returns zero matches

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>