### PR TITLE
fix(grdb): rebuild rate-cache *_meta tables as WITHOUT ROWID

### DIFF
--- a/Backends/GRDB/ProfileSchema+RateCacheWithoutRowid.swift
+++ b/Backends/GRDB/ProfileSchema+RateCacheWithoutRowid.swift
@@ -1,0 +1,106 @@
+// Backends/GRDB/ProfileSchema+RateCacheWithoutRowid.swift
+
+import Foundation
+import GRDB
+
+// MARK: - v4 migration body
+//
+// Rebuilds the three rate-cache `*_meta` tables (created by `v1_initial`
+// with default ROWIDs) as `WITHOUT ROWID` per
+// `guides/DATABASE_SCHEMA_GUIDE.md` §3 — single-TEXT-PK lookup tables.
+//
+// `v1_initial` is shipped, so editing its body in place is forbidden by
+// §6. The data in the meta tables is derived (date-span summary of the
+// matching rate / price table); each row is rebuilt from a single
+// `MIN/MAX` aggregation and discarded if the source table is empty.
+//
+// Companion code change: rate-cache record types now use
+// `persistenceConflictPolicy = PersistenceConflictPolicy(insert: .replace)`
+// and writers call `record.insert(database)` instead of
+// `record.upsert(database)`. GRDB 7's `upsert` hard-codes
+// `RETURNING "rowid"` (see
+// `MutablePersistableRecord+Upsert.swift:upsertAndFetchWithoutCallbacks`)
+// which fails against rowid-less tables. Plain `insert` with
+// `INSERT OR REPLACE` does not emit `RETURNING` and the conflict
+// resolution semantics are equivalent for these single-PK tables (no
+// FKs reference them, no triggers fire on delete).
+
+extension ProfileSchema {
+  static func rebuildRateCacheMetaWithoutRowid(_ database: Database) throws {
+    try rebuildExchangeRateMeta(database)
+    try rebuildStockTickerMeta(database)
+    try rebuildCryptoTokenMeta(database)
+  }
+
+  private static func rebuildExchangeRateMeta(_ database: Database) throws {
+    try database.execute(
+      sql: """
+        DROP TABLE exchange_rate_meta;
+
+        CREATE TABLE exchange_rate_meta (
+            base TEXT PRIMARY KEY,
+            earliest_date TEXT NOT NULL,
+            latest_date TEXT NOT NULL
+        ) STRICT, WITHOUT ROWID;
+
+        INSERT INTO exchange_rate_meta (base, earliest_date, latest_date)
+        SELECT base, MIN(date), MAX(date)
+        FROM exchange_rate
+        GROUP BY base;
+        """)
+  }
+
+  private static func rebuildStockTickerMeta(_ database: Database) throws {
+    // `instrument_id` is not derivable from `stock_price` (price rows
+    // have no quote-instrument column). Carry it across via a temp
+    // table. If the meta table is empty, the temp join is a no-op and
+    // the rebuilt table is empty — next live cache write repopulates.
+    try database.execute(
+      sql: """
+        CREATE TEMP TABLE stock_ticker_meta_carry AS
+            SELECT ticker, instrument_id, earliest_date, latest_date
+            FROM stock_ticker_meta;
+
+        DROP TABLE stock_ticker_meta;
+
+        CREATE TABLE stock_ticker_meta (
+            ticker TEXT PRIMARY KEY,
+            instrument_id TEXT NOT NULL,
+            earliest_date TEXT NOT NULL,
+            latest_date TEXT NOT NULL
+        ) STRICT, WITHOUT ROWID;
+
+        INSERT INTO stock_ticker_meta (ticker, instrument_id, earliest_date, latest_date)
+        SELECT ticker, instrument_id, earliest_date, latest_date
+        FROM stock_ticker_meta_carry;
+
+        DROP TABLE stock_ticker_meta_carry;
+        """)
+  }
+
+  private static func rebuildCryptoTokenMeta(_ database: Database) throws {
+    // `symbol` is not derivable from `crypto_price`; carry across via
+    // temp table. Same shape as the stock ticker rebuild above.
+    try database.execute(
+      sql: """
+        CREATE TEMP TABLE crypto_token_meta_carry AS
+            SELECT token_id, symbol, earliest_date, latest_date
+            FROM crypto_token_meta;
+
+        DROP TABLE crypto_token_meta;
+
+        CREATE TABLE crypto_token_meta (
+            token_id TEXT PRIMARY KEY,
+            symbol TEXT NOT NULL,
+            earliest_date TEXT NOT NULL,
+            latest_date TEXT NOT NULL
+        ) STRICT, WITHOUT ROWID;
+
+        INSERT INTO crypto_token_meta (token_id, symbol, earliest_date, latest_date)
+        SELECT token_id, symbol, earliest_date, latest_date
+        FROM crypto_token_meta_carry;
+
+        DROP TABLE crypto_token_meta_carry;
+        """)
+  }
+}

