### PR TITLE
chore(skill): moolah-tell --app flag instead of osascript fallback

### DIFF
--- a/.claude/skills/automate-app/SKILL.md
+++ b/.claude/skills/automate-app/SKILL.md
@@ -17,49 +17,52 @@ Drive the running Moolah macOS app via AppleScript (`osascript`). Data operation
 
 The app must be built and running in **this worktree**. Use `just run-mac` to build and launch, or `just run-mac-with-logs` to also capture logs.
 
-### CRITICAL: Run the wrapper from inside the worktree
-
-**Your shell's current working directory must be inside the worktree before invoking `moolah-tell`.** The wrapper picks the target Moolah.app via `git rev-parse --show-toplevel` of CWD, then `tell application "<that-path>"`.
-
-If you call the wrapper from a different checkout (e.g. the main repo while the worktree has the running app), AppleScript resolves the path you gave it — the **main checkout's bundle** — and LaunchServices launches a *second* instance of the app from that path. Two Moolahs end up running with the same CloudKit container, which is the recipe for a corrupted profile. The wrapper's path is the only signal AppleScript looks at; it does not notice that a worktree binary is already up.
-
-Always invoke the wrapper as `cd <worktree> && moolah-tell …` (or, if you can't `cd` in your harness, see the absolute-path fallback below). Do not call it via a relative `.worktrees/<branch>/.claude/skills/automate-app/scripts/moolah-tell` path from a sibling checkout — the wrapper's location does not change which app is targeted; only your CWD does.
-
 ### Why the wrapper
 
 Do **not** use raw `osascript -e 'tell application "Moolah" to …'` for Moolah automation. `osascript` resolves "Moolah" through LaunchServices, which picks `/Applications/Moolah.app` (the installed release build) over the worktree's debug build. Your automation will silently read from and write to the wrong app.
 
-Use the wrapper bundled with this skill instead:
+**All automation goes through the wrapper.** It accepts a body and (optionally) an `--app` path; in return you get the right bundle targeted, a stderr line showing the resolved path, and a duplicate-instance check that refuses to start a second Moolah against the same CloudKit container.
 
-- `.claude/skills/automate-app/scripts/moolah-tell` — AppleScript runner; auto-wraps the body in `tell application "<worktree-abs-path>" … end tell`.
+- `.claude/skills/automate-app/scripts/moolah-tell` — AppleScript runner; auto-wraps the body in `tell application "<abs-path>" … end tell`.
 
-It resolves the bundle via `git rev-parse --show-toplevel` + `/.build/Build/Products/Debug/Moolah.app`, prints the resolved path on stderr (so you can spot a wrong-CWD mistake immediately), and fails fast with `error: Moolah.app not built at <path>; run 'just run-mac' in this worktree first` if the build is missing. The wrapper never builds on your behalf — run `just run-mac` yourself first.
+#### Picking the bundle
 
-Examples below use the short name `moolah-tell` for readability. When copy-pasting, prefix it with the full relative path from inside the worktree:
+The wrapper resolves the target Moolah.app two ways. Pick whichever fits your environment:
 
-```bash
-cd /path/to/<worktree>
-.claude/skills/automate-app/scripts/moolah-tell 'get name of every profile'
-```
+1. **CWD-resolved (default).** With no `--app` flag, the wrapper takes `git rev-parse --show-toplevel` of CWD and appends `.build/Build/Products/Debug/Moolah.app`. Use this when your shell's working directory is already inside the worktree — typical interactive use.
 
-Or add the scripts dir to `$PATH` for the session:
+   ```bash
+   cd /path/to/<worktree>
+   .claude/skills/automate-app/scripts/moolah-tell 'get name of every profile'
+   ```
+
+2. **Explicit path (`--app`).** Pass the absolute bundle path as the first argument when you can't `cd` (some agent harnesses) or when you want to target a bundle that isn't in the current worktree's `.build/`. The path is used verbatim — no git lookup, no CWD dependency.
+
+   ```bash
+   .claude/skills/automate-app/scripts/moolah-tell \
+     --app /abs/path/to/<worktree>/.build/Build/Products/Debug/Moolah.app \
+     'get name of every profile'
+   ```
+
+Either way, the wrapper:
+
+- prints `moolah-tell → <resolved-app>` on stderr so a wrong path is visible at the call site;
+- fails fast with `error: Moolah.app not found at <path>` if the bundle is missing (and, in CWD-resolved mode, suggests `just run-mac`);
+- refuses to launch when a different Moolah is already running, with the conflicting bundle path printed.
+
+The wrapper never builds on your behalf — run `just run-mac` yourself first.
+
+#### CWD pitfall (no `--app`)
+
+Without `--app`, the bundle is derived from CWD. Calling the wrapper from a sibling checkout (e.g. `cd main && .worktrees/foo/.../moolah-tell …`) targets the **CWD's checkout, not the script's**. AppleScript resolves the path it's given; LaunchServices then launches a *second* instance from that path while the worktree's app is already up. Two Moolahs sharing the same CloudKit container is a recipe for a corrupted profile. The duplicate-instance check now catches this and refuses, but the cleaner answer is to either `cd` first or pass `--app` with the absolute bundle path.
+
+Add the scripts dir to `$PATH` for the session if you'll call the wrapper repeatedly:
 
 ```bash
 cd /path/to/<worktree>
 export PATH="$PWD/.claude/skills/automate-app/scripts:$PATH"
 moolah-tell 'get name of every profile'
 ```
-
-#### Absolute-path fallback (no `cd` available)
-
-If your environment cannot `cd` into the worktree (some agent harnesses), bypass the wrapper and write the bundle path explicitly:
-
-```bash
-APP="/abs/path/to/<worktree>/.build/Build/Products/Debug/Moolah.app"
-osascript -e "tell application \"$APP\" to navigate to profile \"Test\""
-```
-
-This is the same shape the wrapper produces — just sidestepping its CWD-based resolution.
 
 ## AppleScript Reference
 

--- a/.claude/skills/automate-app/scripts/moolah-tell
+++ b/.claude/skills/automate-app/scripts/moolah-tell
@@ -1,25 +1,53 @@
 #!/usr/bin/env bash
-# Run AppleScript against the Moolah app built in the current worktree.
-# Auto-wraps the body in `tell application "<abs-path>" ... end tell` so the
-# command targets the worktree's debug build, not /Applications/Moolah.app.
+# Run AppleScript against a specific Moolah.app bundle. The wrapper picks
+# the bundle from `--app <path>` if given, otherwise from
+# `git rev-parse --show-toplevel` of CWD + `.build/Build/Products/Debug`.
+# Either way it then auto-wraps the body in `tell application "<abs-path>"
+# ... end tell` so AppleScript targets that exact bundle, never
+# `/Applications/Moolah.app` via LaunchServices name resolution.
 #
-# CWD matters: the bundle path is derived from `git rev-parse --show-toplevel`
-# of the SHELL'S working directory. Calling this wrapper from a sibling
-# checkout (e.g. `cd main && .worktrees/foo/.../moolah-tell …`) targets the
-# CWD's checkout, NOT the script's. Symptom: a SECOND Moolah launches from
-# the wrong path while the worktree's app keeps running, and both fight
-# over the same CloudKit container. Always `cd` into the worktree first.
+# Usage:
+#   moolah-tell 'get name of every profile'             # CWD-resolved
+#   moolah-tell --app /abs/path/Moolah.app 'body'       # explicit bundle
+#   moolah-tell - <<<'body'                             # body on stdin
+#   moolah-tell --app /abs/path/Moolah.app -            # both
+#
+# CWD matters when --app is omitted: the bundle path is derived from
+# `git rev-parse --show-toplevel` of the SHELL'S working directory.
+# Calling this wrapper from a sibling checkout (e.g.
+# `cd main && .worktrees/foo/.../moolah-tell …`) targets the CWD's
+# checkout, NOT the script's. Symptom: a SECOND Moolah launches from
+# the wrong path while the worktree's app keeps running, and both
+# fight over the same CloudKit container. Either `cd` into the
+# worktree first, or pass `--app` with the absolute bundle path.
 set -euo pipefail
 
-root=$(git rev-parse --show-toplevel 2>/dev/null) || {
-    echo "error: moolah-tell must be run from inside a Moolah worktree" >&2
-    exit 1
-}
-app="$root/.build/Build/Products/Debug/Moolah.app"
+app=""
+app_explicit=0
+if [ "${1:-}" = "--app" ]; then
+    if [ "$#" -lt 2 ]; then
+        echo "error: --app requires a path argument" >&2
+        exit 1
+    fi
+    app="$2"
+    app_explicit=1
+    shift 2
+fi
+
+if [ -z "$app" ]; then
+    root=$(git rev-parse --show-toplevel 2>/dev/null) || {
+        echo "error: moolah-tell must be run from inside a Moolah worktree" >&2
+        echo "       (or pass --app /path/to/Moolah.app for an explicit bundle)" >&2
+        exit 1
+    }
+    app="$root/.build/Build/Products/Debug/Moolah.app"
+fi
 
 if [ ! -d "$app" ]; then
-    echo "error: Moolah.app not built at $app" >&2
-    echo "       run 'just run-mac' in this worktree first" >&2
+    echo "error: Moolah.app not found at $app" >&2
+    if [ "$app_explicit" -eq 0 ]; then
+        echo "       run 'just run-mac' in this worktree first" >&2
+    fi
     exit 1
 fi
 
@@ -55,12 +83,12 @@ if [ "${#foreign[@]}" -gt 0 ]; then
     printf '       %s\n' "${foreign[@]}" >&2
     echo "       targeting $target_exec would launch a second instance" >&2
     echo "       and both apps would share the CloudKit container." >&2
-    echo "       Quit the foreign instance, or 'cd' into its worktree" >&2
-    echo "       and re-run moolah-tell from there." >&2
+    echo "       Quit the foreign instance, 'cd' into its worktree, or" >&2
+    echo "       pass --app pointing at the running bundle." >&2
     exit 1
 fi
 
-# No args or `-` means read the AppleScript body from stdin.
+# No args (after any --app) or `-` means read the AppleScript body from stdin.
 if [ "$#" -eq 0 ] || [ "$1" = "-" ]; then
     body=$(cat)
 else


### PR DESCRIPTION
## Summary

Follow-up to #487. Replace the "drop down to raw `osascript -e \"tell application …\"`" fallback in SKILL.md with a first-class `--app <path>` option on the wrapper, so every Moolah automation call goes through `moolah-tell` and benefits from the bundle-path echo, missing-build error, and duplicate-instance refusal.

```bash
moolah-tell --app /abs/path/to/Moolah.app 'get name of every profile'
```

The flag is parsed before the body, sets the bundle path verbatim (no git lookup, no CWD dependency), and then runs the same checks the CWD-resolved path already runs. Existing call sites (no flag) are unchanged.

SKILL.md restructured around "pick the bundle two ways" as the primary contract — CWD-resolved or `--app` — and folds the old "CRITICAL: run from inside the worktree" warning into a "CWD pitfall (no `--app`)" note since the duplicate-instance check now catches the trap regardless of how the bundle was picked. Removes the raw-osascript fallback section entirely.

## Test plan

- [x] `moolah-tell --app <running-bundle>` from a sibling CWD: succeeds, returns AppleScript result.
- [x] `moolah-tell --app /Applications/Moolah.app` while a different Moolah is running: refuses with the conflicting bundle path printed; exit 1.
- [x] CWD-resolved from a sibling checkout (no `--app`): still refuses (existing behaviour from #487).
- [x] `moolah-tell --app` with no path argument: clear `error: --app requires a path argument`; exit 1.
- [x] `bash -n` syntax check passes; script exec bit preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)