### PR TITLE
fix(trades): UI polish + LegDraft holds Instrument directly

### DIFF
--- a/App/UITestSeedHydrator+TradeReady.swift
+++ b/App/UITestSeedHydrator+TradeReady.swift
@@ -1,0 +1,177 @@
+import Foundation
+import SwiftData
+
+// Trade-Ready seed helpers split out of `UITestSeedHydrator` so the main enum
+// body stays under SwiftLint's `type_body_length` threshold.
+extension UITestSeedHydrator {
+  // MARK: - Specs
+
+  struct TradeFeeSpec {
+    let instrument: Instrument
+    let quantity: Decimal
+    let categoryId: UUID
+  }
+
+  struct TradeTransactionSpec {
+    let id: UUID
+    let date: Date
+    let payee: String?
+    let accountId: UUID
+    let paid: (instrument: Instrument, quantity: Decimal)
+    let received: (instrument: Instrument, quantity: Decimal)
+    let fee: TradeFeeSpec?
+  }
+
+  // MARK: - Trade-Ready seed
+
+  static func hydrateTradeReady(
+    into manager: ProfileContainerManager
+  ) throws -> Profile {
+    let fixtures = UITestFixtures.TradeReady.self
+
+    let profile = Profile(
+      id: fixtures.profileId,
+      label: fixtures.profileLabel,
+      currencyCode: fixtures.profileCurrencyCode,
+      financialYearStartMonth: 7,
+      createdAt: Date(timeIntervalSince1970: 1_700_000_000)
+    )
+    try upsertProfile(profile, into: manager)
+
+    let container = try manager.container(for: profile.id)
+    let context = ModelContext(container)
+    let audInstrument = profile.instrument
+
+    try upsertInstrument(audInstrument, in: context)
+    try upsertAccount(
+      AccountSpec(
+        id: fixtures.brokerageAccountId,
+        name: fixtures.brokerageAccountName,
+        type: .bank,
+        instrumentId: audInstrument.id,
+        position: 0),
+      in: context)
+
+    let vgsax = Instrument.stock(
+      ticker: fixtures.vgsaxTicker,
+      exchange: fixtures.vgsaxExchange,
+      name: fixtures.vgsaxName)
+    try upsertInstrument(vgsax, in: context)
+
+    try upsertCategory(
+      id: fixtures.brokerageCategoryId,
+      name: fixtures.brokerageCategoryName,
+      in: context)
+
+    try seedTradeReadyTransactions(
+      brokerageId: fixtures.brokerageAccountId,
+      audInstrument: audInstrument,
+      vgsax: vgsax,
+      brokerageCategoryId: fixtures.brokerageCategoryId,
+      in: context)
+
+    try context.save()
+    return profile
+  }
+
+  /// Sample trades for the `tradeReady` seed:
+  /// - 14-Apr-26 buy: −$300 AUD → +20 VGS.AX with $10 brokerage fee.
+  /// - 21-Apr-26 buy: −$160 AUD → +10 VGS.AX (no fee).
+  /// - 28-Apr-26 sell: +$425 AUD → −10 VGS.AX with $5 brokerage fee.
+  private static func seedTradeReadyTransactions(
+    brokerageId: UUID,
+    audInstrument: Instrument,
+    vgsax: Instrument,
+    brokerageCategoryId: UUID,
+    in context: ModelContext
+  ) throws {
+    let day: TimeInterval = 86_400
+    let base = Date(timeIntervalSince1970: 1_776_000_000)  // mid-April 2026
+    let fixtures = UITestFixtures.TradeReady.self
+
+    try insertTradeTransaction(
+      TradeTransactionSpec(
+        id: fixtures.trade1Id,
+        date: base,
+        payee: "SelfWealth",
+        accountId: brokerageId,
+        paid: (audInstrument, -300),
+        received: (vgsax, 20),
+        fee: TradeFeeSpec(instrument: audInstrument, quantity: -10, categoryId: brokerageCategoryId)
+      ),
+      in: context)
+
+    try insertTradeTransaction(
+      TradeTransactionSpec(
+        id: fixtures.trade2Id,
+        date: base.addingTimeInterval(7 * day),
+        payee: nil,
+        accountId: brokerageId,
+        paid: (audInstrument, -160),
+        received: (vgsax, 10),
+        fee: nil
+      ),
+      in: context)
+
+    try insertTradeTransaction(
+      TradeTransactionSpec(
+        id: fixtures.trade3Id,
+        date: base.addingTimeInterval(14 * day),
+        payee: "SelfWealth",
+        accountId: brokerageId,
+        paid: (audInstrument, 425),
+        received: (vgsax, -10),
+        fee: TradeFeeSpec(instrument: audInstrument, quantity: -5, categoryId: brokerageCategoryId)
+      ),
+      in: context)
+  }
+
+  private static func insertTradeTransaction(
+    _ spec: TradeTransactionSpec,
+    in context: ModelContext
+  ) throws {
+    let id = spec.id
+    let descriptor = FetchDescriptor<TransactionRecord>(
+      predicate: #Predicate { $0.id == id }
+    )
+    if try context.fetch(descriptor).first != nil { return }
+
+    context.insert(TransactionRecord(id: spec.id, date: spec.date, payee: spec.payee))
+
+    let paidAmount = InstrumentAmount(
+      quantity: spec.paid.quantity, instrument: spec.paid.instrument)
+    let receivedAmount = InstrumentAmount(
+      quantity: spec.received.quantity, instrument: spec.received.instrument)
+    context.insert(
+      TransactionLegRecord(
+        transactionId: spec.id,
+        accountId: spec.accountId,
+        instrumentId: spec.paid.instrument.id,
+        quantity: paidAmount.storageValue,
+        type: TransactionType.trade.rawValue,
+        sortOrder: 0
+      ))
+    context.insert(
+      TransactionLegRecord(
+        transactionId: spec.id,
+        accountId: spec.accountId,
+        instrumentId: spec.received.instrument.id,
+        quantity: receivedAmount.storageValue,
+        type: TransactionType.trade.rawValue,
+        sortOrder: 1
+      ))
+    if let fee = spec.fee {
+      let feeAmount = InstrumentAmount(quantity: fee.quantity, instrument: fee.instrument)
+      context.insert(
+        TransactionLegRecord(
+          transactionId: spec.id,
+          accountId: spec.accountId,
+          instrumentId: fee.instrument.id,
+          quantity: feeAmount.storageValue,
+          type: TransactionType.expense.rawValue,
+          categoryId: fee.categoryId,
+          sortOrder: 2
+        ))
+    }
+  }
+}

