### PR TITLE
feat(crypto): token discovery service with in-flight coalescer

### DIFF
--- a/Backends/GRDB/Repositories/GRDBInstrumentRegistryRepository+Lookup.swift
+++ b/Backends/GRDB/Repositories/GRDBInstrumentRegistryRepository+Lookup.swift
@@ -1,0 +1,34 @@
+// Backends/GRDB/Repositories/GRDBInstrumentRegistryRepository+Lookup.swift
+
+import Foundation
+import GRDB
+
+extension GRDBInstrumentRegistryRepository {
+  /// Looks up a single crypto registration by id. Mirrors the row-shape
+  /// projection in `allCryptoRegistrations()` — rows whose three provider
+  /// columns are all `nil` (e.g. a CSV-imported placeholder that never
+  /// went through the picker) project to `nil` here, matching the
+  /// `cryptoMapping() != nil` filter on the bulk read.
+  ///
+  /// Lives in a sibling extension file so the main repository class body
+  /// stays under SwiftLint's `type_body_length` and `file_length` budgets.
+  func cryptoRegistration(byId id: String) async throws -> CryptoRegistration? {
+    try await database.read { database in
+      let cryptoKind = Instrument.Kind.cryptoToken.rawValue
+      guard
+        let row =
+          try InstrumentRow
+          .filter(InstrumentRow.Columns.id == id)
+          .filter(InstrumentRow.Columns.kind == cryptoKind)
+          .fetchOne(database)
+      else { return nil }
+      guard let mapping = row.cryptoMapping() else { return nil }
+      let status =
+        TokenPricingStatus(rawValue: row.pricingStatus) ?? .priced
+      return CryptoRegistration(
+        instrument: try row.toDomain(),
+        mapping: mapping,
+        pricingStatus: status)
+    }
+  }
+}

--- a/Backends/GRDB/Repositories/GRDBInstrumentRegistryRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBInstrumentRegistryRepository.swift
@@ -37,7 +37,12 @@ import OSLog
 final class GRDBInstrumentRegistryRepository:
   InstrumentRegistryRepository, @unchecked Sendable
 {
-  private let database: any DatabaseWriter
+  // `database` is `internal` rather than `private` so the sibling
+  // extension file `GRDBInstrumentRegistryRepository+Lookup.swift` (which
+  // hosts `cryptoRegistration(byId:)` to keep this file under SwiftLint's
+  // length budgets) can read from it. The other stored properties remain
+  // private — only the database handle is shared across files.
+  let database: any DatabaseWriter
   private let onRecordChanged: @Sendable (String) -> Void
   private let onRecordDeleted: @Sendable (String) -> Void
   private let logger = Logger(
@@ -95,6 +100,10 @@ final class GRDBInstrumentRegistryRepository:
       }
     }
   }
