### PR TITLE
refactor(catalog): polish doc-comments and extract hasAnyProviderId

### DIFF
--- a/App/ProfileSession+Factories.swift
+++ b/App/ProfileSession+Factories.swift
@@ -124,7 +124,7 @@ extension ProfileSession {
 
   /// Bundle of the optional instrument-registry pieces: only CloudKit
   /// profiles expose a registry, crypto token store, search service,
-  /// CoinGecko catalogue, and token resolution client. Remote/moolah
+  /// CoinGecko catalog, and token resolution client. Remote/moolah
   /// profiles are single-instrument by server design and leave all five nil.
   struct RegistryWiring {
     let registry: (any InstrumentRegistryRepository)?
@@ -142,11 +142,11 @@ extension ProfileSession {
   /// `refreshIfStale()` once per session on a background task so the on-disk
   /// snapshot honours the 24 h max-age + ETag guards without blocking
   /// session init. A catalog construction failure (e.g. the SQLite file
-  /// can't be opened) is logged and the catalogue is left `nil` — search
+  /// can't be opened) is logged and the catalog is left `nil` — search
   /// degrades to the registry/Yahoo paths only.
   ///
   /// Under `--ui-testing` the active `UITestSeed` may register fake
-  /// catalogue/resolver implementations via
+  /// catalog/resolver implementations via
   /// `UITestSeedCryptoOverrides.overrides(for:)` — those replace the live
   /// SQLite snapshot and `CompositeTokenResolutionClient` so the picker
   /// flow runs deterministically without disk or network access.
@@ -190,7 +190,7 @@ extension ProfileSession {
     )
   }
 
-  /// Returns the catalogue/resolver overrides for the active UI test seed,
+  /// Returns the catalog/resolver overrides for the active UI test seed,
   /// or `nil` for production launches. Reads the same arguments and
   /// environment variable that `MoolahApp+Setup.uiTestingSeed(from:)`
   /// consumes during app init — keeping the gating consistent between the
@@ -206,7 +206,7 @@ extension ProfileSession {
     return UITestSeedCryptoOverrides.overrides(for: seed)
   }
 
-  /// Builds the per-profile CoinGecko catalogue and kicks off a background
+  /// Builds the per-profile CoinGecko catalog and kicks off a background
   /// `refreshIfStale()` so the SQLite snapshot is brought up to date once per
   /// session without blocking init. Returns `nil` (and logs) when the
   /// SQLite file can't be opened — the caller treats that as a degraded

--- a/Domain/Repositories/TokenResolutionClient.swift
+++ b/Domain/Repositories/TokenResolutionClient.swift
@@ -17,3 +17,12 @@ protocol TokenResolutionClient: Sendable {
     chainId: Int, contractAddress: String?, symbol: String?, isNative: Bool
   ) async throws -> TokenResolutionResult
 }
+
+extension TokenResolutionResult {
+  /// Whether at least one provider produced a usable identifier. The
+  /// instrument-picker registers crypto only when this is `true`; otherwise
+  /// the user sees "Could not find a price source for this token."
+  var hasAnyProviderId: Bool {
+    coingeckoId != nil || cryptocompareSymbol != nil || binanceSymbol != nil
+  }
+}

--- a/Shared/InstrumentPickerStore.swift
+++ b/Shared/InstrumentPickerStore.swift
@@ -119,7 +119,7 @@ final class InstrumentPickerStore {
         symbol: instrument.ticker,
         isNative: isNative
       )
-      guard hasAnyProviderId(resolution) else {
+      guard resolution.hasAnyProviderId else {
         self.error = "Could not find a price source for this token."
         return nil
       }
@@ -136,12 +136,6 @@ final class InstrumentPickerStore {
       self.error = "Couldn't add \(instrument.displayLabel)."
       return nil
     }
-  }
-
-  private func hasAnyProviderId(_ resolution: TokenResolutionResult) -> Bool {
-    resolution.coingeckoId != nil
-      || resolution.cryptocompareSymbol != nil
-      || resolution.binanceSymbol != nil
   }
 
   private func runSearch() async {


### PR DESCRIPTION
## Summary

Two review-feedback nits deferred during the instrument-registry UI plan ([#461](https://github.com/ajsutton/moolah-native/issues/461)):

1. **\`catalogue\` → \`catalog\` across 4 doc-comments.** The codebase identifiers are consistently American (\`CoinGeckoCatalog\`, \`CoinGeckoCatalogSchema\`, \`coinGeckoCatalog\`) but doc text had drifted to British \`catalogue\` in 4 places.
2. **Move \`hasAnyProviderId\` from \`InstrumentPickerStore\` private helper to a \`TokenResolutionResult\` extension.** The check (at-least-one provider produced an id) is a property of the result value, not the picker. The new extension promotes reuse if \`InstrumentSearchService\` (or any future caller) ever needs the same predicate.

## Test plan

- [x] \`just test InstrumentPickerStoreCryptoSelectTests\` passes (the test that exercises the all-nil refusal path through this predicate).
- [x] \`just format-check\` clean.
- [x] No \`.swiftlint-baseline.yml\` change.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)