### PR TITLE
feat(profiles): add WelcomeHero + iCloud status/off chips

### DIFF
--- a/Backends/CloudKit/Sync/SyncCoordinator+Lifecycle.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+Lifecycle.swift
@@ -243,6 +243,11 @@ extension SyncCoordinator {
       "Fetch session complete: \(profileCount) profiles changed, types: \(totalTypes), indexChanged: \(self.fetchSessionIndexChanged)"
     )
     flushFetchSessionChanges()
+    if fetchSessionTouchedIndexZone && !profileIndexFetchedAtLeastOnce {
+      profileIndexFetchedAtLeastOnce = true
+      logger.info("profileIndexFetchedAtLeastOnce flipped true")
+    }
+    fetchSessionTouchedIndexZone = false
   }
 
   private func flushFetchSessionChanges() {

--- a/Features/Profiles/ProfileStore+Cloud.swift
+++ b/Features/Profiles/ProfileStore+Cloud.swift
@@ -30,11 +30,14 @@ extension ProfileStore {
       }
 
       // Auto-select a profile when none is active (e.g. new device receiving
-      // its first cloud profile from another device).
-      if activeProfileID == nil, let first = profiles.first {
+      // its first cloud profile from another device). Suppressed when
+      // `WelcomeView` is mid-create — see design spec §3.3 race condition.
+      if activeProfileID == nil, let first = profiles.first, welcomePhase != .creating {
         self.activeProfileID = first.id
         saveActiveProfileID()
         logger.debug("Auto-selected profile: \(first.id)")
+      } else if welcomePhase == .creating {
+        logger.debug("Skipped auto-select — welcomePhase == .creating")
       }
 
       // Handle profiles deleted on another device.

--- a/Features/Profiles/ProfileStore.swift
+++ b/Features/Profiles/ProfileStore.swift
@@ -23,6 +23,19 @@ final class ProfileStore {
   var isValidating = false
   var validationError: String?
 
+  /// Signal from `WelcomeView` about which interaction phase is on screen.
+  /// When `.creating`, `loadCloudProfiles` suppresses its auto-activate
+  /// behaviour so a single profile arriving from iCloud doesn't race the
+  /// user's in-flight "Create Profile" tap. Cleared (`nil`) when
+  /// `WelcomeView` unmounts. See design spec §3.3, §8.
+  enum WelcomePhase: Sendable {
+    case landing
+    case creating
+    case pickingProfile
+  }
+
+  var welcomePhase: WelcomePhase?
+
   /// True while the initial cloud profile load may still be retrying.
   /// SwiftData with CloudKit may not have its store ready on the first fetch.
   var isCloudLoadPending = false

--- a/Features/Profiles/Views/ICloudOffChip.swift
+++ b/Features/Profiles/Views/ICloudOffChip.swift
@@ -1,0 +1,75 @@
+import SwiftUI
+
+/// Inline chip shown under the hero CTA in state 4 (iCloud unavailable).
+/// Explains that the profile will be local and links to System Settings.
+///
+/// `openSettingsAction` performs the platform-appropriate deep link —
+/// wired by the host (`WelcomeView`, Task 13) so this view stays
+/// platform-agnostic.
+struct ICloudOffChip: View {
+  let openSettingsAction: () -> Void
+
+  var body: some View {
+    HStack(alignment: .top, spacing: 8) {
+      Image(systemName: "icloud.slash")
+        .foregroundStyle(WelcomeBrandColors.coralRed)
+        .font(.footnote)
+        .padding(.top, 2)
+      VStack(alignment: .leading, spacing: 3) {
+        Text("iCloud sync is off.", comment: "First-run iCloud-off chip title")
+          .font(.footnote.weight(.semibold))
+          .foregroundStyle(WelcomeBrandColors.coralRed)
+        HStack(spacing: 4) {
+          Text(
+            "Your profile will be saved on this device.",
+            comment: "First-run iCloud-off chip body"
+          )
+          .font(.footnote)
+          .foregroundStyle(WelcomeBrandColors.muted)
+          Button(action: openSettingsAction) {
+            Text("Open System Settings", comment: "First-run iCloud-off chip link")
+              .font(.footnote)
+              .underline()
+              .foregroundStyle(WelcomeBrandColors.lightBlue)
+              .frame(minHeight: 44)
+          }
+          .buttonStyle(.plain)
+        }
+      }
+    }
+    .padding(10)
+    .background(WelcomeBrandColors.coralRed.opacity(0.12))
+    .clipShape(.rect(cornerRadius: 8))
+    .accessibilityElement(children: .combine)
+    .accessibilityLabel(
+      "iCloud sync is off. Your profile will be saved on this device."
+    )
+    .accessibilityAction(named: "Open System Settings", openSettingsAction)
+  }
+}
+
+#Preview("ICloudOffChip") {
+  ZStack {
+    WelcomeBrandColors.space.ignoresSafeArea()
+    ICloudOffChip(openSettingsAction: {}).padding()
+  }
+  .frame(width: 360, height: 120)
+}
+
+#Preview("ICloudOffChip — dark") {
+  ZStack {
+    WelcomeBrandColors.space.ignoresSafeArea()
+    ICloudOffChip(openSettingsAction: {}).padding()
+  }
+  .frame(width: 360, height: 120)
+  .preferredColorScheme(.dark)
+}
+
+#Preview("ICloudOffChip — AX5") {
+  ZStack {
+    WelcomeBrandColors.space.ignoresSafeArea()
+    ICloudOffChip(openSettingsAction: {}).padding()
+  }
+  .frame(width: 500, height: 240)
+  .dynamicTypeSize(.accessibility5)
+}

