### PR TITLE
fix(sync): remove handler-registration precondition (closes #619)

### DIFF
--- a/App/MoolahApp.swift
+++ b/App/MoolahApp.swift
@@ -121,10 +121,14 @@ struct MoolahApp: App {
 
     let sessionManager = SessionManager(
       containerManager: setup.manager, syncCoordinator: coordinator)
-    // Clean up cached sessions when a profile is removed (locally or via
-    // remote sync).
-    store.onProfileRemoved = { [weak sessionManager] profileID in
+    // Clean up cached sessions and the coordinator's per-profile bundle
+    // cache when a profile is removed (locally or via remote sync).
+    // `containerManager.deleteStore` is about to invalidate the
+    // per-profile `DatabaseQueue`; the coordinator's cached handler /
+    // bundle would otherwise outlive it.
+    store.onProfileRemoved = { [weak sessionManager, weak coordinator] profileID in
       sessionManager?.removeSession(for: profileID)
+      coordinator?.evictCachedState(for: profileID)
     }
     Self.configureAutomationService(
       store: store,

--- a/App/ProfileSession+SyncWiring.swift
+++ b/App/ProfileSession+SyncWiring.swift
@@ -1,47 +1,6 @@
 import Foundation
 
 extension ProfileSession {
-  /// Wires the per-profile GRDB repository bundle with the sync
-  /// coordinator so local mutations queue the corresponding CloudKit
-  /// send. The GRDB repos receive their hooks injected at backend
-  /// construction time (see `makeCloudKitBackend`); this method
-  /// publishes the concrete-class instances to `SyncCoordinator` so
-  /// `handlerForProfileZone` can build a `ProfileDataSyncHandler` that
-  /// reaches them.
-  func wireRepositorySync(coordinator: SyncCoordinator) {
-    registerGRDBRepositoriesForSync(coordinator: coordinator)
-  }
-
-  /// Registers the per-profile GRDB repository bundle with the sync
-  /// coordinator so `handlerForProfileZone` can build a
-  /// `ProfileDataSyncHandler` that reaches them. Only registers when the
-  /// backend is a `CloudKitBackend` — preview / test code paths skip
-  /// registration silently.
-  ///
-  /// **Pre-condition.** Must be called before `SyncCoordinator`
-  /// processes any events for this profile. Guaranteed by
-  /// `ProfileSession.init` call order: `wireRepositorySync` (which
-  /// invokes this method) runs in `registerWithSyncCoordinator`, which
-  /// is the last statement of `init`. The first sync event for the
-  /// profile cannot arrive until `init` returns and the session is
-  /// retained by the caller, so registration always wins the race.
-  private func registerGRDBRepositoriesForSync(coordinator: SyncCoordinator) {
-    guard let cloudBackend = backend as? CloudKitBackend else { return }
-    coordinator.setProfileGRDBRepositories(
-      profileId: profile.id,
-      bundle: ProfileGRDBRepositories(
-        csvImportProfiles: cloudBackend.grdbCSVImportProfiles,
-        importRules: cloudBackend.grdbImportRules,
-        instruments: cloudBackend.grdbInstruments,
-        categories: cloudBackend.grdbCategories,
-        accounts: cloudBackend.grdbAccounts,
-        earmarks: cloudBackend.grdbEarmarks,
-        earmarkBudgetItems: cloudBackend.grdbEarmarkBudgetItems,
-        investmentValues: cloudBackend.grdbInvestments,
-        transactions: cloudBackend.grdbTransactions,
-        transactionLegs: cloudBackend.grdbTransactionLegs))
-  }
-
   /// OptionSet for coalesced store reloads after a sync batch.
   struct StoreReloadPlan: OptionSet, Sendable, Equatable {
     let rawValue: Int

--- a/App/ProfileSession.swift
+++ b/App/ProfileSession.swift
@@ -209,7 +209,6 @@ final class ProfileSession: Identifiable {
     self.syncObserverToken = coordinator.addObserver(for: profileId) { [weak self] changedTypes in
       self?.scheduleReloadFromSync(changedTypes: changedTypes)
     }
-    wireRepositorySync(coordinator: coordinator)
   }
 
   // MARK: - CloudKit Sync
@@ -269,7 +268,6 @@ final class ProfileSession: Identifiable {
       syncObserverToken = nil
     }
     coordinator.removeInstrumentRemoteChangeCallback(profileId: profile.id)
-    coordinator.removeProfileGRDBRepositories(profileId: profile.id)
     syncReloadTask?.cancel()
     syncReloadTask = nil
     catalogRefreshTask?.cancel()

--- a/Backends/CloudKit/Sync/ProfileGRDBRepositories.swift
+++ b/Backends/CloudKit/Sync/ProfileGRDBRepositories.swift
@@ -1,6 +1,7 @@
 // Backends/CloudKit/Sync/ProfileGRDBRepositories.swift
 
 import Foundation
+import GRDB
 
 /// Bundle of the GRDB-backed repositories for the per-profile data
 /// handler.
@@ -29,4 +30,62 @@ struct ProfileGRDBRepositories: Sendable {
   let investmentValues: GRDBInvestmentRepository
   let transactions: GRDBTransactionRepository
   let transactionLegs: GRDBTransactionLegRepository
+}
+
+extension ProfileGRDBRepositories {
+  /// Builds a bundle suitable for the sync apply path: every per-type
+  /// repository targets `database`, hooks are no-ops, and the read-side
+  /// `defaultInstrument` / `conversionService` parameters carry inert
+  /// placeholders. The apply path writes Row objects via
+  /// `applyRemoteChangesSync` and never invokes either placeholder; the
+  /// session-side bundle owned by `CloudKitBackend` continues to carry
+  /// real values for user-mutation paths.
+  static func forApply(database: any GRDB.DatabaseWriter) -> ProfileGRDBRepositories {
+    // USD is a stable, locale-independent fiat that satisfies
+    // `Instrument.fiat(code:)`'s `isoCurrencies` lookup. The choice is
+    // arbitrary — only the type matters for the apply path.
+    let placeholderInstrument = Instrument.fiat(code: "USD")
+    return ProfileGRDBRepositories(
+      csvImportProfiles: GRDBCSVImportProfileRepository(database: database),
+      importRules: GRDBImportRuleRepository(database: database),
+      instruments: GRDBInstrumentRegistryRepository(database: database),
+      categories: GRDBCategoryRepository(database: database),
+      accounts: GRDBAccountRepository(database: database),
+      earmarks: GRDBEarmarkRepository(
+        database: database, defaultInstrument: placeholderInstrument),
+      earmarkBudgetItems: GRDBEarmarkBudgetItemRepository(database: database),
+      investmentValues: GRDBInvestmentRepository(
+        database: database, defaultInstrument: placeholderInstrument),
+      transactions: GRDBTransactionRepository(
+        database: database,
+        defaultInstrument: placeholderInstrument,
+        conversionService: ApplyPathConversionService()),
+      transactionLegs: GRDBTransactionLegRepository(database: database))
+  }
+}
+
+/// Placeholder `InstrumentConversionService` for the apply-path bundle.
+/// Reachable only from `ProfileGRDBRepositories.forApply(database:)`;
+/// every method traps because the apply path never reads through the
+/// conversion service. If a future code change starts invoking it from
+/// the apply path, the trap is preferable to silent zero-conversion.
+private struct ApplyPathConversionService: InstrumentConversionService, Sendable {
+  func convert(
+    _ quantity: Decimal,
+    from: Instrument,
+    to: Instrument,
+    on date: Date
+  ) async throws -> Decimal {
+    preconditionFailure(
+      "ApplyPathConversionService.convert called — apply path never converts")
+  }
+
+  func convertAmount(
+    _ amount: InstrumentAmount,
+    to instrument: Instrument,
+    on date: Date
+  ) async throws -> InstrumentAmount {
+    preconditionFailure(
+      "ApplyPathConversionService.convertAmount called — apply path never converts")
+  }
 }

--- a/Backends/CloudKit/Sync/ProfileGRDBRepositories.swift
+++ b/Backends/CloudKit/Sync/ProfileGRDBRepositories.swift
@@ -66,9 +66,11 @@ extension ProfileGRDBRepositories {
 
 /// Placeholder `InstrumentConversionService` for the apply-path bundle.
 /// Reachable only from `ProfileGRDBRepositories.forApply(database:)`;
-/// every method traps because the apply path never reads through the
-/// conversion service. If a future code change starts invoking it from
-/// the apply path, the trap is preferable to silent zero-conversion.
+/// every method throws `ConversionError.unsupportedConversion` because
+/// the apply path never reads through the conversion service. If a
+/// future code change starts invoking it from the apply path, the
+/// error surfaces as a saveFailed result and the offending call site
+/// is identifiable from the logs — preferable to silent zero-conversion.
 private struct ApplyPathConversionService: InstrumentConversionService, Sendable {
   func convert(
     _ quantity: Decimal,
@@ -76,8 +78,7 @@ private struct ApplyPathConversionService: InstrumentConversionService, Sendable
     to: Instrument,
     on date: Date
   ) async throws -> Decimal {
-    preconditionFailure(
-      "ApplyPathConversionService.convert called — apply path never converts")
+    throw ConversionError.unsupportedConversion(from: from.id, to: to.id)
   }
 
   func convertAmount(
@@ -85,7 +86,7 @@ private struct ApplyPathConversionService: InstrumentConversionService, Sendable
     to instrument: Instrument,
     on date: Date
   ) async throws -> InstrumentAmount {
-    preconditionFailure(
-      "ApplyPathConversionService.convertAmount called — apply path never converts")
+    throw ConversionError.unsupportedConversion(
+      from: amount.instrument.id, to: instrument.id)
   }
 }

--- a/Backends/CloudKit/Sync/ProfileGRDBRepositories.swift
+++ b/Backends/CloudKit/Sync/ProfileGRDBRepositories.swift
@@ -40,7 +40,7 @@ extension ProfileGRDBRepositories {
   /// `applyRemoteChangesSync` and never invokes either placeholder; the
   /// session-side bundle owned by `CloudKitBackend` continues to carry
   /// real values for user-mutation paths.
-  static func forApply(database: any GRDB.DatabaseWriter) -> ProfileGRDBRepositories {
+  static func makeForApply(database: any GRDB.DatabaseWriter) -> ProfileGRDBRepositories {
     // USD is a stable, locale-independent fiat that satisfies
     // `Instrument.fiat(code:)`'s `isoCurrencies` lookup. The choice is
     // arbitrary — only the type matters for the apply path.
@@ -65,13 +65,13 @@ extension ProfileGRDBRepositories {
 }
 
 /// Placeholder `InstrumentConversionService` for the apply-path bundle.
-/// Reachable only from `ProfileGRDBRepositories.forApply(database:)`;
+/// Reachable only from `ProfileGRDBRepositories.makeForApply(database:)`;
 /// every method throws `ConversionError.unsupportedConversion` because
 /// the apply path never reads through the conversion service. If a
 /// future code change starts invoking it from the apply path, the
 /// error surfaces as a saveFailed result and the offending call site
 /// is identifiable from the logs — preferable to silent zero-conversion.
-private struct ApplyPathConversionService: InstrumentConversionService, Sendable {
+private struct ApplyPathConversionService: InstrumentConversionService {
   func convert(
     _ quantity: Decimal,
     from: Instrument,

--- a/Backends/CloudKit/Sync/SyncCoordinator+HandlerAccess.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+HandlerAccess.swift
@@ -2,35 +2,18 @@
 import Foundation
 import OSLog
 
-/// Errors thrown by `SyncCoordinator.handlerForProfileZone(profileId:zoneID:)`.
-///
-/// `profileNotRegistered` indicates a wiring-order bug: a sync event
-/// arrived for a profile whose `ProfileSession` has not yet called
-/// `SyncCoordinator.setProfileGRDBRepositories(profileId:bundle:)`.
-/// Outbound paths (backfill, zone deletion / purge / encrypted reset,
-/// upload-batch building) treat this as recoverable and skip the
-/// profile — the records remain durable in GRDB and are re-queued by
-/// the next backfill scan or local-mutation hook. The inbound apply
-/// path (`applyFetchedProfileDataChanges`) treats it as fatal because
-/// `CKSyncEngine` advances the server change token after the delegate
-/// returns, so a silent skip would lose records permanently.
-enum SyncCoordinatorError: Error, Equatable {
-  case profileNotRegistered(UUID)
-}
-
 extension SyncCoordinator {
   // MARK: - Handler Access
 
   /// Returns (or creates) a `ProfileDataSyncHandler` for the given profile zone.
   ///
-  /// Bundle resolution is delegated to `resolveGRDBRepositories(for:)`:
-  /// a session-registered bundle wins; a test-injected factory is next;
-  /// otherwise a fresh apply-path bundle is built via
-  /// `ProfileGRDBRepositories.forApply(database:)` backed by
-  /// `containerManager.database(for:)`. This last branch allows sync
-  /// apply for un-sessionized profiles (multi-profile background apply,
-  /// pre-render race, encrypted reset on an unopened profile) — the
-  /// scenario that motivated issue #619.
+  /// Bundle resolution is delegated to `resolveGRDBRepositories(for:)`, which
+  /// returns a cached bundle if one was built before, or constructs a fresh
+  /// apply-path bundle via `ProfileGRDBRepositories.forApply(database:)` backed
+  /// by `containerManager.database(for:)`. This allows sync apply for
+  /// un-sessionized profiles (multi-profile background apply, pre-render race,
+  /// encrypted reset on an unopened profile) — the scenario that motivated
+  /// issue #619.
   func handlerForProfileZone(
     profileId: UUID, zoneID: CKRecordZone.ID
   ) throws -> ProfileDataSyncHandler {
@@ -50,58 +33,19 @@ extension SyncCoordinator {
     return handler
   }
 
-  /// Returns the per-profile GRDB repository bundle. Prefers a bundle
-  /// registered by `ProfileSession.registerWithSyncCoordinator` (so the
-  /// session and the coordinator share an instance during normal app
-  /// lifetime), then a test-injected factory, then a freshly-built
-  /// apply-path bundle backed by `containerManager.database(for:)`.
-  /// The last branch is what allows sync apply for un-sessionized
-  /// profiles — see issue #619.
+  /// Returns the per-profile GRDB repository bundle, constructing and caching
+  /// it on first access. The bundle is built via
+  /// `ProfileGRDBRepositories.forApply(database:)` backed by
+  /// `containerManager.database(for:)`, which allows sync apply for
+  /// un-sessionized profiles — see issue #619.
   private func resolveGRDBRepositories(for profileId: UUID) throws -> ProfileGRDBRepositories {
-    if let registered = profileGRDBRepositories[profileId] {
-      return registered
-    }
-    if let factory = fallbackGRDBRepositoriesFactory {
-      let bundle = try factory(profileId)
-      profileGRDBRepositories[profileId] = bundle
-      return bundle
+    if let cached = cachedGRDBRepositories[profileId] {
+      return cached
     }
     let database = try containerManager.database(for: profileId)
     let bundle = ProfileGRDBRepositories.forApply(database: database)
-    profileGRDBRepositories[profileId] = bundle
+    cachedGRDBRepositories[profileId] = bundle
     return bundle
-  }
-
-  /// Registers the GRDB repository bundle for a profile. Must be called
-  /// before the first sync event arrives for the profile so
-  /// `handlerForProfileZone` can construct a handler.
-  ///
-  /// If a handler was already cached (e.g. an earlier call constructed
-  /// it via the test-only fallback bundle), the cached entry is cleared
-  /// so the next `handlerForProfileZone` call rebuilds it against the
-  /// freshly-registered bundle. This makes registration idempotent
-  /// across the test/production boundary.
-  func setProfileGRDBRepositories(
-    profileId: UUID, bundle: ProfileGRDBRepositories
-  ) {
-    if dataHandlers[profileId] != nil {
-      logger.info(
-        """
-        GRDB repository bundle registered for profile \
-        \(profileId, privacy: .public) after handler was cached; \
-        clearing cached handler so the next handlerForProfileZone \
-        call rebuilds against the new bundle
-        """
-      )
-      dataHandlers.removeValue(forKey: profileId)
-    }
-    profileGRDBRepositories[profileId] = bundle
-  }
-
-  /// Removes the per-profile GRDB repository bundle (e.g. on session
-  /// teardown so the database queue it captures can be released).
-  func removeProfileGRDBRepositories(profileId: UUID) {
-    profileGRDBRepositories.removeValue(forKey: profileId)
   }
 
   /// Registers the per-profile closure fired by the data handler whenever a

--- a/Backends/CloudKit/Sync/SyncCoordinator+HandlerAccess.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+HandlerAccess.swift
@@ -23,24 +23,14 @@ extension SyncCoordinator {
 
   /// Returns (or creates) a `ProfileDataSyncHandler` for the given profile zone.
   ///
-  /// A GRDB repository bundle MUST have been registered via
-  /// `setProfileGRDBRepositories(profileId:bundle:)` before this is
-  /// called for the profile — production wiring guarantees this in
-  /// `ProfileSession.registerWithSyncCoordinator`. If no bundle is
-  /// registered and no `fallbackGRDBRepositoriesFactory` was injected
-  /// at coordinator init, the call throws
-  /// `SyncCoordinatorError.profileNotRegistered`. Each caller decides
-  /// what to do with that error: outbound paths skip + log (records
-  /// stay in GRDB and are picked up on the next backfill scan); the
-  /// inbound apply path traps via `preconditionFailure` because
-  /// `CKSyncEngine` would otherwise advance the server change token
-  /// past unapplied records.
-  ///
-  /// Constructing an empty in-memory bundle on the fly is never an
-  /// option — it would silently swallow GRDB writes. Tests that drive
-  /// paths reaching here without staging a bundle inject the factory
-  /// at init time so the throw doesn't fire — see
-  /// `SyncCoordinator.init(... fallbackGRDBRepositoriesFactory:)`.
+  /// Bundle resolution is delegated to `resolveGRDBRepositories(for:)`:
+  /// a session-registered bundle wins; a test-injected factory is next;
+  /// otherwise a fresh apply-path bundle is built via
+  /// `ProfileGRDBRepositories.forApply(database:)` backed by
+  /// `containerManager.database(for:)`. This last branch allows sync
+  /// apply for un-sessionized profiles (multi-profile background apply,
+  /// pre-render race, encrypted reset on an unopened profile) — the
+  /// scenario that motivated issue #619.
   func handlerForProfileZone(
     profileId: UUID, zoneID: CKRecordZone.ID
   ) throws -> ProfileDataSyncHandler {
@@ -48,15 +38,7 @@ extension SyncCoordinator {
       return existing
     }
     let container = try containerManager.container(for: profileId)
-    let grdbRepositories: ProfileGRDBRepositories
-    if let registered = profileGRDBRepositories[profileId] {
-      grdbRepositories = registered
-    } else if let factory = fallbackGRDBRepositoriesFactory {
-      grdbRepositories = try factory(profileId)
-      profileGRDBRepositories[profileId] = grdbRepositories
-    } else {
-      throw SyncCoordinatorError.profileNotRegistered(profileId)
-    }
+    let grdbRepositories = try resolveGRDBRepositories(for: profileId)
     let onInstrumentRemoteChange = instrumentRemoteChangeCallbacks[profileId] ?? {}
     let handler = ProfileDataSyncHandler(
       profileId: profileId,
@@ -66,6 +48,28 @@ extension SyncCoordinator {
       onInstrumentRemoteChange: onInstrumentRemoteChange)
     dataHandlers[profileId] = handler
     return handler
+  }
+
+  /// Returns the per-profile GRDB repository bundle. Prefers a bundle
+  /// registered by `ProfileSession.registerWithSyncCoordinator` (so the
+  /// session and the coordinator share an instance during normal app
+  /// lifetime), then a test-injected factory, then a freshly-built
+  /// apply-path bundle backed by `containerManager.database(for:)`.
+  /// The last branch is what allows sync apply for un-sessionized
+  /// profiles — see issue #619.
+  private func resolveGRDBRepositories(for profileId: UUID) throws -> ProfileGRDBRepositories {
+    if let registered = profileGRDBRepositories[profileId] {
+      return registered
+    }
+    if let factory = fallbackGRDBRepositoriesFactory {
+      let bundle = try factory(profileId)
+      profileGRDBRepositories[profileId] = bundle
+      return bundle
+    }
+    let database = try containerManager.database(for: profileId)
+    let bundle = ProfileGRDBRepositories.forApply(database: database)
+    profileGRDBRepositories[profileId] = bundle
+    return bundle
   }
 
   /// Registers the GRDB repository bundle for a profile. Must be called

--- a/Backends/CloudKit/Sync/SyncCoordinator+HandlerAccess.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+HandlerAccess.swift
@@ -38,6 +38,14 @@ extension SyncCoordinator {
   /// `ProfileGRDBRepositories.makeForApply(database:)` backed by
   /// `containerManager.database(for:)`, which allows sync apply for
   /// un-sessionized profiles — see issue #619.
+  ///
+  /// **Main-actor I/O.** First-access resolution opens the per-profile
+  /// `DatabaseQueue` synchronously on `@MainActor`. This matches the
+  /// pre-existing pattern of `containerManager.container(for:)` two
+  /// lines above. The work is bounded (queue init + idempotent schema
+  /// migration) and only happens once per profile per process. Moving
+  /// it off-actor would require `ProfileContainerManager` to expose
+  /// async open methods — a separate refactor.
   private func resolveGRDBRepositories(for profileId: UUID) throws -> ProfileGRDBRepositories {
     if let cached = cachedGRDBRepositories[profileId] {
       return cached
@@ -79,5 +87,16 @@ extension SyncCoordinator {
   /// teardown so the registry it captures can be released).
   func removeInstrumentRemoteChangeCallback(profileId: UUID) {
     instrumentRemoteChangeCallbacks.removeValue(forKey: profileId)
+  }
+
+  /// Drops the cached handler and GRDB repository bundle for a profile
+  /// being removed locally. The coordinator's caches retain
+  /// `DatabaseQueue` references which `ProfileContainerManager.deleteStore`
+  /// is about to invalidate; without this eviction a delayed sync event
+  /// for the deleted profile would write through a stale queue against
+  /// an unlinked file.
+  func evictCachedState(for profileId: UUID) {
+    dataHandlers.removeValue(forKey: profileId)
+    cachedGRDBRepositories.removeValue(forKey: profileId)
   }
 }

--- a/Backends/CloudKit/Sync/SyncCoordinator+HandlerAccess.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+HandlerAccess.swift
@@ -9,7 +9,7 @@ extension SyncCoordinator {
   ///
   /// Bundle resolution is delegated to `resolveGRDBRepositories(for:)`, which
   /// returns a cached bundle if one was built before, or constructs a fresh
-  /// apply-path bundle via `ProfileGRDBRepositories.forApply(database:)` backed
+  /// apply-path bundle via `ProfileGRDBRepositories.makeForApply(database:)` backed
   /// by `containerManager.database(for:)`. This allows sync apply for
   /// un-sessionized profiles (multi-profile background apply, pre-render race,
   /// encrypted reset on an unopened profile) — the scenario that motivated
@@ -35,7 +35,7 @@ extension SyncCoordinator {
 
   /// Returns the per-profile GRDB repository bundle, constructing and caching
   /// it on first access. The bundle is built via
-  /// `ProfileGRDBRepositories.forApply(database:)` backed by
+  /// `ProfileGRDBRepositories.makeForApply(database:)` backed by
   /// `containerManager.database(for:)`, which allows sync apply for
   /// un-sessionized profiles — see issue #619.
   private func resolveGRDBRepositories(for profileId: UUID) throws -> ProfileGRDBRepositories {
@@ -43,7 +43,7 @@ extension SyncCoordinator {
       return cached
     }
     let database = try containerManager.database(for: profileId)
-    let bundle = ProfileGRDBRepositories.forApply(database: database)
+    let bundle = ProfileGRDBRepositories.makeForApply(database: database)
     cachedGRDBRepositories[profileId] = bundle
     return bundle
   }

--- a/Backends/CloudKit/Sync/SyncCoordinator+Lifecycle.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+Lifecycle.swift
@@ -239,6 +239,13 @@ extension SyncCoordinator {
     )
     profileIndexFetchedAtLeastOnce = false
     fetchSessionTouchedIndexZone = false
+    // `dataHandlers` and `cachedGRDBRepositories` are intentionally
+    // retained across `stop()` / `start()` cycles. Both reference the
+    // same `containerManager`-owned `DatabaseQueue` instances, which
+    // remain valid; rebuilding them would just churn allocations. They
+    // are cleared only by `deleteAllLocalData` (sign-out / account
+    // switch), where the queues themselves need to be rebuilt against
+    // the post-reset on-disk state.
     logger.info("Stopped unified sync coordinator")
     progress.didStop()
   }

--- a/Backends/CloudKit/Sync/SyncCoordinator+RecordChanges.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+RecordChanges.swift
@@ -140,29 +140,16 @@ extension SyncCoordinator {
   ) async {
     // Resolve handler on main (accesses @MainActor-isolated state).
     //
-    // `profileNotRegistered` is fatal in this path: CKSyncEngine
-    // advances the server change token after this delegate call
-    // returns, so silently skipping the apply would lose records
-    // permanently. Production wiring (`MoolahApp.configureSyncCoordinator`
-    // → `coordinator.startAfter(profileIndexMigration:)`) defers
-    // engine start until the GRDB profile-index migration commits and
-    // `ProfileSession` registers its bundle, so reaching here with no
-    // bundle is an invariant violation. Other thrown errors (e.g.
-    // transient `containerManager.container(for:)` failures) fall
-    // through to the existing log + skip path.
+    // The catch-and-skip path covers genuinely transient errors from
+    // `containerManager.container(for:)` / `containerManager.database(for:)`
+    // (e.g. disk pressure or a migration in flight). These are recoverable:
+    // CKSyncEngine retries on the next launch and the records remain in
+    // iCloud. No invariant violations can reach this point — the coordinator
+    // constructs its own handler bundle, so `profileNotRegistered` is
+    // unreachable on the apply path.
     let handler: ProfileDataSyncHandler? = await MainActor.run {
       do {
         return try handlerForProfileZone(profileId: profileId, zoneID: zoneID)
-      } catch SyncCoordinatorError.profileNotRegistered(let id) {
-        preconditionFailure(
-          """
-          applyFetchedProfileDataChanges called for profile \(id.uuidString) \
-          before its GRDB repository bundle was registered. \
-          startAfter(profileIndexMigration:) must complete before any \
-          CKSyncEngine fetch event lands; reaching here means the gate \
-          failed. Crashing rather than advancing the server change token \
-          past unapplied records — restart will re-fetch.
-          """)
       } catch {
         logger.error("Failed to get handler for profile \(profileId): \(error, privacy: .public)")
         return nil

--- a/Backends/CloudKit/Sync/SyncCoordinator+Zones.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+Zones.swift
@@ -245,13 +245,6 @@ extension SyncCoordinator {
           refreshPendingUploadsMirror()
         }
       }
-      // TODO(#619): if `handlerForProfileZone` threw because the profile's
-      // session has not yet been registered, the records keep their stale
-      // (non-nil) `encodedSystemFields` and the backfill scan won't re-queue
-      // them — `queueUnsyncedRecords` only picks up records where the
-      // system field is nil. Eager session construction will close this gap.
-      // https://github.com/ajsutton/moolah-native/issues/619
-      //
       // System fields were cleared; if a later crash happens before the re-upload
       // persists, the next backfill scan must revisit this profile instead of
       // trusting a stale "complete" flag from before the reset.

--- a/Backends/CloudKit/Sync/SyncCoordinator+Zones.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+Zones.swift
@@ -144,6 +144,10 @@ extension SyncCoordinator {
       }
     }
     dataHandlers.removeAll()
+    // Release the per-profile GRDB bundle cache. Each entry retains
+    // a `DatabaseQueue` reference; sign-out / account-switch needs
+    // those rebuilt against the post-reset on-disk state.
+    cachedGRDBRepositories.removeAll()
   }
 
   // MARK: - Fetched Database Changes (Zone Deletions)

--- a/Backends/CloudKit/Sync/SyncCoordinator.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator.swift
@@ -290,16 +290,12 @@ final class SyncCoordinator {
   /// can be captured into the handler's `nonisolated` storage.
   var instrumentRemoteChangeCallbacks: [UUID: @Sendable () -> Void] = [:]
 
-  /// Per-profile GRDB repository bundle. Registered by `ProfileSession`
-  /// during `registerWithSyncCoordinator` so it is available when
-  /// `handlerForProfileZone(profileId:zoneID:)` lazily creates the
-  /// `ProfileDataSyncHandler`. The handler's dispatch tables address
-  /// these repositories directly so the per-record-type save / delete
-  /// helpers can write into SQLite without leaking GRDB types into the
-  /// CKSyncEngine wire layer. See `ProfileGRDBRepositories`.
-  var profileGRDBRepositories: [UUID: ProfileGRDBRepositories] = [:]
-  // Test-only fallback factory — see `+HandlerAccess.swift`.
-  let fallbackGRDBRepositoriesFactory: (@Sendable (UUID) throws -> ProfileGRDBRepositories)?
+  /// Per-profile cache of auto-constructed GRDB repository bundles, keyed by
+  /// profile UUID. Populated on first access in
+  /// `resolveGRDBRepositories(for:)` and retained so subsequent calls to
+  /// `handlerForProfileZone` reuse the same bundle without hitting the
+  /// database layer again. See `ProfileGRDBRepositories`.
+  var cachedGRDBRepositories: [UUID: ProfileGRDBRepositories] = [:]
 
   /// Zones with pending zone creation — records in these zones are skipped in nextRecordZoneChangeBatch.
   var pendingZoneCreation: [CKRecordZone.ID: [CKSyncEngine.PendingRecordZoneChange]] = [:]
@@ -349,8 +345,7 @@ final class SyncCoordinator {
   init(
     containerManager: ProfileContainerManager,
     userDefaults: UserDefaults = .standard,
-    isCloudKitAvailable: Bool = CloudKitAuthProvider.isCloudKitAvailable,
-    fallbackGRDBRepositoriesFactory: (@Sendable (UUID) throws -> ProfileGRDBRepositories)? = nil
+    isCloudKitAvailable: Bool = CloudKitAuthProvider.isCloudKitAvailable
   ) {
     self.containerManager = containerManager
     self.userDefaults = userDefaults
@@ -358,7 +353,6 @@ final class SyncCoordinator {
     self.profileIndexHandler = ProfileIndexSyncHandler(
       repository: containerManager.profileIndexRepository)
     self.isCloudKitAvailable = isCloudKitAvailable
-    self.fallbackGRDBRepositoriesFactory = fallbackGRDBRepositoriesFactory
     if !isCloudKitAvailable {
       applyICloudAvailability(.unavailable(reason: .entitlementsMissing))
     }

--- a/Backends/GRDB/Migration/SwiftDataToGRDBMigrator+CoreFinancialGraph.swift
+++ b/Backends/GRDB/Migration/SwiftDataToGRDBMigrator+CoreFinancialGraph.swift
@@ -11,8 +11,10 @@ import SwiftData
 // `migrateCSVImportProfilesIfNeeded` pattern: open a `ModelContext`,
 // fetch all rows, map to the corresponding GRDB row, write inside one
 // `database.write` transaction, then flip the `UserDefaults` flag in
-// the `defer` block once `committed` is true. `upsert` keeps re-runs
-// idempotent if the app crashes between commit and flag-set.
+// the `defer` block once `committed` is true. `insert(onConflict:
+// .ignore)` keeps re-runs idempotent if the app crashes between commit
+// and flag-set, and preserves sync-applied rows that arrived before
+// the migrator ran.
 //
 // **Ordering.** Parents run before children so foreign-key references
 // resolve at commit time. `transaction_leg.account_id` is
@@ -55,7 +57,7 @@ extension SwiftDataToGRDBMigrator {
     if !mappedRows.isEmpty {
       try await database.write { database in
         for row in mappedRows {
-          try row.upsert(database)
+          try row.insert(database, onConflict: .ignore)
         }
       }
     }
@@ -113,12 +115,12 @@ extension SwiftDataToGRDBMigrator {
       logger: logger)
     // Self-referential FK: a category's `parent_id` references another
     // category in the same table. Sort parents before children so the
-    // child upsert has its parent already on disk under the FK pragma.
+    // child insert has its parent already on disk under the FK pragma.
     let mappedRows = Self.sortCategoriesParentFirst(unsortedRows)
     if !mappedRows.isEmpty {
       try await database.write { database in
         for row in mappedRows {
-          try row.upsert(database)
+          try row.insert(database, onConflict: .ignore)
         }
       }
     }
@@ -204,7 +206,7 @@ extension SwiftDataToGRDBMigrator {
     if !mappedRows.isEmpty {
       try await database.write { database in
         for row in mappedRows {
-          try row.upsert(database)
+          try row.insert(database, onConflict: .ignore)
         }
       }
     }

--- a/Backends/GRDB/Migration/SwiftDataToGRDBMigrator+Earmarks.swift
+++ b/Backends/GRDB/Migration/SwiftDataToGRDBMigrator+Earmarks.swift
@@ -7,8 +7,8 @@ import SwiftData
 // Per-type SwiftData → GRDB migrators for the earmark half of the core
 // financial graph (earmarks, earmark budget items, investment values).
 // Companion to `SwiftDataToGRDBMigrator+CoreFinancialGraph.swift`. Same
-// pattern: `defer`-then-flag, idempotent `upsert`, ordered so parents
-// commit before children.
+// pattern: `defer`-then-flag, idempotent `insert(onConflict: .ignore)`,
+// ordered so parents commit before children.
 
 extension SwiftDataToGRDBMigrator {
 
@@ -41,7 +41,7 @@ extension SwiftDataToGRDBMigrator {
     if !mappedRows.isEmpty {
       try await database.write { database in
         for row in mappedRows {
-          try row.upsert(database)
+          try row.insert(database, onConflict: .ignore)
         }
       }
     }
@@ -97,7 +97,7 @@ extension SwiftDataToGRDBMigrator {
     if !mappedRows.isEmpty {
       try await database.write { database in
         for row in mappedRows {
-          try row.upsert(database)
+          try row.insert(database, onConflict: .ignore)
         }
       }
     }
@@ -147,7 +147,7 @@ extension SwiftDataToGRDBMigrator {
     if !mappedRows.isEmpty {
       try await database.write { database in
         for row in mappedRows {
-          try row.upsert(database)
+          try row.insert(database, onConflict: .ignore)
         }
       }
     }

--- a/Backends/GRDB/Migration/SwiftDataToGRDBMigrator+ProfileIndex.swift
+++ b/Backends/GRDB/Migration/SwiftDataToGRDBMigrator+ProfileIndex.swift
@@ -34,8 +34,10 @@ extension SwiftDataToGRDBMigrator {
   ///
   /// The `committed` defer pattern matches the per-profile migrators:
   /// the gating flag is set only after the GRDB transaction commits,
-  /// and `upsert` (rather than `insert`) keeps a re-run after a crash
-  /// between commit and flag-set harmless.
+  /// and `insert(onConflict: .ignore)` keeps a re-run after a crash
+  /// between commit and flag-set harmless, and preserves any
+  /// sync-applied row so it is not overwritten by an older SwiftData
+  /// copy.
   ///
   /// `encodedSystemFields` is copied byte-for-byte. Decoding it would
   /// lose precision (the `NSKeyedArchiver` round-trip is not guaranteed
@@ -68,7 +70,7 @@ extension SwiftDataToGRDBMigrator {
     if !mappedRows.isEmpty {
       try await profileIndexDatabase.write { database in
         for row in mappedRows {
-          try row.upsert(database)
+          try row.insert(database, onConflict: .ignore)
         }
       }
     }

--- a/Backends/GRDB/Migration/SwiftDataToGRDBMigrator+Transactions.swift
+++ b/Backends/GRDB/Migration/SwiftDataToGRDBMigrator+Transactions.swift
@@ -7,8 +7,8 @@ import SwiftData
 // Per-type SwiftData → GRDB migrators for the transaction half of the
 // core financial graph (transactions and transaction legs). Companion
 // to `SwiftDataToGRDBMigrator+CoreFinancialGraph.swift`. Same pattern:
-// `defer`-then-flag, idempotent `upsert`, ordered so parents commit
-// before children.
+// `defer`-then-flag, idempotent `insert(onConflict: .ignore)`, ordered
+// so parents commit before children.
 
 extension SwiftDataToGRDBMigrator {
 
@@ -41,7 +41,7 @@ extension SwiftDataToGRDBMigrator {
     if !mappedRows.isEmpty {
       try await database.write { database in
         for row in mappedRows {
-          try row.upsert(database)
+          try row.insert(database, onConflict: .ignore)
         }
       }
     }
@@ -103,7 +103,7 @@ extension SwiftDataToGRDBMigrator {
     if !mappedRows.isEmpty {
       try await database.write { database in
         for row in mappedRows {
-          try row.upsert(database)
+          try row.insert(database, onConflict: .ignore)
         }
       }
     }

--- a/Backends/GRDB/Migration/SwiftDataToGRDBMigrator.swift
+++ b/Backends/GRDB/Migration/SwiftDataToGRDBMigrator.swift
@@ -11,12 +11,15 @@ import SwiftData
 /// re-runs against an already-populated table.
 ///
 /// **Idempotency.** Set the flag *only* after the GRDB transaction
-/// commits. The write path uses `upsert` rather than `insert` so a
-/// crash *between* the transaction commit and the `defaults.set(...)`
+/// commits. The write path uses `insert(onConflict: .ignore)` so that
+/// a crash *between* the transaction commit and the `defaults.set(...)`
 /// call (the unavoidable gap) re-running on next launch is harmless —
-/// the upsert no-ops on already-present rows. A `defer { committed ?
-/// flag = true : () }` pattern makes the flag-set-on-success invariant
-/// structurally visible.
+/// insert-or-ignore silently skips already-present rows. Critically,
+/// insert-or-ignore also preserves any row written by sync apply
+/// *before* the migrator runs: a sync-applied row represents a
+/// server-authoritative version and must never be clobbered by an
+/// older SwiftData copy. A `defer { committed ? flag = true : () }`
+/// pattern makes the flag-set-on-success invariant structurally visible.
 ///
 /// **Bit-for-bit `encodedSystemFields`.** The migrator copies the cached
 /// CKRecord change-tag blob byte-for-byte from the SwiftData row to the
@@ -103,7 +106,7 @@ struct SwiftDataToGRDBMigrator {
   /// `async throws` because each per-type migrator awaits
   /// `database.write { ... }` to push the GRDB transaction onto GRDB's
   /// own writer queue (off-MainActor) instead of holding the calling
-  /// thread for the duration of the upsert. The bounded SwiftData
+  /// thread for the duration of the insert. The bounded SwiftData
   /// fetch stays on `@MainActor` (where the `mainContext`-bound
   /// container requires it). Total work is bounded by the row counts
   /// in the source SwiftData store. The eight v3 migrators run in
@@ -137,7 +140,7 @@ struct SwiftDataToGRDBMigrator {
     // Core financial graph — parents before children so each
     // transaction's FK references resolve at commit. PRAGMA
     // foreign_keys = ON is in effect; an unresolved parent fails the
-    // upsert loudly, which is the correct behaviour.
+    // insert loudly, which is the correct behaviour.
     try await migrateInstrumentsIfNeeded(
       modelContainer: modelContainer, database: database, defaults: defaults)
     try await migrateCategoriesIfNeeded(
@@ -174,9 +177,10 @@ struct SwiftDataToGRDBMigrator {
     // The `committed` flag is flipped after the write transaction commits
     // and consulted by the `defer` block — making the
     // "flag is set iff the write committed" invariant visible without
-    // duplicating the success path. `upsert` (rather than `insert`)
-    // keeps re-runs harmless if the app crashes between commit and
-    // flag-set: existing rows are a no-op match.
+    // duplicating the success path. `insert(onConflict: .ignore)` keeps
+    // re-runs harmless if the app crashes between commit and flag-set,
+    // and also preserves any sync-applied row that already exists in GRDB
+    // so it is not clobbered by an older SwiftData copy.
     var committed = false
     var rowCount = 0
     defer {
@@ -198,7 +202,7 @@ struct SwiftDataToGRDBMigrator {
     if !mappedRows.isEmpty {
       try await database.write { database in
         for row in mappedRows {
-          try row.upsert(database)
+          try row.insert(database, onConflict: .ignore)
         }
       }
     }
@@ -234,7 +238,8 @@ struct SwiftDataToGRDBMigrator {
   ) async throws {
     guard !defaults.bool(forKey: Self.importRulesFlag) else { return }
     // See `migrateCSVImportProfilesIfNeeded` for why this uses a
-    // `committed` defer flag and `upsert` (idempotent re-migration).
+    // `committed` defer flag and `insert(onConflict: .ignore)`
+    // (idempotent re-migration; preserves sync-applied rows).
     var committed = false
     var rowCount = 0
     defer {
@@ -256,7 +261,7 @@ struct SwiftDataToGRDBMigrator {
     if !mappedRows.isEmpty {
       try await database.write { database in
         for row in mappedRows {
-          try row.upsert(database)
+          try row.insert(database, onConflict: .ignore)
         }
       }
     }

--- a/MoolahTests/Backends/GRDB/CoreGraphMigratorFailureTests.swift
+++ b/MoolahTests/Backends/GRDB/CoreGraphMigratorFailureTests.swift
@@ -1,0 +1,73 @@
+// MoolahTests/Backends/GRDB/CoreGraphMigratorFailureTests.swift
+
+import Foundation
+import GRDB
+import SwiftData
+import Testing
+
+@testable import Moolah
+
+/// Failure-path coverage for the eight per-type core-graph migrators
+/// (instruments, categories, accounts, earmarks, earmark budget items,
+/// investment values, transactions, transaction legs). Lives in its own
+/// file so `SwiftDataToGRDBMigratorCoreGraphTests` stays under the
+/// `type_body_length` cap.
+@Suite("SwiftData → GRDB migrator — core-graph failure", .serialized)
+@MainActor
+struct CoreGraphMigratorFailureTests {
+  private func makeIsolatedDefaults() -> UserDefaults {
+    let suite = "migrator-core-graph-failure-\(UUID().uuidString)"
+    return UserDefaults(suiteName: suite) ?? .standard
+  }
+
+  /// Pins the `committed = false` invariant for the eight per-type
+  /// core-graph migrators: when the very first per-type write fails, no
+  /// downstream migrator runs, no `*Flag` UserDefaults key flips, and
+  /// the GRDB tables stay empty so the next launch re-runs the chain.
+  /// One test against the first link in the chain (`instrument`) covers
+  /// the shared `committed`/`defer` pattern for all eight; instruments
+  /// runs first in `migrateIfNeeded`, so any failure on its insert
+  /// aborts the rest of the pipeline.
+  @Test("core-graph migration: GRDB write failure leaves every flag unset for retry")
+  func coreGraphMigrationFailureKeepsFlagsUnset() async throws {
+    let container = try TestModelContainer.create()
+    let database = try ProfileDatabase.openInMemory()
+    let context = ModelContext(container)
+    context.insert(
+      InstrumentRecord(id: "AUD", kind: "fiatCurrency", name: "AUD", decimals: 2))
+    try context.save()
+
+    // Force the insert inside `migrateInstrumentsIfNeeded` to fail by
+    // installing a BEFORE-INSERT trigger that aborts. `RAISE(ABORT, ...)`
+    // propagates as a thrown error even with `onConflict: .ignore`
+    // (IGNORE suppresses conflict-resolution errors, not RAISE(ABORT)).
+    try await database.write { database in
+      try database.execute(
+        sql: """
+          CREATE TRIGGER abort_instrument_migration
+          BEFORE INSERT ON instrument
+          BEGIN SELECT RAISE(ABORT, 'forced'); END;
+          """)
+    }
+
+    let defaults = makeIsolatedDefaults()
+    await #expect(throws: (any Error).self) {
+      try await SwiftDataToGRDBMigrator().migrateIfNeeded(
+        modelContainer: container, database: database, defaults: defaults)
+    }
+
+    // Every per-type flag must remain false so the next launch retries.
+    #expect(!defaults.bool(forKey: SwiftDataToGRDBMigrator.instrumentsFlag))
+    #expect(!defaults.bool(forKey: SwiftDataToGRDBMigrator.categoriesFlag))
+    #expect(!defaults.bool(forKey: SwiftDataToGRDBMigrator.accountsFlag))
+    #expect(!defaults.bool(forKey: SwiftDataToGRDBMigrator.earmarksFlag))
+    #expect(!defaults.bool(forKey: SwiftDataToGRDBMigrator.earmarkBudgetItemsFlag))
+    #expect(!defaults.bool(forKey: SwiftDataToGRDBMigrator.investmentValuesFlag))
+    #expect(!defaults.bool(forKey: SwiftDataToGRDBMigrator.transactionsFlag))
+    #expect(!defaults.bool(forKey: SwiftDataToGRDBMigrator.transactionLegsFlag))
+    let count = try await database.read { reader in
+      try InstrumentRow.fetchCount(reader)
+    }
+    #expect(count == 0, "Failed write must leave the instrument table empty")
+  }
+}

--- a/MoolahTests/Backends/GRDB/SwiftDataToGRDBMigratorProfileIndexTests.swift
+++ b/MoolahTests/Backends/GRDB/SwiftDataToGRDBMigratorProfileIndexTests.swift
@@ -156,17 +156,28 @@ struct SwiftDataToGRDBMigratorProfileIndexTests {
     let container = try makeIndexContainer()
     let database = try ProfileIndexDatabase.openInMemory()
     let context = ModelContext(container)
-    // `financial_year_start_month BETWEEN 1 AND 12` is enforced by a
-    // SQLite CHECK constraint in `ProfileIndexSchema`. SwiftData has no
-    // validation on `@Model`, so 13 round-trips through the source and
-    // trips the CHECK at upsert time.
-    let bad = ProfileRecord(
+    let profile = ProfileRecord(
       id: UUID(),
-      label: "Bad",
+      label: "Personal",
       currencyCode: "AUD",
-      financialYearStartMonth: 13)
-    context.insert(bad)
+      financialYearStartMonth: 7)
+    context.insert(profile)
     try context.save()
+
+    // Force the insert inside `migrateProfileIndexIfNeeded` to fail by
+    // installing a BEFORE-INSERT trigger that aborts. `RAISE(ABORT, ...)`
+    // propagates as a thrown error even with `onConflict: .ignore`
+    // (IGNORE suppresses conflict-resolution errors, not RAISE(ABORT)).
+    // The migrator's `committed = true` line runs *after* the write block;
+    // if the write throws, the flag must stay false.
+    try await database.write { database in
+      try database.execute(
+        sql: """
+          CREATE TRIGGER abort_profile_migration
+          BEFORE INSERT ON profile
+          BEGIN SELECT RAISE(ABORT, 'forced'); END;
+          """)
+    }
 
     let defaults = makeIsolatedDefaults()
     let migrator = SwiftDataToGRDBMigrator()
@@ -179,10 +190,6 @@ struct SwiftDataToGRDBMigratorProfileIndexTests {
     #expect(
       !defaults.bool(forKey: SwiftDataToGRDBMigrator.profileIndexFlag),
       "Flag must remain false so the next launch retries")
-    let count = try await database.read { database in
-      try ProfileRow.fetchCount(database)
-    }
-    #expect(count == 0, "Failed write must leave the GRDB table empty")
   }
 
   // MARK: - Empty source

--- a/MoolahTests/Backends/GRDB/SwiftDataToGRDBMigratorProfileIndexTests.swift
+++ b/MoolahTests/Backends/GRDB/SwiftDataToGRDBMigratorProfileIndexTests.swift
@@ -190,6 +190,10 @@ struct SwiftDataToGRDBMigratorProfileIndexTests {
     #expect(
       !defaults.bool(forKey: SwiftDataToGRDBMigrator.profileIndexFlag),
       "Flag must remain false so the next launch retries")
+    let rowCount = try await database.read { database in
+      try ProfileRow.fetchCount(database)
+    }
+    #expect(rowCount == 0, "Failed write must leave the GRDB table empty")
   }
 
   // MARK: - Empty source

--- a/MoolahTests/Support/ProfileDataSyncHandlerTestSupport.swift
+++ b/MoolahTests/Support/ProfileDataSyncHandlerTestSupport.swift
@@ -217,43 +217,6 @@ enum ProfileDataSyncHandlerTestSupport {
       encodedSystemFields: record.encodedSystemFields)
   }
 
-  /// `@Sendable` factory closure suitable for
-  /// `SyncCoordinator.init(... fallbackGRDBRepositoriesFactory:)`. Each
-  /// invocation builds a fresh in-memory `ProfileGRDBRepositories` so
-  /// `SyncCoordinator` tests that drive `handlerForProfileZone` (directly
-  /// or via `queueAllRecordsAfterImport` etc.) don't have to register a
-  /// bundle for every profile they touch.
-  static let inMemoryFallbackFactory: @Sendable (UUID) throws -> ProfileGRDBRepositories = { _ in
-    let database = try ProfileDatabase.openInMemory()
-    return Self.makeBundle(database: database, instrument: .defaultTestInstrument)
-  }
-
-  /// Builds a fallback factory that resolves each profile's GRDB
-  /// repositories against the queue cached on the supplied
-  /// `ProfileContainerManager`. Use this from `SyncCoordinator` tests
-  /// that seed the manager's per-profile container and expect those
-  /// rows to surface through the coordinator's handler. Pairs with
-  /// `mirrorContainerToDatabase` so legacy SwiftData seeds round-trip
-  /// to GRDB.
-  @MainActor
-  static func managerBackedFallbackFactory(
-    manager: ProfileContainerManager
-  ) -> @Sendable (UUID) throws -> ProfileGRDBRepositories {
-    // The manager itself is `@MainActor`-isolated, so the closure must
-    // re-enter the main actor to ask for the queue. `MainActor.assumeIsolated`
-    // is safe here because tests that drive the factory route through
-    // SyncCoordinator methods that themselves run on the main actor.
-    { profileId in
-      try MainActor.assumeIsolated {
-        let database = try manager.database(for: profileId)
-        let container = try manager.container(for: profileId)
-        try Self.mirrorContainerToDatabase(
-          container: container, database: database)
-        return Self.makeBundle(database: database, instrument: .defaultTestInstrument)
-      }
-    }
-  }
-
   /// Three-value variant for tests that need to verify GRDB-side state.
   /// The caller retains a reference to `database` so the in-memory queue
   /// outlives the test's repos.

--- a/MoolahTests/Sync/SwiftDataToGRDBMigratorPreserveTests.swift
+++ b/MoolahTests/Sync/SwiftDataToGRDBMigratorPreserveTests.swift
@@ -1,0 +1,86 @@
+// MoolahTests/Sync/SwiftDataToGRDBMigratorPreserveTests.swift
+
+import Foundation
+import GRDB
+import SwiftData
+import Testing
+
+@testable import Moolah
+
+@Suite("SwiftDataToGRDBMigrator — preserve")
+@MainActor
+struct SwiftDataToGRDBMigratorPreserveTests {
+
+  private func makeIsolatedDefaults(suffix: String) -> UserDefaults {
+    let suiteName = "com.moolah.migrator-preserve-tests.\(suffix)"
+    let defaults = UserDefaults(suiteName: suiteName) ?? .standard
+    defaults.removePersistentDomain(forName: suiteName)
+    return defaults
+  }
+
+  /// Per-type pinned: the migrator does not overwrite a GRDB row that
+  /// sync wrote first (newer truth). The flag still latches.
+  @Test("migrator does not clobber a GRDB row that already exists")
+  func migratorPreservesExistingGRDBRow() async throws {
+    let container = try TestModelContainer.create()
+    let database = try ProfileDatabase.openInMemory()
+    let defaults = makeIsolatedDefaults(suffix: UUID().uuidString)
+
+    // Seed SwiftData with one CategoryRecord.
+    let context = ModelContext(container)
+    let categoryId = UUID()
+    let swiftDataRecord = CategoryRecord(
+      id: categoryId,
+      name: "From SwiftData",
+      parentId: nil)
+    swiftDataRecord.encodedSystemFields = Data([0x01, 0x02, 0x03])
+    context.insert(swiftDataRecord)
+    try context.save()
+
+    // Pre-seed GRDB with a *different* row for the same id (simulating
+    // the sync-applied row).
+    try await database.write { writer in
+      try CategoryRow(
+        id: categoryId,
+        recordName: CategoryRow.recordName(for: categoryId),
+        name: "From CloudKit",
+        parentId: nil,
+        encodedSystemFields: Data([0xAA, 0xBB, 0xCC])
+      ).insert(writer)
+    }
+
+    try await SwiftDataToGRDBMigrator().migrateIfNeeded(
+      modelContainer: container, database: database, defaults: defaults)
+
+    let stored = try await database.read { reader in
+      try CategoryRow.filter(CategoryRow.Columns.id == categoryId).fetchOne(reader)
+    }
+    #expect(stored?.name == "From CloudKit")
+    #expect(stored?.encodedSystemFields == Data([0xAA, 0xBB, 0xCC]))
+    #expect(defaults.bool(forKey: SwiftDataToGRDBMigrator.categoriesFlag))
+  }
+
+  /// Sanity: empty GRDB still gets seeded from SwiftData.
+  @Test("migrator still seeds empty GRDB tables")
+  func migratorSeedsEmptyGRDB() async throws {
+    let container = try TestModelContainer.create()
+    let database = try ProfileDatabase.openInMemory()
+    let defaults = makeIsolatedDefaults(suffix: UUID().uuidString)
+
+    let context = ModelContext(container)
+    let categoryId = UUID()
+    let record = CategoryRecord(id: categoryId, name: "Seed me", parentId: nil)
+    record.encodedSystemFields = Data()
+    context.insert(record)
+    try context.save()
+
+    try await SwiftDataToGRDBMigrator().migrateIfNeeded(
+      modelContainer: container, database: database, defaults: defaults)
+
+    let stored = try await database.read { reader in
+      try CategoryRow.filter(CategoryRow.Columns.id == categoryId).fetchOne(reader)
+    }
+    #expect(stored?.name == "Seed me")
+    #expect(defaults.bool(forKey: SwiftDataToGRDBMigrator.categoriesFlag))
+  }
+}

--- a/MoolahTests/Sync/SyncCoordinatorBackfillFlagTests.swift
+++ b/MoolahTests/Sync/SyncCoordinatorBackfillFlagTests.swift
@@ -26,8 +26,7 @@ struct SyncCoordinatorBackfillFlagTests {
     let defaults = try makeDefaults()
     let coordinator = SyncCoordinator(
       containerManager: manager,
-      userDefaults: defaults,
-      fallbackGRDBRepositoriesFactory: ProfileDataSyncHandlerTestSupport.inMemoryFallbackFactory)
+      userDefaults: defaults)
 
     let profileId = UUID()
     let indexContext = ModelContext(manager.indexContainer)
@@ -39,10 +38,14 @@ struct SyncCoordinatorBackfillFlagTests {
 
     // Seed an unsynced record and scan so the flag is set.
     let accountId = UUID()
-    let context = ModelContext(try manager.container(for: profileId))
+    let container = try manager.container(for: profileId)
+    let context = ModelContext(container)
     context.insert(
       AccountRecord(id: accountId, name: "A1", type: "bank", position: 0, isHidden: false))
     try context.save()
+    let database = try manager.database(for: profileId)
+    try ProfileDataSyncHandlerTestSupport.mirrorContainerToDatabase(
+      container: container, database: database)
     _ = await coordinator.queueUnsyncedRecordsForAllProfiles()
 
     // Simulate the sign-out handler firing.
@@ -63,8 +66,7 @@ struct SyncCoordinatorBackfillFlagTests {
     let defaults = try makeDefaults()
     let coordinator = SyncCoordinator(
       containerManager: manager,
-      userDefaults: defaults,
-      fallbackGRDBRepositoriesFactory: ProfileDataSyncHandlerTestSupport.inMemoryFallbackFactory)
+      userDefaults: defaults)
 
     let profileId = UUID()
     let indexContext = ModelContext(manager.indexContainer)
@@ -75,10 +77,14 @@ struct SyncCoordinatorBackfillFlagTests {
     try indexContext.save()
 
     let accountId = UUID()
-    let context = ModelContext(try manager.container(for: profileId))
+    let container = try manager.container(for: profileId)
+    let context = ModelContext(container)
     context.insert(
       AccountRecord(id: accountId, name: "A1", type: "bank", position: 0, isHidden: false))
     try context.save()
+    let database = try manager.database(for: profileId)
+    try ProfileDataSyncHandlerTestSupport.mirrorContainerToDatabase(
+      container: container, database: database)
     _ = await coordinator.queueUnsyncedRecordsForAllProfiles()
 
     let zoneID = CKRecordZone.ID(
@@ -98,8 +104,7 @@ struct SyncCoordinatorBackfillFlagTests {
     let defaults = try makeDefaults()
     let coordinator = SyncCoordinator(
       containerManager: manager,
-      userDefaults: defaults,
-      fallbackGRDBRepositoriesFactory: ProfileDataSyncHandlerTestSupport.inMemoryFallbackFactory)
+      userDefaults: defaults)
 
     let profileId = UUID()
     let indexContext = ModelContext(manager.indexContainer)
@@ -109,10 +114,14 @@ struct SyncCoordinatorBackfillFlagTests {
         financialYearStartMonth: 7, createdAt: Date()))
     try indexContext.save()
 
-    let context = ModelContext(try manager.container(for: profileId))
+    let container = try manager.container(for: profileId)
+    let context = ModelContext(container)
     context.insert(
       AccountRecord(id: UUID(), name: "A1", type: "bank", position: 0, isHidden: false))
     try context.save()
+    let database = try manager.database(for: profileId)
+    try ProfileDataSyncHandlerTestSupport.mirrorContainerToDatabase(
+      container: container, database: database)
     _ = await coordinator.queueUnsyncedRecordsForAllProfiles()
 
     let zoneID = CKRecordZone.ID(

--- a/MoolahTests/Sync/SyncCoordinatorRegistrationFreeTests.swift
+++ b/MoolahTests/Sync/SyncCoordinatorRegistrationFreeTests.swift
@@ -1,0 +1,47 @@
+import CloudKit
+import Foundation
+import SwiftData
+import Testing
+
+@testable import Moolah
+
+/// Regression tests for issue #619: a sync event for a profile whose
+/// `ProfileSession` is not open must apply successfully. Before the fix,
+/// `SyncCoordinator.handlerForProfileZone` threw
+/// `SyncCoordinatorError.profileNotRegistered` and the apply path
+/// trapped via `preconditionFailure`. After the fix, the coordinator
+/// constructs the per-profile GRDB repositories on demand from
+/// `containerManager.database(for:)`.
+@Suite("SyncCoordinator — registration-free apply")
+@MainActor
+struct SyncCoordinatorRegistrationFreeTests {
+  @Test("handlerForProfileZone constructs a handler when no bundle is registered")
+  func handlerConstructedWithoutRegistration() throws {
+    let manager = try ProfileContainerManager.forTesting()
+    let coordinator = SyncCoordinator(containerManager: manager)
+    let profileId = UUID()
+    let zoneID = CKRecordZone.ID(
+      zoneName: "profile-\(profileId.uuidString)",
+      ownerName: CKCurrentUserDefaultName)
+
+    let handler = try coordinator.handlerForProfileZone(profileId: profileId, zoneID: zoneID)
+
+    #expect(handler.profileId == profileId)
+    #expect(handler.zoneID == zoneID)
+  }
+
+  @Test("a second call returns the cached handler")
+  func handlerCachedAcrossCalls() throws {
+    let manager = try ProfileContainerManager.forTesting()
+    let coordinator = SyncCoordinator(containerManager: manager)
+    let profileId = UUID()
+    let zoneID = CKRecordZone.ID(
+      zoneName: "profile-\(profileId.uuidString)",
+      ownerName: CKCurrentUserDefaultName)
+
+    let first = try coordinator.handlerForProfileZone(profileId: profileId, zoneID: zoneID)
+    let second = try coordinator.handlerForProfileZone(profileId: profileId, zoneID: zoneID)
+
+    #expect(first === second)
+  }
+}

--- a/MoolahTests/Sync/SyncCoordinatorRegistrationFreeTests.swift
+++ b/MoolahTests/Sync/SyncCoordinatorRegistrationFreeTests.swift
@@ -86,4 +86,38 @@ struct SyncCoordinatorRegistrationFreeTests {
     }
     #expect(stored?.name == "Synced from another device")
   }
+
+  @Test("encrypted-data-reset clears system fields and re-queues records without session")
+  func encryptedResetWithoutSession() async throws {
+    let manager = try ProfileContainerManager.forTesting()
+    let coordinator = SyncCoordinator(containerManager: manager)
+    let profileId = UUID()
+    try await manager.profileIndexRepository.upsert(
+      Profile(
+        id: profileId, label: "Reset", currencyCode: "AUD",
+        financialYearStartMonth: 7))
+    let zoneID = CKRecordZone.ID(
+      zoneName: "profile-\(profileId.uuidString)",
+      ownerName: CKCurrentUserDefaultName)
+
+    // Seed a row directly in GRDB with a non-nil encodedSystemFields.
+    let database = try manager.database(for: profileId)
+    let categoryId = UUID()
+    try await database.write { db in
+      try CategoryRow(
+        id: categoryId,
+        recordName: CategoryRow.recordName(for: categoryId),
+        name: "Reset me",
+        parentId: nil,
+        encodedSystemFields: Data([0xDE, 0xAD, 0xBE, 0xEF])
+      ).insert(db)
+    }
+
+    coordinator.handleEncryptedDataReset(zoneID, zoneType: .profileData(profileId))
+
+    let stored = try await database.read { db in
+      try CategoryRow.filter(CategoryRow.Columns.id == categoryId).fetchOne(db)
+    }
+    #expect(stored?.encodedSystemFields == nil)
+  }
 }

--- a/MoolahTests/Sync/SyncCoordinatorRegistrationFreeTests.swift
+++ b/MoolahTests/Sync/SyncCoordinatorRegistrationFreeTests.swift
@@ -1,5 +1,6 @@
 import CloudKit
 import Foundation
+import GRDB
 import SwiftData
 import Testing
 
@@ -43,5 +44,46 @@ struct SyncCoordinatorRegistrationFreeTests {
     let second = try coordinator.handlerForProfileZone(profileId: profileId, zoneID: zoneID)
 
     #expect(first === second)
+  }
+
+  @Test("applyFetchedRecordZoneChanges writes rows for an un-sessionized profile")
+  func applyWritesRowsWithoutSession() async throws {
+    let manager = try ProfileContainerManager.forTesting()
+    let coordinator = SyncCoordinator(containerManager: manager)
+    let profileId = UUID()
+    try await manager.profileIndexRepository.upsert(
+      Profile(
+        id: profileId, label: "Background", currencyCode: "AUD",
+        financialYearStartMonth: 7))
+    let zoneID = CKRecordZone.ID(
+      zoneName: "profile-\(profileId.uuidString)",
+      ownerName: CKCurrentUserDefaultName)
+
+    let accountId = UUID()
+    let record = CKRecord(
+      recordType: AccountRow.recordType,
+      recordID: CKRecord.ID(
+        recordName: AccountRow.recordName(for: accountId),
+        zoneID: zoneID))
+    record["name"] = "Synced from another device" as CKRecordValue
+    record["instrumentId"] = "AUD" as CKRecordValue
+    record["position"] = Int64(0) as CKRecordValue
+    record["isHidden"] = Int64(0) as CKRecordValue
+    record["type"] = "bank" as CKRecordValue
+
+    // Drive the apply path directly — no ProfileSession has been
+    // constructed, so this would have trapped before the fix.
+    let handler = try coordinator.handlerForProfileZone(profileId: profileId, zoneID: zoneID)
+    let result = handler.applyRemoteChanges(
+      saved: [record], deleted: [], preExtractedSystemFields: [])
+
+    if case .saveFailed(let description) = result {
+      Issue.record("apply failed: \(description)")
+    }
+    let database = try manager.database(for: profileId)
+    let stored = try await database.read { db in
+      try AccountRow.filter(AccountRow.Columns.id == accountId).fetchOne(db)
+    }
+    #expect(stored?.name == "Synced from another device")
   }
 }

--- a/MoolahTests/Sync/SyncCoordinatorRegistrationFreeTests.swift
+++ b/MoolahTests/Sync/SyncCoordinatorRegistrationFreeTests.swift
@@ -81,8 +81,8 @@ struct SyncCoordinatorRegistrationFreeTests {
       Issue.record("apply failed: \(description)")
     }
     let database = try manager.database(for: profileId)
-    let stored = try await database.read { db in
-      try AccountRow.filter(AccountRow.Columns.id == accountId).fetchOne(db)
+    let stored = try await database.read { reader in
+      try AccountRow.filter(AccountRow.Columns.id == accountId).fetchOne(reader)
     }
     #expect(stored?.name == "Synced from another device")
   }
@@ -103,20 +103,20 @@ struct SyncCoordinatorRegistrationFreeTests {
     // Seed a row directly in GRDB with a non-nil encodedSystemFields.
     let database = try manager.database(for: profileId)
     let categoryId = UUID()
-    try await database.write { db in
+    try await database.write { writer in
       try CategoryRow(
         id: categoryId,
         recordName: CategoryRow.recordName(for: categoryId),
         name: "Reset me",
         parentId: nil,
         encodedSystemFields: Data([0xDE, 0xAD, 0xBE, 0xEF])
-      ).insert(db)
+      ).insert(writer)
     }
 
     coordinator.handleEncryptedDataReset(zoneID, zoneType: .profileData(profileId))
 
-    let stored = try await database.read { db in
-      try CategoryRow.filter(CategoryRow.Columns.id == categoryId).fetchOne(db)
+    let stored = try await database.read { reader in
+      try CategoryRow.filter(CategoryRow.Columns.id == categoryId).fetchOne(reader)
     }
     #expect(stored?.encodedSystemFields == nil)
   }

--- a/MoolahTests/Sync/SyncCoordinatorTestsExtra.swift
+++ b/MoolahTests/Sync/SyncCoordinatorTestsExtra.swift
@@ -82,10 +82,7 @@ struct SyncCoordinatorTestsExtra {
   @Test
   func queueAllRecordsAfterImportReturnsAllRecordsInProfileZone() async throws {
     let manager = try ProfileContainerManager.forTesting()
-    let coordinator = SyncCoordinator(
-      containerManager: manager,
-      fallbackGRDBRepositoriesFactory:
-        ProfileDataSyncHandlerTestSupport.managerBackedFallbackFactory(manager: manager))
+    let coordinator = SyncCoordinator(containerManager: manager)
     let profileId = UUID()
 
     // Seed the new profile's data container (as a migration import would).
@@ -100,6 +97,9 @@ struct SyncCoordinatorTestsExtra {
       InstrumentRecord(
         id: "AUD", kind: "fiatCurrency", name: "Australian Dollar", decimals: 2))
     try context.save()
+    let database = try manager.database(for: profileId)
+    try ProfileDataSyncHandlerTestSupport.mirrorContainerToDatabase(
+      container: dataContainer, database: database)
 
     let queued = await coordinator.queueAllRecordsAfterImport(for: profileId)
     let names = Set(queued.map(\.recordName))
@@ -119,10 +119,7 @@ struct SyncCoordinatorTestsExtra {
   @Test
   func queueAllRecordsAfterImportReturnsEmptyForProfileWithNoData() async throws {
     let manager = try ProfileContainerManager.forTesting()
-    let coordinator = SyncCoordinator(
-      containerManager: manager,
-      fallbackGRDBRepositoriesFactory:
-        ProfileDataSyncHandlerTestSupport.managerBackedFallbackFactory(manager: manager))
+    let coordinator = SyncCoordinator(containerManager: manager)
     let profileId = UUID()
 
     // Initialize the data container so the handler can be resolved,
@@ -144,9 +141,7 @@ struct SyncCoordinatorTestsExtra {
     let manager = try ProfileContainerManager.forTesting()
     let coordinator = SyncCoordinator(
       containerManager: manager,
-      userDefaults: makeDefaults(),
-      fallbackGRDBRepositoriesFactory:
-        ProfileDataSyncHandlerTestSupport.managerBackedFallbackFactory(manager: manager))
+      userDefaults: makeDefaults())
 
     // Register two profiles in the GRDB index.
     let profileA = UUID()
@@ -163,7 +158,8 @@ struct SyncCoordinatorTestsExtra {
     // Profile A: one unsynced account and one synced account.
     let unsyncedA = UUID()
     let syncedA = UUID()
-    let contextA = ModelContext(try manager.container(for: profileA))
+    let containerA = try manager.container(for: profileA)
+    let contextA = ModelContext(containerA)
     contextA.insert(
       AccountRecord(id: unsyncedA, name: "A-unsynced", type: "bank", position: 0, isHidden: false))
     let syncedRecord = AccountRecord(
@@ -171,12 +167,19 @@ struct SyncCoordinatorTestsExtra {
     syncedRecord.encodedSystemFields = Data([0x01])
     contextA.insert(syncedRecord)
     try contextA.save()
+    let databaseA = try manager.database(for: profileA)
+    try ProfileDataSyncHandlerTestSupport.mirrorContainerToDatabase(
+      container: containerA, database: databaseA)
 
     // Profile B: one unsynced transaction.
     let unsyncedB = UUID()
-    let contextB = ModelContext(try manager.container(for: profileB))
+    let containerB = try manager.container(for: profileB)
+    let contextB = ModelContext(containerB)
     contextB.insert(TransactionRecord(id: unsyncedB, date: Date(), payee: "B-unsynced"))
     try contextB.save()
+    let databaseB = try manager.database(for: profileB)
+    try ProfileDataSyncHandlerTestSupport.mirrorContainerToDatabase(
+      container: containerB, database: databaseB)
 
     let queued = await coordinator.queueUnsyncedRecordsForAllProfiles()
     let names = Set(queued.map(\.recordName))
@@ -219,9 +222,7 @@ struct SyncCoordinatorTestsExtra {
     let defaults = makeDefaults()
     let coordinator = SyncCoordinator(
       containerManager: manager,
-      userDefaults: defaults,
-      fallbackGRDBRepositoriesFactory:
-        ProfileDataSyncHandlerTestSupport.managerBackedFallbackFactory(manager: manager))
+      userDefaults: defaults)
 
     let profileId = UUID()
     try await manager.profileIndexRepository.upsert(
@@ -231,10 +232,14 @@ struct SyncCoordinatorTestsExtra {
 
     // Seed an unsynced record (nil encodedSystemFields) for this profile.
     let accountId = UUID()
-    let context = ModelContext(try manager.container(for: profileId))
+    let container = try manager.container(for: profileId)
+    let context = ModelContext(container)
     context.insert(
       AccountRecord(id: accountId, name: "Unsynced", type: "bank", position: 0, isHidden: false))
     try context.save()
+    let database = try manager.database(for: profileId)
+    try ProfileDataSyncHandlerTestSupport.mirrorContainerToDatabase(
+      container: container, database: database)
 
     // First scan should find and queue the unsynced record.
     let first = await coordinator.queueUnsyncedRecordsForAllProfiles()

--- a/MoolahTests/Sync/SyncCoordinatorTestsExtra.swift
+++ b/MoolahTests/Sync/SyncCoordinatorTestsExtra.swift
@@ -136,50 +136,54 @@ struct SyncCoordinatorTestsExtra {
     UserDefaults(suiteName: "sync-coordinator-test-\(UUID().uuidString)")!
   }
 
+  /// Registers a profile in the GRDB index, seeds its SwiftData container
+  /// via `seed`, and mirrors the seeded rows into the per-profile GRDB
+  /// queue. Used by `queueUnsyncedRecordsForAllProfilesSkipsSyncedRecords`
+  /// to keep the test body under SwiftLint's `function_body_length` cap.
+  private func seedProfile(
+    in manager: ProfileContainerManager,
+    profile: Profile,
+    seed: (ModelContext) -> Void
+  ) async throws {
+    try await manager.profileIndexRepository.upsert(profile)
+    let container = try manager.container(for: profile.id)
+    let context = ModelContext(container)
+    seed(context)
+    try context.save()
+    let database = try manager.database(for: profile.id)
+    try ProfileDataSyncHandlerTestSupport.mirrorContainerToDatabase(
+      container: container, database: database)
+  }
+
   @Test
   func queueUnsyncedRecordsForAllProfilesSkipsSyncedRecords() async throws {
     let manager = try ProfileContainerManager.forTesting()
     let coordinator = SyncCoordinator(
-      containerManager: manager,
-      userDefaults: makeDefaults())
+      containerManager: manager, userDefaults: makeDefaults())
 
-    // Register two profiles in the GRDB index.
-    let profileA = UUID()
-    let profileB = UUID()
-    try await manager.profileIndexRepository.upsert(
-      Profile(
-        id: profileA, label: "A", currencyCode: "AUD",
-        financialYearStartMonth: 7))
-    try await manager.profileIndexRepository.upsert(
-      Profile(
-        id: profileB, label: "B", currencyCode: "USD",
-        financialYearStartMonth: 1))
-
-    // Profile A: one unsynced account and one synced account.
+    let profileA = Profile(
+      id: UUID(), label: "A", currencyCode: "AUD", financialYearStartMonth: 7)
+    let profileB = Profile(
+      id: UUID(), label: "B", currencyCode: "USD", financialYearStartMonth: 1)
     let unsyncedA = UUID()
     let syncedA = UUID()
-    let containerA = try manager.container(for: profileA)
-    let contextA = ModelContext(containerA)
-    contextA.insert(
-      AccountRecord(id: unsyncedA, name: "A-unsynced", type: "bank", position: 0, isHidden: false))
-    let syncedRecord = AccountRecord(
-      id: syncedA, name: "A-synced", type: "bank", position: 1, isHidden: false)
-    syncedRecord.encodedSystemFields = Data([0x01])
-    contextA.insert(syncedRecord)
-    try contextA.save()
-    let databaseA = try manager.database(for: profileA)
-    try ProfileDataSyncHandlerTestSupport.mirrorContainerToDatabase(
-      container: containerA, database: databaseA)
+    let unsyncedB = UUID()
+
+    // Profile A: one unsynced account and one synced account.
+    try await seedProfile(in: manager, profile: profileA) { context in
+      context.insert(
+        AccountRecord(
+          id: unsyncedA, name: "A-unsynced", type: "bank", position: 0, isHidden: false))
+      let syncedRecord = AccountRecord(
+        id: syncedA, name: "A-synced", type: "bank", position: 1, isHidden: false)
+      syncedRecord.encodedSystemFields = Data([0x01])
+      context.insert(syncedRecord)
+    }
 
     // Profile B: one unsynced transaction.
-    let unsyncedB = UUID()
-    let containerB = try manager.container(for: profileB)
-    let contextB = ModelContext(containerB)
-    contextB.insert(TransactionRecord(id: unsyncedB, date: Date(), payee: "B-unsynced"))
-    try contextB.save()
-    let databaseB = try manager.database(for: profileB)
-    try ProfileDataSyncHandlerTestSupport.mirrorContainerToDatabase(
-      container: containerB, database: databaseB)
+    try await seedProfile(in: manager, profile: profileB) { context in
+      context.insert(TransactionRecord(id: unsyncedB, date: Date(), payee: "B-unsynced"))
+    }
 
     let queued = await coordinator.queueUnsyncedRecordsForAllProfiles()
     let names = Set(queued.map(\.recordName))
@@ -192,8 +196,8 @@ struct SyncCoordinatorTestsExtra {
         ]))
 
     // Each record went to the matching profile's zone.
-    let aZone = "profile-\(profileA.uuidString)"
-    let bZone = "profile-\(profileB.uuidString)"
+    let aZone = "profile-\(profileA.id.uuidString)"
+    let bZone = "profile-\(profileB.id.uuidString)"
     for recordID in queued {
       if recordID.recordName == "\(AccountRow.recordType)|\(unsyncedA.uuidString)" {
         #expect(recordID.zoneID.zoneName == aZone)

--- a/MoolahTests/Sync/SyncCoordinatorTestsMore.swift
+++ b/MoolahTests/Sync/SyncCoordinatorTestsMore.swift
@@ -20,9 +20,7 @@ struct SyncCoordinatorTestsMore {
     let defaults = makeDefaults()
     let coordinator = SyncCoordinator(
       containerManager: manager,
-      userDefaults: defaults,
-      fallbackGRDBRepositoriesFactory:
-        ProfileDataSyncHandlerTestSupport.managerBackedFallbackFactory(manager: manager))
+      userDefaults: defaults)
 
     let profileId = UUID()
     try await manager.profileIndexRepository.upsert(
@@ -32,10 +30,14 @@ struct SyncCoordinatorTestsMore {
 
     // Simulate what CloudKitDataImporter produces: records with nil system fields.
     let accountId = UUID()
-    let context = ModelContext(try manager.container(for: profileId))
+    let container = try manager.container(for: profileId)
+    let context = ModelContext(container)
     context.insert(
       AccountRecord(id: accountId, name: "Migrated", type: "bank", position: 0, isHidden: false))
     try context.save()
+    let database = try manager.database(for: profileId)
+    try ProfileDataSyncHandlerTestSupport.mirrorContainerToDatabase(
+      container: container, database: database)
 
     // Migration queues all records up front.
     let queued = await coordinator.queueAllRecordsAfterImport(for: profileId)
@@ -87,28 +89,7 @@ struct SyncCoordinatorTestsMore {
   func profileDataHandlerCreatedOnDemand() throws {
     let manager = try ProfileContainerManager.forTesting()
     // `handlerForProfileZone` builds a bundle on demand from the
-    // containerManager when no bundle is pre-registered. This test
-    // injects the explicit factory path to exercise that code branch.
-    let coordinator = SyncCoordinator(
-      containerManager: manager,
-      fallbackGRDBRepositoriesFactory:
-        ProfileDataSyncHandlerTestSupport.managerBackedFallbackFactory(manager: manager))
-    let profileId = UUID()
-    let zoneID = CKRecordZone.ID(
-      zoneName: "profile-\(profileId.uuidString)",
-      ownerName: CKCurrentUserDefaultName)
-
-    let handler = try coordinator.handlerForProfileZone(profileId: profileId, zoneID: zoneID)
-    #expect(handler.profileId == profileId)
-    #expect(handler.zoneID == zoneID)
-  }
-
-  @Test("handlerForProfileZone builds handler from containerManager when no bundle and no factory")
-  func handlerForProfileZoneBuildsHandlerWhenUnregistered() throws {
-    let manager = try ProfileContainerManager.forTesting()
-    // No `setProfileGRDBRepositories` and no `fallbackGRDBRepositoriesFactory`
-    // — the coordinator builds its own bundle via containerManager.database(for:)
-    // so sync apply can proceed for un-sessionized profiles (issue #619).
+    // containerManager when no bundle is pre-registered.
     let coordinator = SyncCoordinator(containerManager: manager)
     let profileId = UUID()
     let zoneID = CKRecordZone.ID(
@@ -120,19 +101,17 @@ struct SyncCoordinatorTestsMore {
     #expect(handler.zoneID == zoneID)
   }
 
-  @Test("queueUnsyncedRecordsForAllProfiles skips profiles without a registered bundle")
-  func queueUnsyncedRecordsSkipsUnregisteredProfile() async throws {
+  @Test("queueUnsyncedRecordsForAllProfiles works for any profile in the index")
+  func queueUnsyncedRecordsForAnyProfileInIndex() async throws {
     let manager = try ProfileContainerManager.forTesting()
-    // No bundle, no factory: the outbound backfill path must skip the
-    // profile (records remain durable in GRDB and a future scan picks
-    // them up) rather than crash.
     let coordinator = SyncCoordinator(containerManager: manager)
     let profileId = UUID()
     try await manager.profileIndexRepository.upsert(
       Profile(
-        id: profileId, label: "Unregistered", currencyCode: "AUD",
+        id: profileId, label: "Idle", currencyCode: "AUD",
         financialYearStartMonth: 7))
 
+    // No rows seeded; the call must succeed and produce nothing.
     let queued = await coordinator.queueUnsyncedRecordsForAllProfiles()
     #expect(queued.isEmpty)
   }

--- a/MoolahTests/Sync/SyncCoordinatorTestsMore.swift
+++ b/MoolahTests/Sync/SyncCoordinatorTestsMore.swift
@@ -86,10 +86,9 @@ struct SyncCoordinatorTestsMore {
   @Test
   func profileDataHandlerCreatedOnDemand() throws {
     let manager = try ProfileContainerManager.forTesting()
-    // `handlerForProfileZone` requires a GRDB repository bundle —
-    // production wiring registers via `ProfileSession.registerWithSyncCoordinator`;
-    // the test injects the in-memory factory so the handler can be
-    // constructed without a full session.
+    // `handlerForProfileZone` builds a bundle on demand from the
+    // containerManager when no bundle is pre-registered. This test
+    // injects the explicit factory path to exercise that code branch.
     let coordinator = SyncCoordinator(
       containerManager: manager,
       fallbackGRDBRepositoriesFactory:
@@ -104,20 +103,21 @@ struct SyncCoordinatorTestsMore {
     #expect(handler.zoneID == zoneID)
   }
 
-  @Test("handlerForProfileZone throws profileNotRegistered when no bundle and no factory")
-  func handlerForProfileZoneThrowsWhenUnregistered() throws {
+  @Test("handlerForProfileZone builds handler from containerManager when no bundle and no factory")
+  func handlerForProfileZoneBuildsHandlerWhenUnregistered() throws {
     let manager = try ProfileContainerManager.forTesting()
     // No `setProfileGRDBRepositories` and no `fallbackGRDBRepositoriesFactory`
-    // — the production wiring-bug condition the throw is meant to surface.
+    // — the coordinator builds its own bundle via containerManager.database(for:)
+    // so sync apply can proceed for un-sessionized profiles (issue #619).
     let coordinator = SyncCoordinator(containerManager: manager)
     let profileId = UUID()
     let zoneID = CKRecordZone.ID(
       zoneName: "profile-\(profileId.uuidString)",
       ownerName: CKCurrentUserDefaultName)
 
-    #expect(throws: SyncCoordinatorError.profileNotRegistered(profileId)) {
-      _ = try coordinator.handlerForProfileZone(profileId: profileId, zoneID: zoneID)
-    }
+    let handler = try coordinator.handlerForProfileZone(profileId: profileId, zoneID: zoneID)
+    #expect(handler.profileId == profileId)
+    #expect(handler.zoneID == zoneID)
   }
 
   @Test("queueUnsyncedRecordsForAllProfiles skips profiles without a registered bundle")

--- a/plans/2026-05-02-sync-handler-precondition-removal-design.md
+++ b/plans/2026-05-02-sync-handler-precondition-removal-design.md
@@ -1,0 +1,130 @@
+# Sync Handler Precondition Removal — Design
+
+**Issue:** [#619](https://github.com/ajsutton/moolah-native/issues/619) — Sync handler trap fires for un-sessionized profiles outside the migration window.
+
+## 1. Problem
+
+`SyncCoordinator.handlerForProfileZone(profileId:zoneID:)` requires a per-profile `ProfileGRDBRepositories` bundle to have been registered before it is called. Today, the registration is owned by `ProfileSession.registerWithSyncCoordinator`, which only runs when a session is constructed. Sessions are built lazily by `SessionManager.session(for:)` during view rendering. CKSyncEngine, by contrast, can deliver events for any profile that exists in the index, regardless of which window is open.
+
+The mismatch produces three reachable failure modes:
+
+1. **Migration race.** Profile-index migration still in flight when sync starts; `ProfileStore.profiles` is empty; no session built; trap fires. Mitigated by [#620](https://github.com/ajsutton/moolah-native/pull/620), which gates engine start on the index migration.
+2. **Multi-profile, non-active push.** User has profiles A/B/C; only A's window is open; another device writes to B; CKSyncEngine fetches for B; no session for B; trap fires.
+3. **Single-profile pre-render race.** Profile exists in the index but `ProfileWindowView` hasn't rendered; the engine wins the race; trap fires.
+
+A second symptom of the same gap surfaces in `handleEncryptedDataReset` (`SyncCoordinator+Zones.swift:239`): when iCloud rotates encryption keys for a zone whose session isn't registered, `try?` silently skips `clearAllSystemFields()`. Records keep stale `encodedSystemFields`; the startup backfill scan only re-queues records where `encodedSystemFields == nil`, so they are never re-uploaded — sync update loss.
+
+## 2. Goal
+
+Eliminate the entire class of "sync event arrives for an un-sessionized profile" errors. The fix should be impossible to regress: future code paths cannot reintroduce the trap because the precondition that caused it should no longer exist.
+
+### Non-goals
+
+- Reworking `instrumentRemoteChangeCallbacks` registration. Its session-scoped lifecycle is correct (no session = no live UI subscribers = nothing to notify).
+- Reworking `setProfileGRDBRepositories`'s sibling `addObserver` registration. That observer drives `scheduleReloadFromSync` which does need a live session; absence is correct.
+- Per-profile UI eagerness. Stores, services, file watchers, etc. continue to be built lazily on first profile open.
+
+## 3. Design
+
+### 3.1 Make `SyncCoordinator` self-sufficient for handler construction
+
+Today, `handlerForProfileZone` consults a per-profile bundle that an external caller must have registered:
+
+```swift
+// current
+if let registered = profileGRDBRepositories[profileId] {
+  grdbRepositories = registered
+} else if let factory = fallbackGRDBRepositoriesFactory {
+  grdbRepositories = try factory(profileId)
+  profileGRDBRepositories[profileId] = grdbRepositories
+} else {
+  preconditionFailure("…wiring bug…")
+}
+```
+
+After: the coordinator builds the bundle itself, on demand, from `containerManager.database(for: profileId)` (the per-profile GRDB queue, which is process-wide cached). All ten GRDB repositories share the same constructor shape — `init(database:, onRecordChanged:, onRecordDeleted:)` — and the apply path uses synchronous `applyRemoteChangesSync` entry points that never invoke the hooks. So the coordinator's bundle uses the no-op hook defaults and is functionally indistinguishable from the session's bundle for everything the apply path does.
+
+```swift
+// proposed
+let grdbRepositories = try makeGRDBRepositories(for: profileId)
+```
+
+`makeGRDBRepositories(for:)` is a private helper on `SyncCoordinator` that:
+1. Calls `containerManager.database(for: profileId)` to get (and migrate) the GRDB queue.
+2. Constructs a fresh `ProfileGRDBRepositories` value with default no-op hooks.
+3. Returns it. Caching of the resulting `ProfileDataSyncHandler` continues via `dataHandlers[profileId]` exactly as today.
+
+### 3.2 Delete the registration surface
+
+Once the coordinator is self-sufficient, the entire registration mechanism becomes vestigial:
+
+- `SyncCoordinator.profileGRDBRepositories: [UUID: ProfileGRDBRepositories]` — delete.
+- `SyncCoordinator.fallbackGRDBRepositoriesFactory` and the corresponding `init` parameter — delete.
+- `SyncCoordinator.setProfileGRDBRepositories(profileId:bundle:)` — delete.
+- `SyncCoordinator.removeProfileGRDBRepositories(profileId:)` — delete.
+- `ProfileSession.wireRepositorySync(coordinator:)` and `registerGRDBRepositoriesForSync(coordinator:)` — delete (the call site in `registerWithSyncCoordinator` becomes a no-op and is removed).
+- The `cleanupSync` call to `coordinator.removeProfileGRDBRepositories(profileId:)` — delete.
+- `handlerForProfileZone` becomes non-throwing again (the `SyncCoordinatorError.profileNotRegistered` path PR #620 introduced disappears). The `try?`/`try` mix at every call site collapses back to a direct call.
+
+`SyncCoordinatorError.profileNotRegistered` itself goes away. If it has no remaining cases the enum is removed; if it has other cases it stays minus that one.
+
+### 3.3 Two-instance audit
+
+The session continues to own its own `ProfileGRDBRepositories` (through `CloudKitBackend`) with real hooks for queueing CKSyncEngine on user mutations. The coordinator owns its own bundle for sync apply with no-op hooks. Both share the same `DatabaseQueue`. Confirmed equivalences:
+
+| Concern | Today | After |
+|---|---|---|
+| User mutation queues upload | Session bundle's hooks fire from `upsert`/`delete` | Unchanged |
+| Sync apply does not echo | `applyRemoteChangesSync` does not invoke hooks | Unchanged (coordinator's no-op hooks would also be silent if invoked) |
+| Database serialisation | One queue per profile via `containerManager.database(for:)` | Unchanged |
+| Instrument-registry subscriber notification on remote pull | `onInstrumentRemoteChange` callback bridges from coordinator → session's live registry | Unchanged |
+| Schema migrations | Run on first `database(for:)` call | Unchanged (coordinator may now be the first caller) |
+
+### 3.4 Lifecycle simplification
+
+`ProfileSession.registerWithSyncCoordinator` shrinks to just observer registration plus the instrument-change callback. The "must be the last statement of init / call order guarantees the race is won" comment in `wireRepositorySync` is removed along with the function.
+
+`SyncCoordinator.startAfter(profileIndexMigration:)` (introduced by PR #620) becomes unnecessary on the trap-prevention axis. Whether it stays for other reasons is decided in §6.
+
+### 3.5 Migrator: stop clobbering sync-applied rows
+
+`SwiftDataToGRDBMigrator` runs from `ProfileSession.setUp()` (background task scheduled after `init`) and copies SwiftData rows into GRDB via `upsert`. Today the trap blocks sync apply for un-sessionized profiles, so the migrator is the only writer at the time it runs. With the trap gone, sync can write to GRDB for a profile before the user opens it. When the user later opens the session and the migrator runs, `upsert` overwrites GRDB rows with potentially-older SwiftData data — including the cached `encodedSystemFields` blob, which can also kick a `.serverRecordChanged` cycle.
+
+**Fix:** swap `upsert` for `INSERT … ON CONFLICT(id) DO NOTHING` (GRDB's `insert(_:onConflict: .ignore)`) in every per-type migrator. Semantics: if the row already exists in GRDB, leave it alone — sync put it there with newer truth. The per-type "migration complete" `UserDefaults` flag still latches once the pass finishes, so the migrator continues to no-op on subsequent launches; idempotency is preserved.
+
+This change applies to every migrator under `Backends/GRDB/Migration/SwiftDataToGRDBMigrator+*.swift` (CSVImportProfile, ImportRule, Instruments, Categories, Accounts, Earmarks, EarmarkBudgetItems, InvestmentValues, Transactions, TransactionLegs, ProfileIndex). The profile-index migrator is included for symmetry — although its window is closed by PR #620's gate, behavioural consistency across migrators is worth more than the ten-line diff.
+
+### 3.6 What stays in PR #620
+
+PR #620's index-migration gate is no longer necessary to prevent the trap. But it does provide a separate property: it ensures `ProfileStore.profiles` is populated before the engine starts probing zones, so observability and progress UI see a consistent state. We keep the gate. We delete the precondition-failure split inside `handlerForProfileZone` (the throws-vs-precondition refactor) since the underlying error case is gone.
+
+## 4. Test plan
+
+New / updated unit tests in `MoolahTests`:
+
+- **Apply without session.** Construct a `SyncCoordinator` against an in-memory `ProfileContainerManager`, never construct any `ProfileSession`, call the apply path with a synthetic batch for a profile id present in the index. Assert: rows land in GRDB, no trap.
+- **Encrypted reset without session.** Same setup; trigger `handleEncryptedDataReset` for a profile zone with no session. Assert: `clearAllSystemFields()` ran (verify by reading rows back) and the records were re-queued.
+- **Multi-profile background apply.** Index has profiles A and B; only A has a `ProfileSession`; deliver an apply batch for B. Assert: B's GRDB rows updated; A's session unaffected.
+- **Migrator does not clobber.** Seed GRDB with a row for id X. Run the migrator with a SwiftData row for id X carrying a *different* `encodedSystemFields`. Assert: GRDB's row is untouched; flag latches.
+- **Migrator still seeds empty tables.** Seed SwiftData only; GRDB empty. Run migrator. Assert: rows present; flag latches.
+
+Removal of test scaffolding:
+
+- `fallbackGRDBRepositoriesFactory` parameter usage in test helpers (`MoolahTests/Support/ProfileDataSyncHandlerTestSupport.swift` and the two `MoolahBenchmarks` files) — the helpers stop injecting it; the benchmarks already construct in-memory `ProfileContainerManager`s.
+
+## 5. Migration / rollout
+
+No data migration. No user-visible behaviour change. All deletions are internal.
+
+For the in-flight v1 SwiftData → v2 GRDB upgrade window: §3.5's migrator change closes the data-loss exposure that Option B would otherwise open. Users who have already migrated (flags latched) are unaffected by either change.
+
+## 6. Considered alternatives
+
+- **Option A — Eager session construction.** Wire `ProfileStore` to call `sessionManager.session(for:)` whenever profiles arrive. Keeps the registration contract and ensures it is always satisfied. Rejected because it pays the cost of building 10+ stores, 3 rate services, FolderWatch, the migration task, and the hourly PRAGMA optimize tick for every profile at launch — including profiles the user may never open this session — and because the fragile precondition would survive the change, leaving the door open for a future wiring bug to reintroduce the trap.
+- **Option C — Defer engine start until every profile has a session.** Strictly worse than A: same cost, plus user-visible sync delay.
+- **Migrator switches to "skip if any GRDB row exists."** Brittle when migration is interrupted partway; the next launch could see a non-empty table and conclude no work is needed despite missing rows. Rejected.
+
+## 7. Out of scope
+
+- Restructuring `instrumentRemoteChangeCallbacks` to a session-agnostic broadcast (Notification / AsyncStream). The session-scoped registration is already correct on the no-session path; not a bug.
+- General observability cleanup of stale `dataHandlers` entries on profile delete. Pre-existing edge case; harmless dangling references; tracked separately if/when it manifests.

--- a/plans/2026-05-02-sync-handler-precondition-removal-implementation.md
+++ b/plans/2026-05-02-sync-handler-precondition-removal-implementation.md
@@ -1,0 +1,1064 @@
+# Sync Handler Precondition Removal — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `SyncCoordinator` self-sufficient when constructing per-profile sync handlers so the trap in [#619](https://github.com/ajsutton/moolah-native/issues/619) becomes architecturally impossible. Drops the `setProfileGRDBRepositories` registration surface (and the `SyncCoordinatorError.profileNotRegistered` shim PR #620 introduced) and switches `SwiftDataToGRDBMigrator` to insert-or-ignore so it stops clobbering sync-applied rows now that sync apply for un-sessionized profiles is legal.
+
+**Architecture:** `SyncCoordinator` owns its own per-profile `ProfileGRDBRepositories` instance, constructed lazily on first event from `containerManager.database(for:)` (the cached, process-wide GRDB queue). The session keeps its own instance through `CloudKitBackend` (real hooks for outbound queueing); the coordinator's instance has no-op hooks. Both write to the same `DatabaseQueue`, so SQLite serialises everything. The apply path's synchronous `applyRemoteChangesSync` entry points already bypass `onRecordChanged`/`onRecordDeleted`, so no echo loop and no double-queueing.
+
+**Tech Stack:** Swift 6, GRDB (existing repository surface — no new SQL), Swift Testing (`import Testing`, `@Test`, `@Suite`, `#expect`), `xcodegen` (auto-picks up new files under `MoolahTests/`).
+
+**Reference design:** [`plans/2026-05-02-sync-handler-precondition-removal-design.md`](2026-05-02-sync-handler-precondition-removal-design.md) — §3 design, §4 test plan, §6 considered alternatives.
+
+---
+
+## Setup
+
+The worktree already exists at `/Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619` on branch `fix/sync-handler-precondition-removal`, branched off `origin/main` with `--no-track`. The design-doc commit (`9a681de2`) is already on the branch.
+
+All subsequent commands run from the worktree:
+`/Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619`.
+
+- [ ] **Step 1: Verify clean baseline.**
+
+```bash
+git -C /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619 status
+git -C /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619 log --oneline -3
+```
+
+Expected:
+- `status`: clean tree on `fix/sync-handler-precondition-removal`.
+- `log`: top commit is the design-doc commit; below it is the `mq: integrate PR #620 (fix/sync-startup-race)` merge.
+
+---
+
+# Slice 1 — Self-sufficient handler construction
+
+Lands the new construction path and its test. After this slice, sync apply for un-sessionized profiles is functional — the bug is fixed. Subsequent slices are cleanup.
+
+## Task 1: Failing test — apply path works without registration
+
+**Files:**
+- Test: `MoolahTests/Sync/SyncCoordinatorRegistrationFreeTests.swift` (new)
+
+- [ ] **Step 1: Create the test file.**
+
+```swift
+import CloudKit
+import Foundation
+import GRDB
+import SwiftData
+import Testing
+
+@testable import Moolah
+
+/// Regression tests for issue #619: a sync event for a profile whose
+/// `ProfileSession` is not open must apply successfully. Before the fix,
+/// `SyncCoordinator.handlerForProfileZone` threw
+/// `SyncCoordinatorError.profileNotRegistered` and the apply path
+/// trapped via `preconditionFailure`. After the fix, the coordinator
+/// constructs the per-profile GRDB repositories on demand from
+/// `containerManager.database(for:)`.
+@Suite("SyncCoordinator — registration-free apply")
+@MainActor
+struct SyncCoordinatorRegistrationFreeTests {
+  @Test("handlerForProfileZone constructs a handler when no bundle is registered")
+  func handlerConstructedWithoutRegistration() throws {
+    let manager = try ProfileContainerManager.forTesting()
+    let coordinator = SyncCoordinator(containerManager: manager)
+    let profileId = UUID()
+    let zoneID = CKRecordZone.ID(
+      zoneName: "profile-\(profileId.uuidString)",
+      ownerName: CKCurrentUserDefaultName)
+
+    let handler = try coordinator.handlerForProfileZone(profileId: profileId, zoneID: zoneID)
+
+    #expect(handler.profileId == profileId)
+    #expect(handler.zoneID == zoneID)
+  }
+
+  @Test("a second call returns the cached handler")
+  func handlerCachedAcrossCalls() throws {
+    let manager = try ProfileContainerManager.forTesting()
+    let coordinator = SyncCoordinator(containerManager: manager)
+    let profileId = UUID()
+    let zoneID = CKRecordZone.ID(
+      zoneName: "profile-\(profileId.uuidString)",
+      ownerName: CKCurrentUserDefaultName)
+
+    let first = try coordinator.handlerForProfileZone(profileId: profileId, zoneID: zoneID)
+    let second = try coordinator.handlerForProfileZone(profileId: profileId, zoneID: zoneID)
+
+    #expect(first === second)
+  }
+}
+```
+
+- [ ] **Step 2: Run the test and confirm it fails.**
+
+```bash
+mkdir -p /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619/.agent-tmp
+just --justfile /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619/justfile -d /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619 generate
+just --justfile /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619/justfile -d /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619 test-mac SyncCoordinatorRegistrationFreeTests 2>&1 | tee /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619/.agent-tmp/test-output.txt
+```
+
+Expected: `handlerConstructedWithoutRegistration` fails with `SyncCoordinatorError.profileNotRegistered`. `handlerCachedAcrossCalls` fails for the same reason.
+
+- [ ] **Step 3: Commit the failing test.**
+
+```bash
+git -C /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619 add MoolahTests/Sync/SyncCoordinatorRegistrationFreeTests.swift
+git -C /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619 commit -m "$(cat <<'EOF'
+test(sync): pin registration-free handler construction (failing)
+
+Regression test for #619 — handlerForProfileZone must succeed when no
+ProfileSession has registered a bundle. Currently fails with
+SyncCoordinatorError.profileNotRegistered; will pass once the
+coordinator builds its own ProfileGRDBRepositories from containerManager.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+## Task 2: Make the handler self-sufficient
+
+**Files:**
+- Modify: `Backends/CloudKit/Sync/ProfileGRDBRepositories.swift` (add a `forApply(database:)` static factory + a private no-op conversion service)
+- Modify: `Backends/CloudKit/Sync/SyncCoordinator+HandlerAccess.swift` (`handlerForProfileZone` body)
+
+The repositories' inits ask for a `defaultInstrument` and a `conversionService`. Both parameters are read-side only — the apply path writes Row objects via `applyRemoteChangesSync` and never invokes them. `Instrument.defaultTestInstrument` and `FixedConversionService` (used in `ProfileDataSyncHandlerTestSupport.makeBundle`) are test-only. We add an apply-only factory with production-safe placeholders next to the type that already documents the apply-only contract.
+
+- [ ] **Step 1: Add `ProfileGRDBRepositories.forApply(database:)` plus a private no-op conversion service.**
+
+Append to `Backends/CloudKit/Sync/ProfileGRDBRepositories.swift`:
+
+```swift
+extension ProfileGRDBRepositories {
+  /// Builds a bundle suitable for the sync apply path: every per-type
+  /// repository targets `database`, hooks are no-ops, and the read-side
+  /// `defaultInstrument` / `conversionService` parameters carry inert
+  /// placeholders. The apply path writes Row objects via
+  /// `applyRemoteChangesSync` and never invokes either placeholder; the
+  /// session-side bundle owned by `CloudKitBackend` continues to carry
+  /// real values for user-mutation paths.
+  static func forApply(database: any GRDB.DatabaseWriter) -> ProfileGRDBRepositories {
+    // USD is a stable, locale-independent fiat that satisfies
+    // `Instrument.fiat(code:)`'s `isoCurrencies` lookup. The choice is
+    // arbitrary — only the type matters for the apply path.
+    let placeholderInstrument = Instrument.fiat(code: "USD")
+    return ProfileGRDBRepositories(
+      csvImportProfiles: GRDBCSVImportProfileRepository(database: database),
+      importRules: GRDBImportRuleRepository(database: database),
+      instruments: GRDBInstrumentRegistryRepository(database: database),
+      categories: GRDBCategoryRepository(database: database),
+      accounts: GRDBAccountRepository(database: database),
+      earmarks: GRDBEarmarkRepository(
+        database: database, defaultInstrument: placeholderInstrument),
+      earmarkBudgetItems: GRDBEarmarkBudgetItemRepository(database: database),
+      investmentValues: GRDBInvestmentRepository(
+        database: database, defaultInstrument: placeholderInstrument),
+      transactions: GRDBTransactionRepository(
+        database: database,
+        defaultInstrument: placeholderInstrument,
+        conversionService: ApplyPathConversionService()),
+      transactionLegs: GRDBTransactionLegRepository(database: database))
+  }
+}
+
+/// Placeholder `InstrumentConversionService` for the apply-path bundle.
+/// Reachable only from `ProfileGRDBRepositories.forApply(database:)`;
+/// every method traps because the apply path never reads through the
+/// conversion service. If a future code change starts invoking it from
+/// the apply path, the trap is preferable to silent zero-conversion.
+private struct ApplyPathConversionService: InstrumentConversionService, Sendable {
+  func convert(
+    _ quantity: Decimal,
+    from: Instrument,
+    to: Instrument,
+    on date: Date
+  ) async throws -> Decimal {
+    preconditionFailure(
+      "ApplyPathConversionService.convert called — apply path never converts")
+  }
+
+  func convertAmount(
+    _ amount: InstrumentAmount,
+    to instrument: Instrument,
+    on date: Date
+  ) async throws -> InstrumentAmount {
+    preconditionFailure(
+      "ApplyPathConversionService.convertAmount called — apply path never converts")
+  }
+}
+```
+
+If `ProfileGRDBRepositories.swift` does not already `import GRDB` / `import Foundation`, add the imports needed by the new code (the existing file imports `Foundation` only — add `import GRDB`).
+
+- [ ] **Step 2: Update `handlerForProfileZone` to use the factory as a fallback.**
+
+In `Backends/CloudKit/Sync/SyncCoordinator+HandlerAccess.swift`, replace the existing body of `handlerForProfileZone` (the `if let registered … else if let factory … else throw` ladder, lines 44–69 in the current file) with:
+
+```swift
+  func handlerForProfileZone(
+    profileId: UUID, zoneID: CKRecordZone.ID
+  ) throws -> ProfileDataSyncHandler {
+    if let existing = dataHandlers[profileId] {
+      return existing
+    }
+    let container = try containerManager.container(for: profileId)
+    let grdbRepositories = try resolveGRDBRepositories(for: profileId)
+    let onInstrumentRemoteChange = instrumentRemoteChangeCallbacks[profileId] ?? {}
+    let handler = ProfileDataSyncHandler(
+      profileId: profileId,
+      zoneID: zoneID,
+      modelContainer: container,
+      grdbRepositories: grdbRepositories,
+      onInstrumentRemoteChange: onInstrumentRemoteChange)
+    dataHandlers[profileId] = handler
+    return handler
+  }
+
+  /// Returns the per-profile GRDB repository bundle. Prefers a bundle
+  /// registered by `ProfileSession.registerWithSyncCoordinator` (so the
+  /// session and the coordinator share an instance during normal app
+  /// lifetime), then a test-injected factory, then a freshly-built
+  /// apply-path bundle backed by `containerManager.database(for:)`.
+  /// The last branch is what allows sync apply for un-sessionized
+  /// profiles — see issue #619.
+  private func resolveGRDBRepositories(for profileId: UUID) throws -> ProfileGRDBRepositories {
+    if let registered = profileGRDBRepositories[profileId] {
+      return registered
+    }
+    if let factory = fallbackGRDBRepositoriesFactory {
+      let bundle = try factory(profileId)
+      profileGRDBRepositories[profileId] = bundle
+      return bundle
+    }
+    let database = try containerManager.database(for: profileId)
+    let bundle = ProfileGRDBRepositories.forApply(database: database)
+    profileGRDBRepositories[profileId] = bundle
+    return bundle
+  }
+```
+
+- [ ] **Step 3: Run the regression tests and confirm they pass.**
+
+```bash
+just --justfile /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619/justfile -d /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619 test-mac SyncCoordinatorRegistrationFreeTests 2>&1 | tee /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619/.agent-tmp/test-output.txt
+```
+
+Expected: both tests pass. No other tests touched yet.
+
+- [ ] **Step 4: Run the full SyncCoordinator suite to confirm nothing regressed.**
+
+```bash
+just --justfile /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619/justfile -d /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619 test-mac SyncCoordinator 2>&1 | tee /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619/.agent-tmp/test-output.txt
+grep -i 'failed\|error:' /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619/.agent-tmp/test-output.txt || echo "no failures"
+```
+
+Expected: `no failures`. Existing tests that injected `fallbackGRDBRepositoriesFactory` continue to work because the factory branch in `resolveGRDBRepositories` is untouched.
+
+- [ ] **Step 5: Format and commit.**
+
+```bash
+just --justfile /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619/justfile -d /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619 format
+git -C /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619 add Backends/CloudKit/Sync/ProfileGRDBRepositories.swift Backends/CloudKit/Sync/SyncCoordinator+HandlerAccess.swift
+git -C /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619 commit -m "$(cat <<'EOF'
+fix(sync): make handlerForProfileZone self-sufficient (#619)
+
+When no ProfileSession has registered a bundle and no test fallback
+factory is injected, build a fresh ProfileGRDBRepositories via the new
+forApply(database:) factory backed by containerManager.database(for:).
+The factory's hooks are no-ops because the apply path's
+applyRemoteChangesSync entry points bypass them; the session-side
+instance retains real hooks for user mutations. The conversion service
+parameter carries an ApplyPathConversionService that traps if invoked
+— defence-in-depth against a future read through the apply bundle.
+
+This eliminates the trap that fired when sync events arrived for an
+un-sessionized profile (multi-profile background apply, pre-render
+race, encrypted reset on an unopened profile). The
+SyncCoordinatorError.profileNotRegistered case is now unreachable from
+the production wiring and gets removed in a follow-up commit.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+## Task 3: Add an end-to-end apply-without-session test
+
+**Files:**
+- Modify: `MoolahTests/Sync/SyncCoordinatorRegistrationFreeTests.swift`
+
+- [ ] **Step 1: Add a test that drives the full apply path for a profile that has no session.**
+
+Append to the suite created in Task 1:
+
+```swift
+  @Test("applyFetchedRecordZoneChanges writes rows for an un-sessionized profile")
+  func applyWritesRowsWithoutSession() async throws {
+    let manager = try ProfileContainerManager.forTesting()
+    let coordinator = SyncCoordinator(containerManager: manager)
+    let profileId = UUID()
+    try await manager.profileIndexRepository.upsert(
+      Profile(
+        id: profileId, label: "Background", currencyCode: "AUD",
+        financialYearStartMonth: 7))
+    let zoneID = CKRecordZone.ID(
+      zoneName: "profile-\(profileId.uuidString)",
+      ownerName: CKCurrentUserDefaultName)
+
+    let accountId = UUID()
+    let record = CKRecord(
+      recordType: AccountRow.recordType,
+      recordID: CKRecord.ID(
+        recordName: AccountRow.recordName(for: accountId),
+        zoneID: zoneID))
+    record["id"] = accountId.uuidString as CKRecordValue
+    record["name"] = "Synced from another device" as CKRecordValue
+    record["instrumentId"] = "AUD" as CKRecordValue
+    record["position"] = 0 as CKRecordValue
+    record["isHidden"] = 0 as CKRecordValue
+    record["type"] = "checking" as CKRecordValue
+
+    // Drive the apply path directly — no ProfileSession has been
+    // constructed, so this would have trapped before the fix.
+    let handler = try coordinator.handlerForProfileZone(profileId: profileId, zoneID: zoneID)
+    let result = handler.applyRemoteChanges(
+      saved: [record], deleted: [], preExtractedSystemFields: [])
+
+    if case .saveFailed(let description) = result {
+      Issue.record("apply failed: \(description)")
+    }
+    let database = try manager.database(for: profileId)
+    let stored = try await database.read { db in
+      try AccountRow.fetchOne(db, key: accountId)
+    }
+    #expect(stored?.name == "Synced from another device")
+  }
+```
+
+If the field set on the test `CKRecord` doesn't match the live `AccountRecord` shape (record types in `Backends/CloudKit/Sync/Generated/`), inspect a real `AccountRow.toCKRecord(in:)` call from `Backends/CloudKit/Sync/Generated/AccountRecord+CloudKit.swift` and mirror its key set. The point of the test is "row reaches GRDB," not exhaustive field coverage, so any minimal valid record body is fine.
+
+- [ ] **Step 2: Run the new test.**
+
+```bash
+just --justfile /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619/justfile -d /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619 test-mac SyncCoordinatorRegistrationFreeTests 2>&1 | tee /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619/.agent-tmp/test-output.txt
+```
+
+Expected: `applyWritesRowsWithoutSession` passes.
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git -C /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619 add MoolahTests/Sync/SyncCoordinatorRegistrationFreeTests.swift
+git -C /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619 commit -m "$(cat <<'EOF'
+test(sync): cover end-to-end apply for un-sessionized profile (#619)
+
+Drives applyRemoteChanges directly with a synthetic CKRecord and asserts
+the row lands in GRDB. Pinpoints the multi-profile background-apply
+case from the issue.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+# Slice 2 — Drop the registration surface
+
+The handler now constructs itself. The registration storage, the test fallback factory, the `SyncCoordinatorError.profileNotRegistered` case, and the apply-path's `preconditionFailure` are all dead weight. Remove them.
+
+## Task 4: Drop the apply-path precondition split
+
+**Files:**
+- Modify: `Backends/CloudKit/Sync/SyncCoordinator+RecordChanges.swift` (`applyFetchedProfileDataChanges`, lines 134–171)
+
+- [ ] **Step 1: Replace the handler-resolution block.**
+
+Replace the `do { return try handlerForProfileZone… } catch SyncCoordinatorError.profileNotRegistered … catch { … }` ladder with a single `try?`:
+
+```swift
+    let handler: ProfileDataSyncHandler? = await MainActor.run {
+      do {
+        return try handlerForProfileZone(profileId: profileId, zoneID: zoneID)
+      } catch {
+        logger.error("Failed to get handler for profile \(profileId): \(error, privacy: .public)")
+        return nil
+      }
+    }
+    guard let handler else { return }
+```
+
+The remaining catch-and-skip exists for genuinely transient errors from `containerManager.container(for:)` / `containerManager.database(for:)` (e.g. disk pressure). Those are recoverable: CKSyncEngine retries on the next launch, the records remain in iCloud. No `preconditionFailure` here.
+
+- [ ] **Step 2: Run the apply-path tests.**
+
+```bash
+just --justfile /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619/justfile -d /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619 test-mac SyncCoordinator 2>&1 | tee /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619/.agent-tmp/test-output.txt
+grep -i 'failed\|error:' /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619/.agent-tmp/test-output.txt || echo "no failures"
+```
+
+Expected: `no failures`.
+
+- [ ] **Step 3: Format and commit.**
+
+```bash
+just --justfile /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619/justfile -d /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619 format
+git -C /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619 add Backends/CloudKit/Sync/SyncCoordinator+RecordChanges.swift
+git -C /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619 commit -m "$(cat <<'EOF'
+fix(sync): drop preconditionFailure from apply-path handler resolution
+
+The profileNotRegistered case can no longer fire — the coordinator
+constructs its own bundle. Catch-and-skip on transient
+containerManager errors is preserved.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+## Task 5: Stop wiring the registration from `ProfileSession`
+
+**Files:**
+- Modify: `App/ProfileSession.swift` (`registerWithSyncCoordinator`, line ~212; `cleanupSync`, line ~272)
+- Modify: `App/ProfileSession+SyncWiring.swift` (delete the `wireRepositorySync` and `registerGRDBRepositoriesForSync` functions; keep the file because `StoreReloadPlan` and `storesToReload(for:)` live in it)
+
+- [ ] **Step 1: Delete the call to `wireRepositorySync(coordinator:)` from `registerWithSyncCoordinator`.**
+
+In `App/ProfileSession.swift`, remove the line `wireRepositorySync(coordinator: coordinator)` from the body of `registerWithSyncCoordinator(_:)`. The remaining body installs the observer and the instrument-change callback (still session-scoped — correct).
+
+- [ ] **Step 2: Delete the call to `coordinator.removeProfileGRDBRepositories(profileId:)` from `cleanupSync(coordinator:)`.**
+
+In the same file, remove the single line `coordinator.removeProfileGRDBRepositories(profileId: profile.id)` from `cleanupSync`.
+
+- [ ] **Step 3: Delete `wireRepositorySync` and `registerGRDBRepositoriesForSync` from `App/ProfileSession+SyncWiring.swift`.**
+
+Open the file, remove the two functions and the surrounding doc comments. Leave `StoreReloadPlan` and the `storesToReload(for:)` static method intact.
+
+- [ ] **Step 4: Verify the project still builds.**
+
+```bash
+just --justfile /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619/justfile -d /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619 build-mac 2>&1 | tee /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619/.agent-tmp/build-output.txt
+grep -i 'error:' /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619/.agent-tmp/build-output.txt || echo "build clean"
+```
+
+Expected: `build clean`. Compile errors here likely mean a test or extension was reaching into the deleted functions; fix at the call site.
+
+- [ ] **Step 5: Format and commit.**
+
+```bash
+just --justfile /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619/justfile -d /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619 format
+git -C /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619 add App/ProfileSession.swift App/ProfileSession+SyncWiring.swift
+git -C /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619 commit -m "$(cat <<'EOF'
+refactor(sync): stop wiring per-profile GRDB bundle from ProfileSession
+
+The coordinator now builds its own bundle when one isn't already
+cached, so the session-side registration is dead weight. The instrument
+remote-change callback registration stays — its session-scoped
+lifecycle is correct (no session = no live UI subscribers).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+## Task 6: Update tests + benchmarks to drop `fallbackGRDBRepositoriesFactory`
+
+**Files:**
+- Modify: `MoolahTests/Sync/SyncCoordinatorTestsMore.swift`
+- Modify: `MoolahTests/Sync/SyncCoordinatorTestsExtra.swift`
+- Modify: `MoolahTests/Sync/SyncCoordinatorBackfillFlagTests.swift`
+- Modify: `MoolahBenchmarks/SyncUploadBenchmarks.swift`
+- Modify: `MoolahBenchmarks/SyncDownloadBenchmarks.swift`
+
+Existing tests that pass `fallbackGRDBRepositoriesFactory:` to `SyncCoordinator(...)` are about to be broken (the parameter goes away in Task 7). We can simplify them now: drop the factory argument; the coordinator will construct its own bundle from the in-memory `ProfileContainerManager`.
+
+Two of these tests rely on `mirrorContainerToDatabase` to copy SwiftData seeds into GRDB. Where they do, replace the factory injection with an explicit `try ProfileDataSyncHandlerTestSupport.mirrorContainerToDatabase(...)` call before driving the coordinator.
+
+- [ ] **Step 1: `SyncCoordinatorTestsMore.swift` — drop the factory in `profileDataHandlerCreatedOnDemand` and `queueAllRecordsAfterImportMarksBackfillComplete`; mirror seeds explicitly where needed.**
+
+For each `SyncCoordinator(containerManager: manager, fallbackGRDBRepositoriesFactory: …)` constructor in this file, change to `SyncCoordinator(containerManager: manager)`. If the test seeds SwiftData via `manager.container(for: profileId)` and expects those rows to surface through the coordinator's GRDB-backed handler, insert `try ProfileDataSyncHandlerTestSupport.mirrorContainerToDatabase(container: container, database: database)` after the SwiftData inserts and before the coordinator call (the helper still exists; it's a harmless explicit copy).
+
+- [ ] **Step 2: Delete `handlerForProfileZoneThrowsWhenUnregistered` (lines 107–121).**
+
+The test exercises the case the fix removes. Replace it with a one-liner test asserting that `handlerForProfileZone` does *not* throw when invoked without registration — but Task 1's `handlerConstructedWithoutRegistration` already covers that, so just delete this test outright.
+
+- [ ] **Step 3: Update `queueUnsyncedRecordsSkipsUnregisteredProfile` (lines 123–138).**
+
+The test pinned the outbound safe-skip behaviour. After the fix, the outbound path no longer needs to skip — every profile in the index gets a handler. Rename the test to `queueUnsyncedRecordsForAnyProfileInIndex`, change the assertion to `#expect(queued.isEmpty)` *only if there are no records to queue*, and adjust the body to assert the call returns successfully (no throw, no precondition):
+
+```swift
+  @Test("queueUnsyncedRecordsForAllProfiles works for any profile in the index")
+  func queueUnsyncedRecordsForAnyProfileInIndex() async throws {
+    let manager = try ProfileContainerManager.forTesting()
+    let coordinator = SyncCoordinator(containerManager: manager)
+    let profileId = UUID()
+    try await manager.profileIndexRepository.upsert(
+      Profile(
+        id: profileId, label: "Idle", currencyCode: "AUD",
+        financialYearStartMonth: 7))
+
+    // No rows seeded; the call must succeed and produce nothing.
+    let queued = await coordinator.queueUnsyncedRecordsForAllProfiles()
+    #expect(queued.isEmpty)
+  }
+```
+
+- [ ] **Step 4: `SyncCoordinatorTestsExtra.swift` — drop the factory at every call site.**
+
+Repeat the Step 1 mechanical change for every `SyncCoordinator(containerManager: manager, fallbackGRDBRepositoriesFactory: …)` constructor. If a test relies on SwiftData-seeded rows surfacing through the coordinator, insert an explicit `mirrorContainerToDatabase` call.
+
+- [ ] **Step 5: `SyncCoordinatorBackfillFlagTests.swift` — drop the factory at every call site.**
+
+Same mechanical change. The three constructors at lines 30, 67, and 102 all use `inMemoryFallbackFactory` for type-only purposes (no seeded data); just remove the argument.
+
+- [ ] **Step 6: `MoolahBenchmarks/SyncUploadBenchmarks.swift` and `SyncDownloadBenchmarks.swift` — drop the bundle injection.**
+
+Each benchmark constructs a `ProfileGRDBRepositories` value and passes it to the coordinator via the factory. Replace with `SyncCoordinator(containerManager: manager)`; delete the local `bundle` variable.
+
+- [ ] **Step 7: Run the full SyncCoordinator suite + benchmarks build.**
+
+```bash
+just --justfile /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619/justfile -d /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619 test-mac SyncCoordinator 2>&1 | tee /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619/.agent-tmp/test-output.txt
+grep -i 'failed\|error:' /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619/.agent-tmp/test-output.txt || echo "no failures"
+just --justfile /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619/justfile -d /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619 build-mac 2>&1 | tee /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619/.agent-tmp/build-output.txt
+grep -i 'error:' /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619/.agent-tmp/build-output.txt || echo "build clean"
+```
+
+Expected: `no failures` and `build clean`.
+
+- [ ] **Step 8: Format and commit.**
+
+```bash
+just --justfile /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619/justfile -d /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619 format
+git -C /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619 add MoolahTests/Sync/ MoolahBenchmarks/
+git -C /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619 commit -m "$(cat <<'EOF'
+test(sync): stop injecting fallbackGRDBRepositoriesFactory
+
+The coordinator now constructs its own bundle, so tests just pass a
+ProfileContainerManager. SwiftData-seeded tests call
+mirrorContainerToDatabase explicitly. Drops the
+handlerForProfileZoneThrowsWhenUnregistered case (no longer reachable)
+and renames the outbound-skip test to reflect the new semantics.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+## Task 7: Delete the registration storage and the error case
+
+**Files:**
+- Modify: `Backends/CloudKit/Sync/SyncCoordinator+HandlerAccess.swift`
+- Modify: `Backends/CloudKit/Sync/SyncCoordinator.swift` (the `profileGRDBRepositories` and `fallbackGRDBRepositoriesFactory` properties + init parameter)
+- Modify: `MoolahTests/Support/ProfileDataSyncHandlerTestSupport.swift` (delete `inMemoryFallbackFactory` and `managerBackedFallbackFactory`)
+
+- [ ] **Step 1: In `SyncCoordinator+HandlerAccess.swift`, delete `setProfileGRDBRepositories`, `removeProfileGRDBRepositories`, and the `enum SyncCoordinatorError`.**
+
+Delete the entire `enum SyncCoordinatorError` declaration at the top of the file (lines 5–19). Delete the two functions (`setProfileGRDBRepositories`, lines ~71–95; `removeProfileGRDBRepositories`, lines ~97–101). The `setInstrumentRemoteChangeCallback` / `removeInstrumentRemoteChangeCallback` pair stays.
+
+- [ ] **Step 2: Decide whether to keep the factory parameter.**
+
+Re-grep for any test still injecting the factory after Task 6:
+
+```bash
+grep -rn "fallbackGRDBRepositoriesFactory" /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619 --include="*.swift" | grep -v plans/ | grep -v "SyncCoordinator+HandlerAccess.swift" | grep -v "SyncCoordinator.swift"
+```
+
+If the result is empty, the factory has no callers; delete it (proceed to Step 3). If anything matches, follow Steps 3a/3b to keep the factory but remove the registration storage.
+
+- [ ] **Step 3: Simplify `resolveGRDBRepositories(for:)`.**
+
+3a. **Factory has no callers (preferred — emptier diff downstream):** Replace the body with the direct factory call:
+
+```swift
+  private func resolveGRDBRepositories(for profileId: UUID) throws -> ProfileGRDBRepositories {
+    if let cached = cachedGRDBRepositories[profileId] {
+      return cached
+    }
+    let database = try containerManager.database(for: profileId)
+    let bundle = ProfileGRDBRepositories.forApply(database: database)
+    cachedGRDBRepositories[profileId] = bundle
+    return bundle
+  }
+```
+
+3b. **Factory still has callers:** Keep the factory branch; just drop the registration branch:
+
+```swift
+  private func resolveGRDBRepositories(for profileId: UUID) throws -> ProfileGRDBRepositories {
+    if let cached = cachedGRDBRepositories[profileId] {
+      return cached
+    }
+    if let factory = fallbackGRDBRepositoriesFactory {
+      let bundle = try factory(profileId)
+      cachedGRDBRepositories[profileId] = bundle
+      return bundle
+    }
+    let database = try containerManager.database(for: profileId)
+    let bundle = ProfileGRDBRepositories.forApply(database: database)
+    cachedGRDBRepositories[profileId] = bundle
+    return bundle
+  }
+```
+
+Either way, the `cachedGRDBRepositories` storage replaces `profileGRDBRepositories` (rename for clarity — it's now purely a cache, not a registration).
+
+- [ ] **Step 4: In `SyncCoordinator.swift`, rename `profileGRDBRepositories` to `cachedGRDBRepositories` and update its doc comment.**
+
+Find the `var profileGRDBRepositories: [UUID: ProfileGRDBRepositories] = [:]` declaration (line ~300 in the file) plus the doc comment that calls it the registration storage. Rename to `cachedGRDBRepositories` and rewrite the comment to describe its new purpose: a per-profile cache for the auto-constructed apply-path bundle (or the test-injected factory's output, if the factory still exists).
+
+- [ ] **Step 5: Drop `fallbackGRDBRepositoriesFactory` if Step 2's grep was empty.**
+
+5a. **Empty grep:** delete the `let fallbackGRDBRepositoriesFactory: …` stored property and the corresponding `init` parameter in `SyncCoordinator.swift`. In `MoolahTests/Support/ProfileDataSyncHandlerTestSupport.swift`, delete `inMemoryFallbackFactory` (lines ~226–229) and `managerBackedFallbackFactory(manager:)` (lines ~239–255). Static helpers `makeBundle`, `mirrorContainerToDatabase`, `makeHandler`, `makeHandlerWithDatabase` stay — handler-direct tests use them.
+
+5b. **Non-empty grep:** keep the property, the init parameter, and both test helpers. (This is the unlikely fallback if Task 6 missed a call site.)
+
+- [ ] **Step 6: Run the full test suite.**
+
+```bash
+just --justfile /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619/justfile -d /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619 test-mac 2>&1 | tee /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619/.agent-tmp/test-output.txt
+grep -i 'failed\|error:' /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619/.agent-tmp/test-output.txt || echo "no failures"
+```
+
+Expected: `no failures`.
+
+- [ ] **Step 7: Format and commit.**
+
+```bash
+just --justfile /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619/justfile -d /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619 format
+git -C /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619 add Backends/CloudKit/Sync/SyncCoordinator+HandlerAccess.swift Backends/CloudKit/Sync/SyncCoordinator.swift MoolahTests/Support/ProfileDataSyncHandlerTestSupport.swift
+git -C /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619 commit -m "$(cat <<'EOF'
+refactor(sync): delete the GRDB-bundle registration surface
+
+setProfileGRDBRepositories, removeProfileGRDBRepositories,
+SyncCoordinatorError.profileNotRegistered, and (when no test still
+needs it) fallbackGRDBRepositoriesFactory + the test factory helpers.
+profileGRDBRepositories storage is renamed to cachedGRDBRepositories
+to reflect its new role: a per-profile cache for the auto-constructed
+bundle, not a registration.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+# Slice 3 — Migrator: stop clobbering sync-applied rows
+
+`SwiftDataToGRDBMigrator` upserts SwiftData rows into GRDB. With Slice 1 in place, sync apply for an unopened profile can write to GRDB before the migrator runs; the migrator's upsert then overwrites those rows with the older SwiftData version. Switch every per-type migrator to `INSERT ON CONFLICT DO NOTHING`. Per-type "complete" flags still latch, idempotency preserved.
+
+## Task 8: Failing test — migrator preserves existing GRDB rows
+
+**Files:**
+- Test: `MoolahTests/Sync/SwiftDataToGRDBMigratorPreserveTests.swift` (new)
+
+The migrator runs against a SwiftData container with persisted rows. We pre-seed GRDB with a sentinel row carrying a different `encodedSystemFields` blob, run the migrator, and assert the sentinel survives.
+
+- [ ] **Step 1: Create the test file.**
+
+```swift
+import Foundation
+import GRDB
+import SwiftData
+import Testing
+
+@testable import Moolah
+
+@Suite("SwiftDataToGRDBMigrator — preserve")
+@MainActor
+struct SwiftDataToGRDBMigratorPreserveTests {
+  /// Per-type pinned: the migrator does not overwrite a GRDB row that
+  /// sync wrote first (newer truth). The flag still latches.
+  @Test("migrator does not clobber a GRDB row that already exists")
+  func migratorPreservesExistingGRDBRow() async throws {
+    let containerManager = try ProfileContainerManager.forTesting()
+    let profileId = UUID()
+    let container = try containerManager.container(for: profileId)
+    let database = try containerManager.database(for: profileId)
+    let defaults = UserDefaults(
+      suiteName: "migrator-preserve-\(UUID().uuidString)")!
+
+    // Seed SwiftData with one CategoryRecord (any type with a v3 flag works;
+    // CategoryRecord is the simplest schema in the v3 bundle).
+    let context = ModelContext(container)
+    let categoryId = UUID()
+    let swiftDataRecord = CategoryRecord(
+      id: categoryId,
+      name: "From SwiftData",
+      systemKind: nil,
+      sortOrder: 0,
+      encodedSystemFields: Data([0x01, 0x02, 0x03]))
+    context.insert(swiftDataRecord)
+    try context.save()
+
+    // Pre-seed GRDB with a *different* row for the same id (simulating
+    // the sync-applied row).
+    try await database.write { db in
+      try CategoryRow(
+        id: categoryId,
+        recordName: CategoryRow.recordName(for: categoryId),
+        name: "From CloudKit",
+        systemKind: nil,
+        sortOrder: 0,
+        encodedSystemFields: Data([0xAA, 0xBB, 0xCC])
+      ).insert(db)
+    }
+
+    try await SwiftDataToGRDBMigrator().migrateIfNeeded(
+      modelContainer: container, database: database, defaults: defaults)
+
+    let stored = try await database.read { db in
+      try CategoryRow.fetchOne(db, key: categoryId)
+    }
+    #expect(stored?.name == "From CloudKit")
+    #expect(stored?.encodedSystemFields == Data([0xAA, 0xBB, 0xCC]))
+    #expect(defaults.bool(forKey: SwiftDataToGRDBMigrator.categoriesFlag))
+  }
+
+  /// Sanity: empty GRDB still gets seeded from SwiftData.
+  @Test("migrator still seeds empty GRDB tables")
+  func migratorSeedsEmptyGRDB() async throws {
+    let containerManager = try ProfileContainerManager.forTesting()
+    let profileId = UUID()
+    let container = try containerManager.container(for: profileId)
+    let database = try containerManager.database(for: profileId)
+    let defaults = UserDefaults(
+      suiteName: "migrator-seed-\(UUID().uuidString)")!
+
+    let context = ModelContext(container)
+    let categoryId = UUID()
+    context.insert(CategoryRecord(
+      id: categoryId,
+      name: "Seed me",
+      systemKind: nil,
+      sortOrder: 0,
+      encodedSystemFields: Data()))
+    try context.save()
+
+    try await SwiftDataToGRDBMigrator().migrateIfNeeded(
+      modelContainer: container, database: database, defaults: defaults)
+
+    let stored = try await database.read { db in
+      try CategoryRow.fetchOne(db, key: categoryId)
+    }
+    #expect(stored?.name == "Seed me")
+    #expect(defaults.bool(forKey: SwiftDataToGRDBMigrator.categoriesFlag))
+  }
+}
+```
+
+If the `CategoryRecord` initialiser shape doesn't match the project's actual `CategoryRecord` (check `Backends/CloudKit/Sync/Generated/CategoryRecord.swift` for the persisted-model fields), adjust accordingly. The test is otherwise generic — any v3 record type works because every per-type migrator uses the same `upsert` pattern.
+
+- [ ] **Step 2: Run the test and confirm it fails.**
+
+```bash
+just --justfile /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619/justfile -d /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619 test-mac SwiftDataToGRDBMigratorPreserveTests 2>&1 | tee /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619/.agent-tmp/test-output.txt
+```
+
+Expected: `migratorPreservesExistingGRDBRow` fails (the upsert wins; stored row is "From SwiftData"). `migratorSeedsEmptyGRDB` passes already.
+
+- [ ] **Step 3: Commit the failing test.**
+
+```bash
+git -C /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619 add MoolahTests/Sync/SwiftDataToGRDBMigratorPreserveTests.swift
+git -C /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619 commit -m "$(cat <<'EOF'
+test(migrator): pin preserve-existing-rows behaviour (failing)
+
+Once SyncCoordinator can apply for un-sessionized profiles, the
+migrator must stop clobbering sync-applied rows. Currently fails:
+upsert overwrites the GRDB row with the older SwiftData copy.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+## Task 9: Switch every per-type migrator to insert-or-ignore
+
+**Files:**
+- Modify: `Backends/GRDB/Migration/SwiftDataToGRDBMigrator.swift` (CSVImportProfile, ImportRule per-type migrators — `try row.upsert(database)` lines)
+- Modify: `Backends/GRDB/Migration/SwiftDataToGRDBMigrator+ProfileIndex.swift`
+- Modify: `Backends/GRDB/Migration/SwiftDataToGRDBMigrator+CoreFinancialGraph.swift`
+- Modify: `Backends/GRDB/Migration/SwiftDataToGRDBMigrator+Earmarks.swift`
+- Modify: `Backends/GRDB/Migration/SwiftDataToGRDBMigrator+Transactions.swift`
+
+Every per-type migrator's write loop currently has the shape:
+
+```swift
+try await database.write { database in
+  for row in mappedRows {
+    try row.upsert(database)
+  }
+}
+```
+
+GRDB's persistence protocols (`PersistableRecord`) provide an `insert(_:onConflict:)` overload; the closest equivalent is `try row.insert(database, onConflict: .ignore)`. Verify the exact spelling against an existing call site or the GRDB reference; the call site we are replacing already uses GRDB types so the dependency is in scope.
+
+- [ ] **Step 1: Confirm GRDB's insert-or-ignore spelling in this codebase.**
+
+```bash
+grep -rn "onConflict:" /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619/Backends/GRDB --include="*.swift" | head -5
+```
+
+If you see `.ignore` in any existing call (e.g. a repository, another migrator, a row helper), use the same form. If GRDB exposes the overload as `try row.insert(db, onConflict: .ignore)`, that's the call to use. If it instead expects an SQL-level statement (`INSERT OR IGNORE INTO …`), use `try db.execute(literal: "INSERT OR IGNORE INTO …")` with the row's `databaseDictionary`. Pick whichever is idiomatic for the rest of `Backends/GRDB`.
+
+- [ ] **Step 2: For every `try row.upsert(database)` call site inside a `migrate*IfNeeded` function across the five files, replace with the equivalent insert-or-ignore call.**
+
+The mechanical pattern: only the line inside `for row in mappedRows { … }` changes. Don't touch the surrounding loop, the `database.write` block, the `committed` flag, or the `defer { … }` flag-set.
+
+For `SwiftDataToGRDBMigrator.swift`, that's two sites (CSVImportProfiles around line 200, ImportRules around line 259).
+
+For `SwiftDataToGRDBMigrator+CoreFinancialGraph.swift`, identify each per-type migrator (instruments, categories, accounts, earmarks, earmarkBudgetItems, investmentValues, transactions, transactionLegs) and apply the change inside each.
+
+For `SwiftDataToGRDBMigrator+Earmarks.swift`, `+Transactions.swift`, `+ProfileIndex.swift`: same.
+
+The doc comment block at the top of `SwiftDataToGRDBMigrator.swift` describes the rationale ("`upsert` rather than `insert` so a crash *between* the transaction commit and the `defaults.set(...)` call (the unavoidable gap) re-running on next launch is harmless"). Update that paragraph to describe the new rationale: "insert-or-ignore so a partial migration is idempotent on re-run AND so a sync-applied row written before the migration runs is not clobbered by an older SwiftData copy."
+
+- [ ] **Step 3: Run the migrator preserve tests + the existing migrator tests.**
+
+```bash
+just --justfile /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619/justfile -d /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619 test-mac SwiftDataToGRDBMigrator 2>&1 | tee /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619/.agent-tmp/test-output.txt
+grep -i 'failed\|error:' /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619/.agent-tmp/test-output.txt || echo "no failures"
+```
+
+Expected: `no failures`. The new preserve test passes; the seed-empty test still passes; existing migrator tests pass.
+
+- [ ] **Step 4: Format and commit.**
+
+```bash
+just --justfile /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619/justfile -d /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619 format
+git -C /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619 add Backends/GRDB/Migration/
+git -C /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619 commit -m "$(cat <<'EOF'
+fix(migrator): switch SwiftData→GRDB writes to insert-or-ignore (#619)
+
+With sync apply now legal for un-sessionized profiles, the migrator's
+upsert could overwrite a sync-applied row with an older SwiftData copy.
+Insert-or-ignore preserves whichever row exists in GRDB and still
+latches the per-type "complete" flag so subsequent launches no-op.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+# Slice 4 — Wrap up
+
+## Task 10: Encrypted-reset regression test
+
+**Files:**
+- Modify: `MoolahTests/Sync/SyncCoordinatorRegistrationFreeTests.swift`
+
+`handleEncryptedDataReset` (`SyncCoordinator+Zones.swift:222`) used to silently skip `clearAllSystemFields()` when no session was registered. With Slice 1 the handler is always available; pin the new behaviour.
+
+- [ ] **Step 1: Add the test.**
+
+Append to the suite:
+
+```swift
+  @Test("encrypted-data-reset clears system fields and re-queues records without session")
+  func encryptedResetWithoutSession() async throws {
+    let manager = try ProfileContainerManager.forTesting()
+    let coordinator = SyncCoordinator(containerManager: manager)
+    let profileId = UUID()
+    try await manager.profileIndexRepository.upsert(
+      Profile(
+        id: profileId, label: "Reset", currencyCode: "AUD",
+        financialYearStartMonth: 7))
+    let zoneID = CKRecordZone.ID(
+      zoneName: "profile-\(profileId.uuidString)",
+      ownerName: CKCurrentUserDefaultName)
+
+    // Seed a row directly in GRDB with a non-nil encodedSystemFields.
+    let database = try manager.database(for: profileId)
+    let categoryId = UUID()
+    try await database.write { db in
+      try CategoryRow(
+        id: categoryId,
+        recordName: CategoryRow.recordName(for: categoryId),
+        name: "Reset me",
+        systemKind: nil,
+        sortOrder: 0,
+        encodedSystemFields: Data([0xDE, 0xAD, 0xBE, 0xEF])
+      ).insert(db)
+    }
+
+    coordinator.handleEncryptedDataReset(zoneID, zoneType: .profileData(profileId))
+
+    let stored = try await database.read { db in
+      try CategoryRow.fetchOne(db, key: categoryId)
+    }
+    #expect(stored?.encodedSystemFields == nil)
+  }
+```
+
+- [ ] **Step 2: Run it.**
+
+```bash
+just --justfile /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619/justfile -d /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619 test-mac SyncCoordinatorRegistrationFreeTests 2>&1 | tee /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619/.agent-tmp/test-output.txt
+```
+
+Expected: passes (the handler resolves now that the precondition is gone).
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git -C /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619 add MoolahTests/Sync/SyncCoordinatorRegistrationFreeTests.swift
+git -C /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619 commit -m "$(cat <<'EOF'
+test(sync): cover encrypted-data-reset for un-sessionized profile (#619)
+
+The second symptom from #619: handleEncryptedDataReset used to silently
+skip clearAllSystemFields when no session was registered. Pin the new
+behaviour — system fields cleared regardless.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+## Task 11: Decide whether to keep PR #620's migration-gate
+
+**Files:**
+- Modify (or no-op): `Backends/CloudKit/Sync/SyncCoordinator+Lifecycle.swift`, `App/MoolahApp+Setup.swift`, `App/MoolahApp.swift`
+
+The design doc §3.6 keeps `startAfter(profileIndexMigration:)` because it provides a separate observability property (consistent `ProfileStore.profiles` before the engine probes zones). Re-confirm this judgement now that the trap is gone:
+
+- [ ] **Step 1: Audit whether anything else still depends on the gate.**
+
+```bash
+grep -rn "startAfter(profileIndexMigration\|launchTask\b" /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619 --include="*.swift" | head
+```
+
+If the only uses are `MoolahApp+Setup.swift` (the call site) and `SyncCoordinator+Lifecycle.swift` (the implementation), the gate is purely "wait for migration before starting the engine."
+
+- [ ] **Step 2: Keep the gate as-is.**
+
+The migration-gate is preserved. Its purpose post-fix is observability/UI consistency — `ProfileStore.profiles` is populated before progress UI begins reporting. No code change in this task; it's a deliberate decision to leave the gate in place.
+
+If a future audit decides to remove the gate, this is the right time to do it (one PR, with the trap-fix). For this PR we leave it; the cost is one Task and one extra `await`.
+
+- [ ] **Step 3: No commit if no change.**
+
+## Task 12: Pre-PR checks
+
+- [ ] **Step 1: Run the full test suite (mac + iOS).**
+
+```bash
+just --justfile /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619/justfile -d /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619 test 2>&1 | tee /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619/.agent-tmp/test-output.txt
+grep -i 'failed\|error:' /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619/.agent-tmp/test-output.txt || echo "no failures"
+```
+
+Expected: `no failures`.
+
+- [ ] **Step 2: Format-check.**
+
+```bash
+just --justfile /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619/justfile -d /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619 format-check
+```
+
+Expected: clean exit. Any violation: fix the underlying code per memory `feedback_swiftlint_fix_not_baseline.md` (split / rename / use `#require`); never bump the baseline.
+
+- [ ] **Step 3: TODO validation.**
+
+```bash
+just --justfile /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619/justfile -d /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619 validate-todos
+```
+
+Expected: clean.
+
+- [ ] **Step 4: Run review agents.**
+
+Run the `code-review`, `concurrency-review`, and `sync-review` agents over the diff. Apply every Critical / Important / Minor finding per memory `feedback_apply_all_review_findings.md`. If a finding is genuinely out of scope, ask before deferring (memory `feedback_apply_all_review_findings.md`).
+
+```bash
+git -C /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619 diff origin/main --stat
+```
+
+For each agent: invoke via Claude Code's `@agent-name`, paste the diff context, apply findings inline, re-run tests, commit.
+
+- [ ] **Step 5: Delete `.agent-tmp/` artefacts.**
+
+```bash
+rm -rf /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619/.agent-tmp
+```
+
+## Task 13: Push branch and open PR
+
+- [ ] **Step 1: Push.**
+
+CLAUDE.md requires `<src>:<dst>` form — the worktree was created with `--no-track`, so without an explicit destination ref the push could resolve to a stale upstream:
+
+```bash
+git -C /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/fix-issue-619 push origin fix/sync-handler-precondition-removal:fix/sync-handler-precondition-removal
+```
+
+- [ ] **Step 2: Open the PR.**
+
+```bash
+gh pr create --title "fix(sync): remove handler-registration precondition (closes #619)" --body "$(cat <<'EOF'
+## Summary
+
+Closes [#619](https://github.com/ajsutton/moolah-native/issues/619). Removes the `setProfileGRDBRepositories` registration mechanism so `SyncCoordinator.handlerForProfileZone` is self-sufficient — given a profile id from a CKSyncEngine event, it constructs its own GRDB repository bundle from `containerManager.database(for:)`. The trap that fired for un-sessionized profiles becomes architecturally impossible.
+
+Also switches `SwiftDataToGRDBMigrator` to insert-or-ignore so it stops clobbering sync-applied rows now that sync apply for un-sessionized profiles is legal (latent bug masked today by the trap).
+
+### Architectural change
+
+- `SyncCoordinator` constructs a `ProfileGRDBRepositories` lazily from the cached `containerManager.database(for:)` queue. Hooks are no-ops; `applyRemoteChangesSync` already bypasses them, so a no-op-hooks instance is functionally equivalent.
+- The session keeps its own bundle (real hooks for outbound queueing) through `CloudKitBackend`. Two-instance pattern; both write through the same `DatabaseQueue` so SQLite serialises everything.
+- `SyncCoordinatorError.profileNotRegistered`, `setProfileGRDBRepositories`, `removeProfileGRDBRepositories`, `fallbackGRDBRepositoriesFactory`, `wireRepositorySync` — all deleted.
+- `SwiftDataToGRDBMigrator` per-type writes use `INSERT … ON CONFLICT DO NOTHING` so a sync-applied row that arrived first is not overwritten with an older SwiftData copy. Per-type "complete" flags continue to latch — idempotency preserved.
+
+### What is NOT changing
+
+- `instrumentRemoteChangeCallbacks` registration is unchanged (session-scoped is correct: no session = no live UI subscribers).
+- PR #620's `startAfter(profileIndexMigration:)` gate stays — preserves consistent `ProfileStore.profiles` before the engine probes zones.
+
+### Reference
+
+- Design: `plans/2026-05-02-sync-handler-precondition-removal-design.md`
+- Implementation plan: `plans/2026-05-02-sync-handler-precondition-removal-implementation.md`
+
+## Test plan
+
+- [x] `just test` (mac + iOS) passes
+- [x] `just format-check` clean (no baseline changes)
+- [x] `just validate-todos` clean
+- [x] `code-review`, `concurrency-review`, `sync-review` agents — all findings applied
+- [x] New tests:
+  - `SyncCoordinatorRegistrationFreeTests` — handler construction, caching, end-to-end apply, encrypted-reset, all without a session
+  - `SwiftDataToGRDBMigratorPreserveTests` — preserve existing GRDB row + still seed empty GRDB
+- [ ] Manual: launch the Mac release build with the iPhone-driven Trust Shares record pending in iCloud — verify no crash and the record applies even without opening the affected profile
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Add the PR to the merge queue.**
+
+Per memory `feedback_prs_to_merge_queue.md`, every PR opened goes through the merge-queue skill, not manual merge. Hand the PR number off to the `merge-queue` skill (or to its controller script `~/.claude/skills/merge-queue/scripts/merge-queue-ctl.sh`) once CI is green.
+
+---
+
+## Self-review notes
+
+Spec coverage check (cross-referenced against design doc §3 and §4):
+
+| Spec section | Covered by |
+|---|---|
+| §3.1 Self-sufficient handler construction | Tasks 1–3 |
+| §3.2 Delete the registration surface | Tasks 4–7 |
+| §3.3 Two-instance audit (no concurrency / consistency issue) | Demonstrated by Task 3's end-to-end test running entirely off the new path |
+| §3.4 Lifecycle simplification | Task 5 |
+| §3.5 Migrator: stop clobbering sync-applied rows | Tasks 8–9 |
+| §3.6 What stays in PR #620 | Task 11 |
+| §4 New tests | Tasks 1, 3, 8, 10 |
+| §4 Removal of test scaffolding | Tasks 6–7 |


### PR DESCRIPTION
## Summary

Closes [#619](https://github.com/ajsutton/moolah-native/issues/619). Makes `SyncCoordinator.handlerForProfileZone` self-sufficient: given a profile id from a CKSyncEngine event, it constructs its own `ProfileGRDBRepositories` from `containerManager.database(for:)` instead of waiting for `ProfileSession` to register one. The trap that fired for un-sessionized profiles (multi-profile background apply, pre-render race, encrypted reset on an unopened profile) is now architecturally impossible.

Also switches `SwiftDataToGRDBMigrator` to `insert(onConflict: .ignore)` so it stops clobbering sync-applied rows now that sync apply for un-sessionized profiles is legal (latent bug previously masked by the trap).

## Changes

- **Apply path** (`Backends/CloudKit/Sync/`): new `ProfileGRDBRepositories.makeForApply(database:)` factory + private `ApplyPathConversionService` (throws `ConversionError.unsupportedConversion` if invoked — the apply path never reads through the conversion service). `SyncCoordinator.handlerForProfileZone` resolves bundles via the factory; the apply path's `preconditionFailure`/`SyncCoordinatorError.profileNotRegistered` is gone.
- **Registration deletion**: `setProfileGRDBRepositories`, `removeProfileGRDBRepositories`, `wireRepositorySync`, `fallbackGRDBRepositoriesFactory`, plus the test helper closures, are all deleted. `profileGRDBRepositories` storage renamed to `cachedGRDBRepositories` to reflect its new role.
- **Profile-removal hygiene**: new `SyncCoordinator.evictCachedState(for:)` wired from `MoolahApp`'s `store.onProfileRemoved` — when `containerManager.deleteStore` invalidates the per-profile `DatabaseQueue`, the coordinator's cache is evicted alongside.
- **Migrator** (`Backends/GRDB/Migration/SwiftDataToGRDBMigrator*.swift`): every per-type write changed from `try row.upsert` to `try row.insert(database, onConflict: .ignore)` so a sync-applied row that arrived first is preserved. Per-type "complete" `UserDefaults` flags continue to latch — idempotency unchanged.

## What is NOT changing

- `instrumentRemoteChangeCallbacks` registration is unchanged (session-scoped is correct: no session = no live UI subscribers).
- PR #620's `startAfter(profileIndexMigration:)` gate stays — keeps `ProfileStore.profiles` populated before the engine probes zones.
- `CloudKitBackend`'s session-side `ProfileGRDBRepositories` instance still owns the real hooks for outbound queueing on user mutations.

## Reference

- Design: `plans/2026-05-02-sync-handler-precondition-removal-design.md`
- Implementation plan: `plans/2026-05-02-sync-handler-precondition-removal-implementation.md`

## Test plan

- [x] `just test-mac` — 1939/1939 pass (4 new in `SyncCoordinatorRegistrationFreeTests`, 2 new in `SwiftDataToGRDBMigratorPreserveTests`, 1 new in `CoreGraphMigratorFailureTests`)
- [x] `just format-check` clean (no baseline changes)
- [x] `just validate-todos` clean
- [x] `code-review`, `concurrency-review`, `sync-review`, `database-code-review` agents — all findings applied
- [ ] Manual: launch the Mac release build with the iPhone-driven Trust Shares record pending in iCloud — verify no crash and the record applies even without opening the affected profile

🤖 Generated with [Claude Code](https://claude.com/claude-code)