### PR TITLE
fix(sync): drop Task.detached waiver in prepareEngine (#565)

### DIFF
--- a/Backends/CloudKit/Sync/SyncCoordinator+Lifecycle.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+Lifecycle.swift
@@ -68,36 +68,30 @@ extension SyncCoordinator {
 
   /// Off-actor: reads sync state from disk and constructs the `CKSyncEngine`.
   ///
-  /// We deliberately use `Task.detached` rather than relying on the
-  /// `nonisolated async` hop. Per CONCURRENCY_GUIDE §8 detached tasks are
-  /// normally an anti-pattern, but here the heavy synchronous work
-  /// (`NSKeyedUnarchiver` inside `CKSyncEngine.init`) must not run on the
-  /// main thread. Empirically (see `.agent-tmp` startup samples), calling
-  /// this as `nonisolated async` from a `@MainActor`-originating `Task {}`
-  /// still inherits the main thread for the body; `Task.detached` is the
-  /// only reliable way to force execution onto the cooperative pool.
-  ///
-  /// TODO(#565): Verify this is still required under newer Swift dispatch /
-  /// `@concurrent`. If a plain `nonisolated async` hop now lands off-main,
-  /// drop the detached-task waiver. — https://github.com/ajsutton/moolah-native/issues/565
+  /// The body's heavy synchronous work (`NSKeyedUnarchiver` inside
+  /// `CKSyncEngine.init`) must not run on the main thread. The
+  /// `nonisolated async` hop from the `@MainActor`-originating `Task {}`
+  /// in `start()` is sufficient on current toolchain — verified empirically
+  /// (issue #565) by logging `Thread.isMainThread` at entry and observing
+  /// `false`, plus a different OS TID from the surrounding `@MainActor`
+  /// `completeStart`. Earlier toolchains required `Task.detached` here as
+  /// a waiver; that's no longer the case.
   nonisolated static func prepareEngine(
     stateFileURL: URL,
     delegate: any CKSyncEngineDelegate & Sendable
   ) async -> PreparedEngine {
-    await Task.detached(priority: .userInitiated) {
-      let data = try? Data(contentsOf: stateFileURL)
-      let savedState = data.flatMap {
-        try? JSONDecoder().decode(CKSyncEngine.State.Serialization.self, from: $0)
-      }
-      let configuration = CKSyncEngine.Configuration(
-        database: CloudKitContainer.app.privateCloudDatabase,
-        stateSerialization: savedState,
-        delegate: delegate
-      )
-      return PreparedEngine(
-        engine: CKSyncEngine(configuration),
-        isFirstLaunch: savedState == nil)
-    }.value
+    let data = try? Data(contentsOf: stateFileURL)
+    let savedState = data.flatMap {
+      try? JSONDecoder().decode(CKSyncEngine.State.Serialization.self, from: $0)
+    }
+    let configuration = CKSyncEngine.Configuration(
+      database: CloudKitContainer.app.privateCloudDatabase,
+      stateSerialization: savedState,
+      delegate: delegate
+    )
+    return PreparedEngine(
+      engine: CKSyncEngine(configuration),
+      isFirstLaunch: savedState == nil)
   }
 
   /// Back-on-MainActor half of `start()`: installs the engine and kicks off


### PR DESCRIPTION
## Summary

Drops the `Task.detached(priority: .userInitiated)` waiver inside `SyncCoordinator.prepareEngine(stateFileURL:delegate:)` and inlines the body. The `nonisolated async` hop from the `@MainActor`-originating `Task {}` in `start()` is now sufficient on its own to land the heavy `NSKeyedUnarchiver` work off the main thread.

The waiver predated current Swift toolchains and was tracked by [issue #565](https://github.com/ajsutton/moolah-native/issues/565) for re-verification — `CONCURRENCY_GUIDE` §8 treats `Task.detached` as an anti-pattern and wanted the empirical justification re-checked under newer dispatch.

## Verification

Re-ran the experiment by temporarily logging `Thread.isMainThread` at the top of `prepareEngine`'s body (wrapped in a sync nonisolated helper since Swift 6 makes `Thread.isMainThread` unavailable in async contexts). Two independent signals:

1. **`isMainThread=false`** logged at the top of the body.
2. **TIDs differ** from the surrounding `@MainActor` `completeStart` log line in the same launch (`4684605` vs `46845d7`), confirming a different OS thread.

Captured launch log (filtered to `category == "SyncCoordinator"`):

```
2026-04-29 16:30:59.558 I  Moolah[92913:4684605] prepareEngine[#565-verify]: isMainThread=false
2026-04-29 16:31:00.062 I  Moolah[92913:46845d7] Started unified sync coordinator
2026-04-29 16:31:00.062 I  Moolah[92913:46845d7] Sync container: iCloud.rocks.moolah.app.test
2026-04-29 16:31:02.612 I  Moolah[92913:46845d7] Ensured zone exists: <private>
```

After confirming the result, the verification scaffolding (helper + log line) was removed; only the `Task.detached` removal and the updated doc comment remain in this PR.

## Test plan

- [x] `just format-check` clean
- [x] `just build-mac` clean
- [ ] CI runs the full test suite — the change is a dispatch-detail removal with no public behaviour change, so existing `SyncCoordinator` tests should pass unchanged.

Closes #565.

🤖 Generated with [Claude Code](https://claude.com/claude-code)