### PR TITLE
feat: investment view + store read Account.valuationMode

### DIFF
--- a/Features/Investments/InvestmentStore.swift
+++ b/Features/Investments/InvestmentStore.swift
@@ -121,6 +121,7 @@ final class InvestmentStore {
     switch account.valuationMode {
     case .recordedValue:
       await loadValues(accountId: account.id)
+      guard !Task.isCancelled else { return }
       await loadDailyBalances(accountId: account.id, hostCurrency: profileCurrency)
       guard !Task.isCancelled else { return }
       accountPerformance = AccountPerformanceCalculator.computeLegacy(
@@ -129,7 +130,9 @@ final class InvestmentStore {
         instrument: profileCurrency)
     case .calculatedFromTrades:
       await loadPositions(accountId: account.id)
+      guard !Task.isCancelled else { return }
       await valuatePositions(profileCurrency: profileCurrency, on: Date())
+      guard !Task.isCancelled else { return }
       await refreshPositionTrackedPerformance(
         accountId: account.id, profileCurrency: profileCurrency)
     }
@@ -191,7 +194,9 @@ final class InvestmentStore {
   func reloadPositionsIfNeeded(account: Account, profileCurrency: Instrument) async {
     guard account.valuationMode == .calculatedFromTrades else { return }
     await loadPositions(accountId: account.id)
+    guard !Task.isCancelled else { return }
     await valuatePositions(profileCurrency: profileCurrency, on: Date())
+    guard !Task.isCancelled else { return }
     await refreshPositionTrackedPerformance(
       accountId: account.id, profileCurrency: profileCurrency)
   }
@@ -306,6 +311,13 @@ final class InvestmentStore {
     }
   }
 
+}
+
+// MARK: - Position Valuation Helper
+
+// Hoisted into an extension so the class body stays under
+// `type_body_length`. Same-file private access still works.
+extension InvestmentStore {
   private enum ValuationOutcome {
     case success(Decimal)
     case failure(Error)
@@ -351,7 +363,6 @@ final class InvestmentStore {
       return (entry, .failure(error))
     }
   }
-
 }
 
 // MARK: - Computed Properties

--- a/Features/Investments/InvestmentStore.swift
+++ b/Features/Investments/InvestmentStore.swift
@@ -113,25 +113,25 @@ final class InvestmentStore {
   // `InvestmentStore+DailyBalanceAggregation.swift`.
 
   /// Loads the full dataset required by `InvestmentAccountView`, branching on
-  /// whether the account uses legacy manual valuations or position tracking.
-  /// Keeps the branching logic out of the view so `.task`/`.refreshable`
-  /// blocks stay one-liners.
-  func loadAllData(accountId: UUID, profileCurrency: Instrument) async {
+  /// the account's `valuationMode`. Keeps the branching logic out of the view
+  /// so `.task`/`.refreshable` blocks stay one-liners.
+  func loadAllData(account: Account, profileCurrency: Instrument) async {
     loadedHostCurrency = profileCurrency
     accountPerformance = nil  // clear stale data immediately
-    await loadValues(accountId: accountId)
-    if hasLegacyValuations {
-      await loadDailyBalances(accountId: accountId, hostCurrency: profileCurrency)
+    switch account.valuationMode {
+    case .recordedValue:
+      await loadValues(accountId: account.id)
+      await loadDailyBalances(accountId: account.id, hostCurrency: profileCurrency)
       guard !Task.isCancelled else { return }
       accountPerformance = AccountPerformanceCalculator.computeLegacy(
         dailyBalances: dailyBalances,
         values: values,
         instrument: profileCurrency)
-    } else {
-      await loadPositions(accountId: accountId)
+    case .calculatedFromTrades:
+      await loadPositions(accountId: account.id)
       await valuatePositions(profileCurrency: profileCurrency, on: Date())
       await refreshPositionTrackedPerformance(
-        accountId: accountId, profileCurrency: profileCurrency)
+        accountId: account.id, profileCurrency: profileCurrency)
     }
   }
 
@@ -188,12 +188,12 @@ final class InvestmentStore {
 
   /// Refreshes position data after a trade is recorded. Used from
   /// `.onChange` where we only care about position-tracked accounts.
-  func reloadPositionsIfNeeded(accountId: UUID, profileCurrency: Instrument) async {
-    guard !hasLegacyValuations else { return }
-    await loadPositions(accountId: accountId)
+  func reloadPositionsIfNeeded(account: Account, profileCurrency: Instrument) async {
+    guard account.valuationMode == .calculatedFromTrades else { return }
+    await loadPositions(accountId: account.id)
     await valuatePositions(profileCurrency: profileCurrency, on: Date())
     await refreshPositionTrackedPerformance(
-      accountId: accountId, profileCurrency: profileCurrency)
+      accountId: account.id, profileCurrency: profileCurrency)
   }
 
   func setValue(accountId: UUID, date: Date, value: InstrumentAmount) async {
@@ -225,11 +225,6 @@ final class InvestmentStore {
       self.error = error
     }
   }
-
-  /// Whether the account has legacy manual valuations (InvestmentValueRecords).
-  /// When true, the UI shows the legacy chart + valuations list.
-  /// When false, the UI shows position tracking from transaction legs.
-  var hasLegacyValuations: Bool { !values.isEmpty }
 
   // MARK: - Position Tracking
 

--- a/Features/Investments/Views/InvestmentAccountView.swift
+++ b/Features/Investments/Views/InvestmentAccountView.swift
@@ -26,6 +26,13 @@ struct InvestmentAccountView: View {
   /// crashes Release builds on accounts that have legacy investment values
   /// (e.g. Test Profile → Crypto).
   @State private var initialLoadComplete = false
+  /// Flipped to `true` for one render pass whenever `account.valuationMode`
+  /// changes (sync delivery from another device, or the user-facing Picker
+  /// once it ships). Forces a `ProgressView` placeholder in that pass so
+  /// `TransactionListView`'s toolbar tears down cleanly before the new
+  /// layout re-mounts it — same toolbar-stability invariant as
+  /// `initialLoadComplete`, but for mid-session mode flips.
+  @State private var pendingLayoutSwitch = false
 
   /// The profile's reporting currency — used for valuing positions and the
   /// chart series. NOT the account's own instrument: an investment account
@@ -124,13 +131,23 @@ struct InvestmentAccountView: View {
 
   var body: some View {
     Group {
-      if !initialLoadComplete {
+      if !initialLoadComplete || pendingLayoutSwitch {
         ProgressView()
           .frame(maxWidth: .infinity, maxHeight: .infinity)
-      } else if account.valuationMode == .recordedValue {
-        legacyValuationsLayout
       } else {
-        positionTrackedLayout
+        switch account.valuationMode {
+        case .recordedValue:
+          legacyValuationsLayout
+        case .calculatedFromTrades:
+          positionTrackedLayout
+        }
+      }
+    }
+    .onChange(of: account.valuationMode) { _, _ in
+      pendingLayoutSwitch = true
+      Task {
+        await Task.yield()
+        pendingLayoutSwitch = false
       }
     }
     .transactionInspector(

--- a/Features/Investments/Views/InvestmentAccountView.swift
+++ b/Features/Investments/Views/InvestmentAccountView.swift
@@ -1,8 +1,21 @@
+import OSLog
 import SwiftUI
 
 /// Combined investment account view showing summary panels, chart with valuations list,
 /// and an embedded transaction list.
 struct InvestmentAccountView: View {
+  /// Composite identity used to drive `.task(id:)`. Re-fires when either the
+  /// account changes (navigation) or the valuation mode changes (sync push
+  /// from another device, or the user-facing Picker once it ships) so
+  /// `loadAllData` always runs against the active mode.
+  private struct LoadKey: Equatable {
+    let id: UUID
+    let mode: ValuationMode
+  }
+
+  private static let logger = Logger(
+    subsystem: "com.moolah.app", category: "InvestmentAccountView")
+
   let account: Account
   let accounts: Accounts
   let categories: Categories
@@ -26,13 +39,6 @@ struct InvestmentAccountView: View {
   /// crashes Release builds on accounts that have legacy investment values
   /// (e.g. Test Profile → Crypto).
   @State private var initialLoadComplete = false
-  /// Flipped to `true` for one render pass whenever `account.valuationMode`
-  /// changes (sync delivery from another device, or the user-facing Picker
-  /// once it ships). Forces a `ProgressView` placeholder in that pass so
-  /// `TransactionListView`'s toolbar tears down cleanly before the new
-  /// layout re-mounts it — same toolbar-stability invariant as
-  /// `initialLoadComplete`, but for mid-session mode flips.
-  @State private var pendingLayoutSwitch = false
 
   /// The profile's reporting currency — used for valuing positions and the
   /// chart series. NOT the account's own instrument: an investment account
@@ -131,23 +137,19 @@ struct InvestmentAccountView: View {
 
   var body: some View {
     Group {
-      if !initialLoadComplete || pendingLayoutSwitch {
+      if !initialLoadComplete {
         ProgressView()
           .frame(maxWidth: .infinity, maxHeight: .infinity)
+          .accessibilityLabel("Loading account data")
       } else {
         switch account.valuationMode {
         case .recordedValue:
           legacyValuationsLayout
+            .id(ValuationMode.recordedValue)
         case .calculatedFromTrades:
           positionTrackedLayout
+            .id(ValuationMode.calculatedFromTrades)
         }
-      }
-    }
-    .onChange(of: account.valuationMode) { _, _ in
-      pendingLayoutSwitch = true
-      Task {
-        await Task.yield()
-        pendingLayoutSwitch = false
       }
     }
     .transactionInspector(
@@ -163,7 +165,7 @@ struct InvestmentAccountView: View {
       AddInvestmentValueView(
         accountId: account.id, instrument: account.instrument, store: investmentStore)
     }
-    .task(id: account.id) {
+    .task(id: LoadKey(id: account.id, mode: account.valuationMode)) {
       initialLoadComplete = false
       isLoadingPositions = true
       defer { isLoadingPositions = false }
@@ -175,15 +177,16 @@ struct InvestmentAccountView: View {
       } catch is CancellationError {
         return
       } catch {
-        // positionsViewInput is documented to only throw CancellationError;
-        // any other error here is unexpected.
+        Self.logger.error(
+          "Unexpected error from positionsViewInput: \(error.localizedDescription, privacy: .public)"
+        )
       }
       initialLoadComplete = true
     }
     .task(id: positionsRange) {
-      // Skip until loadAllData has populated the store; the .task(id: account.id)
-      // block runs the first build. We only fire re-builds for subsequent
-      // range changes.
+      // Skip until loadAllData has populated the store; the .task(id:) keyed
+      // on (account.id, valuationMode) runs the first build. We only fire
+      // re-builds for subsequent range changes.
       guard investmentStore.loadedAccountId != nil else { return }
       do {
         positionsInput = try await investmentStore.positionsViewInput(
@@ -191,8 +194,9 @@ struct InvestmentAccountView: View {
       } catch is CancellationError {
         return
       } catch {
-        // positionsViewInput is documented to only throw CancellationError;
-        // any other error here is unexpected.
+        Self.logger.error(
+          "Unexpected error from positionsViewInput: \(error.localizedDescription, privacy: .public)"
+        )
       }
     }
     .refreshable {
@@ -206,8 +210,9 @@ struct InvestmentAccountView: View {
       } catch is CancellationError {
         return
       } catch {
-        // positionsViewInput is documented to only throw CancellationError;
-        // any other error here is unexpected.
+        Self.logger.error(
+          "Unexpected error from positionsViewInput: \(error.localizedDescription, privacy: .public)"
+        )
       }
     }
   }
@@ -365,7 +370,11 @@ private func seedPositionValuations(backend: any BackendProvider, account: Accou
   // GRDB queue with no disk access. A trap here is acceptable in #Preview.
   // swiftlint:disable:next force_try
   let session = try! ProfileSession.preview()
-  let account = Account(name: "Brokerage", type: .investment, instrument: .AUD)
+  let account = Account(
+    name: "Brokerage",
+    type: .investment,
+    instrument: .AUD,
+    valuationMode: .calculatedFromTrades)
   return NavigationStack {
     InvestmentAccountView(
       account: account,

--- a/Features/Investments/Views/InvestmentAccountView.swift
+++ b/Features/Investments/Views/InvestmentAccountView.swift
@@ -127,7 +127,7 @@ struct InvestmentAccountView: View {
       if !initialLoadComplete {
         ProgressView()
           .frame(maxWidth: .infinity, maxHeight: .infinity)
-      } else if investmentStore.hasLegacyValuations {
+      } else if account.valuationMode == .recordedValue {
         legacyValuationsLayout
       } else {
         positionTrackedLayout
@@ -151,7 +151,7 @@ struct InvestmentAccountView: View {
       isLoadingPositions = true
       defer { isLoadingPositions = false }
       await investmentStore.loadAllData(
-        accountId: account.id, profileCurrency: profileCurrencyInstrument)
+        account: account, profileCurrency: profileCurrencyInstrument)
       do {
         positionsInput = try await investmentStore.positionsViewInput(
           title: account.name, range: positionsRange)
@@ -182,7 +182,7 @@ struct InvestmentAccountView: View {
       isLoadingPositions = true
       defer { isLoadingPositions = false }
       await investmentStore.loadAllData(
-        accountId: account.id, profileCurrency: profileCurrencyInstrument)
+        account: account, profileCurrency: profileCurrencyInstrument)
       do {
         positionsInput = try await investmentStore.positionsViewInput(
           title: account.name, range: positionsRange)

--- a/MoolahTests/Features/InvestmentStorePerformanceTests.swift
+++ b/MoolahTests/Features/InvestmentStorePerformanceTests.swift
@@ -16,11 +16,13 @@ struct InvestmentStorePerformanceTests {
       transactionRepository: backend.transactions,
       conversionService: backend.conversionService)
 
-    let account = Account(name: "Brokerage", type: .investment, instrument: aud)
+    let account = Account(
+      name: "Brokerage", type: .investment, instrument: aud,
+      valuationMode: .calculatedFromTrades)
     _ = try await backend.accounts.create(
       account, openingBalance: InstrumentAmount(quantity: 10_000, instrument: aud))
 
-    await store.loadAllData(accountId: account.id, profileCurrency: aud)
+    await store.loadAllData(account: account, profileCurrency: aud)
 
     let perf = try #require(store.accountPerformance)
     #expect(perf.instrument == aud)
@@ -29,7 +31,9 @@ struct InvestmentStorePerformanceTests {
 
   @Test("loadAllData populates accountPerformance for a legacy-valuation account")
   func loadAllDataLegacyPerformance() async throws {
-    let accountId = UUID()
+    let account = Account(
+      name: "Brokerage", type: .investment, instrument: .AUD,
+      valuationMode: .recordedValue)
     let aud = Instrument.AUD
     let calendar = Calendar.current
     let earlierDate = try #require(
@@ -39,7 +43,7 @@ struct InvestmentStorePerformanceTests {
     let (backend, database) = try TestBackend.create()
     TestBackend.seed(
       investmentValues: [
-        accountId: [
+        account.id: [
           InvestmentValue(
             date: earlierDate,
             value: InstrumentAmount(quantity: 10_000, instrument: aud)),
@@ -55,7 +59,7 @@ struct InvestmentStorePerformanceTests {
       transactionRepository: backend.transactions,
       conversionService: backend.conversionService)
 
-    await store.loadAllData(accountId: accountId, profileCurrency: aud)
+    await store.loadAllData(account: account, profileCurrency: aud)
 
     let perf = try #require(store.accountPerformance)
     #expect(perf.currentValue == InstrumentAmount(quantity: 11_000, instrument: aud))
@@ -65,19 +69,20 @@ struct InvestmentStorePerformanceTests {
   func loadAllDataNilTransactionRepositoryLeavesPerformanceNil() async throws {
     let aud = Instrument.AUD
     let (backend, _) = try TestBackend.create()
-    // No transaction repository → position-tracked compute can't run; the
-    // legacy branch isn't taken either because no investment values were
-    // seeded. accountPerformance must stay nil.
+    // No transaction repository → position-tracked compute can't run.
+    // accountPerformance must stay nil for a calculatedFromTrades account.
     let store = InvestmentStore(
       repository: backend.investments,
       transactionRepository: nil,
       conversionService: backend.conversionService)
 
-    let account = Account(name: "Brokerage", type: .investment, instrument: aud)
+    let account = Account(
+      name: "Brokerage", type: .investment, instrument: aud,
+      valuationMode: .calculatedFromTrades)
     _ = try await backend.accounts.create(
       account, openingBalance: InstrumentAmount(quantity: 1_000, instrument: aud))
 
-    await store.loadAllData(accountId: account.id, profileCurrency: aud)
+    await store.loadAllData(account: account, profileCurrency: aud)
 
     #expect(store.accountPerformance == nil)
   }
@@ -95,7 +100,9 @@ struct InvestmentStorePerformanceTests {
       transactionRepository: backend.transactions,
       conversionService: conversion)
 
-    let account = Account(name: "Brokerage", type: .investment, instrument: aud)
+    let account = Account(
+      name: "Brokerage", type: .investment, instrument: aud,
+      valuationMode: .calculatedFromTrades)
     _ = try await backend.accounts.create(
       account, openingBalance: InstrumentAmount(quantity: 0, instrument: aud))
 
@@ -115,7 +122,7 @@ struct InvestmentStorePerformanceTests {
       )
     )
 
-    await store.loadAllData(accountId: account.id, profileCurrency: aud)
+    await store.loadAllData(account: account, profileCurrency: aud)
 
     #expect(store.accountPerformance == nil)
     #expect(store.error != nil)
@@ -123,7 +130,9 @@ struct InvestmentStorePerformanceTests {
 
   @Test("setValue refreshes accountPerformance on the legacy path")
   func setValueRefreshesPerformance() async throws {
-    let accountId = UUID()
+    let account = Account(
+      name: "Brokerage", type: .investment, instrument: .AUD,
+      valuationMode: .recordedValue)
     let aud = Instrument.AUD
     let calendar = Calendar.current
     let earlierDate = try #require(
@@ -133,7 +142,7 @@ struct InvestmentStorePerformanceTests {
     let (backend, database) = try TestBackend.create()
     TestBackend.seed(
       investmentValues: [
-        accountId: [
+        account.id: [
           InvestmentValue(
             date: earlierDate,
             value: InstrumentAmount(quantity: 10_000, instrument: aud))
@@ -145,10 +154,10 @@ struct InvestmentStorePerformanceTests {
       repository: backend.investments,
       transactionRepository: backend.transactions,
       conversionService: backend.conversionService)
-    await store.loadAllData(accountId: accountId, profileCurrency: aud)
+    await store.loadAllData(account: account, profileCurrency: aud)
 
     await store.setValue(
-      accountId: accountId, date: laterDate,
+      accountId: account.id, date: laterDate,
       value: InstrumentAmount(quantity: 12_000, instrument: aud))
 
     let perf = try #require(store.accountPerformance)
@@ -157,7 +166,9 @@ struct InvestmentStorePerformanceTests {
 
   @Test("removeValue refreshes accountPerformance on the legacy path")
   func removeValueRefreshesPerformance() async throws {
-    let accountId = UUID()
+    let account = Account(
+      name: "Brokerage", type: .investment, instrument: .AUD,
+      valuationMode: .recordedValue)
     let aud = Instrument.AUD
     let calendar = Calendar.current
     let earlierDate = try #require(
@@ -167,7 +178,7 @@ struct InvestmentStorePerformanceTests {
     let (backend, database) = try TestBackend.create()
     TestBackend.seed(
       investmentValues: [
-        accountId: [
+        account.id: [
           InvestmentValue(
             date: earlierDate,
             value: InstrumentAmount(quantity: 10_000, instrument: aud)),
@@ -182,9 +193,9 @@ struct InvestmentStorePerformanceTests {
       repository: backend.investments,
       transactionRepository: backend.transactions,
       conversionService: backend.conversionService)
-    await store.loadAllData(accountId: accountId, profileCurrency: aud)
+    await store.loadAllData(account: account, profileCurrency: aud)
 
-    await store.removeValue(accountId: accountId, date: laterDate)
+    await store.removeValue(accountId: account.id, date: laterDate)
 
     let perf = try #require(store.accountPerformance)
     #expect(perf.currentValue == InstrumentAmount(quantity: 10_000, instrument: aud))
@@ -211,10 +222,12 @@ struct InvestmentStorePerformanceTests {
       repository: backend.investments,
       transactionRepository: backend.transactions,
       conversionService: backend.conversionService)
-    let account = Account(name: "Brokerage", type: .investment, instrument: aud)
+    let account = Account(
+      name: "Brokerage", type: .investment, instrument: aud,
+      valuationMode: .calculatedFromTrades)
     _ = try await backend.accounts.create(
       account, openingBalance: InstrumentAmount(quantity: 5_000, instrument: aud))
-    await store.loadAllData(accountId: account.id, profileCurrency: aud)
+    await store.loadAllData(account: account, profileCurrency: aud)
 
     // Intra-account USD ↔ AUD trade: per the §2 rule, no boundary crossed
     // → no flow → totalContributions stays at the opening-balance $5,000.
@@ -229,7 +242,7 @@ struct InvestmentStorePerformanceTests {
         ]
       )
     )
-    await store.reloadPositionsIfNeeded(accountId: account.id, profileCurrency: aud)
+    await store.reloadPositionsIfNeeded(account: account, profileCurrency: aud)
 
     let perf = try #require(store.accountPerformance)
     #expect(perf.totalContributions == InstrumentAmount(quantity: 5_000, instrument: aud))

--- a/MoolahTests/Features/InvestmentStorePositionsInputTests.swift
+++ b/MoolahTests/Features/InvestmentStorePositionsInputTests.swift
@@ -17,7 +17,9 @@ struct InvestmentStorePositionsInputTests {
       transactionRepository: backend.transactions,
       conversionService: backend.conversionService
     )
-    let account = Account(name: "Brokerage", type: .investment, instrument: aud)
+    let account = Account(
+      name: "Brokerage", type: .investment, instrument: aud,
+      valuationMode: .calculatedFromTrades)
     _ = try await backend.accounts.create(
       account, openingBalance: InstrumentAmount(quantity: 0, instrument: aud))
     _ = try await backend.transactions.create(
@@ -29,7 +31,7 @@ struct InvestmentStorePositionsInputTests {
         ]
       )
     )
-    await store.loadAllData(accountId: account.id, profileCurrency: aud)
+    await store.loadAllData(account: account, profileCurrency: aud)
 
     let input = try await store.positionsViewInput(
       title: account.name, range: .threeMonths)
@@ -74,7 +76,9 @@ struct InvestmentStorePositionsInputTests {
       transactionRepository: backend.transactions,
       conversionService: conversionService
     )
-    let account = Account(name: "Crypto", type: .investment, instrument: aud)
+    let account = Account(
+      name: "Crypto", type: .investment, instrument: aud,
+      valuationMode: .calculatedFromTrades)
     _ = try await backend.accounts.create(
       account, openingBalance: InstrumentAmount(quantity: 0, instrument: aud))
 
@@ -104,7 +108,7 @@ struct InvestmentStorePositionsInputTests {
       )
     )
 
-    await store.loadAllData(accountId: account.id, profileCurrency: aud)
+    await store.loadAllData(account: account, profileCurrency: aud)
     let input = try await store.positionsViewInput(title: account.name, range: .threeMonths)
 
     let ethRow = try #require(input.positions.first(where: { $0.instrument == eth }))

--- a/MoolahTests/Features/InvestmentStoreValuationModeTests.swift
+++ b/MoolahTests/Features/InvestmentStoreValuationModeTests.swift
@@ -11,7 +11,7 @@ struct InvestmentStoreValuationModeTests {
     let (backend, _) = try TestBackend.create()
     let account = try await backend.accounts.create(
       Account(
-        name: "B", type: .investment, instrument: .AUD,
+        name: "Recorded", type: .investment, instrument: .AUD,
         valuationMode: .recordedValue))
     try await backend.investments.setValue(
       accountId: account.id,
@@ -31,14 +31,25 @@ struct InvestmentStoreValuationModeTests {
   @Test("loadAllData(account:) calls trades path when mode is calculatedFromTrades")
   func tradesTakesPositionsPath() async throws {
     let (backend, _) = try TestBackend.create()
+    let bhp = Instrument.stock(ticker: "BHP.AX", exchange: "ASX", name: "BHP")
     let account = try await backend.accounts.create(
       Account(
-        name: "T", type: .investment, instrument: .AUD,
+        name: "Trades", type: .investment, instrument: .AUD,
         valuationMode: .calculatedFromTrades))
     try await backend.investments.setValue(
       accountId: account.id,
       date: Date(timeIntervalSince1970: 1_700_000_000),
       value: InstrumentAmount(quantity: 9999, instrument: .AUD))
+    // Seed a trade so the trades path produces a non-empty `positions`
+    // result; pinning both sides ensures the test fails not just when
+    // the legacy branch fires but also when the trades branch is a no-op.
+    _ = try await backend.transactions.create(
+      Transaction(
+        date: Date(),
+        legs: [
+          TransactionLeg(accountId: account.id, instrument: bhp, quantity: 100, type: .trade),
+          TransactionLeg(accountId: account.id, instrument: .AUD, quantity: -4_000, type: .trade),
+        ]))
 
     let store = InvestmentStore(
       repository: backend.investments,
@@ -47,5 +58,6 @@ struct InvestmentStoreValuationModeTests {
     await store.loadAllData(account: account, profileCurrency: .AUD)
 
     #expect(store.values.isEmpty)
+    #expect(!store.positions.isEmpty)
   }
 }

--- a/MoolahTests/Features/InvestmentStoreValuationModeTests.swift
+++ b/MoolahTests/Features/InvestmentStoreValuationModeTests.swift
@@ -1,0 +1,51 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@MainActor
+@Suite("InvestmentStore branches on Account.valuationMode")
+struct InvestmentStoreValuationModeTests {
+  @Test("loadAllData(account:) calls legacy path when mode is recordedValue")
+  func recordedTakesLegacyPath() async throws {
+    let (backend, _) = try TestBackend.create()
+    let account = try await backend.accounts.create(
+      Account(
+        name: "B", type: .investment, instrument: .AUD,
+        valuationMode: .recordedValue))
+    try await backend.investments.setValue(
+      accountId: account.id,
+      date: Date(timeIntervalSince1970: 1_700_000_000),
+      value: InstrumentAmount(quantity: 100, instrument: .AUD))
+
+    let store = InvestmentStore(
+      repository: backend.investments,
+      transactionRepository: backend.transactions,
+      conversionService: backend.conversionService)
+    await store.loadAllData(account: account, profileCurrency: .AUD)
+
+    #expect(!store.values.isEmpty)
+    #expect(store.positions.isEmpty)
+  }
+
+  @Test("loadAllData(account:) calls trades path when mode is calculatedFromTrades")
+  func tradesTakesPositionsPath() async throws {
+    let (backend, _) = try TestBackend.create()
+    let account = try await backend.accounts.create(
+      Account(
+        name: "T", type: .investment, instrument: .AUD,
+        valuationMode: .calculatedFromTrades))
+    try await backend.investments.setValue(
+      accountId: account.id,
+      date: Date(timeIntervalSince1970: 1_700_000_000),
+      value: InstrumentAmount(quantity: 9999, instrument: .AUD))
+
+    let store = InvestmentStore(
+      repository: backend.investments,
+      transactionRepository: backend.transactions,
+      conversionService: backend.conversionService)
+    await store.loadAllData(account: account, profileCurrency: .AUD)
+
+    #expect(store.values.isEmpty)
+  }
+}


### PR DESCRIPTION
## Summary
- `InvestmentStore.loadAllData(account:profileCurrency:)` and `reloadPositionsIfNeeded(account:profileCurrency:)` now switch on `account.valuationMode`. Signature changed from `accountId: UUID` to `account: Account`. `hasLegacyValuations` removed.
- `InvestmentAccountView` body branches on the mode via a `switch`. `.task(id:)` reacts to either `account.id` or `account.valuationMode` changes (combined `LoadKey` struct), so a mode flip triggers a fresh load. `.id(ValuationMode...)` on layout subtrees gives SwiftUI a deterministic teardown frame.
- Cancellation guards added between every sequential `await` in both branches of `loadAllData` and in `reloadPositionsIfNeeded` (pre-existing concurrency gap, addressed during this PR).

Mode-flip-in-Release smoke test deferred to Phase 6 (the user-facing Picker that lets a user actually flip the mode lands there).

**Stacked on top of #733 (Phase 3).** Diff narrows once #733 lands.

Spec: Phase 4 of `plans/2026-05-04-per-account-valuation-mode-design.md` (#730).

## Review history
Reviewed by `code-review`, `ui-review`, `concurrency-review`. All in-scope findings applied in `d3500a98`, including:
- **Critical (code-review):** mode-change without reload — fixed via `LoadKey` task id + `.id()` layout subtrees + removal of the `pendingLayoutSwitch` fire-and-forget Task.
- **Important (concurrency):** cancellation guards between sequential awaits in `loadAllData` / `reloadPositionsIfNeeded`.
- **Important (code):** `tradesTakesPositionsPath` test now seeds a trade and asserts `!store.positions.isEmpty` symmetrically.
- **Important (code):** Position-tracked preview uses `valuationMode: .calculatedFromTrades`.
- **Minor (UI):** ProgressView accessibility label.
- **Minor (concurrency):** silent `try?` catches replaced with `Self.logger.error(...)`.

### Deferred (pre-existing UI / cleanup, separate PR)
- `timePeriodPicker` 6pt vertical padding < iOS 44pt touch target.
- VoiceOver focus anchor on layout transition.
- `#Preview` blocks may crash in some workspaces (preview-infrastructure issue, unrelated to Phase 4 diff).
- `async let` for parallel `loadValues`/`loadDailyBalances`.
- `refreshable` block code duplication with `.task` (extract method).
- Icon-only "Record Value" button missing `.accessibilityLabel`.
- `accountTransactionList` per-call instantiation semantics rename.

## Test plan
- [x] `just test-mac` green (2044 tests / 320 suites)
- [x] `just format-check` clean
- [x] `.swiftlint-baseline.yml` untouched
- [x] No new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)