### PR TITLE
feat(transactions): ⌥⌘1–⌥⌘5 to switch transaction type

### DIFF
--- a/App/MoolahDomainCommands.swift
+++ b/App/MoolahDomainCommands.swift
@@ -91,6 +91,7 @@ struct MoolahDomainCommands: Commands {
   @FocusedValue(\.goBackAction) private var goBackAction
   @FocusedValue(\.goForwardAction) private var goForwardAction
   @FocusedValue(\.findInListAction) private var findInListAction
+  @FocusedValue(\.setTransactionTypeAction) private var setTransactionTypeAction
   @Environment(\.openWindow) private var openWindow
   @Environment(\.openURL) private var openURL
 
@@ -105,6 +106,11 @@ struct MoolahDomainCommands: Commands {
       .disabled(selectedTransaction?.wrappedValue == nil)
 
       Button("Duplicate Transaction") {}.disabled(true)
+
+      Menu("Type") {
+        transactionTypeMenuItems
+      }
+      .disabled(setTransactionTypeAction == nil)
 
       Button("Pay Scheduled Transaction") {
         NotificationCenter.default.post(
@@ -228,6 +234,24 @@ struct MoolahDomainCommands: Commands {
         if let url = URL(string: "https://moolah.app/terms") { openURL(url) }
       }
     }
+  }
+
+  @ViewBuilder private var transactionTypeMenuItems: some View {
+    Button("Income") { setTransactionTypeAction?(.income) }
+      .keyboardShortcut("1", modifiers: [.option, .command])
+      .disabled(setTransactionTypeAction == nil)
+    Button("Expense") { setTransactionTypeAction?(.expense) }
+      .keyboardShortcut("2", modifiers: [.option, .command])
+      .disabled(setTransactionTypeAction == nil)
+    Button("Transfer") { setTransactionTypeAction?(.transfer) }
+      .keyboardShortcut("3", modifiers: [.option, .command])
+      .disabled(setTransactionTypeAction == nil)
+    Button("Trade") { setTransactionTypeAction?(.trade) }
+      .keyboardShortcut("4", modifiers: [.option, .command])
+      .disabled(setTransactionTypeAction == nil)
+    Button("Custom") { setTransactionTypeAction?(.custom) }
+      .keyboardShortcut("5", modifiers: [.option, .command])
+      .disabled(setTransactionTypeAction == nil)
   }
 
   @ViewBuilder private var goMenuItems: some View {

--- a/Features/Help/KeyboardShortcutsView.swift
+++ b/Features/Help/KeyboardShortcutsView.swift
@@ -54,6 +54,11 @@ struct KeyboardShortcutsView: View {
     section("Transaction") {
       row("Return", "Edit Transaction (on selected row)")
       row("Delete", "Delete Transaction (on selected row)")
+      row("⌥⌘1", "Type ▸ Income")
+      row("⌥⌘2", "Type ▸ Expense")
+      row("⌥⌘3", "Type ▸ Transfer")
+      row("⌥⌘4", "Type ▸ Trade")
+      row("⌥⌘5", "Type ▸ Custom")
     }
     section("List Navigation") {
       row("↑ / ↓", "Move selection")

--- a/Features/Transactions/Views/Detail/TransactionDetailFocus+ModeSwitch.swift
+++ b/Features/Transactions/Views/Detail/TransactionDetailFocus+ModeSwitch.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+extension TransactionDetailFocus {
+  /// Returns the equivalent focus in `newStructure`. Payee always stays
+  /// put. An amount-shaped focus is preserved when the new structure can
+  /// still host it (e.g. `.legAmount(N)` survives a custom→custom switch),
+  /// otherwise it is remapped to the new structure's primary amount slot.
+  ///
+  /// `.tradeFeeAmount(_)`'s associated index is intentionally discarded
+  /// when leaving Trade — fee legs don't survive a structural change, so
+  /// any non-trade target lands the user on the new structure's primary
+  /// amount.
+  func remapping(toStructure newStructure: ModeStructure) -> TransactionDetailFocus {
+    let primary: TransactionDetailFocus =
+      switch newStructure {
+      case .simple: .amount
+      case .trade: .tradePaidAmount
+      case .custom: .legAmount(0)
+      }
+    switch self {
+    case .payee:
+      return .payee
+    case .legAmount:
+      return newStructure == .custom ? self : primary
+    case .tradePaidAmount, .tradeReceivedAmount, .tradeFeeAmount:
+      return newStructure == .trade ? self : primary
+    case .amount, .counterpartAmount:
+      return primary
+    }
+  }
+}

--- a/Features/Transactions/Views/Detail/TransactionDetailFocus.swift
+++ b/Features/Transactions/Views/Detail/TransactionDetailFocus.swift
@@ -12,4 +12,16 @@ enum TransactionDetailFocus: Hashable {
   case tradePaidAmount
   case tradeReceivedAmount
   case tradeFeeAmount(Int)  // index into legDrafts
+
+  /// Higher-level grouping of transaction modes by the shape of their
+  /// form. Income, Expense, and Transfer share one focus surface
+  /// (`.amount` / `.counterpartAmount`); Trade and Custom each have their
+  /// own. The shortcut-driven type switcher uses this enum to decide
+  /// whether the focused field still exists in the new mode and where to
+  /// remap it otherwise.
+  enum ModeStructure: Hashable {
+    case simple
+    case trade
+    case custom
+  }
 }

--- a/Features/Transactions/Views/Detail/TransactionDetailMode.swift
+++ b/Features/Transactions/Views/Detail/TransactionDetailMode.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// User-facing transaction-mode selection driving the inspector's type
+/// picker and the Transaction > Type menu items.
+///
+/// `expense`, `income`, `transfer`, and `trade` map onto `TransactionType`
+/// via `TransactionDraft.setType(_:accounts:)` or the trade-switch helpers.
+/// `custom` flips `TransactionDraft.isCustom` to switch the editor into
+/// multi-leg mode. `openingBalance` legs collapse onto `.expense` for
+/// binding purposes — `TransactionDetailModeSection` disables the picker
+/// entirely for those transactions.
+enum TransactionDetailMode: Hashable {
+  case income
+  case expense
+  case transfer
+  case trade
+  case custom
+
+  var displayName: String {
+    switch self {
+    case .income: return "Income"
+    case .expense: return "Expense"
+    case .transfer: return "Transfer"
+    case .trade: return "Trade"
+    case .custom: return "Custom"
+    }
+  }
+
+  /// Form-shape grouping used to decide whether a focused amount field
+  /// survives the switch to this mode.
+  var focusStructure: TransactionDetailFocus.ModeStructure {
+    switch self {
+    case .income, .expense, .transfer: return .simple
+    case .trade: return .trade
+    case .custom: return .custom
+    }
+  }
+}

--- a/Features/Transactions/Views/Detail/TransactionDetailModeSection.swift
+++ b/Features/Transactions/Views/Detail/TransactionDetailModeSection.swift
@@ -1,26 +1,5 @@
 import SwiftUI
 
-/// User-facing transaction mode driving the simple-mode/custom-mode picker.
-///
-/// `expense`, `income`, `transfer`, and `trade` map onto `TransactionType` via
-/// `TransactionDraft.setType(_:accounts:)` or the trade-switch helpers.
-/// `custom` flips `TransactionDraft.isCustom` to switch the editor into
-/// multi-leg mode. `openingBalance` legs collapse onto `.expense` for binding
-/// purposes — the section disables the picker entirely for those transactions.
-private enum TransactionMode: Hashable {
-  case income, expense, transfer, trade, custom
-
-  var displayName: String {
-    switch self {
-    case .income: return "Income"
-    case .expense: return "Expense"
-    case .transfer: return "Transfer"
-    case .trade: return "Trade"
-    case .custom: return "Custom"
-    }
-  }
-}
-
 /// The "Type" picker section.
 ///
 /// Renders one of three forms depending on the underlying transaction:
@@ -29,16 +8,29 @@ private enum TransactionMode: Hashable {
 /// - Read-only "Custom" label when the transaction has multi-leg structure
 ///   that can't be re-expressed as a simple income/expense/transfer/trade.
 /// - The interactive `Picker` of income / expense / transfer / trade / custom.
+///
+/// While the interactive picker is visible, the section publishes a
+/// `setTransactionTypeAction` focused-scene-value so the Transaction > Type
+/// menu items (⌥⌘1–⌥⌘5) drive the same code path as the picker — even
+/// while a text field has focus. Focus is migrated to the new mode's
+/// primary amount slot when the form structure changes (see
+/// `TransactionDetailFocus.remapping(toStructure:)`).
 struct TransactionDetailModeSection: View {
   let transaction: Transaction
   @Binding var draft: TransactionDraft
   let accounts: Accounts
+  @FocusState.Binding var focusedField: TransactionDetailFocus?
 
-  private var modeBinding: Binding<TransactionMode> {
-    Binding(get: { modeGet() }, set: { modeSet($0) })
+  /// Available modes, in display order (also the ⌥⌘1–⌥⌘5 mapping).
+  private static let modes: [TransactionDetailMode] = [
+    .income, .expense, .transfer, .trade, .custom,
+  ]
+
+  private var modeBinding: Binding<TransactionDetailMode> {
+    Binding(get: { currentMode() }, set: { applyModeChange(to: $0) })
   }
 
-  private func modeGet() -> TransactionMode {
+  private func currentMode() -> TransactionDetailMode {
     if draft.isCustom { return .custom }
     if draft.legDrafts.contains(where: { $0.type == .trade }) { return .trade }
     switch draft.type {
@@ -50,7 +42,18 @@ struct TransactionDetailModeSection: View {
     }
   }
 
-  private func modeSet(_ newMode: TransactionMode) {
+  /// Apply a mode change and migrate focus when the form's structure
+  /// changes. Used by both the picker binding and the menu-driven
+  /// `setTransactionTypeAction` so the two paths share semantics.
+  private func applyModeChange(to newMode: TransactionDetailMode) {
+    let oldStructure = currentMode().focusStructure
+    let newStructure = newMode.focusStructure
+    applyMode(newMode)
+    guard oldStructure != newStructure, let oldFocus = focusedField else { return }
+    focusedField = oldFocus.remapping(toStructure: newStructure)
+  }
+
+  private func applyMode(_ newMode: TransactionDetailMode) {
     let wasTrade = draft.legDrafts.contains { $0.type == .trade }
     switch newMode {
     case .custom: draft.isCustom = true
@@ -80,14 +83,28 @@ struct TransactionDetailModeSection: View {
     }
   }
 
+  /// Single source of truth for whether the type can be interactively
+  /// changed. Drives both the body's branching (picker vs read-only label)
+  /// and the publication of `setTransactionTypeAction` to the menu.
+  private var pickerInteractive: Bool {
+    let hasOpeningBalance = transaction.legs.contains(where: { $0.type == .openingBalance })
+    let irreducibleCustom =
+      !transaction.isSimple && !transaction.isTrade && !draft.isCustom
+    return !hasOpeningBalance && !irreducibleCustom
+  }
+
+  private var hasOpeningBalance: Bool {
+    transaction.legs.contains { $0.type == .openingBalance }
+  }
+
   var body: some View {
     Section {
-      if transaction.legs.contains(where: { $0.type == .openingBalance }) {
+      if hasOpeningBalance {
         LabeledContent("Type") {
           Text(TransactionType.openingBalance.displayName)
             .foregroundStyle(.secondary)
         }
-      } else if !transaction.isSimple && !transaction.isTrade && !draft.isCustom {
+      } else if !pickerInteractive {
         LabeledContent("Type") {
           Text("Custom").foregroundStyle(.secondary)
         }
@@ -95,9 +112,7 @@ struct TransactionDetailModeSection: View {
           "This transaction has custom sub-transactions and cannot be changed to a simpler type.")
       } else {
         Picker("Type", selection: modeBinding) {
-          ForEach(
-            [TransactionMode.income, .expense, .transfer, .trade, .custom], id: \.self
-          ) { mode in
+          ForEach(Self.modes, id: \.self) { mode in
             Text(mode.displayName).tag(mode)
           }
         }
@@ -105,8 +120,41 @@ struct TransactionDetailModeSection: View {
         .accessibilityIdentifier(UITestIdentifiers.Detail.modeTypePicker)
         #if os(iOS)
           .pickerStyle(.segmented)
+          .background { iPadShortcutButtons }
+        #else
+          .focusedSceneValue(\.setTransactionTypeAction) { mode in
+            applyModeChange(to: mode)
+          }
         #endif
       }
     }
   }
+
+  #if os(iOS)
+    /// Hidden buttons that bind ⌥⌘1–⌥⌘5 on iPad with a hardware keyboard.
+    /// macOS uses the Transaction > Type menu items instead (per UI Guide
+    /// §14), but iOS has no menu bar — `keyboardShortcut` only fires when
+    /// the bound `Button` is in the view tree, hence this tiny invisible
+    /// surface placed inside the section's `.background` so it joins the
+    /// responder chain only while the picker is visible.
+    @ViewBuilder private var iPadShortcutButtons: some View {
+      HStack(spacing: 0) {
+        shortcutButton(label: "Income", key: "1") { applyModeChange(to: .income) }
+        shortcutButton(label: "Expense", key: "2") { applyModeChange(to: .expense) }
+        shortcutButton(label: "Transfer", key: "3") { applyModeChange(to: .transfer) }
+        shortcutButton(label: "Trade", key: "4") { applyModeChange(to: .trade) }
+        shortcutButton(label: "Custom", key: "5") { applyModeChange(to: .custom) }
+      }
+      .frame(width: 0, height: 0)
+      .opacity(0)
+      .accessibilityHidden(true)
+    }
+
+    private func shortcutButton(
+      label: String, key: KeyEquivalent, action: @escaping () -> Void
+    ) -> some View {
+      Button(label, action: action)
+        .keyboardShortcut(key, modifiers: [.option, .command])
+    }
+  #endif
 }

--- a/Features/Transactions/Views/TransactionDetailView.swift
+++ b/Features/Transactions/Views/TransactionDetailView.swift
@@ -315,7 +315,8 @@ extension TransactionDetailView {
     TransactionDetailModeSection(
       transaction: transaction,
       draft: $draft,
-      accounts: accounts
+      accounts: accounts,
+      focusedField: $focusedField
     )
   }
 

--- a/MoolahTests/Features/TransactionDetailFocusModeSwitchTests.swift
+++ b/MoolahTests/Features/TransactionDetailFocusModeSwitchTests.swift
@@ -1,0 +1,65 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("TransactionDetailFocus.remapping(toStructure:)")
+struct TransactionDetailFocusModeSwitchTests {
+  private typealias ModeStructure = TransactionDetailFocus.ModeStructure
+
+  @Test
+  func payeeStaysPutAcrossEveryStructure() {
+    #expect(TransactionDetailFocus.payee.remapping(toStructure: .simple) == .payee)
+    #expect(TransactionDetailFocus.payee.remapping(toStructure: .trade) == .payee)
+    #expect(TransactionDetailFocus.payee.remapping(toStructure: .custom) == .payee)
+  }
+
+  @Test
+  func amountMapsToTheNewStructuresPrimaryAmount() {
+    #expect(TransactionDetailFocus.amount.remapping(toStructure: .simple) == .amount)
+    #expect(
+      TransactionDetailFocus.amount.remapping(toStructure: .trade) == .tradePaidAmount)
+    #expect(
+      TransactionDetailFocus.amount.remapping(toStructure: .custom) == .legAmount(0))
+  }
+
+  @Test
+  func counterpartAmountMapsToTheNewStructuresPrimaryAmount() {
+    let focus = TransactionDetailFocus.counterpartAmount
+    #expect(focus.remapping(toStructure: .simple) == .amount)
+    #expect(focus.remapping(toStructure: .trade) == .tradePaidAmount)
+    #expect(focus.remapping(toStructure: .custom) == .legAmount(0))
+  }
+
+  @Test
+  func legAmountStaysPutWithinCustomAndMapsOutOfCustom() {
+    let focus = TransactionDetailFocus.legAmount(2)
+    #expect(focus.remapping(toStructure: .custom) == .legAmount(2))
+    #expect(focus.remapping(toStructure: .simple) == .amount)
+    #expect(focus.remapping(toStructure: .trade) == .tradePaidAmount)
+  }
+
+  @Test
+  func tradePaidAmountStaysWithinTradeAndMapsOutOfTrade() {
+    let focus = TransactionDetailFocus.tradePaidAmount
+    #expect(focus.remapping(toStructure: .trade) == .tradePaidAmount)
+    #expect(focus.remapping(toStructure: .simple) == .amount)
+    #expect(focus.remapping(toStructure: .custom) == .legAmount(0))
+  }
+
+  @Test
+  func tradeReceivedAmountStaysWithinTradeAndMapsOutOfTrade() {
+    let focus = TransactionDetailFocus.tradeReceivedAmount
+    #expect(focus.remapping(toStructure: .trade) == .tradeReceivedAmount)
+    #expect(focus.remapping(toStructure: .simple) == .amount)
+    #expect(focus.remapping(toStructure: .custom) == .legAmount(0))
+  }
+
+  @Test
+  func tradeFeeAmountStaysWithinTradeAndMapsOutOfTrade() {
+    let focus = TransactionDetailFocus.tradeFeeAmount(1)
+    #expect(focus.remapping(toStructure: .trade) == .tradeFeeAmount(1))
+    #expect(focus.remapping(toStructure: .simple) == .amount)
+    #expect(focus.remapping(toStructure: .custom) == .legAmount(0))
+  }
+}

--- a/MoolahUITests_macOS/Helpers/Screens/TradeFormDriver.swift
+++ b/MoolahUITests_macOS/Helpers/Screens/TradeFormDriver.swift
@@ -27,18 +27,19 @@ struct TradeFormDriver {
 
     // ui-test-review: allow single-resolver — on macOS, SwiftUI Pickers open
     // a native NSMenu whose items attach to the application's menu hierarchy
-    // at runtime. `.accessibilityIdentifier(_:)` on the inline `Text(…)`
-    // inside the ForEach does not propagate to the NSMenuItem, so querying
-    // by label is the only viable resolution path here.
-    //
-    // The same label ("Trade") also appears as a static entry under the
-    // menu bar's `Transaction > Type ▸` submenu, so the bare query
-    // `menuItems["Trade"]` matches multiple elements. The popup's "Trade"
-    // is the only hittable match while the menu bar is collapsed; pick it.
-    let tradeItem = firstHittableMenuItem(labelled: "Trade")
+    // at runtime as descendants of the popUpButton. Their AX labels are
+    // empty (the inline `Text(…)` inside the ForEach doesn't propagate to
+    // the NSMenuItem), so label-based lookup is unavailable; positional
+    // indexing scoped to the picker is the only stable handle. The
+    // production picker is built from
+    // `[.income, .expense, .transfer, .trade, .custom]`, so Trade is at
+    // index 3. Scoping to `picker.menuItems` excludes the static
+    // `Transaction > Type ▸ Trade` menu-bar entry, which descends from the
+    // app's menu bar, not the popUpButton.
+    let tradeItem = picker.menuItems.element(boundBy: 3)
     if !tradeItem.waitForExistence(timeout: 3) {
-      Trace.recordFailure("'Trade' menu item did not appear after opening type picker")
-      XCTFail("'Trade' menu item did not appear within 3s of opening the Type picker")
+      Trace.recordFailure("popup menu item at index 3 did not appear after opening type picker")
+      XCTFail("Picker popup item at index 3 (Trade) did not appear within 3s of opening")
       return
     }
     tradeItem.click()
@@ -173,20 +174,6 @@ struct TradeFormDriver {
   }
 
   // MARK: - Private helpers
-
-  /// Returns the first hittable menu item with the given label. Used to
-  /// pick a SwiftUI Picker's popup item when a static menu-bar entry
-  /// shares the same label — the menu bar's copy stays unhittable while
-  /// the bar is collapsed, so hittability cleanly picks the popup.
-  private func firstHittableMenuItem(labelled label: String) -> XCUIElement {
-    let predicate = NSPredicate(format: "label == %@", label)
-    let matches = app.application.menuItems.matching(predicate)
-    for index in 0..<matches.count {
-      let candidate = matches.element(boundBy: index)
-      if candidate.isHittable { return candidate }
-    }
-    return matches.firstMatch
-  }
 
   /// Clears any existing text in `identifier` and types `text`. Returns once
   /// the field's `value` contains `text`.

--- a/MoolahUITests_macOS/Helpers/Screens/TradeFormDriver.swift
+++ b/MoolahUITests_macOS/Helpers/Screens/TradeFormDriver.swift
@@ -28,9 +28,14 @@ struct TradeFormDriver {
     // ui-test-review: allow single-resolver — on macOS, SwiftUI Pickers open
     // a native NSMenu whose items attach to the application's menu hierarchy
     // at runtime. `.accessibilityIdentifier(_:)` on the inline `Text(…)`
-    // inside the ForEach does not propagate to the NSMenuItem, so querying by
-    // label via `menuItems["Trade"]` is the only viable resolution path here.
-    let tradeItem = app.application.menuItems["Trade"]
+    // inside the ForEach does not propagate to the NSMenuItem, so querying
+    // by label is the only viable resolution path here.
+    //
+    // The same label ("Trade") also appears as a static entry under the
+    // menu bar's `Transaction > Type ▸` submenu, so the bare query
+    // `menuItems["Trade"]` matches multiple elements. The popup's "Trade"
+    // is the only hittable match while the menu bar is collapsed; pick it.
+    let tradeItem = firstHittableMenuItem(labelled: "Trade")
     if !tradeItem.waitForExistence(timeout: 3) {
       Trace.recordFailure("'Trade' menu item did not appear after opening type picker")
       XCTFail("'Trade' menu item did not appear within 3s of opening the Type picker")
@@ -168,6 +173,20 @@ struct TradeFormDriver {
   }
 
   // MARK: - Private helpers
+
+  /// Returns the first hittable menu item with the given label. Used to
+  /// pick a SwiftUI Picker's popup item when a static menu-bar entry
+  /// shares the same label — the menu bar's copy stays unhittable while
+  /// the bar is collapsed, so hittability cleanly picks the popup.
+  private func firstHittableMenuItem(labelled label: String) -> XCUIElement {
+    let predicate = NSPredicate(format: "label == %@", label)
+    let matches = app.application.menuItems.matching(predicate)
+    for index in 0..<matches.count {
+      let candidate = matches.element(boundBy: index)
+      if candidate.isHittable { return candidate }
+    }
+    return matches.firstMatch
+  }
 
   /// Clears any existing text in `identifier` and types `text`. Returns once
   /// the field's `value` contains `text`.

--- a/Shared/FocusedValues.swift
+++ b/Shared/FocusedValues.swift
@@ -82,6 +82,14 @@ struct PasteCSVActionKey: FocusedValueKey {
   typealias Value = () -> Void
 }
 
+/// Action published by an open transaction inspector while its type
+/// picker is interactive. Drives the Transaction > Type submenu (⌥⌘1–⌥⌘5).
+/// `nil` whenever no editable inspector is in scope (e.g. opening-balance
+/// transactions, irreducible-custom shapes, or no inspector open).
+struct SetTransactionTypeActionKey: FocusedValueKey {
+  typealias Value = (TransactionDetailMode) -> Void
+}
+
 extension FocusedValues {
   var newTransactionAction: NewTransactionActionKey.Value? {
     get { self[NewTransactionActionKey.self] }
@@ -146,5 +154,9 @@ extension FocusedValues {
   var pasteCSVAction: PasteCSVActionKey.Value? {
     get { self[PasteCSVActionKey.self] }
     set { self[PasteCSVActionKey.self] = newValue }
+  }
+  var setTransactionTypeAction: SetTransactionTypeActionKey.Value? {
+    get { self[SetTransactionTypeActionKey.self] }
+    set { self[SetTransactionTypeActionKey.self] = newValue }
   }
 }


### PR DESCRIPTION
## Summary

- Adds ⌥⌘1–⌥⌘5 to switch the transaction type (Income / Expense / Transfer / Trade / Custom) from inside the detail inspector — works while a text field has focus.
- Wired through a new **Transaction > Type** submenu on macOS (UI Guide §14: every shortcut has a menu item, surfaced via Help > Search and Full Keyboard Access).
- Hidden in-view shortcut buttons cover the iPad-with-hardware-keyboard path where there is no menu bar.
- Focus follows the user: payee stays put; any amount-shaped focus migrates to the new mode's primary amount slot (simple → `.amount`, trade → `.tradePaidAmount`, custom → `.legAmount(0)`).
- No-ops on opening-balance and irreducible-custom transactions, mirroring the picker's read-only branches.

## Implementation notes

- New `TransactionDetailMode` enum (extracted from a previously private enum in `TransactionDetailModeSection`) is the public selection type.
- New `SetTransactionTypeActionKey` `@FocusedValue` is published only while the picker is interactive, so the menu items disable themselves when no editable inspector is in scope.
- `TransactionDetailFocus.ModeStructure` is now a nested type; `remapping(toStructure:)` is a pure helper with seven Swift Testing tests.
- `pickerInteractive` is the single source of truth for whether the type can be changed, used by both the body's branching and the `@FocusedValue` publication.

## Test plan

- [x] `just build-mac` — clean, no warnings.
- [x] `just build-ios` — clean, no warnings.
- [x] `just test-mac TransactionDetailFocusModeSwitchTests TransactionDraftTests TransactionStoreTests` — all pass.
- [x] `just format-check` — clean.
- [ ] Manual: open transaction inspector on macOS, verify ⌥⌘1–⌥⌘5 cycle through types while typing in payee / amount.
- [ ] Manual: verify Transaction > Type menu shows the five items with shortcuts; disabled when no inspector is open and on opening-balance transactions.
- [ ] Manual: focus migration — type in amount field on Expense, ⌥⌘4 should land on the trade "Paid" amount.

🤖 Generated with [Claude Code](https://claude.com/claude-code)