### PR TITLE
chore(lint): document sorted_first_last preference (#298)

### DIFF
--- a/guides/CODE_GUIDE.md
+++ b/guides/CODE_GUIDE.md
@@ -390,6 +390,14 @@ SwiftLint enforces most of these via opt-in rules; follow them by habit.
   let legs = transaction.legs.map { $0 }             // Bad — use `Array(…)`
   ```
 
+- **`min()` / `max()` over `sorted().first` / `sorted().last`.** Sorting to pick a single extreme value is O(n log n) and allocates; `min()` / `max()` do it in O(n) without the intermediate array. Use the closure-taking overloads (`min(by:)`, `max(by:)`) when the ordering key is non-default. Enforced by [`sorted_first_last`](https://realm.github.io/SwiftLint/sorted_first_last.html).
+
+  ```swift
+  let earliest = transactions.min(by: { $0.date < $1.date })   // Good
+  let latest = prices.max()                                    // Good
+  let earliest = transactions.sorted { $0.date < $1.date }.first   // Bad — use `min(by:)`
+  ```
+
 ---
 
 ## 15. Control Flow


### PR DESCRIPTION
## Summary

The `sorted_first_last` rule is already enforced as a SwiftLint opt-in and the live count is zero — the single file called out in the issue's baseline snapshot (`MoolahTests/Support/FixedCryptoPriceClient.swift`) has since been cleaned up during unrelated work, so both the live violation count and the baseline count are 0.

- Current live count: **0** `sorted_first_last` violations.
- Current baseline count: **0** (rule has no entries).
- No code or baseline changes are needed — the rule is already at zero.

The only change in this PR is a `guides/CODE_GUIDE.md` §14 (Collection Idioms) bullet pinning down the rule's intent (prefer `min()` / `max()` over `sorted().first` / `sorted().last` to avoid O(n log n) + allocation for picking a single extreme) so a future contributor doesn't re-introduce the pattern out of habit.

**Stacked on [#407](https://github.com/ajsutton/moolah-native/pull/407).** Retarget to `main` when that lands.

Fixes https://github.com/ajsutton/moolah-native/issues/298

## Test plan

- [x] `just format-check` clean
- [x] `swiftlint --reporter json` reports zero `sorted_first_last` violations
- [x] No production code changes; no build needed

Generated with [Claude Code](https://claude.com/claude-code)