### PR TITLE
perf(transactions): snapshot sort keys to skip SwiftData property faults

### DIFF
--- a/Backends/CloudKit/Repositories/CloudKitTransactionRepository+FetchPipeline.swift
+++ b/Backends/CloudKit/Repositories/CloudKitTransactionRepository+FetchPipeline.swift
@@ -25,13 +25,10 @@ extension CloudKitTransactionRepository {
     }
     return try await MainActor.run {
       let scheduled = filter.scheduled == .scheduledOnly
-      var filteredRecords = try loadAndFilter(
+      let filteredRecords = try loadAndFilter(
         filter: filter, scheduled: scheduled, signpostID: signpostID)
-      filteredRecords.sort { lhs, rhs in
-        if lhs.date != rhs.date { return lhs.date > rhs.date }
-        return lhs.id < rhs.id
-      }
-      return try loadPageTransactions(filteredRecords[...], signpostID: signpostID)
+      let sortedRecords = sortedByDateDescThenId(filteredRecords)
+      return try loadPageTransactions(sortedRecords[...], signpostID: signpostID)
     }
   }
 
@@ -47,12 +44,9 @@ extension CloudKitTransactionRepository {
     signpostID: OSSignpostID
   ) throws -> FetchResult {
     let scheduled = filter.scheduled == .scheduledOnly
-    var filteredRecords = try loadAndFilter(
+    let unsortedRecords = try loadAndFilter(
       filter: filter, scheduled: scheduled, signpostID: signpostID)
-    filteredRecords.sort { lhs, rhs in
-      if lhs.date != rhs.date { return lhs.date > rhs.date }
-      return lhs.id < rhs.id
-    }
+    let filteredRecords = sortedByDateDescThenId(unsortedRecords)
 
     let resolvedTarget = resolveTargetInstrument(for: filter.accountId)
     let offset = page * pageSize
@@ -88,6 +82,30 @@ extension CloudKitTransactionRepository {
       hasAccountFilter: filter.accountId != nil,
       totalCount: totalCount,
       isEmpty: false)
+  }
+
+  // MARK: - Ordering
+
+  /// Sorts records by date descending, with `id` ascending as a stable
+  /// tiebreaker so pagination doesn't reshuffle when several transactions
+  /// share a date. The contract is pinned by `TransactionRepositoryOrderingTests`.
+  ///
+  /// Snapshots `(date, id)` into a value-type key per record so the comparator
+  /// reads Swift fields rather than re-faulting the persisted properties on
+  /// every comparison. The previous in-memory sort closure paid the SwiftData
+  /// `_PersistedProperty` + `swift_dynamicCast` cost on each `record.date`
+  /// access — ~333 ms on the cold-launch scheduled-only path with 36 rows.
+  /// See #517 for the profile.
+  @MainActor
+  func sortedByDateDescThenId(_ records: [TransactionRecord]) -> [TransactionRecord] {
+    let keys = records.enumerated().map { offset, record in
+      RecordSortKey(date: record.date, id: record.id, offset: offset)
+    }
+    let ordered = keys.sorted { lhs, rhs in
+      if lhs.date != rhs.date { return lhs.date > rhs.date }
+      return lhs.id < rhs.id
+    }
+    return ordered.map { records[$0.offset] }
   }
 
   // MARK: - Filtering

--- a/Backends/CloudKit/Repositories/CloudKitTransactionRepository.swift
+++ b/Backends/CloudKit/Repositories/CloudKitTransactionRepository.swift
@@ -105,7 +105,7 @@ final class CloudKitTransactionRepository: TransactionRepository, @unchecked Sen
 // Shared across CloudKitTransactionRepository+FetchPipeline.swift and the
 // class's public `fetch` entry point. Kept at file scope (not nested in the
 // class) so the extension file can see them without a cross-file private
-// widening; the three types are otherwise purely internal to the fetch
+// widening; otherwise these types are purely internal to the fetch
 // pipeline.
 
 /// Per-instrument subtotal carried across the `MainActor`/async-conversion
@@ -144,4 +144,14 @@ struct FetchResult: Sendable {
 struct DescriptorResult: Sendable {
   let pushedScheduled: Bool
   let pushedDateRange: Bool
+}
+
+/// Snapshot of the (date, id) tuple used to order `TransactionRecord`s without
+/// re-faulting the SwiftData persisted properties for every comparison. The
+/// `offset` indexes back into the original record array so the sorted result
+/// can be reconstructed. See `sortedByDateDescThenId` and #517.
+struct RecordSortKey: Sendable {
+  let date: Date
+  let id: UUID
+  let offset: Int
 }

--- a/MoolahTests/Domain/TransactionRepositoryOrderingTests.swift
+++ b/MoolahTests/Domain/TransactionRepositoryOrderingTests.swift
@@ -1,0 +1,127 @@
+import Foundation
+import SwiftData
+import Testing
+
+@testable import Moolah
+
+/// Pagination depends on a deterministic order coming out of
+/// `CloudKitTransactionRepository.fetch`. The repository must order results by
+/// date descending, with `id` ascending as a stable tiebreaker so pages don't
+/// reshuffle across calls when several transactions share a date.
+///
+/// These tests pin down the contract independently of the implementation, so
+/// the perf rework in #517 (snapshotting sort keys to avoid SwiftData property
+/// faults) can't accidentally regress ordering.
+@Suite("TransactionRepository — Ordering")
+struct TransactionRepositoryOrderingTests {
+  @Test("scheduled fetch sorts ties by id ascending")
+  func testScheduledTiesBreakById() async throws {
+    let calendar = Calendar.current
+    let sharedDate = try #require(
+      calendar.date(from: DateComponents(year: 2026, month: 1, day: 15)))
+    let accountId = UUID()
+
+    let idA = try #require(UUID(uuidString: "00000000-0000-0000-0000-00000000000A"))
+    let idB = try #require(UUID(uuidString: "00000000-0000-0000-0000-00000000000B"))
+    let idC = try #require(UUID(uuidString: "00000000-0000-0000-0000-00000000000C"))
+    let txnA = makeScheduled(id: idA, date: sharedDate, accountId: accountId, payee: "A")
+    let txnB = makeScheduled(id: idB, date: sharedDate, accountId: accountId, payee: "B")
+    let txnC = makeScheduled(id: idC, date: sharedDate, accountId: accountId, payee: "C")
+
+    // Insert deliberately out-of-order so the test fails if we accidentally
+    // rely on insertion order.
+    let repository = try makeContractCloudKitTransactionRepository(
+      initialTransactions: [txnC, txnA, txnB])
+
+    let page = try await repository.fetch(
+      filter: TransactionFilter(scheduled: .scheduledOnly),
+      page: 0,
+      pageSize: 50)
+
+    #expect(page.transactions.map(\.id) == [idA, idB, idC])
+  }
+
+  @Test("scheduled fetch sorts by date descending then id ascending")
+  func testScheduledOrderByDateDescThenId() async throws {
+    let calendar = Calendar.current
+    let earlyDate = try #require(
+      calendar.date(from: DateComponents(year: 2026, month: 1, day: 10)))
+    let midDate = try #require(
+      calendar.date(from: DateComponents(year: 2026, month: 1, day: 15)))
+    let lateDate = try #require(
+      calendar.date(from: DateComponents(year: 2026, month: 1, day: 20)))
+    let accountId = UUID()
+
+    let earlyId = try #require(UUID(uuidString: "00000000-0000-0000-0000-00000000E001"))
+    let midAId = try #require(UUID(uuidString: "00000000-0000-0000-0000-0000000000A1"))
+    let midBId = try #require(UUID(uuidString: "00000000-0000-0000-0000-0000000000B1"))
+    let lateId = try #require(UUID(uuidString: "00000000-0000-0000-0000-0000000000F1"))
+    let early = makeScheduled(id: earlyId, date: earlyDate, accountId: accountId, payee: "early")
+    let midA = makeScheduled(id: midAId, date: midDate, accountId: accountId, payee: "midA")
+    let midB = makeScheduled(id: midBId, date: midDate, accountId: accountId, payee: "midB")
+    let late = makeScheduled(id: lateId, date: lateDate, accountId: accountId, payee: "late")
+
+    let repository = try makeContractCloudKitTransactionRepository(
+      initialTransactions: [midB, early, late, midA])
+
+    let page = try await repository.fetch(
+      filter: TransactionFilter(scheduled: .scheduledOnly),
+      page: 0,
+      pageSize: 50)
+
+    #expect(page.transactions.map(\.id) == [lateId, midAId, midBId, earlyId])
+  }
+
+  @Test("pagination is stable across calls when dates collide")
+  func testPaginationStableAcrossCallsOnSameDate() async throws {
+    let calendar = Calendar.current
+    let sharedDate = try #require(
+      calendar.date(from: DateComponents(year: 2026, month: 1, day: 15)))
+    let accountId = UUID()
+
+    // Twelve transactions on the same date, inserted in a scrambled order.
+    var ids: [UUID] = []
+    for index in 0..<12 {
+      let suffix = String(format: "%012d", index)
+      ids.append(try #require(UUID(uuidString: "00000000-0000-0000-0000-\(suffix)")))
+    }
+    let scrambled = [9, 2, 7, 0, 11, 4, 1, 8, 3, 10, 5, 6].map { index in
+      makeScheduled(
+        id: ids[index], date: sharedDate, accountId: accountId, payee: "row\(index)")
+    }
+    let repository = try makeContractCloudKitTransactionRepository(
+      initialTransactions: scrambled)
+
+    let pageSize = 5
+    var collected: [UUID] = []
+    for page in 0..<3 {
+      let result = try await repository.fetch(
+        filter: TransactionFilter(scheduled: .scheduledOnly),
+        page: page,
+        pageSize: pageSize)
+      collected.append(contentsOf: result.transactions.map(\.id))
+    }
+
+    #expect(collected == ids)
+  }
+
+  // MARK: - Fixture
+
+  private func makeScheduled(
+    id: UUID, date: Date, accountId: UUID, payee: String
+  ) -> Transaction {
+    Transaction(
+      id: id,
+      date: date,
+      payee: payee,
+      recurPeriod: .month,
+      recurEvery: 1,
+      legs: [
+        TransactionLeg(
+          accountId: accountId,
+          instrument: .defaultTestInstrument,
+          quantity: -10,
+          type: .expense)
+      ])
+  }
+}


