### PR TITLE
feat(sync): add profile-index fetch tracking scaffolding

### DIFF
--- a/App/MoolahApp.swift
+++ b/App/MoolahApp.swift
@@ -47,7 +47,11 @@ struct MoolahApp: App {
     syncCoordinator = coordinator
     uiTestingProfileId = setup.uiTestingProfileId
 
-    let store = ProfileStore(validator: RemoteServerValidator(), containerManager: setup.manager)
+    let store = ProfileStore(
+      validator: RemoteServerValidator(),
+      containerManager: setup.manager,
+      syncCoordinator: coordinator
+    )
     _profileStore = State(initialValue: store)
 
     Self.configureSyncCoordinator(

--- a/Backends/CloudKit/Sync/SyncCoordinator+Lifecycle.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+Lifecycle.swift
@@ -152,6 +152,8 @@ extension SyncCoordinator {
     // remains correct — a rebuild of the coordinator would be needed to clear it.
     iCloudAvailability =
       isCloudKitAvailable ? .unknown : .unavailable(reason: .entitlementsMissing)
+    profileIndexFetchedAtLeastOnce = false
+    fetchSessionTouchedIndexZone = false
     logger.info("Stopped unified sync coordinator")
   }
 
@@ -211,6 +213,7 @@ extension SyncCoordinator {
     isFetchingChanges = true
     fetchSessionChangedTypes.removeAll()
     fetchSessionIndexChanged = false
+    fetchSessionTouchedIndexZone = false
   }
 
   func endFetchingChanges() {

--- a/Backends/CloudKit/Sync/SyncCoordinator.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator.swift
@@ -257,6 +257,21 @@ final class SyncCoordinator {
   /// Whether the profile-index zone had changes during the current fetch session.
   var fetchSessionIndexChanged = false
 
+  /// True once the `profile-index` zone has been fetched (even empty-handed)
+  /// at least once since the last `start()`. `WelcomeView` uses this to
+  /// swap "Checking iCloud…" for "No profiles in iCloud yet." once we
+  /// know the answer. Must NOT flip on fetches that only touched
+  /// `profile-data` zones. See design spec §6.2.
+  /// Writable-internal because `+Lifecycle` (separate file) resets it
+  /// inside `stop()` and flips it inside `endFetchingChanges()`.
+  var profileIndexFetchedAtLeastOnce: Bool = false
+
+  /// Per-session flag — set true inside the delegate zone-fetch path
+  /// when the `profile-index` zone ID is observed, regardless of whether
+  /// records were applied. Flushed into `profileIndexFetchedAtLeastOnce`
+  /// inside `endFetchingChanges()`. Reset inside `beginFetchingChanges()`.
+  var fetchSessionTouchedIndexZone = false
+
   /// Cached profile data handlers, keyed by profile UUID.
   var dataHandlers: [UUID: ProfileDataSyncHandler] = [:]
 

--- a/Features/Profiles/ProfileStore.swift
+++ b/Features/Profiles/ProfileStore.swift
@@ -50,7 +50,15 @@ final class ProfileStore {
   let defaults: UserDefaults
   let validator: (any ServerValidator)?
   let containerManager: ProfileContainerManager?
+  private let syncCoordinator: SyncCoordinator?
   let logger = Logger(subsystem: "com.moolah.app", category: "ProfileStore")
+
+  /// Pass-through to ``SyncCoordinator/iCloudAvailability``. `.unknown`
+  /// when no coordinator was injected (tests, previews). View code (e.g.
+  /// `WelcomeView`) reads this rather than reaching into the sync layer.
+  var iCloudAvailability: ICloudAvailability {
+    syncCoordinator?.iCloudAvailability ?? .unknown
+  }
 
   /// Combined list of all profiles from both backends.
   var profiles: [Profile] {
@@ -68,11 +76,13 @@ final class ProfileStore {
   init(
     defaults: UserDefaults = .standard,
     validator: (any ServerValidator)? = nil,
-    containerManager: ProfileContainerManager? = nil
+    containerManager: ProfileContainerManager? = nil,
+    syncCoordinator: SyncCoordinator? = nil
   ) {
     self.defaults = defaults
     self.validator = validator
     self.containerManager = containerManager
+    self.syncCoordinator = syncCoordinator
     loadFromDefaults()
     if containerManager != nil {
       loadCloudProfiles(isInitialLoad: true)

--- a/MoolahTests/Features/ProfileStoreAvailabilityTests.swift
+++ b/MoolahTests/Features/ProfileStoreAvailabilityTests.swift
@@ -1,0 +1,41 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("ProfileStore — iCloudAvailability passthrough")
+@MainActor
+struct ProfileStoreAvailabilityTests {
+  private func makeDefaults() throws -> UserDefaults {
+    let suiteName = "com.moolah.test.\(UUID().uuidString)"
+    let defaults = try #require(UserDefaults(suiteName: suiteName))
+    defaults.removePersistentDomain(forName: suiteName)
+    return defaults
+  }
+
+  @Test("mirrors SyncCoordinator.iCloudAvailability")
+  func mirrors() throws {
+    let manager = try ProfileContainerManager.forTesting()
+    let coordinator = SyncCoordinator(
+      containerManager: manager,
+      isCloudKitAvailable: true
+    )
+    let store = ProfileStore(
+      defaults: try makeDefaults(),
+      containerManager: manager,
+      syncCoordinator: coordinator
+    )
+
+    coordinator.iCloudAvailability = .unavailable(reason: .notSignedIn)
+    #expect(store.iCloudAvailability == .unavailable(reason: .notSignedIn))
+
+    coordinator.iCloudAvailability = .available
+    #expect(store.iCloudAvailability == .available)
+  }
+
+  @Test("returns .unknown when no coordinator is injected")
+  func defaultsUnknown() throws {
+    let store = ProfileStore(defaults: try makeDefaults())
+    #expect(store.iCloudAvailability == .unknown)
+  }
+}

--- a/MoolahTests/Sync/SyncCoordinatorProfileIndexFetchTests.swift
+++ b/MoolahTests/Sync/SyncCoordinatorProfileIndexFetchTests.swift
@@ -1,0 +1,35 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("SyncCoordinator — profileIndexFetchedAtLeastOnce")
+@MainActor
+struct SyncCoordinatorProfileIndexFetchTests {
+
+  @Test("initial value is false")
+  func initialValue() throws {
+    let manager = try ProfileContainerManager.forTesting()
+    let coordinator = SyncCoordinator(
+      containerManager: manager,
+      isCloudKitAvailable: true
+    )
+    #expect(coordinator.profileIndexFetchedAtLeastOnce == false)
+  }
+
+  @Test("fetchSessionTouchedIndexZone starts false on each beginFetchingChanges")
+  func sessionFlagResetsOnBegin() throws {
+    let manager = try ProfileContainerManager.forTesting()
+    let coordinator = SyncCoordinator(
+      containerManager: manager,
+      isCloudKitAvailable: true
+    )
+
+    coordinator.beginFetchingChanges()
+    coordinator.fetchSessionTouchedIndexZone = true
+    coordinator.endFetchingChanges()
+
+    coordinator.beginFetchingChanges()
+    #expect(coordinator.fetchSessionTouchedIndexZone == false)
+  }
+}


### PR DESCRIPTION
## Summary

Implements Task 5 of [`plans/2026-04-24-first-run-experience-implementation.md`](https://github.com/ajsutton/moolah-native/blob/main/plans/2026-04-24-first-run-experience-implementation.md). Builds on [#423](https://github.com/ajsutton/moolah-native/pull/423) (Task 4).

Adds two flags on `SyncCoordinator`:

- `profileIndexFetchedAtLeastOnce: Bool` (initial `false`) — WelcomeView uses this to swap "Checking iCloud…" for "No profiles in iCloud yet." once the index zone has been observed. Task 7 will flip it.
- `fetchSessionTouchedIndexZone: Bool` (per-session) — will be set by the delegate in Task 6 when the profile-index zone is observed during a fetch, even if empty.

`beginFetchingChanges()` clears the per-session flag; `stop()` resets both.

## Plan divergence

Plan called for `private(set)`, but Swift's `private` restricts to the declaring file, which blocks the legitimate writes from `+Lifecycle` (separate file). Using plain `var` with a comment explaining why.

## Test plan

- [x] `just test SyncCoordinatorProfileIndexFetchTests` — 2 green
- [x] Sync regression tests — 24 green
- [x] `just format-check` — clean