--- a/Features/Profiles/Views/ICloudStatusLine.swift
+++ b/Features/Profiles/Views/ICloudStatusLine.swift
@@ -1,0 +1,74 @@
+import SwiftUI
+
+/// Quiet status line that sits under the hero CTA in state 1.
+/// Shows a spinner + "Checking iCloud for your profiles…" while we're
+/// waiting, swaps to "No profiles in iCloud yet." once a fetch has
+/// completed empty. Never visible in state 4 (iCloud unavailable) —
+/// that's handled by ``ICloudOffChip``.
+struct ICloudStatusLine: View {
+  enum State: Equatable {
+    case checking
+    case noneFound
+  }
+
+  let state: State
+
+  var body: some View {
+    HStack(alignment: .firstTextBaseline, spacing: 8) {
+      if state == .checking {
+        ProgressView()
+          .controlSize(.small)
+          .tint(WelcomeBrandColors.lightBlue)
+      }
+      Text(label)
+        .font(.footnote)
+        .foregroundStyle(WelcomeBrandColors.muted)
+    }
+    .accessibilityElement(children: .combine)
+    .accessibilityLabel(label)
+    .accessibilityAddTraits(state == .checking ? .updatesFrequently : [])
+  }
+
+  private var label: String {
+    switch state {
+    case .checking:
+      String(localized: "Checking iCloud for your profiles…")
+    case .noneFound:
+      String(localized: "No profiles in iCloud yet.")
+    }
+  }
+}
+
+#Preview("Checking") {
+  ZStack {
+    WelcomeBrandColors.space.ignoresSafeArea()
+    ICloudStatusLine(state: .checking).padding()
+  }
+  .frame(width: 360, height: 100)
+}
+
+#Preview("None found") {
+  ZStack {
+    WelcomeBrandColors.space.ignoresSafeArea()
+    ICloudStatusLine(state: .noneFound).padding()
+  }
+  .frame(width: 360, height: 100)
+}
+
+#Preview("None found — dark") {
+  ZStack {
+    WelcomeBrandColors.space.ignoresSafeArea()
+    ICloudStatusLine(state: .noneFound).padding()
+  }
+  .frame(width: 360, height: 100)
+  .preferredColorScheme(.dark)
+}
+
+#Preview("Checking — AX5") {
+  ZStack {
+    WelcomeBrandColors.space.ignoresSafeArea()
+    ICloudStatusLine(state: .checking).padding()
+  }
+  .frame(width: 520, height: 180)
+  .dynamicTypeSize(.accessibility5)
+}

