### PR TITLE
fix(transactions): preserve typed text on Escape; commit highlighted on Tab

### DIFF
--- a/Features/Earmarks/Views/AddBudgetLineItemSheet.swift
+++ b/Features/Earmarks/Views/AddBudgetLineItemSheet.swift
@@ -63,7 +63,8 @@ struct AddBudgetLineItemSheet: View {
             showCategorySuggestions = true
           }
         },
-        onAcceptHighlighted: acceptHighlightedCategory
+        onAcceptHighlighted: acceptHighlightedCategory,
+        onCancel: cancelCategorySuggestions
       )
       .focused($categoryFieldFocused)
       .onChange(of: categoryFieldFocused) { _, focused in
@@ -117,6 +118,14 @@ struct AddBudgetLineItemSheet: View {
       categoryText = ""
       selectedCategoryId = nil
     }
+  }
+
+  /// Closes the dropdown without clearing typed text — Escape (#510). The
+  /// next keystroke is left free to re-open the dropdown, so
+  /// `categoryJustSelected` stays unset.
+  private func cancelCategorySuggestions() {
+    showCategorySuggestions = false
+    categoryHighlightedIndex = nil
   }
 
   private var categoryVisibleSuggestions: [CategorySuggestion] {

--- a/Features/Earmarks/Views/AddBudgetLineItemSheet.swift
+++ b/Features/Earmarks/Views/AddBudgetLineItemSheet.swift
@@ -7,9 +7,7 @@ struct AddBudgetLineItemSheet: View {
   @State private var selectedCategoryId: UUID?
   @State private var amountText = ""
   @State private var categoryText = ""
-  @State private var showCategorySuggestions = false
-  @State private var categoryHighlightedIndex: Int?
-  @State private var categoryJustSelected = false
+  @State private var categoryState = CategoryAutocompleteState()
   @FocusState private var categoryFieldFocused: Bool
   @Environment(EarmarkStore.self) private var earmarkStore
   @Environment(\.dismiss) private var dismiss
@@ -31,7 +29,7 @@ struct AddBudgetLineItemSheet: View {
     }
     .formStyle(.grouped)
     .overlayPreferenceValue(CategoryPickerAnchorKey.self) { anchor in
-      if showCategorySuggestions, !categoryVisibleSuggestions.isEmpty, let anchor {
+      if categoryState.showSuggestions, !categoryVisibleSuggestions.isEmpty, let anchor {
         suggestionDropdown(anchor: anchor)
       }
     }
@@ -54,17 +52,11 @@ struct AddBudgetLineItemSheet: View {
     Section("Category") {
       CategoryAutocompleteField(
         text: $categoryText,
-        highlightedIndex: $categoryHighlightedIndex,
+        highlightedIndex: $categoryState.highlightedIndex,
         suggestionCount: categoryVisibleSuggestionCount,
-        onTextChange: { _ in
-          if categoryJustSelected {
-            categoryJustSelected = false
-          } else {
-            showCategorySuggestions = true
-          }
-        },
+        onTextChange: { _ in handleTextChange() },
         onAcceptHighlighted: acceptHighlightedCategory,
-        onCancel: cancelCategorySuggestions
+        onCancel: { categoryState.cancel() }
       )
       .focused($categoryFieldFocused)
       .onChange(of: categoryFieldFocused) { _, focused in
@@ -94,25 +86,35 @@ struct AddBudgetLineItemSheet: View {
       CategorySuggestionDropdown(
         suggestions: categoryVisibleSuggestions,
         searchText: categoryText,
-        highlightedIndex: $categoryHighlightedIndex,
-        onSelect: { selected in
-          categoryJustSelected = true
-          selectedCategoryId = selected.id
-          categoryText = selected.path
-          showCategorySuggestions = false
-          categoryHighlightedIndex = nil
-        }
+        highlightedIndex: $categoryState.highlightedIndex,
+        onSelect: { selected in commit(suggestion: selected) }
       )
       .frame(width: rect.width)
       .offset(x: rect.minX, y: rect.maxY + 4)
     }
   }
 
+  private func handleTextChange() {
+    if categoryState.justSelected {
+      categoryState.justSelected = false
+    } else {
+      categoryState.showSuggestions = true
+    }
+  }
+
+  /// On focus loss, commit a highlighted suggestion if there is one
+  /// (#509 — same blur-loses-highlight bug as the transaction-detail
+  /// category field), otherwise reconcile typed text against
+  /// `selectedCategoryId` so partially-typed input that never resolved
+  /// to a known category doesn't linger in the field.
   private func handleCategoryFieldUnfocused() {
-    categoryJustSelected = true
-    showCategorySuggestions = false
-    categoryHighlightedIndex = nil
-    if let id = selectedCategoryId, let cat = categories.by(id: id) {
+    let highlighted = categoryState.highlightedSuggestion(
+      for: categoryText, in: categories)
+    categoryState.dismiss()
+    if let highlighted {
+      selectedCategoryId = highlighted.id
+      categoryText = highlighted.path
+    } else if let id = selectedCategoryId, let cat = categories.by(id: id) {
       categoryText = categories.path(for: cat)
     } else {
       categoryText = ""
@@ -120,24 +122,8 @@ struct AddBudgetLineItemSheet: View {
     }
   }
 
-  /// Closes the dropdown without clearing typed text — Escape (#510). The
-  /// next keystroke is left free to re-open the dropdown, so
-  /// `categoryJustSelected` stays unset.
-  private func cancelCategorySuggestions() {
-    showCategorySuggestions = false
-    categoryHighlightedIndex = nil
-  }
-
   private var categoryVisibleSuggestions: [CategorySuggestion] {
-    guard showCategorySuggestions else { return [] }
-    let allEntries = categories.flattenedByPath()
-    let filtered: [Categories.FlatEntry]
-    if categoryText.trimmingCharacters(in: .whitespaces).isEmpty {
-      filtered = allEntries
-    } else {
-      filtered = allEntries.filter { matchesCategorySearch($0.path, query: categoryText) }
-    }
-    return filtered.prefix(8).map { CategorySuggestion(id: $0.category.id, path: $0.path) }
+    categoryState.visibleSuggestions(for: categoryText, in: categories)
   }
 
   private var categoryVisibleSuggestionCount: Int {
@@ -145,15 +131,17 @@ struct AddBudgetLineItemSheet: View {
   }
 
   private func acceptHighlightedCategory() {
-    guard let index = categoryHighlightedIndex, index < categoryVisibleSuggestions.count else {
-      return
-    }
-    let selected = categoryVisibleSuggestions[index]
-    categoryJustSelected = true
-    selectedCategoryId = selected.id
-    categoryText = selected.path
-    showCategorySuggestions = false
-    categoryHighlightedIndex = nil
+    guard
+      let selected = categoryState.highlightedSuggestion(
+        for: categoryText, in: categories)
+    else { return }
+    commit(suggestion: selected)
+  }
+
+  private func commit(suggestion: CategorySuggestion) {
+    categoryState.dismiss()
+    selectedCategoryId = suggestion.id
+    categoryText = suggestion.path
   }
 
   private func save() {

--- a/Features/Transactions/Views/Detail/CategoryAutocompleteState.swift
+++ b/Features/Transactions/Views/Detail/CategoryAutocompleteState.swift
@@ -27,6 +27,15 @@ extension CategoryAutocompleteState {
     highlightedIndex = nil
   }
 
+  /// Closes the dropdown without arming `justSelected`. Used when the user
+  /// dismisses the picker without changing the field text — Escape — so
+  /// the next character they type is still recognised as user-driven
+  /// editing and re-opens the dropdown.
+  mutating func cancel() {
+    showSuggestions = false
+    highlightedIndex = nil
+  }
+
   /// Visible category suggestions for the current `query`. Returns up to
   /// 8 entries to match the dropdown's render budget; an empty/whitespace
   /// query returns the full (capped) list so users can browse without

--- a/Features/Transactions/Views/Detail/CategoryAutocompleteState.swift
+++ b/Features/Transactions/Views/Detail/CategoryAutocompleteState.swift
@@ -2,40 +2,16 @@ import SwiftUI
 
 /// Bundled state for the simple-mode category autocomplete dropdown.
 /// Shared between `TransactionDetailCategorySection` (the field row) and
-/// `TransactionDetailCategoryOverlay` (the floating dropdown).
-struct CategoryAutocompleteState: Equatable {
-  /// `true` while the dropdown should render (subject to having
-  /// suggestions to show).
+/// `TransactionDetailCategoryOverlay` (the floating dropdown). Conforms
+/// to `AutocompleteDropdownState`, which supplies `dismiss()` and
+/// `cancel()`.
+struct CategoryAutocompleteState: AutocompleteDropdownState {
   var showSuggestions: Bool = false
-  /// Index of the visible suggestion that ↑/↓ have moved through and that
-  /// `Enter` will accept. `nil` means nothing is highlighted yet.
   var highlightedIndex: Int?
-  /// Set when a suggestion is accepted so the resulting binding-driven
-  /// `onTextChange` does not immediately re-open the dropdown.
   var justSelected: Bool = false
 }
 
 extension CategoryAutocompleteState {
-  /// Closes the dropdown and arms `justSelected` so the next
-  /// binding-driven `onTextChange` (caused by us writing the accepted
-  /// path back into the field, or by the blur handler normalising stray
-  /// text against the canonical path) does not immediately re-open the
-  /// picker.
-  mutating func dismiss() {
-    justSelected = true
-    showSuggestions = false
-    highlightedIndex = nil
-  }
-
-  /// Closes the dropdown without arming `justSelected`. Used when the user
-  /// dismisses the picker without changing the field text — Escape — so
-  /// the next character they type is still recognised as user-driven
-  /// editing and re-opens the dropdown.
-  mutating func cancel() {
-    showSuggestions = false
-    highlightedIndex = nil
-  }
-
   /// Visible category suggestions for the current `query`. Returns up to
   /// 8 entries to match the dropdown's render budget; an empty/whitespace
   /// query returns the full (capped) list so users can browse without
@@ -53,5 +29,19 @@ extension CategoryAutocompleteState {
       filtered = allEntries.filter { matchesCategorySearch($0.path, query: query) }
     }
     return filtered.prefix(8).map { CategorySuggestion(id: $0.category.id, path: $0.path) }
+  }
+
+  /// The `CategorySuggestion` the user has arrow-keyed to, or `nil` if
+  /// nothing is highlighted, the dropdown is hidden, or the index has
+  /// drifted out of bounds. Lets blur handlers commit the highlight in
+  /// one call without re-doing the index-bounds check at the call site.
+  func highlightedSuggestion(
+    for query: String, in categories: Categories
+  ) -> CategorySuggestion? {
+    let visible = visibleSuggestions(for: query, in: categories)
+    guard let index = highlightedIndex, visible.indices.contains(index) else {
+      return nil
+    }
+    return visible[index]
   }
 }

--- a/Features/Transactions/Views/Detail/PayeeAutocompleteRow.swift
+++ b/Features/Transactions/Views/Detail/PayeeAutocompleteRow.swift
@@ -3,11 +3,18 @@ import SwiftUI
 /// The payee text field with autocomplete callbacks wired to a shared
 /// `PayeeAutocompleteState`. The matching dropdown is rendered by
 /// `PayeeAutocompleteOverlay` at the form level.
+///
+/// Owns a private `@FocusState` so it can dismiss the dropdown without
+/// clearing the field text when the user moves focus away (Tab, click
+/// elsewhere). Per #510, the typed text must be preserved on focus loss
+/// — only `Enter` / clicking a suggestion should replace it.
 struct PayeeAutocompleteRow: View {
   @Binding var payee: String
   @Binding var state: PayeeAutocompleteState
   let suggestionSource: PayeeSuggestionSource
   let onAutofill: (String) -> Void
+
+  @FocusState private var fieldFocused: Bool
 
   var body: some View {
     PayeeAutocompleteField(
@@ -15,9 +22,14 @@ struct PayeeAutocompleteRow: View {
       highlightedIndex: $state.highlightedIndex,
       suggestionCount: state.visibleSuggestions(from: suggestionSource.suggestions).count,
       onTextChange: handleTextChange,
-      onAcceptHighlighted: acceptHighlighted
+      onAcceptHighlighted: acceptHighlighted,
+      onCancel: { state.cancel() }
     )
+    .focused($fieldFocused)
     .accessibilityIdentifier(UITestIdentifiers.Detail.payee)
+    .onChange(of: fieldFocused) { _, focused in
+      if !focused { state.cancel() }
+    }
   }
 
   private func handleTextChange(_ newValue: String) {

--- a/Features/Transactions/Views/Detail/PayeeAutocompleteState.swift
+++ b/Features/Transactions/Views/Detail/PayeeAutocompleteState.swift
@@ -1,18 +1,11 @@
 import SwiftUI
 
 /// Bundled state for the payee autocomplete dropdown — shared between the
-/// in-section field row and the form-level overlay.
-struct PayeeAutocompleteState: Equatable {
-  /// `true` while the dropdown should be considered visible (subject to
-  /// other gates: a non-empty payee and at least one suggestion in the
-  /// source).
+/// in-section field row and the form-level overlay. Conforms to
+/// `AutocompleteDropdownState`, which supplies `dismiss()` and `cancel()`.
+struct PayeeAutocompleteState: AutocompleteDropdownState {
   var showSuggestions: Bool = false
-  /// Index of the visible suggestion that ↑/↓ have moved through and that
-  /// `Enter` will accept. `nil` means nothing is highlighted yet.
   var highlightedIndex: Int?
-  /// Mirrors the legacy `payeeJustSelected` flag — set when a suggestion
-  /// is accepted so the resulting binding-driven `onTextChange` does not
-  /// immediately re-open the dropdown and re-trigger a prefix fetch.
   var justSelected: Bool = false
 }
 
@@ -23,24 +16,5 @@ extension PayeeAutocompleteState {
   func visibleSuggestions(from source: [String]) -> [String] {
     guard showSuggestions else { return [] }
     return Array(source.prefix(8))
-  }
-
-  /// Closes the dropdown and arms `justSelected` so the next
-  /// binding-driven `onTextChange` (caused by us writing the accepted
-  /// payee back into the field) does not immediately re-open the picker
-  /// and re-fetch suggestions.
-  mutating func dismiss() {
-    justSelected = true
-    showSuggestions = false
-    highlightedIndex = nil
-  }
-
-  /// Closes the dropdown without arming `justSelected`. Used when the user
-  /// dismisses the picker without changing the field text — Escape, or
-  /// moving focus away — so the next character they type is still
-  /// recognised as user-driven editing and re-opens the dropdown.
-  mutating func cancel() {
-    showSuggestions = false
-    highlightedIndex = nil
   }
 }

--- a/Features/Transactions/Views/Detail/PayeeAutocompleteState.swift
+++ b/Features/Transactions/Views/Detail/PayeeAutocompleteState.swift
@@ -34,4 +34,13 @@ extension PayeeAutocompleteState {
     showSuggestions = false
     highlightedIndex = nil
   }
+
+  /// Closes the dropdown without arming `justSelected`. Used when the user
+  /// dismisses the picker without changing the field text — Escape, or
+  /// moving focus away — so the next character they type is still
+  /// recognised as user-driven editing and re-opens the dropdown.
+  mutating func cancel() {
+    showSuggestions = false
+    highlightedIndex = nil
+  }
 }

--- a/Features/Transactions/Views/Detail/TransactionDetailCategorySection.swift
+++ b/Features/Transactions/Views/Detail/TransactionDetailCategorySection.swift
@@ -26,7 +26,8 @@ struct TransactionDetailCategorySection: View {
         highlightedIndex: $state.highlightedIndex,
         suggestionCount: visibleSuggestions.count,
         onTextChange: { _ in openDropdownIfFocused() },
-        onAcceptHighlighted: acceptHighlighted
+        onAcceptHighlighted: acceptHighlighted,
+        onCancel: { state.cancel() }
       )
       .focused($fieldFocused)
       .accessibilityIdentifier(UITestIdentifiers.Detail.category)
@@ -59,13 +60,19 @@ struct TransactionDetailCategorySection: View {
     }
   }
 
-  /// Resets picker UI state on blur and delegates the
-  /// `categoryText`/`categoryId` reconciliation to `TransactionDraft` so
-  /// the rule — "text that doesn't resolve to a known category is
-  /// cleared" — is exercised directly by `TransactionDraft` tests.
+  /// Resets picker UI state on blur and either commits the highlighted
+  /// suggestion or normalises the typed text against the category tree —
+  /// whichever applies. Delegated to `TransactionDraft` so the rules are
+  /// exercised directly by `TransactionDraft` tests. Without committing
+  /// the highlighted suggestion before normalising, Tab from a highlighted
+  /// suggestion would clear the field (#509).
   private func handleBlur() {
+    let highlighted = state.highlightedIndex.flatMap { index in
+      visibleSuggestions.indices.contains(index) ? visibleSuggestions[index] : nil
+    }
     state.dismiss()
-    draft.normaliseCategoryText(using: categories)
+    draft.commitHighlightedCategoryOrNormalise(
+      highlighted: highlighted, using: categories)
   }
 
   private func acceptHighlighted() {

--- a/Features/Transactions/Views/Detail/TransactionDetailCategorySection.swift
+++ b/Features/Transactions/Views/Detail/TransactionDetailCategorySection.swift
@@ -67,9 +67,8 @@ struct TransactionDetailCategorySection: View {
   /// the highlighted suggestion before normalising, Tab from a highlighted
   /// suggestion would clear the field (#509).
   private func handleBlur() {
-    let highlighted = state.highlightedIndex.flatMap { index in
-      visibleSuggestions.indices.contains(index) ? visibleSuggestions[index] : nil
-    }
+    let highlighted = state.highlightedSuggestion(
+      for: draft.categoryText, in: categories)
     state.dismiss()
     draft.commitHighlightedCategoryOrNormalise(
       highlighted: highlighted, using: categories)

--- a/Features/Transactions/Views/Detail/TransactionDetailLegRow.swift
+++ b/Features/Transactions/Views/Detail/TransactionDetailLegRow.swift
@@ -177,9 +177,8 @@ struct TransactionDetailLegRow: View {
   }
 
   private func handleBlur() {
-    let highlighted = categoryState.highlightedIndex.flatMap { idx in
-      visibleSuggestions.indices.contains(idx) ? visibleSuggestions[idx] : nil
-    }
+    let highlighted = categoryState.highlightedSuggestion(
+      for: draft.legDrafts[index].categoryText, in: categories)
     categoryState.dismiss()
     draft.commitHighlightedLegCategoryOrNormalise(
       at: index, highlighted: highlighted, using: categories)

--- a/Features/Transactions/Views/Detail/TransactionDetailLegRow.swift
+++ b/Features/Transactions/Views/Detail/TransactionDetailLegRow.swift
@@ -120,7 +120,8 @@ struct TransactionDetailLegRow: View {
       highlightedIndex: $categoryState.highlightedIndex,
       suggestionCount: visibleSuggestions.count,
       onTextChange: { _ in openDropdownIfFocused() },
-      onAcceptHighlighted: acceptHighlighted
+      onAcceptHighlighted: acceptHighlighted,
+      onCancel: { categoryState.cancel() }
     )
     .focused($categoryFieldFocused)
     .accessibilityIdentifier(UITestIdentifiers.Detail.legCategory(index))
@@ -176,8 +177,12 @@ struct TransactionDetailLegRow: View {
   }
 
   private func handleBlur() {
+    let highlighted = categoryState.highlightedIndex.flatMap { idx in
+      visibleSuggestions.indices.contains(idx) ? visibleSuggestions[idx] : nil
+    }
     categoryState.dismiss()
-    draft.normaliseLegCategoryText(at: index, using: categories)
+    draft.commitHighlightedLegCategoryOrNormalise(
+      at: index, highlighted: highlighted, using: categories)
   }
 
   private func acceptHighlighted() {

--- a/Features/Transactions/Views/PayeeAutocompleteField.swift
+++ b/Features/Transactions/Views/PayeeAutocompleteField.swift
@@ -10,6 +10,7 @@ struct PayeeAutocompleteField: View {
   let suggestionCount: Int
   let onTextChange: (String) -> Void
   let onAcceptHighlighted: () -> Void
+  let onCancel: () -> Void
 
   var body: some View {
     AutocompleteField(
@@ -18,7 +19,8 @@ struct PayeeAutocompleteField: View {
       highlightedIndex: $highlightedIndex,
       suggestionCount: suggestionCount,
       onTextChange: onTextChange,
-      onAcceptHighlighted: onAcceptHighlighted
+      onAcceptHighlighted: onAcceptHighlighted,
+      onCancel: onCancel
     )
   }
 }
@@ -77,7 +79,8 @@ private struct AutocompletePreviewForm: View {
           highlightedIndex: $highlighted,
           suggestionCount: autocompletePreviewSuggestions.count,
           onTextChange: { _ in },
-          onAcceptHighlighted: {}
+          onAcceptHighlighted: {},
+          onCancel: {}
         )
         HStack {
           TextField("Amount", text: .constant("0.00"))

--- a/MoolahTests/Features/CategoryAutocompleteStateTests.swift
+++ b/MoolahTests/Features/CategoryAutocompleteStateTests.swift
@@ -1,0 +1,40 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("CategoryAutocompleteState")
+struct CategoryAutocompleteStateTests {
+  @Test
+  func testCancelClosesDropdownWithoutArmingJustSelected() {
+    var state = CategoryAutocompleteState(
+      showSuggestions: true,
+      highlightedIndex: 0,
+      justSelected: false
+    )
+
+    state.cancel()
+
+    #expect(state.showSuggestions == false)
+    #expect(state.highlightedIndex == nil)
+    // See `PayeeAutocompleteStateTests` for the reasoning — the text
+    // didn't change on Escape, so the next keystroke must be free to
+    // re-open the dropdown.
+    #expect(state.justSelected == false)
+  }
+
+  @Test
+  func testDismissArmsJustSelectedSoBindingDrivenOnChangeIsEaten() {
+    var state = CategoryAutocompleteState(
+      showSuggestions: true,
+      highlightedIndex: 0,
+      justSelected: false
+    )
+
+    state.dismiss()
+
+    #expect(state.showSuggestions == false)
+    #expect(state.highlightedIndex == nil)
+    #expect(state.justSelected == true)
+  }
+}

--- a/MoolahTests/Features/CategoryAutocompleteStateTests.swift
+++ b/MoolahTests/Features/CategoryAutocompleteStateTests.swift
@@ -37,4 +37,57 @@ struct CategoryAutocompleteStateTests {
     #expect(state.highlightedIndex == nil)
     #expect(state.justSelected == true)
   }
+
+  @Test
+  func testHighlightedSuggestionReturnsTheArrowKeyedRow() {
+    let groceriesId = UUID()
+    let gymId = UUID()
+    let categories = Categories(
+      from: [
+        Category(id: groceriesId, name: "Groceries"),
+        Category(id: gymId, name: "Gym"),
+      ])
+
+    var state = CategoryAutocompleteState(
+      showSuggestions: true,
+      highlightedIndex: 1,
+      justSelected: false
+    )
+
+    let highlighted = state.highlightedSuggestion(for: "G", in: categories)
+
+    // The visible-suggestion list is sorted by path (canonical category
+    // tree order), so index 1 of "G" is "Gym".
+    #expect(highlighted?.id == gymId)
+    #expect(highlighted?.path == "Gym")
+
+    state.highlightedIndex = nil
+    #expect(state.highlightedSuggestion(for: "G", in: categories) == nil)
+  }
+
+  @Test
+  func testHighlightedSuggestionReturnsNilForOutOfRangeIndex() {
+    let categories = Categories(from: [Category(id: UUID(), name: "Groceries")])
+
+    let state = CategoryAutocompleteState(
+      showSuggestions: true,
+      highlightedIndex: 5,
+      justSelected: false
+    )
+
+    #expect(state.highlightedSuggestion(for: "G", in: categories) == nil)
+  }
+
+  @Test
+  func testHighlightedSuggestionReturnsNilWhenDropdownHidden() {
+    let categories = Categories(from: [Category(id: UUID(), name: "Groceries")])
+
+    let state = CategoryAutocompleteState(
+      showSuggestions: false,
+      highlightedIndex: 0,
+      justSelected: false
+    )
+
+    #expect(state.highlightedSuggestion(for: "G", in: categories) == nil)
+  }
 }

--- a/MoolahTests/Features/PayeeAutocompleteStateTests.swift
+++ b/MoolahTests/Features/PayeeAutocompleteStateTests.swift
@@ -1,0 +1,43 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("PayeeAutocompleteState")
+struct PayeeAutocompleteStateTests {
+  @Test
+  func testCancelClosesDropdownWithoutArmingJustSelected() {
+    var state = PayeeAutocompleteState(
+      showSuggestions: true,
+      highlightedIndex: 2,
+      justSelected: false
+    )
+
+    state.cancel()
+
+    #expect(state.showSuggestions == false)
+    #expect(state.highlightedIndex == nil)
+    // `justSelected` must stay false: no binding-driven `onTextChange` is
+    // triggered by Escape (the text didn't change), so the next character
+    // the user types should be free to re-open the dropdown. Setting
+    // `justSelected = true` here would silently eat that next keystroke.
+    #expect(state.justSelected == false)
+  }
+
+  @Test
+  func testDismissArmsJustSelectedSoBindingDrivenOnChangeIsEaten() {
+    var state = PayeeAutocompleteState(
+      showSuggestions: true,
+      highlightedIndex: 1,
+      justSelected: false
+    )
+
+    state.dismiss()
+
+    #expect(state.showSuggestions == false)
+    #expect(state.highlightedIndex == nil)
+    // Used by the suggestion-acceptance path: the resulting binding write
+    // triggers an `onChange(of: text)` we want to ignore.
+    #expect(state.justSelected == true)
+  }
+}

--- a/MoolahTests/Shared/TransactionDraftCategoryTests.swift
+++ b/MoolahTests/Shared/TransactionDraftCategoryTests.swift
@@ -50,4 +50,80 @@ struct TransactionDraftCategoryTests {
     #expect(draft.categoryId == nil)
     #expect(draft.categoryText.isEmpty)
   }
+
+  // swiftlint:disable:next attributes
+  @Test func commitHighlightedAdoptsSuggestion() {
+    let catId = UUID()
+    let categories = Categories(from: [Category(id: catId, name: "Groceries")])
+    let suggestion = CategorySuggestion(id: catId, path: "Groceries")
+
+    var draft = support.makeExpenseDraft()
+    draft.categoryText = "groc"
+
+    draft.commitHighlightedCategoryOrNormalise(
+      highlighted: suggestion, using: categories)
+
+    #expect(draft.categoryId == catId)
+    #expect(draft.categoryText == "Groceries")
+  }
+
+  // swiftlint:disable:next attributes
+  @Test func commitFallsBackToNormaliseWhenNothingHighlighted() {
+    let catId = UUID()
+    let categories = Categories(from: [Category(id: catId, name: "Groceries")])
+
+    var draft = support.makeExpenseDraft()
+    draft.categoryId = catId
+    draft.categoryText = "groc"
+
+    draft.commitHighlightedCategoryOrNormalise(
+      highlighted: nil, using: categories)
+
+    #expect(draft.categoryId == catId)
+    #expect(draft.categoryText == "Groceries")
+  }
+
+  // swiftlint:disable:next attributes
+  @Test func commitFallsBackToNormaliseClearsUnknownText() {
+    let categories = Categories(from: [])
+
+    var draft = support.makeExpenseDraft()
+    draft.categoryText = "Made up"
+
+    draft.commitHighlightedCategoryOrNormalise(
+      highlighted: nil, using: categories)
+
+    #expect(draft.categoryId == nil)
+    #expect(draft.categoryText.isEmpty)
+  }
+
+  // swiftlint:disable:next attributes
+  @Test func commitHighlightedLegAdoptsSuggestion() {
+    let catId = UUID()
+    let categories = Categories(from: [Category(id: catId, name: "Groceries")])
+    let suggestion = CategorySuggestion(id: catId, path: "Groceries")
+
+    var draft = support.makeExpenseDraft()
+    draft.legDrafts[0].categoryText = "groc"
+
+    draft.commitHighlightedLegCategoryOrNormalise(
+      at: 0, highlighted: suggestion, using: categories)
+
+    #expect(draft.legDrafts[0].categoryId == catId)
+    #expect(draft.legDrafts[0].categoryText == "Groceries")
+  }
+
+  // swiftlint:disable:next attributes
+  @Test func commitFallsBackToLegNormaliseWhenNothingHighlighted() {
+    let categories = Categories(from: [])
+
+    var draft = support.makeExpenseDraft()
+    draft.legDrafts[0].categoryText = "Made up"
+
+    draft.commitHighlightedLegCategoryOrNormalise(
+      at: 0, highlighted: nil, using: categories)
+
+    #expect(draft.legDrafts[0].categoryId == nil)
+    #expect(draft.legDrafts[0].categoryText.isEmpty)
+  }
 }

--- a/MoolahUITests_macOS/Helpers/Fields/AutocompleteFieldDriver.swift
+++ b/MoolahUITests_macOS/Helpers/Fields/AutocompleteFieldDriver.swift
@@ -118,9 +118,26 @@ struct AutocompleteFieldDriver {
     }
   }
 
+  /// Sends a single Tab key press to the field. Returns once the
+  /// dropdown has hidden — by then focus has moved off the field, so the
+  /// blur handler has run. For category fields, that handler commits a
+  /// highlighted suggestion (#509); for payee, it preserves the user's
+  /// typed text (#510). Callers assert the resulting field value
+  /// separately.
+  func pressTab() {
+    Trace.record(detail: "field=\(fieldIdentifier)")
+    app.application.typeKey("\t", modifierFlags: [])
+    if !waitUntilDropdownHidden(timeout: 3) {
+      Trace.recordFailure("dropdown '\(dropdownIdentifier)' did not hide after Tab")
+      XCTFail(
+        "Autocomplete dropdown '\(dropdownIdentifier)' did not hide within 3s of Tab")
+    }
+  }
+
   /// Sends a single Escape key press to the field. Returns once the
-  /// dropdown has hidden. `AutocompleteField`'s escape handler also clears
-  /// the field binding — tests that care assert the value separately.
+  /// dropdown has hidden. The user's typed text is **not** cleared —
+  /// callers asserting the field value should still expect whatever the
+  /// user typed before pressing Escape (#510).
   func pressEscape() {
     Trace.record(detail: "field=\(fieldIdentifier)")
     app.application.typeKey(.escape, modifierFlags: [])

--- a/MoolahUITests_macOS/Tests/TransactionDetail/TransactionDetailCategoryTests.swift
+++ b/MoolahUITests_macOS/Tests/TransactionDetail/TransactionDetailCategoryTests.swift
@@ -1,0 +1,34 @@
+import XCTest
+
+/// Behaviour tests for the simple-mode category autocomplete dropdown on
+/// `TransactionDetailView`. The `.tradeBaseline` seed includes the
+/// "Groceries" and "Gym" categories so the prefix "G" yields two
+/// matches and the prefix "Gro" matches exactly one.
+@MainActor
+final class TransactionDetailCategoryTests: MoolahUITestCase {
+  /// Per [#509](https://github.com/ajsutton/moolah-native/issues/509),
+  /// arrow-key highlighting + Tab must commit the highlighted suggestion
+  /// — the same as Enter or clicking the suggestion. Without this, the
+  /// blur handler would dismiss the highlight, then the typed text would
+  /// fail to resolve to a known category, and the field would be
+  /// cleared. The fix lives in
+  /// `TransactionDraft.commitHighlightedCategoryOrNormalise(...)` and
+  /// the section's blur handler.
+  func testTabFromHighlightedCategoryCommitsSuggestion() {
+    let app = launch(seed: .tradeBaseline)
+
+    app.sidebar.switchToAccount(.checking)
+    app.transactionList.openTransaction(.bhpPurchase)
+
+    app.transactionDetail.category.tap()
+    app.transactionDetail.category.type("Gro")
+    app.transactionDetail.category.expectSuggestionsVisible(count: 1)
+    app.transactionDetail.category.pressArrowDown()
+    app.transactionDetail.category.expectHighlightedSuggestion(at: 0)
+
+    app.transactionDetail.category.pressTab()
+
+    app.transactionDetail.category.expectValue("Groceries")
+    app.transactionDetail.category.expectSuggestionsHidden()
+  }
+}

--- a/MoolahUITests_macOS/Tests/TransactionDetail/TransactionDetailPayeeAutocompleteTests.swift
+++ b/MoolahUITests_macOS/Tests/TransactionDetail/TransactionDetailPayeeAutocompleteTests.swift
@@ -53,7 +53,12 @@ final class TransactionDetailPayeeAutocompleteTests: MoolahUITestCase {
     app.transactionDetail.payee.expectSuggestionsHidden()
   }
 
-  func testEscapeClearsPayeeAndClosesDropdown() {
+  /// Escape closes the dropdown but must leave the user's typed text
+  /// alone. Per [#510](https://github.com/ajsutton/moolah-native/issues/510),
+  /// the user is in control of what is in the payee field — autocomplete
+  /// is an aid, not a constraint, so dismissing the dropdown without a
+  /// commit must not also wipe what the user has typed.
+  func testEscapeKeepsTypedTextAndClosesDropdown() {
     let app = launch(seed: .tradeBaseline)
 
     app.sidebar.switchToAccount(.checking)
@@ -65,7 +70,7 @@ final class TransactionDetailPayeeAutocompleteTests: MoolahUITestCase {
 
     app.transactionDetail.payee.pressEscape()
 
-    app.transactionDetail.payee.expectValue("")
+    app.transactionDetail.payee.expectValue("Wool")
     app.transactionDetail.payee.expectSuggestionsHidden()
   }
 

--- a/Shared/Models/AutocompleteDropdownState.swift
+++ b/Shared/Models/AutocompleteDropdownState.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+/// Shared dropdown-visibility state for autocomplete fields. Each
+/// suggestion-source-specific type (`PayeeAutocompleteState`,
+/// `CategoryAutocompleteState`, ...) conforms so the shared
+/// `dismiss()` and `cancel()` semantics live in one place.
+protocol AutocompleteDropdownState: Equatable {
+  /// `true` while the dropdown should render (subject to the
+  /// suggestion-source-specific gates that a non-empty query / non-empty
+  /// suggestion list adds).
+  var showSuggestions: Bool { get set }
+  /// Index of the visible suggestion that ↑/↓ have moved through and
+  /// that `Enter`/Tab will accept. `nil` means nothing is highlighted.
+  var highlightedIndex: Int? { get set }
+  /// Set when a suggestion is accepted so the binding-driven
+  /// `onChange(of: text)` that fires as a side effect of writing the
+  /// accepted value back into the field doesn't immediately re-open the
+  /// dropdown and re-fetch suggestions.
+  var justSelected: Bool { get set }
+}
+
+extension AutocompleteDropdownState {
+  /// Closes the dropdown and arms `justSelected`. Use this from the
+  /// suggestion-acceptance path: writing the accepted value back into
+  /// the field triggers an `onChange(of: text)` we want to ignore.
+  mutating func dismiss() {
+    justSelected = true
+    showSuggestions = false
+    highlightedIndex = nil
+  }
+
+  /// Closes the dropdown without arming `justSelected`. Use this when
+  /// the user dismisses the picker without changing the field text —
+  /// Escape, or moving focus away — so the next character they type is
+  /// still recognised as user-driven editing and re-opens the dropdown.
+  mutating func cancel() {
+    showSuggestions = false
+    highlightedIndex = nil
+  }
+}

--- a/Shared/Models/CategorySuggestion.swift
+++ b/Shared/Models/CategorySuggestion.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+/// Identifiable wrapper for a category suggestion in the dropdown.
+/// Defined here (rather than alongside the SwiftUI dropdown view) so
+/// `TransactionDraft` blur-handling helpers can take it as a parameter
+/// without pulling SwiftUI into the domain extension.
+struct CategorySuggestion: Identifiable, Equatable, Sendable {
+  let id: UUID
+  let path: String
+}

--- a/Shared/Models/TransactionDraft+SimpleMode.swift
+++ b/Shared/Models/TransactionDraft+SimpleMode.swift
@@ -95,6 +95,38 @@ extension TransactionDraft {
     }
   }
 
+  /// Commits the currently-highlighted suggestion to the simple-mode
+  /// category, falling back to `normaliseCategoryText(using:)` when no
+  /// suggestion is highlighted. Called from the category field's blur
+  /// handler so the suggestion the user navigated to with arrow keys is
+  /// captured even when they Tab or click out instead of pressing Enter
+  /// (#509). Without this, blurring with a highlight pending dropped the
+  /// suggestion and then cleared the typed text because the unmatched
+  /// path didn't resolve to any `categoryId`.
+  mutating func commitHighlightedCategoryOrNormalise(
+    highlighted: CategorySuggestion?, using categories: Categories
+  ) {
+    if let highlighted {
+      categoryId = highlighted.id
+      categoryText = highlighted.path
+    } else {
+      normaliseCategoryText(using: categories)
+    }
+  }
+
+  /// Per-leg variant of `commitHighlightedCategoryOrNormalise(...)`. See
+  /// that method's note for the motivation.
+  mutating func commitHighlightedLegCategoryOrNormalise(
+    at index: Int, highlighted: CategorySuggestion?, using categories: Categories
+  ) {
+    if let highlighted {
+      legDrafts[index].categoryId = highlighted.id
+      legDrafts[index].categoryText = highlighted.path
+    } else {
+      normaliseLegCategoryText(at: index, using: categories)
+    }
+  }
+
   /// Whether the "other account" label should read "From Account" instead of "To Account".
   /// True when viewing from the counterpart's perspective (the relevant leg is not the primary leg).
   var showFromAccount: Bool {

--- a/Shared/Views/AutocompleteField.swift
+++ b/Shared/Views/AutocompleteField.swift
@@ -17,6 +17,10 @@ struct AutocompleteField: View {
   let suggestionCount: Int
   let onTextChange: (String) -> Void
   let onAcceptHighlighted: () -> Void
+  /// Invoked when the user presses Escape with the dropdown visible. The
+  /// consumer should close the dropdown but **must not** clear the field
+  /// text — the user's typed content is what they want kept (#510).
+  let onCancel: () -> Void
 
   var body: some View {
     TextField(placeholder, text: $text)
@@ -42,12 +46,12 @@ struct AutocompleteField: View {
           return .handled
         }
         .onKeyPress(.escape) {
-          guard suggestionCount > 0 else { return .ignored }
-          highlightedIndex = nil
-          // Clear the binding directly — `.onChange(of: text)` will fire
-          // `onTextChange("")` as a side effect, propagating dropdown
-          // dismissal to the consumer.
-          text = ""
+          // Only consume Escape when there's something to dismiss; otherwise
+          // let the responder chain handle it (e.g. close the inspector).
+          guard suggestionCount > 0 || highlightedIndex != nil else {
+            return .ignored
+          }
+          onCancel()
           return .handled
         }
       #endif

--- a/Shared/Views/CategoryAutocompleteField.swift
+++ b/Shared/Views/CategoryAutocompleteField.swift
@@ -9,12 +9,6 @@ struct CategoryPickerAnchorKey: PreferenceKey {
   }
 }
 
-/// Identifiable wrapper for a category suggestion in the dropdown.
-struct CategorySuggestion: Identifiable {
-  let id: UUID
-  let path: String
-}
-
 /// A category autocomplete field using the same pattern as PayeeAutocompleteField.
 ///
 /// The text field shows the selected category path. Typing filters suggestions.
@@ -26,6 +20,7 @@ struct CategoryAutocompleteField: View {
   let suggestionCount: Int
   let onTextChange: (String) -> Void
   let onAcceptHighlighted: () -> Void
+  let onCancel: () -> Void
 
   var body: some View {
     AutocompleteField(
@@ -34,7 +29,8 @@ struct CategoryAutocompleteField: View {
       highlightedIndex: $highlightedIndex,
       suggestionCount: suggestionCount,
       onTextChange: onTextChange,
-      onAcceptHighlighted: onAcceptHighlighted
+      onAcceptHighlighted: onAcceptHighlighted,
+      onCancel: onCancel
     )
     .anchorPreference(key: CategoryPickerAnchorKey.self, value: .bounds) { $0 }
   }
@@ -106,6 +102,7 @@ struct LegCategoryAutocompleteField: View {
   let suggestionCount: Int
   let onTextChange: (String) -> Void
   let onAcceptHighlighted: () -> Void
+  let onCancel: () -> Void
 
   var body: some View {
     AutocompleteField(
@@ -114,7 +111,8 @@ struct LegCategoryAutocompleteField: View {
       highlightedIndex: $highlightedIndex,
       suggestionCount: suggestionCount,
       onTextChange: onTextChange,
-      onAcceptHighlighted: onAcceptHighlighted
+      onAcceptHighlighted: onAcceptHighlighted,
+      onCancel: onCancel
     )
     .anchorPreference(key: LegCategoryPickerAnchorKey.self, value: .bounds) { anchor in
       [legIndex: anchor]


### PR DESCRIPTION
## Summary

Fixes two related transaction-detail autocomplete bugs:

- [#509](https://github.com/ajsutton/moolah-native/issues/509) — arrow-key highlight + Tab in the category field cleared the field instead of committing the highlighted suggestion. The blur handler dismissed state and then \`normaliseCategoryText\` cleared text whose \`categoryId\` was never set.
- [#510](https://github.com/ajsutton/moolah-native/issues/510) — Escape in the payee field cleared the user's typed text. The shared \`AutocompleteField\` Escape handler hard-coded \`text = ""\`. Tab/click-out also didn't dismiss the dropdown for the payee field.

## Approach

- Extract \`CategorySuggestion\` to \`Shared/Models/\` so testable \`TransactionDraft\` extensions can take it without importing SwiftUI.
- Add \`commitHighlightedCategoryOrNormalise(highlighted:using:)\` and a per-leg variant on \`TransactionDraft\`. Section/leg blur handlers now capture the highlighted suggestion before dismissing and delegate to these methods.
- Add \`cancel()\` on \`PayeeAutocompleteState\` and \`CategoryAutocompleteState\` (closes the dropdown without arming \`justSelected\`, since no binding-driven \`onTextChange\` follows).
- Add an \`onCancel\` callback on \`AutocompleteField\`. Its Escape handler now invokes that instead of mutating text. All wrappers were updated to wire it.
- \`PayeeAutocompleteRow\` gains a private \`@FocusState\` to dismiss the dropdown on focus loss without clearing text.

## Tests

- New \`PayeeAutocompleteStateTests\`, \`CategoryAutocompleteStateTests\` — contrast \`cancel()\` (don't arm \`justSelected\`) with \`dismiss()\` (do).
- New \`TransactionDraft.commitHighlightedCategoryOrNormalise\` tests (simple + per-leg variants).
- Updated \`testEscapeKeepsTypedTextAndClosesDropdown\` (was \`…ClearsPayee…\`) — asserts the new payee Escape behaviour.
- New UI test \`testTabFromHighlightedCategoryCommitsSuggestion\` + a \`pressTab()\` driver method on \`AutocompleteFieldDriver\`.

## Test plan

- [x] \`just test-mac PayeeAutocompleteStateTests CategoryAutocompleteStateTests TransactionDraftCategoryTests\` — green
- [x] \`just test-mac TransactionDraft… TransactionStorePayScheduledTests TransactionStoreAutocompleteTests\` — no regressions
- [x] \`just build-mac\`, \`just build-ios\` — clean (warnings-as-errors on)
- [x] \`just format-check\` — clean
- [ ] \`just test-ui\` on CI — local screen was locked, deferring UI gate to CI
- [ ] CI green before merge-queue

Fixes #509
Fixes #510

🤖 Generated with [Claude Code](https://claude.com/claude-code)