### PR TITLE
feat(crypto): Alchemy client + chain config + rate limiter

### DIFF
--- a/Domain/Models/WalletSyncError.swift
+++ b/Domain/Models/WalletSyncError.swift
@@ -3,7 +3,12 @@ import Foundation
 /// Structured outcome of a failed wallet sync cycle. Stored in `WalletSyncState`
 /// so the `CryptoSyncStore` can format it for display without coupling the
 /// domain model to localised strings.
-enum WalletSyncError: Codable, Sendable, Hashable {
+///
+/// Conforms to `Error` so the wallet-sync data layer (Stage 4 onward) can
+/// throw it directly. The associated values are persisted by JSON-encoding
+/// the value via `Codable`, so the conformance is additive — no shape
+/// change to existing storage.
+enum WalletSyncError: Error, Codable, Sendable, Hashable {
   case missingApiKey
   case invalidApiKey
   case rateLimited(retryAfter: Date?)

--- a/MoolahTests/Shared/CryptoImport/AlchemyTestSupport.swift
+++ b/MoolahTests/Shared/CryptoImport/AlchemyTestSupport.swift
@@ -1,0 +1,196 @@
+// MoolahTests/Shared/CryptoImport/AlchemyTestSupport.swift
+import Foundation
+
+@testable import Moolah
+
+/// Sentinel URL used to construct synthetic HTTP responses without
+/// force-unwrapping the request URL. `URL(fileURLWithPath:)` is total —
+/// always returns a non-optional URL — so the helper avoids the
+/// `force_unwrapping` lint while still producing a valid `HTTPURLResponse`.
+enum AlchemyTestSupport {
+  static let stubResponseURL = URL(fileURLWithPath: "/")
+
+  /// Build a `LiveAlchemyClient` whose `URLSession` routes through the
+  /// shared `AlchemyURLProtocolStub`. The handler closure controls every
+  /// response; tests that only need a default response pass `.success(...)`.
+  static func makeClient(
+    apiKey: String = "test-key",
+    permitsPerSecond: Double = 1_000,
+    handler: @escaping @Sendable (URLRequest) throws -> (HTTPURLResponse, Data)
+  ) -> LiveAlchemyClient {
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [AlchemyURLProtocolStub.self]
+    let session = URLSession(configuration: config)
+    AlchemyURLProtocolStub.lastRequest = nil
+    AlchemyURLProtocolStub.lastBodyJSON = [:]
+    AlchemyURLProtocolStub.requestHandler = handler
+    let limiter = RateLimiter(permitsPerSecond: permitsPerSecond)
+    return LiveAlchemyClient(session: session, apiKey: apiKey, rateLimiter: limiter)
+  }
+
+  /// Build a 200 OK JSON response for the URL of an inbound request. The
+  /// initialiser only fails on a malformed `httpVersion` — `"HTTP/1.1"` is a
+  /// hardcoded literal, so a `nil` here would be a programmer error rather
+  /// than a runtime failure. We surface it as a sentinel response built
+  /// against `stubResponseURL` so tests stay deterministic on the unhappy
+  /// path too.
+  static func okResponse(for request: URLRequest) -> HTTPURLResponse {
+    let url = request.url ?? stubResponseURL
+    return HTTPURLResponse(
+      url: url,
+      statusCode: 200,
+      httpVersion: "HTTP/1.1",
+      headerFields: ["Content-Type": "application/json"]
+    ) ?? fallbackResponse(statusCode: 200)
+  }
+
+  /// Build an arbitrary status response. See `okResponse(for:)` for why
+  /// the initialiser is treated as total in practice.
+  static func response(
+    for request: URLRequest,
+    statusCode: Int,
+    headerFields: [String: String] = [:]
+  ) -> HTTPURLResponse {
+    let url = request.url ?? stubResponseURL
+    return HTTPURLResponse(
+      url: url,
+      statusCode: statusCode,
+      httpVersion: "HTTP/1.1",
+      headerFields: headerFields
+    ) ?? fallbackResponse(statusCode: statusCode)
+  }
+
+  /// Defensive fallback if the optional `HTTPURLResponse` initialiser
+  /// somehow fails — `URLResponse()` always succeeds and is downcastable.
+  private static func fallbackResponse(statusCode: Int) -> HTTPURLResponse {
+    // `HTTPURLResponse` instances built directly via `init()` lack a
+    // status code, but `URLProtocol` clients only inspect `statusCode`
+    // through the `HTTPURLResponse` accessor — so an out-of-band response
+    // here would just look like a 0-status network failure. That's
+    // acceptable for the "this should never happen" branch.
+    HTTPURLResponse()
+  }
+
+  /// Loads a fixture file from the test bundle as `Data`. Throws an
+  /// explicit `FixtureMissing` error rather than `fatalError` so the
+  /// failing test fails cleanly with a useful message.
+  static func loadFixture(_ name: String) throws -> Data {
+    guard
+      let url = Bundle(for: TestBundleMarker.self)
+        .url(forResource: name, withExtension: "json")
+    else {
+      throw FixtureMissing(name: name)
+    }
+    return try Data(contentsOf: url)
+  }
+
+  struct FixtureMissing: Error { let name: String }
+}
+
+/// `URLProtocol` stub local to the `LiveAlchemyClient` suite — the existing
+/// `URLProtocolStub` in `YahooFinanceClientTests` is module-private to that
+/// file, so this stub is an isolated copy with its own static handler state.
+class AlchemyURLProtocolStub: URLProtocol {
+  nonisolated(unsafe) static var requestHandler:
+    (@Sendable (URLRequest) throws -> (HTTPURLResponse, Data))?
+  nonisolated(unsafe) static var lastRequest: URLRequest?
+  /// Decoded body of the most recent captured request — empty when no
+  /// request has been captured yet, or when the body was non-JSON.
+  /// Initialised to an empty dictionary rather than `nil` because
+  /// SwiftLint disallows optional collections; tests assert on contents
+  /// or on `isEmpty`, which is sufficient.
+  nonisolated(unsafe) static var lastBodyJSON: [String: Any] = [:]
+
+  /// Records the request that was just received and decodes its body
+  /// (whether streamed or in-memory) into a JSON dictionary for later
+  /// assertions. Tests opt-in by calling this from their handler closure.
+  static func captureRequest(_ request: URLRequest) {
+    lastRequest = request
+    if let stream = request.httpBodyStream {
+      lastBodyJSON = decodeBodyStream(stream)
+    } else if let body = request.httpBody {
+      lastBodyJSON = (try? JSONSerialization.jsonObject(with: body) as? [String: Any]) ?? [:]
+    } else {
+      lastBodyJSON = [:]
+    }
+  }
+
+  override class func canInit(with request: URLRequest) -> Bool { true }
+  override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+  override func startLoading() {
+    guard let handler = AlchemyURLProtocolStub.requestHandler else {
+      client?.urlProtocol(self, didFailWithError: URLError(.unknown))
+      return
+    }
+    do {
+      let (response, data) = try handler(request)
+      client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+      client?.urlProtocol(self, didLoad: data)
+      client?.urlProtocolDidFinishLoading(self)
+    } catch {
+      client?.urlProtocol(self, didFailWithError: error)
+    }
+  }
+
+  override func stopLoading() {}
+
+  private static func decodeBodyStream(_ stream: InputStream) -> [String: Any] {
+    stream.open()
+    defer { stream.close() }
+    var data = Data()
+    let bufferSize = 1024
+    let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
+    defer { buffer.deallocate() }
+    while stream.hasBytesAvailable {
+      let read = stream.read(buffer, maxLength: bufferSize)
+      if read <= 0 { break }
+      data.append(buffer, count: read)
+    }
+    return (try? JSONSerialization.jsonObject(with: data) as? [String: Any]) ?? [:]
+  }
+}
+
+/// Records each captured request body as a deserialised dictionary so
+/// tests can assert on the two-pass query shape across calls. Reference
+/// type so the closure-captured stub can mutate it; lock-protected to
+/// satisfy `Sendable`.
+final class TestCallRecorder: @unchecked Sendable {
+  private let lock = NSLock()
+  private var bodies: [[String: Any]] = []
+
+  func record(request: URLRequest) {
+    lock.lock()
+    defer { lock.unlock() }
+    if let stream = request.httpBodyStream {
+      bodies.append(decodeJSON(from: readAll(stream: stream)))
+    } else if let data = request.httpBody {
+      bodies.append(decodeJSON(from: data))
+    }
+  }
+
+  var captured: [[String: Any]] {
+    lock.lock()
+    defer { lock.unlock() }
+    return bodies
+  }
+
+  private func decodeJSON(from data: Data) -> [String: Any] {
+    (try? JSONSerialization.jsonObject(with: data) as? [String: Any]) ?? [:]
+  }
+
+  private func readAll(stream: InputStream) -> Data {
+    stream.open()
+    defer { stream.close() }
+    var data = Data()
+    let bufferSize = 1024
+    let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
+    defer { buffer.deallocate() }
+    while stream.hasBytesAvailable {
+      let read = stream.read(buffer, maxLength: bufferSize)
+      if read <= 0 { break }
+      data.append(buffer, count: read)
+    }
+    return data
+  }
+}

--- a/MoolahTests/Shared/CryptoImport/AlchemyTransferDecodingTests.swift
+++ b/MoolahTests/Shared/CryptoImport/AlchemyTransferDecodingTests.swift
@@ -1,0 +1,176 @@
+// MoolahTests/Shared/CryptoImport/AlchemyTransferDecodingTests.swift
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("AlchemyTransfer decoding")
+struct AlchemyTransferDecodingTests {
+  // MARK: - Fixture loading
+
+  private func loadFixture(_ name: String) throws -> Data {
+    guard
+      let url = Bundle(for: TestBundleMarker.self)
+        .url(forResource: name, withExtension: "json")
+    else {
+      Issue.record("Could not find \(name).json fixture")
+      throw FixtureMissing(name: name)
+    }
+    return try Data(contentsOf: url)
+  }
+
+  private struct FixtureMissing: Error { let name: String }
+
+  /// The Alchemy fixtures wrap the array in a JSON-RPC envelope. Tests
+  /// that only care about the inner `transfers` array decode through
+  /// this helper.
+  private func decodeTransfers(_ data: Data) throws -> [AlchemyTransfer] {
+    let envelope = try JSONDecoder().decode(JSONRPCFixtureEnvelope.self, from: data)
+    return envelope.result.transfers
+  }
+
+  // MARK: - Tests
+
+  @Test
+  func decodesNativeEthSend() throws {
+    let data = try loadFixture("eth-simple-eth-send")
+    let transfers = try decodeTransfers(data)
+    #expect(transfers.count == 1)
+    let transfer = try #require(transfers.first)
+    #expect(
+      transfer.hash == "0xabc123def456000000000000000000000000000000000000000000000000aaaa")
+    #expect(transfer.from == "0x1111111111111111111111111111111111111111")
+    #expect(transfer.to == "0x2222222222222222222222222222222222222222")
+    #expect(transfer.category == .external)
+    #expect(transfer.asset == "ETH")
+    #expect(transfer.rawContract.address == nil)
+    #expect(transfer.rawContract.decimalsValue == 18)  // 0x12
+    #expect(transfer.rawContract.rawDecimalValue == Decimal(0x00b1_a2bc_2ec5_0000))
+    #expect(transfer.metadata.blockTimestamp == "2024-09-12T12:34:56.000Z")
+    #expect(transfer.blockNum == "0x12d4f0a")
+  }
+
+  @Test
+  func decodesErc20AndInternalCategories() throws {
+    let data = try loadFixture("eth-erc20-transfer")
+    let transfers = try decodeTransfers(data)
+    #expect(transfers.count == 2)
+
+    let erc20 = transfers[0]
+    #expect(erc20.category == .erc20)
+    #expect(erc20.asset == "USDC")
+    #expect(erc20.rawContract.address == "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48")
+    #expect(erc20.rawContract.decimalsValue == 6)
+    #expect(erc20.rawContract.rawDecimalValue == Decimal(0x3b9b_ca00))
+
+    let internalTx = transfers[1]
+    #expect(internalTx.category == .internal)
+    #expect(internalTx.asset == "ETH")
+    #expect(internalTx.rawContract.address == nil)
+  }
+
+  @Test
+  func decodesPolygonSpamAirdropAndUnknownCategoryIsLenient() throws {
+    let data = try loadFixture("polygon-spam-airdrop")
+    let transfers = try decodeTransfers(data)
+    #expect(transfers.count == 2)
+
+    let spam = transfers[0]
+    #expect(spam.category == .erc20)
+    #expect(spam.asset == "VISIT-AIRDROP-SITE.COM")
+    #expect(spam.rawContract.address == "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
+    #expect(spam.rawContract.decimalsValue == 18)
+    // Decimal must accept 256-bit-scale hex without overflow.
+    #expect(spam.rawContract.rawDecimalValue == dec("1000000000000000000000000"))
+
+    // NFT category in real data — the request filter excludes it, but the
+    // decoder must not crash if one slips through. We surface it as
+    // `.unknown` so callers can drop it.
+    let nft = transfers[1]
+    #expect(nft.category == .unknown)
+    #expect(nft.rawContract.decimalsValue == nil)
+  }
+
+  @Test
+  func receiveOnlyEventDecodesWithNonNilTo() throws {
+    let data = try loadFixture("eth-simple-eth-send")
+    let transfers = try decodeTransfers(data)
+    let transfer = try #require(transfers.first)
+    #expect(transfer.to != nil)
+  }
+
+  @Test
+  func nullToFieldDecodesAsNil() throws {
+    // Alchemy returns `to: null` for contract-creation transactions —
+    // the decoder must treat the nil string field as Swift `nil`, not
+    // throw or substitute an empty string.
+    let json = Data(
+      """
+      {
+        "blockNum": "0x100",
+        "uniqueId": "0xaaaa:contract-creation",
+        "hash": "0xaaaa",
+        "from": "0x1111111111111111111111111111111111111111",
+        "to": null,
+        "value": null,
+        "asset": null,
+        "category": "external",
+        "rawContract": {
+          "rawValue": "0x0",
+          "address": null,
+          "decimal": null
+        },
+        "metadata": { "blockTimestamp": "2024-09-12T12:34:56.000Z" }
+      }
+      """.utf8)
+    let transfer = try JSONDecoder().decode(AlchemyTransfer.self, from: json)
+    #expect(transfer.to == nil)
+    #expect(transfer.asset == nil)
+    #expect(transfer.rawContract.decimalsValue == nil)
+  }
+
+  @Test
+  func categoryEnumLeniencyAcceptsNftCategoriesAsUnknown() throws {
+    for raw in ["erc721", "erc1155", "specialnft", "future-category"] {
+      let json = Data("\"\(raw)\"".utf8)
+      let category = try JSONDecoder().decode(AlchemyTransferCategory.self, from: json)
+      #expect(category == .unknown)
+    }
+  }
+
+  @Test
+  func malformedHexFieldsReturnNilInsteadOfThrowing() throws {
+    let json = Data(
+      """
+      {
+        "blockNum": "0x100",
+        "uniqueId": "0xbbbb:log:0",
+        "hash": "0xbbbb",
+        "from": "0x1",
+        "to": "0x2",
+        "category": "erc20",
+        "rawContract": {
+          "rawValue": "0xZZZ",
+          "address": "0xabc",
+          "decimal": "not-hex"
+        },
+        "metadata": { "blockTimestamp": null }
+      }
+      """.utf8)
+    let transfer = try JSONDecoder().decode(AlchemyTransfer.self, from: json)
+    #expect(transfer.rawContract.rawDecimalValue == nil)
+    #expect(transfer.rawContract.decimalsValue == nil)
+  }
+}
+
+// MARK: - Fixture envelope
+
+/// Mirrors the JSON-RPC envelope shape from the production decoder; defined
+/// here so tests don't reach into `LiveAlchemyClient`'s `private` types.
+private struct JSONRPCFixtureEnvelope: Decodable {
+  let result: Result
+
+  struct Result: Decodable {
+    let transfers: [AlchemyTransfer]
+  }
+}

--- a/MoolahTests/Shared/CryptoImport/ChainConfigTests.swift
+++ b/MoolahTests/Shared/CryptoImport/ChainConfigTests.swift
@@ -1,0 +1,103 @@
+// MoolahTests/Shared/CryptoImport/ChainConfigTests.swift
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("ChainConfig")
+struct ChainConfigTests {
+  @Test
+  func ethereumConfigIsCorrect() {
+    let config = ChainConfig.ethereum
+    #expect(config.chainId == 1)
+    #expect(config.alchemyNetworkSlug == "eth-mainnet")
+    #expect(config.supportsInternalTransfers == true)
+    #expect(config.displayName == "Ethereum")
+    #expect(config.blockExplorerBaseURL.absoluteString == "https://etherscan.io")
+    #expect(config.nativeInstrument.ticker == "ETH")
+    #expect(config.nativeInstrument.chainId == 1)
+    #expect(config.nativeInstrument.contractAddress == nil)
+    #expect(config.nativeInstrument.decimals == 18)
+  }
+
+  @Test
+  func optimismConfigIsCorrect() {
+    let config = ChainConfig.optimism
+    #expect(config.chainId == 10)
+    #expect(config.alchemyNetworkSlug == "opt-mainnet")
+    #expect(config.supportsInternalTransfers == false)
+    #expect(config.displayName == "OP Mainnet")
+    #expect(config.blockExplorerBaseURL.absoluteString == "https://optimistic.etherscan.io")
+    #expect(config.nativeInstrument.ticker == "ETH")
+    #expect(config.nativeInstrument.chainId == 10)
+  }
+
+  @Test
+  func baseConfigIsCorrect() {
+    let config = ChainConfig.base
+    #expect(config.chainId == 8453)
+    #expect(config.alchemyNetworkSlug == "base-mainnet")
+    #expect(config.supportsInternalTransfers == false)
+    #expect(config.displayName == "Base")
+    #expect(config.blockExplorerBaseURL.absoluteString == "https://basescan.org")
+    #expect(config.nativeInstrument.ticker == "ETH")
+    #expect(config.nativeInstrument.chainId == 8453)
+  }
+
+  @Test
+  func polygonConfigIsCorrect() {
+    let config = ChainConfig.polygon
+    #expect(config.chainId == 137)
+    #expect(config.alchemyNetworkSlug == "polygon-mainnet")
+    #expect(config.supportsInternalTransfers == true)
+    #expect(config.displayName == "Polygon")
+    #expect(config.blockExplorerBaseURL.absoluteString == "https://polygonscan.com")
+    #expect(config.nativeInstrument.ticker == "MATIC")
+    #expect(config.nativeInstrument.chainId == 137)
+  }
+
+  @Test
+  func allChainsAreUnique() {
+    let chainIds = ChainConfig.all.map(\.chainId)
+    #expect(Set(chainIds).count == chainIds.count)
+    #expect(chainIds == [1, 10, 8453, 137])
+  }
+
+  @Test
+  func lookupByIdReturnsMatchingConfig() {
+    #expect(ChainConfig.config(for: 1) == .ethereum)
+    #expect(ChainConfig.config(for: 10) == .optimism)
+    #expect(ChainConfig.config(for: 8453) == .base)
+    #expect(ChainConfig.config(for: 137) == .polygon)
+  }
+
+  @Test
+  func lookupByIdReturnsNilForUnsupportedChain() {
+    #expect(ChainConfig.config(for: 0) == nil)
+    #expect(ChainConfig.config(for: 42_161) == nil)  // Arbitrum, not yet supported
+    #expect(ChainConfig.config(for: 999_999) == nil)
+  }
+
+  @Test
+  func nativeInstrumentsUseCorrectFactoryFormat() {
+    // The crypto factory normalises native instruments to "<chainId>:native".
+    #expect(ChainConfig.ethereum.nativeInstrument.id == "1:native")
+    #expect(ChainConfig.optimism.nativeInstrument.id == "10:native")
+    #expect(ChainConfig.base.nativeInstrument.id == "8453:native")
+    #expect(ChainConfig.polygon.nativeInstrument.id == "137:native")
+  }
+
+  @Test
+  func internalTransferSupportMatchesDesignDoc() {
+    // Per design open question 3: ETH and Polygon support `internal`,
+    // OP and Base do not. This invariant is load-bearing for the
+    // request shape Stage 4 builds.
+    let supports = Dictionary(
+      uniqueKeysWithValues: ChainConfig.all.map { ($0.chainId, $0.supportsInternalTransfers) }
+    )
+    #expect(supports[1] == true)
+    #expect(supports[137] == true)
+    #expect(supports[10] == false)
+    #expect(supports[8453] == false)
+  }
+}

--- a/MoolahTests/Shared/CryptoImport/LiveAlchemyClientErrorTests.swift
+++ b/MoolahTests/Shared/CryptoImport/LiveAlchemyClientErrorTests.swift
@@ -1,0 +1,116 @@
+// MoolahTests/Shared/CryptoImport/LiveAlchemyClientErrorTests.swift
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("LiveAlchemyClient — error mapping")
+struct LiveAlchemyClientErrorTests {
+  @Test
+  func httpUnauthorizedMapsToInvalidApiKey() async throws {
+    let client = AlchemyTestSupport.makeClient { request in
+      let response = AlchemyTestSupport.response(for: request, statusCode: 401)
+      return (response, Data())
+    }
+    await #expect(throws: WalletSyncError.invalidApiKey) {
+      _ = try await client.getAssetTransfers(
+        chain: .ethereum, walletAddress: "0xabc", fromBlock: 0
+      )
+    }
+  }
+
+  @Test
+  func httpForbiddenMapsToInvalidApiKey() async throws {
+    let client = AlchemyTestSupport.makeClient { request in
+      let response = AlchemyTestSupport.response(for: request, statusCode: 403)
+      return (response, Data())
+    }
+    await #expect(throws: WalletSyncError.invalidApiKey) {
+      _ = try await client.getAssetTransfers(
+        chain: .ethereum, walletAddress: "0xabc", fromBlock: 0
+      )
+    }
+  }
+
+  @Test
+  func httpTooManyRequestsMapsToRateLimitedWithRetryAfter() async throws {
+    let client = AlchemyTestSupport.makeClient { request in
+      let response = AlchemyTestSupport.response(
+        for: request,
+        statusCode: 429,
+        headerFields: ["Retry-After": "10"]
+      )
+      return (response, Data())
+    }
+    do {
+      _ = try await client.getAssetTransfers(
+        chain: .ethereum, walletAddress: "0xabc", fromBlock: 0
+      )
+      Issue.record("Expected WalletSyncError.rateLimited")
+    } catch let WalletSyncError.rateLimited(retryAfter) {
+      let date = try #require(retryAfter)
+      #expect(date.timeIntervalSinceNow > 5)
+      #expect(date.timeIntervalSinceNow < 15)
+    }
+  }
+
+  @Test
+  func httpTooManyRequestsWithoutRetryAfterMapsToRateLimitedWithNilDate() async throws {
+    let client = AlchemyTestSupport.makeClient { request in
+      let response = AlchemyTestSupport.response(for: request, statusCode: 429)
+      return (response, Data())
+    }
+    do {
+      _ = try await client.getAssetTransfers(
+        chain: .ethereum, walletAddress: "0xabc", fromBlock: 0
+      )
+      Issue.record("Expected WalletSyncError.rateLimited")
+    } catch let WalletSyncError.rateLimited(retryAfter) {
+      #expect(retryAfter == nil)
+    }
+  }
+
+  @Test
+  func httpServerErrorMapsToNetworkError() async throws {
+    let client = AlchemyTestSupport.makeClient { request in
+      let response = AlchemyTestSupport.response(for: request, statusCode: 503)
+      return (response, Data())
+    }
+    do {
+      _ = try await client.getAssetTransfers(
+        chain: .ethereum, walletAddress: "0xabc", fromBlock: 0
+      )
+      Issue.record("Expected WalletSyncError.network")
+    } catch let WalletSyncError.network(description) {
+      #expect(description.contains("503"))
+    }
+  }
+
+  @Test
+  func transportFailureMapsToNetworkError() async throws {
+    let client = AlchemyTestSupport.makeClient { _ in
+      throw URLError(.notConnectedToInternet)
+    }
+    do {
+      _ = try await client.getAssetTransfers(
+        chain: .ethereum, walletAddress: "0xabc", fromBlock: 0
+      )
+      Issue.record("Expected WalletSyncError.network")
+    } catch let WalletSyncError.network(description) {
+      #expect(description.isEmpty == false)
+    }
+  }
+
+  @Test
+  func malformedJSONMapsToProviderMalformedResponse() async throws {
+    let client = AlchemyTestSupport.makeClient { request in
+      let response = AlchemyTestSupport.okResponse(for: request)
+      return (response, Data("not json".utf8))
+    }
+    await #expect(throws: WalletSyncError.providerMalformedResponse(stage: "getAssetTransfers")) {
+      _ = try await client.getAssetTransfers(
+        chain: .ethereum, walletAddress: "0xabc", fromBlock: 0
+      )
+    }
+  }
+}

