### PR TITLE
feat(catalog): FTS5 search with attached platform bindings (Task 4, #461)

### DIFF
--- a/Backends/CoinGecko/SQLiteCoinGeckoCatalog+Search.swift
+++ b/Backends/CoinGecko/SQLiteCoinGeckoCatalog+Search.swift
@@ -1,0 +1,132 @@
+// Backends/CoinGecko/SQLiteCoinGeckoCatalog+Search.swift
+import Foundation
+import SQLite3
+
+/// FTS5 search path for `SQLiteCoinGeckoCatalog`. Hosted in a separate file
+/// so the actor's primary body stays focused on schema bootstrap and
+/// replace-all writes (see CLAUDE.md and `guides/CODE_GUIDE.md` §7 on
+/// extension grouping).
+extension SQLiteCoinGeckoCatalog {
+  func search(query: String, limit: Int) async -> [CatalogEntry] {
+    let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty, limit > 0 else { return [] }
+
+    do {
+      let ranked = try Self.fetchRankedCoins(
+        database: database, query: trimmed, limit: limit)
+      guard !ranked.isEmpty else { return [] }
+      let bindings = try Self.fetchPlatformBindings(
+        database: database, coingeckoIds: ranked.map(\.id))
+      return ranked.map { row in
+        CatalogEntry(
+          coingeckoId: row.id,
+          symbol: row.symbol,
+          name: row.name,
+          platforms: Self.orderedPlatforms(for: row.id, bindings: bindings)
+        )
+      }
+    } catch {
+      log.error("search failed: \(String(describing: error), privacy: .public)")
+      return []
+    }
+  }
+}
+
+extension SQLiteCoinGeckoCatalog {
+  private struct RankedCoin: Sendable {
+    let id: String
+    let symbol: String
+    let name: String
+  }
+
+  private static func fetchRankedCoins(
+    database: OpaquePointer?,
+    query: String,
+    limit: Int
+  ) throws -> [RankedCoin] {
+    let ftsQuery = ftsQueryString(for: query)
+    var statement: OpaquePointer?
+    try prepare(
+      database: database,
+      """
+      SELECT c.coingecko_id, c.symbol, c.name
+      FROM coin_fts JOIN coin c ON c.rowid = coin_fts.rowid
+      WHERE coin_fts MATCH ?
+      ORDER BY rank
+      LIMIT ?;
+      """,
+      &statement
+    )
+    defer { sqlite3_finalize(statement) }
+    try bind(statement, 1, ftsQuery)
+    try bind(statement, 2, limit)
+    var rows: [RankedCoin] = []
+    while sqlite3_step(statement) == SQLITE_ROW {
+      let id = readText(statement, column: 0) ?? ""
+      let symbol = readText(statement, column: 1) ?? ""
+      let name = readText(statement, column: 2) ?? ""
+      rows.append(RankedCoin(id: id, symbol: symbol, name: name))
+    }
+    return rows
+  }
+
+  private static func fetchPlatformBindings(
+    database: OpaquePointer?,
+    coingeckoIds: [String]
+  ) throws -> [String: [PlatformBinding]] {
+    guard !coingeckoIds.isEmpty else { return [:] }
+    let placeholders = Array(repeating: "?", count: coingeckoIds.count)
+      .joined(separator: ", ")
+    var statement: OpaquePointer?
+    try prepare(
+      database: database,
+      """
+      SELECT cp.coingecko_id, cp.platform_slug, cp.contract_address, p.chain_id
+      FROM coin_platform cp
+      LEFT JOIN platform p ON p.slug = cp.platform_slug
+      WHERE cp.coingecko_id IN (\(placeholders));
+      """,
+      &statement
+    )
+    defer { sqlite3_finalize(statement) }
+    for (offset, id) in coingeckoIds.enumerated() {
+      try bind(statement, Int32(offset + 1), id)
+    }
+    var bindingsById: [String: [PlatformBinding]] = [:]
+    while sqlite3_step(statement) == SQLITE_ROW {
+      let coingeckoId = readText(statement, column: 0) ?? ""
+      let slug = readText(statement, column: 1) ?? ""
+      let contract = readText(statement, column: 2) ?? ""
+      let chainId: Int? =
+        sqlite3_column_type(statement, 3) == SQLITE_NULL
+        ? nil : Int(sqlite3_column_int64(statement, 3))
+      bindingsById[coingeckoId, default: []].append(
+        PlatformBinding(slug: slug, chainId: chainId, contractAddress: contract)
+      )
+    }
+    return bindingsById
+  }
+
+  private static func orderedPlatforms(
+    for coingeckoId: String,
+    bindings: [String: [PlatformBinding]]
+  ) -> [PlatformBinding] {
+    let raw = bindings[coingeckoId] ?? []
+    let priority = CoinGeckoCatalogSchema.platformPriority
+    return raw.sorted { lhs, rhs in
+      let lhsRank = priority.firstIndex(of: lhs.slug) ?? Int.max
+      let rhsRank = priority.firstIndex(of: rhs.slug) ?? Int.max
+      if lhsRank != rhsRank { return lhsRank < rhsRank }
+      return lhs.slug < rhs.slug
+    }
+  }
+
+  private static func ftsQueryString(for query: String) -> String {
+    let tokens =
+      query
+      .components(separatedBy: .whitespaces)
+      .filter { !$0.isEmpty }
+      .map { $0.replacingOccurrences(of: "\"", with: "\"\"") }
+    return tokens.map { "\"\($0)\"*" }.joined(separator: " ")
+  }
+}

--- a/Backends/CoinGecko/SQLiteCoinGeckoCatalog+Search.swift
+++ b/Backends/CoinGecko/SQLiteCoinGeckoCatalog+Search.swift
@@ -7,6 +7,15 @@ import SQLite3
 /// replace-all writes (see CLAUDE.md and `guides/CODE_GUIDE.md` §7 on
 /// extension grouping).
 extension SQLiteCoinGeckoCatalog {
+  /// FTS5 prefix search over coin id/symbol/name, ranked by BM25, with
+  /// platform bindings attached per hit. Platforms are ordered by
+  /// `CoinGeckoCatalogSchema.platformPriority`, then alphabetical by slug.
+  ///
+  /// Infallible by design (see design §4.1): an unavailable database, an
+  /// FTS query parse error, or any underlying SQLite failure is logged via
+  /// `os_log` and swallowed — the picker degrades to "no results" rather
+  /// than crashing on a corrupted snapshot. An empty/whitespace-only
+  /// `query` or `limit <= 0` short-circuits to `[]` without touching SQLite.
   func search(query: String, limit: Int) async -> [CatalogEntry] {
     let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !trimmed.isEmpty, limit > 0 else { return [] }
@@ -31,6 +40,8 @@ extension SQLiteCoinGeckoCatalog {
     }
   }
 }
+
+// MARK: - Private helpers
 
 extension SQLiteCoinGeckoCatalog {
   private struct RankedCoin: Sendable {

--- a/Backends/CoinGecko/SQLiteCoinGeckoCatalog.swift
+++ b/Backends/CoinGecko/SQLiteCoinGeckoCatalog.swift
@@ -10,8 +10,13 @@ import os
 actor SQLiteCoinGeckoCatalog: CoinGeckoCatalog {
   private let directory: URL
   private let session: URLSession
-  private let log = Logger(subsystem: "moolah.instrument-registry", category: "catalog")
-  private var database: OpaquePointer?
+  let log = Logger(subsystem: "moolah.instrument-registry", category: "catalog")
+  private(set) var database: OpaquePointer?
+
+  // Note: `log` and `database` are module-internal (no explicit modifier
+  // per CODE_GUIDE §7) so the `+Search.swift` extension can read them.
+  // Helpers like `prepare`, `bind`, and `readText` below are also
+  // module-internal for the same reason.
 
   init(
     directory: URL,
@@ -30,10 +35,8 @@ actor SQLiteCoinGeckoCatalog: CoinGeckoCatalog {
   }
 
   // MARK: - CoinGeckoCatalog
-
-  func search(query: String, limit: Int) async -> [CatalogEntry] {
-    []  // Implemented in Task 4.
-  }
+  //
+  // `search(query:limit:)` lives in `SQLiteCoinGeckoCatalog+Search.swift`.
 
   func refreshIfStale() async {
     // Implemented in Task 5.
@@ -205,7 +208,7 @@ actor SQLiteCoinGeckoCatalog: CoinGeckoCatalog {
     }
   }
 
-  private static func prepare(
+  static func prepare(
     database: OpaquePointer?,
     _ sql: String,
     _ statement: inout OpaquePointer?
@@ -216,7 +219,7 @@ actor SQLiteCoinGeckoCatalog: CoinGeckoCatalog {
     }
   }
 
-  private static func bind(
+  static func bind(
     _ statement: OpaquePointer?,
     _ index: Int32,
     _ value: String
@@ -231,7 +234,7 @@ actor SQLiteCoinGeckoCatalog: CoinGeckoCatalog {
     guard result == SQLITE_OK else { throw CatalogError.sqlite("bind text \(result)") }
   }
 
-  private static func bind(
+  static func bind(
     _ statement: OpaquePointer?,
     _ index: Int32,
     _ value: Int
@@ -257,7 +260,7 @@ actor SQLiteCoinGeckoCatalog: CoinGeckoCatalog {
     return Int(sqlite3_column_int64(statement, 0))
   }
 
-  private static func readText(_ statement: OpaquePointer?, column: Int32) -> String? {
+  static func readText(_ statement: OpaquePointer?, column: Int32) -> String? {
     guard let cString = sqlite3_column_text(statement, column) else { return nil }
     return String(cString: cString)
   }

--- a/Backends/CoinGecko/SQLiteCoinGeckoCatalog.swift
+++ b/Backends/CoinGecko/SQLiteCoinGeckoCatalog.swift
@@ -13,10 +13,18 @@ actor SQLiteCoinGeckoCatalog: CoinGeckoCatalog {
   let log = Logger(subsystem: "moolah.instrument-registry", category: "catalog")
   private(set) var database: OpaquePointer?
 
-  // Note: `log` and `database` are module-internal (no explicit modifier
-  // per CODE_GUIDE §7) so the `+Search.swift` extension can read them.
-  // Helpers like `prepare`, `bind`, and `readText` below are also
-  // module-internal for the same reason.
+  // MARK: - Cross-extension internals
+  //
+  // `private` declarations are not visible to extensions in other files,
+  // so members called from `SQLiteCoinGeckoCatalog+Search.swift` (and any
+  // future `+…` extension) drop their `private` keyword and become module-
+  // internal: `log`, `database` (read-only via `private(set)`), and the
+  // low-level SQLite helpers `prepare`, `bind` (both overloads), and
+  // `readText` further down the file.
+  //
+  // These remain implementation details of the actor — callers outside
+  // `Backends/CoinGecko/` MUST NOT use them. New backend extensions on
+  // the actor should treat this list as the closed surface of helpers.
 
   init(
     directory: URL,

--- a/MoolahTests/Backends/SQLiteCoinGeckoCatalogSearchTests.swift
+++ b/MoolahTests/Backends/SQLiteCoinGeckoCatalogSearchTests.swift
@@ -36,6 +36,8 @@ final class SQLiteCoinGeckoCatalogSearchTests {
       ),
       .init(id: "tether", symbol: "USDT", name: "Tether", platforms: [:]),
       .init(id: "blockstack", symbol: "STX", name: "Stacks", platforms: [:]),
+      .init(id: "eos", symbol: "EOS", name: "EOS", platforms: [:]),
+      .init(id: "electroneum", symbol: "ETN", name: "Electroneum", platforms: [:]),
     ]
     let platforms: [SQLiteCoinGeckoCatalog.RawPlatform] = [
       .init(slug: "ethereum", chainId: 1, name: "Ethereum"),
@@ -90,7 +92,7 @@ final class SQLiteCoinGeckoCatalogSearchTests {
   @Test
   func limitIsRespected() async throws {
     try await seedFixture()
-    let results = await catalog.search(query: "e*", limit: 2)
-    #expect(results.count <= 2)
+    let results = await catalog.search(query: "e", limit: 2)
+    #expect(results.count == 2)
   }
 }

--- a/MoolahTests/Backends/SQLiteCoinGeckoCatalogSearchTests.swift
+++ b/MoolahTests/Backends/SQLiteCoinGeckoCatalogSearchTests.swift
@@ -1,0 +1,96 @@
+// MoolahTests/Backends/SQLiteCoinGeckoCatalogSearchTests.swift
+import Foundation
+import Testing
+
+@testable import Moolah
+
+/// Class-based suite so `deinit` can deterministically remove the per-test
+/// temp directory. Each `@Test` method runs on its own instance, mirroring
+/// the XCTest setUp/tearDown pattern from the plan.
+@Suite("SQLiteCoinGeckoCatalog search")
+final class SQLiteCoinGeckoCatalogSearchTests {
+  private let tempDir: URL
+  private let catalog: SQLiteCoinGeckoCatalog
+
+  init() throws {
+    tempDir = URL(fileURLWithPath: NSTemporaryDirectory())
+      .appendingPathComponent("search-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    catalog = try SQLiteCoinGeckoCatalog(directory: tempDir)
+  }
+
+  deinit {
+    try? FileManager.default.removeItem(at: tempDir)
+  }
+
+  private func seedFixture() async throws {
+    let coins: [SQLiteCoinGeckoCatalog.RawCoin] = [
+      .init(id: "bitcoin", symbol: "BTC", name: "Bitcoin", platforms: [:]),
+      .init(id: "ethereum", symbol: "ETH", name: "Ethereum", platforms: [:]),
+      .init(
+        id: "uniswap", symbol: "UNI", name: "Uniswap",
+        platforms: [
+          "ethereum": "0x1F9840a85d5aF5bf1D1762F925BDADdC4201F984",
+          "polygon-pos": "0xb33EaAd8d922B1083446DC23f610c2567fB5180f",
+        ]
+      ),
+      .init(id: "tether", symbol: "USDT", name: "Tether", platforms: [:]),
+      .init(id: "blockstack", symbol: "STX", name: "Stacks", platforms: [:]),
+    ]
+    let platforms: [SQLiteCoinGeckoCatalog.RawPlatform] = [
+      .init(slug: "ethereum", chainId: 1, name: "Ethereum"),
+      .init(slug: "polygon-pos", chainId: 137, name: "Polygon"),
+    ]
+    try await catalog.replaceAllForTesting(coins: coins, platforms: platforms)
+  }
+
+  @Test
+  func symbolPrefixHits() async throws {
+    try await seedFixture()
+    let results = await catalog.search(query: "btc", limit: 10)
+    #expect(results.first?.coingeckoId == "bitcoin")
+  }
+
+  @Test
+  func nameTokenHits() async throws {
+    try await seedFixture()
+    let results = await catalog.search(query: "uniswap", limit: 10)
+    #expect(results.first?.coingeckoId == "uniswap")
+  }
+
+  @Test
+  func platformsAttachedToHit() async throws {
+    try await seedFixture()
+    let results = await catalog.search(query: "uni", limit: 10)
+    let uni = try #require(results.first { $0.coingeckoId == "uniswap" })
+    #expect(uni.platforms.first?.slug == "ethereum")
+    #expect(uni.platforms.first?.chainId == 1)
+    #expect(
+      uni.platforms.first?.contractAddress
+        == "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984"
+    )
+    #expect(uni.platforms.contains { $0.slug == "polygon-pos" })
+  }
+
+  @Test
+  func platformOrderingHonoursPriority() async throws {
+    try await seedFixture()
+    let results = await catalog.search(query: "uni", limit: 10)
+    let uni = try #require(results.first { $0.coingeckoId == "uniswap" })
+    #expect(uni.platforms.map(\.slug) == ["ethereum", "polygon-pos"])
+  }
+
+  @Test
+  func emptyQueryReturnsEmpty() async throws {
+    try await seedFixture()
+    let results = await catalog.search(query: "", limit: 10)
+    #expect(results.isEmpty)
+  }
+
+  @Test
+  func limitIsRespected() async throws {
+    try await seedFixture()
+    let results = await catalog.search(query: "e*", limit: 2)
+    #expect(results.count <= 2)
+  }
+}


### PR DESCRIPTION
## Summary

Task 4 of the [instrument-registry UI plan](https://github.com/ajsutton/moolah-native/blob/main/plans/2026-04-27-instrument-registry-ui-implementation.md) (resolves #461). Replaces the Task 3 stub `search` with a real FTS5 implementation.

- `Backends/CoinGecko/SQLiteCoinGeckoCatalog+Search.swift` (new): public `search(query:limit:) async -> [CatalogEntry]` plus four private statics (`fetchRankedCoins`, `fetchPlatformBindings`, `orderedPlatforms`, `ftsQueryString`) and a `RankedCoin` row struct.
- Two-step query: `coin_fts MATCH ? ORDER BY rank LIMIT ?` for the top-N rows, then `… IN (?, ?, …)` to fan out platforms in a single round-trip.
- Per-coin platforms ordered by `CoinGeckoCatalogSchema.platformPriority` (ethereum → polygon-pos → …) with alphabetical fallback for unknown slugs.
- `ftsQueryString(for:)` quotes each token, escapes embedded `\"` as `\"\"`, and appends `*` for prefix matching: `\"btc\"*`, `\"apple\"* \"inc\"*`.
- `search` is **infallible by design** (returns `[]` on any error, logged via `os_log`) — see docstring on the method for rationale.

The actor file (`SQLiteCoinGeckoCatalog.swift`) loosens five members from `private` to module-internal so the cross-file extension can use them: `log`, `database` (read-only via `private(set)`), `prepare`, `bind` (both overloads), and `readText`. A new `// MARK: - Cross-extension internals` block documents this is the closed surface and warns callers outside `Backends/CoinGecko/` not to use them.

7 Swift Testing tests (6 new search + 5 existing storage from Task 3); all 11 pass on Mac and iOS. Two review fixes folded in (commit \`fdee627\`): the original `limitIsRespected` test was using `\"e*\"` which becomes a literal-token search returning 0 rows — replaced with a proper 3-coin seed and `count == 2` equality assertion.

Follows [#527](https://github.com/ajsutton/moolah-native/pull/527) (Task 3, storage layer — merged).

## Test plan

- [x] `just test SQLiteCoinGeckoCatalogSearchTests` passes 6/6 on `MoolahTests_iOS` and `MoolahTests_macOS`.
- [x] `just test SQLiteCoinGeckoCatalogStorageTests` (Task 3 regression check) passes 5/5 on both.
- [x] `just format-check` clean.
- [x] `swiftlint lint` reports 0 violations on all three files.
- [x] No `.swiftlint-baseline.yml` change.
- [x] xcodegen auto-globs the new files.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)