### PR TITLE
fix(release): pin release operations to a single commit SHA

### DIFF
--- a/guides/RELEASE_GUIDE.md
+++ b/guides/RELEASE_GUIDE.md
@@ -42,11 +42,17 @@ CloudKit Production schema changes can only be deployed via the **CloudKit Conso
 
 The pipeline writes detailed instructions to the workflow run's job summary when it pauses — follow those.
 
+## SHA pinning
+
+The release pipeline locks onto a single commit at pre-flight time and uses it for every subsequent step. `release-preflight` checks CI on that exact SHA (not "latest CI on main"); `release-create-rc` tags that SHA (not `--target main`, which resolves server-side and would silently bump if a PR landed mid-release).
+
+Practical implication: **don't `git pull` or `git fetch` between `release-preflight` and `release-create-rc`.** If you do, your local HEAD moves and so does the SHA you pinned. If you genuinely need the new tip, re-run `release-preflight` to lock onto the new SHA — nothing else changes.
+
 ## Cut a release candidate
 
-1. **Pre-flight.** Run `just release-preflight`. Fix any issue it reports (push outstanding work, sync with origin, authenticate `gh`, wait for green CI) before continuing.
+1. **Pre-flight.** Run `just release-preflight`. It locks onto local HEAD and prints the pinned SHA. Fix any issue it reports (push outstanding work, sync with origin, authenticate `gh`, wait for green CI on the pinned SHA) before continuing. Don't pull again after this.
 
-2. **Confirm intent.** Pre-flight verifies your local main is in sync with `origin/main`; it cannot verify which PRs you *believe* are in this release. A stale local main, an unmerged PR, or a merge that landed seconds after you tagged will all sail through pre-flight.
+2. **Confirm intent.** Pre-flight checks CI for the pinned SHA; it cannot verify which PRs you *believe* are in this release. A stale local main or an unmerged PR will both sail through pre-flight.
    - [ ] Run `git log <previous-rc-tag>..HEAD --oneline` and read the list end-to-end. Every issue / PR you mean to ship must appear.
    - [ ] For any PR you're unsure about, run `gh pr view <N> --json mergedAt,mergeCommit | jq` and confirm `mergedAt` is non-null AND `mergeCommit.oid` shows up in the log above.
    - [ ] If anything you expected is missing: either wait for the merge to land and re-run pre-flight, or accept reduced scope and adjust the release notes accordingly. Don't tag and "fix it in the next rc" — once an rc is installed, it takes on a life of its own.

--- a/scripts/release-create-rc.sh
+++ b/scripts/release-create-rc.sh
@@ -34,11 +34,24 @@ if gh release view "$tag" >/dev/null 2>&1; then
     exit 1
 fi
 
+# Refuse if HEAD isn't on main — guards against tagging a stray local branch.
+branch=$(git rev-parse --abbrev-ref HEAD)
+if [[ "$branch" != "main" ]]; then
+    printf 'must be on main to cut an RC; HEAD is on %s\n' "$branch" >&2
+    exit 1
+fi
+
+# Pin to local HEAD instead of `--target main`. `--target main` resolves
+# server-side at API-call time, so a PR that lands between preflight and now
+# would silently bump the release commit. Tagging the SHA gives the operator
+# the same commit they preflighted.
+target_sha=$(git rev-parse HEAD)
+
 gh release create "$tag" \
-    --target main \
+    --target "$target_sha" \
     --title "$tag" \
     --notes-file "$notes_file" \
     --prerelease
 
-printf '✓ created GH pre-release %s; release-rc.yml will fire shortly\n' "$tag"
+printf '✓ created GH pre-release %s at %s; release-rc.yml will fire shortly\n' "$tag" "$target_sha"
 printf '  watch: just release-wait %s\n' "$tag"

--- a/scripts/release-preflight.sh
+++ b/scripts/release-preflight.sh
@@ -43,16 +43,29 @@ if ! gh auth status >/dev/null 2>&1; then
     fail "gh CLI is not authenticated (run 'gh auth login')"
 fi
 
