### PR TITLE
fix(sync): pin txn update/delete leg-record-type, refresh deletion mirror

### DIFF
--- a/Backends/CloudKit/Sync/SyncCoordinator+Lifecycle.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+Lifecycle.swift
@@ -288,36 +288,9 @@ extension SyncCoordinator {
     syncEngine.state.remove(pendingRecordZoneChanges: stale)
   }
 
-  // During the short window between `start()` returning and `completeStart`
-  // installing the engine, these queue calls silently no-op. That's safe
-  // because no user-driven edits can reach `queueSave`/`queueDeletion` before
-  // the UI is ready, and any already-persisted records are re-queued by
-  // `queueAllExistingRecordsForAllZones` / `queueUnsyncedRecordsForAllProfiles`
-  // inside `completeStart`.
-  func queueSave(recordType: String, id: UUID, zoneID: CKRecordZone.ID) {
-    let recordID = CKRecord.ID(
-      recordType: recordType, uuid: id, zoneID: zoneID)
-    syncEngine?.state.add(pendingRecordZoneChanges: [.saveRecord(recordID)])
-    refreshPendingUploadsMirror()
-  }
-
-  func queueSave(recordName: String, zoneID: CKRecordZone.ID) {
-    let recordID = CKRecord.ID(recordName: recordName, zoneID: zoneID)
-    syncEngine?.state.add(pendingRecordZoneChanges: [.saveRecord(recordID)])
-    refreshPendingUploadsMirror()
-  }
-
-  func queueDeletion(recordType: String, id: UUID, zoneID: CKRecordZone.ID) {
-    let recordID = CKRecord.ID(
-      recordType: recordType, uuid: id, zoneID: zoneID)
-    syncEngine?.state.add(pendingRecordZoneChanges: [.deleteRecord(recordID)])
-    refreshPendingUploadsMirror()
-  }
-
-  func queueDeletion(recordName: String, zoneID: CKRecordZone.ID) {
-    let recordID = CKRecord.ID(recordName: recordName, zoneID: zoneID)
-    syncEngine?.state.add(pendingRecordZoneChanges: [.deleteRecord(recordID)])
-  }
+  // The four `queueSave` / `queueDeletion` overloads have moved to
+  // `SyncCoordinator+QueueChanges.swift` — extracted to keep this file
+  // under SwiftLint's 400-line `file_length` threshold.
 
   func sendChanges() async {
     guard let syncEngine, isRunning else { return }

--- a/Backends/CloudKit/Sync/SyncCoordinator+QueueChanges.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+QueueChanges.swift
@@ -1,0 +1,44 @@
+import CloudKit
+import Foundation
+
+// `queueSave` / `queueDeletion` overloads extracted from
+// `SyncCoordinator+Lifecycle.swift` so that file stays under SwiftLint's
+// 400-line `file_length` threshold. Same per-method behaviour: append a
+// `pendingRecordZoneChange` to the engine's state and refresh the
+// sidebar mirror so the pending-uploads counter stays in sync.
+extension SyncCoordinator {
+
+  // MARK: - Pending Changes
+
+  // During the short window between `start()` returning and `completeStart`
+  // installing the engine, these queue calls silently no-op. That's safe
+  // because no user-driven edits can reach `queueSave`/`queueDeletion` before
+  // the UI is ready, and any already-persisted records are re-queued by
+  // `queueAllExistingRecordsForAllZones` / `queueUnsyncedRecordsForAllProfiles`
+  // inside `completeStart`.
+  func queueSave(recordType: String, id: UUID, zoneID: CKRecordZone.ID) {
+    let recordID = CKRecord.ID(
+      recordType: recordType, uuid: id, zoneID: zoneID)
+    syncEngine?.state.add(pendingRecordZoneChanges: [.saveRecord(recordID)])
+    refreshPendingUploadsMirror()
+  }
+
+  func queueSave(recordName: String, zoneID: CKRecordZone.ID) {
+    let recordID = CKRecord.ID(recordName: recordName, zoneID: zoneID)
+    syncEngine?.state.add(pendingRecordZoneChanges: [.saveRecord(recordID)])
+    refreshPendingUploadsMirror()
+  }
+
+  func queueDeletion(recordType: String, id: UUID, zoneID: CKRecordZone.ID) {
+    let recordID = CKRecord.ID(
+      recordType: recordType, uuid: id, zoneID: zoneID)
+    syncEngine?.state.add(pendingRecordZoneChanges: [.deleteRecord(recordID)])
+    refreshPendingUploadsMirror()
+  }
+
+  func queueDeletion(recordName: String, zoneID: CKRecordZone.ID) {
+    let recordID = CKRecord.ID(recordName: recordName, zoneID: zoneID)
+    syncEngine?.state.add(pendingRecordZoneChanges: [.deleteRecord(recordID)])
+    refreshPendingUploadsMirror()
+  }
+}

--- a/MoolahTests/Sync/TransactionHookUpdateDeleteTests.swift
+++ b/MoolahTests/Sync/TransactionHookUpdateDeleteTests.swift
@@ -1,0 +1,134 @@
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+/// Pins the per-leg multi-type hook contract for `GRDBTransactionRepository`
+/// `update(_:)` and `delete(id:)`. The header tests for `create(_:)` live
+/// in `RepositoryHookRecordTypeTests`; these are split out so neither
+/// file exceeds SwiftLint's 250-line `type_body_length` budget.
+///
+/// A regression that hard-coded `TransactionRow.recordType` on the leg
+/// emits in `update` / `delete` would upload leg records under the wrong
+/// recordName and phantom-delete on every other device.
+@Suite("Transaction hooks emit per-leg record types on update/delete")
+@MainActor
+struct TransactionHookUpdateDeleteTests {
+
+  /// Confined to `@MainActor` so the (non-Sendable) closures wired to the
+  /// repository can append into the buffers without crossing actors.
+  @MainActor
+  final class HookCapture {
+    var changed: [(recordType: String, id: UUID)] = []
+    var deleted: [(recordType: String, id: UUID)] = []
+  }
+
+  private func makeChangedHook(
+    _ capture: HookCapture
+  ) -> @Sendable (String, UUID) -> Void {
+    { recordType, id in
+      Task { @MainActor in
+        capture.changed.append((recordType, id))
+      }
+    }
+  }
+
+  private func makeDeletedHook(
+    _ capture: HookCapture
+  ) -> @Sendable (String, UUID) -> Void {
+    { recordType, id in
+      Task { @MainActor in
+        capture.deleted.append((recordType, id))
+      }
+    }
+  }
+
+  private func drainHookHops() async throws {
+    try await Task.sleep(for: .milliseconds(50))
+  }
+
+  @Test("update(_:) emits TransactionRecord change plus per-leg LegRecord changes/deletes")
+  func transactionUpdateEmitsLegRecordType() async throws {
+    let database = try ProfileDatabase.openInMemory()
+    let capture = HookCapture()
+    let txnRepo = GRDBTransactionRepository(
+      database: database,
+      defaultInstrument: .defaultTestInstrument,
+      conversionService: FixedConversionService(),
+      onRecordChanged: makeChangedHook(capture),
+      onRecordDeleted: makeDeletedHook(capture))
+
+    let accountId = UUID()
+    let txn = try await txnRepo.create(
+      Transaction(
+        date: Date(), payee: "Trade",
+        legs: [
+          makeContractTestLeg(accountId: accountId, quantity: -100, type: .transfer),
+          makeContractTestLeg(accountId: accountId, quantity: 100, type: .transfer),
+        ]))
+    try await drainHookHops()
+    capture.changed.removeAll()
+    capture.deleted.removeAll()
+
+    // Update with a fresh 2-leg set. `performUpdate` always replaces
+    // every leg row (new UUIDs assigned inside the repo) so the hook
+    // fan-out is: 1 TransactionRow change, 2 TransactionLegRow changes
+    // for the new legs, 2 TransactionLegRow deletes for the old legs.
+    let updated = Transaction(
+      id: txn.id, date: txn.date, payee: "Trade",
+      legs: [
+        makeContractTestLeg(accountId: accountId, quantity: -50, type: .transfer),
+        makeContractTestLeg(accountId: accountId, quantity: 50, type: .transfer),
+      ])
+    _ = try await txnRepo.update(updated)
+    try await drainHookHops()
+
+    let txnEmits = capture.changed.filter { $0.recordType == TransactionRow.recordType }
+    #expect(txnEmits.map(\.id) == [txn.id])
+    let legChanges = capture.changed.filter { $0.recordType == TransactionLegRow.recordType }
+    // A regression that mis-tagged the per-leg insert emit with the
+    // TransactionRow.recordType would drop this count to 0.
+    #expect(legChanges.count == 2)
+    let legDeletes = capture.deleted.filter { $0.recordType == TransactionLegRow.recordType }
+    #expect(legDeletes.count == 2)
+    let txnDeletes = capture.deleted.filter { $0.recordType == TransactionRow.recordType }
+    #expect(txnDeletes.isEmpty)
+  }
+
+  @Test("delete(id:) emits TransactionRecord delete plus per-leg LegRecord deletes")
+  func transactionDeleteEmitsLegRecordType() async throws {
+    let database = try ProfileDatabase.openInMemory()
+    let capture = HookCapture()
+    let txnRepo = GRDBTransactionRepository(
+      database: database,
+      defaultInstrument: .defaultTestInstrument,
+      conversionService: FixedConversionService(),
+      onRecordChanged: makeChangedHook(capture),
+      onRecordDeleted: makeDeletedHook(capture))
+
+    let accountId = UUID()
+    let txn = try await txnRepo.create(
+      Transaction(
+        date: Date(), payee: "Trade",
+        legs: [
+          makeContractTestLeg(accountId: accountId, quantity: -100, type: .transfer),
+          makeContractTestLeg(accountId: accountId, quantity: 100, type: .transfer),
+        ]))
+    try await drainHookHops()
+    capture.changed.removeAll()
+    capture.deleted.removeAll()
+
+    try await txnRepo.delete(id: txn.id)
+    try await drainHookHops()
+
+    let txnDeletes = capture.deleted.filter { $0.recordType == TransactionRow.recordType }
+    #expect(txnDeletes.map(\.id) == [txn.id])
+    let legDeletes = capture.deleted.filter { $0.recordType == TransactionLegRow.recordType }
+    // Two legs created → two leg-deletes emitted. A regression that
+    // hard-coded `TransactionRow.recordType` on leg emits would drop
+    // these to zero (and uploads would phantom-delete on other devices).
+    #expect(legDeletes.count == 2)
+    #expect(capture.changed.isEmpty)
+  }
+}


### PR DESCRIPTION
## Summary

Supersedes [#723](https://github.com/ajsutton/moolah-native/pull/723) (ejected from merge queue: spec build tripped `file_length` on `SyncCoordinator+Lifecycle.swift` after #722's churn brought the file to exactly 400 lines, leaving no room for the new call).

- **#684** — `queueDeletion(recordName:zoneID:)` now calls `refreshPendingUploadsMirror()` like its three sibling overloads.
- **Refactor** — Extracts the four `queueSave` / `queueDeletion` overloads to a new sibling `SyncCoordinator+QueueChanges.swift` so `+Lifecycle` stays under 400 lines (currently 373).
- **#681** — Adds `transactionUpdateEmitsLegRecordType` and `transactionDeleteEmitsLegRecordType` tests pinning the multi-type hook contract. Lives in a new file so `RepositoryHookRecordTypeTests` stays under SwiftLint's 250-line `type_body_length` budget.

## Test plan

- [x] `just test-mac TransactionHookUpdateDeleteTests RepositoryHookRecordTypeTests` — green locally.
- [x] `SyncCoordinator+Lifecycle.swift` at 373 lines, well under the 400 threshold.
- [ ] CI green (macOS + iOS test suites; `just format-check`).

Closes #723
Fixes #681
Fixes #684

🤖 Generated with [Claude Code](https://claude.com/claude-code)