### PR TITLE
refactor(rates): persist FX/stock/crypto caches in per-profile GRDB SQLite

### DIFF
--- a/App/MoolahApp+Lifecycle.swift
+++ b/App/MoolahApp+Lifecycle.swift
@@ -11,10 +11,23 @@ extension MoolahApp {
     switch newPhase {
     case .background:
       flushPendingChanges()
+      runPragmaOptimizeOnAllSessions()
     case .active:
       Task { await fetchRemoteChanges() }
     default:
       break
+    }
+  }
+
+  /// Per `guides/DATABASE_SCHEMA_GUIDE.md` §5, the recommended cadence for
+  /// `PRAGMA optimize` is "once on app resign-active". Iterates the open
+  /// profile sessions and dispatches a best-effort optimize on each. The
+  /// hourly-while-active tick is a follow-up — current rate-cache schemas
+  /// are small enough that once-per-resign suffices.
+  func runPragmaOptimizeOnAllSessions() {
+    let sessions = sessionManager.openProfiles
+    for session in sessions {
+      Task { await session.runPragmaOptimize() }
     }
   }
 

--- a/App/MoolahApp+Lifecycle.swift
+++ b/App/MoolahApp+Lifecycle.swift
@@ -20,14 +20,15 @@ extension MoolahApp {
   }
 
   /// Per `guides/DATABASE_SCHEMA_GUIDE.md` §5, the recommended cadence for
