### PR TITLE
fix(sync): propagate malformed recordID as error, not phantom row

### DIFF
--- a/Backends/CloudKit/Sync/AccountRecord+CloudKit.swift
+++ b/Backends/CloudKit/Sync/AccountRecord+CloudKit.swift
@@ -18,9 +18,10 @@ extension AccountRecord: CloudKitRecordConvertible {
     return record
   }
 
-  static func fieldValues(from ckRecord: CKRecord) -> AccountRecord {
-    AccountRecord(
-      id: ckRecord.recordID.uuid ?? UUID(),
+  static func fieldValues(from ckRecord: CKRecord) -> AccountRecord? {
+    guard let id = ckRecord.recordID.uuid else { return nil }
+    return AccountRecord(
+      id: id,
       name: ckRecord["name"] as? String ?? "",
       type: ckRecord["type"] as? String ?? "bank",
       instrumentId: ckRecord["instrumentId"] as? String ?? "AUD",

--- a/Backends/CloudKit/Sync/CSVImportProfileRecord+CloudKit.swift
+++ b/Backends/CloudKit/Sync/CSVImportProfileRecord+CloudKit.swift
@@ -24,9 +24,10 @@ extension CSVImportProfileRecord: CloudKitRecordConvertible {
     return record
   }
 
-  static func fieldValues(from ckRecord: CKRecord) -> CSVImportProfileRecord {
+  static func fieldValues(from ckRecord: CKRecord) -> CSVImportProfileRecord? {
+    guard let id = ckRecord.recordID.uuid else { return nil }
     let record = CSVImportProfileRecord(
-      id: ckRecord.recordID.uuid ?? UUID(),
+      id: id,
       accountId: (ckRecord["accountId"] as? String).flatMap { UUID(uuidString: $0) } ?? UUID(),
       parserIdentifier: ckRecord["parserIdentifier"] as? String ?? "",
       headerSignature: [],

--- a/Backends/CloudKit/Sync/CategoryRecord+CloudKit.swift
+++ b/Backends/CloudKit/Sync/CategoryRecord+CloudKit.swift
@@ -15,9 +15,10 @@ extension CategoryRecord: CloudKitRecordConvertible {
     return record
   }
 
-  static func fieldValues(from ckRecord: CKRecord) -> CategoryRecord {
-    CategoryRecord(
-      id: ckRecord.recordID.uuid ?? UUID(),
+  static func fieldValues(from ckRecord: CKRecord) -> CategoryRecord? {
+    guard let id = ckRecord.recordID.uuid else { return nil }
+    return CategoryRecord(
+      id: id,
       name: ckRecord["name"] as? String ?? "",
       parentId: (ckRecord["parentId"] as? String).flatMap { UUID(uuidString: $0) }
     )

--- a/Backends/CloudKit/Sync/CloudKitRecordConvertible.swift
+++ b/Backends/CloudKit/Sync/CloudKitRecordConvertible.swift
@@ -8,9 +8,17 @@ protocol CloudKitRecordConvertible {
   /// Converts this record to a CKRecord in the given zone.
   func toCKRecord(in zoneID: CKRecordZone.ID) -> CKRecord
 
-  /// Extracts field values from a CKRecord. Returns a new instance with the extracted values.
+  /// Extracts field values from a CKRecord. Returns a new instance with the extracted values,
+  /// or `nil` if the `CKRecord` does not carry a valid identifier for this record type.
+  /// For UUID-keyed conformers (everything except `InstrumentRecord`) this means
+  /// `recordID.uuid == nil`. `InstrumentRecord` is keyed by `recordID.recordName`, which
+  /// is always present on a valid `CKRecord.ID`, so it never returns `nil`.
+  ///
+  /// Callers are expected to log and skip when this returns `nil` so a malformed incoming
+  /// record surfaces as an error rather than a phantom row with a fresh random id.
+  ///
   /// Note: This does not create a managed @Model instance — it returns field values only.
-  static func fieldValues(from ckRecord: CKRecord) -> Self
+  static func fieldValues(from ckRecord: CKRecord) -> Self?
 }
 
 /// Protocol for records that have a UUID `id` property.

--- a/Backends/CloudKit/Sync/EarmarkBudgetItemRecord+CloudKit.swift
+++ b/Backends/CloudKit/Sync/EarmarkBudgetItemRecord+CloudKit.swift
@@ -17,9 +17,10 @@ extension EarmarkBudgetItemRecord: CloudKitRecordConvertible {
     return record
   }
 
-  static func fieldValues(from ckRecord: CKRecord) -> EarmarkBudgetItemRecord {
-    EarmarkBudgetItemRecord(
-      id: ckRecord.recordID.uuid ?? UUID(),
+  static func fieldValues(from ckRecord: CKRecord) -> EarmarkBudgetItemRecord? {
+    guard let id = ckRecord.recordID.uuid else { return nil }
+    return EarmarkBudgetItemRecord(
+      id: id,
       earmarkId: (ckRecord["earmarkId"] as? String).flatMap { UUID(uuidString: $0) } ?? UUID(),
       categoryId: (ckRecord["categoryId"] as? String).flatMap { UUID(uuidString: $0) } ?? UUID(),
       amount: ckRecord["amount"] as? Int64 ?? 0,

--- a/Backends/CloudKit/Sync/EarmarkRecord+CloudKit.swift
+++ b/Backends/CloudKit/Sync/EarmarkRecord+CloudKit.swift
@@ -23,9 +23,10 @@ extension EarmarkRecord: CloudKitRecordConvertible {
     return record
   }
 
-  static func fieldValues(from ckRecord: CKRecord) -> EarmarkRecord {
-    EarmarkRecord(
-      id: ckRecord.recordID.uuid ?? UUID(),
+  static func fieldValues(from ckRecord: CKRecord) -> EarmarkRecord? {
+    guard let id = ckRecord.recordID.uuid else { return nil }
+    return EarmarkRecord(
+      id: id,
       name: ckRecord["name"] as? String ?? "",
       position: ckRecord["position"] as? Int ?? 0,
       isHidden: (ckRecord["isHidden"] as? Int ?? 0) != 0,

--- a/Backends/CloudKit/Sync/ImportRuleRecord+CloudKit.swift
+++ b/Backends/CloudKit/Sync/ImportRuleRecord+CloudKit.swift
@@ -20,8 +20,8 @@ extension ImportRuleRecord: CloudKitRecordConvertible {
     return record
   }
 
-  static func fieldValues(from ckRecord: CKRecord) -> ImportRuleRecord {
-    let id = ckRecord.recordID.uuid ?? UUID()
+  static func fieldValues(from ckRecord: CKRecord) -> ImportRuleRecord? {
+    guard let id = ckRecord.recordID.uuid else { return nil }
     // The convenience initializer re-encodes the conditions/actions arrays,
     // so to avoid a decode-then-re-encode round trip we go through the
     // synthesised property setters on a fresh record.

--- a/Backends/CloudKit/Sync/InstrumentRecord+CloudKit.swift
+++ b/Backends/CloudKit/Sync/InstrumentRecord+CloudKit.swift
@@ -19,7 +19,11 @@ extension InstrumentRecord: CloudKitRecordConvertible {
     return record
   }
 
-  static func fieldValues(from ckRecord: CKRecord) -> InstrumentRecord {
+  /// InstrumentRecord is keyed by `recordName` (e.g. "AUD", "ASX:BHP") rather than a
+  /// UUID. `recordName` is always non-nil on a valid `CKRecord.ID`, so this never
+  /// returns `nil`; the Optional return type exists to keep the protocol signature
+  /// uniform with UUID-keyed conformers.
+  static func fieldValues(from ckRecord: CKRecord) -> InstrumentRecord? {
     InstrumentRecord(
       id: ckRecord.recordID.recordName,
       kind: ckRecord["kind"] as? String ?? "fiatCurrency",

--- a/Backends/CloudKit/Sync/InvestmentValueRecord+CloudKit.swift
+++ b/Backends/CloudKit/Sync/InvestmentValueRecord+CloudKit.swift
@@ -17,9 +17,10 @@ extension InvestmentValueRecord: CloudKitRecordConvertible {
     return record
   }
 
-  static func fieldValues(from ckRecord: CKRecord) -> InvestmentValueRecord {
-    InvestmentValueRecord(
-      id: ckRecord.recordID.uuid ?? UUID(),
+  static func fieldValues(from ckRecord: CKRecord) -> InvestmentValueRecord? {
+    guard let id = ckRecord.recordID.uuid else { return nil }
+    return InvestmentValueRecord(
+      id: id,
       accountId: (ckRecord["accountId"] as? String).flatMap { UUID(uuidString: $0) } ?? UUID(),
       date: ckRecord["date"] as? Date ?? Date(),
       value: ckRecord["value"] as? Int64 ?? 0,

--- a/Backends/CloudKit/Sync/ProfileDataSyncHandler+BatchUpsert.swift
+++ b/Backends/CloudKit/Sync/ProfileDataSyncHandler+BatchUpsert.swift
@@ -8,12 +8,18 @@ extension ProfileDataSyncHandler {
   nonisolated static func batchUpsertInstruments(
     _ ckRecords: [CKRecord], context: ModelContext, systemFields: [String: Data]
   ) {
-    let pairs: [(String, CKRecord)] = ckRecords.map { ($0.recordID.recordName, $0) }
     let existing = fetchOrLog(FetchDescriptor<InstrumentRecord>(), context: context)
     var byID = Dictionary(uniqueKeysWithValues: existing.map { ($0.id, $0) })
 
-    for (id, ckRecord) in pairs {
-      let values = InstrumentRecord.fieldValues(from: ckRecord)
+    for ckRecord in ckRecords {
+      guard let values = InstrumentRecord.fieldValues(from: ckRecord) else {
+        logMalformed("batchUpsertInstruments", ckRecord)
+        continue
+      }
+      // `InstrumentRecord.id` is the raw `recordName` string (e.g. "AUD", "ASX:BHP"),
+      // not a UUID, so `systemFields` is keyed by the bare string here — unlike every
+      // other `batchUpsertX` below, which keys by `id.uuidString`.
+      let id = values.id
       if let existing = byID[id] {
         existing.kind = values.kind
         existing.name = values.name
@@ -34,7 +40,6 @@ extension ProfileDataSyncHandler {
   nonisolated static func batchUpsertAccounts(
     _ ckRecords: [CKRecord], context: ModelContext, systemFields: [String: Data]
   ) {
-    let pairs = uuidPairs(from: ckRecords)
     let existing: [AccountRecord]
     do {
       existing = try context.fetch(FetchDescriptor<AccountRecord>())
@@ -45,9 +50,15 @@ extension ProfileDataSyncHandler {
     var byID = Dictionary(uniqueKeysWithValues: existing.map { ($0.id, $0) })
     var insertCount = 0
     var updateCount = 0
+    var incomingCount = 0
 
-    for (id, ckRecord) in pairs {
-      let values = AccountRecord.fieldValues(from: ckRecord)
+    for ckRecord in ckRecords {
+      guard let values = AccountRecord.fieldValues(from: ckRecord) else {
+        logMalformed("batchUpsertAccounts", ckRecord)
+        continue
+      }
+      incomingCount += 1
+      let id = values.id
       if let existing = byID[id] {
         existing.name = values.name
         existing.type = values.type
@@ -64,19 +75,22 @@ extension ProfileDataSyncHandler {
       }
     }
     batchLogger.info(
-      "batchUpsertAccounts: \(pairs.count) incoming, \(existing.count) existing in store, \(insertCount) inserted, \(updateCount) updated"
+      "batchUpsertAccounts: \(incomingCount) incoming, \(existing.count) existing in store, \(insertCount) inserted, \(updateCount) updated"
     )
   }
 
   nonisolated static func batchUpsertTransactions(
     _ ckRecords: [CKRecord], context: ModelContext, systemFields: [String: Data]
   ) {
-    let pairs = uuidPairs(from: ckRecords)
     let existing = fetchOrLog(FetchDescriptor<TransactionRecord>(), context: context)
     var byID = Dictionary(uniqueKeysWithValues: existing.map { ($0.id, $0) })
 
-    for (id, ckRecord) in pairs {
-      let values = TransactionRecord.fieldValues(from: ckRecord)
+    for ckRecord in ckRecords {
+      guard let values = TransactionRecord.fieldValues(from: ckRecord) else {
+        logMalformed("batchUpsertTransactions", ckRecord)
+        continue
+      }
+      let id = values.id
       if let existing = byID[id] {
         existing.date = values.date
         existing.payee = values.payee
@@ -103,12 +117,15 @@ extension ProfileDataSyncHandler {
   nonisolated static func batchUpsertTransactionLegs(
     _ ckRecords: [CKRecord], context: ModelContext, systemFields: [String: Data]
   ) {
-    let pairs = uuidPairs(from: ckRecords)
     let existing = fetchOrLog(FetchDescriptor<TransactionLegRecord>(), context: context)
     var byID = Dictionary(uniqueKeysWithValues: existing.map { ($0.id, $0) })
 
-    for (id, ckRecord) in pairs {
-      let values = TransactionLegRecord.fieldValues(from: ckRecord)
+    for ckRecord in ckRecords {
+      guard let values = TransactionLegRecord.fieldValues(from: ckRecord) else {
+        logMalformed("batchUpsertTransactionLegs", ckRecord)
+        continue
+      }
+      let id = values.id
       if let existing = byID[id] {
         existing.transactionId = values.transactionId
         existing.accountId = values.accountId
@@ -130,12 +147,15 @@ extension ProfileDataSyncHandler {
   nonisolated static func batchUpsertCategories(
     _ ckRecords: [CKRecord], context: ModelContext, systemFields: [String: Data]
   ) {
-    let pairs = uuidPairs(from: ckRecords)
     let existing = fetchOrLog(FetchDescriptor<CategoryRecord>(), context: context)
     var byID = Dictionary(uniqueKeysWithValues: existing.map { ($0.id, $0) })
 
-    for (id, ckRecord) in pairs {
-      let values = CategoryRecord.fieldValues(from: ckRecord)
+    for ckRecord in ckRecords {
+      guard let values = CategoryRecord.fieldValues(from: ckRecord) else {
+        logMalformed("batchUpsertCategories", ckRecord)
+        continue
+      }
+      let id = values.id
       if let existing = byID[id] {
         existing.name = values.name
         existing.parentId = values.parentId
@@ -151,12 +171,15 @@ extension ProfileDataSyncHandler {
   nonisolated static func batchUpsertEarmarks(
     _ ckRecords: [CKRecord], context: ModelContext, systemFields: [String: Data]
   ) {
-    let pairs = uuidPairs(from: ckRecords)
     let existing = fetchOrLog(FetchDescriptor<EarmarkRecord>(), context: context)
     var byID = Dictionary(uniqueKeysWithValues: existing.map { ($0.id, $0) })
 
-    for (id, ckRecord) in pairs {
-      let values = EarmarkRecord.fieldValues(from: ckRecord)
+    for ckRecord in ckRecords {
+      guard let values = EarmarkRecord.fieldValues(from: ckRecord) else {
+        logMalformed("batchUpsertEarmarks", ckRecord)
+        continue
+      }
+      let id = values.id
       if let existing = byID[id] {
         existing.name = values.name
         existing.position = values.position
@@ -177,12 +200,15 @@ extension ProfileDataSyncHandler {
   nonisolated static func batchUpsertEarmarkBudgetItems(
     _ ckRecords: [CKRecord], context: ModelContext, systemFields: [String: Data]
   ) {
-    let pairs = uuidPairs(from: ckRecords)
     let existing = fetchOrLog(FetchDescriptor<EarmarkBudgetItemRecord>(), context: context)
     var byID = Dictionary(uniqueKeysWithValues: existing.map { ($0.id, $0) })
 
-    for (id, ckRecord) in pairs {
-      let values = EarmarkBudgetItemRecord.fieldValues(from: ckRecord)
+    for ckRecord in ckRecords {
+      guard let values = EarmarkBudgetItemRecord.fieldValues(from: ckRecord) else {
+        logMalformed("batchUpsertEarmarkBudgetItems", ckRecord)
+        continue
+      }
+      let id = values.id
       if let existing = byID[id] {
         existing.earmarkId = values.earmarkId
         existing.categoryId = values.categoryId
@@ -200,12 +226,15 @@ extension ProfileDataSyncHandler {
   nonisolated static func batchUpsertInvestmentValues(
     _ ckRecords: [CKRecord], context: ModelContext, systemFields: [String: Data]
   ) {
-    let pairs = uuidPairs(from: ckRecords)
     let existing = fetchOrLog(FetchDescriptor<InvestmentValueRecord>(), context: context)
     var byID = Dictionary(uniqueKeysWithValues: existing.map { ($0.id, $0) })
 
-    for (id, ckRecord) in pairs {
-      let values = InvestmentValueRecord.fieldValues(from: ckRecord)
+    for ckRecord in ckRecords {
+      guard let values = InvestmentValueRecord.fieldValues(from: ckRecord) else {
+        logMalformed("batchUpsertInvestmentValues", ckRecord)
+        continue
+      }
+      let id = values.id
       if let existing = byID[id] {
         existing.accountId = values.accountId
         existing.date = values.date
@@ -223,12 +252,15 @@ extension ProfileDataSyncHandler {
   nonisolated static func batchUpsertCSVImportProfiles(
     _ ckRecords: [CKRecord], context: ModelContext, systemFields: [String: Data]
   ) {
-    let pairs = uuidPairs(from: ckRecords)
     let existing = fetchOrLog(FetchDescriptor<CSVImportProfileRecord>(), context: context)
     var byID = Dictionary(uniqueKeysWithValues: existing.map { ($0.id, $0) })
 
-    for (id, ckRecord) in pairs {
-      let values = CSVImportProfileRecord.fieldValues(from: ckRecord)
+    for ckRecord in ckRecords {
+      guard let values = CSVImportProfileRecord.fieldValues(from: ckRecord) else {
+        logMalformed("batchUpsertCSVImportProfiles", ckRecord)
+        continue
+      }
+      let id = values.id
       if let existing = byID[id] {
         existing.accountId = values.accountId
         existing.parserIdentifier = values.parserIdentifier
@@ -251,12 +283,15 @@ extension ProfileDataSyncHandler {
   nonisolated static func batchUpsertImportRules(
     _ ckRecords: [CKRecord], context: ModelContext, systemFields: [String: Data]
   ) {
-    let pairs = uuidPairs(from: ckRecords)
     let existing = fetchOrLog(FetchDescriptor<ImportRuleRecord>(), context: context)
     var byID = Dictionary(uniqueKeysWithValues: existing.map { ($0.id, $0) })
 
-    for (id, ckRecord) in pairs {
-      let values = ImportRuleRecord.fieldValues(from: ckRecord)
+    for ckRecord in ckRecords {
+      guard let values = ImportRuleRecord.fieldValues(from: ckRecord) else {
+        logMalformed("batchUpsertImportRules", ckRecord)
+        continue
+      }
+      let id = values.id
       if let existing = byID[id] {
         existing.name = values.name
         existing.enabled = values.enabled
@@ -274,12 +309,12 @@ extension ProfileDataSyncHandler {
     }
   }
 
-  /// Converts `CKRecord`s whose record names are UUID strings into `(UUID, CKRecord)`
-  /// pairs, silently dropping any records whose name isn't a valid UUID.
-  nonisolated private static func uuidPairs(from ckRecords: [CKRecord]) -> [(UUID, CKRecord)] {
-    ckRecords.compactMap { record in
-      guard let uuid = record.recordID.uuid else { return nil }
-      return (uuid, record)
-    }
+  /// Logs a malformed incoming record (one whose `recordID` does not decode into a valid
+  /// id for its record type) at error level so the skip is visible in diagnostics
+  /// instead of being silently dropped.
+  nonisolated private static func logMalformed(_ site: String, _ ckRecord: CKRecord) {
+    batchLogger.error(
+      "\(site): malformed recordID '\(ckRecord.recordID.recordName)' (recordType \(ckRecord.recordType)) — skipping"
+    )
   }
 }

--- a/Backends/CloudKit/Sync/ProfileIndexSyncHandler.swift
+++ b/Backends/CloudKit/Sync/ProfileIndexSyncHandler.swift
@@ -48,10 +48,15 @@ final class ProfileIndexSyncHandler {
 
     for ckRecord in saved {
       guard ckRecord.recordType == ProfileRecord.recordType else { continue }
-      guard let profileId = ckRecord.recordID.uuid else { continue }
+      guard let values = ProfileRecord.fieldValues(from: ckRecord) else {
+        logger.error(
+          "applyRemoteChanges: malformed recordID '\(ckRecord.recordID.recordName)' (recordType \(ckRecord.recordType)) — skipping"
+        )
+        continue
+      }
 
+      let profileId = values.id
       let systemFieldsData = ckRecord.encodedSystemFields
-      let values = ProfileRecord.fieldValues(from: ckRecord)
       let descriptor = FetchDescriptor<ProfileRecord>(
         predicate: #Predicate { $0.id == profileId }
       )
@@ -68,7 +73,12 @@ final class ProfileIndexSyncHandler {
     }
 
     for recordID in deleted {
-      guard let profileId = recordID.uuid else { continue }
+      guard let profileId = recordID.uuid else {
+        logger.error(
+          "applyRemoteChanges: malformed deleted recordID '\(recordID.recordName)' — skipping"
+        )
+        continue
+      }
       let descriptor = FetchDescriptor<ProfileRecord>(
         predicate: #Predicate { $0.id == profileId }
       )

--- a/Backends/CloudKit/Sync/ProfileRecord+CloudKit.swift
+++ b/Backends/CloudKit/Sync/ProfileRecord+CloudKit.swift
@@ -17,9 +17,10 @@ extension ProfileRecord: CloudKitRecordConvertible {
     return record
   }
 
-  static func fieldValues(from ckRecord: CKRecord) -> ProfileRecord {
-    ProfileRecord(
-      id: ckRecord.recordID.uuid ?? UUID(),
+  static func fieldValues(from ckRecord: CKRecord) -> ProfileRecord? {
+    guard let id = ckRecord.recordID.uuid else { return nil }
+    return ProfileRecord(
+      id: id,
       label: ckRecord["label"] as? String ?? "",
       currencyCode: ckRecord["currencyCode"] as? String ?? "",
       financialYearStartMonth: ckRecord["financialYearStartMonth"] as? Int ?? 7,

--- a/Backends/CloudKit/Sync/TransactionLegRecord+CloudKit.swift
+++ b/Backends/CloudKit/Sync/TransactionLegRecord+CloudKit.swift
@@ -21,9 +21,10 @@ extension TransactionLegRecord: CloudKitRecordConvertible {
     return record
   }
 
-  static func fieldValues(from ckRecord: CKRecord) -> TransactionLegRecord {
-    TransactionLegRecord(
-      id: ckRecord.recordID.uuid ?? UUID(),
+  static func fieldValues(from ckRecord: CKRecord) -> TransactionLegRecord? {
+    guard let id = ckRecord.recordID.uuid else { return nil }
+    return TransactionLegRecord(
+      id: id,
       transactionId: (ckRecord["transactionId"] as? String).flatMap { UUID(uuidString: $0) }
         ?? UUID(),
       accountId: (ckRecord["accountId"] as? String).flatMap { UUID(uuidString: $0) },

--- a/Backends/CloudKit/Sync/TransactionRecord+CloudKit.swift
+++ b/Backends/CloudKit/Sync/TransactionRecord+CloudKit.swift
@@ -50,9 +50,10 @@ extension TransactionRecord: CloudKitRecordConvertible {
     }
   }
 
-  static func fieldValues(from ckRecord: CKRecord) -> TransactionRecord {
+  static func fieldValues(from ckRecord: CKRecord) -> TransactionRecord? {
+    guard let id = ckRecord.recordID.uuid else { return nil }
     let record = TransactionRecord(
-      id: ckRecord.recordID.uuid ?? UUID(),
+      id: id,
       date: ckRecord["date"] as? Date ?? Date(),
       payee: ckRecord["payee"] as? String,
       notes: ckRecord["notes"] as? String,

--- a/MoolahTests/Sync/RecordMappingTests.swift
+++ b/MoolahTests/Sync/RecordMappingTests.swift
@@ -12,7 +12,7 @@ struct RecordMappingTests {
   // MARK: - ProfileRecord
 
   @Test
-  func profileRecordRoundTrip() {
+  func profileRecordRoundTrip() throws {
     let profile = ProfileRecord(
       id: UUID(),
       label: "My Budget",
@@ -33,7 +33,7 @@ struct RecordMappingTests {
     #expect(ckRecord["financialYearStartMonth"] as? Int == 7)
     #expect(ckRecord["createdAt"] as? Date == profile.createdAt)
 
-    let restored = ProfileRecord.fieldValues(from: ckRecord)
+    let restored = try #require(ProfileRecord.fieldValues(from: ckRecord))
     #expect(restored.id == profile.id)
     #expect(restored.label == "My Budget")
     #expect(restored.currencyCode == "AUD")
@@ -44,7 +44,7 @@ struct RecordMappingTests {
   // MARK: - AccountRecord
 
   @Test
-  func accountRecordRoundTrip() {
+  func accountRecordRoundTrip() throws {
     let account = AccountRecord(
       id: UUID(),
       name: "Savings",
@@ -66,7 +66,7 @@ struct RecordMappingTests {
     #expect(ckRecord["position"] as? Int == 2)
     #expect(ckRecord["isHidden"] as? Int == 1)
 
-    let restored = AccountRecord.fieldValues(from: ckRecord)
+    let restored = try #require(AccountRecord.fieldValues(from: ckRecord))
     #expect(restored.id == account.id)
     #expect(restored.name == "Savings")
     #expect(restored.type == "bank")
@@ -76,22 +76,23 @@ struct RecordMappingTests {
   }
 
   @Test
-  func accountRecordFieldValuesDefaultsInstrumentId() {
+  func accountRecordFieldValuesDefaultsInstrumentId() throws {
     // When instrumentId is missing from CKRecord, default to "AUD"
-    let recordID = CKRecord.ID(recordName: UUID().uuidString, zoneID: zoneID)
+    let recordID = CKRecord.ID(
+      recordType: AccountRecord.recordType, uuid: UUID(), zoneID: zoneID)
     let ckRecord = CKRecord(recordType: "CD_AccountRecord", recordID: recordID)
     ckRecord["name"] = "Test" as CKRecordValue
     ckRecord["type"] = "bank" as CKRecordValue
     // No instrumentId set
 
-    let restored = AccountRecord.fieldValues(from: ckRecord)
+    let restored = try #require(AccountRecord.fieldValues(from: ckRecord))
     #expect(restored.instrumentId == "AUD")
   }
 
   // MARK: - TransactionRecord
 
   @Test
-  func transactionRecordRoundTrip() {
+  func transactionRecordRoundTrip() throws {
     let txnDate = Date(timeIntervalSince1970: 1_700_000_000)
 
     let txn = TransactionRecord(
@@ -115,7 +116,7 @@ struct RecordMappingTests {
     #expect(ckRecord["recurPeriod"] as? String == "monthly")
     #expect(ckRecord["recurEvery"] as? Int == 1)
 
-    let restored = TransactionRecord.fieldValues(from: ckRecord)
+    let restored = try #require(TransactionRecord.fieldValues(from: ckRecord))
     #expect(restored.id == txn.id)
     #expect(restored.date == txnDate)
     #expect(restored.payee == "Rent")
@@ -125,7 +126,7 @@ struct RecordMappingTests {
   }
 
   @Test
-  func transactionRecordNilOptionals() {
+  func transactionRecordNilOptionals() throws {
     let txn = TransactionRecord(
       id: UUID(),
       date: Date()
@@ -137,7 +138,7 @@ struct RecordMappingTests {
     #expect(ckRecord["recurPeriod"] == nil)
     #expect(ckRecord["recurEvery"] == nil)
 
-    let restored = TransactionRecord.fieldValues(from: ckRecord)
+    let restored = try #require(TransactionRecord.fieldValues(from: ckRecord))
     #expect(restored.payee == nil)
     #expect(restored.notes == nil)
     #expect(restored.recurPeriod == nil)
@@ -147,7 +148,7 @@ struct RecordMappingTests {
   // MARK: - TransactionLegRecord
 
   @Test
-  func transactionLegRecordRoundTrip() {
+  func transactionLegRecordRoundTrip() throws {
     let transactionId = UUID()
     let accountId = UUID()
     let categoryId = UUID()
@@ -180,7 +181,7 @@ struct RecordMappingTests {
     #expect(ckRecord["earmarkId"] as? String == earmarkId.uuidString)
     #expect(ckRecord["sortOrder"] as? Int == 0)
 
-    let restored = TransactionLegRecord.fieldValues(from: ckRecord)
+    let restored = try #require(TransactionLegRecord.fieldValues(from: ckRecord))
     #expect(restored.id == leg.id)
     #expect(restored.transactionId == transactionId)
     #expect(restored.accountId == accountId)
@@ -190,5 +191,63 @@ struct RecordMappingTests {
     #expect(restored.categoryId == categoryId)
     #expect(restored.earmarkId == earmarkId)
     #expect(restored.sortOrder == 0)
+  }
+
+  // MARK: - Malformed recordID propagation
+
+  /// UUID-keyed conformers must return `nil` from `fieldValues(from:)` when the
+  /// incoming `CKRecord` has a non-UUID `recordName`, so a phantom row with a
+  /// freshly-minted UUID is never silently inserted.
+  @Test
+  func uuidKeyedRecordsReturnNilForNonUUIDRecordName() {
+    let malformedID = CKRecord.ID(recordName: "not-a-uuid", zoneID: zoneID)
+
+    let accountRecord = CKRecord(recordType: AccountRecord.recordType, recordID: malformedID)
+    #expect(AccountRecord.fieldValues(from: accountRecord) == nil)
+
+    let txnRecord = CKRecord(recordType: TransactionRecord.recordType, recordID: malformedID)
+    #expect(TransactionRecord.fieldValues(from: txnRecord) == nil)
+
+    let legRecord = CKRecord(recordType: TransactionLegRecord.recordType, recordID: malformedID)
+    #expect(TransactionLegRecord.fieldValues(from: legRecord) == nil)
+
+    let categoryRecord = CKRecord(recordType: CategoryRecord.recordType, recordID: malformedID)
+    #expect(CategoryRecord.fieldValues(from: categoryRecord) == nil)
+
+    let earmarkRecord = CKRecord(recordType: EarmarkRecord.recordType, recordID: malformedID)
+    #expect(EarmarkRecord.fieldValues(from: earmarkRecord) == nil)
+
+    let budgetItemRecord = CKRecord(
+      recordType: EarmarkBudgetItemRecord.recordType, recordID: malformedID)
+    #expect(EarmarkBudgetItemRecord.fieldValues(from: budgetItemRecord) == nil)
+
+    let investmentRecord = CKRecord(
+      recordType: InvestmentValueRecord.recordType, recordID: malformedID)
+    #expect(InvestmentValueRecord.fieldValues(from: investmentRecord) == nil)
+
+    let profileRecord = CKRecord(recordType: ProfileRecord.recordType, recordID: malformedID)
+    #expect(ProfileRecord.fieldValues(from: profileRecord) == nil)
+
+    let csvProfileRecord = CKRecord(
+      recordType: CSVImportProfileRecord.recordType, recordID: malformedID)
+    #expect(CSVImportProfileRecord.fieldValues(from: csvProfileRecord) == nil)
+
+    let ruleRecord = CKRecord(recordType: ImportRuleRecord.recordType, recordID: malformedID)
+    #expect(ImportRuleRecord.fieldValues(from: ruleRecord) == nil)
+  }
+
+  /// InstrumentRecord is keyed by `recordName` rather than `uuid`, so any non-empty
+  /// record name is valid. The Optional return keeps the protocol uniform, but
+  /// successful decoding always yields a non-nil value.
+  @Test
+  func instrumentRecordIsNotSubjectToUUIDNilPropagation() throws {
+    let recordID = CKRecord.ID(recordName: "AUD", zoneID: zoneID)
+    let ckRecord = CKRecord(recordType: InstrumentRecord.recordType, recordID: recordID)
+    ckRecord["kind"] = "fiatCurrency" as CKRecordValue
+    ckRecord["name"] = "Australian Dollar" as CKRecordValue
+    ckRecord["decimals"] = 2 as CKRecordValue
+
+    let restored = try #require(InstrumentRecord.fieldValues(from: ckRecord))
+    #expect(restored.id == "AUD")
   }
 }

--- a/MoolahTests/Sync/RecordMappingTestsExtra.swift
+++ b/MoolahTests/Sync/RecordMappingTestsExtra.swift
@@ -9,7 +9,7 @@ struct RecordMappingTestsExtra {
   let zoneID = CKRecordZone.ID(zoneName: "profile-test", ownerName: CKCurrentUserDefaultName)
 
   @Test
-  func transactionLegRecordNilOptionals() {
+  func transactionLegRecordNilOptionals() throws {
     let leg = TransactionLegRecord(
       transactionId: UUID(),
       accountId: UUID(),
@@ -22,7 +22,7 @@ struct RecordMappingTestsExtra {
     #expect(ckRecord["categoryId"] == nil)
     #expect(ckRecord["earmarkId"] == nil)
 
-    let restored = TransactionLegRecord.fieldValues(from: ckRecord)
+    let restored = try #require(TransactionLegRecord.fieldValues(from: ckRecord))
     #expect(restored.categoryId == nil)
     #expect(restored.earmarkId == nil)
   }
@@ -30,7 +30,7 @@ struct RecordMappingTestsExtra {
   // MARK: - InstrumentRecord
 
   @Test
-  func instrumentRecordRoundTrip() {
+  func instrumentRecordRoundTrip() throws {
     let instrument = InstrumentRecord(
       id: "AUD",
       kind: "fiatCurrency",
@@ -48,7 +48,7 @@ struct RecordMappingTestsExtra {
     #expect(ckRecord["ticker"] == nil)
     #expect(ckRecord["exchange"] == nil)
 
-    let restored = InstrumentRecord.fieldValues(from: ckRecord)
+    let restored = try #require(InstrumentRecord.fieldValues(from: ckRecord))
     #expect(restored.id == "AUD")
     #expect(restored.kind == "fiatCurrency")
     #expect(restored.name == "Australian Dollar")
@@ -58,7 +58,7 @@ struct RecordMappingTestsExtra {
   }
 
   @Test
-  func instrumentRecordWithStockFields() {
+  func instrumentRecordWithStockFields() throws {
     let instrument = InstrumentRecord(
       id: "ASX:BHP",
       kind: "stock",
@@ -72,7 +72,7 @@ struct RecordMappingTestsExtra {
     #expect(ckRecord["ticker"] as? String == "BHP")
     #expect(ckRecord["exchange"] as? String == "ASX")
 
-    let restored = InstrumentRecord.fieldValues(from: ckRecord)
+    let restored = try #require(InstrumentRecord.fieldValues(from: ckRecord))
     #expect(restored.ticker == "BHP")
     #expect(restored.exchange == "ASX")
   }
@@ -80,7 +80,7 @@ struct RecordMappingTestsExtra {
   // MARK: - CategoryRecord
 
   @Test
-  func categoryRecordRoundTrip() {
+  func categoryRecordRoundTrip() throws {
     let parentId = UUID()
     let category = CategoryRecord(id: UUID(), name: "Food", parentId: parentId)
 
@@ -90,27 +90,27 @@ struct RecordMappingTestsExtra {
     #expect(ckRecord["name"] as? String == "Food")
     #expect(ckRecord["parentId"] as? String == parentId.uuidString)
 
-    let restored = CategoryRecord.fieldValues(from: ckRecord)
+    let restored = try #require(CategoryRecord.fieldValues(from: ckRecord))
     #expect(restored.id == category.id)
     #expect(restored.name == "Food")
     #expect(restored.parentId == parentId)
   }
 
   @Test
-  func categoryRecordNilParent() {
+  func categoryRecordNilParent() throws {
     let category = CategoryRecord(id: UUID(), name: "Root", parentId: nil)
 
     let ckRecord = category.toCKRecord(in: zoneID)
     #expect(ckRecord["parentId"] == nil)
 
-    let restored = CategoryRecord.fieldValues(from: ckRecord)
+    let restored = try #require(CategoryRecord.fieldValues(from: ckRecord))
     #expect(restored.parentId == nil)
   }
 
   // MARK: - EarmarkRecord
 
   @Test
-  func earmarkRecordRoundTrip() {
+  func earmarkRecordRoundTrip() throws {
     let startDate = Date(timeIntervalSince1970: 1_700_000_000)
     let endDate = Date(timeIntervalSince1970: 1_710_000_000)
     let earmark = EarmarkRecord(
@@ -135,7 +135,7 @@ struct RecordMappingTestsExtra {
     #expect(ckRecord["savingsStartDate"] as? Date == startDate)
     #expect(ckRecord["savingsEndDate"] as? Date == endDate)
 
-    let restored = EarmarkRecord.fieldValues(from: ckRecord)
+    let restored = try #require(EarmarkRecord.fieldValues(from: ckRecord))
     #expect(restored.id == earmark.id)
     #expect(restored.name == "Holiday Fund")
     #expect(restored.position == 3)
@@ -147,7 +147,7 @@ struct RecordMappingTestsExtra {
   }
 
   @Test
-  func earmarkRecordNilOptionals() {
+  func earmarkRecordNilOptionals() throws {
     let earmark = EarmarkRecord(
       id: UUID(),
       name: "Basic",
@@ -161,7 +161,7 @@ struct RecordMappingTestsExtra {
     #expect(ckRecord["savingsStartDate"] == nil)
     #expect(ckRecord["savingsEndDate"] == nil)
 
-    let restored = EarmarkRecord.fieldValues(from: ckRecord)
+    let restored = try #require(EarmarkRecord.fieldValues(from: ckRecord))
     #expect(restored.savingsTarget == nil)
     #expect(restored.savingsTargetInstrumentId == nil)
     #expect(restored.savingsStartDate == nil)

--- a/MoolahTests/Sync/RecordMappingTestsMore.swift
+++ b/MoolahTests/Sync/RecordMappingTestsMore.swift
@@ -9,7 +9,7 @@ struct RecordMappingTestsMore {
   let zoneID = CKRecordZone.ID(zoneName: "profile-test", ownerName: CKCurrentUserDefaultName)
 
   @Test
-  func earmarkBudgetItemRecordRoundTrip() {
+  func earmarkBudgetItemRecordRoundTrip() throws {
     let earmarkId = UUID()
     let categoryId = UUID()
     let item = EarmarkBudgetItemRecord(
@@ -28,7 +28,7 @@ struct RecordMappingTestsMore {
     #expect(ckRecord["amount"] as? Int64 == 1_000_000_000)
     #expect(ckRecord["instrumentId"] as? String == "AUD")
 
-    let restored = EarmarkBudgetItemRecord.fieldValues(from: ckRecord)
+    let restored = try #require(EarmarkBudgetItemRecord.fieldValues(from: ckRecord))
     #expect(restored.id == item.id)
     #expect(restored.earmarkId == earmarkId)
     #expect(restored.categoryId == categoryId)
@@ -39,7 +39,7 @@ struct RecordMappingTestsMore {
   // MARK: - InvestmentValueRecord
 
   @Test
-  func investmentValueRecordRoundTrip() {
+  func investmentValueRecordRoundTrip() throws {
     let accountId = UUID()
     let date = Date(timeIntervalSince1970: 1_700_000_000)
     let record = InvestmentValueRecord(
@@ -58,7 +58,7 @@ struct RecordMappingTestsMore {
     #expect(ckRecord["value"] as? Int64 == 25_000_000_000)
     #expect(ckRecord["instrumentId"] as? String == "AUD")
 
-    let restored = InvestmentValueRecord.fieldValues(from: ckRecord)
+    let restored = try #require(InvestmentValueRecord.fieldValues(from: ckRecord))
     #expect(restored.id == record.id)
     #expect(restored.accountId == accountId)
     #expect(restored.date == date)
@@ -69,7 +69,7 @@ struct RecordMappingTestsMore {
   // MARK: - Multi-instrument persistence
 
   @Test
-  func instrumentRecordCryptoFieldsRoundTrip() {
+  func instrumentRecordCryptoFieldsRoundTrip() throws {
     let instrument = InstrumentRecord(
       id: "1:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
       kind: "cryptoToken",
@@ -89,7 +89,7 @@ struct RecordMappingTestsMore {
       ckRecord["contractAddress"] as? String == "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48")
     #expect(ckRecord["exchange"] == nil)
 
-    let restored = InstrumentRecord.fieldValues(from: ckRecord)
+    let restored = try #require(InstrumentRecord.fieldValues(from: ckRecord))
     #expect(restored.id == "1:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48")
     #expect(restored.kind == "cryptoToken")
     #expect(restored.decimals == 6)
@@ -99,7 +99,7 @@ struct RecordMappingTestsMore {
   }
 
   @Test
-  func instrumentRecordNativeCryptoHasNoContractAddress() {
+  func instrumentRecordNativeCryptoHasNoContractAddress() throws {
     // Bitcoin uses chainId = 0 and nil contractAddress; ETH native uses chainId = 1.
     let btc = InstrumentRecord(
       id: "0:native",
@@ -115,7 +115,7 @@ struct RecordMappingTestsMore {
     #expect(ckRecord["chainId"] as? Int == 0)
     #expect(ckRecord["contractAddress"] == nil)
 
-    let restored = InstrumentRecord.fieldValues(from: ckRecord)
+    let restored = try #require(InstrumentRecord.fieldValues(from: ckRecord))
     #expect(restored.chainId == 0)
     #expect(restored.contractAddress == nil)
   }
@@ -163,7 +163,7 @@ struct RecordMappingTestsMore {
   }
 
   @Test
-  func accountRecordRoundTripForStockInstrumentId() {
+  func accountRecordRoundTripForStockInstrumentId() throws {
     let account = AccountRecord(
       id: UUID(),
       name: "Sharesight",
@@ -176,13 +176,13 @@ struct RecordMappingTestsMore {
     let ckRecord = account.toCKRecord(in: zoneID)
     #expect(ckRecord["instrumentId"] as? String == "ASX:BHP")
 
-    let restored = AccountRecord.fieldValues(from: ckRecord)
+    let restored = try #require(AccountRecord.fieldValues(from: ckRecord))
     #expect(restored.instrumentId == "ASX:BHP")
     #expect(restored.type == "investment")
   }
 
   @Test
-  func accountRecordRoundTripForCryptoInstrumentId() {
+  func accountRecordRoundTripForCryptoInstrumentId() throws {
     let account = AccountRecord(
       id: UUID(),
       name: "Wallet",
@@ -197,12 +197,12 @@ struct RecordMappingTestsMore {
       ckRecord["instrumentId"] as? String
         == "1:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48")
 
-    let restored = AccountRecord.fieldValues(from: ckRecord)
+    let restored = try #require(AccountRecord.fieldValues(from: ckRecord))
     #expect(restored.instrumentId == "1:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48")
   }
 
   @Test
-  func transactionLegRecordRoundTripForStockInstrument() {
+  func transactionLegRecordRoundTripForStockInstrument() throws {
     let leg = TransactionLegRecord(
       id: UUID(),
       transactionId: UUID(),
@@ -218,13 +218,13 @@ struct RecordMappingTestsMore {
     #expect(ckRecord["instrumentId"] as? String == "ASX:BHP")
     #expect(ckRecord["quantity"] as? Int64 == 15_000_000_000)
 
-    let restored = TransactionLegRecord.fieldValues(from: ckRecord)
+    let restored = try #require(TransactionLegRecord.fieldValues(from: ckRecord))
     #expect(restored.instrumentId == "ASX:BHP")
     #expect(restored.quantity == 15_000_000_000)
   }
 
   @Test
-  func transactionLegRecordRoundTripForCryptoInstrument() {
+  func transactionLegRecordRoundTripForCryptoInstrument() throws {
     let leg = TransactionLegRecord(
       id: UUID(),
       transactionId: UUID(),
@@ -240,13 +240,13 @@ struct RecordMappingTestsMore {
     #expect(ckRecord["instrumentId"] as? String == "1:native")
     #expect(ckRecord["quantity"] as? Int64 == 50_000_000)
 
-    let restored = TransactionLegRecord.fieldValues(from: ckRecord)
+    let restored = try #require(TransactionLegRecord.fieldValues(from: ckRecord))
     #expect(restored.instrumentId == "1:native")
     #expect(restored.quantity == 50_000_000)
   }
 
   @Test
-  func earmarkRecordRoundTripForNonFiatSavingsTarget() {
+  func earmarkRecordRoundTripForNonFiatSavingsTarget() throws {
     // Earmark tracking a stock or crypto target for goals like "own 100 BHP".
     let earmark = EarmarkRecord(
       id: UUID(),
@@ -262,12 +262,12 @@ struct RecordMappingTestsMore {
     let ckRecord = earmark.toCKRecord(in: zoneID)
     #expect(ckRecord["savingsTargetInstrumentId"] as? String == "ASX:BHP")
 
-    let restored = EarmarkRecord.fieldValues(from: ckRecord)
+    let restored = try #require(EarmarkRecord.fieldValues(from: ckRecord))
     #expect(restored.savingsTargetInstrumentId == "ASX:BHP")
   }
 
   @Test
-  func earmarkBudgetItemRecordRoundTripForForeignInstrument() {
+  func earmarkBudgetItemRecordRoundTripForForeignInstrument() throws {
     let item = EarmarkBudgetItemRecord(
       id: UUID(),
       earmarkId: UUID(),
@@ -280,7 +280,7 @@ struct RecordMappingTestsMore {
     #expect(ckRecord["instrumentId"] as? String == "USD")
     #expect(ckRecord["amount"] as? Int64 == 100_000_000_000)
 
-    let restored = EarmarkBudgetItemRecord.fieldValues(from: ckRecord)
+    let restored = try #require(EarmarkBudgetItemRecord.fieldValues(from: ckRecord))
     #expect(restored.instrumentId == "USD")
     #expect(restored.amount == 100_000_000_000)
   }


### PR DESCRIPTION
## Summary

- Changes `CloudKitRecordConvertible.fieldValues(from:)` to return `Self?` so UUID-keyed conformers can signal a malformed `recordID` instead of silently manufacturing a fresh `UUID()` and creating a phantom SwiftData row.
- Removes the two upstream silent-drop filters (`uuidPairs` in `ProfileDataSyncHandler+BatchUpsert.swift` and the early `guard let profileId = ckRecord.recordID.uuid else { continue }` on both the save and delete loops in `ProfileIndexSyncHandler.applyRemoteChanges`). Each call site now logs at error level via `logMalformed(_:_:)` and skips, so a malformed incoming record surfaces in the logs rather than being dropped invisibly.
- `InstrumentRecord` is keyed by `recordName` (e.g. `"AUD"`, `"ASX:BHP"`) rather than `uuid` — it adopts the uniform `Self?` signature but never returns `nil`. The protocol doc comment and an inline comment on `batchUpsertInstruments`'s `systemFields[id]` key make the asymmetry explicit so a future reader doesn't \"fix\" it.

Fixes #427

## Stacked on

PR #439 (#416 collision fix). Base branch is \`fix/sync-record-name-collision\`.

## Test plan

- [x] New unit test \`uuidKeyedRecordsReturnNilForNonUUIDRecordName\` in \`MoolahTests/Sync/RecordMappingTests.swift\` covers all 10 UUID-keyed conformers.
- [x] New unit test \`instrumentRecordIsNotSubjectToUUIDNilPropagation\` confirms the string-keyed outlier still decodes successfully.
- [x] All 23 existing \`fieldValues\` round-trip call sites updated to \`try #require(...)\`.
- [x] \`just format-check\` clean.
- [x] \`just test-mac\` — 1533 / 1533 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)