### PR TITLE
feat(conversion): discriminated price/conversion result for unpriced vs unavailable

### DIFF
--- a/App/ProfileSession+CloudKitBackendBuild.swift
+++ b/App/ProfileSession+CloudKitBackendBuild.swift
@@ -42,8 +42,8 @@ extension ProfileSession {
       exchangeRates: marketData.exchangeRates,
       stockPrices: marketData.stockPrices,
       cryptoPrices: marketData.cryptoPrices,
-      providerMappings: {
-        try await registry.allCryptoRegistrations().map(\.mapping)
+      cryptoRegistrations: {
+        try await registry.allCryptoRegistrations()
       }
     )
     let hooks = grdbRepoHooks(zoneID: zoneID, syncCoordinator: syncCoordinator)

--- a/Backends/CloudKit/Sync/ProfileGRDBRepositories.swift
+++ b/Backends/CloudKit/Sync/ProfileGRDBRepositories.swift
@@ -89,4 +89,15 @@ private struct ApplyPathConversionService: InstrumentConversionService {
     throw ConversionError.unsupportedConversion(
       from: amount.instrument.id, to: instrument.id)
   }
+
+  func convertResult(
+    _ amount: InstrumentAmount,
+    to instrument: Instrument,
+    on date: Date
+  ) async throws -> ConversionResult {
+    throw ConversionError.unsupportedConversion(
+      from: amount.instrument.id, to: instrument.id)
+  }
+
+  func invalidateCache(for instrument: Instrument) async {}
 }

--- a/Domain/Models/ConversionResult.swift
+++ b/Domain/Models/ConversionResult.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+/// Discriminated conversion result. `.value` carries the successful
+/// conversion; `.knownZero` indicates an intentionally-zero contribution
+/// (e.g. the source instrument is an `.unpriced` or `.spam` crypto token).
+/// A real failure throws — never collapses to `.knownZero`.
+///
+/// Required by aggregation paths that need to keep "intentional zero"
+/// distinct from "rate unavailable" per
+/// `guides/INSTRUMENT_CONVERSION_GUIDE.md` Rule 11.
+enum ConversionResult: Sendable, Equatable {
+  /// A converted amount in the caller-supplied target instrument.
+  case value(InstrumentAmount)
+  /// The source's registration resolved to `.knownZero` (the token is
+  /// `.unpriced` or `.spam`); the contribution to any total is exactly
+  /// zero in `targetInstrument`. The caller can fold this in as a
+  /// `.zero(instrument: targetInstrument)` cleanly.
+  case knownZero(targetInstrument: Instrument)
+}

--- a/Domain/Models/CryptoPriceLookup.swift
+++ b/Domain/Models/CryptoPriceLookup.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+/// Discriminated price-lookup result. `.unpriced` and `.spam` registrations
+/// resolve to `.knownZero`; provider failure for a `.priced` registration
+/// continues to `throw` — distinguishable from `.knownZero` everywhere.
+///
+/// Per `guides/INSTRUMENT_CONVERSION_GUIDE.md` Rule 11: an intentional
+/// zero (the user has marked the token unpriced or spam) must stay
+/// distinct from a real provider failure ("rate unavailable") at every
+/// aggregation surface, so we never substitute `0` for an unavailable
+/// rate or surface a thrown error as zero.
+enum CryptoPriceLookup: Sendable, Equatable {
+  /// Real provider rate (USD-denominated for the existing
+  /// `CryptoPriceService.price(for:mapping:on:)` path).
+  case priced(Decimal)
+  /// The source registration is `.unpriced` or `.spam`; its fiat value
+  /// is intentionally zero. No provider call was made.
+  case knownZero
+}

--- a/Domain/Services/InstrumentConversionService.swift
+++ b/Domain/Services/InstrumentConversionService.swift
@@ -17,6 +17,28 @@ protocol InstrumentConversionService: Sendable {
     to instrument: Instrument,
     on date: Date
   ) async throws -> InstrumentAmount
