### PR TITLE
fix(investments): widen positions split default when chart is shown

### DIFF
--- a/Features/Investments/Views/InvestmentAccountView+Previews.swift
+++ b/Features/Investments/Views/InvestmentAccountView+Previews.swift
@@ -1,0 +1,96 @@
+import SwiftUI
+
+@MainActor
+private func seedLegacyValuations(
+  backend: any BackendProvider, account: Account, store: InvestmentStore
+) async {
+  _ = try? await backend.accounts.create(
+    account, openingBalance: InstrumentAmount(quantity: 10_000, instrument: .AUD))
+  let calendar = Calendar.current
+  for monthsAgo in (0..<6).reversed() {
+    let date = calendar.date(byAdding: .month, value: -monthsAgo, to: Date()) ?? Date()
+    let quantity: Decimal = 9_500 + Decimal(6 - monthsAgo) * 400
+    await store.setValue(
+      accountId: account.id,
+      date: date,
+      value: InstrumentAmount(quantity: quantity, instrument: .AUD))
+  }
+}
+
+@MainActor
+private func seedPositionValuations(backend: any BackendProvider, account: Account) async {
+  let bhp = Instrument.stock(ticker: "BHP.AX", exchange: "ASX", name: "BHP")
+  _ = try? await backend.accounts.create(
+    account, openingBalance: InstrumentAmount(quantity: 0, instrument: .AUD))
+  _ = try? await backend.transactions.create(
+    Transaction(
+      date: Date().addingTimeInterval(-86_400 * 30),
+      legs: [
+        TransactionLeg(accountId: account.id, instrument: bhp, quantity: 100, type: .income),
+        TransactionLeg(accountId: account.id, instrument: .AUD, quantity: -4_000, type: .expense),
+      ]))
+}
+
+#Preview {
+  let (backend, _) = PreviewBackend.create()
+  let investmentStore = InvestmentStore(
+    repository: backend.investments,
+    transactionRepository: backend.transactions,
+    conversionService: backend.conversionService)
+  let transactionStore = TransactionStore(
+    repository: backend.transactions,
+    conversionService: backend.conversionService,
+    targetInstrument: .AUD)
+  // In-memory preview session can't fail in practice: opens an ephemeral
+  // GRDB queue with no disk access. A trap here is acceptable in #Preview.
+  // swiftlint:disable:next force_try
+  let session = try! ProfileSession.preview()
+  let account = Account(name: "Brokerage", type: .investment, instrument: .AUD)
+  return NavigationStack {
+    InvestmentAccountView(
+      account: account,
+      accounts: Accounts(from: [account]),
+      categories: Categories(from: []),
+      earmarks: Earmarks(from: []),
+      investmentStore: investmentStore,
+      transactionStore: transactionStore
+    )
+    .environment(session)
+  }
+  .frame(width: 720, height: 560)
+  .task { await seedLegacyValuations(backend: backend, account: account, store: investmentStore) }
+}
+
+#Preview("Position-tracked") {
+  let (backend, _) = PreviewBackend.create()
+  let investmentStore = InvestmentStore(
+    repository: backend.investments,
+    transactionRepository: backend.transactions,
+    conversionService: backend.conversionService)
+  let transactionStore = TransactionStore(
+    repository: backend.transactions,
+    conversionService: backend.conversionService,
+    targetInstrument: .AUD)
+  // In-memory preview session can't fail in practice: opens an ephemeral
+  // GRDB queue with no disk access. A trap here is acceptable in #Preview.
+  // swiftlint:disable:next force_try
+  let session = try! ProfileSession.preview()
+  let account = Account(
+    name: "Brokerage",
+    type: .investment,
+    instrument: .AUD,
+    valuationMode: .calculatedFromTrades)
+  return NavigationStack {
+    InvestmentAccountView(
+      account: account,
+      accounts: Accounts(from: [account]),
+      categories: Categories(from: []),
+      earmarks: Earmarks(from: []),
+      investmentStore: investmentStore,
+      transactionStore: transactionStore
+    )
+    .environment(session)
+  }
+  .frame(width: 720, height: 600)
+  .task { await seedPositionValuations(backend: backend, account: account) }
+}