--- a/App/UITestSeedHydrator.swift
+++ b/App/UITestSeedHydrator.swift
@@ -90,49 +90,6 @@ enum UITestSeedHydrator {
 
   // MARK: - Seeds
 
-  private static func hydrateTradeReady(
-    into manager: ProfileContainerManager
-  ) throws -> Profile {
-    let fixtures = UITestFixtures.TradeReady.self
-
-    let profile = Profile(
-      id: fixtures.profileId,
-      label: fixtures.profileLabel,
-      currencyCode: fixtures.profileCurrencyCode,
-      financialYearStartMonth: 7,
-      createdAt: Date(timeIntervalSince1970: 1_700_000_000)
-    )
-    try upsertProfile(profile, into: manager)
-
-    let container = try manager.container(for: profile.id)
-    let context = ModelContext(container)
-    let audInstrument = profile.instrument
-
-    try upsertInstrument(audInstrument, in: context)
-    try upsertAccount(
-      AccountSpec(
-        id: fixtures.brokerageAccountId,
-        name: fixtures.brokerageAccountName,
-        type: .bank,
-        instrumentId: audInstrument.id,
-        position: 0),
-      in: context)
-
-    let vgsax = Instrument.stock(
-      ticker: fixtures.vgsaxTicker,
-      exchange: fixtures.vgsaxExchange,
-      name: fixtures.vgsaxName)
-    try upsertInstrument(vgsax, in: context)
-
-    try upsertCategory(
-      id: fixtures.brokerageCategoryId,
-      name: fixtures.brokerageCategoryName,
-      in: context)
-
-    try context.save()
-    return profile
-  }
-
   private static func hydrateTradeBaseline(
     into manager: ProfileContainerManager
   ) throws -> Profile {

--- a/Features/Transactions/Views/Detail/TransactionDetailAddLegSection.swift
+++ b/Features/Transactions/Views/Detail/TransactionDetailAddLegSection.swift
@@ -13,7 +13,7 @@ struct TransactionDetailAddLegSection: View {
         let defaultAccount = sortedAccounts.first
         draft.addLeg(
           defaultAccountId: defaultAccount?.id,
-          instrumentId: defaultAccount?.instrument.id
+          instrument: defaultAccount?.instrument
         )
       }
       .accessibilityLabel("Add Sub-transaction")

--- a/Features/Transactions/Views/Detail/TransactionDetailFeeSection.swift
+++ b/Features/Transactions/Views/Detail/TransactionDetailFeeSection.swift
@@ -9,7 +9,6 @@ struct TransactionDetailFeeSection: View {
   let accounts: Accounts
   let categories: Categories
   let earmarks: Earmarks
-  let knownInstruments: [Instrument]
   @Binding var categoryState: CategoryAutocompleteState
   @FocusState.Binding var focusedField: TransactionDetailFocus?
   let onRequestRemove: () -> Void
@@ -38,11 +37,8 @@ struct TransactionDetailFeeSection: View {
       get: { draft.legDrafts[legIndex].amountText },
       set: { draft.legDrafts[legIndex].amountText = $0 })
     let instrumentBinding = Binding<Instrument>(
-      get: {
-        let id = draft.legDrafts[legIndex].instrumentId ?? Instrument.AUD.id
-        return knownInstruments.first { $0.id == id } ?? Instrument.fiat(code: id)
-      },
-      set: { draft.legDrafts[legIndex].instrumentId = $0.id })
+      get: { draft.legDrafts[legIndex].instrument ?? Instrument.AUD },
+      set: { draft.legDrafts[legIndex].instrument = $0 })
 
     return LabeledContent {
       HStack(spacing: 8) {
@@ -55,10 +51,7 @@ struct TransactionDetailFeeSection: View {
           #endif
           .focused($focusedField, equals: .tradeFeeAmount(legIndex))
           .accessibilityIdentifier(UITestIdentifiers.Detail.tradeFeeAmount(displayNumber - 1))
-        CompactInstrumentPickerButton(
-          selection: instrumentBinding,
-          knownInstruments: knownInstruments
-        )
+        CompactInstrumentPickerButton(selection: instrumentBinding)
       }
     } label: {
       Text("Amount")

--- a/Features/Transactions/Views/Detail/TransactionDetailFeeSection.swift
+++ b/Features/Transactions/Views/Detail/TransactionDetailFeeSection.swift
@@ -15,20 +15,32 @@ struct TransactionDetailFeeSection: View {
 
   @FocusState private var categoryFieldFocused: Bool
 
+  /// True when `legIndex` still refers to an `.expense` leg in `legDrafts`.
+  /// SwiftUI re-evaluates this view's body once after `removeFee(at:)` has
+  /// shrunk `legDrafts` but before the surrounding `ForEach` finishes
+  /// removing the row, so a naive subscript would trap.
+  private var isLive: Bool {
+    draft.legDrafts.indices.contains(legIndex)
+      && draft.legDrafts[legIndex].type == .expense
+  }
+
   private var visibleSuggestions: [CategorySuggestion] {
-    categoryState.visibleSuggestions(
+    guard isLive else { return [] }
+    return categoryState.visibleSuggestions(
       for: draft.legDrafts[legIndex].categoryText, in: categories)
   }
 
   var body: some View {
-    Section("Fee \(displayNumber)") {
-      amountRow
-      categoryField
-      earmarkPicker
-      Button(role: .destructive, action: onRequestRemove) {
-        Text("Remove Fee").frame(maxWidth: .infinity)
+    if isLive {
+      Section("Fee \(displayNumber)") {
+        amountRow
+        categoryField
+        earmarkPicker
+        Button(role: .destructive, action: onRequestRemove) {
+          Text("Remove Fee").frame(maxWidth: .infinity)
+        }
+        .accessibilityIdentifier(UITestIdentifiers.Detail.tradeFeeRemove(displayNumber - 1))
       }
-      .accessibilityIdentifier(UITestIdentifiers.Detail.tradeFeeRemove(displayNumber - 1))
     }
   }
 

--- a/Features/Transactions/Views/Detail/TransactionDetailLegRow.swift
+++ b/Features/Transactions/Views/Detail/TransactionDetailLegRow.swift
@@ -15,7 +15,6 @@ struct TransactionDetailLegRow: View {
   let accounts: Accounts
   let categories: Categories
   let earmarks: Earmarks
-  let knownInstruments: [Instrument]
   let sortedAccounts: [Account]
   @Binding var categoryState: CategoryAutocompleteState
   @FocusState.Binding var focusedField: TransactionDetailFocus?
@@ -72,22 +71,19 @@ struct TransactionDetailLegRow: View {
     .onChange(of: draft.legDrafts[index].accountId) { _, newAccountId in
       draft.enforceEarmarkOnlyInvariants(at: index)
       if let newAccountId, let account = accounts.by(id: newAccountId) {
-        draft.legDrafts[index].instrumentId = account.instrument.id
+        draft.legDrafts[index].instrument = account.instrument
       } else if let emId = draft.legDrafts[index].earmarkId,
         let earmark = earmarks.by(id: emId)
       {
-        draft.legDrafts[index].instrumentId = earmark.instrument.id
+        draft.legDrafts[index].instrument = earmark.instrument
       }
     }
   }
 
   @ViewBuilder private var instrumentPicker: some View {
     let binding = Binding<Instrument>(
-      get: {
-        let id = draft.legDrafts[index].instrumentId ?? defaultInstrumentId
-        return resolveInstrument(id)
-      },
-      set: { draft.legDrafts[index].instrumentId = $0.id }
+      get: { draft.legDrafts[index].instrument ?? defaultInstrument },
+      set: { draft.legDrafts[index].instrument = $0 }
     )
     InstrumentPickerField(
       label: "Asset",
@@ -107,7 +103,7 @@ struct TransactionDetailLegRow: View {
           .keyboardType(.decimalPad)
         #endif
         .focused($focusedField, equals: .legAmount(index))
-      Text(draft.legDrafts[index].instrumentId ?? defaultInstrumentId)
+      Text(draft.legDrafts[index].instrument?.shortCode ?? defaultInstrument.shortCode)
         .foregroundStyle(.secondary)
         .monospacedDigit()
     }
@@ -148,20 +144,16 @@ struct TransactionDetailLegRow: View {
   }
 
   /// Falls back to the leg's account instrument and then earmark
-  /// instrument when the leg has no explicit override.
-  private var defaultInstrumentId: String {
+  /// instrument when the leg has no explicit instrument stored.
+  private var defaultInstrument: Instrument {
     let leg = draft.legDrafts[index]
     if let acctId = leg.accountId, let account = accounts.by(id: acctId) {
-      return account.instrument.id
+      return account.instrument
     }
     if let emId = leg.earmarkId, let earmark = earmarks.by(id: emId) {
-      return earmark.instrument.id
+      return earmark.instrument
     }
-    return ""
-  }
-
-  private func resolveInstrument(_ id: String) -> Instrument {
-    knownInstruments.first { $0.id == id } ?? Instrument.fiat(code: id)
+    return Instrument.AUD
   }
 
   /// Opens the dropdown in response to a *user-driven* edit. Programmatic

--- a/Features/Transactions/Views/Detail/TransactionDetailTradeSection.swift
+++ b/Features/Transactions/Views/Detail/TransactionDetailTradeSection.swift
@@ -15,7 +15,6 @@ struct TransactionDetailTradeSection: View {
   @Binding var draft: TransactionDraft
   let accounts: Accounts
   let sortedAccounts: [Account]
-  let knownInstruments: [Instrument]
   @FocusState.Binding var focusedField: TransactionDetailFocus?
 
   var body: some View {
@@ -43,8 +42,8 @@ struct TransactionDetailTradeSection: View {
             draft.legDrafts[index].type == .expense
           {
             // Default new fee instruments to the account's currency.
-            draft.legDrafts[index].instrumentId =
-              draft.legDrafts[index].instrumentId ?? account.instrument.id
+            draft.legDrafts[index].instrument =
+              draft.legDrafts[index].instrument ?? account.instrument
           }
         }
       }
@@ -94,11 +93,8 @@ struct TransactionDetailTradeSection: View {
         get: { draft.legDrafts[idx].amountText },
         set: { draft.legDrafts[idx].amountText = $0 })
       let instrumentBinding = Binding<Instrument>(
-        get: {
-          let id = draft.legDrafts[idx].instrumentId ?? Instrument.AUD.id
-          return knownInstruments.first { $0.id == id } ?? Instrument.fiat(code: id)
-        },
-        set: { draft.legDrafts[idx].instrumentId = $0.id })
+        get: { draft.legDrafts[idx].instrument ?? Instrument.AUD },
+        set: { draft.legDrafts[idx].instrument = $0 })
 
       LabeledContent {
         HStack(spacing: 8) {
@@ -111,11 +107,8 @@ struct TransactionDetailTradeSection: View {
             #endif
             .focused($focusedField, equals: focus)
             .accessibilityIdentifier(identifier)
-          CompactInstrumentPickerButton(
-            selection: instrumentBinding,
-            knownInstruments: knownInstruments
-          )
-          .accessibilityIdentifier(instrumentIdentifier)
+          CompactInstrumentPickerButton(selection: instrumentBinding)
+            .accessibilityIdentifier(instrumentIdentifier)
         }
       } label: {
         Text(label)
@@ -131,14 +124,8 @@ struct TransactionDetailTradeSection: View {
     else { return nil }
     let paid = draft.legDrafts[paidIdx]
     let received = draft.legDrafts[receivedIdx]
-    let paidInst =
-      paid.instrumentId.flatMap { id in
-        knownInstruments.first { $0.id == id } ?? Instrument.fiat(code: id)
-      } ?? Instrument.AUD
-    let receivedInst =
-      received.instrumentId.flatMap { id in
-        knownInstruments.first { $0.id == id } ?? Instrument.fiat(code: id)
-      } ?? Instrument.AUD
+    let paidInst = paid.instrument ?? Instrument.AUD
+    let receivedInst = received.instrument ?? Instrument.AUD
     guard
       let paidQty = InstrumentAmount.parseQuantity(
         from: paid.amountText, decimals: paidInst.decimals),

--- a/Features/Transactions/Views/TransactionDetailView+Actions.swift
+++ b/Features/Transactions/Views/TransactionDetailView+Actions.swift
@@ -1,13 +1,5 @@
 import SwiftUI
 
-// Common fiat instruments available to leg-instrument resolution when the
-// instrument registry has not yet loaded (e.g. on first render). Registered
-// stocks/crypto are supplied by `knownInstruments` loaded via `.task`.
-private let commonFiatInstruments: [Instrument] = [
-  "AUD", "CAD", "CHF", "CNY", "EUR", "GBP", "HKD", "INR", "JPY", "KRW",
-  "MXN", "NOK", "NZD", "SEK", "SGD", "USD", "ZAR",
-].map { Instrument.fiat(code: $0) }
-
 // MARK: - Actions
 
 extension TransactionDetailView {
@@ -33,13 +25,11 @@ extension TransactionDetailView {
   }
 
   func saveIfValid() {
-    let allKnownInstruments = knownInstruments + commonFiatInstruments
     guard
       let updated = draft.toTransaction(
         id: transaction.id,
         accounts: accounts,
-        earmarks: earmarks,
-        availableInstruments: allKnownInstruments)
+        earmarks: earmarks)
     else { return }
     onUpdate(updated)
   }

--- a/Features/Transactions/Views/TransactionDetailView.swift
+++ b/Features/Transactions/Views/TransactionDetailView.swift
@@ -13,13 +13,12 @@ struct TransactionDetailView: View {
 
   @Environment(ProfileSession.self) private var session: ProfileSession?
 
-  // `draft`, `knownInstruments`, and `openedAsNewTransaction` use internal
-  // access (no `private`) so that extension files in this module
+  // `draft` and `openedAsNewTransaction` use internal access (no `private`)
+  // so that extension files in this module
   // (TransactionDetailView+Helpers.swift, TransactionDetailView+Actions.swift)
   // can reference them. SwiftLint's strict_fileprivate rule disallows
   // `fileprivate`, making internal the smallest legal cross-file scope.
   @State var draft: TransactionDraft
-  @State var knownInstruments: [Instrument] = []
   @State private var showDeleteConfirmation = false
   @State private var payeeState = PayeeAutocompleteState()
   @State private var categoryState = CategoryAutocompleteState()
@@ -117,9 +116,6 @@ struct TransactionDetailView: View {
         }
       #endif
       .onChange(of: draft) { _, _ in debouncedSave() }
-      .task {
-        knownInstruments = (try? await session?.instrumentRegistry?.all()) ?? []
-      }
       .confirmationDialog(
         "Delete Transaction",
         isPresented: $showDeleteConfirmation,
@@ -198,11 +194,22 @@ extension TransactionDetailView {
 
   @ViewBuilder private var tradeModeContent: some View {
     modeSection.disabled(!isEditable)
+    // Payee + date sit at the top alongside the type picker, mirroring the
+    // simple income / expense / transfer layout so the form reads
+    // consistently across modes.
+    TransactionDetailCustomDetailsSection(
+      draft: $draft,
+      suggestionSource: transactionStore.payeeSuggestionSource,
+      payeeState: $payeeState,
+      onAutofill: autofillFromPayee,
+      focusedField: $focusedField
+    )
+    .disabled(!isEditable)
+
     TransactionDetailTradeSection(
       draft: $draft,
       accounts: accounts,
       sortedAccounts: sortedAccounts,
-      knownInstruments: knownInstruments,
       focusedField: $focusedField
     )
     .disabled(!isEditable)
@@ -215,7 +222,6 @@ extension TransactionDetailView {
         accounts: accounts,
         categories: categories,
         earmarks: earmarks,
-        knownInstruments: knownInstruments,
         categoryState: legCategoryStateBinding(for: legIndex),
         focusedField: $focusedField,
         onRequestRemove: { draft.removeFee(at: legIndex) }
@@ -224,24 +230,16 @@ extension TransactionDetailView {
 
     Section {
       Button {
-        let fallback =
+        let defaultInstrument =
           draft.legDrafts.first?.accountId
-          .flatMap { accounts.by(id: $0) }?.instrument.id ?? Instrument.AUD.id
-        draft.appendFee(defaultInstrumentId: fallback)
+          .flatMap { accounts.by(id: $0) }?.instrument ?? Instrument.AUD
+        draft.appendFee(defaultInstrument: defaultInstrument)
       } label: {
         Label("Add Fee", systemImage: "plus")
           .frame(maxWidth: .infinity)
       }
       .accessibilityIdentifier(UITestIdentifiers.Detail.tradeAddFeeButton)
     }
-
-    TransactionDetailCustomDetailsSection(
-      draft: $draft,
-      suggestionSource: transactionStore.payeeSuggestionSource,
-      payeeState: $payeeState,
-      onAutofill: autofillFromPayee,
-      focusedField: $focusedField
-    )
 
     if showRecurrence {
       TransactionDetailRecurrenceSection(draft: $draft).disabled(!isEditable)
@@ -300,7 +298,6 @@ extension TransactionDetailView {
         accounts: accounts,
         categories: categories,
         earmarks: earmarks,
-        knownInstruments: knownInstruments,
         sortedAccounts: sortedAccounts,
         categoryState: legCategoryStateBinding(for: index),
         focusedField: $focusedField,

--- a/Features/Transactions/Views/TransactionInspectorModifier.swift
+++ b/Features/Transactions/Views/TransactionInspectorModifier.swift
@@ -26,7 +26,9 @@ struct TransactionInspectorModifier: ViewModifier {
       #if os(macOS)
         .inspector(isPresented: isPresented) {
           if let selected = selectedTransaction {
-            detailView(for: selected).id(selected.id)
+            detailView(for: selected)
+            .id(selected.id)
+            .inspectorColumnWidth(min: 320, ideal: 360, max: 600)
           }
         }
         .toolbar { hideDetailsToolbar }

--- a/MoolahTests/Features/TransactionStoreScheduledOneOffTests.swift
+++ b/MoolahTests/Features/TransactionStoreScheduledOneOffTests.swift
@@ -45,9 +45,7 @@ struct TransactionStoreScheduledOneOffTests {
     var draft = TransactionDraft(from: created)
     draft.isRepeating = false
     let updated = try #require(
-      draft.toTransaction(
-        id: created.id,
-        availableInstruments: [Instrument.defaultTestInstrument]))
+      draft.toTransaction(id: created.id))
     await store.update(updated)
 
     // The persisted transaction stays scheduled (period demoted to .once)

--- a/MoolahTests/Shared/TransactionDraftAccountTests.swift
+++ b/MoolahTests/Shared/TransactionDraftAccountTests.swift
@@ -76,13 +76,13 @@ struct TransactionDraftAccountTests {
         TransactionDraft.LegDraft(
           type: .expense, accountId: support.accountA, amountText: "4.50",
           categoryId: nil, categoryText: "", earmarkId: nil,
-          instrumentId: Instrument.USD.id)
+          instrument: Instrument.USD)
       ],
       relevantLegIndex: 0, viewingAccountId: nil
     )
 
     let transaction = try #require(
-      draft.toTransaction(id: UUID(), accounts: accounts, availableInstruments: [.USD]))
+      draft.toTransaction(id: UUID(), accounts: accounts))
     let expectedQuantity = try #require(Decimal(string: "-4.50"))
     #expect(transaction.legs.count == 1)
     #expect(transaction.legs[0].instrument == .USD)
@@ -103,17 +103,17 @@ struct TransactionDraftAccountTests {
         TransactionDraft.LegDraft(
           type: .transfer, accountId: support.accountA, amountText: "1000.00",
           categoryId: nil, categoryText: "", earmarkId: nil,
-          instrumentId: Instrument.AUD.id),
+          instrument: Instrument.AUD),
         TransactionDraft.LegDraft(
           type: .transfer, accountId: support.accountB, amountText: "-650.00",
           categoryId: nil, categoryText: "", earmarkId: nil,
-          instrumentId: Instrument.USD.id),
+          instrument: Instrument.USD),
       ],
       relevantLegIndex: 0, viewingAccountId: nil
     )
 
     let transaction = try #require(
-      draft.toTransaction(id: UUID(), accounts: accounts, availableInstruments: [.AUD, .USD]))
+      draft.toTransaction(id: UUID(), accounts: accounts))
     let audQuantity = try #require(Decimal(string: "-1000.00"))
     let usdQuantity = try #require(Decimal(string: "650.00"))
     #expect(transaction.legs.count == 2)
@@ -139,17 +139,17 @@ struct TransactionDraftAccountTests {
         TransactionDraft.LegDraft(
           type: .transfer, accountId: support.accountA, amountText: "6345.00",
           categoryId: nil, categoryText: "", earmarkId: nil,
-          instrumentId: Instrument.AUD.id),
+          instrument: Instrument.AUD),
         TransactionDraft.LegDraft(
           type: .transfer, accountId: support.accountB, amountText: "-150",
           categoryId: nil, categoryText: "", earmarkId: nil,
-          instrumentId: bhp.id),
+          instrument: bhp),
       ],
       relevantLegIndex: 0, viewingAccountId: nil
     )
 
     let transaction = try #require(
-      draft.toTransaction(id: UUID(), accounts: accounts, availableInstruments: [.AUD, bhp]))
+      draft.toTransaction(id: UUID(), accounts: accounts))
     let audQuantity = try #require(Decimal(string: "-6345.00"))
     #expect(transaction.legs.count == 2)
     #expect(transaction.legs[0].instrument == .AUD)

--- a/MoolahTests/Shared/TransactionDraftAutofillTests.swift
+++ b/MoolahTests/Shared/TransactionDraftAutofillTests.swift
@@ -133,7 +133,7 @@ struct TransactionDraftAutofillTests {
     draft.applyAutofill(from: matchTx, categories: Categories(from: []), accounts: accounts)
 
     #expect(draft.legDrafts[0].accountId == support.accountA)
-    #expect(draft.legDrafts[0].instrumentId == usd.id)
+    #expect(draft.legDrafts[0].instrument == usd)
   }
 
   @Test

--- a/MoolahTests/Shared/TransactionDraftCrossCurrencyTests.swift
+++ b/MoolahTests/Shared/TransactionDraftCrossCurrencyTests.swift
@@ -203,8 +203,7 @@ struct TransactionDraftCrossCurrencyTests {
     let draft = TransactionDraft(
       from: original, viewingAccountId: support.accountA, accounts: accounts)
     let roundTripped = try #require(
-      draft.toTransaction(
-        id: id, accounts: accounts, availableInstruments: [.AUD, .USD]))
+      draft.toTransaction(id: id, accounts: accounts))
     #expect(roundTripped.legs.count == 2)
     #expect(roundTripped.legs[0].quantity == Decimal(string: "-100"))
     #expect(roundTripped.legs[0].instrument == .AUD)

--- a/MoolahTests/Shared/TransactionDraftEarmarkOnlyTests.swift
+++ b/MoolahTests/Shared/TransactionDraftEarmarkOnlyTests.swift
@@ -48,7 +48,8 @@ struct TransactionDraftEarmarkOnlyTests {
       legDrafts: [
         TransactionDraft.LegDraft(
           type: .income, accountId: nil, amountText: "100",
-          categoryId: nil, categoryText: "", earmarkId: UUID())
+          categoryId: nil, categoryText: "", earmarkId: UUID(),
+          instrument: support.instrument)
       ],
       relevantLegIndex: 0, viewingAccountId: nil
     )
@@ -80,10 +81,12 @@ struct TransactionDraftEarmarkOnlyTests {
       legDrafts: [
         TransactionDraft.LegDraft(
           type: .expense, accountId: UUID(), amountText: "50",
-          categoryId: nil, categoryText: "", earmarkId: nil),
+          categoryId: nil, categoryText: "", earmarkId: nil,
+          instrument: support.instrument),
         TransactionDraft.LegDraft(
           type: .income, accountId: nil, amountText: "50",
-          categoryId: nil, categoryText: "", earmarkId: UUID()),
+          categoryId: nil, categoryText: "", earmarkId: UUID(),
+          instrument: support.instrument),
       ],
       relevantLegIndex: 0, viewingAccountId: nil
     )
@@ -101,7 +104,7 @@ struct TransactionDraftEarmarkOnlyTests {
         TransactionDraft.LegDraft(
           type: .income, accountId: nil, amountText: "500",
           categoryId: nil, categoryText: "", earmarkId: emId,
-          instrumentId: Instrument.defaultTestInstrument.id)
+          instrument: Instrument.defaultTestInstrument)
       ],
       relevantLegIndex: 0, viewingAccountId: nil
     )
@@ -112,8 +115,7 @@ struct TransactionDraftEarmarkOnlyTests {
     ])
     let transaction = try #require(
       draft.toTransaction(
-        id: UUID(), accounts: Accounts(from: []), earmarks: earmarks,
-        availableInstruments: [support.instrument]))
+        id: UUID(), accounts: Accounts(from: []), earmarks: earmarks))
     #expect(transaction.legs.count == 1)
     #expect(transaction.legs[0].accountId == nil)
     #expect(transaction.legs[0].earmarkId == emId)
