### PR TITLE
Task 7 of instrument-registry: add StockTickerValidator + Yahoo implementation

### DIFF
--- a/Backends/YahooFinance/YahooFinancePriceFetcher.swift
+++ b/Backends/YahooFinance/YahooFinancePriceFetcher.swift
@@ -1,0 +1,33 @@
+// Backends/YahooFinance/YahooFinancePriceFetcher.swift
+import Foundation
+
+/// Minimal seam used by `YahooFinanceStockTickerValidator` to probe
+/// whether a parsed ticker corresponds to a real Yahoo-known instrument.
+/// Kept narrower than `StockPriceClient` so tests can stub it without
+/// constructing a full price-history response.
+protocol YahooFinancePriceFetcher: Sendable {
+  /// Returns the most recent available price for `ticker`, or nil when
+  /// Yahoo has no data for that symbol (i.e. the ticker is unknown).
+  func currentPrice(for ticker: String) async throws -> Decimal?
+}
+
+extension YahooFinanceClient: YahooFinancePriceFetcher {
+  /// Adapts `fetchDailyPrices` into a single-value probe. We look back a
+  /// week to tolerate weekends / holidays and return the latest price by
+  /// date. Treats "ticker not found" errors (`.apiError` / `.noData`) as
+  /// `nil` rather than rethrowing, so the validator can report the
+  /// ticker as invalid cleanly. All other errors (e.g. transport
+  /// failures) propagate.
+  func currentPrice(for ticker: String) async throws -> Decimal? {
+    let to = Date()
+    let from = to.addingTimeInterval(-7 * 24 * 60 * 60)
+    let response: StockPriceResponse
+    do {
+      response = try await fetchDailyPrices(ticker: ticker, from: from, to: to)
+    } catch YahooFinanceError.apiError, YahooFinanceError.noData {
+      return nil
+    }
+    guard let latestKey = response.prices.keys.max() else { return nil }
+    return response.prices[latestKey]
+  }
+}

--- a/Backends/YahooFinance/YahooFinanceStockTickerValidator.swift
+++ b/Backends/YahooFinance/YahooFinanceStockTickerValidator.swift
@@ -1,0 +1,56 @@
+// Backends/YahooFinance/YahooFinanceStockTickerValidator.swift
+import Foundation
+
+/// Default `StockTickerValidator` implementation — parses the query into
+/// an `(exchange, ticker)` pair and probes Yahoo Finance to confirm the
+/// ticker resolves to a real instrument.
+struct YahooFinanceStockTickerValidator: StockTickerValidator {
+  private let priceFetcher: any YahooFinancePriceFetcher
+
+  init(priceFetcher: any YahooFinancePriceFetcher) {
+    self.priceFetcher = priceFetcher
+  }
+
+  func validate(query: String) async throws -> ValidatedStockTicker? {
+    guard let parsed = parse(query: query) else { return nil }
+    let price = try await priceFetcher.currentPrice(for: parsed.ticker)
+    guard price != nil else { return nil }
+    return parsed
+  }
+
+  private func parse(query: String) -> ValidatedStockTicker? {
+    let trimmed = query.trimmingCharacters(in: .whitespaces)
+    guard !trimmed.isEmpty else { return nil }
+
+    if trimmed.contains(":") {
+      let parts = trimmed.split(separator: ":", maxSplits: 1)
+      guard parts.count == 2 else { return nil }
+      return ValidatedStockTicker(
+        ticker: String(parts[1]),
+        exchange: String(parts[0]).uppercased())
+    }
+
+    if trimmed.contains(".") {
+      let parts = trimmed.split(separator: ".", maxSplits: 1)
+      guard parts.count == 2 else { return nil }
+      let exchange = Self.yahooSuffixToExchange(String(parts[1]))
+      return ValidatedStockTicker(ticker: trimmed, exchange: exchange)
+    }
+
+    // Bare ticker — default to NASDAQ.
+    return ValidatedStockTicker(ticker: trimmed.uppercased(), exchange: "NASDAQ")
+  }
+
+  private static func yahooSuffixToExchange(_ suffix: String) -> String {
+    switch suffix.uppercased() {
+    case "AX": "ASX"
+    case "L": "LSE"
+    case "TO": "TSX"
+    case "HK": "HKEX"
+    case "T": "TYO"
+    case "PA": "EPA"
+    case "DE": "FRA"
+    default: suffix.uppercased()
+    }
+  }
+}

