### PR TITLE
build: add GRDB.swift via SwiftPM (Step 1)

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -58,6 +58,14 @@ fileGroups:
   - justfile
   - project.yml
 
+packages:
+  GRDB:
+    url: https://github.com/groue/GRDB.swift
+    # Pinned to an exact version. Moolah.xcodeproj is gitignored, so
+    # Package.resolved isn't tracked; pinning here is the substitute.
+    # Bump deliberately when we want to take a new release.
+    exactVersion: 7.10.0
+
 targets:
   Moolah_iOS:
     type: application
@@ -74,6 +82,7 @@ targets:
       - path: UITestSupport
     dependencies:
       - sdk: AppIntents.framework
+      - package: GRDB
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: rocks.moolah.app
@@ -116,6 +125,7 @@ targets:
       - path: UITestSupport
     dependencies:
       - sdk: AppIntents.framework
+      - package: GRDB
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: rocks.moolah.app
@@ -152,6 +162,7 @@ targets:
         BUNDLE_LOADER: "$(TEST_HOST)"
     dependencies:
       - target: Moolah_iOS
+      - package: GRDB
 
   MoolahTests_macOS:
     type: bundle.unit-test
@@ -170,6 +181,7 @@ targets:
         BUNDLE_LOADER: "$(TEST_HOST)"
     dependencies:
       - target: Moolah_macOS
+      - package: GRDB
 
   MoolahBenchmarks_macOS:
     type: bundle.unit-test
@@ -189,6 +201,7 @@ targets:
         BUNDLE_LOADER: "$(TEST_HOST)"
     dependencies:
       - target: Moolah_macOS
+      - package: GRDB
 
   MoolahUITests_macOS:
     type: bundle.ui-testing


### PR DESCRIPTION
## Summary

Step 1 of the GRDB migration roadmap in [`plans/grdb-migration.md`](https://github.com/ajsutton/moolah-native/blob/main/plans/grdb-migration.md) — pure dependency addition, no runtime change.

- Adds [groue/GRDB.swift](https://github.com/groue/GRDB.swift) **7.10.0** to the project's SwiftPM packages.
- Pins to an exact version (`exactVersion: 7.10.0`). Rationale: \`Moolah.xcodeproj\` is gitignored so \`Package.resolved\` isn't tracked; pinning in \`project.yml\` is the substitute. Bumps are deliberate.
- Wires the package as a dependency on \`Moolah_iOS\`, \`Moolah_macOS\`, \`MoolahTests_iOS\`, \`MoolahTests_macOS\`, and \`MoolahBenchmarks_macOS\` (UITests target doesn't need it).
- Nothing imports GRDB yet; this PR strictly enables the next steps.

### Note on \`InferSendableFromCaptures\`

The PR-555 \`DATABASE_CODE_GUIDE.md\` recommended enabling the \`InferSendableFromCaptures\` upcoming feature. It turns out the project's \`SWIFT_VERSION: "6.0"\` already enables this by default ([SE-0418](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0418-inferring-sendable-for-methods.md)) — adding the flag now produces \`error: upcoming feature 'InferSendableFromCaptures' is already enabled as of Swift version 6\`. The guide will get a fix-up PR after #555 lands; no \`OTHER_SWIFT_FLAGS\` change in this PR.

## Test plan

- [x] \`just generate\` succeeds with the new package wired in.
- [x] \`just build-mac\` ✅ BUILD SUCCEEDED
- [x] \`just build-ios\` ✅ BUILD SUCCEEDED
- [x] No tracked files outside \`project.yml\` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)