### PR TITLE
feat(stock): Yahoo Finance name-search via /v1/finance/search (Task 6, #461)

### DIFF
--- a/Backends/YahooFinance/YahooFinanceStockSearchClient.swift
+++ b/Backends/YahooFinance/YahooFinanceStockSearchClient.swift
@@ -1,0 +1,72 @@
+// Backends/YahooFinance/YahooFinanceStockSearchClient.swift
+import Foundation
+
+/// Yahoo Finance `/v1/finance/search` name-search adapter.
+///
+/// Filters the raw `quotes` array to `EQUITY ∪ ETF ∪ MUTUALFUND` and
+/// trims whitespace from `shortname` (Yahoo pads many names with
+/// trailing spaces). Falls back to `longname` then `symbol` when
+/// `shortname` is missing or empty after trimming.
+struct YahooFinanceStockSearchClient: StockSearchClient {
+  private let session: URLSession
+  private static let baseURL: URL = {
+    guard let url = URL(string: "https://query1.finance.yahoo.com/v1/finance/search")
+    else { preconditionFailure("malformed Yahoo search URL — fix the literal") }
+    return url
+  }()
+
+  init(session: URLSession = .shared) {
+    self.session = session
+  }
+
+  func search(query: String) async throws -> [StockSearchHit] {
+    var components = URLComponents(url: Self.baseURL, resolvingAgainstBaseURL: false)
+    components?.queryItems = [
+      URLQueryItem(name: "q", value: query),
+      URLQueryItem(name: "quotesCount", value: "20"),
+      URLQueryItem(name: "newsCount", value: "0"),
+    ]
+    guard let url = components?.url else { throw URLError(.badURL) }
+
+    var request = URLRequest(url: url)
+    request.setValue("Mozilla/5.0", forHTTPHeaderField: "User-Agent")
+
+    let (data, response) = try await session.data(for: request)
+    guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+      throw URLError(.badServerResponse)
+    }
+
+    let decoded = try JSONDecoder().decode(Wire.self, from: data)
+    return decoded.quotes.compactMap { wire in
+      guard let quoteType = QuoteType(rawValue: wire.quoteType) else { return nil }
+      let trimmedShort = wire.shortname?.trimmingCharacters(in: .whitespacesAndNewlines)
+      let trimmedLong = wire.longname?.trimmingCharacters(in: .whitespacesAndNewlines)
+      let displayName: String
+      if let short = trimmedShort, !short.isEmpty {
+        displayName = short
+      } else if let long = trimmedLong, !long.isEmpty {
+        displayName = long
+      } else {
+        displayName = wire.symbol
+      }
+      return StockSearchHit(
+        symbol: wire.symbol,
+        name: displayName,
+        exchange: wire.exchange,
+        quoteType: quoteType
+      )
+    }
+  }
+}
+
+private struct Wire: Decodable {
+  let quotes: [WireQuote]
+}
+
+private struct WireQuote: Decodable {
+  let symbol: String
+  let shortname: String?
+  let longname: String?
+  let exchange: String
+  let quoteType: String
+}

--- a/Domain/Repositories/StockSearchClient.swift
+++ b/Domain/Repositories/StockSearchClient.swift
@@ -1,0 +1,29 @@
+// Domain/Repositories/StockSearchClient.swift
+import Foundation
+
+/// A hit from a stock-name search provider (typically Yahoo Finance's
+/// `/v1/finance/search` endpoint). Filtered to investable instrument
+/// types — equities, ETFs, and mutual funds.
+struct StockSearchHit: Sendable {
+  let symbol: String
+  let name: String
+  let exchange: String
+  let quoteType: QuoteType
+}
+
+extension StockSearchHit: Hashable {}
+
+/// Subset of Yahoo Finance `quoteType` values that the picker exposes.
+/// Other types (`OPTION`, `INDEX`, `CURRENCY`, `CRYPTOCURRENCY`, …) are
+/// dropped at the boundary so callers don't need to filter again.
+enum QuoteType: String, Sendable, CaseIterable {
+  case equity = "EQUITY"
+  case etf = "ETF"
+  case mutualFund = "MUTUALFUND"
+}
+
+/// Abstract name-search service for investable stock-like instruments.
+/// Production: `YahooFinanceStockSearchClient`.
+protocol StockSearchClient: Sendable {
+  func search(query: String) async throws -> [StockSearchHit]
+}

