### PR TITLE
fix(grdb): apply Slice 1 reviewer findings and gap-analysis follow-ups

### DIFF
--- a/App/ContentView.swift
+++ b/App/ContentView.swift
@@ -1,4 +1,6 @@
 // swiftlint:disable multiline_arguments
+// Reason: swift-format wraps long initialisers / SwiftUI builders across
+// multiple lines in a way the multiline_arguments rule disagrees with.
 
 import SwiftUI
 

--- a/App/MoolahApp+Setup.swift
+++ b/App/MoolahApp+Setup.swift
@@ -1,4 +1,6 @@
 // swiftlint:disable multiline_arguments
+// Reason: swift-format wraps long initialisers / SwiftUI builders across
+// multiple lines in a way the multiline_arguments rule disagrees with.
 
 import CloudKit
 import Foundation

--- a/App/MoolahApp.swift
+++ b/App/MoolahApp.swift
@@ -1,4 +1,6 @@
 // swiftlint:disable multiline_arguments
+// Reason: swift-format wraps long initialisers / SwiftUI builders across
+// multiple lines in a way the multiline_arguments rule disagrees with.
 
 import CloudKit
 import OSLog

--- a/App/ProfileSession+Factories.swift
+++ b/App/ProfileSession+Factories.swift
@@ -1,4 +1,6 @@
 // swiftlint:disable multiline_arguments
+// Reason: swift-format wraps long initialisers / SwiftUI builders across
+// multiple lines in a way the multiline_arguments rule disagrees with.
 
 import CloudKit
 import Foundation

