### PR TITLE
fix(sync): tag each onRecordChanged emit with its own recordType

### DIFF
--- a/.claude/agents/sync-review.md
+++ b/.claude/agents/sync-review.md
@@ -27,11 +27,27 @@ Key files are in `Backends/CloudKit/Sync/` and `Backends/CloudKit/Repositories/`
 ## What to Check
 
 ### Sync Change Queueing
-- Repository mutation methods (create, update, delete) call `onRecordChanged(id)` or `onRecordDeleted(id)` after saving (Rule 2, Rule 4)
+- Repository mutation methods (create, update, delete) call `onRecordChanged(recordType, id)` or `onRecordDeleted(recordType, id)` after saving (Rule 2, Rule 4)
 - Derived-data updates (`recomputeAllBalances`, `invalidateCachedBalances`, `computeBalance`) do NOT call sync closures (Rule 2)
 - No use of `NSManagedObjectContextDidSave` notifications for sync queueing -- this pattern was removed (Rule 2)
 - New syncable record types have closure calls in all mutation methods
 - `queueAllExistingRecords` includes the new record type in dependency order (Rule 14)
+
+### Record Type Tagging on Hook Calls (regression class -- PR #416 / fix #483)
+
+The `onRecordChanged` / `onRecordDeleted` hooks on every multi-emit repository carry the `recordType` of the record being mutated -- not the repository's "primary" type. Mismatch causes CloudKit to receive a save under the wrong `<recordType>|<UUID>` recordName; the next downlink lookup misses, `handleMissingRecordToSave` converts the save into a phantom delete, and the record is silently lost on every other device.
+
+For each mutation method, verify:
+
+- **Every call to `onRecordChanged(...)` / `onRecordDeleted(...)` passes the `XxxRecord.recordType` constant for the record whose UUID it is emitting**, not a hard-coded constant or the repository's primary type. If a `TransactionLegRecord.id` is being emitted, the call MUST pass `TransactionLegRecord.recordType` -- not `TransactionRecord.recordType`.
+- **Multi-type emit paths are tagged consistently** -- when one mutation persists records of more than one type and emits a hook for each, every emit names its own type. Watch especially for:
+  - `CloudKitTransactionRepository.create/update/delete` -- emits `TransactionRecord` (parent) + `TransactionLegRecord` (per leg)
+  - `CloudKitAccountRepository.create` with opening balance -- emits `AccountRecord` + `TransactionRecord` + `TransactionLegRecord`
+  - `CloudKitCategoryRepository.delete` cascade -- emits `CategoryRecord` (deleted + orphaned children) + `TransactionLegRecord` (reassigned legs) + `EarmarkBudgetItemRecord` (deleted/updated budgets)
+  - `CloudKitEarmarkRepository.setBudget` -- emits `EarmarkBudgetItemRecord`, never `EarmarkRecord`
+- **Wiring closures in `App/ProfileSession+SyncWiring.swift` forward the received `recordType` verbatim** -- they must read `{ recordType, id in coordinator?.queueSave(recordType: recordType, id: id, zoneID: zoneID) }`. Any wiring that hard-codes a single `recordType` constant for a multi-type repo is the regression. (Single-type repos may forward the same way; uniform pattern is the goal.)
+- **`InstrumentRecord` is intentionally NOT prefixed** -- it uses string recordNames (`"AUD"`, `"ASX:BHP"`) and routes via `queueSave(recordName:zoneID:)`. Don't flag the absence of a `(String, UUID)` hook on `CloudKitInstrumentRegistryRepository`.
+- **A regression test must pin the `(recordType, id)` contract per multi-type method** -- see `MoolahTests/Sync/RepositoryHookRecordTypeTests.swift`. New multi-type emit paths need a new test that captures the (recordType, id) pairs and asserts both the type tag and the count, not just "some emit happened".
 
 ### Zone Management
 - `ensureZoneExists()` called proactively in `start()`, followed by `sendChanges()` (Rule 3)
@@ -105,7 +121,7 @@ Produce a detailed report with:
 ### Issues Found
 
 Categorize by severity:
