### PR TITLE
fix(import): suffix SelfWealth ASX codes with .AX

### DIFF
--- a/Features/Import/ImportStore+Transactions.swift
+++ b/Features/Import/ImportStore+Transactions.swift
@@ -67,7 +67,7 @@ extension ImportStore {
 
   /// Rewrite placeholder-instrument legs (cash legs from parsers) to the
   /// routed account's actual instrument. Explicit instrument legs (e.g.
-  /// SelfWealth's `ASX:BHP` position leg) are left alone. The flag is set
+  /// SelfWealth's `ASX:BHP.AX` position leg) are left alone. The flag is set
   /// by the parser at the leg's point-of-origin, replacing the earlier
   /// fragile "is it AUD?" heuristic.
   func resolveParsedLeg(

--- a/MoolahTests/Features/Import/ImportStoreTestsMoreSecondHalf.swift
+++ b/MoolahTests/Features/Import/ImportStoreTestsMoreSecondHalf.swift
@@ -163,7 +163,7 @@ struct ImportStoreTestsMoreSecondHalf {
       $0.instrument == .AUD && $0.quantity == Decimal(string: "-5000.00")
     })
     #expect(cashLeg?.type == .trade)
-    let positionLeg = buy.legs.first(where: { $0.instrument.id == "ASX:WXYZ" })
+    let positionLeg = buy.legs.first(where: { $0.instrument.id == "ASX:WXYZ.AX" })
     #expect(positionLeg?.quantity == 100)
     #expect(positionLeg?.type == .trade)
     let brokerageLeg = buy.legs.first(where: {
@@ -179,12 +179,12 @@ struct ImportStoreTestsMoreSecondHalf {
       $0.importOrigin?.rawDescription.contains("Sell") == true
         && $0.importOrigin?.rawDescription.contains("ABCD") == true
     })
-    let sellPosition = sell?.legs.first(where: { $0.instrument.id == "ASX:ABCD" })
+    let sellPosition = sell?.legs.first(where: { $0.instrument.id == "ASX:ABCD.AX" })
     #expect(sellPosition?.quantity == -50)
     // In row: one-leg position income, no cash counterpart. User reclassifies
     // in-app if it's actually a transfer rather than DRP.
     let drp = imported.first(where: {
-      $0.legs.count == 1 && $0.legs.first?.instrument.id == "ASX:WXYZ"
+      $0.legs.count == 1 && $0.legs.first?.instrument.id == "ASX:WXYZ.AX"
     })
     #expect(drp?.legs.first?.type == .income)
   }

--- a/MoolahTests/Shared/CSVImport/SelfWealthMovementsParserTests.swift
+++ b/MoolahTests/Shared/CSVImport/SelfWealthMovementsParserTests.swift
@@ -37,7 +37,8 @@ struct SelfWealthMovementsParserTests {
       $0.instrument == .AUD && $0.type == .trade && $0.quantity == Decimal(string: "-5000.00")
     })
     #expect(cashLeg != nil)
-    let positionLeg = try #require(buy.legs.first(where: { $0.instrument.id == "ASX:WXYZ" }))
+    let positionLeg = try #require(buy.legs.first(where: { $0.instrument.id == "ASX:WXYZ.AX" }))
+    #expect(positionLeg.instrument.ticker == "WXYZ.AX")
     #expect(positionLeg.quantity == 100)
     #expect(positionLeg.type == .trade)
     #expect(positionLeg.instrument.kind == .stock)
@@ -65,7 +66,7 @@ struct SelfWealthMovementsParserTests {
         $0.instrument == .AUD && $0.type == .trade
       }))
     #expect(cashLeg.quantity == Decimal(string: "4000.00"))
-    let positionLeg = try #require(sell.legs.first(where: { $0.instrument.id == "ASX:ABCD" }))
+    let positionLeg = try #require(sell.legs.first(where: { $0.instrument.id == "ASX:ABCD.AX" }))
     #expect(positionLeg.quantity == -50)
     #expect(positionLeg.type == .trade)
     let brokerageLeg = try #require(
@@ -85,7 +86,7 @@ struct SelfWealthMovementsParserTests {
         $0.rawDescription.contains("In") && $0.rawDescription.contains("WXYZ")
       }))
     #expect(drp.legs.count == 1)