--- a/MoolahTests/Shared/CryptoImport/LiveAlchemyClientRequestTests.swift
+++ b/MoolahTests/Shared/CryptoImport/LiveAlchemyClientRequestTests.swift
@@ -1,0 +1,155 @@
+// MoolahTests/Shared/CryptoImport/LiveAlchemyClientRequestTests.swift
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("LiveAlchemyClient — request shape")
+struct LiveAlchemyClientRequestTests {
+  @Test
+  func ethereumRequestUsesEthMainnetSlugAndIncludesInternalCategory() async throws {
+    let fixture = try AlchemyTestSupport.loadFixture("eth-simple-eth-send")
+    let client = AlchemyTestSupport.makeClient { request in
+      AlchemyURLProtocolStub.captureRequest(request)
+      return (AlchemyTestSupport.okResponse(for: request), fixture)
+    }
+
+    _ = try await client.getAssetTransfers(
+      chain: .ethereum,
+      walletAddress: "0xabc",
+      fromBlock: 0
+    )
+
+    let url = try #require(AlchemyURLProtocolStub.lastRequest?.url)
+    #expect(url.host == "eth-mainnet.g.alchemy.com")
+    #expect(url.path == "/v2/test-key")
+    #expect(AlchemyURLProtocolStub.lastRequest?.httpMethod == "POST")
+
+    let body = AlchemyURLProtocolStub.lastBodyJSON
+    #expect(body["method"] as? String == "alchemy_getAssetTransfers")
+    let paramsArray = try #require(body["params"] as? [[String: Any]])
+    let params = try #require(paramsArray.first)
+    let categories = try #require(params["category"] as? [String])
+    #expect(categories.contains("external"))
+    #expect(categories.contains("erc20"))
+    #expect(categories.contains("internal"))
+  }
+
+  @Test
+  func optimismRequestExcludesInternalCategory() async throws {
+    let fixture = try AlchemyTestSupport.loadFixture("eth-simple-eth-send")
+    let client = AlchemyTestSupport.makeClient { request in
+      AlchemyURLProtocolStub.captureRequest(request)
+      return (AlchemyTestSupport.okResponse(for: request), fixture)
+    }
+    _ = try await client.getAssetTransfers(
+      chain: .optimism, walletAddress: "0xabc", fromBlock: 0
+    )
+
+    let url = try #require(AlchemyURLProtocolStub.lastRequest?.url)
+    #expect(url.host == "opt-mainnet.g.alchemy.com")
+    let body = AlchemyURLProtocolStub.lastBodyJSON
+    let paramsArray = try #require(body["params"] as? [[String: Any]])
+    let categories = try #require(paramsArray.first?["category"] as? [String])
+    #expect(categories.contains("external"))
+    #expect(categories.contains("erc20"))
+    #expect(categories.contains("internal") == false)
+  }
+
+  @Test
+  func baseRequestExcludesInternalCategory() async throws {
+    let fixture = try AlchemyTestSupport.loadFixture("eth-simple-eth-send")
+    let client = AlchemyTestSupport.makeClient { request in
+      AlchemyURLProtocolStub.captureRequest(request)
+      return (AlchemyTestSupport.okResponse(for: request), fixture)
+    }
+    _ = try await client.getAssetTransfers(
+      chain: .base, walletAddress: "0xabc", fromBlock: 0
+    )
+    let url = try #require(AlchemyURLProtocolStub.lastRequest?.url)
+    #expect(url.host == "base-mainnet.g.alchemy.com")
+    let body = AlchemyURLProtocolStub.lastBodyJSON
+    let paramsArray = try #require(body["params"] as? [[String: Any]])
+    let categories = try #require(paramsArray.first?["category"] as? [String])
+    #expect(categories.contains("internal") == false)
+  }
+
+  @Test
+  func polygonRequestUsesPolygonSlugAndIncludesInternal() async throws {
+    let fixture = try AlchemyTestSupport.loadFixture("polygon-spam-airdrop")
+    let client = AlchemyTestSupport.makeClient { request in
+      AlchemyURLProtocolStub.captureRequest(request)
+      return (AlchemyTestSupport.okResponse(for: request), fixture)
+    }
+    _ = try await client.getAssetTransfers(
+      chain: .polygon, walletAddress: "0xdef", fromBlock: 0
+    )
+    let url = try #require(AlchemyURLProtocolStub.lastRequest?.url)
+    #expect(url.host == "polygon-mainnet.g.alchemy.com")
+    let body = AlchemyURLProtocolStub.lastBodyJSON
+    let paramsArray = try #require(body["params"] as? [[String: Any]])
+    let categories = try #require(paramsArray.first?["category"] as? [String])
+    #expect(categories.contains("internal"))
+  }
+
+  @Test
+  func twoPassQueryUsesFromAddressThenToAddress() async throws {
+    let fixture = try AlchemyTestSupport.loadFixture("eth-simple-eth-send")
+    let calls = TestCallRecorder()
+    let client = AlchemyTestSupport.makeClient { request in
+      calls.record(request: request)
+      return (AlchemyTestSupport.okResponse(for: request), fixture)
+    }
+    _ = try await client.getAssetTransfers(
+      chain: .ethereum, walletAddress: "0xWALLET", fromBlock: 0x100
+    )
+
+    let recorded = calls.captured
+    #expect(recorded.count == 2)
+    let firstParams = try #require((recorded[0]["params"] as? [[String: Any]])?.first)
+    let secondParams = try #require((recorded[1]["params"] as? [[String: Any]])?.first)
+    #expect(firstParams["fromAddress"] as? String == "0xWALLET")
+    #expect(firstParams["toAddress"] == nil)
+    #expect(secondParams["toAddress"] as? String == "0xWALLET")
+    #expect(secondParams["fromAddress"] == nil)
+    #expect(firstParams["fromBlock"] as? String == "0x100")
+    #expect(firstParams["withMetadata"] as? Bool == true)
+    #expect(firstParams["excludeZeroValue"] as? Bool == true)
+  }
+
+  @Test
+  func responseDecodesIntoTransfersArray() async throws {
+    let fixture = try AlchemyTestSupport.loadFixture("eth-simple-eth-send")
+    let client = AlchemyTestSupport.makeClient { request in
+      (AlchemyTestSupport.okResponse(for: request), fixture)
+    }
+    let transfers = try await client.getAssetTransfers(
+      chain: .ethereum, walletAddress: "0xabc", fromBlock: 0
+    )
+    // Two-pass query → both passes return the same fixture.
+    #expect(transfers.count == 2)
+    #expect(transfers[0].asset == "ETH")
+  }
+
+  @Test
+  func tokenMetadataDecodesUSDC() async throws {
+    let fixture = try AlchemyTestSupport.loadFixture("token-metadata-usdc")
+    let client = AlchemyTestSupport.makeClient { request in
+      AlchemyURLProtocolStub.captureRequest(request)
+      return (AlchemyTestSupport.okResponse(for: request), fixture)
+    }
+    let metadata = try await client.getTokenMetadata(
+      chain: .ethereum,
+      contractAddress: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+    )
+    #expect(metadata.symbol == "USDC")
+    #expect(metadata.name == "USD Coin")
+    #expect(metadata.decimals == 6)
+    #expect(metadata.isSpam == false)
+
+    let body = AlchemyURLProtocolStub.lastBodyJSON
+    #expect(body["method"] as? String == "alchemy_getTokenMetadata")
+    let paramsArray = try #require(body["params"] as? [String])
+    #expect(paramsArray.first == "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48")
+  }
+}

