### PR TITLE
fix(db-code): document Shared/ exceptions, explicit onConflict, dedupe plan-test rationale

### DIFF
--- a/MoolahTests/Backends/GRDB/AnalysisAggregationPlanPinningTests.swift
+++ b/MoolahTests/Backends/GRDB/AnalysisAggregationPlanPinningTests.swift
@@ -10,6 +10,16 @@ import Testing
 /// Split out of `AnalysisPlanPinningTests` so each file stays under the
 /// SwiftLint `type_body_length` budget. Same `EXPLAIN QUERY PLAN`
 /// methodology as the parent suite (see its file header).
+///
+/// **Temp B-tree GROUP/ORDER lines are accepted across this whole
+/// file.** Aggregations group and order by `day = DATE(t.date)` — a
+/// derived expression with no index keying, so SQLite has no choice
+/// but to materialise the groups and the sort in temp B-trees.
+/// Trying to forbid `USE TEMP B-TREE FOR GROUP BY` /
+/// `USE TEMP B-TREE FOR ORDER BY` would force the planner away from
+/// the covering index entirely. The perf-critical signals are the
+/// bare-SCAN rejection (`planHasFullTableScanOf`) and the
+/// `USING COVERING INDEX` assertion where applicable.
 @Suite("Analysis aggregation plan-pinning")
 struct AnalysisAggregationPlanPinningTests {
   /// `makeDatabase` and `planDetail` are shared with
@@ -100,18 +110,11 @@ struct AnalysisAggregationPlanPinningTests {
     // table (here `transaction_leg leg`); pin against the alias rather
     // than the bare table name to avoid a false-negative assertion.
     #expect(!PlanPinningTestHelpers.planHasFullTableScanOf(detail, alias: "leg"))
-    // SQLite's plan is permitted to (and does) include both
-    // `USE TEMP B-TREE FOR GROUP BY` and `USE TEMP B-TREE FOR ORDER BY`.
-    // We do NOT reject those lines because the GROUP BY and ORDER BY
-    // both key on `day = DATE(t.date)` — a derived expression with no
-    // index keying. SQLite has no choice but to materialise the groups
-    // and the sort in temp B-trees; trying to forbid them would force
-    // the planner away from the covering index entirely. The
-    // covering-index property captured by the positive
-    // `USING COVERING INDEX` assertion is the perf-critical signal —
-    // it's what flips when the leg-side composite loses a column or
-    // the WHERE clause grows a predicate the partial index doesn't
-    // cover (e.g. a re-introduced `account_id IS NOT NULL`).
+    // Temp B-tree GROUP/ORDER lines accepted — see file-header rationale.
+    // The covering-index property captured by `USING COVERING INDEX`
+    // above is the perf-critical signal: it flips when the leg-side
+    // composite loses a column or the WHERE clause grows a predicate
+    // the partial index doesn't cover.
   }
 
   @Test("computeEarmarkPositions JOIN+GROUP BY avoids a transaction_leg SCAN")

--- a/MoolahTests/Backends/GRDB/DailyBalancesPlanPinningTests.swift
+++ b/MoolahTests/Backends/GRDB/DailyBalancesPlanPinningTests.swift
@@ -11,6 +11,17 @@ import Testing
 /// `AnalysisAggregationPlanPinningTests` so each file stays under the
 /// SwiftLint `type_body_length` and `file_length` budgets — same
 /// methodology, different aggregation surface.
+///
+/// **Temp B-tree GROUP/ORDER lines are accepted across this whole
+/// file.** Every aggregation here groups and orders by
+/// `day = DATE(t.date)` — a derived expression with no index keying,
+/// so SQLite has no choice but to materialise the groups and the sort
+/// in temp B-trees. Trying to forbid `USE TEMP B-TREE FOR GROUP BY` /
+/// `USE TEMP B-TREE FOR ORDER BY` would force the planner away from
+/// the leg-side / covering index entirely. The perf-critical signals
+/// are the bare-SCAN rejection (`planHasFullTableScanOf`) and the
+/// `USING COVERING INDEX` assertion where applicable. Each `@Test`
+/// references this rationale rather than restating it.
 @Suite("Daily-balance aggregation plan-pinning")
 struct DailyBalancesPlanPinningTests {
   private func makeDatabase() throws -> DatabaseQueue {
@@ -72,17 +83,7 @@ struct DailyBalancesPlanPinningTests {
     // table name (which would silently pass even on a full scan).
     #expect(!PlanPinningTestHelpers.planHasFullTableScanOf(detail, alias: "leg"))
     #expect(!detail.contains("SCAN \"transaction\""))
-    // SQLite's plan is permitted to (and does) include both
-    // `USE TEMP B-TREE FOR GROUP BY` and `USE TEMP B-TREE FOR ORDER BY`.
-    // We do NOT reject those lines because the GROUP BY and ORDER BY
-    // both key on `day = DATE(t.date)` — a derived expression with no
-    // index keying. SQLite has no choice but to materialise the groups
-    // and the sort in temp B-trees; trying to forbid them would force
-    // the planner away from the leg-side index entirely. The
-    // bare-SCAN rejection captured by `planHasFullTableScanOf` is the
-    // perf-critical signal — it's what flips when the leg-side index
-    // is dropped or the WHERE clause grows a predicate the partial
-    // index doesn't cover.
+    // Temp B-tree GROUP/ORDER lines accepted — see file-header rationale.
   }
 
   @Test("fetchDailyBalances pre-cutoff account-dimension SUM avoids a SCAN")
@@ -118,15 +119,7 @@ struct DailyBalancesPlanPinningTests {
     #expect(usesAcceptableLegIndex)
     #expect(!PlanPinningTestHelpers.planHasFullTableScanOf(detail, alias: "leg"))
     #expect(!detail.contains("SCAN \"transaction\""))
-    // SQLite's plan is permitted to (and does) include both
-    // `USE TEMP B-TREE FOR GROUP BY` and `USE TEMP B-TREE FOR ORDER BY`.
-    // We do NOT reject those lines because the GROUP BY and ORDER BY
-    // both key on `day = DATE(t.date)` — a derived expression with no
-    // index keying. SQLite has no choice but to materialise the groups
-    // and the sort in temp B-trees; trying to forbid them would force
-    // the planner away from the leg-side index entirely. The
-    // bare-SCAN rejection captured by `planHasFullTableScanOf` is the
-    // perf-critical signal.
+    // Temp B-tree GROUP/ORDER lines accepted — see file-header rationale.
   }
 
   @Test("fetchDailyBalances per-day earmark-dimension SUM uses leg_analysis_by_earmark_type")
@@ -161,15 +154,7 @@ struct DailyBalancesPlanPinningTests {
     #expect(detail.contains("USING COVERING INDEX"))
     #expect(!PlanPinningTestHelpers.planHasFullTableScanOf(detail, alias: "leg"))
     #expect(!detail.contains("SCAN \"transaction\""))
-    // SQLite's plan is permitted to (and does) include both
-    // `USE TEMP B-TREE FOR GROUP BY` and `USE TEMP B-TREE FOR ORDER BY`.
-    // We do NOT reject those lines because the GROUP BY and ORDER BY
-    // both key on `day = DATE(t.date)` — a derived expression with no
-    // index keying. SQLite has no choice but to materialise the groups
-    // and the sort in temp B-trees; trying to forbid them would force
-    // the planner away from the covering index entirely. The
-    // covering-index property captured by the positive
-    // `USING COVERING INDEX` assertion is the perf-critical signal.
+    // Temp B-tree GROUP/ORDER lines accepted — see file-header rationale.
   }
 
   @Test("fetchDailyBalances pre-cutoff earmark-dimension SUM uses leg_analysis_by_earmark_type")
@@ -203,15 +188,7 @@ struct DailyBalancesPlanPinningTests {
     #expect(detail.contains("USING COVERING INDEX"))
     #expect(!PlanPinningTestHelpers.planHasFullTableScanOf(detail, alias: "leg"))
     #expect(!detail.contains("SCAN \"transaction\""))
-    // SQLite's plan is permitted to (and does) include both
-    // `USE TEMP B-TREE FOR GROUP BY` and `USE TEMP B-TREE FOR ORDER BY`.
-    // We do NOT reject those lines because the GROUP BY and ORDER BY
-    // both key on `day = DATE(t.date)` — a derived expression with no
-    // index keying. SQLite has no choice but to materialise the groups
-    // and the sort in temp B-trees; trying to forbid them would force
-    // the planner away from the covering index entirely. The
-    // covering-index property captured by the positive
-    // `USING COVERING INDEX` assertion is the perf-critical signal.
+    // Temp B-tree GROUP/ORDER lines accepted — see file-header rationale.
   }
 
   @Test("fetchDailyBalances investment-value lookup uses iv_by_account_date_value")

--- a/Shared/CryptoPriceService+Persistence.swift
+++ b/Shared/CryptoPriceService+Persistence.swift
@@ -76,7 +76,7 @@ extension CryptoPriceService {
       for record in deltaRecords {
         try record.insert(database, onConflict: .replace)
       }
-      try meta.insert(database)
+      try meta.insert(database, onConflict: .replace)
     }
   }
 }

--- a/Shared/ExchangeRateService+Persistence.swift
+++ b/Shared/ExchangeRateService+Persistence.swift
@@ -75,7 +75,7 @@ extension ExchangeRateService {
       for record in deltaRecords {
         try record.insert(database, onConflict: .replace)
       }
-      try meta.insert(database)
+      try meta.insert(database, onConflict: .replace)
     }
   }
 }

