### PR TITLE
fix(ui): negate trade Paid field for natural-sign entry

### DIFF
--- a/Features/Transactions/Views/Detail/TransactionDetailTradeSection.swift
+++ b/Features/Transactions/Views/Detail/TransactionDetailTradeSection.swift
@@ -1,12 +1,23 @@
 import SwiftUI
 
 // Sign-handling note:
-// `TransactionDraft.displaysNegated(.trade) == false`, so the user enters
-// signed quantities directly into Paid and Received and the storage matches
-// 1:1. Trade reversals legitimately have unconventional signs, so the editor
-// preserves whatever the user types — see CLAUDE.md "Monetary Sign
+// At the draft-model layer `TransactionDraft.displaysNegated(.trade) ==
+// false`, so the stored leg `amountText` matches the leg's signed quantity
+// 1:1. Trade reversals legitimately have unconventional signs, so the
+// model preserves whatever the user enters — see CLAUDE.md "Monetary Sign
 // Convention" and `feedback_no_abs_on_trade_legs.md` (no abs, no sign-by-
 // position).
+//
+// The Paid field is the one exception, applied here in the *view layer*:
+// users expect "I paid $10" to decrease their balance, so the Paid binding
+// flips the sign for display via
+// `TransactionDraft.flipTradePaidDisplaySign(_:)`. Storage still reflects
+// the underlying signed leg quantity (a normal buy stores `-300`); the
+// flip is bidirectional, so a refund booked against the Paid leg is
+// entered as a negative number in the field, which the view-side flip
+// turns into a positive stored quantity. The Received field is unaffected:
+// positive entry, positive stored quantity.
+
 /// Trade-mode primary section. Mirrors the structure of
 /// `TransactionDetailDetailsSection` + `TransactionDetailAccountSection` for
 /// transfers, but with a single shared account picker and dual amount
