### PR TITLE
Task 8 of instrument-registry: add InstrumentSearchResult + InstrumentSearchService

### DIFF
--- a/Domain/Models/Instrument.swift
+++ b/Domain/Models/Instrument.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 struct Instrument: Codable, Sendable, Hashable, Identifiable {
-  enum Kind: String, Codable, Sendable {
+  enum Kind: String, Codable, Sendable, CaseIterable {
     case fiatCurrency
     case stock
     case cryptoToken

--- a/MoolahTests/Shared/InstrumentSearchServiceTests.swift
+++ b/MoolahTests/Shared/InstrumentSearchServiceTests.swift
@@ -1,0 +1,207 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("InstrumentSearchService")
+@MainActor
+struct InstrumentSearchServiceTests {
+  @MainActor
+  func makeSubject(
+    registered: [Instrument] = [],
+    cryptoHits: [CryptoSearchHit] = [],
+    cryptoSearchThrows: Bool = false,
+    stockValidated: ValidatedStockTicker? = nil,
+    stockValidatorThrows: Bool = false,
+    resolvedRegistration: CryptoRegistration? = nil
+  ) -> InstrumentSearchService {
+    let registry = StubRegistry(instruments: registered)
+    let crypto = StubCryptoSearchClient(hits: cryptoHits, shouldThrow: cryptoSearchThrows)
+    let stock = StubStockTickerValidator(
+      validated: stockValidated, shouldThrow: stockValidatorThrows)
+    let resolver = StubTokenResolutionClient(resolved: resolvedRegistration)
+    return InstrumentSearchService(
+      registry: registry,
+      cryptoSearchClient: crypto,
+      resolutionClient: resolver,
+      stockValidator: stock
+    )
+  }
+
+  @Test("fiat prefix match on ISO code")
+  func fiatPrefixMatch() async throws {
+    let service = makeSubject()
+    let results = await service.search(query: "usd")
+    #expect(results.contains { $0.instrument.id == "USD" })
+    #expect(results.allSatisfy { $0.instrument.kind == .fiatCurrency })
+  }
+
+  @Test("fiat substring match on localized name")
+  func fiatNameMatch() async throws {
+    let service = makeSubject()
+    let results = await service.search(query: "dollar")
+    // At minimum USD and AUD should surface; asserting "at least one" keeps
+    // the test robust against locale variation.
+    let ids = results.map(\.instrument.id)
+    #expect(ids.contains("USD") || ids.contains("AUD"))
+  }
+
+  @Test("crypto hits marked requiresResolution = true with populated coingeckoId")
+  func cryptoHitsMarkedForResolution() async throws {
+    let hits = [
+      CryptoSearchHit(
+        coingeckoId: "bitcoin", symbol: "BTC", name: "Bitcoin", thumbnail: nil),
+      CryptoSearchHit(
+        coingeckoId: "ethereum", symbol: "ETH", name: "Ethereum", thumbnail: nil),
+    ]
+    let service = makeSubject(cryptoHits: hits)
+    let results = await service.search(query: "bitcoin", kinds: [.cryptoToken])
+    #expect(results.contains { $0.instrument.ticker == "BTC" && $0.requiresResolution })
+    #expect(
+      results.contains {
+        $0.cryptoMapping?.coingeckoId == "bitcoin"
+      }
+    )
+  }
+
+  @Test("crypto query matching contract-address pattern bypasses search and calls resolver")
+  func contractAddressBypassesSearch() async throws {
+    let eth = Instrument.crypto(
+      chainId: 1,
+      contractAddress: "0xdac17f958d2ee523a2206206994597c13d831ec7",
+      symbol: "USDT", name: "Tether", decimals: 6)
+    let mapping = CryptoProviderMapping(
+      instrumentId: eth.id,
+      coingeckoId: "tether",
+      cryptocompareSymbol: "USDT",
+      binanceSymbol: "USDTUSDT")
+    let service = makeSubject(
+      cryptoHits: [],  // would cause the test to fail if the search path was used
+      resolvedRegistration: CryptoRegistration(instrument: eth, mapping: mapping)
+    )
+    let results = await service.search(
+      query: "0xdAC17F958D2ee523a2206206994597C13D831ec7", kinds: [.cryptoToken])
+    #expect(results.count == 1)
+    #expect(results.first?.requiresResolution == false)
+    #expect(results.first?.cryptoMapping?.cryptocompareSymbol == "USDT")
+  }
+
+  @Test("valid typed stock ticker yields one result")
+  func stockValidTypedTicker() async throws {
+    let validated = ValidatedStockTicker(ticker: "BHP.AX", exchange: "ASX")
+    let service = makeSubject(stockValidated: validated)
+    let results = await service.search(query: "BHP.AX", kinds: [.stock])
+    #expect(results.count == 1)
+    #expect(results.first?.instrument.id == "ASX:BHP.AX")
+    #expect(results.first?.requiresResolution == false)
+  }
+
+  @Test("invalid stock ticker yields no stock results")
+  func stockInvalidTicker() async throws {
+    let service = makeSubject(stockValidated: nil)
+    let results = await service.search(query: "UNKNOWN", kinds: [.stock])
+    #expect(results.isEmpty)
+  }
+
+  @Test("stock validator throw is absorbed; other kinds still return")
+  func stockValidatorThrowAbsorbed() async throws {
+    let service = makeSubject(stockValidatorThrows: true)
+    let results = await service.search(query: "usd")
+    // Fiat results still surface.
+    #expect(results.contains { $0.instrument.id == "USD" })
+  }
+
+  @Test("registered instruments marked isRegistered = true and ranked first")
+  func registeredRankFirst() async throws {
+    let bhp = Instrument.stock(ticker: "BHP.AX", exchange: "ASX", name: "BHP")
+    let service = makeSubject(registered: [bhp])
+    let results = await service.search(query: "BHP", kinds: [.stock])
+    let bhpResult = try #require(results.first { $0.instrument.id == "ASX:BHP.AX" })
+    #expect(bhpResult.isRegistered == true)
+    // It appears before any non-registered stock result.
+    let idx = results.firstIndex { $0.instrument.id == "ASX:BHP.AX" } ?? 0
+    let otherStockIdx =
+      results.firstIndex {
+        $0.instrument.kind == .stock && !$0.isRegistered
+      } ?? Int.max
+    #expect(idx < otherStockIdx)
+  }
+
+  @Test("provider hit sharing an id with a registered entry is dropped")
+  func dedupePreferRegistered() async throws {
+    let eth = Instrument.crypto(
+      chainId: 1, contractAddress: nil, symbol: "ETH",
+      name: "Ethereum", decimals: 18)
+    // registered ETH exists; crypto search hit also claims ETH (same id).
+    let hit = CryptoSearchHit(
+      coingeckoId: "ethereum", symbol: "ETH", name: "Ethereum", thumbnail: nil)
+    let service = makeSubject(registered: [eth], cryptoHits: [hit])
+    let results = await service.search(query: "ETH", kinds: [.cryptoToken])
+    let matching = results.filter { $0.instrument.id == eth.id }
+    #expect(matching.count == 1)
+    #expect(matching.first?.isRegistered == true)
+  }
+
+  @Test("empty query returns the registered set")
+  func emptyQueryReturnsRegistered() async throws {
+    let bhp = Instrument.stock(ticker: "BHP.AX", exchange: "ASX", name: "BHP")
+    let service = makeSubject(registered: [bhp])
+    let results = await service.search(query: "")
+    #expect(results.contains { $0.instrument.id == "ASX:BHP.AX" })
+    #expect(results.allSatisfy { $0.isRegistered })
+  }
+}
+
+// MARK: - Stubs
+
+private struct StubRegistry: InstrumentRegistryRepository, @unchecked Sendable {
+  let instruments: [Instrument]
+
+  func all() async throws -> [Instrument] { instruments }
+  func allCryptoRegistrations() async throws -> [CryptoRegistration] { [] }
+  func registerCrypto(
+    _ instrument: Instrument, mapping: CryptoProviderMapping
+  ) async throws {}
+  func registerStock(_ instrument: Instrument) async throws {}
+  func remove(id: String) async throws {}
+  @MainActor
+  func observeChanges() -> AsyncStream<Void> { AsyncStream { _ in } }
+}
+
+private struct StubCryptoSearchClient: CryptoSearchClient {
+  let hits: [CryptoSearchHit]
+  let shouldThrow: Bool
+
+  func search(query: String) async throws -> [CryptoSearchHit] {
+    if shouldThrow { throw URLError(.cannotConnectToHost) }
+    return hits
+  }
+}
+
+private struct StubStockTickerValidator: StockTickerValidator {
+  let validated: ValidatedStockTicker?
+  let shouldThrow: Bool
+
+  func validate(query: String) async throws -> ValidatedStockTicker? {
+    if shouldThrow { throw URLError(.cannotConnectToHost) }
+    return validated
+  }
+}
+
+private struct StubTokenResolutionClient: TokenResolutionClient {
+  let resolved: CryptoRegistration?
+
+  func resolve(
+    chainId: Int, contractAddress: String?, symbol: String?, isNative: Bool
+  ) async throws -> TokenResolutionResult {
+    guard let resolved else { return TokenResolutionResult() }
+    return TokenResolutionResult(
+      coingeckoId: resolved.mapping.coingeckoId,
+      cryptocompareSymbol: resolved.mapping.cryptocompareSymbol,
+      binanceSymbol: resolved.mapping.binanceSymbol,
+      resolvedName: resolved.instrument.name,
+      resolvedSymbol: resolved.instrument.ticker,
+      resolvedDecimals: resolved.instrument.decimals
+    )
+  }
+}

--- a/Shared/InstrumentSearchResult.swift
+++ b/Shared/InstrumentSearchResult.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// One candidate returned by `InstrumentSearchService`. May represent an
+/// already-registered instrument (pulled from `InstrumentRegistryRepository`),
+/// a crypto provider hit that still needs resolution before it can be
+/// persisted, a validated stock ticker, or an ambient fiat currency.
+struct InstrumentSearchResult: Sendable, Identifiable {
+  let instrument: Instrument
+  let cryptoMapping: CryptoProviderMapping?
+  let isRegistered: Bool
+  let requiresResolution: Bool
+
+  var id: String { instrument.id }
+}
+
+extension InstrumentSearchResult: Equatable {
+  static func == (lhs: Self, rhs: Self) -> Bool { lhs.id == rhs.id }
+}
+
+extension InstrumentSearchResult: Hashable {
+  func hash(into hasher: inout Hasher) { hasher.combine(id) }
+}

--- a/Shared/InstrumentSearchService.swift
+++ b/Shared/InstrumentSearchService.swift
@@ -1,0 +1,248 @@
+import Foundation
+import OSLog
+
+struct InstrumentSearchService: Sendable {
+  private let registry: any InstrumentRegistryRepository
+  private let cryptoSearchClient: any CryptoSearchClient
+  private let resolutionClient: any TokenResolutionClient
+  private let stockValidator: any StockTickerValidator
+  private let logger = Logger(
+    subsystem: "com.moolah.app",
+    category: "InstrumentSearch"
+  )
+
+  init(
+    registry: any InstrumentRegistryRepository,
+    cryptoSearchClient: any CryptoSearchClient,
+    resolutionClient: any TokenResolutionClient,
+    stockValidator: any StockTickerValidator
+  ) {
+    self.registry = registry
+    self.cryptoSearchClient = cryptoSearchClient
+    self.resolutionClient = resolutionClient
+    self.stockValidator = stockValidator
+  }
+
+  func search(
+    query: String,
+    kinds: Set<Instrument.Kind> = Set(Instrument.Kind.allCases)
+  ) async -> [InstrumentSearchResult] {
+    let trimmed = query.trimmingCharacters(in: .whitespaces)
+    let registered = await loadRegisteredOrLog()
+    if trimmed.isEmpty {
+      return registered.map {
+        InstrumentSearchResult(
+          instrument: $0,
+          cryptoMapping: nil,
+          isRegistered: true,
+          requiresResolution: false
+        )
+      }
+    }
+
+    async let fiatResults: [InstrumentSearchResult] =
+      kinds.contains(.fiatCurrency) ? fiatMatches(query: trimmed) : []
+    async let cryptoResults: [InstrumentSearchResult] =
+      kinds.contains(.cryptoToken) ? cryptoMatches(query: trimmed) : []
+    async let stockResults: [InstrumentSearchResult] =
+      kinds.contains(.stock) ? stockMatches(query: trimmed) : []
+
+    let provider = await (fiatResults + cryptoResults + stockResults)
+    let registeredMatches = registeredMatches(query: trimmed, all: registered)
+    return merge(registered: registeredMatches, provider: provider)
+  }
+
+  private func loadRegisteredOrLog() async -> [Instrument] {
+    do {
+      return try await registry.all()
+    } catch {
+      logger.warning(
+        "Registry fetch failed; returning empty registered set: \(error, privacy: .public)"
+      )
+      return []
+    }
+  }
+
+  // MARK: - Fiat
+
+  /// Fiat-currency search path.
+  ///
+  /// Every fiat result is marked `isRegistered: true` by design (see the design
+  /// spec §2.1): fiat is ambient — the full ISO currency set from
+  /// `Locale.Currency.isoCurrencies` is always available without any registration
+  /// step. From a picker's perspective "already in registry" is the correct
+  /// affordance for fiat: no "Add" button should appear. Stock/crypto hits, in
+  /// contrast, default `isRegistered: false` until they're promoted by the
+  /// merge step when they share an id with a stored row.
+  private func fiatMatches(query: String) -> [InstrumentSearchResult] {
+    let lowered = query.lowercased()
+    return Locale.Currency.isoCurrencies.compactMap { currency in
+      let code = currency.identifier
+      let lowerCode = code.lowercased()
+      let localizedName =
+        Locale.current.localizedString(forCurrencyCode: code)?.lowercased() ?? ""
+      guard lowerCode.hasPrefix(lowered) || localizedName.contains(lowered)
+      else { return nil }
+      return InstrumentSearchResult(
+        instrument: Instrument.fiat(code: code),
+        cryptoMapping: nil,
+        isRegistered: true,
+        requiresResolution: false
+      )
+    }
+  }
+
+  // MARK: - Crypto
+
+  private func cryptoMatches(query: String) async -> [InstrumentSearchResult] {
+    if isContractAddress(query) {
+      return await cryptoContractLookup(address: query)
+    }
+    do {
+      let hits = try await cryptoSearchClient.search(query: query)
+      return hits.map { hit in
+        let placeholder = Instrument.crypto(
+          chainId: 0,
+          contractAddress: nil,
+          symbol: hit.symbol,
+          name: hit.name,
+          decimals: 18
+        )
+        let mapping = CryptoProviderMapping(
+          instrumentId: placeholder.id,
+          coingeckoId: hit.coingeckoId,
+          cryptocompareSymbol: nil,
+          binanceSymbol: nil
+        )
+        return InstrumentSearchResult(
+          instrument: placeholder,
+          cryptoMapping: mapping,
+          isRegistered: false,
+          requiresResolution: true
+        )
+      }
+    } catch {
+      logger.warning(
+        "Crypto search failed for query=\(query, privacy: .public): \(error, privacy: .public)"
+      )
+      return []
+    }
+  }
+
+  private func cryptoContractLookup(address: String) async -> [InstrumentSearchResult] {
+    do {
+      // chainId 1 (Ethereum mainnet) is the most common; the follow-up UI
+      // can expose a chain selector later.
+      let result = try await resolutionClient.resolve(
+        chainId: 1,
+        contractAddress: address,
+        symbol: nil,
+        isNative: false
+      )
+      guard let coingeckoId = result.coingeckoId,
+        let symbol = result.resolvedSymbol,
+        let name = result.resolvedName,
+        let decimals = result.resolvedDecimals
+      else { return [] }
+      let instrument = Instrument.crypto(
+        chainId: 1,
+        contractAddress: address,
+        symbol: symbol,
+        name: name,
+        decimals: decimals
+      )
+      let mapping = CryptoProviderMapping(
+        instrumentId: instrument.id,
+        coingeckoId: coingeckoId,
+        cryptocompareSymbol: result.cryptocompareSymbol,
+        binanceSymbol: result.binanceSymbol
+      )
+      return [
+        InstrumentSearchResult(
+          instrument: instrument,
+          cryptoMapping: mapping,
+          isRegistered: false,
+          requiresResolution: false
+        )
+      ]
+    } catch {
+      logger.warning(
+        "Contract resolve failed for address=\(address, privacy: .public): \(error, privacy: .public)"
+      )
+      return []
+    }
+  }
+
+  private func isContractAddress(_ query: String) -> Bool {
+    guard query.count == 42 else { return false }
+    guard query.hasPrefix("0x") else { return false }
+    let hexPart = query.dropFirst(2)
+    return hexPart.allSatisfy { $0.isHexDigit }
+  }
+
+  // MARK: - Stock
+
+  private func stockMatches(query: String) async -> [InstrumentSearchResult] {
+    do {
+      guard let validated = try await stockValidator.validate(query: query) else {
+        return []
+      }
+      let stock = Instrument.stock(
+        ticker: validated.ticker,
+        exchange: validated.exchange,
+        name: validated.ticker,
+        decimals: 0
+      )
+      return [
+        InstrumentSearchResult(
+          instrument: stock,
+          cryptoMapping: nil,
+          isRegistered: false,
+          requiresResolution: false
+        )
+      ]
+    } catch {
+      logger.warning(
+        "Stock validator failed for query=\(query, privacy: .public): \(error, privacy: .public)"
+      )
+      return []
+    }
+  }
+
+  // MARK: - Merge + rank
+
+  private func registeredMatches(
+    query: String,
+    all: [Instrument]
+  ) -> [InstrumentSearchResult] {
+    let lowered = query.lowercased()
+    return all.compactMap { instrument in
+      let id = instrument.id.lowercased()
+      let ticker = instrument.ticker?.lowercased() ?? ""
+      let name = instrument.name.lowercased()
+      guard id.contains(lowered) || ticker.contains(lowered) || name.contains(lowered)
+      else { return nil }
+      return InstrumentSearchResult(
+        instrument: instrument,
+        cryptoMapping: nil,
+        isRegistered: true,
+        requiresResolution: false
+      )
+    }
+  }
+
+  private func merge(
+    registered: [InstrumentSearchResult],
+    provider: [InstrumentSearchResult]
+  ) -> [InstrumentSearchResult] {
+    var seen = Set<String>()
+    var out: [InstrumentSearchResult] = []
+    for result in registered where seen.insert(result.id).inserted {
+      out.append(result)
+    }
+    for result in provider where seen.insert(result.id).inserted {
+      out.append(result)
+    }
+    return out
+  }
+}


### PR DESCRIPTION
## Summary

- Task 8 of [`plans/2026-04-24-instrument-registry-implementation.md`](https://github.com/ajsutton/moolah-native/blob/main/plans/2026-04-24-instrument-registry-implementation.md). Tasks 1–7 already merged.
- Adds `Shared/InstrumentSearchResult.swift` — value type with custom `Equatable`/`Hashable` keyed on `id` only, so dedupe by `Instrument.id` works across registered + provider-hit variants.
- Adds `Shared/InstrumentSearchService.swift` — stateless `struct Sendable` (not an actor — concurrent searches fan out in parallel). `async let` over fiat (local ISO list), crypto (CoinGecko `/search` + contract-address resolver path), stock (`StockTickerValidator` probe). Individual-kind failures absorbed and logged via `os.Logger`; the method itself never throws.
- Adds 10 swift-testing cases covering fiat prefix/name match, crypto placeholder-with-mapping, contract-address resolver bypass, stock valid/invalid paths, validator-throw absorption, registered-first ranking, provider-vs-registered dedupe, and empty-query → registered set.

### Autonomous scope expansions the implementer made (flagged in the PR for reviewer awareness)
- Added `CaseIterable` to `Instrument.Kind` so `kinds` parameter can default to `Set(Instrument.Kind.allCases)` — avoids SwiftLint `discouraged_optional_collection` on the `Set<...>? = nil` shape in the plan.
- Replaced the plan's `try! NSRegularExpression(...)` with a `Character.isHexDigit`-based contract-address check to avoid `force_try`. Logic equivalent to `^0x[0-9a-fA-F]{40}$`.

## Test plan

- [x] `just format-check` clean
- [x] `just test` — macOS 1574 / iOS 1545 pass (10 new tests)
- [x] Spec + code-quality review ✅ after one amend round (added error-logging helper; added design-rationale doc comment for fiat `isRegistered: true` semantic per design §2.1)
- [x] `Shared/InstrumentSearchService.swift` imports only `Foundation` + `OSLog` — no backend/URLSession leakage
- [x] `.swiftlint-baseline.yml` diff empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)