### PR TITLE
feat(sync): add SyncCoordinator.iCloudAvailability + initial probe

### DIFF
--- a/Backends/CloudKit/Sync/ICloudAvailability.swift
+++ b/Backends/CloudKit/Sync/ICloudAvailability.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+/// Current observability-oriented view of iCloud account status for
+/// Moolah's CloudKit sync.
+///
+/// Source of truth lives on ``SyncCoordinator`` — see
+/// `guides/SYNC_GUIDE.md` Rule 8 (single owner for account-change
+/// handling). Views read through ``ProfileStore.iCloudAvailability``
+/// which is a pass-through.
+///
+/// `.unknown` is the initial state before the first `accountStatus()`
+/// probe has returned, **and** the state we fall back to on
+/// `CKAccountStatus.couldNotDetermine` or a thrown probe error. We
+/// deliberately treat these as transient and keep the welcome screen's
+/// "Checking iCloud…" copy running — see design spec §6.1 and §8.
+enum ICloudAvailability: Equatable, Sendable {
+  case unknown
+  case available
+  case unavailable(reason: UnavailableReason)
+
+  /// Why iCloud is unavailable right now. Surfaced to view code for
+  /// copy selection (see `WelcomeView`'s iCloud-off chip variants).
+  enum UnavailableReason: Equatable, Sendable {
+    /// `CKAccountStatus.noAccount` — user is not signed into iCloud.
+    case notSignedIn
+    /// `CKAccountStatus.restricted` — parental controls / MDM.
+    case restricted
+    /// `CKAccountStatus.temporarilyUnavailable` — iCloud is reachable
+    /// but the account is in a temporary bad state.
+    case temporarilyUnavailable
+    /// `CloudKitAuthProvider.isCloudKitAvailable == false` — the build
+    /// is missing the iCloud entitlements (dev / CI builds).
+    case entitlementsMissing
+  }
+}

--- a/Backends/CloudKit/Sync/SyncCoordinator+Lifecycle.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+Lifecycle.swift
@@ -111,6 +111,24 @@ extension SyncCoordinator {
         await self.sendChanges()
       }
     }