--- a/App/ProfileSession+SyncWiring.swift
+++ b/App/ProfileSession+SyncWiring.swift
@@ -1,4 +1,3 @@
-import CloudKit
 import Foundation
 
 extension ProfileSession {
@@ -9,7 +8,7 @@ extension ProfileSession {
   /// publishes the concrete-class instances to `SyncCoordinator` so
   /// `handlerForProfileZone` can build a `ProfileDataSyncHandler` that
   /// reaches them.
-  func wireRepositorySync(coordinator: SyncCoordinator, zoneID: CKRecordZone.ID) {
+  func wireRepositorySync(coordinator: SyncCoordinator) {
     registerGRDBRepositoriesForSync(coordinator: coordinator)
   }
 

--- a/App/ProfileSession.swift
+++ b/App/ProfileSession.swift
@@ -66,6 +66,10 @@ final class ProfileSession: Identifiable {
   /// be tracked). Replaced (with cancellation of the prior handle) on
   /// each call to `schedulePragmaOptimize()`.
   private var pragmaOptimizeTask: Task<Void, Never>?
+  /// Tasks spawned by the investment-store → account-store bridge, kept
+  /// reachable so `cleanupSync` can cancel in-flight balance updates
+  /// (per `guides/CONCURRENCY_GUIDE.md` §8).
+  private var crossStoreUpdateTasks: [Task<Void, Never>] = []
 
   /// Synchronous initialiser — opens the per-profile GRDB queue and runs
   /// pending migrations on the calling thread. The migrator currently only
@@ -140,17 +144,16 @@ final class ProfileSession: Identifiable {
     registerWithSyncCoordinator(syncCoordinator)
   }
 
-  /// Wires the investment-store -> account-store callback so the sidebar
-  /// total updates when a position revalues. The callback is fire-and-forget
-  /// in production; `updateInvestmentValue` awaits its own first conversion
-  /// pass, so the sidebar reflects the new value once the Task completes
-  /// on MainActor.
+  /// Wires the investment-store -> account-store callback. The spawned
+  /// Task is appended to `crossStoreUpdateTasks` so `cleanupSync` can
+  /// cancel in-flight updates if the session is torn down.
   private func wireCrossStoreSideEffects() {
     let accountStore = self.accountStore
-    self.investmentStore.onInvestmentValueChanged = { accountId, latestValue in
-      Task {
+    self.investmentStore.onInvestmentValueChanged = { [weak self] accountId, latestValue in
+      let task = Task { @MainActor in
         await accountStore.updateInvestmentValue(accountId: accountId, value: latestValue)
       }
+      self?.crossStoreUpdateTasks.append(task)
     }
   }
 
@@ -164,14 +167,11 @@ final class ProfileSession: Identifiable {
       logger.warning("CloudKit not available — profile sync disabled for \(profileId)")
       return
     }
-    let zoneID = CKRecordZone.ID(
-      zoneName: "profile-\(profileId.uuidString)",
-      ownerName: CKCurrentUserDefaultName)
     logger.info("Registering profile \(profileId) with sync coordinator")
     self.syncObserverToken = coordinator.addObserver(for: profileId) { [weak self] changedTypes in
       self?.scheduleReloadFromSync(changedTypes: changedTypes)
     }
-    wireRepositorySync(coordinator: coordinator, zoneID: zoneID)
+    wireRepositorySync(coordinator: coordinator)
   }
 
   // MARK: - CloudKit Sync
@@ -238,6 +238,10 @@ final class ProfileSession: Identifiable {
     catalogRefreshTask = nil
     pragmaOptimizeTask?.cancel()
     pragmaOptimizeTask = nil
+    for task in crossStoreUpdateTasks {
+      task.cancel()
+    }
+    crossStoreUpdateTasks.removeAll()
   }
 
   // MARK: - Folder watch
@@ -267,9 +271,10 @@ final class ProfileSession: Identifiable {
   /// are logged but never propagated. Per
   /// `guides/DATABASE_SCHEMA_GUIDE.md` §5, the recommended cadence is once
   /// on app resign-active and at most hourly while active. The on-resign
-  /// hook is wired by `MoolahApp+Lifecycle.handleScenePhaseChange`; the
-  /// hourly-while-active tick is a follow-up — for now profile DBs are
-  /// small enough that the once-per-resign cadence suffices.
+  /// hook is wired by `MoolahApp+Lifecycle.handleScenePhaseChange`.
+  ///
+  /// TODO(#576): add the hourly-while-active tick —
+  /// https://github.com/ajsutton/moolah-native/issues/576
   ///
   /// Runs inside `database.write` because `PRAGMA optimize` may invoke
   /// `ANALYZE` and update the `sqlite_stat1` / `sqlite_stat4` tables — a
@@ -334,13 +339,17 @@ final class ProfileSession: Identifiable {
   /// `containerManager` is supplied (tests / previews build a fresh
   /// in-memory GRDB queue and have nothing to migrate from).
   ///
-  /// Slice 0 of `plans/grdb-migration.md`: MUST run before
-  /// `registerWithSyncCoordinator` so CKSyncEngine reads from a fully
-  /// populated `data.sqlite` on the first sync session.
+  /// Must run before `registerWithSyncCoordinator` so CKSyncEngine
+  /// reads from a fully populated `data.sqlite` on the first sync
+  /// session.
   ///
   /// `@MainActor` is explicit (not inherited from the class) because
   /// `SwiftDataToGRDBMigrator.migrateIfNeeded` is `@MainActor` (the
   /// SwiftData fetch path requires it).
+  ///
+  /// TODO(#575): make this `async` and run the GRDB writes off
+  /// `@MainActor` so heavy first-launch migrations can't block the UI —
+  /// https://github.com/ajsutton/moolah-native/issues/575
   @MainActor
   static func runSwiftDataToGRDBMigrationIfNeeded(
     profileId: UUID,

--- a/Backends/CloudKit/CloudKitDataImporter.swift
+++ b/Backends/CloudKit/CloudKitDataImporter.swift
@@ -190,6 +190,11 @@ struct CloudKitDataImporter {
   /// `database.write` transaction commits; non-fiat instruments are
   /// upserted up-front so accounts and legs that reference them by id
   /// can resolve their full domain `Instrument` on read.
+  ///
+  /// TODO(#575): make `writeGRDB` `async` and call
+  /// `try await database.write { … }` so heavy imports don't block the
+  /// main thread —
+  /// https://github.com/ajsutton/moolah-native/issues/575
   private func writeGRDB(data: ExportedData) throws {
     try database.write { database in
       try Self.writeInstrumentsAndCategories(data: data, database: database)

--- a/Backends/CloudKit/Models/EarmarkBudgetItemRecord.swift
+++ b/Backends/CloudKit/Models/EarmarkBudgetItemRecord.swift
@@ -1,4 +1,6 @@
 // swiftlint:disable multiline_arguments
+// Reason: swift-format wraps long initialisers / SwiftUI builders across
+// multiple lines in a way the multiline_arguments rule disagrees with.
 
 import Foundation
 import SwiftData

--- a/Backends/CloudKit/Repositories/CategoryBalancesQuery.swift
+++ b/Backends/CloudKit/Repositories/CategoryBalancesQuery.swift
@@ -1,0 +1,63 @@
+// Backends/CloudKit/Repositories/CategoryBalancesQuery.swift
+
+import Foundation
+
+/// Parameter bundle and per-leg accumulator for `fetchCategoryBalances`,
+/// shared between every `AnalysisRepository` implementation. Keeping the
+/// type in one place stops the GRDB and CloudKit copies from drifting
+/// — the conversion-date rule (Rule 5 of
+/// `guides/INSTRUMENT_CONVERSION_GUIDE.md`) and the per-instrument
+/// arithmetic safety (Rule 1) live here, and any change has to land
+/// once for both backends.
+///
+/// Conversion is delegated to `CloudKitAnalysisRepository.convertedAmount`,
+/// which preserves the historic-snapshot date and applies the
+/// single-instrument fast path.
+struct CategoryBalancesQuery: Sendable {
+  let dateRange: ClosedRange<Date>
+  let transactionType: TransactionType
+  let filters: TransactionFilter?
+  let targetInstrument: Instrument
+  let conversionService: any InstrumentConversionService
+
+  func shouldInclude(_ transaction: Transaction) -> Bool {
+    guard dateRange.contains(transaction.date) else { return false }
+    guard transaction.recurPeriod == nil else { return false }
+    if let accountId = filters?.accountId,
+      !transaction.accountIds.contains(accountId)
+    {
+      return false
+    }
+    if let payee = filters?.payee, transaction.payee != payee {
+      return false
+    }
+    return true
+  }
+
+  func accumulate(
+    transaction: Transaction,
+    into balances: inout [UUID: InstrumentAmount]
+  ) async throws {
+    for leg in transaction.legs {
+      guard leg.type == transactionType else { continue }
+      guard let categoryId = leg.categoryId else { continue }
+
+      if let earmarkId = filters?.earmarkId, leg.earmarkId != earmarkId {
+        continue
+      }
+      if let categoryIds = filters?.categoryIds, !categoryIds.isEmpty,
+        !categoryIds.contains(categoryId)
+      {
+        continue
+      }
+
+      let amount = try await CloudKitAnalysisRepository.convertedAmount(
+        leg,
+        to: targetInstrument,
+        on: transaction.date,
+        conversionService: conversionService
+      )
+      balances[categoryId, default: .zero(instrument: targetInstrument)] += amount
+    }
+  }
+}

--- a/Backends/CloudKit/Repositories/CloudKitAnalysisRepository.swift
+++ b/Backends/CloudKit/Repositories/CloudKitAnalysisRepository.swift
@@ -1,4 +1,6 @@
 // swiftlint:disable multiline_arguments
+// Reason: swift-format wraps long initialisers / SwiftUI builders across
+// multiple lines in a way the multiline_arguments rule disagrees with.
 
 import Foundation
 import OSLog
@@ -189,57 +191,9 @@ final class CloudKitAnalysisRepository: AnalysisRepository, @unchecked Sendable 
     return balances
   }
 
-  /// Parameter bundle for `fetchCategoryBalances`. Encapsulates the filtering
-  /// predicate and per-leg accumulation so both helpers stay at a single
-  /// parameter each and satisfy the `function_parameter_count` threshold.
-  struct CategoryBalancesQuery: Sendable {
-    let dateRange: ClosedRange<Date>
-    let transactionType: TransactionType
-    let filters: TransactionFilter?
-    let targetInstrument: Instrument
-    let conversionService: any InstrumentConversionService
-
-    func shouldInclude(_ transaction: Transaction) -> Bool {
-      guard dateRange.contains(transaction.date) else { return false }
-      guard transaction.recurPeriod == nil else { return false }
-      if let accountId = filters?.accountId,
-        !transaction.accountIds.contains(accountId)
-      {
-        return false
-      }
-      if let payee = filters?.payee, transaction.payee != payee {
-        return false
-      }
-      return true
-    }
-
-    func accumulate(
-      transaction: Transaction,
-      into balances: inout [UUID: InstrumentAmount]
-    ) async throws {
-      for leg in transaction.legs {
-        guard leg.type == transactionType else { continue }
-        guard let categoryId = leg.categoryId else { continue }
-
-        if let earmarkId = filters?.earmarkId, leg.earmarkId != earmarkId {
-          continue
-        }
-        if let categoryIds = filters?.categoryIds, !categoryIds.isEmpty,
-          !categoryIds.contains(categoryId)
-        {
-          continue
-        }
-
-        let amount = try await CloudKitAnalysisRepository.convertedAmount(
-          leg,
-          to: targetInstrument,
-          on: transaction.date,
-          conversionService: conversionService
-        )
-        balances[categoryId, default: .zero(instrument: targetInstrument)] += amount
-      }
-    }
-  }
+  // CategoryBalancesQuery moved to its own file
+  // (`CategoryBalancesQuery.swift`) so the GRDB AnalysisRepository can
+  // share the same accumulator instead of mirroring it locally.
 
   // MARK: - Data Fetching Helpers
 

--- a/Backends/CloudKit/Sync/ProfileDataSyncHandler+ApplyRemoteChanges.swift
+++ b/Backends/CloudKit/Sync/ProfileDataSyncHandler+ApplyRemoteChanges.swift
@@ -1,4 +1,6 @@
 // swiftlint:disable multiline_arguments
+// Reason: swift-format wraps long initialisers / SwiftUI builders across
+// multiple lines in a way the multiline_arguments rule disagrees with.
 
 @preconcurrency import CloudKit
 import Foundation

--- a/Backends/CloudKit/Sync/ProfileDataSyncHandler+SystemFields.swift
+++ b/Backends/CloudKit/Sync/ProfileDataSyncHandler+SystemFields.swift
@@ -13,11 +13,14 @@ extension ProfileDataSyncHandler {
     }
   }
 
-  /// Per-record-type clear operations, in dependency order.
+  /// Per-record-type clear operations, listed in the same dependency
+  /// order `deleteLocalData()` uses (parents before children, with the
+  /// CSV-import / import-rule pair at the end). Independent updates so
+  /// the order doesn't affect correctness, but matching the two lists
+  /// keeps a future maintainer from getting them out of step when a
+  /// new record type is added.
   private func clearOperations() -> [(String, () throws -> Void)] {
     [
-      (CSVImportProfileRow.recordType, grdbRepositories.csvImportProfiles.clearAllSystemFieldsSync),
-      (ImportRuleRow.recordType, grdbRepositories.importRules.clearAllSystemFieldsSync),
       (InstrumentRow.recordType, grdbRepositories.instruments.clearAllSystemFieldsSync),
       (CategoryRow.recordType, grdbRepositories.categories.clearAllSystemFieldsSync),
       (AccountRow.recordType, grdbRepositories.accounts.clearAllSystemFieldsSync),
@@ -29,6 +32,8 @@ extension ProfileDataSyncHandler {
       (InvestmentValueRow.recordType, grdbRepositories.investmentValues.clearAllSystemFieldsSync),
       (TransactionRow.recordType, grdbRepositories.transactions.clearAllSystemFieldsSync),
       (TransactionLegRow.recordType, grdbRepositories.transactionLegs.clearAllSystemFieldsSync),
+      (CSVImportProfileRow.recordType, grdbRepositories.csvImportProfiles.clearAllSystemFieldsSync),
+      (ImportRuleRow.recordType, grdbRepositories.importRules.clearAllSystemFieldsSync),
     ]
   }
 

--- a/Backends/CloudKit/Sync/ProfileDataSyncHandler.swift
+++ b/Backends/CloudKit/Sync/ProfileDataSyncHandler.swift
@@ -28,11 +28,12 @@ final class ProfileDataSyncHandler {
   nonisolated let profileId: UUID
   nonisolated let zoneID: CKRecordZone.ID
   nonisolated let modelContainer: ModelContainer
-  /// GRDB-backed repos for the record types migrated to SQLite. Used by
-  /// the dispatch tables in `+ApplyRemoteChanges`, `+QueueAndDelete`,
-  /// `+RecordLookup`, and `+SystemFields` for the two record types
-  /// covered by `v2_csv_import_and_rules`. Subsequent slices extend the
-  /// list.
+  /// GRDB-backed repos for the record types whose persistence lives in
+  /// SQLite rather than SwiftData. Used by the dispatch tables in
+  /// `+ApplyRemoteChanges`, `+QueueAndDelete`, `+RecordLookup`, and
+  /// `+SystemFields` so each per-type save/delete handler can address
+  /// the right repository without leaking GRDB types into the sync
+  /// engine's wire layer.
   nonisolated let grdbRepositories: ProfileGRDBRepositories
 
   /// Closure fired from `applyRemoteChanges` whenever a remote pull touches

--- a/Backends/CloudKit/Sync/SyncCoordinator+Delegate.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+Delegate.swift
@@ -1,4 +1,6 @@
 // swiftlint:disable multiline_arguments
+// Reason: swift-format wraps long initialisers / SwiftUI builders across
+// multiple lines in a way the multiline_arguments rule disagrees with.
 
 @preconcurrency import CloudKit
 import Foundation

--- a/Backends/CloudKit/Sync/SyncCoordinator+RecordChanges.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+RecordChanges.swift
@@ -1,4 +1,6 @@
 // swiftlint:disable multiline_arguments
+// Reason: swift-format wraps long initialisers / SwiftUI builders across
+// multiple lines in a way the multiline_arguments rule disagrees with.
 
 @preconcurrency import CloudKit
 import Foundation

--- a/Backends/CloudKit/Sync/SyncCoordinator.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator.swift
@@ -288,11 +288,12 @@ final class SyncCoordinator {
   var instrumentRemoteChangeCallbacks: [UUID: @Sendable () -> Void] = [:]
 
   /// Per-profile GRDB repository bundle. Registered by `ProfileSession`
-  /// during `registerWithSyncCoordinator` (before the handler is lazily
-  /// created in `handlerForProfileZone`) so the dispatch tables in
-  /// `ProfileDataSyncHandler+ApplyRemoteChanges` etc. can route the
-  /// record types covered by `v2_csv_import_and_rules` (and subsequent
-  /// slices) through GRDB instead of SwiftData. See `ProfileGRDBRepositories`.
+  /// during `registerWithSyncCoordinator` so it is available when
+  /// `handlerForProfileZone(profileId:zoneID:)` lazily creates the
+  /// `ProfileDataSyncHandler`. The handler's dispatch tables address
+  /// these repositories directly so the per-record-type save / delete
+  /// helpers can write into SQLite without leaking GRDB types into the
+  /// CKSyncEngine wire layer. See `ProfileGRDBRepositories`.
   var profileGRDBRepositories: [UUID: ProfileGRDBRepositories] = [:]
   // Test-only fallback factory — see `+HandlerAccess.swift`.
   let fallbackGRDBRepositoriesFactory: (@Sendable (UUID) throws -> ProfileGRDBRepositories)?

--- a/Backends/GRDB/ProfileSchema+CoreFinancialGraph.swift
+++ b/Backends/GRDB/ProfileSchema+CoreFinancialGraph.swift
@@ -191,6 +191,9 @@ extension ProfileSchema {
             WHERE recur_period IS NOT NULL;
         CREATE INDEX transaction_by_payee
             ON "transaction"(payee) WHERE payee IS NOT NULL;
+        -- TODO(#581): no read caller yet — either wire
+        -- `fetchByImportSession` for the CSV-import revert path or drop
+        -- this index. https://github.com/ajsutton/moolah-native/issues/581
         CREATE INDEX transaction_by_session
             ON "transaction"(import_origin_import_session_id)
             WHERE import_origin_import_session_id IS NOT NULL;

--- a/Backends/GRDB/ProfileSchema+RateCaches.swift
+++ b/Backends/GRDB/ProfileSchema+RateCaches.swift
@@ -4,6 +4,13 @@ import Foundation
 import GRDB
 
 // MARK: - v1 migration body
+//
+// TODO(#582): the three `*_meta` tables use a single TEXT primary key
+// and would benefit from `WITHOUT ROWID` per
+// `guides/DATABASE_SCHEMA_GUIDE.md` §3, but GRDB's `PersistableRecord`
+// upsert path emits `RETURNING "rowid"` which fails against
+// rowid-less tables. Resolve once the records can opt out.
+// https://github.com/ajsutton/moolah-native/issues/582
 
 extension ProfileSchema {
   static func createInitialTables(_ database: Database) throws {

--- a/Backends/GRDB/Records/AccountRow+Mapping.swift
+++ b/Backends/GRDB/Records/AccountRow+Mapping.swift
@@ -37,6 +37,8 @@ extension AccountRow {
     return Account(
       id: id,
       name: name,
+      // TODO(#578): handle unknown raw values explicitly instead of
+      // silently falling back — https://github.com/ajsutton/moolah-native/issues/578
       type: AccountType(rawValue: type) ?? .bank,
       instrument: instrument,
       positions: positions,

--- a/Backends/GRDB/Records/TransactionLegRow+Mapping.swift
+++ b/Backends/GRDB/Records/TransactionLegRow+Mapping.swift
@@ -45,6 +45,8 @@ extension TransactionLegRow {
       accountId: accountId,
       instrument: instrument,
       quantity: InstrumentAmount(storageValue: quantity, instrument: instrument).quantity,
+      // TODO(#578): handle unknown raw values explicitly instead of
+      // silently falling back — https://github.com/ajsutton/moolah-native/issues/578
       type: TransactionType(rawValue: type) ?? .expense,
       categoryId: categoryId,
       earmarkId: earmarkId

--- a/Backends/GRDB/Repositories/GRDBAccountRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBAccountRepository.swift
@@ -174,7 +174,13 @@ final class GRDBAccountRepository: AccountRepository, @unchecked Sendable {
       throw BackendError.validationFailed("Account name cannot be empty")
     }
 
-    let updated = try await database.write { database -> AccountRow in
+    // Combine the row update and the post-update position read into a
+    // single `database.write` so the returned `Account` reflects the
+    // exact same database state as the row mutation. A separate
+    // follow-up `database.read` would race with concurrent writers and
+    // could observe positions from after the update commit, or — worse
+    // — emit `onRecordChanged` before the second read settled.
+    let resolved = try await database.write { database -> Account in
       guard
         var existing =
           try AccountRow
@@ -189,16 +195,14 @@ final class GRDBAccountRepository: AccountRepository, @unchecked Sendable {
       existing.position = account.position
       existing.isHidden = account.isHidden
       try existing.update(database)
-      return existing
-    }
-    onRecordChanged(AccountRow.recordType, account.id)
 
-    return try await database.read { database -> Account in
       let instruments = try Self.fetchInstrumentMap(database: database)
       let positions = try Self.computePositions(
         database: database, instruments: instruments, accountId: account.id)
-      return updated.toDomain(instruments: instruments, positions: positions)
+      return existing.toDomain(instruments: instruments, positions: positions)
     }
+    onRecordChanged(AccountRow.recordType, account.id)
+    return resolved
   }
 
   func delete(id: UUID) async throws {

--- a/Backends/GRDB/Repositories/GRDBAnalysisRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBAnalysisRepository.swift
@@ -149,147 +149,127 @@ final class GRDBAnalysisRepository: AnalysisRepository, @unchecked Sendable {
     let investmentValues: [InvestmentValueSnapshot]
   }
 
+  /// Loads transactions, accounts, and investment values in a single
+  /// `database.read` so every value comes from the same MVCC snapshot.
+  /// Three independent reads under WAL would race a concurrent writer
+  /// and surface internally inconsistent state — e.g. a leg referencing
+  /// an account that hasn't yet appeared in the account list.
   private func fetchSharedData() async throws -> SharedData {
-    let allTransactions = try await fetchTransactions(filter: .all)
-    let accounts = try await fetchAccounts()
-    let nonScheduled = allTransactions.filter { !$0.isScheduled }
-    let scheduled = allTransactions.filter { $0.isScheduled }
-    let investmentAccountIds = Set(accounts.filter { $0.type == .investment }.map(\.id))
-    let investmentValues = try await fetchAllInvestmentValues(
-      investmentAccountIds: investmentAccountIds)
-    return SharedData(
-      nonScheduled: nonScheduled,
-      scheduled: scheduled,
-      accounts: accounts,
-      investmentValues: investmentValues)
+    let resolvedInstrument = self.instrument
+    return try await database.read { database -> SharedData in
+      let allTransactions = try Self.fetchTransactionsSnapshot(
+        filter: .all, database: database)
+      let accounts = try Self.fetchAccountsSnapshot(
+        database: database, instrument: resolvedInstrument)
+      let nonScheduled = allTransactions.filter { !$0.isScheduled }
+      let scheduled = allTransactions.filter { $0.isScheduled }
+      let investmentAccountIds = Set(
+        accounts.filter { $0.type == .investment }.map(\.id))
+      let investmentValues = try Self.fetchAllInvestmentValuesSnapshot(
+        database: database, investmentAccountIds: investmentAccountIds)
+      return SharedData(
+        nonScheduled: nonScheduled,
+        scheduled: scheduled,
+        accounts: accounts,
+        investmentValues: investmentValues)
+    }
   }
 
+  /// Loads every transaction (and its legs) as Domain values.
+  ///
+  /// **Intentional full table scan.** This method drives the analysis
+  /// hot paths and currently materialises every row in `transaction`,
+  /// `transaction_leg`, and `instrument` so the existing Swift-side
+  /// compute helpers can run unchanged. The four covering indexes
+  /// (`leg_analysis_by_type_account`, `leg_analysis_by_type_category`,
+  /// `leg_analysis_by_earmark_type`, `iv_by_account_date_value`) are
+  /// in place but not yet exploited from this path — TODO(#577) pushes
+  /// the per-instrument GROUP BY into SQL and removes the SCAN —
+  /// https://github.com/ajsutton/moolah-native/issues/577
   private func fetchTransactions(filter: ScheduledFilter) async throws -> [Transaction] {
     try await database.read { database -> [Transaction] in
-      let txnRows = try TransactionRow.fetchAll(database)
-      let legRows = try TransactionLegRow.fetchAll(database)
-      let instrumentRows = try InstrumentRow.fetchAll(database)
-
-      var instrumentLookup: [String: Instrument] = [:]
-      for row in instrumentRows {
-        instrumentLookup[row.id] = row.toDomain()
-      }
-
-      let legsByTxnId = Dictionary(grouping: legRows, by: \.transactionId)
-
-      var transactions = txnRows.map { row -> Transaction in
-        let legs =
-          (legsByTxnId[row.id] ?? [])
-          .sorted { $0.sortOrder < $1.sortOrder }
-          .map { legRow -> TransactionLeg in
-            let legInstrument =
-              instrumentLookup[legRow.instrumentId]
-              ?? Instrument.fiat(code: legRow.instrumentId)
-            return legRow.toDomain(instrument: legInstrument)
-          }
-        return row.toDomain(legs: legs)
-      }
-
-      switch filter {
-      case .all:
-        return transactions
-      case .scheduledOnly:
-        transactions = transactions.filter(\.isScheduled)
-      case .nonScheduledOnly:
-        transactions = transactions.filter { !$0.isScheduled }
-      }
-      return transactions
+      try Self.fetchTransactionsSnapshot(filter: filter, database: database)
     }
+  }
+
+  private static func fetchTransactionsSnapshot(
+    filter: ScheduledFilter, database: Database
+  ) throws -> [Transaction] {
+    let txnRows = try TransactionRow.fetchAll(database)
+    let legRows = try TransactionLegRow.fetchAll(database)
+    let instrumentRows = try InstrumentRow.fetchAll(database)
+
+    var instrumentLookup: [String: Instrument] = [:]
+    for row in instrumentRows {
+      instrumentLookup[row.id] = row.toDomain()
+    }
+
+    let legsByTxnId = Dictionary(grouping: legRows, by: \.transactionId)
+
+    var transactions = txnRows.map { row -> Transaction in
+      let legs =
+        (legsByTxnId[row.id] ?? [])
+        .sorted { $0.sortOrder < $1.sortOrder }
+        .map { legRow -> TransactionLeg in
+          let legInstrument =
+            instrumentLookup[legRow.instrumentId]
+            ?? Instrument.fiat(code: legRow.instrumentId)
+          return legRow.toDomain(instrument: legInstrument)
+        }
+      return row.toDomain(legs: legs)
+    }
+
+    switch filter {
+    case .all:
+      return transactions
+    case .scheduledOnly:
+      transactions = transactions.filter(\.isScheduled)
+    case .nonScheduledOnly:
+      transactions = transactions.filter { !$0.isScheduled }
+    }
+    return transactions
   }
 
   private func fetchAccounts() async throws -> [Account] {
     let resolvedInstrument = self.instrument
     return try await database.read { database -> [Account] in
-      let rows = try AccountRow.fetchAll(database)
-      return rows.map { row in
-        Account(
-          id: row.id,
-          name: row.name,
-          type: AccountType(rawValue: row.type) ?? .bank,
-          instrument: resolvedInstrument,
-          position: row.position,
-          isHidden: row.isHidden)
-      }
+      try Self.fetchAccountsSnapshot(database: database, instrument: resolvedInstrument)
     }
   }
 
-  private func fetchAllInvestmentValues(
+  private static func fetchAccountsSnapshot(
+    database: Database, instrument: Instrument
+  ) throws -> [Account] {
+    let rows = try AccountRow.fetchAll(database)
+    return rows.map { row in
+      Account(
+        id: row.id,
+        name: row.name,
+        type: AccountType(rawValue: row.type) ?? .bank,
+        instrument: instrument,
+        position: row.position,
+        isHidden: row.isHidden)
+    }
+  }
+
+  private static func fetchAllInvestmentValuesSnapshot(
+    database: Database,
     investmentAccountIds: Set<UUID>
-  ) async throws -> [InvestmentValueSnapshot] {
+  ) throws -> [InvestmentValueSnapshot] {
     guard !investmentAccountIds.isEmpty else { return [] }
-    return try await database.read { database -> [InvestmentValueSnapshot] in
-      let rows =
-        try InvestmentValueRow
-        .filter(investmentAccountIds.contains(InvestmentValueRow.Columns.accountId))
-        .fetchAll(database)
-      return
-        rows
-        .map { row -> InvestmentValueSnapshot in
-          let value = row.toDomain().value
-          return InvestmentValueSnapshot(
-            accountId: row.accountId,
-            date: row.date,
-            value: value)
-        }
-        .sorted { $0.date < $1.date }
-    }
-  }
-}
-
-// MARK: - Local copy of the shared category-balances accumulator
-
-extension GRDBAnalysisRepository {
-  /// Mirror of `CloudKitAnalysisRepository.CategoryBalancesQuery`. Local
-  /// copy so this implementation does not depend on the CloudKit repo's
-  /// nested types beyond the static compute helpers.
-  private struct CategoryBalancesQuery: Sendable {
-    let dateRange: ClosedRange<Date>
-    let transactionType: TransactionType
-    let filters: TransactionFilter?
-    let targetInstrument: Instrument
-    let conversionService: any InstrumentConversionService
-
-    func shouldInclude(_ transaction: Transaction) -> Bool {
-      guard dateRange.contains(transaction.date) else { return false }
-      guard transaction.recurPeriod == nil else { return false }
-      if let accountId = filters?.accountId,
-        !transaction.accountIds.contains(accountId)
-      {
-        return false
+    let rows =
+      try InvestmentValueRow
+      .filter(investmentAccountIds.contains(InvestmentValueRow.Columns.accountId))
+      .fetchAll(database)
+    return
+      rows
+      .map { row -> InvestmentValueSnapshot in
+        let value = row.toDomain().value
+        return InvestmentValueSnapshot(
+          accountId: row.accountId,
+          date: row.date,
+          value: value)
       }
-      if let payee = filters?.payee, transaction.payee != payee {
-        return false
-      }
-      return true
-    }
-
-    func accumulate(
-      transaction: Transaction,
-      into balances: inout [UUID: InstrumentAmount]
-    ) async throws {
-      for leg in transaction.legs {
-        guard leg.type == transactionType else { continue }
-        guard let categoryId = leg.categoryId else { continue }
-        if let earmarkId = filters?.earmarkId, leg.earmarkId != earmarkId {
-          continue
-        }
-        if let categoryIds = filters?.categoryIds, !categoryIds.isEmpty,
-          !categoryIds.contains(categoryId)
-        {
-          continue
-        }
-        let amount = try await CloudKitAnalysisRepository.convertedAmount(
-          leg,
-          to: targetInstrument,
-          on: transaction.date,
-          conversionService: conversionService)
-        balances[categoryId, default: .zero(instrument: targetInstrument)] += amount
-      }
-    }
+      .sorted { $0.date < $1.date }
   }
 }

--- a/Backends/GRDB/Repositories/GRDBCSVImportProfileRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBCSVImportProfileRepository.swift
@@ -5,24 +5,20 @@ import GRDB
 
 /// GRDB-backed implementation of `CSVImportProfileRepository`. Replaces
 /// the SwiftData-backed `CloudKitCSVImportProfileRepository` for the
-/// `csv_import_profile` table introduced by `v2_csv_import_and_rules`.
+/// `csv_import_profile` table.
 ///
 /// **Concurrency.** `final class` + `@unchecked Sendable` rather than
-/// `actor`, mirroring the existing CloudKit-repo shape. Plan
-/// `plans/grdb-slice-0-csv-import.md` §3.7 originally recommended `actor`
-/// but flagged the fallback: "If `actor` introduces an `await` cascade
-/// that `@unchecked Sendable` avoided, fall back to the existing
-/// pattern." The cascade does materialise here — `ProfileDataSyncHandler`
-/// sync entry points (`applyBatchSaves`, `recordToSave`,
-/// `setEncodedSystemFields`, etc.) are synchronous and called from
-/// CKSyncEngine delegate paths that are not trivially convertible to
-/// `async` without rippling through every record-type's dispatch table.
-/// Sticking with the class shape keeps slice 0's blast radius tight; the
-/// repo's *public* protocol surface is still `async throws` (writes go
-/// through the GRDB queue's serialised executor; reads do too) so callers
-/// see no concurrency-model change. Hook closures are `let` properties
-/// set during `init` per the plan — post-init reassignment is not
-/// supported.
+/// `actor`. The CKSyncEngine delegate path (`applyBatchSaves`,
+/// `recordToSave`, `setEncodedSystemFields`, …) calls into the
+/// repository's sync entry points synchronously; converting those to
+/// `await` against an `actor` would ripple async propagation through
+/// every per-record-type dispatch table for no concurrency benefit
+/// (the GRDB queue's serial executor already mediates concurrent
+/// access). The repo's *public* protocol surface is still `async
+/// throws` (writes go through the GRDB queue's serialised executor;
+/// reads do too) so callers see no concurrency-model change. Hook
+/// closures are `let` properties set during `init` — post-init
+/// reassignment is not supported.
 ///
 /// **`@unchecked Sendable` justification.** All stored properties are
 /// `let`. `database` (`any DatabaseWriter`) is itself `Sendable` (GRDB

--- a/Backends/GRDB/Repositories/GRDBInvestmentRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBInvestmentRepository.swift
@@ -157,6 +157,15 @@ final class GRDBInvestmentRepository: InvestmentRepository, @unchecked Sendable 
   /// looks up their dates, accumulates a running balance, and
   /// collapses to one entry per calendar day. Mirrors
   /// `CloudKitInvestmentRepository.fetchDailyBalances`.
+  ///
+  /// TODO(#579): the running total is summed across every leg's
+  /// `quantity` regardless of `instrumentId`, then labelled with
+  /// `defaultInstrument`. For an investment account that holds a
+  /// single instrument (the production case today) the result is
+  /// correct; for a multi-instrument account it conflates quantities
+  /// of different instruments under one label. Group by
+  /// `(date, instrument_id)` and emit one balance per (date,
+  /// instrument) — https://github.com/ajsutton/moolah-native/issues/579
   private static func computeDailyBalances(
     database: Database,
     accountId: UUID,

--- a/Backends/GRDB/Repositories/GRDBTransactionRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBTransactionRepository.swift
@@ -40,12 +40,7 @@ import OSLog
 /// race; `@unchecked` only waives Swift's structural check that
 /// `final class` types meet `Sendable`'s requirements automatically.
 final class GRDBTransactionRepository: TransactionRepository, @unchecked Sendable {
-  // `private(set) internal var` mirrors `let` immutability (no setter
-  // is exposed externally; `init` runs in the same file as the
-  // declaration, so the implicit private setter is reachable from
-  // there) while keeping read access available to the sibling
-  // extension files (`+Sync.swift`) that need to reach the queue.
-  private(set) var database: any DatabaseWriter
+  let database: any DatabaseWriter
   /// Profile instrument used to label the running balance for global
   /// (non-account-scoped) fetches. Mirrors
   /// `CloudKitTransactionRepository.instrument`.

--- a/Features/Investments/InvestmentChartData.swift
+++ b/Features/Investments/InvestmentChartData.swift
@@ -1,0 +1,121 @@
+// Features/Investments/InvestmentChartData.swift
+
+import Foundation
+
+/// Pure functions that merge investment values and daily balances into
+/// chart data points. Namespaced in a caseless enum so they don't leak
+/// into the app target's top level — visible to `@testable import
+/// Moolah` so the algorithm can be unit-tested without driving the
+/// store's async pipeline. Algorithm ported from
+/// InvestmentValueGraph.vue:61-141.
+enum InvestmentChartData {
+  /// One bucket of merged data before forward-filling. `value` is the
+  /// snapshot price for the date, `balance` is the cumulative cost
+  /// basis. Both are optional because a date may have only one of the
+  /// two recorded.
+  struct Bucket: Equatable {
+    let value: Decimal?
+    let balance: Decimal?
+  }
+
+  /// One forward-filled chart point pre-pack into `InvestmentChartDataPoint`.
+  /// Replaces a three-element tuple to satisfy `large_tuple` and avoid
+  /// positional-argument confusion at the call site.
+  private struct PendingPoint {
+    let date: Date
+    let value: Decimal?
+    let balance: Decimal?
+  }
+
+  static func merge(
+    values: [InvestmentValue],
+    balances: [AccountDailyBalance],
+    period: TimePeriod
+  ) -> [InvestmentChartDataPoint] {
+    let startDate = period.startDate
+    let collected = collectByDate(values: values, balances: balances, startDate: startDate)
+    return forwardFill(dataByDate: collected)
+  }
+
+  private static func collectByDate(
+    values: [InvestmentValue],
+    balances: [AccountDailyBalance],
+    startDate: Date?
+  ) -> [Date: Bucket] {
+    var dataByDate: [Date: Bucket] = [:]
+    var startValue: InvestmentValue?
+    var startBalance: AccountDailyBalance?
+
+    for value in values {
+      if let startDate, value.date < startDate {
+        if value.date > (startValue?.date ?? .distantPast) { startValue = value }
+        continue
+      }
+      let existing = dataByDate[value.date]
+      dataByDate[value.date] = Bucket(value: value.value.quantity, balance: existing?.balance)
+    }
+
+    for balance in balances {
+      if let startDate, balance.date < startDate {
+        if balance.date > (startBalance?.date ?? .distantPast) { startBalance = balance }
+        continue
+      }
+      let existing = dataByDate[balance.date]
+      dataByDate[balance.date] = Bucket(value: existing?.value, balance: balance.balance.quantity)
+    }
+
+    // If we have pre-period values, add them at the start date.
+    if let startDate {
+      if let seedValue = startValue {
+        let existing = dataByDate[startDate]
+        dataByDate[startDate] = Bucket(
+          value: existing?.value ?? seedValue.value.quantity,
+          balance: existing?.balance)
+      }
+      if let seedBalance = startBalance {
+        let existing = dataByDate[startDate]
+        dataByDate[startDate] = Bucket(
+          value: existing?.value,
+          balance: existing?.balance ?? seedBalance.balance.quantity)
+      }
+    }
+    return dataByDate
+  }
+
+  private static func forwardFill(
+    dataByDate: [Date: Bucket]
+  ) -> [InvestmentChartDataPoint] {
+    let sorted =
+      dataByDate
+      .map { PendingPoint(date: $0.key, value: $0.value.value, balance: $0.value.balance) }
+      .sorted { $0.date < $1.date }
+
+    var lastValue: Decimal?
+    var lastBalance: Decimal?
+    var result: [InvestmentChartDataPoint] = []
+
+    for item in sorted {
+      let currentValue = item.value ?? lastValue
+      let currentBalance = item.balance ?? lastBalance
+
+      if let itemValue = item.value { lastValue = itemValue }
+      if let itemBalance = item.balance { lastBalance = itemBalance }
+
+      let profitLoss: Decimal? =
+        if let value = currentValue, let balance = currentBalance {
+          value - balance
+        } else {
+          nil
+        }
+
+      result.append(
+        InvestmentChartDataPoint(
+          date: item.date,
+          value: currentValue,
+          balance: currentBalance,
+          profitLoss: profitLoss))
+    }
+
+    return result
+  }
+}

--- a/Features/Investments/InvestmentStore.swift
+++ b/Features/Investments/InvestmentStore.swift
@@ -291,7 +291,7 @@ final class InvestmentStore {
   /// Merged chart data points combining values and balances.
   /// Follows the web app's algorithm: merge by date, forward-fill gaps, compute profit/loss.
   var chartDataPoints: [InvestmentChartDataPoint] {
-    mergeChartData(
+    InvestmentChartData.merge(
       values: values,
       balances: dailyBalances,
       period: selectedPeriod
@@ -300,100 +300,6 @@ final class InvestmentStore {
 
 }
 
-// MARK: - Chart Data Merging
-
-/// Merges investment values and daily balances into chart data points.
-/// Algorithm ported from InvestmentValueGraph.vue:61-141.
-func mergeChartData(
-  values: [InvestmentValue],
-  balances: [AccountDailyBalance],
-  period: TimePeriod
-) -> [InvestmentChartDataPoint] {
-  let startDate = period.startDate
-  let collected = collectChartDataByDate(
-    values: values, balances: balances, startDate: startDate)
-  return forwardFillChartData(dataByDate: collected)
-}
-
-private func collectChartDataByDate(
-  values: [InvestmentValue],
-  balances: [AccountDailyBalance],
-  startDate: Date?
-) -> [Date: (value: Decimal?, balance: Decimal?)] {
-  var dataByDate: [Date: (value: Decimal?, balance: Decimal?)] = [:]
-  var startValue: InvestmentValue?
-  var startBalance: AccountDailyBalance?
-
-  for value in values {
-    if let startDate, value.date < startDate {
-      if value.date > (startValue?.date ?? .distantPast) { startValue = value }
-      continue
-    }
-    let existing = dataByDate[value.date]
-    dataByDate[value.date] = (value: value.value.quantity, balance: existing?.balance)
-  }
-
-  for balance in balances {
-    if let startDate, balance.date < startDate {
-      if balance.date > (startBalance?.date ?? .distantPast) { startBalance = balance }
-      continue
-    }
-    let existing = dataByDate[balance.date]
-    dataByDate[balance.date] = (value: existing?.value, balance: balance.balance.quantity)
-  }
-
-  // If we have pre-period values, add them at the start date
-  if let startDate {
-    if let seedValue = startValue {
-      let existing = dataByDate[startDate]
-      dataByDate[startDate] = (
-        value: existing?.value ?? seedValue.value.quantity,
-        balance: existing?.balance
-      )
-    }
-    if let seedBalance = startBalance {
-      let existing = dataByDate[startDate]
-      dataByDate[startDate] = (
-        value: existing?.value,
-        balance: existing?.balance ?? seedBalance.balance.quantity
-      )
-    }
-  }
-  return dataByDate
-}
-
-private func forwardFillChartData(
-  dataByDate: [Date: (value: Decimal?, balance: Decimal?)]
-) -> [InvestmentChartDataPoint] {
-  var sorted = dataByDate.map { (date: $0.key, value: $0.value.value, balance: $0.value.balance) }
-  sorted.sort { $0.date < $1.date }
-
-  var lastValue: Decimal?
-  var lastBalance: Decimal?
-  var result: [InvestmentChartDataPoint] = []
-
-  for item in sorted {
-    let currentValue = item.value ?? lastValue
-    let currentBalance = item.balance ?? lastBalance
-
-    if let itemValue = item.value { lastValue = itemValue }
-    if let itemBalance = item.balance { lastBalance = itemBalance }
-
-    let profitLoss: Decimal? =
-      if let value = currentValue, let balance = currentBalance {
-        value - balance
-      } else {
-        nil
-      }
-
-    result.append(
-      InvestmentChartDataPoint(
-        date: item.date,
-        value: currentValue,
-        balance: currentBalance,
-        profitLoss: profitLoss
-      ))
-  }
-
-  return result
-}
+// `InvestmentChartData` (the merge + forward-fill helpers used by
+// `chartDataPoints`) lives in `InvestmentChartData.swift` so this file
+// stays under the file_length budget.

--- a/MoolahTests/Backends/GRDB/AnalysisPlanPinningTests.swift
+++ b/MoolahTests/Backends/GRDB/AnalysisPlanPinningTests.swift
@@ -31,16 +31,20 @@ struct AnalysisPlanPinningTests {
     try ProfileDatabase.openInMemory()
   }
 
-  /// Returns the joined `detail` column from the EXPLAIN QUERY PLAN rows.
-  /// Joining keeps `contains` checks readable and matches the format the
-  /// SQLite docs use to describe plans.
+  /// Returns the joined `detail` column from the EXPLAIN QUERY PLAN rows
+  /// for the given query. Callers pass the bare query SQL (without the
+  /// `EXPLAIN QUERY PLAN` prefix) — the helper prepends the directive
+  /// via string concatenation so the `sql:` argument carries no string
+  /// interpolation, satisfying `guides/DATABASE_CODE_GUIDE.md` §4.
+  /// Joining the `detail` column keeps `contains` checks readable and
+  /// matches the format the SQLite docs use to describe plans.
   private func planDetail(
-    _ database: DatabaseQueue, sql: String, arguments: StatementArguments = []
+    _ database: DatabaseQueue, query: String, arguments: StatementArguments = []
   ) throws -> String {
     try database.read { database in
-      let rows = try Row.fetchAll(
-        database, sql: "EXPLAIN QUERY PLAN \(sql)", arguments: arguments)
-      return rows.compactMap { $0["detail"] as? String }.joined(separator: "; ")
+      let planSQL = "EXPLAIN QUERY PLAN " + query
+      let rows = try Row.fetchAll(database, sql: planSQL, arguments: arguments)
+      return rows.compactMap { $0["detail"] as String? }.joined(separator: "; ")
     }
   }
 
@@ -61,7 +65,7 @@ struct AnalysisPlanPinningTests {
     // line in the plan is the regression signal.
     let detail = try planDetail(
       database,
-      sql: """
+      query: """
         SELECT payee
         FROM "transaction"
         WHERE payee IS NOT NULL
@@ -79,7 +83,7 @@ struct AnalysisPlanPinningTests {
     let database = try makeDatabase()
     let detail = try planDetail(
       database,
-      sql: """
+      query: """
         SELECT id FROM "transaction" WHERE payee = ?
         """,
       arguments: ["Coffee"])
@@ -92,7 +96,7 @@ struct AnalysisPlanPinningTests {
     let database = try makeDatabase()
     let detail = try planDetail(
       database,
-      sql: """
+      query: """
         SELECT id FROM "transaction" WHERE date >= ? ORDER BY date
         """,
       arguments: [Date()])
@@ -109,7 +113,7 @@ struct AnalysisPlanPinningTests {
     // ordered by date — outside the partial-index test's scope.
     let detail = try planDetail(
       database,
-      sql: """
+      query: """
         SELECT id FROM "transaction" WHERE recur_period IS NOT NULL
         """)
     #expect(detail.contains("transaction_scheduled"))
@@ -123,7 +127,7 @@ struct AnalysisPlanPinningTests {
     let database = try makeDatabase()
     let detail = try planDetail(
       database,
-      sql: """
+      query: """
         SELECT id FROM transaction_leg WHERE transaction_id = ?
         """,
       arguments: [UUID()])
@@ -136,7 +140,7 @@ struct AnalysisPlanPinningTests {
     let database = try makeDatabase()
     let detail = try planDetail(
       database,
-      sql: """
+      query: """
         SELECT id FROM transaction_leg WHERE account_id = ?
         """,
       arguments: [UUID()])
@@ -149,7 +153,7 @@ struct AnalysisPlanPinningTests {
     let database = try makeDatabase()
     let detail = try planDetail(
       database,
-      sql: """
+      query: """
         SELECT id FROM transaction_leg WHERE category_id = ?
         """,
       arguments: [UUID()])
@@ -162,7 +166,7 @@ struct AnalysisPlanPinningTests {
     let database = try makeDatabase()
     let detail = try planDetail(
       database,
-      sql: """
+      query: """
         SELECT id FROM transaction_leg WHERE earmark_id = ?
         """,
       arguments: [UUID()])
@@ -177,7 +181,7 @@ struct AnalysisPlanPinningTests {
     let database = try makeDatabase()
     let detail = try planDetail(
       database,
-      sql: """
+      query: """
         SELECT id FROM investment_value WHERE account_id = ? ORDER BY date DESC LIMIT 50
         """,
       arguments: [UUID()])
@@ -196,7 +200,7 @@ struct AnalysisPlanPinningTests {
     let database = try makeDatabase()
     let detail = try planDetail(
       database,
-      sql: """
+      query: """
         SELECT id FROM earmark_budget_item WHERE earmark_id = ?
         """,
       arguments: [UUID()])
@@ -209,7 +213,7 @@ struct AnalysisPlanPinningTests {
     let database = try makeDatabase()
     let detail = try planDetail(
       database,
-      sql: """
+      query: """
         SELECT id FROM earmark_budget_item WHERE category_id = ?
         """,
       arguments: [UUID()])
@@ -224,7 +228,7 @@ struct AnalysisPlanPinningTests {
     let database = try makeDatabase()
     let detail = try planDetail(
       database,
-      sql: """
+      query: """
         SELECT id FROM category WHERE parent_id = ?
         """,
       arguments: [UUID()])
@@ -239,7 +243,7 @@ struct AnalysisPlanPinningTests {
     let database = try makeDatabase()
     let detail = try planDetail(
       database,
-      sql: """
+      query: """
         SELECT id FROM account ORDER BY position
         """)
     #expect(detail.contains("account_by_position"))
@@ -253,11 +257,31 @@ struct AnalysisPlanPinningTests {
     let database = try makeDatabase()
     let detail = try planDetail(
       database,
-      sql: """
+      query: """
         SELECT id FROM earmark ORDER BY position
         """)
     #expect(detail.contains("earmark_by_position"))
     #expect(!detail.contains("USE TEMP B-TREE"))
+  }
+
+  // MARK: - Analysis full-table reads (intentional)
+
+  /// Pins the *current* shape of `GRDBAnalysisRepository.fetchTransactions`
+  /// — three full-table reads against `transaction`, `transaction_leg`,
+  /// and `instrument`. Not an index-driven query: the analysis path
+  /// materialises every row into Swift values today. The test exists so
+  /// the ratchet flips when TODO(#577) pushes the per-instrument
+  /// GROUP BY into SQL — the SCAN should disappear once the rewrite
+  /// lands. https://github.com/ajsutton/moolah-native/issues/577
+  @Test("analysis-path fetchTransactions is an intentional SCAN until #577 lands")
+  func analysisFetchTransactionsScansByDesign() throws {
+    let database = try makeDatabase()
+    // SQLite's EXPLAIN QUERY PLAN strips the table-name quotes when it
+    // emits the SCAN line, so the assertion drops them too.
+    let txnPlan = try planDetail(database, query: "SELECT * FROM \"transaction\"")
+    let legPlan = try planDetail(database, query: "SELECT * FROM transaction_leg")
+    #expect(txnPlan.contains("SCAN transaction"))
+    #expect(legPlan.contains("SCAN transaction_leg"))
   }
 
   // MARK: - Aggregations
@@ -270,7 +294,7 @@ struct AnalysisPlanPinningTests {
     // group `(account_id, instrument_id)` without scanning every leg.
     let detail = try planDetail(
       database,
-      sql: """
+      query: """
         SELECT leg.account_id     AS account_id,
                leg.instrument_id  AS instrument_id,
                SUM(leg.quantity)  AS quantity
@@ -299,7 +323,7 @@ struct AnalysisPlanPinningTests {
     // Mirrors `GRDBEarmarkRepository.computeEarmarkPositions`.
     let detail = try planDetail(
       database,
-      sql: """
+      query: """
         SELECT leg.earmark_id     AS earmark_id,
                leg.instrument_id  AS instrument_id,
                leg.type           AS type,

--- a/MoolahTests/Backends/GRDB/CoreFinancialGraphRollbackTests.swift
+++ b/MoolahTests/Backends/GRDB/CoreFinancialGraphRollbackTests.swift
@@ -163,7 +163,16 @@ struct CoreFinancialGraphRollbackTests {
     // deletes existing legs, then re-inserts the new ones — the trigger
     // fires on the first re-insert, and the header update plus the
     // pre-update leg deletes must roll back.
-    try await installFailingLegInsertTrigger(in: database, name: "fail_txn_update_leg")
+    try await database.write { database in
+      try database.execute(
+        sql: """
+          CREATE TRIGGER fail_txn_update_leg
+          BEFORE INSERT ON transaction_leg
+          BEGIN
+              SELECT RAISE(ABORT, 'forced failure for rollback test');
+          END;
+          """)
+    }
 
     let mutated = Transaction(
       id: txn.id, date: txn.date, payee: "Tea", notes: nil,
@@ -213,19 +222,52 @@ struct CoreFinancialGraphRollbackTests {
     }
   }
 
-  private func installFailingLegInsertTrigger(
-    in database: any DatabaseWriter, name: String
-  ) async throws {
+  // MARK: - GRDBAccountRepository.update(_:)
+
+  /// `update(_:)` does a fetch-then-update inside one `write` block;
+  /// after the fix, the post-update position read also runs inside the
+  /// same write transaction. A failure mid-update must leave the row
+  /// byte-equal to its pre-call state. The fixture forces the failure
+  /// via a BEFORE-UPDATE trigger so the row's first-pass UPDATE aborts
+  /// after the row was loaded for mutation.
+  @Test
+  func accountUpdateRollsBackOnFailure() async throws {
+    let database = try ProfileDatabase.openInMemory()
+    let repo = GRDBAccountRepository(database: database)
+
+    let id = UUID()
+    let original = Account(id: id, name: "Original", type: .bank, instrument: .AUD)
+    _ = try await repo.create(original, openingBalance: nil)
+
     try await database.write { database in
       try database.execute(
         sql: """
-          CREATE TRIGGER \(name)
-          BEFORE INSERT ON transaction_leg
+          CREATE TRIGGER fail_account_update
+          BEFORE UPDATE ON account
           BEGIN
               SELECT RAISE(ABORT, 'forced failure for rollback test');
           END;
           """)
     }
+
+    let mutated = Account(
+      id: id, name: "Renamed", type: .bank, instrument: .AUD,
+      position: 99, isHidden: true)
+    do {
+      _ = try await repo.update(mutated)
+      Issue.record("update should have thrown but did not")
+    } catch {
+      // Expected.
+    }
+
+    // Original row survived byte-equal to the pre-update snapshot.
+    let surviving = try await database.read { database in
+      try AccountRow.filter(AccountRow.Columns.id == id).fetchOne(database)
+    }
+    let row = try #require(surviving)
+    #expect(row.name == "Original")
+    #expect(row.position != 99)
+    #expect(row.isHidden == false)
   }
 
   // MARK: - GRDBEarmarkRepository.setBudget(...)

--- a/MoolahTests/Features/InvestmentStoreTestsMore.swift
+++ b/MoolahTests/Features/InvestmentStoreTestsMore.swift
@@ -101,7 +101,7 @@ struct InvestmentStoreTestsMore {
           quantity: dec("1000.00"), instrument: .defaultTestInstrument)),
     ]
 
-    let result = mergeChartData(values: values, balances: balances, period: .all)
+    let result = InvestmentChartData.merge(values: values, balances: balances, period: .all)
 
     #expect(result.count == 2)
     #expect(result[0].value == dec("1000.00"))
@@ -141,7 +141,7 @@ struct InvestmentStoreTestsMore {
           quantity: dec("1000.00"), instrument: .defaultTestInstrument)),
     ]
 
-    let result = mergeChartData(values: values, balances: balances, period: .all)
+    let result = InvestmentChartData.merge(values: values, balances: balances, period: .all)
 
     #expect(result.count == 3)
     // date1: both present
@@ -195,7 +195,7 @@ struct InvestmentStoreTestsMore {
 
     // Filter to 3 months: should include threeMonthsAgo and now,
     // plus pre-period anchors from sixMonthsAgo
-    let result = mergeChartData(values: values, balances: balances, period: .months(3))
+    let result = InvestmentChartData.merge(values: values, balances: balances, period: .months(3))
 
     // Should have data points, and the pre-period value should be anchored
     #expect(result.count >= 2)

--- a/MoolahTests/Features/InvestmentStoreTestsMoreExtra.swift
+++ b/MoolahTests/Features/InvestmentStoreTestsMoreExtra.swift
@@ -25,7 +25,7 @@ struct InvestmentStoreTestsMoreExtra {
 
   @Test("Empty data produces empty chart data points")
   func testChartDataPointsEmpty() {
-    let result = mergeChartData(values: [], balances: [], period: .all)
+    let result = InvestmentChartData.merge(values: [], balances: [], period: .all)
     #expect(result.isEmpty)
   }
 

--- a/MoolahTests/Support/TestBackend.swift
+++ b/MoolahTests/Support/TestBackend.swift
@@ -9,7 +9,12 @@ import GRDB
 /// failure here means the test harness is broken and the suite cannot
 /// proceed. Trapping keeps seed call sites free of `try!` without
 /// forcing every seed helper (and its hundreds of callers) to throw.
-private func writeOrTrap(
+///
+/// Marked `nonisolated` so the synchronous GRDB write doesn't block
+/// the main actor when callers happen to be `@MainActor`-isolated test
+/// methods. The GRDB queue mediates concurrent access internally; the
+/// only state this helper touches is the (`Sendable`) database handle.
+nonisolated private func writeOrTrap(
   _ database: any DatabaseWriter,
   file: StaticString = #file,
   line: UInt = #line,

--- a/MoolahTests/Sync/RepositoryHookRecordTypeTests.swift
+++ b/MoolahTests/Sync/RepositoryHookRecordTypeTests.swift
@@ -163,4 +163,171 @@ struct RepositoryHookRecordTypeTests {
     }
     #expect(budgetEmits.count == 1)
   }
+
+  // MARK: - CategoryRepository
+
+  /// Pins the multi-type fan-out from `delete(id:withReplacement:)`.
+  /// The cascade emits four record types in one call: the deleted
+  /// category itself, any orphaned children (CategoryRecord), any legs
+  /// whose category was reassigned to the replacement
+  /// (TransactionLegRecord), and any budget items that were either
+  /// rerouted or deleted (EarmarkBudgetItemRecord). A regression that
+  /// mis-tags any one of these emits would silently corrupt sync —
+  /// `nextRecordZoneChangeBatch` keys off the recordType string.
+  @Test(
+    "delete cascade tags Category, TransactionLeg, and EarmarkBudgetItem with their own record types"
+  )
+  func categoryDeleteEmitsCascadingRecordTypes() async throws {
+    let database = try ProfileDatabase.openInMemory()
+    let capture = HookCapture()
+    let categoryRepo = GRDBCategoryRepository(
+      database: database,
+      onRecordChanged: makeChangedHook(capture),
+      onRecordDeleted: makeDeletedHook(capture))
+
+    let ids = CategoryDeleteFixtureIds()
+    try await seedCategoryDeleteFixture(in: database, ids: ids)
+
+    try await categoryRepo.delete(id: ids.parentId, withReplacement: ids.replacementId)
+    try await drainHookHops()
+    let parentId = ids.parentId
+    let childId = ids.childId
+    let legId = ids.legId
+    let budgetItemId = ids.budgetItemId
+
+    // 1. The deleted category itself — exactly one CategoryRecord delete
+    //    keyed by parentId.
+    let categoryDeletes = capture.deleted.filter { $0.recordType == CategoryRow.recordType }
+    #expect(categoryDeletes.map(\.id) == [parentId])
+
+    // 2. Orphaned child — emitted as CategoryRecord *change* (parent_id
+    //    nulled), not delete.
+    let categoryChanges = capture.changed.filter { $0.recordType == CategoryRow.recordType }
+    #expect(categoryChanges.map(\.id) == [childId])
+
+    // 3. Reassigned leg — emitted as TransactionLegRecord change.
+    let legChanges = capture.changed.filter { $0.recordType == TransactionLegRow.recordType }
+    #expect(legChanges.map(\.id) == [legId])
+
+    // 4. Budget item whose category was rerouted to the replacement —
+    //    emitted as EarmarkBudgetItemRecord change (no duplicate exists,
+    //    so the row is updated rather than deleted).
+    let budgetChanges = capture.changed.filter {
+      $0.recordType == EarmarkBudgetItemRow.recordType
+    }
+    #expect(budgetChanges.map(\.id) == [budgetItemId])
+
+    // No EarmarkRecord emits — earmark itself wasn't touched.
+    let earmarkEmits = capture.changed.filter { $0.recordType == EarmarkRow.recordType }
+    #expect(earmarkEmits.isEmpty)
+  }
+
+  // MARK: - Category-delete fixture
+
+  /// IDs threaded through `seedCategoryDeleteFixture` so the test can
+  /// assert against them by name rather than by re-fetching.
+  private struct CategoryDeleteFixtureIds {
+    let parentId = UUID()
+    let childId = UUID()
+    let replacementId = UUID()
+    let accountId = UUID()
+    let earmarkId = UUID()
+    let legId = UUID()
+    let budgetItemId = UUID()
+    let txnId = UUID()
+  }
+
+  /// Seeds a fixture covering every record type the category-delete
+  /// cascade fans out to. Splits the writes across small per-topic
+  /// transactions to keep the closure body under SwiftLint's length
+  /// budget; correctness only requires that all rows are present
+  /// before the test drives `delete`, not that they share a write.
+  private func seedCategoryDeleteFixture(
+    in database: any DatabaseWriter, ids: CategoryDeleteFixtureIds
+  ) async throws {
+    try await seedCategories(in: database, ids: ids)
+    try await seedAccountAndEarmark(in: database, ids: ids)
+    try await seedBudgetAndTransaction(in: database, ids: ids)
+  }
+
+  private func seedCategories(
+    in database: any DatabaseWriter, ids: CategoryDeleteFixtureIds
+  ) async throws {
+    try await database.write { database in
+      try CategoryRow(domain: Moolah.Category(id: ids.parentId, name: "Parent"))
+        .insert(database)
+      try CategoryRow(
+        domain: Moolah.Category(id: ids.childId, name: "Child", parentId: ids.parentId)
+      ).insert(database)
+      try CategoryRow(domain: Moolah.Category(id: ids.replacementId, name: "Replacement"))
+        .insert(database)
+    }
+  }
+
+  private func seedAccountAndEarmark(
+    in database: any DatabaseWriter, ids: CategoryDeleteFixtureIds
+  ) async throws {
+    try await database.write { database in
+      try AccountRow(
+        domain: Account(id: ids.accountId, name: "Cash", type: .bank, instrument: .AUD)
+      ).insert(database)
+      try EarmarkRow(
+        domain: Earmark(id: ids.earmarkId, name: "Holiday", instrument: .AUD)
+      ).insert(database)
+    }
+  }
+
+  private func seedBudgetAndTransaction(
+    in database: any DatabaseWriter, ids: CategoryDeleteFixtureIds
+  ) async throws {
+    try await seedBudgetItem(in: database, ids: ids)
+    try await seedTransactionAndLeg(in: database, ids: ids)
+  }
+
+  private func seedBudgetItem(
+    in database: any DatabaseWriter, ids: CategoryDeleteFixtureIds
+  ) async throws {
+    try await database.write { database in
+      try EarmarkBudgetItemRow(
+        id: ids.budgetItemId,
+        recordName: EarmarkBudgetItemRow.recordName(for: ids.budgetItemId),
+        earmarkId: ids.earmarkId,
+        categoryId: ids.parentId,
+        amount: 1_000,
+        instrumentId: Instrument.AUD.id,
+        encodedSystemFields: nil
+      ).insert(database)
+    }
+  }
+
+  private func seedTransactionAndLeg(
+    in database: any DatabaseWriter, ids: CategoryDeleteFixtureIds
+  ) async throws {
+    let txn = TransactionRow(
+      id: ids.txnId,
+      recordName: TransactionRow.recordName(for: ids.txnId),
+      date: Date(), payee: "Train", notes: nil,
+      recurPeriod: nil, recurEvery: nil,
+      importOriginRawDescription: nil, importOriginBankReference: nil,
+      importOriginRawAmount: nil, importOriginRawBalance: nil,
+      importOriginImportedAt: nil, importOriginImportSessionId: nil,
+      importOriginSourceFilename: nil, importOriginParserIdentifier: nil,
+      encodedSystemFields: nil)
+    let leg = TransactionLegRow(
+      id: ids.legId,
+      recordName: TransactionLegRow.recordName(for: ids.legId),
+      transactionId: ids.txnId,
+      accountId: ids.accountId,
+      instrumentId: Instrument.AUD.id,
+      quantity: -100,
+      type: TransactionType.expense.rawValue,
+      categoryId: ids.parentId,
+      earmarkId: nil,
+      sortOrder: 0,
+      encodedSystemFields: nil)
+    try await database.write { database in
+      try txn.insert(database)
+      try leg.insert(database)
+    }
+  }
 }

--- a/Shared/ProfileContainerManager.swift
+++ b/Shared/ProfileContainerManager.swift
@@ -62,6 +62,15 @@ final class ProfileContainerManager {
   /// and the import path share writes; on-disk managers re-open the
   /// same `data.sqlite` either way but caching avoids redundant
   /// migrator runs.
+  ///
+  /// **Cache-fill safety.** This method is `@MainActor`-isolated, so
+  /// the check-then-store sequence below is atomic with respect to
+  /// other callers — Swift serialises every entry to `database(for:)`
+  /// through the main actor's executor. The `ProfileDatabase.open(at:)`
+  /// call may block briefly on disk I/O, but the next `database(for:)`
+  /// call cannot run until this one returns and the cache is populated.
+  /// If this type is ever made non-isolated, this routine needs an
+  /// explicit lock around the dictionary mutation.
   func database(for profileId: UUID) throws -> DatabaseQueue {
     if let existing = databases[profileId] {
       return existing


### PR DESCRIPTION
## Summary

Stacks on top of [#573](https://github.com/ajsutton/moolah-native/pull/573). Addresses every Critical / Important / Minor finding from the six reviewer agents (`code-review`, `concurrency-review`, `database-schema-review`, `database-code-review`, `sync-review`, `instrument-conversion-review`) and the plan-vs-implementation gap analysis run against the Slice 1 PR.

Findings whose fix requires architectural surgery — making `ProfileSession.init` async ([#575](https://github.com/ajsutton/moolah-native/issues/575)), the §3.4 SQL `GROUP BY` rewrite ([#577](https://github.com/ajsutton/moolah-native/issues/577)), enum-fallback handling ([#578](https://github.com/ajsutton/moolah-native/issues/578)), multi-instrument `computeDailyBalances` ([#579](https://github.com/ajsutton/moolah-native/issues/579)), conversion-test discipline ([#580](https://github.com/ajsutton/moolah-native/issues/580)), the `fetchByImportSession` accessor ([#581](https://github.com/ajsutton/moolah-native/issues/581)), and `WITHOUT ROWID` on the rate-cache meta tables ([#582](https://github.com/ajsutton/moolah-native/issues/582)) — are tracked as GitHub issues and referenced from the source as `TODO(#N)`. Each will land as its own follow-up PR.

## What changes here

### Critical

- `GRDBTransactionRepository.database` reverts from `private(set) var` to `let`. The previous shape invalidated the `@unchecked Sendable` justification.
- `AnalysisPlanPinningTests.planDetail` no longer interpolates the `EXPLAIN QUERY PLAN` prefix into the `sql:` argument; the prefix is concatenated into a local first, satisfying §4 of `DATABASE_CODE_GUIDE.md`. The shared trigger helper in `CoreFinancialGraphRollbackTests` (which also interpolated `\(name)` into a `CREATE TRIGGER`) is removed and the trigger SQL is inlined per-test.
- `RepositoryHookRecordTypeTests` gains a `categoryDeleteEmitsCascadingRecordTypes` test pinning the multi-type fan-out from `CategoryRepository.delete` (CategoryRecord delete + child change, TransactionLegRecord change for reassigned legs, EarmarkBudgetItemRecord change for rerouted budgets).

### Important

- `GRDBAccountRepository.update` combines the row mutation and post-update position read into one `database.write` so the returned `Account` reflects the same database state as the row mutation; eliminates the hook-fire-before-position-read race.
- `GRDBAnalysisRepository.fetchSharedData` runs as a single `database.read` snapshot for transactions / accounts / investment values. Three independent reads under WAL would race a concurrent writer.
- `CategoryBalancesQuery` lifts into its own file (`Backends/CloudKit/Repositories/CategoryBalancesQuery.swift`) so the GRDB and CloudKit copies can no longer drift.
- `InvestmentStore`'s file-scope chart helpers move into a `InvestmentChartData` caseless enum in its own file. The three-element tuple in `forwardFillChartData` is replaced with a named `PendingPoint` struct (`large_tuple`).
- `ProfileSession`'s fire-and-forget `Task` for the `InvestmentStore → AccountStore` bridge is now tracked in `crossStoreUpdateTasks` and cancelled in `cleanupSync` (per `CONCURRENCY_GUIDE.md` §8).
- Unused `zoneID` parameter dropped from `wireRepositorySync(coordinator:zoneID:)`.
- `CoreFinancialGraphRollbackTests` gains the missing rollback test for `GRDBAccountRepository.update`.
- `TestBackend.writeOrTrap` carries an explicit `nonisolated` annotation so the helper's intent is visible under Swift 6.2 default-MainActor isolation.

### Minor

- All slice / `plans/grdb-migration.md` references removed from production comments per the no-PR-history-in-comments rule.
- File-level `// swiftlint:disable multiline_arguments` directives carry a reason line (PR-introduced files plus pre-existing siblings touched by this PR's context).
- The three `*_meta` cache tables stay ROWID — `WITHOUT ROWID` collides with GRDB's `RETURNING \"rowid\"` in `PersistableRecord.upsert`. Tracked as `TODO(#582)`.
- `PRAGMA optimize` hourly-while-active tick deferred with `TODO(#576)`.
- `ProfileContainerManager.database(for:)` documents the `@MainActor`-as-cache-fill-lock invariant.
- `SyncCoordinator` and `ProfileDataSyncHandler` comments rewritten to explain *why* the GRDB dispatch lives at the boundary rather than *what* it does.
- `clearOperations()` in `ProfileDataSyncHandler+SystemFields.swift` reorders to match `deleteLocalData()` so a future maintainer can't get the two lists out of step.
- `Row` subscript typing tightened from `as? String` to `as String?` in the plan-pinning helper.
- `transaction_by_session` partial index has no read caller; tracked as `TODO(#581)` in the schema until either `fetchByImportSession` ships or the index is dropped.

## Tracking issues opened by this PR

- [#575](https://github.com/ajsutton/moolah-native/issues/575) — make `SwiftDataToGRDBMigrator` and `CloudKitDataImporter` async (off-MainActor GRDB writes)
- [#576](https://github.com/ajsutton/moolah-native/issues/576) — PRAGMA optimize hourly-while-active tick
- [#577](https://github.com/ajsutton/moolah-native/issues/577) — §3.4 SQL `GROUP BY` rewrite for `AnalysisRepository`
- [#578](https://github.com/ajsutton/moolah-native/issues/578) — handle unknown enum raw values explicitly in row mapping
- [#579](https://github.com/ajsutton/moolah-native/issues/579) — `computeDailyBalances` multi-instrument support
- [#580](https://github.com/ajsutton/moolah-native/issues/580) — prefer `DateBasedFixedConversionService` for date-sensitive tests
- [#581](https://github.com/ajsutton/moolah-native/issues/581) — `fetchByImportSession` accessor or drop the dead index
- [#582](https://github.com/ajsutton/moolah-native/issues/582) — `WITHOUT ROWID` on the rate-cache `*_meta` tables

## Test plan

- [x] `just format-check` clean (no `.swiftlint-baseline.yml` changes)
- [x] `just build-mac` green
- [x] `just test-mac` green: 1734 tests across 264 suites pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)