### PR TITLE
feat: add per-account valuationMode field (no behaviour change)

### DIFF
--- a/App/UITestSeedHydrator+Upserts.swift
+++ b/App/UITestSeedHydrator+Upserts.swift
@@ -94,7 +94,8 @@ extension UITestSeedHydrator {
       instrumentId: spec.instrumentId,
       position: spec.position,
       isHidden: false,
-      encodedSystemFields: nil)
+      encodedSystemFields: nil,
+      valuationMode: ValuationMode.recordedValue.rawValue)
     try row.upsert(database)
   }
 

--- a/Backends/CloudKit/Models/AccountRecord.swift
+++ b/Backends/CloudKit/Models/AccountRecord.swift
@@ -12,6 +12,7 @@ final class AccountRecord {
   var position: Int = 0
   var instrumentId: String = "AUD"
   var isHidden: Bool = false
+  var valuationMode: String = "recordedValue"  // Raw value of ValuationMode
   var encodedSystemFields: Data?
 
   init(
@@ -45,12 +46,13 @@ final class AccountRecord {
       instrument: instrument,
       positions: positions,
       position: position,
-      isHidden: isHidden
+      isHidden: isHidden,
+      valuationMode: ValuationMode(rawValue: valuationMode) ?? .recordedValue
     )
   }
 
   static func from(_ account: Account) -> AccountRecord {
-    AccountRecord(
+    let record = AccountRecord(
       id: account.id,
       name: account.name,
       type: account.type.rawValue,
@@ -58,5 +60,7 @@ final class AccountRecord {
       position: account.position,
       isHidden: account.isHidden
     )
+    record.valuationMode = account.valuationMode.rawValue
+    return record
   }
 }

--- a/Backends/CloudKit/Models/AccountRecord.swift
+++ b/Backends/CloudKit/Models/AccountRecord.swift
@@ -21,7 +21,8 @@ final class AccountRecord {
     type: String,
     instrumentId: String = "AUD",
     position: Int = 0,
-    isHidden: Bool = false
+    isHidden: Bool = false,
+    valuationMode: String = "recordedValue"
   ) {
     self.id = id
     self.name = name
@@ -29,6 +30,7 @@ final class AccountRecord {
     self.instrumentId = instrumentId
     self.position = position
     self.isHidden = isHidden
+    self.valuationMode = valuationMode
   }
 
   /// Throws `BackendError.dataCorrupted` when `type` carries a raw value
@@ -52,15 +54,14 @@ final class AccountRecord {
   }
 
   static func from(_ account: Account) -> AccountRecord {
-    let record = AccountRecord(
+    AccountRecord(
       id: account.id,
       name: account.name,
       type: account.type.rawValue,
       instrumentId: account.instrument.id,
       position: account.position,
-      isHidden: account.isHidden
+      isHidden: account.isHidden,
+      valuationMode: account.valuationMode.rawValue
     )
-    record.valuationMode = account.valuationMode.rawValue
-    return record
   }
 }

--- a/Backends/GRDB/Migration/SwiftDataToGRDBMigrator+CoreFinancialGraph.swift
+++ b/Backends/GRDB/Migration/SwiftDataToGRDBMigrator+CoreFinancialGraph.swift
@@ -223,7 +223,8 @@ extension SwiftDataToGRDBMigrator {
       instrumentId: source.instrumentId,
       position: source.position,
       isHidden: source.isHidden,
-      encodedSystemFields: source.encodedSystemFields)
+      encodedSystemFields: source.encodedSystemFields,
+      valuationMode: ValuationMode.recordedValue.rawValue)
   }
 
 }

--- a/Backends/GRDB/Migration/SwiftDataToGRDBMigrator+CoreFinancialGraph.swift
+++ b/Backends/GRDB/Migration/SwiftDataToGRDBMigrator+CoreFinancialGraph.swift
@@ -224,7 +224,7 @@ extension SwiftDataToGRDBMigrator {
       position: source.position,
       isHidden: source.isHidden,
       encodedSystemFields: source.encodedSystemFields,
-      valuationMode: ValuationMode.recordedValue.rawValue)
+      valuationMode: source.valuationMode)
   }
 
 }

--- a/Backends/GRDB/ProfileSchema+AccountValuationMode.swift
+++ b/Backends/GRDB/ProfileSchema+AccountValuationMode.swift
@@ -1,0 +1,20 @@
+// Backends/GRDB/ProfileSchema+AccountValuationMode.swift
+
+import Foundation
+import GRDB
+
+extension ProfileSchema {
+  /// v6 migration body. Adds `valuation_mode` to the `account` table.
+  /// Default `'recordedValue'` backfills every existing row so the
+  /// CHECK constraint stays satisfied; per
+  /// `guides/DATABASE_SCHEMA_GUIDE.md` enum-shaped TEXT columns must
+  /// pin the raw values from the matching Swift enum (`ValuationMode`).
+  static func addAccountValuationMode(_ database: Database) throws {
+    try database.execute(
+      sql: """
+        ALTER TABLE account
+          ADD COLUMN valuation_mode TEXT NOT NULL DEFAULT 'recordedValue'
+            CHECK (valuation_mode IN ('recordedValue', 'calculatedFromTrades'));
+        """)
+  }
+}

