### PR TITLE
fix(sync): make CloudKit error logging public so failures are diagnosable

### DIFF
--- a/Backends/CloudKit/Sync/LegacyZoneCleanup.swift
+++ b/Backends/CloudKit/Sync/LegacyZoneCleanup.swift
@@ -46,7 +46,7 @@ enum LegacyZoneCleanup {
       UserDefaults.standard.set(true, forKey: cleanupKey)
     } catch {
       // Don't mark as done on failure — will retry next launch
-      logger.error("Failed to delete legacy zone: \(error)")
+      logger.error("Failed to delete legacy zone: \(error, privacy: .public)")
     }
   }
 }

--- a/Backends/CloudKit/Sync/ProfileDataSyncHandler+ApplyRemoteChanges.swift
+++ b/Backends/CloudKit/Sync/ProfileDataSyncHandler+ApplyRemoteChanges.swift
@@ -58,7 +58,7 @@ extension ProfileDataSyncHandler {
       return .success(changedTypes: Set(saved.map(\.recordType) + deleted.map(\.1)))
     } catch {
       os_signpost(.end, log: Signposts.sync, name: "contextSave", signpostID: signpostID)
-      logger.error("Failed to save remote changes: \(error)")
+      logger.error("Failed to save remote changes: \(error, privacy: .public)")
       return .saveFailed(error.localizedDescription)
     }
   }

--- a/Backends/CloudKit/Sync/ProfileDataSyncHandler+QueueAndDelete.swift
+++ b/Backends/CloudKit/Sync/ProfileDataSyncHandler+QueueAndDelete.swift
@@ -110,7 +110,7 @@ extension ProfileDataSyncHandler {
       logger.info("Deleted all local data for profile \(self.profileId)")
       return Set(RecordTypeRegistry.allTypes.keys)
     } catch {
-      logger.error("Failed to delete local data: \(error)")
+      logger.error("Failed to delete local data: \(error, privacy: .public)")
       return []
     }
   }

--- a/Backends/CloudKit/Sync/ProfileDataSyncHandler+SystemFields.swift
+++ b/Backends/CloudKit/Sync/ProfileDataSyncHandler+SystemFields.swift
@@ -31,7 +31,7 @@ extension ProfileDataSyncHandler {
       try context.save()
       logger.info("Cleared all system fields for profile \(self.profileId)")
     } catch {
-      logger.error("Failed to save after clearing system fields: \(error)")
+      logger.error("Failed to save after clearing system fields: \(error, privacy: .public)")
     }
   }
 
@@ -98,7 +98,7 @@ extension ProfileDataSyncHandler {
         "Applied system fields for \(savedRecords.count) saved records (hadChanges=\(hadChanges))"
       )
     } catch {
-      logger.error("Failed to save system fields after upload: \(error)")
+      logger.error("Failed to save system fields after upload: \(error, privacy: .public)")
     }
   }
 
@@ -119,7 +119,8 @@ extension ProfileDataSyncHandler {
     do {
       try context.save()
     } catch {
-      logger.error("Failed to save system fields after conflict resolution: \(error)")
+      logger.error(
+        "Failed to save system fields after conflict resolution: \(error, privacy: .public)")
     }
   }
 

--- a/Backends/CloudKit/Sync/ProfileDataSyncHandler.swift
+++ b/Backends/CloudKit/Sync/ProfileDataSyncHandler.swift
@@ -87,7 +87,9 @@ final class ProfileDataSyncHandler {
     do {
       return try context.fetch(descriptor)
     } catch {
-      batchLogger.error("SwiftData fetch failed for \(T.self): \(error)")
+      batchLogger.error(
+        "SwiftData fetch failed for \(String(describing: T.self), privacy: .public): \(error, privacy: .public)"
+      )
       return []
     }
   }

--- a/Backends/CloudKit/Sync/ProfileIndexSyncHandler.swift
+++ b/Backends/CloudKit/Sync/ProfileIndexSyncHandler.swift
@@ -34,7 +34,9 @@ final class ProfileIndexSyncHandler {
     do {
       return try context.fetch(descriptor)
     } catch {
-      logger.error("SwiftData fetch failed for \(T.self): \(error)")
+      logger.error(
+        "SwiftData fetch failed for \(String(describing: T.self), privacy: .public): \(error, privacy: .public)"
+      )
       return []
     }
   }
