### PR TITLE
Task 10 of instrument-registry: make FullConversionService.providerMappings throwing

### DIFF
--- a/MoolahTests/Shared/FullConversionErrorPropagationTests.swift
+++ b/MoolahTests/Shared/FullConversionErrorPropagationTests.swift
@@ -1,0 +1,49 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("FullConversionService — providerMappings throws")
+struct FullConversionErrorPropagationTests {
+  struct FakeRegistryError: Error {}
+
+  /// When the `providerMappings` closure throws (e.g. registry read failure),
+  /// the error must propagate through `convert(_:from:to:on:)` for a crypto
+  /// conversion rather than being silently collapsed to an empty mapping
+  /// table — which would masquerade as a spurious `noProviderMapping` error
+  /// and violate Rule 11 of `guides/INSTRUMENT_CONVERSION_GUIDE.md`.
+  @Test
+  func cryptoConversionPropagatesRegistryError() async throws {
+    let cryptoService = CryptoPriceService(
+      clients: [FixedCryptoPriceClient()],
+      cacheDirectory: FileManager.default.temporaryDirectory
+        .appendingPathComponent(UUID().uuidString)
+    )
+    let exchangeService = ExchangeRateService(
+      client: FixedRateClient(rates: [:]),
+      cacheDirectory: FileManager.default.temporaryDirectory
+        .appendingPathComponent(UUID().uuidString)
+    )
+    let stockService = StockPriceService(client: FixedStockPriceClient())
+
+    let service = FullConversionService(
+      exchangeRates: exchangeService,
+      stockPrices: stockService,
+      cryptoPrices: cryptoService,
+      providerMappings: { () async throws -> [CryptoProviderMapping] in
+        throw FakeRegistryError()
+      }
+    )
+
+    let eth = Instrument.crypto(
+      chainId: 1, contractAddress: nil, symbol: "ETH",
+      name: "Ethereum", decimals: 18
+    )
+
+    await #expect(throws: FakeRegistryError.self) {
+      _ = try await service.convert(
+        Decimal(1), from: eth, to: Instrument.USD, on: Date()
+      )
+    }
+  }
+}

--- a/Shared/FullConversionService.swift
+++ b/Shared/FullConversionService.swift
@@ -9,18 +9,21 @@ actor FullConversionService: InstrumentConversionService {
   private let exchangeRates: ExchangeRateService
   private let stockPrices: StockPriceService
   private let cryptoPrices: CryptoPriceService?
-  private let providerMappings: @Sendable () async -> [CryptoProviderMapping]
+  private let providerMappings: @Sendable () async throws -> [CryptoProviderMapping]
   private let logger = Logger(subsystem: "com.moolah.app", category: "CurrencyConversion")
 
   /// - Parameter providerMappings: Closure invoked on each crypto conversion
   ///   to obtain the current set of provider mappings. Tokens registered via
   ///   `CryptoPriceService` after service construction become resolvable on
-  ///   the next conversion without rebuilding the service.
+  ///   the next conversion without rebuilding the service. Errors thrown by
+  ///   the closure (e.g. registry read failures) propagate through
+  ///   `convert(_:from:to:on:)` rather than collapsing silently to an empty
+  ///   mapping table — see `guides/INSTRUMENT_CONVERSION_GUIDE.md` Rule 11.
   init(
     exchangeRates: ExchangeRateService,
     stockPrices: StockPriceService,
     cryptoPrices: CryptoPriceService? = nil,
-    providerMappings: @Sendable @escaping () async -> [CryptoProviderMapping] = { [] }
+    providerMappings: @Sendable @escaping () async throws -> [CryptoProviderMapping] = { [] }
   ) {
     self.exchangeRates = exchangeRates
     self.stockPrices = stockPrices
@@ -134,7 +137,7 @@ actor FullConversionService: InstrumentConversionService {
     guard let cryptoPrices else {
       throw ConversionError.noCryptoPriceService
     }
-    let mappings = await providerMappings()
+    let mappings = try await providerMappings()
     guard let mapping = mappings.first(where: { $0.instrumentId == instrument.id }) else {
       throw ConversionError.noProviderMapping(instrumentId: instrument.id)
     }


### PR DESCRIPTION
## Summary

- Task 10 of [`plans/2026-04-24-instrument-registry-implementation.md`](https://github.com/ajsutton/moolah-native/blob/main/plans/2026-04-24-instrument-registry-implementation.md). Tasks 1–9 already merged.
- Changes `FullConversionService.init`'s `providerMappings` closure from `@Sendable @escaping () async -> [CryptoProviderMapping]` to the throwing variant. `cryptoUsdPrice(for:on:)` now invokes it with `try await`, and errors surface via the existing `throws` on `convert(_:from:to:on:)`.
- Prevents silent collapse to an empty mapping table when a future registry read fails — conforms to `guides/INSTRUMENT_CONVERSION_GUIDE.md` Rule 11 (failed conversions must be surfaced, not silently swallowed). Rule cited in an inline doc comment above `init`.
- Existing non-throwing call sites (`ProfileSession+Factories.swift` and four test files) compile unchanged via Swift's throws-subtype relationship.
- New `FullConversionErrorPropagationTests` asserts the injected error type propagates via `#expect(throws: FakeRegistryError.self)`. File name shortened from the plan's `FullConversionServiceErrorPropagationTests` to satisfy SwiftLint's 40-char `type_name` cap.

## Test plan

- [x] `just format-check` clean
- [x] `just test` — macOS 1577 / iOS 1548 pass
- [x] `instrument-conversion-review` ✅ on first pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)