### PR TITLE
fix(release): use macOS-suffixed env var for Developer ID profile

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -190,7 +190,10 @@ platform :mac do
       is_key_content_base64: true
     )
 
-    profile_name = ENV["sigh_rocks.moolah.app_developer_id_profile-name"]
+    # match exports this with `_macos` infix because we passed `platform: "macos"`.
+    # iOS appstore uses `sigh_<bundle>_appstore_profile-name` (no platform suffix)
+    # because iOS is fastlane's default platform.
+    profile_name = ENV["sigh_rocks.moolah.app_developer_id_macos_profile-name"]
     entitlements_path = File.expand_path("Moolah-mac.entitlements", __dir__)
 
     build_app(


### PR DESCRIPTION
## Summary
- Read `sigh_rocks.moolah.app_developer_id_macos_profile-name` (with `_macos` infix) instead of `..._developer_id_profile-name` (no infix) in the `mac dmg` lane
- `fastlane match` exports the env var with `_macos` infix when `platform: "macos"` is passed; iOS appstore has no infix because iOS is fastlane's default platform
- Surfaced by [release-rc.yml run 24968926210](https://github.com/ajsutton/moolah-native/actions/runs/24968926210) failing with: *"Moolah_macOS" requires a provisioning profile with the iCloud feature*. The empty env var caused `PROVISIONING_PROFILE_SPECIFIER=` to be passed to xcodebuild

## Note
A separate credentials issue (PKCS12 MAC verification failed during keychain import of the Developer ID .p12) was logged earlier in the same job and is being addressed out-of-band by re-running `match import` with the correct `MATCH_PASSWORD`. Both issues need to be resolved before the Mac DMG step can pass.

## Test plan
- [ ] Tag `v1.1.0-rc.5` once both this PR and the .p12 re-import are done; verify the Mac DMG step in the new release run reaches `xcodebuild` with a non-empty `PROVISIONING_PROFILE_SPECIFIER`