### PR TITLE
feat(crypto): pricingStatus cross-device merge + cache invalidation

### DIFF
--- a/App/ProfileSession+Factories.swift
+++ b/App/ProfileSession+Factories.swift
@@ -157,7 +157,8 @@ extension ProfileSession {
     }
     let store = CryptoTokenStore(
       registry: cloudBackend.instrumentRegistry,
-      cryptoPriceService: cryptoPriceService)
+      cryptoPriceService: cryptoPriceService,
+      conversionService: cloudBackend.conversionService)
     let searchService = InstrumentSearchService(
       registry: cloudBackend.instrumentRegistry,
       catalog: catalog,

--- a/Backends/GRDB/Records/PricingStatusMerge.swift
+++ b/Backends/GRDB/Records/PricingStatusMerge.swift
@@ -1,0 +1,28 @@
+// Backends/GRDB/Records/PricingStatusMerge.swift
+
+import Foundation
+
+/// Cross-device merge rule for `TokenPricingStatus`.
+///
+/// CKSyncEngine's default "server wins" semantics would let the daily
+/// auto-resolver on one device clobber a `.spam` classification a user
+/// made on another. The merge rule below makes spam wins symmetric (user
+/// intent dominates from either side) and resolution-positive (`.priced`
+/// beats `.unpriced` either direction). Where the two sides agree, the
+/// status is unchanged.
+///
+/// See `plans/2026-05-05-crypto-wallet-import-design.md` §"Cross-device
+/// conflict resolution" for the truth-table that defines this contract.
+enum PricingStatusMerge {
+  /// Applies the cross-device merge rule and returns the resolved
+  /// status to persist. Pure — no I/O — so it can be unit-tested
+  /// against every cell of the 3x3 truth table without a database.
+  static func merge(
+    local: TokenPricingStatus,
+    incoming: TokenPricingStatus
+  ) -> TokenPricingStatus {
+    if local == .spam || incoming == .spam { return .spam }
+    if local == .priced || incoming == .priced { return .priced }
+    return .unpriced
+  }
+}

--- a/Backends/GRDB/Repositories/GRDBInstrumentRegistryRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBInstrumentRegistryRepository.swift
@@ -242,17 +242,31 @@ final class GRDBInstrumentRegistryRepository:
   func applyRemoteChangesSync(saved rows: [InstrumentRow], deleted ids: [String]) throws {
     try database.write { database in
       for var row in rows {
-        // Per spec §"`CryptoRegistration.pricingStatus`" — apply the field-
-        // level merge rule for pricingStatus before upserting. CKSyncEngine's
-        // default "server wins" would let the daily auto-resolver on one
-        // device clobber a `.spam` classification a user made on another.
+        // Per spec §"`CryptoRegistration.pricingStatus`" — apply the
+        // field-level merge rule for `pricingStatus` before upserting.
+        // CKSyncEngine's default "server wins" would let the daily
+        // auto-resolver on one device clobber a `.spam` classification a
+        // user made on another. The rule is centralised in
+        // `PricingStatusMerge.merge` and unit-tested against the full
+        // 3x3 truth table.
+        //
+        // Unrecognised raw values (only possible from a future-version
+        // device sending an enum case this build doesn't compile against,
+        // since legacy records that omit the field decode as `"priced"`
+        // in `InstrumentRow+CloudKit.swift`) decode as `.priced`. That
+        // matches the legacy fallback and keeps the merge defensive
+        // rather than throwing.
         if let existing =
           try InstrumentRow
           .filter(InstrumentRow.Columns.id == row.id)
           .fetchOne(database)
         {
-          row.pricingStatus = Self.mergedPricingStatus(
-            local: existing.pricingStatus, incoming: row.pricingStatus)
+          let local = TokenPricingStatus(rawValue: existing.pricingStatus) ?? .priced
+          let incoming = TokenPricingStatus(rawValue: row.pricingStatus) ?? .priced
+          row.pricingStatus =
+            PricingStatusMerge.merge(
+              local: local, incoming: incoming
+            ).rawValue
         }
         try row.upsert(database)
       }
@@ -262,18 +276,43 @@ final class GRDBInstrumentRegistryRepository:
     }
   }
 
-  /// Cross-device merge rule for `pricingStatus` per design spec:
-  /// - local `.spam` always wins (user intent never auto-reverts)
-  /// - incoming `.spam` always accepted (mirror user intent across devices)
-  /// - `.priced` beats `.unpriced` either direction (resolution success sticks)
-  /// - same → no change
-  static func mergedPricingStatus(local: String, incoming: String) -> String {
-    let spam = TokenPricingStatus.spam.rawValue
-    let priced = TokenPricingStatus.priced.rawValue
-    if local == spam { return spam }
-    if incoming == spam { return spam }
-    if local == priced || incoming == priced { return priced }
-    return incoming
+  /// Persists a new `pricingStatus` for the row identified by
+  /// `registration.instrument.id`, leaving every other column unchanged.
+  /// Used by `CryptoTokenStore.setStatus(_:for:)` to record a user-driven
+  /// classification (`.spam` / `.priced` / `.unpriced`). Throws when no
+  /// row is registered for the supplied instrument id — callers should
+  /// have an existing registration in hand before calling.
+  ///
+  /// **Field coverage.** Only the `pricing_status` column is rewritten;
+  /// `instrument` / `mapping` are read from `registration` purely to
+  /// locate the row. To rewrite the provider mapping, call
+  /// `registerCrypto(_:mapping:)` instead. Splitting the two surfaces
+  /// keeps the cross-device merge rule (which only governs
+  /// `pricing_status`) from having to reason about partial updates of
+  /// other server-authoritative columns.
+  ///
+  /// Fires `onRecordChanged` and the `observeChanges()` fan-out on
+  /// success so CKSyncEngine queues the record for upload and any picker
+  /// UI refreshes.
+  func update(_ registration: CryptoRegistration) async throws {
+    let updated = try await database.write { database -> Bool in
+      guard
+        var existing =
+          try InstrumentRow
+          .filter(InstrumentRow.Columns.id == registration.instrument.id)
+          .fetchOne(database)
+      else { return false }
+      existing.pricingStatus = registration.pricingStatus.rawValue
+      try existing.update(database)
+      return true
+    }
+    guard updated else {
+      throw BackendError.notFound(
+        "InstrumentRegistry: no row registered for id '\(registration.instrument.id)'"
+      )
+    }
+    onRecordChanged(registration.instrument.id)
+    await notifySubscribers()
   }
 
   /// Writes (or clears) the cached system-fields blob on a single row.

--- a/Domain/Repositories/InstrumentRegistryRepository.swift
+++ b/Domain/Repositories/InstrumentRegistryRepository.swift
@@ -41,6 +41,24 @@ protocol InstrumentRegistryRepository: Sendable {
   ///   kind is a programmer error and traps.
   func registerStock(_ instrument: Instrument) async throws
 
+  /// Persists a new `pricingStatus` for an existing crypto registration,
+  /// leaving every other column unchanged. Used by user-mutation paths
+  /// (e.g. the Discovered Tokens inbox / Spam tokens management UI) that
+  /// flip a token between `.priced` / `.unpriced` / `.spam` without
+  /// rewriting its provider mapping. Invokes the implementation's
+  /// sync-queue hook on success.
+  ///
+  /// Implementations rewrite only `pricingStatus`; `instrument` and
+  /// `mapping` on the supplied `registration` are used solely to locate
+  /// the row. Callers wanting to rewrite the provider mapping should
+  /// call `registerCrypto(_:mapping:)`, which upserts the full row.
+  ///
+  /// Throws `BackendError.notFound(_:)` when no row is registered for
+  /// `registration.instrument.id` — callers must have an existing
+  /// registration in hand. To insert a brand-new registration, call
+  /// `registerCrypto(_:mapping:)` instead.
+  func update(_ registration: CryptoRegistration) async throws
+
   /// Removes a registered instrument by id. No-op for fiat ids and for
   /// ids that are not currently registered — does not throw. Invokes the
   /// implementation's sync-queue hook after a successful delete.

--- a/Features/Settings/CryptoTokenStore.swift
+++ b/Features/Settings/CryptoTokenStore.swift
@@ -15,6 +15,7 @@ final class CryptoTokenStore {
 
   private let registry: any InstrumentRegistryRepository
   private let cryptoPriceService: CryptoPriceService
+  private let conversionService: any InstrumentConversionService
   private let logger = Logger(
     subsystem: "com.moolah.app", category: "CryptoTokenStore")
 
@@ -24,10 +25,12 @@ final class CryptoTokenStore {
 
   init(
     registry: any InstrumentRegistryRepository,
-    cryptoPriceService: CryptoPriceService
+    cryptoPriceService: CryptoPriceService,
+    conversionService: any InstrumentConversionService
   ) {
     self.registry = registry
     self.cryptoPriceService = cryptoPriceService
+    self.conversionService = conversionService
   }
 
   func loadRegistrations() async {
@@ -66,6 +69,36 @@ final class CryptoTokenStore {
     guard let registration = registrations.first(where: { $0.instrument.id == instrument.id })
     else { return }
     await removeRegistration(registration)
+  }
+
+  /// Persists a new `pricingStatus` for an existing registration and
+  /// synchronously invalidates any cached conversion derived from the
+  /// instrument so the next aggregation reads fresh data. Used by the
+  /// Discovered Tokens inbox + Spam tokens management UI to flip a
+  /// registration between `.priced` / `.unpriced` / `.spam`.
+  ///
+  /// On failure the local in-memory `registrations` list is left
+  /// untouched and `error` is set; the caller's view re-renders against
+  /// the previous state. Cache invalidation only runs after the registry
+  /// write succeeds — we never invalidate on behalf of a write that
+  /// didn't happen.
+  func setStatus(
+    _ status: TokenPricingStatus,
+    for registration: CryptoRegistration
+  ) async {
+    var updated = registration
+    updated.pricingStatus = status
+    do {
+      try await registry.update(updated)
+      await conversionService.invalidateCache(for: registration.instrument)
+      if let index = registrations.firstIndex(where: { $0.id == registration.id }) {
+        registrations[index] = updated
+      }
+      error = nil
+    } catch {
+      logger.error("Failed to set pricing status: \(error, privacy: .public)")
+      self.error = error.localizedDescription
+    }
   }
 
   // MARK: - API Key

--- a/MoolahTests/Backends/CloudKit/Sync/InstrumentSyncPricingStatusMergeTests.swift
+++ b/MoolahTests/Backends/CloudKit/Sync/InstrumentSyncPricingStatusMergeTests.swift
@@ -1,0 +1,182 @@
+// MoolahTests/Backends/CloudKit/Sync/InstrumentSyncPricingStatusMergeTests.swift
+
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+/// End-to-end tests for the `pricingStatus` cross-device merge applied
+/// inside `GRDBInstrumentRegistryRepository.applyRemoteChangesSync` —
+/// the GRDB write path the CKSyncEngine apply-batch handler routes
+/// remote `InstrumentRecord` changes through. Pure-helper coverage for
+/// the truth table lives in `PricingStatusMergeRuleTests`; these tests
+/// guarantee the helper actually runs on the persistence path and that
+/// non-`pricingStatus` columns remain server-authoritative.
+@Suite("InstrumentRow sync pricingStatus merge")
+struct InstrumentSyncPricingStatusMergeTests {
+  // MARK: - Fixture helpers
+
+  /// Builds a fresh in-memory database + registry for one test.
+  private func makeRegistry() throws -> (
+    database: any DatabaseWriter,
+    registry: GRDBInstrumentRegistryRepository
+  ) {
+    let database = try ProfileDatabase.openInMemory()
+    let registry = GRDBInstrumentRegistryRepository(database: database)
+    return (database, registry)
+  }
+
+  /// Seeds a crypto registration into the registry with a chosen
+  /// `pricingStatus`, returning the seeded `Instrument` for use by the
+  /// caller. `registerCrypto` always seeds with the default `.priced`,
+  /// so the seed is followed by `update(_:)` when a different status is
+  /// required.
+  private func seedRegistration(
+    in registry: GRDBInstrumentRegistryRepository,
+    status: TokenPricingStatus
+  ) async throws -> CryptoRegistration {
+    let preset = CryptoRegistration.builtInPresets[1]  // ETH
+    try await registry.registerCrypto(preset.instrument, mapping: preset.mapping)
+    var stored = preset
+    stored.pricingStatus = status
+    if status != .priced {
+      try await registry.update(stored)
+    }
+    return stored
+  }
+
+  /// Reads back the persisted `pricing_status` for a row id.
+  private func storedStatus(
+    in database: any DatabaseWriter, id: String
+  ) async throws -> String? {
+    try await database.read { database in
+      try InstrumentRow
+        .filter(InstrumentRow.Columns.id == id)
+        .fetchOne(database)?
+        .pricingStatus
+    }
+  }
+
+  /// Builds an incoming `InstrumentRow` mirroring the seeded one but
+  /// with a chosen `pricingStatus` — the shape CKSyncEngine would deliver
+  /// from another device.
+  private func incomingRow(
+    for registration: CryptoRegistration,
+    status: TokenPricingStatus
+  ) -> InstrumentRow {
+    var row = InstrumentRow(domain: registration.instrument)
+    row.coingeckoId = registration.mapping.coingeckoId
+    row.cryptocompareSymbol = registration.mapping.cryptocompareSymbol
+    row.binanceSymbol = registration.mapping.binanceSymbol
+    row.pricingStatus = status.rawValue
+    return row
+  }
+
+  // MARK: - Merge rule on the apply path
+
+  @Test("Local .spam survives an incoming .priced from another device")
+  func localSpamSurvivesIncomingPriced() async throws {
+    let (database, registry) = try makeRegistry()
+    let registration = try await seedRegistration(in: registry, status: .spam)
+
+    let incoming = incomingRow(for: registration, status: .priced)
+    try registry.applyRemoteChangesSync(saved: [incoming], deleted: [])
+
+    #expect(
+      try await storedStatus(in: database, id: registration.instrument.id)
+        == TokenPricingStatus.spam.rawValue)
+  }
+
+  @Test("Incoming .spam from another device overwrites a local .priced")
+  func incomingSpamOverwritesLocalPriced() async throws {
+    let (database, registry) = try makeRegistry()
+    let registration = try await seedRegistration(in: registry, status: .priced)
+
+    let incoming = incomingRow(for: registration, status: .spam)
+    try registry.applyRemoteChangesSync(saved: [incoming], deleted: [])
+
+    #expect(
+      try await storedStatus(in: database, id: registration.instrument.id)
+        == TokenPricingStatus.spam.rawValue)
+  }
+
+  @Test("Incoming .priced beats a stale local .unpriced (resolution sticks)")
+  func incomingPricedBeatsLocalUnpriced() async throws {
+    let (database, registry) = try makeRegistry()
+    let registration = try await seedRegistration(in: registry, status: .unpriced)
+
+    let incoming = incomingRow(for: registration, status: .priced)
+    try registry.applyRemoteChangesSync(saved: [incoming], deleted: [])
+
+    #expect(
+      try await storedStatus(in: database, id: registration.instrument.id)
+        == TokenPricingStatus.priced.rawValue)
+  }
+
+  @Test("Local .priced is preserved when an incoming row regresses to .unpriced")
+  func localPricedSurvivesIncomingUnpriced() async throws {
+    let (database, registry) = try makeRegistry()
+    let registration = try await seedRegistration(in: registry, status: .priced)
+
+    let incoming = incomingRow(for: registration, status: .unpriced)
+    try registry.applyRemoteChangesSync(saved: [incoming], deleted: [])
+
+    #expect(
+      try await storedStatus(in: database, id: registration.instrument.id)
+        == TokenPricingStatus.priced.rawValue)
+  }
+
+  // MARK: - Non-pricingStatus fields stay server-authoritative
+
+  @Test("Non-pricingStatus columns remain server-authoritative on apply")
+  func incomingNameAndMappingStillWinForServerAuthoritativeFields() async throws {
+    let (database, registry) = try makeRegistry()
+    // Seed a registration with one provider mapping.
+    let registration = try await seedRegistration(in: registry, status: .spam)
+
+    // Build an incoming row that mirrors the seeded id but rewrites a
+    // server-authoritative column (`name`) to confirm the merge rule
+    // affects only `pricingStatus`.
+    var incoming = InstrumentRow(domain: registration.instrument)
+    incoming.coingeckoId = registration.mapping.coingeckoId
+    incoming.cryptocompareSymbol = registration.mapping.cryptocompareSymbol
+    incoming.binanceSymbol = registration.mapping.binanceSymbol
+    incoming.name = "Renamed-By-Other-Device"
+    incoming.pricingStatus = TokenPricingStatus.priced.rawValue
+
+    try registry.applyRemoteChangesSync(saved: [incoming], deleted: [])
+
+    let row = try await database.read { database in
+      try InstrumentRow
+        .filter(InstrumentRow.Columns.id == registration.instrument.id)
+        .fetchOne(database)
+    }
+    let stored = try #require(row)
+    // pricingStatus: merge rule kept the local `.spam`.
+    #expect(stored.pricingStatus == TokenPricingStatus.spam.rawValue)
+    // name: server-authoritative — incoming value wins.
+    #expect(stored.name == "Renamed-By-Other-Device")
+  }
+
+  // MARK: - Defensive: legacy / unknown raw values
+
+  @Test("An unrecognised incoming raw value is treated as .priced for the merge")
+  func unknownIncomingRawValueTreatedAsPriced() async throws {
+    let (database, registry) = try makeRegistry()
+    // Local .unpriced — so an incoming `.priced` (or anything decoded
+    // as `.priced`) should win per the merge rule.
+    let registration = try await seedRegistration(in: registry, status: .unpriced)
+
+    var incoming = incomingRow(for: registration, status: .priced)
+    // Simulate a future-version device sending an enum case this build
+    // doesn't compile against. The legacy fallback at decode is
+    // `.priced`, and the merge rule should therefore promote the row.
+    incoming.pricingStatus = "future-status-x"
+    try registry.applyRemoteChangesSync(saved: [incoming], deleted: [])
+
+    #expect(
+      try await storedStatus(in: database, id: registration.instrument.id)
+        == TokenPricingStatus.priced.rawValue)
+  }
+}

--- a/MoolahTests/Backends/GRDB/PricingStatusMergeRuleTests.swift
+++ b/MoolahTests/Backends/GRDB/PricingStatusMergeRuleTests.swift
@@ -4,52 +4,70 @@ import Testing
 
 @testable import Moolah
 
-@Suite("GRDBInstrumentRegistryRepository pricingStatus merge rule")
+/// Pure-function tests for `PricingStatusMerge.merge(local:incoming:)`.
+/// Covers every cell of the 3x3 truth table from the design's "Cross-device
+/// conflict resolution" section.
+@Suite("PricingStatusMerge.merge — full truth table")
 struct PricingStatusMergeRuleTests {
-  private let priced = TokenPricingStatus.priced.rawValue
-  private let unpriced = TokenPricingStatus.unpriced.rawValue
-  private let spam = TokenPricingStatus.spam.rawValue
+  // MARK: - Local .spam wins over any incoming
 
   @Test
-  func localSpamSurvivesAnyIncoming() {
+  func localSpamBeatsIncomingPriced() {
     #expect(
-      GRDBInstrumentRegistryRepository.mergedPricingStatus(
-        local: spam, incoming: priced) == spam)
-    #expect(
-      GRDBInstrumentRegistryRepository.mergedPricingStatus(
-        local: spam, incoming: unpriced) == spam)
-    #expect(
-      GRDBInstrumentRegistryRepository.mergedPricingStatus(
-        local: spam, incoming: spam) == spam)
+      PricingStatusMerge.merge(local: .spam, incoming: .priced) == .spam)
   }
 
   @Test
