### PR TITLE
fix(display): use Unicode minus in InstrumentAmount.signedFormatted

### DIFF
--- a/Domain/Models/ValuedPosition+Display.swift
+++ b/Domain/Models/ValuedPosition+Display.swift
@@ -48,11 +48,24 @@ extension ValuedPosition {
 
 extension InstrumentAmount {
   /// Signed-amount string with explicit `+` prefix for positive values
-  /// (negative values keep their natural `-` from `formatted`). Zero shows
-  /// no prefix. Used for gain/loss display.
+  /// and a Unicode minus (U+2212) prefix for negative values. Zero shows
+  /// no prefix. Used for gain/loss display so the sign character lines
+  /// up with `GainLossPercentDisplay.formatted` under
+  /// `.monospacedDigit()` — the locale-native `formatted` produces an
+  /// ASCII hyphen-minus (U+002D) which renders narrower than digits and
+  /// disagrees with the percent text alongside it. See issue #608.
+  ///
+  /// Locales whose negative-currency form does not start with a leading
+  /// hyphen-minus (e.g. accounting paren-wrap `($500)`) are passed
+  /// through untouched — substitution only fires when the first
+  /// character of `formatted` is U+002D.
   var signedFormatted: String {
-    let sign = quantity > 0 ? "+" : ""
-    return "\(sign)\(formatted)"
+    let raw = formatted
+    if quantity > 0 { return "+\(raw)" }
+    if quantity < 0, raw.first == "-" {
+      return "\u{2212}" + raw.dropFirst()
+    }
+    return raw
   }
 }
 

--- a/MoolahTests/Domain/InstrumentAmountTests.swift
+++ b/MoolahTests/Domain/InstrumentAmountTests.swift
@@ -132,6 +132,74 @@ struct InstrumentAmountTests {
     #expect(text.contains("1234.56") || text.contains("1,234.56"))
   }
 
+  // MARK: - signedFormatted
+
+  /// Positive amounts get an explicit `+` prefix so gain/loss displays
+  /// distinguish gains from zero changes.
+  @Test
+  func signedFormattedPositiveFiatPrefixesPlus() {
+    let amount = InstrumentAmount(quantity: dec("500"), instrument: aud)
+    #expect(amount.signedFormatted.hasPrefix("+"))
+  }
+
+  /// Negative fiat amounts must use the Unicode minus (U+2212) not the
+  /// ASCII hyphen-minus (U+002D), so they line up with
+  /// `GainLossPercentDisplay.formatted` under `.monospacedDigit()`.
+  /// See issue #608.
+  @Test
+  func signedFormattedNegativeFiatUsesUnicodeMinus() {
+    let amount = InstrumentAmount(quantity: dec("-500"), instrument: aud)
+    let formatted = amount.signedFormatted
+    #expect(formatted.first == "\u{2212}")
+    #expect(!formatted.contains("\u{002D}"))
+  }
+
+  /// Negative stock amounts use the same leading-hyphen format from
+  /// `formatted` (e.g. `"-10 BHP.AX"`), so the same substitution must
+  /// apply.
+  @Test
+  func signedFormattedNegativeStockUsesUnicodeMinus() {
+    let bhp = Instrument.stock(ticker: "BHP.AX", exchange: "ASX", name: "BHP")
+    let amount = InstrumentAmount(quantity: dec("-10"), instrument: bhp)
+    #expect(amount.signedFormatted == "\u{2212}10 BHP.AX")
+  }
+
+  /// Negative crypto amounts use the same leading-hyphen format from
+  /// `formatted`.
+  @Test
+  func signedFormattedNegativeCryptoUsesUnicodeMinus() {
+    let eth = Instrument.crypto(
+      chainId: 1, contractAddress: nil, symbol: "ETH", name: "Ethereum", decimals: 18)
+    let amount = InstrumentAmount(quantity: dec("-0.5"), instrument: eth)
+    #expect(amount.signedFormatted == "\u{2212}0.5 ETH")
+  }
+
+  /// Zero renders without a sign prefix.
+  @Test
+  func signedFormattedZeroHasNoPrefix() {
+    let amount = InstrumentAmount(quantity: 0, instrument: aud)
+    let formatted = amount.signedFormatted
+    #expect(!formatted.hasPrefix("+"))
+    #expect(!formatted.hasPrefix("\u{2212}"))
+    #expect(!formatted.hasPrefix("-"))
+  }
+
+  /// Locales that emit a non-leading-hyphen negative form (e.g.
+  /// accounting paren-wrap `($500)`) are left untouched — substitution
+  /// only fires when the first character is U+002D.
+  @Test
+  func signedFormattedPreservesNonHyphenNegativeFormats() {
+    // We can't force a specific locale here without invasive plumbing,
+    // but we can assert the invariant: if the underlying `formatted`
+    // does not start with U+002D, `signedFormatted` returns it
+    // unchanged for negative quantities.
+    let amount = InstrumentAmount(quantity: dec("-500"), instrument: aud)
+    let raw = amount.formatted
+    if raw.first != "-" {
+      #expect(amount.signedFormatted == raw)
+    }
+  }
+
   @Test
   func reduceForSumming() {
     let amounts = [


### PR DESCRIPTION
## Summary

- `InstrumentAmount.signedFormatted` now substitutes a Unicode minus (U+2212) for the leading ASCII hyphen-minus (U+002D) emitted by `Decimal.formatted(.currency)` / `.formatted(.number)`, so negative monetary amounts line up typographically with `GainLossPercentDisplay.formatted` (which already uses U+2212) under `.monospacedDigit()`.
- Affects every gain/loss display site: `PositionRow.trailingColumn`, `PositionsTable.gainCell`, `AccountPerformanceTiles.profitLossTile`, `PositionsHeader.plPill`. Positive `+` prefix and zero-no-prefix behaviour are unchanged.
- Locales whose negative form does not start with a hyphen-minus (e.g. accounting paren-wrap `($500)`) pass through unchanged — substitution only fires when the first character of `formatted` is U+002D.

Fixes #608

## Test plan

- [x] `just test-mac InstrumentAmountTests` — new `signedFormatted*` tests pass (positive `+`, negative fiat/stock/crypto use U+2212 with no remaining U+002D, zero has no prefix, locale-paren-wrap passthrough invariant).
- [x] `just test` — full suite (1915 macOS, 1890 iOS) passes.
- [x] `just format-check` — clean.
- [ ] Manual visual check on the Positions screen: `−$500  −5.0%` reads with consistent sign widths under `.monospacedDigit()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)