### PR TITLE
refactor(transactions): move payee autocomplete state machine out of view

### DIFF
--- a/Backends/GRDB/Repositories/GRDBTransactionRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBTransactionRepository.swift
@@ -197,7 +197,9 @@ final class GRDBTransactionRepository: TransactionRepository, @unchecked Sendabl
     }
   }
 
-  func fetchPayeeSuggestions(prefix: String) async throws -> [String] {
+  func fetchPayeeSuggestions(
+    prefix: String, excludingTransactionId: UUID?
+  ) async throws -> [String] {
     guard !prefix.isEmpty else { return [] }
     return try await database.read { database in
       // `LIKE ? || '%'` keeps the wildcard out of the bound argument so
@@ -206,6 +208,25 @@ final class GRDBTransactionRepository: TransactionRepository, @unchecked Sendabl
       // frequency (descending) puts most-used payees at the top, with
       // the payee string as a stable tie-breaker for deterministic
       // pagination.
+      //
+      // `excludingTransactionId` removes the editing row from both the
+      // GROUP BY count and the visible list (#538) so a payee that only
+      // exists on the row being edited disappears, and one that exists
+      // on N rows is counted as N-1 from that row's perspective.
+      if let excludingTransactionId {
+        let sql = """
+          SELECT payee
+          FROM "transaction"
+          WHERE payee IS NOT NULL
+            AND id != ?
+            AND lower(payee) LIKE lower(?) || '%'
+          GROUP BY payee
+          ORDER BY COUNT(*) DESC, payee ASC
+          LIMIT 20
+          """
+        return try String.fetchAll(
+          database, sql: sql, arguments: [excludingTransactionId, prefix])
+      }
       let sql = """
         SELECT payee
         FROM "transaction"

--- a/Domain/Repositories/TransactionRepository.swift
+++ b/Domain/Repositories/TransactionRepository.swift
@@ -10,5 +10,19 @@ protocol TransactionRepository: Sendable {
   func create(_ transaction: Transaction) async throws -> Transaction
   func update(_ transaction: Transaction) async throws -> Transaction
   func delete(id: UUID) async throws
-  func fetchPayeeSuggestions(prefix: String) async throws -> [String]
+  /// Frequency-sorted payee strings beginning with `prefix`. When
+  /// `excludingTransactionId` is supplied, the matching transaction does
+  /// not contribute to the frequency count and its payee will not appear
+  /// in the result if no other transaction shares it. Unknown ids — and
+  /// unsaved drafts — leave the unfiltered list intact.
+  func fetchPayeeSuggestions(prefix: String, excludingTransactionId: UUID?) async throws
+    -> [String]
+}
+
+extension TransactionRepository {
+  /// Convenience overload with `excludingTransactionId` defaulting to
+  /// `nil`. Returns the unfiltered frequency-sorted prefix matches.
+  func fetchPayeeSuggestions(prefix: String) async throws -> [String] {
+    try await fetchPayeeSuggestions(prefix: prefix, excludingTransactionId: nil)
+  }
 }

--- a/Features/Transactions/PayeeSuggestionSource.swift
+++ b/Features/Transactions/PayeeSuggestionSource.swift
@@ -30,7 +30,12 @@ final class PayeeSuggestionSource {
   /// empty prefix clears the current list without issuing a request.
   /// Subsequent calls cancel any pending fetch so only the most recent
   /// keystroke's request completes.
-  func fetch(prefix: String) {
+  ///
+  /// `excludingTransactionId` is the id of the transaction the user is
+  /// editing; the repo drops it from the frequency count so a row never
+  /// suggests its own payee back to itself (#538). Pass `nil` for
+  /// non-editing contexts.
+  func fetch(prefix: String, excludingTransactionId: UUID? = nil) {
     task?.cancel()
 
     guard !prefix.isEmpty else {
@@ -43,7 +48,8 @@ final class PayeeSuggestionSource {
       guard !Task.isCancelled else { return }
 
       do {
-        let results = try await repository.fetchPayeeSuggestions(prefix: prefix)
+        let results = try await repository.fetchPayeeSuggestions(
+          prefix: prefix, excludingTransactionId: excludingTransactionId)
         guard !Task.isCancelled else { return }
         suggestions = results
       } catch {

--- a/Features/Transactions/Views/Detail/PayeeAutocompleteRow.swift
+++ b/Features/Transactions/Views/Detail/PayeeAutocompleteRow.swift
@@ -12,6 +12,11 @@ struct PayeeAutocompleteRow: View {
   @Binding var payee: String
   @Binding var state: PayeeAutocompleteState
   let suggestionSource: PayeeSuggestionSource
+  /// Id of the transaction the field is editing; forwarded to the
+  /// suggestion source so the row's own payee is dropped from the
+  /// frequency count and the visible list (#538). `nil` for fresh /
+  /// unsaved drafts where no row exists in the repo yet.
+  let editingTransactionId: UUID?
   let onAutofill: (String) -> Void
 
   @FocusState private var fieldFocused: Bool
@@ -37,7 +42,8 @@ struct PayeeAutocompleteRow: View {
       state.justSelected = false
     } else {
       state.showSuggestions = !newValue.isEmpty
-      suggestionSource.fetch(prefix: newValue)
+      suggestionSource.fetch(
+        prefix: newValue, excludingTransactionId: editingTransactionId)
     }
   }
 

--- a/Features/Transactions/Views/Detail/PayeeAutocompleteRow.swift
+++ b/Features/Transactions/Views/Detail/PayeeAutocompleteRow.swift
@@ -38,13 +38,9 @@ struct PayeeAutocompleteRow: View {
   }
 
   private func handleTextChange(_ newValue: String) {
-    if state.justSelected {
-      state.justSelected = false
-    } else {
-      state.showSuggestions = !newValue.isEmpty
-      suggestionSource.fetch(
-        prefix: newValue, excludingTransactionId: editingTransactionId)
-    }
+    guard state.registerTextEdit(to: newValue) else { return }
+    suggestionSource.fetch(
+      prefix: newValue, excludingTransactionId: editingTransactionId)
   }
 
   private func acceptHighlighted() {

--- a/Features/Transactions/Views/Detail/PayeeAutocompleteState.swift
+++ b/Features/Transactions/Views/Detail/PayeeAutocompleteState.swift
@@ -17,4 +17,19 @@ extension PayeeAutocompleteState {
     guard showSuggestions else { return [] }
     return Array(source.prefix(8))
   }
+
+  /// Reports whether the caller should fetch suggestions for this text
+  /// change. Returns `false` exactly once after `dismiss()` to swallow
+  /// the binding echo of a suggestion acceptance — without this, the
+  /// dropdown would re-open showing the suggestion the user just
+  /// picked. The fetch decision lives in the state struct so the view
+  /// can stay a single dispatch line.
+  mutating func registerTextEdit(to newValue: String) -> Bool {
+    if justSelected {
+      justSelected = false
+      return false
+    }
+    showSuggestions = !newValue.isEmpty
+    return true
+  }
 }

--- a/Features/Transactions/Views/Detail/TransactionDetailCustomDetailsSection.swift
+++ b/Features/Transactions/Views/Detail/TransactionDetailCustomDetailsSection.swift
@@ -6,6 +6,7 @@ import SwiftUI
 struct TransactionDetailCustomDetailsSection: View {
   @Binding var draft: TransactionDraft
   let suggestionSource: PayeeSuggestionSource
+  let editingTransactionId: UUID?
   @Binding var payeeState: PayeeAutocompleteState
   let onAutofill: (String) -> Void
   @FocusState.Binding var focusedField: TransactionDetailFocus?
@@ -16,6 +17,7 @@ struct TransactionDetailCustomDetailsSection: View {
         payee: $draft.payee,
         state: $payeeState,
         suggestionSource: suggestionSource,
+        editingTransactionId: editingTransactionId,
         onAutofill: onAutofill
       )
       .focused($focusedField, equals: .payee)

--- a/Features/Transactions/Views/Detail/TransactionDetailDetailsSection.swift
+++ b/Features/Transactions/Views/Detail/TransactionDetailDetailsSection.swift
@@ -11,6 +11,7 @@ struct TransactionDetailDetailsSection: View {
   let relevantInstrument: Instrument?
   let isCrossCurrency: Bool
   let suggestionSource: PayeeSuggestionSource
+  let editingTransactionId: UUID?
   @Binding var payeeState: PayeeAutocompleteState
   let onAutofill: (String) -> Void
   @FocusState.Binding var focusedField: TransactionDetailFocus?
@@ -21,6 +22,7 @@ struct TransactionDetailDetailsSection: View {
         payee: $draft.payee,
         state: $payeeState,
         suggestionSource: suggestionSource,
+        editingTransactionId: editingTransactionId,
         onAutofill: onAutofill
       )
       .focused($focusedField, equals: .payee)

--- a/Features/Transactions/Views/TransactionDetailView.swift
+++ b/Features/Transactions/Views/TransactionDetailView.swift
@@ -200,6 +200,7 @@ extension TransactionDetailView {
     TransactionDetailCustomDetailsSection(
       draft: $draft,
       suggestionSource: transactionStore.payeeSuggestionSource,
+      editingTransactionId: transaction.id,
       payeeState: $payeeState,
       onAutofill: autofillFromPayee,
       focusedField: $focusedField
@@ -255,6 +256,7 @@ extension TransactionDetailView {
       relevantInstrument: relevantInstrument,
       isCrossCurrency: isCrossCurrency,
       suggestionSource: transactionStore.payeeSuggestionSource,
+      editingTransactionId: transaction.id,
       payeeState: $payeeState,
       onAutofill: autofillFromPayee,
       focusedField: $focusedField
@@ -286,6 +288,7 @@ extension TransactionDetailView {
     TransactionDetailCustomDetailsSection(
       draft: $draft,
       suggestionSource: transactionStore.payeeSuggestionSource,
+      editingTransactionId: transaction.id,
       payeeState: $payeeState,
       onAutofill: autofillFromPayee,
       focusedField: $focusedField

--- a/MoolahTests/Backends/GRDB/AnalysisPlanPinningTests.swift
+++ b/MoolahTests/Backends/GRDB/AnalysisPlanPinningTests.swift
@@ -68,6 +68,31 @@ struct AnalysisPlanPinningTests {
     #expect(detail.contains("transaction_by_payee"))
   }
 
+  @Test("fetchPayeeSuggestions with excludingTransactionId still uses the payee index")
+  func payeePrefixWithExclusionMatchesProduction() throws {
+    let database = try makeDatabase()
+    // Mirrors the `excludingTransactionId` branch of
+    // `GRDBTransactionRepository.fetchPayeeSuggestions(prefix:excludingTransactionId:)`.
+    // The added `id != ?` predicate must not push the planner off the
+    // partial `transaction_by_payee` index — a regression here would
+    // turn every keystroke into a full table scan.
+    let detail = try planDetail(
+      database,
+      sql: """
+        SELECT payee
+        FROM "transaction"
+        WHERE payee IS NOT NULL
+          AND id != ?
+          AND lower(payee) LIKE lower(?) || '%'
+        GROUP BY payee
+        ORDER BY COUNT(*) DESC, payee ASC
+        LIMIT 20
+        """,
+      arguments: [UUID(), "X"])
+    #expect(detail.contains("transaction_by_payee"))
+    #expect(!detail.contains("SCAN \"transaction\""))
+  }
+
   @Test("transaction equality filter on payee uses the partial payee index")
   func payeeEqualityUsesPayeeIndex() throws {
     let database = try makeDatabase()

--- a/MoolahTests/Backends/GRDB/AnalysisPlanPinningTests.swift
+++ b/MoolahTests/Backends/GRDB/AnalysisPlanPinningTests.swift
@@ -78,7 +78,7 @@ struct AnalysisPlanPinningTests {
     // turn every keystroke into a full table scan.
     let detail = try planDetail(
       database,
-      sql: """
+      query: """
         SELECT payee
         FROM "transaction"
         WHERE payee IS NOT NULL
@@ -90,7 +90,7 @@ struct AnalysisPlanPinningTests {
         """,
       arguments: [UUID(), "X"])
     #expect(detail.contains("transaction_by_payee"))
-    #expect(!detail.contains("SCAN \"transaction\""))
+    #expect(!PlanPinningTestHelpers.planHasFullTableScanOf(detail, alias: "\"transaction\""))
   }
 
   @Test("transaction equality filter on payee uses the partial payee index")

--- a/MoolahTests/Domain/TransactionRepositoryAuxFilterTests.swift
+++ b/MoolahTests/Domain/TransactionRepositoryAuxFilterTests.swift
@@ -126,4 +126,48 @@ struct TransactionRepositoryAuxFilterTests {
     #expect(suggestions[0] == "Coles", "Most frequent payee should be first")
     #expect(suggestions[1] == "Coffee Shop")
   }
+
+  @Test("fetchPayeeSuggestions excludes the editing transaction's own row")
+  func testPayeeSuggestionsExcludesEditingTransaction() async throws {
+    // "Woolworths" appears on exactly one transaction in the fixture; passing
+    // its id as `excludingTransactionId` drops the only occurrence so the
+    // payee disappears from the suggestion list. Without this, the field would
+    // suggest the row's own payee back to itself (#538).
+    let transactions = try makePayeeSuggestionContractTestTransactions()
+    let woolworths = try #require(transactions.first { $0.payee == "Woolworths" })
+    let repository = try makeContractCloudKitTransactionRepository(
+      initialTransactions: transactions)
+
+    let suggestions = try await repository.fetchPayeeSuggestions(
+      prefix: "Wool", excludingTransactionId: woolworths.id)
+    #expect(suggestions.isEmpty)
+  }
+
+  @Test("fetchPayeeSuggestions excludingTransactionId reduces frequency counts")
+  func testPayeeSuggestionsExclusionReducesFrequency() async throws {
+    // "Coles" appears 3 times. Excluding one of those rows leaves 2 — still
+    // a match, but the frequency count must reflect the exclusion so the
+    // ordering stays correct relative to other prefix matches.
+    let transactions = try makePayeeSuggestionContractTestTransactions()
+    let firstColes = try #require(transactions.first { $0.payee == "Coles" })
+    let repository = try makeContractCloudKitTransactionRepository(
+      initialTransactions: transactions)
+
+    let suggestions = try await repository.fetchPayeeSuggestions(
+      prefix: "Co", excludingTransactionId: firstColes.id)
+
+    #expect(suggestions == ["Coles", "Coffee Shop"])
+  }
+
+  @Test("fetchPayeeSuggestions excludingTransactionId for unknown id is a no-op")
+  func testPayeeSuggestionsExclusionUnknownIdNoOp() async throws {
+    // Acceptance criterion 2: an id that isn't in the repo (e.g. an unsaved
+    // draft) leaves the result identical to the no-exclusion path.
+    let repository = try makeContractCloudKitTransactionRepository(
+      initialTransactions: try makePayeeSuggestionContractTestTransactions())
+
+    let suggestions = try await repository.fetchPayeeSuggestions(
+      prefix: "Co", excludingTransactionId: UUID())
+    #expect(suggestions == ["Coles", "Coffee Shop"])
+  }
 }

