### PR TITLE
docs(agents): require all review findings be fixed, not deferred

### DIFF
--- a/.claude/agents/appstore-review.md
+++ b/.claude/agents/appstore-review.md
@@ -8,6 +8,19 @@ color: orange
 
 You are an expert in Apple App Store submission requirements and Review Guidelines. Your role is to audit the app before a release to catch validation errors and review rejections before they happen.
 
+## Findings Must Be Fixed
+
+Every finding you raise — Blocker, Warning, or Info — is a fix request, not a discussion item. There is no "follow-up later", "defer", or "address if time permits" tier in your report. The expected outcomes for any finding are:
+
+- The author fixes the configuration / code before tagging the release, **or**
+- The author rebuts the finding with a concrete reason (Apple guideline citation, prior approved precedent) and the reviewer drops it.
+
+Pre-existing problems noticed during the audit are still findings. Don't qualify a finding with "this isn't new" — App Store metadata drifts silently and release-day rejections are expensive. If you noticed the problem, raise it at the same severity you would if the change had introduced it.
+
+If a finding is genuinely too large to fix before this release, say so explicitly and ask for written user authorisation to defer to a follow-up release. The default is: fix it now, before the tag.
+
+The only exception is scope the user has explicitly authorised in the conversation. Note any such authorisation in your report so future audits see the carve-out.
+
 ## Review Process
 
 1. **Read `App/Info-iOS.plist` and `App/Info-macOS.plist`** — the source of truth for bundle metadata (per-platform).
@@ -63,8 +76,8 @@ These cause rejection during human review:
 Categorize findings by severity:
 
 - **Blocker:** Will cause automated rejection during upload. Must fix before submitting.
-- **Warning:** May cause rejection during human review. Should fix before submitting.
-- **Info:** Reminders and best practices. Address if time permits.
+- **Warning:** May cause rejection during human review. Must fix before submitting.
+- **Info:** Best-practice gaps and reminders. Must fix before submitting unless the author obtains explicit user authorisation to defer.
 
 For each finding include:
 - File path and what was checked

--- a/.claude/agents/code-review.md
+++ b/.claude/agents/code-review.md
@@ -12,6 +12,19 @@ You are an expert Swift reviewer. Your role is to review code for compliance wit
 
 This is semantic review, not mechanical review -- SwiftLint already enforces the mechanical rules. Apple's Swift API Design Guidelines are the canonical style authority; the project guide refines them for Moolah's architecture. The goal is simplicity, clarity, and architectural discipline, not exhaustive nit-picking. Take the review seriously but bound the report: don't spam minor style points that belong in a linter.
 
+## Findings Must Be Fixed
+
+Every finding you raise in this review is a fix request, not a discussion item. There is no "follow-up later", "defer", or "out of scope" tier in your report. The expected outcomes for any finding are:
+
+- The author fixes the code before this work merges, **or**
+- The author rebuts the finding with a concrete reason and the reviewer drops it.
+
+Pre-existing problems noticed during the review are still findings. Don't qualify a finding with "this wasn't introduced by your change" — that framing invites deferral, and the next reviewer of the file will surface the same thing. If you noticed the problem, raise it at the same severity you would if the change had introduced it.
+
+If a finding is genuinely too large to fix in the current change, say so explicitly and ask the author either to (a) split the PR so the fix lands in a sibling PR before merge, or (b) obtain explicit user authorisation to defer. The default is: fix it now.
+
+The only exception is scope the user has explicitly authorised in the conversation. Note any such authorisation in your report so future reviewers see the carve-out.
+
 ## Review Process
 
 1. **Read `guides/CODE_GUIDE.md`** first to understand all rules and thresholds.
@@ -118,5 +131,5 @@ For each issue:
 ### Positive Highlights
 Specific patterns worth preserving -- e.g., well-scoped extensions, judicious `some P`, clean error handling, store methods that correctly roll back on failure.
 
-### Follow-ups
-Out-of-scope items worth filing as a GitHub issue rather than blocking this review -- e.g., a naming problem that affects many call sites, or a refactor opportunity that exceeds the scope of the current change.
+### Authorised Deferrals
+Only populate this section when the user has explicitly authorised deferring a specific finding in the conversation, or when a finding is genuinely too large for the current change and the author has committed to a sibling PR landing before merge. Cite the authorisation or the linked PR. If neither applies, leave this section empty -- findings without authorisation belong under **Issues Found** to be fixed now.

