### PR TITLE
fix(rates): widen cold-cache fetch window for stock and crypto prices

### DIFF
--- a/MoolahTests/Shared/CryptoPriceServiceTests.swift
+++ b/MoolahTests/Shared/CryptoPriceServiceTests.swift
@@ -119,6 +119,21 @@ struct CryptoPriceServiceTests {
     }
   }
 
+  @Test
+  func coldCacheMissingCurrentDateFallsBackToPriorDay() async throws {
+    // Mirrors the stock-side cold-cache fix: when the provider has no data
+    // for the requested date but does have data for prior days, a cold-start
+    // lookup must populate cache with a wider window and fall back instead
+    // of throwing.
+    let working = FixedCryptoPriceClient(prices: [
+      "1:native": ["2026-04-09": dec("1600.00")]  // 2026-04-10 deliberately absent
+    ])
+    let service = makeService(clients: [working])
+    let price = try await service.price(
+      for: ethInstrument, mapping: ethMapping, on: date("2026-04-10"))
+    #expect(price == dec("1600.00"))
+  }
+
   // MARK: - Fallback never uses future dates
 
   @Test

--- a/MoolahTests/Shared/StockPriceServiceTests.swift
+++ b/MoolahTests/Shared/StockPriceServiceTests.swift
@@ -98,6 +98,27 @@ struct StockPriceServiceTests {
     }
   }
 
+  // MARK: - Cold-cache non-trading-day fallback
+
+  @Test
+  func coldCacheNonTradingDayFallsBackToPriorTradingDay() async throws {
+    // Reproduces the "Yahoo error 2 / noData" failure: opening the app on a
+    // Sunday for an uncached ticker. The provider has no data for the
+    // requested Sunday but has data for the prior trading day; the service
+    // should populate cache with a wide cold-start window and fall back.
+    let weekdayPrices = StockPriceResponse(
+      instrument: .AUD,
+      prices: [
+        "2026-04-09": dec("39.00"),  // Thursday
+        "2026-04-10": dec("38.25"),  // Friday — last trading day before request
+        // Sat 2026-04-11 and Sun 2026-04-12 deliberately absent
+      ]
+    )
+    let service = makeService(responses: ["BHP.AX": weekdayPrices])
+    let price = try await service.price(ticker: "BHP.AX", on: date("2026-04-12"))
+    #expect(price == dec("38.25"))
+  }
+
   // MARK: - Network failure
 
   @Test

--- a/Shared/CryptoPriceService.swift
+++ b/Shared/CryptoPriceService.swift
@@ -95,10 +95,15 @@ actor CryptoPriceService {
     }
 
     let symbol = instrument.ticker ?? instrument.name
