### PR TITLE
fix(cloudkit): unconditional Dev dryrun before promoting schema to Prod

### DIFF
--- a/justfile
+++ b/justfile
@@ -235,9 +235,11 @@ dryrun-promote-schema:
 verify-prod-matches-baseline:
     bash scripts/verify-prod-matches-baseline.sh
 
-# Release-tag CI: imports CloudKit/schema.ckdb to Production with --validate,
-# refreshes CloudKit/schema-prod-baseline.ckdb from live Production, and
-# opens a follow-up PR with the new baseline. Run via the testflight workflow.
+# Release-tag CI: validates CloudKit/schema.ckdb against Development as a
+# sanity check, imports it to Production, refreshes
+# CloudKit/schema-prod-baseline.ckdb from live Production, and opens a
+# follow-up PR with the new baseline. See the script header for why
+# Apple's API requires the validate-against-Dev / import-to-Prod split.
 # Production schema changes are one-way — to run locally, re-run with
 # CKTOOL_PROMOTE_FORCE=1.
 promote-schema:

--- a/scripts/promote-schema.sh
+++ b/scripts/promote-schema.sh
@@ -1,8 +1,29 @@
 #!/usr/bin/env bash
 #
-# Release-tag CI: imports CloudKit/schema.ckdb to Production with --validate,
-# exports the resulting Production schema into the baseline file, and opens
-# a follow-up PR that commits the refreshed baseline.
+# Release-tag CI: validates CloudKit/schema.ckdb against Development, then
+# imports it to Production. Exports the resulting Production schema into
+# the baseline file and opens a follow-up PR that commits the refreshed
+# baseline.
+#
+# Apple's cktool `--validate` flag is dry-run-only; the API rejects it
+# against the `production` environment ("BadRequestException: endpoint
+# not applicable in the environment 'production'"). So we --validate
+# against Development as a sanity check on the schema file's internal
+# validity, then do the real import against Production.
+#
+# We deliberately do NOT reset Dev to Production state first. Dev is
+# sandboxed: whatever state it's in doesn't affect Production's import.
+# Production safety comes from two additivity invariants that hold
+# before this script runs:
+#   - `just check-schema-additive` (per-PR) — proposed schema is
+#     additive over the committed baseline file.
+#   - `just verify-prod-matches-baseline` (release-time, runs
+#     immediately before this script) — live Production matches the
+#     committed baseline.
+# Together: live Production ≤ proposed schema, so the Prod import is
+# mathematically safe regardless of Dev's state. The Dev validate is a
+# best-effort sanity check that catches malformed schema files cheaply
+# before we touch Prod.
 set -euo pipefail
 HERE="$(cd "$(dirname "$0")" && pwd)"
 # shellcheck source=scripts/cloudkit-config.sh
@@ -15,9 +36,21 @@ cloudkit_require_env
 
 baseline="CloudKit/schema-prod-baseline.ckdb"
 
+# Step 1: dry-run validation against Development (sanity check only).
+# We don't reset Dev first — its state is uncontrolled and irrelevant to
+# Prod's import. This catches malformed schema files cheaply; the real
+# safety net for Prod is the additivity invariants documented above.
+echo "Step 1/2: validating $CLOUDKIT_SCHEMA_FILE against Development."
+cloudkit_cktool import-schema \
+    --environment development \
+    --validate \
+    --file "$CLOUDKIT_SCHEMA_FILE"
+echo "Dev-side validation passed."
+
+# Step 2: actually import to Production.
+echo "Step 2/2: importing $CLOUDKIT_SCHEMA_FILE to Production."
 cloudkit_cktool import-schema \
     --environment production \
-    --validate \
     --file "$CLOUDKIT_SCHEMA_FILE"
 echo "Promoted $CLOUDKIT_SCHEMA_FILE to CloudKit Production."
 


### PR DESCRIPTION
## Summary

The release-tag schema promote step has been silently broken: Apple's API rejects `cktool import-schema --validate --environment production` with `BadRequestException: endpoint not applicable in the environment 'production'`. `--validate` is dry-run-only and isn't supported on production containers.

Surfaced today trying to cut a verification testflight build ([run 24954831139](https://github.com/ajsutton/moolah-native/actions/runs/24954831139)) — this step has likely never actually worked against real Prod.

## Fix

Split the single broken call into two:

1. `cktool import-schema --validate --environment development` — dry-run sanity check on the schema file's internal validity.
2. `cktool import-schema --environment production` — the real import.

## Production safety is unchanged

It already comes from two additivity invariants that hold before this script runs:
- `just check-schema-additive` (per-PR, text-only) — proposed schema is additive over the committed baseline.
- `just verify-prod-matches-baseline` (release-time, runs immediately before this script) — live Production matches the committed baseline.

Together: live Production ≤ proposed schema, so the Prod import is mathematically safe regardless of Dev's state.

## Why we don't reset Dev

We deliberately do NOT reset Dev to Production state before the validate. Dev is sandboxed and its state is irrelevant to Prod's import — resetting it adds a destructive side effect for no real safety gain. The standalone `scripts/dryrun-promote-schema.sh` is still available for local pre-flight checks during schema development (it does reset Dev, on demand).

## Test plan

- [ ] Re-run `testflight.yml` manually post-merge (using `workflow_dispatch`) to confirm the schema promote step actually completes — it never has before, that's the bug this fixes.
- [ ] Verify the resulting `schema-prod-baseline.ckdb` refresh PR opens automatically (existing behaviour, downstream of the import).

## Related

Blocks #490 (release-process implementation) — that PR was queued earlier and pulled out when this surfaced. After this lands and `testflight.yml` is verified clean, #490 gets rebased and re-queued.