### PR TITLE
feat(grdb): trades-mode historical net-worth fold (closes #738)

### DIFF
--- a/Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalances.swift
+++ b/Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalances.swift
@@ -89,6 +89,17 @@ extension GRDBAnalysisRepository {
     let earmarkRows: [DailyBalanceEarmarkRow]
     let investmentValues: [InvestmentValueSnapshot]
     let investmentAccountIds: Set<UUID>
+    /// Account ids of trades-mode investment accounts. Drives the new
+    /// per-day position-valuation fold; recorded-value accounts are
+    /// carried in `investmentAccountIds` and drive the snapshot fold.
+    let tradesModeInvestmentAccountIds: Set<UUID>
+    /// Pre-cutoff `transaction_leg` SUM rows filtered to trades-mode
+    /// investment accounts only. Pre-fold seed for the new fold's
+    /// cumulative position dict.
+    let priorTradesModeAccountRows: [DailyBalanceAccountRow]
+    /// Post-cutoff `transaction_leg` SUM rows filtered to trades-mode
+    /// investment accounts only.
+    let tradesModeAccountRows: [DailyBalanceAccountRow]
     let scheduled: [Transaction]
     let instrumentMap: [String: Instrument]
     let forecastUntil: Date?
@@ -124,6 +135,12 @@ extension GRDBAnalysisRepository {
   /// each function fits SwiftLint's `function_parameter_count` budget.
   struct DailyBalancesAssemblyContext: Sendable {
     let investmentAccountIds: Set<UUID>
+    /// Account ids of trades-mode investment accounts — read by
+    /// `applyTradesModePositionValuations` to early-exit when the
+    /// profile has none. None of the seed/walk helpers consult this
+    /// field; trades-mode accounts contribute through the new fold,
+    /// not through `accountsFromTransfers`.
+    let tradesModeInvestmentAccountIds: Set<UUID>
     let instrumentMap: [String: Instrument]
     let profileInstrument: Instrument
     let conversionService: any InstrumentConversionService
@@ -168,6 +185,7 @@ extension GRDBAnalysisRepository {
   ) async throws -> [DailyBalance] {
     let context = DailyBalancesAssemblyContext(
       investmentAccountIds: aggregation.investmentAccountIds,
+      tradesModeInvestmentAccountIds: aggregation.tradesModeInvestmentAccountIds,
       instrumentMap: aggregation.instrumentMap,
       profileInstrument: profileInstrument,
       conversionService: conversionService)
@@ -351,8 +369,9 @@ extension GRDBAnalysisRepository {
   /// Reconstruct an `Instrument` value from the row's `instrument_id`
   /// string, falling back to ambient fiat when the registry has no
   /// stored row for the id. Mirrors the same lookup used by the other
-  /// SQL aggregations.
-  private static func resolveInstrument(
+  /// SQL aggregations. Internal so sibling `+DailyBalances*.swift`
+  /// extensions can share one decoding helper.
+  static func resolveInstrument(
     _ id: String, in map: [String: Instrument]
   ) -> Instrument {
     map[id] ?? Instrument.fiat(code: id)

--- a/Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalances.swift
+++ b/Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalances.swift
@@ -5,7 +5,9 @@ import GRDB
 /// Companion files split the workload further:
 /// - `+DailyBalancesAggregation.swift` holds the four SQL fetches.
 /// - `+DailyBalancesInvestmentValues.swift` holds the per-day
-///   investment-value fold-in.
+///   recorded-value snapshot fold-in.
+/// - `+DailyBalancesTradesMode.swift` holds the per-day trades-mode
+///   position-valuation fold-in (sister of the snapshot fold).
 /// - `+DailyBalancesForecast.swift` holds the forecast extrapolation.
 ///
 /// Mirrors the `+ExpenseBreakdown.swift`, `+CategoryBalances.swift`,
@@ -207,6 +209,13 @@ extension GRDBAnalysisRepository {
       context: context,
       handlers: handlers)
 
+    try await applyTradesModePositionValuations(
+      priorRows: aggregation.priorTradesModeAccountRows,
+      postRows: aggregation.tradesModeAccountRows,
+      to: &dailyBalances,
+      context: context,
+      handlers: handlers)
+
     var actualBalances = dailyBalances.values.sorted { $0.date < $1.date }
     applyBestFit(to: &actualBalances, instrument: profileInstrument)
 
@@ -290,8 +299,18 @@ extension GRDBAnalysisRepository {
     let accountByDay = Dictionary(grouping: accountRows, by: \.day)
     let earmarkByDay = Dictionary(grouping: earmarkRows, by: \.day)
     let allDayStrings = Set(accountByDay.keys).union(earmarkByDay.keys).sorted()
+    // Trades-mode accounts contribute to investmentValue via
+    // applyTradesModePositionValuations, not to bankTotal. Including
+    // them in BalanceContext.investmentAccountIds excludes them from
+    // PositionBook.dailyBalance's `for ... where !investmentAccountIds`
+    // sum (no double-count) without changing accountsFromTransfers
+    // membership (which seedPriorBook / applyDailyDeltas gate on the
+    // recorded-value-only set, so the .investmentTransfersOnly read
+    // continues to see only recorded-value transfer cash).
+    let allInvestmentIds =
+      context.investmentAccountIds.union(context.tradesModeInvestmentAccountIds)
     let balanceContext = PositionBook.BalanceContext(
-      investmentAccountIds: context.investmentAccountIds,
+      investmentAccountIds: allInvestmentIds,
       profileInstrument: context.profileInstrument,
       rule: .investmentTransfersOnly,
       conversionService: context.conversionService)

--- a/Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesAggregation.swift
+++ b/Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesAggregation.swift
@@ -74,6 +74,9 @@ extension GRDBAnalysisRepository {
       earmarkRows: earmarkRows,
       investmentValues: investmentValues,
       investmentAccountIds: investmentAccountIds,
+      tradesModeInvestmentAccountIds: [],  // populated in Task 3
+      priorTradesModeAccountRows: [],  // populated in Task 3
+      tradesModeAccountRows: [],  // populated in Task 3
       scheduled: scheduled,
       instrumentMap: instrumentMap,
       forecastUntil: forecastUntil)

--- a/Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesAggregation.swift
+++ b/Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesAggregation.swift
@@ -20,7 +20,7 @@ extension GRDBAnalysisRepository {
   ///   way;
   /// - the scheduled `[Transaction]` for forecast extrapolation;
   /// - the accounts table (so we know which accounts are
-  ///   investments);
+  ///   investments — split into recorded-value and trades-mode);
   /// - every `investment_value` row (the cursor walk needs the
   ///   pre-window snapshots so it can carry the most-recent value
   ///   forward into the first in-window day);
@@ -55,6 +55,8 @@ extension GRDBAnalysisRepository {
       database: database, after: after)
     let investmentAccountIds = try Self.fetchInvestmentAccountIds(
       database: database)
+    let tradesModeInvestmentAccountIds =
+      try Self.fetchTradesModeInvestmentAccountIds(database: database)
     // Fetch `instrumentMap` before the investment-value snapshots so
     // `fetchInvestmentValueSnapshots` can resolve each row's instrument
     // to its registered `Instrument` (with the right `kind` for stock /
@@ -67,6 +69,16 @@ extension GRDBAnalysisRepository {
     let scheduled =
       forecastUntil != nil
       ? try Self.fetchScheduledTransactions(database: database) : []
+    // Pre-filter trades-mode rows out of the already-fetched arrays.
+    // Doing the filter inside the read closure (not later) keeps every
+    // input the assembly walk needs inside one MVCC snapshot and saves
+    // re-checking membership inside the per-day fold.
+    let priorTradesModeAccountRows = priorAccountRows.filter {
+      tradesModeInvestmentAccountIds.contains($0.accountId)
+    }
+    let tradesModeAccountRows = accountRows.filter {
+      tradesModeInvestmentAccountIds.contains($0.accountId)
+    }
     return DailyBalancesAggregation(
       priorAccountRows: priorAccountRows,
       priorEarmarkRows: priorEarmarkRows,
@@ -74,9 +86,9 @@ extension GRDBAnalysisRepository {
       earmarkRows: earmarkRows,
       investmentValues: investmentValues,
       investmentAccountIds: investmentAccountIds,
-      tradesModeInvestmentAccountIds: [],  // populated in Task 3
-      priorTradesModeAccountRows: [],  // populated in Task 3
-      tradesModeAccountRows: [],  // populated in Task 3
+      tradesModeInvestmentAccountIds: tradesModeInvestmentAccountIds,
+      priorTradesModeAccountRows: priorTradesModeAccountRows,
+      tradesModeAccountRows: tradesModeAccountRows,
       scheduled: scheduled,
       instrumentMap: instrumentMap,
       forecastUntil: forecastUntil)

--- a/Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesForecast.swift
+++ b/Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesForecast.swift
@@ -190,8 +190,19 @@ extension GRDBAnalysisRepository {
   ) async throws -> [DailyBalance] {
     var book = startingBook
     var forecastBalances: [Date: DailyBalance] = [:]
+    // Trades-mode accounts contribute to investmentValue via the
+    // historic per-day fold; forecast days don't get a trades-mode
+    // contribution and would otherwise sum the raw quantity into
+    // `balance`. Including the trades-mode set in
+    // BalanceContext.investmentAccountIds excludes those accounts
+    // from PositionBook.dailyBalance's bankTotal sum. The second use
+    // of context.investmentAccountIds below (book.apply) is left
+    // unchanged — it gates accountsFromTransfers membership and must
+    // stay recorded-value-only.
+    let allInvestmentIds =
+      context.investmentAccountIds.union(context.tradesModeInvestmentAccountIds)
     let balanceContext = PositionBook.BalanceContext(
-      investmentAccountIds: context.investmentAccountIds,
+      investmentAccountIds: allInvestmentIds,
       profileInstrument: context.profileInstrument,
       rule: .investmentTransfersOnly,
       conversionService: context.conversionService)

--- a/Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesInvestmentValues.swift
+++ b/Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesInvestmentValues.swift
@@ -41,6 +41,34 @@ extension GRDBAnalysisRepository {
     return ids
   }
 
+  /// Loads every account id whose `type = 'investment'` AND whose
+  /// `valuation_mode = 'calculatedFromTrades'`. The trades-mode fold
+  /// (`applyTradesModePositionValuations`) walks per-day position
+  /// deltas for these accounts and valuates the cumulative positions
+  /// against the conversion service on the day's date. Recorded-value
+  /// investment accounts are intentionally excluded — they contribute
+  /// via the snapshot fold instead. Reading the column directly off
+  /// the `account` table avoids carrying the full account row across
+  /// the position-row boundary.
+  static func fetchTradesModeInvestmentAccountIds(
+    database: Database
+  ) throws -> Set<UUID> {
+    let rows = try Row.fetchAll(
+      database,
+      sql: """
+        SELECT id FROM account
+        WHERE type = 'investment' AND valuation_mode = 'calculatedFromTrades'
+        """)
+    var ids = Set<UUID>()
+    ids.reserveCapacity(rows.count)
+    for row in rows {
+      if let id: UUID = row["id"] {
+        ids.insert(id)
+      }
+    }
+    return ids
+  }
+
   /// Loads the per-account latest-as-of-day investment values pinned
   /// by
   /// `DailyBalancesPlanPinningTests.fetchDailyBalancesInvestmentValuesUseAccountDateIndex`.

--- a/Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesInvestmentValues.swift
+++ b/Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesInvestmentValues.swift
@@ -127,11 +127,22 @@ extension GRDBAnalysisRepository {
   }
 
   // MARK: - Per-day fold-in
-  /// Fold the investment-value snapshots into the per-day balances by
-  /// walking the days in order and tracking the latest value per
-  /// account. Same per-day error contract as the historic walk: a
-  /// failed conversion logs and drops just that day's investment
-  /// override; the rest of the days continue.
+  /// Per-day investment-value override: for each recorded-value
+  /// investment account, carries the latest snapshot forward to each
+  /// day and replaces the bank-balance-derived `investmentValue`
+  /// with the converted total.
+  ///
+  /// Rule 11 contract (same as `walkDays`): a conversion failure on a
+  /// single day drops that day from `dailyBalances` via
+  /// `removeValue(forKey:)` so the chart shows a gap rather than an
+  /// incorrect partial total. Sibling days are unaffected.
+  /// `CancellationError` rethrows immediately and is never routed
+  /// through the failure callback.
+  ///
+  /// `Task.checkCancellation()` at the top of the per-day loop covers
+  /// the all-fast-path case (every snapshot already in the profile
+  /// instrument): no `await` would otherwise occur, so the runtime
+  /// would never get a chance to surface cancellation.
   static func applyInvestmentValues(
     _ investmentValues: [InvestmentValueSnapshot],
     to dailyBalances: inout [Date: DailyBalance],

--- a/Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesInvestmentValues.swift
+++ b/Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesInvestmentValues.swift
@@ -142,13 +142,18 @@ extension GRDBAnalysisRepository {
     var latestByAccount: [UUID: InstrumentAmount] = [:]
     var valueIndex = 0
     for date in dailyBalances.keys.sorted() {
+      // The Rule 8 fast path can let the loop run synchronously when
+      // every snapshot is in the profile instrument; an explicit
+      // cancellation check ensures the outer task can be torn down
+      // promptly even in that case.
+      try Task.checkCancellation()
       valueIndex = advanceInvestmentCursor(
         values: investmentValues,
         latestByAccount: &latestByAccount,
         from: valueIndex,
         upTo: date)
       if latestByAccount.isEmpty { continue }
-      let totalValue: InstrumentAmount?
+      let totalValue: InstrumentAmount
       do {
         totalValue = try await sumInvestmentValues(
           latestByAccount: latestByAccount,
@@ -158,10 +163,14 @@ extension GRDBAnalysisRepository {
       } catch let cancel as CancellationError {
         throw cancel
       } catch {
+        // Rule 11: drop the day from dailyBalances so the chart shows
+        // a gap rather than rendering a partial total. Matches the
+        // walkDays per-day error contract.
         handlers.handleInvestmentValueFailure(error, date)
+        dailyBalances.removeValue(forKey: date)
         continue
       }
-      guard let totalValue, let balance = dailyBalances[date] else { continue }
+      guard let balance = dailyBalances[date] else { continue }
       dailyBalances[date] = DailyBalance(
         date: balance.date,
         balance: balance.balance,
@@ -199,16 +208,16 @@ extension GRDBAnalysisRepository {
   }
 
   /// Sum the per-account investment values, converting foreign
-  /// instruments to the profile instrument on `date`. Returns `nil`
-  /// when any conversion fails so the caller can drop just this day's
-  /// override without folding the failure into the historic-walk
-  /// error path.
+  /// instruments to the profile instrument on `date`. Throws on any
+  /// conversion failure so the caller can drop the day from the
+  /// `dailyBalances` dict per Rule 11. The return is non-optional —
+  /// the function either throws or returns the converted total.
   private static func sumInvestmentValues(
     latestByAccount: [UUID: InstrumentAmount],
     on date: Date,
     profileInstrument: Instrument,
     conversionService: any InstrumentConversionService
-  ) async throws -> InstrumentAmount? {
+  ) async throws -> InstrumentAmount {
     var total: Decimal = 0
     for value in latestByAccount.values {
       if value.instrument.id == profileInstrument.id {

--- a/Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesTradesMode.swift
+++ b/Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesTradesMode.swift
@@ -160,6 +160,9 @@ extension GRDBAnalysisRepository {
     on dayKey: Date,
     profileInstrument: Instrument
   ) {
+    precondition(
+      total.instrument == profileInstrument,
+      "mergeTradesModeTotal: total must be in profileInstrument; got \(total.instrument.id)")
     guard let existing = dailyBalances[dayKey] else { return }
     let combined =
       (existing.investmentValue ?? .zero(instrument: profileInstrument)) + total

--- a/Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesTradesMode.swift
+++ b/Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesTradesMode.swift
@@ -1,0 +1,211 @@
+import Foundation
+
+/// Per-day position-valuation fold for trades-mode investment
+/// accounts. Sister of `applyInvestmentValues` in
+/// `+DailyBalancesInvestmentValues.swift` — same per-day Rule 11
+/// error contract: `CancellationError` rethrows immediately; any
+/// other thrown error drops the day from `dailyBalances` and logs
+/// through `handleInvestmentValueFailure`.
+///
+/// Split out of `+DailyBalancesInvestmentValues.swift` for the
+/// SwiftLint `file_length` budget — recorded-value (snapshot) and
+/// trades-mode (position) folds are conceptually paired but each is
+/// long enough to warrant its own file.
+extension GRDBAnalysisRepository {
+
+  // MARK: - Trades-mode per-day fold
+
+  /// One decoded entry in the trades-mode cursor walk — a per-day,
+  /// per-account, per-instrument quantity ready to apply to the
+  /// cumulative `positions` dict. Four fields exceeds SwiftLint's
+  /// `large_tuple` error threshold, so a named struct is required.
+  private struct TradesModePositionEntry {
+    let dayKey: Date
+    let accountId: UUID
+    let instrument: Instrument
+    let quantity: Decimal
+  }
+
+  /// Per-day position-valuation fold for trades-mode investment
+  /// accounts. Sister of `applyInvestmentValues` — same per-day error
+  /// contract: `CancellationError` rethrows immediately; any other
+  /// thrown error drops the day from `dailyBalances` and logs through
+  /// `handleInvestmentValueFailure`.
+  ///
+  /// The fold builds a sorted cursor over trades-mode rows
+  /// (`(dayKey, accountId, instrument, quantity)` entries), then
+  /// walks `dailyBalances.keys.sorted()`. For each output `dayKey`,
+  /// the cursor advances through every entry with `entry.dayKey <=
+  /// dayKey` — including entries for days absent from
+  /// `dailyBalances` (e.g. dropped by an earlier snapshot-fold
+  /// failure) — so cumulative position state stays correct on every
+  /// following day.
+  ///
+  /// `priorRows` and `postRows` carry only rows whose `accountId`
+  /// belongs to a trades-mode investment account — pre-filtered in
+  /// `readDailyBalancesAggregation` so this fold neither re-checks
+  /// membership nor walks rows for accounts it doesn't own.
+  static func applyTradesModePositionValuations(
+    priorRows: [DailyBalanceAccountRow],
+    postRows: [DailyBalanceAccountRow],
+    to dailyBalances: inout [Date: DailyBalance],
+    context: DailyBalancesAssemblyContext,
+    handlers: DailyBalancesHandlers
+  ) async throws {
+    guard !context.tradesModeInvestmentAccountIds.isEmpty,
+      !dailyBalances.isEmpty
+    else { return }
+
+    var positions = seedTradesModePriorPositions(
+      priorRows: priorRows, instrumentMap: context.instrumentMap)
+    let entries = buildTradesModeEntries(
+      postRows: postRows, instrumentMap: context.instrumentMap)
+
+    var valueIndex = 0
+    for dayKey in dailyBalances.keys.sorted() {
+      // The Rule 8 fast path inside `sumTradesModePositions` can let
+      // the loop run synchronously when every position is in the
+      // profile instrument; an explicit cancellation check ensures
+      // the outer task can be torn down promptly even in that case.
+      try Task.checkCancellation()
+      // Advance the cursor: apply every entry on-or-before dayKey,
+      // including those for days absent from dailyBalances.
+      while valueIndex < entries.count, entries[valueIndex].dayKey <= dayKey {
+        let entry = entries[valueIndex]
+        positions[entry.accountId, default: [:]][entry.instrument, default: 0] +=
+          entry.quantity
+        valueIndex += 1
+      }
+      if positions.isEmpty { continue }
+      do {
+        // dayKey is `Calendar.current.startOfDay(for: row.sampleDate)`
+        // — same normalization as walkDays and the conversion-service
+        // lookup.
+        let total = try await sumTradesModePositions(
+          positions: positions,
+          on: dayKey,
+          profileInstrument: context.profileInstrument,
+          conversionService: context.conversionService)
+        mergeTradesModeTotal(
+          total,
+          into: &dailyBalances,
+          on: dayKey,
+          profileInstrument: context.profileInstrument)
+      } catch let cancel as CancellationError {
+        throw cancel
+      } catch {
+        // Rule 11: drop the day from dailyBalances so the chart shows
+        // a gap. Matches the walkDays / applyInvestmentValues
+        // per-day error contract.
+        handlers.handleInvestmentValueFailure(error, dayKey)
+        dailyBalances.removeValue(forKey: dayKey)
+        continue
+      }
+    }
+  }
+
+  /// Pre-fold priors into a per-account, per-instrument cumulative
+  /// dict. Decoding mirrors `applyDailyDeltas`: resolve the instrument
+  /// via the registry, then convert the row's storage value into a
+  /// Decimal quantity.
+  private static func seedTradesModePriorPositions(
+    priorRows: [DailyBalanceAccountRow],
+    instrumentMap: [String: Instrument]
+  ) -> [UUID: [Instrument: Decimal]] {
+    var positions: [UUID: [Instrument: Decimal]] = [:]
+    for row in priorRows {
+      let instrument = resolveInstrument(row.instrumentId, in: instrumentMap)
+      let quantity = InstrumentAmount(
+        storageValue: row.qty, instrument: instrument
+      ).quantity
+      positions[row.accountId, default: [:]][instrument, default: 0] += quantity
+    }
+    return positions
+  }
+
+  /// Build a sorted cursor over post rows. Grouping by SQL `\.day`
+  /// (UTC string) is intentionally avoided — the outer walk is over
+  /// local-startOfDay `Date` keys, so we key the cursor at `dayKey`
+  /// granularity directly to avoid Rule 10 timezone mismatch.
+  private static func buildTradesModeEntries(
+    postRows: [DailyBalanceAccountRow],
+    instrumentMap: [String: Instrument]
+  ) -> [TradesModePositionEntry] {
+    var entries: [TradesModePositionEntry] = []
+    entries.reserveCapacity(postRows.count)
+    for row in postRows {
+      let instrument = resolveInstrument(row.instrumentId, in: instrumentMap)
+      let quantity = InstrumentAmount(
+        storageValue: row.qty, instrument: instrument
+      ).quantity
+      entries.append(
+        TradesModePositionEntry(
+          dayKey: Calendar.current.startOfDay(for: row.sampleDate),
+          accountId: row.accountId,
+          instrument: instrument,
+          quantity: quantity))
+    }
+    entries.sort { $0.dayKey < $1.dayKey }
+    return entries
+  }
+
+  /// Merge a per-day trades-mode total into the existing
+  /// `dailyBalances[dayKey]` row, summing into any
+  /// recorded-value-fold-supplied `investmentValue` and recomputing
+  /// `netWorth`. No-op when the day is absent (already dropped by
+  /// an earlier failure).
+  private static func mergeTradesModeTotal(
+    _ total: InstrumentAmount,
+    into dailyBalances: inout [Date: DailyBalance],
+    on dayKey: Date,
+    profileInstrument: Instrument
+  ) {
+    guard let existing = dailyBalances[dayKey] else { return }
+    let combined =
+      (existing.investmentValue ?? .zero(instrument: profileInstrument)) + total
+    dailyBalances[dayKey] = DailyBalance(
+      date: existing.date,
+      balance: existing.balance,
+      earmarked: existing.earmarked,
+      availableFunds: existing.availableFunds,
+      investments: existing.investments,
+      investmentValue: combined,
+      netWorth: existing.balance + combined,
+      bestFit: existing.bestFit,
+      isForecast: existing.isForecast)
+  }
+
+  /// Sum per-account, per-instrument trades-mode positions on `date`,
+  /// converting foreign instruments to the profile instrument via the
+  /// conversion service. Rule 8 fast path applies at the leaf level
+  /// so an account holding both profile-instrument and foreign-
+  /// instrument positions still routes only the foreign positions
+  /// through the service. Zero-quantity positions are skipped (a
+  /// lingering instrument key after a same-day BUY+SELL nets out)
+  /// to honour Rule 8's spirit — there is no value in a `0 * rate`
+  /// async hop, and the answer is identically zero. When every
+  /// position is in the profile instrument the function returns
+  /// synchronously — the outer `applyTradesModePositionValuations`
+  /// loop is responsible for the `try Task.checkCancellation()`
+  /// that keeps the all-fast-path case promptly cancellable.
+  private static func sumTradesModePositions(
+    positions: [UUID: [Instrument: Decimal]],
+    on date: Date,
+    profileInstrument: Instrument,
+    conversionService: any InstrumentConversionService
+  ) async throws -> InstrumentAmount {
+    var total: Decimal = 0
+    for (_, perInstrument) in positions {
+      for (instrument, quantity) in perInstrument {
+        if quantity == 0 { continue }
+        if instrument.id == profileInstrument.id {
+          total += quantity
+          continue
+        }
+        total += try await conversionService.convert(
+          quantity, from: instrument, to: profileInstrument, on: date)
+      }
+    }
+    return InstrumentAmount(quantity: total, instrument: profileInstrument)
+  }
+}

--- a/Backends/GRDB/Repositories/GRDBAnalysisRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBAnalysisRepository.swift
@@ -66,7 +66,16 @@ final class GRDBAnalysisRepository: AnalysisRepository, @unchecked Sendable {
   // plus its private cursor helpers (`advanceInvestmentCursor`,
   // `sumInvestmentValues`); also owns the SQL fetches that produce
   // its inputs (`fetchInvestmentAccountIds`,
-  // `fetchInvestmentValueSnapshots`).
+  // `fetchInvestmentValueSnapshots`,
+  // `fetchTradesModeInvestmentAccountIds`).
+  //
+  // `+DailyBalancesTradesMode.swift` — `applyTradesModePositionValuations`
+  // fold + private helpers (`seedTradesModePriorPositions`,
+  // `buildTradesModeEntries`, `mergeTradesModeTotal`,
+  // `sumTradesModePositions`, `TradesModePositionEntry`).
+  // Pre-filtered trades-mode rows arrive via the aggregation; the fold
+  // computes per-day position valuations and adds them onto
+  // `DailyBalance.investmentValue`.
   //
   // `+DailyBalancesForecast.swift` — `generateForecast` plus its
   // private helpers (`preConvertForecastInstances`,

--- a/Features/Investments/InvestmentStore+PositionsInput.swift
+++ b/Features/Investments/InvestmentStore+PositionsInput.swift
@@ -12,6 +12,22 @@ import Foundation
 extension InvestmentStore {
   // MARK: - PositionsView Input
 
+  /// Coordinates the two-step "load then build positions input" sequence
+  /// that the `InvestmentAccountView` runs from its `.task` and
+  /// `.refreshable` modifiers. Hoisted out of the view so the view bodies
+  /// stay free of multi-step async coordination.
+  ///
+  /// Errors from `positionsViewInput` propagate; `loadAllData` swallows
+  /// its own errors into `self.error` so it never throws here.
+  func loadAndBuildPositionsInput(
+    account: Account,
+    profileCurrency: Instrument,
+    range: PositionsTimeRange
+  ) async throws -> PositionsViewInput {
+    await loadAllData(account: account, profileCurrency: profileCurrency)
+    return try await positionsViewInput(title: account.name, range: range)
+  }
+
   /// Builds the `PositionsViewInput` for the unified positions UI. Reads
   /// from the already-loaded `valuedPositions` for the row data, replays
   /// trade transactions through the shared `TradeEventClassifier` +

--- a/Features/Investments/Views/InvestmentAccountView.swift
+++ b/Features/Investments/Views/InvestmentAccountView.swift
@@ -169,11 +169,11 @@ struct InvestmentAccountView: View {
       initialLoadComplete = false
       isLoadingPositions = true
       defer { isLoadingPositions = false }
-      await investmentStore.loadAllData(
-        account: account, profileCurrency: profileCurrencyInstrument)
       do {
-        positionsInput = try await investmentStore.positionsViewInput(
-          title: account.name, range: positionsRange)
+        positionsInput = try await investmentStore.loadAndBuildPositionsInput(
+          account: account,
+          profileCurrency: profileCurrencyInstrument,
+          range: positionsRange)
       } catch is CancellationError {
         return
       } catch {
@@ -202,11 +202,11 @@ struct InvestmentAccountView: View {
     .refreshable {
       isLoadingPositions = true
       defer { isLoadingPositions = false }
-      await investmentStore.loadAllData(
-        account: account, profileCurrency: profileCurrencyInstrument)
       do {
-        positionsInput = try await investmentStore.positionsViewInput(
-          title: account.name, range: positionsRange)
+        positionsInput = try await investmentStore.loadAndBuildPositionsInput(
+          account: account,
+          profileCurrency: profileCurrencyInstrument,
+          range: positionsRange)
       } catch is CancellationError {
         return
       } catch {

--- a/MoolahTests/Backends/GRDB/DailyBalancesPlanPinningTests.swift
+++ b/MoolahTests/Backends/GRDB/DailyBalancesPlanPinningTests.swift
@@ -214,6 +214,28 @@ struct DailyBalancesPlanPinningTests {
     #expect(!PlanPinningTestHelpers.planHasFullTableScanOf(detail, alias: "account"))
   }
 
+  @Test("fetchTradesModeInvestmentAccountIds uses account_by_type")
+  func fetchTradesModeInvestmentAccountIdsUsesAccountByType() throws {
+    let database = try makeDatabase()
+    // Mirrors the per-account id loader driven by
+    // `GRDBAnalysisRepository.fetchTradesModeInvestmentAccountIds`. The
+    // production SQL filters on `type = 'investment'` AND
+    // `valuation_mode = 'calculatedFromTrades'`. The `account_by_type`
+    // index keys on `(type)` and serves the selective `type =
+    // 'investment'` predicate; the `valuation_mode` predicate filters
+    // the candidate rows post-seek. SQLite emits `SEARCH account USING
+    // INDEX account_by_type` for this shape, which is *not* a full
+    // table scan.
+    let detail = try planDetail(
+      database,
+      query: """
+        SELECT id FROM account
+        WHERE type = 'investment' AND valuation_mode = 'calculatedFromTrades'
+        """)
+    #expect(detail.contains("SEARCH account USING INDEX account_by_type"))
+    #expect(!PlanPinningTestHelpers.planHasFullTableScanOf(detail, alias: "account"))
+  }
+
   @Test("fetchDailyBalances investment-value lookup uses iv_by_account_date_value")
   func fetchDailyBalancesInvestmentValuesUseAccountDateIndex() throws {
     let database = try makeDatabase()

--- a/MoolahTests/Backends/GRDB/GRDBDailyBalancesAggregationTests.swift
+++ b/MoolahTests/Backends/GRDB/GRDBDailyBalancesAggregationTests.swift
@@ -1,0 +1,102 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+/// Aggregation-layer integration tests pinning that
+/// `fetchDailyBalancesAggregation` populates the trades-mode fields
+/// from `readDailyBalancesAggregation`. The fold-contract tests in
+/// `GRDBDailyBalancesTradesModeTests` exercise the new fold by
+/// constructing `DailyBalancesAggregation` directly; these tests
+/// pin the SQL-to-struct wiring so a regression in the aggregation
+/// builder doesn't ship past every fold-contract assertion.
+@Suite("GRDBAnalysisRepository fetchDailyBalancesAggregation — trades-mode fields")
+struct GRDBDailyBalancesAggregationTests {
+
+  @Test("populates tradesModeInvestmentAccountIds for trades-mode accounts")
+  func populatesTradesModeAccountIds() async throws {
+    let backend = try CloudKitAnalysisTestBackend()
+    let tradesAccount = Account(
+      id: UUID(), name: "Trades Account", type: .investment,
+      instrument: .defaultTestInstrument,
+      valuationMode: .calculatedFromTrades)
+    _ = try await backend.accounts.create(tradesAccount)
+    let snapshotAccount = Account(
+      id: UUID(), name: "Snapshot Account", type: .investment,
+      instrument: .defaultTestInstrument,
+      valuationMode: .recordedValue)
+    _ = try await backend.accounts.create(snapshotAccount)
+
+    let aggregation = try await backend.testFetchAggregation(
+      after: nil, forecastUntil: nil)
+
+    #expect(aggregation.tradesModeInvestmentAccountIds.contains(tradesAccount.id))
+    #expect(!aggregation.tradesModeInvestmentAccountIds.contains(snapshotAccount.id))
+    #expect(aggregation.investmentAccountIds.contains(snapshotAccount.id))
+    #expect(!aggregation.investmentAccountIds.contains(tradesAccount.id))
+  }
+
+  @Test("priorTradesModeAccountRows / tradesModeAccountRows hold only trades-mode account rows")
+  func filtersAccountRowsByMode() async throws {
+    let backend = try CloudKitAnalysisTestBackend()
+    let tradesAccount = Account(
+      id: UUID(), name: "Trades Account", type: .investment,
+      instrument: .defaultTestInstrument,
+      valuationMode: .calculatedFromTrades)
+    _ = try await backend.accounts.create(tradesAccount)
+    let snapshotAccount = Account(
+      id: UUID(), name: "Snapshot Account", type: .investment,
+      instrument: .defaultTestInstrument,
+      valuationMode: .recordedValue)
+    _ = try await backend.accounts.create(snapshotAccount)
+    let bankAccount = Account(
+      id: UUID(), name: "Cash", type: .bank,
+      instrument: .defaultTestInstrument)
+    _ = try await backend.accounts.create(bankAccount)
+
+    let cutoff = try AnalysisTestHelpers.date(year: 2025, month: 6, day: 1)
+    let priorDate = try AnalysisTestHelpers.date(year: 2025, month: 5, day: 15)
+    let postDate = try AnalysisTestHelpers.date(year: 2025, month: 6, day: 15)
+
+    // One transaction on each side of the cutoff for each account.
+    for (account, date) in [
+      (tradesAccount, priorDate), (tradesAccount, postDate),
+      (snapshotAccount, priorDate), (snapshotAccount, postDate),
+      (bankAccount, priorDate), (bankAccount, postDate),
+    ] {
+      _ = try await backend.transactions.create(
+        Transaction(
+          date: date, payee: "Tick",
+          legs: [
+            TransactionLeg(
+              accountId: account.id, instrument: .defaultTestInstrument,
+              quantity: 10, type: .income)
+          ]))
+    }
+
+    let aggregation = try await backend.testFetchAggregation(
+      after: cutoff, forecastUntil: nil)
+
+    let priorIds = Set(aggregation.priorTradesModeAccountRows.map(\.accountId))
+    let postIds = Set(aggregation.tradesModeAccountRows.map(\.accountId))
+    #expect(priorIds == [tradesAccount.id])
+    #expect(postIds == [tradesAccount.id])
+  }
+
+  @Test("empty trades-mode profile produces empty arrays")
+  func emptyTradesModeProfileEmptyArrays() async throws {
+    let backend = try CloudKitAnalysisTestBackend()
+    let snapshotAccount = Account(
+      id: UUID(), name: "Snapshot Account", type: .investment,
+      instrument: .defaultTestInstrument,
+      valuationMode: .recordedValue)
+    _ = try await backend.accounts.create(snapshotAccount)
+
+    let aggregation = try await backend.testFetchAggregation(
+      after: nil, forecastUntil: nil)
+
+    #expect(aggregation.tradesModeInvestmentAccountIds.isEmpty)
+    #expect(aggregation.priorTradesModeAccountRows.isEmpty)
+    #expect(aggregation.tradesModeAccountRows.isEmpty)
+  }
+}

--- a/MoolahTests/Backends/GRDB/GRDBDailyBalancesAggregationTests.swift
+++ b/MoolahTests/Backends/GRDB/GRDBDailyBalancesAggregationTests.swift
@@ -27,7 +27,7 @@ struct GRDBDailyBalancesAggregationTests {
       valuationMode: .recordedValue)
     _ = try await backend.accounts.create(snapshotAccount)
 
-    let aggregation = try await backend.testFetchAggregation(
+    let aggregation = try await backend.fetchAggregationForTesting(
       after: nil, forecastUntil: nil)
 
     #expect(aggregation.tradesModeInvestmentAccountIds.contains(tradesAccount.id))
@@ -74,7 +74,7 @@ struct GRDBDailyBalancesAggregationTests {
           ]))
     }
 
-    let aggregation = try await backend.testFetchAggregation(
+    let aggregation = try await backend.fetchAggregationForTesting(
       after: cutoff, forecastUntil: nil)
 
     let priorIds = Set(aggregation.priorTradesModeAccountRows.map(\.accountId))
@@ -92,7 +92,7 @@ struct GRDBDailyBalancesAggregationTests {
       valuationMode: .recordedValue)
     _ = try await backend.accounts.create(snapshotAccount)
 
-    let aggregation = try await backend.testFetchAggregation(
+    let aggregation = try await backend.fetchAggregationForTesting(
       after: nil, forecastUntil: nil)
 
     #expect(aggregation.tradesModeInvestmentAccountIds.isEmpty)

--- a/MoolahTests/Backends/GRDB/GRDBDailyBalancesAssembleTests.swift
+++ b/MoolahTests/Backends/GRDB/GRDBDailyBalancesAssembleTests.swift
@@ -177,4 +177,91 @@ struct GRDBDailyBalancesAssembleTests {
     #expect(visited.snapshot().isEmpty)
     #expect(conversionService.calls == 1)
   }
+
+  @Test("snapshot fold drops the day from dailyBalances on per-day conversion failure")
+  func snapshotFoldDropsDayOnFailure() async throws {
+    // Build an aggregation with one investment-value snapshot on day D.
+    let day = try AnalysisTestHelpers.utcDate(year: 2025, month: 6, day: 10, hour: 12)
+    let dayKey = Calendar.current.startOfDay(for: day)
+    let usd = Instrument.fiat(code: "USD")
+    let accountId = UUID()
+    let aggregation = makeSnapshotFoldAggregation(
+      day: day, accountId: accountId, usd: usd)
+    // Seed the dailyBalances dict directly so we test the fold in
+    // isolation. Insert a placeholder DailyBalance for `dayKey` so the
+    // fold has a key to drop.
+    var dailyBalances: [Date: DailyBalance] = [
+      dayKey: makePlaceholderDailyBalance(on: dayKey)
+    ]
+    let conversionService = DateFailingConversionService(
+      rates: [:], failingDates: [dayKey])
+    let captured = InvestmentValueFailureLog()
+    let handlers = GRDBAnalysisRepository.DailyBalancesHandlers(
+      handleUnparseableDay: { _ in },
+      handleConversionFailure: { _, _ in },
+      handleInvestmentValueFailure: { error, date in
+        captured.append(error, date)
+      })
+    let context = GRDBAnalysisRepository.DailyBalancesAssemblyContext(
+      investmentAccountIds: aggregation.investmentAccountIds,
+      tradesModeInvestmentAccountIds: aggregation.tradesModeInvestmentAccountIds,
+      instrumentMap: aggregation.instrumentMap,
+      profileInstrument: .defaultTestInstrument,
+      conversionService: conversionService)
+
+    try await GRDBAnalysisRepository.applyInvestmentValues(
+      aggregation.investmentValues,
+      to: &dailyBalances,
+      context: context,
+      handlers: handlers)
+
+    // Rule 11: a snapshot conversion failure on day D must drop day D
+    // from dailyBalances. Sibling days (none here) are unaffected.
+    #expect(dailyBalances[dayKey] == nil)
+    let snapshot = captured.snapshot()
+    #expect(snapshot.count == 1)
+    #expect(snapshot.first?.1 == dayKey)
+  }
+
+  /// Build a single-snapshot aggregation for the snapshot-fold Rule 11
+  /// test. Extracted out of the test body to keep
+  /// `snapshotFoldDropsDayOnFailure` under SwiftLint's function-body
+  /// budget.
+  private func makeSnapshotFoldAggregation(
+    day: Date, accountId: UUID, usd: Instrument
+  ) -> GRDBAnalysisRepository.DailyBalancesAggregation {
+    GRDBAnalysisRepository.DailyBalancesAggregation(
+      priorAccountRows: [],
+      priorEarmarkRows: [],
+      accountRows: [],
+      earmarkRows: [],
+      investmentValues: [
+        InvestmentValueSnapshot(
+          accountId: accountId, date: day,
+          value: InstrumentAmount(quantity: 100, instrument: usd))
+      ],
+      investmentAccountIds: [accountId],
+      tradesModeInvestmentAccountIds: [],
+      priorTradesModeAccountRows: [],
+      tradesModeAccountRows: [],
+      scheduled: [],
+      instrumentMap: ["USD": usd],
+      forecastUntil: nil)
+  }
+
+  /// Zero-everything `DailyBalance` placeholder so the snapshot fold
+  /// has an entry to remove. Same extraction reason as
+  /// `makeSnapshotFoldAggregation`.
+  private func makePlaceholderDailyBalance(on dayKey: Date) -> DailyBalance {
+    DailyBalance(
+      date: dayKey,
+      balance: .zero(instrument: .defaultTestInstrument),
+      earmarked: .zero(instrument: .defaultTestInstrument),
+      availableFunds: .zero(instrument: .defaultTestInstrument),
+      investments: .zero(instrument: .defaultTestInstrument),
+      investmentValue: nil,
+      netWorth: .zero(instrument: .defaultTestInstrument),
+      bestFit: nil,
+      isForecast: false)
+  }
 }

--- a/MoolahTests/Backends/GRDB/GRDBDailyBalancesAssembleTests.swift
+++ b/MoolahTests/Backends/GRDB/GRDBDailyBalancesAssembleTests.swift
@@ -63,6 +63,9 @@ struct GRDBDailyBalancesAssembleTests {
       earmarkRows: [],
       investmentValues: [],
       investmentAccountIds: [],
+      tradesModeInvestmentAccountIds: [],
+      priorTradesModeAccountRows: [],
+      tradesModeAccountRows: [],
       scheduled: [],
       instrumentMap: [usd: .fiat(code: usd)],
       forecastUntil: nil)

--- a/MoolahTests/Backends/GRDB/GRDBDailyBalancesTradesModeRule11Tests.swift
+++ b/MoolahTests/Backends/GRDB/GRDBDailyBalancesTradesModeRule11Tests.swift
@@ -1,0 +1,231 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+/// Multi-day, Rule 11 failure-scoping, carry-forward, priors-seed, and
+/// end-to-end pipeline tests for
+/// `GRDBAnalysisRepository.applyTradesModePositionValuations`. Split
+/// out of `GRDBDailyBalancesTradesModeTests` for SwiftLint
+/// `file_length` / `type_body_length` budgets — same fold, same
+/// helpers (`TradesModeFoldTestSupport`), partitioned by topic.
+@Suite("GRDBAnalysisRepository applyTradesModePositionValuations — Rule 11 / cross-day")
+struct GRDBDailyBalancesTradesModeRule11Tests {
+
+  @Test("case 4: per-day conversion failure drops day from dailyBalances")
+  func ruleEleven_perDayFailureScopedToDay() async throws {
+    // `Calendar.current.startOfDay` is the production fold's day-key
+    // function (Rule 10). Build the test's seed key the same way so a
+    // calendar mismatch can't make the test pass vacuously.
+    let dayOne = try AnalysisTestHelpers.utcDate(year: 2025, month: 6, day: 10, hour: 12)
+    let dayTwo = try AnalysisTestHelpers.utcDate(year: 2025, month: 6, day: 11, hour: 12)
+    let keyOne = Calendar.current.startOfDay(for: dayOne)
+    let keyTwo = Calendar.current.startOfDay(for: dayTwo)
+    let usd = Instrument.fiat(code: "USD")
+    let accountId = UUID()
+    let rowOne = GRDBAnalysisRepository.DailyBalanceAccountRow(
+      day: "2025-06-10", sampleDate: dayOne,
+      accountId: accountId, instrumentId: "USD", type: "trade", qty: 1_000_000_000)
+    // Rate available on day two only; day one fails.
+    let conversion = DateFailingConversionService(
+      rates: [
+        try AnalysisTestHelpers.utcDate(year: 2025, month: 1, day: 1, hour: 0): [
+          "USD": try AnalysisTestHelpers.decimal("1.5")
+        ]
+      ],
+      failingDates: [keyOne])
+    var balances: [Date: DailyBalance] = [
+      keyOne: TradesModeFoldTestSupport.placeholderBalance(at: keyOne),
+      keyTwo: TradesModeFoldTestSupport.placeholderBalance(at: keyTwo),
+    ]
+    let context = TradesModeFoldTestSupport.makeContext(
+      tradesIds: [accountId],
+      instrumentMap: ["USD": usd],
+      conversionService: conversion)
+    let captured = InvestmentValueFailureLog()
+    let handlers = TradesModeFoldTestSupport.makeHandlers { error, date in
+      captured.append(error, date)
+    }
+
+    try await GRDBAnalysisRepository.applyTradesModePositionValuations(
+      priorRows: [], postRows: [rowOne],
+      to: &balances, context: context, handlers: handlers)
+
+    // Day one dropped (failed conversion); day two retained
+    // (cumulative position 10 USD * 1.5 = 15).
+    #expect(balances[keyOne] == nil)
+    let value = try #require(balances[keyTwo]?.investmentValue)
+    let expected = try AnalysisTestHelpers.decimal("15")
+    #expect(value.quantity == expected)
+    let snapshot = captured.snapshot()
+    #expect(snapshot.count == 1)
+    #expect(snapshot.first?.1 == keyOne)
+  }
+
+  @Test("case 6: trades-fold failure on day D after snapshot-fold success drops day")
+  func mixedFoldFailureDropsDay() async throws {
+    let day = try AnalysisTestHelpers.utcDate(year: 2025, month: 6, day: 10, hour: 12)
+    let dayKey = Calendar.current.startOfDay(for: day)
+    let usd = Instrument.fiat(code: "USD")
+    let accountId = UUID()
+    let row = GRDBAnalysisRepository.DailyBalanceAccountRow(
+      day: "2025-06-10", sampleDate: day,
+      accountId: accountId, instrumentId: "USD", type: "trade", qty: 1_000_000_000)
+    let conversion = DateFailingConversionService(
+      rates: [:], failingDates: [dayKey])
+    // Pre-seed the day as if applyInvestmentValues had succeeded with
+    // a recorded-value snapshot total of 100.
+    var balances: [Date: DailyBalance] = [
+      dayKey: TradesModeFoldTestSupport.preSeededDailyBalance(on: dayKey)
+    ]
+    let context = TradesModeFoldTestSupport.makeContext(
+      tradesIds: [accountId],
+      instrumentMap: ["USD": usd],
+      conversionService: conversion)
+    let captured = InvestmentValueFailureLog()
+    let handlers = TradesModeFoldTestSupport.makeHandlers { error, date in
+      captured.append(error, date)
+    }
+
+    try await GRDBAnalysisRepository.applyTradesModePositionValuations(
+      priorRows: [], postRows: [row],
+      to: &balances, context: context, handlers: handlers)
+
+    #expect(balances[dayKey] == nil)
+    let snapshot = captured.snapshot()
+    #expect(snapshot.count == 1)
+    #expect(snapshot.first?.1 == dayKey)
+  }
+
+  @Test("case 12: carry-forward across a dropped day stays correct")
+  func carryForwardAcrossDroppedDay() async throws {
+    let dayOne = try AnalysisTestHelpers.utcDate(year: 2025, month: 6, day: 10, hour: 12)
+    let dayTwo = try AnalysisTestHelpers.utcDate(year: 2025, month: 6, day: 11, hour: 12)
+    let keyTwo = Calendar.current.startOfDay(for: dayTwo)
+    let usd = Instrument.fiat(code: "USD")
+    let accountId = UUID()
+    let rowOne = GRDBAnalysisRepository.DailyBalanceAccountRow(
+      day: "2025-06-10", sampleDate: dayOne,
+      accountId: accountId, instrumentId: "USD", type: "trade", qty: 1_000_000_000)
+    let conversion = DateBasedFixedConversionService(
+      rates: [
+        try AnalysisTestHelpers.utcDate(year: 2025, month: 1, day: 1, hour: 0): [
+          "USD": try AnalysisTestHelpers.decimal("1.5")
+        ]
+      ])
+    // Simulate a snapshot-fold dropout on day 1: dailyBalances has
+    // entries only for day 2 (day 1 was removed by an earlier fold).
+    var balances: [Date: DailyBalance] = [
+      keyTwo: TradesModeFoldTestSupport.placeholderBalance(at: keyTwo)
+    ]
+    let context = TradesModeFoldTestSupport.makeContext(
+      tradesIds: [accountId],
+      instrumentMap: ["USD": usd],
+      conversionService: conversion)
+    let handlers = TradesModeFoldTestSupport.makeHandlers { _, _ in }
+
+    try await GRDBAnalysisRepository.applyTradesModePositionValuations(
+      priorRows: [], postRows: [rowOne],
+      to: &balances, context: context, handlers: handlers)
+
+    // Day 2 must valuate the cumulative position from day 1's buy
+    // even though day 1 itself isn't in dailyBalances.
+    let value = try #require(balances[keyTwo]?.investmentValue)
+    let expected = try AnalysisTestHelpers.decimal("15")
+    #expect(value.quantity == expected)
+  }
+
+  @Test("case 13: priorRows seed contributes to first in-window day")
+  func priorRowsSeedSeenOnFirstWindowDay() async throws {
+    // priorRows simulates pre-cutoff legs the user holds going into
+    // the window. The fold's pre-fold seed (§4 step 2) must apply
+    // them so the first in-window dayKey valuates the carried
+    // position.
+    let priorDay = try AnalysisTestHelpers.utcDate(year: 2025, month: 5, day: 1, hour: 12)
+    let windowDay = try AnalysisTestHelpers.utcDate(year: 2025, month: 6, day: 10, hour: 12)
+    let dayKey = Calendar.current.startOfDay(for: windowDay)
+    let usd = Instrument.fiat(code: "USD")
+    let accountId = UUID()
+    let prior = GRDBAnalysisRepository.DailyBalanceAccountRow(
+      day: "2025-05-01", sampleDate: priorDay,
+      accountId: accountId, instrumentId: "USD", type: "trade", qty: 1_000_000_000)
+    let conversion = DateBasedFixedConversionService(
+      rates: [
+        try AnalysisTestHelpers.utcDate(year: 2025, month: 1, day: 1, hour: 0): [
+          "USD": try AnalysisTestHelpers.decimal("1.5")
+        ]
+      ])
+    var balances: [Date: DailyBalance] = [
+      dayKey: TradesModeFoldTestSupport.placeholderBalance(at: dayKey)
+    ]
+    let context = TradesModeFoldTestSupport.makeContext(
+      tradesIds: [accountId],
+      instrumentMap: ["USD": usd],
+      conversionService: conversion)
+    let handlers = TradesModeFoldTestSupport.makeHandlers { _, _ in }
+
+    try await GRDBAnalysisRepository.applyTradesModePositionValuations(
+      priorRows: [prior], postRows: [],
+      to: &balances, context: context, handlers: handlers)
+
+    // Pre-fold seed applied 1_000_000_000 storage units = 10 USD;
+    // converted at 1.5 = 15 AUD on `dayKey`.
+    let value = try #require(balances[dayKey]?.investmentValue)
+    let expected = try AnalysisTestHelpers.decimal("15")
+    #expect(value.quantity == expected)
+  }
+
+  @Test("case 14: end-to-end pipeline does not double-count trades-mode positions in netWorth")
+  func endToEndNetWorthSingleCount() async throws {
+    // Round-trip through the real fetchDailyBalances pipeline: a
+    // trades-mode account with one trade leg on day D. After
+    // walkDays, `existing.balance` would normally include the trade
+    // position (because trades-mode accounts aren't in the
+    // recorded-value `investmentAccountIds` set used by
+    // PositionBook.dailyBalance). The fix in Task 6 step 3 unions
+    // trades-mode ids into BalanceContext.investmentAccountIds so
+    // those positions are excluded from balance and contribute only
+    // via investmentValue. This test pins that fix.
+    let conversion = DateBasedFixedConversionService(
+      rates: [
+        try AnalysisTestHelpers.utcDate(year: 2025, month: 1, day: 1, hour: 0): [
+          "USD": try AnalysisTestHelpers.decimal("1.5")
+        ]
+      ])
+    let backend = try CloudKitAnalysisTestBackend(conversionService: conversion)
+    let aud = Instrument.defaultTestInstrument
+    let usd = Instrument.fiat(code: "USD")
+    let tradesAccount = Account(
+      id: UUID(), name: "Trades", type: .investment, instrument: aud,
+      valuationMode: .calculatedFromTrades)
+    _ = try await backend.accounts.create(tradesAccount)
+
+    let day = try AnalysisTestHelpers.utcDate(year: 2025, month: 6, day: 10, hour: 12)
+    _ = try await backend.transactions.create(
+      Transaction(
+        date: day, payee: "Buy",
+        legs: [
+          TransactionLeg(
+            accountId: tradesAccount.id, instrument: usd,
+            quantity: 10, type: .trade)
+        ]))
+
+    let balances = try await backend.analysis.fetchDailyBalances(
+      after: nil, forecastUntil: nil)
+
+    let dayKey = Calendar.current.startOfDay(for: day)
+    let dayBalance = try #require(balances.first { $0.date == dayKey })
+
+    // 10 USD * 1.5 = 15 AUD on day D. Critically:
+    // - investmentValue == 15 AUD (from the new fold).
+    // - balance == 0 AUD (the trades-mode account's USD position is
+    //   excluded from bankTotal because it's now in
+    //   BalanceContext.investmentAccountIds — the double-count fix).
+    // - netWorth == 15 AUD (single count, not 30).
+    let expected = try AnalysisTestHelpers.decimal("15")
+    let value = try #require(dayBalance.investmentValue)
+    #expect(value.quantity == expected)
+    #expect(dayBalance.balance.quantity == 0)
+    #expect(dayBalance.netWorth.quantity == expected)
+  }
+}

--- a/MoolahTests/Backends/GRDB/GRDBDailyBalancesTradesModeRule11Tests.swift
+++ b/MoolahTests/Backends/GRDB/GRDBDailyBalancesTradesModeRule11Tests.swift
@@ -228,4 +228,40 @@ struct GRDBDailyBalancesTradesModeRule11Tests {
     #expect(dayBalance.balance.quantity == 0)
     #expect(dayBalance.netWorth.quantity == expected)
   }
+
+  @Test("CancellationError from Task.checkCancellation rethrows immediately")
+  func cancellationRethrown() async throws {
+    // All-fast-path scenario: a profile-instrument position means
+    // `sumTradesModePositions` never `await`s, so without an explicit
+    // `try Task.checkCancellation()` at the top of the per-day loop
+    // the runtime would never get a chance to surface cancellation.
+    // This test pins that the cancellation check is wired and rethrows
+    // directly (Rule 11 contract: never via the failure callback).
+    let day = try AnalysisTestHelpers.utcDate(year: 2025, month: 6, day: 10, hour: 12)
+    let dayKey = Calendar.current.startOfDay(for: day)
+    let aud = Instrument.defaultTestInstrument
+    let accountId = UUID()
+    // Profile-instrument position — all-fast-path, no service calls.
+    let row = GRDBAnalysisRepository.DailyBalanceAccountRow(
+      day: "2025-06-10", sampleDate: day,
+      accountId: accountId, instrumentId: aud.id, type: "trade",
+      qty: 1_000_000_000)
+    let task = Task {
+      var balances: [Date: DailyBalance] = [
+        dayKey: TradesModeFoldTestSupport.placeholderBalance(at: dayKey)
+      ]
+      let context = TradesModeFoldTestSupport.makeContext(
+        tradesIds: [accountId],
+        instrumentMap: [aud.id: aud],
+        conversionService: DateBasedFixedConversionService(rates: [:]))
+      let handlers = TradesModeFoldTestSupport.makeHandlers { _, _ in }
+      try await GRDBAnalysisRepository.applyTradesModePositionValuations(
+        priorRows: [], postRows: [row],
+        to: &balances, context: context, handlers: handlers)
+    }
+    task.cancel()
+    await #expect(throws: CancellationError.self) {
+      try await task.value
+    }
+  }
 }

--- a/MoolahTests/Backends/GRDB/GRDBDailyBalancesTradesModeTests.swift
+++ b/MoolahTests/Backends/GRDB/GRDBDailyBalancesTradesModeTests.swift
@@ -135,11 +135,13 @@ struct GRDBDailyBalancesTradesModeTests {
 
   @Test("case 7: startOfDay normalization keys days correctly across local boundary")
   func rule10StartOfDayNormalization() async throws {
-    // Use the local-calendar `date(year:month:day:hour:)` overload
+    // Use the local-calendar `localDate(year:month:day:hour:)` helper
     // (added by Task 0) so the test agrees with the production
     // fold's `Calendar.current.startOfDay` math.
-    let dayMorning = try AnalysisTestHelpers.date(year: 2025, month: 6, day: 10, hour: 9)
-    let dayEvening = try AnalysisTestHelpers.date(year: 2025, month: 6, day: 10, hour: 23)
+    let dayMorning = try AnalysisTestHelpers.localDate(
+      year: 2025, month: 6, day: 10, hour: 9)
+    let dayEvening = try AnalysisTestHelpers.localDate(
+      year: 2025, month: 6, day: 10, hour: 23)
     let dayKey = Calendar.current.startOfDay(for: dayMorning)
     #expect(Calendar.current.startOfDay(for: dayEvening) == dayKey)
 
@@ -161,7 +163,7 @@ struct GRDBDailyBalancesTradesModeTests {
     // would walk past 06:00 and pick up 99.99 instead, yielding a
     // far larger total. Both rows would then mis-rate identically,
     // turning the assertion below into a sharp signal.
-    let midDay = try AnalysisTestHelpers.date(
+    let midDay = try AnalysisTestHelpers.localDate(
       year: 2025, month: 6, day: 10, hour: 6)
     let conversion = DateBasedFixedConversionService(
       rates: [

--- a/MoolahTests/Backends/GRDB/GRDBDailyBalancesTradesModeTests.swift
+++ b/MoolahTests/Backends/GRDB/GRDBDailyBalancesTradesModeTests.swift
@@ -1,0 +1,319 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+/// Fold-contract tests for
+/// `GRDBAnalysisRepository.applyTradesModePositionValuations` —
+/// happy-path, single-day, and no-op cases. Multi-day failure
+/// scoping, cumulative carry-forward, priors-seeding, and the
+/// end-to-end pipeline pin live in `GRDBDailyBalancesTradesModeRule11Tests`
+/// (split for SwiftLint `file_length` / `type_body_length` budgets;
+/// shared helpers are in `TradesModeFoldTestSupport`).
+///
+/// Tests construct `DailyBalancesAggregation` directly and seed
+/// `dailyBalances` with placeholder entries so the fold can be
+/// exercised in isolation, mirroring the
+/// `GRDBDailyBalancesAssembleTests` style.
+@Suite("GRDBAnalysisRepository applyTradesModePositionValuations")
+struct GRDBDailyBalancesTradesModeTests {
+
+  @Test("case 1: single buy on day D values at day D's price")
+  func singleBuyOnDay() async throws {
+    let day = try AnalysisTestHelpers.utcDate(year: 2025, month: 6, day: 10, hour: 12)
+    let dayKey = Calendar.current.startOfDay(for: day)
+    let usd = Instrument.fiat(code: "USD")
+    let accountId = UUID()
+    let row = GRDBAnalysisRepository.DailyBalanceAccountRow(
+      day: "2025-06-10", sampleDate: day,
+      accountId: accountId, instrumentId: "USD", type: "trade", qty: 1_000_000_000)
+    let conversion = DateBasedFixedConversionService(
+      rates: [
+        try AnalysisTestHelpers.utcDate(year: 2025, month: 1, day: 1, hour: 0): [
+          "USD": try AnalysisTestHelpers.decimal("1.5")
+        ]
+      ])
+    var balances: [Date: DailyBalance] = [
+      dayKey: TradesModeFoldTestSupport.placeholderBalance(at: dayKey)
+    ]
+    let context = TradesModeFoldTestSupport.makeContext(
+      tradesIds: [accountId],
+      instrumentMap: ["USD": usd],
+      conversionService: conversion)
+    let handlers = TradesModeFoldTestSupport.makeHandlers { _, _ in }
+
+    try await GRDBAnalysisRepository.applyTradesModePositionValuations(
+      priorRows: [], postRows: [row],
+      to: &balances, context: context, handlers: handlers)
+
+    let dayBalance = try #require(balances[dayKey])
+    // qty 1_000_000_000 storage units (scale 10^8) = 10 USD; * 1.5 rate = 15 AUD.
+    let expected = try AnalysisTestHelpers.decimal("15")
+    let value = try #require(dayBalance.investmentValue)
+    #expect(value.quantity == expected)
+    #expect(value.instrument == .defaultTestInstrument)
+    #expect(dayBalance.netWorth.quantity == expected)
+  }
+
+  @Test("case 2: two trades-mode accounts both contribute on day D")
+  func twoTradesModeAccountsSameDay() async throws {
+    let day = try AnalysisTestHelpers.utcDate(year: 2025, month: 6, day: 10, hour: 12)
+    let dayKey = Calendar.current.startOfDay(for: day)
+    let usd = Instrument.fiat(code: "USD")
+    let aId = UUID()
+    let bId = UUID()
+    let rowA = GRDBAnalysisRepository.DailyBalanceAccountRow(
+      day: "2025-06-10", sampleDate: day,
+      accountId: aId, instrumentId: "USD", type: "trade", qty: 1_000_000_000)
+    let rowB = GRDBAnalysisRepository.DailyBalanceAccountRow(
+      day: "2025-06-10", sampleDate: day,
+      accountId: bId, instrumentId: "USD", type: "trade", qty: 2_000_000_000)
+    let conversion = DateBasedFixedConversionService(
+      rates: [
+        try AnalysisTestHelpers.utcDate(year: 2025, month: 1, day: 1, hour: 0): [
+          "USD": try AnalysisTestHelpers.decimal("1.5")
+        ]
+      ])
+    var balances: [Date: DailyBalance] = [
+      dayKey: TradesModeFoldTestSupport.placeholderBalance(at: dayKey)
+    ]
+    let context = TradesModeFoldTestSupport.makeContext(
+      tradesIds: [aId, bId],
+      instrumentMap: ["USD": usd],
+      conversionService: conversion)
+    let handlers = TradesModeFoldTestSupport.makeHandlers { _, _ in }
+
+    try await GRDBAnalysisRepository.applyTradesModePositionValuations(
+      priorRows: [], postRows: [rowA, rowB],
+      to: &balances, context: context, handlers: handlers)
+
+    // (10 + 20) * 1.5 = 45.
+    let value = try #require(balances[dayKey]?.investmentValue)
+    let expected = try AnalysisTestHelpers.decimal("45")
+    #expect(value.quantity == expected)
+  }
+
+  @Test("case 3: trades-mode + recorded-value account totals add into one investmentValue")
+  func tradesModePlusRecordedValueSum() async throws {
+    let day = try AnalysisTestHelpers.utcDate(year: 2025, month: 6, day: 10, hour: 12)
+    let dayKey = Calendar.current.startOfDay(for: day)
+    let usd = Instrument.fiat(code: "USD")
+    let tradesId = UUID()
+    let row = GRDBAnalysisRepository.DailyBalanceAccountRow(
+      day: "2025-06-10", sampleDate: day,
+      accountId: tradesId, instrumentId: "USD", type: "trade", qty: 1_000_000_000)
+    let conversion = DateBasedFixedConversionService(
+      rates: [
+        try AnalysisTestHelpers.utcDate(year: 2025, month: 1, day: 1, hour: 0): [
+          "USD": try AnalysisTestHelpers.decimal("1.5")
+        ]
+      ])
+    // Pre-seed the day with a snapshot-fold contribution so the new
+    // fold's add-not-overwrite contract is visible.
+    var balances: [Date: DailyBalance] = [
+      dayKey: TradesModeFoldTestSupport.preSeededDailyBalance(on: dayKey)
+    ]
+    let context = TradesModeFoldTestSupport.makeContext(
+      tradesIds: [tradesId],
+      instrumentMap: ["USD": usd],
+      conversionService: conversion)
+    let handlers = TradesModeFoldTestSupport.makeHandlers { _, _ in }
+
+    try await GRDBAnalysisRepository.applyTradesModePositionValuations(
+      priorRows: [], postRows: [row],
+      to: &balances, context: context, handlers: handlers)
+
+    // Snapshot 100 + trades (10 USD * 1.5) = 115.
+    let dayBalance = try #require(balances[dayKey])
+    let value = try #require(dayBalance.investmentValue)
+    let expectedValue = try AnalysisTestHelpers.decimal("115")
+    let expectedNetWorth = try AnalysisTestHelpers.decimal("125")
+    #expect(value.quantity == expectedValue)
+    // netWorth = balance (10) + investmentValue (115) = 125.
+    #expect(dayBalance.netWorth.quantity == expectedNetWorth)
+  }
+
+  @Test("case 7: startOfDay normalization keys days correctly across local boundary")
+  func rule10StartOfDayNormalization() async throws {
+    // Use the local-calendar `date(year:month:day:hour:)` overload
+    // (added by Task 0) so the test agrees with the production
+    // fold's `Calendar.current.startOfDay` math.
+    let dayMorning = try AnalysisTestHelpers.date(year: 2025, month: 6, day: 10, hour: 9)
+    let dayEvening = try AnalysisTestHelpers.date(year: 2025, month: 6, day: 10, hour: 23)
+    let dayKey = Calendar.current.startOfDay(for: dayMorning)
+    #expect(Calendar.current.startOfDay(for: dayEvening) == dayKey)
+
+    let usd = Instrument.fiat(code: "USD")
+    let accountId = UUID()
+    let rowMorning = GRDBAnalysisRepository.DailyBalanceAccountRow(
+      day: "2025-06-10", sampleDate: dayMorning,
+      accountId: accountId, instrumentId: "USD", type: "trade", qty: 500_000_000)
+    let rowEvening = GRDBAnalysisRepository.DailyBalanceAccountRow(
+      day: "2025-06-10", sampleDate: dayEvening,
+      accountId: accountId, instrumentId: "USD", type: "trade", qty: 500_000_000)
+    // Two rate buckets that distinguish dayKey from sampleDate:
+    //   - dayKey (00:00 local) → 1.5
+    //   - 06:00 local → 99.99
+    // ratesAsOf walks descending and returns the first bucket with
+    // date <= requested. A request on dayKey (00:00) finds 1.5
+    // because 06:00 is in the future relative to 00:00. A regression
+    // that passed `row.sampleDate` (a 09:00 or 23:00 local instant)
+    // would walk past 06:00 and pick up 99.99 instead, yielding a
+    // far larger total. Both rows would then mis-rate identically,
+    // turning the assertion below into a sharp signal.
+    let midDay = try AnalysisTestHelpers.date(
+      year: 2025, month: 6, day: 10, hour: 6)
+    let conversion = DateBasedFixedConversionService(
+      rates: [
+        dayKey: ["USD": try AnalysisTestHelpers.decimal("1.5")],
+        midDay: ["USD": try AnalysisTestHelpers.decimal("99.99")],
+      ])
+    var balances: [Date: DailyBalance] = [
+      dayKey: TradesModeFoldTestSupport.placeholderBalance(at: dayKey)
+    ]
+    let context = TradesModeFoldTestSupport.makeContext(
+      tradesIds: [accountId],
+      instrumentMap: ["USD": usd],
+      conversionService: conversion)
+    let handlers = TradesModeFoldTestSupport.makeHandlers { _, _ in }
+
+    try await GRDBAnalysisRepository.applyTradesModePositionValuations(
+      priorRows: [], postRows: [rowMorning, rowEvening],
+      to: &balances, context: context, handlers: handlers)
+
+    // Both rows applied on the same dayKey; total = 10 USD * 1.5 = 15.
+    // A regression that passed `row.sampleDate` to the conversion
+    // service would resolve to the 99.99 bucket (since the row
+    // timestamps fall after midDay 06:00) and yield 999. The
+    // assertion catches that.
+    let value = try #require(balances[dayKey]?.investmentValue)
+    let expected = try AnalysisTestHelpers.decimal("15")
+    #expect(value.quantity == expected)
+  }
+
+  @Test("case 8: no trades-mode accounts — fold is a no-op")
+  func noTradesModeAccounts() async throws {
+    let day = try AnalysisTestHelpers.utcDate(year: 2025, month: 6, day: 10, hour: 12)
+    let dayKey = Calendar.current.startOfDay(for: day)
+    var balances: [Date: DailyBalance] = [
+      dayKey: TradesModeFoldTestSupport.placeholderBalance(at: dayKey)
+    ]
+    let originalBalance = balances[dayKey]
+    let conversion = DateBasedFixedConversionService(rates: [:])
+    let context = TradesModeFoldTestSupport.makeContext(
+      tradesIds: [], instrumentMap: [:], conversionService: conversion)
+    let handlers = TradesModeFoldTestSupport.makeHandlers { _, _ in }
+
+    try await GRDBAnalysisRepository.applyTradesModePositionValuations(
+      priorRows: [], postRows: [],
+      to: &balances, context: context, handlers: handlers)
+
+    #expect(balances[dayKey] == originalBalance)
+  }
+
+  @Test("case 9: empty dailyBalances — no callback fires")
+  func emptyDailyBalances() async throws {
+    let accountId = UUID()
+    var balances: [Date: DailyBalance] = [:]
+    let usd = Instrument.fiat(code: "USD")
+    let conversion = DateBasedFixedConversionService(rates: [:])
+    let context = TradesModeFoldTestSupport.makeContext(
+      tradesIds: [accountId],
+      instrumentMap: ["USD": usd],
+      conversionService: conversion)
+    let captured = InvestmentValueFailureLog()
+    let handlers = TradesModeFoldTestSupport.makeHandlers { error, date in
+      captured.append(error, date)
+    }
+
+    try await GRDBAnalysisRepository.applyTradesModePositionValuations(
+      priorRows: [], postRows: [],
+      to: &balances, context: context, handlers: handlers)
+
+    #expect(balances.isEmpty)
+    #expect(captured.snapshot().isEmpty)
+  }
+
+  @Test("case 10: CSV-imported transfer cash leg + trade position leg both contribute")
+  func csvImportedTransferPlusTrade() async throws {
+    let day = try AnalysisTestHelpers.utcDate(year: 2025, month: 6, day: 10, hour: 12)
+    let dayKey = Calendar.current.startOfDay(for: day)
+    let usd = Instrument.fiat(code: "USD")
+    let aud = Instrument.defaultTestInstrument
+    let accountId = UUID()
+    // .transfer cash leg in profile instrument (AUD) — Rule 8 fast path.
+    let cashRow = GRDBAnalysisRepository.DailyBalanceAccountRow(
+      day: "2025-06-10", sampleDate: day,
+      accountId: accountId, instrumentId: aud.id, type: "transfer", qty: 5_000_000_000)
+    // .trade position leg in USD.
+    let tradeRow = GRDBAnalysisRepository.DailyBalanceAccountRow(
+      day: "2025-06-10", sampleDate: day,
+      accountId: accountId, instrumentId: "USD", type: "trade", qty: 1_000_000_000)
+    let conversion = DateBasedFixedConversionService(
+      rates: [
+        try AnalysisTestHelpers.utcDate(year: 2025, month: 1, day: 1, hour: 0): [
+          "USD": try AnalysisTestHelpers.decimal("1.5")
+        ]
+      ])
+    var balances: [Date: DailyBalance] = [
+      dayKey: TradesModeFoldTestSupport.placeholderBalance(at: dayKey)
+    ]
+    let context = TradesModeFoldTestSupport.makeContext(
+      tradesIds: [accountId],
+      instrumentMap: [aud.id: aud, "USD": usd],
+      conversionService: conversion)
+    let handlers = TradesModeFoldTestSupport.makeHandlers { _, _ in }
+
+    try await GRDBAnalysisRepository.applyTradesModePositionValuations(
+      priorRows: [], postRows: [cashRow, tradeRow],
+      to: &balances, context: context, handlers: handlers)
+
+    // Cash 50 (AUD identity) + position 10 USD * 1.5 = 65.
+    let value = try #require(balances[dayKey]?.investmentValue)
+    let expected = try AnalysisTestHelpers.decimal("65")
+    #expect(value.quantity == expected)
+  }
+
+  @Test("case 11: same-day BUY + SELL netting produces zero contribution")
+  func sameDayBuyAndSellNetZero() async throws {
+    let day = try AnalysisTestHelpers.utcDate(year: 2025, month: 6, day: 10, hour: 12)
+    let dayKey = Calendar.current.startOfDay(for: day)
+    let usd = Instrument.fiat(code: "USD")
+    let accountId = UUID()
+    let buy = GRDBAnalysisRepository.DailyBalanceAccountRow(
+      day: "2025-06-10", sampleDate: day,
+      accountId: accountId, instrumentId: "USD", type: "trade", qty: 1_000_000_000)
+    let sell = GRDBAnalysisRepository.DailyBalanceAccountRow(
+      day: "2025-06-10", sampleDate: day,
+      accountId: accountId, instrumentId: "USD", type: "trade", qty: -1_000_000_000)
+    let conversion = DateBasedFixedConversionService(
+      rates: [
+        try AnalysisTestHelpers.utcDate(year: 2025, month: 1, day: 1, hour: 0): [
+          "USD": try AnalysisTestHelpers.decimal("1.5")
+        ]
+      ])
+    var balances: [Date: DailyBalance] = [
+      dayKey: TradesModeFoldTestSupport.placeholderBalance(at: dayKey)
+    ]
+    let context = TradesModeFoldTestSupport.makeContext(
+      tradesIds: [accountId],
+      instrumentMap: ["USD": usd],
+      conversionService: conversion)
+    let handlers = TradesModeFoldTestSupport.makeHandlers { _, _ in }
+
+    try await GRDBAnalysisRepository.applyTradesModePositionValuations(
+      priorRows: [], postRows: [buy, sell],
+      to: &balances, context: context, handlers: handlers)
+
+    // After the cursor advance, positions[accountId][USD] = 0 — the
+    // outer dict key is still present, so positions.isEmpty is false
+    // and `sumTradesModePositions` is invoked. The new
+    // `quantity == 0` guard inside the helper skips the zero
+    // position before the Rule 8 fast-path / convert decision —
+    // total stays 0. existing.investmentValue is nil, so
+    // `(nil ?? .zero(AUD)) + .zero(AUD) == .zero(AUD)`. The day's
+    // investmentValue is .zero(AUD) — non-nil, but quantity == 0.
+    let value = try #require(balances[dayKey]?.investmentValue)
+    #expect(value.quantity == 0)
+  }
+}

--- a/MoolahTests/Features/InvestmentStorePositionsInputTests.swift
+++ b/MoolahTests/Features/InvestmentStorePositionsInputTests.swift
@@ -116,4 +116,41 @@ struct InvestmentStorePositionsInputTests {
     #expect(ethRow.costBasis == InstrumentAmount(quantity: 6_000, instrument: aud))
     #expect(btcRow.costBasis == InstrumentAmount(quantity: 6_000, instrument: aud))
   }
+
+  @Test("loadAndBuildPositionsInput loads store state and returns built input")
+  func loadAndBuildPositionsInputCoordinatesBothSteps() async throws {
+    let (backend, _) = try TestBackend.create()
+    let store = InvestmentStore(
+      repository: backend.investments,
+      transactionRepository: backend.transactions,
+      conversionService: backend.conversionService
+    )
+    let account = Account(
+      name: "Brokerage", type: .investment, instrument: aud,
+      valuationMode: .calculatedFromTrades)
+    _ = try await backend.accounts.create(
+      account, openingBalance: InstrumentAmount(quantity: 0, instrument: aud))
+    _ = try await backend.transactions.create(
+      Transaction(
+        date: Date(),
+        legs: [
+          TransactionLeg(accountId: account.id, instrument: bhp, quantity: 100, type: .trade),
+          TransactionLeg(accountId: account.id, instrument: aud, quantity: -4_000, type: .trade),
+        ]
+      )
+    )
+
+    let input = try await store.loadAndBuildPositionsInput(
+      account: account, profileCurrency: aud, range: .threeMonths)
+
+    // Result reflects the second-step output, with the account name as title.
+    #expect(input.title == "Brokerage")
+    #expect(input.hostCurrency == aud)
+    #expect(input.positions.contains(where: { $0.instrument == bhp }))
+
+    // Store state was populated by the first-step `loadAllData` call.
+    #expect(store.loadedAccountId == account.id)
+    #expect(store.loadedHostCurrency == aud)
+    #expect(store.positions.contains(where: { $0.instrument == bhp }))
+  }
 }

--- a/MoolahTests/Support/AnalysisTestHelpers.swift
+++ b/MoolahTests/Support/AnalysisTestHelpers.swift
@@ -27,11 +27,17 @@ enum AnalysisTestHelpers {
   }
 
   /// Build a local-calendar `Date` at a specific `hour:` on the given
-  /// day. Uses `Calendar.current` so the resulting `Date`'s
-  /// `startOfDay` agrees with the production fold's
-  /// `Calendar.current.startOfDay(for: row.sampleDate)` math —
-  /// required by Rule 10 same-`startOfDay` normalization tests.
-  static func date(
+  /// day. Uses `Calendar.current` (not the fixed-Gregorian `calendar`
+  /// used by the parameterless-hour `date(year:month:day:)` overload)
+  /// so the resulting `Date`'s `startOfDay` agrees with the
+  /// production fold's `Calendar.current.startOfDay(for:
+  /// row.sampleDate)` math — required by Rule 10
+  /// same-`startOfDay` normalization tests.
+  ///
+  /// Renamed from the `date(...)` overload to make the calendar
+  /// asymmetry explicit at the call site: the prefix-shared
+  /// `date(year:month:day:)` is fixed-Gregorian; this is local.
+  static func localDate(
     year: Int, month: Int, day: Int, hour: Int
   ) throws -> Date {
     try #require(

--- a/MoolahTests/Support/AnalysisTestHelpers.swift
+++ b/MoolahTests/Support/AnalysisTestHelpers.swift
@@ -26,6 +26,20 @@ enum AnalysisTestHelpers {
       calendar.date(from: DateComponents(year: year, month: month, day: day)))
   }
 
+  /// Build a local-calendar `Date` at a specific `hour:` on the given
+  /// day. Uses `Calendar.current` so the resulting `Date`'s
+  /// `startOfDay` agrees with the production fold's
+  /// `Calendar.current.startOfDay(for: row.sampleDate)` math —
+  /// required by Rule 10 same-`startOfDay` normalization tests.
+  static func date(
+    year: Int, month: Int, day: Int, hour: Int
+  ) throws -> Date {
+    try #require(
+      currentCalendar.date(
+        from: DateComponents(
+          year: year, month: month, day: day, hour: hour)))
+  }
+
   /// Build a UTC-anchored Date from year/month/day components.
   ///
   /// SQL `DATE(t.date)` extracts the UTC calendar day, and

--- a/MoolahTests/Support/CloudKitAnalysisTestBackend.swift
+++ b/MoolahTests/Support/CloudKitAnalysisTestBackend.swift
@@ -74,7 +74,7 @@ extension CloudKitAnalysisTestBackend {
   /// per-day walk. Reads from the backend's already-public
   /// `DatabaseQueue` — no peek into `GRDBAnalysisRepository`'s
   /// private storage.
-  func testFetchAggregation(
+  func fetchAggregationForTesting(
     after: Date?, forecastUntil: Date?
   ) async throws -> GRDBAnalysisRepository.DailyBalancesAggregation {
     try await GRDBAnalysisRepository.fetchDailyBalancesAggregation(

--- a/MoolahTests/Support/CloudKitAnalysisTestBackend.swift
+++ b/MoolahTests/Support/CloudKitAnalysisTestBackend.swift
@@ -65,3 +65,21 @@ struct CloudKitAnalysisTestBackend: BackendProvider, @unchecked Sendable {
     self.importRules = backend.importRules
   }
 }
+
+extension CloudKitAnalysisTestBackend {
+  /// Test-only entry point that exposes `fetchDailyBalancesAggregation`
+  /// for aggregation-layer integration tests. Production callers go
+  /// through `analysis.fetchDailyBalances(...)`; this shim lets tests
+  /// pin the aggregation contract without re-running the full
+  /// per-day walk. Reads from the backend's already-public
+  /// `DatabaseQueue` — no peek into `GRDBAnalysisRepository`'s
+  /// private storage.
+  func testFetchAggregation(
+    after: Date?, forecastUntil: Date?
+  ) async throws -> GRDBAnalysisRepository.DailyBalancesAggregation {
+    try await GRDBAnalysisRepository.fetchDailyBalancesAggregation(
+      database: self.database,
+      after: after,
+      forecastUntil: forecastUntil)
+  }
+}

--- a/MoolahTests/Support/DateFailingConversionService.swift
+++ b/MoolahTests/Support/DateFailingConversionService.swift
@@ -16,6 +16,14 @@ import Foundation
 // internal (was fileprivate) so sibling test files can use this helper
 struct DateFailingConversionService: InstrumentConversionService {
   let rates: [Date: [String: Decimal]]
+  /// Entries must be `Calendar.current.startOfDay`-normalised so
+  /// they line up with how production callers compute their
+  /// `dayKey` (`applyInvestmentValues`,
+  /// `applyTradesModePositionValuations`). The service no longer
+  /// re-normalises the `on:` argument inside `convert(...)` — a
+  /// second `startOfDay` call with a non-Gregorian calendar would
+  /// silently disagree with the caller's `Calendar.current`-keyed
+  /// `failingDates`, turning Rule 10 regressions into false-greens.
   let failingDates: Set<Date>
   private let sortedRateEntries: [(date: Date, rates: [String: Decimal])]
 
@@ -39,9 +47,8 @@ struct DateFailingConversionService: InstrumentConversionService {
     _ quantity: Decimal, from: Instrument, to: Instrument, on date: Date
   ) async throws -> Decimal {
     if from.id == to.id { return quantity }
-    let dayKey = Calendar(identifier: .gregorian).startOfDay(for: date)
-    if failingDates.contains(dayKey) {
-      throw DateFailingConversionError.unavailable(date: dayKey)
+    if failingDates.contains(date) {
+      throw DateFailingConversionError.unavailable(date: date)
     }
     let asOf = ratesAsOf(date)
     guard let rate = asOf[from.id] else {

--- a/MoolahTests/Support/DateFailingConversionService.swift
+++ b/MoolahTests/Support/DateFailingConversionService.swift
@@ -13,7 +13,6 @@ import Foundation
 // the requested conversion date (normalized to start-of-day) is in
 // `failingDates`. Same-instrument conversions always succeed. Otherwise
 // behaves like `DateBasedFixedConversionService`.
-// internal (was fileprivate) so sibling test files can use this helper
 struct DateFailingConversionService: InstrumentConversionService {
   let rates: [Date: [String: Decimal]]
   /// Entries must be `Calendar.current.startOfDay`-normalised so
@@ -67,7 +66,6 @@ struct DateFailingConversionService: InstrumentConversionService {
   }
 }
 
-// internal (was fileprivate) so sibling test files can use this helper
 enum DateFailingConversionError: Error, Equatable {
   case unavailable(date: Date)
 }

--- a/MoolahTests/Support/ThrowingCountingConversionService.swift
+++ b/MoolahTests/Support/ThrowingCountingConversionService.swift
@@ -72,6 +72,12 @@ final class FailureLog: Sendable {
 /// reason as `FailureLog` — and exposes only `append(_:_:)` and
 /// `snapshot()` so multi-field reads are atomic with respect to a
 /// single lock acquisition (mirrors the `FailureLog` API shape).
+///
+/// `(Error, Date)` is `Sendable` because Swift's `Error` protocol
+/// inherits from `Sendable` (Swift 5.7+), so the existential
+/// `any Error` is `Sendable` and `OSAllocatedUnfairLock<[(Error, Date)]>`
+/// satisfies the conditional `Sendable where State: Sendable`
+/// requirement.
 final class InvestmentValueFailureLog: Sendable {
   private let entries = OSAllocatedUnfairLock<[(Error, Date)]>(initialState: [])
 

--- a/MoolahTests/Support/ThrowingCountingConversionService.swift
+++ b/MoolahTests/Support/ThrowingCountingConversionService.swift
@@ -63,3 +63,23 @@ final class FailureLog: Sendable {
     entries.withLock { $0 }
   }
 }
+
+/// Async-safe collector for `(Error, Date)` failure tuples emitted by
+/// `DailyBalancesHandlers.handleInvestmentValueFailure`. Used by
+/// tests that need to assert which day surfaced through the per-day
+/// error callback (and how many times). Backed by
+/// `OSAllocatedUnfairLock` for the same `@Sendable`-closure-mutation
+/// reason as `FailureLog` — and exposes only `append(_:_:)` and
+/// `snapshot()` so multi-field reads are atomic with respect to a
+/// single lock acquisition (mirrors the `FailureLog` API shape).
+final class InvestmentValueFailureLog: Sendable {
+  private let entries = OSAllocatedUnfairLock<[(Error, Date)]>(initialState: [])
+
+  func append(_ error: Error, _ date: Date) {
+    entries.withLock { $0.append((error, date)) }
+  }
+
+  func snapshot() -> [(Error, Date)] {
+    entries.withLock { $0 }
+  }
+}

--- a/MoolahTests/Support/TradesModeFoldTestSupport.swift
+++ b/MoolahTests/Support/TradesModeFoldTestSupport.swift
@@ -1,0 +1,79 @@
+import Foundation
+
+@testable import Moolah
+
+/// Shared helpers for the trades-mode position-valuation fold tests.
+/// Hoisted out of `GRDBDailyBalancesTradesModeTests` so the suite can be
+/// split across multiple files (SwiftLint `file_length` /
+/// `type_body_length`) while keeping the helper definitions in a
+/// single place.
+enum TradesModeFoldTestSupport {
+
+  /// Build the standard `DailyBalancesHandlers` for fold-contract
+  /// tests. The trades-mode fold only ever invokes
+  /// `handleInvestmentValueFailure` — the other two callbacks are
+  /// no-ops. Pass `InvestmentValueFailureLog.append` (or a
+  /// `{ _, _ in }` no-op for cases that don't assert on failures).
+  static func makeHandlers(
+    failures: @escaping @Sendable (Error, Date) -> Void
+  ) -> GRDBAnalysisRepository.DailyBalancesHandlers {
+    GRDBAnalysisRepository.DailyBalancesHandlers(
+      handleUnparseableDay: { _ in },
+      handleConversionFailure: { _, _ in },
+      handleInvestmentValueFailure: failures)
+  }
+
+  /// Zero-everything `DailyBalance` placeholder so the fold has an
+  /// entry to look up / drop on the given day.
+  static func placeholderBalance(at dayKey: Date) -> DailyBalance {
+    DailyBalance(
+      date: dayKey,
+      balance: .zero(instrument: .defaultTestInstrument),
+      earmarked: .zero(instrument: .defaultTestInstrument),
+      availableFunds: .zero(instrument: .defaultTestInstrument),
+      investments: .zero(instrument: .defaultTestInstrument),
+      investmentValue: nil,
+      netWorth: .zero(instrument: .defaultTestInstrument),
+      bestFit: nil,
+      isForecast: false)
+  }
+
+  /// Pre-seeded `DailyBalance` mirroring a recorded-value snapshot
+  /// contribution on the day. Used by tests that exercise the
+  /// add-not-overwrite contract for `investmentValue` /
+  /// `netWorth`.
+  static func preSeededDailyBalance(on dayKey: Date) -> DailyBalance {
+    DailyBalance(
+      date: dayKey,
+      balance: InstrumentAmount(
+        quantity: 10, instrument: .defaultTestInstrument),
+      earmarked: .zero(instrument: .defaultTestInstrument),
+      availableFunds: InstrumentAmount(
+        quantity: 10, instrument: .defaultTestInstrument),
+      investments: .zero(instrument: .defaultTestInstrument),
+      investmentValue: InstrumentAmount(
+        quantity: 100, instrument: .defaultTestInstrument),
+      netWorth: InstrumentAmount(
+        quantity: 110, instrument: .defaultTestInstrument),
+      bestFit: nil,
+      isForecast: false)
+  }
+
+  /// Build a `DailyBalancesAssemblyContext` parameterised for the
+  /// trades-mode fold: empty `investmentAccountIds` (the
+  /// snapshot/recorded-value fold isn't under test), explicit
+  /// trades-mode ids, instrument map, and conversion service. Profile
+  /// instrument is the default test instrument (AUD).
+  static func makeContext(
+    tradesIds: Set<UUID>,
+    instrumentMap: [String: Instrument],
+    conversionService: any InstrumentConversionService
+  ) -> GRDBAnalysisRepository.DailyBalancesAssemblyContext {
+    GRDBAnalysisRepository.DailyBalancesAssemblyContext(
+      investmentAccountIds: [],
+      tradesModeInvestmentAccountIds: tradesIds,
+      instrumentMap: instrumentMap,
+      profileInstrument: .defaultTestInstrument,
+      conversionService: conversionService)
+  }
+}

--- a/Shared/PositionsHistoryBuilder.swift
+++ b/Shared/PositionsHistoryBuilder.swift
@@ -35,6 +35,7 @@ struct PositionsHistoryBuilder: Sendable {
   private let logger = Logger(
     subsystem: "com.moolah.app", category: "PositionsHistoryBuilder")
 
+  @concurrent
   func build(
     transactions: [Transaction],
     accountId: UUID,

--- a/plans/2026-05-04-trades-mode-historical-net-worth-design.md
+++ b/plans/2026-05-04-trades-mode-historical-net-worth-design.md
@@ -22,8 +22,10 @@ In the same change, tighten the existing snapshot fold
 (`applyInvestmentValues`) to comply with Rule 11: a per-day conversion
 failure removes that day from `dailyBalances` (matches `walkDays`'s
 existing per-day error contract) instead of silently leaving a partial
-total in place. Both folds end up with the same Rule 11 behaviour after
-this PR.
+total in place. Drop the vestigial `?` on `sumInvestmentValues`'s
+return type (it never returns `nil` on success) at the same time so
+the predecessor and the new helper share a clean signature. Both folds
+end up with the same Rule 11 behaviour after this PR.
 
 The current value (today's number) is already correct for trades-mode
 accounts via `PositionsValuator`; only the *historical series* is broken.
@@ -198,7 +200,10 @@ set, because trades-mode accounts contribute via the new fold instead.
 
 Lives next to `applyInvestmentValues` in
 `+DailyBalancesInvestmentValues.swift` so the two folds share a file.
-Public entry point:
+The function is `static` and carries no actor annotation — it is
+called from the existing `@concurrent` `assembleDailyBalances` and
+inherits the off-main context, matching `applyInvestmentValues`. Public
+entry point:
 
 ```swift
 /// Per-day position-valuation fold for trades-mode investment accounts.
@@ -207,11 +212,10 @@ Public entry point:
 /// drops the day from `dailyBalances` and logs through
 /// `handleInvestmentValueFailure`.
 ///
-/// `priorTradesModeAccountRows` and `tradesModeAccountRows` carry only
-/// rows whose `accountId` belongs to a trades-mode investment account
-/// — pre-filtered in `readDailyBalancesAggregation` so this fold
-/// neither re-checks membership nor walks rows for accounts it doesn't
-/// own.
+/// `priorRows` and `postRows` carry only rows whose `accountId`
+/// belongs to a trades-mode investment account — pre-filtered in
+/// `readDailyBalancesAggregation` so this fold neither re-checks
+/// membership nor walks rows for accounts it doesn't own.
 static func applyTradesModePositionValuations(
   priorRows: [DailyBalanceAccountRow],
   postRows: [DailyBalanceAccountRow],
@@ -221,65 +225,101 @@ static func applyTradesModePositionValuations(
 ) async throws
 ```
 
-Algorithm:
+Algorithm — designed as a **cursor walk** mirroring
+`applyInvestmentValues` / `advanceInvestmentCursor` so cumulative
+position state is updated for every day with trades-mode activity,
+even days that are absent from `dailyBalances` (e.g. dropped by an
+earlier fold's per-day failure). Walking only `dailyBalances.keys`
+would silently miss those days' trades and corrupt carry-forward
+positions on every following day.
 
 1. **Early return** if `context.tradesModeInvestmentAccountIds.isEmpty`
    or `dailyBalances.isEmpty` (matches `applyInvestmentValues`'s guard
    shape).
-2. **Pre-fold priors** into a per-account, per-instrument cumulative dict
-   `var positions: [UUID: [Instrument: Decimal]] = [:]`. `Instrument`
-   conforms to `Hashable` (`Domain/Models/Instrument.swift:4`); the
-   shape mirrors `PositionBook.accounts`. Decode each row's raw `Int64`
-   `qty` via `InstrumentAmount(storageValue:instrument:).quantity` —
-   same pattern as `applyDailyDeltas` so storage-unit semantics stay
-   pinned in one place.
-3. **Group post rows by UTC day-string**, mirroring `walkDays` exactly:
-   `Dictionary(grouping: postRows, by: \.day)`. The day-string is
-   `DATE(t.date)` from SQL — the indexing key. `walkDays`'s `dayKey`
-   (the local-startOfDay used as the `dailyBalances` key) is derived
-   from the group's first row's `sampleDate` via
-   `Calendar.current.startOfDay(for:)`. We use the same pattern here
-   (Rule 10 same-`startOfDay` normalization) so `dayKey` agrees with
-   the keys `walkDays` produced.
-4. **Walk `dailyBalances.keys.sorted()`** in date order. For each
+2. **Pre-fold priors** into a per-account, per-instrument cumulative
+   dict `var positions: [UUID: [Instrument: Decimal]] = [:]`.
+   `Instrument` conforms to `Hashable`
+   (`Domain/Models/Instrument.swift:4`); the shape mirrors
+   `PositionBook.accounts`. For each prior row:
+   1. Resolve the instrument via
+      `resolveInstrument(row.instrumentId, in: context.instrumentMap)`
+      (the existing helper at the bottom of `+DailyBalances.swift` —
+      same call as `applyDailyDeltas`).
+   2. Decode the raw `Int64` `qty` via
+      `InstrumentAmount(storageValue: row.qty, instrument: instrument).quantity` —
+      same pattern as `applyDailyDeltas` so storage-unit semantics
+      stay pinned in one place.
+   3. `positions[row.accountId, default: [:]][instrument, default: 0] += quantity`.
+3. **Build a sorted cursor over post rows.** Decode each `postRow` into
+   an internal `(dayKey: Date, accountId: UUID, instrument: Instrument,
+   quantity: Decimal)` tuple, where
+   `dayKey = Calendar.current.startOfDay(for: row.sampleDate)`. Sort
+   the array by `dayKey` ascending. This is the new fold's equivalent
+   of `applyInvestmentValues`'s sorted `[InvestmentValueSnapshot]` — a
+   pre-built, instrument-resolved, dayKey-keyed cursor that the walk
+   advances through. Grouping by the SQL `\.day` UTC string is
+   intentionally avoided here: the new fold's outer iteration is over
+   local `Date` keys, and matching UTC day-strings to local-startOfDay
+   keys would re-introduce the Rule 10 timezone bug. Building the
+   cursor at `dayKey` granularity directly removes the mismatch.
+4. **Walk `dailyBalances.keys.sorted()`** in date order. Maintain a
+   cursor index `valueIndex` over the sorted post-row tuples. For each
    `dayKey`:
-   1. Apply the day's grouped rows (those whose mapped `dayKey`
-      matches) to the cumulative `positions` dict.
-   2. Skip the day if `positions` is empty (no trades-mode account has
-      ever held anything yet) — leaves the day's `DailyBalance`
-      untouched.
-   3. Inside an explicit two-catch `do { } catch let cancel as
-      CancellationError { throw cancel } catch { ... }` block (matches
-      `applyInvestmentValues`'s shape — see §10 for the literal code
-      sketch), call
+   1. **Advance the cursor:** while `valueIndex < tuples.count` and
+      `tuples[valueIndex].dayKey <= dayKey`, apply
+      `positions[t.accountId, default: [:]][t.instrument, default: 0] += t.quantity`
+      and `valueIndex += 1`. This applies *every* trades-mode row
+      whose `dayKey` is on-or-before the current outer `dayKey`,
+      including rows for days that are not themselves in
+      `dailyBalances` (the carry-forward correctness fix).
+   2. Skip the rest of this iteration if `positions` is empty (no
+      trades-mode account has ever held anything yet) — leaves the
+      day's `DailyBalance` untouched.
+   3. Inside the explicit two-catch block from §10, call
       `sumTradesModePositions(positions:on:profileInstrument:conversionService:)`
       to obtain the day's `InstrumentAmount` total in the profile
       instrument.
-   4. **On success:** `let combined = (existing.investmentValue ??
-      .zero(instrument: profileInstrument)) + total`; rebuild the day's
-      `DailyBalance` with `investmentValue = combined` and `netWorth =
-      balance + combined`.
+   4. **On success:** rebuild the day's `DailyBalance` with
+      `investmentValue = (existing.investmentValue ??
+      .zero(instrument: profileInstrument)) + total` and `netWorth =
+      balance + investmentValue`. Because `dayKey` came from
+      `dailyBalances.keys.sorted()`, the existing entry is provably
+      present — direct subscript access (`dailyBalances[dayKey]!`) is
+      sound, but the spec sketch in §10 uses an `if let existing` bind
+      to keep the success-path code readable without an
+      implicit-unwrap.
    5. **On any non-cancellation throw (Rule 11 — failing day must
       surface as unavailable):** log via
       `handlers.handleInvestmentValueFailure(error, dayKey)` and
       `dailyBalances.removeValue(forKey: dayKey)`. The chart shows a
       gap on that day, matching `walkDays`'s existing per-day-failure
       contract.
+5. **After the outer walk completes**, any tail tuples whose `dayKey`
+   exceeds every `dailyBalances` key are intentionally not visited.
+   They cannot affect any output because no `dailyBalances` entry on
+   or after them exists. (The bestFit / forecast steps run on the
+   already-converted historic span, and forecast valuation is out of
+   scope per §Non-Goals.)
 
 The `priorRows` / `postRows` parameters are deliberately *not* the
 unfiltered `aggregation.priorAccountRows` / `aggregation.accountRows`
-— they're the new pre-filtered fields from §2, named without the
+— they're the pre-filtered fields from §2, named without the
 `accountRows` suffix to avoid suggesting "every account" at the call
-site. The doc comment on the entry point states the filtering contract
-explicitly.
+site. The doc comment on the entry point states the filtering
+contract explicitly.
 
 ### 5. Conversion helper — `sumTradesModePositions`
 
 Mirrors `sumInvestmentValues`, file-private, **non-optional** return
-type (the `?` on `sumInvestmentValues` is vestigial — the function
-either throws or returns a value; out-of-scope to clean up the
-predecessor in this PR, but the new helper does not perpetuate the
-pattern):
+type. As part of this PR, also clean up the vestigial `?` on
+`sumInvestmentValues`'s return type — it never returns `nil` on
+success (any error throws), and dropping the `?` removes a latent
+silent-nil-return risk and brings the predecessor signature into line
+with the new helper. The mechanical change: drop `?` from
+`sumInvestmentValues`'s return type, return the `InstrumentAmount`
+directly at the bottom of the function, and update the single caller
+in `applyInvestmentValues` to `let totalValue = try await
+sumInvestmentValues(...)` (no optional-bind).
 
 ```swift
 private static func sumTradesModePositions(
@@ -306,11 +346,24 @@ A failed convert throws to the caller (per-day error contract — see
 profileInstrument)`. On a warm cache the per-day cost is
 O(distinct instruments held that day), which is bounded.
 
+**Cancellation contract.** The inner loop relies on the conversion
+service's cooperative cancellation: every `await
+conversionService.convert(...)` is itself a suspension point that
+re-checks `Task.isCancelled` and throws `CancellationError` when the
+enclosing task is cancelled. The `CancellationError` propagates
+through this helper into the per-day two-catch block in §10, where
+the cancel branch rethrows immediately. No manual `Task.isCancelled`
+check between iterations is required — same pattern as
+`sumInvestmentValues`. The Rule 8 fast-path branch performs no
+suspension, so a single `Task.isCancelled` check at the top of the
+helper would only fire after each suspension anyway; we omit it for
+parity with the predecessor.
+
 The caller passes `dayKey` (the `startOfDay`-normalized key from §4)
-as `on:`. Add a one-line comment at the call site stating "`dayKey` is
-`Calendar.current.startOfDay(for: row.sampleDate)` — same normalization
-as `walkDays` and the conversion-service lookup" so future readers
-don't need to chase the call site to verify Rule 10.
+as `on:`. Add a one-line comment at the call site stating "`dayKey`
+is `Calendar.current.startOfDay(for: row.sampleDate)` — same
+normalization as `walkDays` and the conversion-service lookup" so
+future readers don't need to chase the call site to verify Rule 10.
 
 ### 6. Wire into `assembleDailyBalances` and tighten the snapshot fold
 
@@ -333,35 +386,49 @@ try await applyTradesModePositionValuations(
 ```
 
 **`applyInvestmentValues` is updated in this PR** so its per-day error
-branch matches the new fold (and `walkDays`):
+branch matches the new fold (and `walkDays`). Concretely:
 
-```swift
-} catch let cancel as CancellationError {
-  throw cancel
-} catch {
-  handlers.handleInvestmentValueFailure(error, date)
-  dailyBalances.removeValue(forKey: date)  // Rule 11 — was: continue
-  continue
-}
-```
+- The existing two-catch block at lines 130–135 of
+  `+DailyBalancesInvestmentValues.swift` already has the right shape
+  (`catch let cancel as CancellationError { throw cancel } catch
+  { ... }`); the only diff is in the second catch's body.
+- **Before:** the second catch was
+  `handlers.handleInvestmentValueFailure(error, date); continue`.
+- **After:**
+  ```swift
+  catch {
+    handlers.handleInvestmentValueFailure(error, date)
+    dailyBalances.removeValue(forKey: date)  // new — Rule 11
+    continue
+  }
+  ```
+- The success-path guard `guard let totalValue, let balance =
+  dailyBalances[date] else { continue }` (line 136) is unchanged —
+  not affected by this fix.
 
 Before this change, a snapshot-fold conversion failure left the day's
 `DailyBalance` untouched — the chart line at that day reflected only
 the bank-balance + transfers-only investments contribution, with no
 indication that the snapshot couldn't be computed. Per Rule 11, that's
-an incorrect partial total rendered as authoritative. Removing the day
-matches `walkDays`'s existing per-day-failure contract and ends the
-deviation called out in the round-1 instrument-conversion review.
+an incorrect partial total rendered as authoritative. Removing the
+day matches `walkDays`'s existing per-day-failure contract and ends
+the deviation called out in the round-1 instrument-conversion review.
 
-Order of the two folds is significant only for log-ordering (snapshots
-log before trades). Both folds drop the day from `dailyBalances` on
-failure; if either fold fails for a day, the day is gone from the
-result regardless of which ran first. Both folds touch disjoint account
-sets, so on the success path the additive `investmentValue` is
-order-independent.
+**Fold ordering.** Output (`investmentValue` / `netWorth` updates) is
+order-independent because the two folds touch disjoint account sets,
+both drop the day from `dailyBalances` on failure (if either fold
+fails for a day, the day is gone from the result regardless of which
+ran first), and addition is commutative. The cumulative-position
+update inside the trades fold (§4 step 4i) advances regardless of
+whether the current day is still in `dailyBalances` — so a day
+dropped by `applyInvestmentValues` does not skip its trades-mode
+rows, and the carry-forward position state stays correct on every
+following day. Logging order (snapshots before trades) is the only
+observable order difference.
 
-`applyBestFit` and the forecast tail run after both folds, both already
-iterate `dailyBalances.values` — they automatically skip dropped days.
+`applyBestFit` and the forecast tail run after both folds, both
+already iterate `dailyBalances.values` — they automatically skip
+dropped days.
 
 ### 7. Edge cases
 
@@ -454,7 +521,11 @@ table — no new test doubles.
 
 #### 9.1 Plan-pinning
 
-- §8: `fetchTradesModeInvestmentAccountIdsUsesAccountByType`.
+- §8: `fetchTradesModeInvestmentAccountIdsUsesAccountByType`. The
+  Swift-side filter pass that produces `priorTradesModeAccountRows`
+  / `tradesModeAccountRows` from the existing prior/post arrays is an
+  in-memory `Array.filter` (no SQL), so no additional plan-pinning
+  test is required for it.
 
 #### 9.2 Aggregation-layer integration
 
@@ -509,17 +580,32 @@ Add to
 9. **Empty `dailyBalances` ⇒ no-op** — nothing to fold over; no
    logger output.
 10. **CSV-imported trade with a `.transfer` cash leg + a `.trade`
-    position leg.** Cumulative position picks up both legs; cash leg
-    adds via Rule 8 fast path (when in profile instrument), or FX
-    otherwise; position leg adds via stock-price conversion.
+    position leg.** A profile-instrument cash transfer of `C` and a
+    same-day trade buying `N` shares of an instrument priced `P` on
+    that day → day's `investmentValue` ≈ `C + N * P`. Cash leg adds
+    via Rule 8 fast path (in profile instrument) or FX otherwise;
+    position leg adds via stock-price conversion.
 11. **Same-day BUY + SELL of equal quantities** → day's net
     contribution = zero; `investmentValue` unchanged from the
     snapshot fold.
+12. **Carry-forward correctness across a dropped day** — a
+    trades-mode account has a buy on day D₁; the snapshot fold drops
+    day D₁ from `dailyBalances` (e.g. via a recorded-value
+    snapshot-conversion failure on a sibling account). Day D₂
+    (D₂ > D₁) is in `dailyBalances` and the trades-mode position is
+    valuated correctly on D₂ — i.e. day D₁'s buy was applied to the
+    cumulative `positions` dict during the cursor walk even though
+    D₁ itself was not visited as an output day. Asserts that the
+    fix in §4 step 4i (advance positions for every dayKey ≤ outer
+    dayKey, regardless of `dailyBalances` membership) is in effect.
 
 ### 10. Two-catch shape (literal sketch)
 
 Both folds use the same explicit two-catch pattern so future readers
-don't have to infer the cancellation contract from prose:
+don't have to infer the cancellation contract from prose. `dayKey`
+came from `dailyBalances.keys.sorted()` — the entry must exist, so we
+bind it via `if let existing = dailyBalances[dayKey]` rather than
+force-unwrapping; either is sound, the `if let` reads more naturally:
 
 ```swift
 do {
@@ -530,19 +616,21 @@ do {
     on: dayKey,
     profileInstrument: context.profileInstrument,
     conversionService: context.conversionService)
-  guard let existing = dailyBalances[dayKey] else { continue }
-  let combined =
-    (existing.investmentValue ?? .zero(instrument: context.profileInstrument)) + total
-  dailyBalances[dayKey] = DailyBalance(
-    date: existing.date,
-    balance: existing.balance,
-    earmarked: existing.earmarked,
-    availableFunds: existing.availableFunds,
-    investments: existing.investments,
-    investmentValue: combined,
-    netWorth: existing.balance + combined,
-    bestFit: existing.bestFit,
-    isForecast: existing.isForecast)
+  if let existing = dailyBalances[dayKey] {
+    let combined =
+      (existing.investmentValue ?? .zero(instrument: context.profileInstrument))
+      + total
+    dailyBalances[dayKey] = DailyBalance(
+      date: existing.date,
+      balance: existing.balance,
+      earmarked: existing.earmarked,
+      availableFunds: existing.availableFunds,
+      investments: existing.investments,
+      investmentValue: combined,
+      netWorth: existing.balance + combined,
+      bestFit: existing.bestFit,
+      isForecast: existing.isForecast)
+  }
 } catch let cancel as CancellationError {
   throw cancel
 } catch {
@@ -552,9 +640,10 @@ do {
 }
 ```
 
-`applyInvestmentValues` is updated to match (see §6) — the only
-difference between the two folds is which input drives the per-day
-total (cumulative positions vs. carry-forward snapshots).
+`applyInvestmentValues` is updated per §6 to match in the catch
+branch — the only difference between the two folds is which input
+drives the per-day total (cumulative positions vs. carry-forward
+snapshots).
 
 ### 11. Logging
 
@@ -615,10 +704,6 @@ confirm.
 
 ## Out-of-Scope Followups
 
-- Cleaning up the vestigial `?` on `sumInvestmentValues`'s return type
-  (the function effectively always returns non-nil on success; the `?`
-  is dead). The new helper avoids the same shape; the predecessor
-  cleanup is a one-liner suitable for a follow-up.
 - Extending the trades-mode contribution onto the *forecast tail* via
   `Date()` valuation — would mirror Rule 7's service-level clamp and
   could be added without further design.

--- a/plans/2026-05-04-trades-mode-historical-net-worth-design.md
+++ b/plans/2026-05-04-trades-mode-historical-net-worth-design.md
@@ -1,7 +1,7 @@
 # Trades-Mode Historical Net-Worth Contribution — Design
 
 **Date:** 2026-05-04
-**Status:** Draft, pending review
+**Status:** Draft — round 2 (post-review revisions)
 **Tracking issue:** [#738](https://github.com/ajsutton/moolah-native/issues/738)
 **Predecessor:**
 [`plans/completed/2026-05-04-per-account-valuation-mode-design.md`](completed/2026-05-04-per-account-valuation-mode-design.md)
@@ -17,6 +17,13 @@ activity, valuate each instrument quantity in the profile instrument using
 the historical price for that day (per
 `guides/INSTRUMENT_CONVERSION_GUIDE.md` Rule 5), and add the result into the
 day's `DailyBalance.investmentValue` and `netWorth`.
+
+In the same change, tighten the existing snapshot fold
+(`applyInvestmentValues`) to comply with Rule 11: a per-day conversion
+failure removes that day from `dailyBalances` (matches `walkDays`'s
+existing per-day error contract) instead of silently leaving a partial
+total in place. Both folds end up with the same Rule 11 behaviour after
+this PR.
 
 The current value (today's number) is already correct for trades-mode
 accounts via `PositionsValuator`; only the *historical series* is broken.
@@ -41,25 +48,28 @@ inaccurate for any user who:
 Issue #738 calls this out as the natural next step now that the toggle
 itself is shipped and stable.
 
+A first-round review surfaced a Critical Rule 11 finding: the new fold's
+proposed "log + skip override" failure contract would have replicated the
+existing `applyInvestmentValues` deviation, leaving partial totals in
+`investmentValue` / `netWorth` when a day's conversion fails. The revised
+design fixes Rule 11 in **both** folds in this PR — see §6 and §10.
+
 ## Goals
 
 - For every trades-mode investment account, the historical net-worth chart
   reflects the value of its held positions on every historical day with
   activity, using historical prices for that day.
-- Snapshot-mode accounts continue to contribute via the existing
-  `applyInvestmentValues` fold without behavioural change.
+- Snapshot-mode accounts continue to contribute via `applyInvestmentValues`.
 - Mixed-mode profiles (some accounts in each mode) sum both contributions
   cleanly into a single `investmentValue` per day.
-- Per-day Rule 11 contract for the new fold matches the existing
-  `applyInvestmentValues` pattern (log + skip the override on per-day
-  conversion failure; `CancellationError` rethrows immediately). This is a
-  conscious match of the in-tree pattern; tightening Rule 11 compliance
-  for the daily-balance pipeline is a separate concern (see Out-of-Scope).
+- Per-day Rule 11 contract for **both** folds: log + drop the day from
+  `dailyBalances` on conversion failure (matches `walkDays`'s existing
+  contract). `CancellationError` rethrows immediately.
 - All historical conversions go through `InstrumentConversionService` on
-  the day's `Date` (Rule 5 / Rule 10 / Rule 8 fast path).
-- SQL plan-pinning maintained — no new full table scans introduced; the
-  new SELECT mirrors the existing snapshot-mode predicate and uses the
-  same shape.
+  the day's `Date` (Rule 5 / Rule 8 fast path / Rule 10 same-startOfDay
+  normalization).
+- SQL plan-pinning maintained — the new SELECT mirrors the existing
+  snapshot-mode predicate and uses the same `account_by_type` index.
 
 ## Non-Goals
 
@@ -72,30 +82,29 @@ itself is shipped and stable.
 - **No new conversion service.** The fold uses the existing
   `InstrumentConversionService` — same path that
   `PositionsHistoryBuilder` and `PositionsValuator` already use.
-- **No change to `PositionsValuator`.** The current-value path is
-  unchanged.
-- **No change to `applyInvestmentValues`** (the snapshot fold).
+- **No change to `PositionsValuator`** (current-value path).
 - **No change to per-account chart on `InvestmentAccountView`**
   (`PositionsHistoryBuilder` already covers it).
-- **No tightening of `applyInvestmentValues`'s pre-existing Rule 11
-  deviation** (it logs + leaves the day's investmentValue at whatever
-  walkDays produced, rather than dropping the day from the dict). The new
-  fold matches that pattern for consistency; a separate issue can address
-  Rule 11 compliance for the entire daily-balance pipeline.
 - **No new `Position`-history schema or persisted series.** The series is
   computed Swift-side per request from the existing `transaction_leg`
   rows (same source of truth as `walkDays` itself), so there is no new
   persisted state, no new sync surface, and no new migration.
+- **No on-screen "this day's contribution unavailable" affordance.** The
+  chart already gaps days dropped by `walkDays` on conversion failure;
+  this PR makes the snapshot and trades folds consistent with that
+  behaviour. A surfaced retry-now affordance is a separate UI concern.
 
 ## Design
 
 ### 1. New SQL fetch — trades-mode investment account ids
 
-Add a sibling of `fetchInvestmentAccountIds`
+Add a sibling of `fetchInvestmentAccountIds` in the same file
 (`Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesInvestmentValues.swift`):
 
 ```swift
-static func fetchTradesModeInvestmentAccountIds(database: Database) throws -> Set<UUID> {
+static func fetchTradesModeInvestmentAccountIds(
+  database: Database
+) throws -> Set<UUID> {
   let rows = try Row.fetchAll(
     database,
     sql: """
@@ -106,41 +115,57 @@ static func fetchTradesModeInvestmentAccountIds(database: Database) throws -> Se
 }
 ```
 
-The two SELECTs differ only on the `valuation_mode = '…'` literal — kept
-as a separate function for `guides/DATABASE_CODE_GUIDE.md` §4 (no
-dynamically composed `sql:` arguments). The plan is the same shape as
-`fetchInvestmentAccountIds` (a small-table scan); no new index required.
+Plain string-literal SQL — kept as a separate function (rather than a
+parameterised predicate) for `guides/DATABASE_CODE_GUIDE.md` §4. The query
+shape is identical to the existing snapshot-mode predicate and resolves
+through the same `account_by_type` index — the only difference is the
+`valuation_mode` literal. See §8 for the plan-pinning test.
 
-### 2. Aggregation type carries both account-id sets
+### 2. Aggregation type carries pre-filtered trades-mode rows
 
-Extend `DailyBalancesAggregation`
-(`+DailyBalances.swift`) with one extra field:
+Extend `DailyBalancesAggregation` (`+DailyBalances.swift`) with **two**
+new fields, mirroring the way `applyInvestmentValues` consumes
+`investmentValues: [InvestmentValueSnapshot]` (a purpose-built bundle,
+not the raw row arrays):
 
 ```swift
 struct DailyBalancesAggregation: Sendable {
   // existing fields ...
   let investmentAccountIds: Set<UUID>            // recorded-value (existing)
   let tradesModeInvestmentAccountIds: Set<UUID>  // new
+  /// Pre-cutoff `transaction_leg` SUM rows filtered to trades-mode
+  /// investment accounts only. Pre-fold seed for the new fold's
+  /// cumulative position dict.
+  let priorTradesModeAccountRows: [DailyBalanceAccountRow]  // new
+  /// Post-cutoff `transaction_leg` SUM rows filtered to trades-mode
+  /// investment accounts only.
+  let tradesModeAccountRows: [DailyBalanceAccountRow]       // new
   // ...
 }
 ```
 
-`investmentAccountIds` keeps its current meaning (recorded-value only) so
-that `accountsFromTransfers` continues to be populated only for the
-snapshot mode — exactly as PR #735 designed. The new field is consumed
-only by the new fold (see §4) and the assembly context (see §3).
+Pre-filtering inside `readDailyBalancesAggregation` (the synchronous
+helper that runs inside the existing single `database.read` snapshot, so
+all classifications observe one MVCC state — no need for a separate
+`database.read`) keeps `applyTradesModePositionValuations` focused on
+the cumulative-position fold and avoids duplicating the row-type filter
+across both `walkDays` and the new fold. The cost is one in-memory
+filter pass per aggregation read; row counts are bounded by the existing
+SUM aggregation (one row per `(day, account, instrument, type)`),
+typically O(thousands) for an active profile.
 
-`fetchDailyBalancesAggregation`
-(`+DailyBalancesAggregation.swift`) calls the new fetch alongside
-`fetchInvestmentAccountIds` and threads the result onto the struct.
+`investmentAccountIds` keeps its current meaning (recorded-value only) —
+exactly as PR #735 designed — and continues to drive `accountsFromTransfers`
+membership in the seed and walk steps. The new account-id set has a
+single consumer: the new fold's empty-check.
 
-### 3. Assembly context exposes both sets
+### 3. Assembly context exposes the trades-mode set
 
 Extend `DailyBalancesAssemblyContext` (`+DailyBalances.swift`) with the
 trades-mode set so the new fold can take it from a stable context object
-rather than a free parameter (matches the existing pattern of carrying
+rather than a free parameter — matches the existing pattern of carrying
 `investmentAccountIds`, `instrumentMap`, `profileInstrument`,
-`conversionService` in one struct):
+`conversionService` in one struct:
 
 ```swift
 struct DailyBalancesAssemblyContext: Sendable {
@@ -152,6 +177,18 @@ struct DailyBalancesAssemblyContext: Sendable {
 }
 ```
 
+The construction site in `assembleDailyBalances` is updated to pass the
+new field through:
+
+```swift
+let context = DailyBalancesAssemblyContext(
+  investmentAccountIds: aggregation.investmentAccountIds,
+  tradesModeInvestmentAccountIds: aggregation.tradesModeInvestmentAccountIds,
+  instrumentMap: aggregation.instrumentMap,
+  profileInstrument: profileInstrument,
+  conversionService: conversionService)
+```
+
 `seedPriorBook`, `walkDays`, and `applyDailyDeltas` continue to read only
 `investmentAccountIds` (recorded-value) for `accountsFromTransfers`
 membership — none of those helpers need to know about the trades-mode
@@ -160,13 +197,24 @@ set, because trades-mode accounts contribute via the new fold instead.
 ### 4. New fold — `applyTradesModePositionValuations`
 
 Lives next to `applyInvestmentValues` in
-`+DailyBalancesInvestmentValues.swift` so the two folds share a file (and
-a SwiftLint budget). Public entry point:
+`+DailyBalancesInvestmentValues.swift` so the two folds share a file.
+Public entry point:
 
 ```swift
+/// Per-day position-valuation fold for trades-mode investment accounts.
+/// Sister of `applyInvestmentValues` — same per-day error contract:
+/// `CancellationError` rethrows immediately; any other thrown error
+/// drops the day from `dailyBalances` and logs through
+/// `handleInvestmentValueFailure`.
+///
+/// `priorTradesModeAccountRows` and `tradesModeAccountRows` carry only
+/// rows whose `accountId` belongs to a trades-mode investment account
+/// — pre-filtered in `readDailyBalancesAggregation` so this fold
+/// neither re-checks membership nor walks rows for accounts it doesn't
+/// own.
 static func applyTradesModePositionValuations(
-  priorAccountRows: [DailyBalanceAccountRow],
-  accountRows: [DailyBalanceAccountRow],
+  priorRows: [DailyBalanceAccountRow],
+  postRows: [DailyBalanceAccountRow],
   to dailyBalances: inout [Date: DailyBalance],
   context: DailyBalancesAssemblyContext,
   handlers: DailyBalancesHandlers
@@ -175,51 +223,63 @@ static func applyTradesModePositionValuations(
 
 Algorithm:
 
-1. **Early return** if `context.tradesModeInvestmentAccountIds` is empty
-   or `dailyBalances` is empty.
-2. **Pre-fold priors** (rows with `t.date < :after`) into a per-account,
-   per-instrument cumulative dict
-   `var positions: [UUID: [Instrument: Decimal]] = [:]`. Skip rows whose
-   `accountId` is not in `tradesModeInvestmentAccountIds`. Decoding the
-   raw `Int64` `qty` → `Decimal` matches `applyDailyDeltas` exactly
-   (single `InstrumentAmount(storageValue:instrument:).quantity` step,
-   so the storage-unit semantics are pinned in one place).
-3. **Group post-cutoff rows by local-startOfDay key.** Use
-   `Calendar.current.startOfDay(for: row.sampleDate)` (matching
-   `walkDays`'s `dayKey` math — Rule 10 same-`startOfDay` normalization).
-   Skip rows whose `accountId` is not in
-   `tradesModeInvestmentAccountIds`.
+1. **Early return** if `context.tradesModeInvestmentAccountIds.isEmpty`
+   or `dailyBalances.isEmpty` (matches `applyInvestmentValues`'s guard
+   shape).
+2. **Pre-fold priors** into a per-account, per-instrument cumulative dict
+   `var positions: [UUID: [Instrument: Decimal]] = [:]`. `Instrument`
+   conforms to `Hashable` (`Domain/Models/Instrument.swift:4`); the
+   shape mirrors `PositionBook.accounts`. Decode each row's raw `Int64`
+   `qty` via `InstrumentAmount(storageValue:instrument:).quantity` —
+   same pattern as `applyDailyDeltas` so storage-unit semantics stay
+   pinned in one place.
+3. **Group post rows by UTC day-string**, mirroring `walkDays` exactly:
+   `Dictionary(grouping: postRows, by: \.day)`. The day-string is
+   `DATE(t.date)` from SQL — the indexing key. `walkDays`'s `dayKey`
+   (the local-startOfDay used as the `dailyBalances` key) is derived
+   from the group's first row's `sampleDate` via
+   `Calendar.current.startOfDay(for:)`. We use the same pattern here
+   (Rule 10 same-`startOfDay` normalization) so `dayKey` agrees with
+   the keys `walkDays` produced.
 4. **Walk `dailyBalances.keys.sorted()`** in date order. For each
    `dayKey`:
-   1. Apply the day's grouped trades-mode rows to the cumulative
-      `positions` dict.
+   1. Apply the day's grouped rows (those whose mapped `dayKey`
+      matches) to the cumulative `positions` dict.
    2. Skip the day if `positions` is empty (no trades-mode account has
-      ever held anything yet).
-   3. Convert per-account-per-instrument positions into a single
-      `InstrumentAmount` total via `sumTradesModePositions(...)` — see
-      §5. Conversion runs on `dayKey` (the day's local-startOfDay,
-      Rule 10), via the conversion service, with the Rule 8 fast path
-      for same-instrument positions.
-   4. On `CancellationError`, rethrow (no logging).
-   5. On any other thrown error,
+      ever held anything yet) — leaves the day's `DailyBalance`
+      untouched.
+   3. Inside an explicit two-catch `do { } catch let cancel as
+      CancellationError { throw cancel } catch { ... }` block (matches
+      `applyInvestmentValues`'s shape — see §10 for the literal code
+      sketch), call
+      `sumTradesModePositions(positions:on:profileInstrument:conversionService:)`
+      to obtain the day's `InstrumentAmount` total in the profile
+      instrument.
+   4. **On success:** `let combined = (existing.investmentValue ??
+      .zero(instrument: profileInstrument)) + total`; rebuild the day's
+      `DailyBalance` with `investmentValue = combined` and `netWorth =
+      balance + combined`.
+   5. **On any non-cancellation throw (Rule 11 — failing day must
+      surface as unavailable):** log via
       `handlers.handleInvestmentValueFailure(error, dayKey)` and
-      `continue` — same per-day error contract as
-      `applyInvestmentValues`.
-   6. Otherwise, **add** the converted total to the day's existing
-      `investmentValue` (which is `nil` if no snapshot fold ran for the
-      day, else the snapshot total) and recompute `netWorth = balance +
-      investmentValue`. Build a fresh `DailyBalance` (the type is a
-      struct; mutate via reconstruction).
+      `dailyBalances.removeValue(forKey: dayKey)`. The chart shows a
+      gap on that day, matching `walkDays`'s existing per-day-failure
+      contract.
 
-Per-day error contract is reused from
-`DailyBalancesHandlers.handleInvestmentValueFailure` — the existing
-callback already carries `(Error, Date)`. The new fold logs through the
-same handler; production callers route into the same `os.Logger`
-category that the snapshot fold uses.
+The `priorRows` / `postRows` parameters are deliberately *not* the
+unfiltered `aggregation.priorAccountRows` / `aggregation.accountRows`
+— they're the new pre-filtered fields from §2, named without the
+`accountRows` suffix to avoid suggesting "every account" at the call
+site. The doc comment on the entry point states the filtering contract
+explicitly.
 
 ### 5. Conversion helper — `sumTradesModePositions`
 
-Mirrors `sumInvestmentValues`, file-private:
+Mirrors `sumInvestmentValues`, file-private, **non-optional** return
+type (the `?` on `sumInvestmentValues` is vestigial — the function
+either throws or returns a value; out-of-scope to clean up the
+predecessor in this PR, but the new helper does not perpetuate the
+pattern):
 
 ```swift
 private static func sumTradesModePositions(
@@ -227,24 +287,32 @@ private static func sumTradesModePositions(
   on date: Date,
   profileInstrument: Instrument,
   conversionService: any InstrumentConversionService
-) async throws -> InstrumentAmount?
+) async throws -> InstrumentAmount
 ```
 
 For each `(accountId, [Instrument: Decimal])`, for each
 `(instrument, qty)`:
 
 - If `instrument.id == profileInstrument.id`, add `qty` to the running
-  `Decimal` total (Rule 8 fast path).
+  `Decimal` total (Rule 8 fast path — applied at the leaf level so an
+  account holding both profile-instrument and foreign-instrument
+  positions still routes only the foreign positions through the
+  service).
 - Otherwise call `conversionService.convert(qty, from: instrument, to:
   profileInstrument, on: date)` and add the result.
 
-A failed convert throws to the caller, which routes to
-`handleInvestmentValueFailure` per the per-day contract. Returns
-`InstrumentAmount(quantity: total, instrument: profileInstrument)`. On a
-warm cache the per-day cost is O(distinct instruments held that day),
-which is bounded.
+A failed convert throws to the caller (per-day error contract — see
+§4). Returns `InstrumentAmount(quantity: total, instrument:
+profileInstrument)`. On a warm cache the per-day cost is
+O(distinct instruments held that day), which is bounded.
 
-### 6. Wire the new fold into `assembleDailyBalances`
+The caller passes `dayKey` (the `startOfDay`-normalized key from §4)
+as `on:`. Add a one-line comment at the call site stating "`dayKey` is
+`Calendar.current.startOfDay(for: row.sampleDate)` — same normalization
+as `walkDays` and the conversion-service lookup" so future readers
+don't need to chase the call site to verify Rule 10.
+
+### 6. Wire into `assembleDailyBalances` and tighten the snapshot fold
 
 Inside `assembleDailyBalances` (`+DailyBalances.swift`), after the
 existing `applyInvestmentValues` call:
@@ -257,191 +325,339 @@ try await applyInvestmentValues(
   handlers: handlers)
 
 try await applyTradesModePositionValuations(
-  priorAccountRows: aggregation.priorAccountRows,
-  accountRows: aggregation.accountRows,
+  priorRows: aggregation.priorTradesModeAccountRows,
+  postRows: aggregation.tradesModeAccountRows,
   to: &dailyBalances,
   context: context,
   handlers: handlers)
 ```
 
-Order is significant only in that the second fold *adds* to whatever the
-first fold left in `investmentValue`. Either ordering would produce the
-same arithmetic total since they touch disjoint account sets and addition
-is commutative; running the new fold *after* the snapshot fold keeps the
-log message ordering consistent with the read order (snapshots → trades).
-
-`bestFit` regression runs after both folds (same line as today). The
-forecast extrapolation runs after that, unchanged — see Non-Goals on the
-forecast carve-out.
-
-### 7. Edge cases
-
-- **No trades-mode accounts in the profile.** The new fetch returns an
-  empty set; the new fold early-returns; behaviour is bit-identical to
-  today.
-- **Trades-mode account with only a transfer leg (cash deposited but
-  never traded).** The cash is in the profile instrument (or some other
-  fiat). The fold sums it via the Rule 8 fast path (or via FX
-  conversion). The day's investmentValue picks up the cash. This is
-  correct: the cash on the investment account is part of the account's
-  value.
-- **Trades-mode account with a buy on day D and no other activity.** Day
-  D appears in `dailyBalances` (walkDays sees the trade legs as account
-  rows). The fold valuates the position on day D using day D's price.
-  Days after D with other-account activity carry forward the position
-  via the cumulative dict; their valuations use that day's price.
-- **Stock not yet listed on day D (price-cache miss).** Conversion
-  throws → fold logs via `handleInvestmentValueFailure` → fold leaves
-  the day's existing `investmentValue` (snapshot fold's contribution, or
-  `nil`) untouched. The chart line for that day reflects whatever made
-  it through the snapshot fold; the trades-mode contribution drops just
-  for that day.
-- **Profile instrument changes mid-history.** Out of scope (no profile
-  flow currently allows this), and would require re-running the pipeline
-  with a new profile instrument anyway.
-- **Mixed-mode profile.** Snapshot and trades-mode accounts are
-  partitioned by `valuation_mode`; the snapshot fold reads
-  `recorded-value` accounts only; the trades fold reads
-  `calculated-from-trades` accounts only. Both fold totals add into one
-  `investmentValue` per day.
-- **Mode flip mid-window.** A user flipping an account from snapshot to
-  trades changes the SQL classification; the next pipeline run will
-  classify the account into the new set. The historic chart will
-  re-render under the new mode (snapshot contributions disappear; trades
-  contributions appear). This matches today's mode-flip semantics — same
-  surface, no special handling.
-- **Two-trade same-day (BUY + SELL on the same day).** SQL `SUM` over
-  legs grouped by `(day, account, instrument, type)` already nets these
-  in `accountRows`. The fold applies the netted row exactly once per
-  `(day, account, instrument, type)` group; cumulative state stays
-  consistent.
-
-### 8. SQL plan-pinning test
-
-Add one pinning test next to the existing daily-balance pins
-(`MoolahTests/Backends/GRDB/DailyBalancesPlanPinningTests.swift`):
+**`applyInvestmentValues` is updated in this PR** so its per-day error
+branch matches the new fold (and `walkDays`):
 
 ```swift
-@Test
-func fetchTradesModeInvestmentAccountIdsAvoidsScanWhenSelectiveOrUsesAcceptableScan() throws {
-  // ... assert plan shape matches fetchInvestmentAccountIds — both are
-  // selective small-table reads; the SQL planner typically emits
-  // SCAN account on a tiny table or USING INDEX on the account-type
-  // index if/when one exists. Either is acceptable; this test pins the
-  // plan to whatever the existing snapshot-mode predicate produces so a
-  // future regression that diverges from the established shape is
-  // visible. ...
+} catch let cancel as CancellationError {
+  throw cancel
+} catch {
+  handlers.handleInvestmentValueFailure(error, date)
+  dailyBalances.removeValue(forKey: date)  // Rule 11 — was: continue
+  continue
 }
 ```
 
-The test mirrors the existing `fetchInvestmentAccountIdsAvoidsScan…`
-pattern (or the closest equivalent in
-`DailyBalancesPlanPinningTests`) — same plan-string capture, same
-indexed-vs-scan assertion.
+Before this change, a snapshot-fold conversion failure left the day's
+`DailyBalance` untouched — the chart line at that day reflected only
+the bank-balance + transfers-only investments contribution, with no
+indication that the snapshot couldn't be computed. Per Rule 11, that's
+an incorrect partial total rendered as authoritative. Removing the day
+matches `walkDays`'s existing per-day-failure contract and ends the
+deviation called out in the round-1 instrument-conversion review.
 
-### 9. Repository contract / aggregation contract tests
+Order of the two folds is significant only for log-ordering (snapshots
+log before trades). Both folds drop the day from `dailyBalances` on
+failure; if either fold fails for a day, the day is gone from the
+result regardless of which ran first. Both folds touch disjoint account
+sets, so on the success path the additive `investmentValue` is
+order-independent.
 
-Add tests to the existing
+`applyBestFit` and the forecast tail run after both folds, both already
+iterate `dailyBalances.values` — they automatically skip dropped days.
+
+### 7. Edge cases
+
+- **No trades-mode accounts in the profile.** The pre-filter produces
+  empty arrays; the new fold early-returns; behaviour is bit-identical
+  to today.
+- **Trades-mode account with only a `.transfer` leg (cash deposited but
+  never traded).** The cash sits as a position on the investment
+  account; the fold sums it via the Rule 8 fast path (or via FX
+  conversion if the cash leg is in a non-profile fiat). The day's
+  `investmentValue` picks up the cash. This is correct — cash on an
+  investment account is part of the account's value.
+- **Trades-mode account with a buy on day D and no other activity.**
+  Day D appears in `dailyBalances` (walkDays sees the trade legs as
+  account rows). The fold valuates the position on day D using day D's
+  price. Days after D with other-account activity carry forward the
+  position via the cumulative dict; their valuations use that day's
+  price.
+- **Stock not yet listed on day D (price-cache miss).** Conversion
+  throws → fold logs via `handleInvestmentValueFailure` → fold drops
+  day D from `dailyBalances`. The chart shows a gap on D. Sibling days
+  render normally.
+- **Same-day BUY + SELL of equal quantities.** SQL `SUM` over legs
+  grouped by `(day, account, instrument, type)` does *not* net BUY vs
+  SELL (those are still both `type = 'trade'` but with opposite
+  quantities — they net inside the same group). After the cumulative
+  fold, the per-instrument quantity for the day is zero. The fold
+  sums it (zero contribution via fast path) and adds zero to
+  `investmentValue` — i.e. the day's `investmentValue` stays at
+  whatever the snapshot fold produced (or `.zero(...)` if no snapshot
+  fold ran for the day). This is correct: a day with no net position
+  change should not move `investmentValue`.
+- **Profile instrument changes mid-history.** Out of scope (no profile
+  flow currently allows this), and would require re-running the
+  pipeline with a new profile instrument anyway.
+- **Mixed-mode profile.** Snapshot and trades-mode accounts are
+  partitioned by `valuation_mode`; the snapshot fold reads
+  `recorded-value` accounts only; the trades fold reads
+  `calculated-from-trades` accounts only. Both fold totals add into
+  one `investmentValue` per day. Either fold's failure on day D drops
+  D entirely (per §6).
+- **Mode flip mid-window.** A user flipping an account from snapshot
+  to trades changes the SQL classification; the next pipeline run
+  classifies the account into the new set. The historic chart will
+  re-render under the new mode (snapshot contributions disappear;
+  trades contributions appear). This matches today's mode-flip
+  semantics — same surface, no special handling.
+
+### 8. SQL plan-pinning test
+
+Add one pinning test to `MoolahTests/Backends/GRDB/DailyBalancesPlanPinningTests.swift`,
+named symmetrically to the sibling
+`fetchInvestmentAccountIdsUsesAccountByType`:
+
+```swift
+@Test("fetchTradesModeInvestmentAccountIds uses account_by_type")
+func fetchTradesModeInvestmentAccountIdsUsesAccountByType() throws {
+  let database = try makeDatabase()
+  // Mirrors the per-account id loader driven by
+  // `GRDBAnalysisRepository.fetchTradesModeInvestmentAccountIds`. The
+  // production SQL filters on `type = 'investment'` AND
+  // `valuation_mode = 'calculatedFromTrades'`. The `account_by_type`
+  // index keys on `(type)` and serves the selective `type =
+  // 'investment'` predicate; the `valuation_mode` predicate filters
+  // the candidate rows post-seek. SQLite emits `SEARCH account USING
+  // INDEX account_by_type` for this shape, which is *not* a full
+  // table scan.
+  let detail = try planDetail(
+    database,
+    query: """
+      SELECT id FROM account
+      WHERE type = 'investment' AND valuation_mode = 'calculatedFromTrades'
+      """)
+  #expect(detail.contains("SEARCH account USING INDEX account_by_type"))
+  #expect(!PlanPinningTestHelpers.planHasFullTableScanOf(detail, alias: "account"))
+}
+```
+
+The assertion deliberately matches the sibling one-for-one — same
+index name, same scan-rejection — so a regression that diverges the
+two predicates is visible.
+
+### 9. Tests
+
+All new tests use Swift Testing per `guides/TEST_GUIDE.md`. Reuses the
+existing `DateFailingConversionService`
+(`MoolahTests/Support/DateFailingConversionService.swift`) for Rule 11
+scoping, and `DateBasedFixedConversionService` for the per-day rate
+table — no new test doubles.
+
+#### 9.1 Plan-pinning
+
+- §8: `fetchTradesModeInvestmentAccountIdsUsesAccountByType`.
+
+#### 9.2 Aggregation-layer integration
+
+Add to the existing
+`MoolahTests/Backends/GRDB/GRDBDailyBalancesAggregateTests.swift` (or
+its closest sibling):
+
+- **`fetchDailyBalancesAggregation` populates
+  `tradesModeInvestmentAccountIds`** when the profile contains a
+  trades-mode account.
+- **`fetchDailyBalancesAggregation` populates
+  `priorTradesModeAccountRows` and `tradesModeAccountRows`** with
+  *only* trades-mode account rows (sibling recorded-value account
+  rows are excluded from these fields, even though they remain in
+  `priorAccountRows` / `accountRows`).
+- **Empty-mode profile** → both fields are empty arrays.
+
+#### 9.3 Fold contract
+
+Add to
 `MoolahTests/Backends/GRDB/GRDBAnalysisRepositoryDailyBalancesTests.swift`
-(or its closest sibling) covering:
+(or its closest sibling):
 
-1. **Trades-mode account with one buy of N shares at price P on day D.**
-   Day D's `investmentValue` ≈ `N * P`. Day D+1 (if present in
-   `dailyBalances` due to other activity) carries the position forward
-   and revaluates at day D+1's price.
-2. **Two trades-mode accounts, both with positions on day D.**
+1. Trades-mode account with one buy of N shares at price P on day D
+   → day D's `investmentValue` ≈ `N * P`. Day D+1 (if present in
+   `dailyBalances`) carries the position forward and revaluates at
+   day D+1's price.
+2. Two trades-mode accounts, both with positions on day D →
    `investmentValue` sums both contributions.
-3. **One trades-mode + one recorded-value account on day D.** Day D's
+3. One trades-mode + one recorded-value account on day D → Day D's
    `investmentValue` = (recorded snapshot total) + (trades-mode
    valuation). `netWorth` reflects both.
-4. **Rule 11 per-day failure scoping** — a `DateBasedFailingConversion`
-   service that throws only on day D leaves day D's investmentValue at
-   whatever the snapshot fold produced (or `nil` if no snapshot fold)
-   and *does not* affect day D-1 or D+1. The
-   `handleInvestmentValueFailure` callback fires exactly once with
-   `(error, dayKey: D)`.
-5. **Rule 10 same-startOfDay normalization** — a trade transaction at
+4. **Rule 11 per-day failure scoping** for the new fold — a
+   `DateFailingConversionService` that throws only on day D drops day
+   D from `dailyBalances`, leaves day D-1 and D+1 intact, and fires
+   `handleInvestmentValueFailure` exactly once with `(error, dayKey:
+   D)`.
+5. **Rule 11 per-day failure scoping** for the snapshot fold (new
+   behaviour) — a snapshot-conversion failure on day D drops day D
+   from `dailyBalances`, leaves siblings intact. Pinned by the same
+   `DateFailingConversionService` shape as case 4.
+6. **Rule 11 mixed-fold failure** — when both folds run and the trades
+   fold fails on day D (the snapshot fold succeeded on D), day D is
+   dropped, sibling days unaffected.
+7. **Rule 10 same-startOfDay normalization** — a trade transaction at
    23:59:59 local on day D and a trade at 00:00:01 local on day D+1
    apply on the correct days; `Calendar.current.startOfDay`-keyed
    comparisons match `walkDays`'s key.
-6. **No trades-mode accounts ⇒ no behaviour change** — fold is a no-op;
-   `investmentValue` reflects only the snapshot fold; pinning tests for
-   the existing path stay green.
-7. **Empty `dailyBalances` ⇒ no-op** — nothing to fold over; no logger
-   output.
-8. **CSV-imported trade with a `.transfer` cash leg + a `.trade`
-   position leg.** Cumulative position picks up both legs; cash leg adds
-   via Rule 8 fast path (when in profile instrument), or FX otherwise;
-   position leg adds via stock-price conversion.
-9. **Trades-mode account that was previously in recorded mode** — flip
-   captured by next pipeline run; chart flips between contributions.
+8. **No trades-mode accounts ⇒ no behaviour change** — fold is a
+   no-op; `investmentValue` reflects only the snapshot fold; pinning
+   tests for the existing path stay green.
+9. **Empty `dailyBalances` ⇒ no-op** — nothing to fold over; no
+   logger output.
+10. **CSV-imported trade with a `.transfer` cash leg + a `.trade`
+    position leg.** Cumulative position picks up both legs; cash leg
+    adds via Rule 8 fast path (when in profile instrument), or FX
+    otherwise; position leg adds via stock-price conversion.
+11. **Same-day BUY + SELL of equal quantities** → day's net
+    contribution = zero; `investmentValue` unchanged from the
+    snapshot fold.
 
-`DateBasedFixedConversionService` is the canonical test double for
-date-sensitive conversions per
-`guides/INSTRUMENT_CONVERSION_GUIDE.md` §1; we use it (and a
-`DateBasedFailingConversion` extension) here.
+### 10. Two-catch shape (literal sketch)
 
-### 10. Logging
+Both folds use the same explicit two-catch pattern so future readers
+don't have to infer the cancellation contract from prose:
 
-The fold reuses
+```swift
+do {
+  let total = try await sumTradesModePositions(
+    positions: positions,
+    // dayKey is `Calendar.current.startOfDay(for: row.sampleDate)` —
+    // same normalization as walkDays and the conversion-service lookup.
+    on: dayKey,
+    profileInstrument: context.profileInstrument,
+    conversionService: context.conversionService)
+  guard let existing = dailyBalances[dayKey] else { continue }
+  let combined =
+    (existing.investmentValue ?? .zero(instrument: context.profileInstrument)) + total
+  dailyBalances[dayKey] = DailyBalance(
+    date: existing.date,
+    balance: existing.balance,
+    earmarked: existing.earmarked,
+    availableFunds: existing.availableFunds,
+    investments: existing.investments,
+    investmentValue: combined,
+    netWorth: existing.balance + combined,
+    bestFit: existing.bestFit,
+    isForecast: existing.isForecast)
+} catch let cancel as CancellationError {
+  throw cancel
+} catch {
+  handlers.handleInvestmentValueFailure(error, dayKey)
+  dailyBalances.removeValue(forKey: dayKey)
+  continue
+}
+```
+
+`applyInvestmentValues` is updated to match (see §6) — the only
+difference between the two folds is which input drives the per-day
+total (cumulative positions vs. carry-forward snapshots).
+
+### 11. Logging
+
+Both folds reuse
 `DailyBalancesHandlers.handleInvestmentValueFailure: @Sendable (Error,
-Date) -> Void` — same callback the snapshot fold uses. The production
-caller wires this to its existing `Logger`
-(`subsystem: "com.moolah.app", category: "GRDBAnalysisRepository"` or
-the closest existing category). No new logger category required.
+Date) -> Void`. The production caller wires this to the existing
+`Logger` (`subsystem: "com.moolah.app", category:
+"GRDBAnalysisRepository"`). No new logger category required.
 
-### 11. Performance
+`Calendar.current` is used inside the `@concurrent`
+`assembleDailyBalances` for the `startOfDay` math — Foundation's
+`Calendar` is a value type and `Calendar.current` returns a copy, so
+the access is safe in the off-main context. This matches the existing
+`walkDays` and `advanceInvestmentCursor` usage.
 
-Per-day work after the fold:
-- Pre-fold priors: O(N_priors), one-shot, where `N_priors` is the
-  number of trade-relevant pre-cutoff legs (already loaded by the
-  existing prior-rows fetch — no new SQL).
-- Per day: O(M × I) conversion calls, where M = trades-mode account
-  count and I = distinct instruments held. Warm-cache calls are O(1)
-  per (instrument, date) tuple via `StockPriceCache` /
+### 12. Performance
+
+- **Pre-filter inside `readDailyBalancesAggregation`:** O(N_total)
+  one-shot pass over the SUM rows, where `N_total` is the bounded SUM
+  row count.
+- **Pre-fold priors:** O(N_priors_trades_only).
+- **Per day:** O(M × I) conversion calls, where M = trades-mode
+  account count and I = distinct instruments held. Warm-cache calls
+  are O(1) per (instrument, date) tuple via `StockPriceCache` /
   `ExchangeRateCache` / `CryptoPriceCache`. Cold-cache calls pay one
-  round-trip per (instrument, date) — the same cost
+  round-trip per (instrument, date) — same cost
   `PositionsHistoryBuilder` already pays for the per-account chart.
 
 For a typical user (≤5 trades-mode accounts × ≤10 instruments ×
-~365 days = ~18 000 conversion calls per request) this is well within
-the cached-rate budget. We do NOT introduce parallelism (the fold uses
-sequential `await`, matching `applyInvestmentValues` and
-`PositionsHistoryBuilder`); switching to a `TaskGroup` is a
-self-contained change if profiling later shows it's user-visible.
+~365 days = ~18 000 conversion calls per request) this is well
+within the cached-rate budget. Sequential `await` in the day loop
+matches `applyInvestmentValues` and `PositionsHistoryBuilder`;
+switching to a `TaskGroup` is a self-contained change if profiling
+later shows it's user-visible.
 
 The new SQL fetch (`fetchTradesModeInvestmentAccountIds`) adds one
-small-table read inside the existing `database.read` snapshot; cost is
-the same shape as `fetchInvestmentAccountIds`.
+small-table read inside the existing `database.read` snapshot; cost
+is the same shape as `fetchInvestmentAccountIds` (resolves through
+`account_by_type`).
+
+### 13. File-size budget
+
+Current sizes:
+
+- `+DailyBalancesInvestmentValues.swift` — 195 lines.
+- `+DailyBalancesAggregation.swift` — ~330 lines.
+- `+DailyBalances.swift` — ~360 lines.
+
+The new fold (~50 lines including doc comments) plus the new helper
+(~20 lines) plus the new fetch (~15 lines) lands on
+`+DailyBalancesInvestmentValues.swift`, taking it to ~280 lines —
+well under the SwiftLint `file_length` warn threshold (400). The
+aggregation-layer wiring (one extra SQL fetch call site, two extra
+struct fields, one filter pass) lands on `+DailyBalancesAggregation.swift`
+and `+DailyBalances.swift`; both stay under threshold. The
+implementer should run `just format-check` after each commit to
+confirm.
 
 ## Out-of-Scope Followups
 
-- Tightening `applyInvestmentValues`'s pre-existing Rule 11 deviation
-  (logging + skipping the day's override on conversion failure rather
-  than dropping the entire day from `dailyBalances`).
+- Cleaning up the vestigial `?` on `sumInvestmentValues`'s return type
+  (the function effectively always returns non-nil on success; the `?`
+  is dead). The new helper avoids the same shape; the predecessor
+  cleanup is a one-liner suitable for a follow-up.
 - Extending the trades-mode contribution onto the *forecast tail* via
-  `Date()` valuation — would mirror Rule 7's service-level clamp behaviour
-  and could be added without further design.
+  `Date()` valuation — would mirror Rule 7's service-level clamp and
+  could be added without further design.
 - A persisted "valued positions over time" series (e.g. for offline
-  rendering or sync). The current design recomputes from scratch on every
-  request; persistence would only be worthwhile if profiling shows the
-  recompute is the bottleneck.
+  rendering or sync). The current design recomputes from scratch on
+  every request; persistence would only be worthwhile if profiling
+  shows the recompute is the bottleneck.
 - Parallelising the per-day conversion fan-out via `TaskGroup`.
-- Surfacing per-day "this contribution couldn't be computed" markers in
-  the chart UI itself (today the chart silently gaps a missing day; the
-  on-screen affordance is a separate UI concern).
+- A user-facing "this day's contribution couldn't be computed" /
+  "retry" affordance on the chart UI itself (today the chart silently
+  gaps days dropped by the pipeline; an on-screen retry-now indicator
+  is a separate UI concern).
 
 ## Migration & Rollout
 
-Single PR. The change is additive (one new SQL fetch + one new fold) and
-behind no flag. Existing recorded-value behaviour is unchanged.
-Trades-mode accounts gain accurate historical chart contribution
-immediately — there is no observable regression for any existing user
-because the *only* behaviour change is "trades-mode accounts now
-contribute their position-valuation series to the historical chart on
-days they previously contributed zero (or only a transfer leg)."
+Single PR. The change is additive (one new SQL fetch, one new fold,
+two new aggregation fields) plus one tightening (snapshot fold's
+per-day failure now drops the day, matching walkDays). Behind no
+flag.
 
-The rollout matches recent analysis-fold PRs:
+The snapshot-fold tightening is a small behavioural change: a
+recorded-value snapshot whose conversion fails on a given day will
+now cause that day to gap in the chart instead of rendering with a
+stale partial total. This matches `walkDays`'s pre-existing
+per-day-failure contract, brings the daily-balance pipeline into
+Rule 11 compliance, and is the right behaviour given the chart's
+"missing day = visible gap" semantics. No tests rely on the old
+behaviour (`MoolahTests/Backends/GRDB/GRDBDailyBalancesAssembleTests`
+asserts `handleInvestmentValueFailure` is invoked but doesn't
+assert the day is retained); the new tests in §9.3 case 5 pin the
+new behaviour.
+
+Trades-mode accounts gain accurate historical chart contribution
+immediately — there is no observable regression for any existing
+user because the *only* behaviour change for trades-mode is "now
+contribute their position-valuation series to the historical chart
+on days they previously contributed zero (or only a transfer leg)."
+
+Rollout matches recent analysis-fold PRs:
 
 1. Open the PR against `main`.
 2. Run `code-review`, `database-code-review`,

--- a/plans/2026-05-04-trades-mode-historical-net-worth-design.md
+++ b/plans/2026-05-04-trades-mode-historical-net-worth-design.md
@@ -250,31 +250,51 @@ positions on every following day.
       same pattern as `applyDailyDeltas` so storage-unit semantics
       stay pinned in one place.
    3. `positions[row.accountId, default: [:]][instrument, default: 0] += quantity`.
-3. **Build a sorted cursor over post rows.** Decode each `postRow` into
-   an internal `(dayKey: Date, accountId: UUID, instrument: Instrument,
-   quantity: Decimal)` tuple, where
-   `dayKey = Calendar.current.startOfDay(for: row.sampleDate)`. Sort
-   the array by `dayKey` ascending. This is the new fold's equivalent
-   of `applyInvestmentValues`'s sorted `[InvestmentValueSnapshot]` — a
-   pre-built, instrument-resolved, dayKey-keyed cursor that the walk
-   advances through. Grouping by the SQL `\.day` UTC string is
-   intentionally avoided here: the new fold's outer iteration is over
-   local `Date` keys, and matching UTC day-strings to local-startOfDay
-   keys would re-introduce the Rule 10 timezone bug. Building the
-   cursor at `dayKey` granularity directly removes the mismatch.
+3. **Build a sorted cursor over post rows.** Decode each `postRow`
+   into a file-private struct (four fields exceeds SwiftLint's
+   `large_tuple` error threshold of 3, so a tuple is not viable):
+
+   ```swift
+   private struct TradesModePositionEntry {
+     let dayKey: Date
+     let accountId: UUID
+     let instrument: Instrument
+     let quantity: Decimal
+   }
+   ```
+
+   `dayKey = Calendar.current.startOfDay(for: row.sampleDate)`;
+   `instrument = resolveInstrument(row.instrumentId, in: context.instrumentMap)`;
+   `quantity = InstrumentAmount(storageValue: row.qty, instrument: instrument).quantity`.
+   Sort the resulting `[TradesModePositionEntry]` by `dayKey`
+   ascending — `entries.sort { $0.dayKey < $1.dayKey }` reads more
+   clearly than the equivalent tuple-positional sort. This is the new
+   fold's equivalent of `applyInvestmentValues`'s sorted
+   `[InvestmentValueSnapshot]` — a pre-built, instrument-resolved,
+   dayKey-keyed cursor that the walk advances through. Grouping by
+   the SQL `\.day` UTC string is intentionally avoided here: the new
+   fold's outer iteration is over local `Date` keys, and matching
+   UTC day-strings to local-startOfDay keys would re-introduce the
+   Rule 10 timezone bug. Building the cursor at `dayKey` granularity
+   directly removes the mismatch.
 4. **Walk `dailyBalances.keys.sorted()`** in date order. Maintain a
-   cursor index `valueIndex` over the sorted post-row tuples. For each
+   cursor index `valueIndex` over the sorted entries array. For each
    `dayKey`:
-   1. **Advance the cursor:** while `valueIndex < tuples.count` and
-      `tuples[valueIndex].dayKey <= dayKey`, apply
-      `positions[t.accountId, default: [:]][t.instrument, default: 0] += t.quantity`
-      and `valueIndex += 1`. This applies *every* trades-mode row
+   1. **Advance the cursor:** while `valueIndex < entries.count` and
+      `entries[valueIndex].dayKey <= dayKey`, apply
+      `positions[entry.accountId, default: [:]][entry.instrument, default: 0] += entry.quantity`
+      and `valueIndex += 1`. This applies *every* trades-mode entry
       whose `dayKey` is on-or-before the current outer `dayKey`,
-      including rows for days that are not themselves in
+      including entries for days that are not themselves in
       `dailyBalances` (the carry-forward correctness fix).
-   2. Skip the rest of this iteration if `positions` is empty (no
-      trades-mode account has ever held anything yet) — leaves the
-      day's `DailyBalance` untouched.
+   2. Skip the rest of this iteration if `positions` is empty — i.e.
+      no priors have been seeded *and* no entries have been advanced
+      yet (`priorRows` was empty for this profile, and no post entry
+      has `dayKey ≤ current dayKey`). Once any quantity has been
+      added, the per-instrument inner dict retains the key even when
+      a same-day BUY+SELL drives that instrument's quantity to zero,
+      so this guard primarily skips early days before the profile's
+      first trade.
    3. Inside the explicit two-catch block from §10, call
       `sumTradesModePositions(positions:on:profileInstrument:conversionService:)`
       to obtain the day's `InstrumentAmount` total in the profile
@@ -294,7 +314,7 @@ positions on every following day.
       `dailyBalances.removeValue(forKey: dayKey)`. The chart shows a
       gap on that day, matching `walkDays`'s existing per-day-failure
       contract.
-5. **After the outer walk completes**, any tail tuples whose `dayKey`
+5. **After the outer walk completes**, any tail entries whose `dayKey`
    exceeds every `dailyBalances` key are intentionally not visited.
    They cannot affect any output because no `dailyBalances` entry on
    or after them exists. (The bestFit / forecast steps run on the
@@ -385,16 +405,18 @@ try await applyTradesModePositionValuations(
   handlers: handlers)
 ```
 
-**`applyInvestmentValues` is updated in this PR** so its per-day error
-branch matches the new fold (and `walkDays`). Concretely:
+**`applyInvestmentValues` is updated in this PR** in two coordinated
+ways: (a) the per-day error branch matches the new fold (and
+`walkDays`); (b) the `sumInvestmentValues` return-type cleanup from §5
+ripples into the caller's optional-bind. Concretely:
 
 - The existing two-catch block at lines 130–135 of
   `+DailyBalancesInvestmentValues.swift` already has the right shape
   (`catch let cancel as CancellationError { throw cancel } catch
   { ... }`); the only diff is in the second catch's body.
-- **Before:** the second catch was
+- **Catch-branch — Before:**
   `handlers.handleInvestmentValueFailure(error, date); continue`.
-- **After:**
+- **Catch-branch — After:**
   ```swift
   catch {
     handlers.handleInvestmentValueFailure(error, date)
@@ -402,9 +424,39 @@ branch matches the new fold (and `walkDays`). Concretely:
     continue
   }
   ```
-- The success-path guard `guard let totalValue, let balance =
-  dailyBalances[date] else { continue }` (line 136) is unchanged —
-  not affected by this fix.
+- **Return-type cleanup — Before** (lines 122–136):
+  ```swift
+  let totalValue: InstrumentAmount?
+  do {
+    totalValue = try await sumInvestmentValues(...)
+  } catch let cancel as CancellationError {
+    throw cancel
+  } catch {
+    handlers.handleInvestmentValueFailure(error, date)
+    continue
+  }
+  guard let totalValue, let balance = dailyBalances[date] else { continue }
+  ```
+- **Return-type cleanup — After** (the `?` on `sumInvestmentValues`'s
+  return type is dropped per §5; `totalValue` becomes non-optional and
+  the guard simplifies):
+  ```swift
+  let totalValue: InstrumentAmount
+  do {
+    totalValue = try await sumInvestmentValues(...)
+  } catch let cancel as CancellationError {
+    throw cancel
+  } catch {
+    handlers.handleInvestmentValueFailure(error, date)
+    dailyBalances.removeValue(forKey: date)  // Rule 11
+    continue
+  }
+  guard let balance = dailyBalances[date] else { continue }
+  ```
+
+The implementer must apply both diffs together — the catch-branch
+addition alone leaves a partial fix; the return-type alone does not
+satisfy Rule 11.
 
 Before this change, a snapshot-fold conversion failure left the day's
 `DailyBalance` untouched — the chart line at that day reflected only
@@ -562,7 +614,10 @@ Add to
    `DateFailingConversionService` that throws only on day D drops day
    D from `dailyBalances`, leaves day D-1 and D+1 intact, and fires
    `handleInvestmentValueFailure` exactly once with `(error, dayKey:
-   D)`.
+   D)`. Call counts and arguments are captured via a closure-captured
+   `var failures: [(Error, Date)] = []` hoisted before the
+   `DailyBalancesHandlers` construction (same pattern as
+   `GRDBDailyBalancesAssembleTests`'s `FailureLog`).
 5. **Rule 11 per-day failure scoping** for the snapshot fold (new
    behaviour) — a snapshot-conversion failure on day D drops day D
    from `dailyBalances`, leaves siblings intact. Pinned by the same
@@ -578,7 +633,10 @@ Add to
    no-op; `investmentValue` reflects only the snapshot fold; pinning
    tests for the existing path stay green.
 9. **Empty `dailyBalances` ⇒ no-op** — nothing to fold over; no
-   logger output.
+   `handleInvestmentValueFailure` callback fires (verified via the
+   closure-captured counter pattern used by sibling tests in
+   `GRDBDailyBalancesAssembleTests` — a local `var failures = 0`
+   hoisted before the `DailyBalancesHandlers` construction).
 10. **CSV-imported trade with a `.transfer` cash leg + a `.trade`
     position leg.** A profile-instrument cash transfer of `C` and a
     same-day trade buying `N` shares of an instrument priced `P` on

--- a/plans/2026-05-04-trades-mode-historical-net-worth-design.md
+++ b/plans/2026-05-04-trades-mode-historical-net-worth-design.md
@@ -1,0 +1,452 @@
+# Trades-Mode Historical Net-Worth Contribution — Design
+
+**Date:** 2026-05-04
+**Status:** Draft, pending review
+**Tracking issue:** [#738](https://github.com/ajsutton/moolah-native/issues/738)
+**Predecessor:**
+[`plans/completed/2026-05-04-per-account-valuation-mode-design.md`](completed/2026-05-04-per-account-valuation-mode-design.md)
+(Pre-Existing Limitation: Historical Chart, plus §5e).
+
+## Scope
+
+Make trades-mode investment accounts contribute correctly to the historical
+net-worth chart by adding a per-day "valued positions over time" fold. For
+each trades-mode investment account, compute the held positions
+(per-instrument quantities) cumulative through each historical day with
+activity, valuate each instrument quantity in the profile instrument using
+the historical price for that day (per
+`guides/INSTRUMENT_CONVERSION_GUIDE.md` Rule 5), and add the result into the
+day's `DailyBalance.investmentValue` and `netWorth`.
+
+The current value (today's number) is already correct for trades-mode
+accounts via `PositionsValuator`; only the *historical series* is broken.
+
+## Motivation
+
+PR series #731–#736 introduced the per-account `ValuationMode` toggle
+(`recordedValue` / `calculatedFromTrades`). PR #735 wired the daily-balance
+fold to filter `fetchInvestmentAccountIds` by mode so trades-mode accounts
+no longer leak stale snapshots into the historical chart. This left a
+documented hole: there is no equivalent fold for *trade-derived position
+market values over time*. A trades-mode account with no snapshots and only
+trades silently contributes zero (or only the cash transfer leg of each
+trade) to the historical net-worth chart. The chart is therefore
+inaccurate for any user who:
+
+- imports trades from CSV into a fresh investment account, then flips it to
+  trades mode, **or**
+- creates a new investment account (which now defaults to
+  `.calculatedFromTrades` after PR #736).
+
+Issue #738 calls this out as the natural next step now that the toggle
+itself is shipped and stable.
+
+## Goals
+
+- For every trades-mode investment account, the historical net-worth chart
+  reflects the value of its held positions on every historical day with
+  activity, using historical prices for that day.
+- Snapshot-mode accounts continue to contribute via the existing
+  `applyInvestmentValues` fold without behavioural change.
+- Mixed-mode profiles (some accounts in each mode) sum both contributions
+  cleanly into a single `investmentValue` per day.
+- Per-day Rule 11 contract for the new fold matches the existing
+  `applyInvestmentValues` pattern (log + skip the override on per-day
+  conversion failure; `CancellationError` rethrows immediately). This is a
+  conscious match of the in-tree pattern; tightening Rule 11 compliance
+  for the daily-balance pipeline is a separate concern (see Out-of-Scope).
+- All historical conversions go through `InstrumentConversionService` on
+  the day's `Date` (Rule 5 / Rule 10 / Rule 8 fast path).
+- SQL plan-pinning maintained — no new full table scans introduced; the
+  new SELECT mirrors the existing snapshot-mode predicate and uses the
+  same shape.
+
+## Non-Goals
+
+- **No change to the forecast tail.** Forecast days continue to use the
+  `generateForecast` extrapolation. Trades-mode accounts do not contribute
+  to forecast days under this change. (Trade transactions are not
+  recurring, so the forecast pipeline never sees them; today's positions
+  carry forward to the forecast tail only via the existing position-book
+  state, which the forecast already handles for non-investment accounts.)
+- **No new conversion service.** The fold uses the existing
+  `InstrumentConversionService` — same path that
+  `PositionsHistoryBuilder` and `PositionsValuator` already use.
+- **No change to `PositionsValuator`.** The current-value path is
+  unchanged.
+- **No change to `applyInvestmentValues`** (the snapshot fold).
+- **No change to per-account chart on `InvestmentAccountView`**
+  (`PositionsHistoryBuilder` already covers it).
+- **No tightening of `applyInvestmentValues`'s pre-existing Rule 11
+  deviation** (it logs + leaves the day's investmentValue at whatever
+  walkDays produced, rather than dropping the day from the dict). The new
+  fold matches that pattern for consistency; a separate issue can address
+  Rule 11 compliance for the entire daily-balance pipeline.
+- **No new `Position`-history schema or persisted series.** The series is
+  computed Swift-side per request from the existing `transaction_leg`
+  rows (same source of truth as `walkDays` itself), so there is no new
+  persisted state, no new sync surface, and no new migration.
+
+## Design
+
+### 1. New SQL fetch — trades-mode investment account ids
+
+Add a sibling of `fetchInvestmentAccountIds`
+(`Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesInvestmentValues.swift`):
+
+```swift
+static func fetchTradesModeInvestmentAccountIds(database: Database) throws -> Set<UUID> {
+  let rows = try Row.fetchAll(
+    database,
+    sql: """
+      SELECT id FROM account
+      WHERE type = 'investment' AND valuation_mode = 'calculatedFromTrades'
+      """)
+  // ... same decode as fetchInvestmentAccountIds ...
+}
+```
+
+The two SELECTs differ only on the `valuation_mode = '…'` literal — kept
+as a separate function for `guides/DATABASE_CODE_GUIDE.md` §4 (no
+dynamically composed `sql:` arguments). The plan is the same shape as
+`fetchInvestmentAccountIds` (a small-table scan); no new index required.
+
+### 2. Aggregation type carries both account-id sets
+
+Extend `DailyBalancesAggregation`
+(`+DailyBalances.swift`) with one extra field:
+
+```swift
+struct DailyBalancesAggregation: Sendable {
+  // existing fields ...
+  let investmentAccountIds: Set<UUID>            // recorded-value (existing)
+  let tradesModeInvestmentAccountIds: Set<UUID>  // new
+  // ...
+}
+```
+
+`investmentAccountIds` keeps its current meaning (recorded-value only) so
+that `accountsFromTransfers` continues to be populated only for the
+snapshot mode — exactly as PR #735 designed. The new field is consumed
+only by the new fold (see §4) and the assembly context (see §3).
+
+`fetchDailyBalancesAggregation`
+(`+DailyBalancesAggregation.swift`) calls the new fetch alongside
+`fetchInvestmentAccountIds` and threads the result onto the struct.
+
+### 3. Assembly context exposes both sets
+
+Extend `DailyBalancesAssemblyContext` (`+DailyBalances.swift`) with the
+trades-mode set so the new fold can take it from a stable context object
+rather than a free parameter (matches the existing pattern of carrying
+`investmentAccountIds`, `instrumentMap`, `profileInstrument`,
+`conversionService` in one struct):
+
+```swift
+struct DailyBalancesAssemblyContext: Sendable {
+  let investmentAccountIds: Set<UUID>            // recorded-value (existing)
+  let tradesModeInvestmentAccountIds: Set<UUID>  // new
+  let instrumentMap: [String: Instrument]
+  let profileInstrument: Instrument
+  let conversionService: any InstrumentConversionService
+}
+```
+
+`seedPriorBook`, `walkDays`, and `applyDailyDeltas` continue to read only
+`investmentAccountIds` (recorded-value) for `accountsFromTransfers`
+membership — none of those helpers need to know about the trades-mode
+set, because trades-mode accounts contribute via the new fold instead.
+
+### 4. New fold — `applyTradesModePositionValuations`
+
+Lives next to `applyInvestmentValues` in
+`+DailyBalancesInvestmentValues.swift` so the two folds share a file (and
+a SwiftLint budget). Public entry point:
+
+```swift
+static func applyTradesModePositionValuations(
+  priorAccountRows: [DailyBalanceAccountRow],
+  accountRows: [DailyBalanceAccountRow],
+  to dailyBalances: inout [Date: DailyBalance],
+  context: DailyBalancesAssemblyContext,
+  handlers: DailyBalancesHandlers
+) async throws
+```
+
+Algorithm:
+
+1. **Early return** if `context.tradesModeInvestmentAccountIds` is empty
+   or `dailyBalances` is empty.
+2. **Pre-fold priors** (rows with `t.date < :after`) into a per-account,
+   per-instrument cumulative dict
+   `var positions: [UUID: [Instrument: Decimal]] = [:]`. Skip rows whose
+   `accountId` is not in `tradesModeInvestmentAccountIds`. Decoding the
+   raw `Int64` `qty` → `Decimal` matches `applyDailyDeltas` exactly
+   (single `InstrumentAmount(storageValue:instrument:).quantity` step,
+   so the storage-unit semantics are pinned in one place).
+3. **Group post-cutoff rows by local-startOfDay key.** Use
+   `Calendar.current.startOfDay(for: row.sampleDate)` (matching
+   `walkDays`'s `dayKey` math — Rule 10 same-`startOfDay` normalization).
+   Skip rows whose `accountId` is not in
+   `tradesModeInvestmentAccountIds`.
+4. **Walk `dailyBalances.keys.sorted()`** in date order. For each
+   `dayKey`:
+   1. Apply the day's grouped trades-mode rows to the cumulative
+      `positions` dict.
+   2. Skip the day if `positions` is empty (no trades-mode account has
+      ever held anything yet).
+   3. Convert per-account-per-instrument positions into a single
+      `InstrumentAmount` total via `sumTradesModePositions(...)` — see
+      §5. Conversion runs on `dayKey` (the day's local-startOfDay,
+      Rule 10), via the conversion service, with the Rule 8 fast path
+      for same-instrument positions.
+   4. On `CancellationError`, rethrow (no logging).
+   5. On any other thrown error,
+      `handlers.handleInvestmentValueFailure(error, dayKey)` and
+      `continue` — same per-day error contract as
+      `applyInvestmentValues`.
+   6. Otherwise, **add** the converted total to the day's existing
+      `investmentValue` (which is `nil` if no snapshot fold ran for the
+      day, else the snapshot total) and recompute `netWorth = balance +
+      investmentValue`. Build a fresh `DailyBalance` (the type is a
+      struct; mutate via reconstruction).
+
+Per-day error contract is reused from
+`DailyBalancesHandlers.handleInvestmentValueFailure` — the existing
+callback already carries `(Error, Date)`. The new fold logs through the
+same handler; production callers route into the same `os.Logger`
+category that the snapshot fold uses.
+
+### 5. Conversion helper — `sumTradesModePositions`
+
+Mirrors `sumInvestmentValues`, file-private:
+
+```swift
+private static func sumTradesModePositions(
+  positions: [UUID: [Instrument: Decimal]],
+  on date: Date,
+  profileInstrument: Instrument,
+  conversionService: any InstrumentConversionService
+) async throws -> InstrumentAmount?
+```
+
+For each `(accountId, [Instrument: Decimal])`, for each
+`(instrument, qty)`:
+
+- If `instrument.id == profileInstrument.id`, add `qty` to the running
+  `Decimal` total (Rule 8 fast path).
+- Otherwise call `conversionService.convert(qty, from: instrument, to:
+  profileInstrument, on: date)` and add the result.
+
+A failed convert throws to the caller, which routes to
+`handleInvestmentValueFailure` per the per-day contract. Returns
+`InstrumentAmount(quantity: total, instrument: profileInstrument)`. On a
+warm cache the per-day cost is O(distinct instruments held that day),
+which is bounded.
+
+### 6. Wire the new fold into `assembleDailyBalances`
+
+Inside `assembleDailyBalances` (`+DailyBalances.swift`), after the
+existing `applyInvestmentValues` call:
+
+```swift
+try await applyInvestmentValues(
+  aggregation.investmentValues,
+  to: &dailyBalances,
+  context: context,
+  handlers: handlers)
+
+try await applyTradesModePositionValuations(
+  priorAccountRows: aggregation.priorAccountRows,
+  accountRows: aggregation.accountRows,
+  to: &dailyBalances,
+  context: context,
+  handlers: handlers)
+```
+
+Order is significant only in that the second fold *adds* to whatever the
+first fold left in `investmentValue`. Either ordering would produce the
+same arithmetic total since they touch disjoint account sets and addition
+is commutative; running the new fold *after* the snapshot fold keeps the
+log message ordering consistent with the read order (snapshots → trades).
+
+`bestFit` regression runs after both folds (same line as today). The
+forecast extrapolation runs after that, unchanged — see Non-Goals on the
+forecast carve-out.
+
+### 7. Edge cases
+
+- **No trades-mode accounts in the profile.** The new fetch returns an
+  empty set; the new fold early-returns; behaviour is bit-identical to
+  today.
+- **Trades-mode account with only a transfer leg (cash deposited but
+  never traded).** The cash is in the profile instrument (or some other
+  fiat). The fold sums it via the Rule 8 fast path (or via FX
+  conversion). The day's investmentValue picks up the cash. This is
+  correct: the cash on the investment account is part of the account's
+  value.
+- **Trades-mode account with a buy on day D and no other activity.** Day
+  D appears in `dailyBalances` (walkDays sees the trade legs as account
+  rows). The fold valuates the position on day D using day D's price.
+  Days after D with other-account activity carry forward the position
+  via the cumulative dict; their valuations use that day's price.
+- **Stock not yet listed on day D (price-cache miss).** Conversion
+  throws → fold logs via `handleInvestmentValueFailure` → fold leaves
+  the day's existing `investmentValue` (snapshot fold's contribution, or
+  `nil`) untouched. The chart line for that day reflects whatever made
+  it through the snapshot fold; the trades-mode contribution drops just
+  for that day.
+- **Profile instrument changes mid-history.** Out of scope (no profile
+  flow currently allows this), and would require re-running the pipeline
+  with a new profile instrument anyway.
+- **Mixed-mode profile.** Snapshot and trades-mode accounts are
+  partitioned by `valuation_mode`; the snapshot fold reads
+  `recorded-value` accounts only; the trades fold reads
+  `calculated-from-trades` accounts only. Both fold totals add into one
+  `investmentValue` per day.
+- **Mode flip mid-window.** A user flipping an account from snapshot to
+  trades changes the SQL classification; the next pipeline run will
+  classify the account into the new set. The historic chart will
+  re-render under the new mode (snapshot contributions disappear; trades
+  contributions appear). This matches today's mode-flip semantics — same
+  surface, no special handling.
+- **Two-trade same-day (BUY + SELL on the same day).** SQL `SUM` over
+  legs grouped by `(day, account, instrument, type)` already nets these
+  in `accountRows`. The fold applies the netted row exactly once per
+  `(day, account, instrument, type)` group; cumulative state stays
+  consistent.
+
+### 8. SQL plan-pinning test
+
+Add one pinning test next to the existing daily-balance pins
+(`MoolahTests/Backends/GRDB/DailyBalancesPlanPinningTests.swift`):
+
+```swift
+@Test
+func fetchTradesModeInvestmentAccountIdsAvoidsScanWhenSelectiveOrUsesAcceptableScan() throws {
+  // ... assert plan shape matches fetchInvestmentAccountIds — both are
+  // selective small-table reads; the SQL planner typically emits
+  // SCAN account on a tiny table or USING INDEX on the account-type
+  // index if/when one exists. Either is acceptable; this test pins the
+  // plan to whatever the existing snapshot-mode predicate produces so a
+  // future regression that diverges from the established shape is
+  // visible. ...
+}
+```
+
+The test mirrors the existing `fetchInvestmentAccountIdsAvoidsScan…`
+pattern (or the closest equivalent in
+`DailyBalancesPlanPinningTests`) — same plan-string capture, same
+indexed-vs-scan assertion.
+
+### 9. Repository contract / aggregation contract tests
+
+Add tests to the existing
+`MoolahTests/Backends/GRDB/GRDBAnalysisRepositoryDailyBalancesTests.swift`
+(or its closest sibling) covering:
+
+1. **Trades-mode account with one buy of N shares at price P on day D.**
+   Day D's `investmentValue` ≈ `N * P`. Day D+1 (if present in
+   `dailyBalances` due to other activity) carries the position forward
+   and revaluates at day D+1's price.
+2. **Two trades-mode accounts, both with positions on day D.**
+   `investmentValue` sums both contributions.
+3. **One trades-mode + one recorded-value account on day D.** Day D's
+   `investmentValue` = (recorded snapshot total) + (trades-mode
+   valuation). `netWorth` reflects both.
+4. **Rule 11 per-day failure scoping** — a `DateBasedFailingConversion`
+   service that throws only on day D leaves day D's investmentValue at
+   whatever the snapshot fold produced (or `nil` if no snapshot fold)
+   and *does not* affect day D-1 or D+1. The
+   `handleInvestmentValueFailure` callback fires exactly once with
+   `(error, dayKey: D)`.
+5. **Rule 10 same-startOfDay normalization** — a trade transaction at
+   23:59:59 local on day D and a trade at 00:00:01 local on day D+1
+   apply on the correct days; `Calendar.current.startOfDay`-keyed
+   comparisons match `walkDays`'s key.
+6. **No trades-mode accounts ⇒ no behaviour change** — fold is a no-op;
+   `investmentValue` reflects only the snapshot fold; pinning tests for
+   the existing path stay green.
+7. **Empty `dailyBalances` ⇒ no-op** — nothing to fold over; no logger
+   output.
+8. **CSV-imported trade with a `.transfer` cash leg + a `.trade`
+   position leg.** Cumulative position picks up both legs; cash leg adds
+   via Rule 8 fast path (when in profile instrument), or FX otherwise;
+   position leg adds via stock-price conversion.
+9. **Trades-mode account that was previously in recorded mode** — flip
+   captured by next pipeline run; chart flips between contributions.
+
+`DateBasedFixedConversionService` is the canonical test double for
+date-sensitive conversions per
+`guides/INSTRUMENT_CONVERSION_GUIDE.md` §1; we use it (and a
+`DateBasedFailingConversion` extension) here.
+
+### 10. Logging
+
+The fold reuses
+`DailyBalancesHandlers.handleInvestmentValueFailure: @Sendable (Error,
+Date) -> Void` — same callback the snapshot fold uses. The production
+caller wires this to its existing `Logger`
+(`subsystem: "com.moolah.app", category: "GRDBAnalysisRepository"` or
+the closest existing category). No new logger category required.
+
+### 11. Performance
+
+Per-day work after the fold:
+- Pre-fold priors: O(N_priors), one-shot, where `N_priors` is the
+  number of trade-relevant pre-cutoff legs (already loaded by the
+  existing prior-rows fetch — no new SQL).
+- Per day: O(M × I) conversion calls, where M = trades-mode account
+  count and I = distinct instruments held. Warm-cache calls are O(1)
+  per (instrument, date) tuple via `StockPriceCache` /
+  `ExchangeRateCache` / `CryptoPriceCache`. Cold-cache calls pay one
+  round-trip per (instrument, date) — the same cost
+  `PositionsHistoryBuilder` already pays for the per-account chart.
+
+For a typical user (≤5 trades-mode accounts × ≤10 instruments ×
+~365 days = ~18 000 conversion calls per request) this is well within
+the cached-rate budget. We do NOT introduce parallelism (the fold uses
+sequential `await`, matching `applyInvestmentValues` and
+`PositionsHistoryBuilder`); switching to a `TaskGroup` is a
+self-contained change if profiling later shows it's user-visible.
+
+The new SQL fetch (`fetchTradesModeInvestmentAccountIds`) adds one
+small-table read inside the existing `database.read` snapshot; cost is
+the same shape as `fetchInvestmentAccountIds`.
+
+## Out-of-Scope Followups
+
+- Tightening `applyInvestmentValues`'s pre-existing Rule 11 deviation
+  (logging + skipping the day's override on conversion failure rather
+  than dropping the entire day from `dailyBalances`).
+- Extending the trades-mode contribution onto the *forecast tail* via
+  `Date()` valuation — would mirror Rule 7's service-level clamp behaviour
+  and could be added without further design.
+- A persisted "valued positions over time" series (e.g. for offline
+  rendering or sync). The current design recomputes from scratch on every
+  request; persistence would only be worthwhile if profiling shows the
+  recompute is the bottleneck.
+- Parallelising the per-day conversion fan-out via `TaskGroup`.
+- Surfacing per-day "this contribution couldn't be computed" markers in
+  the chart UI itself (today the chart silently gaps a missing day; the
+  on-screen affordance is a separate UI concern).
+
+## Migration & Rollout
+
+Single PR. The change is additive (one new SQL fetch + one new fold) and
+behind no flag. Existing recorded-value behaviour is unchanged.
+Trades-mode accounts gain accurate historical chart contribution
+immediately — there is no observable regression for any existing user
+because the *only* behaviour change is "trades-mode accounts now
+contribute their position-valuation series to the historical chart on
+days they previously contributed zero (or only a transfer leg)."
+
+The rollout matches recent analysis-fold PRs:
+
+1. Open the PR against `main`.
+2. Run `code-review`, `database-code-review`,
+   `instrument-conversion-review`, `concurrency-review` agents per
+   project policy.
+3. Add to the merge queue via the `merge-queue` skill.
+
+No CloudKit schema change. No GRDB migration. No new sync surface.

--- a/plans/2026-05-04-trades-mode-historical-net-worth-design.md
+++ b/plans/2026-05-04-trades-mode-historical-net-worth-design.md
@@ -633,10 +633,10 @@ Add to
    no-op; `investmentValue` reflects only the snapshot fold; pinning
    tests for the existing path stay green.
 9. **Empty `dailyBalances` ⇒ no-op** — nothing to fold over; no
-   `handleInvestmentValueFailure` callback fires (verified via the
-   closure-captured counter pattern used by sibling tests in
-   `GRDBDailyBalancesAssembleTests` — a local `var failures = 0`
-   hoisted before the `DailyBalancesHandlers` construction).
+   `handleInvestmentValueFailure` callback fires. Asserted via the
+   same closure-captured `var failures: [(Error, Date)] = []`
+   pattern as case 4 (`#expect(failures.isEmpty)`) so the two cases
+   share one mechanism rather than diverging on counter shape.
 10. **CSV-imported trade with a `.transfer` cash leg + a `.trade`
     position leg.** A profile-instrument cash transfer of `C` and a
     same-day trade buying `N` shares of an instrument priced `P` on

--- a/plans/2026-05-04-trades-mode-historical-net-worth-plan.md
+++ b/plans/2026-05-04-trades-mode-historical-net-worth-plan.md
@@ -1,0 +1,1838 @@
+# Trades-Mode Historical Net-Worth Fold — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a per-day "valued positions over time" fold so trades-mode
+investment accounts contribute correctly to the historical net-worth
+chart. In the same change, tighten `applyInvestmentValues` for Rule 11
+compliance and drop the vestigial `?` on its `sumInvestmentValues`
+helper. Closes [#738](https://github.com/ajsutton/moolah-native/issues/738).
+
+**Architecture:** Mirror `applyInvestmentValues`/`advanceInvestmentCursor`
+exactly: pre-filter trades-mode rows in `readDailyBalancesAggregation`,
+build a sorted per-(dayKey, account, instrument, quantity) cursor inside
+the new fold, walk `dailyBalances.keys.sorted()` advancing the cursor
+through entries on-or-before each day, valuate via
+`InstrumentConversionService.convert(...)` on the day's `dayKey`, add
+the result onto `DailyBalance.investmentValue` and recompute `netWorth`.
+Per-day failures drop the day from `dailyBalances`; `CancellationError`
+rethrows.
+
+**Tech Stack:** Swift 6, GRDB, `swift-format`, SwiftLint, Swift Testing,
+`InstrumentConversionService`, `os.Logger`. Build via `just`. Reference
+spec:
+[`plans/2026-05-04-trades-mode-historical-net-worth-design.md`](2026-05-04-trades-mode-historical-net-worth-design.md).
+
+---
+
+## File Map
+
+**Production (modify):**
+
+- `Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalances.swift`
+  - Extend `DailyBalancesAggregation` with `tradesModeInvestmentAccountIds`,
+    `priorTradesModeAccountRows`, `tradesModeAccountRows`.
+  - Extend `DailyBalancesAssemblyContext` with
+    `tradesModeInvestmentAccountIds`.
+  - Update `assembleDailyBalances` to pass the new field through the
+    context construction and call the new fold after
+    `applyInvestmentValues`.
+- `Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesAggregation.swift`
+  - Call `fetchTradesModeInvestmentAccountIds` inside
+    `readDailyBalancesAggregation`.
+  - Pre-filter the existing prior/post account-row arrays into the new
+    trades-mode-only fields.
+- `Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesInvestmentValues.swift`
+  - Add `fetchTradesModeInvestmentAccountIds`.
+  - Add `applyTradesModePositionValuations` and its helpers
+    (`TradesModePositionEntry`, `sumTradesModePositions`).
+  - Drop the vestigial `?` on `sumInvestmentValues`'s return type.
+  - Update `applyInvestmentValues` to drop the day from `dailyBalances`
+    on per-day conversion failure (Rule 11) and update its
+    `sumInvestmentValues` call site to the non-optional return.
+
+**Tests (create / modify):**
+
+- `MoolahTests/Backends/GRDB/DailyBalancesPlanPinningTests.swift`
+  - Add `fetchTradesModeInvestmentAccountIdsUsesAccountByType`.
+- `MoolahTests/Backends/GRDB/GRDBDailyBalancesAggregateTests.swift`
+  - Add tests covering the three new fields populated by
+    `fetchDailyBalancesAggregation`. (If the file does not exist, create
+    it; otherwise extend.)
+- `MoolahTests/Backends/GRDB/GRDBDailyBalancesTradesModeTests.swift`
+  - **New file.** Holds the 12 fold-contract tests from the spec
+    (§9.3).
+- `MoolahTests/Backends/GRDB/GRDBDailyBalancesAssembleTests.swift`
+  - Add a Rule 11 test for the snapshot-fold tightening (case 5 from
+    spec §9.3).
+- `MoolahTests/Domain/AnalysisRule11ScopingTests.swift`
+  - No-op (existing per-day-drop test stays green; the snapshot-fold
+    tightening makes it consistent — verify nothing regresses).
+
+**Docs (modify):**
+
+- `plans/2026-05-04-trades-mode-historical-net-worth-design.md` →
+  `plans/completed/...` after merge (manual step at PR landing time, not
+  in this plan).
+
+---
+
+## Build Commands (Reference)
+
+| When you need to | Command |
+|------------------|---------|
+| Run all tests on macOS | `just test-mac 2>&1 \| tee .agent-tmp/test-mac.txt` |
+| Run a subset of tests | `just test-mac GRDBDailyBalancesTradesModeTests 2>&1 \| tee .agent-tmp/test.txt` |
+| Format Swift files | `just format` |
+| Verify formatting | `just format-check` |
+| Build the macOS app | `just build-mac` |
+
+`mkdir -p .agent-tmp` before piping output to `.agent-tmp/`.
+
+---
+
+## Task 1: Add `fetchTradesModeInvestmentAccountIds` SQL fetch + plan-pinning test
+
+**Files:**
+- Modify: `Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesInvestmentValues.swift`
+- Test: `MoolahTests/Backends/GRDB/DailyBalancesPlanPinningTests.swift`
+
+- [ ] **Step 1: Write the failing plan-pinning test**
+
+Open `MoolahTests/Backends/GRDB/DailyBalancesPlanPinningTests.swift`.
+Find the existing `fetchInvestmentAccountIdsUsesAccountByType` test
+(around line 195). Add a sibling test directly after it:
+
+```swift
+@Test("fetchTradesModeInvestmentAccountIds uses account_by_type")
+func fetchTradesModeInvestmentAccountIdsUsesAccountByType() throws {
+  let database = try makeDatabase()
+  // Mirrors the per-account id loader driven by
+  // `GRDBAnalysisRepository.fetchTradesModeInvestmentAccountIds`. The
+  // production SQL filters on `type = 'investment'` AND
+  // `valuation_mode = 'calculatedFromTrades'`. The `account_by_type`
+  // index keys on `(type)` and serves the selective `type =
+  // 'investment'` predicate; the `valuation_mode` predicate filters
+  // the candidate rows post-seek. SQLite emits `SEARCH account USING
+  // INDEX account_by_type` for this shape, which is *not* a full
+  // table scan.
+  let detail = try planDetail(
+    database,
+    query: """
+      SELECT id FROM account
+      WHERE type = 'investment' AND valuation_mode = 'calculatedFromTrades'
+      """)
+  #expect(detail.contains("SEARCH account USING INDEX account_by_type"))
+  #expect(!PlanPinningTestHelpers.planHasFullTableScanOf(detail, alias: "account"))
+}
+```
+
+- [ ] **Step 2: Run the test to verify it passes already (no production change yet)**
+
+```bash
+mkdir -p .agent-tmp
+just test-mac DailyBalancesPlanPinningTests/fetchTradesModeInvestmentAccountIdsUsesAccountByType 2>&1 | tee .agent-tmp/test.txt
+```
+
+Expected: PASS — the SQL string is a literal and the planner emits the
+same shape as the snapshot-mode predicate. The test pins the plan
+shape; the production helper is added in Step 3.
+
+- [ ] **Step 3: Add the production fetch helper**
+
+Open `Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesInvestmentValues.swift`.
+Locate `fetchInvestmentAccountIds` (around line 27). Add a sibling
+function directly after it:
+
+```swift
+  /// Loads every account id whose `type = 'investment'` AND whose
+  /// `valuation_mode = 'calculatedFromTrades'`. The trades-mode fold
+  /// (`applyTradesModePositionValuations`) walks per-day position
+  /// deltas for these accounts and valuates the cumulative positions
+  /// against the conversion service on the day's date. Recorded-value
+  /// investment accounts are intentionally excluded — they contribute
+  /// via the snapshot fold instead. Reading the column directly off
+  /// the `account` table avoids carrying the full account row across
+  /// the position-row boundary.
+  static func fetchTradesModeInvestmentAccountIds(
+    database: Database
+  ) throws -> Set<UUID> {
+    let rows = try Row.fetchAll(
+      database,
+      sql: """
+        SELECT id FROM account
+        WHERE type = 'investment' AND valuation_mode = 'calculatedFromTrades'
+        """)
+    var ids = Set<UUID>()
+    ids.reserveCapacity(rows.count)
+    for row in rows {
+      if let id: UUID = row["id"] {
+        ids.insert(id)
+      }
+    }
+    return ids
+  }
+```
+
+- [ ] **Step 4: Run `just format` and verify the build**
+
+```bash
+just format
+just build-mac 2>&1 | tee .agent-tmp/build.txt
+grep -i "error:\|warning:" .agent-tmp/build.txt | grep -v "Preview"
+```
+
+Expected: empty (no errors / warnings).
+
+- [ ] **Step 5: Run the plan-pinning test again — confirms the new helper hasn't regressed**
+
+```bash
+just test-mac DailyBalancesPlanPinningTests 2>&1 | tee .agent-tmp/test.txt
+grep -i "failed\|error:" .agent-tmp/test.txt
+```
+
+Expected: no failures.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C . add Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesInvestmentValues.swift MoolahTests/Backends/GRDB/DailyBalancesPlanPinningTests.swift
+git -C . commit -m "feat(grdb): add fetchTradesModeInvestmentAccountIds + plan-pin"
+```
+
+---
+
+## Task 2: Extend `DailyBalancesAggregation` and `DailyBalancesAssemblyContext`
+
+**Files:**
+- Modify: `Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalances.swift`
+
+This task only adds fields and updates the construction site; the
+fields are wired by Task 3 and consumed by Task 5. Builds cleanly on
+its own because the fields default to empty values everywhere they're
+read until Task 5 lands.
+
+- [ ] **Step 1: Add new fields to `DailyBalancesAggregation`**
+
+Open `+DailyBalances.swift`. Locate `struct DailyBalancesAggregation:
+Sendable` (around line 85). Add the new fields after the existing
+`investmentAccountIds`:
+
+```swift
+  struct DailyBalancesAggregation: Sendable {
+    let priorAccountRows: [DailyBalanceAccountRow]
+    let priorEarmarkRows: [DailyBalanceEarmarkRow]
+    let accountRows: [DailyBalanceAccountRow]
+    let earmarkRows: [DailyBalanceEarmarkRow]
+    let investmentValues: [InvestmentValueSnapshot]
+    let investmentAccountIds: Set<UUID>
+    /// Account ids of trades-mode investment accounts. Drives the new
+    /// per-day position-valuation fold; recorded-value accounts are
+    /// carried in `investmentAccountIds` and drive the snapshot fold.
+    let tradesModeInvestmentAccountIds: Set<UUID>
+    /// Pre-cutoff `transaction_leg` SUM rows filtered to trades-mode
+    /// investment accounts only. Pre-fold seed for the new fold's
+    /// cumulative position dict.
+    let priorTradesModeAccountRows: [DailyBalanceAccountRow]
+    /// Post-cutoff `transaction_leg` SUM rows filtered to trades-mode
+    /// investment accounts only.
+    let tradesModeAccountRows: [DailyBalanceAccountRow]
+    let scheduled: [Transaction]
+    let instrumentMap: [String: Instrument]
+    let forecastUntil: Date?
+  }
+```
+
+- [ ] **Step 2: Add the new field to `DailyBalancesAssemblyContext`**
+
+Locate `struct DailyBalancesAssemblyContext: Sendable` (around line
+125). Add `tradesModeInvestmentAccountIds`:
+
+```swift
+  struct DailyBalancesAssemblyContext: Sendable {
+    let investmentAccountIds: Set<UUID>
+    /// Account ids of trades-mode investment accounts — read by
+    /// `applyTradesModePositionValuations` to early-exit when the
+    /// profile has none. None of the seed/walk helpers consult this
+    /// field; trades-mode accounts contribute through the new fold,
+    /// not through `accountsFromTransfers`.
+    let tradesModeInvestmentAccountIds: Set<UUID>
+    let instrumentMap: [String: Instrument]
+    let profileInstrument: Instrument
+    let conversionService: any InstrumentConversionService
+  }
+```
+
+- [ ] **Step 3: Update `assembleDailyBalances` context construction**
+
+Locate `assembleDailyBalances` (around line 162). Update the
+`DailyBalancesAssemblyContext` construction to forward the new field:
+
+```swift
+    let context = DailyBalancesAssemblyContext(
+      investmentAccountIds: aggregation.investmentAccountIds,
+      tradesModeInvestmentAccountIds: aggregation.tradesModeInvestmentAccountIds,
+      instrumentMap: aggregation.instrumentMap,
+      profileInstrument: profileInstrument,
+      conversionService: conversionService)
+```
+
+- [ ] **Step 4: Build to make sure existing call sites still compile**
+
+`DailyBalancesAggregation` has only one constructing call site
+(`readDailyBalancesAggregation` in `+DailyBalancesAggregation.swift`).
+The build will fail until that call site is updated; Task 3 fixes it.
+Skip the build step here and continue to Task 3.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C . add Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalances.swift
+git -C . commit -m "feat(grdb): add trades-mode fields to DailyBalancesAggregation"
+```
+
+---
+
+## Task 3: Wire `fetchTradesModeInvestmentAccountIds` and pre-filter rows in `readDailyBalancesAggregation`
+
+**Files:**
+- Modify: `Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesAggregation.swift`
+
+- [ ] **Step 1: Update `readDailyBalancesAggregation` to populate the new fields**
+
+Open `+DailyBalancesAggregation.swift`. Locate `readDailyBalancesAggregation`
+(around line 47). Update it to call the new fetch and pre-filter the
+existing row arrays:
+
+```swift
+  private static func readDailyBalancesAggregation(
+    database: Database, after: Date?, forecastUntil: Date?
+  ) throws -> DailyBalancesAggregation {
+    let accountRows = try Self.fetchAccountDeltaRowsPostCutoff(
+      database: database, after: after)
+    let earmarkRows = try Self.fetchEarmarkDeltaRowsPostCutoff(
+      database: database, after: after)
+    let (priorAccountRows, priorEarmarkRows) = try Self.fetchPriorDeltaRows(
+      database: database, after: after)
+    let investmentAccountIds = try Self.fetchInvestmentAccountIds(
+      database: database)
+    let tradesModeInvestmentAccountIds =
+      try Self.fetchTradesModeInvestmentAccountIds(database: database)
+    // Fetch `instrumentMap` before the investment-value snapshots so
+    // `fetchInvestmentValueSnapshots` can resolve each row's instrument
+    // to its registered `Instrument` (with the right `kind` for stock /
+    // crypto investments) instead of falling back to fiat-by-id.
+    let instrumentMap = try InstrumentRow.fetchInstrumentMap(database: database)
+    let investmentValues = try Self.fetchInvestmentValueSnapshots(
+      database: database,
+      investmentAccountIds: investmentAccountIds,
+      instrumentMap: instrumentMap)
+    let scheduled =
+      forecastUntil != nil
+      ? try Self.fetchScheduledTransactions(database: database) : []
+    // Pre-filter trades-mode rows out of the already-fetched arrays.
+    // Doing the filter inside the read closure (not later) keeps every
+    // input the assembly walk needs inside one MVCC snapshot and saves
+    // re-checking membership inside the per-day fold.
+    let priorTradesModeAccountRows = priorAccountRows.filter {
+      tradesModeInvestmentAccountIds.contains($0.accountId)
+    }
+    let tradesModeAccountRows = accountRows.filter {
+      tradesModeInvestmentAccountIds.contains($0.accountId)
+    }
+    return DailyBalancesAggregation(
+      priorAccountRows: priorAccountRows,
+      priorEarmarkRows: priorEarmarkRows,
+      accountRows: accountRows,
+      earmarkRows: earmarkRows,
+      investmentValues: investmentValues,
+      investmentAccountIds: investmentAccountIds,
+      tradesModeInvestmentAccountIds: tradesModeInvestmentAccountIds,
+      priorTradesModeAccountRows: priorTradesModeAccountRows,
+      tradesModeAccountRows: tradesModeAccountRows,
+      scheduled: scheduled,
+      instrumentMap: instrumentMap,
+      forecastUntil: forecastUntil)
+  }
+```
+
+- [ ] **Step 2: Update the docstring on `fetchDailyBalancesAggregation`**
+
+Same file, around line 12. Add a bullet for the new fetch in the
+existing list ("Loads every input the assembly walk needs in a single
+`database.read` snapshot:"):
+
+```swift
+  /// Loads every input the assembly walk needs in a single
+  /// `database.read` snapshot:
+  /// - per-`(day, account, instrument, type)` SUMs split on the
+  ///   `:after` cutoff (the post-cutoff rows drive the day-by-day
+  ///   walk; the pre-cutoff rows seed the `PositionBook`);
+  /// - per-`(day, earmark, instrument, type)` SUMs split the same
+  ///   way;
+  /// - the scheduled `[Transaction]` for forecast extrapolation;
+  /// - the accounts table (so we know which accounts are
+  ///   investments — split into recorded-value and trades-mode);
+  /// - every `investment_value` row (the cursor walk needs the
+  ///   pre-window snapshots so it can carry the most-recent value
+  ///   forward into the first in-window day);
+  /// - the instrument map.
+  ///
+  /// One snapshot keeps the four leg-side reads and the scheduled
+  /// transactions consistent — three independent reads under WAL
+  /// could surface a leg referencing a transaction that hasn't yet
+  /// appeared in the transaction list.
+```
+
+- [ ] **Step 3: Format and build**
+
+```bash
+just format
+just build-mac 2>&1 | tee .agent-tmp/build.txt
+grep -i "error:\|warning:" .agent-tmp/build.txt | grep -v "Preview"
+```
+
+Expected: clean.
+
+- [ ] **Step 4: Run all daily-balance tests to confirm zero regression**
+
+```bash
+just test-mac GRDBDailyBalancesAssembleTests GRDBDailyBalancesConversionTests DailyBalancesPlanPinningTests AnalysisRule11ScopingTests 2>&1 | tee .agent-tmp/test.txt
+grep -i "failed\|error:" .agent-tmp/test.txt
+```
+
+Expected: no failures.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C . add Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesAggregation.swift
+git -C . commit -m "feat(grdb): wire fetchTradesModeInvestmentAccountIds into aggregation read"
+```
+
+---
+
+## Task 4: Aggregation-layer integration tests for the new fields
+
+**Files:**
+- Test: `MoolahTests/Backends/GRDB/GRDBDailyBalancesAggregateTests.swift` (or closest sibling — see Step 1)
+
+These pin that `fetchDailyBalancesAggregation` populates the new
+fields correctly, so a future bug in `readDailyBalancesAggregation`
+that returns empty sets is caught by the aggregation contract tests
+(not only by the fold-contract tests in Task 7).
+
+- [ ] **Step 1: Find or create the aggregation-layer test file**
+
+Run:
+
+```bash
+ls MoolahTests/Backends/GRDB/ | grep -i "Aggreg\|DailyBalancesAssemble"
+```
+
+If `GRDBDailyBalancesAggregateTests.swift` exists, extend it. If it
+doesn't, the closest sibling is `GRDBDailyBalancesAssembleTests.swift`
+— add the new tests in a fresh `@Suite` block at the bottom of that
+file. The tests below assume the new file
+`MoolahTests/Backends/GRDB/GRDBDailyBalancesAggregateTests.swift`. If
+you place them in `GRDBDailyBalancesAssembleTests.swift`, copy the
+file's existing imports and helper-creation patterns rather than the
+self-contained fixture below.
+
+- [ ] **Step 2: Write the three failing tests**
+
+Create / edit
+`MoolahTests/Backends/GRDB/GRDBDailyBalancesAggregateTests.swift`:
+
+```swift
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+/// Aggregation-layer integration tests pinning that
+/// `fetchDailyBalancesAggregation` populates the trades-mode fields
+/// from `readDailyBalancesAggregation`. The fold-contract tests in
+/// `GRDBDailyBalancesTradesModeTests` exercise the new fold by
+/// constructing `DailyBalancesAggregation` directly; these tests
+/// pin the SQL-to-struct wiring so a regression in the aggregation
+/// builder doesn't ship past every fold-contract assertion.
+@Suite("GRDBAnalysisRepository fetchDailyBalancesAggregation — trades-mode fields")
+struct GRDBDailyBalancesAggregateTradesModeTests {
+
+  @Test("populates tradesModeInvestmentAccountIds for trades-mode accounts")
+  func populatesTradesModeAccountIds() async throws {
+    let backend = try CloudKitAnalysisTestBackend()
+    let tradesAccount = Account(
+      id: UUID(), name: "Trades Account", type: .investment,
+      instrument: .defaultTestInstrument,
+      valuationMode: .calculatedFromTrades)
+    _ = try await backend.accounts.create(tradesAccount)
+    let snapshotAccount = Account(
+      id: UUID(), name: "Snapshot Account", type: .investment,
+      instrument: .defaultTestInstrument,
+      valuationMode: .recordedValue)
+    _ = try await backend.accounts.create(snapshotAccount)
+
+    let aggregation = try await backend.analysis.testFetchAggregation(
+      after: nil, forecastUntil: nil)
+
+    #expect(aggregation.tradesModeInvestmentAccountIds.contains(tradesAccount.id))
+    #expect(!aggregation.tradesModeInvestmentAccountIds.contains(snapshotAccount.id))
+    #expect(aggregation.investmentAccountIds.contains(snapshotAccount.id))
+    #expect(!aggregation.investmentAccountIds.contains(tradesAccount.id))
+  }
+
+  @Test("priorTradesModeAccountRows / tradesModeAccountRows hold only trades-mode account rows")
+  func filtersAccountRowsByMode() async throws {
+    let backend = try CloudKitAnalysisTestBackend()
+    let tradesAccount = Account(
+      id: UUID(), name: "Trades Account", type: .investment,
+      instrument: .defaultTestInstrument,
+      valuationMode: .calculatedFromTrades)
+    _ = try await backend.accounts.create(tradesAccount)
+    let snapshotAccount = Account(
+      id: UUID(), name: "Snapshot Account", type: .investment,
+      instrument: .defaultTestInstrument,
+      valuationMode: .recordedValue)
+    _ = try await backend.accounts.create(snapshotAccount)
+    let bankAccount = Account(
+      id: UUID(), name: "Cash", type: .bank,
+      instrument: .defaultTestInstrument)
+    _ = try await backend.accounts.create(bankAccount)
+
+    let cutoff = try AnalysisTestHelpers.date(year: 2025, month: 6, day: 1)
+    let priorDate = try AnalysisTestHelpers.date(year: 2025, month: 5, day: 15)
+    let postDate = try AnalysisTestHelpers.date(year: 2025, month: 6, day: 15)
+
+    // One transaction on each side of the cutoff for each account.
+    for (account, date) in [
+      (tradesAccount, priorDate), (tradesAccount, postDate),
+      (snapshotAccount, priorDate), (snapshotAccount, postDate),
+      (bankAccount, priorDate), (bankAccount, postDate),
+    ] {
+      _ = try await backend.transactions.create(
+        Transaction(
+          date: date, payee: "Tick",
+          legs: [
+            TransactionLeg(
+              accountId: account.id, instrument: .defaultTestInstrument,
+              quantity: 10, type: .income)
+          ]))
+    }
+
+    let aggregation = try await backend.analysis.testFetchAggregation(
+      after: cutoff, forecastUntil: nil)
+
+    let priorIds = Set(aggregation.priorTradesModeAccountRows.map(\.accountId))
+    let postIds = Set(aggregation.tradesModeAccountRows.map(\.accountId))
+    #expect(priorIds == [tradesAccount.id])
+    #expect(postIds == [tradesAccount.id])
+  }
+
+  @Test("empty trades-mode profile produces empty arrays")
+  func emptyTradesModeProfileEmptyArrays() async throws {
+    let backend = try CloudKitAnalysisTestBackend()
+    let snapshotAccount = Account(
+      id: UUID(), name: "Snapshot Account", type: .investment,
+      instrument: .defaultTestInstrument,
+      valuationMode: .recordedValue)
+    _ = try await backend.accounts.create(snapshotAccount)
+
+    let aggregation = try await backend.analysis.testFetchAggregation(
+      after: nil, forecastUntil: nil)
+
+    #expect(aggregation.tradesModeInvestmentAccountIds.isEmpty)
+    #expect(aggregation.priorTradesModeAccountRows.isEmpty)
+    #expect(aggregation.tradesModeAccountRows.isEmpty)
+  }
+}
+```
+
+- [ ] **Step 3: Add a `testFetchAggregation` shim to `CloudKitAnalysisTestBackend` if it doesn't exist**
+
+Run:
+
+```bash
+grep -n "testFetchAggregation\|fetchDailyBalancesAggregation" MoolahTests/Support/CloudKitAnalysisTestBackend.swift
+```
+
+If `testFetchAggregation` is not defined, add it. Open the file, find
+the `analysis` accessor, and add a new method:
+
+```swift
+extension CloudKitAnalysisTestBackend {
+  /// Test-only entry point that exposes `fetchDailyBalancesAggregation`
+  /// for aggregation-layer integration tests. Production callers go
+  /// through `analysis.fetchDailyBalances(...)`; this shim lets tests
+  /// pin the aggregation contract without re-running the full
+  /// per-day walk.
+  func testFetchAggregation(
+    after: Date?, forecastUntil: Date?
+  ) async throws -> GRDBAnalysisRepository.DailyBalancesAggregation {
+    let analysis = self.analysis as! GRDBAnalysisRepository
+    return try await GRDBAnalysisRepository.fetchDailyBalancesAggregation(
+      database: analysis.databaseReader,
+      after: after,
+      forecastUntil: forecastUntil)
+  }
+}
+```
+
+The `as!` cast is acceptable in test support code because the test
+backend is constructed against `GRDBAnalysisRepository` specifically.
+
+If the `databaseReader` property is `private`, expose an internal
+`testDatabaseReader: any DatabaseReader { databaseReader }` on
+`GRDBAnalysisRepository` and use that instead. Check by running:
+
+```bash
+grep -n "databaseReader\|database:.*DatabaseReader" Backends/GRDB/Repositories/GRDBAnalysisRepository.swift
+```
+
+Use whichever access path is already exposed.
+
+- [ ] **Step 4: Run the new tests — they should pass**
+
+```bash
+just format
+just test-mac GRDBDailyBalancesAggregateTradesModeTests 2>&1 | tee .agent-tmp/test.txt
+grep -i "failed\|error:" .agent-tmp/test.txt
+```
+
+Expected: 3 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C . add MoolahTests/Backends/GRDB/GRDBDailyBalancesAggregateTests.swift MoolahTests/Support/CloudKitAnalysisTestBackend.swift
+git -C . commit -m "test(grdb): aggregation-layer pins for trades-mode fields"
+```
+
+---
+
+## Task 5: Drop vestigial `?` on `sumInvestmentValues` and tighten Rule 11 in `applyInvestmentValues`
+
+**Files:**
+- Modify: `Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesInvestmentValues.swift`
+
+This task fixes the existing snapshot fold:
+1. Drop the `?` on `sumInvestmentValues`'s return type — never returns
+   `nil` on success, `?` is dead.
+2. Update its caller in `applyInvestmentValues` to the non-optional
+   shape.
+3. Add `dailyBalances.removeValue(forKey: date)` to the catch branch
+   so per-day failures drop the day (Rule 11) — matches `walkDays`.
+
+- [ ] **Step 1: Write the failing Rule 11 test for the snapshot fold**
+
+Open `MoolahTests/Backends/GRDB/GRDBDailyBalancesAssembleTests.swift`.
+Add a new test at the bottom of the existing suite:
+
+```swift
+  @Test("snapshot fold drops the day from dailyBalances on per-day conversion failure")
+  func snapshotFoldDropsDayOnFailure() async throws {
+    // Build an aggregation with one investment-value snapshot on day D.
+    let day = try AnalysisTestHelpers.utcDate(year: 2025, month: 6, day: 10, hour: 12)
+    let dayKey = AnalysisTestHelpers.calendar.startOfDay(for: day)
+    let usd = Instrument.fiat(code: "USD")
+    let accountId = UUID()
+    let aggregation = GRDBAnalysisRepository.DailyBalancesAggregation(
+      priorAccountRows: [],
+      priorEarmarkRows: [],
+      accountRows: [],
+      earmarkRows: [],
+      investmentValues: [
+        InvestmentValueSnapshot(
+          accountId: accountId, date: day,
+          value: InstrumentAmount(quantity: 100, instrument: usd))
+      ],
+      investmentAccountIds: [accountId],
+      tradesModeInvestmentAccountIds: [],
+      priorTradesModeAccountRows: [],
+      tradesModeAccountRows: [],
+      scheduled: [],
+      instrumentMap: ["USD": usd],
+      forecastUntil: nil)
+    // Seed the dailyBalances dict directly so we test the fold in
+    // isolation. Insert a placeholder DailyBalance for `dayKey` so the
+    // fold has a key to drop.
+    var dailyBalances: [Date: DailyBalance] = [
+      dayKey: DailyBalance(
+        date: dayKey,
+        balance: .zero(instrument: .defaultTestInstrument),
+        earmarked: .zero(instrument: .defaultTestInstrument),
+        availableFunds: .zero(instrument: .defaultTestInstrument),
+        investments: .zero(instrument: .defaultTestInstrument),
+        investmentValue: nil,
+        netWorth: .zero(instrument: .defaultTestInstrument),
+        bestFit: nil,
+        isForecast: false)
+    ]
+    let conversionService = DateFailingConversionService(
+      rates: [:], failingDates: [dayKey])
+    var capturedFailures: [(Error, Date)] = []
+    let handlers = GRDBAnalysisRepository.DailyBalancesHandlers(
+      handleUnparseableDay: { _ in },
+      handleConversionFailure: { _, _ in },
+      handleInvestmentValueFailure: { error, date in
+        capturedFailures.append((error, date))
+      })
+    let context = GRDBAnalysisRepository.DailyBalancesAssemblyContext(
+      investmentAccountIds: aggregation.investmentAccountIds,
+      tradesModeInvestmentAccountIds: aggregation.tradesModeInvestmentAccountIds,
+      instrumentMap: aggregation.instrumentMap,
+      profileInstrument: .defaultTestInstrument,
+      conversionService: conversionService)
+
+    try await GRDBAnalysisRepository.applyInvestmentValues(
+      aggregation.investmentValues,
+      to: &dailyBalances,
+      context: context,
+      handlers: handlers)
+
+    // Rule 11: a snapshot conversion failure on day D must drop day D
+    // from dailyBalances. Sibling days (none here) are unaffected.
+    #expect(dailyBalances[dayKey] == nil)
+    #expect(capturedFailures.count == 1)
+    #expect(capturedFailures.first?.1 == dayKey)
+  }
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+just test-mac GRDBDailyBalancesAssembleTests/snapshotFoldDropsDayOnFailure 2>&1 | tee .agent-tmp/test.txt
+grep -i "failed\|error:" .agent-tmp/test.txt
+```
+
+Expected: FAIL — current `applyInvestmentValues` `continue`s without
+removing the day, so `dailyBalances[dayKey]` is still present.
+
+- [ ] **Step 3: Drop `?` from `sumInvestmentValues`**
+
+Open `+DailyBalancesInvestmentValues.swift`. Locate
+`sumInvestmentValues` (around line 178). Change:
+
+```swift
+  private static func sumInvestmentValues(
+    latestByAccount: [UUID: InstrumentAmount],
+    on date: Date,
+    profileInstrument: Instrument,
+    conversionService: any InstrumentConversionService
+  ) async throws -> InstrumentAmount? {
+```
+
+to:
+
+```swift
+  /// Sum the per-account investment values, converting foreign
+  /// instruments to the profile instrument on `date`. Throws on any
+  /// conversion failure so the caller can drop the day from the
+  /// `dailyBalances` dict per Rule 11. The return is non-optional —
+  /// the function either throws or returns the converted total.
+  private static func sumInvestmentValues(
+    latestByAccount: [UUID: InstrumentAmount],
+    on date: Date,
+    profileInstrument: Instrument,
+    conversionService: any InstrumentConversionService
+  ) async throws -> InstrumentAmount {
+```
+
+The function body's `return InstrumentAmount(quantity: total,
+instrument: profileInstrument)` already returns a non-optional — no
+body change required.
+
+- [ ] **Step 4: Update `applyInvestmentValues`'s call to the non-optional shape and tighten the catch branch**
+
+Same file. Locate `applyInvestmentValues` (around line 107). Replace
+the body from `let totalValue: InstrumentAmount?` through the
+`dailyBalances[date] = DailyBalance(...)` block with:
+
+```swift
+    for date in dailyBalances.keys.sorted() {
+      valueIndex = advanceInvestmentCursor(
+        values: investmentValues,
+        latestByAccount: &latestByAccount,
+        from: valueIndex,
+        upTo: date)
+      if latestByAccount.isEmpty { continue }
+      let totalValue: InstrumentAmount
+      do {
+        totalValue = try await sumInvestmentValues(
+          latestByAccount: latestByAccount,
+          on: date,
+          profileInstrument: context.profileInstrument,
+          conversionService: context.conversionService)
+      } catch let cancel as CancellationError {
+        throw cancel
+      } catch {
+        // Rule 11: drop the day from dailyBalances so the chart shows
+        // a gap rather than rendering a partial total. Matches the
+        // walkDays per-day error contract.
+        handlers.handleInvestmentValueFailure(error, date)
+        dailyBalances.removeValue(forKey: date)
+        continue
+      }
+      guard let balance = dailyBalances[date] else { continue }
+      dailyBalances[date] = DailyBalance(
+        date: balance.date,
+        balance: balance.balance,
+        earmarked: balance.earmarked,
+        availableFunds: balance.availableFunds,
+        investments: balance.investments,
+        investmentValue: totalValue,
+        netWorth: balance.balance + totalValue,
+        bestFit: balance.bestFit,
+        isForecast: balance.isForecast)
+    }
+```
+
+(Diffs from the original: `let totalValue: InstrumentAmount?` →
+`let totalValue: InstrumentAmount`; new
+`dailyBalances.removeValue(forKey: date)` line in the catch branch;
+`guard let totalValue, let balance = dailyBalances[date] else { continue }`
+collapses to `guard let balance = dailyBalances[date] else { continue }`.)
+
+- [ ] **Step 5: Format and run the new test**
+
+```bash
+just format
+just test-mac GRDBDailyBalancesAssembleTests/snapshotFoldDropsDayOnFailure 2>&1 | tee .agent-tmp/test.txt
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Run the full daily-balance suite to confirm nothing else regresses**
+
+```bash
+just test-mac GRDBDailyBalancesAssembleTests GRDBDailyBalancesConversionTests AnalysisRule11ScopingTests DailyBalancesPlanPinningTests 2>&1 | tee .agent-tmp/test.txt
+grep -i "failed\|error:" .agent-tmp/test.txt
+```
+
+Expected: no failures.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git -C . add Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesInvestmentValues.swift MoolahTests/Backends/GRDB/GRDBDailyBalancesAssembleTests.swift
+git -C . commit -m "fix(grdb): drop snapshot day on conversion failure (Rule 11) + cleanup"
+```
+
+---
+
+## Task 6: Add the new fold — `applyTradesModePositionValuations`
+
+**Files:**
+- Modify: `Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesInvestmentValues.swift`
+- Modify: `Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalances.swift`
+
+This task introduces the production fold. Tests come in Task 7.
+
+- [ ] **Step 1: Add the file-private `TradesModePositionEntry` struct + the new fold + helper**
+
+Open `+DailyBalancesInvestmentValues.swift`. Append the following at
+the bottom of the existing `extension GRDBAnalysisRepository` block,
+after `sumInvestmentValues`:
+
+```swift
+  // MARK: - Trades-mode per-day fold
+
+  /// One decoded entry in the trades-mode cursor walk — a per-day,
+  /// per-account, per-instrument quantity ready to apply to the
+  /// cumulative `positions` dict. Four fields exceeds SwiftLint's
+  /// `large_tuple` error threshold, so a named struct is required.
+  private struct TradesModePositionEntry {
+    let dayKey: Date
+    let accountId: UUID
+    let instrument: Instrument
+    let quantity: Decimal
+  }
+
+  /// Per-day position-valuation fold for trades-mode investment
+  /// accounts. Sister of `applyInvestmentValues` — same per-day error
+  /// contract: `CancellationError` rethrows immediately; any other
+  /// thrown error drops the day from `dailyBalances` and logs through
+  /// `handleInvestmentValueFailure`.
+  ///
+  /// The fold builds a sorted cursor over trades-mode rows
+  /// (`(dayKey, accountId, instrument, quantity)` entries), then
+  /// walks `dailyBalances.keys.sorted()`. For each output `dayKey`,
+  /// the cursor advances through every entry with `entry.dayKey <=
+  /// dayKey` — including entries for days absent from
+  /// `dailyBalances` (e.g. dropped by an earlier snapshot-fold
+  /// failure) — so cumulative position state stays correct on every
+  /// following day.
+  ///
+  /// `priorRows` and `postRows` carry only rows whose `accountId`
+  /// belongs to a trades-mode investment account — pre-filtered in
+  /// `readDailyBalancesAggregation` so this fold neither re-checks
+  /// membership nor walks rows for accounts it doesn't own.
+  static func applyTradesModePositionValuations(
+    priorRows: [DailyBalanceAccountRow],
+    postRows: [DailyBalanceAccountRow],
+    to dailyBalances: inout [Date: DailyBalance],
+    context: DailyBalancesAssemblyContext,
+    handlers: DailyBalancesHandlers
+  ) async throws {
+    guard !context.tradesModeInvestmentAccountIds.isEmpty,
+      !dailyBalances.isEmpty
+    else { return }
+
+    // Pre-fold priors into a per-account, per-instrument cumulative
+    // dict. Decoding mirrors `applyDailyDeltas`: resolve the
+    // instrument via the registry, then convert the row's storage
+    // value into a Decimal quantity.
+    var positions: [UUID: [Instrument: Decimal]] = [:]
+    for row in priorRows {
+      let instrument = resolveInstrument(row.instrumentId, in: context.instrumentMap)
+      let quantity = InstrumentAmount(
+        storageValue: row.qty, instrument: instrument
+      ).quantity
+      positions[row.accountId, default: [:]][instrument, default: 0] += quantity
+    }
+
+    // Build a sorted cursor over post rows. Grouping by SQL `\.day`
+    // (UTC string) is intentionally avoided — the outer walk is over
+    // local-startOfDay `Date` keys, so we key the cursor at `dayKey`
+    // granularity directly to avoid Rule 10 timezone mismatch.
+    var entries: [TradesModePositionEntry] = []
+    entries.reserveCapacity(postRows.count)
+    for row in postRows {
+      let instrument = resolveInstrument(row.instrumentId, in: context.instrumentMap)
+      let quantity = InstrumentAmount(
+        storageValue: row.qty, instrument: instrument
+      ).quantity
+      entries.append(
+        TradesModePositionEntry(
+          dayKey: Calendar.current.startOfDay(for: row.sampleDate),
+          accountId: row.accountId,
+          instrument: instrument,
+          quantity: quantity))
+    }
+    entries.sort { $0.dayKey < $1.dayKey }
+
+    var valueIndex = 0
+    for dayKey in dailyBalances.keys.sorted() {
+      // Advance the cursor: apply every entry on-or-before dayKey,
+      // including those for days absent from dailyBalances.
+      while valueIndex < entries.count, entries[valueIndex].dayKey <= dayKey {
+        let entry = entries[valueIndex]
+        positions[entry.accountId, default: [:]][entry.instrument, default: 0] +=
+          entry.quantity
+        valueIndex += 1
+      }
+      if positions.isEmpty { continue }
+      do {
+        // dayKey is `Calendar.current.startOfDay(for: row.sampleDate)`
+        // — same normalization as walkDays and the conversion-service
+        // lookup.
+        let total = try await sumTradesModePositions(
+          positions: positions,
+          on: dayKey,
+          profileInstrument: context.profileInstrument,
+          conversionService: context.conversionService)
+        if let existing = dailyBalances[dayKey] {
+          let combined =
+            (existing.investmentValue ?? .zero(instrument: context.profileInstrument))
+            + total
+          dailyBalances[dayKey] = DailyBalance(
+            date: existing.date,
+            balance: existing.balance,
+            earmarked: existing.earmarked,
+            availableFunds: existing.availableFunds,
+            investments: existing.investments,
+            investmentValue: combined,
+            netWorth: existing.balance + combined,
+            bestFit: existing.bestFit,
+            isForecast: existing.isForecast)
+        }
+      } catch let cancel as CancellationError {
+        throw cancel
+      } catch {
+        // Rule 11: drop the day from dailyBalances so the chart shows
+        // a gap. Matches the walkDays / applyInvestmentValues
+        // per-day error contract.
+        handlers.handleInvestmentValueFailure(error, dayKey)
+        dailyBalances.removeValue(forKey: dayKey)
+        continue
+      }
+    }
+  }
+
+  /// Sum per-account, per-instrument trades-mode positions on `date`,
+  /// converting foreign instruments to the profile instrument via the
+  /// conversion service. Rule 8 fast path applies at the leaf level
+  /// so an account holding both profile-instrument and foreign-
+  /// instrument positions still routes only the foreign positions
+  /// through the service. Cancellation propagates via the service's
+  /// own `await` — no manual `Task.isCancelled` check needed (matches
+  /// `sumInvestmentValues`).
+  private static func sumTradesModePositions(
+    positions: [UUID: [Instrument: Decimal]],
+    on date: Date,
+    profileInstrument: Instrument,
+    conversionService: any InstrumentConversionService
+  ) async throws -> InstrumentAmount {
+    var total: Decimal = 0
+    for (_, perInstrument) in positions {
+      for (instrument, quantity) in perInstrument {
+        if instrument.id == profileInstrument.id {
+          total += quantity
+          continue
+        }
+        total += try await conversionService.convert(
+          quantity, from: instrument, to: profileInstrument, on: date)
+      }
+    }
+    return InstrumentAmount(quantity: total, instrument: profileInstrument)
+  }
+```
+
+- [ ] **Step 2: Wire the fold into `assembleDailyBalances`**
+
+Open `+DailyBalances.swift`. Locate `assembleDailyBalances` (around
+line 162). After the existing `try await applyInvestmentValues(...)`
+call, add the new fold call:
+
+```swift
+    try await applyInvestmentValues(
+      aggregation.investmentValues,
+      to: &dailyBalances,
+      context: context,
+      handlers: handlers)
+
+    try await applyTradesModePositionValuations(
+      priorRows: aggregation.priorTradesModeAccountRows,
+      postRows: aggregation.tradesModeAccountRows,
+      to: &dailyBalances,
+      context: context,
+      handlers: handlers)
+```
+
+(Place the new call before the `var actualBalances = ...` line and
+the subsequent `applyBestFit` / forecast steps.)
+
+- [ ] **Step 3: Format and build**
+
+```bash
+just format
+just build-mac 2>&1 | tee .agent-tmp/build.txt
+grep -i "error:\|warning:" .agent-tmp/build.txt | grep -v "Preview"
+```
+
+Expected: clean.
+
+- [ ] **Step 4: Run the existing daily-balance suite — no behaviour change for
+  profiles without trades-mode accounts**
+
+```bash
+just test-mac GRDBDailyBalancesAssembleTests GRDBDailyBalancesConversionTests AnalysisRule11ScopingTests DailyBalancesPlanPinningTests GRDBDailyBalancesAggregateTradesModeTests 2>&1 | tee .agent-tmp/test.txt
+grep -i "failed\|error:" .agent-tmp/test.txt
+```
+
+Expected: no failures.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C . add Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesInvestmentValues.swift Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalances.swift
+git -C . commit -m "feat(grdb): per-day trades-mode position-valuation fold"
+```
+
+---
+
+## Task 7: Fold-contract tests for `applyTradesModePositionValuations`
+
+**Files:**
+- Test: `MoolahTests/Backends/GRDB/GRDBDailyBalancesTradesModeTests.swift` (new file)
+
+Twelve tests from spec §9.3 covering happy path, mixed mode, Rule 11
+failure scoping, Rule 10 normalization, no-op early return,
+CSV-imported trade interaction, same-day BUY+SELL, and the
+carry-forward-across-dropped-day correctness pin.
+
+- [ ] **Step 1: Create the test file with the suite header and two helpers**
+
+Create `MoolahTests/Backends/GRDB/GRDBDailyBalancesTradesModeTests.swift`:
+
+```swift
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+/// Fold-contract tests for
+/// `GRDBAnalysisRepository.applyTradesModePositionValuations`.
+/// Tests construct `DailyBalancesAggregation` directly and seed
+/// `dailyBalances` with placeholder entries so the fold can be
+/// exercised in isolation, mirroring the
+/// `GRDBDailyBalancesAssembleTests` style.
+@Suite("GRDBAnalysisRepository applyTradesModePositionValuations")
+struct GRDBDailyBalancesTradesModeTests {
+
+  /// Closure-captured failure log shared across cases that need to
+  /// assert per-day callback shape. Same pattern as
+  /// `GRDBDailyBalancesAssembleTests`'s `FailureLog`.
+  static func makeHandlers(
+    failures: @escaping @Sendable (Error, Date) -> Void
+  ) -> GRDBAnalysisRepository.DailyBalancesHandlers {
+    GRDBAnalysisRepository.DailyBalancesHandlers(
+      handleUnparseableDay: { _ in },
+      handleConversionFailure: { _, _ in },
+      handleInvestmentValueFailure: failures)
+  }
+
+  static func placeholderBalance(at dayKey: Date) -> DailyBalance {
+    DailyBalance(
+      date: dayKey,
+      balance: .zero(instrument: .defaultTestInstrument),
+      earmarked: .zero(instrument: .defaultTestInstrument),
+      availableFunds: .zero(instrument: .defaultTestInstrument),
+      investments: .zero(instrument: .defaultTestInstrument),
+      investmentValue: nil,
+      netWorth: .zero(instrument: .defaultTestInstrument),
+      bestFit: nil,
+      isForecast: false)
+  }
+
+  static func makeContext(
+    tradesIds: Set<UUID>,
+    instrumentMap: [String: Instrument],
+    conversionService: any InstrumentConversionService
+  ) -> GRDBAnalysisRepository.DailyBalancesAssemblyContext {
+    GRDBAnalysisRepository.DailyBalancesAssemblyContext(
+      investmentAccountIds: [],
+      tradesModeInvestmentAccountIds: tradesIds,
+      instrumentMap: instrumentMap,
+      profileInstrument: .defaultTestInstrument,
+      conversionService: conversionService)
+  }
+}
+```
+
+- [ ] **Step 2: Add cases 1, 8, 9 (single buy, no trades-mode accounts, empty dailyBalances)**
+
+Inside the same `struct GRDBDailyBalancesTradesModeTests` body, append:
+
+```swift
+  @Test("case 1: single buy on day D values at day D's price")
+  func singleBuyOnDay() async throws {
+    let day = try AnalysisTestHelpers.utcDate(year: 2025, month: 6, day: 10, hour: 12)
+    let dayKey = AnalysisTestHelpers.calendar.startOfDay(for: day)
+    let usd = Instrument.fiat(code: "USD")
+    let accountId = UUID()
+    let row = GRDBAnalysisRepository.DailyBalanceAccountRow(
+      day: "2025-06-10", sampleDate: day,
+      accountId: accountId, instrumentId: "USD", type: "trade", qty: 1000)
+    let conversion = DateBasedFixedConversionService(
+      rates: [
+        try AnalysisTestHelpers.utcDate(year: 2025, month: 1, day: 1, hour: 0): [
+          "USD": try AnalysisTestHelpers.decimal("1.5")
+        ]
+      ])
+    var balances: [Date: DailyBalance] = [
+      dayKey: GRDBDailyBalancesTradesModeTests.placeholderBalance(at: dayKey)
+    ]
+    let context = Self.makeContext(
+      tradesIds: [accountId],
+      instrumentMap: ["USD": usd],
+      conversionService: conversion)
+    let handlers = Self.makeHandlers { _, _ in }
+
+    try await GRDBAnalysisRepository.applyTradesModePositionValuations(
+      priorRows: [], postRows: [row],
+      to: &balances, context: context, handlers: handlers)
+
+    let dayBalance = try #require(balances[dayKey])
+    // qty 1000 storage units = 10.00 quantity for USD; * 1.5 rate = 15.00 AUD.
+    let expected = try AnalysisTestHelpers.decimal("15")
+    let value = try #require(dayBalance.investmentValue)
+    #expect(value.quantity == expected)
+    #expect(value.instrument == .defaultTestInstrument)
+    #expect(dayBalance.netWorth.quantity == expected)
+  }
+
+  @Test("case 8: no trades-mode accounts — fold is a no-op")
+  func noTradesModeAccounts() async throws {
+    let day = try AnalysisTestHelpers.utcDate(year: 2025, month: 6, day: 10, hour: 12)
+    let dayKey = AnalysisTestHelpers.calendar.startOfDay(for: day)
+    var balances: [Date: DailyBalance] = [
+      dayKey: GRDBDailyBalancesTradesModeTests.placeholderBalance(at: dayKey)
+    ]
+    let originalBalance = balances[dayKey]
+    let conversion = DateBasedFixedConversionService(rates: [:])
+    let context = Self.makeContext(
+      tradesIds: [], instrumentMap: [:], conversionService: conversion)
+    let handlers = Self.makeHandlers { _, _ in }
+
+    try await GRDBAnalysisRepository.applyTradesModePositionValuations(
+      priorRows: [], postRows: [],
+      to: &balances, context: context, handlers: handlers)
+
+    #expect(balances[dayKey] == originalBalance)
+  }
+
+  @Test("case 9: empty dailyBalances — no callback fires")
+  func emptyDailyBalances() async throws {
+    let accountId = UUID()
+    var balances: [Date: DailyBalance] = [:]
+    let usd = Instrument.fiat(code: "USD")
+    let conversion = DateBasedFixedConversionService(rates: [:])
+    let context = Self.makeContext(
+      tradesIds: [accountId],
+      instrumentMap: ["USD": usd],
+      conversionService: conversion)
+    var failures: [(Error, Date)] = []
+    let handlers = Self.makeHandlers { error, date in
+      failures.append((error, date))
+    }
+
+    try await GRDBAnalysisRepository.applyTradesModePositionValuations(
+      priorRows: [], postRows: [],
+      to: &balances, context: context, handlers: handlers)
+
+    #expect(balances.isEmpty)
+    #expect(failures.isEmpty)
+  }
+```
+
+- [ ] **Step 3: Add case 2 (two trades-mode accounts on same day)**
+
+Append:
+
+```swift
+  @Test("case 2: two trades-mode accounts both contribute on day D")
+  func twoTradesModeAccountsSameDay() async throws {
+    let day = try AnalysisTestHelpers.utcDate(year: 2025, month: 6, day: 10, hour: 12)
+    let dayKey = AnalysisTestHelpers.calendar.startOfDay(for: day)
+    let usd = Instrument.fiat(code: "USD")
+    let aId = UUID()
+    let bId = UUID()
+    let rowA = GRDBAnalysisRepository.DailyBalanceAccountRow(
+      day: "2025-06-10", sampleDate: day,
+      accountId: aId, instrumentId: "USD", type: "trade", qty: 1000)
+    let rowB = GRDBAnalysisRepository.DailyBalanceAccountRow(
+      day: "2025-06-10", sampleDate: day,
+      accountId: bId, instrumentId: "USD", type: "trade", qty: 2000)
+    let conversion = DateBasedFixedConversionService(
+      rates: [
+        try AnalysisTestHelpers.utcDate(year: 2025, month: 1, day: 1, hour: 0): [
+          "USD": try AnalysisTestHelpers.decimal("1.5")
+        ]
+      ])
+    var balances: [Date: DailyBalance] = [
+      dayKey: GRDBDailyBalancesTradesModeTests.placeholderBalance(at: dayKey)
+    ]
+    let context = Self.makeContext(
+      tradesIds: [aId, bId],
+      instrumentMap: ["USD": usd],
+      conversionService: conversion)
+    let handlers = Self.makeHandlers { _, _ in }
+
+    try await GRDBAnalysisRepository.applyTradesModePositionValuations(
+      priorRows: [], postRows: [rowA, rowB],
+      to: &balances, context: context, handlers: handlers)
+
+    // (10 + 20) * 1.5 = 45.
+    let value = try #require(balances[dayKey]?.investmentValue)
+    #expect(value.quantity == try AnalysisTestHelpers.decimal("45"))
+  }
+```
+
+- [ ] **Step 4: Add case 3 (trades-mode + recorded-value sum)**
+
+Append:
+
+```swift
+  @Test("case 3: trades-mode + recorded-value account totals add into one investmentValue")
+  func tradesModePlusRecordedValueSum() async throws {
+    let day = try AnalysisTestHelpers.utcDate(year: 2025, month: 6, day: 10, hour: 12)
+    let dayKey = AnalysisTestHelpers.calendar.startOfDay(for: day)
+    let usd = Instrument.fiat(code: "USD")
+    let tradesId = UUID()
+    let row = GRDBAnalysisRepository.DailyBalanceAccountRow(
+      day: "2025-06-10", sampleDate: day,
+      accountId: tradesId, instrumentId: "USD", type: "trade", qty: 1000)
+    let conversion = DateBasedFixedConversionService(
+      rates: [
+        try AnalysisTestHelpers.utcDate(year: 2025, month: 1, day: 1, hour: 0): [
+          "USD": try AnalysisTestHelpers.decimal("1.5")
+        ]
+      ])
+    // Pre-seed the day with a snapshot-fold contribution so the new
+    // fold's add-not-overwrite contract is visible.
+    var balances: [Date: DailyBalance] = [
+      dayKey: DailyBalance(
+        date: dayKey,
+        balance: InstrumentAmount(
+          quantity: 10, instrument: .defaultTestInstrument),
+        earmarked: .zero(instrument: .defaultTestInstrument),
+        availableFunds: InstrumentAmount(
+          quantity: 10, instrument: .defaultTestInstrument),
+        investments: .zero(instrument: .defaultTestInstrument),
+        investmentValue: InstrumentAmount(
+          quantity: 100, instrument: .defaultTestInstrument),
+        netWorth: InstrumentAmount(
+          quantity: 110, instrument: .defaultTestInstrument),
+        bestFit: nil,
+        isForecast: false)
+    ]
+    let context = Self.makeContext(
+      tradesIds: [tradesId],
+      instrumentMap: ["USD": usd],
+      conversionService: conversion)
+    let handlers = Self.makeHandlers { _, _ in }
+
+    try await GRDBAnalysisRepository.applyTradesModePositionValuations(
+      priorRows: [], postRows: [row],
+      to: &balances, context: context, handlers: handlers)
+
+    // Snapshot 100 + trades (10 USD * 1.5) = 115.
+    let dayBalance = try #require(balances[dayKey])
+    let value = try #require(dayBalance.investmentValue)
+    #expect(value.quantity == try AnalysisTestHelpers.decimal("115"))
+    // netWorth = balance (10) + investmentValue (115) = 125.
+    #expect(dayBalance.netWorth.quantity == try AnalysisTestHelpers.decimal("125"))
+  }
+```
+
+- [ ] **Step 5: Add case 4 (Rule 11 per-day failure scoping for the new fold)**
+
+Append:
+
+```swift
+  @Test("case 4: per-day conversion failure drops day from dailyBalances")
+  func ruleEleven_perDayFailureScopedToDay() async throws {
+    let dayOne = try AnalysisTestHelpers.utcDate(year: 2025, month: 6, day: 10, hour: 12)
+    let dayTwo = try AnalysisTestHelpers.utcDate(year: 2025, month: 6, day: 11, hour: 12)
+    let keyOne = AnalysisTestHelpers.calendar.startOfDay(for: dayOne)
+    let keyTwo = AnalysisTestHelpers.calendar.startOfDay(for: dayTwo)
+    let usd = Instrument.fiat(code: "USD")
+    let accountId = UUID()
+    let rowOne = GRDBAnalysisRepository.DailyBalanceAccountRow(
+      day: "2025-06-10", sampleDate: dayOne,
+      accountId: accountId, instrumentId: "USD", type: "trade", qty: 1000)
+    // Rate available on day two only; day one fails.
+    let conversion = DateFailingConversionService(
+      rates: [
+        try AnalysisTestHelpers.utcDate(year: 2025, month: 1, day: 1, hour: 0): [
+          "USD": try AnalysisTestHelpers.decimal("1.5")
+        ]
+      ],
+      failingDates: [keyOne])
+    var balances: [Date: DailyBalance] = [
+      keyOne: GRDBDailyBalancesTradesModeTests.placeholderBalance(at: keyOne),
+      keyTwo: GRDBDailyBalancesTradesModeTests.placeholderBalance(at: keyTwo),
+    ]
+    let context = Self.makeContext(
+      tradesIds: [accountId],
+      instrumentMap: ["USD": usd],
+      conversionService: conversion)
+    var failures: [(Error, Date)] = []
+    let handlers = Self.makeHandlers { error, date in
+      failures.append((error, date))
+    }
+
+    try await GRDBAnalysisRepository.applyTradesModePositionValuations(
+      priorRows: [], postRows: [rowOne],
+      to: &balances, context: context, handlers: handlers)
+
+    // Day one dropped (failed conversion); day two retained
+    // (cumulative position 10 USD * 1.5 = 15).
+    #expect(balances[keyOne] == nil)
+    let value = try #require(balances[keyTwo]?.investmentValue)
+    #expect(value.quantity == try AnalysisTestHelpers.decimal("15"))
+    #expect(failures.count == 1)
+    #expect(failures.first?.1 == keyOne)
+  }
+```
+
+- [ ] **Step 6: Add cases 5 and 6 (snapshot-fold-then-trades-fold interactions)**
+
+Case 5 was added in Task 5. Case 6 follows the §9.3 spec: when the
+trades fold fails on day D after the snapshot fold succeeded, day D
+is dropped.
+
+Append:
+
+```swift
+  @Test("case 6: trades-fold failure on day D after snapshot-fold success drops day")
+  func mixedFoldFailureDropsDay() async throws {
+    let day = try AnalysisTestHelpers.utcDate(year: 2025, month: 6, day: 10, hour: 12)
+    let dayKey = AnalysisTestHelpers.calendar.startOfDay(for: day)
+    let usd = Instrument.fiat(code: "USD")
+    let accountId = UUID()
+    let row = GRDBAnalysisRepository.DailyBalanceAccountRow(
+      day: "2025-06-10", sampleDate: day,
+      accountId: accountId, instrumentId: "USD", type: "trade", qty: 1000)
+    let conversion = DateFailingConversionService(
+      rates: [:], failingDates: [dayKey])
+    // Pre-seed the day as if applyInvestmentValues had succeeded with
+    // a recorded-value snapshot total of 100.
+    var balances: [Date: DailyBalance] = [
+      dayKey: DailyBalance(
+        date: dayKey,
+        balance: InstrumentAmount(
+          quantity: 10, instrument: .defaultTestInstrument),
+        earmarked: .zero(instrument: .defaultTestInstrument),
+        availableFunds: InstrumentAmount(
+          quantity: 10, instrument: .defaultTestInstrument),
+        investments: .zero(instrument: .defaultTestInstrument),
+        investmentValue: InstrumentAmount(
+          quantity: 100, instrument: .defaultTestInstrument),
+        netWorth: InstrumentAmount(
+          quantity: 110, instrument: .defaultTestInstrument),
+        bestFit: nil,
+        isForecast: false)
+    ]
+    let context = Self.makeContext(
+      tradesIds: [accountId],
+      instrumentMap: ["USD": usd],
+      conversionService: conversion)
+    var failures: [(Error, Date)] = []
+    let handlers = Self.makeHandlers { error, date in
+      failures.append((error, date))
+    }
+
+    try await GRDBAnalysisRepository.applyTradesModePositionValuations(
+      priorRows: [], postRows: [row],
+      to: &balances, context: context, handlers: handlers)
+
+    #expect(balances[dayKey] == nil)
+    #expect(failures.count == 1)
+  }
+```
+
+- [ ] **Step 7: Add case 7 (Rule 10 startOfDay normalization)**
+
+The fold uses `Calendar.current.startOfDay(for: row.sampleDate)` for
+the cursor key. Two trades whose `sampleDate` straddles a local-day
+boundary must apply on their respective `startOfDay` keys.
+
+Append:
+
+```swift
+  @Test("case 7: startOfDay normalization keys days correctly across local boundary")
+  func rule10StartOfDayNormalization() async throws {
+    let cal = AnalysisTestHelpers.calendar
+    // Create two timestamps in the same local day; both must
+    // produce the same dayKey.
+    let dayMorning = try AnalysisTestHelpers.date(year: 2025, month: 6, day: 10, hour: 9)
+    let dayEvening = try AnalysisTestHelpers.date(year: 2025, month: 6, day: 10, hour: 23)
+    let dayKey = cal.startOfDay(for: dayMorning)
+    #expect(cal.startOfDay(for: dayEvening) == dayKey)
+
+    let usd = Instrument.fiat(code: "USD")
+    let accountId = UUID()
+    let rowMorning = GRDBAnalysisRepository.DailyBalanceAccountRow(
+      day: "2025-06-10", sampleDate: dayMorning,
+      accountId: accountId, instrumentId: "USD", type: "trade", qty: 500)
+    let rowEvening = GRDBAnalysisRepository.DailyBalanceAccountRow(
+      day: "2025-06-10", sampleDate: dayEvening,
+      accountId: accountId, instrumentId: "USD", type: "trade", qty: 500)
+    let conversion = DateBasedFixedConversionService(
+      rates: [
+        try AnalysisTestHelpers.utcDate(year: 2025, month: 1, day: 1, hour: 0): [
+          "USD": try AnalysisTestHelpers.decimal("1.5")
+        ]
+      ])
+    var balances: [Date: DailyBalance] = [
+      dayKey: GRDBDailyBalancesTradesModeTests.placeholderBalance(at: dayKey)
+    ]
+    let context = Self.makeContext(
+      tradesIds: [accountId],
+      instrumentMap: ["USD": usd],
+      conversionService: conversion)
+    let handlers = Self.makeHandlers { _, _ in }
+
+    try await GRDBAnalysisRepository.applyTradesModePositionValuations(
+      priorRows: [], postRows: [rowMorning, rowEvening],
+      to: &balances, context: context, handlers: handlers)
+
+    // Both rows applied on the same dayKey; total = 10 USD * 1.5 = 15.
+    let value = try #require(balances[dayKey]?.investmentValue)
+    #expect(value.quantity == try AnalysisTestHelpers.decimal("15"))
+  }
+```
+
+- [ ] **Step 8: Add cases 10 and 11 (CSV transfer+trade, same-day BUY+SELL)**
+
+Append:
+
+```swift
+  @Test("case 10: CSV-imported transfer cash leg + trade position leg both contribute")
+  func csvImportedTransferPlusTrade() async throws {
+    let day = try AnalysisTestHelpers.utcDate(year: 2025, month: 6, day: 10, hour: 12)
+    let dayKey = AnalysisTestHelpers.calendar.startOfDay(for: day)
+    let usd = Instrument.fiat(code: "USD")
+    let aud = Instrument.defaultTestInstrument
+    let accountId = UUID()
+    // .transfer cash leg in profile instrument (AUD) — Rule 8 fast path.
+    let cashRow = GRDBAnalysisRepository.DailyBalanceAccountRow(
+      day: "2025-06-10", sampleDate: day,
+      accountId: accountId, instrumentId: aud.id, type: "transfer", qty: 5000)
+    // .trade position leg in USD.
+    let tradeRow = GRDBAnalysisRepository.DailyBalanceAccountRow(
+      day: "2025-06-10", sampleDate: day,
+      accountId: accountId, instrumentId: "USD", type: "trade", qty: 1000)
+    let conversion = DateBasedFixedConversionService(
+      rates: [
+        try AnalysisTestHelpers.utcDate(year: 2025, month: 1, day: 1, hour: 0): [
+          "USD": try AnalysisTestHelpers.decimal("1.5")
+        ]
+      ])
+    var balances: [Date: DailyBalance] = [
+      dayKey: GRDBDailyBalancesTradesModeTests.placeholderBalance(at: dayKey)
+    ]
+    let context = Self.makeContext(
+      tradesIds: [accountId],
+      instrumentMap: [aud.id: aud, "USD": usd],
+      conversionService: conversion)
+    let handlers = Self.makeHandlers { _, _ in }
+
+    try await GRDBAnalysisRepository.applyTradesModePositionValuations(
+      priorRows: [], postRows: [cashRow, tradeRow],
+      to: &balances, context: context, handlers: handlers)
+
+    // Cash 50 (AUD identity) + position 10 USD * 1.5 = 65.
+    let value = try #require(balances[dayKey]?.investmentValue)
+    #expect(value.quantity == try AnalysisTestHelpers.decimal("65"))
+  }
+
+  @Test("case 11: same-day BUY + SELL netting produces zero contribution")
+  func sameDayBuyAndSellNetZero() async throws {
+    let day = try AnalysisTestHelpers.utcDate(year: 2025, month: 6, day: 10, hour: 12)
+    let dayKey = AnalysisTestHelpers.calendar.startOfDay(for: day)
+    let usd = Instrument.fiat(code: "USD")
+    let accountId = UUID()
+    let buy = GRDBAnalysisRepository.DailyBalanceAccountRow(
+      day: "2025-06-10", sampleDate: day,
+      accountId: accountId, instrumentId: "USD", type: "trade", qty: 1000)
+    let sell = GRDBAnalysisRepository.DailyBalanceAccountRow(
+      day: "2025-06-10", sampleDate: day,
+      accountId: accountId, instrumentId: "USD", type: "trade", qty: -1000)
+    let conversion = DateBasedFixedConversionService(
+      rates: [
+        try AnalysisTestHelpers.utcDate(year: 2025, month: 1, day: 1, hour: 0): [
+          "USD": try AnalysisTestHelpers.decimal("1.5")
+        ]
+      ])
+    var balances: [Date: DailyBalance] = [
+      dayKey: GRDBDailyBalancesTradesModeTests.placeholderBalance(at: dayKey)
+    ]
+    let context = Self.makeContext(
+      tradesIds: [accountId],
+      instrumentMap: ["USD": usd],
+      conversionService: conversion)
+    let handlers = Self.makeHandlers { _, _ in }
+
+    try await GRDBAnalysisRepository.applyTradesModePositionValuations(
+      priorRows: [], postRows: [buy, sell],
+      to: &balances, context: context, handlers: handlers)
+
+    // Net position is 0; investmentValue ends up at 0 (zero added to
+    // existing nil → .zero(instrument: AUD)).
+    let value = try #require(balances[dayKey]?.investmentValue)
+    #expect(value.quantity == 0)
+  }
+```
+
+- [ ] **Step 9: Add case 12 (carry-forward across a dropped day)**
+
+Append:
+
+```swift
+  @Test("case 12: carry-forward across a dropped day stays correct")
+  func carryForwardAcrossDroppedDay() async throws {
+    let dayOne = try AnalysisTestHelpers.utcDate(year: 2025, month: 6, day: 10, hour: 12)
+    let dayTwo = try AnalysisTestHelpers.utcDate(year: 2025, month: 6, day: 11, hour: 12)
+    let keyOne = AnalysisTestHelpers.calendar.startOfDay(for: dayOne)
+    let keyTwo = AnalysisTestHelpers.calendar.startOfDay(for: dayTwo)
+    let usd = Instrument.fiat(code: "USD")
+    let accountId = UUID()
+    let rowOne = GRDBAnalysisRepository.DailyBalanceAccountRow(
+      day: "2025-06-10", sampleDate: dayOne,
+      accountId: accountId, instrumentId: "USD", type: "trade", qty: 1000)
+    let conversion = DateBasedFixedConversionService(
+      rates: [
+        try AnalysisTestHelpers.utcDate(year: 2025, month: 1, day: 1, hour: 0): [
+          "USD": try AnalysisTestHelpers.decimal("1.5")
+        ]
+      ])
+    // Simulate a snapshot-fold dropout on day 1: dailyBalances has
+    // entries only for day 2 (day 1 was removed by an earlier fold).
+    var balances: [Date: DailyBalance] = [
+      keyTwo: GRDBDailyBalancesTradesModeTests.placeholderBalance(at: keyTwo)
+    ]
+    let context = Self.makeContext(
+      tradesIds: [accountId],
+      instrumentMap: ["USD": usd],
+      conversionService: conversion)
+    let handlers = Self.makeHandlers { _, _ in }
+
+    try await GRDBAnalysisRepository.applyTradesModePositionValuations(
+      priorRows: [], postRows: [rowOne],
+      to: &balances, context: context, handlers: handlers)
+
+    // Day 2 must valuate the cumulative position from day 1's buy
+    // even though day 1 itself isn't in dailyBalances.
+    let value = try #require(balances[keyTwo]?.investmentValue)
+    #expect(value.quantity == try AnalysisTestHelpers.decimal("15"))
+  }
+```
+
+- [ ] **Step 10: Format and run the new suite**
+
+```bash
+just format
+just test-mac GRDBDailyBalancesTradesModeTests 2>&1 | tee .agent-tmp/test.txt
+grep -i "failed\|error:" .agent-tmp/test.txt
+```
+
+Expected: 12 tests pass.
+
+- [ ] **Step 11: Run the entire daily-balance test surface to confirm nothing else regresses**
+
+```bash
+just test-mac GRDBDailyBalancesAssembleTests GRDBDailyBalancesConversionTests AnalysisRule11ScopingTests DailyBalancesPlanPinningTests GRDBDailyBalancesAggregateTradesModeTests GRDBDailyBalancesTradesModeTests 2>&1 | tee .agent-tmp/test.txt
+grep -i "failed\|error:" .agent-tmp/test.txt
+```
+
+Expected: no failures.
+
+- [ ] **Step 12: Commit**
+
+```bash
+git -C . add MoolahTests/Backends/GRDB/GRDBDailyBalancesTradesModeTests.swift
+git -C . commit -m "test(grdb): trades-mode position-valuation fold contract tests"
+```
+
+---
+
+## Task 8: Cross-cutting verification — build everything, run full mac suite, format-check
+
+**Files:**
+- None (verification only)
+
+- [ ] **Step 1: Run `just format` to apply final formatting**
+
+```bash
+just format
+```
+
+- [ ] **Step 2: Run `just format-check` to confirm CI will pass**
+
+```bash
+just format-check 2>&1 | tee .agent-tmp/format-check.txt
+echo "exit: $?"
+```
+
+Expected: exit code 0. If non-zero, inspect the file flagged by the
+output and fix the formatting / SwiftLint issue without modifying
+`.swiftlint-baseline.yml`.
+
+- [ ] **Step 3: Run the full macOS test suite**
+
+```bash
+just test-mac 2>&1 | tee .agent-tmp/test-mac.txt
+grep -i "failed\|error:" .agent-tmp/test-mac.txt
+```
+
+Expected: no failures. Investigate any failures by re-running the
+specific class:
+
+```bash
+just test-mac <FailingClass> 2>&1 | tee .agent-tmp/test-fail.txt
+```
+
+- [ ] **Step 4: Run a build of the macOS app to surface any warnings-as-errors**
+
+```bash
+just build-mac 2>&1 | tee .agent-tmp/build.txt
+grep -E "error:|warning:" .agent-tmp/build.txt | grep -v "Preview"
+```
+
+Expected: clean (Preview macro warnings are acceptable per CLAUDE.md;
+all other warnings are errors per `SWIFT_TREAT_WARNINGS_AS_ERRORS:
+YES`).
+
+- [ ] **Step 5: Clean up `.agent-tmp/`**
+
+```bash
+rm -f .agent-tmp/build.txt .agent-tmp/test*.txt .agent-tmp/format-check.txt
+```
+
+---
+
+## Task 9: Run review agents and apply findings
+
+**Files:**
+- None initially (review-driven; files modified per agent findings)
+
+- [ ] **Step 1: Run the four relevant review agents in parallel**
+
+Spawn `code-review`, `database-code-review`,
+`instrument-conversion-review`, `concurrency-review` agents on the
+working tree. Brief each on the task: "review the trades-mode
+historical fold change against your guide; the design spec is
+`plans/2026-05-04-trades-mode-historical-net-worth-design.md`."
+
+- [ ] **Step 2: For each finding, apply the fix in the appropriate file**
+
+Apply Critical and Important findings always. Apply Minor findings
+unless deferred with explicit user authorisation. Each fix is a
+separate commit, named for what it does (not "review feedback").
+
+- [ ] **Step 3: Re-run reviewers after every batch of fixes**
+
+Iterate until all four agents return clean.
+
+- [ ] **Step 4: Re-run `just format-check` and `just test-mac` after the final
+  fix batch**
+
+```bash
+just format-check
+just test-mac 2>&1 | tee .agent-tmp/test-mac.txt
+grep -i "failed\|error:" .agent-tmp/test-mac.txt
+```
+
+Expected: clean.
+
+- [ ] **Step 5: Commit anything outstanding from the review pass**
+
+(Each review fix should already be committed; this step is a
+last-pass safety net.)
+
+---
+
+## Task 10: Open PR and queue
+
+**Files:**
+- None (PR-only)
+
+- [ ] **Step 1: Push the branch with explicit `<src>:<dst>` form**
+
+```bash
+git -C . push origin trades-mode/historical-chart:trades-mode/historical-chart
+```
+
+- [ ] **Step 2: Open the PR**
+
+```bash
+gh pr create \
+  --base main \
+  --head trades-mode/historical-chart \
+  --title "feat(grdb): trades-mode historical net-worth fold + Rule 11 tighten" \
+  --body "$(cat <<'EOF'
+## Summary
+
+- Adds a per-day "valued positions over time" fold for trades-mode
+  investment accounts (`applyTradesModePositionValuations` in
+  `Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesInvestmentValues.swift`).
+- Pre-filters trades-mode rows in `readDailyBalancesAggregation` so
+  the fold takes purpose-built input.
+- Tightens `applyInvestmentValues` to drop the day from
+  `dailyBalances` on per-day conversion failure (Rule 11 alignment
+  with `walkDays`); drops the vestigial `?` on `sumInvestmentValues`'s
+  return type.
+
+Fixes #738.
+
+Design spec:
+[plans/2026-05-04-trades-mode-historical-net-worth-design.md](https://github.com/ajsutton/moolah-native/blob/trades-mode/historical-chart/plans/2026-05-04-trades-mode-historical-net-worth-design.md).
+Implementation plan:
+[plans/2026-05-04-trades-mode-historical-net-worth-plan.md](https://github.com/ajsutton/moolah-native/blob/trades-mode/historical-chart/plans/2026-05-04-trades-mode-historical-net-worth-plan.md).
+
+## Test plan
+
+- [x] `just test-mac GRDBDailyBalancesTradesModeTests` — 12 fold-contract tests pass
+- [x] `just test-mac GRDBDailyBalancesAggregateTradesModeTests` — 3 aggregation pins pass
+- [x] `just test-mac GRDBDailyBalancesAssembleTests/snapshotFoldDropsDayOnFailure` — Rule 11 tightening pinned
+- [x] `just test-mac DailyBalancesPlanPinningTests` — `account_by_type` plan pinned for the new fetch
+- [x] `just test-mac` (full mac suite) — no regressions
+- [x] `just format-check` — clean
+- [x] `just build-mac` — clean
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 2: Add the PR to the merge queue**
+
+Use the `merge-queue` skill to queue the PR:
+
+```
+/skill merge-queue add <PR_NUMBER>
+```
+
+(The PR number is in the `gh pr create` output; substitute it.)
+
+- [ ] **Step 3: Verify the PR is in the queue**
+
+```bash
+~/.claude/skills/merge-queue/scripts/merge-queue-ctl.sh status
+```
+
+Expected: the PR appears in the queue.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+| Spec section | Implementing task |
+|--------------|-------------------|
+| §1 New SQL fetch | Task 1 |
+| §2 Aggregation type with new fields | Task 2 + Task 3 |
+| §3 Assembly context with trades-mode set | Task 2 |
+| §4 New fold algorithm | Task 6 |
+| §5 `sumTradesModePositions` helper | Task 6 |
+| §5 `sumInvestmentValues` `?` cleanup | Task 5 |
+| §6 Wire into `assembleDailyBalances` | Task 6 (step 2) |
+| §6 `applyInvestmentValues` Rule 11 tighten | Task 5 |
+| §7 Edge cases | Tasks 7 cases 1, 2, 3, 4, 6, 7, 10, 11, 12 |
+| §8 Plan-pinning | Task 1 |
+| §9.1 Plan-pinning | Task 1 |
+| §9.2 Aggregation-layer | Task 4 |
+| §9.3 Fold-contract cases 1–12 | Task 7 (cases 1, 2, 3, 4, 6, 7, 8, 9, 10, 11, 12) and Task 5 (case 5) |
+| §10 Two-catch shape | Task 6 (literal sketch in fold body) + Task 5 (literal sketch in `applyInvestmentValues`) |
+| §11 Logging / `Calendar.current` | Task 6 (no new logger; reuses handler) |
+| §12 Performance | Implicitly verified via `just test-mac` (no regressions) |
+| §13 File-size budget | Task 8 (`just format-check`) |
+
+No spec section is unimplemented.
+
+**Type / signature consistency:**
+
+- `TradesModePositionEntry` is defined once in Task 6 step 1 and used
+  there only.
+- `applyTradesModePositionValuations(priorRows:postRows:to:context:handlers:)`
+  signature is identical at the definition (Task 6 step 1) and at the
+  call site (Task 6 step 2).
+- `sumTradesModePositions(positions:on:profileInstrument:conversionService:)`
+  signature is identical at definition and call site (Task 6 step 1).
+- `fetchTradesModeInvestmentAccountIds(database:)` is identical at
+  definition (Task 1 step 3) and call site (Task 3 step 1).
+- `tradesModeInvestmentAccountIds: Set<UUID>` is the field name on
+  both `DailyBalancesAggregation` (Task 2 step 1) and
+  `DailyBalancesAssemblyContext` (Task 2 step 2), and is referenced
+  by that exact name in Task 3 step 1, Task 6 step 2, and the test
+  helpers in Task 7 step 1.
+- `priorTradesModeAccountRows` / `tradesModeAccountRows` field names
+  are stable across Task 2, Task 3, Task 4, and Task 6.
+
+No signature drift.
+
+**Placeholder scan:**
+
+No "TBD", "TODO", "implement later", "fill in details", or "Similar
+to Task N" without inline code. Every step shows the exact code or
+exact command. Caveat: Task 9 (review-driven) describes the iteration
+loop without prescribing specific findings — that's appropriate
+because the findings depend on what the reviewers say. Task 10
+prescribes the PR body verbatim.

--- a/plans/2026-05-04-trades-mode-historical-net-worth-plan.md
+++ b/plans/2026-05-04-trades-mode-historical-net-worth-plan.md
@@ -111,12 +111,72 @@ spec:
 ## Task 0: Add test-support helpers (`InvestmentValueFailureLog`, local-calendar `date(...)` overload)
 
 **Files:**
+- Modify: `MoolahTests/Support/DateFailingConversionService.swift`
 - Modify: `MoolahTests/Support/ThrowingCountingConversionService.swift`
 - Modify: `MoolahTests/Support/AnalysisTestHelpers.swift`
 
-These helpers are dependencies of Tasks 5 and 7. They are tiny, mechanical
-additions and have no production-code coupling — landing them first keeps
-each subsequent task self-contained.
+These helpers are dependencies of Tasks 5 and 7. They are tiny,
+mechanical additions and behaviour-preserving simplifications
+with no production-code coupling — landing them first keeps each
+subsequent task self-contained.
+
+- [ ] **Step 0: Make `DateFailingConversionService` trust caller-normalised dates**
+
+Open `MoolahTests/Support/DateFailingConversionService.swift`. The
+existing `convert(...)` body re-normalises the incoming `date` with
+`Calendar(identifier: .gregorian).startOfDay(for:)` before checking
+membership in `failingDates`:
+
+```swift
+let dayKey = Calendar(identifier: .gregorian).startOfDay(for: date)
+if failingDates.contains(dayKey) {
+  throw DateFailingConversionError.unavailable(date: dayKey)
+}
+```
+
+Production callers (the existing `applyInvestmentValues` and the
+new `applyTradesModePositionValuations`) already pass a `dayKey`
+produced by `Calendar.current.startOfDay(for: row.sampleDate)`. The
+re-normalisation step is redundant for those callers and silently
+mismatches when the host calendar is non-Gregorian (Rule 10
+inconsistency). Drop the re-normalisation and trust the caller's
+already-normalised date:
+
+```swift
+func convert(
+  _ quantity: Decimal, from: Instrument, to: Instrument, on date: Date
+) async throws -> Decimal {
+  if from.id == to.id { return quantity }
+  // The caller is expected to pass a startOfDay-normalized date —
+  // matches the contract every caller in `MoolahTests` honours.
+  // Applying a second calendar's startOfDay here would silently
+  // disagree on non-Gregorian locales (Rule 10) and turn the test
+  // into a false-green.
+  if failingDates.contains(date) {
+    throw DateFailingConversionError.unavailable(date: date)
+  }
+  let asOf = ratesAsOf(date)
+  guard let rate = asOf[from.id] else {
+    return quantity
+  }
+  return quantity * rate
+}
+```
+
+Existing call sites already pass `startOfDay`-normalised dates
+(verified by grepping `.startOfDay` against `failingDates:`
+construction in `MoolahTests/`); the simplification is
+behaviour-preserving for them.
+
+Verify by running every existing test that uses
+`DateFailingConversionService`:
+
+```bash
+just test-mac AnalysisRule11ScopingTests 2>&1 | tee .agent-tmp/test.txt
+grep -i "failed\|error:" .agent-tmp/test.txt
+```
+
+Expected: no failures.
 
 - [ ] **Step 1: Add `InvestmentValueFailureLog` to `ThrowingCountingConversionService.swift`**
 
@@ -125,10 +185,13 @@ the bottom of the file, after the existing `FailureLog` class, add:
 
 ```swift
 /// Async-safe collector for `(Error, Date)` failure tuples emitted by
-/// `DailyBalancesHandlers.handleInvestmentValueFailure`. Used by tests
-/// that need to assert which day surfaced through the per-day error
-/// callback (and how many times). Backed by `OSAllocatedUnfairLock`
-/// for the same `@Sendable`-closure-mutation reason as `FailureLog`.
+/// `DailyBalancesHandlers.handleInvestmentValueFailure`. Used by
+/// tests that need to assert which day surfaced through the per-day
+/// error callback (and how many times). Backed by
+/// `OSAllocatedUnfairLock` for the same `@Sendable`-closure-mutation
+/// reason as `FailureLog` — and exposes only `append(_:_:)` and
+/// `snapshot()` so multi-field reads are atomic with respect to a
+/// single lock acquisition (mirrors the `FailureLog` API shape).
 final class InvestmentValueFailureLog: Sendable {
   private let entries = OSAllocatedUnfairLock<[(Error, Date)]>(initialState: [])
 
@@ -138,14 +201,6 @@ final class InvestmentValueFailureLog: Sendable {
 
   func snapshot() -> [(Error, Date)] {
     entries.withLock { $0 }
-  }
-
-  var count: Int {
-    entries.withLock { $0.count }
-  }
-
-  var dates: [Date] {
-    entries.withLock { $0.map(\.1) }
   }
 }
 ```
@@ -194,8 +249,8 @@ Expected: clean.
 - [ ] **Step 4: Commit**
 
 ```bash
-git -C . add MoolahTests/Support/ThrowingCountingConversionService.swift MoolahTests/Support/AnalysisTestHelpers.swift
-git -C . commit -m "test(support): add InvestmentValueFailureLog + local-calendar date helper"
+git add MoolahTests/Support/DateFailingConversionService.swift MoolahTests/Support/ThrowingCountingConversionService.swift MoolahTests/Support/AnalysisTestHelpers.swift
+git commit -m "test(support): add InvestmentValueFailureLog, date(hour:), simplify DateFailingConversionService"
 ```
 
 ---
@@ -311,24 +366,27 @@ Expected: no failures.
 - [ ] **Step 6: Commit**
 
 ```bash
-git -C . add Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesInvestmentValues.swift MoolahTests/Backends/GRDB/DailyBalancesPlanPinningTests.swift
-git -C . commit -m "feat(grdb): add fetchTradesModeInvestmentAccountIds + plan-pin"
+git add Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesInvestmentValues.swift MoolahTests/Backends/GRDB/DailyBalancesPlanPinningTests.swift
+git commit -m "feat(grdb): add fetchTradesModeInvestmentAccountIds + plan-pin"
 ```
 
 ---
 
-## Task 2: Extend `DailyBalancesAggregation`, `DailyBalancesAssemblyContext`, widen `resolveInstrument`, and update existing `makeAggregation()`
+## Task 2: Extend `DailyBalancesAggregation`, `DailyBalancesAssemblyContext`, widen `resolveInstrument`, and seed the production aggregation builder with empty defaults
 
 **Files:**
 - Modify: `Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalances.swift`
+- Modify: `Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesAggregation.swift`
 - Modify: `MoolahTests/Backends/GRDB/GRDBDailyBalancesAssembleTests.swift`
 
-This task adds the new struct fields, widens
-`resolveInstrument`'s access from `private` to `internal`, and
-updates the *existing* `makeAggregation()` test helper so the
-project still compiles after the struct gains required fields.
-Without that update the working tree is non-compiling between
-Task 2 and Task 3.
+This task adds the new struct fields, widens `resolveInstrument`'s
+access from `private` to `internal`, updates the *existing*
+`makeAggregation()` test helper to pass empty defaults for the new
+fields, **and** seeds `readDailyBalancesAggregation` (the production
+aggregation builder) with the same empty defaults so the working
+tree compiles after Task 2's commit. Task 3 then replaces those
+empty defaults with the real `fetchTradesModeInvestmentAccountIds`
+fetch and the prior/post row pre-filter.
 
 - [ ] **Step 1: Add new fields to `DailyBalancesAggregation`**
 
@@ -441,28 +499,57 @@ fields with empty defaults:
 (Diff: three new fields between `investmentAccountIds` and
 `scheduled`.)
 
-- [ ] **Step 6: Build to confirm compilation**
+- [ ] **Step 6: Seed the production aggregation builder with empty defaults**
 
-`DailyBalancesAggregation`'s other constructing call site
-(`readDailyBalancesAggregation` in `+DailyBalancesAggregation.swift`)
-will still fail; Task 3 fixes it. The Swift compiler will report
-that single call site failing — confirm it's the only failure, then
-proceed to Task 3.
+Open `Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesAggregation.swift`.
+Locate `readDailyBalancesAggregation` (around line 47). Update the
+`DailyBalancesAggregation(...)` constructor at the end of the
+function to add the three new fields with empty defaults — the
+real values land in Task 3:
+
+```swift
+    return DailyBalancesAggregation(
+      priorAccountRows: priorAccountRows,
+      priorEarmarkRows: priorEarmarkRows,
+      accountRows: accountRows,
+      earmarkRows: earmarkRows,
+      investmentValues: investmentValues,
+      investmentAccountIds: investmentAccountIds,
+      tradesModeInvestmentAccountIds: [],     // populated in Task 3
+      priorTradesModeAccountRows: [],         // populated in Task 3
+      tradesModeAccountRows: [],              // populated in Task 3
+      scheduled: scheduled,
+      instrumentMap: instrumentMap,
+      forecastUntil: forecastUntil)
+```
+
+The empty defaults are temporary — Task 3 swaps them out for the
+real fetch + filter inside the same `database.read` snapshot. They
+exist here only so the working tree compiles after Task 2's commit.
+
+- [ ] **Step 7: Build to confirm compilation**
 
 ```bash
 just build-mac 2>&1 | tee .agent-tmp/build.txt
 grep "error:" .agent-tmp/build.txt | grep -v "Preview"
 ```
 
-Expected: only `+DailyBalancesAggregation.swift` errors about missing
-arguments to `DailyBalancesAggregation`. Anything else is unexpected
-— investigate before proceeding.
+Expected: clean. The whole tree compiles.
 
-- [ ] **Step 7: Commit**
+- [ ] **Step 8: Run the existing test suites to confirm nothing regresses**
 
 ```bash
-git -C . add Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalances.swift MoolahTests/Backends/GRDB/GRDBDailyBalancesAssembleTests.swift
-git -C . commit -m "feat(grdb): add trades-mode fields to DailyBalancesAggregation; widen resolveInstrument"
+just test-mac GRDBDailyBalancesAssembleTests GRDBDailyBalancesConversionTests AnalysisRule11ScopingTests DailyBalancesPlanPinningTests 2>&1 | tee .agent-tmp/test.txt
+grep -i "failed\|error:" .agent-tmp/test.txt
+```
+
+Expected: no failures.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalances.swift Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesAggregation.swift MoolahTests/Backends/GRDB/GRDBDailyBalancesAssembleTests.swift
+git commit -m "feat(grdb): add trades-mode fields to DailyBalancesAggregation; widen resolveInstrument"
 ```
 
 ---
@@ -471,6 +558,11 @@ git -C . commit -m "feat(grdb): add trades-mode fields to DailyBalancesAggregati
 
 **Files:**
 - Modify: `Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesAggregation.swift`
+
+This task replaces Task 2's empty defaults with the real fetch and
+pre-filter. After this commit, `tradesModeInvestmentAccountIds`,
+`priorTradesModeAccountRows`, and `tradesModeAccountRows` all carry
+real data.
 
 - [ ] **Step 1: Update `readDailyBalancesAggregation` to populate the new fields**
 
@@ -580,8 +672,8 @@ Expected: no failures.
 - [ ] **Step 5: Commit**
 
 ```bash
-git -C . add Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesAggregation.swift
-git -C . commit -m "feat(grdb): wire fetchTradesModeInvestmentAccountIds into aggregation read"
+git add Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesAggregation.swift
+git commit -m "feat(grdb): wire fetchTradesModeInvestmentAccountIds into aggregation read"
 ```
 
 ---
@@ -768,8 +860,8 @@ Expected: 3 tests pass.
 - [ ] **Step 5: Commit**
 
 ```bash
-git -C . add MoolahTests/Backends/GRDB/GRDBDailyBalancesAggregateTests.swift MoolahTests/Support/CloudKitAnalysisTestBackend.swift
-git -C . commit -m "test(grdb): aggregation-layer pins for trades-mode fields"
+git add MoolahTests/Backends/GRDB/GRDBDailyBalancesAggregateTests.swift MoolahTests/Support/CloudKitAnalysisTestBackend.swift
+git commit -m "test(grdb): aggregation-layer pins for trades-mode fields"
 ```
 
 ---
@@ -857,8 +949,9 @@ Add a new test at the bottom of the existing suite:
     // Rule 11: a snapshot conversion failure on day D must drop day D
     // from dailyBalances. Sibling days (none here) are unaffected.
     #expect(dailyBalances[dayKey] == nil)
-    #expect(captured.count == 1)
-    #expect(captured.dates == [dayKey])
+    let snapshot = captured.snapshot()
+    #expect(snapshot.count == 1)
+    #expect(snapshot.first?.1 == dayKey)
   }
 ```
 
@@ -984,8 +1077,8 @@ Expected: no failures.
 - [ ] **Step 7: Commit**
 
 ```bash
-git -C . add Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesInvestmentValues.swift MoolahTests/Backends/GRDB/GRDBDailyBalancesAssembleTests.swift
-git -C . commit -m "fix(grdb): drop snapshot day on conversion failure (Rule 11) + cleanup"
+git add Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesInvestmentValues.swift MoolahTests/Backends/GRDB/GRDBDailyBalancesAssembleTests.swift
+git commit -m "fix(grdb): drop snapshot day on conversion failure (Rule 11) + cleanup"
 ```
 
 ---
@@ -1212,8 +1305,8 @@ Expected: no failures.
 - [ ] **Step 5: Commit**
 
 ```bash
-git -C . add Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesInvestmentValues.swift Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalances.swift
-git -C . commit -m "feat(grdb): per-day trades-mode position-valuation fold"
+git add Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesInvestmentValues.swift Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalances.swift
+git commit -m "feat(grdb): per-day trades-mode position-valuation fold"
 ```
 
 ---
@@ -1234,7 +1327,6 @@ Create `MoolahTests/Backends/GRDB/GRDBDailyBalancesTradesModeTests.swift`:
 
 ```swift
 import Foundation
-import GRDB
 import Testing
 
 @testable import Moolah
@@ -1372,7 +1464,7 @@ Inside the same `struct GRDBDailyBalancesTradesModeTests` body, append:
       to: &balances, context: context, handlers: handlers)
 
     #expect(balances.isEmpty)
-    #expect(captured.count == 0)
+    #expect(captured.snapshot().isEmpty)
   }
 ```
 
@@ -1525,8 +1617,9 @@ Append:
     #expect(balances[keyOne] == nil)
     let value = try #require(balances[keyTwo]?.investmentValue)
     #expect(value.quantity == try AnalysisTestHelpers.decimal("15"))
-    #expect(captured.count == 1)
-    #expect(captured.dates == [keyOne])
+    let snapshot = captured.snapshot()
+    #expect(snapshot.count == 1)
+    #expect(snapshot.first?.1 == keyOne)
   }
 ```
 
@@ -1582,8 +1675,9 @@ Append:
       to: &balances, context: context, handlers: handlers)
 
     #expect(balances[dayKey] == nil)
-    #expect(captured.count == 1)
-    #expect(captured.dates == [dayKey])
+    let snapshot = captured.snapshot()
+    #expect(snapshot.count == 1)
+    #expect(snapshot.first?.1 == dayKey)
   }
 ```
 
@@ -1731,11 +1825,12 @@ Append:
 
     // After the cursor advance, positions[accountId][USD] = 0 — the
     // outer dict key is still present, so positions.isEmpty is false
-    // and `sumTradesModePositions` is invoked. The Rule 8 fast path
-    // (USD ≠ AUD profile, so the conversion service is called) plus
-    // the zero quantity yields a 0 contribution. existing.investmentValue
-    // is nil, so `(nil ?? .zero) + .zero == .zero`, and the day's
-    // investmentValue ends up at .zero(instrument: AUD).
+    // and `sumTradesModePositions` is invoked. USD ≠ AUD profile, so
+    // the Rule 8 fast path does NOT apply and the conversion service
+    // is called with quantity 0; `0 * rate = 0` regardless of the
+    // rate. existing.investmentValue is nil, so `(nil ?? .zero(AUD))
+    // + .zero(AUD) == .zero(AUD)`. The day's investmentValue is
+    // .zero(AUD) — non-nil, but quantity == 0.
     let value = try #require(balances[dayKey]?.investmentValue)
     #expect(value.quantity == 0)
   }
@@ -1783,6 +1878,45 @@ Append:
     let value = try #require(balances[keyTwo]?.investmentValue)
     #expect(value.quantity == try AnalysisTestHelpers.decimal("15"))
   }
+
+  @Test("case 13: priorRows seed contributes to first in-window day")
+  func priorRowsSeedSeenOnFirstWindowDay() async throws {
+    // priorRows simulates pre-cutoff legs the user holds going into
+    // the window. The fold's pre-fold seed (§4 step 2) must apply
+    // them so the first in-window dayKey valuates the carried
+    // position.
+    let priorDay = try AnalysisTestHelpers.utcDate(year: 2025, month: 5, day: 1, hour: 12)
+    let windowDay = try AnalysisTestHelpers.utcDate(year: 2025, month: 6, day: 10, hour: 12)
+    let dayKey = Calendar.current.startOfDay(for: windowDay)
+    let usd = Instrument.fiat(code: "USD")
+    let accountId = UUID()
+    let prior = GRDBAnalysisRepository.DailyBalanceAccountRow(
+      day: "2025-05-01", sampleDate: priorDay,
+      accountId: accountId, instrumentId: "USD", type: "trade", qty: 1000)
+    let conversion = DateBasedFixedConversionService(
+      rates: [
+        try AnalysisTestHelpers.utcDate(year: 2025, month: 1, day: 1, hour: 0): [
+          "USD": try AnalysisTestHelpers.decimal("1.5")
+        ]
+      ])
+    var balances: [Date: DailyBalance] = [
+      dayKey: Self.placeholderBalance(at: dayKey)
+    ]
+    let context = Self.makeContext(
+      tradesIds: [accountId],
+      instrumentMap: ["USD": usd],
+      conversionService: conversion)
+    let handlers = Self.makeHandlers { _, _ in }
+
+    try await GRDBAnalysisRepository.applyTradesModePositionValuations(
+      priorRows: [prior], postRows: [],
+      to: &balances, context: context, handlers: handlers)
+
+    // Pre-fold seed applied 1000 storage units = 10 USD; converted
+    // at 1.5 = 15 AUD on `dayKey`.
+    let value = try #require(balances[dayKey]?.investmentValue)
+    #expect(value.quantity == try AnalysisTestHelpers.decimal("15"))
+  }
 ```
 
 - [ ] **Step 10: Format and run the new suite**
@@ -1807,8 +1941,8 @@ Expected: no failures.
 - [ ] **Step 12: Commit**
 
 ```bash
-git -C . add MoolahTests/Backends/GRDB/GRDBDailyBalancesTradesModeTests.swift
-git -C . commit -m "test(grdb): trades-mode position-valuation fold contract tests"
+git add MoolahTests/Backends/GRDB/GRDBDailyBalancesTradesModeTests.swift
+git commit -m "test(grdb): trades-mode position-valuation fold contract tests"
 ```
 
 ---
@@ -1917,7 +2051,7 @@ last-pass safety net.)
 - [ ] **Step 1: Push the branch with explicit `<src>:<dst>` form**
 
 ```bash
-git -C . push origin trades-mode/historical-chart:trades-mode/historical-chart
+git push origin trades-mode/historical-chart:trades-mode/historical-chart
 ```
 
 - [ ] **Step 2: Open the PR**

--- a/plans/2026-05-04-trades-mode-historical-net-worth-plan.md
+++ b/plans/2026-05-04-trades-mode-historical-net-worth-plan.md
@@ -40,11 +40,21 @@ spec:
   - Widen `resolveInstrument` from `private static` to `static` (drop
     `private`) so the new fold in
     `+DailyBalancesInvestmentValues.swift` can call it.
+  - In `walkDays`, pass `investmentAccountIds.union(tradesModeInvestmentAccountIds)`
+    to the read-side `PositionBook.BalanceContext.investmentAccountIds`
+    so trades-mode positions are excluded from `bankTotal`
+    (no double-count in `netWorth`).
 - `Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesAggregation.swift`
   - Call `fetchTradesModeInvestmentAccountIds` inside
     `readDailyBalancesAggregation`.
   - Pre-filter the existing prior/post account-row arrays into the new
     trades-mode-only fields.
+- `Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesForecast.swift`
+  - Apply the same `investmentAccountIds.union(tradesModeInvestmentAccountIds)`
+    in `generateForecast`'s `BalanceContext` so the forecast tail's
+    `bankTotal` excludes trades-mode positions (forecast days do not
+    receive a trades-fold contribution and would otherwise sum the
+    raw position quantity into `balance`).
 - `Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesInvestmentValues.swift`
   - Add `fetchTradesModeInvestmentAccountIds`.
   - Add `applyTradesModePositionValuations` and its helpers
@@ -80,8 +90,9 @@ spec:
   - **New file.** Aggregation-layer integration tests for the three
     new fields populated by `fetchDailyBalancesAggregation`.
 - `MoolahTests/Backends/GRDB/GRDBDailyBalancesTradesModeTests.swift`
-  - **New file.** Holds the 12 fold-contract tests from the spec
-    (§9.3).
+  - **New file.** Holds 13 fold-contract tests (cases 1–4, 6–14 from
+    spec §9.3 plus the round-3 additions; case 5 lives in
+    `GRDBDailyBalancesAssembleTests`).
 - `MoolahTests/Domain/AnalysisRule11ScopingTests.swift`
   - No-op (existing per-day-drop test stays green; the snapshot-fold
     tightening makes it consistent — verify nothing regresses).
@@ -1925,9 +1936,9 @@ Append:
   }
 ```
 
-- [ ] **Step 9: Add case 12 (carry-forward across a dropped day)**
+- [ ] **Step 9: Add cases 12, 13, 14 (carry-forward, priorRows seed, end-to-end double-count pin)**
 
-Append:
+Append (in numeric order — case 12, then 13, then 14):
 
 ```swift
   @Test("case 12: carry-forward across a dropped day stays correct")
@@ -1965,6 +1976,45 @@ Append:
     // Day 2 must valuate the cumulative position from day 1's buy
     // even though day 1 itself isn't in dailyBalances.
     let value = try #require(balances[keyTwo]?.investmentValue)
+    #expect(value.quantity == try AnalysisTestHelpers.decimal("15"))
+  }
+
+  @Test("case 13: priorRows seed contributes to first in-window day")
+  func priorRowsSeedSeenOnFirstWindowDay() async throws {
+    // priorRows simulates pre-cutoff legs the user holds going into
+    // the window. The fold's pre-fold seed (§4 step 2) must apply
+    // them so the first in-window dayKey valuates the carried
+    // position.
+    let priorDay = try AnalysisTestHelpers.utcDate(year: 2025, month: 5, day: 1, hour: 12)
+    let windowDay = try AnalysisTestHelpers.utcDate(year: 2025, month: 6, day: 10, hour: 12)
+    let dayKey = Calendar.current.startOfDay(for: windowDay)
+    let usd = Instrument.fiat(code: "USD")
+    let accountId = UUID()
+    let prior = GRDBAnalysisRepository.DailyBalanceAccountRow(
+      day: "2025-05-01", sampleDate: priorDay,
+      accountId: accountId, instrumentId: "USD", type: "trade", qty: 1000)
+    let conversion = DateBasedFixedConversionService(
+      rates: [
+        try AnalysisTestHelpers.utcDate(year: 2025, month: 1, day: 1, hour: 0): [
+          "USD": try AnalysisTestHelpers.decimal("1.5")
+        ]
+      ])
+    var balances: [Date: DailyBalance] = [
+      dayKey: Self.placeholderBalance(at: dayKey)
+    ]
+    let context = Self.makeContext(
+      tradesIds: [accountId],
+      instrumentMap: ["USD": usd],
+      conversionService: conversion)
+    let handlers = Self.makeHandlers { _, _ in }
+
+    try await GRDBAnalysisRepository.applyTradesModePositionValuations(
+      priorRows: [prior], postRows: [],
+      to: &balances, context: context, handlers: handlers)
+
+    // Pre-fold seed applied 1000 storage units = 10 USD; converted
+    // at 1.5 = 15 AUD on `dayKey`.
+    let value = try #require(balances[dayKey]?.investmentValue)
     #expect(value.quantity == try AnalysisTestHelpers.decimal("15"))
   }
 
@@ -2020,45 +2070,6 @@ Append:
     #expect(value.quantity == expected)
     #expect(dayBalance.balance.quantity == 0)
     #expect(dayBalance.netWorth.quantity == expected)
-  }
-
-  @Test("case 13: priorRows seed contributes to first in-window day")
-  func priorRowsSeedSeenOnFirstWindowDay() async throws {
-    // priorRows simulates pre-cutoff legs the user holds going into
-    // the window. The fold's pre-fold seed (§4 step 2) must apply
-    // them so the first in-window dayKey valuates the carried
-    // position.
-    let priorDay = try AnalysisTestHelpers.utcDate(year: 2025, month: 5, day: 1, hour: 12)
-    let windowDay = try AnalysisTestHelpers.utcDate(year: 2025, month: 6, day: 10, hour: 12)
-    let dayKey = Calendar.current.startOfDay(for: windowDay)
-    let usd = Instrument.fiat(code: "USD")
-    let accountId = UUID()
-    let prior = GRDBAnalysisRepository.DailyBalanceAccountRow(
-      day: "2025-05-01", sampleDate: priorDay,
-      accountId: accountId, instrumentId: "USD", type: "trade", qty: 1000)
-    let conversion = DateBasedFixedConversionService(
-      rates: [
-        try AnalysisTestHelpers.utcDate(year: 2025, month: 1, day: 1, hour: 0): [
-          "USD": try AnalysisTestHelpers.decimal("1.5")
-        ]
-      ])
-    var balances: [Date: DailyBalance] = [
-      dayKey: Self.placeholderBalance(at: dayKey)
-    ]
-    let context = Self.makeContext(
-      tradesIds: [accountId],
-      instrumentMap: ["USD": usd],
-      conversionService: conversion)
-    let handlers = Self.makeHandlers { _, _ in }
-
-    try await GRDBAnalysisRepository.applyTradesModePositionValuations(
-      priorRows: [prior], postRows: [],
-      to: &balances, context: context, handlers: handlers)
-
-    // Pre-fold seed applied 1000 storage units = 10 USD; converted
-    // at 1.5 = 15 AUD on `dayKey`.
-    let value = try #require(balances[dayKey]?.investmentValue)
-    #expect(value.quantity == try AnalysisTestHelpers.decimal("15"))
   }
 ```
 

--- a/plans/2026-05-04-trades-mode-historical-net-worth-plan.md
+++ b/plans/2026-05-04-trades-mode-historical-net-worth-plan.md
@@ -134,32 +134,46 @@ if failingDates.contains(dayKey) {
 }
 ```
 
-Production callers (the existing `applyInvestmentValues` and the
-new `applyTradesModePositionValuations`) already pass a `dayKey`
-produced by `Calendar.current.startOfDay(for: row.sampleDate)`. The
-re-normalisation step is redundant for those callers and silently
-mismatches when the host calendar is non-Gregorian (Rule 10
-inconsistency). Drop the re-normalisation and trust the caller's
-already-normalised date:
+Production callers that route through this service —
+`applyInvestmentValues` and the new
+`applyTradesModePositionValuations` — already pass a
+`Calendar.current.startOfDay`-normalised `dayKey`. Other callers
+that go through `PositionBook.dailyBalance` pass a raw sample-date
+(non-normalised) and never use `failingDates`, so they're
+unaffected. Drop the re-normalisation and document the caller
+contract on the `failingDates` field so future test authors know
+to normalise.
+
+Update the type declaration and `convert(...)` body:
 
 ```swift
-func convert(
-  _ quantity: Decimal, from: Instrument, to: Instrument, on date: Date
-) async throws -> Decimal {
-  if from.id == to.id { return quantity }
-  // The caller is expected to pass a startOfDay-normalized date —
-  // matches the contract every caller in `MoolahTests` honours.
-  // Applying a second calendar's startOfDay here would silently
-  // disagree on non-Gregorian locales (Rule 10) and turn the test
-  // into a false-green.
-  if failingDates.contains(date) {
-    throw DateFailingConversionError.unavailable(date: date)
+struct DateFailingConversionService: InstrumentConversionService {
+  let rates: [Date: [String: Decimal]]
+  /// Entries must be `Calendar.current.startOfDay`-normalised so
+  /// they line up with how production callers compute their
+  /// `dayKey` (`applyInvestmentValues`,
+  /// `applyTradesModePositionValuations`). The service no longer
+  /// re-normalises the `on:` argument inside `convert(...)` — a
+  /// second `startOfDay` call with a non-Gregorian calendar would
+  /// silently disagree with the caller's `Calendar.current`-keyed
+  /// `failingDates`, turning Rule 10 regressions into false-greens.
+  let failingDates: Set<Date>
+  // ... existing private storage / init ...
+
+  func convert(
+    _ quantity: Decimal, from: Instrument, to: Instrument, on date: Date
+  ) async throws -> Decimal {
+    if from.id == to.id { return quantity }
+    if failingDates.contains(date) {
+      throw DateFailingConversionError.unavailable(date: date)
+    }
+    let asOf = ratesAsOf(date)
+    guard let rate = asOf[from.id] else {
+      return quantity
+    }
+    return quantity * rate
   }
-  let asOf = ratesAsOf(date)
-  guard let rate = asOf[from.id] else {
-    return quantity
-  }
-  return quantity * rate
+  // ... existing convertAmount(...) ...
 }
 ```
 
@@ -1232,11 +1246,14 @@ after `sumInvestmentValues`:
   /// conversion service. Rule 8 fast path applies at the leaf level
   /// so an account holding both profile-instrument and foreign-
   /// instrument positions still routes only the foreign positions
-  /// through the service. When every position is in the profile
-  /// instrument the function returns synchronously — the outer
-  /// `applyTradesModePositionValuations` loop is responsible for the
-  /// `try Task.checkCancellation()` that keeps the all-fast-path case
-  /// promptly cancellable.
+  /// through the service. Zero-quantity positions are skipped (a
+  /// lingering instrument key after a same-day BUY+SELL nets out)
+  /// to honour Rule 8's spirit — there is no value in a `0 * rate`
+  /// async hop, and the answer is identically zero. When every
+  /// position is in the profile instrument the function returns
+  /// synchronously — the outer `applyTradesModePositionValuations`
+  /// loop is responsible for the `try Task.checkCancellation()`
+  /// that keeps the all-fast-path case promptly cancellable.
   private static func sumTradesModePositions(
     positions: [UUID: [Instrument: Decimal]],
     on date: Date,
@@ -1246,6 +1263,7 @@ after `sumInvestmentValues`:
     var total: Decimal = 0
     for (_, perInstrument) in positions {
       for (instrument, quantity) in perInstrument {
+        if quantity == 0 { continue }
         if instrument.id == profileInstrument.id {
           total += quantity
           continue
@@ -1282,7 +1300,78 @@ call, add the new fold call:
 (Place the new call before the `var actualBalances = ...` line and
 the subsequent `applyBestFit` / forecast steps.)
 
-- [ ] **Step 3: Format and build**
+- [ ] **Step 3: Exclude trades-mode accounts from `PositionBook.dailyBalance`'s `bankTotal`**
+
+This is the **double-counting fix** flagged in plan review round 3.
+
+Without this change, trades-mode account positions appear twice in
+`netWorth`:
+
+1. `walkDays` constructs `PositionBook.BalanceContext` with only
+   recorded-value accounts in `investmentAccountIds`. Inside
+   `PositionBook.dailyBalance`, the `bankTotal` loop is `for
+   (accountId, positions) in accounts where
+   !investmentAccountIds.contains(accountId)`. Because trades-mode
+   accounts are NOT in the set, their positions (cash + stocks) get
+   converted into the profile instrument and added to `bankTotal`,
+   which becomes the day's `balance`.
+2. `applyTradesModePositionValuations` then converts the same
+   positions and adds them to `investmentValue`.
+3. The fold's `netWorth = existing.balance + combined` would sum
+   them twice.
+
+Fix: pass the **union** of recorded-value and trades-mode account
+ids to `PositionBook.BalanceContext.investmentAccountIds`. This
+excludes trades-mode positions from `bankTotal` while leaving
+`accountsFromTransfers` (and therefore `investmentsTotal`)
+unaffected — `accountsFromTransfers` only ever has recorded-value
+account entries because `seedPriorBook` / `applyDailyDeltas` write
+to it gated on `context.investmentAccountIds`, which we keep
+recorded-value-only.
+
+Open `+DailyBalances.swift`. Locate `walkDays` (around line 265).
+Update the `balanceContext` construction (around line 275):
+
+```swift
+    // Trades-mode accounts contribute to investmentValue via
+    // applyTradesModePositionValuations, not to bankTotal. Including
+    // them in BalanceContext.investmentAccountIds excludes them from
+    // PositionBook.dailyBalance's `for ... where !investmentAccountIds`
+    // sum (no double-count) without changing accountsFromTransfers
+    // membership (which seedPriorBook / applyDailyDeltas gate on the
+    // recorded-value-only set, so the .investmentTransfersOnly read
+    // continues to see only recorded-value transfer cash).
+    let allInvestmentIds =
+      context.investmentAccountIds.union(context.tradesModeInvestmentAccountIds)
+    let balanceContext = PositionBook.BalanceContext(
+      investmentAccountIds: allInvestmentIds,
+      profileInstrument: context.profileInstrument,
+      rule: .investmentTransfersOnly,
+      conversionService: context.conversionService)
+```
+
+Apply the same union in
+`+DailyBalancesForecast.swift`'s `generateForecast` at the
+`PositionBook.BalanceContext` construction (line ~193). The forecast
+must also exclude trades-mode account positions from `bankTotal` —
+forecast days don't get a trades-mode fold contribution
+(out-of-scope), and double-counting in the forecast tail would be
+just as wrong as in the historic span. Update:
+
+```swift
+    let allInvestmentIds =
+      context.investmentAccountIds.union(context.tradesModeInvestmentAccountIds)
+    let balanceContext = PositionBook.BalanceContext(
+      investmentAccountIds: allInvestmentIds,
+      ...
+```
+
+(Leave the second use of `context.investmentAccountIds` —
+`book.apply(instance, investmentAccountIds:)` — alone. That's a
+write-side flag for `accountsFromTransfers` membership, which must
+stay recorded-value-only.)
+
+- [ ] **Step 4: Format and build**
 
 ```bash
 just format
@@ -1292,7 +1381,7 @@ grep -i "error:\|warning:" .agent-tmp/build.txt | grep -v "Preview"
 
 Expected: clean.
 
-- [ ] **Step 4: Run the existing daily-balance suite — no behaviour change for
+- [ ] **Step 5: Run the existing daily-balance suite — no behaviour change for
   profiles without trades-mode accounts**
 
 ```bash
@@ -1302,11 +1391,11 @@ grep -i "failed\|error:" .agent-tmp/test.txt
 
 Expected: no failures.
 
-- [ ] **Step 5: Commit**
+- [ ] **Step 6: Commit**
 
 ```bash
-git add Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesInvestmentValues.swift Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalances.swift
-git commit -m "feat(grdb): per-day trades-mode position-valuation fold"
+git add Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesInvestmentValues.swift Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalances.swift Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesForecast.swift
+git commit -m "feat(grdb): per-day trades-mode position-valuation fold; exclude trades from bankTotal"
 ```
 
 ---
@@ -1825,12 +1914,12 @@ Append:
 
     // After the cursor advance, positions[accountId][USD] = 0 — the
     // outer dict key is still present, so positions.isEmpty is false
-    // and `sumTradesModePositions` is invoked. USD ≠ AUD profile, so
-    // the Rule 8 fast path does NOT apply and the conversion service
-    // is called with quantity 0; `0 * rate = 0` regardless of the
-    // rate. existing.investmentValue is nil, so `(nil ?? .zero(AUD))
-    // + .zero(AUD) == .zero(AUD)`. The day's investmentValue is
-    // .zero(AUD) — non-nil, but quantity == 0.
+    // and `sumTradesModePositions` is invoked. The new
+    // `quantity == 0` guard inside the helper skips the zero
+    // position before the Rule 8 fast-path / convert decision —
+    // total stays 0. existing.investmentValue is nil, so
+    // `(nil ?? .zero(AUD)) + .zero(AUD) == .zero(AUD)`. The day's
+    // investmentValue is .zero(AUD) — non-nil, but quantity == 0.
     let value = try #require(balances[dayKey]?.investmentValue)
     #expect(value.quantity == 0)
   }
@@ -1877,6 +1966,60 @@ Append:
     // even though day 1 itself isn't in dailyBalances.
     let value = try #require(balances[keyTwo]?.investmentValue)
     #expect(value.quantity == try AnalysisTestHelpers.decimal("15"))
+  }
+
+  @Test("case 14: end-to-end pipeline does not double-count trades-mode positions in netWorth")
+  func endToEndNetWorthSingleCount() async throws {
+    // Round-trip through the real fetchDailyBalances pipeline: a
+    // trades-mode account with one trade leg on day D. After
+    // walkDays, `existing.balance` would normally include the trade
+    // position (because trades-mode accounts aren't in the
+    // recorded-value `investmentAccountIds` set used by
+    // PositionBook.dailyBalance). The fix in Task 6 step 3 unions
+    // trades-mode ids into BalanceContext.investmentAccountIds so
+    // those positions are excluded from balance and contribute only
+    // via investmentValue. This test pins that fix.
+    let conversion = DateBasedFixedConversionService(
+      rates: [
+        try AnalysisTestHelpers.utcDate(year: 2025, month: 1, day: 1, hour: 0): [
+          "USD": try AnalysisTestHelpers.decimal("1.5")
+        ]
+      ])
+    let backend = try CloudKitAnalysisTestBackend(conversionService: conversion)
+    let aud = Instrument.defaultTestInstrument
+    let usd = Instrument.fiat(code: "USD")
+    let tradesAccount = Account(
+      id: UUID(), name: "Trades", type: .investment, instrument: aud,
+      valuationMode: .calculatedFromTrades)
+    _ = try await backend.accounts.create(tradesAccount)
+
+    let day = try AnalysisTestHelpers.utcDate(year: 2025, month: 6, day: 10, hour: 12)
+    _ = try await backend.transactions.create(
+      Transaction(
+        date: day, payee: "Buy",
+        legs: [
+          TransactionLeg(
+            accountId: tradesAccount.id, instrument: usd,
+            quantity: 10, type: .trade)
+        ]))
+
+    let balances = try await backend.analysis.fetchDailyBalances(
+      after: nil, forecastUntil: nil)
+
+    let dayKey = Calendar.current.startOfDay(for: day)
+    let dayBalance = try #require(balances.first { $0.date == dayKey })
+
+    // 10 USD * 1.5 = 15 AUD on day D. Critically:
+    // - investmentValue == 15 AUD (from the new fold).
+    // - balance == 0 AUD (the trades-mode account's USD position is
+    //   excluded from bankTotal because it's now in
+    //   BalanceContext.investmentAccountIds — the double-count fix).
+    // - netWorth == 15 AUD (single count, not 30).
+    let expected = try AnalysisTestHelpers.decimal("15")
+    let value = try #require(dayBalance.investmentValue)
+    #expect(value.quantity == expected)
+    #expect(dayBalance.balance.quantity == 0)
+    #expect(dayBalance.netWorth.quantity == expected)
   }
 
   @Test("case 13: priorRows seed contributes to first in-window day")
@@ -1927,7 +2070,7 @@ just test-mac GRDBDailyBalancesTradesModeTests 2>&1 | tee .agent-tmp/test.txt
 grep -i "failed\|error:" .agent-tmp/test.txt
 ```
 
-Expected: 12 tests pass.
+Expected: 13 tests pass (cases 1, 2, 3, 4, 6, 7, 8, 9, 10, 11, 12, 13, 14 — case 5 lives in `GRDBDailyBalancesAssembleTests`).
 
 - [ ] **Step 11: Run the entire daily-balance test surface to confirm nothing else regresses**
 

--- a/plans/2026-05-04-trades-mode-historical-net-worth-plan.md
+++ b/plans/2026-05-04-trades-mode-historical-net-worth-plan.md
@@ -37,6 +37,9 @@ spec:
   - Update `assembleDailyBalances` to pass the new field through the
     context construction and call the new fold after
     `applyInvestmentValues`.
+  - Widen `resolveInstrument` from `private static` to `static` (drop
+    `private`) so the new fold in
+    `+DailyBalancesInvestmentValues.swift` can call it.
 - `Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesAggregation.swift`
   - Call `fetchTradesModeInvestmentAccountIds` inside
     `readDailyBalancesAggregation`.
@@ -50,21 +53,35 @@ spec:
   - Update `applyInvestmentValues` to drop the day from `dailyBalances`
     on per-day conversion failure (Rule 11) and update its
     `sumInvestmentValues` call site to the non-optional return.
+  - Add `try Task.checkCancellation()` to the outer per-day loops in
+    both folds so cancellation surfaces promptly even when every
+    position takes the Rule 8 fast path (no `await`).
 
 **Tests (create / modify):**
 
+- `MoolahTests/Support/ThrowingCountingConversionService.swift`
+  - Add a sibling `Sendable` collector class
+    `InvestmentValueFailureLog` for `(Error, Date)` tuples (mirrors
+    the existing `FailureLog` pattern). Used by every test that
+    asserts the `handleInvestmentValueFailure` callback.
+- `MoolahTests/Support/AnalysisTestHelpers.swift`
+  - Add a `date(year:month:day:hour:)` overload that uses
+    `Calendar.current` (so the test's day-key math agrees with the
+    production fold's `Calendar.current.startOfDay(for:)`). The
+    existing `date(year:month:day:)` and `utcDate(year:month:day:hour:)`
+    are not changed.
 - `MoolahTests/Backends/GRDB/DailyBalancesPlanPinningTests.swift`
   - Add `fetchTradesModeInvestmentAccountIdsUsesAccountByType`.
+- `MoolahTests/Backends/GRDB/GRDBDailyBalancesAssembleTests.swift`
+  - **Modify** the existing `makeAggregation()` helper to pass the
+    three new struct fields (compile fix for Task 2) and add a Rule
+    11 test for the snapshot-fold tightening (case 5).
 - `MoolahTests/Backends/GRDB/GRDBDailyBalancesAggregateTests.swift`
-  - Add tests covering the three new fields populated by
-    `fetchDailyBalancesAggregation`. (If the file does not exist, create
-    it; otherwise extend.)
+  - **New file.** Aggregation-layer integration tests for the three
+    new fields populated by `fetchDailyBalancesAggregation`.
 - `MoolahTests/Backends/GRDB/GRDBDailyBalancesTradesModeTests.swift`
   - **New file.** Holds the 12 fold-contract tests from the spec
     (§9.3).
-- `MoolahTests/Backends/GRDB/GRDBDailyBalancesAssembleTests.swift`
-  - Add a Rule 11 test for the snapshot-fold tightening (case 5 from
-    spec §9.3).
 - `MoolahTests/Domain/AnalysisRule11ScopingTests.swift`
   - No-op (existing per-day-drop test stays green; the snapshot-fold
     tightening makes it consistent — verify nothing regresses).
@@ -88,6 +105,98 @@ spec:
 | Build the macOS app | `just build-mac` |
 
 `mkdir -p .agent-tmp` before piping output to `.agent-tmp/`.
+
+---
+
+## Task 0: Add test-support helpers (`InvestmentValueFailureLog`, local-calendar `date(...)` overload)
+
+**Files:**
+- Modify: `MoolahTests/Support/ThrowingCountingConversionService.swift`
+- Modify: `MoolahTests/Support/AnalysisTestHelpers.swift`
+
+These helpers are dependencies of Tasks 5 and 7. They are tiny, mechanical
+additions and have no production-code coupling — landing them first keeps
+each subsequent task self-contained.
+
+- [ ] **Step 1: Add `InvestmentValueFailureLog` to `ThrowingCountingConversionService.swift`**
+
+Open `MoolahTests/Support/ThrowingCountingConversionService.swift`. At
+the bottom of the file, after the existing `FailureLog` class, add:
+
+```swift
+/// Async-safe collector for `(Error, Date)` failure tuples emitted by
+/// `DailyBalancesHandlers.handleInvestmentValueFailure`. Used by tests
+/// that need to assert which day surfaced through the per-day error
+/// callback (and how many times). Backed by `OSAllocatedUnfairLock`
+/// for the same `@Sendable`-closure-mutation reason as `FailureLog`.
+final class InvestmentValueFailureLog: Sendable {
+  private let entries = OSAllocatedUnfairLock<[(Error, Date)]>(initialState: [])
+
+  func append(_ error: Error, _ date: Date) {
+    entries.withLock { $0.append((error, date)) }
+  }
+
+  func snapshot() -> [(Error, Date)] {
+    entries.withLock { $0 }
+  }
+
+  var count: Int {
+    entries.withLock { $0.count }
+  }
+
+  var dates: [Date] {
+    entries.withLock { $0.map(\.1) }
+  }
+}
+```
+
+- [ ] **Step 2: Add a local-calendar `date(...)` overload to `AnalysisTestHelpers.swift`**
+
+Open `MoolahTests/Support/AnalysisTestHelpers.swift`. Locate the existing
+`static func date(year: Int, month: Int, day: Int) throws -> Date`
+(around line 24). Add a new overload directly after it:
+
+```swift
+  /// Build a local-calendar `Date` at a specific `hour:` on the given
+  /// day. Uses `Calendar.current` so the resulting `Date`'s
+  /// `startOfDay` agrees with the production fold's
+  /// `Calendar.current.startOfDay(for: row.sampleDate)` math —
+  /// required by Rule 10 same-`startOfDay` normalization tests.
+  static func date(
+    year: Int, month: Int, day: Int, hour: Int
+  ) throws -> Date {
+    var components = DateComponents()
+    components.year = year
+    components.month = month
+    components.day = day
+    components.hour = hour
+    components.calendar = currentCalendar
+    guard let date = currentCalendar.date(from: components) else {
+      throw TestError.invalidDate(components)
+    }
+    return date
+  }
+```
+
+(The existing `enum TestError` and `currentCalendar` are already in
+the file — no new types or imports.)
+
+- [ ] **Step 3: Build to confirm support-file additions compile**
+
+```bash
+mkdir -p .agent-tmp
+just build-mac 2>&1 | tee .agent-tmp/build.txt
+grep -i "error:\|warning:" .agent-tmp/build.txt | grep -v "Preview"
+```
+
+Expected: clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C . add MoolahTests/Support/ThrowingCountingConversionService.swift MoolahTests/Support/AnalysisTestHelpers.swift
+git -C . commit -m "test(support): add InvestmentValueFailureLog + local-calendar date helper"
+```
 
 ---
 
@@ -127,16 +236,22 @@ func fetchTradesModeInvestmentAccountIdsUsesAccountByType() throws {
 }
 ```
 
-- [ ] **Step 2: Run the test to verify it passes already (no production change yet)**
+- [ ] **Step 2: Run the test (it is a pure EXPLAIN over a literal SQL string — passes before the helper exists)**
+
+The plan-pinning test asserts the SQLite query plan for the literal
+SQL string; it does not call the new Swift helper, so it passes on
+first run. The "verify it fails" leg of TDD doesn't apply for
+plan-pinning tests in this file (consistent with the sibling
+`fetchInvestmentAccountIdsUsesAccountByType`).
 
 ```bash
 mkdir -p .agent-tmp
 just test-mac DailyBalancesPlanPinningTests/fetchTradesModeInvestmentAccountIdsUsesAccountByType 2>&1 | tee .agent-tmp/test.txt
 ```
 
-Expected: PASS — the SQL string is a literal and the planner emits the
-same shape as the snapshot-mode predicate. The test pins the plan
-shape; the production helper is added in Step 3.
+Expected: PASS — the SQL string is a literal and the planner emits
+the same shape as the snapshot-mode predicate. The production helper
+is added in Step 3.
 
 - [ ] **Step 3: Add the production fetch helper**
 
@@ -202,15 +317,18 @@ git -C . commit -m "feat(grdb): add fetchTradesModeInvestmentAccountIds + plan-p
 
 ---
 
-## Task 2: Extend `DailyBalancesAggregation` and `DailyBalancesAssemblyContext`
+## Task 2: Extend `DailyBalancesAggregation`, `DailyBalancesAssemblyContext`, widen `resolveInstrument`, and update existing `makeAggregation()`
 
 **Files:**
 - Modify: `Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalances.swift`
+- Modify: `MoolahTests/Backends/GRDB/GRDBDailyBalancesAssembleTests.swift`
 
-This task only adds fields and updates the construction site; the
-fields are wired by Task 3 and consumed by Task 5. Builds cleanly on
-its own because the fields default to empty values everywhere they're
-read until Task 5 lands.
+This task adds the new struct fields, widens
+`resolveInstrument`'s access from `private` to `internal`, and
+updates the *existing* `makeAggregation()` test helper so the
+project still compiles after the struct gains required fields.
+Without that update the working tree is non-compiling between
+Task 2 and Task 3.
 
 - [ ] **Step 1: Add new fields to `DailyBalancesAggregation`**
 
@@ -277,18 +395,74 @@ Locate `assembleDailyBalances` (around line 162). Update the
       conversionService: conversionService)
 ```
 
-- [ ] **Step 4: Build to make sure existing call sites still compile**
+- [ ] **Step 4: Widen `resolveInstrument` from `private static` to `static`**
 
-`DailyBalancesAggregation` has only one constructing call site
-(`readDailyBalancesAggregation` in `+DailyBalancesAggregation.swift`).
-The build will fail until that call site is updated; Task 3 fixes it.
-Skip the build step here and continue to Task 3.
+Same file. Locate `resolveInstrument` (around line 355). Drop the
+`private` access modifier (Swift `private` scopes to the file, and
+the new fold in `+DailyBalancesInvestmentValues.swift` needs to call
+it):
 
-- [ ] **Step 5: Commit**
+```swift
+  /// Reconstruct an `Instrument` value from the row's `instrument_id`
+  /// string, falling back to ambient fiat when the registry has no
+  /// stored row for the id. Mirrors the same lookup used by the other
+  /// SQL aggregations. Internal so sibling `+DailyBalances*.swift`
+  /// extensions can share one decoding helper.
+  static func resolveInstrument(
+    _ id: String, in map: [String: Instrument]
+  ) -> Instrument {
+    map[id] ?? Instrument.fiat(code: id)
+  }
+```
+
+- [ ] **Step 5: Update the existing `makeAggregation()` helper to pass the new fields**
+
+Open `MoolahTests/Backends/GRDB/GRDBDailyBalancesAssembleTests.swift`.
+Locate `makeAggregation()` (around line 37). Update the
+`DailyBalancesAggregation(...)` literal to include the three new
+fields with empty defaults:
+
+```swift
+    let aggregation = GRDBAnalysisRepository.DailyBalancesAggregation(
+      priorAccountRows: [],
+      priorEarmarkRows: [],
+      accountRows: accountRows,
+      earmarkRows: [],
+      investmentValues: [],
+      investmentAccountIds: [],
+      tradesModeInvestmentAccountIds: [],
+      priorTradesModeAccountRows: [],
+      tradesModeAccountRows: [],
+      scheduled: [],
+      instrumentMap: [usd: .fiat(code: usd)],
+      forecastUntil: nil)
+```
+
+(Diff: three new fields between `investmentAccountIds` and
+`scheduled`.)
+
+- [ ] **Step 6: Build to confirm compilation**
+
+`DailyBalancesAggregation`'s other constructing call site
+(`readDailyBalancesAggregation` in `+DailyBalancesAggregation.swift`)
+will still fail; Task 3 fixes it. The Swift compiler will report
+that single call site failing — confirm it's the only failure, then
+proceed to Task 3.
 
 ```bash
-git -C . add Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalances.swift
-git -C . commit -m "feat(grdb): add trades-mode fields to DailyBalancesAggregation"
+just build-mac 2>&1 | tee .agent-tmp/build.txt
+grep "error:" .agent-tmp/build.txt | grep -v "Preview"
+```
+
+Expected: only `+DailyBalancesAggregation.swift` errors about missing
+arguments to `DailyBalancesAggregation`. Anything else is unexpected
+— investigate before proceeding.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git -C . add Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalances.swift MoolahTests/Backends/GRDB/GRDBDailyBalancesAssembleTests.swift
+git -C . commit -m "feat(grdb): add trades-mode fields to DailyBalancesAggregation; widen resolveInstrument"
 ```
 
 ---
@@ -446,7 +620,6 @@ Create / edit
 
 ```swift
 import Foundation
-import GRDB
 import Testing
 
 @testable import Moolah
@@ -550,16 +723,14 @@ struct GRDBDailyBalancesAggregateTradesModeTests {
 }
 ```
 
-- [ ] **Step 3: Add a `testFetchAggregation` shim to `CloudKitAnalysisTestBackend` if it doesn't exist**
+- [ ] **Step 3: Add a `testFetchAggregation` shim to `CloudKitAnalysisTestBackend`**
 
-Run:
-
-```bash
-grep -n "testFetchAggregation\|fetchDailyBalancesAggregation" MoolahTests/Support/CloudKitAnalysisTestBackend.swift
-```
-
-If `testFetchAggregation` is not defined, add it. Open the file, find
-the `analysis` accessor, and add a new method:
+Open `MoolahTests/Support/CloudKitAnalysisTestBackend.swift`. The
+backend already exposes its `DatabaseQueue` publicly as `let database:
+DatabaseQueue`, so the shim doesn't need to reach into the production
+repository's private storage. Append at the bottom of the file (or
+inside the existing `extension CloudKitAnalysisTestBackend` block, if
+one exists):
 
 ```swift
 extension CloudKitAnalysisTestBackend {
@@ -567,31 +738,22 @@ extension CloudKitAnalysisTestBackend {
   /// for aggregation-layer integration tests. Production callers go
   /// through `analysis.fetchDailyBalances(...)`; this shim lets tests
   /// pin the aggregation contract without re-running the full
-  /// per-day walk.
+  /// per-day walk. Reads from the backend's already-public
+  /// `DatabaseQueue` — no peek into `GRDBAnalysisRepository`'s
+  /// private storage.
   func testFetchAggregation(
     after: Date?, forecastUntil: Date?
   ) async throws -> GRDBAnalysisRepository.DailyBalancesAggregation {
-    let analysis = self.analysis as! GRDBAnalysisRepository
-    return try await GRDBAnalysisRepository.fetchDailyBalancesAggregation(
-      database: analysis.databaseReader,
+    try await GRDBAnalysisRepository.fetchDailyBalancesAggregation(
+      database: self.database,
       after: after,
       forecastUntil: forecastUntil)
   }
 }
 ```
 
-The `as!` cast is acceptable in test support code because the test
-backend is constructed against `GRDBAnalysisRepository` specifically.
-
-If the `databaseReader` property is `private`, expose an internal
-`testDatabaseReader: any DatabaseReader { databaseReader }` on
-`GRDBAnalysisRepository` and use that instead. Check by running:
-
-```bash
-grep -n "databaseReader\|database:.*DatabaseReader" Backends/GRDB/Repositories/GRDBAnalysisRepository.swift
-```
-
-Use whichever access path is already exposed.
+(`DatabaseQueue` conforms to `DatabaseReader`, which is the parameter
+type expected by `fetchDailyBalancesAggregation`. No cast needed.)
 
 - [ ] **Step 4: Run the new tests — they should pass**
 
@@ -635,7 +797,7 @@ Add a new test at the bottom of the existing suite:
   func snapshotFoldDropsDayOnFailure() async throws {
     // Build an aggregation with one investment-value snapshot on day D.
     let day = try AnalysisTestHelpers.utcDate(year: 2025, month: 6, day: 10, hour: 12)
-    let dayKey = AnalysisTestHelpers.calendar.startOfDay(for: day)
+    let dayKey = Calendar.current.startOfDay(for: day)
     let usd = Instrument.fiat(code: "USD")
     let accountId = UUID()
     let aggregation = GRDBAnalysisRepository.DailyBalancesAggregation(
@@ -672,12 +834,12 @@ Add a new test at the bottom of the existing suite:
     ]
     let conversionService = DateFailingConversionService(
       rates: [:], failingDates: [dayKey])
-    var capturedFailures: [(Error, Date)] = []
+    let captured = InvestmentValueFailureLog()
     let handlers = GRDBAnalysisRepository.DailyBalancesHandlers(
       handleUnparseableDay: { _ in },
       handleConversionFailure: { _, _ in },
       handleInvestmentValueFailure: { error, date in
-        capturedFailures.append((error, date))
+        captured.append(error, date)
       })
     let context = GRDBAnalysisRepository.DailyBalancesAssemblyContext(
       investmentAccountIds: aggregation.investmentAccountIds,
@@ -695,8 +857,8 @@ Add a new test at the bottom of the existing suite:
     // Rule 11: a snapshot conversion failure on day D must drop day D
     // from dailyBalances. Sibling days (none here) are unaffected.
     #expect(dailyBalances[dayKey] == nil)
-    #expect(capturedFailures.count == 1)
-    #expect(capturedFailures.first?.1 == dayKey)
+    #expect(captured.count == 1)
+    #expect(captured.dates == [dayKey])
   }
 ```
 
@@ -744,14 +906,19 @@ The function body's `return InstrumentAmount(quantity: total,
 instrument: profileInstrument)` already returns a non-optional — no
 body change required.
 
-- [ ] **Step 4: Update `applyInvestmentValues`'s call to the non-optional shape and tighten the catch branch**
+- [ ] **Step 4: Update `applyInvestmentValues`'s call to the non-optional shape, tighten the catch branch, and add a cancellation check**
 
 Same file. Locate `applyInvestmentValues` (around line 107). Replace
-the body from `let totalValue: InstrumentAmount?` through the
+the body from `for date in dailyBalances.keys.sorted()` through the
 `dailyBalances[date] = DailyBalance(...)` block with:
 
 ```swift
     for date in dailyBalances.keys.sorted() {
+      // The Rule 8 fast path can let the loop run synchronously when
+      // every snapshot is in the profile instrument; an explicit
+      // cancellation check ensures the outer task can be torn down
+      // promptly even in that case.
+      try Task.checkCancellation()
       valueIndex = advanceInvestmentCursor(
         values: investmentValues,
         latestByAccount: &latestByAccount,
@@ -789,7 +956,8 @@ the body from `let totalValue: InstrumentAmount?` through the
     }
 ```
 
-(Diffs from the original: `let totalValue: InstrumentAmount?` →
+(Diffs from the original: new `try Task.checkCancellation()` at the
+top of the loop; `let totalValue: InstrumentAmount?` →
 `let totalValue: InstrumentAmount`; new
 `dailyBalances.removeValue(forKey: date)` line in the catch branch;
 `guard let totalValue, let balance = dailyBalances[date] else { continue }`
@@ -915,6 +1083,11 @@ after `sumInvestmentValues`:
 
     var valueIndex = 0
     for dayKey in dailyBalances.keys.sorted() {
+      // The Rule 8 fast path inside `sumTradesModePositions` can let
+      // the loop run synchronously when every position is in the
+      // profile instrument; an explicit cancellation check ensures
+      // the outer task can be torn down promptly even in that case.
+      try Task.checkCancellation()
       // Advance the cursor: apply every entry on-or-before dayKey,
       // including those for days absent from dailyBalances.
       while valueIndex < entries.count, entries[valueIndex].dayKey <= dayKey {
@@ -966,9 +1139,11 @@ after `sumInvestmentValues`:
   /// conversion service. Rule 8 fast path applies at the leaf level
   /// so an account holding both profile-instrument and foreign-
   /// instrument positions still routes only the foreign positions
-  /// through the service. Cancellation propagates via the service's
-  /// own `await` — no manual `Task.isCancelled` check needed (matches
-  /// `sumInvestmentValues`).
+  /// through the service. When every position is in the profile
+  /// instrument the function returns synchronously — the outer
+  /// `applyTradesModePositionValuations` loop is responsible for the
+  /// `try Task.checkCancellation()` that keeps the all-fast-path case
+  /// promptly cancellable.
   private static func sumTradesModePositions(
     positions: [UUID: [Instrument: Decimal]],
     on date: Date,
@@ -1073,9 +1248,11 @@ import Testing
 @Suite("GRDBAnalysisRepository applyTradesModePositionValuations")
 struct GRDBDailyBalancesTradesModeTests {
 
-  /// Closure-captured failure log shared across cases that need to
-  /// assert per-day callback shape. Same pattern as
-  /// `GRDBDailyBalancesAssembleTests`'s `FailureLog`.
+  /// Build the standard `DailyBalancesHandlers` for these tests.
+  /// The trades-mode fold only ever invokes
+  /// `handleInvestmentValueFailure` — the other two callbacks are
+  /// no-ops. Pass `InvestmentValueFailureLog.append` (or a
+  /// `{ _, _ in }` no-op for cases that don't assert on failures).
   static func makeHandlers(
     failures: @escaping @Sendable (Error, Date) -> Void
   ) -> GRDBAnalysisRepository.DailyBalancesHandlers {
@@ -1121,7 +1298,7 @@ Inside the same `struct GRDBDailyBalancesTradesModeTests` body, append:
   @Test("case 1: single buy on day D values at day D's price")
   func singleBuyOnDay() async throws {
     let day = try AnalysisTestHelpers.utcDate(year: 2025, month: 6, day: 10, hour: 12)
-    let dayKey = AnalysisTestHelpers.calendar.startOfDay(for: day)
+    let dayKey = Calendar.current.startOfDay(for: day)
     let usd = Instrument.fiat(code: "USD")
     let accountId = UUID()
     let row = GRDBAnalysisRepository.DailyBalanceAccountRow(
@@ -1134,7 +1311,7 @@ Inside the same `struct GRDBDailyBalancesTradesModeTests` body, append:
         ]
       ])
     var balances: [Date: DailyBalance] = [
-      dayKey: GRDBDailyBalancesTradesModeTests.placeholderBalance(at: dayKey)
+      dayKey: Self.placeholderBalance(at: dayKey)
     ]
     let context = Self.makeContext(
       tradesIds: [accountId],
@@ -1158,9 +1335,9 @@ Inside the same `struct GRDBDailyBalancesTradesModeTests` body, append:
   @Test("case 8: no trades-mode accounts — fold is a no-op")
   func noTradesModeAccounts() async throws {
     let day = try AnalysisTestHelpers.utcDate(year: 2025, month: 6, day: 10, hour: 12)
-    let dayKey = AnalysisTestHelpers.calendar.startOfDay(for: day)
+    let dayKey = Calendar.current.startOfDay(for: day)
     var balances: [Date: DailyBalance] = [
-      dayKey: GRDBDailyBalancesTradesModeTests.placeholderBalance(at: dayKey)
+      dayKey: Self.placeholderBalance(at: dayKey)
     ]
     let originalBalance = balances[dayKey]
     let conversion = DateBasedFixedConversionService(rates: [:])
@@ -1185,9 +1362,9 @@ Inside the same `struct GRDBDailyBalancesTradesModeTests` body, append:
       tradesIds: [accountId],
       instrumentMap: ["USD": usd],
       conversionService: conversion)
-    var failures: [(Error, Date)] = []
+    let captured = InvestmentValueFailureLog()
     let handlers = Self.makeHandlers { error, date in
-      failures.append((error, date))
+      captured.append(error, date)
     }
 
     try await GRDBAnalysisRepository.applyTradesModePositionValuations(
@@ -1195,7 +1372,7 @@ Inside the same `struct GRDBDailyBalancesTradesModeTests` body, append:
       to: &balances, context: context, handlers: handlers)
 
     #expect(balances.isEmpty)
-    #expect(failures.isEmpty)
+    #expect(captured.count == 0)
   }
 ```
 
@@ -1207,7 +1384,7 @@ Append:
   @Test("case 2: two trades-mode accounts both contribute on day D")
   func twoTradesModeAccountsSameDay() async throws {
     let day = try AnalysisTestHelpers.utcDate(year: 2025, month: 6, day: 10, hour: 12)
-    let dayKey = AnalysisTestHelpers.calendar.startOfDay(for: day)
+    let dayKey = Calendar.current.startOfDay(for: day)
     let usd = Instrument.fiat(code: "USD")
     let aId = UUID()
     let bId = UUID()
@@ -1224,7 +1401,7 @@ Append:
         ]
       ])
     var balances: [Date: DailyBalance] = [
-      dayKey: GRDBDailyBalancesTradesModeTests.placeholderBalance(at: dayKey)
+      dayKey: Self.placeholderBalance(at: dayKey)
     ]
     let context = Self.makeContext(
       tradesIds: [aId, bId],
@@ -1250,7 +1427,7 @@ Append:
   @Test("case 3: trades-mode + recorded-value account totals add into one investmentValue")
   func tradesModePlusRecordedValueSum() async throws {
     let day = try AnalysisTestHelpers.utcDate(year: 2025, month: 6, day: 10, hour: 12)
-    let dayKey = AnalysisTestHelpers.calendar.startOfDay(for: day)
+    let dayKey = Calendar.current.startOfDay(for: day)
     let usd = Instrument.fiat(code: "USD")
     let tradesId = UUID()
     let row = GRDBAnalysisRepository.DailyBalanceAccountRow(
@@ -1306,10 +1483,13 @@ Append:
 ```swift
   @Test("case 4: per-day conversion failure drops day from dailyBalances")
   func ruleEleven_perDayFailureScopedToDay() async throws {
+    // `Calendar.current.startOfDay` is the production fold's day-key
+    // function (Rule 10). Build the test's seed key the same way so a
+    // calendar mismatch can't make the test pass vacuously.
     let dayOne = try AnalysisTestHelpers.utcDate(year: 2025, month: 6, day: 10, hour: 12)
     let dayTwo = try AnalysisTestHelpers.utcDate(year: 2025, month: 6, day: 11, hour: 12)
-    let keyOne = AnalysisTestHelpers.calendar.startOfDay(for: dayOne)
-    let keyTwo = AnalysisTestHelpers.calendar.startOfDay(for: dayTwo)
+    let keyOne = Calendar.current.startOfDay(for: dayOne)
+    let keyTwo = Calendar.current.startOfDay(for: dayTwo)
     let usd = Instrument.fiat(code: "USD")
     let accountId = UUID()
     let rowOne = GRDBAnalysisRepository.DailyBalanceAccountRow(
@@ -1324,16 +1504,16 @@ Append:
       ],
       failingDates: [keyOne])
     var balances: [Date: DailyBalance] = [
-      keyOne: GRDBDailyBalancesTradesModeTests.placeholderBalance(at: keyOne),
-      keyTwo: GRDBDailyBalancesTradesModeTests.placeholderBalance(at: keyTwo),
+      keyOne: Self.placeholderBalance(at: keyOne),
+      keyTwo: Self.placeholderBalance(at: keyTwo),
     ]
     let context = Self.makeContext(
       tradesIds: [accountId],
       instrumentMap: ["USD": usd],
       conversionService: conversion)
-    var failures: [(Error, Date)] = []
+    let captured = InvestmentValueFailureLog()
     let handlers = Self.makeHandlers { error, date in
-      failures.append((error, date))
+      captured.append(error, date)
     }
 
     try await GRDBAnalysisRepository.applyTradesModePositionValuations(
@@ -1345,8 +1525,8 @@ Append:
     #expect(balances[keyOne] == nil)
     let value = try #require(balances[keyTwo]?.investmentValue)
     #expect(value.quantity == try AnalysisTestHelpers.decimal("15"))
-    #expect(failures.count == 1)
-    #expect(failures.first?.1 == keyOne)
+    #expect(captured.count == 1)
+    #expect(captured.dates == [keyOne])
   }
 ```
 
@@ -1362,7 +1542,7 @@ Append:
   @Test("case 6: trades-fold failure on day D after snapshot-fold success drops day")
   func mixedFoldFailureDropsDay() async throws {
     let day = try AnalysisTestHelpers.utcDate(year: 2025, month: 6, day: 10, hour: 12)
-    let dayKey = AnalysisTestHelpers.calendar.startOfDay(for: day)
+    let dayKey = Calendar.current.startOfDay(for: day)
     let usd = Instrument.fiat(code: "USD")
     let accountId = UUID()
     let row = GRDBAnalysisRepository.DailyBalanceAccountRow(
@@ -1392,9 +1572,9 @@ Append:
       tradesIds: [accountId],
       instrumentMap: ["USD": usd],
       conversionService: conversion)
-    var failures: [(Error, Date)] = []
+    let captured = InvestmentValueFailureLog()
     let handlers = Self.makeHandlers { error, date in
-      failures.append((error, date))
+      captured.append(error, date)
     }
 
     try await GRDBAnalysisRepository.applyTradesModePositionValuations(
@@ -1402,7 +1582,8 @@ Append:
       to: &balances, context: context, handlers: handlers)
 
     #expect(balances[dayKey] == nil)
-    #expect(failures.count == 1)
+    #expect(captured.count == 1)
+    #expect(captured.dates == [dayKey])
   }
 ```
 
@@ -1417,13 +1598,13 @@ Append:
 ```swift
   @Test("case 7: startOfDay normalization keys days correctly across local boundary")
   func rule10StartOfDayNormalization() async throws {
-    let cal = AnalysisTestHelpers.calendar
-    // Create two timestamps in the same local day; both must
-    // produce the same dayKey.
+    // Use the local-calendar `date(year:month:day:hour:)` overload
+    // (added by Task 0) so the test agrees with the production
+    // fold's `Calendar.current.startOfDay` math.
     let dayMorning = try AnalysisTestHelpers.date(year: 2025, month: 6, day: 10, hour: 9)
     let dayEvening = try AnalysisTestHelpers.date(year: 2025, month: 6, day: 10, hour: 23)
-    let dayKey = cal.startOfDay(for: dayMorning)
-    #expect(cal.startOfDay(for: dayEvening) == dayKey)
+    let dayKey = Calendar.current.startOfDay(for: dayMorning)
+    #expect(Calendar.current.startOfDay(for: dayEvening) == dayKey)
 
     let usd = Instrument.fiat(code: "USD")
     let accountId = UUID()
@@ -1433,14 +1614,25 @@ Append:
     let rowEvening = GRDBAnalysisRepository.DailyBalanceAccountRow(
       day: "2025-06-10", sampleDate: dayEvening,
       accountId: accountId, instrumentId: "USD", type: "trade", qty: 500)
+    // Two rate buckets that distinguish dayKey from sampleDate:
+    //   - dayKey (00:00 local) → 1.5
+    //   - 06:00 local → 99.99
+    // ratesAsOf walks descending and returns the first bucket with
+    // date <= requested. A request on dayKey (00:00) finds 1.5
+    // because 06:00 is in the future relative to 00:00. A regression
+    // that passed `row.sampleDate` (a 09:00 or 23:00 local instant)
+    // would walk past 06:00 and pick up 99.99 instead, yielding a
+    // far larger total. Both rows would then mis-rate identically,
+    // turning the assertion below into a sharp signal.
+    let midDay = try AnalysisTestHelpers.date(
+      year: 2025, month: 6, day: 10, hour: 6)
     let conversion = DateBasedFixedConversionService(
       rates: [
-        try AnalysisTestHelpers.utcDate(year: 2025, month: 1, day: 1, hour: 0): [
-          "USD": try AnalysisTestHelpers.decimal("1.5")
-        ]
+        dayKey: ["USD": try AnalysisTestHelpers.decimal("1.5")],
+        midDay: ["USD": try AnalysisTestHelpers.decimal("99.99")],
       ])
     var balances: [Date: DailyBalance] = [
-      dayKey: GRDBDailyBalancesTradesModeTests.placeholderBalance(at: dayKey)
+      dayKey: Self.placeholderBalance(at: dayKey)
     ]
     let context = Self.makeContext(
       tradesIds: [accountId],
@@ -1453,6 +1645,10 @@ Append:
       to: &balances, context: context, handlers: handlers)
 
     // Both rows applied on the same dayKey; total = 10 USD * 1.5 = 15.
+    // A regression that passed `row.sampleDate` to the conversion
+    // service would resolve to the 99.99 bucket (since the row
+    // timestamps fall after midDay 06:00) and yield 999. The
+    // assertion catches that.
     let value = try #require(balances[dayKey]?.investmentValue)
     #expect(value.quantity == try AnalysisTestHelpers.decimal("15"))
   }
@@ -1466,7 +1662,7 @@ Append:
   @Test("case 10: CSV-imported transfer cash leg + trade position leg both contribute")
   func csvImportedTransferPlusTrade() async throws {
     let day = try AnalysisTestHelpers.utcDate(year: 2025, month: 6, day: 10, hour: 12)
-    let dayKey = AnalysisTestHelpers.calendar.startOfDay(for: day)
+    let dayKey = Calendar.current.startOfDay(for: day)
     let usd = Instrument.fiat(code: "USD")
     let aud = Instrument.defaultTestInstrument
     let accountId = UUID()
@@ -1485,7 +1681,7 @@ Append:
         ]
       ])
     var balances: [Date: DailyBalance] = [
-      dayKey: GRDBDailyBalancesTradesModeTests.placeholderBalance(at: dayKey)
+      dayKey: Self.placeholderBalance(at: dayKey)
     ]
     let context = Self.makeContext(
       tradesIds: [accountId],
@@ -1505,7 +1701,7 @@ Append:
   @Test("case 11: same-day BUY + SELL netting produces zero contribution")
   func sameDayBuyAndSellNetZero() async throws {
     let day = try AnalysisTestHelpers.utcDate(year: 2025, month: 6, day: 10, hour: 12)
-    let dayKey = AnalysisTestHelpers.calendar.startOfDay(for: day)
+    let dayKey = Calendar.current.startOfDay(for: day)
     let usd = Instrument.fiat(code: "USD")
     let accountId = UUID()
     let buy = GRDBAnalysisRepository.DailyBalanceAccountRow(
@@ -1521,7 +1717,7 @@ Append:
         ]
       ])
     var balances: [Date: DailyBalance] = [
-      dayKey: GRDBDailyBalancesTradesModeTests.placeholderBalance(at: dayKey)
+      dayKey: Self.placeholderBalance(at: dayKey)
     ]
     let context = Self.makeContext(
       tradesIds: [accountId],
@@ -1533,8 +1729,13 @@ Append:
       priorRows: [], postRows: [buy, sell],
       to: &balances, context: context, handlers: handlers)
 
-    // Net position is 0; investmentValue ends up at 0 (zero added to
-    // existing nil → .zero(instrument: AUD)).
+    // After the cursor advance, positions[accountId][USD] = 0 — the
+    // outer dict key is still present, so positions.isEmpty is false
+    // and `sumTradesModePositions` is invoked. The Rule 8 fast path
+    // (USD ≠ AUD profile, so the conversion service is called) plus
+    // the zero quantity yields a 0 contribution. existing.investmentValue
+    // is nil, so `(nil ?? .zero) + .zero == .zero`, and the day's
+    // investmentValue ends up at .zero(instrument: AUD).
     let value = try #require(balances[dayKey]?.investmentValue)
     #expect(value.quantity == 0)
   }
@@ -1549,8 +1750,8 @@ Append:
   func carryForwardAcrossDroppedDay() async throws {
     let dayOne = try AnalysisTestHelpers.utcDate(year: 2025, month: 6, day: 10, hour: 12)
     let dayTwo = try AnalysisTestHelpers.utcDate(year: 2025, month: 6, day: 11, hour: 12)
-    let keyOne = AnalysisTestHelpers.calendar.startOfDay(for: dayOne)
-    let keyTwo = AnalysisTestHelpers.calendar.startOfDay(for: dayTwo)
+    let keyOne = Calendar.current.startOfDay(for: dayOne)
+    let keyTwo = Calendar.current.startOfDay(for: dayTwo)
     let usd = Instrument.fiat(code: "USD")
     let accountId = UUID()
     let rowOne = GRDBAnalysisRepository.DailyBalanceAccountRow(
@@ -1565,7 +1766,7 @@ Append:
     // Simulate a snapshot-fold dropout on day 1: dailyBalances has
     // entries only for day 2 (day 1 was removed by an earlier fold).
     var balances: [Date: DailyBalance] = [
-      keyTwo: GRDBDailyBalancesTradesModeTests.placeholderBalance(at: keyTwo)
+      keyTwo: Self.placeholderBalance(at: keyTwo)
     ]
     let context = Self.makeContext(
       tradesIds: [accountId],


### PR DESCRIPTION
## Summary

Adds a per-day "valued positions over time" fold for trades-mode investment accounts so the historical net-worth chart accurately reflects their value, instead of showing only the cash transfer leg of each trade. Closes #738.

## What lands

- **New fold (`applyTradesModePositionValuations`)** in `Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesTradesMode.swift`. Per-day cursor walk over trades-mode account legs; each day valuates cumulative positions in the profile instrument using the historical price for that day (Rule 5 / Rule 8 / Rule 10). Per-day failures drop the day from `dailyBalances` (Rule 11).
- **Pre-filter inside the existing `database.read` snapshot** in `+DailyBalancesAggregation.swift` so the fold takes purpose-built input.
- **Double-count fix**: `walkDays` and `runForecastAccumulator` pass `investmentAccountIds.union(tradesModeInvestmentAccountIds)` to `PositionBook.BalanceContext` so trades-mode positions are excluded from `bankTotal` (the new fold is the sole contributor of their value to `investmentValue` / `netWorth`).
- **Tightens the existing `applyInvestmentValues` snapshot fold** for Rule 11 alignment with `walkDays` (drop the day on per-day conversion failure instead of leaving a partial total). Drops the vestigial `?` on `sumInvestmentValues`'s return type at the same time.
- **Extracts `InvestmentStore.loadAndBuildPositionsInput`** so the `.task` / `.refreshable` blocks in `InvestmentAccountView` reduce to view-local state plus a single store-method call.
- **Adds `@concurrent`** to `PositionsHistoryBuilder.build` to take its per-day pricing loop off the main thread, matching `assembleDailyBalances`.

Design spec: [`plans/2026-05-04-trades-mode-historical-net-worth-design.md`](https://github.com/ajsutton/moolah-native/blob/trades-mode/historical-chart/plans/2026-05-04-trades-mode-historical-net-worth-design.md)
Implementation plan: [`plans/2026-05-04-trades-mode-historical-net-worth-plan.md`](https://github.com/ajsutton/moolah-native/blob/trades-mode/historical-chart/plans/2026-05-04-trades-mode-historical-net-worth-plan.md)

## Test plan

- [x] `just test-mac GRDBDailyBalancesTradesModeTests GRDBDailyBalancesTradesModeRule11Tests` — 13 fold-contract tests pass (cases 1–4, 6–14)
- [x] `just test-mac GRDBDailyBalancesAggregationTests` — 3 aggregation-layer pins pass
- [x] `just test-mac GRDBDailyBalancesAssembleTests/snapshotFoldDropsDayOnFailure` — Rule 11 tightening pinned (case 5)
- [x] `just test-mac DailyBalancesPlanPinningTests/fetchTradesModeInvestmentAccountIdsUsesAccountByType` — `account_by_type` plan pinned
- [x] `just test-mac InvestmentStorePositionsInputTests/loadAndBuildPositionsInputCoordinatesBothSteps` — store-coordination test pins the hoisted method
- [x] `just test-mac` — full mac suite (2081 tests) passes
- [x] `just format-check` — clean
- [x] `just build-mac` — clean

## Review rounds

Spec passed 4 rounds of multi-agent review (`code-review`, `database-code-review`, `instrument-conversion-review`, `concurrency-review`). Plan passed 3 rounds. Implementation passed 3 rounds. Notable findings caught:

- **Critical (round 1, instrument-conversion):** `netWorth` would have double-counted trades-mode positions because `PositionBook.dailyBalance`'s `bankTotal` includes accounts not in `investmentAccountIds`. Fixed via the union-into-`BalanceContext` change above. Pinned by case 14 (end-to-end pipeline test).
- **Important (round 2, code-review):** `AnalysisTestHelpers.date(year:month:day:hour:)` was calendar-asymmetric with the existing `date(year:month:day:)` (Gregorian vs `Calendar.current`). Renamed to `localDate(year:month:day:hour:)` for call-site clarity.
- **Important (round 2, db-code):** `testFetchAggregation` test seam renamed to `fetchAggregationForTesting` to match the project's `…ForTesting` convention.
- **Important (round 3, concurrency):** Pre-existing `PositionsHistoryBuilder.build` lacked `@concurrent`; per-day pricing loop ran on the main thread. Fixed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)