-- **Critical:** Missing conflict resolution, missing account change handling, repository mutation missing sync closure call, silently dropping records in default error case, returning >400 records from nextRecordZoneChangeBatch
+- **Critical:** Missing conflict resolution, missing account change handling, repository mutation missing sync closure call, **mismatched `recordType` passed to `onRecordChanged` / `onRecordDeleted` (e.g. emitting a leg's UUID under `TransactionRecord.recordType`)**, **wiring closure that hard-codes a single `recordType` for a repo whose mutations emit ids of multiple record types**, silently dropping records in default error case, returning >400 records from nextRecordZoneChangeBatch
 - **Important:** Missing error handling for specific codes, not preserving system fields, incomplete zone deletion handling, missing proactive zone creation
 - **Minor:** Missing logging, suboptimal patterns, missing defensive defaults in record mapping
 

--- a/App/ProfileSession+SyncWiring.swift
+++ b/App/ProfileSession+SyncWiring.swift
@@ -5,6 +5,16 @@ extension ProfileSession {
   /// Wires each `CloudKit*Repository`'s change/delete callbacks to the
   /// given sync coordinator so local mutations queue the corresponding
   /// CloudKit send. Called from `init` for iCloud profiles.
+  ///
+  /// Each repository hands the wiring `(recordType, id)` so the coordinator
+  /// can build the prefixed `<recordType>|<UUID>` recordName (issue #416).
+  /// The repos that emit ids of more than one record type per call —
+  /// transactions (txn + leg), accounts (account + opening-balance txn +
+  /// leg), categories (category + reassigned legs + budget items), and
+  /// earmarks (earmark + budget items) — all rely on the type travelling
+  /// with the id; otherwise the wiring would mis-tag downstream records and
+  /// `nextRecordZoneChangeBatch` would convert their save into a phantom
+  /// delete (regression covered by `RepositoryHookRecordTypeTests`).
   func wireRepositorySync(coordinator: SyncCoordinator, zoneID: CKRecordZone.ID) {
     wireAccountsAndTransactionsSync(coordinator: coordinator, zoneID: zoneID)
     wireSimpleRepositorySync(coordinator: coordinator, zoneID: zoneID)
@@ -16,23 +26,22 @@ extension ProfileSession {
     coordinator: SyncCoordinator, zoneID: CKRecordZone.ID
   ) {
     if let repo = backend.accounts as? CloudKitAccountRepository {
-      repo.onRecordChanged = { [weak coordinator] id in
-        coordinator?.queueSave(recordType: AccountRecord.recordType, id: id, zoneID: zoneID)
+      repo.onRecordChanged = { [weak coordinator] recordType, id in
+        coordinator?.queueSave(recordType: recordType, id: id, zoneID: zoneID)
       }
-      repo.onRecordDeleted = { [weak coordinator] id in
-        coordinator?.queueDeletion(recordType: AccountRecord.recordType, id: id, zoneID: zoneID)
+      repo.onRecordDeleted = { [weak coordinator] recordType, id in
+        coordinator?.queueDeletion(recordType: recordType, id: id, zoneID: zoneID)
       }
       repo.onInstrumentChanged = { [weak coordinator] id in
         coordinator?.queueSave(recordName: id, zoneID: zoneID)
       }
     }
     if let repo = backend.transactions as? CloudKitTransactionRepository {
-      repo.onRecordChanged = { [weak coordinator] id in
-        coordinator?.queueSave(recordType: TransactionRecord.recordType, id: id, zoneID: zoneID)
+      repo.onRecordChanged = { [weak coordinator] recordType, id in
+        coordinator?.queueSave(recordType: recordType, id: id, zoneID: zoneID)
       }
-      repo.onRecordDeleted = { [weak coordinator] id in
-        coordinator?.queueDeletion(
-          recordType: TransactionRecord.recordType, id: id, zoneID: zoneID)
+      repo.onRecordDeleted = { [weak coordinator] recordType, id in
+        coordinator?.queueDeletion(recordType: recordType, id: id, zoneID: zoneID)
       }
       repo.onInstrumentChanged = { [weak coordinator] id in
         coordinator?.queueSave(recordName: id, zoneID: zoneID)
@@ -47,48 +56,43 @@ extension ProfileSession {
     coordinator: SyncCoordinator, zoneID: CKRecordZone.ID
   ) {
     if let repo = backend.categories as? CloudKitCategoryRepository {
-      repo.onRecordChanged = { [weak coordinator] id in
-        coordinator?.queueSave(recordType: CategoryRecord.recordType, id: id, zoneID: zoneID)
+      repo.onRecordChanged = { [weak coordinator] recordType, id in
+        coordinator?.queueSave(recordType: recordType, id: id, zoneID: zoneID)
       }
-      repo.onRecordDeleted = { [weak coordinator] id in
-        coordinator?.queueDeletion(recordType: CategoryRecord.recordType, id: id, zoneID: zoneID)
+      repo.onRecordDeleted = { [weak coordinator] recordType, id in
+        coordinator?.queueDeletion(recordType: recordType, id: id, zoneID: zoneID)
       }
     }
     if let repo = backend.earmarks as? CloudKitEarmarkRepository {
-      repo.onRecordChanged = { [weak coordinator] id in
-        coordinator?.queueSave(recordType: EarmarkRecord.recordType, id: id, zoneID: zoneID)
+      repo.onRecordChanged = { [weak coordinator] recordType, id in
+        coordinator?.queueSave(recordType: recordType, id: id, zoneID: zoneID)
       }
-      repo.onRecordDeleted = { [weak coordinator] id in
-        coordinator?.queueDeletion(recordType: EarmarkRecord.recordType, id: id, zoneID: zoneID)
+      repo.onRecordDeleted = { [weak coordinator] recordType, id in
+        coordinator?.queueDeletion(recordType: recordType, id: id, zoneID: zoneID)
       }
     }
     if let repo = backend.investments as? CloudKitInvestmentRepository {
-      repo.onRecordChanged = { [weak coordinator] id in
-        coordinator?.queueSave(
-          recordType: InvestmentValueRecord.recordType, id: id, zoneID: zoneID)
+      repo.onRecordChanged = { [weak coordinator] recordType, id in
+        coordinator?.queueSave(recordType: recordType, id: id, zoneID: zoneID)
       }
-      repo.onRecordDeleted = { [weak coordinator] id in
-        coordinator?.queueDeletion(
-          recordType: InvestmentValueRecord.recordType, id: id, zoneID: zoneID)
+      repo.onRecordDeleted = { [weak coordinator] recordType, id in
+        coordinator?.queueDeletion(recordType: recordType, id: id, zoneID: zoneID)
       }
     }
     if let repo = backend.csvImportProfiles as? CloudKitCSVImportProfileRepository {
-      repo.onRecordChanged = { [weak coordinator] id in
-        coordinator?.queueSave(
-          recordType: CSVImportProfileRecord.recordType, id: id, zoneID: zoneID)
+      repo.onRecordChanged = { [weak coordinator] recordType, id in
+        coordinator?.queueSave(recordType: recordType, id: id, zoneID: zoneID)
       }
-      repo.onRecordDeleted = { [weak coordinator] id in
-        coordinator?.queueDeletion(
-          recordType: CSVImportProfileRecord.recordType, id: id, zoneID: zoneID)
+      repo.onRecordDeleted = { [weak coordinator] recordType, id in
+        coordinator?.queueDeletion(recordType: recordType, id: id, zoneID: zoneID)
       }
     }
     if let repo = backend.importRules as? CloudKitImportRuleRepository {
-      repo.onRecordChanged = { [weak coordinator] id in
-        coordinator?.queueSave(recordType: ImportRuleRecord.recordType, id: id, zoneID: zoneID)
+      repo.onRecordChanged = { [weak coordinator] recordType, id in
+        coordinator?.queueSave(recordType: recordType, id: id, zoneID: zoneID)
       }
-      repo.onRecordDeleted = { [weak coordinator] id in
-        coordinator?.queueDeletion(
-          recordType: ImportRuleRecord.recordType, id: id, zoneID: zoneID)
+      repo.onRecordDeleted = { [weak coordinator] recordType, id in
+        coordinator?.queueDeletion(recordType: recordType, id: id, zoneID: zoneID)
       }
     }
   }

--- a/Backends/CloudKit/Repositories/CloudKitAccountRepository.swift
+++ b/Backends/CloudKit/Repositories/CloudKitAccountRepository.swift
@@ -6,8 +6,11 @@ import os
 final class CloudKitAccountRepository: AccountRepository, @unchecked Sendable {
   private let logger = Logger(subsystem: "com.moolah.app", category: "AccountRepository")
   let modelContainer: ModelContainer
-  var onRecordChanged: (UUID) -> Void = { _ in }
-  var onRecordDeleted: (UUID) -> Void = { _ in }
+  /// Receives `(recordType, id)` so the opening-balance create path can tag
+  /// its txn and leg writes with `TransactionRecord` / `TransactionLegRecord`
+  /// instead of the account's own type — see `RepositoryHookRecordTypeTests`.
+  var onRecordChanged: (String, UUID) -> Void = { _, _ in }
+  var onRecordDeleted: (String, UUID) -> Void = { _, _ in }
   var onInstrumentChanged: (String) -> Void = { _ in }
 
   init(modelContainer: ModelContainer) {
@@ -95,12 +98,12 @@ final class CloudKitAccountRepository: AccountRepository, @unchecked Sendable {
         )
         context.insert(legRecord)
         try context.save()
-        onRecordChanged(account.id)
-        onRecordChanged(txnRecord.id)
-        onRecordChanged(legRecord.id)
+        onRecordChanged(AccountRecord.recordType, account.id)
+        onRecordChanged(TransactionRecord.recordType, txnRecord.id)
+        onRecordChanged(TransactionLegRecord.recordType, legRecord.id)
       } else {
         try context.save()
-        onRecordChanged(account.id)
+        onRecordChanged(AccountRecord.recordType, account.id)
       }
     }
 
@@ -134,7 +137,7 @@ final class CloudKitAccountRepository: AccountRepository, @unchecked Sendable {
       record.position = account.position
       record.isHidden = account.isHidden
       try context.save()
-      onRecordChanged(account.id)
+      onRecordChanged(AccountRecord.recordType, account.id)
 
       let instruments = try fetchInstrumentMap()
       let allPositions = try computeAllPositions(instruments: instruments)
@@ -173,7 +176,7 @@ final class CloudKitAccountRepository: AccountRepository, @unchecked Sendable {
       // Soft delete
       record.isHidden = true
       try context.save()
-      onRecordChanged(id)
+      onRecordChanged(AccountRecord.recordType, id)
     }
   }
 

--- a/Backends/CloudKit/Repositories/CloudKitCSVImportProfileRepository.swift
+++ b/Backends/CloudKit/Repositories/CloudKitCSVImportProfileRepository.swift
@@ -3,8 +3,8 @@ import SwiftData
 
 final class CloudKitCSVImportProfileRepository: CSVImportProfileRepository, @unchecked Sendable {
   private let modelContainer: ModelContainer
-  var onRecordChanged: (UUID) -> Void = { _ in }
-  var onRecordDeleted: (UUID) -> Void = { _ in }
+  var onRecordChanged: (String, UUID) -> Void = { _, _ in }
+  var onRecordDeleted: (String, UUID) -> Void = { _, _ in }
 
   init(modelContainer: ModelContainer) {
     self.modelContainer = modelContainer
@@ -25,7 +25,7 @@ final class CloudKitCSVImportProfileRepository: CSVImportProfileRepository, @unc
       let record = CSVImportProfileRecord.from(profile)
       context.insert(record)
       try context.save()
-      onRecordChanged(profile.id)
+      onRecordChanged(CSVImportProfileRecord.recordType, profile.id)
       return record.toDomain()
     }
   }
@@ -49,7 +49,7 @@ final class CloudKitCSVImportProfileRepository: CSVImportProfileRepository, @unc
       record.columnRoleRawValuesEncoded = CSVImportProfileRecord.encodeColumnRoles(
         profile.columnRoleRawValues)
       try context.save()
-      onRecordChanged(profile.id)
+      onRecordChanged(CSVImportProfileRecord.recordType, profile.id)
       return record.toDomain()
     }
   }
@@ -63,7 +63,7 @@ final class CloudKitCSVImportProfileRepository: CSVImportProfileRepository, @unc
       }
       context.delete(record)
       try context.save()
-      onRecordDeleted(id)
+      onRecordDeleted(CSVImportProfileRecord.recordType, id)
     }
   }
 }

--- a/Backends/CloudKit/Repositories/CloudKitCategoryRepository.swift
+++ b/Backends/CloudKit/Repositories/CloudKitCategoryRepository.swift
@@ -4,8 +4,12 @@ import os
 
 final class CloudKitCategoryRepository: CategoryRepository, @unchecked Sendable {
   private let modelContainer: ModelContainer
-  var onRecordChanged: (UUID) -> Void = { _ in }
-  var onRecordDeleted: (UUID) -> Void = { _ in }
+  /// Receives `(recordType, id)` so deleting a category — which fans out to
+  /// orphaned children, reassigned legs, and budget-item upserts/deletes —
+  /// tags each downstream emit with its own type. See
+  /// `RepositoryHookRecordTypeTests`.
+  var onRecordChanged: (String, UUID) -> Void = { _, _ in }
+  var onRecordDeleted: (String, UUID) -> Void = { _, _ in }
 
   init(modelContainer: ModelContainer) {
     self.modelContainer = modelContainer
@@ -44,7 +48,7 @@ final class CloudKitCategoryRepository: CategoryRepository, @unchecked Sendable 
     try await MainActor.run {
       context.insert(record)
       try context.save()
-      onRecordChanged(category.id)
+      onRecordChanged(CategoryRecord.recordType, category.id)
     }
     return category
   }
@@ -68,7 +72,7 @@ final class CloudKitCategoryRepository: CategoryRepository, @unchecked Sendable 
       record.name = category.name
       record.parentId = category.parentId
       try context.save()
-      onRecordChanged(category.id)
+      onRecordChanged(CategoryRecord.recordType, category.id)
     }
     return category
   }
@@ -106,12 +110,17 @@ final class CloudKitCategoryRepository: CategoryRepository, @unchecked Sendable 
     context.delete(record)
     try context.save()
 
-    // Queue sync changes for all affected records
-    onRecordDeleted(id)
-    for child in children { onRecordChanged(child.id) }
-    for leg in affectedLegs { onRecordChanged(leg.id) }
-    for budgetId in deletedBudgetIds { onRecordDeleted(budgetId) }
-    for budgetId in updatedBudgetIds { onRecordChanged(budgetId) }
+    // Queue sync changes for all affected records — each emit names its own
+    // type so the wiring queues the right `<recordType>|<UUID>` (issue #416).
+    onRecordDeleted(CategoryRecord.recordType, id)
+    for child in children { onRecordChanged(CategoryRecord.recordType, child.id) }
+    for leg in affectedLegs { onRecordChanged(TransactionLegRecord.recordType, leg.id) }
+    for budgetId in deletedBudgetIds {
+      onRecordDeleted(EarmarkBudgetItemRecord.recordType, budgetId)
+    }
+    for budgetId in updatedBudgetIds {
+      onRecordChanged(EarmarkBudgetItemRecord.recordType, budgetId)
+    }
   }
 
   /// Orphan child categories of `targetId` (server always sets parent_id = NULL).

--- a/Backends/CloudKit/Repositories/CloudKitEarmarkRepository.swift
+++ b/Backends/CloudKit/Repositories/CloudKitEarmarkRepository.swift
@@ -7,8 +7,11 @@ import os
 final class CloudKitEarmarkRepository: EarmarkRepository, @unchecked Sendable {
   private let modelContainer: ModelContainer
   private let instrument: Instrument
-  var onRecordChanged: (UUID) -> Void = { _ in }
-  var onRecordDeleted: (UUID) -> Void = { _ in }
+  /// Receives `(recordType, id)` so budget-item upserts emit the
+  /// `EarmarkBudgetItemRecord` type rather than being mis-tagged as
+  /// `EarmarkRecord`. See `RepositoryHookRecordTypeTests`.
+  var onRecordChanged: (String, UUID) -> Void = { _, _ in }
+  var onRecordDeleted: (String, UUID) -> Void = { _, _ in }
 
   init(modelContainer: ModelContainer, instrument: Instrument) {
     self.modelContainer = modelContainer
@@ -54,7 +57,7 @@ final class CloudKitEarmarkRepository: EarmarkRepository, @unchecked Sendable {
     try await MainActor.run {
       context.insert(record)
       try context.save()
-      onRecordChanged(earmark.id)
+      onRecordChanged(EarmarkRecord.recordType, earmark.id)
     }
     return earmark
   }
@@ -84,7 +87,7 @@ final class CloudKitEarmarkRepository: EarmarkRepository, @unchecked Sendable {
       record.savingsStartDate = earmark.savingsStartDate
       record.savingsEndDate = earmark.savingsEndDate
       try context.save()
-      onRecordChanged(earmark.id)
+      onRecordChanged(EarmarkRecord.recordType, earmark.id)
     }
     return earmark
   }
@@ -172,7 +175,7 @@ final class CloudKitEarmarkRepository: EarmarkRepository, @unchecked Sendable {
         let deletedId = existing.id
         context.delete(existing)
         try context.save()
-        onRecordDeleted(deletedId)
+        onRecordDeleted(EarmarkBudgetItemRecord.recordType, deletedId)
       }
       return
     }
@@ -180,7 +183,7 @@ final class CloudKitEarmarkRepository: EarmarkRepository, @unchecked Sendable {
       existing.amount = amount.storageValue
       existing.instrumentId = amount.instrument.id
       try context.save()
-      onRecordChanged(existing.id)
+      onRecordChanged(EarmarkBudgetItemRecord.recordType, existing.id)
       return
     }
     let record = EarmarkBudgetItemRecord(
@@ -191,7 +194,7 @@ final class CloudKitEarmarkRepository: EarmarkRepository, @unchecked Sendable {
     )
     context.insert(record)
     try context.save()
-    onRecordChanged(record.id)
+    onRecordChanged(EarmarkBudgetItemRecord.recordType, record.id)
   }
 
   /// Three position lists computed for a single earmark — one per flow

--- a/Backends/CloudKit/Repositories/CloudKitImportRuleRepository.swift
+++ b/Backends/CloudKit/Repositories/CloudKitImportRuleRepository.swift
@@ -3,8 +3,8 @@ import SwiftData
 
 final class CloudKitImportRuleRepository: ImportRuleRepository, @unchecked Sendable {
   private let modelContainer: ModelContainer
-  var onRecordChanged: (UUID) -> Void = { _ in }
-  var onRecordDeleted: (UUID) -> Void = { _ in }
+  var onRecordChanged: (String, UUID) -> Void = { _, _ in }
+  var onRecordDeleted: (String, UUID) -> Void = { _, _ in }
 
   init(modelContainer: ModelContainer) {
     self.modelContainer = modelContainer
@@ -25,7 +25,7 @@ final class CloudKitImportRuleRepository: ImportRuleRepository, @unchecked Senda
       let record = ImportRuleRecord.from(rule)
       context.insert(record)
       try context.save()
-      onRecordChanged(rule.id)
+      onRecordChanged(ImportRuleRecord.recordType, rule.id)
       return record.toDomain()
     }
   }
@@ -47,7 +47,7 @@ final class CloudKitImportRuleRepository: ImportRuleRepository, @unchecked Senda
       record.actionsJSON = updated.actionsJSON
       record.accountScope = updated.accountScope
       try context.save()
-      onRecordChanged(rule.id)
+      onRecordChanged(ImportRuleRecord.recordType, rule.id)
       return record.toDomain()
     }
   }
@@ -61,7 +61,7 @@ final class CloudKitImportRuleRepository: ImportRuleRepository, @unchecked Senda
       }
       context.delete(record)
       try context.save()
-      onRecordDeleted(id)
+      onRecordDeleted(ImportRuleRecord.recordType, id)
     }
   }
 
@@ -90,7 +90,7 @@ final class CloudKitImportRuleRepository: ImportRuleRepository, @unchecked Senda
         }
       }
       try context.save()
-      for id in changedIds { onRecordChanged(id) }
+      for id in changedIds { onRecordChanged(ImportRuleRecord.recordType, id) }
     }
   }
 }

--- a/Backends/CloudKit/Repositories/CloudKitInvestmentRepository.swift
+++ b/Backends/CloudKit/Repositories/CloudKitInvestmentRepository.swift
@@ -6,8 +6,8 @@ import SwiftData
 final class CloudKitInvestmentRepository: InvestmentRepository, @unchecked Sendable {
   private let modelContainer: ModelContainer
   private let instrument: Instrument
-  var onRecordChanged: (UUID) -> Void = { _ in }
-  var onRecordDeleted: (UUID) -> Void = { _ in }
+  var onRecordChanged: (String, UUID) -> Void = { _, _ in }
+  var onRecordDeleted: (String, UUID) -> Void = { _, _ in }
 
   init(modelContainer: ModelContainer, instrument: Instrument) {
     self.modelContainer = modelContainer
@@ -52,14 +52,14 @@ final class CloudKitInvestmentRepository: InvestmentRepository, @unchecked Senda
         existing.value = value.storageValue
         existing.instrumentId = value.instrument.id
         try context.save()
-        onRecordChanged(existing.id)
+        onRecordChanged(InvestmentValueRecord.recordType, existing.id)
       } else {
         let record = InvestmentValueRecord(
           accountId: accountId, date: normalizedDate,
           value: value.storageValue, instrumentId: value.instrument.id)
         context.insert(record)
         try context.save()
-        onRecordChanged(record.id)
+        onRecordChanged(InvestmentValueRecord.recordType, record.id)
       }
     }
   }
@@ -79,7 +79,7 @@ final class CloudKitInvestmentRepository: InvestmentRepository, @unchecked Senda
       let deletedId = record.id
       context.delete(record)
       try context.save()
-      onRecordDeleted(deletedId)
+      onRecordDeleted(InvestmentValueRecord.recordType, deletedId)
     }
   }
 