@@ -134,11 +136,11 @@ struct TransactionDraftEarmarkOnlyTests {
         TransactionDraft.LegDraft(
           type: .expense, accountId: acctId, amountText: "50",
           categoryId: nil, categoryText: "", earmarkId: nil,
-          instrumentId: Instrument.defaultTestInstrument.id),
+          instrument: Instrument.defaultTestInstrument),
         TransactionDraft.LegDraft(
           type: .income, accountId: nil, amountText: "50",
           categoryId: nil, categoryText: "", earmarkId: emId,
-          instrumentId: Instrument.defaultTestInstrument.id),
+          instrument: Instrument.defaultTestInstrument),
       ],
       relevantLegIndex: 0, viewingAccountId: nil
     )
@@ -153,8 +155,7 @@ struct TransactionDraftEarmarkOnlyTests {
     ])
     let transaction = try #require(
       draft.toTransaction(
-        id: UUID(), accounts: accounts, earmarks: earmarks,
-        availableInstruments: [support.instrument]))
+        id: UUID(), accounts: accounts, earmarks: earmarks))
     #expect(transaction.legs.count == 2)
     #expect(transaction.legs[0].accountId == acctId)
     #expect(transaction.legs[1].accountId == nil)

--- a/MoolahTests/Shared/TransactionDraftForwardSwitchTests.swift
+++ b/MoolahTests/Shared/TransactionDraftForwardSwitchTests.swift
@@ -20,11 +20,11 @@ struct TransactionDraftForwardSwitchTests {
 
   @Test("Income → Trade: existing leg becomes Received, Paid added at 0 in account currency")
   func incomeToTrade() throws {
-    var draft = TransactionDraft(accountId: acctA, instrumentId: aud.id)
+    var draft = TransactionDraft(accountId: acctA, instrument: aud)
     draft.legDrafts = [
       TransactionDraft.LegDraft(
         type: .income, accountId: acctA, amountText: "3500",
-        categoryId: nil, categoryText: "", earmarkId: nil, instrumentId: aud.id)
+        categoryId: nil, categoryText: "", earmarkId: nil, instrument: aud)
     ]
     draft.switchToTrade(accounts: accountsAUD())
     #expect(draft.legDrafts.count == 2)
@@ -32,11 +32,11 @@ struct TransactionDraftForwardSwitchTests {
     let receivedIndex = try #require(draft.receivedLegIndex)
     let received = draft.legDrafts[receivedIndex]
     #expect(received.amountText == "3500")
-    #expect(received.instrumentId == aud.id)
+    #expect(received.instrument == aud)
     let paidIndex = try #require(draft.paidLegIndex)
     let paid = draft.legDrafts[paidIndex]
     #expect(paid.amountText == "0")
-    #expect(paid.instrumentId == aud.id)
+    #expect(paid.instrument == aud)
   }
 
   @Test("Expense → Trade: existing leg becomes Paid; sign re-emitted for trade display")
@@ -44,11 +44,11 @@ struct TransactionDraftForwardSwitchTests {
     // Expense's `displaysNegated == true` means amountText "300" represents
     // a stored quantity of -300. `.trade` doesn't negate, so the carried
     // amountText flips to "-300" so the same -300 round-trips through trade.
-    var draft = TransactionDraft(accountId: acctA, instrumentId: aud.id)
+    var draft = TransactionDraft(accountId: acctA, instrument: aud)
     draft.legDrafts = [
       TransactionDraft.LegDraft(
         type: .expense, accountId: acctA, amountText: "300",
-        categoryId: nil, categoryText: "", earmarkId: nil, instrumentId: aud.id)
+        categoryId: nil, categoryText: "", earmarkId: nil, instrument: aud)
     ]
     draft.switchToTrade(accounts: accountsAUD())
     let paidIndex = try #require(draft.paidLegIndex)
@@ -61,14 +61,14 @@ struct TransactionDraftForwardSwitchTests {
 
   @Test("Transfer → Trade: counterpart leg dropped, then Expense flow")
   func transferToTrade() {
-    var draft = TransactionDraft(accountId: acctA, instrumentId: aud.id)
+    var draft = TransactionDraft(accountId: acctA, instrument: aud)
     draft.legDrafts = [
       TransactionDraft.LegDraft(
         type: .transfer, accountId: acctA, amountText: "500",
-        categoryId: nil, categoryText: "", earmarkId: nil, instrumentId: aud.id),
+        categoryId: nil, categoryText: "", earmarkId: nil, instrument: aud),
       TransactionDraft.LegDraft(
         type: .transfer, accountId: acctB, amountText: "500",
-        categoryId: nil, categoryText: "", earmarkId: nil, instrumentId: aud.id),
+        categoryId: nil, categoryText: "", earmarkId: nil, instrument: aud),
     ]
     draft.switchToTrade(accounts: accountsAUD())
     #expect(draft.legDrafts.count == 2)
@@ -78,15 +78,15 @@ struct TransactionDraftForwardSwitchTests {
 
   @Test("Custom (already trade-shaped) → Trade: no structural change, isCustom flips")
   func customToTrade() {
-    var draft = TransactionDraft(accountId: acctA, instrumentId: aud.id)
+    var draft = TransactionDraft(accountId: acctA, instrument: aud)
     draft.isCustom = true
     draft.legDrafts = [
       TransactionDraft.LegDraft(
         type: .trade, accountId: acctA, amountText: "300",
-        categoryId: nil, categoryText: "", earmarkId: nil, instrumentId: aud.id),
+        categoryId: nil, categoryText: "", earmarkId: nil, instrument: aud),
       TransactionDraft.LegDraft(
         type: .trade, accountId: acctA, amountText: "20",
-        categoryId: nil, categoryText: "", earmarkId: nil, instrumentId: vgs.id),
+        categoryId: nil, categoryText: "", earmarkId: nil, instrument: vgs),
     ]
     draft.switchToTrade(accounts: accountsAUD())
     #expect(draft.isCustom == false)
@@ -95,11 +95,11 @@ struct TransactionDraftForwardSwitchTests {
 
   @Test("canSwitchToTrade reflects shape compatibility")
   func canSwitch() {
-    var draft = TransactionDraft(accountId: acctA, instrumentId: aud.id)
+    var draft = TransactionDraft(accountId: acctA, instrument: aud)
     draft.legDrafts = [
       TransactionDraft.LegDraft(
         type: .income, accountId: acctA, amountText: "100",
-        categoryId: nil, categoryText: "", earmarkId: nil, instrumentId: aud.id)
+        categoryId: nil, categoryText: "", earmarkId: nil, instrument: aud)
     ]
     #expect(draft.canSwitchToTrade(accounts: accountsAUD()) == true)
   }

--- a/MoolahTests/Shared/TransactionDraftInstrumentIdTests.swift
+++ b/MoolahTests/Shared/TransactionDraftInstrumentIdTests.swift
@@ -3,15 +3,15 @@ import Testing
 
 @testable import Moolah
 
-@Suite("TransactionDraft LegDraft instrumentId overrides")
+@Suite("TransactionDraft LegDraft instrument storage")
 struct TransactionDraftInstrumentIdTests {
   private let support = TransactionDraftTestSupport()
 
   @Test
-  func legDraftInstrumentIdOverridesToTransaction() throws {
+  func legDraftInstrumentOverridesToTransaction() throws {
     let acctId = UUID()
+    let usd = Instrument.fiat(code: "USD")
     let accounts = support.makeAccounts([support.makeAccount(id: acctId, instrument: .AUD)])
-    let availableInstruments = ["AUD", "USD", "EUR", "GBP"].map { Instrument.fiat(code: $0) }
     let draft = TransactionDraft(
       payee: "", date: Date(), notes: "",
       isRepeating: false, recurPeriod: nil, recurEvery: 1,
@@ -20,20 +20,18 @@ struct TransactionDraftInstrumentIdTests {
         TransactionDraft.LegDraft(
           type: .expense, accountId: acctId, amountText: "100.00",
           categoryId: nil, categoryText: "", earmarkId: nil,
-          instrumentId: "USD")
+          instrument: usd)
       ],
       relevantLegIndex: 0, viewingAccountId: nil
     )
     let transaction = try #require(
-      draft.toTransaction(
-        id: UUID(), accounts: accounts, availableInstruments: availableInstruments))
+      draft.toTransaction(id: UUID(), accounts: accounts))
     #expect(transaction.legs[0].instrument.id == "USD")
   }
 
   @Test