--- a/Backends/GRDB/ProfileSchema+RateCaches.swift
+++ b/Backends/GRDB/ProfileSchema+RateCaches.swift
@@ -5,12 +5,14 @@ import GRDB
 
 // MARK: - v1 migration body
 //
-// TODO(#582): the three `*_meta` tables use a single TEXT primary key
-// and would benefit from `WITHOUT ROWID` per
-// `guides/DATABASE_SCHEMA_GUIDE.md` §3, but GRDB's `PersistableRecord`
-// upsert path emits `RETURNING "rowid"` which fails against
-// rowid-less tables. Resolve once the records can opt out.
-// https://github.com/ajsutton/moolah-native/issues/582
+// The three `*_meta` tables ship here as ROWID tables — the shape
+// originally chosen because GRDB 7's `PersistableRecord.upsert(_:)`
+// hard-codes `RETURNING "rowid"` and trips on `WITHOUT ROWID` tables.
+// `v4_rate_cache_without_rowid` rebuilds them as `WITHOUT ROWID`
+// (single-TEXT-PK lookup tables per
+// `guides/DATABASE_SCHEMA_GUIDE.md` §3) once the writers switched
+// away from `upsert` to `insert(onConflict: .replace)`. Editing this
+// body in place would violate §6 (frozen migrations).
 
 extension ProfileSchema {
   static func createInitialTables(_ database: Database) throws {

--- a/Backends/GRDB/ProfileSchema.swift
+++ b/Backends/GRDB/ProfileSchema.swift
@@ -14,6 +14,12 @@ import GRDB
 /// account, transaction, transaction_leg, category, earmark,
 /// earmark_budget_item, investment_value). See
 /// `ProfileSchema+CoreFinancialGraph.swift`.
+/// `v4_rate_cache_without_rowid` — rebuilds the three rate-cache
+/// `*_meta` tables as `WITHOUT ROWID` so they round-trip through
+/// `record.insert(database)` (with `persistenceConflictPolicy =
+/// .replace`) instead of `record.upsert(database)` — GRDB 7's
+/// `upsert` hard-codes `RETURNING "rowid"` which fails against
+/// rowid-less tables. See `ProfileSchema+RateCacheWithoutRowid.swift`.
 ///
 /// **Retention policy for the cache tables.** All six cache tables
 /// created by `v1_initial` (`exchange_rate`, `exchange_rate_meta`,
@@ -34,7 +40,7 @@ enum ProfileSchema {
   /// Bumped each time a migration is added. Surfaced for open-time
   /// integrity checks; not used by `DatabaseMigrator` (which keys on
   /// the stable string IDs of registered migrations).
-  static let version = 3
+  static let version = 4
 
   static var migrator: DatabaseMigrator {
     var migrator = DatabaseMigrator()
@@ -48,6 +54,8 @@ enum ProfileSchema {
       "v2_csv_import_and_rules", migrate: createCSVImportAndRulesTables)
     migrator.registerMigration(
       "v3_core_financial_graph", migrate: createCoreFinancialGraphTables)
+    migrator.registerMigration(
+      "v4_rate_cache_without_rowid", migrate: rebuildRateCacheMetaWithoutRowid)
 
     return migrator
   }

--- a/Backends/GRDB/Records/CryptoTokenMetaRecord.swift
+++ b/Backends/GRDB/Records/CryptoTokenMetaRecord.swift
@@ -11,6 +11,14 @@ import GRDB
 struct CryptoTokenMetaRecord {
   static let databaseTableName = "crypto_token_meta"
 
+  // `INSERT OR REPLACE` instead of GRDB's default `INSERT ... ON CONFLICT
+  // DO UPDATE`. The latter hard-codes `RETURNING "rowid"` (see
+  // GRDB 7's `MutablePersistableRecord+Upsert.swift`) which breaks
+  // against this table's `WITHOUT ROWID` shape. No FK references this
+  // table and no triggers fire on delete, so the delete-then-insert
+  // semantics of `.replace` are observably equivalent here.
+  static let persistenceConflictPolicy = PersistenceConflictPolicy(insert: .replace)
+
   enum Columns: String, ColumnExpression, CaseIterable {
     case tokenId = "token_id"
     case symbol

--- a/Backends/GRDB/Records/ExchangeRateMetaRecord.swift
+++ b/Backends/GRDB/Records/ExchangeRateMetaRecord.swift
@@ -11,6 +11,15 @@ import GRDB
 struct ExchangeRateMetaRecord {
   static let databaseTableName = "exchange_rate_meta"
 
+  // `INSERT OR REPLACE` instead of GRDB's default `INSERT ... ON CONFLICT
+  // DO UPDATE`. The latter goes through `upsert(_:)`, which hard-codes
+  // `RETURNING "rowid"` and breaks against the `WITHOUT ROWID` shape
+  // chosen for this table per `guides/DATABASE_SCHEMA_GUIDE.md` §3. No
+  // FK references this table and no triggers fire on delete, so the
+  // delete-then-insert semantics of `.replace` are observably equivalent
+  // to an in-place `DO UPDATE`.
+  static let persistenceConflictPolicy = PersistenceConflictPolicy(insert: .replace)
+
   enum Columns: String, ColumnExpression, CaseIterable {
     case base
     case earliestDate = "earliest_date"

--- a/Backends/GRDB/Records/StockTickerMetaRecord.swift
+++ b/Backends/GRDB/Records/StockTickerMetaRecord.swift
@@ -12,6 +12,14 @@ import GRDB
 struct StockTickerMetaRecord {
   static let databaseTableName = "stock_ticker_meta"
 
+  // `INSERT OR REPLACE` instead of GRDB's default `INSERT ... ON CONFLICT
+  // DO UPDATE`. The latter hard-codes `RETURNING "rowid"` (see
+  // GRDB 7's `MutablePersistableRecord+Upsert.swift`) which breaks
+  // against this table's `WITHOUT ROWID` shape. No FK references this
+  // table and no triggers fire on delete, so the delete-then-insert
+  // semantics of `.replace` are observably equivalent here.
+  static let persistenceConflictPolicy = PersistenceConflictPolicy(insert: .replace)
+
   enum Columns: String, ColumnExpression, CaseIterable {
     case ticker
     case instrumentId = "instrument_id"

--- a/MoolahTests/Backends/GRDB/RateCacheSchemaTests.swift
+++ b/MoolahTests/Backends/GRDB/RateCacheSchemaTests.swift
@@ -1,0 +1,46 @@
+// MoolahTests/Backends/GRDB/RateCacheSchemaTests.swift
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+/// Schema-introspection tests for the three rate-cache `*_meta` tables.
+///
+/// `guides/DATABASE_SCHEMA_GUIDE.md` §3 requires single-TEXT-PK lookup
+/// tables to be `WITHOUT ROWID` for the smaller storage footprint and
+/// faster point lookups. These tests pin the invariant so that a
+/// future migration can't silently regress to a rowid table (which
+/// would also reintroduce the `RETURNING "rowid"` upsert hazard
+/// described in #582).
+@Suite("Rate cache *_meta table schema")
+struct RateCacheSchemaTests {
+  @Test
+  func exchangeRateMetaIsWithoutRowid() async throws {
+    try await assertWithoutRowid(table: "exchange_rate_meta")
+  }
+
+  @Test
+  func stockTickerMetaIsWithoutRowid() async throws {
+    try await assertWithoutRowid(table: "stock_ticker_meta")
+  }
+
+  @Test
+  func cryptoTokenMetaIsWithoutRowid() async throws {
+    try await assertWithoutRowid(table: "crypto_token_meta")
+  }
+
+  private func assertWithoutRowid(table: String) async throws {
+    let database = try ProfileDatabase.openInMemory()
+    let createSQL = try await database.read { database in
+      try String.fetchOne(
+        database,
+        sql: "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = ?",
+        arguments: [table])
+    }
+    let sql = try #require(createSQL)
+    #expect(
+      sql.uppercased().contains("WITHOUT ROWID"),
+      "Expected \(table) to be WITHOUT ROWID; got: \(sql)")
+  }
+}

--- a/Shared/CryptoPriceService+Persistence.swift
+++ b/Shared/CryptoPriceService+Persistence.swift
@@ -47,8 +47,9 @@ extension CryptoPriceService {
   }
 
   /// Persists `caches[tokenId]` to SQLite. Replaces prior rows for this
-  /// token in a single transaction and upserts the meta row alongside so
-  /// the symbol is never out of sync with the prices.
+  /// token in a single transaction and writes the meta row via
+  /// `INSERT OR REPLACE` alongside so the symbol is never out of sync
+  /// with the prices.
   ///
   /// Multi-statement; covered by a rollback test in
   /// `CryptoPriceServiceTests.swift`.
@@ -79,7 +80,7 @@ extension CryptoPriceService {
         .filter(CryptoPriceRecord.Columns.tokenId == tokenId)
         .deleteAll(database)
       for record in records { try record.insert(database) }
-      try meta.upsert(database)
+      try meta.insert(database)
     }
   }
 }

--- a/Shared/ExchangeRateService+Persistence.swift
+++ b/Shared/ExchangeRateService+Persistence.swift
@@ -49,8 +49,9 @@ extension ExchangeRateService {
   }
 
   /// Persists `caches[base]` to SQLite. Replaces the prior rows for this
-  /// base in a single transaction (delete-and-rewrite) and upserts the meta
-  /// row alongside, so the meta is never out of sync with the rates.
+  /// base in a single transaction (delete-and-rewrite) and writes the meta
+  /// row via `INSERT OR REPLACE` alongside, so the meta is never out of
+  /// sync with the rates.
   ///
   /// Multi-statement; covered by a rollback test in
   /// `ExchangeRateServicePersistenceTests.swift`.
@@ -83,7 +84,7 @@ extension ExchangeRateService {
         .filter(ExchangeRateRecord.Columns.base == base)
         .deleteAll(database)
       for record in records { try record.insert(database) }
-      try meta.upsert(database)
+      try meta.insert(database)
     }
   }
 }

--- a/Shared/StockPriceService.swift
+++ b/Shared/StockPriceService.swift
@@ -271,8 +271,9 @@ actor StockPriceService {
   }
 
   /// Persists `caches[ticker]` to SQLite. Replaces prior rows for this
-  /// ticker in a single transaction and upserts the meta row alongside so
-  /// the price denomination is never out of sync with the prices.
+  /// ticker in a single transaction and writes the meta row via
+  /// `INSERT OR REPLACE` alongside so the price denomination is never out
+  /// of sync with the prices.
   ///
   /// Multi-statement; covered by a rollback test in
   /// `StockPriceServiceTests.swift`.
@@ -306,7 +307,7 @@ actor StockPriceService {
         .filter(StockPriceRecord.Columns.ticker == ticker)
         .deleteAll(database)
       for record in records { try record.insert(database) }
-      try meta.upsert(database)
+      try meta.insert(database)
     }
   }
 }


### PR DESCRIPTION
## Summary

- Adds migration `v4_rate_cache_without_rowid` that DROPs and recreates the three rate-cache `*_meta` tables (`exchange_rate_meta`, `stock_ticker_meta`, `crypto_token_meta`) as `STRICT, WITHOUT ROWID` per [DATABASE_SCHEMA_GUIDE.md §3](guides/DATABASE_SCHEMA_GUIDE.md). `v1_initial`'s body is unchanged (frozen per §6).
- Switches the three meta records to `persistenceConflictPolicy = PersistenceConflictPolicy(insert: .replace)` so writers use `meta.insert(database)` (no `RETURNING` clause) instead of `meta.upsert(database)` (which hard-codes `RETURNING "rowid"` in GRDB 7 — see `MutablePersistableRecord+Upsert.swift:upsertAndFetchWithoutCallbacks`). No FK references these tables and no triggers fire on delete, so `INSERT OR REPLACE` is semantically equivalent.
- `exchange_rate_meta` repopulates via `MIN/MAX(date) GROUP BY base` over `exchange_rate`. The other two carry non-derivable columns (`instrument_id`, `symbol`) across via a `TEMP TABLE` inside the same migration transaction.
- Adds plan-pinning tests in `MoolahTests/Backends/GRDB/RateCacheSchemaTests.swift` that introspect `sqlite_master.sql` for `WITHOUT ROWID` on all three meta tables.

## Test plan

- [x] `just format-check` clean
- [x] `just test-mac` green (1737 tests, +3 new schema tests)
- [x] Rate-cache rollback tests (`saveCacheRollsBackOnInsertFailure` × 3) still pass — `saveCache` remains a single transaction.
- [x] `database-schema-review` agent: no findings.
- [x] `database-code-review` agent: one Minor (stale "upsert" doc-comments) — fixed in the same commit.

Fixes #582

🤖 Generated with [Claude Code](https://claude.com/claude-code)