### PR TITLE
chore(lint): document for-where preference (#290)

### DIFF
--- a/guides/CODE_GUIDE.md
+++ b/guides/CODE_GUIDE.md
@@ -382,6 +382,23 @@ SwiftLint enforces most of these via opt-in rules; follow them by habit.
   ```
 
 - **More than 3 levels of nesting → extract a function.** SwiftLint's [`nesting`](https://realm.github.io/SwiftLint/nesting.html) rule warns past function-level 2, but readability degrades well before the warning. Extract early.
+- **Use `for … where` instead of `for … { if … }`** when the whole loop body is guarded by a single condition. Enforced by [`for_where`](https://realm.github.io/SwiftLint/for_where.html). The `where` clause reads as part of the iteration contract ("for every X that matches P …") and drops one level of nesting from the body.
+
+  ```swift
+  // Good
+  for cachedDate in sortedDates where cachedDate <= dateString {
+    return cache.prices[cachedDate]
+  }
+
+  // Bad — the inner `if` wraps the entire body
+  for cachedDate in sortedDates {
+    if cachedDate <= dateString {
+      return cache.prices[cachedDate]
+    }
+  }
+  ```
+
+  Only applies when the `if` wraps the entire loop body. A loop that does meaningful work before or after a conditional branch should keep the `if` — moving a partial guard into `where` would change the loop's shape.
 
 ---
 


### PR DESCRIPTION
## Summary

The rule is already at zero in the current baseline — commits [0c5e65b](https://github.com/ajsutton/moolah-native/commit/0c5e65b) (`TransactionDetailView.legCategoryFieldFocused` + `StockPriceService.fallbackPrice`) and [149ff15](https://github.com/ajsutton/moolah-native/commit/149ff15) (`CryptoPriceService.fallbackPrice`) converted the three original `for ... { if ... }` call sites to `for ... where ...`.

- Current live count: **0** `for_where` violations.
- Current baseline count: **0** (rule has no entries).
- No code change is needed to drop the count further — it's already there.

The only change in this PR is a `guides/CODE_GUIDE.md` §15 (Control Flow) bullet pinning down the pattern (guard the whole loop body via `where`, not an inner `if`) so the rule stays at zero without every contributor rediscovering it.

**Stacked on [#399](https://github.com/ajsutton/moolah-native/pull/399).** Retarget to `main` when that lands.

Fixes https://github.com/ajsutton/moolah-native/issues/290

## Test plan

- [x] `just format-check` clean
- [x] `swiftlint lint --baseline .swiftlint-baseline.yml --strict --quiet | grep for_where` returns zero matches

Generated with [Claude Code](https://claude.com/claude-code)