### PR TITLE
feat(catalog): ETag-aware refresh against /coins/list and /asset_platforms (Task 5, #461)

### DIFF
--- a/Backends/CoinGecko/SQLiteCoinGeckoCatalog+Refresh.swift
+++ b/Backends/CoinGecko/SQLiteCoinGeckoCatalog+Refresh.swift
@@ -25,10 +25,12 @@ extension SQLiteCoinGeckoCatalog {
       {
         return
       }
-      let coinsResult = try await Self.fetchConditional(
+      async let coinsRequest = Self.fetchConditional(
         session: session, url: Self.coinsListURL, ifNoneMatch: meta.coinsEtag)
-      let platformsResult = try await Self.fetchConditional(
+      async let platformsRequest = Self.fetchConditional(
         session: session, url: Self.assetPlatformsURL, ifNoneMatch: meta.platformsEtag)
+      let coinsResult = try await coinsRequest
+      let platformsResult = try await platformsRequest
 
       var newCoinsEtag = meta.coinsEtag
       var newPlatformsEtag = meta.platformsEtag
@@ -67,12 +69,18 @@ extension SQLiteCoinGeckoCatalog {
 // MARK: - Constants and fetch primitives
 
 extension SQLiteCoinGeckoCatalog {
-  static let coinsListURL: URL =
-    URL(string: "https://api.coingecko.com/api/v3/coins/list?include_platform=true")
-    ?? URL(fileURLWithPath: "/")
-  static let assetPlatformsURL: URL =
-    URL(string: "https://api.coingecko.com/api/v3/asset_platforms")
-    ?? URL(fileURLWithPath: "/")
+  static let coinsListURL: URL = {
+    guard
+      let url = URL(string: "https://api.coingecko.com/api/v3/coins/list?include_platform=true")
+    else { preconditionFailure("malformed CoinGecko coins-list URL — fix the literal") }
+    return url
+  }()
+
+  static let assetPlatformsURL: URL = {
+    guard let url = URL(string: "https://api.coingecko.com/api/v3/asset_platforms")
+    else { preconditionFailure("malformed CoinGecko asset-platforms URL — fix the literal") }
+    return url
+  }()
   /// 24-hour stale-fetch guard. Refresh callers are no-ops within this
   /// window even if the previous fetch returned 304.
   static let maxAge: TimeInterval = 24 * 3600
@@ -86,12 +94,12 @@ extension SQLiteCoinGeckoCatalog {
   /// a fresh body (`.replace`) or a 304 (`.unchanged`). Modeled as an enum
   /// so the SQLite write path doesn't conflate "no change" with "empty
   /// list".
-  enum CoinsUpdate {
+  enum CoinsUpdate: Sendable {
     case unchanged
     case replace([RawCoin])
   }
 
-  enum PlatformsUpdate {
+  enum PlatformsUpdate: Sendable {
     case unchanged
     case replace([RawPlatform])
   }
@@ -108,7 +116,7 @@ extension SQLiteCoinGeckoCatalog {
     request.setValue("gzip", forHTTPHeaderField: "Accept-Encoding")
     let (data, response) = try await session.data(for: request)
     guard let http = response as? HTTPURLResponse else {
-      throw CatalogError.sqlite("non-HTTP response from \(url.absoluteString)")
+      throw CatalogError.network("non-HTTP response from \(url.absoluteString)")
     }
     switch http.statusCode {
     case 200:
@@ -116,7 +124,7 @@ extension SQLiteCoinGeckoCatalog {
     case 304:
       return .notModified
     default:
-      throw CatalogError.sqlite("status \(http.statusCode) for \(url.absoluteString)")
+      throw CatalogError.network("status \(http.statusCode) for \(url.absoluteString)")
     }
   }
 }

--- a/Backends/CoinGecko/SQLiteCoinGeckoCatalog+Refresh.swift
+++ b/Backends/CoinGecko/SQLiteCoinGeckoCatalog+Refresh.swift
@@ -1,0 +1,270 @@
+// Backends/CoinGecko/SQLiteCoinGeckoCatalog+Refresh.swift
+import Foundation
+import SQLite3
+
+/// ETag-aware refresh path for `SQLiteCoinGeckoCatalog`. Hosted in a
+/// separate file so the actor's primary body stays focused on schema
+/// bootstrap and the storage seam (see CLAUDE.md and `guides/CODE_GUIDE.md`
+/// §7 on extension grouping).
+extension SQLiteCoinGeckoCatalog {
+  /// Performs a conditional GET against CoinGecko's `/coins/list` and
+  /// `/asset_platforms`, replacing the relevant tables in a transaction and
+  /// updating the meta row.
+  ///
+  /// Skipped when the prior fetch happened within `Self.maxAge` (24h).
+  /// Silent on failure (logged via `os_log` and swallowed) — the catalog
+  /// degrades to a stale snapshot rather than propagating errors to UI.
+  /// Crucially, when the network call throws the catch fires *before*
+  /// `writeMeta` runs, so `last_fetched` stays at its previous value and
+  /// the next launch retries.
+  func refreshIfStale() async {
+    do {
+      let meta = try Self.readMeta(database: database)
+      if let lastFetched = meta.lastFetched,
+        Date().timeIntervalSince(lastFetched) < Self.maxAge
+      {
+        return
+      }
+      let coinsResult = try await Self.fetchConditional(
+        session: session, url: Self.coinsListURL, ifNoneMatch: meta.coinsEtag)
+      let platformsResult = try await Self.fetchConditional(
+        session: session, url: Self.assetPlatformsURL, ifNoneMatch: meta.platformsEtag)
+
+      var newCoinsEtag = meta.coinsEtag
+      var newPlatformsEtag = meta.platformsEtag
+      var coinsUpdate = CoinsUpdate.unchanged
+      var platformsUpdate = PlatformsUpdate.unchanged
+
+      switch coinsResult {
+      case .notModified:
+        break
+      case let .ok(body, etag):
+        coinsUpdate = try .replace(Self.parseCoins(body))
+        newCoinsEtag = etag
+      }
+      switch platformsResult {
+      case .notModified:
+        break
+      case let .ok(body, etag):
+        platformsUpdate = try .replace(Self.parsePlatforms(body))
+        newPlatformsEtag = etag
+      }
+
+      try Self.applyUpdates(
+        database: database, coins: coinsUpdate, platforms: platformsUpdate)
+      try Self.writeMeta(
+        database: database,
+        lastFetched: Date(),
+        coinsEtag: newCoinsEtag,
+        platformsEtag: newPlatformsEtag
+      )
+    } catch {
+      log.error("refresh failed: \(String(describing: error), privacy: .public)")
+    }
+  }
+}
+
+// MARK: - Constants and fetch primitives
+
+extension SQLiteCoinGeckoCatalog {
+  static let coinsListURL: URL =
+    URL(string: "https://api.coingecko.com/api/v3/coins/list?include_platform=true")
+    ?? URL(fileURLWithPath: "/")
+  static let assetPlatformsURL: URL =
+    URL(string: "https://api.coingecko.com/api/v3/asset_platforms")
+    ?? URL(fileURLWithPath: "/")
+  /// 24-hour stale-fetch guard. Refresh callers are no-ops within this
+  /// window even if the previous fetch returned 304.
+  static let maxAge: TimeInterval = 24 * 3600
+
+  enum FetchOutcome: Sendable {
+    case ok(Data, etag: String?)
+    case notModified
+  }
+
+  /// One side of a `refreshIfStale()` snapshot: the network either returned
+  /// a fresh body (`.replace`) or a 304 (`.unchanged`). Modeled as an enum
+  /// so the SQLite write path doesn't conflate "no change" with "empty
+  /// list".
+  enum CoinsUpdate {
+    case unchanged
+    case replace([RawCoin])
+  }
+
+  enum PlatformsUpdate {
+    case unchanged
+    case replace([RawPlatform])
+  }
+
+  static func fetchConditional(
+    session: URLSession,
+    url: URL,
+    ifNoneMatch: String?
+  ) async throws -> FetchOutcome {
+    var request = URLRequest(url: url)
+    if let ifNoneMatch {
+      request.setValue(ifNoneMatch, forHTTPHeaderField: "If-None-Match")
+    }
+    request.setValue("gzip", forHTTPHeaderField: "Accept-Encoding")
+    let (data, response) = try await session.data(for: request)
+    guard let http = response as? HTTPURLResponse else {
+      throw CatalogError.sqlite("non-HTTP response from \(url.absoluteString)")
+    }
+    switch http.statusCode {
+    case 200:
+      return .ok(data, etag: http.value(forHTTPHeaderField: "ETag"))
+    case 304:
+      return .notModified
+    default:
+      throw CatalogError.sqlite("status \(http.statusCode) for \(url.absoluteString)")
+    }
+  }
+}
+
+// MARK: - JSON parsing
+
+/// Wire shape for one row of CoinGecko's `/coins/list` response. Top-level
+/// to keep SwiftLint's `nesting` rule (max one level deep) satisfied.
+private struct CoinWire: Decodable {
+  let id: String
+  let symbol: String
+  let name: String
+  /// CoinGecko sometimes maps a known platform slug to `null` for de-listed
+  /// tokens; the parser compacts the dictionary to non-empty strings before
+  /// inserting. The `platforms` key is always present in `?include_platform=true`
+  /// responses; defaults to `[:]` for defensive decoding if a future API
+  /// version omits it.
+  let platforms: [String: String?]
+
+  enum CodingKeys: String, CodingKey {
+    case id, symbol, name, platforms
+  }
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    self.id = try container.decode(String.self, forKey: .id)
+    self.symbol = try container.decode(String.self, forKey: .symbol)
+    self.name = try container.decode(String.self, forKey: .name)
+    self.platforms =
+      try container.decodeIfPresent([String: String?].self, forKey: .platforms) ?? [:]
+  }
+}
+
+/// Wire shape for one row of CoinGecko's `/asset_platforms` response.
+private struct PlatformWire: Decodable {
+  let id: String
+  let chainIdentifier: Int?
+  let name: String
+
+  enum CodingKeys: String, CodingKey {
+    case id
+    case chainIdentifier = "chain_identifier"
+    case name
+  }
+}
+
+extension SQLiteCoinGeckoCatalog {
+  static func parseCoins(_ data: Data) throws -> [RawCoin] {
+    let decoded = try JSONDecoder().decode([CoinWire].self, from: data)
+    return decoded.map { wire in
+      var platforms: [String: String] = [:]
+      for (slug, contract) in wire.platforms {
+        if let contract, !contract.isEmpty {
+          platforms[slug] = contract
+        }
+      }
+      return RawCoin(
+        id: wire.id,
+        symbol: wire.symbol.uppercased(),
+        name: wire.name,
+        platforms: platforms
+      )
+    }
+  }
+
+  static func parsePlatforms(_ data: Data) throws -> [RawPlatform] {
+    let decoded = try JSONDecoder().decode([PlatformWire].self, from: data)
+    return decoded.map {
+      RawPlatform(slug: $0.id, chainId: $0.chainIdentifier, name: $0.name)
+    }
+  }
+}
+
+// MARK: - Apply updates and meta write
+
+extension SQLiteCoinGeckoCatalog {
+  /// If both halves changed, delegate to the all-tables `replaceAll` so the
+  /// snapshot is consistent. Otherwise replace only the side that changed,
+  /// preserving the other. A 304/304 pair is a no-op.
+  static func applyUpdates(
+    database: OpaquePointer?,
+    coins: CoinsUpdate,
+    platforms: PlatformsUpdate
+  ) throws {
+    switch (coins, platforms) {
+    case (.unchanged, .unchanged):
+      return
+    case let (.replace(coins), .replace(platforms)):
+      try replaceAll(database: database, coins: coins, platforms: platforms)
+    case let (.replace(coins), .unchanged):
+      try replaceCoinsOnly(database: database, coins: coins)
+    case let (.unchanged, .replace(platforms)):
+      try replacePlatformsOnly(database: database, platforms: platforms)
+    }
+  }
+
+  private static func replaceCoinsOnly(
+    database: OpaquePointer?, coins: [RawCoin]
+  ) throws {
+    try exec(database: database, "BEGIN IMMEDIATE;")
+    do {
+      try exec(database: database, "DELETE FROM coin;")
+      try insertCoins(database: database, coins: coins)
+      try exec(database: database, "COMMIT;")
+    } catch {
+      try? exec(database: database, "ROLLBACK;")
+      throw error
+    }
+  }
+
+  private static func replacePlatformsOnly(
+    database: OpaquePointer?, platforms: [RawPlatform]
+  ) throws {
+    try exec(database: database, "BEGIN IMMEDIATE;")
+    do {
+      try exec(database: database, "DELETE FROM platform;")
+      try insertPlatforms(database: database, platforms: platforms)
+      try exec(database: database, "COMMIT;")
+    } catch {
+      try? exec(database: database, "ROLLBACK;")
+      throw error
+    }
+  }
+
+  static func writeMeta(
+    database: OpaquePointer?,
+    lastFetched: Date,
+    coinsEtag: String?,
+    platformsEtag: String?
+  ) throws {
+    var statement: OpaquePointer?
+    try prepare(
+      database: database,
+      "UPDATE meta SET last_fetched = ?, coins_etag = ?, platforms_etag = ?;",
+      &statement
+    )
+    defer { sqlite3_finalize(statement) }
+    sqlite3_bind_double(statement, 1, lastFetched.timeIntervalSince1970)
+    if let coinsEtag {
+      try bind(statement, 2, coinsEtag)
+    } else {
+      sqlite3_bind_null(statement, 2)
+    }
+    if let platformsEtag {
+      try bind(statement, 3, platformsEtag)
+    } else {
+      sqlite3_bind_null(statement, 3)
+    }
+    try step(statement)
+  }
+}

--- a/Backends/CoinGecko/SQLiteCoinGeckoCatalog.swift
+++ b/Backends/CoinGecko/SQLiteCoinGeckoCatalog.swift
@@ -15,18 +15,17 @@ actor SQLiteCoinGeckoCatalog: CoinGeckoCatalog {
 
   // MARK: - Cross-extension internals
   //
-  // `private` declarations are not visible to extensions in other files,
-  // so members called from `SQLiteCoinGeckoCatalog+Search.swift` and
-  // `SQLiteCoinGeckoCatalog+Refresh.swift` drop their `private` keyword and
-  // become module-internal: `log`, `session`, `database` (read-only via
-  // `private(set)`), the low-level SQLite helpers `exec`, `prepare`, `bind`
-  // (both overloads), `step`, and `readText` further down the file, the
-  // replace-all writers `replaceAll`, `insertCoins`, `insertPlatforms`, and
-  // the meta reader `readMeta`.
+  // Swift's `private` doesn't reach across files, so members called from
+  // `+Search.swift` or `+Refresh.swift` drop their `private` keyword and
+  // become module-internal. This is the closed surface — callers outside
+  // `Backends/CoinGecko/` MUST NOT use them.
   //
-  // These remain implementation details of the actor — callers outside
-  // `Backends/CoinGecko/` MUST NOT use them. New backend extensions on
-  // the actor should treat this list as the closed surface of helpers.
+  // Used by +Search.swift only:    `readText`
+  // Used by +Refresh.swift only:   `session`, `exec`, `step`,
+  //                                `replaceAll`, `insertCoins`,
+  //                                `insertPlatforms`, `readMeta`
+  // Used by both extensions:       `log`, `database` (read-only),
+  //                                `prepare`, `bind` (×2)
 
   init(
     directory: URL,
@@ -278,6 +277,7 @@ actor SQLiteCoinGeckoCatalog: CoinGeckoCatalog {
 
   enum CatalogError: Error, Equatable {
     case sqlite(String)
+    case network(String)
   }
 }
 

--- a/Backends/CoinGecko/SQLiteCoinGeckoCatalog.swift
+++ b/Backends/CoinGecko/SQLiteCoinGeckoCatalog.swift
@@ -9,18 +9,20 @@ import os
 /// shared across threads. See design §4.1 / §6.
 actor SQLiteCoinGeckoCatalog: CoinGeckoCatalog {
   private let directory: URL
-  private let session: URLSession
+  let session: URLSession
   let log = Logger(subsystem: "moolah.instrument-registry", category: "catalog")
   private(set) var database: OpaquePointer?
 
   // MARK: - Cross-extension internals
   //
   // `private` declarations are not visible to extensions in other files,
-  // so members called from `SQLiteCoinGeckoCatalog+Search.swift` (and any
-  // future `+…` extension) drop their `private` keyword and become module-
-  // internal: `log`, `database` (read-only via `private(set)`), and the
-  // low-level SQLite helpers `prepare`, `bind` (both overloads), and
-  // `readText` further down the file.
+  // so members called from `SQLiteCoinGeckoCatalog+Search.swift` and
+  // `SQLiteCoinGeckoCatalog+Refresh.swift` drop their `private` keyword and
+  // become module-internal: `log`, `session`, `database` (read-only via
+  // `private(set)`), the low-level SQLite helpers `exec`, `prepare`, `bind`
+  // (both overloads), `step`, and `readText` further down the file, the
+  // replace-all writers `replaceAll`, `insertCoins`, `insertPlatforms`, and
+  // the meta reader `readMeta`.
   //
   // These remain implementation details of the actor — callers outside
   // `Backends/CoinGecko/` MUST NOT use them. New backend extensions on
@@ -45,10 +47,7 @@ actor SQLiteCoinGeckoCatalog: CoinGeckoCatalog {
   // MARK: - CoinGeckoCatalog
   //
   // `search(query:limit:)` lives in `SQLiteCoinGeckoCatalog+Search.swift`.
-
-  func refreshIfStale() async {
-    // Implemented in Task 5.
-  }
+  // `refreshIfStale()` lives in `SQLiteCoinGeckoCatalog+Refresh.swift`.
 
   // MARK: - Schema bootstrap
   //
@@ -105,21 +104,25 @@ actor SQLiteCoinGeckoCatalog: CoinGeckoCatalog {
 
   // MARK: - Replace-all
 
-  private func replaceAll(coins: [RawCoin], platforms: [RawPlatform]) throws {
-    try Self.exec(database: database, "BEGIN IMMEDIATE;")
+  static func replaceAll(
+    database: OpaquePointer?,
+    coins: [RawCoin],
+    platforms: [RawPlatform]
+  ) throws {
+    try exec(database: database, "BEGIN IMMEDIATE;")
     do {
-      try Self.exec(database: database, "DELETE FROM coin;")
-      try Self.exec(database: database, "DELETE FROM platform;")
-      try Self.insertCoins(database: database, coins: coins)
-      try Self.insertPlatforms(database: database, platforms: platforms)
-      try Self.exec(database: database, "COMMIT;")
+      try exec(database: database, "DELETE FROM coin;")
+      try exec(database: database, "DELETE FROM platform;")
+      try insertCoins(database: database, coins: coins)
+      try insertPlatforms(database: database, platforms: platforms)
+      try exec(database: database, "COMMIT;")
     } catch {
-      try? Self.exec(database: database, "ROLLBACK;")
+      try? exec(database: database, "ROLLBACK;")
       throw error
     }
   }
 
-  private static func insertCoins(database: OpaquePointer?, coins: [RawCoin]) throws {
+  static func insertCoins(database: OpaquePointer?, coins: [RawCoin]) throws {
     guard !coins.isEmpty else { return }
     var insertCoin: OpaquePointer?
     try prepare(
@@ -152,7 +155,7 @@ actor SQLiteCoinGeckoCatalog: CoinGeckoCatalog {
     }
   }
 
-  private static func insertPlatforms(
+  static func insertPlatforms(
     database: OpaquePointer?,
     platforms: [RawPlatform]
   ) throws {
@@ -178,7 +181,7 @@ actor SQLiteCoinGeckoCatalog: CoinGeckoCatalog {
 
   // MARK: - Meta read / write
 
-  private static func readMeta(database: OpaquePointer?) throws -> MetaSnapshot {
+  static func readMeta(database: OpaquePointer?) throws -> MetaSnapshot {
     var statement: OpaquePointer?
     try prepare(
       database: database,
@@ -206,7 +209,7 @@ actor SQLiteCoinGeckoCatalog: CoinGeckoCatalog {
 
   // MARK: - Low-level SQLite helpers
 
-  private static func exec(database: OpaquePointer?, _ sql: String) throws {
+  static func exec(database: OpaquePointer?, _ sql: String) throws {
     var error: UnsafeMutablePointer<CChar>?
     let result = sqlite3_exec(database, sql, nil, nil, &error)
     if result != SQLITE_OK {
@@ -251,7 +254,7 @@ actor SQLiteCoinGeckoCatalog: CoinGeckoCatalog {
     guard result == SQLITE_OK else { throw CatalogError.sqlite("bind int \(result)") }
   }
 
-  private static func step(_ statement: OpaquePointer?) throws {
+  static func step(_ statement: OpaquePointer?) throws {
     let result = sqlite3_step(statement)
     guard result == SQLITE_DONE || result == SQLITE_ROW else {
       throw CatalogError.sqlite("step \(result)")
@@ -281,9 +284,9 @@ actor SQLiteCoinGeckoCatalog: CoinGeckoCatalog {
 // MARK: - Test seams
 //
 // The `RawCoin` / `RawPlatform` / `MetaSnapshot` value types and the
-// `*ForTesting` accessors are module-internal so storage tests can
-// exercise replace-all and meta read/write without depending on the
-// network refresh path (which lands in Task 5). Production callers go
+// `*ForTesting` accessors are module-internal so storage and refresh tests
+// can exercise replace-all, meta read/write, and the stale-fetch guard
+// without depending on the network refresh path. Production callers go
 // through `search(query:limit:)` and `refreshIfStale()`. Hosting them in
 // an extension keeps the actor body focused on production code paths.
 
@@ -310,7 +313,14 @@ extension SQLiteCoinGeckoCatalog {
   }
 
   func replaceAllForTesting(coins: [RawCoin], platforms: [RawPlatform]) throws {
-    try replaceAll(coins: coins, platforms: platforms)
+    try Self.replaceAll(database: database, coins: coins, platforms: platforms)
+  }
+
+  func bumpLastFetchedBackwardForTesting(by seconds: TimeInterval) throws {
+    try Self.exec(
+      database: database,
+      "UPDATE meta SET last_fetched = COALESCE(last_fetched, 0) - \(seconds);"
+    )
   }
 
   func readMetaForTesting() throws -> MetaSnapshot {

--- a/MoolahTests/Backends/CoinGeckoSearchClientTests.swift
+++ b/MoolahTests/Backends/CoinGeckoSearchClientTests.swift
@@ -4,7 +4,7 @@ import Testing
 
 @testable import Moolah
 
-@Suite("CoinGeckoSearchClient")
+@Suite("CoinGeckoSearchClient", .serialized)
 struct CoinGeckoSearchClientTests {
   @Test
   func searchReturnsHitsFromFixture() async throws {
@@ -114,23 +114,4 @@ private class CoinGeckoSearchURLProtocolStub: URLProtocol {
   }
 
   override func stopLoading() {}
-}
-
-private final class LockedBox<Value>: @unchecked Sendable {
-  private let lock = NSLock()
-  private var value: Value
-
-  init(_ initial: Value) { self.value = initial }
-
-  func get() -> Value {
-    lock.lock()
-    defer { lock.unlock() }
-    return value
-  }
-
-  func set(_ newValue: Value) {
-    lock.lock()
-    defer { lock.unlock() }
-    value = newValue
-  }
 }

--- a/MoolahTests/Backends/SQLiteCoinGeckoCatalogRefreshTests.swift
+++ b/MoolahTests/Backends/SQLiteCoinGeckoCatalogRefreshTests.swift
@@ -1,0 +1,184 @@
+// MoolahTests/Backends/SQLiteCoinGeckoCatalogRefreshTests.swift
+import Foundation
+import Testing
+
+@testable import Moolah
+
+/// Class-based suite so `deinit` can deterministically clean up the per-test
+/// temp directory and the shared `StubURLProtocol` handlers map. Each
+/// `@Test` instantiates a fresh suite, so handlers don't leak across tests.
+@Suite("SQLiteCoinGeckoCatalog refresh")
+final class SQLiteCoinGeckoCatalogRefreshTests {
+  private let tempDir: URL
+
+  init() throws {
+    tempDir = URL(fileURLWithPath: NSTemporaryDirectory())
+      .appendingPathComponent("refresh-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+  }
+
+  deinit {
+    StubURLProtocol.handlers = [:]
+    try? FileManager.default.removeItem(at: tempDir)
+  }
+
+  private func makeSession() -> URLSession {
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [StubURLProtocol.self]
+    return URLSession(configuration: config)
+  }
+
+  private func loadFixture(_ name: String) throws -> Data {
+    let bundle = Bundle(for: TestBundleMarker.self)
+    let url = try #require(bundle.url(forResource: name, withExtension: "json"))
+    return try Data(contentsOf: url)
+  }
+
+  @Test
+  func refreshDownloadsAndPopulates() async throws {
+    let coinsData = try loadFixture("coingecko-coins-list-small")
+    let platformsData = try loadFixture("coingecko-asset-platforms")
+    StubURLProtocol.handlers["api.coingecko.com:/api/v3/coins/list"] = { _ in
+      (HTTPURLResponse.ok(etag: "W/\"a1\""), coinsData)
+    }
+    StubURLProtocol.handlers["api.coingecko.com:/api/v3/asset_platforms"] = { _ in
+      (HTTPURLResponse.ok(etag: "W/\"p1\""), platformsData)
+    }
+
+    let catalog = try SQLiteCoinGeckoCatalog(directory: tempDir, session: makeSession())
+    await catalog.refreshIfStale()
+
+    let count = try await catalog.coinCountForTesting()
+    #expect(count == 3)
+    let platforms = try await catalog.platformCountForTesting()
+    #expect(platforms == 3)
+    let meta = try await catalog.readMetaForTesting()
+    #expect(meta.coinsEtag == "W/\"a1\"")
+    #expect(meta.platformsEtag == "W/\"p1\"")
+    #expect(meta.lastFetched != nil)
+  }
+
+  @Test
+  func refreshSendsIfNoneMatchOnSubsequentCall() async throws {
+    let coinsData = try loadFixture("coingecko-coins-list-small")
+    let platformsData = try loadFixture("coingecko-asset-platforms")
+    StubURLProtocol.handlers["api.coingecko.com:/api/v3/coins/list"] = { _ in
+      (HTTPURLResponse.ok(etag: "W/\"a1\""), coinsData)
+    }
+    StubURLProtocol.handlers["api.coingecko.com:/api/v3/asset_platforms"] = { _ in
+      (HTTPURLResponse.ok(etag: "W/\"p1\""), platformsData)
+    }
+    let catalog = try SQLiteCoinGeckoCatalog(directory: tempDir, session: makeSession())
+    await catalog.refreshIfStale()
+
+    // Fast-forward `last_fetched` so the next call is "stale".
+    try await catalog.bumpLastFetchedBackwardForTesting(by: 25 * 3600)
+
+    let capturedHeaders = LockedBox<[String: String]>([:])
+    StubURLProtocol.handlers["api.coingecko.com:/api/v3/coins/list"] = { request in
+      capturedHeaders.set(request.allHTTPHeaderFields ?? [:])
+      return (HTTPURLResponse.notModified(), Data())
+    }
+    StubURLProtocol.handlers["api.coingecko.com:/api/v3/asset_platforms"] = { _ in
+      (HTTPURLResponse.notModified(), Data())
+    }
+    await catalog.refreshIfStale()
+
+    #expect(capturedHeaders.get()["If-None-Match"] == "W/\"a1\"")
+  }
+
+  @Test
+  func refreshSkippedWhenWithinMaxAge() async throws {
+    let coinsData = try loadFixture("coingecko-coins-list-small")
+    let platformsData = try loadFixture("coingecko-asset-platforms")
+    let coinsCallCount = LockedBox<Int>(0)
+    StubURLProtocol.handlers["api.coingecko.com:/api/v3/coins/list"] = { _ in
+      coinsCallCount.set(coinsCallCount.get() + 1)
+      return (HTTPURLResponse.ok(etag: "W/\"a1\""), coinsData)
+    }
+    StubURLProtocol.handlers["api.coingecko.com:/api/v3/asset_platforms"] = { _ in
+      (HTTPURLResponse.ok(etag: "W/\"p1\""), platformsData)
+    }
+    let catalog = try SQLiteCoinGeckoCatalog(directory: tempDir, session: makeSession())
+    await catalog.refreshIfStale()
+    await catalog.refreshIfStale()
+
+    #expect(coinsCallCount.get() == 1)
+  }
+
+  @Test
+  func refreshOnNetworkErrorPreservesPriorSnapshot() async throws {
+    let coinsData = try loadFixture("coingecko-coins-list-small")
+    let platformsData = try loadFixture("coingecko-asset-platforms")
+    StubURLProtocol.handlers["api.coingecko.com:/api/v3/coins/list"] = { _ in
+      (HTTPURLResponse.ok(etag: "W/\"a1\""), coinsData)
+    }
+    StubURLProtocol.handlers["api.coingecko.com:/api/v3/asset_platforms"] = { _ in
+      (HTTPURLResponse.ok(etag: "W/\"p1\""), platformsData)
+    }
+    let catalog = try SQLiteCoinGeckoCatalog(directory: tempDir, session: makeSession())
+    await catalog.refreshIfStale()
+    try await catalog.bumpLastFetchedBackwardForTesting(by: 25 * 3600)
+
+    StubURLProtocol.handlers["api.coingecko.com:/api/v3/coins/list"] = { _ in
+      throw URLError(.notConnectedToInternet)
+    }
+    StubURLProtocol.handlers["api.coingecko.com:/api/v3/asset_platforms"] = { _ in
+      throw URLError(.notConnectedToInternet)
+    }
+    await catalog.refreshIfStale()
+
+    let count = try await catalog.coinCountForTesting()
+    #expect(count == 3)  // unchanged
+  }
+
+  @Test
+  func refreshAcceptsUpdatedSnapshot() async throws {
+    let firstCoins = try loadFixture("coingecko-coins-list-small")
+    let secondCoins = try loadFixture("coingecko-coins-list-small-updated")
+    let platforms = try loadFixture("coingecko-asset-platforms")
+    StubURLProtocol.handlers["api.coingecko.com:/api/v3/coins/list"] = { _ in
+      (HTTPURLResponse.ok(etag: "W/\"a1\""), firstCoins)
+    }
+    StubURLProtocol.handlers["api.coingecko.com:/api/v3/asset_platforms"] = { _ in
+      (HTTPURLResponse.ok(etag: "W/\"p1\""), platforms)
+    }
+    let catalog = try SQLiteCoinGeckoCatalog(directory: tempDir, session: makeSession())
+    await catalog.refreshIfStale()
+    try await catalog.bumpLastFetchedBackwardForTesting(by: 25 * 3600)
+
+    StubURLProtocol.handlers["api.coingecko.com:/api/v3/coins/list"] = { _ in
+      (HTTPURLResponse.ok(etag: "W/\"a2\""), secondCoins)
+    }
+    await catalog.refreshIfStale()
+
+    let count = try await catalog.coinCountForTesting()
+    #expect(count == 4)
+    let pepe = await catalog.search(query: "pepe", limit: 5)
+    #expect(pepe.first?.coingeckoId == "pepe")
+    let meta = try await catalog.readMetaForTesting()
+    #expect(meta.coinsEtag == "W/\"a2\"")
+  }
+}
+
+/// Mutex-protected box for shared mutable state captured into a stub
+/// `URLProtocol` handler. The handler closure is `@Sendable`, so any captured
+/// state must be safely shareable.
+private final class LockedBox<Value>: @unchecked Sendable {
+  private let lock = NSLock()
+  private var value: Value
+
+  init(_ initial: Value) { self.value = initial }
+
+  func get() -> Value {
+    lock.lock()
+    defer { lock.unlock() }
+    return value
+  }
+
+  func set(_ newValue: Value) {
+    lock.lock()
+    defer { lock.unlock() }
+    value = newValue
+  }
+}

--- a/MoolahTests/Backends/SQLiteCoinGeckoCatalogRefreshTests.swift
+++ b/MoolahTests/Backends/SQLiteCoinGeckoCatalogRefreshTests.swift
@@ -7,7 +7,7 @@ import Testing
 /// Class-based suite so `deinit` can deterministically clean up the per-test
 /// temp directory and the shared `StubURLProtocol` handlers map. Each
 /// `@Test` instantiates a fresh suite, so handlers don't leak across tests.
-@Suite("SQLiteCoinGeckoCatalog refresh")
+@Suite("SQLiteCoinGeckoCatalog refresh", .serialized)
 final class SQLiteCoinGeckoCatalogRefreshTests {
   private let tempDir: URL
 
@@ -85,6 +85,13 @@ final class SQLiteCoinGeckoCatalogRefreshTests {
     await catalog.refreshIfStale()
 
     #expect(capturedHeaders.get()["If-None-Match"] == "W/\"a1\"")
+
+    let meta = try await catalog.readMetaForTesting()
+    let lastFetched = try #require(meta.lastFetched)
+    // 304/304 round-trip should bump last_fetched forward (within the last few
+    // seconds) — without this, a regression that skipped `writeMeta` on the
+    // all-304 path would let the catalog re-fetch on every launch.
+    #expect(lastFetched.timeIntervalSinceNow > -60)
   }
 
   @Test
@@ -158,27 +165,5 @@ final class SQLiteCoinGeckoCatalogRefreshTests {
     #expect(pepe.first?.coingeckoId == "pepe")
     let meta = try await catalog.readMetaForTesting()
     #expect(meta.coinsEtag == "W/\"a2\"")
-  }
-}
-
-/// Mutex-protected box for shared mutable state captured into a stub
-/// `URLProtocol` handler. The handler closure is `@Sendable`, so any captured
-/// state must be safely shareable.
-private final class LockedBox<Value>: @unchecked Sendable {
-  private let lock = NSLock()
-  private var value: Value
-
-  init(_ initial: Value) { self.value = initial }
-
-  func get() -> Value {
-    lock.lock()
-    defer { lock.unlock() }
-    return value
-  }
-
-  func set(_ newValue: Value) {
-    lock.lock()
-    defer { lock.unlock() }
-    value = newValue
   }
 }

--- a/MoolahTests/Support/Fixtures/coingecko-asset-platforms.json
+++ b/MoolahTests/Support/Fixtures/coingecko-asset-platforms.json
@@ -1,0 +1,5 @@
+[
+  {"id": "ethereum", "chain_identifier": 1, "name": "Ethereum"},
+  {"id": "polygon-pos", "chain_identifier": 137, "name": "Polygon POS"},
+  {"id": "solana", "chain_identifier": null, "name": "Solana"}
+]

--- a/MoolahTests/Support/Fixtures/coingecko-coins-list-small-updated.json
+++ b/MoolahTests/Support/Fixtures/coingecko-coins-list-small-updated.json
@@ -1,0 +1,8 @@
+[
+  {"id": "bitcoin", "symbol": "btc", "name": "Bitcoin", "platforms": {}},
+  {"id": "ethereum", "symbol": "eth", "name": "Ethereum", "platforms": {}},
+  {"id": "uniswap", "symbol": "uni", "name": "Uniswap",
+   "platforms": {"ethereum": "0x1F9840a85d5aF5bf1D1762F925BDADdC4201F984"}},
+  {"id": "pepe", "symbol": "pepe", "name": "Pepe",
+   "platforms": {"ethereum": "0x6982508145454Ce325dDbE47a25d4ec3d2311933"}}
+]

--- a/MoolahTests/Support/Fixtures/coingecko-coins-list-small.json
+++ b/MoolahTests/Support/Fixtures/coingecko-coins-list-small.json
@@ -1,0 +1,6 @@
+[
+  {"id": "bitcoin", "symbol": "btc", "name": "Bitcoin", "platforms": {}},
+  {"id": "ethereum", "symbol": "eth", "name": "Ethereum", "platforms": {}},
+  {"id": "uniswap", "symbol": "uni", "name": "Uniswap",
+   "platforms": {"ethereum": "0x1F9840a85d5aF5bf1D1762F925BDADdC4201F984"}}
+]

--- a/MoolahTests/Support/LockedBox.swift
+++ b/MoolahTests/Support/LockedBox.swift
@@ -1,0 +1,25 @@
+// MoolahTests/Support/LockedBox.swift
+import Foundation
+
+/// Lock-guarded mutable box used by tests to capture state from `@Sendable`
+/// closures (e.g. `URLProtocol` request handlers) without tripping Swift 6
+/// strict concurrency rules. Module-internal so multiple test files can share
+/// a single definition rather than each declaring their own private copy.
+final class LockedBox<Value>: @unchecked Sendable {
+  private let lock = NSLock()
+  private var value: Value
+
+  init(_ initial: Value) { self.value = initial }
+
+  func get() -> Value {
+    lock.lock()
+    defer { lock.unlock() }
+    return value
+  }
+
+  func set(_ newValue: Value) {
+    lock.lock()
+    defer { lock.unlock() }
+    value = newValue
+  }
+}

--- a/MoolahTests/Support/StubURLProtocol.swift
+++ b/MoolahTests/Support/StubURLProtocol.swift
@@ -56,18 +56,22 @@ extension HTTPURLResponse {
   /// returns a non-optional URL, so we get a force-unwrap-free constant.
   private static let stubResponseURL = URL(fileURLWithPath: "/")
 
+  // swiftlint:disable force_unwrapping
+  // `HTTPURLResponse(url:statusCode:httpVersion:headerFields:)` only fails on
+  // a malformed `httpVersion`, and `"HTTP/1.1"` is a hardcoded literal — so
+  // the force-unwraps below are provably safe. The previous
+  // `?? HTTPURLResponse()` fallback would have papered over a programmer
+  // error rather than handling a real failure mode, so force-unwrap is the
+  // honest spelling. CODE_GUIDE §9 explicitly permits this in test code.
+
   /// Convenience for tests building 200 responses with an `ETag` header.
-  /// Returns a non-optional value via the same `URL(fileURLWithPath:)`
-  /// fallback as `stubResponseURL`; the underlying `HTTPURLResponse`
-  /// initialiser only fails on malformed `httpVersion`, which is a literal
-  /// here.
   static func ok(etag: String) -> HTTPURLResponse {
     HTTPURLResponse(
       url: stubResponseURL,
       statusCode: 200,
       httpVersion: "HTTP/1.1",
       headerFields: ["ETag": etag, "Content-Type": "application/json"]
-    ) ?? HTTPURLResponse()
+    )!
   }
 
   /// 304 Not Modified for conditional GETs returning no body.
@@ -77,6 +81,7 @@ extension HTTPURLResponse {
       statusCode: 304,
       httpVersion: "HTTP/1.1",
       headerFields: [:]
-    ) ?? HTTPURLResponse()
+    )!
   }
+  // swiftlint:enable force_unwrapping
 }

--- a/MoolahTests/Support/StubURLProtocol.swift
+++ b/MoolahTests/Support/StubURLProtocol.swift
@@ -1,0 +1,82 @@
+// MoolahTests/Support/StubURLProtocol.swift
+import Foundation
+
+/// Process-wide `URLProtocol` stub that dispatches by `"<host>:<path>"` so a
+/// single registration can serve multiple endpoints in the same test. Tests
+/// install handlers per-test (in `init`) and reset them on teardown.
+///
+/// Tests construct an ephemeral `URLSession` whose `protocolClasses` lists
+/// this stub, so requests stay scoped to the test's session — calling
+/// `URLProtocol.registerClass(_:)` is unnecessary and skipped.
+///
+/// Intentionally non-`final` so SwiftLint's `static_over_final_class` rule
+/// doesn't apply to the inherited overrides. `URLProtocol` already declares
+/// its own (unavailable) Sendable conformance, so the subclass can't add a
+/// new one — `nonisolated(unsafe)` on the static handlers map is what
+/// actually keeps Swift 6 strict concurrency happy here.
+class StubURLProtocol: URLProtocol {
+  /// `nonisolated(unsafe)` because tests are single-threaded with respect to
+  /// this map (handlers are installed in `init`, read on the session's
+  /// internal queue per request, and cleared in `deinit`). Concurrent
+  /// fixture-loading tests use disjoint host/path keys, so there is no
+  /// shared mutable state at the test boundary.
+  nonisolated(unsafe) static var handlers:
+    [String: @Sendable (URLRequest) throws -> (HTTPURLResponse, Data)] = [:]
+
+  override class func canInit(with request: URLRequest) -> Bool { true }
+  override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+  override func startLoading() {
+    guard let url = request.url, let host = url.host else {
+      client?.urlProtocol(self, didFailWithError: URLError(.badURL))
+      return
+    }
+    let key = "\(host):\(url.path)"
+    guard let handler = Self.handlers[key] else {
+      client?.urlProtocol(self, didFailWithError: URLError(.unsupportedURL))
+      return
+    }
+    do {
+      let (response, data) = try handler(request)
+      client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+      client?.urlProtocol(self, didLoad: data)
+      client?.urlProtocolDidFinishLoading(self)
+    } catch {
+      client?.urlProtocol(self, didFailWithError: error)
+    }
+  }
+
+  override func stopLoading() {}
+}
+
+extension HTTPURLResponse {
+  /// Sentinel response URL for stub-built responses; the value is irrelevant
+  /// to the assertions because `URLSession` reports the request URL on the
+  /// resulting response object regardless. `URL(fileURLWithPath:)` always
+  /// returns a non-optional URL, so we get a force-unwrap-free constant.
+  private static let stubResponseURL = URL(fileURLWithPath: "/")
+
+  /// Convenience for tests building 200 responses with an `ETag` header.
+  /// Returns a non-optional value via the same `URL(fileURLWithPath:)`
+  /// fallback as `stubResponseURL`; the underlying `HTTPURLResponse`
+  /// initialiser only fails on malformed `httpVersion`, which is a literal
+  /// here.
+  static func ok(etag: String) -> HTTPURLResponse {
+    HTTPURLResponse(
+      url: stubResponseURL,
+      statusCode: 200,
+      httpVersion: "HTTP/1.1",
+      headerFields: ["ETag": etag, "Content-Type": "application/json"]
+    ) ?? HTTPURLResponse()
+  }
+
+  /// 304 Not Modified for conditional GETs returning no body.
+  static func notModified() -> HTTPURLResponse {
+    HTTPURLResponse(
+      url: stubResponseURL,
+      statusCode: 304,
+      httpVersion: "HTTP/1.1",
+      headerFields: [:]
+    ) ?? HTTPURLResponse()
+  }
+}


### PR DESCRIPTION
## Summary

Task 5 of the [instrument-registry UI plan](https://github.com/ajsutton/moolah-native/blob/main/plans/2026-04-27-instrument-registry-ui-implementation.md) (resolves #461). Replaces the Task 3 stub `refreshIfStale()` with the real CoinGecko refresh path.

- `Backends/CoinGecko/SQLiteCoinGeckoCatalog+Refresh.swift` (new): public `refreshIfStale() async` plus statics for `fetchConditional` (with `If-None-Match` conditional GET), `parseCoins`/`parsePlatforms`, `applyUpdates`/`replaceCoinsOnly`/`replacePlatformsOnly`, and `writeMeta`.
- 24h max-age guard short-circuits before any network IO.
- Two parallel requests via `async let` (per design §5.4).
- `200 OK` parses JSON, replaces only the affected table inside a `BEGIN IMMEDIATE` / `COMMIT` (with `ROLLBACK` on error). `304 Not Modified` is a no-op for that table.
- `last_fetched` is updated after a successful round-trip (including all-304 — suppresses redundant fetch for the next 24h). On any thrown error: log via `os_log` and do NOT update `last_fetched` (retry on next launch). Snapshot is preserved.
- `CoinsUpdate` / `PlatformsUpdate` enums replace `Optional<[T]>` parameters (avoids `discouraged_optional_collection` while keeping the four-state semantics explicit).

`MoolahTests/Support/StubURLProtocol.swift` (new): reusable URL stub with per-host:path handler dispatch. Task 6's Yahoo test will reuse it.

`MoolahTests/Support/LockedBox.swift` (new): module-internal lock-guarded box, deduplicated from two existing test files (`CoinGeckoSearchClientTests.swift` + the new refresh test).

5 Swift Testing tests covering: download+populate, conditional GET sends `If-None-Match`, max-age skip, network error preserves prior snapshot, accepts updated snapshot. Plus a `lastFetched`-updated assertion folded into the 304 test (proves design invariant). Both the new refresh suite and `CoinGeckoSearchClientTests` are marked `@Suite(.serialized)` to eliminate the `nonisolated(unsafe)` race on shared static handler state under Swift Testing's parallel executor.

\`CatalogError\` gains a \`.network(String)\` case so HTTP failures stop being mislabelled as \`.sqlite(...)\`.

Follows [#532](https://github.com/ajsutton/moolah-native/pull/532) (Task 4: FTS5 search — merged).

### Notable deviations from the plan-supplied skeleton

- **Static helpers** (per the actor pattern established in Tasks 3–4); no plan code lives unchanged on the actor's nonisolated init.
- **Top-level wire types** `CoinWire`/`PlatformWire` (`private` at file scope) to satisfy SwiftLint's `nesting` rule.
- **Guarded URL init** (`preconditionFailure` on malformed literal) instead of either force-unwrap (lint) or `??` fallback (silent failure); URLs are static and known-good but loud-fail beats silent-fail.
- **`async let`** for parallel \`/coins/list\` and \`/asset_platforms\` fetches per design §5.4.
- **`@Suite(.serialized)`** on suites that touch \`StubURLProtocol.handlers\` and equivalent statics.

## Test plan

- [x] `just test SQLiteCoinGeckoCatalogRefreshTests` passes 5/5 on `MoolahTests_iOS` and `MoolahTests_macOS`.
- [x] `just test SQLiteCoinGeckoCatalogSearchTests` (Task 4 regression) passes 6/6 on both.
- [x] `just test SQLiteCoinGeckoCatalogStorageTests` (Task 3 regression) passes 5/5 on both.
- [x] `just test CoinGeckoSearchClientTests` (existing) passes 3/3 on both.
- [x] Full suite: 1681 iOS / 1710 macOS green.
- [x] `just format-check` clean.
- [x] `swiftlint lint` reports 0 violations on all changed/new files.
- [x] No `.swiftlint-baseline.yml` change.
- [x] xcodegen auto-globs all new files.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)