### PR TITLE
feat(automation): navigate to specific accounts and earmarks from AppleScript

### DIFF
--- a/.claude/skills/automate-app/SKILL.md
+++ b/.claude/skills/automate-app/SKILL.md
@@ -139,8 +139,12 @@ moolah-tell 'tell profile "Test" to create category name "Fruit" parent "Groceri
 # Refresh data from backend
 moolah-tell 'refresh profile "Test"'
 
-# Navigate to a specific account
+# Navigate to a specific account (selects it in the sidebar and shows its
+# detail pane — equivalent to clicking the row)
 moolah-tell 'navigate to account "Savings" of profile "Test"'
+
+# Navigate to a specific earmark (same: selects in sidebar, shows detail)
+moolah-tell 'navigate to earmark "Holiday" of profile "Test"'
 ```
 
 ### Multi-line scripts
@@ -169,6 +173,10 @@ moolah-tell 'navigate to profile "Test"'
 moolah-tell 'navigate to every account of profile "Test"'
 moolah-tell 'navigate to every earmark of profile "Test"'
 moolah-tell 'navigate to every category of profile "Test"'
+
+# Open a specific account or earmark's detail pane (matches sidebar click)
+moolah-tell 'navigate to account "Crypto" of profile "Test"'
+moolah-tell 'navigate to earmark "Holiday" of profile "Test"'
 ```
 
 **Profile resolution:** Matches by name (case-insensitive), then by UUID. If the profile isn't open, a window opens for it.

--- a/Automation/AppleScript/Commands/NavigateCommand.swift
+++ b/Automation/AppleScript/Commands/NavigateCommand.swift
@@ -102,14 +102,34 @@
     /// `scriptableEarmarks`, …) onto a `NavigationDestination`. Returns `nil`
     /// for specifier keys that don't correspond to a list/detail view — the
     /// caller treats that as "navigate to the profile root only".
+    ///
+    /// For name / ID specifiers that resolve to a concrete `ScriptableAccount`
+    /// or `ScriptableEarmark`, returns the specific `.account(id)` /
+    /// `.earmark(id)` destination so callers of `navigate to account "X"`
+    /// land on that detail view (equivalent to clicking the sidebar row).
+    /// When the specifier is the full collection or resolution fails, falls
+    /// back to the collection-level destination.
     private static func destination(
       for specifier: NSScriptObjectSpecifier
     ) -> NavigationDestination? {
+      let resolved = specifier.objectsByEvaluatingSpecifier
       switch specifier.key {
-      case "scriptableAccounts": .accounts
-      case "scriptableEarmarks": .earmarks
-      case "scriptableCategories": .categories
-      default: nil
+      case "scriptableAccounts":
+        if let account = resolved as? ScriptableAccount,
+          let uuid = UUID(uuidString: account.uniqueID)
+        {
+          return .account(uuid)
+        }
+        return .accounts
+      case "scriptableEarmarks":
+        if let earmark = resolved as? ScriptableEarmark,
+          let uuid = UUID(uuidString: earmark.uniqueID)
+        {
+          return .earmark(uuid)
+        }
+        return .earmarks
+      case "scriptableCategories": return .categories
+      default: return nil
       }
     }
 


### PR DESCRIPTION
## Summary

- `navigate to account "X" of profile "Y"` previously always landed on the accounts list regardless of the named account — the specifier's name was ignored. Same for earmarks.
- Resolve name / ID specifiers to a `ScriptableAccount` or `ScriptableEarmark` via `objectsByEvaluatingSpecifier` and return the corresponding `.account(id)` / `.earmark(id)` destination, so AppleScript navigation matches a sidebar click. Collection-level specifiers still fall through to the list destinations.
- Update the `automate-app` skill docs to describe the new behaviour.

Reproduce the old behaviour:

```bash
osascript -e 'tell application "/path/to/Moolah.app" to navigate to account "Crypto" of profile "Test Profile"'
# Before: lands on the "Accounts" list.
# After: opens the Crypto detail view.
```

## Test plan

- [x] `just test-mac` — 1,500 tests pass.
- [x] Manual: `navigate to account "Crypto" of profile "Test Profile"` opens the Crypto detail pane in a Release build.
- [x] Manual: `navigate to earmark "…" of profile "X"` opens the earmark's detail.
- [x] Manual: `navigate to every account of profile "X"` still shows the accounts list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)