--- a/Domain/Repositories/StockTickerValidator.swift
+++ b/Domain/Repositories/StockTickerValidator.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+/// Successfully parsed stock-ticker identity — the `(exchange, ticker)`
+/// pair that uniquely identifies the instrument in the registry.
+struct ValidatedStockTicker: Sendable, Hashable {
+  let ticker: String
+  let exchange: String
+}
+
+/// Validates typed stock-ticker search queries before they are persisted
+/// as registry instruments.
+protocol StockTickerValidator: Sendable {
+  /// Attempts to validate a typed stock-ticker query. Accepts two forms:
+  /// - `"EXCHANGE:TICKER"` — the canonical id form used throughout the
+  ///   registry (e.g. `"ASX:BHP.AX"`).
+  /// - Yahoo-native suffixed ticker — e.g. `"BHP.AX"`, `"AAPL"`,
+  ///   `"^GSPC"`. The validator normalises both forms to an
+  ///   `(exchange, ticker)` pair before fetching a probe price.
+  /// Returns nil when no price is available for the parsed ticker.
+  func validate(query: String) async throws -> ValidatedStockTicker?
+}

--- a/MoolahTests/Backends/YahooFinanceStockTickerValidatorTests.swift
+++ b/MoolahTests/Backends/YahooFinanceStockTickerValidatorTests.swift
@@ -1,0 +1,51 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("YahooFinanceStockTickerValidator")
+struct YahooFinanceStockTickerValidatorTests {
+  @Test("parses EXCHANGE:TICKER form")
+  func parsesExchangeTickerForm() async throws {
+    let stub = StubYahooFinancePriceFetcher(available: ["BHP.AX": 45.0])
+    let validator = YahooFinanceStockTickerValidator(priceFetcher: stub)
+    let result = try await validator.validate(query: "ASX:BHP.AX")
+    #expect(result?.ticker == "BHP.AX")
+    #expect(result?.exchange == "ASX")
+  }
+
+  @Test("parses Yahoo-native suffix form")
+  func parsesYahooSuffixForm() async throws {
+    let stub = StubYahooFinancePriceFetcher(available: ["BHP.AX": 45.0])
+    let validator = YahooFinanceStockTickerValidator(priceFetcher: stub)
+    let result = try await validator.validate(query: "BHP.AX")
+    #expect(result?.ticker == "BHP.AX")
+    #expect(result?.exchange == "ASX")
+  }
+
+  @Test("returns nil when price fetcher finds nothing")
+  func returnsNilWhenUnknown() async throws {
+    let stub = StubYahooFinancePriceFetcher(available: [:])
+    let validator = YahooFinanceStockTickerValidator(priceFetcher: stub)
+    let result = try await validator.validate(query: "UNKNOWN")
+    #expect(result == nil)
+  }
+
+  @Test("bare ticker without Yahoo suffix defaults to NASDAQ")
+  func bareTickerDefaultsToNasdaq() async throws {
+    let stub = StubYahooFinancePriceFetcher(available: ["AAPL": 180.0])
+    let validator = YahooFinanceStockTickerValidator(priceFetcher: stub)
+    let result = try await validator.validate(query: "AAPL")
+    #expect(result?.ticker == "AAPL")
+    #expect(result?.exchange == "NASDAQ")
+  }
+}
+
+private struct StubYahooFinancePriceFetcher: YahooFinancePriceFetcher {
+  let available: [String: Double]
+
+  func currentPrice(for ticker: String) async throws -> Decimal? {
+    guard let price = available[ticker] else { return nil }
+    return Decimal(price)
+  }
+}


### PR DESCRIPTION
## Summary

- Task 7 of [`plans/2026-04-24-instrument-registry-implementation.md`](https://github.com/ajsutton/moolah-native/blob/main/plans/2026-04-24-instrument-registry-implementation.md). Tasks 1–6 already merged (through [#454](https://github.com/ajsutton/moolah-native/pull/454)).
- Adds `StockTickerValidator` protocol (`Domain/Repositories/`) + `ValidatedStockTicker` Sendable/Hashable value type.
- Adds `YahooFinancePriceFetcher` adapter protocol + `YahooFinanceStockTickerValidator` (`Backends/YahooFinance/`). The validator parses `EXCHANGE:TICKER` / Yahoo-suffix (`.AX`, `.L`, `.TO`, `.HK`, `.T`, `.PA`, `.DE`) / bare ticker (→ NASDAQ) forms and probes via a 7-day Yahoo price fetch.
- `currentPrice(for:)` adapter maps `.apiError` / `.noData` → `nil` (ticker-not-found) and rethrows transport errors.
- Four tests covering all three parse forms + unknown-ticker → nil.
- Will be consumed by `InstrumentSearchService` in Task 8.

## Test plan

- [x] `just format-check` clean
- [x] `just test` — full suite passes (new: 4 tests in `YahooFinanceStockTickerValidator` suite)
- [x] Spec + code-quality review ✅ on first pass
- [x] Domain protocol imports `Foundation` only; no backend/URLSession leakage

🤖 Generated with [Claude Code](https://claude.com/claude-code)