### PR TITLE
feat: daily-balance fold filters by valuationMode

### DIFF
--- a/Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesInvestmentValues.swift
+++ b/Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesInvestmentValues.swift
@@ -14,16 +14,23 @@ extension GRDBAnalysisRepository {
 
   // MARK: - SQL fetches
 
-  /// Loads every account id whose `type = 'investment'`. The Swift
-  /// assembly walks per-day deltas and needs to know which accounts
-  /// are investments so it can route transfer legs into
-  /// `accountsFromTransfers`. Reading the column directly off the
-  /// `account` table avoids redundantly carrying the full account row
-  /// across the snapshot boundary.
+  /// Loads every account id whose `type = 'investment'` AND whose
+  /// `valuation_mode = 'recordedValue'`. The Swift assembly walks
+  /// per-day deltas and folds in snapshot values for these accounts;
+  /// trades-mode investment accounts are intentionally excluded
+  /// because their per-day value comes from a different path and they
+  /// have no snapshot fold to apply — including them here would
+  /// overwrite their daily balance with a stale or missing snapshot.
+  /// Reading the column directly off the `account` table avoids
+  /// redundantly carrying the full account row across the snapshot
+  /// boundary.
   static func fetchInvestmentAccountIds(database: Database) throws -> Set<UUID> {
     let rows = try Row.fetchAll(
       database,
-      sql: "SELECT id FROM account WHERE type = 'investment'")
+      sql: """
+        SELECT id FROM account
+        WHERE type = 'investment' AND valuation_mode = 'recordedValue'
+        """)
     var ids = Set<UUID>()
     ids.reserveCapacity(rows.count)
     for row in rows {

--- a/MoolahTests/Backends/GRDB/DailyBalancesPlanPinningTests.swift
+++ b/MoolahTests/Backends/GRDB/DailyBalancesPlanPinningTests.swift
@@ -191,6 +191,29 @@ struct DailyBalancesPlanPinningTests {
     // Temp B-tree GROUP/ORDER lines accepted — see file-header rationale.
   }
 
+  @Test("fetchInvestmentAccountIds uses account_by_type")
+  func fetchInvestmentAccountIdsUsesAccountByType() throws {
+    let database = try makeDatabase()
+    // Mirrors the per-account id loader driven by
+    // `GRDBAnalysisRepository.fetchInvestmentAccountIds`. The
+    // production SQL filters on `type = 'investment'` AND
+    // `valuation_mode = 'recordedValue'` so the snapshot fold only
+    // applies to recorded-value investment accounts. The
+    // `account_by_type` index keys on `(type)` and serves the
+    // selective `type = 'investment'` predicate; the
+    // `valuation_mode` predicate filters the candidate rows post-seek.
+    // SQLite emits `SEARCH account USING INDEX account_by_type` for
+    // this shape, which is *not* a full table scan.
+    let detail = try planDetail(
+      database,
+      query: """
+        SELECT id FROM account
+        WHERE type = 'investment' AND valuation_mode = 'recordedValue'
+        """)
+    #expect(detail.contains("account_by_type"))
+    #expect(!PlanPinningTestHelpers.planHasFullTableScanOf(detail, alias: "account"))
+  }
+
   @Test("fetchDailyBalances investment-value lookup uses iv_by_account_date_value")
   func fetchDailyBalancesInvestmentValuesUseAccountDateIndex() throws {
     let database = try makeDatabase()

--- a/MoolahTests/Backends/GRDB/DailyBalancesPlanPinningTests.swift
+++ b/MoolahTests/Backends/GRDB/DailyBalancesPlanPinningTests.swift
@@ -210,7 +210,7 @@ struct DailyBalancesPlanPinningTests {
         SELECT id FROM account
         WHERE type = 'investment' AND valuation_mode = 'recordedValue'
         """)
-    #expect(detail.contains("account_by_type"))
+    #expect(detail.contains("SEARCH account USING INDEX account_by_type"))
     #expect(!PlanPinningTestHelpers.planHasFullTableScanOf(detail, alias: "account"))
   }
 

--- a/MoolahTests/Backends/GRDB/InvestmentAccountIdsModeFilterTests.swift
+++ b/MoolahTests/Backends/GRDB/InvestmentAccountIdsModeFilterTests.swift
@@ -1,0 +1,54 @@
+// MoolahTests/Backends/GRDB/InvestmentAccountIdsModeFilterTests.swift
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+/// `fetchInvestmentAccountIds` must not surface trades-mode investment
+/// accounts. The daily-balance snapshot fold owns recorded-value
+/// accounts only; trades-mode accounts get their per-day value from a
+/// different (planned) path. Pinning this filter at the SQL boundary
+/// keeps the snapshot loader from leaking trades-mode ids into the
+/// fold, which would overwrite the calculated value with a stale or
+/// missing snapshot.
+@Suite("fetchInvestmentAccountIds filters by mode")
+struct InvestmentAccountIdsModeFilterTests {
+  /// Encode a `UUID` as a 16-byte BLOB, matching how the production
+  /// `account.id` BLOB column is populated.
+  private static func uuidBlob(_ id: UUID) -> Data {
+    withUnsafeBytes(of: id.uuid) { Data($0) }
+  }
+
+  @Test("only recordedValue investment accounts are returned")
+  func filtersByMode() throws {
+    let queue = try DatabaseQueue()
+    try ProfileSchema.migrator.migrate(queue)
+    let recordedId = UUID()
+    let tradesId = UUID()
+    let bankId = UUID()
+    try queue.write { database in
+      for (id, type, mode) in [
+        (recordedId, "investment", "recordedValue"),
+        (tradesId, "investment", "calculatedFromTrades"),
+        (bankId, "bank", "recordedValue"),
+      ] {
+        try database.execute(
+          sql: """
+            INSERT INTO account
+              (id, record_name, name, type, instrument_id, position,
+               is_hidden, valuation_mode)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+          arguments: [
+            Self.uuidBlob(id), "AccountRecord|\(id)", "n",
+            type, "AUD", 0, 0, mode,
+          ])
+      }
+    }
+    let ids = try queue.read { database in
+      try GRDBAnalysisRepository.fetchInvestmentAccountIds(database: database)
+    }
+    #expect(ids == [recordedId])
+  }
+}

