### PR TITLE
fix(release-rc): bake build number into Mac archive

### DIFF
--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -168,7 +168,10 @@ jobs:
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
           MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
           DEVELOPMENT_TEAM: ${{ secrets.DEVELOPMENT_TEAM }}
-        run: bundle exec fastlane mac zip version:${{ steps.version.outputs.base }}
+        run: |
+          bundle exec fastlane mac zip \
+              version:${{ steps.version.outputs.base }} \
+              build_number:"$(cat build/build-number.txt)"
 
       - name: Attach Mac zip and build-number to GH pre-release
         env:

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -170,6 +170,7 @@ platform :mac do
   desc "Build, sign, notarise, and zip the Mac app for direct distribution"
   lane :zip do |options|
     version = options[:version] or UI.user_error!("missing :version (e.g. 1.2.0)")
+    build_number = options[:build_number] or UI.user_error!("missing :build_number (the iOS lane's TestFlight build number; the Mac and iOS builds for an RC must share it)")
 
     certificates
 
@@ -197,6 +198,13 @@ platform :mac do
     # iOS appstore uses `sigh_<bundle>_appstore_profile-name` (no platform suffix)
     # because iOS is fastlane's default platform.
     bake_profile("MAC_PROVISIONING_PROFILE", ENV["sigh_rocks.moolah.app_developer_id_macos_profile-name"])
+
+    # Same ordering rule as the iOS `beta` lane (see comment there): anything that
+    # mutates the pbxproj must come AFTER the last `just generate` (the one inside
+    # `bake_profile`) and BEFORE `build_app`. Setting CURRENT_PROJECT_VERSION here
+    # keeps the Mac build number in lockstep with the iOS upload and lets the
+    # "Verify Release build number" pre-build phase pass.
+    increment_build_number(build_number: build_number)
 
     # Resolve build dir to an absolute path off the repo root. gym/build_app
     # writes outputs to <repo_root>/build/ regardless of fastlane's own cwd,


### PR DESCRIPTION
## Summary

Mac `zip` lane now sets `CURRENT_PROJECT_VERSION` after the last `just generate` and before `build_app`, mirroring the iOS `beta` lane's pattern. Caught by [v1.1.0-rc.16](https://github.com/ajsutton/moolah-native/releases/tag/v1.1.0-rc.16) where every RC build was failing the "Verify Release build number" pre-build phase added in a0b1b0c3.

## What was happening

- iOS lane bumps the build number into `project.pbxproj` and uploads to TestFlight ✓
- Workflow captures the build number into `build/build-number.txt` ✓
- Mac lane `before_all` runs `just generate`, regenerating `project.pbxproj` from `project.yml` → resets `CURRENT_PROJECT_VERSION` to the `1` placeholder
- Mac lane `bake_profile` runs `just generate` again → still `1`
- `build_app` invokes `xcodebuild` → the "Verify Release build number" pre-build phase sees `Release` config + `CURRENT_PROJECT_VERSION = 1` → aborts the archive

The iOS lane already documents this ordering hazard (Fastfile:88-93) and works around it by calling `increment_build_number` *after* the last `bake_profile`. The Mac lane had no equivalent.

## Fix

- `fastlane/Fastfile`: accept `build_number:` as a required `mac zip` parameter; call `increment_build_number(build_number: ...)` after `bake_profile`.
- `.github/workflows/release-rc.yml`: pass `build_number:"$(cat build/build-number.txt)"` to the lane (the file is already produced by the existing "Capture TestFlight build number" step).

`release-final.yml` is unaffected — it copies the existing Mac zip from the RC release rather than rebuilding.

## Test plan

- [x] `git diff` reviewed; both edits localised to the Mac-zip path.
- [ ] Cut `v1.1.0-rc.17` after this lands; verify the workflow archives, notarises, and attaches the Mac zip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)