-    #expect(drp.legs[0].instrument.id == "ASX:WXYZ")
+    #expect(drp.legs[0].instrument.id == "ASX:WXYZ.AX")
     #expect(drp.legs[0].quantity == 3)
     #expect(drp.legs[0].type == .income)
     #expect(drp.legs[0].isInstrumentPlaceholder == false)
@@ -101,7 +102,7 @@ struct SelfWealthMovementsParserTests {
         $0.bankReference == "9000000000000001"
       }))
     #expect(offMarket.legs.count == 1)
-    #expect(offMarket.legs[0].instrument.id == "ASX:MNOP")
+    #expect(offMarket.legs[0].instrument.id == "ASX:MNOP.AX")
     #expect(offMarket.legs[0].quantity == 250)
     #expect(offMarket.legs[0].type == .income)
   }
@@ -116,7 +117,7 @@ struct SelfWealthMovementsParserTests {
         $0.rawDescription.contains("Out") && $0.rawDescription.contains("ABCD")
       }))
     #expect(out.legs.count == 1)
-    #expect(out.legs[0].instrument.id == "ASX:ABCD")
+    #expect(out.legs[0].instrument.id == "ASX:ABCD.AX")
     #expect(out.legs[0].quantity == -10)
     #expect(out.legs[0].type == .expense)
   }

--- a/Shared/CSVImport/SelfWealthMovementsParser.swift
+++ b/Shared/CSVImport/SelfWealthMovementsParser.swift
@@ -148,8 +148,7 @@ struct SelfWealthMovementsParser: CSVParser, Sendable {
         row: context.row)
     }
     let brokerage = SelfWealthCSVParsing.parseDecimal(brokerageField) ?? 0
-    let stockInstrument = Instrument.stock(
-      ticker: context.code, exchange: "ASX", name: context.code)
+    let stockInstrument = Self.instrument(forASXCode: context.code)
     let cashAmount = isBuy ? -consideration : consideration
 
     var legs = [
@@ -175,13 +174,20 @@ struct SelfWealthMovementsParser: CSVParser, Sendable {
         bankReference: context.reference.isEmpty ? nil : context.reference))
   }
 
+  /// SelfWealth's CSV stores the bare ASX code (e.g. `BHP`); the rest of
+  /// the app uses the Yahoo-Finance-style `BHP.AX` ticker so imported legs
+  /// share an `Instrument.id` with anything registered through the picker.
+  private static func instrument(forASXCode code: String) -> Instrument {
+    Instrument.stock(ticker: "\(code).AX", exchange: "ASX", name: code)
+  }
+
   private func makeTransferRecord(
     context: RowContext, isInbound: Bool
   ) -> ParsedRecord {
     let signedUnits = isInbound ? context.units : -context.units
     let leg = ParsedLeg(
       accountId: nil,
-      instrument: Instrument.stock(ticker: context.code, exchange: "ASX", name: context.code),
+      instrument: Self.instrument(forASXCode: context.code),
       quantity: signedUnits,
       type: isInbound ? .income : .expense,
       isInstrumentPlaceholder: false)


### PR DESCRIPTION
## Summary

- SelfWealth Movements CSV stores bare ASX codes (e.g. `BHP`), but the rest of the app keys stocks on the Yahoo-Finance-style suffix (`BHP.AX`, id `ASX:BHP.AX`) — the canonical form produced by `InstrumentSearchService` when the user adds an instrument through the picker. Without the suffix, an imported row constructed a fresh `ASX:BHP` instrument that never matched the user's existing holding, so aggregation, position pricing, and currency conversion all silently broke for SelfWealth-imported trades.
- Append `.AX` in `SelfWealthMovementsParser` via a small private helper that centralises the SelfWealth-specific exchange + ticker mapping. Updates the parser tests and the end-to-end `ImportStore` test to assert the canonical id; refreshes one stale doc comment that referenced the old form.

## Test plan

- [x] `just test-mac SelfWealthMovementsParserTests` — five existing assertions fail before the fix (RED), pass after (GREEN).
- [x] `just test-mac` — full macOS suite (1992 tests).
- [x] `just test-ios` — full iOS suite.
- [x] `just format-check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)