### PR TITLE
feat(profiles): add iCloud profile picker for multi-profile first launch

### DIFF
--- a/Features/Profiles/ProfileStore+Cloud.swift
+++ b/Features/Profiles/ProfileStore+Cloud.swift
@@ -30,11 +30,14 @@ extension ProfileStore {
       }
 
       // Auto-select a profile when none is active (e.g. new device receiving
-      // its first cloud profile from another device).
-      if activeProfileID == nil, let first = profiles.first {
+      // its first cloud profile from another device). Suppressed when
+      // `WelcomeView` is mid-create — see design spec §3.3 race condition.
+      if activeProfileID == nil, let first = profiles.first, welcomePhase != .creating {
         self.activeProfileID = first.id
         saveActiveProfileID()
         logger.debug("Auto-selected profile: \(first.id)")
+      } else if welcomePhase == .creating {
+        logger.debug("Skipped auto-select — welcomePhase == .creating")
       }
 
       // Handle profiles deleted on another device.

--- a/Features/Profiles/ProfileStore.swift
+++ b/Features/Profiles/ProfileStore.swift
@@ -23,6 +23,19 @@ final class ProfileStore {
   var isValidating = false
   var validationError: String?
 
+  /// Signal from `WelcomeView` about which interaction phase is on screen.
+  /// When `.creating`, `loadCloudProfiles` suppresses its auto-activate
+  /// behaviour so a single profile arriving from iCloud doesn't race the
+  /// user's in-flight "Create Profile" tap. Cleared (`nil`) when
+  /// `WelcomeView` unmounts. See design spec §3.3, §8.
+  enum WelcomePhase: Sendable {
+    case landing
+    case creating
+    case pickingProfile
+  }
+
+  var welcomePhase: WelcomePhase?
+
   /// True while the initial cloud profile load may still be retrying.
   /// SwiftData with CloudKit may not have its store ready on the first fetch.
   var isCloudLoadPending = false

--- a/Features/Profiles/Views/CreateProfileFormView.swift
+++ b/Features/Profiles/Views/CreateProfileFormView.swift
@@ -1,0 +1,251 @@
+import SwiftUI
+
+#if canImport(UIKit)
+  import UIKit
+#endif
+
+/// System-styled create-profile form (states 2 and 3). Single required
+/// field (Name); Currency + Financial year start are behind an Advanced
+/// disclosure with locale defaults.
+///
+/// Background iCloud-checking spinner is owned by the host — pass it via
+/// `backgroundCheckingICloud`. The optional banner is rendered above
+/// the form when `banner` is non-nil (state 3).
+///
+/// On iOS, the "Create Profile" button fires a `.success` notification
+/// haptic when the async create completes (design spec §4.3).
+struct CreateProfileFormView: View {
+  @Binding var name: String
+  @Binding var currencyCode: String
+  @Binding var financialYearStartMonth: Int
+  let banner: ICloudArrivalBanner.Kind?
+  let onBannerPrimary: () -> Void
+  let onBannerDismiss: () -> Void
+  let backgroundCheckingICloud: Bool
+  let cancelAction: () -> Void
+  let createAction: () async -> Void
+
+  @State private var isSubmitting = false
+  @FocusState private var focus: Focus?
+
+  private enum Focus: Hashable {
+    case name
+  }
+
+  private static let monthNames: [String] = {
+    let formatter = DateFormatter()
+    formatter.locale = Locale.current
+    return formatter.monthSymbols ?? []
+  }()
+
+  var body: some View {
+    VStack(spacing: 0) {
+      bannerContent
+      form
+    }
+    .toolbar {
+      ToolbarItem(placement: .cancellationAction) {
+        Button(String(localized: "Cancel"), action: cancelAction)
+      }
+      ToolbarItem(placement: .confirmationAction) {
+        confirmationButton
+      }
+    }
+    .onAppear { focus = .name }
+  }
+
+  @ViewBuilder private var bannerContent: some View {
+    if let banner {
+      ICloudArrivalBanner(
+        kind: banner,
+        primaryAction: onBannerPrimary,
+        dismissAction: onBannerDismiss
+      )
+      .padding(.horizontal, 16)
+      .padding(.top, 16)
+      .accessibilityIdentifier(
+        banner.isSingle
+          ? UITestIdentifiers.Welcome.bannerOpenAction
+          : UITestIdentifiers.Welcome.bannerViewAction
+      )
+    }
+  }
+
+  private var form: some View {
+    Form {
+      Section {
+        TextField(String(localized: "Name"), text: $name)
+          .focused($focus, equals: .name)
+          .submitLabel(.done)
+          .accessibilityIdentifier(UITestIdentifiers.Welcome.nameField)
+        advancedDisclosure
+      } header: {
+        header
+      } footer: {
+        footer
+      }
+    }
+    .formStyle(.grouped)
+  }
+
+  private var advancedDisclosure: some View {
+    DisclosureGroup(
+      String(localized: "Advanced", comment: "Form advanced disclosure")
+    ) {
+      CurrencyPicker(selection: $currencyCode)
+      Picker(
+        String(localized: "Financial year starts", comment: "Form FY month"),
+        selection: $financialYearStartMonth
+      ) {
+        ForEach(1...12, id: \.self) { month in
+          if month <= Self.monthNames.count {
+            Text(Self.monthNames[month - 1]).tag(month)
+          }
+        }
+      }
+    }
+  }
+
+  private var header: some View {
+    VStack(alignment: .leading, spacing: 4) {
+      Text("Create a profile", comment: "Form title")
+        .font(.title2.bold())
+        .foregroundStyle(.primary)
+        .textCase(nil)
+      Text(
+        "Just give it a name. You can tweak the rest later.",
+        comment: "Form subtitle"
+      )
+      .font(.subheadline)
+      .foregroundStyle(.secondary)
+      .textCase(nil)
+    }
+    .padding(.bottom, 8)
+  }
+
+  @ViewBuilder private var footer: some View {
+    if backgroundCheckingICloud {
+      HStack(spacing: 6) {
+        ProgressView().controlSize(.small)
+        Text("Still checking iCloud…", comment: "Form background status")
+          .font(.footnote)
+          .foregroundStyle(.secondary)
+      }
+    }
+  }
+
+  @ViewBuilder private var confirmationButton: some View {
+    if isSubmitting {
+      ProgressView().controlSize(.small)
+    } else {
+      Button(action: submit) {
+        Text("Create Profile", comment: "Form primary CTA")
+      }
+      .buttonStyle(.borderedProminent)
+      .disabled(name.trimmingCharacters(in: .whitespaces).isEmpty)
+      .accessibilityIdentifier(UITestIdentifiers.Welcome.createProfileButton)
+    }
+  }
+
+  private func submit() {
+    isSubmitting = true
+    Task {
+      await createAction()
+      isSubmitting = false
+      #if os(iOS)
+        UINotificationFeedbackGenerator().notificationOccurred(.success)
+      #endif
+    }
+  }
+}
+
+extension ICloudArrivalBanner.Kind {
+  // Internal (default) — the sibling view is in the same module; keeping
+  // file scope isn't strictly necessary and `strict_fileprivate` flags it.
+  var isSingle: Bool {
+    if case .single = self { return true }
+    return false
+  }
+}
+
+#Preview("Create — default") {
+  @Previewable @State var name = ""
+  @Previewable @State var currency = "AUD"
+  @Previewable @State var month = 7
+  NavigationStack {
+    CreateProfileFormView(
+      name: $name,
+      currencyCode: $currency,
+      financialYearStartMonth: $month,
+      banner: nil,
+      onBannerPrimary: {},
+      onBannerDismiss: {},
+      backgroundCheckingICloud: true,
+      cancelAction: {},
+      createAction: {}
+    )
+  }
+  .frame(width: 480, height: 560)
+}
+
+#Preview("Create — with banner") {
+  @Previewable @State var name = "Hous"
+  @Previewable @State var currency = "AUD"
+  @Previewable @State var month = 7
+  NavigationStack {
+    CreateProfileFormView(
+      name: $name,
+      currencyCode: $currency,
+      financialYearStartMonth: $month,
+      banner: .single(label: "Household"),
+      onBannerPrimary: {},
+      onBannerDismiss: {},
+      backgroundCheckingICloud: true,
+      cancelAction: {},
+      createAction: {}
+    )
+  }
+  .frame(width: 480, height: 600)
+}
+
+#Preview("Create — dark") {
+  @Previewable @State var name = "Household"
+  @Previewable @State var currency = "AUD"
+  @Previewable @State var month = 7
+  NavigationStack {
+    CreateProfileFormView(
+      name: $name,
+      currencyCode: $currency,
+      financialYearStartMonth: $month,
+      banner: nil,
+      onBannerPrimary: {},
+      onBannerDismiss: {},
+      backgroundCheckingICloud: false,
+      cancelAction: {},
+      createAction: {}
+    )
+  }
+  .frame(width: 480, height: 560)
+  .preferredColorScheme(.dark)
+}
+
+#Preview("Create — AX5") {
+  @Previewable @State var name = "Household"
+  @Previewable @State var currency = "AUD"
+  @Previewable @State var month = 7
+  NavigationStack {
+    CreateProfileFormView(
+      name: $name,
+      currencyCode: $currency,
+      financialYearStartMonth: $month,
+      banner: nil,
+      onBannerPrimary: {},
+      onBannerDismiss: {},
+      backgroundCheckingICloud: false,
+      cancelAction: {},
+      createAction: {}
+    )
+  }
+  .frame(width: 600, height: 800)
+  .dynamicTypeSize(.accessibility5)
+}

