### PR TITLE
fix(cloudkit): drop --environment from cktool reset-schema calls

### DIFF
--- a/scripts/dryrun-promote-schema.sh
+++ b/scripts/dryrun-promote-schema.sh
@@ -29,7 +29,7 @@ EOF
     exit 1
 fi
 
-cloudkit_cktool reset-schema --environment development
+cloudkit_cktool reset-schema
 cloudkit_cktool import-schema \
     --environment development \
     --validate \

--- a/scripts/import-schema-to-dev.sh
+++ b/scripts/import-schema-to-dev.sh
@@ -24,7 +24,10 @@ cloudkit_require_env
     || cloudkit_fail "$CLOUDKIT_SCHEMA_FILE is missing."
 
 echo "Resetting Development schema to match Production…"
-cloudkit_cktool reset-schema --environment development
+# cktool reset-schema only operates on the development environment by
+# definition (per `cktool reset-schema --help`); passing --environment is
+# rejected as an unknown option.
+cloudkit_cktool reset-schema
 
 echo "Validating $CLOUDKIT_SCHEMA_FILE against Development (dry-run)…"
 cloudkit_cktool import-schema \


### PR DESCRIPTION
Surfaced when v1.1.0-rc.2 fired release-rc.yml — `scripts/import-schema-to-dev.sh` hit:

```
Error: Unknown option '--environment'
Usage: cktool reset-schema [--token <token>] --team-id <team-id> --container-id <container-id>
```

cktool 1.0.23001's `reset-schema` subcommand only operates on the development environment by definition (per its own `--help`). Passing `--environment` is rejected.

Per the "fix all instances" rule, I grepped: `scripts/dryrun-promote-schema.sh` has the same bug (untriggered in CI; fails on local dryrun). Both fixed in one pass.

Behaviour is unchanged — `reset-schema` only ever resets dev. Only the redundant flag is dropped. Added a comment in `import-schema-to-dev.sh` noting the constraint so the next reader doesn't re-add the flag.

## Test plan

- [x] shellcheck clean.
- [ ] After merge: cut v1.1.0-rc.3 — preflight should fail-and-stage Dev (this time without erroring), then pause on `await-prod-deploy` for manual approval.