### PR TITLE
fix(transactions): preserve category on Enter-then-Tab (#509)

### DIFF
--- a/Features/Transactions/Views/Detail/TransactionDetailCategoryOverlay.swift
+++ b/Features/Transactions/Views/Detail/TransactionDetailCategoryOverlay.swift
@@ -33,7 +33,6 @@ struct TransactionDetailCategoryOverlay: View {
 
   private func select(_ selected: CategorySuggestion) {
     state.dismiss()
-    draft.categoryId = selected.id
-    draft.categoryText = selected.path
+    draft.commitCategorySelection(id: selected.id, path: selected.path)
   }
 }

--- a/Features/Transactions/Views/Detail/TransactionDetailCategorySection.swift
+++ b/Features/Transactions/Views/Detail/TransactionDetailCategorySection.swift
@@ -80,7 +80,6 @@ struct TransactionDetailCategorySection: View {
     }
     let selected = visibleSuggestions[index]
     state.dismiss()
-    draft.categoryId = selected.id
-    draft.categoryText = selected.path
+    draft.commitCategorySelection(id: selected.id, path: selected.path)
   }
 }

--- a/Features/Transactions/Views/Detail/TransactionDetailLegCategoryOverlay.swift
+++ b/Features/Transactions/Views/Detail/TransactionDetailLegCategoryOverlay.swift
@@ -58,7 +58,6 @@ struct TransactionDetailLegCategoryOverlay: View {
     var state = legStates[index] ?? CategoryAutocompleteState()
     state.dismiss()
     legStates[index] = state
-    draft.legDrafts[index].categoryId = selected.id
-    draft.legDrafts[index].categoryText = selected.path
+    draft.commitLegCategorySelection(at: index, id: selected.id, path: selected.path)
   }
 }

--- a/Features/Transactions/Views/Detail/TransactionDetailLegRow.swift
+++ b/Features/Transactions/Views/Detail/TransactionDetailLegRow.swift
@@ -190,7 +190,6 @@ struct TransactionDetailLegRow: View {
     else { return }
     let selected = visibleSuggestions[highlighted]
     categoryState.dismiss()
-    draft.legDrafts[index].categoryId = selected.id
-    draft.legDrafts[index].categoryText = selected.path
+    draft.commitLegCategorySelection(at: index, id: selected.id, path: selected.path)
   }
 }

--- a/MoolahTests/Shared/TransactionDraftCategoryTests.swift
+++ b/MoolahTests/Shared/TransactionDraftCategoryTests.swift
@@ -126,4 +126,41 @@ struct TransactionDraftCategoryTests {
     #expect(draft.legDrafts[0].categoryId == nil)
     #expect(draft.legDrafts[0].categoryText.isEmpty)
   }
+
+  // Per https://github.com/ajsutton/moolah-native/issues/509 reopening:
+  // `commitCategorySelection(id:path:)` must set both fields in a single
+  // mutation so call sites doing `draft.commitCategorySelection(...)`
+  // through a `@Binding` produce one read-modify-write rather than two
+  // snapshot-based writes that clobber each other.
+  // swiftlint:disable:next attributes
+  @Test func commitCategorySelectionSetsBothFields() {
+    let catId = UUID()
+
+    var draft = support.makeExpenseDraft()
+    draft.categoryId = nil
+    draft.categoryText = "groc"
+
+    draft.commitCategorySelection(id: catId, path: "Groceries")
+
+    #expect(draft.categoryId == catId)
+    #expect(draft.categoryText == "Groceries")
+  }
+
+  // Per-leg counterpart to `commitCategorySelectionSetsBothFields` —
+  // the per-leg call sites in `TransactionDetailLegRow` and
+  // `TransactionDetailLegCategoryOverlay` rely on the single-mutation
+  // guarantee.
+  // swiftlint:disable:next attributes
+  @Test func commitLegCategorySelectionSetsBothFieldsAtIndex() {
+    let catId = UUID()
+
+    var draft = support.makeExpenseDraft()
+    draft.legDrafts[0].categoryId = nil
+    draft.legDrafts[0].categoryText = "gym"
+
+    draft.commitLegCategorySelection(at: 0, id: catId, path: "Gym")
+
+    #expect(draft.legDrafts[0].categoryId == catId)
+    #expect(draft.legDrafts[0].categoryText == "Gym")
+  }
 }

--- a/MoolahUITests_macOS/Tests/TransactionDetail/TransactionDetailCategoryTests.swift
+++ b/MoolahUITests_macOS/Tests/TransactionDetail/TransactionDetailCategoryTests.swift
@@ -31,4 +31,32 @@ final class TransactionDetailCategoryTests: MoolahUITestCase {
     app.transactionDetail.category.expectValue("Groceries")
     app.transactionDetail.category.expectSuggestionsHidden()
   }