--- a/Features/Profiles/Views/ICloudArrivalBanner.swift
+++ b/Features/Profiles/Views/ICloudArrivalBanner.swift
@@ -1,0 +1,147 @@
+import SwiftUI
+
+/// Non-blocking brand-gold banner surfaced above the create-profile
+/// form (state 3) when iCloud returns profiles while the user is
+/// mid-setup.
+///
+/// Single-profile path → Open/Dismiss. Multi-profile path → View/Dismiss.
+///
+/// Brand colour is deliberately kept (not system yellow) — this is the
+/// one system-styled screen element that sits narratively with the
+/// hero (iCloud has something for you). See design spec §4.1.
+struct ICloudArrivalBanner: View {
+  enum Kind: Equatable {
+    case single(label: String)
+    case multiple(count: Int)
+  }
+
+  let kind: Kind
+  let primaryAction: () -> Void
+  let dismissAction: () -> Void
+
+  var body: some View {
+    HStack(alignment: .firstTextBaseline, spacing: 10) {
+      Image(systemName: "icloud")
+        .foregroundStyle(WelcomeBrandColors.space)
+        .padding(.top, 1)
+      labels
+      Spacer(minLength: 0)
+      actions
+    }
+    .padding(12)
+    .background(WelcomeBrandColors.balanceGold.opacity(0.95))
+    .clipShape(.rect(cornerRadius: 10))
+    .accessibilityElement(children: .combine)
+    .accessibilityLabel(accessibilityLabelText)
+    .accessibilityAction(named: primaryLabel, primaryAction)
+    .accessibilityAction(named: "Dismiss", dismissAction)
+    .accessibilityAddTraits(.updatesFrequently)
+  }
+
+  private var labels: some View {
+    VStack(alignment: .leading, spacing: 2) {
+      Text(title)
+        .font(.footnote.weight(.semibold))
+        .foregroundStyle(WelcomeBrandColors.space)
+      if let subtitle {
+        Text(subtitle)
+          .font(.caption)
+          .foregroundStyle(WelcomeBrandColors.space.opacity(0.75))
+      }
+    }
+  }
+
+  private var actions: some View {
+    HStack(spacing: 12) {
+      Button(primaryLabel, action: primaryAction)
+        .buttonStyle(.plain)
+        .font(.footnote.weight(.semibold))
+        .foregroundStyle(WelcomeBrandColors.space)
+        .underline()
+        .frame(minHeight: 44)
+      Button(action: dismissAction) {
+        Text("Dismiss", comment: "First-run iCloud banner dismiss")
+          .font(.footnote)
+          .foregroundStyle(WelcomeBrandColors.space.opacity(0.6))
+          .frame(minHeight: 44)
+      }
+      .buttonStyle(.plain)
+    }
+  }
+
+  private var title: String {
+    switch kind {
+    case .single(let label):
+      return String(localized: "Found '\(label)' in iCloud.")
+    case .multiple(let count):
+      return String(localized: "Looks like you've got \(count) profiles in iCloud.")
+    }
+  }
+
+  private var subtitle: String? {
+    switch kind {
+    case .single:
+      return String(localized: "You can open it instead of creating a new one.")
+    case .multiple:
+      return nil
+    }
+  }
+
+  private var primaryLabel: String {
+    switch kind {
+    case .single:
+      return String(localized: "Open")
+    case .multiple:
+      return String(localized: "View")
+    }
+  }
+
+  private var accessibilityLabelText: String {
+    if let subtitle {
+      return "\(title). \(subtitle)"
+    }
+    return title
+  }
+}
+
+#Preview("Single") {
+  ICloudArrivalBanner(
+    kind: .single(label: "Household"),
+    primaryAction: {},
+    dismissAction: {}
+  )
+  .padding()
+  .frame(width: 440, height: 120)
+}
+
+#Preview("Multiple") {
+  ICloudArrivalBanner(
+    kind: .multiple(count: 3),
+    primaryAction: {},
+    dismissAction: {}
+  )
+  .padding()
+  .frame(width: 440, height: 120)
+}
+
+#Preview("Single — dark") {
+  ICloudArrivalBanner(
+    kind: .single(label: "Household"),
+    primaryAction: {},
+    dismissAction: {}
+  )
+  .padding()
+  .frame(width: 440, height: 120)
+  .preferredColorScheme(.dark)
+}
+
+#Preview("Multiple — AX5") {
+  ICloudArrivalBanner(
+    kind: .multiple(count: 3),
+    primaryAction: {},
+    dismissAction: {}
+  )
+  .padding()
+  .frame(width: 560, height: 240)
+  .dynamicTypeSize(.accessibility5)
+}

