### PR TITLE
chore(lint): document convenience_type preference (#300)

### DIFF
--- a/guides/CODE_GUIDE.md
+++ b/guides/CODE_GUIDE.md
@@ -193,6 +193,20 @@ Apple's [Choosing Between Structures and Classes](https://developer.apple.com/do
 - **`final class` always.** Inheritance costs more than it delivers for most app code. NetNewsWire shows 253 `final class` vs 12 bare `class` across 92k lines ([CodingGuidelines.md](https://github.com/Ranchero-Software/NetNewsWire/blob/main/Technotes/CodingGuidelines.md)). Non-`final` is the exception and needs a justification in review.
 - **`enum` for closed sets of cases.** Exhaustive `switch` catches missed cases at compile time.
 - **`indirect enum` for recursive types** (expression trees, linked structures).
+- **Case-less `enum` for pure namespaces.** A type that only groups static members (or nested types, as in our `@Suite` contract-test aggregators) should be a case-less `enum`, not a `struct` / `class` / `final class`. The `enum` has no cases, so it can't be instantiated — the compiler enforces the "namespace only" intent that a `struct` would merely document. Enforced by [`convenience_type`](https://realm.github.io/SwiftLint/convenience_type.html).
+
+  ```swift
+  enum CurrencyFormat {                          // Good
+    static let maxFractionDigits = 2
+    static func parseCents(from text: String) -> Int? { … }
+  }
+
+  struct CurrencyFormat {                        // Bad — use a case-less enum
+    static let maxFractionDigits = 2
+    static func parseCents(from text: String) -> Int? { … }
+  }
+  ```
+
 - **`actor`** — defer to `guides/CONCURRENCY_GUIDE.md`. Actors exist for concurrency isolation, not for general "reference-type-with-extras" needs.
 
 ---


### PR DESCRIPTION
## Summary

The `convenience_type` rule is already enforced as a SwiftLint opt-in and the live count is zero — the single file called out in the issue's baseline snapshot (`MoolahTests/Domain/AuthContractTests.swift`) already uses a case-less `enum` as its `@Suite` namespace, so both the live violation count and the baseline count are 0.

- Current live count: **0** `convenience_type` violations.
- Current baseline count: **0** (rule has no entries).
- No code or baseline changes are needed — the rule is already at zero.

The only change in this PR is a `guides/CODE_GUIDE.md` §5 (Types — value vs reference) bullet pinning down the rule's intent (prefer a case-less `enum` over a `struct` / `class` for pure namespaces, so the compiler enforces the "can't be instantiated" contract that a `struct` would merely document) so a future contributor doesn't re-introduce the pattern out of habit.

**Stacked on [#409](https://github.com/ajsutton/moolah-native/pull/409).** Retarget to `main` when that lands.

Fixes https://github.com/ajsutton/moolah-native/issues/300

## Test plan

- [x] `just format-check` clean
- [x] `swiftlint --reporter json` reports zero `convenience_type` violations
- [x] No production code changes; no build needed

Generated with [Claude Code](https://claude.com/claude-code)