-  func legDraftNilInstrumentIdReturnsNil() {
-    // instrumentId is the canonical source of truth; a leg without one can't
-    // resolve to an instrument and the draft is considered invalid-to-save.
+  func legDraftNilInstrumentReturnsNil() {
+    // A leg with no instrument is invalid — the draft cannot be saved.
     let acctId = UUID()
     let accounts = support.makeAccounts([support.makeAccount(id: acctId, instrument: .AUD)])
     let draft = TransactionDraft(
@@ -47,13 +45,14 @@ struct TransactionDraftInstrumentIdTests {
       ],
       relevantLegIndex: 0, viewingAccountId: nil
     )
-    let transaction = draft.toTransaction(
-      id: UUID(), accounts: accounts, availableInstruments: [.AUD])
+    let transaction = draft.toTransaction(id: UUID(), accounts: accounts)
     #expect(transaction == nil)
   }
 
   @Test
-  func legDraftInvalidInstrumentIdReturnsNil() {
+  func legDraftInstrumentRoundTripsFullObject() throws {
+    // The full Instrument value — not just its id — is preserved on the round-trip.
+    let vgs = Instrument.stock(ticker: "VGS.AX", exchange: "ASX", name: "VGS")
     let acctId = UUID()
     let accounts = support.makeAccounts([support.makeAccount(id: acctId, instrument: .AUD)])
     let draft = TransactionDraft(
@@ -62,15 +61,14 @@ struct TransactionDraftInstrumentIdTests {
       isCustom: true,
       legDrafts: [
         TransactionDraft.LegDraft(
-          type: .expense, accountId: acctId, amountText: "100.00",
+          type: .expense, accountId: acctId, amountText: "10",
           categoryId: nil, categoryText: "", earmarkId: nil,
-          instrumentId: "FAKE_CURRENCY")
+          instrument: vgs)
       ],
       relevantLegIndex: 0, viewingAccountId: nil
     )
-    let transaction = draft.toTransaction(
-      id: UUID(), accounts: accounts,
-      availableInstruments: [Instrument.fiat(code: "AUD")])
-    #expect(transaction == nil)
+    let transaction = try #require(
+      draft.toTransaction(id: UUID(), accounts: accounts))
+    #expect(transaction.legs[0].instrument == vgs)
   }
 }

