### PR TITLE
fix(csv): tag SelfWealth Buy/Sell trade legs as .trade

### DIFF
--- a/MoolahTests/Features/Import/ImportStoreTestsMoreSecondHalf.swift
+++ b/MoolahTests/Features/Import/ImportStoreTestsMoreSecondHalf.swift
@@ -162,10 +162,10 @@ struct ImportStoreTestsMoreSecondHalf {
     let cashLeg = buy.legs.first(where: {
       $0.instrument == .AUD && $0.quantity == Decimal(string: "-5000.00")
     })
-    #expect(cashLeg?.type == .expense)
+    #expect(cashLeg?.type == .trade)
     let positionLeg = buy.legs.first(where: { $0.instrument.id == "ASX:WXYZ" })
     #expect(positionLeg?.quantity == 100)
-    #expect(positionLeg?.type == .income)
+    #expect(positionLeg?.type == .trade)
     let brokerageLeg = buy.legs.first(where: {
       $0.instrument == .AUD && $0.quantity == Decimal(string: "-9.50")
     })

--- a/MoolahTests/Shared/CSVImport/SelfWealthMovementsParserTests.swift
+++ b/MoolahTests/Shared/CSVImport/SelfWealthMovementsParserTests.swift
@@ -23,7 +23,7 @@ struct SelfWealthMovementsParserTests {
     #expect(parser.recognizes(headers: rows[0]))
   }
 
-  @Test("Buy → three legs: cash -expense, position +income, brokerage -expense")
+  @Test("Buy → three legs: cash -trade, position +trade, brokerage -expense")
   func buyTradeThreeLegs() throws {
     let parser = SelfWealthMovementsParser()
     let rows = try self.rows("selfwealth-movements")
@@ -34,12 +34,12 @@ struct SelfWealthMovementsParserTests {
       }))
     #expect(buy.legs.count == 3)
     let cashLeg = buy.legs.first(where: {
-      $0.instrument == .AUD && $0.type == .expense && $0.quantity == Decimal(string: "-5000.00")
+      $0.instrument == .AUD && $0.type == .trade && $0.quantity == Decimal(string: "-5000.00")
     })
     #expect(cashLeg != nil)
     let positionLeg = try #require(buy.legs.first(where: { $0.instrument.id == "ASX:WXYZ" }))
     #expect(positionLeg.quantity == 100)
-    #expect(positionLeg.type == .income)
+    #expect(positionLeg.type == .trade)
     #expect(positionLeg.instrument.kind == .stock)
     #expect(positionLeg.isInstrumentPlaceholder == false)
     let brokerageLeg = buy.legs.first(where: {
@@ -50,7 +50,7 @@ struct SelfWealthMovementsParserTests {
     #expect(buy.bankReference == "1000001")
   }
 
-  @Test("Sell → three legs: cash +income, position -expense, brokerage -expense")
+  @Test("Sell → three legs: cash +trade, position -trade, brokerage -expense")
   func sellTradeThreeLegs() throws {
     let parser = SelfWealthMovementsParser()
     let rows = try self.rows("selfwealth-movements")
@@ -62,12 +62,12 @@ struct SelfWealthMovementsParserTests {
     #expect(sell.legs.count == 3)
     let cashLeg = try #require(
       sell.legs.first(where: {
-        $0.instrument == .AUD && $0.type == .income
+        $0.instrument == .AUD && $0.type == .trade
       }))
     #expect(cashLeg.quantity == Decimal(string: "4000.00"))
     let positionLeg = try #require(sell.legs.first(where: { $0.instrument.id == "ASX:ABCD" }))
     #expect(positionLeg.quantity == -50)
-    #expect(positionLeg.type == .expense)
+    #expect(positionLeg.type == .trade)
     let brokerageLeg = try #require(
       sell.legs.first(where: {
         $0.instrument == .AUD && $0.type == .expense

--- a/Shared/CSVImport/SelfWealthMovementsParser.swift
+++ b/Shared/CSVImport/SelfWealthMovementsParser.swift
@@ -155,11 +155,11 @@ struct SelfWealthMovementsParser: CSVParser, Sendable {
     var legs = [
       ParsedLeg(
         accountId: nil, instrument: .AUD, quantity: cashAmount,
-        type: isBuy ? .expense : .income, isInstrumentPlaceholder: true),
+        type: .trade, isInstrumentPlaceholder: true),
       ParsedLeg(
         accountId: nil, instrument: stockInstrument,
         quantity: isBuy ? context.units : -context.units,
-        type: isBuy ? .income : .expense, isInstrumentPlaceholder: false),
+        type: .trade, isInstrumentPlaceholder: false),
     ]
     if brokerage > 0 {
       legs.append(


### PR DESCRIPTION
## Summary
- The SelfWealth Movements parser tagged Buy/Sell legs as `.expense` / `.income` (matching the cash flow direction). Now tags both the cash leg and the position leg as `.trade`, matching how the rest of the app handles trade transactions.
- The brokerage fee leg stays `.expense` — it really is a fee.
- Updates the parser unit tests and the import-pipeline end-to-end tests to assert the new types.

## Test plan
- [x] `just test-mac SelfWealthMovementsParserTests ImportStoreTestsMoreSecondHalf ImportRulesEngineTests`
- [x] `just build-mac`
- [x] `just format-check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)