--- a/Backends/GRDB/ProfileSchema.swift
+++ b/Backends/GRDB/ProfileSchema.swift
@@ -24,6 +24,10 @@ import GRDB
 /// core financial graph (`category`, `earmark_budget_item`,
 /// `transaction_leg`, `investment_value`) without any FK clauses.
 /// See `ProfileSchema+DropForeignKeys.swift` for rationale.
+/// `v6_account_valuation_mode` — adds the `valuation_mode` column to
+/// the `account` table (per-account choice between recorded value and
+/// calculated-from-trades). See
+/// `ProfileSchema+AccountValuationMode.swift`.
 ///
 /// **Retention policy for the cache tables.** All six cache tables
 /// created by `v1_initial` (`exchange_rate`, `exchange_rate_meta`,
@@ -44,7 +48,7 @@ enum ProfileSchema {
   /// Bumped each time a migration is added. Surfaced for open-time
   /// integrity checks; not used by `DatabaseMigrator` (which keys on
   /// the stable string IDs of registered migrations).
-  static let version = 5
+  static let version = 6
 
   static var migrator: DatabaseMigrator {
     var migrator = DatabaseMigrator()
@@ -62,6 +66,8 @@ enum ProfileSchema {
       "v4_rate_cache_without_rowid", migrate: rebuildRateCacheMetaWithoutRowid)
     migrator.registerMigration(
       "v5_drop_foreign_keys", migrate: dropForeignKeys)
+    migrator.registerMigration(
+      "v6_account_valuation_mode", migrate: addAccountValuationMode)
 
     return migrator
   }

--- a/Backends/GRDB/Records/AccountRow+Mapping.swift
+++ b/Backends/GRDB/Records/AccountRow+Mapping.swift
@@ -23,6 +23,7 @@ extension AccountRow {
     self.position = domain.position
     self.isHidden = domain.isHidden
     self.encodedSystemFields = nil
+    self.valuationMode = domain.valuationMode.rawValue
   }
 
   /// Domain projection. `instruments` is the registry lookup
@@ -45,6 +46,7 @@ extension AccountRow {
       instrument: instrument,
       positions: positions,
       position: position,
-      isHidden: isHidden)
+      isHidden: isHidden,
+      valuationMode: ValuationMode(rawValue: valuationMode) ?? .recordedValue)
   }
 }

--- a/Backends/GRDB/Records/AccountRow.swift
+++ b/Backends/GRDB/Records/AccountRow.swift
@@ -23,6 +23,7 @@ struct AccountRow {
     case position
     case isHidden = "is_hidden"
     case encodedSystemFields = "encoded_system_fields"
+    case valuationMode = "valuation_mode"
   }
 
   enum CodingKeys: String, CodingKey {
@@ -34,6 +35,7 @@ struct AccountRow {
     case position
     case isHidden = "is_hidden"
     case encodedSystemFields = "encoded_system_fields"
+    case valuationMode = "valuation_mode"
   }
 
   var id: UUID
@@ -46,6 +48,10 @@ struct AccountRow {
   var position: Int
   var isHidden: Bool
   var encodedSystemFields: Data?
+  /// Raw value of `ValuationMode` (`"recordedValue"` /
+  /// `"calculatedFromTrades"`). Decoded with a `recordedValue` fallback
+  /// to tolerate forward-incompatible schema migrations.
+  var valuationMode: String
 }
 
 extension AccountRow: Codable {}

--- a/Backends/GRDB/Repositories/GRDBAccountRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBAccountRepository.swift
@@ -196,6 +196,7 @@ final class GRDBAccountRepository: AccountRepository, @unchecked Sendable {
       existing.instrumentId = account.instrument.id
       existing.position = account.position
       existing.isHidden = account.isHidden
+      existing.valuationMode = account.valuationMode.rawValue
       try existing.update(database)
 
       let instruments = try Self.fetchInstrumentMap(database: database)

--- a/Backends/GRDB/Sync/AccountRow+CloudKit.swift
+++ b/Backends/GRDB/Sync/AccountRow+CloudKit.swift
@@ -38,7 +38,10 @@ extension AccountRow: CloudKitRecordConvertible {
       isHidden: (fields.isHidden ?? 0) != 0,
       // Stamped by applyGRDBBatchSave after upsert; never read from the
       // CKRecord itself.
-      encodedSystemFields: nil
+      encodedSystemFields: nil,
+      // Wire-level default until valuation mode is part of the CloudKit
+      // schema (handled in a later task).
+      valuationMode: ValuationMode.recordedValue.rawValue
     )
   }
 }

--- a/Backends/GRDB/Sync/AccountRow+CloudKit.swift
+++ b/Backends/GRDB/Sync/AccountRow+CloudKit.swift
@@ -20,7 +20,8 @@ extension AccountRow: CloudKitRecordConvertible {
       isHidden: isHidden ? 1 : 0,
       name: name,
       position: Int64(position),
-      type: type
+      type: type,
+      valuationMode: valuationMode
     ).write(to: record)
     return record
   }
