### PR TITLE
fix(stores): swallow CancellationError in load paths

### DIFF
--- a/Features/Investments/InvestmentStore.swift
+++ b/Features/Investments/InvestmentStore.swift
@@ -91,6 +91,8 @@ final class InvestmentStore {
       let raw = try await repository.fetchDailyBalances(accountId: accountId)
       dailyBalances = try await aggregateDailyBalances(
         raw: raw, hostCurrency: hostCurrency)
+    } catch is CancellationError {
+      return  // Cancelling a `.task` mid-load is not a failure.
     } catch {
       logger.error("Failed to load daily balances: \(error.localizedDescription)")
       self.error = error

--- a/Features/Transactions/TransactionStore.swift
+++ b/Features/Transactions/TransactionStore.swift
@@ -302,6 +302,15 @@ final class TransactionStore {
         recomputeMs: recomputeMs,
         count: page.transactions.count,
         totalLoaded: rawTransactions.count)
+    } catch is CancellationError {
+      // Cancelling a `.task` mid-fetch (e.g. a structural branch flip in
+      // `InvestmentAccountView` that unmounts the embedded transaction list
+      // while a load is in flight) is a normal lifecycle event, not a
+      // user-actionable error. Latching it as `self.error` would cause the
+      // alert observer to surface "Swift.CancellationError" on every
+      // subsequent mount; matches the pattern already used in `loadValues` /
+      // `loadPositions` on `InvestmentStore`.
+      return
     } catch {
       // Only surface the error for the live load — a superseded one's
       // failure isn't user-actionable because the newer load is running.

--- a/MoolahTests/Features/TransactionStoreLoadRaceTests.swift
+++ b/MoolahTests/Features/TransactionStoreLoadRaceTests.swift
@@ -161,6 +161,35 @@ struct TransactionStoreLoadRaceTests {
     #expect(!store.isLoading)
     #expect(!store.isLoaded(for: filter))
   }
+
+  /// A `load(filter:)` cancelled mid-fetch must not surface
+  /// `CancellationError` as a user-facing error. The InvestmentAccountView
+  /// flips `initialLoadComplete` on account switch, which unmounts the
+  /// embedded `TransactionListView` and cancels its in-flight load; the
+  /// surrounding alert observer treats any non-nil `store.error` as
+  /// presentable, so leaking the cancellation produced a spurious "Operation
+  /// failed: Swift.CancellationError" dialog on every subsequent visit to an
+  /// investment account.
+  @Test
+  func cancelledLoadDoesNotSurfaceCancellationError() async throws {
+    let repo = FirstFetchGatedTransactionRepository()
+    let store = TransactionStore(
+      repository: repo,
+      conversionService: FixedConversionService(),
+      targetInstrument: .defaultTestInstrument
+    )
+    let filter = TransactionFilter(accountId: accountId)
+
+    let task = Task { @MainActor in
+      await store.load(filter: filter)
+    }
+    await repo.waitUntilFetchStarted()
+    task.cancel()
+    await repo.releaseFetch()
+    await task.value
+
+    #expect(store.error == nil)
+  }
 }
 
 /// Minimal `TransactionRepository` that suspends inside `fetch` until the
@@ -184,6 +213,12 @@ actor FirstFetchGatedTransactionRepository: TransactionRepository {
   func fetch(filter: TransactionFilter, page: Int, pageSize: Int) async throws -> TransactionPage {
     await fetchStarted.open()
     await fetchRelease.wait()
+    // Mirror GRDB's `database.read` cooperative cancellation: when the
+    // surrounding task has been cancelled by the time the read can proceed,
+    // throw `CancellationError` rather than returning a stale page. This is
+    // what the production repository does and is the shape `fetchPage`'s
+    // catch block has to handle.
+    try Task.checkCancellation()
     return TransactionPage(
       transactions: [],
       targetInstrument: .defaultTestInstrument,


### PR DESCRIPTION
## Summary

Switching between investment accounts (e.g. Crypto → Trust Shares in the Large Test Profile) produced a sticky "Operation failed: The operation couldn't be completed. (Swift.CancellationError error 1.)" alert that re-appeared on every subsequent visit to any investment account.

### Root cause

`InvestmentAccountView` flips `initialLoadComplete` to `false` inside its `.task(id: account.id)` on each account switch — that unmounts the embedded `TransactionListView` while its own `.task(id: baseFilter)` still has a `transactionStore.load(...)` in flight. The unmount cancels the load, GRDB's `database.read { … }` throws `CancellationError`, and `TransactionStore.fetchPage`'s catch — which only had a generation guard — stored the cancellation as `self.error`. `TransactionListView`'s alert observer (`.task(id: transactionStore.error?.localizedDescription)`) then surfaced it as a user-facing dialog and never reset `showError` when the next `load()` cleared `error`. (The alert-observer reset is a separate, smaller fix that will follow in its own PR.)

This only repros for investment accounts because regular `TransactionListView` parents don't unmount the list mid-load.

### Fix

Filter `CancellationError` ahead of the generic catch in `TransactionStore.fetchPage`, matching the pattern already used by `InvestmentStore.loadValues` / `loadPositions`. Apply the same fix to `InvestmentStore.loadDailyBalances` for consistency. Cancellation is a normal SwiftUI lifecycle event, not a user-actionable error.

### Regression test

`TransactionStoreLoadRaceTests.cancelledLoadDoesNotSurfaceCancellationError` exercises a load() cancelled mid-fetch using the existing `FirstFetchGatedTransactionRepository` (gated fake hardened to throw `CancellationError` on cancellation, mirroring GRDB's behaviour) and asserts `store.error == nil`. Verified to fail before the fix and pass after.

## Test plan

- [x] `just format-check` clean
- [x] `just test TransactionStoreLoadRaceTests` (macOS) — all 8 cases pass
- [x] `just test` — full suite green (1776 iOS + 1801 macOS)
- [ ] Manual: switch Crypto ↔ Trust Shares in Large Test Profile — no error dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)