### PR TITLE
feat: derive Account.valuationMode on profile bootstrap

### DIFF
--- a/App/MoolahApp+Setup.swift
+++ b/App/MoolahApp+Setup.swift
@@ -48,9 +48,16 @@ extension MoolahApp {
         // SwiftData → GRDB migration flags, the second launch's
         // migrator would skip and the seeded SwiftData rows would
         // never reach GRDB — sidebar / accounts queries return empty
-        // and downstream UI assertions time out. Production code
+        // and downstream UI assertions time out. The same reasoning
+        // applies to `ValuationModeMigration`'s per-profile gate
+        // flags: the first launch's profile UUID is dead by the
+        // second launch, but its key would persist and short-circuit
+        // any newer profile that happens to reuse the same UUID
+        // (rare) and — more importantly — leaves stale state visible
+        // to tests that read `UserDefaults.standard`. Production code
         // paths never enter this branch.
         SwiftDataToGRDBMigrator.resetMigrationFlags()
+        ValuationModeMigration.resetGateFlags(in: .standard)
         let manager = try ProfileContainerManager.forTesting()
         let profile = try UITestSeedHydrator.hydrate(seed, into: manager)
         return ContainerSetup(manager: manager, uiTestingProfileId: profile?.id)

--- a/App/ProfileSession.swift
+++ b/App/ProfileSession.swift
@@ -340,6 +340,12 @@ final class ProfileSession: Identifiable {
   /// `SessionManager`) is responsible for surfacing the error to the
   /// user. A failed setUp leaves the migration's `UserDefaults` flags
   /// unset, so the next launch retries.
+  ///
+  /// After the SwiftData → GRDB migration completes, runs the one-shot
+  /// `ValuationModeMigration` so each existing investment account's
+  /// `valuationMode` reflects whether it has any snapshot rows. The
+  /// migration is non-fatal: a failure is logged and the app continues
+  /// because read sites still auto-detect at this rollout stage.
   func setUp() async throws {
     if let existing = setUpTask {
       return try await existing.value
@@ -355,6 +361,27 @@ final class ProfileSession: Identifiable {
     }
     setUpTask = task
     try await task.value
+    await runValuationModeMigration()
+  }
+
+  /// Runs `ValuationModeMigration` for this profile. Non-fatal: any
+  /// thrown error is logged but does not surface to the caller because
+  /// auto-detect read sites are still in place at this rollout stage.
+  /// Called from `setUp()` after the SwiftData → GRDB migration so the
+  /// account / investment-value rows are visible to GRDB-backed
+  /// repositories.
+  private func runValuationModeMigration() async {
+    let migration = ValuationModeMigration(
+      profileId: profile.id,
+      accountRepository: backend.accounts,
+      investmentRepository: backend.investments,
+      userDefaults: .standard)
+    do {
+      try await migration.run()
+    } catch {
+      logger.error(
+        "ValuationModeMigration failed: \(error.localizedDescription, privacy: .public)")
+    }
   }
 
 }

--- a/App/ProfileSession.swift
+++ b/App/ProfileSession.swift
@@ -330,22 +330,25 @@ final class ProfileSession: Identifiable {
       modelContainer: modelContainer, database: database)
   }
 
-  /// Runs the SwiftData → GRDB migration off `@MainActor` and reloads
-  /// the affected stores. Idempotent: subsequent calls return the same
+  /// Runs the bootstrap migrations off `@MainActor` and reloads the
+  /// affected stores. Idempotent: subsequent calls return the same
   /// task so callers can `await session.setUp()` from multiple sites
   /// (UI test seed setup, `SessionManager.session(for:)`, etc.) without
-  /// re-running the migration.
+  /// re-running anything.
   ///
-  /// Throws whatever the migrator throws — the caller (typically
-  /// `SessionManager`) is responsible for surfacing the error to the
-  /// user. A failed setUp leaves the migration's `UserDefaults` flags
-  /// unset, so the next launch retries.
+  /// Phase 1 — SwiftData → GRDB migration.
+  /// Throws whatever the migrator throws (the caller, typically
+  /// `SessionManager`, surfaces the error to the user). A throw leaves
+  /// the migration's `UserDefaults` flags unset so the next launch
+  /// retries.
   ///
-  /// After the SwiftData → GRDB migration completes, runs the one-shot
-  /// `ValuationModeMigration` so each existing investment account's
-  /// `valuationMode` reflects whether it has any snapshot rows. The
-  /// migration is non-fatal: a failure is logged and the app continues
-  /// because read sites still auto-detect at this rollout stage.
+  /// Phase 2 — `ValuationModeMigration`.
+  /// Runs after Phase 1 commits so the GRDB-backed repositories see
+  /// every account / `InvestmentValue` row. Non-fatal: errors are
+  /// logged but do not propagate, because read sites still auto-detect
+  /// at this rollout stage and the next launch will retry. Both phases
+  /// share the same `setUpTask` so the per-session idempotency guard
+  /// covers the whole bootstrap, not just Phase 1.
   func setUp() async throws {
     if let existing = setUpTask {
       return try await existing.value
@@ -358,10 +361,10 @@ final class ProfileSession: Identifiable {
         profileId: profileId,
         containerManager: containerManager,
         database: database)
+      await self.runValuationModeMigration()
     }
     setUpTask = task
     try await task.value
-    await runValuationModeMigration()
   }
 
   /// Runs `ValuationModeMigration` for this profile. Non-fatal: any
@@ -374,7 +377,6 @@ final class ProfileSession: Identifiable {
     let migration = ValuationModeMigration(
       profileId: profile.id,
       accountRepository: backend.accounts,
-      investmentRepository: backend.investments,
       userDefaults: .standard)
     do {
       try await migration.run()

--- a/App/ValuationModeMigration.swift
+++ b/App/ValuationModeMigration.swift
@@ -12,31 +12,47 @@ import OSLog
 struct ValuationModeMigration {
   let profileId: UUID
   let accountRepository: any AccountRepository
-  let investmentRepository: any InvestmentRepository
   let userDefaults: UserDefaults
 
-  private var gateKey: String { "didMigrateValuationMode_\(profileId)" }
-
-  private var logger: Logger {
-    Logger(subsystem: "com.moolah.app", category: "ValuationModeMigration")
+  /// Stable symbol exposed so the UI-test reset path
+  /// (`SwiftDataToGRDBMigrator.resetMigrationFlags`) can clear the
+  /// per-profile gate flag without duplicating the format string.
+  static func gateKey(for profileId: UUID) -> String {
+    "didMigrateValuationMode_\(profileId)"
   }
+
+  /// Common prefix shared by every per-profile gate key. Used by
+  /// `resetGateFlags(in:)` to enumerate all keys this migration owns
+  /// in `UserDefaults` without needing each profile id up front.
+  static let gateKeyPrefix = "didMigrateValuationMode_"
+
+  /// Wipes every per-profile gate key under `gateKeyPrefix` from the
+  /// passed-in `UserDefaults`. Intended for `--ui-testing` launches
+  /// only — each UI test launches a fresh in-memory profile container
+  /// with new ids, so leftover keys from prior launches must not
+  /// short-circuit the migration. No production code path should
+  /// invoke this.
+  static func resetGateFlags(in defaults: UserDefaults) {
+    for key in defaults.dictionaryRepresentation().keys
+    where key.hasPrefix(gateKeyPrefix) {
+      defaults.removeObject(forKey: key)
+    }
+  }
+
+  private static let logger = Logger(
+    subsystem: "com.moolah.app", category: "ValuationModeMigration")
+
+  private var gateKey: String { Self.gateKey(for: profileId) }
 
   func run() async throws {
     if userDefaults.bool(forKey: gateKey) { return }
-
-    let accounts = try await accountRepository.fetchAll()
-    for account in accounts where account.type == .investment {
-      let page = try await investmentRepository.fetchValues(
-        accountId: account.id, page: 0, pageSize: 1)
-      if page.values.isEmpty {
-        var updated = account
-        updated.valuationMode = .calculatedFromTrades
-        _ = try await accountRepository.update(updated)
-        logger.info(
-          "Migrated account \(account.name, privacy: .public) → calculatedFromTrades")
-      }
-      // else: snapshot exists → leave at .recordedValue (no-op write).
-    }
+    guard !Task.isCancelled else { return }
+    let count =
+      try await accountRepository
+      .backfillValuationModeForUnsnapshotInvestmentAccounts()
+    Self.logger.info(
+      "Migrated \(count, privacy: .public) account(s) → calculatedFromTrades")
+    guard !Task.isCancelled else { return }
     userDefaults.set(true, forKey: gateKey)
   }
 }

--- a/App/ValuationModeMigration.swift
+++ b/App/ValuationModeMigration.swift
@@ -1,0 +1,42 @@
+import Foundation
+import OSLog
+
+/// One-shot per-profile migration that derives each investment
+/// account's initial `valuationMode` from snapshot presence.
+///
+/// Runs on first launch after upgrade, gated by a per-profile
+/// `UserDefaults` flag. Re-running with the flag already set is a
+/// no-op. See `plans/2026-05-04-per-account-valuation-mode-design.md`
+/// §4 for the algorithm and §Migration & Rollout for ordering.
+@MainActor
+struct ValuationModeMigration {
+  let profileId: UUID
+  let accountRepository: any AccountRepository
+  let investmentRepository: any InvestmentRepository
+  let userDefaults: UserDefaults
+
+  private var gateKey: String { "didMigrateValuationMode_\(profileId)" }
+
+  private var logger: Logger {
+    Logger(subsystem: "com.moolah.app", category: "ValuationModeMigration")
+  }
+
+  func run() async throws {
+    if userDefaults.bool(forKey: gateKey) { return }
+
+    let accounts = try await accountRepository.fetchAll()
+    for account in accounts where account.type == .investment {
+      let page = try await investmentRepository.fetchValues(
+        accountId: account.id, page: 0, pageSize: 1)
+      if page.values.isEmpty {
+        var updated = account
+        updated.valuationMode = .calculatedFromTrades
+        _ = try await accountRepository.update(updated)
+        logger.info(
+          "Migrated account \(account.name, privacy: .public) → calculatedFromTrades")
+      }
+      // else: snapshot exists → leave at .recordedValue (no-op write).
+    }
+    userDefaults.set(true, forKey: gateKey)
+  }
+}

--- a/Backends/GRDB/Repositories/GRDBAccountRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBAccountRepository.swift
@@ -208,6 +208,35 @@ final class GRDBAccountRepository: AccountRepository, @unchecked Sendable {
     return resolved
   }
 
+  /// Single-statement bootstrap migration: flips every investment
+  /// account without an `InvestmentValue` snapshot to
+  /// `valuationMode = .calculatedFromTrades`. Runs inside one
+  /// `database.write { … }` so the whole pass is one transaction / one
+  /// fsync — replaces the historic per-account loop driven by
+  /// `ValuationModeMigration.run()`.
+  ///
+  /// Idempotency lives one level up — `ValuationModeMigration` gates
+  /// the call on a per-profile `UserDefaults` flag and never invokes
+  /// this method twice for the same install.
+  ///
+  /// Hooks are deliberately not fired: this runs at bootstrap before
+  /// any sync subscriber is attached, and the new value is locally
+  /// derived state (CKSyncEngine treats `valuation_mode` like any
+  /// other field — the next remote upload will surface the change via
+  /// the regular store path).
+  func backfillValuationModeForUnsnapshotInvestmentAccounts() async throws -> Int {
+    try await database.write { database in
+      try database.execute(
+        literal: """
+          UPDATE account
+          SET valuation_mode = \(ValuationMode.calculatedFromTrades.rawValue)
+          WHERE type = \(AccountType.investment.rawValue)
+            AND id NOT IN (SELECT DISTINCT account_id FROM investment_value)
+          """)
+      return database.changesCount
+    }
+  }
+
   func delete(id: UUID) async throws {
     // Soft-delete: flip `is_hidden = true` on the matching row.
     // Rejects deletes against an account with non-zero positions —

--- a/Domain/Repositories/AccountRepository.swift
+++ b/Domain/Repositories/AccountRepository.swift
@@ -5,6 +5,15 @@ protocol AccountRepository: Sendable {
   func create(_ account: Account, openingBalance: InstrumentAmount?) async throws -> Account
   func update(_ account: Account) async throws -> Account
   func delete(id: UUID) async throws
+  /// Sets every investment account that has no `InvestmentValue`
+  /// snapshot to `valuationMode = .calculatedFromTrades`. Single SQL
+  /// UPDATE in one transaction; idempotent — re-running is a no-op once
+  /// every empty investment account has been flipped because the row
+  /// matches its target value. Returns the number of rows changed.
+  ///
+  /// Used by `ValuationModeMigration` so the per-profile bootstrap
+  /// happens in one transaction / one fsync rather than per-account.
+  func backfillValuationModeForUnsnapshotInvestmentAccounts() async throws -> Int
 }
 
 extension AccountRepository {

--- a/MoolahTests/App/ValuationModeMigrationTests.swift
+++ b/MoolahTests/App/ValuationModeMigrationTests.swift
@@ -25,10 +25,13 @@ struct ValuationModeMigrationTests {
     let migration = ValuationModeMigration(
       profileId: profileId,
       accountRepository: backend.accounts,
-      investmentRepository: backend.investments,
       userDefaults: defaults)
     return Fixture(backend: backend, defaults: defaults, migration: migration)
   }
+
+  /// Fixed snapshot date; tests don't read it, but anchoring it removes
+  /// any incidental dependency on the wall clock.
+  private static let fixedSnapshotDate = Date(timeIntervalSince1970: 1_700_000_000)
 
   @Test("investment account with snapshot stays at recordedValue")
   func snapshotAccountUntouched() async throws {
@@ -36,7 +39,7 @@ struct ValuationModeMigrationTests {
     let saved = try await fixture.backend.accounts.create(
       Account(name: "Brokerage", type: .investment, instrument: .AUD))
     try await fixture.backend.investments.setValue(
-      accountId: saved.id, date: Date(),
+      accountId: saved.id, date: Self.fixedSnapshotDate,
       value: InstrumentAmount(quantity: 100, instrument: .AUD))
 
     try await fixture.migration.run()
@@ -72,6 +75,27 @@ struct ValuationModeMigrationTests {
     #expect(after.valuationMode == .recordedValue)
   }
 
+  @Test("mixed accounts: only empty ones flip, snapshot accounts stay")
+  func mixedAccountsMigration() async throws {
+    let fixture = try makeFixture()
+    let withSnapshot = try await fixture.backend.accounts.create(
+      Account(name: "Brokerage", type: .investment, instrument: .AUD))
+    try await fixture.backend.investments.setValue(
+      accountId: withSnapshot.id,
+      date: Self.fixedSnapshotDate,
+      value: InstrumentAmount(quantity: 100, instrument: .AUD))
+    let withoutSnapshot = try await fixture.backend.accounts.create(
+      Account(name: "Crypto", type: .investment, instrument: .AUD))
+
+    try await fixture.migration.run()
+
+    let all = try await fixture.backend.accounts.fetchAll()
+    let afterWith = try #require(all.first { $0.id == withSnapshot.id })
+    let afterWithout = try #require(all.first { $0.id == withoutSnapshot.id })
+    #expect(afterWith.valuationMode == .recordedValue)
+    #expect(afterWithout.valuationMode == .calculatedFromTrades)
+  }
+
   @Test("re-running with the gate flag set is a no-op")
   func gateFlagShortCircuits() async throws {
     let fixture = try makeFixture()
@@ -80,7 +104,7 @@ struct ValuationModeMigrationTests {
     try await fixture.migration.run()
     #expect(
       fixture.defaults.bool(
-        forKey: "didMigrateValuationMode_\(fixture.migration.profileId)"))
+        forKey: ValuationModeMigration.gateKey(for: fixture.migration.profileId)))
 
     // Pre-flip an account to recordedValue; re-running must not flip it back.
     let allAccounts = try await fixture.backend.accounts.fetchAll()
@@ -100,15 +124,32 @@ struct ValuationModeMigrationTests {
     let migrationB = ValuationModeMigration(
       profileId: UUID(),
       accountRepository: migrationA.accountRepository,
-      investmentRepository: migrationA.investmentRepository,
       userDefaults: fixture.defaults)
 
     try await migrationA.run()
     #expect(
       fixture.defaults.bool(
-        forKey: "didMigrateValuationMode_\(migrationA.profileId)"))
+        forKey: ValuationModeMigration.gateKey(for: migrationA.profileId)))
     #expect(
       !fixture.defaults.bool(
-        forKey: "didMigrateValuationMode_\(migrationB.profileId)"))
+        forKey: ValuationModeMigration.gateKey(for: migrationB.profileId)))
+  }
+
+  @Test("resetGateFlags wipes every per-profile gate key")
+  func resetGateFlagsClearsAll() async throws {
+    let suiteName = "test-\(UUID().uuidString)"
+    let defaults = try #require(UserDefaults(suiteName: suiteName))
+    defaults.removePersistentDomain(forName: suiteName)
+    defaults.set(true, forKey: ValuationModeMigration.gateKey(for: UUID()))
+    defaults.set(true, forKey: ValuationModeMigration.gateKey(for: UUID()))
+    // An unrelated key must be left alone.
+    defaults.set("untouched", forKey: "some.other.key")
+
+    ValuationModeMigration.resetGateFlags(in: defaults)
+
+    let remaining = defaults.dictionaryRepresentation().keys
+      .filter { $0.hasPrefix(ValuationModeMigration.gateKeyPrefix) }
+    #expect(remaining.isEmpty)
+    #expect(defaults.string(forKey: "some.other.key") == "untouched")
   }
 }

