### PR TITLE
feat: AccountBalanceCalculator + preload filter read Account.valuationMode

### DIFF
--- a/Features/Accounts/AccountBalanceCalculator.swift
+++ b/Features/Accounts/AccountBalanceCalculator.swift
@@ -42,12 +42,20 @@ struct AccountBalanceCalculator {
     var anyFailed = false
     var newBalances: [UUID: InstrumentAmount] = [:]
 
+    // Capture once so every conversion in this pass uses the same `date`.
+    // Without this, a pass that crosses midnight would convert some
+    // accounts at the previous day's rate and others at the next day's,
+    // producing an aggregate that doesn't tie out to any single day.
+    let date = Date()
+
     // Phase 1: per-account display balance in the account's own instrument.
     // Iterate all accounts so per-account display works regardless of showHidden.
     for account in allAccounts {
       do {
         let balance = try await displayBalance(
-          for: account, investmentValue: investmentValues.value(for: account.id))
+          for: account,
+          investmentValue: investmentValues.value(for: account.id),
+          date: date)
         guard !Task.isCancelled else { return cancelledSnapshot() }
         newBalances[account.id] = balance
       } catch {
@@ -57,11 +65,13 @@ struct AccountBalanceCalculator {
       }
     }
 
+    guard !Task.isCancelled else { return cancelledSnapshot() }
+
     // Phase 2: aggregate totals — only valid when every contributing account
     // converted successfully *and* the per-account → target conversion works.
-    let date = Date()
     let (currentTotal, currentValid) = await sumConverted(
       accounts: currentAccounts, balances: newBalances, on: date)
+    guard !Task.isCancelled else { return cancelledSnapshot() }
     let (investmentTotal, investmentValid) = await sumConverted(
       accounts: investmentAccounts, balances: newBalances, on: date)
 
@@ -101,6 +111,7 @@ struct AccountBalanceCalculator {
           total += try await conversionService.convertAmount(
             snapshot, to: target, on: date)
         }
+        try Task.checkCancellation()
         continue
       }
       for position in account.positions {
@@ -110,6 +121,7 @@ struct AccountBalanceCalculator {
           total += try await conversionService.convertAmount(
             position.amount, to: target, on: date)
         }
+        try Task.checkCancellation()
       }
     }
     return total
