### PR TITLE
fix(release): scope distribution signing to the app target

### DIFF
--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -143,7 +143,6 @@ jobs:
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
           MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
           DEVELOPMENT_TEAM: ${{ secrets.DEVELOPMENT_TEAM }}
-          CODE_SIGN_STYLE: "Manual"
         run: bundle exec fastlane ios beta
 
       - name: Capture TestFlight build number
@@ -169,7 +168,6 @@ jobs:
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
           MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
           DEVELOPMENT_TEAM: ${{ secrets.DEVELOPMENT_TEAM }}
-          CODE_SIGN_STYLE: "Manual"
         run: bundle exec fastlane mac zip version:${{ steps.version.outputs.base }}
 
       - name: Attach Mac zip and build-number to GH pre-release

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -5,6 +5,17 @@ before_all do
   sh("cd .. && just generate")
 end
 
+# Provisioning profile is the only signing setting that varies per build —
+# `match` produces a fresh profile name each time. Everything else (style,
+# identity, entitlements) lives on the app target's Release config in
+# project.yml. The setting MUST be scoped to the app target with
+# `[target=...]`; an unscoped xcarg leaks to SPM dependencies (e.g. GRDB),
+# which fail at archive with "<package> does not support provisioning
+# profiles."
+def release_xcargs(target_name, profile_name)
+  "'PROVISIONING_PROFILE_SPECIFIER[target=#{target_name}]=#{profile_name}'"
+end
+
 platform :ios do
   before_all do
     setup_ci
@@ -40,26 +51,12 @@ platform :ios do
 
     profile_name = ENV["sigh_rocks.moolah.app_appstore_profile-name"]
 
-    # Distribution entitlements live in fastlane/Moolah.entitlements and are
-    # shared by both `validate` and `beta` lanes so they can never diverge.
-    # The file is intentionally kept outside any XcodeGen source path; XcodeGen
-    # auto-discovers .entitlements files in source directories and would apply
-    # them to all builds, breaking CI simulator tests without CloudKit.
-    entitlements_path = File.expand_path("Moolah.entitlements", __dir__)
-
     build_app(
       scheme: "Moolah-iOS",
       export_method: "app-store",
       output_directory: "./build",
       output_name: "Moolah.ipa",
-      xcargs: [
-        "CODE_SIGN_ENTITLEMENTS=#{entitlements_path}",
-        "CODE_SIGN_STYLE=Manual",
-        "DEVELOPMENT_TEAM=#{ENV['DEVELOPMENT_TEAM']}",
-        "'CODE_SIGN_IDENTITY=Apple Distribution'",
-        "'PROVISIONING_PROFILE_SPECIFIER=#{profile_name}'",
-        "SWIFT_ACTIVE_COMPILATION_CONDITIONS='$(inherited) CLOUDKIT_ENABLED'"
-      ].join(" ")
+      xcargs: release_xcargs("Moolah_iOS", profile_name)
     )
 
     UI.message("Validating IPA against App Store rules...")
@@ -94,24 +91,12 @@ platform :ios do
 
     profile_name = ENV["sigh_rocks.moolah.app_appstore_profile-name"]
 