--- a/MoolahTests/Shared/TransactionDraftRecurrenceTests.swift
+++ b/MoolahTests/Shared/TransactionDraftRecurrenceTests.swift
@@ -57,7 +57,7 @@ struct TransactionDraftRecurrenceTests {
     let accounts = support.makeAccounts([support.makeAccount(id: support.accountA)])
     let transaction = try #require(
       draft.toTransaction(
-        id: UUID(), accounts: accounts, availableInstruments: [support.instrument]))
+        id: UUID(), accounts: accounts))
 
     #expect(transaction.recurPeriod == .once)
     #expect(transaction.isScheduled == true)
@@ -126,7 +126,7 @@ struct TransactionDraftRecurrenceTests {
     let accounts = support.makeAccounts([support.makeAccount(id: support.accountA)])
     let roundTripped = try #require(
       draft.toTransaction(
-        id: id, accounts: accounts, availableInstruments: [support.instrument]))
+        id: id, accounts: accounts))
 
     #expect(roundTripped.recurPeriod == .once)
     #expect(roundTripped.isScheduled == true)

--- a/MoolahTests/Shared/TransactionDraftReverseSwitchTests.swift
+++ b/MoolahTests/Shared/TransactionDraftReverseSwitchTests.swift
@@ -20,20 +20,20 @@ struct TransactionDraftReverseSwitchTests {
   private func tradeDraft(withFee: Bool = false) -> TransactionDraft {
     // Buy-shaped fixture: cash leg quantity -300 (literal in amountText since
     // `displaysNegated(.trade) == false`), position leg quantity +20.
-    var draft = TransactionDraft(accountId: acctA, instrumentId: aud.id)
+    var draft = TransactionDraft(accountId: acctA, instrument: aud)
     draft.legDrafts = [
       TransactionDraft.LegDraft(
         type: .trade, accountId: acctA, amountText: "-300",
-        categoryId: nil, categoryText: "", earmarkId: nil, instrumentId: aud.id),
+        categoryId: nil, categoryText: "", earmarkId: nil, instrument: aud),
       TransactionDraft.LegDraft(
         type: .trade, accountId: acctA, amountText: "20",
-        categoryId: nil, categoryText: "", earmarkId: nil, instrumentId: vgs.id),
+        categoryId: nil, categoryText: "", earmarkId: nil, instrument: vgs),
     ]
     if withFee {
       draft.legDrafts.append(
         TransactionDraft.LegDraft(
           type: .expense, accountId: acctA, amountText: "10",
-          categoryId: nil, categoryText: "", earmarkId: nil, instrumentId: aud.id))
+          categoryId: nil, categoryText: "", earmarkId: nil, instrument: aud))
     }
     return draft
   }
@@ -45,7 +45,7 @@ struct TransactionDraftReverseSwitchTests {
     #expect(draft.legDrafts.count == 1)
     #expect(draft.legDrafts[0].type == .income)
     #expect(draft.legDrafts[0].amountText == "20")
-    #expect(draft.legDrafts[0].instrumentId == vgs.id)
+    #expect(draft.legDrafts[0].instrument == vgs)
     #expect(draft.legDrafts[0].accountId == acctA)
   }
 
@@ -56,7 +56,7 @@ struct TransactionDraftReverseSwitchTests {
     #expect(draft.legDrafts.count == 1)
     #expect(draft.legDrafts[0].type == .expense)
     #expect(draft.legDrafts[0].amountText == "300")
-    #expect(draft.legDrafts[0].instrumentId == aud.id)
+    #expect(draft.legDrafts[0].instrument == aud)
   }
 
   @Test("Trade → Transfer: keep Paid leg + add counterpart on a different account")

--- a/MoolahTests/Shared/TransactionDraftRoundTripTests.swift
+++ b/MoolahTests/Shared/TransactionDraftRoundTripTests.swift
@@ -12,15 +12,13 @@ struct TransactionDraftRoundTripTests {
   private func roundTrip(
     _ original: Transaction,
     accounts: Accounts,
-    earmarks: Earmarks = Earmarks(from: []),
-    availableInstruments: [Instrument]
+    earmarks: Earmarks = Earmarks(from: [])
   ) -> Transaction? {
     let draft = TransactionDraft(from: original, accounts: accounts)
     return draft.toTransaction(
       id: original.id,
       accounts: accounts,
-      earmarks: earmarks,
-      availableInstruments: availableInstruments
+      earmarks: earmarks
     )
   }
 
@@ -32,7 +30,6 @@ struct TransactionDraftRoundTripTests {
   func customTransactionMixedInstrumentsSameAccountRoundTrips() throws {
     let accountId = UUID()
     let accounts = support.makeAccounts([support.makeAccount(id: accountId, instrument: .AUD)])
-    let availableInstruments = [Instrument.AUD, Instrument.fiat(code: "NZD")]
     let original = Transaction(
       id: UUID(),
       date: Date(),
@@ -47,7 +44,7 @@ struct TransactionDraftRoundTripTests {
     )
 
     let roundTripped = try #require(
-      roundTrip(original, accounts: accounts, availableInstruments: availableInstruments))
+      roundTrip(original, accounts: accounts))
 
     #expect(roundTripped.legs.count == 2)
     #expect(roundTripped.legs[0].instrument == .AUD)
@@ -80,7 +77,7 @@ struct TransactionDraftRoundTripTests {
     )
 
     let roundTripped = try #require(
-      roundTrip(original, accounts: accounts, availableInstruments: [support.instrument]))
+      roundTrip(original, accounts: accounts))
 
     #expect(roundTripped.legs.count == 3)
     #expect(roundTripped.legs[0].accountId == accountIds[0])
@@ -118,7 +115,7 @@ struct TransactionDraftRoundTripTests {
     )
 
     let roundTripped = try #require(
-      roundTrip(original, accounts: accounts, availableInstruments: [support.instrument]))
+      roundTrip(original, accounts: accounts))
 
     #expect(roundTripped.legs[0].type == .expense)
     #expect(roundTripped.legs[0].categoryId == categoryIdA)
@@ -153,7 +150,7 @@ struct TransactionDraftRoundTripTests {
     )
 
     let roundTripped = try #require(
-      roundTrip(original, accounts: accounts, availableInstruments: [jpy, .AUD]))
+      roundTrip(original, accounts: accounts))
 
     #expect(roundTripped.legs[0].quantity == Decimal(-12_345))
     #expect(roundTripped.legs[0].instrument == jpy)
@@ -190,7 +187,7 @@ struct TransactionDraftRoundTripTests {
     )
 
     let roundTripped = try #require(
-      roundTrip(original, accounts: accounts, availableInstruments: [support.instrument]))
+      roundTrip(original, accounts: accounts))
 
     #expect(roundTripped.id == id)
     #expect(roundTripped.date == date)
