### PR TITLE
fix(transactions): keep scheduled date when paying a scheduled transaction

### DIFF
--- a/Domain/Models/Transaction+Defaults.swift
+++ b/Domain/Models/Transaction+Defaults.swift
@@ -43,13 +43,17 @@ extension Transaction {
     )
   }
 
-  /// A non-scheduled copy of `scheduled` dated today. Used by
-  /// `TransactionStore.payScheduledTransaction` to record the actual payment
-  /// without altering the scheduled template.
+  /// A non-scheduled copy of `scheduled` dated as of its scheduled date.
+  /// Used by `TransactionStore.payScheduledTransaction` to record the actual
+  /// payment without altering the scheduled template. Keeping the scheduled
+  /// date — not the click time — means a batch of bills paid in one sitting
+  /// lands on the dates the user budgeted for, so reports and running
+  /// balances reflect the schedule rather than when the user happened to
+  /// click pay.
   static func paidCopy(of scheduled: Transaction) -> Transaction {
     Transaction(
       id: UUID(),
-      date: Date(),
+      date: scheduled.date,
       payee: scheduled.payee,
       notes: scheduled.notes,
       legs: scheduled.legs

--- a/MoolahTests/Features/TransactionStorePayScheduledTests.swift
+++ b/MoolahTests/Features/TransactionStorePayScheduledTests.swift
@@ -158,6 +158,41 @@ struct TransactionStorePayScheduledTests {
   }
 
   @Test
+  func testPaidCopyKeepsScheduledDate() async throws {
+    let scheduledDate = try TransactionStoreTestSupport.makeDate("2024-01-15")
+    let scheduled = Transaction(
+      date: scheduledDate,
+      payee: "Rent",
+      recurPeriod: .month,
+      recurEvery: 1,
+      legs: [
+        TransactionLeg(
+          accountId: accountId,
+          instrument: Instrument.defaultTestInstrument,
+          quantity: Decimal(-200000) / 100,
+          type: .expense
+        )
+      ]
+    )
+    let (backend, container) = try TestBackend.create()
+    TestBackend.seed(transactions: [scheduled], in: container)
+    let store = TransactionStore(
+      repository: backend.transactions,
+      conversionService: FixedConversionService(),
+      targetInstrument: .defaultTestInstrument
+    )
+
+    await store.load(filter: TransactionFilter(scheduled: .scheduledOnly))
+    _ = await store.payScheduledTransaction(scheduled)
+
+    let allPage = try await backend.transactions.fetch(
+      filter: TransactionFilter(), page: 0, pageSize: 50)
+    let paid = allPage.transactions.first { $0.id != scheduled.id }
+    #expect(paid != nil)
+    #expect(paid?.date == scheduledDate)
+  }
+
+  @Test
   func testPayPreservesAllTransactionFields() async throws {
     let categoryId = UUID()
     let earmarkId = UUID()


### PR DESCRIPTION
## Summary

- `Transaction.paidCopy(of:)` was setting the new (paid) transaction's `date` to `Date()` (the click time) instead of `scheduled.date`. Batch-paying a week's bills on a Sunday collapsed every payment onto that one day, distorting reports, monthly category breakdowns, and running balances.
- Use `scheduled.date` so the recorded payment lands on the date the user actually budgeted for.
- Add a store-level test (`testPaidCopyKeepsScheduledDate`) that fails on the old behaviour and passes after the fix.

Fixes [#508](https://github.com/ajsutton/moolah-native/issues/508).

## Test plan

- [x] `just test-mac TransactionStorePayScheduledTests TransactionStoreEarmarkTests` — all green.
- [x] `just format-check` — clean.
- [ ] CI — full suite on iOS + macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)