### PR TITLE
fix(db-schema): pragma-optimize profile-index, document retention/separation

### DIFF
--- a/App/MoolahApp+Lifecycle.swift
+++ b/App/MoolahApp+Lifecycle.swift
@@ -1,4 +1,5 @@
 import Foundation
+import GRDB
 import SwiftUI
 
 // Scene-phase sync flushing and URL-scheme routing extracted from the main
@@ -24,12 +25,31 @@ extension MoolahApp {
   /// hour while active". This handler covers the resign-active half by
   /// asking each open session to schedule its own tracked optimize task —
   /// the session stores the handle and cancels it on teardown, so this
-  /// loop never leaks fire-and-forget Tasks. The hourly-while-active half
-  /// is owned by `ProfileSession.startPeriodicPragmaOptimize(interval:)`,
-  /// which is started from the session initialiser.
+  /// loop never leaks fire-and-forget Tasks. It also runs `PRAGMA optimize`
+  /// on the app-scoped `profile-index.sqlite` queue (which has no owning
+  /// session). The hourly-while-active half is owned by
+  /// `ProfileSession.startPeriodicPragmaOptimize(interval:)`, which is
+  /// started from the session initialiser.
   func runPragmaOptimizeOnAllSessions() {
     for session in sessionManager.openProfiles {
       session.schedulePragmaOptimize()
+    }
+    optimizeProfileIndexQueue()
+  }
+
+  /// Best-effort synchronous `PRAGMA optimize` on the app-scoped
+  /// `profile-index.sqlite` queue. Synchronous because we only run on
+  /// resign-active (the OS may suspend us shortly) and `PRAGMA optimize`
+  /// completes in milliseconds.
+  private func optimizeProfileIndexQueue() {
+    do {
+      try containerManager.profileIndexDatabase.write { database in
+        try database.execute(sql: "PRAGMA optimize")
+      }
+    } catch {
+      logger.warning(
+        "PRAGMA optimize failed for profile-index: \(error.localizedDescription, privacy: .public)"
+      )
     }
   }
 

--- a/Backends/CoinGecko/CoinGeckoCatalogSchema.swift
+++ b/Backends/CoinGecko/CoinGeckoCatalogSchema.swift
@@ -5,6 +5,14 @@ import Foundation
 /// Bump `version` whenever the on-disk shape changes; the catalogue
 /// implementation drops and recreates the file rather than running a
 /// migration.
+///
+/// Retention: this is a derived cache of the public CoinGecko catalogue.
+/// The whole table contents are replaced atomically on every successful
+/// refresh (bounded by `maxAge` = 24 h in `SQLiteCoinGeckoCatalog`), and
+/// on a schema-version mismatch the entire SQLite file is dropped and
+/// recreated clean. The source of truth is the live CoinGecko API, so
+/// no per-row TTL or scheduled purge migration is needed —
+/// `replaceAll` and the drop-and-recreate path together bound staleness.
 enum CoinGeckoCatalogSchema {
   static let version: Int = 1
 

--- a/Backends/GRDB/ProfileIndexSchema.swift
+++ b/Backends/GRDB/ProfileIndexSchema.swift
@@ -10,6 +10,13 @@ import GRDB
 /// activated. Independent of any per-profile `data.sqlite` — no FKs in
 /// or out.
 ///
+/// A separate file (rather than a table inside `data.sqlite`) is
+/// justified because the index has a materially different lifetime than
+/// per-profile data: it must be readable before any profile is
+/// activated, it survives every profile delete, and its access pattern
+/// (one read at launch, occasional writes when profiles change) does
+/// not benefit from sharing the per-profile WAL.
+///
 /// Migration history:
 /// `v1_initial` — the `profile` table.
 ///


### PR DESCRIPTION
## Summary

- Run `PRAGMA optimize` on `containerManager.profileIndexDatabase` from the resign-active path so the app-scoped `profile-index.sqlite` queue participates in the cadence required by DATABASE_SCHEMA_GUIDE §5 (#676).
- Add a retention-policy doc-comment to `CoinGeckoCatalogSchema` (#675).
- Add a separation-rationale sentence to `ProfileIndexSchema` (#673).

## Test plan

- [ ] CI green (macOS + iOS test suites; `just format-check`).
- [ ] `MoolahApp+Lifecycle.swift` builds with the new `import GRDB`.
- [ ] `ProfileSessionPragmaOptimizeTests` still passes (no behaviour change for per-session path).

Fixes #676
Fixes #675
Fixes #673

🤖 Generated with [Claude Code](https://claude.com/claude-code)