+
+  /// Regression for [#509](https://github.com/ajsutton/moolah-native/issues/509)
+  /// reopening: pressing Enter to commit the highlighted suggestion and then
+  /// Tabbing to the next field must keep the committed value. The original
+  /// fix only handled the "Tab without Enter" path; this case (Enter then Tab)
+  /// was still clearing the field because the blur handler renormalised
+  /// against a category text that had been just-set, found a stale
+  /// resolution, and cleared.
+  func testEnterThenTabPreservesCommittedCategory() {
+    let app = launch(seed: .tradeBaseline)
+
+    app.sidebar.switchToAccount(.checking)
+    app.transactionList.openTransaction(.bhpPurchase)
+
+    app.transactionDetail.category.tap()
+    app.transactionDetail.category.type("Gro")
+    app.transactionDetail.category.expectSuggestionsVisible(count: 1)
+    app.transactionDetail.category.pressArrowDown()
+    app.transactionDetail.category.expectHighlightedSuggestion(at: 0)
+
+    app.transactionDetail.category.pressEnter()
+    app.transactionDetail.category.expectValue("Groceries")
+
+    app.transactionDetail.category.pressTab()
+
+    app.transactionDetail.category.expectValue("Groceries")
+    app.transactionDetail.category.expectSuggestionsHidden()
+  }
 }

--- a/Shared/Models/TransactionDraft+SimpleMode.swift
+++ b/Shared/Models/TransactionDraft+SimpleMode.swift
@@ -107,8 +107,7 @@ extension TransactionDraft {
     highlighted: CategorySuggestion?, using categories: Categories
   ) {
     if let highlighted {
-      categoryId = highlighted.id
-      categoryText = highlighted.path
+      commitCategorySelection(id: highlighted.id, path: highlighted.path)
     } else {
       normaliseCategoryText(using: categories)
     }
@@ -120,11 +119,31 @@ extension TransactionDraft {
     at index: Int, highlighted: CategorySuggestion?, using categories: Categories
   ) {
     if let highlighted {
-      legDrafts[index].categoryId = highlighted.id
-      legDrafts[index].categoryText = highlighted.path
+      commitLegCategorySelection(at: index, id: highlighted.id, path: highlighted.path)
     } else {
       normaliseLegCategoryText(at: index, using: categories)
     }
+  }
+
+  /// Sets the simple-mode category id and display path in a single
+  /// mutation. Must be a single mutating method (not two separate
+  /// `categoryId = …; categoryText = …` writes through a `@Binding`):
+  /// SwiftUI snapshots the source between consecutive binding writes, so
+  /// the second write is built from a snapshot taken before the first
+  /// landed and clobbers it. With two writes, `categoryId` would silently
+  /// revert to nil, then `normaliseCategoryText(using:)` on the next blur
+  /// would clear the field — the reopening of #509 reported by the user
+  /// after the original Tab-without-Enter fix.
+  mutating func commitCategorySelection(id: UUID, path: String) {
+    categoryId = id
+    categoryText = path
+  }
+
+  /// Per-leg variant of `commitCategorySelection(id:path:)`. See that
+  /// method's note for why a single mutating call is required.
+  mutating func commitLegCategorySelection(at index: Int, id: UUID, path: String) {
+    legDrafts[index].categoryId = id
+    legDrafts[index].categoryText = path
   }
 
   /// Whether the "other account" label should read "From Account" instead of "To Account".


### PR DESCRIPTION
## Summary

- Reopens [#509](https://github.com/ajsutton/moolah-native/issues/509) — typing a prefix → ↓ → Enter → Tab cleared the category field, even though the previous fix (Tab without Enter) still works.
- Root cause: two consecutive binding writes (`draft.categoryId = …; draft.categoryText = …`) on the same `@State` source. SwiftUI snapshots the source between writes, so the second write is built from a snapshot taken before the first landed and clobbers `categoryId` back to nil. On the next blur, `normaliseCategoryText` sees the nil id and clears the typed text.
- Fix: introduce `commitCategorySelection(id:path:)` and `commitLegCategorySelection(at:id:path:)` on `TransactionDraft`. A single `mutating` method invoked through a `@Binding` produces one read-modify-write, side-stepping the snapshot race. All four call sites (simple-mode Enter, simple-mode dropdown click, per-leg Enter, per-leg dropdown click) route through these methods.

Fixes #509

## Test plan

- [x] New UI test `testEnterThenTabPreservesCommittedCategory` — types prefix, arrow-keys to highlight, presses Enter, presses Tab; asserts the field still shows "Groceries". Fails on `main`, passes with this change.
- [x] New unit tests `commitCategorySelectionSetsBothFields` and `commitLegCategorySelectionSetsBothFieldsAtIndex` pin the both-fields-in-one-call contract on `TransactionDraft`.
- [x] Existing `testTabFromHighlightedCategoryCommitsSuggestion` (Tab without Enter) and the `commitHighlighted…` unit tests still pass.
- [x] Full `just test` (1738 unit tests) and `just test-ui` pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)