### PR TITLE
feat(ci): automate CloudKit schema promotion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,3 +71,21 @@ jobs:
           path: .agent-tmp/ui-fail-*
           if-no-files-found: ignore
           retention-days: 7
+
+  schema-drift:
+    name: CloudKit schema drift
+    runs-on: macos-26
+    # Secrets are withheld from fork PRs — skip rather than fail spuriously.
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+    timeout-minutes: 10
+    env:
+      DEVELOPMENT_TEAM: ${{ secrets.DEVELOPMENT_TEAM }}
+      CKTOOL_MANAGEMENT_TOKEN: ${{ secrets.CKTOOL_MANAGEMENT_TOKEN }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install tools
+        run: brew install just
+
+      - name: Verify CloudKit schema
+        run: just verify-schema

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -55,6 +55,12 @@ jobs:
         run: |
           sed -i '' "s/MARKETING_VERSION: .*/MARKETING_VERSION: \"$APP_VERSION\"/" project.yml
 
+      - name: Promote CloudKit schema to Production
+        env:
+          DEVELOPMENT_TEAM: ${{ secrets.DEVELOPMENT_TEAM }}
+          CKTOOL_MANAGEMENT_TOKEN: ${{ secrets.CKTOOL_MANAGEMENT_TOKEN }}
+        run: just promote-schema
+
       - name: Deploy to TestFlight
         env:
           ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}

