### PR TITLE
feat(domain): preferredCurrencySymbol + CurrencyPicker on Instrument

### DIFF
--- a/Domain/Models/Instrument.swift
+++ b/Domain/Models/Instrument.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 
 struct Instrument: Codable, Sendable, Hashable, Identifiable {
   enum Kind: String, Codable, Sendable, CaseIterable {
@@ -36,14 +37,11 @@ struct Instrument: Codable, Sendable, Hashable, Identifiable {
     )
   }
 
-  /// Derive the currency symbol from system locale (fiat only).
+  /// Derive the currency symbol from the currency's representative locale (fiat only).
   /// Returns nil for non-fiat instruments.
   var currencySymbol: String? {
     guard kind == .fiatCurrency else { return nil }
-    let formatter = NumberFormatter()
-    formatter.numberStyle = .currency
-    formatter.currencyCode = id
-    return formatter.currencySymbol
+    return Self.preferredCurrencySymbol(for: id)
   }
 
   /// Factory for stock instruments.
@@ -92,6 +90,36 @@ struct Instrument: Codable, Sendable, Hashable, Identifiable {
   // Convenience constants
   static let AUD = Instrument.fiat(code: "AUD")
   static let USD = Instrument.fiat(code: "USD")
+}
+
+extension Instrument {
+  /// Currency symbol from the currency's primary locale, not the user's.
+  /// Returns nil when no representative locale produces a distinctive
+  /// symbol (the result would just echo the ISO code).
+  static func preferredCurrencySymbol(for code: String) -> String? {
+    symbolCache.withLock { cache in
+      if let hit = cache[code] { return hit.value }
+      let resolved = Self.shortestCurrencySymbol(for: code)
+      cache[code] = SymbolCacheEntry(value: resolved)
+      return resolved
+    }
+  }
+
+  private static func shortestCurrencySymbol(for code: String) -> String? {
+    Locale.availableIdentifiers
+      .lazy
+      .map(Locale.init(identifier:))
+      .filter { $0.currency?.identifier == code }
+      .compactMap { $0.currencySymbol }
+      .filter { !$0.isEmpty && $0 != code }
+      .min(by: { $0.count < $1.count })
+  }
+
+  private struct SymbolCacheEntry: Sendable { let value: String? }
+
+  private static let symbolCache = OSAllocatedUnfairLock<[String: SymbolCacheEntry]>(
+    initialState: [:]
+  )
 }
 
 extension Instrument {

--- a/Features/Accounts/Views/CreateAccountView.swift
+++ b/Features/Accounts/Views/CreateAccountView.swift
@@ -7,7 +7,7 @@ struct CreateAccountView: View {
 
   @State private var name = ""
   @State private var type: AccountType = .bank
-  @State private var currencyCode: String
+  @State private var currency: Instrument
   @State private var balanceDecimal: Decimal = 0
   @State private var date = Date()
   @State private var isSubmitting = false
@@ -31,7 +31,7 @@ struct CreateAccountView: View {
     self.instrument = instrument
     self.accountStore = accountStore
     self.supportsComplexTransactions = supportsComplexTransactions
-    _currencyCode = State(initialValue: instrument.id)
+    _currency = State(initialValue: instrument)
   }
 
   var body: some View {
@@ -87,11 +87,11 @@ struct CreateAccountView: View {
     }
 
     if supportsComplexTransactions {
-      CurrencyPicker(selection: $currencyCode)
+      CurrencyPicker(selection: $currency)
     }
 
     LabeledContent("Initial Balance") {
-      TextField("Amount", value: $balanceDecimal, format: .currency(code: currencyCode))
+      TextField("Amount", value: $balanceDecimal, format: .currency(code: currency.id))
         .monospacedDigit()
         .focused($focusedField, equals: .balance)
         #if os(iOS)
@@ -116,7 +116,7 @@ struct CreateAccountView: View {
 
     let selectedInstrument =
       supportsComplexTransactions
-      ? Instrument.fiat(code: currencyCode) : instrument
+      ? currency : instrument
     let openingBalance = InstrumentAmount(quantity: balanceDecimal, instrument: selectedInstrument)
     let newAccount = Account(
       id: UUID(),

--- a/Features/Accounts/Views/EditAccountView.swift
+++ b/Features/Accounts/Views/EditAccountView.swift
@@ -4,7 +4,7 @@ struct EditAccountView: View {
   @Environment(\.dismiss) private var dismiss
   @State private var name: String
   @State private var type: AccountType
-  @State private var currencyCode: String
+  @State private var currency: Instrument
   @State private var isHidden: Bool
   @State private var isSubmitting = false
   @State private var errorMessage: String?
@@ -25,7 +25,7 @@ struct EditAccountView: View {
     self.supportsComplexTransactions = supportsComplexTransactions
     _name = State(initialValue: account.name)
     _type = State(initialValue: account.type)
-    _currencyCode = State(initialValue: account.instrument.id)
+    _currency = State(initialValue: account.instrument)
     _isHidden = State(initialValue: account.isHidden)
   }
 
@@ -90,7 +90,7 @@ struct EditAccountView: View {
         }
       }
       if supportsComplexTransactions {
-        CurrencyPicker(selection: $currencyCode)
+        CurrencyPicker(selection: $currency)
       }
       LabeledContent("Current Balance") {
         currentBalanceDisplay
@@ -175,7 +175,7 @@ struct EditAccountView: View {
     updated.name = name.trimmingCharacters(in: .whitespaces)
     updated.type = type
     if supportsComplexTransactions {
-      updated.instrument = Instrument.fiat(code: currencyCode)
+      updated.instrument = currency
     }
     updated.isHidden = isHidden
 

--- a/Features/Earmarks/Views/CreateEarmarkSheet.swift
+++ b/Features/Earmarks/Views/CreateEarmarkSheet.swift
@@ -6,7 +6,7 @@ struct CreateEarmarkSheet: View {
   let onCreate: (Earmark) -> Void
 
   @State private var name: String = ""
-  @State private var currencyCode: String
+  @State private var currency: Instrument
   @State private var savingsGoal: String = ""
   @State private var startDate = Date()
   @State private var endDate: Date =
@@ -22,11 +22,11 @@ struct CreateEarmarkSheet: View {
     self.instrument = instrument
     self.supportsComplexTransactions = supportsComplexTransactions
     self.onCreate = onCreate
-    _currencyCode = State(initialValue: instrument.id)
+    _currency = State(initialValue: instrument)
   }
 
   private var selectedInstrument: Instrument {
-    supportsComplexTransactions ? Instrument.fiat(code: currencyCode) : instrument
+    supportsComplexTransactions ? currency : instrument
   }
 
   var body: some View {
@@ -44,7 +44,7 @@ struct CreateEarmarkSheet: View {
         TextField("Name", text: $name)
           .accessibilityLabel("Earmark name")
         if supportsComplexTransactions {
-          CurrencyPicker(selection: $currencyCode)
+          CurrencyPicker(selection: $currency)
         }
       }
       Section("Savings Goal") {

--- a/Features/Earmarks/Views/EditEarmarkSheet.swift
+++ b/Features/Earmarks/Views/EditEarmarkSheet.swift
@@ -6,7 +6,7 @@ struct EditEarmarkSheet: View {
   let onUpdate: (Earmark) -> Void
 
   @State private var name: String
-  @State private var currencyCode: String
+  @State private var currency: Instrument
   @State private var savingsGoal: String
   @State private var startDate: Date
   @State private var endDate: Date
@@ -23,7 +23,7 @@ struct EditEarmarkSheet: View {
     self.supportsComplexTransactions = supportsComplexTransactions
     self.onUpdate = onUpdate
     _name = State(initialValue: earmark.name)
-    _currencyCode = State(initialValue: earmark.instrument.id)
+    _currency = State(initialValue: earmark.instrument)
     _savingsGoal = State(initialValue: earmark.savingsGoal?.decimalValue.description ?? "")
     _startDate = State(initialValue: earmark.savingsStartDate ?? Date())
     _endDate = State(
@@ -36,7 +36,7 @@ struct EditEarmarkSheet: View {
   }
 
   private var selectedInstrument: Instrument {
-    supportsComplexTransactions ? Instrument.fiat(code: currencyCode) : earmark.instrument
+    supportsComplexTransactions ? currency : earmark.instrument
   }
 
   var body: some View {
@@ -54,7 +54,7 @@ struct EditEarmarkSheet: View {
         TextField("Name", text: $name)
           .accessibilityLabel("Earmark name")
         if supportsComplexTransactions {
-          CurrencyPicker(selection: $currencyCode)
+          CurrencyPicker(selection: $currency)
         } else {
           LabeledContent("Currency") {
             Text(earmark.instrument.displayLabel)

--- a/Features/Profiles/Views/CreateProfileFormView.swift
+++ b/Features/Profiles/Views/CreateProfileFormView.swift
@@ -16,7 +16,7 @@ import SwiftUI
 /// haptic when the async create completes (design spec §4.3).
 struct CreateProfileFormView: View {
   @Binding var name: String
-  @Binding var currencyCode: String
+  @Binding var currency: Instrument
   @Binding var financialYearStartMonth: Int
   let banner: ICloudArrivalBanner.Kind?
   let onBannerPrimary: () -> Void
@@ -103,7 +103,7 @@ struct CreateProfileFormView: View {
     DisclosureGroup(
       String(localized: "Advanced", comment: "Form advanced disclosure")
     ) {
-      CurrencyPicker(selection: $currencyCode)
+      CurrencyPicker(selection: $currency)
       Picker(
         String(localized: "Financial year starts", comment: "Form FY month"),
         selection: $financialYearStartMonth
@@ -187,12 +187,12 @@ extension ICloudArrivalBanner.Kind {
 
 #Preview("Create — default") {
   @Previewable @State var name = ""
-  @Previewable @State var currency = "AUD"
+  @Previewable @State var currency: Instrument = .AUD
   @Previewable @State var month = 7
   NavigationStack {
     CreateProfileFormView(
       name: $name,
-      currencyCode: $currency,
+      currency: $currency,
       financialYearStartMonth: $month,
       banner: nil,
       onBannerPrimary: {},
@@ -207,12 +207,12 @@ extension ICloudArrivalBanner.Kind {
 
 #Preview("Create — with banner") {
   @Previewable @State var name = "Hous"
-  @Previewable @State var currency = "AUD"
+  @Previewable @State var currency: Instrument = .AUD
   @Previewable @State var month = 7
   NavigationStack {
     CreateProfileFormView(
       name: $name,
-      currencyCode: $currency,
+      currency: $currency,
       financialYearStartMonth: $month,
       banner: .single(label: "Household"),
       onBannerPrimary: {},
@@ -227,12 +227,12 @@ extension ICloudArrivalBanner.Kind {
 
 #Preview("Create — dark") {
   @Previewable @State var name = "Household"
-  @Previewable @State var currency = "AUD"
+  @Previewable @State var currency: Instrument = .AUD
   @Previewable @State var month = 7
   NavigationStack {
     CreateProfileFormView(
       name: $name,
-      currencyCode: $currency,
+      currency: $currency,
       financialYearStartMonth: $month,
       banner: nil,
       onBannerPrimary: {},
@@ -248,12 +248,12 @@ extension ICloudArrivalBanner.Kind {
 
 #Preview("Create — AX5") {
   @Previewable @State var name = "Household"
-  @Previewable @State var currency = "AUD"
+  @Previewable @State var currency: Instrument = .AUD
   @Previewable @State var month = 7
   NavigationStack {
     CreateProfileFormView(
       name: $name,
-      currencyCode: $currency,
+      currency: $currency,
       financialYearStartMonth: $month,
       banner: nil,
       onBannerPrimary: {},

--- a/Features/Profiles/Views/ProfileFormView.swift
+++ b/Features/Profiles/Views/ProfileFormView.swift
@@ -18,7 +18,8 @@ struct ProfileFormView: View {
 
   // iCloud profile fields
   @State private var cloudName = ""
-  @State private var cloudCurrencyCode = Locale.current.currency?.identifier ?? "AUD"
+  @State private var cloudCurrency = Instrument.fiat(
+    code: Locale.current.currency?.identifier ?? "AUD")
   @State private var cloudFinancialYearStartMonth = 7
 
   private static let monthNames: [String] = {
@@ -106,7 +107,7 @@ struct ProfileFormView: View {
   private var cloudKitSection: some View {
     Section("Profile") {
       TextField("Name", text: $cloudName)
-      CurrencyPicker(selection: $cloudCurrencyCode)
+      CurrencyPicker(selection: $cloudCurrency)
       Picker("Financial Year Starts", selection: $cloudFinancialYearStartMonth) {
         ForEach(1...12, id: \.self) { month in
           if month <= Self.monthNames.count {
@@ -163,7 +164,7 @@ struct ProfileFormView: View {
       profile = Profile(
         label: trimmedName,
         backendType: .cloudKit,
-        currencyCode: cloudCurrencyCode,
+        currencyCode: cloudCurrency.id,
         financialYearStartMonth: cloudFinancialYearStartMonth
       )
     }

--- a/Features/Profiles/Views/WelcomeView.swift
+++ b/Features/Profiles/Views/WelcomeView.swift
@@ -27,7 +27,8 @@ struct WelcomeView: View {
   @State private var hasEverDownloaded = false
 
   @State private var name = ""
-  @State private var currencyCode = Locale.current.currency?.identifier ?? "AUD"
+  @State private var currency = Instrument.fiat(
+    code: Locale.current.currency?.identifier ?? "AUD")
   @State private var financialYearStartMonth = 7
 
   var body: some View {
@@ -156,7 +157,7 @@ struct WelcomeView: View {
 
     return CreateProfileFormView(
       name: $name,
-      currencyCode: $currencyCode,
+      currency: $currency,
       financialYearStartMonth: $financialYearStartMonth,
       banner: banner.map(mapBanner),
       onBannerPrimary: handleBannerPrimary,
@@ -198,7 +199,7 @@ struct WelcomeView: View {
     let profile = Profile(
       label: trimmedName,
       backendType: .cloudKit,
-      currencyCode: currencyCode,
+      currencyCode: currency.id,
       financialYearStartMonth: financialYearStartMonth
     )
     _ = await profileStore.validateAndAddProfile(profile)

--- a/Features/Settings/MoolahProfileDetailView.swift
+++ b/Features/Settings/MoolahProfileDetailView.swift
@@ -14,7 +14,7 @@ struct MoolahProfileDetailView: View {
   let session: ProfileSession?
 
   @State private var label: String
-  @State private var currencyCode: String
+  @State private var currency: Instrument
   @State private var financialYearStartMonth: Int
   @State private var showMigration = false
 
@@ -29,7 +29,7 @@ struct MoolahProfileDetailView: View {
     self.authStore = authStore
     self.session = session
     _label = State(initialValue: profile.label)
-    _currencyCode = State(initialValue: profile.currencyCode)
+    _currency = State(initialValue: Instrument.fiat(code: profile.currencyCode))
     _financialYearStartMonth = State(initialValue: profile.financialYearStartMonth)
   }
 
@@ -41,8 +41,8 @@ struct MoolahProfileDetailView: View {
       }
 
       Section("Settings") {
-        CurrencyPicker(selection: $currencyCode)
-          .onChange(of: currencyCode) { _, _ in saveChanges() }
+        CurrencyPicker(selection: $currency)
+          .onChange(of: currency) { _, _ in saveChanges() }
 
         Picker("Financial Year Starts", selection: $financialYearStartMonth) {
           ForEach(1...12, id: \.self) { month in
@@ -79,8 +79,8 @@ struct MoolahProfileDetailView: View {
       updated.label = trimmedLabel
       changed = true
     }
-    if currencyCode != profile.currencyCode {
-      updated.currencyCode = currencyCode
+    if currency.id != profile.currencyCode {
+      updated.currencyCode = currency.id
       changed = true
     }
     if financialYearStartMonth != profile.financialYearStartMonth {
@@ -103,7 +103,7 @@ struct CustomServerProfileDetailView: View {
 
   @State private var label: String
   @State private var serverURL: String
-  @State private var currencyCode: String
+  @State private var currency: Instrument
   @State private var financialYearStartMonth: Int
   @State private var showMigration = false
 
@@ -119,7 +119,7 @@ struct CustomServerProfileDetailView: View {
     self.session = session
     _label = State(initialValue: profile.label)
     _serverURL = State(initialValue: profile.serverURL?.absoluteString ?? "")
-    _currencyCode = State(initialValue: profile.currencyCode)
+    _currency = State(initialValue: Instrument.fiat(code: profile.currencyCode))
     _financialYearStartMonth = State(initialValue: profile.financialYearStartMonth)
   }
 
@@ -142,8 +142,8 @@ struct CustomServerProfileDetailView: View {
       }
 
       Section("Settings") {
-        CurrencyPicker(selection: $currencyCode)
-          .onChange(of: currencyCode) { _, _ in saveChanges() }
+        CurrencyPicker(selection: $currency)
+          .onChange(of: currency) { _, _ in saveChanges() }
 
         Picker("Financial Year Starts", selection: $financialYearStartMonth) {
           ForEach(1...12, id: \.self) { month in
@@ -196,8 +196,8 @@ struct CustomServerProfileDetailView: View {
       updated.label = trimmedLabel
       changed = true
     }
-    if currencyCode != profile.currencyCode {
-      updated.currencyCode = currencyCode
+    if currency.id != profile.currencyCode {
+      updated.currencyCode = currency.id
       changed = true
     }
     if financialYearStartMonth != profile.financialYearStartMonth {
@@ -227,7 +227,7 @@ struct CloudKitProfileDetailView: View {
   let profile: Profile
 
   @State private var label: String
-  @State private var currencyCode: String
+  @State private var currency: Instrument
   @State private var financialYearStartMonth: Int
 
   private static let monthNames: [String] = {
@@ -239,7 +239,7 @@ struct CloudKitProfileDetailView: View {
   init(profile: Profile) {
     self.profile = profile
     _label = State(initialValue: profile.label)
-    _currencyCode = State(initialValue: profile.currencyCode)
+    _currency = State(initialValue: Instrument.fiat(code: profile.currencyCode))
     _financialYearStartMonth = State(initialValue: profile.financialYearStartMonth)
   }
 
@@ -258,8 +258,8 @@ struct CloudKitProfileDetailView: View {
       }
 
       Section("Settings") {
-        CurrencyPicker(selection: $currencyCode)
-          .onChange(of: currencyCode) { _, _ in saveChanges() }
+        CurrencyPicker(selection: $currency)
+          .onChange(of: currency) { _, _ in saveChanges() }
 
         Picker("Financial Year Starts", selection: $financialYearStartMonth) {
           ForEach(1...12, id: \.self) { month in
@@ -286,8 +286,8 @@ struct CloudKitProfileDetailView: View {
       updated.label = trimmedLabel
       changed = true
     }
-    if currencyCode != profile.currencyCode {
-      updated.currencyCode = currencyCode
+    if currency.id != profile.currencyCode {
+      updated.currencyCode = currency.id
       changed = true
     }
     if financialYearStartMonth != profile.financialYearStartMonth {

--- a/MoolahTests/Domain/InstrumentSymbolTests.swift
+++ b/MoolahTests/Domain/InstrumentSymbolTests.swift
@@ -1,0 +1,49 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("Instrument.preferredCurrencySymbol")
+struct InstrumentSymbolTests {
+  @Test("USD resolves to $ regardless of host locale")
+  func usdSymbol() {
+    #expect(Instrument.preferredCurrencySymbol(for: "USD") == "$")
+  }
+
+  @Test("GBP resolves to £")
+  func gbpSymbol() {
+    #expect(Instrument.preferredCurrencySymbol(for: "GBP") == "£")
+  }
+
+  @Test("EUR resolves to €")
+  func eurSymbol() {
+    #expect(Instrument.preferredCurrencySymbol(for: "EUR") == "€")
+  }
+
+  @Test("AUD resolves to $ via en_AU locale")
+  func audSymbol() {
+    #expect(Instrument.preferredCurrencySymbol(for: "AUD") == "$")
+  }
+
+  @Test("JPY resolves to ¥")
+  func jpySymbol() {
+    #expect(Instrument.preferredCurrencySymbol(for: "JPY") == "¥")
+  }
+
+  @Test("Unknown ISO code returns nil")
+  func unknownCodeReturnsNil() {
+    #expect(Instrument.preferredCurrencySymbol(for: "ZZZ") == nil)
+  }
+
+  @Test("Instance currencySymbol delegates to helper for fiat")
+  func instanceSymbolDelegatesForFiat() {
+    let usd = Instrument.fiat(code: "USD")
+    #expect(usd.currencySymbol == "$")
+  }
+
+  @Test("Instance currencySymbol returns nil for non-fiat")
+  func instanceSymbolNilForStock() {
+    let stock = Instrument.stock(ticker: "AAPL", exchange: "NASDAQ", name: "Apple")
+    #expect(stock.currencySymbol == nil)
+  }
+}

--- a/Shared/Views/CurrencyPicker.swift
+++ b/Shared/Views/CurrencyPicker.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct CurrencyPicker: View {
-  @Binding var selection: String
+  @Binding var selection: Instrument
 
   static let commonCurrencyCodes: [String] = [
     "AUD", "CAD", "CHF", "CNY", "EUR", "GBP", "HKD", "INR", "JPY", "KRW",
@@ -12,14 +12,19 @@ struct CurrencyPicker: View {
     Locale.current.localizedString(forCurrencyCode: code) ?? code
   }
 
-  /// Currency codes sorted by their localized display name.
   private static let sortedCodes: [String] = commonCurrencyCodes.sorted {
     currencyName(for: $0).localizedCaseInsensitiveCompare(currencyName(for: $1))
       == .orderedAscending
   }
 
   var body: some View {
-    Picker("Currency", selection: $selection) {
+    Picker(
+      "Currency",
+      selection: Binding(
+        get: { selection.id },
+        set: { selection = Instrument.fiat(code: $0) }
+      )
+    ) {
       ForEach(Self.sortedCodes, id: \.self) { code in
         Text("\(code) — \(Self.currencyName(for: code))").tag(code)
       }
@@ -29,7 +34,7 @@ struct CurrencyPicker: View {
 }
 
 #Preview {
-  @Previewable @State var selection = "AUD"
+  @Previewable @State var selection: Instrument = .AUD
   Form {
     CurrencyPicker(selection: $selection)
   }


### PR DESCRIPTION
## Summary
- Adds `Instrument.preferredCurrencySymbol(for:)` — locale-independent symbol resolution. Picks the **shortest** non-ISO symbol across all matching locales so AUD/USD glyph as `$` (was `USD` on `en_AU` locale), JPY as `¥` (was `JP¥`), GBP as `£`, EUR as `€`. Backed by `OSAllocatedUnfairLock`-protected cache.
- `Instrument.currencySymbol` rewritten to delegate to the helper for fiat instruments.
- `CurrencyPicker.selection` migrated from `Binding<String>` to `Binding<Instrument>`.
- All 8 fiat-only call sites migrated:
  - `MoolahProfileDetailView` (×3 sub-views), `ProfileFormView`, `CreateProfileFormView`, `WelcomeView`
  - `CreateAccountView`, `EditAccountView`
  - `CreateEarmarkSheet`, `EditEarmarkSheet`

PR-1 of 3 in the multi-instrument-picker rollout. See [`plans/2026-04-25-multi-instrument-picker-design.md`](https://github.com/ajsutton/moolah-native/blob/main/plans/2026-04-25-multi-instrument-picker-design.md).

## Test plan
- [x] New `InstrumentSymbolTests` (8 cases: USD, GBP, EUR, AUD, JPY, unknown, instance delegation, non-fiat nil)
- [x] Full mac suite: 1636 tests passed
- [x] `just format-check` clean
- [x] `BUILD SUCCEEDED` with no new warnings (project is `SWIFT_TREAT_WARNINGS_AS_ERRORS: YES`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)