+
+  // `cryptoRegistration(byId:)` lives in
+  // `GRDBInstrumentRegistryRepository+Lookup.swift` to keep this file
+  // under SwiftLint's `file_length` and `type_body_length` thresholds.
 
   func registerCrypto(
     _ instrument: Instrument, mapping: CryptoProviderMapping

--- a/Domain/Repositories/InstrumentRegistryRepository.swift
+++ b/Domain/Repositories/InstrumentRegistryRepository.swift
@@ -21,6 +21,19 @@ protocol InstrumentRegistryRepository: Sendable {
   /// Throws on a backing-store failure.
   func allCryptoRegistrations() async throws -> [CryptoRegistration]
 
+  /// Looks up a single crypto registration by its `Instrument.id`. Returns
+  /// `nil` when no row exists for that id, when the row exists but has no
+  /// provider mapping (all three mapping columns nil — e.g. an auto-insert
+  /// from CSV import that never went through the picker), or when the row
+  /// exists but is not a crypto kind.
+  ///
+  /// Used by `CryptoTokenDiscoveryService` as the fast existence check
+  /// before kicking off a network resolve. Implementations must be safe to
+  /// call concurrently with other reads and writes — the wallet sync's
+  /// build phase issues many concurrent lookups for the same key.
+  /// Throws on a backing-store failure.
+  func cryptoRegistration(byId id: String) async throws -> CryptoRegistration?
+
   /// Registers (or upserts) a crypto instrument with its provider mapping.
   /// Re-registering an id that already exists overwrites the mapping and
   /// mutable metadata fields rather than duplicating the row. Invokes the

--- a/MoolahTests/Features/CryptoTokenStoreTests.swift
+++ b/MoolahTests/Features/CryptoTokenStoreTests.swift
@@ -144,6 +144,9 @@ private struct FailingRegistry: InstrumentRegistryRepository, @unchecked Sendabl
   struct BoomError: Error {}
   func all() async throws -> [Instrument] { throw BoomError() }
   func allCryptoRegistrations() async throws -> [CryptoRegistration] { throw BoomError() }
+  func cryptoRegistration(byId id: String) async throws -> CryptoRegistration? {
+    throw BoomError()
+  }
   func registerCrypto(
     _ instrument: Instrument, mapping: CryptoProviderMapping
   ) async throws { throw BoomError() }

--- a/MoolahTests/Shared/CryptoImport/CryptoTokenDiscoveryCoalescerTests.swift
+++ b/MoolahTests/Shared/CryptoImport/CryptoTokenDiscoveryCoalescerTests.swift
@@ -1,0 +1,91 @@
+// MoolahTests/Shared/CryptoImport/CryptoTokenDiscoveryCoalescerTests.swift
+import Foundation
+import Testing
+
+@testable import Moolah
+
+/// Concurrency-focused tests for `CryptoTokenDiscoveryService`'s
+/// in-flight task coalescer. The behavioural / classification tests live
+/// in `CryptoTokenDiscoveryServiceTests`; this file isolates the heavier
+/// stress assertions.
+@Suite("CryptoTokenDiscoveryService — Coalescer")
+struct CryptoTokenDiscoveryCoalescerTests {
+  private static let usdcAddress = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+  private static let usdcId = "1:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+
+  @Test("100 concurrent resolves on the same key → 1 resolver + 1 Alchemy call")
+  func coalescerCoalescesIdenticalKey() async throws {
+    let subject = makeDiscoverySubject()
+    subject.resolver.script(
+      .init(chainId: 1, contractAddress: Self.usdcAddress.lowercased()),
+      .success(coingecko: "usd-coin", cryptocompare: nil, binance: nil))
+
+    let n = 100
+    try await withThrowingTaskGroup(of: CryptoRegistration.self) { group in
+      for _ in 0..<n {
+        group.addTask {
+          try await subject.service.resolveOrLoad(
+            chain: .ethereum,
+            contractAddress: Self.usdcAddress,
+            symbol: "USDC",
+            name: "USD Coin",
+            decimals: 6)
+        }
+      }
+      var observedIds: Set<String> = []
+      for try await result in group {
+        observedIds.insert(result.id)
+      }
+      #expect(observedIds == [Self.usdcId])
+    }
+
+    let resolverKey = CountingRegistrationResolver.Key(
+      chainId: 1, contractAddress: Self.usdcAddress.lowercased())
+    let alchemyKey = CountingAlchemyClientStub.Key(
+      chainId: 1, contractAddress: Self.usdcAddress.lowercased())
+    #expect(subject.resolver.callCount(for: resolverKey) == 1)
+    #expect(subject.alchemy.callCount(for: alchemyKey) == 1)
+  }
+
+  @Test("Stress: 1000 resolves across 5 keys → exactly 1 call per key")
+  func coalescerScalesAcrossKeys() async throws {
+    let subject = makeDiscoverySubject()
+    let keys: [(chain: ChainConfig, address: String)] = [
+      (.ethereum, "0x1111111111111111111111111111111111111111"),
+      (.ethereum, "0x2222222222222222222222222222222222222222"),
+      (.optimism, "0x3333333333333333333333333333333333333333"),
+      (.base, "0x4444444444444444444444444444444444444444"),
+      (.polygon, "0x5555555555555555555555555555555555555555"),
+    ]
+    for (chain, address) in keys {
+      subject.resolver.script(
+        .init(chainId: chain.chainId, contractAddress: address.lowercased()),
+        .success(coingecko: "id-\(chain.chainId)", cryptocompare: nil, binance: nil))
+    }
+
+    let totalCalls = 1000
+    try await withThrowingTaskGroup(of: Void.self) { group in
+      for index in 0..<totalCalls {
+        let pick = keys[index % keys.count]
+        group.addTask {
+          _ = try await subject.service.resolveOrLoad(
+            chain: pick.chain,
+            contractAddress: pick.address,
+            symbol: "T\(pick.chain.chainId)",
+            name: "Token \(pick.chain.chainId)",
+            decimals: 18)
+        }
+      }
+      try await group.waitForAll()
+    }
+
+    for (chain, address) in keys {
+      let resolverKey = CountingRegistrationResolver.Key(
+        chainId: chain.chainId, contractAddress: address.lowercased())
+      let alchemyKey = CountingAlchemyClientStub.Key(
+        chainId: chain.chainId, contractAddress: address.lowercased())
+      #expect(subject.resolver.callCount(for: resolverKey) == 1)
+      #expect(subject.alchemy.callCount(for: alchemyKey) == 1)
+    }
+  }
+}

--- a/MoolahTests/Shared/CryptoImport/CryptoTokenDiscoveryServiceTests.swift
+++ b/MoolahTests/Shared/CryptoImport/CryptoTokenDiscoveryServiceTests.swift
@@ -1,0 +1,217 @@
+// MoolahTests/Shared/CryptoImport/CryptoTokenDiscoveryServiceTests.swift
+import Foundation
+import Testing
+
+@testable import Moolah
+
+/// Behavioural tests for `CryptoTokenDiscoveryService`. The in-flight
+/// coalescer / stress assertions live in `CryptoTokenDiscoveryCoalescerTests`
+/// to keep this file under SwiftLint's length thresholds.
+@Suite("CryptoTokenDiscoveryService — Resolution")
+struct CryptoTokenDiscoveryServiceTests {
+  // Reusable USDC-like contract for the ERC-20 paths.
+  static let usdcAddress = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+  static let usdcId = "1:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+
+  // MARK: - Single-resolve happy paths
+
+  @Test("Resolved mapping → .priced registration persisted")
+  func resolvedMappingIsPriced() async throws {
+    let subject = makeDiscoverySubject()
+    subject.resolver.script(
+      .init(chainId: 1, contractAddress: Self.usdcAddress.lowercased()),
+      .success(coingecko: "usd-coin", cryptocompare: "USDC", binance: "USDCUSDT"))
+
+    let registration = try await subject.service.resolveOrLoad(
+      chain: .ethereum,
+      contractAddress: Self.usdcAddress,
+      symbol: "USDC",
+      name: "USD Coin",
+      decimals: 6)
+
+    #expect(registration.pricingStatus == .priced)
+    #expect(registration.mapping.coingeckoId == "usd-coin")
+    #expect(registration.instrument.id == Self.usdcId)
+
+    let stored = try await subject.registry.cryptoRegistration(byId: Self.usdcId)
+    #expect(stored?.pricingStatus == .priced)
+    #expect(stored?.mapping.coingeckoId == "usd-coin")
+  }
+
+  @Test("isSpam metadata wins over a successful provider resolution")
+  func spamWinsOverResolution() async throws {
+    let subject = makeDiscoverySubject()
+    subject.resolver.script(
+      .init(chainId: 1, contractAddress: Self.usdcAddress.lowercased()),
+      .success(coingecko: "spammy-but-listed", cryptocompare: nil, binance: nil))
+    subject.alchemy.script(
+      .init(chainId: 1, contractAddress: Self.usdcAddress.lowercased()),
+      .metadata(
+        AlchemyTokenMetadata(
+          symbol: "SPAM", name: "Spam", decimals: 18, logo: nil, isSpam: true)))
+
+    let registration = try await subject.service.resolveOrLoad(
+      chain: .ethereum,
+      contractAddress: Self.usdcAddress,
+      symbol: "SPAM",
+      name: "Spam",
+      decimals: 18)
+
+    #expect(registration.pricingStatus == .spam)
+    let stored = try await subject.registry.cryptoRegistration(byId: Self.usdcId)
+    #expect(stored?.pricingStatus == .spam)
+  }
+
+  @Test("No mapping + not spam → .unpriced")
+  func noMappingIsUnpriced() async throws {
+    struct ProviderFailed: Error {}
+    let subject = makeDiscoverySubject()
+    subject.resolver.script(
+      .init(chainId: 1, contractAddress: Self.usdcAddress.lowercased()),
+      .failure(ProviderFailed()))
+    subject.alchemy.setDefaultSpam(false)
+
+    let registration = try await subject.service.resolveOrLoad(
+      chain: .ethereum,
+      contractAddress: Self.usdcAddress,
+      symbol: "OBS",
+      name: "Obscure",
+      decimals: 18)
+
+    #expect(registration.pricingStatus == .unpriced)
+    #expect(registration.mapping.coingeckoId == nil)
+    let all = try await subject.registry.allCryptoRegistrations()
+    #expect(all.contains { $0.id == Self.usdcId && $0.pricingStatus == .unpriced })
+  }
+
+  @Test("Provider success but no mapping ids → .unpriced")
+  func providerSucceedsWithoutMappingIsUnpriced() async throws {
+    let subject = makeDiscoverySubject()
+    subject.resolver.script(
+      .init(chainId: 1, contractAddress: Self.usdcAddress.lowercased()),
+      .success(coingecko: nil, cryptocompare: nil, binance: nil))
+
+    let registration = try await subject.service.resolveOrLoad(
+      chain: .ethereum,
+      contractAddress: Self.usdcAddress,
+      symbol: "OBS",
+      name: "Obscure",
+      decimals: 18)
+
+    #expect(registration.pricingStatus == .unpriced)
+    #expect(registration.mapping.coingeckoId == nil)
+    #expect(registration.mapping.cryptocompareSymbol == nil)
+    #expect(registration.mapping.binanceSymbol == nil)
+  }
+
+  @Test("Native token never queries Alchemy spam metadata")
+  func nativeTokenSkipsSpamCheck() async throws {
+    let subject = makeDiscoverySubject()
+    subject.resolver.setDefault(
+      .success(coingecko: "ethereum", cryptocompare: "ETH", binance: "ETHUSDT"))
+
+    let registration = try await subject.service.resolveOrLoad(
+      chain: .ethereum,
+      contractAddress: nil,
+      symbol: "ETH",
+      name: "Ethereum",
+      decimals: 18)
+
+    #expect(registration.pricingStatus == .priced)
+    // The Alchemy stub keys on (chainId, contractAddress); a native call
+    // would key on the empty address. Either way, the only ERC-20-style
+    // callers are the explicit scripts we set above, so the recorded
+    // count for the empty-string key is the right thing to check.
+    #expect(subject.alchemy.callCount(for: .init(chainId: 1, contractAddress: "")) == 0)
+  }
+
+  @Test("Existing registration short-circuits — no resolver or Alchemy call")
+  func existingRegistrationShortCircuits() async throws {
+    let preexisting = CryptoRegistration(
+      instrument: Instrument.crypto(
+        chainId: 1, contractAddress: Self.usdcAddress, symbol: "USDC",
+        name: "USD Coin", decimals: 6),
+      mapping: CryptoProviderMapping(
+        instrumentId: Self.usdcId,
+        coingeckoId: "usd-coin", cryptocompareSymbol: "USDC", binanceSymbol: "USDCUSDT"),
+      pricingStatus: .priced)
+    let subject = makeDiscoverySubject(seededRegistrations: [preexisting])
+
+    let registration = try await subject.service.resolveOrLoad(
+      chain: .ethereum,
+      contractAddress: Self.usdcAddress,
+      symbol: "USDC",
+      name: "USD Coin",
+      decimals: 6)
+
+    #expect(registration.id == preexisting.id)
+    #expect(
+      subject.resolver.callCount(
+        for: .init(chainId: 1, contractAddress: Self.usdcAddress.lowercased())) == 0)
+    #expect(
+      subject.alchemy.callCount(
+        for: .init(chainId: 1, contractAddress: Self.usdcAddress.lowercased())) == 0)
+  }
+
+  // MARK: - Re-resolution
+
+  @Test("reResolve(.unpriced → .priced) flips status when provider now succeeds")
+  func reResolveUnpricedToPriced() async throws {
+    let unpriced = CryptoRegistration(
+      instrument: Instrument.crypto(
+        chainId: 1, contractAddress: Self.usdcAddress, symbol: "OBS",
+        name: "Obscure", decimals: 18),
+      mapping: CryptoProviderMapping(
+        instrumentId: Self.usdcId,
+        coingeckoId: nil, cryptocompareSymbol: nil, binanceSymbol: nil),
+      pricingStatus: .unpriced)
+    let subject = makeDiscoverySubject(seededRegistrations: [unpriced])
+    subject.resolver.script(
+      .init(chainId: 1, contractAddress: Self.usdcAddress.lowercased()),
+      .success(coingecko: "newly-listed", cryptocompare: nil, binance: nil))
+
+    let updated = try await subject.service.reResolve(unpriced, chain: .ethereum)
+
+    #expect(updated.pricingStatus == .priced)
+    #expect(updated.mapping.coingeckoId == "newly-listed")
+    let stored = try await subject.registry.cryptoRegistration(byId: Self.usdcId)
+    #expect(stored?.pricingStatus == .priced)
+    #expect(stored?.mapping.coingeckoId == "newly-listed")
+  }
+
+  @Test("reResolve respects registry-current status when caller's snapshot is stale")
+  func reResolveSkipsWhenRegistryNoLongerUnpriced() async throws {
+    // Caller hands in an `.unpriced` snapshot, but the registry has
+    // since been updated to `.spam` (e.g. user classified the token on
+    // another device while this device was idle between daily cycles).
+    // The "user intent wins" property requires reResolve to re-read the
+    // registry and bail out without re-resolving.
+    let staleSnapshot = CryptoRegistration(
+      instrument: Instrument.crypto(
+        chainId: 1, contractAddress: Self.usdcAddress, symbol: "OBS",
+        name: "Obscure", decimals: 18),
+      mapping: CryptoProviderMapping(
+        instrumentId: Self.usdcId,
+        coingeckoId: nil, cryptocompareSymbol: nil, binanceSymbol: nil),
+      pricingStatus: .unpriced)
+    let liveRow = CryptoRegistration(
+      instrument: staleSnapshot.instrument,
+      mapping: staleSnapshot.mapping,
+      pricingStatus: .spam)
+    let subject = makeDiscoverySubject(seededRegistrations: [liveRow])
+    // Even if the provider would succeed, reResolve must not call it.
+    subject.resolver.script(
+      .init(chainId: 1, contractAddress: Self.usdcAddress.lowercased()),
+      .success(coingecko: "should-not-be-used", cryptocompare: nil, binance: nil))
+
+    let result = try await subject.service.reResolve(staleSnapshot, chain: .ethereum)
+
+    #expect(result.pricingStatus == .spam)
+    let resolverKey = CountingRegistrationResolver.Key(
+      chainId: 1, contractAddress: Self.usdcAddress.lowercased())
+    #expect(subject.resolver.callCount(for: resolverKey) == 0)
+    let alchemyKey = CountingAlchemyClientStub.Key(
+      chainId: 1, contractAddress: Self.usdcAddress.lowercased())
+    #expect(subject.alchemy.callCount(for: alchemyKey) == 0)
+  }
+}

