### PR TITLE
feat(transaction-detail): inline instrument picker on every Amount row

### DIFF
--- a/Features/Transactions/Views/Detail/TransactionDetailAccountSection.swift
+++ b/Features/Transactions/Views/Detail/TransactionDetailAccountSection.swift
@@ -23,6 +23,14 @@ struct TransactionDetailAccountSection: View {
           Text(account.name).tag(UUID?.some(account.id))
         }
       }
+      // Snap the relevant leg's instrument to the newly chosen account's
+      // instrument so the inline picker on the Amount row tracks the
+      // account. Mirrors the multi-leg row in `TransactionDetailLegRow`.
+      .onChange(of: draft.legDrafts[draft.relevantLegIndex].accountId) { _, newAccountId in
+        if let newAccountId, let account = accounts.by(id: newAccountId) {
+          draft.legDrafts[draft.relevantLegIndex].instrument = account.instrument
+        }
+      }
 
       if draft.type == .transfer {
         transferRows
@@ -43,7 +51,13 @@ struct TransactionDetailAccountSection: View {
       }
     }
     .accessibilityIdentifier(UITestIdentifiers.Detail.toAccountPicker)
-    .onChange(of: draft.legDrafts[counterpartIndex].accountId) { _, _ in
+    .onChange(of: draft.legDrafts[counterpartIndex].accountId) { _, newAccountId in
+      // Snap the counterpart leg's instrument to the new account before
+      // mirroring amounts — the cross-currency picker reads the leg's
+      // instrument first.
+      if let newAccountId, let account = accounts.by(id: newAccountId) {
+        draft.legDrafts[counterpartIndex].instrument = account.instrument
+      }
       draft.snapToSameCurrencyIfNeeded(accounts: accounts)
     }
 

--- a/Features/Transactions/Views/Detail/TransactionDetailCrossCurrencyRow.swift
+++ b/Features/Transactions/Views/Detail/TransactionDetailCrossCurrencyRow.swift
@@ -37,25 +37,45 @@ struct TransactionDetailCrossCurrencyRow: View {
     )
   }
 
