### PR TITLE
fix(transactions): include Trade in custom-leg Type picker

### DIFF
--- a/Features/Transactions/Views/Detail/TransactionDetailLegRow.swift
+++ b/Features/Transactions/Views/Detail/TransactionDetailLegRow.swift
@@ -58,6 +58,7 @@ struct TransactionDetailLegRow: View {
       Text(TransactionType.income.displayName).tag(TransactionType.income)
       Text(TransactionType.expense.displayName).tag(TransactionType.expense)
       Text(TransactionType.transfer.displayName).tag(TransactionType.transfer)
+      Text(TransactionType.trade.displayName).tag(TransactionType.trade)
     }
   }
 


### PR DESCRIPTION
## Summary
- The per-leg Type picker in the custom (multi-leg) transaction editor listed only income, expense, and transfer — `.trade` was missing even though it is a user-selectable type and the top-level mode picker already supports it.
- Adds `.trade` as an option, matching `TransactionType.userSelectableTypes` and `TransactionDetailModeSection`.

## Test plan
- [x] `just build-mac`
- [x] `just format-check`
- [ ] Manual: open a custom transaction, verify the per-leg Type dropdown now includes Trade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)