+
+  /// Discriminated convert. Returns `.knownZero(targetInstrument: to)`
+  /// when the source instrument's provider mapping resolves to a
+  /// `.knownZero` price (e.g. `.unpriced` or `.spam` crypto token).
+  /// Returns `.value` on real conversions. Throws on provider failure —
+  /// never collapses failure to `.knownZero`.
+  ///
+  /// Required for any aggregation path that needs to keep "intentional
+  /// zero" distinct from "rate unavailable" per
+  /// `guides/INSTRUMENT_CONVERSION_GUIDE.md` Rule 11.
+  func convertResult(
+    _ amount: InstrumentAmount,
+    to instrument: Instrument,
+    on date: Date
+  ) async throws -> ConversionResult
+
+  /// Invalidate any cached state held about `instrument` (and any rate
+  /// derived from it). Called when a user mutation changes
+  /// `pricingStatus` for a crypto registration so the next aggregation
+  /// reads fresh data. No-op for fiat instruments and for
+  /// implementations that don't cache.
+  func invalidateCache(for instrument: Instrument) async
 }
 
 enum ConversionError: Error, Equatable {

--- a/MoolahTests/Domain/ConversionResultTests.swift
+++ b/MoolahTests/Domain/ConversionResultTests.swift
@@ -1,0 +1,40 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("ConversionResult")
+struct ConversionResultTests {
+  private let usd = Instrument.USD
+  private let aud = Instrument.AUD
+
+  @Test
+  func valueEqualityIsValueBased() {
+    let lhs = ConversionResult.value(InstrumentAmount(quantity: dec("10"), instrument: usd))
+    let rhs = ConversionResult.value(InstrumentAmount(quantity: dec("10"), instrument: usd))
+    #expect(lhs == rhs)
+
+    let differentQuantity = ConversionResult.value(
+      InstrumentAmount(quantity: dec("11"), instrument: usd))
+    #expect(lhs != differentQuantity)
+
+    let differentInstrument = ConversionResult.value(
+      InstrumentAmount(quantity: dec("10"), instrument: aud))
+    #expect(lhs != differentInstrument)
+  }
+
+  @Test
+  func knownZeroEqualityKeysOnTargetInstrument() {
+    #expect(ConversionResult.knownZero(targetInstrument: usd) == .knownZero(targetInstrument: usd))
+    #expect(ConversionResult.knownZero(targetInstrument: usd) != .knownZero(targetInstrument: aud))
+  }
+
+  /// The whole point of the discriminated type: a `.value(...)` whose
+  /// quantity happens to be zero must remain distinguishable from an
+  /// intentional `.knownZero(...)`.
+  @Test
+  func valueZeroDoesNotEqualKnownZero() {
+    let zeroValue = ConversionResult.value(.zero(instrument: usd))
+    #expect(zeroValue != .knownZero(targetInstrument: usd))
+  }
+}

--- a/MoolahTests/Domain/CryptoPriceLookupTests.swift
+++ b/MoolahTests/Domain/CryptoPriceLookupTests.swift
@@ -1,0 +1,48 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("CryptoPriceLookup")
+struct CryptoPriceLookupTests {
+  @Test
+  func pricedEqualityIsValueBased() {
+    #expect(CryptoPriceLookup.priced(dec("123.45")) == .priced(dec("123.45")))
+    #expect(CryptoPriceLookup.priced(dec("123.45")) != .priced(dec("123.46")))
+  }
+
+  @Test
+  func knownZeroEqualsKnownZero() {
+    #expect(CryptoPriceLookup.knownZero == .knownZero)
+  }
+
+  @Test
+  func pricedDoesNotEqualKnownZero() {
+    // The whole point of the discriminated type: a `.priced(0)` (which
+    // could plausibly happen if a provider reported 0) must remain
+    // distinguishable from an intentional `.knownZero`.
+    #expect(CryptoPriceLookup.priced(.zero) != .knownZero)
+  }
+
+  /// `Sendable` conformance is checked by the compiler; this test is a
+  /// runtime smoke that the value can be sent across an actor hop without
+  /// requiring `@unchecked` annotations or losing equality.
+  @Test
+  func sendableRoundTripPreservesValue() async {
+    let actor = LookupBox()
+    let cases: [CryptoPriceLookup] = [.priced(dec("0.001")), .knownZero]
+    for value in cases {
+      await actor.set(value)
+      let echoed = await actor.value
+      #expect(echoed == value)
+    }
+  }
+}
+
+private actor LookupBox {
+  var value: CryptoPriceLookup = .knownZero
+
+  func set(_ value: CryptoPriceLookup) {
+    self.value = value
+  }
+}

--- a/MoolahTests/Shared/CapitalGainsCalculatorTestsMoreExtra.swift
+++ b/MoolahTests/Shared/CapitalGainsCalculatorTestsMoreExtra.swift
@@ -95,6 +95,15 @@ struct CapitalGainsCalculatorTestsMoreExtra {
       return InstrumentAmount(quantity: converted, instrument: instrument)
     }
 
+    func convertResult(
+      _ amount: InstrumentAmount, to instrument: Instrument, on date: Date
+    ) async throws -> ConversionResult {
+      let converted = try await convertAmount(amount, to: instrument, on: date)
+      return .value(converted)
+    }
+
+    func invalidateCache(for instrument: Instrument) async {}
+
     func recordedCalls() -> [(from: String, quantity: Decimal)] { calls }
   }
 

--- a/MoolahTests/Shared/ConvertCacheInvalidationTests.swift
+++ b/MoolahTests/Shared/ConvertCacheInvalidationTests.swift
@@ -1,0 +1,176 @@
+import Foundation
+import GRDB
+import Testing
+import os
+
+@testable import Moolah
+
+@Suite("FullConversionService.invalidateCache")
+struct ConvertCacheInvalidationTests {
+  private let eth = Instrument.crypto(
+    chainId: 1, contractAddress: nil, symbol: "ETH", name: "Ethereum", decimals: 18
+  )
+  private let usd = Instrument.USD
+
+  private func date(_ string: String) throws -> Date {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withFullDate]
+    return try #require(formatter.date(from: string))
+  }
+
+  private func ethRegistration() -> CryptoRegistration {
+    CryptoRegistration(
+      instrument: eth,
+      mapping: CryptoProviderMapping(
+        instrumentId: "1:native", coingeckoId: "ethereum",
+        cryptocompareSymbol: "ETH", binanceSymbol: "ETHUSDT"
+      )
+    )
+  }
+
+  /// Invalidating a crypto instrument must purge the underlying
+  /// `CryptoPriceService` cache for that instrument so the next
+  /// conversion goes back to the network. Verified by toggling a
+  /// `Toggleable` price client between "available" and "fail": once the
+  /// cache is cleared, the next conversion observes the fail and throws.
+  @Test
+  func invalidateCacheForCryptoInstrumentForcesRefetch() async throws {
+    let toggle = ToggleableCryptoPriceClient()
+    await toggle.setPrices(["1:native": ["2026-04-10": dec("1623.45")]])
+
+    let database = try ProfileDatabase.openInMemory()
+    let cryptoService = CryptoPriceService(
+      clients: [toggle], database: database)
+    let exchangeService = ExchangeRateService(
+      client: FixedRateClient(rates: [:]), database: database)
+    let stockService = StockPriceService(client: FixedStockPriceClient(), database: database)
+    let registration = ethRegistration()
+    let service = FullConversionService(
+      exchangeRates: exchangeService,
+      stockPrices: stockService,
+      cryptoPrices: cryptoService,
+      cryptoRegistrations: { [registration] }
+    )
+
+    // First conversion populates the cache.
+    let first = try await service.convert(
+      Decimal(1), from: eth, to: usd, on: try date("2026-04-10"))
+    #expect(first == dec("1623.45"))
+
+    // Force the underlying client to throw on subsequent calls. With
+    // the cache still warm, the next conversion still succeeds.
+    await toggle.setShouldFail(true)
+    let second = try await service.convert(
+      Decimal(1), from: eth, to: usd, on: try date("2026-04-10"))
+    #expect(second == dec("1623.45"))
+
+    // Invalidate the cache for this instrument — the next conversion
+    // must round-trip through the (now-failing) client and surface the
+    // error.
+    await service.invalidateCache(for: eth)
+    await #expect(throws: (any Error).self) {
+      _ = try await service.convert(
+        Decimal(1), from: eth, to: usd, on: try date("2026-04-10"))
+    }
+  }
+
+  /// Fiat invalidation is a documented no-op — the rate cache for fiat
+  /// pairs lives in `ExchangeRateService` and is keyed differently. The
+  /// call must complete without trapping or throwing and must not
+  /// affect any subsequent crypto conversion.
+  @Test
+  func invalidateCacheForFiatInstrumentIsNoOp() async throws {
+    let database = try ProfileDatabase.openInMemory()
+    let cryptoService = CryptoPriceService(
+      clients: [FixedCryptoPriceClient(prices: ["1:native": ["2026-04-10": dec("1623.45")]])],
+      database: database)
+    let exchangeService = ExchangeRateService(
+      client: FixedRateClient(rates: [:]), database: database)
+    let stockService = StockPriceService(client: FixedStockPriceClient(), database: database)
+    let service = FullConversionService(
+      exchangeRates: exchangeService,
+      stockPrices: stockService,
+      cryptoPrices: cryptoService,
+      cryptoRegistrations: { [self.ethRegistration()] }
+    )
+
+    // Warm the crypto cache.
+    let first = try await service.convert(
+      Decimal(1), from: eth, to: usd, on: try date("2026-04-10"))
+    #expect(first == dec("1623.45"))
+
+    // Invalidate USD (fiat) — must be a no-op so the next crypto
+    // conversion still hits the warm crypto cache.
+    await service.invalidateCache(for: usd)
+
+    let second = try await service.convert(
+      Decimal(1), from: eth, to: usd, on: try date("2026-04-10"))
+    #expect(second == dec("1623.45"))
+  }
+}
+
+// MARK: - Toggleable client
+
+/// Test double whose responses can be flipped at runtime. Backed by an
+/// `actor` so concurrent reads / writes from the conversion-service
+/// pipeline stay race-free without any `@unchecked Sendable` waiver.
+actor ToggleableCryptoPriceClient: CryptoPriceClient {
+  private var prices: [String: [String: Decimal]] = [:]
+  private var shouldFail: Bool = false
+
+  func setPrices(_ prices: [String: [String: Decimal]]) {
+    self.prices = prices
+  }
+
+  func setShouldFail(_ value: Bool) {
+    self.shouldFail = value
+  }
+
+  func dailyPrice(for mapping: CryptoProviderMapping, on date: Date) async throws -> Decimal {
+    if shouldFail { throw URLError(.notConnectedToInternet) }
+    let dateString = Self.dateFormatter.string(from: date)
+    guard let price = prices[mapping.instrumentId]?[dateString] else {
+      throw CryptoPriceError.noPriceAvailable(tokenId: mapping.instrumentId, date: dateString)
+    }
+    return price
+  }
+
+  func dailyPrices(
+    for mapping: CryptoProviderMapping, in range: ClosedRange<Date>
+  ) async throws -> [String: Decimal] {
+    if shouldFail { throw URLError(.notConnectedToInternet) }
+    guard let tokenPrices = prices[mapping.instrumentId] else { return [:] }
+
+    let calendar = Calendar(identifier: .gregorian)
+    var filtered: [String: Decimal] = [:]
+    var current = range.lowerBound
+    while current <= range.upperBound {
+      let key = Self.dateFormatter.string(from: current)
+      if let price = tokenPrices[key] {
+        filtered[key] = price
+      }
+      guard let next = calendar.date(byAdding: .day, value: 1, to: current) else { break }
+      current = next
+    }
+    return filtered
+  }
+
+  func currentPrices(for mappings: [CryptoProviderMapping]) async throws -> [String: Decimal] {
+    if shouldFail { throw URLError(.notConnectedToInternet) }
+    var result: [String: Decimal] = [:]
+    for mapping in mappings {
+      if let tokenPrices = prices[mapping.instrumentId],
+        let latest = tokenPrices.keys.max()
+      {
+        result[mapping.instrumentId] = tokenPrices[latest]
+      }
+    }
+    return result
+  }
+
+  nonisolated(unsafe) private static let dateFormatter: ISO8601DateFormatter = {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withFullDate]
+    return formatter
+  }()
+}

