### PR TITLE
chore(cloudkit): refresh schema-prod-baseline after rc.8 deploy

### DIFF
--- a/CloudKit/schema-prod-baseline.ckdb
+++ b/CloudKit/schema-prod-baseline.ckdb
@@ -1,12 +1,218 @@
 DEFINE SCHEMA
 
+    RECORD TYPE AccountRecord (
+        "___createTime" TIMESTAMP,
+        "___createdBy"  REFERENCE,
+        "___etag"       STRING,
+        "___modTime"    TIMESTAMP,
+        "___modifiedBy" REFERENCE,
+        "___recordID"   REFERENCE QUERYABLE,
+        instrumentId    STRING QUERYABLE SEARCHABLE SORTABLE,
+        isHidden        INT64 QUERYABLE SORTABLE,
+        name            STRING QUERYABLE SEARCHABLE SORTABLE,
+        position        INT64 QUERYABLE SORTABLE,
+        type            STRING QUERYABLE SEARCHABLE SORTABLE,
+        GRANT WRITE TO "_creator",
+        GRANT CREATE TO "_icloud",
+        GRANT READ TO "_world"
+    );
+
+    RECORD TYPE CSVImportProfileRecord (
+        "___createTime"            TIMESTAMP,
+        "___createdBy"             REFERENCE,
+        "___etag"                  STRING,
+        "___modTime"               TIMESTAMP,
+        "___modifiedBy"            REFERENCE,
+        "___recordID"              REFERENCE QUERYABLE,
+        accountId                  STRING QUERYABLE SEARCHABLE SORTABLE,
+        columnRoleRawValuesEncoded STRING QUERYABLE SEARCHABLE SORTABLE,
+        createdAt                  TIMESTAMP QUERYABLE SORTABLE,
+        dateFormatRawValue         STRING QUERYABLE SEARCHABLE SORTABLE,
+        deleteAfterImport          INT64 QUERYABLE SORTABLE,
+        filenamePattern            STRING QUERYABLE SEARCHABLE SORTABLE,
+        headerSignature            STRING QUERYABLE SEARCHABLE SORTABLE,
+        lastUsedAt                 TIMESTAMP QUERYABLE SORTABLE,
+        parserIdentifier           STRING QUERYABLE SEARCHABLE SORTABLE,
+        GRANT WRITE TO "_creator",
+        GRANT CREATE TO "_icloud",
+        GRANT READ TO "_world"
+    );
+
+    RECORD TYPE CategoryRecord (
+        "___createTime" TIMESTAMP,
+        "___createdBy"  REFERENCE,
+        "___etag"       STRING,
+        "___modTime"    TIMESTAMP,
+        "___modifiedBy" REFERENCE,
+        "___recordID"   REFERENCE QUERYABLE,
+        name            STRING QUERYABLE SEARCHABLE SORTABLE,
+        parentId        STRING QUERYABLE SEARCHABLE SORTABLE,
+        GRANT WRITE TO "_creator",
+        GRANT CREATE TO "_icloud",
+        GRANT READ TO "_world"
+    );
+
+    RECORD TYPE EarmarkBudgetItemRecord (
+        "___createTime" TIMESTAMP,
+        "___createdBy"  REFERENCE,
+        "___etag"       STRING,
+        "___modTime"    TIMESTAMP,
+        "___modifiedBy" REFERENCE,
+        "___recordID"   REFERENCE QUERYABLE,
+        amount          INT64 QUERYABLE SORTABLE,
+        categoryId      STRING QUERYABLE SEARCHABLE SORTABLE,
+        earmarkId       STRING QUERYABLE SEARCHABLE SORTABLE,
+        instrumentId    STRING QUERYABLE SEARCHABLE SORTABLE,
+        GRANT WRITE TO "_creator",
+        GRANT CREATE TO "_icloud",
+        GRANT READ TO "_world"
+    );
+
+    RECORD TYPE EarmarkRecord (
+        "___createTime"           TIMESTAMP,
+        "___createdBy"            REFERENCE,
+        "___etag"                 STRING,
+        "___modTime"              TIMESTAMP,
+        "___modifiedBy"           REFERENCE,
+        "___recordID"             REFERENCE QUERYABLE,
+        instrumentId              STRING QUERYABLE SEARCHABLE SORTABLE,
+        isHidden                  INT64 QUERYABLE SORTABLE,
+        name                      STRING QUERYABLE SEARCHABLE SORTABLE,
+        position                  INT64 QUERYABLE SORTABLE,
+        savingsEndDate            TIMESTAMP QUERYABLE SORTABLE,
+        savingsStartDate          TIMESTAMP QUERYABLE SORTABLE,
+        savingsTarget             INT64 QUERYABLE SORTABLE,
+        savingsTargetInstrumentId STRING QUERYABLE SEARCHABLE SORTABLE,
+        GRANT WRITE TO "_creator",
+        GRANT CREATE TO "_icloud",
+        GRANT READ TO "_world"
+    );
+
+    RECORD TYPE ImportRuleRecord (
+        "___createTime" TIMESTAMP,
+        "___createdBy"  REFERENCE,
+        "___etag"       STRING,
+        "___modTime"    TIMESTAMP,
+        "___modifiedBy" REFERENCE,
+        "___recordID"   REFERENCE QUERYABLE,
+        accountScope    STRING QUERYABLE SEARCHABLE SORTABLE,
+        actionsJSON     BYTES,
+        conditionsJSON  BYTES,
+        enabled         INT64 QUERYABLE SORTABLE,
+        matchMode       STRING QUERYABLE SEARCHABLE SORTABLE,
+        name            STRING QUERYABLE SEARCHABLE SORTABLE,
+        position        INT64 QUERYABLE SORTABLE,
+        GRANT WRITE TO "_creator",
+        GRANT CREATE TO "_icloud",
+        GRANT READ TO "_world"
+    );
+
+    RECORD TYPE InstrumentRecord (
+        "___createTime"     TIMESTAMP,
+        "___createdBy"      REFERENCE,
+        "___etag"           STRING,
+        "___modTime"        TIMESTAMP,
+        "___modifiedBy"     REFERENCE,
+        "___recordID"       REFERENCE QUERYABLE,
+        binanceSymbol       STRING QUERYABLE SEARCHABLE SORTABLE,
+        chainId             INT64 QUERYABLE SORTABLE,
+        coingeckoId         STRING QUERYABLE SEARCHABLE SORTABLE,
+        contractAddress     STRING QUERYABLE SEARCHABLE SORTABLE,
+        cryptocompareSymbol STRING QUERYABLE SEARCHABLE SORTABLE,
+        decimals            INT64 QUERYABLE SORTABLE,
+        exchange            STRING QUERYABLE SEARCHABLE SORTABLE,
+        kind                STRING QUERYABLE SEARCHABLE SORTABLE,
+        name                STRING QUERYABLE SEARCHABLE SORTABLE,
+        ticker              STRING QUERYABLE SEARCHABLE SORTABLE,
+        GRANT WRITE TO "_creator",
+        GRANT CREATE TO "_icloud",
+        GRANT READ TO "_world"
+    );
+
+    RECORD TYPE InvestmentValueRecord (
+        "___createTime" TIMESTAMP,
+        "___createdBy"  REFERENCE,
+        "___etag"       STRING,
+        "___modTime"    TIMESTAMP,
+        "___modifiedBy" REFERENCE,
+        "___recordID"   REFERENCE QUERYABLE,
+        accountId       STRING QUERYABLE SEARCHABLE SORTABLE,
+        date            TIMESTAMP QUERYABLE SORTABLE,
+        instrumentId    STRING QUERYABLE SEARCHABLE SORTABLE,
+        value           INT64 QUERYABLE SORTABLE,
+        GRANT WRITE TO "_creator",
+        GRANT CREATE TO "_icloud",
+        GRANT READ TO "_world"
+    );
+
+    RECORD TYPE ProfileRecord (
+        "___createTime"         TIMESTAMP,
+        "___createdBy"          REFERENCE,
+        "___etag"               STRING,
+        "___modTime"            TIMESTAMP,
+        "___modifiedBy"         REFERENCE,
+        "___recordID"           REFERENCE QUERYABLE,
+        createdAt               TIMESTAMP QUERYABLE SORTABLE,
+        currencyCode            STRING QUERYABLE SEARCHABLE SORTABLE,
+        financialYearStartMonth INT64 QUERYABLE SORTABLE,
+        label                   STRING QUERYABLE SEARCHABLE SORTABLE,
+        GRANT WRITE TO "_creator",
+        GRANT CREATE TO "_icloud",
+        GRANT READ TO "_world"
+    );
+
+    RECORD TYPE TransactionLegRecord (
+        "___createTime" TIMESTAMP,
+        "___createdBy"  REFERENCE,
+        "___etag"       STRING,
+        "___modTime"    TIMESTAMP,
+        "___modifiedBy" REFERENCE,
+        "___recordID"   REFERENCE QUERYABLE,
+        accountId       STRING QUERYABLE SEARCHABLE SORTABLE,
+        categoryId      STRING QUERYABLE SEARCHABLE SORTABLE,
+        earmarkId       STRING QUERYABLE SEARCHABLE SORTABLE,
+        instrumentId    STRING QUERYABLE SEARCHABLE SORTABLE,
+        quantity        INT64 QUERYABLE SORTABLE,
+        sortOrder       INT64 QUERYABLE SORTABLE,
+        transactionId   STRING QUERYABLE SEARCHABLE SORTABLE,
+        type            STRING QUERYABLE SEARCHABLE SORTABLE,
+        GRANT WRITE TO "_creator",
+        GRANT CREATE TO "_icloud",
+        GRANT READ TO "_world"
+    );
+
+    RECORD TYPE TransactionRecord (
+        "___createTime"              TIMESTAMP,
+        "___createdBy"               REFERENCE,
+        "___etag"                    STRING,
+        "___modTime"                 TIMESTAMP,
+        "___modifiedBy"              REFERENCE,
+        "___recordID"                REFERENCE QUERYABLE,
+        date                         TIMESTAMP QUERYABLE SORTABLE,
+        importOriginBankReference    STRING QUERYABLE SEARCHABLE SORTABLE,
+        importOriginImportSessionId  STRING QUERYABLE SEARCHABLE SORTABLE,
+        importOriginImportedAt       TIMESTAMP QUERYABLE SORTABLE,
+        importOriginParserIdentifier STRING QUERYABLE SEARCHABLE SORTABLE,
+        importOriginRawAmount        STRING QUERYABLE SEARCHABLE SORTABLE,
+        importOriginRawBalance       STRING QUERYABLE SEARCHABLE SORTABLE,
+        importOriginRawDescription   STRING QUERYABLE SEARCHABLE SORTABLE,
+        importOriginSourceFilename   STRING QUERYABLE SEARCHABLE SORTABLE,
+        notes                        STRING QUERYABLE SEARCHABLE SORTABLE,
+        payee                        STRING QUERYABLE SEARCHABLE SORTABLE,
+        recurEvery                   INT64 QUERYABLE SORTABLE,
+        recurPeriod                  STRING QUERYABLE SEARCHABLE SORTABLE,
+        GRANT WRITE TO "_creator",
+        GRANT CREATE TO "_icloud",
+        GRANT READ TO "_world"
+    );
+
     RECORD TYPE Users (
         "___createTime" TIMESTAMP,
         "___createdBy"  REFERENCE,
         "___etag"       STRING,
         "___modTime"    TIMESTAMP,
         "___modifiedBy" REFERENCE,
-        "___recordID"   REFERENCE,
+        "___recordID"   REFERENCE QUERYABLE,
         roles           LIST<INT64>,
         GRANT WRITE TO "_creator",
         GRANT READ TO "_world"


### PR DESCRIPTION
Auto-generated branch from \`release-rc.yml\`'s post-build refresh step on the rc.8 run. The workflow couldn't open this PR itself — repo setting \`Allow GitHub Actions to create and approve pull requests\` is currently disabled.

Refreshes \`CloudKit/schema-prod-baseline.ckdb\` to match what was exported from live Production after the schema deploy that landed during rc.8's build job.

No code changes; only the baseline file was touched.