--- a/MoolahTests/Shared/CryptoImport/RateLimiterTests.swift
+++ b/MoolahTests/Shared/CryptoImport/RateLimiterTests.swift
@@ -1,0 +1,137 @@
+// MoolahTests/Shared/CryptoImport/RateLimiterTests.swift
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("RateLimiter")
+struct RateLimiterTests {
+  /// Test clock: a `Sendable` closure backed by a `Mutex` so the test can
+  /// pin "now" deterministically. `RateLimiter`'s constructor and `refill`
+  /// only ever call the closure inside the actor, so a single shared
+  /// reference under a lock is safe and adequate here.
+  private final class TestClock: @unchecked Sendable {
+    private let lock = NSLock()
+    private var currentTime: Date
+
+    init(start: Date) { self.currentTime = start }
+
+    func now() -> Date {
+      lock.lock()
+      defer { lock.unlock() }
+      return currentTime
+    }
+
+    func advance(by seconds: TimeInterval) {
+      lock.lock()
+      defer { lock.unlock() }
+      currentTime = currentTime.addingTimeInterval(seconds)
+    }
+  }
+
+  @Test
+  func fullBucketAllowsBurstWithoutWaiting() async throws {
+    let clock = TestClock(start: Date(timeIntervalSince1970: 1_000_000))
+    let limiter = RateLimiter(permitsPerSecond: 25) { clock.now() }
+
+    // 25 acquires must complete with no advancement of the clock. If the
+    // limiter required wall-clock time we'd hang the test runner; we
+    // bound the assertion with a timeout via `withTimeout`.
+    try await withTimeout(seconds: 1) {
+      for _ in 0..<25 {
+        try await limiter.acquire()
+      }
+    }
+  }
+
+  @Test
+  func twentySixthAcquireWaitsForRefill() async throws {
+    let clock = TestClock(start: Date(timeIntervalSince1970: 1_000_000))
+    let limiter = RateLimiter(permitsPerSecond: 25) { clock.now() }
+
+    // Burn the bucket.
+    for _ in 0..<25 {
+      try await limiter.acquire()
+    }
+
+    // Start a 26th acquire in a child task; it should still be running
+    // because the clock has not advanced.
+    let task = Task { try await limiter.acquire() }
+
+    // Yield enough times for the limiter to enter its sleep loop. Without
+    // advancing the clock, the actor must not return.
+    for _ in 0..<5 {
+      await Task.yield()
+    }
+    #expect(task.isCancelled == false)
+    // The task is still in flight (not yet completed) — we can verify
+    // by checking it hasn't published a result. There's no public API
+    // for that; cancel and check the cancellation propagates instead.
+    task.cancel()
+    await #expect(throws: CancellationError.self) {
+      try await task.value
+    }
+  }
+
+  @Test
+  func cancelledAcquireThrowsCancellationError() async throws {
+    let clock = TestClock(start: Date(timeIntervalSince1970: 1_000_000))
+    let limiter = RateLimiter(permitsPerSecond: 25) { clock.now() }
+
+    for _ in 0..<25 {
+      try await limiter.acquire()
+    }
+    let task = Task { try await limiter.acquire() }
+    // Allow the task to enter the sleep loop, then cancel.
+    for _ in 0..<3 {
+      await Task.yield()
+    }
+    task.cancel()
+    await #expect(throws: CancellationError.self) {
+      try await task.value
+    }
+  }
+
+  @Test
+  func bucketRefillsOverTime() async throws {
+    let clock = TestClock(start: Date(timeIntervalSince1970: 1_000_000))
+    let limiter = RateLimiter(permitsPerSecond: 25) { clock.now() }
+
+    // Burn the bucket.
+    for _ in 0..<25 {
+      try await limiter.acquire()
+    }
+    // Advance one second — that should refill the entire bucket.
+    clock.advance(by: 1.0)
+    try await withTimeout(seconds: 1) {
+      for _ in 0..<25 {
+        try await limiter.acquire()
+      }
+    }
+  }
+}
+
+// MARK: - Test helpers
+
+/// Runs `body` and traps if it does not return within `seconds`. Used to
+/// guarantee that "no-wait" assertions do not hang the test runner if the
+/// implementation regresses to a real wait.
+private func withTimeout<T: Sendable>(
+  seconds: TimeInterval,
+  body: @Sendable @escaping () async throws -> T
+) async throws -> T {
+  try await withThrowingTaskGroup(of: T.self) { group in
+    group.addTask { try await body() }
+    group.addTask {
+      try await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
+      throw TimeoutError()
+    }
+    guard let value = try await group.next() else {
+      throw TimeoutError()
+    }
+    group.cancelAll()
+    return value
+  }
+}
+
+private struct TimeoutError: Error {}

