### PR TITLE
feat(catalog): CoinGeckoCatalog SQLite schema (Task 2, #461)

### DIFF
--- a/Backends/CoinGecko/CoinGeckoCatalogSchema.swift
+++ b/Backends/CoinGecko/CoinGeckoCatalogSchema.swift
@@ -1,0 +1,101 @@
+// Backends/CoinGecko/CoinGeckoCatalogSchema.swift
+import Foundation
+
+/// Single source of truth for the CoinGecko-catalogue SQLite schema.
+/// Bump `version` whenever the on-disk shape changes; the catalogue
+/// implementation drops and recreates the file rather than running a
+/// migration.
+enum CoinGeckoCatalogSchema {
+  static let version: Int = 1
+
+  static let statements: [String] = [
+    "PRAGMA journal_mode = WAL;",
+    "PRAGMA foreign_keys = ON;",
+
+    """
+    CREATE TABLE meta (
+      schema_version  INTEGER NOT NULL,
+      last_fetched    REAL,
+      coins_etag      TEXT,
+      platforms_etag  TEXT
+    );
+    """,
+
+    "INSERT INTO meta (schema_version) VALUES (\(version));",
+
+    """
+    CREATE TABLE coin (
+      rowid          INTEGER PRIMARY KEY,
+      coingecko_id   TEXT NOT NULL UNIQUE,
+      symbol         TEXT NOT NULL,
+      name           TEXT NOT NULL
+    );
+    """,
+
+    """
+    CREATE TABLE coin_platform (
+      coingecko_id     TEXT NOT NULL,
+      platform_slug    TEXT NOT NULL,
+      contract_address TEXT NOT NULL,
+      PRIMARY KEY (coingecko_id, platform_slug),
+      FOREIGN KEY (coingecko_id) REFERENCES coin(coingecko_id) ON DELETE CASCADE
+    );
+    """,
+
+    """
+    CREATE INDEX coin_platform_chain_contract
+      ON coin_platform(platform_slug, contract_address);
+    """,
+
+    """
+    CREATE TABLE platform (
+      slug      TEXT PRIMARY KEY,
+      chain_id  INTEGER,
+      name      TEXT NOT NULL
+    );
+    """,
+
+    """
+    CREATE VIRTUAL TABLE coin_fts USING fts5(
+      symbol, name,
+      content='coin',
+      content_rowid='rowid',
+      tokenize='unicode61 remove_diacritics 1'
+    );
+    """,
+
+    """
+    CREATE TRIGGER coin_ai AFTER INSERT ON coin BEGIN
+      INSERT INTO coin_fts(rowid, symbol, name) VALUES (new.rowid, new.symbol, new.name);
+    END;
+    """,
+
+    """
+    CREATE TRIGGER coin_ad AFTER DELETE ON coin BEGIN
+      INSERT INTO coin_fts(coin_fts, rowid, symbol, name)
+      VALUES('delete', old.rowid, old.symbol, old.name);
+    END;
+    """,
+
+    """
+    CREATE TRIGGER coin_au AFTER UPDATE ON coin BEGIN
+      INSERT INTO coin_fts(coin_fts, rowid, symbol, name)
+      VALUES('delete', old.rowid, old.symbol, old.name);
+      INSERT INTO coin_fts(rowid, symbol, name) VALUES (new.rowid, new.symbol, new.name);
+    END;
+    """,
+  ]
+
+  /// Built-in priority order for picking a coin's preferred chain when it
+  /// is listed on multiple platforms. Slugs not in this list fall through
+  /// to the order returned from SQLite.
+  static let platformPriority: [String] = [
+    "ethereum",
+    "polygon-pos",
+    "binance-smart-chain",
+    "base",
+    "arbitrum-one",
+    "optimism",
+    "avalanche",
+  ]
+}

--- a/MoolahTests/Backends/CoinGeckoCatalogSchemaTests.swift
+++ b/MoolahTests/Backends/CoinGeckoCatalogSchemaTests.swift
@@ -1,0 +1,31 @@
+// MoolahTests/Backends/CoinGeckoCatalogSchemaTests.swift
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("CoinGeckoCatalogSchema")
+struct CoinGeckoCatalogSchemaTests {
+  @Test
+  func schemaVersionStartsAtOne() {
+    #expect(CoinGeckoCatalogSchema.version == 1)
+  }
+
+  @Test
+  func schemaContainsCoreTables() {
+    let ddl = CoinGeckoCatalogSchema.statements.joined(separator: "\n")
+    #expect(ddl.contains("CREATE TABLE meta"))
+    #expect(ddl.contains("CREATE TABLE coin"))
+    #expect(ddl.contains("CREATE TABLE coin_platform"))
+    #expect(ddl.contains("CREATE TABLE platform"))
+    #expect(ddl.contains("CREATE VIRTUAL TABLE coin_fts USING fts5"))
+  }
+
+  @Test
+  func schemaInstallsFtsTriggers() {
+    let ddl = CoinGeckoCatalogSchema.statements.joined(separator: "\n")
+    #expect(ddl.contains("CREATE TRIGGER coin_ai"))
+    #expect(ddl.contains("CREATE TRIGGER coin_ad"))
+    #expect(ddl.contains("CREATE TRIGGER coin_au"))
+  }
+}


### PR DESCRIPTION
## Summary

Task 2 of the [instrument-registry UI plan](https://github.com/ajsutton/moolah-native/blob/main/plans/2026-04-27-instrument-registry-ui-implementation.md) (resolves #461). Adds `Backends/CoinGecko/CoinGeckoCatalogSchema.swift` — a constants-only enum carrying:

- `version: Int = 1`
- `statements: [String]` — the 12 SQL DDL strings (PRAGMAs, `CREATE TABLE meta/coin/coin_platform/platform`, `CREATE INDEX`, `CREATE VIRTUAL TABLE coin_fts USING fts5`, three `CREATE TRIGGER coin_ai/ad/au` for FTS sync).
- `platformPriority: [String]` — fallback order (ethereum → polygon-pos → binance-smart-chain → base → arbitrum-one → optimism → avalanche) for picking a coin's preferred chain.

Follows [#523](https://github.com/ajsutton/moolah-native/pull/523) (Task 1, the protocol + value types — merged). `SQLiteCoinGeckoCatalog` will reference these constants in Task 3.

## Test plan

- [x] `just test CoinGeckoCatalogSchemaTests` passes 3/3 on `MoolahTests_iOS` and `MoolahTests_macOS`.
- [x] `just format-check` clean.
- [x] No `.swiftlint-baseline.yml` change.
- [x] xcodegen auto-globs the new file; no `project.yml` edit needed.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)