--- a/CloudKit/schema.ckdb
+++ b/CloudKit/schema.ckdb
@@ -1,0 +1,144 @@
+DEFINE SCHEMA
+
+    RECORD TYPE CD_AccountRecord (
+        CD_entityName           STRING QUERYABLE SEARCHABLE SORTABLE,
+        CD_id                   STRING QUERYABLE SEARCHABLE SORTABLE,
+        CD_instrumentId         STRING QUERYABLE SEARCHABLE SORTABLE,
+        CD_isHidden             INT64 QUERYABLE SORTABLE,
+        CD_name                 STRING QUERYABLE SEARCHABLE SORTABLE,
+        CD_position             INT64 QUERYABLE SORTABLE,
+        CD_type                 STRING QUERYABLE SEARCHABLE SORTABLE,
+        CD_usesPositionTracking INT64 QUERYABLE SORTABLE,
+        "___createTime"         TIMESTAMP,
+        "___createdBy"          REFERENCE,
+        "___etag"               STRING,
+        "___modTime"            TIMESTAMP,
+        "___modifiedBy"         REFERENCE,
+        "___recordID"           REFERENCE,
+        GRANT WRITE TO "_creator",
+        GRANT CREATE TO "_icloud",
+        GRANT READ TO "_world"
+    );
+
+    RECORD TYPE CD_EarmarkBudgetItemRecord (
+        CD_amount       INT64 QUERYABLE SORTABLE,
+        CD_categoryId   STRING QUERYABLE SEARCHABLE SORTABLE,
+        CD_earmarkId    STRING QUERYABLE SEARCHABLE SORTABLE,
+        CD_entityName   STRING QUERYABLE SEARCHABLE SORTABLE,
+        CD_id           STRING QUERYABLE SEARCHABLE SORTABLE,
+        CD_instrumentId STRING QUERYABLE SEARCHABLE SORTABLE,
+        "___createTime" TIMESTAMP,
+        "___createdBy"  REFERENCE,
+        "___etag"       STRING,
+        "___modTime"    TIMESTAMP,
+        "___modifiedBy" REFERENCE,
+        "___recordID"   REFERENCE,
+        GRANT WRITE TO "_creator",
+        GRANT CREATE TO "_icloud",
+        GRANT READ TO "_world"
+    );
+
+    RECORD TYPE CD_EarmarkRecord (
+        CD_entityName                STRING QUERYABLE SEARCHABLE SORTABLE,
+        CD_id                        STRING QUERYABLE SEARCHABLE SORTABLE,
+        CD_instrumentId              STRING QUERYABLE SEARCHABLE SORTABLE,
+        CD_isHidden                  INT64 QUERYABLE SORTABLE,
+        CD_name                      STRING QUERYABLE SEARCHABLE SORTABLE,
+        CD_position                  INT64 QUERYABLE SORTABLE,
+        CD_savingsTarget             INT64 QUERYABLE SORTABLE,
+        CD_savingsTargetInstrumentId STRING QUERYABLE SEARCHABLE SORTABLE,
+        "___createTime"              TIMESTAMP,
+        "___createdBy"               REFERENCE,
+        "___etag"                    STRING,
+        "___modTime"                 TIMESTAMP,
+        "___modifiedBy"              REFERENCE,
+        "___recordID"                REFERENCE,
+        GRANT WRITE TO "_creator",
+        GRANT CREATE TO "_icloud",
+        GRANT READ TO "_world"
+    );
+
+    RECORD TYPE CD_InstrumentRecord (
+        CD_decimals     INT64 QUERYABLE SORTABLE,
+        CD_entityName   STRING QUERYABLE SEARCHABLE SORTABLE,
+        CD_id           STRING QUERYABLE SEARCHABLE SORTABLE,
+        CD_kind         STRING QUERYABLE SEARCHABLE SORTABLE,
+        CD_name         STRING QUERYABLE SEARCHABLE SORTABLE,
+        "___createTime" TIMESTAMP,
+        "___createdBy"  REFERENCE,
+        "___etag"       STRING,
+        "___modTime"    TIMESTAMP,
+        "___modifiedBy" REFERENCE,
+        "___recordID"   REFERENCE,
+        GRANT WRITE TO "_creator",
+        GRANT CREATE TO "_icloud",
+        GRANT READ TO "_world"
+    );
+
+    RECORD TYPE CD_ProfileRecord (
+        CD_createdAt               TIMESTAMP QUERYABLE SORTABLE,
+        CD_currencyCode            STRING QUERYABLE SEARCHABLE SORTABLE,
+        CD_entityName              STRING QUERYABLE SEARCHABLE SORTABLE,
+        CD_financialYearStartMonth INT64 QUERYABLE SORTABLE,
+        CD_id                      STRING QUERYABLE SEARCHABLE SORTABLE,
+        CD_label                   STRING QUERYABLE SEARCHABLE SORTABLE,
+        "___createTime"            TIMESTAMP,
+        "___createdBy"             REFERENCE,
+        "___etag"                  STRING,
+        "___modTime"               TIMESTAMP,
+        "___modifiedBy"            REFERENCE,
+        "___recordID"              REFERENCE,
+        GRANT WRITE TO "_creator",
+        GRANT CREATE TO "_icloud",
+        GRANT READ TO "_world"
+    );
+
+    RECORD TYPE CD_TransactionLegRecord (
+        CD_accountId     STRING QUERYABLE SEARCHABLE SORTABLE,
+        CD_categoryId    STRING QUERYABLE SEARCHABLE SORTABLE,
+        CD_earmarkId     STRING QUERYABLE SEARCHABLE SORTABLE,
+        CD_entityName    STRING QUERYABLE SEARCHABLE SORTABLE,
+        CD_id            STRING QUERYABLE SEARCHABLE SORTABLE,
+        CD_instrumentId  STRING QUERYABLE SEARCHABLE SORTABLE,
+        CD_quantity      INT64 QUERYABLE SORTABLE,
+        CD_sortOrder     INT64 QUERYABLE SORTABLE,
+        CD_transactionId STRING QUERYABLE SEARCHABLE SORTABLE,
+        CD_type          STRING QUERYABLE SEARCHABLE SORTABLE,
+        "___createTime"  TIMESTAMP,
+        "___createdBy"   REFERENCE,
+        "___etag"        STRING,
+        "___modTime"     TIMESTAMP,
+        "___modifiedBy"  REFERENCE,
+        "___recordID"    REFERENCE,
+        GRANT WRITE TO "_creator",
+        GRANT CREATE TO "_icloud",
+        GRANT READ TO "_world"
+    );
+
+    RECORD TYPE CD_TransactionRecord (
+        CD_date         TIMESTAMP QUERYABLE SORTABLE,
+        CD_entityName   STRING QUERYABLE SEARCHABLE SORTABLE,
+        CD_id           STRING QUERYABLE SEARCHABLE SORTABLE,
+        CD_payee        STRING QUERYABLE SEARCHABLE SORTABLE,
+        "___createTime" TIMESTAMP,
+        "___createdBy"  REFERENCE,
+        "___etag"       STRING,
+        "___modTime"    TIMESTAMP,
+        "___modifiedBy" REFERENCE,
+        "___recordID"   REFERENCE,
+        GRANT WRITE TO "_creator",
+        GRANT CREATE TO "_icloud",
+        GRANT READ TO "_world"
+    );
+
+    RECORD TYPE Users (
+        "___createTime" TIMESTAMP,
+        "___createdBy"  REFERENCE,
+        "___etag"       STRING,
+        "___modTime"    TIMESTAMP,
+        "___modifiedBy" REFERENCE,
+        "___recordID"   REFERENCE,
+        roles           LIST<INT64>,
+        GRANT WRITE TO "_creator",
+        GRANT READ TO "_world"
+    );

