### PR TITLE
fix(release): preflight fetches tags so release-next-version sees current state

### DIFF
--- a/scripts/release-preflight.sh
+++ b/scripts/release-preflight.sh
@@ -28,6 +28,10 @@ fi
 
 # 3. In sync with origin/main.
 git fetch origin main --quiet
+# Sync tags so downstream tag-based logic (e.g. release-next-version) sees the
+# same set as origin — otherwise stale local state can produce a wrong "next"
+# version. See https://github.com/ajsutton/moolah-native/issues/498.
+git fetch --tags --prune --force origin --quiet
 local_sha=$(git rev-parse HEAD)
 remote_sha=$(git rev-parse origin/main)
 if [[ "$local_sha" != "$remote_sha" ]]; then


### PR DESCRIPTION
## Summary
- `scripts/release-preflight.sh` now runs `git fetch --tags --prune --force origin --quiet` right after the existing `git fetch origin main --quiet`, so downstream tag-based logic (notably `release-next-version`) sees the same tag set as origin.
- Without this, an operator with stale local tags could pass preflight and then have `just release-next-version rc` compute a duplicate version (e.g. `1.1.0-rc.1` instead of `1.1.0-rc.2`). The existing-release check inside `release-create-rc.sh` would catch it, but the error wouldn't make the staleness obvious.

Fixes #498

## Test plan
- [x] `bash -n scripts/release-preflight.sh` (syntax check)
- [ ] Reviewer sanity-checks the diff (single new fetch line, idempotent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)