### PR TITLE
chore(lint): document strict_fileprivate preference (#291)

### DIFF
--- a/guides/CODE_GUIDE.md
+++ b/guides/CODE_GUIDE.md
@@ -219,7 +219,7 @@ Apple's [Choosing Between Structures and Classes](https://developer.apple.com/do
 
 - **Language default is `internal`.** Don't write `internal` explicitly — it's noise.
 - **Prefer `private`** for members. Smaller surface area = fewer coupling paths.
-- **`fileprivate` only when the compiler requires it.** The project's `.swift-format` `fileScopedDeclarationPrivacy` rule handles the common case of file-scoped declarations automatically; reach for `fileprivate` manually only when an extension in the same file needs access that `private` blocks.
+- **`fileprivate` only when the compiler requires it.** The project's `.swift-format` `fileScopedDeclarationPrivacy` rule handles the common case of file-scoped declarations automatically; reach for `fileprivate` manually only when an extension in the same file needs access that `private` blocks. SwiftLint's `strict_fileprivate` rule enforces this — if an extension of the same type sits in the same file, the member should be `private`, not `fileprivate` (Swift's `private` already reaches same-file same-type extensions). Use `internal` (the language default, written by omitting the keyword) when a sibling extension in a different file needs access.
 - **`public` only at module boundaries.** This project has effectively one module boundary today: `Domain/`. Inside the app target, everything is `internal` or tighter; writing `public` anywhere else is almost certainly wrong.
 
 ---


### PR DESCRIPTION
## Summary

The rule is already enforced in `opt_in_rules` and live count is zero — earlier cleanup promoted same-file extension members from `fileprivate` to `private`, and the remaining legitimate cross-file cases (e.g. `CloudKitAnalysisRepository.fetchTransactions`) were widened to `internal` with an explanatory comment.

- Current live count: **0** `strict_fileprivate` violations.
- Current baseline count: **0** (rule has no entries).
- No code or baseline changes are needed — the rule is already at zero.

The only change in this PR is a `guides/CODE_GUIDE.md` §7 (Access Control) bullet extension pinning down the pattern (same-file same-type extension uses `private`; cross-file sibling extension widens to `internal`; `fileprivate` stays reserved for the rare cases the compiler actually requires) so the rule stays at zero without every contributor rediscovering it.

**Stacked on [#400](https://github.com/ajsutton/moolah-native/pull/400).** Retarget to `main` when that lands.

Fixes https://github.com/ajsutton/moolah-native/issues/291

## Test plan

- [x] `just format-check` clean
- [x] `swiftlint lint --baseline .swiftlint-baseline.yml --strict --quiet | grep strict_fileprivate` returns zero matches
- [x] `just build-mac` succeeds

Generated with [Claude Code](https://claude.com/claude-code)