### PR TITLE
feat(sync): fan-out remote instrument changes to registry observers (Task 12, #461)

### DIFF
--- a/App/ProfileSession+CloudKitBackendBuild.swift
+++ b/App/ProfileSession+CloudKitBackendBuild.swift
@@ -1,0 +1,105 @@
+import CloudKit
+import Foundation
+import SwiftData
+
+extension ProfileSession {
+  /// Bundle of the three market-data services consumed by the CloudKit
+  /// backend's `FullConversionService`. Lets `makeCloudKitBackend` take a
+  /// single value instead of three separate parameters so it stays at
+  /// SwiftLint's parameter-count policy.
+  struct CloudKitMarketDataServices {
+    let exchangeRates: ExchangeRateService
+    let stockPrices: StockPriceService
+    let cryptoPrices: CryptoPriceService
+  }
+
+  /// Builds the CloudKit `BackendProvider` branch of `makeBackend`. Pulled
+  /// out so `makeBackend` itself stays at SwiftLint's body-length policy
+  /// while still doing the full registry/conversion-service/backend wiring
+  /// inline (the construction order is load-bearing — see issue #102).
+  static func makeCloudKitBackend(
+    profile: Profile,
+    containerManager: ProfileContainerManager,
+    syncCoordinator: SyncCoordinator?,
+    marketData: CloudKitMarketDataServices
+  ) -> BackendProvider {
+    // A missing container here means the profile can't be constructed;
+    // every call site depends on the session existing so there's no recovery.
+    // swiftlint:disable:next force_try
+    let profileContainer = try! containerManager.container(for: profile.id)
+    let zoneID = CKRecordZone.ID(
+      zoneName: "profile-\(profile.id.uuidString)",
+      ownerName: CKCurrentUserDefaultName)
+    let registry = makeInstrumentRegistry(
+      profileContainer: profileContainer, zoneID: zoneID, syncCoordinator: syncCoordinator)
+    // Wire the inverse direction: when the per-profile data handler
+    // applies a remote pull that touches `InstrumentRecord` rows, fan
+    // out to the registry's local subscribers so the picker UI refreshes
+    // without waiting for an app relaunch.
+    wireInstrumentRemoteChangeFanOut(
+      registry: registry, profileId: profile.id, syncCoordinator: syncCoordinator)
+    // CloudKit profiles need full stock+crypto conversion support. The
+    // closure reads the profile's registry on each conversion so
+    // registrations added at runtime become usable without rebuilding the
+    // service. See issue #102.
+    let conversionService = FullConversionService(
+      exchangeRates: marketData.exchangeRates,
+      stockPrices: marketData.stockPrices,
+      cryptoPrices: marketData.cryptoPrices,
+      providerMappings: {
+        try await registry.allCryptoRegistrations().map(\.mapping)
+      }
+    )
+    return CloudKitBackend(
+      modelContainer: profileContainer,
+      instrument: profile.instrument,
+      profileLabel: profile.label,
+      conversionService: conversionService,
+      instrumentRegistry: registry
+    )
+  }
+
+  /// Builds the `CloudKitInstrumentRegistryRepository` for a profile, wiring
+  /// its mutation hooks to the sync coordinator's per-zone queue helpers.
+  /// Extracted from `makeCloudKitBackend` so the per-mutation closure
+  /// definitions don't bloat its body length.
+  private static func makeInstrumentRegistry(
+    profileContainer: ModelContainer,
+    zoneID: CKRecordZone.ID,
+    syncCoordinator: SyncCoordinator?
+  ) -> CloudKitInstrumentRegistryRepository {
+    CloudKitInstrumentRegistryRepository(
+      modelContainer: profileContainer,
+      onRecordChanged: { [weak syncCoordinator] recordName in
+        // Registry callbacks may run off MainActor; hop onto MainActor to
+        // reach the actor-isolated SyncCoordinator.queueSave(_:zoneID:).
+        Task { @MainActor [weak syncCoordinator] in
+          syncCoordinator?.queueSave(recordName: recordName, zoneID: zoneID)
+        }
+      },
+      onRecordDeleted: { [weak syncCoordinator] recordName in
+        Task { @MainActor [weak syncCoordinator] in
+          syncCoordinator?.queueDeletion(recordName: recordName, zoneID: zoneID)
+        }
+      }
+    )
+  }
+
+  /// Registers the closure that the per-profile data handler invokes when
+  /// a remote pull touches an `InstrumentRecord` row. The registry is
+  /// captured weakly so the coordinator-held closure does not retain it
+  /// beyond the session's natural lifetime; the `Task { @MainActor }` hop
+  /// is required because `notifyExternalChange()` is `@MainActor`-isolated.
+  /// No-op when there is no `SyncCoordinator` (test backends, previews).
+  private static func wireInstrumentRemoteChangeFanOut(
+    registry: CloudKitInstrumentRegistryRepository,
+    profileId: UUID,
+    syncCoordinator: SyncCoordinator?
+  ) {
+    syncCoordinator?.setInstrumentRemoteChangeCallback(profileId: profileId) { [weak registry] in
+      Task { @MainActor [weak registry] in
+        registry?.notifyExternalChange()
+      }
+    }
+  }
+}

--- a/App/ProfileSession+Factories.swift
+++ b/App/ProfileSession+Factories.swift
@@ -105,47 +105,14 @@ extension ProfileSession {
       guard let containerManager else {
         fatalError("ProfileContainerManager is required for CloudKit profiles")
       }
-      // A missing container here means the profile can't be constructed;
-      // every call site depends on the session existing so there's no recovery.
-      // swiftlint:disable:next force_try
-      let profileContainer = try! containerManager.container(for: profile.id)
-      let zoneID = CKRecordZone.ID(
-        zoneName: "profile-\(profile.id.uuidString)",
-        ownerName: CKCurrentUserDefaultName)
-      let registry = CloudKitInstrumentRegistryRepository(
-        modelContainer: profileContainer,
-        onRecordChanged: { [weak syncCoordinator] recordName in
-          // Registry callbacks may run off MainActor; hop onto MainActor to
-          // reach the actor-isolated SyncCoordinator.queueSave(_:zoneID:).
-          Task { @MainActor [weak syncCoordinator] in
-            syncCoordinator?.queueSave(recordName: recordName, zoneID: zoneID)
-          }
-        },
-        onRecordDeleted: { [weak syncCoordinator] recordName in
-          Task { @MainActor [weak syncCoordinator] in
-            syncCoordinator?.queueDeletion(recordName: recordName, zoneID: zoneID)
-          }
-        }
-      )
-      // CloudKit profiles need full stock+crypto conversion support. The
-      // closure reads the profile's registry on each conversion so
-      // registrations added at runtime become usable without rebuilding the
-      // service. See issue #102.
-      let conversionService = FullConversionService(
-        exchangeRates: exchangeRates,
-        stockPrices: stockPrices,
-        cryptoPrices: cryptoPrices,
-        providerMappings: {
-          try await registry.allCryptoRegistrations().map(\.mapping)
-        }
-      )
-      return CloudKitBackend(
-        modelContainer: profileContainer,
-        instrument: profile.instrument,
-        profileLabel: profile.label,
-        conversionService: conversionService,
-        instrumentRegistry: registry
-      )
+      return makeCloudKitBackend(
+        profile: profile,
+        containerManager: containerManager,
+        syncCoordinator: syncCoordinator,
+        marketData: CloudKitMarketDataServices(
+          exchangeRates: exchangeRates,
+          stockPrices: stockPrices,
+          cryptoPrices: cryptoPrices))
     }
   }
 

