### PR TITLE
chore(just): forward extra args to run-mac / run-mac-with-logs

### DIFF
--- a/justfile
+++ b/justfile
@@ -85,16 +85,24 @@ build-mac: generate
     fi
     xcodebuild build "${args[@]}"
 
-# Build and launch the macOS app
-run-mac: generate
+# Build and launch the macOS app. Extra args are forwarded as launch
+# arguments to the app process (e.g. `just run-mac --ui-testing`).
+# Environment variables exported by the caller (e.g.
+# `UI_TESTING_SEED=welcomeEmpty just run-mac --ui-testing`) are
+# inherited by the launched process via `open`.
+run-mac *args: generate
     #!/usr/bin/env bash
     set -euo pipefail
-    args=(-scheme Moolah-macOS -destination 'platform=macOS' -derivedDataPath .build)
+    build=(-scheme Moolah-macOS -destination 'platform=macOS' -derivedDataPath .build)
     if [ -z "${DEVELOPMENT_TEAM:-}" ]; then
-        args+=(CODE_SIGN_IDENTITY="-" ENABLE_HARDENED_RUNTIME=NO)
+        build+=(CODE_SIGN_IDENTITY="-" ENABLE_HARDENED_RUNTIME=NO)
     fi
-    xcodebuild build "${args[@]}"
-    open .build/Build/Products/Debug/Moolah.app
+    xcodebuild build "${build[@]}"
+    if [ -n "{{args}}" ]; then
+        open .build/Build/Products/Debug/Moolah.app --args {{args}}
+    else
+        open .build/Build/Products/Debug/Moolah.app
+    fi
 
 # Build a Release macOS app and install to /Applications.
 # Forces ENABLE_ENTITLEMENTS=1 for the regenerate: Release bakes in
@@ -171,9 +179,12 @@ bump-version version:
     sed -i '' 's/MARKETING_VERSION: .*/MARKETING_VERSION: "{{version}}"/' project.yml
     just generate
 
-# Build, launch macOS app, and stream logs to .agent-tmp/app-logs.txt
-run-mac-with-logs predicate='subsystem == "com.moolah.app"': generate
-    bash scripts/run-with-logs.sh '{{predicate}}'
+# Build, launch macOS app, and stream logs to .agent-tmp/app-logs.txt.
+# Extra args after the predicate are forwarded as launch arguments to
+# the app process (e.g.
+# `just run-mac-with-logs 'subsystem == "com.moolah.app"' --ui-testing`).
+run-mac-with-logs predicate='subsystem == "com.moolah.app"' *args: generate
+    bash scripts/run-with-logs.sh '{{predicate}}' {{args}}
 
 # Open the project in Xcode
 open:

--- a/scripts/run-with-logs.sh
+++ b/scripts/run-with-logs.sh
@@ -18,6 +18,10 @@
 set -euo pipefail
 
 PREDICATE="${1:-subsystem == \"com.moolah.app\"}"
+# Shift off the predicate so $@ holds any extra launch arguments for
+# the app binary (e.g. --ui-testing). `shift` fails on an empty list,
+# hence the `|| true` guard for the no-args case.
+shift || true
 LOG_DIR=".agent-tmp"
 LOG_FILE="$LOG_DIR/app-logs.txt"
 APP_PATH=".build/Build/Products/Debug/Moolah.app"
@@ -49,7 +53,11 @@ sleep 1
 
 # Launch
 echo "Launching app..."
-open "$APP_PATH"
+if [ $# -gt 0 ]; then
+    open "$APP_PATH" --args "$@"
+else
+    open "$APP_PATH"
+fi
 
 # Wait for app to appear (up to 10s)
 for i in $(seq 1 20); do


### PR DESCRIPTION
## Summary

Stacks on [#437](https://github.com/ajsutton/moolah-native/pull/437) (Task 17 seeds). Adds `*args` variadic to `run-mac` and `run-mac-with-logs`; `scripts/run-with-logs.sh` shifts off the predicate and forwards remaining args.

Combined with env vars from the caller, this lets reviewers exercise the first-run `WelcomeView` seeds without touching real on-disk data:

```bash
UI_TESTING_SEED=welcomeEmpty just run-mac --ui-testing
UI_TESTING_SEED=welcomeSingleCloudProfile just run-mac --ui-testing
UI_TESTING_SEED=welcomeMultipleCloudProfiles just run-mac --ui-testing
```

Production launches (`just run-mac` with no args) are unchanged — `open … --args` only fires when there are args to pass.

## Test plan

- [x] `just --list` parses cleanly, shows both targets with `*args`
- [x] `just run-mac` with no args still opens the prod app (unchanged code path)