### PR TITLE
Task 4 of instrument-registry: implement CloudKitInstrumentRegistryRepository

### DIFF
--- a/Backends/CloudKit/Repositories/CloudKitInstrumentRegistryRepository.swift
+++ b/Backends/CloudKit/Repositories/CloudKitInstrumentRegistryRepository.swift
@@ -1,0 +1,213 @@
+import Foundation
+import OSLog
+import SwiftData
+
+/// `@unchecked Sendable` because:
+/// - `modelContainer` is `Sendable` (SwiftData's contract).
+/// - Injected hooks are `@Sendable` closures.
+/// - `subscribers` is confined to `@MainActor` for all reads and writes.
+/// Matches the pattern used by `CloudKitAccountRepository` and peers.
+final class CloudKitInstrumentRegistryRepository:
+  InstrumentRegistryRepository, @unchecked Sendable
+{
+  let modelContainer: ModelContainer
+  private let onRecordChanged: @Sendable (String) -> Void
+  private let onRecordDeleted: @Sendable (String) -> Void
+  private let logger = Logger(
+    subsystem: "com.moolah.app", category: "InstrumentRegistry")
+
+  @MainActor private var subscribers: [UUID: AsyncStream<Void>.Continuation] = [:]
+
+  /// - Parameters:
+  ///   - onRecordChanged: Invoked from whatever task context completes the
+  ///     SwiftData write — do not assume `@MainActor`. Typically used to
+  ///     queue CKSyncEngine saves, which are themselves thread-safe.
+  ///   - onRecordDeleted: Invoked from whatever task context completes the
+  ///     SwiftData write — do not assume `@MainActor`. Typically used to
+  ///     queue CKSyncEngine deletes, which are themselves thread-safe.
+  init(
+    modelContainer: ModelContainer,
+    onRecordChanged: @escaping @Sendable (String) -> Void = { _ in },
+    onRecordDeleted: @escaping @Sendable (String) -> Void = { _ in }
+  ) {
+    self.modelContainer = modelContainer
+    self.onRecordChanged = onRecordChanged
+    self.onRecordDeleted = onRecordDeleted
+  }
+
+  // MARK: - Reads (background context)
+
+  func all() async throws -> [Instrument] {
+    let context = ModelContext(modelContainer)
+    let descriptor = FetchDescriptor<InstrumentRecord>()
+    let records = try context.fetch(descriptor)
+    let stored = records.map { $0.toDomain() }
+    let storedIds = Set(stored.map(\.id))
+    let ambient =
+      Locale.Currency.isoCurrencies
+      .map(\.identifier)
+      .map { Instrument.fiat(code: $0) }
+      .filter { !storedIds.contains($0.id) }
+    return stored + ambient
+  }
+
+  func allCryptoRegistrations() async throws -> [CryptoRegistration] {
+    let context = ModelContext(modelContainer)
+    let cryptoKind = Instrument.Kind.cryptoToken.rawValue
+    let descriptor = FetchDescriptor<InstrumentRecord>(
+      predicate: #Predicate { $0.kind == cryptoKind }
+    )
+    let rows = try context.fetch(descriptor)
+    return rows.compactMap { row -> CryptoRegistration? in
+      let hasMapping =
+        row.coingeckoId != nil
+        || row.cryptocompareSymbol != nil
+        || row.binanceSymbol != nil
+      guard hasMapping else { return nil }
+      let mapping = CryptoProviderMapping(
+        instrumentId: row.id,
+        coingeckoId: row.coingeckoId,
+        cryptocompareSymbol: row.cryptocompareSymbol,
+        binanceSymbol: row.binanceSymbol
+      )
+      return CryptoRegistration(instrument: row.toDomain(), mapping: mapping)
+    }
+  }
+
+  // MARK: - Writes (main context)
+
+  func registerCrypto(
+    _ instrument: Instrument, mapping: CryptoProviderMapping
+  ) async throws {
+    precondition(instrument.kind == .cryptoToken)
+    try await MainActor.run {
+      try upsertCrypto(instrument: instrument, mapping: mapping)
+    }
+    onRecordChanged(instrument.id)
+    await notifySubscribers()
+  }
+
+  @MainActor
+  private func upsertCrypto(
+    instrument: Instrument, mapping: CryptoProviderMapping
+  ) throws {
+    let context = modelContainer.mainContext
+    let id = instrument.id
+    let descriptor = FetchDescriptor<InstrumentRecord>(
+      predicate: #Predicate { $0.id == id }
+    )
+    if let existing = try context.fetch(descriptor).first {
+      existing.kind = instrument.kind.rawValue
+      existing.name = instrument.name
+      existing.decimals = instrument.decimals
+      existing.ticker = instrument.ticker
+      existing.exchange = instrument.exchange
+      existing.chainId = instrument.chainId
+      existing.contractAddress = instrument.contractAddress
+      existing.coingeckoId = mapping.coingeckoId
+      existing.cryptocompareSymbol = mapping.cryptocompareSymbol
+      existing.binanceSymbol = mapping.binanceSymbol
+    } else {
+      let row = InstrumentRecord(
+        id: id,
+        kind: instrument.kind.rawValue,
+        name: instrument.name,
+        decimals: instrument.decimals,
+        ticker: instrument.ticker,
+        exchange: instrument.exchange,
+        chainId: instrument.chainId,
+        contractAddress: instrument.contractAddress,
+        coingeckoId: mapping.coingeckoId,
+        cryptocompareSymbol: mapping.cryptocompareSymbol,
+        binanceSymbol: mapping.binanceSymbol
+      )
+      context.insert(row)
+    }
+    try context.save()
+  }
+
+  func registerStock(_ instrument: Instrument) async throws {
+    precondition(instrument.kind == .stock)
+    try await MainActor.run {
+      try upsertStock(instrument: instrument)
+    }
+    onRecordChanged(instrument.id)
+    await notifySubscribers()
+  }
+
+  @MainActor
+  private func upsertStock(instrument: Instrument) throws {
+    let context = modelContainer.mainContext
+    let id = instrument.id
+    let descriptor = FetchDescriptor<InstrumentRecord>(
+      predicate: #Predicate { $0.id == id }
+    )
+    if let existing = try context.fetch(descriptor).first {
+      existing.kind = instrument.kind.rawValue
+      existing.name = instrument.name
+      existing.decimals = instrument.decimals
+      existing.ticker = instrument.ticker
+      existing.exchange = instrument.exchange
+    } else {
+      let row = InstrumentRecord(
+        id: id,
+        kind: instrument.kind.rawValue,
+        name: instrument.name,
+        decimals: instrument.decimals,
+        ticker: instrument.ticker,
+        exchange: instrument.exchange
+      )
+      context.insert(row)
+    }
+    try context.save()
+  }
+
+  func remove(id: String) async throws {
+    let didDelete: Bool = try await MainActor.run {
+      try deleteRecord(id: id)
+    }
+    guard didDelete else { return }
+    onRecordDeleted(id)
+    await notifySubscribers()
+  }
+
+  @MainActor
+  private func deleteRecord(id: String) throws -> Bool {
+    let context = modelContainer.mainContext
+    let fiatKind = Instrument.Kind.fiatCurrency.rawValue
+    let descriptor = FetchDescriptor<InstrumentRecord>(
+      predicate: #Predicate { $0.id == id }
+    )
+    guard let existing = try context.fetch(descriptor).first else { return false }
+    guard existing.kind != fiatKind else { return false }
+    context.delete(existing)
+    try context.save()
+    return true
+  }
+
+  // MARK: - Change fan-out
+
+  @MainActor
+  func observeChanges() -> AsyncStream<Void> {
+    let key = UUID()
+    return AsyncStream { [weak self] continuation in
+      guard let self else {
+        continuation.finish()
+        return
+      }
+      self.subscribers[key] = continuation
+      continuation.onTermination = { @Sendable [weak self] _ in
+        Task { @MainActor [weak self] in
+          self?.subscribers.removeValue(forKey: key)
+        }
+      }
+    }
+  }
+
+  @MainActor
+  private func notifySubscribers() {
+    for continuation in subscribers.values {
+      continuation.yield()
+    }
+  }
+}