-  func incomingSpamWinsOverNonSpamLocal() {
+  func localSpamBeatsIncomingUnpriced() {
     #expect(
-      GRDBInstrumentRegistryRepository.mergedPricingStatus(
-        local: priced, incoming: spam) == spam)
-    #expect(
-      GRDBInstrumentRegistryRepository.mergedPricingStatus(
-        local: unpriced, incoming: spam) == spam)
+      PricingStatusMerge.merge(local: .spam, incoming: .unpriced) == .spam)
   }
 
   @Test
-  func pricedWinsOverUnpricedEitherDirection() {
+  func localSpamMatchesIncomingSpam() {
     #expect(
-      GRDBInstrumentRegistryRepository.mergedPricingStatus(
-        local: priced, incoming: unpriced) == priced)
+      PricingStatusMerge.merge(local: .spam, incoming: .spam) == .spam)
+  }
+
+  // MARK: - Incoming .spam wins over any non-spam local
+
+  @Test
+  func incomingSpamBeatsLocalPriced() {
     #expect(
-      GRDBInstrumentRegistryRepository.mergedPricingStatus(
-        local: unpriced, incoming: priced) == priced)
+      PricingStatusMerge.merge(local: .priced, incoming: .spam) == .spam)
   }
 
   @Test
-  func identicalStatusesAreUnchanged() {
+  func incomingSpamBeatsLocalUnpriced() {
     #expect(
-      GRDBInstrumentRegistryRepository.mergedPricingStatus(
-        local: priced, incoming: priced) == priced)
+      PricingStatusMerge.merge(local: .unpriced, incoming: .spam) == .spam)
+  }
+
+  // MARK: - .priced beats .unpriced either direction (resolution sticks)
+
+  @Test
+  func localPricedBeatsIncomingUnpriced() {
     #expect(
-      GRDBInstrumentRegistryRepository.mergedPricingStatus(
-        local: unpriced, incoming: unpriced) == unpriced)
+      PricingStatusMerge.merge(local: .priced, incoming: .unpriced) == .priced)
+  }
+
+  @Test
+  func incomingPricedBeatsLocalUnpriced() {
+    #expect(
+      PricingStatusMerge.merge(local: .unpriced, incoming: .priced) == .priced)
+  }
+
+  // MARK: - Same-on-both-sides → unchanged
+
+  @Test
+  func bothPricedReturnsPriced() {
+    #expect(
+      PricingStatusMerge.merge(local: .priced, incoming: .priced) == .priced)
+  }
+
+  @Test
+  func bothUnpricedReturnsUnpriced() {
+    #expect(
+      PricingStatusMerge.merge(local: .unpriced, incoming: .unpriced) == .unpriced)
   }
 }

