### PR TITLE
Multi-select picker for transaction filter categories

### DIFF
--- a/Domain/Models/Category.swift
+++ b/Domain/Models/Category.swift
@@ -36,6 +36,13 @@ struct Categories: Sendable {
     (childrenOf[parentId] ?? []).sorted { $0.name < $1.name }
   }
 
+  /// Whether `id` has at least one direct child. Single dictionary lookup —
+  /// preferred over `!children(of: id).isEmpty` for hot per-row checks
+  /// because it skips the array allocation and sort.
+  func hasChildren(_ id: UUID) -> Bool {
+    !(childrenOf[id]?.isEmpty ?? true)
+  }
+
   /// Full path for a category, e.g. "Income:Salary:Janet".
   func path(for category: Category) -> String {
     var parts: [String] = [category.name]
@@ -61,6 +68,18 @@ struct Categories: Sendable {
       result.append(contentsOf: descendants(of: child.id))
     }
     return result
+  }
+
+  /// All ids in the subtree rooted at `id` — the id itself plus every
+  /// descendant. The returned set is the unit operated on by callers
+  /// who select or deselect a whole branch (e.g. the picker's subtree
+  /// shortcut). For an id with no descendants — including ids that
+  /// aren't in this `Categories` value — the result is the singleton
+  /// containing only that id.
+  func subtreeIds(of id: UUID) -> Set<UUID> {
+    var ids: Set<UUID> = [id]
+    ids.formUnion(descendants(of: id).lazy.map(\.id))
+    return ids
   }
 
   /// Filter-trigger label for a multi-category selection.

--- a/Domain/Models/Category.swift
+++ b/Domain/Models/Category.swift
@@ -110,6 +110,13 @@ struct Categories: Sendable {
 
     /// Hierarchy depth derived from the colon-separated path.
     /// Roots have depth `0`; each level of nesting adds `1`.
+    ///
+    /// - Precondition: `Category.name` values must not contain `":"`.
+    ///   `path(for:)` uses `":"` as the hierarchy separator, so a colon
+    ///   inside a name produces an artificially high depth and incorrect
+    ///   indentation. The current model accepts arbitrary `String` names
+    ///   without UI validation, so callers that synthesise categories
+    ///   need to keep colons out of names themselves.
     var depth: Int { path.split(separator: ":").count - 1 }
   }
 

--- a/Domain/Models/Category.swift
+++ b/Domain/Models/Category.swift
@@ -47,6 +47,16 @@ struct Categories: Sendable {
     return parts.joined(separator: ":")
   }
 
