### PR TITLE
fix(settings): fill macOS Profiles tab when no profile is selected

### DIFF
--- a/Features/Settings/SettingsView+macOS.swift
+++ b/Features/Settings/SettingsView+macOS.swift
@@ -245,11 +245,15 @@
         profileDetailView(for: profile)
           .id(selectedID)
       } else {
+        // Without `maxHeight: .infinity` the `HSplitView` collapses both
+        // columns to the intrinsic height of `ContentUnavailableView`, so
+        // the sidebar fill stops short of the window's bottom edge.
         ContentUnavailableView(
           "No Profile Selected",
           systemImage: "person.crop.circle",
           description: Text("Select a profile to view its settings.")
         )
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
       }
     }
   }


### PR DESCRIPTION
## Summary
- The Profiles tab's `HSplitView` sized both columns to the intrinsic height of the right pane. With a profile selected the right pane is a grouped `Form` that expands; with nothing selected it's a `ContentUnavailableView` whose intrinsic height is much shorter, so the entire split view collapsed and the sidebar fill / divider stopped short of the window's bottom edge.
- Pin the empty `ContentUnavailableView` to `maxWidth: .infinity, maxHeight: .infinity` so the right pane claims full height; the sidebar then matches.

## Test plan
- [x] Verified visually via Xcode `#Preview` that the sidebar now extends to the window's bottom in the no-selection state and matches the in-selection layout.
- [x] `just format-check` clean.
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)