### PR TITLE
feat(cloudkit): split CloudKit env storage; install-mac → Production

### DIFF
--- a/App/Info-iOS.plist
+++ b/App/Info-iOS.plist
@@ -52,5 +52,7 @@
         <string>UIInterfaceOrientationLandscapeLeft</string>
         <string>UIInterfaceOrientationLandscapeRight</string>
     </array>
+    <key>MoolahCloudKitEnvironment</key>
+    <string>$(CLOUDKIT_ENVIRONMENT)</string>
 </dict>
 </plist>

--- a/App/Info-macOS.plist
+++ b/App/Info-macOS.plist
@@ -38,5 +38,7 @@
             <string>Moolah</string>
         </dict>
     </dict>
+    <key>MoolahCloudKitEnvironment</key>
+    <string>$(CLOUDKIT_ENVIRONMENT)</string>
 </dict>
 </plist>

--- a/App/MoolahApp+Setup.swift
+++ b/App/MoolahApp+Setup.swift
@@ -45,7 +45,8 @@ extension MoolahApp {
       }
 
       let profileSchema = Schema([ProfileRecord.self])
-      let profileStoreURL = URL.applicationSupportDirectory.appending(path: "Moolah-v2.store")
+      let profileStoreURL = URL.moolahScopedApplicationSupport
+        .appending(path: "Moolah-v2.store")
       let profileConfig = ModelConfiguration(
         url: profileStoreURL,
         cloudKitDatabase: .none

--- a/App/ProfileSession.swift
+++ b/App/ProfileSession.swift
@@ -226,15 +226,7 @@ final class ProfileSession: Identifiable {
   /// lives. Not part of the SwiftData store because staging is device-local
   /// and doesn't sync.
   nonisolated static func importStagingDirectory(for profileId: UUID) -> URL {
-    let base =
-      (try? FileManager.default.url(
-        for: .applicationSupportDirectory,
-        in: .userDomainMask,
-        appropriateFor: nil,
-        create: true))
-      ?? FileManager.default.temporaryDirectory
-    return
-      base
+    URL.moolahScopedApplicationSupport
       .appendingPathComponent("Moolah", isDirectory: true)
       .appendingPathComponent("csv-staging", isDirectory: true)
       .appendingPathComponent(profileId.uuidString, isDirectory: true)

--- a/Backends/CloudKit/Sync/SyncCoordinator.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator.swift
@@ -180,7 +180,7 @@ final class SyncCoordinator {
 
   // MARK: - State
 
-  let stateFileURL = URL.applicationSupportDirectory
+  let stateFileURL = URL.moolahScopedApplicationSupport
     .appending(path: "Moolah-v2-sync.syncstate")
 
   let containerManager: ProfileContainerManager

--- a/MoolahTests/App/ProfileContainerManagerTests.swift
+++ b/MoolahTests/App/ProfileContainerManagerTests.swift
@@ -4,7 +4,12 @@ import Testing
 
 @testable import Moolah
 
-@Suite("ProfileContainerManager")
+// Serialised because testContainerUsesScopedStoreURL mutates
+// `URL.moolahApplicationSupportOverride`, a `nonisolated(unsafe)` static.
+// The other tests in this suite use the in-memory forTesting() path and
+// would be safe to parallelise, but the suite is small enough that
+// serialisation is a cheap way to eliminate the override-leak hazard.
+@Suite("ProfileContainerManager", .serialized)
 struct ProfileContainerManagerTests {
   @Test("creates index container with ProfileRecord schema only")
   @MainActor

--- a/MoolahTests/App/ProfileContainerManagerTests.swift
+++ b/MoolahTests/App/ProfileContainerManagerTests.swift
@@ -58,4 +58,53 @@ struct ProfileContainerManagerTests {
     let container2 = try manager.container(for: profileId)
     #expect(container1 !== container2)
   }
+
+  @Test("configures per-profile store URL under the scoped Application Support root")
+  @MainActor
+  func testContainerUsesScopedStoreURL() throws {
+    let root = FileManager.default.temporaryDirectory
+      .appending(path: UUID().uuidString)
+    try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    URL.moolahApplicationSupportOverride = root
+    defer { URL.moolahApplicationSupportOverride = nil }
+
+    let indexSchema = Schema([ProfileRecord.self])
+    let indexConfig = ModelConfiguration(isStoredInMemoryOnly: true)
+    let indexContainer = try ModelContainer(for: indexSchema, configurations: [indexConfig])
+    let dataSchema = Schema([
+      AccountRecord.self,
+      TransactionRecord.self,
+      TransactionLegRecord.self,
+      InstrumentRecord.self,
+      CategoryRecord.self,
+      EarmarkRecord.self,
+      EarmarkBudgetItemRecord.self,
+      InvestmentValueRecord.self,
+      CSVImportProfileRecord.self,
+      ImportRuleRecord.self,
+    ])
+
+    let manager = ProfileContainerManager(
+      indexContainer: indexContainer,
+      dataSchema: dataSchema,
+      inMemory: false
+    )
+
+    let profileId = UUID()
+    let container = try manager.container(for: profileId)
+
+    let envSubdir = CloudKitEnvironment.resolved().storageSubdirectory
+    let expectedStore =
+      root
+      .appending(path: envSubdir)
+      .appending(path: "Moolah-\(profileId.uuidString).store")
+    let actualURL = container.configurations.first?.url
+    #expect(actualURL?.standardizedFileURL == expectedStore.standardizedFileURL)
+
+    // Env subdir must have been created on demand by the scoped helper.
+    let envDir = root.appending(path: envSubdir)
+    #expect(FileManager.default.fileExists(atPath: envDir.path()))
+  }
 }

--- a/MoolahTests/Backup/StoreBackupManagerDefaultLocationTests.swift
+++ b/MoolahTests/Backup/StoreBackupManagerDefaultLocationTests.swift
@@ -1,0 +1,33 @@
+#if os(macOS)
+  import Foundation
+  import Testing
+
+  @testable import Moolah
+
+  // Serialised because it mutates `URL.moolahApplicationSupportOverride`,
+  // a `nonisolated(unsafe)` static. See URLMoolahStorageTests for the
+  // same pattern.
+  @Suite("StoreBackupManager default location", .serialized)
+  struct StoreBackupManagerDefaultLocationTests {
+    @Test("default backup directory is scoped by CloudKit environment")
+    @MainActor
+    func testDefaultBackupDirectoryIsScoped() throws {
+      let root = FileManager.default.temporaryDirectory
+        .appending(path: UUID().uuidString)
+      try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+      defer { try? FileManager.default.removeItem(at: root) }
+
+      URL.moolahApplicationSupportOverride = root
+      defer { URL.moolahApplicationSupportOverride = nil }
+
+      let manager = StoreBackupManager()
+
+      let envSubdir = CloudKitEnvironment.resolved().storageSubdirectory
+      let expected =
+        root
+        .appending(path: envSubdir)
+        .appending(path: "Moolah/Backups")
+      #expect(manager.testingBackupDirectory.standardizedFileURL == expected.standardizedFileURL)
+    }
+  }
+#endif

--- a/MoolahTests/Shared/CloudKitEnvironmentTests.swift
+++ b/MoolahTests/Shared/CloudKitEnvironmentTests.swift
@@ -1,0 +1,25 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("CloudKitEnvironment")
+struct CloudKitEnvironmentTests {
+  @Test("resolves Development from raw value")
+  func testResolveDevelopment() {
+    let env = CloudKitEnvironment.resolve(from: "Development")
+    #expect(env == .development)
+  }
+
+  @Test("resolves Production from raw value")
+  func testResolveProduction() {
+    let env = CloudKitEnvironment.resolve(from: "Production")
+    #expect(env == .production)
+  }
+
+  @Test("storageSubdirectory matches raw value")
+  func testStorageSubdirectory() {
+    #expect(CloudKitEnvironment.development.storageSubdirectory == "Development")
+    #expect(CloudKitEnvironment.production.storageSubdirectory == "Production")
+  }
+}

--- a/MoolahTests/Shared/URLMoolahStorageTests.swift
+++ b/MoolahTests/Shared/URLMoolahStorageTests.swift
@@ -3,7 +3,10 @@ import Testing
 
 @testable import Moolah
 
-@Suite("URL+MoolahStorage")
+// Serialised because both tests mutate `URL.moolahApplicationSupportOverride`,
+// a `nonisolated(unsafe)` static. Parallel execution would let one test's
+// override leak into the other's assertions.
+@Suite("URL+MoolahStorage", .serialized)
 struct URLMoolahStorageTests {
   @Test("returns <root>/<env>/ with env subdir created")
   func testScopedRootUsesEnvironmentSubdirectory() throws {

--- a/MoolahTests/Shared/URLMoolahStorageTests.swift
+++ b/MoolahTests/Shared/URLMoolahStorageTests.swift
@@ -1,0 +1,33 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("URL+MoolahStorage")
+struct URLMoolahStorageTests {
+  @Test("returns <root>/<env>/ with env subdir created")
+  func testScopedRootUsesEnvironmentSubdirectory() throws {
+    let root = FileManager.default.temporaryDirectory
+      .appending(path: UUID().uuidString)
+    try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    URL.moolahApplicationSupportOverride = root
+    defer { URL.moolahApplicationSupportOverride = nil }
+
+    let scoped = URL.moolahScopedApplicationSupport
+
+    let expected = root.appending(path: CloudKitEnvironment.resolved().storageSubdirectory)
+    #expect(scoped.standardizedFileURL == expected.standardizedFileURL)
+    #expect(FileManager.default.fileExists(atPath: scoped.path()))
+  }
+
+  @Test("falls back to Application Support when no override is set")
+  func testScopedRootDefaultsToApplicationSupport() {
+    URL.moolahApplicationSupportOverride = nil
+    let scoped = URL.moolahScopedApplicationSupport
+    let expectedPrefix = URL.applicationSupportDirectory
+      .appending(path: CloudKitEnvironment.resolved().storageSubdirectory)
+    #expect(scoped.standardizedFileURL == expectedPrefix.standardizedFileURL)
+  }
+}

--- a/Shared/CloudKitEnvironment.swift
+++ b/Shared/CloudKitEnvironment.swift
@@ -8,8 +8,9 @@ enum CloudKitEnvironment: String, Sendable {
   case development = "Development"
   case production = "Production"
 
-  /// Name of the subdirectory under Application Support that this environment
-  /// writes to. Equal to the raw value.
+  /// Filesystem subdirectory name used to segregate on-disk state for this
+  /// environment. Stable across launches so an upgrade of the app reads back
+  /// exactly what the previous run wrote.
   var storageSubdirectory: String { rawValue }
 
   private static let cached: CloudKitEnvironment = {
@@ -36,5 +37,5 @@ enum CloudKitEnvironment: String, Sendable {
     return env
   }
 
-  static let infoPlistKey = "MoolahCloudKitEnvironment"
+  private static let infoPlistKey = "MoolahCloudKitEnvironment"
 }

--- a/Shared/CloudKitEnvironment.swift
+++ b/Shared/CloudKitEnvironment.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+/// The CloudKit environment this build is signed for, as declared in
+/// Info.plist. Resolves once at launch and is the single source of truth for
+/// any code that must separate on-disk state between Development and
+/// Production CloudKit containers.
+enum CloudKitEnvironment: String, Sendable {
+  case development = "Development"
+  case production = "Production"
+
+  /// Name of the subdirectory under Application Support that this environment
+  /// writes to. Equal to the raw value.
+  var storageSubdirectory: String { rawValue }
+
+  private static let cached: CloudKitEnvironment = {
+    resolve(from: Bundle.main.object(forInfoDictionaryKey: Self.infoPlistKey))
+  }()
+
+  /// The CloudKit environment the running process is signed for. Resolves
+  /// from `Bundle.main`'s `MoolahCloudKitEnvironment` Info.plist key once
+  /// per process. Aborts the process via `fatalError` if the key is missing
+  /// or does not match a known environment.
+  static func resolved() -> CloudKitEnvironment { cached }
+
+  /// Testable form of the resolver. Production code uses `resolved()`.
+  static func resolve(from value: Any?) -> CloudKitEnvironment {
+    guard let raw = value as? String, let env = CloudKitEnvironment(rawValue: raw) else {
+      fatalError(
+        """
+        \(infoPlistKey) Info.plist key missing or invalid (got: \
+        \(String(describing: value))). Expected "Development" or "Production". \
+        This build is misconfigured; refusing to start.
+        """
+      )
+    }
+    return env
+  }
+
+  static let infoPlistKey = "MoolahCloudKitEnvironment"
+}

--- a/Shared/ProfileContainerManager.swift
+++ b/Shared/ProfileContainerManager.swift
@@ -31,7 +31,7 @@ final class ProfileContainerManager {
       config = ModelConfiguration(isStoredInMemoryOnly: true)
     } else {
       let storeName = "Moolah-\(profileId.uuidString)"
-      let url = URL.applicationSupportDirectory
+      let url = URL.moolahScopedApplicationSupport
         .appending(path: "Moolah-\(profileId.uuidString).store")
       config = ModelConfiguration(storeName, url: url, cloudKitDatabase: .none)
     }
@@ -53,7 +53,7 @@ final class ProfileContainerManager {
     guard !inMemory else { return }
 
     let basePath = "Moolah-\(profileId.uuidString).store"
-    let baseURL = URL.applicationSupportDirectory.appending(path: basePath)
+    let baseURL = URL.moolahScopedApplicationSupport.appending(path: basePath)
     let fileManager = FileManager.default
     for suffix in ["", "-shm", "-wal"] {
       let url = baseURL.deletingLastPathComponent()
@@ -62,7 +62,7 @@ final class ProfileContainerManager {
     }
 
     // Delete the sync state file
-    let syncStateURL = URL.applicationSupportDirectory
+    let syncStateURL = URL.moolahScopedApplicationSupport
       .appending(path: "Moolah-\(profileId.uuidString).syncstate")
     try? fileManager.removeItem(at: syncStateURL)
 

--- a/Shared/StoreBackupManager.swift
+++ b/Shared/StoreBackupManager.swift
@@ -17,7 +17,8 @@
     }()
 
     init(
-      backupDirectory: URL = URL.applicationSupportDirectory.appending(path: "Moolah/Backups"),
+      backupDirectory: URL = URL.moolahScopedApplicationSupport
+        .appending(path: "Moolah/Backups"),
       retentionDays: Int = 7,
       fileManager: FileManager = .default
     ) {
@@ -91,5 +92,8 @@
         }
       }
     }
+
+    /// Test-only accessor for the configured backup directory. Read-only.
+    var testingBackupDirectory: URL { backupDirectory }
   }
 #endif

--- a/Shared/URL+MoolahStorage.swift
+++ b/Shared/URL+MoolahStorage.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+extension URL {
+  /// Test-only override for the Application Support root. Production code
+  /// should leave this `nil`; tests set it to a temporary directory and reset
+  /// it in a defer block.
+  nonisolated(unsafe) static var moolahApplicationSupportOverride: URL?
+
+  /// Application Support, scoped to the current CloudKit environment.
+  ///
+  /// Use this for any on-disk state tied to a CloudKit container: SwiftData
+  /// stores, sync-state files, `CKSyncEngine` serialisations, nightly
+  /// backups. The subdirectory is created on demand so callers never need to
+  /// guard on its existence.
+  static var moolahScopedApplicationSupport: URL {
+    let root = moolahApplicationSupportOverride ?? URL.applicationSupportDirectory
+    let scoped = root.appending(path: CloudKitEnvironment.resolved().storageSubdirectory)
+    try? FileManager.default.createDirectory(at: scoped, withIntermediateDirectories: true)
+    return scoped
+  }
+}

--- a/fastlane/Moolah.entitlements
+++ b/fastlane/Moolah.entitlements
@@ -6,6 +6,8 @@
   <array><string>iCloud.rocks.moolah.app.v2</string></array>
   <key>com.apple.developer.icloud-services</key>
   <array><string>CloudKit</string></array>
+  <key>com.apple.developer.icloud-container-environment</key>
+  <string>$(CLOUDKIT_ENVIRONMENT)</string>
   <key>com.apple.security.app-sandbox</key>
   <true/>
   <key>com.apple.security.network.client</key>

--- a/plans/2026-04-24-cloudkit-env-storage-split-design.md
+++ b/plans/2026-04-24-cloudkit-env-storage-split-design.md
@@ -1,0 +1,199 @@
+# CloudKit Environment / Storage Split — Design
+
+## Background
+
+CloudKit routes each app build to one of two server environments — **Development** or **Production** — based on the code‑signing context and (optionally) the `com.apple.developer.icloud-container-environment` entitlement. Token state held by `CKSyncEngine` (server change tokens, per‑zone change tokens, pending record changes) and the CK `systemFields` baked into each SwiftData row are valid only against the environment they were negotiated with.
+
+Today the Moolah app:
+
+- Does **not** declare `com.apple.developer.icloud-container-environment`, so CloudKit falls back to code‑signing inference: developer‑signed builds (Xcode Debug, and currently `just install-mac`) hit **Development**; only distribution‑signed TestFlight/App Store builds hit **Production**.
+- Keeps *all* on‑disk state that is tied to a CloudKit container at the Application‑Support root:
+  - `~/Library/Application Support/Moolah-v2.store` (profile index)
+  - `~/Library/Application Support/Moolah-<uuid>.store` (per‑profile SwiftData)
+  - `~/Library/Application Support/Moolah-<uuid>.syncstate` (per‑profile sync state)
+  - `~/Library/Application Support/` sibling files for `SyncCoordinator` serialisation
+  - `~/Library/Application Support/Moolah/Backups/<uuid>/…` (nightly SwiftData snapshots)
+
+The combination is unsafe. If the same Mac ever runs two builds that resolve to different CloudKit environments — e.g. a Debug Xcode run and a TestFlight / App Store / Developer‑ID install — they read and write the same tokens and system fields against different servers. Symptoms: phantom records, silent sync drops, `unknown record` errors, corrupted backups being restored into the wrong environment.
+
+`just install-mac` is intended to mimic outside‑App‑Store distribution (Developer ID signing + notarisation) for the primary macOS channel. The owner wants that binary, once installed into `/Applications`, to hit **Production** CloudKit and to keep its on‑disk state strictly separate from any developer build of the same bundle ID running from Xcode.
+
+## Goal
+
+1. The CloudKit environment each build targets is pinned explicitly and deterministically from `project.yml`, not inferred from the signing context.
+2. `just install-mac` targets **Production** CloudKit. Every other local build (Xcode Debug, `just test`, UI tests) targets **Development** (or runs without iCloud entitlements).
+3. All on‑disk state tied to a CloudKit container (SwiftData stores, sync state files, `SyncCoordinator` serialisations, nightly backups) is scoped to an environment‑specific subdirectory. Under no circumstances can a build signed for one environment read or write state produced by a build signed for the other.
+4. A developer running Xcode Debug on the same Mac that has `/Applications/Moolah.app` installed can use both without cross‑contamination.
+5. Misconfiguration (missing or unexpected `MoolahCloudKitEnvironment` Info.plist value) aborts the process at launch rather than silently selecting a default.
+
+### Acceptance criteria
+
+- `codesign -d --entitlements :- /Applications/Moolah.app` after `just install-mac` contains `com.apple.developer.icloud-container-environment = Production`.
+- The Xcode Debug build (with `ENABLE_ENTITLEMENTS=1 just generate`) signs with `com.apple.developer.icloud-container-environment = Development`.
+- `just test` and `just test-mac` still pass with no iCloud entitlement on the test host (Debug‑Tests unchanged on the entitlements front).
+- On first launch after the change:
+  - `just install-mac` → Production build creates and uses `~/Library/Application Support/Production/…`. The Development subtree, if present, is untouched.
+  - Xcode Debug → Development build creates and uses `~/Library/Application Support/Development/…`. The Production subtree, if present, is untouched.
+  - Any existing files at the Application Support root (`Moolah-v2.store`, `Moolah-<uuid>.store`, `Moolah-<uuid>.syncstate`, `Moolah/Backups/…`) remain untouched — no migration, no deletion.
+- Launching a build whose embedded `MoolahCloudKitEnvironment` is absent, empty, or not one of `Development` / `Production` calls `fatalError(_:)` with a message that names the Info.plist key.
+
+## Non‑goals
+
+- Automated migration of existing root‑level stores into an environment subdirectory. The owner will handle that by hand if/when needed.
+- Touching `fastlane` / TestFlight / App Store pipelines beyond adding the new entitlement key. (Distribution builds already resolve to Production CloudKit today; the entitlement just makes that explicit.)
+- Changing `CODE_SIGN_IDENTITY` defaults. The owner's local `.env` in the main checkout already overrides automatic signing for `just install-mac` with a Developer ID profile. This design assumes that override stays in place.
+- Introducing a third environment (`Staging`, `Test`). Apple only supports `Development` and `Production`; Debug‑Tests uses `Development` as an inert value (it never reaches iCloud because it has no entitlement and runs in‑memory).
+- A debug UI or log line surfacing legacy root‑level files. Owner confirmed: silent is fine.
+
+## Design
+
+### Source of truth: a per‑configuration build setting
+
+Add `CLOUDKIT_ENVIRONMENT` to each configuration block in `project.yml`:
+
+| Configuration | `CLOUDKIT_ENVIRONMENT` | Notes |
+|---|---|---|
+| `Debug` | `Development` | Xcode dev runs (with or without `ENABLE_ENTITLEMENTS=1`). |
+| `Debug-Tests` | `Development` | Value is never read — test host has no iCloud entitlement and uses in‑memory `ModelContainer`. Set only so Info.plist expansion yields a literal string rather than the unexpanded variable. |
+| `Release` | `Production` | Feeds both `just install-mac` (Developer ID signed) and any future fastlane / TestFlight / App Store distribution. |
+
+Xcode build variable expansion then drives both the entitlement and the Info.plist at codesign / bundle time:
+
+- **Entitlements plist** (`.build/Moolah.entitlements` via `scripts/inject-entitlements.sh`, and `fastlane/Moolah.entitlements` for distribution):
+
+  ```xml
+  <key>com.apple.developer.icloud-container-environment</key>
+  <string>$(CLOUDKIT_ENVIRONMENT)</string>
+  ```
+
+  Xcode's entitlements preprocessing expands `$(CLOUDKIT_ENVIRONMENT)` using the target's active configuration at sign time. A Release build signs with `Production`; a Debug build signs with `Development`. Debug‑Tests doesn't get this entitlements file at all (see `scripts/inject-entitlements.sh`), so it remains iCloud‑free.
+
+- **Info.plist** (`App/Info-iOS.plist` and `App/Info-macOS.plist`, both referenced by `project.yml`'s `INFOPLIST_FILE` setting): add
+
+  ```xml
+  <key>MoolahCloudKitEnvironment</key>
+  <string>$(CLOUDKIT_ENVIRONMENT)</string>
+  ```
+
+  Xcode's `INFOPLIST_EXPAND_BUILD_SETTINGS` (default YES) expands `$(CLOUDKIT_ENVIRONMENT)` using the active configuration at bundle time, in the same way existing keys in these plists (`$(EXECUTABLE_NAME)`, `$(PRODUCT_NAME)`, etc.) are already expanded. This value is what Swift code reads at runtime to decide the storage subdirectory.
+
+Because both the entitlement and the Info.plist derive from the same `CLOUDKIT_ENVIRONMENT` build setting, they cannot drift.
+
+### Runtime resolver
+
+New Swift type in `Shared/`:
+
+```swift
+/// The CloudKit environment the current build is signed for, as declared in
+/// Info.plist. Resolves once at launch and is the single source of truth for
+/// any code that must separate state between Development and Production
+/// CloudKit containers.
+enum CloudKitEnvironment: String, Sendable {
+  case development = "Development"
+  case production = "Production"
+
+  /// The `Moolah/Application Support` subdirectory this environment writes to.
+  var storageSubdirectory: String { rawValue }
+
+  /// Resolves from `Bundle.main`'s `MoolahCloudKitEnvironment` Info.plist key.
+  /// Calls `fatalError` if the key is missing, empty, or not one of the
+  /// recognised values — the invariant "dev builds never write to production
+  /// state" depends on this being unambiguous at launch.
+  static func resolved() -> CloudKitEnvironment { … }
+}
+```
+
+`resolved()` reads `Bundle.main.object(forInfoDictionaryKey: "MoolahCloudKitEnvironment")`, coerces to `String`, and matches the raw value. Any deviation (nil, non‑string, unknown string) calls `fatalError` with a message that names the Info.plist key so the cause is obvious from the crash log.
+
+The value is resolved lazily on first access and cached for the process lifetime via a `static let` on `CloudKitEnvironment`. This makes misconfiguration fatal at the first call site rather than silently deferred.
+
+### Storage helper
+
+A single `URL` extension in `Shared/` replaces every production call site that reaches for `URL.applicationSupportDirectory` for CloudKit‑related state:
+
+```swift
+extension URL {
+  /// Application Support, scoped to the current CloudKit environment.
+  /// Use for any on-disk state tied to a CloudKit container: SwiftData stores,
+  /// sync-state files, CKSyncEngine serialisations, nightly backups.
+  /// Creates the subdirectory on demand.
+  static var moolahEnvironmentScopedApplicationSupport: URL { … }
+}
+```
+
+The helper appends `CloudKitEnvironment.resolved().storageSubdirectory` to `URL.applicationSupportDirectory` and ensures the directory exists (creating intermediate directories if needed). `StoreBackupManager` and the tests that inject a custom `backupDirectory` keep their existing injection seam — only the default value changes.
+
+### File‑by‑file change surface
+
+Production code:
+
+- `project.yml` — add `CLOUDKIT_ENVIRONMENT` per configuration (`Debug` / `Debug-Tests` → `Development`, `Release` → `Production`) for both `Moolah_iOS` and `Moolah_macOS` targets.
+- `App/Info-iOS.plist`, `App/Info-macOS.plist` — add `MoolahCloudKitEnvironment` key with value `$(CLOUDKIT_ENVIRONMENT)`.
+- `scripts/inject-entitlements.sh` — extend the entitlements plist to include `com.apple.developer.icloud-container-environment = $(CLOUDKIT_ENVIRONMENT)`.
+- `fastlane/Moolah.entitlements` — add the same entitlement key, value `$(CLOUDKIT_ENVIRONMENT)`. (Distribution builds already target Production; this makes it explicit and matches the in‑tree entitlements file.)
+- `Shared/CloudKitEnvironment.swift` *(new)* — the resolver above.
+- `Shared/URL+MoolahStorage.swift` *(new)* — the storage helper above. Internal test‑only override seam for swapping the Application Support root.
+- `Shared/ProfileContainerManager.swift` — replace `URL.applicationSupportDirectory` at lines 34, 56, 65 with the scoped helper.
+- `App/MoolahApp+Setup.swift` — replace at line 48 (`Moolah-v2.store`).
+- `Backends/CloudKit/Sync/SyncCoordinator.swift` — replace at line 183 (`stateFileURL`).
+- `App/ProfileSession.swift` — replace at line 231 (Application Support directory existence check).
+- `Shared/StoreBackupManager.swift` — change default `backupDirectory` at line 20 to the scoped helper.
+
+Test code:
+
+- `MoolahTests/Shared/CloudKitEnvironmentTests.swift` *(new)* — covers the happy path of the resolver against a synthetic bundle, plus `storageSubdirectory` mapping. Fatal paths are verified by code review + Info.plist wiring, not unit tested (XCTest can't safely assert on `fatalError`).
+- `MoolahTests/Shared/ProfileContainerManagerScopedStorageTests.swift` *(new)* — a file‑system smoke test that asserts a non‑in‑memory `ProfileContainerManager` writes into `<scoped root>/Moolah-<uuid>.store` using a test‑scoped override of the Application Support root.
+- Existing `ProfileContainerManager.forTesting()` tests are unchanged: they use `inMemory: true` and never touch the scoped helper.
+
+No UI test changes expected — UI tests already run with the `Debug-Tests`‑style iCloud‑free test host.
+
+### On‑disk layout after the change
+
+```
+~/Library/Application Support/
+├── Moolah-v2.store              ← orphaned legacy (untouched)
+├── Moolah-<uuid>.store          ← orphaned legacy (untouched)
+├── Moolah-<uuid>.syncstate      ← orphaned legacy (untouched)
+├── Moolah/Backups/              ← orphaned legacy (untouched)
+├── Development/
+│   ├── Moolah-v2.store
+│   ├── Moolah-<uuid>.store
+│   ├── Moolah-<uuid>.syncstate
+│   ├── SyncCoordinator state files
+│   └── Moolah/Backups/<profileId>/…
+└── Production/
+    ├── Moolah-v2.store
+    ├── Moolah-<uuid>.store
+    ├── Moolah-<uuid>.syncstate
+    ├── SyncCoordinator state files
+    └── Moolah/Backups/<profileId>/…
+```
+
+Both subtrees only appear once their respective build has run at least once on the machine.
+
+### Error handling / misconfiguration
+
+One mode matters: the embedded `MoolahCloudKitEnvironment` is missing, empty, or unknown. `CloudKitEnvironment.resolved()` calls `fatalError(_:)` with a message of the form:
+
+> `MoolahCloudKitEnvironment Info.plist key missing or invalid (got: "<raw>"). Expected "Development" or "Production". This build is misconfigured; refusing to start.`
+
+Rationale: the alternative — falling back to a default — would make it possible for a build that *thinks* it's Development to write into Production's subdirectory, defeating the entire point of the split. Fatal at launch is consistent with the "dev builds never touch production data" invariant and is easy to diagnose from the crash log.
+
+There is no Swift‑side check that the embedded environment matches the entitlement; they derive from the same `CLOUDKIT_ENVIRONMENT` build setting and cannot disagree without someone editing the built bundle by hand. The runtime check against Info.plist is sufficient.
+
+## Testing
+
+- **Unit**: `CloudKitEnvironmentTests` — resolver happy path for both values, `storageSubdirectory` mapping.
+- **Integration**: `ProfileContainerManagerScopedStorageTests` — `ProfileContainerManager.container(for:)` on a non‑in‑memory instance, with the Application Support root overridden to a temp directory, writes `Moolah-<uuid>.store` under `<tmp>/Development/`.
+- **Existing contract / store tests**: no change required. Tests build under `Debug-Tests`, the new `CLOUDKIT_ENVIRONMENT=Development` build setting feeds into the test host's Info.plist at build time, and the resolver returns `.development` — but the only code path that consumes it (`moolahEnvironmentScopedApplicationSupport`) isn't exercised by tests that use `inMemory: true` stores.
+- **Manual verification** (one‑shot):
+  1. `ENABLE_ENTITLEMENTS=1 just generate`, run from Xcode → confirm `~/Library/Application Support/Development/` populates; Production subtree is absent or untouched.
+  2. `just install-mac`, launch `/Applications/Moolah.app` → confirm `~/Library/Application Support/Production/` populates; Development subtree untouched.
+  3. `codesign -d --entitlements :- /Applications/Moolah.app` → confirm `com.apple.developer.icloud-container-environment = Production`.
+  4. CloudKit dashboard → confirm records written by (1) appear in the Development container and records written by (2) appear in Production.
+
+## Rollout
+
+- Single PR. The build‑system changes and the runtime scoping are inseparable — landing one without the other either leaves `install-mac` pointing at Development CloudKit (no improvement) or writes Production state into the shared root (the corruption case we're preventing).
+- Existing local stores at `~/Library/Application Support/Moolah-*.store` are left untouched. The owner handles any manual migration post‑merge; no code in this change touches those paths.
+- No database schema change; no CloudKit schema change; no network‑side coordination required.

--- a/plans/2026-04-24-cloudkit-env-storage-split-design.md
+++ b/plans/2026-04-24-cloudkit-env-storage-split-design.md
@@ -117,7 +117,7 @@ extension URL {
   /// Use for any on-disk state tied to a CloudKit container: SwiftData stores,
   /// sync-state files, CKSyncEngine serialisations, nightly backups.
   /// Creates the subdirectory on demand.
-  static var moolahEnvironmentScopedApplicationSupport: URL { … }
+  static var moolahScopedApplicationSupport: URL { … }
 }
 ```
 
@@ -185,7 +185,7 @@ There is no Swift‑side check that the embedded environment matches the entitle
 
 - **Unit**: `CloudKitEnvironmentTests` — resolver happy path for both values, `storageSubdirectory` mapping.
 - **Integration**: `ProfileContainerManagerScopedStorageTests` — `ProfileContainerManager.container(for:)` on a non‑in‑memory instance, with the Application Support root overridden to a temp directory, writes `Moolah-<uuid>.store` under `<tmp>/Development/`.
-- **Existing contract / store tests**: no change required. Tests build under `Debug-Tests`, the new `CLOUDKIT_ENVIRONMENT=Development` build setting feeds into the test host's Info.plist at build time, and the resolver returns `.development` — but the only code path that consumes it (`moolahEnvironmentScopedApplicationSupport`) isn't exercised by tests that use `inMemory: true` stores.
+- **Existing contract / store tests**: no change required. Tests build under `Debug-Tests`, the new `CLOUDKIT_ENVIRONMENT=Development` build setting feeds into the test host's Info.plist at build time, and the resolver returns `.development` — but the only code path that consumes it (`moolahScopedApplicationSupport`) isn't exercised by tests that use `inMemory: true` stores.
 - **Manual verification** (one‑shot):
   1. `ENABLE_ENTITLEMENTS=1 just generate`, run from Xcode → confirm `~/Library/Application Support/Development/` populates; Production subtree is absent or untouched.
   2. `just install-mac`, launch `/Applications/Moolah.app` → confirm `~/Library/Application Support/Production/` populates; Development subtree untouched.

--- a/plans/2026-04-24-cloudkit-env-storage-split-implementation.md
+++ b/plans/2026-04-24-cloudkit-env-storage-split-implementation.md
@@ -4,7 +4,7 @@
 
 **Goal:** Pin each build's CloudKit environment explicitly via a per‑configuration `CLOUDKIT_ENVIRONMENT` build setting, expose it in the entitlement and Info.plist, and scope every piece of on‑disk state tied to a CloudKit container into a `Development/` or `Production/` subdirectory of Application Support.
 
-**Architecture:** Single source of truth — the `CLOUDKIT_ENVIRONMENT` build setting — drives both `com.apple.developer.icloud-container-environment` (entitlement) and `MoolahCloudKitEnvironment` (Info.plist). Swift code reads the Info.plist value through a new `CloudKitEnvironment` resolver and uses a `URL.moolahEnvironmentScopedApplicationSupport` helper for all CloudKit‑related on‑disk state. Missing or malformed Info.plist value aborts launch via `fatalError`.
+**Architecture:** Single source of truth — the `CLOUDKIT_ENVIRONMENT` build setting — drives both `com.apple.developer.icloud-container-environment` (entitlement) and `MoolahCloudKitEnvironment` (Info.plist). Swift code reads the Info.plist value through a new `CloudKitEnvironment` resolver and uses a `URL.moolahScopedApplicationSupport` helper for all CloudKit‑related on‑disk state. Missing or malformed Info.plist value aborts launch via `fatalError`.
 
 **Tech Stack:** Swift 6, Swift Testing (`@Suite`, `@Test`, `#expect`), SwiftData, `xcodegen` (`just generate`). Build via `just build-mac`, test via `just test-mac`. Pre‑commit: `just format` then `just format-check`.
 
@@ -341,7 +341,7 @@
 
 ---
 
-## Task 4: Add `URL.moolahEnvironmentScopedApplicationSupport` helper + test override (TDD)
+## Task 4: Add `URL.moolahScopedApplicationSupport` helper + test override (TDD)
 
 **Files:**
 - Create: `Shared/URL+MoolahStorage.swift`
@@ -369,7 +369,7 @@
       URL.moolahApplicationSupportOverride = root
       defer { URL.moolahApplicationSupportOverride = nil }
 
-      let scoped = URL.moolahEnvironmentScopedApplicationSupport
+      let scoped = URL.moolahScopedApplicationSupport
 
       let expected = root.appending(path: CloudKitEnvironment.resolved().storageSubdirectory)
       #expect(scoped.standardizedFileURL == expected.standardizedFileURL)
@@ -379,7 +379,7 @@
     @Test("falls back to Application Support when no override is set")
     func testScopedRootDefaultsToApplicationSupport() {
       URL.moolahApplicationSupportOverride = nil
-      let scoped = URL.moolahEnvironmentScopedApplicationSupport
+      let scoped = URL.moolahScopedApplicationSupport
       let expectedPrefix = URL.applicationSupportDirectory
         .appending(path: CloudKitEnvironment.resolved().storageSubdirectory)
       #expect(scoped.standardizedFileURL == expectedPrefix.standardizedFileURL)
@@ -393,7 +393,7 @@
   just test-mac URLMoolahStorageTests 2>&1 | tee .agent-tmp/test-output.txt | tail -20
   ```
 
-  Expected: compile error for missing `moolahApplicationSupportOverride` and `moolahEnvironmentScopedApplicationSupport`.
+  Expected: compile error for missing `moolahApplicationSupportOverride` and `moolahScopedApplicationSupport`.
 
 - [ ] **Step 3: Create the helper**
 
@@ -414,7 +414,7 @@
     /// stores, sync-state files, `CKSyncEngine` serialisations, nightly
     /// backups. The subdirectory is created on demand so callers never need to
     /// guard on its existence.
-    static var moolahEnvironmentScopedApplicationSupport: URL {
+    static var moolahScopedApplicationSupport: URL {
       let root = moolahApplicationSupportOverride ?? URL.applicationSupportDirectory
       let scoped = root.appending(path: CloudKitEnvironment.resolved().storageSubdirectory)
       try? FileManager.default.createDirectory(at: scoped, withIntermediateDirectories: true)
@@ -530,7 +530,7 @@
 
   ```swift
         let storeName = "Moolah-\(profileId.uuidString)"
-        let url = URL.moolahEnvironmentScopedApplicationSupport
+        let url = URL.moolahScopedApplicationSupport
           .appending(path: "Moolah-\(profileId.uuidString).store")
         config = ModelConfiguration(storeName, url: url, cloudKitDatabase: .none)
   ```
@@ -546,7 +546,7 @@
 
   ```swift
       let basePath = "Moolah-\(profileId.uuidString).store"
-      let baseURL = URL.moolahEnvironmentScopedApplicationSupport.appending(path: basePath)
+      let baseURL = URL.moolahScopedApplicationSupport.appending(path: basePath)
   ```
 
   Line 64–66 (also inside `deleteStore(for:)`), replace:
@@ -561,7 +561,7 @@
 
   ```swift
       // Delete the sync state file
-      let syncStateURL = URL.moolahEnvironmentScopedApplicationSupport
+      let syncStateURL = URL.moolahScopedApplicationSupport
         .appending(path: "Moolah-\(profileId.uuidString).syncstate")
   ```
 
@@ -609,7 +609,7 @@
   Replace with:
 
   ```swift
-        let profileStoreURL = URL.moolahEnvironmentScopedApplicationSupport
+        let profileStoreURL = URL.moolahScopedApplicationSupport
           .appending(path: "Moolah-v2.store")
   ```
 
@@ -649,7 +649,7 @@
   with:
 
   ```swift
-    let stateFileURL = URL.moolahEnvironmentScopedApplicationSupport
+    let stateFileURL = URL.moolahScopedApplicationSupport
       .appending(path: "Moolah-v2-sync.syncstate")
   ```
 
@@ -705,7 +705,7 @@ Context: `importStagingDirectory(for:)` returns `<ApplicationSupport>/Moolah/csv
 
   ```swift
     nonisolated static func importStagingDirectory(for profileId: UUID) -> URL {
-      URL.moolahEnvironmentScopedApplicationSupport
+      URL.moolahScopedApplicationSupport
         .appendingPathComponent("Moolah", isDirectory: true)
         .appendingPathComponent("csv-staging", isDirectory: true)
         .appendingPathComponent(profileId.uuidString, isDirectory: true)
@@ -814,7 +814,7 @@ Context: `importStagingDirectory(for:)` returns `<ApplicationSupport>/Moolah/csv
 
   ```swift
       init(
-        backupDirectory: URL = URL.moolahEnvironmentScopedApplicationSupport
+        backupDirectory: URL = URL.moolahScopedApplicationSupport
           .appending(path: "Moolah/Backups"),
   ```
 

--- a/plans/2026-04-24-cloudkit-env-storage-split-implementation.md
+++ b/plans/2026-04-24-cloudkit-env-storage-split-implementation.md
@@ -1,0 +1,934 @@
+# CloudKit Environment / Storage Split — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Pin each build's CloudKit environment explicitly via a per‑configuration `CLOUDKIT_ENVIRONMENT` build setting, expose it in the entitlement and Info.plist, and scope every piece of on‑disk state tied to a CloudKit container into a `Development/` or `Production/` subdirectory of Application Support.
+
+**Architecture:** Single source of truth — the `CLOUDKIT_ENVIRONMENT` build setting — drives both `com.apple.developer.icloud-container-environment` (entitlement) and `MoolahCloudKitEnvironment` (Info.plist). Swift code reads the Info.plist value through a new `CloudKitEnvironment` resolver and uses a `URL.moolahEnvironmentScopedApplicationSupport` helper for all CloudKit‑related on‑disk state. Missing or malformed Info.plist value aborts launch via `fatalError`.
+
+**Tech Stack:** Swift 6, Swift Testing (`@Suite`, `@Test`, `#expect`), SwiftData, `xcodegen` (`just generate`). Build via `just build-mac`, test via `just test-mac`. Pre‑commit: `just format` then `just format-check`.
+
+**Spec:** `plans/2026-04-24-cloudkit-env-storage-split-design.md`.
+
+**Ordering rationale:** Build‑setting / Info.plist / entitlement wiring (Tasks 1–2) lands first and has no runtime effect. The Swift resolver and helper (Tasks 3–4) are introduced next with unit tests that don't read real bundles, so they also cause no launch‑time behaviour change. Only Tasks 5–9 switch production call sites to the helper — at which point the resolver reads the Info.plist key that was already wired in Task 1. This ordering means each intermediate commit is safe to run.
+
+---
+
+## Task 1: Wire `CLOUDKIT_ENVIRONMENT` build setting + `MoolahCloudKitEnvironment` Info.plist key
+
+**Files:**
+- Modify: `project.yml` (configs blocks for `Moolah_iOS` and `Moolah_macOS`)
+- Modify: `App/Info-iOS.plist`
+- Modify: `App/Info-macOS.plist`
+
+- [ ] **Step 1: Add `CLOUDKIT_ENVIRONMENT` per configuration to `Moolah_iOS`**
+
+  In `project.yml`, locate the `Moolah_iOS` target's `configs:` block (currently under `settings.configs:` around line 72). Replace:
+
+  ```yaml
+        configs:
+          Debug-Tests:
+            # Tests must never pick up iCloud entitlements, even when a dev
+            # runs `ENABLE_ENTITLEMENTS=1 just generate` to inject them into Debug.
+            CODE_SIGN_ENTITLEMENTS: ""
+            SWIFT_ACTIVE_COMPILATION_CONDITIONS: "$(inherited)"
+          Release:
+            SWIFT_ACTIVE_COMPILATION_CONDITIONS: "$(inherited) CLOUDKIT_ENABLED"
+  ```
+
+  with:
+
+  ```yaml
+        configs:
+          Debug:
+            CLOUDKIT_ENVIRONMENT: Development
+          Debug-Tests:
+            # Tests must never pick up iCloud entitlements, even when a dev
+            # runs `ENABLE_ENTITLEMENTS=1 just generate` to inject them into Debug.
+            CODE_SIGN_ENTITLEMENTS: ""
+            SWIFT_ACTIVE_COMPILATION_CONDITIONS: "$(inherited)"
+            # Value is unused at runtime (test host has no iCloud entitlement
+            # and uses in-memory stores) but must be defined so Info.plist
+            # expansion yields a literal string rather than "$(CLOUDKIT_ENVIRONMENT)".
+            CLOUDKIT_ENVIRONMENT: Development
+          Release:
+            SWIFT_ACTIVE_COMPILATION_CONDITIONS: "$(inherited) CLOUDKIT_ENABLED"
+            CLOUDKIT_ENVIRONMENT: Production
+  ```
+
+- [ ] **Step 2: Add `CLOUDKIT_ENVIRONMENT` per configuration to `Moolah_macOS`**
+
+  Same change in the `Moolah_macOS` target's `configs:` block (around line 103). The macOS Release block additionally has `ENABLE_HARDENED_RUNTIME: YES`; keep it. Final form:
+
+  ```yaml
+        configs:
+          Debug:
+            CLOUDKIT_ENVIRONMENT: Development
+          Debug-Tests:
+            CODE_SIGN_ENTITLEMENTS: ""
+            SWIFT_ACTIVE_COMPILATION_CONDITIONS: "$(inherited)"
+            CLOUDKIT_ENVIRONMENT: Development
+          Release:
+            ENABLE_HARDENED_RUNTIME: YES
+            SWIFT_ACTIVE_COMPILATION_CONDITIONS: "$(inherited) CLOUDKIT_ENABLED"
+            CLOUDKIT_ENVIRONMENT: Production
+  ```
+
+- [ ] **Step 3: Add `MoolahCloudKitEnvironment` key to `App/Info-iOS.plist`**
+
+  Insert immediately before the closing `</dict>` of the top-level dictionary:
+
+  ```xml
+  	<key>MoolahCloudKitEnvironment</key>
+  	<string>$(CLOUDKIT_ENVIRONMENT)</string>
+  ```
+
+- [ ] **Step 4: Add `MoolahCloudKitEnvironment` key to `App/Info-macOS.plist`**
+
+  Insert the same two lines in `App/Info-macOS.plist` immediately before the closing `</dict>` of the top-level dictionary.
+
+- [ ] **Step 5: Regenerate Xcode project**
+
+  ```bash
+  just generate
+  ```
+
+  Expected: completes without error; no diff in `Moolah.xcodeproj` tracked state (the project is gitignored).
+
+- [ ] **Step 6: Verify the build setting is defined for each configuration**
+
+  ```bash
+  xcodebuild -showBuildSettings -project Moolah.xcodeproj -target Moolah_macOS -configuration Release 2>/dev/null | grep -E "^\s*CLOUDKIT_ENVIRONMENT = "
+  xcodebuild -showBuildSettings -project Moolah.xcodeproj -target Moolah_macOS -configuration Debug 2>/dev/null | grep -E "^\s*CLOUDKIT_ENVIRONMENT = "
+  xcodebuild -showBuildSettings -project Moolah.xcodeproj -target Moolah_macOS -configuration Debug-Tests 2>/dev/null | grep -E "^\s*CLOUDKIT_ENVIRONMENT = "
+  ```
+
+  Expected output (one line per command):
+
+  ```
+      CLOUDKIT_ENVIRONMENT = Production
+      CLOUDKIT_ENVIRONMENT = Development
+      CLOUDKIT_ENVIRONMENT = Development
+  ```
+
+- [ ] **Step 7: Build macOS and verify Info.plist expansion**
+
+  ```bash
+  just build-mac 2>&1 | tail -5
+  /usr/libexec/PlistBuddy -c "Print :MoolahCloudKitEnvironment" build/Build/Products/Debug/Moolah.app/Contents/Info.plist
+  ```
+
+  Expected: build succeeds; second command prints `Development`.
+
+- [ ] **Step 8: Commit**
+
+  ```bash
+  git add project.yml App/Info-iOS.plist App/Info-macOS.plist
+  git commit -m "build: declare CLOUDKIT_ENVIRONMENT per configuration"
+  ```
+
+---
+
+## Task 2: Declare `com.apple.developer.icloud-container-environment` in both entitlement sources
+
+**Files:**
+- Modify: `scripts/inject-entitlements.sh` (heredoc writing `.build/Moolah.entitlements`)
+- Modify: `fastlane/Moolah.entitlements`
+
+- [ ] **Step 1: Extend the entitlements heredoc in `scripts/inject-entitlements.sh`**
+
+  Replace the current heredoc body (lines 25–46, the `PLIST` heredoc) with the version that adds one new key:
+
+  ```bash
+  cat > "$ENTITLEMENTS_FILE" <<'PLIST'
+  <?xml version="1.0" encoding="UTF-8"?>
+  <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+  <plist version="1.0">
+  <dict>
+      <key>com.apple.security.app-sandbox</key>
+      <true/>
+      <key>com.apple.security.network.client</key>
+      <true/>
+      <key>com.apple.security.files.user-selected.read-write</key>
+      <true/>
+      <key>com.apple.developer.icloud-services</key>
+      <array>
+          <string>CloudKit</string>
+      </array>
+      <key>com.apple.developer.icloud-container-identifiers</key>
+      <array>
+          <string>iCloud.rocks.moolah.app.v2</string>
+      </array>
+      <key>com.apple.developer.icloud-container-environment</key>
+      <string>$(CLOUDKIT_ENVIRONMENT)</string>
+  </dict>
+  </plist>
+  PLIST
+  ```
+
+  The `$(CLOUDKIT_ENVIRONMENT)` token is a build variable, not a shell variable: the single‑quoted heredoc (`<<'PLIST'`) preserves it literally so Xcode's entitlements preprocessing expands it at codesign time.
+
+- [ ] **Step 2: Extend `fastlane/Moolah.entitlements`**
+
+  Replace its contents with:
+
+  ```xml
+  <?xml version="1.0" encoding="UTF-8"?>
+  <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+  <plist version="1.0">
+  <dict>
+    <key>com.apple.developer.icloud-container-identifiers</key>
+    <array><string>iCloud.rocks.moolah.app.v2</string></array>
+    <key>com.apple.developer.icloud-services</key>
+    <array><string>CloudKit</string></array>
+    <key>com.apple.developer.icloud-container-environment</key>
+    <string>$(CLOUDKIT_ENVIRONMENT)</string>
+    <key>com.apple.security.app-sandbox</key>
+    <true/>
+    <key>com.apple.security.network.client</key>
+    <true/>
+  </dict>
+  </plist>
+  ```
+
+- [ ] **Step 3: Regenerate with entitlements and verify the script's output plist**
+
+  ```bash
+  ENABLE_ENTITLEMENTS=1 just generate
+  /usr/libexec/PlistBuddy -c "Print :com.apple.developer.icloud-container-environment" .build/Moolah.entitlements
+  ```
+
+  Expected: second command prints `$(CLOUDKIT_ENVIRONMENT)` literally (the token is expanded later, at codesign time — not here).
+
+- [ ] **Step 4: Build and verify the signed binary's entitlements**
+
+  ```bash
+  ENABLE_ENTITLEMENTS=1 just generate
+  xcodebuild build -scheme Moolah-macOS -destination 'platform=macOS' -configuration Debug -derivedDataPath .build-debug 2>&1 | tail -5
+  codesign -d --entitlements :- .build-debug/Build/Products/Debug/Moolah.app 2>/dev/null | grep -A1 "icloud-container-environment"
+  ```
+
+  Expected: last command prints an element whose string value is `Development`.
+
+  Clean up: `rm -rf .build-debug`.
+
+- [ ] **Step 5: Commit**
+
+  ```bash
+  git add scripts/inject-entitlements.sh fastlane/Moolah.entitlements
+  git commit -m "build: declare iCloud container environment in entitlements"
+  ```
+
+---
+
+## Task 3: Add `CloudKitEnvironment` resolver (TDD)
+
+**Files:**
+- Create: `Shared/CloudKitEnvironment.swift`
+- Create: `MoolahTests/Shared/CloudKitEnvironmentTests.swift`
+
+- [ ] **Step 1: Write the failing tests**
+
+  Create `MoolahTests/Shared/CloudKitEnvironmentTests.swift`:
+
+  ```swift
+  import Foundation
+  import Testing
+
+  @testable import Moolah
+
+  @Suite("CloudKitEnvironment")
+  struct CloudKitEnvironmentTests {
+    @Test("resolves Development from raw value")
+    func testResolveDevelopment() {
+      let env = CloudKitEnvironment.resolve(from: "Development")
+      #expect(env == .development)
+    }
+
+    @Test("resolves Production from raw value")
+    func testResolveProduction() {
+      let env = CloudKitEnvironment.resolve(from: "Production")
+      #expect(env == .production)
+    }
+
+    @Test("storageSubdirectory matches raw value")
+    func testStorageSubdirectory() {
+      #expect(CloudKitEnvironment.development.storageSubdirectory == "Development")
+      #expect(CloudKitEnvironment.production.storageSubdirectory == "Production")
+    }
+  }
+  ```
+
+- [ ] **Step 2: Run the test and confirm it fails to compile**
+
+  ```bash
+  mkdir -p .agent-tmp
+  just test-mac CloudKitEnvironmentTests 2>&1 | tee .agent-tmp/test-output.txt | tail -20
+  ```
+
+  Expected: compile error referencing missing `CloudKitEnvironment`.
+
+- [ ] **Step 3: Create the resolver**
+
+  Create `Shared/CloudKitEnvironment.swift`:
+
+  ```swift
+  import Foundation
+
+  /// The CloudKit environment this build is signed for, as declared in
+  /// Info.plist. Resolves once at launch and is the single source of truth for
+  /// any code that must separate on-disk state between Development and
+  /// Production CloudKit containers.
+  enum CloudKitEnvironment: String, Sendable {
+    case development = "Development"
+    case production = "Production"
+
+    /// Name of the subdirectory under Application Support that this environment
+    /// writes to. Equal to the raw value.
+    var storageSubdirectory: String { rawValue }
+
+    private static let cached: CloudKitEnvironment = {
+      resolve(from: Bundle.main.object(forInfoDictionaryKey: Self.infoPlistKey))
+    }()
+
+    /// The CloudKit environment the running process is signed for. Resolves
+    /// from `Bundle.main`'s `MoolahCloudKitEnvironment` Info.plist key once
+    /// per process. Aborts the process via `fatalError` if the key is missing
+    /// or does not match a known environment.
+    static func resolved() -> CloudKitEnvironment { cached }
+
+    /// Testable form of the resolver. Production code uses `resolved()`.
+    static func resolve(from value: Any?) -> CloudKitEnvironment {
+      guard let raw = value as? String, let env = CloudKitEnvironment(rawValue: raw) else {
+        fatalError(
+          """
+          \(infoPlistKey) Info.plist key missing or invalid (got: \
+          \(String(describing: value))). Expected "Development" or "Production". \
+          This build is misconfigured; refusing to start.
+          """
+        )
+      }
+      return env
+    }
+
+    static let infoPlistKey = "MoolahCloudKitEnvironment"
+  }
+  ```
+
+- [ ] **Step 4: Run the tests and confirm they pass**
+
+  ```bash
+  just test-mac CloudKitEnvironmentTests 2>&1 | tee .agent-tmp/test-output.txt | tail -20
+  ```
+
+  Expected: 3 tests passing.
+
+- [ ] **Step 5: Format and commit**
+
+  ```bash
+  just format
+  just format-check
+  git add Shared/CloudKitEnvironment.swift MoolahTests/Shared/CloudKitEnvironmentTests.swift
+  git commit -m "feat(cloudkit): add CloudKitEnvironment resolver"
+  rm -f .agent-tmp/test-output.txt
+  ```
+
+  `MoolahTests/Shared/` is new — `xcodegen` picks it up automatically via the target's `- path: MoolahTests` source entry. Regenerate if Xcode complains:
+
+  ```bash
+  just generate
+  ```
+
+---
+
+## Task 4: Add `URL.moolahEnvironmentScopedApplicationSupport` helper + test override (TDD)
+
+**Files:**
+- Create: `Shared/URL+MoolahStorage.swift`
+- Create: `MoolahTests/Shared/URLMoolahStorageTests.swift`
+
+- [ ] **Step 1: Write the failing tests**
+
+  Create `MoolahTests/Shared/URLMoolahStorageTests.swift`:
+
+  ```swift
+  import Foundation
+  import Testing
+
+  @testable import Moolah
+
+  @Suite("URL+MoolahStorage")
+  struct URLMoolahStorageTests {
+    @Test("returns <root>/<env>/ with env subdir created")
+    func testScopedRootUsesEnvironmentSubdirectory() throws {
+      let root = FileManager.default.temporaryDirectory
+        .appending(path: UUID().uuidString)
+      try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+      defer { try? FileManager.default.removeItem(at: root) }
+
+      URL.moolahApplicationSupportOverride = root
+      defer { URL.moolahApplicationSupportOverride = nil }
+
+      let scoped = URL.moolahEnvironmentScopedApplicationSupport
+
+      let expected = root.appending(path: CloudKitEnvironment.resolved().storageSubdirectory)
+      #expect(scoped.standardizedFileURL == expected.standardizedFileURL)
+      #expect(FileManager.default.fileExists(atPath: scoped.path()))
+    }
+
+    @Test("falls back to Application Support when no override is set")
+    func testScopedRootDefaultsToApplicationSupport() {
+      URL.moolahApplicationSupportOverride = nil
+      let scoped = URL.moolahEnvironmentScopedApplicationSupport
+      let expectedPrefix = URL.applicationSupportDirectory
+        .appending(path: CloudKitEnvironment.resolved().storageSubdirectory)
+      #expect(scoped.standardizedFileURL == expectedPrefix.standardizedFileURL)
+    }
+  }
+  ```
+
+- [ ] **Step 2: Run and confirm it fails to compile**
+
+  ```bash
+  just test-mac URLMoolahStorageTests 2>&1 | tee .agent-tmp/test-output.txt | tail -20
+  ```
+
+  Expected: compile error for missing `moolahApplicationSupportOverride` and `moolahEnvironmentScopedApplicationSupport`.
+
+- [ ] **Step 3: Create the helper**
+
+  Create `Shared/URL+MoolahStorage.swift`:
+
+  ```swift
+  import Foundation
+
+  extension URL {
+    /// Test-only override for the Application Support root. Production code
+    /// should leave this `nil`; tests set it to a temporary directory and reset
+    /// it in a defer block.
+    nonisolated(unsafe) static var moolahApplicationSupportOverride: URL?
+
+    /// Application Support, scoped to the current CloudKit environment.
+    ///
+    /// Use this for any on-disk state tied to a CloudKit container: SwiftData
+    /// stores, sync-state files, `CKSyncEngine` serialisations, nightly
+    /// backups. The subdirectory is created on demand so callers never need to
+    /// guard on its existence.
+    static var moolahEnvironmentScopedApplicationSupport: URL {
+      let root = moolahApplicationSupportOverride ?? URL.applicationSupportDirectory
+      let scoped = root.appending(path: CloudKitEnvironment.resolved().storageSubdirectory)
+      try? FileManager.default.createDirectory(at: scoped, withIntermediateDirectories: true)
+      return scoped
+    }
+  }
+  ```
+
+- [ ] **Step 4: Run the tests and confirm they pass**
+
+  ```bash
+  just test-mac URLMoolahStorageTests 2>&1 | tee .agent-tmp/test-output.txt | tail -20
+  ```
+
+  Expected: 2 tests passing.
+
+- [ ] **Step 5: Format and commit**
+
+  ```bash
+  just format
+  just format-check
+  git add Shared/URL+MoolahStorage.swift MoolahTests/Shared/URLMoolahStorageTests.swift
+  git commit -m "feat(cloudkit): add environment-scoped Application Support helper"
+  rm -f .agent-tmp/test-output.txt
+  ```
+
+---
+
+## Task 5: Route `ProfileContainerManager` through the scoped helper (TDD)
+
+**Files:**
+- Modify: `Shared/ProfileContainerManager.swift` (lines 34, 56, 65)
+- Modify: `MoolahTests/App/ProfileContainerManagerTests.swift` (add one new test)
+
+- [ ] **Step 1: Add the failing test**
+
+  Append inside `MoolahTests/App/ProfileContainerManagerTests.swift`'s `ProfileContainerManagerTests` struct (after `testDeleteStore`):
+
+  ```swift
+    @Test("configures per-profile store URL under the scoped Application Support root")
+    @MainActor
+    func testContainerUsesScopedStoreURL() throws {
+      let root = FileManager.default.temporaryDirectory
+        .appending(path: UUID().uuidString)
+      try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+      defer { try? FileManager.default.removeItem(at: root) }
+
+      URL.moolahApplicationSupportOverride = root
+      defer { URL.moolahApplicationSupportOverride = nil }
+
+      let indexSchema = Schema([ProfileRecord.self])
+      let indexConfig = ModelConfiguration(isStoredInMemoryOnly: true)
+      let indexContainer = try ModelContainer(for: indexSchema, configurations: [indexConfig])
+      let dataSchema = Schema([
+        AccountRecord.self,
+        TransactionRecord.self,
+        TransactionLegRecord.self,
+        InstrumentRecord.self,
+        CategoryRecord.self,
+        EarmarkRecord.self,
+        EarmarkBudgetItemRecord.self,
+        InvestmentValueRecord.self,
+        CSVImportProfileRecord.self,
+        ImportRuleRecord.self,
+      ])
+
+      let manager = ProfileContainerManager(
+        indexContainer: indexContainer,
+        dataSchema: dataSchema,
+        inMemory: false
+      )
+
+      let profileId = UUID()
+      let container = try manager.container(for: profileId)
+
+      let envSubdir = CloudKitEnvironment.resolved().storageSubdirectory
+      let expectedStore = root
+        .appending(path: envSubdir)
+        .appending(path: "Moolah-\(profileId.uuidString).store")
+      let actualURL = container.configurations.first?.url
+      #expect(actualURL?.standardizedFileURL == expectedStore.standardizedFileURL)
+
+      // Env subdir must have been created on demand by the scoped helper.
+      let envDir = root.appending(path: envSubdir)
+      #expect(FileManager.default.fileExists(atPath: envDir.path()))
+    }
+  ```
+
+  (Asserting on `container.configurations.first?.url` rather than checking for the `.store` file on disk keeps the test deterministic — SwiftData may lazily materialise the store file until the first fetch / save.)
+
+- [ ] **Step 2: Run the test and confirm it fails**
+
+  ```bash
+  just test-mac ProfileContainerManagerTests/testContainerUsesScopedStoreURL 2>&1 | tee .agent-tmp/test-output.txt | tail -20
+  ```
+
+  Expected: failure — `container.configurations.first?.url` still points at the real `URL.applicationSupportDirectory`'s `Moolah-<uuid>.store`, which won't equal `<root>/<env>/Moolah-<uuid>.store`.
+
+- [ ] **Step 3: Replace the three `URL.applicationSupportDirectory` call sites in `ProfileContainerManager`**
+
+  In `Shared/ProfileContainerManager.swift`:
+
+  Line 33–36 (inside `container(for:)`), replace:
+
+  ```swift
+        let storeName = "Moolah-\(profileId.uuidString)"
+        let url = URL.applicationSupportDirectory
+          .appending(path: "Moolah-\(profileId.uuidString).store")
+        config = ModelConfiguration(storeName, url: url, cloudKitDatabase: .none)
+  ```
+
+  with:
+
+  ```swift
+        let storeName = "Moolah-\(profileId.uuidString)"
+        let url = URL.moolahEnvironmentScopedApplicationSupport
+          .appending(path: "Moolah-\(profileId.uuidString).store")
+        config = ModelConfiguration(storeName, url: url, cloudKitDatabase: .none)
+  ```
+
+  Line 55–56 (inside `deleteStore(for:)`), replace:
+
+  ```swift
+      let basePath = "Moolah-\(profileId.uuidString).store"
+      let baseURL = URL.applicationSupportDirectory.appending(path: basePath)
+  ```
+
+  with:
+
+  ```swift
+      let basePath = "Moolah-\(profileId.uuidString).store"
+      let baseURL = URL.moolahEnvironmentScopedApplicationSupport.appending(path: basePath)
+  ```
+
+  Line 64–66 (also inside `deleteStore(for:)`), replace:
+
+  ```swift
+      // Delete the sync state file
+      let syncStateURL = URL.applicationSupportDirectory
+        .appending(path: "Moolah-\(profileId.uuidString).syncstate")
+  ```
+
+  with:
+
+  ```swift
+      // Delete the sync state file
+      let syncStateURL = URL.moolahEnvironmentScopedApplicationSupport
+        .appending(path: "Moolah-\(profileId.uuidString).syncstate")
+  ```
+
+- [ ] **Step 4: Run the new test and confirm it passes**
+
+  ```bash
+  just test-mac ProfileContainerManagerTests/testContainerUsesScopedStoreURL 2>&1 | tee .agent-tmp/test-output.txt | tail -20
+  ```
+
+  Expected: PASS.
+
+- [ ] **Step 5: Run the full `ProfileContainerManagerTests` suite to confirm no regressions**
+
+  ```bash
+  just test-mac ProfileContainerManagerTests 2>&1 | tee .agent-tmp/test-output.txt | tail -20
+  ```
+
+  Expected: all tests passing.
+
+- [ ] **Step 6: Format and commit**
+
+  ```bash
+  just format
+  just format-check
+  git add Shared/ProfileContainerManager.swift MoolahTests/App/ProfileContainerManagerTests.swift
+  git commit -m "refactor(profiles): scope per-profile stores by CloudKit environment"
+  rm -f .agent-tmp/test-output.txt
+  ```
+
+---
+
+## Task 6: Scope the profile index store in `MoolahApp+Setup`
+
+**Files:**
+- Modify: `App/MoolahApp+Setup.swift:48`
+
+- [ ] **Step 1: Replace the `URL.applicationSupportDirectory` call**
+
+  Locate line 48 in `App/MoolahApp+Setup.swift`:
+
+  ```swift
+        let profileStoreURL = URL.applicationSupportDirectory.appending(path: "Moolah-v2.store")
+  ```
+
+  Replace with:
+
+  ```swift
+        let profileStoreURL = URL.moolahEnvironmentScopedApplicationSupport
+          .appending(path: "Moolah-v2.store")
+  ```
+
+- [ ] **Step 2: Build and confirm the app compiles**
+
+  ```bash
+  just build-mac 2>&1 | tail -5
+  ```
+
+  Expected: succeeds with no warnings.
+
+- [ ] **Step 3: Format and commit**
+
+  ```bash
+  just format
+  just format-check
+  git add App/MoolahApp+Setup.swift
+  git commit -m "refactor(profiles): scope profile index store by CloudKit environment"
+  ```
+
+---
+
+## Task 7: Scope the `SyncCoordinator` state file
+
+**Files:**
+- Modify: `Backends/CloudKit/Sync/SyncCoordinator.swift:183-184`
+
+- [ ] **Step 1: Replace the `stateFileURL` declaration**
+
+  At lines 183–184 of `Backends/CloudKit/Sync/SyncCoordinator.swift`, replace:
+
+  ```swift
+    let stateFileURL = URL.applicationSupportDirectory
+      .appending(path: "Moolah-v2-sync.syncstate")
+  ```
+
+  with:
+
+  ```swift
+    let stateFileURL = URL.moolahEnvironmentScopedApplicationSupport
+      .appending(path: "Moolah-v2-sync.syncstate")
+  ```
+
+- [ ] **Step 3: Build and run the full CloudKit test suite**
+
+  ```bash
+  just test-mac CloudKit 2>&1 | tee .agent-tmp/test-output.txt | tail -20
+  ```
+
+  Expected: existing CloudKit tests continue to pass. They operate on synthetic zones / in-memory stores and should not be affected, but this catches any accidental cross-file impact.
+
+- [ ] **Step 4: Format and commit**
+
+  ```bash
+  just format
+  just format-check
+  git add Backends/CloudKit/Sync/SyncCoordinator.swift
+  git commit -m "refactor(sync): scope SyncCoordinator state file by CloudKit environment"
+  rm -f .agent-tmp/test-output.txt
+  ```
+
+---
+
+## Task 8: Scope `ProfileSession.importStagingDirectory(for:)`'s root
+
+**Files:**
+- Modify: `App/ProfileSession.swift:225-241` (the `importStagingDirectory(for:)` static function)
+
+Context: `importStagingDirectory(for:)` returns `<ApplicationSupport>/Moolah/csv-staging/<profileId>/`. CSV staging is device‑local and doesn't itself sync, but it is keyed on a profile ID whose SwiftData store is env‑scoped, so the staging root has to move under the env subdirectory too. Otherwise a build signed for Production would reach into the same `Moolah/csv-staging/` tree that a Development build wrote, defeating the separation for anything that reads staged files after a profile switch.
+
+- [ ] **Step 1: Replace the body of `importStagingDirectory(for:)`**
+
+  Replace lines 228–241 (the whole function body) in `App/ProfileSession.swift`:
+
+  ```swift
+    nonisolated static func importStagingDirectory(for profileId: UUID) -> URL {
+      let base =
+        (try? FileManager.default.url(
+          for: .applicationSupportDirectory,
+          in: .userDomainMask,
+          appropriateFor: nil,
+          create: true))
+        ?? FileManager.default.temporaryDirectory
+      return
+        base
+        .appendingPathComponent("Moolah", isDirectory: true)
+        .appendingPathComponent("csv-staging", isDirectory: true)
+        .appendingPathComponent(profileId.uuidString, isDirectory: true)
+    }
+  ```
+
+  with:
+
+  ```swift
+    nonisolated static func importStagingDirectory(for profileId: UUID) -> URL {
+      URL.moolahEnvironmentScopedApplicationSupport
+        .appendingPathComponent("Moolah", isDirectory: true)
+        .appendingPathComponent("csv-staging", isDirectory: true)
+        .appendingPathComponent(profileId.uuidString, isDirectory: true)
+    }
+  ```
+
+  The fallback to `FileManager.default.temporaryDirectory` is dropped: the scoped helper already creates its directory on demand and doesn't throw. Losing that fallback is intentional — if Application Support is genuinely unwritable the app cannot function, so failing loudly on the subsequent file I/O is correct.
+
+- [ ] **Step 2: Build**
+
+  ```bash
+  just build-mac 2>&1 | tail -5
+  ```
+
+  Expected: succeeds.
+
+- [ ] **Step 3: Run the `ProfileSession`‑adjacent test suites**
+
+  ```bash
+  just test-mac ProfileSessionTests 2>&1 | tee .agent-tmp/test-output.txt | tail -20
+  ```
+
+  Expected: existing tests pass. If any import‑staging test asserts on the absolute path it may need updating to the env‑scoped form; inspect the failure and adjust the assertion to match `.../<env>/Moolah/csv-staging/<profileId>/`.
+
+- [ ] **Step 4: Format and commit**
+
+  ```bash
+  just format
+  just format-check
+  git add App/ProfileSession.swift
+  git commit -m "refactor(profiles): scope CSV import staging by CloudKit environment"
+  rm -f .agent-tmp/test-output.txt
+  ```
+
+---
+
+## Task 9: Scope the default `StoreBackupManager.backupDirectory` (TDD)
+
+**Files:**
+- Modify: `Shared/StoreBackupManager.swift:20`
+- Create: `MoolahTests/Backup/StoreBackupManagerDefaultLocationTests.swift`
+
+- [ ] **Step 1: Write the failing test**
+
+  Create `MoolahTests/Backup/StoreBackupManagerDefaultLocationTests.swift`:
+
+  ```swift
+  #if os(macOS)
+    import Foundation
+    import Testing
+
+    @testable import Moolah
+
+    @Suite("StoreBackupManager default location")
+    struct StoreBackupManagerDefaultLocationTests {
+      @Test("default backup directory is scoped by CloudKit environment")
+      @MainActor
+      func testDefaultBackupDirectoryIsScoped() throws {
+        let root = FileManager.default.temporaryDirectory
+          .appending(path: UUID().uuidString)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        URL.moolahApplicationSupportOverride = root
+        defer { URL.moolahApplicationSupportOverride = nil }
+
+        let manager = StoreBackupManager()
+
+        let envSubdir = CloudKitEnvironment.resolved().storageSubdirectory
+        let expected = root
+          .appending(path: envSubdir)
+          .appending(path: "Moolah/Backups")
+        #expect(manager.testing_backupDirectory.standardizedFileURL == expected.standardizedFileURL)
+      }
+    }
+  #endif
+  ```
+
+- [ ] **Step 2: Expose a test accessor on `StoreBackupManager`**
+
+  At the bottom of `StoreBackupManager` (still inside the `#if os(macOS)` block), add:
+
+  ```swift
+      /// Test-only accessor for the configured backup directory. Read-only.
+      var testing_backupDirectory: URL { backupDirectory }
+  ```
+
+- [ ] **Step 3: Run the test and confirm it fails**
+
+  ```bash
+  just test-mac StoreBackupManagerDefaultLocationTests 2>&1 | tee .agent-tmp/test-output.txt | tail -20
+  ```
+
+  Expected: fails because the default `backupDirectory` is still `URL.applicationSupportDirectory.appending(path: "Moolah/Backups")` — no env subdir.
+
+- [ ] **Step 4: Scope the default**
+
+  In `Shared/StoreBackupManager.swift`, replace line 20's default:
+
+  ```swift
+      init(
+        backupDirectory: URL = URL.applicationSupportDirectory.appending(path: "Moolah/Backups"),
+  ```
+
+  with:
+
+  ```swift
+      init(
+        backupDirectory: URL = URL.moolahEnvironmentScopedApplicationSupport
+          .appending(path: "Moolah/Backups"),
+  ```
+
+- [ ] **Step 5: Run the test and confirm it passes**
+
+  ```bash
+  just test-mac StoreBackupManagerDefaultLocationTests 2>&1 | tee .agent-tmp/test-output.txt | tail -20
+  ```
+
+  Expected: passing.
+
+- [ ] **Step 6: Run the full Backup test suite for regressions**
+
+  ```bash
+  just test-mac Backup 2>&1 | tee .agent-tmp/test-output.txt | tail -20
+  ```
+
+  Expected: all tests pass (existing tests inject their own `backupDirectory` and aren't affected).
+
+- [ ] **Step 7: Format and commit**
+
+  ```bash
+  just format
+  just format-check
+  git add Shared/StoreBackupManager.swift MoolahTests/Backup/StoreBackupManagerDefaultLocationTests.swift
+  git commit -m "refactor(backup): scope default backup directory by CloudKit environment"
+  rm -f .agent-tmp/test-output.txt
+  ```
+
+---
+
+## Task 10: Full‑suite regression + build sweep
+
+- [ ] **Step 1: Run the complete test suite on macOS**
+
+  ```bash
+  just test-mac 2>&1 | tee .agent-tmp/test-output.txt | tail -30
+  ```
+
+  Expected: all tests pass.
+
+- [ ] **Step 2: Run the iOS test suite**
+
+  ```bash
+  just test-ios 2>&1 | tee .agent-tmp/test-output.txt | tail -30
+  ```
+
+  Expected: all tests pass.
+
+- [ ] **Step 3: Build the iOS target**
+
+  ```bash
+  just build-ios 2>&1 | tail -5
+  ```
+
+  Expected: succeeds without warnings.
+
+- [ ] **Step 4: Verify no new navigator issues**
+
+  Use Xcode MCP (`mcp__xcode__XcodeListNavigatorIssues`) with `severity: "warning"` to confirm zero warnings in user code.
+
+- [ ] **Step 5: Clean up temp files**
+
+  ```bash
+  rm -f .agent-tmp/test-output.txt
+  ```
+
+---
+
+## Task 11: Manual verification (owner‑run; plan records the procedure)
+
+These steps are not automatable from this session — they require running real builds on the owner's Mac, with their local signing identity, against the real CloudKit containers. The implementation is not considered complete until they have been walked through.
+
+- [ ] **Step 1: Verify Xcode Debug build signs for Development**
+
+  ```bash
+  ENABLE_ENTITLEMENTS=1 just generate
+  ```
+
+  Build and run from Xcode. After first launch, verify:
+
+  - `~/Library/Application Support/Development/Moolah-v2.store` exists.
+  - `~/Library/Application Support/Production/` is either absent or untouched.
+  - `codesign -d --entitlements :- .build-debug/Build/Products/Debug/Moolah.app` (or equivalent path from Xcode's DerivedData) shows `com.apple.developer.icloud-container-environment = Development`.
+  - CloudKit dashboard → records appear in the **Development** container.
+
+- [ ] **Step 2: Verify `just install-mac` signs for Production**
+
+  ```bash
+  just install-mac
+  open /Applications/Moolah.app
+  ```
+
+  After first launch, verify:
+
+  - `~/Library/Application Support/Production/Moolah-v2.store` exists.
+  - `~/Library/Application Support/Development/` is either absent or untouched.
+  - `codesign -d --entitlements :- /Applications/Moolah.app` shows `com.apple.developer.icloud-container-environment = Production`.
+  - CloudKit dashboard → records appear in the **Production** container.
+
+- [ ] **Step 3: Verify coexistence**
+
+  Run both builds (Xcode Debug → then `just install-mac` again) and confirm each reads its own environment's subdirectory without touching the other. Open the app from `/Applications` and confirm its data is independent of what Xcode Debug sees.
+
+- [ ] **Step 4: Spot‑check legacy files are untouched**
+
+  ```bash
+  ls ~/Library/Application\ Support/ | grep -E "^Moolah-" || echo "(no root-level legacy stores)"
+  ```
+
+  Whatever is there should still be there, with the same mtimes, after both builds have run. No code in this change touches these paths.
+
+---
+
+## Rollback
+
+If Task 11 reveals a misconfiguration that wasn't caught in Tasks 1–10, the fastest rollback is `git revert` on the Task 2 commit (entitlement declaration) and the Task 1 commit (build setting). Without those, the Swift code still falls back safely — but on launch the resolver will `fatalError` because Info.plist no longer contains the key. So rollback must revert Task 1's plist changes *alongside* reverting the code, or leave everything reverted. Do not leave the Swift helpers live with the Info.plist key absent.

--- a/project.yml
+++ b/project.yml
@@ -70,13 +70,20 @@ targets:
         INFOPLIST_FILE: App/Info-iOS.plist
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
       configs:
+        Debug:
+          CLOUDKIT_ENVIRONMENT: Development
         Debug-Tests:
           # Tests must never pick up iCloud entitlements, even when a dev
           # runs `ENABLE_ENTITLEMENTS=1 just generate` to inject them into Debug.
           CODE_SIGN_ENTITLEMENTS: ""
           SWIFT_ACTIVE_COMPILATION_CONDITIONS: "$(inherited)"
+          # Value is unused at runtime (test host has no iCloud entitlement
+          # and uses in-memory stores) but must be defined so Info.plist
+          # expansion yields a literal string rather than "$(CLOUDKIT_ENVIRONMENT)".
+          CLOUDKIT_ENVIRONMENT: Development
         Release:
           SWIFT_ACTIVE_COMPILATION_CONDITIONS: "$(inherited) CLOUDKIT_ENABLED"
+          CLOUDKIT_ENVIRONMENT: Production
 
   Moolah_macOS:
     type: application
@@ -101,14 +108,16 @@ targets:
         INFOPLIST_FILE: App/Info-macOS.plist
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
       configs:
+        Debug:
+          CLOUDKIT_ENVIRONMENT: Development
         Debug-Tests:
-          # Tests must never pick up iCloud entitlements, even when a dev
-          # runs `ENABLE_ENTITLEMENTS=1 just generate` to inject them into Debug.
           CODE_SIGN_ENTITLEMENTS: ""
           SWIFT_ACTIVE_COMPILATION_CONDITIONS: "$(inherited)"
+          CLOUDKIT_ENVIRONMENT: Development
         Release:
           ENABLE_HARDENED_RUNTIME: YES
           SWIFT_ACTIVE_COMPILATION_CONDITIONS: "$(inherited) CLOUDKIT_ENABLED"
+          CLOUDKIT_ENVIRONMENT: Production
 
   MoolahTests_iOS:
     type: bundle.unit-test

--- a/scripts/inject-entitlements.sh
+++ b/scripts/inject-entitlements.sh
@@ -3,8 +3,9 @@
 #
 # 1. Writes .build/Moolah.entitlements with the full sandbox + CloudKit keys.
 # 2. Produces project-entitlements.yml — a copy of project.yml that:
-#    - Adds a Debug-only block to each app target wiring in
+#    - Augments each app target's existing Debug block with
 #      CODE_SIGN_ENTITLEMENTS and the CLOUDKIT_ENABLED compilation condition.
+#      (project.yml already carries a Debug block for CLOUDKIT_ENVIRONMENT.)
 #    - Appends CODE_SIGN_ENTITLEMENTS to each target's existing Release block.
 #      Release already bakes in CLOUDKIT_ENABLED via project.yml; without the
 #      matching entitlements file the signed binary calls CKContainer.default()
@@ -72,11 +73,11 @@ for target in ("Moolah_iOS", "Moolah_macOS"):
             f"inject-entitlements: could not find configs: block for {target}"
         )
 
-    # Prepend CODE_SIGN_ENTITLEMENTS and the CLOUDKIT_ENABLED compilation
-    # condition to the existing Debug: block. project.yml already carries a
-    # Debug: block (for CLOUDKIT_ENVIRONMENT: Development); inserting a second
-    # Debug: sibling would make xcodegen's YAML loader keep only the last
-    # occurrence and silently drop these keys.
+    # Insert CODE_SIGN_ENTITLEMENTS and the CLOUDKIT_ENABLED compilation
+    # condition at the top of the existing Debug: block. project.yml already
+    # carries a Debug: block (for CLOUDKIT_ENVIRONMENT: Development); inserting
+    # a second Debug: sibling would make xcodegen's YAML loader keep only the
+    # last occurrence and silently drop these keys.
     debug_header = "        Debug:\n"
     debug_pos = content.find(debug_header, configs_pos)
     if debug_pos == -1:

--- a/scripts/inject-entitlements.sh
+++ b/scripts/inject-entitlements.sh
@@ -41,6 +41,8 @@ cat > "$ENTITLEMENTS_FILE" <<'PLIST'
     <array>
         <string>iCloud.rocks.moolah.app.v2</string>
     </array>
+    <key>com.apple.developer.icloud-container-environment</key>
+    <string>$(CLOUDKIT_ENVIRONMENT)</string>
 </dict>
 </plist>
 PLIST
@@ -52,13 +54,6 @@ with open("project.yml") as f:
     content = f.read()
 
 entitlements_path = os.environ["ENTITLEMENTS_FILE"]
-
-debug_block = "\n".join([
-    "        Debug:",
-    f"          CODE_SIGN_ENTITLEMENTS: {entitlements_path}",
-    '          SWIFT_ACTIVE_COMPILATION_CONDITIONS: "$(inherited) CLOUDKIT_ENABLED"',
-    "",
-])
 
 release_entitlements_line = (
     f"          CODE_SIGN_ENTITLEMENTS: {entitlements_path}\n"
@@ -77,14 +72,29 @@ for target in ("Moolah_iOS", "Moolah_macOS"):
             f"inject-entitlements: could not find configs: block for {target}"
         )
 
-    insert_at = configs_pos + len(configs_marker)
-    content = content[:insert_at] + debug_block + content[insert_at:]
+    # Prepend CODE_SIGN_ENTITLEMENTS and the CLOUDKIT_ENABLED compilation
+    # condition to the existing Debug: block. project.yml already carries a
+    # Debug: block (for CLOUDKIT_ENVIRONMENT: Development); inserting a second
+    # Debug: sibling would make xcodegen's YAML loader keep only the last
+    # occurrence and silently drop these keys.
+    debug_header = "        Debug:\n"
+    debug_pos = content.find(debug_header, configs_pos)
+    if debug_pos == -1:
+        raise SystemExit(
+            f"inject-entitlements: could not find Debug: block for {target}"
+        )
+    debug_insert_at = debug_pos + len(debug_header)
+    debug_injection = (
+        f"          CODE_SIGN_ENTITLEMENTS: {entitlements_path}\n"
+        '          SWIFT_ACTIVE_COMPILATION_CONDITIONS: "$(inherited) CLOUDKIT_ENABLED"\n'
+    )
+    content = content[:debug_insert_at] + debug_injection + content[debug_insert_at:]
 
     # Append CODE_SIGN_ENTITLEMENTS to this target's existing Release: block.
-    # Search forward from the Debug block we just inserted so we stay inside
+    # Search forward from the Debug block we just touched so we stay inside
     # this target's configs: section.
     release_header = "        Release:\n"
-    release_pos = content.find(release_header, insert_at)
+    release_pos = content.find(release_header, debug_insert_at)
     if release_pos == -1:
         raise SystemExit(
             f"inject-entitlements: could not find Release: block for {target}"


### PR DESCRIPTION
## Summary

- Pins each build's CloudKit environment explicitly via a per‑configuration `CLOUDKIT_ENVIRONMENT` build setting, surfaced in the entitlement (`com.apple.developer.icloud-container-environment`) and `MoolahCloudKitEnvironment` Info.plist key.
- Scopes every on‑disk store tied to a CloudKit container (SwiftData profile index + per‑profile stores, sync state, `SyncCoordinator` state, CSV import staging, nightly backups) into a `Development/` or `Production/` subdirectory of Application Support, resolved once at launch from Info.plist.
- `just install-mac` (your local Developer‑ID distribution build) now hits **Production** CloudKit; Xcode Debug runs continue to hit **Development**. The two coexist on the same Mac without cross‑contamination.

Closes the "silent sync drop" class of bugs caused by `CKSyncEngine` tokens and SwiftData `systemFields` bleeding across CloudKit environments on a single on‑disk path.

Stacked on top of [#445](https://github.com/ajsutton/moolah-native/pull/445) (design + implementation plan). Rebases / merges cleanly regardless of merge order because the plan file content is identical, plus this branch renames `moolahEnvironmentScopedApplicationSupport` → `moolahScopedApplicationSupport` (41 → 30 chars) to fit the project's SwiftLint `identifier_name` cap.

## What's in the branch

Build wiring (Tasks 1–2):
- `project.yml` per-config `CLOUDKIT_ENVIRONMENT` (Debug/Debug-Tests=Development, Release=Production) for both app targets.
- `App/Info-iOS.plist` / `App/Info-macOS.plist` gain `MoolahCloudKitEnvironment = $(CLOUDKIT_ENVIRONMENT)`.
- Both entitlements sources (`scripts/inject-entitlements.sh` heredoc and `fastlane/Moolah.entitlements`) declare `com.apple.developer.icloud-container-environment = $(CLOUDKIT_ENVIRONMENT)`.
- `inject-entitlements.sh`'s Python block now augments the existing Debug block (which carries `CLOUDKIT_ENVIRONMENT`) rather than prepending a duplicate — previously the two `Debug:` siblings collapsed and silently dropped `CODE_SIGN_ENTITLEMENTS` for Debug.

Runtime (Tasks 3–9):
- `Shared/CloudKitEnvironment.swift` — `Development` / `Production` enum with `resolved()` (Bundle.main‑cached) and `resolve(from:)` test seam. `fatalError` at launch on absent/invalid Info.plist value.
- `Shared/URL+MoolahStorage.swift` — `URL.moolahScopedApplicationSupport` (creates `<Application Support>/<env>/` on demand) and `URL.moolahApplicationSupportOverride` test seam.
- `Shared/ProfileContainerManager.swift`, `App/MoolahApp+Setup.swift`, `Backends/CloudKit/Sync/SyncCoordinator.swift`, `App/ProfileSession.swift`, `Shared/StoreBackupManager.swift` — all migrated to the scoped helper.

Tests (Tasks 3, 4, 5, 9):
- New Swift Testing suites under `MoolahTests/Shared/` and `MoolahTests/Backup/`, `.serialized` where they mutate the override.
- New test in `ProfileContainerManagerTests` that asserts `container.configurations.first?.url` lands under `<root>/<env>/Moolah-<uuid>.store` via an override on a UUID temp root.

## Acceptance criteria

Verified by CI (already green locally):
- [x] macOS full suite: 1521 tests / 0 failures.
- [x] iOS full suite: 1492 tests / 0 failures.
- [x] iOS build: `** BUILD SUCCEEDED **`.
- [x] No new user-code warnings.
- [x] No remaining `URL.applicationSupportDirectory` call sites outside the helper itself and its tests.

To verify manually on your Mac before / after merge:

- [ ] `ENABLE_ENTITLEMENTS=1 just generate`, run from Xcode → confirm `~/Library/Application Support/Development/` populates; Production subtree absent/untouched.
- [ ] `codesign -d --entitlements :- <Xcode-built .app>` shows `com.apple.developer.icloud-container-environment = Development`.
- [ ] `just install-mac`, launch `/Applications/Moolah.app` → confirm `~/Library/Application Support/Production/` populates; Development subtree untouched.
- [ ] `codesign -d --entitlements :- /Applications/Moolah.app` shows `com.apple.developer.icloud-container-environment = Production`.
- [ ] CloudKit dashboard → records written by Xcode Debug appear in Development container; records written by `install-mac` appear in Production container.
- [ ] Existing root‑level stores (`Moolah-v2.store`, `Moolah-<uuid>.store`, `Moolah-<uuid>.syncstate`, `Moolah/Backups/`) untouched after both builds have run — no deletion, no mtime change.

## Test plan

- [ ] CI runs `just format-check`, `just test` on both platforms, `just build-mac`, `just build-ios`.
- [ ] Owner runs the manual verification steps above on their Mac.