### PR TITLE
build: bump marketing version to 1.1.0

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -28,7 +28,7 @@ settings:
     CLOUDKIT_CONTAINER_ID: iCloud.rocks.moolah.app.v2
 
     # ---- Versioning ----
-    MARKETING_VERSION: "1.0.0"
+    MARKETING_VERSION: "1.1.0"
     CURRENT_PROJECT_VERSION: "1"
 
     # ---- Signing (env-driven) ----


### PR DESCRIPTION
Pre-RC bump for the v1.1.0 release line. Previous final tag was v1.0.1; `release-next-version` sets `confirm_marketing=true` on the current state because `MARKETING_VERSION` (1.0.0) is behind. Bump aligns with the design's default-minor-bump policy.

Once this lands, `just release-next-version rc` will return `v1.1.0-rc.1` and the RC cut can proceed.