--- a/MoolahTests/Shared/CryptoPriceServicePriceLookupTests.swift
+++ b/MoolahTests/Shared/CryptoPriceServicePriceLookupTests.swift
@@ -1,0 +1,88 @@
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+@Suite("CryptoPriceService.priceLookup")
+struct CryptoPriceServicePriceLookupTests {
+  private let ethInstrument = Instrument.crypto(
+    chainId: 1, contractAddress: nil, symbol: "ETH", name: "Ethereum", decimals: 18
+  )
+  private let ethMapping = CryptoProviderMapping(
+    instrumentId: "1:native", coingeckoId: "ethereum",
+    cryptocompareSymbol: "ETH", binanceSymbol: "ETHUSDT"
+  )
+
+  private func date(_ string: String) throws -> Date {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withFullDate]
+    return try #require(formatter.date(from: string))
+  }
+
+  private func makeService(
+    prices: [String: [String: Decimal]] = [:],
+    shouldFail: Bool = false
+  ) throws -> CryptoPriceService {
+    let database = try ProfileDatabase.openInMemory()
+    return CryptoPriceService(
+      clients: [FixedCryptoPriceClient(prices: prices, shouldFail: shouldFail)],
+      database: database
+    )
+  }
+
+  @Test
+  func pricedRegistrationProducesPriced() async throws {
+    let service = try makeService(
+      prices: ["1:native": ["2026-04-10": dec("1623.45")]]
+    )
+    let registration = CryptoRegistration(
+      instrument: ethInstrument, mapping: ethMapping, pricingStatus: .priced)
+
+    let lookup = try await service.priceLookup(for: registration, on: try date("2026-04-10"))
+
+    #expect(lookup == .priced(dec("1623.45")))
+  }
+
+  /// `.unpriced` must short-circuit to `.knownZero` *before* the provider
+  /// is consulted — wiring `shouldFail = true` would throw if the call
+  /// reached the underlying client. The lookup path must never depend on
+  /// network availability for an `.unpriced` token.
+  @Test
+  func unpricedRegistrationReturnsKnownZeroWithoutInvokingProvider() async throws {
+    let service = try makeService(prices: [:], shouldFail: true)
+    let registration = CryptoRegistration(
+      instrument: ethInstrument, mapping: ethMapping, pricingStatus: .unpriced)
+
+    let lookup = try await service.priceLookup(for: registration, on: try date("2026-04-10"))
+
+    #expect(lookup == .knownZero)
+  }
+
+  /// `.spam` behaves identically to `.unpriced` at the lookup layer —
+  /// the provider must not be consulted, no error must surface.
+  @Test
+  func spamRegistrationReturnsKnownZeroWithoutInvokingProvider() async throws {
+    let service = try makeService(prices: [:], shouldFail: true)
+    let registration = CryptoRegistration(
+      instrument: ethInstrument, mapping: ethMapping, pricingStatus: .spam)
+
+    let lookup = try await service.priceLookup(for: registration, on: try date("2026-04-10"))
+
+    #expect(lookup == .knownZero)
+  }
+
+  /// Provider failure on a `.priced` registration must propagate as a
+  /// thrown error — never collapse to `.knownZero`. This is the
+  /// load-bearing distinction Stage 2 introduces.
+  @Test
+  func pricedRegistrationProviderFailureThrows() async throws {
+    let service = try makeService(prices: [:], shouldFail: true)
+    let registration = CryptoRegistration(
+      instrument: ethInstrument, mapping: ethMapping, pricingStatus: .priced)
+
+    await #expect(throws: (any Error).self) {
+      _ = try await service.priceLookup(for: registration, on: try date("2026-04-10"))
+    }
+  }
+}

