### PR TITLE
fix(rate-cache): cap requests at yesterday and overlap-overwrite latest

### DIFF
--- a/Backends/GRDB/ProfileSchema+PurgeIntradayCaches.swift
+++ b/Backends/GRDB/ProfileSchema+PurgeIntradayCaches.swift
@@ -1,0 +1,46 @@
+// Backends/GRDB/ProfileSchema+PurgeIntradayCaches.swift
+
+import Foundation
+import GRDB
+
+// MARK: - v7 migration body
+//
+// Empties all six rate-cache tables — `exchange_rate`,
+// `exchange_rate_meta`, `stock_price`, `stock_ticker_meta`,
+// `crypto_price`, `crypto_token_meta`.
+//
+// Why a one-shot purge: earlier builds wrote partial intraday bars to
+// the cache as if they were finalised closes, then froze them
+// (cache-hits never re-fetched). Once a row was poisoned, every
+// subsequent read returned a stale tick — most visibly as VGS.AX
+// reporting an intraday print after the session settled. The fix in
+// `Shared/PriceCacheCap.swift` caps every request at yesterday-UTC and
+// re-fetches the latest cached date on every forward extension, but
+// the rule only governs *future* writes. Any pre-fix poisoned row sits
+// in the cache as actual-yesterday once today rolls over, and there's
+// no way for the service to tell a finalised close from a frozen
+// intraday tick. Wiping the lot is the cheapest way to guarantee a
+// clean baseline.
+//
+// Cost: every cached date is re-fetched on demand from Yahoo /
+// Frankfurter / CoinGecko the next time someone asks for that range.
+// `guides/DATABASE_SCHEMA_GUIDE.md` §9's "rate caches kept forever"
+// retention rule is unaffected — we're not changing the policy, just
+// resetting state once.
+//
+// `v1_initial` is shipped, so editing its body in place to seed the
+// new schema differently is forbidden by §6.
+
+extension ProfileSchema {
+  static func purgeIntradayCachedPrices(_ database: Database) throws {
+    try database.execute(
+      sql: """
+        DELETE FROM exchange_rate;
+        DELETE FROM exchange_rate_meta;
+        DELETE FROM stock_price;
+        DELETE FROM stock_ticker_meta;
+        DELETE FROM crypto_price;
+        DELETE FROM crypto_token_meta;
+        """)
+  }
+}

--- a/Backends/GRDB/ProfileSchema.swift
+++ b/Backends/GRDB/ProfileSchema.swift
@@ -28,13 +28,19 @@ import GRDB
 /// the `account` table (per-account choice between recorded value and
 /// calculated-from-trades). See
 /// `ProfileSchema+AccountValuationMode.swift`.
+/// `v7_purge_intraday_cached_prices` — one-shot `DELETE FROM` of all
+/// six rate-cache tables to clear poisoned intraday rows persisted by
+/// pre-cap builds. See `ProfileSchema+PurgeIntradayCaches.swift` and
+/// `Shared/PriceCacheCap.swift` for the cap-at-yesterday rule that
+/// prevents re-poisoning.
 ///
 /// **Retention policy for the cache tables.** All six cache tables
 /// created by `v1_initial` (`exchange_rate`, `exchange_rate_meta`,
 /// `stock_price`, `stock_ticker_meta`, `crypto_price`,
 /// `crypto_token_meta`) are **kept forever** — needed for
 /// historic-conversion correctness on reports older than the upstream
-/// rate APIs can serve. See `guides/DATABASE_SCHEMA_GUIDE.md` §9.
+/// rate APIs can serve. See `guides/DATABASE_SCHEMA_GUIDE.md` §9. The
+/// `v7` purge resets state once; the retention policy is unchanged.
 ///
 /// Each migration body lives in its own sibling-extension file so
 /// `ProfileSchema.swift` stays a small index of registered migrations.
