### PR TITLE
feat(sync): log batch-build pipeline and stop silent drops on handler errors

### DIFF
--- a/Backends/CloudKit/Sync/ProfileDataSyncHandler+SystemFields.swift
+++ b/Backends/CloudKit/Sync/ProfileDataSyncHandler+SystemFields.swift
@@ -36,13 +36,15 @@ extension ProfileDataSyncHandler {
   }
 
   /// Applies (or clears, when `data` is nil) the encoded system fields on the UUID-keyed
-  /// model record matching the given type. Replaces the former `update`/`clear`
-  /// per-UUID pair and reduces cyclomatic complexity by dispatching through
-  /// `systemFieldSetters`.
+  /// model record matching the given type. Returns `true` when a local row was found
+  /// and mutated; `false` when the dispatch table has no entry for the record type or
+  /// no local row matched the UUID.
+  @discardableResult
   nonisolated static func setEncodedSystemFields(
     _ id: UUID, data: Data?, recordType: String, context: ModelContext
-  ) {
-    systemFieldSetters[recordType]?(id, data, context)
+  ) -> Bool {
+    guard let setter = systemFieldSetters[recordType] else { return false }
+    return setter(id, data, context)
   }
 
   /// Applies (or clears, when `data` is nil) the encoded system fields on an