--- a/MoolahTests/Features/CryptoTokenStoreSetStatusTests.swift
+++ b/MoolahTests/Features/CryptoTokenStoreSetStatusTests.swift
@@ -1,0 +1,146 @@
+// MoolahTests/Features/CryptoTokenStoreSetStatusTests.swift
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+/// Tests for `CryptoTokenStore.setStatus(_:for:)`. The method must:
+///
+/// 1. Persist the new `pricingStatus` through the registry repository so
+///    the change survives restart and propagates through CKSyncEngine.
+/// 2. Synchronously invalidate the conversion-service cache for the
+///    affected instrument so the next aggregation reads fresh data.
+/// 3. Refresh the local in-memory `registrations` list so observers see
+///    the update without an explicit `loadRegistrations()` call.
+///
+/// The registry is exercised through a real
+/// `GRDBInstrumentRegistryRepository` (in-memory SQLite) per the
+/// project's "test against a real repository" convention. The
+/// conversion service is the only piece mocked here — it sits at the
+/// `BackendProvider` boundary and a stub is the cleanest way to assert
+/// invocation order.
+@Suite("CryptoTokenStore.setStatus")
+@MainActor
+struct CryptoTokenStoreSetStatusTests {
+  // MARK: - Fixture
+
+  /// Bundle returned from `makeStore` so tests can reach the registry
+  /// (for direct read-back of persisted values) and the recording
+  /// conversion service (for invalidation assertions) alongside the
+  /// store under test. Keeps the helper signature under SwiftLint's
+  /// `large_tuple` ceiling.
+  private struct Fixture {
+    let store: CryptoTokenStore
+    let registry: GRDBInstrumentRegistryRepository
+    let conversionService: RecordingConversionService
+  }
+
+  /// Builds a fresh store backed by an in-memory GRDB database with
+  /// `count` built-in presets registered so the store has rows to mutate.
+  private func makeStore(presetCount: Int = 1) async throws -> Fixture {
+    let database = try ProfileDatabase.openInMemory()
+    let registry = GRDBInstrumentRegistryRepository(database: database)
+    for preset in CryptoRegistration.builtInPresets.prefix(presetCount) {
+      try await registry.registerCrypto(preset.instrument, mapping: preset.mapping)
+    }
+    let priceService = CryptoPriceService(
+      clients: [FixedCryptoPriceClient()], database: database)
+    let conversionService = RecordingConversionService()
+    let store = CryptoTokenStore(
+      registry: registry,
+      cryptoPriceService: priceService,
+      conversionService: conversionService)
+    await store.loadRegistrations()
+    return Fixture(
+      store: store, registry: registry, conversionService: conversionService)
+  }
+
+  // MARK: - Persistence
+
+  @Test("setStatus(.spam) is persisted by the registry")
+  func setStatusPersistsThroughRegistry() async throws {
+    let fixture = try await makeStore()
+    let registration = try #require(fixture.store.registrations.first)
+
+    await fixture.store.setStatus(.spam, for: registration)
+
+    let reloaded = try await fixture.registry.allCryptoRegistrations()
+    let updated = try #require(reloaded.first { $0.id == registration.id })
+    #expect(updated.pricingStatus == .spam)
+  }
+
+  @Test("setStatus refreshes the store's in-memory registrations list")
+  func setStatusRefreshesInMemoryList() async throws {
+    let fixture = try await makeStore()
+    let registration = try #require(fixture.store.registrations.first)
+
+    await fixture.store.setStatus(.spam, for: registration)
+
+    let updated = try #require(
+      fixture.store.registrations.first { $0.id == registration.id })
+    #expect(updated.pricingStatus == .spam)
+  }
+
+  // MARK: - Cache invalidation
+
+  @Test("setStatus invalidates the conversion cache exactly once")
+  func setStatusInvalidatesCacheExactlyOnce() async throws {
+    let fixture = try await makeStore()
+    let registration = try #require(fixture.store.registrations.first)
+
+    await fixture.store.setStatus(.spam, for: registration)
+
+    #expect(fixture.conversionService.invalidatedInstruments.count == 1)
+    let firstInvalidated =
+      try #require(fixture.conversionService.invalidatedInstruments.first)
+    #expect(firstInvalidated.id == registration.instrument.id)
+  }
+
+  @Test("Setting the same status twice still invalidates the cache twice")
+  func setStatusInvalidatesEvenWhenStatusUnchanged() async throws {
+    let fixture = try await makeStore()
+    let registration = try #require(fixture.store.registrations.first)
+
+    await fixture.store.setStatus(.spam, for: registration)
+    await fixture.store.setStatus(.spam, for: registration)
+
+    // No premature dedup at the store layer — the design relies on the
+    // conversion service to be cheaply idempotent rather than the caller.
+    #expect(fixture.conversionService.invalidatedInstruments.count == 2)
+    #expect(
+      fixture.conversionService.invalidatedInstruments.allSatisfy {
+        $0.id == registration.instrument.id
+      })
+  }
+
+  @Test("setStatus only invalidates the supplied instrument, not unrelated ones")
+  func setStatusOnlyInvalidatesSuppliedInstrument() async throws {
+    let fixture = try await makeStore(presetCount: 2)
+    let target = try #require(fixture.store.registrations.first)
+    let other = try #require(fixture.store.registrations.last)
+    #expect(target.id != other.id)
+
+    await fixture.store.setStatus(.spam, for: target)
+
+    #expect(
+      fixture.conversionService.invalidatedInstruments.allSatisfy {
+        $0.id == target.instrument.id
+      })
+  }
+
+  // MARK: - Round-trips through the full enum
+
+  @Test("setStatus accepts every TokenPricingStatus case")
+  func setStatusRoundTripsAllCases() async throws {
+    let fixture = try await makeStore()
+    let registration = try #require(fixture.store.registrations.first)
+
+    for status in TokenPricingStatus.allCases {
+      await fixture.store.setStatus(status, for: registration)
+      let reloaded = try await fixture.registry.allCryptoRegistrations()
+      let updated = try #require(reloaded.first { $0.id == registration.id })
+      #expect(updated.pricingStatus == status)
+    }
+  }
+}

