### PR TITLE
fix(sync): encode record type in CKRecord.ID to stop cross-type collisions

### DIFF
--- a/App/MoolahApp+Setup.swift
+++ b/App/MoolahApp+Setup.swift
@@ -114,13 +114,13 @@ extension MoolahApp {
       let zoneID = CKRecordZone.ID(
         zoneName: "profile-index", ownerName: CKCurrentUserDefaultName)
       coordinator?.queueSave(
-        id: id, recordType: ProfileRecord.recordType, zoneID: zoneID)
+        recordType: ProfileRecord.recordType, id: id, zoneID: zoneID)
     }
     store.onProfileDeleted = { [weak coordinator] id in
       let zoneID = CKRecordZone.ID(
         zoneName: "profile-index", ownerName: CKCurrentUserDefaultName)
       coordinator?.queueDeletion(
-        id: id, recordType: ProfileRecord.recordType, zoneID: zoneID)
+        recordType: ProfileRecord.recordType, id: id, zoneID: zoneID)
     }
     coordinator.start()
     // Clean up the legacy CloudKit zone from SwiftData's automatic sync.

--- a/App/MoolahApp+Setup.swift
+++ b/App/MoolahApp+Setup.swift
@@ -113,12 +113,14 @@ extension MoolahApp {
     store.onProfileChanged = { [weak coordinator] id in
       let zoneID = CKRecordZone.ID(
         zoneName: "profile-index", ownerName: CKCurrentUserDefaultName)
-      coordinator?.queueSave(id: id, zoneID: zoneID)
+      coordinator?.queueSave(
+        id: id, recordType: ProfileRecord.recordType, zoneID: zoneID)
     }
     store.onProfileDeleted = { [weak coordinator] id in
       let zoneID = CKRecordZone.ID(
         zoneName: "profile-index", ownerName: CKCurrentUserDefaultName)
-      coordinator?.queueDeletion(id: id, zoneID: zoneID)
+      coordinator?.queueDeletion(
+        id: id, recordType: ProfileRecord.recordType, zoneID: zoneID)
     }
     coordinator.start()
     // Clean up the legacy CloudKit zone from SwiftData's automatic sync.

--- a/App/ProfileSession+SyncWiring.swift
+++ b/App/ProfileSession+SyncWiring.swift
@@ -17,10 +17,10 @@ extension ProfileSession {
   ) {
     if let repo = backend.accounts as? CloudKitAccountRepository {
       repo.onRecordChanged = { [weak coordinator] id in
-        coordinator?.queueSave(id: id, recordType: AccountRecord.recordType, zoneID: zoneID)
+        coordinator?.queueSave(recordType: AccountRecord.recordType, id: id, zoneID: zoneID)
       }
       repo.onRecordDeleted = { [weak coordinator] id in
-        coordinator?.queueDeletion(id: id, recordType: AccountRecord.recordType, zoneID: zoneID)
+        coordinator?.queueDeletion(recordType: AccountRecord.recordType, id: id, zoneID: zoneID)
       }
       repo.onInstrumentChanged = { [weak coordinator] id in
         coordinator?.queueSave(recordName: id, zoneID: zoneID)
@@ -28,11 +28,11 @@ extension ProfileSession {
     }
     if let repo = backend.transactions as? CloudKitTransactionRepository {
       repo.onRecordChanged = { [weak coordinator] id in
-        coordinator?.queueSave(id: id, recordType: TransactionRecord.recordType, zoneID: zoneID)
+        coordinator?.queueSave(recordType: TransactionRecord.recordType, id: id, zoneID: zoneID)
       }
       repo.onRecordDeleted = { [weak coordinator] id in
         coordinator?.queueDeletion(
-          id: id, recordType: TransactionRecord.recordType, zoneID: zoneID)
+          recordType: TransactionRecord.recordType, id: id, zoneID: zoneID)
       }
       repo.onInstrumentChanged = { [weak coordinator] id in
         coordinator?.queueSave(recordName: id, zoneID: zoneID)
@@ -48,47 +48,47 @@ extension ProfileSession {
   ) {
     if let repo = backend.categories as? CloudKitCategoryRepository {
       repo.onRecordChanged = { [weak coordinator] id in
-        coordinator?.queueSave(id: id, recordType: CategoryRecord.recordType, zoneID: zoneID)
+        coordinator?.queueSave(recordType: CategoryRecord.recordType, id: id, zoneID: zoneID)
       }
       repo.onRecordDeleted = { [weak coordinator] id in
-        coordinator?.queueDeletion(id: id, recordType: CategoryRecord.recordType, zoneID: zoneID)
+        coordinator?.queueDeletion(recordType: CategoryRecord.recordType, id: id, zoneID: zoneID)
       }
     }
     if let repo = backend.earmarks as? CloudKitEarmarkRepository {
       repo.onRecordChanged = { [weak coordinator] id in
-        coordinator?.queueSave(id: id, recordType: EarmarkRecord.recordType, zoneID: zoneID)
+        coordinator?.queueSave(recordType: EarmarkRecord.recordType, id: id, zoneID: zoneID)
       }
       repo.onRecordDeleted = { [weak coordinator] id in
-        coordinator?.queueDeletion(id: id, recordType: EarmarkRecord.recordType, zoneID: zoneID)
+        coordinator?.queueDeletion(recordType: EarmarkRecord.recordType, id: id, zoneID: zoneID)
       }
     }
     if let repo = backend.investments as? CloudKitInvestmentRepository {
       repo.onRecordChanged = { [weak coordinator] id in
         coordinator?.queueSave(
-          id: id, recordType: InvestmentValueRecord.recordType, zoneID: zoneID)
+          recordType: InvestmentValueRecord.recordType, id: id, zoneID: zoneID)
       }
       repo.onRecordDeleted = { [weak coordinator] id in
         coordinator?.queueDeletion(
-          id: id, recordType: InvestmentValueRecord.recordType, zoneID: zoneID)
+          recordType: InvestmentValueRecord.recordType, id: id, zoneID: zoneID)
       }
     }
     if let repo = backend.csvImportProfiles as? CloudKitCSVImportProfileRepository {
       repo.onRecordChanged = { [weak coordinator] id in
         coordinator?.queueSave(
-          id: id, recordType: CSVImportProfileRecord.recordType, zoneID: zoneID)
+          recordType: CSVImportProfileRecord.recordType, id: id, zoneID: zoneID)
       }
       repo.onRecordDeleted = { [weak coordinator] id in
         coordinator?.queueDeletion(
-          id: id, recordType: CSVImportProfileRecord.recordType, zoneID: zoneID)
+          recordType: CSVImportProfileRecord.recordType, id: id, zoneID: zoneID)
       }
     }
     if let repo = backend.importRules as? CloudKitImportRuleRepository {
       repo.onRecordChanged = { [weak coordinator] id in
-        coordinator?.queueSave(id: id, recordType: ImportRuleRecord.recordType, zoneID: zoneID)
+        coordinator?.queueSave(recordType: ImportRuleRecord.recordType, id: id, zoneID: zoneID)
       }
       repo.onRecordDeleted = { [weak coordinator] id in
         coordinator?.queueDeletion(
-          id: id, recordType: ImportRuleRecord.recordType, zoneID: zoneID)
+          recordType: ImportRuleRecord.recordType, id: id, zoneID: zoneID)
       }
     }
   }

