### PR TITLE
test(investments): cover per-date conversion in daily-balance and positions-history pipelines

### DIFF
--- a/MoolahTests/Features/InvestmentStoreDailyBalanceDateTests.swift
+++ b/MoolahTests/Features/InvestmentStoreDailyBalanceDateTests.swift
@@ -1,0 +1,103 @@
+import Foundation
+import SwiftData
+import Testing
+
+@testable import Moolah
+
+/// Locks in Rule 5 of `guides/INSTRUMENT_CONVERSION_GUIDE.md` for the
+/// legacy daily-balance pipeline: each (date, instrument) tuple must
+/// be converted to the host currency on its own snapshot date, not on
+/// today's rate.
+///
+/// `FixedConversionService` ignores its `on:` parameter, so it cannot
+/// catch a regression that swaps `on: date` for `on: Date()`. These
+/// tests use `DateBasedFixedConversionService` (rate keyed by date) so
+/// a future refactor that drops the snapshot date fails loudly.
+@Suite("InvestmentStore.aggregateDailyBalances conversion date")
+@MainActor
+struct InvestmentStoreDailyBalanceDateTests {
+  private let aud = Instrument.AUD
+  private let usd = Instrument.USD
+
+  private func makeDate(year: Int, month: Int, day: Int) throws -> Date {
+    try #require(
+      Calendar(identifier: .gregorian).date(
+        from: DateComponents(year: year, month: month, day: day)))
+  }
+
+  @Test("aggregates each date's USD balance using that date's rate, not today's")
+  func usesSnapshotDateForConversion() async throws {
+    let date1 = try makeDate(year: 2024, month: 1, day: 1)
+    let date2 = try makeDate(year: 2024, month: 6, day: 1)
+
+    let (backend, _) = try TestBackend.create(instrument: aud)
+    let store = InvestmentStore(
+      repository: backend.investments,
+      conversionService: DateBasedFixedConversionService(rates: [
+        date1: [usd.id: dec("1.5")],
+        date2: [usd.id: dec("1.8")],
+      ]))
+
+    let raw = [
+      AccountDailyBalance(
+        date: date1,
+        balance: InstrumentAmount(quantity: dec("100.00"), instrument: usd)),
+      AccountDailyBalance(
+        date: date2,
+        balance: InstrumentAmount(quantity: dec("100.00"), instrument: usd)),
+    ]
+
+    let result = try await store.aggregateDailyBalances(
+      raw: raw, hostCurrency: aud)
+
+    // Forward-fill keeps the latest USD balance on each active date, then
+    // converts at THAT date's rate: day1 = 100 USD * 1.5 = 150 AUD,
+    // day2 = 100 USD * 1.8 = 180 AUD. A regression to "always use today's
+    // rate" would produce two equal numbers.
+    #expect(result.count == 2)
+    #expect(result[0].date == date1)
+    #expect(result[0].balance == InstrumentAmount(quantity: dec("150.00"), instrument: aud))
+    #expect(result[1].date == date2)
+    #expect(result[1].balance == InstrumentAmount(quantity: dec("180.00"), instrument: aud))
+  }
+
+  @Test("forward-filled USD balance on a later date converts at that later date's rate")
+  func forwardFilledBalanceUsesLaterDateRate() async throws {
+    let buyDate = try makeDate(year: 2024, month: 1, day: 1)
+    let cashFlowDate = try makeDate(year: 2024, month: 6, day: 1)
+
+    let (backend, _) = try TestBackend.create(instrument: aud)
+    let store = InvestmentStore(
+      repository: backend.investments,
+      conversionService: DateBasedFixedConversionService(rates: [
+        buyDate: [usd.id: dec("1.5")],
+        cashFlowDate: [usd.id: dec("2.0")],
+      ]))
+
+    // USD balance only changes on day 1; day 2 has an AUD movement only.
+    // Forward-fill keeps the 100 USD running on day 2, where it must be
+    // converted at day 2's rate (2.0), not day 1's (1.5).
+    let raw = [
+      AccountDailyBalance(
+        date: buyDate,
+        balance: InstrumentAmount(quantity: dec("100.00"), instrument: usd)),
+      AccountDailyBalance(
+        date: cashFlowDate,
+        balance: InstrumentAmount(quantity: dec("50.00"), instrument: aud)),
+    ]
+
+    let result = try await store.aggregateDailyBalances(
+      raw: raw, hostCurrency: aud)
+
+    #expect(result.count == 2)
+    #expect(result[0].date == buyDate)
+    // Day 1: 100 USD * 1.5 = 150 AUD.
+    #expect(result[0].balance == InstrumentAmount(quantity: dec("150.00"), instrument: aud))
+    #expect(result[1].date == cashFlowDate)
+    // Day 2: 100 USD * 2.0 + 50 AUD = 250 AUD. A regression that uses
+    // `Date()` instead of `date` for the USD leg's conversion would
+    // produce a different number on this date (likely a 1:1 fallback
+    // since `Date()` is not in the rate table).
+    #expect(result[1].balance == InstrumentAmount(quantity: dec("250.00"), instrument: aud))
+  }
+}

