### PR TITLE
fix(benchmarks): repair benchmark target build under Swift 6

### DIFF
--- a/MoolahBenchmarks/ConversionBenchmarks.swift
+++ b/MoolahBenchmarks/ConversionBenchmarks.swift
@@ -68,11 +68,11 @@ final class ConversionBenchmarks: XCTestCase {
       .filter(txnIds.contains(TransactionLegRow.Columns.transactionId))
       .fetchAll(database)
     let legsByTxn = Dictionary(grouping: legRows, by: \.transactionId)
-    return rows.map { row in
-      let legs = (legsByTxn[row.id] ?? [])
+    return try rows.map { row in
+      let legs = try (legsByTxn[row.id] ?? [])
         .sorted(by: { $0.sortOrder < $1.sortOrder })
-        .map { $0.toDomain(instrument: Instrument.fiat(code: $0.instrumentId)) }
-      return row.toDomain(legs: legs)
+        .map { try $0.toDomain(instrument: Instrument.fiat(code: $0.instrumentId)) }
+      return try row.toDomain(legs: legs)
     }
   }
 }

--- a/MoolahBenchmarks/SyncDownloadBenchmarks.swift
+++ b/MoolahBenchmarks/SyncDownloadBenchmarks.swift
@@ -16,7 +16,10 @@ final class SyncDownloadBenchmarks: XCTestCase {
   nonisolated(unsafe) private static var _handler: ProfileDataSyncHandler?
   nonisolated(unsafe) private static var _zoneID: CKRecordZone.ID?
 
-  @MainActor
+  // `XCTestCase.setUp` is nonisolated, so this override cannot carry
+  // `@MainActor`. `ProfileDataSyncHandler.init` is the only call here
+  // that requires the main actor; XCTest runs class-level setUp on the
+  // main thread, so `MainActor.assumeIsolated` is safe.
   override static func setUp() {
     super.setUp()
     let result = expecting("benchmark TestBackend.create failed") {
@@ -43,9 +46,11 @@ final class SyncDownloadBenchmarks: XCTestCase {
       investmentValues: result.backend.grdbInvestments,
       transactions: result.backend.grdbTransactions,
       transactionLegs: result.backend.grdbTransactionLegs)
-    _handler = ProfileDataSyncHandler(
-      profileId: profileId, zoneID: zoneID, modelContainer: container,
-      grdbRepositories: bundle)
+    _handler = MainActor.assumeIsolated {
+      ProfileDataSyncHandler(
+        profileId: profileId, zoneID: zoneID, modelContainer: container,
+        grdbRepositories: bundle)
+    }
     _zoneID = zoneID
   }
 

--- a/MoolahBenchmarks/SyncUploadBenchmarks.swift
+++ b/MoolahBenchmarks/SyncUploadBenchmarks.swift
@@ -17,7 +17,10 @@ final class SyncUploadBenchmarks: XCTestCase {
   nonisolated(unsafe) private static var _handler: ProfileDataSyncHandler?
   nonisolated(unsafe) private static var _transactionUUIDs400: Set<UUID> = []
 
-  @MainActor
+  // `XCTestCase.setUp` is nonisolated, so this override cannot carry
+  // `@MainActor`. `ProfileDataSyncHandler.init` is the only call here
+  // that requires the main actor; XCTest runs class-level setUp on the
+  // main thread, so `MainActor.assumeIsolated` is safe.
   override static func setUp() {
     super.setUp()
     let result = expecting("benchmark TestBackend.create failed") {
@@ -44,9 +47,11 @@ final class SyncUploadBenchmarks: XCTestCase {
       investmentValues: result.backend.grdbInvestments,
       transactions: result.backend.grdbTransactions,
       transactionLegs: result.backend.grdbTransactionLegs)
-    _handler = ProfileDataSyncHandler(
-      profileId: profileId, zoneID: zoneID, modelContainer: container,
-      grdbRepositories: bundle)
+    _handler = MainActor.assumeIsolated {
+      ProfileDataSyncHandler(
+        profileId: profileId, zoneID: zoneID, modelContainer: container,
+        grdbRepositories: bundle)
+    }
     let ids = expecting("benchmark fetch existing ids failed") {
       try result.database.read { database in
         try TransactionRow

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -22,8 +22,10 @@ xcodebuild build-for-testing "${COMMON_ARGS[@]}" \
     -scheme Moolah-Benchmarks \
     -destination "platform=macOS"
 
+# `xcodebuild build-for-testing` writes artifacts under `Debug-Tests`,
+# not `Debug`. Use the test-build subdirectory.
 PRODUCTS="$REPO_ROOT/.DerivedData-bench/Build/Products"
-APP_BUNDLE="$PRODUCTS/Debug/Moolah.app"
+APP_BUNDLE="$PRODUCTS/Debug-Tests/Moolah.app"
 TEST_BUNDLE="$APP_BUNDLE/Contents/PlugIns/MoolahBenchmarks_macOS.xctest"
 
 # Copy debug dylib (same fix as test.sh)


### PR DESCRIPTION
## Summary

Three pre-existing breakages prevented `just benchmark` from running on this Xcode / Swift 6 toolchain. Surfaced while trying to capture pre/post benchmark numbers for #577.

- **`SyncDownloadBenchmarks` / `SyncUploadBenchmarks`** annotated `setUp` with `@MainActor` to call `ProfileDataSyncHandler.init` (main-actor isolated). Swift 6 rejects this because `XCTestCase.setUp` is `nonisolated` — overrides cannot tighten isolation. Replaced the override-level `@MainActor` with a `MainActor.assumeIsolated { ... }` wrapper around the handler init only. XCTest runs class-level setUp on the main thread, so the assumption holds.
- **`ConversionBenchmarks`** called `TransactionLegRow.toDomain(instrument:)` and `TransactionRow.toDomain(legs:)` without `try`. Both became `throws` in #587 (unknown enum raw values). Added `try` to the call chain.
- **`scripts/benchmark.sh`** looked for the test app under `Build/Products/Debug/`, but `xcodebuild build-for-testing` writes under `Debug-Tests/`. Repointed the path.

## Test plan

- [x] `just benchmark AnalysisBenchmarks/testFetchCategoryBalances` runs successfully — 0.170s mean clock time over 10 iterations
- [x] Build is warning-free (no SwiftLint baseline growth — pre-existing entries unchanged)
- [x] No production-code changes; only benchmark target + benchmark runner script

🤖 Generated with [Claude Code](https://claude.com/claude-code)