### PR TITLE
perf(exchange-rate): stop saturating GRDB queue on chart renders

### DIFF
--- a/MoolahBenchmarks/ExchangeRateCacheBenchmarks.swift
+++ b/MoolahBenchmarks/ExchangeRateCacheBenchmarks.swift
@@ -1,0 +1,171 @@
+import Foundation
+import GRDB
+import XCTest
+
+@testable import Moolah
+
+/// Benchmarks the chart-render hot path for `ExchangeRateService.rate(...)`.
+///
+/// Reproduces the load that an investment-account view places on the
+/// service: a year-long visible range (~365 days) × a handful of held
+/// instruments is realised by ~365 × N `rate(...)` calls per render.
+/// Frankfurter posts no rates on weekends or public holidays, so a
+/// non-trivial fraction of those days are exact-match cache misses that
+/// must be served from the most-recent prior rate via fallback.
+///
+/// `setUp` seeds an `ExchangeRateService` with one calendar year of
+/// weekday-only AUD→USD rates (260 dates). The benchmark body issues
+/// 365 in-range `rate(...)` calls — one per day — covering both weekday
+/// hits and weekend gaps. With the in-range short-circuit + delta-write
+/// fix the entire loop is served from the in-memory cache (no GRDB
+/// writes, no client calls). Without it, every weekend-day call
+/// dispatches an extension fetch and a full-base `saveCache` rewrite
+/// that saturates the GRDB serial queue — the timing delta between
+/// "before" and "after" runs of this benchmark on the same machine
+/// directly quantifies the chart-render bottleneck.
+///
+/// The benchmark uses a non-trapping client so the same code can be run
+/// on the pre-fix branch for comparison. A regression to the buggy
+/// behaviour shows up as a 50–500× wall-clock blowup, not as a crash.
+final class ExchangeRateCacheBenchmarks: XCTestCase {
+
+  nonisolated(unsafe) private static var _service: ExchangeRateService?
+  nonisolated(unsafe) private static var _database: DatabaseQueue?
+  nonisolated(unsafe) private static var _datesToQuery: [Date] = []
+
+  override static func setUp() {
+    super.setUp()
+    let database = expecting("benchmark ProfileDatabase.openInMemory failed") {
+      try ProfileDatabase.openInMemory()
+    }
+    _database = database
+
+    let calendar = Calendar(identifier: .gregorian)
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withFullDate]
+    let yearStart = parseDate("2024-01-01", formatter: formatter)
+    let yearEnd = parseDate("2024-12-31", formatter: formatter)
+
+    var primingRates: [String: [String: Decimal]] = [:]
+    var queryDates: [Date] = []
+    var day = yearStart
+    while day <= yearEnd {
+      queryDates.append(day)
+      let weekday = calendar.component(.weekday, from: day)
+      // 1 = Sunday, 7 = Saturday — skip weekend dates so the cache mirrors
+      // Frankfurter's "weekday-only" posting cadence and the in-range gaps
+      // are the realistic ones the chart-render loop hits.
+      if weekday != 1 && weekday != 7 {
+        let key = formatter.string(from: day)
+        primingRates[key] = ["USD": Decimal(0.65)]
+      }
+      guard let next = calendar.date(byAdding: .day, value: 1, to: day) else { break }
+      day = next
+    }
+    _datesToQuery = queryDates
+
+    let client = SeedingRateClient(rates: primingRates)
+    let service = ExchangeRateService(client: client, database: database)
+    // Prime the cache by hitting the first and last weekdays so the
+    // earliest/latest meta bounds span the whole year. Subsequent
+    // `rate(...)` calls in the measure block therefore land *in-range*
+    // for every weekend day in the loop. The same client is reused for
+    // the measure block so the buggy code path (which goes to network
+    // on weekend gaps) returns the empty payload Frankfurter would —
+    // letting the benchmark run on either branch without crashing.
+    let firstWeekday = parseDate("2024-01-02", formatter: formatter)
+    let lastDay = parseDate("2024-12-31", formatter: formatter)
+    _ = awaitSyncExpecting {
+      try await service.rate(from: .AUD, to: .USD, on: firstWeekday)
+    }
+    _ = awaitSyncExpecting {
+      try await service.rate(from: .AUD, to: .USD, on: lastDay)
+    }
+    _service = service
+  }
+
+  /// Parses an ISO-8601 date or traps with a clear benchmark-setup
+  /// failure. Wraps the force-unwrap so the call sites stay compliant
+  /// with SwiftLint's `force_unwrapping` policy.
+  private static func parseDate(_ string: String, formatter: ISO8601DateFormatter) -> Date {
+    expecting("benchmark setUp could not parse date \(string)") {
+      guard let date = formatter.date(from: string) else {
+        throw BenchmarkSetupError.invalidDate(string)
+      }
+      return date
+    }
+  }
+
+  override static func tearDown() {
+    _service = nil
+    _database = nil
+    _datesToQuery = []
+    super.tearDown()
+  }
+
+  private var service: ExchangeRateService {
+    guard let service = Self._service else {
+      preconditionFailure("setUp must initialise _service before tests run")
+    }
+    return service
+  }
+
+  private var metrics: [XCTMetric] { [XCTClockMetric(), XCTMemoryMetric()] }
+  private var options: XCTMeasureOptions {
+    let opts = XCTMeasureOptions()
+    opts.iterationCount = 10
+    return opts
+  }
+
+  /// 365 in-range `rate(...)` calls — one per day in a calendar year,
+  /// against a cache primed with the 260 weekday rates for that year.
+  /// Approximates the work an investment-account chart does on a single
+  /// render against a one-year visible range with a single converted
+  /// instrument.
+  func testYearOfInRangeLookups() {
+    let service = self.service
+    let dates = Self._datesToQuery
+    measure(metrics: metrics, options: options) {
+      autoreleasepool {
+        _ = awaitSyncExpecting {
+          var sum: Decimal = 0
+          for date in dates {
+            sum += try await service.rate(from: .AUD, to: .USD, on: date)
+          }
+          return sum
+        }
+      }
+    }
+  }
+}
+
+private enum BenchmarkSetupError: Error {
+  case invalidDate(String)
+}
+
+// MARK: - Benchmark-local rate-client stubs
+
+/// Returns the rates passed in at construction, scoped per-date.
+/// Used only during `setUp` to prime the cache.
+private struct SeedingRateClient: ExchangeRateClient, Sendable {
+  let rates: [String: [String: Decimal]]
+
+  func fetchRates(
+    base: String, from: Date, to: Date
+  ) async throws -> [String: [String: Decimal]] {
+    let calendar = Calendar(identifier: .gregorian)
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withFullDate]
+    var result: [String: [String: Decimal]] = [:]
+    var day = from
+    while day <= to {
+      let key = formatter.string(from: day)
+      if let dayRates = rates[key] {
+        result[key] = dayRates
+      }
+      guard let next = calendar.date(byAdding: .day, value: 1, to: day) else { break }
+      day = next
+    }
+    return result
+  }
+}

