### PR TITLE
ui: anchor instrument picker empty-state to top, kind-aware copy

### DIFF
--- a/Shared/InstrumentPickerStore.swift
+++ b/Shared/InstrumentPickerStore.swift
@@ -97,3 +97,17 @@ final class InstrumentPickerStore {
       }
   }
 }
+
+extension InstrumentPickerStore {
+  /// Empty-state description for the picker, phrased to the kinds the picker
+  /// is filtering on (so a fiat-only picker doesn't tell the user about
+  /// stocks or tokens). Surfaced by `InstrumentPickerSheet.listContent`.
+  var noMatchesDescription: String {
+    var parts: [String] = []
+    if kinds.contains(.fiatCurrency) { parts.append("currencies") }
+    if kinds.contains(.stock) { parts.append("stocks") }
+    if kinds.contains(.cryptoToken) { parts.append("registered tokens") }
+    let kindsLabel = parts.formatted(.list(type: .or))
+    return "No matching \(kindsLabel) for \"\(query)\"."
+  }
+}

--- a/Shared/Views/InstrumentPickerSheet.swift
+++ b/Shared/Views/InstrumentPickerSheet.swift
@@ -184,9 +184,13 @@ struct InstrumentPickerSheet: View {
       ContentUnavailableView(
         "No matches",
         systemImage: "magnifyingglass",
-        description: Text(
-          "No matching currencies, stocks, or registered tokens for \"\(store.query)\".")
+        description: Text(store.noMatchesDescription)
       )
+      // The populated branch returns a `List`, which fills available space.
+      // ContentUnavailableView is intrinsically sized — without this, the
+      // parent VStack would shrink and the popover would centre the whole
+      // header + search + empty-state column vertically.
+      .frame(maxWidth: .infinity, maxHeight: .infinity)
     } else {
       ScrollViewReader { proxy in
         List {
@@ -287,4 +291,35 @@ struct InstrumentPickerSheet: View {
       .frame(width: 28, height: 28)
       .background(.tint.opacity(0.12), in: RoundedRectangle(cornerRadius: 6))
   }
+}
+
+#Preview("Default (single result)") {
+  // Multi-row static rendering of this view crashes the previewer with
+  // SIGTRAP (corpse incomplete, no usable backtrace; ruled out
+  // preferredCurrencySymbol, .listRowBackground, and store stability).
+  // Use a single-result query for snapshot review; for multi-row review,
+  // interact with the canvas (clear the search to see all 17 fiat codes).
+  let store = InstrumentPickerStore(kinds: [.fiatCurrency])
+  store.updateQuery("AUD")
+  return InstrumentPickerSheet(
+    store: store,
+    label: "Currency",
+    selection: .constant(.AUD),
+    isPresented: .constant(true)
+  )
+  .frame(width: 460, height: 480)
+}
+
+#Preview("No matches") {
+  let store = InstrumentPickerStore(kinds: [.fiatCurrency])
+  // Seed a query that doesn't match any common fiat code so the empty-state
+  // view is what renders. The 250ms debounce settles inside the preview.
+  store.updateQuery("zxqy")
+  return InstrumentPickerSheet(
+    store: store,
+    label: "Currency",
+    selection: .constant(.AUD),
+    isPresented: .constant(true)
+  )
+  .frame(width: 460, height: 480)
 }


### PR DESCRIPTION
Stacked on top of [#483](https://github.com/ajsutton/moolah-native/pull/483).

## Summary

`InstrumentPickerSheet`'s empty branch returned a bare `ContentUnavailableView`, which is intrinsically sized — so the parent `VStack` shrank below the popover's `minHeight` and the popover centred the whole header + search + empty-state column vertically. The populated branch returns a `List`, which fills available space, so the two states anchored differently.

- Empty state now applies `.frame(maxWidth: .infinity, maxHeight: .infinity)` so the `VStack` fills the popover the same way the populated state does. Header and search stay anchored at the top across both states.
- `ContentUnavailableView` description is keyed off `store.kinds` via a new `InstrumentPickerStore.noMatchesDescription` computed property — a fiat-only picker now says *"No matching currencies for ..."* instead of the generic *"currencies, stocks, or registered tokens"* copy.
- Added `#Preview` definitions to the picker (default + no-matches) so this layout can be iterated without going through `CreateAccountView`'s popover.

## Known caveat

Multi-row static rendering of the populated picker crashes the previewer with `SIGTRAP` (corpse incomplete; ruled out `preferredCurrencySymbol`, `.listRowBackground`, store stability). The Default preview uses a single-result query (`AUD`) so the snapshot path works; multi-row is reachable interactively in the canvas (clear the search) and works fine in the running app. Comment in the file documents the trade-off.

## Test plan

- [ ] Open the No matches `#Preview` — header anchored at top, search field below, empty-state fills the rest with content centred.
- [ ] In a fiat-only picker (e.g. Create Account → Currency), search for `zxqy` — description reads "No matching currencies for "zxqy"." (no mention of stocks/tokens).
- [ ] Open the Default `#Preview` — single AUD row renders cleanly.
- [ ] Existing UI tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)