### PR TITLE
chore(lint): document closure_parameter_position preference (#289)

### DIFF
--- a/guides/CODE_GUIDE.md
+++ b/guides/CODE_GUIDE.md
@@ -318,6 +318,20 @@ Apple's [Choosing Between Structures and Classes](https://developer.apple.com/do
 
 - **`[weak self]` only when capturing a reference type with a plausible retain cycle.** SwiftUI views are value types — they don't need `[weak self]`. A `Task { }` inside a `@MainActor` store method capturing the store itself does need it when the store's lifetime is shorter than the task.
 - **Explicit `[self]` captures when semantics matter.** Swift 5.8 requires `self.` inside escaping closures only for non-`@Sendable` contexts; be explicit when the capture list communicates intent, even when the compiler doesn't demand it.
+- **Closure parameter list stays on the opening-brace line.** Enforced by [`closure_parameter_position`](https://realm.github.io/SwiftLint/closure_parameter_position.html). swift-format will happily wrap a long call-site before the trailing `{`, so if the invocation pushes the `{ params in` past the column limit the fix is to shorten the call (extract an arg to a local, rename a verbose identifier), not to drop the params onto their own line.
+
+  ```swift
+  // Good
+  coordinator.addObserver(for: profileId) { [weak self] changedTypes in
+    self?.scheduleReloadFromSync(changedTypes: changedTypes)
+  }
+
+  // Bad — params wrapped onto the next line
+  coordinator.addObserver(for: profileId) {
+    [weak self] changedTypes in
+    self?.scheduleReloadFromSync(changedTypes: changedTypes)
+  }
+  ```
 
 ---
 


### PR DESCRIPTION
## Summary

The rule is already at zero in the current baseline — commit 08b3b9d fixed the two original offending call sites (`App/ProfileSession.swift` and `Features/Analysis/Views/IncomeExpenseTableCard.swift`) by shortening the invocation before the trailing `{` so `{ params in` fits on the opening-brace line.

- Current live count: **0** `closure_parameter_position` violations.
- Current baseline count: **0** (out of 305 total).
- No code change is needed to drop the count further — it's already there.

The only change in this PR is a `guides/CODE_GUIDE.md` §13 (Closures) bullet pinning down the pattern (shorten the call, never drop params onto their own line) so the rule stays at zero without every contributor rediscovering it.

**Stacked on [#398](https://github.com/ajsutton/moolah-native/pull/398).** Retarget to `main` when that lands.

Fixes https://github.com/ajsutton/moolah-native/issues/289

## Test plan

- [x] `just format-check` clean
- [x] `swiftlint lint --strict --quiet | grep closure_parameter_position` returns zero matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)