--- a/Features/Profiles/Views/WelcomeHero.swift
+++ b/Features/Profiles/Views/WelcomeHero.swift
@@ -1,0 +1,153 @@
+import SwiftUI
+
+/// Brand colour tokens for the first-run hero. Hex values are scoped to
+/// this file and the sibling `ICloudStatusLine` / `ICloudOffChip` /
+/// `ICloudArrivalBanner` per design spec §4.1 — never leaked to
+/// project-wide `Color` extensions.
+///
+/// **Access scope:** `internal` by convention — intended only for the
+/// sibling welcome views listed above. Do not consume elsewhere: the
+/// rest of the app uses semantic system colours per `guides/UI_GUIDE.md` §5.
+enum WelcomeBrandColors {
+  static let space = Color(red: 0x07 / 255, green: 0x10 / 255, blue: 0x2E / 255)
+  static let incomeBlue = Color(red: 0x1E / 255, green: 0x64 / 255, blue: 0xEE / 255)
+  static let balanceGold = Color(red: 0xFF / 255, green: 0xD5 / 255, blue: 0x6B / 255)
+  static let lightBlue = Color(red: 0x7A / 255, green: 0xBD / 255, blue: 0xFF / 255)
+  static let muted = Color(red: 0xAA / 255, green: 0xB4 / 255, blue: 0xC8 / 255)
+  static let coralRed = Color(red: 0xFF / 255, green: 0x78 / 255, blue: 0x7F / 255)
+}
+
+/// Branded hero used for first-run states 1 (welcome + checking) and 4
+/// (iCloud off). Content slot below the CTA receives either
+/// ``ICloudStatusLine`` (state 1) or ``ICloudOffChip`` (state 4).
+///
+/// Colour tokens come from `guides/BRAND_GUIDE.md` §3. Hardcoded hex is
+/// scoped to this file per design spec §4.1.
+struct WelcomeHero<Footer: View>: View {
+  let primaryAction: () -> Void
+  @ViewBuilder let footer: () -> Footer
+
+  @FocusState private var focus: Focus?
+
+  private enum Focus: Hashable {
+    case primaryCTA
+  }
+
+  var body: some View {
+    ZStack(alignment: .leading) {
+      WelcomeBrandColors.space.ignoresSafeArea()
+      heroContent
+    }
+    .task { focus = .primaryCTA }
+  }
+
+  private var heroContent: some View {
+    VStack(alignment: .leading, spacing: 0) {
+      Spacer(minLength: 48)
+      eyebrow
+      titleBlock
+      subhead
+      Spacer()
+      ctaButton
+      footer().frame(maxWidth: 320, alignment: .leading)
+      Spacer(minLength: 28)
+    }
+    .padding(.horizontal, 32)
+  }
+
+  private var eyebrow: some View {
+    Text("Moolah", comment: "First-run hero eyebrow label")
+      .font(.caption.weight(.medium))
+      .tracking(1.8)
+      .textCase(.uppercase)
+      .foregroundStyle(WelcomeBrandColors.balanceGold)
+      .accessibilityHidden(true)
+  }
+
+  private var titleBlock: some View {
+    VStack(alignment: .leading, spacing: 0) {
+      Text("Your money,", comment: "First-run hero title line 1")
+        .foregroundStyle(.white)
+      Text("rock solid.", comment: "First-run hero title line 2")
+        .foregroundStyle(WelcomeBrandColors.balanceGold)
+    }
+    .font(.largeTitle.bold())
+    .accessibilityElement(children: .combine)
+    .accessibilityLabel("Your money, rock solid.")
+    .accessibilityAddTraits(.isHeader)
+    .padding(.top, 10)
+  }
+
+  private var subhead: some View {
+    Text(
+      "Money stuff should be boring. Locked down, sorted out, taken care of — so the rest of your life doesn't have to be.",
+      comment: "First-run hero subhead"
+    )
+    .font(.body)
+    .foregroundStyle(WelcomeBrandColors.muted)
+    .lineLimit(nil)
+    .fixedSize(horizontal: false, vertical: true)
+    .frame(maxWidth: 320, alignment: .leading)
+    .padding(.top, 14)
+  }
+
+  private var ctaButton: some View {
+    Button(action: primaryAction) {
+      Text("Get started", comment: "First-run primary CTA")
+        .font(.headline)
+        .frame(maxWidth: 280)
+        .frame(minHeight: 44)
+    }
+    .buttonStyle(PrimaryHeroButtonStyle())
+    .focusable(true)
+    .focused($focus, equals: .primaryCTA)
+    .onKeyPress(.return) {
+      primaryAction()
+      return .handled
+    }
+    .padding(.bottom, 12)
+  }
+}
+
+private struct PrimaryHeroButtonStyle: ButtonStyle {
+  func makeBody(configuration: Configuration) -> some View {
+    configuration.label
+      .foregroundStyle(.white)
+      .padding(.vertical, 12)
+      .padding(.horizontal, 24)
+      .background(
+        WelcomeBrandColors.incomeBlue
+          .opacity(configuration.isPressed ? 0.85 : 1.0)
+      )
+      .clipShape(.rect(cornerRadius: 10))
+      .contentShape(.rect)
+  }
+}
+
+// The hero renders dark regardless of system colour scheme (always-dark
+// brand splash); the default/dark previews are intentionally near-identical.
+#Preview("WelcomeHero — default") {
+  WelcomeHero(
+    primaryAction: {},
+    footer: { ICloudStatusLine(state: .checking) }
+  )
+  .frame(width: 420, height: 560)
+}
+
+#Preview("WelcomeHero — dark") {
+  WelcomeHero(
+    primaryAction: {},
+    footer: { ICloudStatusLine(state: .checking) }
+  )
+  .frame(width: 420, height: 560)
+  .preferredColorScheme(.dark)
+}
+
+#Preview("WelcomeHero — AX5") {
+  WelcomeHero(
+    primaryAction: {},
+    footer: { ICloudStatusLine(state: .noneFound) }
+  )
+  .frame(width: 500, height: 720)
+  .dynamicTypeSize(.accessibility5)
+}

