### PR TITLE
docs(release): require explicit "Confirm intent" check before tagging

### DIFF
--- a/guides/RELEASE_GUIDE.md
+++ b/guides/RELEASE_GUIDE.md
@@ -37,18 +37,23 @@ The pipeline writes detailed instructions to the workflow run's job summary when
 
 1. **Pre-flight.** Run `just release-preflight`. Fix any issue it reports (push outstanding work, sync with origin, authenticate `gh`, wait for green CI) before continuing.
 
-2. **Determine the version.** Run `just release-next-version rc`. Read the JSON output:
+2. **Confirm intent.** Pre-flight verifies your local main is in sync with `origin/main`; it cannot verify which PRs you *believe* are in this release. A stale local main, an unmerged PR, or a merge that landed seconds after you tagged will all sail through pre-flight.
+   - [ ] Run `git log <previous-rc-tag>..HEAD --oneline` and read the list end-to-end. Every issue / PR you mean to ship must appear.
+   - [ ] For any PR you're unsure about, run `gh pr view <N> --json mergedAt,mergeCommit | jq` and confirm `mergedAt` is non-null AND `mergeCommit.oid` shows up in the log above.
+   - [ ] If anything you expected is missing: either wait for the merge to land and re-run pre-flight, or accept reduced scope and adjust the release notes accordingly. Don't tag and "fix it in the next rc" — once an rc is installed, it takes on a life of its own.
+
+3. **Determine the version.** Run `just release-next-version rc`. Read the JSON output:
    - `version` — the proposed RC version (e.g. `1.2.0-rc.2`).
    - `confirm_marketing` — `true` when the previous tag was a final release. When true, confirm the marketing version in `project.yml` is right for the new RC. If wrong, run `just bump-version <X.Y.Z>`, open a PR to land it, then return to step 1.
    - `notes_base` — the previous RC tag (or previous final, if this is `rc.1`). Use this as the comparison base when authoring release notes. If this is the first release ever for the project (no prior tags), `notes_base` will be empty — in that case, summarise the project's purpose and headline features rather than describing a delta.
 
-3. **Author release notes.** RC notes describe what changed since `notes_base` — the audience is testers; they want the delta from the previous RC. See "Authoring release notes" below for the procedure. Save the draft to `.agent-tmp/release-notes-<version>.md`.
+4. **Author release notes.** RC notes describe what changed since `notes_base` — the audience is testers; they want the delta from the previous RC. See "Authoring release notes" below for the procedure. Save the draft to `.agent-tmp/release-notes-<version>.md`.
 
-4. **Cut the GH pre-release.** Run `just release-create-rc <version> .agent-tmp/release-notes-<version>.md`. This creates the tag, which fires `release-rc.yml`.
+5. **Cut the GH pre-release.** Run `just release-create-rc <version> .agent-tmp/release-notes-<version>.md`. This creates the tag, which fires `release-rc.yml`.
 
-5. **Wait + verify.** Run `just release-wait v<version>`. The workflow may pause on the `await-prod-deploy` job — if so, follow the "Schema deploys" procedure above (open Console → Deploy → approve the GH job). When the workflow concludes green, run `just release-status v<version>` to confirm the Mac zip is attached to the GH pre-release and the IPA reached TestFlight.
+6. **Wait + verify.** Run `just release-wait v<version>`. The workflow may pause on the `await-prod-deploy` job — if so, follow the "Schema deploys" procedure above (open Console → Deploy → approve the GH job). When the workflow concludes green, run `just release-status v<version>` to confirm the Mac zip is attached to the GH pre-release and the IPA reached TestFlight.
 
-6. **Smoke-test.** Install the TestFlight build (iOS device + simulator) and the Mac zip (extract, drag `Moolah.app` to `/Applications`, run). If anything is broken, document the issue, fix on `main`, and cut a fresh RC. Don't delete the bad RC; mark its release body to note it is obsolete.
+7. **Smoke-test.** Install the TestFlight build (iOS device + simulator) and the Mac zip (extract, drag `Moolah.app` to `/Applications`, run). If anything is broken, document the issue, fix on `main`, and cut a fresh RC. Don't delete the bad RC; mark its release body to note it is obsolete.
 
 ## Promote an RC to final
 


### PR DESCRIPTION
## Summary

rc.13 shipped without PR #620's startup-race fix because pre-flight passed (local main in sync with origin/main) but the operator tagged before #620's merge actually landed and assumed it was in. Pre-flight cannot detect this class of mistake — it has no model of "which PRs the operator believes are in this release."

This adds a new **Confirm intent** step in `guides/RELEASE_GUIDE.md` between Pre-flight and version selection:

- Read `git log <previous-rc>..HEAD --oneline` end-to-end and verify every intended PR appears.
- For any in-doubt PR, run `gh pr view <N> --json mergedAt,mergeCommit | jq` and confirm `mergedAt` is non-null and the merge SHA shows up in the log.
- If anything's missing: wait, or accept reduced scope. Don't tag and "fix it in the next rc."

The companion `.claude/skills/cutting-a-release/SKILL.md` was deliberately **not** edited: that skill's existing convention is "Don't restate or paraphrase the procedure here; the runbook is the source of truth." A duplicate Confirm-intent line in SKILL.md would violate that convention. The runbook update is the correct shape.

## Test plan

- [ ] Read the inserted step in `guides/RELEASE_GUIDE.md` for accuracy and tone.
- [ ] Verify the surrounding step numbers (3-7) are renumbered consistently.