--- a/MoolahTests/App/ValuationModeMigrationTests.swift
+++ b/MoolahTests/App/ValuationModeMigrationTests.swift
@@ -1,0 +1,114 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@MainActor
+@Suite("ValuationModeMigration")
+struct ValuationModeMigrationTests {
+  /// Bundle of references each test needs from `makeFixture`.
+  private struct Fixture {
+    let backend: CloudKitBackend
+    let defaults: UserDefaults
+    let migration: ValuationModeMigration
+  }
+
+  /// Builds a fresh in-memory backend and migration with a unique
+  /// `UserDefaults` suite per test so gate flags don't bleed between tests.
+  private func makeFixture(
+    profileId: UUID = UUID()
+  ) throws -> Fixture {
+    let suiteName = "test-\(UUID().uuidString)"
+    let defaults = try #require(UserDefaults(suiteName: suiteName))
+    defaults.removePersistentDomain(forName: suiteName)
+    let (backend, _) = try TestBackend.create()
+    let migration = ValuationModeMigration(
+      profileId: profileId,
+      accountRepository: backend.accounts,
+      investmentRepository: backend.investments,
+      userDefaults: defaults)
+    return Fixture(backend: backend, defaults: defaults, migration: migration)
+  }
+
+  @Test("investment account with snapshot stays at recordedValue")
+  func snapshotAccountUntouched() async throws {
+    let fixture = try makeFixture()
+    let saved = try await fixture.backend.accounts.create(
+      Account(name: "Brokerage", type: .investment, instrument: .AUD))
+    try await fixture.backend.investments.setValue(
+      accountId: saved.id, date: Date(),
+      value: InstrumentAmount(quantity: 100, instrument: .AUD))
+
+    try await fixture.migration.run()
+
+    let allAccounts = try await fixture.backend.accounts.fetchAll()
+    let after = try #require(allAccounts.first { $0.id == saved.id })
+    #expect(after.valuationMode == .recordedValue)
+  }
+
+  @Test("investment account without snapshot flips to calculatedFromTrades")
+  func emptyAccountFlips() async throws {
+    let fixture = try makeFixture()
+    let saved = try await fixture.backend.accounts.create(
+      Account(name: "Crypto", type: .investment, instrument: .AUD))
+
+    try await fixture.migration.run()
+
+    let allAccounts = try await fixture.backend.accounts.fetchAll()
+    let after = try #require(allAccounts.first { $0.id == saved.id })
+    #expect(after.valuationMode == .calculatedFromTrades)
+  }
+
+  @Test("non-investment account is left alone")
+  func nonInvestmentSkipped() async throws {
+    let fixture = try makeFixture()
+    let saved = try await fixture.backend.accounts.create(
+      Account(name: "Checking", type: .bank, instrument: .AUD))
+
+    try await fixture.migration.run()
+
+    let allAccounts = try await fixture.backend.accounts.fetchAll()
+    let after = try #require(allAccounts.first { $0.id == saved.id })
+    #expect(after.valuationMode == .recordedValue)
+  }
+
+  @Test("re-running with the gate flag set is a no-op")
+  func gateFlagShortCircuits() async throws {
+    let fixture = try makeFixture()
+    _ = try await fixture.backend.accounts.create(
+      Account(name: "Brokerage", type: .investment, instrument: .AUD))
+    try await fixture.migration.run()
+    #expect(
+      fixture.defaults.bool(
+        forKey: "didMigrateValuationMode_\(fixture.migration.profileId)"))
+
+    // Pre-flip an account to recordedValue; re-running must not flip it back.
+    let allAccounts = try await fixture.backend.accounts.fetchAll()
+    var account = allAccounts[0]
+    account.valuationMode = .recordedValue
+    _ = try await fixture.backend.accounts.update(account)
+
+    try await fixture.migration.run()
+    let after = (try await fixture.backend.accounts.fetchAll())[0]
+    #expect(after.valuationMode == .recordedValue)
+  }
+
+  @Test("per-profile gate flags are independent")
+  func perProfileGateIsolation() async throws {
+    let fixture = try makeFixture()
+    let migrationA = fixture.migration
+    let migrationB = ValuationModeMigration(
+      profileId: UUID(),
+      accountRepository: migrationA.accountRepository,
+      investmentRepository: migrationA.investmentRepository,
+      userDefaults: fixture.defaults)
+
+    try await migrationA.run()
+    #expect(
+      fixture.defaults.bool(
+        forKey: "didMigrateValuationMode_\(migrationA.profileId)"))
+    #expect(
+      !fixture.defaults.bool(
+        forKey: "didMigrateValuationMode_\(migrationB.profileId)"))
+  }
+}

