### PR TITLE
fix(transactions): refresh list after CSV drop on account view

### DIFF
--- a/Features/Transactions/Views/TransactionListView.swift
+++ b/Features/Transactions/Views/TransactionListView.swift
@@ -217,7 +217,11 @@ struct TransactionListView: View {
   /// Mirror of `RecentlyAddedView.ingestDroppedURLs` but with a forced
   /// account. Kept here so the view can hand off to `ImportStore`
   /// directly; logic is intentionally minimal (security-scope → read
-  /// bytes → ingest).
+  /// bytes → ingest → reload list).
+  ///
+  /// `ImportStore` writes via `backend.transactions.create(_:)` but does
+  /// not signal `TransactionStore`; without an explicit reload here the
+  /// account's list keeps showing its pre-import snapshot.
   private func ingestDroppedURLs(_ urls: [URL], forcedAccountId: UUID) async {
     for url in urls {
       guard url.pathExtension.lowercased() == "csv" || url.pathExtension.isEmpty else {
@@ -232,6 +236,7 @@ struct TransactionListView: View {
         data: data,
         source: .droppedFile(url: url, forcedAccountId: forcedAccountId))
     }
+    await transactionStore.load(filter: filter)
   }
 
   func createNewTransaction() {


### PR DESCRIPTION
## Summary
- Dropping a CSV onto an account's transaction list ingested the file via `ImportStore` (writing rows through `backend.transactions.create`) but never asked the view's `TransactionStore` to re-fetch, so the list kept showing its pre-import snapshot until the user navigated away or hit Refresh.
- After the ingest loop, call `transactionStore.load(filter:)` — mirroring `RecentlyAddedView.ingestDroppedURLs`, the toolbar Refresh button, and pull-to-refresh.

## Test plan
- [x] `just format-check` clean.
- [x] `just build-mac` succeeds.
- [x] `just test-mac ImportStoreTests` — 4 / 4 pass (covers the `dropping onto a specific account bypasses the matcher` path the fix consumes).
- [ ] Manual: drop a CSV onto an open account view; new rows appear without needing Refresh / re-navigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)