### PR TITLE
Task 9 of instrument-registry: skip fiat in ensureInstrument

### DIFF
--- a/Backends/CloudKit/Repositories/CloudKitAccountRepository.swift
+++ b/Backends/CloudKit/Repositories/CloudKitAccountRepository.swift
@@ -183,6 +183,10 @@ final class CloudKitAccountRepository: AccountRepository, @unchecked Sendable {
 
   @MainActor
   private func ensureInstrument(_ instrument: Instrument) throws {
+    guard instrument.kind != .fiatCurrency else {
+      instrumentCacheForAccount[instrument.id] = instrument
+      return
+    }
     let iid = instrument.id
     let descriptor = FetchDescriptor<InstrumentRecord>(predicate: #Predicate { $0.id == iid })
     if try context.fetch(descriptor).isEmpty {

--- a/Backends/CloudKit/Repositories/CloudKitTransactionRepository.swift
+++ b/Backends/CloudKit/Repositories/CloudKitTransactionRepository.swift
@@ -48,6 +48,10 @@ final class CloudKitTransactionRepository: TransactionRepository, @unchecked Sen
 
   @MainActor
   func ensureInstrument(_ instrument: Instrument) throws {
+    guard instrument.kind != .fiatCurrency else {
+      instrumentCache[instrument.id] = instrument
+      return
+    }
     let iid = instrument.id
     let descriptor = FetchDescriptor<InstrumentRecord>(predicate: #Predicate { $0.id == iid })
     if try context.fetch(descriptor).isEmpty {

--- a/MoolahTests/Domain/EnsureInstrumentSkipFiatTests.swift
+++ b/MoolahTests/Domain/EnsureInstrumentSkipFiatTests.swift
@@ -1,0 +1,40 @@
+import Foundation
+import SwiftData
+import Testing
+
+@testable import Moolah
+
+@Suite("ensureInstrument — skips fiat")
+@MainActor
+struct EnsureInstrumentSkipFiatTests {
+  @Test
+  func fiatDoesNotInsertInstrumentRecord() async throws {
+    let repo = try makeContractCloudKitTransactionRepository()
+    let context = repo.modelContainer.mainContext
+
+    try repo.ensureInstrument(Instrument.fiat(code: "EUR"))
+    try context.save()
+
+    let descriptor = FetchDescriptor<InstrumentRecord>(
+      predicate: #Predicate { $0.id == "EUR" }
+    )
+    let rows = try context.fetch(descriptor)
+    #expect(rows.isEmpty)
+  }
+
+  @Test
+  func stockStillInserts() async throws {
+    let repo = try makeContractCloudKitTransactionRepository()
+    let context = repo.modelContainer.mainContext
+
+    let bhp = Instrument.stock(ticker: "BHP.AX", exchange: "ASX", name: "BHP")
+    try repo.ensureInstrument(bhp)
+    try context.save()
+
+    let descriptor = FetchDescriptor<InstrumentRecord>(
+      predicate: #Predicate { $0.id == "ASX:BHP.AX" }
+    )
+    let rows = try context.fetch(descriptor)
+    #expect(rows.count == 1)
+  }
+}


### PR DESCRIPTION
## Summary

- Task 9 of [`plans/2026-04-24-instrument-registry-implementation.md`](https://github.com/ajsutton/moolah-native/blob/main/plans/2026-04-24-instrument-registry-implementation.md). Tasks 1–8 already merged.
- Adds a fiat-skip guard at the top of both `CloudKitTransactionRepository.ensureInstrument(_:)` and `CloudKitAccountRepository.ensureInstrument(_:)`. Fiat instruments are served ambient by `InstrumentRegistryRepository.all()` (from `Locale.Currency.isoCurrencies`); writing a per-profile `InstrumentRecord` for a fiat code creates a redundant per-profile duplicate of a universal constant and unnecessarily churns the sync engine.
- Stock/crypto behaviour is unchanged — DB insert + `onInstrumentChanged` fire as before.
- Two new tests in `MoolahTests/Domain/EnsureInstrumentSkipFiatTests.swift` covering fiat-skip and stock-still-inserts (using the new `EXCHANGE:TICKER` id form).

## Test plan

- [x] `just format-check` clean
- [x] `just test` — macOS 1576 / iOS 1547 pass
- [x] Spec + code-quality review ✅ on first pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)