+    // Cold cache: fetch a month-wide surrounding window so a request on a
+    // day the provider has not (yet) published can still fall back to a
+    // recent prior price. Mirrors ExchangeRateService.fetchToCoverDate.
+    let calendar = Calendar(identifier: .gregorian)
+    let fetchStart = calendar.date(byAdding: .day, value: -30, to: date) ?? date
     var lastError: (any Error)?
     for client in clients {
       do {
-        let fetched = try await client.dailyPrices(for: mapping, in: date...date)
+        let fetched = try await client.dailyPrices(for: mapping, in: fetchStart...date)
         if !fetched.isEmpty {
           merge(tokenId: tokenId, symbol: symbol, newPrices: fetched)
           saveCacheToDisk(tokenId: tokenId)

--- a/Shared/StockPriceService.swift
+++ b/Shared/StockPriceService.swift
@@ -49,22 +49,7 @@ actor StockPriceService {
 
     // Fetch from client — expand range to fill gap between cache and requested date
     do {
-      let gregorian = Calendar(identifier: .gregorian)
-      if let cache = caches[ticker] {
-        if dateString > cache.latestDate,
-          let latestDate = dateFormatter.date(from: cache.latestDate),
-          let fetchStart = gregorian.date(byAdding: .day, value: 1, to: latestDate)
-        {
-          try await fetchInChunks(ticker: ticker, from: fetchStart, to: date)
-        } else if dateString < cache.earliestDate,
-          let earliestDate = dateFormatter.date(from: cache.earliestDate),
-          let fetchEnd = gregorian.date(byAdding: .day, value: -1, to: earliestDate)
-        {
-          try await fetchInChunks(ticker: ticker, from: date, to: fetchEnd)
-        }
-      } else {
-        try await fetchAndMerge(ticker: ticker, from: date, to: date)
-      }
+      try await fetchToCoverDate(ticker: ticker, date: date, dateString: dateString)
       if let cached = lookupPrice(ticker: ticker, dateString: dateString) {
         return cached
       }
@@ -144,6 +129,35 @@ actor StockPriceService {
   }
 
   // MARK: - Private helpers
+
+  /// Fetches the surrounding window needed to cover `date`. Cold cache fetches
+  /// a month-wide window so a request on a weekend / holiday can still resolve
+  /// via `fallbackPrice`. Warm cache extends only the gap between the cache
+  /// edge and the requested date.
+  ///
+  /// Unlike `ExchangeRateService.fetchToCoverDate`, this method propagates
+  /// fetch errors so `price(ticker:on:)` can surface network failures when
+  /// the fallback cache is also empty.
+  private func fetchToCoverDate(ticker: String, date: Date, dateString: String) async throws {
+    let gregorian = Calendar(identifier: .gregorian)
+    if let cache = caches[ticker] {
+      if dateString > cache.latestDate,
+        let latestDate = dateFormatter.date(from: cache.latestDate),
+        let fetchStart = gregorian.date(byAdding: .day, value: 1, to: latestDate)
+      {
+        try await fetchInChunks(ticker: ticker, from: fetchStart, to: date)
+      } else if dateString < cache.earliestDate,
+        let earliestDate = dateFormatter.date(from: cache.earliestDate),
+        let fetchEnd = gregorian.date(byAdding: .day, value: -1, to: earliestDate)
+      {
+        try await fetchInChunks(ticker: ticker, from: date, to: fetchEnd)
+      }
+    } else if let fetchStart = gregorian.date(byAdding: .day, value: -30, to: date) {
+      try await fetchInChunks(ticker: ticker, from: fetchStart, to: date)
+    } else {
+      try await fetchAndMerge(ticker: ticker, from: date, to: date)
+    }
+  }
 
   private func lookupPrice(ticker: String, dateString: String) -> Decimal? {
     caches[ticker]?.prices[dateString]


### PR DESCRIPTION
## Summary
- On a non-trading day (weekend / holiday / before market data lands), Yahoo Finance returns a chart `result` with `meta` but no `timestamp`, which `YahooFinanceClient.parseResponse` raises as `YahooFinanceError.noData`. The cold-cache branch in `StockPriceService.price(ticker:on:)` was only fetching `[date, date]`, so on a Sunday with no warm cache the fetch threw, the in-memory cache stayed empty, and `fallbackPrice` had nothing to return — the error then propagated up to the user-visible "rate source recovers" message.
- Widen cold-cache to `[date - 30d, date]`, mirroring `ExchangeRateService.fetchToCoverDate`. Apply the same widening to `CryptoPriceService.price(for:mapping:on:)` for parity (crypto providers can also return empty arrays during outages or rate-limit windows).
- Extract the warm/cold-cache decision in `StockPriceService` into a private `fetchToCoverDate` helper to stay under the SwiftLint cyclomatic-complexity limit.

## Live verification (run today, Sun 2026-04-26)

| Yahoo window | Result |
|---|---|
| `[now, now]` (Sun only) | `meta` present, **no `timestamp`** → `noData` |
| `[now-1d, now]` | 1 timestamp |
| `[now-7d, now]` | 5 timestamps |
| `[now-30d, now]` | 20 timestamps |

## Test plan
- [x] New `StockPriceServiceTests.coldCacheNonTradingDayFallsBackToPriorTradingDay` reproduces the failure (Sunday request, only Thu/Fri configured) and verifies the wider window populates cache so fallback returns Friday's close.
- [x] New `CryptoPriceServiceTests.coldCacheMissingCurrentDateFallsBackToPriorDay` covers the equivalent crypto path.
- [x] Both tests fail before the fix and pass after.
- [x] `just test-mac` — full suite (1668 tests / 244 suites) green.
- [x] `just test-ios StockPriceServiceTests CryptoPriceServiceTests` green.
- [x] `just format-check` clean.
- [x] Reviewed by `code-review` agent — fixed misleading docstring on `fetchToCoverDate` to clarify it propagates errors rather than swallowing them.
- [x] Reviewed by `concurrency-review` agent — no findings (actor isolation preserved, no new task hygiene issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)