### PR TITLE
chore(lint): document empty_collection_literal preference (#299)

### DIFF
--- a/guides/CODE_GUIDE.md
+++ b/guides/CODE_GUIDE.md
@@ -398,6 +398,15 @@ SwiftLint enforces most of these via opt-in rules; follow them by habit.
   let earliest = transactions.sorted { $0.date < $1.date }.first   // Bad — use `min(by:)`
   ```
 
+- **`isEmpty` over `== []` / `== [:]` literal comparison.** Comparing a collection to an empty literal forces `Equatable` element-wise equality on an empty shape and reads as a value test; `isEmpty` names the intent and is O(1) on every standard collection. Applies to arrays, dictionaries, sets, and strings (`== ""`). Enforced by [`empty_collection_literal`](https://realm.github.io/SwiftLint/empty_collection_literal.html).
+
+  ```swift
+  if transactions.isEmpty { /* Good */ }
+  if lookup.isEmpty { /* Good */ }
+  if transactions == [] { /* Bad — use `isEmpty` */ }
+  if lookup == [:] { /* Bad — use `isEmpty` */ }
+  ```
+
 ---
 
 ## 15. Control Flow


### PR DESCRIPTION
## Summary

The `empty_collection_literal` rule is already enforced as a SwiftLint opt-in and the live count is zero — the single file called out in the issue's baseline snapshot (`MoolahTests/Shared/CSVImport/CSVTokenizerTests.swift`) has since been cleaned up during unrelated work, so both the live violation count and the baseline count are 0.

- Current live count: **0** `empty_collection_literal` violations.
- Current baseline count: **0** (rule has no entries).
- No code or baseline changes are needed — the rule is already at zero.

The only change in this PR is a `guides/CODE_GUIDE.md` §14 (Collection Idioms) bullet pinning down the rule's intent (prefer `isEmpty` over `== []` / `== [:]` literal comparison) so a future contributor doesn't re-introduce the pattern out of habit.

**Stacked on [#408](https://github.com/ajsutton/moolah-native/pull/408).** Retarget to `main` when that lands.

Fixes https://github.com/ajsutton/moolah-native/issues/299

## Test plan

- [x] `just format-check` clean
- [x] `swiftlint --reporter json` reports zero `empty_collection_literal` violations
- [x] No production code changes; no build needed

Generated with [Claude Code](https://claude.com/claude-code)