### PR TITLE
fix(release): semantic schema equality check, not byte-equal

### DIFF
--- a/scripts/verify-prod-deployed.sh
+++ b/scripts/verify-prod-deployed.sh
@@ -10,8 +10,15 @@
 # after a developer clicks Deploy in the Console, this script confirms the
 # bytes landed.
 #
-# Exits 0 if Production matches schema.ckdb; non-zero with a descriptive
-# message and the diff if it doesn't.
+# Comparison is *semantic*, not byte-equal: cktool's `export-schema` returns
+# record types in chronological-creation order and uses different
+# column-alignment whitespace than human-edited `.ckdb` files. We delegate
+# to `tools/CKDBSchemaGen check-equal`, which parses both files and compares
+# their parsed AST (record types, fields, types, indexes, deprecation flags)
+# regardless of source-file order or whitespace.
+#
+# Exits 0 if Production is semantically equal to schema.ckdb; non-zero with
+# a descriptive list of differences (printed by the Swift tool) if not.
 set -euo pipefail
 HERE="$(cd "$(dirname "$0")" && pwd)"
 # shellcheck source=scripts/cloudkit-config.sh
@@ -29,12 +36,16 @@ cloudkit_cktool export-schema \
     --environment production \
     --output-file "$live" >/dev/null
 
-if cmp -s "$live" "$CLOUDKIT_SCHEMA_FILE"; then
+if swift run --quiet --package-path tools/CKDBSchemaGen ckdb-schema-gen check-equal \
+    --a "$live" \
+    --b "$CLOUDKIT_SCHEMA_FILE" >&2
+then
     echo "✓ live Production schema matches $CLOUDKIT_SCHEMA_FILE"
     exit 0
 fi
 
 cat >&2 <<EOF
+
 ✗ live Production schema does not match $CLOUDKIT_SCHEMA_FILE.
 
 The proposed schema has not been deployed to Production. Apple's API does
@@ -48,8 +59,5 @@ deploy is the CloudKit Console:
      ran via the release pipeline; if not, run 'just import-schema-to-dev'
      first).
   4. Confirm Deploy.
-
-Diff (live Production vs. proposed schema.ckdb):
 EOF
-diff -u "$live" "$CLOUDKIT_SCHEMA_FILE" >&2 || true
 exit 1