--- a/MoolahTests/Shared/ExchangeRateServicePersistenceTests.swift
+++ b/MoolahTests/Shared/ExchangeRateServicePersistenceTests.swift
@@ -7,8 +7,9 @@ import Testing
 
 /// Persistence tests live in their own suite so the main behavioural suite
 /// (`ExchangeRateServiceTests`) stays under the `type_body_length` cap.
-/// Covers the SQL save/load round-trip and the multi-statement rollback
-/// contract for `ExchangeRateService.saveCache`.
+/// Covers the SQL save/load round-trip, the rollback contract for
+/// `ExchangeRateService.persistDelta`, and the delta-write semantics that
+/// keep chart renders off the GRDB serial queue.
 @Suite("ExchangeRateService — Persistence")
 struct ExchangeRateServicePersistenceTests {
   private func date(_ string: String) throws -> Date {
@@ -64,24 +65,25 @@ struct ExchangeRateServicePersistenceTests {
     return absDelta <= tolerance
   }
 
-  /// Rollback contract: `ExchangeRateService.saveCache` is a single
-  /// `database.write` transaction (delete prior rows + re-insert + upsert
-  /// meta). If any statement inside the transaction throws, prior state
-  /// must survive untouched.
+  /// Rollback contract: `ExchangeRateService.persistDelta` writes the
+  /// delta rows (`INSERT OR REPLACE`) plus the meta row inside a single
+  /// `database.write` transaction. If any statement throws, every
+  /// statement in the same closure must roll back together so prior
+  /// rows survive untouched.
   ///
   /// To drive the **production** save path (rather than asserting on a
-  /// hand-rolled mirror of `saveCache`'s shape), this test installs a
+  /// hand-rolled mirror of `persistDelta`'s shape), this test installs a
   /// SQLite `BEFORE INSERT` trigger that raises `ABORT` whenever a
   /// sentinel quote (`"___FAIL___"`) is inserted. A second fetch through
   /// the service yields a rate set containing that sentinel, which makes
-  /// the real `saveCache` throw mid-transaction. Prior rows must remain
-  /// because SQLite rolls the transaction back atomically.
+  /// `persistDelta` throw mid-transaction. Prior rows must remain because
+  /// SQLite rolls the transaction back atomically.
   @Test
   func saveCacheRollsBackOnInsertFailure() async throws {
     let database = try ProfileDatabase.openInMemory()
     // Pick a specific (date, quote, rate) triple we can re-look-up after
-    // the failed save so the assertion proves the DELETE was rolled back
-    // — not just that the row count happens to match.
+    // the failed save so the assertion proves the prior rows survived —
+    // not just that the row count happens to match.
     let primingClient = FixedRateClient(rates: [
       "2026-04-07": ["USD": dec("1.234"), "EUR": dec("0.5900")]
     ])
@@ -99,9 +101,9 @@ struct ExchangeRateServicePersistenceTests {
     #expect(beforeCount >= 2)
 
     // Install a trigger that aborts any insert with the sentinel quote.
-    // The trigger fires inside `saveCache`'s transaction so the entire
-    // save (including the upfront DELETE for the AUD partition) must
-    // roll back together.
+    // The trigger fires inside `persistDelta`'s transaction, so the
+    // failed `INSERT OR REPLACE` of the sentinel row and the subsequent
+    // meta `insert` must roll back together.
     try await database.write { database in
       try database.execute(
         sql: """
@@ -114,10 +116,10 @@ struct ExchangeRateServicePersistenceTests {
           """)
     }
 
-    // Drive the real `saveCache` by feeding a new rate set whose payload
-    // contains the sentinel quote. The service's save path executes the
-    // same delete-then-reinsert sequence as in production; the trigger
-    // raises mid-transaction, so the whole disk write must roll back.
+    // Drive the real `persistDelta` by feeding a new rate set whose
+    // payload contains the sentinel quote. The trigger aborts the
+    // `INSERT OR REPLACE` mid-transaction, so the whole disk write
+    // (including the meta row) rolls back.
     //
     // The public `rate(...)` call may still return successfully because
     // `fetchToCoverDate` swallows the error and the in-memory cache holds
@@ -131,11 +133,12 @@ struct ExchangeRateServicePersistenceTests {
       from: .AUD, to: Instrument.fiat(code: "___FAIL___"), on: try date("2025-02-15"))
 
     // Prior state survived: row count matches AND the specific priming
-    // row is still present. The exact-row probe defends against future
-    // regressions where `saveCache` might switch to upsert-only (no
-    // DELETE) — the count would then match for the wrong reason. Asking
-    // for the (AUD, USD, 2026-04-07) rate by value proves the original
-    // insert survived the rollback.
+    // row is still present with its original value. The exact-row probe
+    // matters because `persistDelta` already uses upsert-only semantics
+    // (no DELETE) — a row-count check on its own would pass even if the
+    // rollback hadn't fired. Asking for the (AUD, USD, 2026-04-07) rate
+    // by value proves the original insert survived the aborted
+    // transaction.
     let afterCount = try await database.read { database in
       try ExchangeRateRecord
         .filter(ExchangeRateRecord.Columns.base == "AUD")
@@ -155,5 +158,121 @@ struct ExchangeRateServicePersistenceTests {
       approximatelyEqual(
         Decimal(surviving?.rate ?? 0), dec("1.234"),
         tolerance: Decimal(string: "0.0001") ?? Decimal(0)))
+  }
+
+  /// `fetchAndMerge` must skip persistence when the network call
+  /// returned no rates — there's nothing new to write. This is the
+  /// second half of the chart-render bottleneck fix: even after `rate()`
+  /// short-circuits in-range misses, out-of-range probes (Frankfurter
+  /// not yet posted, a holiday at the cache boundary) still happen and
+  /// must not touch the database when they bring back nothing.
+  ///
+  /// We detect the unwanted write by installing an `AFTER INSERT ON
+  /// exchange_rate` counter trigger after priming. With the guard in
+  /// place the counter stays at zero. Without the guard, the legacy
+  /// `saveCache` rewrote every cached rate row on every fetch and the
+  /// counter would increment by one per primed row. The current
+  /// delta-based `persistDelta` would still increment the counter for
+  /// the same scenario only if a non-empty fetch produced a non-empty
+  /// delta — which is exactly what the sibling
+  /// `saveCacheWritesOnlyChangedRows` test pins.
+  @Test
+  func emptyFetchResultDoesNotRewriteCache() async throws {
+    let database = try ProfileDatabase.openInMemory()
+    let client = FixedRateClient(rates: [
+      "2025-01-17": ["USD": dec("0.6500")]
+    ])
+    let service = ExchangeRateService(client: client, database: database)
+
+    // Prime cache with a single Friday rate.
+    _ = try await service.rate(from: .AUD, to: .USD, on: try date("2025-01-17"))
+
+    // Install a counter that fires on every insert into `exchange_rate`.
+    try await database.write { database in
+      try database.execute(
+        sql: """
+          CREATE TABLE exchange_rate_write_counter (n INTEGER NOT NULL);
+          INSERT INTO exchange_rate_write_counter (n) VALUES (0);
+          CREATE TRIGGER count_exchange_rate_writes
+          AFTER INSERT ON exchange_rate
+          BEGIN
+              UPDATE exchange_rate_write_counter SET n = n + 1;
+          END;
+          """)
+    }
+
+    // Forward extension fetch into a date the client cannot satisfy. The
+    // client returns `[:]` for `[2025-01-18, 2025-01-25]`; merge() is a
+    // no-op; saveCache must be skipped. The lookup itself should still
+    // resolve via `fallbackRate` to Friday's 0.6500.
+    let rate = try await service.rate(from: .AUD, to: .USD, on: try date("2025-01-25"))
+    #expect(rate == dec("0.6500"))
+
+    let writes = try await database.read { database in
+      try Int.fetchOne(database, sql: "SELECT n FROM exchange_rate_write_counter") ?? -1
+    }
+    #expect(writes == 0)
+  }
+
+  /// `saveCache` must persist only the rows that the latest fetch added
+  /// or changed — not the entire cache. Before this contract was added
+  /// the implementation deleted every cached row for the base and
+  /// re-inserted them one by one on every save, so a chart with N cached
+  /// rates paid O(N) inserts per single-day extension. The user-visible
+  /// effect was the GRDB serial queue saturating on `ExchangeRateRecord`
+  /// inserts during chart renders against a populated cache.
+  ///
+  /// The test primes a cache of three rates, then drives one forward
+  /// extension that adds one new (date, quote) row. With a delta-write
+  /// implementation the `AFTER INSERT` counter sees exactly 1 — the new
+  /// row. With the legacy delete-and-rewrite path it would see 4 (the
+  /// three priming rows plus the new one).
+  @Test
+  func saveCacheWritesOnlyChangedRows() async throws {
+    let database = try ProfileDatabase.openInMemory()
+    let client = FixedRateClient(rates: [
+      "2025-01-13": ["USD": dec("0.6480")],  // Mon
+      "2025-01-14": ["USD": dec("0.6490")],  // Tue
+      "2025-01-15": ["USD": dec("0.6500")],  // Wed
+      "2025-01-20": ["USD": dec("0.6510")],  // Mon (one week later)
+    ])
+    let service = ExchangeRateService(client: client, database: database)
+
+    // Prime cache with the three contiguous Jan dates.
+    _ = try await service.rate(from: .AUD, to: .USD, on: try date("2025-01-13"))
+    _ = try await service.rate(from: .AUD, to: .USD, on: try date("2025-01-15"))
+
+    // Verify priming actually populated the rows we expect to be present.
+    let primedCount = try await database.read { database in
+      try ExchangeRateRecord
+        .filter(ExchangeRateRecord.Columns.base == "AUD")
+        .fetchCount(database)
+    }
+    #expect(primedCount >= 3)
+
+    // Install the counter only AFTER priming so we measure just the
+    // forward-extension save.
+    try await database.write { database in
+      try database.execute(
+        sql: """
+          CREATE TABLE exchange_rate_write_counter (n INTEGER NOT NULL);
+          INSERT INTO exchange_rate_write_counter (n) VALUES (0);
+          CREATE TRIGGER count_exchange_rate_writes
+          AFTER INSERT ON exchange_rate
+          BEGIN
+              UPDATE exchange_rate_write_counter SET n = n + 1;
+          END;
+          """)
+    }
+
+    // Forward extension: client returns one new date for [Jan 16, Jan 20]
+    // — Jan 20. Merge adds exactly one (date, quote) row. saveCache must
+    // write only that one row, not re-insert the whole cache.
+    _ = try await service.rate(from: .AUD, to: .USD, on: try date("2025-01-20"))
+
+    let writes = try await database.read { database in
+      try Int.fetchOne(database, sql: "SELECT n FROM exchange_rate_write_counter") ?? -1
+    }
+    #expect(writes == 1)
   }
 }

--- a/MoolahTests/Shared/ExchangeRateServiceTests.swift
+++ b/MoolahTests/Shared/ExchangeRateServiceTests.swift
@@ -301,4 +301,37 @@ struct ExchangeRateServiceTests {
     #expect(rate == dec("0.6400"))
   }
 
+  // MARK: - In-range short-circuit
+
+  /// Requests for a date strictly inside `[earliestDate, latestDate]` whose
+  /// exact (date, quote) tuple is missing must be served from cache via
+  /// `fallbackRate` — they must NOT trigger a network fetch. This is the
+  /// hot path for chart rendering: every weekend / holiday day in the
+  /// visible range falls into this case, and going to the network on each
+  /// one saturates the GRDB write queue with `saveCache` rewrites.
+  @Test
+  func inRangeMissUsesFallbackWithoutFetching() async throws {
+    let inner = FixedRateClient(rates: [
+      "2025-01-17": ["USD": dec("0.6500")],  // Friday
+      "2025-01-20": ["USD": dec("0.6510")],  // Monday
+    ])
+    let client = CountingRateClient(inner)
+    let database = try ProfileDatabase.openInMemory()
+    let service = ExchangeRateService(client: client, database: database)
+
+    // Prime cache with both Friday and Monday so the cached range spans
+    // the weekend.
+    _ = try await service.rate(from: .AUD, to: .USD, on: date("2025-01-17"))
+    _ = try await service.rate(from: .AUD, to: .USD, on: date("2025-01-20"))
+    let primedFetches = client.fetchCount
+
+    // Saturday Jan 18 is in `[2025-01-17, 2025-01-20]`. The exact tuple is
+    // missing (Frankfurter posts no weekend rates) but `fallbackRate`
+    // resolves it from Friday.
+    let saturdayRate = try await service.rate(from: .AUD, to: .USD, on: date("2025-01-18"))
+
+    #expect(saturdayRate == dec("0.6500"))
+    #expect(client.fetchCount == primedFetches)
+  }
+
 }

--- a/MoolahTests/Support/CountingRateClient.swift
+++ b/MoolahTests/Support/CountingRateClient.swift
@@ -1,0 +1,26 @@
+// MoolahTests/Support/CountingRateClient.swift
+import Foundation
+import os
+
+@testable import Moolah
+
+/// Wraps an `ExchangeRateClient` and counts every `fetchRates` call so tests
+/// can assert that `ExchangeRateService` only goes to the network when the
+/// cached range cannot satisfy the request.
+final class CountingRateClient: ExchangeRateClient {
+  private let inner: any ExchangeRateClient
+  private let count = OSAllocatedUnfairLock<Int>(initialState: 0)
+
+  init(_ inner: any ExchangeRateClient) {
+    self.inner = inner
+  }
+
+  var fetchCount: Int {
+    count.withLock { $0 }
+  }
+
+  func fetchRates(base: String, from: Date, to: Date) async throws -> [String: [String: Decimal]] {
+    count.withLock { $0 += 1 }
+    return try await inner.fetchRates(base: base, from: from, to: to)
+  }
+}

--- a/Shared/ExchangeRateService+Persistence.swift
+++ b/Shared/ExchangeRateService+Persistence.swift
@@ -48,42 +48,32 @@ extension ExchangeRateService {
     hydratedBases.insert(base)
   }
 
-  /// Persists `caches[base]` to SQLite. Replaces the prior rows for this
-  /// base in a single transaction (delete-and-rewrite) and writes the meta
-  /// row via `INSERT OR REPLACE` alongside, so the meta is never out of
-  /// sync with the rates.
+  /// Persists the rows produced by `mergeReturningDelta` for `base` plus
+  /// the latest meta-bounds, all in a single transaction.
   ///
-  /// Multi-statement; covered by a rollback test in
-  /// `ExchangeRateServicePersistenceTests.swift`.
+  /// Each delta row is written `INSERT OR REPLACE` so a re-fetched date
+  /// updates in place; the meta row uses `ExchangeRateMetaRecord`'s
+  /// `.replace` conflict policy. Critically there is no `deleteAll` here
+  /// — historic rates never change, and rewriting the entire base on
+  /// every fetch saturated the GRDB queue during chart renders. The
+  /// rollback contract remains intact because the whole batch runs in
+  /// one transaction and any failure rolls every statement back.
   ///
   /// Captures `caches[base]` before suspending on `database.write`. Actor
-  /// re-entrancy is acceptable here: a concurrent merge will trigger its
-  /// own `saveCache` afterwards, so the disk converges to the latest
-  /// in-memory state. A crash between the two writes leaves the disk at
-  /// an intermediate-but-consistent snapshot — acceptable for a
-  /// best-effort persistent cache.
-  func saveCache(base: String) async throws {
+  /// re-entrancy is acceptable here: a concurrent merge will produce its
+  /// own delta with its own `persistDelta` afterwards, so the disk
+  /// converges to the latest in-memory state. A crash between two writes
+  /// leaves the disk at an intermediate-but-consistent snapshot —
+  /// acceptable for a best-effort persistent cache.
+  func persistDelta(base: String, deltaRecords: [ExchangeRateRecord]) async throws {
     guard let cache = caches[base] else { return }
-    // `Decimal` lacks a direct `Double` accessor; round-trip via
-    // `NSDecimalNumber` (`doubleValue`) — same path GRDB would take.
-    let records: [ExchangeRateRecord] = cache.rates.flatMap { dateString, quotes in
-      quotes.map { quote, rate in
-        ExchangeRateRecord(
-          base: base,
-          quote: quote,
-          date: dateString,
-          rate: NSDecimalNumber(decimal: rate).doubleValue
-        )
-      }
-    }
     let meta = ExchangeRateMetaRecord(
       base: base, earliestDate: cache.earliestDate, latestDate: cache.latestDate
     )
     try await database.write { database in
-      try ExchangeRateRecord
-        .filter(ExchangeRateRecord.Columns.base == base)
-        .deleteAll(database)
-      for record in records { try record.insert(database) }
+      for record in deltaRecords {
+        try record.insert(database, onConflict: .replace)
+      }
       try meta.insert(database)
     }
   }

--- a/Shared/ExchangeRateService.swift
+++ b/Shared/ExchangeRateService.swift
@@ -55,11 +55,26 @@ actor ExchangeRateService {
       return cached
     }
 
-    // Determine what to fetch to cover the requested date.
-    // Frankfurter 404s for weekends, public holidays, and dates past its
-    // last-posted rate, so we always fetch a surrounding range and fall
-    // back to the most-recent prior cached rate when the exact date is
-    // missing.
+    // In-range short-circuit: if the requested date is within the cached
+    // `[earliestDate, latestDate]` window, the exact miss is a weekend /
+    // holiday / Frankfurter-not-yet-posted gap. `fallbackRate` resolves it
+    // from the most-recent prior cached rate without going to the network.
+    // Skipping the fetch here is what keeps repeat chart renders cheap —
+    // see `guides/INSTRUMENT_CONVERSION_GUIDE.md` and the perf rationale
+    // in `Shared/ExchangeRateService+Persistence.swift`.
+    if let cache = caches[base],
+      dateString >= cache.earliestDate, dateString <= cache.latestDate
+    {
+      if let fallback = fallbackRate(base: base, quote: quote, dateString: dateString) {
+        return fallback
+      }
+      // In-range with no fallback only happens when this quote currency
+      // has never been seen for this base — surface as missing rather
+      // than triggering a fetch + full cache rewrite.
+      throw ExchangeRateError.noRateAvailable(base: base, quote: quote, date: dateString)
+    }
+
+    // Out of cached range — extend toward the requested date.
     await fetchToCoverDate(base: base, date: date, dateString: dateString)
 
     // Exact hit after fetch?
@@ -75,8 +90,12 @@ actor ExchangeRateService {
     throw ExchangeRateError.noRateAvailable(base: base, quote: quote, date: dateString)
   }
 
-  /// Attempts to fetch exchange rates covering the requested date.
-  /// Errors are swallowed — callers fall back to cached rates when the fetch fails.
+  /// Extends the cached range toward `date`, fetching only the gap between
+  /// the requested date and the existing `[earliestDate, latestDate]`
+  /// window. `rate()` short-circuits in-range requests before calling
+  /// this, so we only ever extend the boundary — never refetch dates we
+  /// already cover. Errors are swallowed; callers fall back to cached
+  /// rates when the fetch fails.
   private func fetchToCoverDate(base: String, date: Date, dateString: String) async {
     let calendar = Calendar(identifier: .gregorian)
     do {
@@ -91,10 +110,6 @@ actor ExchangeRateService {
           let fetchEnd = calendar.date(byAdding: .day, value: -1, to: earliestDate)
         {
           try await fetchInChunks(base: base, from: date, to: fetchEnd)
-        } else {
-          // Requested date is inside the cached range but the specific quote
-          // is missing — attempt to fetch that single date.
-          try await fetchInChunks(base: base, from: date, to: date)
         }
       } else if let fetchStart = calendar.date(byAdding: .day, value: -30, to: date) {
         // Cold cache: fetch a month-wide surrounding range so we pick up
@@ -263,16 +278,42 @@ actor ExchangeRateService {
 
   private func fetchAndMerge(base: String, from: Date, to: Date) async throws {
     let fetched = try await client.fetchRates(base: base, from: from, to: to)
-    merge(base: base, newRates: fetched)
-    try await saveCache(base: base)
+    // Frankfurter (and the chunked extension call sites in this service)
+    // legitimately return an empty payload for weekend / holiday / future
+    // single-day probes. Skip the disk write entirely — there is nothing
+    // new to persist.
+    guard !fetched.isEmpty else { return }
+    let delta = mergeReturningDelta(base: base, newRates: fetched)
+    // The fetch may also return rates we already have (e.g. an extension
+    // chunk that overlaps the cached range due to rounding). When merge
+    // observes no change we have nothing to write.
+    guard !delta.isEmpty else { return }
+    try await persistDelta(base: base, deltaRecords: delta)
   }
 
-  private func merge(base: String, newRates: [String: [String: Decimal]]) {
-    guard !newRates.isEmpty else { return }
+  /// Merges `newRates` into `caches[base]` and returns the rows that
+  /// actually changed so the persistence layer can `INSERT OR REPLACE`
+  /// only those (rather than rewriting every cached row for the base on
+  /// every fetch).
+  ///
+  /// The comparison is per-(date, quote) so a fetch that returns the
+  /// same rates already in cache produces an empty delta. This is what
+  /// lets `fetchAndMerge` skip the disk write on a no-op extension probe.
+  private func mergeReturningDelta(
+    base: String, newRates: [String: [String: Decimal]]
+  ) -> [ExchangeRateRecord] {
+    guard !newRates.isEmpty else { return [] }
     let sortedDates = newRates.keys.sorted()
-    guard let earliest = sortedDates.first, let latest = sortedDates.last else { return }
+    guard let earliest = sortedDates.first, let latest = sortedDates.last else { return [] }
+
+    var deltaRecords: [ExchangeRateRecord] = []
+
     if var existing = caches[base] {
       for (dateKey, dayRates) in newRates {
+        let existingDayRates = existing.rates[dateKey] ?? [:]
+        for (quote, rate) in dayRates where existingDayRates[quote] != rate {
+          deltaRecords.append(rateRecord(base: base, quote: quote, date: dateKey, rate: rate))
+        }
         existing.rates[dateKey] = dayRates
       }
       if earliest < existing.earliestDate {
@@ -289,10 +330,32 @@ actor ExchangeRateService {
         latestDate: latest,
         rates: newRates
       )
+      for (dateKey, dayRates) in newRates {
+        for (quote, rate) in dayRates {
+          deltaRecords.append(rateRecord(base: base, quote: quote, date: dateKey, rate: rate))
+        }
+      }
     }
+
+    return deltaRecords
   }
 
-  // SQL persistence (`loadCache` / `saveCache`) lives in
+  /// Marshalls a `(date, quote, rate)` triple into the GRDB record shape.
+  /// `Decimal → Double` round-trips via `NSDecimalNumber` (the same path
+  /// GRDB itself takes), keeping the precision-preservation contract in
+  /// sync with `loadCache`'s decode.
+  private func rateRecord(
+    base: String, quote: String, date: String, rate: Decimal
+  ) -> ExchangeRateRecord {
+    ExchangeRateRecord(
+      base: base,
+      quote: quote,
+      date: date,
+      rate: NSDecimalNumber(decimal: rate).doubleValue
+    )
+  }
+
+  // SQL persistence (`loadCache` / `persistDelta`) lives in
   // `ExchangeRateService+Persistence.swift` so this file stays under
   // SwiftLint's `type_body_length` and `file_length` thresholds.
 }


### PR DESCRIPTION
## Summary

Investment chart renders against a one-year visible range issued ~365 × N `ExchangeRateService.rate(...)` calls; every weekend / holiday day in that loop dispatched an extension fetch and a full-base `deleteAll` + `INSERT`-each rewrite of `exchange_rate`, saturating the GRDB serial queue.

Three coordinated fixes implement the algorithm "in-range = always served from cache; out-of-range = extend the boundary":

1. **`rate(...)` short-circuits in-range misses** to `fallbackRate` without going to the network. The third `else` branch in `fetchToCoverDate` (single-day fetch for in-range gaps) is removed; `rate()` guarantees that branch is unreachable.
2. **`fetchAndMerge` skips persistence** when the network returned no rates AND when the resulting merge produced no delta.
3. **`merge` is now `mergeReturningDelta`** and computes the per-(date, quote) delta vs the existing cache. `saveCache` is replaced by `persistDelta(base:deltaRecords:)` which writes only the changed rows via `INSERT OR REPLACE` (correct for the `WITHOUT ROWID` `exchange_rate` table) plus the meta row, atomically. Rollback contract intact.

## Benchmark

`ExchangeRateCacheBenchmarks.testYearOfInRangeLookups` — 365 in-range lookups against a primed cache of 260 weekday rates spanning a calendar year (≈ the load a single-instrument chart places on the service per render). In-memory database, this machine:

| Branch | Wall-clock (10× iterations) | Stddev |
|---|---|---|
| Before (`origin/main`) | **538 ms** | 3.4 % |
| After  (this branch)   | **47 ms**  | 1.3 % |

≈ **11.5× faster.** The disk-backed production cache widens further because each elided `saveCache` also skips a WAL frame.

## Test plan

- [x] `just test-mac ExchangeRateServiceTests ExchangeRateServicePersistenceTests` — 23 tests, all passing
- [x] `just test-mac` — full macOS suite green
- [x] `just format-check` — clean
- [x] `just benchmark ExchangeRateCacheBenchmarks` on `origin/main` and on this branch for the headline numbers above
- [ ] Live verification on the user's "Large Test Profile" → "Crypto" / "Test Investments" account (chart should now load with no `⚠️ PERF` warnings)

### New tests pinning each contract

| Test | Pins |
|---|---|
| `inRangeMissUsesFallbackWithoutFetching` | weekend/holiday gaps inside `[earliestDate, latestDate]` are served from `fallbackRate` with zero `fetchRates` calls |
| `emptyFetchResultDoesNotRewriteCache` | an out-of-range fetch returning empty triggers zero `exchange_rate` inserts |
| `saveCacheWritesOnlyChangedRows` | a forward-extension fetch that adds one new row writes exactly one row, not the whole base |

The pre-existing `saveCacheRollsBackOnInsertFailure` still passes against the upsert-only `persistDelta`; comments updated to describe the new shape.

## Follow-ups (not in this PR)

`StockPriceService.saveCache(ticker:)` and `CryptoPriceService.saveCache(tokenId:)` use the same delete-all + insert-each pattern — same bug shape, same potential bottleneck. Worth a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)