### PR TITLE
build(release): ship Mac as a notarised .zip instead of a .dmg

### DIFF
--- a/.claude/skills/cutting-a-release/SKILL.md
+++ b/.claude/skills/cutting-a-release/SKILL.md
@@ -37,5 +37,5 @@ Point at the relevant heading under "Recovery" in the runbook. Don't invent reco
 
 ## Hand-off
 
-- After an RC: tell the user how to install the TestFlight build and the DMG, and what to look for in smoke-testing.
+- After an RC: tell the user how to install the TestFlight build and the Mac zip (extract, drag `Moolah.app` to `/Applications`), and what to look for in smoke-testing.
 - After a final: tell the user the App Store submission has been made (auto-release after approval) and that the bump PR is in flight; remind them to edit `project.yml` in the PR if they want a non-default bump.

--- a/.github/workflows/release-final.yml
+++ b/.github/workflows/release-final.yml
@@ -95,13 +95,13 @@ jobs:
               version:${{ steps.pair.outputs.marketing_version }} \
               build_number:${{ steps.build.outputs.build_number }}
 
-      - name: Copy DMG from RC release to final release
+      - name: Copy Mac zip from RC release to final release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release download "${{ steps.pair.outputs.rc_tag }}" \
-              -p "*.dmg" -D build
-          gh release upload "$GITHUB_REF_NAME" build/*.dmg --clobber
+              -p "Moolah-*.zip" -D build
+          gh release upload "$GITHUB_REF_NAME" build/Moolah-*.zip --clobber
 
       - name: Open version-bump PR with automerge
         env:

--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -100,7 +100,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install tools
-        run: brew install xcodegen just create-dmg
+        run: brew install xcodegen just
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@e65c17d16e57e481586a6a5a0282698790062f92 # v1.300.0
@@ -149,7 +149,7 @@ jobs:
           echo "$BUILD" > build/build-number.txt
           echo "Build number: $BUILD"
 
-      - name: Build & notarise Mac DMG
+      - name: Build & notarise Mac zip
         env:
           ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
           ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
@@ -159,14 +159,14 @@ jobs:
           MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
           DEVELOPMENT_TEAM: ${{ secrets.DEVELOPMENT_TEAM }}
           CODE_SIGN_STYLE: "Manual"
-        run: bundle exec fastlane mac dmg version:${{ steps.version.outputs.base }}
+        run: bundle exec fastlane mac zip version:${{ steps.version.outputs.base }}
 
-      - name: Attach DMG and build-number to GH pre-release
+      - name: Attach Mac zip and build-number to GH pre-release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release upload "${{ steps.version.outputs.tag }}" \
-              "build/Moolah-${{ steps.version.outputs.base }}.dmg" \
+              "build/Moolah-${{ steps.version.outputs.base }}.zip" \
               build/build-number.txt \
               --clobber
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -177,8 +177,8 @@ platform :mac do
     )
   end
 
-  desc "Build, sign, notarise, and DMG-package the Mac app for direct distribution"
-  lane :dmg do |options|
+  desc "Build, sign, notarise, and zip the Mac app for direct distribution"
+  lane :zip do |options|
     version = options[:version] or UI.user_error!("missing :version (e.g. 1.2.0)")
 
     certificates
@@ -189,6 +189,19 @@ platform :mac do
       key_content: ENV["ASC_KEY_CONTENT"],
       is_key_content_base64: true
     )
+
+    # `app_store_connect_api_key` returns a hash with the raw PEM content in
+    # `:key` (base64-encoded if `is_key_content_base64`), but no `:key_filepath`
+    # when constructed from `key_content`. notarytool needs a .p8 file path,
+    # so persist the decoded PEM to a tempfile.
+    require "tempfile"
+    require "base64"
+    asc_key_pem = api_key[:key]
+    asc_key_pem = Base64.decode64(asc_key_pem) if api_key[:is_key_content_base64]
+    asc_key_p8 = Tempfile.new(["asc_api_key", ".p8"])
+    asc_key_p8.write(asc_key_pem)
+    asc_key_p8.flush
+    asc_key_p8.close
 
     # match exports this with `_macos` infix because we passed `platform: "macos"`.
     # iOS appstore uses `sigh_<bundle>_appstore_profile-name` (no platform suffix)
@@ -222,35 +235,29 @@ platform :mac do
     app_path = File.join(build_dir, "Moolah.app")
     UI.user_error!("Moolah.app not found at #{app_path}") unless File.directory?(app_path)
 
-    # Notarise the .app first (faster turnaround than notarising the DMG alone).
-    sh "xcrun notarytool submit '#{app_path}' " \
-       "--key '#{api_key[:key_filepath]}' " \
+    # notarytool requires a .zip/.pkg/.dmg, not a bare .app bundle. Wrap with
+    # `ditto -c -k --keepParent` (the only zip format Apple's notarization
+    # service accepts for an .app), submit, then staple the original .app.
+    notarize_zip = File.join(build_dir, "Moolah.app.notarize.zip")
+    sh "rm -f '#{notarize_zip}'"
+    sh "ditto -c -k --keepParent '#{app_path}' '#{notarize_zip}'"
+    sh "xcrun notarytool submit '#{notarize_zip}' " \
+       "--key '#{asc_key_p8.path}' " \
        "--key-id '#{api_key[:key_id]}' " \
        "--issuer '#{api_key[:issuer_id]}' " \
        "--wait"
     sh "xcrun stapler staple '#{app_path}'"
+    sh "rm -f '#{notarize_zip}'"
 
-    # Build the DMG with create-dmg (assumed installed via brew on the runner).
-    dmg_path = File.join(build_dir, "Moolah-#{version}.dmg")
-    sh "rm -f '#{dmg_path}'"
-    sh "create-dmg " \
-       "--volname 'Moolah #{version}' " \
-       "--window-size 540 380 " \
-       "--icon-size 96 " \
-       "--icon 'Moolah.app' 140 190 " \
-       "--app-drop-link 400 190 " \
-       "--no-internet-enable " \
-       "'#{dmg_path}' '#{app_path}'"
+    # Re-zip the now-stapled .app for distribution. The .zip itself can't be
+    # stapled, but Gatekeeper reads the staple from the .app inside, so users
+    # get full offline verification.
+    zip_path = File.join(build_dir, "Moolah-#{version}.zip")
+    sh "rm -f '#{zip_path}'"
+    sh "ditto -c -k --keepParent '#{app_path}' '#{zip_path}'"
 
-    # Sign + notarise + staple the DMG itself.
-    sh "codesign --sign 'Developer ID Application' --timestamp '#{dmg_path}'"
-    sh "xcrun notarytool submit '#{dmg_path}' " \
-       "--key '#{api_key[:key_filepath]}' " \
-       "--key-id '#{api_key[:key_id]}' " \
-       "--issuer '#{api_key[:issuer_id]}' " \
-       "--wait"
-    sh "xcrun stapler staple '#{dmg_path}'"
+    asc_key_p8.unlink
 
-    UI.success("Notarised DMG ready at #{dmg_path}")
+    UI.success("Notarised zip ready at #{zip_path}")
   end
 end

--- a/guides/RELEASE_GUIDE.md
+++ b/guides/RELEASE_GUIDE.md
@@ -6,7 +6,7 @@
 
 - **RC tag:** `v<MAJOR>.<MINOR>.<PATCH>-rc.<N>`. Example: `v1.2.0-rc.1`, `v1.2.0-rc.2`.
 - **Final tag:** `v<MAJOR>.<MINOR>.<PATCH>`. Example: `v1.2.0`.
-- The final tag points at the **same commit** as the RC being promoted. The same iOS binary that was beta-tested ships to the App Store; the same notarised DMG that RC users downloaded is the one attached to the final GitHub Release.
+- The final tag points at the **same commit** as the RC being promoted. The same iOS binary that was beta-tested ships to the App Store; the same notarised Mac zip that RC users downloaded is the one attached to the final GitHub Release.
 - Tags are never deleted once pushed. Abandoned RCs and final releases stay as historical record.
 - Channel signals carry the RC vs final distinction (TestFlight badge, GitHub "Pre-release" label). The binary itself is identical.
 
@@ -46,9 +46,9 @@ The pipeline writes detailed instructions to the workflow run's job summary when
 
 4. **Cut the GH pre-release.** Run `just release-create-rc <version> .agent-tmp/release-notes-<version>.md`. This creates the tag, which fires `release-rc.yml`.
 
-5. **Wait + verify.** Run `just release-wait v<version>`. The workflow may pause on the `await-prod-deploy` job — if so, follow the "Schema deploys" procedure above (open Console → Deploy → approve the GH job). When the workflow concludes green, run `just release-status v<version>` to confirm the DMG is attached to the GH pre-release and the IPA reached TestFlight.
+5. **Wait + verify.** Run `just release-wait v<version>`. The workflow may pause on the `await-prod-deploy` job — if so, follow the "Schema deploys" procedure above (open Console → Deploy → approve the GH job). When the workflow concludes green, run `just release-status v<version>` to confirm the Mac zip is attached to the GH pre-release and the IPA reached TestFlight.
 
-6. **Smoke-test.** Install the TestFlight build (iOS device + simulator) and the DMG (Mac). If anything is broken, document the issue, fix on `main`, and cut a fresh RC. Don't delete the bad RC; mark its release body to note it is obsolete.
+6. **Smoke-test.** Install the TestFlight build (iOS device + simulator) and the Mac zip (extract, drag `Moolah.app` to `/Applications`, run). If anything is broken, document the issue, fix on `main`, and cut a fresh RC. Don't delete the bad RC; mark its release body to note it is obsolete.
 
 ## Promote an RC to final
 
@@ -62,7 +62,7 @@ The pipeline writes detailed instructions to the workflow run's job summary when
 
 5. **Wait.** Run `just release-wait v<version>`.
 
-6. **Verify.** Run `just release-status v<version>`. Confirm the workflow concluded green and the DMG asset is attached to the final release. The workflow's green conclusion implies the App Store submission was made (auto-release on) and the bump PR was opened with automerge enabled — but cross-check both in App Store Connect and the GitHub PR list. If you see a workflow failure, jump to "Recovery" → "Final workflow fails after submission".
+6. **Verify.** Run `just release-status v<version>`. Confirm the workflow concluded green and the Mac zip asset is attached to the final release. The workflow's green conclusion implies the App Store submission was made (auto-release on) and the bump PR was opened with automerge enabled — but cross-check both in App Store Connect and the GitHub PR list. If you see a workflow failure, jump to "Recovery" → "Final workflow fails after submission".
 
 7. **Review the bump PR.** It is opened with the default minor bump and automerge enabled. If you want a different bump (major / patch / explicit version), edit `project.yml` in the PR before automerge fires; otherwise let it merge.
 
@@ -107,7 +107,7 @@ If you click Deploy in the Console and approve the workflow but `await-prod-depl
 ### Schema deploy succeeded, build failed mid-RC
 The Production schema change is permanent. Diagnose the build failure on `main`, fix it, cut a new RC. The next RC's preflight will see Prod already matches `schema.ckdb` and skip straight to the build. The bad RC's GH pre-release stays as a record; edit its body to note it is obsolete.
 
-### iOS upload succeeded, Mac DMG step failed
+### iOS upload succeeded, Mac zip step failed
 Re-run the workflow run from the failed step (Actions → Run → Re-run failed jobs). Notarisation hiccups are usually transient. If a config issue, fix on `main` and cut a new RC.
 
 ### Notarisation timeout
@@ -120,7 +120,7 @@ Don't promote it. Cut a new RC. The bad RC's GH pre-release stays for traceabili
 Open a PR that bumps `MARKETING_VERSION` past it (or back, if you really need to). Land through the merge-queue. The next RC reads the new value.
 
 ### Final workflow fails after submission
-Re-run the workflow. The build is unchanged; idempotent steps (DMG copy, bump PR creation) are safe to retry.
+Re-run the workflow. The build is unchanged; idempotent steps (Mac zip copy, bump PR creation) are safe to retry.
 
 ### Apple rejects the App Store submission
 Address feedback on `main`, cut a new RC + final cycle. Auto-release is per-submission, so the rejected submission has no live effect.


### PR DESCRIPTION
## Summary

Switches the Mac distribution artifact from \`.dmg\` to \`.zip\`. Single notarize submission, fewer moving parts, and folds in the two notarize bugs that broke rc.7.

### What changed in the pipeline

Before: build → notarize .app → staple .app → \`create-dmg\` → codesign DMG → notarize DMG → staple DMG.

After: build → notarize .app (via \`ditto\` zip — the format notarytool requires for a bundle anyway) → staple .app → re-zip the stapled .app for distribution.

The \`.zip\` itself can't be stapled, but Gatekeeper reads the staple from the inner \`.app\`, so users still get full offline verification on first launch.

### Bug fixes folded in

Both surfaced on [rc.7 release run 24971279144](https://github.com/ajsutton/moolah-native/actions/runs/24971279144) — they would have needed fixing whether we kept the DMG or not:

1. notarytool rejected the bare \`.app\` bundle (\"must be .zip/.pkg/.dmg\"). Now wrapped with \`ditto -c -k --keepParent\` before submission.
2. \`--key ''\` was empty because \`app_store_connect_api_key\` returns a hash with the raw PEM in \`:key\`, not a \`:key_filepath\`. Now writes the decoded PEM to a tempfile and passes that path.

### Files touched

- \`fastlane/Fastfile\`: lane renamed \`mac dmg\` → \`mac zip\`, body rewritten.
- \`.github/workflows/release-rc.yml\`: drop \`create-dmg\` from brew install, rename step, change asset name to \`Moolah-<version>.zip\`.
- \`.github/workflows/release-final.yml\`: copy \`Moolah-*.zip\` from RC to final release instead of \`*.dmg\`.
- \`guides/RELEASE_GUIDE.md\` + \`.claude/skills/cutting-a-release/SKILL.md\`: prose updates so smoke-test instructions match the new artifact.

### Trade-off

DMG gives a polished first-run window with \`Applications\` shortcut and custom layout. With \`.zip\`, the user double-clicks to extract, then drags \`.app\` to \`/Applications\` themselves. Plenty of indie Mac apps ship .zip; minor UX downgrade in exchange for a much simpler pipeline.

## Test plan
- [ ] Tag v1.1.0-rc.8 once merged; verify the Mac zip step gets through notarize and produces an attached, notarised \`Moolah-1.1.0.zip\` on the GH pre-release
- [ ] Smoke-test the zip: extract, drag to /Applications, run, confirm Gatekeeper does not block