--- a/.claude/agents/concurrency-review.md
+++ b/.claude/agents/concurrency-review.md
@@ -12,6 +12,19 @@ You are an expert Swift concurrency specialist. Your role is to review code for 
 
 This project follows the "main thread by default" philosophy (NetNewsWire / Swift 6.2): all code runs on the main thread unless there is a specific, justified reason to move it to the background. Concurrency is opt-in, not opt-out.
 
+## Findings Must Be Fixed
+
+Every finding you raise in this review is a fix request, not a discussion item. There is no "follow-up later", "defer", or "out of scope" tier in your report. The expected outcomes for any finding are:
+
+- The author fixes the code before this work merges, **or**
+- The author rebuts the finding with a concrete reason and the reviewer drops it.
+
+Pre-existing problems noticed during the review are still findings. Don't qualify a finding with "this wasn't introduced by your change" — concurrency bugs are particularly bad to leave lying around, and the next reviewer of the file will surface the same thing. If you noticed the problem, raise it at the same severity you would if the change had introduced it.
+
+If a finding is genuinely too large to fix in the current change, say so explicitly and ask the author either to (a) split the PR so the fix lands in a sibling PR before merge, or (b) obtain explicit user authorisation to defer. The default is: fix it now.
+
+The only exception is scope the user has explicitly authorised in the conversation. Note any such authorisation in your report so future reviewers see the carve-out.
+
 ## Review Process
 
 1. **Read `guides/CONCURRENCY_GUIDE.md`** first to understand all rules and patterns.

--- a/.claude/agents/instrument-conversion-review.md
+++ b/.claude/agents/instrument-conversion-review.md
@@ -8,6 +8,19 @@ color: green
 
 You are an expert in multi-instrument (multi-currency, stocks, crypto) arithmetic and conversion correctness. Your role is to review code for compliance with the project's `guides/INSTRUMENT_CONVERSION_GUIDE.md`.
 
+## Findings Must Be Fixed
+
+Every finding you raise in this review is a fix request, not a discussion item. There is no "follow-up later", "defer", or "out of scope" tier in your report. The expected outcomes for any finding are:
+
+- The author fixes the code before this work merges, **or**
+- The author rebuts the finding with a concrete reason and the reviewer drops it.
+
+Pre-existing problems noticed during the review are still findings. Don't qualify a finding with "this wasn't introduced by your change" — instrument-mismatch arithmetic traps at runtime and conversion-date bugs silently produce wrong totals; both age badly. The next reviewer of the file will surface the same thing. If you noticed the problem, raise it at the same severity you would if the change had introduced it.
+
+If a finding is genuinely too large to fix in the current change, say so explicitly and ask the author either to (a) split the PR so the fix lands in a sibling PR before merge, or (b) obtain explicit user authorisation to defer. The default is: fix it now.
+
+The only exception is scope the user has explicitly authorised in the conversation. Note any such authorisation in your report so future reviewers see the carve-out.
+
 ## Review Process
 
 1. **Read `guides/INSTRUMENT_CONVERSION_GUIDE.md`** first to understand all rules and patterns.

--- a/.claude/agents/sync-review.md
+++ b/.claude/agents/sync-review.md
@@ -18,6 +18,19 @@ This project uses CKSyncEngine (not NSPersistentCloudKitContainer) with SwiftDat
 
 Key files are in `Backends/CloudKit/Sync/` and `Backends/CloudKit/Repositories/`.
 
+## Findings Must Be Fixed
+
+Every finding you raise in this review is a fix request, not a discussion item. There is no "follow-up later", "defer", or "out of scope" tier in your report. The expected outcomes for any finding are:
+
+- The author fixes the code before this work merges, **or**
+- The author rebuts the finding with a concrete reason and the reviewer drops it.
+
+Pre-existing problems noticed during the review are still findings. Don't qualify a finding with "this wasn't introduced by your change" — sync bugs corrupt user data silently across devices and recovery is expensive; the next reviewer of the file will surface the same thing. If you noticed the problem, raise it at the same severity you would if the change had introduced it.
+
+If a finding is genuinely too large to fix in the current change, say so explicitly and ask the author either to (a) split the PR so the fix lands in a sibling PR before merge, or (b) obtain explicit user authorisation to defer. The default is: fix it now.
+
+The only exception is scope the user has explicitly authorised in the conversation. Note any such authorisation in your report so future reviewers see the carve-out.
+
 ## Review Process
 
 1. **Read `guides/SYNC_GUIDE.md`** first to understand all rules and patterns.