--- a/MoolahTests/Shared/CryptoImport/CryptoTokenDiscoveryTestDoubles.swift
+++ b/MoolahTests/Shared/CryptoImport/CryptoTokenDiscoveryTestDoubles.swift
@@ -1,0 +1,168 @@
+// MoolahTests/Shared/CryptoImport/CryptoTokenDiscoveryTestDoubles.swift
+import Foundation
+
+@testable import Moolah
+
+/// Namespace matching this file's name so SwiftLint's `file_name` rule
+/// stays satisfied alongside the loose top-level helpers and the two
+/// counting stubs declared below. Mirrors the `AlchemyTestSupport`
+/// pattern in the sibling Alchemy test files.
+enum CryptoTokenDiscoveryTestDoubles {}
+
+/// Counting + scriptable resolver. Records every call and returns the
+/// scripted response for the matching key. The default response is a
+/// successful resolution producing a mapping with one provider id.
+///
+/// `@unchecked Sendable`: scripted responses and call counts live behind
+/// an `NSLock`, mirroring the lock-protected stubs in `AlchemyTestSupport`
+/// and the `RateLimiterTests` test clock. The lock-bracket pattern is
+/// the project convention for non-actor concurrent test stubs.
+final class CountingRegistrationResolver: CryptoRegistrationResolver, @unchecked Sendable {
+  enum Response: Sendable {
+    case success(coingecko: String?, cryptocompare: String?, binance: String?)
+    case failure(any Error)
+  }
+
+  struct Key: Hashable, Sendable {
+    let chainId: Int
+    let contractAddress: String?
+  }
+
+  private let lock = NSLock()
+  private var responses: [Key: Response] = [:]
+  private var callCounts: [Key: Int] = [:]
+  private var defaultResponse: Response = .success(
+    coingecko: "default-id", cryptocompare: nil, binance: nil)
+
+  func setDefault(_ response: Response) {
+    lock.withLock { self.defaultResponse = response }
+  }
+
+  func script(_ key: Key, _ response: Response) {
+    lock.withLock { responses[key] = response }
+  }
+
+  func callCount(for key: Key) -> Int {
+    lock.withLock { callCounts[key] ?? 0 }
+  }
+
+  func resolveRegistration(
+    chainId: Int,
+    contractAddress: String?,
+    symbol: String?,
+    isNative: Bool
+  ) async throws -> CryptoRegistration {
+    let key = Key(chainId: chainId, contractAddress: contractAddress?.lowercased())
+    let response: Response = lock.withLock {
+      callCounts[key, default: 0] += 1
+      return responses[key] ?? defaultResponse
+    }
+
+    switch response {
+    case let .failure(error):
+      throw error
+    case let .success(coingecko, cryptocompare, binance):
+      let resolvedSymbol = symbol ?? "TKN"
+      let instrument = Instrument.crypto(
+        chainId: chainId,
+        contractAddress: isNative ? nil : contractAddress,
+        symbol: resolvedSymbol,
+        name: resolvedSymbol,
+        decimals: 18)
+      let mapping = CryptoProviderMapping(
+        instrumentId: instrument.id,
+        coingeckoId: coingecko,
+        cryptocompareSymbol: cryptocompare,
+        binanceSymbol: binance)
+      return CryptoRegistration(instrument: instrument, mapping: mapping)
+    }
+  }
+}
+
+/// Counting + scriptable Alchemy stub. Only `getTokenMetadata` is
+/// exercised by Stage 5; `getAssetTransfers` is unused here and traps if
+/// called so an accidental call surfaces in tests.
+final class CountingAlchemyClientStub: AlchemyClient, @unchecked Sendable {
+  struct Key: Hashable, Sendable {
+    let chainId: Int
+    let contractAddress: String
+  }
+
+  enum Response: Sendable {
+    case metadata(AlchemyTokenMetadata)
+    case failure(any Error)
+  }
+
+  struct UnexpectedTransfersCall: Error {}
+
+  private let lock = NSLock()
+  private var responses: [Key: Response] = [:]
+  private var callCounts: [Key: Int] = [:]
+  private var defaultIsSpam: Bool = false
+
+  func setDefaultSpam(_ isSpam: Bool) {
+    lock.withLock { self.defaultIsSpam = isSpam }
+  }
+
+  func script(_ key: Key, _ response: Response) {
+    lock.withLock { responses[key] = response }
+  }
+
+  func callCount(for key: Key) -> Int {
+    lock.withLock { callCounts[key] ?? 0 }
+  }
+
+  func getAssetTransfers(
+    chain: ChainConfig,
+    walletAddress: String,
+    fromBlock: UInt64
+  ) async throws -> [AlchemyTransfer] {
+    throw UnexpectedTransfersCall()
+  }
+
+  func getTokenMetadata(
+    chain: ChainConfig,
+    contractAddress: String
+  ) async throws -> AlchemyTokenMetadata {
+    let key = Key(chainId: chain.chainId, contractAddress: contractAddress.lowercased())
+    let (response, fallbackSpam): (Response?, Bool) = lock.withLock {
+      callCounts[key, default: 0] += 1
+      return (responses[key], defaultIsSpam)
+    }
+
+    switch response {
+    case let .failure(error):
+      throw error
+    case let .metadata(metadata):
+      return metadata
+    case .none:
+      return AlchemyTokenMetadata(
+        symbol: nil, name: nil, decimals: nil, logo: nil, isSpam: fallbackSpam)
+    }
+  }
+}
+
+/// Bundle returned by `makeDiscoverySubject()` — a struct rather than a
+/// tuple so SwiftLint's `large_tuple` rule (max 2 members) stays clean
+/// and call sites can address fields by name.
+struct CryptoTokenDiscoverySubject: Sendable {
+  let service: CryptoTokenDiscoveryService
+  let registry: StubInstrumentRegistry
+  let resolver: CountingRegistrationResolver
+  let alchemy: CountingAlchemyClientStub
+}
+
+/// Builds a `CryptoTokenDiscoveryService` wired against the in-memory
+/// `StubInstrumentRegistry` plus the counting test doubles. Tests script
+/// resolver / Alchemy responses on the returned bundle's fields.
+func makeDiscoverySubject(
+  seededRegistrations: [CryptoRegistration] = []
+) -> CryptoTokenDiscoverySubject {
+  let registry = StubInstrumentRegistry(cryptoRegistrations: seededRegistrations)
+  let resolver = CountingRegistrationResolver()
+  let alchemy = CountingAlchemyClientStub()
+  let service = CryptoTokenDiscoveryService(
+    registry: registry, resolver: resolver, alchemy: alchemy)
+  return CryptoTokenDiscoverySubject(
+    service: service, registry: registry, resolver: resolver, alchemy: alchemy)
+}