--- a/Shared/PreviewBackend.swift
+++ b/Shared/PreviewBackend.swift
@@ -8,6 +8,16 @@ import SwiftData
 /// that still seed via SwiftData can share the same wiring as
 /// `TestBackend`; once every preview seed reaches GRDB directly the
 /// container parameter can drop.
+///
+/// **`import GRDB` in `Shared/` is justified.** `DATABASE_CODE_GUIDE.md`
+/// scopes `import GRDB` to `Backends/GRDB/` (and implicitly `App/`), but
+/// `PreviewBackend` is the canonical preview-wiring helper that every
+/// `Features/*/Views/*+Previews.swift` reaches for. Treat this file as
+/// a peer to `TestBackend` — the second of two in-memory backend
+/// factories — rather than as `Shared/` business logic. Moving it under
+/// `Backends/GRDB/` would force every feature preview to import the
+/// backend layer, which is a worse coupling than the targeted
+/// preview-only import here.
 enum PreviewBackend {
   static func create(instrument: Instrument = .AUD) -> (CloudKitBackend, ModelContainer) {
     let schema = Schema([

--- a/Shared/ProfileContainerManager.swift
+++ b/Shared/ProfileContainerManager.swift
@@ -5,6 +5,17 @@ import OSLog
 import Observation
 import SwiftData
 
+/// **`Shared/` location is justified.** `DATABASE_CODE_GUIDE.md` §2 scopes
+/// `DatabaseQueue` ownership to `Backends/GRDB/`, `ProfileSession`, and
+/// test targets — `Shared/` is outside that scope. `ProfileContainerManager`
+/// is an exception because it sits *upstream* of `ProfileSession`:
+/// `MoolahApp` constructs the manager once at launch, then every
+/// `ProfileSession` borrows queues from it. Moving the manager under
+/// `App/` would still leave the `@Environment(ProfileContainerManager.self)`
+/// dependency reach into the App layer from every feature view that
+/// resolves it, which is a worse coupling than the queue-cache exception
+/// here. The cache itself is keyed by profile UUID and never vends raw
+/// queues to feature code — only `ProfileSession.init` reads from it.
 @Observable
 @MainActor
 final class ProfileContainerManager {

--- a/Shared/StockPriceService.swift
+++ b/Shared/StockPriceService.swift
@@ -346,7 +346,7 @@ actor StockPriceService {
       for record in deltaRecords {
         try record.insert(database, onConflict: .replace)
       }
-      try meta.insert(database)
+      try meta.insert(database, onConflict: .replace)
     }
   }
 }


### PR DESCRIPTION
## Summary

- **#671** — Justification doc-comment on `Shared/PreviewBackend.swift` explaining why `import GRDB` is permitted there.
- **#674** — Justification doc-comment on `Shared/ProfileContainerManager` explaining the `[UUID: DatabaseQueue]` cache's upstream-of-ProfileSession exception.
- **#672** — `try meta.insert(database, onConflict: .replace)` made explicit at all three rate-cache `persistDelta` sites.
- **#670** — Temp-B-tree rationale extracted from each `@Test` to the file headers of `DailyBalancesPlanPinningTests` and `AnalysisAggregationPlanPinningTests`.

## Test plan

- [x] `just build-mac` — green locally.
- [ ] CI green (macOS + iOS test suites; `just format-check`).

Fixes #671
Fixes #672
Fixes #674
Fixes #670

🤖 Generated with [Claude Code](https://claude.com/claude-code)