--- a/MoolahTests/Shared/FiatConversionServiceConvertResultTests.swift
+++ b/MoolahTests/Shared/FiatConversionServiceConvertResultTests.swift
@@ -1,0 +1,58 @@
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+@Suite("FiatConversionService.convertResult")
+struct FiatConversionServiceConvertResultTests {
+  private let usd = Instrument.USD
+  private let aud = Instrument.AUD
+
+  private func date(_ string: String) throws -> Date {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withFullDate]
+    return try #require(formatter.date(from: string))
+  }
+
+  private func makeService(
+    rates: [String: [String: Decimal]] = [:]
+  ) throws -> FiatConversionService {
+    let database = try ProfileDatabase.openInMemory()
+    let exchangeService = ExchangeRateService(
+      client: FixedRateClient(rates: rates), database: database)
+    return FiatConversionService(exchangeRates: exchangeService)
+  }
+
+  /// Fiat-to-fiat goes through the standard `convertAmount` path and
+  /// returns `.value(...)` — fiat has no `.knownZero` concept (every
+  /// `.fiatCurrency` instrument has a real rate).
+  @Test
+  func fiatToFiatProducesValue() async throws {
+    let service = try makeService(
+      rates: ["2026-04-10": ["AUD": dec("1.58")]]
+    )
+    let amount = InstrumentAmount(quantity: dec("100"), instrument: usd)
+
+    let result = try await service.convertResult(
+      amount, to: aud, on: try date("2026-04-10"))
+
+    #expect(result == .value(InstrumentAmount(quantity: dec("100") * dec("1.58"), instrument: aud)))
+  }
+
+  /// A non-fiat source must throw `unsupportedInstrumentKind` from the
+  /// underlying `convert` — the discriminated method mirrors the
+  /// throwing contract of `convertAmount` for unsupported pairs and
+  /// must never collapse an unsupported pair to `.knownZero`.
+  @Test
+  func nonFiatSourceThrowsUnsupportedInstrumentKind() async throws {
+    let service = try makeService()
+    let eth = Instrument.crypto(
+      chainId: 1, contractAddress: nil, symbol: "ETH", name: "Ethereum", decimals: 18)
+    let amount = InstrumentAmount(quantity: dec("1"), instrument: eth)
+
+    await #expect(throws: ConversionError.unsupportedInstrumentKind) {
+      _ = try await service.convertResult(amount, to: usd, on: try date("2026-04-10"))
+    }
+  }
+}

