### PR TITLE
fix(investments): gate layout choice on initial load to avoid toolbar crash

### DIFF
--- a/Features/Investments/Views/InvestmentAccountView.swift
+++ b/Features/Investments/Views/InvestmentAccountView.swift
@@ -17,6 +17,15 @@ struct InvestmentAccountView: View {
     title: "", hostCurrency: .AUD, positions: [], historicalValue: nil)
   @State private var positionsRange: PositionsTimeRange = .threeMonths
   @State private var isLoadingPositions = false
+  /// Tracks whether `loadAllData` has run at least once for this account.
+  /// Gates the body so `legacyValuationsLayout` vs `positionTrackedLayout`
+  /// is chosen *after* `investmentStore.values` is known — otherwise the
+  /// branch flips from position-tracked to legacy mid-layout, tearing down
+  /// and re-mounting the embedded `TransactionListView` with its `.toolbar`,
+  /// which double-registers items in SwiftUI's AppKit toolbar bridge and
+  /// crashes Release builds on accounts that have legacy investment values
+  /// (e.g. Test Profile → Crypto).
+  @State private var initialLoadComplete = false
 
   /// The profile's reporting currency — used for valuing positions and the
   /// chart series. NOT the account's own instrument: an investment account
@@ -130,7 +139,10 @@ struct InvestmentAccountView: View {
 
   var body: some View {
     Group {
-      if investmentStore.hasLegacyValuations {
+      if !initialLoadComplete {
+        ProgressView()
+          .frame(maxWidth: .infinity, maxHeight: .infinity)
+      } else if investmentStore.hasLegacyValuations {
         legacyValuationsLayout
       } else {
         positionTrackedLayout
@@ -151,12 +163,14 @@ struct InvestmentAccountView: View {
         accountId: account.id, instrument: account.instrument, store: investmentStore)
     }
     .task(id: account.id) {
+      initialLoadComplete = false
       isLoadingPositions = true
       defer { isLoadingPositions = false }
       await investmentStore.loadAllData(
         accountId: account.id, profileCurrency: profileCurrencyInstrument)
       positionsInput = await investmentStore.positionsViewInput(
         title: account.name, range: positionsRange)
+      initialLoadComplete = true
     }
     .task(id: positionsRange) {
       // Skip until loadAllData has populated the store; the .task(id: account.id)


### PR DESCRIPTION
## Summary

`InvestmentAccountView` switched its body between `positionTrackedLayout` and `legacyValuationsLayout` based on `investmentStore.hasLegacyValuations` (`!values.isEmpty`). On first mount `values = []`, so position-tracked renders first; as soon as `loadValues` completes and the account has legacy investment values (Test Profile → Crypto), the flag flips and the layout switches mid-render — tearing down the embedded `TransactionListView` and remounting it in a new structural position.

Both mounts register their `.toolbar` items against the window's `NSToolbar`, and SwiftUI's AppKit bridge throws an `NSException` from `NSToolbar._insertNewItemWithItemIdentifier:…:propertyListRepresentation:` during `AppKitToolbarStrategy.updateLocations`. Reproduces reliably on Release (and now Debug) builds when clicking an investment-with-values account.

Same remount also explains #412 (transactions fail to load on first open but work after navigating away and back — the first `TransactionListView`'s load task is cancelled mid-flight when the view tears down).

## Fix

Gate the layout choice on a new `initialLoadComplete` flag set at the end of `.task(id: account.id)`. While the initial load is in flight the view shows a bare `ProgressView`; once `loadAllData` returns, the correct layout is chosen and `TransactionListView` mounts exactly once in its final structural position. Subsequent `.refreshable` refreshes keep the flag at `true` so the layout stays stable.

Single-file, 14-line change.

Fixes #412.

## Test plan

- [x] `just test-mac` — all tests pass.
- [x] Manual: Debug build, click Test Profile → Crypto — transactions load on first click (previously required navigating away and back), no crash.
- [x] Manual: click between Crypto, another investment account, and back repeatedly — no crash, transactions always populate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)