### PR TITLE
feat(domain): UnmappedCryptoInstrumentError type (Task 13, #461)

### DIFF
--- a/Backends/CloudKit/Repositories/CloudKitInstrumentRegistryRepository.swift
+++ b/Backends/CloudKit/Repositories/CloudKitInstrumentRegistryRepository.swift
@@ -210,4 +210,15 @@ final class CloudKitInstrumentRegistryRepository:
       continuation.yield()
     }
   }
+
+  /// Yields a `Void` to every active `observeChanges()` subscriber without
+  /// performing a local write. Intended to be called from the sync layer when
+  /// a remote pull touches `InstrumentRecord` rows so picker UIs refresh
+  /// without waiting for an app relaunch. Concrete-only — not part of the
+  /// `InstrumentRegistryRepository` protocol because it is implementation
+  /// plumbing, not a domain contract.
+  @MainActor
+  func notifyExternalChange() {
+    notifySubscribers()
+  }
 }

--- a/Domain/Errors/UnmappedCryptoInstrumentError.swift
+++ b/Domain/Errors/UnmappedCryptoInstrumentError.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+/// Thrown by `ensureInstrument` when a write references a crypto instrument
+/// that has no price-provider mapping registered. Indicates a programmer error —
+/// the UI should have routed the user through `InstrumentPickerStore.resolve(_:)`
+/// (or the Add Token flow) so the mapping is created before the write is attempted.
+struct UnmappedCryptoInstrumentError: Error, Equatable, Sendable {
+  let instrumentId: String
+}
+
+extension UnmappedCryptoInstrumentError: LocalizedError {
+  var errorDescription: String? {
+    "Crypto instrument \(instrumentId) cannot be saved without a price-provider mapping."
+  }
+}

--- a/MoolahTests/Backends/CloudKit/CloudKitInstrumentRegistryNotifyTests.swift
+++ b/MoolahTests/Backends/CloudKit/CloudKitInstrumentRegistryNotifyTests.swift
@@ -1,0 +1,53 @@
+import Foundation
+import SwiftData
+import Testing
+
+@testable import Moolah
+
+@Suite("CloudKitInstrumentRegistryRepository — notifyExternalChange")
+@MainActor
+struct CloudKitInstrumentRegistryNotifyTests {
+  @MainActor
+  private func makeRepo() throws -> CloudKitInstrumentRegistryRepository {
+    let config = ModelConfiguration(isStoredInMemoryOnly: true)
+    let container = try ModelContainer(
+      for: InstrumentRecord.self,
+      configurations: config
+    )
+    return CloudKitInstrumentRegistryRepository(modelContainer: container)
+  }
+
+  @Test("notifyExternalChange yields to an active observeChanges subscriber")
+  func notifyYieldsToActiveSubscriber() async throws {
+    let repo = try makeRepo()
+    let stream = repo.observeChanges()
+    Task {
+      // Give the consumer below time to reach `iterator.next()` so the
+      // continuation is registered before the notification fires.
+      try? await Task.sleep(for: .milliseconds(50))
+      repo.notifyExternalChange()
+    }
+    var iterator = stream.makeAsyncIterator()
+    let first: Void? = await iterator.next()
+    try #require(first != nil)
+  }
+
+  @Test("notifyExternalChange fans out to multiple subscribers")
+  func notifyYieldsToAllSubscribers() async throws {
+    let repo = try makeRepo()
+    let streamA = repo.observeChanges()
+    let streamB = repo.observeChanges()
+    var iteratorA = streamA.makeAsyncIterator()
+    var iteratorB = streamB.makeAsyncIterator()
+
+    Task {
+      try? await Task.sleep(for: .milliseconds(50))
+      repo.notifyExternalChange()
+    }
+
+    let firstA: Void? = await iteratorA.next()
+    let firstB: Void? = await iteratorB.next()
+    try #require(firstA != nil)
+    try #require(firstB != nil)
+  }
+}

--- a/MoolahTests/Domain/UnmappedCryptoInstrumentErrorTests.swift
+++ b/MoolahTests/Domain/UnmappedCryptoInstrumentErrorTests.swift
@@ -1,0 +1,23 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("UnmappedCryptoInstrumentError")
+struct UnmappedCryptoInstrumentErrorTests {
+
+  @Test
+  func testEqualityByInstrumentId() {
+    let first = UnmappedCryptoInstrumentError(instrumentId: "1:0xuni")
+    let sameId = UnmappedCryptoInstrumentError(instrumentId: "1:0xuni")
+    let differentId = UnmappedCryptoInstrumentError(instrumentId: "1:0xother")
+    #expect(first == sameId)
+    #expect(first != differentId)
+  }
+
+  @Test
+  func testLocalizedDescriptionContainsInstrumentId() {
+    let error = UnmappedCryptoInstrumentError(instrumentId: "1:0xuni")
+    #expect(error.localizedDescription.contains("1:0xuni"))
+  }
+}


### PR DESCRIPTION
## Summary

Task 13 of the [instrument-registry UI plan](https://github.com/ajsutton/moolah-native/blob/main/plans/2026-04-27-instrument-registry-ui-implementation.md) (resolves #461). Adds the error type that Tasks 14 and 15 will throw when `ensureInstrument` rejects an unmapped crypto reference.

- `Domain/Errors/UnmappedCryptoInstrumentError.swift` (new) — `struct UnmappedCryptoInstrumentError: Error, Equatable, Sendable { let instrumentId: String }` with `LocalizedError` extension whose `errorDescription` interpolates the id. Imports only `Foundation` (Domain isolation).
- 2 Swift Testing tests covering equality and `localizedDescription`.

The plan offered two paths: extend an existing `RepositoryError` enum, or introduce a dedicated type. A grep across the codebase showed **no shared `RepositoryError` enum exists**, so the dedicated-type path was the right call. Placed in a new `Domain/Errors/` subdirectory to keep error types grouped.

Follows [#541](https://github.com/ajsutton/moolah-native/pull/541) (Task 11: notifyExternalChange — merged).

## Test plan

- [x] `just test UnmappedCryptoInstrumentErrorTests` passes 2/2 on `MoolahTests_iOS` and `MoolahTests_macOS`.
- [x] `just format-check` clean.
- [x] `swiftlint lint` reports 0 violations.
- [x] No `.swiftlint-baseline.yml` change.
- [x] xcodegen auto-globs the new directory.
- [x] Domain isolation verified: imports only Foundation.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)