@@ -119,14 +131,16 @@ struct AccountBalanceCalculator {
   /// accounts in `recordedValue` mode return the externally-provided
   /// snapshot (or zero when absent); all other accounts sum every position
   /// converted via the conversion service.
+  ///
+  /// Pass `date` to share a conversion timestamp across a multi-account
+  /// pass; defaults to `Date()` for one-shot callers.
   func displayBalance(
-    for account: Account, investmentValue: InstrumentAmount?
+    for account: Account, investmentValue: InstrumentAmount?, date: Date = Date()
   ) async throws -> InstrumentAmount {
     if account.type == .investment, account.valuationMode == .recordedValue {
       return investmentValue ?? .zero(instrument: account.instrument)
     }
     var total = InstrumentAmount.zero(instrument: account.instrument)
-    let date = Date()
     for position in account.positions {
       if position.amount.instrument == account.instrument {
         total += position.amount
@@ -134,36 +148,37 @@ struct AccountBalanceCalculator {
         total += try await conversionService.convertAmount(
           position.amount, to: account.instrument, on: date)
       }
+      try Task.checkCancellation()
     }
     return total
   }
 
   /// Sums the per-account balances converted to `targetInstrument`. Returns
   /// `(total, valid)`; `valid` is false if any account is missing from
-  /// `balances` or if its target conversion throws.
+  /// `balances` or if its target conversion throws. Bails out on the first
+  /// failure so we don't keep issuing conversion calls whose results would
+  /// be discarded.
   private func sumConverted(
     accounts list: [Account],
     balances: [UUID: InstrumentAmount],
     on date: Date
   ) async -> (InstrumentAmount, Bool) {
     var total = InstrumentAmount.zero(instrument: targetInstrument)
-    var valid = true
     for account in list {
       guard let balance = balances[account.id] else {
-        valid = false
-        continue
+        return (.zero(instrument: targetInstrument), false)
       }
       do {
         let converted = try await conversionService.convertAmount(
           balance, to: targetInstrument, on: date)
-        if valid { total += converted }
+        total += converted
       } catch {
-        valid = false
         logger.warning(
           "Aggregate conversion failed for \(account.name): \(error.localizedDescription)")
+        return (.zero(instrument: targetInstrument), false)
       }
     }
-    return (total, valid)
+    return (total, true)
   }
 
   private func cancelledSnapshot() -> Snapshot {

--- a/Features/Accounts/AccountBalanceCalculator.swift
+++ b/Features/Accounts/AccountBalanceCalculator.swift
@@ -78,11 +78,11 @@ struct AccountBalanceCalculator {
     )
   }
 
-  /// Sum all positions across `accounts`, converted to `target`. When
-  /// `investmentValues` is provided and the account has an externally-set
-  /// value, that amount is used verbatim (converted once) — avoiding the
-  /// double-conversion a naive `positions → account instrument → target`
-  /// implementation would incur on investment aggregates.
+  /// Sum every account's contribution converted to `target`. Investment
+  /// accounts in `recordedValue` mode contribute their cached snapshot (or
+  /// zero when none is set); every other account sums positions directly to
+  /// `target` in one pass — avoiding the double-conversion a naive
+  /// `positions → account instrument → target` implementation would incur.
   func totalConverted(
     for accounts: [Account],
     to target: Instrument,
@@ -91,11 +91,15 @@ struct AccountBalanceCalculator {
     var total = InstrumentAmount.zero(instrument: target)
     let date = Date()
     for account in accounts {
-      if let investmentValues, let externalValue = investmentValues.value(for: account.id) {
-        if externalValue.instrument == target {
-          total += externalValue
+      if account.type == .investment, account.valuationMode == .recordedValue {
+        let snapshot =
+          investmentValues?.value(for: account.id)
+          ?? .zero(instrument: account.instrument)
+        if snapshot.instrument == target {
+          total += snapshot
         } else {
-          total += try await conversionService.convertAmount(externalValue, to: target, on: date)
+          total += try await conversionService.convertAmount(
+            snapshot, to: target, on: date)
         }
         continue
       }

--- a/Features/Accounts/AccountBalanceCalculator.swift
+++ b/Features/Accounts/AccountBalanceCalculator.swift
@@ -112,13 +112,14 @@ struct AccountBalanceCalculator {
   }
 
   /// The display balance for an account in its own instrument. Investment
-  /// accounts with an externally-provided value return that; otherwise the
-  /// method sums every position converted via the conversion service.
+  /// accounts in `recordedValue` mode return the externally-provided
+  /// snapshot (or zero when absent); all other accounts sum every position
+  /// converted via the conversion service.
   func displayBalance(
     for account: Account, investmentValue: InstrumentAmount?
   ) async throws -> InstrumentAmount {
-    if account.type == .investment, let investmentValue {
-      return investmentValue
+    if account.type == .investment, account.valuationMode == .recordedValue {
+      return investmentValue ?? .zero(instrument: account.instrument)
     }
     var total = InstrumentAmount.zero(instrument: account.instrument)
     let date = Date()

--- a/Features/Accounts/AccountStore.swift
+++ b/Features/Accounts/AccountStore.swift
@@ -291,6 +291,13 @@ final class AccountStore {
       accounts = Accounts(from: accounts.ordered.map { $0.id == updated.id ? updated : $0 })
       logger.debug("Updated account: \(updated.name)")
 
+      // Preload picks up snapshots for accounts whose mode changed to
+      // `recordedValue`: without this, a flip from `calculatedFromTrades`
+      // would leave `displayBalance` returning zero until CloudKit sync
+      // delivered an unrelated refresh.
+      await preloadInvestmentValues()
+      await recomputeConvertedTotals()
+
       isLoading = false
       return updated
     } catch {

--- a/Features/Accounts/AccountStore.swift
+++ b/Features/Accounts/AccountStore.swift
@@ -104,8 +104,11 @@ final class AccountStore {
   /// transaction sum until the user opens an investment account. See
   /// `InvestmentValueCache.preload(for:)` for the failure-tolerant details.
   private func preloadInvestmentValues() async {
+    // Only `recordedValue` investment accounts read from the snapshot cache;
+    // `calculatedFromTrades` accounts derive their value from positions, so
+    // their snapshot fetch would be a wasted round-trip.
     let investmentAccountIds = accounts.ordered
-      .filter { $0.type == .investment }
+      .filter { $0.type == .investment && $0.valuationMode == .recordedValue }
       .map(\.id)
     await investmentValueCache.preload(for: investmentAccountIds)
   }

--- a/Features/Accounts/InvestmentValueCache.swift
+++ b/Features/Accounts/InvestmentValueCache.swift
@@ -48,9 +48,10 @@ final class InvestmentValueCache {
 
   /// Fetches the latest value for each given account ID in parallel and
   /// stores successful results. Per-account failures are silently tolerated
-  /// — absence means "unknown", at which point `displayBalance` falls back
-  /// to summing positions. A single account's fetch failure never blocks
-  /// the rest of the load.
+  /// — absence means the cached value is unknown. For `recordedValue`
+  /// accounts `displayBalance` returns zero when absent; for
+  /// `calculatedFromTrades` accounts it sums positions. A single account's
+  /// fetch failure never blocks the rest of the load.
   func preload(for accountIds: [UUID]) async {
     guard let repository, !accountIds.isEmpty else { return }
 

--- a/MoolahTests/Features/AccountStoreConversionTestsMore.swift
+++ b/MoolahTests/Features/AccountStoreConversionTestsMore.swift
@@ -10,6 +10,7 @@ struct AccountStoreConversionTestsMore {
   @Test
   func displayBalanceForInvestmentAccountPrefersInvestmentValue() async throws {
     let accountId = UUID()
+    // Default `recordedValue` mode — investment-value snapshot drives the balance.
     let account = Account(
       id: accountId, name: "Portfolio", type: .investment, instrument: .AUD)
     let (backend, database) = try TestBackend.create()
@@ -31,11 +32,11 @@ struct AccountStoreConversionTestsMore {
       targetInstrument: .AUD)
     await store.load()
 
-    // No investment value yet → falls back to converted position sum (USD * 1.5 = 150 AUD)
+    // recordedValue + no snapshot → balance = 0 (positions are NOT a fallback).
     let sumBalance = try await store.displayBalance(for: accountId)
-    #expect(sumBalance.quantity == dec("150.00"))
+    #expect(sumBalance == .zero(instrument: .AUD))
 
-    // Investment value set externally → wins over converted positions
+    // Investment value set externally → recorded mode uses the snapshot verbatim.
     let externalValue = InstrumentAmount(
       quantity: dec("999.00"), instrument: .AUD)
     await store.updateInvestmentValue(accountId: accountId, value: externalValue)

--- a/MoolahTests/Features/AccountStoreConversionTestsMoreExtra.swift
+++ b/MoolahTests/Features/AccountStoreConversionTestsMoreExtra.swift
@@ -13,8 +13,11 @@ struct AccountStoreConversionTestsMoreExtra {
     let usd = Instrument.USD
     let eur = Instrument.fiat(code: "EUR")
     let accountId = UUID()
+    // Use `calculatedFromTrades` so position-derived totals contribute (per
+    // Phase 3: recordedValue + no snapshot → 0).
     let account = Account(
-      id: accountId, name: "Portfolio", type: .investment, instrument: aud)
+      id: accountId, name: "Portfolio", type: .investment, instrument: aud,
+      valuationMode: .calculatedFromTrades)
 
     let (backend, database) = try TestBackend.create()
     TestBackend.seed(accounts: [account], in: database)
@@ -88,8 +91,10 @@ struct AccountStoreConversionTestsMoreExtra {
     //   1000 AUD -> USD at 0.67 = 670 USD
     //   total = 770 USD
     // The 0.50 difference is the double-conversion drift.
+    // Use `calculatedFromTrades` so positions are summed for the total.
     let account = Account(
-      id: accountId, name: "Portfolio", type: .investment, instrument: .AUD)
+      id: accountId, name: "Portfolio", type: .investment, instrument: .AUD,
+      valuationMode: .calculatedFromTrades)
     let (backend, database) = try TestBackend.create()
     TestBackend.seed(accounts: [account], in: database)
 
@@ -179,9 +184,11 @@ struct AccountStoreConversionTestsMoreExtra {
     async throws
   {
     let accountId = UUID()
+    // Use `calculatedFromTrades` so positions are summed.
     let account = Account(
       id: accountId, name: "Portfolio", type: .investment,
-      instrument: .defaultTestInstrument)
+      instrument: .defaultTestInstrument,
+      valuationMode: .calculatedFromTrades)
     let (backend, database) = try TestBackend.create()
     TestBackend.seed(accounts: [account], in: database)
 

--- a/MoolahTests/Features/AccountStoreConversionTestsMoreExtra.swift
+++ b/MoolahTests/Features/AccountStoreConversionTestsMoreExtra.swift
@@ -13,8 +13,8 @@ struct AccountStoreConversionTestsMoreExtra {
     let usd = Instrument.USD
     let eur = Instrument.fiat(code: "EUR")
     let accountId = UUID()
-    // Use `calculatedFromTrades` so position-derived totals contribute (per
-    // Phase 3: recordedValue + no snapshot → 0).
+    // Use `calculatedFromTrades` so position-derived totals contribute
+    // (recordedValue + no snapshot → 0).
     let account = Account(
       id: accountId, name: "Portfolio", type: .investment, instrument: aud,
       valuationMode: .calculatedFromTrades)

--- a/MoolahTests/Features/AccountStoreInvestmentValuesTests.swift
+++ b/MoolahTests/Features/AccountStoreInvestmentValuesTests.swift
@@ -46,8 +46,8 @@ struct AccountStoreInvestmentValuesTests {
     #expect(store.convertedBalances[acctId]?.quantity == Decimal(250000) / 100)
   }
 
-  @Test("load leaves investmentValues empty when no values exist")
-  func loadOmitsInvestmentValueWhenRepositoryEmpty() async throws {
+  @Test("load with recordedValue and no snapshot yields zero balance")
+  func loadRecordedValueWithoutSnapshotYieldsZero() async throws {
     let acctId = UUID()
     let (backend, database) = try TestBackend.create()
     _ = AccountStoreTestSupport.seedAccount(

--- a/MoolahTests/Features/AccountStoreInvestmentValuesTests.swift
+++ b/MoolahTests/Features/AccountStoreInvestmentValuesTests.swift
@@ -62,6 +62,29 @@ struct AccountStoreInvestmentValuesTests {
 
     await store.load()
 
+    // `recordedValue` (default) + no snapshot → balance = 0. Position sum is
+    // intentionally not used as a fallback; see `displayBalance` in
+    // `AccountBalanceCalculator`.
+    #expect(store.investmentValues[acctId] == nil)
+    #expect(store.convertedBalances[acctId]?.quantity == 0)
+  }
+
+  @Test("load with calculatedFromTrades sums positions when no snapshot exists")
+  func loadCalculatedFromTradesUsesPositionsWhenSnapshotMissing() async throws {
+    let acctId = UUID()
+    let (backend, database) = try TestBackend.create()
+    _ = AccountStoreTestSupport.seedAccount(
+      id: acctId, name: "Brokerage", type: .investment, balance: Decimal(100000) / 100,
+      valuationMode: .calculatedFromTrades, in: database)
+
+    let store = AccountStore(
+      repository: backend.accounts,
+      conversionService: FixedConversionService(),
+      targetInstrument: .defaultTestInstrument,
+      investmentRepository: backend.investments)
+
+    await store.load()
+
     #expect(store.investmentValues[acctId] == nil)
     #expect(store.convertedBalances[acctId]?.quantity == Decimal(100000) / 100)
   }
@@ -105,12 +128,11 @@ struct AccountStoreInvestmentValuesTests {
     await store.updateInvestmentValue(accountId: account.id, value: nil)
 
     #expect(store.investmentValues[account.id] == nil)
-    // displayBalance sums positions (converted to account's instrument) when investmentValue is nil
+    // recordedValue (default) + cleared snapshot → balance = 0 (no fallback to
+    // positions). The position sum would be 1000.00 if the account were in
+    // calculatedFromTrades mode; see `loadCalculatedFromTradesUsesPositionsWhenSnapshotMissing`.
     let balance = try await store.displayBalance(for: account.id)
-    #expect(
-      balance
-        == InstrumentAmount(
-          quantity: Decimal(100000) / 100, instrument: Instrument.defaultTestInstrument))
+    #expect(balance == .zero(instrument: .defaultTestInstrument))
   }
 
   @Test

--- a/MoolahTests/Features/AccountStoreLoadingTests.swift
+++ b/MoolahTests/Features/AccountStoreLoadingTests.swift
@@ -51,7 +51,7 @@ struct AccountStoreLoadingTests {
     _ = AccountStoreTestSupport.seedAccount(
       name: "Credit Card", type: .creditCard, balance: Decimal(-50000) / 100, in: database)
     // Use `calculatedFromTrades` so position-derived balance contributes to
-    // the investment total (per Phase 3: recordedValue + no snapshot → 0).
+    // the investment total (recordedValue + no snapshot → 0).
     _ = AccountStoreTestSupport.seedAccount(
       name: "Investment", type: .investment, balance: Decimal(2_000_000) / 100,
       valuationMode: .calculatedFromTrades, in: database)

--- a/MoolahTests/Features/AccountStoreLoadingTests.swift
+++ b/MoolahTests/Features/AccountStoreLoadingTests.swift
@@ -50,8 +50,11 @@ struct AccountStoreLoadingTests {
       name: "Asset", type: .asset, balance: Decimal(500000) / 100, in: database)
     _ = AccountStoreTestSupport.seedAccount(
       name: "Credit Card", type: .creditCard, balance: Decimal(-50000) / 100, in: database)
+    // Use `calculatedFromTrades` so position-derived balance contributes to
+    // the investment total (per Phase 3: recordedValue + no snapshot → 0).
     _ = AccountStoreTestSupport.seedAccount(
-      name: "Investment", type: .investment, balance: Decimal(2_000_000) / 100, in: database)
+      name: "Investment", type: .investment, balance: Decimal(2_000_000) / 100,
+      valuationMode: .calculatedFromTrades, in: database)
     _ = AccountStoreTestSupport.seedAccount(
       name: "Hidden", type: .asset, balance: Decimal(100_000_000) / 100, isHidden: true,
       in: database)

--- a/MoolahTests/Features/AccountStorePreloadFilterTests.swift
+++ b/MoolahTests/Features/AccountStorePreloadFilterTests.swift
@@ -34,4 +34,36 @@ struct AccountStorePreloadFilterTests {
     #expect(store.investmentValues[recorded.id] != nil)
     #expect(store.investmentValues[trades.id] == nil)
   }
+
+  @Test("flipping mode to recordedValue triggers a snapshot preload")
+  func updateToRecordedValuePreloadsSnapshot() async throws {
+    let (backend, _) = try TestBackend.create()
+    let account = try await backend.accounts.create(
+      Account(
+        name: "Brokerage", type: .investment, instrument: .AUD,
+        valuationMode: .calculatedFromTrades))
+    try await backend.investments.setValue(
+      accountId: account.id, date: Date(timeIntervalSince1970: 1_700_000_000),
+      value: InstrumentAmount(quantity: 250, instrument: .AUD))
+
+    let store = AccountStore(
+      repository: backend.accounts,
+      conversionService: FixedConversionService(),
+      targetInstrument: .AUD,
+      investmentRepository: backend.investments)
+    await store.load()
+
+    // The snapshot exists in the repo but the cache excluded it because
+    // the account was in `calculatedFromTrades` mode at load time.
+    #expect(store.investmentValues[account.id] == nil)
+
+    var updated = account
+    updated.valuationMode = .recordedValue
+    _ = try await store.update(updated)
+
+    // After the mode flip, `update` preloads investment values so the
+    // cache picks up the existing snapshot for the now-recordedValue
+    // account.
+    #expect(store.investmentValues[account.id]?.quantity == 250)
+  }
 }

--- a/MoolahTests/Features/AccountStorePreloadFilterTests.swift
+++ b/MoolahTests/Features/AccountStorePreloadFilterTests.swift
@@ -1,0 +1,37 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@MainActor
+@Suite("AccountStore preloads only recordedValue accounts")
+struct AccountStorePreloadFilterTests {
+  @Test("only recordedValue investment accounts get a preload")
+  func preloadFiltersByMode() async throws {
+    let (backend, _) = try TestBackend.create()
+    let recorded = try await backend.accounts.create(
+      Account(
+        name: "R", type: .investment, instrument: .AUD,
+        valuationMode: .recordedValue))
+    let trades = try await backend.accounts.create(
+      Account(
+        name: "T", type: .investment, instrument: .AUD,
+        valuationMode: .calculatedFromTrades))
+    try await backend.investments.setValue(
+      accountId: recorded.id, date: Date(timeIntervalSince1970: 1_700_000_000),
+      value: InstrumentAmount(quantity: 100, instrument: .AUD))
+    try await backend.investments.setValue(
+      accountId: trades.id, date: Date(timeIntervalSince1970: 1_700_000_000),
+      value: InstrumentAmount(quantity: 999, instrument: .AUD))
+
+    let store = AccountStore(
+      repository: backend.accounts,
+      conversionService: FixedConversionService(),
+      targetInstrument: .AUD,
+      investmentRepository: backend.investments)
+    await store.load()
+
+    #expect(store.investmentValues[recorded.id] != nil)
+    #expect(store.investmentValues[trades.id] == nil)
+  }
+}

--- a/MoolahTests/Features/BalanceCalculatorValuationModeTests.swift
+++ b/MoolahTests/Features/BalanceCalculatorValuationModeTests.swift
@@ -62,4 +62,43 @@ struct BalanceCalculatorValuationModeTests {
       for: account, investmentValue: snapshot)
     #expect(balance == InstrumentAmount(quantity: 42, instrument: .AUD))
   }
+
+  @Test("totalConverted: recordedValue investment uses cache value")
+  @MainActor
+  func totalConvertedRecordedMode() async throws {
+    let calculator = AccountBalanceCalculator(
+      conversionService: FixedConversionService(), targetInstrument: .AUD)
+    var withSnapshot = Account(
+      name: "A", type: .investment, instrument: .AUD,
+      valuationMode: .recordedValue)
+    withSnapshot.positions = [Position(instrument: .AUD, quantity: 999)]
+    var withoutSnapshot = Account(
+      name: "B", type: .investment, instrument: .AUD,
+      valuationMode: .recordedValue)
+    withoutSnapshot.positions = [Position(instrument: .AUD, quantity: 999)]
+
+    let cache = InvestmentValueCache(repository: nil)
+    cache.set(InstrumentAmount(quantity: 100, instrument: .AUD), for: withSnapshot.id)
+    // withoutSnapshot has no cache entry.
+
+    let total = try await calculator.totalConverted(
+      for: [withSnapshot, withoutSnapshot], to: .AUD, using: cache)
+    #expect(total == InstrumentAmount(quantity: 100, instrument: .AUD))
+  }
+
+  @Test("totalConverted: calculatedFromTrades sums positions, ignores cache")
+  @MainActor
+  func totalConvertedTradesMode() async throws {
+    let calculator = AccountBalanceCalculator(
+      conversionService: FixedConversionService(), targetInstrument: .AUD)
+    var account = Account(
+      name: "A", type: .investment, instrument: .AUD,
+      valuationMode: .calculatedFromTrades)
+    account.positions = [Position(instrument: .AUD, quantity: 500)]
+    let cache = InvestmentValueCache(repository: nil)
+    cache.set(InstrumentAmount(quantity: 99, instrument: .AUD), for: account.id)
+    let total = try await calculator.totalConverted(
+      for: [account], to: .AUD, using: cache)
+    #expect(total == InstrumentAmount(quantity: 500, instrument: .AUD))
+  }
 }

--- a/MoolahTests/Features/BalanceCalculatorValuationModeTests.swift
+++ b/MoolahTests/Features/BalanceCalculatorValuationModeTests.swift
@@ -1,0 +1,65 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("AccountBalanceCalculator + ValuationMode")
+struct BalanceCalculatorValuationModeTests {
+  @Test("recordedValue + snapshot → balance = snapshot")
+  @MainActor
+  func recordedWithSnapshot() async throws {
+    let calculator = AccountBalanceCalculator(
+      conversionService: FixedConversionService(), targetInstrument: .AUD)
+    let account = Account(
+      name: "B", type: .investment, instrument: .AUD,
+      valuationMode: .recordedValue)
+    let snapshot = InstrumentAmount(quantity: 1234, instrument: .AUD)
+    let balance = try await calculator.displayBalance(
+      for: account, investmentValue: snapshot)
+    #expect(balance == snapshot)
+  }
+
+  @Test("recordedValue + missing snapshot → balance = zero (NOT positions sum)")
+  @MainActor
+  func recordedWithoutSnapshotIsZero() async throws {
+    let calculator = AccountBalanceCalculator(
+      conversionService: FixedConversionService(), targetInstrument: .AUD)
+    var account = Account(
+      name: "B", type: .investment, instrument: .AUD,
+      valuationMode: .recordedValue)
+    account.positions = [Position(instrument: .AUD, quantity: 999)]
+    let balance = try await calculator.displayBalance(
+      for: account, investmentValue: nil)
+    #expect(balance == .zero(instrument: .AUD))
+  }
+
+  @Test("calculatedFromTrades → positions sum (snapshot ignored)")
+  @MainActor
+  func calculatedSumsPositionsIgnoringSnapshot() async throws {
+    let calculator = AccountBalanceCalculator(
+      conversionService: FixedConversionService(), targetInstrument: .AUD)
+    var account = Account(
+      name: "B", type: .investment, instrument: .AUD,
+      valuationMode: .calculatedFromTrades)
+    account.positions = [Position(instrument: .AUD, quantity: 500)]
+    let snapshot = InstrumentAmount(quantity: 9999, instrument: .AUD)
+    let balance = try await calculator.displayBalance(
+      for: account, investmentValue: snapshot)
+    #expect(balance == InstrumentAmount(quantity: 500, instrument: .AUD))
+  }
+
+  @Test("non-investment account ignores valuationMode")
+  @MainActor
+  func nonInvestmentIgnoresMode() async throws {
+    let calculator = AccountBalanceCalculator(
+      conversionService: FixedConversionService(), targetInstrument: .AUD)
+    var account = Account(
+      name: "Checking", type: .bank, instrument: .AUD,
+      valuationMode: .recordedValue)
+    account.positions = [Position(instrument: .AUD, quantity: 42)]
+    let snapshot = InstrumentAmount(quantity: 9999, instrument: .AUD)
+    let balance = try await calculator.displayBalance(
+      for: account, investmentValue: snapshot)
+    #expect(balance == InstrumentAmount(quantity: 42, instrument: .AUD))
+  }
+}

--- a/MoolahTests/Features/BalanceCalculatorValuationModeTests.swift
+++ b/MoolahTests/Features/BalanceCalculatorValuationModeTests.swift
@@ -4,9 +4,9 @@ import Testing
 @testable import Moolah
 
 @Suite("AccountBalanceCalculator + ValuationMode")
+@MainActor
 struct BalanceCalculatorValuationModeTests {
   @Test("recordedValue + snapshot → balance = snapshot")
-  @MainActor
   func recordedWithSnapshot() async throws {
     let calculator = AccountBalanceCalculator(
       conversionService: FixedConversionService(), targetInstrument: .AUD)
@@ -20,7 +20,6 @@ struct BalanceCalculatorValuationModeTests {
   }
 
   @Test("recordedValue + missing snapshot → balance = zero (NOT positions sum)")
-  @MainActor
   func recordedWithoutSnapshotIsZero() async throws {
     let calculator = AccountBalanceCalculator(
       conversionService: FixedConversionService(), targetInstrument: .AUD)
@@ -34,7 +33,6 @@ struct BalanceCalculatorValuationModeTests {
   }
 
   @Test("calculatedFromTrades → positions sum (snapshot ignored)")
-  @MainActor
   func calculatedSumsPositionsIgnoringSnapshot() async throws {
     let calculator = AccountBalanceCalculator(
       conversionService: FixedConversionService(), targetInstrument: .AUD)
@@ -49,7 +47,6 @@ struct BalanceCalculatorValuationModeTests {
   }
 
   @Test("non-investment account ignores valuationMode")
-  @MainActor
   func nonInvestmentIgnoresMode() async throws {
     let calculator = AccountBalanceCalculator(
       conversionService: FixedConversionService(), targetInstrument: .AUD)
@@ -64,7 +61,6 @@ struct BalanceCalculatorValuationModeTests {
   }
 
   @Test("totalConverted: recordedValue investment uses cache value")
-  @MainActor
   func totalConvertedRecordedMode() async throws {
     let calculator = AccountBalanceCalculator(
       conversionService: FixedConversionService(), targetInstrument: .AUD)
@@ -87,7 +83,6 @@ struct BalanceCalculatorValuationModeTests {
   }
 
   @Test("totalConverted: calculatedFromTrades sums positions, ignores cache")
-  @MainActor
   func totalConvertedTradesMode() async throws {
     let calculator = AccountBalanceCalculator(
       conversionService: FixedConversionService(), targetInstrument: .AUD)

--- a/MoolahTests/Features/TransactionStoreTransferTests.swift
+++ b/MoolahTests/Features/TransactionStoreTransferTests.swift
@@ -127,8 +127,8 @@ struct TransactionStoreTransferTests {
     let checking = TransactionStoreTestSupport.acct(id: accountId, name: "Checking", balance: 900)
     let savings = TransactionStoreTestSupport.acct(id: savingsId, name: "Savings", balance: 1100)
     // Investment account is `calculatedFromTrades` so its balance reflects
-    // position-derived legs from the transfer (per Phase 3: recordedValue
-    // accounts ignore positions for displayBalance).
+    // position-derived legs from the transfer (recordedValue accounts
+    // ignore positions for displayBalance).
     let investment = TransactionStoreTestSupport.acct(
       id: investmentId, name: "Investment", type: .investment, balance: 500,
       valuationMode: .calculatedFromTrades)

--- a/MoolahTests/Features/TransactionStoreTransferTests.swift
+++ b/MoolahTests/Features/TransactionStoreTransferTests.swift
@@ -126,8 +126,12 @@ struct TransactionStoreTransferTests {
   ) async throws -> ThreeAccountTransferSeed {
     let checking = TransactionStoreTestSupport.acct(id: accountId, name: "Checking", balance: 900)
     let savings = TransactionStoreTestSupport.acct(id: savingsId, name: "Savings", balance: 1100)
+    // Investment account is `calculatedFromTrades` so its balance reflects
+    // position-derived legs from the transfer (per Phase 3: recordedValue
+    // accounts ignore positions for displayBalance).
     let investment = TransactionStoreTestSupport.acct(
-      id: investmentId, name: "Investment", type: .investment, balance: 500)
+      id: investmentId, name: "Investment", type: .investment, balance: 500,
+      valuationMode: .calculatedFromTrades)
     let transfer = Transaction(
       date: try TransactionStoreTestSupport.makeDate("2024-01-15"),
       payee: "",

--- a/MoolahTests/Support/AccountStoreTestSupport.swift
+++ b/MoolahTests/Support/AccountStoreTestSupport.swift
@@ -17,11 +17,12 @@ enum AccountStoreTestSupport {
     balance: Decimal = 0,
     position: Int = 0,
     isHidden: Bool = false,
+    valuationMode: ValuationMode = .recordedValue,
     in database: any DatabaseWriter
   ) -> Account {
     let account = Account(
       id: id, name: name, type: type, instrument: instrument, position: position,
-      isHidden: isHidden)
+      isHidden: isHidden, valuationMode: valuationMode)
     let balanceAmount = InstrumentAmount(quantity: balance, instrument: instrument)
     TestBackend.seed(
       accounts: [(account: account, openingBalance: balanceAmount)],

--- a/MoolahTests/Support/TransactionStoreTestSupport.swift
+++ b/MoolahTests/Support/TransactionStoreTestSupport.swift
@@ -22,10 +22,13 @@ enum TransactionStoreTestSupport {
     id: UUID,
     name: String,
     type: AccountType = .bank,
-    balance: Decimal
+    balance: Decimal,
+    valuationMode: ValuationMode = .recordedValue
   ) -> SeededAccount {
     SeededAccount(
-      account: Account(id: id, name: name, type: type, instrument: .defaultTestInstrument),
+      account: Account(
+        id: id, name: name, type: type, instrument: .defaultTestInstrument,
+        valuationMode: valuationMode),
       openingBalance: InstrumentAmount(quantity: balance, instrument: .defaultTestInstrument)
     )
   }


### PR DESCRIPTION
## Summary
- `AccountBalanceCalculator.displayBalance` and `totalConverted` branch on `account.type == .investment && account.valuationMode == .recordedValue` instead of presence-of-snapshot. Recorded mode + missing snapshot returns zero (was: silently summed positions). Trades mode always sums positions.
- `AccountStore.preloadInvestmentValues` filters investment accounts by `valuationMode == .recordedValue` so trades-mode accounts skip the snapshot fetch.
- `AccountStore.update` re-runs preload after a mode change so flipping `.calculatedFromTrades` → `.recordedValue` immediately picks up any existing snapshot (was: cache stayed stale until next CloudKit sync).

For accounts migrated by PR #732, behaviour is unchanged. Trades-mode accounts (existing or newly created) now correctly sum positions; recorded-mode accounts use the snapshot.

**Stacked on top of #732 (Phase 2).** Diff narrows once Phase 2 lands.

Spec: Phase 3 of `plans/2026-05-04-per-account-valuation-mode-design.md` (#730).

## Review history
Reviewed by `code-review`, `concurrency-review`, `instrument-conversion-review`. All in-scope findings applied in `be95a974`.

### Deferred — needs your call
- **Instrument-conversion-review Critical (zero vs. unavailable):** the reviewer flagged that `displayBalance` returning `$0` for a recorded-mode account with no snapshot could mislead a user (a real $0 vs "haven't entered a value yet" look identical). The design doc §5a deliberately chose `$0` semantics ("user hasn't entered a value yet — that's a $0 balance, not 'fall back to summing positions'"). The reviewer's UX concern is valid; need your call on whether to revise the spec or accept the trade-off.

### Deferred — already planned
- **Instrument-conversion Important 5** (`InvestmentStore.loadAllData` still uses `hasLegacyValuations`) — Phase 4 work, in next PR.
- **Concurrency pre-existing finding** flagged that `AccountBalanceCalculator.displayBalance` and `totalConverted` had no per-iteration cancellation checks. **Applied** in this PR (added `try Task.checkCancellation()` after each `await convertAmount`).
- **Instrument-conversion Important 4** (capture `Date()` once in `compute`). **Applied** — `compute` now captures `Date()` once and threads it through `displayBalance` + `sumConverted`.
- **Instrument-conversion Important 3** (sumConverted early return on first failure). **Applied**.

## Test plan
- [x] `just test-mac` green (2044 tests / 320 suites)
- [x] `just format-check` clean
- [x] `.swiftlint-baseline.yml` untouched
- [x] No new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)