### PR TITLE
chore(scripts): filter run-with-logs to launched PID only

### DIFF
--- a/scripts/run-with-logs.sh
+++ b/scripts/run-with-logs.sh
@@ -1,23 +1,29 @@
 #!/usr/bin/env bash
-# Build the macOS app, start log streaming, and launch the app.
-# Logs are written to .agent-tmp/app-logs.txt for inspection.
+# Build the macOS app, launch it suspended, attach a PID-filtered log
+# stream, then resume the app. Logs are written to .agent-tmp/app-logs.txt.
+#
+# The PID filter ensures the captured logs come ONLY from this launch's
+# process — not from concurrent test hosts (MoolahTests_macOS is loaded
+# into a Moolah-named binary and emits under the same `com.moolah.app`
+# subsystem) or other Moolah instances.
 #
 # Usage:
-#   scripts/run-with-logs.sh [predicate]
+#   scripts/run-with-logs.sh [predicate] [launch-args...]
 #
 # Examples:
 #   scripts/run-with-logs.sh                                    # default: subsystem == "com.moolah.app"
 #   scripts/run-with-logs.sh 'category == "ProfileSyncEngine"'  # custom predicate
+#   scripts/run-with-logs.sh 'subsystem == "com.moolah.app"' --ui-testing
 #
 # Interactive mode (terminal):  Runs until Ctrl-C, then stops the app and log stream.
 # Non-interactive mode (agent): Builds, launches, starts log stream, then exits.
 #   The app and log stream keep running. Clean up with:
 #     pkill -f "Moolah.app/Contents/MacOS/Moolah" 2>/dev/null
-#     pkill -f "log stream.*com.moolah.app" 2>/dev/null
+#     pkill -f "log stream.*processIdentifier" 2>/dev/null
 
 set -euo pipefail
 
-PREDICATE="${1:-subsystem == \"com.moolah.app\"}"
+USER_PREDICATE="${1:-subsystem == \"com.moolah.app\"}"
 # Shift off the predicate so $@ holds any extra launch arguments for
 # the app binary (e.g. --ui-testing). `shift` fails on an empty list,
 # hence the `|| true` guard for the no-args case.
@@ -25,73 +31,90 @@ shift || true
 LOG_DIR=".agent-tmp"
 LOG_FILE="$LOG_DIR/app-logs.txt"
 APP_PATH=".build/Build/Products/Debug/Moolah.app"
+APP_BINARY="$APP_PATH/Contents/MacOS/Moolah"
 
-# Ensure log directory
 mkdir -p "$LOG_DIR"
 
-# Check for existing app instance
 if pgrep -f "Moolah.app/Contents/MacOS/Moolah" > /dev/null 2>&1; then
     echo "⚠️  Moolah is already running. Kill it first or use the running instance."
     echo "   pkill -f 'Moolah.app/Contents/MacOS/Moolah'"
     exit 1
 fi
 
-# Build
 echo "Building macOS app..."
 just build-mac
 
-# Start log stream before launching the app so startup logs are captured
-echo "Starting log stream (predicate: $PREDICATE)..."
+# Launch the binary suspended BEFORE it execs, so we can attach a
+# PID-filtered log stream that catches the very first log emitted by
+# main(). The wrapper `sh -c` self-sends SIGSTOP (its own `$$` matches
+# the parent-visible `$!`), then `exec`s into Moolah once the parent
+# SIGCONTs it — `exec` preserves the PID, so the stream subscription
+# is already in place when the app starts running.
+#
+# We use `sh -c` rather than a bash subshell because macOS ships bash
+# 3.2 (no `$BASHPID`), so a bash subshell cannot identify itself
+# without a child fork. `sh -c` is a fresh process whose `$$` is
+# unambiguous and matches `$!` in the parent.
+echo "Launching app (suspended)..."
 rm -f "$LOG_FILE"
+sh -c 'kill -STOP $$; exec "$@"' _ "$APP_BINARY" "$@" </dev/null >/dev/null 2>&1 &
+APP_PID=$!
+
+# Resume + clean up if anything below fails before we hand off.
+on_error() {
+    kill -CONT "$APP_PID" 2>/dev/null || true
+    kill "$APP_PID" 2>/dev/null || true
+    if [ -n "${LOG_PID:-}" ]; then
+        kill "$LOG_PID" 2>/dev/null || true
+    fi
+}
+trap on_error ERR
+
+# Wait until the kernel reports the subshell as stopped (state 'T')
+# before subscribing. This avoids a race where the parent could start
+# the log stream before the subshell has actually paused.
+for _ in $(seq 1 40); do
+    if ps -o state= -p "$APP_PID" 2>/dev/null | grep -q '^T'; then
+        break
+    fi
+    sleep 0.05
+done
+
+PREDICATE="processIdentifier == $APP_PID AND ($USER_PREDICATE)"
+echo "Starting log stream (predicate: $PREDICATE)..."
 /usr/bin/log stream \
     --predicate "$PREDICATE" \
     --level debug \
     --style compact \
     > "$LOG_FILE" 2>&1 &
 LOG_PID=$!