--- a/Backends/CloudKit/Repositories/CloudKitTransactionRepository+Mutations.swift
+++ b/Backends/CloudKit/Repositories/CloudKitTransactionRepository+Mutations.swift
@@ -30,9 +30,9 @@ extension CloudKitTransactionRepository {
       }
 
       try context.save()
-      onRecordChanged(transaction.id)
+      onRecordChanged(TransactionRecord.recordType, transaction.id)
       for legRecord in legRecords {
-        onRecordChanged(legRecord.id)
+        onRecordChanged(TransactionLegRecord.recordType, legRecord.id)
       }
     }
     return transaction
@@ -76,12 +76,12 @@ extension CloudKitTransactionRepository {
       }
 
       try context.save()
-      onRecordChanged(transaction.id)
+      onRecordChanged(TransactionRecord.recordType, transaction.id)
       for legRecord in newLegRecords {
-        onRecordChanged(legRecord.id)
+        onRecordChanged(TransactionLegRecord.recordType, legRecord.id)
       }
       for oldLegId in oldLegIds {
-        onRecordDeleted(oldLegId)
+        onRecordDeleted(TransactionLegRecord.recordType, oldLegId)
       }
     }
     return transaction
@@ -115,9 +115,9 @@ extension CloudKitTransactionRepository {
 
       context.delete(record)
       try context.save()
-      onRecordDeleted(id)
+      onRecordDeleted(TransactionRecord.recordType, id)
       for legId in legIds {
-        onRecordDeleted(legId)
+        onRecordDeleted(TransactionLegRecord.recordType, legId)
       }
     }
   }

