### PR TITLE
fix(settings): inject session into Import/Rules tabs on macOS

### DIFF
--- a/Features/Settings/SettingsView.swift
+++ b/Features/Settings/SettingsView.swift
@@ -48,7 +48,7 @@ struct SettingsView: View {
 
   #if os(macOS)
     private var cryptoTokenStoreForSettings: CryptoTokenStore {
-      if let session = sessionManager.sessions.values.first {
+      if let session = sessionForSettings {
         return session.cryptoTokenStore
       }
       let fallbackService = CryptoPriceService(
@@ -57,6 +57,18 @@ struct SettingsView: View {
         resolutionClient: CompositeTokenResolutionClient()
       )
       return CryptoTokenStore(cryptoPriceService: fallbackService)
+    }
+
+    /// The Settings scene lives outside `SessionRootView`, so the session
+    /// stores aren't in its environment. Resolve one here for the tabs
+    /// that depend on per-profile state. Prefer the active profile; fall
+    /// back to any open session so Settings still renders after a profile
+    /// switch.
+    private var sessionForSettings: ProfileSession? {
+      if let id = profileStore.activeProfileID, let session = sessionManager.sessions[id] {
+        return session
+      }
+      return sessionManager.sessions.values.first
     }
 
     private var macOSLayout: some View {
@@ -71,10 +83,10 @@ struct SettingsView: View {
         // already supplies chrome and a title, so wrapping in a second
         // `NavigationStack` would produce a duplicate navigation bar.
         Tab("Import", systemImage: "tray.and.arrow.down") {
-          ImportSettingsView()
+          importTabContent
         }
         Tab("Rules", systemImage: "list.bullet.rectangle") {
-          ImportRulesSettingsView()
+          rulesTabContent
         }
       }
       .frame(minWidth: 600, minHeight: 400)
@@ -141,6 +153,34 @@ struct SettingsView: View {
         }
         .buttonStyle(.bordered)
       }
+    }
+
+    @ViewBuilder private var importTabContent: some View {
+      if let session = sessionForSettings {
+        ImportSettingsView()
+          .environment(session)
+      } else {
+        noActiveProfilePlaceholder
+      }
+    }
+
+    @ViewBuilder private var rulesTabContent: some View {
+      if let session = sessionForSettings {
+        ImportRulesSettingsView()
+          .environment(session)
+          .environment(session.importRuleStore)
+          .environment(session.categoryStore)
+      } else {
+        noActiveProfilePlaceholder
+      }
+    }
+
+    private var noActiveProfilePlaceholder: some View {
+      ContentUnavailableView(
+        "No Profile",
+        systemImage: "person.crop.circle",
+        description: Text("Add a profile to configure this tab.")
+      )
     }
   #endif
 


### PR DESCRIPTION
## Summary

- macOS Settings' Import and Rules tabs crashed (`EXC_BREAKPOINT` in `EnvironmentValues.subscript.getter`) because the Settings scene lives outside `SessionRootView`, so `ProfileSession` / `ImportRuleStore` / `CategoryStore` aren't in its environment.
- Once the crash happened with Import selected, TabView's remembered tab caused the Settings window to crash on every subsequent open.
- Resolve a session from `SessionManager` (prefer `profileStore.activeProfileID`, fall back to any open session) and inject the required environment values into those two tabs. Show `ContentUnavailableView` when no session is available.

## Crash evidence

`~/Library/Logs/DiagnosticReports/Moolah-2026-04-24-184102.ips`:

```
frame 0:  _assertionFailure(_:_:file:line:flags:)
frame 1:  specialized EnvironmentValues.subscript.getter
...
frame N:  AppKitWindowController.hostingView(_:didMoveTo:)
frame N+1: -[NSWindow setContentViewController:]
frame N+2: AppWindowsController.makeSettingsWindowController
frame N+3: SceneNavigationStrategy_Mac.openSettings
frame N+4: closure #1 in SettingsLink.body.getter
```

## Test plan

- [x] `just build-mac` clean (BUILD SUCCEEDED, no new warnings)
- [x] `just format-check` clean
- [ ] Manual: open Settings on macOS → Import tab renders (no crash). _Automated UI drive blocked by `osascript` keystroke TCC in Claude Code; needs a manual click once this lands._
- [ ] Manual: with zero profiles, Import and Rules tabs show "No Profile" placeholder.
- [ ] Manual: re-open Settings after selecting the Import tab — it reopens on Import without crashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)