--- a/Features/Profiles/Views/ICloudOffChip.swift
+++ b/Features/Profiles/Views/ICloudOffChip.swift
@@ -1,0 +1,75 @@
+import SwiftUI
+
+/// Inline chip shown under the hero CTA in state 4 (iCloud unavailable).
+/// Explains that the profile will be local and links to System Settings.
+///
+/// `openSettingsAction` performs the platform-appropriate deep link —
+/// wired by the host (`WelcomeView`, Task 13) so this view stays
+/// platform-agnostic.
+struct ICloudOffChip: View {
+  let openSettingsAction: () -> Void
+
+  var body: some View {
+    HStack(alignment: .top, spacing: 8) {
+      Image(systemName: "icloud.slash")
+        .foregroundStyle(WelcomeBrandColors.coralRed)
+        .font(.footnote)
+        .padding(.top, 2)
+      VStack(alignment: .leading, spacing: 3) {
+        Text("iCloud sync is off.", comment: "First-run iCloud-off chip title")
+          .font(.footnote.weight(.semibold))
+          .foregroundStyle(WelcomeBrandColors.coralRed)
+        HStack(spacing: 4) {
+          Text(
+            "Your profile will be saved on this device.",
+            comment: "First-run iCloud-off chip body"
+          )
+          .font(.footnote)
+          .foregroundStyle(WelcomeBrandColors.muted)
+          Button(action: openSettingsAction) {
+            Text("Open System Settings", comment: "First-run iCloud-off chip link")
+              .font(.footnote)
+              .underline()
+              .foregroundStyle(WelcomeBrandColors.lightBlue)
+              .frame(minHeight: 44)
+          }
+          .buttonStyle(.plain)
+        }
+      }
+    }
+    .padding(10)
+    .background(WelcomeBrandColors.coralRed.opacity(0.12))
+    .clipShape(.rect(cornerRadius: 8))
+    .accessibilityElement(children: .combine)
+    .accessibilityLabel(
+      "iCloud sync is off. Your profile will be saved on this device."
+    )
+    .accessibilityAction(named: "Open System Settings", openSettingsAction)
+  }
+}
+
+#Preview("ICloudOffChip") {
+  ZStack {
+    WelcomeBrandColors.space.ignoresSafeArea()
+    ICloudOffChip(openSettingsAction: {}).padding()
+  }
+  .frame(width: 360, height: 120)
+}
+
+#Preview("ICloudOffChip — dark") {
+  ZStack {
+    WelcomeBrandColors.space.ignoresSafeArea()
+    ICloudOffChip(openSettingsAction: {}).padding()
+  }
+  .frame(width: 360, height: 120)
+  .preferredColorScheme(.dark)
+}
+
+#Preview("ICloudOffChip — AX5") {
+  ZStack {
+    WelcomeBrandColors.space.ignoresSafeArea()
+    ICloudOffChip(openSettingsAction: {}).padding()
+  }
+  .frame(width: 500, height: 240)
+  .dynamicTypeSize(.accessibility5)
+}