--- a/justfile
+++ b/justfile
@@ -199,3 +199,27 @@ run-mac-with-logs predicate='subsystem == "com.moolah.app"' *args: generate
 # Open the project in Xcode
 open:
     open Moolah.xcodeproj
+
+# Export the CloudKit Development schema to CloudKit/schema.ckdb.
+# Requires DEVELOPMENT_TEAM and a management token (`xcrun cktool save-token
+# --type management` for local use, or CKTOOL_MANAGEMENT_TOKEN in CI).
+export-schema:
+    bash scripts/export-schema.sh
+
+# Verify the CloudKit Development schema matches CloudKit/schema.ckdb.
+# Non-destructive; exits non-zero on drift. Run by CI on every PR.
+verify-schema:
+    bash scripts/verify-schema.sh
+
+# Promote CloudKit/schema.ckdb to the Production environment.
+# Intended to run from the TestFlight workflow before each upload. Production
+# schema changes are one-way — to run locally, re-run with CKTOOL_PROMOTE_FORCE=1.
+promote-schema:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [ "${CI:-}" != "true" ] && [ "${CKTOOL_PROMOTE_FORCE:-}" != "1" ]; then
+        echo "promote-schema is intended to run only in CI (on release tags)." >&2
+        echo "Re-run with CKTOOL_PROMOTE_FORCE=1 to force a local promotion." >&2
+        exit 1
+    fi
+    bash scripts/promote-schema.sh

--- a/scripts/cloudkit-config.sh
+++ b/scripts/cloudkit-config.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Shared config and helpers for CloudKit schema scripts. Sourced, not executed.
+
+set -euo pipefail
+
+# Must stay in sync with fastlane/Moolah.entitlements
+#   (com.apple.developer.icloud-container-identifiers).
+CLOUDKIT_CONTAINER_ID="iCloud.rocks.moolah.app.v2"
+
+# Committed schema snapshot. Diffed on every PR, promoted to production on
+# every release tag.
+CLOUDKIT_SCHEMA_FILE="CloudKit/schema.ckdb"
+
+cloudkit_fail() {
+    echo "error: $*" >&2
+    exit 1
+}
+
+cloudkit_require_env() {
+    [ -n "${DEVELOPMENT_TEAM:-}" ] \
+        || cloudkit_fail "DEVELOPMENT_TEAM is not set. Put it in .env or export it."
+}
+
+# Usage: cloudkit_cktool <subcommand> [extra args...]
+# Fills in --team-id and --container-id. Passes --token when
+# CKTOOL_MANAGEMENT_TOKEN is set (CI path); otherwise cktool falls back to the
+# keychain entry written by `xcrun cktool save-token` (local-dev path).
+cloudkit_cktool() {
+    local sub="$1"
+    shift
+    local args=(
+        "$sub"
+        --team-id "$DEVELOPMENT_TEAM"
+        --container-id "$CLOUDKIT_CONTAINER_ID"
+    )
+    if [ -n "${CKTOOL_MANAGEMENT_TOKEN:-}" ]; then
+        args+=(--token "$CKTOOL_MANAGEMENT_TOKEN")
+    fi
+    args+=("$@")
+    xcrun cktool "${args[@]}"
+}

--- a/scripts/export-schema.sh
+++ b/scripts/export-schema.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=scripts/cloudkit-config.sh
+source "$HERE/cloudkit-config.sh"
+
+cloudkit_require_env
+
+mkdir -p "$(dirname "$CLOUDKIT_SCHEMA_FILE")"
+cloudkit_cktool export-schema \
+    --environment development \
+    --output-file "$CLOUDKIT_SCHEMA_FILE"
+echo "Wrote $CLOUDKIT_SCHEMA_FILE"

