### PR TITLE
chore(lint): document isMultiple(of:) preference for legacy_multiple (#288)

### DIFF
--- a/guides/CODE_GUIDE.md
+++ b/guides/CODE_GUIDE.md
@@ -181,6 +181,7 @@ Apple's [Swift API Design Guidelines](https://www.swift.org/documentation/api-de
 Apple's [Choosing Between Structures and Classes](https://developer.apple.com/documentation/swift/choosing-between-structures-and-classes) is the canonical decision guide.
 
 - **`struct` is the default for data.** Value semantics eliminate shared-mutable-state bugs and make types trivially `Sendable`.
+- **Prefer a named `struct` over a tuple with three or more elements.** Two-element tuples (e.g. `(Date, Amount)`) are fine locally; once a third field appears, field names at the call site stop being optional and a `struct` makes that explicit. Enforced by [`large_tuple`](https://realm.github.io/SwiftLint/large_tuple.html) (warn at 2, error at 3) — see §3. Scope the struct as narrowly as the use site allows (file-private helpers for single-file aggregations; sibling types when several files share the shape).
 - **`class` only for:**
   - Identity-driven state (two equal values are not interchangeable).
   - Shared mutable state with deliberately controlled access.

--- a/guides/CODE_GUIDE.md
+++ b/guides/CODE_GUIDE.md
@@ -348,6 +348,12 @@ SwiftLint enforces most of these via opt-in rules; follow them by habit.
   ```
 
 - **`for … in` over `forEach`** for side effects. `forEach` hides control flow — you can't `break`, `continue`, or `return` from the enclosing function. Use `forEach` only for pure-call chains where control flow isn't relevant.
+- **`isMultiple(of:)` over `% == 0` for divisibility checks.** `BinaryInteger.isMultiple(of:)` reads as the intent ("is `i` a multiple of `N`") and survives a `0` divisor (`x.isMultiple(of: 0)` is `true` only when `x == 0`, not a trap). Keep `%` for actual remainder arithmetic (e.g. `i % earmarkIds.count` as an index wrap). Enforced by [`legacy_multiple`](https://realm.github.io/SwiftLint/legacy_multiple.html).
+
+  ```swift
+  if index.isMultiple(of: 100) { /* Good */ }
+  if index % 100 == 0 { /* Bad */ }
+  ```
 
 ---
 


### PR DESCRIPTION
## Summary

The `legacy_multiple` rule is already enabled in `opt_in_rules` and live count is **0**. The original 6 violations (3 each in `BenchmarkFixtures.swift` and `AnalysisView.swift`) were rewritten to `isMultiple(of:)` in commit 6031460 — that commit said "Refs #288" rather than "Fixes #288", so the issue is still open.

- Current live count: **0** `legacy_multiple` violations.
- Current baseline count: **0**.
- No code or baseline change is needed — the rule has already been at 0 since 6031460.

The only change in this PR is a `guides/CODE_GUIDE.md` §14 note pinning `isMultiple(of:)` as the preferred divisibility idiom, with the [`legacy_multiple`](https://realm.github.io/SwiftLint/legacy_multiple.html) reference and a note that `%` is still correct for actual remainder arithmetic (e.g. index-wrap like `i % earmarkIds.count`).

Branched on top of [#396](https://github.com/ajsutton/moolah-native/pull/396) (same-shaped doc-only PR for `large_tuple`) so the merge queue can land them in sequence.

Fixes #288

## Test plan

- [x] `just format-check` clean
- [x] `swiftlint lint --quiet | grep -E '\(legacy_multiple\)'` returns zero matches
- [x] `grep -o 'legacy_multiple' .swiftlint-baseline.yml` returns zero matches
- [x] `legacy_multiple` still present in `opt_in_rules` of `.swiftlint.yml`

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>