--- a/Domain/Repositories/InstrumentRegistryRepository.swift
+++ b/Domain/Repositories/InstrumentRegistryRepository.swift
@@ -64,5 +64,11 @@ protocol InstrumentRegistryRepository: Sendable {
   /// and do NOT fan out through this stream — consumers that must react
   /// to remote changes also subscribe to the existing per-profile
   /// `SyncCoordinator` observer signal.
+  ///
+  /// `@MainActor`-isolated because the implementation registers the
+  /// continuation in a `@MainActor`-confined dictionary synchronously —
+  /// hopping via `Task { @MainActor in ... }` would let a mutation fired
+  /// immediately after this call miss the event.
+  @MainActor
   func observeChanges() -> AsyncStream<Void>
 }

--- a/MoolahTests/Domain/InstrumentRegistryContractTests.swift
+++ b/MoolahTests/Domain/InstrumentRegistryContractTests.swift
@@ -1,0 +1,216 @@
+import Foundation
+import SwiftData
+import Testing
+
+@testable import Moolah
+
+@Suite("InstrumentRegistryRepository — Contract")
+@MainActor
+struct InstrumentRegistryContractTests {
+  // Test fixture: builds an in-memory CloudKitInstrumentRegistryRepository
+  // with captured sync-queue hooks, matching the public init signature.
+  @MainActor
+  final class HookCapture {
+    var changedIds: [String] = []
+    var deletedIds: [String] = []
+  }
+
+  @MainActor
+  func makeSubject() throws -> (
+    repo: CloudKitInstrumentRegistryRepository,
+    hooks: HookCapture
+  ) {
+    let config = ModelConfiguration(isStoredInMemoryOnly: true)
+    let container = try ModelContainer(
+      for: InstrumentRecord.self,
+      configurations: config
+    )
+    let hooks = HookCapture()
+    let repo = CloudKitInstrumentRegistryRepository(
+      modelContainer: container,
+      onRecordChanged: { [hooks] id in Task { @MainActor in hooks.changedIds.append(id) } },
+      onRecordDeleted: { [hooks] id in Task { @MainActor in hooks.deletedIds.append(id) } }
+    )
+    return (repo, hooks)
+  }
+
+  @Test("all() on a fresh profile returns every ISO currency and zero non-fiat rows")
+  func freshProfileIsFiatOnly() async throws {
+    let (repo, _) = try makeSubject()
+    let all = try await repo.all()
+    let fiats = all.filter { $0.kind == .fiatCurrency }
+    let nonFiats = all.filter { $0.kind != .fiatCurrency }
+    #expect(fiats.count == Locale.Currency.isoCurrencies.count)
+    #expect(nonFiats.isEmpty)
+    #expect(all.contains { $0.id == "AUD" })
+    #expect(all.contains { $0.id == "USD" })
+  }
+
+  @Test("registerStock makes the stock appear in all()")
+  func registerStockAppears() async throws {
+    let (repo, _) = try makeSubject()
+    let bhp = Instrument.stock(ticker: "BHP.AX", exchange: "ASX", name: "BHP")
+    try await repo.registerStock(bhp)
+    let all = try await repo.all()
+    #expect(all.contains { $0.id == "ASX:BHP.AX" })
+  }
+
+  @Test("registerCrypto round-trips all eight crypto fields + three mapping fields")
+  func registerCryptoRoundTrip() async throws {
+    let (repo, _) = try makeSubject()
+    let eth = Instrument.crypto(
+      chainId: 1, contractAddress: nil, symbol: "ETH",
+      name: "Ethereum", decimals: 18)
+    let mapping = CryptoProviderMapping(
+      instrumentId: eth.id,
+      coingeckoId: "ethereum",
+      cryptocompareSymbol: "ETH",
+      binanceSymbol: "ETHUSDT")
+    try await repo.registerCrypto(eth, mapping: mapping)
+
+    let regs = try await repo.allCryptoRegistrations()
+    let reg = try #require(regs.first { $0.id == eth.id })
+    #expect(reg.instrument.chainId == 1)
+    #expect(reg.instrument.contractAddress == nil)
+    #expect(reg.instrument.ticker == "ETH")
+    #expect(reg.instrument.name == "Ethereum")
+    #expect(reg.instrument.decimals == 18)
+    #expect(reg.mapping.coingeckoId == "ethereum")
+    #expect(reg.mapping.cryptocompareSymbol == "ETH")
+    #expect(reg.mapping.binanceSymbol == "ETHUSDT")
+  }
+
+  @Test("registerCrypto with existing id upserts the mapping")
+  func registerCryptoUpserts() async throws {
+    let (repo, _) = try makeSubject()
+    let eth = Instrument.crypto(
+      chainId: 1, contractAddress: nil, symbol: "ETH",
+      name: "Ethereum", decimals: 18)
+    let first = CryptoProviderMapping(
+      instrumentId: eth.id,
+      coingeckoId: "ethereum", cryptocompareSymbol: nil, binanceSymbol: nil)
+    let second = CryptoProviderMapping(
+      instrumentId: eth.id,
+      coingeckoId: "ethereum", cryptocompareSymbol: "ETH", binanceSymbol: "ETHUSDT")
+    try await repo.registerCrypto(eth, mapping: first)
+    try await repo.registerCrypto(eth, mapping: second)
+
+    let regs = try await repo.allCryptoRegistrations()
+    #expect(regs.count == 1)
+    #expect(regs.first?.mapping.cryptocompareSymbol == "ETH")
+    #expect(regs.first?.mapping.binanceSymbol == "ETHUSDT")
+  }
+
+  @Test("allCryptoRegistrations skips rows whose three mapping fields are all nil")
+  func allCryptoSkipsMissingMapping() async throws {
+    let (repo, _) = try makeSubject()
+    // Simulate an ensureInstrument-auto-inserted row: crypto kind, but no
+    // mapping fields.
+    let context = repo.modelContainer.mainContext
+    let ghost = InstrumentRecord(
+      id: "1:native",
+      kind: "cryptoToken",
+      name: "Ethereum",
+      decimals: 18,
+      ticker: "ETH",
+      chainId: 1,
+      contractAddress: nil
+    )
+    context.insert(ghost)
+    try context.save()
+
+    let regs = try await repo.allCryptoRegistrations()
+    #expect(regs.isEmpty)
+    // But it still appears in all() — it's a valid instrument, just unpriced.
+    let all = try await repo.all()
+    #expect(all.contains { $0.id == "1:native" && $0.kind == .cryptoToken })
+  }
+
+  @Test("remove deletes the row and is a no-op for fiat + unknown ids")
+  func removeBehaviour() async throws {
+    let (repo, _) = try makeSubject()
+    let bhp = Instrument.stock(ticker: "BHP.AX", exchange: "ASX", name: "BHP")
+    try await repo.registerStock(bhp)
+
+    try await repo.remove(id: bhp.id)
+    let all = try await repo.all()
+    #expect(all.contains { $0.id == bhp.id } == false)
+
+    // No-op cases: must not throw.
+    try await repo.remove(id: "AUD")  // fiat id
+    try await repo.remove(id: "DOES_NOT_EXIST:FOO")  // unknown id
+  }
+
+  @Test("sync-queue hook fires on registerStock / registerCrypto / remove")
+  func syncHooksFire() async throws {
+    let (repo, hooks) = try makeSubject()
+    let bhp = Instrument.stock(ticker: "BHP.AX", exchange: "ASX", name: "BHP")
+    try await repo.registerStock(bhp)
+    let eth = Instrument.crypto(
+      chainId: 1, contractAddress: nil, symbol: "ETH",
+      name: "Ethereum", decimals: 18)
+    try await repo.registerCrypto(
+      eth,
+      mapping: CryptoProviderMapping(
+        instrumentId: eth.id, coingeckoId: "ethereum",
+        cryptocompareSymbol: nil, binanceSymbol: nil))
+    try await repo.remove(id: bhp.id)
+
+    // Drain pending @MainActor hops from the sync-queue hook closures. Not
+    // strictly deterministic — if CI flakes, consider making the hooks
+    // async/awaitable so the test can `await` them directly.
+    try await Task.sleep(for: .milliseconds(50))
+
+    #expect(hooks.changedIds == ["ASX:BHP.AX", "1:native"])
+    #expect(hooks.deletedIds == ["ASX:BHP.AX"])
+  }
+
+  @Test("sync-queue hook does not fire for fiat register or unknown remove")
+  func syncHooksSkipNoops() async throws {
+    let (repo, hooks) = try makeSubject()
+    // Fiat register is rejected by the type-level split — there is no
+    // registerFiat. But unknown remove is a runtime no-op.
+    try await repo.remove(id: "DOES_NOT_EXIST:FOO")
+    // Drain pending @MainActor hops from the sync-queue hook closures. Not
+    // strictly deterministic — if CI flakes, consider making the hooks
+    // async/awaitable so the test can `await` them directly.
+    try await Task.sleep(for: .milliseconds(50))
+    #expect(hooks.changedIds.isEmpty)
+    #expect(hooks.deletedIds.isEmpty)
+  }
+
+  @Test("observeChanges fans out to multiple consumers")
+  func observeChangesFanOut() async throws {
+    let (repo, _) = try makeSubject()
+    let streamA = repo.observeChanges()
+    let streamB = repo.observeChanges()
+    var iteratorA = streamA.makeAsyncIterator()
+    var iteratorB = streamB.makeAsyncIterator()
+
+    let bhp = Instrument.stock(ticker: "BHP.AX", exchange: "ASX", name: "BHP")
+    Task { try? await repo.registerStock(bhp) }
+
+    _ = await iteratorA.next()
+    _ = await iteratorB.next()
+    // If both iterators advanced we know both got a yield.
+  }
+
+  @Test("cancelled observeChanges consumer does not block sibling consumers")
+  func observeChangesCancellation() async throws {
+    let (repo, _) = try makeSubject()
+    let alive = repo.observeChanges()
+    var aliveIterator = alive.makeAsyncIterator()
+
+    let cancelTask = Task {
+      var dropped = repo.observeChanges().makeAsyncIterator()
+      _ = await dropped.next()
+    }
+    cancelTask.cancel()
+
+    let bhp = Instrument.stock(ticker: "BHP.AX", exchange: "ASX", name: "BHP")
+    Task { try? await repo.registerStock(bhp) }
+
+    _ = await aliveIterator.next()  // would hang if the cancelled consumer
+    // blocked the fan-out.
+  }
+}


