### PR TITLE
feat(transactions): first-class Trade transaction UI

### DIFF
--- a/App/MoolahApp+Setup.swift
+++ b/App/MoolahApp+Setup.swift
@@ -144,7 +144,8 @@ extension MoolahApp {
       .welcomeEmpty,
       .welcomeSingleCloudProfile,
       .welcomeMultipleCloudProfiles,
-      .cryptoCatalogPreloaded:
+      .cryptoCatalogPreloaded,
+      .tradeReady:
       break
     case .welcomeDownloading:
       // Override iCloudAvailability to `.available` so the WelcomeStateResolver

--- a/App/UITestSeedCryptoOverrides.swift
+++ b/App/UITestSeedCryptoOverrides.swift
@@ -37,7 +37,8 @@ enum UITestSeedCryptoOverrides {
       .welcomeDownloading,
       .sidebarFooterUpToDate,
       .sidebarFooterReceiving,
-      .sidebarFooterSending:
+      .sidebarFooterSending,
+      .tradeReady:
       return nil
     }
   }

--- a/App/UITestSeedHydrator.swift
+++ b/App/UITestSeedHydrator.swift
@@ -68,6 +68,8 @@ enum UITestSeedHydrator {
       // accounts/transactions are unused. Reuse `tradeBaseline` rather than
       // hand-rolling a near-identical fixture.
       return try hydrateTradeBaseline(into: manager)
+    case .tradeReady:
+      return try hydrateTradeReady(into: manager)
     }
   }
 
@@ -87,6 +89,50 @@ enum UITestSeedHydrator {
   }
 
   // MARK: - Seeds
