### PR TITLE
fix(transactions): show exact-match payees and keep autofill from opening category picker

### DIFF
--- a/App/UITestSeedHydrator+Upserts.swift
+++ b/App/UITestSeedHydrator+Upserts.swift
@@ -35,6 +35,7 @@ extension UITestSeedHydrator {
     let date: Date
     let amount: InstrumentAmount
     let accountId: UUID
+    let categoryId: UUID?
   }
 
   struct CustomExpenseSplitSpec {
@@ -161,6 +162,7 @@ extension UITestSeedHydrator {
         instrumentId: spec.amount.instrument.id,
         quantity: outgoing.storageValue,
         type: TransactionType.expense.rawValue,
+        categoryId: spec.categoryId,
         sortOrder: 0
       )
     )

--- a/App/UITestSeedHydrator.swift
+++ b/App/UITestSeedHydrator.swift
@@ -111,6 +111,14 @@ enum UITestSeedHydrator {
         toAccountId: fixtures.brokerageAccountId),
       in: context)
 
+    // Categories must exist before any leg references them by id, so
+    // upsert them ahead of the historical expense loop (one of those
+    // entries attaches `groceriesCategoryId`).
+    try upsertCategory(
+      id: fixtures.groceriesCategoryId, name: fixtures.groceriesCategoryName, in: context)
+    try upsertCategory(
+      id: fixtures.gymCategoryId, name: fixtures.gymCategoryName, in: context)
+
     let historicalAmount = InstrumentAmount(
       quantity: Decimal(fixtures.historicalExpenseAmountCents) / 100,
       instrument: instrument)
@@ -121,14 +129,10 @@ enum UITestSeedHydrator {
           payee: historical.payee,
           date: historical.date,
           amount: historicalAmount,
-          accountId: fixtures.checkingAccountId),
+          accountId: fixtures.checkingAccountId,
+          categoryId: historical.categoryId),
         in: context)
     }