--- a/MoolahTests/Shared/PositionsHistoryBuilderTests.swift
+++ b/MoolahTests/Shared/PositionsHistoryBuilderTests.swift
@@ -185,4 +185,47 @@ struct PositionsHistoryBuilderTests {
     let cutoffDay = Calendar(identifier: .gregorian).startOfDay(for: cutoff)
     #expect(oneMonth.totalSeries.allSatisfy { $0.date >= cutoffDay })
   }
+
+  /// Locks in Rule 5 of `guides/INSTRUMENT_CONVERSION_GUIDE.md`: every
+  /// daily value point must be converted at that day's own rate, not at
+  /// today's rate. The other tests in this suite use
+  /// `FixedConversionService` (date-insensitive), which would silently
+  /// pass a regression that swapped `on: day` for `on: Date()`. This
+  /// test pins the per-day rate by using `DateBasedFixedConversionService`.
+  @Test("each day's value uses that day's rate, not today's rate")
+  func valueSeriesUsesPerDayRate() async {
+    // Single buy on day 1; rate steps day-by-day so each daily point
+    // exercises a different conversion rate.
+    let txns = [buy(instrument: bhp, qty: 100, fiat: 4_000, daysAfterEpoch: 1)]
+    let service = DateBasedFixedConversionService(rates: [
+      date(daysAfterEpoch: 1): [bhp.id: Decimal(50)],
+      date(daysAfterEpoch: 2): [bhp.id: Decimal(60)],
+      date(daysAfterEpoch: 3): [bhp.id: Decimal(70)],
+    ])
+    let builder = PositionsHistoryBuilder(conversionService: service)
+    let now = date(daysAfterEpoch: 3)
+    let series = await builder.build(
+      transactions: txns,
+      accountId: accountId,
+      hostCurrency: aud,
+      range: .threeMonths,
+      now: now
+    )
+
+    // Three points (days 1..3), each priced at that day's rate. A
+    // regression to "always use today's rate" would emit three equal
+    // values (all at day 3's rate of 70).
+    let bhpSeries = series.series(for: bhp)
+    #expect(bhpSeries.count == 3)
+    #expect(bhpSeries[0].value == 100 * Decimal(50))
+    #expect(bhpSeries[1].value == 100 * Decimal(60))
+    #expect(bhpSeries[2].value == 100 * Decimal(70))
+
+    // Aggregate series mirrors the per-instrument series for a single
+    // non-host instrument account.
+    #expect(series.totalSeries.count == 3)
+    #expect(series.totalSeries[0].value == 100 * Decimal(50))
+    #expect(series.totalSeries[1].value == 100 * Decimal(60))
+    #expect(series.totalSeries[2].value == 100 * Decimal(70))
+  }
 }


### PR DESCRIPTION
## Summary

Closes the test-coverage gap from issue #609: two production sites that thread the snapshot/calendar date through `InstrumentConversionService.convert` were tested only with `FixedConversionService` (date-insensitive), so a regression to `on: Date()` would have passed silently.

- `InvestmentStore.aggregateDailyBalances` — new `InvestmentStoreDailyBalanceDateTests` uses `DateBasedFixedConversionService` to verify each forward-filled USD balance is converted at *that date's* rate, including the forward-fill case where a USD balance from day 1 is carried into a later date with a different rate.
- `PositionsHistoryBuilder.build` — new test in `PositionsHistoryBuilderTests` steps the BHP rate day-by-day and asserts each daily value point picks up that day's rate, both per-instrument and on the aggregate series.

Both call sites already implement Rule 5 of `guides/INSTRUMENT_CONVERSION_GUIDE.md` correctly; this PR locks the behaviour in. A regression that swapped `on: date` / `on: day` for `on: Date()` would now fail at least four assertions across the two new tests.

Fixes #609

## Test plan
- [x] `just test-mac InvestmentStoreDailyBalanceDateTests PositionsHistoryBuilderTests` — 10/10 pass
- [x] `just test` — full suite, 1912 tests pass on iOS sim and macOS
- [x] `just format-check` — clean
- [x] No new SwiftLint baseline entries (file/type names sized to fit existing rules; force-unwrap replaced with `try #require`)