--- a/MoolahTests/Features/CryptoTokenStoreTests.swift
+++ b/MoolahTests/Features/CryptoTokenStoreTests.swift
@@ -26,7 +26,10 @@ struct CryptoTokenStoreTests {
       clients: [FixedCryptoPriceClient()],
       database: database
     )
-    let store = CryptoTokenStore(registry: registry, cryptoPriceService: service)
+    let store = CryptoTokenStore(
+      registry: registry,
+      cryptoPriceService: service,
+      conversionService: RecordingConversionService())
     return (store, registry)
   }
 
@@ -72,7 +75,10 @@ struct CryptoTokenStoreTests {
     let failing = FailingRegistry()
     // swiftlint:disable:next force_try
     let service = CryptoPriceService(clients: [], database: try! ProfileDatabase.openInMemory())
-    let store = CryptoTokenStore(registry: failing, cryptoPriceService: service)
+    let store = CryptoTokenStore(
+      registry: failing,
+      cryptoPriceService: service,
+      conversionService: RecordingConversionService())
     await store.loadRegistrations()
     #expect(store.error != nil)
     #expect(store.registrations.isEmpty)
@@ -142,6 +148,7 @@ private struct FailingRegistry: InstrumentRegistryRepository, @unchecked Sendabl
     _ instrument: Instrument, mapping: CryptoProviderMapping
   ) async throws { throw BoomError() }
   func registerStock(_ instrument: Instrument) async throws { throw BoomError() }