--- a/MoolahTests/Support/StubInstrumentRegistry.swift
+++ b/MoolahTests/Support/StubInstrumentRegistry.swift
@@ -62,6 +62,12 @@ extension StubInstrumentRegistry {
     state.withLock { $0.cryptoRegistrations }
   }
 
+  func cryptoRegistration(byId id: String) async throws -> CryptoRegistration? {
+    state.withLock { state in
+      state.cryptoRegistrations.first { $0.id == id }
+    }
+  }
+
   func registerCrypto(
     _ instrument: Instrument, mapping: CryptoProviderMapping
   ) async throws {

--- a/Shared/CryptoImport/CryptoRegistrationResolver.swift
+++ b/Shared/CryptoImport/CryptoRegistrationResolver.swift
@@ -1,0 +1,23 @@
+// Shared/CryptoImport/CryptoRegistrationResolver.swift
+import Foundation
+
+/// Narrow seam over `CryptoPriceService.resolveRegistration(...)` so the
+/// `CryptoTokenDiscoveryService` actor can be unit-tested without spinning
+/// up a real `CryptoPriceService` (which requires a `DatabaseWriter` and a
+/// `TokenResolutionClient`). Production wires this to the live actor; tests
+/// inject a counting / throwing stub.
+protocol CryptoRegistrationResolver: Sendable {
+  /// Resolves a token to a `CryptoRegistration` via the configured provider
+  /// pipeline (CoinGecko by contract → CryptoCompare coin list → Binance
+  /// pair). Throws when no provider can identify the token; the discovery
+  /// service treats a thrown error here as "no mapping" and proceeds to
+  /// the spam / unpriced classification branches.
+  func resolveRegistration(
+    chainId: Int,
+    contractAddress: String?,
+    symbol: String?,
+    isNative: Bool
+  ) async throws -> CryptoRegistration
+}
+
+extension CryptoPriceService: CryptoRegistrationResolver {}

--- a/Shared/CryptoImport/CryptoTokenDiscoveryService.swift
+++ b/Shared/CryptoImport/CryptoTokenDiscoveryService.swift
@@ -1,0 +1,258 @@
+// Shared/CryptoImport/CryptoTokenDiscoveryService.swift
+import Foundation
+import OSLog
+
+/// Resolves on-chain token addresses to `CryptoRegistration` rows.
+///
+/// Concurrent calls for the same `(chainId, contractAddress)` are coalesced
+/// via the in-flight `Task` pattern: the first caller starts the resolution,
+/// later callers `await` the same `Task<CryptoRegistration, Error>`. The
+/// actor serialises the "check repository → launch resolution → store
+/// result" critical section so the registry sees at most one new row per
+/// unique key, even under heavy parallel-build-phase contention.
+///
+/// Resolution algorithm:
+///
+/// 1. Fast path — return any existing registration from the registry.
+/// 2. Resolve provider mappings via `CryptoRegistrationResolver`
+///    (CoinGecko by contract → CryptoCompare → Binance).
+/// 3. Query Alchemy's token metadata for the `isSpam` flag (ERC-20 only;
+///    native gas tokens are never spam).
+/// 4. Apply the design's status precedence:
+///    - `isSpam == true` → `.spam` (regardless of resolver outcome).
+///    - resolver succeeded with at least one provider id → `.priced`.
+///    - else → `.unpriced` (surfaces in the Discovered Tokens inbox).
+/// 5. Persist via the registry. Status is sticky-positive: once a row
+///    transitions out of `.unpriced`, the next sync cycle leaves it alone.
+///
+/// Periodic re-resolution (`reResolve`) is the hook surface for Stage 9's
+/// `CryptoSyncStore`. The actual scheduling — at most once per day per
+/// `.unpriced` token, per design — lives in the sync store.
+/// See issue #753 for the cadence tuning.
+actor CryptoTokenDiscoveryService {
+  private var inFlight: [String: Task<CryptoRegistration, Error>] = [:]
+  private let registry: any InstrumentRegistryRepository
+  private let resolver: any CryptoRegistrationResolver
+  private let alchemy: any AlchemyClient
+  private let logger = Logger(
+    subsystem: "com.moolah.app", category: "CryptoTokenDiscovery")
+
+  init(
+    registry: any InstrumentRegistryRepository,
+    resolver: any CryptoRegistrationResolver,
+    alchemy: any AlchemyClient
+  ) {
+    self.registry = registry
+    self.resolver = resolver
+    self.alchemy = alchemy
+  }
+
+  /// Returns the existing `CryptoRegistration` if one is registered for
+  /// `(chain, contractAddress)`, otherwise resolves and persists a new one.
+  /// Concurrent callers for the same key all `await` the same in-flight
+  /// `Task`; the underlying network round-trip executes once.
+  func resolveOrLoad(
+    chain: ChainConfig,
+    contractAddress: String?,
+    symbol: String,
+    name: String,
+    decimals: Int
+  ) async throws -> CryptoRegistration {
+    let id =
+      Instrument.crypto(
+        chainId: chain.chainId,
+        contractAddress: contractAddress,
+        symbol: symbol,
+        name: name,
+        decimals: decimals
+      ).id
+
+    if let existing = try await registry.cryptoRegistration(byId: id) {
+      return existing
+    }
+    if let task = inFlight[id] {
+      return try await task.value
+    }
+
+    let task = Task<CryptoRegistration, Error> { [self] in
+      try await performResolution(
+        chain: chain,
+        contractAddress: contractAddress,
+        symbol: symbol,
+        name: name,
+        decimals: decimals)
+    }
+    inFlight[id] = task
+    do {
+      let result = try await task.value
+      // Actor-serialised — every coalesced waiter resumed before this
+      // line, so clearing the slot now is race-free without a detached
+      // cleanup task.
+      inFlight[id] = nil
+      return result
+    } catch {
+      inFlight[id] = nil
+      throw error
+    }
+  }
+
+  // MARK: - Resolution algorithm
+
+  private func performResolution(
+    chain: ChainConfig,
+    contractAddress: String?,
+    symbol: String,
+    name: String,
+    decimals: Int
+  ) async throws -> CryptoRegistration {
+    let isNative = contractAddress == nil
+    let instrument = Instrument.crypto(
+      chainId: chain.chainId,
+      contractAddress: contractAddress,
+      symbol: symbol,
+      name: name,
+      decimals: decimals)
+
+    // Resolution via provider chain. A non-cancellation throw means "no
+    // mapping" — a normal outcome (e.g. an obscure ERC-20 with no listing
+    // on any provider). `resolveSilently` swallows that case and returns
+    // `nil`; only `CancellationError` propagates so a cancelled sync
+    // never writes a half-resolved row.
+    let resolved = try await resolveSilently(
+      chainId: chain.chainId,
+      contractAddress: contractAddress,
+      symbol: symbol,
+      isNative: isNative)
+
+    // Native gas tokens are never classified as spam — Alchemy's spam
+    // database only covers token contracts. Skip the metadata round-trip.
+    let isSpam: Bool
+    if let contractAddress, !isNative {
+      isSpam = try await fetchSpamFlag(chain: chain, contractAddress: contractAddress)
+    } else {
+      isSpam = false
+    }
+
+    let mapping: CryptoProviderMapping
+    let status: TokenPricingStatus
+    if isSpam {
+      status = .spam
+      mapping = resolved?.mapping ?? emptyMapping(for: instrument.id)
+    } else if let resolved, hasAnyMapping(resolved.mapping) {
+      status = .priced
+      mapping = resolved.mapping
+    } else {
+      status = .unpriced
+      mapping = emptyMapping(for: instrument.id)
+    }
+
+    let registration = CryptoRegistration(
+      instrument: instrument,
+      mapping: mapping,
+      pricingStatus: status)
+
+    // `registerCrypto` upserts the mapping but preserves the prior
+    // `pricingStatus` on an existing row (default `.priced` only on
+    // insert). When the resolved status differs from what the upsert
+    // would leave behind, follow up with `update(_:)` to enforce this
+    // discovery pass's decision. Read the prior row once so the check is
+    // a single registry round-trip rather than two.
+    let priorStatus = try await registry.cryptoRegistration(
+      byId: instrument.id)?.pricingStatus
+    try await registry.registerCrypto(instrument, mapping: mapping)
+    let upsertedStatus: TokenPricingStatus = priorStatus ?? .priced
+    if upsertedStatus != status {
+      try await registry.update(registration)
+    }
+
+    return registration
+  }
+
+  /// Re-runs resolution for an `.unpriced` registration.
+  ///
+  /// Idempotent: re-reads the registry to find the *current* status before
+  /// deciding whether to re-resolve. If the live row is no longer
+  /// `.unpriced` (user marked it spam, or another path resolved it),
+  /// returns that row without issuing any network calls. This preserves
+  /// the design's "user intent wins" property — a spam classification
+  /// made on another device while we were idling between daily cycles
+  /// must not be clobbered by an automatic re-resolution.
+  ///
+  /// Stage 9's `CryptoSyncStore` is the only intended caller and is
+  /// responsible for the daily-cadence gate (issue #753).
+  func reResolve(
+    _ registration: CryptoRegistration,
+    chain: ChainConfig
+  ) async throws -> CryptoRegistration {
+    let id = registration.instrument.id
+    let current = try await registry.cryptoRegistration(byId: id) ?? registration
+    guard current.pricingStatus == .unpriced else { return current }
+
+    let instrument = current.instrument
+    return try await performResolution(
+      chain: chain,
+      contractAddress: instrument.contractAddress,
+      symbol: instrument.ticker ?? instrument.name,
+      name: instrument.name,
+      decimals: instrument.decimals)
+  }
+
+  // MARK: - Helpers
+
+  private func resolveSilently(
+    chainId: Int,
+    contractAddress: String?,
+    symbol: String,
+    isNative: Bool
+  ) async throws -> CryptoRegistration? {
+    do {
+      return try await resolver.resolveRegistration(
+        chainId: chainId,
+        contractAddress: contractAddress,
+        symbol: symbol,
+        isNative: isNative)
+    } catch is CancellationError {
+      // Cooperative cancellation propagates — never write a half-resolved
+      // row when the caller's task hierarchy is unwinding.
+      throw CancellationError()
+    } catch {
+      logger.debug(
+        "Provider resolution returned no mapping for chain \(chainId, privacy: .public) (\(error.localizedDescription, privacy: .public))"
+      )
+      return nil
+    }
+  }
+
+  private func fetchSpamFlag(
+    chain: ChainConfig,
+    contractAddress: String
+  ) async throws -> Bool {
+    do {
+      let metadata = try await alchemy.getTokenMetadata(
+        chain: chain,
+        contractAddress: contractAddress)
+      return metadata.isSpam
+    } catch is CancellationError {
+      throw CancellationError()
+    } catch {
+      logger.debug(
+        "Alchemy spam-flag lookup failed for chain \(chain.chainId, privacy: .public): \(error.localizedDescription, privacy: .public)"
+      )
+      return false
+    }
+  }
+
+  private func emptyMapping(for instrumentId: String) -> CryptoProviderMapping {
+    CryptoProviderMapping(
+      instrumentId: instrumentId,
+      coingeckoId: nil,
+      cryptocompareSymbol: nil,
+      binanceSymbol: nil)
+  }
+
+  private func hasAnyMapping(_ mapping: CryptoProviderMapping) -> Bool {
+    mapping.coingeckoId != nil
+      || mapping.cryptocompareSymbol != nil
+      || mapping.binanceSymbol != nil
+  }
+}


### PR DESCRIPTION
## Summary

Stage 5 of `plans/2026-05-05-crypto-wallet-import-plan.md`. Adds the actor that resolves on-chain token addresses to `CryptoRegistration` rows with the in-flight `Task` coalescer pattern: concurrent `resolveOrLoad` calls for the same `(chainId, contractAddress)` produce one registration and one network round-trip.

- `CryptoTokenDiscoveryService` actor — `resolveOrLoad` + `reResolve`.
- `CryptoRegistrationResolver` seam over `CryptoPriceService.resolveRegistration` so tests inject a counting/scriptable stub without spinning up a real `CryptoPriceService`.
- `isSpam` classification via Alchemy `getTokenMetadata` (skipped for native gas tokens — Alchemy's spam database only covers contracts).
- Pricing-status precedence: `.spam` wins; provider mapping resolved → `.priced`; otherwise `.unpriced` (surfaces in the Discovered Tokens inbox).
- `reResolve` is idempotent — it re-reads the registry before re-resolving so a user-driven `.spam` classification on another device is never clobbered. The daily-cadence gate (issue #753) lives in Stage 9's `CryptoSyncStore`.
- `CancellationError` propagates rather than being swallowed, so a cancelled sync never writes a half-resolved row.

## Test plan

- [x] `just format-check` clean (no baseline edits).
- [x] All 2,251 tests pass on iOS sim + macOS.
- [x] **In-flight coalescer**: 100 concurrent `resolveOrLoad` calls for the same key produce 1 resolver + 1 Alchemy call; 1000 calls across 5 keys produce exactly 1 call per key.
- [x] **Spam wins**: Alchemy `isSpam = true` overrides a successful provider resolution.
- [x] **Unpriced**: provider failure + `isSpam = false` → `.unpriced`.
- [x] **Native skip**: `contractAddress == nil` never queries Alchemy spam metadata.
- [x] **Existing short-circuit**: pre-seeded registration returns without calling resolver or Alchemy.
- [x] **reResolve `.unpriced` → `.priced`**: provider now succeeds; persisted row reflects new status.
- [x] **reResolve "user intent wins"**: stale `.unpriced` snapshot but live row is `.spam` → returns `.spam`, no resolver call.

## Repository surface

- `InstrumentRegistryRepository.cryptoRegistration(byId:)` added; GRDB implementation lives in a sibling extension (`GRDBInstrumentRegistryRepository+Lookup.swift`) to keep the main file under SwiftLint's length thresholds.
- `StubInstrumentRegistry` and the `FailingRegistry` test double in `CryptoTokenStoreTests` updated for the new method.

🤖 Generated with [Claude Code](https://claude.com/claude-code)