### PR TITLE
chore(lint): drop unused analyzer_rules section

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -92,13 +92,6 @@ opt_in_rules:
   - vertical_parameter_alignment_on_call
   - yoda_condition
 
-# `swiftlint analyze` rules (require a compiler output file, not run by
-# `swiftlint lint`). Kept here so that when `analyze` is run it picks up the
-# same opt-in set the team cares about.
-analyzer_rules:
-  - unused_declaration
-  - unused_import
-
 # SwiftLint (0.63) rejects per-rule `excluded:` on `file_length` and
 # `type_body_length` (surfaces as "invalid key(s) 'excluded'"), and silently
 # ignores it on `function_body_length`. Path-scoping would require moving


### PR DESCRIPTION
## Summary
Follow-up to #441. `swiftlint analyze` isn't wired into CI or any `just` target, and there's no plan to enable it — analyze needs a full `xcodebuild` log per platform, the log parser is fragile across Xcode versions, and `unused_declaration` has notable false-positive rates on `@Observable` / SwiftUI / protocol-conformance-heavy code. The `analyzer_rules:` section was parking `unused_declaration` and `unused_import` as dead config; drop it.

If we ever wire up `swiftlint analyze`, re-add the section alongside the CI plumbing that feeds it a build log.

## Test plan
- [x] `just format-check` — still reports `All Swift files are correctly formatted.`, no new SwiftLint config warnings
- [x] No diff to `.swiftlint-baseline.yml`

Based on #441 — retarget to `main` after that lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)