### PR TITLE
fix(concurrency): track FSEvents tasks, scene-active fetch, fix sendable doc

### DIFF
--- a/App/MoolahApp+Lifecycle.swift
+++ b/App/MoolahApp+Lifecycle.swift
@@ -13,7 +13,12 @@ extension MoolahApp {
       flushPendingChanges()
       runPragmaOptimizeOnAllSessions()
     case .active:
-      Task { await fetchRemoteChanges() }
+      // Tracked + cancellable via SyncCoordinator. Rapid scene-phase
+      // cycling (e.g. dragging a window across Spaces) can call this
+      // repeatedly; the coordinator cancels the prior task before
+      // launching a new one so concurrent fetches don't stack.
+      logger.info("Fetching remote changes on foreground entry")
+      syncCoordinator.scheduleFetchChanges()
     default:
       break
     }
@@ -57,11 +62,6 @@ extension MoolahApp {
         await syncCoordinator.sendChanges()
       }
     #endif
-  }
-
-  func fetchRemoteChanges() async {
-    logger.info("Fetching remote changes on foreground entry")
-    await syncCoordinator.fetchChanges()
   }
 
   // MARK: - URL Handling

--- a/Backends/CloudKit/Sync/SyncCoordinator+Lifecycle.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+Lifecycle.swift
@@ -222,6 +222,8 @@ extension SyncCoordinator {
     zoneSetupTask = nil
     availabilityProbeTask?.cancel()
     availabilityProbeTask = nil
+    fetchChangesTask?.cancel()
+    fetchChangesTask = nil
     cancelRefetchTasks()
     for (_, task) in zoneCreationTasks {
       task.cancel()

--- a/Backends/CloudKit/Sync/SyncCoordinator+SceneActive.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+SceneActive.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+// Scene-active scheduling extracted from `SyncCoordinator+Lifecycle.swift`
+// so each file stays under SwiftLint's `file_length` threshold. Owns the
+// cancel-and-replace pattern that `MoolahApp+Lifecycle` uses on
+// `.active` to avoid stacking concurrent fetches.
+extension SyncCoordinator {
+
+  /// Cancels any pending scene-active fetch and schedules a new one.
+  /// Called from `MoolahApp+Lifecycle.handleScenePhaseChange(.active)`;
+  /// rapid scene-phase cycling can call this repeatedly without
+  /// stacking concurrent fetches. The handle is stored on
+  /// `fetchChangesTask` and cancelled by `stop()` for orderly teardown.
+  func scheduleFetchChanges() {
+    fetchChangesTask?.cancel()
+    fetchChangesTask = Task { [weak self] in
+      await self?.fetchChanges()
+    }
+  }
+}

--- a/Backends/CloudKit/Sync/SyncCoordinator.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator.swift
@@ -331,6 +331,9 @@ final class SyncCoordinator {
   /// `completeStart`. Held so `stop()` can cancel it.
   var availabilityProbeTask: Task<Void, Never>?
 
+  /// Scene-active fetch handle. `scheduleFetchChanges` cancels-and-replaces; `stop()` clears it.
+  var fetchChangesTask: Task<Void, Never>?
+
   /// Number of consecutive re-fetch attempts scheduled after a save failure.
   /// Reset to zero whenever a fetched-record-zone-changes batch applies successfully.
   /// Exposed for testing.

--- a/Backends/GRDB/Repositories/GRDBInstrumentRegistryRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBInstrumentRegistryRepository.swift
@@ -16,17 +16,22 @@ import OSLog
 /// mutations, and a non-protocol `notifyExternalChange()` method that the
 /// sync layer calls when remote pulls touch instrument rows.
 ///
-/// **`@unchecked Sendable` justification.** All stored properties are
-/// `let` except `subscribers`, which is `@MainActor`-isolated and only
-/// touched from `MainActor`-isolated methods. `database`
-/// (`any DatabaseWriter`) is itself `Sendable` (GRDB protocol guarantee —
-/// the queue's serial executor mediates concurrent access).
-/// `onRecordChanged` and `onRecordDeleted` are `@Sendable` closures
-/// captured at init. Nothing mutates post-init outside the
-/// `MainActor`-confined dictionary, so the reference can be shared
-/// across actor boundaries without a data race; `@unchecked` only waives
-/// Swift's structural check that `final class` types meet `Sendable`'s
-/// requirements automatically.
+/// **`@unchecked Sendable` justification.** Unlike the all-`let`
+/// pattern of the other nine GRDB repositories, this one has a
+/// genuinely mutable stored property: `subscribers`, the
+/// `[UUID: AsyncStream<Void>.Continuation]` map that drives
+/// `observeChanges()`. That property is `@MainActor`-isolated, so
+/// every mutation (`observeChanges()`, the AsyncStream's
+/// `onTermination` callback, `notifyExternalChange()`) runs on the
+/// main actor. Swift can't propagate that property-level isolation
+/// into the enclosing class's `Sendable` check, so we use `@unchecked`
+/// to vouch for the runtime guarantee. The remaining stored
+/// properties are `let`: `database` (`any DatabaseWriter`) is itself
+/// `Sendable` (GRDB queue's serial executor mediates concurrent
+/// access); `onRecordChanged` / `onRecordDeleted` are `@Sendable`
+/// closures captured at init; `logger` is a value type. The
+/// `@MainActor`-confined dictionary plus the otherwise-immutable
+/// surface keeps the type race-free in practice.
 /// See `guides/CONCURRENCY_GUIDE.md` §2 "False Positives to Avoid",
 /// Carve-out 3 (GRDB repositories).
 final class GRDBInstrumentRegistryRepository:

--- a/Features/Import/FolderWatchService.swift
+++ b/Features/Import/FolderWatchService.swift
@@ -30,8 +30,10 @@
     /// Tasks spawned by the FSEvents callback — tracked so `stop()` can
     /// cancel any in-flight `handleEvents` before the service is torn
     /// down, avoiding orphan ingests after the watch was explicitly
-    /// stopped.
-    private var inFlightTasks: [Task<Void, Never>] = []
+    /// stopped. Keyed by a fresh UUID per event burst so each task can
+    /// remove itself from the dictionary on completion, keeping the
+    /// dictionary bounded between bursts.
+    private var inFlightTasks: [UUID: Task<Void, Never>] = [:]
 
     init(
       importStore: ImportStore,
@@ -113,17 +115,21 @@
           }
         }
         // `FSEventStreamSetDispatchQueue(newStream, .main)` (in `start()`)
-        // means this callback fires on the main queue — but it's a C
-        // function pointer with no actor isolation, so we still need the
-        // explicit `Task { @MainActor in }` hop. Tracking the task lets
-        // `stop()` cancel it if the watch is torn down mid-ingest.
-        let task: Task<Void, Never> = Task { @MainActor in
-          await service.handleEvents(paths: paths)
-        }
-        Task { @MainActor in
-          service.inFlightTasks.append(task)
-          await task.value
-          service.inFlightTasks.removeAll { $0.isCancelled }
+        // means this callback runs on the main thread, which is
+        // `@MainActor`'s executor. `MainActor.assumeIsolated` enters
+        // that isolation domain synchronously so we can mutate
+        // `inFlightTasks` from this C callback without an extra
+        // `Task { @MainActor in }` hop (which would itself be untracked).
+        // The work task is appended before it starts and removes itself
+        // on completion; `stop()` cancels everything still in flight.
+        MainActor.assumeIsolated {
+          let id = UUID()
+          let task = Task { @MainActor [weak service] in
+            guard let service else { return }
+            defer { service.inFlightTasks[id] = nil }
+            await service.handleEvents(paths: paths)
+          }
+          service.inFlightTasks[id] = task
         }
       }
     }
@@ -143,7 +149,7 @@
       contextPointer = nil
       // Cancel any in-flight handle-events tasks so no ingest kicks off
       // after the watch has been torn down.
-      for task in inFlightTasks { task.cancel() }
+      for task in inFlightTasks.values { task.cancel() }
       inFlightTasks.removeAll()
       if didStartAccess, let watchedURL {
         watchedURL.stopAccessingSecurityScopedResource()


### PR DESCRIPTION
## Summary

- **#663** — `FolderWatchService` FSEvents callback now spawns a single tracked task instead of two (one was untracked, leaving an orphan window during `stop()`). Switches `inFlightTasks` from array to `[UUID: Task]` so each task can self-remove on completion. Uses `MainActor.assumeIsolated` to enter the actor synchronously from the C callback.
- **#664** — `MoolahApp+Lifecycle` `.active` now calls `syncCoordinator.scheduleFetchChanges()` (a tracked cancel-and-replace pattern) instead of a fire-and-forget `Task`. New method lives in a sibling `SyncCoordinator+SceneActive.swift` to keep both existing files under SwiftLint's 400-line threshold. `stop()` also cancels the fetch task.
- **#661** — Updates `GRDBInstrumentRegistryRepository`'s `@unchecked Sendable` justification comment to correctly describe `subscribers` as a `@MainActor`-isolated mutable property (the prior comment claimed "nothing mutates post-init").

## Test plan

- [ ] CI green (macOS + iOS test suites; `just format-check`).
- [ ] Watch a CSV folder on macOS — ingest still works, `stop()` cleans up tasks.
- [ ] Cycle scene phase rapidly — no stacked fetches in logs.

Fixes #663
Fixes #664
Fixes #661

🤖 Generated with [Claude Code](https://claude.com/claude-code)