-
-    try upsertCategory(
-      id: fixtures.groceriesCategoryId, name: fixtures.groceriesCategoryName, in: context)
-    try upsertCategory(
-      id: fixtures.gymCategoryId, name: fixtures.gymCategoryName, in: context)
 
     try upsertCustomExpenseSplit(
       CustomExpenseSplitSpec(

--- a/Features/Transactions/Views/PayeeAutocompleteField.swift
+++ b/Features/Transactions/Views/PayeeAutocompleteField.swift
@@ -37,8 +37,11 @@ struct PayeeSuggestionDropdown: View {
   let onSelect: (String) -> Void
 
   private var visibleSuggestions: [PayeeSuggestion] {
+    // Include exact matches: when the user has typed a known payee in
+    // full, seeing that payee highlighted in the dropdown is the
+    // confirmation that the app recognised it. Suppressing it made the
+    // suggestion look forgotten.
     suggestions
-      .filter { $0.localizedCaseInsensitiveCompare(searchText) != .orderedSame }
       .prefix(8)
       .enumerated()
       .map { PayeeSuggestion(id: $0.offset, name: $0.element) }

--- a/Features/Transactions/Views/TransactionDetailView.swift
+++ b/Features/Transactions/Views/TransactionDetailView.swift
@@ -508,28 +508,13 @@ struct TransactionDetailView: View {
         text: $draft.categoryText,
         highlightedIndex: $categoryHighlightedIndex,
         suggestionCount: categoryVisibleSuggestionCount,
-        onTextChange: { _ in
-          if categoryJustSelected {
-            categoryJustSelected = false
-          } else {
-            showCategorySuggestions = true
-          }
-        },
+        onTextChange: { _ in openCategoryDropdownIfFocused() },
         onAcceptHighlighted: acceptHighlightedCategory
       )
       .focused($categoryFieldFocused)
+      .accessibilityIdentifier(UITestIdentifiers.Detail.category)
       .onChange(of: categoryFieldFocused) { _, focused in
-        if !focused {
-          categoryJustSelected = true
-          showCategorySuggestions = false
-          categoryHighlightedIndex = nil
-          if let id = draft.categoryId, let cat = categories.by(id: id) {
-            draft.categoryText = categories.path(for: cat)
-          } else {
-            draft.categoryText = ""
-            draft.categoryId = nil
-          }
-        }
+        if !focused { handleCategoryFieldBlur() }
       }
 
       Picker("Earmark", selection: $draft.earmarkId) {
@@ -542,6 +527,32 @@ struct TransactionDetailView: View {
         .pickerStyle(.menu)
       #endif
     }
+  }
+
+  /// Opens the category dropdown in response to a user-driven edit.
+  ///
+  /// Only a focused field's text change counts as a user edit. Programmatic
+  /// writes (payee-autofill, focus-out normalisation) also flow through
+  /// `onChange(of: text)`; without the focus guard they'd open the picker
+  /// the user never asked to browse.
+  private func openCategoryDropdownIfFocused() {
+    guard categoryFieldFocused else { return }
+    if categoryJustSelected {
+      categoryJustSelected = false
+    } else {
+      showCategorySuggestions = true
+    }
+  }
+
+  /// Resets picker UI state on blur and delegates the `categoryText` /
+  /// `categoryId` reconciliation to `TransactionDraft` so the rule — "text
+  /// that doesn't resolve to a known category is cleared" — is exercised
+  /// directly by `TransactionDraft` tests without a view host.
+  private func handleCategoryFieldBlur() {
+    categoryJustSelected = true
+    showCategorySuggestions = false
+    categoryHighlightedIndex = nil
+    draft.normaliseCategoryText(using: categories)
   }
 
   private var customDetailsSection: some View {
@@ -845,10 +856,10 @@ struct TransactionDetailView: View {
 
   private var payeeVisibleSuggestions: [String] {
     guard showPayeeSuggestions, !draft.payee.isEmpty else { return [] }
-    return Array(
-      transactionStore.payeeSuggestionSource.suggestions
-        .filter { $0.localizedCaseInsensitiveCompare(draft.payee) != .orderedSame }
-        .prefix(8))
+    // Exact matches are retained — see `PayeeSuggestionDropdown.visibleSuggestions`.
+    // Both layers filter the same source; keeping the logic aligned means
+    // arrow-Enter selection picks whatever the dropdown visibly highlights.
+    return Array(transactionStore.payeeSuggestionSource.suggestions.prefix(8))
   }
 
   private var payeeVisibleSuggestionCount: Int {
@@ -926,7 +937,9 @@ struct TransactionDetailView: View {
             draft.categoryText = selected.path
             showCategorySuggestions = false
             categoryHighlightedIndex = nil
-          }
+          },
+          identifier: UITestIdentifiers.Autocomplete.category,
+          rowIdentifier: UITestIdentifiers.Autocomplete.categorySuggestion(_:)
         )
         .frame(width: rect.width)
         .offset(x: rect.minX, y: rect.maxY + 4)

--- a/MoolahTests/Shared/TransactionDraftCategoryTests.swift
+++ b/MoolahTests/Shared/TransactionDraftCategoryTests.swift
@@ -1,0 +1,53 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("TransactionDraft.normaliseCategoryText")
+struct TransactionDraftCategoryTests {
+  private let support = TransactionDraftTestSupport()
+
+  // swiftlint:disable:next attributes
+  @Test func validCategoryIdRewritesTextToCanonicalPath() {
+    let catId = UUID()
+    let categories = Categories(from: [Category(id: catId, name: "Groceries")])
+
+    var draft = support.makeExpenseDraft()
+    draft.categoryId = catId
+    draft.categoryText = "groc"
+
+    draft.normaliseCategoryText(using: categories)
+
+    #expect(draft.categoryId == catId)
+    #expect(draft.categoryText == "Groceries")
+  }
+
+  // swiftlint:disable:next attributes
+  @Test func unknownCategoryIdClearsBothFields() {
+    let missingId = UUID()
+    let categories = Categories(from: [])
+
+    var draft = support.makeExpenseDraft()
+    draft.categoryId = missingId
+    draft.categoryText = "Something"
+
+    draft.normaliseCategoryText(using: categories)
+
+    #expect(draft.categoryId == nil)
+    #expect(draft.categoryText.isEmpty)
+  }
+
+  // swiftlint:disable:next attributes
+  @Test func nilCategoryIdClearsText() {
+    let categories = Categories(from: [Category(id: UUID(), name: "Groceries")])
+
+    var draft = support.makeExpenseDraft()
+    draft.categoryId = nil
+    draft.categoryText = "partial input"
+
+    draft.normaliseCategoryText(using: categories)
+
+    #expect(draft.categoryId == nil)
+    #expect(draft.categoryText.isEmpty)
+  }
+}

--- a/MoolahUITests_macOS/Helpers/Screens/TransactionDetailScreen.swift
+++ b/MoolahUITests_macOS/Helpers/Screens/TransactionDetailScreen.swift
@@ -18,6 +18,18 @@ struct TransactionDetailScreen {
     )
   }
 
+  /// Driver for the simple-mode category field — a text field with
+  /// autocomplete dropdown. Only exposes the single-leg section; multi-leg
+  /// (custom) transactions use `leg(_:).category` instead.
+  var category: AutocompleteFieldDriver {
+    AutocompleteFieldDriver(
+      app: app,
+      fieldIdentifier: UITestIdentifiers.Detail.category,
+      dropdownIdentifier: UITestIdentifiers.Autocomplete.category,
+      suggestionIdentifier: UITestIdentifiers.Autocomplete.categorySuggestion(_:)
+    )
+  }
+
   /// Driver for a single sub-transaction (leg) section in a multi-leg
   /// (`isCustom`) transaction. Legs are ordered by `sortOrder`; index 0
   /// is the first leg the user sees.

--- a/MoolahUITests_macOS/Tests/TransactionDetail/TransactionDetailAutofillTests.swift
+++ b/MoolahUITests_macOS/Tests/TransactionDetail/TransactionDetailAutofillTests.swift
@@ -1,0 +1,44 @@
+import XCTest
+
+/// Behaviour tests for the payee-driven autofill on `TransactionDetailView`.
+///
+/// When the user selects a payee from the autocomplete dropdown on a *new*
+/// transaction, the view looks up the most recent transaction for that
+/// payee and copies its amount, type, and category into the draft. The
+/// category field gets populated silently — the user never asked to
+/// browse categories, so the category autocomplete dropdown must stay
+/// closed. The previous bug let the background text-binding update fire
+/// `onTextChange`, which opened the dropdown on top of whatever the user
+/// was about to type next.
+///
+/// The `.tradeBaseline` seed attaches `groceriesCategoryId` to the most
+/// recent "Woolworths" entry so autofill has a category to copy.
+@MainActor
+final class TransactionDetailAutofillTests: MoolahUITestCase {
+  func testSelectingPayeeAutofillsCategoryWithoutOpeningPicker() {
+    let app = launch(seed: .tradeBaseline)
+
+    app.sidebar.switchToAccount(.checking)
+    app.transactionList.createTransaction()
+    app.transactionDetail.payee.tap()
+    app.transactionDetail.payee.type("Wool")
+    app.transactionDetail.payee.expectSuggestionsVisible(count: 2)
+
+    // Arrow-down highlights "Woolworths" (the more frequent, thus
+    // higher-ranked, suggestion), Return accepts it → autofill runs.
+    app.transactionDetail.payee.pressArrowDown()
+    app.transactionDetail.payee.expectHighlightedSuggestion(at: 0)
+    app.transactionDetail.payee.pressEnter()
+    app.transactionDetail.payee.expectValue("Woolworths")
+
+    // Post-autofill: category text must reflect the prior "Woolworths"
+    // transaction's category. Waiting on the value gates the assertion
+    // until autofill completes — it's the only observable signal that
+    // the async fetch-and-apply has flowed through the view tree.
+    app.transactionDetail.category.expectValue("Groceries")
+
+    // The bug under test: the category dropdown must not have opened as
+    // a side-effect of autofill writing to the category text binding.
+    app.transactionDetail.category.expectSuggestionsHidden()
+  }
+}

--- a/MoolahUITests_macOS/Tests/TransactionDetail/TransactionDetailPayeeAutocompleteTests.swift
+++ b/MoolahUITests_macOS/Tests/TransactionDetail/TransactionDetailPayeeAutocompleteTests.swift
@@ -68,4 +68,24 @@ final class TransactionDetailPayeeAutocompleteTests: MoolahUITestCase {
     app.transactionDetail.payee.expectValue("")
     app.transactionDetail.payee.expectSuggestionsHidden()
   }
+
+  /// Typing the exact text of a historical payee must still show that
+  /// payee in the dropdown. The seed contains two "Woolworths" expenses
+  /// plus one "Woolworths Metro", so after typing "Woolworths" the user
+  /// should see two suggestions — "Woolworths" (dedup-merged across the
+  /// two historical entries) and "Woolworths Metro". The previous bug
+  /// silently filtered the exact match out, surfacing only one option
+  /// and giving the impression the app had forgotten the payee the user
+  /// had just typed.
+  func testTypingExactPayeeIncludesItInSuggestions() {
+    let app = launch(seed: .tradeBaseline)
+
+    app.sidebar.switchToAccount(.checking)
+    app.transactionList.openTransaction(.bhpPurchase)
+    app.transactionDetail.payee.tap()
+    app.transactionDetail.payee.clear()
+    app.transactionDetail.payee.type("Woolworths")
+
+    app.transactionDetail.payee.expectSuggestionsVisible(count: 2)
+  }
 }

--- a/Shared/Models/TransactionDraft+SimpleMode.swift
+++ b/Shared/Models/TransactionDraft+SimpleMode.swift
@@ -68,6 +68,20 @@ extension TransactionDraft {
     set { legDrafts[0].earmarkId = newValue }
   }
 
+  /// Reconcile `categoryText` with `categoryId` against the current
+  /// `Categories` snapshot. If the id resolves, `categoryText` is reset to
+  /// its canonical path; otherwise both fields are cleared. Called from the
+  /// view on category-field blur so partially-typed text that never
+  /// committed to a real category doesn't linger in the draft.
+  mutating func normaliseCategoryText(using categories: Categories) {
+    if let id = categoryId, let category = categories.by(id: id) {
+      categoryText = categories.path(for: category)
+    } else {
+      categoryText = ""
+      categoryId = nil
+    }
+  }
+
   /// Whether the "other account" label should read "From Account" instead of "To Account".
   /// True when viewing from the counterpart's perspective (the relevant leg is not the primary leg).
   var showFromAccount: Bool {

--- a/UITestSupport/UITestIdentifiers.swift
+++ b/UITestSupport/UITestIdentifiers.swift
@@ -58,6 +58,10 @@ public enum UITestIdentifiers {
     /// "USD"). Rendered in the same row as `counterpartAmount`.
     public static let counterpartAmountInstrument = "detail.counterpartAmount.instrument"
 
+    /// Category text field in the simple-mode (single-leg) category section.
+    /// Only rendered when the transaction is in simple (`!isCustom`) mode.
+    public static let category = "detail.category"
+
     /// Category text field inside the given leg section. Only rendered when
     /// the transaction is in multi-leg (`isCustom`) mode.
     public static func legCategory(_ index: Int) -> String {
@@ -72,6 +76,15 @@ public enum UITestIdentifiers {
     /// Indexed payee suggestion row inside the dropdown.
     public static func payeeSuggestion(_ index: Int) -> String {
       "autocomplete.payee.suggestion.\(index)"
+    }
+
+    /// Container element of the simple-mode category autocomplete dropdown.
+    /// Only rendered when the transaction is in simple (`!isCustom`) mode.
+    public static let category = "autocomplete.category"
+
+    /// Indexed category suggestion row inside the simple-mode dropdown.
+    public static func categorySuggestion(_ index: Int) -> String {
+      "autocomplete.category.suggestion.\(index)"
     }
 
     /// Container element of the category autocomplete dropdown for the given

--- a/UITestSupport/UITestSeed.swift
+++ b/UITestSupport/UITestSeed.swift
@@ -23,15 +23,23 @@ public enum UITestSeed: String, CaseIterable, Sendable {
 }
 
 /// A past single-leg expense used to seed payee suggestions.
+///
+/// `categoryId`, when set, is stored on the leg so the autofill flow
+/// (`TransactionDetailView.autofillFromPayee(_:)`) can copy it into a new
+/// draft. Most entries leave it `nil`; one entry per scenario carries a
+/// category so the test asserts both that autofill fires *and* that it
+/// does not open the category picker as a side-effect.
 public struct UITestHistoricalExpense: Sendable {
   public let id: UUID
   public let payee: String
   public let date: Date
+  public let categoryId: UUID?
 
-  public init(id: UUID, payee: String, date: Date) {
+  public init(id: UUID, payee: String, date: Date, categoryId: UUID? = nil) {
     self.id = id
     self.payee = payee
     self.date = date
+    self.categoryId = categoryId
   }
 }
 
@@ -115,6 +123,11 @@ public enum UITestFixtures {
     /// date. Payee frequency is the only axis `fetchPayeeSuggestions` sorts
     /// on; "Woolworths" appears twice so it ranks strictly above
     /// "Woolworths Metro" for the prefix "Wool".
+    ///
+    /// The most recent "Woolworths" (2026-03-20) carries `groceriesCategoryId`
+    /// so the autofill flow has a category to copy when a user selects the
+    /// "Woolworths" suggestion. The earlier entries leave the category nil so
+    /// the seed still exercises the common "no prior category" path.
     public static let historicalPayees: [UITestHistoricalExpense] = [
       UITestHistoricalExpense(
         id: UUID(uuidString: "A1000000-0000-0000-0000-000000000030")!,
@@ -134,7 +147,8 @@ public enum UITestFixtures {
       UITestHistoricalExpense(
         id: UUID(uuidString: "A1000000-0000-0000-0000-000000000033")!,
         payee: "Woolworths",
-        date: Date(timeIntervalSince1970: 1_773_964_800)  // 2026-03-20 UTC
+        date: Date(timeIntervalSince1970: 1_773_964_800),  // 2026-03-20 UTC
+        categoryId: groceriesCategoryId
       ),
     ]
   }


### PR DESCRIPTION
## Summary

Two autocomplete bugs on `TransactionDetailView`:

- **Exact-match payee was silently filtered out.** Typing `Woolworths` in full dropped `Woolworths` from the dropdown (leaving only `Woolworths Metro`), making the app look like it had forgotten a payee the user had just named. Fixed by removing the `localizedCaseInsensitiveCompare(searchText) != .orderedSame` filter from both `PayeeSuggestionDropdown.visibleSuggestions` and the view-level `payeeVisibleSuggestions`.
- **Autofill opened the category picker as a side-effect.** Selecting a payee on a new transaction ran `applyAutofill`, which wrote `draft.categoryText`. `onChange(of: text)` can't distinguish programmatic writes from user typing, so `onTextChange` fired and opened the picker on top of whatever the user was about to do next. Fixed by guarding the simple-mode `onTextChange` body with `guard categoryFieldFocused else { return }` — only a focused field's text change counts as a user edit.

Multi-leg mode has the same latent pattern (`legCategoryField`'s `onTextChange`); left out of scope since the reported bug is simple-mode only.

Minor refactor: extracted `TransactionDraft.normaliseCategoryText(using:)` from the view's blur handler so the reconciliation rule ("text that doesn't resolve to a known category is cleared") is unit-testable without a view host.

## Test plan

TDD — both UI tests failed against `main` for the expected reasons and pass after the fix.

- [x] `TransactionDetailPayeeAutocompleteTests.testTypingExactPayeeIncludesItInSuggestions` — types `Woolworths`, expects 2 dropdown suggestions (`Woolworths` + `Woolworths Metro`).
- [x] `TransactionDetailAutofillTests.testSelectingPayeeAutofillsCategoryWithoutOpeningPicker` — creates a new transaction, selects `Woolworths` from the dropdown, asserts the category field auto-populates with `Groceries` **and** the category dropdown stays hidden.
- [x] `TransactionDraftCategoryTests` — 3 unit tests for the new `normaliseCategoryText(using:)` extension (valid id rewrites text, unknown id clears both, nil id clears text).
- [x] Full `just test-mac` passes (1500 / 1500).
- [x] Full `TransactionDetail*` UI test suite passes (9 / 9 — picking up the four pre-existing tests plus the new one).
- [x] `just format-check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)