### PR TITLE
Task 2 of instrument-registry: extend InstrumentRecord with crypto provider-mapping fields

### DIFF
--- a/Backends/CloudKit/Models/InstrumentRecord.swift
+++ b/Backends/CloudKit/Models/InstrumentRecord.swift
@@ -11,6 +11,9 @@ final class InstrumentRecord {
   var exchange: String?
   var chainId: Int?
   var contractAddress: String?
+  var coingeckoId: String?
+  var cryptocompareSymbol: String?
+  var binanceSymbol: String?
   var encodedSystemFields: Data?
 
   init(
@@ -21,7 +24,10 @@ final class InstrumentRecord {
     ticker: String? = nil,
     exchange: String? = nil,
     chainId: Int? = nil,
-    contractAddress: String? = nil
+    contractAddress: String? = nil,
+    coingeckoId: String? = nil,
+    cryptocompareSymbol: String? = nil,
+    binanceSymbol: String? = nil
   ) {
     self.id = id
     self.kind = kind
@@ -31,6 +37,9 @@ final class InstrumentRecord {
     self.exchange = exchange
     self.chainId = chainId
     self.contractAddress = contractAddress
+    self.coingeckoId = coingeckoId
+    self.cryptocompareSymbol = cryptocompareSymbol
+    self.binanceSymbol = binanceSymbol
   }
 
   func toDomain() -> Instrument {
@@ -46,6 +55,13 @@ final class InstrumentRecord {
     )
   }
 
+  /// Builds a minimal `InstrumentRecord` from a domain `Instrument`.
+  /// Provider-mapping fields (`coingeckoId`, `cryptocompareSymbol`, `binanceSymbol`)
+  /// are intentionally not copied — they live on the persistence side only, and
+  /// are populated via `InstrumentRegistryRepository.registerCrypto(_:mapping:)`
+  /// when a user registers a crypto instrument with its mapping. Callers using
+  /// `from(_:)` (e.g. `ensureInstrument`) produce rows without mappings, which
+  /// is the correct behaviour for auto-insertion.
   static func from(_ instrument: Instrument) -> InstrumentRecord {
     InstrumentRecord(
       id: instrument.id,

--- a/Backends/CloudKit/Sync/InstrumentRecord+CloudKit.swift
+++ b/Backends/CloudKit/Sync/InstrumentRecord+CloudKit.swift
@@ -16,6 +16,11 @@ extension InstrumentRecord: CloudKitRecordConvertible {
     if let exchange { record["exchange"] = exchange as CKRecordValue }
     if let chainId { record["chainId"] = chainId as CKRecordValue }
     if let contractAddress { record["contractAddress"] = contractAddress as CKRecordValue }
+    if let coingeckoId { record["coingeckoId"] = coingeckoId as CKRecordValue }
+    if let cryptocompareSymbol {
+      record["cryptocompareSymbol"] = cryptocompareSymbol as CKRecordValue
+    }
+    if let binanceSymbol { record["binanceSymbol"] = binanceSymbol as CKRecordValue }
     return record
   }
 
@@ -32,7 +37,10 @@ extension InstrumentRecord: CloudKitRecordConvertible {
       ticker: ckRecord["ticker"] as? String,
       exchange: ckRecord["exchange"] as? String,
       chainId: ckRecord["chainId"] as? Int,
-      contractAddress: ckRecord["contractAddress"] as? String
+      contractAddress: ckRecord["contractAddress"] as? String,
+      coingeckoId: ckRecord["coingeckoId"] as? String,
+      cryptocompareSymbol: ckRecord["cryptocompareSymbol"] as? String,
+      binanceSymbol: ckRecord["binanceSymbol"] as? String
     )
   }
 }

--- a/Backends/CloudKit/Sync/ProfileDataSyncHandler+BatchUpsert.swift
+++ b/Backends/CloudKit/Sync/ProfileDataSyncHandler+BatchUpsert.swift
@@ -28,6 +28,9 @@ extension ProfileDataSyncHandler {
         existing.exchange = values.exchange
         existing.chainId = values.chainId
         existing.contractAddress = values.contractAddress
+        existing.coingeckoId = values.coingeckoId
+        existing.cryptocompareSymbol = values.cryptocompareSymbol
+        existing.binanceSymbol = values.binanceSymbol
         existing.encodedSystemFields = systemFields[id]
       } else {
         values.encodedSystemFields = systemFields[id]

--- a/MoolahTests/Domain/InstrumentRecordCryptoFieldsTests.swift
+++ b/MoolahTests/Domain/InstrumentRecordCryptoFieldsTests.swift
@@ -1,0 +1,100 @@
+import CloudKit
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("InstrumentRecord — Crypto Provider Mapping Fields")
+struct InstrumentRecordCryptoFieldsTests {
+  @Test
+  func initializerAcceptsAllMappingFields() {
+    let record = InstrumentRecord(
+      id: "1:native",
+      kind: "cryptoToken",
+      name: "Ethereum",
+      decimals: 18,
+      ticker: "ETH",
+      exchange: nil,
+      chainId: 1,
+      contractAddress: nil,
+      coingeckoId: "ethereum",
+      cryptocompareSymbol: "ETH",
+      binanceSymbol: "ETHUSDT"
+    )
+    #expect(record.coingeckoId == "ethereum")
+    #expect(record.cryptocompareSymbol == "ETH")
+    #expect(record.binanceSymbol == "ETHUSDT")
+  }
+
+  @Test
+  func mappingFieldsDefaultToNil() {
+    let record = InstrumentRecord(
+      id: "AUD", kind: "fiatCurrency", name: "AUD", decimals: 2)
+    #expect(record.coingeckoId == nil)
+    #expect(record.cryptocompareSymbol == nil)
+    #expect(record.binanceSymbol == nil)
+  }
+
+  @Test
+  func ckRecordRoundTripWithMapping() {
+    let original = InstrumentRecord(
+      id: "1:0xdac17f958d2ee523a2206206994597c13d831ec7",
+      kind: "cryptoToken",
+      name: "Tether",
+      decimals: 6,
+      ticker: "USDT",
+      chainId: 1,
+      contractAddress: "0xdac17f958d2ee523a2206206994597c13d831ec7",
+      coingeckoId: "tether",
+      cryptocompareSymbol: "USDT",
+      binanceSymbol: "USDTUSDT"
+    )
+    let zoneID = CKRecordZone.ID(zoneName: "test", ownerName: CKCurrentUserDefaultName)
+    let ckRecord = original.toCKRecord(in: zoneID)
+
+    #expect(ckRecord["coingeckoId"] as? String == "tether")
+    #expect(ckRecord["cryptocompareSymbol"] as? String == "USDT")
+    #expect(ckRecord["binanceSymbol"] as? String == "USDTUSDT")
+
+    let decoded = InstrumentRecord.fieldValues(from: ckRecord)
+    #expect(decoded.coingeckoId == "tether")
+    #expect(decoded.cryptocompareSymbol == "USDT")
+    #expect(decoded.binanceSymbol == "USDTUSDT")
+  }
+
+  @Test
+  func ckRecordNilMappingFieldsAreAbsentNotNull() {
+    let record = InstrumentRecord(
+      id: "AUD", kind: "fiatCurrency", name: "AUD", decimals: 2)
+    let zoneID = CKRecordZone.ID(zoneName: "test", ownerName: CKCurrentUserDefaultName)
+    let ckRecord = record.toCKRecord(in: zoneID)
+
+    #expect(ckRecord["coingeckoId"] == nil)
+    #expect(ckRecord["cryptocompareSymbol"] == nil)
+    #expect(ckRecord["binanceSymbol"] == nil)
+    // Keys must not be present at all — saves record bytes and matches the
+    // existing convention for ticker/exchange/chainId/contractAddress.
+    #expect(ckRecord.allKeys().contains("coingeckoId") == false)
+    #expect(ckRecord.allKeys().contains("cryptocompareSymbol") == false)
+    #expect(ckRecord.allKeys().contains("binanceSymbol") == false)
+  }
+
+  @Test
+  func decodingPreMigrationCKRecordLeavesMappingFieldsNil() {
+    // Simulate a record saved by an older version that didn't know about
+    // the three new fields. Only the legacy keys are present.
+    let zoneID = CKRecordZone.ID(zoneName: "test", ownerName: CKCurrentUserDefaultName)
+    let recordID = CKRecord.ID(recordName: "AUD", zoneID: zoneID)
+    let ckRecord = CKRecord(recordType: "CD_InstrumentRecord", recordID: recordID)
+    ckRecord["kind"] = "fiatCurrency" as CKRecordValue
+    ckRecord["name"] = "AUD" as CKRecordValue
+    ckRecord["decimals"] = 2 as CKRecordValue
+
+    let decoded = InstrumentRecord.fieldValues(from: ckRecord)
+    #expect(decoded.coingeckoId == nil)
+    #expect(decoded.cryptocompareSymbol == nil)
+    #expect(decoded.binanceSymbol == nil)
+    #expect(decoded.id == "AUD")
+    #expect(decoded.kind == "fiatCurrency")
+  }
+}

--- a/MoolahTests/Domain/InstrumentRecordCryptoFieldsTests.swift
+++ b/MoolahTests/Domain/InstrumentRecordCryptoFieldsTests.swift
@@ -36,7 +36,7 @@ struct InstrumentRecordCryptoFieldsTests {
   }
 
   @Test
-  func ckRecordRoundTripWithMapping() {
+  func ckRecordRoundTripWithMapping() throws {
     let original = InstrumentRecord(
       id: "1:0xdac17f958d2ee523a2206206994597c13d831ec7",
       kind: "cryptoToken",
@@ -56,7 +56,7 @@ struct InstrumentRecordCryptoFieldsTests {
     #expect(ckRecord["cryptocompareSymbol"] as? String == "USDT")
     #expect(ckRecord["binanceSymbol"] as? String == "USDTUSDT")
 
-    let decoded = InstrumentRecord.fieldValues(from: ckRecord)
+    let decoded = try #require(InstrumentRecord.fieldValues(from: ckRecord))
     #expect(decoded.coingeckoId == "tether")
     #expect(decoded.cryptocompareSymbol == "USDT")
     #expect(decoded.binanceSymbol == "USDTUSDT")
@@ -80,7 +80,7 @@ struct InstrumentRecordCryptoFieldsTests {
   }
 
   @Test
-  func decodingPreMigrationCKRecordLeavesMappingFieldsNil() {
+  func decodingPreMigrationCKRecordLeavesMappingFieldsNil() throws {
     // Simulate a record saved by an older version that didn't know about
     // the three new fields. Only the legacy keys are present.
     let zoneID = CKRecordZone.ID(zoneName: "test", ownerName: CKCurrentUserDefaultName)
@@ -90,7 +90,7 @@ struct InstrumentRecordCryptoFieldsTests {
     ckRecord["name"] = "AUD" as CKRecordValue
     ckRecord["decimals"] = 2 as CKRecordValue
 
-    let decoded = InstrumentRecord.fieldValues(from: ckRecord)
+    let decoded = try #require(InstrumentRecord.fieldValues(from: ckRecord))
     #expect(decoded.coingeckoId == nil)
     #expect(decoded.cryptocompareSymbol == nil)
     #expect(decoded.binanceSymbol == nil)


### PR DESCRIPTION
## Summary

- Task 2 of [`plans/2026-04-24-instrument-registry-implementation.md`](https://github.com/ajsutton/moolah-native/blob/feat/instrument-registry-2/plans/2026-04-24-instrument-registry-implementation.md) — stacked on #447 (Task 1).
- Adds three nullable `String?` fields to `InstrumentRecord`: `coingeckoId`, `cryptocompareSymbol`, `binanceSymbol`. SwiftData's automatic lightweight migration handles the schema bump.
- Extends `CloudKitRecordConvertible` encode/decode to round-trip the new fields (conditional-set on nil; safe `as? String` decode for pre-migration records).
- Fixes a latent multi-device data-loss bug: `batchUpsertInstruments` previously enumerated fields by name when updating existing rows and would have silently dropped the three new fields. Update branch now copies them.
- `InstrumentRecord.from(_:)` intentionally does NOT copy the new fields — provider mappings stay off the domain `Instrument` per §1.2 of the design. Added a doc comment explaining this for future readers.
- New contract test file covering all 5 spec'd invariants (init, defaults, round-trip, nil-absent-not-null, pre-migration decode).

## Test plan

- [x] `just format-check` clean
- [x] `just test` — 1520 tests on macOS, 1492 on iOS, all pass
- [x] Spec compliance ✅ and code quality ✅ reviews both passed after one amend round
- [x] `.swiftlint-baseline.yml` diff empty
- [x] Scope: 4 files — `InstrumentRecord.swift`, `InstrumentRecord+CloudKit.swift`, `ProfileDataSyncHandler+BatchUpsert.swift`, new test file

🤖 Generated with [Claude Code](https://claude.com/claude-code)