+  /// Bridges the counterpart leg's `Instrument?` to the picker's
+  /// non-optional binding. Reads fall back to the account-derived
+  /// counterpart instrument; writes update the leg directly.
+  private var counterpartInstrumentBinding: Binding<Instrument> {
+    Binding(
+      get: {
+        if let idx = draft.counterpartLegIndex {
+          return draft.legDrafts[idx].instrument
+            ?? counterpartInstrument ?? .AUD
+        }
+        return counterpartInstrument ?? .AUD
+      },
+      set: { newValue in
+        guard let idx = draft.counterpartLegIndex else { return }
+        draft.legDrafts[idx].instrument = newValue
+      }
+    )
+  }
+
   var body: some View {
     let fieldLabel = draft.showFromAccount ? "Sent" : "Received"
-    HStack {
+    LabeledContent {
+      HStack(spacing: 8) {
+        TextField(fieldLabel, text: counterpartAmountBinding)
+          .labelsHidden()
+          .multilineTextAlignment(.trailing)
+          .monospacedDigit()
+          .accessibilityLabel(draft.showFromAccount ? "Sent amount" : "Received amount")
+          #if os(iOS)
+            .keyboardType(.decimalPad)
+          #endif
+          .focused($focusedField, equals: .counterpartAmount)
+          .onSubmit { focusedField = nil }
+          .accessibilityIdentifier(UITestIdentifiers.Detail.counterpartAmount)
+        CompactInstrumentPickerButton(selection: counterpartInstrumentBinding)
+          .accessibilityIdentifier(UITestIdentifiers.Detail.counterpartAmountInstrument)
+      }
+    } label: {
       Text(fieldLabel)
-      Spacer()
-      TextField(fieldLabel, text: counterpartAmountBinding)
-        .multilineTextAlignment(.trailing)
-        .monospacedDigit()
-        .accessibilityLabel(draft.showFromAccount ? "Sent amount" : "Received amount")
-        #if os(iOS)
-          .keyboardType(.decimalPad)
-        #endif
-        .focused($focusedField, equals: .counterpartAmount)
-        .onSubmit { focusedField = nil }
-        .accessibilityIdentifier(UITestIdentifiers.Detail.counterpartAmount)
-      Text(counterpartInstrument?.id ?? "")
-        .foregroundStyle(.secondary)
-        .monospacedDigit()
-        .accessibilityIdentifier(UITestIdentifiers.Detail.counterpartAmountInstrument)
     }
 
     if let rate = derivedRate {

--- a/Features/Transactions/Views/Detail/TransactionDetailDetailsSection.swift
+++ b/Features/Transactions/Views/Detail/TransactionDetailDetailsSection.swift
@@ -16,6 +16,20 @@ struct TransactionDetailDetailsSection: View {
   let onAutofill: (String) -> Void
   @FocusState.Binding var focusedField: TransactionDetailFocus?
 
+  /// Bridges `LegDraft.instrument` (`Instrument?`) to the picker's
+  /// non-optional binding. Reads fall back to the account-derived
+  /// instrument (and finally `.AUD`) so the picker always has something
+  /// to display; writes materialise the leg-level override.
+  private var relevantInstrumentBinding: Binding<Instrument> {
+    Binding(
+      get: {
+        draft.legDrafts[draft.relevantLegIndex].instrument
+          ?? relevantInstrument ?? .AUD
+      },
+      set: { draft.legDrafts[draft.relevantLegIndex].instrument = $0 }
+    )
+  }
+
   var body: some View {
     Section {
       PayeeAutocompleteRow(
@@ -27,21 +41,25 @@ struct TransactionDetailDetailsSection: View {
       )
       .focused($focusedField, equals: .payee)
 
-      HStack {
-        TextField("Amount", text: amountBinding)
-          .multilineTextAlignment(.trailing)
-          .monospacedDigit()
-          #if os(iOS)
-            .keyboardType(.decimalPad)
-          #endif
-          .focused($focusedField, equals: .amount)
-          .onSubmit {
-            if isCrossCurrency {
-              focusedField = .counterpartAmount
+      LabeledContent {
+        HStack(spacing: 8) {
+          TextField("Amount", text: amountBinding)
+            .labelsHidden()
+            .multilineTextAlignment(.trailing)
+            .monospacedDigit()
+            #if os(iOS)
+              .keyboardType(.decimalPad)
+            #endif
+            .focused($focusedField, equals: .amount)
+            .onSubmit {
+              if isCrossCurrency {
+                focusedField = .counterpartAmount
+              }
             }
-          }
-        Text(relevantInstrument?.id ?? "").foregroundStyle(.secondary)
-          .monospacedDigit()
+          CompactInstrumentPickerButton(selection: relevantInstrumentBinding)
+        }
+      } label: {
+        Text("Amount")
       }
 
       DatePicker("Date", selection: $draft.date, displayedComponents: .date)

--- a/Features/Transactions/Views/Detail/TransactionDetailLegRow.swift
+++ b/Features/Transactions/Views/Detail/TransactionDetailLegRow.swift
@@ -35,7 +35,6 @@ struct TransactionDetailLegRow: View {
         typePicker
       }
       accountPicker
-      instrumentPicker
       amountRow
       if !isEarmarkOnly {
         categoryField
@@ -81,32 +80,27 @@ struct TransactionDetailLegRow: View {
     }
   }
 
-  @ViewBuilder private var instrumentPicker: some View {
-    let binding = Binding<Instrument>(
+  private var amountRow: some View {
+    let instrumentBinding = Binding<Instrument>(
       get: { draft.legDrafts[index].instrument ?? defaultInstrument },
       set: { draft.legDrafts[index].instrument = $0 }
     )
-    InstrumentPickerField(
-      label: "Asset",
-      kinds: Set(Instrument.Kind.allCases),
-      selection: binding
-    )
-    .accessibilityLabel("Currency for sub-transaction \(index + 1)")
-    .accessibilityHint("Overrides the currency derived from the account")
-  }
-
-  private var amountRow: some View {
-    HStack {
-      TextField("Amount", text: $draft.legDrafts[index].amountText)
-        .multilineTextAlignment(.trailing)
-        .monospacedDigit()
-        #if os(iOS)
-          .keyboardType(.decimalPad)
-        #endif
-        .focused($focusedField, equals: .legAmount(index))
-      Text(draft.legDrafts[index].instrument?.shortCode ?? defaultInstrument.shortCode)
-        .foregroundStyle(.secondary)
-        .monospacedDigit()
+    return LabeledContent {
+      HStack(spacing: 8) {
+        TextField("Amount", text: $draft.legDrafts[index].amountText)
+          .labelsHidden()
+          .multilineTextAlignment(.trailing)
+          .monospacedDigit()
+          #if os(iOS)
+            .keyboardType(.decimalPad)
+          #endif
+          .focused($focusedField, equals: .legAmount(index))
+        CompactInstrumentPickerButton(selection: instrumentBinding)
+          .accessibilityLabel("Currency for sub-transaction \(index + 1)")
+          .accessibilityHint("Overrides the currency derived from the account")
+      }
+    } label: {
+      Text("Amount")
     }
   }
 

--- a/MoolahUITests_macOS/Helpers/Fields/CounterpartAmountDriver.swift
+++ b/MoolahUITests_macOS/Helpers/Fields/CounterpartAmountDriver.swift
@@ -28,20 +28,25 @@ struct CounterpartAmountDriver {
           + "did not appear within \(timeout)s")
       return
     }
-    // Poll — the Text's content is exposed via `value` (not `label`) once
-    // an `.accessibilityIdentifier` is attached, and it updates via
-    // `.onChange` after the account picker selection propagates.
+    // The compact picker button exposes its content via the accessibility
+    // `label` ("Asset: <code>") rather than `value`. Poll both fields and
+    // accept either match — the value updates via `.onChange` after the
+    // account picker selection propagates.
     let deadline = Date().addingTimeInterval(timeout)
-    var lastValue = ""
+    var lastSeen = ""
     while Date() < deadline {
-      lastValue = (instrumentLabel.value as? String) ?? ""
-      if lastValue == instrumentCode { return }
+      let label = instrumentLabel.label
+      let value = (instrumentLabel.value as? String) ?? ""
+      lastSeen = label.isEmpty ? value : label
+      if value == instrumentCode || label.hasSuffix(": \(instrumentCode)") {
+        return
+      }
       RunLoop.current.run(until: Date().addingTimeInterval(0.05))
     }
     Trace.recordFailure(
-      "counterpart instrument label was '\(lastValue)' (expected '\(instrumentCode)')")
+      "counterpart instrument label was '\(lastSeen)' (expected '\(instrumentCode)')")
     XCTFail(
-      "Counterpart instrument label expected '\(instrumentCode)', got '\(lastValue)' within \(timeout)s"
+      "Counterpart instrument label expected '\(instrumentCode)', got '\(lastSeen)' within \(timeout)s"
     )
   }
 

--- a/Shared/Views/CompactInstrumentPickerButton.swift
+++ b/Shared/Views/CompactInstrumentPickerButton.swift
@@ -36,8 +36,8 @@ struct CompactInstrumentPickerButton: View {
     }
     .layoutPriority(1)
     .buttonStyle(.plain)
-    .accessibilityLabel(Text("Instrument: \(selection.shortCode)"))
-    .accessibilityHint(Text("Activate to choose a different instrument"))
+    .accessibilityLabel(Text("Asset: \(selection.shortCode)"))
+    .accessibilityHint(Text("Activate to choose a different asset"))
     #if os(macOS)
       .popover(
         isPresented: $isPresented,
@@ -45,7 +45,7 @@ struct CompactInstrumentPickerButton: View {
         content: {
           InstrumentPickerSheet(
             store: store,
-            label: "Instrument",
+            label: "Asset",
             selection: $selection,
             isPresented: $isPresented
           )
@@ -58,7 +58,7 @@ struct CompactInstrumentPickerButton: View {
         content: {
           InstrumentPickerSheet(
             store: store,
-            label: "Instrument",
+            label: "Asset",
             selection: $selection,
             isPresented: $isPresented
           )


### PR DESCRIPTION
## Summary
- Replaces the static instrument-code label trailing each Amount row with the existing `CompactInstrumentPickerButton`, so the user can change currency / token / asset in place without a separate Asset row.
- Fixes the case where a leg's currency differed from the account's and the UI showed the account's currency: the picker now reads the leg's own `instrument` first, falling back to the account-derived value only when the leg has no override.
- Drops the dedicated "Asset" row in custom multi-leg, since the inline button on the Amount row provides the same affordance.
- Standardises every Amount row (simple-mode, cross-currency counterpart, custom multi-leg) on the `LabeledContent { ... } label: { Text(...) }` pattern that trade and fee already use — adds a leading "Amount" / "Sent" / "Received" label and lets the iOS Form row separator run the full width past the trailing `.buttonStyle(.plain)` button.
- Renames the picker sheet title from "Choose Instrument" to "Choose Asset" (plus the matching a11y label/hint). The currency-only `InstrumentPickerField` callers (account / profile / earmark forms) keep their `"Currency"` label.
- Updates `CounterpartAmountDriver` to read the picker button's `label` ("Asset: <code>") instead of the old `Text`'s `value`.

## Test plan
- [x] `just format-check` clean.
- [x] `just build-mac` succeeds.
- [x] Xcode previews verified (Expense, Custom multi-leg, Cross-Currency Transfer) — full-width separators, leading labels, picker chevron present.
- [ ] Run `just test-mac TransactionDetailCrossCurrencyTests` to confirm the updated `CounterpartAmountDriver` still asserts the counterpart instrument label correctly.
- [ ] Manual: open a transaction with a leg whose currency differs from the account's currency; confirm the picker shows the leg's currency and the amount renders in that currency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)