--- a/MoolahTests/Support/Fixtures/alchemy/eth-erc20-transfer.json
+++ b/MoolahTests/Support/Fixtures/alchemy/eth-erc20-transfer.json
@@ -1,0 +1,44 @@
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "transfers": [
+      {
+        "blockNum": "0x12d5102",
+        "uniqueId": "0xfeedface00000000000000000000000000000000000000000000000000000001:log:5",
+        "hash": "0xfeedface00000000000000000000000000000000000000000000000000000001",
+        "from": "0x3333333333333333333333333333333333333333",
+        "to": "0x4444444444444444444444444444444444444444",
+        "value": 1000.5,
+        "asset": "USDC",
+        "category": "erc20",
+        "rawContract": {
+          "rawValue": "0x3b9bca00",
+          "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+          "decimal": "0x6"
+        },
+        "metadata": {
+          "blockTimestamp": "2024-10-01T08:15:30.000Z"
+        }
+      },
+      {
+        "blockNum": "0x12d5300",
+        "uniqueId": "0xfeedface00000000000000000000000000000000000000000000000000000002:internal:0",
+        "hash": "0xfeedface00000000000000000000000000000000000000000000000000000002",
+        "from": "0x4444444444444444444444444444444444444444",
+        "to": "0x3333333333333333333333333333333333333333",
+        "value": 0.0,
+        "asset": "ETH",
+        "category": "internal",
+        "rawContract": {
+          "rawValue": "0x0",
+          "address": null,
+          "decimal": "0x12"
+        },
+        "metadata": {
+          "blockTimestamp": "2024-10-01T08:20:00.000Z"
+        }
+      }
+    ]
+  }
+}