-sleep 1
 
-# Launch. When extra args are provided (typically `--ui-testing`),
-# launch the binary directly so environment variables exported by the
-# caller (e.g. `UI_TESTING_SEED=welcomeEmpty`) reach the child process.
-# Launch Services (`open --args`) does not reliably forward the shell
-# environment.
-echo "Launching app..."
-if [ $# -gt 0 ]; then
-    nohup "$APP_PATH/Contents/MacOS/Moolah" "$@" >/dev/null 2>&1 &
-    disown
-else
-    open "$APP_PATH"
-fi
+# Brief settle so `log stream` has subscribed before we resume the app.
+sleep 0.5
 
-# Wait for app to appear (up to 10s)
-for i in $(seq 1 20); do
-    if pgrep -f "Moolah.app/Contents/MacOS/Moolah" > /dev/null 2>&1; then
-        break
-    fi
-    sleep 0.5
-done
+kill -CONT "$APP_PID"
+trap - ERR
 
-APP_PID=$(pgrep -f "Moolah.app/Contents/MacOS/Moolah" 2>/dev/null || echo "unknown")
 echo "App running (PID: $APP_PID). Logs streaming to $LOG_FILE"
 echo "Log stream PID: $LOG_PID"
 
 if [ -t 0 ]; then
-    # Interactive: wait for Ctrl-C, then clean up
     cleanup() {
         echo ""
         echo "Shutting down..."
         kill "$LOG_PID" 2>/dev/null || true
-        pkill -f "Moolah.app/Contents/MacOS/Moolah" 2>/dev/null || true
+        kill "$APP_PID" 2>/dev/null || true
         echo "Logs saved to $LOG_FILE"
     }
     trap cleanup EXIT
     echo "Press Ctrl-C to stop."
     wait "$LOG_PID" 2>/dev/null || true
 else
-    # Non-interactive (agent): exit and leave app + log stream running.
+    # Detach so the app and stream survive the parent shell exiting.
+    disown "$APP_PID" 2>/dev/null || true
+    disown "$LOG_PID" 2>/dev/null || true
     echo "Non-interactive mode — app and log stream will keep running."
     echo "To stop later:"
-    echo "  pkill -f 'Moolah.app/Contents/MacOS/Moolah'"
-    echo "  kill $LOG_PID  # or: pkill -f 'log stream.*com.moolah.app'"
+    echo "  kill $APP_PID  # or: pkill -f 'Moolah.app/Contents/MacOS/Moolah'"
+    echo "  kill $LOG_PID  # or: pkill -f 'log stream.*processIdentifier'"
 fi


### PR DESCRIPTION
## Summary

- `scripts/run-with-logs.sh` now restricts the log stream to the exact PID of the Moolah process it launched, so `MoolahTests_macOS` (hosted inside a Moolah-named binary, same `com.moolah.app` subsystem) and any other Moolah instances no longer bleed into the captured log file.
- The launch is suspended *before* `exec` via an `sh -c` wrapper that SIGSTOPs itself, then `log stream` subscribes against `processIdentifier == $APP_PID AND (<user predicate>)`, then SIGCONT. `exec` preserves the PID, so the subscription is in place before `main()` ever runs — no startup gap.
- `sh -c` is used instead of a bash subshell because macOS bash 3.2 lacks `$BASHPID`; `sh -c`'s `$$` is unambiguous and matches the parent's `$!`.
- Cleanup now kills by captured PID rather than `pkill -f` matching every Moolah process.

## Test plan

- [x] Smoke-tested the suspend-before-exec pattern with `/bin/echo`: child reaches state `T`, output is captured only after `kill -CONT`.
- [x] `bash -n scripts/run-with-logs.sh` passes.
- [ ] `just run-mac-with-logs` interactively (Ctrl-C cleanup works, captured log file contains only this launch's events).
- [ ] `just run-mac-with-logs 'subsystem == "com.moolah.app"' --ui-testing` (env vars still propagate; PID predicate still scopes correctly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)