+
+    // Initial iCloud availability probe. Skip when entitlements are missing
+    // (already set synchronously in init). On `couldNotDetermine` or thrown
+    // error we stay `.unknown` and rely on the subsequent `.accountChange`
+    // delegate event. Stored so `stop()` can cancel a probe still in flight.
+    if isCloudKitAvailable && iCloudAvailability == .unknown {
+      availabilityProbeTask = Task { [weak self] in
+        do {
+          let status = try await CKContainer.default().accountStatus()
+          guard !Task.isCancelled else { return }
+          self?.iCloudAvailability = Self.mapAccountStatus(status)
+        } catch {
+          self?.logger.info(
+            "Initial accountStatus probe threw: \(error, privacy: .public) — staying .unknown"
+          )
+        }
+      }
+    }
   }
 
   func stop() {
@@ -118,6 +136,8 @@ extension SyncCoordinator {
     startTask = nil
     zoneSetupTask?.cancel()
     zoneSetupTask = nil
+    availabilityProbeTask?.cancel()
+    availabilityProbeTask = nil
     cancelRefetchTasks()
     for (_, task) in zoneCreationTasks {
       task.cancel()
@@ -127,6 +147,11 @@ extension SyncCoordinator {
     isRunning = false
     isFetchingChanges = false
     isQuotaExceeded = false
+    // Reset availability so a subsequent `start()` re-probes. When
+    // entitlements are missing the init-time `.unavailable(.entitlementsMissing)`
+    // remains correct — a rebuild of the coordinator would be needed to clear it.
+    iCloudAvailability =
+      isCloudKitAvailable ? .unknown : .unavailable(reason: .entitlementsMissing)
     logger.info("Stopped unified sync coordinator")
   }
 

--- a/Backends/CloudKit/Sync/SyncCoordinator.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator.swift
@@ -211,6 +211,39 @@ final class SyncCoordinator {
   /// Used to guard against the synthetic `.signIn` event.
   var isFirstLaunch = false
 
+  /// Observable iCloud account availability. `.unknown` while a probe is
+  /// outstanding; see `handleAccountChange` in `SyncCoordinator+Zones.swift`
+  /// for ongoing updates, and `completeStart` in `+Lifecycle.swift` for the
+  /// initial probe. Views bind via `ProfileStore.iCloudAvailability`.
+  var iCloudAvailability: ICloudAvailability = .unknown
+
+  /// Captured at init from `CloudKitAuthProvider.isCloudKitAvailable` (or a
+  /// test override). `false` short-circuits the initial probe in
+  /// `completeStart` because the build has no iCloud entitlements.
+  let isCloudKitAvailable: Bool
+
+  /// Maps `CKAccountStatus` to ``ICloudAvailability``.
+  /// `.couldNotDetermine` and thrown errors are treated as `.unknown`
+  /// (transient) per design spec §6.1.
+  nonisolated static func mapAccountStatus(
+    _ status: CKAccountStatus
+  ) -> ICloudAvailability {
+    switch status {
+    case .available:
+      return .available
+    case .noAccount:
+      return .unavailable(reason: .notSignedIn)
+    case .restricted:
+      return .unavailable(reason: .restricted)
+    case .temporarilyUnavailable:
+      return .unavailable(reason: .temporarilyUnavailable)
+    case .couldNotDetermine:
+      return .unknown
+    @unknown default:
+      return .unknown
+    }
+  }
+
   /// True while CKSyncEngine is fetching changes (between willFetchChanges and didFetchChanges).
   var isFetchingChanges = false
 
@@ -248,6 +281,10 @@ final class SyncCoordinator {
   /// a fetch so persistent failures don't leave local data silently incomplete.
   var longRetryTask: Task<Void, Never>?
 
+  /// Initial `CKContainer.accountStatus()` probe kicked off from
+  /// `completeStart`. Held so `stop()` can cancel it.
+  var availabilityProbeTask: Task<Void, Never>?
+
   /// Number of consecutive re-fetch attempts scheduled after a save failure.
   /// Reset to zero whenever a fetched-record-zone-changes batch applies successfully.
   /// Exposed for testing.
@@ -283,12 +320,17 @@ final class SyncCoordinator {
 
   init(
     containerManager: ProfileContainerManager,
-    userDefaults: UserDefaults = .standard
+    userDefaults: UserDefaults = .standard,
+    isCloudKitAvailable: Bool = CloudKitAuthProvider.isCloudKitAvailable
   ) {
     self.containerManager = containerManager
     self.userDefaults = userDefaults
     self.profileIndexHandler = ProfileIndexSyncHandler(
       modelContainer: containerManager.indexContainer)
+    self.isCloudKitAvailable = isCloudKitAvailable
+    if !isCloudKitAvailable {
+      self.iCloudAvailability = .unavailable(reason: .entitlementsMissing)
+    }
   }
 
   // MARK: - Fetch-Session Book-keeping

--- a/MoolahTests/Sync/ICloudAvailabilityTests.swift
+++ b/MoolahTests/Sync/ICloudAvailabilityTests.swift
@@ -1,0 +1,25 @@
+import Testing
+
+@testable import Moolah
+
+@Suite("ICloudAvailability")
+struct ICloudAvailabilityTests {
+  @Test("reasons are equatable")
+  func reasonsEquatable() {
+    #expect(ICloudAvailability.UnavailableReason.notSignedIn == .notSignedIn)
+    #expect(ICloudAvailability.UnavailableReason.notSignedIn != .restricted)
+  }
+
+  @Test("cases are equatable")
+  func casesEquatable() {
+    #expect(ICloudAvailability.available == .available)
+    #expect(ICloudAvailability.unknown == .unknown)
+    #expect(
+      ICloudAvailability.unavailable(reason: .notSignedIn)
+        == .unavailable(reason: .notSignedIn))
+    #expect(
+      ICloudAvailability.unavailable(reason: .notSignedIn)
+        != .unavailable(reason: .restricted))
+    #expect(ICloudAvailability.available != .unknown)
+  }
+}

--- a/MoolahTests/Sync/SyncCoordinatorICloudAvailabilityTests.swift
+++ b/MoolahTests/Sync/SyncCoordinatorICloudAvailabilityTests.swift
@@ -1,0 +1,92 @@
+import CloudKit
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("SyncCoordinator — iCloudAvailability")
+@MainActor
+struct SyncCoordinatorICloudAvailabilityTests {
+
+  @Test("initial state is .unknown before start (entitlements present)")
+  func initialState() throws {
+    let manager = try ProfileContainerManager.forTesting()
+    // Force entitlements "available" — in test builds CLOUDKIT_ENABLED is
+    // unset, which would otherwise synchronously flip state to
+    // `.unavailable(.entitlementsMissing)`.
+    let coordinator = SyncCoordinator(
+      containerManager: manager,
+      isCloudKitAvailable: true
+    )
+    #expect(coordinator.iCloudAvailability == .unknown)
+  }
+
+  @Test("sets .entitlementsMissing synchronously when CloudKit is unavailable")
+  func entitlementsMissing() throws {
+    let manager = try ProfileContainerManager.forTesting()
+    let coordinator = SyncCoordinator(
+      containerManager: manager,
+      isCloudKitAvailable: false
+    )
+    #expect(coordinator.iCloudAvailability == .unavailable(reason: .entitlementsMissing))
+  }
+
+  @Test("maps CKAccountStatus.available → .available")
+  func mapAvailable() {
+    #expect(SyncCoordinator.mapAccountStatus(.available) == .available)
+  }
+
+  @Test("maps CKAccountStatus.noAccount → .unavailable(.notSignedIn)")
+  func mapNoAccount() {
+    #expect(
+      SyncCoordinator.mapAccountStatus(.noAccount)
+        == .unavailable(reason: .notSignedIn))
+  }
+
+  @Test("maps CKAccountStatus.restricted → .unavailable(.restricted)")
+  func mapRestricted() {
+    #expect(
+      SyncCoordinator.mapAccountStatus(.restricted)
+        == .unavailable(reason: .restricted))
+  }
+
+  @Test("maps CKAccountStatus.temporarilyUnavailable → .unavailable(.temporarilyUnavailable)")
+  func mapTemporarilyUnavailable() {
+    #expect(
+      SyncCoordinator.mapAccountStatus(.temporarilyUnavailable)
+        == .unavailable(reason: .temporarilyUnavailable))
+  }
+
+  @Test("maps CKAccountStatus.couldNotDetermine → .unknown (transient)")
+  func mapCouldNotDetermine() {
+    #expect(SyncCoordinator.mapAccountStatus(.couldNotDetermine) == .unknown)
+  }
+
+  @Test("stop() resets iCloudAvailability to .unknown when entitlements present")
+  func stopResetsToUnknown() throws {
+    let manager = try ProfileContainerManager.forTesting()
+    let coordinator = SyncCoordinator(
+      containerManager: manager,
+      isCloudKitAvailable: true
+    )
+    coordinator.iCloudAvailability = .available
+
+    coordinator.stop()
+
+    #expect(coordinator.iCloudAvailability == .unknown)
+  }
+
+  @Test("stop() keeps .entitlementsMissing when entitlements are unavailable")
+  func stopKeepsEntitlementsMissing() throws {
+    let manager = try ProfileContainerManager.forTesting()
+    let coordinator = SyncCoordinator(
+      containerManager: manager,
+      isCloudKitAvailable: false
+    )
+    coordinator.stop()
+
+    #expect(
+      coordinator.iCloudAvailability == .unavailable(reason: .entitlementsMissing)
+    )
+  }
+}