--- a/MoolahTests/Features/PayeeAutocompleteStateTests.swift
+++ b/MoolahTests/Features/PayeeAutocompleteStateTests.swift
@@ -6,7 +6,7 @@ import Testing
 @Suite("PayeeAutocompleteState")
 struct PayeeAutocompleteStateTests {
   @Test
-  func testCancelClosesDropdownWithoutArmingJustSelected() {
+  func escapeClosesDropdownAndLeavesNextKeystrokeFree() {
     var state = PayeeAutocompleteState(
       showSuggestions: true,
       highlightedIndex: 2,
@@ -19,13 +19,12 @@ struct PayeeAutocompleteStateTests {
     #expect(state.highlightedIndex == nil)
     // `justSelected` must stay false: no binding-driven `onTextChange` is
     // triggered by Escape (the text didn't change), so the next character
-    // the user types should be free to re-open the dropdown. Setting
-    // `justSelected = true` here would silently eat that next keystroke.
+    // the user types should be free to re-open the dropdown.
     #expect(state.justSelected == false)
   }
 
   @Test
-  func testDismissArmsJustSelectedSoBindingDrivenOnChangeIsEaten() {
+  func acceptingSuggestionHidesDropdownAndArmsEchoGuard() {
     var state = PayeeAutocompleteState(
       showSuggestions: true,
       highlightedIndex: 1,
@@ -36,8 +35,62 @@ struct PayeeAutocompleteStateTests {
 
     #expect(state.showSuggestions == false)
     #expect(state.highlightedIndex == nil)
-    // Used by the suggestion-acceptance path: the resulting binding write
-    // triggers an `onChange(of: text)` we want to ignore.
+    // The acceptance writes the suggestion back through the binding; the
+    // resulting `onChange(of: text)` must be ignored once.
     #expect(state.justSelected == true)
+  }
+
+  @Test
+  func typingAfterSuggestionAcceptedDoesNotReopenDropdown() {
+    // After `dismiss()` arms `justSelected`, the next text-change callback
+    // must clear the flag without asking the caller to fetch — that
+    // callback is the binding echo of the suggestion acceptance, not a
+    // real user edit.
+    var state = PayeeAutocompleteState(
+      showSuggestions: false,
+      highlightedIndex: nil,
+      justSelected: true
+    )
+
+    let shouldFetch = state.registerTextEdit(to: "Woolworths")
+
+    #expect(shouldFetch == false)
+    #expect(state.justSelected == false)
+    // `showSuggestions` must NOT be promoted to true — re-opening it on
+    // the echoed text change would show the suggestion the user just
+    // picked.
+    #expect(state.showSuggestions == false)
+  }
+
+  @Test
+  func typingRealTextOpensDropdownAndRequestsFetch() {
+    var state = PayeeAutocompleteState(
+      showSuggestions: false,
+      highlightedIndex: nil,
+      justSelected: false
+    )
+
+    let shouldFetch = state.registerTextEdit(to: "Wool")
+
+    #expect(shouldFetch == true)
+    #expect(state.showSuggestions == true)
+  }
+
+  @Test
+  func clearingTextHidesDropdownAndRequestsFetch() {
+    // The fetch call short-circuits empty prefixes itself (clearing
+    // `suggestions`); the state mirrors that by hiding the dropdown.
+    // Returning `true` keeps the contract simple — the source decides
+    // what to do with an empty prefix, not the state.
+    var state = PayeeAutocompleteState(
+      showSuggestions: true,
+      highlightedIndex: 0,
+      justSelected: false
+    )
+
+    let shouldFetch = state.registerTextEdit(to: "")
+
+    #expect(shouldFetch == true)
+    #expect(state.showSuggestions == false)
   }
 }

--- a/MoolahTests/Features/TransactionStoreLoadRaceTests.swift
+++ b/MoolahTests/Features/TransactionStoreLoadRaceTests.swift
@@ -196,5 +196,7 @@ actor FirstFetchGatedTransactionRepository: TransactionRepository {
   func create(_ transaction: Transaction) async throws -> Transaction { transaction }
   func update(_ transaction: Transaction) async throws -> Transaction { transaction }
   func delete(id: UUID) async throws {}
-  func fetchPayeeSuggestions(prefix: String) async throws -> [String] { [] }
+  func fetchPayeeSuggestions(
+    prefix: String, excludingTransactionId: UUID?
+  ) async throws -> [String] { [] }
 }

--- a/MoolahTests/Support/CancellablePagingTransactionRepository.swift
+++ b/MoolahTests/Support/CancellablePagingTransactionRepository.swift
@@ -57,7 +57,9 @@ actor CancellablePagingTransactionRepository: TransactionRepository {
   func create(_ transaction: Transaction) async throws -> Transaction { transaction }
   func update(_ transaction: Transaction) async throws -> Transaction { transaction }
   func delete(id: UUID) async throws {}
-  func fetchPayeeSuggestions(prefix: String) async throws -> [String] { [] }
+  func fetchPayeeSuggestions(
+    prefix: String, excludingTransactionId: UUID?
+  ) async throws -> [String] { [] }
 }
 
 /// A simple one-shot gate that suspends waiters until `open()` is called.

--- a/MoolahTests/Support/TransactionStoreTestSupport.swift
+++ b/MoolahTests/Support/TransactionStoreTestSupport.swift
@@ -122,7 +122,9 @@ struct FailingTransactionRepository: TransactionRepository {
     throw BackendError.networkUnavailable
   }
 
-  func fetchPayeeSuggestions(prefix: String) async throws -> [String] {
+  func fetchPayeeSuggestions(
+    prefix: String, excludingTransactionId: UUID?
+  ) async throws -> [String] {
     throw BackendError.networkUnavailable
   }
 }


### PR DESCRIPTION
## Summary

Stacked on [#596](https://github.com/ajsutton/moolah-native/pull/596). Addresses the thin-view finding from the #596 code-review:

- Adds `PayeeAutocompleteState.registerTextEdit(to:) -> Bool` that
  consumes the `justSelected` echo guard and updates `showSuggestions`,
  returning whether the caller should fetch.
- `PayeeAutocompleteRow.handleTextChange` collapses to a guard +
  dispatch one-liner. Private view methods are no longer holding
  state-machine logic, so the branching is now unit-tested.
- Renames the existing tests in `PayeeAutocompleteStateTests` to drop
  the redundant `test` prefix and lead with user-visible behaviour,
  matching the project's Swift Testing convention.

## Test plan

- [x] `just test-mac` — full mac suite green (1738 tests)
- [x] `just test-ios` — full iOS suite green
- [x] `just format-check` — clean
- [x] New tests cover the three branches of `registerTextEdit`:
  echo-suppressed (no fetch), real edit (open + fetch), empty text
  (hide + fetch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)