@@ -89,8 +91,12 @@ extension ProfileDataSyncHandler {
     for saved in savedRecords {
       applySystemFields(from: saved, in: context)
     }
+    let hadChanges = context.hasChanges
     do {
       try context.save()
+      logger.info(
+        "Applied system fields for \(savedRecords.count) saved records (hadChanges=\(hadChanges))"
+      )
     } catch {
       logger.error("Failed to save system fields after upload: \(error)")
     }
@@ -121,8 +127,13 @@ extension ProfileDataSyncHandler {
     let recordName = ckRecord.recordID.recordName
     let data = ckRecord.encodedSystemFields
     if let uuid = UUID(uuidString: recordName) {
-      Self.setEncodedSystemFields(
+      let applied = Self.setEncodedSystemFields(
         uuid, data: data, recordType: ckRecord.recordType, context: context)
+      if !applied {
+        logger.warning(
+          "No local row to cache system fields for \(ckRecord.recordType) \(recordName)"
+        )
+      }
     } else {
       Self.setInstrumentSystemFields(recordName, data: data, context: context)
     }
@@ -145,60 +156,49 @@ extension ProfileDataSyncHandler {
   /// `encodedSystemFields` on the matching record. Replaces the former ten-case
   /// switch statement, keeping `setEncodedSystemFields` at cyclomatic complexity 1.
   nonisolated(unsafe) private static let systemFieldSetters:
-    [String: (UUID, Data?, ModelContext) -> Void] = [
+    [String: (UUID, Data?, ModelContext) -> Bool] = [
       AccountRecord.recordType: { id, data, context in
-        let records = fetchOrLog(
-          FetchDescriptor<AccountRecord>(predicate: #Predicate { $0.id == id }),
-          context: context)
-        records.first?.encodedSystemFields = data
+        applyByUUID(AccountRecord.self, id: id, data: data, context: context)
       },
       TransactionRecord.recordType: { id, data, context in
-        let records = fetchOrLog(
-          FetchDescriptor<TransactionRecord>(predicate: #Predicate { $0.id == id }),
-          context: context)
-        records.first?.encodedSystemFields = data
+        applyByUUID(TransactionRecord.self, id: id, data: data, context: context)
       },
       TransactionLegRecord.recordType: { id, data, context in
-        let records = fetchOrLog(
-          FetchDescriptor<TransactionLegRecord>(predicate: #Predicate { $0.id == id }),
-          context: context)
-        records.first?.encodedSystemFields = data
+        applyByUUID(TransactionLegRecord.self, id: id, data: data, context: context)
       },
       CategoryRecord.recordType: { id, data, context in
-        let records = fetchOrLog(
-          FetchDescriptor<CategoryRecord>(predicate: #Predicate { $0.id == id }),
-          context: context)
-        records.first?.encodedSystemFields = data
+        applyByUUID(CategoryRecord.self, id: id, data: data, context: context)
       },
       EarmarkRecord.recordType: { id, data, context in
-        let records = fetchOrLog(
-          FetchDescriptor<EarmarkRecord>(predicate: #Predicate { $0.id == id }),
-          context: context)
-        records.first?.encodedSystemFields = data
+        applyByUUID(EarmarkRecord.self, id: id, data: data, context: context)
       },
       EarmarkBudgetItemRecord.recordType: { id, data, context in
-        let records = fetchOrLog(
-          FetchDescriptor<EarmarkBudgetItemRecord>(predicate: #Predicate { $0.id == id }),
-          context: context)
-        records.first?.encodedSystemFields = data
+        applyByUUID(EarmarkBudgetItemRecord.self, id: id, data: data, context: context)
       },
       InvestmentValueRecord.recordType: { id, data, context in
-        let records = fetchOrLog(
-          FetchDescriptor<InvestmentValueRecord>(predicate: #Predicate { $0.id == id }),
-          context: context)
-        records.first?.encodedSystemFields = data
+        applyByUUID(InvestmentValueRecord.self, id: id, data: data, context: context)
       },
       CSVImportProfileRecord.recordType: { id, data, context in
-        let records = fetchOrLog(
-          FetchDescriptor<CSVImportProfileRecord>(predicate: #Predicate { $0.id == id }),
-          context: context)
-        records.first?.encodedSystemFields = data
+        applyByUUID(CSVImportProfileRecord.self, id: id, data: data, context: context)
       },
       ImportRuleRecord.recordType: { id, data, context in
-        let records = fetchOrLog(
-          FetchDescriptor<ImportRuleRecord>(predicate: #Predicate { $0.id == id }),
-          context: context)
-        records.first?.encodedSystemFields = data
+        applyByUUID(ImportRuleRecord.self, id: id, data: data, context: context)
       },
     ]
+
+  /// Fetches the local row matching `id` and assigns `data` to its cached system
+  /// fields. Returns `true` when a row was found (and mutated), `false` when the
+  /// fetch returned empty. Shared helper so `systemFieldSetters` can signal
+  /// missing-row outcomes without repeating the two-line body per case.
+  nonisolated private static func applyByUUID<T>(
+    _ type: T.Type, id: UUID, data: Data?, context: ModelContext
+  ) -> Bool
+  where T: PersistentModel & IdentifiableRecord & SystemFieldsCacheable {
+    let records = fetchOrLog(
+      FetchDescriptor<T>(predicate: #Predicate { $0.id == id }),
+      context: context)
+    guard let record = records.first else { return false }
+    record.encodedSystemFields = data
+    return true
+  }
 }

--- a/Backends/CloudKit/Sync/SyncCoordinator+Delegate.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+Delegate.swift
@@ -76,50 +76,95 @@ extension SyncCoordinator: CKSyncEngineDelegate {
       os_signpost(.end, log: Signposts.sync, name: "nextBatch", signpostID: signpostID)
     }
 
+    let rawPendingCount = syncEngine.state.pendingRecordZoneChanges.count
     let pendingChanges = dedupedPendingChanges(
       syncEngine: syncEngine, scope: context.options.scope)
-    guard !pendingChanges.isEmpty else { return nil }
-
-    // Partition by zone-kind so atomicByZone can be set correctly per kind.
-    // Profile-index records are independent (atomicByZone: false); profile-data
-    // records within a zone must commit together (atomicByZone: true). See issue #61.
-    guard let batchKind = Self.selectBatchKind(from: pendingChanges) else { return nil }
-    let kindChanges = Self.filterChanges(pendingChanges, matching: batchKind)
-
-    let batchLimit = 400
-    let batch = Array(kindChanges.prefix(batchLimit))
-
-    // Group saves by zone for efficient batch lookup
-    var savesByZone: [CKRecordZone.ID: [CKRecord.ID]] = [:]
-    var deletesByBatch: [CKRecord.ID] = []
-
-    for change in batch {
-      switch change {
-      case .saveRecord(let recordID):
-        savesByZone[recordID.zoneID, default: []].append(recordID)
-      case .deleteRecord(let recordID):
-        deletesByBatch.append(recordID)
-      @unknown default:
-        break
-      }
+    guard !pendingChanges.isEmpty else {
+      logBatchFilteredOut(rawPending: rawPendingCount, deduped: 0, reason: "dedup/zone-creation")
+      return nil
     }
-
+    guard let batchKind = Self.selectBatchKind(from: pendingChanges) else {
+      logBatchFilteredOut(
+        rawPending: rawPendingCount, deduped: pendingChanges.count,
+        reason: "no recognised zone kind")
+      return nil
+    }
+    let batch = Array(
+      Self.filterChanges(pendingChanges, matching: batchKind).prefix(400))
+    let (savesByZone, deletesByBatch) = partitionBatch(batch)
     let recordsToSave = buildRecordsToSave(savesByZone: savesByZone)
-
+    let expectedSaves = savesByZone.values.reduce(0) { $0 + $1.count }
+    logBatchOutcome(
+      BatchOutcome(
+        rawPending: rawPendingCount, deduped: pendingChanges.count,
+        kind: batchKind, batch: batch.count, built: recordsToSave.count,
+        expected: expectedSaves, deletes: deletesByBatch.count))
     guard !recordsToSave.isEmpty || !deletesByBatch.isEmpty else { return nil }
-
-    let zoneCount = Set(recordsToSave.map(\.recordID.zoneID)).union(deletesByBatch.map(\.zoneID))
-      .count
-    os_signpost(
-      .event, log: Signposts.sync, name: "nextBatch", signpostID: signpostID,
-      "%{public}d records across %{public}d zones", recordsToSave.count + deletesByBatch.count,
-      zoneCount)
-
     return CKSyncEngine.RecordZoneChangeBatch(
       recordsToSave: recordsToSave,
       recordIDsToDelete: deletesByBatch,
       atomicByZone: batchKind.atomicByZone
     )
+  }
+
+  /// Splits a batch of pending changes into per-zone save IDs and a flat list of
+  /// delete IDs. Extracted from `nextRecordZoneChangeBatchOnMain` to keep that
+  /// function under the SwiftLint body-length limit.
+  @MainActor
+  private func partitionBatch(
+    _ batch: [CKSyncEngine.PendingRecordZoneChange]
+  ) -> (savesByZone: [CKRecordZone.ID: [CKRecord.ID]], deletes: [CKRecord.ID]) {
+    var savesByZone: [CKRecordZone.ID: [CKRecord.ID]] = [:]
+    var deletes: [CKRecord.ID] = []
+    for change in batch {
+      switch change {
+      case .saveRecord(let recordID):
+        savesByZone[recordID.zoneID, default: []].append(recordID)
+      case .deleteRecord(let recordID):
+        deletes.append(recordID)
+      @unknown default:
+        break
+      }
+    }
+    return (savesByZone, deletes)
+  }
+
+  /// Emits a warning when the pending queue was non-empty but everything got
+  /// filtered out before a batch could be built — highlights scope / dedup /
+  /// zone-creation filters that are silently dropping work.
+  @MainActor
+  private func logBatchFilteredOut(rawPending: Int, deduped: Int, reason: String) {
+    guard rawPending > 0 else { return }
+    logger.warning(
+      "nextBatch: pending=\(rawPending) deduped=\(deduped) — all filtered (\(reason)); returning nil"
+    )
+  }
+
+  /// Counters captured at the end of one `nextBatch` call. Grouped so
+  /// `logBatchOutcome` can stay under the SwiftLint parameter-count limit.
+  struct BatchOutcome {
+    let rawPending: Int
+    let deduped: Int
+    let kind: BatchKind
+    let batch: Int
+    let built: Int
+    let expected: Int
+    let deletes: Int
+  }
+
+  /// Emits the per-call batch summary (always at info) and escalates to error
+  /// when the batch build collapsed expected saves to zero — that's the
+  /// signature of a silent record-drop during CKRecord construction.
+  @MainActor
+  private func logBatchOutcome(_ outcome: BatchOutcome) {
+    logger.info(
+      "nextBatch: pending=\(outcome.rawPending) deduped=\(outcome.deduped) kind=\(String(describing: outcome.kind)) batch=\(outcome.batch) saves=\(outcome.built)/\(outcome.expected) deletes=\(outcome.deletes)"
+    )
+    if outcome.built == 0 && outcome.expected > 0 {
+      logger.error(
+        "nextBatch: expected \(outcome.expected) saves but built 0 records — records remain pending"
+      )
+    }
   }
 
   /// Returns pending changes filtered to the delegate's scope, deduplicated by
@@ -210,8 +255,13 @@ extension SyncCoordinator: CKSyncEngineDelegate {
     recordIDs: [CKRecord.ID],
     into recordsToSave: inout [CKRecord]
   ) {
-    guard let handler = try? handlerForProfileZone(profileId: profileId, zoneID: zoneID)
-    else {
+    let handler: ProfileDataSyncHandler
+    do {
+      handler = try handlerForProfileZone(profileId: profileId, zoneID: zoneID)
+    } catch {
+      logger.error(
+        "Failed to build handler for profile \(profileId): \(error) — \(recordIDs.count) records remain pending for retry"
+      )
       return
     }
 

--- a/Backends/CloudKit/Sync/SyncCoordinator+RecordChanges.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+RecordChanges.swift
@@ -186,6 +186,9 @@ extension SyncCoordinator {
     defer {
       os_signpost(.end, log: Signposts.sync, name: "handleSentChanges", signpostID: signpostID)
     }
+    logger.info(
+      "sentRecordZoneChanges: saved=\(sentChanges.savedRecords.count) failedSaves=\(sentChanges.failedRecordSaves.count) failedDeletes=\(sentChanges.failedRecordDeletes.count)"
+    )
 
     // Group saved records by zone
     var savedByZone: [CKRecordZone.ID: [CKRecord]] = [:]


### PR DESCRIPTION
## Summary

- Closes five silent-drop windows in `CKSyncEngineDelegate` paths where records could vanish without any log line.
- Adds a per-call `nextBatch: pending=… saves=X/Y …` summary + a loud `error` when the batch collapses to zero records despite pending work.
- Adds `handleSentRecordZoneChanges` and `updateSystemFieldsForSaved` summary logs so every send cycle leaves a trace at the app-subsystem level (CKSyncEngine framework logs are all `<private>`-redacted).
- Refactors the ten-case `systemFieldSetters` dispatch into a single `applyByUUID<T>` helper.

This is an observability + defensive PR, **not** a fix for the underlying bug — see [#416](https://github.com/ajsutton/moolah-native/issues/416) for the real issue (record-name collisions across SwiftData types). That will be implemented separately and will benefit directly from these logs.

## Context

While investigating why 16 accounts on a primary profile refused to sync, the CKSyncEngine framework reported clean success (`Finished operation` on `CKModifyRecordsOperation`, no error), but `ZENCODEDSYSTEMFIELDS IS NULL` stayed non-zero for those 16 rows across every launch. Getting from "engine says OK" to "records are landing on the wrong type" required temporary per-record logging we've since removed. The observability added here keeps enough trail that the next bug of this shape is visible from the first reproduction.

## Test plan

- [x] `just format-check` — clean (no swiftlint baseline changes).
- [x] `just build-mac` — warning-free.
- [x] `just test-mac SyncCoordinatorTests ProfileDataSyncHandlerTests SyncErrorRecoveryTests` — 25 tests, all green.
- [x] End-to-end: cleared backfill flag on reproducer profile, relaunched, confirmed new logs fire:
  - `nextBatch: pending=16 deduped=16 kind=… batch=16 saves=16/16 deletes=0`
  - `sentRecordZoneChanges: saved=16 failedSaves=0 failedDeletes=0`
  - `Applied system fields for 16 saved records (hadChanges=true)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)