--- a/MoolahTests/Support/Fixtures/alchemy/eth-simple-eth-send.json
+++ b/MoolahTests/Support/Fixtures/alchemy/eth-simple-eth-send.json
@@ -1,0 +1,26 @@
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "transfers": [
+      {
+        "blockNum": "0x12d4f0a",
+        "uniqueId": "0xabc123def456000000000000000000000000000000000000000000000000aaaa:external:0",
+        "hash": "0xabc123def456000000000000000000000000000000000000000000000000aaaa",
+        "from": "0x1111111111111111111111111111111111111111",
+        "to": "0x2222222222222222222222222222222222222222",
+        "value": 0.05,
+        "asset": "ETH",
+        "category": "external",
+        "rawContract": {
+          "rawValue": "0xb1a2bc2ec50000",
+          "address": null,
+          "decimal": "0x12"
+        },
+        "metadata": {
+          "blockTimestamp": "2024-09-12T12:34:56.000Z"
+        }
+      }
+    ]
+  }
+}

--- a/MoolahTests/Support/Fixtures/alchemy/polygon-spam-airdrop.json
+++ b/MoolahTests/Support/Fixtures/alchemy/polygon-spam-airdrop.json
@@ -1,0 +1,44 @@
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "transfers": [
+      {
+        "blockNum": "0x4321abc",
+        "uniqueId": "0x9999000000000000000000000000000000000000000000000000000000000aaa:log:1",
+        "hash": "0x9999000000000000000000000000000000000000000000000000000000000aaa",
+        "from": "0x0000000000000000000000000000000000005555",
+        "to": "0x6666666666666666666666666666666666666666",
+        "value": 1000000.0,
+        "asset": "VISIT-AIRDROP-SITE.COM",
+        "category": "erc20",
+        "rawContract": {
+          "rawValue": "0xd3c21bcecceda1000000",
+          "address": "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+          "decimal": "0x12"
+        },
+        "metadata": {
+          "blockTimestamp": "2024-11-15T03:45:00.000Z"
+        }
+      },
+      {
+        "blockNum": "0x4321abe",
+        "uniqueId": "0x9999000000000000000000000000000000000000000000000000000000000bbb:specialnft:0",
+        "hash": "0x9999000000000000000000000000000000000000000000000000000000000bbb",
+        "from": "0x0000000000000000000000000000000000005555",
+        "to": "0x6666666666666666666666666666666666666666",
+        "value": null,
+        "asset": "Spam NFT",
+        "category": "specialnft",
+        "rawContract": {
+          "rawValue": "0x1",
+          "address": "0xcafebabecafebabecafebabecafebabecafebabe",
+          "decimal": null
+        },
+        "metadata": {
+          "blockTimestamp": "2024-11-15T03:50:00.000Z"
+        }
+      }
+    ]
+  }
+}

--- a/MoolahTests/Support/Fixtures/alchemy/token-metadata-usdc.json
+++ b/MoolahTests/Support/Fixtures/alchemy/token-metadata-usdc.json
@@ -1,0 +1,11 @@
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "decimals": 6,
+    "logo": "https://static.alchemyapi.io/images/assets/3408.png",
+    "name": "USD Coin",
+    "symbol": "USDC",
+    "isSpam": false
+  }
+}