--- a/MoolahTests/Shared/FullConversionErrorPropagationTests.swift
+++ b/MoolahTests/Shared/FullConversionErrorPropagationTests.swift
@@ -8,11 +8,12 @@ import Testing
 struct FullConversionErrorPropagationTests {
   struct FakeRegistryError: Error {}
 
-  /// When the `providerMappings` closure throws (e.g. registry read failure),
-  /// the error must propagate through `convert(_:from:to:on:)` for a crypto
-  /// conversion rather than being silently collapsed to an empty mapping
-  /// table — which would masquerade as a spurious `noProviderMapping` error
-  /// and violate Rule 11 of `guides/INSTRUMENT_CONVERSION_GUIDE.md`.
+  /// When the `cryptoRegistrations` closure throws (e.g. registry read
+  /// failure), the error must propagate through `convert(_:from:to:on:)` for a
+  /// crypto conversion rather than being silently collapsed to an empty
+  /// mapping table — which would masquerade as a spurious
+  /// `noProviderMapping` error and violate Rule 11 of
+  /// `guides/INSTRUMENT_CONVERSION_GUIDE.md`.
   @Test
   func cryptoConversionPropagatesRegistryError() async throws {
     let database = try ProfileDatabase.openInMemory()
@@ -30,7 +31,7 @@ struct FullConversionErrorPropagationTests {
       exchangeRates: exchangeService,
       stockPrices: stockService,
       cryptoPrices: cryptoService,
-      providerMappings: { () async throws -> [CryptoProviderMapping] in
+      cryptoRegistrations: { () async throws -> [CryptoRegistration] in
         throw FakeRegistryError()
       }
     )

--- a/MoolahTests/Shared/FullConversionServiceConvertResultTests.swift
+++ b/MoolahTests/Shared/FullConversionServiceConvertResultTests.swift
@@ -1,0 +1,174 @@
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+@Suite("FullConversionService.convertResult")
+struct FullConversionServiceConvertResultTests {
+  private let eth = Instrument.crypto(
+    chainId: 1, contractAddress: nil, symbol: "ETH", name: "Ethereum", decimals: 18
+  )
+  private let usd = Instrument.USD
+  private let aud = Instrument.AUD
+
+  private func date(_ string: String) throws -> Date {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withFullDate]
+    return try #require(formatter.date(from: string))
+  }
+
+  private struct Bundle {
+    let service: FullConversionService
+  }
+
+  /// Build a service whose `cryptoRegistrations` closure returns the
+  /// supplied list. The closure shape on `FullConversionService` carries
+  /// `pricingStatus` per registration so `convertResult` can dispatch
+  /// `.priced` / `.knownZero` correctly.
+  private func makeService(
+    cryptoPrices: [String: [String: Decimal]] = [:],
+    exchangeRates: [String: [String: Decimal]] = [:],
+    shouldFail: Bool = false,
+    registrations: [CryptoRegistration] = []
+  ) throws -> Bundle {
+    let database = try ProfileDatabase.openInMemory()
+    let cryptoService = CryptoPriceService(
+      clients: [FixedCryptoPriceClient(prices: cryptoPrices, shouldFail: shouldFail)],
+      database: database
+    )
+    let exchangeService = ExchangeRateService(
+      client: FixedRateClient(rates: exchangeRates),
+      database: database
+    )
+    let stockService = StockPriceService(client: FixedStockPriceClient(), database: database)
+    let service = FullConversionService(
+      exchangeRates: exchangeService,
+      stockPrices: stockService,
+      cryptoPrices: cryptoService,
+      cryptoRegistrations: { registrations }
+    )
+    return Bundle(service: service)
+  }
+
+  private func ethRegistration(status: TokenPricingStatus) -> CryptoRegistration {
+    CryptoRegistration(
+      instrument: eth,
+      mapping: CryptoProviderMapping(
+        instrumentId: "1:native", coingeckoId: "ethereum",
+        cryptocompareSymbol: "ETH", binanceSymbol: "ETHUSDT"
+      ),
+      pricingStatus: status
+    )
+  }
+
+  // MARK: - .priced source -> .value
+
+  @Test
+  func pricedCryptoSourceProducesValue() async throws {
+    let bundle = try makeService(
+      cryptoPrices: ["1:native": ["2026-04-10": dec("1623.45")]],
+      registrations: [ethRegistration(status: .priced)]
+    )
+    let amount = InstrumentAmount(quantity: dec("2.5"), instrument: eth)
+
+    let result = try await bundle.service.convertResult(
+      amount, to: usd, on: try date("2026-04-10"))
+
+    #expect(
+      result == .value(InstrumentAmount(quantity: dec("2.5") * dec("1623.45"), instrument: usd)))
+  }
+
+  // MARK: - .unpriced source -> .knownZero(target)
+
+  /// `.unpriced` must short-circuit to `.knownZero(targetInstrument: to)`
+  /// without consulting the underlying price provider — `shouldFail =
+  /// true` would throw if the call reached the client.
+  @Test
+  func unpricedCryptoSourceProducesKnownZeroAndSkipsProvider() async throws {
+    let bundle = try makeService(
+      cryptoPrices: [:],
+      shouldFail: true,
+      registrations: [ethRegistration(status: .unpriced)]
+    )
+    let amount = InstrumentAmount(quantity: dec("2.5"), instrument: eth)
+
+    let result = try await bundle.service.convertResult(
+      amount, to: usd, on: try date("2026-04-10"))
+
+    #expect(result == .knownZero(targetInstrument: usd))
+  }
+
+  // MARK: - .spam source -> .knownZero(target)
+
+  @Test
+  func spamCryptoSourceProducesKnownZeroAndSkipsProvider() async throws {
+    let bundle = try makeService(
+      cryptoPrices: [:],
+      shouldFail: true,
+      registrations: [ethRegistration(status: .spam)]
+    )
+    let amount = InstrumentAmount(quantity: dec("100"), instrument: eth)
+
+    let result = try await bundle.service.convertResult(
+      amount, to: aud, on: try date("2026-04-10"))
+
+    #expect(result == .knownZero(targetInstrument: aud))
+  }
+
+  // MARK: - .priced source, provider fails -> throws (never .knownZero)
+
+  /// Per `INSTRUMENT_CONVERSION_GUIDE.md` Rule 11 — a real provider
+  /// failure for a `.priced` registration must throw, never collapse to
+  /// `.knownZero`. This is the load-bearing distinction `convertResult`
+  /// adds.
+  @Test
+  func pricedSourceProviderFailureThrowsAndDoesNotReturnKnownZero() async throws {
+    let bundle = try makeService(
+      cryptoPrices: [:],
+      shouldFail: true,
+      registrations: [ethRegistration(status: .priced)]
+    )
+    let amount = InstrumentAmount(quantity: dec("1"), instrument: eth)
+
+    await #expect(throws: (any Error).self) {
+      _ = try await bundle.service.convertResult(amount, to: usd, on: try date("2026-04-10"))
+    }
+  }
+
+  // MARK: - Same-instrument identity fast path
+
+  /// `.unpriced` source converted to itself must NOT collapse to
+  /// `.knownZero`: the position list still renders the native quantity
+  /// of an `.unpriced` token (the token's fiat aggregation contribution
+  /// is zero — its native quantity is its native quantity).
+  @Test
+  func unpricedSourceConvertedToSameInstrumentReturnsValue() async throws {
+    let bundle = try makeService(
+      cryptoPrices: [:],
+      shouldFail: true,
+      registrations: [ethRegistration(status: .unpriced)]
+    )
+    let amount = InstrumentAmount(quantity: dec("2.5"), instrument: eth)
+
+    let result = try await bundle.service.convertResult(
+      amount, to: eth, on: try date("2026-04-10"))
+
+    #expect(result == .value(amount))
+  }
+
+  // MARK: - Fiat source -> .value (no .knownZero concept)
+
+  @Test
+  func fiatSourceProducesValue() async throws {
+    let bundle = try makeService(
+      exchangeRates: ["2026-04-10": ["AUD": dec("1.58")]]
+    )
+    let amount = InstrumentAmount(quantity: dec("100"), instrument: usd)
+
+    let result = try await bundle.service.convertResult(
+      amount, to: aud, on: try date("2026-04-10"))
+
+    #expect(result == .value(InstrumentAmount(quantity: dec("100") * dec("1.58"), instrument: aud)))
+  }
+}

--- a/MoolahTests/Shared/InstrumentConversionServiceCryptoTests.swift
+++ b/MoolahTests/Shared/InstrumentConversionServiceCryptoTests.swift
@@ -38,11 +38,34 @@ struct InstrumentConversionServiceCryptoTests {
       database: database
     )
     let stockService = StockPriceService(client: FixedStockPriceClient(), database: database)
+    let registrations = providerMappings.map { mapping in
+      CryptoRegistration(
+        instrument: Self.instrument(forMappingId: mapping.instrumentId),
+        mapping: mapping)
+    }
     return FullConversionService(
       exchangeRates: exchangeService,
       stockPrices: stockService,
       cryptoPrices: cryptoService,
-      providerMappings: { providerMappings }
+      cryptoRegistrations: { registrations }
+    )
+  }
+
+  /// Reconstruct an `Instrument` from a `CryptoProviderMapping.instrumentId`
+  /// of the form `"chainId:contractOrNative"`. Test fixtures only need
+  /// enough metadata for the registration's `id` to match what the
+  /// service is looking up; any other fields are best-effort.
+  private static func instrument(forMappingId id: String) -> Instrument {
+    let parts = id.split(separator: ":", maxSplits: 1).map(String.init)
+    let chainId = Int(parts.first ?? "") ?? 0
+    let contract = parts.count > 1 ? parts[1] : "native"
+    let isNative = contract == "native"
+    return .crypto(
+      chainId: chainId,
+      contractAddress: isNative ? nil : contract,
+      symbol: isNative ? "NATIVE" : contract,
+      name: isNative ? "NATIVE" : contract,
+      decimals: 18
     )
   }
 
