### PR TITLE
feat(sync): map account-change events to iCloudAvailability

### DIFF
--- a/Backends/CloudKit/Sync/SyncCoordinator+Lifecycle.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+Lifecycle.swift
@@ -111,6 +111,24 @@ extension SyncCoordinator {
         await self.sendChanges()
       }
     }
+
+    // Initial iCloud availability probe. Skip when entitlements are missing
+    // (already set synchronously in init). On `couldNotDetermine` or thrown
+    // error we stay `.unknown` and rely on the subsequent `.accountChange`
+    // delegate event. Stored so `stop()` can cancel a probe still in flight.
+    if isCloudKitAvailable && iCloudAvailability == .unknown {
+      availabilityProbeTask = Task { [weak self] in
+        do {
+          let status = try await CKContainer.default().accountStatus()
+          guard !Task.isCancelled else { return }
+          self?.iCloudAvailability = Self.mapAccountStatus(status)
+        } catch {
+          self?.logger.info(
+            "Initial accountStatus probe threw: \(error, privacy: .public) — staying .unknown"
+          )
+        }
+      }
+    }
   }
 
   func stop() {
@@ -118,6 +136,8 @@ extension SyncCoordinator {
     startTask = nil
     zoneSetupTask?.cancel()
     zoneSetupTask = nil
+    availabilityProbeTask?.cancel()
+    availabilityProbeTask = nil
     cancelRefetchTasks()
     for (_, task) in zoneCreationTasks {
       task.cancel()
@@ -127,6 +147,11 @@ extension SyncCoordinator {
     isRunning = false
     isFetchingChanges = false
     isQuotaExceeded = false
+    // Reset availability so a subsequent `start()` re-probes. When
+    // entitlements are missing the init-time `.unavailable(.entitlementsMissing)`
+    // remains correct — a rebuild of the coordinator would be needed to clear it.
+    iCloudAvailability =
+      isCloudKitAvailable ? .unknown : .unavailable(reason: .entitlementsMissing)
     logger.info("Stopped unified sync coordinator")
   }
 

--- a/Backends/CloudKit/Sync/SyncCoordinator+Zones.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+Zones.swift
@@ -46,7 +46,34 @@ extension SyncCoordinator {
 
   // MARK: - Account Changes
 
+  /// Maps a CloudKit account-change type to ``ICloudAvailability`` and
+  /// applies it. Pure assignment — safe to call on every event, including
+  /// the synthetic first-launch `.signIn`.
+  ///
+  /// `.signIn` / `.switchAccounts` both mean "we now have a usable
+  /// account" → `.available`. `.signOut` → `.unavailable(.notSignedIn)`.
+  func applyAvailability(
+    from changeType: CKSyncEngine.Event.AccountChange.ChangeType
+  ) {
+    switch changeType {
+    case .signIn, .switchAccounts:
+      iCloudAvailability = .available
+    case .signOut:
+      iCloudAvailability = .unavailable(reason: .notSignedIn)
+    @unknown default:
+      logger.warning(
+        "Unhandled account-change type — iCloudAvailability not updated"
+      )
+    }
+  }
+
   func handleAccountChange(_ change: CKSyncEngine.Event.AccountChange) {
+    // Update observable availability first — pure assignment that is
+    // safe to fire on every event (including the synthetic first-launch
+    // `.signIn`), so views react immediately. The isFirstLaunch-gated
+    // zone-reset work below runs exactly as before.
+    applyAvailability(from: change.changeType)
+
     switch change.changeType {
     case .signIn:
       if isFirstLaunch {

--- a/Backends/CloudKit/Sync/SyncCoordinator.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator.swift
@@ -211,6 +211,39 @@ final class SyncCoordinator {
   /// Used to guard against the synthetic `.signIn` event.
   var isFirstLaunch = false
 
+  /// Observable iCloud account availability. `.unknown` while a probe is
+  /// outstanding; see `handleAccountChange` in `SyncCoordinator+Zones.swift`
+  /// for ongoing updates, and `completeStart` in `+Lifecycle.swift` for the
+  /// initial probe. Views bind via `ProfileStore.iCloudAvailability`.
+  var iCloudAvailability: ICloudAvailability = .unknown
+
+  /// Captured at init from `CloudKitAuthProvider.isCloudKitAvailable` (or a
+  /// test override). `false` short-circuits the initial probe in
+  /// `completeStart` because the build has no iCloud entitlements.
+  let isCloudKitAvailable: Bool
+
+  /// Maps `CKAccountStatus` to ``ICloudAvailability``.
+  /// `.couldNotDetermine` and thrown errors are treated as `.unknown`
+  /// (transient) per design spec §6.1.
+  nonisolated static func mapAccountStatus(
+    _ status: CKAccountStatus
+  ) -> ICloudAvailability {
+    switch status {
+    case .available:
+      return .available
+    case .noAccount:
+      return .unavailable(reason: .notSignedIn)
+    case .restricted:
+      return .unavailable(reason: .restricted)
+    case .temporarilyUnavailable:
+      return .unavailable(reason: .temporarilyUnavailable)
+    case .couldNotDetermine:
+      return .unknown
+    @unknown default:
+      return .unknown
+    }
+  }
+
   /// True while CKSyncEngine is fetching changes (between willFetchChanges and didFetchChanges).
   var isFetchingChanges = false
 
@@ -248,6 +281,10 @@ final class SyncCoordinator {
   /// a fetch so persistent failures don't leave local data silently incomplete.
   var longRetryTask: Task<Void, Never>?
 
+  /// Initial `CKContainer.accountStatus()` probe kicked off from
+  /// `completeStart`. Held so `stop()` can cancel it.
+  var availabilityProbeTask: Task<Void, Never>?
+
   /// Number of consecutive re-fetch attempts scheduled after a save failure.
   /// Reset to zero whenever a fetched-record-zone-changes batch applies successfully.
   /// Exposed for testing.
@@ -283,12 +320,17 @@ final class SyncCoordinator {
 
   init(
     containerManager: ProfileContainerManager,
-    userDefaults: UserDefaults = .standard
+    userDefaults: UserDefaults = .standard,
+    isCloudKitAvailable: Bool = CloudKitAuthProvider.isCloudKitAvailable
   ) {
     self.containerManager = containerManager
     self.userDefaults = userDefaults
     self.profileIndexHandler = ProfileIndexSyncHandler(
       modelContainer: containerManager.indexContainer)
+    self.isCloudKitAvailable = isCloudKitAvailable
+    if !isCloudKitAvailable {
+      self.iCloudAvailability = .unavailable(reason: .entitlementsMissing)
+    }
   }
 
   // MARK: - Fetch-Session Book-keeping

--- a/MoolahTests/Sync/SyncCoordinatorAccountChangeTests.swift
+++ b/MoolahTests/Sync/SyncCoordinatorAccountChangeTests.swift
@@ -1,0 +1,56 @@
+import CloudKit
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("SyncCoordinator — applyAvailability")
+@MainActor
+struct SyncCoordinatorAccountChangeTests {
+  private let testUser = CKRecord.ID(recordName: "test-user")
+  private let otherUser = CKRecord.ID(recordName: "other-user")
+
+  @Test("applyAvailability(.signIn) sets availability to .available")
+  func applyAvailabilitySignIn() throws {
+    let manager = try ProfileContainerManager.forTesting()
+    let coordinator = SyncCoordinator(
+      containerManager: manager,
+      isCloudKitAvailable: true
+    )
+    coordinator.iCloudAvailability = .unavailable(reason: .notSignedIn)
+
+    coordinator.applyAvailability(from: .signIn(currentUser: testUser))
+
+    #expect(coordinator.iCloudAvailability == .available)
+  }
+
+  @Test("applyAvailability(.signOut) sets availability to .unavailable(.notSignedIn)")
+  func applyAvailabilitySignOut() throws {
+    let manager = try ProfileContainerManager.forTesting()
+    let coordinator = SyncCoordinator(
+      containerManager: manager,
+      isCloudKitAvailable: true
+    )
+    coordinator.iCloudAvailability = .available
+
+    coordinator.applyAvailability(from: .signOut(previousUser: testUser))
+
+    #expect(coordinator.iCloudAvailability == .unavailable(reason: .notSignedIn))
+  }
+
+  @Test("applyAvailability(.switchAccounts) sets availability to .available")
+  func applyAvailabilitySwitchAccounts() throws {
+    let manager = try ProfileContainerManager.forTesting()
+    let coordinator = SyncCoordinator(
+      containerManager: manager,
+      isCloudKitAvailable: true
+    )
+    coordinator.iCloudAvailability = .unknown
+
+    coordinator.applyAvailability(
+      from: .switchAccounts(previousUser: testUser, currentUser: otherUser)
+    )
+
+    #expect(coordinator.iCloudAvailability == .available)
+  }
+}

--- a/MoolahTests/Sync/SyncCoordinatorICloudAvailabilityTests.swift
+++ b/MoolahTests/Sync/SyncCoordinatorICloudAvailabilityTests.swift
@@ -1,0 +1,92 @@
+import CloudKit
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("SyncCoordinator — iCloudAvailability")
+@MainActor
+struct SyncCoordinatorICloudAvailabilityTests {
+
+  @Test("initial state is .unknown before start (entitlements present)")
+  func initialState() throws {
+    let manager = try ProfileContainerManager.forTesting()
+    // Force entitlements "available" — in test builds CLOUDKIT_ENABLED is
+    // unset, which would otherwise synchronously flip state to
+    // `.unavailable(.entitlementsMissing)`.
+    let coordinator = SyncCoordinator(
+      containerManager: manager,
+      isCloudKitAvailable: true
+    )
+    #expect(coordinator.iCloudAvailability == .unknown)
+  }
+
+  @Test("sets .entitlementsMissing synchronously when CloudKit is unavailable")
+  func entitlementsMissing() throws {
+    let manager = try ProfileContainerManager.forTesting()
+    let coordinator = SyncCoordinator(
+      containerManager: manager,
+      isCloudKitAvailable: false
+    )
+    #expect(coordinator.iCloudAvailability == .unavailable(reason: .entitlementsMissing))
+  }
+
+  @Test("maps CKAccountStatus.available → .available")
+  func mapAvailable() {
+    #expect(SyncCoordinator.mapAccountStatus(.available) == .available)
+  }
+
+  @Test("maps CKAccountStatus.noAccount → .unavailable(.notSignedIn)")
+  func mapNoAccount() {
+    #expect(
+      SyncCoordinator.mapAccountStatus(.noAccount)
+        == .unavailable(reason: .notSignedIn))
+  }
+
+  @Test("maps CKAccountStatus.restricted → .unavailable(.restricted)")
+  func mapRestricted() {
+    #expect(
+      SyncCoordinator.mapAccountStatus(.restricted)
+        == .unavailable(reason: .restricted))
+  }
+
+  @Test("maps CKAccountStatus.temporarilyUnavailable → .unavailable(.temporarilyUnavailable)")
+  func mapTemporarilyUnavailable() {
+    #expect(
+      SyncCoordinator.mapAccountStatus(.temporarilyUnavailable)
+        == .unavailable(reason: .temporarilyUnavailable))
+  }
+
+  @Test("maps CKAccountStatus.couldNotDetermine → .unknown (transient)")
+  func mapCouldNotDetermine() {
+    #expect(SyncCoordinator.mapAccountStatus(.couldNotDetermine) == .unknown)
+  }
+
+  @Test("stop() resets iCloudAvailability to .unknown when entitlements present")
+  func stopResetsToUnknown() throws {
+    let manager = try ProfileContainerManager.forTesting()
+    let coordinator = SyncCoordinator(
+      containerManager: manager,
+      isCloudKitAvailable: true
+    )
+    coordinator.iCloudAvailability = .available
+
+    coordinator.stop()
+
+    #expect(coordinator.iCloudAvailability == .unknown)
+  }
+
+  @Test("stop() keeps .entitlementsMissing when entitlements are unavailable")
+  func stopKeepsEntitlementsMissing() throws {
+    let manager = try ProfileContainerManager.forTesting()
+    let coordinator = SyncCoordinator(
+      containerManager: manager,
+      isCloudKitAvailable: false
+    )
+    coordinator.stop()
+
+    #expect(
+      coordinator.iCloudAvailability == .unavailable(reason: .entitlementsMissing)
+    )
+  }
+}


### PR DESCRIPTION
## Summary

Implements Task 3 of [`plans/2026-04-24-first-run-experience-implementation.md`](https://github.com/ajsutton/moolah-native/blob/main/plans/2026-04-24-first-run-experience-implementation.md). Builds on [#421](https://github.com/ajsutton/moolah-native/pull/421) (Task 2).

Adds `applyAvailability(from:)` on `SyncCoordinator` that maps a `CKSyncEngine.Event.AccountChange.ChangeType` to an `ICloudAvailability`:

- `.signIn` / `.switchAccounts` → `.available`
- `.signOut` → `.unavailable(.notSignedIn)`

`handleAccountChange(_:)` calls it unconditionally before the existing zone-reset `switch`, so views react immediately. The pre-existing `isFirstLaunch` guard on re-upload is preserved.

## Review notes

- `@sync-review`: single-writer rule preserved (the helper owns all three mappings; no other call site mutates `iCloudAvailability` from account events). `@unknown default` now logs a warning instead of a silent `break` so SDK additions don't leave state stale — sync-review minor finding applied.

## Test plan

- [x] `just test SyncCoordinatorAccountChangeTests` — 3 tests green
- [x] `just test SyncCoordinatorICloudAvailabilityTests` — 9 green (regression)
- [x] `just test SyncCoordinatorTests` — 12 green (regression)
- [x] `just format-check` — clean