@@ -50,7 +52,7 @@ final class ProfileIndexSyncHandler {
       guard ckRecord.recordType == ProfileRecord.recordType else { continue }
       guard let values = ProfileRecord.fieldValues(from: ckRecord) else {
         logger.error(
-          "applyRemoteChanges: malformed recordID '\(ckRecord.recordID.recordName)' (recordType \(ckRecord.recordType)) — skipping"
+          "applyRemoteChanges: malformed recordID '\(ckRecord.recordID.recordName)' (recordType \(ckRecord.recordType, privacy: .public)) — skipping"
         )
         continue
       }
@@ -91,7 +93,7 @@ final class ProfileIndexSyncHandler {
       try context.save()
       return .success(changedTypes: Set(saved.map(\.recordType)))
     } catch {
-      logger.error("Failed to save remote profile changes: \(error)")
+      logger.error("Failed to save remote profile changes: \(error, privacy: .public)")
       return .saveFailed(error.localizedDescription)
     }
   }
@@ -162,7 +164,7 @@ final class ProfileIndexSyncHandler {
       try context.save()
       logger.info("Deleted all local profile index data")
     } catch {
-      logger.error("Failed to delete local profile data: \(error)")
+      logger.error("Failed to delete local profile data: \(error, privacy: .public)")
     }
   }
 
@@ -180,7 +182,7 @@ final class ProfileIndexSyncHandler {
       do {
         try context.save()
       } catch {
-        logger.error("Failed to save cleared system fields: \(error)")
+        logger.error("Failed to save cleared system fields: \(error, privacy: .public)")
       }
     }
   }
@@ -197,7 +199,7 @@ final class ProfileIndexSyncHandler {
       do {
         try context.save()
       } catch {
-        logger.error("Failed to save updated system fields: \(error)")
+        logger.error("Failed to save updated system fields: \(error, privacy: .public)")
       }
     }
   }
@@ -216,7 +218,8 @@ final class ProfileIndexSyncHandler {
       do {
         try context.save()
       } catch {
-        logger.error("Failed to save cleared system fields for record: \(error)")
+        logger.error(
+          "Failed to save cleared system fields for record: \(error, privacy: .public)")
       }
     }
   }
@@ -256,7 +259,7 @@ final class ProfileIndexSyncHandler {
     do {
       try context.save()
     } catch {
-      logger.error("Failed to save system fields after upload: \(error)")
+      logger.error("Failed to save system fields after upload: \(error, privacy: .public)")
     }
   }
 
@@ -282,7 +285,8 @@ final class ProfileIndexSyncHandler {
     do {
       try context.save()
     } catch {
-      logger.error("Failed to save system fields after conflict resolution: \(error)")
+      logger.error(
+        "Failed to save system fields after conflict resolution: \(error, privacy: .public)")
     }
   }
 

--- a/Backends/CloudKit/Sync/SyncCoordinator+Backfill.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+Backfill.swift
@@ -122,7 +122,7 @@ extension SyncCoordinator {
             pendingRecordZoneChanges: recordIDs.map { .saveRecord($0) })
         }
       } catch {
-        logger.error("Failed to queue records for profile \(profileId): \(error)")
+        logger.error("Failed to queue records for profile \(profileId): \(error, privacy: .public)")
       }
       // This path queued every record for the profile, so there is nothing left for
       // the per-launch backfill scan to find.

--- a/Backends/CloudKit/Sync/SyncCoordinator+Delegate.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+Delegate.swift
@@ -265,7 +265,7 @@ extension SyncCoordinator: CKSyncEngineDelegate {
       handler = try handlerForProfileZone(profileId: profileId, zoneID: zoneID)
     } catch {
       logger.error(
-        "Failed to build handler for profile \(profileId): \(error) — \(recordIDs.count) records remain pending for retry"
+        "Failed to build handler for profile \(profileId): \(error, privacy: .public) — \(recordIDs.count, privacy: .public) records remain pending for retry"
       )
       return
     }