@@ -48,7 +54,7 @@ enum ProfileSchema {
   /// Bumped each time a migration is added. Surfaced for open-time
   /// integrity checks; not used by `DatabaseMigrator` (which keys on
   /// the stable string IDs of registered migrations).
-  static let version = 6
+  static let version = 7
 
   static var migrator: DatabaseMigrator {
     var migrator = DatabaseMigrator()
@@ -68,6 +74,8 @@ enum ProfileSchema {
       "v5_drop_foreign_keys", migrate: dropForeignKeys)
     migrator.registerMigration(
       "v6_account_valuation_mode", migrate: addAccountValuationMode)
+    migrator.registerMigration(
+      "v7_purge_intraday_cached_prices", migrate: purgeIntradayCachedPrices)
 
     return migrator
   }

--- a/MoolahTests/Backends/GRDB/PurgeIntradayCachesMigrationTests.swift
+++ b/MoolahTests/Backends/GRDB/PurgeIntradayCachesMigrationTests.swift
@@ -1,0 +1,72 @@
+// MoolahTests/Backends/GRDB/PurgeIntradayCachesMigrationTests.swift
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+@Suite("v7_purge_intraday_cached_prices migration")
+struct PurgeIntradayCachesMigrationTests {
+  @Test("seeded rows in all six cache tables are wiped by v7")
+  func purgesAllCacheTables() throws {
+    let queue = try DatabaseQueue()
+
+    // Migrate up to v6 (state where the bug could persist poisoned rows).
+    try ProfileSchema.migrator.migrate(queue, upTo: "v6_account_valuation_mode")
+
+    try queue.write { database in
+      try database.execute(
+        sql: """
+          INSERT INTO exchange_rate_meta (base, earliest_date, latest_date)
+          VALUES ('USD', '2026-04-01', '2026-05-04');
+          INSERT INTO exchange_rate (base, quote, date, rate)
+          VALUES ('USD', 'AUD', '2026-05-04', 1.55);
+
+          INSERT INTO stock_ticker_meta (ticker, instrument_id, earliest_date, latest_date)
+          VALUES ('VGS.AX', 'AUD', '2026-04-01', '2026-05-05');
+          INSERT INTO stock_price (ticker, date, price)
+          VALUES ('VGS.AX', '2026-05-05', 149.82);
+
+          INSERT INTO crypto_token_meta (token_id, symbol, earliest_date, latest_date)
+          VALUES ('1:native', 'ETH', '2026-04-01', '2026-05-04');
+          INSERT INTO crypto_price (token_id, date, price_usd)
+          VALUES ('1:native', '2026-05-04', 1640.0);
+          """)
+    }
+
+    // Now run v7 — should empty every cache table.
+    try ProfileSchema.migrator.migrate(queue)
+
+    try queue.read { database in
+      for table in [
+        "exchange_rate", "exchange_rate_meta",
+        "stock_price", "stock_ticker_meta",
+        "crypto_price", "crypto_token_meta",
+      ] {
+        let count = try Int.fetchOne(database, sql: "SELECT COUNT(*) FROM \(table)") ?? -1
+        #expect(count == 0, "expected \(table) to be empty after v7, got \(count)")
+      }
+    }
+  }
+
+  @Test("schema is intact after v7 — re-inserts work")
+  func schemaIntactAfterPurge() throws {
+    let queue = try DatabaseQueue()
+    try ProfileSchema.migrator.migrate(queue)
+
+    try queue.write { database in
+      try database.execute(
+        sql: """
+          INSERT INTO stock_ticker_meta (ticker, instrument_id, earliest_date, latest_date)
+          VALUES ('VGS.AX', 'AUD', '2026-05-04', '2026-05-04');
+          INSERT INTO stock_price (ticker, date, price)
+          VALUES ('VGS.AX', '2026-05-04', 149.91);
+          """)
+    }
+
+    let price: Double? = try queue.read { database in
+      try Double.fetchOne(database, sql: "SELECT price FROM stock_price WHERE ticker = 'VGS.AX'")
+    }
+    #expect(price == 149.91)
+  }
+}

--- a/MoolahTests/Domain/TransactionRepositoryPriorBalanceTests.swift
+++ b/MoolahTests/Domain/TransactionRepositoryPriorBalanceTests.swift
@@ -110,12 +110,16 @@ struct TransactionRepositoryPriorBalanceTests {
 
     // USD -> AUD at 1.5 today. FixedRateClient keys are ISO-8601 date →
     // quote-currency rates (base is passed separately to fetchRates).
+    // Cache caps "today" requests to yesterday — see
+    // `Shared/PriceCacheCap.swift`. Seed both keys.
     let todayFormatter = ISO8601DateFormatter()
     todayFormatter.formatOptions = [.withFullDate]
     let todayKey = todayFormatter.string(from: Date())
+    let yesterdayKey = todayFormatter.string(from: Date().addingTimeInterval(-86400))
     let audRate = try #require(Decimal(string: "1.5"))
     let rates: [String: [String: Decimal]] = [
-      todayKey: ["AUD": audRate]
+      todayKey: ["AUD": audRate],
+      yesterdayKey: ["AUD": audRate],
     ]
     let (backend, database) = try TestBackend.create(
       instrument: accountInstrument, exchangeRates: rates)

--- a/MoolahTests/Features/AccountStoreConversionTests.swift
+++ b/MoolahTests/Features/AccountStoreConversionTests.swift
@@ -101,11 +101,14 @@ struct AccountStoreConversionTests {
     let account = Account(
       id: accountId, name: "Revolut", type: .bank,
       instrument: .defaultTestInstrument)
+    // Cache cap routes today's request to yesterday's row — see
+    // `Shared/PriceCacheCap.swift`. Seed both keys with the same value
+    // so the assertion is independent of UTC midnight crossings.
     let todayString = Date().iso8601DateOnlyString
+    let yesterdayString = Date().addingTimeInterval(-86400).iso8601DateOnlyString
     let rates: [String: [String: Decimal]] = [
-      todayString: [
-        "AUD": dec("1.5385")
-      ]
+      todayString: ["AUD": dec("1.5385")],
+      yesterdayString: ["AUD": dec("1.5385")],
     ]
     let (backend, database) = try TestBackend.create(exchangeRates: rates)
     TestBackend.seed(accounts: [account], in: database)

--- a/MoolahTests/Features/StockPositionDisplayTests.swift
+++ b/MoolahTests/Features/StockPositionDisplayTests.swift
@@ -69,8 +69,11 @@ struct StockPositionDisplayTests {
     let today = Date()
     let dateKey = dateString(today)
 
+    // Cache caps "today" → yesterday — see `Shared/PriceCacheCap.swift`.
+    let yKey = dateString(today.addingTimeInterval(-86400))
     let stockClient = FixedStockPriceClient(responses: [
-      "BHP.AX": StockPriceResponse(instrument: .AUD, prices: [dateKey: dec("45.00")])
+      "BHP.AX": StockPriceResponse(
+        instrument: .AUD, prices: [dateKey: dec("45.00"), yKey: dec("45.00")])
     ])
     let cacheDatabase = try ProfileDatabase.openInMemory()
     let stockService = StockPriceService(client: stockClient, database: cacheDatabase)
@@ -148,9 +151,13 @@ struct StockPositionDisplayTests {
 
   private func makeTotalPortfolioConversionService(today: Date) throws -> FullConversionService {
     let dateKey = dateString(today)
+    // Cache caps "today" → yesterday — see `Shared/PriceCacheCap.swift`.
+    let yKey = dateString(today.addingTimeInterval(-86400))
     let stockClient = FixedStockPriceClient(responses: [
-      "BHP.AX": StockPriceResponse(instrument: .AUD, prices: [dateKey: dec("45.00")]),
-      "CBA.AX": StockPriceResponse(instrument: .AUD, prices: [dateKey: dec("120.00")]),
+      "BHP.AX": StockPriceResponse(
+        instrument: .AUD, prices: [dateKey: dec("45.00"), yKey: dec("45.00")]),
+      "CBA.AX": StockPriceResponse(
+        instrument: .AUD, prices: [dateKey: dec("120.00"), yKey: dec("120.00")]),
     ])
     let database = try ProfileDatabase.openInMemory()
     let stockService = StockPriceService(client: stockClient, database: database)

--- a/MoolahTests/Shared/CryptoPriceServiceCapTests.swift
+++ b/MoolahTests/Shared/CryptoPriceServiceCapTests.swift
@@ -1,0 +1,120 @@
+// MoolahTests/Shared/CryptoPriceServiceCapTests.swift
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+/// Cap-at-yesterday rule for `CryptoPriceService`. See
+/// `Shared/PriceCacheCap.swift` for the rationale and `Shared/
+/// CryptoPriceService.swift` for the price-fetching path under test.
+@Suite("CryptoPriceService — cap at yesterday")
+struct CryptoPriceServiceCapTests {
+  private let ethInstrument = Instrument.crypto(
+    chainId: 1, contractAddress: nil, symbol: "ETH", name: "Ethereum", decimals: 18
+  )
+  private let ethMapping = CryptoProviderMapping(
+    instrumentId: "1:native", coingeckoId: "ethereum",
+    cryptocompareSymbol: "ETH", binanceSymbol: "ETHUSDT"
+  )
+
+  private func makeService(
+    prices: [String: [String: Decimal]] = [:],
+    shouldFail: Bool = false,
+    database: DatabaseQueue? = nil,
+    now: @Sendable @escaping () -> Date
+  ) throws -> CryptoPriceService {
+    let client = FixedCryptoPriceClient(prices: prices, shouldFail: shouldFail)
+    let resolved = try database ?? ProfileDatabase.openInMemory()
+    return CryptoPriceService(
+      clients: [client],
+      database: resolved,
+      resolutionClient: nil,
+      now: now)
+  }
+
+  private func date(_ string: String) throws -> Date {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withFullDate]
+    return try #require(formatter.date(from: string))
+  }
+
+  @Test
+  func todayRequestRoutesToYesterday() async throws {
+    let frozen = try self.date("2026-04-12")
+    let service = try makeService(
+      prices: ["1:native": ["2026-04-11": dec("1640.00")]],
+      now: { frozen })
+    let price = try await service.price(
+      for: ethInstrument, mapping: ethMapping, on: frozen)
+    #expect(price == dec("1640.00"))
+  }
+
+  @Test
+  func todayHitsCacheWithoutNetworkFetch() async throws {
+    let database = try ProfileDatabase.openInMemory()
+    let frozen = try self.date("2026-04-12")
+    let writer = try makeService(
+      prices: ["1:native": ["2026-04-11": dec("1640.00")]],
+      database: database,
+      now: { frozen })
+    _ = try await writer.price(
+      for: ethInstrument, mapping: ethMapping, on: try self.date("2026-04-11"))
+
+    let reader = try makeService(
+      shouldFail: true,
+      database: database,
+      now: { frozen })
+    let price = try await reader.price(
+      for: ethInstrument, mapping: ethMapping, on: frozen)
+    #expect(price == dec("1640.00"))
+  }
+
+  @Test
+  func forwardExtensionOverwritesStaleLatest() async throws {
+    let database = try ProfileDatabase.openInMemory()
+    let initial: [String: [String: Decimal]] = [
+      "1:native": ["2026-04-11": dec("1640.00")]
+    ]
+    let revised: [String: [String: Decimal]] = [
+      "1:native": [
+        "2026-04-11": dec("1655.00"),
+        "2026-04-13": dec("1670.00"),
+        "2026-04-14": dec("1675.00"),
+      ]
+    ]
+
+    let frozenInitial = try self.date("2026-04-12")
+    let pre = try makeService(prices: initial, database: database, now: { frozenInitial })
+    _ = try await pre.price(
+      for: ethInstrument, mapping: ethMapping, on: try self.date("2026-04-11"))
+
+    let frozenLater = try self.date("2026-04-15")
+    let post = try makeService(prices: revised, database: database, now: { frozenLater })
+    _ = try await post.price(
+      for: ethInstrument, mapping: ethMapping, on: try self.date("2026-04-14"))
+
+    let revisedAt11 = try await post.price(
+      for: ethInstrument, mapping: ethMapping, on: try self.date("2026-04-11"))
+    #expect(revisedAt11 == dec("1655.00"))
+  }
+
+  @Test
+  func rangeEndingTodayCarriesForwardYesterday() async throws {
+    let frozen = try self.date("2026-04-12")
+    let service = try makeService(
+      prices: [
+        "1:native": [
+          "2026-04-10": dec("1620.00"),
+          "2026-04-11": dec("1640.00"),
+        ]
+      ],
+      now: { frozen })
+    let results = try await service.prices(
+      for: ethInstrument, mapping: ethMapping,
+      in: try self.date("2026-04-10")...frozen)
+    #expect(results.count == 3)
+    // Today carries forward yesterday's close, not an intraday tick.
+    #expect(results.last?.price == dec("1640.00"))
+  }
+}

--- a/MoolahTests/Shared/CryptoPriceServiceTests.swift
+++ b/MoolahTests/Shared/CryptoPriceServiceTests.swift
@@ -35,7 +35,8 @@ struct CryptoPriceServiceTests {
     prices: [String: [String: Decimal]] = [:],
     shouldFail: Bool = false,
     database: DatabaseQueue? = nil,
-    resolutionClient: (any TokenResolutionClient)? = nil
+    resolutionClient: (any TokenResolutionClient)? = nil,
+    now: @Sendable @escaping () -> Date = { Date() }
   ) throws -> CryptoPriceService {
     let clientList =
       clients.isEmpty
@@ -45,7 +46,8 @@ struct CryptoPriceServiceTests {
     return CryptoPriceService(
       clients: clientList,
       database: resolved,
-      resolutionClient: resolutionClient
+      resolutionClient: resolutionClient,
+      now: now
     )
   }
 
@@ -263,5 +265,6 @@ struct CryptoPriceServiceTests {
   }
 
   // Rollback contract for `persistDelta` lives in `CryptoPriceServiceTestsMore.swift`
+  // and cap-at-yesterday tests live in `CryptoPriceServiceCapTests.swift`
   // so this file stays under SwiftLint's `type_body_length` cap.
 }

--- a/MoolahTests/Shared/CryptoPriceServiceTestsMore.swift
+++ b/MoolahTests/Shared/CryptoPriceServiceTestsMore.swift
@@ -35,7 +35,8 @@ struct CryptoPriceServiceTestsMore {
     prices: [String: [String: Decimal]] = [:],
     shouldFail: Bool = false,
     database: DatabaseQueue? = nil,
-    resolutionClient: (any TokenResolutionClient)? = nil
+    resolutionClient: (any TokenResolutionClient)? = nil,
+    now: @Sendable @escaping () -> Date = { Date() }
   ) throws -> CryptoPriceService {
     let clientList =
       clients.isEmpty
@@ -45,7 +46,8 @@ struct CryptoPriceServiceTestsMore {
     return CryptoPriceService(
       clients: clientList,
       database: resolved,
-      resolutionClient: resolutionClient
+      resolutionClient: resolutionClient,
+      now: now
     )
   }
 

--- a/MoolahTests/Shared/ExchangeRateServiceCapTests.swift
+++ b/MoolahTests/Shared/ExchangeRateServiceCapTests.swift
@@ -1,0 +1,96 @@
+// MoolahTests/Shared/ExchangeRateServiceCapTests.swift
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+/// Cap-at-yesterday rule for `ExchangeRateService`. See
+/// `Shared/PriceCacheCap.swift` for the rationale and `Shared/
+/// ExchangeRateService.swift` for the rate-fetching path under test.
+@Suite("ExchangeRateService — cap at yesterday")
+struct ExchangeRateServiceCapTests {
+  private func makeService(
+    rates: [String: [String: Decimal]] = [:],
+    shouldFail: Bool = false,
+    database: DatabaseQueue? = nil,
+    now: @Sendable @escaping () -> Date
+  ) throws -> ExchangeRateService {
+    let client = FixedRateClient(rates: rates, shouldFail: shouldFail)
+    let resolved = try database ?? ProfileDatabase.openInMemory()
+    return ExchangeRateService(client: client, database: resolved, now: now)
+  }
+
+  private func date(_ string: String) throws -> Date {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withFullDate]
+    return try #require(formatter.date(from: string))
+  }
+
+  @Test
+  func todayRequestRoutesToYesterday() async throws {
+    let frozen = try self.date("2025-01-20")
+    let service = try makeService(
+      rates: ["2025-01-19": ["USD": dec("0.6510")]],
+      now: { frozen })
+    let rate = try await service.rate(from: .AUD, to: .USD, on: frozen)
+    #expect(rate == dec("0.6510"))
+  }
+
+  @Test
+  func todayHitsCacheWithoutNetworkFetch() async throws {
+    let database = try ProfileDatabase.openInMemory()
+    let frozen = try self.date("2025-01-20")
+    let writer = try makeService(
+      rates: ["2025-01-19": ["USD": dec("0.6510")]],
+      database: database,
+      now: { frozen })
+    _ = try await writer.rate(from: .AUD, to: .USD, on: try self.date("2025-01-19"))
+
+    let reader = try makeService(
+      shouldFail: true,
+      database: database,
+      now: { frozen })
+    let rate = try await reader.rate(from: .AUD, to: .USD, on: frozen)
+    #expect(rate == dec("0.6510"))
+  }
+
+  @Test
+  func forwardExtensionOverwritesStaleLatest() async throws {
+    let database = try ProfileDatabase.openInMemory()
+    let initial: [String: [String: Decimal]] = ["2025-01-17": ["USD": dec("0.6500")]]
+    let revised: [String: [String: Decimal]] = [
+      "2025-01-17": ["USD": dec("0.6555")],
+      "2025-01-18": ["USD": dec("0.6560")],
+      "2025-01-19": ["USD": dec("0.6570")],
+    ]
+
+    let frozenInitial = try self.date("2025-01-18")
+    let pre = try makeService(rates: initial, database: database, now: { frozenInitial })
+    _ = try await pre.rate(from: .AUD, to: .USD, on: try self.date("2025-01-17"))
+
+    let frozenLater = try self.date("2025-01-20")
+    let post = try makeService(rates: revised, database: database, now: { frozenLater })
+    _ = try await post.rate(from: .AUD, to: .USD, on: try self.date("2025-01-19"))
+
+    let revisedAt17 = try await post.rate(
+      from: .AUD, to: .USD, on: try self.date("2025-01-17"))
+    #expect(revisedAt17 == dec("0.6555"))
+  }
+
+  @Test
+  func rangeEndingTodayCarriesForwardYesterday() async throws {
+    let frozen = try self.date("2025-01-20")
+    let service = try makeService(
+      rates: [
+        "2025-01-17": ["USD": dec("0.6500")],
+        "2025-01-19": ["USD": dec("0.6510")],
+      ],
+      now: { frozen })
+    let results = try await service.rates(
+      from: .AUD, to: .USD,
+      in: try self.date("2025-01-17")...frozen)
+    #expect(results.count == 4)
+    #expect(results.last?.rate == dec("0.6510"))
+  }
+}

--- a/MoolahTests/Shared/ExchangeRateServiceTests.swift
+++ b/MoolahTests/Shared/ExchangeRateServiceTests.swift
@@ -10,11 +10,12 @@ struct ExchangeRateServiceTests {
   private func makeService(
     rates: [String: [String: Decimal]] = [:],
     shouldFail: Bool = false,
-    database: DatabaseQueue? = nil
+    database: DatabaseQueue? = nil,
+    now: @Sendable @escaping () -> Date = { Date() }
   ) throws -> ExchangeRateService {
     let client = FixedRateClient(rates: rates, shouldFail: shouldFail)
     let resolved = try database ?? ProfileDatabase.openInMemory()
-    return ExchangeRateService(client: client, database: resolved)
+    return ExchangeRateService(client: client, database: resolved, now: now)
   }
 
   private func date(_ string: String) -> Date {
@@ -334,4 +335,6 @@ struct ExchangeRateServiceTests {
     #expect(client.fetchCount == primedFetches)
   }
 
+  // Cap-at-yesterday tests live in `ExchangeRateServiceCapTests.swift`
+  // so this suite stays under SwiftLint's `type_body_length` cap.
 }

--- a/MoolahTests/Shared/InstrumentConversionServiceStockTests.swift
+++ b/MoolahTests/Shared/InstrumentConversionServiceStockTests.swift
@@ -34,12 +34,16 @@ struct InstrumentConversionServiceStockTests {
 
   @Test
   func stockToListingCurrencySameFiat() async throws {
-    // BHP listed in AUD, converting to AUD — just stock price, no FX
+    // BHP listed in AUD, converting to AUD — just stock price, no FX.
+    // Cache caps "today" requests to yesterday — see
+    // `Shared/PriceCacheCap.swift`. Seed both keys.
     let today = Date()
     let dateKey = dateString(today)
+    let yKey = dateString(today.addingTimeInterval(-86400))
     let service = try makeService(
       stockPrices: [
-        "BHP.AX": StockPriceResponse(instrument: .AUD, prices: [dateKey: dec("42.30")])
+        "BHP.AX": StockPriceResponse(
+          instrument: .AUD, prices: [dateKey: dec("42.30"), yKey: dec("42.30")])
       ]
     )
 
@@ -53,11 +57,16 @@ struct InstrumentConversionServiceStockTests {
     // AAPL listed in USD, converting to AUD — stock price * FX rate
     let today = Date()
     let dateKey = dateString(today)
+    let yKey = dateString(today.addingTimeInterval(-86400))
     let service = try makeService(
       stockPrices: [
-        "AAPL": StockPriceResponse(instrument: .USD, prices: [dateKey: dec("185.50")])
+        "AAPL": StockPriceResponse(
+          instrument: .USD, prices: [dateKey: dec("185.50"), yKey: dec("185.50")])
       ],
-      exchangeRates: [dateKey: ["AUD": dec("1.55")]]  // 1 USD = 1.55 AUD
+      exchangeRates: [
+        dateKey: ["AUD": dec("1.55")],
+        yKey: ["AUD": dec("1.55")],
+      ]
     )
 
     let result = try await service.convert(Decimal(10), from: aapl, to: aud, on: today)
@@ -103,9 +112,11 @@ struct InstrumentConversionServiceStockTests {
     // Simulate a USD-listed stock converting to USD directly (no FX required).
     let today = Date()
     let dateKey = dateString(today)
+    let yKey = dateString(today.addingTimeInterval(-86400))
     let service = try makeService(
       stockPrices: [
-        "AAPL": StockPriceResponse(instrument: .USD, prices: [dateKey: dec("185.50")])
+        "AAPL": StockPriceResponse(
+          instrument: .USD, prices: [dateKey: dec("185.50"), yKey: dec("185.50")])
       ]
     )
 

--- a/MoolahTests/Shared/StockPriceServiceTests.swift
+++ b/MoolahTests/Shared/StockPriceServiceTests.swift
@@ -10,11 +10,12 @@ struct StockPriceServiceTests {
   private func makeService(
     responses: [String: StockPriceResponse] = [:],
     shouldFail: Bool = false,
-    database: DatabaseQueue? = nil
+    database: DatabaseQueue? = nil,
+    now: @Sendable @escaping () -> Date = { Date() }
   ) throws -> StockPriceService {
     let client = FixedStockPriceClient(responses: responses, shouldFail: shouldFail)
     let resolved = try database ?? ProfileDatabase.openInMemory()
-    return StockPriceService(client: client, database: resolved)
+    return StockPriceService(client: client, database: resolved, now: now)
   }
 
   private func date(_ string: String) -> Date {
@@ -185,6 +186,88 @@ struct StockPriceServiceTests {
   // SQL persistence tests (round-trip + rollback + delta-write contracts)
   // live in `StockPriceServicePersistenceTests` so this suite stays under
   // SwiftLint's `type_body_length` cap.
+
+  // MARK: - Cap-at-yesterday rule
+
+  @Test
+  func todayRequestRoutesToYesterday() async throws {
+    // Pin "today" at 2026-04-12 so "yesterday" is 2026-04-11. bhpResponse
+    // has 2026-04-11 = 38.60. The request for "today" should fall back.
+    let frozen = self.date("2026-04-12")
+    let service = try makeService(
+      responses: ["BHP.AX": bhpResponse()], now: { frozen })
+    let price = try await service.price(ticker: "BHP.AX", on: frozen)
+    #expect(price == dec("38.60"))
+  }
+
+  @Test
+  func todayHitsCacheWithoutNetworkFetch() async throws {
+    // Seed yesterday via a writeable client, then re-issue the same query
+    // with a failing client — if the cap routes "today" to "yesterday" and
+    // yesterday is in the cache, no fetch is needed.
+    let database = try ProfileDatabase.openInMemory()
+    let frozen = self.date("2026-04-12")
+    let writer = try makeService(
+      responses: ["BHP.AX": bhpResponse()],
+      database: database,
+      now: { frozen })
+    _ = try await writer.price(ticker: "BHP.AX", on: self.date("2026-04-11"))
+
+    let reader = try makeService(
+      shouldFail: true,
+      database: database,
+      now: { frozen })
+    let price = try await reader.price(ticker: "BHP.AX", on: frozen)
+    #expect(price == dec("38.60"))
+  }
+
+  @Test
+  func forwardExtensionOverwritesStaleLatest() async throws {
+    // First service caches a value for 2026-04-11; second returns a
+    // *different* value for the same date. Asking for a later date should
+    // trigger a forward extension that overlaps 2026-04-11 and overwrites.
+    let database = try ProfileDatabase.openInMemory()
+    let initial = StockPriceResponse(
+      instrument: .AUD,
+      prices: ["2026-04-11": dec("38.60")])
+    let revised = StockPriceResponse(
+      instrument: .AUD,
+      prices: [
+        "2026-04-11": dec("38.99"),
+        "2026-04-13": dec("39.10"),
+        "2026-04-14": dec("39.20"),
+      ])
+
+    let frozenInitial = self.date("2026-04-12")
+    let pre = try makeService(
+      responses: ["BHP.AX": initial],
+      database: database,
+      now: { frozenInitial })
+    _ = try await pre.price(ticker: "BHP.AX", on: self.date("2026-04-11"))
+
+    let frozenLater = self.date("2026-04-15")
+    let post = try makeService(
+      responses: ["BHP.AX": revised],
+      database: database,
+      now: { frozenLater })
+    _ = try await post.price(ticker: "BHP.AX", on: self.date("2026-04-14"))
+
+    let revisedAt11 = try await post.price(ticker: "BHP.AX", on: self.date("2026-04-11"))
+    #expect(revisedAt11 == dec("38.99"))
+  }
+
+  @Test
+  func rangeEndingTodayCarriesForwardYesterday() async throws {
+    let frozen = self.date("2026-04-12")
+    let service = try makeService(
+      responses: ["BHP.AX": bhpResponse()],
+      now: { frozen })
+    let results = try await service.prices(
+      ticker: "BHP.AX",
+      in: self.date("2026-04-10")...frozen)
+    #expect(results.count == 3)
+    #expect(results.last?.price == dec("38.60"))
+  }
 
   // MARK: - Multiple tickers
 

--- a/Shared/CryptoPriceService+Live.swift
+++ b/Shared/CryptoPriceService+Live.swift
@@ -1,0 +1,39 @@
+// Shared/CryptoPriceService+Live.swift
+
+import Foundation
+
+// MARK: - CryptoPriceService live (current) prices
+
+// `currentPrices` lives in its own file so the main actor body stays
+// under SwiftLint's `type_body_length` and `file_length` thresholds.
+// This is the live / spot endpoint — distinct from the historical daily
+// bars handled in `CryptoPriceService.swift`'s `price(for:mapping:on:)`
+// path. The result is intentionally not persisted via the cap-at-yesterday
+// cache; `prefetchLatest` writes a single best-effort yesterday-tagged row
+// and the next forward `dailyPrices` extension overwrites it.
+
+extension CryptoPriceService {
+  func currentPrices(for mappings: [CryptoProviderMapping]) async throws -> [String: Decimal] {
+    var result: [String: Decimal] = [:]
+    for client in clients {
+      do {
+        let prices = try await client.currentPrices(for: mappings)
+        for (id, price) in prices where result[id] == nil {
+          result[id] = price
+        }
+        if result.count == mappings.count { break }
+      } catch {
+        // Best-effort: try the next client. Log so a silent total miss
+        // (all clients failed → empty dict) is diagnosable.
+        logger.debug(
+          "currentPrices: client \(type(of: client), privacy: .public) failed: \(error.localizedDescription, privacy: .public)"
+        )
+        continue
+      }
+    }
+    if result.isEmpty && !mappings.isEmpty {
+      logger.warning("currentPrices: all clients failed; returning empty result")
+    }
+    return result
+  }
+}

--- a/Shared/CryptoPriceService.swift
+++ b/Shared/CryptoPriceService.swift
@@ -5,7 +5,9 @@ import GRDB
 import OSLog
 
 actor CryptoPriceService {
-  private let clients: [CryptoPriceClient]
+  // `clients` is accessed by the live-prices extension in
+  // `CryptoPriceService+Live.swift` so it must be at least internal.
+  let clients: [CryptoPriceClient]
 
   // MARK: - Cross-extension internals
   // `caches`, `hydratedTokenIds`, `database`, and `logger` are accessed
@@ -28,15 +30,19 @@ actor CryptoPriceService {
 
   private let dateFormatter: ISO8601DateFormatter
   private let resolutionClient: TokenResolutionClient
+  /// Injected clock so tests can pin "today" deterministically.
+  private let now: @Sendable () -> Date
 
   init(
     clients: [CryptoPriceClient],
     database: any DatabaseWriter,
-    resolutionClient: (any TokenResolutionClient)? = nil
+    resolutionClient: (any TokenResolutionClient)? = nil,
+    now: @Sendable @escaping () -> Date = { Date() }
   ) {
     self.clients = clients
     self.database = database
     self.resolutionClient = resolutionClient ?? NoOpTokenResolutionClient()
+    self.now = now
     self.dateFormatter = ISO8601DateFormatter()
     self.dateFormatter.formatOptions = [.withFullDate]
   }
@@ -102,6 +108,7 @@ actor CryptoPriceService {
     mapping: CryptoProviderMapping,
     on date: Date
   ) async throws -> Decimal {
+    let date = cappedToYesterday(date, now: now)
     let tokenId = instrument.id
     let dateString = dateFormatter.string(from: date)
 
@@ -182,7 +189,9 @@ actor CryptoPriceService {
   /// `StockPriceService.fetchToCoverDate` and `ExchangeRateService`:
   ///
   /// - **Cache exists, requested date past `latestDate`:** forward
-  ///   extension from the day after `latestDate` to the requested date.
+  ///   extension *including* `latestDate` so a stale value (e.g. an
+  ///   intraday tick persisted by an older build) is overwritten by
+  ///   the next finalised close.
   /// - **Cache exists, requested date before `earliestDate`:** backward
   ///   extension from the requested date to the day before
   ///   `earliestDate`.
@@ -193,14 +202,16 @@ actor CryptoPriceService {
   /// The in-range case is unreachable here — `price(...)` short-circuits
   /// before calling this — but a defensive single-day window is returned
   /// just in case.
+  ///
+  /// `requestedDate` is already capped at yesterday by `price(...)`.
   private func extensionWindow(
     for tokenId: String, requestedDate: Date, dateString: String
   ) -> ClosedRange<Date> {
     let calendar = Calendar(identifier: .gregorian)
     if let cache = caches[tokenId] {
       if dateString > cache.latestDate,
-        let latestDate = dateFormatter.date(from: cache.latestDate),
-        let fetchStart = calendar.date(byAdding: .day, value: 1, to: latestDate)
+        let fetchStart = dateFormatter.date(from: cache.latestDate),
+        fetchStart <= requestedDate
       {
         return fetchStart...requestedDate
       }
@@ -229,8 +240,12 @@ actor CryptoPriceService {
       try await loadCache(tokenId: tokenId)
     }
 
+    // Cap the *fetch* upper bound at yesterday — same rationale as
+    // `price(for:mapping:on:)`. The result series below still walks the
+    // caller-supplied range; today's slot fills via `lastKnownPrice`.
+    let fetchUpperBound = cappedToYesterday(range.upperBound, now: now)
     let rangeStart = dateFormatter.string(from: range.lowerBound)
-    let rangeEnd = dateFormatter.string(from: range.upperBound)
+    let fetchEndString = dateFormatter.string(from: fetchUpperBound)
 
     let gregorian = Calendar(identifier: .gregorian)
     if let cache = caches[tokenId] {
@@ -241,16 +256,18 @@ actor CryptoPriceService {
         try await fetchRange(
           instrument: instrument, mapping: mapping, from: range.lowerBound, to: fetchEnd)
       }
-      if rangeEnd > cache.latestDate,
-        let latestDate = dateFormatter.date(from: cache.latestDate),
-        let fetchStart = gregorian.date(byAdding: .day, value: 1, to: latestDate)
+      // Forward extension overlaps the existing latest entry — same
+      // rationale as `extensionWindow`.
+      if fetchEndString > cache.latestDate,
+        let fetchStart = dateFormatter.date(from: cache.latestDate),
+        fetchStart <= fetchUpperBound
       {
         try await fetchRange(
-          instrument: instrument, mapping: mapping, from: fetchStart, to: range.upperBound)
+          instrument: instrument, mapping: mapping, from: fetchStart, to: fetchUpperBound)
       }
-    } else {
+    } else if range.lowerBound <= fetchUpperBound {
       try await fetchRange(
-        instrument: instrument, mapping: mapping, from: range.lowerBound, to: range.upperBound)
+        instrument: instrument, mapping: mapping, from: range.lowerBound, to: fetchUpperBound)
     }
 
     let dates = generateDateSeries(in: range)
@@ -270,31 +287,9 @@ actor CryptoPriceService {
     return results
   }
 
-  // MARK: - Batch current prices
-
-  func currentPrices(for mappings: [CryptoProviderMapping]) async throws -> [String: Decimal] {
-    var result: [String: Decimal] = [:]
-    for client in clients {
-      do {
-        let prices = try await client.currentPrices(for: mappings)
-        for (id, price) in prices where result[id] == nil {
-          result[id] = price
-        }
-        if result.count == mappings.count { break }
-      } catch {
-        // Best-effort: try the next client. Log so a silent total miss
-        // (all clients failed → empty dict) is diagnosable.
-        logger.debug(
-          "currentPrices: client \(type(of: client), privacy: .public) failed: \(error.localizedDescription, privacy: .public)"
-        )
-        continue
-      }
-    }
-    if result.isEmpty && !mappings.isEmpty {
-      logger.warning("currentPrices: all clients failed; returning empty result")
-    }
-    return result
-  }
+  // `currentPrices(for:)` (the live / spot endpoint) lives in
+  // `CryptoPriceService+Live.swift` so the main actor body stays under
+  // SwiftLint's `type_body_length` and `file_length` thresholds.
 
   // MARK: - Prefetch
 
@@ -309,7 +304,10 @@ actor CryptoPriceService {
       )
       return
     }
-    let dateString = dateFormatter.string(from: Date())
+    // Tag the live tick as yesterday-UTC; see `Shared/PriceCacheCap.swift`.
+    // The next forward `dailyPrices` extension overwrites this best-effort
+    // value with the finalised close.
+    let dateString = dateFormatter.string(from: cappedToYesterday(now(), now: now))
     for (tokenId, price) in prices {
       let registration = registrations.first { $0.id == tokenId }
       let symbol = registration?.instrument.ticker ?? registration?.instrument.name ?? ""
@@ -385,16 +383,8 @@ extension CryptoPriceService {
     if let error = lastError { throw error }
   }
 
-  // `mergeReturningDelta` lives in `CryptoPriceService+Merge.swift` so
-  // the main actor body stays under SwiftLint's `type_body_length` and
+  // `mergeReturningDelta` lives in `CryptoPriceService+Merge.swift` and
+  // `NoOpTokenResolutionClient` lives in its own sibling file so the
+  // main actor body stays under SwiftLint's `type_body_length` and
   // `file_length` thresholds.
-}
-
-/// Fallback when no resolution client is configured. Returns empty results.
-private struct NoOpTokenResolutionClient: TokenResolutionClient {
-  func resolve(
-    chainId: Int, contractAddress: String?, symbol: String?, isNative: Bool
-  ) async throws -> TokenResolutionResult {
-    TokenResolutionResult()
-  }
 }

--- a/Shared/ExchangeRateService+Prefetch.swift
+++ b/Shared/ExchangeRateService+Prefetch.swift
@@ -1,0 +1,59 @@
+// Shared/ExchangeRateService+Prefetch.swift
+
+import Foundation
+import GRDB
+
+// MARK: - ExchangeRateService prefetch
+
+// `prefetchLatest` lives in its own file so the main actor body stays
+// under SwiftLint's `type_body_length` and `file_length` thresholds.
+// Best-effort warm-up of the latest rates for a base instrument; called
+// on app start / profile open. Targets yesterday-UTC rather than today
+// (see `Shared/PriceCacheCap.swift`) and overlaps the existing latest
+// cached date by one day so a stale value gets re-validated.
+
+extension ExchangeRateService {
+  func prefetchLatest(base: Instrument) async {
+    let code = base.id
+
+    if !hydratedBases.contains(code) {
+      do {
+        try await loadCache(base: code)
+      } catch {
+        logger.warning(
+          "prefetchLatest: loadCache failed for base \(code, privacy: .public): \(error.localizedDescription, privacy: .public)"
+        )
+      }
+    }
+
+    let calendar = Calendar(identifier: .gregorian)
+    let target = cappedToYesterday(now(), now: now)
+    let targetString = dateFormatter.string(from: target)
+
+    if let cache = caches[code], cache.latestDate >= targetString {
+      return  // Already up to date
+    }
+
+    let fetchFrom: Date
+    if let cache = caches[code],
+      let latestDate = dateFormatter.date(from: cache.latestDate),
+      latestDate <= target
+    {
+      fetchFrom = latestDate
+    } else if let thirtyDaysAgo = calendar.date(byAdding: .day, value: -30, to: target) {
+      fetchFrom = thirtyDaysAgo
+    } else {
+      fetchFrom = target
+    }
+
+    do {
+      try await fetchAndMerge(base: code, from: fetchFrom, to: target)
+    } catch {
+      // Prefetch is best-effort — log so disk-write failures (which would
+      // otherwise be conflated with expected network errors) are observable.
+      logger.warning(
+        "prefetchLatest: fetchAndMerge failed for base \(code, privacy: .public): \(error.localizedDescription, privacy: .public)"
+      )
+    }
+  }
+}

--- a/Shared/ExchangeRateService.swift
+++ b/Shared/ExchangeRateService.swift
@@ -24,11 +24,21 @@ actor ExchangeRateService {
   let logger = Logger(
     subsystem: "com.moolah.app", category: "ExchangeRateService")
 
-  private let dateFormatter: ISO8601DateFormatter
+  // `dateFormatter` and `now` are accessed by `prefetchLatest` in
+  // `ExchangeRateService+Prefetch.swift`, so they must be at least
+  // internal.
+  let dateFormatter: ISO8601DateFormatter
+  /// Injected clock so tests can pin "today" deterministically.
+  let now: @Sendable () -> Date
 
-  init(client: ExchangeRateClient, database: any DatabaseWriter) {
+  init(
+    client: ExchangeRateClient,
+    database: any DatabaseWriter,
+    now: @Sendable @escaping () -> Date = { Date() }
+  ) {
     self.client = client
     self.database = database
+    self.now = now
     self.dateFormatter = ISO8601DateFormatter()
     self.dateFormatter.formatOptions = [.withFullDate]
   }
@@ -36,6 +46,7 @@ actor ExchangeRateService {
   func rate(from: Instrument, to: Instrument, on date: Date) async throws -> Decimal {
     if from.id == to.id { return Decimal(1) }
 
+    let date = cappedDate(date)
     let dateString = dateFormatter.string(from: date)
     let base = from.id
     let quote = to.id
@@ -93,16 +104,20 @@ actor ExchangeRateService {
   /// Extends the cached range toward `date`, fetching only the gap between
   /// the requested date and the existing `[earliestDate, latestDate]`
   /// window. `rate()` short-circuits in-range requests before calling
-  /// this, so we only ever extend the boundary — never refetch dates we
-  /// already cover. Errors are swallowed; callers fall back to cached
-  /// rates when the fetch fails.
+  /// this, so we only ever extend the boundary. The forward branch
+  /// overlaps the existing latest entry by one day so a stale value
+  /// (e.g. an intraday partial bar persisted by an older build) is
+  /// overwritten by the next finalised close — `mergeReturningDelta`
+  /// is a no-op when the re-fetched value matches what's cached.
+  /// Errors are swallowed; callers fall back to cached rates when the
+  /// fetch fails. `date` is already capped at yesterday by `rate()`.
   private func fetchToCoverDate(base: String, date: Date, dateString: String) async {
     let calendar = Calendar(identifier: .gregorian)
     do {
       if let cache = caches[base] {
         if dateString > cache.latestDate,
-          let latestDate = dateFormatter.date(from: cache.latestDate),
-          let fetchStart = calendar.date(byAdding: .day, value: 1, to: latestDate)
+          let fetchStart = dateFormatter.date(from: cache.latestDate),
+          fetchStart <= date
         {
           try await fetchInChunks(base: base, from: fetchStart, to: date)
         } else if dateString < cache.earliestDate,
@@ -126,6 +141,11 @@ actor ExchangeRateService {
     }
   }
 
+  /// See `Shared/PriceCacheCap.swift` for the rationale.
+  private func cappedDate(_ date: Date) -> Date {
+    cappedToYesterday(date, now: now)
+  }
+
   func rates(
     from: Instrument, to: Instrument, in range: ClosedRange<Date>
   ) async throws -> [(date: Date, rate: Decimal)] {
@@ -141,9 +161,12 @@ actor ExchangeRateService {
       try await loadCache(base: base)
     }
 
-    // Determine what we need to fetch
+    // Cap the *fetch* upper bound at yesterday — same rationale as
+    // `rate()`. The result series below still walks the caller-supplied
+    // range; today's slot fills via `lastKnownRate` carry-forward.
+    let fetchUpperBound = cappedDate(range.upperBound)
     let rangeStart = dateFormatter.string(from: range.lowerBound)
-    let rangeEnd = dateFormatter.string(from: range.upperBound)
+    let fetchEndString = dateFormatter.string(from: fetchUpperBound)
 
     let gregorian = Calendar(identifier: .gregorian)
     if let cache = caches[base] {
@@ -153,14 +176,16 @@ actor ExchangeRateService {
       {
         try await fetchInChunks(base: base, from: range.lowerBound, to: fetchEnd)
       }
-      if rangeEnd > cache.latestDate,
-        let latestDate = dateFormatter.date(from: cache.latestDate),
-        let fetchStart = gregorian.date(byAdding: .day, value: 1, to: latestDate)
+      // Forward extension overlaps the existing latest entry — same
+      // rationale as `fetchToCoverDate`.
+      if fetchEndString > cache.latestDate,
+        let fetchStart = dateFormatter.date(from: cache.latestDate),
+        fetchStart <= fetchUpperBound
       {
-        try await fetchInChunks(base: base, from: fetchStart, to: range.upperBound)
+        try await fetchInChunks(base: base, from: fetchStart, to: fetchUpperBound)
       }
-    } else {
-      try await fetchInChunks(base: base, from: range.lowerBound, to: range.upperBound)
+    } else if range.lowerBound <= fetchUpperBound {
+      try await fetchInChunks(base: base, from: range.lowerBound, to: fetchUpperBound)
     }
 
     // Build result series
@@ -191,49 +216,9 @@ actor ExchangeRateService {
     return InstrumentAmount(quantity: converted, instrument: instrument)
   }
 
-  func prefetchLatest(base: Instrument) async {
-    let code = base.id
-
-    if !hydratedBases.contains(code) {
-      do {
-        try await loadCache(base: code)
-      } catch {
-        logger.warning(
-          "prefetchLatest: loadCache failed for base \(code, privacy: .public): \(error.localizedDescription, privacy: .public)"
-        )
-      }
-    }
-
-    let calendar = Calendar(identifier: .gregorian)
-    let today = Date()
-    let todayString = dateFormatter.string(from: today)
-
-    if let cache = caches[code], cache.latestDate >= todayString {
-      return  // Already up to date
-    }
-
-    let fetchFrom: Date
-    if let cache = caches[code],
-      let latestDate = dateFormatter.date(from: cache.latestDate),
-      let next = calendar.date(byAdding: .day, value: 1, to: latestDate)
-    {
-      fetchFrom = next
-    } else if let thirtyDaysAgo = calendar.date(byAdding: .day, value: -30, to: today) {
-      fetchFrom = thirtyDaysAgo
-    } else {
-      fetchFrom = today
-    }
-
-    do {
-      try await fetchAndMerge(base: code, from: fetchFrom, to: today)
-    } catch {
-      // Prefetch is best-effort — log so disk-write failures (which would
-      // otherwise be conflated with expected network errors) are observable.
-      logger.warning(
-        "prefetchLatest: fetchAndMerge failed for base \(code, privacy: .public): \(error.localizedDescription, privacy: .public)"
-      )
-    }
-  }
+  // `prefetchLatest(base:)` lives in `ExchangeRateService+Prefetch.swift`
+  // so the main actor body stays under SwiftLint's `type_body_length`
+  // and `file_length` thresholds.
 
   // MARK: - Private helpers
 
@@ -276,7 +261,7 @@ actor ExchangeRateService {
     }
   }
 
-  private func fetchAndMerge(base: String, from: Date, to: Date) async throws {
+  func fetchAndMerge(base: String, from: Date, to: Date) async throws {
     let fetched = try await client.fetchRates(base: base, from: from, to: to)
     // Frankfurter (and the chunked extension call sites in this service)
     // legitimately return an empty payload for weekend / holiday / future

--- a/Shared/NoOpTokenResolutionClient.swift
+++ b/Shared/NoOpTokenResolutionClient.swift
@@ -1,0 +1,15 @@
+// Shared/NoOpTokenResolutionClient.swift
+
+import Foundation
+
+/// Fallback `TokenResolutionClient` used by `CryptoPriceService` when no
+/// resolution client is configured. Returns empty results so the service
+/// can still resolve registrations for tokens that don't need a
+/// provider-side mapping (e.g. user-entered free-text symbols).
+struct NoOpTokenResolutionClient: TokenResolutionClient {
+  func resolve(
+    chainId: Int, contractAddress: String?, symbol: String?, isNative: Bool
+  ) async throws -> TokenResolutionResult {
+    TokenResolutionResult()
+  }
+}

--- a/Shared/PriceCacheCap.swift
+++ b/Shared/PriceCacheCap.swift
@@ -1,0 +1,32 @@
+// Shared/PriceCacheCap.swift
+
+import Foundation
+
+/// Clamps `date` to one UTC calendar day before `now()`.
+///
+/// All three price-cache services (FX rates, stock prices, crypto prices)
+/// route same-day-as-now requests to the previous day so the cache only
+/// ever stores finalised closes. Yahoo's `chart?interval=1d` endpoint
+/// returns a partial bar for the still-running session whose `close` /
+/// `adjclose` reflects the latest tick at the moment of the call;
+/// persisting that as today's "close" then freezing it (cache hits never
+/// re-fetch) was reproducing as VGS.AX showing a stale intraday print
+/// even after the session settled.
+///
+/// We never need a live price — the analysis panel and reports happily
+/// use yesterday's close, and avoiding the same-day fetch keeps a fresh
+/// cache run from immediately re-poisoning itself.
+///
+/// `now` is a closure so tests can pin the clock; production passes
+/// `Date.init`. The fallback `return date` is unreachable in practice
+/// (`Calendar.date(byAdding:value:to:)` only fails for nonsensical
+/// inputs) but keeps the helper non-throwing.
+func cappedToYesterday(_ date: Date, now: () -> Date) -> Date {
+  var utc = Calendar(identifier: .gregorian)
+  utc.timeZone = TimeZone(identifier: "UTC") ?? .current
+  let startOfToday = utc.startOfDay(for: now())
+  guard let yesterday = utc.date(byAdding: .day, value: -1, to: startOfToday) else {
+    return date
+  }
+  return min(date, yesterday)
+}

--- a/Shared/StockPriceService.swift
+++ b/Shared/StockPriceService.swift
@@ -17,12 +17,19 @@ actor StockPriceService {
   private var hydratedTickers: Set<String> = []
   private let database: any DatabaseWriter
   private let dateFormatter: ISO8601DateFormatter
+  /// Injected clock so tests can pin "today" deterministically.
+  private let now: @Sendable () -> Date
   private let logger = Logger(
     subsystem: "com.moolah.app", category: "StockPriceService")
 
-  init(client: StockPriceClient, database: any DatabaseWriter) {
+  init(
+    client: StockPriceClient,
+    database: any DatabaseWriter,
+    now: @Sendable @escaping () -> Date = { Date() }
+  ) {
     self.client = client
     self.database = database
+    self.now = now
     self.dateFormatter = ISO8601DateFormatter()
     self.dateFormatter.formatOptions = [.withFullDate]
   }
@@ -30,6 +37,7 @@ actor StockPriceService {
   // MARK: - Public API
 
   func price(ticker: String, on date: Date) async throws -> Decimal {
+    let date = cappedDate(date)
     let dateString = dateFormatter.string(from: date)
 
     // Check in-memory cache
@@ -77,9 +85,13 @@ actor StockPriceService {
       try await loadCache(ticker: ticker)
     }
 
-    // Determine what we need to fetch
+    // Cap the *fetch* upper bound at yesterday — never ask Yahoo for
+    // today's still-running bar. The result series below still walks the
+    // caller-supplied range; today's slot fills via `lastKnownPrice`
+    // carry-forward (which lands on yesterday's close).
+    let fetchUpperBound = cappedDate(range.upperBound)
     let rangeStart = dateFormatter.string(from: range.lowerBound)
-    let rangeEnd = dateFormatter.string(from: range.upperBound)
+    let fetchEndString = dateFormatter.string(from: fetchUpperBound)
 
     let gregorian = Calendar(identifier: .gregorian)
     if let cache = caches[ticker] {
@@ -89,14 +101,17 @@ actor StockPriceService {
       {
         try await fetchInChunks(ticker: ticker, from: range.lowerBound, to: fetchEnd)
       }
-      if rangeEnd > cache.latestDate,
-        let latestDate = dateFormatter.date(from: cache.latestDate),
-        let fetchStart = gregorian.date(byAdding: .day, value: 1, to: latestDate)
+      // Forward extension overlaps the existing latest entry by one day so
+      // a stale value (e.g. an intraday partial bar persisted by an older
+      // build) is overwritten by the next finalised close.
+      if fetchEndString > cache.latestDate,
+        let fetchStart = dateFormatter.date(from: cache.latestDate),
+        fetchStart <= fetchUpperBound
       {
-        try await fetchInChunks(ticker: ticker, from: fetchStart, to: range.upperBound)
+        try await fetchInChunks(ticker: ticker, from: fetchStart, to: fetchUpperBound)
       }
-    } else {
-      try await fetchInChunks(ticker: ticker, from: range.lowerBound, to: range.upperBound)
+    } else if range.lowerBound <= fetchUpperBound {
+      try await fetchInChunks(ticker: ticker, from: range.lowerBound, to: fetchUpperBound)
     }
 
     // Build result series
@@ -137,15 +152,22 @@ actor StockPriceService {
   /// via `fallbackPrice`. Warm cache extends only the gap between the cache
   /// edge and the requested date.
   ///
+  /// Forward extensions overlap the existing latest entry by one day so a
+  /// stale value (an intraday partial bar persisted by an older build) is
+  /// overwritten by the next finalised close. `mergeReturningDelta` is a
+  /// no-op when the re-fetched value matches what's already cached.
+  ///
   /// Unlike `ExchangeRateService.fetchToCoverDate`, this method propagates
   /// fetch errors so `price(ticker:on:)` can surface network failures when
   /// the fallback cache is also empty.
+  ///
+  /// `date` is already capped at yesterday by `price(ticker:on:)`.
   private func fetchToCoverDate(ticker: String, date: Date, dateString: String) async throws {
     let gregorian = Calendar(identifier: .gregorian)
     if let cache = caches[ticker] {
       if dateString > cache.latestDate,
-        let latestDate = dateFormatter.date(from: cache.latestDate),
-        let fetchStart = gregorian.date(byAdding: .day, value: 1, to: latestDate)
+        let fetchStart = dateFormatter.date(from: cache.latestDate),
+        fetchStart <= date
       {
         try await fetchInChunks(ticker: ticker, from: fetchStart, to: date)
       } else if dateString < cache.earliestDate,
@@ -159,6 +181,12 @@ actor StockPriceService {
     } else {
       try await fetchAndMerge(ticker: ticker, from: date, to: date)
     }
+  }
+
+  /// See `Shared/PriceCacheCap.swift` for the rationale on capping
+  /// requests at yesterday-UTC.
+  private func cappedDate(_ date: Date) -> Date {
+    cappedToYesterday(date, now: now)
   }
 
   private func lookupPrice(ticker: String, dateString: String) -> Decimal? {
@@ -317,10 +345,13 @@ actor StockPriceService {
   /// Each delta row is written `INSERT OR REPLACE` so a re-fetched date
   /// updates in place; the meta row is `INSERT OR REPLACE`d via
   /// `StockTickerMetaRecord`'s `.replace` conflict policy. There is no
-  /// `deleteAll` — historic prices never change, and rewriting the whole
-  /// ticker on every fetch saturates the GRDB queue. The rollback
-  /// contract still holds because every statement runs inside one
-  /// `database.write` closure and any failure rolls them back together.
+  /// `deleteAll` — once a date is finalised its close is stable, and the
+  /// forward-extension overlap (see `fetchToCoverDate`) re-fetches the
+  /// latest cached date on every extension so a stale intraday tick
+  /// persisted by an older build gets overwritten the next time the
+  /// range moves forward. The rollback contract still holds because
+  /// every statement runs inside one `database.write` closure and any
+  /// failure rolls them back together.
   ///
   /// The price denomination in `StockPriceCache` is the API-reported
   /// fiat currency the ticker trades in (see


### PR DESCRIPTION
## Summary

- Caps every FX/stock/crypto price request at one UTC day before now and overlaps the existing `cache.latestDate` on every forward extension. Together this stops the cache from persisting Yahoo's intraday partial bar as today's "close" and self-heals any row that was already poisoned. Reproduced today as VGS.AX showing 149.82 (an intraday tick) instead of the 149.91 close — VGS isn't a flaky outlier, it's the entire shape of the bug.
- One-shot v7 `DELETE FROM` of all six rate-cache tables (`exchange_rate`, `exchange_rate_meta`, `stock_price`, `stock_ticker_meta`, `crypto_price`, `crypto_token_meta`) to clear pre-fix poisoned rows. Retention policy in `guides/DATABASE_SCHEMA_GUIDE.md` §9 unchanged.
- Existing tests that seeded only `Date()` and asked for the same date now seed both today *and* yesterday — the cap routes today's lookup to yesterday's row.

Why the cap: Yahoo's `chart?interval=1d` response includes a partial bar for the in-progress day whose `close` is the latest tick. Persisting that and never re-fetching froze the wrong number. We don't need live prices — analysis panel and reports use yesterday's finalised close.

Why overlap-by-one: the cap stops *new* poisoning, but it doesn't repair rows already on disk. Overlapping the forward fetch by one day means the next `dailyPrices` call overwrites the stale latest with the finalised close. `mergeReturningDelta` is a no-op when the value matches, so the cost is one extra date in the wire request.

Affected services: `StockPriceService`, `ExchangeRateService` (incl. `prefetchLatest`), `CryptoPriceService` (incl. `prefetchLatest`).

Sibling-file splits (`NoOpTokenResolutionClient`, `CryptoPriceService+Live`, `ExchangeRateService+Prefetch`) keep `file_length` / `type_body_length` under the SwiftLint thresholds; clock injection (`now: () -> Date`) is added to all three services so tests can pin "today."

## Test plan

- [x] `just format-check` — clean.
- [x] `just test` (mac + iOS) — green.
- [x] New `PurgeIntradayCachesMigrationTests` seeds rows in all six tables before v7 and asserts they're empty after; second test verifies the schema is intact post-purge.
- [x] New `*ServiceCapTests` per service: today-routes-to-yesterday, no-network-fetch when yesterday cached, forward-extension-overwrites-stale, and prices(in:) ending today carries forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)