### PR TITLE
Restrict Edit Account valuation picker to legacy snapshot accounts

### DIFF
--- a/App/UITestSeedHydrator+Upserts.swift
+++ b/App/UITestSeedHydrator+Upserts.swift
@@ -23,6 +23,26 @@ extension UITestSeedHydrator {
     let type: AccountType
     let instrumentId: String
     let position: Int
+    /// Defaults to `.recordedValue` to preserve the historic seed
+    /// behaviour. Pass `.calculatedFromTrades` for accounts seeded for
+    /// the EditAccountView visibility tests.
+    let valuationMode: ValuationMode
+
+    init(
+      id: UUID,
+      name: String,
+      type: AccountType,
+      instrumentId: String,
+      position: Int,
+      valuationMode: ValuationMode = .recordedValue
+    ) {
+      self.id = id
+      self.name = name
+      self.type = type
+      self.instrumentId = instrumentId
+      self.position = position
+      self.valuationMode = valuationMode
+    }
   }
 
   struct TradeSpec {
@@ -95,7 +115,30 @@ extension UITestSeedHydrator {
       position: spec.position,
       isHidden: false,
       encodedSystemFields: nil,
-      valuationMode: ValuationMode.recordedValue.rawValue)
+      valuationMode: spec.valuationMode.rawValue)
+    try row.upsert(database)
+  }
+
+  /// Inserts a single `InvestmentValue` snapshot for an investment
+  /// account. Idempotent — if a row with the same id already exists
+  /// (e.g. on re-hydration), `upsert` overwrites with the same values.
+  /// Synchronous for the same reason as the rest of this file:
+  /// `UITestSeedHydrator.hydrate` runs synchronously during
+  /// `MoolahApp.init`, before any actor or `Task` is in scope.
+  static func upsertInvestmentValue(
+    _ spec: UITestInvestmentValueSeed,
+    in database: Database
+  ) throws {
+    let row = InvestmentValueRow(
+      id: spec.id,
+      recordName: InvestmentValueRow.recordName(for: spec.id),
+      accountId: spec.accountId,
+      date: spec.date,
+      // Cents are quantity × 10^2; `InstrumentAmount.storageValue` is
+      // quantity × 10^8 — so multiply by 10^6 (1_000_000) to convert.
+      value: Int64(spec.cents) * 1_000_000,
+      instrumentId: spec.instrumentId,
+      encodedSystemFields: nil)
     try row.upsert(database)
   }
 

--- a/App/UITestSeedHydrator.swift
+++ b/App/UITestSeedHydrator.swift
@@ -109,6 +109,10 @@ enum UITestSeedHydrator {
 
     try database.write { database in
       try seedTradeBaselineAccounts(instrument: instrument, in: database)
+      // Snapshots depend on accounts existing; transactions don't depend on
+      // either. Order accounts → snapshots → transactions so the
+      // dependency chain reads top-to-bottom.
+      try seedTradeBaselineInvestmentValues(instrument: instrument, in: database)
       try seedTradeBaselineTransactions(instrument: instrument, in: database)
     }
     return profile
@@ -148,6 +152,37 @@ enum UITestSeedHydrator {
         type: .bank,
         instrumentId: usd.id,
         position: 2),
+      in: database)
+
+    // A second investment account in `.calculatedFromTrades` mode with
+    // no `InvestmentValue` snapshots, so `EditAccountValuationPickerTests`
+    // can verify the picker stays hidden for new trade-driven accounts.
+    try upsertAccount(
+      AccountSpec(
+        id: fixtures.tradesBrokerageAccountId,
+        name: fixtures.tradesBrokerageAccountName,
+        type: .investment,
+        instrumentId: instrument.id,
+        position: 3,
+        valuationMode: .calculatedFromTrades),
+      in: database)
+  }
+
+  /// Seed one `InvestmentValue` snapshot on the existing
+  /// `.recordedValue`-mode brokerage account, so
+  /// `EditAccountValuationPickerTests` can verify the picker is shown
+  /// for the legacy-with-data scenario.
+  private static func seedTradeBaselineInvestmentValues(
+    instrument: Instrument, in database: Database
+  ) throws {
+    let fixtures = UITestFixtures.TradeBaseline.self
+    try upsertInvestmentValue(
+      UITestInvestmentValueSeed(
+        id: fixtures.brokerageSnapshotId,
+        accountId: fixtures.brokerageAccountId,
+        date: fixtures.brokerageSnapshotDate,
+        instrumentId: instrument.id,
+        cents: fixtures.brokerageSnapshotCents),
       in: database)
   }
 

--- a/Domain/Models/ValuationMode+DisplayText.swift
+++ b/Domain/Models/ValuationMode+DisplayText.swift
@@ -1,0 +1,28 @@
+extension ValuationMode {
+  /// Short, sentence-fragment description of where this mode's
+  /// balance comes from. Used as a VoiceOver `.accessibilityHint`
+  /// in the Edit Account picker; reusable wherever a brief one-line
+  /// description of the mode's data source is needed.
+  var dataSourceHint: String {
+    switch self {
+    case .recordedValue:
+      return "Balance comes from the value you last recorded"
+    case .calculatedFromTrades:
+      return
+        "Balance is calculated from your trade history and current prices of your holdings"
+    }
+  }
+
+  /// Full-sentence description of the mode's data source, with
+  /// terminating period. Used as the Edit Account picker's section
+  /// footer; reusable as descriptive copy elsewhere.
+  var dataSourceDescription: String {
+    switch self {
+    case .recordedValue:
+      return "The balance comes from the value you last recorded manually."
+    case .calculatedFromTrades:
+      return
+        "The balance is calculated from your trade history and the current prices of your holdings."
+    }
+  }
+}

--- a/Features/Accounts/Views/EditAccountView.swift
+++ b/Features/Accounts/Views/EditAccountView.swift
@@ -18,7 +18,10 @@ private let editAccountLogger = Logger(
   subsystem: "com.moolah.app", category: "EditAccountView")
 
 struct EditAccountView: View {
+  // MARK: - Environment & state
+
   @Environment(\.dismiss) private var dismiss
+  @Environment(ProfileSession.self) private var session
   @State private var name: String
   @State private var type: AccountType
   @State private var currency: Instrument
@@ -26,6 +29,8 @@ struct EditAccountView: View {
   @State private var valuationMode: ValuationMode
   @State private var isSubmitting = false
   @State private var errorMessage: String?
+  @State private var showValuationPicker: Bool
+  @State private var pickerShownDueToProbeFailure = false
   @FocusState private var focusedField: Field?
 
   let account: Account
@@ -34,6 +39,8 @@ struct EditAccountView: View {
   private enum Field: Hashable {
     case name
   }
+
+  // MARK: - Picker visibility
 
   /// Resolves whether the Valuation picker should be shown for an
   /// investment account currently in `.calculatedFromTrades` mode.
@@ -60,6 +67,8 @@ struct EditAccountView: View {
     }
   }
 
+  // MARK: - Init
+
   init(account: Account, accountStore: AccountStore) {
     self.account = account
     self.accountStore = accountStore
@@ -68,7 +77,14 @@ struct EditAccountView: View {
     _currency = State(initialValue: account.instrument)
     _isHidden = State(initialValue: account.isHidden)
     _valuationMode = State(initialValue: account.valuationMode)
+    // Initial visibility: shown for `.recordedValue` accounts so legacy
+    // users see the picker immediately, hidden for `.calculatedFromTrades`
+    // accounts pending the snapshot probe in `.task`. See design §3.3.
+    _showValuationPicker = State(
+      initialValue: account.valuationMode == .recordedValue)
   }
+
+  // MARK: - Body
 
   var body: some View {
     NavigationStack {
@@ -109,7 +125,43 @@ struct EditAccountView: View {
       }
     }
     .animation(.easeInOut(duration: 0.2), value: type)
+    .task(id: account.id) {
+      // Already shown for `.recordedValue` — skip the probe.
+      guard !showValuationPicker else { return }
+      do {
+        let result = try await Self.resolvePickerVisibility(
+          accountId: account.id,
+          snapshotProbe: {
+            try await !session.backend.investments
+              .fetchValues(accountId: account.id, page: 0, pageSize: 1)
+              .values.isEmpty
+          })
+        switch result {
+        case .hidden:
+          showValuationPicker = false
+          pickerShownDueToProbeFailure = false
+        case .shown:
+          showValuationPicker = true
+          pickerShownDueToProbeFailure = false
+        case .shownAfterFailure:
+          showValuationPicker = true
+          pickerShownDueToProbeFailure = true
+        }
+      } catch is CancellationError {
+        // View is being dismissed or `account.id` changed; leave state
+        // unchanged so SwiftUI's teardown is clean.
+      } catch {
+        // Unreachable: `resolvePickerVisibility` converts every
+        // non-cancellation error into `.shownAfterFailure`. Asserting
+        // here turns any future regression into a debug-build crash
+        // rather than silently swallowing the error.
+        assertionFailure(
+          "resolvePickerVisibility threw unexpected error: \(error)")
+      }
+    }
   }
+
+  // MARK: - Sections
 
   private var detailsSection: some View {
     Section {
@@ -131,32 +183,37 @@ struct EditAccountView: View {
     }
   }
 
-  /// Visible only for investment accounts. Lets the user choose between the
-  /// snapshot-driven `recordedValue` mode and the position-driven
-  /// `calculatedFromTrades` mode. Footer text describes the active mode so
-  /// the user can predict what the sidebar balance will read.
+  /// Visible only for investment accounts that already have legacy
+  /// `InvestmentValue` data (or are currently in `.recordedValue` mode).
+  /// New trade-driven accounts never see this section. Footer text
+  /// describes the active mode so the user can predict what the
+  /// sidebar balance will read; on probe failure, an additional info
+  /// note explains that valuation history couldn't be confirmed.
   @ViewBuilder private var valuationSection: some View {
-    if type == .investment {
+    if type == .investment, showValuationPicker {
       Section {
         Picker("Valuation", selection: $valuationMode) {
           Text("Recorded value").tag(ValuationMode.recordedValue)
           Text("Calculated from trades").tag(ValuationMode.calculatedFromTrades)
         }
         .accessibilityIdentifier("editAccount.valuationMode")
-        .accessibilityHint(
-          valuationMode == .recordedValue
-            ? "Balance comes from the value you last recorded"
-            : "Balance is calculated from your trade history and current prices of your holdings"
-        )
+        .accessibilityHint(valuationMode.dataSourceHint)
       } footer: {
-        Text(
-          valuationMode == .recordedValue
-            ? "The balance comes from the value you last recorded manually."
-            : "The balance is calculated from your trade history and the current prices "
-              + "of your holdings.")
+        VStack(alignment: .leading, spacing: 4) {
+          Text(valuationMode.dataSourceDescription)
+          if pickerShownDueToProbeFailure {
+            Label(
+              "Couldn't confirm your valuation history. Reopen the dialog to check again.",
+              systemImage: "info.circle"
+            )
+            .foregroundStyle(.secondary)
+          }
+        }
       }
     }
   }
+
+  // MARK: - Save
 
   private var isValid: Bool {
     !name.trimmingCharacters(in: .whitespaces).isEmpty
@@ -185,30 +242,83 @@ struct EditAccountView: View {
   }
 }
 
-#Preview("Bank account") {
+// MARK: - Previews
+
+@MainActor
+private func makePreviewView(account: Account) -> some View {
   let (backend, _) = PreviewBackend.create()
   let accountStore = AccountStore(
     repository: backend.accounts,
     conversionService: backend.conversionService,
     targetInstrument: .AUD)
-
-  EditAccountView(
-    account: Account(name: "Checking", type: .bank, instrument: .AUD),
-    accountStore: accountStore)
+  // In-memory preview session can't fail in practice: opens an ephemeral
+  // GRDB queue with no disk access. A trap here is acceptable in #Preview.
+  // swiftlint:disable:next force_try
+  let session = try! ProfileSession.preview()
+  return EditAccountView(account: account, accountStore: accountStore)
+    .environment(session)
 }
 
-#Preview("Investment account") {
-  let (backend, _) = PreviewBackend.create()
-  let accountStore = AccountStore(
-    repository: backend.accounts,
-    conversionService: backend.conversionService,
-    targetInstrument: .AUD)
+#Preview("Bank account") {
+  makePreviewView(
+    account: Account(name: "Checking", type: .bank, instrument: .AUD))
+}
 
-  EditAccountView(
+#Preview("Investment account, recordedValue (picker shown)") {
+  makePreviewView(
     account: Account(
-      name: "Brokerage",
+      name: "Legacy brokerage",
       type: .investment,
       instrument: .AUD,
-      valuationMode: .calculatedFromTrades),
-    accountStore: accountStore)
+      valuationMode: .recordedValue))
+}
+
+#Preview("Investment account, calculatedFromTrades (picker hidden)") {
+  makePreviewView(
+    account: Account(
+      name: "New brokerage",
+      type: .investment,
+      instrument: .AUD,
+      valuationMode: .calculatedFromTrades))
+}
+
+/// Wrapper that imitates the section structure used by
+/// `EditAccountView.valuationSection` so the fail-open footer Label
+/// can render in canvas without forcing a preview-only initialiser
+/// onto the production view. Adding a debug-flagged init would widen
+/// the API surface for a concern the production code never has.
+private struct FailOpenValuationPreview: View {
+  @State private var mode: ValuationMode = .calculatedFromTrades
+  var body: some View {
+    Form {
+      Section {
+        Picker("Valuation", selection: $mode) {
+          Text("Recorded value").tag(ValuationMode.recordedValue)
+          Text("Calculated from trades").tag(ValuationMode.calculatedFromTrades)
+        }
+        .accessibilityIdentifier("editAccount.valuationMode")
+        .accessibilityHint(mode.dataSourceHint)
+      } footer: {
+        VStack(alignment: .leading, spacing: 4) {
+          Text(mode.dataSourceDescription)
+          Label(
+            "Couldn't confirm your valuation history. Reopen the dialog to check again.",
+            systemImage: "info.circle"
+          )
+          .foregroundStyle(.secondary)
+        }
+      }
+    }
+    .formStyle(.grouped)
+    .frame(minWidth: 500, minHeight: 280)
+  }
+}
+
+#Preview("Investment account, fail-open footer") {
+  FailOpenValuationPreview()
+}
+
+#Preview("Investment account, fail-open footer (Accessibility3)") {
+  FailOpenValuationPreview()
+    .dynamicTypeSize(.accessibility3)
 }

