### PR TITLE
fix(transactions): load multi-instrument bank accounts on first open

### DIFF
--- a/.claude/skills/automate-app/SKILL.md
+++ b/.claude/skills/automate-app/SKILL.md
@@ -17,6 +17,14 @@ Drive the running Moolah macOS app via AppleScript (`osascript`). Data operation
 
 The app must be built and running in **this worktree**. Use `just run-mac` to build and launch, or `just run-mac-with-logs` to also capture logs.
 
+### CRITICAL: Run the wrapper from inside the worktree
+
+**Your shell's current working directory must be inside the worktree before invoking `moolah-tell`.** The wrapper picks the target Moolah.app via `git rev-parse --show-toplevel` of CWD, then `tell application "<that-path>"`.
+
+If you call the wrapper from a different checkout (e.g. the main repo while the worktree has the running app), AppleScript resolves the path you gave it — the **main checkout's bundle** — and LaunchServices launches a *second* instance of the app from that path. Two Moolahs end up running with the same CloudKit container, which is the recipe for a corrupted profile. The wrapper's path is the only signal AppleScript looks at; it does not notice that a worktree binary is already up.
+
+Always invoke the wrapper as `cd <worktree> && moolah-tell …` (or, if you can't `cd` in your harness, see the absolute-path fallback below). Do not call it via a relative `.worktrees/<branch>/.claude/skills/automate-app/scripts/moolah-tell` path from a sibling checkout — the wrapper's location does not change which app is targeted; only your CWD does.
+
 ### Why the wrapper
 
 Do **not** use raw `osascript -e 'tell application "Moolah" to …'` for Moolah automation. `osascript` resolves "Moolah" through LaunchServices, which picks `/Applications/Moolah.app` (the installed release build) over the worktree's debug build. Your automation will silently read from and write to the wrong app.
@@ -25,19 +33,33 @@ Use the wrapper bundled with this skill instead:
 
 - `.claude/skills/automate-app/scripts/moolah-tell` — AppleScript runner; auto-wraps the body in `tell application "<worktree-abs-path>" … end tell`.
 
-It resolves the bundle via `git rev-parse --show-toplevel` + `/.build/Build/Products/Debug/Moolah.app`, and fails fast with `error: Moolah.app not built at <path>; run 'just run-mac' in this worktree first` if the build is missing. The wrapper never builds on your behalf — run `just run-mac` yourself first.
+It resolves the bundle via `git rev-parse --show-toplevel` + `/.build/Build/Products/Debug/Moolah.app`, prints the resolved path on stderr (so you can spot a wrong-CWD mistake immediately), and fails fast with `error: Moolah.app not built at <path>; run 'just run-mac' in this worktree first` if the build is missing. The wrapper never builds on your behalf — run `just run-mac` yourself first.
 
-Examples below use the short name `moolah-tell` for readability. When copy-pasting, prefix it with the full relative path from the worktree root:
+Examples below use the short name `moolah-tell` for readability. When copy-pasting, prefix it with the full relative path from inside the worktree:
 
 ```bash
+cd /path/to/<worktree>
 .claude/skills/automate-app/scripts/moolah-tell 'get name of every profile'
 ```
 
 Or add the scripts dir to `$PATH` for the session:
 
 ```bash
+cd /path/to/<worktree>
 export PATH="$PWD/.claude/skills/automate-app/scripts:$PATH"
+moolah-tell 'get name of every profile'
 ```
+
+#### Absolute-path fallback (no `cd` available)
+
+If your environment cannot `cd` into the worktree (some agent harnesses), bypass the wrapper and write the bundle path explicitly:
+
+```bash
+APP="/abs/path/to/<worktree>/.build/Build/Products/Debug/Moolah.app"
+osascript -e "tell application \"$APP\" to navigate to profile \"Test\""
+```
+
+This is the same shape the wrapper produces — just sidestepping its CWD-based resolution.
 
 ## AppleScript Reference
 

--- a/.claude/skills/automate-app/scripts/moolah-tell
+++ b/.claude/skills/automate-app/scripts/moolah-tell
@@ -2,6 +2,13 @@
 # Run AppleScript against the Moolah app built in the current worktree.
 # Auto-wraps the body in `tell application "<abs-path>" ... end tell` so the
 # command targets the worktree's debug build, not /Applications/Moolah.app.
+#
+# CWD matters: the bundle path is derived from `git rev-parse --show-toplevel`
+# of the SHELL'S working directory. Calling this wrapper from a sibling
+# checkout (e.g. `cd main && .worktrees/foo/.../moolah-tell …`) targets the
+# CWD's checkout, NOT the script's. Symptom: a SECOND Moolah launches from
+# the wrong path while the worktree's app keeps running, and both fight
+# over the same CloudKit container. Always `cd` into the worktree first.
 set -euo pipefail
 
 root=$(git rev-parse --show-toplevel 2>/dev/null) || {
@@ -13,6 +20,43 @@ app="$root/.build/Build/Products/Debug/Moolah.app"
 if [ ! -d "$app" ]; then
     echo "error: Moolah.app not built at $app" >&2
     echo "       run 'just run-mac' in this worktree first" >&2
+    exit 1
+fi
+
+# Echo the resolved bundle so a wrong-CWD invocation is visible at the
+# call site instead of being discovered later via duplicate-instance
+# corruption. Goes to stderr so it doesn't pollute AppleScript stdout.
+echo "moolah-tell → $app" >&2
+
+# Refuse to launch a duplicate: if some other Moolah.app is already
+# running from a different path, telling our path would spawn a second
+# instance against the same CloudKit container. Better to fail loudly
+# than to corrupt profile data. (We allow our own bundle being already
+# up — that's the normal case.) `pgrep` reports each process's launch
+# command, which is often a relative path (e.g. `just run-mac` runs
+# from the worktree CWD so `ps` shows `.build/...`); we resolve each
+# PID's text-segment path via `lsof -d txt` to get an absolute bundle
+# location for comparison.
+target_exec="$app/Contents/MacOS/Moolah"
+foreign=()
+for pid in $(pgrep -f "Moolah.app/Contents/MacOS/Moolah" 2>/dev/null || true); do
+    pid_path=$(
+        lsof -p "$pid" -d txt -Fn 2>/dev/null \
+        | sed -n 's|^n||p' \
+        | grep -E "Moolah\.app/Contents/MacOS/Moolah$" \
+        | head -1
+    )
+    if [ -n "$pid_path" ] && [ "$pid_path" != "$target_exec" ]; then
+        foreign+=("[pid $pid] $pid_path")
+    fi
+done
+if [ "${#foreign[@]}" -gt 0 ]; then
+    echo "error: a different Moolah is already running:" >&2
+    printf '       %s\n' "${foreign[@]}" >&2
+    echo "       targeting $target_exec would launch a second instance" >&2
+    echo "       and both apps would share the CloudKit container." >&2
+    echo "       Quit the foreign instance, or 'cd' into its worktree" >&2
+    echo "       and re-run moolah-tell from there." >&2
     exit 1
 fi
 

--- a/Features/Transactions/TransactionStore.swift
+++ b/Features/Transactions/TransactionStore.swift
@@ -255,6 +255,15 @@ final class TransactionStore {
     let myGeneration = loadGeneration
     isLoading = true
     logger.debug("Loading transactions page \(self.currentPage)...")
+    // Cancellation can early-return below; without `defer` the live load
+    // would leak `isLoading = true`, making `isLoaded(for: filter)` true
+    // and the next `.task` mount skip its own load. Sibling of #412. The
+    // generation guard avoids stomping on a newer load that owns the flag.
+    defer {
+      if myGeneration == loadGeneration {
+        isLoading = false
+      }
+    }
 
     do {
       let page = try await repository.fetch(
@@ -291,12 +300,6 @@ final class TransactionStore {
       guard myGeneration == loadGeneration else { return }
       logger.error("Failed to load transactions: \(error.localizedDescription)")
       self.error = error
-    }
-
-    // Only clear isLoading for the live load; the newer load owns the flag
-    // otherwise and will clear it when it finishes.
-    if myGeneration == loadGeneration {
-      isLoading = false
     }
   }
 

--- a/Features/Transactions/Views/TransactionListView+List.swift
+++ b/Features/Transactions/Views/TransactionListView+List.swift
@@ -3,10 +3,28 @@
 import SwiftUI
 
 extension TransactionListView {
+  /// Stable structural-branch guard: pins `transactionsList` to a fixed
+  /// view-tree position so the asynchronous resolution of `positionsInput`
+  /// can't flip the layout mid-load and cancel the initial transactions
+  /// fetch. Same root cause as #412.
+  var shouldShowPositionsSplit: Bool {
+    guard !positions.isEmpty else { return false }
+    let nonZeroInstruments = Set(
+      positions.lazy.filter { $0.quantity != 0 }.map(\.instrument)
+    )
+    return nonZeroInstruments != [positionsHostCurrency]
+  }
+
   @ViewBuilder var listView: some View {
-    if let positionsInput, !positionsInput.shouldHide {
+    if shouldShowPositionsSplit {
       PositionsTransactionsSplit(defaultTab: .transactions) {
-        PositionsView(input: positionsInput, range: $positionsRange)
+        if let positionsInput {
+          PositionsView(input: positionsInput, range: $positionsRange)
+        } else {
+          ProgressView()
+            .frame(maxWidth: .infinity)
+            .padding()
+        }
       } transactions: {
         transactionsList
       }

--- a/MoolahTests/Features/TransactionStoreLoadRaceTests.swift
+++ b/MoolahTests/Features/TransactionStoreLoadRaceTests.swift
@@ -132,4 +132,69 @@ struct TransactionStoreLoadRaceTests {
     #expect(store.error != nil)
     #expect(!store.isLoaded(for: filter))
   }
+
+  /// A `load(filter:)` cancelled mid-fetch must not leave the store reporting
+  /// itself as loading or as loaded for that filter. Otherwise the new
+  /// `.task` mount that triggered the cancellation (e.g. from a structural
+  /// branch flip when an asynchronously-resolved positions panel appears
+  /// alongside the transactions list) sees `isLoaded(for: filter) == true`
+  /// and short-circuits its own load — leaving the user staring at an empty
+  /// transaction list. Sibling of #412.
+  @Test
+  func cancelledLoadAllowsRetryOnRemount() async throws {
+    let repo = FirstFetchGatedTransactionRepository()
+    let store = TransactionStore(
+      repository: repo,
+      conversionService: FixedConversionService(),
+      targetInstrument: .defaultTestInstrument
+    )
+    let filter = TransactionFilter(accountId: accountId)
+
+    let task = Task { @MainActor in
+      await store.load(filter: filter)
+    }
+    await repo.waitUntilFetchStarted()
+    task.cancel()
+    await repo.releaseFetch()
+    await task.value
+
+    #expect(!store.isLoading)
+    #expect(!store.isLoaded(for: filter))
+  }
+}
+
+/// Minimal `TransactionRepository` that suspends inside `fetch` until the
+/// test releases it, giving the test a deterministic window in which to
+/// cancel the surrounding `Task`. Distinct from
+/// `CancellablePagingTransactionRepository`, which gates the *second* page
+/// for pagination tests; this one gates the *first* fetch so we can model
+/// an initial-load cancellation.
+actor FirstFetchGatedTransactionRepository: TransactionRepository {
+  private let fetchStarted = AsyncGate()
+  private let fetchRelease = AsyncGate()
+
+  func waitUntilFetchStarted() async {
+    await fetchStarted.wait()
+  }
+
+  func releaseFetch() async {
+    await fetchRelease.open()
+  }
+
+  func fetch(filter: TransactionFilter, page: Int, pageSize: Int) async throws -> TransactionPage {
+    await fetchStarted.open()
+    await fetchRelease.wait()
+    return TransactionPage(
+      transactions: [],
+      targetInstrument: .defaultTestInstrument,
+      priorBalance: nil,
+      totalCount: nil
+    )
+  }
+
+  func fetchAll(filter: TransactionFilter) async throws -> [Transaction] { [] }
+  func create(_ transaction: Transaction) async throws -> Transaction { transaction }
+  func update(_ transaction: Transaction) async throws -> Transaction { transaction }
+  func delete(id: UUID) async throws {}
+  func fetchPayeeSuggestions(prefix: String) async throws -> [String] { [] }
 }


### PR DESCRIPTION
## Summary

Same root cause as #412 (transactions don't load on first open of an investment account, closed Apr 24), but surfacing again in the regular `TransactionListView` path. Reproduces on a bank account whose positions span multiple instruments — e.g. CommBank with AUD + BHP.AX. Open the account from Analysis (or app launch) and the transactions list stays empty; the workaround is to bounce through other accounts until the timing happens to favour the load completing before the structural flip.

The `listView` body branched on `positionsInput`, which is set asynchronously by `.task(id: positions)`. While that task valuated the positions, the initial `.task(id: baseFilter)` had already started `transactionStore.load(filter: …)` — but only briefly: the moment `positionsInput` resolved, the if/else branch flipped, SwiftUI tore down the top-level `transactionsList` and re-mounted it inside `PositionsTransactionsSplit`, cancelling the load mid-fetch. `fetchPage` returned early via `guard !Task.isCancelled` without resetting `isLoading`, so the new `.task(id: baseFilter)` on the re-mounted list saw `isLoaded(for: filter) == true` (currentFilter still matched, isLoading still true) and short-circuited. No data ever loaded.

Two complementary fixes:

- **Stabilise the structural branch.** `listView` now branches on a synchronous `shouldShowPositionsSplit` derived from the `positions` parameter, mirroring the #412 fix in `InvestmentAccountView`. `transactionsList` mounts at a fixed view-tree position regardless of when `positionsInput` resolves; the PositionsView pane shows a `ProgressView` until the async input arrives.
- **Defence-in-depth at the store.** `fetchPage` now `defer`s the `isLoading = false` reset (with the existing generation guard) so a future cancellation race can't leak a stuck loading flag.

Plus a skill hardening (separate commit, same flow): I hit a related foot-gun while verifying — calling `moolah-tell` from main's CWD while the worktree's app was running launched a SECOND Moolah from main's bundle path against the shared CloudKit container. The wrapper now echoes the resolved bundle path on stderr and refuses (via `lsof -d txt`-resolved bundle paths) when a foreign Moolah is already running, and SKILL.md grew an explicit "CWD must be inside the worktree" section plus an absolute-path `osascript` fallback.

## Test plan

- [x] New `cancelledLoadAllowsRetryOnRemount` test plus a `FirstFetchGatedTransactionRepository` actor — verified test fails without the `defer` (asserts `!isLoading` and `!isLoaded(for: filter)`, both flagged) and passes with it.
- [x] Full `MoolahTests_macOS` suite passes.
- [x] Targeted `MoolahTests_iOS` (`TransactionStoreLoadRaceTests` + `TransactionStoreCRUDTests`) passes.
- [x] `just format-check` clean.
- [x] Manual repro on Large Test Profile → Analysis → CommBank - Edited (multi-instrument): transactions load on first navigation. Logs show one `Loading transactions page 0` → `Loaded 50 transactions` cycle with no stuck/skipped second load.
- [x] Manual moolah-tell wrapper test: from worktree CWD it succeeds; from main's CWD with the worktree's app running it refuses with a clear error and exits 1 instead of launching a duplicate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)