### PR TITLE
fix(release): bake provisioning profile via xcodegen, not xcargs

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -6,14 +6,20 @@ before_all do
 end
 
 # Provisioning profile is the only signing setting that varies per build —
-# `match` produces a fresh profile name each time. Everything else (style,
-# identity, entitlements) lives on the app target's Release config in
-# project.yml. The setting MUST be scoped to the app target with
-# `[target=...]`; an unscoped xcarg leaks to SPM dependencies (e.g. GRDB),
-# which fail at archive with "<package> does not support provisioning
-# profiles."
-def release_xcargs(target_name, profile_name)
-  "'PROVISIONING_PROFILE_SPECIFIER[target=#{target_name}]=#{profile_name}'"
+# `match` produces a fresh profile name each time. The Release config of
+# the relevant app target in project.yml has
+# `PROVISIONING_PROFILE_SPECIFIER: ${<env_var>}`; setting that env var
+# and re-running `just generate` bakes the profile name into the project
+# file scoped to the app target only — SPM packages don't see it and
+# don't fail with "<package> does not support provisioning profiles."
+#
+# An xcargs override would be simpler but doesn't work: xcodebuild's
+# command-line setting overrides apply globally to every target in the
+# workspace, and the `[target=...]` qualifier that scopes them inside
+# xcconfig files isn't parsed correctly on the command line.
+def bake_profile(env_var, profile_name)
+  ENV[env_var] = profile_name
+  sh("cd .. && just generate")
 end
 
 platform :ios do
@@ -49,14 +55,13 @@ platform :ios do
       is_key_content_base64: true
     )
 
-    profile_name = ENV["sigh_rocks.moolah.app_appstore_profile-name"]
+    bake_profile("IOS_PROVISIONING_PROFILE", ENV["sigh_rocks.moolah.app_appstore_profile-name"])
 
     build_app(
       scheme: "Moolah-iOS",
       export_method: "app-store",
       output_directory: "./build",
-      output_name: "Moolah.ipa",
-      xcargs: release_xcargs("Moolah_iOS", profile_name)
+      output_name: "Moolah.ipa"
     )
 
     UI.message("Validating IPA against App Store rules...")
@@ -80,23 +85,23 @@ platform :ios do
       is_key_content_base64: true
     )
 
-    # `increment_build_number` edits the generated pbxproj, which is wiped by
-    # `just generate`. That's fine here: nothing regenerates between this call
-    # and `build_app`, and TestFlight is the persistent source of truth for the
-    # next build number (not project.yml's hard-coded "1"). Do NOT add a
-    # `just generate` below this point or the bump will be lost.
+    # Order matters: `bake_profile` re-runs `just generate`, which wipes the
+    # pbxproj. Run it BEFORE `increment_build_number` (which mutates the
+    # pbxproj). Anything that mutates the pbxproj must come AFTER the last
+    # `just generate` and BEFORE `build_app`, since TestFlight (not
+    # project.yml's hard-coded "1") is the persistent source of truth for
+    # the next build number.
+    bake_profile("IOS_PROVISIONING_PROFILE", ENV["sigh_rocks.moolah.app_appstore_profile-name"])
+
     increment_build_number(
       build_number: latest_testflight_build_number(api_key: api_key) + 1
     )
-
-    profile_name = ENV["sigh_rocks.moolah.app_appstore_profile-name"]
 
     build_app(
       scheme: "Moolah-iOS",
       export_method: "app-store",
       output_directory: "./build",
-      output_name: "Moolah.ipa",
-      xcargs: release_xcargs("Moolah_iOS", profile_name)
+      output_name: "Moolah.ipa"
     )
 
     upload_to_testflight(
@@ -191,7 +196,7 @@ platform :mac do
     # match exports this with `_macos` infix because we passed `platform: "macos"`.
     # iOS appstore uses `sigh_<bundle>_appstore_profile-name` (no platform suffix)
     # because iOS is fastlane's default platform.
-    profile_name = ENV["sigh_rocks.moolah.app_developer_id_macos_profile-name"]
+    bake_profile("MAC_PROVISIONING_PROFILE", ENV["sigh_rocks.moolah.app_developer_id_macos_profile-name"])
 
     # Resolve build dir to an absolute path off the repo root. gym/build_app
     # writes outputs to <repo_root>/build/ regardless of fastlane's own cwd,
@@ -204,8 +209,7 @@ platform :mac do
       configuration: "Release",
       export_method: "developer-id",
       output_directory: build_dir,
-      output_name: "Moolah",
-      xcargs: release_xcargs("Moolah_macOS", profile_name)
+      output_name: "Moolah"
     )
 
     app_path = File.join(build_dir, "Moolah.app")