--- a/MoolahTests/Support/AccountStoreTestSupport.swift
+++ b/MoolahTests/Support/AccountStoreTestSupport.swift
@@ -65,4 +65,23 @@ final class FailingAccountRepository: AccountRepository, @unchecked Sendable {
     if shouldFail { throw BackendError.networkUnavailable }
     accounts.removeAll { $0.id == id }
   }
+
+  /// In-memory equivalent of the GRDB single-SQL backfill: flips every
+  /// investment account in the local array to `.calculatedFromTrades`.
+  /// The fake doesn't model investment-value snapshots, so "no
+  /// snapshots" is implicit — every investment account in this fake
+  /// represents the migration's positive case. No tests on this fake
+  /// currently exercise the migration; the conformance is here to
+  /// satisfy the protocol.
+  func backfillValuationModeForUnsnapshotInvestmentAccounts() async throws -> Int {
+    if shouldFail { throw BackendError.networkUnavailable }
+    var changed = 0
+    for index in accounts.indices where accounts[index].type == .investment {
+      if accounts[index].valuationMode != .calculatedFromTrades {
+        accounts[index].valuationMode = .calculatedFromTrades
+        changed += 1
+      }
+    }
+    return changed
+  }
 }


### PR DESCRIPTION
## Summary
- One-shot per-profile migration (`ValuationModeMigration`) sets `Account.valuationMode = .calculatedFromTrades` for every investment account that has no `InvestmentValue` snapshot — single SQL `UPDATE` in one transaction via a new `AccountRepository.backfillValuationModeForUnsnapshotInvestmentAccounts()` method.
- Gated by per-profile UserDefaults flag; idempotent.
- Wired into profile bootstrap inside the existing `setUpTask` so both phases (SwiftData→GRDB migration + valuation-mode backfill) live under the same idempotency guard.
- UI-test reset path also clears the new gate flag (via `ValuationModeMigration.resetGateFlags(in:)`) so test launches don't see stale state.

No observable behaviour change yet — read sites still auto-detect. This PR just stages the field for subsequent PRs to switch read sites onto.

**Stacked on top of #731 (Phase 1).** The diff below contains both PR's commits until #731 lands; once #731 merges, the queue should rebase this onto the resulting `main`.

Spec: Phase 2 of the design doc (#730).

## Review history
Reviewed by `code-review`, `concurrency-review`, `database-code-review`. All Critical and Important findings applied in `6b4f97b9`, including:
- Single SQL UPDATE migration (was: per-account loop, N transactions/fsyncs).
- Critical: UI-test reset includes the new gate flag.
- Both bootstrap phases under the same `setUpTask` idempotency guard.
- Logger as `static let`; cancellation checks; mixed-accounts test added.

### Deferred (pre-existing in unrelated files; out of Phase 2 scope)
- `SessionManager` swallows `setUp()` errors with `try?` and no logging.
- `ProfileSession+Imports.swift:102` uses `try!` on a `FileManager` fallback path.
Both should be addressed in a separate cleanup PR.

## Test plan
- [x] `just test-mac` green across affected suites (migration, repository contract, ProfileSession, store loading)
- [x] `just format-check` clean
- [x] `.swiftlint-baseline.yml` untouched
- [x] No new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)