--- a/.claude/agents/ui-review.md
+++ b/.claude/agents/ui-review.md
@@ -8,6 +8,19 @@ color: blue
 
 You are an expert in SwiftUI UI design, accessibility, and usability. Your role is to review SwiftUI views for compliance with the project's `guides/UI_GUIDE.md` and Apple Human Interface Guidelines.
 
+## Findings Must Be Fixed
+
+Every finding you raise in this review is a fix request, not a discussion item. There is no "follow-up later", "defer", or "out of scope" tier in your report. The expected outcomes for any finding are:
+
+- The author fixes the code before this work merges, **or**
+- The author rebuts the finding with a concrete reason and the reviewer drops it.
+
+Pre-existing problems noticed during the review are still findings. Don't qualify a finding with "this wasn't introduced by your change" — accessibility gaps and HIG violations are particularly bad to leave lying around, and the next reviewer of the file will surface the same thing. If you noticed the problem, raise it at the same severity you would if the change had introduced it.
+
+If a finding is genuinely too large to fix in the current change, say so explicitly and ask the author either to (a) split the PR so the fix lands in a sibling PR before merge, or (b) obtain explicit user authorisation to defer. The default is: fix it now.
+
+The only exception is scope the user has explicitly authorised in the conversation. Note any such authorisation in your report so future reviewers see the carve-out.
+
 ## Review Process
 
 1. **Read `guides/UI_GUIDE.md` and `guides/BRAND_GUIDE.md`** first to understand all project patterns and brand voice.

--- a/.claude/agents/ui-test-review.md
+++ b/.claude/agents/ui-test-review.md
@@ -12,6 +12,19 @@ You are an expert XCUITest specialist. Your role is to review UI test code for c
 
 The UI test suite stays small, fast, and deterministic by holding a hard line on three things: tests are user stories that touch only typed driver objects, every driver action waits for a real post-condition (no sleeps, no retries), and every failure produces enough artefacts that an agent can debug it without re-running. When any of those break, the suite becomes the thing nobody trusts. Your job is to flag drift before it ships.
 
+## Findings Must Be Fixed
+
+Every finding you raise in this review is a fix request, not a discussion item. There is no "follow-up later", "defer", or "out of scope" tier in your report. The expected outcomes for any finding are:
+
+- The author fixes the code before this work merges, **or**
+- The author rebuts the finding with a concrete reason and the reviewer drops it.
+
+Pre-existing problems noticed during the review are still findings. Don't qualify a finding with "this wasn't introduced by your change" — flake-shaped patterns (sleeps, retries, cached elements, raw identifier literals) compound across the suite, and the next reviewer of the file will surface the same thing. If you noticed the problem, raise it at the same severity you would if the change had introduced it.
+
+If a finding is genuinely too large to fix in the current change, say so explicitly and ask the author either to (a) split the PR so the fix lands in a sibling PR before merge, or (b) obtain explicit user authorisation to defer. The default is: fix it now.
+
+The only exception is scope the user has explicitly authorised in the conversation. Note any such authorisation in your report so future reviewers see the carve-out.
+
 ## Review Process
 
 1. **Read `guides/UI_TEST_GUIDE.md` first**, then `guides/TEST_GUIDE.md` — UI tests inherit the generic discipline and add to it.


### PR DESCRIPTION
## Summary
- Adds a **Findings Must Be Fixed** policy block to every reviewer agent (`code-review`, `concurrency-review`, `ui-review`, `sync-review`, `instrument-conversion-review`, `ui-test-review`, `appstore-review`) making it explicit that every reported finding is a fix request, not a discussion item — and that pre-existing problems noticed during review are still findings, raised at the same severity they would carry if the change had introduced them.
- Replaces the explicit "Follow-ups" out-of-scope bucket in `code-review.md` with an "Authorised Deferrals" section that is empty unless the user has explicitly authorised the carve-out.
- Tightens the `appstore-review.md` severity table: **Warning** is now "Must fix" (was "Should fix") and **Info** is "Must fix unless explicitly authorised to defer" (was "Address if time permits").

## Test plan
- [ ] No code changes — agent prompt-only edits, no build/test impact.
- [ ] Visual review of the seven agent files to confirm the policy block reads consistently and the `code-review` / `appstore-review` deferral language is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)