### PR TITLE
fix(instrument-conversion): pin date-sensitive gains, log preload failures

### DIFF
--- a/Features/Accounts/InvestmentValueCache.swift
+++ b/Features/Accounts/InvestmentValueCache.swift
@@ -1,4 +1,5 @@
 import Foundation
+import OSLog
 
 /// Caches the latest externally-set value for each investment account and
 /// knows how to hydrate itself from the investment repository.
@@ -14,6 +15,12 @@ import Foundation
 /// The cache is not `@Observable`: the observable surface is `AccountStore`'s
 /// `convertedBalances` / `convertedInvestmentTotal`, which the store
 /// recomputes whenever cache contents change.
+/// `Logger` is `Sendable`; declared at file scope so the per-account
+/// `withTaskGroup` body (a non-isolated context) can warn on fetch
+/// failures without a MainActor hop.
+private let preloadLogger = Logger(
+  subsystem: "com.moolah.app", category: "InvestmentValueCache")
+
 @MainActor
 final class InvestmentValueCache {
   /// The current cache contents. Kept `private(set)` so callers can read for
@@ -59,6 +66,13 @@ final class InvestmentValueCache {
               accountId: accountId, page: 0, pageSize: 1)
             return (accountId, page.values.first?.value)
           } catch {
+            // nil-fallback is the intended degradation (callers fall back
+            // to position sum), but the failure must be logged so prod
+            // diagnostics can distinguish "no value set" from "fetch
+            // raised an error". Per INSTRUMENT_CONVERSION_GUIDE.md Rule 11.
+            preloadLogger.warning(
+              "preload: fetch failed for \(accountId, privacy: .public): \(error.localizedDescription, privacy: .public)"
+            )
             return (accountId, nil)
           }
         }

--- a/MoolahTests/Shared/CapitalGainsCalculatorTests.swift
+++ b/MoolahTests/Shared/CapitalGainsCalculatorTests.swift
@@ -238,4 +238,62 @@ struct CapitalGainsCalculatorTests {
           categoryId: nil, earmarkId: nil),
       ])
   }
+
+  // MARK: - Date-sensitive conversion regression guard
+
+  /// Pins the contract that `computeWithConversion` looks up FX rates at
+  /// each transaction's date — not at `Date()`. Uses
+  /// `DateBasedFixedConversionService` with two rate entries straddling
+  /// the buy and sell dates so a wrong-date regression (e.g. passing
+  /// `Date()` instead of `transaction.date` into `TradeEventClassifier`)
+  /// converts both legs at the same rate and produces a zero gain — the
+  /// assertion below fails. Mirrors the `TradeEventClassifierTests.buyFoldsFXFee`
+  /// pattern, extended end-to-end through the calculator.
+  @Test
+  func usdBuyAudSell_usesTradeDateForFXLookup() async throws {
+    let usd = Instrument.fiat(code: "USD")
+    let bhp = stockInstrument("BHP")
+    let accountId = UUID()
+    let buyDate = date(0)
+    let sellDate = date(400)
+
+    // 1.5 AUD/USD at buy, 2.0 AUD/USD at sell. Different rates ⇒ a real
+    // (non-zero) gain only when each leg converts at its own date.
+    let conversion = DateBasedFixedConversionService(rates: [
+      buyDate: ["USD": dec("1.5")],
+      sellDate: ["USD": Decimal(2)],
+    ])
+
+    let buyTx = LegTransaction(
+      date: buyDate,
+      legs: [
+        TransactionLeg(
+          accountId: accountId, instrument: usd, quantity: -1_500, type: .trade,
+          categoryId: nil, earmarkId: nil),
+        TransactionLeg(
+          accountId: accountId, instrument: bhp, quantity: 100, type: .trade,
+          categoryId: nil, earmarkId: nil),
+      ])
+    let sellTx = LegTransaction(
+      date: sellDate,
+      legs: [
+        TransactionLeg(
+          accountId: accountId, instrument: bhp, quantity: -100, type: .trade,
+          categoryId: nil, earmarkId: nil),
+        TransactionLeg(
+          accountId: accountId, instrument: usd, quantity: 1_500, type: .trade,
+          categoryId: nil, earmarkId: nil),
+      ])
+
+    let result = try await CapitalGainsCalculator.computeWithConversion(
+      transactions: [buyTx, sellTx],
+      profileCurrency: aud,
+      conversionService: conversion)
+
+    // Cost basis: 1500 USD * 1.5 = 2250 AUD ⇒ 22.5 AUD/unit
+    // Proceeds:   1500 USD * 2.0 = 3000 AUD ⇒ 30 AUD/unit
+    // Gain on 100 units = (30 - 22.5) * 100 = 750 AUD
+    #expect(result.events.count == 1)
+    #expect(result.events[0].gain == Decimal(750))
+  }
 }


### PR DESCRIPTION
## Summary

- **#680** — New `usdBuyAudSell_usesTradeDateForFXLookup` test in `CapitalGainsCalculatorTests` uses `DateBasedFixedConversionService` with rates straddling the buy/sell dates, so a wrong-date regression (Date() in place of transaction.date) collapses the gain to zero and trips the assertion.
- **#679** — `InvestmentValueCache.preload` logs a warning before falling back to nil on a per-account fetch failure (per INSTRUMENT_CONVERSION_GUIDE Rule 11). Logger is file-scope so the non-isolated `withTaskGroup` body can use it.

## Test plan

- [x] `just test-mac CapitalGainsCalculatorTests` — green locally.
- [ ] CI green (macOS + iOS test suites; `just format-check`).

Fixes #680
Fixes #679

🤖 Generated with [Claude Code](https://claude.com/claude-code)