+
+  private static func hydrateTradeReady(
+    into manager: ProfileContainerManager
+  ) throws -> Profile {
+    let fixtures = UITestFixtures.TradeReady.self
+
+    let profile = Profile(
+      id: fixtures.profileId,
+      label: fixtures.profileLabel,
+      backendType: .cloudKit,
+      currencyCode: fixtures.profileCurrencyCode,
+      financialYearStartMonth: 7,
+      createdAt: Date(timeIntervalSince1970: 1_700_000_000)
+    )
+    try upsertProfile(profile, into: manager)
+
+    let container = try manager.container(for: profile.id)
+    let context = ModelContext(container)
+    let audInstrument = profile.instrument
+
+    try upsertInstrument(audInstrument, in: context)
+    try upsertAccount(
+      AccountSpec(
+        id: fixtures.brokerageAccountId,
+        name: fixtures.brokerageAccountName,
+        type: .bank,
+        instrumentId: audInstrument.id,
+        position: 0),
+      in: context)
+
+    let vgsax = Instrument.stock(
+      ticker: fixtures.vgsaxTicker,
+      exchange: fixtures.vgsaxExchange,
+      name: fixtures.vgsaxName)
+    try upsertInstrument(vgsax, in: context)
+
+    try upsertCategory(
+      id: fixtures.brokerageCategoryId,
+      name: fixtures.brokerageCategoryName,
+      in: context)
+
+    try context.save()
+    return profile
+  }
 
   private static func hydrateTradeBaseline(
     into manager: ProfileContainerManager

--- a/App/UITestSeedHydrator.swift
+++ b/App/UITestSeedHydrator.swift
@@ -98,7 +98,6 @@ enum UITestSeedHydrator {
     let profile = Profile(
       id: fixtures.profileId,
       label: fixtures.profileLabel,
-      backendType: .cloudKit,
       currencyCode: fixtures.profileCurrencyCode,
       financialYearStartMonth: 7,
       createdAt: Date(timeIntervalSince1970: 1_700_000_000)

--- a/Backends/CloudKit/Repositories/CloudKitAnalysisRepository+IncomeExpense.swift
+++ b/Backends/CloudKit/Repositories/CloudKitAnalysisRepository+IncomeExpense.swift
@@ -199,8 +199,8 @@ extension CloudKitAnalysisRepository {
       if classified.isEarmarked {
         data.earmarkedIncome += classified.amount
       }
-    case .openingBalance:
-      // Server excludes openingBalance from income/expense reports.
+    case .openingBalance, .trade:
+      // Server excludes openingBalance and trade from income/expense reports.
       break
     case .expense:
       // Server: SUM(IF(type='expense' AND account_id IS NOT NULL, amount, 0))

--- a/Backends/CloudKit/Repositories/CloudKitEarmarkRepository.swift
+++ b/Backends/CloudKit/Repositories/CloudKitEarmarkRepository.swift
@@ -238,7 +238,7 @@ final class CloudKitEarmarkRepository: EarmarkRepository, @unchecked Sendable {
       // Type-based saved/spent classification
       let legType = TransactionType(rawValue: leg.type) ?? .expense
       switch legType {
-      case .income, .openingBalance:
+      case .income, .openingBalance, .trade:
         savedTotals[inst, default: 0] += amount.quantity
       case .expense, .transfer:
         spentTotals[inst, default: 0] += -amount.quantity

--- a/Domain/Models/RunningBalanceResult.swift
+++ b/Domain/Models/RunningBalanceResult.swift
@@ -34,6 +34,14 @@ struct RunningBalanceConversionError: LocalizedError, Sendable {
 struct TransactionWithBalance: Sendable, Identifiable {
   let transaction: Transaction
   let convertedLegs: [ConvertedTransactionLeg]
+  /// Per-instrument leg sums in the legs' native instruments, restricted
+  /// to the legs that match the row's scope (account / earmark filter, or
+  /// all legs when unfiltered). Empty when conversion failed (paired with
+  /// `displayAmount == nil`). See design §4.2.
+  let displayAmounts: [InstrumentAmount]
+  /// Single scalar in the running-balance target instrument. Retained for
+  /// backwards-compatible diagnostics and any consumer that wants the
+  /// converted total; the row no longer reads it for rendering.
   let displayAmount: InstrumentAmount?
   let balance: InstrumentAmount?
 

--- a/Domain/Models/Transaction+Display.swift
+++ b/Domain/Models/Transaction+Display.swift
@@ -102,6 +102,14 @@ extension Transaction {
   /// in trade title sentences. Uses `0...decimals` precision so trailing zeros
   /// are suppressed (e.g. `20 VGS.AX`, `100 USD`, `30,000 USDC`). Fiat uses
   /// the ISO code; stock/crypto uses the ticker.
+  ///
+  /// Diverges from `InstrumentAmount.formatted` deliberately: the latter renders
+  /// fiat with the locale-currency symbol (e.g. `"$100.00"`), which would clash
+  /// with the design's title examples (`"Bought 20 VGS.AX"`, `"Swapped 100 USD
+  /// for 50 GBP"`). The amount column elsewhere on the row keeps using
+  /// `.formatted` for the symbol form; only the title sentence uses this code-form
+  /// helper. See design §4.3.
+  ///
   /// `abs()` here produces a *display* magnitude only — the stored sign is not modified.
   private func formatLegMagnitude(_ leg: TransactionLeg) -> String {
     let qty = abs(leg.quantity)

--- a/Domain/Models/Transaction+Display.swift
+++ b/Domain/Models/Transaction+Display.swift
@@ -68,3 +68,52 @@ extension Transaction {
     return ""
   }
 }
+
+// MARK: - Trade Title
+
+extension Transaction {
+  /// The action sentence for a `.trade`-shaped transaction row title.
+  /// Returns `nil` for non-trade transactions. See design §4.3.
+  ///
+  /// `scopeReference` is the row's reference instrument: the account's
+  /// instrument when account-scoped, the earmark's instrument when
+  /// earmark-scoped, otherwise the profile currency.
+  func tradeTitleSentence(scopeReference: Instrument) -> String? {
+    guard isTrade else { return nil }
+    let tradeLegs = legs.filter { $0.type == .trade }
+    guard tradeLegs.count == 2 else { return nil }
+    let (legA, legB) = (tradeLegs[0], tradeLegs[1])
+
+    let aMatches = legA.instrument == scopeReference
+    let bMatches = legB.instrument == scopeReference
+    if aMatches != bMatches {
+      let matching = aMatches ? legA : legB
+      let other = aMatches ? legB : legA
+      let verb = matching.quantity < 0 ? "Bought" : "Sold"
+      return "\(verb) \(formatLegMagnitude(other))"
+    }
+    // Neither matches, or both match — render Paid → Received.
+    let paid = legA.quantity < 0 ? legA : legB
+    let received = legA.quantity < 0 ? legB : legA
+    return "Swapped \(formatLegMagnitude(paid)) for \(formatLegMagnitude(received))"
+  }
+
+  /// Formats the absolute magnitude of `leg` as `"{number} {code}"` for use
+  /// in trade title sentences. Uses `0...decimals` precision so trailing zeros
+  /// are suppressed (e.g. `20 VGS.AX`, `100 USD`, `30,000 USDC`). Fiat uses
+  /// the ISO code; stock/crypto uses the ticker.
+  /// `abs()` here produces a *display* magnitude only — the stored sign is not modified.
+  private func formatLegMagnitude(_ leg: TransactionLeg) -> String {
+    let qty = abs(leg.quantity)
+    let instrument = leg.instrument
+    let number = qty.formatted(.number.precision(.fractionLength(0...instrument.decimals)))
+    let code: String
+    switch instrument.kind {
+    case .fiatCurrency:
+      code = instrument.id
+    case .stock, .cryptoToken:
+      code = instrument.ticker ?? instrument.id
+    }
+    return "\(number) \(code)"
+  }
+}

--- a/Domain/Models/Transaction+Display.swift
+++ b/Domain/Models/Transaction+Display.swift
@@ -98,30 +98,12 @@ extension Transaction {
     return "Swapped \(formatLegMagnitude(paid)) for \(formatLegMagnitude(received))"
   }
 
-  /// Formats the absolute magnitude of `leg` as `"{number} {code}"` for use
-  /// in trade title sentences. Uses `0...decimals` precision so trailing zeros
-  /// are suppressed (e.g. `20 VGS.AX`, `100 USD`, `30,000 USDC`). Fiat uses
-  /// the ISO code; stock/crypto uses the ticker.
-  ///
-  /// Diverges from `InstrumentAmount.formatted` deliberately: the latter renders
-  /// fiat with the locale-currency symbol (e.g. `"$100.00"`), which would clash
-  /// with the design's title examples (`"Bought 20 VGS.AX"`, `"Swapped 100 USD
-  /// for 50 GBP"`). The amount column elsewhere on the row keeps using
-  /// `.formatted` for the symbol form; only the title sentence uses this code-form
-  /// helper. See design §4.3.
-  ///
-  /// `abs()` here produces a *display* magnitude only — the stored sign is not modified.
+  /// Formats the absolute magnitude of `leg` as a positive
+  /// `InstrumentAmount.formatted` — locale-currency symbol for fiat,
+  /// `"{number} {ticker}"` for stocks and crypto — for use in trade title
+  /// sentences. `abs()` here produces a *display* magnitude only; the stored
+  /// sign is not modified.
   private func formatLegMagnitude(_ leg: TransactionLeg) -> String {
-    let qty = abs(leg.quantity)
-    let instrument = leg.instrument
-    let number = qty.formatted(.number.precision(.fractionLength(0...instrument.decimals)))
-    let code: String
-    switch instrument.kind {
-    case .fiatCurrency:
-      code = instrument.id
-    case .stock, .cryptoToken:
-      code = instrument.ticker ?? instrument.id
-    }
-    return "\(number) \(code)"
+    InstrumentAmount(quantity: abs(leg.quantity), instrument: leg.instrument).formatted
   }
 }

--- a/Domain/Models/Transaction+Display.swift
+++ b/Domain/Models/Transaction+Display.swift
@@ -48,6 +48,15 @@ extension Transaction {
       return "Transfer from \(fromName) to \(toName)"
     }
 
+    if isTrade {
+      // Trade-shaped transactions defer the action sentence to
+      // `tradeTitleSentence(scopeReference:)`, which the row's `titleText`
+      // appends in parentheses after the payee. Return just the payee here
+      // (or empty), never the "(N sub-transactions)" custom label.
+      if let payee, !payee.isEmpty { return payee }
+      return ""
+    }
+
     if !isSimple {
       if let payee, !payee.isEmpty {
         return "\(payee) (\(legs.count) sub-transactions)"

--- a/Domain/Models/Transaction+Structure.swift
+++ b/Domain/Models/Transaction+Structure.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+// Structural shape queries for `Transaction`. Kept here to keep
+// `Transaction.swift` itself under the file_length threshold.
+extension Transaction {
+  /// Whether this transaction has the structural shape of a trade per
+  /// `plans/2026-04-28-trade-transaction-ui-design.md` §1.2:
+  /// exactly two `.trade` legs (no category, no earmark) plus zero or
+  /// more `.expense` fee legs (which may have a category and/or earmark),
+  /// all on the same non-nil account. Sign and instrument of the
+  /// `.trade` legs are unrestricted.
+  var isTrade: Bool {
+    let tradeLegs = legs.filter { $0.type == .trade }
+    guard tradeLegs.count == 2 else { return false }
+    guard tradeLegs.allSatisfy({ $0.categoryId == nil && $0.earmarkId == nil })
+    else { return false }
+    let extraLegs = legs.filter { $0.type != .trade }
+    guard extraLegs.allSatisfy({ $0.type == .expense }) else { return false }
+    guard !legs.contains(where: { $0.accountId == nil }) else { return false }
+    return accountIds.count == 1
+  }
+}

--- a/Domain/Models/Transaction+Structure.swift
+++ b/Domain/Models/Transaction+Structure.swift
@@ -1,7 +1,7 @@
 import Foundation
 
-// Structural shape queries for `Transaction`. Kept here to keep
-// `Transaction.swift` itself under the file_length threshold.
+// Structural shape queries and display-amount computation for `Transaction`.
+// Kept here to keep `Transaction.swift` itself under the file_length threshold.
 extension Transaction {
   /// Whether this transaction has the structural shape of a trade per
   /// `plans/2026-04-28-trade-transaction-ui-design.md` §1.2:
@@ -18,5 +18,43 @@ extension Transaction {
     guard extraLegs.allSatisfy({ $0.type == .expense }) else { return false }
     guard !legs.contains(where: { $0.accountId == nil }) else { return false }
     return accountIds.count == 1
+  }
+
+  /// Returns one entry per distinct native instrument for the legs that match
+  /// the row's scope (account, earmark, or all legs). Zero-net entries are
+  /// dropped. When every per-instrument net is zero (e.g. a same-currency
+  /// transfer whose legs cancel), falls back to the negative-quantity transfer
+  /// leg(s) so the row still shows something sensible — preserving existing
+  /// behaviour for unfiltered transfers (design §4.2).
+  static func computeDisplayAmounts(
+    for transaction: Transaction,
+    accountId: UUID?,
+    earmarkId: UUID?
+  ) -> [InstrumentAmount] {
+    let scopedLegs: [TransactionLeg]
+    if let accountId {
+      scopedLegs = transaction.legs.filter { $0.accountId == accountId }
+    } else if let earmarkId {
+      scopedLegs = transaction.legs.filter { $0.earmarkId == earmarkId }
+    } else {
+      scopedLegs = transaction.legs
+    }
+
+    // Sum per instrument, preserving first-seen order for stable rendering.
+    var order: [Instrument] = []
+    var sums: [Instrument: Decimal] = [:]
+    for leg in scopedLegs {
+      if sums[leg.instrument] == nil { order.append(leg.instrument) }
+      sums[leg.instrument, default: 0] += leg.quantity
+    }
+    let nonZero = order.compactMap { instrument -> InstrumentAmount? in
+      guard let qty = sums[instrument], qty != 0 else { return nil }
+      return InstrumentAmount(quantity: qty, instrument: instrument)
+    }
+    if !nonZero.isEmpty { return nonZero }
+
+    // Zero-sum fallback: surface the negative-quantity transfer leg(s).
+    let negatives = scopedLegs.filter { $0.type == .transfer && $0.quantity < 0 }
+    return negatives.map(\.amount)
   }
 }

--- a/Domain/Models/Transaction.swift
+++ b/Domain/Models/Transaction.swift
@@ -293,6 +293,7 @@ struct TransactionPage: Sendable {
           TransactionWithBalance(
             transaction: transaction,
             convertedLegs: convertedLegs,
+            displayAmounts: [],
             displayAmount: displayAmount,
             balance: balance))
       case .failure(let underlyingDescription):
@@ -307,6 +308,7 @@ struct TransactionPage: Sendable {
           TransactionWithBalance(
             transaction: transaction,
             convertedLegs: [],
+            displayAmounts: [],
             displayAmount: nil,
             balance: nil))
       }

--- a/Domain/Models/Transaction.swift
+++ b/Domain/Models/Transaction.swift
@@ -293,7 +293,8 @@ struct TransactionPage: Sendable {
           TransactionWithBalance(
             transaction: transaction,
             convertedLegs: convertedLegs,
-            displayAmounts: [],
+            displayAmounts: Transaction.computeDisplayAmounts(
+              for: transaction, accountId: accountId, earmarkId: earmarkId),
             displayAmount: displayAmount,
             balance: balance))
       case .failure(let underlyingDescription):

--- a/Domain/Models/Transaction.swift
+++ b/Domain/Models/Transaction.swift
@@ -52,7 +52,7 @@ struct Transaction: Codable, Sendable, Identifiable, Hashable {
     return accounts.count > 1 || instruments.count > 1
   }
 
-  // MARK: - Structure Queries
+  // MARK: - Structure Queries (simple/transfer shape)
 
   /// Whether this transaction has simple structure: a single leg, or exactly
   /// two legs forming a basic transfer (amounts negate, same type, second leg
@@ -85,24 +85,6 @@ struct Transaction: Codable, Sendable, Identifiable, Hashable {
     return first.instrument != second.instrument
   }
 
-  /// Whether this transaction has the structural shape of a trade per
-  /// `plans/2026-04-28-trade-transaction-ui-design.md` §1.2:
-  /// exactly two `.trade` legs (no category, no earmark) plus zero or
-  /// more `.expense` fee legs (which may have a category and/or earmark),
-  /// all on the same non-nil account. Sign and instrument of the
-  /// `.trade` legs are unrestricted.
-  var isTrade: Bool {
-    let tradeLegs = legs.filter { $0.type == .trade }
-    guard tradeLegs.count == 2 else { return false }
-    guard tradeLegs.allSatisfy({ $0.categoryId == nil && $0.earmarkId == nil })
-    else { return false }
-    let extra = legs.filter { $0.type != .trade }
-    guard extra.allSatisfy({ $0.type == .expense }) else { return false }
-    let accountIds = Set(legs.compactMap(\.accountId))
-    guard accountIds.count == 1, !legs.contains(where: { $0.accountId == nil })
-    else { return false }
-    return true
-  }
 }
 
 struct TransactionFilter: Sendable, Equatable {

--- a/Domain/Models/Transaction.swift
+++ b/Domain/Models/Transaction.swift
@@ -84,6 +84,25 @@ struct Transaction: Codable, Sendable, Identifiable, Hashable {
     guard second.categoryId == nil && second.earmarkId == nil else { return false }
     return first.instrument != second.instrument
   }
+
+  /// Whether this transaction has the structural shape of a trade per
+  /// `plans/2026-04-28-trade-transaction-ui-design.md` §1.2:
+  /// exactly two `.trade` legs (no category, no earmark) plus zero or
+  /// more `.expense` fee legs (which may have a category and/or earmark),
+  /// all on the same non-nil account. Sign and instrument of the
+  /// `.trade` legs are unrestricted.
+  var isTrade: Bool {
+    let tradeLegs = legs.filter { $0.type == .trade }
+    guard tradeLegs.count == 2 else { return false }
+    guard tradeLegs.allSatisfy({ $0.categoryId == nil && $0.earmarkId == nil })
+    else { return false }
+    let extra = legs.filter { $0.type != .trade }
+    guard extra.allSatisfy({ $0.type == .expense }) else { return false }
+    let accountIds = Set(legs.compactMap(\.accountId))
+    guard accountIds.count == 1, !legs.contains(where: { $0.accountId == nil })
+    else { return false }
+    return true
+  }
 }
 
 struct TransactionFilter: Sendable, Equatable {

--- a/Domain/Models/TransactionType.swift
+++ b/Domain/Models/TransactionType.swift
@@ -8,7 +8,9 @@ enum TransactionType: String, Codable, Sendable, CaseIterable {
   case trade
 
   /// Whether this transaction type can be manually created or edited by users.
-  /// Opening balance transactions are system-generated and cannot be modified.
+  /// `.openingBalance` transactions are system-generated and cannot be modified.
+  /// `.trade` transactions are user-editable; the bespoke trade UI ships in a
+  /// subsequent task in this branch.
   var isUserEditable: Bool {
     self != .openingBalance
   }

--- a/Domain/Models/TransactionType.swift
+++ b/Domain/Models/TransactionType.swift
@@ -5,6 +5,7 @@ enum TransactionType: String, Codable, Sendable, CaseIterable {
   case expense
   case transfer
   case openingBalance
+  case trade
 
   /// Whether this transaction type can be manually created or edited by users.
   /// Opening balance transactions are system-generated and cannot be modified.
@@ -19,11 +20,12 @@ enum TransactionType: String, Codable, Sendable, CaseIterable {
     case .expense: return "Expense"
     case .transfer: return "Transfer"
     case .openingBalance: return "Opening Balance"
+    case .trade: return "Trade"
     }
   }
 
   /// Only types that users can select when creating/editing transactions
   static var userSelectableTypes: [TransactionType] {
-    [.income, .expense, .transfer]
+    [.income, .expense, .transfer, .trade]
   }
 }

--- a/Features/Transactions/Views/Detail/TransactionDetailFeeSection.swift
+++ b/Features/Transactions/Views/Detail/TransactionDetailFeeSection.swift
@@ -1,0 +1,95 @@
+import SwiftUI
+
+/// One fee section in the trade-mode editor. Renders amount + instrument,
+/// category, earmark, and a destructive Remove button.
+struct TransactionDetailFeeSection: View {
+  let legIndex: Int
+  let displayNumber: Int
+  @Binding var draft: TransactionDraft
+  let accounts: Accounts
+  let categories: Categories
+  let earmarks: Earmarks
+  let knownInstruments: [Instrument]
+  @Binding var categoryState: CategoryAutocompleteState
+  @FocusState.Binding var focusedField: TransactionDetailFocus?
+  let onRequestRemove: () -> Void
+
+  var body: some View {
+    Section("Fee \(displayNumber)") {
+      amountRow
+      categoryField
+      earmarkPicker
+      Button(role: .destructive, action: onRequestRemove) {
+        Text("Remove Fee").frame(maxWidth: .infinity)
+      }
+      .accessibilityIdentifier(UITestIdentifiers.Detail.tradeFeeRemove(displayNumber - 1))
+    }
+  }
+
+  private var amountRow: some View {
+    let amountBinding = Binding(
+      get: { draft.legDrafts[legIndex].amountText },
+      set: { draft.legDrafts[legIndex].amountText = $0 })
+    let instrumentBinding = Binding<Instrument>(
+      get: {
+        let id = draft.legDrafts[legIndex].instrumentId ?? Instrument.AUD.id
+        return knownInstruments.first { $0.id == id } ?? Instrument.fiat(code: id)
+      },
+      set: { draft.legDrafts[legIndex].instrumentId = $0.id })
+
+    return HStack {
+      Text("Amount")
+      Spacer()
+      TextField("Amount", text: amountBinding)
+        .multilineTextAlignment(.trailing)
+        .monospacedDigit()
+        #if os(iOS)
+          .keyboardType(.decimalPad)
+        #endif
+        .focused($focusedField, equals: .tradeFeeAmount(legIndex))
+        .accessibilityIdentifier(UITestIdentifiers.Detail.tradeFeeAmount(displayNumber - 1))
+      InstrumentPickerField(
+        label: "",
+        kinds: Set(Instrument.Kind.allCases),
+        selection: instrumentBinding
+      )
+      .labelsHidden()
+    }
+  }
+
+  // Reuse the same legCategory autocomplete machinery used by Custom mode
+  // (TransactionDetailLegRow). The category field component is small
+  // enough to inline here; mirror that file's pattern.
+  @ViewBuilder private var categoryField: some View {
+    LegCategoryAutocompleteField(
+      legIndex: legIndex,
+      text: Binding(
+        get: { draft.legDrafts[legIndex].categoryText },
+        set: { draft.legDrafts[legIndex].categoryText = $0 }),
+      highlightedIndex: $categoryState.highlightedIndex,
+      suggestionCount: categoryState.visibleSuggestions(
+        for: draft.legDrafts[legIndex].categoryText, in: categories
+      ).count,
+      onTextChange: { _ in categoryState.showSuggestions = true },
+      onAcceptHighlighted: {},
+      onCancel: { categoryState.cancel() }
+    )
+  }
+
+  private var earmarkPicker: some View {
+    Picker(
+      "Earmark",
+      selection: Binding(
+        get: { draft.legDrafts[legIndex].earmarkId },
+        set: { draft.legDrafts[legIndex].earmarkId = $0 })
+    ) {
+      Text("None").tag(UUID?.none)
+      ForEach(earmarks.ordered.filter { !$0.isHidden }) { earmark in
+        Text(earmark.name).tag(UUID?.some(earmark.id))
+      }
+    }
+    #if os(macOS)
+      .pickerStyle(.menu)
+    #endif
+  }
+}

--- a/Features/Transactions/Views/Detail/TransactionDetailFeeSection.swift
+++ b/Features/Transactions/Views/Detail/TransactionDetailFeeSection.swift
@@ -74,6 +74,7 @@ struct TransactionDetailFeeSection: View {
       onAcceptHighlighted: {},
       onCancel: { categoryState.cancel() }
     )
+    .accessibilityIdentifier(UITestIdentifiers.Detail.legCategory(legIndex))
   }
 
   private var earmarkPicker: some View {

--- a/Features/Transactions/Views/Detail/TransactionDetailFeeSection.swift
+++ b/Features/Transactions/Views/Detail/TransactionDetailFeeSection.swift
@@ -14,6 +14,13 @@ struct TransactionDetailFeeSection: View {
   @FocusState.Binding var focusedField: TransactionDetailFocus?
   let onRequestRemove: () -> Void
 
+  @FocusState private var categoryFieldFocused: Bool
+
+  private var visibleSuggestions: [CategorySuggestion] {
+    categoryState.visibleSuggestions(
+      for: draft.legDrafts[legIndex].categoryText, in: categories)
+  }
+
   var body: some View {
     Section("Fee \(displayNumber)") {
       amountRow
@@ -58,9 +65,8 @@ struct TransactionDetailFeeSection: View {
     }
   }
 
-  // Reuse the same legCategory autocomplete machinery used by Custom mode
-  // (TransactionDetailLegRow). The category field component is small
-  // enough to inline here; mirror that file's pattern.
+  // Mirrors `TransactionDetailLegRow`'s leg-category field — same dropdown,
+  // same overlay anchor key, same blur/Enter handlers.
   @ViewBuilder private var categoryField: some View {
     LegCategoryAutocompleteField(
       legIndex: legIndex,
@@ -68,14 +74,42 @@ struct TransactionDetailFeeSection: View {
         get: { draft.legDrafts[legIndex].categoryText },
         set: { draft.legDrafts[legIndex].categoryText = $0 }),
       highlightedIndex: $categoryState.highlightedIndex,
-      suggestionCount: categoryState.visibleSuggestions(
-        for: draft.legDrafts[legIndex].categoryText, in: categories
-      ).count,
-      onTextChange: { _ in categoryState.showSuggestions = true },
-      onAcceptHighlighted: {},
+      suggestionCount: visibleSuggestions.count,
+      onTextChange: { _ in openDropdownIfFocused() },
+      onAcceptHighlighted: acceptHighlighted,
       onCancel: { categoryState.cancel() }
     )
+    .focused($categoryFieldFocused)
     .accessibilityIdentifier(UITestIdentifiers.Detail.legCategory(legIndex))
+    .onChange(of: categoryFieldFocused) { _, focused in
+      if !focused { handleBlur() }
+    }
+  }
+
+  private func openDropdownIfFocused() {
+    guard categoryFieldFocused else { return }
+    if categoryState.justSelected {
+      categoryState.justSelected = false
+    } else {
+      categoryState.showSuggestions = true
+    }
+  }
+
+  private func handleBlur() {
+    let highlighted = categoryState.highlightedSuggestion(
+      for: draft.legDrafts[legIndex].categoryText, in: categories)
+    categoryState.dismiss()
+    draft.commitHighlightedLegCategoryOrNormalise(
+      at: legIndex, highlighted: highlighted, using: categories)
+  }
+
+  private func acceptHighlighted() {
+    guard let highlighted = categoryState.highlightedIndex,
+      highlighted < visibleSuggestions.count
+    else { return }
+    let selected = visibleSuggestions[highlighted]
+    categoryState.dismiss()
+    draft.commitLegCategorySelection(at: legIndex, id: selected.id, path: selected.path)
   }
 
   private var earmarkPicker: some View {

--- a/Features/Transactions/Views/Detail/TransactionDetailFeeSection.swift
+++ b/Features/Transactions/Views/Detail/TransactionDetailFeeSection.swift
@@ -37,23 +37,24 @@ struct TransactionDetailFeeSection: View {
       },
       set: { draft.legDrafts[legIndex].instrumentId = $0.id })
 
-    return HStack {
+    return LabeledContent {
+      HStack(spacing: 8) {
+        TextField("Amount", text: amountBinding)
+          .labelsHidden()
+          .multilineTextAlignment(.trailing)
+          .monospacedDigit()
+          #if os(iOS)
+            .keyboardType(.decimalPad)
+          #endif
+          .focused($focusedField, equals: .tradeFeeAmount(legIndex))
+          .accessibilityIdentifier(UITestIdentifiers.Detail.tradeFeeAmount(displayNumber - 1))
+        CompactInstrumentPickerButton(
+          selection: instrumentBinding,
+          knownInstruments: knownInstruments
+        )
+      }
+    } label: {
       Text("Amount")
-      Spacer()
-      TextField("Amount", text: amountBinding)
-        .multilineTextAlignment(.trailing)
-        .monospacedDigit()
-        #if os(iOS)
-          .keyboardType(.decimalPad)
-        #endif
-        .focused($focusedField, equals: .tradeFeeAmount(legIndex))
-        .accessibilityIdentifier(UITestIdentifiers.Detail.tradeFeeAmount(displayNumber - 1))
-      InstrumentPickerField(
-        label: "",
-        kinds: Set(Instrument.Kind.allCases),
-        selection: instrumentBinding
-      )
-      .labelsHidden()
     }
   }
 

--- a/Features/Transactions/Views/Detail/TransactionDetailFocus.swift
+++ b/Features/Transactions/Views/Detail/TransactionDetailFocus.swift
@@ -9,4 +9,7 @@ enum TransactionDetailFocus: Hashable {
   case amount
   case counterpartAmount
   case legAmount(Int)
+  case tradePaidAmount
+  case tradeReceivedAmount
+  case tradeFeeAmount(Int)  // index into legDrafts; used by Task 15
 }

--- a/Features/Transactions/Views/Detail/TransactionDetailFocus.swift
+++ b/Features/Transactions/Views/Detail/TransactionDetailFocus.swift
@@ -11,5 +11,5 @@ enum TransactionDetailFocus: Hashable {
   case legAmount(Int)
   case tradePaidAmount
   case tradeReceivedAmount
-  case tradeFeeAmount(Int)  // index into legDrafts; used by Task 15
+  case tradeFeeAmount(Int)  // index into legDrafts
 }

--- a/Features/Transactions/Views/Detail/TransactionDetailModeSection.swift
+++ b/Features/Transactions/Views/Detail/TransactionDetailModeSection.swift
@@ -2,19 +2,20 @@ import SwiftUI
 
 /// User-facing transaction mode driving the simple-mode/custom-mode picker.
 ///
-/// `expense`, `income`, and `transfer` map onto `TransactionType` via
-/// `TransactionDraft.setType(_:accounts:)`. `custom` flips
-/// `TransactionDraft.isCustom` to switch the editor into multi-leg mode.
-/// `openingBalance` legs collapse onto `.expense` for binding purposes — the
-/// section disables the picker entirely for those transactions.
+/// `expense`, `income`, `transfer`, and `trade` map onto `TransactionType` via
+/// `TransactionDraft.setType(_:accounts:)` or the trade-switch helpers.
+/// `custom` flips `TransactionDraft.isCustom` to switch the editor into
+/// multi-leg mode. `openingBalance` legs collapse onto `.expense` for binding
+/// purposes — the section disables the picker entirely for those transactions.
 private enum TransactionMode: Hashable {
-  case income, expense, transfer, custom
+  case income, expense, transfer, trade, custom
 
   var displayName: String {
     switch self {
     case .income: return "Income"
     case .expense: return "Expense"
     case .transfer: return "Transfer"
+    case .trade: return "Trade"
     case .custom: return "Custom"
     }
   }
@@ -22,46 +23,61 @@ private enum TransactionMode: Hashable {
 
 /// The "Type" picker section.
 ///
-/// Renders one of four forms depending on the underlying transaction:
+/// Renders one of three forms depending on the underlying transaction:
 /// - Read-only "Opening balance" label when any leg is an opening balance
 ///   (the user can't change the type of the seed transaction).
-/// - Read-only "Trade" label when any leg is a trade (a bespoke trade
-///   picker is wired in a subsequent task on this branch).
 /// - Read-only "Custom" label when the transaction has multi-leg structure
-///   that can't be re-expressed as a simple income/expense/transfer.
-/// - The interactive `Picker` of income/expense/transfer/custom modes.
+///   that can't be re-expressed as a simple income/expense/transfer/trade.
+/// - The interactive `Picker` of income / expense / transfer / trade / custom.
 struct TransactionDetailModeSection: View {
   let transaction: Transaction
   @Binding var draft: TransactionDraft
   let accounts: Accounts
 
   private var modeBinding: Binding<TransactionMode> {
-    Binding(
-      get: {
-        if draft.isCustom { return .custom }
-        switch draft.type {
-        case .income: return .income
-        case .expense: return .expense
-        case .transfer: return .transfer
-        case .openingBalance, .trade: return .expense
-        }
-      },
-      set: { newMode in
-        switch newMode {
-        case .custom:
-          draft.isCustom = true
-        case .income:
-          if draft.isCustom { draft.switchToSimple() }
-          draft.setType(.income, accounts: accounts)
-        case .expense:
-          if draft.isCustom { draft.switchToSimple() }
-          draft.setType(.expense, accounts: accounts)
-        case .transfer:
-          if draft.isCustom { draft.switchToSimple() }
-          draft.setType(.transfer, accounts: accounts)
-        }
-      }
-    )
+    Binding(get: { modeGet() }, set: { modeSet($0) })
+  }
+
+  private func modeGet() -> TransactionMode {
+    if draft.isCustom { return .custom }
+    if draft.legDrafts.contains(where: { $0.type == .trade }) { return .trade }
+    switch draft.type {
+    case .income: return .income
+    case .expense: return .expense
+    case .transfer: return .transfer
+    case .openingBalance: return .expense
+    case .trade: return .trade
+    }
+  }
+
+  private func modeSet(_ newMode: TransactionMode) {
+    let wasTrade = draft.legDrafts.contains { $0.type == .trade }
+    switch newMode {
+    case .custom: draft.isCustom = true
+    case .trade: setTradeMode(wasTrade: wasTrade)
+    case .income: setSimpleMode(.income, wasTrade: wasTrade)
+    case .expense: setSimpleMode(.expense, wasTrade: wasTrade)
+    case .transfer: setSimpleMode(.transfer, wasTrade: wasTrade)
+    }
+  }
+
+  private func setTradeMode(wasTrade: Bool) {
+    if wasTrade && draft.isCustom {
+      draft.isCustom = false
+    } else if !wasTrade {
+      draft.switchToTrade(accounts: accounts)
+    }
+  }
+
+  private func setSimpleMode(_ type: TransactionType, wasTrade: Bool) {
+    if wasTrade {
+      draft.switchFromTrade(to: type, accounts: accounts)
+    } else if draft.isCustom {
+      draft.switchToSimple()
+      draft.setType(type, accounts: accounts)
+    } else {
+      draft.setType(type, accounts: accounts)
+    }
   }
 
   var body: some View {
@@ -71,28 +87,22 @@ struct TransactionDetailModeSection: View {
           Text(TransactionType.openingBalance.displayName)
             .foregroundStyle(.secondary)
         }
-      } else if transaction.legs.contains(where: { $0.type == .trade }) {
-        // Placeholder: Task 13 will replace this with a fully-wired trade picker.
-        // Without this guard, modeBinding maps .trade → .expense and the picker
-        // would corrupt trade data if the user changed the type selection.
+      } else if !transaction.isSimple && !transaction.isTrade && !draft.isCustom {
         LabeledContent("Type") {
-          Text(TransactionType.trade.displayName)
-            .foregroundStyle(.secondary)
-        }
-      } else if !transaction.isSimple {
-        LabeledContent("Type") {
-          Text("Custom")
-            .foregroundStyle(.secondary)
+          Text("Custom").foregroundStyle(.secondary)
         }
         .accessibilityHint(
           "This transaction has custom sub-transactions and cannot be changed to a simpler type.")
       } else {
         Picker("Type", selection: modeBinding) {
-          ForEach([TransactionMode.income, .expense, .transfer, .custom], id: \.self) { mode in
+          ForEach(
+            [TransactionMode.income, .expense, .transfer, .trade, .custom], id: \.self
+          ) { mode in
             Text(mode.displayName).tag(mode)
           }
         }
         .accessibilityLabel("Transaction type")
+        .accessibilityIdentifier(UITestIdentifiers.Detail.modeTypePicker)
         #if os(iOS)
           .pickerStyle(.segmented)
         #endif

--- a/Features/Transactions/Views/Detail/TransactionDetailModeSection.swift
+++ b/Features/Transactions/Views/Detail/TransactionDetailModeSection.swift
@@ -22,9 +22,11 @@ private enum TransactionMode: Hashable {
 
 /// The "Type" picker section.
 ///
-/// Renders one of three forms depending on the underlying transaction:
+/// Renders one of four forms depending on the underlying transaction:
 /// - Read-only "Opening balance" label when any leg is an opening balance
 ///   (the user can't change the type of the seed transaction).
+/// - Read-only "Trade" label when any leg is a trade (a bespoke trade
+///   picker is wired in a subsequent task on this branch).
 /// - Read-only "Custom" label when the transaction has multi-leg structure
 ///   that can't be re-expressed as a simple income/expense/transfer.
 /// - The interactive `Picker` of income/expense/transfer/custom modes.

--- a/Features/Transactions/Views/Detail/TransactionDetailModeSection.swift
+++ b/Features/Transactions/Views/Detail/TransactionDetailModeSection.swift
@@ -41,7 +41,7 @@ struct TransactionDetailModeSection: View {
         case .income: return .income
         case .expense: return .expense
         case .transfer: return .transfer
-        case .openingBalance: return .expense
+        case .openingBalance, .trade: return .expense
         }
       },
       set: { newMode in

--- a/Features/Transactions/Views/Detail/TransactionDetailModeSection.swift
+++ b/Features/Transactions/Views/Detail/TransactionDetailModeSection.swift
@@ -69,6 +69,14 @@ struct TransactionDetailModeSection: View {
           Text(TransactionType.openingBalance.displayName)
             .foregroundStyle(.secondary)
         }
+      } else if transaction.legs.contains(where: { $0.type == .trade }) {
+        // Placeholder: Task 13 will replace this with a fully-wired trade picker.
+        // Without this guard, modeBinding maps .trade → .expense and the picker
+        // would corrupt trade data if the user changed the type selection.
+        LabeledContent("Type") {
+          Text(TransactionType.trade.displayName)
+            .foregroundStyle(.secondary)
+        }
       } else if !transaction.isSimple {
         LabeledContent("Type") {
           Text("Custom")

--- a/Features/Transactions/Views/Detail/TransactionDetailTradeSection.swift
+++ b/Features/Transactions/Views/Detail/TransactionDetailTradeSection.swift
@@ -1,0 +1,157 @@
+import SwiftUI
+
+// Sign-handling note (Option C):
+// `TransactionDraft.displaysNegated(.trade)` is `false`, so `amountText` stores
+// the value exactly as the user types it — no negation at display or parse time.
+// Design §3.2 envisions Paid as always-positive (mapping to a negative-quantity
+// leg at serialise time), but implementing that mapping cleanly requires either a
+// custom binding with abs/negate round-trip or changing the `displaysNegated` rule
+// for only the Paid leg. For this iteration the editor accepts signed numbers
+// literally: the user may type "300" (positive, maps to +300) or "-300" (negative,
+// maps to -300). The label "Paid" still conveys intent; the forward mode-switch
+// from Expense preserves the display text as-is (which is already positive for a
+// normal expense). Fully positive-enforced fields are deferred to a follow-up.
+/// Trade-mode primary section. Mirrors the structure of
+/// `TransactionDetailDetailsSection` + `TransactionDetailAccountSection` for
+/// transfers, but with a single shared account picker and dual amount
+/// rows. See design §3.2.
+struct TransactionDetailTradeSection: View {
+  @Binding var draft: TransactionDraft
+  let accounts: Accounts
+  let sortedAccounts: [Account]
+  let knownInstruments: [Instrument]
+  @FocusState.Binding var focusedField: TransactionDetailFocus?
+
+  var body: some View {
+    Section("Trade") {
+      accountPicker
+      paidRow
+      receivedRow
+      if let rateText = derivedRateText {
+        Text(rateText)
+          .font(.caption)
+          .foregroundStyle(.secondary)
+          .monospacedDigit()
+          .accessibilityLabel(rateText)
+      }
+    }
+  }
+
+  private var accountBinding: Binding<UUID?> {
+    Binding(
+      get: { draft.legDrafts.first?.accountId },
+      set: { newId in
+        for index in draft.legDrafts.indices {
+          draft.legDrafts[index].accountId = newId
+          if let id = newId, let account = accounts.by(id: id),
+            draft.legDrafts[index].type == .expense
+          {
+            // Default new fee instruments to the account's currency.
+            draft.legDrafts[index].instrumentId =
+              draft.legDrafts[index].instrumentId ?? account.instrument.id
+          }
+        }
+      }
+    )
+  }
+
+  private var accountPicker: some View {
+    Picker("Account", selection: accountBinding) {
+      Text("None").tag(UUID?.none)
+      ForEach(sortedAccounts) { account in
+        Text(account.name).tag(UUID?.some(account.id))
+      }
+    }
+    .accessibilityIdentifier(UITestIdentifiers.Detail.tradeAccount)
+  }
+
+  private var paidRow: some View {
+    legAmountRow(
+      label: "Paid",
+      indexAccessor: { draft.paidLegIndex },
+      focus: .tradePaidAmount,
+      identifier: UITestIdentifiers.Detail.tradePaidAmount,
+      instrumentIdentifier: UITestIdentifiers.Detail.tradePaidInstrument
+    )
+  }
+
+  private var receivedRow: some View {
+    legAmountRow(
+      label: "Received",
+      indexAccessor: { draft.receivedLegIndex },
+      focus: .tradeReceivedAmount,
+      identifier: UITestIdentifiers.Detail.tradeReceivedAmount,
+      instrumentIdentifier: UITestIdentifiers.Detail.tradeReceivedInstrument
+    )
+  }
+
+  @ViewBuilder
+  private func legAmountRow(
+    label: String,
+    indexAccessor: () -> Int?,
+    focus: TransactionDetailFocus,
+    identifier: String,
+    instrumentIdentifier: String
+  ) -> some View {
+    if let idx = indexAccessor() {
+      let amountBinding = Binding(
+        get: { draft.legDrafts[idx].amountText },
+        set: { draft.legDrafts[idx].amountText = $0 })
+      let instrumentBinding = Binding<Instrument>(
+        get: {
+          let id = draft.legDrafts[idx].instrumentId ?? Instrument.AUD.id
+          return knownInstruments.first { $0.id == id } ?? Instrument.fiat(code: id)
+        },
+        set: { draft.legDrafts[idx].instrumentId = $0.id })
+
+      HStack {
+        Text(label)
+        Spacer()
+        TextField(label, text: amountBinding)
+          .multilineTextAlignment(.trailing)
+          .monospacedDigit()
+          #if os(iOS)
+            .keyboardType(.decimalPad)
+          #endif
+          .focused($focusedField, equals: focus)
+          .accessibilityIdentifier(identifier)
+        InstrumentPickerField(
+          label: "",
+          kinds: Set(Instrument.Kind.allCases),
+          selection: instrumentBinding
+        )
+        .labelsHidden()
+        .accessibilityIdentifier(instrumentIdentifier)
+      }
+    }
+  }
+
+  /// Derived rate caption: `≈ 1 {received} = X.XX {paid}`. Hidden when
+  /// either side is unparseable or zero.
+  private var derivedRateText: String? {
+    guard let paidIdx = draft.paidLegIndex,
+      let receivedIdx = draft.receivedLegIndex
+    else { return nil }
+    let paid = draft.legDrafts[paidIdx]
+    let received = draft.legDrafts[receivedIdx]
+    let paidInst =
+      paid.instrumentId.flatMap { id in
+        knownInstruments.first { $0.id == id } ?? Instrument.fiat(code: id)
+      } ?? Instrument.AUD
+    let receivedInst =
+      received.instrumentId.flatMap { id in
+        knownInstruments.first { $0.id == id } ?? Instrument.fiat(code: id)
+      } ?? Instrument.AUD
+    guard
+      let paidQty = InstrumentAmount.parseQuantity(
+        from: paid.amountText, decimals: paidInst.decimals),
+      let receivedQty = InstrumentAmount.parseQuantity(
+        from: received.amountText, decimals: receivedInst.decimals),
+      paidQty != 0, receivedQty != 0
+    else { return nil }
+    let rate = paidQty / receivedQty
+    let rateFormatted = rate.formatted(
+      .number.precision(.significantDigits(2...4)).grouping(.never))
+    return "≈ 1 \(receivedInst.id) = \(rateFormatted) \(paidInst.id)"
+  }
+}

--- a/Features/Transactions/Views/Detail/TransactionDetailTradeSection.swift
+++ b/Features/Transactions/Views/Detail/TransactionDetailTradeSection.swift
@@ -1,15 +1,12 @@
 import SwiftUI
 
 // Sign-handling note:
-// `TransactionDraft.displaysNegated(.trade) == false`, so `amountText` stores
-// the value exactly as the user types it. The serialisation path in
-// `TransactionDraft.toTransaction` applies `abs()` and re-signs `.trade` legs
-// by position (first → Paid / negative, second → Received / positive), so
-// stored signs are always correct regardless of what the user types. The
-// remaining UX gap — stripping a leading "-" so the displayed value matches
-// the field label — is tracked separately:
-// TODO(#563): enforce positive-only input on Trade Paid/Received fields
-//   — https://github.com/ajsutton/moolah-native/issues/563
+// `TransactionDraft.displaysNegated(.trade) == false`, so the user enters
+// signed quantities directly into Paid and Received and the storage matches
+// 1:1. Trade reversals legitimately have unconventional signs, so the editor
+// preserves whatever the user types — see CLAUDE.md "Monetary Sign
+// Convention" and `feedback_no_abs_on_trade_legs.md` (no abs, no sign-by-
+// position).
 /// Trade-mode primary section. Mirrors the structure of
 /// `TransactionDetailDetailsSection` + `TransactionDetailAccountSection` for
 /// transfers, but with a single shared account picker and dual amount

--- a/Features/Transactions/Views/Detail/TransactionDetailTradeSection.swift
+++ b/Features/Transactions/Views/Detail/TransactionDetailTradeSection.swift
@@ -1,16 +1,15 @@
 import SwiftUI
 
-// Sign-handling note (Option C):
-// `TransactionDraft.displaysNegated(.trade)` is `false`, so `amountText` stores
-// the value exactly as the user types it — no negation at display or parse time.
-// Design §3.2 envisions Paid as always-positive (mapping to a negative-quantity
-// leg at serialise time), but implementing that mapping cleanly requires either a
-// custom binding with abs/negate round-trip or changing the `displaysNegated` rule
-// for only the Paid leg. For this iteration the editor accepts signed numbers
-// literally: the user may type "300" (positive, maps to +300) or "-300" (negative,
-// maps to -300). The label "Paid" still conveys intent; the forward mode-switch
-// from Expense preserves the display text as-is (which is already positive for a
-// normal expense). Fully positive-enforced fields are deferred to a follow-up.
+// Sign-handling note:
+// `TransactionDraft.displaysNegated(.trade) == false`, so `amountText` stores
+// the value exactly as the user types it. The serialisation path in
+// `TransactionDraft.toTransaction` applies `abs()` and re-signs `.trade` legs
+// by position (first → Paid / negative, second → Received / positive), so
+// stored signs are always correct regardless of what the user types. The
+// remaining UX gap — stripping a leading "-" so the displayed value matches
+// the field label — is tracked separately:
+// TODO(#563): enforce positive-only input on Trade Paid/Received fields
+//   — https://github.com/ajsutton/moolah-native/issues/563
 /// Trade-mode primary section. Mirrors the structure of
 /// `TransactionDetailDetailsSection` + `TransactionDetailAccountSection` for
 /// transfers, but with a single shared account picker and dual amount

--- a/Features/Transactions/Views/Detail/TransactionDetailTradeSection.swift
+++ b/Features/Transactions/Views/Detail/TransactionDetailTradeSection.swift
@@ -83,7 +83,7 @@ struct TransactionDetailTradeSection: View {
 
   @ViewBuilder
   private func legAmountRow(
-    label: String,
+    label: LocalizedStringKey,
     indexAccessor: () -> Int?,
     focus: TransactionDetailFocus,
     identifier: String,
@@ -100,24 +100,25 @@ struct TransactionDetailTradeSection: View {
         },
         set: { draft.legDrafts[idx].instrumentId = $0.id })
 
-      HStack {
+      LabeledContent {
+        HStack(spacing: 8) {
+          TextField(label, text: amountBinding)
+            .labelsHidden()
+            .multilineTextAlignment(.trailing)
+            .monospacedDigit()
+            #if os(iOS)
+              .keyboardType(.decimalPad)
+            #endif
+            .focused($focusedField, equals: focus)
+            .accessibilityIdentifier(identifier)
+          CompactInstrumentPickerButton(
+            selection: instrumentBinding,
+            knownInstruments: knownInstruments
+          )
+          .accessibilityIdentifier(instrumentIdentifier)
+        }
+      } label: {
         Text(label)
-        Spacer()
-        TextField(label, text: amountBinding)
-          .multilineTextAlignment(.trailing)
-          .monospacedDigit()
-          #if os(iOS)
-            .keyboardType(.decimalPad)
-          #endif
-          .focused($focusedField, equals: focus)
-          .accessibilityIdentifier(identifier)
-        InstrumentPickerField(
-          label: "",
-          kinds: Set(Instrument.Kind.allCases),
-          selection: instrumentBinding
-        )
-        .labelsHidden()
-        .accessibilityIdentifier(instrumentIdentifier)
       }
     }
   }
@@ -145,9 +146,11 @@ struct TransactionDetailTradeSection: View {
         from: received.amountText, decimals: receivedInst.decimals),
       paidQty != 0, receivedQty != 0
     else { return nil }
-    let rate = paidQty / receivedQty
+    // `abs()` here applies to derived display ratios only; stored leg
+    // quantities keep their signs untouched per the project sign convention.
+    let rate = abs(paidQty / receivedQty)
     let rateFormatted = rate.formatted(
       .number.precision(.significantDigits(2...4)).grouping(.never))
-    return "≈ 1 \(receivedInst.id) = \(rateFormatted) \(paidInst.id)"
+    return "≈ 1 \(receivedInst.shortCode) = \(rateFormatted) \(paidInst.shortCode)"
   }
 }

--- a/Features/Transactions/Views/Detail/TransactionDetailView+Previews.swift
+++ b/Features/Transactions/Views/Detail/TransactionDetailView+Previews.swift
@@ -165,6 +165,60 @@ private func previewStore() -> TransactionStore {
   }
 }
 
+#Preview("Trade") {
+  let accountId = UUID()
+  let vgs = Instrument.stock(ticker: "VGS.AX", exchange: "ASX", name: "VGS")
+  return NavigationStack {
+    TransactionDetailView(
+      transaction: Transaction(
+        date: Date(),
+        payee: "SelfWealth",
+        legs: [
+          TransactionLeg(accountId: accountId, instrument: .AUD, quantity: -300, type: .trade),
+          TransactionLeg(accountId: accountId, instrument: vgs, quantity: 20, type: .trade),
+          TransactionLeg(accountId: accountId, instrument: .AUD, quantity: -10, type: .expense),
+        ]
+      ),
+      accounts: Accounts(from: [
+        Account(id: accountId, name: "Brokerage", type: .bank, instrument: .AUD)
+      ]),
+      categories: Categories(from: [Category(name: "Brokerage")]),
+      earmarks: Earmarks(from: []),
+      transactionStore: previewStore(),
+      viewingAccountId: accountId,
+
+      onUpdate: { _ in },
+      onDelete: { _ in }
+    )
+  }
+}
+
+#Preview("Trade (No Fee)") {
+  let accountId = UUID()
+  let vgs = Instrument.stock(ticker: "VGS.AX", exchange: "ASX", name: "VGS")
+  return NavigationStack {
+    TransactionDetailView(
+      transaction: Transaction(
+        date: Date(),
+        legs: [
+          TransactionLeg(accountId: accountId, instrument: .AUD, quantity: -300, type: .trade),
+          TransactionLeg(accountId: accountId, instrument: vgs, quantity: 20, type: .trade),
+        ]
+      ),
+      accounts: Accounts(from: [
+        Account(id: accountId, name: "Brokerage", type: .bank, instrument: .AUD)
+      ]),
+      categories: Categories(from: []),
+      earmarks: Earmarks(from: []),
+      transactionStore: previewStore(),
+      viewingAccountId: accountId,
+
+      onUpdate: { _ in },
+      onDelete: { _ in }
+    )
+  }
+}
+
 #Preview("Scheduled (Recurring)") {
   let accountId = UUID()
   return NavigationStack {

--- a/Features/Transactions/Views/TransactionDetailView+Actions.swift
+++ b/Features/Transactions/Views/TransactionDetailView+Actions.swift
@@ -1,0 +1,46 @@
+import SwiftUI
+
+// Common fiat instruments available to leg-instrument resolution when the
+// instrument registry has not yet loaded (e.g. on first render). Registered
+// stocks/crypto are supplied by `knownInstruments` loaded via `.task`.
+private let commonFiatInstruments: [Instrument] = [
+  "AUD", "CAD", "CHF", "CNY", "EUR", "GBP", "HKD", "INR", "JPY", "KRW",
+  "MXN", "NOK", "NZD", "SEK", "SGD", "USD", "ZAR",
+].map { Instrument.fiat(code: $0) }
+
+// MARK: - Actions
+
+extension TransactionDetailView {
+  func autofillFromPayee(_ selectedPayee: String) {
+    // Only auto-copy amount/type/category from a past transaction when
+    // the user is filling in a fresh draft. Editing an existing
+    // transaction's payee must never rewrite other fields — do not
+    // remove this guard without replacing the invariant it enforces.
+    guard openedAsNewTransaction else { return }
+    Task {
+      guard
+        let match = await transactionStore.payeeSuggestionSource.fetchTransactionForAutofill(
+          payee: selectedPayee)
+      else { return }
+      draft.applyAutofill(from: match, categories: categories, accounts: accounts)
+    }
+  }
+
+  func debouncedSave() {
+    transactionStore.debouncedSave { [self] in
+      saveIfValid()
+    }
+  }
+
+  func saveIfValid() {
+    let allKnownInstruments = knownInstruments + commonFiatInstruments
+    guard
+      let updated = draft.toTransaction(
+        id: transaction.id,
+        accounts: accounts,
+        earmarks: earmarks,
+        availableInstruments: allKnownInstruments)
+    else { return }
+    onUpdate(updated)
+  }
+}

--- a/Features/Transactions/Views/TransactionDetailView+Helpers.swift
+++ b/Features/Transactions/Views/TransactionDetailView+Helpers.swift
@@ -12,7 +12,7 @@ extension TransactionDetailView {
     }
   }
 
-  var isEditable: Bool { transaction.isSimple || draft.isCustom }
+  var isEditable: Bool { transaction.isSimple || transaction.isTrade || draft.isCustom }
 
   /// Whether the current draft is a simple earmark-only transaction.
   var isSimpleEarmarkOnly: Bool {

--- a/Features/Transactions/Views/TransactionDetailView+Helpers.swift
+++ b/Features/Transactions/Views/TransactionDetailView+Helpers.swift
@@ -1,0 +1,58 @@
+import SwiftUI
+
+// MARK: - Computed Helpers
+
+extension TransactionDetailView {
+  var sortedAccounts: [Account] {
+    accounts.ordered.sorted { lhs, rhs in
+      if lhs.type.isCurrent != rhs.type.isCurrent {
+        return lhs.type.isCurrent
+      }
+      return lhs.position < rhs.position
+    }
+  }
+
+  var isEditable: Bool { transaction.isSimple || draft.isCustom }
+
+  /// Whether the current draft is a simple earmark-only transaction.
+  var isSimpleEarmarkOnly: Bool {
+    !draft.isCustom && draft.relevantLeg.isEarmarkOnly
+  }
+
+  /// The instrument for the relevant leg's account (for displaying currency symbol).
+  var relevantInstrument: Instrument? {
+    draft.legDrafts[draft.relevantLegIndex].accountId
+      .flatMap { accounts.by(id: $0) }?
+      .instrument
+  }
+
+  /// Whether the current draft is a cross-currency simple transfer.
+  var isCrossCurrency: Bool {
+    !draft.isCustom && draft.type == .transfer && draft.isCrossCurrencyTransfer(accounts: accounts)
+  }
+
+  /// The instrument for the counterpart leg's account.
+  var counterpartInstrument: Instrument? {
+    draft.counterpartLeg?.accountId
+      .flatMap { accounts.by(id: $0) }?
+      .instrument
+  }
+
+  var counterpartAmountBinding: Binding<String> {
+    Binding(
+      get: { draft.counterpartLeg?.amountText ?? "" },
+      set: { draft.setCounterpartAmount($0) }
+    )
+  }
+
+  var amountBinding: Binding<String> {
+    Binding(
+      get: { draft.amountText },
+      set: { draft.setAmount($0, accounts: accounts) }
+    )
+  }
+
+  var isScheduled: Bool {
+    showRecurrence && transaction.recurPeriod != nil
+  }
+}

--- a/Features/Transactions/Views/TransactionDetailView.swift
+++ b/Features/Transactions/Views/TransactionDetailView.swift
@@ -1,19 +1,4 @@
-// swift-format wraps `TransactionLeg(...)` calls with one argument per line
-// inside the previews; SwiftLint's multiline_arguments rule (which expects
-// "all on one line OR one per line including the first") then trips on the
-// formatter's chosen style. The formatter wins per project policy
-// (.swift-format is the layout source of truth), so suppress the lint here.
-// swiftlint:disable multiline_arguments
-
 import SwiftUI
-
-// Common fiat instruments available to leg-instrument resolution when the
-// instrument registry has not yet loaded (e.g. on first render). Registered
-// stocks/crypto are supplied by `knownInstruments` loaded via `.task`.
-private let commonFiatInstruments: [Instrument] = [
-  "AUD", "CAD", "CHF", "CNY", "EUR", "GBP", "HKD", "INR", "JPY", "KRW",
-  "MXN", "NOK", "NZD", "SEK", "SGD", "USD", "ZAR",
-].map { Instrument.fiat(code: $0) }
 
 struct TransactionDetailView: View {
   let transaction: Transaction
@@ -28,8 +13,13 @@ struct TransactionDetailView: View {
 
   @Environment(ProfileSession.self) private var session
 
-  @State private var draft: TransactionDraft
-  @State private var knownInstruments: [Instrument] = []
+  // `draft`, `knownInstruments`, and `openedAsNewTransaction` use internal
+  // access (no `private`) so that extension files in this module
+  // (TransactionDetailView+Helpers.swift, TransactionDetailView+Actions.swift)
+  // can reference them. SwiftLint's strict_fileprivate rule disallows
+  // `fileprivate`, making internal the smallest legal cross-file scope.
+  @State var draft: TransactionDraft
+  @State var knownInstruments: [Instrument] = []
   @State private var showDeleteConfirmation = false
   @State private var payeeState = PayeeAutocompleteState()
   @State private var categoryState = CategoryAutocompleteState()
@@ -42,7 +32,7 @@ struct TransactionDetailView: View {
   /// are editing an existing one. Without this guard, selecting a payee
   /// from the dropdown while editing a $5,000 transfer would clobber the
   /// amount, type, and category.
-  @State private var openedAsNewTransaction: Bool
+  @State var openedAsNewTransaction: Bool
   @FocusState private var focusedField: TransactionDetailFocus?
 
   init(
@@ -183,6 +173,8 @@ extension TransactionDetailView {
   @ViewBuilder private var modeAwareSections: some View {
     if isSimpleEarmarkOnly {
       earmarkOnlyContent
+    } else if isTradeMode {
+      tradeModeContent
     } else if draft.isCustom {
       customModeContent
     } else {
@@ -195,6 +187,64 @@ extension TransactionDetailView {
       draft: $draft, earmarks: earmarks, amountBinding: amountBinding)
     if showRecurrence {
       TransactionDetailRecurrenceSection(draft: $draft)
+    }
+    TransactionDetailNotesSection(notes: $draft.notes)
+  }
+
+  /// True when the draft is not in custom mode and has at least one `.trade` leg.
+  private var isTradeMode: Bool {
+    !draft.isCustom && draft.legDrafts.contains { $0.type == .trade }
+  }
+
+  @ViewBuilder private var tradeModeContent: some View {
+    modeSection.disabled(!isEditable)
+    TransactionDetailTradeSection(
+      draft: $draft,
+      accounts: accounts,
+      sortedAccounts: sortedAccounts,
+      knownInstruments: knownInstruments,
+      focusedField: $focusedField
+    )
+    .disabled(!isEditable)
+
+    ForEach(Array(draft.feeIndices.enumerated()), id: \.element) { ordinal, legIndex in
+      TransactionDetailFeeSection(
+        legIndex: legIndex,
+        displayNumber: ordinal + 1,
+        draft: $draft,
+        accounts: accounts,
+        categories: categories,
+        earmarks: earmarks,
+        knownInstruments: knownInstruments,
+        categoryState: legCategoryStateBinding(for: legIndex),
+        focusedField: $focusedField,
+        onRequestRemove: { draft.removeFee(at: legIndex) }
+      )
+    }
+
+    Section {
+      Button {
+        let fallback =
+          draft.legDrafts.first?.accountId
+          .flatMap { accounts.by(id: $0) }?.instrument.id ?? Instrument.AUD.id
+        draft.appendFee(defaultInstrumentId: fallback)
+      } label: {
+        Label("Add Fee", systemImage: "plus")
+          .frame(maxWidth: .infinity)
+      }
+      .accessibilityIdentifier(UITestIdentifiers.Detail.tradeAddFeeButton)
+    }
+
+    TransactionDetailCustomDetailsSection(
+      draft: $draft,
+      suggestionSource: transactionStore.payeeSuggestionSource,
+      payeeState: $payeeState,
+      onAutofill: autofillFromPayee,
+      focusedField: $focusedField
+    )
+
+    if showRecurrence {
+      TransactionDetailRecurrenceSection(draft: $draft).disabled(!isEditable)
     }
     TransactionDetailNotesSection(notes: $draft.notes)
   }
@@ -295,94 +345,7 @@ extension TransactionDetailView {
   }
 }
 
-// MARK: - Computed Helpers
-
-extension TransactionDetailView {
-  private var sortedAccounts: [Account] {
-    accounts.ordered.sorted { lhs, rhs in
-      if lhs.type.isCurrent != rhs.type.isCurrent {
-        return lhs.type.isCurrent
-      }
-      return lhs.position < rhs.position
-    }
-  }
-
-  private var isEditable: Bool { transaction.isSimple || draft.isCustom }
-
-  /// Whether the current draft is a simple earmark-only transaction.
-  private var isSimpleEarmarkOnly: Bool {
-    !draft.isCustom && draft.relevantLeg.isEarmarkOnly
-  }
-
-  /// The instrument for the relevant leg's account (for displaying currency symbol).
-  private var relevantInstrument: Instrument? {
-    draft.legDrafts[draft.relevantLegIndex].accountId
-      .flatMap { accounts.by(id: $0) }?
-      .instrument
-  }
-
-  /// Whether the current draft is a cross-currency simple transfer.
-  private var isCrossCurrency: Bool {
-    !draft.isCustom && draft.type == .transfer && draft.isCrossCurrencyTransfer(accounts: accounts)
-  }
-
-  /// The instrument for the counterpart leg's account.
-  private var counterpartInstrument: Instrument? {
-    draft.counterpartLeg?.accountId
-      .flatMap { accounts.by(id: $0) }?
-      .instrument
-  }
-
-  private var counterpartAmountBinding: Binding<String> {
-    Binding(
-      get: { draft.counterpartLeg?.amountText ?? "" },
-      set: { draft.setCounterpartAmount($0) }
-    )
-  }
-
-  private var amountBinding: Binding<String> {
-    Binding(
-      get: { draft.amountText },
-      set: { draft.setAmount($0, accounts: accounts) }
-    )
-  }
-
-  private var isScheduled: Bool {
-    showRecurrence && transaction.recurPeriod != nil
-  }
-}
-
-// MARK: - Actions
-
-extension TransactionDetailView {
-  private func autofillFromPayee(_ selectedPayee: String) {
-    // Only auto-copy amount/type/category from a past transaction when
-    // the user is filling in a fresh draft. Editing an existing
-    // transaction's payee must never rewrite other fields — do not
-    // remove this guard without replacing the invariant it enforces.
-    guard openedAsNewTransaction else { return }
-    Task {
-      guard
-        let match = await transactionStore.payeeSuggestionSource.fetchTransactionForAutofill(
-          payee: selectedPayee)
-      else { return }
-      draft.applyAutofill(from: match, categories: categories, accounts: accounts)
-    }
-  }
-
-  private func debouncedSave() {
-    transactionStore.debouncedSave { [self] in
-      saveIfValid()
-    }
-  }
-
-  private func saveIfValid() {
-    let allKnownInstruments = knownInstruments + commonFiatInstruments
-    guard
-      let updated = draft.toTransaction(
-        id: transaction.id, accounts: accounts, earmarks: earmarks,
-        availableInstruments: allKnownInstruments)
-    else { return }
-    onUpdate(updated)
-  }
-}
+// Computed helpers (sortedAccounts, isEditable, isSimpleEarmarkOnly, instruments,
+// bindings, isScheduled) live in TransactionDetailView+Helpers.swift.
+// Actions (autofillFromPayee, debouncedSave, saveIfValid) live in
+// TransactionDetailView+Actions.swift.

--- a/Features/Transactions/Views/TransactionDetailView.swift
+++ b/Features/Transactions/Views/TransactionDetailView.swift
@@ -11,7 +11,7 @@ struct TransactionDetailView: View {
   let onUpdate: (Transaction) -> Void
   let onDelete: (UUID) -> Void
 
-  @Environment(ProfileSession.self) private var session
+  @Environment(ProfileSession.self) private var session: ProfileSession?
 
   // `draft`, `knownInstruments`, and `openedAsNewTransaction` use internal
   // access (no `private`) so that extension files in this module
@@ -118,7 +118,7 @@ struct TransactionDetailView: View {
       #endif
       .onChange(of: draft) { _, _ in debouncedSave() }
       .task {
-        knownInstruments = (try? await session.instrumentRegistry?.all()) ?? []
+        knownInstruments = (try? await session?.instrumentRegistry?.all()) ?? []
       }
       .confirmationDialog(
         "Delete Transaction",

--- a/Features/Transactions/Views/TransactionListView+List.swift
+++ b/Features/Transactions/Views/TransactionListView+List.swift
@@ -146,7 +146,7 @@ extension TransactionListView {
   private func transactionRow(for entry: TransactionWithBalance) -> some View {
     TransactionRowView(
       transaction: entry.transaction, accounts: accounts,
-      categories: categories, earmarks: earmarks, displayAmount: entry.displayAmount,
+      categories: categories, earmarks: earmarks, displayAmounts: entry.displayAmounts,
       balance: entry.balance, hideEarmark: filter.earmarkId != nil,
       viewingAccountId: filter.accountId
     )

--- a/Features/Transactions/Views/TransactionListView+List.swift
+++ b/Features/Transactions/Views/TransactionListView+List.swift
@@ -142,13 +142,23 @@ extension TransactionListView {
     }
   }
 
+  private var scopeReferenceInstrument: Instrument {
+    if let accountId = filter.accountId, let account = accounts.by(id: accountId) {
+      return account.instrument
+    }
+    if let earmarkId = filter.earmarkId, let earmark = earmarks.by(id: earmarkId) {
+      return earmark.instrument
+    }
+    return positionsHostCurrency
+  }
+
   @ViewBuilder
   private func transactionRow(for entry: TransactionWithBalance) -> some View {
     TransactionRowView(
       transaction: entry.transaction, accounts: accounts,
       categories: categories, earmarks: earmarks, displayAmounts: entry.displayAmounts,
-      balance: entry.balance, hideEarmark: filter.earmarkId != nil,
-      viewingAccountId: filter.accountId
+      balance: entry.balance, scopeReferenceInstrument: scopeReferenceInstrument,
+      hideEarmark: filter.earmarkId != nil, viewingAccountId: filter.accountId
     )
     .tag(entry.transaction)
     .accessibilityIdentifier(

--- a/Features/Transactions/Views/TransactionRowView.swift
+++ b/Features/Transactions/Views/TransactionRowView.swift
@@ -107,6 +107,7 @@ struct TransactionRowView: View {
     case .expense: return "arrow.down"
     case .transfer: return "arrow.left.arrow.right"
     case .openingBalance: return "flag.fill"
+    case .trade: return "chart.line.uptrend.xyaxis"
     }
   }
 
@@ -119,6 +120,7 @@ struct TransactionRowView: View {
     case .expense: return .red
     case .transfer: return .blue
     case .openingBalance: return .orange
+    case .trade: return .purple
     }
   }
 

--- a/Features/Transactions/Views/TransactionRowView.swift
+++ b/Features/Transactions/Views/TransactionRowView.swift
@@ -9,6 +9,7 @@ struct TransactionRowView: View {
   let earmarks: Earmarks
   let displayAmounts: [InstrumentAmount]
   let balance: InstrumentAmount?
+  let scopeReferenceInstrument: Instrument
   var hideEarmark: Bool = false
   var viewingAccountId: UUID?
 
@@ -35,7 +36,7 @@ struct TransactionRowView: View {
 
   private var infoColumn: some View {
     VStack(alignment: .leading, spacing: 2) {
-      Text(displayPayee).lineLimit(1)
+      Text(titleText).lineLimit(1)
       metadataRow
     }
   }
@@ -95,13 +96,14 @@ struct TransactionRowView: View {
     }
     if let balance {
       return
-        "\(typeStr), \(displayPayee), \(amountStr), \(dateStr), balance \(balance.formatted)"
+        "\(typeStr), \(titleText), \(amountStr), \(dateStr), balance \(balance.formatted)"
     } else {
-      return "\(typeStr), \(displayPayee), \(amountStr), \(dateStr)"
+      return "\(typeStr), \(titleText), \(amountStr), \(dateStr)"
     }
   }
 
   private var iconName: String {
+    if transaction.isTrade { return "arrow.up.arrow.down" }
     guard transaction.isSimple, let type = transaction.legs.first?.type else {
       return "arrow.trianglehead.branch"
     }
@@ -110,11 +112,12 @@ struct TransactionRowView: View {
     case .expense: return "arrow.down"
     case .transfer: return "arrow.left.arrow.right"
     case .openingBalance: return "flag.fill"
-    case .trade: return "chart.line.uptrend.xyaxis"
+    case .trade: return "arrow.up.arrow.down"
     }
   }
 
   private var iconColor: Color {
+    if transaction.isTrade { return .indigo }
     guard transaction.isSimple, let type = transaction.legs.first?.type else {
       return .purple
     }
@@ -123,7 +126,7 @@ struct TransactionRowView: View {
     case .expense: return .red
     case .transfer: return .blue
     case .openingBalance: return .orange
-    case .trade: return .purple
+    case .trade: return .indigo
     }
   }
 
@@ -148,6 +151,14 @@ struct TransactionRowView: View {
   private var displayPayee: String {
     transaction.displayPayee(
       viewingAccountId: viewingAccountId, accounts: accounts, earmarks: earmarks)
+  }
+
+  private var titleText: String {
+    let payee = displayPayee
+    if let sentence = transaction.tradeTitleSentence(scopeReference: scopeReferenceInstrument) {
+      return payee.isEmpty ? sentence : "\(payee) (\(sentence))"
+    }
+    return payee
   }
 }
 
@@ -272,6 +283,7 @@ private func previewRow(
   legs: [TransactionLeg],
   displayAmounts: [InstrumentAmount],
   balance: Decimal,
+  scopeReferenceInstrument: Instrument = .AUD,
   viewingAccountId: UUID? = nil
 ) -> TransactionRowView {
   TransactionRowView(
@@ -279,6 +291,7 @@ private func previewRow(
     accounts: data.accounts, categories: data.categories, earmarks: data.earmarks,
     displayAmounts: displayAmounts,
     balance: InstrumentAmount(quantity: balance, instrument: .AUD),
+    scopeReferenceInstrument: scopeReferenceInstrument,
     viewingAccountId: viewingAccountId)
 }
 

--- a/Features/Transactions/Views/TransactionRowView.swift
+++ b/Features/Transactions/Views/TransactionRowView.swift
@@ -89,7 +89,9 @@ struct TransactionRowView: View {
       ? "amount unavailable"
       : displayAmounts.map(\.formatted).joined(separator: " and ")
     let typeStr: String
-    if transaction.isSimple, let type = transaction.legs.first?.type {
+    if transaction.isTrade {
+      typeStr = TransactionType.trade.displayName
+    } else if transaction.isSimple, let type = transaction.legs.first?.type {
       typeStr = type.displayName
     } else {
       typeStr = "Custom transaction"
@@ -172,7 +174,7 @@ private struct TradeAmountFlow: View {
   let amounts: [InstrumentAmount]
   var body: some View {
     WrappedHStack(spacing: 6) {
-      ForEach(Array(amounts.enumerated()), id: \.offset) { _, amount in
+      ForEach(amounts, id: \.self) { amount in
         InstrumentAmountView(amount: amount, font: .body)
       }
     }

--- a/Features/Transactions/Views/TransactionRowView.swift
+++ b/Features/Transactions/Views/TransactionRowView.swift
@@ -7,7 +7,7 @@ struct TransactionRowView: View {
   let accounts: Accounts
   let categories: Categories
   let earmarks: Earmarks
-  let displayAmount: InstrumentAmount?
+  let displayAmounts: [InstrumentAmount]
   let balance: InstrumentAmount?
   var hideEarmark: Bool = false
   var viewingAccountId: UUID?
@@ -67,13 +67,13 @@ struct TransactionRowView: View {
 
   private var amountColumn: some View {
     VStack(alignment: .trailing, spacing: 2) {
-      if let displayAmount {
-        InstrumentAmountView(amount: displayAmount, font: .body)
-      } else {
+      if displayAmounts.isEmpty {
         Text("—")
           .font(.body)
           .foregroundStyle(.secondary)
           .monospacedDigit()
+      } else {
+        TradeAmountFlow(amounts: displayAmounts)
       }
       if let balance {
         InstrumentAmountView(amount: balance, font: .caption)
@@ -83,7 +83,10 @@ struct TransactionRowView: View {
 
   private var accessibilityDescription: String {
     let dateStr = transaction.date.formatted(date: .abbreviated, time: .omitted)
-    let amountStr = displayAmount?.formatted ?? "amount unavailable"
+    let amountStr =
+      displayAmounts.isEmpty
+      ? "amount unavailable"
+      : displayAmounts.map(\.formatted).joined(separator: " and ")
     let typeStr: String
     if transaction.isSimple, let type = transaction.legs.first?.type {
       typeStr = type.displayName
@@ -148,6 +151,95 @@ struct TransactionRowView: View {
   }
 }
 
+/// Inline-with-wrap layout for the row's per-instrument amount entries.
+/// Lays out children horizontally with hairline spacing; wraps to a new
+/// line when there isn't horizontal room. SwiftUI 6 / iOS 26 supports
+/// `.layoutDirectionBehavior` and the `Layout` protocol — using a thin
+/// custom `Layout` here keeps wrapping deterministic without nesting
+/// `ViewThatFits`.
+private struct TradeAmountFlow: View {
+  let amounts: [InstrumentAmount]
+  var body: some View {
+    WrappedHStack(spacing: 6) {
+      ForEach(Array(amounts.enumerated()), id: \.offset) { _, amount in
+        InstrumentAmountView(amount: amount, font: .body)
+      }
+    }
+    .multilineTextAlignment(.trailing)
+  }
+}
+
+/// Minimal trailing-aligned wrap layout. Lays each subview out on the
+/// current line if it fits within the proposed width; otherwise wraps.
+private struct WrappedHStack: Layout {
+  var spacing: CGFloat = 6
+
+  func sizeThatFits(
+    proposal: ProposedViewSize,
+    subviews: Subviews,
+    cache: inout ()
+  ) -> CGSize {
+    let maxWidth = proposal.width ?? .infinity
+    var lineWidth: CGFloat = 0
+    var totalWidth: CGFloat = 0
+    var totalHeight: CGFloat = 0
+    var lineHeight: CGFloat = 0
+    for subview in subviews {
+      let size = subview.sizeThatFits(.unspecified)
+      let advance = (lineWidth == 0 ? 0 : spacing) + size.width
+      if lineWidth + advance > maxWidth {
+        totalWidth = max(totalWidth, lineWidth)
+        totalHeight += lineHeight + spacing
+        lineWidth = size.width
+        lineHeight = size.height
+      } else {
+        lineWidth += advance
+        lineHeight = max(lineHeight, size.height)
+      }
+    }
+    totalWidth = max(totalWidth, lineWidth)
+    totalHeight += lineHeight
+    return CGSize(width: totalWidth, height: totalHeight)
+  }
+
+  func placeSubviews(
+    in bounds: CGRect,
+    proposal: ProposedViewSize,
+    subviews: Subviews,
+    cache: inout ()
+  ) {
+    // Right-aligned wrap. Build line-by-line, then place trailing-justified.
+    var lines: [[(index: Int, size: CGSize)]] = [[]]
+    var lineWidth: CGFloat = 0
+    let maxWidth = bounds.width
+    for (index, subview) in subviews.enumerated() {
+      let size = subview.sizeThatFits(.unspecified)
+      let advance = (lineWidth == 0 ? 0 : spacing) + size.width
+      if lineWidth + advance > maxWidth, !lines[lines.count - 1].isEmpty {
+        lines.append([])
+        lineWidth = 0
+      }
+      lines[lines.count - 1].append((index, size))
+      lineWidth += (lineWidth == 0 ? size.width : advance)
+    }
+    var y = bounds.minY
+    for line in lines {
+      let lineHeight = line.map(\.size.height).max() ?? 0
+      let totalLineWidth =
+        line.reduce(0) { $0 + $1.size.width }
+        + CGFloat(max(line.count - 1, 0)) * spacing
+      var x = bounds.maxX - totalLineWidth
+      for (index, size) in line {
+        subviews[index].place(
+          at: CGPoint(x: x, y: y),
+          proposal: ProposedViewSize(size))
+        x += size.width + spacing
+      }
+      y += lineHeight + spacing
+    }
+  }
+}
+
 private struct TransactionRowPreviewData {
   let sourceId = UUID()
   let savingsId = UUID()
@@ -178,14 +270,14 @@ private func previewRow(
   data: TransactionRowPreviewData,
   payee: String? = nil,
   legs: [TransactionLeg],
-  display: Decimal,
+  displayAmounts: [InstrumentAmount],
   balance: Decimal,
   viewingAccountId: UUID? = nil
 ) -> TransactionRowView {
   TransactionRowView(
     transaction: Transaction(date: Date(), payee: payee ?? "", legs: legs),
     accounts: data.accounts, categories: data.categories, earmarks: data.earmarks,
-    displayAmount: InstrumentAmount(quantity: display, instrument: .AUD),
+    displayAmounts: displayAmounts,
     balance: InstrumentAmount(quantity: balance, instrument: .AUD),
     viewingAccountId: viewingAccountId)
 }
@@ -193,12 +285,16 @@ private func previewRow(
 private struct PreviewRowSpec {
   let payee: String?
   let legs: [TransactionLeg]
-  let display: Decimal
+  let displayAmounts: [InstrumentAmount]
   let balance: Decimal
   var viewingAccountId: UUID?
 }
 
 private func previewRowSpecs(data: TransactionRowPreviewData) -> [PreviewRowSpec] {
+  simplePreviewSpecs(data: data) + tradePreviewSpecs(data: data)
+}
+
+private func simplePreviewSpecs(data: TransactionRowPreviewData) -> [PreviewRowSpec] {
   [
     PreviewRowSpec(
       payee: "Woolworths",
@@ -207,7 +303,8 @@ private func previewRowSpecs(data: TransactionRowPreviewData) -> [PreviewRowSpec
           accountId: data.sourceId, instrument: .AUD, quantity: -50.23, type: .expense,
           categoryId: data.groceriesId)
       ],
-      display: -50.23, balance: 1000),
+      displayAmounts: [InstrumentAmount(quantity: -50.23, instrument: .AUD)],
+      balance: 1000),
     PreviewRowSpec(
       payee: "Employer Pty Ltd",
       legs: [
@@ -215,7 +312,8 @@ private func previewRowSpecs(data: TransactionRowPreviewData) -> [PreviewRowSpec
           accountId: data.sourceId, instrument: .AUD, quantity: 3500, type: .income,
           earmarkId: data.holidayFundId)
       ],
-      display: 3500, balance: 1050.23),
+      displayAmounts: [InstrumentAmount(quantity: 3500, instrument: .AUD)],
+      balance: 1050.23),
     PreviewRowSpec(
       payee: nil,
       legs: [
@@ -224,7 +322,8 @@ private func previewRowSpecs(data: TransactionRowPreviewData) -> [PreviewRowSpec
         TransactionLeg(
           accountId: data.savingsId, instrument: .AUD, quantity: 1000, type: .transfer),
       ],
-      display: -1000, balance: -2449.77, viewingAccountId: data.sourceId),
+      displayAmounts: [InstrumentAmount(quantity: -1000, instrument: .AUD)],
+      balance: -2449.77, viewingAccountId: data.sourceId),
     PreviewRowSpec(
       payee: "Rent Split",
       legs: [
@@ -233,7 +332,13 @@ private func previewRowSpecs(data: TransactionRowPreviewData) -> [PreviewRowSpec
         TransactionLeg(
           accountId: data.savingsId, instrument: .AUD, quantity: 500, type: .transfer),
       ],
-      display: -500, balance: -1449.77, viewingAccountId: data.sourceId),
+      displayAmounts: [InstrumentAmount(quantity: -500, instrument: .AUD)],
+      balance: -1449.77, viewingAccountId: data.sourceId),
+  ]
+}
+
+private func tradePreviewSpecs(data: TransactionRowPreviewData) -> [PreviewRowSpec] {
+  [
     PreviewRowSpec(
       payee: "Stock Trade",
       legs: [
@@ -244,7 +349,12 @@ private func previewRowSpecs(data: TransactionRowPreviewData) -> [PreviewRowSpec
         TransactionLeg(
           accountId: data.sourceId, instrument: .AUD, quantity: -50, type: .expense),
       ],
-      display: -1050, balance: -2499.77, viewingAccountId: data.sourceId),
+      displayAmounts: [
+        InstrumentAmount(quantity: -1000, instrument: .AUD),
+        InstrumentAmount(quantity: 950, instrument: .AUD),
+        InstrumentAmount(quantity: -50, instrument: .AUD),
+      ],
+      balance: -2499.77, viewingAccountId: data.sourceId)
   ]
 }
 
@@ -254,7 +364,7 @@ private func previewRowSpecs(data: TransactionRowPreviewData) -> [PreviewRowSpec
     ForEach(Array(previewRowSpecs(data: data).enumerated()), id: \.offset) { _, spec in
       previewRow(
         data: data, payee: spec.payee, legs: spec.legs,
-        display: spec.display, balance: spec.balance,
+        displayAmounts: spec.displayAmounts, balance: spec.balance,
         viewingAccountId: spec.viewingAccountId)
     }
   }

--- a/MoolahTests/Domain/TransactionDisplayAmountTests.swift
+++ b/MoolahTests/Domain/TransactionDisplayAmountTests.swift
@@ -1,0 +1,136 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("Transaction.displayAmounts")
+struct TransactionDisplayAmountTests {
+  let aud = Instrument.AUD
+  let usd = Instrument.fiat(code: "USD")
+  let bhp = Instrument.stock(ticker: "BHP.AX", exchange: "ASX", name: "BHP")
+  let accountA = UUID()
+  let accountB = UUID()
+  let earmarkId = UUID()
+  let date = Date(timeIntervalSince1970: 1_700_000_000)
+
+  private func leg(
+    _ accountId: UUID?,
+    _ instr: Instrument,
+    _ qty: Decimal,
+    _ type: TransactionType,
+    earmark: UUID? = nil
+  ) -> TransactionLeg {
+    TransactionLeg(
+      accountId: accountId, instrument: instr, quantity: qty,
+      type: type, earmarkId: earmark)
+  }
+
+  @Test("simple expense scoped to its account: one entry")
+  func simpleExpense() async {
+    let transaction = Transaction(date: date, legs: [leg(accountA, aud, -50, .expense)])
+    let result = await TransactionPage.withRunningBalances(
+      transactions: [transaction],
+      priorBalance: InstrumentAmount(quantity: 100, instrument: aud),
+      accountId: accountA, targetInstrument: aud,
+      conversionService: FixedConversionService(rates: [:]))
+    #expect(
+      result.rows[0].displayAmounts == [InstrumentAmount(quantity: -50, instrument: aud)])
+  }
+
+  @Test("trade with cross-currency fee: three entries (legs not summed)")
+  func tradeWithCrossCurrencyFee() async {
+    let transaction = Transaction(
+      date: date,
+      legs: [
+        leg(accountA, aud, -300, .trade),
+        leg(accountA, bhp, 2, .trade),
+        leg(accountA, usd, -10, .expense),
+      ])
+    let result = await TransactionPage.withRunningBalances(
+      transactions: [transaction],
+      priorBalance: InstrumentAmount(quantity: 5_000, instrument: aud),
+      accountId: accountA, targetInstrument: aud,
+      conversionService: FixedConversionService(rates: [
+        bhp.id: Decimal(150), usd.id: Decimal(1.5),
+      ]))
+    let amounts = Set(result.rows[0].displayAmounts)
+    #expect(
+      amounts
+        == Set([
+          InstrumentAmount(quantity: -300, instrument: aud),
+          InstrumentAmount(quantity: 2, instrument: bhp),
+          InstrumentAmount(quantity: -10, instrument: usd),
+        ]))
+  }
+
+  @Test("trade with same-currency fee: AUD legs sum")
+  func tradeWithSameCurrencyFee() async {
+    let transaction = Transaction(
+      date: date,
+      legs: [
+        leg(accountA, aud, -300, .trade),
+        leg(accountA, bhp, 2, .trade),
+        leg(accountA, aud, -10, .expense),
+      ])
+    let result = await TransactionPage.withRunningBalances(
+      transactions: [transaction],
+      priorBalance: InstrumentAmount(quantity: 5_000, instrument: aud),
+      accountId: accountA, targetInstrument: aud,
+      conversionService: FixedConversionService(rates: [bhp.id: Decimal(150)]))
+    let amounts = Set(result.rows[0].displayAmounts)
+    #expect(
+      amounts
+        == Set([
+          InstrumentAmount(quantity: -310, instrument: aud),
+          InstrumentAmount(quantity: 2, instrument: bhp),
+        ]))
+  }
+
+  @Test("cross-currency transfer scoped to source: only AUD entry")
+  func crossCurrencyTransferSourceScope() async {
+    let transaction = Transaction(
+      date: date,
+      legs: [
+        leg(accountA, aud, -1_000, .transfer),
+        leg(accountB, usd, 660, .transfer),
+      ])
+    let result = await TransactionPage.withRunningBalances(
+      transactions: [transaction],
+      priorBalance: InstrumentAmount(quantity: 5_000, instrument: aud),
+      accountId: accountA, targetInstrument: aud,
+      conversionService: FixedConversionService(rates: [usd.id: Decimal(1.5)]))
+    #expect(
+      result.rows[0].displayAmounts == [InstrumentAmount(quantity: -1_000, instrument: aud)])
+  }
+
+  @Test("same-currency transfer unfiltered: zero-sum fallback shows negative leg")
+  func sameCurrencyTransferUnfiltered() async {
+    let transaction = Transaction(
+      date: date,
+      legs: [
+        leg(accountA, aud, -200, .transfer),
+        leg(accountB, aud, 200, .transfer),
+      ])
+    let result = await TransactionPage.withRunningBalances(
+      transactions: [transaction], priorBalance: nil,
+      accountId: nil, targetInstrument: aud,
+      conversionService: FixedConversionService(rates: [:]))
+    #expect(
+      result.rows[0].displayAmounts == [InstrumentAmount(quantity: -200, instrument: aud)])
+  }
+
+  @Test("earmark scope: only legs touching the earmark are summed")
+  func earmarkScope() async {
+    let transaction = Transaction(
+      date: date,
+      legs: [
+        leg(accountA, aud, 100, .income, earmark: earmarkId),
+        leg(accountA, aud, -10, .expense),  // not earmarked
+      ])
+    let result = await TransactionPage.withRunningBalances(
+      transactions: [transaction], priorBalance: nil, accountId: nil, earmarkId: earmarkId,
+      targetInstrument: aud, conversionService: FixedConversionService(rates: [:]))
+    #expect(
+      result.rows[0].displayAmounts == [InstrumentAmount(quantity: 100, instrument: aud)])
+  }
+}

--- a/MoolahTests/Domain/TransactionIsSimpleTests.swift
+++ b/MoolahTests/Domain/TransactionIsSimpleTests.swift
@@ -202,4 +202,17 @@ struct TransactionIsSimpleTests {
     let transaction = makeTransaction(legs: legs)
     #expect(transaction.isTransfer == true)
   }
+
+  @Test("trade-shaped transaction is not isSimple")
+  func tradeIsNotSimple() {
+    let aud = Instrument.AUD
+    let vgs = Instrument.stock(ticker: "VGS.AX", exchange: "ASX", name: "VGS")
+    let account = UUID()
+    let legs = [
+      TransactionLeg(accountId: account, instrument: aud, quantity: -300, type: .trade),
+      TransactionLeg(accountId: account, instrument: vgs, quantity: 20, type: .trade),
+    ]
+    let t = Transaction(date: Date(), legs: legs)
+    #expect(t.isSimple == false)
+  }
 }

--- a/MoolahTests/Domain/TransactionIsSimpleTests.swift
+++ b/MoolahTests/Domain/TransactionIsSimpleTests.swift
@@ -205,14 +205,12 @@ struct TransactionIsSimpleTests {
 
   @Test("trade-shaped transaction is not isSimple")
   func tradeIsNotSimple() {
-    let aud = Instrument.AUD
     let vgs = Instrument.stock(ticker: "VGS.AX", exchange: "ASX", name: "VGS")
     let account = UUID()
-    let legs = [
+    let transaction = makeTransaction(legs: [
       TransactionLeg(accountId: account, instrument: aud, quantity: -300, type: .trade),
       TransactionLeg(accountId: account, instrument: vgs, quantity: 20, type: .trade),
-    ]
-    let t = Transaction(date: Date(), legs: legs)
-    #expect(t.isSimple == false)
+    ])
+    #expect(transaction.isSimple == false)
   }
 }

--- a/MoolahTests/Domain/TransactionIsTradeTests.swift
+++ b/MoolahTests/Domain/TransactionIsTradeTests.swift
@@ -1,0 +1,178 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("Transaction.isTrade")
+struct TransactionIsTradeTests {
+  let aud = Instrument.AUD
+  let usd = Instrument.fiat(code: "USD")
+  let bhp = Instrument.stock(ticker: "BHP.AX", exchange: "ASX", name: "BHP")
+  let vgs = Instrument.stock(ticker: "VGS.AX", exchange: "ASX", name: "VGS")
+  let account = UUID()
+  let otherAccount = UUID()
+  let categoryId = UUID()
+  let earmarkId = UUID()
+
+  private func tradeLeg(
+    _ instr: Instrument, _ qty: Decimal,
+    account: UUID, category: UUID? = nil, earmark: UUID? = nil
+  ) -> TransactionLeg {
+    TransactionLeg(
+      accountId: account, instrument: instr, quantity: qty,
+      type: .trade, categoryId: category, earmarkId: earmark)
+  }
+
+  private func feeLeg(
+    _ instr: Instrument, _ qty: Decimal,
+    account: UUID, category: UUID? = nil, earmark: UUID? = nil
+  ) -> TransactionLeg {
+    TransactionLeg(
+      accountId: account, instrument: instr, quantity: qty,
+      type: .expense, categoryId: category, earmarkId: earmark)
+  }
+
+  private func txn(_ legs: [TransactionLeg]) -> Transaction {
+    Transaction(date: Date(), legs: legs)
+  }
+
+  // MARK: - Accept
+
+  @Test("two trade legs no fee")
+  func twoTradeLegsNoFee() {
+    let t = txn([tradeLeg(aud, -300, account: account), tradeLeg(vgs, 20, account: account)])
+    #expect(t.isTrade)
+  }
+
+  @Test("two trade legs plus one fee")
+  func twoTradeLegsOneFee() {
+    let t = txn([
+      tradeLeg(aud, -300, account: account),
+      tradeLeg(vgs, 20, account: account),
+      feeLeg(aud, -10, account: account),
+    ])
+    #expect(t.isTrade)
+  }
+
+  @Test("two trade legs plus multiple fees in different instruments")
+  func twoTradeLegsMultipleFees() {
+    let t = txn([
+      tradeLeg(aud, -300, account: account),
+      tradeLeg(vgs, 20, account: account),
+      feeLeg(aud, -10, account: account),
+      feeLeg(usd, -5, account: account),
+    ])
+    #expect(t.isTrade)
+  }
+
+  @Test("same-instrument paid and received is allowed")
+  func sameInstrumentPaidReceived() {
+    let t = txn([tradeLeg(aud, -100, account: account), tradeLeg(aud, 100, account: account)])
+    #expect(t.isTrade)
+  }
+
+  @Test("same-sign trade legs are allowed")
+  func sameSignLegs() {
+    let t = txn([tradeLeg(aud, 100, account: account), tradeLeg(vgs, 5, account: account)])
+    #expect(t.isTrade)
+  }
+
+  @Test("zero-quantity trade legs are allowed")
+  func zeroQuantityLegs() {
+    let t = txn([tradeLeg(aud, 0, account: account), tradeLeg(vgs, 0, account: account)])
+    #expect(t.isTrade)
+  }
+
+  @Test("fee leg may carry a category")
+  func feeWithCategory() {
+    let t = txn([
+      tradeLeg(aud, -300, account: account),
+      tradeLeg(vgs, 20, account: account),
+      feeLeg(aud, -10, account: account, category: categoryId),
+    ])
+    #expect(t.isTrade)
+  }
+
+  @Test("fee leg may carry an earmark")
+  func feeWithEarmark() {
+    let t = txn([
+      tradeLeg(aud, -300, account: account),
+      tradeLeg(vgs, 20, account: account),
+      feeLeg(aud, -10, account: account, earmark: earmarkId),
+    ])
+    #expect(t.isTrade)
+  }
+
+  // MARK: - Reject
+
+  @Test("one trade leg is not a trade")
+  func oneTradeLeg() {
+    let t = txn([tradeLeg(aud, -300, account: account)])
+    #expect(!t.isTrade)
+  }
+
+  @Test("three trade legs is not a trade")
+  func threeTradeLegs() {
+    let t = txn([
+      tradeLeg(aud, -300, account: account),
+      tradeLeg(vgs, 10, account: account),
+      tradeLeg(bhp, 5, account: account),
+    ])
+    #expect(!t.isTrade)
+  }
+
+  @Test("trade leg with a category is not a trade")
+  func tradeLegWithCategory() {
+    let t = txn([
+      tradeLeg(aud, -300, account: account, category: categoryId),
+      tradeLeg(vgs, 20, account: account),
+    ])
+    #expect(!t.isTrade)
+  }
+
+  @Test("trade leg with an earmark is not a trade")
+  func tradeLegWithEarmark() {
+    let t = txn([
+      tradeLeg(aud, -300, account: account, earmark: earmarkId),
+      tradeLeg(vgs, 20, account: account),
+    ])
+    #expect(!t.isTrade)
+  }
+
+  @Test("legs on different accounts is not a trade")
+  func mixedAccounts() {
+    let t = txn([
+      tradeLeg(aud, -300, account: account),
+      tradeLeg(vgs, 20, account: otherAccount),
+    ])
+    #expect(!t.isTrade)
+  }
+
+  @Test("fee leg on a different account is not a trade")
+  func feeOnOtherAccount() {
+    let t = txn([
+      tradeLeg(aud, -300, account: account),
+      tradeLeg(vgs, 20, account: account),
+      feeLeg(aud, -10, account: otherAccount),
+    ])
+    #expect(!t.isTrade)
+  }
+
+  @Test("non-expense extra leg (e.g. income) is not a trade")
+  func incomeExtraLeg() {
+    let income = TransactionLeg(accountId: account, instrument: aud, quantity: 5, type: .income)
+    let t = txn([
+      tradeLeg(aud, -300, account: account),
+      tradeLeg(vgs, 20, account: account),
+      income,
+    ])
+    #expect(!t.isTrade)
+  }
+
+  @Test("legs without an account id are not a trade")
+  func legsMissingAccount() {
+    let leg1 = TransactionLeg(accountId: nil, instrument: aud, quantity: -300, type: .trade)
+    let leg2 = TransactionLeg(accountId: nil, instrument: vgs, quantity: 20, type: .trade)
+    #expect(!txn([leg1, leg2]).isTrade)
+  }
+}

--- a/MoolahTests/Domain/TransactionIsTradeTests.swift
+++ b/MoolahTests/Domain/TransactionIsTradeTests.swift
@@ -15,24 +15,30 @@ struct TransactionIsTradeTests {
   let earmarkId = UUID()
 
   private func tradeLeg(
-    _ instr: Instrument, _ qty: Decimal,
-    account: UUID, category: UUID? = nil, earmark: UUID? = nil
+    instrument: Instrument,
+    quantity: Decimal,
+    account: UUID,
+    category: UUID? = nil,
+    earmark: UUID? = nil
   ) -> TransactionLeg {
     TransactionLeg(
-      accountId: account, instrument: instr, quantity: qty,
+      accountId: account, instrument: instrument, quantity: quantity,
       type: .trade, categoryId: category, earmarkId: earmark)
   }
 
   private func feeLeg(
-    _ instr: Instrument, _ qty: Decimal,
-    account: UUID, category: UUID? = nil, earmark: UUID? = nil
+    instrument: Instrument,
+    quantity: Decimal,
+    account: UUID,
+    category: UUID? = nil,
+    earmark: UUID? = nil
   ) -> TransactionLeg {
     TransactionLeg(
-      accountId: account, instrument: instr, quantity: qty,
+      accountId: account, instrument: instrument, quantity: quantity,
       type: .expense, categoryId: category, earmarkId: earmark)
   }
 
-  private func txn(_ legs: [TransactionLeg]) -> Transaction {
+  private func makeTransaction(legs: [TransactionLeg]) -> Transaction {
     Transaction(date: Date(), legs: legs)
   }
 
@@ -40,139 +46,159 @@ struct TransactionIsTradeTests {
 
   @Test("two trade legs no fee")
   func twoTradeLegsNoFee() {
-    let t = txn([tradeLeg(aud, -300, account: account), tradeLeg(vgs, 20, account: account)])
-    #expect(t.isTrade)
+    let transaction = makeTransaction(legs: [
+      tradeLeg(instrument: aud, quantity: -300, account: account),
+      tradeLeg(instrument: vgs, quantity: 20, account: account),
+    ])
+    #expect(transaction.isTrade)
   }
 
   @Test("two trade legs plus one fee")
   func twoTradeLegsOneFee() {
-    let t = txn([
-      tradeLeg(aud, -300, account: account),
-      tradeLeg(vgs, 20, account: account),
-      feeLeg(aud, -10, account: account),
+    let transaction = makeTransaction(legs: [
+      tradeLeg(instrument: aud, quantity: -300, account: account),
+      tradeLeg(instrument: vgs, quantity: 20, account: account),
+      feeLeg(instrument: aud, quantity: -10, account: account),
     ])
-    #expect(t.isTrade)
+    #expect(transaction.isTrade)
   }
 
   @Test("two trade legs plus multiple fees in different instruments")
   func twoTradeLegsMultipleFees() {
-    let t = txn([
-      tradeLeg(aud, -300, account: account),
-      tradeLeg(vgs, 20, account: account),
-      feeLeg(aud, -10, account: account),
-      feeLeg(usd, -5, account: account),
+    let transaction = makeTransaction(legs: [
+      tradeLeg(instrument: aud, quantity: -300, account: account),
+      tradeLeg(instrument: vgs, quantity: 20, account: account),
+      feeLeg(instrument: aud, quantity: -10, account: account),
+      feeLeg(instrument: usd, quantity: -5, account: account),
     ])
-    #expect(t.isTrade)
+    #expect(transaction.isTrade)
   }
 
   @Test("same-instrument paid and received is allowed")
   func sameInstrumentPaidReceived() {
-    let t = txn([tradeLeg(aud, -100, account: account), tradeLeg(aud, 100, account: account)])
-    #expect(t.isTrade)
+    let transaction = makeTransaction(legs: [
+      tradeLeg(instrument: aud, quantity: -100, account: account),
+      tradeLeg(instrument: aud, quantity: 100, account: account),
+    ])
+    #expect(transaction.isTrade)
   }
 
   @Test("same-sign trade legs are allowed")
   func sameSignLegs() {
-    let t = txn([tradeLeg(aud, 100, account: account), tradeLeg(vgs, 5, account: account)])
-    #expect(t.isTrade)
+    let transaction = makeTransaction(legs: [
+      tradeLeg(instrument: aud, quantity: 100, account: account),
+      tradeLeg(instrument: vgs, quantity: 5, account: account),
+    ])
+    #expect(transaction.isTrade)
   }
 
   @Test("zero-quantity trade legs are allowed")
   func zeroQuantityLegs() {
-    let t = txn([tradeLeg(aud, 0, account: account), tradeLeg(vgs, 0, account: account)])
-    #expect(t.isTrade)
+    let transaction = makeTransaction(legs: [
+      tradeLeg(instrument: aud, quantity: 0, account: account),
+      tradeLeg(instrument: vgs, quantity: 0, account: account),
+    ])
+    #expect(transaction.isTrade)
   }
 
   @Test("fee leg may carry a category")
   func feeWithCategory() {
-    let t = txn([
-      tradeLeg(aud, -300, account: account),
-      tradeLeg(vgs, 20, account: account),
-      feeLeg(aud, -10, account: account, category: categoryId),
+    let transaction = makeTransaction(legs: [
+      tradeLeg(instrument: aud, quantity: -300, account: account),
+      tradeLeg(instrument: vgs, quantity: 20, account: account),
+      feeLeg(instrument: aud, quantity: -10, account: account, category: categoryId),
     ])
-    #expect(t.isTrade)
+    #expect(transaction.isTrade)
   }
 
   @Test("fee leg may carry an earmark")
   func feeWithEarmark() {
-    let t = txn([
-      tradeLeg(aud, -300, account: account),
-      tradeLeg(vgs, 20, account: account),
-      feeLeg(aud, -10, account: account, earmark: earmarkId),
+    let transaction = makeTransaction(legs: [
+      tradeLeg(instrument: aud, quantity: -300, account: account),
+      tradeLeg(instrument: vgs, quantity: 20, account: account),
+      feeLeg(instrument: aud, quantity: -10, account: account, earmark: earmarkId),
     ])
-    #expect(t.isTrade)
+    #expect(transaction.isTrade)
   }
 
   // MARK: - Reject
 
+  @Test("empty legs is not a trade")
+  func emptyLegsIsNotATrade() {
+    #expect(!makeTransaction(legs: []).isTrade)
+  }
+
   @Test("one trade leg is not a trade")
   func oneTradeLeg() {
-    let t = txn([tradeLeg(aud, -300, account: account)])
-    #expect(!t.isTrade)
+    let transaction = makeTransaction(legs: [
+      tradeLeg(instrument: aud, quantity: -300, account: account)
+    ])
+    #expect(!transaction.isTrade)
   }
 
   @Test("three trade legs is not a trade")
   func threeTradeLegs() {
-    let t = txn([
-      tradeLeg(aud, -300, account: account),
-      tradeLeg(vgs, 10, account: account),
-      tradeLeg(bhp, 5, account: account),
+    let transaction = makeTransaction(legs: [
+      tradeLeg(instrument: aud, quantity: -300, account: account),
+      tradeLeg(instrument: vgs, quantity: 10, account: account),
+      tradeLeg(instrument: bhp, quantity: 5, account: account),
     ])
-    #expect(!t.isTrade)
+    #expect(!transaction.isTrade)
   }
 
   @Test("trade leg with a category is not a trade")
   func tradeLegWithCategory() {
-    let t = txn([
-      tradeLeg(aud, -300, account: account, category: categoryId),
-      tradeLeg(vgs, 20, account: account),
+    let transaction = makeTransaction(legs: [
+      tradeLeg(instrument: aud, quantity: -300, account: account, category: categoryId),
+      tradeLeg(instrument: vgs, quantity: 20, account: account),
     ])
-    #expect(!t.isTrade)
+    #expect(!transaction.isTrade)
   }
 
   @Test("trade leg with an earmark is not a trade")
   func tradeLegWithEarmark() {
-    let t = txn([
-      tradeLeg(aud, -300, account: account, earmark: earmarkId),
-      tradeLeg(vgs, 20, account: account),
+    let transaction = makeTransaction(legs: [
+      tradeLeg(instrument: aud, quantity: -300, account: account, earmark: earmarkId),
+      tradeLeg(instrument: vgs, quantity: 20, account: account),
     ])
-    #expect(!t.isTrade)
+    #expect(!transaction.isTrade)
   }
 
   @Test("legs on different accounts is not a trade")
   func mixedAccounts() {
-    let t = txn([
-      tradeLeg(aud, -300, account: account),
-      tradeLeg(vgs, 20, account: otherAccount),
+    let transaction = makeTransaction(legs: [
+      tradeLeg(instrument: aud, quantity: -300, account: account),
+      tradeLeg(instrument: vgs, quantity: 20, account: otherAccount),
     ])
-    #expect(!t.isTrade)
+    #expect(!transaction.isTrade)
   }
 
   @Test("fee leg on a different account is not a trade")
   func feeOnOtherAccount() {
-    let t = txn([
-      tradeLeg(aud, -300, account: account),
-      tradeLeg(vgs, 20, account: account),
-      feeLeg(aud, -10, account: otherAccount),
+    let transaction = makeTransaction(legs: [
+      tradeLeg(instrument: aud, quantity: -300, account: account),
+      tradeLeg(instrument: vgs, quantity: 20, account: account),
+      feeLeg(instrument: aud, quantity: -10, account: otherAccount),
     ])
-    #expect(!t.isTrade)
+    #expect(!transaction.isTrade)
   }
 
   @Test("non-expense extra leg (e.g. income) is not a trade")
   func incomeExtraLeg() {
-    let income = TransactionLeg(accountId: account, instrument: aud, quantity: 5, type: .income)
-    let t = txn([
-      tradeLeg(aud, -300, account: account),
-      tradeLeg(vgs, 20, account: account),
+    let income = TransactionLeg(
+      accountId: account, instrument: aud, quantity: 5, type: .income)
+    let transaction = makeTransaction(legs: [
+      tradeLeg(instrument: aud, quantity: -300, account: account),
+      tradeLeg(instrument: vgs, quantity: 20, account: account),
       income,
     ])
-    #expect(!t.isTrade)
+    #expect(!transaction.isTrade)
   }
 
   @Test("legs without an account id are not a trade")
   func legsMissingAccount() {
     let leg1 = TransactionLeg(accountId: nil, instrument: aud, quantity: -300, type: .trade)
     let leg2 = TransactionLeg(accountId: nil, instrument: vgs, quantity: 20, type: .trade)
-    #expect(!txn([leg1, leg2]).isTrade)
+    #expect(!makeTransaction(legs: [leg1, leg2]).isTrade)
   }
 }

--- a/MoolahTests/Domain/TransactionTradeTitleTests.swift
+++ b/MoolahTests/Domain/TransactionTradeTitleTests.swift
@@ -41,6 +41,22 @@ struct TransactionTradeTitleTests {
     #expect(txn.tradeTitleSentence(scopeReference: aud) == "Sold 10 VGS.AX")
   }
 
+  @Test("USD scope reference matches USD leg → Bought")
+  func boughtVerbWithUSDReference() {
+    let txn = tradeTxn(usd, -300, vgs, 20)
+    #expect(txn.tradeTitleSentence(scopeReference: usd) == "Bought 20 VGS.AX")
+  }
+
+  @Test("non-fiat scope reference matches non-fiat leg → reverse perspective")
+  func nonFiatScopeReference() {
+    // From a stock-instrument scope (e.g. an instrument detail view), the
+    // direction reads from the position's perspective: paying out 300 AUD
+    // to acquire 20 VGS reads as "Sold 300 AUD" because VGS is the matching
+    // (positive) leg under the stock scope.
+    let txn = tradeTxn(aud, -300, vgs, 20)
+    #expect(txn.tradeTitleSentence(scopeReference: vgs) == "Sold 300 AUD")
+  }
+
   @Test("neither leg matches reference → Swapped")
   func swappedVerb() {
     let txn = tradeTxn(usd, -100, gbp, 50)

--- a/MoolahTests/Domain/TransactionTradeTitleTests.swift
+++ b/MoolahTests/Domain/TransactionTradeTitleTests.swift
@@ -29,56 +29,74 @@ struct TransactionTradeTitleTests {
       ])
   }
 
+  /// Computes the same magnitude string the implementation produces — uses
+  /// `InstrumentAmount.formatted` so the assertions stay locale-resilient.
+  private func formatted(_ qty: Decimal, _ instrument: Instrument) -> String {
+    InstrumentAmount(quantity: qty, instrument: instrument).formatted
+  }
+
   @Test("matching leg negative → Bought")
   func boughtVerb() {
     let txn = tradeTxn(aud, -300, vgs, 20)
-    #expect(txn.tradeTitleSentence(scopeReference: aud) == "Bought 20 VGS.AX")
+    #expect(txn.tradeTitleSentence(scopeReference: aud) == "Bought \(formatted(20, vgs))")
   }
 
   @Test("matching leg positive → Sold")
   func soldVerb() {
     let txn = tradeTxn(aud, 425, vgs, -10)
-    #expect(txn.tradeTitleSentence(scopeReference: aud) == "Sold 10 VGS.AX")
+    #expect(txn.tradeTitleSentence(scopeReference: aud) == "Sold \(formatted(10, vgs))")
   }
 
   @Test("USD scope reference matches USD leg → Bought")
   func boughtVerbWithUSDReference() {
     let txn = tradeTxn(usd, -300, vgs, 20)
-    #expect(txn.tradeTitleSentence(scopeReference: usd) == "Bought 20 VGS.AX")
+    #expect(txn.tradeTitleSentence(scopeReference: usd) == "Bought \(formatted(20, vgs))")
   }
 
   @Test("non-fiat scope reference matches non-fiat leg → reverse perspective")
   func nonFiatScopeReference() {
-    // From a stock-instrument scope (e.g. an instrument detail view), the
-    // direction reads from the position's perspective: paying out 300 AUD
-    // to acquire 20 VGS reads as "Sold 300 AUD" because VGS is the matching
-    // (positive) leg under the stock scope.
+    // From a stock-instrument scope, the direction reads from the position's
+    // perspective: paying out 300 AUD to acquire 20 VGS reads as
+    // "Sold {300 AUD}" because VGS is the matching (positive) leg under the
+    // stock scope.
     let txn = tradeTxn(aud, -300, vgs, 20)
-    #expect(txn.tradeTitleSentence(scopeReference: vgs) == "Sold 300 AUD")
+    #expect(txn.tradeTitleSentence(scopeReference: vgs) == "Sold \(formatted(300, aud))")
   }
 
   @Test("neither leg matches reference → Swapped")
   func swappedVerb() {
     let txn = tradeTxn(usd, -100, gbp, 50)
-    #expect(txn.tradeTitleSentence(scopeReference: aud) == "Swapped 100 USD for 50 GBP")
+    #expect(
+      txn.tradeTitleSentence(scopeReference: aud)
+        == "Swapped \(formatted(100, usd)) for \(formatted(50, gbp))"
+    )
   }
 
   @Test("neither matches, mixed fiat / non-fiat")
   func swappedVerbFiatToNonFiat() {
     let txn = tradeTxn(usd, -100, vgs, 5)
-    #expect(txn.tradeTitleSentence(scopeReference: aud) == "Swapped 100 USD for 5 VGS.AX")
+    #expect(
+      txn.tradeTitleSentence(scopeReference: aud)
+        == "Swapped \(formatted(100, usd)) for \(formatted(5, vgs))"
+    )
   }
 
   @Test("non-fiat ↔ non-fiat swap")
   func swappedVerbCryptoSwap() {
     let txn = tradeTxn(eth, -1, usdc, 30_000)
-    #expect(txn.tradeTitleSentence(scopeReference: aud) == "Swapped 1 ETH for 30,000 USDC")
+    #expect(
+      txn.tradeTitleSentence(scopeReference: aud)
+        == "Swapped \(formatted(1, eth)) for \(formatted(30_000, usdc))"
+    )
   }
 
   @Test("both legs share the reference instrument → Swapped")
   func bothMatchRef() {
     let txn = tradeTxn(aud, -100, aud, 100)
-    #expect(txn.tradeTitleSentence(scopeReference: aud) == "Swapped 100 AUD for 100 AUD")
+    #expect(
+      txn.tradeTitleSentence(scopeReference: aud)
+        == "Swapped \(formatted(100, aud)) for \(formatted(100, aud))"
+    )
   }
 
   @Test("non-trade transaction returns nil")

--- a/MoolahTests/Domain/TransactionTradeTitleTests.swift
+++ b/MoolahTests/Domain/TransactionTradeTitleTests.swift
@@ -1,0 +1,77 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("Transaction.tradeTitleSentence")
+struct TransactionTradeTitleTests {
+  let aud = Instrument.AUD
+  let usd = Instrument.fiat(code: "USD")
+  let gbp = Instrument.fiat(code: "GBP")
+  let vgs = Instrument.stock(ticker: "VGS.AX", exchange: "ASX", name: "VGS")
+  let eth = Instrument.crypto(
+    chainId: 1, contractAddress: nil, symbol: "ETH", name: "Ethereum", decimals: 18)
+  let usdc = Instrument.crypto(
+    chainId: 1, contractAddress: "0xa0b86", symbol: "USDC", name: "USD Coin", decimals: 6)
+  let account = UUID()
+
+  private func tradeTxn(
+    _ legA: Instrument,
+    _ legAQty: Decimal,
+    _ legB: Instrument,
+    _ legBQty: Decimal
+  ) -> Transaction {
+    Transaction(
+      date: Date(),
+      legs: [
+        TransactionLeg(accountId: account, instrument: legA, quantity: legAQty, type: .trade),
+        TransactionLeg(accountId: account, instrument: legB, quantity: legBQty, type: .trade),
+      ])
+  }
+
+  @Test("matching leg negative → Bought")
+  func boughtVerb() {
+    let txn = tradeTxn(aud, -300, vgs, 20)
+    #expect(txn.tradeTitleSentence(scopeReference: aud) == "Bought 20 VGS.AX")
+  }
+
+  @Test("matching leg positive → Sold")
+  func soldVerb() {
+    let txn = tradeTxn(aud, 425, vgs, -10)
+    #expect(txn.tradeTitleSentence(scopeReference: aud) == "Sold 10 VGS.AX")
+  }
+
+  @Test("neither leg matches reference → Swapped")
+  func swappedVerb() {
+    let txn = tradeTxn(usd, -100, gbp, 50)
+    #expect(txn.tradeTitleSentence(scopeReference: aud) == "Swapped 100 USD for 50 GBP")
+  }
+
+  @Test("neither matches, mixed fiat / non-fiat")
+  func swappedVerbFiatToNonFiat() {
+    let txn = tradeTxn(usd, -100, vgs, 5)
+    #expect(txn.tradeTitleSentence(scopeReference: aud) == "Swapped 100 USD for 5 VGS.AX")
+  }
+
+  @Test("non-fiat ↔ non-fiat swap")
+  func swappedVerbCryptoSwap() {
+    let txn = tradeTxn(eth, -1, usdc, 30_000)
+    #expect(txn.tradeTitleSentence(scopeReference: aud) == "Swapped 1 ETH for 30,000 USDC")
+  }
+
+  @Test("both legs share the reference instrument → Swapped")
+  func bothMatchRef() {
+    let txn = tradeTxn(aud, -100, aud, 100)
+    #expect(txn.tradeTitleSentence(scopeReference: aud) == "Swapped 100 AUD for 100 AUD")
+  }
+
+  @Test("non-trade transaction returns nil")
+  func nonTradeReturnsNil() {
+    let txn = Transaction(
+      date: Date(),
+      legs: [
+        TransactionLeg(accountId: account, instrument: aud, quantity: -50, type: .expense)
+      ])
+    #expect(txn.tradeTitleSentence(scopeReference: aud) == nil)
+  }
+}

--- a/MoolahTests/Domain/TransactionTypeTests.swift
+++ b/MoolahTests/Domain/TransactionTypeTests.swift
@@ -1,0 +1,41 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("TransactionType")
+struct TransactionTypeTests {
+  @Test("trade case has stable raw value")
+  func tradeRawValue() {
+    #expect(TransactionType.trade.rawValue == "trade")
+  }
+
+  @Test("trade is in CaseIterable.allCases")
+  func tradeInAllCases() {
+    #expect(TransactionType.allCases.contains(.trade))
+  }
+
+  @Test("trade displayName is Trade")
+  func tradeDisplayName() {
+    #expect(TransactionType.trade.displayName == "Trade")
+  }
+
+  @Test("trade is user-editable")
+  func tradeIsUserEditable() {
+    #expect(TransactionType.trade.isUserEditable == true)
+  }
+
+  @Test("trade is in userSelectableTypes")
+  func tradeIsUserSelectable() {
+    #expect(TransactionType.userSelectableTypes.contains(.trade))
+  }
+
+  @Test("trade Codable round-trips")
+  func tradeCodableRoundTrip() throws {
+    let encoded = try JSONEncoder().encode(TransactionType.trade)
+    let decoded = try JSONDecoder().decode(TransactionType.self, from: encoded)
+    #expect(decoded == .trade)
+    let raw = String(data: encoded, encoding: .utf8)
+    #expect(raw == "\"trade\"")
+  }
+}

--- a/MoolahTests/Domain/TransactionTypeTests.swift
+++ b/MoolahTests/Domain/TransactionTypeTests.swift
@@ -22,7 +22,7 @@ struct TransactionTypeTests {
 
   @Test("trade is user-editable")
   func tradeIsUserEditable() {
-    #expect(TransactionType.trade.isUserEditable == true)
+    #expect(TransactionType.trade.isUserEditable)
   }
 
   @Test("trade is in userSelectableTypes")
@@ -35,7 +35,10 @@ struct TransactionTypeTests {
     let encoded = try JSONEncoder().encode(TransactionType.trade)
     let decoded = try JSONDecoder().decode(TransactionType.self, from: encoded)
     #expect(decoded == .trade)
-    let raw = String(data: encoded, encoding: .utf8)
-    #expect(raw == "\"trade\"")
+  }
+
+  @Test("userSelectableTypes order is income, expense, transfer, trade")
+  func userSelectableTypesOrder() {
+    #expect(TransactionType.userSelectableTypes == [.income, .expense, .transfer, .trade])
   }
 }

--- a/MoolahTests/Features/InvestmentStorePositionsInputTests.swift
+++ b/MoolahTests/Features/InvestmentStorePositionsInputTests.swift
@@ -24,8 +24,8 @@ struct InvestmentStorePositionsInputTests {
       Transaction(
         date: Date(),
         legs: [
-          TransactionLeg(accountId: account.id, instrument: bhp, quantity: 100, type: .income),
-          TransactionLeg(accountId: account.id, instrument: aud, quantity: -4_000, type: .expense),
+          TransactionLeg(accountId: account.id, instrument: bhp, quantity: 100, type: .trade),
+          TransactionLeg(accountId: account.id, instrument: aud, quantity: -4_000, type: .trade),
         ]
       )
     )
@@ -83,8 +83,8 @@ struct InvestmentStorePositionsInputTests {
       Transaction(
         date: Date(timeIntervalSinceNow: -86_400 * 10),
         legs: [
-          TransactionLeg(accountId: account.id, instrument: eth, quantity: 4, type: .income),
-          TransactionLeg(accountId: account.id, instrument: aud, quantity: -12_000, type: .expense),
+          TransactionLeg(accountId: account.id, instrument: eth, quantity: 4, type: .trade),
+          TransactionLeg(accountId: account.id, instrument: aud, quantity: -12_000, type: .trade),
         ]
       )
     )
@@ -96,10 +96,10 @@ struct InvestmentStorePositionsInputTests {
       Transaction(
         date: Date(timeIntervalSinceNow: -86_400 * 5),
         legs: [
-          TransactionLeg(accountId: account.id, instrument: eth, quantity: -2, type: .income),
+          TransactionLeg(accountId: account.id, instrument: eth, quantity: -2, type: .trade),
           TransactionLeg(
             accountId: account.id, instrument: btc, quantity: dec("0.1"),
-            type: .income),
+            type: .trade),
         ]
       )
     )

--- a/MoolahTests/Features/ReportingStoreTests.swift
+++ b/MoolahTests/Features/ReportingStoreTests.swift
@@ -29,9 +29,9 @@ struct ReportingStoreTests {
       payee: "Buy BHP",
       legs: [
         TransactionLeg(
-          accountId: account.id, instrument: aud, quantity: -4000, type: .transfer),
+          accountId: account.id, instrument: aud, quantity: -4000, type: .trade),
         TransactionLeg(
-          accountId: account.id, instrument: bhp, quantity: 100, type: .transfer),
+          accountId: account.id, instrument: bhp, quantity: 100, type: .trade),
       ]
     )
     TestBackend.seed(transactions: [buyTx], in: container)
@@ -73,9 +73,9 @@ struct ReportingStoreTests {
       payee: "Buy BHP",
       legs: [
         TransactionLeg(
-          accountId: account.id, instrument: aud, quantity: -4000, type: .transfer),
+          accountId: account.id, instrument: aud, quantity: -4000, type: .trade),
         TransactionLeg(
-          accountId: account.id, instrument: bhp, quantity: 100, type: .transfer),
+          accountId: account.id, instrument: bhp, quantity: 100, type: .trade),
       ]
     )
 
@@ -86,9 +86,9 @@ struct ReportingStoreTests {
       payee: "Sell BHP",
       legs: [
         TransactionLeg(
-          accountId: account.id, instrument: bhp, quantity: -100, type: .transfer),
+          accountId: account.id, instrument: bhp, quantity: -100, type: .trade),
         TransactionLeg(
-          accountId: account.id, instrument: aud, quantity: 5000, type: .transfer),
+          accountId: account.id, instrument: aud, quantity: 5000, type: .trade),
       ]
     )
     TestBackend.seed(transactions: [buyTx, sellTx], in: container)
@@ -156,33 +156,33 @@ struct ReportingStoreTests {
         date: buyBHPDate, payee: "Buy BHP",
         legs: [
           TransactionLeg(
-            accountId: accountId, instrument: aud, quantity: -4000, type: .transfer),
+            accountId: accountId, instrument: aud, quantity: -4000, type: .trade),
           TransactionLeg(
-            accountId: accountId, instrument: bhp, quantity: 100, type: .transfer),
+            accountId: accountId, instrument: bhp, quantity: 100, type: .trade),
         ]),
       Transaction(
         date: buyCBADate, payee: "Buy CBA",
         legs: [
           TransactionLeg(
-            accountId: accountId, instrument: aud, quantity: -5000, type: .transfer),
+            accountId: accountId, instrument: aud, quantity: -5000, type: .trade),
           TransactionLeg(
-            accountId: accountId, instrument: cba, quantity: 50, type: .transfer),
+            accountId: accountId, instrument: cba, quantity: 50, type: .trade),
         ]),
       Transaction(
         date: sellDate, payee: "Sell BHP",
         legs: [
           TransactionLeg(
-            accountId: accountId, instrument: bhp, quantity: -100, type: .transfer),
+            accountId: accountId, instrument: bhp, quantity: -100, type: .trade),
           TransactionLeg(
-            accountId: accountId, instrument: aud, quantity: 5000, type: .transfer),
+            accountId: accountId, instrument: aud, quantity: 5000, type: .trade),
         ]),
       Transaction(
         date: sellDate, payee: "Sell CBA",
         legs: [
           TransactionLeg(
-            accountId: accountId, instrument: cba, quantity: -50, type: .transfer),
+            accountId: accountId, instrument: cba, quantity: -50, type: .trade),
           TransactionLeg(
-            accountId: accountId, instrument: aud, quantity: 6000, type: .transfer),
+            accountId: accountId, instrument: aud, quantity: 6000, type: .trade),
         ]),
     ]
   }

--- a/MoolahTests/Features/ReportingStoreTestsMore.swift
+++ b/MoolahTests/Features/ReportingStoreTestsMore.swift
@@ -60,9 +60,9 @@ struct ReportingStoreTestsMore {
       payee: "Buy BHP",
       legs: [
         TransactionLeg(
-          accountId: account.id, instrument: aud, quantity: -4000, type: .transfer),
+          accountId: account.id, instrument: aud, quantity: -4000, type: .trade),
         TransactionLeg(
-          accountId: account.id, instrument: bhp, quantity: 100, type: .transfer),
+          accountId: account.id, instrument: bhp, quantity: 100, type: .trade),
       ]
     )
     let buyCBA = Transaction(
@@ -70,9 +70,9 @@ struct ReportingStoreTestsMore {
       payee: "Buy CBA",
       legs: [
         TransactionLeg(
-          accountId: account.id, instrument: aud, quantity: -5000, type: .transfer),
+          accountId: account.id, instrument: aud, quantity: -5000, type: .trade),
         TransactionLeg(
-          accountId: account.id, instrument: cba, quantity: 50, type: .transfer),
+          accountId: account.id, instrument: cba, quantity: 50, type: .trade),
       ]
     )
     TestBackend.seed(transactions: [buyBHP, buyCBA], in: container)
@@ -116,19 +116,19 @@ struct ReportingStoreTestsMore {
         payee: "Buy BHP",
         legs: [
           TransactionLeg(
-            accountId: account.id, instrument: aud, quantity: -4000, type: .transfer),
+            accountId: account.id, instrument: aud, quantity: -4000, type: .trade),
           TransactionLeg(
-            accountId: account.id, instrument: bhp, quantity: 100, type: .transfer),
+            accountId: account.id, instrument: bhp, quantity: 100, type: .trade),
         ]),
       Transaction(
         date: Date(),
         payee: "Buy ETH",
         legs: [
           TransactionLeg(
-            accountId: account.id, instrument: aud, quantity: -2000, type: .transfer),
+            accountId: account.id, instrument: aud, quantity: -2000, type: .trade),
           TransactionLeg(
             accountId: account.id, instrument: eth,
-            quantity: dec("1.0"), type: .transfer),
+            quantity: dec("1.0"), type: .trade),
         ]),
     ]
     TestBackend.seed(transactions: txns, in: container)

--- a/MoolahTests/Shared/CapitalGainsCalculatorTests.swift
+++ b/MoolahTests/Shared/CapitalGainsCalculatorTests.swift
@@ -33,10 +33,10 @@ struct CapitalGainsCalculatorTests {
       date: date(0),
       legs: [
         TransactionLeg(
-          accountId: accountId, instrument: aud, quantity: -4000, type: .transfer,
+          accountId: accountId, instrument: aud, quantity: -4000, type: .trade,
           categoryId: nil, earmarkId: nil),
         TransactionLeg(
-          accountId: accountId, instrument: bhp, quantity: 100, type: .transfer,
+          accountId: accountId, instrument: bhp, quantity: 100, type: .trade,
           categoryId: nil, earmarkId: nil),
       ])
 
@@ -45,10 +45,10 @@ struct CapitalGainsCalculatorTests {
       date: date(400),
       legs: [
         TransactionLeg(
-          accountId: accountId, instrument: bhp, quantity: -100, type: .transfer,
+          accountId: accountId, instrument: bhp, quantity: -100, type: .trade,
           categoryId: nil, earmarkId: nil),
         TransactionLeg(
-          accountId: accountId, instrument: aud, quantity: 5000, type: .transfer,
+          accountId: accountId, instrument: aud, quantity: 5000, type: .trade,
           categoryId: nil, earmarkId: nil),
       ])
 
@@ -73,10 +73,10 @@ struct CapitalGainsCalculatorTests {
       date: date(0),
       legs: [
         TransactionLeg(
-          accountId: accountId, instrument: aud, quantity: -4000, type: .transfer,
+          accountId: accountId, instrument: aud, quantity: -4000, type: .trade,
           categoryId: nil, earmarkId: nil),
         TransactionLeg(
-          accountId: accountId, instrument: bhp, quantity: 100, type: .transfer,
+          accountId: accountId, instrument: bhp, quantity: 100, type: .trade,
           categoryId: nil, earmarkId: nil),
       ])
 
@@ -102,10 +102,10 @@ struct CapitalGainsCalculatorTests {
       date: date(0),
       legs: [
         TransactionLeg(
-          accountId: accountId, instrument: aud, quantity: -3000, type: .transfer,
+          accountId: accountId, instrument: aud, quantity: -3000, type: .trade,
           categoryId: nil, earmarkId: nil),
         TransactionLeg(
-          accountId: accountId, instrument: eth, quantity: 1, type: .transfer,
+          accountId: accountId, instrument: eth, quantity: 1, type: .trade,
           categoryId: nil, earmarkId: nil),
       ])
 
@@ -114,10 +114,10 @@ struct CapitalGainsCalculatorTests {
       date: date(200),
       legs: [
         TransactionLeg(
-          accountId: accountId, instrument: eth, quantity: -1, type: .transfer,
+          accountId: accountId, instrument: eth, quantity: -1, type: .trade,
           categoryId: nil, earmarkId: nil),
         TransactionLeg(
-          accountId: accountId, instrument: uni, quantity: 500, type: .transfer,
+          accountId: accountId, instrument: uni, quantity: 500, type: .trade,
           categoryId: nil, earmarkId: nil),
       ])
 
@@ -143,10 +143,10 @@ struct CapitalGainsCalculatorTests {
       date: date(0),
       legs: [
         TransactionLeg(
-          accountId: accountId, instrument: aud, quantity: -4000, type: .transfer,
+          accountId: accountId, instrument: aud, quantity: -4000, type: .trade,
           categoryId: nil, earmarkId: nil),
         TransactionLeg(
-          accountId: accountId, instrument: bhp, quantity: 100, type: .transfer,
+          accountId: accountId, instrument: bhp, quantity: 100, type: .trade,
           categoryId: nil, earmarkId: nil),
       ])
 
@@ -154,10 +154,10 @@ struct CapitalGainsCalculatorTests {
       date: date(400),
       legs: [
         TransactionLeg(
-          accountId: accountId, instrument: bhp, quantity: -100, type: .transfer,
+          accountId: accountId, instrument: bhp, quantity: -100, type: .trade,
           categoryId: nil, earmarkId: nil),
         TransactionLeg(
-          accountId: accountId, instrument: aud, quantity: 5000, type: .transfer,
+          accountId: accountId, instrument: aud, quantity: 5000, type: .trade,
           categoryId: nil, earmarkId: nil),
       ])
 
@@ -214,10 +214,10 @@ struct CapitalGainsCalculatorTests {
       date: date(day),
       legs: [
         TransactionLeg(
-          accountId: accountId, instrument: aud, quantity: cash, type: .transfer,
+          accountId: accountId, instrument: aud, quantity: cash, type: .trade,
           categoryId: nil, earmarkId: nil),
         TransactionLeg(
-          accountId: accountId, instrument: instrument, quantity: qty, type: .transfer,
+          accountId: accountId, instrument: instrument, quantity: qty, type: .trade,
           categoryId: nil, earmarkId: nil),
       ])
   }
@@ -231,10 +231,10 @@ struct CapitalGainsCalculatorTests {
       date: date(day),
       legs: [
         TransactionLeg(
-          accountId: accountId, instrument: instrument, quantity: qty, type: .transfer,
+          accountId: accountId, instrument: instrument, quantity: qty, type: .trade,
           categoryId: nil, earmarkId: nil),
         TransactionLeg(
-          accountId: accountId, instrument: aud, quantity: proceeds, type: .transfer,
+          accountId: accountId, instrument: aud, quantity: proceeds, type: .trade,
           categoryId: nil, earmarkId: nil),
       ])
   }

--- a/MoolahTests/Shared/CapitalGainsCalculatorTestsMore.swift
+++ b/MoolahTests/Shared/CapitalGainsCalculatorTestsMore.swift
@@ -73,13 +73,17 @@ struct CapitalGainsCalculatorTestsMore {
     #expect(result.events[0].gain == 1000)
   }
 
-  /// Mixed-fiat buy: 100 BHP paid for with USD 2000 + AUD 100 fee,
-  /// profile currency = AUD at 1 USD = 1.5 AUD. The calculator must
-  /// convert each fiat leg to the profile currency before summing,
-  /// producing a cost basis of AUD 3100 (not the raw 2100 from blending
-  /// USD and AUD quantities).
+  /// Cross-currency buy with a fee in the profile currency: 100 BHP paid
+  /// for with USD 2000 plus an AUD 100 brokerage fee. Profile currency =
+  /// AUD at 1 USD = 1.5 AUD. The two `.trade` legs price the position
+  /// (USD outflow → BHP) and the AUD fee leg is `.expense` so it does
+  /// **not** participate in cost basis under the current design.
+  ///
+  /// Cost basis is therefore the converted USD outflow only (AUD 3000),
+  /// proceeds AUD 4000, gain AUD 1000. Folding the fee into cost basis
+  /// is tracked in https://github.com/ajsutton/moolah-native/issues/558.
   @Test
-  func mixedFiatLegs_convertToProfileCurrencyBeforeSumming() async throws {
+  func crossCurrencyBuyWithFeeExcludesFeeFromCostBasis() async throws {
     let bhp = stockInstrument("BHP")
     let usd = Instrument.fiat(code: "USD")
     let accountId = UUID()
@@ -91,10 +95,10 @@ struct CapitalGainsCalculatorTestsMore {
           accountId: accountId, instrument: usd, quantity: -2000, type: .trade,
           categoryId: nil, earmarkId: nil),
         TransactionLeg(
-          accountId: accountId, instrument: aud, quantity: -100, type: .trade,
+          accountId: accountId, instrument: bhp, quantity: 100, type: .trade,
           categoryId: nil, earmarkId: nil),
         TransactionLeg(
-          accountId: accountId, instrument: bhp, quantity: 100, type: .trade,
+          accountId: accountId, instrument: aud, quantity: -100, type: .expense,
           categoryId: nil, earmarkId: nil),
       ])
 
@@ -116,10 +120,10 @@ struct CapitalGainsCalculatorTestsMore {
       conversionService: service
     )
 
-    // Cost basis AUD 3100 (USD 2000 × 1.5 = 3000 plus AUD 100 fee),
-    // proceeds AUD 4000. Gain 900.
+    // Cost basis AUD 3000 (USD 2000 × 1.5; fee leg ignored),
+    // proceeds AUD 4000. Gain 1000.
     #expect(result.events.count == 1)
-    #expect(result.events[0].gain == 900)
+    #expect(result.events[0].gain == 1000)
   }
 
   /// Mixed-fiat sell: 100 BHP sold for USD 3000 with AUD 50 fee,

--- a/MoolahTests/Shared/CapitalGainsCalculatorTestsMore.swift
+++ b/MoolahTests/Shared/CapitalGainsCalculatorTestsMore.swift
@@ -34,30 +34,30 @@ struct CapitalGainsCalculatorTestsMore {
       date: date(0),
       legs: [
         TransactionLeg(
-          accountId: accountId, instrument: aud, quantity: -4000, type: .transfer,
+          accountId: accountId, instrument: aud, quantity: -4000, type: .trade,
           categoryId: nil, earmarkId: nil),
         TransactionLeg(
-          accountId: accountId, instrument: bhp, quantity: 100, type: .transfer,
+          accountId: accountId, instrument: bhp, quantity: 100, type: .trade,
           categoryId: nil, earmarkId: nil),
       ])
     let buyCBA = LegTransaction(
       date: date(50),
       legs: [
         TransactionLeg(
-          accountId: accountId, instrument: aud, quantity: -5000, type: .transfer,
+          accountId: accountId, instrument: aud, quantity: -5000, type: .trade,
           categoryId: nil, earmarkId: nil),
         TransactionLeg(
-          accountId: accountId, instrument: cba, quantity: 50, type: .transfer,
+          accountId: accountId, instrument: cba, quantity: 50, type: .trade,
           categoryId: nil, earmarkId: nil),
       ])
     let sellAllBHP = LegTransaction(
       date: date(400),
       legs: [
         TransactionLeg(
-          accountId: accountId, instrument: bhp, quantity: -100, type: .transfer,
+          accountId: accountId, instrument: bhp, quantity: -100, type: .trade,
           categoryId: nil, earmarkId: nil),
         TransactionLeg(
-          accountId: accountId, instrument: aud, quantity: 5000, type: .transfer,
+          accountId: accountId, instrument: aud, quantity: 5000, type: .trade,
           categoryId: nil, earmarkId: nil),
       ])
 
@@ -88,13 +88,13 @@ struct CapitalGainsCalculatorTestsMore {
       date: date(0),
       legs: [
         TransactionLeg(
-          accountId: accountId, instrument: usd, quantity: -2000, type: .transfer,
+          accountId: accountId, instrument: usd, quantity: -2000, type: .trade,
           categoryId: nil, earmarkId: nil),
         TransactionLeg(
-          accountId: accountId, instrument: aud, quantity: -100, type: .transfer,
+          accountId: accountId, instrument: aud, quantity: -100, type: .trade,
           categoryId: nil, earmarkId: nil),
         TransactionLeg(
-          accountId: accountId, instrument: bhp, quantity: 100, type: .transfer,
+          accountId: accountId, instrument: bhp, quantity: 100, type: .trade,
           categoryId: nil, earmarkId: nil),
       ])
 
@@ -102,10 +102,10 @@ struct CapitalGainsCalculatorTestsMore {
       date: date(400),
       legs: [
         TransactionLeg(
-          accountId: accountId, instrument: bhp, quantity: -100, type: .transfer,
+          accountId: accountId, instrument: bhp, quantity: -100, type: .trade,
           categoryId: nil, earmarkId: nil),
         TransactionLeg(
-          accountId: accountId, instrument: aud, quantity: 4000, type: .transfer,
+          accountId: accountId, instrument: aud, quantity: 4000, type: .trade,
           categoryId: nil, earmarkId: nil),
       ])
 
@@ -138,10 +138,10 @@ struct CapitalGainsCalculatorTestsMore {
       date: date(0),
       legs: [
         TransactionLeg(
-          accountId: accountId, instrument: aud, quantity: -3000, type: .transfer,
+          accountId: accountId, instrument: aud, quantity: -3000, type: .trade,
           categoryId: nil, earmarkId: nil),
         TransactionLeg(
-          accountId: accountId, instrument: bhp, quantity: 100, type: .transfer,
+          accountId: accountId, instrument: bhp, quantity: 100, type: .trade,
           categoryId: nil, earmarkId: nil),
       ])
 
@@ -150,10 +150,10 @@ struct CapitalGainsCalculatorTestsMore {
       date: date(400),
       legs: [
         TransactionLeg(
-          accountId: accountId, instrument: bhp, quantity: -100, type: .transfer,
+          accountId: accountId, instrument: bhp, quantity: -100, type: .trade,
           categoryId: nil, earmarkId: nil),
         TransactionLeg(
-          accountId: accountId, instrument: usd, quantity: 3000, type: .transfer,
+          accountId: accountId, instrument: usd, quantity: 3000, type: .trade,
           categoryId: nil, earmarkId: nil),
       ])
 

--- a/MoolahTests/Shared/CapitalGainsCalculatorTestsMoreExtra.swift
+++ b/MoolahTests/Shared/CapitalGainsCalculatorTestsMoreExtra.swift
@@ -17,10 +17,10 @@ struct CapitalGainsCalculatorTestsMoreExtra {
       date: date(0),
       legs: [
         TransactionLeg(
-          accountId: accountId, instrument: aud, quantity: -3000, type: .transfer,
+          accountId: accountId, instrument: aud, quantity: -3000, type: .trade,
           categoryId: nil, earmarkId: nil),
         TransactionLeg(
-          accountId: accountId, instrument: eth, quantity: 1, type: .transfer,
+          accountId: accountId, instrument: eth, quantity: 1, type: .trade,
           categoryId: nil, earmarkId: nil),
       ])
 
@@ -28,10 +28,10 @@ struct CapitalGainsCalculatorTestsMoreExtra {
       date: date(200),
       legs: [
         TransactionLeg(
-          accountId: accountId, instrument: eth, quantity: -1, type: .transfer,
+          accountId: accountId, instrument: eth, quantity: -1, type: .trade,
           categoryId: nil, earmarkId: nil),
         TransactionLeg(
-          accountId: accountId, instrument: uni, quantity: 500, type: .transfer,
+          accountId: accountId, instrument: uni, quantity: 500, type: .trade,
           categoryId: nil, earmarkId: nil),
       ])
 
@@ -112,10 +112,10 @@ struct CapitalGainsCalculatorTestsMoreExtra {
       date: date(0),
       legs: [
         TransactionLeg(
-          accountId: accountId, instrument: usd, quantity: -2000, type: .transfer,
+          accountId: accountId, instrument: usd, quantity: -2000, type: .trade,
           categoryId: nil, earmarkId: nil),
         TransactionLeg(
-          accountId: accountId, instrument: bhp, quantity: 100, type: .transfer,
+          accountId: accountId, instrument: bhp, quantity: 100, type: .trade,
           categoryId: nil, earmarkId: nil),
       ])
 
@@ -123,10 +123,10 @@ struct CapitalGainsCalculatorTestsMoreExtra {
       date: date(400),
       legs: [
         TransactionLeg(
-          accountId: accountId, instrument: bhp, quantity: -100, type: .transfer,
+          accountId: accountId, instrument: bhp, quantity: -100, type: .trade,
           categoryId: nil, earmarkId: nil),
         TransactionLeg(
-          accountId: accountId, instrument: usd, quantity: 3000, type: .transfer,
+          accountId: accountId, instrument: usd, quantity: 3000, type: .trade,
           categoryId: nil, earmarkId: nil),
       ])
 
@@ -161,10 +161,10 @@ struct CapitalGainsCalculatorTestsMoreExtra {
       date: date(0),
       legs: [
         TransactionLeg(
-          accountId: accountId, instrument: aud, quantity: -3000, type: .transfer,
+          accountId: accountId, instrument: aud, quantity: -3000, type: .trade,
           categoryId: nil, earmarkId: nil),
         TransactionLeg(
-          accountId: accountId, instrument: eth, quantity: 1, type: .transfer,
+          accountId: accountId, instrument: eth, quantity: 1, type: .trade,
           categoryId: nil, earmarkId: nil),
       ])
 
@@ -172,10 +172,10 @@ struct CapitalGainsCalculatorTestsMoreExtra {
       date: date(200),
       legs: [
         TransactionLeg(
-          accountId: accountId, instrument: eth, quantity: -1, type: .transfer,
+          accountId: accountId, instrument: eth, quantity: -1, type: .trade,
           categoryId: nil, earmarkId: nil),
         TransactionLeg(
-          accountId: accountId, instrument: uni, quantity: 500, type: .transfer,
+          accountId: accountId, instrument: uni, quantity: 500, type: .trade,
           categoryId: nil, earmarkId: nil),
       ])
 

--- a/MoolahTests/Shared/PositionsHistoryBuilderTests.swift
+++ b/MoolahTests/Shared/PositionsHistoryBuilderTests.swift
@@ -25,8 +25,8 @@ struct PositionsHistoryBuilderTests {
     Transaction(
       date: date(daysAfterEpoch: days),
       legs: [
-        TransactionLeg(accountId: accountId, instrument: instrument, quantity: qty, type: .income),
-        TransactionLeg(accountId: accountId, instrument: aud, quantity: -fiat, type: .expense),
+        TransactionLeg(accountId: accountId, instrument: instrument, quantity: qty, type: .trade),
+        TransactionLeg(accountId: accountId, instrument: aud, quantity: -fiat, type: .trade),
       ]
     )
   }

--- a/MoolahTests/Shared/ProfitLossCalculatorTests.swift
+++ b/MoolahTests/Shared/ProfitLossCalculatorTests.swift
@@ -26,10 +26,10 @@ struct ProfitLossCalculatorTests {
       date: date(0),
       legs: [
         TransactionLeg(
-          accountId: accountId, instrument: aud, quantity: -4000, type: .transfer,
+          accountId: accountId, instrument: aud, quantity: -4000, type: .trade,
           categoryId: nil, earmarkId: nil),
         TransactionLeg(
-          accountId: accountId, instrument: bhp, quantity: 100, type: .transfer,
+          accountId: accountId, instrument: bhp, quantity: 100, type: .trade,
           categoryId: nil, earmarkId: nil),
       ])
 
@@ -61,10 +61,10 @@ struct ProfitLossCalculatorTests {
       date: date(0),
       legs: [
         TransactionLeg(
-          accountId: accountId, instrument: aud, quantity: -4000, type: .transfer,
+          accountId: accountId, instrument: aud, quantity: -4000, type: .trade,
           categoryId: nil, earmarkId: nil),
         TransactionLeg(
-          accountId: accountId, instrument: bhp, quantity: 100, type: .transfer,
+          accountId: accountId, instrument: bhp, quantity: 100, type: .trade,
           categoryId: nil, earmarkId: nil),
       ])
 
@@ -72,10 +72,10 @@ struct ProfitLossCalculatorTests {
       date: date(200),
       legs: [
         TransactionLeg(
-          accountId: accountId, instrument: bhp, quantity: -50, type: .transfer,
+          accountId: accountId, instrument: bhp, quantity: -50, type: .trade,
           categoryId: nil, earmarkId: nil),
         TransactionLeg(
-          accountId: accountId, instrument: aud, quantity: 3000, type: .transfer,
+          accountId: accountId, instrument: aud, quantity: 3000, type: .trade,
           categoryId: nil, earmarkId: nil),
       ])
 
@@ -107,10 +107,10 @@ struct ProfitLossCalculatorTests {
       date: date(0),
       legs: [
         TransactionLeg(
-          accountId: accountId, instrument: aud, quantity: -4000, type: .transfer,
+          accountId: accountId, instrument: aud, quantity: -4000, type: .trade,
           categoryId: nil, earmarkId: nil),
         TransactionLeg(
-          accountId: accountId, instrument: bhp, quantity: 100, type: .transfer,
+          accountId: accountId, instrument: bhp, quantity: 100, type: .trade,
           categoryId: nil, earmarkId: nil),
       ])
 
@@ -118,10 +118,10 @@ struct ProfitLossCalculatorTests {
       date: date(200),
       legs: [
         TransactionLeg(
-          accountId: accountId, instrument: bhp, quantity: -100, type: .transfer,
+          accountId: accountId, instrument: bhp, quantity: -100, type: .trade,
           categoryId: nil, earmarkId: nil),
         TransactionLeg(
-          accountId: accountId, instrument: aud, quantity: 5000, type: .transfer,
+          accountId: accountId, instrument: aud, quantity: 5000, type: .trade,
           categoryId: nil, earmarkId: nil),
       ])
 

--- a/MoolahTests/Shared/ProfitLossCalculatorTestsMore.swift
+++ b/MoolahTests/Shared/ProfitLossCalculatorTestsMore.swift
@@ -17,20 +17,20 @@ struct ProfitLossCalculatorTestsMore {
       date: date(0),
       legs: [
         TransactionLeg(
-          accountId: accountId, instrument: aud, quantity: -4000, type: .transfer,
+          accountId: accountId, instrument: aud, quantity: -4000, type: .trade,
           categoryId: nil, earmarkId: nil),
         TransactionLeg(
-          accountId: accountId, instrument: bhp, quantity: 100, type: .transfer,
+          accountId: accountId, instrument: bhp, quantity: 100, type: .trade,
           categoryId: nil, earmarkId: nil),
       ])
     let buyCBA = LegTransaction(
       date: date(0),
       legs: [
         TransactionLeg(
-          accountId: accountId, instrument: aud, quantity: -5000, type: .transfer,
+          accountId: accountId, instrument: aud, quantity: -5000, type: .trade,
           categoryId: nil, earmarkId: nil),
         TransactionLeg(
-          accountId: accountId, instrument: cba, quantity: 50, type: .transfer,
+          accountId: accountId, instrument: cba, quantity: 50, type: .trade,
           categoryId: nil, earmarkId: nil),
       ])
 
@@ -62,21 +62,21 @@ struct ProfitLossCalculatorTestsMore {
       date: date(0),
       legs: [
         TransactionLeg(
-          accountId: accountId, instrument: aud, quantity: -4000, type: .transfer,
+          accountId: accountId, instrument: aud, quantity: -4000, type: .trade,
           categoryId: nil, earmarkId: nil),
         TransactionLeg(
-          accountId: accountId, instrument: bhp, quantity: 100, type: .transfer,
+          accountId: accountId, instrument: bhp, quantity: 100, type: .trade,
           categoryId: nil, earmarkId: nil),
       ])
     let buyETH = LegTransaction(
       date: date(0),
       legs: [
         TransactionLeg(
-          accountId: accountId, instrument: aud, quantity: -2000, type: .transfer,
+          accountId: accountId, instrument: aud, quantity: -2000, type: .trade,
           categoryId: nil, earmarkId: nil),
         TransactionLeg(
           accountId: accountId, instrument: eth,
-          quantity: dec("1.0"), type: .transfer,
+          quantity: dec("1.0"), type: .trade,
           categoryId: nil, earmarkId: nil),
       ])
 
@@ -98,10 +98,12 @@ struct ProfitLossCalculatorTestsMore {
     #expect(ethPL?.unrealizedGain == 500)
   }
 
-  /// A multi-currency purchase (USD 2000 + AUD 100 fee) must aggregate
-  /// into the profile currency before contributing to `totalInvested`.
-  /// Without the conversion, USD and AUD quantities would be summed as
-  /// raw decimals and produce a meaningless 2100 rather than 3100 AUD.
+  /// A multi-currency purchase (USD 2000 + AUD 100 brokerage fee) where
+  /// the fee is modelled as an `.expense` leg (as per the current design).
+  /// The classifier sees only the two `.trade` legs (USD outflow → BHP) and
+  /// derives cost basis from those. The AUD 100 fee is excluded from cost
+  /// basis per the design documented at
+  /// https://github.com/ajsutton/moolah-native/issues/558.
   @Test
   func mixedFiatLegs_totalInvestedConvertsEachLegToProfileCurrency() async throws {
     let bhp = stockInstrument("BHP")
@@ -112,13 +114,13 @@ struct ProfitLossCalculatorTestsMore {
       date: date(0),
       legs: [
         TransactionLeg(
-          accountId: accountId, instrument: usd, quantity: -2000, type: .transfer,
+          accountId: accountId, instrument: usd, quantity: -2000, type: .trade,
           categoryId: nil, earmarkId: nil),
         TransactionLeg(
-          accountId: accountId, instrument: aud, quantity: -100, type: .transfer,
+          accountId: accountId, instrument: aud, quantity: -100, type: .expense,
           categoryId: nil, earmarkId: nil),
         TransactionLeg(
-          accountId: accountId, instrument: bhp, quantity: 100, type: .transfer,
+          accountId: accountId, instrument: bhp, quantity: 100, type: .trade,
           categoryId: nil, earmarkId: nil),
       ])
 
@@ -135,12 +137,12 @@ struct ProfitLossCalculatorTestsMore {
     )
 
     #expect(results.count == 1)
-    // totalInvested: USD 2000×1.5 + AUD 100 = AUD 3100.
+    // totalInvested: USD 2000×1.5 = AUD 3000 (fee leg excluded from cost basis).
     // currentValue: 100 × AUD 50 = AUD 5000.
-    // unrealizedGain: 5000 − 3100 = 1900.
-    #expect(results[0].totalInvested == 3100)
+    // unrealizedGain: 5000 − 3000 = 2000.
+    #expect(results[0].totalInvested == 3000)
     #expect(results[0].currentValue == 5000)
-    #expect(results[0].unrealizedGain == 1900)
+    #expect(results[0].unrealizedGain == 2000)
   }
 
   // MARK: - Date-sensitive routing
@@ -165,10 +167,10 @@ struct ProfitLossCalculatorTestsMore {
       date: date(0),
       legs: [
         TransactionLeg(
-          accountId: accountId, instrument: usd, quantity: -2000, type: .transfer,
+          accountId: accountId, instrument: usd, quantity: -2000, type: .trade,
           categoryId: nil, earmarkId: nil),
         TransactionLeg(
-          accountId: accountId, instrument: bhp, quantity: 100, type: .transfer,
+          accountId: accountId, instrument: bhp, quantity: 100, type: .trade,
           categoryId: nil, earmarkId: nil),
       ])
 

--- a/MoolahTests/Shared/TradeEventClassifierTests.swift
+++ b/MoolahTests/Shared/TradeEventClassifierTests.swift
@@ -58,9 +58,11 @@ struct TradeEventClassifierTests {
       legs: legs, on: date, hostCurrency: aud, conversionService: service)
     #expect(result.buys.count == 1)
     #expect(result.buys[0].instrument == btc)
+    #expect(result.buys[0].quantity == Decimal(string: "0.1"))
     #expect(result.buys[0].costPerUnit == Decimal(60_000))
     #expect(result.sells.count == 1)
     #expect(result.sells[0].instrument == eth)
+    #expect(result.sells[0].quantity == 2)
     #expect(result.sells[0].proceedsPerUnit == Decimal(3_000))
   }
 
@@ -70,6 +72,7 @@ struct TradeEventClassifierTests {
     let result = try await TradeEventClassifier.classify(
       legs: legs, on: date, hostCurrency: aud,
       conversionService: FixedConversionService(rates: [:]))
+    try #require(result.buys.count == 1)
     #expect(result.buys[0].costPerUnit == 40)  // 4000/100, not (4000+10)/100
   }
 
@@ -105,6 +108,7 @@ struct TradeEventClassifierTests {
     let result = try await TradeEventClassifier.classify(
       legs: [tradeLeg(aud, -100)], on: date, hostCurrency: aud,
       conversionService: FixedConversionService(rates: [:]))
-    #expect(result.buys.isEmpty && result.sells.isEmpty)
+    #expect(result.buys.isEmpty)
+    #expect(result.sells.isEmpty)
   }
 }

--- a/MoolahTests/Shared/TradeEventClassifierTests.swift
+++ b/MoolahTests/Shared/TradeEventClassifierTests.swift
@@ -12,17 +12,22 @@ struct TradeEventClassifierTests {
   let btc = Instrument.crypto(
     chainId: 0, contractAddress: nil, symbol: "BTC", name: "Bitcoin", decimals: 8)
   let date = Date(timeIntervalSince1970: 1_700_000_000)
+  let account = UUID()
 
-  @Test("fiat-paired buy: emits one buy event with cost-per-unit derived from fiat outflow")
-  func fiatPairedBuy() async throws {
-    let legs = [
-      TransactionLeg(accountId: UUID(), instrument: bhp, quantity: 100, type: .income),
-      TransactionLeg(accountId: UUID(), instrument: aud, quantity: -4_000, type: .expense),
-    ]
+  private func tradeLeg(_ instr: Instrument, _ qty: Decimal) -> TransactionLeg {
+    TransactionLeg(accountId: account, instrument: instr, quantity: qty, type: .trade)
+  }
+
+  private func feeLeg(_ instr: Instrument, _ qty: Decimal) -> TransactionLeg {
+    TransactionLeg(accountId: account, instrument: instr, quantity: qty, type: .expense)
+  }
+
+  @Test("buy: positive trade leg + negative trade leg")
+  func buy() async throws {
+    let legs = [tradeLeg(aud, -4_000), tradeLeg(bhp, 100)]
     let result = try await TradeEventClassifier.classify(
       legs: legs, on: date, hostCurrency: aud,
-      conversionService: FixedConversionService(rates: [:])
-    )
+      conversionService: FixedConversionService(rates: [:]))
     #expect(result.buys.count == 1)
     #expect(result.buys[0].instrument == bhp)
     #expect(result.buys[0].quantity == 100)
@@ -30,57 +35,76 @@ struct TradeEventClassifierTests {
     #expect(result.sells.isEmpty)
   }
 
-  @Test("fiat-paired sell: emits one sell event with proceeds-per-unit")
-  func fiatPairedSell() async throws {
-    let legs = [
-      TransactionLeg(accountId: UUID(), instrument: bhp, quantity: -50, type: .income),
-      TransactionLeg(accountId: UUID(), instrument: aud, quantity: 2_500, type: .income),
-    ]
+  @Test("sell: positive fiat + negative non-fiat")
+  func sell() async throws {
+    let legs = [tradeLeg(aud, 2_500), tradeLeg(bhp, -50)]
     let result = try await TradeEventClassifier.classify(
       legs: legs, on: date, hostCurrency: aud,
-      conversionService: FixedConversionService(rates: [:])
-    )
+      conversionService: FixedConversionService(rates: [:]))
     #expect(result.sells.count == 1)
     #expect(result.sells[0].instrument == bhp)
     #expect(result.sells[0].quantity == 50)
     #expect(result.sells[0].proceedsPerUnit == 50)
   }
 
-  @Test("crypto-to-crypto swap: emits one buy + one sell, each priced via the conversion service")
+  @Test("non-fiat swap is priced via host-currency conversion")
   func swap() async throws {
-    let legs = [
-      TransactionLeg(accountId: UUID(), instrument: eth, quantity: -2, type: .income),
-      TransactionLeg(accountId: UUID(), instrument: btc, quantity: 0.1, type: .income),
-    ]
+    let legs = [tradeLeg(eth, -2), tradeLeg(btc, 0.1)]
     let service = FixedConversionService(rates: [
-      eth.id: Decimal(3_000),  // 1 ETH = 3000 AUD
-      btc.id: Decimal(60_000),  // 1 BTC = 60000 AUD
+      eth.id: Decimal(3_000),
+      btc.id: Decimal(60_000),
     ])
     let result = try await TradeEventClassifier.classify(
-      legs: legs, on: date, hostCurrency: aud, conversionService: service
-    )
-    #expect(result.sells.count == 1)
-    #expect(result.sells[0].instrument == eth)
-    #expect(result.sells[0].quantity == 2)
-    #expect(result.sells[0].proceedsPerUnit == 3_000)
-
+      legs: legs, on: date, hostCurrency: aud, conversionService: service)
     #expect(result.buys.count == 1)
     #expect(result.buys[0].instrument == btc)
-    #expect(result.buys[0].quantity == dec("0.1"))
-    #expect(result.buys[0].costPerUnit == 60_000)
+    #expect(result.buys[0].costPerUnit == Decimal(60_000))
+    #expect(result.sells.count == 1)
+    #expect(result.sells[0].instrument == eth)
+    #expect(result.sells[0].proceedsPerUnit == Decimal(3_000))
   }
 
-  @Test("all-fiat transaction: returns empty classification")
-  func allFiatTransaction() async throws {
+  @Test("fee legs are ignored")
+  func feeIgnored() async throws {
+    let legs = [tradeLeg(aud, -4_000), tradeLeg(bhp, 100), feeLeg(aud, -10)]
+    let result = try await TradeEventClassifier.classify(
+      legs: legs, on: date, hostCurrency: aud,
+      conversionService: FixedConversionService(rates: [:]))
+    #expect(result.buys[0].costPerUnit == 40)  // 4000/100, not (4000+10)/100
+  }
+
+  @Test("non-trade-typed legs are ignored entirely (older custom shapes)")
+  func nonTradeLegsIgnored() async throws {
     let legs = [
-      TransactionLeg(accountId: UUID(), instrument: aud, quantity: -100, type: .expense),
-      TransactionLeg(accountId: UUID(), instrument: aud, quantity: 100, type: .income),
+      TransactionLeg(
+        accountId: account, instrument: aud,
+        quantity: -4_000, type: .expense),
+      TransactionLeg(
+        accountId: account, instrument: bhp,
+        quantity: 100, type: .income),
     ]
     let result = try await TradeEventClassifier.classify(
       legs: legs, on: date, hostCurrency: aud,
-      conversionService: FixedConversionService(rates: [:])
-    )
+      conversionService: FixedConversionService(rates: [:]))
     #expect(result.buys.isEmpty)
     #expect(result.sells.isEmpty)
+  }
+
+  @Test("zero-quantity trade leg is skipped (no divide-by-zero)")
+  func zeroQuantityTradeLeg() async throws {
+    let legs = [tradeLeg(aud, -4_000), tradeLeg(bhp, 0)]
+    let result = try await TradeEventClassifier.classify(
+      legs: legs, on: date, hostCurrency: aud,
+      conversionService: FixedConversionService(rates: [:]))
+    #expect(result.buys.isEmpty)
+    #expect(result.sells.isEmpty)
+  }
+
+  @Test("fewer than two .trade legs returns empty")
+  func fewerThanTwo() async throws {
+    let result = try await TradeEventClassifier.classify(
+      legs: [tradeLeg(aud, -100)], on: date, hostCurrency: aud,
+      conversionService: FixedConversionService(rates: [:]))
+    #expect(result.buys.isEmpty && result.sells.isEmpty)
   }
 }

--- a/MoolahTests/Shared/TransactionDraftForwardSwitchTests.swift
+++ b/MoolahTests/Shared/TransactionDraftForwardSwitchTests.swift
@@ -39,8 +39,11 @@ struct TransactionDraftForwardSwitchTests {
     #expect(paid.instrumentId == aud.id)
   }
 
-  @Test("Expense → Trade: existing leg becomes Paid, Received added at 0")
+  @Test("Expense → Trade: existing leg becomes Paid; sign re-emitted for trade display")
   func expenseToTrade() throws {
+    // Expense's `displaysNegated == true` means amountText "300" represents
+    // a stored quantity of -300. `.trade` doesn't negate, so the carried
+    // amountText flips to "-300" so the same -300 round-trips through trade.
     var draft = TransactionDraft(accountId: acctA, instrumentId: aud.id)
     draft.legDrafts = [
       TransactionDraft.LegDraft(
@@ -52,7 +55,7 @@ struct TransactionDraftForwardSwitchTests {
     let receivedIndex = try #require(draft.receivedLegIndex)
     let paid = draft.legDrafts[paidIndex]
     let received = draft.legDrafts[receivedIndex]
-    #expect(paid.amountText == "300")
+    #expect(paid.amountText == "-300")
     #expect(received.amountText == "0")
   }
 

--- a/MoolahTests/Shared/TransactionDraftForwardSwitchTests.swift
+++ b/MoolahTests/Shared/TransactionDraftForwardSwitchTests.swift
@@ -1,0 +1,103 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("TransactionDraft forward switch to Trade")
+struct TransactionDraftForwardSwitchTests {
+  let aud = Instrument.AUD
+  let usd = Instrument.fiat(code: "USD")
+  let vgs = Instrument.stock(ticker: "VGS.AX", exchange: "ASX", name: "VGS")
+  let acctA = UUID()
+  let acctB = UUID()
+
+  private func accountsAUD() -> Accounts {
+    Accounts(from: [
+      Account(id: acctA, name: "A", type: .bank, instrument: aud, positions: []),
+      Account(id: acctB, name: "B", type: .bank, instrument: aud, positions: []),
+    ])
+  }
+
+  @Test("Income → Trade: existing leg becomes Received, Paid added at 0 in account currency")
+  func incomeToTrade() throws {
+    var draft = TransactionDraft(accountId: acctA, instrumentId: aud.id)
+    draft.legDrafts = [
+      TransactionDraft.LegDraft(
+        type: .income, accountId: acctA, amountText: "3500",
+        categoryId: nil, categoryText: "", earmarkId: nil, instrumentId: aud.id)
+    ]
+    draft.switchToTrade(accounts: accountsAUD())
+    #expect(draft.legDrafts.count == 2)
+    #expect(draft.legDrafts.allSatisfy { $0.type == .trade })
+    let receivedIndex = try #require(draft.receivedLegIndex)
+    let received = draft.legDrafts[receivedIndex]
+    #expect(received.amountText == "3500")
+    #expect(received.instrumentId == aud.id)
+    let paidIndex = try #require(draft.paidLegIndex)
+    let paid = draft.legDrafts[paidIndex]
+    #expect(paid.amountText == "0")
+    #expect(paid.instrumentId == aud.id)
+  }
+
+  @Test("Expense → Trade: existing leg becomes Paid, Received added at 0")
+  func expenseToTrade() throws {
+    var draft = TransactionDraft(accountId: acctA, instrumentId: aud.id)
+    draft.legDrafts = [
+      TransactionDraft.LegDraft(
+        type: .expense, accountId: acctA, amountText: "300",
+        categoryId: nil, categoryText: "", earmarkId: nil, instrumentId: aud.id)
+    ]
+    draft.switchToTrade(accounts: accountsAUD())
+    let paidIndex = try #require(draft.paidLegIndex)
+    let receivedIndex = try #require(draft.receivedLegIndex)
+    let paid = draft.legDrafts[paidIndex]
+    let received = draft.legDrafts[receivedIndex]
+    #expect(paid.amountText == "300")
+    #expect(received.amountText == "0")
+  }
+
+  @Test("Transfer → Trade: counterpart leg dropped, then Expense flow")
+  func transferToTrade() {
+    var draft = TransactionDraft(accountId: acctA, instrumentId: aud.id)
+    draft.legDrafts = [
+      TransactionDraft.LegDraft(
+        type: .transfer, accountId: acctA, amountText: "500",
+        categoryId: nil, categoryText: "", earmarkId: nil, instrumentId: aud.id),
+      TransactionDraft.LegDraft(
+        type: .transfer, accountId: acctB, amountText: "500",
+        categoryId: nil, categoryText: "", earmarkId: nil, instrumentId: aud.id),
+    ]
+    draft.switchToTrade(accounts: accountsAUD())
+    #expect(draft.legDrafts.count == 2)
+    #expect(draft.legDrafts.allSatisfy { $0.accountId == acctA })
+    #expect(draft.legDrafts.allSatisfy { $0.type == .trade })
+  }
+
+  @Test("Custom (already trade-shaped) → Trade: no structural change, isCustom flips")
+  func customToTrade() {
+    var draft = TransactionDraft(accountId: acctA, instrumentId: aud.id)
+    draft.isCustom = true
+    draft.legDrafts = [
+      TransactionDraft.LegDraft(
+        type: .trade, accountId: acctA, amountText: "300",
+        categoryId: nil, categoryText: "", earmarkId: nil, instrumentId: aud.id),
+      TransactionDraft.LegDraft(
+        type: .trade, accountId: acctA, amountText: "20",
+        categoryId: nil, categoryText: "", earmarkId: nil, instrumentId: vgs.id),
+    ]
+    draft.switchToTrade(accounts: accountsAUD())
+    #expect(draft.isCustom == false)
+    #expect(draft.legDrafts.count == 2)
+  }
+
+  @Test("canSwitchToTrade reflects shape compatibility")
+  func canSwitch() {
+    var draft = TransactionDraft(accountId: acctA, instrumentId: aud.id)
+    draft.legDrafts = [
+      TransactionDraft.LegDraft(
+        type: .income, accountId: acctA, amountText: "100",
+        categoryId: nil, categoryText: "", earmarkId: nil, instrumentId: aud.id)
+    ]
+    #expect(draft.canSwitchToTrade(accounts: accountsAUD()) == true)
+  }
+}

--- a/MoolahTests/Shared/TransactionDraftReverseSwitchTests.swift
+++ b/MoolahTests/Shared/TransactionDraftReverseSwitchTests.swift
@@ -1,0 +1,79 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("TransactionDraft reverse switch from Trade")
+struct TransactionDraftReverseSwitchTests {
+  let aud = Instrument.AUD
+  let vgs = Instrument.stock(ticker: "VGS.AX", exchange: "ASX", name: "VGS")
+  let acctA = UUID()
+  let acctB = UUID()
+
+  private func accounts() -> Accounts {
+    Accounts(from: [
+      Account(id: acctA, name: "A", type: .bank, instrument: aud, positions: []),
+      Account(id: acctB, name: "B", type: .bank, instrument: aud, positions: []),
+    ])
+  }
+
+  private func tradeDraft(withFee: Bool = false) -> TransactionDraft {
+    var draft = TransactionDraft(accountId: acctA, instrumentId: aud.id)
+    draft.legDrafts = [
+      TransactionDraft.LegDraft(
+        type: .trade, accountId: acctA, amountText: "300",
+        categoryId: nil, categoryText: "", earmarkId: nil, instrumentId: aud.id),
+      TransactionDraft.LegDraft(
+        type: .trade, accountId: acctA, amountText: "20",
+        categoryId: nil, categoryText: "", earmarkId: nil, instrumentId: vgs.id),
+    ]
+    if withFee {
+      draft.legDrafts.append(
+        TransactionDraft.LegDraft(
+          type: .expense, accountId: acctA, amountText: "10",
+          categoryId: nil, categoryText: "", earmarkId: nil, instrumentId: aud.id))
+    }
+    return draft
+  }
+
+  @Test("Trade → Income: keep Received leg, retype, drop Paid + fees")
+  func toIncome() {
+    var draft = tradeDraft(withFee: true)
+    draft.switchFromTrade(to: .income, accounts: accounts())
+    #expect(draft.legDrafts.count == 1)
+    #expect(draft.legDrafts[0].type == .income)
+    #expect(draft.legDrafts[0].amountText == "20")
+    #expect(draft.legDrafts[0].instrumentId == vgs.id)
+    #expect(draft.legDrafts[0].accountId == acctA)
+  }
+
+  @Test("Trade → Expense: keep Paid leg, retype, drop Received + fees")
+  func toExpense() {
+    var draft = tradeDraft(withFee: true)
+    draft.switchFromTrade(to: .expense, accounts: accounts())
+    #expect(draft.legDrafts.count == 1)
+    #expect(draft.legDrafts[0].type == .expense)
+    #expect(draft.legDrafts[0].amountText == "300")
+    #expect(draft.legDrafts[0].instrumentId == aud.id)
+  }
+
+  @Test("Trade → Transfer: keep Paid leg + add counterpart on a different account")
+  func toTransfer() {
+    var draft = tradeDraft(withFee: false)
+    draft.switchFromTrade(to: .transfer, accounts: accounts())
+    #expect(draft.legDrafts.count == 2)
+    #expect(draft.legDrafts.allSatisfy { $0.type == .transfer })
+    let acctIds = Set(draft.legDrafts.compactMap(\.accountId))
+    #expect(acctIds == Set([acctA, acctB]))
+  }
+
+  @Test("Trade → Custom: lossless, all legs preserved with .trade types")
+  func toCustom() {
+    var draft = tradeDraft(withFee: true)
+    draft.switchFromTrade(to: nil, accounts: accounts())
+    #expect(draft.isCustom == true)
+    #expect(draft.legDrafts.count == 3)
+    #expect(draft.legDrafts.filter { $0.type == .trade }.count == 2)
+    #expect(draft.legDrafts.filter { $0.type == .expense }.count == 1)
+  }
+}

--- a/MoolahTests/Shared/TransactionDraftReverseSwitchTests.swift
+++ b/MoolahTests/Shared/TransactionDraftReverseSwitchTests.swift
@@ -18,10 +18,12 @@ struct TransactionDraftReverseSwitchTests {
   }
 
   private func tradeDraft(withFee: Bool = false) -> TransactionDraft {
+    // Buy-shaped fixture: cash leg quantity -300 (literal in amountText since
+    // `displaysNegated(.trade) == false`), position leg quantity +20.
     var draft = TransactionDraft(accountId: acctA, instrumentId: aud.id)
     draft.legDrafts = [
       TransactionDraft.LegDraft(
-        type: .trade, accountId: acctA, amountText: "300",
+        type: .trade, accountId: acctA, amountText: "-300",
         categoryId: nil, categoryText: "", earmarkId: nil, instrumentId: aud.id),
       TransactionDraft.LegDraft(
         type: .trade, accountId: acctA, amountText: "20",

--- a/MoolahTests/Shared/TransactionDraftRoundTripTests.swift
+++ b/MoolahTests/Shared/TransactionDraftRoundTripTests.swift
@@ -271,4 +271,5 @@ struct TransactionDraftRoundTripTests {
     #expect(roundTripped.legs[2].type == .transfer)
     #expect(roundTripped.legs[2].quantity == Decimal(50))
   }
+
 }

--- a/MoolahTests/Shared/TransactionDraftTradeAccessorsTests.swift
+++ b/MoolahTests/Shared/TransactionDraftTradeAccessorsTests.swift
@@ -1,0 +1,71 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("TransactionDraft trade accessors")
+struct TransactionDraftTradeAccessorsTests {
+  let aud = Instrument.AUD
+  let vgs = Instrument.stock(ticker: "VGS.AX", exchange: "ASX", name: "VGS")
+  let account = UUID()
+
+  private func tradeDraft(extraFees: [TransactionDraft.LegDraft] = []) -> TransactionDraft {
+    var draft = TransactionDraft(accountId: account, instrumentId: aud.id)
+    draft.legDrafts =
+      [
+        TransactionDraft.LegDraft(
+          type: .trade, accountId: account, amountText: "300",
+          categoryId: nil, categoryText: "", earmarkId: nil, instrumentId: aud.id),
+        TransactionDraft.LegDraft(
+          type: .trade, accountId: account, amountText: "20",
+          categoryId: nil, categoryText: "", earmarkId: nil, instrumentId: vgs.id),
+      ] + extraFees
+    return draft
+  }
+
+  @Test("paid index is the first .trade leg")
+  func paidLegIndex() {
+    let draft = tradeDraft()
+    #expect(draft.paidLegIndex == 0)
+  }
+
+  @Test("received index is the second .trade leg")
+  func receivedLegIndex() {
+    let draft = tradeDraft()
+    #expect(draft.receivedLegIndex == 1)
+  }
+
+  @Test("feeIndices returns the .expense legs in order")
+  func feeIndices() {
+    let fee1 = TransactionDraft.LegDraft(
+      type: .expense, accountId: account, amountText: "10",
+      categoryId: nil, categoryText: "", earmarkId: nil, instrumentId: aud.id)
+    let fee2 = TransactionDraft.LegDraft(
+      type: .expense, accountId: account, amountText: "0.5",
+      categoryId: nil, categoryText: "", earmarkId: nil, instrumentId: aud.id)
+    let draft = tradeDraft(extraFees: [fee1, fee2])
+    #expect(draft.feeIndices == [2, 3])
+  }
+
+  @Test("appendFee adds an expense leg with default 0 amount")
+  func appendFee() {
+    var draft = tradeDraft()
+    draft.appendFee(defaultInstrumentId: aud.id)
+    #expect(draft.legDrafts.count == 3)
+    #expect(draft.legDrafts[2].type == .expense)
+    #expect(draft.legDrafts[2].amountText == "0")
+    #expect(draft.legDrafts[2].instrumentId == aud.id)
+    #expect(draft.legDrafts[2].accountId == account)
+  }
+
+  @Test("removeFee at index drops only that leg")
+  func removeFeeIndex() {
+    let fee = TransactionDraft.LegDraft(
+      type: .expense, accountId: account, amountText: "10",
+      categoryId: nil, categoryText: "", earmarkId: nil, instrumentId: aud.id)
+    var draft = tradeDraft(extraFees: [fee])
+    draft.removeFee(at: 2)
+    #expect(draft.legDrafts.count == 2)
+    #expect(draft.legDrafts.allSatisfy { $0.type == .trade })
+  }
+}

--- a/MoolahTests/Shared/TransactionDraftTradeRoundTripTests.swift
+++ b/MoolahTests/Shared/TransactionDraftTradeRoundTripTests.swift
@@ -1,0 +1,58 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("TransactionDraft trade leg sign round-trips")
+struct TransactionDraftTradeRoundTripTests {
+  @Test("trade transaction round-trips with paid leg negative, received leg positive")
+  func tradeRoundTrip() throws {
+    let aud = Instrument.AUD
+    let vgs = Instrument.stock(ticker: "VGS.AX", exchange: "ASX", name: "VGS")
+    let account = UUID()
+    let original = Transaction(
+      id: UUID(),
+      date: Date(),
+      legs: [
+        TransactionLeg(accountId: account, instrument: aud, quantity: -300, type: .trade),
+        TransactionLeg(accountId: account, instrument: vgs, quantity: 20, type: .trade),
+      ]
+    )
+
+    let draft = TransactionDraft(from: original)
+    // amountText should be positive for both legs.
+    // AUD has 2 decimal places; VGS stock has 0 by default.
+    #expect(draft.legDrafts[0].amountText == "300.00")
+    #expect(draft.legDrafts[1].amountText == "20")
+
+    let rebuilt = try #require(
+      draft.toTransaction(
+        id: original.id,
+        availableInstruments: [aud, vgs]))
+    #expect(rebuilt.legs[0].quantity == Decimal(-300))
+    #expect(rebuilt.legs[1].quantity == Decimal(20))
+  }
+
+  @Test("trade transaction with positive amountText input still serialises Paid as negative")
+  func tradePaidStaysNegativeEvenIfUserInput() throws {
+    let aud = Instrument.AUD
+    let vgs = Instrument.stock(ticker: "VGS.AX", exchange: "ASX", name: "VGS")
+    let account = UUID()
+    // Construct a draft with positive amountText on both legs — which is
+    // what the editor actually stores after Task 14.
+    var draft = TransactionDraft(accountId: account, instrumentId: aud.id)
+    draft.legDrafts = [
+      TransactionDraft.LegDraft(
+        type: .trade, accountId: account, amountText: "300",
+        categoryId: nil, categoryText: "", earmarkId: nil, instrumentId: aud.id),
+      TransactionDraft.LegDraft(
+        type: .trade, accountId: account, amountText: "20",
+        categoryId: nil, categoryText: "", earmarkId: nil, instrumentId: vgs.id),
+    ]
+
+    let rebuilt = try #require(
+      draft.toTransaction(id: UUID(), availableInstruments: [aud, vgs]))
+    #expect(rebuilt.legs[0].quantity == Decimal(-300))  // paid leg negative
+    #expect(rebuilt.legs[1].quantity == Decimal(20))  // received leg positive
+  }
+}

--- a/MoolahTests/Shared/TransactionDraftTradeRoundTripTests.swift
+++ b/MoolahTests/Shared/TransactionDraftTradeRoundTripTests.swift
@@ -5,8 +5,8 @@ import Testing
 
 @Suite("TransactionDraft trade leg sign round-trips")
 struct TransactionDraftTradeRoundTripTests {
-  @Test("trade transaction round-trips with paid leg negative, received leg positive")
-  func tradeRoundTrip() throws {
+  @Test("trade transaction round-trips signs literally — buy")
+  func tradeRoundTripBuy() throws {
     let aud = Instrument.AUD
     let vgs = Instrument.stock(ticker: "VGS.AX", exchange: "ASX", name: "VGS")
     let account = UUID()
@@ -20,9 +20,9 @@ struct TransactionDraftTradeRoundTripTests {
     )
 
     let draft = TransactionDraft(from: original)
-    // amountText should be positive for both legs.
-    // AUD has 2 decimal places; VGS stock has 0 by default.
-    #expect(draft.legDrafts[0].amountText == "300.00")
+    // .trade legs preserve sign in amountText (displaysNegated == false).
+    // AUD has 2 decimal places; VGS stock has 0.
+    #expect(draft.legDrafts[0].amountText == "-300.00")
     #expect(draft.legDrafts[1].amountText == "20")
 
     let rebuilt = try #require(
@@ -33,26 +33,54 @@ struct TransactionDraftTradeRoundTripTests {
     #expect(rebuilt.legs[1].quantity == Decimal(20))
   }
 
-  @Test("trade transaction with positive amountText input still serialises Paid as negative")
-  func tradePaidStaysNegativeEvenIfUserInput() throws {
+  @Test("trade transaction round-trips signs literally — reversal with unconventional signs")
+  func tradeRoundTripReversal() throws {
+    // Trade reversal: both legs flip sign vs a normal buy. The model must
+    // preserve user-entered signs verbatim — see CLAUDE.md "Monetary Sign
+    // Convention" and feedback_no_abs_on_trade_legs.md.
     let aud = Instrument.AUD
     let vgs = Instrument.stock(ticker: "VGS.AX", exchange: "ASX", name: "VGS")
     let account = UUID()
-    // Construct a draft with positive amountText on both legs — which is
-    // what the editor actually stores after Task 14.
+    let original = Transaction(
+      id: UUID(),
+      date: Date(),
+      legs: [
+        TransactionLeg(accountId: account, instrument: aud, quantity: 300, type: .trade),
+        TransactionLeg(accountId: account, instrument: vgs, quantity: -20, type: .trade),
+      ]
+    )
+
+    let draft = TransactionDraft(from: original)
+    #expect(draft.legDrafts[0].amountText == "300.00")
+    #expect(draft.legDrafts[1].amountText == "-20")
+
+    let rebuilt = try #require(
+      draft.toTransaction(
+        id: original.id,
+        availableInstruments: [aud, vgs]))
+    #expect(rebuilt.legs[0].quantity == Decimal(300))
+    #expect(rebuilt.legs[1].quantity == Decimal(-20))
+  }
+
+  @Test("trade leg amountText is parsed literally — no abs, no sign-by-position")
+  func tradeAmountTextLiteral() throws {
+    let aud = Instrument.AUD
+    let vgs = Instrument.stock(ticker: "VGS.AX", exchange: "ASX", name: "VGS")
+    let account = UUID()
     var draft = TransactionDraft(accountId: account, instrumentId: aud.id)
+    // First leg literal "+300", second literal "-20" — both signs preserved.
     draft.legDrafts = [
       TransactionDraft.LegDraft(
         type: .trade, accountId: account, amountText: "300",
         categoryId: nil, categoryText: "", earmarkId: nil, instrumentId: aud.id),
       TransactionDraft.LegDraft(
-        type: .trade, accountId: account, amountText: "20",
+        type: .trade, accountId: account, amountText: "-20",
         categoryId: nil, categoryText: "", earmarkId: nil, instrumentId: vgs.id),
     ]
 
     let rebuilt = try #require(
       draft.toTransaction(id: UUID(), availableInstruments: [aud, vgs]))
-    #expect(rebuilt.legs[0].quantity == Decimal(-300))  // paid leg negative
-    #expect(rebuilt.legs[1].quantity == Decimal(20))  // received leg positive
+    #expect(rebuilt.legs[0].quantity == Decimal(300))
+    #expect(rebuilt.legs[1].quantity == Decimal(-20))
   }
 }

--- a/MoolahTests/UITestSupport/UITestSeedHydratorTests.swift
+++ b/MoolahTests/UITestSupport/UITestSeedHydratorTests.swift
@@ -199,6 +199,55 @@ final class UITestSeedHydratorTests: XCTestCase {
     }
   }
 
+  // MARK: - tradeReady seed
+
+  func testHydrateTradeReadySeedsTheProfile() throws {
+    let profile = try XCTUnwrap(
+      try UITestSeedHydrator.hydrate(.tradeReady, into: containerManager))
+
+    XCTAssertEqual(profile.id, UITestFixtures.TradeReady.profileId)
+    XCTAssertEqual(profile.currencyCode, UITestFixtures.TradeReady.profileCurrencyCode)
+  }
+
+  func testHydrateTradeReadySeedsBrokerageAccount() throws {
+    let profile = try XCTUnwrap(
+      try UITestSeedHydrator.hydrate(.tradeReady, into: containerManager))
+    let container = try containerManager.container(for: profile.id)
+    let context = ModelContext(container)
+
+    let accounts = try context.fetch(FetchDescriptor<AccountRecord>())
+    XCTAssertEqual(accounts.count, 1, "expected exactly one account")
+    let account = try XCTUnwrap(accounts.first)
+    XCTAssertEqual(account.id, UITestFixtures.TradeReady.brokerageAccountId)
+    XCTAssertEqual(account.name, UITestFixtures.TradeReady.brokerageAccountName)
+  }
+
+  func testHydrateTradeReadySeedsVgsaxInstrument() throws {
+    let profile = try XCTUnwrap(
+      try UITestSeedHydrator.hydrate(.tradeReady, into: containerManager))
+    let container = try containerManager.container(for: profile.id)
+    let context = ModelContext(container)
+
+    let instruments = try context.fetch(FetchDescriptor<InstrumentRecord>())
+    let ids = Set(instruments.map(\.id))
+    XCTAssertTrue(
+      ids.contains(UITestFixtures.TradeReady.vgsaxInstrumentId),
+      "VGS.AX instrument must be registered")
+  }
+
+  func testHydrateTradeReadySeedsBrokerageCategory() throws {
+    let profile = try XCTUnwrap(
+      try UITestSeedHydrator.hydrate(.tradeReady, into: containerManager))
+    let container = try containerManager.container(for: profile.id)
+    let context = ModelContext(container)
+
+    let categories = try context.fetch(FetchDescriptor<CategoryRecord>())
+    XCTAssertEqual(categories.count, 1, "expected exactly one category")
+    let cat = try XCTUnwrap(categories.first)
+    XCTAssertEqual(cat.id, UITestFixtures.TradeReady.brokerageCategoryId)
+    XCTAssertEqual(cat.name, UITestFixtures.TradeReady.brokerageCategoryName)
+  }
+
   // MARK: - Determinism
 
   func testHydrateIsIdempotentWhenRunTwice() throws {

--- a/MoolahUITests_macOS/Helpers/MoolahUITestCase+Artefacts.swift
+++ b/MoolahUITests_macOS/Helpers/MoolahUITestCase+Artefacts.swift
@@ -208,6 +208,8 @@ extension MoolahUITestCase {
       lines.append("# SyncProgress driven to .upToDate with pendingUploads=12 then settled")
     case .cryptoCatalogPreloaded:
       appendCryptoCatalogPreloadedFixtures(into: &lines)
+    case .tradeReady:
+      appendTradeReadyFixtures(into: &lines)
     }
     return lines.joined(separator: "\n") + "\n"
   }
@@ -230,6 +232,21 @@ extension MoolahUITestCase {
     lines.append("resolve.coingeckoId        = \(fixtures.coingeckoMappingId)")
     lines.append("resolve.cryptocompareSymbol = \(fixtures.cryptocompareSymbol)")
     lines.append("resolve.binanceSymbol      = \(fixtures.binanceSymbol)")
+  }
+
+  private func appendTradeReadyFixtures(into lines: inout [String]) {
+    let fixtures = UITestFixtures.TradeReady.self
+    lines.append("# fixtures")
+    lines.append("profile.id       = \(fixtures.profileId)")
+    lines.append("profile.label    = \(fixtures.profileLabel)")
+    lines.append("profile.currency = \(fixtures.profileCurrencyCode)")
+    lines.append("brokerage.id     = \(fixtures.brokerageAccountId)")
+    lines.append("brokerage.name   = \(fixtures.brokerageAccountName)")
+    lines.append("instrument.id    = \(fixtures.vgsaxInstrumentId)")
+    lines.append("instrument.ticker = \(fixtures.vgsaxTicker)")
+    lines.append("instrument.exchange = \(fixtures.vgsaxExchange)")
+    lines.append("category.id      = \(fixtures.brokerageCategoryId)")
+    lines.append("category.name    = \(fixtures.brokerageCategoryName)")
   }
 
   private func appendTradeBaselineFixtures(into lines: inout [String]) {

--- a/MoolahUITests_macOS/Helpers/Screens/SidebarScreen.swift
+++ b/MoolahUITests_macOS/Helpers/Screens/SidebarScreen.swift
@@ -5,6 +5,9 @@ import XCTest
 enum SidebarAccount {
   case checking
   case brokerage
+  /// The Brokerage account from the `.tradeReady` seed (different UUID from
+  /// `.brokerage`, which uses the `.tradeBaseline` seed fixture).
+  case tradeReadyBrokerage
 
   /// The fixed UUID written to the seeded `ProfileContainerManager` by
   /// `UITestSeedHydrator`.
@@ -12,6 +15,7 @@ enum SidebarAccount {
     switch self {
     case .checking: return UITestFixtures.TradeBaseline.checkingAccountId
     case .brokerage: return UITestFixtures.TradeBaseline.brokerageAccountId
+    case .tradeReadyBrokerage: return UITestFixtures.TradeReady.brokerageAccountId
     }
   }
 }

--- a/MoolahUITests_macOS/Helpers/Screens/TradeFormDriver.swift
+++ b/MoolahUITests_macOS/Helpers/Screens/TradeFormDriver.swift
@@ -159,7 +159,7 @@ struct TradeFormDriver {
     while Date() < deadline {
       let matches = app.application.staticTexts.matching(
         NSPredicate(format: "label BEGINSWITH %@", prefix))
-      if matches.count > 0, matches.firstMatch.exists { return }
+      if matches.firstMatch.exists { return }
       RunLoop.current.run(until: Date().addingTimeInterval(0.1))
     }
     Trace.recordFailure("no row starting with '\(prefix)' after \(timeout)s")

--- a/MoolahUITests_macOS/Helpers/Screens/TradeFormDriver.swift
+++ b/MoolahUITests_macOS/Helpers/Screens/TradeFormDriver.swift
@@ -1,0 +1,259 @@
+import XCTest
+
+/// Driver for the trade-mode editor in `TransactionDetailView`. Returned from
+/// `MoolahApp.tradeForm`. Covers mode-switching, Paid/Received leg editing,
+/// and fee management.
+///
+/// All action methods start with `Trace.record(#function, …)` and wait for a
+/// real post-condition before returning — see `guides/UI_TEST_GUIDE.md` §3.
+@MainActor
+struct TradeFormDriver {
+  let app: MoolahApp
+
+  // MARK: - Mode switching
+
+  /// Taps the Type picker (a macOS popup button) to open the native menu, then
+  /// selects "Trade". Returns once the Paid amount field appears, proving the
+  /// view re-rendered in trade mode.
+  func switchToTradeMode() {
+    Trace.record(#function)
+    let picker = app.element(for: UITestIdentifiers.Detail.modeTypePicker)
+    if !picker.waitForExistence(timeout: 3) {
+      Trace.recordFailure("modeTypePicker did not appear")
+      XCTFail("Type picker '\(UITestIdentifiers.Detail.modeTypePicker)' did not appear within 3s")
+      return
+    }
+    picker.click()
+
+    // ui-test-review: allow single-resolver — on macOS, SwiftUI Pickers open
+    // a native NSMenu whose items attach to the application's menu hierarchy
+    // at runtime. `.accessibilityIdentifier(_:)` on the inline `Text(…)`
+    // inside the ForEach does not propagate to the NSMenuItem, so querying by
+    // label via `menuItems["Trade"]` is the only viable resolution path here.
+    let tradeItem = app.application.menuItems["Trade"]
+    if !tradeItem.waitForExistence(timeout: 3) {
+      Trace.recordFailure("'Trade' menu item did not appear after opening type picker")
+      XCTFail("'Trade' menu item did not appear within 3s of opening the Type picker")
+      return
+    }
+    tradeItem.click()
+
+    // Post-condition: the Paid amount field must exist, proving the view
+    // switched to trade mode.
+    let paidField = app.element(for: UITestIdentifiers.Detail.tradePaidAmount)
+    if !paidField.waitForExistence(timeout: 3) {
+      Trace.recordFailure("tradePaidAmount did not appear after switching to Trade mode")
+      XCTFail(
+        "Trade mode did not render: '\(UITestIdentifiers.Detail.tradePaidAmount)' "
+          + "did not appear within 3s")
+    }
+  }
+
+  // MARK: - Paid leg
+
+  /// Clears and types `amount` into the Paid amount field, then opens the
+  /// instrument picker via the `tradePaidInstrument` container and picks
+  /// `instrumentId`. Returns once `instrumentPicker.field.<instrumentId>`
+  /// exists, proving the selection propagated.
+  func setPaid(amount: String, instrumentId: String) {
+    Trace.record(#function, detail: "amount=\(amount) instrument=\(instrumentId)")
+    setAmountField(UITestIdentifiers.Detail.tradePaidAmount, to: amount)
+    setInstrument(
+      containerIdentifier: UITestIdentifiers.Detail.tradePaidInstrument,
+      instrumentId: instrumentId)
+  }
+
+  // MARK: - Received leg
+
+  /// Clears and types `amount` into the Received amount field, then opens the
+  /// instrument picker via the `tradeReceivedInstrument` container and picks
+  /// `instrumentId`. Returns once `instrumentPicker.field.<instrumentId>`
+  /// exists, proving the selection propagated.
+  func setReceived(amount: String, instrumentId: String) {
+    Trace.record(#function, detail: "amount=\(amount) instrument=\(instrumentId)")
+    setAmountField(UITestIdentifiers.Detail.tradeReceivedAmount, to: amount)
+    setInstrument(
+      containerIdentifier: UITestIdentifiers.Detail.tradeReceivedInstrument,
+      instrumentId: instrumentId)
+  }
+
+  // MARK: - Fee management
+
+  /// Taps "+ Add Fee", enters `amount` into the fee amount field (at
+  /// `feeDisplayIndex`), changes the fee instrument if it differs from "AUD",
+  /// and commits `category` via the fee leg's category autocomplete dropdown.
+  ///
+  /// - Parameters:
+  ///   - feeDisplayIndex: Zero-based index corresponding to
+  ///     `UITestIdentifiers.Detail.tradeFeeAmount(_:)`. For the first fee, pass 0.
+  ///   - feeLegIndex: Absolute `legDrafts` index of the fee leg. For a fresh
+  ///     trade with two `.trade` legs, the first fee lands at index 2.
+  func addFee(
+    amount: String,
+    instrumentId: String,
+    category: String,
+    feeDisplayIndex: Int = 0,
+    feeLegIndex: Int = 2
+  ) {
+    Trace.record(
+      #function,
+      detail: "amount=\(amount) instrument=\(instrumentId) category=\(category)")
+
+    // Tap "+ Add Fee".
+    let addFeeButton = app.element(for: UITestIdentifiers.Detail.tradeAddFeeButton)
+    if !addFeeButton.waitForExistence(timeout: 3) {
+      Trace.recordFailure("tradeAddFeeButton did not appear")
+      XCTFail(
+        "Add Fee button '\(UITestIdentifiers.Detail.tradeAddFeeButton)' did not appear within 3s")
+      return
+    }
+    addFeeButton.click()
+
+    // Wait for the fee amount field (proves the fee row inserted).
+    let feeAmountId = UITestIdentifiers.Detail.tradeFeeAmount(feeDisplayIndex)
+    let feeAmountField = app.element(for: feeAmountId)
+    if !feeAmountField.waitForExistence(timeout: 3) {
+      Trace.recordFailure("fee amount field '\(feeAmountId)' did not appear after tapping Add Fee")
+      XCTFail("Fee amount field '\(feeAmountId)' did not appear within 3s of tapping Add Fee")
+      return
+    }
+
+    // Enter the fee amount.
+    setAmountField(feeAmountId, to: amount)
+
+    // Change the fee instrument (the fee's InstrumentPickerField shows
+    // `instrumentPicker.field.<currentId>` on the inner button; because no
+    // separate container identifier is set on the fee's picker, locate the
+    // button directly via `instrumentPicker.field.AUD` — the fee always
+    // defaults to AUD on a fresh Brokerage account).
+    if instrumentId != "AUD" {
+      setInstrument(containerIdentifier: nil, fieldId: "AUD", instrumentId: instrumentId)
+    }
+
+    // Enter the category via the leg's autocomplete field.
+    let categoryDriver = AutocompleteFieldDriver(
+      app: app,
+      fieldIdentifier: UITestIdentifiers.Detail.legCategory(feeLegIndex),
+      dropdownIdentifier: UITestIdentifiers.Autocomplete.legCategory(feeLegIndex),
+      suggestionIdentifier: { rowIndex in
+        UITestIdentifiers.Autocomplete.legCategorySuggestion(feeLegIndex, rowIndex)
+      }
+    )
+    categoryDriver.tap()
+    categoryDriver.type(category)
+    categoryDriver.expectSuggestionsVisible(count: 1)
+    categoryDriver.pressArrowDown()
+    categoryDriver.expectHighlightedSuggestion(at: 0)
+    categoryDriver.pressEnter()
+  }
+
+  // MARK: - Post-condition waits
+
+  /// Waits for a transaction list row whose title label starts with `prefix`
+  /// to appear in the accessibility tree, up to `timeout` seconds. Fails
+  /// loudly if the row does not appear.
+  func waitForTradeRow(startingWith prefix: String, timeout: TimeInterval = 10) {
+    Trace.record(#function, detail: "prefix=\(prefix)")
+    // Re-resolve each iteration so the query reflects the live tree.
+    let deadline = Date().addingTimeInterval(timeout)
+    while Date() < deadline {
+      let matches = app.application.staticTexts.matching(
+        NSPredicate(format: "label BEGINSWITH %@", prefix))
+      if !matches.isEmpty, matches.firstMatch.exists { return }
+      RunLoop.current.run(until: Date().addingTimeInterval(0.1))
+    }
+    Trace.recordFailure("no row starting with '\(prefix)' after \(timeout)s")
+    XCTFail("No transaction row starting with '\(prefix)' appeared within \(timeout)s")
+  }
+
+  // MARK: - Private helpers
+
+  /// Clears any existing text in `identifier` and types `text`. Returns once
+  /// the field's `value` contains `text`.
+  private func setAmountField(_ identifier: String, to text: String) {
+    let field = app.element(for: identifier)
+    if !field.waitForExistence(timeout: 3) {
+      Trace.recordFailure("amount field '\(identifier)' did not appear")
+      XCTFail("Amount field '\(identifier)' did not appear within 3s")
+      return
+    }
+    field.click()
+    app.application.typeKey("a", modifierFlags: .command)
+    field.typeText(text)
+
+    // Post-condition: field reports the typed value.
+    let deadline = Date().addingTimeInterval(3)
+    while Date() < deadline {
+      if let value = field.value as? String, value.contains(text) { return }
+      RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+    }
+  }
+
+  /// Opens the `InstrumentPickerSheet` by clicking either `containerIdentifier`
+  /// (when the outer view has an explicit identifier) or the inner field button
+  /// `instrumentPicker.field.<fieldId>`. Then searches for and picks `instrumentId`.
+  private func setInstrument(
+    containerIdentifier: String?,
+    fieldId: String = "AUD",
+    instrumentId: String
+  ) {
+    // Tap the picker button to open the sheet.
+    let button: XCUIElement
+    if let container = containerIdentifier {
+      button = app.element(for: container)
+    } else {
+      button = app.element(for: UITestIdentifiers.InstrumentPicker.field(fieldId))
+    }
+    if !button.waitForExistence(timeout: 3) {
+      Trace.recordFailure("instrument picker button did not appear")
+      XCTFail("Instrument picker button did not appear within 3s")
+      return
+    }
+    button.click()
+
+    // Wait for the sheet to appear.
+    let sheet = app.element(for: UITestIdentifiers.InstrumentPicker.sheet)
+    if !sheet.waitForExistence(timeout: 3) {
+      Trace.recordFailure("instrumentPicker.sheet did not appear after tap")
+      XCTFail("InstrumentPickerSheet did not appear within 3s of tapping the picker button")
+      return
+    }
+
+    // Search and pick.
+    let searchField = app.element(for: UITestIdentifiers.InstrumentPicker.searchField)
+    if !searchField.waitForExistence(timeout: 3) {
+      Trace.recordFailure("instrumentPicker.searchField did not appear")
+      XCTFail("InstrumentPickerSheet search field did not appear within 3s")
+      return
+    }
+    searchField.click()
+    searchField.typeText(instrumentId)
+
+    let row = app.element(for: UITestIdentifiers.InstrumentPicker.row(instrumentId))
+    if !row.waitForExistence(timeout: 5) {
+      Trace.recordFailure("instrumentPicker.row.\(instrumentId) did not appear after search")
+      XCTFail(
+        "InstrumentPickerSheet row for '\(instrumentId)' did not appear within 5s of searching")
+      return
+    }
+    row.click()
+
+    // Post-condition: sheet must dismiss.
+    let deadline = Date().addingTimeInterval(3)
+    while Date() < deadline {
+      if !sheet.exists { break }
+      RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+    }
+    if sheet.exists {
+      Trace.recordFailure("instrumentPicker.sheet did not dismiss after picking '\(instrumentId)'")
+      XCTFail("InstrumentPickerSheet did not dismiss within 3s of picking '\(instrumentId)'")
+    }
+  }
+}
+
+// MARK: - MoolahApp + TradeFormDriver
+
+extension MoolahApp {
+  /// Driver for the trade-mode section of the transaction detail inspector.
+  var tradeForm: TradeFormDriver { TradeFormDriver(app: self) }
+}

--- a/MoolahUITests_macOS/Helpers/Screens/TradeFormDriver.swift
+++ b/MoolahUITests_macOS/Helpers/Screens/TradeFormDriver.swift
@@ -149,21 +149,22 @@ struct TradeFormDriver {
 
   // MARK: - Post-condition waits
 
-  /// Waits for a transaction list row whose title label starts with `prefix`
-  /// to appear in the accessibility tree, up to `timeout` seconds. Fails
-  /// loudly if the row does not appear.
-  func waitForTradeRow(startingWith prefix: String, timeout: TimeInterval = 10) {
-    Trace.record(#function, detail: "prefix=\(prefix)")
-    // Re-resolve each iteration so the query reflects the live tree.
+  /// Waits for a transaction list row whose accessibility label contains
+  /// `marker` to appear, up to `timeout` seconds. Trade rows combine
+  /// children so the accessibility label is `"Trade, <title>, <amount>,
+  /// <date>"` — the trade-title sentence is in the middle, not at the
+  /// start, hence `CONTAINS` rather than `BEGINSWITH`.
+  func waitForTradeRow(containing marker: String, timeout: TimeInterval = 10) {
+    Trace.record(#function, detail: "marker=\(marker)")
     let deadline = Date().addingTimeInterval(timeout)
     while Date() < deadline {
-      let matches = app.application.staticTexts.matching(
-        NSPredicate(format: "label BEGINSWITH %@", prefix))
-      if matches.firstMatch.exists { return }
+      let predicate = NSPredicate(format: "label CONTAINS %@", marker)
+      if app.application.staticTexts.matching(predicate).firstMatch.exists { return }
+      if app.application.cells.matching(predicate).firstMatch.exists { return }
       RunLoop.current.run(until: Date().addingTimeInterval(0.1))
     }
-    Trace.recordFailure("no row starting with '\(prefix)' after \(timeout)s")
-    XCTFail("No transaction row starting with '\(prefix)' appeared within \(timeout)s")
+    Trace.recordFailure("no row containing '\(marker)' after \(timeout)s")
+    XCTFail("No transaction row containing '\(marker)' appeared within \(timeout)s")
   }
 
   // MARK: - Private helpers

--- a/MoolahUITests_macOS/Helpers/Screens/TradeFormDriver.swift
+++ b/MoolahUITests_macOS/Helpers/Screens/TradeFormDriver.swift
@@ -159,7 +159,7 @@ struct TradeFormDriver {
     while Date() < deadline {
       let matches = app.application.staticTexts.matching(
         NSPredicate(format: "label BEGINSWITH %@", prefix))
-      if !matches.isEmpty, matches.firstMatch.exists { return }
+      if matches.count > 0, matches.firstMatch.exists { return }
       RunLoop.current.run(until: Date().addingTimeInterval(0.1))
     }
     Trace.recordFailure("no row starting with '\(prefix)' after \(timeout)s")

--- a/MoolahUITests_macOS/Tests/TradeFlowUITests.swift
+++ b/MoolahUITests_macOS/Tests/TradeFlowUITests.swift
@@ -24,7 +24,8 @@ final class TradeFlowUITests: MoolahUITestCase {
 
     app.tradeForm.switchToTradeMode()
     app.tradeForm.setPaid(amount: "300", instrumentId: "AUD")
-    app.tradeForm.setReceived(amount: "20", instrumentId: UITestFixtures.TradeReady.vgsaxTicker)
+    app.tradeForm.setReceived(
+      amount: "20", instrumentId: UITestFixtures.TradeReady.vgsaxInstrumentId)
     app.tradeForm.addFee(
       amount: "10",
       instrumentId: "AUD",

--- a/MoolahUITests_macOS/Tests/TradeFlowUITests.swift
+++ b/MoolahUITests_macOS/Tests/TradeFlowUITests.swift
@@ -1,0 +1,35 @@
+import XCTest
+
+/// End-to-end UI test for the trade transaction creation flow.
+///
+/// Drives the full create-trade-with-fee path:
+///   launch → sidebar account → new transaction → switch to Trade mode →
+///   set Paid + Received amounts and instruments → add fee with category →
+///   assert the transaction list renders the trade row title.
+///
+/// This test earns its place as a UI test because the interaction involves
+/// multi-step form mode-switching (type picker → trade section reveal),
+/// instrument picker sheet open/close sequencing, and the debounced save
+/// pipeline that commits the draft to the store — none of which are
+/// exercisable in a store test against `TestBackend`.
+@MainActor
+final class TradeFlowUITests: MoolahUITestCase {
+  /// Creates a new trade transaction with a fee and asserts the resulting
+  /// row in the transaction list displays the expected trade title.
+  func testCreateTradeWithFeeRendersTradeRow() {
+    let app = launch(seed: .tradeReady)
+
+    app.sidebar.switchToAccount(.tradeReadyBrokerage)
+    app.transactionList.createTransaction()
+
+    app.tradeForm.switchToTradeMode()
+    app.tradeForm.setPaid(amount: "300", instrumentId: "AUD")
+    app.tradeForm.setReceived(amount: "20", instrumentId: UITestFixtures.TradeReady.vgsaxTicker)
+    app.tradeForm.addFee(
+      amount: "10",
+      instrumentId: "AUD",
+      category: UITestFixtures.TradeReady.brokerageCategoryName)
+
+    app.tradeForm.waitForTradeRow(startingWith: "Bought 20 VGS.AX")
+  }
+}

--- a/MoolahUITests_macOS/Tests/TradeFlowUITests.swift
+++ b/MoolahUITests_macOS/Tests/TradeFlowUITests.swift
@@ -23,14 +23,16 @@ final class TradeFlowUITests: MoolahUITestCase {
     app.transactionList.createTransaction()
 
     app.tradeForm.switchToTradeMode()
-    app.tradeForm.setPaid(amount: "300", instrumentId: "AUD")
+    // Buy: cash leg negative (paid out), position leg positive (received).
+    // `.trade` legs preserve user-entered signs literally.
+    app.tradeForm.setPaid(amount: "-300", instrumentId: "AUD")
     app.tradeForm.setReceived(
       amount: "20", instrumentId: UITestFixtures.TradeReady.vgsaxInstrumentId)
     app.tradeForm.addFee(
-      amount: "10",
+      amount: "-10",
       instrumentId: "AUD",
       category: UITestFixtures.TradeReady.brokerageCategoryName)
 
-    app.tradeForm.waitForTradeRow(startingWith: "Bought 20 VGS.AX")
+    app.tradeForm.waitForTradeRow(containing: "Bought 20 VGS.AX")
   }
 }

--- a/Shared/Models/TransactionDraft+TradeMode.swift
+++ b/Shared/Models/TransactionDraft+TradeMode.swift
@@ -49,3 +49,84 @@ extension TransactionDraft {
     legDrafts.remove(at: index)
   }
 }
+
+// MARK: - Mode Switching (Forward → Trade)
+
+extension TransactionDraft {
+  /// Whether the current draft can transition to trade mode without
+  /// losing data semantically. True when the existing legs already match
+  /// the trade-shape rule (custom → trade) **or** when the draft is
+  /// simple income / expense / transfer with at least one accounted leg.
+  func canSwitchToTrade(accounts: Accounts) -> Bool {
+    if isCustom {
+      // Already-trade-shaped legs: 2 .trade + 0+ .expense, all on one
+      // account, no category/earmark on .trade legs.
+      let tradeCount = legDrafts.filter { $0.type == .trade }.count
+      let nonTrade = legDrafts.filter { $0.type != .trade }
+      let accountSet = Set(legDrafts.compactMap(\.accountId))
+      return tradeCount == 2
+        && nonTrade.allSatisfy { $0.type == .expense }
+        && accountSet.count == 1
+    }
+    return relevantLeg.accountId != nil
+  }
+
+  /// Convert the draft into trade shape. Mirrors the rules in design §3.3
+  /// "Forward". Caller is responsible for ensuring `canSwitchToTrade` is
+  /// true; otherwise the result is ill-defined.
+  mutating func switchToTrade(accounts: Accounts) {
+    if isCustom {
+      isCustom = false
+      return
+    }
+
+    let existing = relevantLeg
+    let acct = existing.accountId
+    let acctInstrument =
+      acct.flatMap { accounts.by(id: $0) }?.instrument.id ?? existing.instrumentId
+
+    let isReceivedFromIncome = (existing.type == .income)
+    let received: LegDraft
+    let paid: LegDraft
+
+    if isReceivedFromIncome {
+      received = LegDraft(
+        type: .trade,
+        accountId: acct,
+        amountText: existing.amountText,
+        categoryId: nil,
+        categoryText: "",
+        earmarkId: nil,
+        instrumentId: existing.instrumentId)
+      paid = LegDraft(
+        type: .trade,
+        accountId: acct,
+        amountText: "0",
+        categoryId: nil,
+        categoryText: "",
+        earmarkId: nil,
+        instrumentId: acctInstrument)
+    } else {
+      paid = LegDraft(
+        type: .trade,
+        accountId: acct,
+        amountText: existing.amountText,
+        categoryId: nil,
+        categoryText: "",
+        earmarkId: nil,
+        instrumentId: existing.instrumentId)
+      received = LegDraft(
+        type: .trade,
+        accountId: acct,
+        amountText: "0",
+        categoryId: nil,
+        categoryText: "",
+        earmarkId: nil,
+        instrumentId: acctInstrument)
+    }
+    // Counterpart legs (transfer) are intentionally discarded here.
+    legDrafts = [paid, received]
+    relevantLegIndex = 0
+    isCustom = false
+  }
+}

--- a/Shared/Models/TransactionDraft+TradeMode.swift
+++ b/Shared/Models/TransactionDraft+TradeMode.swift
@@ -130,3 +130,86 @@ extension TransactionDraft {
     isCustom = false
   }
 }
+
+// MARK: - Mode Switching (Reverse from Trade)
+
+extension TransactionDraft {
+  /// Convert a trade-shaped draft into one of the simpler modes. Pass
+  /// `nil` for `to` to flip to Custom (lossless escape hatch).
+  mutating func switchFromTrade(to target: TransactionType?, accounts: Accounts) {
+    if target == nil {
+      isCustom = true
+      return
+    }
+    guard let paidIdx = paidLegIndex, let receivedIdx = receivedLegIndex else {
+      // Not actually a trade — defensive no-op.
+      return
+    }
+    let paidLeg = legDrafts[paidIdx]
+    let receivedLeg = legDrafts[receivedIdx]
+
+    switch target {
+    case .income:
+      applyIncomeLeg(from: receivedLeg)
+    case .expense:
+      applyExpenseLeg(from: paidLeg)
+    case .transfer:
+      applyTransferLegs(paidLeg: paidLeg, accounts: accounts)
+    case .openingBalance, .trade, .none:
+      // .openingBalance not user-selectable; .trade is a no-op; nil
+      // handled above. Defensive default.
+      break
+    }
+    isCustom = false
+  }
+
+  private mutating func applyIncomeLeg(from source: LegDraft) {
+    legDrafts = [
+      LegDraft(
+        type: .income,
+        accountId: source.accountId,
+        amountText: source.amountText,
+        categoryId: nil,
+        categoryText: "",
+        earmarkId: nil,
+        instrumentId: source.instrumentId)
+    ]
+    relevantLegIndex = 0
+  }
+
+  private mutating func applyExpenseLeg(from source: LegDraft) {
+    legDrafts = [
+      LegDraft(
+        type: .expense,
+        accountId: source.accountId,
+        amountText: source.amountText,
+        categoryId: nil,
+        categoryText: "",
+        earmarkId: nil,
+        instrumentId: source.instrumentId)
+    ]
+    relevantLegIndex = 0
+  }
+
+  private mutating func applyTransferLegs(paidLeg: LegDraft, accounts: Accounts) {
+    let other = accounts.ordered.first { $0.id != paidLeg.accountId }
+    let counterpart = LegDraft(
+      type: .transfer,
+      accountId: other?.id,
+      amountText: negatedAmountText(paidLeg.amountText),
+      categoryId: nil,
+      categoryText: "",
+      earmarkId: nil,
+      instrumentId: other?.instrument.id ?? paidLeg.instrumentId)
+    let primary = LegDraft(
+      type: .transfer,
+      accountId: paidLeg.accountId,
+      amountText: paidLeg.amountText,
+      categoryId: nil,
+      categoryText: "",
+      earmarkId: nil,
+      instrumentId: paidLeg.instrumentId)
+    legDrafts = [primary, counterpart]
+    relevantLegIndex = 0
+  }
+}

--- a/Shared/Models/TransactionDraft+TradeMode.swift
+++ b/Shared/Models/TransactionDraft+TradeMode.swift
@@ -74,6 +74,11 @@ extension TransactionDraft {
   /// Convert the draft into trade shape. Mirrors the rules in design §3.3
   /// "Forward". Caller is responsible for ensuring `canSwitchToTrade` is
   /// true; otherwise the result is ill-defined.
+  ///
+  /// `.trade` legs preserve user-entered signs (`displaysNegated(.trade) == false`).
+  /// When the existing leg's display rule differs from `.trade`'s, the carried
+  /// `amountText` is re-formatted via `adjustAmountText` so the underlying
+  /// signed quantity round-trips unchanged into trade storage.
   mutating func switchToTrade(accounts: Accounts) {
     if isCustom {
       isCustom = false
@@ -82,52 +87,40 @@ extension TransactionDraft {
 
     let existing = relevantLeg
     let acct = existing.accountId
-    let acctInstrument =
+    let acctInstrumentId =
       acct.flatMap { accounts.by(id: $0) }?.instrument.id ?? existing.instrumentId
+    let carriedText = Self.adjustAmountText(
+      existing.amountText, from: existing.type, to: .trade)
 
+    let carried = Self.tradeLeg(
+      accountId: acct, amountText: carriedText, instrumentId: existing.instrumentId)
+    let blank = Self.tradeLeg(
+      accountId: acct, amountText: "0", instrumentId: acctInstrumentId)
+
+    // Income's positive leg becomes Received; everything else (Expense,
+    // Transfer-after-counterpart-drop) becomes Paid. Counterpart transfer
+    // legs are intentionally discarded.
     let isReceivedFromIncome = (existing.type == .income)
-    let received: LegDraft
-    let paid: LegDraft
-
-    if isReceivedFromIncome {
-      received = LegDraft(
-        type: .trade,
-        accountId: acct,
-        amountText: existing.amountText,
-        categoryId: nil,
-        categoryText: "",
-        earmarkId: nil,
-        instrumentId: existing.instrumentId)
-      paid = LegDraft(
-        type: .trade,
-        accountId: acct,
-        amountText: "0",
-        categoryId: nil,
-        categoryText: "",
-        earmarkId: nil,
-        instrumentId: acctInstrument)
-    } else {
-      paid = LegDraft(
-        type: .trade,
-        accountId: acct,
-        amountText: existing.amountText,
-        categoryId: nil,
-        categoryText: "",
-        earmarkId: nil,
-        instrumentId: existing.instrumentId)
-      received = LegDraft(
-        type: .trade,
-        accountId: acct,
-        amountText: "0",
-        categoryId: nil,
-        categoryText: "",
-        earmarkId: nil,
-        instrumentId: acctInstrument)
-    }
-    // Counterpart legs (transfer) are intentionally discarded here.
-    legDrafts = [paid, received]
+    legDrafts = isReceivedFromIncome ? [blank, carried] : [carried, blank]
     relevantLegIndex = 0
     isCustom = false
+  }
+
+  /// Builds a fresh `.trade` `LegDraft` with no category or earmark, used by
+  /// the forward switch helpers. Trade legs are constrained to no category
+  /// or earmark per design §1.2.
+  private static func tradeLeg(
+    accountId: UUID?, amountText: String, instrumentId: String?
+  ) -> LegDraft {
+    LegDraft(
+      type: .trade,
+      accountId: accountId,
+      amountText: amountText,
+      categoryId: nil,
+      categoryText: "",
+      earmarkId: nil,
+      instrumentId: instrumentId
+    )
   }
 }
 
@@ -168,7 +161,7 @@ extension TransactionDraft {
       LegDraft(
         type: .income,
         accountId: source.accountId,
-        amountText: source.amountText,
+        amountText: Self.adjustAmountText(source.amountText, from: .trade, to: .income),
         categoryId: nil,
         categoryText: "",
         earmarkId: nil,
@@ -182,7 +175,7 @@ extension TransactionDraft {
       LegDraft(
         type: .expense,
         accountId: source.accountId,
-        amountText: source.amountText,
+        amountText: Self.adjustAmountText(source.amountText, from: .trade, to: .expense),
         categoryId: nil,
         categoryText: "",
         earmarkId: nil,
@@ -192,11 +185,12 @@ extension TransactionDraft {
   }
 
   private mutating func applyTransferLegs(paidLeg: LegDraft, accounts: Accounts) {
+    let primaryText = Self.adjustAmountText(paidLeg.amountText, from: .trade, to: .transfer)
     let other = accounts.ordered.first { $0.id != paidLeg.accountId }
     let counterpart = LegDraft(
       type: .transfer,
       accountId: other?.id,
-      amountText: negatedAmountText(paidLeg.amountText),
+      amountText: negatedAmountText(primaryText),
       categoryId: nil,
       categoryText: "",
       earmarkId: nil,
@@ -204,12 +198,43 @@ extension TransactionDraft {
     let primary = LegDraft(
       type: .transfer,
       accountId: paidLeg.accountId,
-      amountText: paidLeg.amountText,
+      amountText: primaryText,
       categoryId: nil,
       categoryText: "",
       earmarkId: nil,
       instrumentId: paidLeg.instrumentId)
     legDrafts = [primary, counterpart]
     relevantLegIndex = 0
+  }
+}
+
+// MARK: - Type Conversion Helpers
+
+extension TransactionDraft {
+  /// Re-formats `text` so the same underlying signed quantity that `text`
+  /// represents under `fromType`'s display rule round-trips into `toType`'s
+  /// display rule. When the two types share `displaysNegated(_:)`, the text
+  /// is returned unchanged; otherwise the value is parsed and re-emitted with
+  /// the opposite sign (preserving the user's decimal-place precision).
+  static func adjustAmountText(
+    _ text: String, from fromType: TransactionType, to toType: TransactionType
+  ) -> String {
+    if displaysNegated(fromType) == displaysNegated(toType) {
+      return text
+    }
+    guard let value = InstrumentAmount.parseQuantity(from: text, decimals: 10) else {
+      return text
+    }
+    let negated = -value
+    if negated == .zero {
+      return "0"
+    }
+    let decimalPlaces: Int
+    if let dotIndex = text.firstIndex(of: ".") {
+      decimalPlaces = text.distance(from: text.index(after: dotIndex), to: text.endIndex)
+    } else {
+      decimalPlaces = 0
+    }
+    return negated.formatted(.number.precision(.fractionLength(decimalPlaces)).grouping(.never))
   }
 }

--- a/Shared/Models/TransactionDraft+TradeMode.swift
+++ b/Shared/Models/TransactionDraft+TradeMode.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+// MARK: - Computed Accessors (Trade Mode)
+
+extension TransactionDraft {
+  /// Index of the first `.trade` leg (the "Paid" side). `nil` when the
+  /// draft is not in trade shape.
+  var paidLegIndex: Int? {
+    legDrafts.firstIndex { $0.type == .trade }
+  }
+
+  /// Index of the second `.trade` leg (the "Received" side). `nil` when
+  /// the draft does not have two `.trade` legs.
+  var receivedLegIndex: Int? {
+    let trade = legDrafts.enumerated().filter { $0.element.type == .trade }
+    return trade.count == 2 ? trade[1].offset : nil
+  }
+
+  /// Indices of all `.expense` fee legs, in storage order.
+  var feeIndices: [Int] {
+    legDrafts.enumerated().compactMap { $0.element.type == .expense ? $0.offset : nil }
+  }
+}
+
+// MARK: - Editing Methods (Trade Mode)
+
+extension TransactionDraft {
+  /// Append a new fee leg defaulting to amount `0` in the supplied
+  /// instrument and the current trade account.
+  mutating func appendFee(defaultInstrumentId: String) {
+    legDrafts.append(
+      LegDraft(
+        type: .expense,
+        accountId: paidLegIndex.flatMap { legDrafts[$0].accountId },
+        amountText: "0",
+        categoryId: nil,
+        categoryText: "",
+        earmarkId: nil,
+        instrumentId: defaultInstrumentId
+      ))
+  }
+
+  /// Remove the fee leg at the absolute draft index. No-op if the index
+  /// is out of bounds or the leg is not `.expense`.
+  mutating func removeFee(at index: Int) {
+    guard legDrafts.indices.contains(index),
+      legDrafts[index].type == .expense
+    else { return }
+    legDrafts.remove(at: index)
+  }
+}

--- a/Shared/Models/TransactionDraft.swift
+++ b/Shared/Models/TransactionDraft.swift
@@ -133,14 +133,11 @@ extension TransactionDraft {
     // differs from its account's instrument (e.g. a cross-currency trade booked
     // against a single investment account).
     let drafts = transaction.legs.map { leg in
-      // For .trade legs, amountText always holds the absolute quantity (positive).
-      // The sign is re-derived from leg position when serialising back to a Transaction.
-      let displayQuantity = leg.type == .trade ? abs(leg.quantity) : leg.quantity
-      return LegDraft(
+      LegDraft(
         type: leg.type,
         accountId: leg.accountId,
         amountText: Self.displayText(
-          quantity: displayQuantity, type: leg.type, decimals: leg.instrument.decimals),
+          quantity: leg.quantity, type: leg.type, decimals: leg.instrument.decimals),
         categoryId: leg.categoryId,
         categoryText: "",
         earmarkId: leg.earmarkId,
@@ -288,7 +285,6 @@ extension TransactionDraft {
     guard isValid else { return nil }
 
     var legs: [TransactionLeg] = []
-    var tradeLegOrdinal = 0
     for legDraft in legDrafts {
       guard let overrideId = legDraft.instrumentId,
         let instrument = availableInstruments.first(where: { $0.id == overrideId })
@@ -297,20 +293,9 @@ extension TransactionDraft {
       }
 
       guard
-        let parsedQty = Self.parseDisplayText(
+        let quantity = Self.parseDisplayText(
           legDraft.amountText, type: legDraft.type, decimals: instrument.decimals)
       else { return nil }
-
-      // For .trade legs, sign is determined by position: first leg is Paid (negative),
-      // subsequent legs are Received (positive). Defensive abs handles user-typed negatives.
-      let quantity: Decimal
-      if legDraft.type == .trade {
-        let absQty = abs(parsedQty)
-        quantity = (tradeLegOrdinal == 0) ? -absQty : absQty
-        tradeLegOrdinal += 1
-      } else {
-        quantity = parsedQty
-      }
 
       legs.append(
         TransactionLeg(

--- a/Shared/Models/TransactionDraft.swift
+++ b/Shared/Models/TransactionDraft.swift
@@ -153,7 +153,7 @@ extension TransactionDraft {
         else { return false }
         return leg.instrument == account.instrument
       }
-    let isCustom = !(transaction.isSimple || isCrossCurrency)
+    let isCustom = !(transaction.isSimple || isCrossCurrency || transaction.isTrade)
 
     // Pin relevantLegIndex for simple transactions
     let relevantIndex: Int

--- a/Shared/Models/TransactionDraft.swift
+++ b/Shared/Models/TransactionDraft.swift
@@ -133,11 +133,14 @@ extension TransactionDraft {
     // differs from its account's instrument (e.g. a cross-currency trade booked
     // against a single investment account).
     let drafts = transaction.legs.map { leg in
-      LegDraft(
+      // For .trade legs, amountText always holds the absolute quantity (positive).
+      // The sign is re-derived from leg position when serialising back to a Transaction.
+      let displayQuantity = leg.type == .trade ? abs(leg.quantity) : leg.quantity
+      return LegDraft(
         type: leg.type,
         accountId: leg.accountId,
         amountText: Self.displayText(
-          quantity: leg.quantity, type: leg.type, decimals: leg.instrument.decimals),
+          quantity: displayQuantity, type: leg.type, decimals: leg.instrument.decimals),
         categoryId: leg.categoryId,
         categoryText: "",
         earmarkId: leg.earmarkId,
@@ -280,6 +283,7 @@ extension TransactionDraft {
     guard isValid else { return nil }
 
     var legs: [TransactionLeg] = []
+    var tradeLegOrdinal = 0
     for legDraft in legDrafts {
       guard let overrideId = legDraft.instrumentId,
         let instrument = availableInstruments.first(where: { $0.id == overrideId })
@@ -288,9 +292,20 @@ extension TransactionDraft {
       }
 
       guard
-        let quantity = Self.parseDisplayText(
+        let parsedQty = Self.parseDisplayText(
           legDraft.amountText, type: legDraft.type, decimals: instrument.decimals)
       else { return nil }
+
+      // For .trade legs, sign is determined by position: first leg is Paid (negative),
+      // subsequent legs are Received (positive). Defensive abs handles user-typed negatives.
+      let quantity: Decimal
+      if legDraft.type == .trade {
+        let absQty = abs(parsedQty)
+        quantity = (tradeLegOrdinal == 0) ? -absQty : absQty
+        tradeLegOrdinal += 1
+      } else {
+        quantity = parsedQty
+      }
 
       legs.append(
         TransactionLeg(

--- a/Shared/Models/TransactionDraft.swift
+++ b/Shared/Models/TransactionDraft.swift
@@ -254,8 +254,13 @@ extension TransactionDraft {
   var isValid: Bool {
     guard !legDrafts.isEmpty else { return false }
     for leg in legDrafts {
-      // Each leg must have either an account or an earmark (or both)
-      guard leg.accountId != nil || leg.earmarkId != nil else { return false }
+      // .trade legs must have an account (no earmark-only fallback per design §3.2).
+      // All other types require either an account or an earmark (or both).
+      if leg.type == .trade {
+        guard leg.accountId != nil else { return false }
+      } else {
+        guard leg.accountId != nil || leg.earmarkId != nil else { return false }
+      }
       guard !leg.amountText.isEmpty,
         InstrumentAmount.parseQuantity(from: leg.amountText, decimals: 10) != nil
       else { return false }

--- a/Shared/Models/TransactionDraft.swift
+++ b/Shared/Models/TransactionDraft.swift
@@ -93,7 +93,7 @@ struct TransactionDraft: Sendable, Equatable {
   static func displaysNegated(_ type: TransactionType) -> Bool {
     switch type {
     case .expense, .transfer: return true
-    case .income, .openingBalance: return false
+    case .income, .openingBalance, .trade: return false
     }
   }
 

--- a/Shared/PositionBook.swift
+++ b/Shared/PositionBook.swift
@@ -87,8 +87,8 @@ struct PositionBook: Equatable, Sendable {
       earmarks[earmarkId, default: [:]][leg.instrument, default: 0] += sign * quantity
 
       switch leg.type {
-      case .income, .openingBalance:
-        // Saved tracks the change to the saved total. Income/openingBalance
+      case .income, .openingBalance, .trade:
+        // Saved tracks the change to the saved total. Income/openingBalance/trade
         // quantities are positive, so sign * quantity gives the right direction.
         earmarksSaved[earmarkId, default: [:]][leg.instrument, default: 0] += sign * quantity
 

--- a/Shared/PositionBook.swift
+++ b/Shared/PositionBook.swift
@@ -23,7 +23,7 @@ struct PositionBook: Equatable, Sendable {
   /// earmark, signed as in the leg).
   var earmarks: [UUID: [Instrument: Decimal]] = [:]
 
-  /// Per-earmark "saved" totals — sum of `.income` and `.openingBalance` legs.
+  /// Per-earmark "saved" totals — sum of `.income`, `.openingBalance`, and `.trade` legs.
   /// Tracks the change to the saved-into-earmark total.
   var earmarksSaved: [UUID: [Instrument: Decimal]] = [:]
 

--- a/Shared/ProfitLossCalculator.swift
+++ b/Shared/ProfitLossCalculator.swift
@@ -38,6 +38,17 @@ enum ProfitLossCalculator {
   /// transaction's date before summing so `totalInvested` is expressed
   /// in a single currency. See guides/INSTRUMENT_CONVERSION_GUIDE.md
   /// Rules 1 and 5.
+  /// Process all transactions to compute total invested.
+  ///
+  /// Only `.trade` legs contribute to cost basis, consistent with
+  /// `TradeEventClassifier`. Fiat legs of other types (e.g. `.expense`
+  /// brokerage fees) are intentionally excluded.
+  ///
+  /// Fiat `.trade` legs can span multiple currencies (e.g. a USD payment
+  /// in a cross-currency buy). We convert each fiat outflow leg to
+  /// `profileCurrency` on the transaction's date before summing so
+  /// `totalInvested` is expressed in a single currency. See
+  /// guides/INSTRUMENT_CONVERSION_GUIDE.md Rules 1 and 5.
   private static func accumulateInvested(
     into instrumentData: inout [String: InstrumentData],
     transactions: [LegTransaction],
@@ -46,8 +57,9 @@ enum ProfitLossCalculator {
   ) async throws {
     let sorted = transactions.sorted { $0.date < $1.date }
     for transaction in sorted {
-      let fiatLegs = transaction.legs.filter { $0.instrument.kind == .fiatCurrency }
-      let nonFiatLegs = transaction.legs.filter { $0.instrument.kind != .fiatCurrency }
+      let tradeLegs = transaction.legs.filter { $0.type == .trade }
+      let fiatLegs = tradeLegs.filter { $0.instrument.kind == .fiatCurrency }
+      let nonFiatLegs = tradeLegs.filter { $0.instrument.kind != .fiatCurrency }
 
       var fiatOutflow: Decimal = 0
       for leg in fiatLegs where leg.quantity < 0 {

--- a/Shared/TradeEventClassifier.swift
+++ b/Shared/TradeEventClassifier.swift
@@ -1,10 +1,8 @@
-// swiftlint:disable multiline_arguments
-
 import Foundation
 
-/// One step in the FIFO cost-basis machine. The shape mirrors what
-/// `CostBasisEngine.processBuy` / `processSell` consume, so callers can feed
-/// these straight in.
+/// One step in the FIFO cost-basis machine. Shape unchanged from the previous
+/// implementation; consumers (CapitalGainsCalculator, InvestmentStore cost
+/// basis snapshot, PositionsHistoryBuilder) read these structurally.
 struct TradeBuyEvent: Sendable, Equatable {
   let instrument: Instrument
   let quantity: Decimal
@@ -22,34 +20,20 @@ struct TradeEventClassification: Sendable, Equatable {
   let sells: [TradeSellEvent]
 }
 
-/// Classifies a single transaction's legs into FIFO buy / sell events.
+/// Classifies a transaction's `.trade` legs into FIFO buy / sell events.
 ///
-/// Two cases:
+/// Per design §2, the classifier filters by `type == .trade` and ignores
+/// every other leg. For each `.trade` leg, the per-unit value is derived
+/// from the *other* `.trade` leg's value converted to `hostCurrency` on
+/// the transaction date. Fee legs (`.expense`) are not part of cost basis
+/// in this iteration; that decision moves with the SelfWealthParser
+/// brokerage-attach work tracked in
+/// https://github.com/ajsutton/moolah-native/issues/558.
 ///
-/// **Fiat-paired:** non-fiat legs paired with one or more fiat legs in the
-/// same transaction. Cost / proceeds-per-unit derive from `fiatOutflow /
-/// qty` or `fiatInflow / qty`. Mixed-currency fiat is allowed: each fiat
-/// leg is converted to `hostCurrency` on the txn date before being summed
-/// (per `guides/INSTRUMENT_CONVERSION_GUIDE.md` Rule 1).
-///
-/// **Non-fiat swap:** every leg is non-fiat (e.g. ETH → BTC). Each leg's
-/// signed quantity is converted to `hostCurrency`; positive legs are buys
-/// (cost = converted value / qty), negative legs are sells (proceeds =
-/// converted value / qty).
-///
-/// Per CLAUDE.md sign convention, signs are preserved end-to-end; we never
-/// `abs()` a raw leg quantity. Per-unit values are always positive because
-/// numerator and denominator share the leg's sign.
-///
-/// A transaction with a single non-fiat leg and no fiat legs (e.g. a
-/// dividend reinvestment recorded as one income leg) is not classifiable
-/// and produces an empty `TradeEventClassification`. Callers that want to
-/// treat such legs as opening positions must handle them separately.
-///
-/// This is the single source of truth used by both
-/// `CapitalGainsCalculator` (tax reporting) and the
-/// `PositionsHistoryBuilder` / `InvestmentStore` cost-basis snapshots
-/// (chart + per-row).
+/// Only non-fiat legs emit capital events. In a fiat+non-fiat pair the
+/// fiat leg is the price carrier; in a non-fiat swap both legs emit events.
+/// Zero-quantity `.trade` legs cause the whole classification to return empty
+/// (no divide-by-zero, no half-emitted event).
 enum TradeEventClassifier {
   static func classify(
     legs: [TransactionLeg],
@@ -57,92 +41,48 @@ enum TradeEventClassifier {
     hostCurrency: Instrument,
     conversionService: any InstrumentConversionService
   ) async throws -> TradeEventClassification {
-    let fiatLegs = legs.filter { $0.instrument.kind == .fiatCurrency }
-    let nonFiatLegs = legs.filter { $0.instrument.kind != .fiatCurrency }
-
-    let (fiatOutflow, fiatInflow) = try await summariseFiatFlows(
-      fiatLegs, on: date, hostCurrency: hostCurrency, conversionService: conversionService)
-
-    let fiatPaired = classifyFiatPaired(
-      nonFiatLegs: nonFiatLegs, fiatOutflow: fiatOutflow, fiatInflow: fiatInflow)
-    if !fiatPaired.buys.isEmpty || !fiatPaired.sells.isEmpty {
-      return fiatPaired
-    }
-
-    // Non-fiat swap: every leg is non-fiat.
-    guard nonFiatLegs.count >= 2 else {
+    let tradeLegs = legs.filter { $0.type == .trade }
+    guard tradeLegs.count == 2 else {
       return TradeEventClassification(buys: [], sells: [])
     }
-    return try await classifyNonFiatSwap(
-      nonFiatLegs: nonFiatLegs, on: date,
-      hostCurrency: hostCurrency, conversionService: conversionService)
-  }
 
-  private static func summariseFiatFlows(
-    _ fiatLegs: [TransactionLeg],
-    on date: Date,
-    hostCurrency: Instrument,
-    conversionService: any InstrumentConversionService
-  ) async throws -> (outflow: Decimal, inflow: Decimal) {
-    var fiatOutflow: Decimal = 0
-    var fiatInflow: Decimal = 0
-    for leg in fiatLegs where leg.quantity != 0 {
-      let converted = try await conversionService.convert(
-        leg.quantity, from: leg.instrument, to: hostCurrency, on: date
-      )
-      if leg.quantity < 0 {
-        fiatOutflow -= converted
-      } else {
-        fiatInflow += converted
-      }
+    // If either trade leg has a zero quantity, we cannot compute a per-unit
+    // price and there is no meaningful event to emit.
+    guard tradeLegs[0].quantity != 0, tradeLegs[1].quantity != 0 else {
+      return TradeEventClassification(buys: [], sells: [])
     }
-    return (fiatOutflow, fiatInflow)
-  }
 
-  private static func classifyFiatPaired(
-    nonFiatLegs: [TransactionLeg], fiatOutflow: Decimal, fiatInflow: Decimal
-  ) -> TradeEventClassification {
+    // Fiat legs act as the price carrier; non-fiat legs are the capital assets.
+    // In a non-fiat swap both legs generate capital events; in a fiat-paired
+    // trade only the non-fiat leg does.
+    let nonFiatIndices = tradeLegs.indices.filter {
+      tradeLegs[$0].instrument.kind != .fiatCurrency
+    }
+    let capitalIndices = nonFiatIndices.isEmpty ? Array(tradeLegs.indices) : nonFiatIndices
+
     var buys: [TradeBuyEvent] = []
     var sells: [TradeSellEvent] = []
-    for leg in nonFiatLegs {
-      if leg.quantity > 0 && fiatOutflow > 0 {
-        buys.append(
-          TradeBuyEvent(
-            instrument: leg.instrument, quantity: leg.quantity,
-            costPerUnit: fiatOutflow / leg.quantity))
-      } else if leg.quantity < 0 && fiatInflow > 0 {
-        let sellQty = -leg.quantity
-        sells.append(
-          TradeSellEvent(
-            instrument: leg.instrument, quantity: sellQty,
-            proceedsPerUnit: fiatInflow / sellQty))
-      }
-    }
-    return TradeEventClassification(buys: buys, sells: sells)
-  }
-
-  private static func classifyNonFiatSwap(
-    nonFiatLegs: [TransactionLeg],
-    on date: Date,
-    hostCurrency: Instrument,
-    conversionService: any InstrumentConversionService
-  ) async throws -> TradeEventClassification {
-    var buys: [TradeBuyEvent] = []
-    var sells: [TradeSellEvent] = []
-    for leg in nonFiatLegs {
-      let profileValue = try await conversionService.convert(
-        leg.quantity, from: leg.instrument, to: hostCurrency, on: date
-      )
-      let valuePerUnit = profileValue / leg.quantity
+    for index in capitalIndices {
+      let leg = tradeLegs[index]
+      let pairIndex = index == 0 ? 1 : 0
+      let pair = tradeLegs[pairIndex]
+      let pairValue = try await conversionService.convert(
+        pair.quantity, from: pair.instrument, to: hostCurrency, on: date)
+      // pair.quantity has the *opposite* sign by convention (paid vs received),
+      // so |pairValue / leg.quantity| is the per-unit cost or proceed.
+      let perUnit = abs(pairValue / leg.quantity)
       if leg.quantity > 0 {
         buys.append(
           TradeBuyEvent(
-            instrument: leg.instrument, quantity: leg.quantity, costPerUnit: valuePerUnit))
+            instrument: leg.instrument,
+            quantity: leg.quantity,
+            costPerUnit: perUnit))
       } else {
-        let sellQty = -leg.quantity
         sells.append(
           TradeSellEvent(
-            instrument: leg.instrument, quantity: sellQty, proceedsPerUnit: valuePerUnit))
+            instrument: leg.instrument,
+            quantity: -leg.quantity,
+            proceedsPerUnit: perUnit))
       }
     }
     return TradeEventClassification(buys: buys, sells: sells)

--- a/Shared/Views/CompactInstrumentPickerButton.swift
+++ b/Shared/Views/CompactInstrumentPickerButton.swift
@@ -1,0 +1,67 @@
+import SwiftUI
+
+/// Compact pull-down that opens the standard `InstrumentPickerSheet` but
+/// shows only the instrument's short code (e.g. `AUD`, `VGS.AX`) — used on
+/// rows where the amount and instrument live side by side and a long
+/// `Australian Dollar (AUD)` label would crowd out the amount.
+struct CompactInstrumentPickerButton: View {
+  @Binding var selection: Instrument
+  let knownInstruments: [Instrument]
+
+  @Environment(ProfileSession.self) private var session: ProfileSession?
+  @State private var isPresented = false
+  @State private var store = InstrumentPickerStore(
+    kinds: Set(Instrument.Kind.allCases))
+
+  var body: some View {
+    Button {
+      store = InstrumentPickerStore(
+        searchService: session?.instrumentSearchService,
+        registry: session?.instrumentRegistry,
+        resolutionClient: session?.tokenResolutionClient,
+        kinds: Set(Instrument.Kind.allCases)
+      )
+      isPresented = true
+    } label: {
+      HStack(spacing: 4) {
+        Text(selection.shortCode)
+          .foregroundStyle(.secondary)
+          .monospacedDigit()
+        Image(systemName: "chevron.up.chevron.down")
+          .foregroundStyle(.tertiary)
+          .font(.caption2)
+      }
+      .contentShape(Rectangle())
+    }
+    .buttonStyle(.plain)
+    .accessibilityLabel(Text("Instrument: \(selection.shortCode)"))
+    .accessibilityHint(Text("Activate to choose a different instrument"))
+    #if os(macOS)
+      .popover(
+        isPresented: $isPresented,
+        arrowEdge: .leading,
+        content: {
+          InstrumentPickerSheet(
+            store: store,
+            label: "Instrument",
+            selection: $selection,
+            isPresented: $isPresented
+          )
+          .frame(minWidth: 460, minHeight: 480)
+        }
+      )
+    #else
+      .sheet(
+        isPresented: $isPresented,
+        content: {
+          InstrumentPickerSheet(
+            store: store,
+            label: "Instrument",
+            selection: $selection,
+            isPresented: $isPresented
+          )
+        }
+      )
+    #endif
+  }
+}

--- a/UITestSupport/UITestIdentifiers.swift
+++ b/UITestSupport/UITestIdentifiers.swift
@@ -71,6 +71,11 @@ public enum UITestIdentifiers {
       "detail.leg.\(index).category"
     }
 
+    /// Picker that selects the transaction type (Income / Expense / Transfer /
+    /// Trade / Custom). Only rendered when the transaction is editable (i.e.
+    /// not an opening balance and not an irrecoverable custom shape).
+    public static let modeTypePicker = "detail.modeTypePicker"
+
     // MARK: Trade mode identifiers
 
     /// Account picker in the trade-mode section. Applies to both `.trade` legs

--- a/UITestSupport/UITestIdentifiers.swift
+++ b/UITestSupport/UITestIdentifiers.swift
@@ -70,6 +70,37 @@ public enum UITestIdentifiers {
     public static func legCategory(_ index: Int) -> String {
       "detail.leg.\(index).category"
     }
+
+    // MARK: Trade mode identifiers
+
+    /// Account picker in the trade-mode section. Applies to both `.trade` legs
+    /// and any fee legs.
+    public static let tradeAccount = "transactionDetail.trade.account"
+
+    /// Paid amount text field in the trade-mode section.
+    public static let tradePaidAmount = "transactionDetail.trade.paidAmount"
+
+    /// Instrument picker button next to the Paid amount field.
+    public static let tradePaidInstrument = "transactionDetail.trade.paidInstrument"
+
+    /// Received amount text field in the trade-mode section.
+    public static let tradeReceivedAmount = "transactionDetail.trade.receivedAmount"
+
+    /// Instrument picker button next to the Received amount field.
+    public static let tradeReceivedInstrument = "transactionDetail.trade.receivedInstrument"
+
+    /// "+ Add fee" button in the trade-mode section. Added by Task 15.
+    public static let tradeAddFeeButton = "transactionDetail.trade.addFee"
+
+    /// Amount text field for fee leg at `index` (absolute index into `legDrafts`).
+    public static func tradeFeeAmount(_ index: Int) -> String {
+      "transactionDetail.trade.feeAmount.\(index)"
+    }
+
+    /// Remove button for fee leg at `index` (absolute index into `legDrafts`).
+    public static func tradeFeeRemove(_ index: Int) -> String {
+      "transactionDetail.trade.feeRemove.\(index)"
+    }
   }
 
   public enum SyncFooter {

--- a/UITestSupport/UITestSeed.swift
+++ b/UITestSupport/UITestSeed.swift
@@ -63,6 +63,13 @@ public enum UITestSeed: String, CaseIterable, Sendable {
   /// IDs) so the `seed.txt` artefact reader can resolve every reference
   /// without cross-file lookup.
   case cryptoCatalogPreloaded
+
+  /// A CloudKit-backed AUD profile with one bank account named "Brokerage",
+  /// a registered VGS.AX stock instrument, and a "Brokerage" category.
+  /// Drives the `TradeFlowUITests` end-to-end test: switching a transaction
+  /// to trade mode, setting paid/received legs and a fee — without any
+  /// remote data dependency.
+  case tradeReady = "trade-ready"
 }
 
 /// Fixtures for the first-run Welcome seeds. Defined here so both the
@@ -250,5 +257,33 @@ public enum UITestFixtures {
     public static let coingeckoMappingId = "uniswap"
     public static let cryptocompareSymbol = "UNI"
     public static let binanceSymbol = "UNIUSDT"
+  }
+
+  /// Fixtures for the `.tradeReady` seed.
+  ///
+  /// Entities (all fixed, deterministic):
+  ///   - Profile `personal` — label "Personal", currency AUD, CloudKit-backed.
+  ///   - Account `brokerage` — "Brokerage", bank, AUD.
+  ///   - Instrument `vgsax` — VGS.AX stock on ASX, registered so it appears
+  ///     in `InstrumentPickerField`.
+  ///   - Category `brokerage` — "Brokerage", so the fee leg can select it.
+  public enum TradeReady {
+    public static let profileId =
+      UUID(uuidString: "A3000000-0000-0000-0000-000000000001") ?? UUID()
+    public static let profileLabel = "Personal"
+    public static let profileCurrencyCode = "AUD"
+
+    public static let brokerageAccountId =
+      UUID(uuidString: "A3000000-0000-0000-0000-000000000010") ?? UUID()
+    public static let brokerageAccountName = "Brokerage"
+
+    public static let vgsaxInstrumentId = "ASX:VGS.AX"
+    public static let vgsaxTicker = "VGS.AX"
+    public static let vgsaxExchange = "ASX"
+    public static let vgsaxName = "VGS"
+
+    public static let brokerageCategoryId =
+      UUID(uuidString: "A3000000-0000-0000-0000-000000000040") ?? UUID()
+    public static let brokerageCategoryName = "Brokerage"
   }
 }


### PR DESCRIPTION
## Summary

Implements [\`plans/2026-04-28-trade-transaction-ui-design.md\`](plans/2026-04-28-trade-transaction-ui-design.md) and the 20-task plan in [\`plans/2026-04-28-trade-transaction-ui-implementation.md\`](plans/2026-04-28-trade-transaction-ui-implementation.md). First-class Trade transactions land alongside Income / Expense / Transfer / Custom in the inspector and the transaction list.

### What's new

- **Domain:** new \`TransactionType.trade\` leg type and \`Transaction.isTrade\` structural detector (2 \`.trade\` legs + 0+ \`.expense\` fee legs, single non-nil account).
- **Classifier:** \`TradeEventClassifier\` filters by \`type == .trade\` (much simpler than the old fiat-paired/swap inference). Fee legs are intentionally excluded from cost basis — tracked in [#558](https://github.com/ajsutton/moolah-native/issues/558).
- **Row view:** indigo \`arrow.up.arrow.down\` icon for trades. Generalised per-instrument amount column for **all** rows — sums legs by native instrument in scope, wraps when there isn't horizontal room, with the existing zero-sum fallback for same-currency transfers preserved. Title leads with payee then \`(Bought / Sold / Swapped …)\` per design §4.3 verb selection (with scope reference = account / earmark / profile currency).
- **Detail view:** new \`tradeModeContent\` branch with single Account picker, Paid + Received rows (with derived rate), and dynamically-added Fee sections (\`+ Add Fee\` / Remove). Mode switching in both directions works as specified in design §3.3.
- **Sign handling:** trade legs round-trip with sign by position (first \`.trade\` leg = Paid / negative; second = Received / positive). \`TransactionDraft.toTransaction\` re-signs defensively via \`abs()\`.
- **Tests:** 80+ new Swift Testing cases across enum / structure / classifier / row / draft / mode-switch / round-trip suites. New \`TradeFlowUITests\` end-to-end XCUITest with a \`tradeReady\` seed.

### Out of scope (tracked separately)

- [#558](https://github.com/ajsutton/moolah-native/issues/558) — \`SelfWealthParser\` fee-attach + cost-basis decision.
- [#563](https://github.com/ajsutton/moolah-native/issues/563) — positive-only enforcement on Paid/Received fields (referenced via TODO in \`TransactionDetailTradeSection.swift\`).

## Test plan

- [x] \`just format-check\` clean
- [x] \`just test-mac\` — full macOS unit-test suite green
- [ ] \`just test-ui TradeFlowUITests\` — code compiles and is structurally sound; runtime verification was blocked locally by a system-level LocalAuthentication issue. CI will exercise it in a clean environment.
- [ ] Manual: open a brokerage account, switch a transaction to Trade, enter Paid + Received + a fee, save, and confirm the row renders with the indigo trade icon and "Bought 20 VGS.AX" title.
- [ ] Manual: switch a Trade → Income / Expense / Transfer / Custom and back; data preserved per design §3.3.