### PR TITLE
feat(sync): add ICloudAvailability type

### DIFF
--- a/Backends/CloudKit/Sync/ICloudAvailability.swift
+++ b/Backends/CloudKit/Sync/ICloudAvailability.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+/// Current observability-oriented view of iCloud account status for
+/// Moolah's CloudKit sync.
+///
+/// Source of truth lives on ``SyncCoordinator`` — see
+/// `guides/SYNC_GUIDE.md` Rule 8 (single owner for account-change
+/// handling). Views read through ``ProfileStore.iCloudAvailability``
+/// which is a pass-through.
+///
+/// `.unknown` is the initial state before the first `accountStatus()`
+/// probe has returned, **and** the state we fall back to on
+/// `CKAccountStatus.couldNotDetermine` or a thrown probe error. We
+/// deliberately treat these as transient and keep the welcome screen's
+/// "Checking iCloud…" copy running — see design spec §6.1 and §8.
+enum ICloudAvailability: Equatable, Sendable {
+  case unknown
+  case available
+  case unavailable(reason: UnavailableReason)
+
+  /// Why iCloud is unavailable right now. Surfaced to view code for
+  /// copy selection (see `WelcomeView`'s iCloud-off chip variants).
+  enum UnavailableReason: Equatable, Sendable {
+    /// `CKAccountStatus.noAccount` — user is not signed into iCloud.
+    case notSignedIn
+    /// `CKAccountStatus.restricted` — parental controls / MDM.
+    case restricted
+    /// `CKAccountStatus.temporarilyUnavailable` — iCloud is reachable
+    /// but the account is in a temporary bad state.
+    case temporarilyUnavailable
+    /// `CloudKitAuthProvider.isCloudKitAvailable == false` — the build
+    /// is missing the iCloud entitlements (dev / CI builds).
+    case entitlementsMissing
+  }
+}

--- a/MoolahTests/Sync/ICloudAvailabilityTests.swift
+++ b/MoolahTests/Sync/ICloudAvailabilityTests.swift
@@ -1,0 +1,25 @@
+import Testing
+
+@testable import Moolah
+
+@Suite("ICloudAvailability")
+struct ICloudAvailabilityTests {
+  @Test("reasons are equatable")
+  func reasonsEquatable() {
+    #expect(ICloudAvailability.UnavailableReason.notSignedIn == .notSignedIn)
+    #expect(ICloudAvailability.UnavailableReason.notSignedIn != .restricted)
+  }
+
+  @Test("cases are equatable")
+  func casesEquatable() {
+    #expect(ICloudAvailability.available == .available)
+    #expect(ICloudAvailability.unknown == .unknown)
+    #expect(
+      ICloudAvailability.unavailable(reason: .notSignedIn)
+        == .unavailable(reason: .notSignedIn))
+    #expect(
+      ICloudAvailability.unavailable(reason: .notSignedIn)
+        != .unavailable(reason: .restricted))
+    #expect(ICloudAvailability.available != .unknown)
+  }
+}


### PR DESCRIPTION
## Summary

Implements Task 1 of [`plans/2026-04-24-first-run-experience-implementation.md`](https://github.com/ajsutton/moolah-native/blob/docs/first-run-experience-spec/plans/2026-04-24-first-run-experience-implementation.md) (ships as PR [#418](https://github.com/ajsutton/moolah-native/pull/418)).

Introduces the `ICloudAvailability` enum that `SyncCoordinator` will own (Task 2–3) and `ProfileStore` will pass through to `WelcomeView` (Task 4).

- `.unknown` — initial-probe-pending **and** transient `CKAccountStatus.couldNotDetermine` fallback. Keeps the welcome screen on "Checking iCloud…" rather than flashing "iCloud off" on laptop-just-woke-up races.
- `.available` — `CKAccountStatus.available`.
- `.unavailable(reason:)` — signed-out, restricted, temporarily-unavailable, or entitlements-missing.

## Review notes

- `@code-review` run: kept file location under `Backends/CloudKit/Sync/` (one Swift module — no import boundary between `Backends/` and `Features/` — and the plan was already signed off on this location via ui/sync-review on #418). Converted trailing `//` comments on `UnavailableReason` cases to `///` doc comments for Quick Help.
- Tests follow the plan's TDD step; they verify the `Equatable` conformance shape used by call-sites.

## Test plan

- [x] `just test ICloudAvailabilityTests` — all green
- [x] `just format-check` — clean