--- a/Backends/CloudKit/Repositories/CloudKitTransactionRepository.swift
+++ b/Backends/CloudKit/Repositories/CloudKitTransactionRepository.swift
@@ -9,8 +9,13 @@ final class CloudKitTransactionRepository: TransactionRepository, @unchecked Sen
   let conversionService: any InstrumentConversionService
   let logger = Logger(
     subsystem: "com.moolah.app", category: "CloudKitTransactionRepository")
-  var onRecordChanged: (UUID) -> Void = { _ in }
-  var onRecordDeleted: (UUID) -> Void = { _ in }
+  /// Receives `(recordType, id)` so legs and parent transactions tag their
+  /// own CloudKit `recordName` correctly. The transaction repo emits both
+  /// `TransactionRecord` (parent) and `TransactionLegRecord` (per leg) ids
+  /// from the same mutation, so the callback must carry the type — see the
+  /// regression in `RepositoryHookRecordTypeTests`.
+  var onRecordChanged: (String, UUID) -> Void = { _, _ in }
+  var onRecordDeleted: (String, UUID) -> Void = { _, _ in }
   var onInstrumentChanged: (String) -> Void = { _ in }
 
   init(

--- a/MoolahTests/Sync/RepositoryHookRecordTypeTests.swift
+++ b/MoolahTests/Sync/RepositoryHookRecordTypeTests.swift
@@ -1,0 +1,209 @@
+import Foundation
+import SwiftData
+import Testing
+
+@testable import Moolah
+
+/// Regression tests for the bug introduced in PR #416 where every CloudKit
+/// repository's `onRecordChanged` / `onRecordDeleted` closure forced a single
+/// `recordType` regardless of which kind of record the repository was
+/// actually mutating. Repositories that mutate more than one record type
+/// (legs, budget items, child categories, the txn+leg pair built from an
+/// opening balance) emitted IDs that the wiring then mis-prefixed, so the
+/// server-side `nextRecordZoneChangeBatch` lookup missed them and converted
+/// the upload into a phantom delete.
+///
+/// The fix threads the `recordType` through the hook signature so each
+/// emit names its own type. These tests pin that contract per repo so a
+/// future signature regression breaks the build (and the wiring stays
+/// honest about which type each id belongs to).
+@Suite("Repository hooks emit (recordType, id) pairs")
+@MainActor
+struct RepositoryHookRecordTypeTests {
+
+  // MARK: - Capture Helper
+
+  /// Confined to `@MainActor` so the (non-Sendable) closures wired to the
+  /// repository can append into the buffers without crossing actors.
+  @MainActor
+  final class HookCapture {
+    var changed: [(recordType: String, id: UUID)] = []
+    var deleted: [(recordType: String, id: UUID)] = []
+  }
+
+  // MARK: - TransactionRepository
+
+  @Test("create(_:) emits one TransactionRecord and one TransactionLegRecord per leg")
+  func transactionCreateEmitsLegRecordType() async throws {
+    let repo = try makeContractCloudKitTransactionRepository()
+    let capture = HookCapture()
+    repo.onRecordChanged = { recordType, id in capture.changed.append((recordType, id)) }
+    repo.onRecordDeleted = { recordType, id in capture.deleted.append((recordType, id)) }
+
+    let accountId = UUID()
+    let txn = Transaction(
+      date: Date(), payee: "Trade",
+      legs: [
+        makeContractTestLeg(accountId: accountId, quantity: -100, type: .transfer),
+        makeContractTestLeg(accountId: accountId, quantity: 100, type: .transfer),
+      ]
+    )
+
+    _ = try await repo.create(txn)
+
+    let txnEmits = capture.changed.filter { $0.recordType == TransactionRecord.recordType }
+    let legEmits = capture.changed.filter { $0.recordType == TransactionLegRecord.recordType }
+    #expect(txnEmits.map(\.id) == [txn.id])
+    #expect(legEmits.count == 2)
+    #expect(capture.deleted.isEmpty)
+    // Catch any future drift that emits a leg under the wrong type prefix.
+    #expect(capture.changed.count == 3)
+  }
+
+  @Test("update(_:) emits leg-create and leg-delete events tagged with TransactionLegRecord")
+  func transactionUpdateEmitsLegRecordType() async throws {
+    let initialLeg = makeContractTestLeg(accountId: UUID(), quantity: -50, type: .expense)
+    let original = Transaction(date: Date(), payee: "Coffee", legs: [initialLeg])
+    let repo = try makeContractCloudKitTransactionRepository(initialTransactions: [original])
+
+    let capture = HookCapture()
+    repo.onRecordChanged = { recordType, id in capture.changed.append((recordType, id)) }
+    repo.onRecordDeleted = { recordType, id in capture.deleted.append((recordType, id)) }
+
+    var updated = original
+    updated.legs = [makeContractTestLeg(accountId: UUID(), quantity: -75, type: .expense)]
+    _ = try await repo.update(updated)
+
+    let txnChanges = capture.changed.filter { $0.recordType == TransactionRecord.recordType }
+    let legChanges = capture.changed.filter { $0.recordType == TransactionLegRecord.recordType }
+    let legDeletes = capture.deleted.filter { $0.recordType == TransactionLegRecord.recordType }
+    #expect(txnChanges.map(\.id) == [original.id])
+    #expect(legChanges.count == 1)
+    #expect(legDeletes.count == 1)
+  }
+
+  @Test("delete(id:) emits TransactionRecord delete and TransactionLegRecord delete per leg")
+  func transactionDeleteEmitsLegRecordType() async throws {
+    let leg = makeContractTestLeg(accountId: UUID(), quantity: -50, type: .expense)
+    let txn = Transaction(date: Date(), payee: "Coffee", legs: [leg])
+    let repo = try makeContractCloudKitTransactionRepository(initialTransactions: [txn])
+
+    let capture = HookCapture()
+    repo.onRecordChanged = { recordType, id in capture.changed.append((recordType, id)) }
+    repo.onRecordDeleted = { recordType, id in capture.deleted.append((recordType, id)) }
+
+    try await repo.delete(id: txn.id)
+
+    let txnDeletes = capture.deleted.filter { $0.recordType == TransactionRecord.recordType }
+    let legDeletes = capture.deleted.filter { $0.recordType == TransactionLegRecord.recordType }
+    #expect(txnDeletes.map(\.id) == [txn.id])
+    #expect(legDeletes.count == 1)
+    #expect(capture.changed.isEmpty)
+  }
+
+  // MARK: - AccountRepository
+
+  @Test("create with opening balance tags account, txn, and leg with their own record types")
+  func accountCreateOpeningBalanceTagsRecordTypes() async throws {
+    let container = try TestModelContainer.create()
+    let repo = CloudKitAccountRepository(modelContainer: container)
+    let capture = HookCapture()
+    repo.onRecordChanged = { recordType, id in capture.changed.append((recordType, id)) }
+    repo.onRecordDeleted = { recordType, id in capture.deleted.append((recordType, id)) }
+
+    let account = Account(name: "Cash", type: .bank, instrument: .defaultTestInstrument)
+    _ = try await repo.create(
+      account,
+      openingBalance: InstrumentAmount(quantity: 100, instrument: .defaultTestInstrument))
+
+    let accountEmits = capture.changed.filter { $0.recordType == AccountRecord.recordType }
+    let txnEmits = capture.changed.filter { $0.recordType == TransactionRecord.recordType }
+    let legEmits = capture.changed.filter { $0.recordType == TransactionLegRecord.recordType }
+    #expect(accountEmits.map(\.id) == [account.id])
+    #expect(txnEmits.count == 1)
+    #expect(legEmits.count == 1)
+    #expect(capture.changed.count == 3)
+  }
+
+  // MARK: - CategoryRepository
+
+  @Test(
+    "delete cascade tags legs as TransactionLegRecord and budget items as EarmarkBudgetItemRecord")
+  func categoryDeleteCascadeTagsRecordTypes() async throws {
+    let container = try TestModelContainer.create()
+
+    let parentCategoryId = UUID()
+    let childCategoryId = UUID()
+    let earmarkId = UUID()
+    let txnId = UUID()
+    let legId = UUID()
+    let budgetItemId = UUID()
+    let instrumentId = "AUD"
+
+    let context = ModelContext(container)
+    context.insert(
+      InstrumentRecord(
+        id: instrumentId, kind: "fiatCurrency", name: "AUD", decimals: 2))
+    context.insert(CategoryRecord(id: parentCategoryId, name: "Food", parentId: nil))
+    context.insert(
+      CategoryRecord(id: childCategoryId, name: "Groceries", parentId: parentCategoryId))
+    context.insert(EarmarkRecord(id: earmarkId, name: "Holiday", instrumentId: instrumentId))
+    context.insert(
+      EarmarkBudgetItemRecord(
+        id: budgetItemId, earmarkId: earmarkId, categoryId: parentCategoryId,
+        amount: 100, instrumentId: instrumentId))
+    context.insert(TransactionRecord(id: txnId, date: Date(), payee: "Lunch"))
+    context.insert(
+      TransactionLegRecord(
+        id: legId, transactionId: txnId, accountId: UUID(),
+        instrumentId: instrumentId, quantity: -10, type: "expense",
+        categoryId: parentCategoryId, sortOrder: 0))
+    try context.save()
+
+    let repo = CloudKitCategoryRepository(modelContainer: container)
+    let capture = HookCapture()
+    repo.onRecordChanged = { recordType, id in capture.changed.append((recordType, id)) }
+    repo.onRecordDeleted = { recordType, id in capture.deleted.append((recordType, id)) }
+
+    // No replacement: legs lose their categoryId, budget item is deleted, child is orphaned.
+    try await repo.delete(id: parentCategoryId, withReplacement: nil)
+
+    let categoryDeletes = capture.deleted.filter { $0.recordType == CategoryRecord.recordType }
+    let budgetDeletes = capture.deleted.filter {
+      $0.recordType == EarmarkBudgetItemRecord.recordType
+    }
+    let categoryChanges = capture.changed.filter { $0.recordType == CategoryRecord.recordType }
+    let legChanges = capture.changed.filter { $0.recordType == TransactionLegRecord.recordType }
+
+    #expect(categoryDeletes.map(\.id) == [parentCategoryId])
+    #expect(budgetDeletes.map(\.id) == [budgetItemId])
+    #expect(categoryChanges.map(\.id) == [childCategoryId])
+    #expect(legChanges.map(\.id) == [legId])
+  }
+
+  // MARK: - EarmarkRepository
+
+  @Test("setBudget tags emits with EarmarkBudgetItemRecord, not EarmarkRecord")
+  func earmarkSetBudgetTagsBudgetItemRecord() async throws {
+    let container = try TestModelContainer.create()
+    let repo = CloudKitEarmarkRepository(
+      modelContainer: container, instrument: .defaultTestInstrument)
+    let earmark = try await repo.create(
+      Earmark(name: "Holiday", instrument: .defaultTestInstrument))
+    let capture = HookCapture()
+    repo.onRecordChanged = { recordType, id in capture.changed.append((recordType, id)) }
+    repo.onRecordDeleted = { recordType, id in capture.deleted.append((recordType, id)) }
+
+    try await repo.setBudget(
+      earmarkId: earmark.id,
+      categoryId: UUID(),
+      amount: InstrumentAmount(quantity: 50, instrument: .defaultTestInstrument))
+
+    let earmarkEmits = capture.changed.filter { $0.recordType == EarmarkRecord.recordType }
+    let budgetEmits = capture.changed.filter {
+      $0.recordType == EarmarkBudgetItemRecord.recordType
+    }
+    #expect(earmarkEmits.isEmpty)
+    #expect(budgetEmits.count == 1)
+  }
+}


### PR DESCRIPTION
## Summary

PR #416 hard-coded a single `recordType` per repository in the wiring closure, but several `CloudKit*Repository` mutations emit ids of more than one record type from the same callback:

- `CloudKitTransactionRepository.create/update/delete` — emits both `TransactionRecord` (parent) and `TransactionLegRecord` (per leg)
- `CloudKitAccountRepository.create` (opening-balance path) — emits `AccountRecord` + `TransactionRecord` + `TransactionLegRecord`
- `CloudKitCategoryRepository.delete` cascade — emits `CategoryRecord` (deleted + orphaned children) + `TransactionLegRecord` (reassigned legs) + `EarmarkBudgetItemRecord` (deleted/updated budgets)
- `CloudKitEarmarkRepository.setBudget` — emits `EarmarkBudgetItemRecord`, never `EarmarkRecord`

The wiring mis-prefixed those downstream ids (e.g. a leg's UUID went out as `"TransactionRecord|<legUUID>"` instead of `"TransactionLegRecord|<legUUID>"`). `appendProfileDataRecords` did an IN-query against the wrong record type, missed the leg, and `handleMissingRecordToSave` converted the save into a phantom delete on the server. Net effect: **legs and budget items created on one device never reached CloudKit**, so they never replicated to other devices. (Reproduced as a multi-leg trade transaction created on Mac that failed to appear on iPhone despite both devices reporting "in sync with iCloud".)

The fix changes every `CloudKit*Repository` hook signature from `(UUID) -> Void` to `(String, UUID) -> Void` so each emit names its own record type. The wiring in `App/ProfileSession+SyncWiring.swift` becomes a single uniform pattern: every closure forwards `(recordType, id)` straight to `coordinator.queueSave(recordType:id:zoneID:)`. `CloudKitInstrumentRegistryRepository` is unchanged — instruments use raw string recordNames with no `<type>|<UUID>` prefix and route via the separate `queueSave(recordName:zoneID:)` overload.

The sync-review agent is updated to flag mismatched recordType tags and any wiring closure that hard-codes a single recordType for a multi-emit repo as a Critical finding, so this regression class is caught at review time.

## Test plan

- [x] `MoolahTests/Sync/RepositoryHookRecordTypeTests.swift` — new tests pin the `(recordType, id)` contract for transaction create/update/delete, account create-with-opening-balance, category delete cascade, and earmark setBudget. Each captures the emitted (recordType, id) pairs and asserts both the type tag and the count.
- [x] `just test-mac` — 1673 tests pass
- [x] `just test-ios` — passes
- [x] `just format-check` — clean
- [ ] Manual: create a multi-leg trade transaction on Mac, verify it appears on iPhone after foreground sync (cannot run in CI; depends on CloudKit dev container)

🤖 Generated with [Claude Code](https://claude.com/claude-code)