--- a/project.yml
+++ b/project.yml
@@ -109,11 +109,16 @@ targets:
         Release:
           # Distribution signing scoped to this target only — never inherit
           # to SPM dependencies which can't be signed with provisioning
-          # profiles. PROVISIONING_PROFILE_SPECIFIER comes from `match` at
-          # build time via target-scoped xcargs in fastlane/Fastfile.
+          # profiles. PROVISIONING_PROFILE_SPECIFIER is xcodegen-substituted
+          # from $IOS_PROVISIONING_PROFILE; fastlane sets that env var from
+          # `match`'s output and re-runs `just generate` before `build_app`.
+          # Local Debug builds ignore this Release block, so an unset env
+          # var (xcodegen writing the literal `${IOS_PROVISIONING_PROFILE}`)
+          # is harmless.
           CODE_SIGN_STYLE: Manual
           CODE_SIGN_IDENTITY: Apple Distribution
           CODE_SIGN_ENTITLEMENTS: fastlane/Moolah.entitlements
+          PROVISIONING_PROFILE_SPECIFIER: ${IOS_PROVISIONING_PROFILE}
           SWIFT_ACTIVE_COMPILATION_CONDITIONS: "$(inherited) CLOUDKIT_ENABLED"
           CLOUDKIT_ENVIRONMENT: Production
           CLOUDKIT_CONTAINER_ID: iCloud.rocks.moolah.app.v2
@@ -156,6 +161,7 @@ targets:
           CODE_SIGN_STYLE: Manual
           CODE_SIGN_IDENTITY: Developer ID Application
           CODE_SIGN_ENTITLEMENTS: fastlane/Moolah-mac.entitlements
+          PROVISIONING_PROFILE_SPECIFIER: ${MAC_PROVISIONING_PROFILE}
           ENABLE_HARDENED_RUNTIME: YES
           SWIFT_ACTIVE_COMPILATION_CONDITIONS: "$(inherited) CLOUDKIT_ENABLED"
           CLOUDKIT_ENVIRONMENT: Production


### PR DESCRIPTION
## Summary

Follow-up to [#617](https://github.com/ajsutton/moolah-native/pull/617). That PR tried to scope the provisioning-profile xcarg with `[target=Moolah_iOS]`, but xcodebuild does **not** honour the `[target=…]` qualifier on command-line build setting overrides — only inside xcconfig files / project settings. xcodebuild parsed the override at the first `=`, leaving \`PROVISIONING_PROFILE_SPECIFIER\` set to the partial string \`Moolah_iOS]=match AppStore rocks.moolah.app …\` and the build failed at archive with:

> `error: No profile for team '***' matching 'Moolah_iOS]=match AppStore rocks.moolah.app 1777279847' found`

## Real fix

Move the profile spec to a place where target scoping actually works — into the Release config of \`Moolah_iOS\` and \`Moolah_macOS\` in \`project.yml\`, substituted at xcodegen time from per-platform env vars (\`IOS_PROVISIONING_PROFILE\`, \`MAC_PROVISIONING_PROFILE\`). Fastlane sets the env var from \`match\`'s output and re-runs \`just generate\` via a new \`bake_profile\` helper before \`build_app\`. \`xcargs\` becomes empty and the setting is naturally scoped to the app target only — SPM dependencies don't see it.

Beta-lane ordering had to flip: \`certificates\` → \`bake_profile\` → \`increment_build_number\` → \`build_app\`, because \`bake_profile\`'s re-generate wipes the pbxproj that \`increment_build_number\` mutates.

## Test plan

- [x] \`just generate\` with both env vars set: pbxproj has the literal profile name on \`Moolah_iOS\` / \`Moolah_macOS\` Release configs only; nowhere else.
- [x] \`just generate\` with env vars unset: pbxproj has literal \`${IOS_PROVISIONING_PROFILE}\` strings only on the same Release configs (Debug builds bypass them).
- [x] \`just build-mac\` (Debug) succeeds.
- [x] \`just test-mac\` passes (1926 tests in 293 suites).
- [ ] After merge, run \`gh workflow run \"Monthly RC\"\` to produce \`v1.1.0-rc.13\` end-to-end with assets attached.

## Why two PRs

PR #617 fixed the architectural shape (signing on the right config) but used the wrong scoping mechanism (xcargs). This PR fixes the mechanism. Splitting them keeps the diff comprehensible and the audit trail clear: #617 explains why distribution signing belongs on the app target, this one explains why xcconfig-style scoping is required for the dynamic profile name.