@@ -225,8 +222,7 @@ struct TransactionDraftRoundTripTests {
 
     let roundTripped = try #require(
       roundTrip(
-        original, accounts: accounts, earmarks: earmarks,
-        availableInstruments: [support.instrument]))
+        original, accounts: accounts, earmarks: earmarks))
 
     #expect(roundTripped.legs.count == 2)
     #expect(roundTripped.legs[0].accountId == support.accountA)
@@ -262,7 +258,7 @@ struct TransactionDraftRoundTripTests {
     )
 
     let roundTripped = try #require(
-      roundTrip(original, accounts: accounts, availableInstruments: [support.instrument]))
+      roundTrip(original, accounts: accounts))
 
     #expect(roundTripped.legs[0].type == .expense)
     #expect(roundTripped.legs[0].quantity == Decimal(-100))

--- a/MoolahTests/Shared/TransactionDraftToTransactionTests.swift
+++ b/MoolahTests/Shared/TransactionDraftToTransactionTests.swift
@@ -12,8 +12,7 @@ struct TransactionDraftToTransactionTests {
     let draft = support.makeExpenseDraft(amountText: "25.00", accountId: support.accountA)
     let accounts = support.makeAccounts([support.makeAccount(id: support.accountA)])
     let transaction = try #require(
-      draft.toTransaction(
-        id: UUID(), accounts: accounts, availableInstruments: [support.instrument]))
+      draft.toTransaction(id: UUID(), accounts: accounts))
 
     #expect(transaction.legs.count == 1)
     #expect(transaction.legs[0].quantity == Decimal(string: "-25.00"))  // expense: negated back
@@ -31,14 +30,13 @@ struct TransactionDraftToTransactionTests {
         TransactionDraft.LegDraft(
           type: .income, accountId: support.accountA, amountText: "3000.00",
           categoryId: nil, categoryText: "", earmarkId: nil,
-          instrumentId: support.instrument.id)
+          instrument: support.instrument)
       ],
       relevantLegIndex: 0, viewingAccountId: nil
     )
     let accounts = support.makeAccounts([support.makeAccount(id: support.accountA)])
     let transaction = try #require(
-      draft.toTransaction(
-        id: UUID(), accounts: accounts, availableInstruments: [support.instrument]))
+      draft.toTransaction(id: UUID(), accounts: accounts))
 
     #expect(transaction.legs[0].quantity == Decimal(string: "3000.00"))  // income: as-is
   }
@@ -49,8 +47,7 @@ struct TransactionDraftToTransactionTests {
     let draft = support.makeExpenseDraft(amountText: "-10.00", accountId: support.accountA)
     let accounts = support.makeAccounts([support.makeAccount(id: support.accountA)])
     let transaction = try #require(
-      draft.toTransaction(
-        id: UUID(), accounts: accounts, availableInstruments: [support.instrument]))
+      draft.toTransaction(id: UUID(), accounts: accounts))
 
     #expect(transaction.legs[0].quantity == Decimal(string: "10.00"))
   }
@@ -65,8 +62,7 @@ struct TransactionDraftToTransactionTests {
     draft.setType(.transfer, accounts: accounts)
 
     let transaction = try #require(
-      draft.toTransaction(
-        id: UUID(), accounts: accounts, availableInstruments: [support.instrument]))
+      draft.toTransaction(id: UUID(), accounts: accounts))
     #expect(transaction.legs.count == 2)
     #expect(transaction.legs[0].quantity == Decimal(string: "-100.00"))
     #expect(transaction.legs[1].quantity == Decimal(string: "100.00"))
@@ -96,8 +92,7 @@ struct TransactionDraftToTransactionTests {
     let draft = TransactionDraft(from: original)
     let accounts = support.makeAccounts([support.makeAccount(id: support.accountA)])
     let roundTripped = try #require(
-      draft.toTransaction(
-        id: id, accounts: accounts, availableInstruments: [support.instrument]))
+      draft.toTransaction(id: id, accounts: accounts))
 
     #expect(roundTripped.id == original.id)
     #expect(roundTripped.date == original.date)
@@ -136,8 +131,7 @@ struct TransactionDraftToTransactionTests {
       support.makeAccount(id: support.accountB),
     ])
     let roundTripped = try #require(
-      draft.toTransaction(
-        id: id, accounts: accounts, availableInstruments: [support.instrument]))
+      draft.toTransaction(id: id, accounts: accounts))
 
     #expect(roundTripped.legs.count == 2)
     #expect(roundTripped.legs[0].quantity == original.legs[0].quantity)
@@ -169,8 +163,7 @@ struct TransactionDraftToTransactionTests {
       support.makeAccount(id: support.accountB),
     ])
     let roundTripped = try #require(
-      draft.toTransaction(
-        id: id, accounts: accounts, availableInstruments: [support.instrument]))
+      draft.toTransaction(id: id, accounts: accounts))
 
     // Quantities must be preserved regardless of which leg is "relevant"
     #expect(roundTripped.legs[0].quantity == Decimal(string: "-100"))
@@ -193,18 +186,17 @@ struct TransactionDraftToTransactionTests {
         TransactionDraft.LegDraft(
           type: .expense, accountId: support.accountA, amountText: "100.00",
           categoryId: catId, categoryText: "", earmarkId: nil,
-          instrumentId: support.instrument.id),
+          instrument: support.instrument),
         TransactionDraft.LegDraft(
           type: .income, accountId: support.accountB, amountText: "50.00",
           categoryId: nil, categoryText: "", earmarkId: earmarkId,
-          instrumentId: support.instrument.id),
+          instrument: support.instrument),
       ],
       relevantLegIndex: 0, viewingAccountId: nil
     )
 
     let transaction = try #require(
-      draft.toTransaction(
-        id: UUID(), accounts: accounts, availableInstruments: [support.instrument]))
+      draft.toTransaction(id: UUID(), accounts: accounts))
     #expect(transaction.legs.count == 2)
     #expect(transaction.legs[0].quantity == Decimal(string: "-100.00"))  // expense negated
     #expect(transaction.legs[0].categoryId == catId)
@@ -214,7 +206,7 @@ struct TransactionDraftToTransactionTests {
 
   @Test
   func toTransactionReturnsNilWhenInvalid() {
-    let draft = support.makeExpenseDraft(amountText: "")
+    let draft = support.makeExpenseDraft(amountText: "", instrument: nil)
     let accounts = support.makeAccounts([support.makeAccount(id: support.accountA)])
     #expect(draft.toTransaction(id: UUID(), accounts: accounts) == nil)
   }
@@ -228,8 +220,7 @@ struct TransactionDraftToTransactionTests {
 
     let accounts = support.makeAccounts([support.makeAccount(id: support.accountA)])
     let transaction = try #require(
-      draft.toTransaction(
-        id: UUID(), accounts: accounts, availableInstruments: [support.instrument]))
+      draft.toTransaction(id: UUID(), accounts: accounts))
     #expect(transaction.recurPeriod == nil)
     #expect(transaction.recurEvery == nil)
   }

--- a/MoolahTests/Shared/TransactionDraftTradeAccessorsTests.swift
+++ b/MoolahTests/Shared/TransactionDraftTradeAccessorsTests.swift
@@ -10,15 +10,15 @@ struct TransactionDraftTradeAccessorsTests {
   let account = UUID()
 
   private func tradeDraft(extraFees: [TransactionDraft.LegDraft] = []) -> TransactionDraft {
-    var draft = TransactionDraft(accountId: account, instrumentId: aud.id)
+    var draft = TransactionDraft(accountId: account, instrument: aud)
     draft.legDrafts =
       [
         TransactionDraft.LegDraft(
           type: .trade, accountId: account, amountText: "300",
-          categoryId: nil, categoryText: "", earmarkId: nil, instrumentId: aud.id),
+          categoryId: nil, categoryText: "", earmarkId: nil, instrument: aud),
         TransactionDraft.LegDraft(
           type: .trade, accountId: account, amountText: "20",
-          categoryId: nil, categoryText: "", earmarkId: nil, instrumentId: vgs.id),
+          categoryId: nil, categoryText: "", earmarkId: nil, instrument: vgs),
       ] + extraFees
     return draft
   }
@@ -39,10 +39,10 @@ struct TransactionDraftTradeAccessorsTests {
   func feeIndices() {
     let fee1 = TransactionDraft.LegDraft(
       type: .expense, accountId: account, amountText: "10",
-      categoryId: nil, categoryText: "", earmarkId: nil, instrumentId: aud.id)
+      categoryId: nil, categoryText: "", earmarkId: nil, instrument: aud)
     let fee2 = TransactionDraft.LegDraft(
       type: .expense, accountId: account, amountText: "0.5",
-      categoryId: nil, categoryText: "", earmarkId: nil, instrumentId: aud.id)
+      categoryId: nil, categoryText: "", earmarkId: nil, instrument: aud)
     let draft = tradeDraft(extraFees: [fee1, fee2])
     #expect(draft.feeIndices == [2, 3])
   }
@@ -50,11 +50,11 @@ struct TransactionDraftTradeAccessorsTests {
   @Test("appendFee adds an expense leg with default 0 amount")
   func appendFee() {
     var draft = tradeDraft()
-    draft.appendFee(defaultInstrumentId: aud.id)
+    draft.appendFee(defaultInstrument: aud)
     #expect(draft.legDrafts.count == 3)
     #expect(draft.legDrafts[2].type == .expense)
     #expect(draft.legDrafts[2].amountText == "0")
-    #expect(draft.legDrafts[2].instrumentId == aud.id)
+    #expect(draft.legDrafts[2].instrument == aud)
     #expect(draft.legDrafts[2].accountId == account)
   }
 
@@ -62,7 +62,7 @@ struct TransactionDraftTradeAccessorsTests {
   func removeFeeIndex() {
     let fee = TransactionDraft.LegDraft(
       type: .expense, accountId: account, amountText: "10",
-      categoryId: nil, categoryText: "", earmarkId: nil, instrumentId: aud.id)
+      categoryId: nil, categoryText: "", earmarkId: nil, instrument: aud)
     var draft = tradeDraft(extraFees: [fee])
     draft.removeFee(at: 2)
     #expect(draft.legDrafts.count == 2)

--- a/MoolahTests/Shared/TransactionDraftTradeRoundTripTests.swift
+++ b/MoolahTests/Shared/TransactionDraftTradeRoundTripTests.swift
@@ -26,9 +26,7 @@ struct TransactionDraftTradeRoundTripTests {
     #expect(draft.legDrafts[1].amountText == "20")
 
     let rebuilt = try #require(
-      draft.toTransaction(
-        id: original.id,
-        availableInstruments: [aud, vgs]))
+      draft.toTransaction(id: original.id))
     #expect(rebuilt.legs[0].quantity == Decimal(-300))
     #expect(rebuilt.legs[1].quantity == Decimal(20))
   }