### PR DESCRIPTION
## Summary

- Replaces the in-memory `[TransactionRecord].sort` in `CloudKitTransactionRepository.fetchPageOnMainActor` (and `fetchAll`) with a `sortedByDateDescThenId` helper that snapshots `(date, id)` into a value-type `RecordSortKey` once per record, then sorts those keys.
- Same external ordering — date desc, with `id` ascending as the stable tiebreaker pagination relies on. New `TransactionRepositoryOrderingTests` pins the contract.
- Measured on **Large Test** cold launch (18,810 transactions / 36 scheduled): `TransactionStore.load(.scheduledOnly)` drops from **3.171s → 2.829s** (-342 ms). The old line-52 sort hotspot vanishes from `sample` output; the new helper takes ~50 samples vs ~333 before.

Why it was slow: every comparator access of `record.date` faulted a SwiftData persisted property through the `_PersistedProperty` macro + `swift_dynamicCast`. ~187 cmps × 2 accesses ≈ 374 expensive faults per scheduled-only fetch. The snapshot pays the fault cost O(N) instead of O(N log N).

Refs #517 (and is the smallest of the six perf items found while profiling the Analysis Dashboard cold load).

## Test plan
- [x] `just test-mac TransactionRepositoryOrderingTests` — 3/3 pass against unchanged code (baseline) and after the change.
- [x] `just test-mac TransactionRepositoryFilterTests TransactionRepositoryAuxFilterTests TransactionRepositoryBulkFetchTests TransactionRepositoryMultiInstTests TransactionRepositoryPersistenceTests TransactionRepositoryPriorBalanceTests TransactionStore*Tests` — 67/67 pass, no regressions.
- [x] `just format-check` clean.
- [x] Cold-launch the macOS app against the **Large Test** profile and confirm the wall-clock improvement plus the disappearance of the sort hotspot in `sample` output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)