### PR TITLE
feat: settings picker + trades-as-default for new investment accounts

### DIFF
--- a/Features/Accounts/AccountStore.swift
+++ b/Features/Accounts/AccountStore.swift
@@ -250,11 +250,11 @@ final class AccountStore {
     isLoading = true
     error = nil
 
-    // User-driven creation defaults investment accounts to
-    // `.calculatedFromTrades`. Migration paths write through
-    // `AccountRepository.update`, not `create`, so existing rows are
-    // unaffected. Callers that want the struct default explicitly pass
-    // `valuationMode: .recordedValue`; that input is preserved.
+    // User-driven account creation lands in trades mode by default for
+    // investment accounts: any caller-provided `.recordedValue` is silently
+    // promoted to `.calculatedFromTrades`. Migration / sync paths that need
+    // to write `.recordedValue` go through `accountRepository.update(_:)`
+    // directly, not this method.
     var toCreate = account
     if toCreate.type == .investment && toCreate.valuationMode == .recordedValue {
       toCreate.valuationMode = .calculatedFromTrades

--- a/Features/Accounts/AccountStore.swift
+++ b/Features/Accounts/AccountStore.swift
@@ -250,8 +250,18 @@ final class AccountStore {
     isLoading = true
     error = nil
 
+    // User-driven creation defaults investment accounts to
+    // `.calculatedFromTrades`. Migration paths write through
+    // `AccountRepository.update`, not `create`, so existing rows are
+    // unaffected. Callers that want the struct default explicitly pass
+    // `valuationMode: .recordedValue`; that input is preserved.
+    var toCreate = account
+    if toCreate.type == .investment && toCreate.valuationMode == .recordedValue {
+      toCreate.valuationMode = .calculatedFromTrades
+    }
+
     do {
-      let created = try await repository.create(account, openingBalance: openingBalance)
+      let created = try await repository.create(toCreate, openingBalance: openingBalance)
 
       // Optimistically add to local state
       accounts = Accounts(from: accounts.ordered + [created])

--- a/Features/Accounts/Views/EditAccountView.swift
+++ b/Features/Accounts/Views/EditAccountView.swift
@@ -6,6 +6,7 @@ struct EditAccountView: View {
   @State private var type: AccountType
   @State private var currency: Instrument
   @State private var isHidden: Bool
+  @State private var valuationMode: ValuationMode
   @State private var isSubmitting = false
   @State private var errorMessage: String?
   @FocusState private var focusedField: Field?
@@ -24,6 +25,7 @@ struct EditAccountView: View {
     _type = State(initialValue: account.type)
     _currency = State(initialValue: account.instrument)
     _isHidden = State(initialValue: account.isHidden)
+    _valuationMode = State(initialValue: account.valuationMode)
   }
 
   var body: some View {
@@ -38,6 +40,7 @@ struct EditAccountView: View {
   private var form: some View {
     Form {
       detailsSection
+      valuationSection
       if let errorMessage {
         Section {
           Label(errorMessage, systemImage: "exclamationmark.triangle.fill")
@@ -85,6 +88,28 @@ struct EditAccountView: View {
     }
   }
 
+  /// Visible only for investment accounts. Lets the user choose between the
+  /// snapshot-driven `recordedValue` mode and the position-driven
+  /// `calculatedFromTrades` mode. Footer text describes the active mode so
+  /// the user can predict what the sidebar balance will read.
+  @ViewBuilder private var valuationSection: some View {
+    if type == .investment {
+      Section {
+        Picker("Valuation", selection: $valuationMode) {
+          Text("Recorded value").tag(ValuationMode.recordedValue)
+          Text("Calculated from trades").tag(ValuationMode.calculatedFromTrades)
+        }
+        .accessibilityIdentifier("editAccount.valuationMode")
+      } footer: {
+        Text(
+          valuationMode == .recordedValue
+            ? "The account's current value comes from the latest valuation snapshot you entered."
+            : "The account's current value is computed from your trade history and current "
+              + "instrument prices.")
+      }
+    }
+  }
+
   private var isValid: Bool {
     !name.trimmingCharacters(in: .whitespaces).isEmpty
   }
@@ -100,6 +125,7 @@ struct EditAccountView: View {
     updated.type = type
     updated.instrument = currency
     updated.isHidden = isHidden
+    updated.valuationMode = valuationMode
 
     do {
       _ = try await accountStore.update(updated)
@@ -111,7 +137,7 @@ struct EditAccountView: View {
   }
 }
 
-#Preview {
+#Preview("Bank account") {
   let (backend, _) = PreviewBackend.create()
   let accountStore = AccountStore(
     repository: backend.accounts,
@@ -120,5 +146,21 @@ struct EditAccountView: View {
 
   EditAccountView(
     account: Account(name: "Checking", type: .bank, instrument: .AUD),
+    accountStore: accountStore)
+}
+
+#Preview("Investment account") {
+  let (backend, _) = PreviewBackend.create()
+  let accountStore = AccountStore(
+    repository: backend.accounts,
+    conversionService: backend.conversionService,
+    targetInstrument: .AUD)
+
+  EditAccountView(
+    account: Account(
+      name: "Brokerage",
+      type: .investment,
+      instrument: .AUD,
+      valuationMode: .calculatedFromTrades),
     accountStore: accountStore)
 }

--- a/Features/Accounts/Views/EditAccountView.swift
+++ b/Features/Accounts/Views/EditAccountView.swift
@@ -66,6 +66,7 @@ struct EditAccountView: View {
           .disabled(!isValid || isSubmitting)
       }
     }
+    .animation(.easeInOut(duration: 0.2), value: type)
   }
 
   private var detailsSection: some View {
@@ -100,12 +101,17 @@ struct EditAccountView: View {
           Text("Calculated from trades").tag(ValuationMode.calculatedFromTrades)
         }
         .accessibilityIdentifier("editAccount.valuationMode")
+        .accessibilityHint(
+          valuationMode == .recordedValue
+            ? "Balance comes from the value you last recorded"
+            : "Balance is calculated from your trade history and current prices of your holdings"
+        )
       } footer: {
         Text(
           valuationMode == .recordedValue
-            ? "The account's current value comes from the latest valuation snapshot you entered."
-            : "The account's current value is computed from your trade history and current "
-              + "instrument prices.")
+            ? "The balance comes from the value you last recorded manually."
+            : "The balance is calculated from your trade history and the current prices "
+              + "of your holdings.")
       }
     }
   }

--- a/MoolahTests/Automation/AddInvestmentValueIntentPolicyTests.swift
+++ b/MoolahTests/Automation/AddInvestmentValueIntentPolicyTests.swift
@@ -1,0 +1,52 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+/// Regression guard for the documented snapshot-write policy: the
+/// AutomationService `setInvestmentValue` (the entry point invoked by
+/// `AddInvestmentValueIntent`) writes the snapshot regardless of the
+/// account's current `valuationMode`. A user in
+/// `.calculatedFromTrades` mode can still record a manual value
+/// (e.g. for a one-off audit) without first flipping the mode.
+@Suite("AddInvestmentValueIntent (policy)")
+@MainActor
+struct AddInvestmentValueIntentPolicyTests {
+  private func makeServiceWithSession() async throws -> (AutomationService, ProfileSession) {
+    let containerManager = try ProfileContainerManager.forTesting()
+    let sessionManager = SessionManager(containerManager: containerManager)
+    let profile = Profile(
+      label: "Test",
+      currencyCode: "AUD",
+      financialYearStartMonth: 7
+    )
+    let session = sessionManager.session(for: profile)
+    await session.accountStore.load()
+    let service = AutomationService(sessionManager: sessionManager)
+    return (service, session)
+  }
+
+  @Test("writes a snapshot even when account is in calculatedFromTrades mode")
+  func writesInTradesMode() async throws {
+    let (service, session) = try await makeServiceWithSession()
+
+    // The Phase 6 default makes `store.create` set
+    // `.calculatedFromTrades` on every new investment account, so this
+    // matches the production "user creates a brokerage today" path.
+    let saved = try await session.accountStore.create(
+      Account(name: "Brokerage", type: .investment, instrument: session.profile.instrument))
+    #expect(saved.valuationMode == .calculatedFromTrades)
+
+    let date = Date(timeIntervalSince1970: 1_700_000_000)
+    try await service.setInvestmentValue(
+      profileIdentifier: "Test",
+      accountName: "Brokerage",
+      date: date,
+      value: 100)
+
+    let page = try await session.backend.investments.fetchValues(
+      accountId: saved.id, page: 0, pageSize: 10)
+    #expect(page.values.count == 1)
+    #expect(page.values.first?.value.quantity == 100)
+  }
+}

--- a/MoolahTests/Automation/AddInvestmentValueIntentPolicyTests.swift
+++ b/MoolahTests/Automation/AddInvestmentValueIntentPolicyTests.swift
@@ -30,9 +30,9 @@ struct AddInvestmentValueIntentPolicyTests {
   func writesInTradesMode() async throws {
     let (service, session) = try await makeServiceWithSession()
 
-    // The Phase 6 default makes `store.create` set
-    // `.calculatedFromTrades` on every new investment account, so this
-    // matches the production "user creates a brokerage today" path.
+    // `store.create` promotes every new investment account to
+    // `.calculatedFromTrades`, so this matches the production
+    // "user creates a brokerage today" path.
     let saved = try await session.accountStore.create(
       Account(name: "Brokerage", type: .investment, instrument: session.profile.instrument))
     #expect(saved.valuationMode == .calculatedFromTrades)

--- a/MoolahTests/Features/AccountStoreNewAccountDefaultTests.swift
+++ b/MoolahTests/Features/AccountStoreNewAccountDefaultTests.swift
@@ -43,16 +43,15 @@ struct AccountStoreNewAccountDefaultTests {
     #expect(after.valuationMode == .recordedValue)
   }
 
-  @Test("explicit calculatedFromTrades on the input is preserved")
-  func explicitTradesModeRespected() async throws {
+  @Test("explicit recordedValue on investment input is overridden to trades")
+  func explicitRecordedOnInvestmentOverriddenToTrades() async throws {
     let (store, backend) = try makeStore()
     let saved = try await store.create(
       Account(
         name: "B",
         type: .investment,
         instrument: .defaultTestInstrument,
-        valuationMode: .calculatedFromTrades))
-
+        valuationMode: .recordedValue))
     let all = try await backend.accounts.fetchAll()
     let after = try #require(all.first { $0.id == saved.id })
     #expect(after.valuationMode == .calculatedFromTrades)

--- a/MoolahTests/Features/AccountStoreNewAccountDefaultTests.swift
+++ b/MoolahTests/Features/AccountStoreNewAccountDefaultTests.swift
@@ -1,0 +1,60 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+/// Pins the default valuation mode that `AccountStore.create(_:)` applies to
+/// user-driven account creation. Investment accounts default to
+/// `.calculatedFromTrades` so a freshly-created brokerage starts in
+/// position-driven mode rather than the struct-default snapshot mode.
+/// Migration writes go through `AccountRepository.update`, not `create`, so
+/// they remain unaffected.
+@Suite("AccountStore.create defaults investment accounts to calculatedFromTrades")
+@MainActor
+struct AccountStoreNewAccountDefaultTests {
+  private func makeStore() throws -> (AccountStore, CloudKitBackend) {
+    let (backend, _) = try TestBackend.create()
+    let store = AccountStore(
+      repository: backend.accounts,
+      conversionService: FixedConversionService(),
+      targetInstrument: .defaultTestInstrument)
+    return (store, backend)
+  }
+
+  @Test("new investment account whose mode is the struct default → trades")
+  func newInvestmentDefaultsToTrades() async throws {
+    let (store, backend) = try makeStore()
+    let saved = try await store.create(
+      Account(name: "Brokerage", type: .investment, instrument: .defaultTestInstrument))
+
+    let all = try await backend.accounts.fetchAll()
+    let after = try #require(all.first { $0.id == saved.id })
+    #expect(after.valuationMode == .calculatedFromTrades)
+  }
+
+  @Test("new bank account stays at recordedValue (the unread default)")
+  func newBankUnchanged() async throws {
+    let (store, backend) = try makeStore()
+    let saved = try await store.create(
+      Account(name: "Checking", type: .bank, instrument: .defaultTestInstrument))
+
+    let all = try await backend.accounts.fetchAll()
+    let after = try #require(all.first { $0.id == saved.id })
+    #expect(after.valuationMode == .recordedValue)
+  }
+
+  @Test("explicit calculatedFromTrades on the input is preserved")
+  func explicitTradesModeRespected() async throws {
+    let (store, backend) = try makeStore()
+    let saved = try await store.create(
+      Account(
+        name: "B",
+        type: .investment,
+        instrument: .defaultTestInstrument,
+        valuationMode: .calculatedFromTrades))
+
+    let all = try await backend.accounts.fetchAll()
+    let after = try #require(all.first { $0.id == saved.id })
+    #expect(after.valuationMode == .calculatedFromTrades)
+  }
+}

--- a/MoolahTests/Features/AccountStoreUpdateValuationTests.swift
+++ b/MoolahTests/Features/AccountStoreUpdateValuationTests.swift
@@ -9,9 +9,9 @@ import Testing
 /// avoids spinning up XCUITest infrastructure (no edit-account driver,
 /// no seed, no sheet-open identifier exists today) while still pinning
 /// the behaviour the picker relies on.
-@Suite("EditAccountView/ValuationMode")
+@Suite("AccountStore.update (valuation)")
 @MainActor
-struct EditAccountValuationModeTests {
+struct AccountStoreUpdateValuationTests {
   @Test("changing valuationMode and saving persists via the store")
   func picksAndSavesNewMode() async throws {
     let (backend, database) = try TestBackend.create()

--- a/MoolahTests/Features/EditAccountValuationModeTests.swift
+++ b/MoolahTests/Features/EditAccountValuationModeTests.swift
@@ -1,0 +1,60 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+/// Pins the save flow used by `EditAccountView`'s Valuation picker: the
+/// view assigns the user's choice onto a mutable copy of the account and
+/// hands it to `AccountStore.update(_:)`. Exercising the store directly
+/// avoids spinning up XCUITest infrastructure (no edit-account driver,
+/// no seed, no sheet-open identifier exists today) while still pinning
+/// the behaviour the picker relies on.
+@Suite("EditAccountView/ValuationMode")
+@MainActor
+struct EditAccountValuationModeTests {
+  @Test("changing valuationMode and saving persists via the store")
+  func picksAndSavesNewMode() async throws {
+    let (backend, database) = try TestBackend.create()
+    let original = AccountStoreTestSupport.seedAccount(
+      name: "Brokerage", type: .investment, balance: 0,
+      valuationMode: .recordedValue, in: database)
+    let store = AccountStore(
+      repository: backend.accounts,
+      conversionService: FixedConversionService(),
+      targetInstrument: .defaultTestInstrument)
+    await store.load()
+
+    // Mirror EditAccountView.save(): copy the account, assign the picker's
+    // value, then hand it to the store.
+    var updated = original
+    updated.valuationMode = .calculatedFromTrades
+    let saved = try await store.update(updated)
+
+    #expect(saved.valuationMode == .calculatedFromTrades)
+    let fetched = try await backend.accounts.fetchAll()
+    let row = try #require(fetched.first { $0.id == original.id })
+    #expect(row.valuationMode == .calculatedFromTrades)
+  }
+
+  @Test("switching from calculatedFromTrades back to recordedValue persists")
+  func savesRoundTripBackToRecordedValue() async throws {
+    let (backend, database) = try TestBackend.create()
+    let original = AccountStoreTestSupport.seedAccount(
+      name: "Brokerage", type: .investment, balance: 0,
+      valuationMode: .calculatedFromTrades, in: database)
+    let store = AccountStore(
+      repository: backend.accounts,
+      conversionService: FixedConversionService(),
+      targetInstrument: .defaultTestInstrument)
+    await store.load()
+
+    var updated = original
+    updated.valuationMode = .recordedValue
+    let saved = try await store.update(updated)
+
+    #expect(saved.valuationMode == .recordedValue)
+    let fetched = try await backend.accounts.fetchAll()
+    let row = try #require(fetched.first { $0.id == original.id })
+    #expect(row.valuationMode == .recordedValue)
+  }
+}


### PR DESCRIPTION
## Summary

The final PR in the valuation-mode series. **First user-observable change in the series.**

- `EditAccountView` gains a "Valuation" `Picker` (visible only when `type == .investment`) with footer copy in plain-spoken brand voice and a VoiceOver `.accessibilityHint` that summarises the active mode.
- `AccountStore.create(_:openingBalance:)` unconditionally promotes new investment accounts to `.calculatedFromTrades` — even an explicit `valuationMode: .recordedValue` input is overridden. Migration / sync paths that need to write `.recordedValue` go through `accountRepository.update(_:)` directly (already the existing pattern).
- `AddInvestmentValueIntent` regression test pins the documented "snapshot writes succeed regardless of mode" policy.
- Form animates Account-Type changes so the valuation section fades in/out smoothly.

Existing accounts retain whichever mode the bootstrap migration set (PR #732). New investment accounts created in-app default to trades.

**Stacked on top of #735 (Phase 5).** Diff narrows once #735 lands.

Spec: Phase 6 of `plans/2026-05-04-per-account-valuation-mode-design.md` (#730).

## Review history
Reviewed by `code-review` and `ui-review`. All in-scope findings applied in `249f0cbf`:

**Code review:**
- Important: comment on `AccountStore.create` now describes the actual one-way override (any investment input promoted to `.calculatedFromTrades`).
- Important: new test `explicitRecordedOnInvestmentOverriddenToTrades` pins the override of an explicit `.recordedValue` input.
- Important: dropped a planning-phase reference from a test comment.
- Minor: store-level test suite renamed to `"AccountStore.update (valuation)"` since it exercises the store boundary, not the view.

**UI review:**
- Important: Picker carries an `.accessibilityHint` summarising the footer for VoiceOver.
- Important: footer copy switches from `"valuation snapshot"` / `"instrument prices"` to plain-spoken `"value you last recorded manually"` / `"current prices of your holdings"` per `BRAND_GUIDE.md`.
- Minor: form animates `type` changes so the valuation section fades in/out.

### Deferred — needs your call
- The plan included an XCUITest at `MoolahUITests_macOS/EditAccountValuationModeTests.swift`. The required infrastructure (`AccountEditDriver`, sheet-open identifiers, an `editAccountValuationMode` seed) doesn't exist. Building it just for one picker assertion would balloon the change. Pivoted to a store-level Swift Testing suite (`AccountStoreUpdateValuationTests`) that pins the same save-flow invariant. If you want the XCUITest later, it can land in a separate PR alongside the missing driver/seed.
- The deferred Release-build mode-flip smoke test from Phase 4 wasn't run here either: setting up a one-off Release build runs into provisioning + build-number gates. The picker is in a `.sheet`-presented `EditAccountView` that dismisses before the underlying `InvestmentAccountView` redraws — Phase 4's `.id(account.valuationMode)` toolbar guard is the load-bearing mechanism, and Phase 4's tests cover it.

## Test plan
- [x] `just test-mac` green (2059 tests / 325 suites)
- [x] `just format-check` clean
- [x] `.swiftlint-baseline.yml` untouched
- [x] No new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)