-  /// `PRAGMA optimize` is "once on app resign-active". Iterates the open
-  /// profile sessions and dispatches a best-effort optimize on each. The
-  /// hourly-while-active tick is a follow-up — current rate-cache schemas
-  /// are small enough that once-per-resign suffices.
+  /// `PRAGMA optimize` is "once on app resign-active". Asks each open
+  /// session to schedule its own tracked optimize task — the session
+  /// stores the handle and cancels it on teardown, so this loop never
+  /// leaks fire-and-forget Tasks. The hourly-while-active tick is a
+  /// follow-up — current rate-cache schemas are small enough that
+  /// once-per-resign suffices.
   func runPragmaOptimizeOnAllSessions() {
-    let sessions = sessionManager.openProfiles
-    for session in sessions {
-      Task { await session.runPragmaOptimize() }
+    for session in sessionManager.openProfiles {
+      session.schedulePragmaOptimize()
     }
   }
 

--- a/App/MoolahApp+Setup.swift
+++ b/App/MoolahApp+Setup.swift
@@ -206,12 +206,26 @@ extension MoolahApp {
   static func cleanupLegacyRateCachesOnce(defaults: UserDefaults = .standard) {
     let key = "v2.rates.cache.cleared"
     guard !defaults.bool(forKey: key) else { return }
+    let logger = Logger(subsystem: "com.moolah.app", category: "LegacyCacheCleanup")
     if let caches = FileManager.default
       .urls(for: .cachesDirectory, in: .userDomainMask)
       .first
     {
+      let fileManager = FileManager.default
       for sub in ["exchange-rates", "stock-prices", "crypto-prices"] {
-        try? FileManager.default.removeItem(at: caches.appendingPathComponent(sub))
+        let url = caches.appendingPathComponent(sub)
+        do {
+          try fileManager.removeItem(at: url)
+        } catch let error as NSError
+          where error.domain == NSCocoaErrorDomain
+          && error.code == NSFileNoSuchFileError
+        {
+          // Already absent (e.g. fresh install or prior partial cleanup) — fine.
+        } catch {
+          logger.warning(
+            "Failed to delete legacy rate cache \(sub, privacy: .public): \(error.localizedDescription, privacy: .public)"
+          )
+        }
       }
     }
     defaults.set(true, forKey: key)

--- a/App/MoolahApp+Setup.swift
+++ b/App/MoolahApp+Setup.swift
@@ -198,9 +198,13 @@ extension MoolahApp {
   /// the `v2.rates.cache.cleared` `UserDefaults` flag so it runs at most
   /// once per install. Best-effort — failures are silent and the rate
   /// services repopulate from network on demand.
-  static func cleanupLegacyRateCachesOnce() {
+  ///
+  /// `defaults` is injected with a `.standard` default so production callers
+  /// pass nothing while tests can supply an isolated suite — satisfies the
+  /// `CODE_GUIDE.md` §17 "no direct singleton access" rule without
+  /// inventing a wrapper type for a single call site.
+  static func cleanupLegacyRateCachesOnce(defaults: UserDefaults = .standard) {
     let key = "v2.rates.cache.cleared"
-    let defaults = UserDefaults.standard
     guard !defaults.bool(forKey: key) else { return }
     if let caches = FileManager.default
       .urls(for: .cachesDirectory, in: .userDomainMask)

--- a/App/MoolahApp+Setup.swift
+++ b/App/MoolahApp+Setup.swift
@@ -192,4 +192,24 @@ extension MoolahApp {
       AutomationServiceLocator.shared.service = automationService
     #endif
   }
+
+  /// One-shot cleanup: removes the legacy gzipped JSON rate caches that
+  /// shipped before rate persistence moved to per-profile SQLite. Gated by
+  /// the `v2.rates.cache.cleared` `UserDefaults` flag so it runs at most
+  /// once per install. Best-effort — failures are silent and the rate
+  /// services repopulate from network on demand.
+  static func cleanupLegacyRateCachesOnce() {
+    let key = "v2.rates.cache.cleared"
+    let defaults = UserDefaults.standard
+    guard !defaults.bool(forKey: key) else { return }
+    if let caches = FileManager.default
+      .urls(for: .cachesDirectory, in: .userDomainMask)
+      .first
+    {
+      for sub in ["exchange-rates", "stock-prices", "crypto-prices"] {
+        try? FileManager.default.removeItem(at: caches.appendingPathComponent(sub))
+      }
+    }
+    defaults.set(true, forKey: key)
+  }
 }

--- a/App/MoolahApp.swift
+++ b/App/MoolahApp.swift
@@ -57,6 +57,14 @@ struct MoolahApp: App {
     // shaped storage (in-memory `CloudKitBackend`) so XCUITest flows never
     // touch the user's iCloud. See guides/UI_TEST_GUIDE.md §6.
     let uiTestingSeed = Self.uiTestingSeed(from: CommandLine.arguments)
+
+    // One-shot removal of the legacy `Caches/{exchange,stock,crypto}` JSON
+    // cache directories now that rate caches live in per-profile SQLite.
+    // Skipped under UI testing where `Caches` is shared with the host
+    // user's account and we must not mutate it.
+    if uiTestingSeed == nil {
+      Self.cleanupLegacyRateCachesOnce()
+    }
     let setup = Self.makeContainerSetup(uiTestingSeed: uiTestingSeed)
     let coordinator = SyncCoordinator(containerManager: setup.manager)
     containerManager = setup.manager

--- a/App/MoolahApp.swift
+++ b/App/MoolahApp.swift
@@ -37,10 +37,14 @@ struct MoolahApp: App {
   #if os(macOS)
     @NSApplicationDelegateAdaptor(ScriptingBridge.self) var scriptingBridge
     private let backupManager: StoreBackupManager
-    @State private var sessionManager: SessionManager
+    // internal so `+Lifecycle` can iterate open sessions for
+    // `PRAGMA optimize` on resign-active.
+    @State var sessionManager: SessionManager
   #else
     @State private var activeSession: ProfileSession?
-    @State private var sessionManager: SessionManager
+    // internal so `+Lifecycle` can iterate open sessions for
+    // `PRAGMA optimize` on resign-active.
+    @State var sessionManager: SessionManager
   #endif
 
   init() {

--- a/App/ProfileSession+Factories.swift
+++ b/App/ProfileSession+Factories.swift
@@ -104,12 +104,17 @@ extension ProfileSession {
   /// crypto token store, search service, CoinGecko catalog, and token
   /// resolution client. Populated for CloudKit profiles; nil fields indicate
   /// a degraded state (e.g. catalog init failure).
+  ///
+  /// `catalogRefreshTask` carries the once-per-session
+  /// `refreshIfStale()` background task so `ProfileSession` can store and
+  /// cancel it on teardown. `nil` when catalog construction failed.
   struct RegistryWiring {
     let registry: (any InstrumentRegistryRepository)?
     let cryptoTokenStore: CryptoTokenStore?
     let searchService: InstrumentSearchService?
     let coinGeckoCatalog: (any CoinGeckoCatalog)?
     let tokenResolutionClient: (any TokenResolutionClient)?
+    let catalogRefreshTask: Task<Void, Never>?
   }
 
   /// Resolves the instrument-registry wiring for a CloudKit profile. Returns
@@ -140,12 +145,16 @@ extension ProfileSession {
     }
 
     let catalog: (any CoinGeckoCatalog)?
+    let refreshTask: Task<Void, Never>?
     let resolutionClient: any TokenResolutionClient
     if let overrides = uiTestingCryptoOverrides() {
       catalog = overrides.catalog
+      refreshTask = nil
       resolutionClient = overrides.resolutionClient
     } else {
-      catalog = makeCoinGeckoCatalog()
+      let made = makeCoinGeckoCatalog()
+      catalog = made.catalog
+      refreshTask = made.refreshTask
       resolutionClient = CompositeTokenResolutionClient(coinGeckoApiKey: coinGeckoApiKey)
     }
     let store = CryptoTokenStore(
@@ -162,7 +171,8 @@ extension ProfileSession {
       cryptoTokenStore: store,
       searchService: searchService,
       coinGeckoCatalog: catalog,
-      tokenResolutionClient: resolutionClient
+      tokenResolutionClient: resolutionClient,
+      catalogRefreshTask: refreshTask
     )
   }
 
@@ -184,23 +194,26 @@ extension ProfileSession {
 
   /// Builds the per-profile CoinGecko catalog and kicks off a background
   /// `refreshIfStale()` so the SQLite snapshot is brought up to date once per
-  /// session without blocking init. Returns `nil` (and logs) when the
+  /// session without blocking init. Returns `(nil, nil)` (and logs) when the
   /// SQLite file can't be opened — the caller treats that as a degraded
-  /// search path.
+  /// search path. The returned `refreshTask` handle is stored on
+  /// `ProfileSession` so it can be cancelled on teardown.
   @MainActor
-  private static func makeCoinGeckoCatalog() -> (any CoinGeckoCatalog)? {
+  private static func makeCoinGeckoCatalog()
+    -> (catalog: (any CoinGeckoCatalog)?, refreshTask: Task<Void, Never>?)
+  {
     let directory = URL.moolahScopedApplicationSupport
       .appending(path: "InstrumentRegistry", directoryHint: .isDirectory)
     do {
       let catalog = try SQLiteCoinGeckoCatalog(directory: directory)
-      Task(priority: .background) { [catalog] in
+      let refreshTask = Task(priority: .background) { [catalog] in
         await catalog.refreshIfStale()
       }
-      return catalog
+      return (catalog, refreshTask)
     } catch {
       Logger(subsystem: "com.moolah.app", category: "ProfileSession")
         .error("CoinGecko catalog init failed: \(error.localizedDescription, privacy: .public)")
-      return nil
+      return (nil, nil)
     }
   }
 

--- a/App/ProfileSession+Factories.swift
+++ b/App/ProfileSession+Factories.swift
@@ -2,6 +2,7 @@
 
 import CloudKit
 import Foundation
+import GRDB
 import OSLog
 import SwiftData
 
@@ -22,17 +23,19 @@ extension ProfileSession {
 
   /// Builds the fiat/stock/crypto market-data services used throughout the
   /// profile session. Standalone helper so `ProfileSession.init` can build
-  /// and assign the trio in one step.
-  static func makeMarketDataServices() -> MarketDataServices {
+  /// and assign the trio in one step. Each rate service persists to the
+  /// supplied per-profile `database`.
+  static func makeMarketDataServices(database: any DatabaseWriter) -> MarketDataServices {
     let yahooClient = YahooFinanceClient()
     let apiKeyStore = KeychainStore(
       service: "com.moolah.api-keys", account: "coingecko", synchronizable: true
     )
     let coinGeckoApiKey = try? apiKeyStore.restoreString()
     return MarketDataServices(
-      exchangeRate: ExchangeRateService(client: FrankfurterClient()),
-      stockPrice: StockPriceService(client: yahooClient),
-      cryptoPrice: Self.makeCryptoPriceService(coinGeckoApiKey: coinGeckoApiKey),
+      exchangeRate: ExchangeRateService(client: FrankfurterClient(), database: database),
+      stockPrice: StockPriceService(client: yahooClient, database: database),
+      cryptoPrice: Self.makeCryptoPriceService(
+        coinGeckoApiKey: coinGeckoApiKey, database: database),
       yahooPriceFetcher: yahooClient,
       coinGeckoApiKey: coinGeckoApiKey
     )
@@ -42,7 +45,8 @@ extension ProfileSession {
   /// (CoinGecko when an API key is present in the keychain, plus
   /// CryptoCompare and Binance as fallbacks) and the token resolver.
   static func makeCryptoPriceService(
-    coinGeckoApiKey: String?
+    coinGeckoApiKey: String?,
+    database: any DatabaseWriter
   ) -> CryptoPriceService {
     let cryptoCompareClient = CryptoCompareClient()
     let binanceClient = BinanceClient { date in
@@ -66,6 +70,7 @@ extension ProfileSession {
 
     return CryptoPriceService(
       clients: priceClients,
+      database: database,
       resolutionClient: CompositeTokenResolutionClient(coinGeckoApiKey: coinGeckoApiKey)
     )
   }
@@ -77,9 +82,8 @@ extension ProfileSession {
     profile: Profile,
     containerManager: ProfileContainerManager?,
     syncCoordinator: SyncCoordinator? = nil,
-    exchangeRates: ExchangeRateService,
-    stockPrices: StockPriceService,
-    cryptoPrices: CryptoPriceService
+    services: MarketDataServices,
+    database: any DatabaseWriter
   ) -> BackendProvider {
     guard let containerManager else {
       fatalError("ProfileContainerManager is required for CloudKit profiles")
@@ -89,9 +93,9 @@ extension ProfileSession {
       containerManager: containerManager,
       syncCoordinator: syncCoordinator,
       marketData: CloudKitMarketDataServices(
-        exchangeRates: exchangeRates,
-        stockPrices: stockPrices,
-        cryptoPrices: cryptoPrices))
+        exchangeRates: services.exchangeRate,
+        stockPrices: services.stockPrice,
+        cryptoPrices: services.cryptoPrice))
   }
 
   // MARK: - Registry Wiring
@@ -257,110 +261,4 @@ extension ProfileSession {
     )
   }
 
-  // MARK: - Import Pipeline
-
-  /// Bundle of the full CSV import pipeline: the `ImportStore`, the import-rule
-  /// store, and the three folder-watch pieces. Returned from `makeImportPipeline`
-  /// so `ProfileSession.init` can assign all five fields in one step.
-  struct ImportPipeline {
-    let importStore: ImportStore
-    let importRuleStore: ImportRuleStore
-    let preferences: ImportPreferences
-    let scanner: FolderScanService
-    let watcher: FolderWatchService
-  }
-
-  /// Builds the complete CSV import pipeline for a profile: staging store,
-  /// import rules, folder watch, and wires the delete-after-import default
-  /// closure into `ImportStore` before returning.
-  static func makeImportPipeline(
-    backend: BackendProvider,
-    profileId: UUID,
-    logger: Logger
-  ) -> ImportPipeline {
-    let stagingDirectory = ProfileSession.importStagingDirectory(for: profileId)
-    let importStore = Self.makeImportStore(
-      backend: backend,
-      stagingDirectory: stagingDirectory,
-      profileId: profileId,
-      logger: logger
-    )
-    let importRuleStore = ImportRuleStore(repository: backend.importRules)
-    let folderWatch = Self.makeFolderWatch(
-      stagingDirectory: stagingDirectory,
-      profileId: profileId,
-      importStore: importStore
-    )
-    importStore.folderWatchDeleteAfterImport = { [preferences = folderWatch.preferences] in
-      preferences.deleteAfterImportFolderDefault
-    }
-    return ImportPipeline(
-      importStore: importStore,
-      importRuleStore: importRuleStore,
-      preferences: folderWatch.preferences,
-      scanner: folderWatch.scanner,
-      watcher: folderWatch.watcher
-    )
-  }
-
-  // MARK: - Folder Watch Services
-
-  /// Bundle of the services that make up folder-watch ingestion for a
-  /// profile: the on-disk `ImportPreferences`, the catch-up `FolderScanService`,
-  /// and the live `FolderWatchService`. Returned from `makeFolderWatch` so
-  /// `ProfileSession.init` can assign each field in one step.
-  struct FolderWatchServices {
-    let preferences: ImportPreferences
-    let scanner: FolderScanService
-    let watcher: FolderWatchService
-  }
-
-  /// Builds the folder-watch bundle for a profile. `stagingDirectory` is the
-  /// per-profile CSV staging directory; preferences live in its parent so
-  /// they survive staging-store recreation.
-  static func makeFolderWatch(
-    stagingDirectory: URL,
-    profileId: UUID,
-    importStore: ImportStore
-  ) -> FolderWatchServices {
-    let preferencesDirectory = stagingDirectory.deletingLastPathComponent()
-    let preferences = ImportPreferences(directory: preferencesDirectory)
-    let scanner = FolderScanService(
-      profileId: profileId,
-      importStore: importStore,
-      preferences: preferences)
-    let watcher = FolderWatchService(
-      importStore: importStore,
-      preferences: preferences,
-      scanner: scanner)
-    return FolderWatchServices(preferences: preferences, scanner: scanner, watcher: watcher)
-  }
-
-  /// Opens the per-profile CSV import staging store. Falls back to a scratch
-  /// directory in the tmp dir (which cannot fail in practice on Apple
-  /// platforms) if the real directory can't be opened, so the pipeline
-  /// remains functional in the degraded mode.
-  static func makeImportStore(
-    backend: BackendProvider,
-    stagingDirectory: URL,
-    profileId: UUID,
-    logger: Logger
-  ) -> ImportStore {
-    do {
-      let staging = try ImportStagingStore(directory: stagingDirectory)
-      return ImportStore(backend: backend, staging: staging)
-    } catch {
-      let fallback = FileManager.default.temporaryDirectory
-        .appendingPathComponent("csv-staging-fallback-\(profileId.uuidString)")
-      // Fallback in a tmp dir cannot fail in practice on Apple platforms.
-      // swiftlint:disable:next force_try
-      let staging = try! ImportStagingStore(directory: fallback)
-      let errDesc = error.localizedDescription
-      let stagingPath = stagingDirectory.path
-      logger.error(
-        "Failed to open CSV import staging at \(stagingPath, privacy: .public): \(errDesc, privacy: .public). Falling back to tmp."
-      )
-      return ImportStore(backend: backend, staging: staging)
-    }
-  }
 }

--- a/App/ProfileSession+Factories.swift
+++ b/App/ProfileSession+Factories.swift
@@ -206,7 +206,11 @@ extension ProfileSession {
       .appending(path: "InstrumentRegistry", directoryHint: .isDirectory)
     do {
       let catalog = try SQLiteCoinGeckoCatalog(directory: directory)
-      let refreshTask = Task(priority: .background) { [catalog] in
+      // `Task.detached` rather than `Task { ... }` so the long-running
+      // network/disk work in `refreshIfStale()` doesn't inherit the
+      // caller's `@MainActor` isolation. `SQLiteCoinGeckoCatalog` is an
+      // actor (and `CoinGeckoCatalog: Sendable`), so this is safe.
+      let refreshTask = Task.detached(priority: .background) { [catalog] in
         await catalog.refreshIfStale()
       }
       return (catalog, refreshTask)

--- a/App/ProfileSession+Factories.swift
+++ b/App/ProfileSession+Factories.swift
@@ -206,11 +206,10 @@ extension ProfileSession {
       .appending(path: "InstrumentRegistry", directoryHint: .isDirectory)
     do {
       let catalog = try SQLiteCoinGeckoCatalog(directory: directory)
-      // `Task.detached` rather than `Task { ... }` so the long-running
-      // network/disk work in `refreshIfStale()` doesn't inherit the
-      // caller's `@MainActor` isolation. `SQLiteCoinGeckoCatalog` is an
-      // actor (and `CoinGeckoCatalog: Sendable`), so this is safe.
-      let refreshTask = Task.detached(priority: .background) { [catalog] in
+      // `SQLiteCoinGeckoCatalog` is an actor, so `await catalog.refreshIfStale()`
+      // hops to the catalog's executor regardless of the enclosing Task's
+      // isolation — no `Task.detached` needed (CONCURRENCY_GUIDE §8).
+      let refreshTask = Task(priority: .background) { [catalog] in
         await catalog.refreshIfStale()
       }
       return (catalog, refreshTask)

--- a/App/ProfileSession+Imports.swift
+++ b/App/ProfileSession+Imports.swift
@@ -1,0 +1,111 @@
+import Foundation
+import OSLog
+
+extension ProfileSession {
+  // MARK: - Import Pipeline
+
+  /// Bundle of the full CSV import pipeline: the `ImportStore`, the import-rule
+  /// store, and the three folder-watch pieces. Returned from `makeImportPipeline`
+  /// so `ProfileSession.init` can assign all five fields in one step.
+  struct ImportPipeline {
+    let importStore: ImportStore
+    let importRuleStore: ImportRuleStore
+    let preferences: ImportPreferences
+    let scanner: FolderScanService
+    let watcher: FolderWatchService
+  }
+
+  /// Builds the complete CSV import pipeline for a profile: staging store,
+  /// import rules, folder watch, and wires the delete-after-import default
+  /// closure into `ImportStore` before returning.
+  static func makeImportPipeline(
+    backend: BackendProvider,
+    profileId: UUID,
+    logger: Logger
+  ) -> ImportPipeline {
+    let stagingDirectory = ProfileSession.importStagingDirectory(for: profileId)
+    let importStore = Self.makeImportStore(
+      backend: backend,
+      stagingDirectory: stagingDirectory,
+      profileId: profileId,
+      logger: logger
+    )
+    let importRuleStore = ImportRuleStore(repository: backend.importRules)
+    let folderWatch = Self.makeFolderWatch(
+      stagingDirectory: stagingDirectory,
+      profileId: profileId,
+      importStore: importStore
+    )
+    importStore.folderWatchDeleteAfterImport = { [preferences = folderWatch.preferences] in
+      preferences.deleteAfterImportFolderDefault
+    }
+    return ImportPipeline(
+      importStore: importStore,
+      importRuleStore: importRuleStore,
+      preferences: folderWatch.preferences,
+      scanner: folderWatch.scanner,
+      watcher: folderWatch.watcher
+    )
+  }
+
+  // MARK: - Folder Watch Services
+
+  /// Bundle of the services that make up folder-watch ingestion for a
+  /// profile: the on-disk `ImportPreferences`, the catch-up `FolderScanService`,
+  /// and the live `FolderWatchService`. Returned from `makeFolderWatch` so
+  /// `ProfileSession.init` can assign each field in one step.
+  struct FolderWatchServices {
+    let preferences: ImportPreferences
+    let scanner: FolderScanService
+    let watcher: FolderWatchService
+  }
+
+  /// Builds the folder-watch bundle for a profile. `stagingDirectory` is the
+  /// per-profile CSV staging directory; preferences live in its parent so
+  /// they survive staging-store recreation.
+  static func makeFolderWatch(
+    stagingDirectory: URL,
+    profileId: UUID,
+    importStore: ImportStore
+  ) -> FolderWatchServices {
+    let preferencesDirectory = stagingDirectory.deletingLastPathComponent()
+    let preferences = ImportPreferences(directory: preferencesDirectory)
+    let scanner = FolderScanService(
+      profileId: profileId,
+      importStore: importStore,
+      preferences: preferences)
+    let watcher = FolderWatchService(
+      importStore: importStore,
+      preferences: preferences,
+      scanner: scanner)
+    return FolderWatchServices(preferences: preferences, scanner: scanner, watcher: watcher)
+  }
+
+  /// Opens the per-profile CSV import staging store. Falls back to a scratch
+  /// directory in the tmp dir (which cannot fail in practice on Apple
+  /// platforms) if the real directory can't be opened, so the pipeline
+  /// remains functional in the degraded mode.
+  static func makeImportStore(
+    backend: BackendProvider,
+    stagingDirectory: URL,
+    profileId: UUID,
+    logger: Logger
+  ) -> ImportStore {
+    do {
+      let staging = try ImportStagingStore(directory: stagingDirectory)
+      return ImportStore(backend: backend, staging: staging)
+    } catch {
+      let fallback = FileManager.default.temporaryDirectory
+        .appendingPathComponent("csv-staging-fallback-\(profileId.uuidString)")
+      // Fallback in a tmp dir cannot fail in practice on Apple platforms.
+      // swiftlint:disable:next force_try
+      let staging = try! ImportStagingStore(directory: fallback)
+      let errDesc = error.localizedDescription
+      let stagingPath = stagingDirectory.path
+      logger.error(
+        "Failed to open CSV import staging at \(stagingPath, privacy: .public): \(errDesc, privacy: .public). Falling back to tmp."
+      )
+      return ImportStore(backend: backend, staging: staging)
+    }
+  }
+}

--- a/App/ProfileSession.swift
+++ b/App/ProfileSession.swift
@@ -60,6 +60,12 @@ final class ProfileSession: Identifiable {
   /// `cleanupSync(coordinator:)` if the session is torn down before the
   /// refresh completes.
   private var catalogRefreshTask: Task<Void, Never>?
+  /// Background task handle for the most recent `PRAGMA optimize` kick-off.
+  /// Tracked so we can cancel any pending optimize on session teardown
+  /// (per `guides/CONCURRENCY_GUIDE.md` §8 — fire-and-forget tasks must
+  /// be tracked). Replaced (with cancellation of the prior handle) on
+  /// each call to `schedulePragmaOptimize()`.
+  private var pragmaOptimizeTask: Task<Void, Never>?
 
   /// Synchronous initialiser — opens the per-profile GRDB queue and runs
   /// pending migrations on the calling thread. The migrator currently only
@@ -226,6 +232,8 @@ final class ProfileSession: Identifiable {
     syncReloadTask = nil
     catalogRefreshTask?.cancel()
     catalogRefreshTask = nil
+    pragmaOptimizeTask?.cancel()
+    pragmaOptimizeTask = nil
   }
 
   // MARK: - Folder watch
@@ -258,16 +266,34 @@ final class ProfileSession: Identifiable {
   /// hook is wired by `MoolahApp+Lifecycle.handleScenePhaseChange`; the
   /// hourly-while-active tick is a follow-up — for now profile DBs are
   /// small enough that the once-per-resign cadence suffices.
+  ///
+  /// Runs inside `database.write` because `PRAGMA optimize` may invoke
+  /// `ANALYZE` and update the `sqlite_stat1` / `sqlite_stat4` tables — a
+  /// read-only transaction would either silently no-op the analyze step
+  /// or surface a write-from-read error.
   func runPragmaOptimize() async {
     let database = self.database
     do {
-      try await database.read { database in
+      try await database.write { database in
         try database.execute(sql: "PRAGMA optimize")
       }
     } catch {
       logger.warning(
         "PRAGMA optimize failed for profile \(self.profile.id): \(error.localizedDescription, privacy: .public)"
       )
+    }
+  }
+
+  /// Schedules a best-effort `PRAGMA optimize` on a tracked background
+  /// task. Cancels any prior pending optimize before scheduling so we
+  /// never run two concurrently for the same session, and leaves the
+  /// handle in `pragmaOptimizeTask` so `cleanupSync` can cancel it on
+  /// teardown (per `guides/CONCURRENCY_GUIDE.md` §8 — fire-and-forget
+  /// tasks must be tracked).
+  func schedulePragmaOptimize() {
+    pragmaOptimizeTask?.cancel()
+    pragmaOptimizeTask = Task { [weak self] in
+      await self?.runPragmaOptimize()
     }
   }
 

--- a/App/ProfileSession.swift
+++ b/App/ProfileSession.swift
@@ -14,7 +14,10 @@ final class ProfileSession: Identifiable {
   /// (or an in-memory queue under previews / tests). Released when the
   /// session deinits; on profile delete the parent `profiles/<id>/`
   /// directory is removed by `ProfileContainerManager.deleteStore`.
-  let database: DatabaseQueue
+  ///
+  /// Private: external consumers go through repositories and the rate
+  /// services rather than poking the queue directly.
+  private let database: DatabaseQueue
   let backend: BackendProvider
   let authStore: AuthStore
   let accountStore: AccountStore
@@ -52,7 +55,19 @@ final class ProfileSession: Identifiable {
   private var syncReloadTask: Task<Void, Never>?
   private var pendingChangedTypes = Set<String>()
   private var lastSyncEventTime: ContinuousClock.Instant?
+  /// Background task handle for the once-per-session CoinGecko
+  /// `refreshIfStale()` kick-off. Tracked so it can be cancelled in
+  /// `cleanupSync(coordinator:)` if the session is torn down before the
+  /// refresh completes.
+  private var catalogRefreshTask: Task<Void, Never>?
 
+  /// Synchronous initialiser — opens the per-profile GRDB queue and runs
+  /// pending migrations on the calling thread. The migrator currently only
+  /// creates the rate-cache tables (microseconds for fresh databases, no
+  /// disk reads on subsequent opens once the migration is recorded), so
+  /// running on `@MainActor` is acceptable for now. Revisit if profile-DB
+  /// schemas grow large enough that `migrate(_:)` does meaningful work
+  /// each launch — see `guides/CONCURRENCY_GUIDE.md` §1.
   init(
     profile: Profile,
     containerManager: ProfileContainerManager? = nil,
@@ -90,6 +105,7 @@ final class ProfileSession: Identifiable {
     self.instrumentSearchService = registryWiring.searchService
     self.coinGeckoCatalog = registryWiring.coinGeckoCatalog
     self.tokenResolutionClient = registryWiring.tokenResolutionClient
+    self.catalogRefreshTask = registryWiring.catalogRefreshTask
     let stores = Self.makeDomainStores(profile: profile, backend: backend)
     self.authStore = stores.auth
     self.accountStore = stores.account
@@ -208,6 +224,8 @@ final class ProfileSession: Identifiable {
     coordinator.removeInstrumentRemoteChangeCallback(profileId: profile.id)
     syncReloadTask?.cancel()
     syncReloadTask = nil
+    catalogRefreshTask?.cancel()
+    catalogRefreshTask = nil
   }
 
   // MARK: - Folder watch
@@ -229,6 +247,28 @@ final class ProfileSession: Identifiable {
   /// watch isn't available.
   func scanWatchedFolder() async {
     await folderScanner.scanForNewFiles()
+  }
+
+  // MARK: - Database maintenance
+
+  /// Runs `PRAGMA optimize` on the per-profile DB. Best-effort: failures
+  /// are logged but never propagated. Per
+  /// `guides/DATABASE_SCHEMA_GUIDE.md` §5, the recommended cadence is once
+  /// on app resign-active and at most hourly while active. The on-resign
+  /// hook is wired by `MoolahApp+Lifecycle.handleScenePhaseChange`; the
+  /// hourly-while-active tick is a follow-up — for now profile DBs are
+  /// small enough that the once-per-resign cadence suffices.
+  func runPragmaOptimize() async {
+    let database = self.database
+    do {
+      try await database.read { database in
+        try database.execute(sql: "PRAGMA optimize")
+      }
+    } catch {
+      logger.warning(
+        "PRAGMA optimize failed for profile \(self.profile.id): \(error.localizedDescription, privacy: .public)"
+      )
+    }
   }
 
   /// Per-profile directory under Application Support where CSV import staging
@@ -264,7 +304,7 @@ final class ProfileSession: Identifiable {
   ///   2. In-memory queue when the parent `containerManager` is in-memory
   ///      (UI testing, `ProfileContainerManager.forTesting()`).
   ///   3. On-disk `data.sqlite` under `profiles/<id>/` for production.
-  nonisolated private static func resolveDatabase(
+  private static func resolveDatabase(
     override: DatabaseQueue?,
     profile: Profile,
     containerManager: ProfileContainerManager?

--- a/App/ProfileSession.swift
+++ b/App/ProfileSession.swift
@@ -1,5 +1,6 @@
 import CloudKit
 import Foundation
+import GRDB
 import OSLog
 import SwiftData
 
@@ -9,6 +10,11 @@ import SwiftData
 @MainActor
 final class ProfileSession: Identifiable {
   let profile: Profile
+  /// Per-profile GRDB connection. Owns the lifecycle of `data.sqlite`
+  /// (or an in-memory queue under previews / tests). Released when the
+  /// session deinits; on profile delete the parent `profiles/<id>/`
+  /// directory is removed by `ProfileContainerManager.deleteStore`.
+  let database: DatabaseQueue
   let backend: BackendProvider
   let authStore: AuthStore
   let accountStore: AccountStore
@@ -50,11 +56,16 @@ final class ProfileSession: Identifiable {
   init(
     profile: Profile,
     containerManager: ProfileContainerManager? = nil,
-    syncCoordinator: SyncCoordinator? = nil
-  ) {
+    syncCoordinator: SyncCoordinator? = nil,
+    database: DatabaseQueue? = nil
+  ) throws {
     self.profile = profile
 
-    let services = Self.makeMarketDataServices()
+    let resolvedDatabase = try Self.resolveDatabase(
+      override: database, profile: profile, containerManager: containerManager)
+    self.database = resolvedDatabase
+
+    let services = Self.makeMarketDataServices(database: resolvedDatabase)
     self.exchangeRateService = services.exchangeRate
     self.stockPriceService = services.stockPrice
     self.cryptoPriceService = services.cryptoPrice
@@ -63,9 +74,8 @@ final class ProfileSession: Identifiable {
       profile: profile,
       containerManager: containerManager,
       syncCoordinator: syncCoordinator,
-      exchangeRates: services.exchangeRate,
-      stockPrices: services.stockPrice,
-      cryptoPrices: services.cryptoPrice
+      services: services,
+      database: resolvedDatabase
     )
     self.backend = backend
 
@@ -229,5 +239,51 @@ final class ProfileSession: Identifiable {
       .appendingPathComponent("Moolah", isDirectory: true)
       .appendingPathComponent("csv-staging", isDirectory: true)
       .appendingPathComponent(profileId.uuidString, isDirectory: true)
+  }
+
+  /// Per-profile directory containing `data.sqlite` (and its `-wal`/`-shm`
+  /// sidecars). Removed wholesale on profile delete by
+  /// `ProfileContainerManager.deleteStore(for:)`.
+  nonisolated static func profileDatabaseDirectory(for profileId: UUID) -> URL {
+    URL.moolahScopedApplicationSupport
+      .appendingPathComponent("Moolah", isDirectory: true)
+      .appendingPathComponent("profiles", isDirectory: true)
+      .appendingPathComponent(profileId.uuidString, isDirectory: true)
+  }
+
+  /// Opens the profile's `data.sqlite` GRDB queue, creating intermediate
+  /// directories as needed and applying the `ProfileSchema` migrator.
+  nonisolated static func openProfileDatabase(profileId: UUID) throws -> DatabaseQueue {
+    let url = profileDatabaseDirectory(for: profileId)
+      .appendingPathComponent("data.sqlite")
+    return try ProfileDatabase.open(at: url)
+  }
+
+  /// Resolves which `DatabaseQueue` the session should own. Order:
+  ///   1. Caller-provided `override` (tests, previews).
+  ///   2. In-memory queue when the parent `containerManager` is in-memory
+  ///      (UI testing, `ProfileContainerManager.forTesting()`).
+  ///   3. On-disk `data.sqlite` under `profiles/<id>/` for production.
+  nonisolated private static func resolveDatabase(
+    override: DatabaseQueue?,
+    profile: Profile,
+    containerManager: ProfileContainerManager?
+  ) throws -> DatabaseQueue {
+    if let override { return override }
+    if containerManager?.inMemory == true { return try ProfileDatabase.openInMemory() }
+    return try openProfileDatabase(profileId: profile.id)
+  }
+
+  /// Convenience constructor for `#Preview` blocks. Backs the session with
+  /// an in-memory GRDB queue so previews never touch disk. Uses an in-memory
+  /// `ProfileContainerManager` so the CloudKit backend can be constructed
+  /// without touching the network or the on-disk container store.
+  static func preview(
+    profile: Profile = Profile(label: "Preview")
+  ) throws -> ProfileSession {
+    try ProfileSession(
+      profile: profile,
+      containerManager: ProfileContainerManager.forTesting(),
+      database: ProfileDatabase.openInMemory())
   }
 }

--- a/App/SessionManager.swift
+++ b/App/SessionManager.swift
@@ -17,10 +17,20 @@ final class SessionManager {
   }
 
   /// Returns the existing session for a profile, or creates one.
+  ///
+  /// Database creation can fail (disk full, permissions denied, schema
+  /// migration error). On failure we crash with a descriptive message —
+  /// the app cannot meaningfully run without per-profile storage and
+  /// silent fallback would mask data loss.
   func session(for profile: Profile) -> ProfileSession {
     if let existing = sessions[profile.id] { return existing }
-    let session = ProfileSession(
-      profile: profile, containerManager: containerManager, syncCoordinator: syncCoordinator)
+    let session: ProfileSession
+    do {
+      session = try ProfileSession(
+        profile: profile, containerManager: containerManager, syncCoordinator: syncCoordinator)
+    } catch {
+      fatalError("Failed to open profile database for \(profile.id): \(error)")
+    }
     sessions[profile.id] = session
     return session
   }
@@ -56,7 +66,11 @@ final class SessionManager {
     if let oldSession = sessions[profile.id], let syncCoordinator {
       oldSession.cleanupSync(coordinator: syncCoordinator)
     }
-    sessions[profile.id] = ProfileSession(
-      profile: profile, containerManager: containerManager, syncCoordinator: syncCoordinator)
+    do {
+      sessions[profile.id] = try ProfileSession(
+        profile: profile, containerManager: containerManager, syncCoordinator: syncCoordinator)
+    } catch {
+      fatalError("Failed to rebuild profile database for \(profile.id): \(error)")
+    }
   }
 }

--- a/App/SessionManager.swift
+++ b/App/SessionManager.swift
@@ -7,6 +7,17 @@ import SwiftData
 @Observable
 @MainActor
 final class SessionManager {
+  /// Map from `Profile.ID` to the live `ProfileSession`.
+  ///
+  /// **Mutation invariant:** any code path that drops or replaces a
+  /// session **must** go through `removeSession(for:)` or
+  /// `rebuildSession(for:)` so the session's `cleanupSync(coordinator:)`
+  /// runs first. `cleanupSync` is the only place that cancels the
+  /// session's tracked tasks (`syncReloadTask`, `catalogRefreshTask`,
+  /// `pragmaOptimizeTask`); a direct mutation to `sessions` would leak
+  /// any of those that happen to be in flight. Adding new tracked tasks
+  /// to `ProfileSession`? Cancel them in `cleanupSync` and uphold this
+  /// rule for any new mutation site.
   private(set) var sessions: [UUID: ProfileSession] = [:]
   let containerManager: ProfileContainerManager
   let syncCoordinator: SyncCoordinator?

--- a/Backends/GRDB/ProfileDatabase.swift
+++ b/Backends/GRDB/ProfileDatabase.swift
@@ -1,0 +1,57 @@
+// Backends/GRDB/ProfileDatabase.swift
+
+import Foundation
+import GRDB
+
+/// Factory for the per-profile GRDB `DatabaseQueue`.
+///
+/// The queue is owned by `ProfileSession` (one per active profile). Connect
+/// once at profile activation; let the queue go out of scope on profile
+/// switch / sign-out / delete.
+///
+/// See `guides/DATABASE_SCHEMA_GUIDE.md` §2 (lifecycle) and §5 (PRAGMAs)
+/// for the rules this factory enforces.
+enum ProfileDatabase {
+  /// Open (or create) the profile DB at `url` and apply pending migrations.
+  static func open(at url: URL) throws -> DatabaseQueue {
+    try FileManager.default.createDirectory(
+      at: url.deletingLastPathComponent(),
+      withIntermediateDirectories: true)
+    let queue = try DatabaseQueue(
+      path: url.path,
+      configuration: configuration())
+    try ProfileSchema.migrator.migrate(queue)
+    return queue
+  }
+
+  /// In-memory queue for tests and previews. Identical configuration and
+  /// schema to a production queue; differs only in storage location.
+  static func openInMemory() throws -> DatabaseQueue {
+    let queue = try DatabaseQueue(configuration: configuration())
+    try ProfileSchema.migrator.migrate(queue)
+    return queue
+  }
+
+  // MARK: - Configuration
+
+  private static func configuration() -> Configuration {
+    var config = Configuration()
+    config.prepareDatabase { database in
+      // Project PRAGMA defaults — see `guides/DATABASE_SCHEMA_GUIDE.md` §5.
+      // `journal_mode = WAL` is set persistently by the first connection
+      // that opens a fresh file; subsequent connections inherit it from
+      // the file header.
+      try database.execute(
+        sql: """
+          PRAGMA foreign_keys = ON;
+          PRAGMA synchronous = NORMAL;
+          PRAGMA busy_timeout = 5000;
+          PRAGMA temp_store = MEMORY;
+          PRAGMA cache_size = -8000;
+          PRAGMA mmap_size = 0;
+          PRAGMA optimize = 0x10002;
+          """)
+    }
+    return config
+  }
+}

--- a/Backends/GRDB/ProfileDatabase.swift
+++ b/Backends/GRDB/ProfileDatabase.swift
@@ -13,34 +13,44 @@ import GRDB
 /// for the rules this factory enforces.
 enum ProfileDatabase {
   /// Open (or create) the profile DB at `url` and apply pending migrations.
+  ///
+  /// On-disk databases are required to use `journal_mode = WAL` per
+  /// `guides/DATABASE_SCHEMA_GUIDE.md` §5. WAL is enabled via
+  /// `Configuration.journalMode = .wal` (which triggers GRDB's
+  /// `setUpWALMode`) and verified by reading `PRAGMA journal_mode` back
+  /// after the queue is constructed.
   static func open(at url: URL) throws -> DatabaseQueue {
     try FileManager.default.createDirectory(
       at: url.deletingLastPathComponent(),
       withIntermediateDirectories: true)
     let queue = try DatabaseQueue(
       path: url.path,
-      configuration: configuration())
+      configuration: configuration(walMode: true))
     try ProfileSchema.migrator.migrate(queue)
+    try assertJournalMode(queue, expected: "wal")
     return queue
   }
 
   /// In-memory queue for tests and previews. Identical configuration and
-  /// schema to a production queue; differs only in storage location.
+  /// schema to a production queue, except WAL is not requested — SQLite
+  /// rejects WAL on `:memory:` databases (see sqlite.org WAL docs).
   static func openInMemory() throws -> DatabaseQueue {
-    let queue = try DatabaseQueue(configuration: configuration())
+    let queue = try DatabaseQueue(configuration: configuration(walMode: false))
     try ProfileSchema.migrator.migrate(queue)
     return queue
   }
 
   // MARK: - Configuration
 
-  private static func configuration() -> Configuration {
+  private static func configuration(walMode: Bool) -> Configuration {
     var config = Configuration()
+    if walMode {
+      // Triggers GRDB's `setUpWALMode` on the first connection so the
+      // header is rewritten to WAL and inherited by subsequent opens.
+      config.journalMode = .wal
+    }
     config.prepareDatabase { database in
       // Project PRAGMA defaults — see `guides/DATABASE_SCHEMA_GUIDE.md` §5.
-      // `journal_mode = WAL` is set persistently by the first connection
-      // that opens a fresh file; subsequent connections inherit it from
-      // the file header.
       try database.execute(
         sql: """
           PRAGMA foreign_keys = ON;
@@ -53,5 +63,23 @@ enum ProfileDatabase {
           """)
     }
     return config
+  }
+
+  /// Reads `PRAGMA journal_mode` back from the live queue and traps if it
+  /// does not match the expected mode. WAL is required per
+  /// `guides/DATABASE_SCHEMA_GUIDE.md` §5 ("verified on every open"), so a
+  /// mismatch means the DB silently fell back to journalled mode and is
+  /// running with weaker concurrency / durability guarantees than the
+  /// project assumes.
+  private static func assertJournalMode(
+    _ queue: DatabaseQueue, expected: String
+  ) throws {
+    let actual = try queue.read { database -> String in
+      try String.fetchOne(database, sql: "PRAGMA journal_mode") ?? ""
+    }
+    precondition(
+      actual.lowercased() == expected.lowercased(),
+      "Profile DB opened with journal_mode='\(actual)', expected '\(expected)'"
+    )
   }
 }

--- a/Backends/GRDB/ProfileSchema.swift
+++ b/Backends/GRDB/ProfileSchema.swift
@@ -1,0 +1,96 @@
+// Backends/GRDB/ProfileSchema.swift
+
+import Foundation
+import GRDB
+
+/// Schema definition for a profile's `data.sqlite`.
+///
+/// Each profile has exactly one such database. v1 of the schema covers the
+/// rate caches only (FX, stocks, crypto). User-data tables — accounts,
+/// transactions, earmarks, etc. — are added in later migrations as the
+/// remaining slices of the GRDB migration land.
+///
+/// See `guides/DATABASE_SCHEMA_GUIDE.md` for the rules this schema follows
+/// and `plans/grdb-migration.md` for the slice sequencing.
+enum ProfileSchema {
+  /// Bumped each time a migration is added. Surfaced for open-time
+  /// integrity checks; not used by `DatabaseMigrator` (which keys on the
+  /// stable string IDs of registered migrations).
+  static let version = 1
+
+  static var migrator: DatabaseMigrator {
+    var migrator = DatabaseMigrator()
+
+    #if DEBUG
+      migrator.eraseDatabaseOnSchemaChange = true
+    #endif
+
+    migrator.registerMigration("v1_exchange_rate", migrate: createExchangeRateTables)
+    migrator.registerMigration("v1_stock_price", migrate: createStockPriceTables)
+    migrator.registerMigration("v1_crypto_price", migrate: createCryptoPriceTables)
+
+    return migrator
+  }
+
+  // MARK: - v1 migration bodies
+
+  private static func createExchangeRateTables(_ database: Database) throws {
+    try database.execute(
+      sql: """
+        CREATE TABLE exchange_rate (
+            base TEXT NOT NULL,
+            quote TEXT NOT NULL,
+            date TEXT NOT NULL,
+            rate REAL NOT NULL,
+            PRIMARY KEY (base, date, quote)
+        ) STRICT, WITHOUT ROWID;
+
+        CREATE INDEX exchange_rate_lookup
+            ON exchange_rate (base, quote, date);
+
+        CREATE TABLE exchange_rate_meta (
+            base TEXT PRIMARY KEY,
+            earliest_date TEXT NOT NULL,
+            latest_date TEXT NOT NULL
+        ) STRICT;
+        """)
+  }
+
+  private static func createStockPriceTables(_ database: Database) throws {
+    try database.execute(
+      sql: """
+        CREATE TABLE stock_price (
+            ticker TEXT NOT NULL,
+            date TEXT NOT NULL,
+            price REAL NOT NULL,
+            PRIMARY KEY (ticker, date)
+        ) STRICT, WITHOUT ROWID;
+
+        CREATE TABLE stock_ticker_meta (
+            ticker TEXT PRIMARY KEY,
+            instrument_id TEXT NOT NULL,
+            earliest_date TEXT NOT NULL,
+            latest_date TEXT NOT NULL
+        ) STRICT;
+        """)
+  }
+
+  private static func createCryptoPriceTables(_ database: Database) throws {
+    try database.execute(
+      sql: """
+        CREATE TABLE crypto_price (
+            token_id TEXT NOT NULL,
+            date TEXT NOT NULL,
+            price_usd REAL NOT NULL,
+            PRIMARY KEY (token_id, date)
+        ) STRICT, WITHOUT ROWID;
+
+        CREATE TABLE crypto_token_meta (
+            token_id TEXT PRIMARY KEY,
+            symbol TEXT NOT NULL,
+            earliest_date TEXT NOT NULL,
+            latest_date TEXT NOT NULL
+        ) STRICT;
+        """)
+  }
+}

--- a/Backends/GRDB/ProfileSchema.swift
+++ b/Backends/GRDB/ProfileSchema.swift
@@ -10,6 +10,13 @@ import GRDB
 /// transactions, earmarks, etc. — are added in later migrations as the
 /// remaining slices of the GRDB migration land.
 ///
+/// **Retention policy for the cache tables.** All six cache tables created
+/// by `v1_initial` (`exchange_rate`, `exchange_rate_meta`, `stock_price`,
+/// `stock_ticker_meta`, `crypto_price`, `crypto_token_meta`) are **kept
+/// forever** — needed for historic-conversion correctness on reports older
+/// than the upstream rate APIs can serve. See `plans/grdb-migration.md` §4
+/// and `guides/DATABASE_SCHEMA_GUIDE.md` §9.
+///
 /// See `guides/DATABASE_SCHEMA_GUIDE.md` for the rules this schema follows
 /// and `plans/grdb-migration.md` for the slice sequencing.
 enum ProfileSchema {
@@ -25,14 +32,22 @@ enum ProfileSchema {
       migrator.eraseDatabaseOnSchemaChange = true
     #endif
 
-    migrator.registerMigration("v1_exchange_rate", migrate: createExchangeRateTables)
-    migrator.registerMigration("v1_stock_price", migrate: createStockPriceTables)
-    migrator.registerMigration("v1_crypto_price", migrate: createCryptoPriceTables)
+    // Once shipped, migration IDs are frozen forever, so the rate-cache
+    // slice is intentionally registered as a single `v1_initial` migration
+    // rather than three sub-migrations. Splitting later is fine; merging
+    // post-ship is not.
+    migrator.registerMigration("v1_initial", migrate: createInitialTables)
 
     return migrator
   }
 
-  // MARK: - v1 migration bodies
+  // MARK: - v1 migration body
+
+  private static func createInitialTables(_ database: Database) throws {
+    try createExchangeRateTables(database)
+    try createStockPriceTables(database)
+    try createCryptoPriceTables(database)
+  }
 
   private static func createExchangeRateTables(_ database: Database) throws {
     try database.execute(

--- a/Backends/GRDB/Records/CryptoPriceRecord.swift
+++ b/Backends/GRDB/Records/CryptoPriceRecord.swift
@@ -13,7 +13,15 @@ struct CryptoPriceRecord: Codable, Sendable, FetchableRecord, PersistableRecord 
   static let databaseTableName = "crypto_price"
 
   enum Columns: String, ColumnExpression, CaseIterable {
-    case tokenId, date, priceUsd
+    case tokenId = "token_id"
+    case date
+    case priceUsd = "price_usd"
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case tokenId = "token_id"
+    case date
+    case priceUsd = "price_usd"
   }
 
   /// Token id (e.g. `"1:native"`).

--- a/Backends/GRDB/Records/CryptoPriceRecord.swift
+++ b/Backends/GRDB/Records/CryptoPriceRecord.swift
@@ -18,6 +18,10 @@ struct CryptoPriceRecord: Codable, Sendable, FetchableRecord, PersistableRecord 
     case priceUsd = "price_usd"
   }
 
+  // `CodingKeys` is required (not redundant with `Columns`): GRDB's
+  // FetchableRecord/PersistableRecord conformance is Codable-derived, so
+  // this enum drives the snake_case ⇄ camelCase mapping when rows decode
+  // and parameters bind. `Columns` is consumed by the query interface only.
   enum CodingKeys: String, CodingKey {
     case tokenId = "token_id"
     case date

--- a/Backends/GRDB/Records/CryptoPriceRecord.swift
+++ b/Backends/GRDB/Records/CryptoPriceRecord.swift
@@ -1,0 +1,25 @@
+// Backends/GRDB/Records/CryptoPriceRecord.swift
+
+import Foundation
+import GRDB
+
+/// One row in `crypto_price` — one (token_id, date) pair with the day's
+/// closing price in USD.
+///
+/// Crypto prices are always denominated in USD (`CoinGeckoCatalog`'s
+/// canonical anchor). Multi-step conversion to other reporting instruments
+/// happens in Swift via the conversion service.
+struct CryptoPriceRecord: Codable, Sendable, FetchableRecord, PersistableRecord {
+  static let databaseTableName = "crypto_price"
+
+  enum Columns: String, ColumnExpression, CaseIterable {
+    case tokenId, date, priceUsd
+  }
+
+  /// Token id (e.g. `"1:native"`).
+  var tokenId: String
+  /// ISO-8601 date (`YYYY-MM-DD`).
+  var date: String
+  /// Daily closing price in USD.
+  var priceUsd: Double
+}

--- a/Backends/GRDB/Records/CryptoPriceRecord.swift
+++ b/Backends/GRDB/Records/CryptoPriceRecord.swift
@@ -9,7 +9,7 @@ import GRDB
 /// Crypto prices are always denominated in USD (`CoinGeckoCatalog`'s
 /// canonical anchor). Multi-step conversion to other reporting instruments
 /// happens in Swift via the conversion service.
-struct CryptoPriceRecord: Codable, Sendable, FetchableRecord, PersistableRecord {
+struct CryptoPriceRecord {
   static let databaseTableName = "crypto_price"
 
   enum Columns: String, ColumnExpression, CaseIterable {
@@ -35,3 +35,8 @@ struct CryptoPriceRecord: Codable, Sendable, FetchableRecord, PersistableRecord 
   /// Daily closing price in USD.
   var priceUsd: Double
 }
+
+extension CryptoPriceRecord: Codable {}
+extension CryptoPriceRecord: Sendable {}
+extension CryptoPriceRecord: FetchableRecord {}
+extension CryptoPriceRecord: PersistableRecord {}

--- a/Backends/GRDB/Records/CryptoTokenMetaRecord.swift
+++ b/Backends/GRDB/Records/CryptoTokenMetaRecord.swift
@@ -1,0 +1,24 @@
+// Backends/GRDB/Records/CryptoTokenMetaRecord.swift
+
+import Foundation
+import GRDB
+
+/// One row per token in `crypto_token_meta`. Records the display symbol and
+/// the date span we have USD prices for.
+///
+/// Mirrors the `symbol` / `earliestDate` / `latestDate` fields on the
+/// legacy `CryptoPriceCache` JSON struct.
+struct CryptoTokenMetaRecord: Codable, Sendable, FetchableRecord, PersistableRecord {
+  static let databaseTableName = "crypto_token_meta"
+
+  enum Columns: String, ColumnExpression, CaseIterable {
+    case tokenId, symbol, earliestDate, latestDate
+  }
+
+  var tokenId: String
+  /// Display symbol (e.g. `"ETH"`). Not used for lookups; kept for support
+  /// tooling.
+  var symbol: String
+  var earliestDate: String
+  var latestDate: String
+}

--- a/Backends/GRDB/Records/CryptoTokenMetaRecord.swift
+++ b/Backends/GRDB/Records/CryptoTokenMetaRecord.swift
@@ -12,7 +12,17 @@ struct CryptoTokenMetaRecord: Codable, Sendable, FetchableRecord, PersistableRec
   static let databaseTableName = "crypto_token_meta"
 
   enum Columns: String, ColumnExpression, CaseIterable {
-    case tokenId, symbol, earliestDate, latestDate
+    case tokenId = "token_id"
+    case symbol
+    case earliestDate = "earliest_date"
+    case latestDate = "latest_date"
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case tokenId = "token_id"
+    case symbol
+    case earliestDate = "earliest_date"
+    case latestDate = "latest_date"
   }
 
   var tokenId: String

--- a/Backends/GRDB/Records/CryptoTokenMetaRecord.swift
+++ b/Backends/GRDB/Records/CryptoTokenMetaRecord.swift
@@ -18,6 +18,10 @@ struct CryptoTokenMetaRecord: Codable, Sendable, FetchableRecord, PersistableRec
     case latestDate = "latest_date"
   }
 
+  // `CodingKeys` is required (not redundant with `Columns`): GRDB's
+  // FetchableRecord/PersistableRecord conformance is Codable-derived, so
+  // this enum drives the snake_case ⇄ camelCase mapping when rows decode
+  // and parameters bind. `Columns` is consumed by the query interface only.
   enum CodingKeys: String, CodingKey {
     case tokenId = "token_id"
     case symbol

--- a/Backends/GRDB/Records/CryptoTokenMetaRecord.swift
+++ b/Backends/GRDB/Records/CryptoTokenMetaRecord.swift
@@ -8,7 +8,7 @@ import GRDB
 ///
 /// Mirrors the `symbol` / `earliestDate` / `latestDate` fields on the
 /// legacy `CryptoPriceCache` JSON struct.
-struct CryptoTokenMetaRecord: Codable, Sendable, FetchableRecord, PersistableRecord {
+struct CryptoTokenMetaRecord {
   static let databaseTableName = "crypto_token_meta"
 
   enum Columns: String, ColumnExpression, CaseIterable {
@@ -36,3 +36,8 @@ struct CryptoTokenMetaRecord: Codable, Sendable, FetchableRecord, PersistableRec
   var earliestDate: String
   var latestDate: String
 }
+
+extension CryptoTokenMetaRecord: Codable {}
+extension CryptoTokenMetaRecord: Sendable {}
+extension CryptoTokenMetaRecord: FetchableRecord {}
+extension CryptoTokenMetaRecord: PersistableRecord {}

--- a/Backends/GRDB/Records/ExchangeRateMetaRecord.swift
+++ b/Backends/GRDB/Records/ExchangeRateMetaRecord.swift
@@ -8,7 +8,7 @@ import GRDB
 ///
 /// Mirrors the `earliestDate` / `latestDate` fields on the legacy
 /// `ExchangeRateCache` JSON struct.
-struct ExchangeRateMetaRecord: Codable, Sendable, FetchableRecord, PersistableRecord {
+struct ExchangeRateMetaRecord {
   static let databaseTableName = "exchange_rate_meta"
 
   enum Columns: String, ColumnExpression, CaseIterable {
@@ -33,3 +33,8 @@ struct ExchangeRateMetaRecord: Codable, Sendable, FetchableRecord, PersistableRe
   /// ISO-8601 date string of the latest cached rate.
   var latestDate: String
 }
+
+extension ExchangeRateMetaRecord: Codable {}
+extension ExchangeRateMetaRecord: Sendable {}
+extension ExchangeRateMetaRecord: FetchableRecord {}
+extension ExchangeRateMetaRecord: PersistableRecord {}

--- a/Backends/GRDB/Records/ExchangeRateMetaRecord.swift
+++ b/Backends/GRDB/Records/ExchangeRateMetaRecord.swift
@@ -12,7 +12,15 @@ struct ExchangeRateMetaRecord: Codable, Sendable, FetchableRecord, PersistableRe
   static let databaseTableName = "exchange_rate_meta"
 
   enum Columns: String, ColumnExpression, CaseIterable {
-    case base, earliestDate, latestDate
+    case base
+    case earliestDate = "earliest_date"
+    case latestDate = "latest_date"
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case base
+    case earliestDate = "earliest_date"
+    case latestDate = "latest_date"
   }
 
   var base: String

--- a/Backends/GRDB/Records/ExchangeRateMetaRecord.swift
+++ b/Backends/GRDB/Records/ExchangeRateMetaRecord.swift
@@ -1,0 +1,23 @@
+// Backends/GRDB/Records/ExchangeRateMetaRecord.swift
+
+import Foundation
+import GRDB
+
+/// One row in `exchange_rate_meta` — one entry per cached base instrument,
+/// recording the date span we have rates for.
+///
+/// Mirrors the `earliestDate` / `latestDate` fields on the legacy
+/// `ExchangeRateCache` JSON struct.
+struct ExchangeRateMetaRecord: Codable, Sendable, FetchableRecord, PersistableRecord {
+  static let databaseTableName = "exchange_rate_meta"
+
+  enum Columns: String, ColumnExpression, CaseIterable {
+    case base, earliestDate, latestDate
+  }
+
+  var base: String
+  /// ISO-8601 date string of the earliest cached rate.
+  var earliestDate: String
+  /// ISO-8601 date string of the latest cached rate.
+  var latestDate: String
+}

--- a/Backends/GRDB/Records/ExchangeRateMetaRecord.swift
+++ b/Backends/GRDB/Records/ExchangeRateMetaRecord.swift
@@ -17,6 +17,10 @@ struct ExchangeRateMetaRecord: Codable, Sendable, FetchableRecord, PersistableRe
     case latestDate = "latest_date"
   }
 
+  // `CodingKeys` is required (not redundant with `Columns`): GRDB's
+  // FetchableRecord/PersistableRecord conformance is Codable-derived, so
+  // this enum drives the snake_case ⇄ camelCase mapping when rows decode
+  // and parameters bind. `Columns` is consumed by the query interface only.
   enum CodingKeys: String, CodingKey {
     case base
     case earliestDate = "earliest_date"

--- a/Backends/GRDB/Records/ExchangeRateRecord.swift
+++ b/Backends/GRDB/Records/ExchangeRateRecord.swift
@@ -1,0 +1,26 @@
+// Backends/GRDB/Records/ExchangeRateRecord.swift
+
+import Foundation
+import GRDB
+
+/// One row in the `exchange_rate` table — one (base, quote, date) triple.
+///
+/// Rates are `Double` (SQL `REAL`) per `guides/DATABASE_CODE_GUIDE.md` §3.
+/// `Decimal` is forbidden in record structs; conversion to/from `Decimal`
+/// for use by `ExchangeRateService` happens at the service boundary.
+struct ExchangeRateRecord: Codable, Sendable, FetchableRecord, PersistableRecord {
+  static let databaseTableName = "exchange_rate"
+
+  enum Columns: String, ColumnExpression, CaseIterable {
+    case base, quote, date, rate
+  }
+
+  /// Base instrument code (e.g. `"USD"`).
+  var base: String
+  /// Quote instrument code (e.g. `"AUD"`).
+  var quote: String
+  /// ISO-8601 date (`YYYY-MM-DD`).
+  var date: String
+  /// Price of one unit of `base` in `quote` on `date`.
+  var rate: Double
+}

--- a/Backends/GRDB/Records/ExchangeRateRecord.swift
+++ b/Backends/GRDB/Records/ExchangeRateRecord.swift
@@ -8,7 +8,7 @@ import GRDB
 /// Rates are `Double` (SQL `REAL`) per `guides/DATABASE_CODE_GUIDE.md` §3.
 /// `Decimal` is forbidden in record structs; conversion to/from `Decimal`
 /// for use by `ExchangeRateService` happens at the service boundary.
-struct ExchangeRateRecord: Codable, Sendable, FetchableRecord, PersistableRecord {
+struct ExchangeRateRecord {
   static let databaseTableName = "exchange_rate"
 
   enum Columns: String, ColumnExpression, CaseIterable {
@@ -24,3 +24,8 @@ struct ExchangeRateRecord: Codable, Sendable, FetchableRecord, PersistableRecord
   /// Price of one unit of `base` in `quote` on `date`.
   var rate: Double
 }
+
+extension ExchangeRateRecord: Codable {}
+extension ExchangeRateRecord: Sendable {}
+extension ExchangeRateRecord: FetchableRecord {}
+extension ExchangeRateRecord: PersistableRecord {}

--- a/Backends/GRDB/Records/StockPriceRecord.swift
+++ b/Backends/GRDB/Records/StockPriceRecord.swift
@@ -8,7 +8,7 @@ import GRDB
 ///
 /// The instrument denomination is recorded once per ticker in
 /// `stock_ticker_meta` rather than duplicated on every price row.
-struct StockPriceRecord: Codable, Sendable, FetchableRecord, PersistableRecord {
+struct StockPriceRecord {
   static let databaseTableName = "stock_price"
 
   enum Columns: String, ColumnExpression, CaseIterable {
@@ -22,3 +22,8 @@ struct StockPriceRecord: Codable, Sendable, FetchableRecord, PersistableRecord {
   /// Adjusted close price in the ticker's native instrument.
   var price: Double
 }
+
+extension StockPriceRecord: Codable {}
+extension StockPriceRecord: Sendable {}
+extension StockPriceRecord: FetchableRecord {}
+extension StockPriceRecord: PersistableRecord {}

--- a/Backends/GRDB/Records/StockPriceRecord.swift
+++ b/Backends/GRDB/Records/StockPriceRecord.swift
@@ -1,0 +1,24 @@
+// Backends/GRDB/Records/StockPriceRecord.swift
+
+import Foundation
+import GRDB
+
+/// One row in `stock_price` — one (ticker, date) pair with the day's
+/// adjusted close price in the ticker's native instrument.
+///
+/// The instrument denomination is recorded once per ticker in
+/// `stock_ticker_meta` rather than duplicated on every price row.
+struct StockPriceRecord: Codable, Sendable, FetchableRecord, PersistableRecord {
+  static let databaseTableName = "stock_price"
+
+  enum Columns: String, ColumnExpression, CaseIterable {
+    case ticker, date, price
+  }
+
+  /// Ticker symbol (e.g. `"BHP.AX"`).
+  var ticker: String
+  /// ISO-8601 date (`YYYY-MM-DD`).
+  var date: String
+  /// Adjusted close price in the ticker's native instrument.
+  var price: Double
+}

--- a/Backends/GRDB/Records/StockTickerMetaRecord.swift
+++ b/Backends/GRDB/Records/StockTickerMetaRecord.swift
@@ -13,7 +13,17 @@ struct StockTickerMetaRecord: Codable, Sendable, FetchableRecord, PersistableRec
   static let databaseTableName = "stock_ticker_meta"
 
   enum Columns: String, ColumnExpression, CaseIterable {
-    case ticker, instrumentId, earliestDate, latestDate
+    case ticker
+    case instrumentId = "instrument_id"
+    case earliestDate = "earliest_date"
+    case latestDate = "latest_date"
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case ticker
+    case instrumentId = "instrument_id"
+    case earliestDate = "earliest_date"
+    case latestDate = "latest_date"
   }
 
   var ticker: String

--- a/Backends/GRDB/Records/StockTickerMetaRecord.swift
+++ b/Backends/GRDB/Records/StockTickerMetaRecord.swift
@@ -19,6 +19,10 @@ struct StockTickerMetaRecord: Codable, Sendable, FetchableRecord, PersistableRec
     case latestDate = "latest_date"
   }
 
+  // `CodingKeys` is required (not redundant with `Columns`): GRDB's
+  // FetchableRecord/PersistableRecord conformance is Codable-derived, so
+  // this enum drives the snake_case ⇄ camelCase mapping when rows decode
+  // and parameters bind. `Columns` is consumed by the query interface only.
   enum CodingKeys: String, CodingKey {
     case ticker
     case instrumentId = "instrument_id"

--- a/Backends/GRDB/Records/StockTickerMetaRecord.swift
+++ b/Backends/GRDB/Records/StockTickerMetaRecord.swift
@@ -9,7 +9,7 @@ import GRDB
 ///
 /// Mirrors the `instrument` / `earliestDate` / `latestDate` fields on the
 /// legacy `StockPriceCache` JSON struct.
-struct StockTickerMetaRecord: Codable, Sendable, FetchableRecord, PersistableRecord {
+struct StockTickerMetaRecord {
   static let databaseTableName = "stock_ticker_meta"
 
   enum Columns: String, ColumnExpression, CaseIterable {
@@ -37,3 +37,8 @@ struct StockTickerMetaRecord: Codable, Sendable, FetchableRecord, PersistableRec
   var earliestDate: String
   var latestDate: String
 }
+
+extension StockTickerMetaRecord: Codable {}
+extension StockTickerMetaRecord: Sendable {}
+extension StockTickerMetaRecord: FetchableRecord {}
+extension StockTickerMetaRecord: PersistableRecord {}

--- a/Backends/GRDB/Records/StockTickerMetaRecord.swift
+++ b/Backends/GRDB/Records/StockTickerMetaRecord.swift
@@ -1,0 +1,25 @@
+// Backends/GRDB/Records/StockTickerMetaRecord.swift
+
+import Foundation
+import GRDB
+
+/// One row per ticker in `stock_ticker_meta`. Records the ticker's native
+/// instrument denomination (discovered from the price API on first fetch)
+/// and the date span we have prices for.
+///
+/// Mirrors the `instrument` / `earliestDate` / `latestDate` fields on the
+/// legacy `StockPriceCache` JSON struct.
+struct StockTickerMetaRecord: Codable, Sendable, FetchableRecord, PersistableRecord {
+  static let databaseTableName = "stock_ticker_meta"
+
+  enum Columns: String, ColumnExpression, CaseIterable {
+    case ticker, instrumentId, earliestDate, latestDate
+  }
+
+  var ticker: String
+  /// Instrument code in which the ticker is priced (e.g. `"AUD"` for
+  /// `BHP.AX`, `"USD"` for `AAPL`). Discovered from the price API.
+  var instrumentId: String
+  var earliestDate: String
+  var latestDate: String
+}

--- a/Features/Earmarks/Views/EarmarksView.swift
+++ b/Features/Earmarks/Views/EarmarksView.swift
@@ -261,6 +261,8 @@ struct EarmarksView: View {
     conversionService: backend.conversionService,
     targetInstrument: .AUD
   )
+  // In-memory preview session can't fail in practice: opens an ephemeral
+  // GRDB queue with no disk access. A trap here is acceptable in #Preview.
   // swiftlint:disable:next force_try
   let session = try! ProfileSession.preview()
 

--- a/Features/Earmarks/Views/EarmarksView.swift
+++ b/Features/Earmarks/Views/EarmarksView.swift
@@ -261,7 +261,8 @@ struct EarmarksView: View {
     conversionService: backend.conversionService,
     targetInstrument: .AUD
   )
-  let session = ProfileSession(profile: Profile(label: "Preview"))
+  // swiftlint:disable:next force_try
+  let session = try! ProfileSession.preview()
 
   return NavigationStack {
     EarmarksView(

--- a/Features/Investments/Views/InvestmentAccountView.swift
+++ b/Features/Investments/Views/InvestmentAccountView.swift
@@ -308,6 +308,8 @@ private func seedPositionValuations(backend: CloudKitBackend, account: Account) 
     repository: backend.transactions,
     conversionService: backend.conversionService,
     targetInstrument: .AUD)
+  // In-memory preview session can't fail in practice: opens an ephemeral
+  // GRDB queue with no disk access. A trap here is acceptable in #Preview.
   // swiftlint:disable:next force_try
   let session = try! ProfileSession.preview()
   let account = Account(name: "Brokerage", type: .investment, instrument: .AUD)
@@ -336,6 +338,8 @@ private func seedPositionValuations(backend: CloudKitBackend, account: Account) 
     repository: backend.transactions,
     conversionService: backend.conversionService,
     targetInstrument: .AUD)
+  // In-memory preview session can't fail in practice: opens an ephemeral
+  // GRDB queue with no disk access. A trap here is acceptable in #Preview.
   // swiftlint:disable:next force_try
   let session = try! ProfileSession.preview()
   let account = Account(name: "Brokerage", type: .investment, instrument: .AUD)

--- a/Features/Investments/Views/InvestmentAccountView.swift
+++ b/Features/Investments/Views/InvestmentAccountView.swift
@@ -308,7 +308,8 @@ private func seedPositionValuations(backend: CloudKitBackend, account: Account) 
     repository: backend.transactions,
     conversionService: backend.conversionService,
     targetInstrument: .AUD)
-  let session = ProfileSession(profile: Profile(label: "Preview"))
+  // swiftlint:disable:next force_try
+  let session = try! ProfileSession.preview()
   let account = Account(name: "Brokerage", type: .investment, instrument: .AUD)
   return NavigationStack {
     InvestmentAccountView(
@@ -335,7 +336,8 @@ private func seedPositionValuations(backend: CloudKitBackend, account: Account) 
     repository: backend.transactions,
     conversionService: backend.conversionService,
     targetInstrument: .AUD)
-  let session = ProfileSession(profile: Profile(label: "Preview"))
+  // swiftlint:disable:next force_try
+  let session = try! ProfileSession.preview()
   let account = Account(name: "Brokerage", type: .investment, instrument: .AUD)
   return NavigationStack {
     InvestmentAccountView(

--- a/Features/Navigation/SidebarView.swift
+++ b/Features/Navigation/SidebarView.swift
@@ -353,7 +353,8 @@ private func seedSidebarPreview(
     repository: backend.earmarks,
     conversionService: backend.conversionService,
     targetInstrument: .AUD)
-  let session = ProfileSession(profile: Profile(label: "Preview"))
+  // swiftlint:disable:next force_try
+  let session = try! ProfileSession.preview()
 
   return NavigationSplitView {
     SidebarView(selection: .constant(nil))

--- a/Features/Navigation/SidebarView.swift
+++ b/Features/Navigation/SidebarView.swift
@@ -353,6 +353,8 @@ private func seedSidebarPreview(
     repository: backend.earmarks,
     conversionService: backend.conversionService,
     targetInstrument: .AUD)
+  // In-memory preview session can't fail in practice: opens an ephemeral
+  // GRDB queue with no disk access. A trap here is acceptable in #Preview.
   // swiftlint:disable:next force_try
   let session = try! ProfileSession.preview()
 

--- a/Features/Reports/Views/ReportsView.swift
+++ b/Features/Reports/Views/ReportsView.swift
@@ -209,7 +209,8 @@ private func seedReportsPreview(
     Category(id: ids.rentId, name: "Rent"),
   ])
   let account = Account(name: "Checking", type: .bank, instrument: .AUD)
-  let session = ProfileSession(profile: Profile(label: "Preview"))
+  // swiftlint:disable:next force_try
+  let session = try! ProfileSession.preview()
   return ReportsView(
     reportingStore: reportingStore,
     categories: categories,

--- a/Features/Reports/Views/ReportsView.swift
+++ b/Features/Reports/Views/ReportsView.swift
@@ -209,6 +209,8 @@ private func seedReportsPreview(
     Category(id: ids.rentId, name: "Rent"),
   ])
   let account = Account(name: "Checking", type: .bank, instrument: .AUD)
+  // In-memory preview session can't fail in practice: opens an ephemeral
+  // GRDB queue with no disk access. A trap here is acceptable in #Preview.
   // swiftlint:disable:next force_try
   let session = try! ProfileSession.preview()
   return ReportsView(

--- a/MoolahTests/App/ProfileSessionCatalogIntegrationTests.swift
+++ b/MoolahTests/App/ProfileSessionCatalogIntegrationTests.swift
@@ -28,7 +28,7 @@ struct ProfileSessionCatalogIntegrationTests {
       label: "iCloud",
       currencyCode: "AUD", financialYearStartMonth: 7
     )
-    let session = ProfileSession(profile: profile, containerManager: containerManager)
+    let session = try ProfileSession(profile: profile, containerManager: containerManager)
 
     #expect(session.coinGeckoCatalog != nil)
   }

--- a/MoolahTests/App/ProfileSessionInstrumentRegistryTests.swift
+++ b/MoolahTests/App/ProfileSessionInstrumentRegistryTests.swift
@@ -14,7 +14,7 @@ struct ProfileSessionInstrumentRegistryTests {
       label: "iCloud",
       currencyCode: "AUD", financialYearStartMonth: 7
     )
-    let session = ProfileSession(profile: profile, containerManager: containerManager)
+    let session = try ProfileSession(profile: profile, containerManager: containerManager)
 
     #expect(session.instrumentRegistry != nil)
     #expect(session.cryptoTokenStore != nil)

--- a/MoolahTests/App/ProfileSessionTests.swift
+++ b/MoolahTests/App/ProfileSessionTests.swift
@@ -13,7 +13,8 @@ struct ProfileSessionTests {
   @Test("session creates non-nil stores")
   func createsStores() throws {
     let containerManager = try ProfileContainerManager.forTesting()
-    let session = ProfileSession(profile: makeProfile(), containerManager: containerManager)
+    let session = try ProfileSession(
+      profile: makeProfile(), containerManager: containerManager)
 
     #expect(session.authStore.state == .loading)
     #expect(session.accountStore.accounts.ordered.isEmpty)
@@ -27,7 +28,7 @@ struct ProfileSessionTests {
   func sessionIdMatchesProfile() throws {
     let containerManager = try ProfileContainerManager.forTesting()
     let profile = makeProfile()
-    let session = ProfileSession(profile: profile, containerManager: containerManager)
+    let session = try ProfileSession(profile: profile, containerManager: containerManager)
 
     #expect(session.id == profile.id)
   }
@@ -36,9 +37,9 @@ struct ProfileSessionTests {
   func independentSessions() throws {
     let containerManager1 = try ProfileContainerManager.forTesting()
     let containerManager2 = try ProfileContainerManager.forTesting()
-    let session1 = ProfileSession(
+    let session1 = try ProfileSession(
       profile: makeProfile(label: "One"), containerManager: containerManager1)
-    let session2 = ProfileSession(
+    let session2 = try ProfileSession(
       profile: makeProfile(label: "Two"), containerManager: containerManager2)
 
     #expect(session1.id != session2.id)
@@ -47,7 +48,8 @@ struct ProfileSessionTests {
   @Test("onInvestmentValueChanged wiring connects investment store to account store")
   func onInvestmentValueChangedWiring() throws {
     let containerManager = try ProfileContainerManager.forTesting()
-    let session = ProfileSession(profile: makeProfile(), containerManager: containerManager)
+    let session = try ProfileSession(
+      profile: makeProfile(), containerManager: containerManager)
 
     #expect(session.investmentStore.onInvestmentValueChanged != nil)
   }
@@ -60,7 +62,7 @@ struct ProfileSessionTests {
   func cloudKitProfileUsesFullConversionService() throws {
     let containerManager = try ProfileContainerManager.forTesting()
     let profile = Profile(label: "iCloud", currencyCode: "AUD", financialYearStartMonth: 7)
-    let session = ProfileSession(profile: profile, containerManager: containerManager)
+    let session = try ProfileSession(profile: profile, containerManager: containerManager)
 
     #expect(session.backend.conversionService is FullConversionService)
   }
@@ -69,7 +71,7 @@ struct ProfileSessionTests {
   func cloudKitProfileExposesCryptoTokenStore() throws {
     let containerManager = try ProfileContainerManager.forTesting()
     let profile = Profile(label: "iCloud", currencyCode: "AUD", financialYearStartMonth: 7)
-    let session = ProfileSession(profile: profile, containerManager: containerManager)
+    let session = try ProfileSession(profile: profile, containerManager: containerManager)
 
     // Store exists and starts empty (registrations load on demand).
     #expect(session.cryptoTokenStore?.registrations.isEmpty == true)

--- a/MoolahTests/Backends/RateQueryPlanTests.swift
+++ b/MoolahTests/Backends/RateQueryPlanTests.swift
@@ -1,0 +1,71 @@
+// MoolahTests/Backends/RateQueryPlanTests.swift
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+/// `EXPLAIN QUERY PLAN`-pinning tests for the three rate-cache hydration
+/// queries. Per `guides/DATABASE_CODE_GUIDE.md` §6 every perf-critical
+/// query must have a paired plan-pinning test so an index regression
+/// (e.g. a rename, an accidentally-dropped index, or a column-order
+/// change in the PK) breaks the build immediately rather than slipping
+/// through to production as a full-table scan.
+///
+/// All three `loadCache` queries filter on the leading column of the
+/// table's primary key (`base`, `ticker`, `token_id`) so the planner is
+/// expected to choose `SEARCH USING PRIMARY KEY`. Anything else
+/// (including `SCAN <table>`) is a regression.
+@Suite("Rate cache loadCache query plans")
+struct RateQueryPlanTests {
+  @Test
+  func exchangeRateLoadCacheUsesPrimaryKey() async throws {
+    let database = try ProfileDatabase.openInMemory()
+    try await database.read { database in
+      let plan = try Row.fetchAll(
+        database,
+        sql: """
+          EXPLAIN QUERY PLAN
+          SELECT * FROM exchange_rate WHERE base = ?
+          """,
+        arguments: ["AUD"]
+      ).map { String(describing: $0["detail"] ?? "") }
+      #expect(plan.contains { $0.contains("SEARCH") && $0.contains("PRIMARY KEY") })
+      #expect(!plan.contains { $0.contains("SCAN") })
+    }
+  }
+
+  @Test
+  func stockPriceLoadCacheUsesPrimaryKey() async throws {
+    let database = try ProfileDatabase.openInMemory()
+    try await database.read { database in
+      let plan = try Row.fetchAll(
+        database,
+        sql: """
+          EXPLAIN QUERY PLAN
+          SELECT * FROM stock_price WHERE ticker = ?
+          """,
+        arguments: ["BHP.AX"]
+      ).map { String(describing: $0["detail"] ?? "") }
+      #expect(plan.contains { $0.contains("SEARCH") && $0.contains("PRIMARY KEY") })
+      #expect(!plan.contains { $0.contains("SCAN") })
+    }
+  }
+
+  @Test
+  func cryptoPriceLoadCacheUsesPrimaryKey() async throws {
+    let database = try ProfileDatabase.openInMemory()
+    try await database.read { database in
+      let plan = try Row.fetchAll(
+        database,
+        sql: """
+          EXPLAIN QUERY PLAN
+          SELECT * FROM crypto_price WHERE token_id = ?
+          """,
+        arguments: ["1:native"]
+      ).map { String(describing: $0["detail"] ?? "") }
+      #expect(plan.contains { $0.contains("SEARCH") && $0.contains("PRIMARY KEY") })
+      #expect(!plan.contains { $0.contains("SCAN") })
+    }
+  }
+}

--- a/MoolahTests/Domain/CategoryRepositoryContractTests.swift
+++ b/MoolahTests/Domain/CategoryRepositoryContractTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import GRDB
 import SwiftData
 import Testing
 
@@ -224,9 +225,8 @@ private struct CloudKitCategoryTestBackend: BackendProvider, @unchecked Sendable
     let container = try TestModelContainer.create()
     let instrument = Instrument.defaultTestInstrument
     let rateClient = FixedRateClient()
-    let cacheDir = FileManager.default.temporaryDirectory
-      .appendingPathComponent("test-rates-\(UUID().uuidString)")
-    let exchangeRates = ExchangeRateService(client: rateClient, cacheDirectory: cacheDir)
+    let exchangeRates = ExchangeRateService(
+      client: rateClient, database: try ProfileDatabase.openInMemory())
     let conversion = FiatConversionService(exchangeRates: exchangeRates)
     self.auth = InMemoryAuthProvider()
     self.accounts = CloudKitAccountRepository(

--- a/MoolahTests/Domain/InstrumentConversionServiceTests.swift
+++ b/MoolahTests/Domain/InstrumentConversionServiceTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import GRDB
 import Testing
 
 @testable import Moolah
@@ -13,18 +14,16 @@ struct InstrumentConversionServiceTests {
 
   private func makeService(
     rates: [String: [String: Decimal]] = [:]
-  ) -> FiatConversionService {
+  ) throws -> FiatConversionService {
     let client = FixedRateClient(rates: rates)
-    let cacheDir = FileManager.default.temporaryDirectory
-      .appendingPathComponent("conversion-tests")
-      .appendingPathComponent(UUID().uuidString)
-    let exchangeRates = ExchangeRateService(client: client, cacheDirectory: cacheDir)
+    let exchangeRates = ExchangeRateService(
+      client: client, database: try ProfileDatabase.openInMemory())
     return FiatConversionService(exchangeRates: exchangeRates)
   }
 
   @Test
   func sameCurrencyReturnsIdentity() async throws {
-    let service = makeService()
+    let service = try makeService()
     let result = try await service.convert(
       dec("100.00"),
       from: .AUD, to: .AUD,
@@ -35,7 +34,7 @@ struct InstrumentConversionServiceTests {
 
   @Test
   func convertsAUDtoUSD() async throws {
-    let service = makeService(rates: [
+    let service = try makeService(rates: [
       "2025-06-15": ["USD": dec("0.6500")]
     ])
     let result = try await service.convert(
@@ -48,7 +47,7 @@ struct InstrumentConversionServiceTests {
 
   @Test
   func convertsUSDtoAUD() async throws {
-    let service = makeService(rates: [
+    let service = try makeService(rates: [
       "2025-06-15": ["AUD": dec("1.5385")]
     ])
     let result = try await service.convert(
@@ -61,7 +60,7 @@ struct InstrumentConversionServiceTests {
 
   @Test
   func convertAmount() async throws {
-    let service = makeService(rates: [
+    let service = try makeService(rates: [
       "2025-06-15": ["USD": dec("0.6500")]
     ])
     let amount = InstrumentAmount(
@@ -77,7 +76,7 @@ struct InstrumentConversionServiceTests {
 
   @Test
   func convertAmountSameCurrency() async throws {
-    let service = makeService()
+    let service = try makeService()
     let amount = InstrumentAmount(
       quantity: dec("1000.00"),
       instrument: .AUD
@@ -100,7 +99,7 @@ struct InstrumentConversionServiceTests {
     let today = calendar.startOfDay(for: Date())
     let pastDate = calendar.date(byAdding: .day, value: -15, to: today)!
     let pastKey = formatter.string(from: pastDate)
-    let service = makeService(rates: [
+    let service = try makeService(rates: [
       pastKey: ["USD": dec("0.6500")]
     ])
 
@@ -122,7 +121,7 @@ struct InstrumentConversionServiceTests {
     let pastKey = formatter.string(
       from: calendar.date(byAdding: .day, value: -3, to: today)!
     )
-    let service = makeService(rates: [
+    let service = try makeService(rates: [
       pastKey: ["USD": dec("0.6500")]
     ])
 

--- a/MoolahTests/Domain/TransactionRepositoryBulkFetchTests.swift
+++ b/MoolahTests/Domain/TransactionRepositoryBulkFetchTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import GRDB
 import SwiftData
 import Testing
 
@@ -87,11 +88,9 @@ struct TransactionRepositoryBulkFetchTests {
 
   private func makeRepository(initial: [Transaction]) throws -> CloudKitTransactionRepository {
     let container = try TestModelContainer.create()
-    let cacheDir = FileManager.default.temporaryDirectory
-      .appendingPathComponent("test-rates-\(UUID().uuidString)")
     let rateService = ExchangeRateService(
       client: FixedRateClient(rates: [:]),
-      cacheDirectory: cacheDir)
+      database: try ProfileDatabase.openInMemory())
     let repo = CloudKitTransactionRepository(
       modelContainer: container,
       instrument: .defaultTestInstrument,

--- a/MoolahTests/Features/CryptoTokenStoreTests.swift
+++ b/MoolahTests/Features/CryptoTokenStoreTests.swift
@@ -1,5 +1,6 @@
 // MoolahTests/Features/CryptoTokenStoreTests.swift
 import Foundation
+import GRDB
 import SwiftData
 import Testing
 
@@ -25,11 +26,11 @@ struct CryptoTokenStoreTests {
       // swiftlint:disable:next force_try
       try! await registry.registerCrypto(reg.instrument, mapping: reg.mapping)
     }
+    // swiftlint:disable:next force_try
+    let database = try! ProfileDatabase.openInMemory()
     let service = CryptoPriceService(
       clients: [FixedCryptoPriceClient()],
-      cacheDirectory: FileManager.default.temporaryDirectory
-        .appendingPathComponent("crypto-store-tests")
-        .appendingPathComponent(UUID().uuidString)
+      database: database
     )
     let store = CryptoTokenStore(registry: registry, cryptoPriceService: service)
     return (store, registry)
@@ -75,7 +76,8 @@ struct CryptoTokenStoreTests {
   @Test("loadRegistrations surfaces registry failure into error")
   func loadRegistrationsSurfacesError() async {
     let failing = FailingRegistry()
-    let service = CryptoPriceService(clients: [])
+    // swiftlint:disable:next force_try
+    let service = CryptoPriceService(clients: [], database: try! ProfileDatabase.openInMemory())
     let store = CryptoTokenStore(registry: failing, cryptoPriceService: service)
     await store.loadRegistrations()
     #expect(store.error != nil)

--- a/MoolahTests/Features/StockPositionDisplayTests.swift
+++ b/MoolahTests/Features/StockPositionDisplayTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import GRDB
 import SwiftData
 import Testing
 
@@ -71,15 +72,10 @@ struct StockPositionDisplayTests {
     let stockClient = FixedStockPriceClient(responses: [
       "BHP.AX": StockPriceResponse(instrument: .AUD, prices: [dateKey: dec("45.00")])
     ])
-    let stockCacheDir = FileManager.default.temporaryDirectory
-      .appendingPathComponent("stock-valued-tests")
-      .appendingPathComponent(UUID().uuidString)
-    let stockService = StockPriceService(client: stockClient, cacheDirectory: stockCacheDir)
+    let database = try ProfileDatabase.openInMemory()
+    let stockService = StockPriceService(client: stockClient, database: database)
     let rateClient = FixedRateClient(rates: [:])
-    let rateCacheDir = FileManager.default.temporaryDirectory
-      .appendingPathComponent("position-display-tests")
-      .appendingPathComponent(UUID().uuidString)
-    let rateService = ExchangeRateService(client: rateClient, cacheDirectory: rateCacheDir)
+    let rateService = ExchangeRateService(client: rateClient, database: database)
     let conversionService = FullConversionService(
       exchangeRates: rateService,
       stockPrices: stockService
@@ -125,7 +121,7 @@ struct StockPositionDisplayTests {
     let accountId = UUID()
     let today = Date()
 
-    let conversionService = makeTotalPortfolioConversionService(today: today)
+    let conversionService = try makeTotalPortfolioConversionService(today: today)
     let (backend, container) = try TestBackend.create()
     TestBackend.seed(
       accounts: [
@@ -150,21 +146,16 @@ struct StockPositionDisplayTests {
     #expect(store.totalPortfolioValue == dec("405.00"))
   }
 
-  private func makeTotalPortfolioConversionService(today: Date) -> FullConversionService {
+  private func makeTotalPortfolioConversionService(today: Date) throws -> FullConversionService {
     let dateKey = dateString(today)
     let stockClient = FixedStockPriceClient(responses: [
       "BHP.AX": StockPriceResponse(instrument: .AUD, prices: [dateKey: dec("45.00")]),
       "CBA.AX": StockPriceResponse(instrument: .AUD, prices: [dateKey: dec("120.00")]),
     ])
-    let stockCacheDir = FileManager.default.temporaryDirectory
-      .appendingPathComponent("stock-total-tests")
-      .appendingPathComponent(UUID().uuidString)
-    let stockService = StockPriceService(client: stockClient, cacheDirectory: stockCacheDir)
+    let database = try ProfileDatabase.openInMemory()
+    let stockService = StockPriceService(client: stockClient, database: database)
     let rateClient = FixedRateClient(rates: [:])
-    let rateCacheDir = FileManager.default.temporaryDirectory
-      .appendingPathComponent("position-display-tests")
-      .appendingPathComponent(UUID().uuidString)
-    let rateService = ExchangeRateService(client: rateClient, cacheDirectory: rateCacheDir)
+    let rateService = ExchangeRateService(client: rateClient, database: database)
     return FullConversionService(
       exchangeRates: rateService,
       stockPrices: stockService

--- a/MoolahTests/Shared/CryptoPriceServiceTests.swift
+++ b/MoolahTests/Shared/CryptoPriceServiceTests.swift
@@ -262,62 +262,6 @@ struct CryptoPriceServiceTests {
     }
   }
 
-  // MARK: - Rollback test for multi-statement save
-
-  /// Rollback contract: `CryptoPriceService.saveCache` is one
-  /// `database.write` (delete prior price rows + re-insert + upsert meta).
-  ///
-  /// Drives the **production** `saveCache` by installing a trigger that
-  /// raises `ABORT` on a sentinel date string. A second fetch through the
-  /// service merges that sentinel into the cache, the production save path
-  /// runs, the trigger fires inside the transaction, and the entire write
-  /// must roll back — leaving prior rows untouched.
-  @Test
-  func saveCacheRollsBackOnInsertFailure() async throws {
-    let database = try ProfileDatabase.openInMemory()
-    let service = try makeService(
-      prices: ["1:native": ["2026-04-10": dec("1623.45"), "2026-04-11": dec("1700")]],
-      database: database
-    )
-    _ = try await service.price(
-      for: ethInstrument, mapping: ethMapping, on: date("2026-04-10"))
-
-    let beforeCount = try await database.read { database in
-      try CryptoPriceRecord
-        .filter(CryptoPriceRecord.Columns.tokenId == "1:native")
-        .fetchCount(database)
-    }
-    #expect(beforeCount > 0)
-
-    // Install a trigger that aborts inserts carrying the sentinel date.
-    // The trigger fires inside `saveCache`'s transaction so the upfront
-    // DELETE for the 1:native partition + the new inserts roll back together.
-    try await database.write { database in
-      try database.execute(
-        sql: """
-          CREATE TRIGGER fail_save_cache
-          BEFORE INSERT ON crypto_price
-          WHEN NEW.date = '9999-12-31'
-          BEGIN
-              SELECT RAISE(ABORT, 'forced failure for rollback test');
-          END;
-          """)
-    }
-
-    // Drive the real `saveCache` by feeding a price set that contains the
-    // sentinel date.
-    let failingService = try makeService(
-      prices: ["1:native": ["9999-12-31": dec("9999.0")]],
-      database: database
-    )
-    _ = try? await failingService.price(
-      for: ethInstrument, mapping: ethMapping, on: date("9999-12-31"))
-
-    let afterCount = try await database.read { database in
-      try CryptoPriceRecord
-        .filter(CryptoPriceRecord.Columns.tokenId == "1:native")
-        .fetchCount(database)
-    }
-    #expect(afterCount == beforeCount)
-  }
+  // Rollback contract for `saveCache` lives in `CryptoPriceServiceTestsMore.swift`
+  // so this file stays under SwiftLint's `type_body_length` cap.
 }

--- a/MoolahTests/Shared/CryptoPriceServiceTests.swift
+++ b/MoolahTests/Shared/CryptoPriceServiceTests.swift
@@ -215,8 +215,6 @@ struct CryptoPriceServiceTests {
     #expect(prices["0:native"] == dec("67890.00"))
   }
 
-  // MARK: - SQL persistence round-trip
-
   // MARK: - purgeCache
 
   /// `purgeCache` clears both the in-memory entry and the SQL rows for the
@@ -268,9 +266,14 @@ struct CryptoPriceServiceTests {
 
   /// Rollback contract: `CryptoPriceService.saveCache` is one
   /// `database.write` (delete prior price rows + re-insert + upsert meta).
-  /// A constraint violation mid-transaction must leave prior state intact.
+  ///
+  /// Drives the **production** `saveCache` by installing a trigger that
+  /// raises `ABORT` on a sentinel date string. A second fetch through the
+  /// service merges that sentinel into the cache, the production save path
+  /// runs, the trigger fires inside the transaction, and the entire write
+  /// must roll back — leaving prior rows untouched.
   @Test
-  func saveRollsBackOnConstraintFailure() async throws {
+  func saveCacheRollsBackOnInsertFailure() async throws {
     let database = try ProfileDatabase.openInMemory()
     let service = try makeService(
       prices: ["1:native": ["2026-04-10": dec("1623.45"), "2026-04-11": dec("1700")]],
@@ -286,18 +289,29 @@ struct CryptoPriceServiceTests {
     }
     #expect(beforeCount > 0)
 
-    await #expect(throws: (any Error).self) {
-      try await database.write { database in
-        try CryptoPriceRecord
-          .filter(CryptoPriceRecord.Columns.tokenId == "1:native")
-          .deleteAll(database)
-        try CryptoPriceRecord(tokenId: "1:native", date: "2026-01-01", priceUsd: 1.0)
-          .insert(database)
-        // Duplicate (token_id, date) trips the PK on the second insert.
-        try CryptoPriceRecord(tokenId: "1:native", date: "2026-01-01", priceUsd: 2.0)
-          .insert(database)
-      }
+    // Install a trigger that aborts inserts carrying the sentinel date.
+    // The trigger fires inside `saveCache`'s transaction so the upfront
+    // DELETE for the 1:native partition + the new inserts roll back together.
+    try await database.write { database in
+      try database.execute(
+        sql: """
+          CREATE TRIGGER fail_save_cache
+          BEFORE INSERT ON crypto_price
+          WHEN NEW.date = '9999-12-31'
+          BEGIN
+              SELECT RAISE(ABORT, 'forced failure for rollback test');
+          END;
+          """)
     }
+
+    // Drive the real `saveCache` by feeding a price set that contains the
+    // sentinel date.
+    let failingService = try makeService(
+      prices: ["1:native": ["9999-12-31": dec("9999.0")]],
+      database: database
+    )
+    _ = try? await failingService.price(
+      for: ethInstrument, mapping: ethMapping, on: date("9999-12-31"))
 
     let afterCount = try await database.read { database in
       try CryptoPriceRecord

--- a/MoolahTests/Shared/CryptoPriceServiceTests.swift
+++ b/MoolahTests/Shared/CryptoPriceServiceTests.swift
@@ -1,5 +1,6 @@
 // MoolahTests/Shared/CryptoPriceServiceTests.swift
 import Foundation
+import GRDB
 import Testing
 
 @testable import Moolah
@@ -33,21 +34,17 @@ struct CryptoPriceServiceTests {
     clients: [CryptoPriceClient] = [],
     prices: [String: [String: Decimal]] = [:],
     shouldFail: Bool = false,
-    cacheDirectory: URL? = nil,
+    database: DatabaseQueue? = nil,
     resolutionClient: (any TokenResolutionClient)? = nil
-  ) -> CryptoPriceService {
+  ) throws -> CryptoPriceService {
     let clientList =
       clients.isEmpty
       ? [FixedCryptoPriceClient(prices: prices, shouldFail: shouldFail)]
       : clients
-    let cacheDir =
-      cacheDirectory
-      ?? FileManager.default.temporaryDirectory
-      .appendingPathComponent("crypto-price-tests")
-      .appendingPathComponent(UUID().uuidString)
+    let resolved = try database ?? ProfileDatabase.openInMemory()
     return CryptoPriceService(
       clients: clientList,
-      cacheDirectory: cacheDir,
+      database: resolved,
       resolutionClient: resolutionClient
     )
   }
@@ -62,7 +59,7 @@ struct CryptoPriceServiceTests {
 
   @Test
   func cacheMissFetchesFromClient() async throws {
-    let service = makeService(prices: [
+    let service = try makeService(prices: [
       "1:native": ["2026-04-10": dec("1623.45")]
     ])
     let price = try await service.price(
@@ -72,7 +69,7 @@ struct CryptoPriceServiceTests {
 
   @Test
   func cacheHitDoesNotRefetch() async throws {
-    let service = makeService(prices: [
+    let service = try makeService(prices: [
       "1:native": ["2026-04-10": dec("1623.45")]
     ])
     let first = try await service.price(
@@ -90,7 +87,7 @@ struct CryptoPriceServiceTests {
     let working = FixedCryptoPriceClient(prices: [
       "1:native": ["2026-04-10": dec("1623.45")]
     ])
-    let service = makeService(clients: [failing, working])
+    let service = try makeService(clients: [failing, working])
     let price = try await service.price(
       for: ethInstrument, mapping: ethMapping, on: date("2026-04-10"))
     #expect(price == dec("1623.45"))
@@ -101,7 +98,7 @@ struct CryptoPriceServiceTests {
     let working = FixedCryptoPriceClient(prices: [
       "1:native": ["2026-04-09": dec("1600.00")]
     ])
-    let service = makeService(clients: [working])
+    let service = try makeService(clients: [working])
     _ = try await service.price(for: ethInstrument, mapping: ethMapping, on: date("2026-04-09"))
 
     // Request a later date — client has no data for it, triggering fallback
@@ -112,7 +109,7 @@ struct CryptoPriceServiceTests {
 
   @Test
   func allClientsFailWithEmptyCacheThrows() async throws {
-    let service = makeService(shouldFail: true)
+    let service = try makeService(shouldFail: true)
     await #expect(throws: (any Error).self) {
       try await service.price(
         for: self.ethInstrument, mapping: self.ethMapping, on: self.date("2026-04-10"))
@@ -128,7 +125,7 @@ struct CryptoPriceServiceTests {
     let working = FixedCryptoPriceClient(prices: [
       "1:native": ["2026-04-09": dec("1600.00")]  // 2026-04-10 deliberately absent
     ])
-    let service = makeService(clients: [working])
+    let service = try makeService(clients: [working])
     let price = try await service.price(
       for: ethInstrument, mapping: ethMapping, on: date("2026-04-10"))
     #expect(price == dec("1600.00"))
@@ -141,7 +138,7 @@ struct CryptoPriceServiceTests {
     let working = FixedCryptoPriceClient(prices: [
       "1:native": ["2026-04-15": dec("1700.00")]
     ])
-    let service = makeService(clients: [working])
+    let service = try makeService(clients: [working])
     _ = try await service.price(for: ethInstrument, mapping: ethMapping, on: date("2026-04-15"))
 
     await #expect(throws: (any Error).self) {
@@ -154,7 +151,7 @@ struct CryptoPriceServiceTests {
 
   @Test
   func rangeFetchReturnsPricesForEachDay() async throws {
-    let service = makeService(prices: [
+    let service = try makeService(prices: [
       "1:native": [
         "2026-04-07": dec("1600.00"),
         "2026-04-08": dec("1610.00"),
@@ -171,7 +168,7 @@ struct CryptoPriceServiceTests {
 
   @Test
   func rangeFetchOnlyRequestsMissingSegments() async throws {
-    let service = makeService(prices: [
+    let service = try makeService(prices: [
       "1:native": [
         "2026-04-07": dec("1600.00"),
         "2026-04-08": dec("1610.00"),
@@ -192,7 +189,7 @@ struct CryptoPriceServiceTests {
 
   @Test
   func rangeFillsWeekendGapsWithLastKnownPrice() async throws {
-    let service = makeService(prices: [
+    let service = try makeService(prices: [
       "1:native": [
         "2026-04-10": dec("1630.00")
       ]
@@ -209,7 +206,7 @@ struct CryptoPriceServiceTests {
 
   @Test
   func currentPricesFetchesForAllMappings() async throws {
-    let service = makeService(prices: [
+    let service = try makeService(prices: [
       "1:native": ["2026-04-11": dec("1640.00")],
       "0:native": ["2026-04-11": dec("67890.00")],
     ])
@@ -218,39 +215,95 @@ struct CryptoPriceServiceTests {
     #expect(prices["0:native"] == dec("67890.00"))
   }
 
-  // MARK: - Gzip round-trip
+  // MARK: - SQL persistence round-trip
 
   // MARK: - purgeCache
 
-  @Test("purgeCache removes the in-memory cache entry and disk file")
-  func purgeCacheRemovesInMemoryAndDisk() async throws {
-    let tempDir = FileManager.default.temporaryDirectory
-      .appendingPathComponent("purge-test-\(UUID())")
-    try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-    defer { try? FileManager.default.removeItem(at: tempDir) }
+  /// `purgeCache` clears both the in-memory entry and the SQL rows for the
+  /// supplied instrument id. After purge a fresh service against the same
+  /// database must throw when the network is unavailable, proving no row
+  /// or meta entry survived.
+  @Test("purgeCache removes the in-memory cache entry and SQL rows")
+  func purgeCacheRemovesInMemoryAndSQL() async throws {
+    let database = try ProfileDatabase.openInMemory()
 
-    let service = makeService(
+    let service = try makeService(
       prices: ["1:native": ["2026-04-10": dec("1623.45")]],
-      cacheDirectory: tempDir
+      database: database
     )
 
     _ = try await service.price(
       for: ethInstrument, mapping: ethMapping, on: date("2026-04-10"))
-    let filename = "prices-\(ethInstrument.id.replacingOccurrences(of: ":", with: "-")).json.gz"
-    let onDisk = tempDir.appendingPathComponent(filename)
-    #expect(FileManager.default.fileExists(atPath: onDisk.path))
 
-    // Purge and verify the disk file is gone. The in-memory cache is
-    // private; exercising it indirectly through a fresh service against
-    // the same directory proves the disk file is gone (a subsequent
-    // lookup with a failing client would now throw).
+    let beforeRows = try await database.read { database in
+      try CryptoPriceRecord
+        .filter(CryptoPriceRecord.Columns.tokenId == "1:native")
+        .fetchCount(database)
+    }
+    #expect(beforeRows > 0)
+
     await service.purgeCache(instrumentId: ethInstrument.id)
-    #expect(FileManager.default.fileExists(atPath: onDisk.path) == false)
 
-    let freshService = makeService(shouldFail: true, cacheDirectory: tempDir)
+    let afterRows = try await database.read { database in
+      try CryptoPriceRecord
+        .filter(CryptoPriceRecord.Columns.tokenId == "1:native")
+        .fetchCount(database)
+    }
+    let afterMeta = try await database.read { database in
+      try CryptoTokenMetaRecord
+        .filter(CryptoTokenMetaRecord.Columns.tokenId == "1:native")
+        .fetchCount(database)
+    }
+    #expect(afterRows == 0)
+    #expect(afterMeta == 0)
+
+    let freshService = try makeService(shouldFail: true, database: database)
     await #expect(throws: (any Error).self) {
       try await freshService.price(
         for: self.ethInstrument, mapping: self.ethMapping, on: self.date("2026-04-10"))
     }
+  }
+
+  // MARK: - Rollback test for multi-statement save
+
+  /// Rollback contract: `CryptoPriceService.saveCache` is one
+  /// `database.write` (delete prior price rows + re-insert + upsert meta).
+  /// A constraint violation mid-transaction must leave prior state intact.
+  @Test
+  func saveRollsBackOnConstraintFailure() async throws {
+    let database = try ProfileDatabase.openInMemory()
+    let service = try makeService(
+      prices: ["1:native": ["2026-04-10": dec("1623.45"), "2026-04-11": dec("1700")]],
+      database: database
+    )
+    _ = try await service.price(
+      for: ethInstrument, mapping: ethMapping, on: date("2026-04-10"))
+
+    let beforeCount = try await database.read { database in
+      try CryptoPriceRecord
+        .filter(CryptoPriceRecord.Columns.tokenId == "1:native")
+        .fetchCount(database)
+    }
+    #expect(beforeCount > 0)
+
+    await #expect(throws: (any Error).self) {
+      try await database.write { database in
+        try CryptoPriceRecord
+          .filter(CryptoPriceRecord.Columns.tokenId == "1:native")
+          .deleteAll(database)
+        try CryptoPriceRecord(tokenId: "1:native", date: "2026-01-01", priceUsd: 1.0)
+          .insert(database)
+        // Duplicate (token_id, date) trips the PK on the second insert.
+        try CryptoPriceRecord(tokenId: "1:native", date: "2026-01-01", priceUsd: 2.0)
+          .insert(database)
+      }
+    }
+
+    let afterCount = try await database.read { database in
+      try CryptoPriceRecord
+        .filter(CryptoPriceRecord.Columns.tokenId == "1:native")
+        .fetchCount(database)
+    }
+    #expect(afterCount == beforeCount)
   }
 }

--- a/MoolahTests/Shared/CryptoPriceServiceTestsMore.swift
+++ b/MoolahTests/Shared/CryptoPriceServiceTestsMore.swift
@@ -1,5 +1,6 @@
 // MoolahTests/Shared/CryptoPriceServiceTests.swift
 import Foundation
+import GRDB
 import Testing
 
 @testable import Moolah
@@ -33,21 +34,17 @@ struct CryptoPriceServiceTestsMore {
     clients: [CryptoPriceClient] = [],
     prices: [String: [String: Decimal]] = [:],
     shouldFail: Bool = false,
-    cacheDirectory: URL? = nil,
+    database: DatabaseQueue? = nil,
     resolutionClient: (any TokenResolutionClient)? = nil
-  ) -> CryptoPriceService {
+  ) throws -> CryptoPriceService {
     let clientList =
       clients.isEmpty
       ? [FixedCryptoPriceClient(prices: prices, shouldFail: shouldFail)]
       : clients
-    let cacheDir =
-      cacheDirectory
-      ?? FileManager.default.temporaryDirectory
-      .appendingPathComponent("crypto-price-tests")
-      .appendingPathComponent(UUID().uuidString)
+    let resolved = try database ?? ProfileDatabase.openInMemory()
     return CryptoPriceService(
       clients: clientList,
-      cacheDirectory: cacheDir,
+      database: resolved,
       resolutionClient: resolutionClient
     )
   }
@@ -58,22 +55,22 @@ struct CryptoPriceServiceTestsMore {
     return formatter.date(from: string)!
   }
 
+  /// Two service instances sharing the same `DatabaseQueue` — the second
+  /// must load prices persisted by the first. Renamed from
+  /// `gzipRoundTripPreservesData` after the migration to GRDB.
   @Test
-  func gzipRoundTripPreservesData() async throws {
-    let tempDir = FileManager.default.temporaryDirectory
-      .appendingPathComponent("crypto-price-tests")
-      .appendingPathComponent(UUID().uuidString)
-    defer { try? FileManager.default.removeItem(at: tempDir) }
+  func sqlRoundTripPreservesData() async throws {
+    let database = try ProfileDatabase.openInMemory()
 
-    let service1 = makeService(
+    let service1 = try makeService(
       prices: ["1:native": ["2026-04-10": dec("1623.45")]],
-      cacheDirectory: tempDir
+      database: database
     )
     let price = try await service1.price(
       for: ethInstrument, mapping: ethMapping, on: date("2026-04-10"))
     #expect(price == dec("1623.45"))
 
-    let service2 = makeService(shouldFail: true, cacheDirectory: tempDir)
+    let service2 = try makeService(shouldFail: true, database: database)
     let cached = try await service2.price(
       for: ethInstrument, mapping: ethMapping, on: date("2026-04-10"))
     #expect(cached == dec("1623.45"))
@@ -83,7 +80,7 @@ struct CryptoPriceServiceTestsMore {
 
   @Test
   func prefetchUpdatesCacheForRegisteredItems() async throws {
-    let service = makeService(prices: [
+    let service = try makeService(prices: [
       "1:native": ["2026-04-11": dec("1640.00")],
       "0:native": ["2026-04-11": dec("67890.00")],
     ])
@@ -97,7 +94,7 @@ struct CryptoPriceServiceTestsMore {
 
   @Test
   func differentTokensAreCachedIndependently() async throws {
-    let service = makeService(prices: [
+    let service = try makeService(prices: [
       "1:native": ["2026-04-10": dec("1623.45")],
       "0:native": ["2026-04-10": dec("67890.00")],
     ])
@@ -121,7 +118,7 @@ struct CryptoPriceServiceTestsMore {
       resolvedSymbol: "UNI",
       resolvedDecimals: 18
     )
-    let service = makeService(resolutionClient: FixedTokenResolutionClient(result: result))
+    let service = try makeService(resolutionClient: FixedTokenResolutionClient(result: result))
 
     let registration = try await service.resolveRegistration(
       chainId: 1,
@@ -137,7 +134,7 @@ struct CryptoPriceServiceTestsMore {
 
   @Test
   func resolveRegistration_noProvidersMatch_returnsPartialRegistration() async throws {
-    let service = makeService(
+    let service = try makeService(
       resolutionClient: FixedTokenResolutionClient(result: TokenResolutionResult())
     )
     let registration = try await service.resolveRegistration(
@@ -154,7 +151,7 @@ struct CryptoPriceServiceTestsMore {
 
   @Test
   func resolveRegistration_resolutionFails_throws() async throws {
-    let service = makeService(
+    let service = try makeService(
       resolutionClient: FixedTokenResolutionClient(shouldFail: true)
     )
     await #expect(throws: (any Error).self) {

--- a/MoolahTests/Shared/CryptoPriceServiceTestsMore.swift
+++ b/MoolahTests/Shared/CryptoPriceServiceTestsMore.swift
@@ -160,4 +160,80 @@ struct CryptoPriceServiceTestsMore {
       )
     }
   }
+
+  // MARK: - Rollback test for multi-statement save
+
+  /// Rollback contract: `CryptoPriceService.saveCache` is one
+  /// `database.write` (delete prior price rows + re-insert + upsert meta).
+  ///
+  /// Drives the **production** `saveCache` by installing a trigger that
+  /// raises `ABORT` on a sentinel date string. A second fetch through the
+  /// service merges that sentinel into the cache, the production save path
+  /// runs, the trigger fires inside the transaction, and the entire write
+  /// must roll back — leaving prior rows untouched.
+  ///
+  /// Lives in this part-2 file (rather than the main `CryptoPriceServiceTests`)
+  /// so that primary suite stays under SwiftLint's `type_body_length` cap.
+  @Test
+  func saveCacheRollsBackOnInsertFailure() async throws {
+    let database = try ProfileDatabase.openInMemory()
+    let service = try makeService(
+      prices: ["1:native": ["2026-04-10": dec("1623.45"), "2026-04-11": dec("1700")]],
+      database: database
+    )
+    _ = try await service.price(
+      for: ethInstrument, mapping: ethMapping, on: date("2026-04-10"))
+
+    let beforeCount = try await database.read { database in
+      try CryptoPriceRecord
+        .filter(CryptoPriceRecord.Columns.tokenId == "1:native")
+        .fetchCount(database)
+    }
+    #expect(beforeCount > 0)
+
+    // Install a trigger that aborts inserts carrying the sentinel date.
+    // The trigger fires inside `saveCache`'s transaction so the upfront
+    // DELETE for the 1:native partition + the new inserts roll back together.
+    try await database.write { database in
+      try database.execute(
+        sql: """
+          CREATE TRIGGER fail_save_cache
+          BEFORE INSERT ON crypto_price
+          WHEN NEW.date = '9999-12-31'
+          BEGIN
+              SELECT RAISE(ABORT, 'forced failure for rollback test');
+          END;
+          """)
+    }
+
+    // Drive the real `saveCache` by feeding a price set that contains the
+    // sentinel date.
+    let failingService = try makeService(
+      prices: ["1:native": ["9999-12-31": dec("9999.0")]],
+      database: database
+    )
+    _ = try? await failingService.price(
+      for: ethInstrument, mapping: ethMapping, on: date("9999-12-31"))
+
+    let afterCount = try await database.read { database in
+      try CryptoPriceRecord
+        .filter(CryptoPriceRecord.Columns.tokenId == "1:native")
+        .fetchCount(database)
+    }
+    #expect(afterCount == beforeCount)
+
+    // Probe a specific priming row to prove the DELETE inside
+    // `saveCache` was rolled back. Counts can match by accident if a
+    // future regression replaces delete-and-reinsert with upsert-only —
+    // re-looking-up `(1:native, 2026-04-10, 1623.45)` confirms the row
+    // survived rather than being silently rewritten.
+    let surviving = try await database.read { database in
+      try CryptoPriceRecord
+        .filter(CryptoPriceRecord.Columns.tokenId == "1:native")
+        .filter(CryptoPriceRecord.Columns.date == "2026-04-10")
+        .fetchOne(database)
+    }
+    #expect(surviving != nil)
+    #expect(surviving?.priceUsd == 1623.45)
+  }
 }

--- a/MoolahTests/Shared/CryptoPriceServiceTestsMore.swift
+++ b/MoolahTests/Shared/CryptoPriceServiceTestsMore.swift
@@ -1,4 +1,4 @@
-// MoolahTests/Shared/CryptoPriceServiceTests.swift
+// MoolahTests/Shared/CryptoPriceServiceTestsMore.swift
 import Foundation
 import GRDB
 import Testing

--- a/MoolahTests/Shared/ExchangeRateServicePersistenceTests.swift
+++ b/MoolahTests/Shared/ExchangeRateServicePersistenceTests.swift
@@ -11,11 +11,10 @@ import Testing
 /// contract for `ExchangeRateService.saveCache`.
 @Suite("ExchangeRateService — Persistence")
 struct ExchangeRateServicePersistenceTests {
-  private func date(_ string: String) -> Date {
+  private func date(_ string: String) throws -> Date {
     let formatter = ISO8601DateFormatter()
     formatter.formatOptions = [.withFullDate]
-    // swiftlint:disable:next force_unwrapping
-    return formatter.date(from: string)!
+    return try #require(formatter.date(from: string))
   }
 
   /// Two service instances sharing the same `DatabaseQueue` — the second
@@ -39,7 +38,7 @@ struct ExchangeRateServicePersistenceTests {
     let service = ExchangeRateService(client: client, database: database)
 
     // Fetch to populate cache and write to SQL
-    let rate = try await service.rate(from: .AUD, to: .USD, on: date("2026-04-11"))
+    let rate = try await service.rate(from: .AUD, to: .USD, on: try date("2026-04-11"))
     #expect(rate == dec("0.632"))
 
     // New service reading from the same database (fresh in-memory state)
@@ -47,11 +46,11 @@ struct ExchangeRateServicePersistenceTests {
     let service2 = ExchangeRateService(client: failingClient, database: database)
 
     // Should load from the SQL cache, not network
-    let cachedRate = try await service2.rate(from: .AUD, to: .USD, on: date("2026-04-11"))
+    let cachedRate = try await service2.rate(from: .AUD, to: .USD, on: try date("2026-04-11"))
     #expect(approximatelyEqual(cachedRate, dec("0.632")))
 
     let cachedEur = try await service2.rate(
-      from: .AUD, to: Instrument.fiat(code: "EUR"), on: date("2026-04-11"))
+      from: .AUD, to: Instrument.fiat(code: "EUR"), on: try date("2026-04-11"))
     #expect(approximatelyEqual(cachedEur, dec("0.581")))
   }
 
@@ -87,9 +86,9 @@ struct ExchangeRateServicePersistenceTests {
       "2026-04-07": ["USD": dec("1.234"), "EUR": dec("0.5900")]
     ])
     let service = ExchangeRateService(client: primingClient, database: database)
-    _ = try await service.rate(from: .AUD, to: .USD, on: date("2026-04-07"))
+    _ = try await service.rate(from: .AUD, to: .USD, on: try date("2026-04-07"))
     _ = try await service.rate(
-      from: .AUD, to: Instrument.fiat(code: "EUR"), on: date("2026-04-07"))
+      from: .AUD, to: Instrument.fiat(code: "EUR"), on: try date("2026-04-07"))
 
     // Sanity: rows landed via the production save path.
     let beforeCount = try await database.read { database in
@@ -129,7 +128,7 @@ struct ExchangeRateServicePersistenceTests {
     ])
     let failingService = ExchangeRateService(client: failingClient, database: database)
     _ = try? await failingService.rate(
-      from: .AUD, to: Instrument.fiat(code: "___FAIL___"), on: date("2025-02-15"))
+      from: .AUD, to: Instrument.fiat(code: "___FAIL___"), on: try date("2025-02-15"))
 
     // Prior state survived: row count matches AND the specific priming
     // row is still present. The exact-row probe defends against future

--- a/MoolahTests/Shared/ExchangeRateServicePersistenceTests.swift
+++ b/MoolahTests/Shared/ExchangeRateServicePersistenceTests.swift
@@ -80,13 +80,16 @@ struct ExchangeRateServicePersistenceTests {
   @Test
   func saveCacheRollsBackOnInsertFailure() async throws {
     let database = try ProfileDatabase.openInMemory()
+    // Pick a specific (date, quote, rate) triple we can re-look-up after
+    // the failed save so the assertion proves the DELETE was rolled back
+    // — not just that the row count happens to match.
     let primingClient = FixedRateClient(rates: [
-      "2025-01-10": ["USD": dec("0.6400"), "EUR": dec("0.5900")]
+      "2026-04-07": ["USD": dec("1.234"), "EUR": dec("0.5900")]
     ])
     let service = ExchangeRateService(client: primingClient, database: database)
-    _ = try await service.rate(from: .AUD, to: .USD, on: date("2025-01-10"))
+    _ = try await service.rate(from: .AUD, to: .USD, on: date("2026-04-07"))
     _ = try await service.rate(
-      from: .AUD, to: Instrument.fiat(code: "EUR"), on: date("2025-01-10"))
+      from: .AUD, to: Instrument.fiat(code: "EUR"), on: date("2026-04-07"))
 
     // Sanity: rows landed via the production save path.
     let beforeCount = try await database.read { database in
@@ -128,12 +131,30 @@ struct ExchangeRateServicePersistenceTests {
     _ = try? await failingService.rate(
       from: .AUD, to: Instrument.fiat(code: "___FAIL___"), on: date("2025-02-15"))
 
-    // Prior state survived: original rows still in the table.
+    // Prior state survived: row count matches AND the specific priming
+    // row is still present. The exact-row probe defends against future
+    // regressions where `saveCache` might switch to upsert-only (no
+    // DELETE) — the count would then match for the wrong reason. Asking
+    // for the (AUD, USD, 2026-04-07) rate by value proves the original
+    // insert survived the rollback.
     let afterCount = try await database.read { database in
       try ExchangeRateRecord
         .filter(ExchangeRateRecord.Columns.base == "AUD")
         .fetchCount(database)
     }
     #expect(afterCount == beforeCount)
+
+    let surviving = try await database.read { database in
+      try ExchangeRateRecord
+        .filter(ExchangeRateRecord.Columns.base == "AUD")
+        .filter(ExchangeRateRecord.Columns.quote == "USD")
+        .filter(ExchangeRateRecord.Columns.date == "2026-04-07")
+        .fetchOne(database)
+    }
+    #expect(surviving != nil)
+    #expect(
+      approximatelyEqual(
+        Decimal(surviving?.rate ?? 0), dec("1.234"),
+        tolerance: Decimal(string: "0.0001") ?? Decimal(0)))
   }
 }

--- a/MoolahTests/Shared/ExchangeRateServicePersistenceTests.swift
+++ b/MoolahTests/Shared/ExchangeRateServicePersistenceTests.swift
@@ -1,0 +1,121 @@
+// MoolahTests/Shared/ExchangeRateServicePersistenceTests.swift
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+/// Persistence tests live in their own suite so the main behavioural suite
+/// (`ExchangeRateServiceTests`) stays under the `type_body_length` cap.
+/// Covers the SQL save/load round-trip and the multi-statement rollback
+/// contract for `ExchangeRateService.saveCache`.
+@Suite("ExchangeRateService — Persistence")
+struct ExchangeRateServicePersistenceTests {
+  private func date(_ string: String) -> Date {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withFullDate]
+    // swiftlint:disable:next force_unwrapping
+    return formatter.date(from: string)!
+  }
+
+  /// Two service instances sharing the same `DatabaseQueue` — the second
+  /// must load rates persisted by the first without going to the network.
+  /// Renamed from `gzipRoundTripPreservesData` after the migration from
+  /// gzipped JSON cache files to GRDB.
+  ///
+  /// Rates are stored as `REAL` (`Double`) per the schema; the boundary
+  /// conversion `Decimal → Double → Decimal` preserves source precision
+  /// for values that have an exact binary representation but may add a
+  /// trailing precision tail otherwise. The test asserts approximate
+  /// equality (1e-9) rather than exact match — the FX path's user-facing
+  /// precision (4 dp on Frankfurter) is far above this tolerance.
+  @Test
+  func sqlRoundTripPreservesData() async throws {
+    let database = try ProfileDatabase.openInMemory()
+
+    let client = FixedRateClient(rates: [
+      "2026-04-11": ["USD": dec("0.632"), "EUR": dec("0.581")]
+    ])
+    let service = ExchangeRateService(client: client, database: database)
+
+    // Fetch to populate cache and write to SQL
+    let rate = try await service.rate(from: .AUD, to: .USD, on: date("2026-04-11"))
+    #expect(rate == dec("0.632"))
+
+    // New service reading from the same database (fresh in-memory state)
+    let failingClient = FixedRateClient(shouldFail: true)
+    let service2 = ExchangeRateService(client: failingClient, database: database)
+
+    // Should load from the SQL cache, not network
+    let cachedRate = try await service2.rate(from: .AUD, to: .USD, on: date("2026-04-11"))
+    #expect(approximatelyEqual(cachedRate, dec("0.632")))
+
+    let cachedEur = try await service2.rate(
+      from: .AUD, to: Instrument.fiat(code: "EUR"), on: date("2026-04-11"))
+    #expect(approximatelyEqual(cachedEur, dec("0.581")))
+  }
+
+  private func approximatelyEqual(
+    _ lhs: Decimal,
+    _ rhs: Decimal,
+    tolerance: Decimal = Decimal(string: "0.000000001") ?? Decimal(0)
+  ) -> Bool {
+    let delta = lhs - rhs
+    let absDelta = delta < 0 ? -delta : delta
+    return absDelta <= tolerance
+  }
+
+  /// Rollback contract: the service's save path is a single
+  /// `database.write` transaction (delete prior rows + re-insert + upsert
+  /// meta). If any statement inside the transaction throws, prior state
+  /// must survive untouched. This test seeds a successful save through the
+  /// service, then runs a write that mirrors the same shape but trips a
+  /// `PRIMARY KEY` constraint mid-transaction; the prior rows must remain.
+  ///
+  /// Mirrors `SQLiteCoinGeckoCatalogStorageTests.replaceAllRollsBackOnConstraintFailure`.
+  @Test
+  func saveRollsBackOnConstraintFailure() async throws {
+    let database = try ProfileDatabase.openInMemory()
+    let primingClient = FixedRateClient(rates: [
+      "2025-01-10": ["USD": dec("0.6400"), "EUR": dec("0.5900")]
+    ])
+    let service = ExchangeRateService(client: primingClient, database: database)
+    _ = try await service.rate(from: .AUD, to: .USD, on: date("2025-01-10"))
+    _ = try await service.rate(from: .AUD, to: .USD, on: date("2025-01-10"))
+    _ = try await service.rate(
+      from: .AUD, to: Instrument.fiat(code: "EUR"), on: date("2025-01-10"))
+
+    // Sanity: rows landed.
+    let beforeCount = try await database.read { database in
+      try ExchangeRateRecord
+        .filter(ExchangeRateRecord.Columns.base == "AUD")
+        .fetchCount(database)
+    }
+    #expect(beforeCount >= 2)
+
+    // Force a constraint violation inside the same transaction shape that
+    // `saveCache` uses: delete prior rows for AUD, re-insert one, then
+    // re-insert a duplicate (base, date, quote) — the second insert trips
+    // the PK and the whole transaction must roll back.
+    await #expect(throws: (any Error).self) {
+      try await database.write { database in
+        try ExchangeRateRecord
+          .filter(ExchangeRateRecord.Columns.base == "AUD")
+          .deleteAll(database)
+        try ExchangeRateRecord(base: "AUD", quote: "USD", date: "2026-01-01", rate: 0.5)
+          .insert(database)
+        try ExchangeRateRecord(base: "AUD", quote: "USD", date: "2026-01-01", rate: 0.6)
+          .insert(database)
+      }
+    }
+
+    // Prior state survived: original rows are still in the table, the
+    // failed transaction's deletes did not commit.
+    let afterCount = try await database.read { database in
+      try ExchangeRateRecord
+        .filter(ExchangeRateRecord.Columns.base == "AUD")
+        .fetchCount(database)
+    }
+    #expect(afterCount == beforeCount)
+  }
+}

--- a/MoolahTests/Shared/ExchangeRateServicePersistenceTests.swift
+++ b/MoolahTests/Shared/ExchangeRateServicePersistenceTests.swift
@@ -65,27 +65,30 @@ struct ExchangeRateServicePersistenceTests {
     return absDelta <= tolerance
   }
 
-  /// Rollback contract: the service's save path is a single
+  /// Rollback contract: `ExchangeRateService.saveCache` is a single
   /// `database.write` transaction (delete prior rows + re-insert + upsert
   /// meta). If any statement inside the transaction throws, prior state
-  /// must survive untouched. This test seeds a successful save through the
-  /// service, then runs a write that mirrors the same shape but trips a
-  /// `PRIMARY KEY` constraint mid-transaction; the prior rows must remain.
+  /// must survive untouched.
   ///
-  /// Mirrors `SQLiteCoinGeckoCatalogStorageTests.replaceAllRollsBackOnConstraintFailure`.
+  /// To drive the **production** save path (rather than asserting on a
+  /// hand-rolled mirror of `saveCache`'s shape), this test installs a
+  /// SQLite `BEFORE INSERT` trigger that raises `ABORT` whenever a
+  /// sentinel quote (`"___FAIL___"`) is inserted. A second fetch through
+  /// the service yields a rate set containing that sentinel, which makes
+  /// the real `saveCache` throw mid-transaction. Prior rows must remain
+  /// because SQLite rolls the transaction back atomically.
   @Test
-  func saveRollsBackOnConstraintFailure() async throws {
+  func saveCacheRollsBackOnInsertFailure() async throws {
     let database = try ProfileDatabase.openInMemory()
     let primingClient = FixedRateClient(rates: [
       "2025-01-10": ["USD": dec("0.6400"), "EUR": dec("0.5900")]
     ])
     let service = ExchangeRateService(client: primingClient, database: database)
     _ = try await service.rate(from: .AUD, to: .USD, on: date("2025-01-10"))
-    _ = try await service.rate(from: .AUD, to: .USD, on: date("2025-01-10"))
     _ = try await service.rate(
       from: .AUD, to: Instrument.fiat(code: "EUR"), on: date("2025-01-10"))
 
-    // Sanity: rows landed.
+    // Sanity: rows landed via the production save path.
     let beforeCount = try await database.read { database in
       try ExchangeRateRecord
         .filter(ExchangeRateRecord.Columns.base == "AUD")
@@ -93,24 +96,39 @@ struct ExchangeRateServicePersistenceTests {
     }
     #expect(beforeCount >= 2)
 
-    // Force a constraint violation inside the same transaction shape that
-    // `saveCache` uses: delete prior rows for AUD, re-insert one, then
-    // re-insert a duplicate (base, date, quote) — the second insert trips
-    // the PK and the whole transaction must roll back.
-    await #expect(throws: (any Error).self) {
-      try await database.write { database in
-        try ExchangeRateRecord
-          .filter(ExchangeRateRecord.Columns.base == "AUD")
-          .deleteAll(database)
-        try ExchangeRateRecord(base: "AUD", quote: "USD", date: "2026-01-01", rate: 0.5)
-          .insert(database)
-        try ExchangeRateRecord(base: "AUD", quote: "USD", date: "2026-01-01", rate: 0.6)
-          .insert(database)
-      }
+    // Install a trigger that aborts any insert with the sentinel quote.
+    // The trigger fires inside `saveCache`'s transaction so the entire
+    // save (including the upfront DELETE for the AUD partition) must
+    // roll back together.
+    try await database.write { database in
+      try database.execute(
+        sql: """
+          CREATE TRIGGER fail_save_cache
+          BEFORE INSERT ON exchange_rate
+          WHEN NEW.quote = '___FAIL___'
+          BEGIN
+              SELECT RAISE(ABORT, 'forced failure for rollback test');
+          END;
+          """)
     }
 
-    // Prior state survived: original rows are still in the table, the
-    // failed transaction's deletes did not commit.
+    // Drive the real `saveCache` by feeding a new rate set whose payload
+    // contains the sentinel quote. The service's save path executes the
+    // same delete-then-reinsert sequence as in production; the trigger
+    // raises mid-transaction, so the whole disk write must roll back.
+    //
+    // The public `rate(...)` call may still return successfully because
+    // `fetchToCoverDate` swallows the error and the in-memory cache holds
+    // the merged value — `try?` reflects "we don't care about the return
+    // value here; we only care about the rollback observed on disk".
+    let failingClient = FixedRateClient(rates: [
+      "2025-02-15": ["___FAIL___": dec("1.0")]
+    ])
+    let failingService = ExchangeRateService(client: failingClient, database: database)
+    _ = try? await failingService.rate(
+      from: .AUD, to: Instrument.fiat(code: "___FAIL___"), on: date("2025-02-15"))
+
+    // Prior state survived: original rows still in the table.
     let afterCount = try await database.read { database in
       try ExchangeRateRecord
         .filter(ExchangeRateRecord.Columns.base == "AUD")

--- a/MoolahTests/Shared/ExchangeRateServiceTests.swift
+++ b/MoolahTests/Shared/ExchangeRateServiceTests.swift
@@ -1,5 +1,6 @@
 // MoolahTests/Shared/ExchangeRateServiceTests.swift
 import Foundation
+import GRDB
 import Testing
 
 @testable import Moolah
@@ -8,13 +9,12 @@ import Testing
 struct ExchangeRateServiceTests {
   private func makeService(
     rates: [String: [String: Decimal]] = [:],
-    shouldFail: Bool = false
-  ) -> ExchangeRateService {
+    shouldFail: Bool = false,
+    database: DatabaseQueue? = nil
+  ) throws -> ExchangeRateService {
     let client = FixedRateClient(rates: rates, shouldFail: shouldFail)
-    let cacheDir = FileManager.default.temporaryDirectory
-      .appendingPathComponent("exchange-rate-tests")
-      .appendingPathComponent(UUID().uuidString)
-    return ExchangeRateService(client: client, cacheDirectory: cacheDir)
+    let resolved = try database ?? ProfileDatabase.openInMemory()
+    return ExchangeRateService(client: client, database: resolved)
   }
 
   private func date(_ string: String) -> Date {
@@ -27,7 +27,7 @@ struct ExchangeRateServiceTests {
 
   @Test
   func sameCurrencyReturnsIdentityRate() async throws {
-    let service = makeService()
+    let service = try makeService()
     let rate = try await service.rate(from: .AUD, to: .AUD, on: date("2025-01-15"))
     #expect(rate == Decimal(1))
   }
@@ -36,7 +36,7 @@ struct ExchangeRateServiceTests {
 
   @Test
   func cacheMissFetchesFromClient() async throws {
-    let service = makeService(rates: [
+    let service = try makeService(rates: [
       "2025-01-15": ["USD": dec("0.6543")]
     ])
     let rate = try await service.rate(from: .AUD, to: .USD, on: date("2025-01-15"))
@@ -45,7 +45,7 @@ struct ExchangeRateServiceTests {
 
   @Test
   func cacheHitDoesNotRefetch() async throws {
-    let service = makeService(rates: [
+    let service = try makeService(rates: [
       "2025-01-15": ["USD": dec("0.6543")]
     ])
     let first = try await service.rate(from: .AUD, to: .USD, on: date("2025-01-15"))
@@ -63,10 +63,8 @@ struct ExchangeRateServiceTests {
       "2025-01-17": ["USD": dec("0.6500")]
     ]
     let fridayClient = FixedRateClient(rates: fridayRates, shouldFail: false)
-    let cacheDir = FileManager.default.temporaryDirectory
-      .appendingPathComponent("exchange-rate-tests")
-      .appendingPathComponent(UUID().uuidString)
-    let service = ExchangeRateService(client: fridayClient, cacheDirectory: cacheDir)
+    let service = ExchangeRateService(
+      client: fridayClient, database: try ProfileDatabase.openInMemory())
 
     // Fetch Friday to populate cache
     let fridayRate = try await service.rate(from: .AUD, to: .USD, on: date("2025-01-17"))
@@ -82,7 +80,7 @@ struct ExchangeRateServiceTests {
 
   @Test
   func networkFailureWithEmptyCacheThrows() async throws {
-    let service = makeService(shouldFail: true)
+    let service = try makeService(shouldFail: true)
     await #expect(throws: (any Error).self) {
       try await service.rate(from: .AUD, to: .USD, on: date("2025-01-15"))
     }
@@ -92,7 +90,7 @@ struct ExchangeRateServiceTests {
 
   @Test
   func rangeReturnsRatesForEachDay() async throws {
-    let service = makeService(rates: [
+    let service = try makeService(rates: [
       "2026-04-07": ["USD": dec("0.630")],
       "2026-04-08": ["USD": dec("0.631")],
       "2026-04-09": ["USD": dec("0.632")],
@@ -109,7 +107,7 @@ struct ExchangeRateServiceTests {
 
   @Test
   func rangeOnlyFetchesMissingSegments() async throws {
-    let service = makeService(rates: [
+    let service = try makeService(rates: [
       "2026-04-07": ["USD": dec("0.630")],
       "2026-04-08": ["USD": dec("0.631")],
       "2026-04-09": ["USD": dec("0.632")],
@@ -131,7 +129,7 @@ struct ExchangeRateServiceTests {
 
   @Test
   func sameCurrencyRangeReturnsIdentity() async throws {
-    let service = makeService()
+    let service = try makeService()
     let results = try await service.rates(
       from: .AUD, to: .AUD,
       in: date("2026-04-07")...date("2026-04-09")
@@ -144,7 +142,7 @@ struct ExchangeRateServiceTests {
 
   @Test
   func convertProducesCorrectAmount() async throws {
-    let service = makeService(rates: [
+    let service = try makeService(rates: [
       "2026-04-11": ["USD": dec("0.632")]
     ])
     let amount = InstrumentAmount(quantity: dec("100.00"), instrument: .AUD)
@@ -156,7 +154,7 @@ struct ExchangeRateServiceTests {
 
   @Test
   func convertSameCurrencyReturnsIdentical() async throws {
-    let service = makeService()
+    let service = try makeService()
     let amount = InstrumentAmount(quantity: dec("100.00"), instrument: .AUD)
     let converted = try await service.convert(amount, to: .AUD, on: date("2026-04-11"))
     #expect(converted.quantity == dec("100.00"))
@@ -165,7 +163,7 @@ struct ExchangeRateServiceTests {
 
   @Test
   func convertUsesDecimalPrecision() async throws {
-    let service = makeService(rates: [
+    let service = try makeService(rates: [
       "2026-04-11": ["USD": dec("0.5")]
     ])
     let amount = InstrumentAmount(quantity: dec("5.55"), instrument: .AUD)
@@ -178,7 +176,7 @@ struct ExchangeRateServiceTests {
 
   @Test
   func prefetchUpdatesCache() async throws {
-    let service = makeService(rates: [
+    let service = try makeService(rates: [
       "2026-04-10": ["USD": dec("0.629")],
       "2026-04-11": ["USD": dec("0.632")],
     ])
@@ -187,33 +185,8 @@ struct ExchangeRateServiceTests {
     #expect(rate == dec("0.632"))
   }
 
-  @Test
-  func gzipRoundTripPreservesData() async throws {
-    let tempDir = FileManager.default.temporaryDirectory
-      .appendingPathComponent(UUID().uuidString, isDirectory: true)
-    defer { try? FileManager.default.removeItem(at: tempDir) }
-
-    let client = FixedRateClient(rates: [
-      "2026-04-11": ["USD": dec("0.632"), "EUR": dec("0.581")]
-    ])
-    let service = ExchangeRateService(client: client, cacheDirectory: tempDir)
-
-    // Fetch to populate cache and write to disk
-    let rate = try await service.rate(from: .AUD, to: .USD, on: date("2026-04-11"))
-    #expect(rate == dec("0.632"))
-
-    // Create a new service reading from the same directory (fresh in-memory state)
-    let failingClient = FixedRateClient(shouldFail: true)
-    let service2 = ExchangeRateService(client: failingClient, cacheDirectory: tempDir)
-
-    // Should load from disk cache, not network
-    let cachedRate = try await service2.rate(from: .AUD, to: .USD, on: date("2026-04-11"))
-    #expect(cachedRate == dec("0.632"))
-
-    let cachedEur = try await service2.rate(
-      from: .AUD, to: Instrument.fiat(code: "EUR"), on: date("2026-04-11"))
-    #expect(cachedEur == dec("0.581"))
-  }
+  // SQL persistence tests live in `ExchangeRateServicePersistenceTests`
+  // (round-trip + rollback) so this file stays under `type_body_length`.
 
   @Test
   func fallbackNeverUsesFutureDate() async throws {
@@ -222,10 +195,8 @@ struct ExchangeRateServiceTests {
       "2025-01-20": ["USD": dec("0.6500")]
     ]
     let client = FixedRateClient(rates: futureRates, shouldFail: false)
-    let cacheDir = FileManager.default.temporaryDirectory
-      .appendingPathComponent("exchange-rate-tests")
-      .appendingPathComponent(UUID().uuidString)
-    let service = ExchangeRateService(client: client, cacheDirectory: cacheDir)
+    let service = ExchangeRateService(
+      client: client, database: try ProfileDatabase.openInMemory())
 
     // Fetch future date to populate cache
     _ = try await service.rate(from: .AUD, to: .USD, on: date("2025-01-20"))
@@ -248,7 +219,7 @@ struct ExchangeRateServiceTests {
   @Test
   func coldCacheFallsBackToPriorTradingDayWhenRequestedDateMissing() async throws {
     // Client has data for Jan 17 (Friday) but not Jan 18 (Saturday).
-    let service = makeService(rates: [
+    let service = try makeService(rates: [
       "2025-01-17": ["USD": dec("0.6500")]
     ])
 
@@ -263,7 +234,7 @@ struct ExchangeRateServiceTests {
   func coldCacheWithNetworkErrorThrows() async throws {
     // shouldFail simulates a network error. With no prior cache and a failing
     // fetch we have nothing to fall back to, so we must throw.
-    let service = makeService(shouldFail: true)
+    let service = try makeService(shouldFail: true)
     await #expect(throws: (any Error).self) {
       try await service.rate(from: .AUD, to: .USD, on: date("2025-01-15"))
     }
@@ -277,7 +248,7 @@ struct ExchangeRateServiceTests {
   /// the most-recent cached rate rather than throwing.
   @Test
   func futureRequestExtendsForwardAndFallsBack() async throws {
-    let service = makeService(rates: [
+    let service = try makeService(rates: [
       "2025-01-10": ["USD": dec("0.6400")]
     ])
     // Prime the cache by fetching Jan 10.
@@ -294,7 +265,7 @@ struct ExchangeRateServiceTests {
   /// missing historical range.
   @Test
   func pastRequestExtendsBackwardAndReturnsRate() async throws {
-    let service = makeService(rates: [
+    let service = try makeService(rates: [
       "2025-01-15": ["USD": dec("0.6480")],
       "2025-01-25": ["USD": dec("0.6600")],
     ])
@@ -316,19 +287,18 @@ struct ExchangeRateServiceTests {
     let primingClient = FixedRateClient(rates: [
       "2025-01-10": ["USD": dec("0.6400")]
     ])
-    let cacheDir = FileManager.default.temporaryDirectory
-      .appendingPathComponent("exchange-rate-tests")
-      .appendingPathComponent(UUID().uuidString)
-    let service = ExchangeRateService(client: primingClient, cacheDirectory: cacheDir)
+    let database = try ProfileDatabase.openInMemory()
+    let service = ExchangeRateService(client: primingClient, database: database)
     _ = try await service.rate(from: .AUD, to: .USD, on: date("2025-01-10"))
 
-    // Step 2: new service using the same cache dir but with a failing client.
+    // Step 2: new service sharing the same database but with a failing client.
     let failingClient = FixedRateClient(shouldFail: true)
-    let service2 = ExchangeRateService(client: failingClient, cacheDirectory: cacheDir)
+    let service2 = ExchangeRateService(client: failingClient, database: database)
 
     // Requesting Jan 15 triggers a forward extension fetch that fails. Should
     // still return the cached Jan 10 rate via fallback.
     let rate = try await service2.rate(from: .AUD, to: .USD, on: date("2025-01-15"))
     #expect(rate == dec("0.6400"))
   }
+
 }

--- a/MoolahTests/Shared/FullConversionErrorPropagationTests.swift
+++ b/MoolahTests/Shared/FullConversionErrorPropagationTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import GRDB
 import Testing
 
 @testable import Moolah
@@ -14,17 +15,16 @@ struct FullConversionErrorPropagationTests {
   /// and violate Rule 11 of `guides/INSTRUMENT_CONVERSION_GUIDE.md`.
   @Test
   func cryptoConversionPropagatesRegistryError() async throws {
+    let database = try ProfileDatabase.openInMemory()
     let cryptoService = CryptoPriceService(
       clients: [FixedCryptoPriceClient()],
-      cacheDirectory: FileManager.default.temporaryDirectory
-        .appendingPathComponent(UUID().uuidString)
+      database: database
     )
     let exchangeService = ExchangeRateService(
       client: FixedRateClient(rates: [:]),
-      cacheDirectory: FileManager.default.temporaryDirectory
-        .appendingPathComponent(UUID().uuidString)
+      database: database
     )
-    let stockService = StockPriceService(client: FixedStockPriceClient())
+    let stockService = StockPriceService(client: FixedStockPriceClient(), database: database)
 
     let service = FullConversionService(
       exchangeRates: exchangeService,

--- a/MoolahTests/Shared/InstrumentAmountConversionTests.swift
+++ b/MoolahTests/Shared/InstrumentAmountConversionTests.swift
@@ -1,5 +1,6 @@
 // MoolahTests/Shared/InstrumentAmountConversionTests.swift
 import Foundation
+import GRDB
 import Testing
 
 @testable import Moolah
@@ -12,12 +13,16 @@ struct InstrumentAmountConversionTests {
     return formatter.date(from: string)!
   }
 
+  private func makeService(client: ExchangeRateClient) throws -> ExchangeRateService {
+    ExchangeRateService(client: client, database: try ProfileDatabase.openInMemory())
+  }
+
   @Test
   func convertedDelegatesToService() async throws {
     let client = FixedRateClient(rates: [
       "2026-04-11": ["GBP": dec("0.497")]
     ])
-    let service = ExchangeRateService(client: client)
+    let service = try makeService(client: client)
     let amount = InstrumentAmount(quantity: dec("200.00"), instrument: .AUD)
 
     let result = try await service.convert(
@@ -30,7 +35,7 @@ struct InstrumentAmountConversionTests {
   @Test
   func convertedSameInstrumentReturnsOriginal() async throws {
     let client = FixedRateClient()
-    let service = ExchangeRateService(client: client)
+    let service = try makeService(client: client)
     let amount = InstrumentAmount(quantity: dec("123.45"), instrument: .AUD)
 
     let result = try await service.convert(amount, to: .AUD, on: date("2026-04-11"))
@@ -45,7 +50,7 @@ struct InstrumentAmountConversionTests {
     let client = FixedRateClient(rates: [
       "2026-04-11": ["JPY": dec("95.50")]
     ])
-    let service = ExchangeRateService(client: client)
+    let service = try makeService(client: client)
     let amount = InstrumentAmount(quantity: Decimal(100), instrument: .AUD)
 
     let result = try await service.convert(
@@ -60,7 +65,7 @@ struct InstrumentAmountConversionTests {
     let client = FixedRateClient(rates: [
       "2026-04-11": ["USD": dec("0.65")]
     ])
-    let service = ExchangeRateService(client: client)
+    let service = try makeService(client: client)
     let amount = InstrumentAmount(quantity: dec("-200.00"), instrument: .AUD)
 
     let result = try await service.convert(

--- a/MoolahTests/Shared/InstrumentConversionServiceCryptoTests.swift
+++ b/MoolahTests/Shared/InstrumentConversionServiceCryptoTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import GRDB
 import Testing
 
 @testable import Moolah
@@ -24,20 +25,19 @@ struct InstrumentConversionServiceCryptoTests {
     cryptoPrices: [String: [String: Decimal]] = [:],
     exchangeRates: [String: [String: Decimal]] = [:],
     providerMappings: [CryptoProviderMapping] = []
-  ) -> FullConversionService {
+  ) throws -> FullConversionService {
+    let database = try ProfileDatabase.openInMemory()
     let cryptoClient = FixedCryptoPriceClient(prices: cryptoPrices)
     let cryptoService = CryptoPriceService(
       clients: [cryptoClient],
-      cacheDirectory: FileManager.default.temporaryDirectory
-        .appendingPathComponent(UUID().uuidString)
+      database: database
     )
     let exchangeClient = FixedRateClient(rates: exchangeRates)
     let exchangeService = ExchangeRateService(
       client: exchangeClient,
-      cacheDirectory: FileManager.default.temporaryDirectory
-        .appendingPathComponent(UUID().uuidString)
+      database: database
     )
-    let stockService = StockPriceService(client: FixedStockPriceClient())
+    let stockService = StockPriceService(client: FixedStockPriceClient(), database: database)
     return FullConversionService(
       exchangeRates: exchangeService,
       stockPrices: stockService,
@@ -50,7 +50,7 @@ struct InstrumentConversionServiceCryptoTests {
 
   @Test
   func cryptoToUsdUsesDirectPrice() async throws {
-    let service = makeService(
+    let service = try makeService(
       cryptoPrices: ["1:native": ["2026-04-10": dec("1623.45")]],
       providerMappings: [
         CryptoProviderMapping(
@@ -70,7 +70,7 @@ struct InstrumentConversionServiceCryptoTests {
 
   @Test
   func cryptoToAudGoesViaUsd() async throws {
-    let service = makeService(
+    let service = try makeService(
       cryptoPrices: ["1:native": ["2026-04-10": dec("1623.45")]],
       exchangeRates: ["2026-04-10": ["AUD": dec("1.58")]],
       providerMappings: [
@@ -92,7 +92,7 @@ struct InstrumentConversionServiceCryptoTests {
 
   @Test
   func cryptoToCryptoChainsThroughUsd() async throws {
-    let service = makeService(
+    let service = try makeService(
       cryptoPrices: [
         "1:native": ["2026-04-10": dec("1623.45")],
         "0:native": ["2026-04-10": dec("63000.00")],
@@ -120,7 +120,7 @@ struct InstrumentConversionServiceCryptoTests {
 
   @Test
   func missingProviderMappingThrows() async throws {
-    let service = makeService(
+    let service = try makeService(
       cryptoPrices: ["1:native": ["2026-04-10": dec("1623.45")]]
     )
     await #expect(throws: (any Error).self) {
@@ -132,7 +132,7 @@ struct InstrumentConversionServiceCryptoTests {
 
   @Test
   func fiatToCryptoIsInverseOfCryptoToFiat() async throws {
-    let service = makeService(
+    let service = try makeService(
       cryptoPrices: ["1:native": ["2026-04-10": dec("1623.45")]],
       providerMappings: [
         CryptoProviderMapping(
@@ -153,7 +153,7 @@ struct InstrumentConversionServiceCryptoTests {
   @Test
   func cryptoToFiatPreservesHighPrecisionMultiplication() async throws {
     // Verify that high-decimal crypto quantities preserve precision through conversion.
-    let service = makeService(
+    let service = try makeService(
       cryptoPrices: ["1:native": ["2026-04-10": dec("1623.45")]],
       providerMappings: [
         CryptoProviderMapping(
@@ -173,7 +173,7 @@ struct InstrumentConversionServiceCryptoTests {
   func zeroDecimalFiatToCryptoGoesThroughUsd() async throws {
     // JPY has 0 decimals; route JPY → USD → ETH should not throw for fiat bridging.
     let jpy = Instrument.fiat(code: "JPY")
-    let service = makeService(
+    let service = try makeService(
       cryptoPrices: ["1:native": ["2026-04-10": dec("2000.00")]],
       exchangeRates: ["2026-04-10": ["JPY": dec("150.00")]],
       providerMappings: [
@@ -192,7 +192,7 @@ struct InstrumentConversionServiceCryptoTests {
 
   @Test
   func missingCryptoPriceThrows() async throws {
-    let service = makeService(
+    let service = try makeService(
       cryptoPrices: [:],
       providerMappings: [
         CryptoProviderMapping(
@@ -216,17 +216,16 @@ struct InstrumentConversionServiceCryptoTests {
     let cryptoClient = FixedCryptoPriceClient(
       prices: ["1:native": ["2026-04-10": dec("1623.45")]]
     )
+    let database = try ProfileDatabase.openInMemory()
     let cryptoService = CryptoPriceService(
       clients: [cryptoClient],
-      cacheDirectory: FileManager.default.temporaryDirectory
-        .appendingPathComponent(UUID().uuidString)
+      database: database
     )
     let exchangeService = ExchangeRateService(
       client: FixedRateClient(rates: [:]),
-      cacheDirectory: FileManager.default.temporaryDirectory
-        .appendingPathComponent(UUID().uuidString)
+      database: database
     )
-    let stockService = StockPriceService(client: FixedStockPriceClient())
+    let stockService = StockPriceService(client: FixedStockPriceClient(), database: database)
     let source = MutableMappingsSource()
 
     let service = FullConversionService(

--- a/MoolahTests/Shared/InstrumentConversionServiceStockTests.swift
+++ b/MoolahTests/Shared/InstrumentConversionServiceStockTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import GRDB
 import Testing
 
 @testable import Moolah
@@ -13,17 +14,12 @@ struct InstrumentConversionServiceStockTests {
   private func makeService(
     stockPrices: [String: StockPriceResponse] = [:],
     exchangeRates: [String: [String: Decimal]] = [:]
-  ) -> FullConversionService {
+  ) throws -> FullConversionService {
+    let database = try ProfileDatabase.openInMemory()
     let stockClient = FixedStockPriceClient(responses: stockPrices)
-    let stockCacheDir = FileManager.default.temporaryDirectory
-      .appendingPathComponent("stock-price-tests")
-      .appendingPathComponent(UUID().uuidString)
-    let stockService = StockPriceService(client: stockClient, cacheDirectory: stockCacheDir)
+    let stockService = StockPriceService(client: stockClient, database: database)
     let rateClient = FixedRateClient(rates: exchangeRates)
-    let rateCacheDir = FileManager.default.temporaryDirectory
-      .appendingPathComponent("conversion-stock-tests")
-      .appendingPathComponent(UUID().uuidString)
-    let rateService = ExchangeRateService(client: rateClient, cacheDirectory: rateCacheDir)
+    let rateService = ExchangeRateService(client: rateClient, database: database)
     return FullConversionService(
       exchangeRates: rateService,
       stockPrices: stockService
@@ -41,7 +37,7 @@ struct InstrumentConversionServiceStockTests {
     // BHP listed in AUD, converting to AUD — just stock price, no FX
     let today = Date()
     let dateKey = dateString(today)
-    let service = makeService(
+    let service = try makeService(
       stockPrices: [
         "BHP.AX": StockPriceResponse(instrument: .AUD, prices: [dateKey: dec("42.30")])
       ]
@@ -57,7 +53,7 @@ struct InstrumentConversionServiceStockTests {
     // AAPL listed in USD, converting to AUD — stock price * FX rate
     let today = Date()
     let dateKey = dateString(today)
-    let service = makeService(
+    let service = try makeService(
       stockPrices: [
         "AAPL": StockPriceResponse(instrument: .USD, prices: [dateKey: dec("185.50")])
       ],
@@ -73,7 +69,7 @@ struct InstrumentConversionServiceStockTests {
   func stockToStockNotSupported() async throws {
     // Stock-to-stock conversion should throw (go through fiat as intermediate)
     let today = Date()
-    let service = makeService()
+    let service = try makeService()
 
     await #expect(throws: (any Error).self) {
       _ = try await service.convert(Decimal(10), from: bhp, to: aapl, on: today)
@@ -84,7 +80,7 @@ struct InstrumentConversionServiceStockTests {
   func fiatToStockNotSupported() async throws {
     // Fiat-to-stock conversion doesn't make sense for display purposes
     let today = Date()
-    let service = makeService()
+    let service = try makeService()
 
     await #expect(throws: (any Error).self) {
       _ = try await service.convert(Decimal(1000), from: aud, to: bhp, on: today)
@@ -95,7 +91,7 @@ struct InstrumentConversionServiceStockTests {
   func foreignFiatToStockListedInDifferentFiatThrowsSymmetrically() async throws {
     // fiatToStock is not a supported conversion direction regardless of source fiat.
     let today = Date()
-    let service = makeService()
+    let service = try makeService()
 
     await #expect(throws: (any Error).self) {
       _ = try await service.convert(Decimal(1000), from: usd, to: bhp, on: today)
@@ -107,7 +103,7 @@ struct InstrumentConversionServiceStockTests {
     // Simulate a USD-listed stock converting to USD directly (no FX required).
     let today = Date()
     let dateKey = dateString(today)
-    let service = makeService(
+    let service = try makeService(
       stockPrices: [
         "AAPL": StockPriceResponse(instrument: .USD, prices: [dateKey: dec("185.50")])
       ]
@@ -122,7 +118,7 @@ struct InstrumentConversionServiceStockTests {
     // JPY has 0 decimals; request still throws (direction not supported) without crashing.
     let today = Date()
     let jpy = Instrument.fiat(code: "JPY")
-    let service = makeService()
+    let service = try makeService()
 
     await #expect(throws: (any Error).self) {
       _ = try await service.convert(Decimal(100000), from: jpy, to: bhp, on: today)
@@ -132,16 +128,11 @@ struct InstrumentConversionServiceStockTests {
   @Test
   func stockPriceFetchFailureThrows() async throws {
     let today = Date()
+    let database = try ProfileDatabase.openInMemory()
     let stockClient = FixedStockPriceClient(shouldFail: true)
-    let stockCacheDir = FileManager.default.temporaryDirectory
-      .appendingPathComponent("stock-price-fail-tests")
-      .appendingPathComponent(UUID().uuidString)
-    let stockService = StockPriceService(client: stockClient, cacheDirectory: stockCacheDir)
+    let stockService = StockPriceService(client: stockClient, database: database)
     let rateClient = FixedRateClient(rates: [:])
-    let cacheDir = FileManager.default.temporaryDirectory
-      .appendingPathComponent("conversion-stock-tests")
-      .appendingPathComponent(UUID().uuidString)
-    let rateService = ExchangeRateService(client: rateClient, cacheDirectory: cacheDir)
+    let rateService = ExchangeRateService(client: rateClient, database: database)
     let service = FullConversionService(
       exchangeRates: rateService,
       stockPrices: stockService
@@ -161,7 +152,7 @@ struct InstrumentConversionServiceStockTests {
     let calendar = Calendar(identifier: .gregorian)
     let today = calendar.startOfDay(for: Date())
     let pastKey = dateString(calendar.date(byAdding: .day, value: -10, to: today)!)
-    let service = makeService(
+    let service = try makeService(
       exchangeRates: [pastKey: ["USD": dec("0.6500")]]
     )
 

--- a/MoolahTests/Shared/StockPriceServiceTests.swift
+++ b/MoolahTests/Shared/StockPriceServiceTests.swift
@@ -259,6 +259,20 @@ struct StockPriceServiceTests {
         .fetchCount(database)
     }
     #expect(afterCount == beforeCount)
+
+    // Probe a specific priming row to prove the DELETE inside
+    // `saveCache` was rolled back. Counts can match by accident if a
+    // future regression replaces delete-and-reinsert with upsert-only —
+    // re-looking-up `(BHP.AX, 2026-04-07, 38.50)` confirms the row
+    // survived rather than being silently rewritten.
+    let surviving = try await database.read { database in
+      try StockPriceRecord
+        .filter(StockPriceRecord.Columns.ticker == "BHP.AX")
+        .filter(StockPriceRecord.Columns.date == "2026-04-07")
+        .fetchOne(database)
+    }
+    #expect(surviving != nil)
+    #expect(surviving?.price == 38.50)
   }
 
   // MARK: - Multiple tickers

--- a/MoolahTests/Shared/StockPriceServiceTests.swift
+++ b/MoolahTests/Shared/StockPriceServiceTests.swift
@@ -1,5 +1,6 @@
 // MoolahTests/Shared/StockPriceServiceTests.swift
 import Foundation
+import GRDB
 import Testing
 
 @testable import Moolah
@@ -9,15 +10,11 @@ struct StockPriceServiceTests {
   private func makeService(
     responses: [String: StockPriceResponse] = [:],
     shouldFail: Bool = false,
-    cacheDirectory: URL? = nil
-  ) -> StockPriceService {
+    database: DatabaseQueue? = nil
+  ) throws -> StockPriceService {
     let client = FixedStockPriceClient(responses: responses, shouldFail: shouldFail)
-    let cacheDir =
-      cacheDirectory
-      ?? FileManager.default.temporaryDirectory
-      .appendingPathComponent("stock-price-tests")
-      .appendingPathComponent(UUID().uuidString)
-    return StockPriceService(client: client, cacheDirectory: cacheDir)
+    let resolved = try database ?? ProfileDatabase.openInMemory()
+    return StockPriceService(client: client, database: resolved)
   }
 
   private func date(_ string: String) -> Date {
@@ -42,14 +39,14 @@ struct StockPriceServiceTests {
 
   @Test
   func cacheMissFetchesFromClient() async throws {
-    let service = makeService(responses: ["BHP.AX": bhpResponse()])
+    let service = try makeService(responses: ["BHP.AX": bhpResponse()])
     let price = try await service.price(ticker: "BHP.AX", on: date("2026-04-07"))
     #expect(price == dec("38.50"))
   }
 
   @Test
   func cacheHitDoesNotRefetch() async throws {
-    let service = makeService(responses: ["BHP.AX": bhpResponse()])
+    let service = try makeService(responses: ["BHP.AX": bhpResponse()])
     let first = try await service.price(ticker: "BHP.AX", on: date("2026-04-07"))
     let second = try await service.price(ticker: "BHP.AX", on: date("2026-04-07"))
     #expect(first == second)
@@ -60,7 +57,7 @@ struct StockPriceServiceTests {
 
   @Test
   func currencyDiscoveredFromFirstFetch() async throws {
-    let service = makeService(responses: ["BHP.AX": bhpResponse()])
+    let service = try makeService(responses: ["BHP.AX": bhpResponse()])
     _ = try await service.price(ticker: "BHP.AX", on: date("2026-04-07"))
     let instrument = try await service.instrument(for: "BHP.AX")
     #expect(instrument == .AUD)
@@ -68,7 +65,7 @@ struct StockPriceServiceTests {
 
   @Test
   func instrumentThrowsForUnknownTicker() async throws {
-    let service = makeService()
+    let service = try makeService()
     await #expect(throws: (any Error).self) {
       try await service.instrument(for: "UNKNOWN.AX")
     }
@@ -78,7 +75,7 @@ struct StockPriceServiceTests {
 
   @Test
   func weekendFallsBackToFriday() async throws {
-    let service = makeService(responses: ["BHP.AX": bhpResponse()])
+    let service = try makeService(responses: ["BHP.AX": bhpResponse()])
     _ = try await service.price(ticker: "BHP.AX", on: date("2026-04-07"))
     let price = try await service.price(ticker: "BHP.AX", on: date("2026-04-12"))
     #expect(price == dec("38.60"))
@@ -91,7 +88,7 @@ struct StockPriceServiceTests {
       prices: [
         "2026-04-10": dec("38.25")
       ])
-    let service = makeService(responses: ["BHP.AX": futureOnly])
+    let service = try makeService(responses: ["BHP.AX": futureOnly])
     _ = try await service.price(ticker: "BHP.AX", on: date("2026-04-10"))
     await #expect(throws: (any Error).self) {
       try await service.price(ticker: "BHP.AX", on: date("2026-04-07"))
@@ -114,7 +111,7 @@ struct StockPriceServiceTests {
         // Sat 2026-04-11 and Sun 2026-04-12 deliberately absent
       ]
     )
-    let service = makeService(responses: ["BHP.AX": weekdayPrices])
+    let service = try makeService(responses: ["BHP.AX": weekdayPrices])
     let price = try await service.price(ticker: "BHP.AX", on: date("2026-04-12"))
     #expect(price == dec("38.25"))
   }
@@ -123,22 +120,19 @@ struct StockPriceServiceTests {
 
   @Test
   func networkFailureWithCacheReturnsCachedData() async throws {
-    let tempDir = FileManager.default.temporaryDirectory
-      .appendingPathComponent("stock-price-tests")
-      .appendingPathComponent(UUID().uuidString)
-    defer { try? FileManager.default.removeItem(at: tempDir) }
+    let database = try ProfileDatabase.openInMemory()
 
-    let service1 = makeService(responses: ["BHP.AX": bhpResponse()], cacheDirectory: tempDir)
+    let service1 = try makeService(responses: ["BHP.AX": bhpResponse()], database: database)
     _ = try await service1.price(ticker: "BHP.AX", on: date("2026-04-07"))
 
-    let service2 = makeService(shouldFail: true, cacheDirectory: tempDir)
+    let service2 = try makeService(shouldFail: true, database: database)
     let price = try await service2.price(ticker: "BHP.AX", on: date("2026-04-07"))
     #expect(price == dec("38.50"))
   }
 
   @Test
   func networkFailureWithEmptyCacheThrows() async throws {
-    let service = makeService(shouldFail: true)
+    let service = try makeService(shouldFail: true)
     await #expect(throws: (any Error).self) {
       try await service.price(ticker: "BHP.AX", on: date("2026-04-07"))
     }
@@ -148,7 +142,7 @@ struct StockPriceServiceTests {
 
   @Test
   func rangeReturnsOrderedPrices() async throws {
-    let service = makeService(responses: ["BHP.AX": bhpResponse()])
+    let service = try makeService(responses: ["BHP.AX": bhpResponse()])
     let results = try await service.prices(
       ticker: "BHP.AX",
       in: date("2026-04-07")...date("2026-04-09")
@@ -161,7 +155,7 @@ struct StockPriceServiceTests {
 
   @Test
   func rangeExpandsFetchForMissingDates() async throws {
-    let service = makeService(responses: ["BHP.AX": bhpResponse()])
+    let service = try makeService(responses: ["BHP.AX": bhpResponse()])
     _ = try await service.prices(
       ticker: "BHP.AX",
       in: date("2026-04-08")...date("2026-04-09")
@@ -177,7 +171,7 @@ struct StockPriceServiceTests {
 
   @Test
   func rangeFillsWeekendsWithLastKnownPrice() async throws {
-    let service = makeService(responses: ["BHP.AX": bhpResponse()])
+    let service = try makeService(responses: ["BHP.AX": bhpResponse()])
     let results = try await service.prices(
       ticker: "BHP.AX",
       in: date("2026-04-10")...date("2026-04-12")
@@ -190,23 +184,64 @@ struct StockPriceServiceTests {
 
   // MARK: - Disk persistence (gzip round-trip)
 
+  /// Two service instances sharing the same `DatabaseQueue` — the second
+  /// must load prices and the discovered denomination persisted by the
+  /// first without going to the network. Renamed from
+  /// `gzipRoundTripPreservesData` after the migration from gzipped JSON
+  /// cache files to GRDB.
   @Test
-  func gzipRoundTripPreservesData() async throws {
-    let tempDir = FileManager.default.temporaryDirectory
-      .appendingPathComponent("stock-price-tests")
-      .appendingPathComponent(UUID().uuidString)
-    defer { try? FileManager.default.removeItem(at: tempDir) }
+  func sqlRoundTripPreservesData() async throws {
+    let database = try ProfileDatabase.openInMemory()
 
-    let service1 = makeService(responses: ["BHP.AX": bhpResponse()], cacheDirectory: tempDir)
+    let service1 = try makeService(responses: ["BHP.AX": bhpResponse()], database: database)
     let price = try await service1.price(ticker: "BHP.AX", on: date("2026-04-07"))
     #expect(price == dec("38.50"))
 
-    let service2 = makeService(shouldFail: true, cacheDirectory: tempDir)
+    let service2 = try makeService(shouldFail: true, database: database)
     let cachedPrice = try await service2.price(ticker: "BHP.AX", on: date("2026-04-07"))
     #expect(cachedPrice == dec("38.50"))
 
     let instrument = try await service2.instrument(for: "BHP.AX")
     #expect(instrument == .AUD)
+  }
+
+  // MARK: - Rollback test for multi-statement save
+
+  /// Rollback contract: `StockPriceService.saveCache` is a single
+  /// `database.write` (delete prior price rows + re-insert + upsert meta).
+  /// A constraint violation mid-transaction must leave prior state intact.
+  /// See `ExchangeRateServiceTests.saveRollsBackOnConstraintFailure` for
+  /// the equivalent FX assertion.
+  @Test
+  func saveRollsBackOnConstraintFailure() async throws {
+    let database = try ProfileDatabase.openInMemory()
+    let service = try makeService(responses: ["BHP.AX": bhpResponse()], database: database)
+    _ = try await service.price(ticker: "BHP.AX", on: date("2026-04-07"))
+
+    let beforeCount = try await database.read { database in
+      try StockPriceRecord
+        .filter(StockPriceRecord.Columns.ticker == "BHP.AX")
+        .fetchCount(database)
+    }
+    #expect(beforeCount > 0)
+
+    await #expect(throws: (any Error).self) {
+      try await database.write { database in
+        try StockPriceRecord
+          .filter(StockPriceRecord.Columns.ticker == "BHP.AX")
+          .deleteAll(database)
+        try StockPriceRecord(ticker: "BHP.AX", date: "2026-01-01", price: 1.0).insert(database)
+        // Duplicate (ticker, date) trips the PK on the second insert.
+        try StockPriceRecord(ticker: "BHP.AX", date: "2026-01-01", price: 2.0).insert(database)
+      }
+    }
+
+    let afterCount = try await database.read { database in
+      try StockPriceRecord
+        .filter(StockPriceRecord.Columns.ticker == "BHP.AX")
+        .fetchCount(database)
+    }
+    #expect(afterCount == beforeCount)
   }
 
   // MARK: - Multiple tickers
@@ -218,7 +253,7 @@ struct StockPriceServiceTests {
       prices: [
         "2026-04-07": dec("115.20")
       ])
-    let service = makeService(responses: [
+    let service = try makeService(responses: [
       "BHP.AX": bhpResponse(),
       "CBA.AX": cbaResponse,
     ])

--- a/MoolahTests/Shared/StockPriceServiceTests.swift
+++ b/MoolahTests/Shared/StockPriceServiceTests.swift
@@ -209,11 +209,14 @@ struct StockPriceServiceTests {
 
   /// Rollback contract: `StockPriceService.saveCache` is a single
   /// `database.write` (delete prior price rows + re-insert + upsert meta).
-  /// A constraint violation mid-transaction must leave prior state intact.
-  /// See `ExchangeRateServiceTests.saveRollsBackOnConstraintFailure` for
-  /// the equivalent FX assertion.
+  ///
+  /// Drives the **production** `saveCache` by installing a trigger that
+  /// raises `ABORT` on a sentinel date string. A second fetch through the
+  /// service merges that sentinel into the cache, the production save path
+  /// runs, the trigger fires inside the transaction, and the entire write
+  /// must roll back — leaving prior rows untouched.
   @Test
-  func saveRollsBackOnConstraintFailure() async throws {
+  func saveCacheRollsBackOnInsertFailure() async throws {
     let database = try ProfileDatabase.openInMemory()
     let service = try makeService(responses: ["BHP.AX": bhpResponse()], database: database)
     _ = try await service.price(ticker: "BHP.AX", on: date("2026-04-07"))
@@ -225,16 +228,30 @@ struct StockPriceServiceTests {
     }
     #expect(beforeCount > 0)
 
-    await #expect(throws: (any Error).self) {
-      try await database.write { database in
-        try StockPriceRecord
-          .filter(StockPriceRecord.Columns.ticker == "BHP.AX")
-          .deleteAll(database)
-        try StockPriceRecord(ticker: "BHP.AX", date: "2026-01-01", price: 1.0).insert(database)
-        // Duplicate (ticker, date) trips the PK on the second insert.
-        try StockPriceRecord(ticker: "BHP.AX", date: "2026-01-01", price: 2.0).insert(database)
-      }
+    // Install a trigger that aborts inserts carrying the sentinel date.
+    // The trigger fires inside `saveCache`'s transaction so the upfront
+    // DELETE for the BHP.AX partition + the new inserts roll back together.
+    try await database.write { database in
+      try database.execute(
+        sql: """
+          CREATE TRIGGER fail_save_cache
+          BEFORE INSERT ON stock_price
+          WHEN NEW.date = '9999-12-31'
+          BEGIN
+              SELECT RAISE(ABORT, 'forced failure for rollback test');
+          END;
+          """)
     }
+
+    // Drive the real `saveCache` by feeding a price set that contains the
+    // sentinel date. The service merges it in, calls `saveCache`, the
+    // trigger raises mid-transaction, and SQLite rolls the whole write
+    // back atomically.
+    let failingResponse = StockPriceResponse(
+      instrument: .AUD, prices: ["9999-12-31": dec("99.99")])
+    let failingService = try makeService(
+      responses: ["BHP.AX": failingResponse], database: database)
+    _ = try? await failingService.price(ticker: "BHP.AX", on: date("9999-12-31"))
 
     let afterCount = try await database.read { database in
       try StockPriceRecord

--- a/MoolahTests/Support/CloudKitAnalysisTestBackend.swift
+++ b/MoolahTests/Support/CloudKitAnalysisTestBackend.swift
@@ -1,4 +1,5 @@
 import Foundation
+import GRDB
 import SwiftData
 
 @testable import Moolah
@@ -37,9 +38,8 @@ struct CloudKitAnalysisTestBackend: BackendProvider, @unchecked Sendable {
       conversion = customConversion
     } else {
       let rateClient = FixedRateClient()
-      let cacheDir = FileManager.default.temporaryDirectory
-        .appendingPathComponent("test-rates-\(UUID().uuidString)")
-      let exchangeRates = ExchangeRateService(client: rateClient, cacheDirectory: cacheDir)
+      let exchangeRates = ExchangeRateService(
+        client: rateClient, database: try ProfileDatabase.openInMemory())
       conversion = FiatConversionService(exchangeRates: exchangeRates)
     }
     self.auth = InMemoryAuthProvider()

--- a/MoolahTests/Support/TestBackend.swift
+++ b/MoolahTests/Support/TestBackend.swift
@@ -1,4 +1,5 @@
 import Foundation
+import GRDB
 import SwiftData
 
 @testable import Moolah
@@ -36,9 +37,8 @@ enum TestBackend {
   ) throws -> (backend: CloudKitBackend, container: ModelContainer) {
     let container = try TestModelContainer.create()
     let rateClient = FixedRateClient(rates: exchangeRates)
-    let cacheDir = FileManager.default.temporaryDirectory
-      .appendingPathComponent("test-rates-\(UUID().uuidString)")
-    let exchangeRateService = ExchangeRateService(client: rateClient, cacheDirectory: cacheDir)
+    let exchangeRateService = ExchangeRateService(
+      client: rateClient, database: try ProfileDatabase.openInMemory())
     let conversionService = FiatConversionService(exchangeRates: exchangeRateService)
     let backend = CloudKitBackend(
       modelContainer: container,

--- a/MoolahTests/Support/TransactionContractTestFixtures.swift
+++ b/MoolahTests/Support/TransactionContractTestFixtures.swift
@@ -1,4 +1,5 @@
 import Foundation
+import GRDB
 import SwiftData
 import Testing
 
@@ -237,9 +238,8 @@ func makeContractCloudKitTransactionRepository(
 ) throws -> CloudKitTransactionRepository {
   let container = try TestModelContainer.create()
   let rateClient = FixedRateClient(rates: exchangeRates)
-  let cacheDir = FileManager.default.temporaryDirectory
-    .appendingPathComponent("test-rates-\(UUID().uuidString)")
-  let exchangeRateService = ExchangeRateService(client: rateClient, cacheDirectory: cacheDir)
+  let exchangeRateService = ExchangeRateService(
+    client: rateClient, database: try ProfileDatabase.openInMemory())
   let conversionService = FiatConversionService(exchangeRates: exchangeRateService)
   let repo = CloudKitTransactionRepository(
     modelContainer: container,

--- a/Shared/CryptoPriceService+Persistence.swift
+++ b/Shared/CryptoPriceService+Persistence.swift
@@ -3,6 +3,8 @@
 import Foundation
 import GRDB
 
+// MARK: - CryptoPriceService SQL persistence
+
 // SQL persistence for `CryptoPriceService`. Lives in its own file so the
 // main actor body stays under SwiftLint's `type_body_length` and
 // `file_length` thresholds.

--- a/Shared/CryptoPriceService+Persistence.swift
+++ b/Shared/CryptoPriceService+Persistence.swift
@@ -1,0 +1,83 @@
+// Shared/CryptoPriceService+Persistence.swift
+
+import Foundation
+import GRDB
+
+// SQL persistence for `CryptoPriceService`. Lives in its own file so the
+// main actor body stays under SwiftLint's `type_body_length` and
+// `file_length` thresholds.
+
+extension CryptoPriceService {
+  /// Hydrates `caches[tokenId]` from `crypto_price` + `crypto_token_meta`.
+  /// The meta row's `symbol` is display-only — used to populate
+  /// `CryptoPriceCache.symbol` on the way back; not used for lookups.
+  ///
+  /// Marks the token id as hydrated even when no rows exist so we don't
+  /// re-query on every miss.
+  func loadCache(tokenId: String) async throws {
+    let snapshot: CryptoPriceCache? = try await database.read { database in
+      let metaRecord =
+        try CryptoTokenMetaRecord
+        .filter(CryptoTokenMetaRecord.Columns.tokenId == tokenId)
+        .fetchOne(database)
+      guard let metaRecord else { return nil }
+      let priceRecords =
+        try CryptoPriceRecord
+        .filter(CryptoPriceRecord.Columns.tokenId == tokenId)
+        .fetchAll(database)
+      // See `ExchangeRateService.loadCache` for the rationale on the
+      // String-via-Decimal round-trip; preserves source precision instead
+      // of inheriting the binary `Decimal(_: Double)` tail.
+      var prices: [String: Decimal] = [:]
+      for record in priceRecords {
+        prices[record.date] = Decimal(string: String(record.priceUsd)) ?? Decimal(record.priceUsd)
+      }
+      return CryptoPriceCache(
+        tokenId: tokenId,
+        symbol: metaRecord.symbol,
+        earliestDate: metaRecord.earliestDate,
+        latestDate: metaRecord.latestDate,
+        prices: prices
+      )
+    }
+    if let snapshot { caches[tokenId] = snapshot }
+    hydratedTokenIds.insert(tokenId)
+  }
+
+  /// Persists `caches[tokenId]` to SQLite. Replaces prior rows for this
+  /// token in a single transaction and upserts the meta row alongside so
+  /// the symbol is never out of sync with the prices.
+  ///
+  /// Multi-statement; covered by a rollback test in
+  /// `CryptoPriceServiceTests.swift`.
+  ///
+  /// Captures `caches[tokenId]` before suspending on `database.write`.
+  /// Actor re-entrancy is acceptable here: a concurrent merge will trigger
+  /// its own `saveCache` afterwards, so the disk converges to the latest
+  /// in-memory state. A crash between the two writes leaves the disk at an
+  /// intermediate-but-consistent snapshot — acceptable for a best-effort
+  /// persistent cache.
+  func saveCache(tokenId: String) async throws {
+    guard let cache = caches[tokenId] else { return }
+    let records: [CryptoPriceRecord] = cache.prices.map { dateString, price in
+      CryptoPriceRecord(
+        tokenId: tokenId,
+        date: dateString,
+        priceUsd: NSDecimalNumber(decimal: price).doubleValue
+      )
+    }
+    let meta = CryptoTokenMetaRecord(
+      tokenId: tokenId,
+      symbol: cache.symbol,
+      earliestDate: cache.earliestDate,
+      latestDate: cache.latestDate
+    )
+    try await database.write { database in
+      try CryptoPriceRecord
+        .filter(CryptoPriceRecord.Columns.tokenId == tokenId)
+        .deleteAll(database)
+      for record in records { try record.insert(database) }
+      try meta.upsert(database)
+    }
+  }
+}

--- a/Shared/CryptoPriceService.swift
+++ b/Shared/CryptoPriceService.swift
@@ -1,12 +1,16 @@
 // Shared/CryptoPriceService.swift
 
 import Foundation
+import GRDB
 import OSLog
 
 actor CryptoPriceService {
   private let clients: [CryptoPriceClient]
   private var caches: [String: CryptoPriceCache] = [:]
-  private let cacheDirectory: URL
+  /// Loaded token ids — set on first hydration so we don't re-read SQL when
+  /// the cache is genuinely empty.
+  private var hydratedTokenIds: Set<String> = []
+  private let database: any DatabaseWriter
   private let dateFormatter: ISO8601DateFormatter
   private let resolutionClient: TokenResolutionClient
   private let logger = Logger(
@@ -14,19 +18,12 @@ actor CryptoPriceService {
 
   init(
     clients: [CryptoPriceClient],
-    cacheDirectory: URL? = nil,
+    database: any DatabaseWriter,
     resolutionClient: (any TokenResolutionClient)? = nil
   ) {
     self.clients = clients
+    self.database = database
     self.resolutionClient = resolutionClient ?? NoOpTokenResolutionClient()
-    if let cacheDirectory {
-      self.cacheDirectory = cacheDirectory
-    } else {
-      let baseCaches =
-        FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first
-        ?? URL(fileURLWithPath: NSTemporaryDirectory())
-      self.cacheDirectory = baseCaches.appendingPathComponent("crypto-prices")
-    }
     self.dateFormatter = ISO8601DateFormatter()
     self.dateFormatter.formatOptions = [.withFullDate]
   }
@@ -62,14 +59,27 @@ actor CryptoPriceService {
     return CryptoRegistration(instrument: instrument, mapping: mapping)
   }
 
-  /// Drops any cached price data for the given instrument id — removes
-  /// both the in-memory cache entry and the on-disk cache file. Called
-  /// when an instrument is un-registered so we don't retain stale prices
-  /// for something the user no longer cares about.
-  func purgeCache(instrumentId: String) {
+  /// Drops any cached price data for the given instrument id — removes both
+  /// the in-memory cache entry and the on-disk rows. Called when an
+  /// instrument is un-registered so we don't retain stale prices for
+  /// something the user no longer cares about.
+  func purgeCache(instrumentId: String) async {
     caches.removeValue(forKey: instrumentId)
-    let url = cacheFileURL(tokenId: instrumentId)
-    try? FileManager.default.removeItem(at: url)
+    hydratedTokenIds.remove(instrumentId)
+    do {
+      try await database.write { database in
+        try CryptoPriceRecord
+          .filter(CryptoPriceRecord.Columns.tokenId == instrumentId)
+          .deleteAll(database)
+        try CryptoTokenMetaRecord
+          .filter(CryptoTokenMetaRecord.Columns.tokenId == instrumentId)
+          .deleteAll(database)
+      }
+    } catch {
+      logger.warning(
+        "purgeCache failed for \(instrumentId, privacy: .public): \(error.localizedDescription, privacy: .public)"
+      )
+    }
   }
 
   // MARK: - Single price
@@ -86,8 +96,8 @@ actor CryptoPriceService {
       return cached
     }
 
-    if caches[tokenId] == nil {
-      loadCacheFromDisk(tokenId: tokenId)
+    if !hydratedTokenIds.contains(tokenId) {
+      try await loadCache(tokenId: tokenId)
     }
 
     if let cached = lookupPrice(tokenId: tokenId, dateString: dateString) {
@@ -106,7 +116,7 @@ actor CryptoPriceService {
         let fetched = try await client.dailyPrices(for: mapping, in: fetchStart...date)
         if !fetched.isEmpty {
           merge(tokenId: tokenId, symbol: symbol, newPrices: fetched)
-          saveCacheToDisk(tokenId: tokenId)
+          try await saveCache(tokenId: tokenId)
           if let price = lookupPrice(tokenId: tokenId, dateString: dateString) {
             return price
           }
@@ -133,8 +143,8 @@ actor CryptoPriceService {
   ) async throws -> [(date: Date, price: Decimal)] {
     let tokenId = instrument.id
 
-    if caches[tokenId] == nil {
-      loadCacheFromDisk(tokenId: tokenId)
+    if !hydratedTokenIds.contains(tokenId) {
+      try await loadCache(tokenId: tokenId)
     }
 
     let rangeStart = dateFormatter.string(from: range.lowerBound)
@@ -208,7 +218,7 @@ actor CryptoPriceService {
           registrations.first { $0.id == tokenId }?.instrument.ticker
           ?? registrations.first { $0.id == tokenId }?.instrument.name ?? ""
         merge(tokenId: tokenId, symbol: symbol, newPrices: [dateString: price])
-        saveCacheToDisk(tokenId: tokenId)
+        try await saveCache(tokenId: tokenId)
       }
     } catch {
       logger.warning(
@@ -257,7 +267,7 @@ extension CryptoPriceService {
         let fetched = try await client.dailyPrices(for: mapping, in: from...to)
         if !fetched.isEmpty {
           merge(tokenId: tokenId, symbol: symbol, newPrices: fetched)
-          saveCacheToDisk(tokenId: tokenId)
+          try await saveCache(tokenId: tokenId)
           return
         }
       } catch {
@@ -295,36 +305,73 @@ extension CryptoPriceService {
   }
 }
 
-// MARK: - Disk cache I/O
+// MARK: - SQL persistence
 
 extension CryptoPriceService {
-  private func cacheFileURL(tokenId: String) -> URL {
-    let safeName = tokenId.replacingOccurrences(of: ":", with: "-")
-    return cacheDirectory.appendingPathComponent("prices-\(safeName).json.gz")
+  /// Hydrates `caches[tokenId]` from `crypto_price` + `crypto_token_meta`.
+  /// The meta row's `symbol` is display-only — used to populate
+  /// `CryptoPriceCache.symbol` on the way back; not used for lookups.
+  ///
+  /// Marks the token id as hydrated even when no rows exist so we don't
+  /// re-query on every miss.
+  private func loadCache(tokenId: String) async throws {
+    let snapshot: CryptoPriceCache? = try await database.read { database in
+      let metaRecord =
+        try CryptoTokenMetaRecord
+        .filter(CryptoTokenMetaRecord.Columns.tokenId == tokenId)
+        .fetchOne(database)
+      guard let metaRecord else { return nil }
+      let priceRecords =
+        try CryptoPriceRecord
+        .filter(CryptoPriceRecord.Columns.tokenId == tokenId)
+        .fetchAll(database)
+      // See `ExchangeRateService.loadCache` for the rationale on the
+      // String-via-Decimal round-trip; preserves source precision instead
+      // of inheriting the binary `Decimal(_: Double)` tail.
+      var prices: [String: Decimal] = [:]
+      for record in priceRecords {
+        prices[record.date] = Decimal(string: String(record.priceUsd)) ?? Decimal(record.priceUsd)
+      }
+      return CryptoPriceCache(
+        tokenId: tokenId,
+        symbol: metaRecord.symbol,
+        earliestDate: metaRecord.earliestDate,
+        latestDate: metaRecord.latestDate,
+        prices: prices
+      )
+    }
+    if let snapshot { caches[tokenId] = snapshot }
+    hydratedTokenIds.insert(tokenId)
   }
 
-  private func loadCacheFromDisk(tokenId: String) {
-    let url = cacheFileURL(tokenId: tokenId)
-    guard let compressed = try? Data(contentsOf: url) else { return }
-    guard let data = decompress(compressed) else { return }
-    guard let cache = try? JSONDecoder().decode(CryptoPriceCache.self, from: data) else { return }
-    caches[tokenId] = cache
-  }
-
-  private func saveCacheToDisk(tokenId: String) {
+  /// Persists `caches[tokenId]` to SQLite. Replaces prior rows for this
+  /// token in a single transaction and upserts the meta row alongside so
+  /// the symbol is never out of sync with the prices.
+  ///
+  /// Multi-statement; covered by a rollback test in
+  /// `CryptoPriceServiceTests.swift`.
+  private func saveCache(tokenId: String) async throws {
     guard let cache = caches[tokenId] else { return }
-    guard let data = try? JSONEncoder().encode(cache) else { return }
-    guard let compressed = compress(data) else { return }
-    try? FileManager.default.createDirectory(at: cacheDirectory, withIntermediateDirectories: true)
-    try? compressed.write(to: cacheFileURL(tokenId: tokenId), options: .atomic)
-  }
-
-  private func compress(_ data: Data) -> Data? {
-    try? (data as NSData).compressed(using: .zlib) as Data
-  }
-
-  private func decompress(_ data: Data) -> Data? {
-    try? (data as NSData).decompressed(using: .zlib) as Data
+    let records: [CryptoPriceRecord] = cache.prices.map { dateString, price in
+      CryptoPriceRecord(
+        tokenId: tokenId,
+        date: dateString,
+        priceUsd: NSDecimalNumber(decimal: price).doubleValue
+      )
+    }
+    let meta = CryptoTokenMetaRecord(
+      tokenId: tokenId,
+      symbol: cache.symbol,
+      earliestDate: cache.earliestDate,
+      latestDate: cache.latestDate
+    )
+    try await database.write { database in
+      try CryptoPriceRecord
+        .filter(CryptoPriceRecord.Columns.tokenId == tokenId)
+        .deleteAll(database)
+      for record in records { try record.insert(database) }
+      try meta.upsert(database)
+    }
   }
 }
 

--- a/Shared/CryptoPriceService.swift
+++ b/Shared/CryptoPriceService.swift
@@ -208,8 +208,16 @@ actor CryptoPriceService {
         }
         if result.count == mappings.count { break }
       } catch {
+        // Best-effort: try the next client. Log so a silent total miss
+        // (all clients failed → empty dict) is diagnosable.
+        logger.debug(
+          "currentPrices: client \(type(of: client), privacy: .public) failed: \(error.localizedDescription, privacy: .public)"
+        )
         continue
       }
+    }
+    if result.isEmpty && !mappings.isEmpty {
+      logger.warning("currentPrices: all clients failed; returning empty result")
     }
     return result
   }
@@ -229,9 +237,8 @@ actor CryptoPriceService {
     }
     let dateString = dateFormatter.string(from: Date())
     for (tokenId, price) in prices {
-      let symbol =
-        registrations.first { $0.id == tokenId }?.instrument.ticker
-        ?? registrations.first { $0.id == tokenId }?.instrument.name ?? ""
+      let registration = registrations.first { $0.id == tokenId }
+      let symbol = registration?.instrument.ticker ?? registration?.instrument.name ?? ""
       merge(tokenId: tokenId, symbol: symbol, newPrices: [dateString: price])
       do {
         try await saveCache(tokenId: tokenId)

--- a/Shared/CryptoPriceService.swift
+++ b/Shared/CryptoPriceService.swift
@@ -6,14 +6,18 @@ import OSLog
 
 actor CryptoPriceService {
   private let clients: [CryptoPriceClient]
-  private var caches: [String: CryptoPriceCache] = [:]
+  // `caches`, `hydratedTokenIds`, and `database` are accessed by the
+  // SQL persistence extension in `CryptoPriceService+Persistence.swift`.
+  // They remain actor-isolated; the access modifier is internal so the
+  // sibling-file extension can see them.
+  var caches: [String: CryptoPriceCache] = [:]
   /// Loaded token ids — set on first hydration so we don't re-read SQL when
   /// the cache is genuinely empty.
-  private var hydratedTokenIds: Set<String> = []
-  private let database: any DatabaseWriter
+  var hydratedTokenIds: Set<String> = []
+  let database: any DatabaseWriter
   private let dateFormatter: ISO8601DateFormatter
   private let resolutionClient: TokenResolutionClient
-  private let logger = Logger(
+  let logger = Logger(
     subsystem: "com.moolah.app", category: "CryptoPriceService")
 
   init(
@@ -210,20 +214,30 @@ actor CryptoPriceService {
 
   func prefetchLatest(for registrations: [CryptoRegistration]) async {
     let mappings = registrations.map(\.mapping)
+    let prices: [String: Decimal]
     do {
-      let prices = try await currentPrices(for: mappings)
-      let dateString = dateFormatter.string(from: Date())
-      for (tokenId, price) in prices {
-        let symbol =
-          registrations.first { $0.id == tokenId }?.instrument.ticker
-          ?? registrations.first { $0.id == tokenId }?.instrument.name ?? ""
-        merge(tokenId: tokenId, symbol: symbol, newPrices: [dateString: price])
-        try await saveCache(tokenId: tokenId)
-      }
+      prices = try await currentPrices(for: mappings)
     } catch {
       logger.warning(
         "Prefetch failed (best-effort): \(error.localizedDescription, privacy: .public)"
       )
+      return
+    }
+    let dateString = dateFormatter.string(from: Date())
+    for (tokenId, price) in prices {
+      let symbol =
+        registrations.first { $0.id == tokenId }?.instrument.ticker
+        ?? registrations.first { $0.id == tokenId }?.instrument.name ?? ""
+      merge(tokenId: tokenId, symbol: symbol, newPrices: [dateString: price])
+      do {
+        try await saveCache(tokenId: tokenId)
+      } catch {
+        logger.warning(
+          // Best-effort: continue the loop so a single bad token doesn't
+          // poison the rest of the prefetch.
+          "prefetchLatest: saveCache failed for \(tokenId, privacy: .public): \(error.localizedDescription, privacy: .public)"
+        )
+      }
     }
   }
 }
@@ -301,76 +315,6 @@ extension CryptoPriceService {
         latestDate: latest,
         prices: newPrices
       )
-    }
-  }
-}
-
-// MARK: - SQL persistence
-
-extension CryptoPriceService {
-  /// Hydrates `caches[tokenId]` from `crypto_price` + `crypto_token_meta`.
-  /// The meta row's `symbol` is display-only — used to populate
-  /// `CryptoPriceCache.symbol` on the way back; not used for lookups.
-  ///
-  /// Marks the token id as hydrated even when no rows exist so we don't
-  /// re-query on every miss.
-  private func loadCache(tokenId: String) async throws {
-    let snapshot: CryptoPriceCache? = try await database.read { database in
-      let metaRecord =
-        try CryptoTokenMetaRecord
-        .filter(CryptoTokenMetaRecord.Columns.tokenId == tokenId)
-        .fetchOne(database)
-      guard let metaRecord else { return nil }
-      let priceRecords =
-        try CryptoPriceRecord
-        .filter(CryptoPriceRecord.Columns.tokenId == tokenId)
-        .fetchAll(database)
-      // See `ExchangeRateService.loadCache` for the rationale on the
-      // String-via-Decimal round-trip; preserves source precision instead
-      // of inheriting the binary `Decimal(_: Double)` tail.
-      var prices: [String: Decimal] = [:]
-      for record in priceRecords {
-        prices[record.date] = Decimal(string: String(record.priceUsd)) ?? Decimal(record.priceUsd)
-      }
-      return CryptoPriceCache(
-        tokenId: tokenId,
-        symbol: metaRecord.symbol,
-        earliestDate: metaRecord.earliestDate,
-        latestDate: metaRecord.latestDate,
-        prices: prices
-      )
-    }
-    if let snapshot { caches[tokenId] = snapshot }
-    hydratedTokenIds.insert(tokenId)
-  }
-
-  /// Persists `caches[tokenId]` to SQLite. Replaces prior rows for this
-  /// token in a single transaction and upserts the meta row alongside so
-  /// the symbol is never out of sync with the prices.
-  ///
-  /// Multi-statement; covered by a rollback test in
-  /// `CryptoPriceServiceTests.swift`.
-  private func saveCache(tokenId: String) async throws {
-    guard let cache = caches[tokenId] else { return }
-    let records: [CryptoPriceRecord] = cache.prices.map { dateString, price in
-      CryptoPriceRecord(
-        tokenId: tokenId,
-        date: dateString,
-        priceUsd: NSDecimalNumber(decimal: price).doubleValue
-      )
-    }
-    let meta = CryptoTokenMetaRecord(
-      tokenId: tokenId,
-      symbol: cache.symbol,
-      earliestDate: cache.earliestDate,
-      latestDate: cache.latestDate
-    )
-    try await database.write { database in
-      try CryptoPriceRecord
-        .filter(CryptoPriceRecord.Columns.tokenId == tokenId)
-        .deleteAll(database)
-      for record in records { try record.insert(database) }
-      try meta.upsert(database)
     }
   }
 }

--- a/Shared/CryptoPriceService.swift
+++ b/Shared/CryptoPriceService.swift
@@ -6,19 +6,23 @@ import OSLog
 
 actor CryptoPriceService {
   private let clients: [CryptoPriceClient]
-  // `caches`, `hydratedTokenIds`, and `database` are accessed by the
-  // SQL persistence extension in `CryptoPriceService+Persistence.swift`.
-  // They remain actor-isolated; the access modifier is internal so the
-  // sibling-file extension can see them.
+
+  // MARK: - Cross-extension internals
+  // `caches`, `hydratedTokenIds`, `database`, and `logger` are accessed
+  // by the SQL persistence extension in
+  // `CryptoPriceService+Persistence.swift`. They remain actor-isolated;
+  // the access modifier is internal so the sibling-file extension can
+  // see them.
   var caches: [String: CryptoPriceCache] = [:]
   /// Loaded token ids — set on first hydration so we don't re-read SQL when
   /// the cache is genuinely empty.
   var hydratedTokenIds: Set<String> = []
   let database: any DatabaseWriter
-  private let dateFormatter: ISO8601DateFormatter
-  private let resolutionClient: TokenResolutionClient
   let logger = Logger(
     subsystem: "com.moolah.app", category: "CryptoPriceService")
+
+  private let dateFormatter: ISO8601DateFormatter
+  private let resolutionClient: TokenResolutionClient
 
   init(
     clients: [CryptoPriceClient],

--- a/Shared/ExchangeRateService+Persistence.swift
+++ b/Shared/ExchangeRateService+Persistence.swift
@@ -1,0 +1,87 @@
+// Shared/ExchangeRateService+Persistence.swift
+
+import Foundation
+import GRDB
+
+// SQL persistence for `ExchangeRateService`. Lives in its own file so the
+// main actor body stays under SwiftLint's `type_body_length` and
+// `file_length` thresholds.
+
+extension ExchangeRateService {
+  /// Hydrates `caches[base]` from the GRDB-backed `exchange_rate` /
+  /// `exchange_rate_meta` tables. No-op when the base has no rows; marks the
+  /// base as hydrated either way so we don't re-query on every miss.
+  ///
+  /// Rates are stored as `REAL` (`Double`) in SQLite per
+  /// `guides/DATABASE_CODE_GUIDE.md` §3, and converted back to `Decimal` at
+  /// the boundary so the in-memory cache stays decimal-precise.
+  func loadCache(base: String) async throws {
+    let snapshot: ExchangeRateCache? = try await database.read { database in
+      let metaRecord =
+        try ExchangeRateMetaRecord
+        .filter(ExchangeRateMetaRecord.Columns.base == base)
+        .fetchOne(database)
+      guard let metaRecord else { return nil }
+      let rateRecords =
+        try ExchangeRateRecord
+        .filter(ExchangeRateRecord.Columns.base == base)
+        .fetchAll(database)
+      // Decode via the `String` form of the stored `Double` so we recover
+      // the source decimal exactly (e.g. `0.581`), avoiding the precision
+      // tail that `Decimal(_: Double)` would introduce
+      // (`0.5810000000000001024`).
+      var rates: [String: [String: Decimal]] = [:]
+      for record in rateRecords {
+        let value = Decimal(string: String(record.rate)) ?? Decimal(record.rate)
+        rates[record.date, default: [:]][record.quote] = value
+      }
+      return ExchangeRateCache(
+        base: base,
+        earliestDate: metaRecord.earliestDate,
+        latestDate: metaRecord.latestDate,
+        rates: rates
+      )
+    }
+    if let snapshot { caches[base] = snapshot }
+    hydratedBases.insert(base)
+  }
+
+  /// Persists `caches[base]` to SQLite. Replaces the prior rows for this
+  /// base in a single transaction (delete-and-rewrite) and upserts the meta
+  /// row alongside, so the meta is never out of sync with the rates.
+  ///
+  /// Multi-statement; covered by a rollback test in
+  /// `ExchangeRateServicePersistenceTests.swift`.
+  ///
+  /// Captures `caches[base]` before suspending on `database.write`. Actor
+  /// re-entrancy is acceptable here: a concurrent merge will trigger its
+  /// own `saveCache` afterwards, so the disk converges to the latest
+  /// in-memory state. A crash between the two writes leaves the disk at
+  /// an intermediate-but-consistent snapshot — acceptable for a
+  /// best-effort persistent cache.
+  func saveCache(base: String) async throws {
+    guard let cache = caches[base] else { return }
+    // `Decimal` lacks a direct `Double` accessor; round-trip via
+    // `NSDecimalNumber` (`doubleValue`) — same path GRDB would take.
+    let records: [ExchangeRateRecord] = cache.rates.flatMap { dateString, quotes in
+      quotes.map { quote, rate in
+        ExchangeRateRecord(
+          base: base,
+          quote: quote,
+          date: dateString,
+          rate: NSDecimalNumber(decimal: rate).doubleValue
+        )
+      }
+    }
+    let meta = ExchangeRateMetaRecord(
+      base: base, earliestDate: cache.earliestDate, latestDate: cache.latestDate
+    )
+    try await database.write { database in
+      try ExchangeRateRecord
+        .filter(ExchangeRateRecord.Columns.base == base)
+        .deleteAll(database)
+      for record in records { try record.insert(database) }
+      try meta.upsert(database)
+    }
+  }
+}

--- a/Shared/ExchangeRateService+Persistence.swift
+++ b/Shared/ExchangeRateService+Persistence.swift
@@ -3,6 +3,8 @@
 import Foundation
 import GRDB
 
+// MARK: - ExchangeRateService SQL persistence
+
 // SQL persistence for `ExchangeRateService`. Lives in its own file so the
 // main actor body stays under SwiftLint's `type_body_length` and
 // `file_length` thresholds.

--- a/Shared/ExchangeRateService.swift
+++ b/Shared/ExchangeRateService.swift
@@ -10,18 +10,21 @@ enum ExchangeRateError: Error, Equatable {
 
 actor ExchangeRateService {
   private let client: ExchangeRateClient
-  // `caches`, `hydratedBases`, and `database` are accessed by the SQL
-  // persistence extension in `ExchangeRateService+Persistence.swift`. They
-  // remain actor-isolated; the access modifier is internal so the
+
+  // MARK: - Cross-extension internals
+  // `caches`, `hydratedBases`, `database`, and `logger` are accessed by
+  // the SQL persistence extension in `ExchangeRateService+Persistence.swift`.
+  // They remain actor-isolated; the access modifier is internal so the
   // sibling-file extension can see them.
   var caches: [String: ExchangeRateCache] = [:]
   /// Loaded bases — set on first hydration so we don't re-read SQL when the
   /// cache is genuinely empty.
   var hydratedBases: Set<String> = []
   let database: any DatabaseWriter
-  private let dateFormatter: ISO8601DateFormatter
   let logger = Logger(
     subsystem: "com.moolah.app", category: "ExchangeRateService")
+
+  private let dateFormatter: ISO8601DateFormatter
 
   init(client: ExchangeRateClient, database: any DatabaseWriter) {
     self.client = client

--- a/Shared/ExchangeRateService.swift
+++ b/Shared/ExchangeRateService.swift
@@ -2,6 +2,7 @@
 
 import Foundation
 import GRDB
+import OSLog
 
 enum ExchangeRateError: Error, Equatable {
   case noRateAvailable(base: String, quote: String, date: String)
@@ -9,12 +10,18 @@ enum ExchangeRateError: Error, Equatable {
 
 actor ExchangeRateService {
   private let client: ExchangeRateClient
-  private var caches: [String: ExchangeRateCache] = [:]
+  // `caches`, `hydratedBases`, and `database` are accessed by the SQL
+  // persistence extension in `ExchangeRateService+Persistence.swift`. They
+  // remain actor-isolated; the access modifier is internal so the
+  // sibling-file extension can see them.
+  var caches: [String: ExchangeRateCache] = [:]
   /// Loaded bases — set on first hydration so we don't re-read SQL when the
   /// cache is genuinely empty.
-  private var hydratedBases: Set<String> = []
-  private let database: any DatabaseWriter
+  var hydratedBases: Set<String> = []
+  let database: any DatabaseWriter
   private let dateFormatter: ISO8601DateFormatter
+  let logger = Logger(
+    subsystem: "com.moolah.app", category: "ExchangeRateService")
 
   init(client: ExchangeRateClient, database: any DatabaseWriter) {
     self.client = client
@@ -92,7 +99,12 @@ actor ExchangeRateService {
         try await fetchInChunks(base: base, from: fetchStart, to: date)
       }
     } catch {
-      // Fetch failed — proceed to fallback lookup.
+      // Fetch failed — proceed to fallback lookup. Logged so disk-write
+      // failures (which would otherwise be silently swallowed alongside
+      // expected network 404s) are still observable.
+      logger.warning(
+        "fetchToCoverDate failed for base \(base, privacy: .public) on \(dateString, privacy: .public): \(error.localizedDescription, privacy: .public)"
+      )
     }
   }
 
@@ -165,7 +177,13 @@ actor ExchangeRateService {
     let code = base.id
 
     if !hydratedBases.contains(code) {
-      try? await loadCache(base: code)
+      do {
+        try await loadCache(base: code)
+      } catch {
+        logger.warning(
+          "prefetchLatest: loadCache failed for base \(code, privacy: .public): \(error.localizedDescription, privacy: .public)"
+        )
+      }
     }
 
     let calendar = Calendar(identifier: .gregorian)
@@ -191,7 +209,11 @@ actor ExchangeRateService {
     do {
       try await fetchAndMerge(base: code, from: fetchFrom, to: today)
     } catch {
-      // Prefetch is best-effort — silently ignore network errors
+      // Prefetch is best-effort — log so disk-write failures (which would
+      // otherwise be conflated with expected network errors) are observable.
+      logger.warning(
+        "prefetchLatest: fetchAndMerge failed for base \(code, privacy: .public): \(error.localizedDescription, privacy: .public)"
+      )
     }
   }
 
@@ -267,75 +289,7 @@ actor ExchangeRateService {
     }
   }
 
-  // MARK: - SQL persistence
-
-  /// Hydrates `caches[base]` from the GRDB-backed `exchange_rate` /
-  /// `exchange_rate_meta` tables. No-op when the base has no rows; marks the
-  /// base as hydrated either way so we don't re-query on every miss.
-  ///
-  /// Rates are stored as `REAL` (`Double`) in SQLite per
-  /// `guides/DATABASE_CODE_GUIDE.md` §3, and converted back to `Decimal` at
-  /// the boundary so the in-memory cache stays decimal-precise.
-  private func loadCache(base: String) async throws {
-    let snapshot: ExchangeRateCache? = try await database.read { database in
-      let metaRecord =
-        try ExchangeRateMetaRecord
-        .filter(ExchangeRateMetaRecord.Columns.base == base)
-        .fetchOne(database)
-      guard let metaRecord else { return nil }
-      let rateRecords =
-        try ExchangeRateRecord
-        .filter(ExchangeRateRecord.Columns.base == base)
-        .fetchAll(database)
-      // Decode via the `String` form of the stored `Double` so we recover
-      // the source decimal exactly (e.g. `0.581`), avoiding the precision
-      // tail that `Decimal(_: Double)` would introduce
-      // (`0.5810000000000001024`).
-      var rates: [String: [String: Decimal]] = [:]
-      for record in rateRecords {
-        let value = Decimal(string: String(record.rate)) ?? Decimal(record.rate)
-        rates[record.date, default: [:]][record.quote] = value
-      }
-      return ExchangeRateCache(
-        base: base,
-        earliestDate: metaRecord.earliestDate,
-        latestDate: metaRecord.latestDate,
-        rates: rates
-      )
-    }
-    if let snapshot { caches[base] = snapshot }
-    hydratedBases.insert(base)
-  }
-
-  /// Persists `caches[base]` to SQLite. Replaces the prior rows for this
-  /// base in a single transaction (delete-and-rewrite) and upserts the meta
-  /// row alongside, so the meta is never out of sync with the rates.
-  ///
-  /// Multi-statement; covered by a rollback test in
-  /// `ExchangeRateServiceTests.swift`.
-  private func saveCache(base: String) async throws {
-    guard let cache = caches[base] else { return }
-    // `Decimal` lacks a direct `Double` accessor; round-trip via
-    // `NSDecimalNumber` (`doubleValue`) — same path GRDB would take.
-    let records: [ExchangeRateRecord] = cache.rates.flatMap { dateString, quotes in
-      quotes.map { quote, rate in
-        ExchangeRateRecord(
-          base: base,
-          quote: quote,
-          date: dateString,
-          rate: NSDecimalNumber(decimal: rate).doubleValue
-        )
-      }
-    }
-    let meta = ExchangeRateMetaRecord(
-      base: base, earliestDate: cache.earliestDate, latestDate: cache.latestDate
-    )
-    try await database.write { database in
-      try ExchangeRateRecord
-        .filter(ExchangeRateRecord.Columns.base == base)
-        .deleteAll(database)
-      for record in records { try record.insert(database) }
-      try meta.upsert(database)
-    }
-  }
+  // SQL persistence (`loadCache` / `saveCache`) lives in
+  // `ExchangeRateService+Persistence.swift` so this file stays under
+  // SwiftLint's `type_body_length` and `file_length` thresholds.
 }

--- a/Shared/ExchangeRateService.swift
+++ b/Shared/ExchangeRateService.swift
@@ -1,6 +1,7 @@
 // Shared/ExchangeRateService.swift
 
 import Foundation
+import GRDB
 
 enum ExchangeRateError: Error, Equatable {
   case noRateAvailable(base: String, quote: String, date: String)
@@ -9,19 +10,15 @@ enum ExchangeRateError: Error, Equatable {
 actor ExchangeRateService {
   private let client: ExchangeRateClient
   private var caches: [String: ExchangeRateCache] = [:]
-  private let cacheDirectory: URL
+  /// Loaded bases — set on first hydration so we don't re-read SQL when the
+  /// cache is genuinely empty.
+  private var hydratedBases: Set<String> = []
+  private let database: any DatabaseWriter
   private let dateFormatter: ISO8601DateFormatter
 
-  init(client: ExchangeRateClient, cacheDirectory: URL? = nil) {
+  init(client: ExchangeRateClient, database: any DatabaseWriter) {
     self.client = client
-    if let cacheDirectory {
-      self.cacheDirectory = cacheDirectory
-    } else {
-      let baseCaches =
-        FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first
-        ?? URL(fileURLWithPath: NSTemporaryDirectory())
-      self.cacheDirectory = baseCaches.appendingPathComponent("exchange-rates")
-    }
+    self.database = database
     self.dateFormatter = ISO8601DateFormatter()
     self.dateFormatter.formatOptions = [.withFullDate]
   }
@@ -38,9 +35,9 @@ actor ExchangeRateService {
       return cached
     }
 
-    // Load from disk if not already loaded
-    if caches[base] == nil {
-      loadCacheFromDisk(base: base)
+    // Hydrate from SQL on first access
+    if !hydratedBases.contains(base) {
+      try await loadCache(base: base)
     }
 
     // Check again after disk load
@@ -109,9 +106,9 @@ actor ExchangeRateService {
     let base = from.id
     let quote = to.id
 
-    // Load cache if not already in memory
-    if caches[base] == nil {
-      loadCacheFromDisk(base: base)
+    // Hydrate cache if not already in memory
+    if !hydratedBases.contains(base) {
+      try await loadCache(base: base)
     }
 
     // Determine what we need to fetch
@@ -167,8 +164,8 @@ actor ExchangeRateService {
   func prefetchLatest(base: Instrument) async {
     let code = base.id
 
-    if caches[code] == nil {
-      loadCacheFromDisk(base: code)
+    if !hydratedBases.contains(code) {
+      try? await loadCache(base: code)
     }
 
     let calendar = Calendar(identifier: .gregorian)
@@ -242,7 +239,7 @@ actor ExchangeRateService {
   private func fetchAndMerge(base: String, from: Date, to: Date) async throws {
     let fetched = try await client.fetchRates(base: base, from: from, to: to)
     merge(base: base, newRates: fetched)
-    saveCacheToDisk(base: base)
+    try await saveCache(base: base)
   }
 
   private func merge(base: String, newRates: [String: [String: Decimal]]) {
@@ -270,31 +267,75 @@ actor ExchangeRateService {
     }
   }
 
-  private func cacheFileURL(base: String) -> URL {
-    cacheDirectory.appendingPathComponent("rates-\(base).json.gz")
+  // MARK: - SQL persistence
+
+  /// Hydrates `caches[base]` from the GRDB-backed `exchange_rate` /
+  /// `exchange_rate_meta` tables. No-op when the base has no rows; marks the
+  /// base as hydrated either way so we don't re-query on every miss.
+  ///
+  /// Rates are stored as `REAL` (`Double`) in SQLite per
+  /// `guides/DATABASE_CODE_GUIDE.md` §3, and converted back to `Decimal` at
+  /// the boundary so the in-memory cache stays decimal-precise.
+  private func loadCache(base: String) async throws {
+    let snapshot: ExchangeRateCache? = try await database.read { database in
+      let metaRecord =
+        try ExchangeRateMetaRecord
+        .filter(ExchangeRateMetaRecord.Columns.base == base)
+        .fetchOne(database)
+      guard let metaRecord else { return nil }
+      let rateRecords =
+        try ExchangeRateRecord
+        .filter(ExchangeRateRecord.Columns.base == base)
+        .fetchAll(database)
+      // Decode via the `String` form of the stored `Double` so we recover
+      // the source decimal exactly (e.g. `0.581`), avoiding the precision
+      // tail that `Decimal(_: Double)` would introduce
+      // (`0.5810000000000001024`).
+      var rates: [String: [String: Decimal]] = [:]
+      for record in rateRecords {
+        let value = Decimal(string: String(record.rate)) ?? Decimal(record.rate)
+        rates[record.date, default: [:]][record.quote] = value
+      }
+      return ExchangeRateCache(
+        base: base,
+        earliestDate: metaRecord.earliestDate,
+        latestDate: metaRecord.latestDate,
+        rates: rates
+      )
+    }
+    if let snapshot { caches[base] = snapshot }
+    hydratedBases.insert(base)
   }
 
-  private func loadCacheFromDisk(base: String) {
-    let url = cacheFileURL(base: base)
-    guard let compressed = try? Data(contentsOf: url) else { return }
-    guard let data = decompress(compressed) else { return }
-    guard let cache = try? JSONDecoder().decode(ExchangeRateCache.self, from: data) else { return }
-    caches[base] = cache
-  }
-
-  private func saveCacheToDisk(base: String) {
+  /// Persists `caches[base]` to SQLite. Replaces the prior rows for this
+  /// base in a single transaction (delete-and-rewrite) and upserts the meta
+  /// row alongside, so the meta is never out of sync with the rates.
+  ///
+  /// Multi-statement; covered by a rollback test in
+  /// `ExchangeRateServiceTests.swift`.
+  private func saveCache(base: String) async throws {
     guard let cache = caches[base] else { return }
-    guard let data = try? JSONEncoder().encode(cache) else { return }
-    guard let compressed = compress(data) else { return }
-    try? FileManager.default.createDirectory(at: cacheDirectory, withIntermediateDirectories: true)
-    try? compressed.write(to: cacheFileURL(base: base), options: .atomic)
-  }
-
-  private func compress(_ data: Data) -> Data? {
-    try? (data as NSData).compressed(using: .zlib) as Data
-  }
-
-  private func decompress(_ data: Data) -> Data? {
-    try? (data as NSData).decompressed(using: .zlib) as Data
+    // `Decimal` lacks a direct `Double` accessor; round-trip via
+    // `NSDecimalNumber` (`doubleValue`) — same path GRDB would take.
+    let records: [ExchangeRateRecord] = cache.rates.flatMap { dateString, quotes in
+      quotes.map { quote, rate in
+        ExchangeRateRecord(
+          base: base,
+          quote: quote,
+          date: dateString,
+          rate: NSDecimalNumber(decimal: rate).doubleValue
+        )
+      }
+    }
+    let meta = ExchangeRateMetaRecord(
+      base: base, earliestDate: cache.earliestDate, latestDate: cache.latestDate
+    )
+    try await database.write { database in
+      try ExchangeRateRecord
+        .filter(ExchangeRateRecord.Columns.base == base)
+        .deleteAll(database)
+      for record in records { try record.insert(database) }
+      try meta.upsert(database)
+    }
   }
 }

--- a/Shared/PreviewBackend.swift
+++ b/Shared/PreviewBackend.swift
@@ -25,10 +25,11 @@ enum PreviewBackend {
     // only affects SwiftUI canvas rendering.
     // swiftlint:disable:next force_try
     let container = try! ModelContainer(for: schema, configurations: [config])
+    // swiftlint:disable:next force_try
+    let database = try! ProfileDatabase.openInMemory()
     let exchangeRates = ExchangeRateService(
       client: FrankfurterClient(),
-      cacheDirectory: FileManager.default.temporaryDirectory
-        .appendingPathComponent("preview-rates")
+      database: database
     )
     let conversionService = FiatConversionService(exchangeRates: exchangeRates)
     let backend = CloudKitBackend(

--- a/Shared/ProfileContainerManager.swift
+++ b/Shared/ProfileContainerManager.swift
@@ -62,22 +62,41 @@ final class ProfileContainerManager {
     for suffix in ["", "-shm", "-wal"] {
       let url = baseURL.deletingLastPathComponent()
         .appending(path: baseURL.lastPathComponent + suffix)
-      try? fileManager.removeItem(at: url)
+      removeIfPresent(url, fileManager: fileManager, label: "SwiftData store file")
     }
 
     // Delete the sync state file
     let syncStateURL = URL.moolahScopedApplicationSupport
       .appending(path: "Moolah-\(profileId.uuidString).syncstate")
-    try? fileManager.removeItem(at: syncStateURL)
+    removeIfPresent(syncStateURL, fileManager: fileManager, label: "sync state file")
 
     // Delete the per-profile GRDB directory (data.sqlite + -wal/-shm
     // sidecars) added in the rate-storage-grdb refactor. Removing the
     // directory cleans up sidecars without enumerating each suffix.
     let dbDirectory = ProfileSession.profileDatabaseDirectory(for: profileId)
-    try? fileManager.removeItem(at: dbDirectory)
+    removeIfPresent(dbDirectory, fileManager: fileManager, label: "GRDB profile directory")
 
     // Delete the CloudKit zone for this profile
     deleteCloudKitZone(for: profileId)
+  }
+
+  /// Best-effort removal: a missing path is normal (e.g. WAL sidecar absent
+  /// for a clean-shutdown store), so swallow `NSFileNoSuchFileError` quietly
+  /// and log every other failure at `.warning`. Replaces a silent `try?`
+  /// per `CODE_GUIDE.md` §8.
+  private func removeIfPresent(_ url: URL, fileManager: FileManager, label: String) {
+    do {
+      try fileManager.removeItem(at: url)
+    } catch let error as NSError
+      where error.domain == NSCocoaErrorDomain
+      && error.code == NSFileNoSuchFileError
+    {
+      // Path was already absent — fine.
+    } catch {
+      logger.warning(
+        "Failed to delete \(label, privacy: .public) at \(url.path, privacy: .public): \(error.localizedDescription, privacy: .public)"
+      )
+    }
   }
 
   private func deleteCloudKitZone(for profileId: UUID) {

--- a/Shared/ProfileContainerManager.swift
+++ b/Shared/ProfileContainerManager.swift
@@ -9,7 +9,11 @@ import SwiftData
 final class ProfileContainerManager {
   let indexContainer: ModelContainer
   private let dataSchema: Schema
-  private let inMemory: Bool
+  /// `true` when the manager was created via `.forTesting()` — every
+  /// SwiftData container is in-memory and so must the per-profile GRDB
+  /// queue be (otherwise UI tests would write `data.sqlite` files to the
+  /// host's Application Support).
+  let inMemory: Bool
   private var containers: [UUID: ModelContainer] = [:]
 
   init(
@@ -65,6 +69,12 @@ final class ProfileContainerManager {
     let syncStateURL = URL.moolahScopedApplicationSupport
       .appending(path: "Moolah-\(profileId.uuidString).syncstate")
     try? fileManager.removeItem(at: syncStateURL)
+
+    // Delete the per-profile GRDB directory (data.sqlite + -wal/-shm
+    // sidecars) added in the rate-storage-grdb refactor. Removing the
+    // directory cleans up sidecars without enumerating each suffix.
+    let dbDirectory = ProfileSession.profileDatabaseDirectory(for: profileId)
+    try? fileManager.removeItem(at: dbDirectory)
 
     // Delete the CloudKit zone for this profile
     deleteCloudKitZone(for: profileId)

--- a/Shared/StockPriceService.swift
+++ b/Shared/StockPriceService.swift
@@ -71,7 +71,7 @@ actor StockPriceService {
 
   func prices(
     ticker: String, in range: ClosedRange<Date>
-  ) async throws -> [(date: String, price: Decimal)] {
+  ) async throws -> [(date: Date, price: Decimal)] {
     // Hydrate cache if not already in memory
     if !hydratedTickers.contains(ticker) {
       try await loadCache(ticker: ticker)
@@ -101,16 +101,16 @@ actor StockPriceService {
 
     // Build result series
     let dates = generateDateSeries(in: range)
-    var results: [(date: String, price: Decimal)] = []
+    var results: [(date: Date, price: Decimal)] = []
     var lastKnownPrice: Decimal?
 
     for date in dates {
       let dateString = dateFormatter.string(from: date)
       if let price = caches[ticker]?.prices[dateString] {
         lastKnownPrice = price
-        results.append((dateString, price))
+        results.append((date, price))
       } else if let fallback = lastKnownPrice {
-        results.append((dateString, fallback))
+        results.append((date, fallback))
       }
     }
 

--- a/Shared/StockPriceService.swift
+++ b/Shared/StockPriceService.swift
@@ -2,6 +2,7 @@
 
 import Foundation
 import GRDB
+import OSLog
 
 enum StockPriceError: Error, Equatable {
   case noPriceAvailable(ticker: String, date: String)
@@ -16,6 +17,8 @@ actor StockPriceService {
   private var hydratedTickers: Set<String> = []
   private let database: any DatabaseWriter
   private let dateFormatter: ISO8601DateFormatter
+  private let logger = Logger(
+    subsystem: "com.moolah.app", category: "StockPriceService")
 
   init(client: StockPriceClient, database: any DatabaseWriter) {
     self.client = client
@@ -273,6 +276,13 @@ actor StockPriceService {
   ///
   /// Multi-statement; covered by a rollback test in
   /// `StockPriceServiceTests.swift`.
+  ///
+  /// Captures `caches[ticker]` before suspending on `database.write`.
+  /// Actor re-entrancy is acceptable here: a concurrent merge will trigger
+  /// its own `saveCache` afterwards, so the disk converges to the latest
+  /// in-memory state. A crash between the two writes leaves the disk at
+  /// an intermediate-but-consistent snapshot — acceptable for a
+  /// best-effort persistent cache.
   private func saveCache(ticker: String) async throws {
     guard let cache = caches[ticker] else { return }
     let records: [StockPriceRecord] = cache.prices.map { dateString, price in

--- a/Shared/StockPriceService.swift
+++ b/Shared/StockPriceService.swift
@@ -1,6 +1,7 @@
 // Shared/StockPriceService.swift
 
 import Foundation
+import GRDB
 
 enum StockPriceError: Error, Equatable {
   case noPriceAvailable(ticker: String, date: String)
@@ -10,19 +11,15 @@ enum StockPriceError: Error, Equatable {
 actor StockPriceService {
   private let client: StockPriceClient
   private var caches: [String: StockPriceCache] = [:]
-  private let cacheDirectory: URL
+  /// Loaded tickers — set on first hydration so we don't re-read SQL when
+  /// the cache is genuinely empty.
+  private var hydratedTickers: Set<String> = []
+  private let database: any DatabaseWriter
   private let dateFormatter: ISO8601DateFormatter
 
-  init(client: StockPriceClient, cacheDirectory: URL? = nil) {
+  init(client: StockPriceClient, database: any DatabaseWriter) {
     self.client = client
-    if let cacheDirectory {
-      self.cacheDirectory = cacheDirectory
-    } else {
-      let baseCaches =
-        FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first
-        ?? URL(fileURLWithPath: NSTemporaryDirectory())
-      self.cacheDirectory = baseCaches.appendingPathComponent("stock-prices")
-    }
+    self.database = database
     self.dateFormatter = ISO8601DateFormatter()
     self.dateFormatter.formatOptions = [.withFullDate]
   }
@@ -37,9 +34,9 @@ actor StockPriceService {
       return cached
     }
 
-    // Load from disk if not already loaded
-    if caches[ticker] == nil {
-      loadCacheFromDisk(ticker: ticker)
+    // Hydrate from SQL on first access
+    if !hydratedTickers.contains(ticker) {
+      try await loadCache(ticker: ticker)
     }
 
     // Check again after disk load
@@ -72,9 +69,9 @@ actor StockPriceService {
   func prices(
     ticker: String, in range: ClosedRange<Date>
   ) async throws -> [(date: String, price: Decimal)] {
-    // Load cache if not already in memory
-    if caches[ticker] == nil {
-      loadCacheFromDisk(ticker: ticker)
+    // Hydrate cache if not already in memory
+    if !hydratedTickers.contains(ticker) {
+      try await loadCache(ticker: ticker)
     }
 
     // Determine what we need to fetch
@@ -121,7 +118,9 @@ actor StockPriceService {
     if let cache = caches[ticker] {
       return cache.instrument
     }
-    loadCacheFromDisk(ticker: ticker)
+    if !hydratedTickers.contains(ticker) {
+      try await loadCache(ticker: ticker)
+    }
     if let cache = caches[ticker] {
       return cache.instrument
     }
@@ -199,7 +198,7 @@ actor StockPriceService {
   private func fetchAndMerge(ticker: String, from: Date, to: Date) async throws {
     let response = try await client.fetchDailyPrices(ticker: ticker, from: from, to: to)
     merge(ticker: ticker, instrument: response.instrument, newPrices: response.prices)
-    saveCacheToDisk(ticker: ticker)
+    try await saveCache(ticker: ticker)
   }
 
   private func merge(ticker: String, instrument: Instrument, newPrices: [String: Decimal]) {
@@ -228,31 +227,76 @@ actor StockPriceService {
     }
   }
 
-  private func cacheFileURL(ticker: String) -> URL {
-    cacheDirectory.appendingPathComponent("prices-\(ticker).json.gz")
+  // MARK: - SQL persistence
+
+  /// Hydrates `caches[ticker]` from `stock_price` + `stock_ticker_meta`.
+  /// The meta row records the price denomination (`instrument_id`, e.g.
+  /// `"AUD"` for `BHP.AX`); on load we reconstruct a fiat `Instrument` from
+  /// the stored code, mirroring the `Instrument.fiat(code:)` factory used
+  /// when the price API first responds.
+  ///
+  /// Marks the ticker as hydrated even when no rows exist so we don't
+  /// re-query on every miss.
+  private func loadCache(ticker: String) async throws {
+    let snapshot: StockPriceCache? = try await database.read { database in
+      let metaRecord =
+        try StockTickerMetaRecord
+        .filter(StockTickerMetaRecord.Columns.ticker == ticker)
+        .fetchOne(database)
+      guard let metaRecord else { return nil }
+      let priceRecords =
+        try StockPriceRecord
+        .filter(StockPriceRecord.Columns.ticker == ticker)
+        .fetchAll(database)
+      // See `ExchangeRateService.loadCache` for the rationale on the
+      // String-via-Decimal round-trip; preserves source precision instead
+      // of inheriting the binary `Decimal(_: Double)` tail.
+      var prices: [String: Decimal] = [:]
+      for record in priceRecords {
+        prices[record.date] = Decimal(string: String(record.price)) ?? Decimal(record.price)
+      }
+      return StockPriceCache(
+        ticker: ticker,
+        instrument: Instrument.fiat(code: metaRecord.instrumentId),
+        earliestDate: metaRecord.earliestDate,
+        latestDate: metaRecord.latestDate,
+        prices: prices
+      )
+    }
+    if let snapshot { caches[ticker] = snapshot }
+    hydratedTickers.insert(ticker)
   }
 
-  private func loadCacheFromDisk(ticker: String) {
-    let url = cacheFileURL(ticker: ticker)
-    guard let compressed = try? Data(contentsOf: url) else { return }
-    guard let data = decompress(compressed) else { return }
-    guard let cache = try? JSONDecoder().decode(StockPriceCache.self, from: data) else { return }
-    caches[ticker] = cache
-  }
-
-  private func saveCacheToDisk(ticker: String) {
+  /// Persists `caches[ticker]` to SQLite. Replaces prior rows for this
+  /// ticker in a single transaction and upserts the meta row alongside so
+  /// the price denomination is never out of sync with the prices.
+  ///
+  /// Multi-statement; covered by a rollback test in
+  /// `StockPriceServiceTests.swift`.
+  private func saveCache(ticker: String) async throws {
     guard let cache = caches[ticker] else { return }
-    guard let data = try? JSONEncoder().encode(cache) else { return }
-    guard let compressed = compress(data) else { return }
-    try? FileManager.default.createDirectory(at: cacheDirectory, withIntermediateDirectories: true)
-    try? compressed.write(to: cacheFileURL(ticker: ticker), options: .atomic)
-  }
-
-  private func compress(_ data: Data) -> Data? {
-    try? (data as NSData).compressed(using: .zlib) as Data
-  }
-
-  private func decompress(_ data: Data) -> Data? {
-    try? (data as NSData).decompressed(using: .zlib) as Data
+    let records: [StockPriceRecord] = cache.prices.map { dateString, price in
+      StockPriceRecord(
+        ticker: ticker,
+        date: dateString,
+        price: NSDecimalNumber(decimal: price).doubleValue
+      )
+    }
+    // The price denomination in `StockPriceCache` is the API-reported fiat
+    // currency the ticker trades in (see `YahooFinanceClient.parseResponse`).
+    // Persist its code; load reconstructs via `Instrument.fiat(code:)`.
+    let meta = StockTickerMetaRecord(
+      ticker: ticker,
+      instrumentId: cache.instrument.id,
+      earliestDate: cache.earliestDate,
+      latestDate: cache.latestDate
+    )
+    try await database.write { database in
+      try StockPriceRecord
+        .filter(StockPriceRecord.Columns.ticker == ticker)
+        .deleteAll(database)
+      for record in records { try record.insert(database) }
+      try meta.upsert(database)
+    }
   }
 }


### PR DESCRIPTION
## Summary

Step 2 of the GRDB migration (`plans/grdb-migration.md` §6 → Step 2; detailed plan in `plans/grdb-step-2-rate-storage.md` from PR #557).

Replaces the gzipped JSON rate caches in `Caches/{exchange-rates,stock-prices,crypto-prices}/` with per-profile SQLite tables managed by GRDB. The three rate services (`ExchangeRateService`, `StockPriceService`, `CryptoPriceService`) keep their **public API and protocol surface unchanged**; only the persistence guts change.

- `ProfileSession` owns a `private let database: DatabaseQueue` opened at `Application Support/moolah/Moolah/profiles/<id>/data.sqlite` via `ProfileDatabase.open(at:)`.
- `ProfileSchema.migrator` runs a single `v1_initial` migration creating six STRICT tables (`exchange_rate`, `exchange_rate_meta`, `stock_price`, `stock_ticker_meta`, `crypto_price`, `crypto_token_meta`) with composite-key `WITHOUT ROWID` price tables and a covering lookup index per `DATABASE_SCHEMA_GUIDE.md` §4.
- `journal_mode = WAL` set explicitly + read-back assertion at every open. Open-time `PRAGMA optimize = 0x10002`; periodic `PRAGMA optimize` runs in `database.write` on app `.background` scene phase, scheduled per-session via `ProfileSession.schedulePragmaOptimize()` with proper task tracking and teardown.
- Rate caches are kept forever (historic-conversion correctness); retention policy documented in `ProfileSchema`.
- `Decimal ↔ Double` boundary handled with `Decimal(string: String(value))` recovery; persistence test asserts ~1e-9 tolerance.
- One-shot legacy JSON cache cleanup gated by `UserDefaults` flag `v2.rates.cache.cleared`; logs failures, skips already-absent paths.
- `ProfileSession.init` throws — propagated through `SessionManager` (fatalError on failure with descriptive message). All four `#Preview` blocks updated.
- Profile delete removes the whole `profiles/<id>/` directory (covers `-wal` / `-shm` sidecars).

## Quality gates

- 4 reviewer agents (`database-schema-review`, `database-code-review`, `code-review`, `concurrency-review`) ran three rounds; all findings (Critical / Important / Minor) fixed across rounds 1–3 including pre-existing `try?` patterns in `ProfileContainerManager.deleteStore` and `MoolahApp+Setup`.
- `BEFORE INSERT` SQL triggers used in rollback tests so they drive the production `saveCache` transaction; tests assert specific prior rows survive (not just count).
- Plan-pinning tests (`MoolahTests/Backends/RateQueryPlanTests.swift`) confirm `SEARCH USING PRIMARY KEY` for the three `loadCache` filters.

## Test plan
- [x] `just format-check` clean
- [x] `just build-mac` succeeded
- [x] `just build-ios` succeeded
- [x] `just test-mac` — 1744 tests in 263 suites pass
- [x] `just test-ios` pass
- [x] `.swiftlint-baseline.yml` unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)