### PR TITLE
Task 6 of instrument-registry: add CryptoSearchClient + CoinGeckoSearchClient

### DIFF
--- a/Backends/CoinGecko/CoinGeckoSearchClient.swift
+++ b/Backends/CoinGecko/CoinGeckoSearchClient.swift
@@ -1,0 +1,55 @@
+// Backends/CoinGecko/CoinGeckoSearchClient.swift
+import Foundation
+
+struct CoinGeckoSearchClient: CryptoSearchClient {
+  private let apiKey: String?
+  private let session: URLSession
+  private static let baseURL =
+    URL(string: "https://api.coingecko.com/api/v3") ?? URL(fileURLWithPath: "/")
+
+  init(apiKey: String? = nil, session: URLSession = .shared) {
+    self.apiKey = apiKey
+    self.session = session
+  }
+
+  func search(query: String) async throws -> [CryptoSearchHit] {
+    var components = URLComponents(
+      url: Self.baseURL.appendingPathComponent("search"),
+      resolvingAgainstBaseURL: false
+    )
+    components?.queryItems = [URLQueryItem(name: "query", value: query)]
+    guard let url = components?.url else {
+      throw URLError(.badURL)
+    }
+    var request = URLRequest(url: url)
+    if let apiKey {
+      request.setValue(apiKey, forHTTPHeaderField: "x-cg-demo-api-key")
+    }
+    let (data, response) = try await session.data(for: request)
+    guard let http = response as? HTTPURLResponse,
+      (200..<300).contains(http.statusCode)
+    else {
+      throw URLError(.badServerResponse)
+    }
+    let decoded = try JSONDecoder().decode(CoinGeckoSearchResponse.self, from: data)
+    return decoded.coins.map { coin in
+      CryptoSearchHit(
+        coingeckoId: coin.id,
+        symbol: coin.symbol.uppercased(),
+        name: coin.name,
+        thumbnail: URL(string: coin.thumb ?? "")
+      )
+    }
+  }
+}
+
+private struct CoinGeckoSearchResponse: Decodable {
+  let coins: [CoinGeckoSearchCoin]
+}
+
+private struct CoinGeckoSearchCoin: Decodable {
+  let id: String
+  let name: String
+  let symbol: String
+  let thumb: String?
+}

--- a/Domain/Repositories/CryptoSearchClient.swift
+++ b/Domain/Repositories/CryptoSearchClient.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+/// A hit from a crypto-token search provider. Does not yet include
+/// chain / contract / decimals — callers that want to persist the hit
+/// must subsequently resolve those via `TokenResolutionClient`.
+struct CryptoSearchHit: Sendable, Hashable {
+  let coingeckoId: String
+  let symbol: String
+  let name: String
+  let thumbnail: URL?
+}
+
+/// Abstract search service for crypto tokens, typically backed by
+/// CoinGecko's `/search` endpoint.
+protocol CryptoSearchClient: Sendable {
+  func search(query: String) async throws -> [CryptoSearchHit]
+}