@@ -65,23 +76,11 @@ struct TransactionDetailTradeSection: View {
   }
 
   private var paidRow: some View {
-    legAmountRow(
-      label: "Paid",
-      indexAccessor: { draft.paidLegIndex },
-      focus: .tradePaidAmount,
-      identifier: UITestIdentifiers.Detail.tradePaidAmount,
-      instrumentIdentifier: UITestIdentifiers.Detail.tradePaidInstrument
-    )
+    legAmountRow(.paid)
   }
 
   private var receivedRow: some View {
-    legAmountRow(
-      label: "Received",
-      indexAccessor: { draft.receivedLegIndex },
-      focus: .tradeReceivedAmount,
-      identifier: UITestIdentifiers.Detail.tradeReceivedAmount,
-      instrumentIdentifier: UITestIdentifiers.Detail.tradeReceivedInstrument
-    )
+    legAmountRow(.received)
   }
 
   private func defaultInstrument(forLegAt idx: Int) -> Instrument {
@@ -89,37 +88,39 @@ struct TransactionDetailTradeSection: View {
   }
 
   @ViewBuilder
-  private func legAmountRow(
-    label: LocalizedStringKey,
-    indexAccessor: () -> Int?,
-    focus: TransactionDetailFocus,
-    identifier: String,
-    instrumentIdentifier: String
-  ) -> some View {
-    if let idx = indexAccessor() {
+  private func legAmountRow(_ side: TradeLegSide) -> some View {
+    if let idx = side.legIndex(in: draft) {
       let amountBinding = Binding(
-        get: { draft.legDrafts[idx].amountText },
-        set: { draft.legDrafts[idx].amountText = $0 })
+        get: {
+          let stored = draft.legDrafts[idx].amountText
+          return side.negateForDisplay
+            ? TransactionDraft.flipTradePaidDisplaySign(stored) : stored
+        },
+        set: { newValue in
+          draft.legDrafts[idx].amountText =
+            side.negateForDisplay
+            ? TransactionDraft.flipTradePaidDisplaySign(newValue) : newValue
+        })
       let instrumentBinding = Binding<Instrument>(
         get: { draft.legDrafts[idx].instrument ?? defaultInstrument(forLegAt: idx) },
         set: { draft.legDrafts[idx].instrument = $0 })
 
       LabeledContent {
         HStack(spacing: 8) {
-          TextField(label, text: amountBinding)
+          TextField(side.label, text: amountBinding)
             .labelsHidden()
             .multilineTextAlignment(.trailing)
             .monospacedDigit()
             #if os(iOS)
               .keyboardType(.decimalPad)
             #endif
-            .focused($focusedField, equals: focus)
-            .accessibilityIdentifier(identifier)
+            .focused($focusedField, equals: side.focus)
+            .accessibilityIdentifier(side.identifier)
           CompactInstrumentPickerButton(selection: instrumentBinding)
-            .accessibilityIdentifier(instrumentIdentifier)
+            .accessibilityIdentifier(side.instrumentIdentifier)
         }
       } label: {
-        Text(label)
+        Text(side.label)
       }
     }
   }
@@ -141,11 +142,72 @@ struct TransactionDetailTradeSection: View {
         from: received.amountText, decimals: receivedInst.decimals),
       paidQty != 0, receivedQty != 0
     else { return nil }
-    // `abs()` here applies to derived display ratios only; stored leg
+    // `abs()` here applies to the derived display ratio only; stored leg
     // quantities keep their signs untouched per the project sign convention.
+    // The Paid quantity is normally negative for a buy (and positive for a
+    // refund-shaped reversal), so the magnitude must be used either way to
+    // produce a positive exchange-rate caption.
     let rate = abs(paidQty / receivedQty)
     let rateFormatted = rate.formatted(
       .number.precision(.significantDigits(2...4)).grouping(.never))
     return "≈ 1 \(receivedInst.shortCode) = \(rateFormatted) \(paidInst.shortCode)"
+  }
+}
+
+// MARK: - TradeLegSide
+
+/// Identifies which leg of a trade a row is rendering, bundling the per-side
+/// configuration (label, focus identity, accessibility ids, leg-index lookup,
+/// and the display-sign convention) that
+/// `TransactionDetailTradeSection.legAmountRow(_:)` consumes. File-private so
+/// the section's call sites stay readable (`legAmountRow(.paid)`) without
+/// nesting the enum inside the `View` (which would trigger SwiftLint's
+/// `nesting` rule for types declared one level deep in another type).
+private enum TradeLegSide {
+  case paid, received
+
+  var label: LocalizedStringKey {
+    switch self {
+    case .paid: "Paid"
+    case .received: "Received"
+    }
+  }
+
+  var focus: TransactionDetailFocus {
+    switch self {
+    case .paid: .tradePaidAmount
+    case .received: .tradeReceivedAmount
+    }
+  }
+
+  var identifier: String {
+    switch self {
+    case .paid: UITestIdentifiers.Detail.tradePaidAmount
+    case .received: UITestIdentifiers.Detail.tradeReceivedAmount
+    }
+  }
+
+  var instrumentIdentifier: String {
+    switch self {
+    case .paid: UITestIdentifiers.Detail.tradePaidInstrument
+    case .received: UITestIdentifiers.Detail.tradeReceivedInstrument
+    }
+  }
+
+  /// `true` when the field should display the user's natural-sign value
+  /// while storage keeps the leg's signed quantity. Only the Paid leg
+  /// negates; see the file-header sign-handling note.
+  var negateForDisplay: Bool {
+    switch self {
+    case .paid: true
+    case .received: false
+    }
+  }
+
+  func legIndex(in draft: TransactionDraft) -> Int? {
+    switch self {
+    case .paid: draft.paidLegIndex
+    case .received: draft.receivedLegIndex
+    }
   }
 }

--- a/MoolahTests/Shared/TransactionDraftTradeAccessorsTests.swift
+++ b/MoolahTests/Shared/TransactionDraftTradeAccessorsTests.swift
@@ -35,6 +35,29 @@ struct TransactionDraftTradeAccessorsTests {
     #expect(draft.receivedLegIndex == 1)
   }
 
