### PR TITLE
feat(registry): notifyExternalChange() for sync fan-out (Task 11, #461)

### DIFF
--- a/Backends/CloudKit/Repositories/CloudKitInstrumentRegistryRepository.swift
+++ b/Backends/CloudKit/Repositories/CloudKitInstrumentRegistryRepository.swift
@@ -210,4 +210,15 @@ final class CloudKitInstrumentRegistryRepository:
       continuation.yield()
     }
   }
+
+  /// Yields a `Void` to every active `observeChanges()` subscriber without
+  /// performing a local write. Intended to be called from the sync layer when
+  /// a remote pull touches `InstrumentRecord` rows so picker UIs refresh
+  /// without waiting for an app relaunch. Concrete-only — not part of the
+  /// `InstrumentRegistryRepository` protocol because it is implementation
+  /// plumbing, not a domain contract.
+  @MainActor
+  func notifyExternalChange() {
+    notifySubscribers()
+  }
 }

--- a/MoolahTests/Backends/CloudKit/CloudKitInstrumentRegistryNotifyTests.swift
+++ b/MoolahTests/Backends/CloudKit/CloudKitInstrumentRegistryNotifyTests.swift
@@ -1,0 +1,53 @@
+import Foundation
+import SwiftData
+import Testing
+
+@testable import Moolah
+
+@Suite("CloudKitInstrumentRegistryRepository — notifyExternalChange")
+@MainActor
+struct CloudKitInstrumentRegistryNotifyTests {
+  @MainActor
+  private func makeRepo() throws -> CloudKitInstrumentRegistryRepository {
+    let config = ModelConfiguration(isStoredInMemoryOnly: true)
+    let container = try ModelContainer(
+      for: InstrumentRecord.self,
+      configurations: config
+    )
+    return CloudKitInstrumentRegistryRepository(modelContainer: container)
+  }
+
+  @Test("notifyExternalChange yields to an active observeChanges subscriber")
+  func notifyYieldsToActiveSubscriber() async throws {
+    let repo = try makeRepo()
+    let stream = repo.observeChanges()
+    Task {
+      // Give the consumer below time to reach `iterator.next()` so the
+      // continuation is registered before the notification fires.
+      try? await Task.sleep(for: .milliseconds(50))
+      repo.notifyExternalChange()
+    }
+    var iterator = stream.makeAsyncIterator()
+    let first: Void? = await iterator.next()
+    try #require(first != nil)
+  }
+
+  @Test("notifyExternalChange fans out to multiple subscribers")
+  func notifyYieldsToAllSubscribers() async throws {
+    let repo = try makeRepo()
+    let streamA = repo.observeChanges()
+    let streamB = repo.observeChanges()
+    var iteratorA = streamA.makeAsyncIterator()
+    var iteratorB = streamB.makeAsyncIterator()
+
+    Task {
+      try? await Task.sleep(for: .milliseconds(50))
+      repo.notifyExternalChange()
+    }
+
+    let firstA: Void? = await iteratorA.next()
+    let firstB: Void? = await iteratorB.next()
+    try #require(firstA != nil)
+    try #require(firstB != nil)
+  }
+}


### PR DESCRIPTION
## Summary

Task 11 of the [instrument-registry UI plan](https://github.com/ajsutton/moolah-native/blob/main/plans/2026-04-27-instrument-registry-ui-implementation.md) (resolves #461). Adds `@MainActor func notifyExternalChange()` to `CloudKitInstrumentRegistryRepository` — concrete-class plumbing that yields `Void` to every active `observeChanges()` subscriber.

This is the **boundary** between the sync layer and the registry's local fan-out. Task 12 will plumb a closure from `ProfileDataSyncHandler` that fires this method whenever a remote pull touches an `InstrumentRecord`. With the loop closed, an instrument registered on another device shows up in this device's picker without an app relaunch.

- `Backends/CloudKit/Repositories/CloudKitInstrumentRegistryRepository.swift` — adds the method, delegates to existing private `notifySubscribers()` so the fan-out logic stays single-sourced. **Not** added to the `InstrumentRegistryRepository` protocol per design §4.6 (it's plumbing, not part of the read/write contract).
- `MoolahTests/Backends/CloudKit/CloudKitInstrumentRegistryNotifyTests.swift` — 2 Swift Testing tests covering single-subscriber yield and multi-subscriber fan-out.

Follows [#540](https://github.com/ajsutton/moolah-native/pull/540) (Task 10: search-only Add Token flow — merged).

### Notable shape adaptations from plan

- File / type renamed from `CloudKitInstrumentRegistryRepositoryTests` to `CloudKitInstrumentRegistryNotifyTests` (40-char `type_name` SwiftLint limit + better scope label — the existing `InstrumentRegistryContractTests` already covers protocol surface).
- `Void?` annotation on `iterator.next()` to satisfy `SWIFT_TREAT_WARNINGS_AS_ERRORS`.
- Reused the existing private `notifySubscribers()` rather than inlining a duplicate yield loop.

## Test plan

- [x] `just test CloudKitInstrumentRegistryNotifyTests` passes 2/2 on `MoolahTests_iOS` and `MoolahTests_macOS`.
- [x] Adjacent regressions (`InstrumentRegistryContractTests`, `CryptoTokenStoreTests`, `MultiProfileIsolationTests`): 21/21 each platform.
- [x] `just format-check` clean.
- [x] `swiftlint lint` reports 0 violations on changed files.
- [x] No `.swiftlint-baseline.yml` change.
- [x] xcodegen auto-globs the new file.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)