--- a/Features/Profiles/Views/ICloudProfilePickerView.swift
+++ b/Features/Profiles/Views/ICloudProfilePickerView.swift
@@ -1,0 +1,145 @@
+import SwiftUI
+
+/// State 5 — picker surfaced when iCloud returns two or more profiles.
+/// Plain `List` with native rows plus a "+ Create a new profile" footer
+/// row.
+///
+/// Account-count meta text uses `.monospacedDigit()` per
+/// `guides/UI_GUIDE.md` §4 — prevents row-width jitter as sync delivers
+/// data.
+struct ICloudProfilePickerView: View {
+  let profiles: [Profile]
+  let accountCounts: [UUID: Int]
+  let selectAction: (Profile) -> Void
+  let createNewAction: () -> Void
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 0) {
+      header
+        .padding(.horizontal, 20)
+        .padding(.top, 20)
+        .padding(.bottom, 12)
+
+      List {
+        profilesSection
+        createSection
+      }
+      .listStyle(.inset)
+    }
+  }
+
+  private var header: some View {
+    VStack(alignment: .leading, spacing: 4) {
+      Text("Welcome back.", comment: "Picker title")
+        .font(.title2.bold())
+      Text(
+        "You have profiles in iCloud. Pick one to open.",
+        comment: "Picker subtitle"
+      )
+      .font(.subheadline)
+      .foregroundStyle(.secondary)
+    }
+    .accessibilityAddTraits(.isHeader)
+  }
+
+  private var profilesSection: some View {
+    Section {
+      ForEach(profiles) { profile in
+        Button {
+          selectAction(profile)
+        } label: {
+          row(for: profile)
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier(UITestIdentifiers.Welcome.pickerRow(profile.id))
+      }
+    } header: {
+      Text("Your profiles", comment: "Picker section header")
+    }
+  }
+
+  private var createSection: some View {
+    Section {
+      Button(action: createNewAction) {
+        Label(
+          String(localized: "Create a new profile", comment: "Picker footer CTA"),
+          systemImage: "plus"
+        )
+        .foregroundStyle(.tint)
+      }
+      .accessibilityIdentifier(UITestIdentifiers.Welcome.pickerCreateNewRow)
+    }
+  }
+
+  private func row(for profile: Profile) -> some View {
+    HStack {
+      VStack(alignment: .leading, spacing: 2) {
+        Text(profile.label)
+          .font(.body.weight(.medium))
+        metaRow(for: profile)
+          .font(.caption)
+          .foregroundStyle(.secondary)
+      }
+      Spacer()
+      Image(systemName: "chevron.right")
+        .foregroundStyle(.tertiary)
+        .font(.caption)
+    }
+    .contentShape(.rect)
+    .padding(.vertical, 4)
+  }
+
+  @ViewBuilder
+  private func metaRow(for profile: Profile) -> some View {
+    if let count = accountCounts[profile.id] {
+      HStack(spacing: 4) {
+        Text(profile.currencyCode)
+        Text("·")
+        Text(
+          "\(count) \(count == 1 ? String(localized: "account") : String(localized: "accounts"))"
+        )
+        .monospacedDigit()
+      }
+    } else {
+      Text(profile.currencyCode)
+    }
+  }
+}
+
+#Preview("Two profiles") {
+  ICloudProfilePickerView(
+    profiles: [
+      Profile(label: "Household", backendType: .cloudKit, currencyCode: "AUD"),
+      Profile(label: "Side business", backendType: .cloudKit, currencyCode: "AUD"),
+    ],
+    accountCounts: [:],
+    selectAction: { _ in },
+    createNewAction: {}
+  )
+  .frame(width: 480, height: 520)
+}
+
+#Preview("With counts — dark") {
+  let household = Profile(label: "Household", backendType: .cloudKit, currencyCode: "AUD")
+  let business = Profile(label: "Side business", backendType: .cloudKit, currencyCode: "AUD")
+  ICloudProfilePickerView(
+    profiles: [household, business],
+    accountCounts: [household.id: 12, business.id: 3],
+    selectAction: { _ in },
+    createNewAction: {}
+  )
+  .frame(width: 480, height: 520)
+  .preferredColorScheme(.dark)
+}
+
+#Preview("AX5") {
+  let household = Profile(label: "Household", backendType: .cloudKit, currencyCode: "AUD")
+  ICloudProfilePickerView(
+    profiles: [household],
+    accountCounts: [household.id: 12],
+    selectAction: { _ in },
+    createNewAction: {}
+  )
+  .frame(width: 600, height: 800)
+  .dynamicTypeSize(.accessibility5)
+}