@@ -39,9 +40,7 @@ extension AccountRow: CloudKitRecordConvertible {
       // Stamped by applyGRDBBatchSave after upsert; never read from the
       // CKRecord itself.
       encodedSystemFields: nil,
-      // Wire-level default until valuation mode is part of the CloudKit
-      // schema (handled in a later task).
-      valuationMode: ValuationMode.recordedValue.rawValue
+      valuationMode: fields.valuationMode ?? "recordedValue"
     )
   }
 }

--- a/CloudKit/schema.ckdb
+++ b/CloudKit/schema.ckdb
@@ -12,6 +12,7 @@ DEFINE SCHEMA
         name            STRING QUERYABLE SEARCHABLE SORTABLE,
         position        INT64 QUERYABLE SORTABLE,
         type            STRING QUERYABLE SEARCHABLE SORTABLE,
+        valuationMode   STRING QUERYABLE SORTABLE,
         GRANT WRITE TO "_creator",
         GRANT CREATE TO "_icloud",
         GRANT READ TO "_world"

--- a/CloudKit/schema.ckdb
+++ b/CloudKit/schema.ckdb
@@ -12,7 +12,7 @@ DEFINE SCHEMA
         name            STRING QUERYABLE SEARCHABLE SORTABLE,
         position        INT64 QUERYABLE SORTABLE,
         type            STRING QUERYABLE SEARCHABLE SORTABLE,
-        valuationMode   STRING QUERYABLE SORTABLE,
+        valuationMode   STRING QUERYABLE SEARCHABLE SORTABLE,
         GRANT WRITE TO "_creator",
         GRANT CREATE TO "_icloud",
         GRANT READ TO "_world"