--- a/Features/Investments/Views/InvestmentAccountView.swift
+++ b/Features/Investments/Views/InvestmentAccountView.swift
@@ -69,7 +69,17 @@ struct InvestmentAccountView: View {
     if positionsInput.shouldHide && !isLoadingPositions {
       accountTransactionList
     } else {
-      PositionsTransactionsSplit(defaultTab: .positions) {
+      PositionsTransactionsSplit(
+        defaultTab: .positions,
+        // Distinct autosave key from the chartless multi-currency split so
+        // the saved divider position from each layout doesn't bleed into
+        // the other; the chart pushes the table off-screen at the
+        // chartless 180pt default.
+        autosaveName: "positions-transactions-split.with-chart",
+        // Header (~50pt) + chart (~250pt with padding) + a few table rows
+        // need ~530pt to render comfortably without the user dragging.
+        initialTopHeight: 540
+      ) {
         if isLoadingPositions && positionsInput.positions.isEmpty {
           ProgressView()
             .frame(maxWidth: .infinity)
@@ -296,96 +306,4 @@ struct InvestmentAccountView: View {
   }
 }
 
-@MainActor
-private func seedLegacyValuations(
-  backend: any BackendProvider, account: Account, store: InvestmentStore
-) async {
-  _ = try? await backend.accounts.create(
-    account, openingBalance: InstrumentAmount(quantity: 10_000, instrument: .AUD))
-  let calendar = Calendar.current
-  for monthsAgo in (0..<6).reversed() {
-    let date = calendar.date(byAdding: .month, value: -monthsAgo, to: Date()) ?? Date()
-    let quantity: Decimal = 9_500 + Decimal(6 - monthsAgo) * 400
-    await store.setValue(
-      accountId: account.id, date: date,
-      value: InstrumentAmount(quantity: quantity, instrument: .AUD))
-  }
-}
-
-@MainActor
-private func seedPositionValuations(backend: any BackendProvider, account: Account) async {
-  let bhp = Instrument.stock(ticker: "BHP.AX", exchange: "ASX", name: "BHP")
-  _ = try? await backend.accounts.create(
-    account, openingBalance: InstrumentAmount(quantity: 0, instrument: .AUD))
-  _ = try? await backend.transactions.create(
-    Transaction(
-      date: Date().addingTimeInterval(-86_400 * 30),
-      legs: [
-        TransactionLeg(accountId: account.id, instrument: bhp, quantity: 100, type: .income),
-        TransactionLeg(accountId: account.id, instrument: .AUD, quantity: -4_000, type: .expense),
-      ]))
-}
-
-#Preview {
-  let (backend, _) = PreviewBackend.create()
-  let investmentStore = InvestmentStore(
-    repository: backend.investments,
-    transactionRepository: backend.transactions,
-    conversionService: backend.conversionService)
-  let transactionStore = TransactionStore(
-    repository: backend.transactions,
-    conversionService: backend.conversionService,
-    targetInstrument: .AUD)
-  // In-memory preview session can't fail in practice: opens an ephemeral
-  // GRDB queue with no disk access. A trap here is acceptable in #Preview.
-  // swiftlint:disable:next force_try
-  let session = try! ProfileSession.preview()
-  let account = Account(name: "Brokerage", type: .investment, instrument: .AUD)
-  return NavigationStack {
-    InvestmentAccountView(
-      account: account,
-      accounts: Accounts(from: [account]),
-      categories: Categories(from: []),
-      earmarks: Earmarks(from: []),
-      investmentStore: investmentStore,
-      transactionStore: transactionStore
-    )
-    .environment(session)
-  }
-  .frame(width: 720, height: 560)
-  .task { await seedLegacyValuations(backend: backend, account: account, store: investmentStore) }
-}
-
-#Preview("Position-tracked") {
-  let (backend, _) = PreviewBackend.create()
-  let investmentStore = InvestmentStore(
-    repository: backend.investments,
-    transactionRepository: backend.transactions,
-    conversionService: backend.conversionService)
-  let transactionStore = TransactionStore(
-    repository: backend.transactions,
-    conversionService: backend.conversionService,
-    targetInstrument: .AUD)
-  // In-memory preview session can't fail in practice: opens an ephemeral
-  // GRDB queue with no disk access. A trap here is acceptable in #Preview.
-  // swiftlint:disable:next force_try
-  let session = try! ProfileSession.preview()
-  let account = Account(
-    name: "Brokerage",
-    type: .investment,
-    instrument: .AUD,
-    valuationMode: .calculatedFromTrades)
-  return NavigationStack {
-    InvestmentAccountView(
-      account: account,
-      accounts: Accounts(from: [account]),
-      categories: Categories(from: []),
-      earmarks: Earmarks(from: []),
-      investmentStore: investmentStore,
-      transactionStore: transactionStore
-    )
-    .environment(session)
-  }
-  .frame(width: 720, height: 600)
-  .task { await seedPositionValuations(backend: backend, account: account) }
-}
+// Preview seeds and `#Preview` blocks live in InvestmentAccountView+Previews.swift

--- a/Shared/Views/Positions/PositionsTransactionsSplit.swift
+++ b/Shared/Views/Positions/PositionsTransactionsSplit.swift
@@ -6,16 +6,25 @@ import SwiftUI
 /// the two panes leaves neither with enough room, so a segmented picker
 /// swaps between them.
 ///
-/// The macOS divider position is shared across every call site (all users of
-/// this container autosave under the same `NSSplitView` key). That matches
-/// the Finder-sidebar convention: the user adjusts once and their preference
-/// applies everywhere this component renders.
+/// Two layouts coexist and must NOT share a divider:
+///   - **Chartless** (default, used by multi-currency non-investment accounts):
+///     header + table only. ~180pt is plenty for several rows.
+///   - **With chart** (investment accounts in `.calculatedFromTrades`):
+///     header + chart (220pt fixed) + table. ~180pt clips the table below
+///     the chart so it appears empty unless the user drags the divider —
+///     hence a separate, taller default and a distinct autosave key.
+///
+/// Within a layout, the divider position is autosaved and shared across all
+/// call sites — Finder-sidebar style: adjust once, applies everywhere of
+/// the same shape.
 struct PositionsTransactionsSplit<Positions: View, Transactions: View>: View {
   /// The pane the iOS segmented picker selects initially. On macOS both
   /// panes are always visible in the split, so this only affects iOS.
   enum Tab { case positions, transactions }
 
   let defaultTab: Tab
+  let autosaveName: String
+  let initialTopHeight: CGFloat
   @ViewBuilder let positions: () -> Positions
   @ViewBuilder let transactions: () -> Transactions
 
@@ -25,10 +34,14 @@ struct PositionsTransactionsSplit<Positions: View, Transactions: View>: View {
 
   init(
     defaultTab: Tab,
+    autosaveName: String = "positions-transactions-split",
+    initialTopHeight: CGFloat = 180,
     @ViewBuilder positions: @escaping () -> Positions,
     @ViewBuilder transactions: @escaping () -> Transactions
   ) {
     self.defaultTab = defaultTab
+    self.autosaveName = autosaveName
+    self.initialTopHeight = initialTopHeight
     self.positions = positions
     self.transactions = transactions
     #if !os(macOS)
@@ -39,8 +52,8 @@ struct PositionsTransactionsSplit<Positions: View, Transactions: View>: View {
   var body: some View {
     #if os(macOS)
       ResizableVSplit(
-        autosaveName: "positions-transactions-split",
-        initialTopHeight: 180
+        autosaveName: autosaveName,
+        initialTopHeight: initialTopHeight
       ) {
         positions()
       } bottom: {


### PR DESCRIPTION
## Summary

When an investment account is set to **Calculated from trades**,
`InvestmentAccountView` renders `PositionsView` (header + 220pt chart +
positions table) above the transaction list inside
`PositionsTransactionsSplit`. The split's top pane uses a single shared
autosave key and a 180pt initial height, which is fine for the
chartless multi-currency case but is far too small once the chart is
added — the table is pushed off-screen and the user appears to see only
"value graph + transaction list" until they drag the divider down.

This change:

- Adds `autosaveName` and `initialTopHeight` parameters to
  `PositionsTransactionsSplit` (defaults preserved, so the
  multi-currency call site in `TransactionListView` is unchanged).
- Has `InvestmentAccountView.positionTrackedLayout` opt into a distinct
  autosave key (`positions-transactions-split.with-chart`) and a 540pt
  initial top height so header + chart + several table rows render
  without the user dragging.
- Hoists the previews + seed helpers into a sibling
  `InvestmentAccountView+Previews.swift` to keep the main view file
  under its 400-line budget after the comment additions.

## Test plan

- [ ] Manual: open an investment account in `.calculatedFromTrades`
  with at least one non-host position and a cost basis. Confirm the
  positions table is visible without dragging the divider.
- [ ] Manual: open a multi-currency non-investment account. Confirm
  the previously-saved divider position is preserved (different
  autosave key, so untouched).
- [ ] CI: `just format-check`, `just build-mac`, `just test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)