--- a/Features/Profiles/Views/ICloudStatusLine.swift
+++ b/Features/Profiles/Views/ICloudStatusLine.swift
@@ -1,0 +1,74 @@
+import SwiftUI
+
+/// Quiet status line that sits under the hero CTA in state 1.
+/// Shows a spinner + "Checking iCloud for your profiles…" while we're
+/// waiting, swaps to "No profiles in iCloud yet." once a fetch has
+/// completed empty. Never visible in state 4 (iCloud unavailable) —
+/// that's handled by ``ICloudOffChip``.
+struct ICloudStatusLine: View {
+  enum State: Equatable {
+    case checking
+    case noneFound
+  }
+
+  let state: State
+
+  var body: some View {
+    HStack(alignment: .firstTextBaseline, spacing: 8) {
+      if state == .checking {
+        ProgressView()
+          .controlSize(.small)
+          .tint(WelcomeBrandColors.lightBlue)
+      }
+      Text(label)
+        .font(.footnote)
+        .foregroundStyle(WelcomeBrandColors.muted)
+    }
+    .accessibilityElement(children: .combine)
+    .accessibilityLabel(label)
+    .accessibilityAddTraits(state == .checking ? .updatesFrequently : [])
+  }
+
+  private var label: String {
+    switch state {
+    case .checking:
+      String(localized: "Checking iCloud for your profiles…")
+    case .noneFound:
+      String(localized: "No profiles in iCloud yet.")
+    }
+  }
+}
+
+#Preview("Checking") {
+  ZStack {
+    WelcomeBrandColors.space.ignoresSafeArea()
+    ICloudStatusLine(state: .checking).padding()
+  }
+  .frame(width: 360, height: 100)
+}
+
+#Preview("None found") {
+  ZStack {
+    WelcomeBrandColors.space.ignoresSafeArea()
+    ICloudStatusLine(state: .noneFound).padding()
+  }
+  .frame(width: 360, height: 100)
+}
+
+#Preview("None found — dark") {
+  ZStack {
+    WelcomeBrandColors.space.ignoresSafeArea()
+    ICloudStatusLine(state: .noneFound).padding()
+  }
+  .frame(width: 360, height: 100)
+  .preferredColorScheme(.dark)
+}
+
+#Preview("Checking — AX5") {
+  ZStack {
+    WelcomeBrandColors.space.ignoresSafeArea()
+    ICloudStatusLine(state: .checking).padding()
+  }
+  .frame(width: 520, height: 180)
+  .dynamicTypeSize(.accessibility5)
+}