--- a/Shared/CryptoImport/AlchemyClient.swift
+++ b/Shared/CryptoImport/AlchemyClient.swift
@@ -1,0 +1,338 @@
+// Shared/CryptoImport/AlchemyClient.swift
+import Foundation
+import OSLog
+
+/// Public protocol so test stubs can replace the live client. Stage 6's
+/// `WalletSyncEngine` injects an `AlchemyClient` rather than a concrete
+/// struct; v1 ships only `LiveAlchemyClient` plus per-test stubs.
+protocol AlchemyClient: Sendable {
+  /// Returns transfers in `[fromBlock, latestBlock]` for `walletAddress`,
+  /// in two passes: `fromAddress = walletAddress` and
+  /// `toAddress = walletAddress`. Categories include `external` and
+  /// `erc20` always; `internal` is included only when
+  /// `chain.supportsInternalTransfers` is `true`. NFT categories are
+  /// always excluded at the request level.
+  func getAssetTransfers(
+    chain: ChainConfig,
+    walletAddress: String,
+    fromBlock: UInt64
+  ) async throws -> [AlchemyTransfer]
+
+  /// Best-effort token metadata fetch — used for `isSpam` classification
+  /// in Stage 5's discovery service. Native tokens are not represented
+  /// by a contract address, so callers do not call this for native gas.
+  func getTokenMetadata(
+    chain: ChainConfig,
+    contractAddress: String
+  ) async throws -> AlchemyTokenMetadata
+}
+
+/// Token metadata returned by Alchemy's `alchemy_getTokenMetadata` JSON-RPC
+/// method. All fields are optional because Alchemy returns `null` for
+/// unknown tokens. `isSpam` is `false` if the field is absent — the field
+/// is only present on chains where Alchemy provides spam classification.
+struct AlchemyTokenMetadata: Sendable, Hashable, Codable {
+  let symbol: String?
+  let name: String?
+  let decimals: Int?
+  let logo: URL?
+  let isSpam: Bool
+}
+
+extension AlchemyTokenMetadata {
+  /// Custom decoder so a missing `isSpam` field decodes as `false` rather
+  /// than failing the decode. Defined in an extension to preserve the
+  /// synthesised memberwise initializer on the primary declaration.
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    let symbol = try container.decodeIfPresent(String.self, forKey: .symbol)
+    let name = try container.decodeIfPresent(String.self, forKey: .name)
+    let decimals = try container.decodeIfPresent(Int.self, forKey: .decimals)
+    let logo = try container.decodeIfPresent(URL.self, forKey: .logo)
+    let isSpam = try container.decodeIfPresent(Bool.self, forKey: .isSpam) ?? false
+    self.init(symbol: symbol, name: name, decimals: decimals, logo: logo, isSpam: isSpam)
+  }
+}
+
+/// Live `AlchemyClient` over `URLSession`. Sendable struct — no mutable
+/// state; mirrors the shape of `Backends/CoinGecko/CoinGeckoClient.swift`.
+///
+/// Privacy classifications follow the design table:
+/// `chainId` and block numbers → `.public`; wallet addresses and contract
+/// addresses → `.private`; the API key is never logged.
+struct LiveAlchemyClient: AlchemyClient {
+  private let session: URLSession
+  private let apiKey: String
+  private let rateLimiter: RateLimiter
+  private let logger: Logger
+
+  /// - Parameters:
+  ///   - session: `URLSession` for HTTP requests. Default is `.shared`;
+  ///     tests inject an ephemeral session backed by `URLProtocol`.
+  ///   - apiKey: Alchemy API key. Never logged.
+  ///   - rateLimiter: Shared `RateLimiter` actor — caller is responsible
+  ///     for sizing it to the Alchemy plan in use (25 req/s on free tier).
+  init(
+    session: URLSession = .shared,
+    apiKey: String,
+    rateLimiter: RateLimiter
+  ) {
+    self.session = session
+    self.apiKey = apiKey
+    self.rateLimiter = rateLimiter
+    self.logger = Logger(subsystem: "com.moolah.app", category: "AlchemyClient")
+  }
+
+  func getAssetTransfers(
+    chain: ChainConfig,
+    walletAddress: String,
+    fromBlock: UInt64
+  ) async throws -> [AlchemyTransfer] {
+    var transfers: [AlchemyTransfer] = []
+    transfers.append(
+      contentsOf: try await fetchTransfers(
+        chain: chain,
+        address: walletAddress,
+        isFromAddress: true,
+        fromBlock: fromBlock
+      )
+    )
+    transfers.append(
+      contentsOf: try await fetchTransfers(
+        chain: chain,
+        address: walletAddress,
+        isFromAddress: false,
+        fromBlock: fromBlock
+      )
+    )
+    return transfers
+  }
+
+  func getTokenMetadata(
+    chain: ChainConfig,
+    contractAddress: String
+  ) async throws -> AlchemyTokenMetadata {
+    try await rateLimiter.acquire()
+    let body = JSONRPCRequest<AlchemyParams>(
+      method: "alchemy_getTokenMetadata",
+      params: .tokenMetadata(contractAddress: contractAddress)
+    )
+    let request = try buildRequest(chain: chain, body: body)
+    logger.debug(
+      "Alchemy token metadata: chain \(chain.chainId, privacy: .public) contract \(contractAddress, privacy: .private)"
+    )
+    let data = try await send(request: request, stage: "getTokenMetadata")
+    do {
+      let envelope = try JSONDecoder().decode(
+        JSONRPCResponse<AlchemyTokenMetadata>.self,
+        from: data
+      )
+      return envelope.result
+    } catch {
+      logger.error(
+        "Alchemy token metadata decode failed for chain \(chain.chainId, privacy: .public): \(error.localizedDescription, privacy: .public)"
+      )
+      throw WalletSyncError.providerMalformedResponse(stage: "getTokenMetadata")
+    }
+  }
+
+  // MARK: - Internals
+
+  private func fetchTransfers(
+    chain: ChainConfig,
+    address: String,
+    isFromAddress: Bool,
+    fromBlock: UInt64
+  ) async throws -> [AlchemyTransfer] {
+    try await rateLimiter.acquire()
+
+    var categories: [AlchemyTransferCategory] = [.external, .erc20]
+    if chain.supportsInternalTransfers {
+      categories.append(.internal)
+    }
+    let body = JSONRPCRequest<AlchemyParams>(
+      method: "alchemy_getAssetTransfers",
+      params: .assetTransfers(
+        AssetTransfersParams(
+          fromBlock: "0x" + String(fromBlock, radix: 16),
+          toBlock: "latest",
+          fromAddress: isFromAddress ? address : nil,
+          toAddress: isFromAddress ? nil : address,
+          category: categories.map(\.rawValue),
+          withMetadata: true,
+          excludeZeroValue: true
+        )
+      )
+    )
+    let request = try buildRequest(chain: chain, body: body)
+    logger.debug(
+      """
+      Alchemy getAssetTransfers: chain \(chain.chainId, privacy: .public) \
+      direction \(isFromAddress ? "from" : "to", privacy: .public) \
+      address \(address, privacy: .private) \
+      fromBlock \(fromBlock, privacy: .public)
+      """
+    )
+
+    let data = try await send(request: request, stage: "getAssetTransfers")
+    do {
+      let envelope = try JSONDecoder().decode(AlchemyTransferEnvelope.self, from: data)
+      return envelope.result.transfers
+    } catch {
+      logger.error(
+        "Alchemy getAssetTransfers decode failed for chain \(chain.chainId, privacy: .public): \(error.localizedDescription, privacy: .public)"
+      )
+      throw WalletSyncError.providerMalformedResponse(stage: "getAssetTransfers")
+    }
+  }
+
+  private func send(request: URLRequest, stage: String) async throws -> Data {
+    let data: Data
+    let response: URLResponse
+    do {
+      (data, response) = try await session.data(for: request)
+    } catch let urlError as URLError where urlError.code == .cancelled {
+      throw CancellationError()
+    } catch {
+      logger.error(
+        "Alchemy \(stage, privacy: .public) network failure: \(error.localizedDescription, privacy: .public)"
+      )
+      throw WalletSyncError.network(underlyingDescription: error.localizedDescription)
+    }
+    try validate(response: response, stage: stage)
+    return data
+  }
+
+  private func buildRequest<Params: Encodable>(
+    chain: ChainConfig,
+    body: JSONRPCRequest<Params>
+  ) throws -> URLRequest {
+    let urlString = "https://\(chain.alchemyNetworkSlug).g.alchemy.com/v2/\(apiKey)"
+    guard let url = URL(string: urlString) else {
+      throw WalletSyncError.network(
+        underlyingDescription: "Malformed Alchemy URL for chain \(chain.chainId)"
+      )
+    }
+    var request = URLRequest(url: url)
+    request.httpMethod = "POST"
+    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    request.setValue("application/json", forHTTPHeaderField: "Accept")
+    do {
+      request.httpBody = try JSONEncoder().encode(body)
+    } catch {
+      throw WalletSyncError.providerMalformedResponse(stage: "encodeRequestBody")
+    }
+    return request
+  }
+
+  private func validate(response: URLResponse, stage: String) throws {
+    guard let http = response as? HTTPURLResponse else {
+      logger.error(
+        "Alchemy \(stage, privacy: .public): non-HTTP response"
+      )
+      throw WalletSyncError.network(underlyingDescription: "No HTTP response")
+    }
+    switch http.statusCode {
+    case 200...299:
+      return
+    case 401, 403:
+      logger.error(
+        "Alchemy \(stage, privacy: .public): API key rejected (HTTP \(http.statusCode, privacy: .public))"
+      )
+      throw WalletSyncError.invalidApiKey
+    case 429:
+      let retryAfter = parseRetryAfter(http: http)
+      logger.notice(
+        "Alchemy \(stage, privacy: .public): rate limited (HTTP 429)"
+      )
+      throw WalletSyncError.rateLimited(retryAfter: retryAfter)
+    default:
+      logger.error(
+        "Alchemy \(stage, privacy: .public): HTTP \(http.statusCode, privacy: .public)"
+      )
+      throw WalletSyncError.network(
+        underlyingDescription: "HTTP \(http.statusCode)"
+      )
+    }
+  }
+
+  /// Parses `Retry-After` per RFC 7231: either a non-negative integer
+  /// seconds value or an HTTP-date. Returns `nil` when the header is
+  /// absent or unparseable.
+  private func parseRetryAfter(http: HTTPURLResponse) -> Date? {
+    guard let header = http.value(forHTTPHeaderField: "Retry-After") else {
+      return nil
+    }
+    let trimmed = header.trimmingCharacters(in: .whitespaces)
+    if let seconds = TimeInterval(trimmed) {
+      return Date().addingTimeInterval(seconds)
+    }
+    let formatter = DateFormatter()
+    formatter.locale = Locale(identifier: "en_US_POSIX")
+    formatter.timeZone = TimeZone(identifier: "GMT")
+    formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
+    return formatter.date(from: trimmed)
+  }
+}
+
+// MARK: - JSON-RPC envelope
+
+/// Outer JSON-RPC 2.0 request envelope. `id` is fixed at 1 — Alchemy
+/// echoes it back, but our requests are single-shot so we don't correlate.
+private struct JSONRPCRequest<Params: Encodable>: Encodable {
+  let jsonrpc: String
+  let id: Int
+  let method: String
+  let params: Params
+
+  init(method: String, params: Params) {
+    self.jsonrpc = "2.0"
+    self.id = 1
+    self.method = method
+    self.params = params
+  }
+}
+
+/// Outer JSON-RPC 2.0 response envelope, generic over the result body.
+private struct JSONRPCResponse<Result: Decodable>: Decodable {
+  let result: Result
+}
+
+/// Discriminated `params` payload — covers the two JSON-RPC methods this
+/// client makes today. Each case encodes as the JSON-RPC convention of a
+/// one-element array around the parameter object (or address string).
+private enum AlchemyParams: Encodable {
+  case assetTransfers(AssetTransfersParams)
+  case tokenMetadata(contractAddress: String)
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.unkeyedContainer()
+    switch self {
+    case .assetTransfers(let params):
+      try container.encode(params)
+    case .tokenMetadata(let address):
+      try container.encode(address)
+    }
+  }
+}
+
+/// Body for the `params[0]` object of `alchemy_getAssetTransfers`.
+private struct AssetTransfersParams: Encodable {
+  let fromBlock: String
+  let toBlock: String
+  let fromAddress: String?
+  let toAddress: String?
+  let category: [String]
+  let withMetadata: Bool
+  let excludeZeroValue: Bool
+}
+
+/// Decodes the `result` object of `alchemy_getAssetTransfers`. The
+/// outer envelope wraps this in `JSONRPCResponse<AlchemyTransferResult>`.
+private struct AlchemyTransferEnvelope: Decodable {
+  let result: AlchemyTransferResult
+}
+
+private struct AlchemyTransferResult: Decodable {
+  let transfers: [AlchemyTransfer]
+}