-    # Share the entitlements file with the `validate` lane so the IPA we upload
-    # to TestFlight always matches what validate inspected. See the comment in
-    # `validate` for why this file is kept in fastlane/ rather than App/.
-    entitlements_path = File.expand_path("Moolah.entitlements", __dir__)
-
     build_app(
       scheme: "Moolah-iOS",
       export_method: "app-store",
       output_directory: "./build",
       output_name: "Moolah.ipa",
-      xcargs: [
-        "CODE_SIGN_ENTITLEMENTS=#{entitlements_path}",
-        "CODE_SIGN_STYLE=Manual",
-        "DEVELOPMENT_TEAM=#{ENV['DEVELOPMENT_TEAM']}",
-        "'CODE_SIGN_IDENTITY=Apple Distribution'",
-        "'PROVISIONING_PROFILE_SPECIFIER=#{profile_name}'",
-        "SWIFT_ACTIVE_COMPILATION_CONDITIONS='$(inherited) CLOUDKIT_ENABLED'"
-      ].join(" ")
+      xcargs: release_xcargs("Moolah_iOS", profile_name)
     )
 
     upload_to_testflight(
@@ -207,7 +192,6 @@ platform :mac do
     # iOS appstore uses `sigh_<bundle>_appstore_profile-name` (no platform suffix)
     # because iOS is fastlane's default platform.
     profile_name = ENV["sigh_rocks.moolah.app_developer_id_macos_profile-name"]
-    entitlements_path = File.expand_path("Moolah-mac.entitlements", __dir__)
 
     # Resolve build dir to an absolute path off the repo root. gym/build_app
     # writes outputs to <repo_root>/build/ regardless of fastlane's own cwd,
@@ -221,15 +205,7 @@ platform :mac do
       export_method: "developer-id",
       output_directory: build_dir,
       output_name: "Moolah",
-      xcargs: [
-        "CODE_SIGN_ENTITLEMENTS=#{entitlements_path}",
-        "CODE_SIGN_STYLE=Manual",
-        "DEVELOPMENT_TEAM=#{ENV['DEVELOPMENT_TEAM']}",
-        "'CODE_SIGN_IDENTITY=Developer ID Application'",
-        "'PROVISIONING_PROFILE_SPECIFIER=#{profile_name}'",
-        "ENABLE_HARDENED_RUNTIME=YES",
-        "SWIFT_ACTIVE_COMPILATION_CONDITIONS='$(inherited) CLOUDKIT_ENABLED'"
-      ].join(" ")
+      xcargs: release_xcargs("Moolah_macOS", profile_name)
     )
 
     app_path = File.join(build_dir, "Moolah.app")

--- a/project.yml
+++ b/project.yml
@@ -37,15 +37,16 @@ settings:
     MARKETING_VERSION: "1.1.0"
     CURRENT_PROJECT_VERSION: "1"
 
-    # ---- Signing (env-driven) ----
+    # ---- Signing ----
+    # DEVELOPMENT_TEAM is env-driven so a developer can set their own team
+    # for local Debug builds without editing project.yml. The distribution
+    # signing settings (CODE_SIGN_STYLE, CODE_SIGN_IDENTITY,
+    # CODE_SIGN_ENTITLEMENTS) live on the Release config of each app
+    # target — they must be scoped to the app target so SPM dependencies
+    # (e.g. GRDB) don't try to apply provisioning profiles, which they
+    # don't support. The dynamic PROVISIONING_PROFILE_SPECIFIER comes
+    # from `match` at fastlane build-time via target-scoped xcargs.
     DEVELOPMENT_TEAM: ${DEVELOPMENT_TEAM}
-
-    # Default to Automatic if env var not set
-    CODE_SIGN_STYLE: ${CODE_SIGN_STYLE}
-
-    # Only used when CODE_SIGN_STYLE=Manual
-    CODE_SIGN_IDENTITY: ${CODE_SIGN_IDENTITY}
-    PROVISIONING_PROFILE_SPECIFIER: ${PROVISIONING_PROFILE_SPECIFIER}
 
     # Keep Xcode predictable
     CODE_SIGNING_REQUIRED: YES
@@ -106,6 +107,13 @@ targets:
           CLOUDKIT_ENVIRONMENT: Development
           CLOUDKIT_CONTAINER_ID: iCloud.rocks.moolah.app.test
         Release:
+          # Distribution signing scoped to this target only — never inherit
+          # to SPM dependencies which can't be signed with provisioning
+          # profiles. PROVISIONING_PROFILE_SPECIFIER comes from `match` at
+          # build time via target-scoped xcargs in fastlane/Fastfile.
+          CODE_SIGN_STYLE: Manual
+          CODE_SIGN_IDENTITY: Apple Distribution
+          CODE_SIGN_ENTITLEMENTS: fastlane/Moolah.entitlements
           SWIFT_ACTIVE_COMPILATION_CONDITIONS: "$(inherited) CLOUDKIT_ENABLED"
           CLOUDKIT_ENVIRONMENT: Production
           CLOUDKIT_CONTAINER_ID: iCloud.rocks.moolah.app.v2