--- a/MoolahTests/Backends/CoinGeckoSearchClientTests.swift
+++ b/MoolahTests/Backends/CoinGeckoSearchClientTests.swift
@@ -1,0 +1,136 @@
+// MoolahTests/Backends/CoinGeckoSearchClientTests.swift
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("CoinGeckoSearchClient")
+struct CoinGeckoSearchClientTests {
+  @Test
+  func searchReturnsHitsFromFixture() async throws {
+    let client = try Self.makeStubbedClient()
+
+    let hits = try await client.search(query: "bitcoin")
+    #expect(hits.count == 2)
+    #expect(hits.first?.coingeckoId == "bitcoin")
+    #expect(hits.first?.symbol == "BTC")
+    #expect(hits.first?.name == "Bitcoin")
+    #expect(hits.first?.thumbnail == URL(string: "https://x/bitcoin.png"))
+  }
+
+  @Test
+  func searchSendsApiKeyHeaderWhenProvided() async throws {
+    let capturedHeader = LockedBox<String?>(nil)
+    let client = try Self.makeStubbedClient(apiKey: "secret-key") { request in
+      capturedHeader.set(request.value(forHTTPHeaderField: "x-cg-demo-api-key"))
+    }
+
+    _ = try await client.search(query: "bitcoin")
+    #expect(capturedHeader.get() == "secret-key")
+  }
+
+  @Test
+  func searchThrowsOnErrorStatus() async throws {
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [CoinGeckoSearchURLProtocolStub.self]
+    let session = URLSession(configuration: config)
+    let client = CoinGeckoSearchClient(apiKey: nil, session: session)
+
+    CoinGeckoSearchURLProtocolStub.requestHandler = { request in
+      let requestURL = try #require(request.url)
+      let response = try #require(
+        HTTPURLResponse(
+          url: requestURL,
+          statusCode: 500,
+          httpVersion: nil,
+          headerFields: nil
+        ))
+      return (response, Data())
+    }
+
+    await #expect(throws: Error.self) {
+      _ = try await client.search(query: "x")
+    }
+  }
+
+  // MARK: - Helpers
+
+  private static func bitcoinFixtureData() throws -> Data {
+    let bundle = Bundle(for: TestBundleMarker.self)
+    let url = try #require(
+      bundle.url(forResource: "coingecko-search-bitcoin", withExtension: "json"))
+    return try Data(contentsOf: url)
+  }
+
+  private static func makeStubbedClient(
+    statusCode: Int = 200,
+    apiKey: String? = nil,
+    inspectRequest: (@Sendable (URLRequest) -> Void)? = nil
+  ) throws -> CoinGeckoSearchClient {
+    let data = try bitcoinFixtureData()
+
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [CoinGeckoSearchURLProtocolStub.self]
+    let session = URLSession(configuration: config)
+
+    CoinGeckoSearchURLProtocolStub.requestHandler = { request in
+      inspectRequest?(request)
+      let requestURL = try #require(request.url)
+      let response = try #require(
+        HTTPURLResponse(
+          url: requestURL,
+          statusCode: statusCode,
+          httpVersion: nil,
+          headerFields: ["Content-Type": "application/json"]
+        ))
+      return (response, data)
+    }
+
+    return CoinGeckoSearchClient(apiKey: apiKey, session: session)
+  }
+}
+
+// Simple URLProtocol stub for CoinGecko search tests. Intentionally non-final
+// so the SwiftLint `static_over_final_class` rule doesn't apply to the
+// overridden `class func` members.
+private class CoinGeckoSearchURLProtocolStub: URLProtocol {
+  nonisolated(unsafe) static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+
+  override class func canInit(with request: URLRequest) -> Bool { true }
+  override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+  override func startLoading() {
+    guard let handler = CoinGeckoSearchURLProtocolStub.requestHandler else {
+      fatalError("Handler is not set.")
+    }
+    do {
+      let (response, data) = try handler(request)
+      client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+      client?.urlProtocol(self, didLoad: data)
+      client?.urlProtocolDidFinishLoading(self)
+    } catch {
+      client?.urlProtocol(self, didFailWithError: error)
+    }
+  }
+
+  override func stopLoading() {}
+}
+
+private final class LockedBox<Value>: @unchecked Sendable {
+  private let lock = NSLock()
+  private var value: Value
+
+  init(_ initial: Value) { self.value = initial }
+
+  func get() -> Value {
+    lock.lock()
+    defer { lock.unlock() }
+    return value
+  }
+
+  func set(_ newValue: Value) {
+    lock.lock()
+    defer { lock.unlock() }
+    value = newValue
+  }
+}

--- a/MoolahTests/Support/Fixtures/coingecko-search-bitcoin.json
+++ b/MoolahTests/Support/Fixtures/coingecko-search-bitcoin.json
@@ -1,0 +1,6 @@
+{
+  "coins": [
+    { "id": "bitcoin", "name": "Bitcoin", "symbol": "BTC", "thumb": "https://x/bitcoin.png" },
+    { "id": "wrapped-bitcoin", "name": "Wrapped Bitcoin", "symbol": "WBTC", "thumb": "" }
+  ]
+}


### PR DESCRIPTION
## Summary

- Task 6 of [`plans/2026-04-24-instrument-registry-implementation.md`](https://github.com/ajsutton/moolah-native/blob/main/plans/2026-04-24-instrument-registry-implementation.md). Tasks 1–5 already merged (#447, #448, #449, #451, #452).
- Adds `CryptoSearchClient` protocol (`Domain/Repositories/`) + `CryptoSearchHit` Sendable/Hashable value type.
- Adds `CoinGeckoSearchClient` (`Backends/CoinGecko/`) hitting `GET /search?query=...`; API key via `x-cg-demo-api-key` header.
- Will be consumed by `InstrumentSearchService` in Task 8.
- Three URLProtocol-stubbed tests cover: fixture decode, API-key header plumbing, 5xx error propagation. Shared setup extracted to a private helper; fixture load uses `try #require`.

## Test plan

- [x] `just format-check` clean
- [x] `just test` — macOS 1534 / iOS 1506 pass (3 new tests)
- [x] Spec + code-quality review ✅ after one polish round
- [x] Domain protocol imports `Foundation` only; no backend/URLSession leakage

🤖 Generated with [Claude Code](https://claude.com/claude-code)