### PR TITLE
fix(profiles): constrain WelcomeView window size + clean up focus

### DIFF
--- a/App/MoolahApp.swift
+++ b/App/MoolahApp.swift
@@ -47,7 +47,20 @@ struct MoolahApp: App {
     syncCoordinator = coordinator
     uiTestingProfileId = setup.uiTestingProfileId
 
+    // UI-testing mode must NOT read the user's real UserDefaults; remote
+    // profiles are persisted there by `ProfileStore.loadFromDefaults` and
+    // would bleed into the seeded container otherwise. A per-launch
+    // suite gives the store an isolated, ephemeral defaults store.
+    let storeDefaults: UserDefaults
+    if uiTestingSeed != nil {
+      let suiteName = "com.moolah.ui-testing.\(UUID().uuidString)"
+      storeDefaults = UserDefaults(suiteName: suiteName) ?? .standard
+      storeDefaults.removePersistentDomain(forName: suiteName)
+    } else {
+      storeDefaults = .standard
+    }
     let store = ProfileStore(
+      defaults: storeDefaults,
       validator: RemoteServerValidator(),
       containerManager: setup.manager,
       syncCoordinator: coordinator

--- a/App/ProfileRootView.swift
+++ b/App/ProfileRootView.swift
@@ -17,12 +17,21 @@
 
     var body: some View {
       Group {
-        if !profileStore.hasProfiles {
-          WelcomeView()
-        } else if let session = activeSession {
+        // Show WelcomeView for both first-run (no profiles) and the
+        // multi-profile picker state (2+ profiles but none active).
+        // `activeSession` is only set once the user has explicitly
+        // selected a profile, so the else branch naturally handles
+        // the picker case.
+        if let session = activeSession {
           SessionRootView(session: session)
-        } else {
+        } else if profileStore.hasProfiles
+          && profileStore.activeProfileID != nil
+        {
+          // Has an active profile ID but the session hasn't been
+          // created yet (cloud store warming up). Brief transient.
           ProgressView()
+        } else {
+          WelcomeView()
         }
       }
       .onChange(of: profileStore.activeProfileID) { _, newID in

--- a/App/ProfileWindowView.swift
+++ b/App/ProfileWindowView.swift
@@ -15,8 +15,11 @@
 
     @Environment(\.dismiss) private var dismiss
 
-    /// Resolve the profile to display: the window's profileID if it matches a known profile,
-    /// otherwise the active profile, otherwise the first profile.
+    /// Resolve the profile to display: the window's profileID if it matches a
+    /// known profile, otherwise the active profile. Falls back to the single
+    /// profile only when exactly one exists — with 2+ profiles and nothing
+    /// selected, `WelcomeView` shows its picker (state 5) instead of
+    /// silently opening one of them.
     private var resolvedProfile: Profile? {
       if let profileID,
         let profile = profileStore.profiles.first(where: { $0.id == profileID })
@@ -28,7 +31,7 @@
       {
         return profile
       }
-      return profileStore.profiles.first
+      return profileStore.profiles.count == 1 ? profileStore.profiles.first : nil
     }
 
     var body: some View {
@@ -40,24 +43,28 @@
             .onChange(of: profile.resolvedServerURL) { _, _ in
               sessionManager.rebuildSession(for: profile)
             }
-        } else if !profileStore.hasProfiles {
-          // `WelcomeView`'s `.heroChecking` state covers the
-          // `isCloudLoadPending` case too — the old bare `ProgressView`
-          // branch is subsumed by the new state machine.
-          WelcomeView()
-            .onChange(of: profileStore.profiles) { _, newProfiles in
-              if let first = newProfiles.first {
-                openWindow(value: first.id)
-              }
-            }
-        } else {
-          // Profile is genuinely gone — close this window
+        } else if profileID != nil {
+          // This window was opened for a specific profile that no longer
+          // exists. Close it — the user will land on whichever window
+          // SwiftUI brings forward next.
           Color.clear
             .onAppear {
               logger.warning(
                 "Dismissing window — profile not found. profileID=\(profileID?.uuidString ?? "nil", privacy: .public), profileCount=\(profileStore.profiles.count), profileIDs=\(profileStore.profiles.map(\.id).map(\.uuidString).joined(separator: ","), privacy: .public)"
               )
               dismiss()
+            }
+        } else {
+          // No specific profile requested AND no active profile. Covers
+          // both the empty first-run case (`!hasProfiles` → hero state 1)
+          // and the multi-profile-no-selection case (2+ profiles, none
+          // picked → picker state 5). `WelcomeView`'s state machine
+          // picks the right branch.
+          WelcomeView()
+            .onChange(of: profileStore.profiles) { _, newProfiles in
+              if newProfiles.count == 1, let first = newProfiles.first {
+                openWindow(value: first.id)
+              }
             }
         }
       }

--- a/Features/Profiles/ProfileStore+Cloud.swift
+++ b/Features/Profiles/ProfileStore+Cloud.swift
@@ -29,15 +29,26 @@ extension ProfileStore {
         cancelPendingRetry()
       }
 
-      // Auto-select a profile when none is active (e.g. new device receiving
-      // its first cloud profile from another device). Suppressed when
-      // `WelcomeView` is mid-create — see design spec §3.3 race condition.
-      if activeProfileID == nil, let first = profiles.first, welcomePhase != .creating {
+      // Auto-select a profile when none is active AND there is exactly one
+      // profile in total (e.g. new device receiving its first cloud profile
+      // from another device). Suppressed when `WelcomeView` is mid-create —
+      // see design spec §3.3 race condition. With two or more profiles, the
+      // `WelcomeView` picker (state 5) lets the user choose explicitly.
+      if activeProfileID == nil,
+        profiles.count == 1,
+        let first = profiles.first,
+        welcomePhase != .creating
+      {
         self.activeProfileID = first.id
         saveActiveProfileID()
         logger.debug("Auto-selected profile: \(first.id)")
       } else if welcomePhase == .creating {
         logger.debug("Skipped auto-select — welcomePhase == .creating")
+      } else if activeProfileID == nil, profiles.count > 1 {
+        let profileCount = profiles.count
+        logger.debug(
+          "Skipped auto-select — \(profileCount) profiles present, picker will choose"
+        )
       }
 
       // Handle profiles deleted on another device.

--- a/Features/Profiles/Views/CreateProfileFormView.swift
+++ b/Features/Profiles/Views/CreateProfileFormView.swift
@@ -51,7 +51,9 @@ struct CreateProfileFormView: View {
         confirmationButton
       }
     }
-    .onAppear { focus = .name }
+    // Initial focus is declared via `.defaultFocus($focus, .name)` on
+    // the inner `Form` (see `form` below). Re-setting `focus` here in
+    // `onAppear` would race the declarative resolver.
   }
 
   @ViewBuilder private var bannerContent: some View {
@@ -74,6 +76,9 @@ struct CreateProfileFormView: View {
   private var form: some View {
     Form {
       Section {
+        // `.onSubmit` is attached to the TextField directly (not the
+        // parent `Form`) so Return inside the DisclosureGroup's
+        // CurrencyPicker / FY-month Picker doesn't also fire `submit`.
         TextField(String(localized: "Name"), text: $name)
           .focused($focus, equals: .name)
           .submitLabel(.done)

--- a/Features/Profiles/Views/CreateProfileFormView.swift
+++ b/Features/Profiles/Views/CreateProfileFormView.swift
@@ -77,6 +77,7 @@ struct CreateProfileFormView: View {
         TextField(String(localized: "Name"), text: $name)
           .focused($focus, equals: .name)
           .submitLabel(.done)
+          .onSubmit(submit)
           .accessibilityIdentifier(UITestIdentifiers.Welcome.nameField)
         advancedDisclosure
       } header: {
@@ -86,6 +87,11 @@ struct CreateProfileFormView: View {
       }
     }
     .formStyle(.grouped)
+    // `defaultFocus` is the canonical SwiftUI API for initial focus.
+    // `.onAppear { focus = .name }` alone was insufficient on macOS —
+    // the DisclosureGroup was claiming first-responder before the
+    // TextField was ready to accept focus.
+    .defaultFocus($focus, .name)
   }
 
   private var advancedDisclosure: some View {
@@ -148,6 +154,12 @@ struct CreateProfileFormView: View {
   }
 
   private func submit() {
+    // Guard here so keyboard submit (Return in the Name field) respects
+    // the same preconditions as the toolbar button — which disables
+    // itself via the modifier rather than hand-rolling a `guard`.
+    guard !isSubmitting,
+      !name.trimmingCharacters(in: .whitespaces).isEmpty
+    else { return }
     isSubmitting = true
     Task {
       await createAction()

--- a/Features/Profiles/Views/WelcomeView.swift
+++ b/Features/Profiles/Views/WelcomeView.swift
@@ -39,6 +39,29 @@ struct WelcomeView: View {
     )
 
     content(for: state)
+      // macOS only: constrain the window to a compact range so the
+      // hero / form / picker have a sensible layout envelope. Without
+      // this, SwiftUI sizes the window from content ideal — unbounded
+      // `Spacer()`s in the hero let it grow to full-screen, and at
+      // small heights the CTA scrolls off the bottom.
+      //
+      // Minimum keeps the Get started button visible; ideal opens
+      // at a friendly splash size on first appearance. `maxHeight:
+      // .infinity` still lets the picker grow for long profile
+      // lists or accessibility-sized text.
+      //
+      // iOS uses device-level sizing and keyboard avoidance; a
+      // hard `minWidth: 420` would overflow iPhone widths.
+      #if os(macOS)
+        .frame(
+          minWidth: 420,
+          idealWidth: 500,
+          maxWidth: .infinity,
+          minHeight: 560,
+          idealHeight: 720,
+          maxHeight: .infinity
+        )
+      #endif
       .onAppear { profileStore.welcomePhase = phase }
       .onDisappear { profileStore.welcomePhase = nil }
       .onChange(of: phase) { _, newValue in

--- a/justfile
+++ b/justfile
@@ -85,16 +85,24 @@ build-mac: generate
     fi
     xcodebuild build "${args[@]}"
 
-# Build and launch the macOS app
-run-mac: generate
+# Build and launch the macOS app. Extra args are forwarded as launch
+# arguments to the app process (e.g. `just run-mac --ui-testing`).
+# Environment variables exported by the caller (e.g.
+# `UI_TESTING_SEED=welcomeEmpty just run-mac --ui-testing`) are
+# inherited by the launched process via `open`.
+run-mac *args: generate
     #!/usr/bin/env bash
     set -euo pipefail
-    args=(-scheme Moolah-macOS -destination 'platform=macOS' -derivedDataPath .build)
+    build=(-scheme Moolah-macOS -destination 'platform=macOS' -derivedDataPath .build)
     if [ -z "${DEVELOPMENT_TEAM:-}" ]; then
-        args+=(CODE_SIGN_IDENTITY="-" ENABLE_HARDENED_RUNTIME=NO)
+        build+=(CODE_SIGN_IDENTITY="-" ENABLE_HARDENED_RUNTIME=NO)
     fi
-    xcodebuild build "${args[@]}"
-    open .build/Build/Products/Debug/Moolah.app
+    xcodebuild build "${build[@]}"
+    if [ -n "{{args}}" ]; then
+        open .build/Build/Products/Debug/Moolah.app --args {{args}}
+    else
+        open .build/Build/Products/Debug/Moolah.app
+    fi
 
 # Build a Release macOS app and install to /Applications.
 # Forces ENABLE_ENTITLEMENTS=1 for the regenerate: Release bakes in
@@ -171,9 +179,12 @@ bump-version version:
     sed -i '' 's/MARKETING_VERSION: .*/MARKETING_VERSION: "{{version}}"/' project.yml
     just generate
 
-# Build, launch macOS app, and stream logs to .agent-tmp/app-logs.txt
-run-mac-with-logs predicate='subsystem == "com.moolah.app"': generate
-    bash scripts/run-with-logs.sh '{{predicate}}'
+# Build, launch macOS app, and stream logs to .agent-tmp/app-logs.txt.
+# Extra args after the predicate are forwarded as launch arguments to
+# the app process (e.g.
+# `just run-mac-with-logs 'subsystem == "com.moolah.app"' --ui-testing`).
+run-mac-with-logs predicate='subsystem == "com.moolah.app"' *args: generate
+    bash scripts/run-with-logs.sh '{{predicate}}' {{args}}
 
 # Open the project in Xcode
 open:

--- a/justfile
+++ b/justfile
@@ -87,9 +87,14 @@ build-mac: generate
 
 # Build and launch the macOS app. Extra args are forwarded as launch
 # arguments to the app process (e.g. `just run-mac --ui-testing`).
-# Environment variables exported by the caller (e.g.
-# `UI_TESTING_SEED=welcomeEmpty just run-mac --ui-testing`) are
-# inherited by the launched process via `open`.
+#
+# With args: launches the binary directly and backgrounds it so env
+# vars exported by the caller (e.g. `UI_TESTING_SEED=welcomeEmpty`)
+# reach the child process. Launch Services (`open --args`) does not
+# reliably forward the shell environment into the target app.
+#
+# Without args: uses `open` so the app activates through Launch
+# Services like a double-click (preserves Finder-style launch).
 run-mac *args: generate
     #!/usr/bin/env bash
     set -euo pipefail
@@ -99,7 +104,12 @@ run-mac *args: generate
     fi
     xcodebuild build "${build[@]}"
     if [ -n "{{args}}" ]; then
-        open .build/Build/Products/Debug/Moolah.app --args {{args}}
+        # Kill any running instance first; `open` would silently
+        # reuse it, skipping the new launch arguments entirely.
+        pkill -f "Moolah.app/Contents/MacOS/Moolah" 2>/dev/null || true
+        nohup .build/Build/Products/Debug/Moolah.app/Contents/MacOS/Moolah \
+            {{args}} >/dev/null 2>&1 &
+        disown
     else
         open .build/Build/Products/Debug/Moolah.app
     fi

--- a/scripts/run-with-logs.sh
+++ b/scripts/run-with-logs.sh
@@ -51,10 +51,15 @@ rm -f "$LOG_FILE"
 LOG_PID=$!
 sleep 1
 
-# Launch
+# Launch. When extra args are provided (typically `--ui-testing`),
+# launch the binary directly so environment variables exported by the
+# caller (e.g. `UI_TESTING_SEED=welcomeEmpty`) reach the child process.
+# Launch Services (`open --args`) does not reliably forward the shell
+# environment.
 echo "Launching app..."
 if [ $# -gt 0 ]; then
-    open "$APP_PATH" --args "$@"
+    nohup "$APP_PATH/Contents/MacOS/Moolah" "$@" >/dev/null 2>&1 &
+    disown
 else
     open "$APP_PATH"
 fi

--- a/scripts/run-with-logs.sh
+++ b/scripts/run-with-logs.sh
@@ -18,6 +18,10 @@
 set -euo pipefail
 
 PREDICATE="${1:-subsystem == \"com.moolah.app\"}"
+# Shift off the predicate so $@ holds any extra launch arguments for
+# the app binary (e.g. --ui-testing). `shift` fails on an empty list,
+# hence the `|| true` guard for the no-args case.
+shift || true
 LOG_DIR=".agent-tmp"
 LOG_FILE="$LOG_DIR/app-logs.txt"
 APP_PATH=".build/Build/Products/Debug/Moolah.app"
@@ -49,7 +53,11 @@ sleep 1
 
 # Launch
 echo "Launching app..."
-open "$APP_PATH"
+if [ $# -gt 0 ]; then
+    open "$APP_PATH" --args "$@"
+else
+    open "$APP_PATH"
+fi
 
 # Wait for app to appear (up to 10s)
 for i in $(seq 1 20); do


### PR DESCRIPTION
## Summary

Stacks on [#440](https://github.com/ajsutton/moolah-native/pull/440). Three connected polish fixes on `WelcomeView`.

### 1. macOS window sizing

Applies a frame constraint on macOS only (guarded with `#if os(macOS)` per `@ui-review` — iPhones would overflow a `minWidth: 420`):

```swift
.frame(
  minWidth: 420, idealWidth: 500, maxWidth: .infinity,
  minHeight: 560, idealHeight: 720, maxHeight: .infinity
)
```

Without this the hero's unbounded `Spacer()` blocks let the window expand to full-screen; resizing below the hero's natural height pushed the Get started button off the bottom.

### 2. `CreateProfileFormView` focus cleanup

- Removed the dead `.onAppear { focus = .name }` — `.defaultFocus($focus, .name)` on the inner `Form` (from #440) is the declarative winner; the imperative assignment raced it.
- Added a code comment explaining why `.onSubmit(submit)` is on the `TextField` directly (prevents Return inside the DisclosureGroup's pickers from firing submit).

### 3. Multi-profile picker routing

Three fixes so the picker state (design spec §3.1 / §5) actually renders when two or more profiles exist without a user selection:

- `ProfileStore.loadCloudProfiles` now requires `profiles.count == 1` to auto-select. The pre-fix guard picked the first of N profiles the instant sync returned them, bypassing the picker entirely.
- `ProfileWindowView.resolvedProfile` no longer falls back to `profiles.first` when there are multiple profiles and nothing selected — returns `nil` so the view routes to the WelcomeView picker branch.
- `ProfileWindowView` + `ProfileRootView` routing: show `WelcomeView` whenever no resolvable session exists (empty OR multi-no-active), `SessionRootView` only when a profile is actually selected.

Manual verification: `UI_TESTING_SEED=welcomeMultipleCloudProfiles just run-mac --ui-testing` lands on the picker with Household + Side business rows and the "+ Create a new profile" footer.

## Test plan

- [x] `just build-mac` — succeeded
- [x] `just format-check` — clean
- [x] Manual: welcomeEmpty, welcomeMultipleCloudProfiles seeds both land in the expected states.