@@ -143,6 +151,11 @@ targets:
           CLOUDKIT_ENVIRONMENT: Development
           CLOUDKIT_CONTAINER_ID: iCloud.rocks.moolah.app.test
         Release:
+          # See Moolah_iOS.Release for why signing is scoped to the app
+          # target and not inherited from settings.base.
+          CODE_SIGN_STYLE: Manual
+          CODE_SIGN_IDENTITY: Developer ID Application
+          CODE_SIGN_ENTITLEMENTS: fastlane/Moolah-mac.entitlements
           ENABLE_HARDENED_RUNTIME: YES
           SWIFT_ACTIVE_COMPILATION_CONDITIONS: "$(inherited) CLOUDKIT_ENABLED"
           CLOUDKIT_ENVIRONMENT: Production


### PR DESCRIPTION
## Summary

Adding GRDB.swift as an SPM dependency in [#556](https://github.com/ajsutton/moolah-native/pull/556) surfaced a latent bug in our distribution-signing setup: the Fastfile was passing `CODE_SIGN_STYLE`, `CODE_SIGN_IDENTITY`, and `PROVISIONING_PROFILE_SPECIFIER` as **unscoped** xcargs, so xcodebuild applied them to every target in the workspace — including SPM packages. Xcode 26 then refuses to build with:

> `error: GRDB_GRDB does not support provisioning profiles. ... has been manually specified. Set the provisioning profile value to "Automatic" in the build settings editor. (in target 'GRDB_GRDB' from project 'GRDB')`

This is what blocked the `v1.1.0-rc.10` cron run (silently, before [#616](https://github.com/ajsutton/moolah-native/pull/616) was merged) and the `v1.1.0-rc.11` cron run (visibly, immediately after #616). Any RC build since GRDB landed would have hit it.

## What changed

Restructure signing so it lives where it architecturally belongs:

- **`project.yml`**: drop the env-driven signing scaffolding from `settings.base` (which was vestigial — Fastfile xcargs were overriding it anyway). Add proper Release-config signing on `Moolah_iOS` (`Apple Distribution` + `fastlane/Moolah.entitlements`) and `Moolah_macOS` (`Developer ID Application` + `fastlane/Moolah-mac.entitlements`). `DEVELOPMENT_TEAM` stays env-driven in `settings.base` — harmless on SPM and convenient for local dev.

- **`fastlane/Fastfile`**: collapse all three `build_app` xcargs blocks (validate, beta, mac zip) to just the dynamic provisioning profile from `match`, scoped to the app target via `[target=Moolah_iOS]` / `[target=Moolah_macOS]`. Pull the duplication into a single `release_xcargs(target, profile)` helper. Drop now-redundant settings already provided by project.yml's Release config (style, identity, entitlements, `SWIFT_ACTIVE_COMPILATION_CONDITIONS`, `ENABLE_HARDENED_RUNTIME`).

- **`.github/workflows/release-rc.yml`**: drop the `CODE_SIGN_STYLE: \"Manual\"` env vars from both build steps — no project.yml setting reads them anymore.

Net diff: +35 / -48 lines.

## Test plan

- [x] `just generate` succeeds with the updated project.yml.
- [x] `just build-mac` (Debug) succeeds.
- [x] `just test-mac` passes (1926 tests in 293 suites).
- [x] Generated pbxproj has signing only on `Moolah_iOS` / `Moolah_macOS` Release configs; `PROVISIONING_PROFILE_SPECIFIER` does not appear anywhere (will only be set at fastlane build time, target-scoped).
- [ ] After merge, run `gh workflow run \"Monthly RC\"` to produce `v1.1.0-rc.12` end-to-end with assets attached.