### PR TITLE
chore(lint): silence SwiftLint config warnings

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -21,7 +21,7 @@ disabled_rules:
   - closure_spacing
   - colon
   - comma
-  - operator_whitespace
+  - function_name_whitespace
   - return_arrow_whitespace
   - statement_position
   - trailing_whitespace
@@ -89,10 +89,15 @@ opt_in_rules:
   - unavailable_function
   - unneeded_parentheses_in_closure_argument
   - untyped_error_in_catch
-  - unused_declaration
-  - unused_import
   - vertical_parameter_alignment_on_call
   - yoda_condition
+
+# `swiftlint analyze` rules (require a compiler output file, not run by
+# `swiftlint lint`). Kept here so that when `analyze` is run it picks up the
+# same opt-in set the team cares about.
+analyzer_rules:
+  - unused_declaration
+  - unused_import
 
 # SwiftLint (0.63) rejects per-rule `excluded:` on `file_length` and
 # `type_body_length` (surfaces as "invalid key(s) 'excluded'"), and silently


### PR DESCRIPTION
## Summary
- Rename `operator_whitespace` → `function_name_whitespace` in `disabled_rules` (SwiftLint 0.63 warns that the old name is scheduled for removal).
- Move `unused_declaration` and `unused_import` out of `opt_in_rules` into a new `analyzer_rules:` section — SwiftLint warns that these rules only run under `swiftlint analyze`, so listing them as opt-in lint rules was misleading and produced 6 warnings per `just format-check` run.

No behavioural change: `just format-check` only invokes `swiftlint lint`, which never ran those analyzer rules anyway, and the renamed rule remains disabled (it's swift-format's territory).

## Test plan
- [x] `just format-check` — no more `warning:` lines, still reports `All Swift files are correctly formatted.`
- [x] `just format` — runs cleanly with no SwiftLint config warnings
- [x] No diff to `.swiftlint-baseline.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)