@@ -226,13 +249,13 @@ struct InstrumentConversionServiceCryptoTests {
       database: database
     )
     let stockService = StockPriceService(client: FixedStockPriceClient(), database: database)
-    let source = MutableMappingsSource()
+    let source = MutableRegistrationsSource()
 
     let service = FullConversionService(
       exchangeRates: exchangeService,
       stockPrices: stockService,
       cryptoPrices: cryptoService,
-      providerMappings: { await source.current() }
+      cryptoRegistrations: { await source.current() }
     )
 
     await #expect(throws: (any Error).self) {
@@ -240,9 +263,12 @@ struct InstrumentConversionServiceCryptoTests {
     }
 
     await source.set([
-      CryptoProviderMapping(
-        instrumentId: "1:native", coingeckoId: "ethereum",
-        cryptocompareSymbol: "ETH", binanceSymbol: "ETHUSDT"
+      CryptoRegistration(
+        instrument: eth,
+        mapping: CryptoProviderMapping(
+          instrumentId: "1:native", coingeckoId: "ethereum",
+          cryptocompareSymbol: "ETH", binanceSymbol: "ETHUSDT"
+        )
       )
     ])
 
@@ -253,10 +279,10 @@ struct InstrumentConversionServiceCryptoTests {
   }
 }
 
-private actor MutableMappingsSource {
-  private var mappings: [CryptoProviderMapping] = []
+private actor MutableRegistrationsSource {
+  private var registrations: [CryptoRegistration] = []
 
-  func current() -> [CryptoProviderMapping] { mappings }
+  func current() -> [CryptoRegistration] { registrations }
 
-  func set(_ new: [CryptoProviderMapping]) { mappings = new }
+  func set(_ new: [CryptoRegistration]) { registrations = new }
 }

--- a/MoolahTests/Support/CountingConversionService.swift
+++ b/MoolahTests/Support/CountingConversionService.swift
@@ -32,4 +32,13 @@ actor CountingConversionService: InstrumentConversionService {
     )
     return InstrumentAmount(quantity: converted, instrument: instrument)
   }
+
+  func convertResult(
+    _ amount: InstrumentAmount, to instrument: Instrument, on date: Date
+  ) async throws -> ConversionResult {
+    let converted = try await convertAmount(amount, to: instrument, on: date)
+    return .value(converted)
+  }
+
+  func invalidateCache(for instrument: Instrument) async {}
 }

--- a/MoolahTests/Support/DateBasedFixedConversionService.swift
+++ b/MoolahTests/Support/DateBasedFixedConversionService.swift
@@ -52,4 +52,13 @@ struct DateBasedFixedConversionService: InstrumentConversionService {
     )
     return InstrumentAmount(quantity: converted, instrument: instrument)
   }
+
+  func convertResult(
+    _ amount: InstrumentAmount, to instrument: Instrument, on date: Date
+  ) async throws -> ConversionResult {
+    let converted = try await convertAmount(amount, to: instrument, on: date)
+    return .value(converted)
+  }
+
+  func invalidateCache(for instrument: Instrument) async {}
 }

--- a/MoolahTests/Support/DateFailingConversionService.swift
+++ b/MoolahTests/Support/DateFailingConversionService.swift
@@ -64,6 +64,15 @@ struct DateFailingConversionService: InstrumentConversionService {
       amount.quantity, from: amount.instrument, to: instrument, on: date)
     return InstrumentAmount(quantity: converted, instrument: instrument)
   }
+
+  func convertResult(
+    _ amount: InstrumentAmount, to instrument: Instrument, on date: Date
+  ) async throws -> ConversionResult {
+    let converted = try await convertAmount(amount, to: instrument, on: date)
+    return .value(converted)
+  }
+
+  func invalidateCache(for instrument: Instrument) async {}
 }
 
 enum DateFailingConversionError: Error, Equatable {

--- a/MoolahTests/Support/FailingConversionService.swift
+++ b/MoolahTests/Support/FailingConversionService.swift
@@ -48,6 +48,15 @@ actor FailingConversionService: InstrumentConversionService {
     )
     return InstrumentAmount(quantity: converted, instrument: instrument)
   }
+
+  func convertResult(
+    _ amount: InstrumentAmount, to instrument: Instrument, on date: Date
+  ) async throws -> ConversionResult {
+    let converted = try await convertAmount(amount, to: instrument, on: date)
+    return .value(converted)
+  }
+
+  func invalidateCache(for instrument: Instrument) async {}
 }
 
 enum FailingConversionError: Error, Equatable {

--- a/MoolahTests/Support/FixedConversionService.swift
+++ b/MoolahTests/Support/FixedConversionService.swift
@@ -29,4 +29,13 @@ struct FixedConversionService: InstrumentConversionService {
     )
     return InstrumentAmount(quantity: converted, instrument: instrument)
   }
+
+  func convertResult(
+    _ amount: InstrumentAmount, to instrument: Instrument, on date: Date
+  ) async throws -> ConversionResult {
+    let converted = try await convertAmount(amount, to: instrument, on: date)
+    return .value(converted)
+  }
+
+  func invalidateCache(for instrument: Instrument) async {}
 }

--- a/MoolahTests/Support/RecordingConversionService.swift
+++ b/MoolahTests/Support/RecordingConversionService.swift
@@ -45,4 +45,13 @@ final class RecordingConversionService: InstrumentConversionService, Sendable {
       amount.quantity, from: amount.instrument, to: instrument, on: date)
     return InstrumentAmount(quantity: value, instrument: instrument)
   }
+
+  func convertResult(
+    _ amount: InstrumentAmount, to instrument: Instrument, on date: Date
+  ) async throws -> ConversionResult {
+    let converted = try await convertAmount(amount, to: instrument, on: date)
+    return .value(converted)
+  }
+
+  func invalidateCache(for instrument: Instrument) async {}
 }

--- a/MoolahTests/Support/ThrowingConversionService.swift
+++ b/MoolahTests/Support/ThrowingConversionService.swift
@@ -21,4 +21,10 @@ struct ThrowingConversionService: InstrumentConversionService {
   ) async throws -> InstrumentAmount {
     throw Invoked()
   }
+  func convertResult(
+    _ amount: InstrumentAmount, to instrument: Instrument, on date: Date
+  ) async throws -> ConversionResult {
+    throw Invoked()
+  }
+  func invalidateCache(for instrument: Instrument) async {}
 }