--- a/MoolahTests/Features/ProfileStoreAutoActivateGuardTests.swift
+++ b/MoolahTests/Features/ProfileStoreAutoActivateGuardTests.swift
@@ -1,0 +1,78 @@
+import Foundation
+import SwiftData
+import Testing
+
+@testable import Moolah
+
+@Suite("ProfileStore — auto-activate guard")
+@MainActor
+struct ProfileStoreAutoActivateGuardTests {
+  private func makeDefaults() throws -> UserDefaults {
+    let suiteName = "com.moolah.test.\(UUID().uuidString)"
+    let defaults = try #require(UserDefaults(suiteName: suiteName))
+    defaults.removePersistentDomain(forName: suiteName)
+    return defaults
+  }
+
+  private func seedCloudProfile(
+    _ container: ProfileContainerManager
+  ) throws -> Profile {
+    let profile = Profile(
+      id: UUID(),
+      label: "Household",
+      backendType: .cloudKit,
+      currencyCode: "AUD",
+      financialYearStartMonth: 7
+    )
+    let context = ModelContext(container.indexContainer)
+    context.insert(ProfileRecord.from(profile: profile))
+    try context.save()
+    return profile
+  }
+
+  @Test("loadCloudProfiles auto-activates when welcomePhase == .landing")
+  func autoActivatesWhenLanding() throws {
+    let manager = try ProfileContainerManager.forTesting()
+    let store = ProfileStore(
+      defaults: try makeDefaults(),
+      containerManager: manager
+    )
+    let profile = try seedCloudProfile(manager)
+    store.welcomePhase = .landing
+
+    store.loadCloudProfiles()
+
+    #expect(store.activeProfileID == profile.id)
+  }
+
+  @Test("loadCloudProfiles does NOT auto-activate when welcomePhase == .creating")
+  func doesNotAutoActivateWhenCreating() throws {
+    let manager = try ProfileContainerManager.forTesting()
+    let store = ProfileStore(
+      defaults: try makeDefaults(),
+      containerManager: manager
+    )
+    _ = try seedCloudProfile(manager)
+    store.welcomePhase = .creating
+
+    store.loadCloudProfiles()
+
+    #expect(store.activeProfileID == nil)
+    #expect(store.cloudProfiles.count == 1)
+  }
+
+  @Test("loadCloudProfiles auto-activates when welcomePhase is nil")
+  func autoActivatesWhenPhaseNil() throws {
+    let manager = try ProfileContainerManager.forTesting()
+    let store = ProfileStore(
+      defaults: try makeDefaults(),
+      containerManager: manager
+    )
+    let profile = try seedCloudProfile(manager)
+    store.welcomePhase = nil
+
+    store.loadCloudProfiles()
+
+    #expect(store.activeProfileID == profile.id)
+  }
+}

--- a/MoolahTests/Sync/SyncCoordinatorProfileIndexFetchTests.swift
+++ b/MoolahTests/Sync/SyncCoordinatorProfileIndexFetchTests.swift
@@ -81,4 +81,63 @@ struct SyncCoordinatorProfileIndexFetchTests {
     coordinator.markZoneFetched(unknownZoneID)
     #expect(coordinator.fetchSessionTouchedIndexZone == false)
   }
