### PR TITLE
chore(lint): document force_cast preference (#293)

### DIFF
--- a/guides/CODE_GUIDE.md
+++ b/guides/CODE_GUIDE.md
@@ -261,7 +261,8 @@ Apple's [Choosing Between Structures and Classes](https://developer.apple.com/do
   ```
 
 - **No force-unwrap, force-try, or `as!` in production.** SwiftLint enforces [`force_unwrapping`](https://realm.github.io/SwiftLint/force_unwrapping.html), [`force_try`](https://realm.github.io/SwiftLint/force_try.html), [`force_cast`](https://realm.github.io/SwiftLint/force_cast.html) as warnings in production paths.
-- **In tests:** force operations are allowed but prefer `XCTUnwrap` and explicit `try` — they produce better failure messages and fail the test cleanly instead of crashing the suite.
+- **Replace `as!` with `guard let … as?` + an explicit failure.** The fix is not to swap the trap for a different trap — it's to surface *why* the cast is expected to succeed. For benchmarks and integration harnesses the right escape hatch is `guard let typed = value as? TargetType else { fatalError("context: got \(type(of: value))") }`; the type name in the message is what makes a future backend swap debuggable instead of cryptic. For tests, extract the value and unwrap via `#require` (Swift Testing) or `XCTUnwrap` (XCTest) so the shape mismatch reads as a test failure rather than a crash. SwiftLint's [`force_cast`](https://realm.github.io/SwiftLint/force_cast.html) rule catches the raw `as!` form; the preferred replacements above both pass the rule and produce better failure output.
+- **In tests:** force operations are allowed but prefer `#require` / `XCTUnwrap` and explicit `try` — they produce better failure messages and fail the test cleanly instead of crashing the suite.
 - **No implicitly unwrapped optionals** outside the rare IBOutlet case. This is a SwiftUI-only codebase; the exception effectively never applies.
 
 ---


### PR DESCRIPTION
## Summary

The rule is already enforced as a SwiftLint opt-in and the live count is zero — both files called out in the issue's baseline snapshot (`MoolahBenchmarks/AnalysisBenchmarks.swift`, `MoolahTests/Export/ExportedDataTests.swift`) already use `guard let … as?` / `#require` instead of `as!`, so the baseline currently has **zero** `force_cast` entries.

- Current live count: **0** `force_cast` violations.
- Current baseline count: **0** (rule has no entries).
- No code or baseline changes are needed — the rule is already at zero.

The only change in this PR is a `guides/CODE_GUIDE.md` §9 bullet pinning down the replacement pattern (`guard let … as?` + `fatalError("context: got \(type(of:))")` for harnesses; `#require` / `XCTUnwrap` for tests) so a future contributor doesn't "fix" an `as!` by swapping it for a different trap. The existing terse "no force-unwrap / force-try / `as!`" line stays; the new bullet beside it spells out the *how*.

**Stacked on [#402](https://github.com/ajsutton/moolah-native/pull/402).** Retarget to `main` when that lands.

Fixes https://github.com/ajsutton/moolah-native/issues/293

## Test plan

- [x] `just format-check` clean
- [x] `swiftlint lint --baseline .swiftlint-baseline.yml --strict --quiet | grep force_cast` returns zero matches
- [x] No production code changes; no build needed

Generated with [Claude Code](https://claude.com/claude-code)