### PR TITLE
feat(search): InstrumentSearchService uses catalog + stock search (Task 7, #461)

### DIFF
--- a/App/ProfileSession+Factories.swift
+++ b/App/ProfileSession+Factories.swift
@@ -176,8 +176,9 @@ extension ProfileSession {
       cryptoPriceService: cryptoPriceService)
     let searchService = InstrumentSearchService(
       registry: cloudBackend.instrumentRegistry,
-      cryptoSearchClient: CoinGeckoSearchClient(apiKey: coinGeckoApiKey),
+      catalog: nil,
       resolutionClient: CompositeTokenResolutionClient(coinGeckoApiKey: coinGeckoApiKey),
+      stockSearchClient: YahooFinanceStockSearchClient(),
       stockValidator: YahooFinanceStockTickerValidator(priceFetcher: yahooPriceFetcher)
     )
     return RegistryWiring(

--- a/App/ProfileSession+Factories.swift
+++ b/App/ProfileSession+Factories.swift
@@ -178,8 +178,7 @@ extension ProfileSession {
       registry: cloudBackend.instrumentRegistry,
       catalog: nil,
       resolutionClient: CompositeTokenResolutionClient(coinGeckoApiKey: coinGeckoApiKey),
-      stockSearchClient: YahooFinanceStockSearchClient(),
-      stockValidator: YahooFinanceStockTickerValidator(priceFetcher: yahooPriceFetcher)
+      stockSearchClient: YahooFinanceStockSearchClient()
     )
     return RegistryWiring(
       registry: cloudBackend.instrumentRegistry,

--- a/MoolahTests/Shared/InstrumentPickerStoreTests.swift
+++ b/MoolahTests/Shared/InstrumentPickerStoreTests.swift
@@ -13,8 +13,7 @@ struct InstrumentPickerStoreTests {
       registry: backend.instrumentRegistry,
       catalog: nil,
       resolutionClient: StubTokenResolutionClient(),
-      stockSearchClient: StubStockSearchClient(),
-      stockValidator: StubStockTickerValidator()
+      stockSearchClient: StubStockSearchClient()
     )
     let store = InstrumentPickerStore(
       searchService: service,
@@ -33,8 +32,7 @@ struct InstrumentPickerStoreTests {
       registry: backend.instrumentRegistry,
       catalog: nil,
       resolutionClient: StubTokenResolutionClient(),
-      stockSearchClient: StubStockSearchClient(),
-      stockValidator: StubStockTickerValidator()
+      stockSearchClient: StubStockSearchClient()
     )
     let store = InstrumentPickerStore(
       searchService: service,
@@ -59,8 +57,7 @@ struct InstrumentPickerStoreTests {
       registry: backend.instrumentRegistry,
       catalog: nil,
       resolutionClient: StubTokenResolutionClient(),
-      stockSearchClient: StubStockSearchClient(),
-      stockValidator: StubStockTickerValidator()
+      stockSearchClient: StubStockSearchClient()
     )
     let store = InstrumentPickerStore(
       searchService: service,
@@ -85,8 +82,7 @@ struct InstrumentPickerStoreTests {
       registry: backend.instrumentRegistry,
       catalog: nil,
       resolutionClient: StubTokenResolutionClient(),
-      stockSearchClient: StubStockSearchClient(),
-      stockValidator: StubStockTickerValidator()
+      stockSearchClient: StubStockSearchClient()
     )
     let store = InstrumentPickerStore(
       searchService: service,
@@ -137,8 +133,7 @@ struct InstrumentPickerStoreTests {
       registry: backend.instrumentRegistry,
       catalog: nil,
       resolutionClient: StubTokenResolutionClient(),
-      stockSearchClient: StubStockSearchClient(hits: [stockHit]),
-      stockValidator: StubStockTickerValidator()
+      stockSearchClient: StubStockSearchClient(hits: [stockHit])
     )
     let store = InstrumentPickerStore(
       searchService: service,
@@ -170,8 +165,4 @@ private struct StubTokenResolutionClient: TokenResolutionClient {
   ) async throws -> TokenResolutionResult {
     .init()
   }
-}
-
-private struct StubStockTickerValidator: StockTickerValidator {
-  func validate(query: String) async throws -> ValidatedStockTicker? { nil }
 }

--- a/MoolahTests/Shared/InstrumentPickerStoreTests.swift
+++ b/MoolahTests/Shared/InstrumentPickerStoreTests.swift
@@ -11,8 +11,9 @@ struct InstrumentPickerStoreTests {
     let (backend, _) = try TestBackend.create()
     let service = InstrumentSearchService(
       registry: backend.instrumentRegistry,
-      cryptoSearchClient: StubCryptoSearchClient(),
+      catalog: nil,
       resolutionClient: StubTokenResolutionClient(),
+      stockSearchClient: StubStockSearchClient(),
       stockValidator: StubStockTickerValidator()
     )
     let store = InstrumentPickerStore(
@@ -30,8 +31,9 @@ struct InstrumentPickerStoreTests {
     let (backend, _) = try TestBackend.create()
     let service = InstrumentSearchService(
       registry: backend.instrumentRegistry,
-      cryptoSearchClient: StubCryptoSearchClient(),
+      catalog: nil,
       resolutionClient: StubTokenResolutionClient(),
+      stockSearchClient: StubStockSearchClient(),
       stockValidator: StubStockTickerValidator()
     )
     let store = InstrumentPickerStore(
@@ -55,8 +57,9 @@ struct InstrumentPickerStoreTests {
     let (backend, _) = try TestBackend.create()
     let service = InstrumentSearchService(
       registry: backend.instrumentRegistry,
-      cryptoSearchClient: StubCryptoSearchClient(),
+      catalog: nil,
       resolutionClient: StubTokenResolutionClient(),
+      stockSearchClient: StubStockSearchClient(),
       stockValidator: StubStockTickerValidator()
     )
     let store = InstrumentPickerStore(
@@ -80,8 +83,9 @@ struct InstrumentPickerStoreTests {
     try await backend.instrumentRegistry.registerStock(bhp)
     let service = InstrumentSearchService(
       registry: backend.instrumentRegistry,
-      cryptoSearchClient: StubCryptoSearchClient(),
+      catalog: nil,
       resolutionClient: StubTokenResolutionClient(),
+      stockSearchClient: StubStockSearchClient(),
       stockValidator: StubStockTickerValidator()
     )
     let store = InstrumentPickerStore(
@@ -127,12 +131,14 @@ struct InstrumentPickerStoreTests {
   @Test("select of unregistered Yahoo stock auto-registers and returns")
   func selectStockAutoRegisters() async throws {
     let (backend, _) = try TestBackend.create()
-    let validated = ValidatedStockTicker(ticker: "AAPL", exchange: "NASDAQ")
+    let stockHit = StockSearchHit(
+      symbol: "AAPL", name: "Apple Inc.", exchange: "NASDAQ", quoteType: .equity)
     let service = InstrumentSearchService(
       registry: backend.instrumentRegistry,
-      cryptoSearchClient: StubCryptoSearchClient(),
+      catalog: nil,
       resolutionClient: StubTokenResolutionClient(),
-      stockValidator: StubStockTickerValidator(validated: validated)
+      stockSearchClient: StubStockSearchClient(hits: [stockHit]),
+      stockValidator: StubStockTickerValidator()
     )
     let store = InstrumentPickerStore(
       searchService: service,
@@ -150,8 +156,12 @@ struct InstrumentPickerStoreTests {
   }
 }
 
-private struct StubCryptoSearchClient: CryptoSearchClient {
-  func search(query: String) async throws -> [CryptoSearchHit] { [] }
+private struct StubStockSearchClient: StockSearchClient {
+  let hits: [StockSearchHit]
+
+  init(hits: [StockSearchHit] = []) { self.hits = hits }
+
+  func search(query: String) async throws -> [StockSearchHit] { hits }
 }
 
 private struct StubTokenResolutionClient: TokenResolutionClient {
@@ -163,9 +173,5 @@ private struct StubTokenResolutionClient: TokenResolutionClient {
 }
 
 private struct StubStockTickerValidator: StockTickerValidator {
-  let validated: ValidatedStockTicker?
-
-  init(validated: ValidatedStockTicker? = nil) { self.validated = validated }
-
-  func validate(query: String) async throws -> ValidatedStockTicker? { validated }
+  func validate(query: String) async throws -> ValidatedStockTicker? { nil }
 }

--- a/MoolahTests/Shared/InstrumentSearchServiceTests.swift
+++ b/MoolahTests/Shared/InstrumentSearchServiceTests.swift
@@ -9,22 +9,24 @@ struct InstrumentSearchServiceTests {
   @MainActor
   func makeSubject(
     registered: [Instrument] = [],
-    cryptoHits: [CryptoSearchHit] = [],
-    cryptoSearchThrows: Bool = false,
-    stockValidated: ValidatedStockTicker? = nil,
-    stockValidatorThrows: Bool = false,
+    cryptoRegistrations: [CryptoRegistration] = [],
+    catalogEntries: [CatalogEntry] = [],
+    stockHits: [StockSearchHit] = [],
+    stockSearchThrows: Bool = false,
     resolvedRegistration: CryptoRegistration? = nil
   ) -> InstrumentSearchService {
-    let registry = StubRegistry(instruments: registered)
-    let crypto = StubCryptoSearchClient(hits: cryptoHits, shouldThrow: cryptoSearchThrows)
-    let stock = StubStockTickerValidator(
-      validated: stockValidated, shouldThrow: stockValidatorThrows)
+    let registry = StubRegistry(
+      instruments: registered, cryptoRegistrations: cryptoRegistrations)
+    let catalog = StubCatalog(entries: catalogEntries)
+    let stock = StubStockSearchClient(hits: stockHits, shouldThrow: stockSearchThrows)
     let resolver = StubTokenResolutionClient(resolved: resolvedRegistration)
+    let validator = StubStockTickerValidator()
     return InstrumentSearchService(
       registry: registry,
-      cryptoSearchClient: crypto,
+      catalog: catalog,
       resolutionClient: resolver,
-      stockValidator: stock
+      stockSearchClient: stock,
+      stockValidator: validator
     )
   }
 
@@ -40,106 +42,146 @@ struct InstrumentSearchServiceTests {
   func fiatNameMatch() async throws {
     let service = makeSubject()
     let results = await service.search(query: "dollar")
-    // At minimum USD and AUD should surface; asserting "at least one" keeps
-    // the test robust against locale variation.
     let ids = results.map(\.instrument.id)
     #expect(ids.contains("USD") || ids.contains("AUD"))
   }
 
-  @Test("crypto hits marked requiresResolution = true with populated coingeckoId")
-  func cryptoHitsMarkedForResolution() async throws {
-    let hits = [
-      CryptoSearchHit(
-        coingeckoId: "bitcoin", symbol: "BTC", name: "Bitcoin", thumbnail: nil),
-      CryptoSearchHit(
-        coingeckoId: "ethereum", symbol: "ETH", name: "Ethereum", thumbnail: nil),
-    ]
-    let service = makeSubject(cryptoHits: hits)
-    let results = await service.search(query: "bitcoin", kinds: [.cryptoToken])
-    #expect(results.contains { $0.instrument.ticker == "BTC" && $0.requiresResolution })
-    #expect(
-      results.contains {
-        $0.cryptoMapping?.coingeckoId == "bitcoin"
-      }
+  @Test("crypto results loaded from catalog with platform binding")
+  func cryptoResultsCarryCatalogPlatform() async throws {
+    let entry = CatalogEntry(
+      coingeckoId: "uniswap",
+      symbol: "UNI",
+      name: "Uniswap",
+      platforms: [
+        PlatformBinding(
+          slug: "ethereum",
+          chainId: 1,
+          contractAddress: "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984"
+        )
+      ]
     )
+    let service = makeSubject(catalogEntries: [entry])
+    let results = await service.search(query: "uni", kinds: [.cryptoToken])
+    let hit = try #require(results.first)
+    #expect(hit.instrument.kind == .cryptoToken)
+    #expect(hit.instrument.chainId == 1)
+    #expect(hit.instrument.contractAddress == "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984")
+    #expect(hit.instrument.ticker == "UNI")
+    #expect(hit.requiresResolution == true)
+    #expect(hit.cryptoMapping == nil)
+    #expect(hit.isRegistered == false)
   }
 
-  @Test("crypto query matching contract-address pattern bypasses search and calls resolver")
-  func contractAddressBypassesSearch() async throws {
-    let eth = Instrument.crypto(
+  @Test("crypto results for platformless entries fall back to native id")
+  func cryptoNativeEntryMaps() async throws {
+    let entry = CatalogEntry(
+      coingeckoId: "bitcoin",
+      symbol: "BTC",
+      name: "Bitcoin",
+      platforms: []
+    )
+    let service = makeSubject(catalogEntries: [entry])
+    let results = await service.search(query: "btc", kinds: [.cryptoToken])
+    let hit = try #require(results.first)
+    #expect(hit.instrument.kind == .cryptoToken)
+    #expect(hit.instrument.contractAddress == nil)
+    #expect(hit.instrument.ticker == "BTC")
+    #expect(hit.requiresResolution == true)
+  }
+
+  @Test("registered crypto overrides catalog hit and carries mapping")
+  func registeredCryptoOverridesCatalogResult() async throws {
+    let registeredInstrument = Instrument.crypto(
       chainId: 1,
-      contractAddress: "0xdac17f958d2ee523a2206206994597c13d831ec7",
-      symbol: "USDT", name: "Tether", decimals: 6)
-    let mapping = CryptoProviderMapping(
-      instrumentId: eth.id,
-      coingeckoId: "tether",
-      cryptocompareSymbol: "USDT",
-      binanceSymbol: "USDTUSDT")
-    let service = makeSubject(
-      cryptoHits: [],  // would cause the test to fail if the search path was used
-      resolvedRegistration: CryptoRegistration(instrument: eth, mapping: mapping)
+      contractAddress: "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
+      symbol: "UNI",
+      name: "Uniswap",
+      decimals: 18
     )
-    let results = await service.search(
-      query: "0xdAC17F958D2ee523a2206206994597C13D831ec7", kinds: [.cryptoToken])
-    #expect(results.count == 1)
-    #expect(results.first?.requiresResolution == false)
-    #expect(results.first?.cryptoMapping?.cryptocompareSymbol == "USDT")
+    let mapping = CryptoProviderMapping(
+      instrumentId: registeredInstrument.id,
+      coingeckoId: "uniswap",
+      cryptocompareSymbol: "UNI",
+      binanceSymbol: "UNIUSDT"
+    )
+    let registration = CryptoRegistration(
+      instrument: registeredInstrument, mapping: mapping)
+    let entry = CatalogEntry(
+      coingeckoId: "uniswap",
+      symbol: "UNI",
+      name: "Uniswap",
+      platforms: [
+        PlatformBinding(
+          slug: "ethereum",
+          chainId: 1,
+          contractAddress: "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984"
+        )
+      ]
+    )
+    let service = makeSubject(
+      registered: [registeredInstrument],
+      cryptoRegistrations: [registration],
+      catalogEntries: [entry]
+    )
+    let results = await service.search(query: "uni", kinds: [.cryptoToken])
+    let matching = results.filter { $0.instrument.id == registeredInstrument.id }
+    #expect(matching.count == 1)
+    let hit = try #require(matching.first)
+    #expect(hit.isRegistered == true)
+    #expect(hit.requiresResolution == false)
+    #expect(hit.cryptoMapping?.coingeckoId == "uniswap")
   }
 
-  @Test("valid typed stock ticker yields one result")
-  func stockValidTypedTicker() async throws {
-    let validated = ValidatedStockTicker(ticker: "BHP.AX", exchange: "ASX")
-    let service = makeSubject(stockValidated: validated)
-    let results = await service.search(query: "BHP.AX", kinds: [.stock])
-    #expect(results.count == 1)
-    #expect(results.first?.instrument.id == "ASX:BHP.AX")
-    #expect(results.first?.requiresResolution == false)
-  }
-
-  @Test("invalid stock ticker yields no stock results")
-  func stockInvalidTicker() async throws {
-    let service = makeSubject(stockValidated: nil)
-    let results = await service.search(query: "UNKNOWN", kinds: [.stock])
+  @Test("nil catalog returns no crypto results")
+  func nilCatalogYieldsEmptyCrypto() async {
+    let registry = StubRegistry()
+    let service = InstrumentSearchService(
+      registry: registry,
+      catalog: nil,
+      resolutionClient: StubTokenResolutionClient(),
+      stockSearchClient: StubStockSearchClient(),
+      stockValidator: StubStockTickerValidator()
+    )
+    let results = await service.search(query: "btc", kinds: [.cryptoToken])
     #expect(results.isEmpty)
   }
 
-  @Test("stock validator throw is absorbed; other kinds still return")
-  func stockValidatorThrowAbsorbed() async throws {
-    let service = makeSubject(stockValidatorThrows: true)
-    let results = await service.search(query: "usd")
-    // Fiat results still surface.
-    #expect(results.contains { $0.instrument.id == "USD" })
+  @Test("stock results loaded from search client with quoteType-derived ids")
+  func stockResultsAreLoadedFromSearchClient() async throws {
+    let hits = [
+      StockSearchHit(
+        symbol: "AAPL", name: "Apple Inc.", exchange: "NASDAQ", quoteType: .equity),
+      StockSearchHit(
+        symbol: "MSFT", name: "Microsoft Corp.", exchange: "NASDAQ", quoteType: .equity),
+    ]
+    let service = makeSubject(stockHits: hits)
+    let results = await service.search(query: "apple", kinds: [.stock])
+    let aapl = try #require(results.first { $0.instrument.ticker == "AAPL" })
+    #expect(aapl.instrument.id == "NASDAQ:AAPL")
+    #expect(aapl.instrument.kind == .stock)
+    #expect(aapl.instrument.name == "Apple Inc.")
+    #expect(aapl.requiresResolution == true)
+    #expect(aapl.isRegistered == false)
   }
 
-  @Test("registered instruments marked isRegistered = true and ranked first")
-  func registeredRankFirst() async throws {
-    let bhp = Instrument.stock(ticker: "BHP.AX", exchange: "ASX", name: "BHP")
-    let service = makeSubject(registered: [bhp])
-    let results = await service.search(query: "BHP", kinds: [.stock])
-    let bhpResult = try #require(results.first { $0.instrument.id == "ASX:BHP.AX" })
-    #expect(bhpResult.isRegistered == true)
-    // It appears before any non-registered stock result.
-    let idx = results.firstIndex { $0.instrument.id == "ASX:BHP.AX" } ?? 0
-    let otherStockIdx =
-      results.firstIndex {
-        $0.instrument.kind == .stock && !$0.isRegistered
-      } ?? Int.max
-    #expect(idx < otherStockIdx)
-  }
-
-  @Test("provider hit sharing an id with a registered entry is dropped")
-  func dedupePreferRegistered() async throws {
-    let eth = Instrument.crypto(
-      chainId: 1, contractAddress: nil, symbol: "ETH",
-      name: "Ethereum", decimals: 18)
-    // registered ETH exists; crypto search hit also claims ETH (same id).
-    let hit = CryptoSearchHit(
-      coingeckoId: "ethereum", symbol: "ETH", name: "Ethereum", thumbnail: nil)
-    let service = makeSubject(registered: [eth], cryptoHits: [hit])
-    let results = await service.search(query: "ETH", kinds: [.cryptoToken])
-    let matching = results.filter { $0.instrument.id == eth.id }
+  @Test("registered stock overrides Yahoo hit")
+  func registeredStockOverridesSearchHit() async throws {
+    let bhp = Instrument.stock(ticker: "BHP.AX", exchange: "ASX", name: "BHP Group")
+    let hit = StockSearchHit(
+      symbol: "BHP.AX", name: "BHP Group", exchange: "ASX", quoteType: .equity)
+    let service = makeSubject(registered: [bhp], stockHits: [hit])
+    let results = await service.search(query: "bhp", kinds: [.stock])
+    let matching = results.filter { $0.instrument.id == "ASX:BHP.AX" }
     #expect(matching.count == 1)
     #expect(matching.first?.isRegistered == true)
+    #expect(matching.first?.requiresResolution == false)
+  }
+
+  @Test("stock search throw is absorbed; other kinds still return")
+  func stockSearchThrowAbsorbed() async throws {
+    let service = makeSubject(stockSearchThrows: true)
+    let results = await service.search(query: "usd")
+    #expect(results.contains { $0.instrument.id == "USD" })
   }
 
   @Test("empty query returns the registered set")
@@ -151,45 +193,19 @@ struct InstrumentSearchServiceTests {
     #expect(results.allSatisfy { $0.isRegistered })
   }
 
-  @Test("providerSources: .stocksOnly suppresses crypto provider hits")
-  func stocksOnlyExcludesCryptoHits() async throws {
-    let hits = [
-      CryptoSearchHit(coingeckoId: "bitcoin", symbol: "BTC", name: "Bitcoin", thumbnail: nil)
-    ]
-    let service = makeSubject(cryptoHits: hits)
-    let results = await service.search(
-      query: "bitcoin",
-      kinds: [.cryptoToken],
-      providerSources: .stocksOnly
-    )
-    #expect(results.allSatisfy { $0.requiresResolution == false })
-    #expect(results.contains { $0.instrument.ticker == "BTC" } == false)
-  }
-
-  @Test("providerSources: .stocksOnly still allows Yahoo stock hits")
-  func stocksOnlyAllowsStockHits() async throws {
-    let validated = ValidatedStockTicker(ticker: "AAPL", exchange: "NASDAQ")
-    let service = makeSubject(stockValidated: validated)
-    let results = await service.search(
-      query: "AAPL",
-      kinds: [.stock],
-      providerSources: .stocksOnly
-    )
-    #expect(results.contains { $0.instrument.ticker == "AAPL" })
-  }
-
-  @Test("providerSources: .all preserves existing behaviour")
-  func allPreservesExistingBehaviour() async throws {
-    let hits = [
-      CryptoSearchHit(coingeckoId: "ethereum", symbol: "ETH", name: "Ethereum", thumbnail: nil)
-    ]
-    let service = makeSubject(cryptoHits: hits)
-    let results = await service.search(
-      query: "ethereum",
-      kinds: [.cryptoToken],
-      providerSources: .all
-    )
-    #expect(results.contains { $0.instrument.ticker == "ETH" && $0.requiresResolution })
+  @Test("registered instruments ranked first")
+  func registeredRankFirst() async throws {
+    let bhp = Instrument.stock(ticker: "BHP.AX", exchange: "ASX", name: "BHP")
+    let extraHit = StockSearchHit(
+      symbol: "BHP.NS", name: "BHP", exchange: "NSE", quoteType: .equity)
+    let service = makeSubject(registered: [bhp], stockHits: [extraHit])
+    let results = await service.search(query: "BHP", kinds: [.stock])
+    let bhpResult = try #require(results.first { $0.instrument.id == "ASX:BHP.AX" })
+    #expect(bhpResult.isRegistered == true)
+    let registeredIdx = results.firstIndex { $0.instrument.id == "ASX:BHP.AX" } ?? 0
+    let providerIdx =
+      results.firstIndex { $0.instrument.kind == .stock && !$0.isRegistered } ?? Int.max
+    #expect(registeredIdx < providerIdx)
   }
 }
 
@@ -197,9 +213,17 @@ struct InstrumentSearchServiceTests {
 
 private struct StubRegistry: InstrumentRegistryRepository, @unchecked Sendable {
   let instruments: [Instrument]
+  let cryptoRegistrations: [CryptoRegistration]
+
+  init(instruments: [Instrument] = [], cryptoRegistrations: [CryptoRegistration] = []) {
+    self.instruments = instruments
+    self.cryptoRegistrations = cryptoRegistrations
+  }
 
   func all() async throws -> [Instrument] { instruments }
-  func allCryptoRegistrations() async throws -> [CryptoRegistration] { [] }
+  func allCryptoRegistrations() async throws -> [CryptoRegistration] {
+    cryptoRegistrations
+  }
   func registerCrypto(
     _ instrument: Instrument, mapping: CryptoProviderMapping
   ) async throws {}
@@ -209,28 +233,40 @@ private struct StubRegistry: InstrumentRegistryRepository, @unchecked Sendable {
   func observeChanges() -> AsyncStream<Void> { AsyncStream { _ in } }
 }
 
-private struct StubCryptoSearchClient: CryptoSearchClient {
-  let hits: [CryptoSearchHit]
+private struct StubCatalog: CoinGeckoCatalog {
+  let entries: [CatalogEntry]
+
+  init(entries: [CatalogEntry] = []) { self.entries = entries }
+
+  func search(query: String, limit: Int) async -> [CatalogEntry] {
+    Array(entries.prefix(limit))
+  }
+  func refreshIfStale() async {}
+}
+
+private struct StubStockSearchClient: StockSearchClient {
+  let hits: [StockSearchHit]
   let shouldThrow: Bool
 
-  func search(query: String) async throws -> [CryptoSearchHit] {
+  init(hits: [StockSearchHit] = [], shouldThrow: Bool = false) {
+    self.hits = hits
+    self.shouldThrow = shouldThrow
+  }
+
+  func search(query: String) async throws -> [StockSearchHit] {
     if shouldThrow { throw URLError(.cannotConnectToHost) }
     return hits
   }
 }
 
 private struct StubStockTickerValidator: StockTickerValidator {
-  let validated: ValidatedStockTicker?
-  let shouldThrow: Bool
-
-  func validate(query: String) async throws -> ValidatedStockTicker? {
-    if shouldThrow { throw URLError(.cannotConnectToHost) }
-    return validated
-  }
+  func validate(query: String) async throws -> ValidatedStockTicker? { nil }
 }
 
 private struct StubTokenResolutionClient: TokenResolutionClient {
   let resolved: CryptoRegistration?
+
+  init(resolved: CryptoRegistration? = nil) { self.resolved = resolved }
 
   func resolve(
     chainId: Int, contractAddress: String?, symbol: String?, isNative: Bool

--- a/MoolahTests/Shared/InstrumentSearchServiceTests.swift
+++ b/MoolahTests/Shared/InstrumentSearchServiceTests.swift
@@ -20,13 +20,11 @@ struct InstrumentSearchServiceTests {
     let catalog = StubCatalog(entries: catalogEntries)
     let stock = StubStockSearchClient(hits: stockHits, shouldThrow: stockSearchThrows)
     let resolver = StubTokenResolutionClient(resolved: resolvedRegistration)
-    let validator = StubStockTickerValidator()
     return InstrumentSearchService(
       registry: registry,
       catalog: catalog,
       resolutionClient: resolver,
-      stockSearchClient: stock,
-      stockValidator: validator
+      stockSearchClient: stock
     )
   }
 
@@ -132,6 +130,46 @@ struct InstrumentSearchServiceTests {
     #expect(hit.cryptoMapping?.coingeckoId == "uniswap")
   }
 
+  @Test("crypto in registered but without a mapping is treated as unregistered")
+  func cryptoInRegisteredButNoMappingTreatedAsUnregistered() async throws {
+    // A crypto Instrument can exist in the registry without a mapping when
+    // CSV import landed it before the picker had a chance to resolve(). On
+    // the catalog path that case must surface as `isRegistered: false,
+    // requiresResolution: true` — the picker will then run resolve() and
+    // promote it to a fully registered row. The legacy code marked it as
+    // `isRegistered: true` while still asking for resolution, which is a
+    // contradictory state.
+    let preMappingInst = Instrument.crypto(
+      chainId: 1,
+      contractAddress: "0xfoo",
+      symbol: "FOO",
+      name: "Foo Token",
+      decimals: 18
+    )
+    let entry = CatalogEntry(
+      coingeckoId: "foo",
+      symbol: "FOO",
+      name: "Foo Token",
+      platforms: [
+        PlatformBinding(slug: "ethereum", chainId: 1, contractAddress: "0xfoo")
+      ]
+    )
+    // A query that matches the catalog entry (the stub catalog returns all
+    // its entries regardless of query) but does NOT match the registered
+    // Instrument's id, ticker, or name — so `registeredMatches` skips it
+    // and the catalog branch's result survives the merge.
+    let service = makeSubject(
+      registered: [preMappingInst],
+      cryptoRegistrations: [],
+      catalogEntries: [entry]
+    )
+    let results = await service.search(query: "abc", kinds: [.cryptoToken])
+    let foo = try #require(results.first { $0.instrument.id == "1:0xfoo" })
+    #expect(foo.isRegistered == false)
+    #expect(foo.requiresResolution == true)
+    #expect(foo.cryptoMapping == nil)
+  }
+
   @Test("nil catalog returns no crypto results")
   func nilCatalogYieldsEmptyCrypto() async {
     let registry = StubRegistry()
@@ -139,8 +177,7 @@ struct InstrumentSearchServiceTests {
       registry: registry,
       catalog: nil,
       resolutionClient: StubTokenResolutionClient(),
-      stockSearchClient: StubStockSearchClient(),
-      stockValidator: StubStockTickerValidator()
+      stockSearchClient: StubStockSearchClient()
     )
     let results = await service.search(query: "btc", kinds: [.cryptoToken])
     #expect(results.isEmpty)
@@ -257,10 +294,6 @@ private struct StubStockSearchClient: StockSearchClient {
     if shouldThrow { throw URLError(.cannotConnectToHost) }
     return hits
   }
-}
-
-private struct StubStockTickerValidator: StockTickerValidator {
-  func validate(query: String) async throws -> ValidatedStockTicker? { nil }
 }
 
 private struct StubTokenResolutionClient: TokenResolutionClient {

--- a/Shared/InstrumentPickerStore.swift
+++ b/Shared/InstrumentPickerStore.swift
@@ -77,8 +77,7 @@ final class InstrumentPickerStore {
     if let searchService {
       let snapshot = await searchService.search(
         query: query,
-        kinds: kinds,
-        providerSources: .stocksOnly
+        kinds: kinds
       )
       results = snapshot
       return

--- a/Shared/InstrumentSearchService.swift
+++ b/Shared/InstrumentSearchService.swift
@@ -6,7 +6,6 @@ struct InstrumentSearchService: Sendable {
   private let catalog: (any CoinGeckoCatalog)?
   private let resolutionClient: any TokenResolutionClient
   private let stockSearchClient: any StockSearchClient
-  private let stockValidator: any StockTickerValidator
   private let logger = Logger(
     subsystem: "com.moolah.app",
     category: "InstrumentSearch"
@@ -16,14 +15,12 @@ struct InstrumentSearchService: Sendable {
     registry: any InstrumentRegistryRepository,
     catalog: (any CoinGeckoCatalog)?,
     resolutionClient: any TokenResolutionClient,
-    stockSearchClient: any StockSearchClient,
-    stockValidator: any StockTickerValidator
+    stockSearchClient: any StockSearchClient
   ) {
     self.registry = registry
     self.catalog = catalog
     self.resolutionClient = resolutionClient
     self.stockSearchClient = stockSearchClient
-    self.stockValidator = stockValidator
   }
 
   func search(
@@ -150,7 +147,7 @@ struct InstrumentSearchService: Sendable {
       return InstrumentSearchResult(
         instrument: placeholder,
         cryptoMapping: nil,
-        isRegistered: registered.contains { $0.id == placeholder.id },
+        isRegistered: mappings.contains { $0.instrument.id == placeholder.id },
         requiresResolution: true
       )
     }

--- a/Shared/InstrumentSearchService.swift
+++ b/Shared/InstrumentSearchService.swift
@@ -1,21 +1,11 @@
 import Foundation
 import OSLog
 
-/// Controls which provider-search APIs the picker fans out to.
-/// `.all` — registry + fiat + Yahoo + CoinGecko (current behaviour).
-/// `.stocksOnly` — registry + fiat + Yahoo. Used by the multi-instrument
-/// picker so unregistered crypto hits never surface (token registration
-/// flows through `AddTokenSheet` instead, which defends against scam
-/// tokens that share names with established ones).
-enum ProviderSources: Sendable {
-  case all
-  case stocksOnly
-}
-
 struct InstrumentSearchService: Sendable {
   private let registry: any InstrumentRegistryRepository
-  private let cryptoSearchClient: any CryptoSearchClient
+  private let catalog: (any CoinGeckoCatalog)?
   private let resolutionClient: any TokenResolutionClient
+  private let stockSearchClient: any StockSearchClient
   private let stockValidator: any StockTickerValidator
   private let logger = Logger(
     subsystem: "com.moolah.app",
@@ -24,23 +14,25 @@ struct InstrumentSearchService: Sendable {
 
   init(
     registry: any InstrumentRegistryRepository,
-    cryptoSearchClient: any CryptoSearchClient,
+    catalog: (any CoinGeckoCatalog)?,
     resolutionClient: any TokenResolutionClient,
+    stockSearchClient: any StockSearchClient,
     stockValidator: any StockTickerValidator
   ) {
     self.registry = registry
-    self.cryptoSearchClient = cryptoSearchClient
+    self.catalog = catalog
     self.resolutionClient = resolutionClient
+    self.stockSearchClient = stockSearchClient
     self.stockValidator = stockValidator
   }
 
   func search(
     query: String,
-    kinds: Set<Instrument.Kind> = Set(Instrument.Kind.allCases),
-    providerSources: ProviderSources = .all
+    kinds: Set<Instrument.Kind> = Set(Instrument.Kind.allCases)
   ) async -> [InstrumentSearchResult] {
     let trimmed = query.trimmingCharacters(in: .whitespaces)
     let registered = await loadRegisteredOrLog()
+    let cryptoRegistrations = await loadCryptoRegistrationsOrLog()
     let filteredRegistered = registered.filter { kinds.contains($0.kind) }
     if trimmed.isEmpty {
       return filteredRegistered.map {
@@ -56,13 +48,15 @@ struct InstrumentSearchService: Sendable {
     async let fiatResults: [InstrumentSearchResult] =
       kinds.contains(.fiatCurrency) ? fiatMatches(query: trimmed) : []
     async let cryptoResults: [InstrumentSearchResult] =
-      (kinds.contains(.cryptoToken) && providerSources == .all)
-      ? cryptoMatches(query: trimmed) : []
+      kinds.contains(.cryptoToken)
+      ? cryptoMatches(
+        query: trimmed, registered: registered, mappings: cryptoRegistrations) : []
     async let stockResults: [InstrumentSearchResult] =
-      kinds.contains(.stock) ? stockMatches(query: trimmed) : []
+      kinds.contains(.stock) ? stockMatches(query: trimmed, registered: registered) : []
 
     let provider = await (fiatResults + cryptoResults + stockResults)
-    let registeredMatches = registeredMatches(query: trimmed, all: filteredRegistered)
+    let registeredMatches = registeredMatches(
+      query: trimmed, all: filteredRegistered, cryptoMappings: cryptoRegistrations)
     return merge(registered: registeredMatches, provider: provider)
   }
 
@@ -72,6 +66,17 @@ struct InstrumentSearchService: Sendable {
     } catch {
       logger.warning(
         "Registry fetch failed; returning empty registered set: \(error, privacy: .public)"
+      )
+      return []
+    }
+  }
+
+  private func loadCryptoRegistrationsOrLog() async -> [CryptoRegistration] {
+    do {
+      return try await registry.allCryptoRegistrations()
+    } catch {
+      logger.warning(
+        "Registry crypto registrations fetch failed: \(error, privacy: .public)"
       )
       return []
     }
@@ -108,39 +113,71 @@ struct InstrumentSearchService: Sendable {
 
   // MARK: - Crypto
 
-  private func cryptoMatches(query: String) async -> [InstrumentSearchResult] {
+  /// Crypto search path.
+  ///
+  /// Routes through the local CoinGecko `CatalogEntry` snapshot rather than a
+  /// live network search. Each catalogue entry maps to one synthetic
+  /// `Instrument` keyed on `(chainId, contractAddress)`. Hits whose id already
+  /// exists in the registry are dropped here — the merge step replaces them
+  /// with the registered row, which carries the persisted `CryptoProviderMapping`.
+  ///
+  /// `requiresResolution: true` signals to the picker that this row must call
+  /// `TokenResolutionClient.resolve(...)` before it can be persisted (decimals
+  /// and the cryptocompare/binance ids are resolved at registration time).
+  ///
+  /// When `catalog` is `nil` (e.g. a `RemoteBackend` profile), this returns
+  /// the empty list — crypto search is unavailable on those profiles by design.
+  private func cryptoMatches(
+    query: String,
+    registered: [Instrument],
+    mappings: [CryptoRegistration]
+  ) async -> [InstrumentSearchResult] {
     if isContractAddress(query) {
       return await cryptoContractLookup(address: query)
     }
-    do {
-      let hits = try await cryptoSearchClient.search(query: query)
-      return hits.map { hit in
-        let placeholder = Instrument.crypto(
-          chainId: 0,
-          contractAddress: nil,
-          symbol: hit.symbol,
-          name: hit.name,
-          decimals: 18
-        )
-        let mapping = CryptoProviderMapping(
-          instrumentId: placeholder.id,
-          coingeckoId: hit.coingeckoId,
-          cryptocompareSymbol: nil,
-          binanceSymbol: nil
-        )
+    guard let catalog else { return [] }
+    let entries = await catalog.search(query: query, limit: 20)
+    return entries.map { entry in
+      let placeholder = makePlaceholderCryptoInstrument(from: entry)
+      if let registration = mappings.first(where: { $0.id == placeholder.id }) {
         return InstrumentSearchResult(
-          instrument: placeholder,
-          cryptoMapping: mapping,
-          isRegistered: false,
-          requiresResolution: true
+          instrument: registration.instrument,
+          cryptoMapping: registration.mapping,
+          isRegistered: true,
+          requiresResolution: false
         )
       }
-    } catch {
-      logger.warning(
-        "Crypto search failed for query=\(query, privacy: .public): \(error, privacy: .public)"
+      return InstrumentSearchResult(
+        instrument: placeholder,
+        cryptoMapping: nil,
+        isRegistered: registered.contains { $0.id == placeholder.id },
+        requiresResolution: true
       )
-      return []
     }
+  }
+
+  /// Builds the synthetic `Instrument` for an unregistered catalog hit. The
+  /// `decimals` value is a placeholder (18 for EVM-style platforms, 8 for
+  /// platformless natives — both are the most common values for their
+  /// classes). Resolution at registration time replaces it with the real
+  /// decimals from the price provider.
+  private func makePlaceholderCryptoInstrument(from entry: CatalogEntry) -> Instrument {
+    if let platform = entry.preferredPlatform, let chainId = platform.chainId {
+      return Instrument.crypto(
+        chainId: chainId,
+        contractAddress: platform.contractAddress,
+        symbol: entry.symbol,
+        name: entry.name,
+        decimals: 18
+      )
+    }
+    return Instrument.crypto(
+      chainId: 0,
+      contractAddress: nil,
+      symbol: entry.symbol,
+      name: entry.name,
+      decimals: 8
+    )
   }
 
   private func cryptoContractLookup(address: String) async -> [InstrumentSearchResult] {
@@ -196,28 +233,32 @@ struct InstrumentSearchService: Sendable {
 
   // MARK: - Stock
 
-  private func stockMatches(query: String) async -> [InstrumentSearchResult] {
+  /// Stock search path.
+  ///
+  /// Routes through `StockSearchClient` (Yahoo Finance `/v1/finance/search`).
+  /// Each hit maps to a synthetic `Instrument` keyed on `"\(exchange):\(ticker)"`.
+  /// Hits whose id already exists in the registry are marked `isRegistered: true`
+  /// so the picker doesn't redundantly offer to register them; the merge step
+  /// then replaces the synthetic row with the persisted one.
+  private func stockMatches(
+    query: String, registered: [Instrument]
+  ) async -> [InstrumentSearchResult] {
     do {
-      guard let validated = try await stockValidator.validate(query: query) else {
-        return []
-      }
-      let stock = Instrument.stock(
-        ticker: validated.ticker,
-        exchange: validated.exchange,
-        name: validated.ticker,
-        decimals: 0
-      )
-      return [
-        InstrumentSearchResult(
-          instrument: stock,
+      let hits = try await stockSearchClient.search(query: query)
+      return hits.map { hit in
+        let instrument = Instrument.stock(
+          ticker: hit.symbol, exchange: hit.exchange, name: hit.name)
+        let isRegistered = registered.contains { $0.id == instrument.id }
+        return InstrumentSearchResult(
+          instrument: instrument,
           cryptoMapping: nil,
-          isRegistered: false,
-          requiresResolution: false
+          isRegistered: isRegistered,
+          requiresResolution: !isRegistered
         )
-      ]
+      }
     } catch {
       logger.warning(
-        "Stock validator failed for query=\(query, privacy: .public): \(error, privacy: .public)"
+        "Stock search failed for query=\(query, privacy: .public): \(error, privacy: .public)"
       )
       return []
     }
@@ -227,9 +268,12 @@ struct InstrumentSearchService: Sendable {
 
   private func registeredMatches(
     query: String,
-    all: [Instrument]
+    all: [Instrument],
+    cryptoMappings: [CryptoRegistration]
   ) -> [InstrumentSearchResult] {
     let lowered = query.lowercased()
+    let mappingsById = Dictionary(
+      uniqueKeysWithValues: cryptoMappings.map { ($0.instrument.id, $0.mapping) })
     return all.compactMap { instrument in
       let id = instrument.id.lowercased()
       let ticker = instrument.ticker?.lowercased() ?? ""
@@ -238,7 +282,7 @@ struct InstrumentSearchService: Sendable {
       else { return nil }
       return InstrumentSearchResult(
         instrument: instrument,
-        cryptoMapping: nil,
+        cryptoMapping: mappingsById[instrument.id],
         isRegistered: true,
         requiresResolution: false
       )


### PR DESCRIPTION
## Summary

Task 7 of the [instrument-registry UI plan](https://github.com/ajsutton/moolah-native/blob/main/plans/2026-04-27-instrument-registry-ui-implementation.md) (resolves #461). Rewires `InstrumentSearchService` so the picker's crypto path is backed by the local FTS5 catalog and the stock path is backed by Yahoo's name-search.

- New init: `init(registry, catalog: (any CoinGeckoCatalog)?, resolutionClient, stockSearchClient)`. Drops the old `cryptoSearchClient` dependency, drops the `providerSources` parameter from `search(query:kinds:)`, and (per review feedback) drops the now-dead `stockValidator` storage too.
- Crypto results route through `catalog.search(query:limit: 20)`. Unregistered hits → `requiresResolution: true, cryptoMapping: nil`. Registered hits override with the registered Instrument + mapping.
- Stock results route through `stockSearchClient.search(query:)` (Yahoo `/v1/finance/search` from Task 6).
- `catalog == nil` (Remote backend) → no crypto results. Graceful for non-CloudKit profiles.
- Existing service behaviour preserved: empty-query returns registered-only, registered-rank-first via the merge step.

Cascade updates:
- `App/ProfileSession+Factories.swift` — passes `catalog: nil` placeholder (Task 8 wires the real catalog) and `stockSearchClient: YahooFinanceStockSearchClient()`.
- `Shared/InstrumentPickerStore.swift` — drops the `providerSources:` argument from the `searchService.search(...)` call site. The picker's own enum is intentionally left for Task 9 to retire.
- Test files updated for the new init.

Review feedback applied (commit `bd584f8`):
- Removed dead `stockValidator` from the service. The protocol/impl/tests live until Task 10 finishes the picker migration.
- Fixed an `isRegistered: true / requiresResolution: true` contradiction reachable when a crypto Instrument was in `registry.all()` but lacked a mapping (pre-resolution CSV row). Catalog path now uses `mappings.contains` for the registered check, not `registered.contains`. Added a regression test.

Follows [#535](https://github.com/ajsutton/moolah-native/pull/535) (Task 6: stock search — merged).

### Notable shape adaptations from plan

- `Instrument.stock(...)` factory uses labels `(ticker:, exchange:, name:, decimals:)` — plan sketched `(exchange:, ticker:, name:)`. Used the project's actual labels.
- `Instrument.crypto(...)` accepts `contractAddress: String?` — platformless catalog entries pass `chainId: 0, contractAddress: nil` (matches `CryptoRegistration.builtInPresets` for natives).
- Preserved the existing service's empty-query and registered-rank-first behaviours via the `registeredMatches`-then-`merge` pipeline.

## Test plan

- [x] `just test InstrumentSearchServiceTests InstrumentPickerStoreTests` passes 20/20 on `MoolahTests_iOS` and `MoolahTests_macOS`.
- [x] Adjacent suites still green: `SQLiteCoinGecko*`, `YahooFinance*`, `CoinGecko*`, `CryptoTokenStore*`, `CompositeTokenResolutionClient*` — 62/62 each platform.
- [x] `just format-check` clean.
- [x] `swiftlint lint` reports 0 violations on changed files.
- [x] No `.swiftlint-baseline.yml` change.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)