### PR TITLE
fix(repo): ensureInstrument throws on unmapped crypto (Task 14, #461)

### DIFF
--- a/Backends/CloudKit/Repositories/CloudKitTransactionRepository.swift
+++ b/Backends/CloudKit/Repositories/CloudKitTransactionRepository.swift
@@ -53,17 +53,43 @@ final class CloudKitTransactionRepository: TransactionRepository, @unchecked Sen
 
   @MainActor
   func ensureInstrument(_ instrument: Instrument) throws {
-    guard instrument.kind != .fiatCurrency else {
+    switch instrument.kind {
+    case .fiatCurrency:
+      // Fiat is ambient — synthesised from `Locale.Currency.isoCurrencies`
+      // by the registry. No row is required.
       instrumentCache[instrument.id] = instrument
-      return
+    case .stock:
+      // Stock path intentionally unchanged in this plan. CSV imports do
+      // not currently produce unmapped stock rows in the same way the
+      // crypto path does, so tightening this without a clear motivating
+      // failure risks regressing imports. See design plan §4.8.
+      let iid = instrument.id
+      let descriptor = FetchDescriptor<InstrumentRecord>(predicate: #Predicate { $0.id == iid })
+      if try context.fetch(descriptor).isEmpty {
+        context.insert(InstrumentRecord.from(instrument))
+        onInstrumentChanged(instrument.id)
+      }
+      instrumentCache[instrument.id] = instrument
+    case .cryptoToken:
+      // A crypto write must reference an instrument the registry has seen
+      // and assigned at least one provider mapping (CoinGecko, CryptoCompare,
+      // or Binance). Auto-inserting an unmapped row here would defer the
+      // failure to conversion time as `ConversionError.noProviderMapping`.
+      // Routing the user through `InstrumentPickerStore.resolve(_:)` (or
+      // the Add Token flow) is the contract; throwing here surfaces the
+      // programmer error early.
+      let iid = instrument.id
+      let descriptor = FetchDescriptor<InstrumentRecord>(predicate: #Predicate { $0.id == iid })
+      let existing = try context.fetch(descriptor).first
+      let isMapped =
+        existing?.coingeckoId != nil
+        || existing?.cryptocompareSymbol != nil
+        || existing?.binanceSymbol != nil
+      guard isMapped else {
+        throw UnmappedCryptoInstrumentError(instrumentId: instrument.id)
+      }
+      instrumentCache[instrument.id] = instrument
     }
-    let iid = instrument.id
-    let descriptor = FetchDescriptor<InstrumentRecord>(predicate: #Predicate { $0.id == iid })
-    if try context.fetch(descriptor).isEmpty {
-      context.insert(InstrumentRecord.from(instrument))
-      onInstrumentChanged(instrument.id)
-    }
-    instrumentCache[instrument.id] = instrument
   }
 
   /// Returns the instrument associated with the given account, falling back

--- a/MoolahTests/Backends/CloudKit/EnsureInstrumentCryptoMappingTests.swift
+++ b/MoolahTests/Backends/CloudKit/EnsureInstrumentCryptoMappingTests.swift
@@ -1,0 +1,88 @@
+import Foundation
+import SwiftData
+import Testing
+
+@testable import Moolah
+
+/// Tightening: a write that references a crypto instrument with no
+/// price-provider mapping must throw `UnmappedCryptoInstrumentError`
+/// rather than silently inserting an unmapped row (which later trips
+/// `ConversionError.noProviderMapping` at conversion time). Fiat and
+/// stock paths are unaffected — see design plan §4.8.
+@Suite("CloudKitTransactionRepository — ensureInstrument")
+@MainActor
+struct EnsureInstrumentCryptoMappingTests {
+  @Test("fiat instrument is allowed (no insert, no throw)")
+  func fiatInstrumentSucceeds() throws {
+    let repo = try makeContractCloudKitTransactionRepository()
+    try repo.ensureInstrument(Instrument.fiat(code: "USD"))
+  }
+
+  @Test("crypto instrument with a registered mapping is allowed")
+  func mappedCryptoInstrumentSucceeds() throws {
+    let repo = try makeContractCloudKitTransactionRepository()
+    let context = repo.modelContainer.mainContext
+    let eth = Instrument.crypto(
+      chainId: 1, contractAddress: nil, symbol: "ETH",
+      name: "Ethereum", decimals: 18)
+
+    // Seed an InstrumentRecord with a provider mapping populated, mirroring
+    // what InstrumentRegistryRepository.registerCrypto does. ensureInstrument
+    // should treat any non-nil mapping field as "registered".
+    let row = InstrumentRecord(
+      id: eth.id,
+      kind: eth.kind.rawValue,
+      name: eth.name,
+      decimals: eth.decimals,
+      ticker: eth.ticker,
+      exchange: eth.exchange,
+      chainId: eth.chainId,
+      contractAddress: eth.contractAddress,
+      coingeckoId: "ethereum"
+    )
+    context.insert(row)
+    try context.save()
+
+    try repo.ensureInstrument(eth)
+  }
+
+  @Test("crypto instrument with no row throws UnmappedCryptoInstrumentError")
+  func unmappedCryptoInstrumentThrowsWhenRowMissing() throws {
+    let repo = try makeContractCloudKitTransactionRepository()
+    let eth = Instrument.crypto(
+      chainId: 1, contractAddress: nil, symbol: "ETH",
+      name: "Ethereum", decimals: 18)
+
+    #expect(throws: UnmappedCryptoInstrumentError(instrumentId: eth.id)) {
+      try repo.ensureInstrument(eth)
+    }
+  }
+
+  @Test("crypto instrument with row but all mapping fields nil throws")
+  func unmappedCryptoInstrumentThrowsWhenMappingNil() throws {
+    let repo = try makeContractCloudKitTransactionRepository()
+    let context = repo.modelContainer.mainContext
+    let eth = Instrument.crypto(
+      chainId: 1, contractAddress: nil, symbol: "ETH",
+      name: "Ethereum", decimals: 18)
+
+    // Simulates a pre-Task-14 silently-auto-inserted row: crypto kind, but
+    // no provider mapping. Tightening means ensureInstrument now refuses
+    // these instead of treating the row's mere presence as registered.
+    let ghost = InstrumentRecord(
+      id: eth.id,
+      kind: eth.kind.rawValue,
+      name: eth.name,
+      decimals: eth.decimals,
+      ticker: eth.ticker,
+      chainId: eth.chainId,
+      contractAddress: eth.contractAddress
+    )
+    context.insert(ghost)
+    try context.save()
+
+    #expect(throws: UnmappedCryptoInstrumentError(instrumentId: eth.id)) {
+      try repo.ensureInstrument(eth)
+    }
+  }
+}

--- a/MoolahTests/Export/ExportImportIntegrationTests4.swift
+++ b/MoolahTests/Export/ExportImportIntegrationTests4.swift
@@ -24,6 +24,14 @@ struct ExportImportIntegrationTests4 {
       chainId: 1, contractAddress: nil, symbol: "ETH", name: "Ethereum", decimals: 18)
 
     let (backend, _) = try TestBackend.create(instrument: aud)
+    // ensureInstrument now refuses to write an unmapped crypto leg, so
+    // register ETH with a provider mapping before seeding the crypto income
+    // transaction below.
+    try await backend.instrumentRegistry.registerCrypto(
+      eth,
+      mapping: CryptoProviderMapping(
+        instrumentId: eth.id, coingeckoId: "ethereum",
+        cryptocompareSymbol: nil, binanceSymbol: nil))
     let seeded = try await seedMultiCurrencyBackend(
       backend: backend, aud: aud, usd: usd, bhp: bhp, eth: eth)
 

--- a/MoolahTests/Features/InvestmentStorePositionsInputTests.swift
+++ b/MoolahTests/Features/InvestmentStorePositionsInputTests.swift
@@ -41,6 +41,18 @@ struct InvestmentStorePositionsInputTests {
     #expect(bhpRow.costBasis == InstrumentAmount(quantity: 4_000, instrument: aud))
   }
 
+  /// Registers a crypto instrument with a coingecko-only provider mapping
+  /// so writes against it satisfy `ensureInstrument`'s tightening (Task 14).
+  private func registerCoingeckoOnly(
+    _ instrument: Instrument, coingeckoId: String, in backend: CloudKitBackend
+  ) async throws {
+    try await backend.instrumentRegistry.registerCrypto(
+      instrument,
+      mapping: CryptoProviderMapping(
+        instrumentId: instrument.id, coingeckoId: coingeckoId,
+        cryptocompareSymbol: nil, binanceSymbol: nil))
+  }
+
   @Test("crypto-to-crypto swap shifts cost basis correctly")
   func swapShiftsCostBasis() async throws {
     let (backend, _) = try TestBackend.create()
@@ -48,6 +60,8 @@ struct InvestmentStorePositionsInputTests {
       chainId: 1, contractAddress: nil, symbol: "ETH", name: "Ethereum", decimals: 18)
     let btc = Instrument.crypto(
       chainId: 0, contractAddress: nil, symbol: "BTC", name: "Bitcoin", decimals: 8)
+    try await registerCoingeckoOnly(eth, coingeckoId: "ethereum", in: backend)
+    try await registerCoingeckoOnly(btc, coingeckoId: "bitcoin", in: backend)
 
     // Use FixedConversionService so the swap-date rates are deterministic
     // (TestBackend's default conversion service may not have ETH/BTC fixtures).


### PR DESCRIPTION
## Summary

Task 14 of the [instrument-registry UI plan](https://github.com/ajsutton/moolah-native/blob/main/plans/2026-04-27-instrument-registry-ui-implementation.md) (resolves #461). Tightens `CloudKitTransactionRepository.ensureInstrument` so transactions that reference an **unmapped crypto Instrument** fail noisily instead of silently inserting a row with no provider mapping (the failure mode that produced `ConversionError.noProviderMapping` later).

- `Backends/CloudKit/Repositories/CloudKitTransactionRepository.swift` — `ensureInstrument(_:)` now switches on `instrument.kind`. Crypto requires a row with at least one of `coingeckoId` / `cryptocompareSymbol` / `binanceSymbol` populated; otherwise throws `UnmappedCryptoInstrumentError(instrumentId:)`. Fiat path unchanged (ambient). Stock path unchanged (out of scope per design §4.8).
- `MoolahTests/Backends/CloudKit/EnsureInstrumentCryptoMappingTests.swift` (new) — 4 Swift Testing tests: fiat success, mapped-crypto success, no-row throws, all-three-fields-nil throws.

The CSV-import recovery UX is the subject of [#515](https://github.com/ajsutton/moolah-native/issues/515) — for now, unknown tokens fail loudly with this error and the UI surfaces the import as a hard error.

Two pre-existing tests were creating crypto-leg transactions without registering a mapping first; updated to seed the registry (the flows under test legitimately need the writes to succeed, not fail):
- `MoolahTests/Export/ExportImportIntegrationTests4.swift` — registers ETH mapping before seeding crypto income transactions.
- `MoolahTests/Features/InvestmentStorePositionsInputTests.swift` — registers ETH+BTC mappings before the swap test (extracted helper to stay under `function_body_length`).

Follows [#542](https://github.com/ajsutton/moolah-native/pull/542) (Task 13: UnmappedCryptoInstrumentError type — merged).

### Notable shape adaptations from plan

- Test seam wrappers (`ensureInstrumentForTesting`/`seedRegisteredCryptoForTesting`) not needed — `ensureInstrument` is `internal`, so tests call it directly (matches existing `EnsureInstrumentSkipFiatTests` pattern).
- Type name shortened from plan's `CloudKitTransactionRepositoryEnsureInstrumentTests` (50 chars) to `EnsureInstrumentCryptoMappingTests` (33 chars) for SwiftLint's `type_name` cap.

## Test plan

- [x] `just test EnsureInstrumentCryptoMappingTests` passes 4/4 on `MoolahTests_iOS` and `MoolahTests_macOS`.
- [x] Targeted regressions: `EnsureInstrumentSkipFiatTests`, `ExportImportIntegrationTests4`, `InvestmentStorePositionsInputTests`, `TransactionRepository*Tests`, `AccountRepositoryContractTests` — all green.
- [x] Full macOS suite: 1725 / 258 suites pass.
- [x] `just format-check` clean.
- [x] `swiftlint lint` reports 0 violations on changed files.
- [x] No `.swiftlint-baseline.yml` change.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)