### PR TITLE
chore(lint): document orphaned_doc_comment preference (#295)

### DIFF
--- a/guides/CODE_GUIDE.md
+++ b/guides/CODE_GUIDE.md
@@ -453,6 +453,7 @@ These rules concern Swift-language patterns in SwiftUI code. Layout, colour, and
   ```
 
 - **DocC-compatible sections.** Use `- Parameters:`, `- Returns:`, `- Throws:` per [apple/swift DocumentationComments.md](https://github.com/apple/swift/blob/main/docs/DocumentationComments.md).
+- **Attach doc comments directly to the declaration they describe.** SwiftLint's [`orphaned_doc_comment`](https://realm.github.io/SwiftLint/orphaned_doc_comment.html) rule flags `///` blocks separated from the next declaration by a blank line or an intervening `//` comment — the compiler treats those as orphans and drops them from DocC / Xcode Quick Help. If a doc comment isn't documenting the declaration that immediately follows, demote it to `//` (it's narrative, not API docs) or move it adjacent to the declaration it's actually describing. Never leave a blank line between `///` and the `func` / `var` / `let` / `class` it documents.
 - **No block comments** (`/* */`). SwiftLint's `NoBlockComments` rule enforces this.
 - **No commented-out code.** Delete it — `git log` has the history. Commented-out code rots, lies about intent, and triggers false-positive diffs.
 - **`// MARK:` for sections** inside files longer than 300 lines (cross-ref §2).


### PR DESCRIPTION
## Summary

The `orphaned_doc_comment` rule is already enforced as a SwiftLint default and the live count is zero — the single file called out in the issue's baseline snapshot (`App/ProfileSession.swift`) has since been cleaned up during unrelated work, so both the live violation count and the baseline count are 0.

- Current live count: **0** `orphaned_doc_comment` violations.
- Current baseline count: **0** (rule has no entries).
- No code or baseline changes are needed — the rule is already at zero.

The only change in this PR is a `guides/CODE_GUIDE.md` §19 (Documentation) bullet pinning down the rule's intent (attach `///` directly to the declaration it describes; demote narrative blocks to `//` or move them adjacent to the declaration they document) so a future contributor doesn't re-introduce an orphan by leaving a blank line or `//` interjection between a doc comment and its declaration.

**Stacked on [#404](https://github.com/ajsutton/moolah-native/pull/404).** Retarget to `main` when that lands.

Fixes https://github.com/ajsutton/moolah-native/issues/295

## Test plan

- [x] `just format-check` clean
- [x] `swiftlint lint --only-rule orphaned_doc_comment` reports zero violations
- [x] No production code changes; no build needed

Generated with [Claude Code](https://claude.com/claude-code)