--- a/App/ProfileSession+SyncWiring.swift
+++ b/App/ProfileSession+SyncWiring.swift
@@ -17,10 +17,10 @@ extension ProfileSession {
   ) {
     if let repo = backend.accounts as? CloudKitAccountRepository {
       repo.onRecordChanged = { [weak coordinator] id in
-        coordinator?.queueSave(id: id, zoneID: zoneID)
+        coordinator?.queueSave(id: id, recordType: AccountRecord.recordType, zoneID: zoneID)
       }
       repo.onRecordDeleted = { [weak coordinator] id in
-        coordinator?.queueDeletion(id: id, zoneID: zoneID)
+        coordinator?.queueDeletion(id: id, recordType: AccountRecord.recordType, zoneID: zoneID)
       }
       repo.onInstrumentChanged = { [weak coordinator] id in
         coordinator?.queueSave(recordName: id, zoneID: zoneID)
@@ -28,10 +28,11 @@ extension ProfileSession {
     }
     if let repo = backend.transactions as? CloudKitTransactionRepository {
       repo.onRecordChanged = { [weak coordinator] id in
-        coordinator?.queueSave(id: id, zoneID: zoneID)
+        coordinator?.queueSave(id: id, recordType: TransactionRecord.recordType, zoneID: zoneID)
       }
       repo.onRecordDeleted = { [weak coordinator] id in
-        coordinator?.queueDeletion(id: id, zoneID: zoneID)
+        coordinator?.queueDeletion(
+          id: id, recordType: TransactionRecord.recordType, zoneID: zoneID)
       }
       repo.onInstrumentChanged = { [weak coordinator] id in
         coordinator?.queueSave(recordName: id, zoneID: zoneID)
@@ -47,42 +48,47 @@ extension ProfileSession {
   ) {
     if let repo = backend.categories as? CloudKitCategoryRepository {
       repo.onRecordChanged = { [weak coordinator] id in
-        coordinator?.queueSave(id: id, zoneID: zoneID)
+        coordinator?.queueSave(id: id, recordType: CategoryRecord.recordType, zoneID: zoneID)
       }
       repo.onRecordDeleted = { [weak coordinator] id in
-        coordinator?.queueDeletion(id: id, zoneID: zoneID)
+        coordinator?.queueDeletion(id: id, recordType: CategoryRecord.recordType, zoneID: zoneID)
       }
     }
     if let repo = backend.earmarks as? CloudKitEarmarkRepository {
       repo.onRecordChanged = { [weak coordinator] id in
-        coordinator?.queueSave(id: id, zoneID: zoneID)
+        coordinator?.queueSave(id: id, recordType: EarmarkRecord.recordType, zoneID: zoneID)
       }
       repo.onRecordDeleted = { [weak coordinator] id in
-        coordinator?.queueDeletion(id: id, zoneID: zoneID)
+        coordinator?.queueDeletion(id: id, recordType: EarmarkRecord.recordType, zoneID: zoneID)
       }
     }
     if let repo = backend.investments as? CloudKitInvestmentRepository {
       repo.onRecordChanged = { [weak coordinator] id in
-        coordinator?.queueSave(id: id, zoneID: zoneID)
+        coordinator?.queueSave(
+          id: id, recordType: InvestmentValueRecord.recordType, zoneID: zoneID)
       }
       repo.onRecordDeleted = { [weak coordinator] id in
-        coordinator?.queueDeletion(id: id, zoneID: zoneID)
+        coordinator?.queueDeletion(
+          id: id, recordType: InvestmentValueRecord.recordType, zoneID: zoneID)
       }
     }
     if let repo = backend.csvImportProfiles as? CloudKitCSVImportProfileRepository {
       repo.onRecordChanged = { [weak coordinator] id in
-        coordinator?.queueSave(id: id, zoneID: zoneID)
+        coordinator?.queueSave(
+          id: id, recordType: CSVImportProfileRecord.recordType, zoneID: zoneID)
       }
       repo.onRecordDeleted = { [weak coordinator] id in
-        coordinator?.queueDeletion(id: id, zoneID: zoneID)
+        coordinator?.queueDeletion(
+          id: id, recordType: CSVImportProfileRecord.recordType, zoneID: zoneID)
       }
     }
     if let repo = backend.importRules as? CloudKitImportRuleRepository {
       repo.onRecordChanged = { [weak coordinator] id in
-        coordinator?.queueSave(id: id, zoneID: zoneID)
+        coordinator?.queueSave(id: id, recordType: ImportRuleRecord.recordType, zoneID: zoneID)
       }
       repo.onRecordDeleted = { [weak coordinator] id in
-        coordinator?.queueDeletion(id: id, zoneID: zoneID)
+        coordinator?.queueDeletion(
+          id: id, recordType: ImportRuleRecord.recordType, zoneID: zoneID)
       }
     }
   }

--- a/Backends/CloudKit/Sync/AccountRecord+CloudKit.swift
+++ b/Backends/CloudKit/Sync/AccountRecord+CloudKit.swift
@@ -7,7 +7,8 @@ extension AccountRecord: CloudKitRecordConvertible {
   static let recordType = "CD_AccountRecord"
 
   func toCKRecord(in zoneID: CKRecordZone.ID) -> CKRecord {
-    let recordID = CKRecord.ID(recordName: id.uuidString, zoneID: zoneID)
+    let recordID = CKRecord.ID(
+      recordType: Self.recordType, uuid: id, zoneID: zoneID)
     let record = CKRecord(recordType: Self.recordType, recordID: recordID)
     record["name"] = name as CKRecordValue
     record["type"] = type as CKRecordValue
@@ -19,7 +20,7 @@ extension AccountRecord: CloudKitRecordConvertible {
 
   static func fieldValues(from ckRecord: CKRecord) -> AccountRecord {
     AccountRecord(
-      id: UUID(uuidString: ckRecord.recordID.recordName) ?? UUID(),
+      id: ckRecord.recordID.uuid ?? UUID(),
       name: ckRecord["name"] as? String ?? "",
       type: ckRecord["type"] as? String ?? "bank",
       instrumentId: ckRecord["instrumentId"] as? String ?? "AUD",

--- a/Backends/CloudKit/Sync/CKRecordID+RecordName.swift
+++ b/Backends/CloudKit/Sync/CKRecordID+RecordName.swift
@@ -1,0 +1,45 @@
+import CloudKit
+import Foundation
+
+// `CKRecord.ID.recordName` is the primary key for a record in a zone. UUID-keyed
+// records in this app encode the SwiftData record type as a prefix so two
+// different types that happen to share a UUID can't collide on the server
+// (issue #416). Format: `"<recordType>|<uuid.uuidString>"` for new records.
+// Legacy records already on the server continue to use bare `<uuid.uuidString>`;
+// these helpers accept both formats.
+extension CKRecord.ID {
+  /// Constructs a prefixed recordName from a record type and UUID.
+  convenience init(
+    recordType: String, uuid: UUID, zoneID: CKRecordZone.ID
+  ) {
+    self.init(
+      recordName: "\(recordType)|\(uuid.uuidString)",
+      zoneID: zoneID
+    )
+  }
+
+  /// Returns the UUID portion of a recordName regardless of format.
+  /// Accepts `"<TYPE>|<UUID>"` (new) and `"<UUID>"` (legacy).
+  /// Returns `nil` for non-UUID names (e.g. instrument IDs like `"AUD"`).
+  func uuidRecordName() -> UUID? {
+    if let sep = recordName.firstIndex(of: "|") {
+      let uuidPart = recordName[recordName.index(after: sep)...]
+      return UUID(uuidString: String(uuidPart))
+    }
+    return UUID(uuidString: recordName)
+  }
+
+  /// The key used for per-record system-fields caching during batch upsert.
+  /// - For UUID-keyed records: the bare UUID string (prefix stripped).
+  /// - For string-keyed records (instruments): the full recordName.
+  ///
+  /// This matches the keys used by `batchUpsertX` methods which look up
+  /// `systemFields[id.uuidString]` for UUID records and `systemFields[id]`
+  /// for instruments.
+  var systemFieldsKey: String {
+    if let sep = recordName.firstIndex(of: "|") {
+      return String(recordName[recordName.index(after: sep)...])
+    }
+    return recordName
+  }
+}

--- a/Backends/CloudKit/Sync/CKRecordIDRecordName.swift
+++ b/Backends/CloudKit/Sync/CKRecordIDRecordName.swift
@@ -1,9 +1,23 @@
 import CloudKit
 import Foundation
 
-/// Filename-marker enum so SwiftLint's `file_name` rule has a declared type
-/// matching the filename. The extension on `CKRecord.ID` below does the work.
-enum CKRecordIDRecordName {}
+/// Namespace for recordName helpers used on `CKRecord.ID` and on raw
+/// recordName strings. Also serves as the filename-marker type so
+/// SwiftLint's `file_name` rule matches this file's name.
+enum CKRecordIDRecordName {
+  /// The key used for per-record system-fields caching during batch upsert,
+  /// computed from a raw recordName string. See the `CKRecord.ID` extension
+  /// property of the same name for the typed version used throughout the
+  /// codebase; this static is for the downlink pipeline where the lookup
+  /// dictionary is built from `(String, Data)` tuples whose key is a
+  /// `CKRecord.ID.recordName` captured earlier off-main.
+  static func systemFieldsKey(for recordName: String) -> String {
+    if let sep = recordName.firstIndex(of: "|") {
+      return String(recordName[recordName.index(after: sep)...])
+    }
+    return recordName
+  }
+}
 
 // `CKRecord.ID.recordName` is the primary key for a record in a zone. UUID-keyed
 // records in this app encode the SwiftData record type as a prefix so two
@@ -37,9 +51,6 @@ extension CKRecord.ID {
   /// `systemFields[id.uuidString]` for UUID records and `systemFields[id]`
   /// for instruments.
   var systemFieldsKey: String {
-    if let sep = recordName.firstIndex(of: "|") {
-      return String(recordName[recordName.index(after: sep)...])
-    }
-    return recordName
+    CKRecordIDRecordName.systemFieldsKey(for: recordName)
   }
 }

--- a/Backends/CloudKit/Sync/CKRecordIDRecordName.swift
+++ b/Backends/CloudKit/Sync/CKRecordIDRecordName.swift
@@ -22,15 +22,11 @@ extension CKRecord.ID {
     )
   }
 
-  /// Returns the UUID portion of a recordName regardless of format.
-  /// Accepts `"<TYPE>|<UUID>"` (new) and `"<UUID>"` (legacy).
-  /// Returns `nil` for non-UUID names (e.g. instrument IDs like `"AUD"`).
-  func uuidRecordName() -> UUID? {
-    if let sep = recordName.firstIndex(of: "|") {
-      let uuidPart = recordName[recordName.index(after: sep)...]
-      return UUID(uuidString: String(uuidPart))
-    }
-    return UUID(uuidString: recordName)
+  /// The UUID portion of the recordName, or `nil` for non-UUID names
+  /// (e.g. instrument IDs like `"AUD"`). Accepts both `"<TYPE>|<UUID>"`
+  /// (new) and `"<UUID>"` (legacy) by parsing `systemFieldsKey`.
+  var uuid: UUID? {
+    UUID(uuidString: systemFieldsKey)
   }
 
   /// The key used for per-record system-fields caching during batch upsert.

--- a/Backends/CloudKit/Sync/CKRecordIDRecordName.swift
+++ b/Backends/CloudKit/Sync/CKRecordIDRecordName.swift
@@ -1,6 +1,10 @@
 import CloudKit
 import Foundation
 
+/// Filename-marker enum so SwiftLint's `file_name` rule has a declared type
+/// matching the filename. The extension on `CKRecord.ID` below does the work.
+enum CKRecordIDRecordName {}
+
 // `CKRecord.ID.recordName` is the primary key for a record in a zone. UUID-keyed
 // records in this app encode the SwiftData record type as a prefix so two
 // different types that happen to share a UUID can't collide on the server

--- a/Backends/CloudKit/Sync/CSVImportProfileRecord+CloudKit.swift
+++ b/Backends/CloudKit/Sync/CSVImportProfileRecord+CloudKit.swift
@@ -7,7 +7,8 @@ extension CSVImportProfileRecord: CloudKitRecordConvertible {
   static let recordType = "CD_CSVImportProfileRecord"
 
   func toCKRecord(in zoneID: CKRecordZone.ID) -> CKRecord {
-    let recordID = CKRecord.ID(recordName: id.uuidString, zoneID: zoneID)
+    let recordID = CKRecord.ID(
+      recordType: Self.recordType, uuid: id, zoneID: zoneID)
     let record = CKRecord(recordType: Self.recordType, recordID: recordID)
     record["accountId"] = accountId.uuidString as CKRecordValue
     record["parserIdentifier"] = parserIdentifier as CKRecordValue
@@ -25,7 +26,7 @@ extension CSVImportProfileRecord: CloudKitRecordConvertible {
 
   static func fieldValues(from ckRecord: CKRecord) -> CSVImportProfileRecord {
     let record = CSVImportProfileRecord(
-      id: UUID(uuidString: ckRecord.recordID.recordName) ?? UUID(),
+      id: ckRecord.recordID.uuid ?? UUID(),
       accountId: (ckRecord["accountId"] as? String).flatMap { UUID(uuidString: $0) } ?? UUID(),
       parserIdentifier: ckRecord["parserIdentifier"] as? String ?? "",
       headerSignature: [],

--- a/Backends/CloudKit/Sync/CategoryRecord+CloudKit.swift
+++ b/Backends/CloudKit/Sync/CategoryRecord+CloudKit.swift
@@ -7,7 +7,8 @@ extension CategoryRecord: CloudKitRecordConvertible {
   static let recordType = "CD_CategoryRecord"
 
   func toCKRecord(in zoneID: CKRecordZone.ID) -> CKRecord {
-    let recordID = CKRecord.ID(recordName: id.uuidString, zoneID: zoneID)
+    let recordID = CKRecord.ID(
+      recordType: Self.recordType, uuid: id, zoneID: zoneID)
     let record = CKRecord(recordType: Self.recordType, recordID: recordID)
     record["name"] = name as CKRecordValue
     if let parentId { record["parentId"] = parentId.uuidString as CKRecordValue }
@@ -16,7 +17,7 @@ extension CategoryRecord: CloudKitRecordConvertible {
 
   static func fieldValues(from ckRecord: CKRecord) -> CategoryRecord {
     CategoryRecord(
-      id: UUID(uuidString: ckRecord.recordID.recordName) ?? UUID(),
+      id: ckRecord.recordID.uuid ?? UUID(),
       name: ckRecord["name"] as? String ?? "",
       parentId: (ckRecord["parentId"] as? String).flatMap { UUID(uuidString: $0) }
     )

--- a/Backends/CloudKit/Sync/EarmarkBudgetItemRecord+CloudKit.swift
+++ b/Backends/CloudKit/Sync/EarmarkBudgetItemRecord+CloudKit.swift
@@ -7,7 +7,8 @@ extension EarmarkBudgetItemRecord: CloudKitRecordConvertible {
   static let recordType = "CD_EarmarkBudgetItemRecord"
 
   func toCKRecord(in zoneID: CKRecordZone.ID) -> CKRecord {
-    let recordID = CKRecord.ID(recordName: id.uuidString, zoneID: zoneID)
+    let recordID = CKRecord.ID(
+      recordType: Self.recordType, uuid: id, zoneID: zoneID)
     let record = CKRecord(recordType: Self.recordType, recordID: recordID)
     record["earmarkId"] = earmarkId.uuidString as CKRecordValue
     record["categoryId"] = categoryId.uuidString as CKRecordValue
@@ -18,7 +19,7 @@ extension EarmarkBudgetItemRecord: CloudKitRecordConvertible {
 
   static func fieldValues(from ckRecord: CKRecord) -> EarmarkBudgetItemRecord {
     EarmarkBudgetItemRecord(
-      id: UUID(uuidString: ckRecord.recordID.recordName) ?? UUID(),
+      id: ckRecord.recordID.uuid ?? UUID(),
       earmarkId: (ckRecord["earmarkId"] as? String).flatMap { UUID(uuidString: $0) } ?? UUID(),
       categoryId: (ckRecord["categoryId"] as? String).flatMap { UUID(uuidString: $0) } ?? UUID(),
       amount: ckRecord["amount"] as? Int64 ?? 0,

--- a/Backends/CloudKit/Sync/EarmarkRecord+CloudKit.swift
+++ b/Backends/CloudKit/Sync/EarmarkRecord+CloudKit.swift
@@ -7,7 +7,8 @@ extension EarmarkRecord: CloudKitRecordConvertible {
   static let recordType = "CD_EarmarkRecord"
 
   func toCKRecord(in zoneID: CKRecordZone.ID) -> CKRecord {
-    let recordID = CKRecord.ID(recordName: id.uuidString, zoneID: zoneID)
+    let recordID = CKRecord.ID(
+      recordType: Self.recordType, uuid: id, zoneID: zoneID)
     let record = CKRecord(recordType: Self.recordType, recordID: recordID)
     record["name"] = name as CKRecordValue
     if let instrumentId { record["instrumentId"] = instrumentId as CKRecordValue }
@@ -24,7 +25,7 @@ extension EarmarkRecord: CloudKitRecordConvertible {
 
   static func fieldValues(from ckRecord: CKRecord) -> EarmarkRecord {
     EarmarkRecord(
-      id: UUID(uuidString: ckRecord.recordID.recordName) ?? UUID(),
+      id: ckRecord.recordID.uuid ?? UUID(),
       name: ckRecord["name"] as? String ?? "",
       position: ckRecord["position"] as? Int ?? 0,
       isHidden: (ckRecord["isHidden"] as? Int ?? 0) != 0,

--- a/Backends/CloudKit/Sync/ImportRuleRecord+CloudKit.swift
+++ b/Backends/CloudKit/Sync/ImportRuleRecord+CloudKit.swift
@@ -7,7 +7,8 @@ extension ImportRuleRecord: CloudKitRecordConvertible {
   static let recordType = "CD_ImportRuleRecord"
 
   func toCKRecord(in zoneID: CKRecordZone.ID) -> CKRecord {
-    let recordID = CKRecord.ID(recordName: id.uuidString, zoneID: zoneID)
+    let recordID = CKRecord.ID(
+      recordType: Self.recordType, uuid: id, zoneID: zoneID)
     let record = CKRecord(recordType: Self.recordType, recordID: recordID)
     record["name"] = name as CKRecordValue
     record["enabled"] = (enabled ? 1 : 0) as CKRecordValue
@@ -20,7 +21,7 @@ extension ImportRuleRecord: CloudKitRecordConvertible {
   }
 
   static func fieldValues(from ckRecord: CKRecord) -> ImportRuleRecord {
-    let id = UUID(uuidString: ckRecord.recordID.recordName) ?? UUID()
+    let id = ckRecord.recordID.uuid ?? UUID()
     // The convenience initializer re-encodes the conditions/actions arrays,
     // so to avoid a decode-then-re-encode round trip we go through the
     // synthesised property setters on a fresh record.

--- a/Backends/CloudKit/Sync/InvestmentValueRecord+CloudKit.swift
+++ b/Backends/CloudKit/Sync/InvestmentValueRecord+CloudKit.swift
@@ -7,7 +7,8 @@ extension InvestmentValueRecord: CloudKitRecordConvertible {
   static let recordType = "CD_InvestmentValueRecord"
 
   func toCKRecord(in zoneID: CKRecordZone.ID) -> CKRecord {
-    let recordID = CKRecord.ID(recordName: id.uuidString, zoneID: zoneID)
+    let recordID = CKRecord.ID(
+      recordType: Self.recordType, uuid: id, zoneID: zoneID)
     let record = CKRecord(recordType: Self.recordType, recordID: recordID)
     record["accountId"] = accountId.uuidString as CKRecordValue
     record["date"] = date as CKRecordValue
@@ -18,7 +19,7 @@ extension InvestmentValueRecord: CloudKitRecordConvertible {
 
   static func fieldValues(from ckRecord: CKRecord) -> InvestmentValueRecord {
     InvestmentValueRecord(
-      id: UUID(uuidString: ckRecord.recordID.recordName) ?? UUID(),
+      id: ckRecord.recordID.uuid ?? UUID(),
       accountId: (ckRecord["accountId"] as? String).flatMap { UUID(uuidString: $0) } ?? UUID(),
       date: ckRecord["date"] as? Date ?? Date(),
       value: ckRecord["value"] as? Int64 ?? 0,

--- a/Backends/CloudKit/Sync/ProfileDataSyncHandler+ApplyRemoteChanges.swift
+++ b/Backends/CloudKit/Sync/ProfileDataSyncHandler+ApplyRemoteChanges.swift
@@ -90,7 +90,7 @@ extension ProfileDataSyncHandler {
     var stringGrouped: [String: [String]] = [:]
 
     for (recordID, recordType) in deletions {
-      if let uuid = UUID(uuidString: recordID.recordName) {
+      if let uuid = recordID.uuid {
         uuidGrouped[recordType, default: []].append(uuid)
       } else {
         stringGrouped[recordType, default: []].append(recordID.recordName)
@@ -138,11 +138,26 @@ extension ProfileDataSyncHandler {
   nonisolated private static func systemFieldsLookup(
     saved: [CKRecord], preExtracted: [(String, Data)]
   ) -> [String: Data] {
+    // Both sources key by recordName, but the batchUpsertX methods look up
+    // by uuid.uuidString (for UUID records) or record.id (for instruments) —
+    // never by the full prefixed recordName. Normalize by stripping the
+    // "<recordType>|" prefix when present so the downstream lookup works
+    // for both the new and legacy recordName formats.
+    func keyFor(_ recordName: String) -> String {
+      if let sep = recordName.firstIndex(of: "|") {
+        return String(recordName[recordName.index(after: sep)...])
+      }
+      return recordName
+    }
     if !preExtracted.isEmpty {
-      return Dictionary(preExtracted, uniquingKeysWith: { _, last in last })
+      return Dictionary(
+        preExtracted.map { (keyFor($0.0), $0.1) },
+        uniquingKeysWith: { _, last in last })
     }
     return Dictionary(
-      uniqueKeysWithValues: saved.map { ($0.recordID.recordName, $0.encodedSystemFields) }
+      uniqueKeysWithValues: saved.map {
+        (keyFor($0.recordID.recordName), $0.encodedSystemFields)
+      }
     )
   }
 

--- a/Backends/CloudKit/Sync/ProfileDataSyncHandler+ApplyRemoteChanges.swift
+++ b/Backends/CloudKit/Sync/ProfileDataSyncHandler+ApplyRemoteChanges.swift
@@ -140,15 +140,10 @@ extension ProfileDataSyncHandler {
   ) -> [String: Data] {
     // Both sources key by recordName, but the batchUpsertX methods look up
     // by uuid.uuidString (for UUID records) or record.id (for instruments) —
-    // never by the full prefixed recordName. Normalize by stripping the
-    // "<recordType>|" prefix when present so the downstream lookup works
-    // for both the new and legacy recordName formats.
-    func keyFor(_ recordName: String) -> String {
-      if let sep = recordName.firstIndex(of: "|") {
-        return String(recordName[recordName.index(after: sep)...])
-      }
-      return recordName
-    }
+    // never by the full prefixed recordName. Normalize via the shared
+    // `CKRecordIDRecordName.systemFieldsKey(for:)` helper so the downstream
+    // lookup works for both the new and legacy recordName formats.
+    let keyFor = CKRecordIDRecordName.systemFieldsKey(for:)
     if !preExtracted.isEmpty {
       return Dictionary(
         preExtracted.map { (keyFor($0.0), $0.1) },
@@ -156,7 +151,7 @@ extension ProfileDataSyncHandler {
     }
     return Dictionary(
       uniqueKeysWithValues: saved.map {
-        (keyFor($0.recordID.recordName), $0.encodedSystemFields)
+        ($0.recordID.systemFieldsKey, $0.encodedSystemFields)
       }
     )
   }

--- a/Backends/CloudKit/Sync/ProfileDataSyncHandler+BatchUpsert.swift
+++ b/Backends/CloudKit/Sync/ProfileDataSyncHandler+BatchUpsert.swift
@@ -278,7 +278,7 @@ extension ProfileDataSyncHandler {
   /// pairs, silently dropping any records whose name isn't a valid UUID.
   nonisolated private static func uuidPairs(from ckRecords: [CKRecord]) -> [(UUID, CKRecord)] {
     ckRecords.compactMap { record in
-      guard let uuid = UUID(uuidString: record.recordID.recordName) else { return nil }
+      guard let uuid = record.recordID.uuid else { return nil }
       return (uuid, record)
     }
   }

--- a/Backends/CloudKit/Sync/ProfileDataSyncHandler+QueueAndDelete.swift
+++ b/Backends/CloudKit/Sync/ProfileDataSyncHandler+QueueAndDelete.swift
@@ -33,15 +33,15 @@ extension ProfileDataSyncHandler {
     // 9. CSV import profiles (reference accounts)
     // 10. Import rules (optionally reference accounts via accountScope)
     collectAllStringIDs(InstrumentRecord.self, into: &recordIDs) { $0.id }
-    collectAllUUIDs(CategoryRecord.self, into: &recordIDs) { $0.id }
-    collectAllUUIDs(AccountRecord.self, into: &recordIDs) { $0.id }
-    collectAllUUIDs(EarmarkRecord.self, into: &recordIDs) { $0.id }
-    collectAllUUIDs(EarmarkBudgetItemRecord.self, into: &recordIDs) { $0.id }
-    collectAllUUIDs(InvestmentValueRecord.self, into: &recordIDs) { $0.id }
-    collectAllUUIDs(TransactionRecord.self, into: &recordIDs) { $0.id }
-    collectAllUUIDs(TransactionLegRecord.self, into: &recordIDs) { $0.id }
-    collectAllUUIDs(CSVImportProfileRecord.self, into: &recordIDs) { $0.id }
-    collectAllUUIDs(ImportRuleRecord.self, into: &recordIDs) { $0.id }
+    collectAllUUIDs(CategoryRecord.self, into: &recordIDs)
+    collectAllUUIDs(AccountRecord.self, into: &recordIDs)
+    collectAllUUIDs(EarmarkRecord.self, into: &recordIDs)
+    collectAllUUIDs(EarmarkBudgetItemRecord.self, into: &recordIDs)
+    collectAllUUIDs(InvestmentValueRecord.self, into: &recordIDs)
+    collectAllUUIDs(TransactionRecord.self, into: &recordIDs)
+    collectAllUUIDs(TransactionLegRecord.self, into: &recordIDs)
+    collectAllUUIDs(CSVImportProfileRecord.self, into: &recordIDs)
+    collectAllUUIDs(ImportRuleRecord.self, into: &recordIDs)
 
     if !recordIDs.isEmpty {
       logger.info("Collected \(recordIDs.count) existing records for upload")
@@ -65,15 +65,15 @@ extension ProfileDataSyncHandler {
     var recordIDs: [CKRecord.ID] = []
     // Same dependency order as queueAllExistingRecords.
     collectUnsyncedInstruments(into: &recordIDs)
-    collectUnsynced(CategoryRecord.self, into: &recordIDs) { $0.id }
-    collectUnsynced(AccountRecord.self, into: &recordIDs) { $0.id }
-    collectUnsynced(EarmarkRecord.self, into: &recordIDs) { $0.id }
-    collectUnsynced(EarmarkBudgetItemRecord.self, into: &recordIDs) { $0.id }
-    collectUnsynced(InvestmentValueRecord.self, into: &recordIDs) { $0.id }
-    collectUnsynced(TransactionRecord.self, into: &recordIDs) { $0.id }
-    collectUnsynced(TransactionLegRecord.self, into: &recordIDs) { $0.id }
-    collectUnsynced(CSVImportProfileRecord.self, into: &recordIDs) { $0.id }
-    collectUnsynced(ImportRuleRecord.self, into: &recordIDs) { $0.id }
+    collectUnsynced(CategoryRecord.self, into: &recordIDs)
+    collectUnsynced(AccountRecord.self, into: &recordIDs)
+    collectUnsynced(EarmarkRecord.self, into: &recordIDs)
+    collectUnsynced(EarmarkBudgetItemRecord.self, into: &recordIDs)
+    collectUnsynced(InvestmentValueRecord.self, into: &recordIDs)
+    collectUnsynced(TransactionRecord.self, into: &recordIDs)
+    collectUnsynced(TransactionLegRecord.self, into: &recordIDs)
+    collectUnsynced(CSVImportProfileRecord.self, into: &recordIDs)
+    collectUnsynced(ImportRuleRecord.self, into: &recordIDs)
 
     if !recordIDs.isEmpty {
       logger.info("Collected \(recordIDs.count) unsynced records for upload")
@@ -117,14 +117,15 @@ extension ProfileDataSyncHandler {
 
   // MARK: - Private Helpers
 
-  private func collectAllUUIDs<T: PersistentModel & CloudKitRecordConvertible>(
-    _ type: T.Type, into recordIDs: inout [CKRecord.ID], extract: (T) -> UUID
+  private func collectAllUUIDs<
+    T: PersistentModel & CloudKitRecordConvertible & IdentifiableRecord
+  >(
+    _ type: T.Type, into recordIDs: inout [CKRecord.ID]
   ) {
     let context = ModelContext(modelContainer)
     for record in Self.fetchOrLog(FetchDescriptor<T>(), context: context) {
       recordIDs.append(
-        CKRecord.ID(
-          recordType: T.recordType, uuid: extract(record), zoneID: zoneID))
+        CKRecord.ID(recordType: T.recordType, uuid: record.id, zoneID: zoneID))
     }
   }
 
@@ -139,15 +140,15 @@ extension ProfileDataSyncHandler {
 
   private func collectUnsynced<
     T: PersistentModel & SystemFieldsCacheable & CloudKitRecordConvertible
+      & IdentifiableRecord
   >(
-    _ type: T.Type, into recordIDs: inout [CKRecord.ID], extract: (T) -> UUID
+    _ type: T.Type, into recordIDs: inout [CKRecord.ID]
   ) {
     let context = ModelContext(modelContainer)
     for record in Self.fetchOrLog(FetchDescriptor<T>(), context: context)
     where record.encodedSystemFields == nil {
       recordIDs.append(
-        CKRecord.ID(
-          recordType: T.recordType, uuid: extract(record), zoneID: zoneID))
+        CKRecord.ID(recordType: T.recordType, uuid: record.id, zoneID: zoneID))
     }
   }
 

--- a/Backends/CloudKit/Sync/ProfileDataSyncHandler+QueueAndDelete.swift
+++ b/Backends/CloudKit/Sync/ProfileDataSyncHandler+QueueAndDelete.swift
@@ -64,16 +64,16 @@ extension ProfileDataSyncHandler {
 
     var recordIDs: [CKRecord.ID] = []
     // Same dependency order as queueAllExistingRecords.
-    collectUnsynced(InstrumentRecord.self, into: &recordIDs) { $0.id }
-    collectUnsynced(CategoryRecord.self, into: &recordIDs) { $0.id.uuidString }
-    collectUnsynced(AccountRecord.self, into: &recordIDs) { $0.id.uuidString }
-    collectUnsynced(EarmarkRecord.self, into: &recordIDs) { $0.id.uuidString }
-    collectUnsynced(EarmarkBudgetItemRecord.self, into: &recordIDs) { $0.id.uuidString }
-    collectUnsynced(InvestmentValueRecord.self, into: &recordIDs) { $0.id.uuidString }
-    collectUnsynced(TransactionRecord.self, into: &recordIDs) { $0.id.uuidString }
-    collectUnsynced(TransactionLegRecord.self, into: &recordIDs) { $0.id.uuidString }
-    collectUnsynced(CSVImportProfileRecord.self, into: &recordIDs) { $0.id.uuidString }
-    collectUnsynced(ImportRuleRecord.self, into: &recordIDs) { $0.id.uuidString }
+    collectUnsyncedInstruments(into: &recordIDs)
+    collectUnsynced(CategoryRecord.self, into: &recordIDs) { $0.id }
+    collectUnsynced(AccountRecord.self, into: &recordIDs) { $0.id }
+    collectUnsynced(EarmarkRecord.self, into: &recordIDs) { $0.id }
+    collectUnsynced(EarmarkBudgetItemRecord.self, into: &recordIDs) { $0.id }
+    collectUnsynced(InvestmentValueRecord.self, into: &recordIDs) { $0.id }
+    collectUnsynced(TransactionRecord.self, into: &recordIDs) { $0.id }
+    collectUnsynced(TransactionLegRecord.self, into: &recordIDs) { $0.id }
+    collectUnsynced(CSVImportProfileRecord.self, into: &recordIDs) { $0.id }
+    collectUnsynced(ImportRuleRecord.self, into: &recordIDs) { $0.id }
 
     if !recordIDs.isEmpty {
       logger.info("Collected \(recordIDs.count) unsynced records for upload")
@@ -117,12 +117,14 @@ extension ProfileDataSyncHandler {
 
   // MARK: - Private Helpers
 
-  private func collectAllUUIDs<T: PersistentModel>(
+  private func collectAllUUIDs<T: PersistentModel & CloudKitRecordConvertible>(
     _ type: T.Type, into recordIDs: inout [CKRecord.ID], extract: (T) -> UUID
   ) {
     let context = ModelContext(modelContainer)
     for record in Self.fetchOrLog(FetchDescriptor<T>(), context: context) {
-      recordIDs.append(CKRecord.ID(recordName: extract(record).uuidString, zoneID: zoneID))
+      recordIDs.append(
+        CKRecord.ID(
+          recordType: T.recordType, uuid: extract(record), zoneID: zoneID))
     }
   }
 
@@ -135,13 +137,29 @@ extension ProfileDataSyncHandler {
     }
   }
 
-  private func collectUnsynced<T: PersistentModel & SystemFieldsCacheable>(
-    _ type: T.Type, into recordIDs: inout [CKRecord.ID], extract: (T) -> String
+  private func collectUnsynced<
+    T: PersistentModel & SystemFieldsCacheable & CloudKitRecordConvertible
+  >(
+    _ type: T.Type, into recordIDs: inout [CKRecord.ID], extract: (T) -> UUID
   ) {
     let context = ModelContext(modelContainer)
     for record in Self.fetchOrLog(FetchDescriptor<T>(), context: context)
     where record.encodedSystemFields == nil {
-      recordIDs.append(CKRecord.ID(recordName: extract(record), zoneID: zoneID))
+      recordIDs.append(
+        CKRecord.ID(
+          recordType: T.recordType, uuid: extract(record), zoneID: zoneID))
+    }
+  }
+
+  private func collectUnsyncedInstruments(
+    into recordIDs: inout [CKRecord.ID]
+  ) {
+    let context = ModelContext(modelContainer)
+    for record in Self.fetchOrLog(
+      FetchDescriptor<InstrumentRecord>(), context: context)
+    where record.encodedSystemFields == nil {
+      recordIDs.append(
+        CKRecord.ID(recordName: record.id, zoneID: zoneID))
     }
   }
 }

--- a/Backends/CloudKit/Sync/ProfileDataSyncHandler+RecordLookup.swift
+++ b/Backends/CloudKit/Sync/ProfileDataSyncHandler+RecordLookup.swift
@@ -45,7 +45,7 @@ extension ProfileDataSyncHandler {
       return buildCKRecord(for: record)
     }
 
-    guard let uuid = UUID(uuidString: recordName) else {
+    guard let uuid = recordID.uuid else {
       logger.warning("Could not find local record for non-UUID ID: \(recordName)")
       return nil
     }

--- a/Backends/CloudKit/Sync/ProfileDataSyncHandler+SystemFields.swift
+++ b/Backends/CloudKit/Sync/ProfileDataSyncHandler+SystemFields.swift
@@ -131,7 +131,7 @@ extension ProfileDataSyncHandler {
     // both matched the same recordName (issue #416).
     if ckRecord.recordType == InstrumentRecord.recordType {
       Self.setInstrumentSystemFields(
-        ckRecord.recordID.recordName, data: data, context: context)
+        ckRecord.recordID.systemFieldsKey, data: data, context: context)
       return
     }
     guard let uuid = ckRecord.recordID.uuid else {
@@ -154,7 +154,7 @@ extension ProfileDataSyncHandler {
   ) {
     if recordType == InstrumentRecord.recordType {
       Self.setInstrumentSystemFields(
-        recordID.recordName, data: nil, context: context)
+        recordID.systemFieldsKey, data: nil, context: context)
       return
     }
     guard let uuid = recordID.uuid else {

--- a/Backends/CloudKit/Sync/ProfileDataSyncHandler+SystemFields.swift
+++ b/Backends/CloudKit/Sync/ProfileDataSyncHandler+SystemFields.swift
@@ -124,30 +124,47 @@ extension ProfileDataSyncHandler {
   }
 
   private func applySystemFields(from ckRecord: CKRecord, in context: ModelContext) {
-    let recordName = ckRecord.recordID.recordName
     let data = ckRecord.encodedSystemFields
-    if let uuid = UUID(uuidString: recordName) {
-      let applied = Self.setEncodedSystemFields(
-        uuid, data: data, recordType: ckRecord.recordType, context: context)
-      if !applied {
-        logger.warning(
-          "No local row to cache system fields for \(ckRecord.recordType) \(recordName)"
-        )
-      }
-    } else {
-      Self.setInstrumentSystemFields(recordName, data: data, context: context)
+    // Dispatch by ckRecord.recordType — the authoritative type from the
+    // server — rather than by parsing recordName. This avoids the
+    // historical collision where two record types with colliding UUIDs
+    // both matched the same recordName (issue #416).
+    if ckRecord.recordType == InstrumentRecord.recordType {
+      Self.setInstrumentSystemFields(
+        ckRecord.recordID.recordName, data: data, context: context)
+      return
+    }
+    guard let uuid = ckRecord.recordID.uuid else {
+      logger.warning(
+        "applySystemFields: recordName \(ckRecord.recordID.recordName) has no UUID component for \(ckRecord.recordType)"
+      )
+      return
+    }
+    let applied = Self.setEncodedSystemFields(
+      uuid, data: data, recordType: ckRecord.recordType, context: context)
+    if !applied {
+      logger.warning(
+        "No local row to cache system fields for \(ckRecord.recordType) \(uuid.uuidString)"
+      )
     }
   }
 
   private func clearSystemFields(
     for recordID: CKRecord.ID, recordType: String, in context: ModelContext
   ) {
-    let recordName = recordID.recordName
-    if let uuid = UUID(uuidString: recordName) {
-      Self.setEncodedSystemFields(uuid, data: nil, recordType: recordType, context: context)
-    } else {
-      Self.setInstrumentSystemFields(recordName, data: nil, context: context)
+    if recordType == InstrumentRecord.recordType {
+      Self.setInstrumentSystemFields(
+        recordID.recordName, data: nil, context: context)
+      return
     }
+    guard let uuid = recordID.uuid else {
+      logger.warning(
+        "clearSystemFields: recordName \(recordID.recordName) has no UUID component for \(recordType)"
+      )
+      return
+    }
+    Self.setEncodedSystemFields(
+      uuid, data: nil, recordType: recordType, context: context)
   }
 
   // MARK: - Dispatch Table

--- a/Backends/CloudKit/Sync/ProfileIndexSyncHandler.swift
+++ b/Backends/CloudKit/Sync/ProfileIndexSyncHandler.swift
@@ -48,7 +48,7 @@ final class ProfileIndexSyncHandler {
 
     for ckRecord in saved {
       guard ckRecord.recordType == ProfileRecord.recordType else { continue }
-      guard let profileId = UUID(uuidString: ckRecord.recordID.recordName) else { continue }
+      guard let profileId = ckRecord.recordID.uuid else { continue }
 
       let systemFieldsData = ckRecord.encodedSystemFields
       let values = ProfileRecord.fieldValues(from: ckRecord)
@@ -68,7 +68,7 @@ final class ProfileIndexSyncHandler {
     }
 
     for recordID in deleted {
-      guard let profileId = UUID(uuidString: recordID.recordName) else { continue }
+      guard let profileId = recordID.uuid else { continue }
       let descriptor = FetchDescriptor<ProfileRecord>(
         predicate: #Predicate { $0.id == profileId }
       )
@@ -108,7 +108,7 @@ final class ProfileIndexSyncHandler {
 
   /// Looks up a ProfileRecord by CKRecord.ID and builds a CKRecord for upload.
   func recordToSave(for recordID: CKRecord.ID) -> CKRecord? {
-    guard let profileId = UUID(uuidString: recordID.recordName) else { return nil }
+    guard let profileId = recordID.uuid else { return nil }
     let context = ModelContext(modelContainer)
     let descriptor = FetchDescriptor<ProfileRecord>(
       predicate: #Predicate { $0.id == profileId }
@@ -129,7 +129,8 @@ final class ProfileIndexSyncHandler {
     guard !records.isEmpty else { return [] }
 
     let recordIDs = records.map { record in
-      CKRecord.ID(recordName: record.id.uuidString, zoneID: zoneID)
+      CKRecord.ID(
+        recordType: ProfileRecord.recordType, uuid: record.id, zoneID: zoneID)
     }
     logger.info("Collected \(recordIDs.count) existing profiles for upload")
     return recordIDs
@@ -176,7 +177,7 @@ final class ProfileIndexSyncHandler {
 
   /// Updates `encodedSystemFields` on the ProfileRecord matching the given record ID.
   func updateEncodedSystemFields(_ recordID: CKRecord.ID, data: Data) {
-    guard let profileId = UUID(uuidString: recordID.recordName) else { return }
+    guard let profileId = recordID.uuid else { return }
     let context = ModelContext(modelContainer)
     let descriptor = FetchDescriptor<ProfileRecord>(
       predicate: #Predicate { $0.id == profileId }
@@ -195,7 +196,7 @@ final class ProfileIndexSyncHandler {
   /// Called on `.unknownItem` — the server deleted the record, so the stale change tag
   /// must be cleared so the next upload creates a fresh record.
   func clearEncodedSystemFields(_ recordID: CKRecord.ID) {
-    guard let profileId = UUID(uuidString: recordID.recordName) else { return }
+    guard let profileId = recordID.uuid else { return }
     let context = ModelContext(modelContainer)
     let descriptor = FetchDescriptor<ProfileRecord>(
       predicate: #Predicate { $0.id == profileId }
@@ -237,7 +238,7 @@ final class ProfileIndexSyncHandler {
     let context = ModelContext(modelContainer)
     for saved in savedRecords {
       updateSystemFields(
-        forProfileId: saved.recordID.recordName,
+        for: saved.recordID,
         context: context,
         to: saved.encodedSystemFields
       )
@@ -256,14 +257,14 @@ final class ProfileIndexSyncHandler {
     let context = ModelContext(modelContainer)
     for (_, serverRecord) in failures.conflicts {
       updateSystemFields(
-        forProfileId: serverRecord.recordID.recordName,
+        for: serverRecord.recordID,
         context: context,
         to: serverRecord.encodedSystemFields
       )
     }
     for (recordID, _) in failures.unknownItems {
       updateSystemFields(
-        forProfileId: recordID.recordName,
+        for: recordID,
         context: context,
         to: nil
       )
@@ -277,11 +278,11 @@ final class ProfileIndexSyncHandler {
 
   /// Look up a `ProfileRecord` by id string and replace its cached system fields.
   private func updateSystemFields(
-    forProfileId recordName: String,
+    for recordID: CKRecord.ID,
     context: ModelContext,
     to data: Data?
   ) {
-    guard let profileId = UUID(uuidString: recordName) else { return }
+    guard let profileId = recordID.uuid else { return }
     let descriptor = FetchDescriptor<ProfileRecord>(
       predicate: #Predicate { $0.id == profileId }
     )

--- a/Backends/CloudKit/Sync/ProfileRecord+CloudKit.swift
+++ b/Backends/CloudKit/Sync/ProfileRecord+CloudKit.swift
@@ -7,7 +7,8 @@ extension ProfileRecord: CloudKitRecordConvertible {
   static let recordType = "CD_ProfileRecord"
 
   func toCKRecord(in zoneID: CKRecordZone.ID) -> CKRecord {
-    let recordID = CKRecord.ID(recordName: id.uuidString, zoneID: zoneID)
+    let recordID = CKRecord.ID(
+      recordType: Self.recordType, uuid: id, zoneID: zoneID)
     let record = CKRecord(recordType: Self.recordType, recordID: recordID)
     record["label"] = label as CKRecordValue
     record["currencyCode"] = currencyCode as CKRecordValue
@@ -18,7 +19,7 @@ extension ProfileRecord: CloudKitRecordConvertible {
 
   static func fieldValues(from ckRecord: CKRecord) -> ProfileRecord {
     ProfileRecord(
-      id: UUID(uuidString: ckRecord.recordID.recordName) ?? UUID(),
+      id: ckRecord.recordID.uuid ?? UUID(),
       label: ckRecord["label"] as? String ?? "",
       currencyCode: ckRecord["currencyCode"] as? String ?? "",
       financialYearStartMonth: ckRecord["financialYearStartMonth"] as? Int ?? 7,

--- a/Backends/CloudKit/Sync/SyncCoordinator+Delegate.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+Delegate.swift
@@ -274,7 +274,7 @@ extension SyncCoordinator: CKSyncEngineDelegate {
     var uuidRecordNames: [(CKRecord.ID, UUID)] = []
     var stringRecordIDs: [CKRecord.ID] = []
     for recordID in recordIDs {
-      if let uuid = UUID(uuidString: recordID.recordName) {
+      if let uuid = recordID.uuid {
         uuidRecordNames.append((recordID, uuid))
       } else {
         stringRecordIDs.append(recordID)

--- a/Backends/CloudKit/Sync/SyncCoordinator+Lifecycle.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+Lifecycle.swift
@@ -169,7 +169,7 @@ extension SyncCoordinator {
   // the UI is ready, and any already-persisted records are re-queued by
   // `queueAllExistingRecordsForAllZones` / `queueUnsyncedRecordsForAllProfiles`
   // inside `completeStart`.
-  func queueSave(id: UUID, recordType: String, zoneID: CKRecordZone.ID) {
+  func queueSave(recordType: String, id: UUID, zoneID: CKRecordZone.ID) {
     let recordID = CKRecord.ID(
       recordType: recordType, uuid: id, zoneID: zoneID)
     syncEngine?.state.add(pendingRecordZoneChanges: [.saveRecord(recordID)])
@@ -180,7 +180,7 @@ extension SyncCoordinator {
     syncEngine?.state.add(pendingRecordZoneChanges: [.saveRecord(recordID)])
   }
 
-  func queueDeletion(id: UUID, recordType: String, zoneID: CKRecordZone.ID) {
+  func queueDeletion(recordType: String, id: UUID, zoneID: CKRecordZone.ID) {
     let recordID = CKRecord.ID(
       recordType: recordType, uuid: id, zoneID: zoneID)
     syncEngine?.state.add(pendingRecordZoneChanges: [.deleteRecord(recordID)])

--- a/Backends/CloudKit/Sync/SyncCoordinator+Lifecycle.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+Lifecycle.swift
@@ -169,8 +169,9 @@ extension SyncCoordinator {
   // the UI is ready, and any already-persisted records are re-queued by
   // `queueAllExistingRecordsForAllZones` / `queueUnsyncedRecordsForAllProfiles`
   // inside `completeStart`.
-  func queueSave(id: UUID, zoneID: CKRecordZone.ID) {
-    let recordID = CKRecord.ID(recordName: id.uuidString, zoneID: zoneID)
+  func queueSave(id: UUID, recordType: String, zoneID: CKRecordZone.ID) {
+    let recordID = CKRecord.ID(
+      recordType: recordType, uuid: id, zoneID: zoneID)
     syncEngine?.state.add(pendingRecordZoneChanges: [.saveRecord(recordID)])
   }
 
@@ -179,8 +180,9 @@ extension SyncCoordinator {
     syncEngine?.state.add(pendingRecordZoneChanges: [.saveRecord(recordID)])
   }
 
-  func queueDeletion(id: UUID, zoneID: CKRecordZone.ID) {
-    let recordID = CKRecord.ID(recordName: id.uuidString, zoneID: zoneID)
+  func queueDeletion(id: UUID, recordType: String, zoneID: CKRecordZone.ID) {
+    let recordID = CKRecord.ID(
+      recordType: recordType, uuid: id, zoneID: zoneID)
     syncEngine?.state.add(pendingRecordZoneChanges: [.deleteRecord(recordID)])
   }
 

--- a/Backends/CloudKit/Sync/TransactionLegRecord+CloudKit.swift
+++ b/Backends/CloudKit/Sync/TransactionLegRecord+CloudKit.swift
@@ -7,7 +7,8 @@ extension TransactionLegRecord: CloudKitRecordConvertible {
   static let recordType = "CD_TransactionLegRecord"
 
   func toCKRecord(in zoneID: CKRecordZone.ID) -> CKRecord {
-    let recordID = CKRecord.ID(recordName: id.uuidString, zoneID: zoneID)
+    let recordID = CKRecord.ID(
+      recordType: Self.recordType, uuid: id, zoneID: zoneID)
     let record = CKRecord(recordType: Self.recordType, recordID: recordID)
     record["transactionId"] = transactionId.uuidString as CKRecordValue
     if let accountId { record["accountId"] = accountId.uuidString as CKRecordValue }
@@ -22,7 +23,7 @@ extension TransactionLegRecord: CloudKitRecordConvertible {
 
   static func fieldValues(from ckRecord: CKRecord) -> TransactionLegRecord {
     TransactionLegRecord(
-      id: UUID(uuidString: ckRecord.recordID.recordName) ?? UUID(),
+      id: ckRecord.recordID.uuid ?? UUID(),
       transactionId: (ckRecord["transactionId"] as? String).flatMap { UUID(uuidString: $0) }
         ?? UUID(),
       accountId: (ckRecord["accountId"] as? String).flatMap { UUID(uuidString: $0) },

--- a/Backends/CloudKit/Sync/TransactionRecord+CloudKit.swift
+++ b/Backends/CloudKit/Sync/TransactionRecord+CloudKit.swift
@@ -7,7 +7,8 @@ extension TransactionRecord: CloudKitRecordConvertible {
   static let recordType = "CD_TransactionRecord"
 
   func toCKRecord(in zoneID: CKRecordZone.ID) -> CKRecord {
-    let recordID = CKRecord.ID(recordName: id.uuidString, zoneID: zoneID)
+    let recordID = CKRecord.ID(
+      recordType: Self.recordType, uuid: id, zoneID: zoneID)
     let record = CKRecord(recordType: Self.recordType, recordID: recordID)
     record["date"] = date as CKRecordValue
     if let payee { record["payee"] = payee as CKRecordValue }
@@ -51,7 +52,7 @@ extension TransactionRecord: CloudKitRecordConvertible {
 
   static func fieldValues(from ckRecord: CKRecord) -> TransactionRecord {
     let record = TransactionRecord(
-      id: UUID(uuidString: ckRecord.recordID.recordName) ?? UUID(),
+      id: ckRecord.recordID.uuid ?? UUID(),
       date: ckRecord["date"] as? Date ?? Date(),
       payee: ckRecord["payee"] as? String,
       notes: ckRecord["notes"] as? String,

--- a/MoolahTests/Migration/MigrationIntegrationTests.swift
+++ b/MoolahTests/Migration/MigrationIntegrationTests.swift
@@ -269,7 +269,9 @@ struct MigrationIntegrationTests {
     let context = ModelContext(container)
     let importedAccounts = try context.fetch(FetchDescriptor<AccountRecord>())
     for account in importedAccounts {
-      #expect(recordNames.contains(account.id.uuidString))
+      #expect(
+        recordNames.contains(
+          "\(AccountRecord.recordType)|\(account.id.uuidString)"))
     }
 
     // The startup backfill scan must skip this profile — migration has already queued

--- a/MoolahTests/Sync/CKRecordIDRecordNameTests.swift
+++ b/MoolahTests/Sync/CKRecordIDRecordNameTests.swift
@@ -1,0 +1,88 @@
+import CloudKit
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("CKRecord.ID — recordName helpers")
+struct CKRecordIDRecordNameTests {
+
+  private let zoneID = CKRecordZone.ID(
+    zoneName: "profile-test",
+    ownerName: CKCurrentUserDefaultName
+  )
+
+  // MARK: - init(recordType:uuid:zoneID:)
+
+  @Test
+  func initBuildsPrefixedRecordName() {
+    let uuid = UUID(uuidString: "1CAC9567-574B-481A-BADA-D595325CBE0C")!
+    let recordID = CKRecord.ID(
+      recordType: "CD_AccountRecord", uuid: uuid, zoneID: zoneID)
+    #expect(
+      recordID.recordName
+        == "CD_AccountRecord|1CAC9567-574B-481A-BADA-D595325CBE0C")
+    #expect(recordID.zoneID == zoneID)
+  }
+
+  // MARK: - uuidRecordName()
+
+  @Test
+  func uuidRecordNameStripsPrefix() {
+    let uuid = UUID(uuidString: "1CAC9567-574B-481A-BADA-D595325CBE0C")!
+    let recordID = CKRecord.ID(
+      recordName: "CD_AccountRecord|1CAC9567-574B-481A-BADA-D595325CBE0C",
+      zoneID: zoneID)
+    #expect(recordID.uuidRecordName() == uuid)
+  }
+
+  @Test
+  func uuidRecordNameAcceptsBareUUIDLegacyFormat() {
+    let uuid = UUID(uuidString: "1CAC9567-574B-481A-BADA-D595325CBE0C")!
+    let recordID = CKRecord.ID(
+      recordName: "1CAC9567-574B-481A-BADA-D595325CBE0C",
+      zoneID: zoneID)
+    #expect(recordID.uuidRecordName() == uuid)
+  }
+
+  @Test
+  func uuidRecordNameReturnsNilForInstrumentIDs() {
+    #expect(
+      CKRecord.ID(recordName: "AUD", zoneID: zoneID).uuidRecordName() == nil)
+    #expect(
+      CKRecord.ID(recordName: "ASX:BHP", zoneID: zoneID).uuidRecordName()
+        == nil)
+  }
+
+  @Test
+  func uuidRecordNameReturnsNilForNonUUIDAfterPrefix() {
+    let recordID = CKRecord.ID(
+      recordName: "CD_AccountRecord|not-a-uuid",
+      zoneID: zoneID)
+    #expect(recordID.uuidRecordName() == nil)
+  }
+
+  // MARK: - systemFieldsKey
+
+  @Test
+  func systemFieldsKeyStripsTypePrefixForPrefixedRecord() {
+    let recordID = CKRecord.ID(
+      recordName: "CD_AccountRecord|1CAC9567-574B-481A-BADA-D595325CBE0C",
+      zoneID: zoneID)
+    #expect(recordID.systemFieldsKey == "1CAC9567-574B-481A-BADA-D595325CBE0C")
+  }
+
+  @Test
+  func systemFieldsKeyReturnsBareUUIDForLegacyRecord() {
+    let recordID = CKRecord.ID(
+      recordName: "1CAC9567-574B-481A-BADA-D595325CBE0C",
+      zoneID: zoneID)
+    #expect(recordID.systemFieldsKey == "1CAC9567-574B-481A-BADA-D595325CBE0C")
+  }
+
+  @Test
+  func systemFieldsKeyReturnsRecordNameForInstrument() {
+    let recordID = CKRecord.ID(recordName: "ASX:BHP", zoneID: zoneID)
+    #expect(recordID.systemFieldsKey == "ASX:BHP")
+  }
+}

--- a/MoolahTests/Sync/CKRecordIDRecordNameTests.swift
+++ b/MoolahTests/Sync/CKRecordIDRecordNameTests.swift
@@ -15,8 +15,8 @@ struct CKRecordIDRecordNameTests {
   // MARK: - init(recordType:uuid:zoneID:)
 
   @Test
-  func initBuildsPrefixedRecordName() {
-    let uuid = UUID(uuidString: "1CAC9567-574B-481A-BADA-D595325CBE0C")!
+  func initBuildsPrefixedRecordName() throws {
+    let uuid = try #require(UUID(uuidString: "1CAC9567-574B-481A-BADA-D595325CBE0C"))
     let recordID = CKRecord.ID(
       recordType: "CD_AccountRecord", uuid: uuid, zoneID: zoneID)
     #expect(
@@ -28,8 +28,8 @@ struct CKRecordIDRecordNameTests {
   // MARK: - uuidRecordName()
 
   @Test
-  func uuidRecordNameStripsPrefix() {
-    let uuid = UUID(uuidString: "1CAC9567-574B-481A-BADA-D595325CBE0C")!
+  func uuidRecordNameStripsPrefix() throws {
+    let uuid = try #require(UUID(uuidString: "1CAC9567-574B-481A-BADA-D595325CBE0C"))
     let recordID = CKRecord.ID(
       recordName: "CD_AccountRecord|1CAC9567-574B-481A-BADA-D595325CBE0C",
       zoneID: zoneID)
@@ -37,8 +37,8 @@ struct CKRecordIDRecordNameTests {
   }
 
   @Test
-  func uuidRecordNameAcceptsBareUUIDLegacyFormat() {
-    let uuid = UUID(uuidString: "1CAC9567-574B-481A-BADA-D595325CBE0C")!
+  func uuidRecordNameAcceptsBareUUIDLegacyFormat() throws {
+    let uuid = try #require(UUID(uuidString: "1CAC9567-574B-481A-BADA-D595325CBE0C"))
     let recordID = CKRecord.ID(
       recordName: "1CAC9567-574B-481A-BADA-D595325CBE0C",
       zoneID: zoneID)

--- a/MoolahTests/Sync/CKRecordIDRecordNameTests.swift
+++ b/MoolahTests/Sync/CKRecordIDRecordNameTests.swift
@@ -25,41 +25,38 @@ struct CKRecordIDRecordNameTests {
     #expect(recordID.zoneID == zoneID)
   }
 
-  // MARK: - uuidRecordName()
+  // MARK: - uuid
 
   @Test
-  func uuidRecordNameStripsPrefix() throws {
+  func uuidStripsPrefix() throws {
     let uuid = try #require(UUID(uuidString: "1CAC9567-574B-481A-BADA-D595325CBE0C"))
     let recordID = CKRecord.ID(
       recordName: "CD_AccountRecord|1CAC9567-574B-481A-BADA-D595325CBE0C",
       zoneID: zoneID)
-    #expect(recordID.uuidRecordName() == uuid)
+    #expect(recordID.uuid == uuid)
   }
 
   @Test
-  func uuidRecordNameAcceptsBareUUIDLegacyFormat() throws {
+  func uuidAcceptsBareUUIDLegacyFormat() throws {
     let uuid = try #require(UUID(uuidString: "1CAC9567-574B-481A-BADA-D595325CBE0C"))
     let recordID = CKRecord.ID(
       recordName: "1CAC9567-574B-481A-BADA-D595325CBE0C",
       zoneID: zoneID)
-    #expect(recordID.uuidRecordName() == uuid)
+    #expect(recordID.uuid == uuid)
   }
 
   @Test
-  func uuidRecordNameReturnsNilForInstrumentIDs() {
-    #expect(
-      CKRecord.ID(recordName: "AUD", zoneID: zoneID).uuidRecordName() == nil)
-    #expect(
-      CKRecord.ID(recordName: "ASX:BHP", zoneID: zoneID).uuidRecordName()
-        == nil)
+  func uuidReturnsNilForInstrumentIDs() {
+    #expect(CKRecord.ID(recordName: "AUD", zoneID: zoneID).uuid == nil)
+    #expect(CKRecord.ID(recordName: "ASX:BHP", zoneID: zoneID).uuid == nil)
   }
 
   @Test
-  func uuidRecordNameReturnsNilForNonUUIDAfterPrefix() {
+  func uuidReturnsNilForNonUUIDAfterPrefix() {
     let recordID = CKRecord.ID(
       recordName: "CD_AccountRecord|not-a-uuid",
       zoneID: zoneID)
-    #expect(recordID.uuidRecordName() == nil)
+    #expect(recordID.uuid == nil)
   }
 
   // MARK: - systemFieldsKey

--- a/MoolahTests/Sync/ProfileDataSyncHandlerQueueTests.swift
+++ b/MoolahTests/Sync/ProfileDataSyncHandlerQueueTests.swift
@@ -63,8 +63,8 @@ struct ProfileDataSyncHandlerQueueTests {
     #expect(recordIDs.count == 3)
 
     let recordNames = Set(recordIDs.map(\.recordName))
-    #expect(recordNames.contains(accountId.uuidString))
-    #expect(recordNames.contains(txnId.uuidString))
+    #expect(recordNames.contains("\(AccountRecord.recordType)|\(accountId.uuidString)"))
+    #expect(recordNames.contains("\(TransactionRecord.recordType)|\(txnId.uuidString)"))
     #expect(recordNames.contains(instrumentId))
 
     for recordID in recordIDs {
@@ -109,9 +109,11 @@ struct ProfileDataSyncHandlerQueueTests {
     let recordIDs = handler.queueUnsyncedRecords()
     let recordNames = Set(recordIDs.map(\.recordName))
 
-    #expect(recordNames.contains(unsyncedAccountId.uuidString))
+    #expect(
+      recordNames.contains("\(AccountRecord.recordType)|\(unsyncedAccountId.uuidString)"))
     #expect(recordNames.contains(unsyncedInstrumentId))
-    #expect(!recordNames.contains(syncedAccountId.uuidString))
+    #expect(
+      !recordNames.contains("\(AccountRecord.recordType)|\(syncedAccountId.uuidString)"))
     #expect(!recordNames.contains(syncedInstrumentId))
   }
 
@@ -130,10 +132,7 @@ struct ProfileDataSyncHandlerQueueTests {
     #expect(recordIDs.isEmpty)
   }
 
-  @Test
-  func queueUnsyncedRecordsReturnsAllWhenNoneSynced() throws {
-    let (handler, container) = try ProfileDataSyncHandlerTestSupport.makeHandler()
-
+  private struct AllRecordSeed {
     let accountId = UUID()
     let txnId = UUID()
     let legId = UUID()
@@ -143,45 +142,52 @@ struct ProfileDataSyncHandlerQueueTests {
     let investmentValueId = UUID()
     let instrumentId = "AUD"
 
-    let context = ModelContext(container)
-    context.insert(
-      InstrumentRecord(
-        id: instrumentId, kind: "fiatCurrency",
-        name: "Australian Dollar", decimals: 2))
-    context.insert(
-      AccountRecord(id: accountId, name: "Acc", type: "bank", position: 0, isHidden: false))
-    context.insert(
-      CategoryRecord(id: categoryId, name: "Food", parentId: nil))
-    context.insert(
-      EarmarkRecord(id: earmarkId, name: "Holiday", instrumentId: instrumentId))
-    context.insert(
-      EarmarkBudgetItemRecord(
-        id: budgetItemId, earmarkId: earmarkId, categoryId: categoryId,
-        amount: 0, instrumentId: instrumentId))
-    context.insert(
-      InvestmentValueRecord(
-        id: investmentValueId, accountId: accountId, date: Date(),
-        value: 0, instrumentId: instrumentId))
-    context.insert(TransactionRecord(id: txnId, date: Date(), payee: "Test"))
-    context.insert(
-      TransactionLegRecord(
-        id: legId, transactionId: txnId, accountId: accountId,
-        instrumentId: instrumentId, quantity: 0, type: "income", sortOrder: 0))
-    try context.save()
+    func insert(into context: ModelContext) throws {
+      context.insert(
+        InstrumentRecord(id: instrumentId, kind: "fiatCurrency", name: "AUD Dollar", decimals: 2))
+      context.insert(
+        AccountRecord(id: accountId, name: "Acc", type: "bank", position: 0, isHidden: false))
+      context.insert(CategoryRecord(id: categoryId, name: "Food", parentId: nil))
+      context.insert(EarmarkRecord(id: earmarkId, name: "Holiday", instrumentId: instrumentId))
+      context.insert(
+        EarmarkBudgetItemRecord(
+          id: budgetItemId, earmarkId: earmarkId, categoryId: categoryId,
+          amount: 0, instrumentId: instrumentId))
+      context.insert(
+        InvestmentValueRecord(
+          id: investmentValueId, accountId: accountId, date: Date(),
+          value: 0, instrumentId: instrumentId))
+      context.insert(TransactionRecord(id: txnId, date: Date(), payee: "Test"))
+      context.insert(
+        TransactionLegRecord(
+          id: legId, transactionId: txnId, accountId: accountId,
+          instrumentId: instrumentId, quantity: 0, type: "income", sortOrder: 0))
+      try context.save()
+    }
+  }
+
+  @Test
+  func queueUnsyncedRecordsReturnsAllWhenNoneSynced() throws {
+    let (handler, container) = try ProfileDataSyncHandlerTestSupport.makeHandler()
+    let seed = AllRecordSeed()
+    try seed.insert(into: ModelContext(container))
 
     let recordIDs = handler.queueUnsyncedRecords()
     let recordNames = Set(recordIDs.map(\.recordName))
 
     #expect(recordNames.count == 8)
-    #expect(recordNames.contains(instrumentId))
-    #expect(recordNames.contains(accountId.uuidString))
-    #expect(recordNames.contains(categoryId.uuidString))
-    #expect(recordNames.contains(earmarkId.uuidString))
-    #expect(recordNames.contains(budgetItemId.uuidString))
-    #expect(recordNames.contains(investmentValueId.uuidString))
-    #expect(recordNames.contains(txnId.uuidString))
-    #expect(recordNames.contains(legId.uuidString))
-
+    #expect(recordNames.contains(seed.instrumentId))
+    #expect(recordNames.contains("\(AccountRecord.recordType)|\(seed.accountId.uuidString)"))
+    #expect(recordNames.contains("\(CategoryRecord.recordType)|\(seed.categoryId.uuidString)"))
+    #expect(recordNames.contains("\(EarmarkRecord.recordType)|\(seed.earmarkId.uuidString)"))
+    #expect(
+      recordNames.contains(
+        "\(EarmarkBudgetItemRecord.recordType)|\(seed.budgetItemId.uuidString)"))
+    #expect(
+      recordNames.contains(
+        "\(InvestmentValueRecord.recordType)|\(seed.investmentValueId.uuidString)"))
+    #expect(recordNames.contains("\(TransactionRecord.recordType)|\(seed.txnId.uuidString)"))
+    #expect(recordNames.contains("\(TransactionLegRecord.recordType)|\(seed.legId.uuidString)"))
     for recordID in recordIDs {
       #expect(recordID.zoneID == handler.zoneID)
     }

--- a/MoolahTests/Sync/ProfileDataSyncHandlerTests.swift
+++ b/MoolahTests/Sync/ProfileDataSyncHandlerTests.swift
@@ -124,7 +124,9 @@ struct ProfileDataSyncHandlerTests {
     let ckRecord = handler.buildCKRecord(for: account)
 
     #expect(ckRecord.recordType == "CD_AccountRecord")
-    #expect(ckRecord.recordID.recordName == account.id.uuidString)
+    #expect(
+      ckRecord.recordID.recordName
+        == "\(AccountRecord.recordType)|\(account.id.uuidString)")
     #expect(ckRecord.recordID.zoneID == handler.zoneID)
     #expect(ckRecord["name"] as? String == "Savings")
   }
@@ -166,7 +168,9 @@ struct ProfileDataSyncHandlerTests {
     // A fresh (unsent) CKRecord has no change tag. Sending with the foreign
     // tag would be rejected with serverRecordChanged forever.
     #expect(built.recordChangeTag == nil)
-    #expect(built.recordID.recordName == accountId.uuidString)
+    #expect(
+      built.recordID.recordName
+        == "\(AccountRecord.recordType)|\(accountId.uuidString)")
     #expect(built["name"] as? String == "Corrupt")
   }
 

--- a/MoolahTests/Sync/ProfileIndexSyncHandlerTests.swift
+++ b/MoolahTests/Sync/ProfileIndexSyncHandlerTests.swift
@@ -190,7 +190,9 @@ struct ProfileIndexSyncHandlerTests {
     let ckRecord = handler.buildCKRecord(for: profile)
 
     #expect(ckRecord.recordType == ProfileRecord.recordType)
-    #expect(ckRecord.recordID.recordName == profileId.uuidString)
+    #expect(
+      ckRecord.recordID.recordName
+        == "\(ProfileRecord.recordType)|\(profileId.uuidString)")
     #expect(ckRecord.recordID.zoneID == handler.zoneID)
     #expect(ckRecord["label"] as? String == "Test Profile")
     #expect(ckRecord["currencyCode"] as? String == "AUD")

--- a/MoolahTests/Sync/ProfileIndexSyncHandlerTests.swift
+++ b/MoolahTests/Sync/ProfileIndexSyncHandlerTests.swift
@@ -158,8 +158,12 @@ struct ProfileIndexSyncHandlerTests {
 
     #expect(recordIDs.count == 2)
     let recordNames = Set(recordIDs.map(\.recordName))
-    #expect(recordNames.contains(id1.uuidString))
-    #expect(recordNames.contains(id2.uuidString))
+    #expect(
+      recordNames.contains(
+        "\(ProfileRecord.recordType)|\(id1.uuidString)"))
+    #expect(
+      recordNames.contains(
+        "\(ProfileRecord.recordType)|\(id2.uuidString)"))
     for recordID in recordIDs {
       #expect(recordID.zoneID == handler.zoneID)
     }

--- a/MoolahTests/Sync/RecordMappingTests.swift
+++ b/MoolahTests/Sync/RecordMappingTests.swift
@@ -24,7 +24,9 @@ struct RecordMappingTests {
     let ckRecord = profile.toCKRecord(in: zoneID)
 
     #expect(ckRecord.recordType == "CD_ProfileRecord")
-    #expect(ckRecord.recordID.recordName == profile.id.uuidString)
+    #expect(
+      ckRecord.recordID.recordName
+        == "\(ProfileRecord.recordType)|\(profile.id.uuidString)")
     #expect(ckRecord.recordID.zoneID == zoneID)
     #expect(ckRecord["label"] as? String == "My Budget")
     #expect(ckRecord["currencyCode"] as? String == "AUD")
@@ -55,7 +57,9 @@ struct RecordMappingTests {
     let ckRecord = account.toCKRecord(in: zoneID)
 
     #expect(ckRecord.recordType == "CD_AccountRecord")
-    #expect(ckRecord.recordID.recordName == account.id.uuidString)
+    #expect(
+      ckRecord.recordID.recordName
+        == "\(AccountRecord.recordType)|\(account.id.uuidString)")
     #expect(ckRecord["name"] as? String == "Savings")
     #expect(ckRecord["type"] as? String == "bank")
     #expect(ckRecord["instrumentId"] as? String == "USD")
@@ -102,7 +106,9 @@ struct RecordMappingTests {
     let ckRecord = txn.toCKRecord(in: zoneID)
 
     #expect(ckRecord.recordType == "CD_TransactionRecord")
-    #expect(ckRecord.recordID.recordName == txn.id.uuidString)
+    #expect(
+      ckRecord.recordID.recordName
+        == "\(TransactionRecord.recordType)|\(txn.id.uuidString)")
     #expect(ckRecord["date"] as? Date == txnDate)
     #expect(ckRecord["payee"] as? String == "Rent")
     #expect(ckRecord["notes"] as? String == "Monthly rent")
@@ -162,7 +168,9 @@ struct RecordMappingTests {
     let ckRecord = leg.toCKRecord(in: zoneID)
 
     #expect(ckRecord.recordType == "CD_TransactionLegRecord")
-    #expect(ckRecord.recordID.recordName == leg.id.uuidString)
+    #expect(
+      ckRecord.recordID.recordName
+        == "\(TransactionLegRecord.recordType)|\(leg.id.uuidString)")
     #expect(ckRecord["transactionId"] as? String == transactionId.uuidString)
     #expect(ckRecord["accountId"] as? String == accountId.uuidString)
     #expect(ckRecord["instrumentId"] as? String == "AUD")

--- a/MoolahTests/Sync/RecordNameCollisionTests.swift
+++ b/MoolahTests/Sync/RecordNameCollisionTests.swift
@@ -1,0 +1,200 @@
+import CloudKit
+import Foundation
+import SwiftData
+import Testing
+
+@testable import Moolah
+
+@Suite("Record-name collision fix — issue #416")
+@MainActor
+struct RecordNameCollisionTests {
+
+  // MARK: - 1. UUID collision between types (regression test)
+
+  @Test("Account and Transaction sharing a UUID both upload as distinct CKRecords")
+  func collidingUUIDsYieldDistinctPrefixedRecordNames() throws {
+    let (handler, container) =
+      try ProfileDataSyncHandlerTestSupport
+      .makeHandler()
+
+    let sharedId = UUID()
+    let context = ModelContext(container)
+    context.insert(
+      AccountRecord(
+        id: sharedId, name: "Shares", type: "bank", position: 0,
+        isHidden: false))
+    context.insert(
+      TransactionRecord(
+        id: sharedId, date: Date(), payee: "Opening balance"))
+    try context.save()
+
+    let lookup = handler.buildBatchRecordLookup(for: [sharedId])
+
+    // buildBatchRecordLookup returns [UUID: CKRecord] — dedupes by UUID.
+    // The distinction between the two record types is carried on the
+    // recordName prefix, which we assert next.
+    let record = try #require(lookup[sharedId])
+    let expectedPrefix = "\(record.recordType)|\(sharedId.uuidString)"
+    #expect(record.recordID.recordName == expectedPrefix)
+  }
+
+  @Test("queueUnsyncedRecords produces prefixed recordNames per type")
+  func queueUnsyncedProducesPrefixedRecordNamesPerType() throws {
+    let (handler, container) =
+      try ProfileDataSyncHandlerTestSupport
+      .makeHandler()
+
+    let sharedId = UUID()
+    let context = ModelContext(container)
+    context.insert(
+      AccountRecord(
+        id: sharedId, name: "Shares", type: "bank", position: 0,
+        isHidden: false))
+    context.insert(
+      TransactionRecord(
+        id: sharedId, date: Date(), payee: "Opening balance"))
+    try context.save()
+
+    let recordIDs = handler.queueUnsyncedRecords()
+    let names = Set(recordIDs.map(\.recordName))
+    #expect(
+      names.contains("\(AccountRecord.recordType)|\(sharedId.uuidString)"))
+    #expect(
+      names.contains(
+        "\(TransactionRecord.recordType)|\(sharedId.uuidString)"))
+  }
+
+  // MARK: - 2. Uplink uses prefixed name for new records
+
+  @Test("buildCKRecord for a brand-new AccountRecord emits a prefixed recordName")
+  func buildCKRecordEmitsPrefixedRecordNameForNewRecords() throws {
+    let (handler, container) =
+      try ProfileDataSyncHandlerTestSupport
+      .makeHandler()
+
+    let accountId = UUID()
+    let account = AccountRecord(
+      id: accountId, name: "New", type: "bank", position: 0,
+      isHidden: false)
+    let context = ModelContext(container)
+    context.insert(account)
+    try context.save()
+
+    let built = handler.buildCKRecord(for: account)
+    #expect(
+      built.recordID.recordName
+        == "\(AccountRecord.recordType)|\(accountId.uuidString)")
+  }
+
+  // MARK: - 3. Uplink preserves legacy bare-UUID name for already-synced records
+
+  @Test("buildCKRecord keeps legacy bare-UUID recordName when cached system fields exist")
+  func buildCKRecordReusesLegacyRecordNameFromCachedSystemFields() throws {
+    let (handler, container) =
+      try ProfileDataSyncHandlerTestSupport
+      .makeHandler()
+
+    let accountId = UUID()
+    // Seed an encodedSystemFields blob whose recordID uses the legacy
+    // bare-UUID recordName. Simulates a row already synced under the
+    // old format.
+    let legacyRecord = CKRecord(
+      recordType: "CD_AccountRecord",
+      recordID: CKRecord.ID(
+        recordName: accountId.uuidString, zoneID: handler.zoneID))
+    let legacySystemFields = legacyRecord.encodedSystemFields
+
+    let context = ModelContext(container)
+    let account = AccountRecord(
+      id: accountId, name: "Legacy", type: "bank", position: 0,
+      isHidden: false)
+    account.encodedSystemFields = legacySystemFields
+    context.insert(account)
+    try context.save()
+
+    // Mutate and rebuild — should reuse the legacy recordID (no prefix).
+    account.name = "Updated"
+    let built = handler.buildCKRecord(for: account)
+    #expect(built.recordID.recordName == accountId.uuidString)
+    #expect(built["name"] as? String == "Updated")
+  }
+
+  // MARK: - 4. Downlink accepts both formats
+
+  @Test("applyRemoteChanges ingests both prefixed and bare-UUID CKRecords")
+  func applyRemoteChangesAcceptsBothRecordNameFormats() throws {
+    let (handler, container) =
+      try ProfileDataSyncHandlerTestSupport
+      .makeHandler()
+
+    let legacyId = UUID()
+    let legacyCK = CKRecord(
+      recordType: "CD_AccountRecord",
+      recordID: CKRecord.ID(
+        recordName: legacyId.uuidString, zoneID: handler.zoneID))
+    legacyCK["name"] = "Legacy" as CKRecordValue
+    legacyCK["type"] = "bank" as CKRecordValue
+    legacyCK["position"] = 0 as CKRecordValue
+    legacyCK["isHidden"] = 0 as CKRecordValue
+
+    let newId = UUID()
+    let newCK = CKRecord(
+      recordType: "CD_AccountRecord",
+      recordID: CKRecord.ID(
+        recordType: "CD_AccountRecord",
+        uuid: newId,
+        zoneID: handler.zoneID))
+    newCK["name"] = "Prefixed" as CKRecordValue
+    newCK["type"] = "bank" as CKRecordValue
+    newCK["position"] = 1 as CKRecordValue
+    newCK["isHidden"] = 0 as CKRecordValue
+
+    _ = handler.applyRemoteChanges(saved: [legacyCK, newCK], deleted: [])
+
+    let context = ModelContext(container)
+    let all = try context.fetch(FetchDescriptor<AccountRecord>())
+    let byId = Dictionary(uniqueKeysWithValues: all.map { ($0.id, $0) })
+    #expect(byId[legacyId]?.name == "Legacy")
+    #expect(byId[newId]?.name == "Prefixed")
+    #expect(byId[legacyId]?.encodedSystemFields != nil)
+    #expect(byId[newId]?.encodedSystemFields != nil)
+  }
+
+  // MARK: - 5. System-fields round-trip for prefixed records
+
+  @Test("handleSentRecordZoneChanges writes system fields back using recordType")
+  func handleSentRecordZoneChangesAppliesSystemFieldsForPrefixedRecords() throws {
+    let (handler, container) =
+      try ProfileDataSyncHandlerTestSupport
+      .makeHandler()
+
+    let accountId = UUID()
+    let context = ModelContext(container)
+    let account = AccountRecord(
+      id: accountId, name: "Test", type: "bank", position: 0,
+      isHidden: false)
+    context.insert(account)
+    try context.save()
+    #expect(account.encodedSystemFields == nil)
+
+    // Simulate a CK round-trip where the server returns a prefixed
+    // CKRecord as "saved".
+    let savedCK = CKRecord(
+      recordType: "CD_AccountRecord",
+      recordID: CKRecord.ID(
+        recordType: "CD_AccountRecord",
+        uuid: accountId,
+        zoneID: handler.zoneID))
+    savedCK["name"] = "Test" as CKRecordValue
+
+    _ = handler.handleSentRecordZoneChanges(
+      savedRecords: [savedCK], failedSaves: [], failedDeletes: [])
+
+    let fresh = ModelContext(container)
+    let reloaded = try fresh.fetch(
+      FetchDescriptor<AccountRecord>(
+        predicate: #Predicate { $0.id == accountId })
+    ).first
+    #expect(reloaded?.encodedSystemFields != nil)
+  }
+}

--- a/MoolahTests/Sync/RecordNameCollisionTests.swift
+++ b/MoolahTests/Sync/RecordNameCollisionTests.swift
@@ -197,4 +197,100 @@ struct RecordNameCollisionTests {
     ).first
     #expect(reloaded?.encodedSystemFields != nil)
   }
+
+  // MARK: - 6. ProfileIndexSyncHandler dual-format
+
+  private func makeProfileIndexHandler() throws -> (ProfileIndexSyncHandler, ModelContainer) {
+    let schema = Schema([ProfileRecord.self])
+    let config = ModelConfiguration(isStoredInMemoryOnly: true, cloudKitDatabase: .none)
+    let container = try ModelContainer(for: schema, configurations: [config])
+    let handler = ProfileIndexSyncHandler(modelContainer: container)
+    return (handler, container)
+  }
+
+  @Test("ProfileIndexSyncHandler.recordToSave accepts prefixed recordID")
+  func profileIndexRecordToSaveAcceptsPrefixedRecordID() throws {
+    let (handler, container) = try makeProfileIndexHandler()
+
+    let profileId = UUID()
+    let profile = ProfileRecord(
+      id: profileId, label: "Test", currencyCode: "AUD",
+      financialYearStartMonth: 7, createdAt: Date())
+    let context = ModelContext(container)
+    context.insert(profile)
+    try context.save()
+
+    let prefixedID = CKRecord.ID(
+      recordType: ProfileRecord.recordType,
+      uuid: profileId,
+      zoneID: handler.zoneID)
+
+    let result = try #require(handler.recordToSave(for: prefixedID))
+    #expect(result.recordType == ProfileRecord.recordType)
+    #expect(
+      result.recordID.recordName
+        == "\(ProfileRecord.recordType)|\(profileId.uuidString)")
+  }
+
+  @Test("ProfileIndexSyncHandler.applyRemoteChanges accepts prefixed ProfileRecord")
+  func profileIndexApplyRemoteChangesAcceptsPrefixedProfileRecord() throws {
+    let (handler, container) = try makeProfileIndexHandler()
+
+    let profileId = UUID()
+    let prefixedCK = CKRecord(
+      recordType: ProfileRecord.recordType,
+      recordID: CKRecord.ID(
+        recordType: ProfileRecord.recordType,
+        uuid: profileId,
+        zoneID: handler.zoneID))
+    prefixedCK["label"] = "Prefixed" as CKRecordValue
+    prefixedCK["currencyCode"] = "AUD" as CKRecordValue
+    prefixedCK["financialYearStartMonth"] = 7 as CKRecordValue
+    prefixedCK["createdAt"] = Date() as CKRecordValue
+
+    _ = handler.applyRemoteChanges(saved: [prefixedCK], deleted: [])
+
+    let context = ModelContext(container)
+    let records = try context.fetch(
+      FetchDescriptor<ProfileRecord>(
+        predicate: #Predicate { $0.id == profileId })
+    )
+    #expect(records.count == 1)
+    #expect(records.first?.label == "Prefixed")
+    #expect(records.first?.encodedSystemFields != nil)
+  }
+
+  @Test(
+    "ProfileIndexSyncHandler.handleSentRecordZoneChanges caches system fields for prefixed records"
+  )
+  func profileIndexHandleSentCachesSystemFieldsForPrefixedRecord() throws {
+    let (handler, container) = try makeProfileIndexHandler()
+
+    let profileId = UUID()
+    let context = ModelContext(container)
+    let profile = ProfileRecord(
+      id: profileId, label: "Test", currencyCode: "AUD",
+      financialYearStartMonth: 7, createdAt: Date())
+    context.insert(profile)
+    try context.save()
+    #expect(profile.encodedSystemFields == nil)
+
+    let savedCK = CKRecord(
+      recordType: ProfileRecord.recordType,
+      recordID: CKRecord.ID(
+        recordType: ProfileRecord.recordType,
+        uuid: profileId,
+        zoneID: handler.zoneID))
+    savedCK["label"] = "Test" as CKRecordValue
+
+    _ = handler.handleSentRecordZoneChanges(
+      savedRecords: [savedCK], failedSaves: [], failedDeletes: [])
+
+    let fresh = ModelContext(container)
+    let reloaded = try fresh.fetch(
+      FetchDescriptor<ProfileRecord>(
+        predicate: #Predicate { $0.id == profileId })
+    ).first
+    #expect(reloaded?.encodedSystemFields != nil)
+  }
 }

--- a/MoolahTests/Sync/SyncCoordinatorTestsExtra.swift
+++ b/MoolahTests/Sync/SyncCoordinatorTestsExtra.swift
@@ -49,7 +49,7 @@ struct SyncCoordinatorTestsExtra {
       ownerName: CKCurrentUserDefaultName)
 
     // Should not crash — just adds to pending (no sync engine to actually process)
-    coordinator.queueSave(id: id, zoneID: zoneID)
+    coordinator.queueSave(id: id, recordType: AccountRecord.recordType, zoneID: zoneID)
     // No assertion needed beyond "doesn't crash" since CKSyncEngine is not started
   }
 
@@ -74,7 +74,7 @@ struct SyncCoordinatorTestsExtra {
       zoneName: "profile-\(UUID().uuidString)",
       ownerName: CKCurrentUserDefaultName)
 
-    coordinator.queueDeletion(id: id, zoneID: zoneID)
+    coordinator.queueDeletion(id: id, recordType: AccountRecord.recordType, zoneID: zoneID)
   }
 
   // MARK: - Post-Migration / Import Record Queueing
@@ -101,7 +101,13 @@ struct SyncCoordinatorTestsExtra {
     let queued = await coordinator.queueAllRecordsAfterImport(for: profileId)
     let names = Set(queued.map(\.recordName))
 
-    #expect(names == Set([accountId.uuidString, txnId.uuidString, "AUD"]))
+    #expect(
+      names
+        == Set([
+          "\(AccountRecord.recordType)|\(accountId.uuidString)",
+          "\(TransactionRecord.recordType)|\(txnId.uuidString)",
+          "AUD",
+        ]))
     for recordID in queued {
       #expect(recordID.zoneID.zoneName == "profile-\(profileId.uuidString)")
     }
@@ -168,16 +174,21 @@ struct SyncCoordinatorTestsExtra {
     let queued = coordinator.queueUnsyncedRecordsForAllProfiles()
     let names = Set(queued.map(\.recordName))
 
-    #expect(names == Set([unsyncedA.uuidString, unsyncedB.uuidString]))
+    #expect(
+      names
+        == Set([
+          "\(AccountRecord.recordType)|\(unsyncedA.uuidString)",
+          "\(TransactionRecord.recordType)|\(unsyncedB.uuidString)",
+        ]))
 
     // Each record went to the matching profile's zone.
     let aZone = "profile-\(profileA.uuidString)"
     let bZone = "profile-\(profileB.uuidString)"
     for recordID in queued {
-      if recordID.recordName == unsyncedA.uuidString {
+      if recordID.recordName == "\(AccountRecord.recordType)|\(unsyncedA.uuidString)" {
         #expect(recordID.zoneID.zoneName == aZone)
       }
-      if recordID.recordName == unsyncedB.uuidString {
+      if recordID.recordName == "\(TransactionRecord.recordType)|\(unsyncedB.uuidString)" {
         #expect(recordID.zoneID.zoneName == bZone)
       }
     }
@@ -218,7 +229,7 @@ struct SyncCoordinatorTestsExtra {
 
     // First scan should find and queue the unsynced record.
     let first = coordinator.queueUnsyncedRecordsForAllProfiles()
-    #expect(first.map(\.recordName) == [accountId.uuidString])
+    #expect(first.map(\.recordName) == ["\(AccountRecord.recordType)|\(accountId.uuidString)"])
 
     // Second scan must NOT re-queue the same record — the profile has been marked
     // as scanned and is skipped. Avoids doing a SwiftData pass on every app launch.

--- a/MoolahTests/Sync/SyncCoordinatorTestsExtra.swift
+++ b/MoolahTests/Sync/SyncCoordinatorTestsExtra.swift
@@ -49,7 +49,7 @@ struct SyncCoordinatorTestsExtra {
       ownerName: CKCurrentUserDefaultName)
 
     // Should not crash — just adds to pending (no sync engine to actually process)
-    coordinator.queueSave(id: id, recordType: AccountRecord.recordType, zoneID: zoneID)
+    coordinator.queueSave(recordType: AccountRecord.recordType, id: id, zoneID: zoneID)
     // No assertion needed beyond "doesn't crash" since CKSyncEngine is not started
   }
 
@@ -74,7 +74,7 @@ struct SyncCoordinatorTestsExtra {
       zoneName: "profile-\(UUID().uuidString)",
       ownerName: CKCurrentUserDefaultName)
 
-    coordinator.queueDeletion(id: id, recordType: AccountRecord.recordType, zoneID: zoneID)
+    coordinator.queueDeletion(recordType: AccountRecord.recordType, id: id, zoneID: zoneID)
   }
 
   // MARK: - Post-Migration / Import Record Queueing

--- a/MoolahTests/Sync/SyncCoordinatorTestsMore.swift
+++ b/MoolahTests/Sync/SyncCoordinatorTestsMore.swift
@@ -37,7 +37,8 @@ struct SyncCoordinatorTestsMore {
 
     // Migration queues all records up front.
     let queued = await coordinator.queueAllRecordsAfterImport(for: profileId)
-    #expect(queued.map(\.recordName) == [accountId.uuidString])
+    #expect(
+      queued.map(\.recordName) == ["\(AccountRecord.recordType)|\(accountId.uuidString)"])
 
     // A subsequent startup scan must skip this profile — migration has already done
     // the equivalent work, and re-scanning would just do a pointless SwiftData pass.

--- a/plans/2026-04-24-sync-record-name-collision-design.md
+++ b/plans/2026-04-24-sync-record-name-collision-design.md
@@ -1,0 +1,352 @@
+# Sync: Record-Name Collision Fix — Design
+
+**Date:** 2026-04-24
+**Issue:** [#416](https://github.com/ajsutton/moolah-native/issues/416)
+**Base branch:** `fix/sync-silent-drop-observability` (PR [#417](https://github.com/ajsutton/moolah-native/pull/417))
+**Status:** Draft → pending user approval
+
+## Summary
+
+Encode the SwiftData record type into every UUID-keyed `CKRecord.ID.recordName`
+so records of different types can never share a server-side identity, even when
+their UUIDs collide locally. Ship dual-format readers (`TYPE|UUID` and bare
+`UUID`) so legacy records already on the server continue to sync without
+disruption. Skip active migration of legacy records in this release; file a
+follow-up issue for a cleanup pass once this change is widely adopted.
+
+## Background
+
+`ProfileDataSyncHandler+RecordLookup.swift` uses the UUID-string recordName as
+the sole identifier when building a `CKRecord` to upload. The lookup iterates
+record types in a fixed order and returns the first match — it implicitly
+assumes UUIDs are globally unique across types, but nothing in the schema
+enforces that.
+
+In the wild, 16 accounts on a reporter's profile shared UUIDs with their
+opening-balance transactions. Every upload of those accounts returned the
+matching `TransactionRecord` instead, CloudKit saw "no new record," and the
+16 accounts never left the device. CKSyncEngine reported clean success on
+every cycle.
+
+The broader CloudKit invariant: records are identified by
+`(recordName, zoneID)`. If two record types share a UUID, only one can ever
+exist at that recordName on the server. Today the first-type-to-sync wins and
+the others are silently shadowed.
+
+The diagnostic PR [#417](https://github.com/ajsutton/moolah-native/pull/417) has
+already closed the silent-drop observability gap. This PR fixes the underlying
+collision.
+
+## Scope
+
+**In scope (v1, this PR):**
+
+- New recordName format `"<recordType>|<uuid.uuidString>"` for every
+  UUID-keyed record.
+- Prefix-tolerant downlink readers that accept both the new format and bare
+  UUIDs (so records already on the server keep working).
+- `queueSave` / `queueDeletion` signature change that forces callers to pass
+  the record type — eliminates the structural source of the bug permanently.
+- Regression test coverage (UUID collision; legacy compat; downlink; uplink;
+  system-fields round-trip).
+
+**Out of scope (deferred):**
+
+- Active deletion of legacy UUID-only records on the server. Tracked as a
+  follow-up issue; unsafe until v1 is widely adopted (see Risks below).
+- Changes to `InstrumentRecord` (string-keyed, can't collide).
+
+## Architecture
+
+### Record-name format
+
+For every UUID-keyed record:
+
+```
+"<recordType>|<uuid.uuidString>"
+```
+
+Examples:
+
+```
+CD_AccountRecord|1CAC9567-574B-481A-BADA-D595325CBE0C
+CD_TransactionRecord|1CAC9567-574B-481A-BADA-D595325CBE0C
+CD_ProfileRecord|A1B2C3D4-...
+```
+
+The `|` delimiter is safe: CloudKit permits it in recordNames, none of our
+`recordType` constants contain it, and it can't appear in an `InstrumentRecord`
+string ID (`"AUD"`, `"ASX:BHP"`, etc.).
+
+`InstrumentRecord` recordNames keep their string-ID form. The parser
+distinguishes them by the absence of `|` and the fact that bare IDs don't
+parse as UUIDs.
+
+### Central helpers
+
+Two helpers on `CKRecord.ID` centralize construction and parsing. They live in
+a new file `Backends/CloudKit/Sync/CKRecordID+RecordName.swift`.
+
+```swift
+extension CKRecord.ID {
+  /// Constructs the new prefixed recordName from a type and UUID.
+  convenience init(recordType: String, uuid: UUID, zoneID: CKRecordZone.ID) {
+    self.init(
+      recordName: "\(recordType)|\(uuid.uuidString)",
+      zoneID: zoneID
+    )
+  }
+
+  /// Returns the UUID portion of a recordName regardless of format.
+  /// Accepts `"<TYPE>|<UUID>"` (new) and `"<UUID>"` (legacy).
+  /// Returns `nil` for non-UUID names (e.g. instrument IDs like `"AUD"`).
+  func uuidRecordName() -> UUID? {
+    if let sep = recordName.firstIndex(of: "|") {
+      let uuidPart = recordName[recordName.index(after: sep)...]
+      return UUID(uuidString: String(uuidPart))
+    }
+    return UUID(uuidString: recordName)
+  }
+}
+```
+
+Every other site that used to build or parse a UUID recordName by hand
+delegates to these two helpers.
+
+### Uplink (local → CloudKit)
+
+#### Queue signatures
+
+`SyncCoordinator+Lifecycle.swift`:
+
+```swift
+func queueSave(id: UUID, recordType: String, zoneID: CKRecordZone.ID) { ... }
+func queueDeletion(id: UUID, recordType: String, zoneID: CKRecordZone.ID) { ... }
+// String-ID overload for InstrumentRecord stays unchanged:
+func queueSave(recordName: String, zoneID: CKRecordZone.ID) { ... }
+```
+
+Both construct the `CKRecord.ID` via the new `init(recordType:uuid:zoneID:)`.
+
+#### Callers
+
+- **`App/ProfileSession+SyncWiring.swift`** — each repository wires its own
+  `onRecordChanged` / `onRecordDeleted` callback; every repository is
+  type-specific, so each call passes its corresponding `XxxRecord.recordType`.
+- **`App/MoolahApp+Setup.swift`** — `ProfileRecord` callbacks pass
+  `ProfileRecord.recordType`.
+- **`ProfileDataSyncHandler+QueueAndDelete.swift`** — `collectUnsynced<T>` and
+  `collectAllUUIDs<T>` emit `CKRecord.ID` via the new init, using
+  `T.recordType` directly (T conforms to `CloudKitRecordConvertible`).
+
+#### CKRecord construction
+
+Each `<Type>Record+CloudKit.swift` has a `toCKRecord(in:)` that builds
+`CKRecord.ID` inline from `id.uuidString`. All ten UUID-keyed types swap to
+the new init:
+
+```swift
+func toCKRecord(in zoneID: CKRecordZone.ID) -> CKRecord {
+  let recordID = CKRecord.ID(
+    recordType: Self.recordType, uuid: id, zoneID: zoneID)
+  let record = CKRecord(recordType: Self.recordType, recordID: recordID)
+  ...
+}
+```
+
+#### Legacy-record preservation
+
+`ProfileDataSyncHandler.buildCKRecord(for:)` already reuses the cached CKRecord
+from `encodedSystemFields` when present, copying fresh field values onto it.
+For a record that was synced before this change, `encodedSystemFields` decodes
+to a `CKRecord` whose `recordID.recordName` is the bare UUID, so re-uploads
+automatically stay under that legacy name. No new code required for this
+path.
+
+### Downlink (CloudKit → local)
+
+Five sites parse `recordID.recordName` today. All except `applySystemFields`
+switch to `uuidRecordName()`.
+
+| File | Function | Change |
+|---|---|---|
+| `ProfileDataSyncHandler+BatchUpsert.swift:279` | `uuidPairs(from:)` | Use `uuidRecordName()`. |
+| `ProfileDataSyncHandler+ApplyRemoteChanges.swift:93` | `applyBatchDeletions` UUID parse | Use `uuidRecordName()`. |
+| `ProfileDataSyncHandler+SystemFields.swift:129` | `applySystemFields` | Drop recordName parsing entirely; dispatch by `ckRecord.recordType`. |
+| `ProfileDataSyncHandler+SystemFields.swift:146` | `clearSystemFields` | Use `uuidRecordName()` (recordType is passed in separately). |
+| `ProfileDataSyncHandler+RecordLookup.swift:48` | `recordToSave` | Unchanged — its "not a UUID" branch handles instrument IDs. Prefixed UUIDs route via `appendProfileDataRecords` before reaching this site. |
+
+In `SyncCoordinator+Delegate.swift:252`, `appendProfileDataRecords` partitions
+recordIDs into UUID-based vs. string-based. Switch to `uuidRecordName()` —
+prefixed records land in the UUID bucket correctly.
+
+Each `<Type>Record+CloudKit.swift`'s `fieldValues(from:)` parses
+`ckRecord.recordID.recordName` back to a UUID. All ten swap to
+`uuidRecordName()`:
+
+```swift
+static func fieldValues(from ckRecord: CKRecord) -> AccountRecord {
+  AccountRecord(
+    id: ckRecord.recordID.uuidRecordName() ?? UUID(),
+    ...
+  )
+}
+```
+
+### No active migration in v1
+
+Legacy records already synced under bare-UUID recordNames stay on the server
+under those names indefinitely. `buildCKRecord`'s cached-record reuse keeps
+them there on re-upload. The downlink helpers accept both formats, so peer
+devices (current or future) continue to fetch them correctly.
+
+## Alternatives considered
+
+**Option A (chosen).** Dual-format reader, write new format only for
+never-synced records, no migration.
+
+- Pro: zero risk to mixed-version users.
+- Con: server carries both formats forever (until v2).
+- Con: downlink parses through a prefix branch on every record (negligible cost).
+
+**Option B.** Opportunistically clear `encodedSystemFields` on a legacy record
+the next time it's mutated, forcing it to re-upload under a prefixed name.
+
+- Rejected: orphans the old UUID-only record on the server.
+
+**Option C.** Option A + a collision detector that forces prefix-mode upload
+for records whose UUID collides locally.
+
+- Rejected: the collision-detector logic adds code to a path that's already
+  correct under Option A. For the reporter's profile specifically, Option A
+  alone is sufficient — the 16 affected accounts have `encodedSystemFields
+  == nil` (never synced) so they naturally get the new prefixed name on first
+  upload. The Transaction side keeps its UUID-only name, and peers see both
+  records correctly after the fix.
+
+**Option D.** Atomic delete-old + upload-new migration on launch of new build.
+
+- Rejected for v1: breaks mixed-version users. A peer on the old build would
+  receive the delete (losing its local copy) plus a prefixed save that the
+  old downlink can't parse (silent drop). Net effect: data loss on peers
+  that haven't updated yet.
+- Deferred to v2 (follow-up issue). Once v1 is widely adopted, the
+  prefix-parser is everywhere and D becomes safe.
+
+## Risks & edge cases
+
+### Mixed-version devices
+
+A user with one device on v1 and another on the prior release continues to
+work: v1 keeps re-uploading legacy records under UUID-only names (via the
+cached `encodedSystemFields`), so the old device sees no change in recordName
+format. Any record created on v1 (with a prefixed name) will be dropped by
+the old device's downlink — that's the v1 → v0 regression path, but it only
+affects new records and converges as soon as the old device updates.
+
+The v1 → v0 drop is strictly better than today, where the 16 colliding records
+are invisible on every device.
+
+### State-file migration
+
+`CKSyncEngine.State.Serialization` on disk from a prior launch may carry
+pending `CKRecord.ID`s with bare UUIDs. On the first v1 launch, those are
+still valid recordNames: `buildCKRecord` resolves them via the cached
+`encodedSystemFields` (UUID-only path), and the send cycle uploads under the
+same bare UUID. No state-file migration required.
+
+Pending records with no `encodedSystemFields` but bare-UUID recordNames (e.g.
+a crashed launch between SwiftData write and CloudKit send) would upload
+under bare UUID unnecessarily — but that's only an issue if the same UUID
+collides with another record type, and in that specific case we want to
+re-queue under the prefixed name. The backfill scan in
+`queueUnsyncedRecords` handles this: `collectUnsynced` emits prefixed
+`CKRecord.ID`s, and CKSyncEngine's pending-list dedup (SYNC_GUIDE Rule 12)
+merges duplicates by recordID — bare UUID and `TYPE|UUID` are distinct
+recordIDs, so the prefixed version wins for the next send cycle.
+
+### ProfileRecord single-type zone
+
+The profile-index zone is single-type today, so `ProfileRecord` cannot
+collide. We still prefix it for uniformity and forward compatibility. The
+dual-format parser is cheap and keeps the policy consistent across zones.
+
+### Instrument IDs
+
+`InstrumentRecord` uses string IDs (`"AUD"`, `"ASX:BHP"`). These cannot
+contain `|` and cannot parse as UUIDs, so `uuidRecordName()` returns `nil`
+and the string-ID branch takes over — same as today.
+
+## Testing
+
+Five targeted tests under `MoolahTests/Sync/`:
+
+1. **UUID-collision regression.** Seed an `AccountRecord(id: X)` and a
+   `TransactionRecord(id: X)`, both unsynced. Run the queue → batch-build
+   path for both profile-data saves. Assert two CKRecords are built:
+   `CD_AccountRecord|X` (recordType `CD_AccountRecord`) and
+   `CD_TransactionRecord|X` (recordType `CD_TransactionRecord`). Assert
+   both land on the server after the send event.
+
+2. **Uplink uses prefixed name for new records.** Queue a save for a
+   never-synced `AccountRecord`. Inspect the CKRecord built for upload —
+   `recordID.recordName == "CD_AccountRecord|<UUID>"`.
+
+3. **Uplink preserves legacy name for already-synced records.** Seed an
+   `AccountRecord` whose cached `encodedSystemFields` decodes to a
+   `CKRecord.ID` with a bare-UUID recordName. Mutate the record, queue a
+   save, build the batch. Assert the rebuilt CKRecord's
+   `recordID.recordName` is the bare UUID (no prefix).
+
+4. **Downlink accepts both formats.** Call `applyRemoteChanges` with two
+   synthetic `CD_AccountRecord` CKRecords: one with
+   `recordName == "<UUID1>"` (legacy) and one with
+   `recordName == "CD_AccountRecord|<UUID2>"` (new). Assert both land in
+   SwiftData as distinct `AccountRecord` rows with the correct UUIDs and
+   `encodedSystemFields`.
+
+5. **System-fields round-trip for prefixed records.** Simulate a successful
+   `sentRecordZoneChanges` event carrying a saved CKRecord with
+   `recordID.recordName == "CD_AccountRecord|<UUID>"` and
+   `recordType == "CD_AccountRecord"`. Assert the local `AccountRecord`'s
+   `encodedSystemFields` is populated — verifies `applySystemFields`
+   dispatches by `recordType` (not by parsing the prefix).
+
+All five run against the in-memory `TestBackend` (`CloudKitBackend` +
+in-memory SwiftData).
+
+## Files touched
+
+**New file:**
+
+- `Backends/CloudKit/Sync/CKRecordID+RecordName.swift` — the two helpers.
+
+**Modified:**
+
+- `Backends/CloudKit/Sync/SyncCoordinator+Lifecycle.swift` — queue signatures.
+- `App/ProfileSession+SyncWiring.swift` — pass recordType to queue calls.
+- `App/MoolahApp+Setup.swift` — `ProfileRecord` queue calls pass recordType.
+- `Backends/CloudKit/Sync/ProfileDataSyncHandler+QueueAndDelete.swift` —
+  `collectUnsynced` / `collectAllUUIDs` use prefixed construction.
+- `Backends/CloudKit/Sync/ProfileDataSyncHandler+SystemFields.swift` —
+  `applySystemFields` dispatches by `recordType`; `clearSystemFields` uses
+  `uuidRecordName()`.
+- `Backends/CloudKit/Sync/ProfileDataSyncHandler+BatchUpsert.swift` —
+  `uuidPairs(from:)` uses `uuidRecordName()`.
+- `Backends/CloudKit/Sync/ProfileDataSyncHandler+ApplyRemoteChanges.swift` —
+  deletion UUID-parse uses `uuidRecordName()`.
+- `Backends/CloudKit/Sync/SyncCoordinator+Delegate.swift` —
+  `appendProfileDataRecords` partition uses `uuidRecordName()`.
+- `Backends/CloudKit/Sync/<Type>Record+CloudKit.swift` × 10 —
+  `toCKRecord` uses the new init; `fieldValues` uses `uuidRecordName()`.
+
+**New tests:**
+
+- `MoolahTests/Sync/RecordNameCollisionTests.swift` — the five tests above.
+
+## Follow-up
+
+GitHub issue (to be filed after spec approval): **"sync: migrate legacy
+UUID-only records to prefixed recordNames"**. Tracks the v2 delete-old +
+upload-new migration pass, gated on v1 having been in the field long enough
+that mixed-version data loss is acceptable risk.

--- a/plans/2026-04-24-sync-record-name-collision-implementation.md
+++ b/plans/2026-04-24-sync-record-name-collision-implementation.md
@@ -9,7 +9,7 @@ downlink readers.
 
 **Architecture:** New format is `"<recordType>|<uuid.uuidString>"`. Two helpers
 on `CKRecord.ID` centralize construction (`init(recordType:uuid:zoneID:)`) and
-parsing (`uuidRecordName()`). Legacy records stay under their bare-UUID
+parsing (`uuid: UUID?` computed property). Legacy records stay under their bare-UUID
 recordName via `buildCKRecord`'s cached-record reuse. No active migration in
 v1 — tracked as [#420](https://github.com/ajsutton/moolah-native/issues/420).
 
@@ -24,13 +24,13 @@ v1 — tracked as [#420](https://github.com/ajsutton/moolah-native/issues/420).
 
 **New:**
 
-- `Backends/CloudKit/Sync/CKRecordID+RecordName.swift` — `init(recordType:uuid:zoneID:)`, `uuidRecordName()`, `systemFieldsKey`.
+- `Backends/CloudKit/Sync/CKRecordIDRecordName.swift` — `init(recordType:uuid:zoneID:)`, `uuid: UUID?`, `systemFieldsKey`.
 - `MoolahTests/Sync/CKRecordIDRecordNameTests.swift` — unit tests for the three helpers.
 - `MoolahTests/Sync/RecordNameCollisionTests.swift` — five regression tests from the spec.
 
 **Modified (per-type × 10 — AccountRecord, TransactionRecord, TransactionLegRecord, CategoryRecord, EarmarkRecord, EarmarkBudgetItemRecord, InvestmentValueRecord, CSVImportProfileRecord, ImportRuleRecord, ProfileRecord):**
 
-- `Backends/CloudKit/Sync/<Type>Record+CloudKit.swift` — `toCKRecord` uses prefixed init; `fieldValues(from:)` uses `uuidRecordName()`.
+- `Backends/CloudKit/Sync/<Type>Record+CloudKit.swift` — `toCKRecord` uses prefixed init; `fieldValues(from:)` uses `recordID.uuid`.
 
 **Modified (single sites):**
 
@@ -99,7 +99,7 @@ struct CKRecordIDRecordNameTests {
     let recordID = CKRecord.ID(
       recordName: "CD_AccountRecord|1CAC9567-574B-481A-BADA-D595325CBE0C",
       zoneID: zoneID)
-    #expect(recordID.uuidRecordName() == uuid)
+    #expect(recordID.uuid == uuid)
   }
 
   @Test
@@ -108,7 +108,7 @@ struct CKRecordIDRecordNameTests {
     let recordID = CKRecord.ID(
       recordName: "1CAC9567-574B-481A-BADA-D595325CBE0C",
       zoneID: zoneID)
-    #expect(recordID.uuidRecordName() == uuid)
+    #expect(recordID.uuid == uuid)
   }
 
   @Test
@@ -126,7 +126,7 @@ struct CKRecordIDRecordNameTests {
     let recordID = CKRecord.ID(
       recordName: "CD_AccountRecord|not-a-uuid",
       zoneID: zoneID)
-    #expect(recordID.uuidRecordName() == nil)
+    #expect(recordID.uuid == nil)
   }
 
   // MARK: - systemFieldsKey
@@ -280,7 +280,7 @@ rm .agent-tmp/t1-*.txt
    ```
    with
    ```swift
-   id: ckRecord.recordID.uuidRecordName() ?? UUID(),
+   id: ckRecord.recordID.uuid ?? UUID(),
    ```
 
 `InstrumentRecord+CloudKit.swift` is NOT in the list — it uses a string ID
@@ -439,7 +439,7 @@ feat(sync): emit prefixed recordNames from per-type toCKRecord (#416)
 Every UUID-keyed <Type>Record+CloudKit.swift now constructs
 CKRecord.IDs via CKRecord.ID(recordType:uuid:zoneID:), producing
 "<recordType>|<UUID>" recordNames for brand-new records. The
-matching fieldValues(from:) uses CKRecord.ID.uuidRecordName() so the
+matching fieldValues(from:) uses ckRecord.recordID.uuid so the
 downlink half of the mapping accepts both the new format and the
 legacy bare-UUID form.
 
@@ -725,7 +725,7 @@ with
 ```swift
 nonisolated private static func uuidPairs(from ckRecords: [CKRecord]) -> [(UUID, CKRecord)] {
   ckRecords.compactMap { record in
-    guard let uuid = record.recordID.uuidRecordName() else { return nil }
+    guard let uuid = record.recordID.uuid else { return nil }
     return (uuid, record)
   }
 }
@@ -749,7 +749,7 @@ with
 
 ```swift
 for (recordID, recordType) in deletions {
-  if let uuid = recordID.uuidRecordName() {
+  if let uuid = recordID.uuid {
     uuidGrouped[recordType, default: []].append(uuid)
   } else {
     stringGrouped[recordType, default: []].append(recordID.recordName)
@@ -845,7 +845,7 @@ private func applySystemFields(from ckRecord: CKRecord, in context: ModelContext
       ckRecord.recordID.recordName, data: data, context: context)
     return
   }
-  guard let uuid = ckRecord.recordID.uuidRecordName() else {
+  guard let uuid = ckRecord.recordID.uuid else {
     logger.warning(
       "applySystemFields: recordName \(ckRecord.recordID.recordName) has no UUID component for \(ckRecord.recordType)"
     )
@@ -887,7 +887,7 @@ private func clearSystemFields(
       recordID.recordName, data: nil, context: context)
     return
   }
-  guard let uuid = recordID.uuidRecordName() else {
+  guard let uuid = recordID.uuid else {
     logger.warning(
       "clearSystemFields: recordName \(recordID.recordName) has no UUID component for \(recordType)"
     )
@@ -912,7 +912,7 @@ guard let uuid = UUID(uuidString: recordName) else {
 with
 
 ```swift
-guard let uuid = recordID.uuidRecordName() else {
+guard let uuid = recordID.uuid else {
   logger.warning("Could not find local record for non-UUID ID: \(recordName)")
   return nil
 }
@@ -940,7 +940,7 @@ with
 
 ```swift
 for recordID in recordIDs {
-  if let uuid = recordID.uuidRecordName() {
+  if let uuid = recordID.uuid {
     uuidRecordNames.append((recordID, uuid))
   } else {
     stringRecordIDs.append(recordID)
@@ -973,7 +973,7 @@ git -C /Users/aj/Documents/code/moolah-project/moolah-native/.claude/worktrees/f
 feat(sync): accept prefixed and legacy recordNames on downlink (#416)
 
 Five downlink sites that parsed recordID.recordName as a bare UUID
-now go through CKRecord.ID.uuidRecordName() which accepts both the
+now go through CKRecord.ID.uuid which accepts both the
 new "<recordType>|<UUID>" format and the legacy bare-UUID form:
 
 - ProfileDataSyncHandler+BatchUpsert uuidPairs(from:)
@@ -1367,7 +1367,7 @@ EOF
   Every code snippet is complete.
 - **Type consistency:** `queueSave`/`queueDeletion` signatures match across
   SyncCoordinator and all callers. `systemFieldsKey` is used consistently.
-  `uuidRecordName()` returns `UUID?` everywhere it's used.
+  `uuid` returns `UUID?` everywhere it's used.
 - **One known caveat:** Step 5.1 / Test #1 asserts `lookup.count == 2 || 1`
   because `buildBatchRecordLookup` returns `[UUID: CKRecord]`, which dedupes
   by UUID. The real regression coverage is the second test

--- a/plans/2026-04-24-sync-record-name-collision-implementation.md
+++ b/plans/2026-04-24-sync-record-name-collision-implementation.md
@@ -1,0 +1,1376 @@
+# Sync: Record-Name Collision Fix — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Encode record type into every UUID-keyed `CKRecord.ID.recordName`
+so collisions across SwiftData types can't share a server-side identity, while
+keeping every bare-UUID record already on the server working via dual-format
+downlink readers.
+
+**Architecture:** New format is `"<recordType>|<uuid.uuidString>"`. Two helpers
+on `CKRecord.ID` centralize construction (`init(recordType:uuid:zoneID:)`) and
+parsing (`uuidRecordName()`). Legacy records stay under their bare-UUID
+recordName via `buildCKRecord`'s cached-record reuse. No active migration in
+v1 — tracked as [#420](https://github.com/ajsutton/moolah-native/issues/420).
+
+**Tech Stack:** Swift 6, CKSyncEngine, SwiftData, Swift Testing. Build via
+`just build-mac` / `just test`. Format via `just format`.
+
+**Spec:** `plans/2026-04-24-sync-record-name-collision-design.md`.
+
+---
+
+## File map
+
+**New:**
+
+- `Backends/CloudKit/Sync/CKRecordID+RecordName.swift` — `init(recordType:uuid:zoneID:)`, `uuidRecordName()`, `systemFieldsKey`.
+- `MoolahTests/Sync/CKRecordIDRecordNameTests.swift` — unit tests for the three helpers.
+- `MoolahTests/Sync/RecordNameCollisionTests.swift` — five regression tests from the spec.
+
+**Modified (per-type × 10 — AccountRecord, TransactionRecord, TransactionLegRecord, CategoryRecord, EarmarkRecord, EarmarkBudgetItemRecord, InvestmentValueRecord, CSVImportProfileRecord, ImportRuleRecord, ProfileRecord):**
+
+- `Backends/CloudKit/Sync/<Type>Record+CloudKit.swift` — `toCKRecord` uses prefixed init; `fieldValues(from:)` uses `uuidRecordName()`.
+
+**Modified (single sites):**
+
+- `Backends/CloudKit/Sync/SyncCoordinator+Lifecycle.swift` — queue signatures.
+- `Backends/CloudKit/Sync/ProfileDataSyncHandler+QueueAndDelete.swift` — `collectUnsynced`/`collectAllUUIDs` emit prefixed.
+- `Backends/CloudKit/Sync/ProfileDataSyncHandler+BatchUpsert.swift` — `uuidPairs(from:)`.
+- `Backends/CloudKit/Sync/ProfileDataSyncHandler+ApplyRemoteChanges.swift` — deletion UUID parse, `systemFieldsLookup` key normalization.
+- `Backends/CloudKit/Sync/ProfileDataSyncHandler+SystemFields.swift` — `applySystemFields` dispatches by `recordType`; `clearSystemFields` uses helper.
+- `Backends/CloudKit/Sync/SyncCoordinator+Delegate.swift` — `appendProfileDataRecords` partition.
+- `App/ProfileSession+SyncWiring.swift` — pass `recordType` to queue calls.
+- `App/MoolahApp+Setup.swift` — ProfileRecord queue calls pass recordType.
+
+**Modified tests (existing assertions that compare recordName to bare UUID):**
+
+- `MoolahTests/Sync/RecordMappingTests.swift` — 4 assertions to update.
+- `MoolahTests/Sync/ProfileIndexSyncHandlerTests.swift` — 1 assertion.
+- `MoolahTests/Sync/ProfileIndexSyncHandlerTestsMore.swift` — 1 assertion.
+- `MoolahTests/Sync/ProfileDataSyncHandlerTests.swift` — 2 assertions (one test — `buildCKRecordPreservesCachedSystemFields` at line 201 — keeps bare UUID because legacy-compat path, so do NOT change it).
+- `MoolahTests/Sync/SyncCoordinatorTestsExtra.swift` — 2 assertions inspecting pending queue state.
+
+---
+
+## Task 1: Add `CKRecord.ID` helpers (construction, UUID parse, cache key)
+
+**Files:**
+- Create: `Backends/CloudKit/Sync/CKRecordID+RecordName.swift`
+- Test: `MoolahTests/Sync/CKRecordIDRecordNameTests.swift`
+
+- [ ] **Step 1.1: Write the failing test file**
+
+Create `MoolahTests/Sync/CKRecordIDRecordNameTests.swift`:
+
+```swift
+import CloudKit
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("CKRecord.ID — recordName helpers")
+struct CKRecordIDRecordNameTests {
+
+  private let zoneID = CKRecordZone.ID(
+    zoneName: "profile-test",
+    ownerName: CKCurrentUserDefaultName
+  )
+
+  // MARK: - init(recordType:uuid:zoneID:)
+
+  @Test
+  func initBuildsPrefixedRecordName() {
+    let uuid = UUID(uuidString: "1CAC9567-574B-481A-BADA-D595325CBE0C")!
+    let recordID = CKRecord.ID(
+      recordType: "CD_AccountRecord", uuid: uuid, zoneID: zoneID)
+    #expect(
+      recordID.recordName
+        == "CD_AccountRecord|1CAC9567-574B-481A-BADA-D595325CBE0C")
+    #expect(recordID.zoneID == zoneID)
+  }
+
+  // MARK: - uuidRecordName()
+
+  @Test
+  func uuidRecordNameStripsPrefix() {
+    let uuid = UUID(uuidString: "1CAC9567-574B-481A-BADA-D595325CBE0C")!
+    let recordID = CKRecord.ID(
+      recordName: "CD_AccountRecord|1CAC9567-574B-481A-BADA-D595325CBE0C",
+      zoneID: zoneID)
+    #expect(recordID.uuidRecordName() == uuid)
+  }
+
+  @Test
+  func uuidRecordNameAcceptsBareUUIDLegacyFormat() {
+    let uuid = UUID(uuidString: "1CAC9567-574B-481A-BADA-D595325CBE0C")!
+    let recordID = CKRecord.ID(
+      recordName: "1CAC9567-574B-481A-BADA-D595325CBE0C",
+      zoneID: zoneID)
+    #expect(recordID.uuidRecordName() == uuid)
+  }
+
+  @Test
+  func uuidRecordNameReturnsNilForInstrumentIDs() {
+    #expect(
+      CKRecord.ID(recordName: "AUD", zoneID: zoneID).uuidRecordName() == nil)
+    #expect(
+      CKRecord.ID(recordName: "ASX:BHP", zoneID: zoneID).uuidRecordName()
+        == nil)
+  }
+
+  @Test
+  func uuidRecordNameReturnsNilForNonUUIDAfterPrefix() {
+    // If somebody ever passes a non-UUID after the pipe, we should reject.
+    let recordID = CKRecord.ID(
+      recordName: "CD_AccountRecord|not-a-uuid",
+      zoneID: zoneID)
+    #expect(recordID.uuidRecordName() == nil)
+  }
+
+  // MARK: - systemFieldsKey
+
+  @Test
+  func systemFieldsKeyStripsTypePrefixForPrefixedRecord() {
+    let recordID = CKRecord.ID(
+      recordName: "CD_AccountRecord|1CAC9567-574B-481A-BADA-D595325CBE0C",
+      zoneID: zoneID)
+    #expect(recordID.systemFieldsKey == "1CAC9567-574B-481A-BADA-D595325CBE0C")
+  }
+
+  @Test
+  func systemFieldsKeyReturnsBareUUIDForLegacyRecord() {
+    let recordID = CKRecord.ID(
+      recordName: "1CAC9567-574B-481A-BADA-D595325CBE0C",
+      zoneID: zoneID)
+    #expect(recordID.systemFieldsKey == "1CAC9567-574B-481A-BADA-D595325CBE0C")
+  }
+
+  @Test
+  func systemFieldsKeyReturnsRecordNameForInstrument() {
+    let recordID = CKRecord.ID(recordName: "ASX:BHP", zoneID: zoneID)
+    #expect(recordID.systemFieldsKey == "ASX:BHP")
+  }
+}
+```
+
+- [ ] **Step 1.2: Run tests to verify they fail**
+
+```bash
+just test-mac CKRecordIDRecordNameTests 2>&1 | tee .agent-tmp/t1-red.txt
+```
+
+Expected: build failure — `Type 'CKRecord.ID' has no member` or equivalent.
+
+- [ ] **Step 1.3: Write the helpers**
+
+Create `Backends/CloudKit/Sync/CKRecordID+RecordName.swift`:
+
+```swift
+import CloudKit
+import Foundation
+
+// `CKRecord.ID.recordName` is the primary key for a record in a zone. UUID-keyed
+// records in this app encode the SwiftData record type as a prefix so two
+// different types that happen to share a UUID can't collide on the server
+// (issue #416). Format: `"<recordType>|<uuid.uuidString>"` for new records.
+// Legacy records already on the server continue to use bare `<uuid.uuidString>`;
+// these helpers accept both formats.
+extension CKRecord.ID {
+  /// Constructs a prefixed recordName from a record type and UUID.
+  convenience init(
+    recordType: String, uuid: UUID, zoneID: CKRecordZone.ID
+  ) {
+    self.init(
+      recordName: "\(recordType)|\(uuid.uuidString)",
+      zoneID: zoneID
+    )
+  }
+
+  /// Returns the UUID portion of a recordName regardless of format.
+  /// Accepts `"<TYPE>|<UUID>"` (new) and `"<UUID>"` (legacy).
+  /// Returns `nil` for non-UUID names (e.g. instrument IDs like `"AUD"`).
+  func uuidRecordName() -> UUID? {
+    if let sep = recordName.firstIndex(of: "|") {
+      let uuidPart = recordName[recordName.index(after: sep)...]
+      return UUID(uuidString: String(uuidPart))
+    }
+    return UUID(uuidString: recordName)
+  }
+
+  /// The key used for per-record system-fields caching during batch upsert.
+  /// - For UUID-keyed records: the bare UUID string (prefix stripped).
+  /// - For string-keyed records (instruments): the full recordName.
+  ///
+  /// This matches the keys used by `batchUpsertX` methods which look up
+  /// `systemFields[id.uuidString]` for UUID records and `systemFields[id]`
+  /// for instruments.
+  var systemFieldsKey: String {
+    if let sep = recordName.firstIndex(of: "|") {
+      return String(recordName[recordName.index(after: sep)...])
+    }
+    return recordName
+  }
+}
+```
+
+- [ ] **Step 1.4: Run tests to verify they pass**
+
+```bash
+just test-mac CKRecordIDRecordNameTests 2>&1 | tee .agent-tmp/t1-green.txt
+```
+
+Expected: all 8 tests pass.
+
+- [ ] **Step 1.5: Format and commit**
+
+```bash
+just format
+git -C /Users/aj/Documents/code/moolah-project/moolah-native/.claude/worktrees/fix-sync-silent-drop add Backends/CloudKit/Sync/CKRecordID+RecordName.swift MoolahTests/Sync/CKRecordIDRecordNameTests.swift
+git -C /Users/aj/Documents/code/moolah-project/moolah-native/.claude/worktrees/fix-sync-silent-drop commit -m "$(cat <<'EOF'
+feat(sync): add CKRecord.ID helpers for prefixed recordNames (#416)
+
+Adds init(recordType:uuid:zoneID:) for building the new
+"<recordType>|<UUID>" recordName format, plus uuidRecordName() and
+systemFieldsKey helpers that accept both the new format and legacy
+bare-UUID recordNames. The prefix lets two SwiftData record types
+with colliding UUIDs land on distinct CKRecord.IDs on the server;
+the dual-format parsers keep records already on the server working.
+
+Helpers are covered by CKRecordIDRecordNameTests (8 tests).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+rm .agent-tmp/t1-*.txt
+```
+
+---
+
+## Task 2: Update per-type `toCKRecord` / `fieldValues` to prefixed format
+
+**Files (× 10):**
+- Modify: `Backends/CloudKit/Sync/AccountRecord+CloudKit.swift`
+- Modify: `Backends/CloudKit/Sync/TransactionRecord+CloudKit.swift`
+- Modify: `Backends/CloudKit/Sync/TransactionLegRecord+CloudKit.swift`
+- Modify: `Backends/CloudKit/Sync/CategoryRecord+CloudKit.swift`
+- Modify: `Backends/CloudKit/Sync/EarmarkRecord+CloudKit.swift`
+- Modify: `Backends/CloudKit/Sync/EarmarkBudgetItemRecord+CloudKit.swift`
+- Modify: `Backends/CloudKit/Sync/InvestmentValueRecord+CloudKit.swift`
+- Modify: `Backends/CloudKit/Sync/CSVImportProfileRecord+CloudKit.swift`
+- Modify: `Backends/CloudKit/Sync/ImportRuleRecord+CloudKit.swift`
+- Modify: `Backends/CloudKit/Sync/ProfileRecord+CloudKit.swift`
+
+**Mechanical rule** — every UUID-keyed `+CloudKit.swift` file gets two edits:
+
+1. In `toCKRecord(in:)`: replace
+   ```swift
+   let recordID = CKRecord.ID(recordName: id.uuidString, zoneID: zoneID)
+   ```
+   with
+   ```swift
+   let recordID = CKRecord.ID(
+     recordType: Self.recordType, uuid: id, zoneID: zoneID)
+   ```
+
+2. In `fieldValues(from:)`: replace
+   ```swift
+   id: UUID(uuidString: ckRecord.recordID.recordName) ?? UUID(),
+   ```
+   with
+   ```swift
+   id: ckRecord.recordID.uuidRecordName() ?? UUID(),
+   ```
+
+`InstrumentRecord+CloudKit.swift` is NOT in the list — it uses a string ID
+and cannot collide.
+
+- [ ] **Step 2.1: Apply the two mechanical edits to `AccountRecord+CloudKit.swift`**
+
+- [ ] **Step 2.2: Apply the two mechanical edits to `TransactionRecord+CloudKit.swift`**
+
+- [ ] **Step 2.3: Apply the two mechanical edits to `TransactionLegRecord+CloudKit.swift`**
+
+- [ ] **Step 2.4: Apply the two mechanical edits to `CategoryRecord+CloudKit.swift`**
+
+- [ ] **Step 2.5: Apply the two mechanical edits to `EarmarkRecord+CloudKit.swift`**
+
+- [ ] **Step 2.6: Apply the two mechanical edits to `EarmarkBudgetItemRecord+CloudKit.swift`**
+
+- [ ] **Step 2.7: Apply the two mechanical edits to `InvestmentValueRecord+CloudKit.swift`**
+
+- [ ] **Step 2.8: Apply the two mechanical edits to `CSVImportProfileRecord+CloudKit.swift`**
+
+- [ ] **Step 2.9: Apply the two mechanical edits to `ImportRuleRecord+CloudKit.swift`**
+
+- [ ] **Step 2.10: Apply the two mechanical edits to `ProfileRecord+CloudKit.swift`**
+
+- [ ] **Step 2.11: Update existing tests that assert bare-UUID recordNames**
+
+Six assertions are now wrong because `toCKRecord` emits a prefixed name.
+Update them to expect the prefixed format.
+
+**`MoolahTests/Sync/RecordMappingTests.swift`:**
+
+Line 27 — change
+```swift
+#expect(ckRecord.recordID.recordName == profile.id.uuidString)
+```
+to
+```swift
+#expect(
+  ckRecord.recordID.recordName
+    == "\(ProfileRecord.recordType)|\(profile.id.uuidString)")
+```
+
+Line 58 — change
+```swift
+#expect(ckRecord.recordID.recordName == account.id.uuidString)
+```
+to
+```swift
+#expect(
+  ckRecord.recordID.recordName
+    == "\(AccountRecord.recordType)|\(account.id.uuidString)")
+```
+
+Line 105 — change
+```swift
+#expect(ckRecord.recordID.recordName == txn.id.uuidString)
+```
+to
+```swift
+#expect(
+  ckRecord.recordID.recordName
+    == "\(TransactionRecord.recordType)|\(txn.id.uuidString)")
+```
+
+Line 165 — change
+```swift
+#expect(ckRecord.recordID.recordName == leg.id.uuidString)
+```
+to
+```swift
+#expect(
+  ckRecord.recordID.recordName
+    == "\(TransactionLegRecord.recordType)|\(leg.id.uuidString)")
+```
+
+**`MoolahTests/Sync/ProfileIndexSyncHandlerTests.swift`:**
+
+Line 193 — change
+```swift
+#expect(ckRecord.recordID.recordName == profileId.uuidString)
+```
+to
+```swift
+#expect(
+  ckRecord.recordID.recordName
+    == "\(ProfileRecord.recordType)|\(profileId.uuidString)")
+```
+
+**`MoolahTests/Sync/ProfileIndexSyncHandlerTestsMore.swift`:**
+
+Line 45 — change
+```swift
+#expect(built.recordID.recordName == profileId.uuidString)
+```
+to
+```swift
+#expect(
+  built.recordID.recordName
+    == "\(ProfileRecord.recordType)|\(profileId.uuidString)")
+```
+
+**`MoolahTests/Sync/ProfileDataSyncHandlerTests.swift`:**
+
+Line 127 — change
+```swift
+#expect(ckRecord.recordID.recordName == account.id.uuidString)
+```
+to
+```swift
+#expect(
+  ckRecord.recordID.recordName
+    == "\(AccountRecord.recordType)|\(account.id.uuidString)")
+```
+
+Line 169 (inside `buildCKRecordDropsCachedFieldsOnZoneMismatch`) — change
+```swift
+#expect(built.recordID.recordName == accountId.uuidString)
+```
+to
+```swift
+#expect(
+  built.recordID.recordName
+    == "\(AccountRecord.recordType)|\(accountId.uuidString)")
+```
+
+**DO NOT change** `ProfileDataSyncHandlerTests.swift:201` inside
+`buildCKRecordPreservesCachedSystemFields` — that test specifically seeds
+a bare-UUID cached CKRecord and expects `buildCKRecord` to preserve it.
+That's the legacy-compat path we want to keep exercising.
+
+- [ ] **Step 2.12: Run affected tests**
+
+```bash
+just test-mac RecordMappingTests ProfileIndexSyncHandlerTests ProfileIndexSyncHandlerTestsMore ProfileDataSyncHandlerTests 2>&1 | tee .agent-tmp/t2-tests.txt
+```
+
+Expected: all pass.
+
+- [ ] **Step 2.13: Build the app**
+
+```bash
+just build-mac 2>&1 | tee .agent-tmp/t2-build.txt
+```
+
+Expected: build succeeds, no warnings.
+
+- [ ] **Step 2.14: Format and commit**
+
+```bash
+just format
+git -C /Users/aj/Documents/code/moolah-project/moolah-native/.claude/worktrees/fix-sync-silent-drop add -u
+git -C /Users/aj/Documents/code/moolah-project/moolah-native/.claude/worktrees/fix-sync-silent-drop commit -m "$(cat <<'EOF'
+feat(sync): emit prefixed recordNames from per-type toCKRecord (#416)
+
+Every UUID-keyed <Type>Record+CloudKit.swift now constructs
+CKRecord.IDs via CKRecord.ID(recordType:uuid:zoneID:), producing
+"<recordType>|<UUID>" recordNames for brand-new records. The
+matching fieldValues(from:) uses CKRecord.ID.uuidRecordName() so the
+downlink half of the mapping accepts both the new format and the
+legacy bare-UUID form.
+
+InstrumentRecord is unchanged (string-keyed, cannot collide).
+Existing tests that asserted bare-UUID recordNames updated to expect
+the prefixed format. buildCKRecordPreservesCachedSystemFields keeps
+its bare-UUID assertion — it exercises the legacy-compat path.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+rm .agent-tmp/t2-*.txt
+```
+
+---
+
+## Task 3: Change queue signatures and propagate recordType
+
+**Files:**
+- Modify: `Backends/CloudKit/Sync/SyncCoordinator+Lifecycle.swift`
+- Modify: `Backends/CloudKit/Sync/ProfileDataSyncHandler+QueueAndDelete.swift`
+- Modify: `App/ProfileSession+SyncWiring.swift`
+- Modify: `App/MoolahApp+Setup.swift`
+- Modify: `MoolahTests/Sync/SyncCoordinatorTestsExtra.swift` (2 assertions)
+
+- [ ] **Step 3.1: Change `queueSave`/`queueDeletion` signatures**
+
+In `Backends/CloudKit/Sync/SyncCoordinator+Lifecycle.swift`, replace the two
+UUID-keyed queue methods (around lines 145 and 155) with:
+
+```swift
+func queueSave(id: UUID, recordType: String, zoneID: CKRecordZone.ID) {
+  let recordID = CKRecord.ID(
+    recordType: recordType, uuid: id, zoneID: zoneID)
+  syncEngine?.state.add(pendingRecordZoneChanges: [.saveRecord(recordID)])
+}
+
+func queueSave(recordName: String, zoneID: CKRecordZone.ID) {
+  let recordID = CKRecord.ID(recordName: recordName, zoneID: zoneID)
+  syncEngine?.state.add(pendingRecordZoneChanges: [.saveRecord(recordID)])
+}
+
+func queueDeletion(id: UUID, recordType: String, zoneID: CKRecordZone.ID) {
+  let recordID = CKRecord.ID(
+    recordType: recordType, uuid: id, zoneID: zoneID)
+  syncEngine?.state.add(pendingRecordZoneChanges: [.deleteRecord(recordID)])
+}
+```
+
+- [ ] **Step 3.2: Update all callers in `App/ProfileSession+SyncWiring.swift`**
+
+Every `coordinator?.queueSave(id: id, zoneID: zoneID)` and
+`coordinator?.queueDeletion(id: id, zoneID: zoneID)` becomes:
+
+```swift
+coordinator?.queueSave(id: id, recordType: XxxRecord.recordType, zoneID: zoneID)
+coordinator?.queueDeletion(id: id, recordType: XxxRecord.recordType, zoneID: zoneID)
+```
+
+Mapping of closures to record types:
+
+| Closure on | Record type |
+|---|---|
+| `backend.accounts` — `onRecordChanged`/`onRecordDeleted` | `AccountRecord.recordType` |
+| `backend.transactions` — `onRecordChanged`/`onRecordDeleted` | `TransactionRecord.recordType` |
+| `backend.categories` — `onRecordChanged`/`onRecordDeleted` | `CategoryRecord.recordType` |
+| `backend.earmarks` — `onRecordChanged`/`onRecordDeleted` | `EarmarkRecord.recordType` |
+| `backend.investments` — `onRecordChanged`/`onRecordDeleted` | `InvestmentValueRecord.recordType` |
+| `backend.csvImportProfiles` — `onRecordChanged`/`onRecordDeleted` | `CSVImportProfileRecord.recordType` |
+| `backend.importRules` — `onRecordChanged`/`onRecordDeleted` | `ImportRuleRecord.recordType` |
+
+`onInstrumentChanged` keeps using the string `queueSave(recordName:zoneID:)`
+overload — no change.
+
+- [ ] **Step 3.3: Update `App/MoolahApp+Setup.swift`**
+
+In `configureSyncCoordinator`, the two profile-index hooks (lines ~113, 118)
+become:
+
+```swift
+store.onProfileChanged = { [weak coordinator] id in
+  let zoneID = CKRecordZone.ID(
+    zoneName: "profile-index", ownerName: CKCurrentUserDefaultName)
+  coordinator?.queueSave(
+    id: id, recordType: ProfileRecord.recordType, zoneID: zoneID)
+}
+store.onProfileDeleted = { [weak coordinator] id in
+  let zoneID = CKRecordZone.ID(
+    zoneName: "profile-index", ownerName: CKCurrentUserDefaultName)
+  coordinator?.queueDeletion(
+    id: id, recordType: ProfileRecord.recordType, zoneID: zoneID)
+}
+```
+
+- [ ] **Step 3.4: Update `collectUnsynced` / `collectAllUUIDs` to emit prefixed IDs**
+
+In `Backends/CloudKit/Sync/ProfileDataSyncHandler+QueueAndDelete.swift`, the
+private helpers construct `CKRecord.ID(recordName: extract(record), zoneID:)`
+today (lines 125 and 144). The `extract` closure returns `String` — for UUID
+types this is `$0.id.uuidString`, for instruments it's `$0.id`.
+
+Option taken: make the helpers type-aware by passing `T.recordType` at the
+call site and building the prefixed `CKRecord.ID` inside the helper.
+
+Replace `collectAllUUIDs` and `collectUnsynced` with versions that know `T`
+is UUID-keyed:
+
+```swift
+private func collectAllUUIDs<T: PersistentModel & CloudKitRecordConvertible>(
+  _ type: T.Type, into recordIDs: inout [CKRecord.ID], extract: (T) -> UUID
+) {
+  let context = ModelContext(modelContainer)
+  for record in Self.fetchOrLog(FetchDescriptor<T>(), context: context) {
+    recordIDs.append(
+      CKRecord.ID(
+        recordType: T.recordType, uuid: extract(record), zoneID: zoneID))
+  }
+}
+
+private func collectUnsynced<
+  T: PersistentModel & SystemFieldsCacheable & CloudKitRecordConvertible
+>(
+  _ type: T.Type, into recordIDs: inout [CKRecord.ID], extract: (T) -> UUID
+) {
+  let context = ModelContext(modelContainer)
+  for record in Self.fetchOrLog(FetchDescriptor<T>(), context: context)
+  where record.encodedSystemFields == nil {
+    recordIDs.append(
+      CKRecord.ID(
+        recordType: T.recordType, uuid: extract(record), zoneID: zoneID))
+  }
+}
+```
+
+And update the call sites in the same file (around lines 36–44 and 67–76) so
+the closures return `UUID` (not `String`):
+
+```swift
+// queueAllExistingRecords:
+collectAllStringIDs(InstrumentRecord.self, into: &recordIDs) { $0.id }
+collectAllUUIDs(CategoryRecord.self, into: &recordIDs) { $0.id }
+collectAllUUIDs(AccountRecord.self, into: &recordIDs) { $0.id }
+collectAllUUIDs(EarmarkRecord.self, into: &recordIDs) { $0.id }
+collectAllUUIDs(EarmarkBudgetItemRecord.self, into: &recordIDs) { $0.id }
+collectAllUUIDs(InvestmentValueRecord.self, into: &recordIDs) { $0.id }
+collectAllUUIDs(TransactionRecord.self, into: &recordIDs) { $0.id }
+collectAllUUIDs(TransactionLegRecord.self, into: &recordIDs) { $0.id }
+collectAllUUIDs(CSVImportProfileRecord.self, into: &recordIDs) { $0.id }
+collectAllUUIDs(ImportRuleRecord.self, into: &recordIDs) { $0.id }
+
+// queueUnsyncedRecords:
+collectUnsynced(InstrumentRecord.self, into: &recordIDs) { $0.id }
+collectUnsynced(CategoryRecord.self, into: &recordIDs) { $0.id }
+collectUnsynced(AccountRecord.self, into: &recordIDs) { $0.id }
+collectUnsynced(EarmarkRecord.self, into: &recordIDs) { $0.id }
+collectUnsynced(EarmarkBudgetItemRecord.self, into: &recordIDs) { $0.id }
+collectUnsynced(InvestmentValueRecord.self, into: &recordIDs) { $0.id }
+collectUnsynced(TransactionRecord.self, into: &recordIDs) { $0.id }
+collectUnsynced(TransactionLegRecord.self, into: &recordIDs) { $0.id }
+collectUnsynced(CSVImportProfileRecord.self, into: &recordIDs) { $0.id }
+collectUnsynced(ImportRuleRecord.self, into: &recordIDs) { $0.id }
+```
+
+`collectAllStringIDs` stays as-is (used only for InstrumentRecord). However
+`collectUnsynced` is also currently called for `InstrumentRecord` (line 67);
+that call returns `String` from the closure, which will fail to compile now
+that `collectUnsynced` takes `(T) -> UUID`. Extract a string-keyed overload:
+
+Add a parallel helper for InstrumentRecord in the same file:
+
+```swift
+private func collectUnsyncedInstruments(
+  into recordIDs: inout [CKRecord.ID]
+) {
+  let context = ModelContext(modelContainer)
+  for record in Self.fetchOrLog(FetchDescriptor<InstrumentRecord>(), context: context)
+  where record.encodedSystemFields == nil {
+    recordIDs.append(
+      CKRecord.ID(recordName: record.id, zoneID: zoneID))
+  }
+}
+```
+
+And in `queueUnsyncedRecords`, replace the first line of the collect block:
+
+```swift
+// Before:
+collectUnsynced(InstrumentRecord.self, into: &recordIDs) { $0.id }
+// After:
+collectUnsyncedInstruments(into: &recordIDs)
+```
+
+- [ ] **Step 3.5: Update assertions in `MoolahTests/Sync/SyncCoordinatorTestsExtra.swift`**
+
+Lines 177 and 180 inspect pending queue state:
+
+```swift
+// Before (lines 177 and 180):
+if recordID.recordName == unsyncedA.uuidString { ... }
+if recordID.recordName == unsyncedB.uuidString { ... }
+```
+
+Read the surrounding context in that test to determine the record type
+(likely `AccountRecord` based on the fixture — read and confirm). Replace
+with:
+
+```swift
+if recordID.recordName == "\(AccountRecord.recordType)|\(unsyncedA.uuidString)" { ... }
+if recordID.recordName == "\(AccountRecord.recordType)|\(unsyncedB.uuidString)" { ... }
+```
+
+If the fixture uses a different record type, use that type's `recordType`.
+
+- [ ] **Step 3.6: Build the app**
+
+```bash
+just build-mac 2>&1 | tee .agent-tmp/t3-build.txt
+```
+
+Expected: builds cleanly, no warnings.
+
+- [ ] **Step 3.7: Run all sync tests**
+
+```bash
+just test-mac SyncCoordinatorTests SyncCoordinatorTestsExtra SyncCoordinatorTestsMore ProfileDataSyncHandlerTests ProfileDataSyncHandlerLookupTests ProfileDataSyncHandlerQueueTests ProfileIndexSyncHandlerTests ProfileIndexSyncHandlerTestsMore RecordMappingTests RecordMappingTestsExtra RecordMappingTestsMore SyncErrorRecoveryTests 2>&1 | tee .agent-tmp/t3-tests.txt
+```
+
+Expected: all pass.
+
+- [ ] **Step 3.8: Format and commit**
+
+```bash
+just format
+git -C /Users/aj/Documents/code/moolah-project/moolah-native/.claude/worktrees/fix-sync-silent-drop add -u
+git -C /Users/aj/Documents/code/moolah-project/moolah-native/.claude/worktrees/fix-sync-silent-drop commit -m "$(cat <<'EOF'
+feat(sync): propagate recordType through queueSave/queueDeletion (#416)
+
+queueSave(id:recordType:zoneID:) and queueDeletion(id:recordType:zoneID:)
+now carry the record type so the pending CKRecord.ID can be built with
+the prefixed "<recordType>|<UUID>" format. Every call site — the
+CloudKit repositories via ProfileSession+SyncWiring, and the profile-
+index hooks in MoolahApp+Setup — passes its corresponding XxxRecord
+.recordType constant. The string-ID overload used for InstrumentRecord
+is unchanged.
+
+collectAllUUIDs/collectUnsynced now receive T.recordType (via
+CloudKitRecordConvertible) and emit prefixed CKRecord.IDs directly.
+InstrumentRecord gets its own collectUnsyncedInstruments helper since
+it's string-keyed.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+rm .agent-tmp/t3-*.txt
+```
+
+---
+
+## Task 4: Update downlink parsing sites
+
+**Files:**
+- Modify: `Backends/CloudKit/Sync/ProfileDataSyncHandler+BatchUpsert.swift`
+- Modify: `Backends/CloudKit/Sync/ProfileDataSyncHandler+ApplyRemoteChanges.swift`
+- Modify: `Backends/CloudKit/Sync/ProfileDataSyncHandler+SystemFields.swift`
+- Modify: `Backends/CloudKit/Sync/ProfileDataSyncHandler+RecordLookup.swift`
+- Modify: `Backends/CloudKit/Sync/SyncCoordinator+Delegate.swift`
+
+- [ ] **Step 4.1: Update `uuidPairs(from:)` in `ProfileDataSyncHandler+BatchUpsert.swift`**
+
+Around line 279, replace
+
+```swift
+nonisolated private static func uuidPairs(from ckRecords: [CKRecord]) -> [(UUID, CKRecord)] {
+  ckRecords.compactMap { record in
+    guard let uuid = UUID(uuidString: record.recordID.recordName) else { return nil }
+    return (uuid, record)
+  }
+}
+```
+
+with
+
+```swift
+nonisolated private static func uuidPairs(from ckRecords: [CKRecord]) -> [(UUID, CKRecord)] {
+  ckRecords.compactMap { record in
+    guard let uuid = record.recordID.uuidRecordName() else { return nil }
+    return (uuid, record)
+  }
+}
+```
+
+- [ ] **Step 4.2: Update `applyBatchDeletions` in `ProfileDataSyncHandler+ApplyRemoteChanges.swift`**
+
+Around line 93, replace
+
+```swift
+for (recordID, recordType) in deletions {
+  if let uuid = UUID(uuidString: recordID.recordName) {
+    uuidGrouped[recordType, default: []].append(uuid)
+  } else {
+    stringGrouped[recordType, default: []].append(recordID.recordName)
+  }
+}
+```
+
+with
+
+```swift
+for (recordID, recordType) in deletions {
+  if let uuid = recordID.uuidRecordName() {
+    uuidGrouped[recordType, default: []].append(uuid)
+  } else {
+    stringGrouped[recordType, default: []].append(recordID.recordName)
+  }
+}
+```
+
+- [ ] **Step 4.3: Normalize keys in `systemFieldsLookup`**
+
+Still in `ProfileDataSyncHandler+ApplyRemoteChanges.swift`, around line 138,
+replace
+
+```swift
+nonisolated private static func systemFieldsLookup(
+  saved: [CKRecord], preExtracted: [(String, Data)]
+) -> [String: Data] {
+  if !preExtracted.isEmpty {
+    return Dictionary(preExtracted, uniquingKeysWith: { _, last in last })
+  }
+  return Dictionary(
+    uniqueKeysWithValues: saved.map { ($0.recordID.recordName, $0.encodedSystemFields) }
+  )
+}
+```
+
+with
+
+```swift
+nonisolated private static func systemFieldsLookup(
+  saved: [CKRecord], preExtracted: [(String, Data)]
+) -> [String: Data] {
+  // Both sources key by recordName, but the batchUpsertX methods look up
+  // by uuid.uuidString (for UUID records) or record.id (for instruments) —
+  // never by the full prefixed recordName. Normalize by stripping the
+  // "<recordType>|" prefix when present so the downstream lookup works
+  // for both the new and legacy recordName formats.
+  func keyFor(_ recordName: String) -> String {
+    if let sep = recordName.firstIndex(of: "|") {
+      return String(recordName[recordName.index(after: sep)...])
+    }
+    return recordName
+  }
+  if !preExtracted.isEmpty {
+    return Dictionary(
+      preExtracted.map { (keyFor($0.0), $0.1) },
+      uniquingKeysWith: { _, last in last })
+  }
+  return Dictionary(
+    uniqueKeysWithValues: saved.map {
+      (keyFor($0.recordID.recordName), $0.encodedSystemFields)
+    }
+  )
+}
+```
+
+Note: the `keyFor` logic intentionally duplicates `CKRecord.ID.systemFieldsKey`
+because `preExtracted` entries are `(String, Data)` tuples, not `CKRecord.ID`s.
+Keep the inner function scoped to this method so the one-liner doesn't leak.
+
+- [ ] **Step 4.4: Update `applySystemFields` / `clearSystemFields` in `ProfileDataSyncHandler+SystemFields.swift`**
+
+Around line 126, replace
+
+```swift
+private func applySystemFields(from ckRecord: CKRecord, in context: ModelContext) {
+  let recordName = ckRecord.recordID.recordName
+  let data = ckRecord.encodedSystemFields
+  if let uuid = UUID(uuidString: recordName) {
+    let applied = Self.setEncodedSystemFields(
+      uuid, data: data, recordType: ckRecord.recordType, context: context)
+    if !applied {
+      logger.warning(
+        "No local row to cache system fields for \(ckRecord.recordType) \(recordName)"
+      )
+    }
+  } else {
+    Self.setInstrumentSystemFields(recordName, data: data, context: context)
+  }
+}
+```
+
+with
+
+```swift
+private func applySystemFields(from ckRecord: CKRecord, in context: ModelContext) {
+  let data = ckRecord.encodedSystemFields
+  // Dispatch by ckRecord.recordType — the authoritative type from the
+  // server — rather than by parsing recordName. This avoids the
+  // historical collision where two record types with colliding UUIDs
+  // both matched the same recordName (issue #416).
+  if ckRecord.recordType == InstrumentRecord.recordType {
+    Self.setInstrumentSystemFields(
+      ckRecord.recordID.recordName, data: data, context: context)
+    return
+  }
+  guard let uuid = ckRecord.recordID.uuidRecordName() else {
+    logger.warning(
+      "applySystemFields: recordName \(ckRecord.recordID.recordName) has no UUID component for \(ckRecord.recordType)"
+    )
+    return
+  }
+  let applied = Self.setEncodedSystemFields(
+    uuid, data: data, recordType: ckRecord.recordType, context: context)
+  if !applied {
+    logger.warning(
+      "No local row to cache system fields for \(ckRecord.recordType) \(uuid.uuidString)"
+    )
+  }
+}
+```
+
+Around line 142, replace
+
+```swift
+private func clearSystemFields(
+  for recordID: CKRecord.ID, recordType: String, in context: ModelContext
+) {
+  let recordName = recordID.recordName
+  if let uuid = UUID(uuidString: recordName) {
+    Self.setEncodedSystemFields(uuid, data: nil, recordType: recordType, context: context)
+  } else {
+    Self.setInstrumentSystemFields(recordName, data: nil, context: context)
+  }
+}
+```
+
+with
+
+```swift
+private func clearSystemFields(
+  for recordID: CKRecord.ID, recordType: String, in context: ModelContext
+) {
+  if recordType == InstrumentRecord.recordType {
+    Self.setInstrumentSystemFields(
+      recordID.recordName, data: nil, context: context)
+    return
+  }
+  guard let uuid = recordID.uuidRecordName() else {
+    logger.warning(
+      "clearSystemFields: recordName \(recordID.recordName) has no UUID component for \(recordType)"
+    )
+    return
+  }
+  Self.setEncodedSystemFields(
+    uuid, data: nil, recordType: recordType, context: context)
+}
+```
+
+- [ ] **Step 4.5: Update `recordToSave` in `ProfileDataSyncHandler+RecordLookup.swift`**
+
+Around line 48, replace
+
+```swift
+guard let uuid = UUID(uuidString: recordName) else {
+  logger.warning("Could not find local record for non-UUID ID: \(recordName)")
+  return nil
+}
+```
+
+with
+
+```swift
+guard let uuid = recordID.uuidRecordName() else {
+  logger.warning("Could not find local record for non-UUID ID: \(recordName)")
+  return nil
+}
+```
+
+This tolerates prefixed recordNames if `recordToSave` ever receives one
+(defensive — `appendProfileDataRecords` routes via `buildBatchRecordLookup`
+for UUID-keyed records today, but the fall-through should work regardless).
+
+- [ ] **Step 4.6: Update `appendProfileDataRecords` partition in `SyncCoordinator+Delegate.swift`**
+
+Around line 272, replace
+
+```swift
+for recordID in recordIDs {
+  if let uuid = UUID(uuidString: recordID.recordName) {
+    uuidRecordNames.append((recordID, uuid))
+  } else {
+    stringRecordIDs.append(recordID)
+  }
+}
+```
+
+with
+
+```swift
+for recordID in recordIDs {
+  if let uuid = recordID.uuidRecordName() {
+    uuidRecordNames.append((recordID, uuid))
+  } else {
+    stringRecordIDs.append(recordID)
+  }
+}
+```
+
+- [ ] **Step 4.7: Build**
+
+```bash
+just build-mac 2>&1 | tee .agent-tmp/t4-build.txt
+```
+
+Expected: builds cleanly.
+
+- [ ] **Step 4.8: Run all sync tests**
+
+```bash
+just test-mac SyncCoordinatorTests SyncCoordinatorTestsExtra SyncCoordinatorTestsMore ProfileDataSyncHandlerTests ProfileDataSyncHandlerLookupTests ProfileDataSyncHandlerQueueTests ProfileIndexSyncHandlerTests ProfileIndexSyncHandlerTestsMore RecordMappingTests RecordMappingTestsExtra RecordMappingTestsMore SyncErrorRecoveryTests 2>&1 | tee .agent-tmp/t4-tests.txt
+```
+
+Expected: all pass.
+
+- [ ] **Step 4.9: Format and commit**
+
+```bash
+just format
+git -C /Users/aj/Documents/code/moolah-project/moolah-native/.claude/worktrees/fix-sync-silent-drop add -u
+git -C /Users/aj/Documents/code/moolah-project/moolah-native/.claude/worktrees/fix-sync-silent-drop commit -m "$(cat <<'EOF'
+feat(sync): accept prefixed and legacy recordNames on downlink (#416)
+
+Five downlink sites that parsed recordID.recordName as a bare UUID
+now go through CKRecord.ID.uuidRecordName() which accepts both the
+new "<recordType>|<UUID>" format and the legacy bare-UUID form:
+
+- ProfileDataSyncHandler+BatchUpsert uuidPairs(from:)
+- ProfileDataSyncHandler+ApplyRemoteChanges applyBatchDeletions +
+  systemFieldsLookup (normalises the cache key too)
+- ProfileDataSyncHandler+SystemFields applySystemFields +
+  clearSystemFields (applySystemFields now dispatches by recordType,
+  the authoritative type from the server, rather than parsing the
+  name)
+- ProfileDataSyncHandler+RecordLookup recordToSave (defensive)
+- SyncCoordinator+Delegate appendProfileDataRecords partition
+
+Legacy records already on the server keep their bare-UUID names and
+continue to round-trip cleanly.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+rm .agent-tmp/t4-*.txt
+```
+
+---
+
+## Task 5: Regression tests
+
+**Files:**
+- Create: `MoolahTests/Sync/RecordNameCollisionTests.swift`
+
+- [ ] **Step 5.1: Write the new test file**
+
+Create `MoolahTests/Sync/RecordNameCollisionTests.swift`:
+
+```swift
+import CloudKit
+import Foundation
+import SwiftData
+import Testing
+
+@testable import Moolah
+
+@Suite("Record-name collision fix — issue #416")
+@MainActor
+struct RecordNameCollisionTests {
+
+  // MARK: - 1. UUID collision between types (regression test)
+
+  @Test("Account and Transaction sharing a UUID both upload as distinct CKRecords")
+  func collidingUUIDsYieldDistinctPrefixedRecordNames() throws {
+    let (handler, container) = try ProfileDataSyncHandlerTestSupport
+      .makeHandler()
+
+    let sharedId = UUID()
+    let context = ModelContext(container)
+    context.insert(
+      AccountRecord(
+        id: sharedId, name: "Shares", type: "bank", position: 0,
+        isHidden: false))
+    context.insert(
+      TransactionRecord(
+        id: sharedId, date: Date(), payee: "Opening balance"))
+    try context.save()
+
+    let lookup = handler.buildBatchRecordLookup(for: [sharedId])
+
+    // Both types must be represented — the pre-fix behaviour returned
+    // only the first-in-iteration-order match.
+    #expect(lookup.count == 2 || lookup.count == 1)
+    // Pre-fix: .count == 1, because a single UUID key dedupes in the
+    // [UUID: CKRecord] map.
+    // Post-fix: the batch lookup is still keyed by UUID so we still get
+    // one entry per UUID; the *distinction* is the prefix on the
+    // recordName. Assert the returned CKRecord.recordID encodes one of
+    // the two types via the prefix.
+    let record = try #require(lookup[sharedId])
+    let expectedPrefix = "\(record.recordType)|\(sharedId.uuidString)"
+    #expect(record.recordID.recordName == expectedPrefix)
+  }
+
+  @Test("collectUnsynced produces prefixed recordNames per type")
+  func collectUnsyncedProducesPrefixedRecordNamesPerType() throws {
+    let (handler, container) = try ProfileDataSyncHandlerTestSupport
+      .makeHandler()
+
+    let sharedId = UUID()
+    let context = ModelContext(container)
+    context.insert(
+      AccountRecord(
+        id: sharedId, name: "Shares", type: "bank", position: 0,
+        isHidden: false))
+    context.insert(
+      TransactionRecord(
+        id: sharedId, date: Date(), payee: "Opening balance"))
+    try context.save()
+
+    let recordIDs = handler.queueUnsyncedRecords()
+    let names = Set(recordIDs.map(\.recordName))
+    #expect(
+      names.contains("\(AccountRecord.recordType)|\(sharedId.uuidString)"))
+    #expect(
+      names.contains(
+        "\(TransactionRecord.recordType)|\(sharedId.uuidString)"))
+  }
+
+  // MARK: - 2. Uplink uses prefixed name for new records
+
+  @Test("buildCKRecord for a brand-new AccountRecord emits a prefixed recordName")
+  func buildCKRecordEmitsPrefixedRecordNameForNewRecords() throws {
+    let (handler, container) = try ProfileDataSyncHandlerTestSupport
+      .makeHandler()
+
+    let accountId = UUID()
+    let account = AccountRecord(
+      id: accountId, name: "New", type: "bank", position: 0,
+      isHidden: false)
+    let context = ModelContext(container)
+    context.insert(account)
+    try context.save()
+
+    let built = handler.buildCKRecord(for: account)
+    #expect(
+      built.recordID.recordName
+        == "\(AccountRecord.recordType)|\(accountId.uuidString)")
+  }
+
+  // MARK: - 3. Uplink preserves legacy bare-UUID name for already-synced records
+
+  @Test("buildCKRecord keeps legacy bare-UUID recordName when cached system fields exist")
+  func buildCKRecordReusesLegacyRecordNameFromCachedSystemFields() throws {
+    let (handler, container) = try ProfileDataSyncHandlerTestSupport
+      .makeHandler()
+
+    let accountId = UUID()
+    // Seed an encodedSystemFields blob whose recordID uses the legacy
+    // bare-UUID recordName. Simulates a row already synced under the
+    // old format.
+    let legacyRecord = CKRecord(
+      recordType: "CD_AccountRecord",
+      recordID: CKRecord.ID(
+        recordName: accountId.uuidString, zoneID: handler.zoneID))
+    let legacySystemFields = legacyRecord.encodedSystemFields
+
+    let context = ModelContext(container)
+    let account = AccountRecord(
+      id: accountId, name: "Legacy", type: "bank", position: 0,
+      isHidden: false)
+    account.encodedSystemFields = legacySystemFields
+    context.insert(account)
+    try context.save()
+
+    // Mutate and rebuild — should reuse the legacy recordID (no prefix).
+    account.name = "Updated"
+    let built = handler.buildCKRecord(for: account)
+    #expect(built.recordID.recordName == accountId.uuidString)
+    #expect(built["name"] as? String == "Updated")
+  }
+
+  // MARK: - 4. Downlink accepts both formats
+
+  @Test("applyRemoteChanges ingests both prefixed and bare-UUID CKRecords")
+  func applyRemoteChangesAcceptsBothRecordNameFormats() throws {
+    let (handler, container) = try ProfileDataSyncHandlerTestSupport
+      .makeHandler()
+
+    let legacyId = UUID()
+    let legacyCK = CKRecord(
+      recordType: "CD_AccountRecord",
+      recordID: CKRecord.ID(
+        recordName: legacyId.uuidString, zoneID: handler.zoneID))
+    legacyCK["name"] = "Legacy" as CKRecordValue
+    legacyCK["type"] = "bank" as CKRecordValue
+    legacyCK["position"] = 0 as CKRecordValue
+    legacyCK["isHidden"] = 0 as CKRecordValue
+
+    let newId = UUID()
+    let newCK = CKRecord(
+      recordType: "CD_AccountRecord",
+      recordID: CKRecord.ID(
+        recordType: "CD_AccountRecord",
+        uuid: newId,
+        zoneID: handler.zoneID))
+    newCK["name"] = "Prefixed" as CKRecordValue
+    newCK["type"] = "bank" as CKRecordValue
+    newCK["position"] = 1 as CKRecordValue
+    newCK["isHidden"] = 0 as CKRecordValue
+
+    _ = handler.applyRemoteChanges(saved: [legacyCK, newCK], deleted: [])
+
+    let context = ModelContext(container)
+    let all = try context.fetch(FetchDescriptor<AccountRecord>())
+    let byId = Dictionary(uniqueKeysWithValues: all.map { ($0.id, $0) })
+    #expect(byId[legacyId]?.name == "Legacy")
+    #expect(byId[newId]?.name == "Prefixed")
+    #expect(byId[legacyId]?.encodedSystemFields != nil)
+    #expect(byId[newId]?.encodedSystemFields != nil)
+  }
+
+  // MARK: - 5. System-fields round-trip for prefixed records
+
+  @Test("handleSentRecordZoneChanges writes system fields back using recordType")
+  func handleSentRecordZoneChangesAppliesSystemFieldsForPrefixedRecords() throws {
+    let (handler, container) = try ProfileDataSyncHandlerTestSupport
+      .makeHandler()
+
+    let accountId = UUID()
+    let context = ModelContext(container)
+    let account = AccountRecord(
+      id: accountId, name: "Test", type: "bank", position: 0,
+      isHidden: false)
+    context.insert(account)
+    try context.save()
+    #expect(account.encodedSystemFields == nil)
+
+    // Simulate a CK round-trip where the server returns a prefixed
+    // CKRecord as "saved".
+    let savedCK = CKRecord(
+      recordType: "CD_AccountRecord",
+      recordID: CKRecord.ID(
+        recordType: "CD_AccountRecord",
+        uuid: accountId,
+        zoneID: handler.zoneID))
+    savedCK["name"] = "Test" as CKRecordValue
+
+    _ = handler.handleSentRecordZoneChanges(
+      savedRecords: [savedCK], failedSaves: [], failedDeletes: [])
+
+    let fresh = ModelContext(container)
+    let reloaded = try fresh.fetch(
+      FetchDescriptor<AccountRecord>(
+        predicate: #Predicate { $0.id == accountId })
+    ).first
+    #expect(reloaded?.encodedSystemFields != nil)
+  }
+}
+```
+
+- [ ] **Step 5.2: Run the new tests**
+
+```bash
+just test-mac RecordNameCollisionTests 2>&1 | tee .agent-tmp/t5-tests.txt
+```
+
+Expected: all 6 tests pass.
+
+- [ ] **Step 5.3: Commit**
+
+```bash
+just format
+git -C /Users/aj/Documents/code/moolah-project/moolah-native/.claude/worktrees/fix-sync-silent-drop add MoolahTests/Sync/RecordNameCollisionTests.swift
+git -C /Users/aj/Documents/code/moolah-project/moolah-native/.claude/worktrees/fix-sync-silent-drop commit -m "$(cat <<'EOF'
+test(sync): regression tests for record-name collision fix (#416)
+
+Six tests covering the five scenarios from the design:
+
+- UUID collision between types: Account + Transaction sharing a UUID
+  round-trip through buildBatchRecordLookup and queueUnsyncedRecords
+  as distinct prefixed CKRecord.IDs.
+- Uplink new record: buildCKRecord emits "<recordType>|<UUID>".
+- Uplink legacy preservation: a record with cached bare-UUID
+  encodedSystemFields keeps its legacy recordID on re-upload.
+- Downlink dual format: applyRemoteChanges ingests both formats and
+  caches system fields for each.
+- System-fields round-trip: handleSentRecordZoneChanges writes back
+  to the correct local row when the saved CKRecord uses the prefixed
+  recordName (verifies applySystemFields dispatches by recordType,
+  not by parsing the name).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+rm .agent-tmp/t5-*.txt
+```
+
+---
+
+## Task 6: Final validation
+
+- [ ] **Step 6.1: Run the entire macOS test suite**
+
+```bash
+mkdir -p .agent-tmp
+just test-mac 2>&1 | tee .agent-tmp/t6-full-mac.txt
+grep -iE 'failed|error:' .agent-tmp/t6-full-mac.txt || echo "no failures"
+```
+
+Expected: no failures.
+
+- [ ] **Step 6.2: Run the iOS test suite**
+
+```bash
+just test-ios 2>&1 | tee .agent-tmp/t6-full-ios.txt
+grep -iE 'failed|error:' .agent-tmp/t6-full-ios.txt || echo "no failures"
+```
+
+Expected: no failures.
+
+- [ ] **Step 6.3: Format check**
+
+```bash
+just format-check
+```
+
+Expected: clean — no diffs, no new SwiftLint baseline entries.
+
+If this fails: fix the underlying code per `feedback_swiftlint_fix_not_baseline.md`. Do NOT modify `.swiftlint-baseline.yml`.
+
+- [ ] **Step 6.4: Build for macOS + iOS**
+
+```bash
+just build-mac 2>&1 | tee .agent-tmp/t6-build-mac.txt
+just build-ios 2>&1 | tee .agent-tmp/t6-build-ios.txt
+grep -iE 'warning:|error:' .agent-tmp/t6-build-mac.txt .agent-tmp/t6-build-ios.txt | grep -v '#Preview' || echo "clean"
+```
+
+Expected: clean (preview macro warnings can be ignored).
+
+- [ ] **Step 6.5: Run the `sync-review` agent on the branch changes**
+
+Invoke the `sync-review` agent with the list of changed files and the spec
+reference. Ask for findings at Critical / Blocking / Nice-to-have levels.
+Address any Critical or Blocking findings before proceeding.
+
+- [ ] **Step 6.6: Run the `code-review` agent**
+
+Invoke the `code-review` agent on the production Swift files. Address any
+Critical findings before proceeding.
+
+- [ ] **Step 6.7: Clean up temp files**
+
+```bash
+rm -f .agent-tmp/t6-*.txt
+```
+
+- [ ] **Step 6.8: Push the branch and open a PR**
+
+Push the worktree branch and open a PR whose base is
+`fix/sync-silent-drop-observability` (PR #417). When the queue-manager
+eventually lands #417 on main, this PR will rebase onto main automatically.
+
+```bash
+git -C /Users/aj/Documents/code/moolah-project/moolah-native/.claude/worktrees/fix-sync-silent-drop push -u origin HEAD
+gh pr create --base fix/sync-silent-drop-observability \
+  --title "fix(sync): encode record type in CKRecord.ID to stop cross-type collisions" \
+  --body "$(cat <<'EOF'
+## Summary
+
+Fixes [#416](https://github.com/ajsutton/moolah-native/issues/416). Encodes the SwiftData record type into every UUID-keyed `CKRecord.ID.recordName` as `"<recordType>|<UUID>"` so records of different types can never collide on the server, even when their UUIDs clash locally.
+
+Legacy records already on the server keep their bare-UUID recordNames — the new downlink path accepts both formats, and `buildCKRecord`'s cached-record reuse means re-uploads of legacy records stay on their existing names.
+
+No active migration of legacy records in this PR; tracked as [#420](https://github.com/ajsutton/moolah-native/issues/420) for a future release once v1 is widely adopted.
+
+## Design
+
+Full spec in `plans/2026-04-24-sync-record-name-collision-design.md` (committed in this PR). Implementation plan in `plans/2026-04-24-sync-record-name-collision-implementation.md`.
+
+## Test plan
+
+- [x] `just test-mac` — full macOS test suite passes.
+- [x] `just test-ios` — iOS test suite passes.
+- [x] `just format-check` — clean, no new SwiftLint baseline entries.
+- [x] `just build-mac` / `just build-ios` — warning-free.
+- [x] Six new regression tests in `RecordNameCollisionTests` cover the UUID-collision case, prefixed uplink, legacy-recordName preservation, dual-format downlink, and system-fields round-trip.
+
+## Related
+
+- Depends on [#417](https://github.com/ajsutton/moolah-native/pull/417) (observability / silent-drop logging). Will rebase to `main` once #417 lands.
+- Follow-up: [#420](https://github.com/ajsutton/moolah-native/issues/420) — active migration of legacy records on the server.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 6.9: Add the PR to the merge queue**
+
+```bash
+~/.claude/skills/merge-queue/scripts/merge-queue-ctl.sh add <PR-number>
+```
+
+(The PR number comes from the `gh pr create` output in the previous step.)
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** every section of the design doc is represented — central
+  helpers (Task 1), uplink CKRecord construction (Task 2), uplink queue
+  signatures (Task 3), downlink (Task 4), tests #1–#5 (Task 5), validation
+  (Task 6).
+- **Placeholder scan:** no TBDs, TODOs, or "see above" references.
+  Every code snippet is complete.
+- **Type consistency:** `queueSave`/`queueDeletion` signatures match across
+  SyncCoordinator and all callers. `systemFieldsKey` is used consistently.
+  `uuidRecordName()` returns `UUID?` everywhere it's used.
+- **One known caveat:** Step 5.1 / Test #1 asserts `lookup.count == 2 || 1`
+  because `buildBatchRecordLookup` returns `[UUID: CKRecord]`, which dedupes
+  by UUID. The real regression coverage is the second test
+  (`collectUnsyncedProducesPrefixedRecordNamesPerType`) which inspects the
+  emitted CKRecord.IDs directly. Left both in for clarity — one tests
+  lookup, the other tests queueing, both matter.


### PR DESCRIPTION
## Summary

Fixes [#416](https://github.com/ajsutton/moolah-native/issues/416). Encodes the SwiftData record type into every UUID-keyed `CKRecord.ID.recordName` as `"<recordType>|<UUID>"` so records of different types can never collide on the server, even when their UUIDs clash locally.

Legacy records already on the server keep their bare-UUID recordNames — the downlink path accepts both formats, and `buildCKRecord`'s cached-record reuse means re-uploads of legacy records stay on their existing names. Mixed-version devices therefore continue to work: old builds keep receiving legacy records; new builds generate prefixed records that old builds would silently drop, but that's a v1-only risk, strictly better than today where the colliding records are invisible on every device.

No active migration of legacy records in this PR; tracked as [#420](https://github.com/ajsutton/moolah-native/issues/420) for a future release once this change is widely adopted.

## Architecture

- **New helper file** `Backends/CloudKit/Sync/CKRecordIDRecordName.swift`: `CKRecord.ID(recordType:uuid:zoneID:)` constructor, `var uuid: UUID?` (parses both formats), `var systemFieldsKey: String`, and a namespaced `CKRecordIDRecordName.systemFieldsKey(for:)` static used by the downlink pipeline where keys are raw strings.
- **Uplink**: all 10 UUID-keyed `<Type>Record+CloudKit.swift` files build prefixed CKRecord.IDs; `queueSave`/`queueDeletion` now take `recordType:`; `collectAllUUIDs`/`collectUnsynced` emit prefixed IDs directly via `T.recordType`.
- **Downlink**: 5 parse sites in `ProfileDataSyncHandler+*.swift`, `SyncCoordinator+Delegate.swift`, and all 6 sites in `ProfileIndexSyncHandler` use `recordID.uuid` which accepts both formats. `applySystemFields` now dispatches by `ckRecord.recordType` (authoritative from server) rather than parsing the recordName — this is the line that directly addresses the silent-drop bug.
- **Nine regression tests** in `RecordNameCollisionTests` covering UUID collision, prefixed uplink, legacy preservation, downlink dual-format, system-fields round-trip, and ProfileIndexSyncHandler paths.

## Review highlights

- `sync-review` agent caught `ProfileIndexSyncHandler` was overlooked in the initial pass — without that fix, every profile edit would have turned into a server deletion. Fixed in `da35160` (rebased to `1c0182a` on this branch).
- `code-review` findings addressed per-task: `uuidRecordName()` method renamed to `var uuid` computed property per Swift API Design Guidelines; `queueSave` argument order changed to lead with `recordType`; `collectUnsynced` closure dropped in favour of `IdentifiableRecord` constraint; `keyFor` duplication eliminated by lifting to the namespaced static.

## Follow-ups

- [#420](https://github.com/ajsutton/moolah-native/issues/420) — active migration of legacy records on the server.
- [#427](https://github.com/ajsutton/moolah-native/issues/427) — `CloudKitRecordConvertible.fieldValues(from:)` should return `T?` so malformed recordIDs surface instead of producing phantom rows.

## Design

- Design spec: `plans/2026-04-24-sync-record-name-collision-design.md`
- Implementation plan: `plans/2026-04-24-sync-record-name-collision-implementation.md`

## Test plan

- [x] `just test-mac` — 1494 tests pass.
- [x] `just test-ios` — 1466 tests pass.
- [x] `just format-check` — clean, no SwiftLint baseline changes.
- [x] `just build-mac` / `just build-ios` — warning-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)