--- a/Shared/CryptoImport/AlchemyTransfer.swift
+++ b/Shared/CryptoImport/AlchemyTransfer.swift
@@ -1,0 +1,121 @@
+// Shared/CryptoImport/AlchemyTransfer.swift
+import Foundation
+
+/// One entry from Alchemy's `alchemy_getAssetTransfers` response.
+///
+/// Stage 4 only decodes — the transformation to `BuiltTransaction` is
+/// Stage 6's job. All fields needed by later stages are preserved here:
+///
+/// - `hash` / `uniqueId` — used as the `externalId` for de-duplication
+///   across two-pass `fromAddress` / `toAddress` queries.
+/// - `from` / `to` — required for cross-account transfer detection.
+/// - `category` — distinguishes native, internal, and ERC-20 transfers
+///   (NFT categories are filtered at request time and not represented).
+/// - `asset` — the human-readable token symbol from Alchemy. Best-effort;
+///   may differ from the canonical CoinGecko symbol.
+/// - `rawContract.address` — `nil` for native transfers; the ERC-20
+///   contract address otherwise. Used as part of the instrument key.
+/// - `rawContract.decimal` — token decimals as a 0x-prefixed hex string.
+///   Required to convert `rawValue` into a human-scaled `Decimal`.
+/// - `rawContract.rawValue` — exact integer-units value as a 0x-prefixed
+///   hex string. Source-of-truth for arithmetic; the JSON `value` field
+///   is a lossy IEEE-754 representation that rounds large amounts.
+/// - `metadata.blockTimestamp` — ISO-8601 timestamp of the block that
+///   contains this transfer. Used for the transaction date.
+/// - `blockNum` — 0x-prefixed hex block number; persisted as the
+///   `lastSyncedBlock` watermark.
+struct AlchemyTransfer: Sendable, Hashable, Decodable {
+  let hash: String
+  let uniqueId: String
+  let from: String
+  let to: String?
+  let category: AlchemyTransferCategory
+  let asset: String?
+  let rawContract: RawContract
+  let metadata: Metadata
+  let blockNum: String
+
+  /// Inner `rawContract` object. Hex-encoded fields are kept as strings —
+  /// callers that need numeric values use the `decimalValue` and
+  /// `decimalsValue` helpers, both of which return `nil` rather than
+  /// throwing on malformed input (so a single bad row doesn't fail the
+  /// whole sync).
+  struct RawContract: Sendable, Hashable, Decodable {
+    /// Contract address (`nil` for native-token transfers).
+    let address: String?
+    /// 0x-prefixed hex of the token decimals (e.g. `"0x12"` = 18). May
+    /// be missing on native transfers — Alchemy then omits the field.
+    let decimal: String?
+    /// 0x-prefixed hex of the integer-units transfer amount. Always
+    /// present for transfers Alchemy returns.
+    let rawValue: String?
+
+    /// Parses `decimal` from 0x-hex into an `Int`. Returns `nil` if the
+    /// field is missing or malformed.
+    var decimalsValue: Int? {
+      decimal.flatMap { Self.parseHexInt($0) }
+    }
+
+    /// Parses `rawValue` from 0x-hex into a `Decimal`. Returns `nil` if
+    /// the field is missing or malformed. `Decimal` is used because
+    /// 256-bit token amounts overflow `UInt64`.
+    var rawDecimalValue: Decimal? {
+      rawValue.flatMap { Self.parseHexDecimal($0) }
+    }
+
+    private static func parseHexInt(_ string: String) -> Int? {
+      let trimmed = stripHexPrefix(string)
+      return Int(trimmed, radix: 16)
+    }
+
+    /// Parses a 0x-prefixed hex string into a `Decimal`. Loops over each
+    /// nibble multiplying by 16 — accumulator-based because `Decimal`
+    /// has no built-in radix-16 initializer and we need the full
+    /// 256-bit range.
+    private static func parseHexDecimal(_ string: String) -> Decimal? {
+      let trimmed = stripHexPrefix(string)
+      guard !trimmed.isEmpty else { return nil }
+      var result: Decimal = 0
+      for char in trimmed {
+        guard let nibble = char.hexDigitValue else { return nil }
+        result = result * 16 + Decimal(nibble)
+      }
+      return result
+    }
+
+    private static func stripHexPrefix(_ string: String) -> String {
+      string.hasPrefix("0x") || string.hasPrefix("0X")
+        ? String(string.dropFirst(2))
+        : string
+    }
+  }
+
+  /// Inner `metadata` object. Alchemy provides `blockTimestamp` only when
+  /// the request sets `withMetadata: true`.
+  struct Metadata: Sendable, Hashable, Decodable {
+    /// ISO-8601 block timestamp (e.g. `"2024-09-12T12:34:56.000Z"`).
+    let blockTimestamp: String?
+  }
+}
+
+/// Subset of Alchemy's transfer categories we accept.
+///
+/// NFT categories (`erc721`, `erc1155`, `specialnft`) are deliberately
+/// filtered at the request level — we never request them. The `unknown`
+/// case keeps decoding lenient: if a future Alchemy release introduces a
+/// new category, callers can filter it out without crashing the sync.
+enum AlchemyTransferCategory: String, Sendable, Hashable, Codable {
+  case external
+  case `internal`
+  case erc20
+  /// Defensive default — covers any unrecognised string Alchemy might
+  /// return (including NFT categories that slip through despite the
+  /// request-level filter).
+  case unknown
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    let raw = try container.decode(String.self)
+    self = AlchemyTransferCategory(rawValue: raw) ?? .unknown
+  }
+}

