### PR TITLE
feat(categories): show full category path outside the category-management screens

### DIFF
--- a/Domain/Models/BudgetLineItem.swift
+++ b/Domain/Models/BudgetLineItem.swift
@@ -2,7 +2,7 @@ import Foundation
 
 struct BudgetLineItem: Identifiable, Sendable {
   let id: UUID
-  let categoryName: String
+  let categoryPath: String
   let actual: InstrumentAmount
   let budgeted: InstrumentAmount
 
@@ -27,13 +27,13 @@ struct BudgetLineItem: Identifiable, Sendable {
     // Add all budgeted categories
     for item in budgetItems {
       seen.insert(item.categoryId)
-      let name = categories.by(id: item.categoryId)?.name ?? "Unknown"
+      let path = categories.by(id: item.categoryId).map { categories.path(for: $0) } ?? "Unknown"
       let budgeted = item.inInstrument(earmarkInstrument).amount
       let actual = categoryBalances[item.categoryId] ?? zero
       result.append(
         BudgetLineItem(
           id: item.categoryId,
-          categoryName: name,
+          categoryPath: path,
           actual: actual,
           budgeted: budgeted
         ))
@@ -41,17 +41,17 @@ struct BudgetLineItem: Identifiable, Sendable {
 
     // Add categories with spending but no budget
     for (categoryId, actual) in categoryBalances where !seen.contains(categoryId) {
-      let name = categories.by(id: categoryId)?.name ?? "Unknown"
+      let path = categories.by(id: categoryId).map { categories.path(for: $0) } ?? "Unknown"
       result.append(
         BudgetLineItem(
           id: categoryId,
-          categoryName: name,
+          categoryPath: path,
           actual: actual,
           budgeted: zero
         ))
     }
 
-    return result.sorted { $0.categoryName < $1.categoryName }
+    return result.sorted { $0.categoryPath < $1.categoryPath }
   }
 
   /// Calculates the unallocated portion of a savings goal.

--- a/Features/Analysis/Views/CategoriesOverTimeCard.swift
+++ b/Features/Analysis/Views/CategoriesOverTimeCard.swift
@@ -53,7 +53,7 @@ struct CategoriesOverTimeCard: View {
   private var chart: some View {
     Chart {
       ForEach(entries) { entry in
-        let name = categoryName(for: entry.categoryId)
+        let name = categoryLabel(for: entry.categoryId)
         ForEach(entry.points) { point in
           AreaMark(
             x: .value("Month", point.monthDate),
@@ -74,7 +74,7 @@ struct CategoriesOverTimeCard: View {
       }
     }
     .chartForegroundStyleScale(
-      domain: entries.map { categoryName(for: $0.categoryId) },
+      domain: entries.map { categoryLabel(for: $0.categoryId) },
       range: entries.map { categoryColor(for: $0.categoryId) }
     )
     .chartXAxis {
@@ -116,7 +116,7 @@ struct CategoriesOverTimeCard: View {
           Circle()
             .fill(categoryColor(for: entry.categoryId))
             .frame(width: 10, height: 10)
-          Text(categoryName(for: entry.categoryId))
+          Text(categoryLabel(for: entry.categoryId))
             .font(.caption)
             .lineLimit(1)
           Spacer()
@@ -127,15 +127,15 @@ struct CategoriesOverTimeCard: View {
         }
         .accessibilityElement(children: .combine)
         .accessibilityLabel(
-          "\(categoryName(for: entry.categoryId)): \(InstrumentAmount(quantity: entry.totalAmount, instrument: instrument).formatted)"
+          "\(categoryLabel(for: entry.categoryId)): \(InstrumentAmount(quantity: entry.totalAmount, instrument: instrument).formatted)"
         )
       }
     }
   }
 
-  private func categoryName(for id: UUID?) -> String {
-    guard let id else { return "Uncategorized" }
-    return categories.by(id: id)?.name ?? "Unknown"
+  private func categoryLabel(for id: UUID?) -> String {
+    guard let id, let category = categories.by(id: id) else { return "Uncategorized" }
+    return categories.path(for: category)
   }
 
   private static let chartPalette: [Color] = [

--- a/Features/Analysis/Views/ExpenseBreakdownCard.swift
+++ b/Features/Analysis/Views/ExpenseBreakdownCard.swift
@@ -42,7 +42,7 @@ struct ExpenseBreakdownCard: View {
         innerRadius: .ratio(0.5),
         angularInset: 1.5
       )
-      .foregroundStyle(by: .value("Category", categoryName(for: item.categoryId)))
+      .foregroundStyle(by: .value("Category", categoryLabel(for: item.categoryId)))
       .annotation(position: .overlay) {
         if item.percentage > 5 {  // Only show label if >5%
           Text("\(Int(item.percentage))%")
@@ -67,7 +67,7 @@ struct ExpenseBreakdownCard: View {
             Circle()
               .fill(categoryColor(for: item.categoryId))
               .frame(width: 12, height: 12)
-            Text(categoryName(for: item.categoryId))
+            Text(categoryLabel(for: item.categoryId))
               .font(.caption)
               .foregroundStyle(.primary)
             Spacer()
@@ -79,7 +79,7 @@ struct ExpenseBreakdownCard: View {
         }
         .buttonStyle(.plain)
         .accessibilityLabel(
-          "\(categoryName(for: item.categoryId)): \(item.totalExpenses.formatted)"
+          "\(categoryLabel(for: item.categoryId)): \(item.totalExpenses.formatted)"
         )
         .accessibilityHint(hasChildren(item.categoryId) ? "Double tap to drill down" : "")
       }
@@ -105,9 +105,9 @@ struct ExpenseBreakdownCard: View {
       from: breakdown, categories: categories, selectedCategoryId: selectedCategoryId)
   }
 
-  private func categoryName(for id: UUID?) -> String {
-    guard let id = id else { return "Uncategorized" }
-    return categories.by(id: id)?.name ?? "Unknown"
+  private func categoryLabel(for id: UUID?) -> String {
+    guard let id = id, let category = categories.by(id: id) else { return "Uncategorized" }
+    return categories.path(for: category)
   }
 
   /// Fixed palette of system-compatible colors for chart segments.

--- a/Features/Earmarks/Views/EarmarkBudgetSectionView.swift
+++ b/Features/Earmarks/Views/EarmarkBudgetSectionView.swift
@@ -72,7 +72,7 @@ struct EarmarkBudgetSectionView: View {
         }
       }
     } message: { item in
-      Text("Remove \(item.categoryName) from the budget?")
+      Text("Remove \(item.categoryPath) from the budget?")
     }
     .refreshable {
       await loadData()
@@ -158,7 +158,7 @@ struct EarmarkBudgetSectionView: View {
 
   private func budgetRow(_ lineItem: BudgetLineItem) -> some View {
     HStack(spacing: 0) {
-      Text(lineItem.categoryName)
+      Text(lineItem.categoryPath)
         .frame(maxWidth: .infinity, alignment: .leading)
         .font(.body)
 
@@ -174,7 +174,7 @@ struct EarmarkBudgetSectionView: View {
           .frame(minWidth: columnMinWidth, idealWidth: columnIdealWidth, alignment: .trailing)
       }
       .buttonStyle(.plain)
-      .accessibilityLabel("Edit budget for \(lineItem.categoryName)")
+      .accessibilityLabel("Edit budget for \(lineItem.categoryPath)")
 
       InstrumentAmountView(amount: lineItem.remaining)
         .font(.body)
@@ -182,7 +182,7 @@ struct EarmarkBudgetSectionView: View {
     }
     .accessibilityElement(children: .combine)
     .accessibilityLabel(
-      "\(lineItem.categoryName): spent \(lineItem.actual.formatted), budget \(lineItem.budgeted.formatted), remaining \(lineItem.remaining.formatted)"
+      "\(lineItem.categoryPath): spent \(lineItem.actual.formatted), budget \(lineItem.budgeted.formatted), remaining \(lineItem.remaining.formatted)"
     )
   }
 

--- a/Features/Earmarks/Views/EditBudgetAmountSheet.swift
+++ b/Features/Earmarks/Views/EditBudgetAmountSheet.swift
@@ -25,7 +25,7 @@ struct EditBudgetAmountSheet: View {
 
   private var form: some View {
     Form {
-      Section("Budget for \(lineItem.categoryName)") {
+      Section("Budget for \(lineItem.categoryPath)") {
         HStack {
           Text(lineItem.budgeted.instrument.currencySymbol ?? lineItem.budgeted.instrument.id)
             .foregroundStyle(.secondary)

--- a/Features/Import/Views/RuleEditorActionRow.swift
+++ b/Features/Import/Views/RuleEditorActionRow.swift
@@ -33,7 +33,7 @@ struct RuleEditorActionRow: View {
             set: { action = .setCategory($0) })
         ) {
           ForEach(flatCategories, id: \.id) { category in
-            Text(category.name).tag(category.id)
+            Text(categories.path(for: category)).tag(category.id)
           }
         }
         .labelsHidden()

--- a/Features/Reports/Views/CategoryBalanceTable.swift
+++ b/Features/Reports/Views/CategoryBalanceTable.swift
@@ -24,7 +24,7 @@ struct CategoryBalanceTable: View {
         roots[rootId]
         ?? CategoryGroup(
           categoryId: rootId,
-          name: categories.by(id: rootId)?.name ?? "Unknown",
+          name: categories.by(id: rootId).map { categories.path(for: $0) } ?? "Unknown",
           totalAmount: .zero(instrument: amount.instrument),
           children: []
         )
@@ -37,7 +37,7 @@ struct CategoryBalanceTable: View {
         group.children.append(
           CategoryChild(
             categoryId: categoryId,
-            name: categories.by(id: categoryId)?.name ?? "Unknown",
+            name: categories.by(id: categoryId).map { categories.path(for: $0) } ?? "Unknown",
             amount: amount
           ))
         group.totalAmount += amount

--- a/Features/Reports/Views/ReportsView.swift
+++ b/Features/Reports/Views/ReportsView.swift
@@ -101,7 +101,8 @@ struct ReportsView: View {
 
   @ViewBuilder
   private func drillDownDestination(_ drillDown: CategoryDrillDown) -> some View {
-    let categoryName = categories.by(id: drillDown.categoryId)?.name ?? "Category"
+    let categoryName =
+      categories.by(id: drillDown.categoryId).map { categories.path(for: $0) } ?? "Category"
     TransactionListView(
       title: categoryName,
       filter: TransactionFilter(

--- a/Features/Transactions/Views/TransactionFilterView.swift
+++ b/Features/Transactions/Views/TransactionFilterView.swift
@@ -155,7 +155,7 @@ struct TransactionFilterView: View {
       } else {
         ForEach(allCategories) { category in
           Toggle(
-            category.name,
+            categories.path(for: category),
             isOn: Binding(
               get: { selectedCategoryIds.contains(category.id) },
               set: { isOn in

--- a/Features/Transactions/Views/TransactionRowView.swift
+++ b/Features/Transactions/Views/TransactionRowView.swift
@@ -128,7 +128,7 @@ struct TransactionRowView: View {
         transaction.legs.filter { $0.accountId == id }
       } ?? transaction.legs
     let uniqueIds = applicable.compactMap(\.categoryId).uniqued()
-    return uniqueIds.compactMap { categories.by(id: $0)?.name }
+    return uniqueIds.compactMap { id in categories.by(id: id).map { categories.path(for: $0) } }
   }
 
   private var earmarkNames: [String] {

--- a/Features/Transactions/Views/UpcomingTransactionRow.swift
+++ b/Features/Transactions/Views/UpcomingTransactionRow.swift
@@ -61,7 +61,7 @@ struct UpcomingTransactionRow: View {
       ForEach(transaction.legs.compactMap(\.categoryId).uniqued(), id: \.self) { catId in
         if let category = categories.by(id: catId) {
           metaSeparator
-          Text(category.name).font(.caption).foregroundStyle(.secondary)
+          Text(categories.path(for: category)).font(.caption).foregroundStyle(.secondary)
         }
       }
 
@@ -116,7 +116,7 @@ struct UpcomingTransactionRow: View {
       parts.append("repeats \(recurrence)")
     }
     let categoryNames = transaction.legs.compactMap(\.categoryId).uniqued()
-      .compactMap { categories.by(id: $0)?.name }
+      .compactMap { id in categories.by(id: id).map { categories.path(for: $0) } }
     parts.append(contentsOf: categoryNames)
     let earmarkNames = transaction.legs.compactMap(\.earmarkId).uniqued()
       .compactMap { earmarks.by(id: $0)?.name }

--- a/MoolahTests/Features/BudgetLineItemMergeTests.swift
+++ b/MoolahTests/Features/BudgetLineItemMergeTests.swift
@@ -30,7 +30,7 @@ struct BudgetLineItemMergeTests {
     )
 
     #expect(result.count == 1)
-    #expect(result.first?.categoryName == "Flights")
+    #expect(result.first?.categoryPath == "Flights")
     #expect(result.first?.actual.quantity == Decimal(-50000) / 100)
     #expect(result.first?.budgeted.quantity == Decimal(80000) / 100)
     #expect(result.first?.remaining.quantity == Decimal(30000) / 100)
@@ -110,7 +110,7 @@ struct BudgetLineItemMergeTests {
   }
 
   @Test
-  func testMergeSortsByCategoryName() {
+  func testMergeSortsByCategoryPath() {
     let cat1 = Category(id: UUID(), name: "Zebra")
     let cat2 = Category(id: UUID(), name: "Alpha")
     let cat3 = Category(id: UUID(), name: "Middle")
@@ -137,7 +137,7 @@ struct BudgetLineItemMergeTests {
       earmarkInstrument: .defaultTestInstrument
     )
 
-    #expect(result.map(\.categoryName) == ["Alpha", "Middle", "Zebra"])
+    #expect(result.map(\.categoryPath) == ["Alpha", "Middle", "Zebra"])
   }
 
   @Test
@@ -209,7 +209,32 @@ struct BudgetLineItemMergeTests {
       earmarkInstrument: .defaultTestInstrument
     )
 
-    #expect(result.first?.categoryName == "Unknown")
+    #expect(result.first?.categoryPath == "Unknown")
+  }
+
+  @Test
+  func testLineItemUsesFullCategoryPath() {
+    let parentId = UUID()
+    let childId = UUID()
+    let categories = Categories(from: [
+      Category(id: parentId, name: "Income"),
+      Category(id: childId, name: "Salary", parentId: parentId),
+    ])
+    let budgetItems = [
+      EarmarkBudgetItem(
+        categoryId: childId,
+        amount: InstrumentAmount(
+          quantity: Decimal(10000) / 100, instrument: Instrument.defaultTestInstrument))
+    ]
+
+    let result = BudgetLineItem.buildLineItems(
+      budgetItems: budgetItems,
+      categoryBalances: [:],
+      categories: categories,
+      earmarkInstrument: .defaultTestInstrument
+    )
+
+    #expect(result.first?.categoryPath == "Income:Salary")
   }
 
   // MARK: - Budget item instrument parity

--- a/plans/2026-04-24-category-full-path-design.md
+++ b/plans/2026-04-24-category-full-path-design.md
@@ -1,0 +1,60 @@
+# Category full-path display — design
+
+## Goal
+
+Every category label rendered outside the category-management screens displays the full colon-separated path from `Categories.path(for:)` (e.g. `Income:Salary:Adrian`) instead of only the leaf `category.name` (e.g. `Adrian`). A leaf name in isolation is ambiguous — the same leaf (`Adrian`) can appear under several parents — so transaction rows, reports, filters, and pickers need the full path for users to identify categories at a glance.
+
+## Non-goals
+
+- **No data-model change.** `Category.name` keeps its current semantics (leaf only). `Categories.path(for:)` already exists and is the single source of truth for the displayed path.
+- **No change to search or match semantics.** `matchesCategorySearch(_:query:)` already matches against full paths.
+- **No change inside the category-management surfaces.** `CategoriesView`, `CategoryTreeView`, and the "Parent" field in `CategoryDetailView` continue to show leaf names because those screens convey hierarchy structurally (indentation, grouping) and a repeated full path would add noise.
+
+## Separator convention
+
+Colon (`:`) — already used by `Categories.path(for:)` and by existing test fixtures (`Income:Salary:Janet`, `Groceries:Food`). No alternative separators appear in the codebase.
+
+## Change list
+
+### Already correct — no change
+
+- `TransactionDetailView` (draft uses `categories.path(for:)`, search matches full path).
+- `CategoryAutocompleteField` (suggestion row renders `suggestion.path`).
+- `AddBudgetLineItemSheet` (picker text uses `categories.path(for:)`).
+
+### View-only swap: `category.name` → `categories.path(for: category)`
+
+- `Features/Transactions/TransactionRowView.swift` — metadata row.
+- `Features/Transactions/UpcomingTransactionRow.swift` — scheduled transaction row (two sites).
+- `Features/Reports/ReportsView.swift` — drill-down title.
+- `Features/Reports/CategoryBalanceTable.swift` — report table rows.
+- `Features/ImportRules/RuleEditorActionRow.swift` — category picker.
+- `Features/Transactions/TransactionFilterView.swift` — filter toggle labels.
+
+### Chart helper rename
+
+`CategoriesOverTimeCard.categoryName(for:)` and `ExpenseBreakdownCard.categoryName(for:)` currently do a `.name` lookup. Replace with `categories.path(for:)` and rename the helpers to `categoryLabel(for:)` so the changed meaning is visible at call sites. These remain view-local one-liners — they are lookup helpers, not business logic, so extraction isn't warranted.
+
+### Structural change: `BudgetLineItem.categoryName` → `categoryPath`
+
+`BudgetLineItem` currently stores the leaf `categoryName: String`, populated at build time. Four consumers read it (`EarmarkBudgetSectionView` in four places, `EditBudgetAmountSheet:28`). The field is written once and read from multiple views, so computing the path once at build time is cheaper than on every row render.
+
+- Rename the field to `categoryPath` across `BudgetLineItem.swift` and its consumers.
+- Populate it with `categories.path(for:)` in both construction sites inside `BudgetLineItem.swift`.
+
+## Testing
+
+- **Unit test** — `BudgetLineItemTests` (new or extended): assert that for a nested category `Income/Salary/Adrian`, the generated line item has `categoryPath == "Income:Salary:Adrian"`, and for a root category the path equals the leaf name. This is the only piece of new logic outside view code.
+- **Compile check + manual spot-check** — every other change is a one-line substitution inside a thin view. `just build-mac` catches typos; manual verification of transaction list, reports drill-down, transaction filter, and the import-rule picker confirms the change is visible.
+- **Existing test impact** — `CategoryMatchingTests` already uses full-path strings; UI tests that assert on leaf-only labels (if any) will be updated only if they break.
+
+## Risks and edge cases
+
+- **Root category**: `Categories.path(for:)` returns the leaf name when there's no parent. Behaviour unchanged for flat categories.
+- **Orphaned `categoryId`** (category deleted but still referenced): `categories.by(id:)` returns nil. Existing optional-chaining at all call sites handles this — unchanged.
+- **Narrow columns / chart legends**: long paths may truncate via existing `.lineLimit` modifiers. Acceptable — partial truncation still conveys more context than the leaf alone.
+- **Performance**: `categories.path(for:)` walks the parent chain per call. Category depth is small in practice; no memoisation needed. For `BudgetLineItem` (built once, read many times) the path is computed at build time, not per row.
+
+## Rollout
+
+Single PR. No migration, no feature flag — this is a display-layer change with no persisted state.

--- a/plans/2026-04-24-category-full-path-implementation.md
+++ b/plans/2026-04-24-category-full-path-implementation.md
@@ -1,0 +1,339 @@
+# Category full-path display — implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show `Categories.path(for:)` (e.g. `Income:Salary:Adrian`) instead of leaf `category.name` everywhere outside the category-management screens.
+
+**Architecture:** `Categories.path(for:)` already exists in `Domain/Models/Category.swift`. The work is (a) one structural rename — `BudgetLineItem.categoryName: String` → `categoryPath: String` — plus its four consumers, and (b) mechanical call-site swaps in ~8 view files. `CategoriesView`, `CategoryTreeView`, and `CategoryDetailView` are out of scope; they display hierarchy structurally and keep leaf names.
+
+**Tech Stack:** Swift 6, SwiftUI, Swift Testing (`#expect`). Build via `just build-mac`, test via `just test-mac` (macOS-only suite is sufficient for this UI + domain change; full `just test` runs at the end).
+
+**Spec:** `plans/2026-04-24-category-full-path-design.md`.
+
+---
+
+## Task 1: Rename `BudgetLineItem.categoryName` → `categoryPath`, populate via full path (TDD)
+
+**Files:**
+- Modify: `Domain/Models/BudgetLineItem.swift` (field rename + populate with `categories.path(for:)`)
+- Modify: `MoolahTests/Features/BudgetLineItemMergeTests.swift` (rename field reads; add nested-path test)
+- Modify: `Features/Earmarks/Views/EarmarkBudgetSectionView.swift:75, 161, 177, 185` (consumer reads)
+- Modify: `Features/Earmarks/Views/EditBudgetAmountSheet.swift:28` (consumer read)
+
+- [ ] **Step 1: Add failing test for nested-path population**
+
+Append to `MoolahTests/Features/BudgetLineItemMergeTests.swift`, inside the `@Suite("BudgetLineItem Merge") struct BudgetLineItemMergeTests`:
+
+```swift
+@Test
+func testLineItemUsesFullCategoryPath() {
+  let parentId = UUID()
+  let childId = UUID()
+  let categories = Categories(from: [
+    Category(id: parentId, name: "Income"),
+    Category(id: childId, name: "Salary", parentId: parentId),
+  ])
+  let budgetItems = [
+    EarmarkBudgetItem(
+      categoryId: childId,
+      amount: InstrumentAmount(
+        quantity: Decimal(10000) / 100, instrument: Instrument.defaultTestInstrument))
+  ]
+
+  let result = BudgetLineItem.buildLineItems(
+    budgetItems: budgetItems,
+    categoryBalances: [:],
+    categories: categories,
+    earmarkInstrument: .defaultTestInstrument
+  )
+
+  #expect(result.first?.categoryPath == "Income:Salary")
+}
+```
+
+- [ ] **Step 2: Rename existing test assertions from `categoryName` → `categoryPath`**
+
+In `MoolahTests/Features/BudgetLineItemMergeTests.swift`, replace every read of `.categoryName` on a `BudgetLineItem` with `.categoryPath`. These are on the following test methods:
+
+- `testMergeCombinesBudgetAndActuals` — `result.first?.categoryName == "Flights"` → `result.first?.categoryPath == "Flights"` (single root category; path equals leaf).
+- `testMergeSortsByCategoryName` — `result.map(\.categoryName) == ["Alpha", "Middle", "Zebra"]` → `result.map(\.categoryPath) == ["Alpha", "Middle", "Zebra"]`. Also rename the method to `testMergeSortsByCategoryPath` for accuracy.
+- `testUnknownCategoryNameForDeletedCategory` — `result.first?.categoryName == "Unknown"` → `result.first?.categoryPath == "Unknown"`.
+
+- [ ] **Step 3: Run tests to confirm they fail**
+
+Run: `just test-mac BudgetLineItemMergeTests 2>&1 | tee .agent-tmp/test-bli.txt`
+
+Expected: compile error — `BudgetLineItem` has no member `categoryPath`.
+
+- [ ] **Step 4: Rename field and use `categories.path(for:)` in builder**
+
+Edit `Domain/Models/BudgetLineItem.swift`:
+
+1. Line 5: rename `let categoryName: String` → `let categoryPath: String`.
+2. Lines 30 and 44: the current lookup is
+   ```swift
+   let name = categories.by(id: item.categoryId)?.name ?? "Unknown"
+   ```
+   (line 44 uses `categoryId` instead of `item.categoryId`). Replace both with the path equivalent:
+   ```swift
+   let path = categories.by(id: item.categoryId).map { categories.path(for: $0) } ?? "Unknown"
+   ```
+   and for the second site:
+   ```swift
+   let path = categories.by(id: categoryId).map { categories.path(for: $0) } ?? "Unknown"
+   ```
+3. Lines 36 and 48: change init arg label from `categoryName: name` to `categoryPath: path`.
+4. Line 54: change the sort key from `$0.categoryName < $1.categoryName` to `$0.categoryPath < $1.categoryPath`.
+
+- [ ] **Step 5: Update consumers**
+
+Edit `Features/Earmarks/Views/EarmarkBudgetSectionView.swift`:
+- Line 75: `Text("Remove \(item.categoryName) from the budget?")` → `Text("Remove \(item.categoryPath) from the budget?")`
+- Line 161: `Text(lineItem.categoryName)` → `Text(lineItem.categoryPath)`
+- Line 177: `.accessibilityLabel("Edit budget for \(lineItem.categoryName)")` → `.accessibilityLabel("Edit budget for \(lineItem.categoryPath)")`
+- Line 185: `"\(lineItem.categoryName): spent ..."` → `"\(lineItem.categoryPath): spent ..."`
+
+Edit `Features/Earmarks/Views/EditBudgetAmountSheet.swift`:
+- Line 28: `Section("Budget for \(lineItem.categoryName)")` → `Section("Budget for \(lineItem.categoryPath)")`
+
+- [ ] **Step 6: Run tests and build to confirm green**
+
+Run:
+```bash
+just test-mac BudgetLineItemMergeTests 2>&1 | tee .agent-tmp/test-bli.txt
+just build-mac 2>&1 | tee .agent-tmp/build-mac.txt
+```
+
+Expected: all `BudgetLineItemMergeTests` pass; `just build-mac` succeeds with no warnings.
+
+- [ ] **Step 7: Clean up temp files**
+
+```bash
+rm -f .agent-tmp/test-bli.txt .agent-tmp/build-mac.txt
+```
+
+---
+
+## Task 2: View-only path swaps in transaction + reports + filter + import views
+
+**Files:**
+- Modify: `Features/Transactions/Views/TransactionRowView.swift:131`
+- Modify: `Features/Transactions/Views/UpcomingTransactionRow.swift:64, 119`
+- Modify: `Features/Transactions/Views/TransactionFilterView.swift:158`
+- Modify: `Features/Reports/Views/ReportsView.swift:104`
+- Modify: `Features/Reports/Views/CategoryBalanceTable.swift:40`
+- Modify: `Features/Import/Views/RuleEditorActionRow.swift:36`
+
+Each change is a single-line substitution. No new logic.
+
+- [ ] **Step 1: `TransactionRowView.swift:131`**
+
+Current:
+```swift
+return uniqueIds.compactMap { categories.by(id: $0)?.name }
+```
+Replace with:
+```swift
+return uniqueIds.compactMap { id in categories.by(id: id).map { categories.path(for: $0) } }
+```
+
+- [ ] **Step 2: `UpcomingTransactionRow.swift:64`**
+
+Current:
+```swift
+Text(category.name).font(.caption).foregroundStyle(.secondary)
+```
+Replace with:
+```swift
+Text(categories.path(for: category)).font(.caption).foregroundStyle(.secondary)
+```
+
+- [ ] **Step 3: `UpcomingTransactionRow.swift:119`**
+
+Current (inside the accessibility `categoryNames` computed property):
+```swift
+.compactMap { categories.by(id: $0)?.name }
+```
+Replace with:
+```swift
+.compactMap { id in categories.by(id: id).map { categories.path(for: $0) } }
+```
+
+- [ ] **Step 4: `TransactionFilterView.swift:158`**
+
+The view has `let categories: Categories` (line 8) and iterates `allCategories: [Category]` — the `Categories` lookup is in scope as `categories`. Replace the label on line 158:
+- From `category.name,`
+- To `categories.path(for: category),`
+
+- [ ] **Step 5: `ReportsView.swift:104`**
+
+Current:
+```swift
+let categoryName = categories.by(id: drillDown.categoryId)?.name ?? "Category"
+```
+Replace with:
+```swift
+let categoryName = categories.by(id: drillDown.categoryId).map { categories.path(for: $0) } ?? "Category"
+```
+
+The local identifier `categoryName` stays as-is to minimise the diff; it now holds a path.
+
+- [ ] **Step 6: `CategoryBalanceTable.swift:40`**
+
+Current:
+```swift
+name: categories.by(id: categoryId)?.name ?? "Unknown",
+```
+Replace with:
+```swift
+name: categories.by(id: categoryId).map { categories.path(for: $0) } ?? "Unknown",
+```
+
+- [ ] **Step 7: `RuleEditorActionRow.swift:36`**
+
+The view has `let categories: Categories` (line 10) and iterates `flatCategories: [Category]` derived from it. Replace line 36:
+- From `Text(category.name).tag(category.id)`
+- To `Text(categories.path(for: category)).tag(category.id)`
+
+- [ ] **Step 8: Build**
+
+Run: `just build-mac 2>&1 | tee .agent-tmp/build-mac.txt`
+
+Expected: success, no warnings. Any "ambiguous reference" or "value of type `Category` has no member `path`" is a typo — the code should always be `categories.path(for: category)`, never `category.path(...)`.
+
+- [ ] **Step 9: Clean up**
+
+```bash
+rm -f .agent-tmp/build-mac.txt
+```
+
+---
+
+## Task 3: Rename chart helpers `categoryName(for:)` → `categoryLabel(for:)` and use paths
+
+**Files:**
+- Modify: `Features/Analysis/Views/CategoriesOverTimeCard.swift:56, 77, 119, 130, 136` (helper definition + 4 call sites)
+- Modify: `Features/Analysis/Views/ExpenseBreakdownCard.swift:45, 70, 82, 108` (helper definition + 3 call sites)
+
+- [ ] **Step 1: `CategoriesOverTimeCard.swift` helper definition (line 136)**
+
+The current helper (near line 136) looks like:
+```swift
+private func categoryName(for id: UUID?) -> String {
+  guard let id, let category = categories.by(id: id) else { return "Uncategorized" }
+  return category.name
+}
+```
+
+Replace with (renaming, and using the path):
+```swift
+private func categoryLabel(for id: UUID?) -> String {
+  guard let id, let category = categories.by(id: id) else { return "Uncategorized" }
+  return categories.path(for: category)
+}
+```
+
+Preserve the existing fallback string verbatim — whether it's `"Uncategorized"`, `"Unknown"`, or something else, copy it. Read the two lines around line 136 before editing.
+
+- [ ] **Step 2: Update all four `categoryName(for:)` call sites in `CategoriesOverTimeCard.swift`**
+
+Lines 56, 77, 119, 130 — replace `categoryName(for:` with `categoryLabel(for:`. (A file-wide find/replace on this file is safe because no other symbol named `categoryName` exists in it.)
+
+- [ ] **Step 3: `ExpenseBreakdownCard.swift` helper definition (line 108)**
+
+Same treatment as Step 1: rename `categoryName(for:)` → `categoryLabel(for:)` and change the final `return category.name` to `return categories.path(for: category)`. Preserve the existing fallback string.
+
+- [ ] **Step 4: Update all three `categoryName(for:)` call sites in `ExpenseBreakdownCard.swift`**
+
+Lines 45, 70, 82 — replace `categoryName(for:` with `categoryLabel(for:`.
+
+- [ ] **Step 5: Build**
+
+Run: `just build-mac 2>&1 | tee .agent-tmp/build-mac.txt`
+
+Expected: success, no warnings. A "`categoryName` is not defined" error means one of the call-site replacements was missed — grep the two files for `categoryName(for:` and update any remaining hit.
+
+- [ ] **Step 6: Clean up**
+
+```bash
+rm -f .agent-tmp/build-mac.txt
+```
+
+---
+
+## Task 4: Format, full test, commit, push, open PR, add to merge queue
+
+- [ ] **Step 1: Format**
+
+Run: `just format`
+
+No assertion beyond "exits 0". If `just format-check` afterwards still fails, investigate the specific violation — do NOT edit `.swiftlint-baseline.yml`.
+
+- [ ] **Step 2: Full test suite**
+
+Run: `just test 2>&1 | tee .agent-tmp/test-full.txt`
+
+Expected: all suites green on both iOS simulator and macOS. Scan with `grep -iE 'failed|error:' .agent-tmp/test-full.txt` — any hit must be investigated, not ignored. Do NOT proceed to commit until the suite is green.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/category-full-path add -A
+git -C /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/category-full-path commit -m "$(cat <<'EOF'
+feat(categories): show full category path everywhere outside the category-management screens
+
+Leaf-only category labels (e.g. "Adrian") are ambiguous when the same leaf appears under multiple parents. Every display surface outside the category-management screens now uses `Categories.path(for:)` (e.g. "Income:Salary:Adrian").
+
+- Rename `BudgetLineItem.categoryName` → `categoryPath`; populate via `categories.path(for:)`.
+- Swap `category.name` for `categories.path(for:)` in TransactionRowView, UpcomingTransactionRow, TransactionFilterView, ReportsView, CategoryBalanceTable, RuleEditorActionRow.
+- Rename chart helpers `categoryName(for:)` → `categoryLabel(for:)` in CategoriesOverTimeCard and ExpenseBreakdownCard; they now return the path.
+- `CategoriesView`, `CategoryTreeView`, and the parent field in `CategoryDetailView` are unchanged — those screens already convey hierarchy structurally.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+- [ ] **Step 4: Push branch**
+
+```bash
+git -C /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/category-full-path push -u origin feat/category-full-path
+```
+
+- [ ] **Step 5: Open PR**
+
+```bash
+gh pr create --title "feat(categories): show full category path everywhere outside the category-management screens" --body "$(cat <<'EOF'
+## Summary
+- Leaf-only category labels like "Adrian" are ambiguous when the same leaf appears under multiple parents. Every display surface outside the category-management screens now shows the full colon-separated path (e.g. `Income:Salary:Adrian`) via the existing `Categories.path(for:)` helper.
+- Structural rename: `BudgetLineItem.categoryName` → `categoryPath`, populated at build time via `categories.path(for:)`. Four consumers updated.
+- Thin-view substitutions in `TransactionRowView`, `UpcomingTransactionRow`, `TransactionFilterView`, `ReportsView`, `CategoryBalanceTable`, `RuleEditorActionRow`.
+- Chart helpers renamed: `categoryName(for:)` → `categoryLabel(for:)` in `CategoriesOverTimeCard` and `ExpenseBreakdownCard` so the changed meaning is visible at call sites.
+- Out of scope: `CategoriesView`, `CategoryTreeView`, and the parent field in `CategoryDetailView` keep leaf names — those screens convey hierarchy structurally.
+
+## Test plan
+- [x] New unit test: `BudgetLineItemMergeTests.testLineItemUsesFullCategoryPath` verifies a nested category produces `categoryPath == "Income:Salary"`.
+- [x] Existing `BudgetLineItemMergeTests` updated to read `categoryPath` instead of `categoryName`.
+- [x] `just test` green (macOS + iOS).
+- [x] `just format-check` green.
+- [ ] Manual spot-check post-merge: transaction list, upcoming transactions, reports drill-down, transaction filter, import-rule picker, earmark budget section, expense-breakdown chart legend.
+
+Spec: `plans/2026-04-24-category-full-path-design.md`.
+Plan: `plans/2026-04-24-category-full-path-implementation.md`.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Capture the PR number from the URL gh returns.
+
+- [ ] **Step 6: Add to merge queue**
+
+Invoke the `merge-queue` skill with the captured PR number. Do NOT merge manually.
+
+- [ ] **Step 7: Clean up**
+
+```bash
+rm -f .agent-tmp/test-full.txt
+```


### PR DESCRIPTION
## Summary
- Leaf-only category labels like "Adrian" are ambiguous when the same leaf appears under multiple parents. Every display surface outside the category-management screens now shows the full colon-separated path (e.g. `Income:Salary:Adrian`) via the existing `Categories.path(for:)` helper.
- Structural rename: `BudgetLineItem.categoryName` → `categoryPath`, populated at build time via `categories.path(for:)`. Four consumers updated (`EarmarkBudgetSectionView`, `EditBudgetAmountSheet`).
- Thin-view substitutions in `TransactionRowView`, `UpcomingTransactionRow`, `TransactionFilterView`, `ReportsView`, `CategoryBalanceTable`, `RuleEditorActionRow`.
- Chart helpers renamed `categoryName(for:)` → `categoryLabel(for:)` in `CategoriesOverTimeCard` and `ExpenseBreakdownCard` so the changed meaning is visible at call sites.
- **Out of scope:** `CategoriesView`, `CategoryTreeView`, and the parent field in `CategoryDetailView` keep leaf names — those screens convey hierarchy structurally via indentation, so full paths would be redundant.
- **Separator** stays `:` (GnuCash / Beancount / Quicken convention, one-line to change if we want `/` later).

## Known trade-off
`CategoryBalanceTable` groups rows under a root section header. With full paths, children under the "Income" section now read `Income:Salary`, `Income:Bonus`, etc. — technically repeating the section header. Fixing this properly means stripping the root prefix only for this table, which is scope creep for a "show full path everywhere" change. Following up separately if it proves awkward.

## Test plan
- [x] New unit test `BudgetLineItemMergeTests.testLineItemUsesFullCategoryPath` verifies a nested category produces `categoryPath == "Income:Salary"`.
- [x] Existing `BudgetLineItemMergeTests` updated to read `categoryPath` instead of `categoryName`; `testMergeSortsByCategoryName` renamed to `testMergeSortsByCategoryPath`.
- [x] `just test` green (iOS simulator + macOS).
- [x] `just format-check` clean.
- [x] `just build-mac` succeeds with zero warnings.
- [ ] Manual spot-check after merge: transaction list metadata row, upcoming-transactions list, reports drill-down title, category balance table, transaction filter toggles, import-rule category picker, earmark budget section, expense-breakdown chart legend, categories-over-time chart legend.

Spec: `plans/2026-04-24-category-full-path-design.md`.
Plan: `plans/2026-04-24-category-full-path-implementation.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)