### PR TITLE
fix(release): cron-driven Monthly RC invokes build pipeline

### DIFF
--- a/.github/workflows/monthly-tag.yml
+++ b/.github/workflows/monthly-tag.yml
@@ -7,11 +7,14 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   cut-rc:
     name: Cut monthly RC
     runs-on: macos-26
+    outputs:
+      tag: ${{ steps.version.outputs.tag }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -33,6 +36,11 @@ jobs:
         # requires a `--notes-file`, and the cron path uses `--generate-notes`
         # (mutually exclusive). The version is computed by the same library
         # used in release-create-rc and is well-formed by construction.
+        #
+        # The downstream `build-rc` job invokes release-rc.yml via
+        # workflow_call: tags created by GITHUB_TOKEN don't fire other
+        # workflows, so the implicit tag-push trigger on release-rc.yml is
+        # not enough on the cron path.
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -41,4 +49,11 @@ jobs:
               --title "${{ steps.version.outputs.tag }}" \
               --prerelease \
               --generate-notes
-          # release-rc.yml fires from the tag push that gh release just created.
+
+  build-rc:
+    name: Build & publish RC artefacts
+    needs: cut-rc
+    uses: ./.github/workflows/release-rc.yml
+    with:
+      tag: ${{ needs.cut-rc.outputs.tag }}
+    secrets: inherit

--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+"
+  workflow_call:
+    inputs:
+      tag:
+        description: "Existing RC tag to build (e.g. v1.1.0-rc.11). Required when invoked via workflow_call; ignored on push:tags."
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -21,6 +27,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
+          ref: ${{ inputs.tag || github.ref_name }}
 
       - name: Install tools
         run: brew install just
@@ -68,6 +75,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
+          ref: ${{ inputs.tag || github.ref_name }}
 
       - name: Install tools
         run: brew install just
@@ -98,6 +106,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
+          ref: ${{ inputs.tag || github.ref_name }}
 
       - name: Install tools
         run: brew install xcodegen just
@@ -110,13 +119,15 @@ jobs:
 
       - name: Extract base version from tag
         id: version
+        env:
+          TAG: ${{ inputs.tag || github.ref_name }}
         run: |
           # v1.2.0-rc.1 → 1.2.0
-          BASE_VERSION="${GITHUB_REF_NAME#v}"
+          BASE_VERSION="${TAG#v}"
           BASE_VERSION="${BASE_VERSION%%-rc.*}"
           {
               echo "base=$BASE_VERSION"
-              echo "tag=$GITHUB_REF_NAME"
+              echo "tag=$TAG"
           } >> "$GITHUB_OUTPUT"
 
       - name: Update marketing version


### PR DESCRIPTION
## Summary

The May 2026 Monthly RC ran successfully and created tag `v1.1.0-rc.10`, but the GitHub release ended up with an empty `assets` array — no Mac zip, no IPA, no TestFlight build. Root cause: GitHub's recursion guard. The cron job in `monthly-tag.yml` calls `gh release create` authenticated as `${{ secrets.GITHUB_TOKEN }}`, and tags created by `GITHUB_TOKEN` do not fire downstream workflow triggers. So `release-rc.yml`'s `on: push: tags:` trigger never saw the tag.

Every prior RC (rc.1–rc.9) was cut via the local `scripts/release-create-rc.sh` runbook, which pushes the tag from a real user account — that does trigger workflows. rc.10 was the first cron-driven RC, and it surfaced the gap.

This PR fixes the cron path:

- `release-rc.yml` now accepts a `workflow_call` invocation with an explicit `tag` input. It keeps the existing `on: push: tags:` trigger so the manual runbook still works unchanged.
- All three jobs (`preflight`, `await-prod-deploy`, `build`) now pin their checkout to the resolved tag (`inputs.tag || github.ref_name`) so the build always operates on the committed state of the tagged ref, regardless of whether the trigger was a tag push or a `workflow_call`.
- `monthly-tag.yml`'s `cut-rc` job exposes the new tag as an output. A new downstream `build-rc` job calls `./.github/workflows/release-rc.yml` with that tag and `secrets: inherit`, so the cron path now actually runs the build.
- Removed the misleading inline comment in `monthly-tag.yml` that claimed the implicit tag-push would fire `release-rc.yml`.

The next monthly RC (or a manual `gh workflow run "Monthly RC"`) will go through the full preflight → build → notarise → upload pipeline.

## Test plan

- [ ] After merge, run `gh workflow run "Monthly RC"` and confirm `release-rc.yml` is invoked as a downstream `workflow_call`.
- [ ] Confirm the resulting `v1.1.0-rc.11` GitHub release has `Moolah-1.1.0.zip` and `build-number.txt` attached, and a TestFlight build appears.
- [ ] Confirm `scripts/release-create-rc.sh` (push-tags path) still works for human-cut RCs after merge — covered by tagging once via the script in a future RC.

## Notes

- The orphaned `v1.1.0-rc.10` release on GitHub is unaffected by this PR. We can either delete it or leave it; this PR just stops the next one from being orphaned.