--- a/Features/Profiles/Views/WelcomeHero.swift
+++ b/Features/Profiles/Views/WelcomeHero.swift
@@ -1,0 +1,153 @@
+import SwiftUI
+
+/// Brand colour tokens for the first-run hero. Hex values are scoped to
+/// this file and the sibling `ICloudStatusLine` / `ICloudOffChip` /
+/// `ICloudArrivalBanner` per design spec §4.1 — never leaked to
+/// project-wide `Color` extensions.
+///
+/// **Access scope:** `internal` by convention — intended only for the
+/// sibling welcome views listed above. Do not consume elsewhere: the
+/// rest of the app uses semantic system colours per `guides/UI_GUIDE.md` §5.
+enum WelcomeBrandColors {
+  static let space = Color(red: 0x07 / 255, green: 0x10 / 255, blue: 0x2E / 255)
+  static let incomeBlue = Color(red: 0x1E / 255, green: 0x64 / 255, blue: 0xEE / 255)
+  static let balanceGold = Color(red: 0xFF / 255, green: 0xD5 / 255, blue: 0x6B / 255)
+  static let lightBlue = Color(red: 0x7A / 255, green: 0xBD / 255, blue: 0xFF / 255)
+  static let muted = Color(red: 0xAA / 255, green: 0xB4 / 255, blue: 0xC8 / 255)
+  static let coralRed = Color(red: 0xFF / 255, green: 0x78 / 255, blue: 0x7F / 255)
+}
+
+/// Branded hero used for first-run states 1 (welcome + checking) and 4
+/// (iCloud off). Content slot below the CTA receives either
+/// ``ICloudStatusLine`` (state 1) or ``ICloudOffChip`` (state 4).
+///
+/// Colour tokens come from `guides/BRAND_GUIDE.md` §3. Hardcoded hex is
+/// scoped to this file per design spec §4.1.
+struct WelcomeHero<Footer: View>: View {
+  let primaryAction: () -> Void
+  @ViewBuilder let footer: () -> Footer
+
+  @FocusState private var focus: Focus?
+
+  private enum Focus: Hashable {
+    case primaryCTA
+  }
+
+  var body: some View {
+    ZStack(alignment: .leading) {
+      WelcomeBrandColors.space.ignoresSafeArea()
+      heroContent
+    }
+    .task { focus = .primaryCTA }
+  }
+
+  private var heroContent: some View {
+    VStack(alignment: .leading, spacing: 0) {
+      Spacer(minLength: 48)
+      eyebrow
+      titleBlock
+      subhead
+      Spacer()
+      ctaButton
+      footer().frame(maxWidth: 320, alignment: .leading)
+      Spacer(minLength: 28)
+    }
+    .padding(.horizontal, 32)
+  }
+
+  private var eyebrow: some View {
+    Text("Moolah", comment: "First-run hero eyebrow label")
+      .font(.caption.weight(.medium))
+      .tracking(1.8)
+      .textCase(.uppercase)
+      .foregroundStyle(WelcomeBrandColors.balanceGold)
+      .accessibilityHidden(true)
+  }
+
+  private var titleBlock: some View {
+    VStack(alignment: .leading, spacing: 0) {
+      Text("Your money,", comment: "First-run hero title line 1")
+        .foregroundStyle(.white)
+      Text("rock solid.", comment: "First-run hero title line 2")
+        .foregroundStyle(WelcomeBrandColors.balanceGold)
+    }
+    .font(.largeTitle.bold())
+    .accessibilityElement(children: .combine)
+    .accessibilityLabel("Your money, rock solid.")
+    .accessibilityAddTraits(.isHeader)
+    .padding(.top, 10)
+  }
+
+  private var subhead: some View {
+    Text(
+      "Money stuff should be boring. Locked down, sorted out, taken care of — so the rest of your life doesn't have to be.",
+      comment: "First-run hero subhead"
+    )
+    .font(.body)
+    .foregroundStyle(WelcomeBrandColors.muted)
+    .lineLimit(nil)
+    .fixedSize(horizontal: false, vertical: true)
+    .frame(maxWidth: 320, alignment: .leading)
+    .padding(.top, 14)
+  }
+
+  private var ctaButton: some View {
+    Button(action: primaryAction) {
+      Text("Get started", comment: "First-run primary CTA")
+        .font(.headline)
+        .frame(maxWidth: 280)
+        .frame(minHeight: 44)
+    }
+    .buttonStyle(PrimaryHeroButtonStyle())
+    .focusable(true)
+    .focused($focus, equals: .primaryCTA)
+    .onKeyPress(.return) {
+      primaryAction()
+      return .handled
+    }
+    .padding(.bottom, 12)
+  }
+}
+
+private struct PrimaryHeroButtonStyle: ButtonStyle {
+  func makeBody(configuration: Configuration) -> some View {
+    configuration.label
+      .foregroundStyle(.white)
+      .padding(.vertical, 12)
+      .padding(.horizontal, 24)
+      .background(
+        WelcomeBrandColors.incomeBlue
+          .opacity(configuration.isPressed ? 0.85 : 1.0)
+      )
+      .clipShape(.rect(cornerRadius: 10))
+      .contentShape(.rect)
+  }
+}
+
+// The hero renders dark regardless of system colour scheme (always-dark
+// brand splash); the default/dark previews are intentionally near-identical.
+#Preview("WelcomeHero — default") {
+  WelcomeHero(
+    primaryAction: {},
+    footer: { ICloudStatusLine(state: .checking) }
+  )
+  .frame(width: 420, height: 560)
+}
+
+#Preview("WelcomeHero — dark") {
+  WelcomeHero(
+    primaryAction: {},
+    footer: { ICloudStatusLine(state: .checking) }
+  )
+  .frame(width: 420, height: 560)
+  .preferredColorScheme(.dark)
+}
+
+#Preview("WelcomeHero — AX5") {
+  WelcomeHero(
+    primaryAction: {},
+    footer: { ICloudStatusLine(state: .noneFound) }
+  )
+  .frame(width: 500, height: 720)
+  .dynamicTypeSize(.accessibility5)
+}