--- a/Shared/CryptoImport/ChainConfig.swift
+++ b/Shared/CryptoImport/ChainConfig.swift
@@ -1,0 +1,106 @@
+// Shared/CryptoImport/ChainConfig.swift
+import Foundation
+
+/// Per-chain config for the crypto wallet importer.
+///
+/// v1 covers Ethereum, OP Mainnet, Base, and Polygon. Extending to other EVM
+/// chains (Arbitrum, Avalanche, …) is purely additive — add a new entry to
+/// `all`. See `plans/2026-05-05-crypto-wallet-import-design.md` for the
+/// open question on `internal` transfer-category support across chains.
+struct ChainConfig: Sendable, Hashable {
+  /// EVM chain identifier (e.g. 1 for Ethereum mainnet).
+  let chainId: Int
+
+  /// Alchemy network slug, e.g. `eth-mainnet`, `opt-mainnet`,
+  /// `base-mainnet`, `polygon-mainnet`. Used as the path component for the
+  /// JSON-RPC endpoint hostname (`https://<slug>.g.alchemy.com/v2/<key>`).
+  let alchemyNetworkSlug: String
+
+  /// The instrument used as the chain's native token (gas) — ETH for
+  /// Ethereum / OP / Base; MATIC for Polygon.
+  let nativeInstrument: Instrument
+
+  /// `true` if Alchemy supports the `internal` transfer category on this
+  /// chain (Ethereum, Polygon). OP / Base do NOT support `internal` — see
+  /// design open question 3.
+  let supportsInternalTransfers: Bool
+
+  /// Block-explorer base URL (no trailing slash). Used by `BlockExplorerLink`
+  /// in Stage 12.
+  let blockExplorerBaseURL: URL
+
+  /// Human-readable name for the chain picker / settings UI.
+  let displayName: String
+
+  /// All supported chains, indexed by `chainId` order. Stage 10's chain
+  /// picker renders this in declaration order; stable across launches.
+  static let all: [ChainConfig] = [
+    .ethereum, .optimism, .base, .polygon,
+  ]
+
+  /// Lookup by EVM chain ID. Returns `nil` for unsupported chains.
+  static func config(for chainId: Int) -> ChainConfig? {
+    all.first { $0.chainId == chainId }
+  }
+}
+
+extension ChainConfig {
+  /// Ethereum mainnet — chain 1. Native token: ETH (18 decimals).
+  /// Supports the `internal` transfer category.
+  static let ethereum = ChainConfig(
+    chainId: 1,
+    alchemyNetworkSlug: "eth-mainnet",
+    nativeInstrument: Instrument.crypto(
+      chainId: 1, contractAddress: nil, symbol: "ETH", name: "Ethereum", decimals: 18),
+    supportsInternalTransfers: true,
+    blockExplorerBaseURL: requireURL("https://etherscan.io"),
+    displayName: "Ethereum"
+  )
+
+  /// OP Mainnet (Optimism) — chain 10. Native token: ETH (18 decimals).
+  /// Does NOT support the `internal` transfer category.
+  static let optimism = ChainConfig(
+    chainId: 10,
+    alchemyNetworkSlug: "opt-mainnet",
+    nativeInstrument: Instrument.crypto(
+      chainId: 10, contractAddress: nil, symbol: "ETH", name: "Ethereum", decimals: 18),
+    supportsInternalTransfers: false,
+    blockExplorerBaseURL: requireURL("https://optimistic.etherscan.io"),
+    displayName: "OP Mainnet"
+  )
+
+  /// Base — chain 8453. Native token: ETH (18 decimals).
+  /// Does NOT support the `internal` transfer category.
+  static let base = ChainConfig(
+    chainId: 8453,
+    alchemyNetworkSlug: "base-mainnet",
+    nativeInstrument: Instrument.crypto(
+      chainId: 8453, contractAddress: nil, symbol: "ETH", name: "Ethereum", decimals: 18),
+    supportsInternalTransfers: false,
+    blockExplorerBaseURL: requireURL("https://basescan.org"),
+    displayName: "Base"
+  )
+
+  /// Polygon PoS — chain 137. Native token: MATIC (18 decimals).
+  /// Supports the `internal` transfer category.
+  static let polygon = ChainConfig(
+    chainId: 137,
+    alchemyNetworkSlug: "polygon-mainnet",
+    nativeInstrument: Instrument.crypto(
+      chainId: 137, contractAddress: nil, symbol: "MATIC", name: "Polygon", decimals: 18),
+    supportsInternalTransfers: true,
+    blockExplorerBaseURL: requireURL("https://polygonscan.com"),
+    displayName: "Polygon"
+  )
+
+  /// Compile-time URL constructor. The hardcoded literals above are valid
+  /// URLs by inspection; a `nil` here is a programmer error rather than a
+  /// runtime failure mode, so `preconditionFailure` is the honest spelling
+  /// (we don't want to paper over a typo with a bogus fallback URL).
+  private static func requireURL(_ string: String) -> URL {
+    guard let url = URL(string: string) else {
+      preconditionFailure("ChainConfig: malformed URL literal \(string)")
+    }
+    return url
+  }
+}

--- a/Shared/CryptoImport/RateLimiter.swift
+++ b/Shared/CryptoImport/RateLimiter.swift
@@ -1,0 +1,73 @@
+// Shared/CryptoImport/RateLimiter.swift
+import Foundation
+
+/// Token-bucket rate limiter.
+///
+/// Used to throttle Alchemy calls to 25 req/s (free-tier limit). The clock
+/// is injected so tests can pin "now" deterministically — the live caller
+/// passes `{ Date() }` and tests pass a closure backed by a counter.
+///
+/// Concurrency: this is an `actor`; multiple concurrent callers serialise
+/// through `acquire()`. Cancellation is honoured between sleeps via
+/// `Task.checkCancellation()`.
+actor RateLimiter {
+  private let permitsPerSecond: Double
+  private let now: @Sendable () -> Date
+  private var availablePermits: Double
+  private var lastRefill: Date
+
+  /// - Parameters:
+  ///   - permitsPerSecond: Steady-state refill rate. The bucket capacity
+  ///     also equals `permitsPerSecond`, so a freshly-constructed limiter
+  ///     allows a burst of that many permits before throttling kicks in.
+  ///   - now: Closure returning the current time. Defaults to `Date()`.
+  ///     Tests inject a counter so wall-clock variance does not flake them.
+  init(
+    permitsPerSecond: Double,
+    now: @Sendable @escaping () -> Date = { Date() }
+  ) {
+    precondition(permitsPerSecond > 0, "RateLimiter requires a positive permit rate")
+    self.permitsPerSecond = permitsPerSecond
+    self.availablePermits = permitsPerSecond
+    self.now = now
+    self.lastRefill = now()
+  }
+
+  /// Awaits until at least one permit is available, then consumes it.
+  ///
+  /// Cancellation: throws `CancellationError` if the surrounding `Task` is
+  /// cancelled while waiting, either before the first refill check or via
+  /// `Task.sleep` interruption.
+  func acquire() async throws {
+    while true {
+      try Task.checkCancellation()
+      refill()
+      if availablePermits >= 1 {
+        availablePermits -= 1
+        return
+      }
+      // Compute sleep duration until at least one permit is available.
+      let needed = 1 - availablePermits
+      let secondsToWait = needed / permitsPerSecond
+      // Floor at 1ms so a near-zero deficit still yields a real sleep
+      // rather than a busy loop. Convert to nanoseconds for `Task.sleep`.
+      let nanos = UInt64(max(0.001, secondsToWait) * 1_000_000_000)
+      try await Task.sleep(nanoseconds: nanos)
+    }
+  }
+
+  /// Refills the bucket based on the time elapsed since the last refill.
+  /// Capacity is bounded by `permitsPerSecond`. Always called from inside
+  /// the actor's isolation domain.
+  private func refill() {
+    let currentTime = now()
+    let elapsed = currentTime.timeIntervalSince(lastRefill)
+    if elapsed > 0 {
+      availablePermits = min(
+        permitsPerSecond,
+        availablePermits + elapsed * permitsPerSecond
+      )
+      lastRefill = currentTime
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Stage 4 of `plans/2026-05-05-crypto-wallet-import-plan.md`. Adds the network-facing primitives wallets need to fetch on-chain data — purely additive plumbing; no caller wires this in until Stage 6. No dependency on Stages 2/3.

- `ChainConfig`: per-chain metadata (Alchemy slug, native instrument, block-explorer URL, `supportsInternalTransfers`) for ETH / OP / Base / Polygon. `internal` transfer category is enabled only for Ethereum + Polygon, per design open question 3.
- `AlchemyClient` protocol + `LiveAlchemyClient` struct (`Sendable`, `URLSession` pattern matching `CoinGeckoClient`). Two-pass `fromAddress` / `toAddress` query, JSON-RPC envelope, NFT categories filtered at request level.
- `AlchemyTransfer` + `AlchemyTokenMetadata` `Codable` decoding. Hex-encoded `rawValue` parsed into `Decimal` to handle 256-bit token amounts; `AlchemyTransferCategory` decodes leniently with `.unknown` fallback for any future / NFT categories.
- `RateLimiter` actor: token-bucket throttling for the 25 req/s free-tier limit; clock-injected for deterministic tests; cancellation honored between sleeps.
- Privacy-classified `os.Logger` throughout per design table (chain ID / blocks `.public`; wallet / contract addresses `.private`; API key never logged).
- Adds `Error` conformance to `WalletSyncError` so the data layer can throw it directly. `Codable` shape unchanged — persisted state stays backward-compatible.

Reference: `plans/2026-05-05-crypto-wallet-import-design.md` §"Sync engine", §"Concurrency model", §"Privacy-classified logging".

## Test plan

- [x] `just generate` regenerates Xcode project cleanly
- [x] `just build-mac` succeeds with zero warnings (project enforces `SWIFT_TREAT_WARNINGS_AS_ERRORS`)
- [x] `just format-check` clean (no SwiftLint baseline edits)
- [x] `just test` — all 2197 macOS + 2172 iOS tests pass
- [x] New test coverage:
  - `ChainConfigTests` — all four chains, lookup-by-id, internal-transfer support matches design
  - `RateLimiterTests` — full-bucket burst, 26th call waits, cancellation throws, refill over time
  - `AlchemyTransferDecodingTests` — native ETH send, ERC-20, internal-tx, Polygon spam, null-`to` contract creation, malformed hex, NFT categories decode as `.unknown`
  - `LiveAlchemyClientRequestTests` — per-chain URL/host correctness, two-pass query shape, `internal` toggle, token-metadata decode
  - `LiveAlchemyClientErrorTests` — 401/403 → `.invalidApiKey`, 429 + Retry-After → `.rateLimited(retryAfter:)`, 5xx + transport failure → `.network(...)`, malformed JSON → `.providerMalformedResponse(stage:)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)