### PR TITLE
test(ui): register a crypto token via picker search (Task 16, #461)

### DIFF
--- a/App/MoolahApp+Setup.swift
+++ b/App/MoolahApp+Setup.swift
@@ -143,7 +143,8 @@ extension MoolahApp {
     case .tradeBaseline,
       .welcomeEmpty,
       .welcomeSingleCloudProfile,
-      .welcomeMultipleCloudProfiles:
+      .welcomeMultipleCloudProfiles,
+      .cryptoCatalogPreloaded:
       break
     case .welcomeDownloading:
       // Override iCloudAvailability to `.available` so the WelcomeStateResolver

--- a/App/PreloadedCryptoCatalog.swift
+++ b/App/PreloadedCryptoCatalog.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+/// In-memory `CoinGeckoCatalog` containing a single hard-coded entry.
+/// Returned from `UITestSeedCryptoOverrides.overrides(for:)` for seeds that
+/// need a deterministic catalogue. `refreshIfStale()` is a no-op so no
+/// network access happens during the UI-testing launch.
+struct PreloadedCryptoCatalog: CoinGeckoCatalog, Sendable {
+  let entries: [CatalogEntry]
+
+  func search(query: String, limit: Int) async -> [CatalogEntry] {
+    let trimmed = query.trimmingCharacters(in: .whitespaces).lowercased()
+    if trimmed.isEmpty { return Array(entries.prefix(limit)) }
+    let matches = entries.filter { entry in
+      entry.coingeckoId.lowercased().contains(trimmed)
+        || entry.symbol.lowercased().contains(trimmed)
+        || entry.name.lowercased().contains(trimmed)
+    }
+    return Array(matches.prefix(limit))
+  }
+
+  func refreshIfStale() async {}
+}
+
+extension PreloadedCryptoCatalog {
+  /// The catalogue snapshot installed for the `.cryptoCatalogPreloaded`
+  /// seed: a single coin (Uniswap, ETH chainId 1) so the picker has
+  /// exactly one match for the search prefix `"uni"`.
+  static let cryptoCatalogPreloaded = PreloadedCryptoCatalog(
+    entries: [
+      CatalogEntry(
+        coingeckoId: UITestFixtures.CryptoCatalogPreloaded.coingeckoId,
+        symbol: UITestFixtures.CryptoCatalogPreloaded.symbol,
+        name: UITestFixtures.CryptoCatalogPreloaded.name,
+        platforms: [
+          PlatformBinding(
+            slug: UITestFixtures.CryptoCatalogPreloaded.chainSlug,
+            chainId: UITestFixtures.CryptoCatalogPreloaded.chainId,
+            contractAddress: UITestFixtures.CryptoCatalogPreloaded.contractAddress
+          )
+        ]
+      )
+    ]
+  )
+}

--- a/App/PreloadedTokenResolutionClient.swift
+++ b/App/PreloadedTokenResolutionClient.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+/// Deterministic `TokenResolutionClient` used in UI tests. Returns a
+/// hard-coded `(coingeckoId, cryptocompareSymbol, binanceSymbol)` triple
+/// for the matching `(chainId, contractAddress)` and an empty result
+/// otherwise — so a row that doesn't match the seed's expected token is
+/// not silently registered.
+struct PreloadedTokenResolutionClient: TokenResolutionClient, Sendable {
+  let chainId: Int
+  let contractAddress: String
+  let result: TokenResolutionResult
+
+  func resolve(
+    chainId: Int, contractAddress: String?, symbol: String?, isNative: Bool
+  ) async throws -> TokenResolutionResult {
+    if chainId == self.chainId,
+      let address = contractAddress,
+      address.lowercased() == self.contractAddress.lowercased()
+    {
+      return result
+    }
+    return TokenResolutionResult()
+  }
+}
+
+extension PreloadedTokenResolutionClient {
+  /// The resolution stub installed for the `.cryptoCatalogPreloaded` seed.
+  /// Matches the catalogue's single coin so a tap on the Uniswap row
+  /// resolves with all three provider IDs populated and registration
+  /// succeeds.
+  static let cryptoCatalogPreloaded = PreloadedTokenResolutionClient(
+    chainId: UITestFixtures.CryptoCatalogPreloaded.chainId,
+    contractAddress: UITestFixtures.CryptoCatalogPreloaded.contractAddress,
+    result: TokenResolutionResult(
+      coingeckoId: UITestFixtures.CryptoCatalogPreloaded.coingeckoMappingId,
+      cryptocompareSymbol: UITestFixtures.CryptoCatalogPreloaded.cryptocompareSymbol,
+      binanceSymbol: UITestFixtures.CryptoCatalogPreloaded.binanceSymbol,
+      resolvedName: UITestFixtures.CryptoCatalogPreloaded.name,
+      resolvedSymbol: UITestFixtures.CryptoCatalogPreloaded.symbol,
+      resolvedDecimals: 18
+    )
+  )
+}

--- a/App/ProfileSession+Factories.swift
+++ b/App/ProfileSession+Factories.swift
@@ -6,6 +6,8 @@ import OSLog
 import SwiftData
 
 extension ProfileSession {
+  // MARK: - Market Data Services
+
   /// Bundle of the external market-data services a profile session depends
   /// on: fiat exchange rates, stock prices, and crypto prices. Returned
   /// from `makeMarketDataServices` so `init` can assign each field in one
@@ -68,6 +70,8 @@ extension ProfileSession {
     )
   }
 
+  // MARK: - Backend
+
   /// Builds the `BackendProvider` for the profile based on its backend type.
   /// iCloud profiles get the full conversion service (stock + crypto + fiat);
   /// remote profiles use their own internal fiat-only conversion.
@@ -115,6 +119,8 @@ extension ProfileSession {
           cryptoPrices: cryptoPrices))
     }
   }
+
+  // MARK: - Registry Wiring
 
   /// Bundle of the optional instrument-registry pieces: only CloudKit
   /// profiles expose a registry, crypto token store, search service,
@@ -222,6 +228,8 @@ extension ProfileSession {
     }
   }
 
+  // MARK: - Domain Stores
+
   /// Bundle of the per-profile domain stores. Returned from
   /// `makeDomainStores` so `ProfileSession.init` can assign each stored
   /// property in one step without inlining every constructor call.
@@ -277,6 +285,8 @@ extension ProfileSession {
     )
   }
 
+  // MARK: - Import Pipeline
+
   /// Bundle of the full CSV import pipeline: the `ImportStore`, the import-rule
   /// store, and the three folder-watch pieces. Returned from `makeImportPipeline`
   /// so `ProfileSession.init` can assign all five fields in one step.
@@ -320,6 +330,8 @@ extension ProfileSession {
       watcher: folderWatch.watcher
     )
   }
+
+  // MARK: - Folder Watch Services
 
   /// Bundle of the services that make up folder-watch ingestion for a
   /// profile: the on-disk `ImportPreferences`, the catch-up `FolderScanService`,

