### PR TITLE
refactor(grdb): apply Slice 0 follow-up review findings

### DIFF
--- a/App/ProfileSession+SyncWiring.swift
+++ b/App/ProfileSession+SyncWiring.swift
@@ -147,10 +147,10 @@ extension ProfileSession {
     if changedTypes.contains(ImportRuleRow.recordType) {
       plan.insert(.importRules)
     }
-    // NOTE: CSVImportProfileRow has no dedicated store — the setup form
-    // fetches profiles directly via `backend.csvImportProfiles`. Remote
-    // changes land in GRDB; the setup form reads through to the fresh
-    // values on its own `task`.
+    // CSVImportProfileRow has no dedicated store — the setup form fetches
+    // profiles directly via `backend.csvImportProfiles`. Remote changes
+    // land in GRDB; the setup form reads through to the fresh values on
+    // its own `task`.
     return plan
   }
 }

--- a/Backends/CloudKit/CloudKitBackend.swift
+++ b/Backends/CloudKit/CloudKitBackend.swift
@@ -19,7 +19,7 @@ final class CloudKitBackend: BackendProvider, @unchecked Sendable {
   /// Concrete GRDB-backed repositories for the record types covered by
   /// `v2_csv_import_and_rules`. Exposed alongside the protocol-typed
   /// `csvImportProfiles` / `importRules` so `ProfileSession` can register
-  /// them with `SyncCoordinator` (which needs the concrete actor type to
+  /// them with `SyncCoordinator` (which needs the concrete class type to
   /// reach the synchronous sync entry points). The protocol-typed
   /// properties point at the same instances.
   let grdbCSVImportProfiles: GRDBCSVImportProfileRepository

--- a/Backends/CloudKit/Sync/ProfileDataSyncHandler+QueueAndDelete.swift
+++ b/Backends/CloudKit/Sync/ProfileDataSyncHandler+QueueAndDelete.swift
@@ -124,10 +124,14 @@ extension ProfileDataSyncHandler {
 
     // GRDB-backed tables — wiped via the per-table repository helpers.
     // Failures are logged but never propagated; partial wipe is preferable
-    // to leaving local data in an inconsistent state.
+    // to leaving local data in an inconsistent state. Track success so
+    // the "Deleted all local data" info log only fires when every wipe
+    // (SwiftData + GRDB) actually completed; mirrors `clearAllSystemFields`.
+    var clearedAll = true
     do {
       try grdbRepositories.csvImportProfiles.deleteAllSync()
     } catch {
+      clearedAll = false
       logger.error(
         """
         Failed to delete CSV import profiles from GRDB for profile \
@@ -138,6 +142,7 @@ extension ProfileDataSyncHandler {
     do {
       try grdbRepositories.importRules.deleteAllSync()
     } catch {
+      clearedAll = false
       logger.error(
         """
         Failed to delete import rules from GRDB for profile \
@@ -145,7 +150,12 @@ extension ProfileDataSyncHandler {
         \(error.localizedDescription, privacy: .public)
         """)
     }
-    logger.info("Deleted all local data for profile \(self.profileId)")
+    if clearedAll {
+      logger.info("Deleted all local data for profile \(self.profileId)")
+    }
+    // Always return all types so the caller fans out the change
+    // notification even on partial failure (the SwiftData branch above
+    // followed the same convention before this change).
     return Set(RecordTypeRegistry.allTypes.keys)
   }
 

--- a/Backends/CloudKit/Sync/ProfileGRDBRepositories.swift
+++ b/Backends/CloudKit/Sync/ProfileGRDBRepositories.swift
@@ -14,15 +14,13 @@ import Foundation
 /// production all build the GRDB repos eagerly during backend
 /// construction.
 ///
-/// **Sendable.** `@unchecked Sendable` because the bundle is captured by
-/// reference into `ProfileDataSyncHandler.grdbRepositories` (a
-/// `nonisolated let`) and read from CKSyncEngine's delegate executor.
-/// The two members are themselves classes annotated `@unchecked
-/// Sendable`, the bundle's stored properties are `let`, and nothing
-/// mutates the struct after init — the `@unchecked` waiver is the
-/// pragmatic shape that mirrors the existing CloudKit repository
-/// classes.
-struct ProfileGRDBRepositories: @unchecked Sendable {
+/// **Sendable.** Plain `Sendable` synthesis. Every stored property is
+/// `let` and itself `Sendable` — the GRDB repositories are
+/// `final class … : @unchecked Sendable`, which satisfies the
+/// `Sendable` protocol requirement. The struct has no escape hatches,
+/// so the compiler derives `Sendable` automatically and no
+/// `@unchecked` waiver is needed.
+struct ProfileGRDBRepositories: Sendable {
   let csvImportProfiles: GRDBCSVImportProfileRepository
   let importRules: GRDBImportRuleRepository
 }

--- a/Backends/GRDB/Migration/SwiftDataToGRDBMigrator.swift
+++ b/Backends/GRDB/Migration/SwiftDataToGRDBMigrator.swift
@@ -40,7 +40,7 @@ import SwiftData
 /// `migrateIfNeeded` to async and call with `await` from
 /// `ProfileSession.init` (per `guides/CONCURRENCY_GUIDE.md` §1).
 @MainActor
-final class SwiftDataToGRDBMigrator {
+struct SwiftDataToGRDBMigrator {
   /// `UserDefaults` key gating the CSV-import-profile copy. Once true,
   /// the migrator skips this record type for the install's lifetime.
   static let csvImportProfilesFlag = "v2.csvImportProfiles.grdbMigrated"
@@ -67,25 +67,26 @@ final class SwiftDataToGRDBMigrator {
     database: any DatabaseWriter,
     defaults: UserDefaults = .standard
   ) throws {
-    #if DEBUG
-      let start = ContinuousClock.now
-      defer {
-        let elapsedMs = (ContinuousClock.now - start).inMilliseconds
-        // 16ms ≈ one frame at 60Hz. Sync migrator runs on @MainActor, so
-        // exceeding this budget means we're hanging the UI on a slow
-        // device. Logging instead of asserting because actual migration
-        // time depends on row count, which scales with user data —
-        // intentional signal-only check, not a hard precondition.
-        if elapsedMs > 16 {
-          logger.warning(
-            """
-            SwiftDataToGRDBMigrator.migrateIfNeeded took \(elapsedMs, privacy: .public)ms \
-            on @MainActor; convert to async if this reproduces on real hardware (see \
-            file header).
-            """)
-        }
+    let start = ContinuousClock.now
+    defer {
+      let elapsedMs = (ContinuousClock.now - start).inMilliseconds
+      // 16ms ≈ one frame at 60Hz. Sync migrator runs on @MainActor, so
+      // exceeding this budget means we're hanging the UI on a slow
+      // device. Log in release as well as debug so production
+      // diagnostics surface real-world durations on heavy users —
+      // tracked via the `os_log` warning channel (subsystem
+      // `com.moolah.app`, category `SwiftDataToGRDBMigrator`).
+      // Intentional signal-only check, not a hard precondition; the
+      // migration's correctness is independent of how long it takes.
+      if elapsedMs > 16 {
+        logger.warning(
+          """
+          SwiftDataToGRDBMigrator.migrateIfNeeded took \(elapsedMs, privacy: .public)ms \
+          on @MainActor; convert to async if this reproduces on real hardware (see \
+          file header).
+          """)
       }
-    #endif
+    }
     try migrateCSVImportProfilesIfNeeded(
       modelContainer: modelContainer, database: database, defaults: defaults)
     try migrateImportRulesIfNeeded(

--- a/Backends/GRDB/ProfileSchema.swift
+++ b/Backends/GRDB/ProfileSchema.swift
@@ -136,8 +136,6 @@ enum ProfileSchema {
   //     `Domain/Models/CSVImport/ImportRule.swift` — change in lock-step
   //     if the enum's raw values ever diverge.
   //   * `position` is non-negative; `reorder` always produces 0…n-1.
-  // The branch is unshipped, so the v2 migration body is edited in
-  // place rather than layered behind a v3 migration.
 
   private static func createCSVImportProfileTable(_ database: Database) throws {
     try database.execute(
@@ -145,6 +143,12 @@ enum ProfileSchema {
         CREATE TABLE csv_import_profile (
             id                              BLOB    NOT NULL PRIMARY KEY,
             record_name                     TEXT    NOT NULL UNIQUE,
+            -- No REFERENCES clause: the `account` table lands in the
+            -- core-financial-graph migration (Slice 1 of
+            -- `plans/grdb-migration.md`). Referential integrity is
+            -- enforced at the application layer until that migration
+            -- closes the FK loop; SQLite's table-rebuild pattern can
+            -- add the REFERENCES at that point if desired.
             account_id                      BLOB    NOT NULL,
             parser_identifier               TEXT    NOT NULL,
             header_signature                TEXT    NOT NULL,
@@ -158,8 +162,11 @@ enum ProfileSchema {
             encoded_system_fields           BLOB
         ) STRICT;
 
+        -- account_id FK child index (`fetchByAccount`-style filters).
         CREATE INDEX csv_import_profile_account
             ON csv_import_profile(account_id);
+        -- Covers `fetchAll().order(created_at)` in
+        -- `GRDBCSVImportProfileRepository.fetchAll`.
         CREATE INDEX csv_import_profile_created
             ON csv_import_profile(created_at);
         """)

--- a/Backends/GRDB/Repositories/GRDBCSVImportProfileRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBCSVImportProfileRepository.swift
@@ -50,12 +50,12 @@ final class GRDBCSVImportProfileRepository: CSVImportProfileRepository, @uncheck
   // MARK: - CSVImportProfileRepository conformance
 
   func fetchAll() async throws -> [CSVImportProfile] {
-    let rows = try await database.read { database in
+    try await database.read { database in
       try CSVImportProfileRow
         .order(CSVImportProfileRow.Columns.createdAt.asc)
         .fetchAll(database)
+        .map { $0.toDomain() }
     }
-    return rows.map { $0.toDomain() }
   }
 
   func create(_ profile: CSVImportProfile) async throws -> CSVImportProfile {

--- a/Backends/GRDB/Repositories/GRDBImportRuleRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBImportRuleRepository.swift
@@ -37,12 +37,12 @@ final class GRDBImportRuleRepository: ImportRuleRepository, @unchecked Sendable 
   // MARK: - ImportRuleRepository conformance
 
   func fetchAll() async throws -> [ImportRule] {
-    let rows = try await database.read { database in
+    try await database.read { database in
       try ImportRuleRow
         .order(ImportRuleRow.Columns.position.asc)
         .fetchAll(database)
+        .map { $0.toDomain() }
     }
-    return rows.map { $0.toDomain() }
   }
 
   func create(_ rule: ImportRule) async throws -> ImportRule {
@@ -119,6 +119,13 @@ final class GRDBImportRuleRepository: ImportRuleRepository, @unchecked Sendable 
   }
 
   // MARK: - Sync entry points (synchronous, GRDB-queue-blocking)
+  //
+  // Mirrors `GRDBCSVImportProfileRepository`'s sync section. See that
+  // file for the full doc-block on threading semantics: each `…Sync`
+  // entry point is called from `ProfileDataSyncHandler` on the
+  // CKSyncEngine delegate executor and uses the synchronous
+  // `DatabaseWriter.write { … }` overload. Never call these from
+  // `@MainActor`.
 
   func applyRemoteChangesSync(saved rows: [ImportRuleRow], deleted ids: [UUID]) throws {
     try database.write { database in

--- a/MoolahTests/Backends/GRDB/CSVImportPlanPinningTests.swift
+++ b/MoolahTests/Backends/GRDB/CSVImportPlanPinningTests.swift
@@ -21,6 +21,15 @@ import Testing
 ///    `GRDBCSVImportProfileRepository.update`/`delete` (and the
 ///    sync-side single-record fetcher). Must use the table's primary
 ///    key.
+/// 3. `csv_import_profile.created_at` ascending — the canonical fetch
+///    order used by `GRDBCSVImportProfileRepository.fetchAll()`. Must
+///    hit `csv_import_profile_created` and avoid a temp B-tree sort.
+/// 4. `csv_import_profile.account_id` lookup — partial filter for
+///    account-scoped profile listing. Must hit
+///    `csv_import_profile_account`.
+/// 5. `import_rule.account_scope` lookup — partial filter used by the
+///    rule evaluator for account-scoped rules. Must hit
+///    `import_rule_account_scope`.
 @Suite("CSV-import GRDB query plans")
 struct CSVImportPlanPinningTests {
   @Test
@@ -31,7 +40,7 @@ struct CSVImportPlanPinningTests {
         database,
         sql: """
           EXPLAIN QUERY PLAN
-          SELECT * FROM import_rule ORDER BY position
+          SELECT id FROM import_rule ORDER BY position
           """
       ).map { String(describing: $0["detail"] ?? "") }
       #expect(plan.contains { $0.contains("USING INDEX import_rule_position") })
@@ -47,7 +56,7 @@ struct CSVImportPlanPinningTests {
         database,
         sql: """
           EXPLAIN QUERY PLAN
-          SELECT * FROM csv_import_profile WHERE id = ?
+          SELECT id FROM csv_import_profile WHERE id = ?
           """,
         arguments: [UUID()]
       ).map { String(describing: $0["detail"] ?? "") }
@@ -70,7 +79,7 @@ struct CSVImportPlanPinningTests {
         database,
         sql: """
           EXPLAIN QUERY PLAN
-          SELECT * FROM import_rule WHERE account_scope = ?
+          SELECT id FROM import_rule WHERE account_scope = ?
           """,
         arguments: [UUID()]
       ).map { String(describing: $0["detail"] ?? "") }
@@ -93,12 +102,32 @@ struct CSVImportPlanPinningTests {
         database,
         sql: """
           EXPLAIN QUERY PLAN
-          SELECT * FROM csv_import_profile WHERE account_id = ?
+          SELECT id FROM csv_import_profile WHERE account_id = ?
           """,
         arguments: [UUID()]
       ).map { String(describing: $0["detail"] ?? "") }
       #expect(plan.contains { $0.contains("USING INDEX csv_import_profile_account") })
       #expect(!plan.contains { $0.contains("SCAN") })
+    }
+  }
+
+  @Test
+  func csvImportProfileOrderByCreatedAtUsesIndex() async throws {
+    let database = try ProfileDatabase.openInMemory()
+    try await database.read { database in
+      let plan = try Row.fetchAll(
+        database,
+        sql: """
+          EXPLAIN QUERY PLAN
+          SELECT id FROM csv_import_profile ORDER BY created_at
+          """
+      ).map { String(describing: $0["detail"] ?? "") }
+      // `GRDBCSVImportProfileRepository.fetchAll` orders by created_at
+      // ASC — pinning the index here prevents a future schema edit from
+      // silently regressing fetchAll() to a temp-B-tree sort over the
+      // entire table.
+      #expect(plan.contains { $0.contains("USING INDEX csv_import_profile_created") })
+      #expect(!plan.contains { $0.contains("USE TEMP B-TREE") })
     }
   }
 }

--- a/MoolahTests/Backends/GRDB/SwiftDataToGRDBMigratorTests.swift
+++ b/MoolahTests/Backends/GRDB/SwiftDataToGRDBMigratorTests.swift
@@ -13,7 +13,7 @@ import Testing
 ///
 /// Each test runs against an isolated `UserDefaults` suite so the
 /// per-record-type migration flags don't bleed across tests.
-@Suite("SwiftData → GRDB migrator")
+@Suite("SwiftData → GRDB migrator", .serialized)
 @MainActor
 struct SwiftDataToGRDBMigratorTests {
 
@@ -182,5 +182,87 @@ struct SwiftDataToGRDBMigratorTests {
     #expect(ruleCount == 0)
     #expect(defaults.bool(forKey: SwiftDataToGRDBMigrator.csvImportProfilesFlag))
     #expect(defaults.bool(forKey: SwiftDataToGRDBMigrator.importRulesFlag))
+  }
+
+  // MARK: - Failure paths
+  //
+  // These tests force the GRDB write to throw and assert the
+  // `committed` defer-flag invariant: the `UserDefaults` flag must NOT
+  // be set when the write fails, so the next launch retries the
+  // migration. A regression where `committed = true` moves above the
+  // write block would silently fail without these tests.
+
+  @Test("CSV migration: GRDB write failure leaves the flag unset for retry")
+  func csvImportProfileMigrationFailureKeepsFlagUnset() async throws {
+    let container = try TestModelContainer.create()
+    let database = try ProfileDatabase.openInMemory()
+    let context = ModelContext(container)
+    context.insert(
+      CSVImportProfileRecord(
+        id: UUID(), accountId: UUID(),
+        parserIdentifier: "p", headerSignature: ["a"]))
+    try context.save()
+
+    // Force the inserts inside `migrateCSVImportProfilesIfNeeded` to fail
+    // by installing a BEFORE-INSERT trigger that aborts. The migrator's
+    // `committed = true` line runs *after* the write block; if the write
+    // throws, the flag must stay false.
+    try await database.write { database in
+      try database.execute(
+        sql: """
+          CREATE TRIGGER abort_csv_migration
+          BEFORE INSERT ON csv_import_profile
+          BEGIN SELECT RAISE(ABORT, 'forced'); END;
+          """)
+    }
+
+    let defaults = makeIsolatedDefaults()
+    let migrator = SwiftDataToGRDBMigrator()
+    #expect(throws: (any Error).self) {
+      try migrator.migrateIfNeeded(
+        modelContainer: container, database: database, defaults: defaults)
+    }
+    #expect(
+      !defaults.bool(forKey: SwiftDataToGRDBMigrator.csvImportProfilesFlag),
+      "CSV flag must remain false so the next launch retries")
+    #expect(
+      !defaults.bool(forKey: SwiftDataToGRDBMigrator.importRulesFlag),
+      "Rules flag must also remain false — CSV step throws before rules step runs")
+  }
+
+  @Test("Import-rule migration: GRDB write failure leaves the flag unset for retry")
+  func importRuleMigrationFailureKeepsFlagUnset() async throws {
+    let container = try TestModelContainer.create()
+    let database = try ProfileDatabase.openInMemory()
+    let context = ModelContext(container)
+    context.insert(
+      ImportRuleRecord(
+        id: UUID(), name: "X", enabled: true, position: 0,
+        matchMode: .all, conditions: [], actions: [],
+        accountScope: nil))
+    try context.save()
+
+    // Trigger only on the import_rule table so the CSV migration
+    // succeeds and the rule step is the one that throws.
+    try await database.write { database in
+      try database.execute(
+        sql: """
+          CREATE TRIGGER abort_rule_migration
+          BEFORE INSERT ON import_rule
+          BEGIN SELECT RAISE(ABORT, 'forced'); END;
+          """)
+    }
+
+    let defaults = makeIsolatedDefaults()
+    let migrator = SwiftDataToGRDBMigrator()
+    #expect(throws: (any Error).self) {
+      try migrator.migrateIfNeeded(
+        modelContainer: container, database: database, defaults: defaults)
+    }
+    // CSV step succeeded (no CSV source rows); flag set is allowed.
+    // Rules step threw; its flag MUST stay false for retry.
+    #expect(
+      !defaults.bool(forKey: SwiftDataToGRDBMigrator.importRulesFlag),
+      "Rules flag must remain false so the next launch retries")
   }
 }

--- a/MoolahTests/Backends/GRDB/SyncRoundTripCSVImportTests.swift
+++ b/MoolahTests/Backends/GRDB/SyncRoundTripCSVImportTests.swift
@@ -205,6 +205,59 @@ struct SyncRoundTripCSVImportTests {
     #expect(rowB.encodedSystemFields == outgoing.encodedSystemFields)
   }
 
+  /// Sibling of `csvImportProfileUplinkRoundTrip` for `ImportRuleRow`.
+  /// Exercises `recordToSave(for:)` → `fetchImportRuleRow` →
+  /// `mapBuiltRows` → `applyRemoteChanges` to ensure the upload-side
+  /// path doesn't silently regress (e.g. a future refactor that
+  /// returns `nil` from `fetchImportRuleRow`, or a missing
+  /// `ImportRuleRow.recordType` case in `mapBuiltRows`).
+  @Test
+  func importRuleUplinkRoundTrip() async throws {
+    let harnessA = try ProfileDataSyncHandlerTestSupport.makeHandlerWithDatabase()
+    let id = UUID()
+    let domain = ImportRule(
+      id: id,
+      name: "Coffee shops",
+      enabled: true,
+      position: 0,
+      matchMode: .all,
+      conditions: [],
+      actions: [],
+      accountScope: nil)
+    _ = try await harnessA.handler.grdbRepositories.importRules.create(domain)
+    let recordID = CKRecord.ID(
+      recordType: ImportRuleRow.recordType, uuid: id, zoneID: harnessA.handler.zoneID)
+    let outgoing = try #require(harnessA.handler.recordToSave(for: recordID))
+
+    // Stamp server-issued change tag and write it back to the row.
+    let stampedFields = outgoing.encodedSystemFields
+    _ = try harnessA.handler.grdbRepositories.importRules
+      .setEncodedSystemFieldsSync(id: id, data: stampedFields)
+    let rowsA = try await harnessA.database.read { database in
+      try ImportRuleRow.fetchAll(database)
+    }
+    let rowA = try #require(rowsA.first)
+    #expect(rowA.encodedSystemFields == stampedFields)
+
+    // Device B applies the same CKRecord via apply-remote-changes and
+    // must end up with the same fields and bytes.
+    let harnessB = try ProfileDataSyncHandlerTestSupport.makeHandlerWithDatabase()
+    let result = harnessB.handler.applyRemoteChanges(saved: [outgoing], deleted: [])
+    if case .saveFailed(let message) = result {
+      Issue.record("applyRemoteChanges reported saveFailed on device B: \(message)")
+    }
+    let rowsB = try await harnessB.database.read { database in
+      try ImportRuleRow.fetchAll(database)
+    }
+    let rowB = try #require(rowsB.first)
+    #expect(rowB.id == rowA.id)
+    #expect(rowB.name == "Coffee shops")
+    #expect(rowB.enabled == true)
+    #expect(rowB.position == 0)
+    #expect(rowB.matchMode == "all")
+    #expect(rowB.encodedSystemFields == outgoing.encodedSystemFields)
+  }
+
   // MARK: - Data-loss regression: GRDB write failure must surface .saveFailed
 
   /// Regression for the round-2 finding I-1 (silent data loss on remote


### PR DESCRIPTION
## Summary

Post-merge audit of [PR #567](https://github.com/ajsutton/moolah-native/pull/567) (Slice 0 GRDB migration) by all five relevant reviewer agents — database-schema, database-code, concurrency, sync, code — surfaced a cluster of small fixes that warrant a follow-up rather than waiting for Slice 1. None are correctness-critical (Slice 0 is in production and working); each is a guide-compliance / observability / test-coverage improvement.

The sync-review agent's claim that `CSVImportProfileRow.toCKRecord` doesn't rehydrate `encodedSystemFields` was investigated and found to be a **false positive** — the upload path goes through `buildCKRecord(from:encodedSystemFields:)` (`ProfileDataSyncHandler.swift:98–113`), which restores the cached `CKRecord` and copies the fresh field values onto it. Verified by the existing `csvImportProfileUplinkRoundTrip` test which calls `recordToSave(for:)` and asserts the change-tag bytes survive a two-device round-trip. No code change needed.

## Schema (`ProfileSchema.swift`)

- Remove the stale `// The branch is unshipped, so the v2 migration body is edited in place` comment — it contradicts the migration-immutability rule now that v2 is on main.
- Add an inline note explaining the intentional deferral of the `csv_import_profile.account_id REFERENCES account(id)` clause to the Slice 1 `v3` migration.
- Tie the `csv_import_profile_account` and `csv_import_profile_created` indexes to their driver queries with one-line comments so reviewers can audit index necessity from the schema file alone.

## Repos

- `GRDBCSVImportProfileRepository.fetchAll` / `GRDBImportRuleRepository.fetchAll`: move the `.map { toDomain() }` **inside** the `database.read` closure (`DATABASE_CODE_GUIDE.md` §2 — Domain mapping never escapes).
- `GRDBImportRuleRepository`: add a cross-reference doc comment on the Sync entry-point section so its threading contract is discoverable from the file alone.

## Concurrency / Sendable

- `ProfileGRDBRepositories`: drop the unnecessary `@unchecked Sendable` on a struct whose properties are all `Sendable`; let the compiler synthesise plain `Sendable`.
- `SwiftDataToGRDBMigrator`: change `final class` to `struct` (single `let logger` property; no identity required, no shared mutable state). Move the 16ms `@MainActor`-budget warning out of `#if DEBUG` so production diagnostics surface real-world durations on heavy users.

## Logging accuracy

- `ProfileDataSyncHandler+QueueAndDelete.deleteLocalData`: guard the ``Deleted all local data`` success log behind a `clearedAll` flag so it doesn't fire when a GRDB deletion failed (mirrors the existing `clearAllSystemFields` pattern). The function still returns the full set of record types so callers fan out the change notification — the only correction is the misleading log.

## Comments

- `CloudKitBackend.swift`: ``concrete actor type`` → ``concrete class type`` (the GRDB repos are `final class … : @unchecked Sendable`, not actors).
- `ProfileSession+SyncWiring.swift`: drop the loud `// NOTE:` prefix on a regular inline comment.

## Tests

- `CSVImportPlanPinningTests`: add a plan-pinning test for `csv_import_profile ORDER BY created_at` hitting `csv_import_profile_created` (the existing four tests didn't cover the `fetchAll` path). Replace `SELECT *` with `SELECT id` in `EXPLAIN QUERY PLAN` bodies (no plan effect; cosmetic alignment with `DATABASE_CODE_GUIDE.md` §4).
- `SwiftDataToGRDBMigratorTests`: add `@Suite(.serialized)` and two GRDB-write-failure tests that install a `BEFORE INSERT` trigger and verify the `committed` defer-flag invariant — when the write fails, the corresponding `UserDefaults` flag stays false so the next launch retries.
- `SyncRoundTripCSVImportTests`: add `importRuleUplinkRoundTrip` mirroring `csvImportProfileUplinkRoundTrip` — the upload path for `ImportRuleRow` had no coverage. If `fetchImportRuleRow` ever regresses to `nil` or `mapBuiltRows` loses the `ImportRuleRow.recordType` case, this test now catches it.

## Test plan

- [x] `just format-check` clean.
- [x] `just test-mac` passes (full suite).
- [ ] Reviewers re-check the changed sections.
- [ ] Add to merge queue once approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)