--- a/MoolahTests/Features/ProfileStoreAutoActivateGuardTests.swift
+++ b/MoolahTests/Features/ProfileStoreAutoActivateGuardTests.swift
@@ -1,0 +1,78 @@
+import Foundation
+import SwiftData
+import Testing
+
+@testable import Moolah
+
+@Suite("ProfileStore — auto-activate guard")
+@MainActor
+struct ProfileStoreAutoActivateGuardTests {
+  private func makeDefaults() throws -> UserDefaults {
+    let suiteName = "com.moolah.test.\(UUID().uuidString)"
+    let defaults = try #require(UserDefaults(suiteName: suiteName))
+    defaults.removePersistentDomain(forName: suiteName)
+    return defaults
+  }
+
+  private func seedCloudProfile(
+    _ container: ProfileContainerManager
+  ) throws -> Profile {
+    let profile = Profile(
+      id: UUID(),
+      label: "Household",
+      backendType: .cloudKit,
+      currencyCode: "AUD",
+      financialYearStartMonth: 7
+    )
+    let context = ModelContext(container.indexContainer)
+    context.insert(ProfileRecord.from(profile: profile))
+    try context.save()
+    return profile
+  }
+
+  @Test("loadCloudProfiles auto-activates when welcomePhase == .landing")
+  func autoActivatesWhenLanding() throws {
+    let manager = try ProfileContainerManager.forTesting()
+    let store = ProfileStore(
+      defaults: try makeDefaults(),
+      containerManager: manager
+    )
+    let profile = try seedCloudProfile(manager)
+    store.welcomePhase = .landing
+
+    store.loadCloudProfiles()
+
+    #expect(store.activeProfileID == profile.id)
+  }
+
+  @Test("loadCloudProfiles does NOT auto-activate when welcomePhase == .creating")
+  func doesNotAutoActivateWhenCreating() throws {
+    let manager = try ProfileContainerManager.forTesting()
+    let store = ProfileStore(
+      defaults: try makeDefaults(),
+      containerManager: manager
+    )
+    _ = try seedCloudProfile(manager)
+    store.welcomePhase = .creating
+
+    store.loadCloudProfiles()
+
+    #expect(store.activeProfileID == nil)
+    #expect(store.cloudProfiles.count == 1)
+  }
+
+  @Test("loadCloudProfiles auto-activates when welcomePhase is nil")
+  func autoActivatesWhenPhaseNil() throws {
+    let manager = try ProfileContainerManager.forTesting()
+    let store = ProfileStore(
+      defaults: try makeDefaults(),
+      containerManager: manager
+    )
+    let profile = try seedCloudProfile(manager)
+    store.welcomePhase = nil
+
+    store.loadCloudProfiles()
+
+    #expect(store.activeProfileID == profile.id)
+  }
+}

