### PR TITLE
feat(session): wire CoinGeckoCatalog into ProfileSession lifecycle (Task 8, #461)

### DIFF
--- a/App/ProfileSession+Factories.swift
+++ b/App/ProfileSession+Factories.swift
@@ -150,17 +150,26 @@ extension ProfileSession {
   }
 
   /// Bundle of the optional instrument-registry pieces: only CloudKit
-  /// profiles expose a registry and crypto token store. Remote/moolah
-  /// profiles are single-instrument by server design and leave both nil.
+  /// profiles expose a registry, crypto token store, search service, and
+  /// CoinGecko catalogue. Remote/moolah profiles are single-instrument by
+  /// server design and leave all four nil.
   struct RegistryWiring {
     let registry: (any InstrumentRegistryRepository)?
     let cryptoTokenStore: CryptoTokenStore?
     let searchService: InstrumentSearchService?
+    let coinGeckoCatalog: (any CoinGeckoCatalog)?
   }
 
   /// Resolves the optional instrument-registry wiring for a profile. Returns
   /// a populated bundle for CloudKit profiles; returns nils for Remote/moolah
   /// profiles so settings views can gate on `cryptoTokenStore != nil`.
+  ///
+  /// CloudKit profiles also build a `SQLiteCoinGeckoCatalog` and fire its
+  /// `refreshIfStale()` once per session on a background task so the on-disk
+  /// snapshot honours the 24 h max-age + ETag guards without blocking
+  /// session init. A catalog construction failure (e.g. the SQLite file
+  /// can't be opened) is logged and the catalogue is left `nil` — search
+  /// degrades to the registry/Yahoo paths only.
   @MainActor
   static func makeRegistryWiring(
     backend: BackendProvider,
@@ -169,22 +178,48 @@ extension ProfileSession {
     coinGeckoApiKey: String?
   ) -> RegistryWiring {
     guard let cloudBackend = backend as? CloudKitBackend else {
-      return RegistryWiring(registry: nil, cryptoTokenStore: nil, searchService: nil)
+      return RegistryWiring(
+        registry: nil, cryptoTokenStore: nil, searchService: nil, coinGeckoCatalog: nil)
     }
+
+    let catalog = makeCoinGeckoCatalog()
     let store = CryptoTokenStore(
       registry: cloudBackend.instrumentRegistry,
       cryptoPriceService: cryptoPriceService)
     let searchService = InstrumentSearchService(
       registry: cloudBackend.instrumentRegistry,
-      catalog: nil,
+      catalog: catalog,
       resolutionClient: CompositeTokenResolutionClient(coinGeckoApiKey: coinGeckoApiKey),
       stockSearchClient: YahooFinanceStockSearchClient()
     )
     return RegistryWiring(
       registry: cloudBackend.instrumentRegistry,
       cryptoTokenStore: store,
-      searchService: searchService
+      searchService: searchService,
+      coinGeckoCatalog: catalog
     )
+  }
+
+  /// Builds the per-profile CoinGecko catalogue and kicks off a background
+  /// `refreshIfStale()` so the SQLite snapshot is brought up to date once per
+  /// session without blocking init. Returns `nil` (and logs) when the
+  /// SQLite file can't be opened — the caller treats that as a degraded
+  /// search path.
+  @MainActor
+  private static func makeCoinGeckoCatalog() -> (any CoinGeckoCatalog)? {
+    let directory = URL.moolahScopedApplicationSupport
+      .appending(path: "InstrumentRegistry", directoryHint: .isDirectory)
+    do {
+      let catalog = try SQLiteCoinGeckoCatalog(directory: directory)
+      Task.detached(priority: .background) { [catalog] in
+        await catalog.refreshIfStale()
+      }
+      return catalog
+    } catch {
+      Logger(subsystem: "moolah.instrument-registry", category: "session")
+        .error("CoinGecko catalog init failed: \(String(describing: error), privacy: .public)")
+      return nil
+    }
   }
 
   /// Bundle of the per-profile domain stores. Returned from

--- a/App/ProfileSession+Factories.swift
+++ b/App/ProfileSession+Factories.swift
@@ -211,13 +211,13 @@ extension ProfileSession {
       .appending(path: "InstrumentRegistry", directoryHint: .isDirectory)
     do {
       let catalog = try SQLiteCoinGeckoCatalog(directory: directory)
-      Task.detached(priority: .background) { [catalog] in
+      Task(priority: .background) { [catalog] in
         await catalog.refreshIfStale()
       }
       return catalog
     } catch {
-      Logger(subsystem: "moolah.instrument-registry", category: "session")
-        .error("CoinGecko catalog init failed: \(String(describing: error), privacy: .public)")
+      Logger(subsystem: "com.moolah.app", category: "ProfileSession")
+        .error("CoinGecko catalog init failed: \(error.localizedDescription, privacy: .public)")
       return nil
     }
   }

--- a/App/ProfileSession.swift
+++ b/App/ProfileSession.swift
@@ -24,6 +24,7 @@ final class ProfileSession: Identifiable {
   let instrumentRegistry: (any InstrumentRegistryRepository)?
   let cryptoTokenStore: CryptoTokenStore?
   let instrumentSearchService: InstrumentSearchService?
+  let coinGeckoCatalog: (any CoinGeckoCatalog)?
   let importStore: ImportStore
   let importRuleStore: ImportRuleStore
   let importPreferences: ImportPreferences
@@ -76,6 +77,7 @@ final class ProfileSession: Identifiable {
     self.instrumentRegistry = registryWiring.registry
     self.cryptoTokenStore = registryWiring.cryptoTokenStore
     self.instrumentSearchService = registryWiring.searchService
+    self.coinGeckoCatalog = registryWiring.coinGeckoCatalog
     let stores = Self.makeDomainStores(profile: profile, backend: backend)
     self.authStore = stores.auth
     self.accountStore = stores.account

--- a/MoolahTests/App/ProfileSessionCatalogIntegrationTests.swift
+++ b/MoolahTests/App/ProfileSessionCatalogIntegrationTests.swift
@@ -1,0 +1,44 @@
+// MoolahTests/App/ProfileSessionCatalogIntegrationTests.swift
+import Foundation
+import Testing
+
+@testable import Moolah
+
+// Serialised because the suite mutates `URL.moolahApplicationSupportOverride`,
+// a `nonisolated(unsafe)` static, to keep the on-disk SQLite catalogue out
+// of the user's real Application Support directory. Parallel execution would
+// let one test's override leak into another's assertions.
+@Suite("ProfileSession — CoinGecko catalog wiring", .serialized)
+@MainActor
+struct ProfileSessionCatalogIntegrationTests {
+  @Test("CloudKit profile exposes a non-nil CoinGecko catalog")
+  func cloudKitProfileExposesCatalog() throws {
+    let root = FileManager.default.temporaryDirectory
+      .appending(path: "ProfileSessionCatalogIntegrationTests-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    URL.moolahApplicationSupportOverride = root
+    // The catalog actor outlives this test (a background `refreshIfStale()`
+    // task captures it); deleting `root` here would race with the actor's
+    // SQLite handle and produce noisy "vnode unlinked while in use" logs
+    // from libsqlite3. The temp directory is reaped by the OS on exit.
+    defer { URL.moolahApplicationSupportOverride = nil }
+
+    let containerManager = try ProfileContainerManager.forTesting()
+    let profile = Profile(
+      label: "iCloud", backendType: .cloudKit,
+      currencyCode: "AUD", financialYearStartMonth: 7
+    )
+    let session = ProfileSession(profile: profile, containerManager: containerManager)
+
+    #expect(session.coinGeckoCatalog != nil)
+  }
+
+  @Test("Remote profile has no CoinGecko catalog")
+  func remoteProfileHasNoCatalog() throws {
+    let url = try #require(URL(string: "https://moolah.rocks/api/"))
+    let profile = Profile(label: "Remote", serverURL: url)
+    let session = ProfileSession(profile: profile)
+
+    #expect(session.coinGeckoCatalog == nil)
+  }
+}


### PR DESCRIPTION
## Summary

Task 8 of the [instrument-registry UI plan](https://github.com/ajsutton/moolah-native/blob/main/plans/2026-04-27-instrument-registry-ui-implementation.md) (resolves #461). Plumbs `SQLiteCoinGeckoCatalog` into the `ProfileSession` lifecycle and replaces the Task 7 `catalog: nil` placeholder with the real catalog.

- `App/ProfileSession.swift` — adds `coinGeckoCatalog: (any CoinGeckoCatalog)?` stored property, wired through the existing `RegistryWiring` bundle.
- `App/ProfileSession+Factories.swift` — extends `RegistryWiring`, adds a `makeCoinGeckoCatalog()` helper that constructs a `SQLiteCoinGeckoCatalog` rooted at `URL.moolahScopedApplicationSupport/InstrumentRegistry/`, fires `refreshIfStale()` on a background `Task(priority: .background)`, and gracefully nils on init failure (logs via `os_log`, doesn't block session init). Remote (non-CloudKit) profiles get `coinGeckoCatalog: nil` and the picker's crypto path correctly returns no results.
- `MoolahTests/App/ProfileSessionCatalogIntegrationTests.swift` — 2 Swift Testing tests (`@MainActor`, `.serialized`) verifying CloudKit profiles get a non-nil catalog and Remote profiles get nil.

Review feedback applied (commit `0cf0d14`):
- Logger subsystem aligned with the rest of the app layer (`com.moolah.app`, category `ProfileSession`).
- `error.localizedDescription` instead of `String(describing: error)` (matches surrounding error logs).
- `Task(priority: .background)` instead of `Task.detached` (CONCURRENCY_GUIDE §8) — the actor hop on `await catalog.refreshIfStale()` still frees the main thread.

Follows [#536](https://github.com/ajsutton/moolah-native/pull/536) (Task 7: search service rewire — merged).

### Notable shape adaptations from plan

- `TestBackend.cloudKit()` / `.remote()` and `ProfileSession.makeForTest(...)` don't exist in the project. Used the existing convention (`ProfileContainerManager.forTesting()` + `ProfileSession(profile:containerManager:)` for CloudKit; `ProfileSession(profile:)` for Remote).
- Catalog directory uses `URL.moolahScopedApplicationSupport` (existing project abstraction with `URL.moolahApplicationSupportOverride` test redirection) instead of a hand-rolled helper.
- Test doesn't `defer`-delete its temp dir because the detached `refreshIfStale` task outlives the test scope; documented inline.

## Test plan

- [x] `just test ProfileSessionCatalogIntegrationTests` passes 2/2 on `MoolahTests_iOS` and `MoolahTests_macOS`.
- [x] `ProfileSessionTests` + `InstrumentSearchServiceTests` + `InstrumentPickerStoreTests` regression: 35/35 each platform.
- [x] Full repo: 1685 iOS / 1714 macOS green.
- [x] `just format-check` clean.
- [x] `swiftlint lint` reports 0 violations.
- [x] No `.swiftlint-baseline.yml` change.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)