--- a/App/ProfileSession+Factories.swift
+++ b/App/ProfileSession+Factories.swift
@@ -138,6 +138,12 @@ extension ProfileSession {
   /// session init. A catalog construction failure (e.g. the SQLite file
   /// can't be opened) is logged and the catalogue is left `nil` — search
   /// degrades to the registry/Yahoo paths only.
+  ///
+  /// Under `--ui-testing` the active `UITestSeed` may register fake
+  /// catalogue/resolver implementations via
+  /// `UITestSeedCryptoOverrides.overrides(for:)` — those replace the live
+  /// SQLite snapshot and `CompositeTokenResolutionClient` so the picker
+  /// flow runs deterministically without disk or network access.
   @MainActor
   static func makeRegistryWiring(
     backend: BackendProvider,
@@ -151,11 +157,18 @@ extension ProfileSession {
         coinGeckoCatalog: nil, tokenResolutionClient: nil)
     }
 
-    let catalog = makeCoinGeckoCatalog()
+    let catalog: (any CoinGeckoCatalog)?
+    let resolutionClient: any TokenResolutionClient
+    if let overrides = uiTestingCryptoOverrides() {
+      catalog = overrides.catalog
+      resolutionClient = overrides.resolutionClient
+    } else {
+      catalog = makeCoinGeckoCatalog()
+      resolutionClient = CompositeTokenResolutionClient(coinGeckoApiKey: coinGeckoApiKey)
+    }
     let store = CryptoTokenStore(
       registry: cloudBackend.instrumentRegistry,
       cryptoPriceService: cryptoPriceService)
-    let resolutionClient = CompositeTokenResolutionClient(coinGeckoApiKey: coinGeckoApiKey)
     let searchService = InstrumentSearchService(
       registry: cloudBackend.instrumentRegistry,
       catalog: catalog,
@@ -169,6 +182,22 @@ extension ProfileSession {
       coinGeckoCatalog: catalog,
       tokenResolutionClient: resolutionClient
     )
+  }
+
+  /// Returns the catalogue/resolver overrides for the active UI test seed,
+  /// or `nil` for production launches. Reads the same arguments and
+  /// environment variable that `MoolahApp+Setup.uiTestingSeed(from:)`
+  /// consumes during app init — keeping the gating consistent between the
+  /// two call sites.
+  @MainActor
+  private static func uiTestingCryptoOverrides()
+    -> (catalog: any CoinGeckoCatalog, resolutionClient: any TokenResolutionClient)?
+  {
+    guard CommandLine.arguments.contains("--ui-testing") else { return nil }
+    guard let raw = ProcessInfo.processInfo.environment["UI_TESTING_SEED"],
+      let seed = UITestSeed(rawValue: raw)
+    else { return nil }
+    return UITestSeedCryptoOverrides.overrides(for: seed)
   }
 
   /// Builds the per-profile CoinGecko catalogue and kicks off a background

--- a/App/UITestSeedCryptoOverrides.swift
+++ b/App/UITestSeedCryptoOverrides.swift
@@ -10,6 +10,10 @@ import Foundation
 /// can hit the CoinGecko API; `CompositeTokenResolutionClient` always hits
 /// the network. Neither is acceptable in a UI test, so seeds that exercise
 /// the picker substitute the pair below for a fixed, in-memory snapshot.
+///
+/// The concrete fakes live in their own files (one primary type per file):
+///   - `PreloadedCryptoCatalog.swift`
+///   - `PreloadedTokenResolutionClient.swift`
 @MainActor
 enum UITestSeedCryptoOverrides {
   /// Returns the catalogue/resolver pair to use under UI testing for the
@@ -37,89 +41,4 @@ enum UITestSeedCryptoOverrides {
       return nil
     }
   }
-}
-
-/// In-memory `CoinGeckoCatalog` containing a single hard-coded entry.
-/// Returned from `UITestSeedCryptoOverrides.overrides(for:)` for seeds that
-/// need a deterministic catalogue. `refreshIfStale()` is a no-op so no
-/// network access happens during the UI-testing launch.
-struct PreloadedCryptoCatalog: CoinGeckoCatalog, Sendable {
-  let entries: [CatalogEntry]
-
-  func search(query: String, limit: Int) async -> [CatalogEntry] {
-    let trimmed = query.trimmingCharacters(in: .whitespaces).lowercased()
-    if trimmed.isEmpty { return Array(entries.prefix(limit)) }
-    let matches = entries.filter { entry in
-      entry.coingeckoId.lowercased().contains(trimmed)
-        || entry.symbol.lowercased().contains(trimmed)
-        || entry.name.lowercased().contains(trimmed)
-    }
-    return Array(matches.prefix(limit))
-  }
-
-  func refreshIfStale() async {}
-}
-
-extension PreloadedCryptoCatalog {
-  /// The catalogue snapshot installed for the `.cryptoCatalogPreloaded`
-  /// seed: a single coin (Uniswap, ETH chainId 1) so the picker has
-  /// exactly one match for the search prefix `"uni"`.
-  static let cryptoCatalogPreloaded = PreloadedCryptoCatalog(
-    entries: [
-      CatalogEntry(
-        coingeckoId: UITestFixtures.CryptoCatalogPreloaded.coingeckoId,
-        symbol: UITestFixtures.CryptoCatalogPreloaded.symbol,
-        name: UITestFixtures.CryptoCatalogPreloaded.name,
-        platforms: [
-          PlatformBinding(
-            slug: UITestFixtures.CryptoCatalogPreloaded.chainSlug,
-            chainId: UITestFixtures.CryptoCatalogPreloaded.chainId,
-            contractAddress: UITestFixtures.CryptoCatalogPreloaded.contractAddress
-          )
-        ]
-      )
-    ]
-  )
-}
-
-/// Deterministic `TokenResolutionClient` used in UI tests. Returns a
-/// hard-coded `(coingeckoId, cryptocompareSymbol, binanceSymbol)` triple
-/// for the matching `(chainId, contractAddress)` and an empty result
-/// otherwise — so a row that doesn't match the seed's expected token is
-/// not silently registered.
-struct PreloadedTokenResolutionClient: TokenResolutionClient, Sendable {
-  let chainId: Int
-  let contractAddress: String
-  let result: TokenResolutionResult
-
-  func resolve(
-    chainId: Int, contractAddress: String?, symbol: String?, isNative: Bool
-  ) async throws -> TokenResolutionResult {
-    if chainId == self.chainId,
-      let address = contractAddress,
-      address.lowercased() == self.contractAddress.lowercased()
-    {
-      return result
-    }
-    return TokenResolutionResult()
-  }
-}
-
-extension PreloadedTokenResolutionClient {
-  /// The resolution stub installed for the `.cryptoCatalogPreloaded` seed.
-  /// Matches the catalogue's single coin so a tap on the Uniswap row
-  /// resolves with all three provider IDs populated and registration
-  /// succeeds.
-  static let cryptoCatalogPreloaded = PreloadedTokenResolutionClient(
-    chainId: UITestFixtures.CryptoCatalogPreloaded.chainId,
-    contractAddress: UITestFixtures.CryptoCatalogPreloaded.contractAddress,
-    result: TokenResolutionResult(
-      coingeckoId: UITestFixtures.CryptoCatalogPreloaded.coingeckoMappingId,
-      cryptocompareSymbol: UITestFixtures.CryptoCatalogPreloaded.cryptocompareSymbol,
-      binanceSymbol: UITestFixtures.CryptoCatalogPreloaded.binanceSymbol,
-      resolvedName: UITestFixtures.CryptoCatalogPreloaded.name,
-      resolvedSymbol: UITestFixtures.CryptoCatalogPreloaded.symbol,
-      resolvedDecimals: 18
-    )
-  )
 }

--- a/App/UITestSeedCryptoOverrides.swift
+++ b/App/UITestSeedCryptoOverrides.swift
@@ -1,0 +1,125 @@
+import Foundation
+
+/// UI-testing-only overrides for the CoinGecko catalogue and the token
+/// resolution client. Consulted from `ProfileSession.makeRegistryWiring`
+/// when the process was launched with `--ui-testing` and the active
+/// `UITestSeed` requests a deterministic catalogue/resolver instead of
+/// the live SQLite-backed snapshot and network resolver.
+///
+/// The live `SQLiteCoinGeckoCatalog` reads from disk and `refreshIfStale()`
+/// can hit the CoinGecko API; `CompositeTokenResolutionClient` always hits
+/// the network. Neither is acceptable in a UI test, so seeds that exercise
+/// the picker substitute the pair below for a fixed, in-memory snapshot.
+@MainActor
+enum UITestSeedCryptoOverrides {
+  /// Returns the catalogue/resolver pair to use under UI testing for the
+  /// given seed, or `nil` to fall through to the production wiring. Any
+  /// seed not listed here uses the live wiring (so for example
+  /// `tradeBaseline` keeps the SQLite snapshot — the trade tests don't
+  /// exercise crypto search).
+  static func overrides(
+    for seed: UITestSeed
+  ) -> (catalog: any CoinGeckoCatalog, resolutionClient: any TokenResolutionClient)? {
+    switch seed {
+    case .cryptoCatalogPreloaded:
+      return (
+        catalog: PreloadedCryptoCatalog.cryptoCatalogPreloaded,
+        resolutionClient: PreloadedTokenResolutionClient.cryptoCatalogPreloaded
+      )
+    case .tradeBaseline,
+      .welcomeEmpty,
+      .welcomeSingleCloudProfile,
+      .welcomeMultipleCloudProfiles,
+      .welcomeDownloading,
+      .sidebarFooterUpToDate,
+      .sidebarFooterReceiving,
+      .sidebarFooterSending:
+      return nil
+    }
+  }
+}
+
+/// In-memory `CoinGeckoCatalog` containing a single hard-coded entry.
+/// Returned from `UITestSeedCryptoOverrides.overrides(for:)` for seeds that
+/// need a deterministic catalogue. `refreshIfStale()` is a no-op so no
+/// network access happens during the UI-testing launch.
+struct PreloadedCryptoCatalog: CoinGeckoCatalog, Sendable {
+  let entries: [CatalogEntry]
+
+  func search(query: String, limit: Int) async -> [CatalogEntry] {
+    let trimmed = query.trimmingCharacters(in: .whitespaces).lowercased()
+    if trimmed.isEmpty { return Array(entries.prefix(limit)) }
+    let matches = entries.filter { entry in
+      entry.coingeckoId.lowercased().contains(trimmed)
+        || entry.symbol.lowercased().contains(trimmed)
+        || entry.name.lowercased().contains(trimmed)
+    }
+    return Array(matches.prefix(limit))
+  }
+
+  func refreshIfStale() async {}
+}
+
+extension PreloadedCryptoCatalog {
+  /// The catalogue snapshot installed for the `.cryptoCatalogPreloaded`
+  /// seed: a single coin (Uniswap, ETH chainId 1) so the picker has
+  /// exactly one match for the search prefix `"uni"`.
+  static let cryptoCatalogPreloaded = PreloadedCryptoCatalog(
+    entries: [
+      CatalogEntry(
+        coingeckoId: UITestFixtures.CryptoCatalogPreloaded.coingeckoId,
+        symbol: UITestFixtures.CryptoCatalogPreloaded.symbol,
+        name: UITestFixtures.CryptoCatalogPreloaded.name,
+        platforms: [
+          PlatformBinding(
+            slug: UITestFixtures.CryptoCatalogPreloaded.chainSlug,
+            chainId: UITestFixtures.CryptoCatalogPreloaded.chainId,
+            contractAddress: UITestFixtures.CryptoCatalogPreloaded.contractAddress
+          )
+        ]
+      )
+    ]
+  )
+}
+
+/// Deterministic `TokenResolutionClient` used in UI tests. Returns a
+/// hard-coded `(coingeckoId, cryptocompareSymbol, binanceSymbol)` triple
+/// for the matching `(chainId, contractAddress)` and an empty result
+/// otherwise — so a row that doesn't match the seed's expected token is
+/// not silently registered.
+struct PreloadedTokenResolutionClient: TokenResolutionClient, Sendable {
+  let chainId: Int
+  let contractAddress: String
+  let result: TokenResolutionResult
+
+  func resolve(
+    chainId: Int, contractAddress: String?, symbol: String?, isNative: Bool
+  ) async throws -> TokenResolutionResult {
+    if chainId == self.chainId,
+      let address = contractAddress,
+      address.lowercased() == self.contractAddress.lowercased()
+    {
+      return result
+    }
+    return TokenResolutionResult()
+  }
+}
+
+extension PreloadedTokenResolutionClient {
+  /// The resolution stub installed for the `.cryptoCatalogPreloaded` seed.
+  /// Matches the catalogue's single coin so a tap on the Uniswap row
+  /// resolves with all three provider IDs populated and registration
+  /// succeeds.
+  static let cryptoCatalogPreloaded = PreloadedTokenResolutionClient(
+    chainId: UITestFixtures.CryptoCatalogPreloaded.chainId,
+    contractAddress: UITestFixtures.CryptoCatalogPreloaded.contractAddress,
+    result: TokenResolutionResult(
+      coingeckoId: UITestFixtures.CryptoCatalogPreloaded.coingeckoMappingId,
+      cryptocompareSymbol: UITestFixtures.CryptoCatalogPreloaded.cryptocompareSymbol,
+      binanceSymbol: UITestFixtures.CryptoCatalogPreloaded.binanceSymbol,
+      resolvedName: UITestFixtures.CryptoCatalogPreloaded.name,
+      resolvedSymbol: UITestFixtures.CryptoCatalogPreloaded.symbol,
+      resolvedDecimals: 18
+    )
+  )
+}