--- a/MoolahTests/Support/ThrowingCountingConversionService.swift
+++ b/MoolahTests/Support/ThrowingCountingConversionService.swift
@@ -46,6 +46,15 @@ final class ThrowingCountingConversionService: InstrumentConversionService, Send
       amount.quantity, from: amount.instrument, to: instrument, on: date)
     return InstrumentAmount(quantity: value, instrument: instrument)
   }
+
+  func convertResult(
+    _ amount: InstrumentAmount, to instrument: Instrument, on date: Date
+  ) async throws -> ConversionResult {
+    let converted = try await convertAmount(amount, to: instrument, on: date)
+    return .value(converted)
+  }
+
+  func invalidateCache(for instrument: Instrument) async {}
 }
 
 /// Async-safe collector for per-row failure-callback fan-out observed by

--- a/Shared/CryptoPriceService+PriceLookup.swift
+++ b/Shared/CryptoPriceService+PriceLookup.swift
@@ -1,0 +1,43 @@
+// Shared/CryptoPriceService+PriceLookup.swift
+
+import Foundation
+
+// MARK: - Discriminated price lookup
+
+// `priceLookup(for:on:)` honours `CryptoRegistration.pricingStatus` so
+// `.unpriced` / `.spam` tokens resolve to `.knownZero` without invoking
+// any provider, while a `.priced` registration goes through the
+// existing `price(for:mapping:on:)` path and surfaces provider failure
+// via `throw` (never collapsed to `.knownZero`). Lives in its own file
+// to keep `CryptoPriceService.swift` under SwiftLint's `file_length`
+// threshold.
+
+extension CryptoPriceService {
+  /// Discriminated price lookup. Honours `registration.pricingStatus`:
+  /// - `.priced`   → `.priced(rate)` from the existing
+  ///   `price(for:mapping:on:)` path.
+  /// - `.unpriced` → `.knownZero` (no provider call).
+  /// - `.spam`     → `.knownZero` (no provider call).
+  ///
+  /// Provider failure on a `.priced` registration still throws.
+  ///
+  /// Per `guides/INSTRUMENT_CONVERSION_GUIDE.md` Rule 11: this seam is
+  /// the load-bearing fix that lets aggregation sites keep "intentional
+  /// zero" distinct from "rate unavailable" for any total that aggregates
+  /// crypto tokens.
+  func priceLookup(
+    for registration: CryptoRegistration,
+    on date: Date
+  ) async throws -> CryptoPriceLookup {
+    switch registration.pricingStatus {
+    case .unpriced, .spam:
+      return .knownZero
+    case .priced:
+      let rate = try await price(
+        for: registration.instrument,
+        mapping: registration.mapping,
+        on: date)
+      return .priced(rate)
+    }
+  }
+}

--- a/Shared/FiatConversionService.swift
+++ b/Shared/FiatConversionService.swift
@@ -39,4 +39,27 @@ actor FiatConversionService: InstrumentConversionService {
     )
     return InstrumentAmount(quantity: converted, instrument: instrument)
   }
+
+  /// Discriminated convert. Fiat has no `.knownZero` concept (every
+  /// `.fiatCurrency` instrument has a real rate), so this always wraps
+  /// the existing `convertAmount` in `.value(...)` and propagates a
+  /// thrown error unchanged. Aggregation callers can use this method
+  /// uniformly across both fiat and crypto-aware services. Per
+  /// `guides/INSTRUMENT_CONVERSION_GUIDE.md` Rule 11, a thrown error
+  /// is never collapsed to `.knownZero`.
+  func convertResult(
+    _ amount: InstrumentAmount,
+    to instrument: Instrument,
+    on date: Date
+  ) async throws -> ConversionResult {
+    let converted = try await convertAmount(amount, to: instrument, on: date)
+    return .value(converted)
+  }
+
+  /// No-op: the fiat conversion cache lives in `ExchangeRateService` and
+  /// is keyed by date, not by individual instrument. Crypto-specific
+  /// invalidation only matters in `FullConversionService`.
+  func invalidateCache(for instrument: Instrument) async {
+    // Intentionally empty.
+  }
 }

