### PR TITLE
feat(catalog): CoinGeckoCatalog protocol and value types (Task 1, #461)

### DIFF
--- a/MoolahTests/Shared/CoinGeckoCatalogTypesTests.swift
+++ b/MoolahTests/Shared/CoinGeckoCatalogTypesTests.swift
@@ -1,0 +1,28 @@
+import XCTest
+
+@testable import Moolah
+
+final class CoinGeckoCatalogTypesTests: XCTestCase {
+  func testPlatformBindingNormalisesContractAddressToLowercase() {
+    let binding = PlatformBinding(slug: "ethereum", chainId: 1, contractAddress: "0xABCDef1234")
+    XCTAssertEqual(binding.contractAddress, "0xabcdef1234")
+  }
+
+  func testCatalogEntryReturnsHighestPriorityPlatform() {
+    let entry = CatalogEntry(
+      coingeckoId: "usd-coin",
+      symbol: "USDC",
+      name: "USD Coin",
+      platforms: [
+        PlatformBinding(slug: "ethereum", chainId: 1, contractAddress: "0xethereum"),
+        PlatformBinding(slug: "polygon-pos", chainId: 137, contractAddress: "0xpolygon"),
+      ]
+    )
+    XCTAssertEqual(entry.preferredPlatform?.slug, "ethereum")
+  }
+
+  func testCatalogEntryWithoutPlatformsReturnsNilPreferred() {
+    let entry = CatalogEntry(coingeckoId: "btc", symbol: "BTC", name: "Bitcoin", platforms: [])
+    XCTAssertNil(entry.preferredPlatform)
+  }
+}

--- a/MoolahTests/Shared/CoinGeckoCatalogTypesTests.swift
+++ b/MoolahTests/Shared/CoinGeckoCatalogTypesTests.swift
@@ -1,14 +1,17 @@
-import XCTest
+import Testing
 
 @testable import Moolah
 
-final class CoinGeckoCatalogTypesTests: XCTestCase {
-  func testPlatformBindingNormalisesContractAddressToLowercase() {
+@Suite("CoinGeckoCatalog types")
+struct CoinGeckoCatalogTypesTests {
+  @Test
+  func platformBindingNormalisesContractAddressToLowercase() {
     let binding = PlatformBinding(slug: "ethereum", chainId: 1, contractAddress: "0xABCDef1234")
-    XCTAssertEqual(binding.contractAddress, "0xabcdef1234")
+    #expect(binding.contractAddress == "0xabcdef1234")
   }
 
-  func testCatalogEntryReturnsHighestPriorityPlatform() {
+  @Test
+  func catalogEntryReturnsHighestPriorityPlatform() {
     let entry = CatalogEntry(
       coingeckoId: "usd-coin",
       symbol: "USDC",
@@ -18,11 +21,12 @@ final class CoinGeckoCatalogTypesTests: XCTestCase {
         PlatformBinding(slug: "polygon-pos", chainId: 137, contractAddress: "0xpolygon"),
       ]
     )
-    XCTAssertEqual(entry.preferredPlatform?.slug, "ethereum")
+    #expect(entry.preferredPlatform?.slug == "ethereum")
   }
 
-  func testCatalogEntryWithoutPlatformsReturnsNilPreferred() {
+  @Test
+  func catalogEntryWithoutPlatformsReturnsNilPreferred() {
     let entry = CatalogEntry(coingeckoId: "btc", symbol: "BTC", name: "Bitcoin", platforms: [])
-    XCTAssertNil(entry.preferredPlatform)
+    #expect(entry.preferredPlatform == nil)
   }
 }

--- a/Shared/CoinGeckoCatalog.swift
+++ b/Shared/CoinGeckoCatalog.swift
@@ -2,13 +2,11 @@ import Foundation
 
 /// One coin from the cached CoinGecko catalogue snapshot. Carries every
 /// platform binding the picker needs to call `TokenResolutionClient.resolve()`.
-struct CatalogEntry: Sendable, Hashable, Identifiable {
+struct CatalogEntry: Sendable {
   let coingeckoId: String
   let symbol: String
   let name: String
   let platforms: [PlatformBinding]
-
-  var id: String { coingeckoId }
 
   /// First platform binding by canonical priority — used by the picker to
   /// resolve a search hit to a `(chainId, contractAddress)` pair. `nil`
@@ -16,9 +14,15 @@ struct CatalogEntry: Sendable, Hashable, Identifiable {
   var preferredPlatform: PlatformBinding? { platforms.first }
 }
 
+extension CatalogEntry: Hashable {}
+
+extension CatalogEntry: Identifiable {
+  var id: String { coingeckoId }
+}
+
 /// One coin's binding to a single chain. `chainId` is `nil` when the
 /// platform slug isn't known to `/asset_platforms` (typically non-EVM).
-struct PlatformBinding: Sendable, Hashable {
+struct PlatformBinding: Sendable {
   let slug: String
   let chainId: Int?
   let contractAddress: String
@@ -30,9 +34,10 @@ struct PlatformBinding: Sendable, Hashable {
   }
 }
 
+extension PlatformBinding: Hashable {}
+
 /// Read-only catalogue of CoinGecko coins. Backed by a refreshable SQLite
-/// snapshot of `/coins/list?include_platform=true`. See
-/// `plans/2026-04-27-instrument-registry-ui-design.md` §4.1 / §6 for shape.
+/// snapshot of `/coins/list?include_platform=true`.
 protocol CoinGeckoCatalog: Sendable {
   /// Returns up to `limit` matching entries with their full platform list
   /// attached, ordered by FTS BM25 rank. Empty when the snapshot is missing

--- a/Shared/CoinGeckoCatalog.swift
+++ b/Shared/CoinGeckoCatalog.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+/// One coin from the cached CoinGecko catalogue snapshot. Carries every
+/// platform binding the picker needs to call `TokenResolutionClient.resolve()`.
+struct CatalogEntry: Sendable, Hashable, Identifiable {
+  let coingeckoId: String
+  let symbol: String
+  let name: String
+  let platforms: [PlatformBinding]
+
+  var id: String { coingeckoId }
+
+  /// First platform binding by canonical priority — used by the picker to
+  /// resolve a search hit to a `(chainId, contractAddress)` pair. `nil`
+  /// when the coin is platformless (cross-chain natives like BTC, ETH).
+  var preferredPlatform: PlatformBinding? { platforms.first }
+}
+
+/// One coin's binding to a single chain. `chainId` is `nil` when the
+/// platform slug isn't known to `/asset_platforms` (typically non-EVM).
+struct PlatformBinding: Sendable, Hashable {
+  let slug: String
+  let chainId: Int?
+  let contractAddress: String
+
+  init(slug: String, chainId: Int?, contractAddress: String) {
+    self.slug = slug
+    self.chainId = chainId
+    self.contractAddress = contractAddress.lowercased()
+  }
+}
+
+/// Read-only catalogue of CoinGecko coins. Backed by a refreshable SQLite
+/// snapshot of `/coins/list?include_platform=true`. See
+/// `plans/2026-04-27-instrument-registry-ui-design.md` §4.1 / §6 for shape.
+protocol CoinGeckoCatalog: Sendable {
+  /// Returns up to `limit` matching entries with their full platform list
+  /// attached, ordered by FTS BM25 rank. Empty when the snapshot is missing
+  /// or the query has no hits.
+  func search(query: String, limit: Int) async -> [CatalogEntry]
+
+  /// Triggered once per app session. Never blocks the caller; refresh runs
+  /// on a background task and logs failures via `os_log`. Honours the 24 h
+  /// max-age and ETag conditional-GET semantics described in design §5.4.
+  func refreshIfStale() async
+}


### PR DESCRIPTION
## Summary

Task 1 of the [instrument-registry UI plan](https://github.com/ajsutton/moolah-native/blob/main/plans/2026-04-27-instrument-registry-ui-implementation.md) (resolves #461). Lays the foundation for the crypto-search path:

- New value type `CatalogEntry` (Sendable; Hashable & Identifiable in extensions per CODE_GUIDE §2 / §11).
- New value type `PlatformBinding` — init lowercases `contractAddress`.
- New protocol `CoinGeckoCatalog` with two `async` requirements: `search(query:limit:)` and `refreshIfStale()`.
- 3 Swift Testing tests covering address normalisation, `preferredPlatform == platforms.first`, and the empty-platforms case.

This task ships **only the contract**. The SQLite-backed implementation lands across Tasks 2–5; the search service rewire is Task 7.

## Test plan

- [x] `just test CoinGeckoCatalogTypesTests` passes 3/3 on both `MoolahTests_iOS` and `MoolahTests_macOS`.
- [x] `just format-check` clean.
- [x] No `.swiftlint-baseline.yml` change.
- [x] xcodegen auto-globs the new files; no `project.yml` edit needed.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)