### PR TITLE
chore(lint): document unused_enumerated preference (#296)

### DIFF
--- a/guides/CODE_GUIDE.md
+++ b/guides/CODE_GUIDE.md
@@ -367,6 +367,14 @@ SwiftLint enforces most of these via opt-in rules; follow them by habit.
   ```
 
 - **`for … in` over `forEach`** for side effects. `forEach` hides control flow — you can't `break`, `continue`, or `return` from the enclosing function. Use `forEach` only for pure-call chains where control flow isn't relevant.
+- **Don't reach for `.enumerated()` unless you need the index.** SwiftLint's [`unused_enumerated`](https://realm.github.io/SwiftLint/unused_enumerated.html) rule flags `for (_, element) in sequence.enumerated()` — drop the `.enumerated()` and iterate the sequence directly. If you only need the offset for a SwiftUI `ForEach`'s `id:`, prefer giving the element a stable identity (conform to `Identifiable` or key by a domain-unique property) over `Array(…​.enumerated())` + `\.offset`, which re-orders animations on insertion and hides the real identity of the row.
+
+  ```swift
+  for leg in transaction.legs { … }                     // Good
+  for (_, leg) in transaction.legs.enumerated() { … }   // Bad — use the sequence directly
+  for (index, leg) in transaction.legs.enumerated() { … }   // OK — index is used
+  ```
+
 - **`isMultiple(of:)` over `% == 0` for divisibility checks.** `BinaryInteger.isMultiple(of:)` reads as the intent ("is `i` a multiple of `N`") and survives a `0` divisor (`x.isMultiple(of: 0)` is `true` only when `x == 0`, not a trap). Keep `%` for actual remainder arithmetic (e.g. `i % earmarkIds.count` as an index wrap). Enforced by [`legacy_multiple`](https://realm.github.io/SwiftLint/legacy_multiple.html).
 
   ```swift


### PR DESCRIPTION
## Summary

The `unused_enumerated` rule is already enforced as a SwiftLint default and the live count is zero — the single file called out in the issue's baseline snapshot (`Features/Analysis/Views/CategoriesOverTimeCard.swift`) has since been cleaned up during unrelated work, so both the live violation count and the baseline count are 0.

- Current live count: **0** `unused_enumerated` violations.
- Current baseline count: **0** (rule has no entries).
- No code or baseline changes are needed — the rule is already at zero.

The only change in this PR is a `guides/CODE_GUIDE.md` §14 (Collection Idioms) bullet pinning down the rule's intent (drop `.enumerated()` when the index isn't used; prefer stable `Identifiable` row identity over `Array(…​.enumerated())` + `\.offset` in SwiftUI `ForEach`) so a future contributor doesn't re-introduce `for (_, element) in sequence.enumerated()` out of habit.

**Stacked on [#405](https://github.com/ajsutton/moolah-native/pull/405).** Retarget to `main` when that lands.

Fixes https://github.com/ajsutton/moolah-native/issues/296

## Test plan

- [x] `just format-check` clean
- [x] `swiftlint lint --only-rule unused_enumerated` reports zero violations
- [x] No production code changes; no build needed

Generated with [Claude Code](https://claude.com/claude-code)