### PR TITLE
feat(profiles): suppress auto-activate when WelcomeView is mid-create

### DIFF
--- a/Backends/CloudKit/Sync/SyncCoordinator+Delegate.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+Delegate.swift
@@ -45,8 +45,13 @@ extension SyncCoordinator: CKSyncEngineDelegate {
     case .didFetchChanges:
       endFetchingChanges()
 
-    case .sentDatabaseChanges,
-      .willFetchRecordZoneChanges, .didFetchRecordZoneChanges,
+    case .didFetchRecordZoneChanges(let event):
+      // Fires even when the fetch returned zero changes, so the
+      // "Checking iCloud…" → "No profiles in iCloud yet." transition
+      // is possible for first-run users with an empty index zone.
+      markZoneFetched(event.zoneID)
+
+    case .sentDatabaseChanges, .willFetchRecordZoneChanges,
       .willSendChanges, .didSendChanges:
       break
 

--- a/Backends/CloudKit/Sync/SyncCoordinator+Lifecycle.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+Lifecycle.swift
@@ -152,6 +152,8 @@ extension SyncCoordinator {
     // remains correct — a rebuild of the coordinator would be needed to clear it.
     iCloudAvailability =
       isCloudKitAvailable ? .unknown : .unavailable(reason: .entitlementsMissing)
+    profileIndexFetchedAtLeastOnce = false
+    fetchSessionTouchedIndexZone = false
     logger.info("Stopped unified sync coordinator")
   }
 
@@ -211,6 +213,7 @@ extension SyncCoordinator {
     isFetchingChanges = true
     fetchSessionChangedTypes.removeAll()
     fetchSessionIndexChanged = false
+    fetchSessionTouchedIndexZone = false
   }
 
   func endFetchingChanges() {

--- a/Backends/CloudKit/Sync/SyncCoordinator+Lifecycle.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+Lifecycle.swift
@@ -216,6 +216,23 @@ extension SyncCoordinator {
     fetchSessionTouchedIndexZone = false
   }
 
+  /// Called from the delegate zone-fetch event path. If the zone ID is the
+  /// profile-index zone, sets `fetchSessionTouchedIndexZone = true` so
+  /// `endFetchingChanges()` can flip `profileIndexFetchedAtLeastOnce`
+  /// once we've definitively heard back from iCloud (Task 7).
+  ///
+  /// Guarded on `isFetchingChanges` so a stray `.didFetchRecordZoneChanges`
+  /// outside a `willFetchChanges` / `didFetchChanges` envelope (e.g. a
+  /// recovery re-fetch after `.zoneNotFound`) doesn't land on a stale
+  /// session — the flag would otherwise be cleared by the next
+  /// `endFetchingChanges()` before Task 7's flip could observe it.
+  func markZoneFetched(_ zoneID: CKRecordZone.ID) {
+    guard isFetchingChanges else { return }
+    if SyncCoordinator.parseZone(zoneID) == .profileIndex {
+      fetchSessionTouchedIndexZone = true
+    }
+  }
+
   func endFetchingChanges() {
     isFetchingChanges = false
     let profileCount = fetchSessionChangedTypes.filter { !$0.value.isEmpty }.count

--- a/Backends/CloudKit/Sync/SyncCoordinator+Lifecycle.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+Lifecycle.swift
@@ -243,6 +243,11 @@ extension SyncCoordinator {
       "Fetch session complete: \(profileCount) profiles changed, types: \(totalTypes), indexChanged: \(self.fetchSessionIndexChanged)"
     )
     flushFetchSessionChanges()
+    if fetchSessionTouchedIndexZone && !profileIndexFetchedAtLeastOnce {
+      profileIndexFetchedAtLeastOnce = true
+      logger.info("profileIndexFetchedAtLeastOnce flipped true")
+    }
+    fetchSessionTouchedIndexZone = false
   }
 
   private func flushFetchSessionChanges() {

--- a/Backends/CloudKit/Sync/SyncCoordinator.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator.swift
@@ -257,6 +257,21 @@ final class SyncCoordinator {
   /// Whether the profile-index zone had changes during the current fetch session.
   var fetchSessionIndexChanged = false
 
+  /// True once the `profile-index` zone has been fetched (even empty-handed)
+  /// at least once since the last `start()`. `WelcomeView` uses this to
+  /// swap "Checking iCloud…" for "No profiles in iCloud yet." once we
+  /// know the answer. Must NOT flip on fetches that only touched
+  /// `profile-data` zones. See design spec §6.2.
+  /// Writable-internal because `+Lifecycle` (separate file) resets it
+  /// inside `stop()` and flips it inside `endFetchingChanges()`.
+  var profileIndexFetchedAtLeastOnce: Bool = false
+
+  /// Per-session flag — set true inside the delegate zone-fetch path
+  /// when the `profile-index` zone ID is observed, regardless of whether
+  /// records were applied. Flushed into `profileIndexFetchedAtLeastOnce`
+  /// inside `endFetchingChanges()`. Reset inside `beginFetchingChanges()`.
+  var fetchSessionTouchedIndexZone = false
+
   /// Cached profile data handlers, keyed by profile UUID.
   var dataHandlers: [UUID: ProfileDataSyncHandler] = [:]
 

--- a/Features/Profiles/ProfileStore+Cloud.swift
+++ b/Features/Profiles/ProfileStore+Cloud.swift
@@ -30,11 +30,14 @@ extension ProfileStore {
       }
 
       // Auto-select a profile when none is active (e.g. new device receiving
-      // its first cloud profile from another device).
-      if activeProfileID == nil, let first = profiles.first {
+      // its first cloud profile from another device). Suppressed when
+      // `WelcomeView` is mid-create — see design spec §3.3 race condition.
+      if activeProfileID == nil, let first = profiles.first, welcomePhase != .creating {
         self.activeProfileID = first.id
         saveActiveProfileID()
         logger.debug("Auto-selected profile: \(first.id)")
+      } else if welcomePhase == .creating {
+        logger.debug("Skipped auto-select — welcomePhase == .creating")
       }
 
       // Handle profiles deleted on another device.

--- a/Features/Profiles/ProfileStore.swift
+++ b/Features/Profiles/ProfileStore.swift
@@ -23,6 +23,19 @@ final class ProfileStore {
   var isValidating = false
   var validationError: String?
 
+  /// Signal from `WelcomeView` about which interaction phase is on screen.
+  /// When `.creating`, `loadCloudProfiles` suppresses its auto-activate
+  /// behaviour so a single profile arriving from iCloud doesn't race the
+  /// user's in-flight "Create Profile" tap. Cleared (`nil`) when
+  /// `WelcomeView` unmounts. See design spec §3.3, §8.
+  enum WelcomePhase: Sendable {
+    case landing
+    case creating
+    case pickingProfile
+  }
+
+  var welcomePhase: WelcomePhase?
+
   /// True while the initial cloud profile load may still be retrying.
   /// SwiftData with CloudKit may not have its store ready on the first fetch.
   var isCloudLoadPending = false

--- a/MoolahTests/Features/ProfileStoreAutoActivateGuardTests.swift
+++ b/MoolahTests/Features/ProfileStoreAutoActivateGuardTests.swift
@@ -1,0 +1,78 @@
+import Foundation
+import SwiftData
+import Testing
+
+@testable import Moolah
+
+@Suite("ProfileStore — auto-activate guard")
+@MainActor
+struct ProfileStoreAutoActivateGuardTests {
+  private func makeDefaults() throws -> UserDefaults {
+    let suiteName = "com.moolah.test.\(UUID().uuidString)"
+    let defaults = try #require(UserDefaults(suiteName: suiteName))
+    defaults.removePersistentDomain(forName: suiteName)
+    return defaults
+  }
+
+  private func seedCloudProfile(
+    _ container: ProfileContainerManager
+  ) throws -> Profile {
+    let profile = Profile(
+      id: UUID(),
+      label: "Household",
+      backendType: .cloudKit,
+      currencyCode: "AUD",
+      financialYearStartMonth: 7
+    )
+    let context = ModelContext(container.indexContainer)
+    context.insert(ProfileRecord.from(profile: profile))
+    try context.save()
+    return profile
+  }
+
+  @Test("loadCloudProfiles auto-activates when welcomePhase == .landing")
+  func autoActivatesWhenLanding() throws {
+    let manager = try ProfileContainerManager.forTesting()
+    let store = ProfileStore(
+      defaults: try makeDefaults(),
+      containerManager: manager
+    )
+    let profile = try seedCloudProfile(manager)
+    store.welcomePhase = .landing
+
+    store.loadCloudProfiles()
+
+    #expect(store.activeProfileID == profile.id)
+  }
+
+  @Test("loadCloudProfiles does NOT auto-activate when welcomePhase == .creating")
+  func doesNotAutoActivateWhenCreating() throws {
+    let manager = try ProfileContainerManager.forTesting()
+    let store = ProfileStore(
+      defaults: try makeDefaults(),
+      containerManager: manager
+    )
+    _ = try seedCloudProfile(manager)
+    store.welcomePhase = .creating
+
+    store.loadCloudProfiles()
+
+    #expect(store.activeProfileID == nil)
+    #expect(store.cloudProfiles.count == 1)
+  }
+
+  @Test("loadCloudProfiles auto-activates when welcomePhase is nil")
+  func autoActivatesWhenPhaseNil() throws {
+    let manager = try ProfileContainerManager.forTesting()
+    let store = ProfileStore(
+      defaults: try makeDefaults(),
+      containerManager: manager
+    )
+    let profile = try seedCloudProfile(manager)
+    store.welcomePhase = nil
+
+    store.loadCloudProfiles()
+
+    #expect(store.activeProfileID == profile.id)
+  }
+}

--- a/MoolahTests/Sync/SyncCoordinatorProfileIndexFetchTests.swift
+++ b/MoolahTests/Sync/SyncCoordinatorProfileIndexFetchTests.swift
@@ -1,0 +1,35 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("SyncCoordinator — profileIndexFetchedAtLeastOnce")
+@MainActor
+struct SyncCoordinatorProfileIndexFetchTests {
+
+  @Test("initial value is false")
+  func initialValue() throws {
+    let manager = try ProfileContainerManager.forTesting()
+    let coordinator = SyncCoordinator(
+      containerManager: manager,
+      isCloudKitAvailable: true
+    )
+    #expect(coordinator.profileIndexFetchedAtLeastOnce == false)
+  }
+
+  @Test("fetchSessionTouchedIndexZone starts false on each beginFetchingChanges")
+  func sessionFlagResetsOnBegin() throws {
+    let manager = try ProfileContainerManager.forTesting()
+    let coordinator = SyncCoordinator(
+      containerManager: manager,
+      isCloudKitAvailable: true
+    )
+
+    coordinator.beginFetchingChanges()
+    coordinator.fetchSessionTouchedIndexZone = true
+    coordinator.endFetchingChanges()
+
+    coordinator.beginFetchingChanges()
+    #expect(coordinator.fetchSessionTouchedIndexZone == false)
+  }
+}

--- a/MoolahTests/Sync/SyncCoordinatorProfileIndexFetchTests.swift
+++ b/MoolahTests/Sync/SyncCoordinatorProfileIndexFetchTests.swift
@@ -1,3 +1,4 @@
+import CloudKit
 import Foundation
 import Testing
 
@@ -30,6 +31,54 @@ struct SyncCoordinatorProfileIndexFetchTests {
     coordinator.endFetchingChanges()
 
     coordinator.beginFetchingChanges()
+    #expect(coordinator.fetchSessionTouchedIndexZone == false)
+  }
+
+  @Test("markZoneFetched flips session flag true for index zone")
+  func touchedFlagSetOnIndexZone() throws {
+    let manager = try ProfileContainerManager.forTesting()
+    let coordinator = SyncCoordinator(
+      containerManager: manager,
+      isCloudKitAvailable: true
+    )
+    let indexZoneID = coordinator.profileIndexHandler.zoneID
+
+    coordinator.beginFetchingChanges()
+    coordinator.markZoneFetched(indexZoneID)
+    #expect(coordinator.fetchSessionTouchedIndexZone == true)
+  }
+
+  @Test("markZoneFetched leaves session flag false for profile-data zone")
+  func touchedFlagIgnoresDataZone() throws {
+    let manager = try ProfileContainerManager.forTesting()
+    let coordinator = SyncCoordinator(
+      containerManager: manager,
+      isCloudKitAvailable: true
+    )
+    let dataZoneID = CKRecordZone.ID(
+      zoneName: "profile-\(UUID().uuidString)",
+      ownerName: CKCurrentUserDefaultName
+    )
+
+    coordinator.beginFetchingChanges()
+    coordinator.markZoneFetched(dataZoneID)
+    #expect(coordinator.fetchSessionTouchedIndexZone == false)
+  }
+
+  @Test("markZoneFetched leaves session flag false for unknown zone")
+  func touchedFlagIgnoresUnknownZone() throws {
+    let manager = try ProfileContainerManager.forTesting()
+    let coordinator = SyncCoordinator(
+      containerManager: manager,
+      isCloudKitAvailable: true
+    )
+    let unknownZoneID = CKRecordZone.ID(
+      zoneName: "some-other-zone",
+      ownerName: CKCurrentUserDefaultName
+    )
+
+    coordinator.beginFetchingChanges()
+    coordinator.markZoneFetched(unknownZoneID)
     #expect(coordinator.fetchSessionTouchedIndexZone == false)
   }
 }

--- a/MoolahTests/Sync/SyncCoordinatorProfileIndexFetchTests.swift
+++ b/MoolahTests/Sync/SyncCoordinatorProfileIndexFetchTests.swift
@@ -81,4 +81,63 @@ struct SyncCoordinatorProfileIndexFetchTests {
     coordinator.markZoneFetched(unknownZoneID)
     #expect(coordinator.fetchSessionTouchedIndexZone == false)
   }
+
+  @Test("profileIndexFetchedAtLeastOnce flips after first session that touched index zone")
+  func flipsOnFirstIndexSession() throws {
+    let manager = try ProfileContainerManager.forTesting()
+    let coordinator = SyncCoordinator(
+      containerManager: manager,
+      isCloudKitAvailable: true
+    )
+    let indexZoneID = coordinator.profileIndexHandler.zoneID
+
+    coordinator.beginFetchingChanges()
+    coordinator.markZoneFetched(indexZoneID)
+    coordinator.endFetchingChanges()
+
+    #expect(coordinator.profileIndexFetchedAtLeastOnce == true)
+  }
+
+  @Test("profileIndexFetchedAtLeastOnce stays false when only profile-data zones fetched")
+  func staysFalseOnDataOnlySession() throws {
+    let manager = try ProfileContainerManager.forTesting()
+    let coordinator = SyncCoordinator(
+      containerManager: manager,
+      isCloudKitAvailable: true
+    )
+    let dataZoneID = CKRecordZone.ID(
+      zoneName: "profile-\(UUID().uuidString)",
+      ownerName: CKCurrentUserDefaultName
+    )
+
+    coordinator.beginFetchingChanges()
+    coordinator.markZoneFetched(dataZoneID)
+    coordinator.endFetchingChanges()
+
+    #expect(coordinator.profileIndexFetchedAtLeastOnce == false)
+  }
+
+  @Test("profileIndexFetchedAtLeastOnce stays true once set")
+  func remainsTrue() throws {
+    let manager = try ProfileContainerManager.forTesting()
+    let coordinator = SyncCoordinator(
+      containerManager: manager,
+      isCloudKitAvailable: true
+    )
+    let indexZoneID = coordinator.profileIndexHandler.zoneID
+    let dataZoneID = CKRecordZone.ID(
+      zoneName: "profile-\(UUID().uuidString)",
+      ownerName: CKCurrentUserDefaultName
+    )
+
+    coordinator.beginFetchingChanges()
+    coordinator.markZoneFetched(indexZoneID)
+    coordinator.endFetchingChanges()
+
+    coordinator.beginFetchingChanges()
+    coordinator.markZoneFetched(dataZoneID)
+    coordinator.endFetchingChanges()
+
+    #expect(coordinator.profileIndexFetchedAtLeastOnce == true)
+  }
 }


### PR DESCRIPTION
## Summary

Implements Task 8 of [`plans/2026-04-24-first-run-experience-implementation.md`](https://github.com/ajsutton/moolah-native/blob/main/plans/2026-04-24-first-run-experience-implementation.md). Builds on [#426](https://github.com/ajsutton/moolah-native/pull/426) (Task 7).

- Adds `ProfileStore.WelcomePhase` (`landing` / `creating` / `pickingProfile`) and a `welcomePhase: WelcomePhase?` property.
- `loadCloudProfiles` skips its auto-select block when `welcomePhase == .creating` so a single cloud profile arriving mid-form doesn't race the user's "Create Profile" tap.

Design spec §3.3, §8.

## Test plan

- [x] `just test ProfileStoreAutoActivateGuardTests` — 3 green
- [x] `just test ProfileStoreTests ProfileStoreAvailabilityTests` — 17 green (regression)
- [x] `just format-check` — clean