--- a/UITestSupport/UITestIdentifiers.swift
+++ b/UITestSupport/UITestIdentifiers.swift
@@ -69,6 +69,30 @@ public enum UITestIdentifiers {
     }
   }
 
+  public enum Welcome {
+    /// "Get started" primary CTA on the first-run hero (states 1 and 4).
+    public static let heroGetStartedButton = "welcome.hero.getStarted"
+    /// Name text field in the create-profile form.
+    public static let nameField = "welcome.create.nameField"
+    /// "Create Profile" submit button in the create-profile form.
+    public static let createProfileButton = "welcome.create.createButton"
+    /// Profile row in the multi-profile picker. Suffix is the profile UUID,
+    /// lowercased.
+    public static func pickerRow(_ id: UUID) -> String {
+      "welcome.picker.row.\(id.uuidString.lowercased())"
+    }
+    /// "+ Create a new profile" footer row in the multi-profile picker.
+    public static let pickerCreateNewRow = "welcome.picker.createNew"
+    /// "Open" action on the single-profile arrival banner.
+    public static let bannerOpenAction = "welcome.banner.open"
+    /// "View" action on the multi-profile arrival banner.
+    public static let bannerViewAction = "welcome.banner.view"
+    /// "Dismiss" action on any arrival banner.
+    public static let bannerDismissAction = "welcome.banner.dismiss"
+    /// "Open System Settings" link on the iCloud-off hero chip.
+    public static let iCloudOffSystemSettingsLink = "welcome.off.systemSettings"
+  }
+
   public enum Autocomplete {
     /// Container element of the payee autocomplete dropdown.
     public static let payee = "autocomplete.payee"


### PR DESCRIPTION
## Summary

Implements Task 12 of [`plans/2026-04-24-first-run-experience-implementation.md`](https://github.com/ajsutton/moolah-native/blob/main/plans/2026-04-24-first-run-experience-implementation.md). Builds on [#431](https://github.com/ajsutton/moolah-native/pull/431) (Task 11).

State 5 — picker surfaced when iCloud returns two or more profiles. Plain `List` with native rows (profile label + "currency · N accounts" meta) plus a "+ Create a new profile" footer row. Account-count text uses `.monospacedDigit()` to prevent row-width jitter as sync delivers data.

Each row carries `UITestIdentifiers.Welcome.pickerRow(profile.id)`; the footer uses `UITestIdentifiers.Welcome.pickerCreateNewRow`.

## Test plan

- [x] `just build-mac` — succeeded
- [x] `just format-check` — clean