### PR TITLE
fix(reviewer-sweep): apply critical reviewer findings

### DIFF
--- a/App/PrivacyInfo.xcprivacy
+++ b/App/PrivacyInfo.xcprivacy
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>NSPrivacyTracking</key>
+    <false/>
+    <key>NSPrivacyTrackingDomains</key>
+    <array/>
+    <key>NSPrivacyCollectedDataTypes</key>
+    <array/>
+    <key>NSPrivacyAccessedAPITypes</key>
+    <array>
+        <dict>
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+                <string>CA92.1</string>
+            </array>
+        </dict>
+        <dict>
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+                <string>C617.1</string>
+            </array>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/Features/Analysis/Views/AnalysisView.swift
+++ b/Features/Analysis/Views/AnalysisView.swift
@@ -192,7 +192,7 @@ struct ForecastPicker: View {
 
 @MainActor
 private func seedAnalysisPreview(
-  backend: CloudKitBackend,
+  backend: any BackendProvider,
   categoryStore: CategoryStore
 ) async {
   let account = Account(id: UUID(), name: "Checking", type: .bank, instrument: .AUD)

--- a/Features/Analysis/Views/NetWorthGraphCard+Marks.swift
+++ b/Features/Analysis/Views/NetWorthGraphCard+Marks.swift
@@ -1,0 +1,126 @@
+import Charts
+import SwiftUI
+
+/// Per-series chart-content builders. Split out so the main view's body
+/// stays focused on layout / accessibility / state, and the
+/// `type_body_length` budget isn't dominated by Swift Charts plumbing.
+extension NetWorthGraphCard {
+  @ChartContentBuilder var availableFundsMarks: some ChartContent {
+    if visibleSeries.contains(.availableFunds) {
+      ForEach(actualBalances) { balance in
+        LineMark(
+          x: .value("Date", balance.date),
+          y: .value("Amount", balance.availableFunds.doubleValue),
+          series: .value("Series", "Available Funds")
+        )
+        .foregroundStyle(.green)
+        .lineStyle(StrokeStyle(lineWidth: 2))
+        .interpolationMethod(.stepEnd)
+      }
+      ForEach(forecastBalances) { balance in
+        LineMark(
+          x: .value("Date", balance.date),
+          y: .value("Amount", balance.availableFunds.doubleValue),
+          series: .value("Series", "Available Funds Forecast")
+        )
+        .foregroundStyle(.green.opacity(0.5))
+        .lineStyle(StrokeStyle(lineWidth: 1, dash: [3, 3]))
+        .interpolationMethod(.stepEnd)
+      }
+    }
+  }
+
+  @ChartContentBuilder var currentFundsMarks: some ChartContent {
+    if visibleSeries.contains(.currentFunds) {
+      ForEach(actualBalances) { balance in
+        LineMark(
+          x: .value("Date", balance.date),
+          y: .value("Amount", balance.balance.doubleValue),
+          series: .value("Series", "Current Funds")
+        )
+        .foregroundStyle(.orange)
+        .lineStyle(StrokeStyle(lineWidth: 2))
+        .interpolationMethod(.stepEnd)
+      }
+      ForEach(forecastBalances) { balance in
+        LineMark(
+          x: .value("Date", balance.date),
+          y: .value("Amount", balance.balance.doubleValue),
+          series: .value("Series", "Current Funds Forecast")
+        )
+        .foregroundStyle(.orange.opacity(0.5))
+        .lineStyle(StrokeStyle(lineWidth: 1, dash: [3, 3]))
+        .interpolationMethod(.stepEnd)
+      }
+    }
+  }
+
+  @ChartContentBuilder var investedAmountMarks: some ChartContent {
+    if visibleSeries.contains(.investedAmount) {
+      ForEach(actualBalances) { balance in
+        LineMark(
+          x: .value("Date", balance.date),
+          y: .value("Amount", balance.investments.doubleValue),
+          series: .value("Series", "Invested Amount")
+        )
+        .foregroundStyle(.purple)
+        .lineStyle(StrokeStyle(lineWidth: 2))
+        .interpolationMethod(.stepEnd)
+      }
+    }
+  }
+
+  @ChartContentBuilder var investmentValueMarks: some ChartContent {
+    if visibleSeries.contains(.investmentValue) {
+      ForEach(actualBalances.filter { $0.investmentValue != nil }) { balance in
+        LineMark(
+          x: .value("Date", balance.date),
+          y: .value("Amount", (balance.investmentValue?.doubleValue) ?? 0),
+          series: .value("Series", "Investment Value")
+        )
+        .foregroundStyle(.indigo)
+        .lineStyle(StrokeStyle(lineWidth: 2))
+        .interpolationMethod(.stepEnd)
+      }
+    }
+  }
+
+  @ChartContentBuilder var netWorthMarks: some ChartContent {
+    if visibleSeries.contains(.netWorth) {
+      ForEach(actualBalances) { balance in
+        LineMark(
+          x: .value("Date", balance.date),
+          y: .value("Amount", balance.netWorth.doubleValue),
+          series: .value("Series", "Net Worth")
+        )
+        .foregroundStyle(.blue)
+        .lineStyle(StrokeStyle(lineWidth: 2))
+        .interpolationMethod(.stepEnd)
+      }
+      ForEach(forecastBalances) { balance in
+        LineMark(
+          x: .value("Date", balance.date),
+          y: .value("Amount", balance.netWorth.doubleValue),
+          series: .value("Series", "Net Worth Forecast")
+        )
+        .foregroundStyle(.blue.opacity(0.5))
+        .lineStyle(StrokeStyle(lineWidth: 1, dash: [3, 3]))
+        .interpolationMethod(.stepEnd)
+      }
+    }
+  }
+
+  @ChartContentBuilder var bestFitMarks: some ChartContent {
+    if visibleSeries.contains(.bestFit) {
+      ForEach(actualBalances.filter { $0.bestFit != nil }) { balance in
+        LineMark(
+          x: .value("Date", balance.date),
+          y: .value("Amount", (balance.bestFit?.doubleValue) ?? 0),
+          series: .value("Series", "Best Fit")
+        )
+        .foregroundStyle(.gray)
+        .lineStyle(StrokeStyle(lineWidth: 1, dash: [5, 5]))
+      }
+    }
+  }
+}

--- a/Features/Analysis/Views/NetWorthGraphCard.swift
+++ b/Features/Analysis/Views/NetWorthGraphCard.swift
@@ -31,7 +31,9 @@ struct NetWorthGraphCard: View {
   let balances: [DailyBalance]
 
   @State private var selectedDate: Date?
-  @State private var visibleSeries: Set<ChartSeries> = Set(
+  // Internal so the chart-content builders in `+Marks.swift` can read
+  // it without the file going over `type_body_length`.
+  @State var visibleSeries: Set<ChartSeries> = Set(
     ChartSeries.allCases.filter(\.enabledByDefault))
 
   var body: some View {
@@ -110,7 +112,26 @@ struct NetWorthGraphCard: View {
     }
     .chartXSelection(value: $selectedDate)
     .frame(height: 300)
-    .accessibilityLabel("Net worth graph showing financial data over time")
+    .accessibilityLabel(chartAccessibilityLabel)
+  }
+
+  /// Summarises the chart's range and current net worth so VoiceOver
+  /// gives a useful financial snapshot rather than "Net worth graph".
+  /// Empty state is handled by `emptyState` (the chart isn't built when
+  /// `balances` is empty), so we can read first / last unconditionally.
+  private var chartAccessibilityLabel: String {
+    guard let first = actualBalances.first, let last = actualBalances.last else {
+      return "Net worth graph"
+    }
+    let dateFormat: Date.FormatStyle = .dateTime.month(.abbreviated).day().year()
+    let rangeText: String
+    if first.date == last.date {
+      rangeText = first.date.formatted(dateFormat)
+    } else {
+      rangeText = "\(first.date.formatted(dateFormat)) to \(last.date.formatted(dateFormat))"
+    }
+    let currentNet = last.netWorth.formatted
+    return "Net worth graph from \(rangeText). Current net worth \(currentNet)."
   }
 
   private var seriesToggles: some View {
@@ -138,7 +159,9 @@ struct NetWorthGraphCard: View {
                 .foregroundStyle(visibleSeries.contains(series) ? .primary : .tertiary)
             }
           }
-          .buttonStyle(.plain)
+          // `.borderless` (vs `.plain`) preserves keyboard activation
+          // on macOS — Space toggles the series instead of being eaten.
+          .buttonStyle(.borderless)
           .accessibilityLabel("\(series.rawValue) series")
           .accessibilityAddTraits(visibleSeries.contains(series) ? .isSelected : [])
           .accessibilityHint("Double tap to toggle visibility")
@@ -148,124 +171,7 @@ struct NetWorthGraphCard: View {
     .font(.caption)
   }
 
-  @ChartContentBuilder private var availableFundsMarks: some ChartContent {
-    if visibleSeries.contains(.availableFunds) {
-      ForEach(actualBalances) { balance in
-        LineMark(
-          x: .value("Date", balance.date),
-          y: .value("Amount", balance.availableFunds.doubleValue),
-          series: .value("Series", "Available Funds")
-        )
-        .foregroundStyle(.green)
-        .lineStyle(StrokeStyle(lineWidth: 2))
-        .interpolationMethod(.stepEnd)
-      }
-      ForEach(forecastBalances) { balance in
-        LineMark(
-          x: .value("Date", balance.date),
-          y: .value("Amount", balance.availableFunds.doubleValue),
-          series: .value("Series", "Available Funds Forecast")
-        )
-        .foregroundStyle(.green.opacity(0.5))
-        .lineStyle(StrokeStyle(lineWidth: 1, dash: [3, 3]))
-        .interpolationMethod(.stepEnd)
-      }
-    }
-  }
-
-  @ChartContentBuilder private var currentFundsMarks: some ChartContent {
-    if visibleSeries.contains(.currentFunds) {
-      ForEach(actualBalances) { balance in
-        LineMark(
-          x: .value("Date", balance.date),
-          y: .value("Amount", balance.balance.doubleValue),
-          series: .value("Series", "Current Funds")
-        )
-        .foregroundStyle(.orange)
-        .lineStyle(StrokeStyle(lineWidth: 2))
-        .interpolationMethod(.stepEnd)
-      }
-      ForEach(forecastBalances) { balance in
-        LineMark(
-          x: .value("Date", balance.date),
-          y: .value("Amount", balance.balance.doubleValue),
-          series: .value("Series", "Current Funds Forecast")
-        )
-        .foregroundStyle(.orange.opacity(0.5))
-        .lineStyle(StrokeStyle(lineWidth: 1, dash: [3, 3]))
-        .interpolationMethod(.stepEnd)
-      }
-    }
-  }
-
-  @ChartContentBuilder private var investedAmountMarks: some ChartContent {
-    if visibleSeries.contains(.investedAmount) {
-      ForEach(actualBalances) { balance in
-        LineMark(
-          x: .value("Date", balance.date),
-          y: .value("Amount", balance.investments.doubleValue),
-          series: .value("Series", "Invested Amount")
-        )
-        .foregroundStyle(.purple)
-        .lineStyle(StrokeStyle(lineWidth: 2))
-        .interpolationMethod(.stepEnd)
-      }
-    }
-  }
-
-  @ChartContentBuilder private var investmentValueMarks: some ChartContent {
-    if visibleSeries.contains(.investmentValue) {
-      ForEach(actualBalances.filter { $0.investmentValue != nil }) { balance in
-        LineMark(
-          x: .value("Date", balance.date),
-          y: .value("Amount", (balance.investmentValue?.doubleValue) ?? 0),
-          series: .value("Series", "Investment Value")
-        )
-        .foregroundStyle(.indigo)
-        .lineStyle(StrokeStyle(lineWidth: 2))
-        .interpolationMethod(.stepEnd)
-      }
-    }
-  }
-
-  @ChartContentBuilder private var netWorthMarks: some ChartContent {
-    if visibleSeries.contains(.netWorth) {
-      ForEach(actualBalances) { balance in
-        LineMark(
-          x: .value("Date", balance.date),
-          y: .value("Amount", balance.netWorth.doubleValue),
-          series: .value("Series", "Net Worth")
-        )
-        .foregroundStyle(.blue)
-        .lineStyle(StrokeStyle(lineWidth: 2))
-        .interpolationMethod(.stepEnd)
-      }
-      ForEach(forecastBalances) { balance in
-        LineMark(
-          x: .value("Date", balance.date),
-          y: .value("Amount", balance.netWorth.doubleValue),
-          series: .value("Series", "Net Worth Forecast")
-        )
-        .foregroundStyle(.blue.opacity(0.5))
-        .lineStyle(StrokeStyle(lineWidth: 1, dash: [3, 3]))
-        .interpolationMethod(.stepEnd)
-      }
-    }
-  }
-
-  @ChartContentBuilder private var bestFitMarks: some ChartContent {
-    if visibleSeries.contains(.bestFit) {
-      ForEach(actualBalances.filter { $0.bestFit != nil }) { balance in
-        LineMark(
-          x: .value("Date", balance.date),
-          y: .value("Amount", (balance.bestFit?.doubleValue) ?? 0),
-          series: .value("Series", "Best Fit")
-        )
-        .foregroundStyle(.gray)
-        .lineStyle(StrokeStyle(lineWidth: 1, dash: [5, 5]))
-      }
-    }
-  }
+  // Per-series chart-content builders live in `NetWorthGraphCard+Marks.swift`.
 
   private var availableSeries: [ChartSeries] {
     var series: [ChartSeries] = [.availableFunds, .currentFunds, .netWorth]
@@ -285,11 +191,12 @@ struct NetWorthGraphCard: View {
     return series
   }
 
-  private var actualBalances: [DailyBalance] {
+  // Internal so the per-series builders in `+Marks.swift` can read them.
+  var actualBalances: [DailyBalance] {
     balances.filter { !$0.isForecast }
   }
 
-  private var forecastBalances: [DailyBalance] {
+  var forecastBalances: [DailyBalance] {
     balances.filter { $0.isForecast }
   }
 }

--- a/Features/Analysis/Views/UpcomingTransactionsCard.swift
+++ b/Features/Analysis/Views/UpcomingTransactionsCard.swift
@@ -247,7 +247,7 @@ private struct SimpleTransactionRow: View {
 }
 
 @MainActor
-private func seedUpcomingPreview(backend: CloudKitBackend, store: TransactionStore) async {
+private func seedUpcomingPreview(backend: any BackendProvider, store: TransactionStore) async {
   let account = Account(id: UUID(), name: "Test Account", type: .bank, instrument: .AUD)
   _ = try? await backend.accounts.create(
     account,

--- a/Features/Earmarks/Views/EarmarkDetailView.swift
+++ b/Features/Earmarks/Views/EarmarkDetailView.swift
@@ -120,6 +120,7 @@ struct EarmarkDetailView: View {
       balance.isPositive
       ? Double(truncating: (balance.quantity / goal.quantity) as NSDecimalNumber)
       : 0.0
+    let percentComplete = Int(min(progress, 1.0) * 100)
     return VStack(spacing: 4) {
       ProgressView(value: min(progress, 1.0)) {
         HStack {
@@ -131,8 +132,13 @@ struct EarmarkDetailView: View {
         }
       }
       .tint(progress >= 1.0 ? .green : .blue)
+      .accessibilityLabel(
+        "Savings goal: \(balance.formatted) of \(goal.formatted), "
+          + "\(percentComplete)% complete"
+      )
       savingsDateRow
     }
+    .accessibilityElement(children: .combine)
   }
 
   private func summaryItem(label: String, amount: InstrumentAmount) -> some View {
@@ -203,7 +209,7 @@ struct EarmarkDetailView: View {
 
 @MainActor
 private func seedEarmarkDetailPreview(
-  backend: CloudKitBackend,
+  backend: any BackendProvider,
   earmark: Earmark,
   earmarkStore: EarmarkStore,
   store: TransactionStore

--- a/Features/Earmarks/Views/EarmarksView.swift
+++ b/Features/Earmarks/Views/EarmarksView.swift
@@ -280,7 +280,7 @@ struct EarmarksView: View {
 }
 
 @MainActor
-private func seedEarmarksPreview(backend: CloudKitBackend, earmarkStore: EarmarkStore) async {
+private func seedEarmarksPreview(backend: any BackendProvider, earmarkStore: EarmarkStore) async {
   _ = try? await backend.earmarks.create(
     Earmark(
       name: "Holiday Fund",

--- a/Features/Import/Views/ImportRulesSettingsView.swift
+++ b/Features/Import/Views/ImportRulesSettingsView.swift
@@ -8,11 +8,13 @@ struct ImportRulesSettingsView: View {
   @Environment(ProfileSession.self) private var session
   @State private var editingRule: ImportRule?
   @State private var showingAddSheet = false
+  @State private var selectedRuleId: ImportRule.ID?
 
   var body: some View {
-    List {
+    List(selection: $selectedRuleId) {
       ForEach(ruleStore.rules) { rule in
-        RuleRow(rule: rule) { editingRule = rule }
+        RuleRow(rule: rule)
+          .tag(rule.id)
       }
       .onMove { source, destination in
         var ids = ruleStore.rules.map(\.id)
@@ -24,6 +26,17 @@ struct ImportRulesSettingsView: View {
         for id in ids {
           Task { await ruleStore.delete(id: id) }
         }
+      }
+    }
+    // List selection + primaryAction wires Return / double-click to
+    // open the editor — the same keyboard path the sidebar uses.
+    .contextMenu(forSelectionType: ImportRule.ID.self) { _ in
+      // Empty context menu items — primary action handles the open.
+      // Returning no buttons keeps the right-click menu absent rather
+      // than showing a stub item.
+    } primaryAction: { ids in
+      if let id = ids.first, let rule = ruleStore.rules.first(where: { $0.id == id }) {
+        editingRule = rule
       }
     }
     .overlay {
@@ -80,7 +93,6 @@ struct ImportRulesSettingsView: View {
 
 private struct RuleRow: View {
   let rule: ImportRule
-  let onEdit: () -> Void
   @Environment(ImportRuleStore.self) private var ruleStore
 
   var body: some View {
@@ -112,17 +124,11 @@ private struct RuleRow: View {
         }
       }
       Spacer()
-      // Tab-reachable keyboard path for macOS users; redundant with the
-      // whole-row tap on mouse/touch.
-      Button("Edit") { onEdit() }
-        .buttonStyle(.borderless)
     }
-    // Whole-row click target: a bare `.onTapGesture` on the VStack only
-    // responded to taps on the label text, which left most of the row
-    // dead. `.contentShape(Rectangle())` + row-level tap routes every
-    // click — including on the trailing `Spacer()` — to the editor.
+    // Make the full row a hit target so a click anywhere in the row
+    // updates the List's selection (the editor opens via Return /
+    // double-click via `contextMenu(forSelectionType:primaryAction:)`).
     .contentShape(Rectangle())
-    .onTapGesture { onEdit() }
   }
 
   private func statsCaption(_ stats: ImportRuleStore.RuleMatchStats) -> String {

--- a/Features/Import/Views/RecentlyAddedView.swift
+++ b/Features/Import/Views/RecentlyAddedView.swift
@@ -13,6 +13,7 @@ struct RecentlyAddedView: View {
   @State private var createRuleFromTransaction: Transaction?
   @State private var showingCreateRuleFromSearch: Bool = false
   @State private var transactionForDetail: Transaction?
+  @State private var transactionPendingDelete: Transaction?
 
   var body: some View {
     VStack(alignment: .leading, spacing: 0) {
@@ -56,6 +57,24 @@ struct RecentlyAddedView: View {
     }
     .sheet(item: $transactionForDetail) { transaction in
       RecentlyAddedDetailSheet(transaction: transaction)
+    }
+    .confirmationDialog(
+      "Delete this transaction?",
+      isPresented: Binding(
+        get: { transactionPendingDelete != nil },
+        set: { if !$0 { transactionPendingDelete = nil } }
+      ),
+      titleVisibility: .visible
+    ) {
+      Button("Delete Transaction", role: .destructive) {
+        if let transaction = transactionPendingDelete {
+          Task { await deleteTransaction(transaction) }
+        }
+        transactionPendingDelete = nil
+      }
+      Button("Cancel", role: .cancel) { transactionPendingDelete = nil }
+    } message: {
+      Text("This action cannot be undone.")
     }
     // `.task(id:)` fires on first appearance and re-fires (auto-cancelling
     // any in-flight load) whenever any of the tracked values change. We
@@ -107,7 +126,7 @@ struct RecentlyAddedView: View {
                   createRuleFromTransaction = transaction
                 }
                 Button("Delete", role: .destructive) {
-                  Task { await deleteTransaction(transaction) }
+                  transactionPendingDelete = transaction
                 }
               }
           }

--- a/Features/Investments/Views/InvestmentAccountView.swift
+++ b/Features/Investments/Views/InvestmentAccountView.swift
@@ -276,7 +276,7 @@ struct InvestmentAccountView: View {
 
 @MainActor
 private func seedLegacyValuations(
-  backend: CloudKitBackend, account: Account, store: InvestmentStore
+  backend: any BackendProvider, account: Account, store: InvestmentStore
 ) async {
   _ = try? await backend.accounts.create(
     account, openingBalance: InstrumentAmount(quantity: 10_000, instrument: .AUD))
@@ -291,7 +291,7 @@ private func seedLegacyValuations(
 }
 
 @MainActor
-private func seedPositionValuations(backend: CloudKitBackend, account: Account) async {
+private func seedPositionValuations(backend: any BackendProvider, account: Account) async {
   let bhp = Instrument.stock(ticker: "BHP.AX", exchange: "ASX", name: "BHP")
   _ = try? await backend.accounts.create(
     account, openingBalance: InstrumentAmount(quantity: 0, instrument: .AUD))

--- a/Features/Navigation/SidebarView.swift
+++ b/Features/Navigation/SidebarView.swift
@@ -328,7 +328,7 @@ extension SidebarView {
 
 @MainActor
 private func seedSidebarPreview(
-  backend: CloudKitBackend,
+  backend: any BackendProvider,
   accountStore: AccountStore,
   earmarkStore: EarmarkStore
 ) async {

--- a/Features/Reports/CapitalGainsSummary.swift
+++ b/Features/Reports/CapitalGainsSummary.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+/// Summary of capital gains for a financial year.
+struct CapitalGainsSummary: Sendable {
+  let shortTermGain: Decimal
+  let longTermGain: Decimal
+  let totalGain: Decimal
+  let eventCount: Int
+
+  /// Australian CGT discount: 50% on long-term gains for individuals.
+  var discountedLongTermGain: Decimal {
+    max(0, longTermGain) / 2
+  }
+
+  /// Net capital gain after applying CGT discount (losses offset gains before discount).
+  var netCapitalGain: Decimal {
+    let netShortTerm = shortTermGain
+    let netLongTerm = longTermGain > 0 ? discountedLongTermGain : longTermGain
+    return max(0, netShortTerm + netLongTerm)
+  }
+
+  /// Capital-gains values in a form suitable for populating
+  /// `TaxYearAdjustments` fields. Nested because it is only ever produced
+  /// by `asTaxAdjustmentValues(currency:)` below.
+  struct TaxAdjustmentValues {
+    /// Gains from assets held < 12 months.
+    let shortTerm: InstrumentAmount
+    /// Pre-discount gains from assets held > 12 months.
+    let longTerm: InstrumentAmount
+    /// Absolute value of net losses (if total is negative).
+    let losses: InstrumentAmount
+  }
+}
+
+extension CapitalGainsSummary {
+  /// Convert to values suitable for `TaxYearAdjustments` fields.
+  func asTaxAdjustmentValues(currency: Instrument) -> TaxAdjustmentValues {
+    let shortTerm = InstrumentAmount(
+      quantity: max(0, shortTermGain), instrument: currency
+    )
+    let longTerm = InstrumentAmount(
+      quantity: max(0, longTermGain), instrument: currency
+    )
+    let totalLoss = min(0, shortTermGain) + min(0, longTermGain)
+    let losses = InstrumentAmount(
+      quantity: abs(totalLoss), instrument: currency
+    )
+    return TaxAdjustmentValues(shortTerm: shortTerm, longTerm: longTerm, losses: losses)
+  }
+}

--- a/Features/Reports/ReportingStore.swift
+++ b/Features/Reports/ReportingStore.swift
@@ -2,55 +2,6 @@ import Foundation
 import OSLog
 import Observation
 
-/// Summary of capital gains for a financial year.
-struct CapitalGainsSummary: Sendable {
-  let shortTermGain: Decimal
-  let longTermGain: Decimal
-  let totalGain: Decimal
-  let eventCount: Int
-
-  /// Australian CGT discount: 50% on long-term gains for individuals.
-  var discountedLongTermGain: Decimal {
-    max(0, longTermGain) / 2
-  }
-
-  /// Net capital gain after applying CGT discount (losses offset gains before discount).
-  var netCapitalGain: Decimal {
-    let netShortTerm = shortTermGain
-    let netLongTerm = longTermGain > 0 ? discountedLongTermGain : longTermGain
-    return max(0, netShortTerm + netLongTerm)
-  }
-}
-
-/// Capital-gains values in a form suitable for populating
-/// `TaxYearAdjustments` fields.
-///
-/// - `shortTerm`: gains from assets held < 12 months
-/// - `longTerm`: pre-discount gains from assets held > 12 months
-/// - `losses`: absolute value of net losses (if total is negative)
-struct TaxAdjustmentValues {
-  let shortTerm: InstrumentAmount
-  let longTerm: InstrumentAmount
-  let losses: InstrumentAmount
-}
-
-extension CapitalGainsSummary {
-  /// Convert to values suitable for `TaxYearAdjustments` fields.
-  func asTaxAdjustmentValues(currency: Instrument) -> TaxAdjustmentValues {
-    let shortTerm = InstrumentAmount(
-      quantity: max(0, shortTermGain), instrument: currency
-    )
-    let longTerm = InstrumentAmount(
-      quantity: max(0, longTermGain), instrument: currency
-    )
-    let totalLoss = min(0, shortTermGain) + min(0, longTermGain)
-    let losses = InstrumentAmount(
-      quantity: abs(totalLoss), instrument: currency
-    )
-    return TaxAdjustmentValues(shortTerm: shortTerm, longTerm: longTerm, losses: losses)
-  }
-}
-
 @Observable
 @MainActor
 final class ReportingStore {

--- a/Features/Reports/Views/ReportsView.swift
+++ b/Features/Reports/Views/ReportsView.swift
@@ -156,7 +156,7 @@ private struct ReportsPreviewIds {
 
 @MainActor
 private func seedReportsPreview(
-  backend: CloudKitBackend,
+  backend: any BackendProvider,
   account: Account,
   ids: ReportsPreviewIds
 ) async {

--- a/Features/Transactions/Views/TransactionListView.swift
+++ b/Features/Transactions/Views/TransactionListView.swift
@@ -281,7 +281,7 @@ struct TransactionListView: View {
 
 @MainActor
 private func seedTransactionListPreview(
-  backend: CloudKitBackend,
+  backend: any BackendProvider,
   accountId: UUID,
   savingsId: UUID,
   store: TransactionStore

--- a/Features/Transactions/Views/UpcomingView.swift
+++ b/Features/Transactions/Views/UpcomingView.swift
@@ -216,7 +216,7 @@ struct UpcomingView: View {
 
 @MainActor
 private func previewSeedTransactions(
-  backend: CloudKitBackend,
+  backend: any BackendProvider,
   accountId: UUID,
   categoryId: UUID,
   store: TransactionStore

--- a/MoolahUITests_macOS/Helpers/Screens/WelcomeScreen.swift
+++ b/MoolahUITests_macOS/Helpers/Screens/WelcomeScreen.swift
@@ -15,10 +15,26 @@ struct WelcomeScreen {
   /// auto-activating.
   func waitForHero(timeout: TimeInterval = 5) {
     Trace.record()
-    let button = app.application.buttons["Get started"]
+    let button = app.element(for: UITestIdentifiers.Welcome.heroGetStartedButton)
     if !button.waitForExistence(timeout: timeout) {
       Trace.recordFailure("hero 'Get started' button did not appear")
       XCTFail("Welcome hero did not appear within \(timeout)s")
+    }
+  }
+
+  /// Post-condition for auto-open paths (single cloud profile, etc.)
+  /// where the hero must never appear. Waits up to `timeout` for the
+  /// hero CTA to be absent and fails if it ever shows up.
+  func expectHeroAbsent(timeout: TimeInterval = 5) {
+    Trace.record()
+    let hero = app.element(for: UITestIdentifiers.Welcome.heroGetStartedButton)
+    let expectation = XCTNSPredicateExpectation(
+      predicate: NSPredicate(format: "exists == false"),
+      object: hero
+    )
+    if XCTWaiter().wait(for: [expectation], timeout: timeout) != .completed {
+      Trace.recordFailure("hero 'Get started' button appeared unexpectedly")
+      XCTFail("Welcome hero appeared within \(timeout)s when it should have stayed hidden")
     }
   }
 
@@ -45,7 +61,7 @@ struct WelcomeScreen {
   /// appear.
   func tapGetStarted() {
     Trace.record()
-    app.application.buttons["Get started"].click()
+    app.element(for: UITestIdentifiers.Welcome.heroGetStartedButton).click()
     let nameField = app.element(for: UITestIdentifiers.Welcome.nameField)
     if !nameField.waitForExistence(timeout: 3) {
       Trace.recordFailure("name field did not appear after tapGetStarted")
@@ -66,14 +82,6 @@ struct WelcomeScreen {
   func tapCreateProfile() {
     Trace.record()
     app.element(for: UITestIdentifiers.Welcome.createProfileButton).click()
-    let hero = app.application.buttons["Get started"]
-    let expectation = XCTNSPredicateExpectation(
-      predicate: NSPredicate(format: "exists == false"),
-      object: hero
-    )
-    if XCTWaiter().wait(for: [expectation], timeout: 5) != .completed {
-      Trace.recordFailure("hero still visible after tapping Create Profile")
-      XCTFail("Welcome hero remained visible after Create Profile")
-    }
+    expectHeroAbsent()
   }
 }

--- a/MoolahUITests_macOS/Tests/WelcomeViewTests.swift
+++ b/MoolahUITests_macOS/Tests/WelcomeViewTests.swift
@@ -29,14 +29,7 @@ final class WelcomeViewTests: MoolahUITestCase {
   func testFirstLaunchWithOneCloudProfile_autoOpens() {
     let app = launch(seed: .welcomeSingleCloudProfile)
 
-    let hero = app.application.buttons["Get started"]
-    let expectation = XCTNSPredicateExpectation(
-      predicate: NSPredicate(format: "exists == false"),
-      object: hero
-    )
-    if XCTWaiter().wait(for: [expectation], timeout: 5) != .completed {
-      XCTFail("Welcome hero appeared despite a single cloud profile being seeded")
-    }
+    app.welcome.expectHeroAbsent()
   }
 
   /// Two cloud profiles → the picker (state 5) is shown with both


### PR DESCRIPTION
## Summary

Fixes the open severity:critical / code-review issues from the 2026-05-04 reviewer-agent sweep:

- Closes [#706](https://github.com/ajsutton/moolah-native/issues/706) — UI test screen-driver violation in `WelcomeViewTests`
- Closes [#685](https://github.com/ajsutton/moolah-native/issues/685) — `RecentlyAddedView` delete needs confirmation
- Closes [#686](https://github.com/ajsutton/moolah-native/issues/686) — `ImportRulesSettingsView` row primary action not keyboard-accessible
- Closes [#683](https://github.com/ajsutton/moolah-native/issues/683) — `EarmarkDetailView` savings progress accessibility
- Closes [#682](https://github.com/ajsutton/moolah-native/issues/682) — `NetWorthGraphCard` chart accessibility + `.plain` → `.borderless`
- Closes [#647](https://github.com/ajsutton/moolah-native/issues/647) — `SidebarView` (and seven other preview helpers) referencing `CloudKitBackend` directly
- Closes [#648](https://github.com/ajsutton/moolah-native/issues/648) — `ReportingStore.swift` had three primary types
- Closes [#643](https://github.com/ajsutton/moolah-native/issues/643) — missing `PrivacyInfo.xcprivacy` privacy manifest

Side cleanup so the chart accessibility-label addition doesn't push `NetWorthGraphCard` over the `type_body_length` budget: per-series `@ChartContentBuilder` builders moved to a new `NetWorthGraphCard+Marks.swift` extension.

## Test plan

- [x] `just build-mac` — succeeds, no new warnings
- [x] `just build-ios` — succeeds
- [x] `just format-check` — clean (after extracting marks builders)
- [x] `just test-mac` — all 2008 tests pass
- [x] `xcodebuild build-for-testing` for `Moolah-macOS-UITests` — succeeds, so the `WelcomeScreen` driver changes compile against the UI test target
- [x] `find Moolah.app -name 'PrivacyInfo*'` — manifest is bundled into `Contents/Resources/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)