### PR TITLE
fix(sidebar): show section totals with semantic colors

### DIFF
--- a/Features/Navigation/SidebarView.swift
+++ b/Features/Navigation/SidebarView.swift
@@ -294,7 +294,7 @@ extension SidebarView {
   private func totalRow(label: String, value: InstrumentAmount?) -> some View {
     LabeledContent(label) {
       if let value {
-        InstrumentAmountView(amount: value, colorOverride: .secondary)
+        InstrumentAmountView(amount: value)
       } else {
         ProgressView()
           .controlSize(.small)


### PR DESCRIPTION
## Summary
- Drop `colorOverride: .secondary` from the sidebar `totalRow` helper so Current Total, Earmarked Total, and Investment Total render with `InstrumentAmountView`'s standard semantic colors (green positive, red negative, primary zero).
- Label text stays `.secondary` via the surrounding `LabeledContent` modifier; only the amount picks up the color.

## Test plan
- [ ] Sidebar: confirm a positive-total section shows the amount in green and a negative-total section in red, while labels remain muted.
- [ ] Sidebar: confirm a zero total renders in primary (matches Available Funds / Net Worth treatment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)