--- a/Shared/FullConversionService.swift
+++ b/Shared/FullConversionService.swift
@@ -9,26 +9,32 @@ actor FullConversionService: InstrumentConversionService {
   private let exchangeRates: ExchangeRateService
   private let stockPrices: StockPriceService
   private let cryptoPrices: CryptoPriceService?
-  private let providerMappings: @Sendable () async throws -> [CryptoProviderMapping]
+  private let cryptoRegistrations: @Sendable () async throws -> [CryptoRegistration]
   private let logger = Logger(subsystem: "com.moolah.app", category: "CurrencyConversion")
 
-  /// - Parameter providerMappings: Closure invoked on each crypto conversion
-  ///   to obtain the current set of provider mappings. Tokens registered via
-  ///   `CryptoPriceService` after service construction become resolvable on
-  ///   the next conversion without rebuilding the service. Errors thrown by
-  ///   the closure (e.g. registry read failures) propagate through
-  ///   `convert(_:from:to:on:)` rather than collapsing silently to an empty
-  ///   mapping table — see `guides/INSTRUMENT_CONVERSION_GUIDE.md` Rule 11.
+  /// - Parameter cryptoRegistrations: Closure invoked on each crypto
+  ///   conversion to obtain the current set of crypto registrations. Tokens
+  ///   registered via `CryptoPriceService` after service construction become
+  ///   resolvable on the next conversion without rebuilding the service.
+  ///   Errors thrown by the closure (e.g. registry read failures) propagate
+  ///   through `convert(_:from:to:on:)` rather than collapsing silently to an
+  ///   empty mapping table — see `guides/INSTRUMENT_CONVERSION_GUIDE.md`
+  ///   Rule 11.
+  ///
+  ///   Returning the full `CryptoRegistration` (rather than just its
+  ///   `mapping`) is required so `convertResult(...)` can honour the
+  ///   `pricingStatus` (`.priced` / `.unpriced` / `.spam`) per the
+  ///   discriminated `CryptoPriceLookup` flow.
   init(
     exchangeRates: ExchangeRateService,
     stockPrices: StockPriceService,
     cryptoPrices: CryptoPriceService? = nil,
-    providerMappings: @Sendable @escaping () async throws -> [CryptoProviderMapping] = { [] }
+    cryptoRegistrations: @Sendable @escaping () async throws -> [CryptoRegistration] = { [] }
   ) {
     self.exchangeRates = exchangeRates
     self.stockPrices = stockPrices
     self.cryptoPrices = cryptoPrices
-    self.providerMappings = providerMappings
+    self.cryptoRegistrations = cryptoRegistrations
   }
 
   func convert(
@@ -99,6 +105,51 @@ actor FullConversionService: InstrumentConversionService {
     return InstrumentAmount(quantity: converted, instrument: instrument)
   }
 
+  /// Discriminated convert. When the source instrument is a crypto token
+  /// whose registration carries a non-`.priced` `pricingStatus` (i.e.
+  /// `.unpriced` or `.spam`), returns `.knownZero(targetInstrument:)`
+  /// without invoking any price provider. Otherwise wraps the existing
+  /// `convertAmount` in `.value(...)`. A real provider failure throws —
+  /// per `guides/INSTRUMENT_CONVERSION_GUIDE.md` Rule 11, never collapsed
+  /// to `.knownZero`.
+  ///
+  /// Same-instrument identity is a fast path — even for `.unpriced` /
+  /// `.spam` tokens — because the position list still wants to render
+  /// the native quantity for the user (the token isn't worth zero ETH
+  /// of itself; its *fiat aggregation* contribution is zero).
+  func convertResult(
+    _ amount: InstrumentAmount,
+    to instrument: Instrument,
+    on date: Date
+  ) async throws -> ConversionResult {
+    if amount.instrument == instrument {
+      return .value(amount)
+    }
+    if amount.instrument.kind == .cryptoToken {
+      let registrations = try await cryptoRegistrations()
+      if let registration = registrations.first(where: { $0.id == amount.instrument.id }),
+        registration.pricingStatus != .priced
+      {
+        // `.unpriced` and `.spam` resolve to a clean zero in the
+        // requested target instrument without a provider call.
+        return .knownZero(targetInstrument: instrument)
+      }
+    }
+    let converted = try await convertAmount(amount, to: instrument, on: date)
+    return .value(converted)
+  }
+
+  /// Invalidate any cached state held about `instrument`. For crypto
+  /// instruments this clears the in-memory and on-disk price rows in
+  /// `CryptoPriceService` so the next conversion fetches fresh data —
+  /// required after any user mutation that changes
+  /// `pricingStatus` for the instrument's registration. No-op for
+  /// fiat / stock instruments and when no `CryptoPriceService` is wired.
+  func invalidateCache(for instrument: Instrument) async {
+    guard instrument.kind == .cryptoToken, let cryptoPrices else { return }
+    await cryptoPrices.purgeCache(instrumentId: instrument.id)
+  }
+
   // MARK: - Stock helpers
 
   private func convertStockToFiat(
@@ -137,11 +188,12 @@ actor FullConversionService: InstrumentConversionService {
     guard let cryptoPrices else {
       throw ConversionError.noCryptoPriceService
     }
-    let mappings = try await providerMappings()
-    guard let mapping = mappings.first(where: { $0.instrumentId == instrument.id }) else {
+    let registrations = try await cryptoRegistrations()
+    guard let registration = registrations.first(where: { $0.id == instrument.id }) else {
       throw ConversionError.noProviderMapping(instrumentId: instrument.id)
     }
-    return try await cryptoPrices.price(for: instrument, mapping: mapping, on: date)
+    return try await cryptoPrices.price(
+      for: registration.instrument, mapping: registration.mapping, on: date)
   }
 
   // MARK: - USD intermediary helpers


### PR DESCRIPTION
## Summary

Stage 2 of [`plans/2026-05-05-crypto-wallet-import-plan.md`](plans/2026-05-05-crypto-wallet-import-plan.md). Adds the discriminated `CryptoPriceLookup` and `ConversionResult` types and the matching `priceLookup` / `convertResult` / `invalidateCache(for:)` seams so an intentionally-zero token (`.unpriced` / `.spam`) stays distinct from a real provider failure at every aggregation surface.

- `CryptoPriceLookup` enum (`.priced(Decimal)` / `.knownZero` / throws on failure).
- `ConversionResult` enum (`.value(InstrumentAmount)` / `.knownZero(targetInstrument:)`).
- `CryptoPriceService.priceLookup(for:on:)` honours `registration.pricingStatus` — `.unpriced` / `.spam` short-circuit to `.knownZero` without invoking the provider; `.priced` goes through the existing `price(for:mapping:on:)` path.
- `InstrumentConversionService.convertResult(_:to:on:)` and `invalidateCache(for:)` added to the protocol; implemented on `FullConversionService` and `FiatConversionService`.
- `FullConversionService`'s registry closure migrated from `[CryptoProviderMapping]` to `[CryptoRegistration]` so `pricingStatus` flows through to `convertResult`.

**Behaviour unchanged for users** — every token currently has `pricingStatus == .priced`. The UI / aggregation rewrites that consume this seam land in Stage 3+.

Per spec: `plans/2026-05-05-crypto-wallet-import-design.md` §"Instrument conversion semantics" and `guides/INSTRUMENT_CONVERSION_GUIDE.md` Rule 11 (degrade gracefully; never display incorrect or confusing data).

## Test plan

- [x] New: `MoolahTests/Domain/CryptoPriceLookupTests.swift` — equality + Sendable round-trip.
- [x] New: `MoolahTests/Domain/ConversionResultTests.swift` — equality of `.value(...)` and `.knownZero(targetInstrument:)`.
- [x] New: `MoolahTests/Shared/CryptoPriceServicePriceLookupTests.swift` — `.priced` → `.priced(rate)`; `.unpriced` / `.spam` → `.knownZero` without invoking the provider; provider failure on `.priced` throws.
- [x] New: `MoolahTests/Shared/FullConversionServiceConvertResultTests.swift` — `.priced` crypto source → `.value(...)`; `.unpriced` / `.spam` → `.knownZero(targetInstrument: to)`; provider failure on `.priced` throws (never `.knownZero`); fiat source → `.value(...)`; same-instrument identity → `.value(amount)` even for `.unpriced` (position list still renders native quantity).
- [x] New: `MoolahTests/Shared/ConvertCacheInvalidationTests.swift` — invalidate for crypto purges `CryptoPriceService` cache (next conversion forced through the failing client and surfaces an error); invalidate for fiat is a no-op.
- [x] New: `MoolahTests/Shared/FiatConversionServiceConvertResultTests.swift` — fiat-to-fiat → `.value(...)`; non-fiat throws `.unsupportedInstrumentKind`.
- [x] `just format-check` clean.
- [x] Full test suite: `2184 tests in 351 suites passed` on `Moolah_macOS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)