### PR TITLE
feat(shared): InstrumentSearchService.providerSources

### DIFF
--- a/MoolahTests/Shared/InstrumentSearchServiceTests.swift
+++ b/MoolahTests/Shared/InstrumentSearchServiceTests.swift
@@ -150,6 +150,47 @@ struct InstrumentSearchServiceTests {
     #expect(results.contains { $0.instrument.id == "ASX:BHP.AX" })
     #expect(results.allSatisfy { $0.isRegistered })
   }
+
+  @Test("providerSources: .stocksOnly suppresses crypto provider hits")
+  func stocksOnlyExcludesCryptoHits() async throws {
+    let hits = [
+      CryptoSearchHit(coingeckoId: "bitcoin", symbol: "BTC", name: "Bitcoin", thumbnail: nil)
+    ]
+    let service = makeSubject(cryptoHits: hits)
+    let results = await service.search(
+      query: "bitcoin",
+      kinds: [.cryptoToken],
+      providerSources: .stocksOnly
+    )
+    #expect(results.allSatisfy { $0.requiresResolution == false })
+    #expect(results.contains { $0.instrument.ticker == "BTC" } == false)
+  }
+
+  @Test("providerSources: .stocksOnly still allows Yahoo stock hits")
+  func stocksOnlyAllowsStockHits() async throws {
+    let validated = ValidatedStockTicker(ticker: "AAPL", exchange: "NASDAQ")
+    let service = makeSubject(stockValidated: validated)
+    let results = await service.search(
+      query: "AAPL",
+      kinds: [.stock],
+      providerSources: .stocksOnly
+    )
+    #expect(results.contains { $0.instrument.ticker == "AAPL" })
+  }
+
+  @Test("providerSources: .all preserves existing behaviour")
+  func allPreservesExistingBehaviour() async throws {
+    let hits = [
+      CryptoSearchHit(coingeckoId: "ethereum", symbol: "ETH", name: "Ethereum", thumbnail: nil)
+    ]
+    let service = makeSubject(cryptoHits: hits)
+    let results = await service.search(
+      query: "ethereum",
+      kinds: [.cryptoToken],
+      providerSources: .all
+    )
+    #expect(results.contains { $0.instrument.ticker == "ETH" && $0.requiresResolution })
+  }
 }
 
 // MARK: - Stubs

--- a/Shared/InstrumentSearchService.swift
+++ b/Shared/InstrumentSearchService.swift
@@ -1,6 +1,17 @@
 import Foundation
 import OSLog
 
+/// Controls which provider-search APIs the picker fans out to.
+/// `.all` — registry + fiat + Yahoo + CoinGecko (current behaviour).
+/// `.stocksOnly` — registry + fiat + Yahoo. Used by the multi-instrument
+/// picker so unregistered crypto hits never surface (token registration
+/// flows through `AddTokenSheet` instead, which defends against scam
+/// tokens that share names with established ones).
+enum ProviderSources: Sendable {
+  case all
+  case stocksOnly
+}
+
 struct InstrumentSearchService: Sendable {
   private let registry: any InstrumentRegistryRepository
   private let cryptoSearchClient: any CryptoSearchClient
@@ -25,7 +36,8 @@ struct InstrumentSearchService: Sendable {
 
   func search(
     query: String,
-    kinds: Set<Instrument.Kind> = Set(Instrument.Kind.allCases)
+    kinds: Set<Instrument.Kind> = Set(Instrument.Kind.allCases),
+    providerSources: ProviderSources = .all
   ) async -> [InstrumentSearchResult] {
     let trimmed = query.trimmingCharacters(in: .whitespaces)
     let registered = await loadRegisteredOrLog()
@@ -43,7 +55,8 @@ struct InstrumentSearchService: Sendable {
     async let fiatResults: [InstrumentSearchResult] =
       kinds.contains(.fiatCurrency) ? fiatMatches(query: trimmed) : []
     async let cryptoResults: [InstrumentSearchResult] =
-      kinds.contains(.cryptoToken) ? cryptoMatches(query: trimmed) : []
+      (kinds.contains(.cryptoToken) && providerSources == .all)
+      ? cryptoMatches(query: trimmed) : []
     async let stockResults: [InstrumentSearchResult] =
       kinds.contains(.stock) ? stockMatches(query: trimmed) : []
 


### PR DESCRIPTION
## Summary
- Adds `ProviderSources` enum and `providerSources: ProviderSources = .all` parameter to `InstrumentSearchService.search`.
- `.stocksOnly` suppresses CoinGecko fan-out (used by the upcoming multi-instrument picker).
- Default is `.all` so no other callers move.

PR-2 of 3 in the multi-instrument-picker rollout. See [`plans/2026-04-25-multi-instrument-picker-design.md`](https://github.com/ajsutton/moolah-native/blob/main/plans/2026-04-25-multi-instrument-picker-design.md).

## Test plan
- [x] `InstrumentSearchServiceTests` extended with three new cases (`.stocksOnly` suppresses crypto hits, `.stocksOnly` still allows Yahoo, `.all` preserves existing behaviour)
- [x] Existing tests remain green
- [x] Full mac suite green
- [x] `just format-check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)