### PR TITLE
Task 11 of instrument-registry: wire InstrumentRegistryRepository through services + views

### DIFF
--- a/App/ProfileSession+Factories.swift
+++ b/App/ProfileSession+Factories.swift
@@ -58,7 +58,6 @@ extension ProfileSession {
 
     return CryptoPriceService(
       clients: priceClients,
-      tokenRepository: ICloudTokenRepository(),
       resolutionClient: CompositeTokenResolutionClient(coinGeckoApiKey: coinGeckoApiKey)
     )
   }
@@ -69,6 +68,7 @@ extension ProfileSession {
   static func makeBackend(
     profile: Profile,
     containerManager: ProfileContainerManager?,
+    syncCoordinator: SyncCoordinator? = nil,
     exchangeRates: ExchangeRateService,
     stockPrices: StockPriceService,
     cryptoPrices: CryptoPriceService
@@ -103,25 +103,69 @@ extension ProfileSession {
       // every call site depends on the session existing so there's no recovery.
       // swiftlint:disable:next force_try
       let profileContainer = try! containerManager.container(for: profile.id)
+      let zoneID = CKRecordZone.ID(
+        zoneName: "profile-\(profile.id.uuidString)",
+        ownerName: CKCurrentUserDefaultName)
+      let registry = CloudKitInstrumentRegistryRepository(
+        modelContainer: profileContainer,
+        onRecordChanged: { [weak syncCoordinator] recordName in
+          // Registry callbacks may run off MainActor; hop onto MainActor to
+          // reach the actor-isolated SyncCoordinator.queueSave(_:zoneID:).
+          Task { @MainActor [weak syncCoordinator] in
+            syncCoordinator?.queueSave(recordName: recordName, zoneID: zoneID)
+          }
+        },
+        onRecordDeleted: { [weak syncCoordinator] recordName in
+          Task { @MainActor [weak syncCoordinator] in
+            syncCoordinator?.queueDeletion(recordName: recordName, zoneID: zoneID)
+          }
+        }
+      )
       // CloudKit profiles need full stock+crypto conversion support. The
-      // closure reads registered tokens from CryptoPriceService on each
-      // conversion so registrations added at runtime become usable without
-      // rebuilding the service. See issue #102.
+      // closure reads the profile's registry on each conversion so
+      // registrations added at runtime become usable without rebuilding the
+      // service. See issue #102.
       let conversionService = FullConversionService(
         exchangeRates: exchangeRates,
         stockPrices: stockPrices,
         cryptoPrices: cryptoPrices,
         providerMappings: {
-          await cryptoPrices.registeredItems().map(\.mapping)
+          try await registry.allCryptoRegistrations().map(\.mapping)
         }
       )
       return CloudKitBackend(
         modelContainer: profileContainer,
         instrument: profile.instrument,
         profileLabel: profile.label,
-        conversionService: conversionService
+        conversionService: conversionService,
+        instrumentRegistry: registry
       )
     }
+  }
+
+  /// Bundle of the optional instrument-registry pieces: only CloudKit
+  /// profiles expose a registry and crypto token store. Remote/moolah
+  /// profiles are single-instrument by server design and leave both nil.
+  struct RegistryWiring {
+    let registry: (any InstrumentRegistryRepository)?
+    let cryptoTokenStore: CryptoTokenStore?
+  }
+
+  /// Resolves the optional instrument-registry wiring for a profile. Returns
+  /// a populated pair for CloudKit profiles; returns nils for Remote/moolah
+  /// profiles so settings views can gate on `cryptoTokenStore != nil`.
+  @MainActor
+  static func makeRegistryWiring(
+    backend: BackendProvider, cryptoPriceService: CryptoPriceService
+  ) -> RegistryWiring {
+    guard let cloudBackend = backend as? CloudKitBackend else {
+      return RegistryWiring(registry: nil, cryptoTokenStore: nil)
+    }
+    let store = CryptoTokenStore(
+      registry: cloudBackend.instrumentRegistry,
+      cryptoPriceService: cryptoPriceService)
+    return RegistryWiring(
+      registry: cloudBackend.instrumentRegistry, cryptoTokenStore: store)
   }
 
   /// Bundle of the per-profile domain stores. Returned from

--- a/App/ProfileSession.swift
+++ b/App/ProfileSession.swift
@@ -21,7 +21,8 @@ final class ProfileSession: Identifiable {
   let exchangeRateService: ExchangeRateService
   let stockPriceService: StockPriceService
   let cryptoPriceService: CryptoPriceService
-  let cryptoTokenStore: CryptoTokenStore
+  let instrumentRegistry: (any InstrumentRegistryRepository)?
+  let cryptoTokenStore: CryptoTokenStore?
   let importStore: ImportStore
   let importRuleStore: ImportRuleStore
   let importPreferences: ImportPreferences
@@ -54,16 +55,21 @@ final class ProfileSession: Identifiable {
     self.exchangeRateService = services.exchangeRate
     self.stockPriceService = services.stockPrice
     self.cryptoPriceService = services.cryptoPrice
-    self.cryptoTokenStore = CryptoTokenStore(cryptoPriceService: services.cryptoPrice)
 
     let backend = Self.makeBackend(
       profile: profile,
       containerManager: containerManager,
+      syncCoordinator: syncCoordinator,
       exchangeRates: services.exchangeRate,
       stockPrices: services.stockPrice,
       cryptoPrices: services.cryptoPrice
     )
     self.backend = backend
+
+    let registryWiring = Self.makeRegistryWiring(
+      backend: backend, cryptoPriceService: services.cryptoPrice)
+    self.instrumentRegistry = registryWiring.registry
+    self.cryptoTokenStore = registryWiring.cryptoTokenStore
     let stores = Self.makeDomainStores(profile: profile, backend: backend)
     self.authStore = stores.auth
     self.accountStore = stores.account

--- a/Backends/CloudKit/CloudKitBackend.swift
+++ b/Backends/CloudKit/CloudKitBackend.swift
@@ -14,12 +14,14 @@ final class CloudKitBackend: BackendProvider, @unchecked Sendable {
   let conversionService: any InstrumentConversionService
   let csvImportProfiles: any CSVImportProfileRepository
   let importRules: any ImportRuleRepository
+  let instrumentRegistry: any InstrumentRegistryRepository
 
   init(
     modelContainer: ModelContainer,
     instrument: Instrument,
     profileLabel: String,
-    conversionService: any InstrumentConversionService
+    conversionService: any InstrumentConversionService,
+    instrumentRegistry: any InstrumentRegistryRepository
   ) {
     self.auth = CloudKitAuthProvider(profileLabel: profileLabel)
     self.accounts = CloudKitAccountRepository(
@@ -40,5 +42,6 @@ final class CloudKitBackend: BackendProvider, @unchecked Sendable {
     self.csvImportProfiles = CloudKitCSVImportProfileRepository(
       modelContainer: modelContainer)
     self.importRules = CloudKitImportRuleRepository(modelContainer: modelContainer)
+    self.instrumentRegistry = instrumentRegistry
   }
 }

--- a/Backends/CloudKit/Sync/SyncCoordinator+Lifecycle.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+Lifecycle.swift
@@ -186,6 +186,11 @@ extension SyncCoordinator {
     syncEngine?.state.add(pendingRecordZoneChanges: [.deleteRecord(recordID)])
   }
 
+  func queueDeletion(recordName: String, zoneID: CKRecordZone.ID) {
+    let recordID = CKRecord.ID(recordName: recordName, zoneID: zoneID)
+    syncEngine?.state.add(pendingRecordZoneChanges: [.deleteRecord(recordID)])
+  }
+
   func sendChanges() async {
     guard let syncEngine, isRunning else { return }
     do {

--- a/Features/Settings/CryptoTokenStore.swift
+++ b/Features/Settings/CryptoTokenStore.swift
@@ -1,5 +1,6 @@
 // Features/Settings/CryptoTokenStore.swift
 import Foundation
+import OSLog
 
 @MainActor
 @Observable
@@ -15,35 +16,51 @@ final class CryptoTokenStore {
 
   private(set) var error: String?
 
+  private let registry: any InstrumentRegistryRepository
   private let cryptoPriceService: CryptoPriceService
+  private let logger = Logger(
+    subsystem: "com.moolah.app", category: "CryptoTokenStore")
 
   private let apiKeyStore = KeychainStore(
     service: "com.moolah.api-keys", account: "coingecko", synchronizable: true
   )
 
-  init(cryptoPriceService: CryptoPriceService) {
+  init(
+    registry: any InstrumentRegistryRepository,
+    cryptoPriceService: CryptoPriceService
+  ) {
+    self.registry = registry
     self.cryptoPriceService = cryptoPriceService
   }
 
   func loadRegistrations() async {
     isLoading = true
     defer { isLoading = false }
-    let loaded = await cryptoPriceService.registeredItems()
-    registrations = loaded
-    instruments = loaded.map(\.instrument)
-    providerMappings = Dictionary(
-      loaded.map { ($0.mapping.instrumentId, $0.mapping) },
-      uniquingKeysWith: { _, last in last }
-    )
+    do {
+      let loaded = try await registry.allCryptoRegistrations()
+      registrations = loaded
+      instruments = loaded.map(\.instrument)
+      providerMappings = Dictionary(
+        loaded.map { ($0.mapping.instrumentId, $0.mapping) },
+        uniquingKeysWith: { _, last in last }
+      )
+      error = nil
+    } catch {
+      logger.error(
+        "Failed to load crypto registrations: \(error, privacy: .public)")
+      self.error = error.localizedDescription
+    }
   }
 
   func removeRegistration(_ registration: CryptoRegistration) async {
     do {
-      try await cryptoPriceService.remove(registration)
+      try await registry.remove(id: registration.id)
+      await cryptoPriceService.purgeCache(instrumentId: registration.id)
       registrations.removeAll { $0.id == registration.id }
       instruments.removeAll { $0.id == registration.id }
       providerMappings.removeValue(forKey: registration.id)
     } catch {
+      logger.error("Failed to remove registration: \(error, privacy: .public)")
       self.error = error.localizedDescription
     }
   }
@@ -77,12 +94,14 @@ final class CryptoTokenStore {
   func confirmRegistration() async {
     guard let registration = resolvedRegistration else { return }
     do {
-      try await cryptoPriceService.register(registration)
+      try await registry.registerCrypto(
+        registration.instrument, mapping: registration.mapping)
       registrations.append(registration)
       instruments.append(registration.instrument)
       providerMappings[registration.mapping.instrumentId] = registration.mapping
       resolvedRegistration = nil
     } catch {
+      logger.error("Failed to confirm registration: \(error, privacy: .public)")
       self.error = error.localizedDescription
     }
   }

--- a/Features/Settings/SettingsView+iOS.swift
+++ b/Features/Settings/SettingsView+iOS.swift
@@ -9,18 +9,6 @@
 
     // MARK: - iOS: NavigationStack layout
 
-    var cryptoTokenStoreForSettings: CryptoTokenStore {
-      if let session = activeSession {
-        return session.cryptoTokenStore
-      }
-      let fallbackService = CryptoPriceService(
-        clients: [CryptoCompareClient(), BinanceClient()],
-        tokenRepository: ICloudTokenRepository(),
-        resolutionClient: CompositeTokenResolutionClient()
-      )
-      return CryptoTokenStore(cryptoPriceService: fallbackService)
-    }
-
     var iOSLayout: some View {
       List {
         profilesSection
@@ -130,12 +118,14 @@
       }
     }
 
-    var cryptoSection: some View {
-      Section {
-        NavigationLink {
-          CryptoSettingsView(store: cryptoTokenStoreForSettings)
-        } label: {
-          Label("Crypto Tokens", systemImage: "bitcoinsign.circle")
+    @ViewBuilder var cryptoSection: some View {
+      if let store = activeSession?.cryptoTokenStore {
+        Section {
+          NavigationLink {
+            CryptoSettingsView(store: store)
+          } label: {
+            Label("Crypto Tokens", systemImage: "bitcoinsign.circle")
+          }
         }
       }
     }

--- a/Features/Settings/SettingsView.swift
+++ b/Features/Settings/SettingsView.swift
@@ -47,18 +47,6 @@ struct SettingsView: View {
   // MARK: - macOS: HSplitView layout
 
   #if os(macOS)
-    private var cryptoTokenStoreForSettings: CryptoTokenStore {
-      if let session = sessionForSettings {
-        return session.cryptoTokenStore
-      }
-      let fallbackService = CryptoPriceService(
-        clients: [CryptoCompareClient(), BinanceClient()],
-        tokenRepository: ICloudTokenRepository(),
-        resolutionClient: CompositeTokenResolutionClient()
-      )
-      return CryptoTokenStore(cryptoPriceService: fallbackService)
-    }
-
     /// The Settings scene lives outside `SessionRootView`, so the session
     /// stores aren't in its environment. Resolve one here for the tabs
     /// that depend on per-profile state. Prefer the active profile; fall
@@ -71,13 +59,26 @@ struct SettingsView: View {
       return sessionManager.sessions.values.first
     }
 
+    /// The Crypto Tokens tab's store, taken strictly from the *active* profile's
+    /// session — not any open session — so switching to a Remote/moolah active
+    /// profile correctly hides crypto settings even when a CloudKit session is
+    /// still open in another profile's window.
+    private var activeCryptoTokenStore: CryptoTokenStore? {
+      guard let id = profileStore.activeProfileID,
+        let session = sessionManager.sessions[id]
+      else { return nil }
+      return session.cryptoTokenStore
+    }
+
     private var macOSLayout: some View {
       TabView {
         Tab("Profiles", systemImage: "person.2") {
           profilesContent
         }
-        Tab("Crypto", systemImage: "bitcoinsign.circle") {
-          CryptoSettingsView(store: cryptoTokenStoreForSettings)
+        if let store = activeCryptoTokenStore {
+          Tab("Crypto", systemImage: "bitcoinsign.circle") {
+            CryptoSettingsView(store: store)
+          }
         }
         // macOS Settings tabs host the Form / List directly — the window
         // already supplies chrome and a title, so wrapping in a second

--- a/MoolahTests/App/ProfileSessionInstrumentRegistryTests.swift
+++ b/MoolahTests/App/ProfileSessionInstrumentRegistryTests.swift
@@ -1,0 +1,32 @@
+// MoolahTests/App/ProfileSessionInstrumentRegistryTests.swift
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("ProfileSession — instrumentRegistry wiring")
+@MainActor
+struct ProfileSessionInstrumentRegistryTests {
+  @Test("CloudKit profile has both registry and cryptoTokenStore")
+  func cloudKitProfileHasRegistry() throws {
+    let containerManager = try ProfileContainerManager.forTesting()
+    let profile = Profile(
+      label: "iCloud", backendType: .cloudKit,
+      currencyCode: "AUD", financialYearStartMonth: 7
+    )
+    let session = ProfileSession(profile: profile, containerManager: containerManager)
+
+    #expect(session.instrumentRegistry != nil)
+    #expect(session.cryptoTokenStore != nil)
+  }
+
+  @Test("Remote profile has no registry and no cryptoTokenStore")
+  func remoteProfileHasNoRegistry() throws {
+    let url = try #require(URL(string: "https://moolah.rocks/api/"))
+    let profile = Profile(label: "Remote", serverURL: url)
+    let session = ProfileSession(profile: profile)
+
+    #expect(session.instrumentRegistry == nil)
+    #expect(session.cryptoTokenStore == nil)
+  }
+}

--- a/MoolahTests/App/ProfileSessionTests.swift
+++ b/MoolahTests/App/ProfileSessionTests.swift
@@ -76,7 +76,7 @@ struct ProfileSessionTests {
     let session = ProfileSession(profile: profile, containerManager: containerManager)
 
     // Store exists and starts empty (registrations load on demand).
-    #expect(session.cryptoTokenStore.registrations.isEmpty)
+    #expect(session.cryptoTokenStore?.registrations.isEmpty == true)
   }
 
   // MARK: - storesToReload (sync reload dispatch policy)

--- a/MoolahTests/CloudKit/MultiProfileIsolationTests.swift
+++ b/MoolahTests/CloudKit/MultiProfileIsolationTests.swift
@@ -36,10 +36,12 @@ struct MultiProfileIsolationTests {
 
     let backendA = CloudKitBackend(
       modelContainer: containerA, instrument: .defaultTestInstrument, profileLabel: "A",
-      conversionService: FixedConversionService())
+      conversionService: FixedConversionService(),
+      instrumentRegistry: CloudKitInstrumentRegistryRepository(modelContainer: containerA))
     let backendB = CloudKitBackend(
       modelContainer: containerB, instrument: .defaultTestInstrument, profileLabel: "B",
-      conversionService: FixedConversionService())
+      conversionService: FixedConversionService(),
+      instrumentRegistry: CloudKitInstrumentRegistryRepository(modelContainer: containerB))
 
     _ = try await backendA.categories.create(Moolah.Category(name: "A-Cat"))
     _ = try await backendB.categories.create(Moolah.Category(name: "B-Cat"))

--- a/MoolahTests/Export/ExportImportIntegrationTests.swift
+++ b/MoolahTests/Export/ExportImportIntegrationTests.swift
@@ -67,6 +67,21 @@ struct ExportImportIntegrationTests {
       .appendingPathComponent("moolah-test-\(UUID().uuidString).json")
   }
 
+  /// Builds a `CloudKitBackend` over an existing `ModelContainer` for the
+  /// post-import verification step. Centralised so each test isn't repeating
+  /// the constructor boilerplate.
+  private func makeCloudBackend(
+    container: ModelContainer, label: String = "Test Profile"
+  ) -> CloudKitBackend {
+    CloudKitBackend(
+      modelContainer: container,
+      instrument: instrument,
+      profileLabel: label,
+      conversionService: FixedConversionService(),
+      instrumentRegistry: CloudKitInstrumentRegistryRepository(modelContainer: container)
+    )
+  }
+
   @Test("export to JSON file and verify contents")
   func exportToFileAndVerify() async throws {
     let backend = try await makeSeededBackend()
@@ -145,12 +160,7 @@ struct ExportImportIntegrationTests {
     #expect(result.budgetItemCount == 1)
 
     // Verify data is readable through CloudKit repositories
-    let cloudBackend = CloudKitBackend(
-      modelContainer: freshContainer,
-      instrument: instrument,
-      profileLabel: "Test Profile",
-      conversionService: FixedConversionService()
-    )
+    let cloudBackend = makeCloudBackend(container: freshContainer)
 
     let accounts = try await cloudBackend.accounts.fetchAll()
     #expect(accounts.count == 1)

--- a/MoolahTests/Export/ExportImportIntegrationTests4.swift
+++ b/MoolahTests/Export/ExportImportIntegrationTests4.swift
@@ -51,7 +51,8 @@ struct ExportImportIntegrationTests4 {
       modelContainer: freshContainer,
       instrument: aud,
       profileLabel: profile.label,
-      conversionService: FixedConversionService()
+      conversionService: FixedConversionService(),
+      instrumentRegistry: CloudKitInstrumentRegistryRepository(modelContainer: freshContainer)
     )
 
     try await verifyMultiCurrencyRoundTrip(

--- a/MoolahTests/Features/CryptoTokenStoreTests.swift
+++ b/MoolahTests/Features/CryptoTokenStoreTests.swift
@@ -1,5 +1,6 @@
 // MoolahTests/Features/CryptoTokenStoreTests.swift
 import Foundation
+import SwiftData
 import Testing
 
 @testable import Moolah
@@ -11,29 +12,39 @@ struct CryptoTokenStoreTests {
     registrations: [CryptoRegistration] = [],
     resolutionResult: TokenResolutionResult = TokenResolutionResult(),
     resolutionFails: Bool = false
-  ) async -> CryptoTokenStore {
-    let repo = InMemoryTokenRepository()
-    if !registrations.isEmpty {
-      try? await repo.saveRegistrations(registrations)
+  ) async -> (CryptoTokenStore, CloudKitInstrumentRegistryRepository) {
+    let config = ModelConfiguration(isStoredInMemoryOnly: true)
+    let schema = Schema([InstrumentRecord.self])
+    // In-memory ModelContainer construction on a known schema never fails at
+    // runtime; trapping makes the test fixture a one-liner without threading
+    // throws through every caller.
+    // swiftlint:disable:next force_try
+    let container = try! ModelContainer(for: schema, configurations: [config])
+    let registry = CloudKitInstrumentRegistryRepository(modelContainer: container)
+    for reg in registrations {
+      // Seeding in-memory data cannot fail in practice; trap on any error so
+      // the test fixture remains a one-liner.
+      // swiftlint:disable:next force_try
+      try! await registry.registerCrypto(reg.instrument, mapping: reg.mapping)
     }
     let service = CryptoPriceService(
       clients: [FixedCryptoPriceClient()],
       cacheDirectory: FileManager.default.temporaryDirectory
         .appendingPathComponent("crypto-store-tests")
         .appendingPathComponent(UUID().uuidString),
-      tokenRepository: repo,
       resolutionClient: FixedTokenResolutionClient(
         result: resolutionResult,
         shouldFail: resolutionFails
       )
     )
-    return CryptoTokenStore(cryptoPriceService: service)
+    let store = CryptoTokenStore(registry: registry, cryptoPriceService: service)
+    return (store, registry)
   }
 
   @Test
   func loadRegistrations_populatesList() async {
     let presets = Array(CryptoRegistration.builtInPresets.prefix(2))
-    let store = await makeStore(registrations: presets)
+    let (store, _) = await makeStore(registrations: presets)
     await store.loadRegistrations()
     #expect(store.registrations.count == 2)
   }
@@ -41,7 +52,7 @@ struct CryptoTokenStoreTests {
   @Test
   func loadRegistrations_populatesInstruments() async {
     let presets = Array(CryptoRegistration.builtInPresets.prefix(2))
-    let store = await makeStore(registrations: presets)
+    let (store, _) = await makeStore(registrations: presets)
     await store.loadRegistrations()
     #expect(store.instruments.count == 2)
     #expect(store.instruments.allSatisfy { $0.kind == .cryptoToken })
@@ -50,17 +61,27 @@ struct CryptoTokenStoreTests {
   @Test
   func loadRegistrations_populatesProviderMappings() async {
     let presets = Array(CryptoRegistration.builtInPresets.prefix(2))
-    let store = await makeStore(registrations: presets)
+    let (store, _) = await makeStore(registrations: presets)
     await store.loadRegistrations()
     #expect(store.providerMappings.count == 2)
     let btcMapping = store.providerMappings["0:native"]
     #expect(btcMapping?.coingeckoId == "bitcoin")
   }
 
+  @Test("loadRegistrations surfaces registry failure into error")
+  func loadRegistrationsSurfacesError() async {
+    let failing = FailingRegistry()
+    let service = CryptoPriceService(clients: [])
+    let store = CryptoTokenStore(registry: failing, cryptoPriceService: service)
+    await store.loadRegistrations()
+    #expect(store.error != nil)
+    #expect(store.registrations.isEmpty)
+  }
+
   @Test
   func removeRegistration_removesFromList() async {
     let presets = Array(CryptoRegistration.builtInPresets.prefix(2))
-    let store = await makeStore(registrations: presets)
+    let (store, _) = await makeStore(registrations: presets)
     await store.loadRegistrations()
     await store.removeRegistration(presets[0])
     #expect(store.registrations.count == 1)
@@ -71,7 +92,7 @@ struct CryptoTokenStoreTests {
   @Test
   func removeInstrument_removesFromAllCollections() async {
     let presets = Array(CryptoRegistration.builtInPresets.prefix(2))
-    let store = await makeStore(registrations: presets)
+    let (store, _) = await makeStore(registrations: presets)
     await store.loadRegistrations()
     let instrumentToRemove = store.instruments[0]
     await store.removeInstrument(instrumentToRemove)
@@ -90,7 +111,7 @@ struct CryptoTokenStoreTests {
       resolvedSymbol: "UNI",
       resolvedDecimals: 18
     )
-    let store = await makeStore(resolutionResult: result)
+    let (store, _) = await makeStore(resolutionResult: result)
     await store.resolveToken(
       chainId: 1,
       contractAddress: "0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984",
@@ -111,7 +132,7 @@ struct CryptoTokenStoreTests {
       resolvedSymbol: "UNI",
       resolvedDecimals: 18
     )
-    let store = await makeStore(resolutionResult: result)
+    let (store, _) = await makeStore(resolutionResult: result)
     await store.resolveToken(
       chainId: 1,
       contractAddress: "0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984",
@@ -124,7 +145,7 @@ struct CryptoTokenStoreTests {
 
   @Test
   func resolveToken_failure_setsError() async {
-    let store = await makeStore(resolutionFails: true)
+    let (store, _) = await makeStore(resolutionFails: true)
     await store.resolveToken(
       chainId: 1, contractAddress: "0xabc", symbol: nil, isNative: false
     )
@@ -140,7 +161,7 @@ struct CryptoTokenStoreTests {
       resolvedSymbol: "UNI",
       resolvedDecimals: 18
     )
-    let store = await makeStore(resolutionResult: result)
+    let (store, _) = await makeStore(resolutionResult: result)
     await store.resolveToken(
       chainId: 1,
       contractAddress: "0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984",
@@ -159,7 +180,7 @@ struct CryptoTokenStoreTests {
   func loadRegistrations_preservesMultipleChainsWithSamePrefix() async {
     // All presets should load — presets include Bitcoin (chainId 0), Ethereum (1),
     // Optimism (10), and ERC20s on Ethereum. Store keeps them distinct.
-    let store = await makeStore(registrations: CryptoRegistration.builtInPresets)
+    let (store, _) = await makeStore(registrations: CryptoRegistration.builtInPresets)
     await store.loadRegistrations()
     #expect(store.registrations.count == CryptoRegistration.builtInPresets.count)
     let chainIds = Set(store.instruments.compactMap(\.chainId))
@@ -172,7 +193,7 @@ struct CryptoTokenStoreTests {
   @Test
   func loadRegistrations_keepsNativeAndErc20OnSameChainDistinct() async {
     // builtInPresets contains ETH (chainId 1, native) and UNI/ENS (chainId 1, ERC20).
-    let store = await makeStore(registrations: CryptoRegistration.builtInPresets)
+    let (store, _) = await makeStore(registrations: CryptoRegistration.builtInPresets)
     await store.loadRegistrations()
     let chain1 = store.instruments.filter { $0.chainId == 1 }
     let natives = chain1.filter { $0.contractAddress == nil }
@@ -180,4 +201,19 @@ struct CryptoTokenStoreTests {
     #expect(!natives.isEmpty)
     #expect(!erc20s.isEmpty)
   }
+}
+
+// MARK: - Test doubles
+
+private struct FailingRegistry: InstrumentRegistryRepository, @unchecked Sendable {
+  struct BoomError: Error {}
+  func all() async throws -> [Instrument] { throw BoomError() }
+  func allCryptoRegistrations() async throws -> [CryptoRegistration] { throw BoomError() }
+  func registerCrypto(
+    _ instrument: Instrument, mapping: CryptoProviderMapping
+  ) async throws { throw BoomError() }
+  func registerStock(_ instrument: Instrument) async throws { throw BoomError() }
+  func remove(id: String) async throws { throw BoomError() }
+  @MainActor
+  func observeChanges() -> AsyncStream<Void> { AsyncStream { _ in } }
 }

--- a/MoolahTests/Migration/MigrationIntegrationTests.swift
+++ b/MoolahTests/Migration/MigrationIntegrationTests.swift
@@ -127,7 +127,8 @@ struct MigrationIntegrationTests {
       modelContainer: container,
       instrument: instrument,
       profileLabel: "Test",
-      conversionService: FixedConversionService()
+      conversionService: FixedConversionService(),
+      instrumentRegistry: CloudKitInstrumentRegistryRepository(modelContainer: container)
     )
     let cloudAccounts = try await cloudBackend.accounts.fetchAll()
     #expect(cloudAccounts.count == exported.accounts.count)
@@ -174,7 +175,8 @@ struct MigrationIntegrationTests {
       modelContainer: container,
       instrument: instrument,
       profileLabel: "Test",
-      conversionService: FixedConversionService()
+      conversionService: FixedConversionService(),
+      instrumentRegistry: CloudKitInstrumentRegistryRepository(modelContainer: container)
     )
     let categories = try await cloudBackend.categories.fetchAll()
     let groceries = categories.first { $0.name == "Groceries" }
@@ -208,7 +210,8 @@ struct MigrationIntegrationTests {
       modelContainer: container,
       instrument: instrument,
       profileLabel: "Test",
-      conversionService: FixedConversionService()
+      conversionService: FixedConversionService(),
+      instrumentRegistry: CloudKitInstrumentRegistryRepository(modelContainer: container)
     )
     let earmarks = try await cloudBackend.earmarks.fetchAll()
     let holiday = earmarks.first { $0.name == "Holiday" }

--- a/MoolahTests/Shared/CryptoPriceServiceTests.swift
+++ b/MoolahTests/Shared/CryptoPriceServiceTests.swift
@@ -34,7 +34,6 @@ struct CryptoPriceServiceTests {
     prices: [String: [String: Decimal]] = [:],
     shouldFail: Bool = false,
     cacheDirectory: URL? = nil,
-    tokenRepository: CryptoTokenRepository? = nil,
     resolutionClient: (any TokenResolutionClient)? = nil
   ) -> CryptoPriceService {
     let clientList =
@@ -49,7 +48,6 @@ struct CryptoPriceServiceTests {
     return CryptoPriceService(
       clients: clientList,
       cacheDirectory: cacheDir,
-      tokenRepository: tokenRepository ?? InMemoryTokenRepository(),
       resolutionClient: resolutionClient
     )
   }

--- a/MoolahTests/Shared/CryptoPriceServiceTestsMore.swift
+++ b/MoolahTests/Shared/CryptoPriceServiceTestsMore.swift
@@ -34,7 +34,6 @@ struct CryptoPriceServiceTestsMore {
     prices: [String: [String: Decimal]] = [:],
     shouldFail: Bool = false,
     cacheDirectory: URL? = nil,
-    tokenRepository: CryptoTokenRepository? = nil,
     resolutionClient: (any TokenResolutionClient)? = nil
   ) -> CryptoPriceService {
     let clientList =
@@ -49,7 +48,6 @@ struct CryptoPriceServiceTestsMore {
     return CryptoPriceService(
       clients: clientList,
       cacheDirectory: cacheDir,
-      tokenRepository: tokenRepository ?? InMemoryTokenRepository(),
       resolutionClient: resolutionClient
     )
   }
@@ -84,24 +82,6 @@ struct CryptoPriceServiceTestsMore {
   // MARK: - Prefetch
 
   @Test
-  func prefetchLatest_usesRegisteredItemsWhenNoneProvided() async throws {
-    let repo = InMemoryTokenRepository()
-    try await repo.saveRegistrations([ethRegistration, btcRegistration])
-
-    let service = makeService(
-      prices: [
-        "1:native": ["2026-04-11": dec("1640.00")],
-        "0:native": ["2026-04-11": dec("67890.00")],
-      ],
-      tokenRepository: repo
-    )
-    await service.prefetchLatest()
-    let ethPrice = try await service.price(
-      for: ethInstrument, mapping: ethMapping, on: date("2026-04-11"))
-    #expect(ethPrice == dec("1640.00"))
-  }
-
-  @Test
   func prefetchUpdatesCacheForRegisteredItems() async throws {
     let service = makeService(prices: [
       "1:native": ["2026-04-11": dec("1640.00")],
@@ -127,39 +107,6 @@ struct CryptoPriceServiceTestsMore {
       for: btcInstrument, mapping: btcMapping, on: date("2026-04-10"))
     #expect(ethPrice == dec("1623.45"))
     #expect(btcPrice == dec("67890.00"))
-  }
-
-  // MARK: - Registration management
-
-  @Test
-  func registerAddsToList() async throws {
-    let service = makeService()
-    let registration = CryptoRegistration.builtInPresets[0]
-    try await service.register(registration)
-    let items = await service.registeredItems()
-    #expect(items.count == 1)
-    #expect(items[0].id == registration.id)
-  }
-
-  @Test
-  func removeDeletesFromList() async throws {
-    let service = makeService()
-    let registration = CryptoRegistration.builtInPresets[0]
-    try await service.register(registration)
-    try await service.remove(registration)
-    let items = await service.registeredItems()
-    #expect(items.isEmpty)
-  }
-
-  @Test
-  func registrationsPersistViaRepository() async throws {
-    let repo = InMemoryTokenRepository()
-    let service1 = makeService(tokenRepository: repo)
-    try await service1.register(CryptoRegistration.builtInPresets[0])
-
-    let service2 = makeService(tokenRepository: repo)
-    let items = await service2.registeredItems()
-    #expect(items.count == 1)
   }
 
   // MARK: - Token resolution

--- a/MoolahTests/Support/TestBackend.swift
+++ b/MoolahTests/Support/TestBackend.swift
@@ -44,7 +44,8 @@ enum TestBackend {
       modelContainer: container,
       instrument: instrument,
       profileLabel: "Test",
-      conversionService: conversionService
+      conversionService: conversionService,
+      instrumentRegistry: CloudKitInstrumentRegistryRepository(modelContainer: container)
     )
     return (backend, container)
   }

--- a/Shared/CryptoPriceService.swift
+++ b/Shared/CryptoPriceService.swift
@@ -1,23 +1,23 @@
 // Shared/CryptoPriceService.swift
 
 import Foundation
+import OSLog
 
 actor CryptoPriceService {
   private let clients: [CryptoPriceClient]
   private var caches: [String: CryptoPriceCache] = [:]
   private let cacheDirectory: URL
   private let dateFormatter: ISO8601DateFormatter
-  private let tokenRepository: CryptoTokenRepository
   private let resolutionClient: TokenResolutionClient
+  private let logger = Logger(
+    subsystem: "com.moolah.app", category: "CryptoPriceService")
 
   init(
     clients: [CryptoPriceClient],
     cacheDirectory: URL? = nil,
-    tokenRepository: CryptoTokenRepository = ICloudTokenRepository(),
     resolutionClient: (any TokenResolutionClient)? = nil
   ) {
     self.clients = clients
-    self.tokenRepository = tokenRepository
     self.resolutionClient = resolutionClient ?? NoOpTokenResolutionClient()
     if let cacheDirectory {
       self.cacheDirectory = cacheDirectory
@@ -60,38 +60,6 @@ actor CryptoPriceService {
       binanceSymbol: result.binanceSymbol
     )
     return CryptoRegistration(instrument: instrument, mapping: mapping)
-  }
-
-  // MARK: - Registration management
-
-  func registeredItems() async -> [CryptoRegistration] {
-    (try? await tokenRepository.loadRegistrations()) ?? []
-  }
-
-  func register(_ registration: CryptoRegistration) async throws {
-    var registrations = try await tokenRepository.loadRegistrations()
-    registrations.removeAll { $0.id == registration.id }
-    registrations.append(registration)
-    try await tokenRepository.saveRegistrations(registrations)
-  }
-
-  func remove(_ registration: CryptoRegistration) async throws {
-    var registrations = try await tokenRepository.loadRegistrations()
-    registrations.removeAll { $0.id == registration.id }
-    try await tokenRepository.saveRegistrations(registrations)
-    // Remove cached price data
-    caches.removeValue(forKey: registration.id)
-    let url = cacheFileURL(tokenId: registration.id)
-    try? FileManager.default.removeItem(at: url)
-  }
-
-  func removeById(_ instrumentId: String) async throws {
-    var registrations = try await tokenRepository.loadRegistrations()
-    registrations.removeAll { $0.id == instrumentId }
-    try await tokenRepository.saveRegistrations(registrations)
-    caches.removeValue(forKey: instrumentId)
-    let url = cacheFileURL(tokenId: instrumentId)
-    try? FileManager.default.removeItem(at: url)
   }
 
   /// Drops any cached price data for the given instrument id — removes
@@ -225,13 +193,6 @@ actor CryptoPriceService {
 
   // MARK: - Prefetch
 
-  /// Prefetch latest prices for all registered items.
-  func prefetchLatest() async {
-    let items = await registeredItems()
-    guard !items.isEmpty else { return }
-    await prefetchLatest(for: items)
-  }
-
   func prefetchLatest(for registrations: [CryptoRegistration]) async {
     let mappings = registrations.map(\.mapping)
     do {
@@ -245,7 +206,9 @@ actor CryptoPriceService {
         saveCacheToDisk(tokenId: tokenId)
       }
     } catch {
-      // Prefetch is best-effort
+      logger.warning(
+        "Prefetch failed (best-effort): \(error.localizedDescription, privacy: .public)"
+      )
     }
   }
 }

--- a/Shared/PreviewBackend.swift
+++ b/Shared/PreviewBackend.swift
@@ -34,7 +34,8 @@ enum PreviewBackend {
     let backend = CloudKitBackend(
       modelContainer: container,
       instrument: instrument, profileLabel: "Preview",
-      conversionService: conversionService
+      conversionService: conversionService,
+      instrumentRegistry: CloudKitInstrumentRegistryRepository(modelContainer: container)
     )
     return (backend, container)
   }


### PR DESCRIPTION
## Summary

- Task 11 of [`plans/2026-04-24-instrument-registry-implementation.md`](https://github.com/ajsutton/moolah-native/blob/main/plans/2026-04-24-instrument-registry-implementation.md). Tasks 1–10 already merged.
- **Big integration PR** — bundles four tightly-coupled changes that can't ship separately without leaving `main` uncompilable between commits:

### 1. CryptoPriceService stripped
Removes `registeredItems()`, `register(_:)`, `remove(_:)`, `removeById(_:)`, zero-arg `prefetchLatest()`, and the `tokenRepository` init param. Keeps `resolveRegistration`, `price`, `prices`, `currentPrices`, `prefetchLatest(for:)`, and `purgeCache(instrumentId:)`. Now a focused price-fetch + cache + resolver actor.

### 2. CryptoTokenStore rewired
`init(registry: any InstrumentRegistryRepository, cryptoPriceService:)`. Reads via `registry.allCryptoRegistrations()` with `do/catch` + `os.Logger` + `error` surface — no silent `try?`. `confirmRegistration` → `registerCrypto(_:mapping:)`. `removeRegistration` → `remove(id:)` then `purgeCache`.

### 3. CloudKitBackend + ProfileSession threaded
`CloudKitBackend.instrumentRegistry` is now a required init param (tightened per reviewer: the earlier optional-with-fallback was a silent-sync-loss footgun). `ProfileSession.instrumentRegistry: (any InstrumentRegistryRepository)?` and `cryptoTokenStore: CryptoTokenStore?` — nil for Remote/moolah profiles.

### 4. ProfileSession+Factories + settings view gating
`makeBackend` CloudKit branch builds `CloudKitInstrumentRegistryRepository` with `onRecordChanged` / `onRecordDeleted` hopping onto `@MainActor` to call `SyncCoordinator.queueSave(recordName:zoneID:)` and a new `queueDeletion(recordName:zoneID:)` overload. `providerMappings` closure: `{ try await registry.allCryptoRegistrations().map(\.mapping) }`. Both settings views drop the broken `ICloudTokenRepository()` fallback; macOS keys on `profileStore.activeProfileID` (not `sessions.values.first`) so multi-profile users get the right profile's registry.

### Other

- New `SyncCoordinator.queueDeletion(recordName:zoneID:)` mirrors the existing save overload.
- `CryptoPriceService.prefetchLatest(for:)` catch now logs via `os.Logger` (previously silent).
- `ICloudTokenRepository` + `CryptoTokenRepository` still present but have zero callers — Task 12 deletes them.

## Test plan

- [x] `just format-check` clean
- [x] `just test` — macOS 1576 / iOS 1547 pass
- [x] All four reviewers (spec / concurrency / sync / instrument-conversion) ✅ after one amend round addressing: tighten `instrumentRegistry` to required, add `privacy: .public` to prefetch log, add `os.Logger` to `CryptoPriceService.prefetchLatest` catch
- [x] `.swiftlint-baseline.yml` diff empty
- [x] `grep -rn 'registeredItems|InMemoryTokenRepository|ICloudTokenRepository'` returns hits only inside the deleted-in-Task-12 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)