### PR TITLE
fix(repo): ensureInstrument throws on unmapped crypto (account repo, Task 15, #461)

### DIFF
--- a/Backends/CloudKit/Repositories/CloudKitAccountRepository.swift
+++ b/Backends/CloudKit/Repositories/CloudKitAccountRepository.swift
@@ -185,17 +185,44 @@ final class CloudKitAccountRepository: AccountRepository, @unchecked Sendable {
   @MainActor private var instrumentCacheForAccount: [String: Instrument] = [:]
 
   @MainActor
-  private func ensureInstrument(_ instrument: Instrument) throws {
-    guard instrument.kind != .fiatCurrency else {
+  func ensureInstrument(_ instrument: Instrument) throws {
+    switch instrument.kind {
+    case .fiatCurrency:
+      // Fiat is ambient — synthesised from `Locale.Currency.isoCurrencies`
+      // by the registry. No row is required.
       instrumentCacheForAccount[instrument.id] = instrument
-      return
+    case .stock:
+      // Stock path intentionally unchanged in this plan. CSV imports do
+      // not currently produce unmapped stock rows in the same way the
+      // crypto path does, so tightening this without a clear motivating
+      // failure risks regressing imports. See design plan §4.8.
+      let iid = instrument.id
+      let descriptor = FetchDescriptor<InstrumentRecord>(predicate: #Predicate { $0.id == iid })
+      if try context.fetch(descriptor).isEmpty {
+        context.insert(InstrumentRecord.from(instrument))
+        onInstrumentChanged(instrument.id)
+      }
+      instrumentCacheForAccount[instrument.id] = instrument
+    case .cryptoToken:
+      // A crypto write must reference an instrument the registry has seen
+      // and assigned at least one provider mapping (CoinGecko, CryptoCompare,
+      // or Binance). Auto-inserting an unmapped row here would defer the
+      // failure to conversion time as `ConversionError.noProviderMapping`.
+      // Routing the user through `InstrumentPickerStore.resolve(_:)` (or
+      // the Add Token flow) is the contract; throwing here surfaces the
+      // programmer error early. Mirrors the transaction repo's tightening
+      // (Task 14).
+      let iid = instrument.id
+      let descriptor = FetchDescriptor<InstrumentRecord>(predicate: #Predicate { $0.id == iid })
+      let existing = try context.fetch(descriptor).first
+      let isMapped =
+        existing?.coingeckoId != nil
+        || existing?.cryptocompareSymbol != nil
+        || existing?.binanceSymbol != nil
+      guard isMapped else {
+        throw UnmappedCryptoInstrumentError(instrumentId: instrument.id)
+      }
+      instrumentCacheForAccount[instrument.id] = instrument
     }
-    let iid = instrument.id
-    let descriptor = FetchDescriptor<InstrumentRecord>(predicate: #Predicate { $0.id == iid })
-    if try context.fetch(descriptor).isEmpty {
-      context.insert(InstrumentRecord.from(instrument))
-      onInstrumentChanged(instrument.id)
-    }
-    instrumentCacheForAccount[instrument.id] = instrument
   }
 }

--- a/MoolahTests/Backends/CloudKit/AccountEnsureCryptoMappingTests.swift
+++ b/MoolahTests/Backends/CloudKit/AccountEnsureCryptoMappingTests.swift
@@ -1,0 +1,96 @@
+import Foundation
+import SwiftData
+import Testing
+
+@testable import Moolah
+
+/// Mirrors `EnsureInstrumentCryptoMappingTests` for the account repo: a
+/// write that references a crypto instrument with no price-provider mapping
+/// must throw `UnmappedCryptoInstrumentError` rather than silently inserting
+/// an unmapped row (which later trips `ConversionError.noProviderMapping`
+/// at conversion time). Fiat and stock paths are unaffected — see design
+/// plan §4.8.
+@Suite("CloudKitAccountRepository — ensureInstrument")
+@MainActor
+struct AccountEnsureCryptoMappingTests {
+  @Test("fiat instrument is allowed (no insert, no throw)")
+  func fiatInstrumentSucceeds() throws {
+    let repo = try makeAccountRepo()
+    try repo.ensureInstrument(Instrument.fiat(code: "USD"))
+  }
+
+  @Test("crypto instrument with a registered mapping is allowed")
+  func mappedCryptoInstrumentSucceeds() throws {
+    let repo = try makeAccountRepo()
+    let context = repo.modelContainer.mainContext
+    let eth = Instrument.crypto(
+      chainId: 1, contractAddress: nil, symbol: "ETH",
+      name: "Ethereum", decimals: 18)
+
+    // Seed an InstrumentRecord with a provider mapping populated, mirroring
+    // what InstrumentRegistryRepository.registerCrypto does. ensureInstrument
+    // should treat any non-nil mapping field as "registered".
+    let row = InstrumentRecord(
+      id: eth.id,
+      kind: eth.kind.rawValue,
+      name: eth.name,
+      decimals: eth.decimals,
+      ticker: eth.ticker,
+      exchange: eth.exchange,
+      chainId: eth.chainId,
+      contractAddress: eth.contractAddress,
+      coingeckoId: "ethereum"
+    )
+    context.insert(row)
+    try context.save()
+
+    try repo.ensureInstrument(eth)
+  }
+
+  @Test("crypto instrument with no row throws UnmappedCryptoInstrumentError")
+  func unmappedCryptoInstrumentThrowsWhenRowMissing() throws {
+    let repo = try makeAccountRepo()
+    let eth = Instrument.crypto(
+      chainId: 1, contractAddress: nil, symbol: "ETH",
+      name: "Ethereum", decimals: 18)
+
+    #expect(throws: UnmappedCryptoInstrumentError(instrumentId: eth.id)) {
+      try repo.ensureInstrument(eth)
+    }
+  }
+
+  @Test("crypto instrument with row but all mapping fields nil throws")
+  func unmappedCryptoInstrumentThrowsWhenMappingNil() throws {
+    let repo = try makeAccountRepo()
+    let context = repo.modelContainer.mainContext
+    let eth = Instrument.crypto(
+      chainId: 1, contractAddress: nil, symbol: "ETH",
+      name: "Ethereum", decimals: 18)
+
+    // Simulates a pre-Task-15 silently-auto-inserted row: crypto kind, but
+    // no provider mapping. Tightening means ensureInstrument now refuses
+    // these instead of treating the row's mere presence as registered.
+    let ghost = InstrumentRecord(
+      id: eth.id,
+      kind: eth.kind.rawValue,
+      name: eth.name,
+      decimals: eth.decimals,
+      ticker: eth.ticker,
+      chainId: eth.chainId,
+      contractAddress: eth.contractAddress
+    )
+    context.insert(ghost)
+    try context.save()
+
+    #expect(throws: UnmappedCryptoInstrumentError(instrumentId: eth.id)) {
+      try repo.ensureInstrument(eth)
+    }
+  }
+
+  // MARK: - Helpers
+
+  private func makeAccountRepo() throws -> CloudKitAccountRepository {
+    let container = try TestModelContainer.create()
+    return CloudKitAccountRepository(modelContainer: container)
+  }
+}

--- a/MoolahTests/Domain/AccountRepositoryContractTests.swift
+++ b/MoolahTests/Domain/AccountRepositoryContractTests.swift
@@ -215,6 +215,9 @@ struct AccountRepositoryContractTests {
       contractAddress: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
       symbol: "USDC", name: "USD Coin", decimals: 6
     )
+    // ensureInstrument now refuses to write an unmapped crypto leg, so seed
+    // a provider mapping before creating the account-with-opening-balance.
+    try await seedCryptoMapping(usdc, coingeckoId: "usd-coin", in: repository)
     let account = Account(name: "Wallet", type: .investment, instrument: usdc)
     let openingBalance = InstrumentAmount(
       quantity: dec("2500.000000"), instrument: usdc)
@@ -347,6 +350,25 @@ private func makeCloudKitAccountRepository(
   }
 
   return repo
+}
+
+/// Inserts an `InstrumentRecord` for the given crypto instrument with a
+/// non-nil `coingeckoId`, so `ensureInstrument` accepts subsequent writes
+/// that reference it. Mirrors what `InstrumentRegistryRepository.registerCrypto`
+/// does at runtime, but routes around the registry repo to keep this fixture
+/// synchronous with the SwiftData container the account repo holds.
+@MainActor
+private func seedCryptoMapping(
+  _ instrument: Instrument, coingeckoId: String, in repo: CloudKitAccountRepository
+) throws {
+  let context = repo.modelContainer.mainContext
+  context.insert(
+    InstrumentRecord(
+      id: instrument.id, kind: instrument.kind.rawValue, name: instrument.name,
+      decimals: instrument.decimals, ticker: instrument.ticker,
+      chainId: instrument.chainId, contractAddress: instrument.contractAddress,
+      coingeckoId: coingeckoId))
+  try context.save()
 }
 
 private func makeCloudKitWithPositionedAccounts() throws -> CloudKitAccountRepository {


### PR DESCRIPTION
## Summary

Task 15 of the [instrument-registry UI plan](https://github.com/ajsutton/moolah-native/blob/main/plans/2026-04-27-instrument-registry-ui-implementation.md) (resolves #461). Mirrors Task 14's tightening for the **account** repository. Account creation/edit that references an unmapped crypto Instrument now throws `UnmappedCryptoInstrumentError` instead of silently inserting an unmapped row.

- `Backends/CloudKit/Repositories/CloudKitAccountRepository.swift` — `ensureInstrument(_:)` now switches on `instrument.kind` (matches the Task 14 shape exactly): fiat ambient, stock unchanged auto-insert, crypto requires a non-nil `coingeckoId`/`cryptocompareSymbol`/`binanceSymbol`. Visibility relaxed from `private` → internal so tests can call it directly (matches the transaction repo).
- `MoolahTests/Backends/CloudKit/AccountEnsureCryptoMappingTests.swift` (new) — 4 Swift Testing tests: fiat success, mapped-crypto success, no-row throws, all-fields-nil throws.
- `MoolahTests/Domain/AccountRepositoryContractTests.swift` — `testRoundTripCryptoAccount` now seeds an `InstrumentRecord` with `coingeckoId` before calling `repository.create(...)` (since opening-balance creation goes through `ensureInstrument`). Seed extracted to a file-scope helper to stay under `type_body_length`.

Follows [#543](https://github.com/ajsutton/moolah-native/pull/543) (Task 14: transaction-repo ensureInstrument — merged).

### Notable shape adaptations from plan

- Type/file renamed from `EnsureInstrumentAccountCryptoMappingTests` (41 chars) to `AccountEnsureCryptoMappingTests` (31 chars) — SwiftLint `type_name` cap is 40.
- Helper extraction in the contract test (file-scope `seedCryptoMapping`) instead of an inline seed, to avoid pushing the test struct over `type_body_length: 250`. No baseline change.

## Test plan

- [x] `just test AccountEnsureCryptoMappingTests` passes 4/4 on `MoolahTests_iOS` and `MoolahTests_macOS`.
- [x] Targeted regressions: `AccountRepositoryContractTests`, `AccountStore*Tests` (8 suites, 46 tests), `EnsureInstrumentSkipFiatTests`, `EnsureInstrumentCryptoMappingTests`: all green.
- [x] Full repo: 1700 / 1729 (iOS / macOS) pass.
- [x] `just format-check` clean.
- [x] `swiftlint lint` reports 0 violations.
- [x] No `.swiftlint-baseline.yml` change.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)