--- a/App/UITestSeedHydrator.swift
+++ b/App/UITestSeedHydrator.swift
@@ -62,6 +62,12 @@ enum UITestSeedHydrator {
       // These seeds exercise the sidebar footer; the profile itself is the
       // same minimal fixture used by tradeBaseline.
       return try hydrateTradeBaseline(into: manager)
+    case .cryptoCatalogPreloaded:
+      // The crypto picker test only needs a CloudKit-backed profile (so
+      // `CryptoTokenStore` is built and the Crypto Settings tab renders);
+      // accounts/transactions are unused. Reuse `tradeBaseline` rather than
+      // hand-rolling a near-identical fixture.
+      return try hydrateTradeBaseline(into: manager)
     }
   }
 

--- a/Features/Settings/AddTokenSheet.swift
+++ b/Features/Settings/AddTokenSheet.swift
@@ -5,6 +5,12 @@ import SwiftUI
 /// limited to crypto results; the picker handles resolution and registration
 /// internally. `onRegistered` fires once when a token is successfully picked
 /// (and therefore added to the registry); the sheet then dismisses.
+///
+/// The fixed minimum frame matches `InstrumentPickerField`'s popover sizing
+/// (460×480) so the picker has room for results plus the footer hint;
+/// without it SwiftUI sizes the sheet to the empty-state view's intrinsic
+/// content and the first row presented after a search renders outside the
+/// hit-testable bounds.
 struct AddTokenSheet: View {
   @Environment(\.dismiss) private var dismiss
   let onRegistered: () -> Void
@@ -14,5 +20,6 @@ struct AddTokenSheet: View {
       if instrument != nil { onRegistered() }
       dismiss()
     }
+    .frame(minWidth: 460, minHeight: 480)
   }
 }

--- a/Features/Settings/CryptoSettingsView.swift
+++ b/Features/Settings/CryptoSettingsView.swift
@@ -13,6 +13,7 @@ struct CryptoSettingsView: View {
     }
     .formStyle(.grouped)
     .navigationTitle("Crypto Tokens")
+    .accessibilityIdentifier(UITestIdentifiers.CryptoSettings.container)
     .task { await store.loadRegistrations() }
     .sheet(isPresented: $showAddToken) {
       AddTokenSheet {
@@ -61,6 +62,7 @@ struct CryptoSettingsView: View {
         }
         .buttonStyle(.borderless)
         .accessibilityLabel("Add token")
+        .accessibilityIdentifier(UITestIdentifiers.CryptoSettings.addTokenButton)
       }
     }
   }
@@ -83,6 +85,7 @@ struct CryptoSettingsView: View {
       providerIndicators(for: mapping)
     }
     .accessibilityElement(children: .combine)
