### PR TITLE
feat(trade): fold .expense fee legs into per-unit cost basis (#558)

### DIFF
--- a/MoolahTests/Shared/CapitalGainsCalculatorTestsMore.swift
+++ b/MoolahTests/Shared/CapitalGainsCalculatorTestsMore.swift
@@ -76,14 +76,13 @@ struct CapitalGainsCalculatorTestsMore {
   /// Cross-currency buy with a fee in the profile currency: 100 BHP paid
   /// for with USD 2000 plus an AUD 100 brokerage fee. Profile currency =
   /// AUD at 1 USD = 1.5 AUD. The two `.trade` legs price the position
-  /// (USD outflow → BHP) and the AUD fee leg is `.expense` so it does
-  /// **not** participate in cost basis under the current design.
+  /// (USD outflow → BHP) and the AUD fee leg folds into cost basis at
+  /// the host-currency fast path.
   ///
-  /// Cost basis is therefore the converted USD outflow only (AUD 3000),
-  /// proceeds AUD 4000, gain AUD 1000. Folding the fee into cost basis
-  /// is tracked in https://github.com/ajsutton/moolah-native/issues/558.
+  /// Cost basis: USD 2000 × 1.5 = AUD 3000, plus AUD 100 fee = AUD 3100.
+  /// Proceeds AUD 4000. Gain = AUD 900.
   @Test
-  func crossCurrencyBuyWithFeeExcludesFeeFromCostBasis() async throws {
+  func crossCurrencyBuyWithFeeFoldsFeeIntoCostBasis() async throws {
     let bhp = stockInstrument("BHP")
     let usd = Instrument.fiat(code: "USD")
     let accountId = UUID()
@@ -120,10 +119,10 @@ struct CapitalGainsCalculatorTestsMore {
       conversionService: service
     )
 
-    // Cost basis AUD 3000 (USD 2000 × 1.5; fee leg ignored),
-    // proceeds AUD 4000. Gain 1000.
+    // Cost basis AUD 3100 (USD 2000 × 1.5 + AUD 100 fee),
+    // proceeds AUD 4000. Gain 900.
     #expect(result.events.count == 1)
-    #expect(result.events[0].gain == 1000)
+    #expect(result.events[0].gain == 900)
   }
 
   /// Mixed-fiat sell: 100 BHP sold for USD 3000 with AUD 50 fee,

--- a/MoolahTests/Shared/CapitalGainsCalculatorTestsMore.swift
+++ b/MoolahTests/Shared/CapitalGainsCalculatorTestsMore.swift
@@ -180,9 +180,7 @@ struct CapitalGainsCalculatorTestsMore {
   // `tx.date` for `Date()` or another date; this test uses
   // `DateBasedFixedConversionService` to make that observable.
 
-  /// Crypto-to-crypto swap: both legs are valued via the conversion
-  /// service. The rate schedule below has a different rate effective at
-  /// the swap date than would be returned for "today" (`Date()`), so a
-  /// regression that misrouted the lookup date would yield a different
-  /// gain than the assertion permits.
+  // Crypto-to-crypto swap test placeholder — described above but not
+  // implemented. Tracking issue not filed; dead documentation kept as
+  // a `//` block so it isn't picked up by DocC.
 }

--- a/MoolahTests/Shared/ProfitLossCalculatorTestsMore.swift
+++ b/MoolahTests/Shared/ProfitLossCalculatorTestsMore.swift
@@ -196,6 +196,76 @@ struct ProfitLossCalculatorTestsMore {
     #expect(result.unrealizedGain == 2000)
   }
 
+  /// Buy with an attached AUD fee leg: `totalInvested` must include the
+  /// fee, otherwise it diverges from the FIFO `remainingCostBasis` and
+  /// `returnPercentage` over-states returns.
+  @Test
+  func buyWithHostCurrencyFeeIncreasesTotalInvested() async throws {
+    let bhp = stockInstrument("BHP")
+    let accountId = UUID()
+    let buyTx = LegTransaction(
+      date: date(0),
+      legs: [
+        TransactionLeg(
+          accountId: accountId, instrument: aud, quantity: -4000, type: .trade,
+          categoryId: nil, earmarkId: nil),
+        TransactionLeg(
+          accountId: accountId, instrument: bhp, quantity: 100, type: .trade,
+          categoryId: nil, earmarkId: nil),
+        TransactionLeg(
+          accountId: accountId, instrument: aud, quantity: -10, type: .expense,
+          categoryId: nil, earmarkId: nil),
+      ])
+    let results = try await ProfitLossCalculator.compute(
+      transactions: [buyTx],
+      profileCurrency: aud,
+      conversionService: FixedConversionService(rates: [:]),
+      asOfDate: date(0)
+    )
+    try #require(results.count == 1)
+    #expect(results[0].totalInvested == 4010)
+  }
+
+  /// FX fee leg on a buy: `accumulateInvested` must convert the fee on
+  /// `transaction.date`, not `Date()`. Two rate entries straddle the
+  /// trade date so a wrong-date implementation picks the 2.0 rate at
+  /// `nextDay` and the assertion fails (wall-clock today > `nextDay`
+  /// because the `date(_)` helper bases on 2024-01-01).
+  @Test
+  func buyWithFXFeeConvertsAtTransactionDate() async throws {
+    let bhp = stockInstrument("BHP")
+    let usd = Instrument.fiat(code: "USD")
+    let accountId = UUID()
+    let tradeDate = date(0)
+    let nextDay = date(1)
+    let service = DateBasedFixedConversionService(rates: [
+      tradeDate: ["USD": dec("1.5")],
+      nextDay: ["USD": Decimal(2)],
+    ])
+    let buyTx = LegTransaction(
+      date: tradeDate,
+      legs: [
+        TransactionLeg(
+          accountId: accountId, instrument: aud, quantity: -4000, type: .trade,
+          categoryId: nil, earmarkId: nil),
+        TransactionLeg(
+          accountId: accountId, instrument: bhp, quantity: 100, type: .trade,
+          categoryId: nil, earmarkId: nil),
+        TransactionLeg(
+          accountId: accountId, instrument: usd, quantity: -10, type: .expense,
+          categoryId: nil, earmarkId: nil),
+      ])
+    let results = try await ProfitLossCalculator.compute(
+      transactions: [buyTx],
+      profileCurrency: aud,
+      conversionService: service,
+      asOfDate: nextDay
+    )
+    try #require(results.count == 1)
+    // -10 USD * 1.5 = -15 AUD fee → +15 cost contribution. 4000 + 15 = 4015.
+    #expect(results[0].totalInvested == 4015)
+  }
+
   // MARK: - Helpers
 
   private func stockInstrument(_ name: String) -> Instrument {

--- a/MoolahTests/Shared/ProfitLossCalculatorTestsMore.swift
+++ b/MoolahTests/Shared/ProfitLossCalculatorTestsMore.swift
@@ -99,11 +99,10 @@ struct ProfitLossCalculatorTestsMore {
   }
 
   /// A multi-currency purchase (USD 2000 + AUD 100 brokerage fee) where
-  /// the fee is modelled as an `.expense` leg (as per the current design).
-  /// The classifier sees only the two `.trade` legs (USD outflow → BHP) and
-  /// derives cost basis from those. The AUD 100 fee is excluded from cost
-  /// basis per the design documented at
-  /// https://github.com/ajsutton/moolah-native/issues/558.
+  /// the fee is modelled as an `.expense` leg. The classifier converts
+  /// the USD trade leg to AUD on the trade date and folds the AUD 100
+  /// fee in via the host-currency fast path, giving total invested =
+  /// AUD 3100.
   @Test
   func mixedFiatLegs_totalInvestedConvertsEachLegToProfileCurrency() async throws {
     let bhp = stockInstrument("BHP")
@@ -137,12 +136,12 @@ struct ProfitLossCalculatorTestsMore {
     )
 
     #expect(results.count == 1)
-    // totalInvested: USD 2000×1.5 = AUD 3000 (fee leg excluded from cost basis).
+    // totalInvested: USD 2000×1.5 + AUD 100 fee = AUD 3100.
     // currentValue: 100 × AUD 50 = AUD 5000.
-    // unrealizedGain: 5000 − 3000 = 2000.
-    #expect(results[0].totalInvested == 3000)
+    // unrealizedGain: 5000 − 3100 = 1900.
+    #expect(results[0].totalInvested == 3100)
     #expect(results[0].currentValue == 5000)
-    #expect(results[0].unrealizedGain == 2000)
+    #expect(results[0].unrealizedGain == 1900)
   }
 
   // MARK: - Date-sensitive routing

--- a/MoolahTests/Shared/TradeEventClassifierTests.swift
+++ b/MoolahTests/Shared/TradeEventClassifierTests.swift
@@ -107,7 +107,7 @@ struct TradeEventClassifierTests {
     #expect(result.sells.isEmpty)
   }
 
-  // MARK: - Fee-folding tests (#558)
+  // MARK: - Fee folding
 
   @Test("buy: AUD fee on AUD-host trade folds into per-unit cost")
   func buyFoldsAUDFee() async throws {

--- a/MoolahTests/Shared/TradeEventClassifierTests.swift
+++ b/MoolahTests/Shared/TradeEventClassifierTests.swift
@@ -6,11 +6,16 @@ import Testing
 @Suite("TradeEventClassifier")
 struct TradeEventClassifierTests {
   let aud = Instrument.AUD
+  let usd = Instrument.USD
   let bhp = Instrument.stock(ticker: "BHP.AX", exchange: "ASX", name: "BHP")
   let eth = Instrument.crypto(
     chainId: 1, contractAddress: nil, symbol: "ETH", name: "Ethereum", decimals: 18)
   let btc = Instrument.crypto(
     chainId: 0, contractAddress: nil, symbol: "BTC", name: "Bitcoin", decimals: 8)
+  // November 2023. Past-date precondition for `buyFoldsFXFee` — that test
+  // straddles `date` and `date + 1 day` with two FX rates and relies on
+  // wall-clock `Date()` being later than `date + 1 day` so a buggy
+  // `Date()`-instead-of-`date` implementation picks the wrong rate.
   let date = Date(timeIntervalSince1970: 1_700_000_000)
   let account = UUID()
 
@@ -66,16 +71,6 @@ struct TradeEventClassifierTests {
     #expect(result.sells[0].proceedsPerUnit == Decimal(3_000))
   }
 
-  @Test("fee legs are ignored")
-  func feeIgnored() async throws {
-    let legs = [tradeLeg(aud, -4_000), tradeLeg(bhp, 100), feeLeg(aud, -10)]
-    let result = try await TradeEventClassifier.classify(
-      legs: legs, on: date, hostCurrency: aud,
-      conversionService: FixedConversionService(rates: [:]))
-    try #require(result.buys.count == 1)
-    #expect(result.buys[0].costPerUnit == 40)  // 4000/100, not (4000+10)/100
-  }
-
   @Test("non-trade-typed legs are ignored entirely (older custom shapes)")
   func nonTradeLegsIgnored() async throws {
     let legs = [
@@ -110,5 +105,125 @@ struct TradeEventClassifierTests {
       conversionService: FixedConversionService(rates: [:]))
     #expect(result.buys.isEmpty)
     #expect(result.sells.isEmpty)
+  }
+
+  // MARK: - Fee-folding tests (#558)
+
+  @Test("buy: AUD fee on AUD-host trade folds into per-unit cost")
+  func buyFoldsAUDFee() async throws {
+    let legs = [tradeLeg(aud, -4_000), tradeLeg(bhp, 100), feeLeg(aud, -10)]
+    let result = try await TradeEventClassifier.classify(
+      legs: legs, on: date, hostCurrency: aud,
+      conversionService: FixedConversionService(rates: [:]))
+    try #require(result.buys.count == 1)
+    #expect(result.buys[0].costPerUnit == Decimal(40) + Decimal(10) / Decimal(100))
+    #expect(result.sells.isEmpty)
+  }
+
+  @Test("sell: fee reduces per-unit proceeds")
+  func sellReducesProceedsByFee() async throws {
+    let legs = [tradeLeg(aud, 2_500), tradeLeg(bhp, -50), feeLeg(aud, -10)]
+    let result = try await TradeEventClassifier.classify(
+      legs: legs, on: date, hostCurrency: aud,
+      conversionService: FixedConversionService(rates: [:]))
+    try #require(result.sells.count == 1)
+    #expect(result.sells[0].proceedsPerUnit == Decimal(50) - Decimal(10) / Decimal(50))
+    #expect(result.buys.isEmpty)
+  }
+
+  @Test("buy: multiple AUD fee legs sum")
+  func buyFoldsMultipleFees() async throws {
+    let legs = [
+      tradeLeg(aud, -4_000), tradeLeg(bhp, 100),
+      feeLeg(aud, -10), feeLeg(aud, -3),
+    ]
+    let result = try await TradeEventClassifier.classify(
+      legs: legs, on: date, hostCurrency: aud,
+      conversionService: FixedConversionService(rates: [:]))
+    try #require(result.buys.count == 1)
+    #expect(result.buys[0].costPerUnit == Decimal(40) + Decimal(13) / Decimal(100))
+  }
+
+  @Test("buy: fee debit and equal refund credit cancel to zero")
+  func feeContributionsCancelToZero() async throws {
+    let legs = [
+      tradeLeg(aud, -4_000), tradeLeg(bhp, 100),
+      feeLeg(aud, -10), feeLeg(aud, 10),
+    ]
+    let result = try await TradeEventClassifier.classify(
+      legs: legs, on: date, hostCurrency: aud,
+      conversionService: FixedConversionService(rates: [:]))
+    try #require(result.buys.count == 1)
+    #expect(result.buys[0].costPerUnit == Decimal(40))
+  }
+
+  @Test("buy: FX fee converts at the trade date")
+  func buyFoldsFXFee() async throws {
+    // Two rate entries straddling the trade date. If the implementation
+    // accidentally passes Date() instead of `date`, the lookup picks the
+    // 2.0 rate and the assertion below fails — making the wrong-date bug
+    // detectable rather than silent. (Wall-clock Date() at test-run time
+    // > nextDay because `date` is a past fixture; see comment above.)
+    let nextDay = date.addingTimeInterval(86_400)
+    let service = DateBasedFixedConversionService(rates: [
+      date: [usd.id: dec("1.5")],
+      nextDay: [usd.id: Decimal(2)],
+    ])
+    let legs = [tradeLeg(aud, -4_000), tradeLeg(bhp, 100), feeLeg(usd, -5)]
+    let result = try await TradeEventClassifier.classify(
+      legs: legs, on: date, hostCurrency: aud, conversionService: service)
+    try #require(result.buys.count == 1)
+    // -5 USD * 1.5 = -7.5 AUD; negate → +7.5; / 100 BHP → 0.075 per unit.
+    #expect(
+      result.buys[0].costPerUnit
+        == Decimal(40) + dec("7.5") / Decimal(100))
+  }
+
+  @Test("swap: fee splits evenly across both capital events")
+  func swapSplitsFeeEvenlyAcrossEvents() async throws {
+    let service = FixedConversionService(rates: [
+      eth.id: Decimal(3_000),
+      btc.id: Decimal(60_000),
+    ])
+    let legs = [
+      tradeLeg(eth, -2),
+      tradeLeg(btc, dec("0.1")),
+      feeLeg(aud, -50),
+    ]
+    let result = try await TradeEventClassifier.classify(
+      legs: legs, on: date, hostCurrency: aud, conversionService: service)
+    try #require(result.buys.count == 1)
+    try #require(result.sells.count == 1)
+    // 50 / 2 events = 25 AUD per event.
+    #expect(result.buys[0].instrument == btc)
+    #expect(
+      result.buys[0].costPerUnit
+        == Decimal(60_000) + Decimal(25) / dec("0.1"))
+    #expect(result.sells[0].instrument == eth)
+    #expect(
+      result.sells[0].proceedsPerUnit
+        == Decimal(3_000) - Decimal(25) / Decimal(2))
+  }
+
+  @Test("buy: host-currency fee skips the conversion service")
+  func hostCurrencyFeeNeedsNoConversionLookup() async throws {
+    // RecordingConversionService records every convert() call without a
+    // same-instrument short-circuit. The pair-leg conversion (AUD→AUD,
+    // for the BHP capital leg) goes through the service unconditionally
+    // — the classifier does not fast-path the *pair* leg today — so the
+    // recorder sees that one call. The fee leg (also AUD on AUD-host)
+    // MUST be fast-pathed inside the classifier so the recorder sees
+    // exactly one call total. If the fast path is missing, the recorder
+    // sees two calls and `count == 1` catches it.
+    let service = RecordingConversionService()
+    let legs = [tradeLeg(aud, -4_000), tradeLeg(bhp, 100), feeLeg(aud, -10)]
+    let result = try await TradeEventClassifier.classify(
+      legs: legs, on: date, hostCurrency: aud, conversionService: service)
+    try #require(result.buys.count == 1)
+    #expect(result.buys[0].costPerUnit == Decimal(40) + Decimal(10) / Decimal(100))
+    // RecordingConversionService returns input unchanged (1:1), so the
+    // pair-leg conversion still produces -4 000.
+    #expect(service.calls.count == 1)
+    #expect(service.calls.first?.quantity == -4_000)
   }
 }

--- a/MoolahTests/Support/RecordingConversionService.swift
+++ b/MoolahTests/Support/RecordingConversionService.swift
@@ -1,0 +1,49 @@
+import Foundation
+import os
+
+@testable import Moolah
+
+/// One recorded call to `RecordingConversionService.convert(...)`. Top-level
+/// (not nested in the service) so the SwiftLint `nesting: type_level` rule
+/// stays at 0 — adding a nested type would cross the warn threshold and
+/// cannot be appeased without growing the baseline.
+struct RecordingConversionServiceCall: Sendable, Equatable {
+  let quantity: Decimal
+  let fromId: String
+  let toId: String
+  let date: Date
+}
+
+/// Test conversion service that records every `convert(_:from:to:on:)` call
+/// so tests can assert which conversions the caller actually performed.
+/// Returns `quantity` unchanged (1:1 fallback) on every call — this double
+/// is for *call-site* assertions, not rate behaviour.
+///
+/// Backed by `OSAllocatedUnfairLock` so it is async-safe and `Sendable` and
+/// usable from any isolation domain (same lock-around-mutable-state pattern
+/// as `FailureLog` in `ThrowingCountingConversionService.swift`).
+final class RecordingConversionService: InstrumentConversionService, Sendable {
+  private let recorded = OSAllocatedUnfairLock<[RecordingConversionServiceCall]>(
+    initialState: [])
+
+  var calls: [RecordingConversionServiceCall] { recorded.withLock { $0 } }
+
+  func convert(
+    _ quantity: Decimal, from: Instrument, to: Instrument, on date: Date
+  ) async throws -> Decimal {
+    recorded.withLock {
+      $0.append(
+        RecordingConversionServiceCall(
+          quantity: quantity, fromId: from.id, toId: to.id, date: date))
+    }
+    return quantity
+  }
+
+  func convertAmount(
+    _ amount: InstrumentAmount, to instrument: Instrument, on date: Date
+  ) async throws -> InstrumentAmount {
+    let value = try await convert(
+      amount.quantity, from: amount.instrument, to: instrument, on: date)
+    return InstrumentAmount(quantity: value, instrument: instrument)
+  }
+}

--- a/MoolahTests/Support/RecordingConversionService.swift
+++ b/MoolahTests/Support/RecordingConversionService.swift
@@ -3,14 +3,13 @@ import os
 
 @testable import Moolah
 
-/// One recorded call to `RecordingConversionService.convert(...)`. Top-level
-/// (not nested in the service) so the SwiftLint `nesting: type_level` rule
-/// stays at 0 — adding a nested type would cross the warn threshold and
-/// cannot be appeased without growing the baseline.
+/// One recorded call to `RecordingConversionService.convert(...)`.
+/// Top-level so tests can construct, compare, and pattern-match values
+/// without needing to fully qualify them through the service type.
 struct RecordingConversionServiceCall: Sendable, Equatable {
   let quantity: Decimal
-  let fromId: String
-  let toId: String
+  let from: Instrument
+  let to: Instrument
   let date: Date
 }
 
@@ -34,7 +33,7 @@ final class RecordingConversionService: InstrumentConversionService, Sendable {
     recorded.withLock {
       $0.append(
         RecordingConversionServiceCall(
-          quantity: quantity, fromId: from.id, toId: to.id, date: date))
+          quantity: quantity, from: from, to: to, date: date))
     }
     return quantity
   }

--- a/Shared/ProfitLossCalculator.swift
+++ b/Shared/ProfitLossCalculator.swift
@@ -36,12 +36,12 @@ enum ProfitLossCalculator {
   /// `totalInvested` is the lifetime fiat input attributed to each
   /// non-fiat acquisition: every fiat `.trade` outflow plus every
   /// `.expense` fee leg attached to the same transaction, all converted
-  /// to `profileCurrency` on the transaction's date. Mirrors
-  /// `TradeEventClassifier`'s fee fold-in (#558) so `totalInvested`
-  /// stays consistent with `remainingCostBasis` from the FIFO engine —
-  /// otherwise `returnPercentage` (computed against `totalInvested`)
-  /// would over-state returns by ignoring transaction costs.
-  /// See guides/INSTRUMENT_CONVERSION_GUIDE.md Rules 1, 5, and 8.
+  /// to `profileCurrency` on the transaction's date. Mirrors the
+  /// classifier's fee fold-in via `TradeEventClassifier.feeContribution`
+  /// so `totalInvested` stays consistent with `remainingCostBasis` from
+  /// the FIFO engine — otherwise `returnPercentage` (computed against
+  /// `totalInvested`) would over-state returns by ignoring transaction
+  /// costs. See guides/INSTRUMENT_CONVERSION_GUIDE.md Rules 1, 5, and 8.
   private static func accumulateInvested(
     into instrumentData: inout [String: InstrumentData],
     transactions: [LegTransaction],
@@ -57,28 +57,15 @@ enum ProfitLossCalculator {
       var fiatOutflow: Decimal = 0
       for leg in fiatLegs where leg.quantity < 0 {
         let converted = try await conversionService.convert(
-          abs(leg.quantity), from: leg.instrument, to: profileCurrency, on: transaction.date
+          -leg.quantity, from: leg.instrument, to: profileCurrency, on: transaction.date
         )
         fiatOutflow += converted
       }
-      // Fold attached `.expense` fee legs in. Same-instrument fast path
-      // matches the classifier (host-currency fees skip the conversion
-      // hop). Negate so a normal negative-quantity fee becomes a positive
-      // cost contribution; a positive-quantity refund correctly reduces
-      // the contribution. Sign-preserving; never abs().
-      for feeLeg in transaction.legs where feeLeg.type == .expense {
-        let convertedFee: Decimal
-        if feeLeg.instrument == profileCurrency {
-          convertedFee = feeLeg.quantity
-        } else {
-          convertedFee = try await conversionService.convert(
-            feeLeg.quantity,
-            from: feeLeg.instrument,
-            to: profileCurrency,
-            on: transaction.date)
-        }
-        fiatOutflow += -convertedFee
-      }
+      fiatOutflow += try await TradeEventClassifier.feeContribution(
+        from: transaction.legs,
+        hostCurrency: profileCurrency,
+        on: transaction.date,
+        using: conversionService)
 
       for leg in nonFiatLegs where leg.quantity > 0 {
         instrumentData[leg.instrument.id, default: InstrumentData(instrument: leg.instrument)]

--- a/Shared/ProfitLossCalculator.swift
+++ b/Shared/ProfitLossCalculator.swift
@@ -33,22 +33,15 @@ enum ProfitLossCalculator {
 
   /// Process all transactions to compute total invested.
   ///
-  /// Fiat legs can span multiple currencies (e.g. a USD payment plus an
-  /// AUD fee). We convert each outflow leg to `profileCurrency` on the
-  /// transaction's date before summing so `totalInvested` is expressed
-  /// in a single currency. See guides/INSTRUMENT_CONVERSION_GUIDE.md
-  /// Rules 1 and 5.
-  /// Process all transactions to compute total invested.
-  ///
-  /// Only `.trade` legs contribute to cost basis, consistent with
-  /// `TradeEventClassifier`. Fiat legs of other types (e.g. `.expense`
-  /// brokerage fees) are intentionally excluded.
-  ///
-  /// Fiat `.trade` legs can span multiple currencies (e.g. a USD payment
-  /// in a cross-currency buy). We convert each fiat outflow leg to
-  /// `profileCurrency` on the transaction's date before summing so
-  /// `totalInvested` is expressed in a single currency. See
-  /// guides/INSTRUMENT_CONVERSION_GUIDE.md Rules 1 and 5.
+  /// `totalInvested` is the lifetime fiat input attributed to each
+  /// non-fiat acquisition: every fiat `.trade` outflow plus every
+  /// `.expense` fee leg attached to the same transaction, all converted
+  /// to `profileCurrency` on the transaction's date. Mirrors
+  /// `TradeEventClassifier`'s fee fold-in (#558) so `totalInvested`
+  /// stays consistent with `remainingCostBasis` from the FIFO engine —
+  /// otherwise `returnPercentage` (computed against `totalInvested`)
+  /// would over-state returns by ignoring transaction costs.
+  /// See guides/INSTRUMENT_CONVERSION_GUIDE.md Rules 1, 5, and 8.
   private static func accumulateInvested(
     into instrumentData: inout [String: InstrumentData],
     transactions: [LegTransaction],
@@ -67,6 +60,24 @@ enum ProfitLossCalculator {
           abs(leg.quantity), from: leg.instrument, to: profileCurrency, on: transaction.date
         )
         fiatOutflow += converted
+      }
+      // Fold attached `.expense` fee legs in. Same-instrument fast path
+      // matches the classifier (host-currency fees skip the conversion
+      // hop). Negate so a normal negative-quantity fee becomes a positive
+      // cost contribution; a positive-quantity refund correctly reduces
+      // the contribution. Sign-preserving; never abs().
+      for feeLeg in transaction.legs where feeLeg.type == .expense {
+        let convertedFee: Decimal
+        if feeLeg.instrument == profileCurrency {
+          convertedFee = feeLeg.quantity
+        } else {
+          convertedFee = try await conversionService.convert(
+            feeLeg.quantity,
+            from: feeLeg.instrument,
+            to: profileCurrency,
+            on: transaction.date)
+        }
+        fiatOutflow += -convertedFee
       }
 
       for leg in nonFiatLegs where leg.quantity > 0 {

--- a/Shared/TradeEventClassifier.swift
+++ b/Shared/TradeEventClassifier.swift
@@ -1,8 +1,8 @@
 import Foundation
 
-/// One step in the FIFO cost-basis machine. Shape unchanged from the previous
-/// implementation; consumers (CapitalGainsCalculator, InvestmentStore cost
-/// basis snapshot, PositionsHistoryBuilder) read these structurally.
+/// One step in the FIFO cost-basis machine. Consumers
+/// (`CapitalGainsCalculator`, `InvestmentStore` cost-basis snapshot,
+/// `PositionsHistoryBuilder`) read these structurally.
 struct TradeBuyEvent: Sendable, Equatable {
   let instrument: Instrument
   let quantity: Decimal
@@ -67,28 +67,13 @@ enum TradeEventClassifier {
     }
     let capitalIndices = nonFiatIndices.isEmpty ? Array(tradeLegs.indices) : nonFiatIndices
 
-    // Sum attached fee legs in hostCurrency. Same-instrument fast path is
-    // enforced here at the call site, not delegated to the conversion
-    // service — that keeps the host-currency case off the async hop and
-    // is directly testable (see hostCurrencyFeeNeedsNoConversionLookup).
-    var totalFeeHost: Decimal = 0
-    for feeLeg in legs where feeLeg.type == .expense {
-      if feeLeg.instrument == hostCurrency {
-        totalFeeHost += feeLeg.quantity
-      } else {
-        totalFeeHost += try await conversionService.convert(
-          feeLeg.quantity, from: feeLeg.instrument, to: hostCurrency, on: date)
-      }
-    }
-    // Negate: fee-leg quantity is negative by convention (cost paid out).
-    // Negating turns the sum into a positive cost contribution. A positive
-    // .expense leg (a refund attached to a trade) becomes a negative
-    // contribution, correctly reducing cost. Sign-preserving on purpose;
-    // never abs().
-    let feeContribution = -totalFeeHost
-    // feePerEvent is a per-event total in hostCurrency (NOT yet per-unit).
-    // The per-unit division happens inside the loop below.
-    let feePerEvent = feeContribution / Decimal(capitalIndices.count)
+    let feePerEvent =
+      try await feeContribution(
+        from: legs,
+        hostCurrency: hostCurrency,
+        on: date,
+        using: conversionService)
+      / Decimal(capitalIndices.count)
 
     var buys: [TradeBuyEvent] = []
     var sells: [TradeSellEvent] = []
@@ -123,5 +108,36 @@ enum TradeEventClassifier {
       }
     }
     return TradeEventClassification(buys: buys, sells: sells)
+  }
+
+  /// Sum attached `.expense` legs converted to `hostCurrency` on `date`,
+  /// then negate so a normal-sign (negative-quantity) fee yields a
+  /// positive cost contribution. A positive `.expense` quantity (refund
+  /// attached to a trade) yields a negative contribution and reduces
+  /// cost. Sign-preserving on purpose; never `abs()`.
+  ///
+  /// Same-instrument fast path is enforced here at the call site, not
+  /// delegated to the conversion service — that keeps the host-currency
+  /// case off the async hop and is directly testable (see
+  /// `hostCurrencyFeeNeedsNoConversionLookup`).
+  ///
+  /// Also called by `ProfitLossCalculator.accumulateInvested` so
+  /// `totalInvested` stays consistent with the FIFO `remainingCostBasis`.
+  static func feeContribution(
+    from legs: [TransactionLeg],
+    hostCurrency: Instrument,
+    on date: Date,
+    using conversionService: any InstrumentConversionService
+  ) async throws -> Decimal {
+    var totalFeeHost: Decimal = 0
+    for feeLeg in legs where feeLeg.type == .expense {
+      if feeLeg.instrument == hostCurrency {
+        totalFeeHost += feeLeg.quantity
+      } else {
+        totalFeeHost += try await conversionService.convert(
+          feeLeg.quantity, from: feeLeg.instrument, to: hostCurrency, on: date)
+      }
+    }
+    return -totalFeeHost
   }
 }

--- a/Shared/TradeEventClassifier.swift
+++ b/Shared/TradeEventClassifier.swift
@@ -22,13 +22,20 @@ struct TradeEventClassification: Sendable, Equatable {
 
 /// Classifies a transaction's `.trade` legs into FIFO buy / sell events.
 ///
-/// Per design §2, the classifier filters by `type == .trade` and ignores
-/// every other leg. For each `.trade` leg, the per-unit value is derived
-/// from the *other* `.trade` leg's value converted to `hostCurrency` on
-/// the transaction date. Fee legs (`.expense`) are not part of cost basis
-/// in this iteration; that decision moves with the
-/// `SelfWealthMovementsParser` brokerage-attach work tracked in
-/// https://github.com/ajsutton/moolah-native/issues/558.
+/// Per design §2, the classifier filters by `type == .trade` to identify
+/// capital legs. For each one, the per-unit value is derived from the
+/// *other* `.trade` leg's value converted to `hostCurrency` on the
+/// transaction date.
+///
+/// Attached `.expense` legs are folded into per-unit cost: each fee leg
+/// is converted to `hostCurrency` on the trade date (or summed directly
+/// when already in `hostCurrency`), summed, and split *evenly* across
+/// the capital events. Even split is deterministic and avoids the extra
+/// conversion call value-weighting would require; for the typical
+/// two-leg fair-value swap the result is the same to within rounding.
+/// Buy events have the per-unit fee added to `costPerUnit`; Sell events
+/// have it subtracted from `proceedsPerUnit`. Transfers (`In` / `Out`)
+/// do not enter the classifier and are unaffected.
 ///
 /// Only non-fiat legs emit capital events. In a fiat+non-fiat pair the
 /// fiat leg is the price carrier; in a non-fiat swap both legs emit events.
@@ -60,6 +67,29 @@ enum TradeEventClassifier {
     }
     let capitalIndices = nonFiatIndices.isEmpty ? Array(tradeLegs.indices) : nonFiatIndices
 
+    // Sum attached fee legs in hostCurrency. Same-instrument fast path is
+    // enforced here at the call site, not delegated to the conversion
+    // service — that keeps the host-currency case off the async hop and
+    // is directly testable (see hostCurrencyFeeNeedsNoConversionLookup).
+    var totalFeeHost: Decimal = 0
+    for feeLeg in legs where feeLeg.type == .expense {
+      if feeLeg.instrument == hostCurrency {
+        totalFeeHost += feeLeg.quantity
+      } else {
+        totalFeeHost += try await conversionService.convert(
+          feeLeg.quantity, from: feeLeg.instrument, to: hostCurrency, on: date)
+      }
+    }
+    // Negate: fee-leg quantity is negative by convention (cost paid out).
+    // Negating turns the sum into a positive cost contribution. A positive
+    // .expense leg (a refund attached to a trade) becomes a negative
+    // contribution, correctly reducing cost. Sign-preserving on purpose;
+    // never abs().
+    let feeContribution = -totalFeeHost
+    // feePerEvent is a per-event total in hostCurrency (NOT yet per-unit).
+    // The per-unit division happens inside the loop below.
+    let feePerEvent = feeContribution / Decimal(capitalIndices.count)
+
     var buys: [TradeBuyEvent] = []
     var sells: [TradeSellEvent] = []
     for index in capitalIndices {
@@ -69,20 +99,27 @@ enum TradeEventClassifier {
       let pairValue = try await conversionService.convert(
         pair.quantity, from: pair.instrument, to: hostCurrency, on: date)
       // pair.quantity has the *opposite* sign by convention (paid vs received),
-      // so |pairValue / leg.quantity| is the per-unit cost or proceed.
+      // so |pairValue / leg.quantity| is the per-unit cost or proceed. abs()
+      // here gives the magnitude of the exchange rate, NOT a monetary amount;
+      // the buy-vs-sell sign is carried by `leg.quantity > 0` below.
       let perUnit = abs(pairValue / leg.quantity)
+      // The Sell formula uses subtraction so a positive feePerUnit (the
+      // normal-fee case) reduces proceeds, and a negative feePerUnit
+      // (the refund case) increases them. Buy is the mirror — addition
+      // gives cost-up for fees, cost-down for refunds.
+      let feePerUnit = feePerEvent / leg.quantity.magnitude
       if leg.quantity > 0 {
         buys.append(
           TradeBuyEvent(
             instrument: leg.instrument,
             quantity: leg.quantity,
-            costPerUnit: perUnit))
+            costPerUnit: perUnit + feePerUnit))
       } else {
         sells.append(
           TradeSellEvent(
             instrument: leg.instrument,
             quantity: -leg.quantity,
-            proceedsPerUnit: perUnit))
+            proceedsPerUnit: perUnit - feePerUnit))
       }
     }
     return TradeEventClassification(buys: buys, sells: sells)

--- a/plans/2026-05-03-trade-fees-cost-basis-design.md
+++ b/plans/2026-05-03-trade-fees-cost-basis-design.md
@@ -26,18 +26,28 @@ are part of the cost base).
    capital events. Fiat-paired trades emit one event → 100 % to that event.
    Non-fiat swaps emit two events → 50 / 50. Predictable, deterministic,
    matches what most retail tax workflows assume; ATO guidance is not
-   prescriptive on the alternative (value-weighted).
+   prescriptive on the alternative (value-weighted). Even-split also avoids
+   one extra conversion call per fee leg that value-weighting would require.
 3. **`In` / `Out` transfers — out of scope.** Transfers produce a single
    `.income` or `.expense` leg (not `.trade`) and never enter the classifier.
    Adding fee folding for them would require a different pipeline and risks
    producing surprising cost-basis events from data the user thinks of as
-   transfers. Open a follow-up issue if this is ever requested.
+   transfers. No follow-up issue is filed; we'll add one if/when a user
+   actually asks.
 4. **Sign handling — preserve, don't `abs()`.** Fee-leg quantities are
    conventionally negative (paid out). The classifier negates the *sum* of
    converted fee quantities to obtain a positive cost contribution. A
    positive `.expense` quantity (a refund attached to a trade) would
    correctly *reduce* the cost contribution. Not a tested case (YAGNI), but
    the math stays right rather than asymmetrically discarding sign.
+5. **Error contract — propagate (no scope creep).** A failed fee-leg FX
+   conversion throws from `conversionService.convert(...)`, propagates up
+   through `TradeEventClassifier.classify(...)`, and aborts the surrounding
+   `CapitalGainsCalculator.computeWithConversion(...)` call. This matches
+   the *existing* behaviour for trade-leg conversion failures
+   (`Shared/TradeEventClassifier.swift:69-70`); no new error surface area is
+   introduced. Per-transaction scoping of failures is a separate concern
+   (out of scope here, applies equally to existing trade-leg conversion).
 
 ## Algorithm
 
@@ -47,20 +57,38 @@ zero-quantity guards, before constructing buy/sell events:
 
 ```
 1. feeLegs = legs.filter { $0.type == .expense }
-2. For each fee leg, convert quantity to hostCurrency on `date` via
-   conversionService. Sum into totalFeeHost.
+
+2. Sum fees in hostCurrency (Decimal, signed):
+     totalFeeHost = 0
+     for feeLeg in feeLegs:
+       if feeLeg.instrument == hostCurrency:
+         totalFeeHost += feeLeg.quantity            // fast path, no service call
+       else:
+         totalFeeHost += try await conversionService.convert(
+             feeLeg.quantity, from: feeLeg.instrument, to: hostCurrency, on: date)
+
 3. feeContribution = -totalFeeHost
-   // Negation: typical fee-leg quantity is negative (cost paid out);
+   // Negation: fee-leg quantity is negative by convention (cost paid out);
    // negating turns it into a positive cost contribution. A positive
-   // .expense leg (refund) yields a negative contribution → reduces
-   // cost. Sign-preserving on purpose.
+   // .expense leg (refund) yields a negative contribution → reduces cost.
+   // Sign-preserving on purpose; never abs().
+
 4. feePerEvent = feeContribution / Decimal(capitalIndices.count)
-   // capitalIndices.count is 1 for fiat-paired trades, 2 for non-fiat
-   // swaps. Per Decision 2.
+   // feePerEvent is a per-event total in hostCurrency (Decimal monetary
+   // amount, NOT yet per-unit). It's the share of feeContribution
+   // allocated to one capital event. Step 5 divides it again to get the
+   // per-unit number. capitalIndices.count is 1 for fiat-paired trades,
+   // 2 for non-fiat swaps. Per Decision 2.
+
 5. For each capital event, after computing the existing perUnit:
      feePerUnit = feePerEvent / leg.quantity.magnitude
-     Buy:  costPerUnit = perUnit + feePerUnit
+     Buy:  costPerUnit     = perUnit + feePerUnit
      Sell: proceedsPerUnit = perUnit - feePerUnit
+   // The Sell formula uses subtraction so that a positive feePerUnit
+   // (the normal-fee case) reduces proceeds, and a negative feePerUnit
+   // (the refund case from Decision 4) increases them. The Buy formula
+   // is the natural mirror — addition gives cost-up for fees, cost-down
+   // for refunds. Do NOT write `perUnit + feePerUnit` for both branches.
 ```
 
 The `leg.quantity.magnitude` is the absolute value of the *capital* leg
@@ -68,6 +96,15 @@ quantity. The capital leg's sign is what classifies the event as Buy
 (positive) or Sell (negative); the per-unit fee is always per-share, so
 absolute value is correct here. This is consistent with the existing code
 that does `abs(pairValue / leg.quantity)` on line 73.
+
+**Same-instrument fast path (step 2).** Skipping the conversion-service
+call when `feeLeg.instrument == hostCurrency` avoids an unnecessary async
+hop on the common case (brokerage in host currency on a host-currency
+trade) and keeps the fee-leg path off the rate-resolution code entirely.
+This is a behaviour the *classifier* enforces; relying on the underlying
+service's identity short-circuit is not enough — it leaves the door open
+for a future `InstrumentConversionService` implementation without that
+optimisation, and it can't be asserted directly in a test.
 
 ## API & call-sites
 
@@ -91,40 +128,59 @@ not part of cost basis in this iteration; that decision moves with the
 sentence and the issue link get replaced with:
 
 > Attached `.expense` legs are folded into per-unit cost: each fee leg is
-> converted to `hostCurrency` on the trade date, summed, and split evenly
-> across the capital events. Buy events have the per-unit fee added to
-> `costPerUnit`; Sell events have it subtracted from `proceedsPerUnit`.
-> Transfers (`In` / `Out`) do not enter the classifier and are unaffected.
+> converted to `hostCurrency` on the trade date (or summed directly when
+> already in `hostCurrency`), summed, and split *evenly* across the
+> capital events. Even split is deterministic and avoids the extra
+> conversion call value-weighting would require; for the typical
+> two-leg fair-value swap the result is the same to within rounding.
+> Buy events have the per-unit fee added to `costPerUnit`; Sell events
+> have it subtracted from `proceedsPerUnit`. Transfers (`In` / `Out`)
+> do not enter the classifier and are unaffected.
 
 ## Tests
 
-All in `MoolahTests/Shared/TradeEventClassifierTests.swift`. Existing
-no-fee tests (`buy`, `sell`, `swap`, `nonTradeLegsIgnored`,
-`zeroQuantityTradeLeg`, `fewerThanTwo`) act as the **(c) regression
-suite** — none of them have a `.expense` leg, so their expectations are
-unchanged.
+All in `MoolahTests/Shared/TradeEventClassifierTests.swift`.
 
-The existing `feeIgnored` test gets repurposed (renamed and expectation
-flipped) since the behaviour it asserted no longer matches policy.
+**Existing `feeIgnored` test is deleted** (its assertion `costPerUnit == 40`
+contradicts the new policy). It is replaced by `buyFoldsAUDFee` below
+(same fixture, flipped expectation).
+
+**Existing no-fee tests** (`buy`, `sell`, `swap`, `nonTradeLegsIgnored`,
+`zeroQuantityTradeLeg`, `fewerThanTwo`) are untouched — none of them
+have a `.expense` leg, so their expectations are unchanged. They serve as
+the **(c) no-fee regression suite**.
+
+**Decimal-literal discipline.** All new fixtures and assertions use exact
+`Decimal` literal forms — `Decimal(40)`, `Decimal(40) + Decimal(13) /
+Decimal(100)`, or `Decimal(string: "40.10")`. **Never** `Decimal(40.10)`
+(that's a `Double` literal coerced through `Decimal.init(_: Double)` and
+introduces float-rounding error). All expected values in the table below
+are reachable exactly under `Decimal` arithmetic; the test author should
+write assertions that demonstrate this.
 
 | Acceptance | Test name | Fixture | Expectation |
 |---|---|---|---|
-| (a) AUD fee on AUD-host trade | `buyFoldsAUDFee` | Buy 100 BHP for −4 000 AUD, fee −10 AUD | `costPerUnit == 40.10` |
-| (b) FX fee on AUD-host trade | `buyFoldsFXFee` | Buy 100 BHP for −4 000 AUD, fee −5 USD; rate USD→AUD = 1.5 | `costPerUnit == 40.075` |
+| (a) AUD fee on AUD-host trade | `buyFoldsAUDFee` | Buy 100 BHP for −4 000 AUD, fee −10 AUD | `costPerUnit == 40 + 10/100` |
+| (b) FX fee on AUD-host trade | `buyFoldsFXFee` | Buy 100 BHP for −4 000 AUD, fee −5 USD; **`DateBasedFixedConversionService`** with USD→AUD = 1.5 effective at trade date and USD→AUD = 2.0 effective at trade date + 1 day | `costPerUnit == 40 + 7.5/100` (i.e. 40.075 — only reachable if implementation passes the trade date) |
 | (c) no-fee regression | existing tests | unchanged | unchanged |
-| (d) multiple fee legs | `buyFoldsMultipleFees` | Buy 100 BHP for −4 000 AUD; fees −10 AUD and −3 AUD | `costPerUnit == 40.13` |
+| (d) multiple fee legs | `buyFoldsMultipleFees` | Buy 100 BHP for −4 000 AUD; fees −10 AUD and −3 AUD | `costPerUnit == 40 + 13/100` |
 
-Plus three additional tests called out by the design (not in the issue's
-acceptance grid, but required for behavioural coverage):
+Plus four additional behavioural tests:
 
 | Test name | Fixture | Expectation |
 |---|---|---|
-| `sellReducesProceedsByFee` | Sell 50 BHP for +2 500 AUD, fee −10 AUD | `proceedsPerUnit == 49.80` |
-| `swapSplitsFeeEvenlyAcrossEvents` | −2 ETH ↔ +0.1 BTC priced via host-currency conversion (rates ETH=3 000, BTC=60 000); fee −50 AUD | BTC `costPerUnit == 60_250` (60 000 + 25 / 0.1); ETH `proceedsPerUnit == 2_987.5` (3 000 − 25 / 2) |
-| `feeInHostCurrencyIsNotConverted` | Buy 100 BHP for −4 000 AUD, fee −10 AUD; conversion service has no rate entry | `costPerUnit == 40.10` (proves the host-currency short-circuit in `FixedConversionService` is exercised) |
+| `sellReducesProceedsByFee` | Sell 50 BHP for +2 500 AUD, fee −10 AUD | `proceedsPerUnit == 50 - 10/50` (i.e. 49.80) |
+| `swapSplitsFeeEvenlyAcrossEvents` | −2 ETH ↔ +0.1 BTC priced via host-currency conversion (`FixedConversionService`, rates ETH=3 000, BTC=60 000); fee −50 AUD | BTC `costPerUnit == 60_000 + 25/Decimal(string: "0.1")` (i.e. 60_250); ETH `proceedsPerUnit == 3_000 - Decimal(25)/2` (i.e. 2_987.5) |
+| `feeContributionsCancelToZero` | Buy 100 BHP for −4 000 AUD; fees −10 AUD and +10 AUD (a fee debit fully offset by a refund credit) | `costPerUnit == 40` (proves the sum-to-zero path produces the same result as the empty-fee-list path) |
+| `hostCurrencyFeeNeedsNoConversionLookup` | Buy 100 BHP for −4 000 AUD, fee −10 AUD; conversion service is a `RecordingConversionService` test double that fails (or records a call) on every `convert(...)` invocation | `costPerUnit == 40.10` AND no call was made to `convert` for the AUD fee leg (proves the classifier's fast path, not the production service's identity short-circuit) |
 
-The existing `feeIgnored` test name and body are removed — replaced by
-`buyFoldsAUDFee` above (same fixture, new expectation).
+`RecordingConversionService` is a small, local test double introduced for
+this test — three fields max (`calls: [(from, to, on)]`, optional
+`shouldFail: Bool`, returns `quantity` unchanged on hit since this test
+doesn't exercise non-host-currency conversions). Lives next to
+`FixedConversionService` in `MoolahTests/Support/`. If the existing
+`FixedConversionService` is trivially extensible to record calls, prefer
+extending it over a new type — implementer's call.
 
 ## Edge cases
 
@@ -132,14 +188,16 @@ The existing `feeIgnored` test name and body are removed — replaced by
   fee work runs. No divide-by-zero possible from fee folding.
 - **No `.expense` legs.** `feeLegs` is empty → `feeContribution = 0`
   → `feePerUnit = 0` → existing per-unit values pass through unchanged.
-  Verified by the `(c)` regression suite.
-- **`.expense` leg with `instrument == hostCurrency`.** `FixedConversionService`
-  (and the production `FullConversionService` / `FiatConversionService`)
-  return `quantity` unchanged when `from.id == to.id`. No FX call wasted,
-  no rate lookup needed.
+  Verified by the (c) regression suite.
+- **`.expense` legs that sum to zero.** Different code path from the
+  empty-list case (the loop runs, conversions may happen, signs cancel
+  in the sum). Verified by `feeContributionsCancelToZero`.
+- **`.expense` leg with `instrument == hostCurrency`.** Skipped at the
+  classifier level via the explicit fast path in Algorithm step 2. No
+  conversion-service call. Verified by `hostCurrencyFeeNeedsNoConversionLookup`.
 - **`.expense` leg in a foreign currency the rate service can't price.**
-  Errors propagate from `conversionService.convert(...)` exactly as the
-  existing code already does for trade-leg conversion. No new error path.
+  Errors propagate from `conversionService.convert(...)` per Decision 5.
+  No new error path beyond what trade-leg conversion already does today.
 
 ## Out of scope
 
@@ -151,3 +209,6 @@ The existing `feeIgnored` test name and body are removed — replaced by
   structurally.
 - Folding fees into `In` / `Out` transfers (Decision 3).
 - Apportioning fees by leg value rather than evenly (Decision 2).
+- Per-transaction scoping of conversion errors in `CapitalGainsCalculator`
+  (Decision 5). Applies equally to existing trade-leg conversion; would be
+  its own refactor.

--- a/plans/2026-05-03-trade-fees-cost-basis-design.md
+++ b/plans/2026-05-03-trade-fees-cost-basis-design.md
@@ -170,7 +170,7 @@ Plus four additional behavioural tests:
 | Test name | Fixture | Expectation |
 |---|---|---|
 | `sellReducesProceedsByFee` | Sell 50 BHP for +2 500 AUD, fee −10 AUD | `proceedsPerUnit == 50 - 10/50` (i.e. 49.80) |
-| `swapSplitsFeeEvenlyAcrossEvents` | −2 ETH ↔ +0.1 BTC priced via host-currency conversion (`FixedConversionService`, rates ETH=3 000, BTC=60 000); fee −50 AUD | BTC `costPerUnit == 60_000 + 25/Decimal(string: "0.1")` (i.e. 60_250); ETH `proceedsPerUnit == 3_000 - Decimal(25)/2` (i.e. 2_987.5) |
+| `swapSplitsFeeEvenlyAcrossEvents` | −2 ETH ↔ +0.1 BTC; `FixedConversionService` with 1 ETH = 3 000 AUD and 1 BTC = 60 000 AUD (used by the classifier for pair-value conversion only); fee −50 AUD (host-currency fast-pathed, no conversion call) | BTC `costPerUnit == 60_000 + 25/Decimal(string: "0.1")` (i.e. 60_250); ETH `proceedsPerUnit == 3_000 - Decimal(25)/2` (i.e. 2_987.5) |
 | `feeContributionsCancelToZero` | Buy 100 BHP for −4 000 AUD; fees −10 AUD and +10 AUD (a fee debit fully offset by a refund credit) | `costPerUnit == 40` (proves the sum-to-zero path produces the same result as the empty-fee-list path) |
 | `hostCurrencyFeeNeedsNoConversionLookup` | Buy 100 BHP for −4 000 AUD, fee −10 AUD; conversion service is a `RecordingConversionService` test double that fails (or records a call) on every `convert(...)` invocation | `costPerUnit == 40.10` AND no call was made to `convert` for the AUD fee leg (proves the classifier's fast path, not the production service's identity short-circuit) |
 

--- a/plans/2026-05-03-trade-fees-cost-basis-design.md
+++ b/plans/2026-05-03-trade-fees-cost-basis-design.md
@@ -1,0 +1,153 @@
+# Fold `.expense` fee legs into trade cost basis
+
+**Issue:** [#558](https://github.com/ajsutton/moolah-native/issues/558)
+**Date:** 2026-05-03
+**Status:** approved (design)
+
+## Summary
+
+`TradeEventClassifier` currently emits cost-basis events from `.trade` legs only,
+discarding any `.expense` (fee) leg attached to the same transaction
+(`Shared/TradeEventClassifier.swift:44`). The CSV importer half of #558 has
+shipped — `SelfWealthMovementsParser` already attaches brokerage as a `.expense`
+fee leg on the trade transaction
+(`Shared/CSVImport/SelfWealthMovementsParser.swift:164-169`) — but that fee
+contributes nothing to cost basis today.
+
+This design folds attached `.expense` legs into the per-unit `costPerUnit` for
+Buy events and reduces the per-unit `proceedsPerUnit` for Sell events,
+mirroring conventional capital-gains-tax treatment (brokerage and stamp duty
+are part of the cost base).
+
+## Decisions
+
+1. **`.expense` legs on a trade transaction fold into cost basis.** Yes.
+2. **Multi-event apportionment (non-fiat swaps).** Split fees evenly across
+   capital events. Fiat-paired trades emit one event → 100 % to that event.
+   Non-fiat swaps emit two events → 50 / 50. Predictable, deterministic,
+   matches what most retail tax workflows assume; ATO guidance is not
+   prescriptive on the alternative (value-weighted).
+3. **`In` / `Out` transfers — out of scope.** Transfers produce a single
+   `.income` or `.expense` leg (not `.trade`) and never enter the classifier.
+   Adding fee folding for them would require a different pipeline and risks
+   producing surprising cost-basis events from data the user thinks of as
+   transfers. Open a follow-up issue if this is ever requested.
+4. **Sign handling — preserve, don't `abs()`.** Fee-leg quantities are
+   conventionally negative (paid out). The classifier negates the *sum* of
+   converted fee quantities to obtain a positive cost contribution. A
+   positive `.expense` quantity (a refund attached to a trade) would
+   correctly *reduce* the cost contribution. Not a tested case (YAGNI), but
+   the math stays right rather than asymmetrically discarding sign.
+
+## Algorithm
+
+`TradeEventClassifier.classify(legs:on:hostCurrency:conversionService:)`
+adds the following work after the existing `tradeLegs.count == 2` and
+zero-quantity guards, before constructing buy/sell events:
+
+```
+1. feeLegs = legs.filter { $0.type == .expense }
+2. For each fee leg, convert quantity to hostCurrency on `date` via
+   conversionService. Sum into totalFeeHost.
+3. feeContribution = -totalFeeHost
+   // Negation: typical fee-leg quantity is negative (cost paid out);
+   // negating turns it into a positive cost contribution. A positive
+   // .expense leg (refund) yields a negative contribution → reduces
+   // cost. Sign-preserving on purpose.
+4. feePerEvent = feeContribution / Decimal(capitalIndices.count)
+   // capitalIndices.count is 1 for fiat-paired trades, 2 for non-fiat
+   // swaps. Per Decision 2.
+5. For each capital event, after computing the existing perUnit:
+     feePerUnit = feePerEvent / leg.quantity.magnitude
+     Buy:  costPerUnit = perUnit + feePerUnit
+     Sell: proceedsPerUnit = perUnit - feePerUnit
+```
+
+The `leg.quantity.magnitude` is the absolute value of the *capital* leg
+quantity. The capital leg's sign is what classifies the event as Buy
+(positive) or Sell (negative); the per-unit fee is always per-share, so
+absolute value is correct here. This is consistent with the existing code
+that does `abs(pairValue / leg.quantity)` on line 73.
+
+## API & call-sites
+
+No public-API change. Signature of `classify(...)` is unchanged. Downstream
+consumers read `costPerUnit` and `proceedsPerUnit` structurally:
+
+- `Shared/CapitalGainsCalculator.swift:56-72` — passes per-unit values into
+  `CostBasisEngine.processBuy` / `processSell` directly.
+- `Shared/PositionsHistoryBuilder.swift:225` — same shape.
+- `Features/Investments/InvestmentStore+PositionsInput.swift:113` — same
+  shape.
+
+All three transparently pick up improved numbers; no edit needed.
+
+## Doc-comment rewrite
+
+The existing classifier doc-comment
+(`Shared/TradeEventClassifier.swift:23-36`) reads "Fee legs (`.expense`) are
+not part of cost basis in this iteration; that decision moves with the
+`SelfWealthMovementsParser` brokerage-attach work tracked in #558." That
+sentence and the issue link get replaced with:
+
+> Attached `.expense` legs are folded into per-unit cost: each fee leg is
+> converted to `hostCurrency` on the trade date, summed, and split evenly
+> across the capital events. Buy events have the per-unit fee added to
+> `costPerUnit`; Sell events have it subtracted from `proceedsPerUnit`.
+> Transfers (`In` / `Out`) do not enter the classifier and are unaffected.
+
+## Tests
+
+All in `MoolahTests/Shared/TradeEventClassifierTests.swift`. Existing
+no-fee tests (`buy`, `sell`, `swap`, `nonTradeLegsIgnored`,
+`zeroQuantityTradeLeg`, `fewerThanTwo`) act as the **(c) regression
+suite** — none of them have a `.expense` leg, so their expectations are
+unchanged.
+
+The existing `feeIgnored` test gets repurposed (renamed and expectation
+flipped) since the behaviour it asserted no longer matches policy.
+
+| Acceptance | Test name | Fixture | Expectation |
+|---|---|---|---|
+| (a) AUD fee on AUD-host trade | `buyFoldsAUDFee` | Buy 100 BHP for −4 000 AUD, fee −10 AUD | `costPerUnit == 40.10` |
+| (b) FX fee on AUD-host trade | `buyFoldsFXFee` | Buy 100 BHP for −4 000 AUD, fee −5 USD; rate USD→AUD = 1.5 | `costPerUnit == 40.075` |
+| (c) no-fee regression | existing tests | unchanged | unchanged |
+| (d) multiple fee legs | `buyFoldsMultipleFees` | Buy 100 BHP for −4 000 AUD; fees −10 AUD and −3 AUD | `costPerUnit == 40.13` |
+
+Plus three additional tests called out by the design (not in the issue's
+acceptance grid, but required for behavioural coverage):
+
+| Test name | Fixture | Expectation |
+|---|---|---|
+| `sellReducesProceedsByFee` | Sell 50 BHP for +2 500 AUD, fee −10 AUD | `proceedsPerUnit == 49.80` |
+| `swapSplitsFeeEvenlyAcrossEvents` | −2 ETH ↔ +0.1 BTC priced via host-currency conversion (rates ETH=3 000, BTC=60 000); fee −50 AUD | BTC `costPerUnit == 60_250` (60 000 + 25 / 0.1); ETH `proceedsPerUnit == 2_987.5` (3 000 − 25 / 2) |
+| `feeInHostCurrencyIsNotConverted` | Buy 100 BHP for −4 000 AUD, fee −10 AUD; conversion service has no rate entry | `costPerUnit == 40.10` (proves the host-currency short-circuit in `FixedConversionService` is exercised) |
+
+The existing `feeIgnored` test name and body are removed — replaced by
+`buyFoldsAUDFee` above (same fixture, new expectation).
+
+## Edge cases
+
+- **Zero `.trade` quantity.** Already short-circuits at line 51 before any
+  fee work runs. No divide-by-zero possible from fee folding.
+- **No `.expense` legs.** `feeLegs` is empty → `feeContribution = 0`
+  → `feePerUnit = 0` → existing per-unit values pass through unchanged.
+  Verified by the `(c)` regression suite.
+- **`.expense` leg with `instrument == hostCurrency`.** `FixedConversionService`
+  (and the production `FullConversionService` / `FiatConversionService`)
+  return `quantity` unchanged when `from.id == to.id`. No FX call wasted,
+  no rate lookup needed.
+- **`.expense` leg in a foreign currency the rate service can't price.**
+  Errors propagate from `conversionService.convert(...)` exactly as the
+  existing code already does for trade-leg conversion. No new error path.
+
+## Out of scope
+
+- Re-parsing or back-filling existing imported transactions. The classifier
+  is pure; cost basis recomputes from the existing leg shapes the next time
+  it runs.
+- Changing `CapitalGainsCalculator`, `PositionsHistoryBuilder`, or
+  `InvestmentStore+PositionsInput`. They consume per-unit values
+  structurally.
+- Folding fees into `In` / `Out` transfers (Decision 3).
+- Apportioning fees by leg value rather than evenly (Decision 2).

--- a/plans/2026-05-03-trade-fees-cost-basis-plan.md
+++ b/plans/2026-05-03-trade-fees-cost-basis-plan.md
@@ -1,0 +1,512 @@
+# Fold `.expense` fee legs into trade cost basis — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `TradeEventClassifier` fold attached `.expense` (fee) legs into per-unit `costPerUnit` (Buy) and `proceedsPerUnit` (Sell), with foreign-currency fees converted to host currency on the trade date and split evenly across capital events.
+
+**Architecture:** Pure-function change to `Shared/TradeEventClassifier.swift`. After the existing trade-leg guards, sum `.expense` legs in host currency (with a same-instrument fast path), negate to get a positive cost contribution, divide evenly across capital events, and adjust each event's per-unit number. Doc-comment rewritten to reflect the new policy.
+
+**Tech Stack:** Swift 6, Swift Testing (`@Test`, `#expect`, `#require`), `InstrumentConversionService`, project test doubles (`FixedConversionService`, `DateBasedFixedConversionService`).
+
+**Spec:** `plans/2026-05-03-trade-fees-cost-basis-design.md`. Read it before starting Task 1.
+
+---
+
+## File Map
+
+- **Modify:** `Shared/TradeEventClassifier.swift` — algorithm extension + doc-comment rewrite. ~25 lines added inside `classify(...)`, ~10 lines of doc-comment replaced.
+- **Modify:** `MoolahTests/Shared/TradeEventClassifierTests.swift` — delete one test (`feeIgnored`), add seven new tests.
+- **Create:** `MoolahTests/Support/RecordingConversionService.swift` — small test double (single file, ~30 lines) that records every `convert(...)` call so the host-currency fast-path test can assert "no call was made for the AUD fee leg". Lives next to existing test doubles in `MoolahTests/Support/`.
+
+No project.yml change needed — both target dirs (`Shared/` and `MoolahTests/`) are already glob-included. No CloudKit schema change. No public API change to `classify(...)`.
+
+---
+
+## Task 1: Add `RecordingConversionService` test double
+
+**Why:** The `hostCurrencyFeeNeedsNoConversionLookup` test in Task 5 needs to assert that the classifier did **not** call the conversion service for an AUD fee leg on an AUD-host trade. Existing test doubles either short-circuit same-instrument calls inside the service (hiding whether the classifier called them), throw on every call (would also throw on the legitimate pair-leg conversion), or count `convertAmount` only (the classifier uses `convert`). A small per-call recorder is the cleanest fit.
+
+**Files:**
+- Create: `MoolahTests/Support/RecordingConversionService.swift`
+
+- [ ] **Step 1: Create the file**
+
+```swift
+import Foundation
+import os
+
+@testable import Moolah
+
+/// Test conversion service that records every `convert(_:from:to:on:)` call
+/// so tests can assert which conversions the caller actually performed.
+/// Returns `quantity` unchanged (1:1 fallback) on every call — this double
+/// is for *call-site* assertions, not rate behaviour.
+///
+/// Backed by `OSAllocatedUnfairLock` so it is async-safe and `Sendable` and
+/// usable from any isolation domain (matching the pattern in
+/// `ThrowingCountingConversionService`).
+final class RecordingConversionService: InstrumentConversionService, Sendable {
+  struct Call: Sendable, Equatable {
+    let quantity: Decimal
+    let fromId: String
+    let toId: String
+    let date: Date
+  }
+
+  private let recorded = OSAllocatedUnfairLock<[Call]>(initialState: [])
+
+  var calls: [Call] { recorded.withLock { $0 } }
+
+  func convert(
+    _ quantity: Decimal, from: Instrument, to: Instrument, on date: Date
+  ) async throws -> Decimal {
+    recorded.withLock {
+      $0.append(Call(quantity: quantity, fromId: from.id, toId: to.id, date: date))
+    }
+    return quantity
+  }
+
+  func convertAmount(
+    _ amount: InstrumentAmount, to instrument: Instrument, on date: Date
+  ) async throws -> InstrumentAmount {
+    let value = try await convert(
+      amount.quantity, from: amount.instrument, to: instrument, on: date)
+    return InstrumentAmount(quantity: value, instrument: instrument)
+  }
+}
+```
+
+- [ ] **Step 2: Build to verify the file compiles**
+
+Run from `.worktrees/fix-issue-558`:
+
+```bash
+just build-mac 2>&1 | tee .agent-tmp/build.txt | tail -20
+```
+
+Expected: BUILD SUCCEEDED. If it fails, fix the compile errors before proceeding (do not move to Task 2 with a broken build).
+
+Clean up: `rm .agent-tmp/build.txt`
+
+- [ ] **Step 3: Format and commit**
+
+```bash
+just format
+git -C $(pwd) add MoolahTests/Support/RecordingConversionService.swift
+git -C $(pwd) commit -m "$(cat <<'EOF'
+test(support): add RecordingConversionService test double
+
+Records every convert(_:from:to:on:) call so call-site assertions
+(e.g. "the classifier did not call the conversion service for a
+host-currency fee leg") can be expressed directly.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Write all seven new tests + delete `feeIgnored`
+
+**Why:** TDD red phase. We add the full failing-test suite up front so the production-code task in Task 3 can be a single coherent change verified against all behavioural cases at once. This is appropriate granularity for a ~25-line algorithm extension where the tests collectively form the spec.
+
+**Files:**
+- Modify: `MoolahTests/Shared/TradeEventClassifierTests.swift`
+
+- [ ] **Step 1: Replace the test file body**
+
+Open `MoolahTests/Shared/TradeEventClassifierTests.swift`. Make the following edits:
+
+**(a) Delete the `feeIgnored` test** (lines 69–77 in the current file — the test function plus its preceding `@Test("fee legs are ignored")` attribute and the blank line that follows). Its assertion `costPerUnit == 40` contradicts the new policy (`40.10`); we replace it below with `buyFoldsAUDFee`.
+
+**(b) Add a date helper** above the test functions (right after the `account` field at the top of the suite):
+
+```swift
+  private let usd = Instrument.fiatCurrency(code: "USD", name: "US Dollar")
+```
+
+Add `usd` next to `aud` so the FX-fee test has a foreign currency available. If `Instrument.fiatCurrency(code:name:)` is not the right factory, use whatever the existing codebase uses to construct USD — search the test suite (`grep -rn "USD" MoolahTests/Support MoolahTests/Shared`) for a precedent before improvising.
+
+**(c) Append the seven new test functions** at the end of the suite (immediately before the closing brace):
+
+```swift
+  // MARK: - Fee-folding tests (#558)
+
+  @Test("buy: AUD fee on AUD-host trade folds into per-unit cost")
+  func buyFoldsAUDFee() async throws {
+    let legs = [tradeLeg(aud, -4_000), tradeLeg(bhp, 100), feeLeg(aud, -10)]
+    let result = try await TradeEventClassifier.classify(
+      legs: legs, on: date, hostCurrency: aud,
+      conversionService: FixedConversionService(rates: [:]))
+    try #require(result.buys.count == 1)
+    #expect(result.buys[0].costPerUnit == Decimal(40) + Decimal(10) / Decimal(100))
+    #expect(result.sells.isEmpty)
+  }
+
+  @Test("sell: fee reduces per-unit proceeds")
+  func sellReducesProceedsByFee() async throws {
+    let legs = [tradeLeg(aud, 2_500), tradeLeg(bhp, -50), feeLeg(aud, -10)]
+    let result = try await TradeEventClassifier.classify(
+      legs: legs, on: date, hostCurrency: aud,
+      conversionService: FixedConversionService(rates: [:]))
+    try #require(result.sells.count == 1)
+    #expect(result.sells[0].proceedsPerUnit == Decimal(50) - Decimal(10) / Decimal(50))
+    #expect(result.buys.isEmpty)
+  }
+
+  @Test("buy: multiple AUD fee legs sum")
+  func buyFoldsMultipleFees() async throws {
+    let legs = [
+      tradeLeg(aud, -4_000), tradeLeg(bhp, 100),
+      feeLeg(aud, -10), feeLeg(aud, -3),
+    ]
+    let result = try await TradeEventClassifier.classify(
+      legs: legs, on: date, hostCurrency: aud,
+      conversionService: FixedConversionService(rates: [:]))
+    try #require(result.buys.count == 1)
+    #expect(result.buys[0].costPerUnit == Decimal(40) + Decimal(13) / Decimal(100))
+  }
+
+  @Test("buy: fee debit and equal refund credit cancel to zero")
+  func feeContributionsCancelToZero() async throws {
+    let legs = [
+      tradeLeg(aud, -4_000), tradeLeg(bhp, 100),
+      feeLeg(aud, -10), feeLeg(aud, 10),
+    ]
+    let result = try await TradeEventClassifier.classify(
+      legs: legs, on: date, hostCurrency: aud,
+      conversionService: FixedConversionService(rates: [:]))
+    try #require(result.buys.count == 1)
+    #expect(result.buys[0].costPerUnit == Decimal(40))
+  }
+
+  @Test("buy: FX fee converts at the trade date")
+  func buyFoldsFXFee() async throws {
+    // Two rate entries straddling the trade date. If the implementation
+    // accidentally passes Date() instead of `date`, the lookup picks the
+    // 2.0 rate and the assertion below fails — making the wrong-date bug
+    // detectable rather than silent.
+    let nextDay = date.addingTimeInterval(86_400)
+    let service = DateBasedFixedConversionService(rates: [
+      date: [usd.id: Decimal(string: "1.5")!],
+      nextDay: [usd.id: Decimal(2)],
+    ])
+    let legs = [tradeLeg(aud, -4_000), tradeLeg(bhp, 100), feeLeg(usd, -5)]
+    let result = try await TradeEventClassifier.classify(
+      legs: legs, on: date, hostCurrency: aud, conversionService: service)
+    try #require(result.buys.count == 1)
+    // -5 USD * 1.5 = -7.5 AUD; negate → +7.5; / 100 BHP → 0.075 per unit
+    #expect(
+      result.buys[0].costPerUnit
+        == Decimal(40) + Decimal(string: "7.5")! / Decimal(100))
+  }
+
+  @Test("swap: fee splits evenly across both capital events")
+  func swapSplitsFeeEvenlyAcrossEvents() async throws {
+    let service = FixedConversionService(rates: [
+      eth.id: Decimal(3_000),
+      btc.id: Decimal(60_000),
+    ])
+    let legs = [tradeLeg(eth, -2), tradeLeg(btc, Decimal(string: "0.1")!), feeLeg(aud, -50)]
+    let result = try await TradeEventClassifier.classify(
+      legs: legs, on: date, hostCurrency: aud, conversionService: service)
+    try #require(result.buys.count == 1)
+    try #require(result.sells.count == 1)
+    // 50 / 2 events = 25 AUD per event.
+    #expect(result.buys[0].instrument == btc)
+    #expect(
+      result.buys[0].costPerUnit
+        == Decimal(60_000) + Decimal(25) / Decimal(string: "0.1")!)
+    #expect(result.sells[0].instrument == eth)
+    #expect(
+      result.sells[0].proceedsPerUnit
+        == Decimal(3_000) - Decimal(25) / Decimal(2))
+  }
+
+  @Test("buy: host-currency fee skips the conversion service")
+  func hostCurrencyFeeNeedsNoConversionLookup() async throws {
+    // RecordingConversionService records every convert() call. For a
+    // host-currency fee leg the classifier MUST short-circuit at the
+    // call site so the recorder sees only the pair-leg conversion,
+    // never the fee-leg one.
+    let service = RecordingConversionService()
+    let legs = [tradeLeg(aud, -4_000), tradeLeg(bhp, 100), feeLeg(aud, -10)]
+    let result = try await TradeEventClassifier.classify(
+      legs: legs, on: date, hostCurrency: aud, conversionService: service)
+    try #require(result.buys.count == 1)
+    #expect(result.buys[0].costPerUnit == Decimal(40) + Decimal(10) / Decimal(100))
+    // RecordingConversionService returns input unchanged (1:1), so the
+    // pair-leg conversion still produces -4 000. The assertion below
+    // proves the fee leg was *not* sent to the service.
+    #expect(service.calls.count == 1)
+    #expect(service.calls.first?.quantity == -4_000)
+  }
+```
+
+- [ ] **Step 2: Run the new tests to verify they fail**
+
+```bash
+mkdir -p .agent-tmp
+just test-mac TradeEventClassifierTests 2>&1 | tee .agent-tmp/red.txt | tail -40
+```
+
+Expected: every one of the seven new tests **fails** (the production code still discards `.expense` legs, so cost/proceeds come out at the no-fee values). The pre-existing tests (`buy`, `sell`, `swap`, `nonTradeLegsIgnored`, `zeroQuantityTradeLeg`, `fewerThanTwo`) still pass — they have no `.expense` leg.
+
+Specifically expect:
+- `buyFoldsAUDFee`: actual `costPerUnit == 40`, expected `40.10`. FAIL.
+- `sellReducesProceedsByFee`: actual `proceedsPerUnit == 50`, expected `49.80`. FAIL.
+- `buyFoldsMultipleFees`: actual 40, expected `40.13`. FAIL.
+- `feeContributionsCancelToZero`: actual 40, expected 40. **PASS** (sum-to-zero degenerates to no-fee). That's fine — the test still proves the path doesn't crash, which is half its purpose; Task 3 will keep it green.
+- `buyFoldsFXFee`: actual 40, expected `40.075`. FAIL.
+- `swapSplitsFeeEvenlyAcrossEvents`: actual BTC 60 000 / ETH 3 000, expected 60 250 / 2 987.5. FAIL.
+- `hostCurrencyFeeNeedsNoConversionLookup`: actual cost 40, expected `40.10`. FAIL on the cost assertion. Call-count assertion may PASS today (no fee call is made because fee is ignored entirely) — that's fine, Task 3 must keep that property.
+
+Confirm by `grep -E "Test [\"]?(buy|sell|swap|fee|host)" .agent-tmp/red.txt`. Six failures expected.
+
+If you see anything other than this pattern, debug before proceeding. Do **not** start Task 3 if a pre-existing test failed (that's a regression already, before any production change).
+
+Clean up: `rm .agent-tmp/red.txt`
+
+- [ ] **Step 3: Commit the failing tests**
+
+```bash
+just format
+git -C $(pwd) add MoolahTests/Shared/TradeEventClassifierTests.swift
+git -C $(pwd) commit -m "$(cat <<'EOF'
+test(trade): add fee-folding tests; delete feeIgnored
+
+TDD red phase for #558 — seven new behavioural tests covering AUD/FX
+fees, multi-fee summing, sum-to-zero, sell-side proceeds reduction,
+non-fiat swap even-split, and host-currency fast-path enforcement.
+Production change in TradeEventClassifier follows next.
+
+The previous feeIgnored test asserted the now-wrong behaviour
+(costPerUnit == 40) and is deleted. buyFoldsAUDFee uses the same
+fixture with the new expectation (40.10).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+Note: this commit deliberately leaves the test suite red. The next task makes it green. This is standard TDD; the next task lands within minutes.
+
+---
+
+## Task 3: Implement fee folding + doc-comment rewrite
+
+**Why:** TDD green phase. One coherent code change that takes all seven new tests from red to green and updates the doc-comment to reflect the new policy.
+
+**Files:**
+- Modify: `Shared/TradeEventClassifier.swift`
+
+- [ ] **Step 1: Replace the `classify(...)` body and the doc-comment**
+
+Open `Shared/TradeEventClassifier.swift`. Replace the doc-comment at lines 23–36 and the entire `classify(...)` function with:
+
+```swift
+/// Classifies a transaction's `.trade` legs into FIFO buy / sell events.
+///
+/// Per design §2, the classifier filters by `type == .trade` to identify
+/// capital legs. For each one, the per-unit value is derived from the
+/// *other* `.trade` leg's value converted to `hostCurrency` on the
+/// transaction date.
+///
+/// Attached `.expense` legs are folded into per-unit cost: each fee leg
+/// is converted to `hostCurrency` on the trade date (or summed directly
+/// when already in `hostCurrency`), summed, and split *evenly* across
+/// the capital events. Even split is deterministic and avoids the extra
+/// conversion call value-weighting would require; for the typical
+/// two-leg fair-value swap the result is the same to within rounding.
+/// Buy events have the per-unit fee added to `costPerUnit`; Sell events
+/// have it subtracted from `proceedsPerUnit`. Transfers (`In` / `Out`)
+/// do not enter the classifier and are unaffected.
+///
+/// Only non-fiat legs emit capital events. In a fiat+non-fiat pair the
+/// fiat leg is the price carrier; in a non-fiat swap both legs emit events.
+/// Zero-quantity `.trade` legs cause the whole classification to return empty
+/// (no divide-by-zero, no half-emitted event).
+enum TradeEventClassifier {
+  static func classify(
+    legs: [TransactionLeg],
+    on date: Date,
+    hostCurrency: Instrument,
+    conversionService: any InstrumentConversionService
+  ) async throws -> TradeEventClassification {
+    let tradeLegs = legs.filter { $0.type == .trade }
+    guard tradeLegs.count == 2 else {
+      return TradeEventClassification(buys: [], sells: [])
+    }
+
+    // If either trade leg has a zero quantity, we cannot compute a per-unit
+    // price and there is no meaningful event to emit.
+    guard tradeLegs[0].quantity != 0, tradeLegs[1].quantity != 0 else {
+      return TradeEventClassification(buys: [], sells: [])
+    }
+
+    // Fiat legs act as the price carrier; non-fiat legs are the capital assets.
+    // In a non-fiat swap both legs generate capital events; in a fiat-paired
+    // trade only the non-fiat leg does.
+    let nonFiatIndices = tradeLegs.indices.filter {
+      tradeLegs[$0].instrument.kind != .fiatCurrency
+    }
+    let capitalIndices = nonFiatIndices.isEmpty ? Array(tradeLegs.indices) : nonFiatIndices
+
+    // Sum attached fee legs in hostCurrency. Same-instrument fast path is
+    // enforced here at the call site, not delegated to the conversion
+    // service — that keeps the host-currency case off the async hop and
+    // is directly testable (see hostCurrencyFeeNeedsNoConversionLookup).
+    var totalFeeHost: Decimal = 0
+    for feeLeg in legs where feeLeg.type == .expense {
+      if feeLeg.instrument == hostCurrency {
+        totalFeeHost += feeLeg.quantity
+      } else {
+        totalFeeHost += try await conversionService.convert(
+          feeLeg.quantity, from: feeLeg.instrument, to: hostCurrency, on: date)
+      }
+    }
+    // Negate: fee-leg quantity is negative by convention (cost paid out).
+    // Negating turns the sum into a positive cost contribution. A positive
+    // .expense leg (a refund attached to a trade) becomes a negative
+    // contribution, correctly reducing cost. Sign-preserving on purpose;
+    // never abs().
+    let feeContribution = -totalFeeHost
+    // feePerEvent is a per-event total in hostCurrency (NOT yet per-unit).
+    // Step further down divides by leg.quantity.magnitude to get per-unit.
+    let feePerEvent = feeContribution / Decimal(capitalIndices.count)
+
+    var buys: [TradeBuyEvent] = []
+    var sells: [TradeSellEvent] = []
+    for index in capitalIndices {
+      let leg = tradeLegs[index]
+      let pairIndex = index == 0 ? 1 : 0
+      let pair = tradeLegs[pairIndex]
+      let pairValue = try await conversionService.convert(
+        pair.quantity, from: pair.instrument, to: hostCurrency, on: date)
+      // pair.quantity has the *opposite* sign by convention (paid vs received),
+      // so |pairValue / leg.quantity| is the per-unit cost or proceed.
+      let perUnit = abs(pairValue / leg.quantity)
+      // The Sell formula uses subtraction so a positive feePerUnit (the
+      // normal-fee case) reduces proceeds, and a negative feePerUnit
+      // (the refund case from Decision 4) increases them. Buy is the
+      // mirror — addition gives cost-up for fees, cost-down for refunds.
+      let feePerUnit = feePerEvent / leg.quantity.magnitude
+      if leg.quantity > 0 {
+        buys.append(
+          TradeBuyEvent(
+            instrument: leg.instrument,
+            quantity: leg.quantity,
+            costPerUnit: perUnit + feePerUnit))
+      } else {
+        sells.append(
+          TradeSellEvent(
+            instrument: leg.instrument,
+            quantity: -leg.quantity,
+            proceedsPerUnit: perUnit - feePerUnit))
+      }
+    }
+    return TradeEventClassification(buys: buys, sells: sells)
+  }
+}
+```
+
+Two notes on details:
+
+1. `Decimal` does not have a `.magnitude` property in the Swift standard library the same way `Int` does — `Decimal` conforms to `SignedNumeric` so `.magnitude` is available there. Verify the build picks it up; if not, replace `leg.quantity.magnitude` with `abs(leg.quantity)`. Same semantics, definitely available on `Decimal`.
+
+2. The fee-leg loop reads from `legs` (the original parameter), not `tradeLegs` — correct, because `tradeLegs` was filtered down to `.trade` only and would never contain `.expense` legs.
+
+- [ ] **Step 2: Run the test class to verify all green**
+
+```bash
+mkdir -p .agent-tmp
+just test-mac TradeEventClassifierTests 2>&1 | tee .agent-tmp/green.txt | tail -40
+```
+
+Expected: all tests in the suite pass. The seven new tests now succeed; the pre-existing six tests still succeed. No failures.
+
+If any test fails:
+- For arithmetic mismatches, recompute by hand using the exact `Decimal` literal forms in the assertion — the test file deliberately avoids `Decimal(40.075)` (which loses precision through `Double`).
+- For `hostCurrencyFeeNeedsNoConversionLookup` failing on `service.calls.count == 1`, the host-currency fast path in step 2 of the algorithm is missing or has the comparison wrong (`feeLeg.instrument == hostCurrency` — both sides are `Instrument`, which is `Equatable`; if the test sees 2 calls, the fast path is bypassed).
+
+Clean up: `rm .agent-tmp/green.txt`
+
+- [ ] **Step 3: Run the full mac test suite to check for regressions**
+
+`TradeEventClassifier` is consumed by `CapitalGainsCalculator`, `PositionsHistoryBuilder`, and `InvestmentStore+PositionsInput`. None of their existing tests use `.expense` legs in trade transactions (verified: `grep -rn "feeLeg\|\.expense" MoolahTests/` returns only the new test file we just edited and a handful of unrelated suites). But run the broader suite to be sure:
+
+```bash
+mkdir -p .agent-tmp
+just test-mac 2>&1 | tee .agent-tmp/full.txt | tail -30
+grep -i "failed\|error:" .agent-tmp/full.txt || echo "ALL CLEAN"
+```
+
+Expected: ALL CLEAN. If anything broke, investigate before proceeding — a downstream consumer probably has a fixture with an `.expense` leg attached to a trade that we didn't anticipate.
+
+Clean up: `rm .agent-tmp/full.txt`
+
+- [ ] **Step 4: Format and check for warnings**
+
+```bash
+just format
+just format-check 2>&1 | tail -10
+```
+
+Expected: format-check exits 0. No new SwiftLint warnings (baseline must not change). If format-check complains, fix the underlying code — **never** modify `.swiftlint-baseline.yml`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C $(pwd) add Shared/TradeEventClassifier.swift
+git -C $(pwd) commit -m "$(cat <<'EOF'
+feat(trade): fold .expense fee legs into per-unit cost basis
+
+Closes #558. TradeEventClassifier now sums attached .expense legs
+(converted to hostCurrency on the trade date, host-currency legs
+fast-pathed without a service call), splits the total evenly across
+capital events, and adjusts each event's per-unit number — added to
+costPerUnit for Buys, subtracted from proceedsPerUnit for Sells.
+
+Sign-preserving: a positive .expense leg (refund attached to a
+trade) correctly reduces the cost contribution rather than being
+discarded by abs(). Doc-comment rewritten to describe the new policy
+and call out why even split (not value-weighted).
+
+Out of scope: In/Out transfers, which never enter the classifier.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Final Verification
+
+After Task 3, before proceeding to the code-review loop:
+
+- [ ] **Sanity-check git state**
+
+```bash
+git -C $(pwd) status
+git -C $(pwd) log --oneline origin/main..HEAD
+```
+
+Expected: working tree clean. Three commits ahead of `origin/main`:
+1. `test(support): add RecordingConversionService test double`
+2. `test(trade): add fee-folding tests; delete feeIgnored`
+3. `feat(trade): fold .expense fee legs into per-unit cost basis`
+
+- [ ] **Final test-suite run** (one more time, paranoid)
+
+```bash
+mkdir -p .agent-tmp
+just test 2>&1 | tee .agent-tmp/final.txt | tail -20
+grep -i "failed\|error:" .agent-tmp/final.txt || echo "FINAL: ALL CLEAN"
+rm .agent-tmp/final.txt
+```
+
+Expected: FINAL: ALL CLEAN on both `MoolahTests_iOS` and `MoolahTests_macOS`.
+
+If anything failed, do not move on — investigate and fix before the code-review loop.

--- a/plans/2026-05-03-trade-fees-cost-basis-plan.md
+++ b/plans/2026-05-03-trade-fees-cost-basis-plan.md
@@ -16,7 +16,7 @@
 
 - **Modify:** `Shared/TradeEventClassifier.swift` — algorithm extension + doc-comment rewrite. ~25 lines added inside `classify(...)`, ~10 lines of doc-comment replaced.
 - **Modify:** `MoolahTests/Shared/TradeEventClassifierTests.swift` — delete one test (`feeIgnored`), add seven new tests.
-- **Create:** `MoolahTests/Support/RecordingConversionService.swift` — small test double (single file, ~30 lines) that records every `convert(...)` call so the host-currency fast-path test can assert "no call was made for the AUD fee leg". Lives next to existing test doubles in `MoolahTests/Support/`.
+- **Create:** `MoolahTests/Support/RecordingConversionService.swift` — small test double (single file, ~35 lines) that records every `convert(...)` call so the host-currency fast-path test can assert "no call was made for the AUD fee leg". Lives next to existing test doubles in `MoolahTests/Support/`. Defines a top-level `RecordingConversionServiceCall` struct (kept top-level rather than nested to avoid the SwiftLint `nesting: type_level: 1` warning).
 
 No project.yml change needed — both target dirs (`Shared/` and `MoolahTests/`) are already glob-included. No CloudKit schema change. No public API change to `classify(...)`.
 
@@ -37,31 +37,38 @@ import os
 
 @testable import Moolah
 
+/// One recorded call to `RecordingConversionService.convert(...)`. Top-level
+/// (not nested in the service) so the SwiftLint `nesting: type_level` rule
+/// stays at 0 — adding a nested type would cross the warn threshold and
+/// cannot be appeased without growing the baseline.
+struct RecordingConversionServiceCall: Sendable, Equatable {
+  let quantity: Decimal
+  let fromId: String
+  let toId: String
+  let date: Date
+}
+
 /// Test conversion service that records every `convert(_:from:to:on:)` call
 /// so tests can assert which conversions the caller actually performed.
 /// Returns `quantity` unchanged (1:1 fallback) on every call — this double
 /// is for *call-site* assertions, not rate behaviour.
 ///
 /// Backed by `OSAllocatedUnfairLock` so it is async-safe and `Sendable` and
-/// usable from any isolation domain (matching the pattern in
-/// `ThrowingCountingConversionService`).
+/// usable from any isolation domain (same lock-around-mutable-state pattern
+/// as `FailureLog` in `ThrowingCountingConversionService.swift`).
 final class RecordingConversionService: InstrumentConversionService, Sendable {
-  struct Call: Sendable, Equatable {
-    let quantity: Decimal
-    let fromId: String
-    let toId: String
-    let date: Date
-  }
+  private let recorded = OSAllocatedUnfairLock<[RecordingConversionServiceCall]>(
+    initialState: [])
 
-  private let recorded = OSAllocatedUnfairLock<[Call]>(initialState: [])
-
-  var calls: [Call] { recorded.withLock { $0 } }
+  var calls: [RecordingConversionServiceCall] { recorded.withLock { $0 } }
 
   func convert(
     _ quantity: Decimal, from: Instrument, to: Instrument, on date: Date
   ) async throws -> Decimal {
     recorded.withLock {
-      $0.append(Call(quantity: quantity, fromId: from.id, toId: to.id, date: date))
+      $0.append(
+        RecordingConversionServiceCall(
+          quantity: quantity, fromId: from.id, toId: to.id, date: date))
     }
     return quantity
   }
@@ -120,13 +127,25 @@ Open `MoolahTests/Shared/TradeEventClassifierTests.swift`. Make the following ed
 
 **(a) Delete the `feeIgnored` test** (lines 69–77 in the current file — the test function plus its preceding `@Test("fee legs are ignored")` attribute and the blank line that follows). Its assertion `costPerUnit == 40` contradicts the new policy (`40.10`); we replace it below with `buyFoldsAUDFee`.
 
-**(b) Add a date helper** above the test functions (right after the `account` field at the top of the suite):
+**(b) Add a USD instrument field** above the test functions (right after the `account` field at the top of the suite):
 
 ```swift
-  private let usd = Instrument.fiatCurrency(code: "USD", name: "US Dollar")
+  let usd = Instrument.USD
 ```
 
-Add `usd` next to `aud` so the FX-fee test has a foreign currency available. If `Instrument.fiatCurrency(code:name:)` is not the right factory, use whatever the existing codebase uses to construct USD — search the test suite (`grep -rn "USD" MoolahTests/Support MoolahTests/Shared`) for a precedent before improvising.
+`Instrument.USD` is a static convenience constant defined at
+`Domain/Models/Instrument.swift:92` — it expands to `Instrument.fiat(code: "USD")`.
+Used by `buyFoldsFXFee` to provide a foreign-currency fee leg.
+
+Also confirm the existing `date` field in this suite is a past date —
+the existing `let date = Date(timeIntervalSince1970: 1_700_000_000)` is
+November 2023, which is in the past. This is a precondition for the
+`buyFoldsFXFee` test's wrong-date detection to work: the test relies on
+`Date()` (today, at test-run time) being strictly *later* than `date +
+1 day` so that a buggy implementation passing `Date()` instead of `date`
+would pick the 2.0 rate (later entry) and fail the assertion. If the
+existing fixture is ever changed to a future date, that test loses its
+bite.
 
 **(c) Append the seven new test functions** at the end of the suite (immediately before the closing brace):
 
@@ -226,10 +245,14 @@ Add `usd` next to `aud` so the FX-fee test has a foreign currency available. If 
 
   @Test("buy: host-currency fee skips the conversion service")
   func hostCurrencyFeeNeedsNoConversionLookup() async throws {
-    // RecordingConversionService records every convert() call. For a
-    // host-currency fee leg the classifier MUST short-circuit at the
-    // call site so the recorder sees only the pair-leg conversion,
-    // never the fee-leg one.
+    // RecordingConversionService records every convert() call without a
+    // same-instrument short-circuit. The pair-leg conversion (AUD→AUD,
+    // for the BHP capital leg) goes through the service unconditionally
+    // — the classifier does not fast-path the *pair* leg today — so the
+    // recorder sees that one call. The fee leg (also AUD on AUD-host)
+    // MUST be fast-pathed inside the classifier so the recorder sees
+    // exactly one call total. If the fast path is missing, the recorder
+    // sees two calls and `count == 1` catches it.
     let service = RecordingConversionService()
     let legs = [tradeLeg(aud, -4_000), tradeLeg(bhp, 100), feeLeg(aud, -10)]
     let result = try await TradeEventClassifier.classify(
@@ -237,8 +260,7 @@ Add `usd` next to `aud` so the FX-fee test has a foreign currency available. If 
     try #require(result.buys.count == 1)
     #expect(result.buys[0].costPerUnit == Decimal(40) + Decimal(10) / Decimal(100))
     // RecordingConversionService returns input unchanged (1:1), so the
-    // pair-leg conversion still produces -4 000. The assertion below
-    // proves the fee leg was *not* sent to the service.
+    // pair-leg conversion still produces -4 000.
     #expect(service.calls.count == 1)
     #expect(service.calls.first?.quantity == -4_000)
   }
@@ -262,16 +284,23 @@ Specifically expect:
 - `swapSplitsFeeEvenlyAcrossEvents`: actual BTC 60 000 / ETH 3 000, expected 60 250 / 2 987.5. FAIL.
 - `hostCurrencyFeeNeedsNoConversionLookup`: actual cost 40, expected `40.10`. FAIL on the cost assertion. Call-count assertion may PASS today (no fee call is made because fee is ignored entirely) — that's fine, Task 3 must keep that property.
 
-Confirm by `grep -E "Test [\"]?(buy|sell|swap|fee|host)" .agent-tmp/red.txt`. Six failures expected.
+Confirm by `grep -E "buyFolds|sellReduces|swapSplits|feeContrib|hostCurrency" .agent-tmp/red.txt` — function names are stable in xcodebuild output. Six failures expected.
 
 If you see anything other than this pattern, debug before proceeding. Do **not** start Task 3 if a pre-existing test failed (that's a regression already, before any production change).
 
 Clean up: `rm .agent-tmp/red.txt`
 
-- [ ] **Step 3: Commit the failing tests**
+- [ ] **Step 3: Format, verify, and commit the failing tests**
 
 ```bash
 just format
+just format-check 2>&1 | tail -10
+```
+
+Expected: `format-check` exits 0. If it complains, fix the underlying
+code — never edit `.swiftlint-baseline.yml`.
+
+```bash
 git -C $(pwd) add MoolahTests/Shared/TradeEventClassifierTests.swift
 git -C $(pwd) commit -m "$(cat <<'EOF'
 test(trade): add fee-folding tests; delete feeIgnored
@@ -385,7 +414,9 @@ enum TradeEventClassifier {
       let pairValue = try await conversionService.convert(
         pair.quantity, from: pair.instrument, to: hostCurrency, on: date)
       // pair.quantity has the *opposite* sign by convention (paid vs received),
-      // so |pairValue / leg.quantity| is the per-unit cost or proceed.
+      // so |pairValue / leg.quantity| is the per-unit cost or proceed. abs()
+      // here gives the magnitude of the exchange rate, NOT a monetary amount;
+      // the buy-vs-sell sign is carried by `leg.quantity > 0` below.
       let perUnit = abs(pairValue / leg.quantity)
       // The Sell formula uses subtraction so a positive feePerUnit (the
       // normal-fee case) reduces proceeds, and a negative feePerUnit
@@ -413,7 +444,7 @@ enum TradeEventClassifier {
 
 Two notes on details:
 
-1. `Decimal` does not have a `.magnitude` property in the Swift standard library the same way `Int` does — `Decimal` conforms to `SignedNumeric` so `.magnitude` is available there. Verify the build picks it up; if not, replace `leg.quantity.magnitude` with `abs(leg.quantity)`. Same semantics, definitely available on `Decimal`.
+1. `.magnitude` is available on `Decimal` via `SignedNumeric` conformance — no fallback should be needed. If a future compiler revision changes that, `abs(leg.quantity)` is a drop-in equivalent.
 
 2. The fee-leg loop reads from `legs` (the original parameter), not `tradeLegs` — correct, because `tradeLegs` was filtered down to `.trade` only and would never contain `.expense` legs.
 


### PR DESCRIPTION
## Summary

- `TradeEventClassifier` now folds attached `.expense` (fee) legs into per-unit cost: each fee converts to host currency on the trade date (host-currency fees fast-pathed at the call site), summed total split evenly across capital events, then added to `costPerUnit` for Buys / subtracted from `proceedsPerUnit` for Sells. Sign-preserving (refund attached to a trade reduces the contribution rather than being discarded by `abs()`).
- `ProfitLossCalculator.accumulateInvested` calls the same shared helper (`TradeEventClassifier.feeContribution(...)`), so `totalInvested` stays consistent with the FIFO `remainingCostBasis` — otherwise `returnPercentage` would over-state returns by ignoring transaction costs.
- Transfers (`In` / `Out`) remain out of scope; they don't enter the classifier at all.

Closes #558.

## Design

Approved spec at [`plans/2026-05-03-trade-fees-cost-basis-design.md`](plans/2026-05-03-trade-fees-cost-basis-design.md). Decisions: fold yes; even-split across capital events for non-fiat swaps; transfers out of scope; sign-preserving (no `abs()` on the fee sum); errors propagate as today.

## Test plan

- [x] `just test-mac` — all suites pass (1998 tests / 308 suites).
- [x] `just test-ios` — all suites pass on the iOS Simulator.
- [x] `just format-check` — clean (no SwiftLint baseline changes; existing `dec("…")` helper used instead of `Decimal(string:)!` to satisfy `force_unwrapping`).
- [x] Seven new behavioural tests in `TradeEventClassifierTests` cover: AUD fee on AUD-host buy, sell-side proceeds reduction, multiple fee legs sum, fee/refund cancel-to-zero, FX fee with `DateBasedFixedConversionService` straddle (catches a wrong-date implementation), non-fiat swap even split, host-currency fast-path enforced via `RecordingConversionService` (asserts the classifier didn't call the conversion service for the AUD fee leg).
- [x] Two new tests in `ProfitLossCalculatorTestsMore` cover the same fee-folding semantics on the `accumulateInvested` path, including a `DateBasedFixedConversionService` straddle for FX fees.
- [x] Two pre-existing placeholder tests (`crossCurrencyBuyWithFeeExcludesFeeFromCostBasis`, `mixedFiatLegs_totalInvestedConvertsEachLegToProfileCurrency`) updated — they were explicit guards for the old "fees ignored" behaviour and referenced #558 in their doc-comments as the tracking issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)