+  @Test("received index is nil when there are three or more .trade legs")
+  func receivedLegIndexRejectsExtraTradeLegs() {
+    // Trade-shape invariant: exactly two `.trade` legs. A third indicates a
+    // malformed or custom-mode draft, so the trade UI should not bind to it.
+    var draft = tradeDraft()
+    draft.legDrafts.append(
+      TransactionDraft.LegDraft(
+        type: .trade, accountId: account, amountText: "5",
+        categoryId: nil, categoryText: "", earmarkId: nil, instrument: aud))
+    #expect(draft.receivedLegIndex == nil)
+  }
+
+  @Test("received index is nil when there is only one .trade leg")
+  func receivedLegIndexNilForSingleTrade() {
+    var draft = TransactionDraft(accountId: account, instrument: aud)
+    draft.legDrafts = [
+      TransactionDraft.LegDraft(
+        type: .trade, accountId: account, amountText: "300",
+        categoryId: nil, categoryText: "", earmarkId: nil, instrument: aud)
+    ]
+    #expect(draft.receivedLegIndex == nil)
+  }
+
   @Test("feeIndices returns the .expense legs in order")
   func feeIndices() {
     let fee1 = TransactionDraft.LegDraft(

--- a/MoolahTests/Shared/TransactionDraftTradePaidDisplayTests.swift
+++ b/MoolahTests/Shared/TransactionDraftTradePaidDisplayTests.swift
@@ -1,0 +1,126 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+/// `TransactionDraft.flipTradePaidDisplaySign(_:)` is the view-side bijection
+/// that lets the trade Paid field display amounts in the user's natural sign:
+/// the user types `300` to mean "I paid $300, balance goes down", and the
+/// underlying leg quantity is stored as `-300`. The helper must round-trip
+/// (`flip(flip(x)) == x`) so the Binding's get/set composition is stable, and
+/// must pass partial input (`""`, `"-"`, `"0."`) through unchanged so typing
+/// is not interrupted mid-keystroke.
+@Suite("TransactionDraft.flipTradePaidDisplaySign")
+struct TransactionDraftTradePaidDisplayTests {
+
+  // MARK: - Round-trip cases (display ↔ storage)
+
+  @Test("positive display flips to negative storage")
+  func positiveToNegative() {
+    #expect(TransactionDraft.flipTradePaidDisplaySign("300") == "-300")
+    #expect(TransactionDraft.flipTradePaidDisplaySign("1") == "-1")
+    #expect(TransactionDraft.flipTradePaidDisplaySign("10.5") == "-10.5")
+    #expect(TransactionDraft.flipTradePaidDisplaySign("300.00") == "-300.00")
+  }
+
+  @Test("negative display flips to positive storage")
+  func negativeToPositive() {
+    #expect(TransactionDraft.flipTradePaidDisplaySign("-300") == "300")
+    #expect(TransactionDraft.flipTradePaidDisplaySign("-1") == "1")
+    #expect(TransactionDraft.flipTradePaidDisplaySign("-10.5") == "10.5")
+    #expect(TransactionDraft.flipTradePaidDisplaySign("-300.00") == "300.00")
+  }
+
+  // MARK: - Zero handling (clean initial display)
+
+  @Test("canonical zero stays positive — no '-0' rendered for fresh paid leg")
+  func zeroStaysPositive() {
+    // The blank Paid leg's stored amountText is "0"; users should see "0",
+    // not "-0", in the field on a fresh trade form.
+    #expect(TransactionDraft.flipTradePaidDisplaySign("0") == "0")
+    #expect(TransactionDraft.flipTradePaidDisplaySign("0.") == "0.")
+  }
+
+  @Test("'-0' / '-0.' preserve the leading minus during partial typing of '-0.5'")
+  func negativeZeroPreservedForTyping() {
+    // User enters a refund (negative paid amount) by typing "-", "0", ".",
+    // "5". The "-0" intermediate state must keep its minus so the next
+    // keystroke continues building "-0.5" rather than collapsing to "0.5".
+    #expect(TransactionDraft.flipTradePaidDisplaySign("-0") == "-0")
+    #expect(TransactionDraft.flipTradePaidDisplaySign("-0.") == "-0.")
+  }
+
+  // MARK: - Partial input passthrough
+
+  @Test("empty string passes through unchanged")
+  func emptyPassesThrough() {
+    #expect(TransactionDraft.flipTradePaidDisplaySign("").isEmpty)
+  }
+
+  @Test("lone '-' passes through unchanged so typing a refund's leading minus survives")
+  func loneMinusPassesThrough() {
+    #expect(TransactionDraft.flipTradePaidDisplaySign("-") == "-")
+  }
+
+  // MARK: - Idempotency under composition (Binding round-trip stability)
+
+  @Test("flip(flip(x)) == x for typical values — Binding round-trip is stable")
+  func idempotentUnderComposition() {
+    let cases = [
+      "", "-", "0", "0.", "-0", "-0.", "1", "-1", "10.", "10.5",
+      "-10.5", "300.00", "-300.00", "0.5", "-0.5",
+    ]
+    for value in cases {
+      let roundTripped = TransactionDraft.flipTradePaidDisplaySign(
+        TransactionDraft.flipTradePaidDisplaySign(value))
+      #expect(
+        roundTripped == value,
+        "flip(flip(\"\(value)\")) yielded \"\(roundTripped)\", expected \"\(value)\"")
+    }
+  }
+
+  // MARK: - Typing simulations (keystroke-by-keystroke)
+
+  @Test("typing '300' from empty — every intermediate state displays naturally")
+  func typingPositiveAmount() {
+    // Each keystroke: the displayed text is what we feed into the setter,
+    // and the next render call re-flips storage back to the displayed text.
+    // For positive entries the rendered value equals the typed value (no
+    // phantom minus appearing mid-typing).
+    var stored = ""
+    for keystroke in ["3", "30", "300"] {
+      stored = TransactionDraft.flipTradePaidDisplaySign(keystroke)
+      let rendered = TransactionDraft.flipTradePaidDisplaySign(stored)
+      #expect(rendered == keystroke, "after typing \"\(keystroke)\" rendered \"\(rendered)\"")
+    }
+    // Final storage is the negated leg quantity.
+    #expect(stored == "-300")
+  }
+
+  @Test("typing '-0.5' from empty — '-' and '-0' intermediates are preserved")
+  func typingNegativeRefundAmount() {
+    var stored = ""
+    let keystrokes = ["-", "-0", "-0.", "-0.5"]
+    for display in keystrokes {
+      stored = TransactionDraft.flipTradePaidDisplaySign(display)
+      let rendered = TransactionDraft.flipTradePaidDisplaySign(stored)
+      #expect(rendered == display, "after typing \"\(display)\" rendered \"\(rendered)\"")
+    }
+    // Final storage is the negated leg quantity.
+    #expect(stored == "0.5")
+  }
+
+  @Test("typing '0.5' from empty — neither '0' nor '0.' grow a phantom minus")
+  func typingFractionalAmount() {
+    // For positive entries the rendered value equals the typed value at
+    // every keystroke; the canonical-zero special-cases ensure "0" and "0."
+    // do not flicker into "-0" / "-0." mid-typing.
+    var stored = ""
+    for keystroke in ["0", "0.", "0.5"] {
+      stored = TransactionDraft.flipTradePaidDisplaySign(keystroke)
+      let rendered = TransactionDraft.flipTradePaidDisplaySign(stored)
+      #expect(rendered == keystroke, "after typing \"\(keystroke)\" rendered \"\(rendered)\"")
+    }
+    #expect(stored == "-0.5")
+  }
+}

--- a/MoolahUITests_macOS/Tests/TradeFlowUITests.swift
+++ b/MoolahUITests_macOS/Tests/TradeFlowUITests.swift
@@ -23,9 +23,12 @@ final class TradeFlowUITests: MoolahUITestCase {
     app.transactionList.createTransaction()
 
     app.tradeForm.switchToTradeMode()
-    // Buy: cash leg negative (paid out), position leg positive (received).
-    // `.trade` legs preserve user-entered signs literally.
-    app.tradeForm.setPaid(amount: "-300", instrumentId: "AUD")
+    // Buy: user types positive amounts in both Paid and Received. The Paid
+    // field flips the sign for storage so the cash leg quantity is `-300`,
+    // matching the user's mental model ("I paid $300, balance goes down").
+    // Received stores `+20` directly. Fees are entered in the Expense leg's
+    // own sign convention (negative = outflow).
+    app.tradeForm.setPaid(amount: "300", instrumentId: "AUD")
     app.tradeForm.setReceived(
       amount: "20", instrumentId: UITestFixtures.TradeReady.vgsaxInstrumentId)
     app.tradeForm.addFee(

--- a/Shared/Models/TransactionDraft+TradeMode.swift
+++ b/Shared/Models/TransactionDraft+TradeMode.swift
@@ -208,6 +208,41 @@ extension TransactionDraft {
   }
 }
 
+// MARK: - Trade Paid Display Negation
+
+extension TransactionDraft {
+  /// View-side bijection between the trade Paid leg's stored `amountText`
+  /// (the signed leg quantity, e.g. `-300`) and what the user types into the
+  /// Paid field (the natural-sign value, e.g. `300` for "I paid $300, balance
+  /// goes down by $300"). The Received leg is unaffected — users enter
+  /// positive amounts and the leg quantity is positive, matching expectation.
+  ///
+  /// Operates at the character level rather than parse-and-format so partial
+  /// input (`""`, `"-"`, `"0."`, `"-0."`) survives mid-keystroke without the
+  /// formatter dropping a trailing dot or collapsing a transient `-0` into
+  /// `0`. The function is idempotent under composition — `flip(flip(x)) == x`
+  /// — so the SwiftUI `Binding`'s get/set round-trip is stable.
+  static func flipTradePaidDisplaySign(_ text: String) -> String {
+    if text.isEmpty { return text }
+    if text == "-" { return text }
+
+    if text.hasPrefix("-") {
+      let rest = String(text.dropFirst())
+      // Preserve the leading minus when the remainder is a zero-magnitude
+      // partial value so `-`, `-0`, `-0.` round-trip cleanly while the user
+      // is typing toward `-0.5` (a refund booked against the Paid leg).
+      if rest == "0" || rest == "0." { return text }
+      return rest
+    }
+
+    // Canonical zero stays positive — a fresh blank Paid leg has stored
+    // `amountText == "0"`; rendering it as `-0` would be jarring.
+    if text == "0" || text == "0." { return text }
+
+    return "-" + text
+  }
+}
+
 // MARK: - Type Conversion Helpers
 
 extension TransactionDraft {

--- a/Shared/Models/TransactionDraft+TradeMode.swift
+++ b/Shared/Models/TransactionDraft+TradeMode.swift
@@ -10,10 +10,22 @@ extension TransactionDraft {
   }
 
   /// Index of the second `.trade` leg (the "Received" side). `nil` when
-  /// the draft does not have two `.trade` legs.
+  /// the draft does not have *exactly* two `.trade` legs — three or more
+  /// indicates a malformed or custom-mode draft, not a trade shape, so the
+  /// trade UI should not bind to it.
   var receivedLegIndex: Int? {
-    let trade = legDrafts.enumerated().filter { $0.element.type == .trade }
-    return trade.count == 2 ? trade[1].offset : nil
+    var first: Int?
+    var second: Int?
+    for (offset, leg) in legDrafts.enumerated() where leg.type == .trade {
+      if first == nil {
+        first = offset
+      } else if second == nil {
+        second = offset
+      } else {
+        return nil
+      }
+    }
+    return second
   }
 
   /// Indices of all `.expense` fee legs, in storage order.


### PR DESCRIPTION
## Summary

- The trade form's **Paid** field previously required users to type a negative amount (e.g. `-300`) to record a $300 outflow — the label promises "Paid" but the natural reading "I paid \$300" was treated as a $300 inflow. Users now type `300` and the leg quantity is stored as `-300`. Refunds remain supported by typing a negative number; **Received** is unchanged (positive entry → positive stored quantity).
- Implemented as a **view-layer** sign flip via the new `TransactionDraft.flipTradePaidDisplaySign(_:)`. The `.trade` storage convention (`displaysNegated == false`, sign-preserving) is intentionally unchanged per `feedback_no_abs_on_trade_legs.md` — no `abs()`, no auto-sign-by-position. The flip is character-level and idempotent so partial typing input (`""`, `"-"`, `"-0"`, `"0."`) survives mid-keystroke.
- Drive-by refactor: `TransactionDraft.receivedLegIndex` now does a single pass without copying `LegDraft`s into a `filter` array; the exactly-2-trade-legs invariant is preserved and pinned by new accessor tests.

## Test plan

- [x] `TransactionDraftTradePaidDisplayTests` — 10 new Swift Testing cases covering round-trip, idempotency under composition, partial-input passthrough, and keystroke-by-keystroke typing simulations for `300`, `-0.5`, and `0.5`.
- [x] `TransactionDraftTradeAccessorsTests` — added two new cases pinning `receivedLegIndex` returns `nil` for one trade leg and for three or more trade legs (the trade-shape invariant).
- [x] `TradeFlowUITests.testCreateTradeWithFeeRendersTradeRow` — updated to type `300` (positive, natural sign) into Paid; the resulting trade row still renders "Bought 20 VGS.AX", confirming the leg quantity is stored as `-300` end-to-end.
- [x] Full macOS test suite: 1985 tests, all passing.
- [x] `just format-check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)