--- a/Domain/Repositories/StockSearchClient.swift
+++ b/Domain/Repositories/StockSearchClient.swift
@@ -23,7 +23,11 @@ enum QuoteType: String, Sendable, CaseIterable {
 }
 
 /// Abstract name-search service for investable stock-like instruments.
-/// Production: `YahooFinanceStockSearchClient`.
 protocol StockSearchClient: Sendable {
+  /// Searches for stock-like instruments by free-text query (ticker or company name).
+  ///
+  /// - Returns: Hits ranked by the underlying provider; empty when nothing matches.
+  /// - Throws: `URLError` (or equivalent) on network/HTTP failure. Callers should
+  ///   surface a transient-failure UX rather than propagate the error to the user.
   func search(query: String) async throws -> [StockSearchHit]
 }

--- a/MoolahTests/Backends/YahooFinanceStockSearchClientTests.swift
+++ b/MoolahTests/Backends/YahooFinanceStockSearchClientTests.swift
@@ -49,7 +49,7 @@ final class YahooFinanceStockSearchClientTests {
 
     let hits = try await client.search(query: "apple")
 
-    let trimmed = "Apple Inc.                    R".trimmingCharacters(in: .whitespaces)
+    let trimmed = "Apple Inc.                    R".trimmingCharacters(in: .whitespacesAndNewlines)
     #expect(hits.first { $0.symbol == "APC.DE" }?.name == trimmed)
   }
 

--- a/MoolahTests/Backends/YahooFinanceStockSearchClientTests.swift
+++ b/MoolahTests/Backends/YahooFinanceStockSearchClientTests.swift
@@ -1,0 +1,76 @@
+// MoolahTests/Backends/YahooFinanceStockSearchClientTests.swift
+import Foundation
+import Testing
+
+@testable import Moolah
+
+/// Class-based suite so `deinit` can deterministically clear the shared
+/// `StubURLProtocol.handlers` map between tests. `.serialized` because that
+/// map is process-wide global state.
+@Suite("Yahoo Finance stock search", .serialized)
+final class YahooFinanceStockSearchClientTests {
+  deinit {
+    StubURLProtocol.handlers = [:]
+  }
+
+  private func makeSession() -> URLSession {
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [StubURLProtocol.self]
+    return URLSession(configuration: config)
+  }
+
+  private func loadFixture() throws -> Data {
+    let bundle = Bundle(for: TestBundleMarker.self)
+    let url = try #require(
+      bundle.url(forResource: "yahoo-finance-search-apple", withExtension: "json"))
+    return try Data(contentsOf: url)
+  }
+
+  @Test
+  func returnsEquityEtfMutualFundOnly() async throws {
+    let data = try loadFixture()
+    StubURLProtocol.handlers["query1.finance.yahoo.com:/v1/finance/search"] = { _ in
+      (HTTPURLResponse.ok(etag: ""), data)
+    }
+    let client = YahooFinanceStockSearchClient(session: makeSession())
+
+    let hits = try await client.search(query: "apple")
+
+    #expect(hits.map(\.symbol) == ["AAPL", "APC.DE", "APLE.TO", "FXAIX"])
+  }
+
+  @Test
+  func namesAreTrimmed() async throws {
+    let data = try loadFixture()
+    StubURLProtocol.handlers["query1.finance.yahoo.com:/v1/finance/search"] = { _ in
+      (HTTPURLResponse.ok(etag: ""), data)
+    }
+    let client = YahooFinanceStockSearchClient(session: makeSession())
+
+    let hits = try await client.search(query: "apple")
+
+    let trimmed = "Apple Inc.                    R".trimmingCharacters(in: .whitespaces)
+    #expect(hits.first { $0.symbol == "APC.DE" }?.name == trimmed)
+  }
+
+  @Test
+  func queryParamsAreSentCorrectly() async throws {
+    let data = try loadFixture()
+    let captured = LockedBox<URL?>(nil)
+    StubURLProtocol.handlers["query1.finance.yahoo.com:/v1/finance/search"] = { request in
+      captured.set(request.url)
+      return (HTTPURLResponse.ok(etag: ""), data)
+    }
+    let client = YahooFinanceStockSearchClient(session: makeSession())
+
+    _ = try await client.search(query: "apple")
+
+    let url = try #require(captured.get())
+    let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+    let items =
+      components?.queryItems?.reduce(into: [String: String]()) { $0[$1.name] = $1.value } ?? [:]
+    #expect(items["q"] == "apple")
+    #expect(items["quotesCount"] == "20")
+    #expect(items["newsCount"] == "0")
+  }
+}

