### PR TITLE
feat(sync): flip profileIndexFetchedAtLeastOnce after first index fetch

### DIFF
--- a/Backends/CloudKit/Sync/SyncCoordinator+Delegate.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+Delegate.swift
@@ -45,8 +45,13 @@ extension SyncCoordinator: CKSyncEngineDelegate {
     case .didFetchChanges:
       endFetchingChanges()
 
-    case .sentDatabaseChanges,
-      .willFetchRecordZoneChanges, .didFetchRecordZoneChanges,
+    case .didFetchRecordZoneChanges(let event):
+      // Fires even when the fetch returned zero changes, so the
+      // "Checking iCloud…" → "No profiles in iCloud yet." transition
+      // is possible for first-run users with an empty index zone.
+      markZoneFetched(event.zoneID)
+
+    case .sentDatabaseChanges, .willFetchRecordZoneChanges,
       .willSendChanges, .didSendChanges:
       break
 

--- a/Backends/CloudKit/Sync/SyncCoordinator+Lifecycle.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+Lifecycle.swift
@@ -152,6 +152,8 @@ extension SyncCoordinator {
     // remains correct — a rebuild of the coordinator would be needed to clear it.
     iCloudAvailability =
       isCloudKitAvailable ? .unknown : .unavailable(reason: .entitlementsMissing)
+    profileIndexFetchedAtLeastOnce = false
+    fetchSessionTouchedIndexZone = false
     logger.info("Stopped unified sync coordinator")
   }
 
@@ -211,6 +213,7 @@ extension SyncCoordinator {
     isFetchingChanges = true
     fetchSessionChangedTypes.removeAll()
     fetchSessionIndexChanged = false
+    fetchSessionTouchedIndexZone = false
   }
 
   func endFetchingChanges() {

--- a/Backends/CloudKit/Sync/SyncCoordinator+Lifecycle.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+Lifecycle.swift
@@ -216,6 +216,23 @@ extension SyncCoordinator {
     fetchSessionTouchedIndexZone = false
   }
 
+  /// Called from the delegate zone-fetch event path. If the zone ID is the
+  /// profile-index zone, sets `fetchSessionTouchedIndexZone = true` so
+  /// `endFetchingChanges()` can flip `profileIndexFetchedAtLeastOnce`
+  /// once we've definitively heard back from iCloud (Task 7).
+  ///
+  /// Guarded on `isFetchingChanges` so a stray `.didFetchRecordZoneChanges`
+  /// outside a `willFetchChanges` / `didFetchChanges` envelope (e.g. a
+  /// recovery re-fetch after `.zoneNotFound`) doesn't land on a stale
+  /// session — the flag would otherwise be cleared by the next
+  /// `endFetchingChanges()` before Task 7's flip could observe it.
+  func markZoneFetched(_ zoneID: CKRecordZone.ID) {
+    guard isFetchingChanges else { return }
+    if SyncCoordinator.parseZone(zoneID) == .profileIndex {
+      fetchSessionTouchedIndexZone = true
+    }
+  }
+
   func endFetchingChanges() {
     isFetchingChanges = false
     let profileCount = fetchSessionChangedTypes.filter { !$0.value.isEmpty }.count

--- a/Backends/CloudKit/Sync/SyncCoordinator+Lifecycle.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+Lifecycle.swift
@@ -243,6 +243,11 @@ extension SyncCoordinator {
       "Fetch session complete: \(profileCount) profiles changed, types: \(totalTypes), indexChanged: \(self.fetchSessionIndexChanged)"
     )
     flushFetchSessionChanges()
+    if fetchSessionTouchedIndexZone && !profileIndexFetchedAtLeastOnce {
+      profileIndexFetchedAtLeastOnce = true
+      logger.info("profileIndexFetchedAtLeastOnce flipped true")
+    }
+    fetchSessionTouchedIndexZone = false
   }
 
   private func flushFetchSessionChanges() {

--- a/Backends/CloudKit/Sync/SyncCoordinator.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator.swift
@@ -257,6 +257,21 @@ final class SyncCoordinator {
   /// Whether the profile-index zone had changes during the current fetch session.
   var fetchSessionIndexChanged = false
 
+  /// True once the `profile-index` zone has been fetched (even empty-handed)
+  /// at least once since the last `start()`. `WelcomeView` uses this to
+  /// swap "Checking iCloud…" for "No profiles in iCloud yet." once we
+  /// know the answer. Must NOT flip on fetches that only touched
+  /// `profile-data` zones. See design spec §6.2.
+  /// Writable-internal because `+Lifecycle` (separate file) resets it
+  /// inside `stop()` and flips it inside `endFetchingChanges()`.
+  var profileIndexFetchedAtLeastOnce: Bool = false
+
+  /// Per-session flag — set true inside the delegate zone-fetch path
+  /// when the `profile-index` zone ID is observed, regardless of whether
+  /// records were applied. Flushed into `profileIndexFetchedAtLeastOnce`
+  /// inside `endFetchingChanges()`. Reset inside `beginFetchingChanges()`.
+  var fetchSessionTouchedIndexZone = false
+
   /// Cached profile data handlers, keyed by profile UUID.
   var dataHandlers: [UUID: ProfileDataSyncHandler] = [:]
 

--- a/MoolahTests/Sync/SyncCoordinatorProfileIndexFetchTests.swift
+++ b/MoolahTests/Sync/SyncCoordinatorProfileIndexFetchTests.swift
@@ -1,0 +1,35 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("SyncCoordinator — profileIndexFetchedAtLeastOnce")
+@MainActor
+struct SyncCoordinatorProfileIndexFetchTests {
+
+  @Test("initial value is false")
+  func initialValue() throws {
+    let manager = try ProfileContainerManager.forTesting()
+    let coordinator = SyncCoordinator(
+      containerManager: manager,
+      isCloudKitAvailable: true
+    )
+    #expect(coordinator.profileIndexFetchedAtLeastOnce == false)
+  }
+
+  @Test("fetchSessionTouchedIndexZone starts false on each beginFetchingChanges")
+  func sessionFlagResetsOnBegin() throws {
+    let manager = try ProfileContainerManager.forTesting()
+    let coordinator = SyncCoordinator(
+      containerManager: manager,
+      isCloudKitAvailable: true
+    )
+
+    coordinator.beginFetchingChanges()
+    coordinator.fetchSessionTouchedIndexZone = true
+    coordinator.endFetchingChanges()
+
+    coordinator.beginFetchingChanges()
+    #expect(coordinator.fetchSessionTouchedIndexZone == false)
+  }
+}

--- a/MoolahTests/Sync/SyncCoordinatorProfileIndexFetchTests.swift
+++ b/MoolahTests/Sync/SyncCoordinatorProfileIndexFetchTests.swift
@@ -1,3 +1,4 @@
+import CloudKit
 import Foundation
 import Testing
 
@@ -30,6 +31,54 @@ struct SyncCoordinatorProfileIndexFetchTests {
     coordinator.endFetchingChanges()
 
     coordinator.beginFetchingChanges()
+    #expect(coordinator.fetchSessionTouchedIndexZone == false)
+  }
+
+  @Test("markZoneFetched flips session flag true for index zone")
+  func touchedFlagSetOnIndexZone() throws {
+    let manager = try ProfileContainerManager.forTesting()
+    let coordinator = SyncCoordinator(
+      containerManager: manager,
+      isCloudKitAvailable: true
+    )
+    let indexZoneID = coordinator.profileIndexHandler.zoneID
+
+    coordinator.beginFetchingChanges()
+    coordinator.markZoneFetched(indexZoneID)
+    #expect(coordinator.fetchSessionTouchedIndexZone == true)
+  }
+
+  @Test("markZoneFetched leaves session flag false for profile-data zone")
+  func touchedFlagIgnoresDataZone() throws {
+    let manager = try ProfileContainerManager.forTesting()
+    let coordinator = SyncCoordinator(
+      containerManager: manager,
+      isCloudKitAvailable: true
+    )
+    let dataZoneID = CKRecordZone.ID(
+      zoneName: "profile-\(UUID().uuidString)",
+      ownerName: CKCurrentUserDefaultName
+    )
+
+    coordinator.beginFetchingChanges()
+    coordinator.markZoneFetched(dataZoneID)
+    #expect(coordinator.fetchSessionTouchedIndexZone == false)
+  }
+
+  @Test("markZoneFetched leaves session flag false for unknown zone")
+  func touchedFlagIgnoresUnknownZone() throws {
+    let manager = try ProfileContainerManager.forTesting()
+    let coordinator = SyncCoordinator(
+      containerManager: manager,
+      isCloudKitAvailable: true
+    )
+    let unknownZoneID = CKRecordZone.ID(
+      zoneName: "some-other-zone",
+      ownerName: CKCurrentUserDefaultName
+    )
+
+    coordinator.beginFetchingChanges()
+    coordinator.markZoneFetched(unknownZoneID)
     #expect(coordinator.fetchSessionTouchedIndexZone == false)
   }
 }

--- a/MoolahTests/Sync/SyncCoordinatorProfileIndexFetchTests.swift
+++ b/MoolahTests/Sync/SyncCoordinatorProfileIndexFetchTests.swift
@@ -81,4 +81,63 @@ struct SyncCoordinatorProfileIndexFetchTests {
     coordinator.markZoneFetched(unknownZoneID)
     #expect(coordinator.fetchSessionTouchedIndexZone == false)
   }
+
+  @Test("profileIndexFetchedAtLeastOnce flips after first session that touched index zone")
+  func flipsOnFirstIndexSession() throws {
+    let manager = try ProfileContainerManager.forTesting()
+    let coordinator = SyncCoordinator(
+      containerManager: manager,
+      isCloudKitAvailable: true
+    )
+    let indexZoneID = coordinator.profileIndexHandler.zoneID
+
+    coordinator.beginFetchingChanges()
+    coordinator.markZoneFetched(indexZoneID)
+    coordinator.endFetchingChanges()
+
+    #expect(coordinator.profileIndexFetchedAtLeastOnce == true)
+  }
+
+  @Test("profileIndexFetchedAtLeastOnce stays false when only profile-data zones fetched")
+  func staysFalseOnDataOnlySession() throws {
+    let manager = try ProfileContainerManager.forTesting()
+    let coordinator = SyncCoordinator(
+      containerManager: manager,
+      isCloudKitAvailable: true
+    )
+    let dataZoneID = CKRecordZone.ID(
+      zoneName: "profile-\(UUID().uuidString)",
+      ownerName: CKCurrentUserDefaultName
+    )
+
+    coordinator.beginFetchingChanges()
+    coordinator.markZoneFetched(dataZoneID)
+    coordinator.endFetchingChanges()
+
+    #expect(coordinator.profileIndexFetchedAtLeastOnce == false)
+  }
+
+  @Test("profileIndexFetchedAtLeastOnce stays true once set")
+  func remainsTrue() throws {
+    let manager = try ProfileContainerManager.forTesting()
+    let coordinator = SyncCoordinator(
+      containerManager: manager,
+      isCloudKitAvailable: true
+    )
+    let indexZoneID = coordinator.profileIndexHandler.zoneID
+    let dataZoneID = CKRecordZone.ID(
+      zoneName: "profile-\(UUID().uuidString)",
+      ownerName: CKCurrentUserDefaultName
+    )
+
+    coordinator.beginFetchingChanges()
+    coordinator.markZoneFetched(indexZoneID)
+    coordinator.endFetchingChanges()
+
+    coordinator.beginFetchingChanges()
+    coordinator.markZoneFetched(dataZoneID)
+    coordinator.endFetchingChanges()
+
+    #expect(coordinator.profileIndexFetchedAtLeastOnce == true)
+  }
 }


### PR DESCRIPTION
## Summary

Implements Task 7 of [`plans/2026-04-24-first-run-experience-implementation.md`](https://github.com/ajsutton/moolah-native/blob/main/plans/2026-04-24-first-run-experience-implementation.md). Builds on [#425](https://github.com/ajsutton/moolah-native/pull/425) (Task 6).

`endFetchingChanges()` now flips `profileIndexFetchedAtLeastOnce` to `true` once a session has completed in which the profile-index zone was fetched (empty or not). Sessions that only touched profile-data zones don't flip the flag. Once set, it stays true for the lifetime of the coordinator (reset only via `stop()`).

This unlocks the `WelcomeView` "Checking iCloud…" → "No profiles in iCloud yet." transition for first-run users with an empty iCloud index zone.

## Test plan

- [x] `just test SyncCoordinatorProfileIndexFetchTests` — 8 green (adds 3 tests for the flip behaviour)
- [x] `just test SyncCoordinatorTests` — 12 green (regression)
- [x] `just format-check` — clean