--- a/App/ProfileSession.swift
+++ b/App/ProfileSession.swift
@@ -197,6 +197,7 @@ final class ProfileSession: Identifiable {
       coordinator.removeObserver(token: token)
       syncObserverToken = nil
     }
+    coordinator.removeInstrumentRemoteChangeCallback(profileId: profile.id)
     syncReloadTask?.cancel()
     syncReloadTask = nil
   }

--- a/Backends/CloudKit/Sync/ProfileDataSyncHandler+ApplyRemoteChanges.swift
+++ b/Backends/CloudKit/Sync/ProfileDataSyncHandler+ApplyRemoteChanges.swift
@@ -55,7 +55,17 @@ extension ProfileDataSyncHandler {
       logBatchDuration(
         batchStart: batchStart, upsertDuration: upsertDuration, saveDuration: saveDuration,
         saveCount: saved.count, deleteCount: deleted.count)
-      return .success(changedTypes: Set(saved.map(\.recordType) + deleted.map(\.1)))
+      let changedTypes = Set(saved.map(\.recordType) + deleted.map(\.1))
+      // Fan out the instrument-touched signal exactly once per batch (not per
+      // record). Picker UIs subscribe to the registry's `observeChanges()`
+      // stream, which is local-write-driven; without this hop a token
+      // registered on another device would not surface until the next app
+      // launch. Fired only after a successful `context.save()` so observers
+      // never see speculative state.
+      if changedTypes.contains(InstrumentRecord.recordType) {
+        onInstrumentRemoteChange()
+      }
+      return .success(changedTypes: changedTypes)
     } catch {
       os_signpost(.end, log: Signposts.sync, name: "contextSave", signpostID: signpostID)
       logger.error("Failed to save remote changes: \(error, privacy: .public)")

--- a/Backends/CloudKit/Sync/ProfileDataSyncHandler.swift
+++ b/Backends/CloudKit/Sync/ProfileDataSyncHandler.swift
@@ -29,6 +29,15 @@ final class ProfileDataSyncHandler {
   nonisolated let zoneID: CKRecordZone.ID
   nonisolated let modelContainer: ModelContainer
 
+  /// Closure fired from `applyRemoteChanges` whenever a remote pull touches
+  /// any `InstrumentRecord` row (insert, update, or delete). Wired by
+  /// `ProfileSession` to call `CloudKitInstrumentRegistryRepository.notifyExternalChange()`
+  /// so picker UIs that subscribe via `observeChanges()` refresh after a
+  /// token registered on another device arrives — without this, the
+  /// registry's notify path only fires on local writes. Defaults to a
+  /// no-op so non-iCloud and test callers don't need to provide one.
+  nonisolated let onInstrumentRemoteChange: @Sendable () -> Void
+
   nonisolated let logger = Logger(
     subsystem: "com.moolah.app", category: "ProfileDataSyncHandler")
 
@@ -36,10 +45,16 @@ final class ProfileDataSyncHandler {
   nonisolated static let batchLogger = Logger(
     subsystem: "com.moolah.app", category: "ProfileDataSyncHandler")
 
-  init(profileId: UUID, zoneID: CKRecordZone.ID, modelContainer: ModelContainer) {
+  init(
+    profileId: UUID,
+    zoneID: CKRecordZone.ID,
+    modelContainer: ModelContainer,
+    onInstrumentRemoteChange: @escaping @Sendable () -> Void = {}
+  ) {
     self.profileId = profileId
     self.zoneID = zoneID
     self.modelContainer = modelContainer
+    self.onInstrumentRemoteChange = onInstrumentRemoteChange
   }
 
   // MARK: - Building CKRecords

--- a/Backends/CloudKit/Sync/SyncCoordinator+HandlerAccess.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+HandlerAccess.swift
@@ -22,14 +22,16 @@ extension SyncCoordinator {
     return handler
   }
 
-  /// Registers (or replaces) the per-profile closure fired by the data
-  /// handler whenever a remote pull touches an `InstrumentRecord` row. The
-  /// closure is captured by the handler at creation time, so callers must
-  /// register it before the first sync session for the profile (in practice,
-  /// from `ProfileSession.registerWithSyncCoordinator`). If a handler is
-  /// already cached, its `nonisolated let` closure is already wired, so
-  /// re-registration only takes effect for handlers created afterwards
-  /// (e.g. after `stop()` clears `dataHandlers`).
+  /// Registers the per-profile closure fired by the data handler whenever a
+  /// remote pull touches an `InstrumentRecord` row. The closure is captured
+  /// by `ProfileDataSyncHandler` at handler-construction time, so callers
+  /// MUST register it before the first sync session for the profile (in
+  /// practice, from `ProfileSession.registerWithSyncCoordinator`).
+  /// Re-registering for a profile whose handler is already cached is a no-op
+  /// — `dataHandlers` is not cleared by `stop()`, so the cached handler
+  /// retains its original `nonisolated let` closure for its full lifetime.
+  /// Pair with `removeInstrumentRemoteChangeCallback(profileId:)` on session
+  /// teardown so the dictionary doesn't accumulate stale entries.
   func setInstrumentRemoteChangeCallback(
     profileId: UUID,
     _ callback: @escaping @Sendable () -> Void

--- a/Backends/CloudKit/Sync/SyncCoordinator+HandlerAccess.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+HandlerAccess.swift
@@ -36,6 +36,16 @@ extension SyncCoordinator {
     profileId: UUID,
     _ callback: @escaping @Sendable () -> Void
   ) {
+    if dataHandlers[profileId] != nil {
+      logger.warning(
+        """
+        instrument-change callback registered for profile \
+        \(profileId, privacy: .public) after handler was cached; \
+        the new closure will not be picked up until \
+        removeInstrumentRemoteChangeCallback() is called and the handler is rebuilt
+        """
+      )
+    }
     instrumentRemoteChangeCallbacks[profileId] = callback
   }
 

--- a/Backends/CloudKit/Sync/SyncCoordinator+HandlerAccess.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+HandlerAccess.swift
@@ -1,0 +1,45 @@
+@preconcurrency import CloudKit
+import Foundation
+
+extension SyncCoordinator {
+  // MARK: - Handler Access
+
+  /// Returns (or creates) a `ProfileDataSyncHandler` for the given profile zone.
+  func handlerForProfileZone(
+    profileId: UUID, zoneID: CKRecordZone.ID
+  ) throws -> ProfileDataSyncHandler {
+    if let existing = dataHandlers[profileId] {
+      return existing
+    }
+    let container = try containerManager.container(for: profileId)
+    let onInstrumentRemoteChange = instrumentRemoteChangeCallbacks[profileId] ?? {}
+    let handler = ProfileDataSyncHandler(
+      profileId: profileId,
+      zoneID: zoneID,
+      modelContainer: container,
+      onInstrumentRemoteChange: onInstrumentRemoteChange)
+    dataHandlers[profileId] = handler
+    return handler
+  }
+
+  /// Registers (or replaces) the per-profile closure fired by the data
+  /// handler whenever a remote pull touches an `InstrumentRecord` row. The
+  /// closure is captured by the handler at creation time, so callers must
+  /// register it before the first sync session for the profile (in practice,
+  /// from `ProfileSession.registerWithSyncCoordinator`). If a handler is
+  /// already cached, its `nonisolated let` closure is already wired, so
+  /// re-registration only takes effect for handlers created afterwards
+  /// (e.g. after `stop()` clears `dataHandlers`).
+  func setInstrumentRemoteChangeCallback(
+    profileId: UUID,
+    _ callback: @escaping @Sendable () -> Void
+  ) {
+    instrumentRemoteChangeCallbacks[profileId] = callback
+  }
+
+  /// Removes the per-profile instrument-change callback (e.g. on session
+  /// teardown so the registry it captures can be released).
+  func removeInstrumentRemoteChangeCallback(profileId: UUID) {
+    instrumentRemoteChangeCallbacks.removeValue(forKey: profileId)
+  }
+}

--- a/Backends/CloudKit/Sync/SyncCoordinator.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator.swift
@@ -280,6 +280,13 @@ final class SyncCoordinator {
   /// Cached profile data handlers, keyed by profile UUID.
   var dataHandlers: [UUID: ProfileDataSyncHandler] = [:]
 
+  /// Per-profile callback fired by the handler whenever a remote pull touches
+  /// any `InstrumentRecord` row. Registered by `ProfileSession` ahead of the
+  /// first sync session so it is available when the handler is lazily created
+  /// in `handlerForProfileZone(profileId:zoneID:)`. Sendable so the closure
+  /// can be captured into the handler's `nonisolated` storage.
+  var instrumentRemoteChangeCallbacks: [UUID: @Sendable () -> Void] = [:]
+
   /// Zones with pending zone creation — records in these zones are skipped in nextRecordZoneChangeBatch.
   var pendingZoneCreation: [CKRecordZone.ID: [CKSyncEngine.PendingRecordZoneChange]] = [:]
 
@@ -364,20 +371,8 @@ final class SyncCoordinator {
   }
 
   // MARK: - Handler Access
-
-  /// Returns (or creates) a `ProfileDataSyncHandler` for the given profile zone.
-  func handlerForProfileZone(
-    profileId: UUID, zoneID: CKRecordZone.ID
-  ) throws -> ProfileDataSyncHandler {
-    if let existing = dataHandlers[profileId] {
-      return existing
-    }
-    let container = try containerManager.container(for: profileId)
-    let handler = ProfileDataSyncHandler(
-      profileId: profileId, zoneID: zoneID, modelContainer: container)
-    dataHandlers[profileId] = handler
-    return handler
-  }
+  // (Lazy `ProfileDataSyncHandler` creation and the per-profile
+  // instrument-change callback registry live on `+HandlerAccess`.)
 
   // MARK: - State Persistence
   // (Load of the state serialization happens off-actor in `prepareEngine`, on `+Lifecycle`.)

--- a/MoolahTests/Sync/InstrumentRemoteChangeFanOutTests.swift
+++ b/MoolahTests/Sync/InstrumentRemoteChangeFanOutTests.swift
@@ -132,6 +132,10 @@ struct InstrumentRemoteChangeFanOutTests {
       return
     }
     #expect(fired.get() == 1)
+    // Verify the row was actually deleted from the local context.
+    let descriptor = FetchDescriptor<InstrumentRecord>()
+    let remaining = try context.fetch(descriptor)
+    #expect(remaining.isEmpty)
   }
 
   @Test("Remote deletion of a non-instrument record does not fire the closure")

--- a/MoolahTests/Sync/InstrumentRemoteChangeFanOutTests.swift
+++ b/MoolahTests/Sync/InstrumentRemoteChangeFanOutTests.swift
@@ -1,0 +1,151 @@
+import CloudKit
+import Foundation
+import SwiftData
+import Testing
+
+@testable import Moolah
+
+/// Verifies that `ProfileDataSyncHandler.applyRemoteChanges` fires the
+/// `onInstrumentRemoteChange` closure whenever a remote pull touches an
+/// `InstrumentRecord` row (either via upsert or via deletion), and only
+/// then. This is the sync-side fan-out that lets the picker UI's
+/// `observeChanges()` subscribers refresh after a token registered on
+/// another device arrives — without it, the registry's notify path only
+/// fires for local writes.
+@Suite("ProfileDataSyncHandler — onInstrumentRemoteChange fan-out")
+@MainActor
+struct InstrumentRemoteChangeFanOutTests {
+
+  // MARK: - Helpers
+
+  /// Builds a handler whose `onInstrumentRemoteChange` closure increments
+  /// the supplied `LockedBox<Int>` every time it fires. Returns the handler
+  /// and its model container so tests can drive `applyRemoteChanges`
+  /// directly, mirroring the existing per-handler tests in this folder.
+  private func makeHandler(
+    fired: LockedBox<Int>
+  ) throws -> (ProfileDataSyncHandler, ModelContainer) {
+    let container = try TestModelContainer.create()
+    let profileId = UUID()
+    let zoneID = CKRecordZone.ID(
+      zoneName: "profile-\(profileId.uuidString)",
+      ownerName: CKCurrentUserDefaultName
+    )
+    let handler = ProfileDataSyncHandler(
+      profileId: profileId,
+      zoneID: zoneID,
+      modelContainer: container,
+      onInstrumentRemoteChange: {
+        fired.set(fired.get() + 1)
+      }
+    )
+    return (handler, container)
+  }
+
+  private func makeInstrumentRecord(
+    id: String, in zoneID: CKRecordZone.ID
+  ) -> CKRecord {
+    let recordID = CKRecord.ID(recordName: id, zoneID: zoneID)
+    let record = CKRecord(recordType: InstrumentRecord.recordType, recordID: recordID)
+    record["kind"] = "cryptoToken" as CKRecordValue
+    record["name"] = "Uniswap" as CKRecordValue
+    record["decimals"] = 18 as CKRecordValue
+    record["coingeckoId"] = "uniswap" as CKRecordValue
+    return record
+  }
+
+  private func makeAccountRecord(
+    in zoneID: CKRecordZone.ID
+  ) -> CKRecord {
+    let accountId = UUID()
+    let recordID = CKRecord.ID(
+      recordType: AccountRecord.recordType, uuid: accountId, zoneID: zoneID)
+    let record = CKRecord(recordType: AccountRecord.recordType, recordID: recordID)
+    record["name"] = "Checking" as CKRecordValue
+    record["type"] = "bank" as CKRecordValue
+    record["position"] = 0 as CKRecordValue
+    record["isHidden"] = 0 as CKRecordValue
+    return record
+  }
+
+  // MARK: - Tests
+
+  @Test("Remote upsert of an instrument fires the closure exactly once")
+  func remoteUpsertOfInstrumentFiresClosure() throws {
+    let fired = LockedBox(0)
+    let (handler, _) = try makeHandler(fired: fired)
+    let record = makeInstrumentRecord(id: "1:0xuni", in: handler.zoneID)
+
+    let result = handler.applyRemoteChanges(saved: [record], deleted: [])
+
+    guard case .success = result else {
+      Issue.record("Expected .success but got \(result)")
+      return
+    }
+    #expect(fired.get() == 1)
+  }
+
+  @Test("A multi-instrument batch still fires the closure exactly once")
+  func multiInstrumentBatchFiresClosureOnce() throws {
+    let fired = LockedBox(0)
+    let (handler, _) = try makeHandler(fired: fired)
+    let first = makeInstrumentRecord(id: "1:0xuni", in: handler.zoneID)
+    let second = makeInstrumentRecord(id: "1:0xaave", in: handler.zoneID)
+
+    _ = handler.applyRemoteChanges(saved: [first, second], deleted: [])
+
+    #expect(fired.get() == 1)
+  }
+
+  @Test("Remote upsert of a non-instrument record does not fire the closure")
+  func remoteUpsertOfNonInstrumentDoesNotFireClosure() throws {
+    let fired = LockedBox(0)
+    let (handler, _) = try makeHandler(fired: fired)
+    let record = makeAccountRecord(in: handler.zoneID)
+
+    _ = handler.applyRemoteChanges(saved: [record], deleted: [])
+
+    #expect(fired.get() == 0)
+  }
+
+  @Test("Remote deletion of an instrument fires the closure exactly once")
+  func remoteDeletionOfInstrumentFiresClosure() throws {
+    let fired = LockedBox(0)
+    let (handler, container) = try makeHandler(fired: fired)
+    // Seed an instrument so the deletion has something to remove. The
+    // closure must still fire even if the row is already absent locally,
+    // but seeding lets us also verify the row is gone after the call.
+    let context = ModelContext(container)
+    context.insert(
+      InstrumentRecord(
+        id: "1:0xuni", kind: "cryptoToken", name: "Uniswap", decimals: 18))
+    try context.save()
+
+    let recordID = CKRecord.ID(recordName: "1:0xuni", zoneID: handler.zoneID)
+    let result = handler.applyRemoteChanges(
+      saved: [],
+      deleted: [(recordID, InstrumentRecord.recordType)]
+    )
+
+    guard case .success = result else {
+      Issue.record("Expected .success but got \(result)")
+      return
+    }
+    #expect(fired.get() == 1)
+  }
+
+  @Test("Remote deletion of a non-instrument record does not fire the closure")
+  func remoteDeletionOfNonInstrumentDoesNotFireClosure() throws {
+    let fired = LockedBox(0)
+    let (handler, _) = try makeHandler(fired: fired)
+    let recordID = CKRecord.ID(
+      recordType: AccountRecord.recordType, uuid: UUID(), zoneID: handler.zoneID)
+
+    _ = handler.applyRemoteChanges(
+      saved: [],
+      deleted: [(recordID, AccountRecord.recordType)]
+    )
+
+    #expect(fired.get() == 0)
+  }
+}


### PR DESCRIPTION
## Summary

Task 12 of the [instrument-registry UI plan](https://github.com/ajsutton/moolah-native/blob/main/plans/2026-04-27-instrument-registry-ui-implementation.md) (resolves #461). Closes the loop between sync and the picker UI: when CKSyncEngine pulls remote `InstrumentRecord` changes, an open picker on this device refreshes without an app relaunch.

- `Backends/CloudKit/Sync/ProfileDataSyncHandler.swift` — gains `nonisolated let onInstrumentRemoteChange: @Sendable () -> Void` plus init param (default `{ }`).
- `Backends/CloudKit/Sync/ProfileDataSyncHandler+ApplyRemoteChanges.swift` — fires the closure once per call after `context.save()` if `changedTypes.contains(InstrumentRecord.recordType)`. The unified `applyRemoteChanges(saved:deleted:)` API covers both upsert and deletion in one place.
- `Backends/CloudKit/Sync/SyncCoordinator.swift` + new sibling `+HandlerAccess.swift` — coordinator stores per-profile callbacks, passes them to `ProfileDataSyncHandler` at lazy handler-construction time.
- `App/ProfileSession+CloudKitBackendBuild.swift` (new, factored from `+Factories.swift`) — `wireInstrumentRemoteChangeFanOut` captures `[weak registry]` and hops to `@MainActor` for `notifyExternalChange()`.
- `MoolahTests/Sync/InstrumentRemoteChangeFanOutTests.swift` (new) — 5 Swift Testing tests with `LockedBox<Int>` for the Sendable counter.

Three rounds of review feedback applied:
- **`9004928`** — `cleanupSync` removes the per-profile callback on session teardown (no dictionary leak; `SessionManager.rebuildSession` picks up a fresh closure with a live `[weak registry]`). Fixed misleading comment about `stop()` clearing `dataHandlers` (it doesn't — only `deleteAllLocalData()` does).
- **`6894869`** — Deletion test now asserts the row is actually gone post-call (fulfils the comment's promise). `setInstrumentRemoteChangeCallback` logs a warning when called for a profile whose handler is already cached (so the no-op behaviour is debuggable).

Follows [#544](https://github.com/ajsutton/moolah-native/pull/544) (Task 15: account-repo `ensureInstrument` — merged).

### Notable shape adaptations from plan

- **Unified `applyRemoteChanges(saved:deleted:)`** in the actual project replaces the plan's separate `batchUpsertInstruments` / deletion-path methods. Closure fires in one place, covers both directions.
- **Indirect handler construction via `SyncCoordinator`** — handlers are built lazily inside `handlerForProfileZone`; `ProfileSession` registers the callback via `setInstrumentRemoteChangeCallback(profileId:_:)` ahead of first sync session.
- **5 tests instead of 3** — added multi-instrument batch (fires once) and non-instrument deletion (no fire) for completeness.
- **SwiftLint refactors** — split `SyncCoordinator+HandlerAccess.swift` and `ProfileSession+CloudKitBackendBuild.swift` siblings; introduced `CloudKitMarketDataServices` parameter bundle. No baseline change.

## Test plan

- [x] `just test InstrumentRemoteChangeFanOutTests` passes 5/5 on `MoolahTests_iOS` and `MoolahTests_macOS`.
- [x] Sync regressions (every test in `MoolahTests/Sync/` + `ProfileSessionTests`): 226/226 each platform.
- [x] Full repo: 1734 tests pass on macOS.
- [x] `just format-check` clean.
- [x] `swiftlint lint` reports 0 violations on changed files.
- [x] No `.swiftlint-baseline.yml` change.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)