### PR DESCRIPTION
## Summary

- Task 4 of [`plans/2026-04-24-instrument-registry-implementation.md`](https://github.com/ajsutton/moolah-native/blob/feat/instrument-registry-4/plans/2026-04-24-instrument-registry-implementation.md) — stacked on #449.
- Adds `Backends/CloudKit/Repositories/CloudKitInstrumentRegistryRepository.swift` — the concrete impl of the protocol from #449.
- Reads (`all`, `allCryptoRegistrations`) run on a fresh background `ModelContext` in the async method body, matching `CloudKitAccountRepository.fetchAll()`.
- Writes (`registerCrypto`, `registerStock`, `remove`) run on `MainActor` with `modelContainer.mainContext`; emit the injected `onRecordChanged` / `onRecordDeleted` hooks (wired to `SyncCoordinator` in Task 11).
- `observeChanges()` is `@MainActor` — subscribers are registered synchronously into a main-actor-confined dictionary; mutations fan out to every outstanding stream. `onTermination` cleans up. Protocol method also became `@MainActor` (Swift 6 strict concurrency requires matching isolation between protocol requirement and conforming impl when the impl needs synchronous main-actor state access).
- 10 contract tests in `MoolahTests/Domain/InstrumentRegistryContractTests.swift` covering fresh-profile fiat-only, register appearance, round-trip, upsert, skip-nil-mapping, remove behaviour, sync-hook fire/no-op, fan-out, and cancellation.

## Test plan

- [x] `just format-check` clean
- [x] `just test` — macOS 1530 / iOS 1502 (new: 10 registry contract tests) all pass
- [x] Spec compliance ✅ and concurrency-review ✅ after one amend round (Task.detached removed; observeChanges @MainActor; flakiness comments added; `@unchecked Sendable` rationale documented)
- [x] `.swiftlint-baseline.yml` diff empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)