-# 5. Latest CI run on main passed.
-ci_status=$(gh run list --branch main --limit 1 \
-    --json status,conclusion --jq '.[0] | "\(.status):\(.conclusion)"')
+# 5. CI for the pinned commit passed.
+#
+# Verify CI for `$local_sha` specifically — not "latest CI on main" — so the
+# release locks onto the exact commit the operator preflighted, even if other
+# PRs land on main while the release is in flight. A `--branch main --limit 1`
+# query chases a moving target: by the time the result comes back, a newer
+# commit may have landed and reset the latest CI run to in_progress, looping
+# the operator forever. `--commit "$local_sha"` is the SHA-pinned form.
+ci_status=$(gh run list --commit "$local_sha" --workflow CI \
+    --json status,conclusion --jq '.[0] | "\(.status):\(.conclusion)"' 2>/dev/null || true)
 case "$ci_status" in
     completed:success) ;;
-    completed:*) fail "latest CI run on main concluded as ${ci_status#completed:}" ;;
-    in_progress:*|queued:*) fail "CI is still running on main; wait for it to finish" ;;
-    *) fail "unexpected CI status '$ci_status'" ;;
+    completed:*) fail "CI for $local_sha concluded as ${ci_status#completed:}" ;;
+    in_progress:*|queued:*) fail "CI for $local_sha is still running; wait for it to finish" ;;
+    "" | "null:null") fail "no CI run found for $local_sha (push it to a branch CI watches, then re-run)" ;;
+    *) fail "unexpected CI status '$ci_status' for $local_sha" ;;
 esac
 
 printf '✓ release-preflight passed\n'
 printf '  branch: %s\n' "$branch"
 printf '  HEAD:   %s\n' "$local_sha"
+printf '\n'
+printf 'Locked SHA: %s\n' "$local_sha"
+printf 'All subsequent release commands target this commit. Do NOT `git pull` or\n'
+printf '`git fetch` between now and `release-create-rc` — main may move on origin,\n'
+printf 'but the tag will pin to local HEAD.\n'


### PR DESCRIPTION
## Summary

The release pipeline chased a moving HEAD on `main`, so cutting an RC while other PRs were landing in parallel could loop the operator forever or, worse, silently tag a different commit than the one preflighted. Pin every step to the local HEAD SHA at preflight time.

## What was happening

- **`release-preflight.sh:47`** queried `gh run list --branch main --limit 1`. By the time the result came back, a newer commit had landed and reset the latest CI run to `in_progress` → preflight bounced. Re-pulling caught up to the new tip and the loop could repeat indefinitely.
- **`release-create-rc.sh:38`** used `--target main`. `gh release create` resolves `main` server-side at API-call time; a PR landing in the seconds between preflight and the API call would silently bump the release commit.

Caught while cutting `v1.1.0-rc.17` ([#757](https://github.com/ajsutton/moolah-native/pull/757) follow-up).

## Fix

- **preflight:** `gh run list --commit \"\$local_sha\" --workflow CI` — SHA-specific. Prints the pinned SHA prominently and reminds the operator not to `git pull` before `release-create-rc`.
- **create-rc:** resolves `git rev-parse HEAD` and passes `--target \"\$target_sha\"` to gh, plus a HEAD-must-be-on-main guard.
- **release-create-final.sh** is unaffected — it already pins to the resolved RC commit SHA via `git rev-list -n 1`.
- **`RELEASE_GUIDE.md`** gains a \"SHA pinning\" section that documents the contract.

## Test plan

- [x] Diff reviewed; no behavioural change for the happy path (operator pulls once → preflight → create-rc).
- [x] New behaviour tested under the failure mode (main moving while preflight runs): preflight now reports CI status for the locked SHA, not whatever just landed.
- [ ] First real use is `v1.1.0-rc.17` immediately after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)