### PR TITLE
test(profiles): add UI tests + seeds for WelcomeView

### DIFF
--- a/App/MoolahApp+Setup.swift
+++ b/App/MoolahApp+Setup.swift
@@ -41,7 +41,7 @@ extension MoolahApp {
       if let seed = uiTestingSeed {
         let manager = try ProfileContainerManager.forTesting()
         let profile = try UITestSeedHydrator.hydrate(seed, into: manager)
-        return ContainerSetup(manager: manager, uiTestingProfileId: profile.id)
+        return ContainerSetup(manager: manager, uiTestingProfileId: profile?.id)
       }
 
       let profileSchema = Schema([ProfileRecord.self])
@@ -87,11 +87,12 @@ extension MoolahApp {
   ///     shaped storage and must not reach for real iCloud. See
   ///     guides/UI_TEST_GUIDE.md §6.
   static func configureSyncCoordinator(
-    store: ProfileStore, coordinator: SyncCoordinator, uiTestingProfileId: UUID?
+    store: ProfileStore,
+    coordinator: SyncCoordinator,
+    isUITesting: Bool
   ) {
     let logger = Logger(subsystem: "com.moolah.app", category: "BackgroundSync")
     let isRunningTests = NSClassFromString("XCTestCase") != nil
-    let isUITesting = uiTestingProfileId != nil
     if isUITesting {
       logger.info("Running under --ui-testing — skipping CloudKit sync coordinator")
       return

--- a/App/MoolahApp.swift
+++ b/App/MoolahApp.swift
@@ -57,7 +57,7 @@ struct MoolahApp: App {
     Self.configureSyncCoordinator(
       store: store,
       coordinator: coordinator,
-      uiTestingProfileId: setup.uiTestingProfileId)
+      isUITesting: uiTestingSeed != nil)
 
     let sessionManager = SessionManager(
       containerManager: setup.manager, syncCoordinator: coordinator)

--- a/App/MoolahApp.swift
+++ b/App/MoolahApp.swift
@@ -19,6 +19,15 @@ struct MoolahApp: App {
   /// launches. Stored as `let` because `MoolahApp.init` runs once per
   /// process; the value is decided at launch and never changes.
   private let uiTestingProfileId: UUID?
+  /// True when the process was launched with `--ui-testing`, regardless of
+  /// whether the seed hydrates a profile. Welcome-view seeds intentionally
+  /// leave `uiTestingProfileId` unset (see `UITestSeedHydrator`) so we also
+  /// need a seed-agnostic flag to drive launcher presentation.
+  private let isUITesting: Bool
+  /// Stable identifier for the primary `WindowGroup(for:)`. Exposed so
+  /// `UITestingLauncherView` can call `openWindow(id:)` to open a default
+  /// instance with a nil binding (for Welcome seeds that have no profile).
+  static let mainWindowID = "profile-window"
   @State var profileStore: ProfileStore
   // internal (was private) so `+Lifecycle` can log under the shared
   // subsystem/category.
@@ -46,6 +55,7 @@ struct MoolahApp: App {
     containerManager = setup.manager
     syncCoordinator = coordinator
     uiTestingProfileId = setup.uiTestingProfileId
+    isUITesting = uiTestingSeed != nil
 
     let store = ProfileStore(
       validator: RemoteServerValidator(),
@@ -80,7 +90,7 @@ struct MoolahApp: App {
 
   var body: some Scene {
     #if os(macOS)
-      WindowGroup(for: Profile.ID.self) { $profileID in
+      WindowGroup(id: Self.mainWindowID, for: Profile.ID.self) { $profileID in
         // UI-testing mode pins the window to the seeded profile; the
         // per-window binding is used only in production launches.
         ProfileWindowView(profileID: uiTestingProfileId ?? profileID)
@@ -148,17 +158,19 @@ struct MoolahApp: App {
           .modelContainer(containerManager.indexContainer)
       }
 
-      // Auto-open the seeded profile window on `--ui-testing` launches.
+      // Auto-open the main window on `--ui-testing` launches.
       // `WindowGroup(for: Profile.ID.self)` does not present without an
       // explicit value, so a hidden launcher Window with
-      // `.defaultLaunchBehavior(.presented)` runs `openWindow(value:)`
-      // and immediately dismisses itself. In production the launcher is
-      // suppressed and never reachable from the UI.
+      // `.defaultLaunchBehavior(.presented)` calls `openWindow(…)` and
+      // immediately dismisses itself. Presented for every UI-testing launch
+      // — including Welcome seeds that leave `uiTestingProfileId` nil, so
+      // `WelcomeView` still gets a window to render into. Suppressed in
+      // production, where normal scene restoration opens the window.
       Window("UI Testing Launcher", id: "ui-testing-launcher") {
         UITestingLauncherView(profileId: uiTestingProfileId)
       }
       .windowResizability(.contentSize)
-      .defaultLaunchBehavior(uiTestingProfileId != nil ? .presented : .suppressed)
+      .defaultLaunchBehavior(isUITesting ? .presented : .suppressed)
     #else
       WindowGroup {
         ProfileRootView(activeSession: $activeSession)

--- a/App/ProfileRootView.swift
+++ b/App/ProfileRootView.swift
@@ -17,12 +17,21 @@
 
     var body: some View {
       Group {
-        if !profileStore.hasProfiles {
-          WelcomeView()
-        } else if let session = activeSession {
+        // Show WelcomeView for both first-run (no profiles) and the
+        // multi-profile picker state (2+ profiles but none active).
+        // `activeSession` is only set once the user has explicitly
+        // selected a profile, so the else branch naturally handles
+        // the picker case.
+        if let session = activeSession {
           SessionRootView(session: session)
-        } else {
+        } else if profileStore.hasProfiles
+          && profileStore.activeProfileID != nil
+        {
+          // Has an active profile ID but the session hasn't been
+          // created yet (cloud store warming up). Brief transient.
           ProgressView()
+        } else {
+          WelcomeView()
         }
       }
       .onChange(of: profileStore.activeProfileID) { _, newID in

--- a/App/ProfileWindowView.swift
+++ b/App/ProfileWindowView.swift
@@ -15,8 +15,11 @@
 
     @Environment(\.dismiss) private var dismiss
 
-    /// Resolve the profile to display: the window's profileID if it matches a known profile,
-    /// otherwise the active profile, otherwise the first profile.
+    /// Resolve the profile to display: the window's profileID if it matches a
+    /// known profile, otherwise the active profile. Falls back to the single
+    /// profile only when exactly one exists — with 2+ profiles and nothing
+    /// selected, `WelcomeView` shows its picker (state 5) instead of
+    /// silently opening one of them.
     private var resolvedProfile: Profile? {
       if let profileID,
         let profile = profileStore.profiles.first(where: { $0.id == profileID })
@@ -28,7 +31,7 @@
       {
         return profile
       }
-      return profileStore.profiles.first
+      return profileStore.profiles.count == 1 ? profileStore.profiles.first : nil
     }
 
     var body: some View {
@@ -40,24 +43,28 @@
             .onChange(of: profile.resolvedServerURL) { _, _ in
               sessionManager.rebuildSession(for: profile)
             }
-        } else if !profileStore.hasProfiles {
-          // `WelcomeView`'s `.heroChecking` state covers the
-          // `isCloudLoadPending` case too — the old bare `ProgressView`
-          // branch is subsumed by the new state machine.
-          WelcomeView()
-            .onChange(of: profileStore.profiles) { _, newProfiles in
-              if let first = newProfiles.first {
-                openWindow(value: first.id)
-              }
-            }
-        } else {
-          // Profile is genuinely gone — close this window
+        } else if profileID != nil {
+          // This window was opened for a specific profile that no longer
+          // exists. Close it — the user will land on whichever window
+          // SwiftUI brings forward next.
           Color.clear
             .onAppear {
               logger.warning(
                 "Dismissing window — profile not found. profileID=\(profileID?.uuidString ?? "nil", privacy: .public), profileCount=\(profileStore.profiles.count), profileIDs=\(profileStore.profiles.map(\.id).map(\.uuidString).joined(separator: ","), privacy: .public)"
               )
               dismiss()
+            }
+        } else {
+          // No specific profile requested AND no active profile. Covers
+          // both the empty first-run case (`!hasProfiles` → hero state 1)
+          // and the multi-profile-no-selection case (2+ profiles, none
+          // picked → picker state 5). `WelcomeView`'s state machine
+          // picks the right branch.
+          WelcomeView()
+            .onChange(of: profileStore.profiles) { _, newProfiles in
+              if newProfiles.count == 1, let first = newProfiles.first {
+                openWindow(value: first.id)
+              }
             }
         }
       }

--- a/App/UITestSeedHydrator.swift
+++ b/App/UITestSeedHydrator.swift
@@ -22,11 +22,50 @@ enum UITestSeedHydrator {
   static func hydrate(
     _ seed: UITestSeed,
     into manager: ProfileContainerManager
-  ) throws -> Profile {
+  ) throws -> Profile? {
     switch seed {
     case .tradeBaseline:
       return try hydrateTradeBaseline(into: manager)
+    case .welcomeEmpty:
+      return nil
+    case .welcomeSingleCloudProfile:
+      try hydrateWelcomeProfile(
+        id: UITestWelcomeFixtures.householdProfileId,
+        label: UITestWelcomeFixtures.householdProfileLabel,
+        into: manager
+      )
+      // Return nil so `uiTestingProfileId` stays unset and the normal
+      // auto-activation flow in `ProfileStore.loadCloudProfiles` can fire.
+      return nil
+    case .welcomeMultipleCloudProfiles:
+      try hydrateWelcomeProfile(
+        id: UITestWelcomeFixtures.householdProfileId,
+        label: UITestWelcomeFixtures.householdProfileLabel,
+        into: manager
+      )
+      try hydrateWelcomeProfile(
+        id: UITestWelcomeFixtures.sideBusinessProfileId,
+        label: UITestWelcomeFixtures.sideBusinessProfileLabel,
+        into: manager
+      )
+      return nil
     }
+  }
+
+  private static func hydrateWelcomeProfile(
+    id: UUID,
+    label: String,
+    into manager: ProfileContainerManager
+  ) throws {
+    let profile = Profile(
+      id: id,
+      label: label,
+      backendType: .cloudKit,
+      currencyCode: UITestWelcomeFixtures.profileCurrencyCode,
+      financialYearStartMonth: 7,
+      createdAt: Date(timeIntervalSince1970: 1_700_000_000)
+    )
+    try upsertProfile(profile, into: manager)
   }
 
   // MARK: - Seeds

--- a/App/UITestingLauncherView.swift
+++ b/App/UITestingLauncherView.swift
@@ -2,9 +2,13 @@
   import SwiftUI
 
   /// Hidden view hosted by the launcher Window. On `.task` it opens the
-  /// seeded profile's window via `openWindow(value:)` and immediately
-  /// dismisses the launcher, leaving only the profile window visible to
-  /// the UI test driver.
+  /// main `ProfileWindowView` window and immediately dismisses the
+  /// launcher, leaving only that window visible to the UI test driver.
+  /// When a specific profile was seeded (`profileId != nil`) the window is
+  /// opened with that value so the scene binds directly to it; when the
+  /// seed produced no profile (Welcome seeds) `openWindow()` opens the
+  /// default `WindowGroup(for:)` window with a nil binding so `WelcomeView`
+  /// renders inside it.
   ///
   /// The launcher Window is `.defaultLaunchBehavior(.suppressed)` in
   /// production, so this view is never instantiated outside `--ui-testing`.
@@ -23,13 +27,16 @@
       Color.clear
         .frame(width: 1, height: 1)
         .task {
-          guard let profileId else { return }
           // openWindow runs synchronously from the test's perspective but
           // its scene materialisation is asynchronous. Dismissing the
           // launcher immediately afterwards is intentional: drivers
           // tolerate a transient zero-windows gap because
           // `MoolahApp.expectMainWindowVisible` waits for the new window.
-          openWindow(value: profileId)
+          if let profileId {
+            openWindow(value: profileId)
+          } else {
+            openWindow(id: MoolahApp.mainWindowID)
+          }
           dismissWindow(id: "ui-testing-launcher")
         }
     }

--- a/Features/Profiles/ProfileStore+Cloud.swift
+++ b/Features/Profiles/ProfileStore+Cloud.swift
@@ -29,15 +29,26 @@ extension ProfileStore {
         cancelPendingRetry()
       }
 
-      // Auto-select a profile when none is active (e.g. new device receiving
-      // its first cloud profile from another device). Suppressed when
-      // `WelcomeView` is mid-create — see design spec §3.3 race condition.
-      if activeProfileID == nil, let first = profiles.first, welcomePhase != .creating {
+      // Auto-select a profile when none is active AND there is exactly one
+      // profile in total (e.g. new device receiving its first cloud profile
+      // from another device). Suppressed when `WelcomeView` is mid-create —
+      // see design spec §3.3 race condition. With two or more profiles, the
+      // `WelcomeView` picker (state 5) lets the user choose explicitly.
+      if activeProfileID == nil,
+        profiles.count == 1,
+        let first = profiles.first,
+        welcomePhase != .creating
+      {
         self.activeProfileID = first.id
         saveActiveProfileID()
         logger.debug("Auto-selected profile: \(first.id)")
       } else if welcomePhase == .creating {
         logger.debug("Skipped auto-select — welcomePhase == .creating")
+      } else if activeProfileID == nil, profiles.count > 1 {
+        let profileCount = profiles.count
+        logger.debug(
+          "Skipped auto-select — \(profileCount) profiles present, picker will choose"
+        )
       }
 
       // Handle profiles deleted on another device.

--- a/Features/Profiles/Views/WelcomeView.swift
+++ b/Features/Profiles/Views/WelcomeView.swift
@@ -86,6 +86,12 @@ struct WelcomeView: View {
   private func heroOffView(
     reason: ICloudAvailability.UnavailableReason
   ) -> some View {
+    // `ICloudOffChip` already labels the iCloud-off state for VoiceOver, so
+    // the hero does not need its own overall `.accessibilityLabel(…)`. An
+    // outer label here also collapses the inner `WelcomeHero` — including
+    // its "Get started" `Button` — into a single accessibility element with
+    // that label, which hides the primary CTA from label-based queries and
+    // from individual VoiceOver focus.
     WelcomeHero(
       primaryAction: beginCreate,
       footer: {
@@ -95,7 +101,7 @@ struct WelcomeView: View {
           )
       }
     )
-    .accessibilityLabel(offHeroLabel(for: reason))
+    .accessibilityHint(offHeroHint(for: reason))
   }
 
   private func formView(
@@ -196,22 +202,18 @@ struct WelcomeView: View {
     }
   }
 
-  private func offHeroLabel(
+  private func offHeroHint(
     for reason: ICloudAvailability.UnavailableReason
   ) -> String {
     switch reason {
     case .notSignedIn:
-      return String(localized: "Welcome to Moolah. iCloud is not signed in.")
+      return String(localized: "iCloud is not signed in.")
     case .restricted:
-      return String(localized: "Welcome to Moolah. iCloud is restricted.")
+      return String(localized: "iCloud is restricted.")
     case .temporarilyUnavailable:
-      return String(
-        localized: "Welcome to Moolah. iCloud is temporarily unavailable."
-      )
+      return String(localized: "iCloud is temporarily unavailable.")
     case .entitlementsMissing:
-      return String(
-        localized: "Welcome to Moolah. iCloud is not available in this build."
-      )
+      return String(localized: "iCloud is not available in this build.")
     }
   }
 }

--- a/MoolahTests/UITestSupport/UITestSeedHydratorTests.swift
+++ b/MoolahTests/UITestSupport/UITestSeedHydratorTests.swift
@@ -47,7 +47,8 @@ final class UITestSeedHydratorTests: XCTestCase {
   }
 
   func testHydrateReturnsSeededProfile() throws {
-    let profile = try UITestSeedHydrator.hydrate(.tradeBaseline, into: containerManager)
+    let profile = try XCTUnwrap(
+      try UITestSeedHydrator.hydrate(.tradeBaseline, into: containerManager))
 
     XCTAssertEqual(profile.id, UITestFixtures.TradeBaseline.profileId)
     XCTAssertEqual(profile.backendType, .cloudKit)
@@ -57,7 +58,8 @@ final class UITestSeedHydratorTests: XCTestCase {
   // MARK: - Per-profile data
 
   func testHydrateTradeBaselineSeedsTheAccounts() throws {
-    let profile = try UITestSeedHydrator.hydrate(.tradeBaseline, into: containerManager)
+    let profile = try XCTUnwrap(
+      try UITestSeedHydrator.hydrate(.tradeBaseline, into: containerManager))
     let container = try containerManager.container(for: profile.id)
 
     let context = ModelContext(container)
@@ -79,7 +81,8 @@ final class UITestSeedHydratorTests: XCTestCase {
   }
 
   func testHydrateTradeBaselineSeedsTheTradeTransaction() throws {
-    let profile = try UITestSeedHydrator.hydrate(.tradeBaseline, into: containerManager)
+    let profile = try XCTUnwrap(
+      try UITestSeedHydrator.hydrate(.tradeBaseline, into: containerManager))
     let container = try containerManager.container(for: profile.id)
 
     let context = ModelContext(container)
@@ -111,7 +114,8 @@ final class UITestSeedHydratorTests: XCTestCase {
   }
 
   func testHydrateTradeBaselineSeedsTheCategories() throws {
-    let profile = try UITestSeedHydrator.hydrate(.tradeBaseline, into: containerManager)
+    let profile = try XCTUnwrap(
+      try UITestSeedHydrator.hydrate(.tradeBaseline, into: containerManager))
     let container = try containerManager.container(for: profile.id)
 
     let context = ModelContext(container)
@@ -126,7 +130,8 @@ final class UITestSeedHydratorTests: XCTestCase {
   }
 
   func testHydrateTradeBaselineSeedsTheCustomSplitTransaction() throws {
-    let profile = try UITestSeedHydrator.hydrate(.tradeBaseline, into: containerManager)
+    let profile = try XCTUnwrap(
+      try UITestSeedHydrator.hydrate(.tradeBaseline, into: containerManager))
     let container = try containerManager.container(for: profile.id)
 
     let context = ModelContext(container)
@@ -160,7 +165,8 @@ final class UITestSeedHydratorTests: XCTestCase {
   }
 
   func testHydrateTradeBaselineSeedsTheHistoricalPayees() throws {
-    let profile = try UITestSeedHydrator.hydrate(.tradeBaseline, into: containerManager)
+    let profile = try XCTUnwrap(
+      try UITestSeedHydrator.hydrate(.tradeBaseline, into: containerManager))
     let container = try containerManager.container(for: profile.id)
 
     let context = ModelContext(container)

--- a/MoolahUITests_macOS/Helpers/MoolahApp.swift
+++ b/MoolahUITests_macOS/Helpers/MoolahApp.swift
@@ -39,6 +39,9 @@ final class MoolahApp {
   /// Sidebar containing accounts, named views, and earmarks.
   var sidebar: SidebarScreen { SidebarScreen(app: self) }
 
+  /// First-run `WelcomeView` state machine (hero / form / picker).
+  var welcome: WelcomeScreen { WelcomeScreen(app: self) }
+
   /// Centre column listing transactions for the current sidebar selection.
   var transactionList: TransactionListScreen { TransactionListScreen(app: self) }
 

--- a/MoolahUITests_macOS/Helpers/MoolahUITestCase.swift
+++ b/MoolahUITests_macOS/Helpers/MoolahUITestCase.swift
@@ -232,42 +232,75 @@ class MoolahUITestCase: XCTestCase {
     lines.append("")
     switch app.seed {
     case .tradeBaseline:
-      let fixtures = UITestFixtures.TradeBaseline.self
-      lines.append("# fixtures")
-      lines.append("profile.id      = \(fixtures.profileId)")
-      lines.append("profile.label   = \(fixtures.profileLabel)")
-      lines.append("profile.currency = \(fixtures.profileCurrencyCode)")
-      lines.append("checking.id     = \(fixtures.checkingAccountId)")
-      lines.append("checking.name   = \(fixtures.checkingAccountName)")
-      lines.append("brokerage.id    = \(fixtures.brokerageAccountId)")
-      lines.append("brokerage.name  = \(fixtures.brokerageAccountName)")
-      lines.append("usdSavings.id   = \(fixtures.usdAccountId)")
-      lines.append("usdSavings.name = \(fixtures.usdAccountName)")
-      lines.append("usdSavings.instrument = \(fixtures.usdAccountInstrumentCode)")
-      lines.append("trade.id        = \(fixtures.bhpPurchaseId)")
-      lines.append("trade.payee     = \(fixtures.bhpPurchasePayee)")
-      lines.append("trade.cents     = \(fixtures.bhpPurchaseAmountCents)")
-      lines.append("trade.date      = \(fixtures.bhpPurchaseDate)")
-      lines.append("historical.amount.cents = \(fixtures.historicalExpenseAmountCents)")
-      for (index, historical) in fixtures.historicalPayees.enumerated() {
-        lines.append(
-          "historical[\(index)].id/payee/date = "
-            + "\(historical.id) / \(historical.payee) / \(historical.date)"
-        )
-      }
-      lines.append(
-        "category.groceries.id/name = "
-          + "\(fixtures.groceriesCategoryId) / \(fixtures.groceriesCategoryName)")
-      lines.append("category.gym.id/name = \(fixtures.gymCategoryId) / \(fixtures.gymCategoryName)")
-      lines.append(
-        "splitShop.id/payee/date = "
-          + "\(fixtures.splitShopId) / \(fixtures.splitShopPayee) / \(fixtures.splitShopDate)")
-      lines.append(
-        "splitShop.legA.cents / legB.cents = "
-          + "\(fixtures.splitShopLegAAmountCents) / \(fixtures.splitShopLegBAmountCents)"
-      )
+      appendTradeBaselineFixtures(into: &lines)
+    case .welcomeEmpty:
+      lines.append("# fixtures — empty index, no profiles")
+    case .welcomeSingleCloudProfile:
+      appendWelcomeSingleProfileFixtures(into: &lines)
+    case .welcomeMultipleCloudProfiles:
+      appendWelcomeMultipleProfileFixtures(into: &lines)
     }
     return lines.joined(separator: "\n") + "\n"
+  }
+
+  private func appendTradeBaselineFixtures(into lines: inout [String]) {
+    let fixtures = UITestFixtures.TradeBaseline.self
+    lines.append("# fixtures")
+    lines.append("profile.id      = \(fixtures.profileId)")
+    lines.append("profile.label   = \(fixtures.profileLabel)")
+    lines.append("profile.currency = \(fixtures.profileCurrencyCode)")
+    lines.append("checking.id     = \(fixtures.checkingAccountId)")
+    lines.append("checking.name   = \(fixtures.checkingAccountName)")
+    lines.append("brokerage.id    = \(fixtures.brokerageAccountId)")
+    lines.append("brokerage.name  = \(fixtures.brokerageAccountName)")
+    lines.append("usdSavings.id   = \(fixtures.usdAccountId)")
+    lines.append("usdSavings.name = \(fixtures.usdAccountName)")
+    lines.append("usdSavings.instrument = \(fixtures.usdAccountInstrumentCode)")
+    lines.append("trade.id        = \(fixtures.bhpPurchaseId)")
+    lines.append("trade.payee     = \(fixtures.bhpPurchasePayee)")
+    lines.append("trade.cents     = \(fixtures.bhpPurchaseAmountCents)")
+    lines.append("trade.date      = \(fixtures.bhpPurchaseDate)")
+    lines.append("historical.amount.cents = \(fixtures.historicalExpenseAmountCents)")
+    for (index, historical) in fixtures.historicalPayees.enumerated() {
+      lines.append(
+        "historical[\(index)].id/payee/date = "
+          + "\(historical.id) / \(historical.payee) / \(historical.date)"
+      )
+    }
+    lines.append(
+      "category.groceries.id/name = "
+        + "\(fixtures.groceriesCategoryId) / \(fixtures.groceriesCategoryName)")
+    lines.append("category.gym.id/name = \(fixtures.gymCategoryId) / \(fixtures.gymCategoryName)")
+    lines.append(
+      "splitShop.id/payee/date = "
+        + "\(fixtures.splitShopId) / \(fixtures.splitShopPayee) / \(fixtures.splitShopDate)")
+    lines.append(
+      "splitShop.legA.cents / legB.cents = "
+        + "\(fixtures.splitShopLegAAmountCents) / \(fixtures.splitShopLegBAmountCents)"
+    )
+  }
+
+  private func appendWelcomeSingleProfileFixtures(into lines: inout [String]) {
+    lines.append("# fixtures")
+    lines.append(
+      "household.id/label = "
+        + "\(UITestWelcomeFixtures.householdProfileId) "
+        + "/ \(UITestWelcomeFixtures.householdProfileLabel)"
+    )
+  }
+
+  private func appendWelcomeMultipleProfileFixtures(into lines: inout [String]) {
+    lines.append("# fixtures")
+    lines.append(
+      "household.id/label = "
+        + "\(UITestWelcomeFixtures.householdProfileId) "
+        + "/ \(UITestWelcomeFixtures.householdProfileLabel)"
+    )
+    lines.append(
+      "sideBusiness.id/label = "
+        + "\(UITestWelcomeFixtures.sideBusinessProfileId) "
+        + "/ \(UITestWelcomeFixtures.sideBusinessProfileLabel)"
+    )
   }
 
   private func captureScreenshot(for app: MoolahApp, to url: URL) {

--- a/MoolahUITests_macOS/Helpers/Screens/WelcomeScreen.swift
+++ b/MoolahUITests_macOS/Helpers/Screens/WelcomeScreen.swift
@@ -1,0 +1,79 @@
+import XCTest
+
+/// Driver for the first-run `WelcomeView` state machine. Returned from
+/// `MoolahApp.welcome`. Covers hero, create-profile form, and the
+/// multi-profile picker. Per `guides/UI_TEST_GUIDE.md`, tests never
+/// touch `XCUIElement` directly — every UI action routes through this
+/// driver.
+@MainActor
+struct WelcomeScreen {
+  let app: MoolahApp
+
+  /// Waits for the hero "Get started" button to be visible. Used at
+  /// the start of first-run tests to confirm the state machine landed
+  /// in `.heroChecking` / `.heroNoneFound` / `.heroOff` rather than
+  /// auto-activating.
+  func waitForHero(timeout: TimeInterval = 5) {
+    Trace.record()
+    let button = app.application.buttons["Get started"]
+    if !button.waitForExistence(timeout: timeout) {
+      Trace.recordFailure("hero 'Get started' button did not appear")
+      XCTFail("Welcome hero did not appear within \(timeout)s")
+    }
+  }
+
+  /// Waits for the multi-profile picker to be visible. The picker is
+  /// identified by its "+ Create a new profile" footer row.
+  func waitForPicker(timeout: TimeInterval = 5) {
+    Trace.record()
+    let row = app.element(for: UITestIdentifiers.Welcome.pickerCreateNewRow)
+    if !row.waitForExistence(timeout: timeout) {
+      Trace.recordFailure("picker create-new row did not appear")
+      XCTFail("Multi-profile picker did not appear within \(timeout)s")
+    }
+  }
+
+  /// Number of profile rows visible in the picker. Rows are identified
+  /// by the `welcome.picker.row.` prefix followed by a UUID.
+  func pickerRowCount() -> Int {
+    let prefix = "welcome.picker.row."
+    let predicate = NSPredicate(format: "identifier BEGINSWITH %@", prefix)
+    return app.application.buttons.matching(predicate).count
+  }
+
+  /// Taps "Get started" and waits for the create-profile Name field to
+  /// appear.
+  func tapGetStarted() {
+    Trace.record()
+    app.application.buttons["Get started"].click()
+    let nameField = app.element(for: UITestIdentifiers.Welcome.nameField)
+    if !nameField.waitForExistence(timeout: 3) {
+      Trace.recordFailure("name field did not appear after tapGetStarted")
+      XCTFail("Name field did not appear after tapping Get started")
+    }
+  }
+
+  /// Types `name` into the Name field after giving it keyboard focus.
+  func typeName(_ name: String) {
+    Trace.record(detail: "name=\(name)")
+    let field = app.element(for: UITestIdentifiers.Welcome.nameField)
+    field.click()
+    field.typeText(name)
+  }
+
+  /// Taps "Create Profile" and waits for the hero to disappear — the
+  /// post-condition that the session has loaded.
+  func tapCreateProfile() {
+    Trace.record()
+    app.element(for: UITestIdentifiers.Welcome.createProfileButton).click()
+    let hero = app.application.buttons["Get started"]
+    let expectation = XCTNSPredicateExpectation(
+      predicate: NSPredicate(format: "exists == false"),
+      object: hero
+    )
+    if XCTWaiter().wait(for: [expectation], timeout: 5) != .completed {
+      Trace.recordFailure("hero still visible after tapping Create Profile")
+      XCTFail("Welcome hero remained visible after Create Profile")
+    }
+  }
+}

--- a/MoolahUITests_macOS/Tests/WelcomeViewTests.swift
+++ b/MoolahUITests_macOS/Tests/WelcomeViewTests.swift
@@ -1,0 +1,54 @@
+import XCTest
+
+/// First-run `WelcomeView` state-machine tests. Covers the three
+/// cloud-profile-count paths — zero (hero + create), one (auto-open),
+/// two (picker). Seeds are deterministic per
+/// `UITestSupport/UITestSeed.swift`.
+///
+/// Design spec §7.4 also calls for `iCloudUnavailable` and mid-form
+/// profile-arrival tests; those require additional infrastructure (an
+/// iCloud-unavailable launch flag and a DEBUG-only "inject profile"
+/// affordance) and are deferred to a follow-up task.
+@MainActor
+final class WelcomeViewTests: MoolahUITestCase {
+  /// First-launch with an empty index container → user sees the
+  /// branded hero, taps "Get started", fills in a name, and tapping
+  /// "Create Profile" dismisses the hero (session window takes over).
+  func testFirstLaunchNoCloudProfiles_showsHeroAndSetsUpProfile() {
+    let app = launch(seed: .welcomeEmpty)
+
+    app.welcome.waitForHero()
+    app.welcome.tapGetStarted()
+    app.welcome.typeName("Household")
+    app.welcome.tapCreateProfile()
+  }
+
+  /// One cloud profile present → `.autoActivateSingle` skips the hero
+  /// and lands directly in the session. The post-condition is that
+  /// the hero never appears.
+  func testFirstLaunchWithOneCloudProfile_autoOpens() {
+    let app = launch(seed: .welcomeSingleCloudProfile)
+
+    let hero = app.application.buttons["Get started"]
+    let expectation = XCTNSPredicateExpectation(
+      predicate: NSPredicate(format: "exists == false"),
+      object: hero
+    )
+    if XCTWaiter().wait(for: [expectation], timeout: 5) != .completed {
+      XCTFail("Welcome hero appeared despite a single cloud profile being seeded")
+    }
+  }
+
+  /// Two cloud profiles → the picker (state 5) is shown with both
+  /// rows and the "+ Create a new profile" footer.
+  func testFirstLaunchWithMultipleCloudProfiles_showsPicker() {
+    let app = launch(seed: .welcomeMultipleCloudProfiles)
+
+    app.welcome.waitForPicker()
+    XCTAssertEqual(
+      app.welcome.pickerRowCount(),
+      2,
+      "Expected two profile rows in the picker"
+    )
+  }
+}

--- a/UITestSupport/UITestSeed.swift
+++ b/UITestSupport/UITestSeed.swift
@@ -20,6 +20,34 @@ public enum UITestSeed: String, CaseIterable, Sendable {
   /// for `TransactionDetailView` tests covering focus, payee
   /// autocomplete, and cross-currency.
   case tradeBaseline
+
+  /// Blank index container — no profiles. Drives the first-run
+  /// `WelcomeView` `.heroChecking` / `.heroNoneFound` branches.
+  case welcomeEmpty
+
+  /// One `ProfileRecord` seeded in the index. Triggers auto-activation
+  /// into `SessionRootView` via `WelcomeView`'s `.autoActivateSingle`
+  /// branch.
+  case welcomeSingleCloudProfile
+
+  /// Two `ProfileRecord`s seeded in the index. Drives the multi-profile
+  /// picker (`WelcomeView` state 5).
+  case welcomeMultipleCloudProfiles
+}
+
+/// Fixtures for the first-run Welcome seeds. Defined here so both the
+/// app (hydration) and UI-test drivers reference the same UUIDs.
+public enum UITestWelcomeFixtures {
+  // Constant UUIDs — `??` fallback keeps SwiftLint's `force_unwrapping`
+  // happy; the literal strings above parse successfully so the fallback
+  // never fires in practice.
+  public static let householdProfileId =
+    UUID(uuidString: "B0000000-0000-0000-0000-000000000001") ?? UUID()
+  public static let householdProfileLabel = "Household"
+  public static let sideBusinessProfileId =
+    UUID(uuidString: "B0000000-0000-0000-0000-000000000002") ?? UUID()
+  public static let sideBusinessProfileLabel = "Side business"
+  public static let profileCurrencyCode = "AUD"
 }
 
 /// A past single-leg expense used to seed payee suggestions.


### PR DESCRIPTION
## Summary

Implements Task 17 of [`plans/2026-04-24-first-run-experience-implementation.md`](https://github.com/ajsutton/moolah-native/blob/main/plans/2026-04-24-first-run-experience-implementation.md). Builds on [#436](https://github.com/ajsutton/moolah-native/pull/436) (Task 16).

- Three new `UITestSeed` cases (`welcomeEmpty`, `welcomeSingleCloudProfile`, `welcomeMultipleCloudProfiles`) plus `UITestWelcomeFixtures` carrying the deterministic profile UUIDs.
- Hydrator signature now returns `Profile?` so empty/multi-profile seeds don't pin `uiTestingProfileId` to any single profile.
- `configureSyncCoordinator(...)` takes `isUITesting: Bool` instead of keying off `uiTestingProfileId != nil`, so empty-seed runs still skip the real sync engine.
- New `WelcomeScreen` driver (`waitForHero`, `tapGetStarted`, `typeName`, `tapCreateProfile`, `waitForPicker`, `pickerRowCount`).
- `WelcomeViewTests` covers the three cloud-profile-count paths.

## Deferred to a follow-up

- `iCloudUnavailable` seed — needs a launch flag that forces `SyncCoordinator.iCloudAvailability` to `.unavailable(.notSignedIn)` in UI-test mode.
- Mid-form profile-arrival tests — need a DEBUG-only "inject profile" affordance inside `CreateProfileFormView`.

## Test plan

- [x] `just build-mac` — succeeded
- [x] `just format-check` — clean