### PR TITLE
feat(go-menu): implement Go Back / Go Forward

### DIFF
--- a/App/ContentView.swift
+++ b/App/ContentView.swift
@@ -35,6 +35,17 @@ struct ContentView: View {
   @State private var showImportCSVPicker = false
   @State private var importError: String?
 
+  // Browser-style back/forward history for the sidebar selection.
+  // Helpers live in the history extension below.
+  @State private var backStack: [SidebarSelection] = []
+  @State private var forwardStack: [SidebarSelection] = []
+  // Token set just before goBack/goForward mutates `selection`. Compared
+  // against the new value inside `recordHistory(previous:new:)` to skip
+  // recording history-driven navigations. Using a value token rather than
+  // a Bool flag avoids any dependence on whether SwiftUI delivers
+  // `onChange` synchronously or on the next render cycle.
+  @State private var historyDrivenSelection: SidebarSelection?
+
   var body: some View {
     NavigationSplitView {
       SidebarView(selection: $selection)
@@ -80,6 +91,14 @@ struct ContentView: View {
         async let earmarksLoad: Void = earmarkStore.load()
         _ = await (accountsLoad, categoriesLoad, earmarksLoad)
       }
+    }
+    // Pass `nil` to disable the menu item when there is nothing to navigate
+    // to — the same pattern used by every other focused-value command above
+    // (e.g. `newTransactionAction == nil` disables File > New Transaction…).
+    .focusedSceneValue(\.goBackAction, backStack.isEmpty ? nil : { goBack() })
+    .focusedSceneValue(\.goForwardAction, forwardStack.isEmpty ? nil : { goForward() })
+    .onChange(of: selection) { oldValue, newValue in
+      recordHistory(previous: oldValue, new: newValue)
     }
     .sheet(isPresented: $showCreateEarmarkSheet) {
       CreateEarmarkSheet(
@@ -263,9 +282,54 @@ struct ContentView: View {
   }
 }
 
+// MARK: - Navigation History
+
+extension ContentView {
+  private static let historyLimit = 50
+
+  private func recordHistory(previous: SidebarSelection?, new: SidebarSelection?) {
+    if let token = historyDrivenSelection, token == new {
+      historyDrivenSelection = nil
+      return
+    }
+    guard let previous else { return }
+    backStack.append(previous)
+    Self.trimToHistoryLimit(&backStack)
+    forwardStack.removeAll()
+  }
+
+  private func goBack() {
+    guard let previous = backStack.popLast() else { return }
+    if let current = selection {
+      forwardStack.append(current)
+      Self.trimToHistoryLimit(&forwardStack)
+    }
+    historyDrivenSelection = previous
+    selection = previous
+  }
+
+  private func goForward() {
+    guard let next = forwardStack.popLast() else { return }
+    if let current = selection {
+      backStack.append(current)
+      Self.trimToHistoryLimit(&backStack)
+    }
+    historyDrivenSelection = next
+    selection = next
+  }
+
+  private static func trimToHistoryLimit(_ stack: inout [SidebarSelection]) {
+    if stack.count > historyLimit {
+      stack.removeFirst(stack.count - historyLimit)
+    }
+  }
+}
+
+// MARK: - Account Detail
+
 extension ContentView {
   @ViewBuilder
-  func accountDetail(id: UUID) -> some View {
+  private func accountDetail(id: UUID) -> some View {
     if let account = accountStore.accounts.by(id: id) {
       if account.type == .investment {
         InvestmentAccountView(

--- a/App/MoolahDomainCommands.swift
+++ b/App/MoolahDomainCommands.swift
@@ -88,6 +88,8 @@ struct MoolahDomainCommands: Commands {
   @FocusedValue(\.selectedEarmark) private var selectedEarmark
   @FocusedValue(\.selectedCategory) private var selectedCategory
   @FocusedValue(\.sidebarSelection) private var sidebarSelection
+  @FocusedValue(\.goBackAction) private var goBackAction
+  @FocusedValue(\.goForwardAction) private var goForwardAction
   @FocusedValue(\.findInListAction) private var findInListAction
   @Environment(\.openWindow) private var openWindow
   @Environment(\.openURL) private var openURL
@@ -229,6 +231,15 @@ struct MoolahDomainCommands: Commands {
   }
 
   @ViewBuilder private var goMenuItems: some View {
+    // Back/Forward at the top of the Go menu, matching macOS HIG / Safari /
+    // Xcode / Finder / Mail. Numbered destinations follow.
+    Button("Go Back") { goBackAction?() }
+      .keyboardShortcut("[", modifiers: .command)
+      .disabled(goBackAction == nil)
+    Button("Go Forward") { goForwardAction?() }
+      .keyboardShortcut("]", modifiers: .command)
+      .disabled(goForwardAction == nil)
+    Divider()
     Button("Transactions") { sidebarSelection?.wrappedValue = .allTransactions }
       .keyboardShortcut("1", modifiers: .command)
       .disabled(sidebarSelection == nil)
@@ -244,12 +255,5 @@ struct MoolahDomainCommands: Commands {
     Button("Analysis") { sidebarSelection?.wrappedValue = .analysis }
       .keyboardShortcut("5", modifiers: .command)
       .disabled(sidebarSelection == nil)
-    Divider()
-    Button("Go Back") {}
-      .keyboardShortcut("[", modifiers: .command)
-      .disabled(true)
-    Button("Go Forward") {}
-      .keyboardShortcut("]", modifiers: .command)
-      .disabled(true)
   }
 }

--- a/Shared/FocusedValues.swift
+++ b/Shared/FocusedValues.swift
@@ -60,6 +60,16 @@ struct SidebarSelectionKey: FocusedValueKey {
   typealias Value = Binding<SidebarSelection?>
 }
 
+/// Trigger action for Go > Go Back (⌘[). `nil` when there is nothing to go back to.
+struct GoBackActionKey: FocusedValueKey {
+  typealias Value = () -> Void
+}
+
+/// Trigger action for Go > Go Forward (⌘]). `nil` when there is nothing to go forward to.
+struct GoForwardActionKey: FocusedValueKey {
+  typealias Value = () -> Void
+}
+
 /// Trigger action for File > Import CSV… (⇧⌘I). Opens the file picker in
 /// the focused window.
 struct ImportCSVActionKey: FocusedValueKey {
@@ -120,6 +130,14 @@ extension FocusedValues {
   var sidebarSelection: SidebarSelectionKey.Value? {
     get { self[SidebarSelectionKey.self] }
     set { self[SidebarSelectionKey.self] = newValue }
+  }
+  var goBackAction: GoBackActionKey.Value? {
+    get { self[GoBackActionKey.self] }
+    set { self[GoBackActionKey.self] = newValue }
+  }
+  var goForwardAction: GoForwardActionKey.Value? {
+    get { self[GoForwardActionKey.self] }
+    set { self[GoForwardActionKey.self] = newValue }
   }
   var importCSVAction: ImportCSVActionKey.Value? {
     get { self[ImportCSVActionKey.self] }

--- a/plans/2026-05-03-go-menu-back-forward-design.md
+++ b/plans/2026-05-03-go-menu-back-forward-design.md
@@ -1,0 +1,175 @@
+# Go Menu — Go Back / Go Forward
+
+Date: 2026-05-03
+Status: Design approved, in implementation
+Owner: Adrian
+
+## Summary
+
+Implement the Go menu's `Go Back` (⌘[) and `Go Forward` (⌘]) items, which currently exist as disabled placeholders in `MoolahDomainCommands.swift`. These items navigate forward and backward through the focused window's history of `SidebarSelection` values (the detail-pane destination chosen from the sidebar or via existing menu commands).
+
+## Goals
+
+- ⌘[ navigates to the previously-selected sidebar destination, ⌘] re-applies a destination just navigated away from via Go Back.
+- Menu items are disabled when their respective stack is empty, matching the existing focused-value-driven disable pattern used by every other Moolah-domain command.
+- History is per-window / per-profile and lives only in memory.
+
+## Non-goals
+
+- Persisting history across app relaunches (browser-tab back/forward isn't expected to survive a quit either).
+- Cmd-clicking the menu / showing a multi-step history pop-out.
+- Recording navigation finer than sidebar selection (e.g. transaction inspector open/close, account scroll position).
+
+## Behaviour
+
+A "navigation step" is a change to `ContentView.selection: SidebarSelection?`. Concretely, the navigable destinations are: `account(UUID)`, `earmark(UUID)`, `recentlyAdded`, `allTransactions`, `upcomingTransactions`, `categories`, `reports`, `analysis`.
+
+- Each change to `selection` driven by user action (sidebar click, ⌘1–⌘5, "View Transactions" account-menu item, App Intents / AppleScript navigation) pushes the **prior** value of `selection` onto the back stack and clears the forward stack. This matches a standard browser back/forward model.
+- Back/forward navigation does **not** itself record history — it pops from one stack and pushes onto the other, mediated by a `historyDrivenSelection` token that the recorder compares against the new `selection` value. A value-based token is used (rather than a Bool flag) so the suppression doesn't depend on whether SwiftUI delivers `onChange` synchronously or on the next render cycle.
+- A `nil` prior value is **not** pushed. (Realistically only happens on iOS, where the initial `selection` is `nil`; we don't want "go back to nothing".)
+- Selecting an already-selected sidebar row does not fire `onChange(of: selection)` and so does not pollute the history.
+- Both stacks are capped at 50 entries; pushing onto a full stack drops the oldest entry. (Bounds memory in the unlikely event of pathological navigation.)
+- History is per-`ContentView`, which is recreated per `ProfileSession`. Switching profile naturally resets both stacks. Closing a window discards its history.
+- Menu items are disabled when their stack is empty — same `.disabled(action == nil)` pattern as `New Transaction…`, `Edit Transaction…`, etc.
+
+## Implementation
+
+### 1. `Shared/FocusedValues.swift` — two new focused values
+
+```swift
+/// Trigger action for Go > Go Back (⌘[). nil = nothing to go back to.
+struct GoBackActionKey: FocusedValueKey {
+  typealias Value = () -> Void
+}
+
+/// Trigger action for Go > Go Forward (⌘]). nil = nothing to go forward to.
+struct GoForwardActionKey: FocusedValueKey {
+  typealias Value = () -> Void
+}
+
+extension FocusedValues {
+  var goBackAction: GoBackActionKey.Value? {
+    get { self[GoBackActionKey.self] }
+    set { self[GoBackActionKey.self] = newValue }
+  }
+  var goForwardAction: GoForwardActionKey.Value? {
+    get { self[GoForwardActionKey.self] }
+    set { self[GoForwardActionKey.self] = newValue }
+  }
+}
+```
+
+### 2. `App/ContentView.swift` — stack-management state & helpers
+
+Add three pieces of `@State` to the primary struct, and a `private extension ContentView` block at the end of the file holding the helpers (so SwiftLint's `type_body_length` keeps counting only the primary struct body):
+
+```swift
+@State private var backStack: [SidebarSelection] = []
+@State private var forwardStack: [SidebarSelection] = []
+@State private var historyDrivenSelection: SidebarSelection?
+```
+
+Add an `.onChange(of: selection)` and the focused-value exposures inside `body`:
+
+```swift
+.focusedSceneValue(\.goBackAction, backStack.isEmpty ? nil : { goBack() })
+.focusedSceneValue(\.goForwardAction, forwardStack.isEmpty ? nil : { goForward() })
+.onChange(of: selection) { oldValue, newValue in
+  recordHistory(previous: oldValue, new: newValue)
+}
+```
+
+In a `private extension ContentView` after the primary body:
+
+```swift
+static let historyLimit = 50
+
+func recordHistory(previous: SidebarSelection?, new: SidebarSelection?) {
+  if let token = historyDrivenSelection, token == new {
+    historyDrivenSelection = nil
+    return
+  }
+  guard let previous else { return }
+  backStack.append(previous)
+  Self.trimToHistoryLimit(&backStack)
+  forwardStack.removeAll()
+}
+
+func goBack() {
+  guard let previous = backStack.popLast() else { return }
+  if let current = selection {
+    forwardStack.append(current)
+    Self.trimToHistoryLimit(&forwardStack)
+  }
+  historyDrivenSelection = previous
+  selection = previous
+}
+
+func goForward() {
+  guard let next = forwardStack.popLast() else { return }
+  if let current = selection {
+    backStack.append(current)
+    Self.trimToHistoryLimit(&backStack)
+  }
+  historyDrivenSelection = next
+  selection = next
+}
+
+static func trimToHistoryLimit(_ stack: inout [SidebarSelection]) {
+  if stack.count > historyLimit { stack.removeFirst(stack.count - historyLimit) }
+}
+```
+
+**Why a value token, not a Bool flag.** A flag-based suppression (`isNavigatingHistory = true; selection = …; isNavigatingHistory = false`) assumes `onChange` fires synchronously inside the `selection` setter. SwiftUI does not guarantee that — `onChange` is generally delivered as part of the next view-update cycle, by which time the flag has already been reset. The value-token approach instead checks whether the new selection equals the destination we just intentionally navigated to, which is true regardless of when the callback fires.
+
+### 3. `App/MoolahDomainCommands.swift` — wire the menu items
+
+In `MoolahDomainCommands` add two `@FocusedValue` properties:
+
+```swift
+@FocusedValue(\.goBackAction) private var goBackAction
+@FocusedValue(\.goForwardAction) private var goForwardAction
+```
+
+Replace the placeholder Buttons in `goMenuItems`:
+
+```swift
+Button("Go Back") { goBackAction?() }
+  .keyboardShortcut("[", modifiers: .command)
+  .disabled(goBackAction == nil)
+Button("Go Forward") { goForwardAction?() }
+  .keyboardShortcut("]", modifiers: .command)
+  .disabled(goForwardAction == nil)
+```
+
+## Edge cases
+
+| Scenario                                            | Handled how                                                                            |
+| --------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| User clicks the same sidebar row again              | `onChange(of:)` doesn't fire — no-op.                                                  |
+| AppleScript / App Intents navigation                | Flows through `applyNavigation` → sets `selection` → trips `onChange` → recorded.      |
+| Initial selection is `nil` (iOS first launch)       | First non-nil change has `oldValue == nil` → not pushed. `backStack` correctly empty.  |
+| Profile switch                                      | New `ProfileSession` → new `ContentView` → fresh `@State` stacks.                      |
+| Window close / reopen                               | New `ContentView` → fresh `@State` stacks. (In-memory only by design.)                 |
+| Rapid back/forward presses                          | Stack pops are synchronous; `withHistorySuppressed` brackets the mutation.             |
+| 51st entry pushed                                   | `cap(_:)` removes the oldest so the stack stays at 50.                                 |
+
+## Testing
+
+- **No store-level unit test.** All logic lives in `ContentView.@State`, which is bound to view lifetime. Adding a store solely to host two arrays and three methods would be over-engineering, and we agreed during brainstorming to skip it.
+- **Manual / UI verification (macOS):**
+  1. Launch app, observe Go > Go Back and Go > Go Forward both disabled.
+  2. ⌘1 (Transactions) — Go Back becomes enabled, Go Forward stays disabled.
+  3. ⌘2 (Scheduled) — both eligible to be navigated; Go Back enabled.
+  4. ⌘3 (Categories).
+  5. ⌘[ — selection goes to Scheduled. Go Forward now enabled.
+  6. ⌘[ — selection goes to Transactions. Go Forward enabled.
+  7. ⌘] — selection goes to Scheduled. Go Back enabled, Go Forward enabled.
+  8. ⌘1 (Transactions, fresh user navigation) — forward stack clears; Go Forward becomes disabled.
+  9. ⌘[ until exhausted — Go Back becomes disabled at the bottom of the stack.
+
+## Out of scope
+
+- Persisting history across launches.
+- Showing a popover/menu of recent destinations on long-press.
+- A separate iOS gesture-based back affordance (the iOS UI doesn't have a menu bar; this PR is fundamentally a macOS menu feature, but the focused-value plumbing is cross-platform and the iOS build will continue to compile).


### PR DESCRIPTION
## Summary

- Wires the Go menu's previously-disabled `Go Back` (⌘[) and `Go Forward` (⌘]) items to per-window navigation history over `SidebarSelection`.
- Browser-style: each user-driven sidebar change pushes the prior selection onto a back stack and clears the forward stack; back/forward move entries between stacks without re-recording. Each stack capped at 50 entries.
- Reorders the Go menu so Back/Forward sit at the top, before the ⌘1–⌘5 destinations, matching macOS HIG (Safari, Xcode, Finder, Mail).

## Notes

- Suppression of history-driven navigation uses a **value token** (`historyDrivenSelection`) rather than a Bool flag — the recorder compares it against the new `selection` value. This is robust regardless of whether SwiftUI delivers `onChange` synchronously or on the next render cycle (a Bool flag bracketed around the assignment can race with deferred `onChange` and double-record).
- History is per `ProfileSession` / per window — closing or switching profile resets it (in-memory only by design).
- Logic deliberately kept in `ContentView` rather than a Store: state is bound to view lifetime, helpers are < 40 lines of pure stack manipulation, no repository interaction. See design doc for the discussion.

## Design

Spec: `plans/2026-05-03-go-menu-back-forward-design.md`.

## Test plan

- [x] `just format-check` — clean
- [x] `just build-mac` — succeeds, no Swift warnings introduced
- [x] `just build-ios` — succeeds
- [x] `just test` — `MoolahTests_iOS` and `MoolahTests_macOS` both pass
- [ ] Manual macOS verification:
  1. Launch app, observe Go > Go Back and Go > Go Forward both disabled.
  2. ⌘1 (Transactions) — Go Back enabled, Forward disabled.
  3. ⌘2, ⌘3 — back/forward eligibility tracks correctly.
  4. ⌘[ goes back; ⌘] goes forward; ⌘1 (fresh navigation) clears forward stack.

## Reviewer agents run pre-PR

- `code-review`: applied (made helper extensions `private`-by-member, renamed `cap` → `trimToHistoryLimit`, added `// MARK:` separators).
- `ui-review`: applied (Critical race-condition fix via value token; reordered Go menu per HIG; documented `nil`-disable pattern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)