--- a/Features/Accounts/Views/EditAccountView.swift
+++ b/Features/Accounts/Views/EditAccountView.swift
@@ -90,6 +90,7 @@ struct EditAccountView: View {
     NavigationStack {
       form
     }
+    .accessibilityIdentifier(UITestIdentifiers.EditAccount.dialog)
     #if os(macOS)
       .frame(minWidth: 500, minHeight: 400)
     #endif
@@ -118,10 +119,12 @@ struct EditAccountView: View {
     .toolbar {
       ToolbarItem(placement: .cancellationAction) {
         Button("Cancel") { dismiss() }
+          .accessibilityIdentifier(UITestIdentifiers.EditAccount.cancelButton)
       }
       ToolbarItem(placement: .confirmationAction) {
         Button("Save") { Task { await save() } }
           .disabled(!isValid || isSubmitting)
+          .accessibilityIdentifier(UITestIdentifiers.EditAccount.saveButton)
       }
     }
     .animation(.easeInOut(duration: 0.2), value: type)
@@ -196,7 +199,7 @@ struct EditAccountView: View {
           Text("Recorded value").tag(ValuationMode.recordedValue)
           Text("Calculated from trades").tag(ValuationMode.calculatedFromTrades)
         }
-        .accessibilityIdentifier("editAccount.valuationMode")
+        .accessibilityIdentifier(UITestIdentifiers.EditAccount.valuationModePicker)
         .accessibilityHint(valuationMode.dataSourceHint)
       } footer: {
         VStack(alignment: .leading, spacing: 4) {
@@ -296,7 +299,7 @@ private struct FailOpenValuationPreview: View {
           Text("Recorded value").tag(ValuationMode.recordedValue)
           Text("Calculated from trades").tag(ValuationMode.calculatedFromTrades)
         }
-        .accessibilityIdentifier("editAccount.valuationMode")
+        .accessibilityIdentifier(UITestIdentifiers.EditAccount.valuationModePicker)
         .accessibilityHint(mode.dataSourceHint)
       } footer: {
         VStack(alignment: .leading, spacing: 4) {

--- a/Features/Accounts/Views/EditAccountView.swift
+++ b/Features/Accounts/Views/EditAccountView.swift
@@ -90,7 +90,6 @@ struct EditAccountView: View {
     NavigationStack {
       form
     }
-    .accessibilityIdentifier(UITestIdentifiers.EditAccount.dialog)
     #if os(macOS)
       .frame(minWidth: 500, minHeight: 400)
     #endif

--- a/Features/Accounts/Views/EditAccountView.swift
+++ b/Features/Accounts/Views/EditAccountView.swift
@@ -1,4 +1,21 @@
+import OSLog
 import SwiftUI
+
+/// Outcome of the snapshot-presence probe used to decide whether
+/// `EditAccountView` offers the Valuation picker. Lifted to module
+/// scope (rather than nested inside `EditAccountView`) because tests
+/// reference it directly via `@testable import Moolah`. Specific
+/// name disambiguates from any future "picker visibility" state in
+/// other features. See
+/// `plans/2026-05-05-restrict-valuation-picker-design.md` §3.3.
+enum ValuationPickerVisibility: Equatable, Sendable {
+  case hidden
+  case shown
+  case shownAfterFailure
+}
+
+private let editAccountLogger = Logger(
+  subsystem: "com.moolah.app", category: "EditAccountView")
 
 struct EditAccountView: View {
   @Environment(\.dismiss) private var dismiss
@@ -16,6 +33,31 @@ struct EditAccountView: View {
 
   private enum Field: Hashable {
     case name
+  }
+
+  /// Resolves whether the Valuation picker should be shown for an
+  /// investment account currently in `.calculatedFromTrades` mode.
+  /// Pure async function over a closure-typed probe so the rule is
+  /// directly unit-testable. The `accountId` parameter exists so the
+  /// warning log on probe failure can identify which account
+  /// triggered it; supply the real account ID for diagnosability.
+  /// Re-throws `CancellationError` per the structured-concurrency
+  /// contract; converts any other error into `.shownAfterFailure`
+  /// (fail-open).
+  static func resolvePickerVisibility(
+    accountId: UUID,
+    snapshotProbe: () async throws -> Bool
+  ) async throws -> ValuationPickerVisibility {
+    do {
+      return try await snapshotProbe() ? .shown : .hidden
+    } catch let error as CancellationError {
+      throw error
+    } catch {
+      editAccountLogger.warning(
+        "valuation snapshot probe failed for \(accountId, privacy: .public): \(error.localizedDescription, privacy: .public)"
+      )
+      return .shownAfterFailure
+    }
   }
 
   init(account: Account, accountStore: AccountStore) {

--- a/Features/Navigation/SidebarView.swift
+++ b/Features/Navigation/SidebarView.swift
@@ -309,6 +309,7 @@ extension SidebarView {
     Button("Edit Account\u{2026}", systemImage: "pencil") {
       accountToEdit = account
     }
+    .accessibilityIdentifier(UITestIdentifiers.Sidebar.editAccountContextMenuItem)
     Button("View Transactions", systemImage: "list.bullet") {
       selection = .account(account.id)
     }

--- a/MoolahTests/Domain/ValuationModeDisplayTextTests.swift
+++ b/MoolahTests/Domain/ValuationModeDisplayTextTests.swift
@@ -1,0 +1,27 @@
+import Testing
+
+@testable import Moolah
+
+@Suite("ValuationMode display text")
+struct ValuationModeDisplayTextTests {
+  @Test("dataSourceHint returns expected string for both modes")
+  func dataSourceHint_returnsExpectedString() {
+    #expect(
+      ValuationMode.recordedValue.dataSourceHint
+        == "Balance comes from the value you last recorded")
+    #expect(
+      ValuationMode.calculatedFromTrades.dataSourceHint
+        == "Balance is calculated from your trade history and current prices of your holdings")
+  }
+
+  @Test("dataSourceDescription returns expected sentence for both modes")
+  func dataSourceDescription_returnsExpectedString() {
+    #expect(
+      ValuationMode.recordedValue.dataSourceDescription
+        == "The balance comes from the value you last recorded manually.")
+    #expect(
+      ValuationMode.calculatedFromTrades.dataSourceDescription
+        == "The balance is calculated from your trade history and the current prices of your holdings."
+    )
+  }
+}

--- a/MoolahTests/Features/EditAccountVisibilityTests.swift
+++ b/MoolahTests/Features/EditAccountVisibilityTests.swift
@@ -1,0 +1,49 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+/// Pins `EditAccountView.resolvePickerVisibility(...)`. The resolver
+/// is a pure async function over a closure-typed snapshot probe — it
+/// owns the rule "show the Valuation picker when an investment account
+/// has at least one snapshot, fail-open on transient probe error,
+/// re-throw on cancellation" but knows nothing about SwiftUI or the
+/// dialog's `@State`. See
+/// `plans/2026-05-05-restrict-valuation-picker-design.md` §3.3 for
+/// the design and §5.2 for the test-branch matrix.
+@Suite("EditAccountView.resolvePickerVisibility")
+struct EditAccountVisibilityTests {
+  @Test("probe returns true → .shown")
+  func probeReturnsTrue_returnsShown() async throws {
+    let result = try await EditAccountView.resolvePickerVisibility(
+      accountId: UUID(),
+      snapshotProbe: { true })
+    #expect(result == .shown)
+  }
+
+  @Test("probe returns false → .hidden")
+  func probeReturnsFalse_returnsHidden() async throws {
+    let result = try await EditAccountView.resolvePickerVisibility(
+      accountId: UUID(),
+      snapshotProbe: { false })
+    #expect(result == .hidden)
+  }
+
+  @Test("probe throws generic error → .shownAfterFailure")
+  func probeThrowsGenericError_returnsShownAfterFailure() async throws {
+    struct ProbeError: Error {}
+    let result = try await EditAccountView.resolvePickerVisibility(
+      accountId: UUID(),
+      snapshotProbe: { throw ProbeError() })
+    #expect(result == .shownAfterFailure)
+  }
+
+  @Test("probe throws CancellationError → re-throws")
+  func probeThrowsCancellationError_propagates() async throws {
+    await #expect(throws: CancellationError.self) {
+      try await EditAccountView.resolvePickerVisibility(
+        accountId: UUID(),
+        snapshotProbe: { throw CancellationError() })
+    }
+  }
+}

--- a/MoolahTests/UITestSupport/UITestSeedHydratorTests.swift
+++ b/MoolahTests/UITestSupport/UITestSeedHydratorTests.swift
@@ -65,7 +65,10 @@ final class UITestSeedHydratorTests: XCTestCase {
     let database = try containerManager.database(for: profile.id)
 
     let accounts = try database.read { database in try AccountRow.fetchAll(database) }
-    XCTAssertEqual(accounts.count, 3, "expected checking + brokerage + USD accounts")
+    XCTAssertEqual(
+      accounts.count, 4,
+      "expected checking + brokerage (recordedValue) + USD + trades-brokerage (calculatedFromTrades)"
+    )
     let ids = Set(accounts.map(\.id))
     XCTAssertEqual(
       ids,
@@ -73,12 +76,53 @@ final class UITestSeedHydratorTests: XCTestCase {
         UITestFixtures.TradeBaseline.checkingAccountId,
         UITestFixtures.TradeBaseline.brokerageAccountId,
         UITestFixtures.TradeBaseline.usdAccountId,
+        UITestFixtures.TradeBaseline.tradesBrokerageAccountId,
       ]
     )
     let usd = try XCTUnwrap(
       accounts.first { $0.id == UITestFixtures.TradeBaseline.usdAccountId }
     )
     XCTAssertEqual(usd.instrumentId, UITestFixtures.TradeBaseline.usdAccountInstrumentCode)
+
+    let tradesBrokerage = try XCTUnwrap(
+      accounts.first { $0.id == UITestFixtures.TradeBaseline.tradesBrokerageAccountId }
+    )
+    XCTAssertEqual(tradesBrokerage.valuationMode, ValuationMode.calculatedFromTrades.rawValue)
+    let legacyBrokerage = try XCTUnwrap(
+      accounts.first { $0.id == UITestFixtures.TradeBaseline.brokerageAccountId }
+    )
+    XCTAssertEqual(legacyBrokerage.valuationMode, ValuationMode.recordedValue.rawValue)
+  }
+
+  func testHydrateTradeBaselineSeedsTheBrokerageInvestmentValueSnapshot() throws {
+    let profile = try XCTUnwrap(
+      try UITestSeedHydrator.hydrate(.tradeBaseline, into: containerManager))
+    let database = try containerManager.database(for: profile.id)
+
+    let snapshots = try database.read { database in
+      try InvestmentValueRow
+        .filter(
+          InvestmentValueRow.Columns.accountId
+            == UITestFixtures.TradeBaseline.brokerageAccountId
+        )
+        .fetchAll(database)
+    }
+    XCTAssertEqual(snapshots.count, 1, "legacy brokerage account should have one snapshot")
+    let snapshot = try XCTUnwrap(snapshots.first)
+    XCTAssertEqual(snapshot.id, UITestFixtures.TradeBaseline.brokerageSnapshotId)
+    XCTAssertEqual(snapshot.date, UITestFixtures.TradeBaseline.brokerageSnapshotDate)
+
+    let tradesSnapshots = try database.read { database in
+      try InvestmentValueRow
+        .filter(
+          InvestmentValueRow.Columns.accountId
+            == UITestFixtures.TradeBaseline.tradesBrokerageAccountId
+        )
+        .fetchAll(database)
+    }
+    XCTAssertTrue(
+      tradesSnapshots.isEmpty,
+      "trades-brokerage account should have no snapshots so picker stays hidden")
   }
 
   func testHydrateTradeBaselineSeedsTheTradeTransaction() throws {

--- a/MoolahUITests_macOS/Helpers/MoolahApp.swift
+++ b/MoolahUITests_macOS/Helpers/MoolahApp.swift
@@ -69,6 +69,11 @@ final class MoolahApp {
   /// `CreateAccountView` sheet. Open it by calling `createAccount.open(...)`.
   var createAccount: CreateAccountScreen { CreateAccountScreen(app: self) }
 
+  /// `EditAccountView` sheet. Open it by right-clicking an account row in
+  /// the sidebar and choosing "Edit Account…", or programmatically via
+  /// `editAccount.open(account:)`.
+  var editAccount: EditAccountScreen { EditAccountScreen(app: self) }
+
   /// macOS Settings scene. Open it via `settings.open()`; tab drivers
   /// (e.g. `settings.openCryptoTab()`) hang off the returned screen.
   var settings: SettingsScreen { SettingsScreen(app: self) }
@@ -99,6 +104,15 @@ final class MoolahApp {
   /// invariant (UI_TEST_GUIDE §3 #5) is preserved.
   func toolbarButton(label: String) -> XCUIElement {
     application.toolbars.buttons[label]
+  }
+
+  /// Menu-item-by-label resolver. Used by drivers when SwiftUI drops
+  /// `.accessibilityIdentifier(_:)` on the underlying control — context
+  /// menus and macOS Picker pop-ups are the current cases (NSMenuItem
+  /// doesn't inherit the SwiftUI identifier). All such lookups route
+  /// through this method so the single-resolver invariant is preserved.
+  func menuItem(label: String) -> XCUIElement {
+    application.menuItems[label]
   }
 
   // MARK: - Predicate-based escape hatches

--- a/MoolahUITests_macOS/Helpers/Screens/EditAccountScreen.swift
+++ b/MoolahUITests_macOS/Helpers/Screens/EditAccountScreen.swift
@@ -1,0 +1,210 @@
+import XCTest
+
+/// Driver for the `EditAccountView` sheet. Returned from
+/// `MoolahApp.editAccount`.
+///
+/// Open the sheet via `open(account:)` (right-clicks the sidebar row and
+/// chooses the context-menu "Edit Account…" item) or by some other test
+/// path that should still call `expectVisible()` before any content
+/// assertion runs — see `guides/UI_TEST_GUIDE.md` §3 invariant 1
+/// ("Actions wait for post-conditions") and §3 invariant 2
+/// ("Actions fail loudly").
+@MainActor
+struct EditAccountScreen {
+  /// Test-side mirror of `ValuationMode`. UI tests don't import the
+  /// `Moolah` app module, so the production enum is not visible here;
+  /// the driver carries this small mirror alongside the helper that
+  /// translates each case to the user-visible label and accessibility
+  /// hint produced by `EditAccountView`. If the production strings
+  /// change, update the helpers below to match — they are deliberately
+  /// duplicated rather than re-imported.
+  enum Mode: Equatable {
+    case recordedValue
+    case calculatedFromTrades
+  }
+
+  let app: MoolahApp
+
+  // MARK: - Open / dismiss
+
+  /// Right-clicks the sidebar row for `account` and clicks the "Edit
+  /// Account…" item to present the dialog. Returns once the dialog's
+  /// root container materialises in the accessibility tree — the
+  /// presence sentinel a subsequent `expectValuationSectionAbsent()`
+  /// call relies on, so the absence check can't pass vacuously when the
+  /// sheet failed to open.
+  func open(account: SidebarAccount) {
+    Trace.record(#function, detail: "account=\(account)")
+    let row = app.element(for: UITestIdentifiers.Sidebar.account(account.id))
+    if !row.waitForExistence(timeout: 3) {
+      Trace.recordFailure(
+        "sidebar row '\(UITestIdentifiers.Sidebar.account(account.id))' did not appear")
+      XCTFail("Sidebar row for account \(account) did not appear within 3s")
+      return
+    }
+    row.rightClick()
+
+    // The sidebar's `accountContextMenu` produces an NSMenu whose
+    // items attach to the application's menu hierarchy at runtime;
+    // SwiftUI doesn't propagate `.accessibilityIdentifier(_:)` onto
+    // the resulting NSMenuItem, so resolve by label. The `menuItem`
+    // helper on `MoolahApp` keeps the single-resolver invariant.
+    let editItem = app.menuItem(label: "Edit Account…")
+    if !editItem.waitForExistence(timeout: 3) {
+      Trace.recordFailure("'Edit Account…' menu item did not appear after right-click")
+      XCTFail("'Edit Account…' menu item did not appear within 3s of right-click")
+      return
+    }
+    editItem.click()
+
+    expectVisible()
+  }
+
+  /// Asserts the dialog is currently on screen. Used as a presence
+  /// sentinel: a subsequent absence assertion on the Valuation section
+  /// would otherwise pass vacuously when the sheet failed to open.
+  func expectVisible() {
+    Trace.record(#function)
+    let dialog = app.element(for: UITestIdentifiers.EditAccount.dialog)
+    if !dialog.waitForExistence(timeout: 3) {
+      Trace.recordFailure(
+        "editAccount.dialog did not appear; cannot assert section visibility")
+      XCTFail("EditAccountView dialog did not appear within 3s")
+    }
+  }
+
+  /// Closes the dialog by clicking the Cancel toolbar button. Returns
+  /// once the dialog's root container disappears.
+  func cancel() {
+    Trace.record(#function)
+    let cancelButton = app.element(for: UITestIdentifiers.EditAccount.cancelButton)
+    if !cancelButton.waitForExistence(timeout: 3) {
+      Trace.recordFailure("editAccount.cancel button did not appear")
+      XCTFail("Cancel button did not appear within 3s")
+      return
+    }
+    cancelButton.click()
+
+    let dialog = app.element(for: UITestIdentifiers.EditAccount.dialog)
+    if !dialog.waitForNonExistence(timeout: 3) {
+      Trace.recordFailure("editAccount.dialog did not disappear after Cancel click")
+      XCTFail("EditAccountView dialog did not disappear within 3s of Cancel")
+    }
+  }
+
+  // MARK: - Expectations (read-only)
+
+  /// Asserts the Valuation section's picker is present. Caller must have
+  /// already invoked `open(account:)` or `expectVisible()` so a missing
+  /// picker reflects the rule, not a missing sheet.
+  func expectValuationSectionVisible() {
+    Trace.record(#function)
+    let picker = app.element(for: UITestIdentifiers.EditAccount.valuationModePicker)
+    if !picker.waitForExistence(timeout: 3) {
+      Trace.recordFailure(
+        "editAccount.valuationMode picker did not appear; expected for "
+          + "recordedValue or has-snapshots accounts")
+      XCTFail("Valuation picker did not appear within 3s")
+    }
+  }
+
+  /// Asserts the Valuation section's picker is **not** present. Pairs
+  /// with a prior `expectVisible()` call so a missing picker reflects
+  /// the rule rather than a missing sheet. Uses XCTest's
+  /// `waitForNonExistence(timeout:)`, which returns `true` when the
+  /// element either never existed or disappeared within the window —
+  /// the right primitive for confirming the asynchronous `.task`
+  /// probe didn't reveal the section.
+  func expectValuationSectionAbsent() {
+    Trace.record(#function)
+    let picker = app.element(for: UITestIdentifiers.EditAccount.valuationModePicker)
+    if !picker.waitForNonExistence(timeout: 2) {
+      Trace.recordFailure(
+        "editAccount.valuationMode picker appeared but the rule says it "
+          + "should be hidden for new calculatedFromTrades accounts")
+      XCTFail("Valuation picker should be hidden but is present")
+    }
+  }
+
+  /// Asserts the picker's currently-selected value reads as `expected`.
+  /// Reads the macOS pop-up button's `value` attribute — the SwiftUI
+  /// idiom for the displayed label of a `Picker(... selection:)`.
+  /// Uses `XCTNSPredicateExpectation` rather than a hand-rolled poll
+  /// loop, per UI_TEST_GUIDE §3 (no sleeps / no retries).
+  func expectValuationMode(_ expected: Mode) {
+    Trace.record(#function, detail: "expected=\(expected)")
+    let picker = app.element(for: UITestIdentifiers.EditAccount.valuationModePicker)
+    if !picker.waitForExistence(timeout: 3) {
+      Trace.recordFailure(
+        "editAccount.valuationMode picker did not appear; cannot read selection")
+      XCTFail("Valuation picker did not appear within 3s")
+      return
+    }
+    let expectedLabel = displayLabel(for: expected)
+    let predicate = NSPredicate { _, _ in
+      (picker.value as? String) == expectedLabel
+    }
+    let expectation = XCTNSPredicateExpectation(predicate: predicate, object: nil)
+    if XCTWaiter().wait(for: [expectation], timeout: 3) != .completed {
+      let actual = (picker.value as? String) ?? "<no value>"
+      Trace.recordFailure(
+        "editAccount.valuationMode shows '\(actual)', expected '\(expectedLabel)'")
+      XCTFail("Valuation picker shows '\(actual)', expected '\(expectedLabel)'")
+    }
+  }
+
+  /// Asserts the picker's `accessibilityHint` matches the canonical
+  /// hint for `mode` (the production source is
+  /// `ValuationMode.dataSourceHint`; mirrored locally in
+  /// `accessibilityHint(for:)` because the UI test target can't import
+  /// the main app module). Detects regressions in the hint copy.
+  func expectAccessibilityHint(for mode: Mode) {
+    Trace.record(#function, detail: "mode=\(mode)")
+    let picker = app.element(for: UITestIdentifiers.EditAccount.valuationModePicker)
+    if !picker.waitForExistence(timeout: 3) {
+      Trace.recordFailure(
+        "editAccount.valuationMode picker did not appear; cannot read hint")
+      XCTFail("Valuation picker did not appear within 3s")
+      return
+    }
+    let expected = accessibilityHint(for: mode)
+    // `accessibilityHint` does not always project as a `value`; SwiftUI
+    // surfaces it in `XCUIElement.label`-adjacent fields. The canonical
+    // pop-up-button accessor for the inline hint string is the
+    // `placeholderValue` / `label` family. We assert via direct property
+    // read — falling through to `XCTFail` when neither matches.
+    let pickerLabel = picker.label
+    if !pickerLabel.contains(expected) {
+      Trace.recordFailure(
+        "editAccount.valuationMode picker label '\(pickerLabel)' "
+          + "does not contain hint '\(expected)'")
+      XCTFail("Valuation picker hint missing or wrong; label='\(pickerLabel)'")
+    }
+  }
+
+  // MARK: - Helpers
+
+  /// Maps `Mode` to the user-visible Picker label produced by
+  /// `EditAccountView.valuationSection`. Kept private so the test body
+  /// stays free of raw strings — drivers own all label-mapping.
+  private func displayLabel(for mode: Mode) -> String {
+    switch mode {
+    case .recordedValue: return "Recorded value"
+    case .calculatedFromTrades: return "Calculated from trades"
+    }
+  }
+
+  /// Mirror of `ValuationMode.dataSourceHint`. Hard-coded because the
+  /// UI test target can't import the main app module. If the
+  /// production hint changes (see
+  /// `Domain/Models/ValuationMode+DisplayText.swift`), update this
+  /// helper to match.
+  private func accessibilityHint(for mode: Mode) -> String {
+    switch mode {
+    case .recordedValue:
+      return "Balance comes from the value you last recorded"
+    case .calculatedFromTrades:
+      return "Balance is calculated from your trade history and current prices of your holdings"
+    }
+  }
+}

--- a/MoolahUITests_macOS/Helpers/Screens/EditAccountScreen.swift
+++ b/MoolahUITests_macOS/Helpers/Screens/EditAccountScreen.swift
@@ -28,11 +28,10 @@ struct EditAccountScreen {
   // MARK: - Open / dismiss
 
   /// Right-clicks the sidebar row for `account` and clicks the "Edit
-  /// Account…" item to present the dialog. Returns once the dialog's
-  /// root container materialises in the accessibility tree — the
-  /// presence sentinel a subsequent `expectValuationSectionAbsent()`
-  /// call relies on, so the absence check can't pass vacuously when the
-  /// sheet failed to open.
+  /// Account…" item to present the dialog. Returns once the Cancel
+  /// button has materialised — the presence sentinel a subsequent
+  /// `expectValuationSectionAbsent()` call relies on, so the absence
+  /// check can't pass vacuously when the sheet failed to open.
   func open(account: SidebarAccount) {
     Trace.record(#function, detail: "account=\(account)")
     let row = app.element(for: UITestIdentifiers.Sidebar.account(account.id))
@@ -44,14 +43,16 @@ struct EditAccountScreen {
     }
     row.rightClick()
 
-    // The sidebar's `accountContextMenu` produces an NSMenu whose
-    // items attach to the application's menu hierarchy at runtime;
-    // SwiftUI doesn't propagate `.accessibilityIdentifier(_:)` onto
-    // the resulting NSMenuItem, so resolve by label. The `menuItem`
-    // helper on `MoolahApp` keeps the single-resolver invariant.
-    let editItem = app.menuItem(label: "Edit Account…")
+    // SwiftUI does propagate `.accessibilityIdentifier(_:)` onto
+    // context-menu Buttons (verified — the menu item's identifier
+    // appears in the accessibility tree). Resolve by identifier
+    // rather than by label so we don't collide with the menu-bar
+    // "Account → Edit Account…" command, which carries the same
+    // title.
+    let editItem = app.element(for: UITestIdentifiers.Sidebar.editAccountContextMenuItem)
     if !editItem.waitForExistence(timeout: 3) {
-      Trace.recordFailure("'Edit Account…' menu item did not appear after right-click")
+      Trace.recordFailure(
+        "sidebar.contextMenu.editAccount item did not appear after right-click")
       XCTFail("'Edit Account…' menu item did not appear within 3s of right-click")
       return
     }
@@ -63,12 +64,15 @@ struct EditAccountScreen {
   /// Asserts the dialog is currently on screen. Used as a presence
   /// sentinel: a subsequent absence assertion on the Valuation section
   /// would otherwise pass vacuously when the sheet failed to open.
+  /// The Cancel button is the working sentinel because SwiftUI's
+  /// `.accessibilityIdentifier(_:)` on `NavigationStack` / `Form`
+  /// does not propagate to the macOS-rendered window root.
   func expectVisible() {
     Trace.record(#function)
-    let dialog = app.element(for: UITestIdentifiers.EditAccount.dialog)
-    if !dialog.waitForExistence(timeout: 3) {
+    let cancelButton = app.element(for: UITestIdentifiers.EditAccount.cancelButton)
+    if !cancelButton.waitForExistence(timeout: 3) {
       Trace.recordFailure(
-        "editAccount.dialog did not appear; cannot assert section visibility")
+        "editAccount.cancel did not appear; the Edit Account sheet failed to open")
       XCTFail("EditAccountView dialog did not appear within 3s")
     }
   }
@@ -85,9 +89,10 @@ struct EditAccountScreen {
     }
     cancelButton.click()
 
-    let dialog = app.element(for: UITestIdentifiers.EditAccount.dialog)
-    if !dialog.waitForNonExistence(timeout: 3) {
-      Trace.recordFailure("editAccount.dialog did not disappear after Cancel click")
+    // Post-condition: the Cancel button (which IS the sentinel)
+    // disappears once the sheet is dismissed.
+    if !cancelButton.waitForNonExistence(timeout: 3) {
+      Trace.recordFailure("editAccount.cancel did not disappear after Cancel click")
       XCTFail("EditAccountView dialog did not disappear within 3s of Cancel")
     }
   }
@@ -153,35 +158,6 @@ struct EditAccountScreen {
     }
   }
 
-  /// Asserts the picker's `accessibilityHint` matches the canonical
-  /// hint for `mode` (the production source is
-  /// `ValuationMode.dataSourceHint`; mirrored locally in
-  /// `accessibilityHint(for:)` because the UI test target can't import
-  /// the main app module). Detects regressions in the hint copy.
-  func expectAccessibilityHint(for mode: Mode) {
-    Trace.record(#function, detail: "mode=\(mode)")
-    let picker = app.element(for: UITestIdentifiers.EditAccount.valuationModePicker)
-    if !picker.waitForExistence(timeout: 3) {
-      Trace.recordFailure(
-        "editAccount.valuationMode picker did not appear; cannot read hint")
-      XCTFail("Valuation picker did not appear within 3s")
-      return
-    }
-    let expected = accessibilityHint(for: mode)
-    // `accessibilityHint` does not always project as a `value`; SwiftUI
-    // surfaces it in `XCUIElement.label`-adjacent fields. The canonical
-    // pop-up-button accessor for the inline hint string is the
-    // `placeholderValue` / `label` family. We assert via direct property
-    // read — falling through to `XCTFail` when neither matches.
-    let pickerLabel = picker.label
-    if !pickerLabel.contains(expected) {
-      Trace.recordFailure(
-        "editAccount.valuationMode picker label '\(pickerLabel)' "
-          + "does not contain hint '\(expected)'")
-      XCTFail("Valuation picker hint missing or wrong; label='\(pickerLabel)'")
-    }
-  }
-
   // MARK: - Helpers
 
   /// Maps `Mode` to the user-visible Picker label produced by
@@ -194,17 +170,4 @@ struct EditAccountScreen {
     }
   }
 
-  /// Mirror of `ValuationMode.dataSourceHint`. Hard-coded because the
-  /// UI test target can't import the main app module. If the
-  /// production hint changes (see
-  /// `Domain/Models/ValuationMode+DisplayText.swift`), update this
-  /// helper to match.
-  private func accessibilityHint(for mode: Mode) -> String {
-    switch mode {
-    case .recordedValue:
-      return "Balance comes from the value you last recorded"
-    case .calculatedFromTrades:
-      return "Balance is calculated from your trade history and current prices of your holdings"
-    }
-  }
 }

--- a/MoolahUITests_macOS/Helpers/Screens/SidebarScreen.swift
+++ b/MoolahUITests_macOS/Helpers/Screens/SidebarScreen.swift
@@ -5,6 +5,11 @@ import XCTest
 enum SidebarAccount {
   case checking
   case brokerage
+  /// `.tradeBaseline`'s second investment account: `.calculatedFromTrades`
+  /// mode with no `InvestmentValue` snapshots. Drives the
+  /// "picker hidden for new trade-driven accounts" branch in
+  /// `EditAccountValuationPickerTests`.
+  case tradesBrokerage
   /// The Brokerage account from the `.tradeReady` seed (different UUID from
   /// `.brokerage`, which uses the `.tradeBaseline` seed fixture).
   case tradeReadyBrokerage
@@ -15,6 +20,7 @@ enum SidebarAccount {
     switch self {
     case .checking: return UITestFixtures.TradeBaseline.checkingAccountId
     case .brokerage: return UITestFixtures.TradeBaseline.brokerageAccountId
+    case .tradesBrokerage: return UITestFixtures.TradeBaseline.tradesBrokerageAccountId
     case .tradeReadyBrokerage: return UITestFixtures.TradeReady.brokerageAccountId
     }
   }

--- a/MoolahUITests_macOS/Tests/EditAccountValuationPickerTests.swift
+++ b/MoolahUITests_macOS/Tests/EditAccountValuationPickerTests.swift
@@ -1,0 +1,51 @@
+import XCTest
+
+/// End-to-end tests for `EditAccountView`'s Valuation-mode picker
+/// visibility rule:
+///
+/// - A legacy investment account in `.recordedValue` mode that has at
+///   least one `InvestmentValue` snapshot SHOWS the picker (preselected
+///   to "Recorded value", with the correct accessibility hint).
+/// - A new investment account in `.calculatedFromTrades` mode with no
+///   snapshots HIDES the picker entirely.
+///
+/// Both scenarios are seeded by the `.tradeBaseline` fixture in
+/// `UITestFixtures.TradeBaseline` (Stage 4 of the implementation plan).
+/// The behaviour under test is in `EditAccountView` and its resolver
+/// `EditAccountView.resolvePickerVisibility(...)`. See
+/// `plans/2026-05-05-restrict-valuation-picker-design.md` §2.
+@MainActor
+final class EditAccountValuationPickerTests: MoolahUITestCase {
+  func testRecordedValueLegacyAccountShowsValuationPicker() {
+    let app = launch(seed: .tradeBaseline)
+
+    app.editAccount.open(account: .brokerage)
+    app.editAccount.expectValuationSectionVisible()
+    app.editAccount.cancel()
+  }
+
+  func testRecordedValueLegacyAccountPreselectsRecordedValue() {
+    let app = launch(seed: .tradeBaseline)
+
+    app.editAccount.open(account: .brokerage)
+    app.editAccount.expectValuationMode(EditAccountScreen.Mode.recordedValue)
+    app.editAccount.cancel()
+  }
+
+  func testRecordedValueLegacyAccountExposesAccessibilityHint() {
+    let app = launch(seed: .tradeBaseline)
+
+    app.editAccount.open(account: .brokerage)
+    app.editAccount.expectAccessibilityHint(for: EditAccountScreen.Mode.recordedValue)
+    app.editAccount.cancel()
+  }
+
+  func testCalculatedFromTradesAccountWithNoSnapshotsHidesValuationPicker() {
+    let app = launch(seed: .tradeBaseline)
+
+    app.editAccount.open(account: .tradesBrokerage)
+    app.editAccount.expectVisible()
+    app.editAccount.expectValuationSectionAbsent()
+    app.editAccount.cancel()
+  }
+}

--- a/MoolahUITests_macOS/Tests/EditAccountValuationPickerTests.swift
+++ b/MoolahUITests_macOS/Tests/EditAccountValuationPickerTests.swift
@@ -32,13 +32,14 @@ final class EditAccountValuationPickerTests: MoolahUITestCase {
     app.editAccount.cancel()
   }
 
-  func testRecordedValueLegacyAccountExposesAccessibilityHint() {
-    let app = launch(seed: .tradeBaseline)
-
-    app.editAccount.open(account: .brokerage)
-    app.editAccount.expectAccessibilityHint(for: EditAccountScreen.Mode.recordedValue)
-    app.editAccount.cancel()
-  }
+  // Note: there is no UI test for the picker's `.accessibilityHint`.
+  // macOS XCUITest does not surface `accessibilityHint` as a
+  // queryable XCUIElement attribute (it is a VoiceOver-only concept
+  // that the runtime delivers through speech, not the accessibility
+  // tree). The hint copy is pinned by
+  // `ValuationModeDisplayTextTests.dataSourceHint_returnsExpectedString`
+  // at the model layer; manual VoiceOver verification covers the
+  // propagation path.
 
   func testCalculatedFromTradesAccountWithNoSnapshotsHidesValuationPicker() {
     let app = launch(seed: .tradeBaseline)

--- a/UITestSupport/UITestIdentifiers.swift
+++ b/UITestSupport/UITestIdentifiers.swift
@@ -216,6 +216,30 @@ public enum UITestIdentifiers {
     }
   }
 
+  public enum EditAccount {
+    /// Root container of the Edit Account dialog. Pinned on the form's
+    /// outermost element. Drivers wait for this to materialise as the
+    /// presence sentinel before any content assertions run, so an
+    /// absent-section assertion can't pass vacuously when the sheet
+    /// failed to open.
+    public static let dialog = "editAccount.dialog"
+
+    /// Valuation-mode picker shown for legacy investment accounts in
+    /// `.recordedValue` mode or `.calculatedFromTrades` accounts that
+    /// still have at least one `InvestmentValue` snapshot. Identifier
+    /// pinned by `EditAccountView.valuationSection`.
+    public static let valuationModePicker = "editAccount.valuationMode"
+
+    /// Cancel toolbar button. Drivers click it to dismiss the dialog
+    /// after assertions run.
+    public static let cancelButton = "editAccount.cancel"
+
+    /// Save toolbar button. Pinned for symmetry with `cancelButton` so
+    /// future tests can exercise the save path through the same
+    /// resolver pattern.
+    public static let saveButton = "editAccount.save"
+  }
+
   public enum Autocomplete {
     /// Container element of the payee autocomplete dropdown.
     public static let payee = "autocomplete.payee"

--- a/UITestSupport/UITestIdentifiers.swift
+++ b/UITestSupport/UITestIdentifiers.swift
@@ -33,6 +33,13 @@ public enum UITestIdentifiers {
 
     /// "New Account" toolbar button in the sidebar (macOS only).
     public static let newAccountButton = "sidebar.toolbar.newAccount"
+
+    /// "Edit Account…" item in the sidebar account context menu.
+    /// Distinct from the menu-bar Account → Edit Account command,
+    /// which has the same title but lives in the application menu —
+    /// drivers must resolve via this identifier rather than the
+    /// shared label.
+    public static let editAccountContextMenuItem = "sidebar.contextMenu.editAccount"
   }
 
   public enum TransactionList {
@@ -217,13 +224,6 @@ public enum UITestIdentifiers {
   }
 
   public enum EditAccount {
-    /// Root container of the Edit Account dialog. Pinned on the form's
-    /// outermost element. Drivers wait for this to materialise as the
-    /// presence sentinel before any content assertions run, so an
-    /// absent-section assertion can't pass vacuously when the sheet
-    /// failed to open.
-    public static let dialog = "editAccount.dialog"
-
     /// Valuation-mode picker shown for legacy investment accounts in
     /// `.recordedValue` mode or `.calculatedFromTrades` accounts that
     /// still have at least one `InvestmentValue` snapshot. Identifier
@@ -231,7 +231,14 @@ public enum UITestIdentifiers {
     public static let valuationModePicker = "editAccount.valuationMode"
 
     /// Cancel toolbar button. Drivers click it to dismiss the dialog
-    /// after assertions run.
+    /// after assertions run, AND use it as the presence sentinel for
+    /// `expectVisible()` — Cancel is the only element that's
+    /// guaranteed to render whenever the dialog opens (the rest of
+    /// the form depends on account type and visibility resolver
+    /// state). SwiftUI's `.accessibilityIdentifier(_:)` on
+    /// `NavigationStack` / `Form` does not propagate to the
+    /// macOS-rendered window root, so a content-element sentinel is
+    /// the working pattern here.
     public static let cancelButton = "editAccount.cancel"
 
     /// Save toolbar button. Pinned for symmetry with `cancelButton` so

--- a/UITestSupport/UITestSeed.swift
+++ b/UITestSupport/UITestSeed.swift
@@ -114,6 +114,29 @@ public struct UITestHistoricalExpense: Sendable {
   }
 }
 
+/// One `InvestmentValue` snapshot row hydrated alongside an
+/// investment account. Stored in the `investment_value` table by
+/// `UITestSeedHydrator+Upserts.upsertInvestmentValue`. Used by the
+/// `EditAccountView` valuation-picker visibility test:
+/// `.recordedValue` accounts that have at least one snapshot show
+/// the picker; accounts with no snapshots in `.calculatedFromTrades`
+/// hide it.
+public struct UITestInvestmentValueSeed: Sendable {
+  public let id: UUID
+  public let accountId: UUID
+  public let date: Date
+  public let instrumentId: String
+  public let cents: Int
+
+  public init(id: UUID, accountId: UUID, date: Date, instrumentId: String, cents: Int) {
+    self.id = id
+    self.accountId = accountId
+    self.date = date
+    self.instrumentId = instrumentId
+    self.cents = cents
+  }
+}
+
 /// Fixed-UUID fixtures used by both the app (when seeding) and UI-test
 /// drivers (when resolving identifiers). Grouping constants by seed family
 /// keeps fixtures local to the scenario that needs them.
@@ -123,7 +146,17 @@ public enum UITestFixtures {
   /// Entities (all fixed, deterministic):
   ///   - Profile `personal` — label "Personal", currency AUD, CloudKit-backed.
   ///   - Account `checking` — "Checking", bank, AUD.
-  ///   - Account `brokerage` — "Brokerage", investment, AUD.
+  ///   - Account `brokerage` — "Brokerage", investment, AUD,
+  ///     `valuationMode = .recordedValue` (legacy). One
+  ///     `InvestmentValue` snapshot for $12,345.00 on 2026-04-15 UTC, so
+  ///     `EditAccountValuationPickerTests` can assert the picker is
+  ///     shown for the legacy-with-data scenario.
+  ///   - Account `tradesBrokerage` — "Trades brokerage", investment,
+  ///     AUD, `valuationMode = .calculatedFromTrades` and **no**
+  ///     `InvestmentValue` snapshots. Drives the
+  ///     "calculatedFromTrades + no snapshots → picker hidden" half of
+  ///     the same test pair.
+  ///   - Account `usd` — "USD Savings", bank, USD.
   ///   - Transaction `bhpPurchase` — trade on 2026-04-01 UTC, payee
   ///     "BHP Purchase". Two legs in the profile instrument: −5,000.00 AUD
   ///     from `checking` (expense) and +5,000.00 AUD into `brokerage`
@@ -133,23 +166,42 @@ public enum UITestFixtures {
   ///     occurs twice so it sorts strictly above single-occurrence payees
   ///     regardless of dictionary iteration order.
   public enum TradeBaseline {
-    public static let profileId = UUID(uuidString: "A1000000-0000-0000-0000-000000000001")!
+    public static let profileId = uuidLiteral("A1000000-0000-0000-0000-000000000001")
     public static let profileLabel = "Personal"
     public static let profileCurrencyCode = "AUD"
 
-    public static let checkingAccountId = UUID(uuidString: "A1000000-0000-0000-0000-000000000010")!
+    public static let checkingAccountId = uuidLiteral("A1000000-0000-0000-0000-000000000010")
     public static let checkingAccountName = "Checking"
 
-    public static let brokerageAccountId = UUID(uuidString: "A1000000-0000-0000-0000-000000000011")!
+    public static let brokerageAccountId = uuidLiteral("A1000000-0000-0000-0000-000000000011")
     public static let brokerageAccountName = "Brokerage"
 
     /// A USD-denominated account so the cross-currency test can switch a
     /// transfer's counterpart leg to a different instrument.
-    public static let usdAccountId = UUID(uuidString: "A1000000-0000-0000-0000-000000000012")!
+    public static let usdAccountId = uuidLiteral("A1000000-0000-0000-0000-000000000012")
     public static let usdAccountName = "USD Savings"
     public static let usdAccountInstrumentCode = "USD"
 
-    public static let bhpPurchaseId = UUID(uuidString: "A1000000-0000-0000-0000-000000000020")!
+    /// Investment account in `.calculatedFromTrades` mode with no
+    /// `InvestmentValue` snapshots. Drives the
+    /// "calculatedFromTrades + no snapshots → picker hidden" test in
+    /// `EditAccountValuationPickerTests`.
+    public static let tradesBrokerageAccountId =
+      uuidLiteral("A1000000-0000-0000-0000-000000000013")
+    public static let tradesBrokerageAccountName = "Trades brokerage"
+
+    /// One `InvestmentValue` snapshot for the existing `brokerage`
+    /// (recordedValue mode) account. Drives the "recordedValue + has
+    /// snapshot → picker shown" test in
+    /// `EditAccountValuationPickerTests`.
+    public static let brokerageSnapshotId =
+      uuidLiteral("A1000000-0000-0000-0000-000000000060")
+    public static let brokerageSnapshotCents = 1_234_500  // 12,345.00 AUD
+    /// 2026-04-15 00:00:00 UTC.
+    public static let brokerageSnapshotDate =
+      Date(timeIntervalSince1970: 1_776_211_200)
+
+    public static let bhpPurchaseId = uuidLiteral("A1000000-0000-0000-0000-000000000020")
     public static let bhpPurchasePayee = "BHP Purchase"
     public static let bhpPurchaseAmountCents = 500_000  // 5,000.00 AUD
     /// 2026-04-01 00:00:00 UTC.
@@ -170,10 +222,10 @@ public enum UITestFixtures {
     // Seeded flat — no parent hierarchy — because the test only asserts
     // dropdown visibility, not label formatting.
     public static let groceriesCategoryId =
-      UUID(uuidString: "A1000000-0000-0000-0000-000000000040")!
+      uuidLiteral("A1000000-0000-0000-0000-000000000040")
     public static let groceriesCategoryName = "Groceries"
     public static let gymCategoryId =
-      UUID(uuidString: "A1000000-0000-0000-0000-000000000041")!
+      uuidLiteral("A1000000-0000-0000-0000-000000000041")
     public static let gymCategoryName = "Gym"
 
     // MARK: - Custom (multi-leg) transaction
@@ -182,7 +234,7 @@ public enum UITestFixtures {
     // account so `Transaction.isSimple == false` → `TransactionDraft.isCustom
     // == true` → the detail view renders per-leg sections with category
     // autocomplete fields.
-    public static let splitShopId = UUID(uuidString: "A1000000-0000-0000-0000-000000000050")!
+    public static let splitShopId = uuidLiteral("A1000000-0000-0000-0000-000000000050")
     public static let splitShopPayee = "Split Shop"
     /// 2026-03-23 00:00:00 UTC — between the historical expenses and the
     /// BHP trade.
@@ -201,22 +253,22 @@ public enum UITestFixtures {
     /// the seed still exercises the common "no prior category" path.
     public static let historicalPayees: [UITestHistoricalExpense] = [
       UITestHistoricalExpense(
-        id: UUID(uuidString: "A1000000-0000-0000-0000-000000000030")!,
+        id: uuidLiteral("A1000000-0000-0000-0000-000000000030"),
         payee: "Coles",
         date: Date(timeIntervalSince1970: 1_772_668_800)  // 2026-03-05 UTC
       ),
       UITestHistoricalExpense(
-        id: UUID(uuidString: "A1000000-0000-0000-0000-000000000031")!,
+        id: uuidLiteral("A1000000-0000-0000-0000-000000000031"),
         payee: "Woolworths",
         date: Date(timeIntervalSince1970: 1_773_100_800)  // 2026-03-10 UTC
       ),
       UITestHistoricalExpense(
-        id: UUID(uuidString: "A1000000-0000-0000-0000-000000000032")!,
+        id: uuidLiteral("A1000000-0000-0000-0000-000000000032"),
         payee: "Woolworths Metro",
         date: Date(timeIntervalSince1970: 1_773_532_800)  // 2026-03-15 UTC
       ),
       UITestHistoricalExpense(
-        id: UUID(uuidString: "A1000000-0000-0000-0000-000000000033")!,
+        id: uuidLiteral("A1000000-0000-0000-0000-000000000033"),
         payee: "Woolworths",
         date: Date(timeIntervalSince1970: 1_773_964_800),  // 2026-03-20 UTC
         categoryId: groceriesCategoryId

--- a/plans/2026-05-05-restrict-valuation-picker-design.md
+++ b/plans/2026-05-05-restrict-valuation-picker-design.md
@@ -1,0 +1,491 @@
+# Restrict Edit Account valuation picker to legacy snapshot accounts
+
+**Status:** Design — pending implementation plan.
+**Owner:** Adrian.
+**Date:** 2026-05-05.
+
+## 1. Problem
+
+The Edit Account dialog (`EditAccountView`) currently shows a "Valuation"
+picker for **every** investment account, letting the user toggle between
+`recordedValue` (snapshot-driven) and `calculatedFromTrades` (positions ×
+current prices).
+
+`recordedValue` is a legacy mode kept alive for accounts created before
+trade-based valuation existed. New investment accounts always land in
+`calculatedFromTrades` (`AccountStore.create` enforces this). Showing
+the picker on accounts that have no `InvestmentValue` snapshot data
+gives users a feature they shouldn't be reaching for, and lets them
+silently flip into a mode that will display zero until they manually
+enter a snapshot.
+
+We want the picker to disappear for the post-migration default case
+("calculated, no snapshots") and remain available for genuine legacy
+accounts.
+
+## 2. Visibility rule
+
+The picker is shown iff **either** of these is true:
+
+1. `account.valuationMode == .recordedValue` — the account is currently
+   driven by snapshots; the user must be able to switch off.
+2. The account has at least one `InvestmentValue` row — the account has
+   legacy snapshot data on file, even if presently in
+   `.calculatedFromTrades` mode (e.g. user already toggled away but
+   hasn't deleted the data).
+
+When neither condition holds, the picker section is omitted from the
+form. The account stays in `.calculatedFromTrades` permanently from
+this dialog's point of view; clearing the last snapshot does not
+auto-flip the mode (avoids a jarring on-save mode change), and a
+trades-mode account with no snapshots cannot be flipped back from this
+dialog. That is the intended end state.
+
+## 3. Implementation
+
+### 3.1 Repository access via environment
+
+`EditAccountView` reads the `InvestmentRepository` from the existing
+`ProfileSession` environment value rather than via a constructor
+parameter:
+
+```swift
+struct EditAccountView: View {
+  @Environment(ProfileSession.self) private var session
+  // … existing fields …
+}
+```
+
+This matches the established pattern in `ImportSettingsView.swift:102,
+111`, which already reads `session.backend.csvImportProfiles` from the
+environment in production view code. The codebase has **no**
+`@Environment(BackendProvider.self)` consumers; `BackendProvider` is
+exposed via `ProfileSession.backend`. The `EditAccountView`
+constructor signature is unchanged.
+
+`AccountStore` is **not** the right home for the snapshot probe. It
+already owns an `InvestmentValueCache`, but that cache deliberately
+preloads only `.recordedValue` accounts (see
+`AccountStore.preloadInvestmentValues` at
+`Features/Accounts/AccountStore.swift:106-114`), so it cannot answer
+the rule-2 case (`.calculatedFromTrades` with snapshots) without
+changing its scope.
+
+### 3.2 Caller wiring (no change)
+
+`SidebarView` is the only call site. Because the dialog now reads the
+session from the environment, the existing call site:
+
+```swift
+.sheet(item: $accountToEdit) { account in
+  EditAccountView(account: account, accountStore: accountStore)
+}
+```
+
+is **unchanged**. SwiftUI's `.sheet` propagates the parent's
+`@Environment(ProfileSession.self)` into the sheet content
+automatically.
+
+### 3.3 Picker visibility state
+
+`EditAccountView` adds two `@State` flags:
+
+```swift
+@State private var showValuationPicker: Bool
+@State private var pickerShownDueToProbeFailure: Bool = false
+```
+
+`showValuationPicker` is initialised in `init` to
+`account.valuationMode == .recordedValue`.
+`pickerShownDueToProbeFailure` is `false` initially and only set
+`true` when the resolver returns via the fail-open branch (§3.5).
+
+The form runs an async `.task` (gated on `account.id` so it doesn't
+re-fire when local fields change) that delegates to a pure async
+resolver and assigns the result back to state. The `.task` body uses
+a typed `catch is CancellationError` so the invariant ("only
+cancellation reaches this catch") is compiler-checked, not just
+asserted in a comment:
+
+```swift
+.task(id: account.id) {
+  guard !showValuationPicker else { return }
+  do {
+    let result = try await Self.resolvePickerVisibility(
+      accountId: account.id,
+      snapshotProbe: {
+        try await session.backend.investments
+          .fetchValues(accountId: account.id, page: 0, pageSize: 1)
+          .values.isEmpty == false
+      })
+    switch result {
+    case .hidden:
+      showValuationPicker = false
+      pickerShownDueToProbeFailure = false
+    case .shown:
+      showValuationPicker = true
+      pickerShownDueToProbeFailure = false
+    case .shownAfterFailure:
+      showValuationPicker = true
+      pickerShownDueToProbeFailure = true
+    }
+  } catch is CancellationError {
+    // View is being dismissed or `account.id` changed; leave state
+    // unchanged so SwiftUI's teardown is clean. If the resolver
+    // ever starts throwing a non-cancellation error, the compiler
+    // will surface the unhandled case, forcing a decision rather
+    // than silently swallowing the error.
+  }
+}
+```
+
+The resolver is a `static` method on `EditAccountView` so it can be
+unit-tested without SwiftUI. It returns a closed-set `enum` so the
+`.task` body must handle every case exhaustively:
+
+```swift
+enum PickerVisibility: Equatable, Sendable {
+  case hidden
+  case shown
+  case shownAfterFailure
+}
+
+static func resolvePickerVisibility(
+  accountId: UUID,
+  snapshotProbe: () async throws -> Bool
+) async throws -> PickerVisibility {
+  do {
+    return try await snapshotProbe() ? .shown : .hidden
+  } catch let error as CancellationError {
+    // Re-propagate the original cancellation — the
+    // structured-concurrency contract requires callers see
+    // cancellation rather than a synthesised fallback value. The
+    // `.task` body catches it and leaves state unchanged.
+    throw error
+  } catch {
+    Self.logger.warning(
+      "valuation snapshot probe failed for \(accountId, privacy: .public): \(error.localizedDescription, privacy: .public)")
+    // Fail-open — see §3.5 Failure mode.
+    return .shownAfterFailure
+  }
+}
+```
+
+`accountId` is threaded through purely to populate the warning log
+line; the resolver does not use it for control-flow decisions (the
+probe closure has already closed over it at the call site). Documented
+explicitly so a future refactor doesn't drop it.
+
+`Self.logger` is `private static let logger = Logger(subsystem: "com.moolah.app", category: "EditAccountView")` declared on the type. The static placement is required so the `static func resolvePickerVisibility` can reach it via `Self.logger` without an instance. Both placements exist in the codebase (`private static let` on the type — `InvestmentAccountView.swift:16-17`; file-scope `private let` — `ImportSettingsView.swift:5`, `InvestmentValueCache.swift:21`) and either is acceptable; the choice here is dictated by the static-method call site, not by `View`-vs-non-`View` convention.
+
+**Visibility outcomes:**
+
+| State | Initial `showValuationPicker` | Resolver result | `pickerShownDueToProbeFailure` | Footer note |
+|------ |--------- |------------- |--------------- |--------------- |
+| `.recordedValue` (any snapshots) | true | not called (guarded) | false | normal |
+| `.calculatedFromTrades`, no snapshots | false | `.hidden` | false | section absent |
+| `.calculatedFromTrades`, has snapshots | false | `.shown` | false | normal |
+| `.calculatedFromTrades`, probe fails | false | `.shownAfterFailure` | true | fail-open hint (§3.4) |
+| `.calculatedFromTrades`, probe cancelled | false | throws (state unchanged) | false | section absent |
+
+The `valuationSection` already checks `if type == .investment`; the new
+guard combines them: `if type == .investment && showValuationPicker`.
+
+### 3.4 Form section gating
+
+The two pieces of mode-dependent text (the `.accessibilityHint` and
+the section footer) move out of the view into a `ValuationMode`
+extension so they can be read from a model layer and reused:
+
+```swift
+extension ValuationMode {
+  /// Short, sentence-fragment description of where this mode's
+  /// balance comes from. Used as a VoiceOver `.accessibilityHint`
+  /// in the Edit Account picker; reusable wherever a brief one-line
+  /// description of the mode's data source is needed.
+  var dataSourceHint: String {
+    switch self {
+    case .recordedValue:
+      return "Balance comes from the value you last recorded"
+    case .calculatedFromTrades:
+      return
+        "Balance is calculated from your trade history and current prices of your holdings"
+    }
+  }
+
+  /// Full-sentence description of the mode's data source, with
+  /// terminating period. Used as the Edit Account picker's section
+  /// footer; reusable as descriptive copy elsewhere.
+  var dataSourceDescription: String {
+    switch self {
+    case .recordedValue:
+      return "The balance comes from the value you last recorded manually."
+    case .calculatedFromTrades:
+      return
+        "The balance is calculated from your trade history and the current prices of your holdings."
+    }
+  }
+}
+```
+
+Per CLAUDE.md "Thin Views, Testable Stores" — display strings derived
+from a domain enum belong on the model, not as private view
+computeds, so they can be unit-tested and reused by other views (e.g.
+`InvestmentAccountView` if it ever needs to mirror the same labels).
+
+`valuationSection` becomes:
+
+```swift
+@ViewBuilder private var valuationSection: some View {
+  if type == .investment, showValuationPicker {
+    Section {
+      Picker("Valuation", selection: $valuationMode) {
+        Text("Recorded value").tag(ValuationMode.recordedValue)
+        Text("Calculated from trades")
+          .tag(ValuationMode.calculatedFromTrades)
+      }
+      .accessibilityIdentifier("editAccount.valuationMode")
+      .accessibilityHint(valuationMode.dataSourceHint)
+    } footer: {
+      VStack(alignment: .leading, spacing: 4) {
+        Text(valuationMode.dataSourceDescription)
+        if pickerShownDueToProbeFailure {
+          Label(
+            "Couldn't confirm your valuation history. Reopen the dialog to check again.",
+            systemImage: "info.circle"
+          )
+          .foregroundStyle(.secondary)
+        }
+      }
+    }
+  }
+}
+```
+
+The fail-open hint uses `Label(_:systemImage:)` so the symbol gives
+VoiceOver and sighted users a semantic cue ("this is a notice, not
+the primary description") and the text inherits the section footer's
+existing typographic style without a manual `.font(.footnote)`
+override (which would double-shrink the line on top of the footer's
+already-secondary style — bad at large Dynamic Type sizes).
+
+The fail-open hint appears **only** when the section was revealed
+because the probe failed (`pickerShownDueToProbeFailure == true`).
+Voice matches BRAND_GUIDE "Calm, helpful, no alarm" — no
+exclamation, no "error", suggests a recovery action.
+
+**On layout stability:** when the `.task` resolver returns
+`.shownAfterFailure`, both `showValuationPicker` and
+`pickerShownDueToProbeFailure` flip in the same render pass, so the
+section appears with its hint already attached. Because the `.task`
+fires once on dialog open and completes before the user can
+realistically reach the footer, the layout growth is not
+user-observable and no `withAnimation(.none)` suppression is needed.
+Documented here so a future change doesn't try to animate the
+appearance and reintroduce flicker.
+
+### 3.5 Failure mode
+
+If `fetchValues` throws a non-cancellation error (transient I/O, db
+contention, profile teardown), the resolver **fails open** and reveals
+the picker. Rationale:
+
+- `.recordedValue` accounts already see it — unaffected (the `guard`
+  short-circuits before the probe).
+- `.calculatedFromTrades` accounts with snapshots see the picker —
+  preserves the user's ability to flip back to recordedValue mode,
+  which is the whole point of rule 2 in §2.
+- `.calculatedFromTrades` accounts **without** snapshots see the
+  picker briefly. Mildly off-spec (the user sees an option we'd
+  ordinarily hide), but recoverable on next open and never traps the
+  user. Picker default selection is still
+  `.calculatedFromTrades`, so no accidental mode flip occurs unless
+  the user explicitly chooses one.
+
+The error is logged at `warning` level. No user-facing error surface
+— the picker's appearance is the recovery path. `CancellationError`
+is treated separately (silent, no log) since it represents normal
+view-dismissal lifecycle, not a real failure.
+
+### 3.6 Accessibility
+
+The Section appears (rather than disappears), which means VoiceOver
+will read it when the user navigates past the existing fields. The
+existing `.accessibilityHint` on the picker reads either:
+
+- "Balance comes from the value you last recorded" (when
+  `valuationMode == .recordedValue`), or
+- "Balance is calculated from your trade history and current prices
+  of your holdings" (when `valuationMode == .calculatedFromTrades`).
+
+Both adequately describe the modes for VoiceOver users. No additional
+`.accessibilityElement` or live-region announcement is needed. The
+common case (`.recordedValue`) shows the picker before the user has
+time to tab into the form, so no in-flight reveal is announced.
+
+The "post-probe additive reveal" case (`.calculatedFromTrades` with
+snapshots, or fail-open) is the only path where VoiceOver focus could
+already be past the section's logical position when it appears.
+Acceptable: the user is editing fields, not auditing the section
+list, and the section's controls are reachable on the next pass
+through the form. The fail-open footer note (§3.4) is plain `Text`
+and is read in document order along with the rest of the section.
+Documented here so future changes don't accidentally rely on mid-edit
+announcement.
+
+## 4. Out-of-scope
+
+- **`AccountStore.create` behaviour.** Already promotes `.recordedValue`
+  → `.calculatedFromTrades` for new investment accounts. No change.
+- **Migration (`ValuationModeMigration`).** Already flips
+  snapshot-less investment accounts to `.calculatedFromTrades`. No
+  change.
+- **`InvestmentAccountView`** (the snapshot editor). Visibility there
+  is driven by `account.valuationMode`, not by this dialog. Unchanged.
+- **Auto-clearing snapshots when mode flips.** Out of scope; the
+  user explicitly preferred *not* to couple the two so the dialog
+  doesn't surprise them on save.
+
+## 5. Tests
+
+### 5.1 Existing coverage
+
+- `MoolahTests/Features/AccountStoreUpdateValuationTests` pins the save
+  flow used by the picker. Unchanged — still valid because the save
+  path itself is unchanged.
+
+### 5.2 New unit coverage (mandatory)
+
+The visibility resolver `EditAccountView.resolvePickerVisibility` is a
+pure async function over a closure-typed probe — directly unit-testable
+without SwiftUI. The project uses Swift Testing (`@Suite`, `@Test`,
+`#expect`, `#require`); see `AccountStoreUpdateValuationTests.swift`
+for the canonical shape. New file
+`MoolahTests/Features/EditAccountVisibilityTests.swift` with one test
+per branch:
+
+1. `probeReturnsTrue_returnsShown` — probe yields `true` (snapshots
+   exist) → resolver returns `.shown`.
+2. `probeReturnsFalse_returnsHidden` — probe yields `false` (no
+   snapshots) → resolver returns `.hidden`.
+3. `probeThrowsGenericError_returnsShownAfterFailure` — probe throws
+   `BackendError.notFound(...)` → resolver returns
+   `.shownAfterFailure` (fail-open).
+4. `probeThrowsCancellationError_propagates` — probe throws
+   `CancellationError` → resolver re-throws the original
+   `CancellationError`. Verified via
+   `await #expect(throws: CancellationError.self) { try await … }`.
+
+A small additional pair of tests pins the `ValuationMode` extension
+introduced in §3.4:
+
+5. `dataSourceHint_returnsExpectedString` — exact-string assertion
+   for both modes' `.dataSourceHint`.
+6. `dataSourceDescription_returnsExpectedString` — exact-string
+   assertion for both modes' `.dataSourceDescription`.
+
+Lives in `MoolahTests/Domain/ValuationModeDisplayTextTests.swift`
+(model-layer test, not feature-layer).
+
+The `.recordedValue` short-circuit lives outside the resolver (it's
+the `.task` body's `guard`), and is a one-line read of an
+`@State` flag, so it does not need its own test — it is exercised in
+the Preview audits in §5.3.
+
+The probe-construction step inside the `.task` body
+(`session.backend.investments.fetchValues(...).values.isEmpty == false`)
+is exercised by the existing `InvestmentRepository` contract tests in
+`MoolahTests/Domain/`; no new contract test required.
+
+### 5.3 Preview audits (visual)
+
+Add two new `#Preview` configurations to make the visibility branching
+reviewable in canvas:
+
+- "Investment account, no snapshots" → backend has no `InvestmentValue`
+  rows for the account; picker stays hidden.
+- "Investment account, calculatedFromTrades with snapshots" → seed one
+  `InvestmentValue` via `backend.investments.setValue(accountId:date:value:)`
+  before constructing the view (using the existing `async`-wrapped
+  preview pattern in `InvestmentAccountView+Previews.swift`); the
+  `.task` probe then reveals the picker.
+
+Existing previews "Bank account" and "Investment account
+(calculatedFromTrades)" remain. Constructors are unchanged because
+the new `InvestmentRepository` is read from the environment, not from
+a constructor parameter; previews already inject `ProfileSession` /
+`PreviewBackend` via `.environment(...)`.
+
+**Canvas limitation:** the seeded preview shows the picker as already
+revealed (probe completes before the snapshot is captured). The
+`hidden → visible` transition itself is **not** exercised by either
+preview — there is no animation we need to verify, but a future
+reviewer should be aware that the canvas captures the post-probe
+steady state, not the in-flight transition.
+
+### 5.4 UI test (mandatory, in-scope)
+
+A UI test exercises the visibility rule end-to-end and is part of the
+implementation plan rather than deferred:
+
+1. Seed: investment account with `valuationMode = .recordedValue` and
+   one `InvestmentValue` snapshot. Open Edit. Picker present.
+2. Seed: investment account with `valuationMode = .calculatedFromTrades`
+   and zero snapshots. Open Edit. Picker absent.
+
+**Prerequisite work** (one implementation stage of its own — see the
+forthcoming implementation plan):
+
+- Extend `UITestSeed` with an `investmentValues` collection of
+  `(accountId, date, instrument, cents)` tuples.
+- Hydrate via `InvestmentRepository.setValue(accountId:date:value:)`
+  in `UITestSeedHydrator+Upserts.swift`.
+- Add an `EditAccountScreen` driver (or extend an existing one)
+  exposing the dialog open/inspect operations needed by the test.
+
+The fail-open path (probe failure) is **not** UI-tested — it requires
+fault injection that the project's UI test surface does not support.
+The unit tests in §5.2 cover that branch.
+
+## 6. Risks & considerations
+
+- **Per-keystroke async work.** The `.task(id: account.id)` block
+  fires once per dialog open and never on field edits because the id
+  is stable across the dialog's lifetime. Confirmed by reading
+  `EditAccountView`'s state ownership.
+- **Repository availability under previews.** `PreviewBackend.create()`
+  returns a backend whose `investments` is functional against
+  in-memory storage. The previews already inject `ProfileSession` via
+  the environment; no preview signature changes.
+- **Locked picker for a hybrid account whose probe fails on first
+  open.** Documented in §3.5. Reopening retries.
+
+## 7. Acceptance criteria
+
+1. New investment account (created via Create Account dialog) opens in
+   Edit Account with **no** Valuation section.
+2. Legacy investment account in `recordedValue` mode opens with the
+   Valuation section visible; picker preselected to "Recorded value".
+3. Investment account in `calculatedFromTrades` mode that has at least
+   one `InvestmentValue` row opens with the Valuation section visible
+   after a brief async probe.
+4. Investment account in `calculatedFromTrades` mode with zero
+   `InvestmentValue` rows opens — and stays — without the Valuation
+   section under normal (probe-success) conditions.
+5. On probe failure, the Valuation section reveals (fail-open) **and**
+   a footnote-styled secondary text reads "Couldn't confirm your
+   valuation history. Reopen the dialog to check again." so the user
+   has a clear signal the section appeared due to a transient error.
+   Default selection is still `.calculatedFromTrades`, so no
+   accidental mode flip occurs.
+6. Bank/credit-card/asset accounts continue to show no Valuation
+   section (unchanged from current behaviour).
+7. Save / Cancel paths and field validation are unchanged.
+8. `AccountStoreUpdateValuationTests` still passes.
+9. New `EditAccountVisibilityTests` covers all four resolver
+   branches in §5.2 (returns `.shown` / `.hidden` /
+   `.shownAfterFailure`; re-throws `CancellationError`).
+10. New UI test exercises the two visibility outcomes (rule-1 and
+    rule-2-negative) with the seeded investment-account dataset
+    described in §5.4.
+11. `just format-check` clean; no new SwiftLint baseline entries.

--- a/plans/2026-05-05-restrict-valuation-picker-implementation-plan.md
+++ b/plans/2026-05-05-restrict-valuation-picker-implementation-plan.md
@@ -1,0 +1,542 @@
+# Implementation plan — restrict Edit Account valuation picker
+
+**Companion to:** `plans/2026-05-05-restrict-valuation-picker-design.md`.
+**Date:** 2026-05-05.
+**Owner:** Adrian.
+
+## How to read this plan
+
+The work is split into five independent or sequenced stages. Each
+stage is small enough to land as a single PR (or a single commit on a
+combined branch), and each ends with reviewer-verifiable acceptance
+criteria so progress is checkable without running the app.
+
+Dependency graph:
+
+```
+Stage 1 (Model text)        ────┐
+                                 ├──▶ Stage 3 (View wiring)
+Stage 2 (Resolver + tests)  ────┘                            ╲
+                                                              ▶  Stage 5 (UI test)
+Stage 4 (UI test seed surface)  ─────────────────────────────╱
+```
+
+Stages 1, 2, 4 are independent and can run in any order. Stage 3
+requires Stages 1 and 2. Stage 5 requires Stages 3 and 4.
+
+Per repo convention, all production work happens in a worktree
+(`CLAUDE.md` Git Workflow). Each stage lives on its own feature branch
+unless explicitly bundled.
+
+## Pre-flight (every stage)
+
+Before opening a PR for any stage:
+
+1. `just format` (apply swift-format + SwiftLint --fix).
+2. `just format-check` clean (CI gate).
+3. `just test` clean.
+4. `mcp__xcode__XcodeListNavigatorIssues` shows no warnings in user code (project has `SWIFT_TREAT_WARNINGS_AS_ERRORS: YES`).
+5. No diff to `.swiftlint-baseline.yml`.
+
+---
+
+## Stage 1 — `ValuationMode` display-text extension
+
+**Branch:** `feat/valuation-mode-display-text`.
+**Depends on:** nothing.
+
+### Files
+
+- **New:** `Domain/Models/ValuationMode+DisplayText.swift` — extension
+  with `dataSourceHint: String` and `dataSourceDescription: String`.
+  Per CLAUDE.md "one extension per protocol/topic" file convention.
+- **New:** `MoolahTests/Domain/ValuationModeDisplayTextTests.swift` —
+  Swift Testing `@Suite` with two `@Test` methods,
+  `dataSourceHint_returnsExpectedString` and
+  `dataSourceDescription_returnsExpectedString`.
+
+### Implementation
+
+Verbatim per design §3.4 — use the exact strings from the existing
+`EditAccountView.swift:104-114` so the move is behaviour-preserving.
+Doc comments per design §3.4.
+
+### Acceptance criteria
+
+- Both new computed properties exist on `ValuationMode` and return
+  the strings quoted in design §3.6 / §3.4.
+- Both unit tests pass against `swift test` and `just test`.
+- No production call site changes yet — Stage 3 will wire the view.
+- Pre-flight checklist clean.
+
+### Reviewers
+
+- `code-review` — model naming, doc comments, file location, test
+  shape per `TEST_GUIDE.md`.
+
+---
+
+## Stage 2 — `EditAccountView.resolvePickerVisibility` resolver + tests
+
+**Branch:** `feat/edit-account-picker-visibility-resolver`.
+**Depends on:** nothing (does not yet wire into the view body).
+
+### Files
+
+- **Modified:** `Features/Accounts/Views/EditAccountView.swift` —
+  add the static `PickerVisibility` enum and the static
+  `resolvePickerVisibility(accountId:snapshotProbe:)` method per
+  design §3.3. Add `private static let logger = Logger(...)`. Do
+  **not** yet add the `@State` flags or the `.task` modifier —
+  Stage 3 wires those.
+- **New:** `MoolahTests/Features/EditAccountVisibilityTests.swift` —
+  Swift Testing `@Suite` with the four resolver tests per design
+  §5.2 (cases 1–4).
+
+### Implementation order (TDD — strict)
+
+CLAUDE.md "Testing & TDD" rule: write the test file before the
+implementation file. Concretely:
+
+1. Create `EditAccountVisibilityTests.swift` with all four `@Test`
+   methods. Bodies reference `EditAccountView.resolvePickerVisibility`
+   and `PickerVisibility` types that don't exist yet → the test file
+   fails to compile.
+2. Add `enum PickerVisibility { … }` and the `static func
+   resolvePickerVisibility(...)` body in `EditAccountView.swift`,
+   stubbed to `fatalError("unimplemented")` (or returning `.hidden`)
+   so compilation succeeds and the four tests fail at runtime.
+3. Run `just test EditAccountVisibilityTests` (or the equivalent)
+   and confirm four red tests.
+4. Implement the resolver per design §3.3.
+5. Run again — four green tests.
+
+The resolver and `PickerVisibility` enum are nested inside
+`EditAccountView` (private to the type, since they have no consumer
+outside it). `WelcomeHero.swift` is the precedent for two
+private-nested types in a single SwiftUI `View`; SwiftLint's
+`nesting type_level: 1` rule allows it (the rule limits depth,
+not count, of nested types).
+
+Test bodies pass closure literals as the `snapshotProbe`, no
+`TestBackend` needed (the resolver only sees the closure):
+
+```swift
+@Test("probeReturnsTrue → .shown")
+func probeReturnsTrue_returnsShown() async throws {
+  let result = try await EditAccountView.resolvePickerVisibility(
+    accountId: UUID(), snapshotProbe: { true })
+  #expect(result == .shown)
+}
+```
+
+### Acceptance criteria
+
+- `EditAccountView.resolvePickerVisibility` and `PickerVisibility`
+  compile and are reachable from the test target (project's existing
+  `@testable import Moolah` path).
+- All four resolver tests pass — verified by `just test
+  EditAccountVisibilityTests`.
+- Test 3 (`probeThrowsGenericError_returnsShownAfterFailure`)
+  passing implicitly proves the `Self.logger.warning(...)` call site
+  is reachable, since the warning branch and the `return
+  .shownAfterFailure` are in the same `catch` block. No separate
+  logger-emission verification required.
+- Pre-flight checklist clean.
+
+### Reviewers
+
+- `code-review` — resolver naming, enum shape, error handling,
+  thin-view discipline.
+- `concurrency-review` — actor isolation of the static method,
+  cancellation propagation, `Sendable` on `PickerVisibility`.
+
+---
+
+## Stage 3 — Wire visibility into the Edit Account form
+
+**Branch:** `feat/edit-account-picker-visibility-wiring`.
+**Depends on:** Stages 1 and 2.
+
+### Files
+
+- **Modified:** `Features/Accounts/Views/EditAccountView.swift` —
+  - Add `@Environment(ProfileSession.self) private var session`.
+  - Add `@State private var showValuationPicker: Bool` (initialised
+    in `init` to `account.valuationMode == .recordedValue`).
+  - Add `@State private var pickerShownDueToProbeFailure: Bool = false`.
+  - Replace `valuationSection`'s inline strings with
+    `valuationMode.dataSourceHint` and
+    `valuationMode.dataSourceDescription` (from Stage 1).
+  - Replace inline footer `Text` with the `VStack { Text(…); if …
+    Label(…) }` pattern per design §3.4.
+  - Add `.task(id: account.id)` body per design §3.3 (guard +
+    do/catch with typed `catch is CancellationError`).
+  - Update `valuationSection` guard to `if type == .investment,
+    showValuationPicker`.
+  - Add two new `#Preview` configs per design §5.3 ("no snapshots"
+    and "calculatedFromTrades with snapshots"). Existing previews
+    unchanged in their bodies but adjust for any environment glue if
+    needed.
+- **Unchanged (verify):** `Features/Navigation/SidebarView.swift` —
+  no call-site changes; `.sheet` propagates ProfileSession from the
+  parent environment automatically.
+
+### Implementation
+
+Per design §3.3 + §3.4. Key invariants:
+
+- `.task(id: account.id)` not `.task` — must be id-keyed so it
+  doesn't re-fire on field edits.
+- The `.task` closure must capture `session.backend.investments` via
+  the closure passed to the resolver, not via a stored property —
+  the resolver receives only the closure, keeping it pure.
+- The `switch` in the `.task` body must be exhaustive (the compiler
+  enforces this — no `default:` clause).
+
+**File-organisation note.** After this stage,
+`EditAccountView.swift` will be ~300 lines (existing ~170 + ~30 new
+state/env + ~30 new `valuationSection` + ~50 new previews +
+`PickerVisibility` enum + resolver from Stage 2). At or above 300
+lines, `CODE_GUIDE.md` §2 requires `// MARK: - <Section>` headers.
+Add at minimum: `// MARK: - State`, `// MARK: - Body`, `// MARK: -
+Sections`, `// MARK: - Picker visibility`, `// MARK: - Save`. Adjust
+to match what the file naturally divides into.
+
+**Third preview (`shownAfterFailure` state).** In addition to the
+two previews from design §5.3 ("no snapshots", "calculatedFromTrades
+with snapshots"), add a third preview that renders the fail-open
+`Label` so its layout, symbol, and copy are visually verified.
+
+**Approach:** a wrapper-view declared **inside** the `#Preview`
+block, not a debug initializer on `EditAccountView`. The wrapper
+imitates only the slice of `EditAccountView` we need to inspect —
+the conditional footer `Label` — without forking the production
+view's initialiser surface or compiling preview-only code into
+release builds:
+
+```swift
+#Preview("Investment account, fail-open footer") {
+  struct FailOpenPreview: View {
+    var body: some View {
+      Form {
+        Section {
+          Picker("Valuation", selection: .constant(ValuationMode.calculatedFromTrades)) {
+            Text("Recorded value").tag(ValuationMode.recordedValue)
+            Text("Calculated from trades").tag(ValuationMode.calculatedFromTrades)
+          }
+        } footer: {
+          VStack(alignment: .leading, spacing: 4) {
+            Text(ValuationMode.calculatedFromTrades.dataSourceDescription)
+            Label(
+              "Couldn't confirm your valuation history. Reopen the dialog to check again.",
+              systemImage: "info.circle"
+            )
+            .foregroundStyle(.secondary)
+          }
+        }
+      }
+      .formStyle(.grouped)
+    }
+  }
+  return FailOpenPreview()
+}
+```
+
+This keeps the production `init` unchanged, avoids `#if DEBUG` API
+pollution per CODE_GUIDE.md §10 ("custom init only to maintain
+invariants"), and matches the precedent in `WelcomeHero.swift` for
+state-pinned previews. The dialog-level coverage of fail-open
+(initial → revealed) is left to the unit test
+`probeThrowsGenericError_returnsShownAfterFailure` from Stage 2 plus
+the manual exercise via `.task` in dev — visual fidelity of the
+`Label` is what this preview pins.
+
+### Acceptance criteria
+
+Verifiable by manual smoke + previews + retained tests:
+
+- All design-spec acceptance criteria §7.1–§7.8 pass:
+  1. (§7.1) New investment account → no Valuation section.
+  2. (§7.2) `.recordedValue` legacy account → section visible, picker
+     on "Recorded value".
+  3. (§7.3) `.calculatedFromTrades` with snapshots → section reveals
+     after probe. *Verified via the "calculatedFromTrades with
+     snapshots" preview from design §5.3 — the seeded preview shows
+     the post-probe steady state.*
+  4. (§7.4) `.calculatedFromTrades` without snapshots → section
+     absent.
+  5. (§7.5) Probe failure → section + fail-open `Label`. *Verified
+     via the third preview defined above.*
+  6. (§7.6) Bank/credit-card/asset → no Valuation section.
+  7. (§7.7) Save / Cancel paths unchanged.
+  8. (§7.8) `AccountStoreUpdateValuationTests` passes.
+- All three new previews render in canvas without runtime errors on
+  **both macOS and iOS** simulator/device targets. The project
+  targets iOS 26+ and macOS 26+; verify both.
+- The third preview renders the fail-open `Label` without clipping
+  or wrapping at `.dynamicTypeSize(.accessibility3)` — the project's
+  Dynamic Type ceiling per `guides/UI_GUIDE.md` line 109
+  (`.dynamicTypeSize(.medium...(.accessibility3))`). Pin via a
+  `.dynamicTypeSize(_:)` modifier on a `#Preview` variant or via
+  Xcode's preview-canvas accessibility-size toggle.
+- VoiceOver hint duplication is verified in Stage 5's UI test
+  (`testRecordedValueLegacyAccountShowsValuationPicker` asserts the
+  picker's accessibility hint matches `valuationMode.dataSourceHint`
+  exactly and that no other element in the dialog exposes the same
+  hint string). Manual VoiceOver verification is therefore not part
+  of Stage 3's AC — automation in Stage 5 catches regressions in
+  CI.
+- Pre-flight checklist clean.
+- No new compiler warnings.
+
+### Reviewers
+
+- `code-review` — view-body naming, exhaustive switch, env usage,
+  thin-view discipline (logic delegated to Stage-1 model and Stage-2
+  resolver).
+- `ui-review` — fail-open Label pattern, footer VStack stability,
+  preview audits, accessibility.
+- `concurrency-review` — `.task(id:)` lifecycle, cancellation catch,
+  closure capture of `session`.
+
+---
+
+## Stage 4 — UI test seed surface for `InvestmentValue`
+
+**Branch:** `feat/uitest-seed-investment-value`.
+**Depends on:** nothing (purely additive; no other stages need it
+until Stage 5).
+
+### Files
+
+- **Modified:** `UITestSupport/UITestSeed.swift` — extend the seed
+  payload with an `investmentValues: [InvestmentValueSeed]` field.
+  Define a new **named struct** (not a tuple, not a typealias over
+  a tuple — explicitly):
+
+  ```swift
+  public struct InvestmentValueSeed: Codable, Sendable {
+    public let accountId: UUID
+    public let date: Date
+    public let instrumentId: String
+    public let cents: Int
+  }
+  ```
+
+  All `date` values **must** be constructed as
+  `Date(timeIntervalSince1970: …)` literals with a UTC-comment
+  suffix (matching the existing seed convention at
+  `UITestSeed.swift:206-221`). `Date()` is banned because it breaks
+  the diffability of `seed.txt` artefacts run-to-run.
+
+- **Modified:** `App/UITestSeedHydrator+Upserts.swift` — add a new
+  static helper `upsertInvestmentValue(_:in:)` following the exact
+  shape of the existing synchronous `upsertAccount`,
+  `upsertCategory`, etc. (lines 73–141). The helper takes the seed
+  struct + a `Database` and inserts via `InvestmentValueRow.upsert`.
+  No `async`, no `Task` — `UITestSeedHydrator.hydrate(...)` itself
+  is `static func ... throws`, not async, and runs entirely inside
+  a `database.write { … }` block during synchronous app init. The
+  earlier draft of this plan said "iterate inside the existing
+  `Task`" — that was wrong; there is no `Task`.
+
+- **Modified:** `App/UITestSeedHydrator.swift` — add an iteration
+  loop in `hydrateTradeBaseline` (and any other seed scenario that
+  needs investment values) that calls
+  `upsertInvestmentValue(seed, in: database)` for each
+  `InvestmentValueSeed`. Order: after `upsertAccount` calls (the
+  pre-FK-removed schema cascade was on `account.id`; we're past
+  v5_drop_foreign_keys but the logical dependency stands — accounts
+  must exist before their values).
+
+- **Modified:** `UITestSupport/UITestSeed.swift` — extend the
+  `tradeBaseline` seed (or whichever scenario Stage 5 elects) with
+  the two `InvestmentValueSeed` fixtures used by the UI tests.
+
+### Implementation
+
+Use the existing synchronous pattern (`UITestSeedHydrator+Upserts.swift`
+already exposes `upsertAccount`, `upsertCategory`,
+`upsertHistoricalExpense`, etc., all `static func ... throws` taking
+a `Database`). The new `upsertInvestmentValue` is the same shape:
+
+```swift
+static func upsertInvestmentValue(
+  _ spec: InvestmentValueSeed, in database: Database
+) throws {
+  let row = InvestmentValueRow(
+    id: ..., // deterministic UUID derived from accountId+date or
+             // explicit per-seed UUID literal
+    accountId: spec.accountId,
+    date: spec.date,
+    instrumentId: spec.instrumentId,
+    cents: spec.cents,
+    encodedSystemFields: nil)
+  try row.upsert(database)
+}
+```
+
+Concrete UUID-derivation strategy — explicit `UUID(uuidString:
+"...")!` literal per seed entry, declared alongside other seed
+fixtures (mirrors `UITestFixtures.TradeBaseline.bhpPurchaseDate`
+pattern at `UITestSeed.swift:156`). Force-unwrap is acceptable in
+test-only code.
+
+### Acceptance criteria
+
+- Existing UI tests still pass (`just test` includes UI tests on
+  macOS).
+- Manual local verification: launch the app under `--ui-testing`
+  with a seed scenario that includes investment values, then
+  inspect OSLog. `InvestmentValueCache.preload(...)` runs at
+  AccountStore.load and is observable via the
+  `Logger(subsystem: "com.moolah.app", category:
+  "InvestmentValueCache")` subsystem — a non-zero
+  `cache.values.count` after preload confirms hydration.
+- This verification is **local only** — do not commit a smoke-test
+  file. The criterion's purpose is to catch hydration bugs before
+  Stage 5 depends on the seed data.
+- Pre-flight checklist clean.
+
+### Reviewers
+
+- `code-review` — seed struct naming, hydrator placement,
+  concurrency of the hydration loop.
+- `ui-test-review` — seed identifier discipline, deterministic
+  fields (no `Date()` literals — use seeded fixed dates).
+
+---
+
+## Stage 5 — UI test for visibility outcomes
+
+**Branch:** `feat/edit-account-picker-visibility-uitest`.
+**Depends on:** Stages 3 and 4.
+
+### Files
+
+- **New:** `MoolahUITests_macOS/Helpers/Screens/EditAccountScreen.swift`
+  — no existing screen driver owns the Edit Account dialog
+  (verified via `MoolahUITests_macOS/Helpers/Screens/` listing —
+  there is `CreateAccountScreen.swift` for the create-flow
+  but no edit-flow driver). New file, mirrors
+  `CreateAccountScreen.swift` structure (`@MainActor`, `let app:
+  MoolahApp`, `Trace.record(#function)` at the top of every action,
+  post-condition `waitForExistence(timeout: 3)` before returning).
+
+  Surface:
+
+  ```swift
+  @MainActor
+  struct EditAccountScreen {
+    let app: MoolahApp
+
+    /// Opens the Edit Account dialog for the named account from
+    /// the sidebar's context menu (or whichever path the app uses).
+    /// Returns once the dialog's name field is visible — this is
+    /// the presence sentinel required by UI_TEST_GUIDE §7.
+    func open(accountName: String) { … }
+
+    /// Presence sentinel for cases where the test opens the dialog
+    /// via a different path. Asserts the dialog is on screen.
+    func expectVisible() { … }
+
+    /// Asserts the Valuation section is present in the dialog.
+    /// Looks up the picker by `editAccount.valuationMode` identifier
+    /// and waits up to 3s.
+    func expectValuationSectionVisible() { … }
+
+    /// Asserts the Valuation section is **not** present after
+    /// `expectVisible()` has confirmed the dialog rendered. Uses
+    /// the existence-then-absence pattern (wait for a known-present
+    /// element first, then assert the picker identifier resolves
+    /// to no element).
+    func expectValuationSectionAbsent() { … }
+
+    /// Asserts the picker's currently-selected mode equals
+    /// `expected`. UI_TEST_GUIDE §3 forbids drivers from returning
+    /// raw values to tests; expectations live in the driver. Reads
+    /// the picker via the existing `editAccount.valuationMode`
+    /// identifier.
+    func expectValuationMode(_ expected: ValuationMode) { … }
+
+    /// Asserts the picker's `accessibilityHint` equals
+    /// `mode.dataSourceHint` exactly. Used by the recordedValue
+    /// test to pin the VoiceOver string and detect duplicate-hint
+    /// regressions.
+    func expectAccessibilityHint(for mode: ValuationMode) { … }
+
+    /// Closes the dialog via the Cancel button.
+    func cancel() { … }
+  }
+  ```
+
+  Key invariants (UI_TEST_GUIDE §7):
+  - **Presence sentinel.** `open(...)` AND `expectVisible()` BOTH
+    wait for the dialog's name field to materialise — otherwise an
+    `expectValuationSectionAbsent()` call could pass vacuously
+    because the sheet never opened.
+  - **No element caching** — every accessor resolves through
+    `app.element(for:)`.
+  - **Trace logs.** Every action method begins with
+    `Trace.record(#function, detail: "...")`.
+
+- **New:** `MoolahUITests_macOS/Tests/EditAccountValuationPickerTests.swift`
+  with two tests using `MoolahUITestCase`:
+  - `testRecordedValueLegacyAccountShowsValuationPicker` — seed an
+    account in `.recordedValue` mode with one `InvestmentValue`,
+    open Edit, `expectValuationSectionVisible()`,
+    `expectValuationMode(.recordedValue)`,
+    `expectAccessibilityHint(for: .recordedValue)`, `cancel()`.
+  - `testCalculatedFromTradesAccountWithNoSnapshotsHidesValuationPicker`
+    — seed an account in `.calculatedFromTrades` mode with zero
+    `InvestmentValue` rows, open Edit, `expectVisible()`
+    (presence sentinel), `expectValuationSectionAbsent()`,
+    `cancel()`.
+
+  Project convention is `testCamelCase` (per
+  `MoolahUITests_macOS/Tests/WelcomeViewTests.swift` and
+  `TradeFlowUITests.swift`). The `test` prefix is required for
+  `XCTestCase` discovery; underscores are not used.
+
+### Implementation
+
+Per design §5.4. Use the seed payload defined in Stage 4 to set up
+each scenario. Driver follows the project's existing screen-driver
+conventions (post-condition waits, single resolver, no element
+caching, no sleeps — see `guides/UI_TEST_GUIDE.md`).
+
+The accessibility identifier `"editAccount.valuationMode"` already
+exists on the picker (verified at
+`Features/Accounts/Views/EditAccountView.swift:103`); add a constant
+for it in `UITestIdentifiers.swift` if not already present (Stage 5
+must check and either add or reuse). Define a new
+`UITestIdentifiers.EditAccount.dialog` for the dialog presence
+sentinel; pin it via an `.accessibilityIdentifier(...)` modifier on
+the form's outermost container. This is part of Stage 5's deliverable.
+
+### Acceptance criteria
+
+- Both UI tests pass on macOS via `just test
+  EditAccountValuationPickerTests` (or `just test-mac`).
+- 20 consecutive runs of the new tests locally without flakes
+  (UI_TEST_GUIDE §10 checklist).
+- Acceptance criterion §7.10 from the design spec is now satisfied.
+- Pre-flight checklist clean.
+
+### Reviewers
+
+- `ui-test-review` — driver invariants, identifier discipline,
+  deterministic seeds, no element caching, no sleeps.
+- `ui-review` — accessibility identifier on the picker section is
+  preserved/exposed.
+
+---
+
+## Out-of-stage cleanup
+
+- After all five stages land, delete this plan and the design from
+  `plans/` and move them to `plans/completed/`. Project convention
+  per CLAUDE.md "Plans Directory."
+- Open follow-up issue(s) only if any reviewer surfaces a deferral
+  during execution (none expected).


### PR DESCRIPTION
## Summary

Hides the Valuation picker in the Edit Account dialog for investment
accounts that don't have legacy `InvestmentValue` snapshot data and
aren't currently in `.recordedValue` mode. New trade-driven accounts
therefore never see an option that exists only for legacy data.

The picker shows iff:

1. `account.valuationMode == .recordedValue` (the user must be able
   to switch off), **or**
2. The account has at least one `InvestmentValue` snapshot row (so a
   user who's already toggled to `.calculatedFromTrades` but kept
   their snapshot data can still flip back).

On probe failure the resolver fails open and surfaces an
`info.circle` `Label` in the section footer ("Couldn't confirm your
valuation history. Reopen the dialog to check again.") so a legacy
user with snapshots is never trapped.

Design: `plans/2026-05-05-restrict-valuation-picker-design.md`
Implementation plan: `plans/2026-05-05-restrict-valuation-picker-implementation-plan.md`

## What landed

- **Stage 1** — `ValuationMode.dataSourceHint` / `.dataSourceDescription` model extensions.
- **Stage 2** — `EditAccountView.resolvePickerVisibility(...)` static resolver + 4 unit tests covering the four branches.
- **Stage 3** — `.task(id: account.id)` wiring + `info.circle` fail-open footer + 5 previews verified in canvas.
- **Stage 4** — `UITestSeed` extension: `UITestInvestmentValueSeed`, `tradesBrokerage` fixture, snapshot for the legacy brokerage account.
- **Stage 5** — `EditAccountScreen` driver + 3 macOS UI tests (visibility shown / hidden / mode preselected).

## Test plan

- [x] `just format-check` clean
- [x] `just test-mac` clean
- [x] `just test-ui EditAccountValuationPickerTests` — 3/3 pass on macOS
- [x] All 5 `#Preview`s render correctly in canvas
- [ ] CI passes
- [ ] PR enters merge queue

🤖 Generated with [Claude Code](https://claude.com/claude-code)