### PR TITLE
fix(ui): VoiceOver labels, dynamic frames, dark-mode shadow, plain-spoken arrows

### DIFF
--- a/Features/Analysis/Views/ExpenseBreakdownCard.swift
+++ b/Features/Analysis/Views/ExpenseBreakdownCard.swift
@@ -49,7 +49,11 @@ struct ExpenseBreakdownCard: View {
             .font(.caption)
             .fontWeight(.semibold)
             .foregroundStyle(.white)
-            .shadow(color: .primary.opacity(0.4), radius: 1, x: 0, y: 1)
+            // Black-with-opacity shadow rather than `.primary` so the
+            // contrast against pale segments (mint, yellow) holds in
+            // both light and dark mode — `.primary` matches the text
+            // in dark mode and provides no contrast.
+            .shadow(color: .black.opacity(0.5), radius: 2, x: 0, y: 1)
         }
       }
     }

--- a/Features/Analysis/Views/IncomeExpenseTableCard.swift
+++ b/Features/Analysis/Views/IncomeExpenseTableCard.swift
@@ -6,12 +6,6 @@ struct IncomeExpenseTableCard: View {
   private static let initialVisibleCount = 6
   private static let loadMoreCount = 6
 
-  nonisolated private static let monthLabelFormatter: DateFormatter = {
-    let formatter = DateFormatter()
-    formatter.dateFormat = "MMM yyyy"
-    return formatter
-  }()
-
   @State private var includeEarmarks = false
   @State private var visibleCount = IncomeExpenseTableCard.initialVisibleCount
 
@@ -180,7 +174,7 @@ struct IncomeExpenseTableCard: View {
   }
 
   nonisolated static func monthLabel(for item: MonthlyIncomeExpense) -> String {
-    Self.monthLabelFormatter.string(from: item.start)
+    item.start.formatted(.dateTime.month(.abbreviated).year())
   }
 
   private func monthsAgoLabel(for item: MonthlyIncomeExpense) -> String {

--- a/Features/Analysis/Views/UpcomingTransactionsCard.swift
+++ b/Features/Analysis/Views/UpcomingTransactionsCard.swift
@@ -106,8 +106,17 @@ struct UpcomingTransactionsCard: View {
     #if os(macOS)
       .frame(minHeight: 200)
     #else
-      .frame(height: 200)
+      // Dynamic frame instead of a fixed 200pt: at larger Dynamic Type
+      // sizes individual rows grow taller and a fixed 200 would clip to
+      // one or two rows. The cap keeps the card from dominating the
+      // screen on very large Dynamic Type settings.
+      .frame(minHeight: 200, maxHeight: 400)
     #endif
+    // Tighter row height for this dense upcoming context — the
+    // analysis dashboard packs several cards onto one screen and the
+    // default 44pt row height eats too much vertical space for a
+    // five- or six-row glance card.
+    .environment(\.defaultMinListRowHeight, 40)
     .accessibilityLabel("List of upcoming and overdue transactions")
   }
 

--- a/Features/Earmarks/Views/EarmarkDetailView.swift
+++ b/Features/Earmarks/Views/EarmarkDetailView.swift
@@ -173,6 +173,7 @@ struct EarmarkDetailView: View {
           Image(systemName: "arrow.right")
             .font(.caption2)
             .foregroundStyle(.tertiary)
+            .accessibilityHidden(true)
         }
 
         if let end = earmark.savingsEndDate {

--- a/Features/Import/Views/ImportRulesSettingsView.swift
+++ b/Features/Import/Views/ImportRulesSettingsView.swift
@@ -150,7 +150,7 @@ private struct RuleRow: View {
       rule.actions.isEmpty
       ? "(no actions)"
       : rule.actions.map(Self.describe).joined(separator: " · ")
-    return "\(conditionSummary) → \(actionSummary)"
+    return "\(conditionSummary) then \(actionSummary)"
   }
 
   private static func describe(_ condition: RuleCondition) -> String {

--- a/Features/Reports/Views/CategoryBalanceTable.swift
+++ b/Features/Reports/Views/CategoryBalanceTable.swift
@@ -104,7 +104,11 @@ struct CategoryBalanceTable: View {
         categorySection(group)
       }
     }
-    .listStyle(.plain)
+    #if os(macOS)
+      .listStyle(.inset)
+    #else
+      .listStyle(.plain)
+    #endif
   }
 
   private func categorySection(_ group: CategoryGroup) -> some View {

--- a/Shared/InstrumentAmountView.swift
+++ b/Shared/InstrumentAmountView.swift
@@ -13,6 +13,7 @@ struct InstrumentAmountView: View {
       .foregroundStyle(effectiveColor)
       .monospacedDigit()
       .font(font)
+      .accessibilityLabel(Text("Amount"))
       .accessibilityValue(amount.formatted)
   }
 


### PR DESCRIPTION
## Summary

- **#705** — `InstrumentAmountView` adds `.accessibilityLabel(Text("Amount"))` so standalone uses read as "Amount, \$X" instead of bare value.
- **#704** — `ImportRulesSettingsView.summarise` swaps the raw Unicode arrow (`→`) for the word `then`.
- **#700** — `IncomeExpenseTableCard` drops the hardcoded `DateFormatter("MMM yyyy")` for `start.formatted(.dateTime.month(.abbreviated).year())` (locale-respecting).
- **#701** — `ExpenseBreakdownCard` pie annotation shadow goes from `.primary.opacity(0.4)` to `.black.opacity(0.5)` with a slightly larger radius so contrast holds in dark mode.
- **#703** + **#697** — `UpcomingTransactionsCard` iOS frame becomes `.frame(minHeight: 200, maxHeight: 400)` and the list applies `.environment(\.defaultMinListRowHeight, 40)` for the dense glance context.
- **#702** — `CategoryBalanceTable.categoryList` becomes platform-conditional `.inset` (macOS) / `.plain` (else).
- **#699** — `EarmarkDetailView` decorative `arrow.right` separator now `.accessibilityHidden(true)`.

## Test plan

- [x] `just build-mac` — green locally.
- [ ] CI green (macOS + iOS test suites; `just format-check`).
- [ ] Skim the analysis dashboard: pie chart shadow, upcoming-card row height.
- [ ] VoiceOver pass on EarmarkDetailView and CategoryBalanceTable footer.

Fixes #704
Fixes #705
Fixes #700
Fixes #701
Fixes #703
Fixes #702
Fixes #699
Fixes #697

🤖 Generated with [Claude Code](https://claude.com/claude-code)