--- a/MoolahTests/Backends/GRDB/InvestmentAccountIdsModeFilterTests.swift
+++ b/MoolahTests/Backends/GRDB/InvestmentAccountIdsModeFilterTests.swift
@@ -14,12 +14,6 @@ import Testing
 /// missing snapshot.
 @Suite("fetchInvestmentAccountIds filters by mode")
 struct InvestmentAccountIdsModeFilterTests {
-  /// Encode a `UUID` as a 16-byte BLOB, matching how the production
-  /// `account.id` BLOB column is populated.
-  private static func uuidBlob(_ id: UUID) -> Data {
-    withUnsafeBytes(of: id.uuid) { Data($0) }
-  }
-
   @Test("only recordedValue investment accounts are returned")
   func filtersByMode() throws {
     let queue = try DatabaseQueue()
@@ -40,10 +34,7 @@ struct InvestmentAccountIdsModeFilterTests {
                is_hidden, valuation_mode)
             VALUES (?, ?, ?, ?, ?, ?, ?, ?)
             """,
-          arguments: [
-            Self.uuidBlob(id), "AccountRecord|\(id)", "n",
-            type, "AUD", 0, 0, mode,
-          ])
+          arguments: [id, "AccountRecord|\(id)", "n", type, "AUD", 0, 0, mode])
       }
     }
     let ids = try queue.read { database in


### PR DESCRIPTION
## Summary
- `fetchInvestmentAccountIds` SQL now filters by `type = 'investment' AND valuation_mode = 'recordedValue'`. Trades-mode investment accounts no longer leak snapshot folds into per-day balances.
- New `InvestmentAccountIdsModeFilterTests` pins the filter behaviour at the SQL level.
- New plan-pinning test pins the exact `SEARCH account USING INDEX account_by_type` plan shape — guards against a future regression to a full table scan.

Per the design, trades-mode historical chart accuracy remains a known limitation tracked separately.

**Stacked on top of #734 (Phase 4).** Diff narrows once #734 lands.

Spec: Phase 5 of `plans/2026-05-04-per-account-valuation-mode-design.md` (#730).

## Review history
Reviewed by `code-review` (Important + Minor applied) and `database-code-review` (clean). Fix-up `38b7c84a`:
- Dropped redundant `uuidBlob` test helper — GRDB's `UUID: DatabaseValueConvertible` converts directly.
- Tightened plan-pinning assertion to match the exact `SEARCH account USING INDEX account_by_type` plan string instead of substring-contains.

## Test plan
- [x] `just test-mac` green
- [x] Plan-pinning verifies index used (no SCAN regression)
- [x] `just format-check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)