@@ -55,9 +53,7 @@ struct TransactionDraftTradeRoundTripTests {
     #expect(draft.legDrafts[1].amountText == "-20")
 
     let rebuilt = try #require(
-      draft.toTransaction(
-        id: original.id,
-        availableInstruments: [aud, vgs]))
+      draft.toTransaction(id: original.id))
     #expect(rebuilt.legs[0].quantity == Decimal(300))
     #expect(rebuilt.legs[1].quantity == Decimal(-20))
   }
@@ -67,19 +63,19 @@ struct TransactionDraftTradeRoundTripTests {
     let aud = Instrument.AUD
     let vgs = Instrument.stock(ticker: "VGS.AX", exchange: "ASX", name: "VGS")
     let account = UUID()
-    var draft = TransactionDraft(accountId: account, instrumentId: aud.id)
+    var draft = TransactionDraft(accountId: account, instrument: aud)
     // First leg literal "+300", second literal "-20" — both signs preserved.
     draft.legDrafts = [
       TransactionDraft.LegDraft(
         type: .trade, accountId: account, amountText: "300",
-        categoryId: nil, categoryText: "", earmarkId: nil, instrumentId: aud.id),
+        categoryId: nil, categoryText: "", earmarkId: nil, instrument: aud),
       TransactionDraft.LegDraft(
         type: .trade, accountId: account, amountText: "-20",
-        categoryId: nil, categoryText: "", earmarkId: nil, instrumentId: vgs.id),
+        categoryId: nil, categoryText: "", earmarkId: nil, instrument: vgs),
     ]
 
     let rebuilt = try #require(
-      draft.toTransaction(id: UUID(), availableInstruments: [aud, vgs]))
+      draft.toTransaction(id: UUID()))
     #expect(rebuilt.legs[0].quantity == Decimal(300))
     #expect(rebuilt.legs[1].quantity == Decimal(-20))
   }

--- a/MoolahTests/Shared/TransactionDraftValidationTests.swift
+++ b/MoolahTests/Shared/TransactionDraftValidationTests.swift
@@ -106,10 +106,12 @@ struct TransactionDraftValidationTests {
     draft.legDrafts = [
       TransactionDraft.LegDraft(
         type: .expense, accountId: support.accountA, amountText: "10.00",
-        categoryId: nil, categoryText: "", earmarkId: nil),
+        categoryId: nil, categoryText: "", earmarkId: nil,
+        instrument: support.instrument),
       TransactionDraft.LegDraft(
         type: .income, accountId: support.accountB, amountText: "5.00",
-        categoryId: nil, categoryText: "", earmarkId: nil),
+        categoryId: nil, categoryText: "", earmarkId: nil,
+        instrument: support.instrument),
     ]
     #expect(draft.isValid == true)
   }
@@ -181,8 +183,7 @@ struct TransactionDraftValidationTests {
     // But conversion would produce different quantity
     let accounts = support.makeAccounts([support.makeAccount(id: support.accountA)])
     let transaction = try #require(
-      draft.toTransaction(
-        id: UUID(), accounts: accounts, availableInstruments: [support.instrument]))
+      draft.toTransaction(id: UUID(), accounts: accounts))
     #expect(transaction.legs[0].quantity == Decimal(string: "50.00"))  // income: as-is
   }
 }

--- a/MoolahTests/Support/TransactionDraftTestSupport.swift
+++ b/MoolahTests/Support/TransactionDraftTestSupport.swift
@@ -15,7 +15,7 @@ struct TransactionDraftTestSupport {
   func makeExpenseDraft(
     amountText: String = "10.00",
     accountId: UUID? = nil,
-    instrumentId: String? = Instrument.defaultTestInstrument.id
+    instrument: Instrument? = Instrument.defaultTestInstrument
   ) -> TransactionDraft {
     TransactionDraft(
       payee: "Test",
@@ -29,7 +29,7 @@ struct TransactionDraftTestSupport {
         TransactionDraft.LegDraft(
           type: .expense, accountId: accountId ?? accountA,
           amountText: amountText, categoryId: nil, categoryText: "", earmarkId: nil,
-          instrumentId: instrumentId)
+          instrument: instrument)
       ],
       relevantLegIndex: 0,
       viewingAccountId: nil

--- a/Shared/Models/TransactionDraft+Autofill.swift
+++ b/Shared/Models/TransactionDraft+Autofill.swift
@@ -40,7 +40,7 @@ extension TransactionDraft {
       if newDraft.legDrafts[idx].accountId != viewingId {
         newDraft.legDrafts[idx].accountId = viewingId
         if let viewedAccount = accounts.by(id: viewingId) {
-          newDraft.legDrafts[idx].instrumentId = viewedAccount.instrument.id
+          newDraft.legDrafts[idx].instrument = viewedAccount.instrument
         }
       }
     }

--- a/Shared/Models/TransactionDraft+SimpleMode.swift
+++ b/Shared/Models/TransactionDraft+SimpleMode.swift
@@ -185,7 +185,7 @@ extension TransactionDraft {
         categoryId: nil,
         categoryText: "",
         earmarkId: nil,
-        instrumentId: defaultAccount?.instrument.id
+        instrument: defaultAccount?.instrument
       )
 
       legDrafts[relevantLegIndex].type = .transfer

--- a/Shared/Models/TransactionDraft+TradeMode.swift
+++ b/Shared/Models/TransactionDraft+TradeMode.swift
@@ -27,7 +27,7 @@ extension TransactionDraft {
 extension TransactionDraft {
   /// Append a new fee leg defaulting to amount `0` in the supplied
   /// instrument and the current trade account.
-  mutating func appendFee(defaultInstrumentId: String) {
+  mutating func appendFee(defaultInstrument: Instrument) {
     legDrafts.append(
       LegDraft(
         type: .expense,
@@ -36,7 +36,7 @@ extension TransactionDraft {
         categoryId: nil,
         categoryText: "",
         earmarkId: nil,
-        instrumentId: defaultInstrumentId
+        instrument: defaultInstrument
       ))
   }
 
@@ -87,15 +87,15 @@ extension TransactionDraft {
 
     let existing = relevantLeg
     let acct = existing.accountId
-    let acctInstrumentId =
-      acct.flatMap { accounts.by(id: $0) }?.instrument.id ?? existing.instrumentId
+    let acctInstrument =
+      acct.flatMap { accounts.by(id: $0) }?.instrument ?? existing.instrument
     let carriedText = Self.adjustAmountText(
       existing.amountText, from: existing.type, to: .trade)
 
     let carried = Self.tradeLeg(
-      accountId: acct, amountText: carriedText, instrumentId: existing.instrumentId)
+      accountId: acct, amountText: carriedText, instrument: existing.instrument)
     let blank = Self.tradeLeg(
-      accountId: acct, amountText: "0", instrumentId: acctInstrumentId)
+      accountId: acct, amountText: "0", instrument: acctInstrument)
 
     // Income's positive leg becomes Received; everything else (Expense,
     // Transfer-after-counterpart-drop) becomes Paid. Counterpart transfer
@@ -110,7 +110,7 @@ extension TransactionDraft {
   /// the forward switch helpers. Trade legs are constrained to no category
   /// or earmark per design §1.2.
   private static func tradeLeg(
-    accountId: UUID?, amountText: String, instrumentId: String?
+    accountId: UUID?, amountText: String, instrument: Instrument?
   ) -> LegDraft {
     LegDraft(
       type: .trade,
@@ -119,7 +119,7 @@ extension TransactionDraft {
       categoryId: nil,
       categoryText: "",
       earmarkId: nil,
-      instrumentId: instrumentId
+      instrument: instrument
     )
   }
 }
@@ -165,7 +165,7 @@ extension TransactionDraft {
         categoryId: nil,
         categoryText: "",
         earmarkId: nil,
-        instrumentId: source.instrumentId)
+        instrument: source.instrument)
     ]
     relevantLegIndex = 0
   }
@@ -179,7 +179,7 @@ extension TransactionDraft {
         categoryId: nil,
         categoryText: "",
         earmarkId: nil,
-        instrumentId: source.instrumentId)
+        instrument: source.instrument)
     ]
     relevantLegIndex = 0
   }
@@ -194,7 +194,7 @@ extension TransactionDraft {
       categoryId: nil,
       categoryText: "",
       earmarkId: nil,
-      instrumentId: other?.instrument.id ?? paidLeg.instrumentId)
+      instrument: other?.instrument ?? paidLeg.instrument)
     let primary = LegDraft(
       type: .transfer,
       accountId: paidLeg.accountId,
@@ -202,7 +202,7 @@ extension TransactionDraft {
       categoryId: nil,
       categoryText: "",
       earmarkId: nil,
-      instrumentId: paidLeg.instrumentId)
+      instrument: paidLeg.instrument)
     legDrafts = [primary, counterpart]
     relevantLegIndex = 0
   }

