### PR TITLE
chore(lint): document type_name preference (#292)

### DIFF
--- a/guides/CODE_GUIDE.md
+++ b/guides/CODE_GUIDE.md
@@ -168,6 +168,8 @@ Apple's [Swift API Design Guidelines](https://www.swift.org/documentation/api-de
   account.balance  // Not: account.accountBalance
   ```
 
+- **Type names are UpperCamelCase, 3–40 characters.** Classes, structs, enums, protocols, actors, and type aliases use UpperCamelCase with no underscores or digits used as separators, and fit inside the 3-character minimum / 40-character warning range. SwiftLint's [`type_name`](https://realm.github.io/SwiftLint/type_name.html) rule enforces this — if a name wants to go longer, the type is almost always doing too much and should be split. Test types are not exempt: a test suite named `TransactionIsSimpleCrossCurrencyTransferTests` is a signal that the scenario wants its own helper fixture or a more focused `…Tests` file, not a longer identifier.
+
 ### 4.1 Project suffix conventions
 
 - **OK as needed:** `Controller`, `ViewController`, `Delegate`, `Store` (the `@Observable` owner of UI-bound state).


### PR DESCRIPTION
## Summary

The rule is already enforced as a SwiftLint default and live count is zero — the two files called out in the issue's baseline snapshot (`AnalysisStoreTests.swift`, `TransactionIsSimpleCrossCurrencyTransferTests.swift`) have since been deleted during unrelated cleanup, so both the live violation count and the baseline count are 0.

- Current live count: **0** `type_name` violations.
- Current baseline count: **0** (rule has no entries).
- No code or baseline changes are needed — the rule is already at zero.

The only change in this PR is a `guides/CODE_GUIDE.md` §4 (Naming) bullet pinning down the pattern (UpperCamelCase, 3–40 character window; a name that wants to go longer is a signal to split the type, not to extend the name — with the `…Tests` case called out because the issue's baseline snapshot points directly at it) so the rule stays at zero without every contributor rediscovering it.

**Stacked on [#401](https://github.com/ajsutton/moolah-native/pull/401).** Retarget to `main` when that lands.

Fixes https://github.com/ajsutton/moolah-native/issues/292

## Test plan

- [x] `just format-check` clean
- [x] `swiftlint lint --baseline .swiftlint-baseline.yml --strict --quiet | grep type_name` returns zero matches
- [x] No production code changes; no build needed

Generated with [Claude Code](https://claude.com/claude-code)