### PR TITLE
chore(lint): document array_init preference (#297)

### DIFF
--- a/guides/CODE_GUIDE.md
+++ b/guides/CODE_GUIDE.md
@@ -382,6 +382,14 @@ SwiftLint enforces most of these via opt-in rules; follow them by habit.
   if index % 100 == 0 { /* Bad */ }
   ```
 
+- **`Array(sequence)` over `sequence.map { $0 }` to materialize a sequence.** The identity-closure `map` is a disguised conversion that allocates and iterates without communicating intent; the `Array` initializer names exactly what's happening. Enforced by [`array_init`](https://realm.github.io/SwiftLint/array_init.html).
+
+  ```swift
+  let ids = Array(transaction.legs.lazy.map(\.id))   // Good — `map` is doing real work
+  let legs = Array(transaction.legs)                 // Good — just materializing
+  let legs = transaction.legs.map { $0 }             // Bad — use `Array(…)`
+  ```
+
 ---
 
 ## 15. Control Flow


### PR DESCRIPTION
## Summary

The `array_init` rule is already enforced as a SwiftLint opt-in and the live count is zero — the single file called out in the issue's baseline snapshot (`Features/Transactions/Views/TransactionDetailView.swift`) has since been cleaned up during unrelated work, so both the live violation count and the baseline count are 0.

- Current live count: **0** `array_init` violations.
- Current baseline count: **0** (rule has no entries).
- No code or baseline changes are needed — the rule is already at zero.

The only change in this PR is a `guides/CODE_GUIDE.md` §14 (Collection Idioms) bullet pinning down the rule's intent (prefer `Array(sequence)` over `sequence.map { $0 }` when the closure is identity) so a future contributor doesn't re-introduce the disguised-conversion form out of habit.

**Stacked on [#406](https://github.com/ajsutton/moolah-native/pull/406).** Retarget to `main` when that lands.

Fixes https://github.com/ajsutton/moolah-native/issues/297

## Test plan

- [x] `just format-check` clean
- [x] `swiftlint --reporter json` reports zero `array_init` violations
- [x] No production code changes; no build needed

Generated with [Claude Code](https://claude.com/claude-code)