+    .accessibilityIdentifier(UITestIdentifiers.CryptoSettings.registrationRow(registration.id))
     .accessibilityLabel(
       "\(instrument.ticker ?? instrument.name), \(instrument.name), "
         + "\(Instrument.chainName(for: instrument.chainId ?? 0))"

--- a/Features/Settings/SettingsView+iOS.swift
+++ b/Features/Settings/SettingsView+iOS.swift
@@ -119,10 +119,18 @@
     }
 
     @ViewBuilder var cryptoSection: some View {
-      if let store = activeSession?.cryptoTokenStore {
+      if let session = activeSession,
+        let store = session.cryptoTokenStore
+      {
         Section {
           NavigationLink {
             CryptoSettingsView(store: store)
+              // The embedded `AddTokenSheet` opens an `InstrumentPickerSheet`
+              // whose callback variant pulls its search service, registry,
+              // and resolution client from `@Environment(ProfileSession.self)`.
+              // Without this injection the picker silently falls back to the
+              // static fiat list and crypto search returns no results.
+              .environment(session)
           } label: {
             Label("Crypto Tokens", systemImage: "bitcoinsign.circle")
           }

--- a/Features/Settings/SettingsView+macOS.swift
+++ b/Features/Settings/SettingsView+macOS.swift
@@ -1,0 +1,257 @@
+#if os(macOS)
+  import SwiftUI
+  import UniformTypeIdentifiers
+
+  // macOS HSplitView/TabView layout extracted from `SettingsView` so the main
+  // struct body stays under SwiftLint's `type_body_length` threshold. Every
+  // member is view composition over the main struct's shared state.
+  extension SettingsView {
+
+    // MARK: - macOS: HSplitView / TabView layout
+
+    /// The Settings scene lives outside `SessionRootView`, so the session
+    /// stores aren't in its environment. Resolve one here for the tabs
+    /// that depend on per-profile state. Prefer the active profile; fall
+    /// back to any open session so Settings still renders after a profile
+    /// switch.
+    var sessionForSettings: ProfileSession? {
+      if let id = profileStore.activeProfileID, let session = sessionManager.sessions[id] {
+        return session
+      }
+      return sessionManager.sessions.values.first
+    }
+
+    /// The Crypto Tokens tab's session, taken strictly from the *active*
+    /// profile's session — not any open session — so switching to a
+    /// Remote/moolah active profile correctly hides crypto settings even
+    /// when a CloudKit session is still open in another profile's window.
+    /// Returned in full (rather than narrowed to just the
+    /// `CryptoTokenStore`) so the tab can also inject the session into
+    /// the SwiftUI environment for the embedded `AddTokenSheet`'s picker
+    /// to consume — `InstrumentPickerSheet`'s callback variant resolves
+    /// its search service / resolver / registry from the session.
+    var activeCryptoSession: ProfileSession? {
+      guard let id = profileStore.activeProfileID,
+        let session = sessionManager.sessions[id],
+        session.cryptoTokenStore != nil
+      else { return nil }
+      return session
+    }
+
+    var macOSLayout: some View {
+      TabView {
+        Tab("Profiles", systemImage: "person.2") {
+          profilesContent
+        }
+        if let session = activeCryptoSession,
+          let store = session.cryptoTokenStore
+        {
+          // SwiftUI's `Tab` does not propagate `.accessibilityIdentifier`
+          // to the generated toolbar button on macOS, so the title doubles
+          // as the driver lookup label. Both sites reference
+          // `UITestIdentifiers.Settings.cryptoTabTitle` so there is one
+          // source of truth.
+          Tab(UITestIdentifiers.Settings.cryptoTabTitle, systemImage: "bitcoinsign.circle") {
+            CryptoSettingsView(store: store)
+              // The embedded `AddTokenSheet` opens an `InstrumentPickerSheet`
+              // whose callback variant pulls its search service, registry,
+              // and resolution client from `@Environment(ProfileSession.self)`.
+              // Without this injection the picker silently falls back to
+              // the static fiat list and crypto search returns no results.
+              .environment(session)
+          }
+        }
+        // macOS Settings tabs host the Form / List directly — the window
+        // already supplies chrome and a title, so wrapping in a second
+        // `NavigationStack` would produce a duplicate navigation bar.
+        Tab("Import", systemImage: "tray.and.arrow.down") {
+          importTabContent
+        }
+        Tab("Rules", systemImage: "list.bullet.rectangle") {
+          rulesTabContent
+        }
+      }
+      .frame(minWidth: 600, minHeight: 400)
+      .sheet(isPresented: $showAddProfile) {
+        ProfileFormView()
+          .environment(profileStore)
+          .frame(minWidth: 400, minHeight: 300)
+      }
+      .alert(deleteAlertTitle, isPresented: $showDeleteAlert) {
+        deleteAlertButtons
+      } message: {
+        deleteAlertMessage
+      }
+      .fileImporter(
+        isPresented: $showImportPicker,
+        allowedContentTypes: [.json]
+      ) { result in
+        Task { await handleImport(result: result) }
+      }
+      .alert(
+        "Import Failed",
+        isPresented: .init(
+          get: { importError != nil },
+          set: { if !$0 { importError = nil } }
+        )
+      ) {
+        Button("OK") { importError = nil }
+      } message: {
+        if let importError {
+          Text(importError)
+        }
+      }
+    }
+
+    var profilesContent: some View {
+      Group {
+        if profileStore.profiles.isEmpty {
+          emptyState
+        } else {
+          HSplitView {
+            profileList
+              .frame(minWidth: 180, idealWidth: 220, maxWidth: 280)
+            detailPane
+              .frame(minWidth: 300, idealWidth: 400)
+          }
+          .onAppear {
+            if selectedProfileID == nil {
+              selectedProfileID =
+                profileStore.activeProfileID ?? profileStore.profiles.first?.id
+            }
+          }
+        }
+      }
+    }
+
+    var emptyState: some View {
+      ContentUnavailableView {
+        Label("No Profiles", systemImage: "person.crop.circle.badge.plus")
+      } description: {
+        Text("Add a profile to connect to a Moolah server.")
+      } actions: {
+        Button("Add Profile") {
+          showAddProfile = true
+        }
+        .buttonStyle(.bordered)
+      }
+    }
+
+    @ViewBuilder var importTabContent: some View {
+      if let session = sessionForSettings {
+        ImportSettingsView()
+          .environment(session)
+      } else {
+        noActiveProfilePlaceholder
+      }
+    }
+
+    @ViewBuilder var rulesTabContent: some View {
+      if let session = sessionForSettings {
+        ImportRulesSettingsView()
+          .environment(session)
+          .environment(session.importRuleStore)
+          .environment(session.categoryStore)
+      } else {
+        noActiveProfilePlaceholder
+      }
+    }
+
+    var noActiveProfilePlaceholder: some View {
+      ContentUnavailableView(
+        "No Profile",
+        systemImage: "person.crop.circle",
+        description: Text("Add a profile to configure this tab.")
+      )
+    }
+
+    // MARK: - macOS Profile List (sidebar)
+
+    var profileList: some View {
+      VStack(spacing: 0) {
+        profileListContent
+        Divider()
+        profileListToolbar
+      }
+    }
+
+    private var profileListContent: some View {
+      List(selection: $selectedProfileID) {
+        Section("Profiles") {
+          ForEach(profileStore.profiles) { profile in
+            profileRow(profile)
+              .tag(profile.id)
+          }
+        }
+      }
+      .listStyle(.sidebar)
+    }
+
+    private var profileListToolbar: some View {
+      HStack(spacing: 8) {
+        addProfileButton
+        removeProfileButton
+        importProfileButton
+        Spacer()
+      }
+      .padding(8)
+    }
+
+    private var addProfileButton: some View {
+      Button {
+        showAddProfile = true
+      } label: {
+        Image(systemName: "plus")
+          .frame(minWidth: 24, minHeight: 24)
+          .contentShape(Rectangle())
+      }
+      .buttonStyle(.borderless)
+      .accessibilityLabel("Add profile")
+    }
+
+    private var removeProfileButton: some View {
+      Button {
+        if let id = selectedProfileID,
+          let profile = profileStore.profiles.first(where: { $0.id == id })
+        {
+          profileToDelete = profile
+          showDeleteAlert = true
+        }
+      } label: {
+        Image(systemName: "minus")
+          .frame(minWidth: 24, minHeight: 24)
+          .contentShape(Rectangle())
+      }
+      .buttonStyle(.borderless)
+      .disabled(selectedProfileID == nil)
+      .accessibilityLabel("Remove selected profile")
+    }
+
+    private var importProfileButton: some View {
+      Button {
+        showImportPicker = true
+      } label: {
+        Image(systemName: "square.and.arrow.down")
+      }
+      .buttonStyle(.borderless)
+      .accessibilityLabel("Import profile")
+    }
+
+    // MARK: - macOS Detail Pane
+
+    @ViewBuilder var detailPane: some View {
+      if let selectedID = selectedProfileID,
+        let profile = profileStore.profiles.first(where: { $0.id == selectedID })
+      {
+        profileDetailView(for: profile)
+          .id(selectedID)
+      } else {
+        ContentUnavailableView(
+          "No Profile Selected",
+          systemImage: "person.crop.circle",
+          description: Text("Select a profile to view its settings.")
+        )
+      }
+    }
+  }
+#endif

--- a/Features/Settings/SettingsView.swift
+++ b/Features/Settings/SettingsView.swift
@@ -59,15 +59,21 @@ struct SettingsView: View {
       return sessionManager.sessions.values.first
     }
 
-    /// The Crypto Tokens tab's store, taken strictly from the *active* profile's
-    /// session — not any open session — so switching to a Remote/moolah active
-    /// profile correctly hides crypto settings even when a CloudKit session is
-    /// still open in another profile's window.
-    private var activeCryptoTokenStore: CryptoTokenStore? {
+    /// The Crypto Tokens tab's session, taken strictly from the *active*
+    /// profile's session — not any open session — so switching to a
+    /// Remote/moolah active profile correctly hides crypto settings even
+    /// when a CloudKit session is still open in another profile's window.
+    /// Returned in full (rather than narrowed to just the
+    /// `CryptoTokenStore`) so the tab can also inject the session into
+    /// the SwiftUI environment for the embedded `AddTokenSheet`'s picker
+    /// to consume — `InstrumentPickerSheet`'s callback variant resolves
+    /// its search service / resolver / registry from the session.
+    private var activeCryptoSession: ProfileSession? {
       guard let id = profileStore.activeProfileID,
-        let session = sessionManager.sessions[id]
+        let session = sessionManager.sessions[id],
+        session.cryptoTokenStore != nil
       else { return nil }
-      return session.cryptoTokenStore
+      return session
     }
 
     private var macOSLayout: some View {
@@ -75,9 +81,17 @@ struct SettingsView: View {
         Tab("Profiles", systemImage: "person.2") {
           profilesContent
         }
-        if let store = activeCryptoTokenStore {
+        if let session = activeCryptoSession,
+          let store = session.cryptoTokenStore
+        {
           Tab("Crypto", systemImage: "bitcoinsign.circle") {
             CryptoSettingsView(store: store)
+              // The embedded `AddTokenSheet` opens an `InstrumentPickerSheet`
+              // whose callback variant pulls its search service, registry,
+              // and resolution client from `@Environment(ProfileSession.self)`.
+              // Without this injection the picker silently falls back to
+              // the static fiat list and crypto search returns no results.
+              .environment(session)
           }
         }
         // macOS Settings tabs host the Form / List directly — the window

--- a/Features/Settings/SettingsView.swift
+++ b/Features/Settings/SettingsView.swift
@@ -5,8 +5,8 @@ import UniformTypeIdentifiers
 /// and as a sheet on iOS.
 struct SettingsView: View {
   // Environment/State visibility widened from `private` to default (internal)
-  // so the `+Actions` extension file can read dependencies and mutate state
-  // from import/export/delete handlers.
+  // so the `+Actions` / `+macOS` / `+iOS` extension files can read
+  // dependencies and mutate state from import/export/delete handlers.
   @Environment(ProfileStore.self) var profileStore
   @Environment(ProfileContainerManager.self) var containerManager
   @Environment(SyncCoordinator.self) var syncCoordinator
@@ -44,243 +44,11 @@ struct SettingsView: View {
     #endif
   }
 
-  // MARK: - macOS: HSplitView layout
-
-  #if os(macOS)
-    /// The Settings scene lives outside `SessionRootView`, so the session
-    /// stores aren't in its environment. Resolve one here for the tabs
-    /// that depend on per-profile state. Prefer the active profile; fall
-    /// back to any open session so Settings still renders after a profile
-    /// switch.
-    private var sessionForSettings: ProfileSession? {
-      if let id = profileStore.activeProfileID, let session = sessionManager.sessions[id] {
-        return session
-      }
-      return sessionManager.sessions.values.first
-    }
-
-    /// The Crypto Tokens tab's session, taken strictly from the *active*
-    /// profile's session — not any open session — so switching to a
-    /// Remote/moolah active profile correctly hides crypto settings even
-    /// when a CloudKit session is still open in another profile's window.
-    /// Returned in full (rather than narrowed to just the
-    /// `CryptoTokenStore`) so the tab can also inject the session into
-    /// the SwiftUI environment for the embedded `AddTokenSheet`'s picker
-    /// to consume — `InstrumentPickerSheet`'s callback variant resolves
-    /// its search service / resolver / registry from the session.
-    private var activeCryptoSession: ProfileSession? {
-      guard let id = profileStore.activeProfileID,
-        let session = sessionManager.sessions[id],
-        session.cryptoTokenStore != nil
-      else { return nil }
-      return session
-    }
-
-    private var macOSLayout: some View {
-      TabView {
-        Tab("Profiles", systemImage: "person.2") {
-          profilesContent
-        }
-        if let session = activeCryptoSession,
-          let store = session.cryptoTokenStore
-        {
-          Tab("Crypto", systemImage: "bitcoinsign.circle") {
-            CryptoSettingsView(store: store)
-              // The embedded `AddTokenSheet` opens an `InstrumentPickerSheet`
-              // whose callback variant pulls its search service, registry,
-              // and resolution client from `@Environment(ProfileSession.self)`.
-              // Without this injection the picker silently falls back to
-              // the static fiat list and crypto search returns no results.
-              .environment(session)
-          }
-        }
-        // macOS Settings tabs host the Form / List directly — the window
-        // already supplies chrome and a title, so wrapping in a second
-        // `NavigationStack` would produce a duplicate navigation bar.
-        Tab("Import", systemImage: "tray.and.arrow.down") {
-          importTabContent
-        }
-        Tab("Rules", systemImage: "list.bullet.rectangle") {
-          rulesTabContent
-        }
-      }
-      .frame(minWidth: 600, minHeight: 400)
-      .sheet(isPresented: $showAddProfile) {
-        ProfileFormView()
-          .environment(profileStore)
-          .frame(minWidth: 400, minHeight: 300)
-      }
-      .alert(deleteAlertTitle, isPresented: $showDeleteAlert) {
-        deleteAlertButtons
-      } message: {
-        deleteAlertMessage
-      }
-      .fileImporter(
-        isPresented: $showImportPicker,
-        allowedContentTypes: [.json]
-      ) { result in
-        Task { await handleImport(result: result) }
-      }
-      .alert(
-        "Import Failed",
-        isPresented: .init(
-          get: { importError != nil },
-          set: { if !$0 { importError = nil } }
-        )
-      ) {
-        Button("OK") { importError = nil }
-      } message: {
-        if let importError {
-          Text(importError)
-        }
-      }
-    }
-
-    private var profilesContent: some View {
-      Group {
-        if profileStore.profiles.isEmpty {
-          emptyState
-        } else {
-          HSplitView {
-            profileList
-              .frame(minWidth: 180, idealWidth: 220, maxWidth: 280)
-            detailPane
-              .frame(minWidth: 300, idealWidth: 400)
-          }
-          .onAppear {
-            if selectedProfileID == nil {
-              selectedProfileID =
-                profileStore.activeProfileID ?? profileStore.profiles.first?.id
-            }
-          }
-        }
-      }
-    }
-
-    private var emptyState: some View {
-      ContentUnavailableView {
-        Label("No Profiles", systemImage: "person.crop.circle.badge.plus")
-      } description: {
-        Text("Add a profile to connect to a Moolah server.")
-      } actions: {
-        Button("Add Profile") {
-          showAddProfile = true
-        }
-        .buttonStyle(.bordered)
-      }
-    }
-
-    @ViewBuilder private var importTabContent: some View {
-      if let session = sessionForSettings {
-        ImportSettingsView()
-          .environment(session)
-      } else {
-        noActiveProfilePlaceholder
-      }
-    }
-
-    @ViewBuilder private var rulesTabContent: some View {
-      if let session = sessionForSettings {
-        ImportRulesSettingsView()
-          .environment(session)
-          .environment(session.importRuleStore)
-          .environment(session.categoryStore)
-      } else {
-        noActiveProfilePlaceholder
-      }
-    }
-
-    private var noActiveProfilePlaceholder: some View {
-      ContentUnavailableView(
-        "No Profile",
-        systemImage: "person.crop.circle",
-        description: Text("Add a profile to configure this tab.")
-      )
-    }
-  #endif
-
-  // MARK: - macOS Profile List (sidebar)
-
-  #if os(macOS)
-    private var profileList: some View {
-      VStack(spacing: 0) {
-        List(selection: $selectedProfileID) {
-          Section("Profiles") {
-            ForEach(profileStore.profiles) { profile in
-              profileRow(profile)
-                .tag(profile.id)
-            }
-          }
-        }
-        .listStyle(.sidebar)
-
-        Divider()
-
-        HStack(spacing: 8) {
-          Button {
-            showAddProfile = true
-          } label: {
-            Image(systemName: "plus")
-              .frame(minWidth: 24, minHeight: 24)
-              .contentShape(Rectangle())
-          }
-          .buttonStyle(.borderless)
-          .accessibilityLabel("Add profile")
-
-          Button {
-            if let id = selectedProfileID,
-              let profile = profileStore.profiles.first(where: { $0.id == id })
-            {
-              profileToDelete = profile
-              showDeleteAlert = true
-            }
-          } label: {
-            Image(systemName: "minus")
-              .frame(minWidth: 24, minHeight: 24)
-              .contentShape(Rectangle())
-          }
-          .buttonStyle(.borderless)
-          .disabled(selectedProfileID == nil)
-          .accessibilityLabel("Remove selected profile")
-
-          Button {
-            showImportPicker = true
-          } label: {
-            Image(systemName: "square.and.arrow.down")
-          }
-          .buttonStyle(.borderless)
-          .accessibilityLabel("Import profile")
-
-          Spacer()
-        }
-        .padding(8)
-      }
-    }
-  #endif
-
-  // MARK: - macOS Detail Pane
-
-  #if os(macOS)
-    @ViewBuilder private var detailPane: some View {
-      if let selectedID = selectedProfileID,
-        let profile = profileStore.profiles.first(where: { $0.id == selectedID })
-      {
-        profileDetailView(for: profile)
-          .id(selectedID)
-      } else {
-        ContentUnavailableView(
-          "No Profile Selected",
-          systemImage: "person.crop.circle",
-          description: Text("Select a profile to view its settings.")
-        )
-      }
-    }
-  #endif
-
   // MARK: - Per-type detail view
 
-  // Access widened from `private` to default (internal) so the `+iOS`
-  // extension can render profile detail from the iOS list.
+  // Access widened from `private` to default (internal) so the `+iOS` /
+  // `+macOS` extensions can render profile detail from their respective
+  // layouts.
   @ViewBuilder
   func profileDetailView(for profile: Profile) -> some View {
     #if os(macOS)
@@ -317,4 +85,5 @@ struct SettingsView: View {
 // `MoolahProfileDetailView`, `CustomServerProfileDetailView`,
 // `CloudKitProfileDetailView`, and `ProfileAuthStatusView` live in
 // `MoolahProfileDetailView.swift`. `ShareSheetView` lives in
-// `SettingsView+iOS.swift`.
+// `SettingsView+iOS.swift`. The macOS HSplitView/TabView layout lives in
+// `SettingsView+macOS.swift`.

--- a/MoolahUITests_macOS/Helpers/MoolahApp.swift
+++ b/MoolahUITests_macOS/Helpers/MoolahApp.swift
@@ -90,6 +90,17 @@ final class MoolahApp {
     application.descendants(matching: .any).matching(identifier: identifier).firstMatch
   }
 
+  /// Toolbar-button-by-label resolver. Used by drivers when SwiftUI
+  /// drops `.accessibilityIdentifier(_:)` on the underlying control —
+  /// macOS Settings `Tab(...)` toolbar buttons are the current case. The
+  /// `label` argument should still be a typed constant from
+  /// `UITestIdentifiers` so drivers stay free of raw English literals.
+  /// All such lookups route through this method so the single-resolver
+  /// invariant (UI_TEST_GUIDE §3 #5) is preserved.
+  func toolbarButton(label: String) -> XCUIElement {
+    application.toolbars.buttons[label]
+  }
+
   /// Keyboard shortcut entrypoint for drivers. Drivers must route keyboard
   /// events through this method rather than reaching into `application`
   /// directly — the single seam keeps `MoolahApp` as the only surface the

--- a/MoolahUITests_macOS/Helpers/MoolahApp.swift
+++ b/MoolahUITests_macOS/Helpers/MoolahApp.swift
@@ -69,6 +69,18 @@ final class MoolahApp {
   /// `CreateAccountView` sheet. Open it by calling `createAccount.open(...)`.
   var createAccount: CreateAccountScreen { CreateAccountScreen(app: self) }
 
+  /// macOS Settings scene. Open it via `settings.open()`; tab drivers
+  /// (e.g. `settings.openCryptoTab()`) hang off the returned screen.
+  var settings: SettingsScreen { SettingsScreen(app: self) }
+
+  /// Crypto tab of the Settings scene (`CryptoSettingsView`). Available
+  /// after `settings.openCryptoTab()` has selected the tab.
+  var cryptoSettings: CryptoSettingsScreen { CryptoSettingsScreen(app: self) }
+
+  /// `AddTokenSheet` (the crypto-only `InstrumentPickerSheet`). Available
+  /// after `cryptoSettings.tapAddToken()` has presented the sheet.
+  var addToken: AddTokenScreen { AddTokenScreen(app: self) }
+
   // MARK: - Single element resolver
 
   /// All identifier lookups in the driver layer go through this method, by

--- a/MoolahUITests_macOS/Helpers/MoolahUITestCase+Artefacts.swift
+++ b/MoolahUITests_macOS/Helpers/MoolahUITestCase+Artefacts.swift
@@ -206,8 +206,30 @@ extension MoolahUITestCase {
       lines.append("# SyncProgress driven to .receiving with recordsReceivedThisSession=1234")
     case .sidebarFooterSending:
       lines.append("# SyncProgress driven to .upToDate with pendingUploads=12 then settled")
+    case .cryptoCatalogPreloaded:
+      appendCryptoCatalogPreloadedFixtures(into: &lines)
     }
     return lines.joined(separator: "\n") + "\n"
+  }
+
+  private func appendCryptoCatalogPreloadedFixtures(into lines: inout [String]) {
+    let fixtures = UITestFixtures.CryptoCatalogPreloaded.self
+    lines.append("# fixtures (CloudKit profile reused from TradeBaseline)")
+    lines.append("profile.id      = \(fixtures.profileId)")
+    lines.append("profile.label   = \(fixtures.profileLabel)")
+    lines.append("profile.currency = \(fixtures.profileCurrencyCode)")
+    lines.append("# Catalog override: PreloadedCryptoCatalog (single coin)")
+    lines.append("catalog.coingeckoId = \(fixtures.coingeckoId)")
+    lines.append("catalog.symbol      = \(fixtures.symbol)")
+    lines.append("catalog.name        = \(fixtures.name)")
+    lines.append("catalog.chainSlug   = \(fixtures.chainSlug)")
+    lines.append("catalog.chainId     = \(fixtures.chainId)")
+    lines.append("catalog.contract    = \(fixtures.contractAddress)")
+    lines.append("instrument.id       = \(fixtures.instrumentId)")
+    lines.append("# Resolution stub: PreloadedTokenResolutionClient")
+    lines.append("resolve.coingeckoId        = \(fixtures.coingeckoMappingId)")
+    lines.append("resolve.cryptocompareSymbol = \(fixtures.cryptocompareSymbol)")
+    lines.append("resolve.binanceSymbol      = \(fixtures.binanceSymbol)")
   }
 
   private func appendTradeBaselineFixtures(into lines: inout [String]) {

--- a/MoolahUITests_macOS/Helpers/Screens/AddTokenScreen.swift
+++ b/MoolahUITests_macOS/Helpers/Screens/AddTokenScreen.swift
@@ -17,11 +17,14 @@ struct AddTokenScreen {
 
   // MARK: - Actions
 
-  /// Types `query` into the picker's search field. Returns once the search
-  /// field has been clicked and the text has been typed; the row-appearance
-  /// post-condition is delegated to `waitForResult(instrumentId:)` so a
-  /// caller types the prefix and then waits for the specific row, mirroring
-  /// the user's perception ("type, see, click").
+  /// Types `query` into the picker's search field. Waits for the typed
+  /// value to propagate into the field's accessibility `value` before
+  /// returning so any subsequent `waitForResult(instrumentId:)` call sees
+  /// the search debounce fire against the intended query, not against an
+  /// empty string. The row-appearance post-condition itself is delegated
+  /// to `waitForResult(instrumentId:)` so a caller types the prefix and
+  /// then waits for the specific row, mirroring the user's perception
+  /// ("type, see, click").
   func search(_ query: String) {
     Trace.record(#function, detail: "query=\(query)")
     let field = app.element(for: UITestIdentifiers.InstrumentPicker.searchField)
@@ -32,6 +35,15 @@ struct AddTokenScreen {
     }
     field.click()
     field.typeText(query)
+    let valuePropagated = XCTNSPredicateExpectation(
+      predicate: NSPredicate(format: "value == %@", query as CVarArg),
+      object: field
+    )
+    if XCTWaiter().wait(for: [valuePropagated], timeout: 5) != .completed {
+      Trace.recordFailure(
+        "instrumentPicker.searchField value did not reach '\(query)' after typeText")
+      XCTFail("Search field did not show typed value '\(query)'")
+    }
   }
 
   /// Waits up to `timeout` seconds for the picker row whose Instrument id
@@ -54,6 +66,12 @@ struct AddTokenScreen {
   /// `InstrumentPickerStore.select(_:)` and the `isResolving` overlay), so
   /// the dismissal post-condition is exposed as a separate
   /// `waitForDismiss()` action that the caller invokes when ready.
+  ///
+  /// After the click we wait for the row to stop being hittable as a
+  /// minimal post-condition that the click registered: either the sheet
+  /// dismisses (success path — `waitForDismiss()` covers that) or the
+  /// `isResolving` overlay disables the row while the network round-trip
+  /// runs.
   func selectResult(instrumentId: String) {
     Trace.record(#function, detail: "instrumentId=\(instrumentId)")
     let row = app.element(for: UITestIdentifiers.InstrumentPicker.row(instrumentId))
@@ -65,6 +83,12 @@ struct AddTokenScreen {
       return
     }
     row.click()
+    let consumed = XCTNSPredicateExpectation(
+      predicate: NSPredicate(format: "exists == false || isHittable == false"),
+      object: row
+    )
+    _ = XCTWaiter().wait(for: [consumed], timeout: 5)
+    // Note: dismissal (success path) is the responsibility of waitForDismiss().
   }
 
   /// Waits for the picker sheet to dismiss, by polling the sentinel

--- a/MoolahUITests_macOS/Helpers/Screens/AddTokenScreen.swift
+++ b/MoolahUITests_macOS/Helpers/Screens/AddTokenScreen.swift
@@ -1,0 +1,89 @@
+import XCTest
+
+/// Driver for the `AddTokenSheet`'s embedded `InstrumentPickerSheet` filtered
+/// to crypto tokens. Returned via `MoolahApp.addToken` once the sheet has
+/// been opened from the Crypto Settings tab.
+///
+/// The sheet itself is the standard `InstrumentPickerSheet`, so its
+/// `instrumentPicker.searchField` and `instrumentPicker.row.<id>`
+/// identifiers (defined in `UITestIdentifiers.InstrumentPicker`) are reused
+/// here verbatim.
+///
+/// Action methods start with `Trace.record(#function)` and wait for a real
+/// post-condition before returning — see `guides/UI_TEST_GUIDE.md` §3.
+@MainActor
+struct AddTokenScreen {
+  let app: MoolahApp
+
+  // MARK: - Actions
+
+  /// Types `query` into the picker's search field. Returns once the search
+  /// field has been clicked and the text has been typed; the row-appearance
+  /// post-condition is delegated to `waitForResult(instrumentId:)` so a
+  /// caller types the prefix and then waits for the specific row, mirroring
+  /// the user's perception ("type, see, click").
+  func search(_ query: String) {
+    Trace.record(#function, detail: "query=\(query)")
+    let field = app.element(for: UITestIdentifiers.InstrumentPicker.searchField)
+    if !field.waitForExistence(timeout: 3) {
+      Trace.recordFailure("instrumentPicker.searchField did not appear")
+      XCTFail("AddTokenSheet search field did not appear within 3s")
+      return
+    }
+    field.click()
+    field.typeText(query)
+  }
+
+  /// Waits up to `timeout` seconds for the picker row whose Instrument id
+  /// matches `instrumentId` to appear. The catalog's debounce + async
+  /// search lookup means this post-condition is the right gate for "the
+  /// user can now click the row I want".
+  func waitForResult(instrumentId: String, timeout: TimeInterval = 5) {
+    Trace.record(#function, detail: "instrumentId=\(instrumentId)")
+    let row = app.element(for: UITestIdentifiers.InstrumentPicker.row(instrumentId))
+    if !row.waitForExistence(timeout: timeout) {
+      Trace.recordFailure(
+        "instrumentPicker.row.\(instrumentId) did not appear within \(timeout)s")
+      XCTFail(
+        "Picker row for '\(instrumentId)' did not appear within \(timeout)s of search")
+    }
+  }
+
+  /// Clicks the row for `instrumentId`. Does NOT wait for sheet dismissal —
+  /// the resolution + registration is async (see
+  /// `InstrumentPickerStore.select(_:)` and the `isResolving` overlay), so
+  /// the dismissal post-condition is exposed as a separate
+  /// `waitForDismiss()` action that the caller invokes when ready.
+  func selectResult(instrumentId: String) {
+    Trace.record(#function, detail: "instrumentId=\(instrumentId)")
+    let row = app.element(for: UITestIdentifiers.InstrumentPicker.row(instrumentId))
+    if !row.waitForExistence(timeout: 3) {
+      Trace.recordFailure(
+        "instrumentPicker.row.\(instrumentId) not found for selection")
+      XCTFail(
+        "Picker row for '\(instrumentId)' did not appear within 3s of selectResult")
+      return
+    }
+    row.click()
+  }
+
+  /// Waits for the picker sheet to dismiss, by polling the sentinel
+  /// `instrumentPicker.sheet` identifier. The sheet stays up while the
+  /// store's `isResolving` overlay is active (network round-trip in
+  /// `TokenResolutionClient.resolve()` and the registry write); a clean
+  /// dismissal proves both completed successfully.
+  func waitForDismiss(timeout: TimeInterval = 5) {
+    Trace.record(#function)
+    let sheet = app.element(for: UITestIdentifiers.InstrumentPicker.sheet)
+    let expectation = XCTNSPredicateExpectation(
+      predicate: NSPredicate(format: "exists == false"),
+      object: sheet
+    )
+    if XCTWaiter().wait(for: [expectation], timeout: timeout) != .completed {
+      Trace.recordFailure(
+        "instrumentPicker.sheet still visible after \(timeout)s — resolve/register stalled")
+      XCTFail(
+        "AddTokenSheet did not dismiss within \(timeout)s of selectResult")
+    }
+  }
+}

--- a/MoolahUITests_macOS/Helpers/Screens/CryptoSettingsScreen.swift
+++ b/MoolahUITests_macOS/Helpers/Screens/CryptoSettingsScreen.swift
@@ -1,0 +1,52 @@
+import XCTest
+
+/// Driver for the Crypto tab of the macOS Settings scene
+/// (`CryptoSettingsView`). Returned from `MoolahApp.cryptoSettings` or via
+/// `SettingsScreen.openCryptoTab()` (after which this screen's root
+/// container is guaranteed to be visible).
+///
+/// Action methods open the embedded `AddTokenSheet` and read the
+/// registrations list; the picker that the sheet hosts has its own driver
+/// (`AddTokenScreen`).
+@MainActor
+struct CryptoSettingsScreen {
+  let app: MoolahApp
+
+  // MARK: - Actions
+
+  /// Taps the "+" button in the Registered Tokens header to present the
+  /// `AddTokenSheet`. Returns once the picker sheet's sentinel
+  /// (`instrumentPicker.sheet`) appears in the accessibility tree.
+  func tapAddToken() {
+    Trace.record(#function)
+    let button = app.element(for: UITestIdentifiers.CryptoSettings.addTokenButton)
+    if !button.waitForExistence(timeout: 3) {
+      Trace.recordFailure("crypto.settings.addToken button did not appear")
+      XCTFail("Add Token button did not appear within 3s")
+      return
+    }
+    button.click()
+    let sheet = app.element(for: UITestIdentifiers.InstrumentPicker.sheet)
+    if !sheet.waitForExistence(timeout: 3) {
+      Trace.recordFailure("instrumentPicker.sheet did not appear after Add Token tap")
+      XCTFail("AddTokenSheet picker did not appear within 3s of tapping +")
+    }
+  }
+
+  /// Waits for the registration row whose Instrument id matches
+  /// `instrumentId` to appear in the registered-tokens list. The
+  /// CryptoTokenStore reloads registrations on the picker's
+  /// `onRegistered` callback, so this is the post-condition the
+  /// end-to-end test asserts.
+  func waitForRegistration(instrumentId: String, timeout: TimeInterval = 5) {
+    Trace.record(#function, detail: "instrumentId=\(instrumentId)")
+    let row = app.element(
+      for: UITestIdentifiers.CryptoSettings.registrationRow(instrumentId))
+    if !row.waitForExistence(timeout: timeout) {
+      Trace.recordFailure(
+        "crypto.settings.registration.\(instrumentId) did not appear within \(timeout)s")
+      XCTFail(
+        "Crypto registration row for '\(instrumentId)' did not appear within \(timeout)s")
+    }
+  }
+}

--- a/MoolahUITests_macOS/Helpers/Screens/SettingsScreen.swift
+++ b/MoolahUITests_macOS/Helpers/Screens/SettingsScreen.swift
@@ -1,0 +1,52 @@
+import XCTest
+
+/// Driver for the macOS Settings scene. Returned from `MoolahApp.settings`.
+///
+/// The Settings scene is opened via the system Cmd+, shortcut and presents
+/// a `TabView` containing the Profiles, Crypto, Import, and Rules tabs.
+/// Each tab is rendered as a toolbar button labelled with its tab title;
+/// tab content drivers hang off this screen (e.g. `openCryptoTab()`).
+///
+/// Each action method starts with `Trace.record(#function)` and waits for
+/// a real post-condition before returning — see
+/// `guides/UI_TEST_GUIDE.md` §3 (driver invariants).
+@MainActor
+struct SettingsScreen {
+  let app: MoolahApp
+
+  // MARK: - Actions
+
+  /// Opens the Settings scene via the system Cmd+, shortcut and waits
+  /// until the Settings window's tab toolbar is visible. The toolbar's
+  /// "Crypto" tab button is the post-condition because every UI-testing
+  /// launch we exercise has a CloudKit profile active, so the Crypto tab
+  /// is always present in this scene.
+  func open() {
+    Trace.record(#function)
+    app.pressKeyboardShortcut(",", modifiers: .command)
+    let cryptoTab = app.application.toolbars.buttons["Crypto"]
+    if !cryptoTab.waitForExistence(timeout: 5) {
+      Trace.recordFailure("Settings 'Crypto' tab toolbar button did not appear")
+      XCTFail("Settings window did not appear within 5s of Cmd+,")
+    }
+  }
+
+  /// Switches the Settings TabView to the Crypto tab and waits for the
+  /// `CryptoSettingsView`'s root container to appear in the accessibility
+  /// tree.
+  func openCryptoTab() {
+    Trace.record(#function)
+    let tab = app.application.toolbars.buttons["Crypto"]
+    if !tab.waitForExistence(timeout: 3) {
+      Trace.recordFailure("Settings 'Crypto' tab toolbar button did not appear")
+      XCTFail("Crypto tab toolbar button did not appear within 3s")
+      return
+    }
+    tab.click()
+    let container = app.element(for: UITestIdentifiers.CryptoSettings.container)
+    if !container.waitForExistence(timeout: 3) {
+      Trace.recordFailure("crypto.settings.container did not appear after tab click")
+      XCTFail("CryptoSettingsView container did not appear within 3s of tab click")
+    }
+  }
+}

--- a/MoolahUITests_macOS/Helpers/Screens/SettingsScreen.swift
+++ b/MoolahUITests_macOS/Helpers/Screens/SettingsScreen.swift
@@ -17,16 +17,22 @@ struct SettingsScreen {
   // MARK: - Actions
 
   /// Opens the Settings scene via the system Cmd+, shortcut and waits
-  /// until the Settings window's tab toolbar is visible. The toolbar's
-  /// "Crypto" tab button is the post-condition because every UI-testing
-  /// launch we exercise has a CloudKit profile active, so the Crypto tab
-  /// is always present in this scene.
+  /// until the Settings window's tab toolbar is visible. The Crypto tab
+  /// button is the post-condition because every UI-testing launch we
+  /// exercise has a CloudKit profile active, so the Crypto tab is always
+  /// present in this scene.
+  ///
+  /// The lookup matches by accessibility label (the tab's title) because
+  /// SwiftUI's `Tab` on macOS does not propagate
+  /// `.accessibilityIdentifier(_:)` to the generated toolbar button. The
+  /// label string lives in `UITestIdentifiers.Settings.cryptoTabTitle` so
+  /// the production view and this driver share one source of truth.
   func open() {
     Trace.record(#function)
     app.pressKeyboardShortcut(",", modifiers: .command)
-    let cryptoTab = app.application.toolbars.buttons["Crypto"]
+    let cryptoTab = cryptoTabButton
     if !cryptoTab.waitForExistence(timeout: 5) {
-      Trace.recordFailure("Settings 'Crypto' tab toolbar button did not appear")
+      Trace.recordFailure("Settings Crypto tab toolbar button did not appear")
       XCTFail("Settings window did not appear within 5s of Cmd+,")
     }
   }
@@ -36,9 +42,9 @@ struct SettingsScreen {
   /// tree.
   func openCryptoTab() {
     Trace.record(#function)
-    let tab = app.application.toolbars.buttons["Crypto"]
+    let tab = cryptoTabButton
     if !tab.waitForExistence(timeout: 3) {
-      Trace.recordFailure("Settings 'Crypto' tab toolbar button did not appear")
+      Trace.recordFailure("Settings Crypto tab toolbar button did not appear")
       XCTFail("Crypto tab toolbar button did not appear within 3s")
       return
     }
@@ -48,5 +54,16 @@ struct SettingsScreen {
       Trace.recordFailure("crypto.settings.container did not appear after tab click")
       XCTFail("CryptoSettingsView container did not appear within 3s of tab click")
     }
+  }
+
+  // MARK: - Helpers
+
+  /// The Settings TabView's Crypto tab toolbar button, located by its
+  /// accessibility label (the title of the `Tab`). See `open()` for why
+  /// this driver uses label matching rather than `app.element(for:)`.
+  /// The lookup routes through `MoolahApp.toolbarButton(label:)` so the
+  /// single-resolver invariant (UI_TEST_GUIDE §3 #5) is preserved.
+  private var cryptoTabButton: XCUIElement {
+    app.toolbarButton(label: UITestIdentifiers.Settings.cryptoTabTitle)
   }
 }

--- a/MoolahUITests_macOS/Tests/InstrumentPickerCryptoSearchTests.swift
+++ b/MoolahUITests_macOS/Tests/InstrumentPickerCryptoSearchTests.swift
@@ -1,0 +1,38 @@
+import XCTest
+
+/// Happy-path UI test for the crypto-token registration flow:
+///   Settings → Crypto → "+" Add Token → search → select → registered.
+///
+/// Reaches every layer that a store test cannot exercise on its own:
+/// the macOS Settings scene's Cmd+, presentation, the TabView tab switch,
+/// the `AddTokenSheet`'s `InstrumentPickerSheet` host, the resolve+register
+/// overlay/dismissal handshake (`InstrumentPickerStore.isResolving`), and
+/// the `CryptoTokenStore.loadRegistrations` reload that surfaces the new
+/// registration row. See `guides/UI_TEST_GUIDE.md` §1 for why this earns
+/// a UI test slot.
+///
+/// The `cryptoCatalogPreloaded` seed installs a deterministic catalog with
+/// a single Uniswap entry and a stubbed `TokenResolutionClient` so the
+/// flow runs without disk or network access — see
+/// `App/UITestSeedCryptoOverrides.swift`.
+@MainActor
+final class InstrumentPickerCryptoSearchTests: MoolahUITestCase {
+  /// Registering a crypto token by searching the picker for "uni",
+  /// selecting the Uniswap row, and confirming the registration appears
+  /// back in the Crypto Settings list.
+  func testRegisterCryptoTokenViaPickerSearch() {
+    let app = launch(seed: .cryptoCatalogPreloaded)
+
+    app.settings.open()
+    app.settings.openCryptoTab()
+    app.cryptoSettings.tapAddToken()
+
+    let instrumentId = UITestFixtures.CryptoCatalogPreloaded.instrumentId
+    app.addToken.search("uni")
+    app.addToken.waitForResult(instrumentId: instrumentId)
+    app.addToken.selectResult(instrumentId: instrumentId)
+    app.addToken.waitForDismiss()
+
+    app.cryptoSettings.waitForRegistration(instrumentId: instrumentId)
+  }
+}

--- a/UITestSupport/UITestIdentifiers.swift
+++ b/UITestSupport/UITestIdentifiers.swift
@@ -138,6 +138,19 @@ public enum UITestIdentifiers {
     }
   }
 
+  public enum Settings {
+    /// Title of the Crypto tab in the macOS Settings TabView. SwiftUI's
+    /// `Tab` does not propagate `.accessibilityIdentifier(_:)` to the
+    /// generated toolbar button on macOS, so drivers locate the button
+    /// by its accessibility label (which mirrors the tab's title) rather
+    /// than by an identifier. Centralising the title here keeps the
+    /// driver free of raw English literals — the production view and the
+    /// driver both reference this constant. If/when `Tab` accessibility
+    /// identifiers ship on macOS, swap the screen driver to
+    /// `app.element(for:)` and switch this to an identifier value.
+    public static let cryptoTabTitle = "Crypto"
+  }
+
   public enum CryptoSettings {
     /// Root container of the `CryptoSettingsView` Form. Sentinel for the
     /// "Crypto tab is on screen" post-condition after switching tabs in the

--- a/UITestSupport/UITestIdentifiers.swift
+++ b/UITestSupport/UITestIdentifiers.swift
@@ -138,6 +138,25 @@ public enum UITestIdentifiers {
     }
   }
 
+  public enum CryptoSettings {
+    /// Root container of the `CryptoSettingsView` Form. Sentinel for the
+    /// "Crypto tab is on screen" post-condition after switching tabs in the
+    /// macOS Settings window.
+    public static let container = "crypto.settings.container"
+
+    /// "+" toolbar button in the Crypto tab header that opens
+    /// `AddTokenSheet`. Tapping it presents the embedded
+    /// `InstrumentPickerSheet` filtered to crypto tokens.
+    public static let addTokenButton = "crypto.settings.addToken"
+
+    /// A row in the registered-tokens list. The qualifier is the
+    /// `CryptoRegistration.id`, which is the Instrument id (e.g.
+    /// `1:0x1f9840…f984`).
+    public static func registrationRow(_ id: String) -> String {
+      "crypto.settings.registration.\(id)"
+    }
+  }
+
   public enum Autocomplete {
     /// Container element of the payee autocomplete dropdown.
     public static let payee = "autocomplete.payee"

--- a/UITestSupport/UITestSeed.swift
+++ b/UITestSupport/UITestSeed.swift
@@ -50,6 +50,16 @@ public enum UITestSeed: String, CaseIterable, Sendable {
 
   /// Drives `SyncProgress` into `.sending` with `pendingUploads = 12`.
   case sidebarFooterSending
+
+  /// CloudKit-backed profile (same shape as `tradeBaseline`) plus a
+  /// deterministic crypto-token catalogue and resolution stub installed
+  /// in place of the live `SQLiteCoinGeckoCatalog` /
+  /// `CompositeTokenResolutionClient`. The catalogue contains exactly one
+  /// row (Uniswap, ethereum chainId 1) and the stub resolver returns the
+  /// matching `(coingeckoId, cryptocompareSymbol, binanceSymbol)` triple.
+  /// Drives the Settings → Crypto → Add Token end-to-end test without
+  /// touching the network.
+  case cryptoCatalogPreloaded
 }
 
 /// Fixtures for the first-run Welcome seeds. Defined here so both the
@@ -196,5 +206,46 @@ public enum UITestFixtures {
         categoryId: groceriesCategoryId
       ),
     ]
+  }
+
+  /// Fixtures for the `.cryptoCatalogPreloaded` seed.
+  ///
+  /// Entities (all fixed, deterministic):
+  ///   - Profile `personal` — same UUID/label/currency as `TradeBaseline`,
+  ///     CloudKit-backed (a CryptoTokenStore is only built for CloudKit
+  ///     profiles; the Crypto Settings tab is otherwise hidden).
+  ///   - Catalog: a single coin "Uniswap" (UNI) with one platform binding
+  ///     `(slug=ethereum, chainId=1, contractAddress=0x1F98…F984)`. The
+  ///     contract address is lower-cased by `Instrument.crypto(...)` so the
+  ///     resulting Instrument id is
+  ///     `1:0x1f9840a85d5af5bf1d1762f925bdaddc4201f984`.
+  ///   - Resolution result: the deterministic
+  ///     `(coingeckoId="uniswap", cryptocompareSymbol="UNI",
+  ///     binanceSymbol="UNIUSDT")` triple returned by the stubbed
+  ///     `TokenResolutionClient` for the matching `(chainId, contract)`.
+  public enum CryptoCatalogPreloaded {
+    public static let profileId = UITestFixtures.TradeBaseline.profileId
+    public static let profileLabel = UITestFixtures.TradeBaseline.profileLabel
+    public static let profileCurrencyCode = UITestFixtures.TradeBaseline.profileCurrencyCode
+
+    /// The single coin in the catalog snapshot.
+    public static let coingeckoId = "uniswap"
+    public static let symbol = "UNI"
+    public static let name = "Uniswap"
+    public static let chainSlug = "ethereum"
+    public static let chainId = 1
+    /// Mixed-case as in the design spec; lower-cased by `Instrument.crypto`
+    /// when the Instrument id is built.
+    public static let contractAddress = "0x1F9840a85d5aF5bf1D1762F925BDADdC4201F984"
+
+    /// The Instrument id the registered token will carry — built from the
+    /// chainId + lower-cased contract address.
+    public static let instrumentId = "1:0x1f9840a85d5af5bf1d1762f925bdaddc4201f984"
+
+    /// Provider IDs the stubbed `TokenResolutionClient` returns for the
+    /// matching `(chainId, contract)` pair.
+    public static let coingeckoMappingId = "uniswap"
+    public static let cryptocompareSymbol = "UNI"
+    public static let binanceSymbol = "UNIUSDT"
   }
 }

--- a/UITestSupport/UITestSeed.swift
+++ b/UITestSupport/UITestSeed.swift
@@ -58,7 +58,10 @@ public enum UITestSeed: String, CaseIterable, Sendable {
   /// row (Uniswap, ethereum chainId 1) and the stub resolver returns the
   /// matching `(coingeckoId, cryptocompareSymbol, binanceSymbol)` triple.
   /// Drives the Settings → Crypto → Add Token end-to-end test without
-  /// touching the network.
+  /// touching the network. See `UITestFixtures.CryptoCatalogPreloaded` for
+  /// the complete fixture (instrumentId, chainId, contractAddress, provider
+  /// IDs) so the `seed.txt` artefact reader can resolve every reference
+  /// without cross-file lookup.
   case cryptoCatalogPreloaded
 }
 


### PR DESCRIPTION
## Summary

**Task 16 (final task)** of the [instrument-registry UI plan](https://github.com/ajsutton/moolah-native/blob/main/plans/2026-04-27-instrument-registry-ui-implementation.md) (resolves #461). End-to-end XCUITest covering the full flow built by Tasks 1–15: open Settings → Crypto → Add Token, search "uni", select Uniswap, confirm registration appears.

- **Test:** `MoolahUITests_macOS/Tests/InstrumentPickerCryptoSearchTests.swift` — single happy-path test, imports only XCTest, all interactions through screen drivers.
- **Screen drivers:** `MoolahUITests_macOS/Helpers/Screens/{Settings,CryptoSettings,AddToken}Screen.swift` (new) — every action wraps in `Trace.record`, every wait is bounded via `XCUIElement.waitForExistence(timeout:)` or `XCTNSPredicateExpectation`, every lookup goes through `MoolahApp.element(for:)` (single-resolver invariant) or its sibling `MoolahApp.toolbarButton(label:)` for the macOS Tab case.
- **Production seed-bridge:** `App/UITestSeedCryptoOverrides.swift` (new dispatcher), `App/PreloadedCryptoCatalog.swift` (new), `App/PreloadedTokenResolutionClient.swift` (new) — substitute deterministic stubs for `CoinGeckoCatalog` and `TokenResolutionClient`. Strictly gated on `--ui-testing` + `UI_TESTING_SEED == cryptoCatalogPreloaded`. Production builds reach the existing `makeCoinGeckoCatalog()` + `CompositeTokenResolutionClient` path unchanged.
- **New seed:** `cryptoCatalogPreloaded` in `UITestSupport/UITestSeed.swift`. Fixture data lives in `UITestFixtures.CryptoCatalogPreloaded`.
- **New identifiers:** `UITestIdentifiers.Settings.cryptoTabTitle` and `UITestIdentifiers.CryptoSettings.{container, addTokenButton, registrationRow(_:)}` — every interactive element accessed by the test has a typed identifier; no inline string literals in drivers.

Two rounds of review feedback applied (commit `0ae8b8c`):
- **Critical** (UI_TEST_GUIDE invariants 4 + 5): `SettingsScreen` no longer reaches `app.application.toolbars` directly with a raw "Crypto" string. Routes through `MoolahApp.toolbarButton(label:)` with a typed constant. (SwiftUI's `Tab` on macOS doesn't propagate `.accessibilityIdentifier` to the generated toolbar button — confirmed via the failure artefact `tree.txt` — so the constant doubles as the accessibility-label seed and the resolver query.)
- **Important**: `AddTokenScreen.search` and `selectResult` now have post-condition waits (typed value propagated; click was registered).
- **Important** (CODE_GUIDE §2): `UITestSeedCryptoOverrides.swift` split into three files (one primary type each).
- **Minor**: `cryptoCatalogPreloaded` seed comment cross-references `UITestFixtures.CryptoCatalogPreloaded`. `// MARK:` section headers added to `ProfileSession+Factories.swift`. Verified `instrumentPicker.{sheet,searchField}` identifiers present on `Shared/Views/InstrumentPickerSheetCore.swift`.

The Critical fix triggered a `type_body_length` violation on `SettingsView`; resolved structurally by extracting the macOS layout to `Features/Settings/SettingsView+macOS.swift` (mirroring the existing `+iOS` pattern). No baseline change.

Follows [#545](https://github.com/ajsutton/moolah-native/pull/545) (Task 12: sync fan-out — merged).

## Test plan

- [x] `just test-ui InstrumentPickerCryptoSearchTests` passes 1/1 on `MoolahUITests_macOS` (~22s).
- [x] Adjacent unit-test regressions: `InstrumentPickerStoreTests`, `InstrumentPickerStoreCryptoSelectTests`, `ProfileSessionTests`, `ProfileSessionCatalogIntegrationTests`, `CryptoTokenStoreTests` — 40/40 pass.
- [x] Smoke regression on existing `InstrumentPickerUITests`: 1/1 pass.
- [x] `just format-check` clean.
- [x] `swiftlint lint` reports 0 violations on changed files.
- [x] No `.swiftlint-baseline.yml` change.
- [x] Production seed-bridge gating verified: stubs only activate when `--ui-testing` is on the command line AND `UI_TESTING_SEED == cryptoCatalogPreloaded`.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)