+  /// All descendants of a given category, depth-first; excludes the category itself.
+  func descendants(of parentId: UUID) -> [Category] {
+    var result: [Category] = []
+    for child in children(of: parentId) {
+      result.append(child)
+      result.append(contentsOf: descendants(of: child.id))
+    }
+    return result
+  }
+
   /// An entry in the flattened category list.
   struct FlatEntry: Sendable {
     let category: Category

--- a/Domain/Models/Category.swift
+++ b/Domain/Models/Category.swift
@@ -63,6 +63,23 @@ struct Categories: Sendable {
     return result
   }
 
+  /// Human-readable summary of a multi-category selection. Returns
+  /// `"All"` when nothing is selected (or every selected id is orphaned),
+  /// the full path when exactly one selected id is still present, and
+  /// `"\(N) selected"` when two or more selected ids are still present.
+  func selectionSummary(for selectedIds: Set<UUID>) -> String {
+    let presentIds = selectedIds.filter { byId[$0] != nil }
+    switch presentIds.count {
+    case 0:
+      return "All"
+    case 1:
+      let id = presentIds.first!  // safe: count == 1
+      return path(for: byId[id]!)
+    default:
+      return "\(presentIds.count) selected"
+    }
+  }
+
   /// An entry in the flattened category list.
   struct FlatEntry: Sendable {
     let category: Category

--- a/Domain/Models/Category.swift
+++ b/Domain/Models/Category.swift
@@ -88,6 +88,10 @@ struct Categories: Sendable {
   struct FlatEntry: Sendable {
     let category: Category
     let path: String
+
+    /// Hierarchy depth derived from the colon-separated path.
+    /// Roots have depth `0`; each level of nesting adds `1`.
+    var depth: Int { path.split(separator: ":").count - 1 }
   }
 
   /// All categories flattened with full paths, sorted alphabetically by path.
@@ -102,5 +106,15 @@ struct Categories: Sendable {
     }
     collect(nil)
     return result.sorted { $0.path.localizedCaseInsensitiveCompare($1.path) == .orderedAscending }
+  }
+
+  /// Subset of `flattenedByPath()` whose paths contain `query` (case-insensitive,
+  /// substring match). Whitespace at either end of `query` is ignored. An empty
+  /// or whitespace-only query returns the full result of `flattenedByPath()`.
+  func flattenedByPath(matching query: String) -> [FlatEntry] {
+    let trimmed = query.trimmingCharacters(in: .whitespaces)
+    let all = flattenedByPath()
+    guard !trimmed.isEmpty else { return all }
+    return all.filter { $0.path.localizedCaseInsensitiveContains(trimmed) }
   }
 }

--- a/Domain/Models/Category.swift
+++ b/Domain/Models/Category.swift
@@ -47,7 +47,13 @@ struct Categories: Sendable {
     return parts.joined(separator: ":")
   }
 
-  /// All descendants of a given category, depth-first; excludes the category itself.
+  /// Every category in the subtree rooted at `parentId`, in depth-first
+  /// pre-order with siblings sorted by name (inherited from `children(of:)`).
+  ///
+  /// The category identified by `parentId` is not included — callers that
+  /// need to operate on the whole subtree (e.g. selecting parent + descendants
+  /// for a multi-category filter) must add the root id themselves. Returns an
+  /// empty array when `parentId` has no children or is not found.
   func descendants(of parentId: UUID) -> [Category] {
     var result: [Category] = []
     for child in children(of: parentId) {

--- a/Domain/Models/Category.swift
+++ b/Domain/Models/Category.swift
@@ -63,18 +63,22 @@ struct Categories: Sendable {
     return result
   }
 
-  /// Human-readable summary of a multi-category selection. Returns
-  /// `"All"` when nothing is selected (or every selected id is orphaned),
-  /// the full path when exactly one selected id is still present, and
-  /// `"\(N) selected"` when two or more selected ids are still present.
+  /// Filter-trigger label for a multi-category selection.
+  ///
+  /// Callers that hold an arbitrary `Set<UUID>` (e.g. a persisted filter
+  /// preference) use this instead of `path(for:)` directly because the
+  /// selection may reference deleted categories. Orphaned ids are silently
+  /// dropped so the label always reflects only categories that are still
+  /// selectable: `"All"` when none remain, the full path when exactly one
+  /// remains, and `"\(N) selected"` for two or more.
   func selectionSummary(for selectedIds: Set<UUID>) -> String {
     let presentIds = selectedIds.filter { byId[$0] != nil }
     switch presentIds.count {
     case 0:
       return "All"
     case 1:
-      let id = presentIds.first!  // safe: count == 1
-      return path(for: byId[id]!)
+      guard let id = presentIds.first, let category = byId[id] else { return "All" }
+      return path(for: category)
     default:
       return "\(presentIds.count) selected"
     }

--- a/Features/Transactions/Views/CategoryMultiSelectPicker.swift
+++ b/Features/Transactions/Views/CategoryMultiSelectPicker.swift
@@ -1,0 +1,98 @@
+import SwiftUI
+
+/// Searchable, hierarchical multi-select picker for categories.
+/// Hosted as a popover on macOS and pushed via `NavigationLink` on iOS.
+struct CategoryMultiSelectPicker: View {
+  let categories: Categories
+  @Binding var selectedIds: Set<UUID>
+
+  @State private var searchText: String = ""
+
+  var body: some View {
+    VStack(spacing: 0) {
+      header
+      list
+    }
+    .searchable(text: $searchText, prompt: "Search categories")
+    #if os(iOS)
+      .navigationTitle("Categories")
+      .navigationBarTitleDisplayMode(.inline)
+    #endif
+  }
+
+  private var header: some View {
+    HStack {
+      Spacer()
+      Button("Clear") { selectedIds.removeAll() }
+        .disabled(selectedIds.isEmpty)
+    }
+    .padding(.horizontal)
+    .padding(.vertical, 8)
+  }
+
+  private var list: some View {
+    List {
+      if categories.roots.isEmpty {
+        Text("No categories available").foregroundStyle(.secondary)
+      } else if visibleEntries.isEmpty {
+        Text("No matches").foregroundStyle(.secondary)
+      } else {
+        ForEach(visibleEntries, id: \.category.id) { entry in
+          row(for: entry)
+        }
+      }
+    }
+  }
+
+  private var visibleEntries: [Categories.FlatEntry] {
+    let all = categories.flattenedByPath()
+    guard !searchText.isEmpty else { return all }
+    return all.filter { $0.path.localizedCaseInsensitiveContains(searchText) }
+  }
+
+  private func indentLevel(for entry: Categories.FlatEntry) -> Int {
+    searchText.isEmpty ? entry.path.split(separator: ":").count - 1 : 0
+  }
+
+  @ViewBuilder
+  private func row(for entry: Categories.FlatEntry) -> some View {
+    let label = searchText.isEmpty ? entry.category.name : entry.path
+    Toggle(
+      isOn: Binding(
+        get: { selectedIds.contains(entry.category.id) },
+        set: { isOn in
+          if isOn {
+            selectedIds.insert(entry.category.id)
+          } else {
+            selectedIds.remove(entry.category.id)
+          }
+        }
+      )
+    ) {
+      Text(label)
+        .lineLimit(1)
+        .truncationMode(.middle)
+        .padding(.leading, CGFloat(indentLevel(for: entry) * 16))
+    }
+  }
+}
+
+#Preview {
+  @Previewable @State var selected: Set<UUID> = []
+
+  let groceries = Category(name: "Groceries")
+  let costco = Category(name: "Costco", parentId: groceries.id)
+  let farmers = Category(name: "Farmers Market", parentId: groceries.id)
+  let transport = Category(name: "Transport")
+  let fuel = Category(name: "Fuel", parentId: transport.id)
+
+  let categories = Categories(from: [
+    groceries, costco, farmers, transport, fuel,
+  ])
+
+  return CategoryMultiSelectPicker(
+    categories: categories,
+    selectedIds: $selected
+  )
+  .frame(width: 320, height: 420)
+}

--- a/Features/Transactions/Views/CategoryMultiSelectPicker.swift
+++ b/Features/Transactions/Views/CategoryMultiSelectPicker.swift
@@ -45,7 +45,7 @@ struct CategoryMultiSelectPicker: View {
   private func row(for entry: Categories.FlatEntry) -> some View {
     let label = searchText.isEmpty ? entry.category.name : entry.path
     let indent = searchText.isEmpty ? entry.depth : 0
-    let isParent = !categories.children(of: entry.category.id).isEmpty
+    let isParent = categories.hasChildren(entry.category.id)
     return Toggle(
       isOn: Binding(
         get: { selectedIds.contains(entry.category.id) },
@@ -70,24 +70,15 @@ struct CategoryMultiSelectPicker: View {
     .contextMenu {
       if isParent {
         Button("Select all in \(entry.category.name)") {
-          selectSubtree(of: entry.category)
+          selectedIds.formUnion(categories.subtreeIds(of: entry.category.id))
         }
         Button("Deselect all in \(entry.category.name)") {
-          deselectSubtree(of: entry.category)
+          selectedIds.subtract(categories.subtreeIds(of: entry.category.id))
         }
       }
     }
   }
 
-  private func selectSubtree(of category: Category) {
-    selectedIds.insert(category.id)
-    selectedIds.formUnion(categories.descendants(of: category.id).map(\.id))
-  }
-
-  private func deselectSubtree(of category: Category) {
-    selectedIds.remove(category.id)
-    selectedIds.subtract(categories.descendants(of: category.id).map(\.id))
-  }
 }
 
 #Preview {

--- a/Features/Transactions/Views/CategoryMultiSelectPicker.swift
+++ b/Features/Transactions/Views/CategoryMultiSelectPicker.swift
@@ -1,7 +1,6 @@
 import SwiftUI
 
 /// Searchable, hierarchical multi-select picker for categories.
-/// Hosted as a popover on macOS and pushed via `NavigationLink` on iOS.
 struct CategoryMultiSelectPicker: View {
   let categories: Categories
   @Binding var selectedIds: Set<UUID>
@@ -9,55 +8,44 @@ struct CategoryMultiSelectPicker: View {
   @State private var searchText: String = ""
 
   var body: some View {
-    VStack(spacing: 0) {
-      header
-      list
-    }
-    .searchable(text: $searchText, prompt: "Search categories")
-    #if os(iOS)
-      .navigationTitle("Categories")
-      .navigationBarTitleDisplayMode(.inline)
-    #endif
-  }
-
-  private var header: some View {
-    HStack {
-      Spacer()
-      Button("Clear") { selectedIds.removeAll() }
-        .disabled(selectedIds.isEmpty)
-    }
-    .padding(.horizontal)
-    .padding(.vertical, 8)
+    list
+      .searchable(text: $searchText, prompt: "Search categories")
+      .toolbar {
+        ToolbarItem(placement: .automatic) {
+          Button("Clear") { selectedIds.removeAll() }
+            .disabled(selectedIds.isEmpty)
+            .help("Clear all selected categories")
+        }
+      }
+      #if os(iOS)
+        .navigationTitle("Categories")
+        .navigationBarTitleDisplayMode(.inline)
+      #endif
   }
 
   private var list: some View {
     List {
       if categories.roots.isEmpty {
-        Text("No categories available").foregroundStyle(.secondary)
+        ContentUnavailableView("No Categories", systemImage: "folder")
       } else if visibleEntries.isEmpty {
-        Text("No matches").foregroundStyle(.secondary)
+        ContentUnavailableView.search(text: searchText)
       } else {
         ForEach(visibleEntries, id: \.category.id) { entry in
           row(for: entry)
         }
       }
     }
+    .listStyle(.plain)
   }
 
   private var visibleEntries: [Categories.FlatEntry] {
-    let all = categories.flattenedByPath()
-    guard !searchText.isEmpty else { return all }
-    return all.filter { $0.path.localizedCaseInsensitiveContains(searchText) }
+    categories.flattenedByPath(matching: searchText)
   }
 
-  private func indentLevel(for entry: Categories.FlatEntry) -> Int {
-    searchText.isEmpty ? entry.path.split(separator: ":").count - 1 : 0
-  }
-
-  @ViewBuilder
   private func row(for entry: Categories.FlatEntry) -> some View {
     let label = searchText.isEmpty ? entry.category.name : entry.path
-    Toggle(
+    let indent = searchText.isEmpty ? entry.depth : 0
+    return Toggle(
       isOn: Binding(
         get: { selectedIds.contains(entry.category.id) },
         set: { isOn in
@@ -70,10 +58,14 @@ struct CategoryMultiSelectPicker: View {
       )
     ) {
       Text(label)
-        .lineLimit(1)
-        .truncationMode(.middle)
-        .padding(.leading, CGFloat(indentLevel(for: entry) * 16))
+        .lineLimit(2)
+        .truncationMode(.tail)
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
+    .padding(.leading, CGFloat(indent * 16))
+    .contentShape(.rect)
+    .accessibilityLabel(entry.path)
+    .accessibilityHint(entry.depth > 0 ? "Subcategory" : "Top-level category")
   }
 }
 

--- a/Features/Transactions/Views/CategoryMultiSelectPicker.swift
+++ b/Features/Transactions/Views/CategoryMultiSelectPicker.swift
@@ -45,6 +45,7 @@ struct CategoryMultiSelectPicker: View {
   private func row(for entry: Categories.FlatEntry) -> some View {
     let label = searchText.isEmpty ? entry.category.name : entry.path
     let indent = searchText.isEmpty ? entry.depth : 0
+    let isParent = !categories.children(of: entry.category.id).isEmpty
     return Toggle(
       isOn: Binding(
         get: { selectedIds.contains(entry.category.id) },
@@ -66,6 +67,26 @@ struct CategoryMultiSelectPicker: View {
     .contentShape(.rect)
     .accessibilityLabel(entry.path)
     .accessibilityHint(entry.depth > 0 ? "Subcategory" : "Top-level category")
+    .contextMenu {
+      if isParent {
+        Button("Select all in \(entry.category.name)") {
+          selectSubtree(of: entry.category)
+        }
+        Button("Deselect all in \(entry.category.name)") {
+          deselectSubtree(of: entry.category)
+        }
+      }
+    }
+  }
+
+  private func selectSubtree(of category: Category) {
+    selectedIds.insert(category.id)
+    selectedIds.formUnion(categories.descendants(of: category.id).map(\.id))
+  }
+
+  private func deselectSubtree(of category: Category) {
+    selectedIds.remove(category.id)
+    selectedIds.subtract(categories.descendants(of: category.id).map(\.id))
   }
 }
 

--- a/Features/Transactions/Views/CategoryMultiSelectPicker.swift
+++ b/Features/Transactions/Views/CategoryMultiSelectPicker.swift
@@ -8,19 +8,29 @@ struct CategoryMultiSelectPicker: View {
   @State private var searchText: String = ""
 
   var body: some View {
-    list
-      .searchable(text: $searchText, prompt: "Search categories")
-      .toolbar {
-        ToolbarItem(placement: .automatic) {
-          Button("Clear") { selectedIds.removeAll() }
-            .disabled(selectedIds.isEmpty)
-            .help("Clear all selected categories")
-        }
-      }
-      #if os(iOS)
-        .navigationTitle("Categories")
-        .navigationBarTitleDisplayMode(.inline)
-      #endif
+    VStack(spacing: 0) {
+      header
+      list
+    }
+    .searchable(text: $searchText, prompt: "Search categories")
+    #if os(iOS)
+      .navigationTitle("Categories")
+      .navigationBarTitleDisplayMode(.inline)
+    #endif
+  }
+
+  // Inline header rather than `.toolbar`: SwiftUI toolbar items don't
+  // render inside a macOS popover, so a toolbar Clear would be invisible
+  // on the macOS host. The inline header works on both platforms.
+  private var header: some View {
+    HStack {
+      Spacer()
+      Button("Clear") { selectedIds.removeAll() }
+        .disabled(selectedIds.isEmpty)
+        .help("Clear all selected categories")
+    }
+    .padding(.horizontal, 12)
+    .padding(.vertical, 8)
   }
 
   private var list: some View {
@@ -67,18 +77,45 @@ struct CategoryMultiSelectPicker: View {
     .contentShape(.rect)
     .accessibilityLabel(entry.path)
     .accessibilityHint(entry.depth > 0 ? "Subcategory" : "Top-level category")
-    .contextMenu {
-      if isParent {
-        Button("Select all in \(entry.category.name)") {
-          selectedIds.formUnion(categories.subtreeIds(of: entry.category.id))
+    .modifier(
+      SubtreeContextMenu(
+        category: entry.category,
+        isParent: isParent,
+        categories: categories,
+        selectedIds: $selectedIds
+      )
+    )
+  }
+}
+
+/// Conditional context menu attached only to parent rows. Avoids the
+/// "always-attached, empty-on-leaves" pattern, which can intercept
+/// right-click on some SwiftUI versions even when the menu body is empty.
+///
+/// "Select all in <Parent>" intentionally selects the parent itself plus
+/// every descendant — the unit `Categories.subtreeIds(of:)` returns. The
+/// per-row `Toggle` still toggles only the parent for users who want
+/// finer-grained control.
+private struct SubtreeContextMenu: ViewModifier {
+  let category: Category
+  let isParent: Bool
+  let categories: Categories
+  @Binding var selectedIds: Set<UUID>
+
+  func body(content: Content) -> some View {
+    if isParent {
+      content.contextMenu {
+        Button("Select all in \(category.name)") {
+          selectedIds.formUnion(categories.subtreeIds(of: category.id))
         }
-        Button("Deselect all in \(entry.category.name)") {
-          selectedIds.subtract(categories.subtreeIds(of: entry.category.id))
+        Button("Deselect all in \(category.name)") {
+          selectedIds.subtract(categories.subtreeIds(of: category.id))
         }
       }
+    } else {
+      content
     }
   }
-
 }
 
 #Preview {

--- a/Features/Transactions/Views/TransactionFilterView.swift
+++ b/Features/Transactions/Views/TransactionFilterView.swift
@@ -156,15 +156,16 @@ struct TransactionFilterView: View {
     let summary = categories.selectionSummary(for: selectedCategoryIds)
     #if os(macOS)
       // `LabeledContent` is the form-row primitive (label left, value right,
-      // standard hover); the trigger Button lives in the value column with
-      // accent colouring so it reads as activatable, matching System Settings
-      // rows that open sub-panels.
+      // standard hover); the trigger Button lives in the value column. The
+      // value text inherits the system foreground style so it stays visually
+      // consistent with the surrounding Picker / DatePicker / TextField rows
+      // — the row's hover highlight and the popover that opens on click are
+      // the activation cues, not a tinted label.
       LabeledContent("Categories") {
         Button(summary) {
           showCategoryPicker = true
         }
         .buttonStyle(.plain)
-        .foregroundStyle(.tint)
         .popover(isPresented: $showCategoryPicker, arrowEdge: .trailing) {
           CategoryMultiSelectPicker(
             categories: categories,

--- a/Features/Transactions/Views/TransactionFilterView.swift
+++ b/Features/Transactions/Views/TransactionFilterView.swift
@@ -16,6 +16,7 @@ struct TransactionFilterView: View {
   @State private var dateRangeUpperBound: Date?
   @State private var selectedCategoryIds: Set<UUID> = []
   @State private var payeeText: String = ""
+  @State private var showCategoryPicker = false
 
   @Environment(\.dismiss) private var dismiss
 
@@ -39,15 +40,6 @@ struct TransactionFilterView: View {
     _dateRangeUpperBound = State(initialValue: filter.dateRange?.upperBound)
     _selectedCategoryIds = State(initialValue: filter.categoryIds)
     _payeeText = State(initialValue: filter.payee ?? "")
-  }
-
-  private var allCategories: [Category] {
-    var result: [Category] = []
-    for root in categories.roots {
-      result.append(root)
-      result.append(contentsOf: categories.children(of: root.id))
-    }
-    return result
   }
 
   var body: some View {
@@ -153,21 +145,38 @@ struct TransactionFilterView: View {
       if categories.roots.isEmpty {
         Text("No categories available").foregroundStyle(.secondary)
       } else {
-        ForEach(allCategories) { category in
-          Toggle(
-            categories.path(for: category),
-            isOn: Binding(
-              get: { selectedCategoryIds.contains(category.id) },
-              set: { isOn in
-                if isOn {
-                  selectedCategoryIds.insert(category.id)
-                } else {
-                  selectedCategoryIds.remove(category.id)
-                }
-              }))
-        }
+        categoryPickerRow
       }
     }
+  }
+
+  @ViewBuilder
+  private var categoryPickerRow: some View {
+    let summary = categories.selectionSummary(for: selectedCategoryIds)
+    #if os(macOS)
+      Button {
+        showCategoryPicker = true
+      } label: {
+        LabeledContent("Categories", value: summary)
+      }
+      .buttonStyle(.plain)
+      .popover(isPresented: $showCategoryPicker, arrowEdge: .trailing) {
+        CategoryMultiSelectPicker(
+          categories: categories,
+          selectedIds: $selectedCategoryIds
+        )
+        .frame(width: 320, height: 420)
+      }
+    #else
+      NavigationLink {
+        CategoryMultiSelectPicker(
+          categories: categories,
+          selectedIds: $selectedCategoryIds
+        )
+      } label: {
+        LabeledContent("Categories", value: summary)
+      }
+    #endif
   }
 
   private var payeeSection: some View {

--- a/Features/Transactions/Views/TransactionFilterView.swift
+++ b/Features/Transactions/Views/TransactionFilterView.swift
@@ -150,8 +150,7 @@ struct TransactionFilterView: View {
     }
   }
 
-  @ViewBuilder
-  private var categoryPickerRow: some View {
+  @ViewBuilder private var categoryPickerRow: some View {
     // Local `let` is fine before `#if` inside @ViewBuilder — it's a binding,
     // not a result-builder statement.
     let summary = categories.selectionSummary(for: selectedCategoryIds)

--- a/Features/Transactions/Views/TransactionFilterView.swift
+++ b/Features/Transactions/Views/TransactionFilterView.swift
@@ -152,20 +152,27 @@ struct TransactionFilterView: View {
 
   @ViewBuilder
   private var categoryPickerRow: some View {
+    // Local `let` is fine before `#if` inside @ViewBuilder — it's a binding,
+    // not a result-builder statement.
     let summary = categories.selectionSummary(for: selectedCategoryIds)
     #if os(macOS)
-      Button {
-        showCategoryPicker = true
-      } label: {
-        LabeledContent("Categories", value: summary)
-      }
-      .buttonStyle(.plain)
-      .popover(isPresented: $showCategoryPicker, arrowEdge: .trailing) {
-        CategoryMultiSelectPicker(
-          categories: categories,
-          selectedIds: $selectedCategoryIds
-        )
-        .frame(width: 320, height: 420)
+      // `LabeledContent` is the form-row primitive (label left, value right,
+      // standard hover); the trigger Button lives in the value column with
+      // accent colouring so it reads as activatable, matching System Settings
+      // rows that open sub-panels.
+      LabeledContent("Categories") {
+        Button(summary) {
+          showCategoryPicker = true
+        }
+        .buttonStyle(.plain)
+        .foregroundStyle(.tint)
+        .popover(isPresented: $showCategoryPicker, arrowEdge: .trailing) {
+          CategoryMultiSelectPicker(
+            categories: categories,
+            selectedIds: $selectedCategoryIds
+          )
+          .frame(width: 320, height: 420)
+        }
       }
     #else
       NavigationLink {

--- a/MoolahTests/Domain/CategoriesTests.swift
+++ b/MoolahTests/Domain/CategoriesTests.swift
@@ -199,11 +199,11 @@ struct CategoriesTests {
   }
 
   @Test
-  func flatEntryDepthForRootIsZero() {
+  func flatEntryDepthForRootIsZero() throws {
     let root = Category(name: "Groceries")
     let categories = Categories(from: [root])
 
-    let entry = categories.flattenedByPath().first!
+    let entry = try #require(categories.flattenedByPath().first)
 
     #expect(entry.depth == 0)
   }

--- a/MoolahTests/Domain/CategoriesTests.swift
+++ b/MoolahTests/Domain/CategoriesTests.swift
@@ -164,4 +164,61 @@ struct CategoriesTests {
 
     #expect(categories.selectionSummary(for: [UUID(), UUID()]) == "All")
   }
+
+  @Test
+  func flattenedByPathMatchingEmptyQueryReturnsAll() {
+    let groceries = Category(name: "Groceries")
+    let costco = Category(name: "Costco", parentId: groceries.id)
+    let categories = Categories(from: [groceries, costco])
+
+    let entries = categories.flattenedByPath(matching: "")
+
+    #expect(entries.map(\.path) == ["Groceries", "Groceries:Costco"])
+  }
+
+  @Test
+  func flattenedByPathMatchingFiltersBySubstringCaseInsensitive() {
+    let groceries = Category(name: "Groceries")
+    let costco = Category(name: "Costco", parentId: groceries.id)
+    let income = Category(name: "Income")
+    let categories = Categories(from: [groceries, costco, income])
+
+    let entries = categories.flattenedByPath(matching: "cost")
+
+    #expect(entries.map(\.path) == ["Groceries:Costco"])
+  }
+
+  @Test
+  func flattenedByPathMatchingTrimsLeadingAndTrailingWhitespace() {
+    let groceries = Category(name: "Groceries")
+    let categories = Categories(from: [groceries])
+
+    let entries = categories.flattenedByPath(matching: "  Groceries  ")
+
+    #expect(entries.map(\.path) == ["Groceries"])
+  }
+
+  @Test
+  func flatEntryDepthForRootIsZero() {
+    let root = Category(name: "Groceries")
+    let categories = Categories(from: [root])
+
+    let entry = categories.flattenedByPath().first!
+
+    #expect(entry.depth == 0)
+  }
+
+  @Test
+  func flatEntryDepthCountsColonSegments() {
+    let income = Category(name: "Income")
+    let salary = Category(name: "Salary", parentId: income.id)
+    let janet = Category(name: "Janet", parentId: salary.id)
+    let categories = Categories(from: [income, salary, janet])
+
+    let depths = categories.flattenedByPath().reduce(into: [String: Int]()) { acc, entry in
+      acc[entry.path] = entry.depth
+    }
+
+    #expect(depths == ["Income": 0, "Income:Salary": 1, "Income:Salary:Janet": 2])
+  }
 }

--- a/MoolahTests/Domain/CategoriesTests.swift
+++ b/MoolahTests/Domain/CategoriesTests.swift
@@ -129,25 +129,39 @@ struct CategoriesTests {
   }
 
   @Test
-  func selectionSummaryMultipleSelectionReturnsCount() {
-    let g = Category(name: "Groceries")
-    let t = Category(name: "Transport")
-    let i = Category(name: "Income")
-    let categories = Categories(from: [g, t, i])
+  func selectionSummaryTwoSelectionsReturnsCount() {
+    let groceries = Category(name: "Groceries")
+    let transport = Category(name: "Transport")
+    let categories = Categories(from: [groceries, transport])
 
-    #expect(categories.selectionSummary(for: [g.id, t.id]) == "2 selected")
-    #expect(categories.selectionSummary(for: [g.id, t.id, i.id]) == "3 selected")
+    #expect(categories.selectionSummary(for: [groceries.id, transport.id]) == "2 selected")
   }
 
   @Test
-  func selectionSummaryIgnoresOrphanedIds() {
-    let g = Category(name: "Groceries")
-    let categories = Categories(from: [g])
+  func selectionSummaryThreeSelectionsReturnsCount() {
+    let groceries = Category(name: "Groceries")
+    let transport = Category(name: "Transport")
+    let income = Category(name: "Income")
+    let categories = Categories(from: [groceries, transport, income])
+
+    let ids: Set<UUID> = [groceries.id, transport.id, income.id]
+    #expect(categories.selectionSummary(for: ids) == "3 selected")
+  }
+
+  @Test
+  func selectionSummaryWithOnePresentAndOrphanIdReturnsSinglePath() {
+    let groceries = Category(name: "Groceries")
+    let categories = Categories(from: [groceries])
     let orphan = UUID()
 
-    // One real id + one orphan → still "single" semantics, returns the real path.
-    #expect(categories.selectionSummary(for: [g.id, orphan]) == "Groceries")
-    // Two orphans → "All" because no present ids remain.
-    #expect(categories.selectionSummary(for: [orphan, UUID()]) == "All")
+    #expect(categories.selectionSummary(for: [groceries.id, orphan]) == "Groceries")
+  }
+
+  @Test
+  func selectionSummaryWithAllOrphanedIdsReturnsAll() {
+    let groceries = Category(name: "Groceries")
+    let categories = Categories(from: [groceries])
+
+    #expect(categories.selectionSummary(for: [UUID(), UUID()]) == "All")
   }
 }

--- a/MoolahTests/Domain/CategoriesTests.swift
+++ b/MoolahTests/Domain/CategoriesTests.swift
@@ -49,4 +49,54 @@ struct CategoriesTests {
     let categories = Categories(from: [])
     #expect(categories.flattenedByPath().isEmpty)
   }
+
+  @Test
+  func descendantsOfLeafCategoryIsEmpty() {
+    let leaf = Category(name: "Groceries")
+    let categories = Categories(from: [leaf])
+
+    #expect(categories.descendants(of: leaf.id).isEmpty)
+  }
+
+  @Test
+  func descendantsOfParentReturnsDirectChildren() {
+    let groceries = Category(name: "Groceries")
+    let costco = Category(name: "Costco", parentId: groceries.id)
+    let farmers = Category(name: "Farmers Market", parentId: groceries.id)
+    let categories = Categories(from: [groceries, costco, farmers])
+
+    let names = Set(categories.descendants(of: groceries.id).map(\.name))
+
+    #expect(names == ["Costco", "Farmers Market"])
+  }
+
+  @Test
+  func descendantsOfDeepParentReturnsAllLevels() {
+    let income = Category(name: "Income")
+    let salary = Category(name: "Salary", parentId: income.id)
+    let janet = Category(name: "Janet", parentId: salary.id)
+    let adrian = Category(name: "Adrian", parentId: salary.id)
+    let categories = Categories(from: [income, salary, janet, adrian])
+
+    let names = Set(categories.descendants(of: income.id).map(\.name))
+
+    #expect(names == ["Salary", "Janet", "Adrian"])
+  }
+
+  @Test
+  func descendantsExcludesSelfAndUnrelatedSubtrees() {
+    let groceries = Category(name: "Groceries")
+    let costco = Category(name: "Costco", parentId: groceries.id)
+    let transport = Category(name: "Transport")
+    let fuel = Category(name: "Fuel", parentId: transport.id)
+    let categories = Categories(from: [groceries, costco, transport, fuel])
+
+    let descendants = categories.descendants(of: groceries.id)
+    let ids = Set(descendants.map(\.id))
+
+    #expect(ids == [costco.id])
+    #expect(!ids.contains(groceries.id))
+    #expect(!ids.contains(transport.id))
+    #expect(!ids.contains(fuel.id))
+  }
 }

--- a/MoolahTests/Domain/CategoriesTests.swift
+++ b/MoolahTests/Domain/CategoriesTests.swift
@@ -138,17 +138,6 @@ struct CategoriesTests {
   }
 
   @Test
-  func selectionSummaryThreeSelectionsReturnsCount() {
-    let groceries = Category(name: "Groceries")
-    let transport = Category(name: "Transport")
-    let income = Category(name: "Income")
-    let categories = Categories(from: [groceries, transport, income])
-
-    let ids: Set<UUID> = [groceries.id, transport.id, income.id]
-    #expect(categories.selectionSummary(for: ids) == "3 selected")
-  }
-
-  @Test
   func selectionSummaryWithOnePresentAndOrphanIdReturnsSinglePath() {
     let groceries = Category(name: "Groceries")
     let categories = Categories(from: [groceries])
@@ -159,8 +148,9 @@ struct CategoriesTests {
 
   @Test
   func selectionSummaryWithAllOrphanedIdsReturnsAll() {
-    let groceries = Category(name: "Groceries")
-    let categories = Categories(from: [groceries])
+    // Empty categories makes the intent unambiguous: no known ids,
+    // so every selected id is orphaned and the result is "All".
+    let categories = Categories(from: [])
 
     #expect(categories.selectionSummary(for: [UUID(), UUID()]) == "All")
   }
@@ -196,6 +186,19 @@ struct CategoriesTests {
     let entries = categories.flattenedByPath(matching: "  Groceries  ")
 
     #expect(entries.map(\.path) == ["Groceries"])
+  }
+
+  @Test
+  func flattenedByPathMatchingWhitespaceOnlyQueryReturnsAll() {
+    // Docstring contract: a whitespace-only query is treated as empty
+    // after trimming and returns the full result.
+    let groceries = Category(name: "Groceries")
+    let income = Category(name: "Income")
+    let categories = Categories(from: [groceries, income])
+
+    let entries = categories.flattenedByPath(matching: "   ")
+
+    #expect(entries.map(\.path) == ["Groceries", "Income"])
   }
 
   @Test

--- a/MoolahTests/Domain/CategoriesTests.swift
+++ b/MoolahTests/Domain/CategoriesTests.swift
@@ -78,24 +78,35 @@ struct CategoriesTests {
     let adrian = Category(name: "Adrian", parentId: salary.id)
     let categories = Categories(from: [income, salary, janet, adrian])
 
-    let names = Set(categories.descendants(of: income.id).map(\.name))
+    let names = categories.descendants(of: income.id).map(\.name)
 
-    #expect(names == ["Salary", "Janet", "Adrian"])
+    // Depth-first pre-order; salary's children are sorted alphabetically
+    // (Adrian before Janet) by `children(of:)`.
+    #expect(names == ["Salary", "Adrian", "Janet"])
   }
 
   @Test
-  func descendantsExcludesSelfAndUnrelatedSubtrees() {
+  func descendantsExcludeSelf() {
+    let parent = Category(name: "Groceries")
+    let child = Category(name: "Costco", parentId: parent.id)
+    let categories = Categories(from: [parent, child])
+
+    let ids = Set(categories.descendants(of: parent.id).map(\.id))
+
+    #expect(!ids.contains(parent.id))
+  }
+
+  @Test
+  func descendantsExcludeUnrelatedSubtrees() {
     let groceries = Category(name: "Groceries")
     let costco = Category(name: "Costco", parentId: groceries.id)
     let transport = Category(name: "Transport")
     let fuel = Category(name: "Fuel", parentId: transport.id)
     let categories = Categories(from: [groceries, costco, transport, fuel])
 
-    let descendants = categories.descendants(of: groceries.id)
-    let ids = Set(descendants.map(\.id))
+    let ids = Set(categories.descendants(of: groceries.id).map(\.id))
 
     #expect(ids == [costco.id])
-    #expect(!ids.contains(groceries.id))
     #expect(!ids.contains(transport.id))
     #expect(!ids.contains(fuel.id))
   }

--- a/MoolahTests/Domain/CategoriesTests.swift
+++ b/MoolahTests/Domain/CategoriesTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 
 @testable import Moolah
@@ -109,5 +110,44 @@ struct CategoriesTests {
     #expect(ids == [costco.id])
     #expect(!ids.contains(transport.id))
     #expect(!ids.contains(fuel.id))
+  }
+
+  @Test
+  func selectionSummaryEmptyReturnsAll() {
+    let categories = Categories(from: [Category(name: "Groceries")])
+
+    #expect(categories.selectionSummary(for: []) == "All")
+  }
+
+  @Test
+  func selectionSummarySingleSelectionReturnsFullPath() {
+    let income = Category(name: "Income")
+    let salary = Category(name: "Salary", parentId: income.id)
+    let categories = Categories(from: [income, salary])
+
+    #expect(categories.selectionSummary(for: [salary.id]) == "Income:Salary")
+  }
+
+  @Test
+  func selectionSummaryMultipleSelectionReturnsCount() {
+    let g = Category(name: "Groceries")
+    let t = Category(name: "Transport")
+    let i = Category(name: "Income")
+    let categories = Categories(from: [g, t, i])
+
+    #expect(categories.selectionSummary(for: [g.id, t.id]) == "2 selected")
+    #expect(categories.selectionSummary(for: [g.id, t.id, i.id]) == "3 selected")
+  }
+
+  @Test
+  func selectionSummaryIgnoresOrphanedIds() {
+    let g = Category(name: "Groceries")
+    let categories = Categories(from: [g])
+    let orphan = UUID()
+
+    // One real id + one orphan → still "single" semantics, returns the real path.
+    #expect(categories.selectionSummary(for: [g.id, orphan]) == "Groceries")
+    // Two orphans → "All" because no present ids remain.
+    #expect(categories.selectionSummary(for: [orphan, UUID()]) == "All")
   }
 }

--- a/MoolahTests/Domain/CategoriesTests.swift
+++ b/MoolahTests/Domain/CategoriesTests.swift
@@ -221,4 +221,56 @@ struct CategoriesTests {
 
     #expect(depths == ["Income": 0, "Income:Salary": 1, "Income:Salary:Janet": 2])
   }
+
+  @Test
+  func subtreeIdsOfLeafReturnsOnlyTheLeaf() {
+    let leaf = Category(name: "Groceries")
+    let categories = Categories(from: [leaf])
+
+    #expect(categories.subtreeIds(of: leaf.id) == [leaf.id])
+  }
+
+  @Test
+  func subtreeIdsOfParentIncludesParentAndAllDescendants() {
+    let income = Category(name: "Income")
+    let salary = Category(name: "Salary", parentId: income.id)
+    let janet = Category(name: "Janet", parentId: salary.id)
+    let categories = Categories(from: [income, salary, janet])
+
+    #expect(categories.subtreeIds(of: income.id) == [income.id, salary.id, janet.id])
+  }
+
+  @Test
+  func subtreeIdsOfMissingIdReturnsOnlyTheMissingId() {
+    // Out-of-tree behaviour: returns the id alone (no descendants found).
+    // Callers using it for selection still get a correct, no-op-ish result.
+    let categories = Categories(from: [])
+    let phantom = UUID()
+
+    #expect(categories.subtreeIds(of: phantom) == [phantom])
+  }
+
+  @Test
+  func hasChildrenReturnsFalseForLeaf() {
+    let leaf = Category(name: "Groceries")
+    let categories = Categories(from: [leaf])
+
+    #expect(categories.hasChildren(leaf.id) == false)
+  }
+
+  @Test
+  func hasChildrenReturnsTrueForParent() {
+    let income = Category(name: "Income")
+    let salary = Category(name: "Salary", parentId: income.id)
+    let categories = Categories(from: [income, salary])
+
+    #expect(categories.hasChildren(income.id) == true)
+  }
+
+  @Test
+  func hasChildrenReturnsFalseForMissingId() {
+    let categories = Categories(from: [])
+
+    #expect(categories.hasChildren(UUID()) == false)
+  }
 }

--- a/plans/2026-04-30-category-multi-select-design.md
+++ b/plans/2026-04-30-category-multi-select-design.md
@@ -1,0 +1,137 @@
+# Category multi-select for transaction filter — design
+
+## Goal
+
+Replace the inline-toggle Categories section in `TransactionFilterView` with a dedicated multi-select picker that scales to any number of categories. The current section renders one `Toggle` per category in the same `Form` as five other sections; with a real-world category list it grows past full-screen height, pushes toolbar buttons (Cancel / Apply / Clear All) out of view, and the dialog never reaches a usable size.
+
+## Non-goals
+
+- **No filter-semantics change.** Selection stays a flat `Set<UUID>`. Selecting a parent matches only transactions tagged with that parent — descendants are not implicitly included. The semantics question is real but separable; this design fixes the layout problem first.
+- **No data-model change.** `Category`, `Categories`, `TransactionFilter`, and `Categories.path(for:)` are unchanged.
+- **No change to other category pickers.** The single-category autocomplete used in `AddBudgetLineItemSheet` and `RuleEditorActionRow` keeps its current shape; this picker is for multi-select only.
+- **No keyboard-shortcut design.** Tab/arrow navigation works for free via SwiftUI focus; we don't add custom shortcuts.
+
+## User flow
+
+1. User opens the transaction filter sheet.
+2. The Categories section shows a single row: `Categories  [summary]  ›`.
+3. User taps the row.
+   - **macOS:** a popover anchors to the row.
+   - **iOS:** the picker pushes onto the existing `NavigationStack` inside the sheet.
+4. The picker shows the category hierarchy with checkboxes. The user toggles individual categories or right-clicks / long-presses a parent to reveal "Select all in <Parent>" / "Deselect all in <Parent>".
+5. User dismisses the popover (click-away on macOS, back button on iOS).
+6. The trigger row's summary updates to reflect the new selection.
+
+The filter sheet's existing **Apply** / **Cancel** / **Clear All** buttons are unchanged. As toggles flip the picker mutates the sheet-local `selectedCategoryIds` state (same as today's inline toggles); the underlying filter only changes when the user presses **Apply**. This is identical to current behaviour — there is no new "buffered vs live" semantic.
+
+## Components
+
+### 1. Trigger row in `TransactionFilterView`
+
+The Categories section becomes:
+
+```
+Section("Categories") {
+  Button { showCategoryPicker = true } label: {
+    LabeledContent("Categories", value: categorySelectionSummary)
+  }
+  .buttonStyle(.plain)
+  .popover(isPresented: $showCategoryPicker, …) {  // macOS
+    CategoryMultiSelectPicker(…)
+  }
+}
+```
+
+On iOS, the same row is wrapped in a `NavigationLink` instead of a popover binding (single `#if os(iOS)` split — the picker view itself is the same).
+
+The selection summary string:
+- empty set → `"All"`
+- exactly 1 → `categories.path(for: theOne)`
+- 2+ → `"\(N) selected"`
+
+### 2. `CategoryMultiSelectPicker`
+
+A new view at `Features/Transactions/Views/CategoryMultiSelectPicker.swift`. Props:
+
+- `categories: Categories`
+- `selectedIds: Binding<Set<UUID>>`
+
+Layout, top to bottom:
+- Title bar with `Clear` button (disabled when `selectedIds.isEmpty`).
+- `.searchable` text field.
+- A `List` of category rows.
+
+**Row rendering:**
+- No active search → walk the hierarchy: each root row, followed by its children indented one level. Same flattening pass as the current `allCategories` computed property, but the row indents children so the tree shape is visible.
+- Active search → flat list of matches against `categories.path(for:)` (substring, case-insensitive). Each row shows the full path so users don't lose context. No indentation in this mode.
+
+**Per-row controls:**
+- A `Toggle` (checkbox style on macOS, switch on iOS — SwiftUI's defaults already do this) bound to `selectedIds.contains(id)`.
+- For parent rows only, a `.contextMenu` with two items:
+  - `Select all in <Parent>` — inserts the parent's id and every descendant id into `selectedIds`.
+  - `Deselect all in <Parent>` — removes the parent's id and every descendant id.
+
+The descendant collection lives in a new helper on `Categories`:
+
+```swift
+extension Categories {
+  func descendants(of id: UUID) -> [Category]   // depth-first, excludes self
+}
+```
+
+It walks `children(of:)` recursively. Today's hierarchy is one level deep, but the helper is written for arbitrary depth so it doesn't break if/when nesting deepens. The picker calls `selectedIds.formUnion([id] + descendants(of: id).map(\.id))` for "Select all" and the symmetric `subtract` for "Deselect all". Putting these on `Categories` keeps the view thin (per CLAUDE.md's thin-view rule) and makes them unit-testable without rendering UI.
+
+A second helper produces the trigger-row summary, also on `Categories`:
+
+```swift
+extension Categories {
+  func selectionSummary(for selected: Set<UUID>) -> String
+}
+```
+
+It returns `"All"` for empty, the full path for exactly one **still-present** id, and `"\(N) selected"` for two or more present ids (orphaned ids are excluded from the count — see Risks).
+
+### 3. Sizing
+
+- macOS popover: explicit `.frame(width: 320, height: 420)` on the picker so the popover has a stable size. The `List` scrolls internally.
+- iOS pushed view: no frame override — fills the sheet.
+
+## Wiring back to `TransactionFilterView`
+
+`TransactionFilterView` already owns `@State private var selectedCategoryIds: Set<UUID>`. The picker writes to a `Binding` of that state. The existing `applyFilter()` reads it unchanged. Removing the inline toggle list also removes `allCategories` (it moves into the picker).
+
+## Testing
+
+- **`CategoriesMultiSelectTests` (new, Swift Testing, in `MoolahTests/Domain/`).** Pure unit tests against the new `Categories` extension helpers — no view rendering. Drives the helpers with a small in-memory `Categories` value:
+  - `descendants(of:)` returns every descendant in a deeper-than-one-level tree, excludes self, and returns `[]` for a leaf.
+  - "Select all" path (caller-side): `formUnion([id] + descendants(of: id).map(\.id))` adds parent + all descendants and leaves unrelated selections alone.
+  - "Deselect all" path: `subtract([id] + descendants(of: id).map(\.id))` is the exact inverse.
+  - `selectionSummary(for:)`: empty → `"All"`, 1 present id → full path, 2+ present ids → `"N selected"`, orphaned ids excluded from count.
+- **No new tests for search filtering.** Substring match against `categories.path(for:)` is a one-liner using existing API; test coverage on the helper exists already.
+- **Existing tests stay green.** `TransactionFilterTests` and `TransactionRepositoryFilterTests` are unaffected — semantics don't change.
+- **Manual verification on macOS:**
+  - Filter sheet opens at its previous size with a real category list (currently broken).
+  - Trigger row's summary text updates as toggles flip.
+  - Popover sizes correctly, search filters as typed, right-click on a parent reveals the context menu, "Select all in <Parent>" toggles the whole subtree.
+  - Cancel / Apply / Clear All toolbar buttons remain visible and reachable.
+- **Manual verification on iOS Simulator:** push/pop, long-press context menu, sheet-internal navigation back-button.
+
+## Risks and edge cases
+
+- **Empty categories.** The picker shows the existing "No categories available" placeholder — same string the inline section already used.
+- **Search clearing selection state.** Toggles in the filtered list operate on the same `selectedIds` set, so dropping out of search doesn't lose selection. Verified by the helper test that selection mutations don't depend on which view is rendered.
+- **Long category paths.** `Truncated mode` (`.lineLimit(1)` + `.truncationMode(.middle)`) on the row label and on the trigger-row summary. The summary already handles 2+ via a count, so the truncation only matters for the single-selection case.
+- **Popover dismissal on outside click.** SwiftUI handles this; selection is already committed live, so no special "are you sure" handling is needed.
+- **Stale selection.** If a category is deleted after selection (rare), the id stays in `selectedIds` but no row renders for it. The existing filter already tolerates orphaned ids; the trigger summary just counts the still-present ids — see Implementation Note below.
+- **Discoverability of the context menu.** Acknowledged trade-off; rejected the visible-affordance alternatives (per-row "select subtree" buttons, `DisclosureGroup` parent rows) because both clutter every parent row for an action most users invoke rarely. Right-click / long-press is the standard secondary-action gesture on both platforms.
+
+**Implementation note.** The summary string counts ids that are present in `categories.byId` (i.e., still exist). Orphaned ids in `selectedIds` are excluded from the count; the filter still applies them, but the user-visible "N selected" matches what's actually pickable. This is a one-line filter and gets a unit test.
+
+## Rollout
+
+Single PR. No migration, no feature flag — pure UI restructure on top of unchanged state. The inline-toggle code path is removed, not deprecated; there's no backwards-compatibility surface to preserve.
+
+## Out of scope (future work)
+
+- **Subtree-as-semantics.** Making "select Groceries" implicitly match "Groceries → Costco" too is a `TransactionFilter` change, not a UI change. Worth doing, but separately, with its own test impact on `TransactionRepositoryFilterTests`.
+- **Other filter sheets.** If/when reports or analysis grow a multi-category filter, they reuse `CategoryMultiSelectPicker`. Not built speculatively; refactor when the second consumer arrives.

--- a/plans/2026-04-30-category-multi-select-implementation.md
+++ b/plans/2026-04-30-category-multi-select-implementation.md
@@ -1,0 +1,685 @@
+# Category multi-select picker — implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the inline-toggle Categories section in `TransactionFilterView` with a dedicated multi-select picker (popover on macOS, NavigationLink push on iOS) that scales to any number of categories.
+
+**Architecture:** Two pure helpers on `Categories` (`descendants(of:)`, `selectionSummary(for:)`) keep mutation/formatting logic testable outside the view. The picker view (`CategoryMultiSelectPicker`) renders a searchable list of categories from `Categories.flattenedByPath()`, indented by colon-count when idle and flat with full paths when filtering. Parent rows expose a `.contextMenu` with subtree select/deselect; the primary toggle still mutates a single id at a time. The filter sheet's existing `selectedCategoryIds` state and Apply/Cancel/Clear-All toolbar are unchanged.
+
+**Tech Stack:** SwiftUI (iOS 26+, macOS 26+), Swift Testing for unit tests, no new dependencies.
+
+**Spec:** `plans/2026-04-30-category-multi-select-design.md` (committed in this branch).
+
+**Working directory:** This plan is to be executed inside the worktree at `.worktrees/category-multi-select/` on branch `design/category-multi-select`. All `git`, `just`, and file paths are relative to that worktree root.
+
+---
+
+## File map
+
+- **Modify** `Domain/Models/Category.swift` — add two methods on `Categories`: `descendants(of:)`, `selectionSummary(for:)`.
+- **Modify** `MoolahTests/Domain/CategoriesTests.swift` — add tests for both helpers.
+- **Create** `Features/Transactions/Views/CategoryMultiSelectPicker.swift` — the searchable, hierarchical multi-select picker view, including its `#Preview`.
+- **Modify** `Features/Transactions/Views/TransactionFilterView.swift` — replace the inline toggle list with a single trigger row hosting the picker (popover on macOS, `NavigationLink` on iOS); remove the now-unused `allCategories` computed property.
+
+No `project.yml` edits required — `Features/` and `MoolahTests/` are already auto-globbed, and `just test` / `just build-mac` regenerate the Xcode project automatically.
+
+---
+
+## Task 1: Add `Categories.descendants(of:)` (TDD)
+
+**Files:**
+- Modify: `MoolahTests/Domain/CategoriesTests.swift`
+- Modify: `Domain/Models/Category.swift`
+
+- [ ] **Step 1.1: Write the failing tests**
+
+Append to `MoolahTests/Domain/CategoriesTests.swift` (inside `struct CategoriesTests { … }`, before the closing brace):
+
+```swift
+@Test
+func descendantsOfLeafCategoryIsEmpty() {
+  let leaf = Category(name: "Groceries")
+  let categories = Categories(from: [leaf])
+
+  #expect(categories.descendants(of: leaf.id).isEmpty)
+}
+
+@Test
+func descendantsOfParentReturnsDirectChildren() {
+  let groceries = Category(name: "Groceries")
+  let costco = Category(name: "Costco", parentId: groceries.id)
+  let farmers = Category(name: "Farmers Market", parentId: groceries.id)
+  let categories = Categories(from: [groceries, costco, farmers])
+
+  let names = Set(categories.descendants(of: groceries.id).map(\.name))
+
+  #expect(names == ["Costco", "Farmers Market"])
+}
+
+@Test
+func descendantsOfDeepParentReturnsAllLevels() {
+  let income = Category(name: "Income")
+  let salary = Category(name: "Salary", parentId: income.id)
+  let janet = Category(name: "Janet", parentId: salary.id)
+  let adrian = Category(name: "Adrian", parentId: salary.id)
+  let categories = Categories(from: [income, salary, janet, adrian])
+
+  let names = Set(categories.descendants(of: income.id).map(\.name))
+
+  #expect(names == ["Salary", "Janet", "Adrian"])
+}
+
+@Test
+func descendantsExcludesSelfAndUnrelatedSubtrees() {
+  let groceries = Category(name: "Groceries")
+  let costco = Category(name: "Costco", parentId: groceries.id)
+  let transport = Category(name: "Transport")
+  let fuel = Category(name: "Fuel", parentId: transport.id)
+  let categories = Categories(from: [groceries, costco, transport, fuel])
+
+  let descendants = categories.descendants(of: groceries.id)
+  let ids = Set(descendants.map(\.id))
+
+  #expect(ids == [costco.id])
+  #expect(!ids.contains(groceries.id))
+  #expect(!ids.contains(transport.id))
+  #expect(!ids.contains(fuel.id))
+}
+```
+
+- [ ] **Step 1.2: Run the tests and confirm they fail**
+
+```bash
+mkdir -p .agent-tmp
+just test-mac CategoriesTests 2>&1 | tee .agent-tmp/cat-tests.txt
+grep -i 'failed\|error:' .agent-tmp/cat-tests.txt
+```
+
+Expected: build error — "value of type 'Categories' has no member 'descendants'".
+
+- [ ] **Step 1.3: Implement `descendants(of:)`**
+
+Append inside the `Categories` struct in `Domain/Models/Category.swift`, immediately before the `FlatEntry` declaration:
+
+```swift
+/// All descendants of a given category, depth-first; excludes the category itself.
+func descendants(of parentId: UUID) -> [Category] {
+  var result: [Category] = []
+  for child in children(of: parentId) {
+    result.append(child)
+    result.append(contentsOf: descendants(of: child.id))
+  }
+  return result
+}
+```
+
+- [ ] **Step 1.4: Re-run tests and confirm they pass**
+
+```bash
+just test-mac CategoriesTests 2>&1 | tee .agent-tmp/cat-tests.txt
+grep -i 'failed\|error:' .agent-tmp/cat-tests.txt
+```
+
+Expected: no output from grep (zero failures, zero errors).
+
+- [ ] **Step 1.5: Commit**
+
+```bash
+git -C . add Domain/Models/Category.swift MoolahTests/Domain/CategoriesTests.swift
+git -C . commit -m "feat(categories): add descendants(of:) helper"
+```
+
+---
+
+## Task 2: Add `Categories.selectionSummary(for:)` (TDD)
+
+**Files:**
+- Modify: `MoolahTests/Domain/CategoriesTests.swift`
+- Modify: `Domain/Models/Category.swift`
+
+- [ ] **Step 2.1: Write the failing tests**
+
+Append to `MoolahTests/Domain/CategoriesTests.swift` (inside `struct CategoriesTests { … }`):
+
+```swift
+@Test
+func selectionSummaryEmptyReturnsAll() {
+  let categories = Categories(from: [Category(name: "Groceries")])
+
+  #expect(categories.selectionSummary(for: []) == "All")
+}
+
+@Test
+func selectionSummarySingleSelectionReturnsFullPath() {
+  let income = Category(name: "Income")
+  let salary = Category(name: "Salary", parentId: income.id)
+  let categories = Categories(from: [income, salary])
+
+  #expect(categories.selectionSummary(for: [salary.id]) == "Income:Salary")
+}
+
+@Test
+func selectionSummaryMultipleSelectionReturnsCount() {
+  let g = Category(name: "Groceries")
+  let t = Category(name: "Transport")
+  let i = Category(name: "Income")
+  let categories = Categories(from: [g, t, i])
+
+  #expect(categories.selectionSummary(for: [g.id, t.id]) == "2 selected")
+  #expect(categories.selectionSummary(for: [g.id, t.id, i.id]) == "3 selected")
+}
+
+@Test
+func selectionSummaryIgnoresOrphanedIds() {
+  let g = Category(name: "Groceries")
+  let categories = Categories(from: [g])
+  let orphan = UUID()
+
+  // One real id + one orphan → still "single" semantics, returns the real path.
+  #expect(categories.selectionSummary(for: [g.id, orphan]) == "Groceries")
+  // Two orphans → "All" because no present ids remain.
+  #expect(categories.selectionSummary(for: [orphan, UUID()]) == "All")
+}
+```
+
+- [ ] **Step 2.2: Run the tests and confirm they fail**
+
+```bash
+just test-mac CategoriesTests 2>&1 | tee .agent-tmp/cat-tests.txt
+grep -i 'failed\|error:' .agent-tmp/cat-tests.txt
+```
+
+Expected: build error — "value of type 'Categories' has no member 'selectionSummary'".
+
+- [ ] **Step 2.3: Implement `selectionSummary(for:)`**
+
+Append inside the `Categories` struct in `Domain/Models/Category.swift`, immediately after the `descendants(of:)` method:
+
+```swift
+/// Human-readable summary of a multi-category selection. Returns
+/// `"All"` when nothing is selected (or every selected id is orphaned),
+/// the full path when exactly one selected id is still present, and
+/// `"\(N) selected"` when two or more selected ids are still present.
+func selectionSummary(for selectedIds: Set<UUID>) -> String {
+  let presentIds = selectedIds.filter { byId[$0] != nil }
+  switch presentIds.count {
+  case 0:
+    return "All"
+  case 1:
+    let id = presentIds.first!  // safe: count == 1
+    return path(for: byId[id]!)
+  default:
+    return "\(presentIds.count) selected"
+  }
+}
+```
+
+(The two `!` are gated by the `count` check above; this matches the project's existing optional-handling style for guarded lookups in `path(for:)`.)
+
+- [ ] **Step 2.4: Re-run tests and confirm they pass**
+
+```bash
+just test-mac CategoriesTests 2>&1 | tee .agent-tmp/cat-tests.txt
+grep -i 'failed\|error:' .agent-tmp/cat-tests.txt
+```
+
+Expected: no output from grep.
+
+- [ ] **Step 2.5: Commit**
+
+```bash
+git -C . add Domain/Models/Category.swift MoolahTests/Domain/CategoriesTests.swift
+git -C . commit -m "feat(categories): add selectionSummary(for:) helper"
+```
+
+---
+
+## Task 3: Build `CategoryMultiSelectPicker` view (no context menu yet)
+
+**Files:**
+- Create: `Features/Transactions/Views/CategoryMultiSelectPicker.swift`
+
+- [ ] **Step 3.1: Create the picker view**
+
+Create `Features/Transactions/Views/CategoryMultiSelectPicker.swift` with:
+
+```swift
+import SwiftUI
+
+/// Searchable, hierarchical multi-select picker for categories.
+/// Hosted as a popover on macOS and pushed via `NavigationLink` on iOS.
+struct CategoryMultiSelectPicker: View {
+  let categories: Categories
+  @Binding var selectedIds: Set<UUID>
+
+  @State private var searchText: String = ""
+
+  var body: some View {
+    VStack(spacing: 0) {
+      header
+      list
+    }
+    .searchable(text: $searchText, prompt: "Search categories")
+    #if os(iOS)
+      .navigationTitle("Categories")
+      .navigationBarTitleDisplayMode(.inline)
+    #endif
+  }
+
+  private var header: some View {
+    HStack {
+      Spacer()
+      Button("Clear") { selectedIds.removeAll() }
+        .disabled(selectedIds.isEmpty)
+    }
+    .padding(.horizontal)
+    .padding(.vertical, 8)
+  }
+
+  private var list: some View {
+    List {
+      if categories.roots.isEmpty {
+        Text("No categories available").foregroundStyle(.secondary)
+      } else if visibleEntries.isEmpty {
+        Text("No matches").foregroundStyle(.secondary)
+      } else {
+        ForEach(visibleEntries, id: \.category.id) { entry in
+          row(for: entry)
+        }
+      }
+    }
+  }
+
+  private var visibleEntries: [Categories.FlatEntry] {
+    let all = categories.flattenedByPath()
+    guard !searchText.isEmpty else { return all }
+    return all.filter { $0.path.localizedCaseInsensitiveContains(searchText) }
+  }
+
+  private func indentLevel(for entry: Categories.FlatEntry) -> Int {
+    searchText.isEmpty ? entry.path.split(separator: ":").count - 1 : 0
+  }
+
+  @ViewBuilder
+  private func row(for entry: Categories.FlatEntry) -> some View {
+    let label = searchText.isEmpty ? entry.category.name : entry.path
+    Toggle(
+      isOn: Binding(
+        get: { selectedIds.contains(entry.category.id) },
+        set: { isOn in
+          if isOn {
+            selectedIds.insert(entry.category.id)
+          } else {
+            selectedIds.remove(entry.category.id)
+          }
+        }
+      )
+    ) {
+      Text(label)
+        .lineLimit(1)
+        .truncationMode(.middle)
+        .padding(.leading, CGFloat(indentLevel(for: entry) * 16))
+    }
+  }
+}
+
+#Preview {
+  let groceries = Category(name: "Groceries")
+  let costco = Category(name: "Costco", parentId: groceries.id)
+  let farmers = Category(name: "Farmers Market", parentId: groceries.id)
+  let transport = Category(name: "Transport")
+  let fuel = Category(name: "Fuel", parentId: transport.id)
+
+  let categories = Categories(from: [
+    groceries, costco, farmers, transport, fuel,
+  ])
+
+  @Previewable @State var selected: Set<UUID> = [costco.id]
+
+  return CategoryMultiSelectPicker(
+    categories: categories,
+    selectedIds: $selected
+  )
+  .frame(width: 320, height: 420)
+}
+```
+
+- [ ] **Step 3.2: Build and verify the preview renders**
+
+```bash
+just build-mac 2>&1 | tee .agent-tmp/build.txt
+grep -i 'error:\|warning:' .agent-tmp/build.txt | grep -v "Preview"
+```
+
+Expected: no output (zero non-`#Preview` warnings, zero errors). If warnings appear in user code, fix them per CLAUDE.md "Common Warning Fixes" before continuing.
+
+- [ ] **Step 3.3: Manual visual check via Xcode preview**
+
+Open `CategoryMultiSelectPicker.swift` in Xcode and confirm the preview canvas renders: a list of `Groceries → Costco → Farmers Market → Transport → Fuel` with `Costco` toggled on, indented children, a working "Clear" button, and a search field that filters as you type.
+
+(The user iterates on UI via `#Preview` per their workflow, not by relaunching the app.)
+
+- [ ] **Step 3.4: Commit**
+
+```bash
+git -C . add Features/Transactions/Views/CategoryMultiSelectPicker.swift
+git -C . commit -m "feat(transactions): add CategoryMultiSelectPicker view"
+```
+
+---
+
+## Task 4: Wire the picker into `TransactionFilterView`
+
+**Files:**
+- Modify: `Features/Transactions/Views/TransactionFilterView.swift`
+
+- [ ] **Step 4.1: Add picker presentation state and remove `allCategories`**
+
+In `TransactionFilterView.swift`, add a new `@State` declaration alongside the existing ones (right after `@State private var payeeText: String = ""`):
+
+```swift
+@State private var showCategoryPicker = false
+```
+
+Then **remove** the `allCategories` computed property (currently lines 44–51):
+
+```swift
+// DELETE THIS BLOCK:
+private var allCategories: [Category] {
+  var result: [Category] = []
+  for root in categories.roots {
+    result.append(root)
+    result.append(contentsOf: categories.children(of: root.id))
+  }
+  return result
+}
+```
+
+- [ ] **Step 4.2: Replace `categoriesSection` with the trigger row**
+
+Replace the existing `categoriesSection` (currently lines 151–171) with:
+
+```swift
+private var categoriesSection: some View {
+  Section("Categories") {
+    if categories.roots.isEmpty {
+      Text("No categories available").foregroundStyle(.secondary)
+    } else {
+      categoryPickerRow
+    }
+  }
+}
+
+@ViewBuilder
+private var categoryPickerRow: some View {
+  let summary = categories.selectionSummary(for: selectedCategoryIds)
+  #if os(macOS)
+    Button {
+      showCategoryPicker = true
+    } label: {
+      LabeledContent("Categories", value: summary)
+    }
+    .buttonStyle(.plain)
+    .popover(isPresented: $showCategoryPicker, arrowEdge: .trailing) {
+      CategoryMultiSelectPicker(
+        categories: categories,
+        selectedIds: $selectedCategoryIds
+      )
+      .frame(width: 320, height: 420)
+    }
+  #else
+    NavigationLink {
+      CategoryMultiSelectPicker(
+        categories: categories,
+        selectedIds: $selectedCategoryIds
+      )
+    } label: {
+      LabeledContent("Categories", value: summary)
+    }
+  #endif
+}
+```
+
+- [ ] **Step 4.3: Build and check warnings**
+
+```bash
+just build-mac 2>&1 | tee .agent-tmp/build.txt
+grep -i 'error:\|warning:' .agent-tmp/build.txt | grep -v "Preview"
+```
+
+Expected: no output. Fix any warnings before continuing.
+
+- [ ] **Step 4.4: Manual verification on macOS**
+
+```bash
+just run-mac
+```
+
+In the app:
+- Open the transaction list, click the Filter toolbar button. Sheet opens at its previous size; toolbar buttons (Cancel / Apply / Clear All) are visible.
+- The Categories section shows a single row with the summary ("All" with no selection).
+- Click the row → popover opens anchored to the row.
+- Toggle 2+ categories → close popover → row reads "N selected".
+- Toggle exactly one → row reads the full path of that category.
+- Type in the popover search field → list filters and shows full paths.
+- Click "Clear" in the popover header → all selections cleared, summary reverts to "All".
+- Click Apply → filter applies, sheet closes.
+
+If anything is off, stop and fix before proceeding.
+
+- [ ] **Step 4.5: Commit**
+
+```bash
+git -C . add Features/Transactions/Views/TransactionFilterView.swift
+git -C . commit -m "feat(transactions): host CategoryMultiSelectPicker in filter sheet"
+```
+
+---
+
+## Task 5: Add subtree shortcut via `.contextMenu` on parent rows
+
+**Files:**
+- Modify: `Features/Transactions/Views/CategoryMultiSelectPicker.swift`
+
+- [ ] **Step 5.1: Add the context menu to parent rows**
+
+In `CategoryMultiSelectPicker.swift`, replace the `row(for:)` method with:
+
+```swift
+@ViewBuilder
+private func row(for entry: Categories.FlatEntry) -> some View {
+  let label = searchText.isEmpty ? entry.category.name : entry.path
+  let isParent = !categories.children(of: entry.category.id).isEmpty
+  Toggle(
+    isOn: Binding(
+      get: { selectedIds.contains(entry.category.id) },
+      set: { isOn in
+        if isOn {
+          selectedIds.insert(entry.category.id)
+        } else {
+          selectedIds.remove(entry.category.id)
+        }
+      }
+    )
+  ) {
+    Text(label)
+      .lineLimit(1)
+      .truncationMode(.middle)
+      .padding(.leading, CGFloat(indentLevel(for: entry) * 16))
+  }
+  .contextMenu {
+    if isParent {
+      Button("Select all in \(entry.category.name)") {
+        selectSubtree(of: entry.category)
+      }
+      Button("Deselect all in \(entry.category.name)") {
+        deselectSubtree(of: entry.category)
+      }
+    }
+  }
+}
+
+private func selectSubtree(of category: Category) {
+  selectedIds.insert(category.id)
+  selectedIds.formUnion(categories.descendants(of: category.id).map(\.id))
+}
+
+private func deselectSubtree(of category: Category) {
+  selectedIds.remove(category.id)
+  selectedIds.subtract(categories.descendants(of: category.id).map(\.id))
+}
+```
+
+The `.contextMenu` is attached unconditionally so SwiftUI can register the gesture, but its body only renders the buttons when `isParent` is true. For leaf rows the menu is empty and SwiftUI does not present it.
+
+- [ ] **Step 5.2: Build and check warnings**
+
+```bash
+just build-mac 2>&1 | tee .agent-tmp/build.txt
+grep -i 'error:\|warning:' .agent-tmp/build.txt | grep -v "Preview"
+```
+
+Expected: no output.
+
+- [ ] **Step 5.3: Manual verification on macOS**
+
+```bash
+just run-mac
+```
+
+In the filter sheet's category popover:
+- Right-click a parent row (e.g. `Groceries`) → menu shows `Select all in Groceries` and `Deselect all in Groceries`.
+- Choose `Select all in Groceries` → parent and every descendant become selected; the Apply-row summary updates accordingly when you close the popover.
+- Choose `Deselect all in Groceries` → parent and every descendant become deselected; unrelated selections (e.g. categories under `Transport`) are untouched.
+- Right-click a leaf row (e.g. `Costco`) → no menu appears (or appears empty depending on SwiftUI behaviour) — primary toggle still works.
+
+- [ ] **Step 5.4: Commit**
+
+```bash
+git -C . add Features/Transactions/Views/CategoryMultiSelectPicker.swift
+git -C . commit -m "feat(transactions): add subtree context-menu to category picker"
+```
+
+---
+
+## Task 6: Format, full test run, review agents
+
+- [ ] **Step 6.1: Format**
+
+```bash
+just format
+git -C . diff --stat
+```
+
+If the diff touches files outside this PR's scope, stop — that means a baseline drift exists pre-PR; revert those files and re-investigate. If the diff only touches files modified in Tasks 1–5, stage them.
+
+- [ ] **Step 6.2: Format check**
+
+```bash
+just format-check
+```
+
+Expected: exit 0, no output. If it fails, fix the underlying code (do **not** modify `.swiftlint-baseline.yml` — see CLAUDE.md and the `fixing-format-check` skill).
+
+- [ ] **Step 6.3: Run the full test suite**
+
+```bash
+just test 2>&1 | tee .agent-tmp/test-output.txt
+grep -i 'failed\|error:' .agent-tmp/test-output.txt
+```
+
+Expected: no output from grep — both iOS and macOS targets green. If anything fails, fix before continuing.
+
+- [ ] **Step 6.4: Run the `code-review` agent**
+
+Invoke `@code-review` against the touched files (`Domain/Models/Category.swift`, `MoolahTests/Domain/CategoriesTests.swift`, `Features/Transactions/Views/CategoryMultiSelectPicker.swift`, `Features/Transactions/Views/TransactionFilterView.swift`). Apply every Critical / Important / Minor finding (per memory: don't dismiss findings, don't skip Minors). If a finding is genuinely out of scope, ask the user before deferring.
+
+- [ ] **Step 6.5: Run the `ui-review` agent**
+
+Invoke `@ui-review` against `CategoryMultiSelectPicker.swift` and the modified `TransactionFilterView.swift`. Apply findings.
+
+- [ ] **Step 6.6: Re-run tests and format-check after review fixes**
+
+```bash
+just format-check && just test 2>&1 | tee .agent-tmp/test-output.txt
+grep -i 'failed\|error:' .agent-tmp/test-output.txt
+```
+
+Expected: no output from grep, format-check exits 0.
+
+- [ ] **Step 6.7: Commit any review fixes**
+
+If the review agents prompted fixes, commit them with a message describing what was changed (e.g. `refactor(transactions): apply review feedback on category picker`).
+
+- [ ] **Step 6.8: Clean up `.agent-tmp/`**
+
+```bash
+rm -f .agent-tmp/cat-tests.txt .agent-tmp/build.txt .agent-tmp/test-output.txt
+```
+
+---
+
+## Task 7: Open PR and add to merge queue
+
+- [ ] **Step 7.1: Push the branch (explicit src:dst form, no upstream tracking)**
+
+The worktree was created with `--no-track`, so the branch is not tracking origin/main. Use the explicit `<src>:<dst>` form to avoid any accidental push into a parent branch (per CLAUDE.md "Stacked-PR worktrees" guidance):
+
+```bash
+git -C . push origin design/category-multi-select:design/category-multi-select
+```
+
+- [ ] **Step 7.2: Open the PR**
+
+```bash
+gh pr create \
+  --base main \
+  --head design/category-multi-select \
+  --title "Multi-select picker for transaction filter categories" \
+  --body "$(cat <<'EOF'
+## Summary
+- Replace the inline-toggle Categories section in `TransactionFilterView` with a single trigger row that hosts a dedicated multi-select picker (popover on macOS, NavigationLink push on iOS). With many categories the old section made the filter sheet taller than the screen and pushed the toolbar out of reach; the new picker scales to any number of categories.
+- Add two pure helpers on `Categories` so the view stays thin: `descendants(of:)` for subtree traversal and `selectionSummary(for:)` for the trigger-row label. Both are unit-tested.
+- Parent rows expose a `.contextMenu` with "Select all in …" / "Deselect all in …" — a discoverable subtree shortcut without per-row chrome. Selection semantics are unchanged: `selectedCategoryIds` stays a flat `Set<UUID>` and Apply still gates the filter.
+
+Design spec: `plans/2026-04-30-category-multi-select-design.md`.
+
+## Test plan
+- [x] `just test` passes on iOS and macOS (new helper tests in `CategoriesTests`).
+- [x] `just format-check` clean.
+- [x] Manual macOS: filter sheet opens at its prior size with toolbar visible; popover anchors to the row; search filters with full-path labels; Clear button works; right-click a parent → "Select all in …" toggles parent + all descendants.
+- [x] Manual iOS Simulator: `NavigationLink` push shows the picker full-height inside the sheet; long-press parent reveals the subtree menu.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Capture the returned PR URL — it's needed for the merge-queue step.
+
+- [ ] **Step 7.3: Add the PR to the merge queue**
+
+Per memory ("every PR opened goes through the merge-queue skill, not manual merge"), invoke the `merge-queue` skill with the PR number from Step 7.2 and let it land the branch on `main`. Do not run `gh pr merge` manually.
+
+- [ ] **Step 7.4: Report the PR URL to the user**
+
+Print the PR URL as a markdown link (`https://github.com/ajsutton/moolah-native/pull/NNN`) so it's clickable.
+
+---
+
+## Notes for the executor
+
+- **Worktree discipline.** All commands run from `.worktrees/category-multi-select/`. Use `git -C .` rather than `cd && git`. Never push to `origin/main` (branch-protected) or to any other branch's remote ref.
+- **Test target.** New tests live in `MoolahTests/Domain/`, run via `just test-mac CategoriesTests` (iOS form: `just test-ios CategoriesTests`). The full suite is `just test`.
+- **Swift Testing, not XCTest.** Tests use `@Test` and `#expect`, mirroring the existing `CategoriesTests` file.
+- **Thin views.** Selection-mutation logic on `selectSubtree(of:)` / `deselectSubtree(of:)` is allowed in the view because it's a one-line orchestration of model helpers (`descendants(of:)` and `Set` operations). Anything more complex would move onto `Categories`.
+- **Don't modify `.swiftlint-baseline.yml`.** If `just format-check` reports a violation, fix the underlying code (split, rename, reword) — see the `fixing-format-check` skill.
+- **Iterate UI via `#Preview`, not by relaunching the app.** The visual checks in Tasks 3–5 use Xcode's preview canvas (with `mcp__xcode__RenderPreview` when verifying remotely). Manual app launches are reserved for end-to-end flow checks in Steps 4.4 and 5.3.
+
+## Self-review (executed against this plan)
+
+**Spec coverage.** Each spec section maps to a task: trigger row + summary → Task 4 + helper from Task 2; picker view (search, hierarchy, Clear) → Task 3; subtree context menu → Task 5; descendants helper → Task 1; tests → Tasks 1, 2 + Task 6 full-suite run; rollout (single PR) → Task 7. ✅
+
+**Placeholder scan.** Every step has concrete code, exact file paths, exact commands, and expected output. No "TBD" / "similar to" / "implement appropriately" remain. ✅
+
+**Type consistency.** `descendants(of:)` returns `[Category]` consistently in helper code, tests, and call sites in Task 5. `selectionSummary(for:)` takes `Set<UUID>` and returns `String` in helper code, tests, and view call site. `selectedCategoryIds` is the binding name throughout (matches existing `TransactionFilterView` state). `CategoryMultiSelectPicker` props (`categories`, `selectedIds`) match across the picker file, the `#Preview`, and the two host call sites. ✅


### PR DESCRIPTION
## Summary

- Replace the inline-toggle Categories section in `TransactionFilterView` with a single trigger row that hosts a dedicated multi-select picker — popover on macOS, `NavigationLink` push on iOS. With many categories the old section grew the filter sheet past full-screen height and pushed the Apply / Cancel / Clear All toolbar out of reach; the new picker scales to any number of categories.
- Add five helpers + one computed property on `Categories`, all unit-tested, so the view stays thin: `descendants(of:)`, `selectionSummary(for:)`, `flattenedByPath(matching:)`, `subtreeIds(of:)`, `hasChildren(_:)`, and `FlatEntry.depth`.
- Parent rows expose a `.contextMenu` (`SubtreeContextMenu` view modifier, attached only when `isParent`) with "Select all in <Parent>" / "Deselect all in <Parent>" — a discoverable subtree shortcut without per-row chrome. Selection semantics are unchanged: `selectedCategoryIds` stays a flat `Set<UUID>`, and the filter still applies via the existing Apply button.
- Picker uses `ContentUnavailableView` for empty/no-match states, an inline Clear header (toolbar items don't render inside a macOS popover), `.searchable` filtering with whitespace-trimmed substring matching, hierarchical indentation idle / flat full-paths under search, `.contentShape(.rect)` for full-row hit-testing, and per-row `accessibilityLabel(entry.path)` so VoiceOver always announces the full hierarchy.

Design spec: [`plans/2026-04-30-category-multi-select-design.md`](plans/2026-04-30-category-multi-select-design.md). Implementation plan: [`plans/2026-04-30-category-multi-select-implementation.md`](plans/2026-04-30-category-multi-select-implementation.md).

## Test plan

- [x] `just test` — 1874 tests pass (iOS + macOS).
- [x] `just format-check` — clean.
- [ ] Manual macOS: filter sheet opens at its prior size with toolbar reachable; popover anchors to the row; search filters with full-path labels; Clear button works in the popover header; right-click a parent → "Select all in …" toggles parent + descendants.
- [ ] Manual iOS Simulator: `NavigationLink` push shows the picker full-height inside the sheet; long-press parent reveals the subtree menu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)