### PR TITLE
fix(crypto): tolerate malformed CryptoCompare coin list entries

### DIFF
--- a/Backends/CryptoCompare/CryptoCompareClient.swift
+++ b/Backends/CryptoCompare/CryptoCompareClient.swift
@@ -119,10 +119,10 @@ struct CryptoCompareClient: CryptoPriceClient, Sendable {
   static func parseCoinListResponse(_ data: Data) throws -> [String: String] {
     let container = try JSONDecoder().decode(CoinListContainer.self, from: data)
     var index: [String: String] = [:]
-    for (_, coin) in container.Data {
-      let addr = coin.SmartContractAddress
+    for coin in container.entries.values {
+      let addr = coin.smartContractAddress
       guard addr != "N/A", !addr.isEmpty else { continue }
-      index[addr.lowercased()] = coin.Symbol
+      index[addr.lowercased()] = coin.symbol
     }
     return index
   }
@@ -131,10 +131,10 @@ struct CryptoCompareClient: CryptoPriceClient, Sendable {
   static func parseNativeSymbols(_ data: Data) throws -> Set<String> {
     let container = try JSONDecoder().decode(CoinListContainer.self, from: data)
     var symbols: Set<String> = []
-    for (_, coin) in container.Data {
-      let addr = coin.SmartContractAddress
+    for coin in container.entries.values {
+      let addr = coin.smartContractAddress
       if addr == "N/A" || addr.isEmpty {
-        symbols.insert(coin.Symbol)
+        symbols.insert(coin.symbol)
       }
     }
     return symbols
@@ -160,14 +160,53 @@ struct CryptoCompareClient: CryptoPriceClient, Sendable {
 
 // MARK: - Response types
 
+/// Decoded per-entry rather than as `[String: CoinListEntry]` because
+/// CryptoCompare's coin list occasionally ships rows with missing fields
+/// (e.g. an `MLS` entry missing `CoinName`). An atomic decode would throw
+/// on the first bad row and break token resolution for every crypto.
 private struct CoinListContainer: Decodable {
-  let Data: [String: CoinListEntry]  // swiftlint:disable:this identifier_name
+  let entries: [String: CoinListEntry]
+
+  init(from decoder: Decoder) throws {
+    let outer = try decoder.container(keyedBy: OuterKey.self)
+    var collected: [String: CoinListEntry] = [:]
+    if let inner = try? outer.nestedContainer(keyedBy: DynamicKey.self, forKey: .data) {
+      for key in inner.allKeys {
+        guard let entry = try? inner.decode(CoinListEntry.self, forKey: key) else { continue }
+        collected[key.stringValue] = entry
+      }
+    }
+    self.entries = collected
+  }
+
+  private enum OuterKey: String, CodingKey {
+    case data = "Data"
+  }
+
+  private struct DynamicKey: CodingKey {
+    let stringValue: String
+    let intValue: Int?
+
+    init?(stringValue: String) {
+      self.stringValue = stringValue
+      self.intValue = nil
+    }
+
+    init?(intValue: Int) {
+      self.stringValue = String(intValue)
+      self.intValue = intValue
+    }
+  }
 }
 
 private struct CoinListEntry: Decodable {
-  let Symbol: String  // swiftlint:disable:this identifier_name
-  let CoinName: String  // swiftlint:disable:this identifier_name
-  let SmartContractAddress: String  // swiftlint:disable:this identifier_name
+  let symbol: String
+  let smartContractAddress: String
+
+  private enum CodingKeys: String, CodingKey {
+    case symbol = "Symbol"
+    case smartContractAddress = "SmartContractAddress"
+  }
 }
 
 private struct HistodayContainer: Decodable {

--- a/MoolahTests/Backends/CryptoCompareClientTests.swift
+++ b/MoolahTests/Backends/CryptoCompareClientTests.swift
@@ -151,6 +151,52 @@ struct CryptoCompareClientTests {
     #expect(nativeSymbols.contains("ETH"))
   }
 
+  // CryptoCompare occasionally ships entries with missing fields (e.g. an MLS
+  // row missing `CoinName`). A single malformed row must not kill the entire
+  // list — token resolution would otherwise fail for every crypto.
+  // See https://github.com/ajsutton/moolah-native/issues/746.
+  @Test
+  func parseCoinListResponse_skipsMalformedEntries() throws {
+    let json = Data(
+      """
+      {
+          "Data": {
+              "MLS": {
+                  "Symbol": "MLS",
+                  "SmartContractAddress": "N/A"
+              },
+              "UNI": {
+                  "Symbol": "UNI",
+                  "CoinName": "Uniswap",
+                  "SmartContractAddress": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984"
+              },
+              "BROKEN": null
+          }
+      }
+      """.utf8)
+
+    let index = try CryptoCompareClient.parseCoinListResponse(json)
+    #expect(index["0x1f9840a85d5af5bf1d1762f925bdaddc4201f984"] == "UNI")
+  }
+
+  @Test
+  func parseNativeSymbols_skipsMalformedEntries() throws {
+    let json = Data(
+      """
+      {
+          "Data": {
+              "MLS": { "Symbol": "MLS", "SmartContractAddress": "N/A" },
+              "BTC": { "Symbol": "BTC", "CoinName": "Bitcoin", "SmartContractAddress": "N/A" },
+              "BROKEN": null
+          }
+      }
+      """.utf8)
+
+    let nativeSymbols = try CryptoCompareClient.parseNativeSymbols(json)
+    #expect(nativeSymbols.contains("BTC"))
+    #expect(nativeSymbols.contains("MLS"))
+  }
+
   // MARK: - Mapping without CryptoCompare symbol
 
   @Test


### PR DESCRIPTION
## Summary

- Fixes [#746](https://github.com/ajsutton/moolah-native/issues/746): adding any crypto token (e.g. OP) failed with "Couldn't add <SYMBOL>." because CryptoCompare currently ships an `MLS` row with no `CoinName`, breaking the atomic decode of the entire coin list.
- Drops the unused `CoinName` field from `CoinListEntry` (neither `parseCoinListResponse` nor `parseNativeSymbols` ever read it) and decodes the `Data` map per-entry so a single malformed row is silently skipped instead of poisoning the whole list.

## Test plan

- [x] New regression test: `parseCoinListResponse_skipsMalformedEntries` (entry missing `CoinName`, plus a `null` entry) — good rows still parse.
- [x] New regression test: `parseNativeSymbols_skipsMalformedEntries` — both the malformed-`MLS` row and the good `BTC` row are returned.
- [x] `just test-mac CryptoCompareClientTests CompositeTokenResolutionClientTests CryptoPriceServiceTests` — 27 tests, 0 failures.
- [ ] Verify in the running app that adding `OP` (and other crypto tokens) succeeds end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)