### PR TITLE
test(positionbook): use DateBasedFixedConversionService in date-sensitive test

### DIFF
--- a/MoolahTests/Shared/PositionBookTests.swift
+++ b/MoolahTests/Shared/PositionBookTests.swift
@@ -188,7 +188,12 @@ struct PositionBookTests {
         TransactionLeg(accountId: bankAccount2, instrument: usd, quantity: 50, type: .income)
       ]))
 
-    let conversion = FixedConversionService(rates: ["USD": 1.5])
+    // Date-aware: anchoring the rate at `date` ensures a regression where
+    // `dailyBalance(on:)` accidentally passed `Date()` instead of the
+    // requested snapshot date would surface as a missing rate (1:1
+    // fallback) and fail the assertion. Per
+    // `guides/INSTRUMENT_CONVERSION_GUIDE.md` §6.
+    let conversion = DateBasedFixedConversionService(rates: [date: ["USD": 1.5]])
 
     let result = try await book.dailyBalance(
       on: date,


### PR DESCRIPTION
## Summary

`PositionBook.dailyBalance(on:)` passes the requested snapshot date to the conversion service. The existing `multiInstrumentDailyBalanceConverts` test used `FixedConversionService`, which ignores the `on:` parameter, so a regression where `dailyBalance(on:)` accidentally passed `Date()` instead of the snapshot date would still pass the assertion.

Migrating this test to `DateBasedFixedConversionService` anchors the rate at the snapshot date — a wrong-date path falls through to the 1:1 fallback and the numeric expectation fails. Per [INSTRUMENT_CONVERSION_GUIDE.md §6](guides/INSTRUMENT_CONVERSION_GUIDE.md).

## Audit

The `instrument-conversion-review` agent audited all 60 test files using `FixedConversionService`. Result: this one file is the only date-sensitive case. Every other call site passes `Date()` in production (current-value reads — sidebar, account detail, available funds, running balances) where the date parameter is semantically irrelevant to the test's assertion. They are correctly left on `FixedConversionService`.

## Test plan

- [x] `just format-check` clean
- [x] `just test-mac` green (1734 tests)
- [x] `PositionBookTests` exercises the new code path

Fixes #580

🤖 Generated with [Claude Code](https://claude.com/claude-code)