### PR TITLE
feat(profiles): pass iCloudAvailability through ProfileStore

### DIFF
--- a/App/MoolahApp.swift
+++ b/App/MoolahApp.swift
@@ -47,7 +47,11 @@ struct MoolahApp: App {
     syncCoordinator = coordinator
     uiTestingProfileId = setup.uiTestingProfileId
 
-    let store = ProfileStore(validator: RemoteServerValidator(), containerManager: setup.manager)
+    let store = ProfileStore(
+      validator: RemoteServerValidator(),
+      containerManager: setup.manager,
+      syncCoordinator: coordinator
+    )
     _profileStore = State(initialValue: store)
 
     Self.configureSyncCoordinator(

--- a/Backends/CloudKit/Sync/SyncCoordinator+Zones.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+Zones.swift
@@ -46,7 +46,34 @@ extension SyncCoordinator {
 
   // MARK: - Account Changes
 
+  /// Maps a CloudKit account-change type to ``ICloudAvailability`` and
+  /// applies it. Pure assignment — safe to call on every event, including
+  /// the synthetic first-launch `.signIn`.
+  ///
+  /// `.signIn` / `.switchAccounts` both mean "we now have a usable
+  /// account" → `.available`. `.signOut` → `.unavailable(.notSignedIn)`.
+  func applyAvailability(
+    from changeType: CKSyncEngine.Event.AccountChange.ChangeType
+  ) {
+    switch changeType {
+    case .signIn, .switchAccounts:
+      iCloudAvailability = .available
+    case .signOut:
+      iCloudAvailability = .unavailable(reason: .notSignedIn)
+    @unknown default:
+      logger.warning(
+        "Unhandled account-change type — iCloudAvailability not updated"
+      )
+    }
+  }
+
   func handleAccountChange(_ change: CKSyncEngine.Event.AccountChange) {
+    // Update observable availability first — pure assignment that is
+    // safe to fire on every event (including the synthetic first-launch
+    // `.signIn`), so views react immediately. The isFirstLaunch-gated
+    // zone-reset work below runs exactly as before.
+    applyAvailability(from: change.changeType)
+
     switch change.changeType {
     case .signIn:
       if isFirstLaunch {

--- a/Features/Profiles/ProfileStore.swift
+++ b/Features/Profiles/ProfileStore.swift
@@ -50,7 +50,15 @@ final class ProfileStore {
   let defaults: UserDefaults
   let validator: (any ServerValidator)?
   let containerManager: ProfileContainerManager?
+  private let syncCoordinator: SyncCoordinator?
   let logger = Logger(subsystem: "com.moolah.app", category: "ProfileStore")
+
+  /// Pass-through to ``SyncCoordinator/iCloudAvailability``. `.unknown`
+  /// when no coordinator was injected (tests, previews). View code (e.g.
+  /// `WelcomeView`) reads this rather than reaching into the sync layer.
+  var iCloudAvailability: ICloudAvailability {
+    syncCoordinator?.iCloudAvailability ?? .unknown
+  }
 
   /// Combined list of all profiles from both backends.
   var profiles: [Profile] {
@@ -68,11 +76,13 @@ final class ProfileStore {
   init(
     defaults: UserDefaults = .standard,
     validator: (any ServerValidator)? = nil,
-    containerManager: ProfileContainerManager? = nil
+    containerManager: ProfileContainerManager? = nil,
+    syncCoordinator: SyncCoordinator? = nil
   ) {
     self.defaults = defaults
     self.validator = validator
     self.containerManager = containerManager
+    self.syncCoordinator = syncCoordinator
     loadFromDefaults()
     if containerManager != nil {
       loadCloudProfiles(isInitialLoad: true)

--- a/MoolahTests/Features/ProfileStoreAvailabilityTests.swift
+++ b/MoolahTests/Features/ProfileStoreAvailabilityTests.swift
@@ -1,0 +1,41 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("ProfileStore — iCloudAvailability passthrough")
+@MainActor
+struct ProfileStoreAvailabilityTests {
+  private func makeDefaults() throws -> UserDefaults {
+    let suiteName = "com.moolah.test.\(UUID().uuidString)"
+    let defaults = try #require(UserDefaults(suiteName: suiteName))
+    defaults.removePersistentDomain(forName: suiteName)
+    return defaults
+  }
+
+  @Test("mirrors SyncCoordinator.iCloudAvailability")
+  func mirrors() throws {
+    let manager = try ProfileContainerManager.forTesting()
+    let coordinator = SyncCoordinator(
+      containerManager: manager,
+      isCloudKitAvailable: true
+    )
+    let store = ProfileStore(
+      defaults: try makeDefaults(),
+      containerManager: manager,
+      syncCoordinator: coordinator
+    )
+
+    coordinator.iCloudAvailability = .unavailable(reason: .notSignedIn)
+    #expect(store.iCloudAvailability == .unavailable(reason: .notSignedIn))
+
+    coordinator.iCloudAvailability = .available
+    #expect(store.iCloudAvailability == .available)
+  }
+
+  @Test("returns .unknown when no coordinator is injected")
+  func defaultsUnknown() throws {
+    let store = ProfileStore(defaults: try makeDefaults())
+    #expect(store.iCloudAvailability == .unknown)
+  }
+}

--- a/MoolahTests/Sync/SyncCoordinatorAccountChangeTests.swift
+++ b/MoolahTests/Sync/SyncCoordinatorAccountChangeTests.swift
@@ -1,0 +1,56 @@
+import CloudKit
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("SyncCoordinator — applyAvailability")
+@MainActor
+struct SyncCoordinatorAccountChangeTests {
+  private let testUser = CKRecord.ID(recordName: "test-user")
+  private let otherUser = CKRecord.ID(recordName: "other-user")
+
+  @Test("applyAvailability(.signIn) sets availability to .available")
+  func applyAvailabilitySignIn() throws {
+    let manager = try ProfileContainerManager.forTesting()
+    let coordinator = SyncCoordinator(
+      containerManager: manager,
+      isCloudKitAvailable: true
+    )
+    coordinator.iCloudAvailability = .unavailable(reason: .notSignedIn)
+
+    coordinator.applyAvailability(from: .signIn(currentUser: testUser))
+
+    #expect(coordinator.iCloudAvailability == .available)
+  }
+
+  @Test("applyAvailability(.signOut) sets availability to .unavailable(.notSignedIn)")
+  func applyAvailabilitySignOut() throws {
+    let manager = try ProfileContainerManager.forTesting()
+    let coordinator = SyncCoordinator(
+      containerManager: manager,
+      isCloudKitAvailable: true
+    )
+    coordinator.iCloudAvailability = .available
+
+    coordinator.applyAvailability(from: .signOut(previousUser: testUser))
+
+    #expect(coordinator.iCloudAvailability == .unavailable(reason: .notSignedIn))
+  }
+
+  @Test("applyAvailability(.switchAccounts) sets availability to .available")
+  func applyAvailabilitySwitchAccounts() throws {
+    let manager = try ProfileContainerManager.forTesting()
+    let coordinator = SyncCoordinator(
+      containerManager: manager,
+      isCloudKitAvailable: true
+    )
+    coordinator.iCloudAvailability = .unknown
+
+    coordinator.applyAvailability(
+      from: .switchAccounts(previousUser: testUser, currentUser: otherUser)
+    )
+
+    #expect(coordinator.iCloudAvailability == .available)
+  }
+}


### PR DESCRIPTION
## Summary

Implements Task 4 of [`plans/2026-04-24-first-run-experience-implementation.md`](https://github.com/ajsutton/moolah-native/blob/main/plans/2026-04-24-first-run-experience-implementation.md). Builds on [#422](https://github.com/ajsutton/moolah-native/pull/422) (Task 3).

- Adds `syncCoordinator: SyncCoordinator?` parameter to `ProfileStore.init`; stores it privately.
- Adds computed `var iCloudAvailability: ICloudAvailability` that forwards to the coordinator (or returns `.unknown` when no coordinator is injected — tests/previews).
- Wires the real coordinator in `MoolahApp.init`.

## Review notes

- `@concurrency-review`: both types are `@Observable @MainActor`, so the forward is on the same actor with no Sendable concerns. The `@Observable` observation chain correctly invalidates views when the upstream property changes.
- Plan divergence: `ProfileStoreICloudAvailabilityPassthroughTests` renamed to `ProfileStoreAvailabilityTests` to satisfy SwiftLint `type_name` 40-char limit; `makeDefaults()` uses `try #require` instead of force-unwrap per `force_unwrapping` rule.

## Test plan

- [x] `just test ProfileStoreAvailabilityTests` — 2 green
- [x] `just test ProfileStoreTests` — 15 green (regression)
- [x] `just format-check` — clean