--- a/tools/CKDBSchemaGen/Sources/CKDBSchemaGen/CLI.swift
+++ b/tools/CKDBSchemaGen/Sources/CKDBSchemaGen/CLI.swift
@@ -11,6 +11,8 @@ enum CKDBSchemaGenCLI {
         try runGenerate(args: Array(args.dropFirst()))
       case "check-additive":
         try runCheckAdditive(args: Array(args.dropFirst()))
+      case "check-equal":
+        try runCheckEqual(args: Array(args.dropFirst()))
       default:
         printUsage()
         exit(2)
@@ -94,6 +96,31 @@ enum CKDBSchemaGenCLI {
     exit(1)
   }
 
+  // MARK: - check-equal
+
+  private static func runCheckEqual(args: [String]) throws {
+    let opts = parseOptions(args, allowed: ["--a", "--b"])
+    guard let aPath = opts["--a"], let bPath = opts["--b"] else {
+      fputs(
+        "ckdb-schema-gen check-equal: --a <ckdb> --b <ckdb> required\n", stderr)
+      exit(2)
+    }
+    let aSource = try String(contentsOfFile: aPath, encoding: .utf8)
+    let bSource = try String(contentsOfFile: bPath, encoding: .utf8)
+    let aSchema = try Parser.parse(aSource)
+    let bSchema = try Parser.parse(bSource)
+    let result = Equality.check(aSchema, bSchema, aLabel: aPath, bLabel: bPath)
+    if result.isEqual {
+      print("ckdb-schema-gen: \(aPath) and \(bPath) are semantically equal")
+      return
+    }
+    fputs("ckdb-schema-gen: schemas differ semantically:\n", stderr)
+    for difference in result.differences {
+      fputs("  - \(difference)\n", stderr)
+    }
+    exit(1)
+  }
+
   // MARK: - shared
 
   private static func parseOptions(_ args: [String], allowed: Set<String>) -> [String: String] {
@@ -117,6 +144,7 @@ enum CKDBSchemaGenCLI {
       Usage:
         ckdb-schema-gen generate --input <schema.ckdb> --output <dir>
         ckdb-schema-gen check-additive --proposed <schema.ckdb> --baseline <baseline.ckdb>
+        ckdb-schema-gen check-equal --a <schema.ckdb> --b <schema.ckdb>
       """,
       stderr)
     fputs("\n", stderr)

--- a/tools/CKDBSchemaGen/Sources/CKDBSchemaGen/Equality.swift
+++ b/tools/CKDBSchemaGen/Sources/CKDBSchemaGen/Equality.swift
@@ -1,0 +1,116 @@
+import Foundation
+
+/// Checks whether two `Schema`s are semantically equal: same set of record
+/// types, each with the same fields, types, indexes, and deprecation flags.
+///
+/// Order of record types and order of fields within a record type are
+/// **not** significant — cktool's `export-schema` returns record types in a
+/// stable but non-deterministic order (chronological by creation time, in
+/// practice), and column-alignment whitespace is normalised differently
+/// between human-edited `.ckdb` files and cktool's exported form. Both
+/// sources need to agree semantically; comparing them byte-equal would
+/// reject correct deploys.
+enum Equality {
+
+  struct Result: Equatable {
+    var differences: [String]
+
+    var isEqual: Bool { differences.isEmpty }
+  }
+
+  /// Compare two schemas. Returns differences sorted for stable output —
+  /// missing record types first, then missing fields, then field-level
+  /// differences within each shared record type.
+  static func check(_ a: Schema, _ b: Schema, aLabel: String = "a", bLabel: String = "b") -> Result
+  {
+    var differences: [String] = []
+
+    let aTypes = Dictionary(uniqueKeysWithValues: a.recordTypes.map { ($0.name, $0) })
+    let bTypes = Dictionary(uniqueKeysWithValues: b.recordTypes.map { ($0.name, $0) })
+
+    let onlyInA = Set(aTypes.keys).subtracting(bTypes.keys).sorted()
+    let onlyInB = Set(bTypes.keys).subtracting(aTypes.keys).sorted()
+    for name in onlyInA {
+      differences.append("record type '\(name)' is in \(aLabel) but not in \(bLabel)")
+    }
+    for name in onlyInB {
+      differences.append("record type '\(name)' is in \(bLabel) but not in \(aLabel)")
+    }
+
+    let common = Set(aTypes.keys).intersection(bTypes.keys).sorted()
+    for name in common {
+      // Force-unwrap is safe — name comes from the intersection.
+      let aType = aTypes[name]!
+      let bType = bTypes[name]!
+      differences.append(
+        contentsOf: differencesForRecordType(
+          aType, bType, aLabel: aLabel, bLabel: bLabel))
+    }
+
+    return Result(differences: differences)
+  }
+
+  private static func differencesForRecordType(
+    _ a: RecordType, _ b: RecordType, aLabel: String, bLabel: String
+  ) -> [String] {
+    var differences: [String] = []
+    let typeName = a.name
+
+    if a.isDeprecated != b.isDeprecated {
+      differences.append(
+        "record type '\(typeName)': deprecation differs "
+          + "(\(aLabel)=\(a.isDeprecated), \(bLabel)=\(b.isDeprecated))")
+    }
+
+    let aFields = Dictionary(uniqueKeysWithValues: a.fields.map { ($0.name, $0) })
+    let bFields = Dictionary(uniqueKeysWithValues: b.fields.map { ($0.name, $0) })
+
+    let onlyInA = Set(aFields.keys).subtracting(bFields.keys).sorted()
+    let onlyInB = Set(bFields.keys).subtracting(aFields.keys).sorted()
+    for fieldName in onlyInA {
+      differences.append(
+        "field '\(typeName).\(fieldName)' is in \(aLabel) but not in \(bLabel)")
+    }
+    for fieldName in onlyInB {
+      differences.append(
+        "field '\(typeName).\(fieldName)' is in \(bLabel) but not in \(aLabel)")
+    }
+
+    let commonFields = Set(aFields.keys).intersection(bFields.keys).sorted()
+    for fieldName in commonFields {
+      // Force-unwrap is safe — fieldName comes from the intersection.
+      let aField = aFields[fieldName]!
+      let bField = bFields[fieldName]!
+
+      if aField.type != bField.type {
+        differences.append(
+          "field '\(typeName).\(fieldName)': type differs "
+            + "(\(aLabel)=\(aField.type.rawValue), \(bLabel)=\(bField.type.rawValue))")
+      }
+
+      if aField.indexes != bField.indexes {
+        let aOnly = aField.indexes.subtracting(bField.indexes)
+        let bOnly = bField.indexes.subtracting(aField.indexes)
+        var parts: [String] = []
+        if !aOnly.isEmpty {
+          let names = aOnly.map(\.rawValue).sorted().joined(separator: ",")
+          parts.append("\(aLabel)-only=\(names)")
+        }
+        if !bOnly.isEmpty {
+          let names = bOnly.map(\.rawValue).sorted().joined(separator: ",")
+          parts.append("\(bLabel)-only=\(names)")
+        }
+        differences.append(
+          "field '\(typeName).\(fieldName)': indexes differ (\(parts.joined(separator: "; ")))")
+      }
+
+      if aField.isDeprecated != bField.isDeprecated {
+        differences.append(
+          "field '\(typeName).\(fieldName)': deprecation differs "
+            + "(\(aLabel)=\(aField.isDeprecated), \(bLabel)=\(bField.isDeprecated))")
+      }
+    }
+
+    return differences
+  }
+}

--- a/tools/CKDBSchemaGen/Tests/CKDBSchemaGenTests/EqualityTests.swift
+++ b/tools/CKDBSchemaGen/Tests/CKDBSchemaGenTests/EqualityTests.swift
@@ -1,0 +1,123 @@
+import Testing
+
+@testable import CKDBSchemaGen
+
+@Suite("Equality")
+struct EqualityTests {
+
+  private let baseline = Schema(recordTypes: [
+    RecordType(
+      name: "AccountRecord",
+      fields: [
+        Field(
+          name: "name", type: .string, indexes: [.queryable, .searchable, .sortable],
+          isDeprecated: false),
+        Field(
+          name: "position", type: .int64, indexes: [.queryable, .sortable], isDeprecated: false),
+      ],
+      isDeprecated: false
+    ),
+    RecordType(
+      name: "ProfileRecord",
+      fields: [
+        Field(
+          name: "label", type: .string, indexes: [.queryable, .searchable, .sortable],
+          isDeprecated: false)
+      ],
+      isDeprecated: false
+    ),
+  ])
+
+  @Test("identical schemas are equal")
+  func identicalIsEqual() {
+    let result = Equality.check(baseline, baseline)
+    #expect(result.isEqual)
+    #expect(result.differences.isEmpty)
+  }
+
+  @Test("record-type order does not matter")
+  func recordTypeOrderIndependent() {
+    let reordered = Schema(recordTypes: baseline.recordTypes.reversed())
+    let result = Equality.check(baseline, reordered)
+    #expect(result.isEqual)
+  }
+
+  @Test("field order does not matter")
+  func fieldOrderIndependent() {
+    var swapped = baseline
+    swapped.recordTypes[0].fields.reverse()
+    let result = Equality.check(baseline, swapped)
+    #expect(result.isEqual)
+  }
+
+  @Test("missing record type is reported on the right side")
+  func missingRecordTypeReported() {
+    var trimmed = baseline
+    trimmed.recordTypes.removeLast()  // drop ProfileRecord
+    let result = Equality.check(baseline, trimmed, aLabel: "left", bLabel: "right")
+    #expect(!result.isEqual)
+    #expect(
+      result.differences.contains {
+        $0.contains("ProfileRecord") && $0.contains("left") && $0.contains("right")
+      })
+  }
+
+  @Test("missing field is reported on the right side")
+  func missingFieldReported() {
+    var trimmed = baseline
+    trimmed.recordTypes[0].fields.removeLast()  // drop position from AccountRecord
+    let result = Equality.check(baseline, trimmed, aLabel: "left", bLabel: "right")
+    #expect(!result.isEqual)
+    #expect(
+      result.differences.contains {
+        $0.contains("AccountRecord.position") && $0.contains("left") && $0.contains("right")
+      })
+  }
+
+  @Test("type difference is reported")
+  func typeDifferenceReported() {
+    var changed = baseline
+    changed.recordTypes[0].fields[0].type = .int64  // change AccountRecord.name to INT64
+    let result = Equality.check(baseline, changed)
+    #expect(!result.isEqual)
+    #expect(
+      result.differences.contains {
+        $0.contains("AccountRecord.name") && $0.contains("STRING") && $0.contains("INT64")
+      })
+  }
+
+  @Test("index difference is reported with side-specific detail")
+  func indexDifferenceReported() {
+    var changed = baseline
+    changed.recordTypes[0].fields[0].indexes.remove(.searchable)
+    let result = Equality.check(baseline, changed, aLabel: "left", bLabel: "right")
+    #expect(!result.isEqual)
+    #expect(
+      result.differences.contains {
+        $0.contains("AccountRecord.name") && $0.contains("SEARCHABLE") && $0.contains("left-only")
+      })
+  }
+
+  @Test("deprecation difference on a field is reported")
+  func fieldDeprecationDifferenceReported() {
+    var changed = baseline
+    changed.recordTypes[0].fields[1].isDeprecated = true
+    let result = Equality.check(baseline, changed)
+    #expect(!result.isEqual)
+    #expect(
+      result.differences.contains {
+        $0.contains("AccountRecord.position") && $0.contains("deprecation")
+      })
+  }
+
+  @Test("equality is symmetric")
+  func symmetric() {
+    var changed = baseline
+    changed.recordTypes[0].fields[0].type = .int64
+    let forward = Equality.check(baseline, changed)
+    let reverse = Equality.check(changed, baseline)
+    #expect(!forward.isEqual)
+    #expect(!reverse.isEqual)
+    #expect(forward.differences.count == reverse.differences.count)
+  }
+}


### PR DESCRIPTION
## Summary

`verify-prod-deployed` compared cktool's `export-schema` output to `CloudKit/schema.ckdb` byte-by-byte (`cmp -s`). That fails on format-only differences — cktool exports record types in chronological-creation order, and uses different column-alignment whitespace than the hand-edited file. Same record types, fields, types, and indexes — different bytes.

v1.1.0-rc.3 was rejected at the `await-prod-deploy` re-verify step for exactly this reason after I manually deployed via the Console. ([failed run 24967960353](https://github.com/ajsutton/moolah-native/actions/runs/24967960353))

## Fix

Parse both files and compare their AST. `tools/CKDBSchemaGen` already has the parser used by the additivity checker. Add a `check-equal` subcommand:

- Order-independent on record types and fields.
- Reports a sorted, side-labelled list of differences (missing types, missing fields, type mismatches, index differences, deprecation flag mismatches).
- Symmetric.

`scripts/verify-prod-deployed.sh` now calls `swift run ... check-equal` instead of `cmp -s`. Dropped the now-unused `diff -u` fallback — the Swift tool prints structured differences, which is more useful than a whitespace-noisy text diff.

## Test plan

- [x] 9 new cases in `EqualityTests.swift` (identity, order independence, missing-type/missing-field reporting, type / index / deprecation differences, symmetry).
- [x] All 33 CKDBSchemaGen tests pass.
- [x] `just test-release-scripts` still passes.
- [x] `shellcheck` clean on `verify-prod-deployed.sh`.
- [x] `just format-check` clean.
- [x] `check-equal --a F --b F` returns equal for identical input.
- [ ] After merge: cut v1.1.0-rc.4 and complete the manual-deploy + re-verify cycle end-to-end.

## Related

- Refines #496 + #499 (the release pipeline's schema-deploy gate).
- Surfaced by run [#24967960353](https://github.com/ajsutton/moolah-native/actions/runs/24967960353) (v1.1.0-rc.3).