### PR TITLE
fix(transactions): clear showError when store error transitions to nil

### DIFF
--- a/Features/Transactions/Views/TransactionListView.swift
+++ b/Features/Transactions/Views/TransactionListView.swift
@@ -157,9 +157,16 @@ struct TransactionListView: View {
         Text(errorMessage)
       }
       .task(id: transactionStore.error?.localizedDescription) {
+        // Re-fires whenever the store's error description changes — including
+        // the X → nil transition that follows a successful retry. Without the
+        // `else` branch a stale `showError = true` would survive the error
+        // being cleared by the next `load()`, latching the alert on every
+        // subsequent mount.
         if let error = transactionStore.error {
           errorMessage = error.userMessage
           showError = true
+        } else {
+          showError = false
         }
       }
       .confirmationDialog(


### PR DESCRIPTION
## Summary

Defence-in-depth follow-up to [#597](https://github.com/ajsutton/moolah-native/pull/597).

`TransactionListView`'s alert observer re-runs whenever `transactionStore.error?.localizedDescription` changes, but only sets `showError = true`. A transient X → nil transition (e.g. a failed load followed by a successful retry, or a momentary error set-then-cleared during a fast view churn) leaves `showError` stuck true and latches the alert on every subsequent mount, even though the store no longer reports an error.

Adding the `else` branch clears `showError` when the error is gone, matching the rest of the binding's intent.

The original investment-account symptom is already fixed by #597 (cancellation no longer reaches `self.error` at all). This PR closes the broader hole so any future transient-error pattern is self-correcting.

### Why no test

The state being fixed is purely view-local SwiftUI `@State`, reachable only via XCUITest. The existing UI test suite has no precedent for asserting alert-dismissal behaviour, and the change is one line on a code path that is otherwise covered by manual QA. Per CLAUDE.md's thin-view convention, the right long-term move is to lift error presentation into the store, but that's a bigger refactor and not blocking this fix.

## Test plan

- [x] `just format-check` clean
- [x] `just build-mac` succeeds (no new warnings; `SWIFT_TREAT_WARNINGS_AS_ERRORS: YES`)
- [ ] Manual: trigger a transient store error and verify the alert dismisses on its own once the error clears

🤖 Generated with [Claude Code](https://claude.com/claude-code)