--- a/Domain/Models/Account.swift
+++ b/Domain/Models/Account.swift
@@ -66,6 +66,8 @@ struct Account: Codable, Sendable, Identifiable, Hashable, Comparable {
     name = try container.decode(String.self, forKey: .name)
     type = try container.decode(AccountType.self, forKey: .type)
     instrument = try container.decodeIfPresent(Instrument.self, forKey: .instrument) ?? .AUD
+    // positions are not persisted via Codable — they are computed by the
+    // repository layer from transaction legs and injected at fetch time.
     positions = []
     position = try container.decode(Int.self, forKey: .position)
     isHidden = try container.decode(Bool.self, forKey: .isHidden)

--- a/Domain/Models/Account.swift
+++ b/Domain/Models/Account.swift
@@ -28,6 +28,7 @@ struct Account: Codable, Sendable, Identifiable, Hashable, Comparable {
   var positions: [Position]
   var position: Int
   var isHidden: Bool
+  var valuationMode: ValuationMode
 
   init(
     id: UUID = UUID(),
@@ -36,7 +37,8 @@ struct Account: Codable, Sendable, Identifiable, Hashable, Comparable {
     instrument: Instrument,
     positions: [Position] = [],
     position: Int = 0,
-    isHidden: Bool = false
+    isHidden: Bool = false,
+    valuationMode: ValuationMode = .recordedValue
   ) {
     self.id = id
     self.name = name
@@ -45,6 +47,7 @@ struct Account: Codable, Sendable, Identifiable, Hashable, Comparable {
     self.positions = positions
     self.position = position
     self.isHidden = isHidden
+    self.valuationMode = valuationMode
   }
 
   private enum CodingKeys: String, CodingKey {
@@ -54,6 +57,7 @@ struct Account: Codable, Sendable, Identifiable, Hashable, Comparable {
     case instrument
     case position
     case isHidden = "hidden"
+    case valuationMode
   }
 
   init(from decoder: Decoder) throws {
@@ -65,6 +69,8 @@ struct Account: Codable, Sendable, Identifiable, Hashable, Comparable {
     positions = []
     position = try container.decode(Int.self, forKey: .position)
     isHidden = try container.decode(Bool.self, forKey: .isHidden)
+    valuationMode =
+      try container.decodeIfPresent(ValuationMode.self, forKey: .valuationMode) ?? .recordedValue
   }
 
   func encode(to encoder: Encoder) throws {
@@ -75,12 +81,14 @@ struct Account: Codable, Sendable, Identifiable, Hashable, Comparable {
     try container.encode(instrument, forKey: .instrument)
     try container.encode(position, forKey: .position)
     try container.encode(isHidden, forKey: .isHidden)
+    try container.encode(valuationMode, forKey: .valuationMode)
   }
 
   static func == (lhs: Account, rhs: Account) -> Bool {
     lhs.id == rhs.id && lhs.name == rhs.name && lhs.type == rhs.type
       && lhs.instrument == rhs.instrument
       && lhs.position == rhs.position && lhs.isHidden == rhs.isHidden
+      && lhs.valuationMode == rhs.valuationMode
   }
 
   func hash(into hasher: inout Hasher) {
@@ -90,6 +98,7 @@ struct Account: Codable, Sendable, Identifiable, Hashable, Comparable {
     hasher.combine(instrument)
     hasher.combine(position)
     hasher.combine(isHidden)
+    hasher.combine(valuationMode)
   }
 
   static func < (lhs: Account, rhs: Account) -> Bool {

--- a/Domain/Models/ValuationMode.swift
+++ b/Domain/Models/ValuationMode.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+/// Selects how an investment account's "current value" is computed for
+/// balance display, totals, and reports.
+///
+/// - `recordedValue`: the latest user-entered `InvestmentValue` snapshot
+///   drives the displayed value. Snapshots are edited via the legacy
+///   investment-account view.
+/// - `calculatedFromTrades`: the value is computed by summing positions
+///   (derived from trade transactions) at current instrument prices.
+///
+/// The mode is a per-`Account` setting; switching is reversible.
+/// See `plans/2026-05-04-per-account-valuation-mode-design.md`.
+enum ValuationMode: String, Codable, Sendable, CaseIterable {
+  case recordedValue
+  case calculatedFromTrades
+}

--- a/Domain/Models/ValuationMode.swift
+++ b/Domain/Models/ValuationMode.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// Selects how an investment account's "current value" is computed for
 /// balance display, totals, and reports.
 ///

--- a/MoolahTests/Backends/CloudKit/AccountRecordValuationModeTests.swift
+++ b/MoolahTests/Backends/CloudKit/AccountRecordValuationModeTests.swift
@@ -1,0 +1,35 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("AccountRecord (SwiftData mirror) valuationMode")
+struct AccountRecordValuationModeTests {
+  @Test("from(_:) writes valuationMode")
+  func fromAccountWritesField() {
+    let account = Account(
+      name: "Brokerage", type: .investment, instrument: .AUD,
+      valuationMode: .calculatedFromTrades)
+    let record = AccountRecord.from(account)
+    #expect(record.valuationMode == "calculatedFromTrades")
+  }
+
+  @Test("toDomain carries valuationMode through")
+  func toDomainCarriesField() throws {
+    let record = AccountRecord(
+      name: "Brokerage", type: "investment",
+      instrumentId: "AUD", position: 0, isHidden: false)
+    record.valuationMode = "calculatedFromTrades"
+    let account = try record.toDomain()
+    #expect(account.valuationMode == .calculatedFromTrades)
+  }
+
+  @Test("missing column defaults to recordedValue")
+  func legacyRowDecodesAsRecordedValue() throws {
+    let record = AccountRecord(
+      name: "Old", type: "investment",
+      instrumentId: "AUD", position: 0, isHidden: false)
+    let account = try record.toDomain()
+    #expect(account.valuationMode == .recordedValue)
+  }
+}

--- a/MoolahTests/Backends/GRDB/AccountRowCloudKitFieldsTests.swift
+++ b/MoolahTests/Backends/GRDB/AccountRowCloudKitFieldsTests.swift
@@ -1,0 +1,38 @@
+import CloudKit
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("AccountRow ↔ CKRecord round-trip (valuationMode)")
+struct AccountRowCloudKitFieldsTests {
+  @Test("explicit valuationMode round-trips")
+  func roundTrip() throws {
+    for raw in ["recordedValue", "calculatedFromTrades"] {
+      let row = AccountRow(
+        id: UUID(), recordName: "AccountRecord|x", name: "B",
+        type: "investment", instrumentId: "AUD", position: 0,
+        isHidden: false, encodedSystemFields: nil, valuationMode: raw)
+      let zoneID = CKRecordZone.ID(zoneName: "z", ownerName: CKCurrentUserDefaultName)
+      let record = row.toCKRecord(in: zoneID)
+      let decoded = try #require(AccountRow.fieldValues(from: record))
+      #expect(decoded.valuationMode == raw)
+    }
+  }
+
+  @Test("missing CKRecord field decodes as recordedValue")
+  func missingFieldFallsBack() throws {
+    let zoneID = CKRecordZone.ID(zoneName: "z", ownerName: CKCurrentUserDefaultName)
+    let recordID = CKRecord.ID(
+      recordType: AccountRow.recordType, uuid: UUID(), zoneID: zoneID)
+    let record = CKRecord(recordType: AccountRow.recordType, recordID: recordID)
+    record["name"] = "B"
+    record["type"] = "investment"
+    record["instrumentId"] = "AUD"
+    record["position"] = Int64(0)
+    record["isHidden"] = Int64(0)
+    // valuationMode intentionally not set
+    let decoded = try #require(AccountRow.fieldValues(from: record))
+    #expect(decoded.valuationMode == "recordedValue")
+  }
+}

--- a/MoolahTests/Backends/GRDB/AccountRowValuationModeTests.swift
+++ b/MoolahTests/Backends/GRDB/AccountRowValuationModeTests.swift
@@ -1,0 +1,40 @@
+// MoolahTests/Backends/GRDB/AccountRowValuationModeTests.swift
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+@Suite("AccountRow.valuationMode")
+struct AccountRowValuationModeTests {
+  @Test("init(domain:) writes valuationMode")
+  func initFromDomain() {
+    let account = Account(
+      name: "Brokerage", type: .investment, instrument: .AUD,
+      valuationMode: .calculatedFromTrades)
+    let row = AccountRow(domain: account)
+    #expect(row.valuationMode == "calculatedFromTrades")
+  }
+
+  @Test("toDomain carries the column back")
+  func toDomain() throws {
+    let row = AccountRow(
+      id: UUID(), recordName: "AccountRecord|x", name: "B",
+      type: "investment", instrumentId: "AUD", position: 0,
+      isHidden: false, encodedSystemFields: nil,
+      valuationMode: "calculatedFromTrades")
+    let account = try row.toDomain()
+    #expect(account.valuationMode == .calculatedFromTrades)
+  }
+
+  @Test("toDomain falls back to recordedValue on unknown raw value")
+  func toDomainUnknownValue() throws {
+    let row = AccountRow(
+      id: UUID(), recordName: "AccountRecord|x", name: "B",
+      type: "investment", instrumentId: "AUD", position: 0,
+      isHidden: false, encodedSystemFields: nil,
+      valuationMode: "garbage")
+    let account = try row.toDomain()
+    #expect(account.valuationMode == .recordedValue)
+  }
+}

--- a/MoolahTests/Backends/GRDB/AccountValuationModeMigrationTests.swift
+++ b/MoolahTests/Backends/GRDB/AccountValuationModeMigrationTests.swift
@@ -41,8 +41,8 @@ struct AccountValuationModeMigrationTests {
     }
   }
 
-  @Test("default value backfills legacy rows when ALTER runs")
-  func defaultBackfills() throws {
+  @Test("INSERT omitting valuation_mode column receives DEFAULT recordedValue")
+  func newRowWithoutValuationModeGetsDefault() throws {
     let queue = try DatabaseQueue()
     try ProfileSchema.migrator.migrate(queue)
     try queue.write { database in

--- a/MoolahTests/Backends/GRDB/AccountValuationModeMigrationTests.swift
+++ b/MoolahTests/Backends/GRDB/AccountValuationModeMigrationTests.swift
@@ -1,0 +1,65 @@
+// MoolahTests/Backends/GRDB/AccountValuationModeMigrationTests.swift
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+@Suite("v6_account_valuation_mode migration")
+struct AccountValuationModeMigrationTests {
+  @Test("column exists on the account table after migration")
+  func columnExists() throws {
+    let queue = try DatabaseQueue()
+    try ProfileSchema.migrator.migrate(queue)
+    try queue.read { database in
+      let columns = try database.columns(in: "account")
+      #expect(columns.contains { $0.name == "valuation_mode" })
+    }
+  }
+
+  @Test("CHECK constraint rejects unknown raw values")
+  func checkConstraintRejectsBadValues() throws {
+    let queue = try DatabaseQueue()
+    try ProfileSchema.migrator.migrate(queue)
+    try queue.write { database in
+      do {
+        try database.execute(
+          sql: """
+            INSERT INTO account
+              (id, record_name, name, type, instrument_id, position,
+               is_hidden, valuation_mode)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+          arguments: [
+            Data(repeating: 1, count: 16), "AccountRecord|y", "B",
+            "investment", "AUD", 0, 0, "garbage",
+          ])
+        Issue.record("Expected CHECK constraint failure")
+      } catch let error as DatabaseError {
+        #expect(error.resultCode == .SQLITE_CONSTRAINT)
+      }
+    }
+  }
+
+  @Test("default value backfills legacy rows when ALTER runs")
+  func defaultBackfills() throws {
+    let queue = try DatabaseQueue()
+    try ProfileSchema.migrator.migrate(queue)
+    try queue.write { database in
+      try database.execute(
+        sql: """
+          INSERT INTO account
+            (id, record_name, name, type, instrument_id, position, is_hidden)
+          VALUES (?, ?, ?, ?, ?, ?, ?)
+          """,
+        arguments: [
+          Data(repeating: 0, count: 16), "AccountRecord|x", "B",
+          "investment", "AUD", 0, 0,
+        ])
+    }
+    let mode: String? = try queue.read { database in
+      try String.fetchOne(database, sql: "SELECT valuation_mode FROM account")
+    }
+    #expect(mode == "recordedValue")
+  }
+}

--- a/MoolahTests/Backends/UnknownEnumRawValueTests.swift
+++ b/MoolahTests/Backends/UnknownEnumRawValueTests.swift
@@ -28,7 +28,8 @@ struct UnknownEnumRawValueTests {
       instrumentId: "AUD",
       position: 0,
       isHidden: false,
-      encodedSystemFields: nil)
+      encodedSystemFields: nil,
+      valuationMode: ValuationMode.recordedValue.rawValue)
 
     #expect(
       throws: BackendError.dataCorrupted("Unknown AccountType raw value: future_account_type")

--- a/MoolahTests/Domain/AccountValuationModeContractTests.swift
+++ b/MoolahTests/Domain/AccountValuationModeContractTests.swift
@@ -3,7 +3,7 @@ import Testing
 
 @testable import Moolah
 
-@Suite("Account ValuationMode Contract")
+@Suite("AccountRepository Contract — valuationMode")
 struct AccountValuationModeContractTests {
 
   @Test("valuationMode round-trips through create + fetchAll + update")
@@ -25,8 +25,8 @@ struct AccountValuationModeContractTests {
     let resaved = try await backend.accounts.update(updated)
     #expect(resaved.valuationMode == .recordedValue)
 
-    let final = try await backend.accounts.fetchAll()
-    let refetched = try #require(final.first { $0.id == saved.id })
+    let refetchedAll = try await backend.accounts.fetchAll()
+    let refetched = try #require(refetchedAll.first { $0.id == saved.id })
     #expect(refetched.valuationMode == .recordedValue)
   }
 }

--- a/MoolahTests/Domain/AccountValuationModeContractTests.swift
+++ b/MoolahTests/Domain/AccountValuationModeContractTests.swift
@@ -1,0 +1,32 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("Account ValuationMode Contract")
+struct AccountValuationModeContractTests {
+
+  @Test("valuationMode round-trips through create + fetchAll + update")
+  func testValuationModeRoundTrip() async throws {
+    let (backend, _) = try TestBackend.create()
+    let account = Account(
+      name: "Brokerage", type: .investment, instrument: .AUD,
+      valuationMode: .calculatedFromTrades)
+
+    let saved = try await backend.accounts.create(account, openingBalance: nil)
+    #expect(saved.valuationMode == .calculatedFromTrades)
+
+    let after = try await backend.accounts.fetchAll()
+    let fetched = try #require(after.first { $0.id == saved.id })
+    #expect(fetched.valuationMode == .calculatedFromTrades)
+
+    var updated = fetched
+    updated.valuationMode = .recordedValue
+    let resaved = try await backend.accounts.update(updated)
+    #expect(resaved.valuationMode == .recordedValue)
+
+    let final = try await backend.accounts.fetchAll()
+    let refetched = try #require(final.first { $0.id == saved.id })
+    #expect(refetched.valuationMode == .recordedValue)
+  }
+}

--- a/MoolahTests/Domain/AccountValuationModeTests.swift
+++ b/MoolahTests/Domain/AccountValuationModeTests.swift
@@ -26,7 +26,7 @@ struct AccountValuationModeTests {
         name: "X", type: .investment, instrument: .AUD, valuationMode: mode)
       let data = try JSONEncoder().encode(original)
       let decoded = try JSONDecoder().decode(Account.self, from: data)
-      #expect(decoded.valuationMode == mode)
+      #expect(decoded == original)
     }
   }
 
@@ -55,6 +55,7 @@ struct AccountValuationModeTests {
       valuationMode: .recordedValue)
     var modified = original
     modified.valuationMode = .calculatedFromTrades
+    #expect(original.id == modified.id)
     #expect(original != modified)
   }
 }

--- a/MoolahTests/Domain/AccountValuationModeTests.swift
+++ b/MoolahTests/Domain/AccountValuationModeTests.swift
@@ -1,0 +1,60 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("Account.valuationMode")
+struct AccountValuationModeTests {
+  @Test("default is recordedValue")
+  func defaultIsRecordedValue() {
+    let account = Account(name: "Brokerage", type: .investment, instrument: .AUD)
+    #expect(account.valuationMode == .recordedValue)
+  }
+
+  @Test("explicit init sets the field")
+  func explicitInit() {
+    let account = Account(
+      name: "Brokerage", type: .investment, instrument: .AUD,
+      valuationMode: .calculatedFromTrades)
+    #expect(account.valuationMode == .calculatedFromTrades)
+  }
+
+  @Test("Codable round-trips both cases")
+  func codableRoundTrip() throws {
+    for mode in ValuationMode.allCases {
+      let original = Account(
+        name: "X", type: .investment, instrument: .AUD, valuationMode: mode)
+      let data = try JSONEncoder().encode(original)
+      let decoded = try JSONDecoder().decode(Account.self, from: data)
+      #expect(decoded.valuationMode == mode)
+    }
+  }
+
+  @Test("Codable decodes missing key as recordedValue")
+  func codableMissingKey() throws {
+    let json = Data(
+      """
+      {
+        "id": "00000000-0000-0000-0000-000000000001",
+        "name": "Old",
+        "type": "investment",
+        "instrument": { "id": "AUD", "kind": "fiatCurrency",
+                        "name": "AUD", "decimals": 2 },
+        "position": 0,
+        "hidden": false
+      }
+      """.utf8)
+    let decoded = try JSONDecoder().decode(Account.self, from: json)
+    #expect(decoded.valuationMode == .recordedValue)
+  }
+
+  @Test("Equality includes valuationMode")
+  func equalityIncludesMode() {
+    let original = Account(
+      name: "A", type: .investment, instrument: .AUD,
+      valuationMode: .recordedValue)
+    var modified = original
+    modified.valuationMode = .calculatedFromTrades
+    #expect(original != modified)
+  }
+}

--- a/MoolahTests/Domain/ValuationModeTests.swift
+++ b/MoolahTests/Domain/ValuationModeTests.swift
@@ -1,0 +1,25 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("ValuationMode")
+struct ValuationModeTests {
+  @Test("raw values are stable wire identifiers")
+  func rawValues() {
+    #expect(ValuationMode.recordedValue.rawValue == "recordedValue")
+    #expect(ValuationMode.calculatedFromTrades.rawValue == "calculatedFromTrades")
+  }
+
+  @Test("decodes from raw value")
+  func decode() {
+    #expect(ValuationMode(rawValue: "recordedValue") == .recordedValue)
+    #expect(ValuationMode(rawValue: "calculatedFromTrades") == .calculatedFromTrades)
+    #expect(ValuationMode(rawValue: "unknown") == nil)
+  }
+
+  @Test("CaseIterable lists both cases")
+  func caseIterable() {
+    #expect(Set(ValuationMode.allCases) == [.recordedValue, .calculatedFromTrades])
+  }
+}

--- a/MoolahTests/Domain/ValuationModeTests.swift
+++ b/MoolahTests/Domain/ValuationModeTests.swift
@@ -18,8 +18,17 @@ struct ValuationModeTests {
     #expect(ValuationMode(rawValue: "unknown") == nil)
   }
 
-  @Test("CaseIterable lists both cases")
+  @Test("Codable round-trips through JSON")
+  func codableRoundTrip() throws {
+    for mode in ValuationMode.allCases {
+      let data = try JSONEncoder().encode(mode)
+      let decoded = try JSONDecoder().decode(ValuationMode.self, from: data)
+      #expect(decoded == mode)
+    }
+  }
+
+  @Test("CaseIterable lists both cases in order")
   func caseIterable() {
-    #expect(Set(ValuationMode.allCases) == [.recordedValue, .calculatedFromTrades])
+    #expect(ValuationMode.allCases == [.recordedValue, .calculatedFromTrades])
   }
 }

--- a/MoolahTests/Support/ProfileDataSyncHandlerTestSupport.swift
+++ b/MoolahTests/Support/ProfileDataSyncHandlerTestSupport.swift
@@ -139,7 +139,7 @@ enum ProfileDataSyncHandlerTestSupport {
       position: record.position,
       isHidden: record.isHidden,
       encodedSystemFields: record.encodedSystemFields,
-      valuationMode: ValuationMode.recordedValue.rawValue)
+      valuationMode: record.valuationMode)
   }
 
   private static func earmarkRow(from record: EarmarkRecord) -> EarmarkRow {

--- a/MoolahTests/Support/ProfileDataSyncHandlerTestSupport.swift
+++ b/MoolahTests/Support/ProfileDataSyncHandlerTestSupport.swift
@@ -138,7 +138,8 @@ enum ProfileDataSyncHandlerTestSupport {
       instrumentId: record.instrumentId,
       position: record.position,
       isHidden: record.isHidden,
-      encodedSystemFields: record.encodedSystemFields)
+      encodedSystemFields: record.encodedSystemFields,
+      valuationMode: ValuationMode.recordedValue.rawValue)
   }
 
   private static func earmarkRow(from record: EarmarkRecord) -> EarmarkRow {

--- a/MoolahTests/Sync/ProfileDataSyncHandlerTests.swift
+++ b/MoolahTests/Sync/ProfileDataSyncHandlerTests.swift
@@ -141,7 +141,8 @@ struct ProfileDataSyncHandlerTests {
       instrumentId: "AUD",
       position: 0,
       isHidden: false,
-      encodedSystemFields: nil)
+      encodedSystemFields: nil,
+      valuationMode: ValuationMode.recordedValue.rawValue)
 
     let ckRecord = handler.buildCKRecord(from: row, encodedSystemFields: nil)
 
@@ -186,7 +187,8 @@ struct ProfileDataSyncHandlerTests {
       instrumentId: "AUD",
       position: 0,
       isHidden: false,
-      encodedSystemFields: foreignSystemFields)
+      encodedSystemFields: foreignSystemFields,
+      valuationMode: ValuationMode.recordedValue.rawValue)
 
     let built = handler.buildCKRecord(from: row, encodedSystemFields: foreignSystemFields)
 
@@ -228,7 +230,8 @@ struct ProfileDataSyncHandlerTests {
       instrumentId: "AUD",
       position: 0,
       isHidden: false,
-      encodedSystemFields: cachedSystemFields)
+      encodedSystemFields: cachedSystemFields,
+      valuationMode: ValuationMode.recordedValue.rawValue)
 
     // Build a CKRecord — should reuse cached system fields, which carry a
     // prefixed recordID by construction. The `buildCKRecord` contract is

--- a/MoolahTests/Sync/RecordMappingTests.swift
+++ b/MoolahTests/Sync/RecordMappingTests.swift
@@ -61,7 +61,8 @@ struct RecordMappingTests {
       instrumentId: "USD",
       position: 2,
       isHidden: true,
-      encodedSystemFields: nil
+      encodedSystemFields: nil,
+      valuationMode: ValuationMode.recordedValue.rawValue
     )
 
     let ckRecord = row.toCKRecord(in: zoneID)

--- a/MoolahTests/Sync/RecordMappingTests.swift
+++ b/MoolahTests/Sync/RecordMappingTests.swift
@@ -62,7 +62,7 @@ struct RecordMappingTests {
       position: 2,
       isHidden: true,
       encodedSystemFields: nil,
-      valuationMode: ValuationMode.recordedValue.rawValue
+      valuationMode: ValuationMode.calculatedFromTrades.rawValue
     )
 
     let ckRecord = row.toCKRecord(in: zoneID)
@@ -76,6 +76,7 @@ struct RecordMappingTests {
     #expect(ckRecord["instrumentId"] as? String == "USD")
     #expect(ckRecord["position"] as? Int == 2)
     #expect(ckRecord["isHidden"] as? Int == 1)
+    #expect(ckRecord["valuationMode"] as? String == ValuationMode.calculatedFromTrades.rawValue)
 
     let restored = try #require(AccountRow.fieldValues(from: ckRecord))
     #expect(restored.id == row.id)
@@ -84,6 +85,7 @@ struct RecordMappingTests {
     #expect(restored.instrumentId == "USD")
     #expect(restored.position == 2)
     #expect(restored.isHidden == true)
+    #expect(restored.valuationMode == ValuationMode.calculatedFromTrades.rawValue)
   }
 
   @Test

--- a/MoolahTests/Sync/RecordNameCollisionTests.swift
+++ b/MoolahTests/Sync/RecordNameCollisionTests.swift
@@ -90,7 +90,8 @@ struct RecordNameCollisionTests {
       instrumentId: "AUD",
       position: 0,
       isHidden: false,
-      encodedSystemFields: nil)
+      encodedSystemFields: nil,
+      valuationMode: ValuationMode.recordedValue.rawValue)
 
     let built = handler.buildCKRecord(from: row, encodedSystemFields: nil)
     #expect(
@@ -126,7 +127,8 @@ struct RecordNameCollisionTests {
       instrumentId: "AUD",
       position: 0,
       isHidden: false,
-      encodedSystemFields: legacySystemFields)
+      encodedSystemFields: legacySystemFields,
+      valuationMode: ValuationMode.recordedValue.rawValue)
 
     let built = handler.buildCKRecord(from: row, encodedSystemFields: legacySystemFields)
     #expect(


### PR DESCRIPTION
## Summary
- New `ValuationMode` enum (`recordedValue` | `calculatedFromTrades`) and `Account.valuationMode` field with default `.recordedValue`.
- Round-trip the field through `AccountRow` (GRDB), `AccountRow+CloudKit` (wire), and the legacy SwiftData `AccountRecord` (used by importer + SwiftData→GRDB migrator).
- v6 GRDB migration adds the `valuation_mode` column with `NOT NULL DEFAULT 'recordedValue'` and a CHECK constraint.
- CloudKit schema gains the `valuationMode STRING QUERYABLE SEARCHABLE SORTABLE` field; wire mapping handles missing-field decode.
- Contract test pins the round-trip through `AccountRepository` (also caught + fixed a real bug in `GRDBAccountRepository.update` that was silently dropping `valuationMode` on update — would have shipped a UI-driven mode flip as a no-op).

No call site reads the new field yet — this PR is observably a no-op for users.

Spec: [`plans/2026-05-04-per-account-valuation-mode-design.md`](https://github.com/ajsutton/moolah-native/pull/730/files) (#730 — docs PR also in queue)
Plan: `plans/2026-05-04-per-account-valuation-mode-plan.md` (Phase 1 of 6)

## Review history
Reviewed by `code-review`, `database-schema-review`, `database-code-review`, `sync-review`. All Critical and Important findings applied in `7e2e25d2`, including:
- Two real data-loss bugs in `SwiftDataToGRDBMigrator` and `ProfileDataSyncHandlerTestSupport` (hard-coded `recordedValue` instead of reading the source).
- Schema gains `SEARCHABLE` (safe default for STRING fields).
- `AccountRecord.init` accepts `valuationMode` parameter (symmetric init).
- `RecordMappingTests` round-trip pins the new wire field.

### Deferred
- `Domain/Models/Account.swift` declares `Codable, Sendable, Identifiable, Hashable, Comparable` inline on the primary declaration. CODE_GUIDE.md §2 wants each non-trivial conformance in its own extension. This is pre-existing structural debt; this PR adds to all three but defers the split to a follow-up to keep this PR scoped to the field-add story.

## Test plan
- [x] `just test-mac` green across every affected suite (domain, GRDB, sync, contract)
- [x] `just format-check` clean
- [x] `.swiftlint-baseline.yml` untouched
- [x] No new warnings (Xcode warnings sweep clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)