### PR DESCRIPTION
## Summary

Implements Task 2 of [`plans/2026-04-24-first-run-experience-implementation.md`](https://github.com/ajsutton/moolah-native/blob/main/plans/2026-04-24-first-run-experience-implementation.md). Builds on [#419](https://github.com/ajsutton/moolah-native/pull/419) (Task 1).

- Adds observable `iCloudAvailability: ICloudAvailability` property on `SyncCoordinator`.
- Adds `nonisolated static func mapAccountStatus(_:)` — maps `CKAccountStatus` → `ICloudAvailability`; `.couldNotDetermine` stays `.unknown` so the welcome screen keeps "Checking iCloud…" on laptop-wake-up races (design spec §6.1).
- Adds `isCloudKitAvailable: Bool` init parameter with a default that reads `CloudKitAuthProvider.isCloudKitAvailable`. Non-optional `Bool` (not `Bool?`) per SwiftLint `discouraged_optional_boolean`.
- Adds initial `CKContainer.default().accountStatus()` probe in `completeStart()`, gated on `isCloudKitAvailable && iCloudAvailability == .unknown`. The probe task is stored on `availabilityProbeTask` so `stop()` cancels it and resets `iCloudAvailability` so a subsequent `start()` re-probes.

## Review notes

`@sync-review` findings addressed:

- **Stop-cancels-probe:** stored the probe in `availabilityProbeTask`; cancelled + nilled in `stop()`.
- **Re-start re-probes:** `stop()` now resets `iCloudAvailability` (`.unknown` when entitlements are present, `.unavailable(.entitlementsMissing)` when not).
- **Test coverage:** added `stopResetsToUnknown` and `stopKeepsEntitlementsMissing` covering the stop/restart stale-state path.

Plan divergence: plan called for `isCloudKitAvailableOverride: Bool? = nil`; I used the non-optional `isCloudKitAvailable: Bool = CloudKitAuthProvider.isCloudKitAvailable` form to avoid the `discouraged_optional_boolean` SwiftLint rule. Same observable behaviour at all call sites.

## Test plan

- [x] `just test SyncCoordinatorICloudAvailabilityTests` — 9 tests green
- [x] `just test SyncCoordinatorTests` — 12 tests green (regression)
- [x] `just format-check` — clean