### PR TITLE
fix(sync): gate sync engine start on profile-index migration

### DIFF
--- a/App/MoolahApp+Setup.swift
+++ b/App/MoolahApp+Setup.swift
@@ -108,7 +108,8 @@ extension MoolahApp {
   static func configureSyncCoordinator(
     store: ProfileStore,
     coordinator: SyncCoordinator,
-    isUITesting: Bool
+    isUITesting: Bool,
+    profileIndexMigrationTask: Task<Void, Never>?
   ) {
     let logger = Logger(subsystem: "com.moolah.app", category: "BackgroundSync")
     let isRunningTests = NSClassFromString("XCTestCase") != nil
@@ -148,7 +149,15 @@ extension MoolahApp {
       coordinator?.queueDeletion(
         recordType: ProfileRow.recordType, id: id, zoneID: zoneID)
     }
-    coordinator.start()
+    // Defer the engine `start()` until the SwiftData → GRDB profile-index
+    // migration commits, otherwise CKSyncEngine can deliver fetched
+    // profile-data zone changes for a profile id whose `ProfileSession`
+    // has not yet been registered (the local index reads zero rows
+    // until the migration finishes), which traps in
+    // `SyncCoordinator.handlerForProfileZone(profileId:zoneID:)`. The
+    // coordinator owns the spawned `launchTask` so `stop()` can cancel
+    // it if the app tears down before the migration finishes.
+    coordinator.startAfter(profileIndexMigration: profileIndexMigrationTask)
     // Clean up the legacy CloudKit zone from SwiftData's automatic sync.
     LegacyZoneCleanup.performIfNeeded()
   }

--- a/App/MoolahApp.swift
+++ b/App/MoolahApp.swift
@@ -116,7 +116,8 @@ struct MoolahApp: App {
     Self.configureSyncCoordinator(
       store: store,
       coordinator: coordinator,
-      isUITesting: uiTestingSeed != nil)
+      isUITesting: uiTestingSeed != nil,
+      profileIndexMigrationTask: profileIndexMigrationTask)
 
     let sessionManager = SessionManager(
       containerManager: setup.manager, syncCoordinator: coordinator)

--- a/Backends/CloudKit/Sync/SyncCoordinator+HandlerAccess.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+HandlerAccess.swift
@@ -2,6 +2,22 @@
 import Foundation
 import OSLog
 
+/// Errors thrown by `SyncCoordinator.handlerForProfileZone(profileId:zoneID:)`.
+///
+/// `profileNotRegistered` indicates a wiring-order bug: a sync event
+/// arrived for a profile whose `ProfileSession` has not yet called
+/// `SyncCoordinator.setProfileGRDBRepositories(profileId:bundle:)`.
+/// Outbound paths (backfill, zone deletion / purge / encrypted reset,
+/// upload-batch building) treat this as recoverable and skip the
+/// profile — the records remain durable in GRDB and are re-queued by
+/// the next backfill scan or local-mutation hook. The inbound apply
+/// path (`applyFetchedProfileDataChanges`) treats it as fatal because
+/// `CKSyncEngine` advances the server change token after the delegate
+/// returns, so a silent skip would lose records permanently.
+enum SyncCoordinatorError: Error, Equatable {
+  case profileNotRegistered(UUID)
+}
+
 extension SyncCoordinator {
   // MARK: - Handler Access
 
@@ -12,11 +28,19 @@ extension SyncCoordinator {
   /// called for the profile — production wiring guarantees this in
   /// `ProfileSession.registerWithSyncCoordinator`. If no bundle is
   /// registered and no `fallbackGRDBRepositoriesFactory` was injected
-  /// at coordinator init, the call traps via `preconditionFailure`:
-  /// constructing an empty in-memory bundle on the fly would silently
-  /// swallow GRDB writes (data loss). Tests that drive paths reaching
-  /// here without staging a bundle inject the factory at init time so
-  /// the trap doesn't fire — see `SyncCoordinator.init(... fallbackGRDBRepositoriesFactory:)`.
+  /// at coordinator init, the call throws
+  /// `SyncCoordinatorError.profileNotRegistered`. Each caller decides
+  /// what to do with that error: outbound paths skip + log (records
+  /// stay in GRDB and are picked up on the next backfill scan); the
+  /// inbound apply path traps via `preconditionFailure` because
+  /// `CKSyncEngine` would otherwise advance the server change token
+  /// past unapplied records.
+  ///
+  /// Constructing an empty in-memory bundle on the fly is never an
+  /// option — it would silently swallow GRDB writes. Tests that drive
+  /// paths reaching here without staging a bundle inject the factory
+  /// at init time so the throw doesn't fire — see
+  /// `SyncCoordinator.init(... fallbackGRDBRepositoriesFactory:)`.
   func handlerForProfileZone(
     profileId: UUID, zoneID: CKRecordZone.ID
   ) throws -> ProfileDataSyncHandler {
@@ -31,18 +55,7 @@ extension SyncCoordinator {
       grdbRepositories = try factory(profileId)
       profileGRDBRepositories[profileId] = grdbRepositories
     } else {
-      preconditionFailure(
-        """
-        SyncCoordinator.handlerForProfileZone called for profile \
-        \(profileId.uuidString) without a registered GRDB repository \
-        bundle. This is a wiring bug — \
-        ProfileSession.registerWithSyncCoordinator (production) must call \
-        setProfileGRDBRepositories(profileId:bundle:) before any sync \
-        event for this profile, and tests should either register a bundle \
-        or inject a fallbackGRDBRepositoriesFactory at coordinator init. \
-        Constructing an empty in-memory bundle here would silently swallow \
-        GRDB writes.
-        """)
+      throw SyncCoordinatorError.profileNotRegistered(profileId)
     }
     let onInstrumentRemoteChange = instrumentRemoteChangeCallbacks[profileId] ?? {}
     let handler = ProfileDataSyncHandler(

--- a/Backends/CloudKit/Sync/SyncCoordinator+Lifecycle.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+Lifecycle.swift
@@ -42,6 +42,43 @@ extension SyncCoordinator {
 
   // MARK: - Lifecycle
 
+  /// Spawns and tracks a launch task that waits for the
+  /// SwiftData → GRDB profile-index migration (if any) and then
+  /// invokes `start` (defaults to `self.start()` — production
+  /// callers omit the parameter). Production wiring (see
+  /// `MoolahApp.configureSyncCoordinator`) routes the launch-time
+  /// migration `Task` through here so CKSyncEngine cannot deliver
+  /// fetched profile-data zone changes before the local profile
+  /// index is hydrated. Without the gate, the index reads
+  /// `ProfileStore` performs at launch can return zero profiles, no
+  /// `ProfileSession` gets constructed for the unknown profile id,
+  /// and `handlerForProfileZone(profileId:zoneID:)` traps via
+  /// `preconditionFailure`.
+  ///
+  /// The spawned task is stored on `launchTask` so `stop()` can
+  /// cancel it if the coordinator is torn down before the migration
+  /// finishes; the post-await guard skips the start invocation in
+  /// that case. Calling this method again replaces (and cancels)
+  /// any prior pending launch.
+  ///
+  /// The `start` closure is a test seam so the await ordering can be
+  /// verified without invoking the real `start()`, which constructs
+  /// a `CKSyncEngine` (unsafe in a test process — it requires the
+  /// iCloud entitlement and leaks background work past test
+  /// teardown). Tests await `launchTask?.value` to observe the
+  /// closure firing.
+  func startAfter(
+    profileIndexMigration: Task<Void, Never>?,
+    start: (@MainActor @Sendable () -> Void)? = nil
+  ) {
+    launchTask?.cancel()
+    launchTask = Task { @MainActor [weak self] in
+      await profileIndexMigration?.value
+      guard !Task.isCancelled, let self else { return }
+      (start ?? self.start)()
+    }
+  }
+
   func start() {
     guard !isRunning, startTask == nil else { return }
 
@@ -177,6 +214,8 @@ extension SyncCoordinator {
   }
 
   func stop() {
+    launchTask?.cancel()
+    launchTask = nil
     startTask?.cancel()
     startTask = nil
     zoneSetupTask?.cancel()

--- a/Backends/CloudKit/Sync/SyncCoordinator+RecordChanges.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+RecordChanges.swift
@@ -138,10 +138,31 @@ extension SyncCoordinator {
     deleted: [(CKRecord.ID, String)],
     preExtractedSystemFields: [(String, Data)]
   ) async {
-    // Resolve handler on main (accesses @MainActor-isolated state)
+    // Resolve handler on main (accesses @MainActor-isolated state).
+    //
+    // `profileNotRegistered` is fatal in this path: CKSyncEngine
+    // advances the server change token after this delegate call
+    // returns, so silently skipping the apply would lose records
+    // permanently. Production wiring (`MoolahApp.configureSyncCoordinator`
+    // → `coordinator.startAfter(profileIndexMigration:)`) defers
+    // engine start until the GRDB profile-index migration commits and
+    // `ProfileSession` registers its bundle, so reaching here with no
+    // bundle is an invariant violation. Other thrown errors (e.g.
+    // transient `containerManager.container(for:)` failures) fall
+    // through to the existing log + skip path.
     let handler: ProfileDataSyncHandler? = await MainActor.run {
       do {
         return try handlerForProfileZone(profileId: profileId, zoneID: zoneID)
+      } catch SyncCoordinatorError.profileNotRegistered(let id) {
+        preconditionFailure(
+          """
+          applyFetchedProfileDataChanges called for profile \(id.uuidString) \
+          before its GRDB repository bundle was registered. \
+          startAfter(profileIndexMigration:) must complete before any \
+          CKSyncEngine fetch event lands; reaching here means the gate \
+          failed. Crashing rather than advancing the server change token \
+          past unapplied records — restart will re-fetch.
+          """)
       } catch {
         logger.error("Failed to get handler for profile \(profileId): \(error, privacy: .public)")
         return nil

--- a/Backends/CloudKit/Sync/SyncCoordinator+Zones.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+Zones.swift
@@ -245,6 +245,13 @@ extension SyncCoordinator {
           refreshPendingUploadsMirror()
         }
       }
+      // TODO(#619): if `handlerForProfileZone` threw because the profile's
+      // session has not yet been registered, the records keep their stale
+      // (non-nil) `encodedSystemFields` and the backfill scan won't re-queue
+      // them — `queueUnsyncedRecords` only picks up records where the
+      // system field is nil. Eager session construction will close this gap.
+      // https://github.com/ajsutton/moolah-native/issues/619
+      //
       // System fields were cleared; if a later crash happens before the re-upload
       // persists, the next backfill scan must revisit this profile instead of
       // trusting a stale "complete" flag from before the reset.

--- a/Backends/CloudKit/Sync/SyncCoordinator.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator.swift
@@ -314,6 +314,12 @@ final class SyncCoordinator {
   /// awaited/cancelled from `stop()`.
   var startTask: Task<Void, Never>?
 
+  /// Task spawned by `startAfter(profileIndexMigration:)` that waits for
+  /// the launch-time SwiftData → GRDB profile-index migration to commit
+  /// before invoking `start()`. Held so `stop()` can cancel it if the
+  /// app tears the coordinator down before the migration finishes.
+  var launchTask: Task<Void, Never>?
+
   /// Task for coalescing re-fetch requests after save failures.
   var refetchTask: Task<Void, Never>?
 

--- a/Features/Profiles/ProfileStore+Cloud.swift
+++ b/Features/Profiles/ProfileStore+Cloud.swift
@@ -142,13 +142,27 @@ extension ProfileStore {
 
   // MARK: - Retry scheduling
 
-  /// If the initial load returned no cloud profiles but we expect some (saved activeProfileID
-  /// doesn't match any remote profile), retry once after a short delay. The GRDB
-  /// profile-index DB may not have its migration completed on the first synchronous fetch.
+  /// Recovers from a stale-empty initial load by retrying once after
+  /// a short delay. The launch-time SwiftData → GRDB profile-index
+  /// migration may still be in flight when `ProfileStore.init` runs
+  /// its synchronous and async fetches, so both can return zero
+  /// rows even when the user has profiles. Without the retry the
+  /// re-read never happens: `SessionManager.session(for:)` is
+  /// driven by `profiles`, so an empty list means no
+  /// `ProfileSession` is constructed, and any subsequent CKSyncEngine
+  /// fetch for that profile's data zone traps in
+  /// `SyncCoordinator.handlerForProfileZone(profileId:zoneID:)`.
+  ///
+  /// The retry fires whenever `profiles.isEmpty`, regardless of
+  /// `activeProfileID`. A fresh-install or wiped device legitimately
+  /// has no saved active profile but still needs the post-migration
+  /// re-read so the chain above can complete.
+  ///
+  /// Mechanism: cancels any prior retry, flips `isCloudLoadPending`
+  /// while it sleeps for one second, then calls `loadCloudProfiles()`
+  /// (which itself populates `profiles` from GRDB).
   func scheduleRetryIfNeeded() {
-    guard profiles.isEmpty,
-      activeProfileID != nil
-    else { return }
+    guard profiles.isEmpty else { return }
 
     // Cancel any existing retry before starting a new one so we never run
     // two pending retries concurrently.

--- a/MoolahTests/Features/ProfileStoreTestsMore.swift
+++ b/MoolahTests/Features/ProfileStoreTestsMore.swift
@@ -36,6 +36,24 @@ struct ProfileStoreTestsMore {
     #expect(store.profiles.isEmpty)
   }
 
+  // Regression: a fresh-install / wiped Mac has no saved active profile
+  // but still needs the post-migration retry. Without it the store stays
+  // empty for the rest of the session, no `ProfileSession` ever gets
+  // constructed for incoming sync events, and CKSyncEngine's first
+  // fetch traps in `SyncCoordinator.handlerForProfileZone`.
+  @Test("initial load schedules a retry when cloud store is empty even with no active profile")
+  func initialLoadSchedulesRetryWhenNoActiveProfile() throws {
+    let defaults = makeDefaults()
+    // Intentionally do NOT seed `com.moolah.activeProfileID`.
+
+    let containerManager = try ProfileContainerManager.forTesting()
+    let store = ProfileStore(defaults: defaults, containerManager: containerManager)
+
+    #expect(store.activeProfileID == nil)
+    #expect(store.profiles.isEmpty)
+    #expect(store.isCloudLoadPending == true)
+  }
+
   @Test("remote change resets activeProfileID when cloud profile was deleted")
   func remoteChangeResetsActiveProfileID() async throws {
     let defaults = makeDefaults()

--- a/MoolahTests/Sync/SyncCoordinatorStartGateTests.swift
+++ b/MoolahTests/Sync/SyncCoordinatorStartGateTests.swift
@@ -1,0 +1,118 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+// Verifies `SyncCoordinator.startAfter(profileIndexMigration:start:)`
+// does not invoke the start closure until the supplied profile-index
+// migration task completes. Production wiring relies on this so
+// CKSyncEngine cannot deliver fetched profile-data zone changes
+// before the local profile index is hydrated; otherwise
+// `SyncCoordinator.handlerForProfileZone(profileId:zoneID:)` traps
+// for any profile zone whose `ProfileSession` has not yet been
+// constructed.
+@Suite("SyncCoordinator start gate")
+@MainActor
+struct SyncCoordinatorStartGateTests {
+  private func makeCoordinator() throws -> SyncCoordinator {
+    let manager = try ProfileContainerManager.forTesting()
+    let defaults = try #require(
+      UserDefaults(suiteName: "sync-start-gate-\(UUID().uuidString)"))
+    return SyncCoordinator(
+      containerManager: manager,
+      userDefaults: defaults,
+      isCloudKitAvailable: false)
+  }
+
+  @Test("start closure is not invoked while the migration task is pending")
+  func startAfterWaitsForMigration() async throws {
+    let coordinator = try makeCoordinator()
+    let counter = StartCounter()
+
+    let release = AsyncStream<Void>.makeStream()
+    let migration = Task<Void, Never> {
+      for await _ in release.stream { return }
+    }
+
+    coordinator.startAfter(
+      profileIndexMigration: migration,
+      start: { counter.increment() })
+
+    // Give the launch task plenty of opportunity to begin awaiting.
+    for _ in 0..<10 { await Task.yield() }
+
+    #expect(counter.value == 0)
+
+    release.continuation.finish()
+    await coordinator.launchTask?.value
+
+    #expect(counter.value == 1)
+  }
+
+  @Test("start closure runs immediately when the migration task is nil")
+  func startAfterWithNilMigrationStartsImmediately() async throws {
+    let coordinator = try makeCoordinator()
+    let counter = StartCounter()
+
+    coordinator.startAfter(
+      profileIndexMigration: nil,
+      start: { counter.increment() })
+    await coordinator.launchTask?.value
+
+    #expect(counter.value == 1)
+  }
+
+  @Test("start closure runs immediately when the migration task already finished")
+  func startAfterWithCompletedMigrationStartsImmediately() async throws {
+    let coordinator = try makeCoordinator()
+    let counter = StartCounter()
+
+    let migration = Task<Void, Never> {}
+    await migration.value
+
+    coordinator.startAfter(
+      profileIndexMigration: migration,
+      start: { counter.increment() })
+    await coordinator.launchTask?.value
+
+    #expect(counter.value == 1)
+  }
+
+  @Test("stop() cancels a pending launch and skips the start invocation")
+  func stopCancelsPendingLaunch() async throws {
+    let coordinator = try makeCoordinator()
+    let counter = StartCounter()
+
+    let release = AsyncStream<Void>.makeStream()
+    let migration = Task<Void, Never> {
+      for await _ in release.stream { return }
+    }
+
+    coordinator.startAfter(
+      profileIndexMigration: migration,
+      start: { counter.increment() })
+
+    for _ in 0..<5 { await Task.yield() }
+
+    // Tear the coordinator down while the launch task is still
+    // awaiting the migration. The post-await `Task.isCancelled`
+    // guard must skip the start invocation.
+    coordinator.stop()
+    release.continuation.finish()
+    if let launchTask = coordinator.launchTask { await launchTask.value }
+
+    #expect(counter.value == 0)
+  }
+}
+
+// Reference-typed `@MainActor` counter the injected `start` closure
+// can mutate. A local `var` would be captured by reference too, but
+// `@MainActor @Sendable () -> Void` rejects mutable-var captures in
+// strict-concurrency mode, so the closure needs to write through a
+// reference instead.
+@MainActor
+private final class StartCounter {
+  private(set) var value = 0
+
+  func increment() { value += 1 }
+}

--- a/MoolahTests/Sync/SyncCoordinatorTestsMore.swift
+++ b/MoolahTests/Sync/SyncCoordinatorTestsMore.swift
@@ -104,6 +104,39 @@ struct SyncCoordinatorTestsMore {
     #expect(handler.zoneID == zoneID)
   }
 
+  @Test("handlerForProfileZone throws profileNotRegistered when no bundle and no factory")
+  func handlerForProfileZoneThrowsWhenUnregistered() throws {
+    let manager = try ProfileContainerManager.forTesting()
+    // No `setProfileGRDBRepositories` and no `fallbackGRDBRepositoriesFactory`
+    // — the production wiring-bug condition the throw is meant to surface.
+    let coordinator = SyncCoordinator(containerManager: manager)
+    let profileId = UUID()
+    let zoneID = CKRecordZone.ID(
+      zoneName: "profile-\(profileId.uuidString)",
+      ownerName: CKCurrentUserDefaultName)
+
+    #expect(throws: SyncCoordinatorError.profileNotRegistered(profileId)) {
+      _ = try coordinator.handlerForProfileZone(profileId: profileId, zoneID: zoneID)
+    }
+  }
+
+  @Test("queueUnsyncedRecordsForAllProfiles skips profiles without a registered bundle")
+  func queueUnsyncedRecordsSkipsUnregisteredProfile() async throws {
+    let manager = try ProfileContainerManager.forTesting()
+    // No bundle, no factory: the outbound backfill path must skip the
+    // profile (records remain durable in GRDB and a future scan picks
+    // them up) rather than crash.
+    let coordinator = SyncCoordinator(containerManager: manager)
+    let profileId = UUID()
+    try await manager.profileIndexRepository.upsert(
+      Profile(
+        id: profileId, label: "Unregistered", currencyCode: "AUD",
+        financialYearStartMonth: 7))
+
+    let queued = await coordinator.queueUnsyncedRecordsForAllProfiles()
+    #expect(queued.isEmpty)
+  }
+
   // MARK: - Batch Kind Selection (issue #61)
 
   @Test


### PR DESCRIPTION
## Summary

Mac release app crashed on startup whenever CKSyncEngine delivered fetched profile-data zone changes before the SwiftData → GRDB profile-index migration had committed (or before any `ProfileSession` had been registered for the affected profile id). The trap fired in `SyncCoordinator.handlerForProfileZone(profileId:zoneID:)` via `preconditionFailure` because no per-profile GRDB repository bundle was registered yet.

The bug was reproducible: an investment value added to "Trust Shares" on iPhone (same app version) would arrive on Mac via CloudKit before the local index hydration completed, hitting the trap.

### Changes

- **Migration gate** (`SyncCoordinator.startAfter(profileIndexMigration:)`): deferred engine `start()` until the launch-time migration `Task` completes. The spawned launch is owned by the coordinator (`launchTask`) so `stop()` can cancel it. A `start` closure parameter is a test seam so the await ordering can be verified without invoking real CKSyncEngine.
- **Retry-guard fix** (`ProfileStore.scheduleRetryIfNeeded`): dropped the `activeProfileID != nil` clause. A fresh-install or wiped Mac legitimately has no saved active profile but still needs the post-migration re-read so `SessionManager` can construct a `ProfileSession` before the next sync event arrives.
- **Scoped throws/precondition split** (`handlerForProfileZone` → `SyncCoordinatorError.profileNotRegistered`): outbound paths (backfill, zone-deletion / purge / encrypted-reset, upload-batch building) skip + log via the existing `try?` patterns — records remain durable in GRDB and are re-queued by the next backfill scan or local-mutation hook. The inbound apply path catches the specific case and traps with a detailed message, because CKSyncEngine advances the server change token after the delegate returns and a silent skip would lose records.

### Known follow-up

[#619](https://github.com/ajsutton/moolah-native/issues/619) tracks the broader gap: the trap can also fire for un-sessionized profiles in multi-profile setups (sync event for an unopened profile) and during the brief pre-render window. Eager `ProfileSession` construction in `ProfileStore.applyLoadedProfiles` is the proper fix; out of scope here. Same root cause as the encrypted-reset re-upload skip flagged with `TODO(#619)` in `+Zones.swift:239`.

## Test plan

- [x] `just test` (mac + iOS) passes
- [x] `just format-check` clean (no baseline changes)
- [x] `just validate-todos` clean
- [x] `code-review`, `concurrency-review`, `sync-review` agents — all findings applied; deferred items tracked in #619
- [x] New tests:
  - `SyncCoordinatorStartGateTests` — pending / nil / completed / `stop()`-cancels migration cases (4)
  - `SyncCoordinatorTestsMore.handlerForProfileZoneThrowsWhenUnregistered` — exact-case error assertion
  - `SyncCoordinatorTestsMore.queueUnsyncedRecordsSkipsUnregisteredProfile` — outbound safe-skip
  - `ProfileStoreTestsMore.initialLoadSchedulesRetryWhenNoActiveProfile` — regression for the dropped guard
- [ ] Manual: launch the Mac release build with the iPhone-driven Trust Shares record pending in iCloud — verify no crash and the record applies after migration completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)