### PR TITLE
docs(plans): instrument registry UI design + implementation plan (#461)

### DIFF
--- a/plans/2026-04-27-instrument-registry-ui-design.md
+++ b/plans/2026-04-27-instrument-registry-ui-design.md
@@ -1,0 +1,388 @@
+# Instrument Registry UI — Design
+
+> Resolves [#461](https://github.com/ajsutton/moolah-native/issues/461). Builds on the backend foundation in
+> [`plans/completed/2026-04-24-instrument-registry-design.md`](completed/2026-04-24-instrument-registry-design.md). The CSV-import counterpart is tracked separately in [#515](https://github.com/ajsutton/moolah-native/issues/515).
+
+## 1. Goal
+
+Take the instrument-registry backend (registry repository, search service, token-resolution client) and turn it into a usable UI: a single instrument picker that handles fiat / stock / crypto end-to-end, a redesigned crypto-token "Add" flow, and a sync bridge so remote registrations show up locally without restart.
+
+## 2. Background
+
+The registry-UI scaffolding (`InstrumentPickerField`, `InstrumentPickerSheet`, `InstrumentPickerStore`) shipped earlier and is wired into every form that picks an instrument:
+
+| Form | File | Today |
+|---|---|---|
+| CloudKit profile creation | `Features/Profiles/Views/ProfileFormView.swift` | `kinds: [.fiatCurrency]` |
+| Moolah profile detail (3 fields) | `Features/Settings/MoolahProfileDetailView.swift` | `kinds: [.fiatCurrency]` |
+| Account create / edit | `Features/Accounts/Views/CreateAccountView.swift`, `EditAccountView.swift` | `kinds: [.fiatCurrency]` |
+| Earmark create / edit | `Features/Earmarks/Views/CreateEarmarkSheet.swift`, `EditEarmarkSheet.swift` | `kinds: [.fiatCurrency]` |
+| Transaction leg | `Features/Transactions/Views/Detail/TransactionDetailLegRow.swift` | `kinds: Set(Instrument.Kind.allCases)` |
+
+Today the picker store handles fiat (ambient) and stock (validate-via-price-probe → `registerStock`) but bails on unregistered crypto and hard-codes `providerSources: .stocksOnly` to defend against scam tokens surfaced by free-form CoinGecko search. Crypto registration only happens via `Features/Settings/AddTokenSheet.swift` — a contract-address form that asks the user to choose a chain and paste an address.
+
+Three other gaps remain:
+
+- `InstrumentRegistryRepository.observeChanges()` fires on local writes only. Remote pulls land in `ProfileDataSyncHandler+BatchUpsert.swift` and bypass the registry's fan-out, so a token registered on another device doesn't refresh the picker on this one.
+- `ensureInstrument` (called by CSV import via `CloudKitTransactionRepository`/`CloudKitAccountRepository`) silently inserts unmapped crypto `InstrumentRecord` rows, producing the `ConversionError.noProviderMapping` that the design doc §1.6 calls out.
+- Stock "search" is exact-ticker-only — there is no name-based lookup ("Apple" → `AAPL`).
+
+## 3. Design decisions (cross-reference)
+
+| # | Decision | Rationale |
+|---|---|---|
+| D1 | "Add Token" becomes search-only; the contract-address form is removed | Pricing depends on having a known mapping from a known provider — there is no path to price an arbitrary contract |
+| D2 | Crypto search is powered by a cached snapshot of CoinGecko `/coins/list?include_platform=true` | Free endpoint (no API key), instant in-app search, hands `(chain, contract)` directly to `resolve()` |
+| D3 | Snapshot lives in a dedicated SQLite database with FTS5 indexing | Pages in only what's needed; ~0 MiB resident when picker is closed; <5 ms FTS query vs ~8 ms linear over 17.5k entries; no ORM ceremony |
+| D4 | No DB migration framework: schema bumps drop the file and redownload | Catalog is rebuildable; migration framework is overkill |
+| D5 | `/asset_platforms` (chain-slug → numeric chain ID map) lives in the same DB | Single file, single refresh transaction |
+| D6 | Refresh policy: never block on download, 24 h max-age, ETag conditional GET, no manual button, silent failure | Pickers stay responsive; bandwidth is preserved when CoinGecko's CDN serves a stable ETag; users don't need to be told about a transient catalogue refresh failure |
+| D7 | "Resolve mapping" affordance is dropped; unmapped state is prevented at the boundary | `ensureInstrument` will throw on unmapped crypto, forcing CSV import (and any other caller) to register through the picker → resolve flow. Recovery UX for pre-existing rows and CSV imports is deferred to #515 |
+| D8 | Stock search uses Yahoo `/v1/finance/search?quotesCount=20`, filtered to `EQUITY ∪ ETF ∪ MUTUALFUND`; no post-select validation | Yahoo is already our price source; per-keystroke search is the only realistic shape (no bulk endpoint at this scale); skipping validation removes a redundant probe — the next price fetch is the real test |
+| D9 | Remote-change fan-out: `ProfileDataSyncHandler` accepts an `onInstrumentRemoteChange: @Sendable () -> Void` closure, fired once per sync transaction that touched any `InstrumentRecord` row (insert / update / delete / mapping-field change) | Mirrors the existing `onRecordChanged` / `onRecordDeleted` closure pattern, avoids cyclic deps between sync and registry, naturally testable |
+| D10 | The transaction-leg picker drops `providerSources: .stocksOnly` and gains crypto registration in `select(_:)` | With catalog-backed search the scam-token risk goes away; users can record a position leg in any kind without bouncing to Settings → Crypto |
+
+## 4. Component map
+
+### 4.1 `CoinGeckoCatalog` — new
+
+**Location:** `Shared/Catalog/CoinGeckoCatalog.swift` (+ supporting files in same directory).
+
+A `@MainActor`-confined facade plus an actor-isolated SQLite connection. Public surface:
+
+```swift
+struct CatalogEntry: Sendable, Hashable {
+  let coingeckoId: String
+  let symbol: String
+  let name: String
+  let platforms: [PlatformBinding]   // ordered by canonical-platform priority
+}
+
+struct PlatformBinding: Sendable, Hashable {
+  let slug: String                   // e.g. "ethereum", "polygon-pos"
+  let chainId: Int?                  // nil if slug not in /asset_platforms or unsupported
+  let contractAddress: String        // already lowercased
+}
+
+protocol CoinGeckoCatalog: Sendable {
+  /// Returns up to `limit` entries with their full platform list attached so
+  /// the picker's `select(_:)` has everything it needs to call `resolve()`.
+  func search(query: String, limit: Int) async -> [CatalogEntry]
+  /// Triggered once per app session; never blocks the caller.
+  func refreshIfStale() async
+}
+```
+
+The concrete implementation:
+
+- Owns one SQLite connection backed by `Application Support/InstrumentRegistry/catalog.sqlite`.
+- Initialises schema on first open, recreates the file when `meta.schema_version` doesn't match `CatalogSchema.version`.
+- Provides `search(query:limit:)` via FTS5 (see §6).
+- Triggers `refreshIfStale()` once per session (called from `ProfileSession` startup), which: reads `meta.last_fetched` + `meta.coins_etag` + `meta.platforms_etag`, kicks off two parallel HTTP requests with `If-None-Match`, parses the response if `200`, replaces all rows in a single transaction, updates the `meta` row.
+
+Refresh is fire-and-forget on a background `Task`. Failures are logged with `os_log` only.
+
+### 4.2 `InstrumentSearchService` — modified
+
+**Location:** `Shared/InstrumentSearchService.swift`.
+
+- Add a `catalog: CoinGeckoCatalog` dependency, replacing `CryptoSearchClient` on the crypto path.
+- Add a `stockSearchClient: any StockSearchClient` dependency (new protocol — see §4.3).
+- Keep `resolutionClient` and `stockValidator` (validator still has callers outside the picker).
+- The `search(query:kinds:providerSources:)` method:
+  - Fiat: unchanged (matches against `Locale.Currency.isoCurrencies`).
+  - Crypto (`kinds.contains(.cryptoToken)`): query catalog, return up to `limit` `InstrumentSearchResult`s with `requiresResolution: true` and `cryptoMapping: nil`. The `instrument.id` is built from the catalog entry's first usable platform (`<chainId>:<contractAddress>` or `<chainId>:native` when no platforms exist), so duplicates against registered rows can be detected.
+  - Stock (`kinds.contains(.stock)`): call `stockSearchClient.search(query:)`; map hits to `InstrumentSearchResult` with `requiresResolution: false` (Yahoo's search is itself the validator).
+- Drop the `providerSources` parameter — every call site can now safely surface every kind.
+
+### 4.3 `StockSearchClient` — new protocol
+
+**Location:** `Domain/Repositories/StockSearchClient.swift`, with a Yahoo implementation in `Backends/YahooFinance/YahooFinanceStockSearchClient.swift`.
+
+```swift
+struct StockSearchHit: Sendable, Hashable {
+  let symbol: String          // Yahoo ticker, e.g. "AAPL", "BHP.AX"
+  let name: String            // shortname or longname, whichever is non-empty, trimmed
+  let exchange: String        // e.g. "NMS", "ASX"
+  let quoteType: QuoteType    // EQUITY | ETF | MUTUALFUND
+}
+
+enum QuoteType: String, Sendable, Hashable {
+  case equity      = "EQUITY"
+  case etf         = "ETF"
+  case mutualFund  = "MUTUALFUND"
+}
+
+protocol StockSearchClient: Sendable {
+  func search(query: String) async throws -> [StockSearchHit]
+}
+```
+
+`YahooFinanceStockSearchClient.search` calls `https://query1.finance.yahoo.com/v1/finance/search?q=<q>&quotesCount=20&newsCount=0` and discards anything outside the three accepted `quoteType`s.
+
+### 4.4 `InstrumentPickerStore` — modified
+
+**Location:** `Shared/InstrumentPickerStore.swift`.
+
+Two changes:
+
+1. **Stop suppressing crypto.** Remove the `.stocksOnly` provider gate; the search service is the source of truth for what to show.
+2. **Register crypto on selection.** Extend `select(_:) async -> Instrument?`:
+   - If the selected result is registered (`isRegistered == true`): return its `Instrument` immediately (existing behaviour).
+   - If the selected result is unregistered crypto (`requiresResolution == true`, kind `.cryptoToken`):
+     - Set `isResolving = true`, clear `error`.
+     - Call `resolutionClient.resolve(chainId:contractAddress:symbol:isNative:)` with the catalog entry's chain/contract (or `isNative: true` and the symbol if there are no platforms).
+     - Build a `CryptoProviderMapping` from the result. Refuse to register if all three provider IDs are still nil — surface "Could not find a price source for this token" as `error` and return `nil`.
+     - Build an `Instrument` from the catalog entry plus resolved decimals.
+     - `await registry.registerCrypto(instrument, mapping: mapping)`; on success, return the instrument.
+   - If the selected result is unregistered stock: existing path (`registry.registerStock(instrument)`); continue to skip post-select validation.
+
+### 4.5 "Add Token" flow — rewritten
+
+**Location:** `Features/Settings/AddTokenSheet.swift` (rewrite), supporting wiring in `Features/Settings/CryptoSettingsView.swift`.
+
+The new `AddTokenSheet` is a thin wrapper around an `InstrumentPickerSheet` configured with `kinds: [.cryptoToken]`. On dismiss with a non-nil `Instrument`, the sheet invokes `store.loadRegistrations()` to refresh the displayed list.
+
+The contract-address form, chain enum, native/contract toggle, and the `CryptoTokenStore.resolveToken` / `confirmRegistration` orchestration go away. `CryptoTokenStore` keeps its loader, remover, and API-key methods.
+
+### 4.6 `CloudKitInstrumentRegistryRepository.notifyExternalChange()` — new
+
+**Location:** `Backends/CloudKit/Repositories/CloudKitInstrumentRegistryRepository.swift`.
+
+```swift
+@MainActor
+func notifyExternalChange() {
+  for continuation in subscribers.values { continuation.yield() }
+}
+```
+
+Concrete-class only. The protocol stays clean: `notifyExternalChange()` is plumbing, not part of the read/write contract.
+
+### 4.7 `ProfileDataSyncHandler` — modified
+
+**Locations:** `Backends/CloudKit/Sync/ProfileDataSyncHandler.swift` (+ `+BatchUpsert.swift`, `+QueueAndDelete.swift`, `+ApplyRemoteChanges.swift` as needed).
+
+- Add an `onInstrumentRemoteChange: @Sendable () -> Void` constructor parameter (default `{ }`).
+- In `batchUpsertInstruments`: track whether *any* `InstrumentRecord` row was inserted, updated, or had a mapping-field change. If so, after the transaction commits, call `onInstrumentRemoteChange()` exactly once.
+- In the deletion path: if any deleted record is an `InstrumentRecord`, call `onInstrumentRemoteChange()` once after the deletions commit.
+- In `ProfileSession+Factories.makeBackend`, after constructing the registry:
+  ```swift
+  onInstrumentRemoteChange: { [registry] in
+    Task { @MainActor in registry.notifyExternalChange() }
+  }
+  ```
+
+Subscribers re-fetch via `all()` / `allCryptoRegistrations()` on every yield; the `Void` payload is a signal, not a diff. We do not coalesce — first batch and a follow-up local write produce two yields, which is fine.
+
+### 4.8 `ensureInstrument` tightening
+
+**Locations:** `Backends/CloudKit/Repositories/CloudKitTransactionRepository.swift:55`, `CloudKitAccountRepository.swift:188`.
+
+The crypto path of `ensureInstrument`:
+
+- If a row already exists in `InstrumentRecord` and it has at least one of `coingeckoId` / `cryptocompareSymbol` / `binanceSymbol` populated, it is treated as registered — proceed.
+- Otherwise (no row, or row exists with all three mapping fields nil) → throw a new `RepositoryError.unmappedCryptoInstrument(instrumentId:)`.
+
+Fiat continues to be ambient — `ensureInstrument` is a no-op-with-cache for `kind == .fiatCurrency`. Stocks are out of scope for this plan: the existing CSV parsers do not produce unmapped stock rows in the same way the crypto path does, and tightening the stock precondition without a clear motivating failure would risk regressing imports. If a real gap surfaces it gets its own follow-up.
+
+After this lands, CSV imports of unknown tokens will fail noisily and the import store is expected to surface that failure as a hard import error. The user-facing recovery UX is the subject of #515.
+
+## 5. Data flow scenarios
+
+### 5.1 User registers crypto via Settings → Crypto → Add Token
+
+1. User taps Add Token. `AddTokenSheet` opens an `InstrumentPickerSheet` with `kinds: [.cryptoToken]`.
+2. User types `pepe`. Picker store debounces 250 ms, then calls `searchService.search(query:"pepe", kinds:[.cryptoToken])`.
+3. Search service queries `coinGeckoCatalog.search(query:"pepe", limit: …)`. FTS5 returns the matching rows (BM25-ranked, capped). Service maps them to `InstrumentSearchResult` (`requiresResolution: true`).
+4. Picker shows results grouped under a "Crypto" section.
+5. User selects "Pepe (PEPE)". `InstrumentPickerStore.select(_:)` calls `resolutionClient.resolve(chainId: 1, contractAddress: "0x6982…", symbol: "pepe", isNative: false)`.
+6. Resolver hits CryptoCompare's coin list (cached) and Binance's exchange info (cached for the resolver's session) and, if a CoinGecko Pro API key is present, the contract-lookup endpoint. Result: `coingeckoId: "pepe"`, `cryptocompareSymbol: "PEPE"`, `binanceSymbol: "PEPEUSDT"` (illustrative — actual values depend on availability).
+7. Picker store calls `registry.registerCrypto(instrument, mapping:)`. Registry writes both rows, fires `observeChanges()`, returns.
+8. Sheet dismisses with the new `Instrument`. `CryptoTokenStore.loadRegistrations()` refreshes the list, the new row appears.
+
+### 5.2 User registers crypto from a transaction-leg picker
+
+Same as 5.1 except `kinds: Set(Instrument.Kind.allCases)` and the resulting `Instrument` is bound to the leg's instrument field rather than a Settings list. The user does not need to pre-register crypto from Settings to record a position — that is the UX win promised in §3 D10.
+
+### 5.3 Another device registers a token; this device's picker reflects it
+
+1. User on Mac runs flow 5.1; CKSyncEngine queues the new `InstrumentRecord` for upload.
+2. iPhone in the user's pocket receives a push, runs an incremental sync.
+3. `ProfileDataSyncHandler.batchUpsertInstruments` upserts the row. The transaction commits; the handler calls `onInstrumentRemoteChange()`.
+4. The closure dispatches onto MainActor and calls `registry.notifyExternalChange()`, which yields `Void` to every active subscriber.
+5. Any open picker re-runs `loadRegistrations()` (or equivalent) and the new token appears without a tab switch or app relaunch.
+
+### 5.4 Catalogue refresh
+
+1. App launch: `ProfileSession` (CloudKit-backed only) calls `coinGeckoCatalog.refreshIfStale()`.
+2. Catalog reads `meta.last_fetched`. If `< 24h` ago, returns immediately.
+3. Otherwise, opens two parallel `URLSession.data(for:)` requests:
+   - `GET https://api.coingecko.com/api/v3/coins/list?include_platform=true` with `If-None-Match: <coins_etag>`.
+   - `GET https://api.coingecko.com/api/v3/asset_platforms` with `If-None-Match: <platforms_etag>`.
+4. For each `200 OK`: parse the JSON, run a single replace-all transaction (`DELETE … ; INSERT …` per affected table; FTS triggers keep `coin_fts` in sync). Store the new ETag and `Date()` into `meta`.
+5. Either response `304 Not Modified`: leave that table's data alone, but still update `last_fetched` to suppress re-attempts for 24 h.
+6. Any thrown error: `os_log` at error level; do not update `last_fetched` so a retry happens on the next launch.
+
+### 5.5 CSV import encounters an unknown crypto token
+
+1. Parser builds an `Instrument.crypto(chainId:contractAddress:symbol:name:decimals:)` for a row that references a token not in the registry.
+2. `CloudKitTransactionRepository.ensureInstrument(_:)` (or the account variant) throws `RepositoryError.unmappedCryptoInstrument(instrumentId:)`.
+3. Import pipeline aborts the offending leg(s) and surfaces the failure to the import UI as a hard error. **Recovery UX (a "Review unknown tokens" step) is the subject of [#515](https://github.com/ajsutton/moolah-native/issues/515).**
+
+## 6. SQLite schema (catalog.sqlite)
+
+```sql
+PRAGMA journal_mode = WAL;
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE meta (
+  schema_version  INTEGER NOT NULL,
+  last_fetched    REAL,        -- unix seconds, NULL until first successful fetch
+  coins_etag      TEXT,
+  platforms_etag  TEXT
+);
+INSERT INTO meta (schema_version) VALUES (1);
+
+CREATE TABLE coin (
+  rowid          INTEGER PRIMARY KEY,
+  coingecko_id   TEXT NOT NULL UNIQUE,
+  symbol         TEXT NOT NULL,
+  name           TEXT NOT NULL
+);
+
+CREATE TABLE coin_platform (
+  coingecko_id     TEXT NOT NULL,
+  platform_slug    TEXT NOT NULL,
+  contract_address TEXT NOT NULL,
+  PRIMARY KEY (coingecko_id, platform_slug),
+  FOREIGN KEY (coingecko_id) REFERENCES coin(coingecko_id) ON DELETE CASCADE
+);
+
+CREATE INDEX coin_platform_chain_contract
+  ON coin_platform(platform_slug, contract_address);
+
+CREATE TABLE platform (
+  slug      TEXT PRIMARY KEY,
+  chain_id  INTEGER,        -- nullable: not every CoinGecko platform is EVM-shaped
+  name      TEXT NOT NULL
+);
+
+CREATE VIRTUAL TABLE coin_fts USING fts5(
+  symbol, name,
+  content='coin',
+  content_rowid='rowid',
+  tokenize='unicode61 remove_diacritics 1'
+);
+
+-- triggers keep coin_fts in sync with coin
+CREATE TRIGGER coin_ai AFTER INSERT ON coin BEGIN
+  INSERT INTO coin_fts(rowid, symbol, name) VALUES (new.rowid, new.symbol, new.name);
+END;
+CREATE TRIGGER coin_ad AFTER DELETE ON coin BEGIN
+  INSERT INTO coin_fts(coin_fts, rowid, symbol, name) VALUES('delete', old.rowid, old.symbol, old.name);
+END;
+CREATE TRIGGER coin_au AFTER UPDATE ON coin BEGIN
+  INSERT INTO coin_fts(coin_fts, rowid, symbol, name) VALUES('delete', old.rowid, old.symbol, old.name);
+  INSERT INTO coin_fts(rowid, symbol, name) VALUES (new.rowid, new.symbol, new.name);
+END;
+```
+
+**Search query (two steps so the per-platform fan-out doesn't break `LIMIT`):**
+
+```sql
+-- step 1: top-N matching coins, ranked by BM25
+SELECT c.coingecko_id, c.symbol, c.name
+FROM coin_fts JOIN coin c ON c.rowid = coin_fts.rowid
+WHERE coin_fts MATCH ?
+ORDER BY rank
+LIMIT ?;
+
+-- step 2: platforms for those coins (single round-trip, parameterised IN)
+SELECT cp.coingecko_id, cp.platform_slug, cp.contract_address, p.chain_id
+FROM coin_platform cp
+LEFT JOIN platform p ON p.slug = cp.platform_slug
+WHERE cp.coingecko_id IN (?, ?, …);
+```
+
+Caller passes the user's query as `?1` with a `*` suffix so prefix matching kicks in (`btc*` matches `BTC`, `BTCB`, …). Exact symbol hits naturally rank above tokenised name hits because BM25 weights the matched column. After step 2, results are merged in code: each `CatalogEntry` carries a `[PlatformBinding]` ordered by the priority list in §13 (ETH → Polygon → BSC → Base → Arbitrum → Optimism → Avalanche → fallback to step-2 row order). Coins with **no** platforms (CoinGecko's "platformless" entries — typically cross-chain natives) are returned with an empty `platforms` array and the picker's `select(_:)` calls `resolve()` with `isNative: true` and the coin symbol.
+
+**Replace-all transaction (refresh):**
+
+```sql
+BEGIN IMMEDIATE;
+DELETE FROM coin;            -- cascades into coin_platform; FTS triggers keep coin_fts current
+INSERT INTO coin(...) VALUES (?, ?, ?), ...;  -- batched
+INSERT INTO coin_platform(...) VALUES (?, ?, ?), ...;
+COMMIT;
+```
+
+Asset-platform refresh uses the same shape on `platform`.
+
+`coin.symbol` and `coin.name` are stored verbatim. FTS handles case-insensitivity; we don't store a redundant lowercased copy.
+
+## 7. Error handling
+
+| Path | Failure | Behaviour |
+|---|---|---|
+| Catalog refresh | network error / non-200 / non-304 | `os_log .error`; don't update `last_fetched`; pickers continue serving previous snapshot |
+| Catalog refresh | JSON parse error | `os_log .error`; abort the replace-all transaction (snapshot unchanged); same retry semantics |
+| Catalog open | corrupt SQLite file | recreate the file (drop + create fresh schema); `os_log .info` |
+| Catalog search | query against empty catalog | return `[]`; pickers show empty crypto section |
+| Stock search | Yahoo error | `os_log .error`; surface a transient "Search failed — try again" banner inside the picker only |
+| `resolve()` | all three provider IDs `nil` | `InstrumentPickerStore` surfaces "Could not find a price source for this token" as `error`, returns `nil`. No registration is written |
+| `resolve()` | network error | `InstrumentPickerStore` surfaces a generic "Couldn't reach token resolver" error; same no-write semantics |
+| `registerCrypto` / `registerStock` | repository throws | propagate to picker store `error`; the row is not written; the picker remains open so the user can retry |
+| `ensureInstrument` (crypto) | unmapped row | throw `RepositoryError.unmappedCryptoInstrument`; CSV-import handling is #515 |
+
+## 8. Concurrency
+
+- `CoinGeckoCatalog` is an actor (or `@unchecked Sendable` wrapping a serial queue); its public methods are `async`. Refresh runs on a `Task.detached(priority: .background)` so it never blocks the caller.
+- `InstrumentSearchService` stays a `Sendable struct`; nothing it does is now stateful (`stockSearchClient` and `coinGeckoCatalog` are themselves Sendable).
+- `InstrumentPickerStore` stays `@MainActor @Observable`. The new crypto branch in `select(_:)` does its `resolve()` call off-main (the resolver is already non-isolated) and hops back via the existing main-actor confinement of the store.
+- `CloudKitInstrumentRegistryRepository.notifyExternalChange()` is `@MainActor`; the closure passed to the sync handler hops onto `MainActor` before invoking it.
+
+All threading guidance in `guides/CONCURRENCY_GUIDE.md` continues to apply.
+
+## 9. Testing strategy
+
+| Surface | Tests |
+|---|---|
+| `CoinGeckoCatalog` | golden-snapshot tests using fixture JSON shipped under `MoolahTests/Support/Fixtures/CoinGecko/`; covers schema-version bump, ETag round-trip, replace-all transaction, FTS query, refresh failures keep prior snapshot |
+| `YahooFinanceStockSearchClient` | URLProtocol-stubbed fixture against `MoolahTests/Support/Fixtures/Yahoo/search-apple.json`; covers parsing, quoteType filtering, trim of stray whitespace |
+| `InstrumentSearchService` | injected fakes for catalog and stock client; covers fiat ambient, crypto-from-catalog, stock-from-search, mixed-kinds dedup against registered rows |
+| `InstrumentPickerStore` | drives `select(_:)` against a fake registry + fake resolver; covers the four selection branches (registered, unregistered crypto, unregistered stock, error path with all-nil resolver result) |
+| `CloudKitInstrumentRegistryRepository.notifyExternalChange()` | MainActor unit test that subscribes via `observeChanges()` and asserts a yield happens after a manual `notifyExternalChange()` call |
+| `ProfileDataSyncHandler` change-fan-out | sync-handler test using `TestBackend`; runs a fake remote upsert touching an `InstrumentRecord`, asserts the `onInstrumentRemoteChange` closure fires exactly once |
+| `ensureInstrument` tightening | repository contract tests; covers throw on unmapped crypto, success on mapped crypto, success on fiat |
+| End-to-end picker UX | XCUITest (macOS) under `MoolahUITests_macOS`: type a stock name → register; type a crypto symbol → register; verify the new instrument shows in the post-flow form. Seeds a deterministic catalog DB for the test profile so search results are stable |
+
+The CoinGecko / Yahoo network paths are never hit live in tests — every external call is fixture-stubbed via `URLProtocol`.
+
+## 10. Telemetry and accessibility
+
+- Catalog refresh outcomes are logged via `os_log` to the existing `instrument-registry` subsystem with categories `catalog.refresh` and `catalog.search`. We log the count of rows replaced on a successful refresh and the duration. No personally-identifying data.
+- New picker rows (stock and crypto search hits) gain an `accessibilityLabel` of `"<symbol>, <name>, <kind>"` (e.g. "AAPL, Apple Inc., stock"). This matches the existing fiat-row pattern.
+- The `AddTokenSheet` reuses `InstrumentPickerSheet`'s existing `accessibilityIdentifier("instrumentPicker.sheet")` — no new identifiers needed for screen-driver wiring.
+
+## 11. Migration notes
+
+This design intentionally does **not** migrate pre-existing unmapped `InstrumentRecord` rows. After this work ships, those rows continue to throw `ConversionError.noProviderMapping` whenever they are priced — the same behaviour as before. The recovery UX (one-shot "Review tokens" sheet at app launch, or in-line per-account affordance) is bundled into [#515](https://github.com/ajsutton/moolah-native/issues/515) so it can be designed alongside the CSV-import "Review unknown tokens" step that produces the same data shape.
+
+## 12. Out of scope
+
+- Server-side moolah-server changes (single-instrument backend; registry doesn't apply).
+- The CSV-import "Review unknown tokens" step (#515).
+- Any UI or migration for pre-existing unmapped `InstrumentRecord` rows (#515).
+- Replacing the resolution client's CryptoCompare/Binance/CoinGecko-Pro plumbing — the existing `CompositeTokenResolutionClient` is reused as-is.
+- Live crypto price fetching from new sources; the bulk catalogue is metadata only, not prices.
+- Non-EVM chain handling beyond what `/asset_platforms` already provides (Solana, Cosmos, etc.) — `chain_id` is nullable on the `platform` table for exactly this case; resolution falls through to native-symbol matching.
+- Bulk stock lists (no good source at the size we need; per-keystroke search is the design).
+
+## 13. Risks and follow-ups
+
+- **CoinGecko CDN ETag rotation.** Sometimes weak ETags rotate even when data is unchanged, so we'll occasionally re-download a 2.5 MB JSON we already had. Acceptable; correctness is unaffected.
+- **Catalogue staleness for brand-new tokens.** A token launched within the last 24 h may not appear in search until the next refresh window. For v1 this is acceptable; if it becomes a real complaint, the follow-up is a "Refresh" button in Settings → Crypto.
+- **Yahoo `/v1/finance/search` is undocumented.** Yahoo could break or rate-limit it. We already depend on Yahoo for prices, so the blast radius is the same as today.
+- **`platform.chain_id IS NULL`.** Some CoinGecko platforms have no canonical numeric chain ID (e.g. non-EVM or oddly-mapped chains). Such platforms are excluded from crypto-search results; coins whose *only* platforms have null chain IDs will be omitted (rare). This keeps `Instrument.id` shapes consistent.
+- **Multi-platform coins.** A coin like USDC is on ten chains. Picker behaviour: the user sees the coin once; on select we pick the highest-priority platform in `PlatformBinding` order (ETH → Polygon → BSC → Base → Arbitrum → Optimism → Avalanche → fallback to first). The user can later register the *same* coin on a different chain through the picker; the registry treats them as separate `Instrument`s by `<chainId>:<contract>` id. Acceptable for v1; richer "which chain?" UX is a follow-up if real users hit it.
+- **Provider-mapping coverage.** Even after `resolve()` runs, some coins return all three IDs nil (very obscure or very new). We already refuse to register in this case; users see an inline error and the row is not written. No silent partial-success.

--- a/plans/2026-04-27-instrument-registry-ui-implementation.md
+++ b/plans/2026-04-27-instrument-registry-ui-implementation.md
@@ -1,0 +1,2962 @@
+# Instrument Registry UI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire the existing instrument registry backend into a usable UI: a curated `/coins/list`-backed crypto picker, Yahoo-backed stock search, a sync→registry change-fan-out, and a tightened `ensureInstrument` boundary.
+
+**Architecture:** Bottom-up. (1) Stand up a new SQLite-backed `CoinGeckoCatalog` and integrate `refreshIfStale()` into the session lifecycle. (2) Add a parallel `StockSearchClient` over Yahoo's name-search endpoint. (3) Rewire `InstrumentSearchService` and `InstrumentPickerStore` so the picker handles fiat / stock / crypto registration end-to-end. (4) Replace the contract-address `AddTokenSheet` with a thin search-only wrapper. (5) Add a `notifyExternalChange()` fan-out that sync uses. (6) Tighten `ensureInstrument` so the unmapped-crypto state cannot recur. (7) End-to-end UI test.
+
+**Tech Stack:** Swift 6 strict concurrency, SwiftUI, SwiftData (existing), `SQLite3` (system), `URLSession`, XCTest, XCUITest.
+
+**Reference:** [`plans/2026-04-27-instrument-registry-ui-design.md`](2026-04-27-instrument-registry-ui-design.md) for design rationale and decision tags D1–D10.
+
+---
+
+## File Map
+
+### New files (production)
+
+- `Shared/CoinGeckoCatalog.swift` — protocol + value types (`CatalogEntry`, `PlatformBinding`).
+- `Backends/CoinGecko/SQLiteCoinGeckoCatalog.swift` — concrete actor combining SQLite store and refresh logic.
+- `Backends/CoinGecko/CoinGeckoCatalogSchema.swift` — schema constant + version. Bumping the version invalidates existing files.
+- `Domain/Repositories/StockSearchClient.swift` — protocol + `StockSearchHit`, `QuoteType`.
+- `Backends/YahooFinance/YahooFinanceStockSearchClient.swift` — Yahoo `/v1/finance/search` impl.
+- `Domain/Repositories/RepositoryError.swift` — only if not already present; otherwise extend in place.
+
+### Modified production files
+
+- `Shared/InstrumentSearchService.swift` — replaces `CryptoSearchClient` with `CoinGeckoCatalog`; adds `StockSearchClient` dependency; drops `providerSources`.
+- `Shared/InstrumentPickerStore.swift` — drops `.stocksOnly`; extends `select(_:)` to register crypto via `resolve()` → `registerCrypto`.
+- `Features/Settings/AddTokenSheet.swift` — rewritten as a thin `InstrumentPickerSheet` wrapper.
+- `Features/Settings/CryptoTokenStore.swift` — drops `resolveToken`, `confirmRegistration`, `resolvedRegistration`, `isResolving`.
+- `Backends/CloudKit/Repositories/CloudKitInstrumentRegistryRepository.swift` — adds `notifyExternalChange()`.
+- `Backends/CloudKit/Sync/ProfileDataSyncHandler.swift` (and `+BatchUpsert.swift`, `+QueueAndDelete.swift`) — accept `onInstrumentRemoteChange: @Sendable () -> Void`; fire once per sync transaction that touched any `InstrumentRecord`.
+- `App/ProfileSession+Factories.swift` — wires the new closure and the catalog into the registry/search-service factory.
+- `Backends/CloudKit/Repositories/CloudKitTransactionRepository.swift` — `ensureInstrument` throws on unmapped crypto.
+- `Backends/CloudKit/Repositories/CloudKitAccountRepository.swift` — same.
+
+### Test files (new)
+
+- `MoolahTests/Backends/SQLiteCoinGeckoCatalogTests.swift`
+- `MoolahTests/Backends/YahooFinanceStockSearchClientTests.swift`
+- `MoolahTests/Shared/InstrumentSearchServiceTests.swift` (extend if exists)
+- `MoolahTests/Shared/InstrumentPickerStoreTests.swift` (extend if exists)
+- `MoolahTests/Backends/CloudKit/CloudKitInstrumentRegistryRepositoryTests.swift` (extend if exists; otherwise create)
+- `MoolahTests/Backends/CloudKit/Sync/ProfileDataSyncHandlerInstrumentChangeTests.swift`
+- `MoolahTests/Backends/CloudKit/CloudKitTransactionRepositoryEnsureInstrumentTests.swift`
+- `MoolahTests/Backends/CloudKit/CloudKitAccountRepositoryEnsureInstrumentTests.swift`
+- `MoolahUITests_macOS/InstrumentPickerCryptoSearchTests.swift`
+- `MoolahTests/Support/Fixtures/coingecko-coins-list-small.json` (≤30 entries; ETag `W/"a"`)
+- `MoolahTests/Support/Fixtures/coingecko-coins-list-small-updated.json` (same shape, different rows; ETag `W/"b"`)
+- `MoolahTests/Support/Fixtures/coingecko-asset-platforms.json`
+- `MoolahTests/Support/Fixtures/yahoo-finance-search-apple.json`
+
+### Conventions
+
+- Every command runs from the worktree root (`.worktrees/instrument-registry-ui-impl`).
+- Pipe test output to `.agent-tmp/<descriptive-name>.txt` per CLAUDE.md.
+- `just generate` after editing `project.yml`.
+- `just format` before every commit.
+- Test seeds: `MoolahTests/Support/TestCurrency.swift` provides `Currency.defaultTestCurrency`.
+
+---
+
+## Task Index
+
+| # | Task | Layer |
+|---|---|---|
+| 1 | `CoinGeckoCatalog` protocol + value types | Shared |
+| 2 | `CoinGeckoCatalogSchema` constant | Backend |
+| 3 | `SQLiteCoinGeckoCatalog` — open / schema bootstrap / replace-all transaction | Backend |
+| 4 | `SQLiteCoinGeckoCatalog` — FTS5 search (two-step) | Backend |
+| 5 | `SQLiteCoinGeckoCatalog` — ETag-aware refresh | Backend |
+| 6 | `StockSearchClient` protocol + `YahooFinanceStockSearchClient` | Backend |
+| 7 | `InstrumentSearchService`: catalog + stock search, drop `providerSources` | Shared |
+| 8 | `ProfileSession` integration: build the catalog, call `refreshIfStale()` | App |
+| 9 | `InstrumentPickerStore`: register crypto on `select(_:)`, drop `.stocksOnly` | Shared |
+| 10 | `AddTokenSheet` rewrite + `CryptoTokenStore` trim | UI |
+| 11 | `CloudKitInstrumentRegistryRepository.notifyExternalChange()` | Backend |
+| 12 | Sync change-fan-out: `ProfileDataSyncHandler` + closure wiring | Backend / Sync |
+| 13 | `RepositoryError.unmappedCryptoInstrument` case | Domain |
+| 14 | Tighten `ensureInstrument` — transaction repo | Backend |
+| 15 | Tighten `ensureInstrument` — account repo | Backend |
+| 16 | XCUITest: register a crypto token from the picker | UI test |
+
+Branch: `feature/instrument-registry-ui` (one PR per task; queue via merge-queue per project policy).
+
+---
+
+## Task 1 — `CoinGeckoCatalog` protocol + value types
+
+**Files:**
+- Create: `Shared/CoinGeckoCatalog.swift`
+- Test: `MoolahTests/Shared/CoinGeckoCatalogTypesTests.swift`
+
+- [ ] **Step 1: Write the failing test**
+
+```swift
+// MoolahTests/Shared/CoinGeckoCatalogTypesTests.swift
+import XCTest
+@testable import Moolah
+
+final class CoinGeckoCatalogTypesTests: XCTestCase {
+  func testPlatformBindingNormalisesContractAddressToLowercase() {
+    let binding = PlatformBinding(slug: "ethereum", chainId: 1, contractAddress: "0xABCDef1234")
+    XCTAssertEqual(binding.contractAddress, "0xabcdef1234")
+  }
+
+  func testCatalogEntryReturnsHighestPriorityPlatform() {
+    let entry = CatalogEntry(
+      coingeckoId: "usd-coin",
+      symbol: "USDC",
+      name: "USD Coin",
+      platforms: [
+        PlatformBinding(slug: "polygon-pos", chainId: 137, contractAddress: "0xpolygon"),
+        PlatformBinding(slug: "ethereum", chainId: 1, contractAddress: "0xethereum"),
+      ]
+    )
+    XCTAssertEqual(entry.preferredPlatform?.slug, "ethereum")
+  }
+
+  func testCatalogEntryWithoutPlatformsReturnsNilPreferred() {
+    let entry = CatalogEntry(coingeckoId: "btc", symbol: "BTC", name: "Bitcoin", platforms: [])
+    XCTAssertNil(entry.preferredPlatform)
+  }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+mkdir -p .agent-tmp
+just test CoinGeckoCatalogTypesTests 2>&1 | tee .agent-tmp/task1.txt
+```
+
+Expected: FAIL with `cannot find 'PlatformBinding' in scope` (or similar — type doesn't exist yet).
+
+- [ ] **Step 3: Add the file to project.yml + write the implementation**
+
+Add `Shared/CoinGeckoCatalog.swift` to the `Moolah` target's source group in `project.yml` if not auto-globbed (verify by running `just generate` and checking the resulting Xcode project).
+
+```swift
+// Shared/CoinGeckoCatalog.swift
+import Foundation
+
+/// One coin from the cached CoinGecko catalogue snapshot. Carries every
+/// platform binding the picker needs to call `TokenResolutionClient.resolve()`.
+struct CatalogEntry: Sendable, Hashable, Identifiable {
+  let coingeckoId: String
+  let symbol: String
+  let name: String
+  let platforms: [PlatformBinding]
+
+  var id: String { coingeckoId }
+
+  /// First platform binding by canonical priority — used by the picker to
+  /// resolve a search hit to a `(chainId, contractAddress)` pair. `nil`
+  /// when the coin is platformless (cross-chain natives like BTC, ETH).
+  var preferredPlatform: PlatformBinding? { platforms.first }
+}
+
+/// One coin's binding to a single chain. `chainId` is `nil` when the
+/// platform slug isn't known to `/asset_platforms` (typically non-EVM).
+struct PlatformBinding: Sendable, Hashable {
+  let slug: String
+  let chainId: Int?
+  let contractAddress: String
+
+  init(slug: String, chainId: Int?, contractAddress: String) {
+    self.slug = slug
+    self.chainId = chainId
+    self.contractAddress = contractAddress.lowercased()
+  }
+}
+
+/// Read-only catalogue of CoinGecko coins. Backed by a refreshable SQLite
+/// snapshot of `/coins/list?include_platform=true`. See
+/// `plans/2026-04-27-instrument-registry-ui-design.md` §4.1 / §6 for shape.
+protocol CoinGeckoCatalog: Sendable {
+  /// Returns up to `limit` matching entries with their full platform list
+  /// attached, ordered by FTS BM25 rank. Empty when the snapshot is missing
+  /// or the query has no hits.
+  func search(query: String, limit: Int) async -> [CatalogEntry]
+
+  /// Triggered once per app session. Never blocks the caller; refresh runs
+  /// on a background task and logs failures via `os_log`. Honours the 24 h
+  /// max-age and ETag conditional-GET semantics described in design §5.4.
+  func refreshIfStale() async
+}
+```
+
+`CatalogEntry`'s `platforms` ordering is established by `SQLiteCoinGeckoCatalog` (Task 4). The `preferredPlatform` accessor is a derived convenience.
+
+- [ ] **Step 4: Run tests to verify they pass + format**
+
+```bash
+just test CoinGeckoCatalogTypesTests 2>&1 | tee .agent-tmp/task1.txt
+just format
+```
+
+Expected: 3 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Shared/CoinGeckoCatalog.swift MoolahTests/Shared/CoinGeckoCatalogTypesTests.swift project.yml
+git commit -m "feat(catalog): add CoinGeckoCatalog protocol and value types"
+rm .agent-tmp/task1.txt
+```
+
+---
+
+## Task 2 — `CoinGeckoCatalogSchema` constant
+
+**Files:**
+- Create: `Backends/CoinGecko/CoinGeckoCatalogSchema.swift`
+- Test: `MoolahTests/Backends/CoinGeckoCatalogSchemaTests.swift`
+
+- [ ] **Step 1: Write the failing test**
+
+```swift
+// MoolahTests/Backends/CoinGeckoCatalogSchemaTests.swift
+import XCTest
+@testable import Moolah
+
+final class CoinGeckoCatalogSchemaTests: XCTestCase {
+  func testSchemaVersionStartsAtOne() {
+    XCTAssertEqual(CoinGeckoCatalogSchema.version, 1)
+  }
+
+  func testSchemaContainsCoreTables() {
+    let ddl = CoinGeckoCatalogSchema.statements.joined(separator: "\n")
+    XCTAssertTrue(ddl.contains("CREATE TABLE meta"))
+    XCTAssertTrue(ddl.contains("CREATE TABLE coin"))
+    XCTAssertTrue(ddl.contains("CREATE TABLE coin_platform"))
+    XCTAssertTrue(ddl.contains("CREATE TABLE platform"))
+    XCTAssertTrue(ddl.contains("CREATE VIRTUAL TABLE coin_fts USING fts5"))
+  }
+
+  func testSchemaInstallsFtsTriggers() {
+    let ddl = CoinGeckoCatalogSchema.statements.joined(separator: "\n")
+    XCTAssertTrue(ddl.contains("CREATE TRIGGER coin_ai"))
+    XCTAssertTrue(ddl.contains("CREATE TRIGGER coin_ad"))
+    XCTAssertTrue(ddl.contains("CREATE TRIGGER coin_au"))
+  }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+just test CoinGeckoCatalogSchemaTests 2>&1 | tee .agent-tmp/task2.txt
+```
+
+Expected: FAIL — `cannot find 'CoinGeckoCatalogSchema' in scope`.
+
+- [ ] **Step 3: Write the implementation**
+
+```swift
+// Backends/CoinGecko/CoinGeckoCatalogSchema.swift
+import Foundation
+
+/// Single source of truth for the CoinGecko-catalogue SQLite schema.
+/// Bump `version` whenever the on-disk shape changes; the catalogue
+/// implementation drops and recreates the file rather than running a
+/// migration. See design §3 D4.
+enum CoinGeckoCatalogSchema {
+  static let version: Int = 1
+
+  static let statements: [String] = [
+    "PRAGMA journal_mode = WAL;",
+    "PRAGMA foreign_keys = ON;",
+
+    """
+    CREATE TABLE meta (
+      schema_version  INTEGER NOT NULL,
+      last_fetched    REAL,
+      coins_etag      TEXT,
+      platforms_etag  TEXT
+    );
+    """,
+
+    "INSERT INTO meta (schema_version) VALUES (\(version));",
+
+    """
+    CREATE TABLE coin (
+      rowid          INTEGER PRIMARY KEY,
+      coingecko_id   TEXT NOT NULL UNIQUE,
+      symbol         TEXT NOT NULL,
+      name           TEXT NOT NULL
+    );
+    """,
+
+    """
+    CREATE TABLE coin_platform (
+      coingecko_id     TEXT NOT NULL,
+      platform_slug    TEXT NOT NULL,
+      contract_address TEXT NOT NULL,
+      PRIMARY KEY (coingecko_id, platform_slug),
+      FOREIGN KEY (coingecko_id) REFERENCES coin(coingecko_id) ON DELETE CASCADE
+    );
+    """,
+
+    """
+    CREATE INDEX coin_platform_chain_contract
+      ON coin_platform(platform_slug, contract_address);
+    """,
+
+    """
+    CREATE TABLE platform (
+      slug      TEXT PRIMARY KEY,
+      chain_id  INTEGER,
+      name      TEXT NOT NULL
+    );
+    """,
+
+    """
+    CREATE VIRTUAL TABLE coin_fts USING fts5(
+      symbol, name,
+      content='coin',
+      content_rowid='rowid',
+      tokenize='unicode61 remove_diacritics 1'
+    );
+    """,
+
+    """
+    CREATE TRIGGER coin_ai AFTER INSERT ON coin BEGIN
+      INSERT INTO coin_fts(rowid, symbol, name) VALUES (new.rowid, new.symbol, new.name);
+    END;
+    """,
+
+    """
+    CREATE TRIGGER coin_ad AFTER DELETE ON coin BEGIN
+      INSERT INTO coin_fts(coin_fts, rowid, symbol, name)
+      VALUES('delete', old.rowid, old.symbol, old.name);
+    END;
+    """,
+
+    """
+    CREATE TRIGGER coin_au AFTER UPDATE ON coin BEGIN
+      INSERT INTO coin_fts(coin_fts, rowid, symbol, name)
+      VALUES('delete', old.rowid, old.symbol, old.name);
+      INSERT INTO coin_fts(rowid, symbol, name) VALUES (new.rowid, new.symbol, new.name);
+    END;
+    """,
+  ]
+
+  /// Built-in priority order for picking a coin's preferred chain when it
+  /// is listed on multiple platforms. Slugs not in this list fall through
+  /// to the order returned from SQLite.
+  static let platformPriority: [String] = [
+    "ethereum",
+    "polygon-pos",
+    "binance-smart-chain",
+    "base",
+    "arbitrum-one",
+    "optimism",
+    "avalanche",
+  ]
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass + format**
+
+```bash
+just test CoinGeckoCatalogSchemaTests 2>&1 | tee .agent-tmp/task2.txt
+just format
+```
+
+Expected: 3 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Backends/CoinGecko/CoinGeckoCatalogSchema.swift MoolahTests/Backends/CoinGeckoCatalogSchemaTests.swift project.yml
+git commit -m "feat(catalog): add CoinGeckoCatalog SQLite schema"
+rm .agent-tmp/task2.txt
+```
+
+---
+
+## Task 3 — `SQLiteCoinGeckoCatalog`: open / schema bootstrap / replace-all
+
+**Files:**
+- Create: `Backends/CoinGecko/SQLiteCoinGeckoCatalog.swift`
+- Create: `MoolahTests/Backends/SQLiteCoinGeckoCatalogStorageTests.swift`
+
+This task installs the storage layer only — search and refresh come in Tasks 4 and 5.
+
+- [ ] **Step 1: Write the failing test**
+
+```swift
+// MoolahTests/Backends/SQLiteCoinGeckoCatalogStorageTests.swift
+import XCTest
+@testable import Moolah
+
+final class SQLiteCoinGeckoCatalogStorageTests: XCTestCase {
+  private var tempDir: URL!
+
+  override func setUpWithError() throws {
+    tempDir = URL(fileURLWithPath: NSTemporaryDirectory())
+      .appendingPathComponent("catalog-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+  }
+
+  override func tearDownWithError() throws {
+    try? FileManager.default.removeItem(at: tempDir)
+  }
+
+  func testOpenCreatesFreshSchema() async throws {
+    let catalog = try SQLiteCoinGeckoCatalog(directory: tempDir)
+    let dbURL = tempDir.appendingPathComponent("catalog.sqlite")
+    XCTAssertTrue(FileManager.default.fileExists(atPath: dbURL.path))
+    let meta = try await catalog.readMetaForTesting()
+    XCTAssertEqual(meta.schemaVersion, CoinGeckoCatalogSchema.version)
+    XCTAssertNil(meta.lastFetched)
+    XCTAssertNil(meta.coinsEtag)
+    XCTAssertNil(meta.platformsEtag)
+  }
+
+  func testReplaceAllCoinsAndPlatformsCommitsAtomically() async throws {
+    let catalog = try SQLiteCoinGeckoCatalog(directory: tempDir)
+    let coins = [
+      RawCoin(id: "bitcoin", symbol: "BTC", name: "Bitcoin", platforms: [:]),
+      RawCoin(
+        id: "uniswap", symbol: "UNI", name: "Uniswap",
+        platforms: ["ethereum": "0x1F9840a85d5aF5bf1D1762F925BDADdC4201F984"]
+      ),
+    ]
+    let platforms = [
+      RawPlatform(slug: "ethereum", chainId: 1, name: "Ethereum"),
+    ]
+    try await catalog.replaceAllForTesting(coins: coins, platforms: platforms)
+
+    let count = try await catalog.coinCountForTesting()
+    XCTAssertEqual(count, 2)
+    let platformCount = try await catalog.platformCountForTesting()
+    XCTAssertEqual(platformCount, 1)
+    let coinPlatformCount = try await catalog.coinPlatformCountForTesting()
+    XCTAssertEqual(coinPlatformCount, 1)
+  }
+
+  func testReplaceAllReplacesPriorContent() async throws {
+    let catalog = try SQLiteCoinGeckoCatalog(directory: tempDir)
+    let first = [RawCoin(id: "bitcoin", symbol: "BTC", name: "Bitcoin", platforms: [:])]
+    let second = [
+      RawCoin(id: "ethereum", symbol: "ETH", name: "Ethereum", platforms: [:]),
+      RawCoin(id: "tether", symbol: "USDT", name: "Tether", platforms: [:]),
+    ]
+    try await catalog.replaceAllForTesting(coins: first, platforms: [])
+    try await catalog.replaceAllForTesting(coins: second, platforms: [])
+
+    XCTAssertEqual(try await catalog.coinCountForTesting(), 2)
+  }
+
+  func testSchemaVersionMismatchRecreatesFile() async throws {
+    _ = try SQLiteCoinGeckoCatalog(directory: tempDir)
+    let dbURL = tempDir.appendingPathComponent("catalog.sqlite")
+    let creationOriginal = try FileManager.default.attributesOfItem(atPath: dbURL.path)[.creationDate] as? Date
+
+    // Simulate stored version from a future build.
+    let stale = try SQLiteCoinGeckoCatalog(directory: tempDir)
+    try await stale.writeMetaSchemaVersionForTesting(999)
+
+    // Re-open should detect mismatch and recreate.
+    let reopened = try SQLiteCoinGeckoCatalog(directory: tempDir)
+    let metaAfter = try await reopened.readMetaForTesting()
+    XCTAssertEqual(metaAfter.schemaVersion, CoinGeckoCatalogSchema.version)
+
+    let creationNew = try FileManager.default.attributesOfItem(atPath: dbURL.path)[.creationDate] as? Date
+    XCTAssertNotEqual(creationOriginal, creationNew)
+  }
+}
+```
+
+The `RawCoin` / `RawPlatform` / `MetaSnapshot` value types and the `*ForTesting` accessors are exposed as `internal` on the actor — they would otherwise be private. Mark them `// MARK: Test seams` and document their purpose.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+just test SQLiteCoinGeckoCatalogStorageTests 2>&1 | tee .agent-tmp/task3.txt
+```
+
+Expected: FAIL — `cannot find 'SQLiteCoinGeckoCatalog' in scope`.
+
+- [ ] **Step 3: Write the implementation**
+
+```swift
+// Backends/CoinGecko/SQLiteCoinGeckoCatalog.swift
+import Foundation
+import SQLite3
+import os
+
+/// Catalogue actor backing `CoinGeckoCatalog` with a local SQLite database
+/// at `<directory>/catalog.sqlite`. Public methods are `async`; all SQLite
+/// work runs on the actor's serial executor so the connection is never
+/// shared across threads. See design §4.1 / §6.
+actor SQLiteCoinGeckoCatalog: CoinGeckoCatalog {
+  private let directory: URL
+  private let session: URLSession
+  private let log = Logger(subsystem: "moolah.instrument-registry", category: "catalog")
+  private var db: OpaquePointer?
+
+  init(
+    directory: URL,
+    session: URLSession = .shared
+  ) throws {
+    self.directory = directory
+    self.session = session
+    try FileManager.default.createDirectory(
+      at: directory, withIntermediateDirectories: true
+    )
+    try open()
+  }
+
+  deinit {
+    if let db { sqlite3_close_v2(db) }
+  }
+
+  // MARK: - CoinGeckoCatalog
+
+  func search(query: String, limit: Int) async -> [CatalogEntry] {
+    [] // Implemented in Task 4.
+  }
+
+  func refreshIfStale() async {
+    // Implemented in Task 5.
+  }
+
+  // MARK: - Schema bootstrap
+
+  private var dbURL: URL {
+    directory.appendingPathComponent("catalog.sqlite")
+  }
+
+  private func open() throws {
+    if FileManager.default.fileExists(atPath: dbURL.path) {
+      try connect()
+      let storedVersion = try readSchemaVersion()
+      if storedVersion != CoinGeckoCatalogSchema.version {
+        sqlite3_close_v2(db)
+        db = nil
+        try FileManager.default.removeItem(at: dbURL)
+        try FileManager.default.removeItem(
+          at: dbURL.appendingPathExtension("wal").deletingPathExtension())
+        try createFresh()
+      }
+    } else {
+      try createFresh()
+    }
+  }
+
+  private func connect() throws {
+    var handle: OpaquePointer?
+    let flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_FULLMUTEX
+    let rc = sqlite3_open_v2(dbURL.path, &handle, flags, nil)
+    guard rc == SQLITE_OK, let handle else {
+      throw CatalogError.sqlite("open failed: \(rc)")
+    }
+    db = handle
+  }
+
+  private func createFresh() throws {
+    try connect()
+    for stmt in CoinGeckoCatalogSchema.statements {
+      try exec(stmt)
+    }
+  }
+
+  // MARK: - Replace-all
+
+  internal struct RawCoin: Sendable {
+    let id: String
+    let symbol: String
+    let name: String
+    /// platform slug → contract address (verbatim, normalised on insert)
+    let platforms: [String: String]
+  }
+
+  internal struct RawPlatform: Sendable {
+    let slug: String
+    let chainId: Int?
+    let name: String
+  }
+
+  internal struct MetaSnapshot: Sendable, Equatable {
+    let schemaVersion: Int
+    let lastFetched: Date?
+    let coinsEtag: String?
+    let platformsEtag: String?
+  }
+
+  internal func replaceAllForTesting(coins: [RawCoin], platforms: [RawPlatform]) throws {
+    try replaceAll(coins: coins, platforms: platforms)
+  }
+
+  internal func readMetaForTesting() throws -> MetaSnapshot { try readMeta() }
+  internal func coinCountForTesting() throws -> Int { try scalarInt("SELECT COUNT(*) FROM coin") }
+  internal func platformCountForTesting() throws -> Int {
+    try scalarInt("SELECT COUNT(*) FROM platform")
+  }
+  internal func coinPlatformCountForTesting() throws -> Int {
+    try scalarInt("SELECT COUNT(*) FROM coin_platform")
+  }
+  internal func writeMetaSchemaVersionForTesting(_ version: Int) throws {
+    try exec("UPDATE meta SET schema_version = \(version);")
+  }
+
+  fileprivate func replaceAll(coins: [RawCoin], platforms: [RawPlatform]) throws {
+    try exec("BEGIN IMMEDIATE;")
+    do {
+      try exec("DELETE FROM coin;")
+      try exec("DELETE FROM platform;")
+
+      if !coins.isEmpty {
+        var insertCoin: OpaquePointer?
+        try prepare(
+          "INSERT INTO coin (coingecko_id, symbol, name) VALUES (?, ?, ?);", &insertCoin)
+        defer { sqlite3_finalize(insertCoin) }
+        var insertCoinPlatform: OpaquePointer?
+        try prepare(
+          "INSERT INTO coin_platform (coingecko_id, platform_slug, contract_address) "
+            + "VALUES (?, ?, ?);", &insertCoinPlatform)
+        defer { sqlite3_finalize(insertCoinPlatform) }
+
+        for coin in coins {
+          try bind(insertCoin, 1, coin.id)
+          try bind(insertCoin, 2, coin.symbol)
+          try bind(insertCoin, 3, coin.name)
+          try step(insertCoin)
+          sqlite3_reset(insertCoin)
+
+          for (slug, contract) in coin.platforms {
+            guard !contract.isEmpty else { continue }
+            try bind(insertCoinPlatform, 1, coin.id)
+            try bind(insertCoinPlatform, 2, slug)
+            try bind(insertCoinPlatform, 3, contract.lowercased())
+            try step(insertCoinPlatform)
+            sqlite3_reset(insertCoinPlatform)
+          }
+        }
+      }
+
+      if !platforms.isEmpty {
+        var insertPlatform: OpaquePointer?
+        try prepare(
+          "INSERT INTO platform (slug, chain_id, name) VALUES (?, ?, ?);", &insertPlatform)
+        defer { sqlite3_finalize(insertPlatform) }
+        for platform in platforms {
+          try bind(insertPlatform, 1, platform.slug)
+          if let chainId = platform.chainId {
+            try bind(insertPlatform, 2, chainId)
+          } else {
+            sqlite3_bind_null(insertPlatform, 2)
+          }
+          try bind(insertPlatform, 3, platform.name)
+          try step(insertPlatform)
+          sqlite3_reset(insertPlatform)
+        }
+      }
+
+      try exec("COMMIT;")
+    } catch {
+      try? exec("ROLLBACK;")
+      throw error
+    }
+  }
+
+  // MARK: - Meta read / write
+
+  private func readMeta() throws -> MetaSnapshot {
+    var statement: OpaquePointer?
+    try prepare(
+      "SELECT schema_version, last_fetched, coins_etag, platforms_etag FROM meta LIMIT 1;",
+      &statement)
+    defer { sqlite3_finalize(statement) }
+    guard sqlite3_step(statement) == SQLITE_ROW else {
+      throw CatalogError.sqlite("meta table empty")
+    }
+    let version = Int(sqlite3_column_int64(statement, 0))
+    let lastFetched: Date? = {
+      let raw = sqlite3_column_double(statement, 1)
+      if sqlite3_column_type(statement, 1) == SQLITE_NULL { return nil }
+      return Date(timeIntervalSince1970: raw)
+    }()
+    let coinsEtag = readText(statement, column: 2)
+    let platformsEtag = readText(statement, column: 3)
+    return MetaSnapshot(
+      schemaVersion: version,
+      lastFetched: lastFetched,
+      coinsEtag: coinsEtag,
+      platformsEtag: platformsEtag
+    )
+  }
+
+  private func readSchemaVersion() throws -> Int {
+    return try readMeta().schemaVersion
+  }
+
+  // MARK: - Low-level SQLite helpers
+
+  private func exec(_ sql: String) throws {
+    var error: UnsafeMutablePointer<CChar>?
+    let rc = sqlite3_exec(db, sql, nil, nil, &error)
+    if rc != SQLITE_OK {
+      let message = error.map { String(cString: $0) } ?? "code \(rc)"
+      sqlite3_free(error)
+      throw CatalogError.sqlite("exec failed: \(message)")
+    }
+  }
+
+  private func prepare(_ sql: String, _ statement: inout OpaquePointer?) throws {
+    let rc = sqlite3_prepare_v2(db, sql, -1, &statement, nil)
+    guard rc == SQLITE_OK else {
+      throw CatalogError.sqlite("prepare failed: \(rc) for \(sql)")
+    }
+  }
+
+  private func bind(_ statement: OpaquePointer?, _ index: Int32, _ value: String) throws {
+    let rc = sqlite3_bind_text(
+      statement, index, value, -1,
+      unsafeBitCast(Int(-1), to: sqlite3_destructor_type.self)
+    )
+    guard rc == SQLITE_OK else { throw CatalogError.sqlite("bind text \(rc)") }
+  }
+
+  private func bind(_ statement: OpaquePointer?, _ index: Int32, _ value: Int) throws {
+    let rc = sqlite3_bind_int64(statement, index, Int64(value))
+    guard rc == SQLITE_OK else { throw CatalogError.sqlite("bind int \(rc)") }
+  }
+
+  private func step(_ statement: OpaquePointer?) throws {
+    let rc = sqlite3_step(statement)
+    guard rc == SQLITE_DONE || rc == SQLITE_ROW else {
+      throw CatalogError.sqlite("step \(rc)")
+    }
+  }
+
+  private func scalarInt(_ sql: String) throws -> Int {
+    var statement: OpaquePointer?
+    try prepare(sql, &statement)
+    defer { sqlite3_finalize(statement) }
+    guard sqlite3_step(statement) == SQLITE_ROW else {
+      throw CatalogError.sqlite("scalar empty")
+    }
+    return Int(sqlite3_column_int64(statement, 0))
+  }
+
+  private func readText(_ statement: OpaquePointer?, column: Int32) -> String? {
+    guard let cString = sqlite3_column_text(statement, column) else { return nil }
+    return String(cString: cString)
+  }
+
+  enum CatalogError: Error, Equatable {
+    case sqlite(String)
+  }
+}
+```
+
+The `unsafeBitCast(Int(-1), to: sqlite3_destructor_type.self)` is the SQLITE_TRANSIENT marker (forces SQLite to copy the bound string). This is the standard Swift workaround for the missing C macro.
+
+- [ ] **Step 4: Run tests to verify they pass + format**
+
+```bash
+just generate
+just test SQLiteCoinGeckoCatalogStorageTests 2>&1 | tee .agent-tmp/task3.txt
+just format
+```
+
+Expected: 4 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Backends/CoinGecko/SQLiteCoinGeckoCatalog.swift MoolahTests/Backends/SQLiteCoinGeckoCatalogStorageTests.swift project.yml
+git commit -m "feat(catalog): SQLite-backed CoinGecko catalogue (storage layer)"
+rm .agent-tmp/task3.txt
+```
+
+---
+
+## Task 4 — `SQLiteCoinGeckoCatalog`: FTS5 search
+
+**Files:**
+- Modify: `Backends/CoinGecko/SQLiteCoinGeckoCatalog.swift` (replace `search(query:limit:)` body)
+- Create: `MoolahTests/Backends/SQLiteCoinGeckoCatalogSearchTests.swift`
+
+- [ ] **Step 1: Write the failing test**
+
+```swift
+// MoolahTests/Backends/SQLiteCoinGeckoCatalogSearchTests.swift
+import XCTest
+@testable import Moolah
+
+final class SQLiteCoinGeckoCatalogSearchTests: XCTestCase {
+  private var tempDir: URL!
+  private var catalog: SQLiteCoinGeckoCatalog!
+
+  override func setUpWithError() throws {
+    tempDir = URL(fileURLWithPath: NSTemporaryDirectory())
+      .appendingPathComponent("search-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    catalog = try SQLiteCoinGeckoCatalog(directory: tempDir)
+  }
+
+  override func tearDownWithError() throws {
+    catalog = nil
+    try? FileManager.default.removeItem(at: tempDir)
+  }
+
+  private func seedFixture() async throws {
+    let coins: [SQLiteCoinGeckoCatalog.RawCoin] = [
+      .init(id: "bitcoin", symbol: "BTC", name: "Bitcoin", platforms: [:]),
+      .init(
+        id: "ethereum", symbol: "ETH", name: "Ethereum",
+        platforms: [:]
+      ),
+      .init(
+        id: "uniswap", symbol: "UNI", name: "Uniswap",
+        platforms: [
+          "ethereum": "0x1F9840a85d5aF5bf1D1762F925BDADdC4201F984",
+          "polygon-pos": "0xb33EaAd8d922B1083446DC23f610c2567fB5180f",
+        ]
+      ),
+      .init(id: "tether", symbol: "USDT", name: "Tether", platforms: [:]),
+      .init(id: "blockstack", symbol: "STX", name: "Stacks", platforms: [:]),
+    ]
+    let platforms: [SQLiteCoinGeckoCatalog.RawPlatform] = [
+      .init(slug: "ethereum", chainId: 1, name: "Ethereum"),
+      .init(slug: "polygon-pos", chainId: 137, name: "Polygon"),
+    ]
+    try await catalog.replaceAllForTesting(coins: coins, platforms: platforms)
+  }
+
+  func testSymbolPrefixHits() async throws {
+    try await seedFixture()
+    let results = await catalog.search(query: "btc", limit: 10)
+    XCTAssertEqual(results.first?.coingeckoId, "bitcoin")
+  }
+
+  func testNameTokenHits() async throws {
+    try await seedFixture()
+    let results = await catalog.search(query: "uniswap", limit: 10)
+    XCTAssertEqual(results.first?.coingeckoId, "uniswap")
+  }
+
+  func testPlatformsAttachedToHit() async throws {
+    try await seedFixture()
+    let results = await catalog.search(query: "uni", limit: 10)
+    let uni = try XCTUnwrap(results.first { $0.coingeckoId == "uniswap" })
+    XCTAssertEqual(uni.platforms.first?.slug, "ethereum")
+    XCTAssertEqual(uni.platforms.first?.chainId, 1)
+    XCTAssertEqual(uni.platforms.first?.contractAddress, "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984")
+    XCTAssertTrue(uni.platforms.contains { $0.slug == "polygon-pos" })
+  }
+
+  func testPlatformOrderingHonoursPriority() async throws {
+    try await seedFixture()
+    let results = await catalog.search(query: "uni", limit: 10)
+    let uni = try XCTUnwrap(results.first { $0.coingeckoId == "uniswap" })
+    XCTAssertEqual(uni.platforms.map(\.slug), ["ethereum", "polygon-pos"])
+  }
+
+  func testEmptyQueryReturnsEmpty() async throws {
+    try await seedFixture()
+    let results = await catalog.search(query: "", limit: 10)
+    XCTAssertTrue(results.isEmpty)
+  }
+
+  func testLimitIsRespected() async throws {
+    try await seedFixture()
+    let results = await catalog.search(query: "e*", limit: 2)
+    XCTAssertLessThanOrEqual(results.count, 2)
+  }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+just test SQLiteCoinGeckoCatalogSearchTests 2>&1 | tee .agent-tmp/task4.txt
+```
+
+Expected: FAIL — `search` currently returns `[]`.
+
+- [ ] **Step 3: Implement `search(query:limit:)`**
+
+Replace the existing stub in `SQLiteCoinGeckoCatalog.swift`:
+
+```swift
+func search(query: String, limit: Int) async -> [CatalogEntry] {
+  let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+  guard !trimmed.isEmpty, limit > 0 else { return [] }
+
+  do {
+    let ranked = try fetchRankedCoins(query: trimmed, limit: limit)
+    guard !ranked.isEmpty else { return [] }
+    let bindings = try fetchPlatformBindings(coingeckoIds: ranked.map(\.id))
+    return ranked.map { row in
+      CatalogEntry(
+        coingeckoId: row.id,
+        symbol: row.symbol,
+        name: row.name,
+        platforms: orderedPlatforms(for: row.id, bindings: bindings)
+      )
+    }
+  } catch {
+    log.error("search failed: \(String(describing: error), privacy: .public)")
+    return []
+  }
+}
+
+private struct RankedCoin {
+  let id: String
+  let symbol: String
+  let name: String
+}
+
+private func fetchRankedCoins(query: String, limit: Int) throws -> [RankedCoin] {
+  let ftsQuery = ftsQueryString(for: query)
+  var statement: OpaquePointer?
+  try prepare(
+    """
+    SELECT c.coingecko_id, c.symbol, c.name
+    FROM coin_fts JOIN coin c ON c.rowid = coin_fts.rowid
+    WHERE coin_fts MATCH ?
+    ORDER BY rank
+    LIMIT ?;
+    """,
+    &statement
+  )
+  defer { sqlite3_finalize(statement) }
+  try bind(statement, 1, ftsQuery)
+  try bind(statement, 2, limit)
+  var rows: [RankedCoin] = []
+  while sqlite3_step(statement) == SQLITE_ROW {
+    let id = readText(statement, column: 0) ?? ""
+    let symbol = readText(statement, column: 1) ?? ""
+    let name = readText(statement, column: 2) ?? ""
+    rows.append(RankedCoin(id: id, symbol: symbol, name: name))
+  }
+  return rows
+}
+
+private func fetchPlatformBindings(coingeckoIds: [String])
+  throws -> [String: [PlatformBinding]] {
+  guard !coingeckoIds.isEmpty else { return [:] }
+  let placeholders = Array(repeating: "?", count: coingeckoIds.count).joined(separator: ", ")
+  var statement: OpaquePointer?
+  try prepare(
+    """
+    SELECT cp.coingecko_id, cp.platform_slug, cp.contract_address, p.chain_id
+    FROM coin_platform cp
+    LEFT JOIN platform p ON p.slug = cp.platform_slug
+    WHERE cp.coingecko_id IN (\(placeholders));
+    """,
+    &statement
+  )
+  defer { sqlite3_finalize(statement) }
+  for (offset, id) in coingeckoIds.enumerated() {
+    try bind(statement, Int32(offset + 1), id)
+  }
+  var bindingsById: [String: [PlatformBinding]] = [:]
+  while sqlite3_step(statement) == SQLITE_ROW {
+    let coingeckoId = readText(statement, column: 0) ?? ""
+    let slug = readText(statement, column: 1) ?? ""
+    let contract = readText(statement, column: 2) ?? ""
+    let chainId: Int? =
+      sqlite3_column_type(statement, 3) == SQLITE_NULL
+      ? nil : Int(sqlite3_column_int64(statement, 3))
+    bindingsById[coingeckoId, default: []].append(
+      PlatformBinding(slug: slug, chainId: chainId, contractAddress: contract)
+    )
+  }
+  return bindingsById
+}
+
+private func orderedPlatforms(
+  for coingeckoId: String,
+  bindings: [String: [PlatformBinding]]
+) -> [PlatformBinding] {
+  let raw = bindings[coingeckoId] ?? []
+  let priority = CoinGeckoCatalogSchema.platformPriority
+  return raw.sorted { lhs, rhs in
+    let lp = priority.firstIndex(of: lhs.slug) ?? Int.max
+    let rp = priority.firstIndex(of: rhs.slug) ?? Int.max
+    if lp != rp { return lp < rp }
+    return lhs.slug < rhs.slug
+  }
+}
+
+private func ftsQueryString(for query: String) -> String {
+  // Tokenise on whitespace; quote each token to escape FTS punctuation;
+  // append `*` for prefix match. e.g. "btc" → `"btc"*`, "apple inc" →
+  // `"apple"* "inc"*`.
+  let tokens =
+    query
+    .components(separatedBy: .whitespaces)
+    .filter { !$0.isEmpty }
+    .map { $0.replacingOccurrences(of: "\"", with: "\"\"") }
+  return tokens.map { "\"\($0)\"*" }.joined(separator: " ")
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass + format**
+
+```bash
+just test SQLiteCoinGeckoCatalogSearchTests 2>&1 | tee .agent-tmp/task4.txt
+just format
+```
+
+Expected: 6 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Backends/CoinGecko/SQLiteCoinGeckoCatalog.swift MoolahTests/Backends/SQLiteCoinGeckoCatalogSearchTests.swift
+git commit -m "feat(catalog): FTS5 search with attached platform bindings"
+rm .agent-tmp/task4.txt
+```
+
+---
+
+## Task 5 — `SQLiteCoinGeckoCatalog`: ETag-aware refresh
+
+**Files:**
+- Modify: `Backends/CoinGecko/SQLiteCoinGeckoCatalog.swift` (replace `refreshIfStale()` stub; add network types and parsing)
+- Create: `MoolahTests/Support/Fixtures/coingecko-coins-list-small.json`
+- Create: `MoolahTests/Support/Fixtures/coingecko-coins-list-small-updated.json`
+- Create: `MoolahTests/Support/Fixtures/coingecko-asset-platforms.json`
+- Create: `MoolahTests/Backends/SQLiteCoinGeckoCatalogRefreshTests.swift`
+
+- [ ] **Step 1: Write the fixtures**
+
+`MoolahTests/Support/Fixtures/coingecko-coins-list-small.json`:
+
+```json
+[
+  {"id": "bitcoin", "symbol": "btc", "name": "Bitcoin", "platforms": {}},
+  {"id": "ethereum", "symbol": "eth", "name": "Ethereum", "platforms": {}},
+  {"id": "uniswap", "symbol": "uni", "name": "Uniswap",
+   "platforms": {"ethereum": "0x1F9840a85d5aF5bf1D1762F925BDADdC4201F984"}}
+]
+```
+
+`MoolahTests/Support/Fixtures/coingecko-coins-list-small-updated.json`:
+
+```json
+[
+  {"id": "bitcoin", "symbol": "btc", "name": "Bitcoin", "platforms": {}},
+  {"id": "ethereum", "symbol": "eth", "name": "Ethereum", "platforms": {}},
+  {"id": "uniswap", "symbol": "uni", "name": "Uniswap",
+   "platforms": {"ethereum": "0x1F9840a85d5aF5bf1D1762F925BDADdC4201F984"}},
+  {"id": "pepe", "symbol": "pepe", "name": "Pepe",
+   "platforms": {"ethereum": "0x6982508145454Ce325dDbE47a25d4ec3d2311933"}}
+]
+```
+
+`MoolahTests/Support/Fixtures/coingecko-asset-platforms.json`:
+
+```json
+[
+  {"id": "ethereum", "chain_identifier": 1, "name": "Ethereum"},
+  {"id": "polygon-pos", "chain_identifier": 137, "name": "Polygon POS"},
+  {"id": "solana", "chain_identifier": null, "name": "Solana"}
+]
+```
+
+- [ ] **Step 2: Write the failing test**
+
+```swift
+// MoolahTests/Backends/SQLiteCoinGeckoCatalogRefreshTests.swift
+import XCTest
+@testable import Moolah
+
+final class SQLiteCoinGeckoCatalogRefreshTests: XCTestCase {
+  private var tempDir: URL!
+
+  override func setUpWithError() throws {
+    tempDir = URL(fileURLWithPath: NSTemporaryDirectory())
+      .appendingPathComponent("refresh-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    URLProtocol.registerClass(StubURLProtocol.self)
+  }
+
+  override func tearDownWithError() throws {
+    URLProtocol.unregisterClass(StubURLProtocol.self)
+    StubURLProtocol.handlers = [:]
+    try? FileManager.default.removeItem(at: tempDir)
+  }
+
+  private func makeSession() -> URLSession {
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [StubURLProtocol.self]
+    return URLSession(configuration: config)
+  }
+
+  private func loadFixture(_ name: String) throws -> Data {
+    let bundle = Bundle(for: type(of: self))
+    let url = try XCTUnwrap(bundle.url(forResource: name, withExtension: "json"))
+    return try Data(contentsOf: url)
+  }
+
+  func testRefreshDownloadsAndPopulates() async throws {
+    let coinsData = try loadFixture("coingecko-coins-list-small")
+    let platformsData = try loadFixture("coingecko-asset-platforms")
+    StubURLProtocol.handlers["api.coingecko.com:/api/v3/coins/list"] = { _ in
+      (HTTPURLResponse.ok(etag: "W/\"a1\""), coinsData)
+    }
+    StubURLProtocol.handlers["api.coingecko.com:/api/v3/asset_platforms"] = { _ in
+      (HTTPURLResponse.ok(etag: "W/\"p1\""), platformsData)
+    }
+
+    let catalog = try SQLiteCoinGeckoCatalog(directory: tempDir, session: makeSession())
+    await catalog.refreshIfStale()
+    let count = try await catalog.coinCountForTesting()
+    XCTAssertEqual(count, 3)
+    let platforms = try await catalog.platformCountForTesting()
+    XCTAssertEqual(platforms, 3)
+    let meta = try await catalog.readMetaForTesting()
+    XCTAssertEqual(meta.coinsEtag, "W/\"a1\"")
+    XCTAssertEqual(meta.platformsEtag, "W/\"p1\"")
+    XCTAssertNotNil(meta.lastFetched)
+  }
+
+  func testRefreshSendsIfNoneMatchOnSubsequentCall() async throws {
+    let coinsData = try loadFixture("coingecko-coins-list-small")
+    let platformsData = try loadFixture("coingecko-asset-platforms")
+    StubURLProtocol.handlers["api.coingecko.com:/api/v3/coins/list"] = { _ in
+      (HTTPURLResponse.ok(etag: "W/\"a1\""), coinsData)
+    }
+    StubURLProtocol.handlers["api.coingecko.com:/api/v3/asset_platforms"] = { _ in
+      (HTTPURLResponse.ok(etag: "W/\"p1\""), platformsData)
+    }
+    let catalog = try SQLiteCoinGeckoCatalog(directory: tempDir, session: makeSession())
+    await catalog.refreshIfStale()
+
+    // Fast-forward `last_fetched` so the next call is "stale".
+    try await catalog.bumpLastFetchedBackwardForTesting(by: 25 * 3600)
+
+    var capturedHeaders: [String: String] = [:]
+    StubURLProtocol.handlers["api.coingecko.com:/api/v3/coins/list"] = { request in
+      request.allHTTPHeaderFields?.forEach { capturedHeaders[$0.key] = $0.value }
+      return (HTTPURLResponse.notModified(), Data())
+    }
+    StubURLProtocol.handlers["api.coingecko.com:/api/v3/asset_platforms"] = { _ in
+      (HTTPURLResponse.notModified(), Data())
+    }
+    await catalog.refreshIfStale()
+    XCTAssertEqual(capturedHeaders["If-None-Match"], "W/\"a1\"")
+  }
+
+  func testRefreshSkippedWhenWithinMaxAge() async throws {
+    let coinsData = try loadFixture("coingecko-coins-list-small")
+    let platformsData = try loadFixture("coingecko-asset-platforms")
+    var coinsCallCount = 0
+    StubURLProtocol.handlers["api.coingecko.com:/api/v3/coins/list"] = { _ in
+      coinsCallCount += 1
+      return (HTTPURLResponse.ok(etag: "W/\"a1\""), coinsData)
+    }
+    StubURLProtocol.handlers["api.coingecko.com:/api/v3/asset_platforms"] = { _ in
+      (HTTPURLResponse.ok(etag: "W/\"p1\""), platformsData)
+    }
+    let catalog = try SQLiteCoinGeckoCatalog(directory: tempDir, session: makeSession())
+    await catalog.refreshIfStale()
+    await catalog.refreshIfStale()
+
+    XCTAssertEqual(coinsCallCount, 1)
+  }
+
+  func testRefreshOnNetworkErrorPreservesPriorSnapshot() async throws {
+    let coinsData = try loadFixture("coingecko-coins-list-small")
+    let platformsData = try loadFixture("coingecko-asset-platforms")
+    StubURLProtocol.handlers["api.coingecko.com:/api/v3/coins/list"] = { _ in
+      (HTTPURLResponse.ok(etag: "W/\"a1\""), coinsData)
+    }
+    StubURLProtocol.handlers["api.coingecko.com:/api/v3/asset_platforms"] = { _ in
+      (HTTPURLResponse.ok(etag: "W/\"p1\""), platformsData)
+    }
+    let catalog = try SQLiteCoinGeckoCatalog(directory: tempDir, session: makeSession())
+    await catalog.refreshIfStale()
+    try await catalog.bumpLastFetchedBackwardForTesting(by: 25 * 3600)
+
+    StubURLProtocol.handlers["api.coingecko.com:/api/v3/coins/list"] = { _ in
+      throw URLError(.notConnectedToInternet)
+    }
+    StubURLProtocol.handlers["api.coingecko.com:/api/v3/asset_platforms"] = { _ in
+      throw URLError(.notConnectedToInternet)
+    }
+    await catalog.refreshIfStale()
+    XCTAssertEqual(try await catalog.coinCountForTesting(), 3)  // unchanged
+  }
+
+  func testRefreshAcceptsUpdatedSnapshot() async throws {
+    let firstCoins = try loadFixture("coingecko-coins-list-small")
+    let secondCoins = try loadFixture("coingecko-coins-list-small-updated")
+    let platforms = try loadFixture("coingecko-asset-platforms")
+    StubURLProtocol.handlers["api.coingecko.com:/api/v3/coins/list"] = { _ in
+      (HTTPURLResponse.ok(etag: "W/\"a1\""), firstCoins)
+    }
+    StubURLProtocol.handlers["api.coingecko.com:/api/v3/asset_platforms"] = { _ in
+      (HTTPURLResponse.ok(etag: "W/\"p1\""), platforms)
+    }
+    let catalog = try SQLiteCoinGeckoCatalog(directory: tempDir, session: makeSession())
+    await catalog.refreshIfStale()
+    try await catalog.bumpLastFetchedBackwardForTesting(by: 25 * 3600)
+
+    StubURLProtocol.handlers["api.coingecko.com:/api/v3/coins/list"] = { _ in
+      (HTTPURLResponse.ok(etag: "W/\"a2\""), secondCoins)
+    }
+    await catalog.refreshIfStale()
+    XCTAssertEqual(try await catalog.coinCountForTesting(), 4)
+    let pepe = await catalog.search(query: "pepe", limit: 5)
+    XCTAssertEqual(pepe.first?.coingeckoId, "pepe")
+    let meta = try await catalog.readMetaForTesting()
+    XCTAssertEqual(meta.coinsEtag, "W/\"a2\"")
+  }
+}
+
+// Lightweight URLProtocol stub. Place at end of file so it's only visible
+// to refresh tests; if reused later, lift to MoolahTests/Support/.
+private final class StubURLProtocol: URLProtocol, @unchecked Sendable {
+  static var handlers: [String: (URLRequest) throws -> (HTTPURLResponse, Data)] = [:]
+
+  override class func canInit(with request: URLRequest) -> Bool { true }
+  override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+  override func startLoading() {
+    guard let url = request.url, let host = url.host else {
+      client?.urlProtocol(self, didFailWithError: URLError(.badURL))
+      return
+    }
+    let key = "\(host):\(url.path)"
+    guard let handler = Self.handlers[key] else {
+      client?.urlProtocol(self, didFailWithError: URLError(.unsupportedURL))
+      return
+    }
+    do {
+      let (response, data) = try handler(request)
+      client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+      client?.urlProtocol(self, didLoad: data)
+      client?.urlProtocolDidFinishLoading(self)
+    } catch {
+      client?.urlProtocol(self, didFailWithError: error)
+    }
+  }
+
+  override func stopLoading() {}
+}
+
+extension HTTPURLResponse {
+  static func ok(etag: String) -> HTTPURLResponse {
+    HTTPURLResponse(
+      url: URL(string: "https://example.invalid")!,
+      statusCode: 200, httpVersion: "HTTP/1.1",
+      headerFields: ["ETag": etag, "Content-Type": "application/json"])!
+  }
+  static func notModified() -> HTTPURLResponse {
+    HTTPURLResponse(
+      url: URL(string: "https://example.invalid")!,
+      statusCode: 304, httpVersion: "HTTP/1.1", headerFields: [:])!
+  }
+}
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+```bash
+just test SQLiteCoinGeckoCatalogRefreshTests 2>&1 | tee .agent-tmp/task5.txt
+```
+
+Expected: FAIL — `bumpLastFetchedBackwardForTesting` and the `refreshIfStale` body are stubs.
+
+- [ ] **Step 4: Implement `refreshIfStale` and related parsing**
+
+Add to `SQLiteCoinGeckoCatalog.swift` (replace stub):
+
+```swift
+private static let coinsListURL = URL(
+  string: "https://api.coingecko.com/api/v3/coins/list?include_platform=true")!
+private static let assetPlatformsURL = URL(
+  string: "https://api.coingecko.com/api/v3/asset_platforms")!
+private static let maxAge: TimeInterval = 24 * 3600
+
+func refreshIfStale() async {
+  do {
+    let meta = try readMeta()
+    if let lastFetched = meta.lastFetched,
+      Date().timeIntervalSince(lastFetched) < Self.maxAge {
+      return
+    }
+    let coinsResult = try await fetchConditional(
+      url: Self.coinsListURL, ifNoneMatch: meta.coinsEtag
+    )
+    let platformsResult = try await fetchConditional(
+      url: Self.assetPlatformsURL, ifNoneMatch: meta.platformsEtag
+    )
+
+    var newCoinsEtag = meta.coinsEtag
+    var newPlatformsEtag = meta.platformsEtag
+
+    var rawCoinsToInsert: [RawCoin]?
+    var rawPlatformsToInsert: [RawPlatform]?
+
+    switch coinsResult {
+    case .notModified:
+      break
+    case .ok(let body, let etag):
+      rawCoinsToInsert = try Self.parseCoins(body)
+      newCoinsEtag = etag
+    }
+    switch platformsResult {
+    case .notModified:
+      break
+    case .ok(let body, let etag):
+      rawPlatformsToInsert = try Self.parsePlatforms(body)
+      newPlatformsEtag = etag
+    }
+
+    if rawCoinsToInsert != nil || rawPlatformsToInsert != nil {
+      try replaceAllOrPartial(
+        coins: rawCoinsToInsert,
+        platforms: rawPlatformsToInsert
+      )
+    }
+    try writeMeta(
+      lastFetched: Date(),
+      coinsEtag: newCoinsEtag,
+      platformsEtag: newPlatformsEtag
+    )
+  } catch {
+    log.error("refresh failed: \(String(describing: error), privacy: .public)")
+  }
+}
+
+private enum FetchOutcome {
+  case ok(Data, etag: String?)
+  case notModified
+}
+
+private func fetchConditional(url: URL, ifNoneMatch: String?) async throws -> FetchOutcome {
+  var request = URLRequest(url: url)
+  if let ifNoneMatch { request.setValue(ifNoneMatch, forHTTPHeaderField: "If-None-Match") }
+  request.setValue("gzip", forHTTPHeaderField: "Accept-Encoding")
+  let (data, response) = try await session.data(for: request)
+  guard let http = response as? HTTPURLResponse else { throw CatalogError.sqlite("non-HTTP") }
+  switch http.statusCode {
+  case 200:
+    return .ok(data, etag: http.value(forHTTPHeaderField: "ETag"))
+  case 304:
+    return .notModified
+  default:
+    throw CatalogError.sqlite("status \(http.statusCode) for \(url.absoluteString)")
+  }
+}
+
+private static func parseCoins(_ data: Data) throws -> [RawCoin] {
+  struct Wire: Decodable {
+    let id: String
+    let symbol: String
+    let name: String
+    let platforms: [String: String]?
+  }
+  let decoded = try JSONDecoder().decode([Wire].self, from: data)
+  return decoded.map { RawCoin(
+    id: $0.id,
+    symbol: $0.symbol.uppercased(),
+    name: $0.name,
+    platforms: ($0.platforms ?? [:]).filter { !$0.value.isEmpty }
+  ) }
+}
+
+private static func parsePlatforms(_ data: Data) throws -> [RawPlatform] {
+  struct Wire: Decodable {
+    let id: String
+    let chain_identifier: Int?
+    let name: String
+  }
+  let decoded = try JSONDecoder().decode([Wire].self, from: data)
+  return decoded.map { RawPlatform(slug: $0.id, chainId: $0.chain_identifier, name: $0.name) }
+}
+
+private func replaceAllOrPartial(coins: [RawCoin]?, platforms: [RawPlatform]?) throws {
+  // If only one side changed, retain the other side's existing rows.
+  if let coins, let platforms {
+    try replaceAll(coins: coins, platforms: platforms)
+    return
+  }
+  if let coins {
+    try exec("BEGIN IMMEDIATE;")
+    do {
+      try exec("DELETE FROM coin;")
+      try insertCoins(coins)
+      try exec("COMMIT;")
+    } catch {
+      try? exec("ROLLBACK;")
+      throw error
+    }
+  }
+  if let platforms {
+    try exec("BEGIN IMMEDIATE;")
+    do {
+      try exec("DELETE FROM platform;")
+      try insertPlatforms(platforms)
+      try exec("COMMIT;")
+    } catch {
+      try? exec("ROLLBACK;")
+      throw error
+    }
+  }
+}
+
+private func insertCoins(_ coins: [RawCoin]) throws {
+  var insertCoin: OpaquePointer?
+  try prepare(
+    "INSERT INTO coin (coingecko_id, symbol, name) VALUES (?, ?, ?);", &insertCoin)
+  defer { sqlite3_finalize(insertCoin) }
+  var insertPlatform: OpaquePointer?
+  try prepare(
+    "INSERT INTO coin_platform (coingecko_id, platform_slug, contract_address) VALUES (?, ?, ?);",
+    &insertPlatform)
+  defer { sqlite3_finalize(insertPlatform) }
+  for coin in coins {
+    try bind(insertCoin, 1, coin.id)
+    try bind(insertCoin, 2, coin.symbol)
+    try bind(insertCoin, 3, coin.name)
+    try step(insertCoin)
+    sqlite3_reset(insertCoin)
+    for (slug, contract) in coin.platforms {
+      try bind(insertPlatform, 1, coin.id)
+      try bind(insertPlatform, 2, slug)
+      try bind(insertPlatform, 3, contract.lowercased())
+      try step(insertPlatform)
+      sqlite3_reset(insertPlatform)
+    }
+  }
+}
+
+private func insertPlatforms(_ platforms: [RawPlatform]) throws {
+  var insertPlatform: OpaquePointer?
+  try prepare(
+    "INSERT INTO platform (slug, chain_id, name) VALUES (?, ?, ?);", &insertPlatform)
+  defer { sqlite3_finalize(insertPlatform) }
+  for platform in platforms {
+    try bind(insertPlatform, 1, platform.slug)
+    if let chainId = platform.chainId { try bind(insertPlatform, 2, chainId) }
+    else { sqlite3_bind_null(insertPlatform, 2) }
+    try bind(insertPlatform, 3, platform.name)
+    try step(insertPlatform)
+    sqlite3_reset(insertPlatform)
+  }
+}
+
+private func writeMeta(lastFetched: Date, coinsEtag: String?, platformsEtag: String?) throws {
+  var statement: OpaquePointer?
+  try prepare(
+    "UPDATE meta SET last_fetched = ?, coins_etag = ?, platforms_etag = ?;", &statement)
+  defer { sqlite3_finalize(statement) }
+  sqlite3_bind_double(statement, 1, lastFetched.timeIntervalSince1970)
+  if let coinsEtag { try bind(statement, 2, coinsEtag) } else { sqlite3_bind_null(statement, 2) }
+  if let platformsEtag { try bind(statement, 3, platformsEtag) }
+  else { sqlite3_bind_null(statement, 3) }
+  try step(statement)
+}
+
+internal func bumpLastFetchedBackwardForTesting(by seconds: TimeInterval) throws {
+  try exec("UPDATE meta SET last_fetched = COALESCE(last_fetched, 0) - \(seconds);")
+}
+```
+
+- [ ] **Step 5: Run tests + format + commit**
+
+```bash
+just test SQLiteCoinGeckoCatalogRefreshTests 2>&1 | tee .agent-tmp/task5.txt
+just format
+git add Backends/CoinGecko/SQLiteCoinGeckoCatalog.swift MoolahTests/Backends/SQLiteCoinGeckoCatalogRefreshTests.swift MoolahTests/Support/Fixtures/coingecko-coins-list-small.json MoolahTests/Support/Fixtures/coingecko-coins-list-small-updated.json MoolahTests/Support/Fixtures/coingecko-asset-platforms.json
+git commit -m "feat(catalog): ETag-aware refresh against /coins/list and /asset_platforms"
+rm .agent-tmp/task5.txt
+```
+
+Expected: 5 tests pass.
+
+---
+
+## Task 8 — `ProfileSession` integration: build the catalog and call `refreshIfStale()`
+
+**Files:**
+- Modify: `App/ProfileSession.swift` (add `coinGeckoCatalog: CoinGeckoCatalog?` stored property)
+- Modify: `App/ProfileSession+Factories.swift` (extend `makeRegistryWiring` to construct the catalog and trigger refresh)
+
+- [ ] **Step 1: Write the failing test**
+
+```swift
+// MoolahTests/App/ProfileSessionCatalogIntegrationTests.swift
+import XCTest
+@testable import Moolah
+
+@MainActor
+final class ProfileSessionCatalogIntegrationTests: XCTestCase {
+  func testCloudKitProfileExposesCatalog() async throws {
+    let backend = TestBackend.cloudKit()
+    let session = ProfileSession.makeForTest(backend: backend)
+    XCTAssertNotNil(session.coinGeckoCatalog)
+  }
+
+  func testRemoteProfileHasNoCatalog() async throws {
+    let backend = TestBackend.remote()
+    let session = ProfileSession.makeForTest(backend: backend)
+    XCTAssertNil(session.coinGeckoCatalog)
+  }
+}
+```
+
+`TestBackend.cloudKit()` and `.remote()` already exist for the existing test wiring. `ProfileSession.makeForTest(backend:)` is a test factory that wraps `makeRegistryWiring`; if it doesn't exist, add it as part of this task using the same composition `App/MoolahApp+Setup.swift` uses today.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+just test ProfileSessionCatalogIntegrationTests 2>&1 | tee .agent-tmp/task6.txt
+```
+
+Expected: FAIL — `coinGeckoCatalog` not a member of `ProfileSession`.
+
+- [ ] **Step 3: Implement**
+
+Add to `App/ProfileSession.swift`:
+
+```swift
+let coinGeckoCatalog: (any CoinGeckoCatalog)?
+```
+
+Add it to the `init` argument list and the existing `RegistryWiring` initialiser path.
+
+In `App/ProfileSession+Factories.swift`, extend `RegistryWiring`:
+
+```swift
+struct RegistryWiring {
+  let registry: (any InstrumentRegistryRepository)?
+  let cryptoTokenStore: CryptoTokenStore?
+  let searchService: InstrumentSearchService?
+  let coinGeckoCatalog: (any CoinGeckoCatalog)?
+}
+```
+
+In `makeRegistryWiring`:
+
+```swift
+@MainActor
+static func makeRegistryWiring(
+  backend: BackendProvider,
+  cryptoPriceService: CryptoPriceService,
+  yahooPriceFetcher: any YahooFinancePriceFetcher,
+  coinGeckoApiKey: String?
+) -> RegistryWiring {
+  guard let cloudBackend = backend as? CloudKitBackend else {
+    return RegistryWiring(
+      registry: nil, cryptoTokenStore: nil, searchService: nil, coinGeckoCatalog: nil)
+  }
+
+  let catalogDirectory = catalogDirectoryURL()
+  let catalog: (any CoinGeckoCatalog)?
+  do {
+    catalog = try SQLiteCoinGeckoCatalog(directory: catalogDirectory)
+    Task.detached(priority: .background) { [catalog] in
+      await catalog?.refreshIfStale()
+    }
+  } catch {
+    Logger(subsystem: "moolah.instrument-registry", category: "session")
+      .error("catalog init failed: \(String(describing: error), privacy: .public)")
+    catalog = nil
+  }
+
+  let store = CryptoTokenStore(
+    registry: cloudBackend.instrumentRegistry,
+    cryptoPriceService: cryptoPriceService)
+  let searchService = InstrumentSearchService(
+    registry: cloudBackend.instrumentRegistry,
+    catalog: catalog,
+    resolutionClient: CompositeTokenResolutionClient(coinGeckoApiKey: coinGeckoApiKey),
+    stockSearchClient: YahooFinanceStockSearchClient(),
+    stockValidator: YahooFinanceStockTickerValidator(priceFetcher: yahooPriceFetcher)
+  )
+  return RegistryWiring(
+    registry: cloudBackend.instrumentRegistry,
+    cryptoTokenStore: store,
+    searchService: searchService,
+    coinGeckoCatalog: catalog
+  )
+}
+
+private static func catalogDirectoryURL() -> URL {
+  let support = try? FileManager.default.url(
+    for: .applicationSupportDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
+  return (support ?? URL(fileURLWithPath: NSTemporaryDirectory()))
+    .appendingPathComponent("InstrumentRegistry", isDirectory: true)
+}
+```
+
+The `InstrumentSearchService(...)` and `YahooFinanceStockSearchClient()` shapes used here come from Tasks 6 and 7 — execute those first.
+
+- [ ] **Step 4: Run tests + format**
+
+```bash
+just test ProfileSessionCatalogIntegrationTests 2>&1 | tee .agent-tmp/task6.txt
+just format
+```
+
+Expected: 2 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add App/ProfileSession.swift App/ProfileSession+Factories.swift MoolahTests/App/ProfileSessionCatalogIntegrationTests.swift project.yml
+git commit -m "feat(session): wire CoinGeckoCatalog into ProfileSession lifecycle"
+rm .agent-tmp/task6.txt
+```
+
+---
+
+## Task 6 — `StockSearchClient` protocol + `YahooFinanceStockSearchClient`
+
+**Files:**
+- Create: `Domain/Repositories/StockSearchClient.swift`
+- Create: `Backends/YahooFinance/YahooFinanceStockSearchClient.swift`
+- Create: `MoolahTests/Support/Fixtures/yahoo-finance-search-apple.json`
+- Create: `MoolahTests/Backends/YahooFinanceStockSearchClientTests.swift`
+
+- [ ] **Step 1: Write the fixture**
+
+`MoolahTests/Support/Fixtures/yahoo-finance-search-apple.json` — a trimmed copy of an actual Yahoo response (use this exact content):
+
+```json
+{
+  "explains": [],
+  "count": 6,
+  "quotes": [
+    {"symbol":"AAPL","shortname":"Apple Inc.","exchange":"NMS","quoteType":"EQUITY"},
+    {"symbol":"APC.DE","shortname":"Apple Inc.                    R","exchange":"GER","quoteType":"EQUITY"},
+    {"symbol":"APLE.TO","shortname":"HARVEST APPLE ENHNCD HIGH INCM  ","exchange":"TOR","quoteType":"ETF"},
+    {"symbol":"AAPY.DE","shortname":"Leverage Shares PLC           E","exchange":"GER","quoteType":"OPTION"},
+    {"symbol":"^GSPC","shortname":"S&P 500","exchange":"SNP","quoteType":"INDEX"},
+    {"symbol":"FXAIX","shortname":"Fidelity 500 Index Fund","exchange":"NAS","quoteType":"MUTUALFUND"}
+  ],
+  "news": []
+}
+```
+
+- [ ] **Step 2: Write the failing test**
+
+```swift
+// MoolahTests/Backends/YahooFinanceStockSearchClientTests.swift
+import XCTest
+@testable import Moolah
+
+final class YahooFinanceStockSearchClientTests: XCTestCase {
+  override func setUp() { URLProtocol.registerClass(StubURLProtocol.self) }
+  override func tearDown() {
+    URLProtocol.unregisterClass(StubURLProtocol.self)
+    StubURLProtocol.handlers = [:]
+  }
+
+  private func session() -> URLSession {
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [StubURLProtocol.self]
+    return URLSession(configuration: config)
+  }
+
+  private func loadFixture() throws -> Data {
+    try Data(contentsOf: XCTUnwrap(
+      Bundle(for: type(of: self)).url(
+        forResource: "yahoo-finance-search-apple", withExtension: "json")))
+  }
+
+  func testReturnsEquityEtfMutualFundOnly() async throws {
+    let data = try loadFixture()
+    StubURLProtocol.handlers["query1.finance.yahoo.com:/v1/finance/search"] = { _ in
+      (HTTPURLResponse.ok(etag: ""), data)
+    }
+    let client = YahooFinanceStockSearchClient(session: session())
+    let hits = try await client.search(query: "apple")
+    XCTAssertEqual(hits.map(\.symbol), ["AAPL", "APC.DE", "APLE.TO", "FXAIX"])
+  }
+
+  func testNamesAreTrimmed() async throws {
+    let data = try loadFixture()
+    StubURLProtocol.handlers["query1.finance.yahoo.com:/v1/finance/search"] = { _ in
+      (HTTPURLResponse.ok(etag: ""), data)
+    }
+    let client = YahooFinanceStockSearchClient(session: session())
+    let hits = try await client.search(query: "apple")
+    XCTAssertEqual(hits.first { $0.symbol == "APC.DE" }?.name, "Apple Inc.                    R".trimmingCharacters(in: .whitespaces))
+  }
+
+  func testQueryParamsAreSentCorrectly() async throws {
+    let data = try loadFixture()
+    var captured: URL?
+    StubURLProtocol.handlers["query1.finance.yahoo.com:/v1/finance/search"] = { request in
+      captured = request.url
+      return (HTTPURLResponse.ok(etag: ""), data)
+    }
+    let client = YahooFinanceStockSearchClient(session: session())
+    _ = try await client.search(query: "apple")
+    let components = URLComponents(url: try XCTUnwrap(captured), resolvingAgainstBaseURL: false)
+    let items = components?.queryItems?.reduce(into: [String: String]()) {
+      $0[$1.name] = $1.value
+    } ?? [:]
+    XCTAssertEqual(items["q"], "apple")
+    XCTAssertEqual(items["quotesCount"], "20")
+    XCTAssertEqual(items["newsCount"], "0")
+  }
+}
+```
+
+The `StubURLProtocol` and `HTTPURLResponse.ok(etag:)` helpers are the same as in Task 5; either copy them locally or — if Task 5 has landed — extract to `MoolahTests/Support/StubURLProtocol.swift` and update both call sites.
+
+- [ ] **Step 3: Run test to verify it fails**
+
+```bash
+just test YahooFinanceStockSearchClientTests 2>&1 | tee .agent-tmp/task7.txt
+```
+
+Expected: FAIL — `cannot find 'YahooFinanceStockSearchClient' in scope`.
+
+- [ ] **Step 4: Implement**
+
+```swift
+// Domain/Repositories/StockSearchClient.swift
+import Foundation
+
+struct StockSearchHit: Sendable, Hashable {
+  let symbol: String
+  let name: String
+  let exchange: String
+  let quoteType: QuoteType
+}
+
+enum QuoteType: String, Sendable, Hashable, CaseIterable {
+  case equity = "EQUITY"
+  case etf = "ETF"
+  case mutualFund = "MUTUALFUND"
+}
+
+protocol StockSearchClient: Sendable {
+  func search(query: String) async throws -> [StockSearchHit]
+}
+```
+
+```swift
+// Backends/YahooFinance/YahooFinanceStockSearchClient.swift
+import Foundation
+
+struct YahooFinanceStockSearchClient: StockSearchClient {
+  private let session: URLSession
+  private static let baseURL = URL(
+    string: "https://query1.finance.yahoo.com/v1/finance/search")!
+
+  init(session: URLSession = .shared) {
+    self.session = session
+  }
+
+  func search(query: String) async throws -> [StockSearchHit] {
+    var components = URLComponents(url: Self.baseURL, resolvingAgainstBaseURL: false)
+    components?.queryItems = [
+      URLQueryItem(name: "q", value: query),
+      URLQueryItem(name: "quotesCount", value: "20"),
+      URLQueryItem(name: "newsCount", value: "0"),
+    ]
+    guard let url = components?.url else { throw URLError(.badURL) }
+    var request = URLRequest(url: url)
+    request.setValue("Mozilla/5.0", forHTTPHeaderField: "User-Agent")
+    let (data, response) = try await session.data(for: request)
+    guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+      throw URLError(.badServerResponse)
+    }
+    let decoded = try JSONDecoder().decode(Wire.self, from: data)
+    return decoded.quotes.compactMap { wire in
+      guard let quoteType = QuoteType(rawValue: wire.quoteType) else { return nil }
+      let displayName =
+        (wire.shortname?.trimmingCharacters(in: .whitespacesAndNewlines).nonEmpty
+          ?? wire.longname?.trimmingCharacters(in: .whitespacesAndNewlines))
+          ?? wire.symbol
+      return StockSearchHit(
+        symbol: wire.symbol,
+        name: displayName,
+        exchange: wire.exchange,
+        quoteType: quoteType
+      )
+    }
+  }
+}
+
+private struct Wire: Decodable {
+  let quotes: [WireQuote]
+}
+
+private struct WireQuote: Decodable {
+  let symbol: String
+  let shortname: String?
+  let longname: String?
+  let exchange: String
+  let quoteType: String
+}
+
+private extension String {
+  var nonEmpty: String? { isEmpty ? nil : self }
+}
+```
+
+- [ ] **Step 5: Run tests + format + commit**
+
+```bash
+just test YahooFinanceStockSearchClientTests 2>&1 | tee .agent-tmp/task7.txt
+just format
+git add Domain/Repositories/StockSearchClient.swift Backends/YahooFinance/YahooFinanceStockSearchClient.swift MoolahTests/Backends/YahooFinanceStockSearchClientTests.swift MoolahTests/Support/Fixtures/yahoo-finance-search-apple.json project.yml
+git commit -m "feat(stock): Yahoo Finance name-search via /v1/finance/search"
+rm .agent-tmp/task7.txt
+```
+
+Expected: 3 tests pass.
+
+---
+
+## Task 7 — `InstrumentSearchService`: catalog + stock search, drop `providerSources`
+
+**Files:**
+- Modify: `Shared/InstrumentSearchService.swift`
+- Modify: `Shared/InstrumentSearchResult.swift` (only if `requiresResolution`-related fields need a docstring update)
+- Create / modify: `MoolahTests/Shared/InstrumentSearchServiceTests.swift`
+
+The new init shape:
+
+```swift
+init(
+  registry: any InstrumentRegistryRepository,
+  catalog: (any CoinGeckoCatalog)?,
+  resolutionClient: any TokenResolutionClient,
+  stockSearchClient: any StockSearchClient,
+  stockValidator: any StockTickerValidator
+)
+```
+
+`CryptoSearchClient` and `ProviderSources` are removed.
+
+- [ ] **Step 1: Write failing tests**
+
+```swift
+// MoolahTests/Shared/InstrumentSearchServiceTests.swift
+import XCTest
+@testable import Moolah
+
+final class InstrumentSearchServiceTests: XCTestCase {
+  func testFiatPrefixHitsAreReturned() async {
+    let service = makeService()
+    let results = await service.search(query: "USD", kinds: [.fiatCurrency])
+    XCTAssertTrue(results.contains { $0.instrument.id == "USD" && $0.isRegistered })
+  }
+
+  func testCryptoResultsCarryCatalogPlatform() async {
+    let catalog = StubCatalog(entries: [
+      CatalogEntry(
+        coingeckoId: "uniswap", symbol: "UNI", name: "Uniswap",
+        platforms: [PlatformBinding(slug: "ethereum", chainId: 1, contractAddress: "0xUNI")]
+      )
+    ])
+    let service = makeService(catalog: catalog)
+    let results = await service.search(query: "uni", kinds: [.cryptoToken])
+    let uni = try XCTUnwrap(results.first)
+    XCTAssertEqual(uni.instrument.id, "1:0xuni")
+    XCTAssertTrue(uni.requiresResolution)
+    XCTAssertNil(uni.cryptoMapping)
+  }
+
+  func testStockResultsAreLoadedFromSearchClient() async throws {
+    let client = StubStockSearchClient(hits: [
+      StockSearchHit(symbol: "AAPL", name: "Apple Inc.", exchange: "NMS", quoteType: .equity)
+    ])
+    let service = makeService(stockSearchClient: client)
+    let results = await service.search(query: "apple", kinds: [.stock])
+    let aapl = try XCTUnwrap(results.first)
+    XCTAssertEqual(aapl.instrument.id, "NMS:AAPL")
+    XCTAssertFalse(aapl.requiresResolution)
+  }
+
+  func testRegisteredCryptoOverridesCatalogResult() async throws {
+    let registry = StubRegistry(
+      stored: [Instrument.crypto(chainId: 1, contractAddress: "0xuni",
+        symbol: "UNI", name: "Uniswap", decimals: 18)],
+      mappings: [CryptoProviderMapping(
+        instrumentId: "1:0xuni", coingeckoId: "uniswap",
+        cryptocompareSymbol: nil, binanceSymbol: nil)]
+    )
+    let catalog = StubCatalog(entries: [
+      CatalogEntry(
+        coingeckoId: "uniswap", symbol: "UNI", name: "Uniswap",
+        platforms: [PlatformBinding(slug: "ethereum", chainId: 1, contractAddress: "0xuni")])
+    ])
+    let service = makeService(registry: registry, catalog: catalog)
+    let results = await service.search(query: "uni", kinds: [.cryptoToken])
+    let uni = try XCTUnwrap(results.first)
+    XCTAssertTrue(uni.isRegistered)
+    XCTAssertFalse(uni.requiresResolution)
+    XCTAssertEqual(uni.cryptoMapping?.coingeckoId, "uniswap")
+  }
+}
+
+// Test seams (place in same file or `MoolahTests/Support/`).
+
+private func makeService(
+  registry: any InstrumentRegistryRepository = StubRegistry(),
+  catalog: (any CoinGeckoCatalog)? = StubCatalog(entries: []),
+  stockSearchClient: any StockSearchClient = StubStockSearchClient(hits: []),
+  resolutionClient: any TokenResolutionClient = NoOpTokenResolutionClient(),
+  stockValidator: any StockTickerValidator = StubStockValidator()
+) -> InstrumentSearchService {
+  InstrumentSearchService(
+    registry: registry, catalog: catalog, resolutionClient: resolutionClient,
+    stockSearchClient: stockSearchClient, stockValidator: stockValidator)
+}
+
+private struct StubCatalog: CoinGeckoCatalog {
+  let entries: [CatalogEntry]
+  func search(query: String, limit: Int) async -> [CatalogEntry] {
+    entries.filter {
+      $0.symbol.localizedCaseInsensitiveContains(query)
+        || $0.name.localizedCaseInsensitiveContains(query)
+    }
+    .prefix(limit).map { $0 }
+  }
+  func refreshIfStale() async {}
+}
+
+private struct StubStockSearchClient: StockSearchClient {
+  let hits: [StockSearchHit]
+  func search(query: String) async throws -> [StockSearchHit] { hits }
+}
+
+private final class StubRegistry: InstrumentRegistryRepository, @unchecked Sendable {
+  private var stored: [Instrument]
+  private var mappings: [CryptoProviderMapping]
+  init(stored: [Instrument] = [], mappings: [CryptoProviderMapping] = []) {
+    self.stored = stored
+    self.mappings = mappings
+  }
+  func all() async throws -> [Instrument] { stored }
+  func allCryptoRegistrations() async throws -> [CryptoRegistration] {
+    mappings.compactMap { mapping in
+      guard let inst = stored.first(where: { $0.id == mapping.instrumentId }) else { return nil }
+      return CryptoRegistration(instrument: inst, mapping: mapping)
+    }
+  }
+  func registerCrypto(_ instrument: Instrument, mapping: CryptoProviderMapping) async throws {
+    stored.removeAll { $0.id == instrument.id }
+    stored.append(instrument)
+    mappings.removeAll { $0.instrumentId == instrument.id }
+    mappings.append(mapping)
+  }
+  func registerStock(_ instrument: Instrument) async throws {
+    stored.removeAll { $0.id == instrument.id }
+    stored.append(instrument)
+  }
+  func remove(id: String) async throws {
+    stored.removeAll { $0.id == id }
+    mappings.removeAll { $0.instrumentId == id }
+  }
+  @MainActor
+  func observeChanges() -> AsyncStream<Void> { AsyncStream { _ in } }
+}
+
+private struct StubStockValidator: StockTickerValidator {
+  func validate(query: String) async throws -> ValidatedStockTicker? { nil }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+just test InstrumentSearchServiceTests 2>&1 | tee .agent-tmp/task8.txt
+```
+
+Expected: FAIL — `extra argument 'catalog' in call` and similar.
+
+- [ ] **Step 3: Implement**
+
+Replace the body of `InstrumentSearchService.swift` (the design's mapping logic translates almost line-for-line; key sections shown below — preserve any existing fiat helper):
+
+```swift
+struct InstrumentSearchService: Sendable {
+  private let registry: any InstrumentRegistryRepository
+  private let catalog: (any CoinGeckoCatalog)?
+  private let resolutionClient: any TokenResolutionClient
+  private let stockSearchClient: any StockSearchClient
+  private let stockValidator: any StockTickerValidator
+
+  init(
+    registry: any InstrumentRegistryRepository,
+    catalog: (any CoinGeckoCatalog)?,
+    resolutionClient: any TokenResolutionClient,
+    stockSearchClient: any StockSearchClient,
+    stockValidator: any StockTickerValidator
+  ) {
+    self.registry = registry
+    self.catalog = catalog
+    self.resolutionClient = resolutionClient
+    self.stockSearchClient = stockSearchClient
+    self.stockValidator = stockValidator
+  }
+
+  func search(
+    query: String,
+    kinds: Set<Instrument.Kind> = Set(Instrument.Kind.allCases)
+  ) async -> [InstrumentSearchResult] {
+    let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+    let registered = (try? await registry.all()) ?? []
+    let cryptoMappings = (try? await registry.allCryptoRegistrations()) ?? []
+    var results: [InstrumentSearchResult] = []
+
+    if kinds.contains(.fiatCurrency) {
+      results.append(contentsOf: searchFiat(query: trimmed, registered: registered))
+    }
+    if kinds.contains(.stock) {
+      results.append(
+        contentsOf: await searchStock(query: trimmed, registered: registered))
+    }
+    if kinds.contains(.cryptoToken) {
+      results.append(
+        contentsOf: await searchCrypto(
+          query: trimmed, registered: registered, mappings: cryptoMappings))
+    }
+    return results
+  }
+
+  // ... `searchFiat` (existing) ...
+
+  private func searchStock(
+    query: String, registered: [Instrument]
+  ) async -> [InstrumentSearchResult] {
+    guard !query.isEmpty else { return [] }
+    do {
+      let hits = try await stockSearchClient.search(query: query)
+      return hits.map { hit in
+        let instrument = Instrument.stock(
+          exchange: hit.exchange, ticker: hit.symbol, name: hit.name)
+        let registeredHit = registered.contains { $0.id == instrument.id }
+        return InstrumentSearchResult(
+          instrument: instrument,
+          cryptoMapping: nil,
+          isRegistered: registeredHit,
+          requiresResolution: !registeredHit
+        )
+      }
+    } catch {
+      return []
+    }
+  }
+
+  private func searchCrypto(
+    query: String,
+    registered: [Instrument],
+    mappings: [CryptoRegistration]
+  ) async -> [InstrumentSearchResult] {
+    guard let catalog else { return [] }
+    let entries = await catalog.search(query: query, limit: 20)
+    return entries.map { entry in
+      let instrument: Instrument
+      let id: String
+      if let platform = entry.preferredPlatform, let chainId = platform.chainId {
+        id = "\(chainId):\(platform.contractAddress)"
+        instrument = Instrument.crypto(
+          chainId: chainId,
+          contractAddress: platform.contractAddress,
+          symbol: entry.symbol,
+          name: entry.name,
+          decimals: 18  // unknown until resolve(); 18 is the EVM default and is overwritten on register
+        )
+      } else {
+        id = "native:\(entry.symbol)"
+        instrument = Instrument.crypto(
+          chainId: 0,
+          contractAddress: entry.symbol.lowercased(),
+          symbol: entry.symbol,
+          name: entry.name,
+          decimals: 8
+        )
+      }
+      let registration = mappings.first { $0.instrument.id == id }
+      let isRegistered = registration != nil
+      return InstrumentSearchResult(
+        instrument: registration?.instrument ?? instrument,
+        cryptoMapping: registration?.mapping,
+        isRegistered: isRegistered,
+        requiresResolution: !isRegistered
+      )
+    }
+  }
+}
+```
+
+The `Instrument.stock(exchange:ticker:name:)` and `Instrument.crypto(chainId:contractAddress:symbol:name:decimals:)` factories are existing — verify their argument labels match the project's current shape and adjust if needed (the factories shipped with the registry-backend work).
+
+- [ ] **Step 4: Run tests + format**
+
+```bash
+just test InstrumentSearchServiceTests 2>&1 | tee .agent-tmp/task8.txt
+just format
+```
+
+Expected: 4 tests pass. Existing call sites that passed `providerSources:` will now fail to compile — the only such call site is in `InstrumentPickerStore` (Task 9). If a temporary blocker appears, drop the `providerSources:` argument at the call site for now; Task 9 finalises that file.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Shared/InstrumentSearchService.swift Shared/InstrumentPickerStore.swift MoolahTests/Shared/InstrumentSearchServiceTests.swift App/ProfileSession+Factories.swift project.yml
+git commit -m "feat(search): InstrumentSearchService uses catalog + stock search"
+rm .agent-tmp/task8.txt
+```
+
+---
+
+## Task 9 — `InstrumentPickerStore`: register crypto on `select(_:)`, drop `.stocksOnly`
+
+**Files:**
+- Modify: `Shared/InstrumentPickerStore.swift`
+- Modify / create: `MoolahTests/Shared/InstrumentPickerStoreTests.swift`
+
+- [ ] **Step 1: Write the failing test**
+
+```swift
+// MoolahTests/Shared/InstrumentPickerStoreTests.swift
+import XCTest
+@testable import Moolah
+
+@MainActor
+final class InstrumentPickerStoreTests: XCTestCase {
+  func testSelectingUnregisteredCryptoRunsResolveAndRegisters() async throws {
+    let registry = StubRegistry()
+    let resolver = StubResolutionClient(result: TokenResolutionResult(
+      coingeckoId: "uniswap",
+      cryptocompareSymbol: "UNI",
+      binanceSymbol: "UNIUSDT",
+      resolvedName: "Uniswap",
+      resolvedSymbol: "UNI",
+      resolvedDecimals: 18
+    ))
+    let result = InstrumentSearchResult(
+      instrument: Instrument.crypto(
+        chainId: 1, contractAddress: "0xuni", symbol: "UNI", name: "Uniswap", decimals: 18),
+      cryptoMapping: nil,
+      isRegistered: false,
+      requiresResolution: true
+    )
+    let store = InstrumentPickerStore(
+      searchService: nil, registry: registry, resolutionClient: resolver,
+      kinds: [.cryptoToken])
+    let selected = await store.select(result)
+    XCTAssertNotNil(selected)
+    let stored = try await registry.allCryptoRegistrations()
+    XCTAssertEqual(stored.first?.mapping.coingeckoId, "uniswap")
+  }
+
+  func testSelectingUnregisteredCryptoWithoutAnyMappingFailsAndDoesNotWrite() async throws {
+    let registry = StubRegistry()
+    let resolver = StubResolutionClient(result: TokenResolutionResult(
+      coingeckoId: nil, cryptocompareSymbol: nil, binanceSymbol: nil,
+      resolvedName: nil, resolvedSymbol: nil, resolvedDecimals: nil))
+    let result = InstrumentSearchResult(
+      instrument: Instrument.crypto(
+        chainId: 1, contractAddress: "0xfoo", symbol: "FOO", name: "Foo", decimals: 18),
+      cryptoMapping: nil,
+      isRegistered: false,
+      requiresResolution: true
+    )
+    let store = InstrumentPickerStore(
+      searchService: nil, registry: registry, resolutionClient: resolver,
+      kinds: [.cryptoToken])
+    let selected = await store.select(result)
+    XCTAssertNil(selected)
+    XCTAssertNotNil(store.error)
+    let stored = try await registry.allCryptoRegistrations()
+    XCTAssertTrue(stored.isEmpty)
+  }
+
+  func testSelectingRegisteredCryptoReturnsImmediately() async throws {
+    let registered = Instrument.crypto(
+      chainId: 1, contractAddress: "0xuni", symbol: "UNI", name: "Uniswap", decimals: 18)
+    let registry = StubRegistry(stored: [registered],
+      mappings: [CryptoProviderMapping(
+        instrumentId: registered.id, coingeckoId: "uniswap",
+        cryptocompareSymbol: nil, binanceSymbol: nil)])
+    let resolver = StubResolutionClient(result: TokenResolutionResult(
+      coingeckoId: nil, cryptocompareSymbol: nil, binanceSymbol: nil,
+      resolvedName: nil, resolvedSymbol: nil, resolvedDecimals: nil))
+    let result = InstrumentSearchResult(
+      instrument: registered,
+      cryptoMapping: CryptoProviderMapping(
+        instrumentId: registered.id, coingeckoId: "uniswap",
+        cryptocompareSymbol: nil, binanceSymbol: nil),
+      isRegistered: true,
+      requiresResolution: false
+    )
+    let store = InstrumentPickerStore(
+      searchService: nil, registry: registry, resolutionClient: resolver,
+      kinds: [.cryptoToken])
+    let selected = await store.select(result)
+    XCTAssertEqual(selected?.id, registered.id)
+    XCTAssertEqual(resolver.callCount, 0)
+  }
+}
+
+// Stubs
+private final class StubResolutionClient: TokenResolutionClient, @unchecked Sendable {
+  let result: TokenResolutionResult
+  private(set) var callCount = 0
+  init(result: TokenResolutionResult) { self.result = result }
+  func resolve(
+    chainId: Int, contractAddress: String?, symbol: String?, isNative: Bool
+  ) async throws -> TokenResolutionResult {
+    callCount += 1
+    return result
+  }
+}
+```
+
+`StubRegistry` is the one defined in Task 7's tests; lift it into `MoolahTests/Support/Stubs/StubRegistry.swift` so Task 9 can reuse it without duplicating the implementation.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+just test InstrumentPickerStoreTests 2>&1 | tee .agent-tmp/task9.txt
+```
+
+Expected: FAIL — `select(_:)` currently bails on crypto.
+
+- [ ] **Step 3: Implement**
+
+Modify `Shared/InstrumentPickerStore.swift`:
+
+1. Drop the `providerSources` parameter from the store (and from internal calls into the service).
+2. Add `private let resolutionClient: any TokenResolutionClient` to the init and store it.
+3. Replace `select(_:)`:
+
+```swift
+func select(_ result: InstrumentSearchResult) async -> Instrument? {
+  if result.isRegistered {
+    return result.instrument
+  }
+  switch result.instrument.kind {
+  case .fiatCurrency:
+    return result.instrument
+  case .stock:
+    do {
+      try await registry?.registerStock(result.instrument)
+      return result.instrument
+    } catch {
+      self.error = error.localizedDescription
+      return nil
+    }
+  case .cryptoToken:
+    return await registerCrypto(result)
+  }
+}
+
+private func registerCrypto(_ result: InstrumentSearchResult) async -> Instrument? {
+  guard let registry else { return nil }
+  isResolving = true
+  error = nil
+  defer { isResolving = false }
+  let instrument = result.instrument
+  let isNative = instrument.chainId == 0  // see InstrumentSearchService.searchCrypto
+  do {
+    let resolution = try await resolutionClient.resolve(
+      chainId: instrument.chainId,
+      contractAddress: isNative ? nil : instrument.contractAddress,
+      symbol: instrument.symbol,
+      isNative: isNative
+    )
+    guard
+      resolution.coingeckoId != nil
+      || resolution.cryptocompareSymbol != nil
+      || resolution.binanceSymbol != nil
+    else {
+      self.error = "Could not find a price source for this token."
+      return nil
+    }
+    let mapping = CryptoProviderMapping(
+      instrumentId: instrument.id,
+      coingeckoId: resolution.coingeckoId,
+      cryptocompareSymbol: resolution.cryptocompareSymbol,
+      binanceSymbol: resolution.binanceSymbol
+    )
+    try await registry.registerCrypto(instrument, mapping: mapping)
+    return instrument
+  } catch {
+    self.error = error.localizedDescription
+    return nil
+  }
+}
+```
+
+Add `var isResolving: Bool = false` to the published state if it does not already exist.
+
+- [ ] **Step 4: Run tests + format**
+
+```bash
+just test InstrumentPickerStoreTests 2>&1 | tee .agent-tmp/task9.txt
+just format
+```
+
+Expected: 3 tests pass. Verify the existing `InstrumentPickerSheet` continues to compile — the `select(_:)` signature is unchanged; only the body grew.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Shared/InstrumentPickerStore.swift MoolahTests/Shared/InstrumentPickerStoreTests.swift project.yml
+git commit -m "feat(picker): register crypto via resolve() on select"
+rm .agent-tmp/task9.txt
+```
+
+---
+
+## Task 10 — `AddTokenSheet` rewrite + `CryptoTokenStore` trim
+
+**Files:**
+- Modify: `Features/Settings/AddTokenSheet.swift`
+- Modify: `Features/Settings/CryptoTokenStore.swift`
+- Modify: `Features/Settings/CryptoSettingsView.swift` (only if it references the removed methods)
+- Modify / create: `MoolahTests/Features/CryptoTokenStoreTests.swift`
+
+- [ ] **Step 1: Write the failing test**
+
+```swift
+// MoolahTests/Features/CryptoTokenStoreTests.swift
+import XCTest
+@testable import Moolah
+
+@MainActor
+final class CryptoTokenStoreTests: XCTestCase {
+  func testInitializerAcceptsTrimmedDependencies() {
+    let registry = StubRegistry()
+    let priceService = MockCryptoPriceService()
+    let store = CryptoTokenStore(registry: registry, cryptoPriceService: priceService)
+    XCTAssertFalse(store.isLoading)
+    XCTAssertNil(store.error)
+  }
+
+  func testRemoveRegistrationDelegatesToRegistry() async throws {
+    let registered = Instrument.crypto(
+      chainId: 1, contractAddress: "0xuni", symbol: "UNI", name: "Uniswap", decimals: 18)
+    let registry = StubRegistry(
+      stored: [registered],
+      mappings: [CryptoProviderMapping(
+        instrumentId: registered.id, coingeckoId: "uniswap",
+        cryptocompareSymbol: nil, binanceSymbol: nil)])
+    let priceService = MockCryptoPriceService()
+    let store = CryptoTokenStore(registry: registry, cryptoPriceService: priceService)
+    await store.loadRegistrations()
+    let registration = try XCTUnwrap(store.registrations.first)
+    await store.removeRegistration(registration)
+    XCTAssertTrue(store.registrations.isEmpty)
+  }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+just test CryptoTokenStoreTests 2>&1 | tee .agent-tmp/task10.txt
+```
+
+Expected: FAIL — likely a compile error on still-present `resolveToken`/`confirmRegistration` after the trim, or the trim hasn't happened yet.
+
+- [ ] **Step 3: Trim `CryptoTokenStore`**
+
+Remove these members from `Features/Settings/CryptoTokenStore.swift`:
+- `var resolvedRegistration: CryptoRegistration?`
+- `var isResolving: Bool`
+- `func resolveToken(chainId:contractAddress:symbol:isNative:) async`
+- `func confirmRegistration() async`
+
+Keep:
+- `loadRegistrations`, `removeRegistration`, `removeInstrument`, `registrations`, `instruments`, `providerMappings`, `isLoading`, `error`, the API-key methods.
+
+- [ ] **Step 4: Rewrite `AddTokenSheet.swift`**
+
+Replace its body with:
+
+```swift
+import SwiftUI
+
+struct AddTokenSheet: View {
+  @Environment(\.dismiss) private var dismiss
+  let onRegistered: () -> Void
+
+  var body: some View {
+    InstrumentPickerSheet(kinds: [.cryptoToken]) { instrument in
+      if instrument != nil { onRegistered() }
+      dismiss()
+    }
+  }
+}
+```
+
+`InstrumentPickerSheet` is the existing sheet wrapper. If its signature does not currently expose a callback variant, add one in this task: an initialiser overload that takes `kinds:` and a `(Instrument?) -> Void` completion. The existing initialiser stays.
+
+In `CryptoSettingsView.swift`, change the "Add Token" action's destination to `AddTokenSheet { Task { await store.loadRegistrations() } }` (or equivalent).
+
+- [ ] **Step 5: Run tests + format + commit**
+
+```bash
+just test CryptoTokenStoreTests 2>&1 | tee .agent-tmp/task10.txt
+just test SettingsViewTests 2>&1 | tee -a .agent-tmp/task10.txt
+just format
+git add Features/Settings/AddTokenSheet.swift Features/Settings/CryptoTokenStore.swift Features/Settings/CryptoSettingsView.swift MoolahTests/Features/CryptoTokenStoreTests.swift Shared/Views/InstrumentPickerSheet.swift project.yml
+git commit -m "feat(settings): search-only Add Token flow"
+rm .agent-tmp/task10.txt
+```
+
+Expected: 2 new tests pass; existing settings tests unaffected.
+
+---
+
+## Task 11 — `CloudKitInstrumentRegistryRepository.notifyExternalChange()`
+
+**Files:**
+- Modify: `Backends/CloudKit/Repositories/CloudKitInstrumentRegistryRepository.swift`
+- Modify / create: `MoolahTests/Backends/CloudKit/CloudKitInstrumentRegistryRepositoryTests.swift`
+
+- [ ] **Step 1: Write the failing test**
+
+```swift
+// MoolahTests/Backends/CloudKit/CloudKitInstrumentRegistryRepositoryTests.swift
+import XCTest
+import SwiftData
+@testable import Moolah
+
+@MainActor
+final class CloudKitInstrumentRegistryRepositoryNotifyTests: XCTestCase {
+  func testNotifyExternalChangeYieldsToActiveSubscribers() async throws {
+    let container = try ModelContainer(
+      for: InstrumentRecord.self,
+      configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+    )
+    let registry = CloudKitInstrumentRegistryRepository(modelContainer: container)
+    let stream = registry.observeChanges()
+    Task {
+      try? await Task.sleep(nanoseconds: 50_000_000)
+      registry.notifyExternalChange()
+    }
+    var iterator = stream.makeAsyncIterator()
+    let first = await iterator.next()
+    XCTAssertNotNil(first)
+  }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+just test CloudKitInstrumentRegistryRepositoryNotifyTests 2>&1 | tee .agent-tmp/task11.txt
+```
+
+Expected: FAIL — `cannot find 'notifyExternalChange'`.
+
+- [ ] **Step 3: Implement**
+
+Add to `CloudKitInstrumentRegistryRepository`:
+
+```swift
+@MainActor
+func notifyExternalChange() {
+  for continuation in subscribers.values {
+    continuation.yield()
+  }
+}
+```
+
+Verify the `subscribers` dictionary is at MainActor scope (it is, per the existing implementation).
+
+- [ ] **Step 4: Run tests + format**
+
+```bash
+just test CloudKitInstrumentRegistryRepositoryNotifyTests 2>&1 | tee .agent-tmp/task11.txt
+just format
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Backends/CloudKit/Repositories/CloudKitInstrumentRegistryRepository.swift MoolahTests/Backends/CloudKit/CloudKitInstrumentRegistryRepositoryTests.swift project.yml
+git commit -m "feat(registry): notifyExternalChange() for sync fan-out"
+rm .agent-tmp/task11.txt
+```
+
+---
+
+## Task 12 — Sync change-fan-out: `ProfileDataSyncHandler` + closure wiring
+
+**Files:**
+- Modify: `Backends/CloudKit/Sync/ProfileDataSyncHandler.swift` (init signature)
+- Modify: `Backends/CloudKit/Sync/ProfileDataSyncHandler+BatchUpsert.swift` (track instrument-touched flag, fire after commit)
+- Modify: `Backends/CloudKit/Sync/ProfileDataSyncHandler+QueueAndDelete.swift` (same on the deletion path)
+- Modify: `App/ProfileSession+Factories.swift` (pass closure when constructing handler)
+- Create: `MoolahTests/Backends/CloudKit/Sync/ProfileDataSyncHandlerInstrumentChangeTests.swift`
+
+- [ ] **Step 1: Write the failing test**
+
+```swift
+// MoolahTests/Backends/CloudKit/Sync/ProfileDataSyncHandlerInstrumentChangeTests.swift
+import XCTest
+import SwiftData
+import CloudKit
+@testable import Moolah
+
+@MainActor
+final class ProfileDataSyncHandlerInstrumentChangeTests: XCTestCase {
+  func testRemoteUpsertOfInstrumentTriggersChangeClosureOnce() async throws {
+    let context = try TestSyncContext.makeInMemory()
+    var fired = 0
+    let handler = ProfileDataSyncHandler(
+      modelContext: context.context,
+      systemFieldsStore: context.systemFieldsStore,
+      onInstrumentRemoteChange: { fired += 1 }
+    )
+    let record = CKRecord(recordType: "Instrument", recordID: CKRecord.ID(recordName: "1:0xuni"))
+    record["coingeckoId"] = "uniswap"
+    record["symbol"] = "UNI"
+    record["name"] = "Uniswap"
+    record["decimals"] = 18
+    record["chainId"] = 1
+    record["contractAddress"] = "0xuni"
+    record["kind"] = "cryptoToken"
+    try await handler.batchUpsertInstruments([record])
+    XCTAssertEqual(fired, 1)
+  }
+
+  func testRemoteUpsertOfNonInstrumentDoesNotTriggerClosure() async throws {
+    let context = try TestSyncContext.makeInMemory()
+    var fired = 0
+    let handler = ProfileDataSyncHandler(
+      modelContext: context.context,
+      systemFieldsStore: context.systemFieldsStore,
+      onInstrumentRemoteChange: { fired += 1 }
+    )
+    let record = CKRecord(recordType: "Account", recordID: CKRecord.ID(recordName: "acc-1"))
+    record["name"] = "Savings"
+    record["instrumentId"] = "USD"
+    try await handler.batchUpsertAccounts([record])
+    XCTAssertEqual(fired, 0)
+  }
+
+  func testRemoteDeletionOfInstrumentTriggersClosure() async throws {
+    let context = try TestSyncContext.makeInMemory()
+    var fired = 0
+    let handler = ProfileDataSyncHandler(
+      modelContext: context.context,
+      systemFieldsStore: context.systemFieldsStore,
+      onInstrumentRemoteChange: { fired += 1 }
+    )
+    try await handler.applyRemoteDeletions([
+      CKRecord.ID(recordName: "1:0xuni"): "Instrument"
+    ])
+    XCTAssertEqual(fired, 1)
+  }
+}
+```
+
+`TestSyncContext.makeInMemory()` is a small helper — add it to `MoolahTests/Support/TestSyncContext.swift` if it doesn't exist; it builds a SwiftData `ModelContainer(isStoredInMemoryOnly: true)` and an in-memory `SystemFieldsStore`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+just test ProfileDataSyncHandlerInstrumentChangeTests 2>&1 | tee .agent-tmp/task12.txt
+```
+
+Expected: FAIL — `extra argument 'onInstrumentRemoteChange'`.
+
+- [ ] **Step 3: Implement**
+
+In `ProfileDataSyncHandler.swift`, extend the initialiser:
+
+```swift
+init(
+  modelContext: ModelContext,
+  systemFieldsStore: SystemFieldsStore,
+  onInstrumentRemoteChange: @Sendable @escaping () -> Void = { }
+) {
+  self.modelContext = modelContext
+  self.systemFieldsStore = systemFieldsStore
+  self.onInstrumentRemoteChange = onInstrumentRemoteChange
+}
+
+private let onInstrumentRemoteChange: @Sendable () -> Void
+```
+
+In `ProfileDataSyncHandler+BatchUpsert.swift` (`batchUpsertInstruments`):
+
+```swift
+func batchUpsertInstruments(_ records: [CKRecord]) async throws {
+  guard !records.isEmpty else { return }
+  var anyTouched = false
+  // ... existing per-record upsert loop ...
+  // Inside the loop, set anyTouched = true whenever the row is inserted,
+  // updated, or has any of {coingeckoId, cryptocompareSymbol, binanceSymbol}
+  // change between old and new. Existing code already loads the record before
+  // updating; compare the relevant fields there.
+  try modelContext.save()
+  if anyTouched { onInstrumentRemoteChange() }
+}
+```
+
+In `ProfileDataSyncHandler+QueueAndDelete.swift` (`applyRemoteDeletions` — actual method name may differ; use the one called on delete paths):
+
+```swift
+func applyRemoteDeletions(_ deletions: [CKRecord.ID: String]) async throws {
+  // ... existing loop ...
+  let deletedAnyInstrument = deletions.values.contains("Instrument")
+  // ... save context ...
+  if deletedAnyInstrument { onInstrumentRemoteChange() }
+}
+```
+
+In `App/ProfileSession+Factories.swift`, when constructing the handler that drives sync (look in `makeBackend` or `makeSyncCoordinator`):
+
+```swift
+let handler = ProfileDataSyncHandler(
+  modelContext: context,
+  systemFieldsStore: systemFieldsStore,
+  onInstrumentRemoteChange: { [weak registry] in
+    Task { @MainActor in registry?.notifyExternalChange() }
+  }
+)
+```
+
+`registry` here is the concrete `CloudKitInstrumentRegistryRepository`. If the factory currently exposes only the protocol-typed `instrumentRegistry`, capture the concrete instance separately at construction time.
+
+- [ ] **Step 4: Run tests + format**
+
+```bash
+just test ProfileDataSyncHandlerInstrumentChangeTests 2>&1 | tee .agent-tmp/task12.txt
+just format
+```
+
+Expected: 3 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Backends/CloudKit/Sync/ProfileDataSyncHandler.swift Backends/CloudKit/Sync/ProfileDataSyncHandler+BatchUpsert.swift Backends/CloudKit/Sync/ProfileDataSyncHandler+QueueAndDelete.swift App/ProfileSession+Factories.swift MoolahTests/Backends/CloudKit/Sync/ProfileDataSyncHandlerInstrumentChangeTests.swift MoolahTests/Support/TestSyncContext.swift project.yml
+git commit -m "feat(sync): fan-out remote instrument changes to registry observers"
+rm .agent-tmp/task12.txt
+```
+
+---
+
+## Task 13 — `RepositoryError.unmappedCryptoInstrument` case
+
+**Files:**
+- Modify: `Domain/Repositories/RepositoryError.swift` (or wherever the project's repository-error enum lives — check via `grep -rn 'enum RepositoryError' Domain/ Backends/`)
+- Create: `MoolahTests/Domain/RepositoryErrorTests.swift`
+
+If no shared `RepositoryError` exists, the existing tightening will need its own dedicated error type — name it `UnmappedCryptoInstrumentError` and place it in `Domain/Errors/UnmappedCryptoInstrumentError.swift`.
+
+- [ ] **Step 1: Write the failing test**
+
+```swift
+// MoolahTests/Domain/RepositoryErrorTests.swift
+import XCTest
+@testable import Moolah
+
+final class RepositoryErrorTests: XCTestCase {
+  func testUnmappedCryptoInstrumentEqualityByInstrumentId() {
+    let a = RepositoryError.unmappedCryptoInstrument(instrumentId: "1:0xuni")
+    let b = RepositoryError.unmappedCryptoInstrument(instrumentId: "1:0xuni")
+    let c = RepositoryError.unmappedCryptoInstrument(instrumentId: "1:0xother")
+    XCTAssertEqual(a, b)
+    XCTAssertNotEqual(a, c)
+  }
+
+  func testUnmappedCryptoInstrumentLocalizedDescription() {
+    let error = RepositoryError.unmappedCryptoInstrument(instrumentId: "1:0xuni")
+    XCTAssertTrue(error.localizedDescription.contains("1:0xuni"))
+  }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+just test RepositoryErrorTests 2>&1 | tee .agent-tmp/task13.txt
+```
+
+Expected: FAIL — case not present.
+
+- [ ] **Step 3: Implement**
+
+Add the case to the existing `RepositoryError` enum (or create the new enum if absent):
+
+```swift
+case unmappedCryptoInstrument(instrumentId: String)
+```
+
+If `RepositoryError` already exists and has a `LocalizedError` extension, add a description for the new case:
+
+```swift
+case .unmappedCryptoInstrument(let id):
+  return "Crypto instrument \(id) cannot be saved without a price-provider mapping."
+```
+
+- [ ] **Step 4: Run tests + format**
+
+```bash
+just test RepositoryErrorTests 2>&1 | tee .agent-tmp/task13.txt
+just format
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Domain/Repositories/RepositoryError.swift MoolahTests/Domain/RepositoryErrorTests.swift
+git commit -m "feat(domain): RepositoryError.unmappedCryptoInstrument case"
+rm .agent-tmp/task13.txt
+```
+
+---
+
+## Task 14 — Tighten `ensureInstrument` in `CloudKitTransactionRepository`
+
+**Files:**
+- Modify: `Backends/CloudKit/Repositories/CloudKitTransactionRepository.swift:55`
+- Create: `MoolahTests/Backends/CloudKit/CloudKitTransactionRepositoryEnsureInstrumentTests.swift`
+
+- [ ] **Step 1: Write the failing test**
+
+```swift
+// MoolahTests/Backends/CloudKit/CloudKitTransactionRepositoryEnsureInstrumentTests.swift
+import XCTest
+import SwiftData
+@testable import Moolah
+
+@MainActor
+final class CloudKitTransactionRepositoryEnsureInstrumentTests: XCTestCase {
+  func testFiatInstrumentSucceeds() throws {
+    let repo = makeRepo()
+    XCTAssertNoThrow(
+      try repo.ensureInstrumentForTesting(
+        Instrument.fiatCurrency(code: "USD")))
+  }
+
+  func testMappedCryptoInstrumentSucceeds() throws {
+    let repo = makeRepo()
+    let inst = Instrument.crypto(
+      chainId: 1, contractAddress: "0xuni", symbol: "UNI", name: "Uniswap", decimals: 18)
+    try repo.seedRegisteredCryptoForTesting(
+      instrument: inst,
+      mapping: CryptoProviderMapping(
+        instrumentId: inst.id, coingeckoId: "uniswap",
+        cryptocompareSymbol: nil, binanceSymbol: nil))
+    XCTAssertNoThrow(try repo.ensureInstrumentForTesting(inst))
+  }
+
+  func testUnmappedCryptoInstrumentThrows() throws {
+    let repo = makeRepo()
+    let inst = Instrument.crypto(
+      chainId: 1, contractAddress: "0xfoo", symbol: "FOO", name: "Foo", decimals: 18)
+    XCTAssertThrowsError(try repo.ensureInstrumentForTesting(inst)) { error in
+      XCTAssertEqual(
+        error as? RepositoryError,
+        .unmappedCryptoInstrument(instrumentId: inst.id))
+    }
+  }
+
+  private func makeRepo() -> CloudKitTransactionRepository { /* Test factory */ }
+}
+```
+
+The `ensureInstrumentForTesting` and `seedRegisteredCryptoForTesting` are thin internal-visibility wrappers exposing the existing private helper for the test. `makeRepo()` constructs the repository against an in-memory `ModelContainer`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+just test CloudKitTransactionRepositoryEnsureInstrumentTests 2>&1 | tee .agent-tmp/task14.txt
+```
+
+Expected: FAIL on `testUnmappedCryptoInstrumentThrows` — current behaviour silently inserts.
+
+- [ ] **Step 3: Implement**
+
+In `CloudKitTransactionRepository.swift`, replace the existing `ensureInstrument(_:)`:
+
+```swift
+func ensureInstrument(_ instrument: Instrument) throws {
+  switch instrument.kind {
+  case .fiatCurrency:
+    instrumentCache[instrument.id] = instrument
+    return
+  case .stock:
+    // Stock path unchanged in this plan; see design §4.8.
+    let iid = instrument.id
+    let descriptor = FetchDescriptor<InstrumentRecord>(
+      predicate: #Predicate { $0.id == iid })
+    if try context.fetch(descriptor).isEmpty {
+      context.insert(InstrumentRecord.from(instrument))
+      onInstrumentChanged(instrument.id)
+    }
+    instrumentCache[instrument.id] = instrument
+  case .cryptoToken:
+    let iid = instrument.id
+    let descriptor = FetchDescriptor<InstrumentRecord>(
+      predicate: #Predicate { $0.id == iid })
+    let existing = try context.fetch(descriptor).first
+    let isMapped: Bool = {
+      guard let existing else { return false }
+      return existing.coingeckoId != nil
+        || existing.cryptocompareSymbol != nil
+        || existing.binanceSymbol != nil
+    }()
+    guard isMapped else {
+      throw RepositoryError.unmappedCryptoInstrument(instrumentId: instrument.id)
+    }
+    instrumentCache[instrument.id] = instrument
+  }
+}
+```
+
+The exact field names on `InstrumentRecord` (`coingeckoId`, etc.) are confirmed by the registry-backend design (§1.1). If they differ, follow the existing record schema.
+
+- [ ] **Step 4: Run tests + format**
+
+```bash
+just test CloudKitTransactionRepositoryEnsureInstrumentTests 2>&1 | tee .agent-tmp/task14.txt
+just format
+```
+
+Expected: 3 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Backends/CloudKit/Repositories/CloudKitTransactionRepository.swift MoolahTests/Backends/CloudKit/CloudKitTransactionRepositoryEnsureInstrumentTests.swift project.yml
+git commit -m "fix(repo): ensureInstrument throws on unmapped crypto"
+rm .agent-tmp/task14.txt
+```
+
+---
+
+## Task 15 — Tighten `ensureInstrument` in `CloudKitAccountRepository`
+
+**Files:**
+- Modify: `Backends/CloudKit/Repositories/CloudKitAccountRepository.swift:188`
+- Create: `MoolahTests/Backends/CloudKit/CloudKitAccountRepositoryEnsureInstrumentTests.swift`
+
+Mirror Task 14 for the account repository: same three test cases, same implementation pattern. Keep the test file separate so it can land independently.
+
+- [ ] **Step 1**: Write the test (same shape as Task 14, swap repository class).
+- [ ] **Step 2**: Run, expect failure on the unmapped-crypto case.
+- [ ] **Step 3**: Apply the same `ensureInstrument` body shown in Task 14.
+- [ ] **Step 4**: Run tests + format.
+- [ ] **Step 5**: Commit:
+
+```bash
+git add Backends/CloudKit/Repositories/CloudKitAccountRepository.swift MoolahTests/Backends/CloudKit/CloudKitAccountRepositoryEnsureInstrumentTests.swift project.yml
+git commit -m "fix(repo): ensureInstrument throws on unmapped crypto (account repo)"
+```
+
+---
+
+## Task 16 — XCUITest: register a crypto token from the picker
+
+**Files:**
+- Create: `MoolahUITests_macOS/InstrumentPickerCryptoSearchTests.swift`
+- Modify: `UITestSupport/UITestSeeds.swift` (add a `cryptoCatalogPreloaded` seed that injects a deterministic mini catalog snapshot via the test bridge)
+- Modify: `UITestSupport/InstrumentPickerScreen.swift` (extend driver as needed)
+
+This is a single happy-path test: open Settings → Crypto → Add Token, search "uni", select Uniswap, confirm the registration appears.
+
+- [ ] **Step 1: Write the test**
+
+```swift
+// MoolahUITests_macOS/InstrumentPickerCryptoSearchTests.swift
+import XCTest
+
+final class InstrumentPickerCryptoSearchTests: XCTestCase {
+  func testRegisterCryptoTokenViaPickerSearch() throws {
+    let app = XCUIApplication.launchedForTest(seed: "cryptoCatalogPreloaded")
+    let settings = app.openSettings()
+    let crypto = settings.openCryptoTab()
+    let addToken = crypto.tapAddToken()
+    addToken.searchField.type("uni")
+    addToken.waitForResult(symbol: "UNI", name: "Uniswap")
+    addToken.selectResult(symbol: "UNI")
+    addToken.waitForDismiss()
+    crypto.waitForRegistration(symbol: "UNI")
+  }
+}
+```
+
+`XCUIApplication.launchedForTest(seed:)`, `openSettings()`, `openCryptoTab()`, `tapAddToken()`, `searchField.type(_:)`, `waitForResult(symbol:name:)`, `selectResult(symbol:)`, `waitForDismiss()`, `waitForRegistration(symbol:)` are screen-driver methods on the existing UITestSupport helpers. Add any that don't yet exist; tests must NOT touch `XCUIElement` directly (per `guides/UI_TEST_GUIDE.md`).
+
+- [ ] **Step 2: Define the deterministic seed**
+
+In `UITestSupport/UITestSeeds.swift`, add a `cryptoCatalogPreloaded` case that the app's test bridge uses to:
+- Skip the live `refreshIfStale()`.
+- Replace the catalog with a fixed mini snapshot containing exactly one row (`uniswap, UNI, Uniswap, ethereum:0x1F9840…`).
+- Pre-stub the resolution client to return `(coingeckoId: "uniswap", cryptocompareSymbol: "UNI", binanceSymbol: "UNIUSDT")` for that input.
+
+The seed mechanism is the same one used elsewhere for deterministic UI tests (search `UITestSeeds.swift` for examples).
+
+- [ ] **Step 3: Run the test**
+
+```bash
+just test InstrumentPickerCryptoSearchTests 2>&1 | tee .agent-tmp/task16.txt
+```
+
+Expected: PASS. If it fails, investigate via `.xcresult` artefacts as per `guides/UI_TEST_GUIDE.md`. Do not add `sleep` calls.
+
+- [ ] **Step 4: Format + commit**
+
+```bash
+just format
+git add MoolahUITests_macOS/InstrumentPickerCryptoSearchTests.swift UITestSupport/UITestSeeds.swift UITestSupport/InstrumentPickerScreen.swift project.yml
+git commit -m "test(ui): register a crypto token via picker search"
+rm .agent-tmp/task16.txt
+```
+
+---
+
+## Self-review checklist (after final task)
+
+After landing all 16 tasks, run the full test matrix to catch regressions:
+
+```bash
+just test 2>&1 | tee .agent-tmp/full-suite.txt
+```
+
+Open the spec ([§ design](./2026-04-27-instrument-registry-ui-design.md)) and check each section has a corresponding task:
+
+| Spec section | Task |
+|---|---|
+| §3 D1 (search-only Add Token) | 10 |
+| §3 D2 (cached `/coins/list`) | 3, 4, 5 |
+| §3 D3 (SQLite + FTS5) | 2, 3, 4 |
+| §3 D4 (no migration framework) | 3 |
+| §3 D5 (`/asset_platforms` in same DB) | 2, 5 |
+| §3 D6 (refresh policy + ETag + silent failure) | 5 |
+| §3 D7 (`ensureInstrument` tightening) | 13, 14, 15 |
+| §3 D8 (Yahoo stock search) | 6 |
+| §3 D9 (sync change-fan-out) | 11, 12 |
+| §3 D10 (drop `.stocksOnly`, register crypto in picker) | 7, 9 |
+| §6 (SQLite schema) | 2 |
+| §7 (refresh / ETag) | 5 |
+| §9 (testing strategy) | covered per task |
+
+If any decision lacks a task, add one before opening the PR.
+
+Verification before claiming completion:
+- `just test` passes locally; CI green on the PR.
+- `just format-check` passes — no SwiftLint baseline mutations.
+- A manual run of the picker on macOS surfaces fiat / stock / crypto results without bouncing to Settings → Crypto.
+- Issue #461 is referenced from every PR description.
+
+When all 16 tasks are merged, queue a final PR that:
+1. Updates [`plans/2026-04-27-instrument-registry-ui-design.md`](2026-04-27-instrument-registry-ui-design.md) and this implementation plan with `Status: Completed`.
+2. Moves both files to `plans/completed/`.
+3. Closes #461.


### PR DESCRIPTION
## Summary

Design and implementation plan for [#461](https://github.com/ajsutton/moolah-native/issues/461) — the UI follow-up to the instrument-registry backend work. Two new docs in `plans/`:

- **`2026-04-27-instrument-registry-ui-design.md`** — captures the 10 design decisions reached during brainstorming. Highlights:
  - Search-only "Add Token" flow (the contract-address form is removed).
  - Crypto search backed by a cached snapshot of `/coins/list?include_platform=true` stored as raw SQLite + FTS5; refreshed via ETag-conditional GET, never blocks, silent failure.
  - `/asset_platforms` lives in the same DB (one file, one refresh transaction); no migration framework — schema bumps drop the file.
  - Yahoo `/v1/finance/search` for stock-name search (filtered to EQUITY + ETF + MUTUALFUND, `quotesCount=20`, no post-select validation).
  - "Resolve mapping" affordance dropped: `ensureInstrument` will throw on unmapped crypto. CSV recovery UX is now its own issue ([#515](https://github.com/ajsutton/moolah-native/issues/515)).
  - Closure-based fan-out so `CKSyncEngine` remote pulls notify `InstrumentRegistryRepository.observeChanges()` subscribers.
  - Picker store drops `.stocksOnly` and gains crypto registration in `select(_:)`, so the transaction-leg picker works for fiat / stock / crypto end-to-end.

- **`2026-04-27-instrument-registry-ui-implementation.md`** — 16 TDD-shaped tasks (one PR each), dependency-ordered. Each task includes the failing test in full, the `just` commands with expected output, the implementation code, and the commit message.

This PR ships docs only — no production code. Implementation PRs will follow as separate merge-queue items, one per task.

## Test plan

- [ ] Reviewer reads `plans/2026-04-27-instrument-registry-ui-design.md` and the spec self-review at the end of the design doc.
- [ ] Reviewer reads the implementation plan's task index and at least Task 1 (catalog protocol) and Task 5 (ETag refresh) to validate the level of detail.
- [ ] Confirm the spec-coverage table at the bottom of the implementation plan maps every D1–D10 decision to at least one task.
- [ ] CI green (`format-check`, `swiftlint-baseline`, `validate-todos`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