--- a/MoolahTests/Support/Fixtures/yahoo-finance-search-apple.json
+++ b/MoolahTests/Support/Fixtures/yahoo-finance-search-apple.json
@@ -1,0 +1,13 @@
+{
+  "explains": [],
+  "count": 6,
+  "quotes": [
+    {"symbol":"AAPL","shortname":"Apple Inc.","exchange":"NMS","quoteType":"EQUITY"},
+    {"symbol":"APC.DE","shortname":"Apple Inc.                    R","exchange":"GER","quoteType":"EQUITY"},
+    {"symbol":"APLE.TO","shortname":"HARVEST APPLE ENHNCD HIGH INCM  ","exchange":"TOR","quoteType":"ETF"},
+    {"symbol":"AAPY.DE","shortname":"Leverage Shares PLC           E","exchange":"GER","quoteType":"OPTION"},
+    {"symbol":"^GSPC","shortname":"S&P 500","exchange":"SNP","quoteType":"INDEX"},
+    {"symbol":"FXAIX","shortname":"Fidelity 500 Index Fund","exchange":"NAS","quoteType":"MUTUALFUND"}
+  ],
+  "news": []
+}


### PR DESCRIPTION
## Summary

Task 6 of the [instrument-registry UI plan](https://github.com/ajsutton/moolah-native/blob/main/plans/2026-04-27-instrument-registry-ui-implementation.md) (resolves #461). Adds the **stock** half of the picker's search surface — a Domain protocol plus a Yahoo Finance backend.

- `Domain/Repositories/StockSearchClient.swift` (new) — `protocol StockSearchClient: Sendable` with `func search(query:) async throws -> [StockSearchHit]`. Plus `StockSearchHit` (value type, `Sendable`, `Hashable` via extension) and `QuoteType` raw-value String enum (equity / etf / mutualFund). Imports only `Foundation` (Domain isolation).
- `Backends/YahooFinance/YahooFinanceStockSearchClient.swift` (new) — calls `https://query1.finance.yahoo.com/v1/finance/search?q=<q>&quotesCount=20&newsCount=0` with `User-Agent: Mozilla/5.0`. Filters `OPTION` / `INDEX` / etc. via `QuoteType(rawValue:)`. Display name = trimmed `shortname` || trimmed `longname` || `symbol`.
- `MoolahTests/Backends/YahooFinanceStockSearchClientTests.swift` (new) — 3 Swift Testing tests, `@Suite(.serialized)` (shared `StubURLProtocol.handlers`), `LockedBox<URL?>` for capture.
- `MoolahTests/Support/Fixtures/yahoo-finance-search-apple.json` (new) — 6-quote fixture (4 accepted, 2 filtered).

The protocol is **not yet wired** into `InstrumentSearchService`; that's Task 7. The picker doesn't surface stock search results until then.

Follows [#534](https://github.com/ajsutton/moolah-native/pull/534) (Task 5: ETag refresh — merged).

### Notable choices

- Guarded URL constant with `preconditionFailure` instead of `!` (loud-fail on malformed literal).
- `String.nonEmpty` helper inlined at the call site (the plan's `private extension String` triggered `swift-format` ↔ SwiftLint `strict_fileprivate` interaction).
- Production trim uses `.whitespacesAndNewlines`; test mirrors the same character set.
- Domain protocol carries no production-impl reference (callers shouldn't see backend names).

## Test plan

- [x] `just test YahooFinanceStockSearchClientTests` passes 3/3 on `MoolahTests_iOS` and `MoolahTests_macOS`.
- [x] Adjacent suites (`SQLiteCoinGeckoCatalog*Tests`, `CoinGeckoSearchClientTests`) still 22/22 each platform.
- [x] `just format-check` clean.
- [x] `swiftlint lint` reports 0 violations.
- [x] No `.swiftlint-baseline.yml` change.
- [x] xcodegen auto-globs the new directory.
- [x] Domain isolation verified: `StockSearchClient.swift` imports only `Foundation`.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)