--- a/Backends/CloudKit/Sync/SyncCoordinator+Lifecycle.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+Lifecycle.swift
@@ -196,7 +196,7 @@ extension SyncCoordinator {
     do {
       try await syncEngine.sendChanges()
     } catch {
-      logger.error("Failed to send changes: \(error)")
+      logger.error("Failed to send changes: \(error, privacy: .public)")
     }
   }
 
@@ -205,7 +205,7 @@ extension SyncCoordinator {
     do {
       try await syncEngine.fetchChanges()
     } catch {
-      logger.error("Failed to fetch changes: \(error)")
+      logger.error("Failed to fetch changes: \(error, privacy: .public)")
     }
   }
 

--- a/Backends/CloudKit/Sync/SyncCoordinator+RecordChanges.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+RecordChanges.swift
@@ -112,7 +112,8 @@ extension SyncCoordinator {
         }
       }
     case .saveFailed(let errorDescription):
-      logger.error("Profile index save failed, scheduling re-fetch: \(errorDescription)")
+      logger.error(
+        "Profile index save failed, scheduling re-fetch: \(errorDescription, privacy: .public)")
       await scheduleRefetch()
     }
   }
@@ -132,7 +133,7 @@ extension SyncCoordinator {
       do {
         return try handlerForProfileZone(profileId: profileId, zoneID: zoneID)
       } catch {
-        logger.error("Failed to get handler for profile \(profileId): \(error)")
+        logger.error("Failed to get handler for profile \(profileId): \(error, privacy: .public)")
         return nil
       }
     }
@@ -166,7 +167,8 @@ extension SyncCoordinator {
       }
     case .saveFailed(let errorDescription):
       logger.error(
-        "Profile data save failed for \(profileId), scheduling re-fetch: \(errorDescription)")
+        "Profile data save failed for \(profileId), scheduling re-fetch: \(errorDescription, privacy: .public)"
+      )
       await scheduleRefetch()
     }
   }

--- a/Backends/CloudKit/Sync/SyncCoordinator+Zones.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+Zones.swift
@@ -16,7 +16,7 @@ extension SyncCoordinator {
       _ = try await CKContainer.default().privateCloudDatabase.save(zone)
       logger.info("Ensured zone exists: \(zoneID.zoneName)")
     } catch {
-      logger.error("Failed to ensure zone exists \(zoneID.zoneName): \(error)")
+      logger.error("Failed to ensure zone exists \(zoneID.zoneName): \(error, privacy: .public)")
     }
   }
 

--- a/Backends/CloudKit/Sync/SyncCoordinator.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator.swift
@@ -381,7 +381,7 @@ final class SyncCoordinator {
       let data = try JSONEncoder().encode(serialization)
       try data.write(to: stateFileURL, options: .atomic)
     } catch {
-      logger.error("Failed to save sync state: \(error)")
+      logger.error("Failed to save sync state: \(error, privacy: .public)")
     }
   }
 

--- a/Backends/CloudKit/Sync/SyncErrorRecovery.swift
+++ b/Backends/CloudKit/Sync/SyncErrorRecovery.swift
@@ -54,27 +54,41 @@ enum SyncErrorRecovery {
     let recordID = failure.record.recordID
     switch failure.error.code {
     case .zoneNotFound, .userDeletedZone:
+      logger.warning(
+        "Save failed (code=\(failure.error.code.rawValue, privacy: .public) zoneNotFound) for \(failure.record.recordType, privacy: .public) \(recordID.recordName) — queueing zone re-creation"
+      )
       result.zoneNotFoundSaves.append(recordID)
 
     case .serverRecordChanged:
       if let serverRecord = failure.error.serverRecord {
+        logger.info(
+          "Save conflict (code=\(failure.error.code.rawValue, privacy: .public) serverRecordChanged) for \(failure.record.recordType, privacy: .public) \(recordID.recordName) — resolving"
+        )
         result.conflicts.append((recordID: recordID, serverRecord: serverRecord))
       } else {
         // Server record unavailable — re-queue so the record isn't silently lost
         logger.warning(
-          "serverRecordChanged with no serverRecord for \(recordID.recordName) — re-queuing")
+          "serverRecordChanged with no serverRecord for \(failure.record.recordType, privacy: .public) \(recordID.recordName) — re-queuing"
+        )
         result.requeue.append(recordID)
       }
 
     case .unknownItem:
+      logger.info(
+        "Save failed (code=\(failure.error.code.rawValue, privacy: .public) unknownItem) for \(failure.record.recordType, privacy: .public) \(recordID.recordName) — clearing system fields and re-queuing as insert"
+      )
       result.unknownItems.append((recordID: recordID, recordType: failure.record.recordType))
 
     case .quotaExceeded:
       logger.error(
-        "iCloud quota exceeded — sync paused for record \(recordID.recordName)")
+        "iCloud quota exceeded (code=\(failure.error.code.rawValue, privacy: .public)) — sync paused for \(failure.record.recordType, privacy: .public) \(recordID.recordName)"
+      )
       result.quotaExceeded.append(recordID)
 
     case .limitExceeded, .batchRequestFailed:
+      logger.warning(
+        "Save deferred (code=\(failure.error.code.rawValue, privacy: .public)) for \(failure.record.recordType, privacy: .public) \(recordID.recordName) — re-queuing"
+      )
       result.requeue.append(recordID)
 
     default:
@@ -82,7 +96,7 @@ enum SyncErrorRecovery {
       // (network, rate limiting) automatically, but other errors drop the
       // record from the queue. Re-queuing ensures we don't silently lose data.
       logger.error(
-        "Save error (code=\(failure.error.code.rawValue)) for \(recordID.recordName): \(failure.error) — re-queuing"
+        "Save error (code=\(failure.error.code.rawValue, privacy: .public)) for \(failure.record.recordType, privacy: .public) \(recordID.recordName): \(failure.error, privacy: .public) — re-queuing"
       )
       result.requeue.append(recordID)
     }
@@ -104,7 +118,7 @@ enum SyncErrorRecovery {
       // succeeded. Don't re-queue (would loop forever) and don't treat as a
       // failure. CKSyncEngine has already removed it from its pending queue.
       logger.info(
-        "Delete returned unknownItem for \(recordID.recordName) — record already gone, treating as success"
+        "Delete returned unknownItem (code=\(error.code.rawValue, privacy: .public)) for \(recordID.recordName) — record already gone, treating as success"
       )
 
     default:
@@ -112,7 +126,7 @@ enum SyncErrorRecovery {
       // unexpected errors). CKSyncEngine drops failed items from its queue, so
       // not re-queuing would leave the record on the server permanently.
       logger.error(
-        "Delete error (code=\(error.code.rawValue)) for \(recordID.recordName): \(error) — re-queuing"
+        "Delete error (code=\(error.code.rawValue, privacy: .public)) for \(recordID.recordName): \(error, privacy: .public) — re-queuing"
       )
       result.requeueDeletes.append(recordID)
     }


### PR DESCRIPTION
## Summary

CKError codes, descriptions, and record types in `os_log` statements throughout `Backends/CloudKit/Sync/` were implicitly redacted as `<private>` in the captured log stream. Adds explicit `privacy: .public` on every error/code/recordType interpolation in the sync pipeline:

- `SyncErrorRecovery.classifySaveFailure` / `classifyDeleteFailure` — every branch now logs at info/warning with the public CKError code and recordType, including the previously-silent `.zoneNotFound`, `.serverRecordChanged` (resolved), `.unknownItem`, and `.limitExceeded`/`.batchRequestFailed` buckets.
- `Failed to send/fetch changes` at the top of the engine loop.
- Every `Failed to save (system fields|remote changes|local data)` in `ProfileDataSyncHandler` and `ProfileIndexSyncHandler`.
- `Failed to ensure zone exists`, `Failed to queue records`, `Failed to get handler` in the coordinator extensions.
- `Failed to delete legacy zone` in `LegacyZoneCleanup`.

Record names, profile UUIDs, and zone names remain `.private` — they identify user data.

## Why

Discovered while investigating a sync regression: every batch send returned `CKErrorDomain Code=2 (.partialFailure)` with `<private>` per-record details, and the silent classification buckets in `SyncErrorRecovery` never logged a code at all, so the actual failure (`code=12 .invalidArguments — "You can't save the same record twice"`) was invisible. With these changes the underlying cause shows up in plain text in `just run-mac-with-logs`.

## Test plan

- [ ] CI passes.
- [ ] `just run-mac-with-logs` shows error codes and CKError descriptions with no `<private>` placeholders for failure paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)