### PR TITLE
fix(profiles): isolate UI-testing state, focus Name, submit on Return

### DIFF
--- a/App/MoolahApp.swift
+++ b/App/MoolahApp.swift
@@ -47,7 +47,20 @@ struct MoolahApp: App {
     syncCoordinator = coordinator
     uiTestingProfileId = setup.uiTestingProfileId
 
+    // UI-testing mode must NOT read the user's real UserDefaults; remote
+    // profiles are persisted there by `ProfileStore.loadFromDefaults` and
+    // would bleed into the seeded container otherwise. A per-launch
+    // suite gives the store an isolated, ephemeral defaults store.
+    let storeDefaults: UserDefaults
+    if uiTestingSeed != nil {
+      let suiteName = "com.moolah.ui-testing.\(UUID().uuidString)"
+      storeDefaults = UserDefaults(suiteName: suiteName) ?? .standard
+      storeDefaults.removePersistentDomain(forName: suiteName)
+    } else {
+      storeDefaults = .standard
+    }
     let store = ProfileStore(
+      defaults: storeDefaults,
       validator: RemoteServerValidator(),
       containerManager: setup.manager,
       syncCoordinator: coordinator

--- a/Features/Profiles/Views/CreateProfileFormView.swift
+++ b/Features/Profiles/Views/CreateProfileFormView.swift
@@ -77,6 +77,7 @@ struct CreateProfileFormView: View {
         TextField(String(localized: "Name"), text: $name)
           .focused($focus, equals: .name)
           .submitLabel(.done)
+          .onSubmit(submit)
           .accessibilityIdentifier(UITestIdentifiers.Welcome.nameField)
         advancedDisclosure
       } header: {
@@ -86,6 +87,11 @@ struct CreateProfileFormView: View {
       }
     }
     .formStyle(.grouped)
+    // `defaultFocus` is the canonical SwiftUI API for initial focus.
+    // `.onAppear { focus = .name }` alone was insufficient on macOS —
+    // the DisclosureGroup was claiming first-responder before the
+    // TextField was ready to accept focus.
+    .defaultFocus($focus, .name)
   }
 
   private var advancedDisclosure: some View {
@@ -148,6 +154,12 @@ struct CreateProfileFormView: View {
   }
 
   private func submit() {
+    // Guard here so keyboard submit (Return in the Name field) respects
+    // the same preconditions as the toolbar button — which disables
+    // itself via the modifier rather than hand-rolling a `guard`.
+    guard !isSubmitting,
+      !name.trimmingCharacters(in: .whitespaces).isEmpty
+    else { return }
     isSubmitting = true
     Task {
       await createAction()

--- a/justfile
+++ b/justfile
@@ -85,16 +85,24 @@ build-mac: generate
     fi
     xcodebuild build "${args[@]}"
 
-# Build and launch the macOS app
-run-mac: generate
+# Build and launch the macOS app. Extra args are forwarded as launch
+# arguments to the app process (e.g. `just run-mac --ui-testing`).
+# Environment variables exported by the caller (e.g.
+# `UI_TESTING_SEED=welcomeEmpty just run-mac --ui-testing`) are
+# inherited by the launched process via `open`.
+run-mac *args: generate
     #!/usr/bin/env bash
     set -euo pipefail
-    args=(-scheme Moolah-macOS -destination 'platform=macOS' -derivedDataPath .build)
+    build=(-scheme Moolah-macOS -destination 'platform=macOS' -derivedDataPath .build)
     if [ -z "${DEVELOPMENT_TEAM:-}" ]; then
-        args+=(CODE_SIGN_IDENTITY="-" ENABLE_HARDENED_RUNTIME=NO)
+        build+=(CODE_SIGN_IDENTITY="-" ENABLE_HARDENED_RUNTIME=NO)
     fi
-    xcodebuild build "${args[@]}"
-    open .build/Build/Products/Debug/Moolah.app
+    xcodebuild build "${build[@]}"
+    if [ -n "{{args}}" ]; then
+        open .build/Build/Products/Debug/Moolah.app --args {{args}}
+    else
+        open .build/Build/Products/Debug/Moolah.app
+    fi
 
 # Build a Release macOS app and install to /Applications.
 # Forces ENABLE_ENTITLEMENTS=1 for the regenerate: Release bakes in
@@ -171,9 +179,12 @@ bump-version version:
     sed -i '' 's/MARKETING_VERSION: .*/MARKETING_VERSION: "{{version}}"/' project.yml
     just generate
 
-# Build, launch macOS app, and stream logs to .agent-tmp/app-logs.txt
-run-mac-with-logs predicate='subsystem == "com.moolah.app"': generate
-    bash scripts/run-with-logs.sh '{{predicate}}'
+# Build, launch macOS app, and stream logs to .agent-tmp/app-logs.txt.
+# Extra args after the predicate are forwarded as launch arguments to
+# the app process (e.g.
+# `just run-mac-with-logs 'subsystem == "com.moolah.app"' --ui-testing`).
+run-mac-with-logs predicate='subsystem == "com.moolah.app"' *args: generate
+    bash scripts/run-with-logs.sh '{{predicate}}' {{args}}
 
 # Open the project in Xcode
 open:

--- a/justfile
+++ b/justfile
@@ -87,9 +87,14 @@ build-mac: generate
 
 # Build and launch the macOS app. Extra args are forwarded as launch
 # arguments to the app process (e.g. `just run-mac --ui-testing`).
-# Environment variables exported by the caller (e.g.
-# `UI_TESTING_SEED=welcomeEmpty just run-mac --ui-testing`) are
-# inherited by the launched process via `open`.
+#
+# With args: launches the binary directly and backgrounds it so env
+# vars exported by the caller (e.g. `UI_TESTING_SEED=welcomeEmpty`)
+# reach the child process. Launch Services (`open --args`) does not
+# reliably forward the shell environment into the target app.
+#
+# Without args: uses `open` so the app activates through Launch
+# Services like a double-click (preserves Finder-style launch).
 run-mac *args: generate
     #!/usr/bin/env bash
     set -euo pipefail
@@ -99,7 +104,12 @@ run-mac *args: generate
     fi
     xcodebuild build "${build[@]}"
     if [ -n "{{args}}" ]; then
-        open .build/Build/Products/Debug/Moolah.app --args {{args}}
+        # Kill any running instance first; `open` would silently
+        # reuse it, skipping the new launch arguments entirely.
+        pkill -f "Moolah.app/Contents/MacOS/Moolah" 2>/dev/null || true
+        nohup .build/Build/Products/Debug/Moolah.app/Contents/MacOS/Moolah \
+            {{args}} >/dev/null 2>&1 &
+        disown
     else
         open .build/Build/Products/Debug/Moolah.app
     fi

--- a/scripts/run-with-logs.sh
+++ b/scripts/run-with-logs.sh
@@ -51,10 +51,15 @@ rm -f "$LOG_FILE"
 LOG_PID=$!
 sleep 1
 
-# Launch
+# Launch. When extra args are provided (typically `--ui-testing`),
+# launch the binary directly so environment variables exported by the
+# caller (e.g. `UI_TESTING_SEED=welcomeEmpty`) reach the child process.
+# Launch Services (`open --args`) does not reliably forward the shell
+# environment.
 echo "Launching app..."
 if [ $# -gt 0 ]; then
-    open "$APP_PATH" --args "$@"
+    nohup "$APP_PATH/Contents/MacOS/Moolah" "$@" >/dev/null 2>&1 &
+    disown
 else
     open "$APP_PATH"
 fi

--- a/scripts/run-with-logs.sh
+++ b/scripts/run-with-logs.sh
@@ -18,6 +18,10 @@
 set -euo pipefail
 
 PREDICATE="${1:-subsystem == \"com.moolah.app\"}"
+# Shift off the predicate so $@ holds any extra launch arguments for
+# the app binary (e.g. --ui-testing). `shift` fails on an empty list,
+# hence the `|| true` guard for the no-args case.
+shift || true
 LOG_DIR=".agent-tmp"
 LOG_FILE="$LOG_DIR/app-logs.txt"
 APP_PATH=".build/Build/Products/Debug/Moolah.app"
@@ -49,7 +53,11 @@ sleep 1
 
 # Launch
 echo "Launching app..."
-open "$APP_PATH"
+if [ $# -gt 0 ]; then
+    open "$APP_PATH" --args "$@"
+else
+    open "$APP_PATH"
+fi
 
 # Wait for app to appear (up to 10s)
 for i in $(seq 1 20); do


### PR DESCRIPTION
## Summary

Stacks on [#438](https://github.com/ajsutton/moolah-native/pull/438) (Justfile args). Three UX fixes that surface once `just run-mac --ui-testing` actually works end-to-end:

1. **UserDefaults isolation** — `MoolahApp.init` gives `ProfileStore` a per-launch `UserDefaults(suiteName:)` in UI-testing mode. Remote profiles are persisted via `loadFromDefaults`, so reading `.standard` under `--ui-testing` was bleeding real Moolah-server profiles into the seeded in-memory container.
2. **Direct-binary launch** — `run-mac` and `run-with-logs.sh` launch the binary directly (killing any running instance) when extra args are passed, rather than `open --args`. Launch Services does not reliably forward the shell environment into the target app, so `UI_TESTING_SEED=…` was being dropped. `open` is still used for the no-args path so production launches keep Finder-style activation.
3. **Name-field focus & Return-to-submit in `CreateProfileFormView`**:
   - `.defaultFocus($focus, .name)` so the Name field owns first responder on appear (the DisclosureGroup was claiming focus first on macOS).
   - `.onSubmit(submit)` so Return in the Name field creates the profile, with a guard in `submit()` so it respects the empty-name / in-flight preconditions the toolbar button enforces via `.disabled(…)`.

## Test plan

- [x] `just build-mac` — succeeded
- [x] `just format-check` — clean
- [x] Manual: `UI_TESTING_SEED=welcomeEmpty just run-mac --ui-testing` — hero shown, no real profiles visible; tapping Get started lands in a form with Name focused; Return submits.