+  func update(_ registration: CryptoRegistration) async throws { throw BoomError() }
   func remove(id: String) async throws { throw BoomError() }
   @MainActor
   func observeChanges() -> AsyncStream<Void> { AsyncStream { _ in } }

--- a/MoolahTests/Support/RecordingConversionService.swift
+++ b/MoolahTests/Support/RecordingConversionService.swift
@@ -18,14 +18,25 @@ struct RecordingConversionServiceCall: Sendable, Equatable {
 /// Returns `quantity` unchanged (1:1 fallback) on every call — this double
 /// is for *call-site* assertions, not rate behaviour.
 ///
+/// Also records every `invalidateCache(for:)` call so tests for
+/// `CryptoTokenStore.setStatus(_:for:)` (and other paths that want to
+/// invalidate conversion-derived caches) can assert which instruments
+/// the caller actually invalidated.
+///
 /// Backed by `OSAllocatedUnfairLock` so it is async-safe and `Sendable` and
 /// usable from any isolation domain (same lock-around-mutable-state pattern
 /// as `FailureLog` in `ThrowingCountingConversionService.swift`).
 final class RecordingConversionService: InstrumentConversionService, Sendable {
   private let recorded = OSAllocatedUnfairLock<[RecordingConversionServiceCall]>(
     initialState: [])
+  private let invalidations = OSAllocatedUnfairLock<[Instrument]>(initialState: [])
 
   var calls: [RecordingConversionServiceCall] { recorded.withLock { $0 } }
+  /// Every instrument passed to `invalidateCache(for:)`, in order.
+  /// Multiple invocations are preserved — there is no dedup at this
+  /// layer because cache invalidation is intentionally idempotent and
+  /// callers may legitimately invalidate the same instrument twice.
+  var invalidatedInstruments: [Instrument] { invalidations.withLock { $0 } }
 
   func convert(
     _ quantity: Decimal, from: Instrument, to: Instrument, on date: Date
@@ -53,5 +64,7 @@ final class RecordingConversionService: InstrumentConversionService, Sendable {
     return .value(converted)
   }
 
-  func invalidateCache(for instrument: Instrument) async {}
+  func invalidateCache(for instrument: Instrument) async {
+    invalidations.withLock { $0.append(instrument) }
+  }
 }

--- a/MoolahTests/Support/StubInstrumentRegistry.swift
+++ b/MoolahTests/Support/StubInstrumentRegistry.swift
@@ -24,7 +24,7 @@ final class StubInstrumentRegistry: InstrumentRegistryRepository, Sendable {
   /// Errors thrown by the stub when `shouldThrowOnRegister` is set. Lets
   /// tests exercise the picker's "registry write failed after a successful
   /// resolve" path without needing a separate stub class.
-  enum RegisterError: Error { case stockFailed, cryptoFailed }
+  enum RegisterError: Error { case stockFailed, cryptoFailed, updateFailed }
 
   private let state: OSAllocatedUnfairLock<State>
 
@@ -82,6 +82,16 @@ extension StubInstrumentRegistry {
       state.registeredStocks.append(instrument)
       state.instruments.removeAll { $0.id == instrument.id }
       state.instruments.append(instrument)
+    }
+  }
+
+  func update(_ registration: CryptoRegistration) async throws {
+    try state.withLock { state in
+      if state.shouldThrowOnRegister { throw RegisterError.updateFailed }
+      guard
+        let index = state.cryptoRegistrations.firstIndex(where: { $0.id == registration.id })
+      else { return }
+      state.cryptoRegistrations[index] = registration
     }
   }
 


### PR DESCRIPTION
## Summary

Stage 3 of `plans/2026-05-05-crypto-wallet-import-plan.md`. Wires the
`TokenPricingStatus` merge rule into the GRDB sync apply-batch handler
for instrument-registry records, and the user-mutation cache-invalidation
hook on `CryptoTokenStore`.

- `PricingStatusMerge`: pure helper applying the design's 3x3 merge rule (`.spam` wins from either side; `.priced` beats `.unpriced` either side).
- `applyRemoteChangesSync`: routes the merge through the new helper using `TokenPricingStatus` enums, with a defensive `.priced` fallback for unrecognised raw values to mirror the legacy CK decode behaviour.
- `InstrumentRegistryRepository.update(_:)`: new protocol method that rewrites only `pricingStatus` on an existing crypto registration and fires the sync-queue hook on success.
- `CryptoTokenStore.setStatus(_:for:)`: persists a new `pricingStatus` and synchronously invalidates the conversion-service cache so totals recompute immediately. Wires `conversionService` into the store via the existing `ProfileSession` factory.

Per spec: `plans/2026-05-05-crypto-wallet-import-design.md` §"Cross-device conflict resolution" + §"Cache invalidation on `pricingStatus` change".

## Test plan

- [x] `PricingStatusMergeRuleTests` — every cell of the 3x3 truth table for the pure helper.
- [x] `InstrumentSyncPricingStatusMergeTests` — end-to-end merge through the GRDB apply path: local `.spam` survives, incoming `.spam` wins, `.priced` beats `.unpriced` both directions, server-authoritative columns still win for non-`pricingStatus` fields, unrecognised raw values fall back to `.priced`.
- [x] `CryptoTokenStoreSetStatusTests` — registry-side persistence, in-memory list refresh, exactly-once cache invalidation per call, no premature dedup, full enum round-trip.
- [x] `just test` (macOS + iOS Simulator) — 2201 tests pass.
- [x] `just format-check` clean.
- [x] No SwiftLint baseline edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)