--- a/Shared/Models/TransactionDraft.swift
+++ b/Shared/Models/TransactionDraft.swift
@@ -60,8 +60,9 @@ struct TransactionDraft: Sendable, Equatable {
     var categoryId: UUID?
     var categoryText: String
     var earmarkId: UUID?
-    /// Optional instrument override for custom mode (e.g. cross-currency legs).
-    var instrumentId: String?
+    /// The full instrument for this leg. Stored directly so the draft is
+    /// self-describing and `toTransaction` never needs a lookup-by-id.
+    var instrument: Instrument?
 
     init(
       type: TransactionType,
@@ -70,7 +71,7 @@ struct TransactionDraft: Sendable, Equatable {
       categoryId: UUID?,
       categoryText: String,
       earmarkId: UUID?,
-      instrumentId: String? = nil
+      instrument: Instrument? = nil
     ) {
       self.type = type
       self.accountId = accountId
@@ -78,7 +79,7 @@ struct TransactionDraft: Sendable, Equatable {
       self.categoryId = categoryId
       self.categoryText = categoryText
       self.earmarkId = earmarkId
-      self.instrumentId = instrumentId
+      self.instrument = instrument
     }
 
     /// True when this leg represents an earmark-only entry (no account).
@@ -128,10 +129,10 @@ extension TransactionDraft {
     viewingAccountId: UUID? = nil,
     accounts: Accounts = Accounts(from: [])
   ) {
-    // Always populate instrumentId so the draft is self-describing and round-trips
-    // preserve each leg's instrument — including cases where a leg's instrument
-    // differs from its account's instrument (e.g. a cross-currency trade booked
-    // against a single investment account).
+    // Always store the full Instrument so the draft is self-describing and
+    // round-trips preserve each leg's instrument — including cases where a
+    // leg's instrument differs from its account's instrument (e.g. a
+    // cross-currency trade booked against a single investment account).
     let drafts = transaction.legs.map { leg in
       LegDraft(
         type: leg.type,
@@ -141,7 +142,7 @@ extension TransactionDraft {
         categoryId: leg.categoryId,
         categoryText: "",
         earmarkId: leg.earmarkId,
-        instrumentId: leg.instrument.id
+        instrument: leg.instrument
       )
     }
 
@@ -180,7 +181,7 @@ extension TransactionDraft {
   }
 
   /// Create a blank earmark-only draft for a new earmark transaction.
-  init(earmarkId: UUID, instrumentId: String? = nil, viewingAccountId: UUID? = nil) {
+  init(earmarkId: UUID, instrument: Instrument? = nil, viewingAccountId: UUID? = nil) {
     self.init(
       payee: "",
       date: Date(),
@@ -193,7 +194,7 @@ extension TransactionDraft {
         LegDraft(
           type: .income, accountId: nil, amountText: "0",
           categoryId: nil, categoryText: "", earmarkId: earmarkId,
-          instrumentId: instrumentId)
+          instrument: instrument)
       ],
       relevantLegIndex: 0,
       viewingAccountId: viewingAccountId
@@ -201,7 +202,7 @@ extension TransactionDraft {
   }
 
   /// Create a blank draft for a new transaction.
-  init(accountId: UUID? = nil, instrumentId: String? = nil, viewingAccountId: UUID? = nil) {
+  init(accountId: UUID? = nil, instrument: Instrument? = nil, viewingAccountId: UUID? = nil) {
     self.init(
       payee: "",
       date: Date(),
@@ -214,7 +215,7 @@ extension TransactionDraft {
         LegDraft(
           type: .expense, accountId: accountId, amountText: "0",
           categoryId: nil, categoryText: "", earmarkId: nil,
-          instrumentId: instrumentId)
+          instrument: instrument)
       ],
       relevantLegIndex: 0,
       viewingAccountId: viewingAccountId
@@ -251,6 +252,7 @@ extension TransactionDraft {
   var isValid: Bool {
     guard !legDrafts.isEmpty else { return false }
     for leg in legDrafts {
+      guard leg.instrument != nil else { return false }
       // .trade legs must have an account (no earmark-only fallback per design §3.2).
       // All other types require either an account or an earmark (or both).
       if leg.type == .trade {
@@ -272,26 +274,21 @@ extension TransactionDraft {
 // MARK: - Conversion
 
 extension TransactionDraft {
-  /// Build a `Transaction` from the draft. Each leg's `instrumentId` must resolve
-  /// in `availableInstruments`; `accounts` and `earmarks` are unused for instrument
-  /// lookup (each leg is self-describing) but remain as parameters for future use.
-  /// Returns nil when the draft is invalid or an instrument can't be resolved.
+  /// Build a `Transaction` from the draft. Each leg must carry a non-nil
+  /// `instrument`; `accounts` and `earmarks` are retained for API
+  /// consistency with callsites that pass them explicitly but are unused for
+  /// instrument resolution (the draft is self-describing).
+  /// Returns nil when the draft is invalid or any leg has no instrument.
   func toTransaction(
     id: UUID,
     accounts: Accounts = Accounts(from: []),
-    earmarks: Earmarks = Earmarks(from: []),
-    availableInstruments: [Instrument] = []
+    earmarks: Earmarks = Earmarks(from: [])
   ) -> Transaction? {
     guard isValid else { return nil }
 
     var legs: [TransactionLeg] = []
     for legDraft in legDrafts {
-      guard let overrideId = legDraft.instrumentId,
-        let instrument = availableInstruments.first(where: { $0.id == overrideId })
-      else {
-        return nil
-      }
-
+      guard let instrument = legDraft.instrument else { return nil }
       guard
         let quantity = Self.parseDisplayText(
           legDraft.amountText, type: legDraft.type, decimals: instrument.decimals)
@@ -338,12 +335,12 @@ extension TransactionDraft {
 extension TransactionDraft {
   /// Append a blank leg for custom mode editing. Callers should pass the default
   /// account's instrument so the leg is self-describing from the start.
-  mutating func addLeg(defaultAccountId: UUID? = nil, instrumentId: String? = nil) {
+  mutating func addLeg(defaultAccountId: UUID? = nil, instrument: Instrument? = nil) {
     legDrafts.append(
       LegDraft(
         type: .expense, accountId: defaultAccountId, amountText: "0",
         categoryId: nil, categoryText: "", earmarkId: nil,
-        instrumentId: instrumentId
+        instrument: instrument
       ))
   }
 

--- a/Shared/Views/CompactInstrumentPickerButton.swift
+++ b/Shared/Views/CompactInstrumentPickerButton.swift
@@ -6,7 +6,6 @@ import SwiftUI
 /// `Australian Dollar (AUD)` label would crowd out the amount.
 struct CompactInstrumentPickerButton: View {
   @Binding var selection: Instrument
-  let knownInstruments: [Instrument]
 
   @Environment(ProfileSession.self) private var session: ProfileSession?
   @State private var isPresented = false
@@ -27,12 +26,15 @@ struct CompactInstrumentPickerButton: View {
         Text(selection.shortCode)
           .foregroundStyle(.secondary)
           .monospacedDigit()
+          .lineLimit(1)
+          .fixedSize(horizontal: true, vertical: false)
         Image(systemName: "chevron.up.chevron.down")
           .foregroundStyle(.tertiary)
           .font(.caption2)
       }
       .contentShape(Rectangle())
     }
+    .layoutPriority(1)
     .buttonStyle(.plain)
     .accessibilityLabel(Text("Instrument: \(selection.shortCode)"))
     .accessibilityHint(Text("Activate to choose a different instrument"))

--- a/UITestSupport/UITestSeed.swift
+++ b/UITestSupport/UITestSeed.swift
@@ -285,5 +285,17 @@ public enum UITestFixtures {
     public static let brokerageCategoryId =
       UUID(uuidString: "A3000000-0000-0000-0000-000000000040") ?? UUID()
     public static let brokerageCategoryName = "Brokerage"
+
+    // MARK: - Trade transactions
+
+    /// 14-Apr-26 buy: −$300 AUD → +20 VGS.AX, $10 brokerage fee.
+    public static let trade1Id =
+      UUID(uuidString: "A3000000-0000-0000-0000-000000000020") ?? UUID()
+    /// 21-Apr-26 buy: −$160 AUD → +10 VGS.AX, no fee.
+    public static let trade2Id =
+      UUID(uuidString: "A3000000-0000-0000-0000-000000000021") ?? UUID()
+    /// 28-Apr-26 sell: +$425 AUD → −10 VGS.AX, $5 brokerage fee.
+    public static let trade3Id =
+      UUID(uuidString: "A3000000-0000-0000-0000-000000000022") ?? UUID()
   }
 }


### PR DESCRIPTION
Follow-up on top of [#564](https://github.com/ajsutton/moolah-native/pull/564) addressing the issues that surfaced during manual testing.

## Summary
- **`LegDraft` now stores the full \`Instrument\` directly** (not an \`instrumentId: String?\` that needed lookup). Eliminates the \`knownInstruments\` cache, the \`availableInstruments\` parameter on \`toTransaction\`, and the silent save-failure that occurred when a freshly-picked stock/crypto wasn't in the cached snapshot yet. The picker hands us a full \`Instrument\` and \`Transaction.legs\` already carry full \`Instrument\`s, so the round-trip never needs lookup-by-id.
- **Removing the last fee no longer crashes.** \`TransactionDetailFeeSection\` now guards its body and \`visibleSuggestions\` on \`draft.legDrafts.indices.contains(legIndex)\` so the transitional render after \`removeFee\` no-ops cleanly instead of trapping on out-of-bounds.

## Test plan
- [x] \`just test-mac\` — full macOS unit-test suite green (1708 tests)
- [x] \`just test-ui TradeFlowUITests\` — end-to-end trade flow passes locally
- [x] \`just format-check\` clean
- [x] Manual: pick a different instrument on the Received row → change persists
- [x] Manual: add a fee, remove it (last fee) → no crash
- [x] Manual: trade rows render with the correct title and amount column