### PR TITLE
refactor(grdb): async SwiftData→GRDB migrator + importer (off-MainActor writes)

### DIFF
--- a/App/ProfileSession+Database.swift
+++ b/App/ProfileSession+Database.swift
@@ -1,0 +1,73 @@
+import Foundation
+import GRDB
+
+// Filesystem layout helpers and the `DatabaseQueue` opener for a
+// profile session. Extracted from `ProfileSession.swift` so the main
+// file stays under SwiftLint's `file_length` threshold; every helper
+// here is `nonisolated static` and reaches none of the session's
+// private state.
+
+extension ProfileSession {
+  /// Per-profile directory under Application Support where CSV import staging
+  /// lives. Not part of the SwiftData store because staging is device-local
+  /// and doesn't sync.
+  nonisolated static func importStagingDirectory(for profileId: UUID) -> URL {
+    URL.moolahScopedApplicationSupport
+      .appendingPathComponent("Moolah", isDirectory: true)
+      .appendingPathComponent("csv-staging", isDirectory: true)
+      .appendingPathComponent(profileId.uuidString, isDirectory: true)
+  }
+
+  /// Per-profile directory containing `data.sqlite` (and its `-wal`/`-shm`
+  /// sidecars). Removed wholesale on profile delete by
+  /// `ProfileContainerManager.deleteStore(for:)`.
+  nonisolated static func profileDatabaseDirectory(for profileId: UUID) -> URL {
+    URL.moolahScopedApplicationSupport
+      .appendingPathComponent("Moolah", isDirectory: true)
+      .appendingPathComponent("profiles", isDirectory: true)
+      .appendingPathComponent(profileId.uuidString, isDirectory: true)
+  }
+
+  /// Opens the profile's `data.sqlite` GRDB queue, creating intermediate
+  /// directories as needed and applying the `ProfileSchema` migrator.
+  nonisolated static func openProfileDatabase(profileId: UUID) throws -> DatabaseQueue {
+    let url = profileDatabaseDirectory(for: profileId)
+      .appendingPathComponent("data.sqlite")
+    return try ProfileDatabase.open(at: url)
+  }
+
+  /// Resolves which `DatabaseQueue` the session should own. Order:
+  ///   1. Caller-provided `override` (tests, previews).
+  ///   2. The container manager's cached per-profile queue. Required so
+  ///      the import path and the session see the same in-memory queue
+  ///      (each `ProfileDatabase.openInMemory()` call returns a fresh
+  ///      queue otherwise) and so on-disk profiles don't run the
+  ///      migrator twice on the same file.
+  ///   3. Fallback: open the on-disk `data.sqlite` directly. Used by
+  ///      callers that pass `containerManager: nil` (a few legacy test
+  ///      paths).
+  static func resolveDatabase(
+    override: DatabaseQueue?,
+    profile: Profile,
+    containerManager: ProfileContainerManager?
+  ) throws -> DatabaseQueue {
+    if let override { return override }
+    if let containerManager {
+      return try containerManager.database(for: profile.id)
+    }
+    return try openProfileDatabase(profileId: profile.id)
+  }
+
+  /// Convenience constructor for `#Preview` blocks. Backs the session with
+  /// an in-memory GRDB queue so previews never touch disk. Uses an in-memory
+  /// `ProfileContainerManager` so the CloudKit backend can be constructed
+  /// without touching the network or the on-disk container store.
+  static func preview(
+    profile: Profile = Profile(label: "Preview")
+  ) throws -> ProfileSession {
+    try ProfileSession(
+      profile: profile,
+      containerManager: ProfileContainerManager.forTesting(),
+      database: ProfileDatabase.openInMemory())
+  }
+}