+
+  @Test("profileIndexFetchedAtLeastOnce flips after first session that touched index zone")
+  func flipsOnFirstIndexSession() throws {
+    let manager = try ProfileContainerManager.forTesting()
+    let coordinator = SyncCoordinator(
+      containerManager: manager,
+      isCloudKitAvailable: true
+    )
+    let indexZoneID = coordinator.profileIndexHandler.zoneID
+
+    coordinator.beginFetchingChanges()
+    coordinator.markZoneFetched(indexZoneID)
+    coordinator.endFetchingChanges()
+
+    #expect(coordinator.profileIndexFetchedAtLeastOnce == true)
+  }
+
+  @Test("profileIndexFetchedAtLeastOnce stays false when only profile-data zones fetched")
+  func staysFalseOnDataOnlySession() throws {
+    let manager = try ProfileContainerManager.forTesting()
+    let coordinator = SyncCoordinator(
+      containerManager: manager,
+      isCloudKitAvailable: true
+    )
+    let dataZoneID = CKRecordZone.ID(
+      zoneName: "profile-\(UUID().uuidString)",
+      ownerName: CKCurrentUserDefaultName
+    )
+
+    coordinator.beginFetchingChanges()
+    coordinator.markZoneFetched(dataZoneID)
+    coordinator.endFetchingChanges()
+
+    #expect(coordinator.profileIndexFetchedAtLeastOnce == false)
+  }
+
+  @Test("profileIndexFetchedAtLeastOnce stays true once set")
+  func remainsTrue() throws {
+    let manager = try ProfileContainerManager.forTesting()
+    let coordinator = SyncCoordinator(
+      containerManager: manager,
+      isCloudKitAvailable: true
+    )
+    let indexZoneID = coordinator.profileIndexHandler.zoneID
+    let dataZoneID = CKRecordZone.ID(
+      zoneName: "profile-\(UUID().uuidString)",
+      ownerName: CKCurrentUserDefaultName
+    )
+
+    coordinator.beginFetchingChanges()
+    coordinator.markZoneFetched(indexZoneID)
+    coordinator.endFetchingChanges()
+
+    coordinator.beginFetchingChanges()
+    coordinator.markZoneFetched(dataZoneID)
+    coordinator.endFetchingChanges()
+
+    #expect(coordinator.profileIndexFetchedAtLeastOnce == true)
+  }
 }


### PR DESCRIPTION
## Summary

Implements Task 9 of [`plans/2026-04-24-first-run-experience-implementation.md`](https://github.com/ajsutton/moolah-native/blob/main/plans/2026-04-24-first-run-experience-implementation.md). Builds on [#428](https://github.com/ajsutton/moolah-native/pull/428) (Task 8).

Three new SwiftUI views for first-run states 1 (welcome + checking) and 4 (iCloud off):

- **WelcomeHero** — always-dark brand splash with Moolah eyebrow, two-line title ("Your money,/rock solid."), subhead, Income Blue "Get started" CTA, and a `@ViewBuilder` footer slot.
- **ICloudStatusLine** — spinner + "Checking iCloud for your profiles…" / "No profiles in iCloud yet."
- **ICloudOffChip** — coral-red "iCloud sync is off." with underlined "Open System Settings" action.

Brand hex (`#07102E` Space, `#1E64EE` Income Blue, `#FFD56B` Balance Gold, `#7ABDFF` Light Blue, `#AAB4C8` Muted, `#FF787F` Coral Red) lives as `WelcomeBrandColors` scoped to these three files per design spec §4.1 — the rest of the app continues to use semantic system colours per `guides/UI_GUIDE.md` §5.

## Review notes

`@ui-review` findings applied:

- **Critical** — `ICloudOffChip` uses `.accessibilityAction(named: "Open System Settings", ...)` rather than relying on `children: .contain`, so VoiceOver can activate the link.
- **Important** — "Open System Settings" button has `.frame(minHeight: 44)` for hit target.
- **Important** — Added `ICloudStatusLine` `None found — dark` preview.
- **Important** — `WelcomeBrandColors` now carries a scope comment documenting intended visibility.
- **Minor** — Renamed "WelcomeHero — light" preview to "default" with a clarifying comment.
- **Minor** — Moved `.updatesFrequently` trait to the combined accessibility element in `ICloudStatusLine`.

Also split `WelcomeHero.body` into subviews to satisfy SwiftLint `closure_body_length`.

## Test plan

- [x] `just build-mac` — build succeeded
- [x] `just format-check` — clean