--- a/scripts/promote-schema.sh
+++ b/scripts/promote-schema.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=scripts/cloudkit-config.sh
+source "$HERE/cloudkit-config.sh"
+
+cloudkit_require_env
+
+[ -f "$CLOUDKIT_SCHEMA_FILE" ] \
+    || cloudkit_fail "$CLOUDKIT_SCHEMA_FILE is missing."
+
+cloudkit_cktool import-schema \
+    --environment production \
+    --file "$CLOUDKIT_SCHEMA_FILE" \
+    --validate
+echo "Promoted $CLOUDKIT_SCHEMA_FILE to CloudKit production."

--- a/scripts/verify-schema.sh
+++ b/scripts/verify-schema.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=scripts/cloudkit-config.sh
+source "$HERE/cloudkit-config.sh"
+
+cloudkit_require_env
+
+[ -f "$CLOUDKIT_SCHEMA_FILE" ] \
+    || cloudkit_fail "$CLOUDKIT_SCHEMA_FILE is missing. Run 'just export-schema' to create it."
+
+tmp="$(mktemp -t cloudkit-schema)"
+trap 'rm -f "$tmp"' EXIT
+
+cloudkit_cktool export-schema \
+    --environment development \
+    --output-file "$tmp"
+
+if diff -u "$CLOUDKIT_SCHEMA_FILE" "$tmp"; then
+    echo "CloudKit development schema matches $CLOUDKIT_SCHEMA_FILE"
+    exit 0
+fi
+
+cat >&2 <<EOF
+
+error: CloudKit development schema has drifted from $CLOUDKIT_SCHEMA_FILE.
+
+Run 'just export-schema' and commit the updated file. If the drift was caused
+by experimentation in CloudKit Console, use 'Reset Development Environment'
+there and re-run.
+EOF
+exit 1


### PR DESCRIPTION
## Summary

- Adds `just export-schema` / `just verify-schema` / `just promote-schema` backed by `xcrun cktool`. The committed `CloudKit/schema.ckdb` is the single source of truth for what ships to production.
- **CI (`schema-drift` job)** runs on every PR and push to `main`/`mq-spec-*`: exports the Development schema, diffs it against the committed snapshot, fails on drift. Skips on fork PRs (no token).
- **TestFlight workflow** runs `just promote-schema` before the upload step. A failed promotion fails the release — better than a half-promoted schema reaching users.
- **Secrets** piggyback on the existing GHA model: one new repo-level secret `CKTOOL_MANAGEMENT_TOKEN`, scoped to `iCloud.rocks.moolah.app.v2` at mint time. `DEVELOPMENT_TEAM` is already wired.
- `just promote-schema` refuses to run outside `CI=true` unless `CKTOOL_PROMOTE_FORCE=1` is set — guards against accidental local promotions.

## Bootstrap — required before this PR can merge

CI will fail on this PR until the schema file and secret exist. One-time steps:

1. In CloudKit Console, mint a **Management token** scoped to `iCloud.rocks.moolah.app.v2`.
2. Save it locally once: `xcrun cktool save-token --type management` (keychain).
3. From this worktree: `DEVELOPMENT_TEAM=<team-id> just export-schema` — produces `CloudKit/schema.ckdb`. Commit it to this branch.
4. Add the same token as a GitHub Actions secret named `CKTOOL_MANAGEMENT_TOKEN` at the repo level (same place as `ASC_KEY_ID` etc.).
5. Push the commit; `schema-drift` should now pass.

## Test plan

- [ ] `just verify-schema` fails locally when `CloudKit/schema.ckdb` is missing.
- [ ] `just verify-schema` passes locally once `schema.ckdb` is committed and Dev matches.
- [ ] `just promote-schema` refuses without `CI=true` or `CKTOOL_PROMOTE_FORCE=1`.
- [ ] CI `schema-drift` job fails on a PR that introduces a new sync record field without running `just export-schema`.
- [ ] CI `schema-drift` job passes on an unrelated PR.
- [ ] A release tag runs `promote-schema` before the TestFlight upload (smoke-test on the next monthly tag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)