--- a/App/ProfileSession.swift
+++ b/App/ProfileSession.swift
@@ -89,13 +89,27 @@ final class ProfileSession: Identifiable {
   /// (per `guides/CONCURRENCY_GUIDE.md` §8).
   private var crossStoreUpdateTasks: [Task<Void, Never>] = []
 
-  /// Synchronous initialiser — opens the per-profile GRDB queue and runs
-  /// pending migrations on the calling thread. The migrator currently only
-  /// creates the rate-cache tables (microseconds for fresh databases, no
-  /// disk reads on subsequent opens once the migration is recorded), so
-  /// running on `@MainActor` is acceptable for now. Revisit if profile-DB
-  /// schemas grow large enough that `migrate(_:)` does meaningful work
-  /// each launch — see `guides/CONCURRENCY_GUIDE.md` §1.
+  /// Stashed reference to the container manager so `setUp()` can open the
+  /// per-profile SwiftData container and run the SwiftData → GRDB
+  /// migration after init returns. `nil` for tests / previews that pass
+  /// `containerManager: nil` (those have nothing to migrate from).
+  private let containerManagerForMigration: ProfileContainerManager?
+
+  /// Tracks the in-flight (or completed) `setUp()` call so callers can
+  /// `await session.setUp()` without re-running the migration. Set by
+  /// `setUp()` on its first invocation; subsequent calls return the
+  /// same task. `nil` until the first call. Tracked here (rather than
+  /// in `SessionManager`) so any caller with the session reference can
+  /// await migration completion.
+  private var setUpTask: Task<Void, any Error>?
+
+  /// Synchronous initialiser — opens the per-profile GRDB queue and
+  /// builds every store / service the session exposes. Does **not** run
+  /// the SwiftData → GRDB migration; that lives in `setUp()` so the
+  /// GRDB writes happen off `@MainActor` (issue #575). Callers must
+  /// invoke `try await session.setUp()` before any code path expects
+  /// the migrated rows to be visible — `SessionManager.session(for:)`
+  /// schedules this automatically when it creates the session.
   init(
     profile: Profile,
     containerManager: ProfileContainerManager? = nil,
@@ -103,14 +117,11 @@ final class ProfileSession: Identifiable {
     database: DatabaseQueue? = nil
   ) throws {
     self.profile = profile
+    self.containerManagerForMigration = containerManager
 
     let resolvedDatabase = try Self.resolveDatabase(
       override: database, profile: profile, containerManager: containerManager)
     self.database = resolvedDatabase
-    try Self.runSwiftDataToGRDBMigrationIfNeeded(
-      profileId: profile.id,
-      containerManager: containerManager,
-      database: resolvedDatabase)
 
     let services = Self.makeMarketDataServices(database: resolvedDatabase)
     self.exchangeRateService = services.exchangeRate
@@ -271,6 +282,8 @@ final class ProfileSession: Identifiable {
       task.cancel()
     }
     crossStoreUpdateTasks.removeAll()
+    setUpTask?.cancel()
+    setUpTask = nil
   }
 
   // MARK: - Folder watch
@@ -294,94 +307,56 @@ final class ProfileSession: Identifiable {
     await folderScanner.scanForNewFiles()
   }
 
-  /// Per-profile directory under Application Support where CSV import staging
-  /// lives. Not part of the SwiftData store because staging is device-local
-  /// and doesn't sync.
-  nonisolated static func importStagingDirectory(for profileId: UUID) -> URL {
-    URL.moolahScopedApplicationSupport
-      .appendingPathComponent("Moolah", isDirectory: true)
-      .appendingPathComponent("csv-staging", isDirectory: true)
-      .appendingPathComponent(profileId.uuidString, isDirectory: true)
-  }
-
-  /// Per-profile directory containing `data.sqlite` (and its `-wal`/`-shm`
-  /// sidecars). Removed wholesale on profile delete by
-  /// `ProfileContainerManager.deleteStore(for:)`.
-  nonisolated static func profileDatabaseDirectory(for profileId: UUID) -> URL {
-    URL.moolahScopedApplicationSupport
-      .appendingPathComponent("Moolah", isDirectory: true)
-      .appendingPathComponent("profiles", isDirectory: true)
-      .appendingPathComponent(profileId.uuidString, isDirectory: true)
-  }
-
-  /// Opens the profile's `data.sqlite` GRDB queue, creating intermediate
-  /// directories as needed and applying the `ProfileSchema` migrator.
-  nonisolated static func openProfileDatabase(profileId: UUID) throws -> DatabaseQueue {
-    let url = profileDatabaseDirectory(for: profileId)
-      .appendingPathComponent("data.sqlite")
-    return try ProfileDatabase.open(at: url)
-  }
-
   /// Drives the one-shot SwiftData → GRDB migration for the given
   /// profile's SwiftData container and GRDB queue. Skipped when no
   /// `containerManager` is supplied (tests / previews build a fresh
   /// in-memory GRDB queue and have nothing to migrate from).
   ///
-  /// Must run before `registerWithSyncCoordinator` so CKSyncEngine
-  /// reads from a fully populated `data.sqlite` on the first sync
-  /// session.
+  /// MUST run before stores read from `data.sqlite` so CKSyncEngine
+  /// and the GRDB repositories read a fully populated database on
+  /// first launch.
   ///
-  /// `@MainActor` is explicit (not inherited from the class) because
-  /// `SwiftDataToGRDBMigrator.migrateIfNeeded` is `@MainActor` (the
-  /// SwiftData fetch path requires it).
-  ///
-  /// TODO(#575): make this `async` and run the GRDB writes off
-  /// `@MainActor` so heavy first-launch migrations can't block the UI —
-  /// https://github.com/ajsutton/moolah-native/issues/575
-  @MainActor
+  /// `async throws` so each per-type migrator can hand off the heavy
+  /// GRDB upserts to GRDB's writer queue via `await database.write`
+  /// rather than holding `@MainActor` for the duration (issue #575).
+  /// The bounded SwiftData fetches stay on `@MainActor` because that's
+  /// where the SwiftData `mainContext` requires them.
   static func runSwiftDataToGRDBMigrationIfNeeded(
     profileId: UUID,
     containerManager: ProfileContainerManager?,
     database: DatabaseQueue
-  ) throws {
+  ) async throws {
     guard let containerManager else { return }
     let modelContainer = try containerManager.container(for: profileId)
-    try SwiftDataToGRDBMigrator().migrateIfNeeded(
+    try await SwiftDataToGRDBMigrator().migrateIfNeeded(
       modelContainer: modelContainer, database: database)
   }
 
-  /// Resolves which `DatabaseQueue` the session should own. Order:
-  ///   1. Caller-provided `override` (tests, previews).
-  ///   2. The container manager's cached per-profile queue. Required so
-  ///      the import path and the session see the same in-memory queue
-  ///      (each `ProfileDatabase.openInMemory()` call returns a fresh
-  ///      queue otherwise) and so on-disk profiles don't run the
-  ///      migrator twice on the same file.
-  ///   3. Fallback: open the on-disk `data.sqlite` directly. Used by
-  ///      callers that pass `containerManager: nil` (a few legacy test
-  ///      paths).
-  private static func resolveDatabase(
-    override: DatabaseQueue?,
-    profile: Profile,
-    containerManager: ProfileContainerManager?
-  ) throws -> DatabaseQueue {
-    if let override { return override }
-    if let containerManager {
-      return try containerManager.database(for: profile.id)
+  /// Runs the SwiftData → GRDB migration off `@MainActor` and reloads
+  /// the affected stores. Idempotent: subsequent calls return the same
+  /// task so callers can `await session.setUp()` from multiple sites
+  /// (UI test seed setup, `SessionManager.session(for:)`, etc.) without
+  /// re-running the migration.
+  ///
+  /// Throws whatever the migrator throws — the caller (typically
+  /// `SessionManager`) is responsible for surfacing the error to the
+  /// user. A failed setUp leaves the migration's `UserDefaults` flags
+  /// unset, so the next launch retries.
+  func setUp() async throws {
+    if let existing = setUpTask {
+      return try await existing.value
     }
-    return try openProfileDatabase(profileId: profile.id)
+    let profileId = profile.id
+    let containerManager = containerManagerForMigration
+    let database = database
+    let task = Task<Void, any Error> {
+      try await Self.runSwiftDataToGRDBMigrationIfNeeded(
+        profileId: profileId,
+        containerManager: containerManager,
+        database: database)
+    }
+    setUpTask = task
+    try await task.value
   }
 
-  /// Convenience constructor for `#Preview` blocks. Backs the session with
-  /// an in-memory GRDB queue so previews never touch disk. Uses an in-memory
-  /// `ProfileContainerManager` so the CloudKit backend can be constructed
-  /// without touching the network or the on-disk container store.
-  static func preview(
-    profile: Profile = Profile(label: "Preview")
-  ) throws -> ProfileSession {
-    try ProfileSession(
-      profile: profile,
-      containerManager: ProfileContainerManager.forTesting(),
-      database: ProfileDatabase.openInMemory())
-  }
 }

--- a/App/SessionManager.swift
+++ b/App/SessionManager.swift
@@ -33,6 +33,13 @@ final class SessionManager {
   /// migration error). On failure we crash with a descriptive message —
   /// the app cannot meaningfully run without per-profile storage and
   /// silent fallback would mask data loss.
+  ///
+  /// Synchronous so SwiftUI view bodies can call it directly. The
+  /// SwiftData → GRDB migration that used to run inside
+  /// `ProfileSession.init` now lives in `session.setUp()` (issue #575)
+  /// and is scheduled here as a background task so it runs off
+  /// `@MainActor`. Callers that need the migration to be observed (e.g.
+  /// tests) can `await session.setUp()` to wait for completion.
   func session(for profile: Profile) -> ProfileSession {
     if let existing = sessions[profile.id] { return existing }
     let session: ProfileSession
@@ -43,6 +50,7 @@ final class SessionManager {
       fatalError("Failed to open profile database for \(profile.id): \(error)")
     }
     sessions[profile.id] = session
+    Task { try? await session.setUp() }
     return session
   }
 
@@ -72,16 +80,21 @@ final class SessionManager {
   }
 
   /// Replaces the session for a profile with a fresh instance
-  /// (e.g. when the profile's server URL changes).
+  /// (e.g. when the profile's server URL changes). Schedules `setUp()`
+  /// on the new session so the migration runs off `@MainActor` (see
+  /// `session(for:)` for the same pattern).
   func rebuildSession(for profile: Profile) {
     if let oldSession = sessions[profile.id], let syncCoordinator {
       oldSession.cleanupSync(coordinator: syncCoordinator)
     }
+    let session: ProfileSession
     do {
-      sessions[profile.id] = try ProfileSession(
+      session = try ProfileSession(
         profile: profile, containerManager: containerManager, syncCoordinator: syncCoordinator)
     } catch {
       fatalError("Failed to rebuild profile database for \(profile.id): \(error)")
     }
+    sessions[profile.id] = session
+    Task { try? await session.setUp() }
   }
 }

--- a/Backends/CloudKit/CloudKitDataImporter.swift
+++ b/Backends/CloudKit/CloudKitDataImporter.swift
@@ -94,8 +94,11 @@ struct CloudKitDataImporter {
 
     // Mirror everything to GRDB so the runtime stores (which read
     // exclusively from `data.sqlite`) see the imported data. Order:
-    // parents before children to satisfy enforced FKs.
-    try writeGRDB(data: data)
+    // parents before children to satisfy enforced FKs. The async
+    // `database.write` overload runs the GRDB transaction on GRDB's
+    // own writer queue rather than blocking `@MainActor` for every
+    // imported row.
+    try await writeGRDB(data: data)
 
     logger.info(
       "Import complete: \(data.accounts.count) accounts, \(data.transactions.count) transactions, \(investmentValueCount) investment values"
@@ -191,12 +194,12 @@ struct CloudKitDataImporter {
   /// upserted up-front so accounts and legs that reference them by id
   /// can resolve their full domain `Instrument` on read.
   ///
-  /// TODO(#575): make `writeGRDB` `async` and call
-  /// `try await database.write { … }` so heavy imports don't block the
-  /// main thread —
-  /// https://github.com/ajsutton/moolah-native/issues/575
-  private func writeGRDB(data: ExportedData) throws {
-    try database.write { database in
+  /// `async throws` so the GRDB transaction runs on GRDB's writer
+  /// queue rather than holding `@MainActor` for the duration of the
+  /// import. The body is otherwise unchanged from the previous
+  /// synchronous version.
+  private func writeGRDB(data: ExportedData) async throws {
+    try await database.write { database in
       try Self.writeInstrumentsAndCategories(data: data, database: database)
       try Self.writeAccountsAndEarmarks(data: data, database: database)
       try Self.writeTransactions(data: data, database: database)
@@ -204,7 +207,7 @@ struct CloudKitDataImporter {
     }
   }
 
-  private static func writeInstrumentsAndCategories(
+  nonisolated private static func writeInstrumentsAndCategories(
     data: ExportedData, database: Database
   ) throws {
     for instrument in data.instruments {
@@ -215,7 +218,7 @@ struct CloudKitDataImporter {
     }
   }
 
-  private static func writeAccountsAndEarmarks(
+  nonisolated private static func writeAccountsAndEarmarks(
     data: ExportedData, database: Database
   ) throws {
     for account in data.accounts {
@@ -234,7 +237,7 @@ struct CloudKitDataImporter {
     }
   }
 
-  private static func writeTransactions(
+  nonisolated private static func writeTransactions(
     data: ExportedData, database: Database
   ) throws {
     for txn in data.transactions {
@@ -249,7 +252,7 @@ struct CloudKitDataImporter {
     }
   }
 
-  private static func writeInvestmentValues(
+  nonisolated private static func writeInvestmentValues(
     data: ExportedData, database: Database
   ) throws {
     for (accountId, values) in data.investmentValues {

--- a/Backends/GRDB/Migration/SwiftDataToGRDBMigrator+CoreFinancialGraph.swift
+++ b/Backends/GRDB/Migration/SwiftDataToGRDBMigrator+CoreFinancialGraph.swift
@@ -32,7 +32,7 @@ extension SwiftDataToGRDBMigrator {
     modelContainer: ModelContainer,
     database: any DatabaseWriter,
     defaults: UserDefaults
-  ) throws {
+  ) async throws {
     guard !defaults.bool(forKey: Self.instrumentsFlag) else { return }
     var committed = false
     var rowCount = 0
@@ -46,23 +46,14 @@ extension SwiftDataToGRDBMigrator {
           """)
       }
     }
-    let context = ModelContext(modelContainer)
-    let descriptor = FetchDescriptor<InstrumentRecord>()
-    let sourceRows: [InstrumentRecord]
-    do {
-      sourceRows = try context.fetch(descriptor)
-    } catch {
-      logger.error(
-        """
-        SwiftData fetch for InstrumentRecord failed during GRDB \
-        migration: \(error.localizedDescription, privacy: .public). \
-        Migration aborted; will retry next launch.
-        """)
-      throw error
-    }
-    let mappedRows = sourceRows.map(Self.mapInstrument(_:))
+    let mappedRows = try Self.fetchSwiftDataRows(
+      modelContainer: modelContainer,
+      recordTypeDescription: "InstrumentRecord",
+      type: InstrumentRecord.self,
+      mapper: Self.mapInstrument(_:),
+      logger: logger)
     if !mappedRows.isEmpty {
-      try database.write { database in
+      try await database.write { database in
         for row in mappedRows {
           try row.upsert(database)
         }
@@ -100,7 +91,7 @@ extension SwiftDataToGRDBMigrator {
     modelContainer: ModelContainer,
     database: any DatabaseWriter,
     defaults: UserDefaults
-  ) throws {
+  ) async throws {
     guard !defaults.bool(forKey: Self.categoriesFlag) else { return }
     var committed = false
     var rowCount = 0
@@ -114,27 +105,18 @@ extension SwiftDataToGRDBMigrator {
           """)
       }
     }
-    let context = ModelContext(modelContainer)
-    let descriptor = FetchDescriptor<CategoryRecord>()
-    let sourceRows: [CategoryRecord]
-    do {
-      sourceRows = try context.fetch(descriptor)
-    } catch {
-      logger.error(
-        """
-        SwiftData fetch for CategoryRecord failed during GRDB \
-        migration: \(error.localizedDescription, privacy: .public). \
-        Migration aborted; will retry next launch.
-        """)
-      throw error
-    }
+    let unsortedRows = try Self.fetchSwiftDataRows(
+      modelContainer: modelContainer,
+      recordTypeDescription: "CategoryRecord",
+      type: CategoryRecord.self,
+      mapper: Self.mapCategory(_:),
+      logger: logger)
     // Self-referential FK: a category's `parent_id` references another
     // category in the same table. Sort parents before children so the
     // child upsert has its parent already on disk under the FK pragma.
-    let mappedRows = Self.sortCategoriesParentFirst(
-      sourceRows.map(Self.mapCategory(_:)))
+    let mappedRows = Self.sortCategoriesParentFirst(unsortedRows)
     if !mappedRows.isEmpty {
-      try database.write { database in
+      try await database.write { database in
         for row in mappedRows {
           try row.upsert(database)
         }
@@ -199,7 +181,7 @@ extension SwiftDataToGRDBMigrator {
     modelContainer: ModelContainer,
     database: any DatabaseWriter,
     defaults: UserDefaults
-  ) throws {
+  ) async throws {
     guard !defaults.bool(forKey: Self.accountsFlag) else { return }
     var committed = false
     var rowCount = 0
@@ -213,23 +195,14 @@ extension SwiftDataToGRDBMigrator {
           """)
       }
     }
-    let context = ModelContext(modelContainer)
-    let descriptor = FetchDescriptor<AccountRecord>()
-    let sourceRows: [AccountRecord]
-    do {
-      sourceRows = try context.fetch(descriptor)
-    } catch {
-      logger.error(
-        """
-        SwiftData fetch for AccountRecord failed during GRDB \
-        migration: \(error.localizedDescription, privacy: .public). \
-        Migration aborted; will retry next launch.
-        """)
-      throw error
-    }
-    let mappedRows = sourceRows.map(Self.mapAccount(_:))
+    let mappedRows = try Self.fetchSwiftDataRows(
+      modelContainer: modelContainer,
+      recordTypeDescription: "AccountRecord",
+      type: AccountRecord.self,
+      mapper: Self.mapAccount(_:),
+      logger: logger)
     if !mappedRows.isEmpty {
-      try database.write { database in
+      try await database.write { database in
         for row in mappedRows {
           try row.upsert(database)
         }

--- a/Backends/GRDB/Migration/SwiftDataToGRDBMigrator+Earmarks.swift
+++ b/Backends/GRDB/Migration/SwiftDataToGRDBMigrator+Earmarks.swift
@@ -18,7 +18,7 @@ extension SwiftDataToGRDBMigrator {
     modelContainer: ModelContainer,
     database: any DatabaseWriter,
     defaults: UserDefaults
-  ) throws {
+  ) async throws {
     guard !defaults.bool(forKey: Self.earmarksFlag) else { return }
     var committed = false
     var rowCount = 0
@@ -32,23 +32,14 @@ extension SwiftDataToGRDBMigrator {
           """)
       }
     }
-    let context = ModelContext(modelContainer)
-    let descriptor = FetchDescriptor<EarmarkRecord>()
-    let sourceRows: [EarmarkRecord]
-    do {
-      sourceRows = try context.fetch(descriptor)
-    } catch {
-      logger.error(
-        """
-        SwiftData fetch for EarmarkRecord failed during GRDB \
-        migration: \(error.localizedDescription, privacy: .public). \
-        Migration aborted; will retry next launch.
-        """)
-      throw error
-    }
-    let mappedRows = sourceRows.map(Self.mapEarmark(_:))
+    let mappedRows = try Self.fetchSwiftDataRows(
+      modelContainer: modelContainer,
+      recordTypeDescription: "EarmarkRecord",
+      type: EarmarkRecord.self,
+      mapper: Self.mapEarmark(_:),
+      logger: logger)
     if !mappedRows.isEmpty {
-      try database.write { database in
+      try await database.write { database in
         for row in mappedRows {
           try row.upsert(database)
         }
@@ -83,7 +74,7 @@ extension SwiftDataToGRDBMigrator {
     modelContainer: ModelContainer,
     database: any DatabaseWriter,
     defaults: UserDefaults
-  ) throws {
+  ) async throws {
     guard !defaults.bool(forKey: Self.earmarkBudgetItemsFlag) else { return }
     var committed = false
     var rowCount = 0
@@ -97,23 +88,14 @@ extension SwiftDataToGRDBMigrator {
           """)
       }
     }
-    let context = ModelContext(modelContainer)
-    let descriptor = FetchDescriptor<EarmarkBudgetItemRecord>()
-    let sourceRows: [EarmarkBudgetItemRecord]
-    do {
-      sourceRows = try context.fetch(descriptor)
-    } catch {
-      logger.error(
-        """
-        SwiftData fetch for EarmarkBudgetItemRecord failed during GRDB \
-        migration: \(error.localizedDescription, privacy: .public). \
-        Migration aborted; will retry next launch.
-        """)
-      throw error
-    }
-    let mappedRows = sourceRows.map(Self.mapEarmarkBudgetItem(_:))
+    let mappedRows = try Self.fetchSwiftDataRows(
+      modelContainer: modelContainer,
+      recordTypeDescription: "EarmarkBudgetItemRecord",
+      type: EarmarkBudgetItemRecord.self,
+      mapper: Self.mapEarmarkBudgetItem(_:),
+      logger: logger)
     if !mappedRows.isEmpty {
-      try database.write { database in
+      try await database.write { database in
         for row in mappedRows {
           try row.upsert(database)
         }
@@ -142,7 +124,7 @@ extension SwiftDataToGRDBMigrator {
     modelContainer: ModelContainer,
     database: any DatabaseWriter,
     defaults: UserDefaults
-  ) throws {
+  ) async throws {
     guard !defaults.bool(forKey: Self.investmentValuesFlag) else { return }
     var committed = false
     var rowCount = 0
@@ -156,23 +138,14 @@ extension SwiftDataToGRDBMigrator {
           """)
       }
     }
-    let context = ModelContext(modelContainer)
-    let descriptor = FetchDescriptor<InvestmentValueRecord>()
-    let sourceRows: [InvestmentValueRecord]
-    do {
-      sourceRows = try context.fetch(descriptor)
-    } catch {
-      logger.error(
-        """
-        SwiftData fetch for InvestmentValueRecord failed during GRDB \
-        migration: \(error.localizedDescription, privacy: .public). \
-        Migration aborted; will retry next launch.
-        """)
-      throw error
-    }
-    let mappedRows = sourceRows.map(Self.mapInvestmentValue(_:))
+    let mappedRows = try Self.fetchSwiftDataRows(
+      modelContainer: modelContainer,
+      recordTypeDescription: "InvestmentValueRecord",
+      type: InvestmentValueRecord.self,
+      mapper: Self.mapInvestmentValue(_:),
+      logger: logger)
     if !mappedRows.isEmpty {
-      try database.write { database in
+      try await database.write { database in
         for row in mappedRows {
           try row.upsert(database)
         }

--- a/Backends/GRDB/Migration/SwiftDataToGRDBMigrator+Transactions.swift
+++ b/Backends/GRDB/Migration/SwiftDataToGRDBMigrator+Transactions.swift
@@ -18,7 +18,7 @@ extension SwiftDataToGRDBMigrator {
     modelContainer: ModelContainer,
     database: any DatabaseWriter,
     defaults: UserDefaults
-  ) throws {
+  ) async throws {
     guard !defaults.bool(forKey: Self.transactionsFlag) else { return }
     var committed = false
     var rowCount = 0
@@ -32,23 +32,14 @@ extension SwiftDataToGRDBMigrator {
           """)
       }
     }
-    let context = ModelContext(modelContainer)
-    let descriptor = FetchDescriptor<TransactionRecord>()
-    let sourceRows: [TransactionRecord]
-    do {
-      sourceRows = try context.fetch(descriptor)
-    } catch {
-      logger.error(
-        """
-        SwiftData fetch for TransactionRecord failed during GRDB \
-        migration: \(error.localizedDescription, privacy: .public). \
-        Migration aborted; will retry next launch.
-        """)
-      throw error
-    }
-    let mappedRows = sourceRows.map(Self.mapTransaction(_:))
+    let mappedRows = try Self.fetchSwiftDataRows(
+      modelContainer: modelContainer,
+      recordTypeDescription: "TransactionRecord",
+      type: TransactionRecord.self,
+      mapper: Self.mapTransaction(_:),
+      logger: logger)
     if !mappedRows.isEmpty {
-      try database.write { database in
+      try await database.write { database in
         for row in mappedRows {
           try row.upsert(database)
         }
@@ -89,7 +80,7 @@ extension SwiftDataToGRDBMigrator {
     modelContainer: ModelContainer,
     database: any DatabaseWriter,
     defaults: UserDefaults
-  ) throws {
+  ) async throws {
     guard !defaults.bool(forKey: Self.transactionLegsFlag) else { return }
     var committed = false
     var rowCount = 0
@@ -103,23 +94,14 @@ extension SwiftDataToGRDBMigrator {
           """)
       }
     }
-    let context = ModelContext(modelContainer)
-    let descriptor = FetchDescriptor<TransactionLegRecord>()
-    let sourceRows: [TransactionLegRecord]
-    do {
-      sourceRows = try context.fetch(descriptor)
-    } catch {
-      logger.error(
-        """
-        SwiftData fetch for TransactionLegRecord failed during GRDB \
-        migration: \(error.localizedDescription, privacy: .public). \
-        Migration aborted; will retry next launch.
-        """)
-      throw error
-    }
-    let mappedRows = sourceRows.map(Self.mapTransactionLeg(_:))
+    let mappedRows = try Self.fetchSwiftDataRows(
+      modelContainer: modelContainer,
+      recordTypeDescription: "TransactionLegRecord",
+      type: TransactionLegRecord.self,
+      mapper: Self.mapTransactionLeg(_:),
+      logger: logger)
     if !mappedRows.isEmpty {
-      try database.write { database in
+      try await database.write { database in
         for row in mappedRows {
           try row.upsert(database)
         }

--- a/Backends/GRDB/Migration/SwiftDataToGRDBMigrator.swift
+++ b/Backends/GRDB/Migration/SwiftDataToGRDBMigrator.swift
@@ -29,14 +29,16 @@ import SwiftData
 /// `SyncCoordinator.start()` so CKSyncEngine reads from a fully
 /// populated `data.sqlite` on the first launch.
 ///
-/// **Concurrency.** `@MainActor` is required because the SwiftData
-/// `ModelContext(modelContainer)` constructor and the resulting
-/// `context.fetch(...)` are `@MainActor`-isolated when the container is
-/// `mainContext`-bound. The GRDB writes themselves are queue-serialised
-/// and don't need main-actor isolation. If profiling ever shows this
-/// blocks for >16ms (one frame) on a p99 device, convert
-/// `migrateIfNeeded` to async and call with `await` from
-/// `ProfileSession.init` (per `guides/CONCURRENCY_GUIDE.md` §1).
+/// **Concurrency.** The struct is `@MainActor`-isolated because the
+/// SwiftData fetches need `@MainActor` (`ModelContext(modelContainer)`
+/// and `context.fetch(...)` are main-actor-isolated when the container
+/// is `mainContext`-bound). Every public method is `async throws` so
+/// the heavy GRDB write can be dispatched onto GRDB's own writer queue
+/// via `await database.write { ... }` — that hop moves the eight v3
+/// core-financial-graph upserts (which can push past one frame on
+/// heavy stores) off the main thread while the bounded SwiftData
+/// fetches stay on `@MainActor` (where the SwiftData container
+/// requires them). Issue #575 tracked this conversion.
 @MainActor
 struct SwiftDataToGRDBMigrator {
   /// `UserDefaults` key gating the CSV-import-profile copy. Once true,
@@ -97,37 +99,37 @@ struct SwiftDataToGRDBMigrator {
   /// callers pass nothing while tests supply an isolated suite (avoids
   /// the `CODE_GUIDE.md` §17 "no direct singleton access" rule).
   ///
-  /// Synchronous because the only places it runs (per-profile session
-  /// init and seed tests) need to block the calling thread until both
-  /// SwiftData reads and GRDB writes complete. Total work is bounded
-  /// by the row counts in the source SwiftData store. The eight v3
-  /// migrators run in parents-before-children order so foreign-key
-  /// references resolve as each transaction commits.
+  /// `async throws` because each per-type migrator awaits
+  /// `database.write { ... }` to push the GRDB transaction onto GRDB's
+  /// own writer queue (off-MainActor) instead of holding the calling
+  /// thread for the duration of the upsert. The bounded SwiftData
+  /// fetch stays on `@MainActor` (where the `mainContext`-bound
+  /// container requires it). Total work is bounded by the row counts
+  /// in the source SwiftData store. The eight v3 migrators run in
+  /// parents-before-children order so foreign-key references resolve
+  /// as each transaction commits.
   func migrateIfNeeded(
     modelContainer: ModelContainer,
     database: any DatabaseWriter,
     defaults: UserDefaults = .standard
-  ) throws {
+  ) async throws {
     let start = ContinuousClock.now
     defer {
       let elapsedMs = (ContinuousClock.now - start).inMilliseconds
-      // 16ms ≈ one frame at 60Hz. Sync migrator runs on @MainActor, so
-      // exceeding this budget means we're hanging the UI on a slow
-      // device. Log in release as well as debug so production
-      // diagnostics surface real-world durations on heavy users —
-      // tracked via the `os_log` warning channel (subsystem
-      // `com.moolah.app`, category `SwiftDataToGRDBMigrator`).
-      // Intentional signal-only check, not a hard precondition; the
-      // migration's correctness is independent of how long it takes.
-      // The v3 core-financial-graph migrators may push past 16ms on
-      // heavy stores (eight transactions × N rows each); the warning
-      // is signal-only and intentionally not bumped.
+      // 16ms ≈ one frame at 60Hz. The async migrator no longer pins
+      // the calling actor for the duration of the GRDB write, so this
+      // warning is now a wall-clock signal: if the elapsed time
+      // exceeds a frame and the caller was @MainActor, scrolling /
+      // animations on the main thread were still potentially impacted
+      // by the bounded SwiftData fetch. Logged in release as well as
+      // debug so production diagnostics surface real-world durations
+      // on heavy users.
       if elapsedMs > 16 {
         logger.warning(
           """
-          SwiftDataToGRDBMigrator.migrateIfNeeded took \(elapsedMs, privacy: .public)ms \
-          on @MainActor; convert to async if this reproduces on real hardware (see \
-          file header).
+          SwiftDataToGRDBMigrator.migrateIfNeeded took \(elapsedMs, privacy: .public)ms; \
+          GRDB writes ran off-actor but the bounded SwiftData fetches still hopped to \
+          @MainActor — investigate if this reproduces on real hardware.
           """)
       }
     }
@@ -135,28 +137,28 @@ struct SwiftDataToGRDBMigrator {
     // transaction's FK references resolve at commit. PRAGMA
     // foreign_keys = ON is in effect; an unresolved parent fails the
     // upsert loudly, which is the correct behaviour.
-    try migrateInstrumentsIfNeeded(
+    try await migrateInstrumentsIfNeeded(
       modelContainer: modelContainer, database: database, defaults: defaults)
-    try migrateCategoriesIfNeeded(
+    try await migrateCategoriesIfNeeded(
       modelContainer: modelContainer, database: database, defaults: defaults)
-    try migrateAccountsIfNeeded(
+    try await migrateAccountsIfNeeded(
       modelContainer: modelContainer, database: database, defaults: defaults)
-    try migrateEarmarksIfNeeded(
+    try await migrateEarmarksIfNeeded(
       modelContainer: modelContainer, database: database, defaults: defaults)
-    try migrateEarmarkBudgetItemsIfNeeded(
+    try await migrateEarmarkBudgetItemsIfNeeded(
       modelContainer: modelContainer, database: database, defaults: defaults)
-    try migrateInvestmentValuesIfNeeded(
+    try await migrateInvestmentValuesIfNeeded(
       modelContainer: modelContainer, database: database, defaults: defaults)
-    try migrateTransactionsIfNeeded(
+    try await migrateTransactionsIfNeeded(
       modelContainer: modelContainer, database: database, defaults: defaults)
-    try migrateTransactionLegsIfNeeded(
+    try await migrateTransactionLegsIfNeeded(
       modelContainer: modelContainer, database: database, defaults: defaults)
     // CSV imports reference accounts; run them after the core graph
     // so any FK validation at the application layer sees a populated
     // `account` table.
-    try migrateCSVImportProfilesIfNeeded(
+    try await migrateCSVImportProfilesIfNeeded(
       modelContainer: modelContainer, database: database, defaults: defaults)
-    try migrateImportRulesIfNeeded(
+    try await migrateImportRulesIfNeeded(
       modelContainer: modelContainer, database: database, defaults: defaults)
   }
 
@@ -166,7 +168,7 @@ struct SwiftDataToGRDBMigrator {
     modelContainer: ModelContainer,
     database: any DatabaseWriter,
     defaults: UserDefaults
-  ) throws {
+  ) async throws {
     guard !defaults.bool(forKey: Self.csvImportProfilesFlag) else { return }
     // The `committed` flag is flipped after the write transaction commits
     // and consulted by the `defer` block — making the
@@ -186,23 +188,14 @@ struct SwiftDataToGRDBMigrator {
           """)
       }
     }
-    let context = ModelContext(modelContainer)
-    let descriptor = FetchDescriptor<CSVImportProfileRecord>()
-    let sourceRows: [CSVImportProfileRecord]
-    do {
-      sourceRows = try context.fetch(descriptor)
-    } catch {
-      logger.error(
-        """
-        SwiftData fetch for CSVImportProfileRecord failed during GRDB \
-        migration: \(error.localizedDescription, privacy: .public). \
-        Migration aborted; will retry next launch.
-        """)
-      throw error
-    }
-    let mappedRows = sourceRows.map(Self.mapCSVProfile(_:))
+    let mappedRows = try Self.fetchSwiftDataRows(
+      modelContainer: modelContainer,
+      recordTypeDescription: "CSVImportProfileRecord",
+      type: CSVImportProfileRecord.self,
+      mapper: Self.mapCSVProfile(_:),
+      logger: logger)
     if !mappedRows.isEmpty {
-      try database.write { database in
+      try await database.write { database in
         for row in mappedRows {
           try row.upsert(database)
         }
@@ -237,7 +230,7 @@ struct SwiftDataToGRDBMigrator {
     modelContainer: ModelContainer,
     database: any DatabaseWriter,
     defaults: UserDefaults
-  ) throws {
+  ) async throws {
     guard !defaults.bool(forKey: Self.importRulesFlag) else { return }
     // See `migrateCSVImportProfilesIfNeeded` for why this uses a
     // `committed` defer flag and `upsert` (idempotent re-migration).
@@ -253,23 +246,14 @@ struct SwiftDataToGRDBMigrator {
           """)
       }
     }
-    let context = ModelContext(modelContainer)
-    let descriptor = FetchDescriptor<ImportRuleRecord>()
-    let sourceRows: [ImportRuleRecord]
-    do {
-      sourceRows = try context.fetch(descriptor)
-    } catch {
-      logger.error(
-        """
-        SwiftData fetch for ImportRuleRecord failed during GRDB \
-        migration: \(error.localizedDescription, privacy: .public). \
-        Migration aborted; will retry next launch.
-        """)
-      throw error
-    }
-    let mappedRows = sourceRows.map(Self.mapImportRule(_:))
+    let mappedRows = try Self.fetchSwiftDataRows(
+      modelContainer: modelContainer,
+      recordTypeDescription: "ImportRuleRecord",
+      type: ImportRuleRecord.self,
+      mapper: Self.mapImportRule(_:),
+      logger: logger)
     if !mappedRows.isEmpty {
-      try database.write { database in
+      try await database.write { database in
         for row in mappedRows {
           try row.upsert(database)
         }
@@ -294,5 +278,46 @@ struct SwiftDataToGRDBMigrator {
       actionsJSON: source.actionsJSON,
       accountScope: source.accountScope,
       encodedSystemFields: source.encodedSystemFields)
+  }
+
+  // MARK: - SwiftData fetch helper
+
+  /// Fetches every persisted instance of `Source` from `modelContainer`
+  /// and maps them into the GRDB row type `Mapped`. Stays on
+  /// `@MainActor` (inherited from the enclosing struct) because
+  /// `ModelContext(_:)` and `context.fetch(_:)` are
+  /// `@MainActor`-isolated when the container is the app's
+  /// `mainContext`. The returned array is `Sendable` (each element is a
+  /// `Sendable` GRDB row), so the calling `async` method can hand it
+  /// off to `await database.write { ... }` and that write runs
+  /// off-MainActor.
+  ///
+  /// Failures are logged at error level then re-thrown so per-type
+  /// migrators can record their own context-specific message and the
+  /// `defer { committed ? flag = true : () }` invariant continues to
+  /// hold (the flag is only set when the function exits via the
+  /// `committed = true` path).
+  static func fetchSwiftDataRows<Source: PersistentModel, Mapped: Sendable>(
+    modelContainer: ModelContainer,
+    recordTypeDescription: String,
+    type: Source.Type,
+    mapper: (Source) -> Mapped,
+    logger: Logger
+  ) throws -> [Mapped] {
+    let context = ModelContext(modelContainer)
+    let descriptor = FetchDescriptor<Source>()
+    let sourceRows: [Source]
+    do {
+      sourceRows = try context.fetch(descriptor)
+    } catch {
+      logger.error(
+        """
+        SwiftData fetch for \(recordTypeDescription, privacy: .public) failed during \
+        GRDB migration: \(error.localizedDescription, privacy: .public). Migration \
+        aborted; will retry next launch.
+        """)
+      throw error
+    }
+    return sourceRows.map(mapper)
   }
 }

--- a/MoolahTests/App/ProfileSessionTests.swift
+++ b/MoolahTests/App/ProfileSessionTests.swift
@@ -67,6 +67,29 @@ struct ProfileSessionTests {
     #expect(session.backend.conversionService is FullConversionService)
   }
 
+  // MARK: - setUp() — async SwiftData → GRDB migration entry point (#575)
+
+  /// `ProfileSession.init` no longer runs the SwiftData → GRDB
+  /// migration; that work moved into `setUp()` so the eight per-type
+  /// `database.write` calls dispatch to GRDB's writer queue rather than
+  /// blocking `@MainActor`. Calling `await session.setUp()` is
+  /// idempotent — multiple awaits coalesce on the same in-flight task,
+  /// which keeps view-side and caller-side awaits cheap and lets
+  /// `SessionManager.session(for:)` fire-and-forget the first call
+  /// without making the second slower.
+  @Test("setUp() is idempotent when called repeatedly")
+  func setUpIsIdempotent() async throws {
+    let containerManager = try ProfileContainerManager.forTesting()
+    let session = try ProfileSession(
+      profile: makeProfile(), containerManager: containerManager)
+    try await session.setUp()
+    try await session.setUp()
+    try await session.setUp()
+    // Reaching here without throwing is the success condition; the
+    // real check is the file-private guard in `setUp()` returning the
+    // existing task on subsequent calls rather than re-running.
+  }
+
   @Test("CloudKit profile exposes cryptoTokenStore on session")
   func cloudKitProfileExposesCryptoTokenStore() throws {
     let containerManager = try ProfileContainerManager.forTesting()

--- a/MoolahTests/Backends/GRDB/SwiftDataToGRDBMigratorCoreGraphTests.swift
+++ b/MoolahTests/Backends/GRDB/SwiftDataToGRDBMigratorCoreGraphTests.swift
@@ -52,7 +52,7 @@ struct SwiftDataToGRDBMigratorCoreGraphTests {
     try context.save()
 
     let defaults = makeIsolatedDefaults()
-    try SwiftDataToGRDBMigrator().migrateIfNeeded(
+    try await SwiftDataToGRDBMigrator().migrateIfNeeded(
       modelContainer: container, database: database, defaults: defaults)
     #expect(defaults.bool(forKey: SwiftDataToGRDBMigrator.instrumentsFlag))
 
@@ -78,9 +78,9 @@ struct SwiftDataToGRDBMigratorCoreGraphTests {
 
     let defaults = makeIsolatedDefaults()
     let migrator = SwiftDataToGRDBMigrator()
-    try migrator.migrateIfNeeded(
+    try await migrator.migrateIfNeeded(
       modelContainer: container, database: database, defaults: defaults)
-    try migrator.migrateIfNeeded(
+    try await migrator.migrateIfNeeded(
       modelContainer: container, database: database, defaults: defaults)
 
     let count = try await database.read { database in
@@ -105,7 +105,7 @@ struct SwiftDataToGRDBMigratorCoreGraphTests {
     try context.save()
 
     let defaults = makeIsolatedDefaults()
-    try SwiftDataToGRDBMigrator().migrateIfNeeded(
+    try await SwiftDataToGRDBMigrator().migrateIfNeeded(
       modelContainer: container, database: database, defaults: defaults)
     #expect(defaults.bool(forKey: SwiftDataToGRDBMigrator.categoriesFlag))
 
@@ -137,7 +137,7 @@ struct SwiftDataToGRDBMigratorCoreGraphTests {
     try context.save()
 
     let defaults = makeIsolatedDefaults()
-    try SwiftDataToGRDBMigrator().migrateIfNeeded(
+    try await SwiftDataToGRDBMigrator().migrateIfNeeded(
       modelContainer: container, database: database, defaults: defaults)
     #expect(defaults.bool(forKey: SwiftDataToGRDBMigrator.accountsFlag))
 
@@ -167,7 +167,7 @@ struct SwiftDataToGRDBMigratorCoreGraphTests {
     try context.save()
 
     let defaults = makeIsolatedDefaults()
-    try SwiftDataToGRDBMigrator().migrateIfNeeded(
+    try await SwiftDataToGRDBMigrator().migrateIfNeeded(
       modelContainer: container, database: database, defaults: defaults)
     #expect(defaults.bool(forKey: SwiftDataToGRDBMigrator.earmarksFlag))
 
@@ -199,7 +199,7 @@ struct SwiftDataToGRDBMigratorCoreGraphTests {
     try context.save()
 
     let defaults = makeIsolatedDefaults()
-    try SwiftDataToGRDBMigrator().migrateIfNeeded(
+    try await SwiftDataToGRDBMigrator().migrateIfNeeded(
       modelContainer: container, database: database, defaults: defaults)
     #expect(defaults.bool(forKey: SwiftDataToGRDBMigrator.earmarkBudgetItemsFlag))
 
@@ -232,7 +232,7 @@ struct SwiftDataToGRDBMigratorCoreGraphTests {
     try context.save()
 
     let defaults = makeIsolatedDefaults()
-    try SwiftDataToGRDBMigrator().migrateIfNeeded(
+    try await SwiftDataToGRDBMigrator().migrateIfNeeded(
       modelContainer: container, database: database, defaults: defaults)
     #expect(defaults.bool(forKey: SwiftDataToGRDBMigrator.investmentValuesFlag))
 
@@ -267,7 +267,7 @@ struct SwiftDataToGRDBMigratorCoreGraphTests {
     try context.save()
 
     let defaults = makeIsolatedDefaults()
-    try SwiftDataToGRDBMigrator().migrateIfNeeded(
+    try await SwiftDataToGRDBMigrator().migrateIfNeeded(
       modelContainer: container, database: database, defaults: defaults)
     #expect(defaults.bool(forKey: SwiftDataToGRDBMigrator.transactionsFlag))
     #expect(defaults.bool(forKey: SwiftDataToGRDBMigrator.transactionLegsFlag))

--- a/MoolahTests/Backends/GRDB/SwiftDataToGRDBMigratorCrossFKTests.swift
+++ b/MoolahTests/Backends/GRDB/SwiftDataToGRDBMigratorCrossFKTests.swift
@@ -106,7 +106,7 @@ struct SwiftDataToGRDBMigratorCrossFKTests {
     try Self.seedCrossFKSwiftDataGraph(context: context, ids: ids)
 
     let defaults = makeIsolatedDefaults()
-    try SwiftDataToGRDBMigrator().migrateIfNeeded(
+    try await SwiftDataToGRDBMigrator().migrateIfNeeded(
       modelContainer: container, database: database, defaults: defaults)
 
     // Every flag should be set; every FK-bearing row should resolve its

--- a/MoolahTests/Backends/GRDB/SwiftDataToGRDBMigratorTests.swift
+++ b/MoolahTests/Backends/GRDB/SwiftDataToGRDBMigratorTests.swift
@@ -56,7 +56,7 @@ struct SwiftDataToGRDBMigratorTests {
 
     let defaults = makeIsolatedDefaults()
     let migrator = SwiftDataToGRDBMigrator()
-    try migrator.migrateIfNeeded(
+    try await migrator.migrateIfNeeded(
       modelContainer: container, database: database, defaults: defaults)
 
     #expect(defaults.bool(forKey: SwiftDataToGRDBMigrator.csvImportProfilesFlag))
@@ -93,7 +93,7 @@ struct SwiftDataToGRDBMigratorTests {
 
     let defaults = makeIsolatedDefaults()
     let migrator = SwiftDataToGRDBMigrator()
-    try migrator.migrateIfNeeded(
+    try await migrator.migrateIfNeeded(
       modelContainer: container, database: database, defaults: defaults)
 
     // Add a row to SwiftData after the flag is set: a true no-op should
@@ -106,7 +106,7 @@ struct SwiftDataToGRDBMigratorTests {
     context.insert(extra)
     try context.save()
 
-    try migrator.migrateIfNeeded(
+    try await migrator.migrateIfNeeded(
       modelContainer: container, database: database, defaults: defaults)
 
     let count = try await database.read { database in
@@ -144,7 +144,7 @@ struct SwiftDataToGRDBMigratorTests {
 
     let defaults = makeIsolatedDefaults()
     let migrator = SwiftDataToGRDBMigrator()
-    try migrator.migrateIfNeeded(
+    try await migrator.migrateIfNeeded(
       modelContainer: container, database: database, defaults: defaults)
 
     #expect(defaults.bool(forKey: SwiftDataToGRDBMigrator.importRulesFlag))
@@ -172,7 +172,7 @@ struct SwiftDataToGRDBMigratorTests {
     let database = try ProfileDatabase.openInMemory()
     let defaults = makeIsolatedDefaults()
     let migrator = SwiftDataToGRDBMigrator()
-    try migrator.migrateIfNeeded(
+    try await migrator.migrateIfNeeded(
       modelContainer: container, database: database, defaults: defaults)
 
     let csvCount = try await database.read { database in
@@ -221,8 +221,8 @@ struct SwiftDataToGRDBMigratorTests {
 
     let defaults = makeIsolatedDefaults()
     let migrator = SwiftDataToGRDBMigrator()
-    #expect(throws: (any Error).self) {
-      try migrator.migrateIfNeeded(
+    await #expect(throws: (any Error).self) {
+      try await migrator.migrateIfNeeded(
         modelContainer: container, database: database, defaults: defaults)
     }
     #expect(
@@ -258,8 +258,8 @@ struct SwiftDataToGRDBMigratorTests {
 
     let defaults = makeIsolatedDefaults()
     let migrator = SwiftDataToGRDBMigrator()
-    #expect(throws: (any Error).self) {
-      try migrator.migrateIfNeeded(
+    await #expect(throws: (any Error).self) {
+      try await migrator.migrateIfNeeded(
         modelContainer: container, database: database, defaults: defaults)
     }
     // CSV step succeeded (no CSV source rows); flag set is allowed.

--- a/MoolahTests/Export/ExportCoordinatorImportNewProfileTests.swift
+++ b/MoolahTests/Export/ExportCoordinatorImportNewProfileTests.swift
@@ -103,7 +103,7 @@ struct ExportCoordinatorImportNewProfileTests {
     let freshDatabase = try ProfileDatabase.openInMemory()
     let migratorDefaults = try #require(
       UserDefaults(suiteName: "export-import-test-\(UUID().uuidString)"))
-    try SwiftDataToGRDBMigrator().migrateIfNeeded(
+    try await SwiftDataToGRDBMigrator().migrateIfNeeded(
       modelContainer: container, database: freshDatabase, defaults: migratorDefaults)
     let freshBackend = CloudKitBackend(
       database: freshDatabase,

--- a/MoolahTests/Export/ExportImportIntegrationTests.swift
+++ b/MoolahTests/Export/ExportImportIntegrationTests.swift
@@ -74,7 +74,7 @@ struct ExportImportIntegrationTests {
   /// and returns a backend that reads through the production code path.
   private func makeCloudBackend(
     container: ModelContainer, label: String = "Test Profile"
-  ) throws -> CloudKitBackend {
+  ) async throws -> CloudKitBackend {
     let database = try ProfileDatabase.openInMemory()
     let suiteName = "export-import-test-\(UUID().uuidString)"
     guard let defaults = UserDefaults(suiteName: suiteName) else {
@@ -83,7 +83,7 @@ struct ExportImportIntegrationTests {
         code: -1,
         userInfo: [NSLocalizedDescriptionKey: "could not allocate UserDefaults suite"])
     }
-    try SwiftDataToGRDBMigrator().migrateIfNeeded(
+    try await SwiftDataToGRDBMigrator().migrateIfNeeded(
       modelContainer: container, database: database, defaults: defaults)
     return CloudKitBackend(
       database: database,
@@ -170,7 +170,7 @@ struct ExportImportIntegrationTests {
     #expect(result.budgetItemCount == 1)
 
     // Verify data is readable through CloudKit repositories
-    let cloudBackend = try makeCloudBackend(container: freshContainer)
+    let cloudBackend = try await makeCloudBackend(container: freshContainer)
 
     let accounts = try await cloudBackend.accounts.fetchAll()
     #expect(accounts.count == 1)

--- a/MoolahTests/Export/ExportImportIntegrationTests4.swift
+++ b/MoolahTests/Export/ExportImportIntegrationTests4.swift
@@ -57,7 +57,7 @@ struct ExportImportIntegrationTests4 {
     let freshDatabase = try ProfileDatabase.openInMemory()
     let migratorDefaults = try #require(
       UserDefaults(suiteName: "export-import-test-\(UUID().uuidString)"))
-    try SwiftDataToGRDBMigrator().migrateIfNeeded(
+    try await SwiftDataToGRDBMigrator().migrateIfNeeded(
       modelContainer: freshContainer, database: freshDatabase, defaults: migratorDefaults)
     let freshBackend = CloudKitBackend(
       database: freshDatabase,


### PR DESCRIPTION
## Summary

- Converts `SwiftDataToGRDBMigrator.migrateIfNeeded` (and the eight per-record-type sub-migrators) plus `CloudKitDataImporter.writeGRDB(data:)` to `async throws`, so the GRDB transactions dispatch onto GRDB's writer queue via `try await database.write { ... }` rather than blocking `@MainActor` for every upsert. This was flagged by the concurrency reviewer on PR #573 and explicitly authorised as a sibling PR.
- The migrator stays `@MainActor`-isolated (the SwiftData fetch requires it); only the heavy GRDB write moves off-actor. The bounded SwiftData fetch still runs on the main thread.
- `ProfileSession.init` no longer runs the migration (it can't, since the migrator is now async). A new `setUp() async throws` method owns that work and is scheduled by `SessionManager.session(for:)` on every fresh session — keeping the view-side `session(for:)` API synchronous for SwiftUI body calls. `setUp()` is idempotent and the task is cancelled in `cleanupSync` so it never outlives the session.
- File hygiene: filesystem helpers move into `ProfileSession+Database.swift` to keep `ProfileSession.swift` under the SwiftLint `file_length` threshold without bumping the baseline.

## Test plan

- [x] `just format-check` clean (no `.swiftlint-baseline.yml` changes)
- [x] `just test` green: 1732 tests across 264 suites on macOS, 1707 tests across 259 suites on iOS, all pass
- [x] New idempotency test for `ProfileSession.setUp()` in `MoolahTests/App/ProfileSessionTests.swift`
- [x] Existing migrator tests (`SwiftDataToGRDBMigratorTests`, `SwiftDataToGRDBMigratorCoreGraphTests`, `SwiftDataToGRDBMigratorCrossFKTests`) updated to `await migrator.migrateIfNeeded(...)` and pass
- [x] Export/import integration tests updated to `await makeCloudBackend(...)` and pass

Fixes #575

🤖 Generated with [Claude Code](https://claude.com/claude-code)