### PR TITLE
fix(release): zip .app for notarytool, write API key to .p8 tempfile

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -190,6 +190,19 @@ platform :mac do
       is_key_content_base64: true
     )
 
+    # `app_store_connect_api_key` returns a hash with the raw PEM content in
+    # `:key` (base64-encoded if `is_key_content_base64`), but no `:key_filepath`
+    # when constructed from `key_content`. notarytool needs a .p8 file path,
+    # so persist the decoded PEM to a tempfile.
+    require "tempfile"
+    require "base64"
+    asc_key_pem = api_key[:key]
+    asc_key_pem = Base64.decode64(asc_key_pem) if api_key[:is_key_content_base64]
+    asc_key_p8 = Tempfile.new(["asc_api_key", ".p8"])
+    asc_key_p8.write(asc_key_pem)
+    asc_key_p8.flush
+    asc_key_p8.close
+
     # match exports this with `_macos` infix because we passed `platform: "macos"`.
     # iOS appstore uses `sigh_<bundle>_appstore_profile-name` (no platform suffix)
     # because iOS is fastlane's default platform.
@@ -222,13 +235,20 @@ platform :mac do
     app_path = File.join(build_dir, "Moolah.app")
     UI.user_error!("Moolah.app not found at #{app_path}") unless File.directory?(app_path)
 
-    # Notarise the .app first (faster turnaround than notarising the DMG alone).
-    sh "xcrun notarytool submit '#{app_path}' " \
-       "--key '#{api_key[:key_filepath]}' " \
+    # Notarise the .app first. notarytool requires a .zip/.pkg/.dmg, not a
+    # bare .app bundle, so wrap it with `ditto -c -k --keepParent` (the only
+    # zip format Apple's notarization service accepts for an .app). Stapling
+    # then runs against the original .app on disk, not the zip.
+    app_zip_path = File.join(build_dir, "Moolah.app.zip")
+    sh "rm -f '#{app_zip_path}'"
+    sh "ditto -c -k --keepParent '#{app_path}' '#{app_zip_path}'"
+    sh "xcrun notarytool submit '#{app_zip_path}' " \
+       "--key '#{asc_key_p8.path}' " \
        "--key-id '#{api_key[:key_id]}' " \
        "--issuer '#{api_key[:issuer_id]}' " \
        "--wait"
     sh "xcrun stapler staple '#{app_path}'"
+    sh "rm -f '#{app_zip_path}'"
 
     # Build the DMG with create-dmg (assumed installed via brew on the runner).
     dmg_path = File.join(build_dir, "Moolah-#{version}.dmg")
@@ -242,14 +262,16 @@ platform :mac do
        "--no-internet-enable " \
        "'#{dmg_path}' '#{app_path}'"
 
-    # Sign + notarise + staple the DMG itself.
+    # Sign + notarise + staple the DMG itself. notarytool accepts .dmg directly.
     sh "codesign --sign 'Developer ID Application' --timestamp '#{dmg_path}'"
     sh "xcrun notarytool submit '#{dmg_path}' " \
-       "--key '#{api_key[:key_filepath]}' " \
+       "--key '#{asc_key_p8.path}' " \
        "--key-id '#{api_key[:key_id]}' " \
        "--issuer '#{api_key[:issuer_id]}' " \
        "--wait"
     sh "xcrun stapler staple '#{dmg_path}'"
+
+    asc_key_p8.unlink
 
     UI.success("Notarised DMG ready at #{dmg_path}")
   end


### PR DESCRIPTION
## Summary

Two bugs in the mac dmg lane's notarization path, both surfaced by the [rc.7 release run](https://github.com/ajsutton/moolah-native/actions/runs/24971279144).

1. **notarytool rejected the bare .app bundle:**
   \`\`\`
   Error: Moolah.app must be a zip archive (.zip), flat installer package (.pkg), or UDIF disk image (.dmg)
   \`\`\`
   Wrap with \`ditto -c -k --keepParent\` (Apple's required zip format for notarization), submit the zip, staple the original .app.

2. **\`--key ''\` was empty in the notarytool invocation.** \`app_store_connect_api_key\` returns a hash with the raw PEM content in \`:key\`, but no \`:key_filepath\` when constructed from \`key_content\`. notarytool needs a .p8 file path, so write the decoded PEM to a tempfile and pass that path. Same fix on both notarize calls.

The DMG submit doesn't need zipping — notarytool accepts .dmg directly.

## Test plan
- [ ] Tag v1.1.0-rc.8 once merged; verify the Mac DMG step gets through both notarize submissions and produces an attached, notarised DMG on the GH pre-release