### PR TITLE
feat(crypto): wallet sync build pipeline (parallel build phase)

### DIFF
--- a/MoolahTests/Shared/CryptoImport/TransferEventBuilderTests.swift
+++ b/MoolahTests/Shared/CryptoImport/TransferEventBuilderTests.swift
@@ -1,0 +1,309 @@
+// MoolahTests/Shared/CryptoImport/TransferEventBuilderTests.swift
+import Foundation
+import Testing
+
+@testable import Moolah
+
+/// Behavioural tests for `TransferEventBuilder`. Exercises the
+/// transfer-leg construction, hash grouping, sign convention, and the
+/// `unknown`-category skip path.
+///
+/// Gas-leg construction is deferred — see issue #762. The "ETH send"
+/// and "ERC-20 send" tests therefore assert on a single transfer leg
+/// rather than the design's eventual transfer + gas pair; the gas-leg
+/// path will gain its own tests once the receipt-fetch wiring lands.
+@Suite("TransferEventBuilder")
+struct TransferEventBuilderTests {
+  // Reusable addresses.
+  private static let wallet = "0x1111111111111111111111111111111111111111"
+  private static let counterparty = "0x2222222222222222222222222222222222222222"
+  private static let usdcAddress = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+
+  // MARK: - Single ETH send
+
+  @Test("Outbound native ETH → one transfer leg, negative quantity")
+  func outboundNativeEthEmitsNegativeTransferLeg() async throws {
+    let subject = makeDiscoverySubject()
+    let account = makeCryptoAccount(walletAddress: Self.wallet, chain: .ethereum)
+    let origin = makeWalletImportOrigin(for: account.id)
+    let transfer = makeAlchemyTransfer(
+      hash: "0xeth-send",
+      from: Self.wallet,
+      to: Self.counterparty,
+      category: .external)
+
+    let built = try await TransferEventBuilder().build(
+      transfers: [transfer],
+      account: account,
+      chain: .ethereum,
+      discovery: subject.service,
+      importOrigin: origin)
+
+    #expect(built.count == 1)
+    let candidate = try #require(built.first)
+    #expect(candidate.originAccountId == account.id)
+    #expect(candidate.transaction.legs.count == 1)
+    let leg = try #require(candidate.transaction.legs.first)
+    #expect(leg.type == .transfer)
+    #expect(leg.accountId == account.id)
+    #expect(leg.externalId == "0xeth-send")
+    #expect(leg.instrument == ChainConfig.ethereum.nativeInstrument)
+    // 1 ETH outbound → -1
+    #expect(leg.quantity == Decimal(-1))
+  }
+
+  // MARK: - ERC-20 send
+
+  @Test("Outbound ERC-20 → one transfer leg in the resolved instrument")
+  func outboundErc20EmitsTransferLegInResolvedInstrument() async throws {
+    let subject = makeDiscoverySubject()
+    subject.resolver.script(
+      .init(chainId: 1, contractAddress: Self.usdcAddress.lowercased()),
+      .success(coingecko: "usd-coin", cryptocompare: nil, binance: nil))
+
+    let account = makeCryptoAccount(walletAddress: Self.wallet, chain: .ethereum)
+    let origin = makeWalletImportOrigin(for: account.id)
+    // 100 USDC (6 decimals) = 100_000_000 raw units.
+    let transfer = makeAlchemyTransfer(
+      hash: "0xerc20-send",
+      from: Self.wallet,
+      to: Self.counterparty,
+      category: .erc20,
+      asset: "USDC",
+      contractAddress: Self.usdcAddress,
+      decimalsHex: "0x6",
+      rawValueHex: "0x5f5e100")
+
+    let built = try await TransferEventBuilder().build(
+      transfers: [transfer],
+      account: account,
+      chain: .ethereum,
+      discovery: subject.service,
+      importOrigin: origin)
+
+    let candidate = try #require(built.first)
+    #expect(candidate.transaction.legs.count == 1)
+    let leg = try #require(candidate.transaction.legs.first)
+    #expect(leg.type == .transfer)
+    #expect(leg.externalId == "0xerc20-send")
+    #expect(leg.instrument.kind == .cryptoToken)
+    #expect(leg.instrument.contractAddress == Self.usdcAddress.lowercased())
+    #expect(leg.instrument.decimals == 6)
+    #expect(leg.quantity == Decimal(-100))
+  }
+
+  // MARK: - Receive-only
+
+  @Test("Inbound transfer → one transfer leg, positive quantity, no gas")
+  func inboundEmitsPositiveTransferLeg() async throws {
+    let subject = makeDiscoverySubject()
+    let account = makeCryptoAccount(walletAddress: Self.wallet, chain: .ethereum)
+    let origin = makeWalletImportOrigin(for: account.id)
+    let transfer = makeAlchemyTransfer(
+      hash: "0xreceive",
+      from: Self.counterparty,
+      to: Self.wallet,
+      category: .external)
+
+    let built = try await TransferEventBuilder().build(
+      transfers: [transfer],
+      account: account,
+      chain: .ethereum,
+      discovery: subject.service,
+      importOrigin: origin)
+
+    let candidate = try #require(built.first)
+    #expect(candidate.transaction.legs.count == 1)
+    let leg = try #require(candidate.transaction.legs.first)
+    #expect(leg.type == .transfer)
+    #expect(leg.quantity == Decimal(1))
+    #expect(leg.externalId == "0xreceive")
+  }
+
+  // MARK: - Coincident events on same hash
+
+  @Test("Two ERC-20 transfers same hash → 1 BuiltTransaction with 2 transfer legs")
+  func coincidentEventsSameHashYieldOneTransactionTwoLegs() async throws {
+    let subject = makeDiscoverySubject()
+    subject.resolver.script(
+      .init(chainId: 1, contractAddress: Self.usdcAddress.lowercased()),
+      .success(coingecko: "usd-coin", cryptocompare: nil, binance: nil))
+
+    let account = makeCryptoAccount(walletAddress: Self.wallet, chain: .ethereum)
+    let origin = makeWalletImportOrigin(for: account.id)
+    let first = makeAlchemyTransfer(
+      hash: "0xcomplex",
+      from: Self.wallet,
+      to: Self.counterparty,
+      category: .erc20,
+      asset: "USDC",
+      contractAddress: Self.usdcAddress,
+      decimalsHex: "0x6",
+      rawValueHex: "0x5f5e100")
+    let second = makeAlchemyTransfer(
+      hash: "0xcomplex",
+      from: Self.counterparty,
+      to: Self.wallet,
+      category: .erc20,
+      asset: "USDC",
+      contractAddress: Self.usdcAddress,
+      decimalsHex: "0x6",
+      // 25 USDC in raw integer units
+      rawValueHex: "0x17d7840")
+
+    let built = try await TransferEventBuilder().build(
+      transfers: [first, second],
+      account: account,
+      chain: .ethereum,
+      discovery: subject.service,
+      importOrigin: origin)
+
+    #expect(built.count == 1)
+    let candidate = try #require(built.first)
+    #expect(candidate.transaction.legs.count == 2)
+    let externalIds = Set(candidate.transaction.legs.compactMap(\.externalId))
+    #expect(externalIds == ["0xcomplex"])
+    let signs = candidate.transaction.legs.map { $0.quantity.sign }
+    #expect(signs.contains(.minus))
+    #expect(signs.contains(.plus))
+  }
+
+  // MARK: - NFT category slipped through
+
+  @Test("Unknown-category transfer is skipped and does not crash")
+  func unknownCategoryIsSkipped() async throws {
+    let subject = makeDiscoverySubject()
+    let account = makeCryptoAccount(walletAddress: Self.wallet, chain: .ethereum)
+    let origin = makeWalletImportOrigin(for: account.id)
+    let json = Data(
+      """
+      {
+        "blockNum": "0x100",
+        "uniqueId": "0xnft:0",
+        "hash": "0xnft",
+        "from": "\(Self.wallet)",
+        "to": "\(Self.counterparty)",
+        "asset": null,
+        "category": "erc721",
+        "rawContract": {
+          "rawValue": "0x0",
+          "address": "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+          "decimal": null
+        },
+        "metadata": { "blockTimestamp": null }
+      }
+      """.utf8)
+    let nftTransfer = try JSONDecoder().decode(AlchemyTransfer.self, from: json)
+    #expect(nftTransfer.category == .unknown)
+
+    let built = try await TransferEventBuilder().build(
+      transfers: [nftTransfer],
+      account: account,
+      chain: .ethereum,
+      discovery: subject.service,
+      importOrigin: origin)
+    #expect(built.isEmpty)
+  }
+
+  // MARK: - Stable instrument across builds
+
+  @Test("100 concurrent builders → single resolver call (coalescer holds)")
+  func concurrentBuildersCoalesceInstrumentResolution() async throws {
+    let subject = makeDiscoverySubject()
+    subject.resolver.script(
+      .init(chainId: 1, contractAddress: Self.usdcAddress.lowercased()),
+      .success(coingecko: "usd-coin", cryptocompare: nil, binance: nil))
+
+    let account = makeCryptoAccount(walletAddress: Self.wallet, chain: .ethereum)
+    let origin = makeWalletImportOrigin(for: account.id)
+    let template = makeAlchemyTransfer(
+      hash: "0xshared",
+      from: Self.wallet,
+      to: Self.counterparty,
+      category: .erc20,
+      asset: "USDC",
+      contractAddress: Self.usdcAddress,
+      decimalsHex: "0x6",
+      rawValueHex: "0x5f5e100")
+
+    // Each task uses a unique hash so the builder doesn't collapse into
+    // a single transaction; the discovery key is the same so the
+    // coalescer is the load-bearing claim.
+    try await withThrowingTaskGroup(of: Set<String>.self) { group in
+      for index in 0..<100 {
+        let hash = "0x\(String(format: "%064x", index))"
+        let transfer = makeAlchemyTransfer(
+          hash: hash,
+          from: template.from,
+          to: template.to,
+          category: .erc20,
+          asset: "USDC",
+          contractAddress: Self.usdcAddress,
+          decimalsHex: "0x6",
+          rawValueHex: "0x5f5e100")
+        group.addTask {
+          let built = try await TransferEventBuilder().build(
+            transfers: [transfer],
+            account: account,
+            chain: .ethereum,
+            discovery: subject.service,
+            importOrigin: origin)
+          return Set(built.flatMap { $0.transaction.legs.map(\.instrument.id) })
+        }
+      }
+      var observed: Set<String> = []
+      for try await ids in group {
+        observed.formUnion(ids)
+      }
+      #expect(observed.count == 1)
+    }
+
+    let resolverKey = CountingRegistrationResolver.Key(
+      chainId: 1, contractAddress: Self.usdcAddress.lowercased())
+    #expect(subject.resolver.callCount(for: resolverKey) == 1)
+  }
+
+  // MARK: - Other edge cases
+
+  @Test("Internal-category transfer is treated as native gas-token movement")
+  func internalCategoryUsesNativeInstrument() async throws {
+    let subject = makeDiscoverySubject()
+    let account = makeCryptoAccount(walletAddress: Self.wallet, chain: .ethereum)
+    let origin = makeWalletImportOrigin(for: account.id)
+    let transfer = makeAlchemyTransfer(
+      hash: "0xinternal",
+      from: Self.counterparty,
+      to: Self.wallet,
+      category: .internal,
+      asset: "ETH",
+      decimalsHex: nil,
+      rawValueHex: "0x0de0b6b3a7640000")
+
+    let built = try await TransferEventBuilder().build(
+      transfers: [transfer],
+      account: account,
+      chain: .ethereum,
+      discovery: subject.service,
+      importOrigin: origin)
+    let leg = try #require(built.first?.transaction.legs.first)
+    #expect(leg.instrument == ChainConfig.ethereum.nativeInstrument)
+    #expect(leg.quantity == Decimal(1))
+  }
+
+  @Test("Missing wallet address on account throws providerMalformedResponse")
+  func missingWalletAddressThrows() async throws {
+    let subject = makeDiscoverySubject()
+    var account = makeCryptoAccount(walletAddress: Self.wallet, chain: .ethereum)
+    account.walletAddress = nil
+    let origin = makeWalletImportOrigin(for: account.id)
+
+    await #expect(throws: WalletSyncError.self) {
+      _ = try await TransferEventBuilder().build(
+        transfers: [],
+        account: account,
+        chain: .ethereum,
+        discovery: subject.service,
+        importOrigin: origin)
+    }
+  }
+}

--- a/MoolahTests/Shared/CryptoImport/WalletSyncEngineTests.swift
+++ b/MoolahTests/Shared/CryptoImport/WalletSyncEngineTests.swift
@@ -1,0 +1,208 @@
+// MoolahTests/Shared/CryptoImport/WalletSyncEngineTests.swift
+import Foundation
+import Testing
+
+@testable import Moolah
+
+/// Behavioural tests for `WalletSyncEngine`. Exercises the per-account
+/// orchestration: account validation → reorg-window `fromBlock` → Alchemy
+/// fetch → builder. Asserts the engine never writes to any repository
+/// (the load-bearing parallel-build invariant).
+@Suite("WalletSyncEngine — Build phase")
+struct WalletSyncEngineTests {
+  private static let wallet = "0x1111111111111111111111111111111111111111"
+  private static let counterparty = "0x2222222222222222222222222222222222222222"
+
+  // MARK: - Helpers
+
+  private func makeEngine(
+    alchemy: RecordingAlchemyClientStub = .init(),
+    syncState: RecordingWalletSyncStateRepository = .init()
+  ) -> (WalletSyncEngine, CryptoTokenDiscoverySubject) {
+    let subject = makeDiscoverySubject()
+    let engine = WalletSyncEngine(
+      alchemy: alchemy,
+      discovery: subject.service,
+      walletSyncState: syncState,
+      importOriginFactory: { accountId in
+        makeWalletImportOrigin(for: accountId)
+      })
+    return (engine, subject)
+  }
+
+  // MARK: - Happy path
+
+  @Test("Returns one BuiltTransaction per inbound transfer; no state writes")
+  func happyPathReturnsBuiltTransactions() async throws {
+    let alchemy = RecordingAlchemyClientStub()
+    alchemy.setTransfersResponse(
+      .transfers([
+        makeAlchemyTransfer(
+          hash: "0xa", from: Self.counterparty, to: Self.wallet, category: .external),
+        makeAlchemyTransfer(
+          hash: "0xb", from: Self.counterparty, to: Self.wallet, category: .external),
+        makeAlchemyTransfer(
+          hash: "0xc", from: Self.wallet, to: Self.counterparty, category: .external),
+      ]))
+    let syncState = RecordingWalletSyncStateRepository()
+    let (engine, _) = makeEngine(alchemy: alchemy, syncState: syncState)
+    let account = makeCryptoAccount(walletAddress: Self.wallet, chain: .ethereum)
+
+    let built = try await engine.build(account: account, chain: .ethereum)
+
+    #expect(built.count == 3)
+    #expect(built.allSatisfy { $0.originAccountId == account.id })
+    #expect(syncState.saveCount == 0)
+    #expect(syncState.deleteCount == 0)
+  }
+
+  // MARK: - fromBlock derivation
+
+  @Test("Pre-existing state → fromBlock = lastSyncedBlockNumber - 32")
+  func fromBlockSubtractsReorgWindow() async throws {
+    let alchemy = RecordingAlchemyClientStub()
+    alchemy.setTransfersResponse(.transfers([]))
+    let syncState = RecordingWalletSyncStateRepository()
+    let account = makeCryptoAccount(walletAddress: Self.wallet, chain: .ethereum)
+    syncState.seed(
+      WalletSyncState(
+        id: account.id,
+        lastSyncedBlockNumber: 100,
+        lastSyncedAt: Date(timeIntervalSince1970: 1_700_000_000),
+        lastError: nil))
+    let (engine, _) = makeEngine(alchemy: alchemy, syncState: syncState)
+
+    _ = try await engine.build(account: account, chain: .ethereum)
+
+    let calls = alchemy.recordedCalls
+    #expect(calls.count == 1)
+    #expect(calls.first?.fromBlock == 68)  // 100 - 32
+  }
+
+  @Test("Pre-existing state inside reorg window → fromBlock = 0")
+  func fromBlockClampsAtZeroInsideWindow() async throws {
+    let alchemy = RecordingAlchemyClientStub()
+    alchemy.setTransfersResponse(.transfers([]))
+    let syncState = RecordingWalletSyncStateRepository()
+    let account = makeCryptoAccount(walletAddress: Self.wallet, chain: .ethereum)
+    syncState.seed(
+      WalletSyncState(
+        id: account.id,
+        lastSyncedBlockNumber: 10,
+        lastSyncedAt: Date(timeIntervalSince1970: 1_700_000_000),
+        lastError: nil))
+    let (engine, _) = makeEngine(alchemy: alchemy, syncState: syncState)
+
+    _ = try await engine.build(account: account, chain: .ethereum)
+    #expect(alchemy.recordedCalls.first?.fromBlock == 0)
+  }
+
+  @Test("No prior state → fromBlock = 0")
+  func fromBlockZeroWhenNoState() async throws {
+    let alchemy = RecordingAlchemyClientStub()
+    alchemy.setTransfersResponse(.transfers([]))
+    let syncState = RecordingWalletSyncStateRepository()
+    let (engine, _) = makeEngine(alchemy: alchemy, syncState: syncState)
+    let account = makeCryptoAccount(walletAddress: Self.wallet, chain: .ethereum)
+
+    _ = try await engine.build(account: account, chain: .ethereum)
+    #expect(alchemy.recordedCalls.first?.fromBlock == 0)
+  }
+
+  // MARK: - Cancellation
+
+  @Test("Cancellation between fetch and build throws CancellationError")
+  func cancellationBetweenStagesIsRespected() async throws {
+    let alchemy = RecordingAlchemyClientStub()
+    alchemy.setTransfersResponse(
+      .transfers([
+        makeAlchemyTransfer(
+          hash: "0xa", from: Self.counterparty, to: Self.wallet, category: .external)
+      ]))
+    let (engine, _) = makeEngine(alchemy: alchemy)
+    let account = makeCryptoAccount(walletAddress: Self.wallet, chain: .ethereum)
+
+    let task = Task<[BuiltTransaction], Error> {
+      try await engine.build(account: account, chain: .ethereum)
+    }
+    // Install a hook that fires inside the alchemy stub so we cancel
+    // *during* the fetch (before the engine reaches its post-fetch
+    // `checkCancellation`). The recording stub itself calls
+    // `checkCancellation()` after the hook so the error surfaces from
+    // the alchemy call, mirroring real-world cooperative cancellation.
+    alchemy.setBeforeAssetTransfers { [task] in
+      task.cancel()
+    }
+
+    await #expect(throws: CancellationError.self) {
+      _ = try await task.value
+    }
+  }
+
+  // MARK: - Account validation
+
+  @Test("Non-crypto account → providerMalformedResponse")
+  func nonCryptoAccountThrows() async throws {
+    let alchemy = RecordingAlchemyClientStub()
+    let (engine, _) = makeEngine(alchemy: alchemy)
+    let account = Account(
+      name: "Bank",
+      type: .bank,
+      instrument: .AUD,
+      walletAddress: Self.wallet,
+      chainId: 1)
+
+    await #expect(throws: WalletSyncError.self) {
+      _ = try await engine.build(account: account, chain: .ethereum)
+    }
+    #expect(alchemy.recordedCalls.isEmpty)
+  }
+
+  @Test("Missing walletAddress → providerMalformedResponse")
+  func missingWalletAddressThrows() async throws {
+    let alchemy = RecordingAlchemyClientStub()
+    let (engine, _) = makeEngine(alchemy: alchemy)
+    var account = makeCryptoAccount(walletAddress: Self.wallet, chain: .ethereum)
+    account.walletAddress = nil
+
+    await #expect(throws: WalletSyncError.self) {
+      _ = try await engine.build(account: account, chain: .ethereum)
+    }
+    #expect(alchemy.recordedCalls.isEmpty)
+  }
+
+  @Test("Empty walletAddress → providerMalformedResponse")
+  func emptyWalletAddressThrows() async throws {
+    let alchemy = RecordingAlchemyClientStub()
+    let (engine, _) = makeEngine(alchemy: alchemy)
+    var account = makeCryptoAccount(walletAddress: Self.wallet, chain: .ethereum)
+    account.walletAddress = ""
+
+    await #expect(throws: WalletSyncError.self) {
+      _ = try await engine.build(account: account, chain: .ethereum)
+    }
+    #expect(alchemy.recordedCalls.isEmpty)
+  }
+
+  // MARK: - Read-only invariant
+
+  @Test("End-to-end run never writes to WalletSyncStateRepository")
+  func endToEndDoesNotWriteRepositories() async throws {
+    let alchemy = RecordingAlchemyClientStub()
+    alchemy.setTransfersResponse(
+      .transfers([
+        makeAlchemyTransfer(
+          hash: "0xa", from: Self.counterparty, to: Self.wallet, category: .external),
+        makeAlchemyTransfer(
+          hash: "0xb", from: Self.wallet, to: Self.counterparty, category: .external),
+      ]))
+    let syncState = RecordingWalletSyncStateRepository()
+    let (engine, _) = makeEngine(alchemy: alchemy, syncState: syncState)
+    let account = makeCryptoAccount(walletAddress: Self.wallet, chain: .ethereum)
+
+    _ = try await engine.build(account: account, chain: .ethereum)
+
+    #expect(syncState.saveCount == 0)
+    #expect(syncState.deleteCount == 0)
+  }
+}

--- a/MoolahTests/Shared/CryptoImport/WalletSyncTestDoubles.swift
+++ b/MoolahTests/Shared/CryptoImport/WalletSyncTestDoubles.swift
@@ -1,0 +1,186 @@
+// MoolahTests/Shared/CryptoImport/WalletSyncTestDoubles.swift
+import Foundation
+
+@testable import Moolah
+
+/// Namespace anchor so SwiftLint's `file_name` rule stays satisfied
+/// alongside the loose top-level helpers and stubs declared below.
+enum WalletSyncTestDoubles {}
+
+/// Counting stub for `AlchemyClient` that returns a scripted transfer
+/// list per `(chainId, walletAddress)` key. Records every call so tests
+/// can assert on `fromBlock` derivation and call counts.
+///
+/// `@unchecked Sendable`: state lives behind an `NSLock`, mirroring the
+/// project convention for non-actor concurrent test stubs (see
+/// `AlchemyTestSupport.swift`, `CryptoTokenDiscoveryTestDoubles.swift`).
+final class RecordingAlchemyClientStub: AlchemyClient, @unchecked Sendable {
+  struct AssetTransfersCall: Sendable, Hashable {
+    let chainId: Int
+    let walletAddress: String
+    let fromBlock: UInt64
+  }
+
+  enum Response: Sendable {
+    case transfers([AlchemyTransfer])
+    case failure(any Error)
+  }
+
+  /// Errors thrown when scripting hooks are unset and a test path hits
+  /// the stub anyway. Keeps the failure message specific to the path.
+  struct UnscriptedTransfersCall: Error { let chainId: Int }
+  struct UnexpectedTokenMetadataCall: Error {}
+
+  private let lock = NSLock()
+  private var transfersResponse: Response?
+  private var assetTransfersCalls: [AssetTransfersCall] = []
+  /// Optional hook fired before the response is returned — the
+  /// cancellation test installs a closure here that cancels the parent
+  /// task so the engine throws on the next `checkCancellation()`.
+  private var beforeAssetTransfers: (@Sendable () async -> Void)?
+
+  func setTransfersResponse(_ response: Response) {
+    lock.withLock { self.transfersResponse = response }
+  }
+
+  func setBeforeAssetTransfers(_ hook: (@Sendable () async -> Void)?) {
+    lock.withLock { self.beforeAssetTransfers = hook }
+  }
+
+  var recordedCalls: [AssetTransfersCall] {
+    lock.withLock { assetTransfersCalls }
+  }
+
+  func getAssetTransfers(
+    chain: ChainConfig,
+    walletAddress: String,
+    fromBlock: UInt64
+  ) async throws -> [AlchemyTransfer] {
+    let (response, hook) = lock.withLock {
+      assetTransfersCalls.append(
+        AssetTransfersCall(
+          chainId: chain.chainId,
+          walletAddress: walletAddress,
+          fromBlock: fromBlock))
+      return (transfersResponse, beforeAssetTransfers)
+    }
+    if let hook { await hook() }
+    try Task.checkCancellation()
+    switch response {
+    case .none:
+      throw UnscriptedTransfersCall(chainId: chain.chainId)
+    case let .failure(error):
+      throw error
+    case let .transfers(transfers):
+      return transfers
+    }
+  }
+
+  func getTokenMetadata(
+    chain: ChainConfig,
+    contractAddress: String
+  ) async throws -> AlchemyTokenMetadata {
+    throw UnexpectedTokenMetadataCall()
+  }
+}
+
+/// In-memory `WalletSyncStateRepository` stub. Records every call so
+/// tests can verify the engine reads but never writes.
+///
+/// `@unchecked Sendable`: state behind an `NSLock`, matching the project
+/// convention.
+final class RecordingWalletSyncStateRepository: WalletSyncStateRepository, @unchecked Sendable {
+  private let lock = NSLock()
+  private var seeded: [UUID: WalletSyncState] = [:]
+  private(set) var saveCount: Int = 0
+  private(set) var deleteCount: Int = 0
+
+  func seed(_ state: WalletSyncState) {
+    lock.withLock { seeded[state.id] = state }
+  }
+
+  func loadAll() async throws -> [WalletSyncState] {
+    lock.withLock { Array(seeded.values) }
+  }
+
+  func load(accountId: UUID) async throws -> WalletSyncState? {
+    lock.withLock { seeded[accountId] }
+  }
+
+  func save(_ state: WalletSyncState) async throws {
+    lock.withLock {
+      saveCount += 1
+      seeded[state.id] = state
+    }
+  }
+
+  func delete(accountId: UUID) async throws {
+    lock.withLock {
+      deleteCount += 1
+      seeded[accountId] = nil
+    }
+  }
+}
+
+// MARK: - Builder shortcuts
+
+/// Constructs an `AlchemyTransfer` with the fields tests inspect — `hash`,
+/// `from`, `to`, `category`, `asset`, contract address / decimals, raw
+/// hex amount. Defaults match a typical native ETH send so cases that
+/// only change one or two fields read concisely.
+func makeAlchemyTransfer(
+  hash: String,
+  from: String,
+  to: String?,
+  category: AlchemyTransferCategory,
+  asset: String? = "ETH",
+  contractAddress: String? = nil,
+  decimalsHex: String? = "0x12",  // 18
+  rawValueHex: String = "0x0de0b6b3a7640000",  // 1.0 * 10^18
+  blockTimestamp: String? = "2024-09-12T12:34:56.000Z",
+  blockNum: String = "0x12d4f0a"
+) -> AlchemyTransfer {
+  AlchemyTransfer(
+    hash: hash,
+    uniqueId: "\(hash):0",
+    from: from,
+    to: to,
+    category: category,
+    asset: asset,
+    rawContract: AlchemyTransfer.RawContract(
+      address: contractAddress?.lowercased(),
+      decimal: decimalsHex,
+      rawValue: rawValueHex),
+    metadata: AlchemyTransfer.Metadata(blockTimestamp: blockTimestamp),
+    blockNum: blockNum)
+}
+
+/// Builds an `ImportOrigin` keyed off the synced account id. Matches
+/// the production factory shape Stage 9 will pass.
+func makeWalletImportOrigin(
+  for accountId: UUID,
+  importedAt: Date = Date(timeIntervalSince1970: 1_700_000_000),
+  sessionId: UUID = UUID()
+) -> ImportOrigin {
+  ImportOrigin(
+    rawDescription: "wallet:\(accountId.uuidString)",
+    rawAmount: 0,
+    importedAt: importedAt,
+    importSessionId: sessionId,
+    parserIdentifier: "alchemy-wallet-sync")
+}
+
+/// Builds a crypto `Account` for a given chain + wallet address.
+func makeCryptoAccount(
+  id: UUID = UUID(),
+  walletAddress: String,
+  chain: ChainConfig
+) -> Account {
+  Account(
+    id: id,
+    name: "Wallet",
+    type: .crypto,
+    instrument: chain.nativeInstrument,
+    walletAddress: walletAddress.lowercased(),
+    chainId: chain.chainId)
+}

--- a/Shared/CryptoImport/BuiltTransaction.swift
+++ b/Shared/CryptoImport/BuiltTransaction.swift
@@ -1,0 +1,21 @@
+// Shared/CryptoImport/BuiltTransaction.swift
+import Foundation
+
+/// In-flight transaction candidate produced by the build phase. Not yet
+/// persisted: Stage 7's `@MainActor` apply pass merges these across
+/// accounts, dedups against existing legs, then writes through
+/// `TransactionRepository`.
+///
+/// `originAccountId` is the account whose Alchemy fetch produced this
+/// candidate — needed for the cross-account merge step (so an outbound
+/// from account A and the matching inbound on account B can be paired
+/// by `externalId` + opposing-sign quantities).
+///
+/// The `transaction` value is structurally complete: legs carry the
+/// correct `externalId` (= on-chain `txHash`) and the right
+/// `TransactionType` per leg. `ImportOrigin` is populated with the
+/// raw fetch context.
+struct BuiltTransaction: Sendable, Hashable {
+  let originAccountId: UUID
+  let transaction: Transaction
+}

--- a/Shared/CryptoImport/TransferEventBuilder.swift
+++ b/Shared/CryptoImport/TransferEventBuilder.swift
@@ -1,0 +1,322 @@
+// Shared/CryptoImport/TransferEventBuilder.swift
+import Foundation
+import OSLog
+
+/// Pure builder that converts raw Alchemy transfers (already grouped by
+/// `hash`) into `BuiltTransaction`s. Stateless and `Sendable` — every
+/// dependency is supplied per call.
+///
+/// Produces multi-leg transactions:
+/// - One `.transfer` leg in the value token per token movement involving
+///   this wallet (negative quantity outbound; positive inbound).
+/// - The gas leg (`.expense` in the chain native token, on the from-side
+///   wallet only) is **deferred to a follow-up** — it requires an
+///   `eth_getTransactionReceipt` round-trip that Stage 4's `AlchemyClient`
+///   does not yet expose. See issue #762. Stage 6 ships transfer-leg-only
+///   `BuiltTransaction`s and the gas leg is added once that client method
+///   lands.
+///
+/// Each leg's `externalId` is set to the event's `hash`. NFT categories
+/// are filtered upstream at the request level; if one slips through (the
+/// decoder's lenient `.unknown` case) the builder skips it with a
+/// `Logger.notice` and continues so a single bad row doesn't fail the
+/// whole sync.
+struct TransferEventBuilder: Sendable {
+  /// Shared static `Logger` — `Logger` is `Sendable`, so this is safe
+  /// across actor boundaries without per-instance allocation.
+  private static let logger = Logger(
+    subsystem: "com.moolah.app", category: "TransferEventBuilder")
+
+  /// Builds candidate transactions for a single account from a list of
+  /// transfers fetched from Alchemy. Resolves token instruments via the
+  /// supplied discovery service so concurrent build calls coalesce on
+  /// the same `(chainId, contractAddress)` key.
+  ///
+  /// `account.walletAddress` is the user's wallet on this chain. The
+  /// builder lowercases it before comparison — Alchemy returns `from` /
+  /// `to` lowercased but callers may have stored the address in
+  /// checksummed form. Transfers where `from` matches the wallet are
+  /// outbound; matches on `to` are inbound. A self-send (both sides on
+  /// this wallet) emits a single inbound leg — Stage 7's apply pass
+  /// pairs the matching outbound from the build phase if the user
+  /// happens to track the same wallet under two accounts (rare).
+  ///
+  /// `importOrigin` carries the per-import audit context (sync session
+  /// id, parser identifier). Caller supplies; the builder echoes it on
+  /// every produced transaction.
+  ///
+  /// Throws: surfaces only `CancellationError` from the discovery actor
+  /// and `WalletSyncError.providerMalformedResponse` when a transfer
+  /// the builder cannot interpret reaches the produced-leg stage.
+  /// Per-row decode failures (malformed hex, missing decimals on a
+  /// non-native transfer) are logged and skipped — they shouldn't fail
+  /// the whole account.
+  func build(
+    transfers: [AlchemyTransfer],
+    account: Account,
+    chain: ChainConfig,
+    discovery: CryptoTokenDiscoveryService,
+    importOrigin: ImportOrigin
+  ) async throws -> [BuiltTransaction] {
+    guard let rawAddress = account.walletAddress else {
+      throw WalletSyncError.providerMalformedResponse(stage: "buildEvents-walletAddress")
+    }
+    let context = BuildContext(
+      account: account,
+      walletAddress: rawAddress.lowercased(),
+      chain: chain,
+      discovery: discovery,
+      importOrigin: importOrigin)
+
+    // Stable order: group preserves first-seen order so test fixtures
+    // and signposts are deterministic.
+    let groups = groupByHash(transfers)
+    var results: [BuiltTransaction] = []
+    results.reserveCapacity(groups.count)
+
+    for events in groups {
+      try Task.checkCancellation()
+      guard let built = try await buildEvent(events: events, context: context) else {
+        continue
+      }
+      results.append(built)
+    }
+    return results
+  }
+
+  // MARK: - Internals
+
+  /// Groups transfers by `hash` while preserving first-seen order so the
+  /// emitted `[BuiltTransaction]` is stable across runs (helps with
+  /// signpost tracing and snapshot assertions in tests). Each event in a
+  /// group already carries its own `hash`, so the key is dropped after
+  /// grouping to keep call sites simple.
+  private func groupByHash(_ transfers: [AlchemyTransfer]) -> [[AlchemyTransfer]] {
+    var order: [String] = []
+    var buckets: [String: [AlchemyTransfer]] = [:]
+    for transfer in transfers {
+      if buckets[transfer.hash] == nil {
+        order.append(transfer.hash)
+      }
+      buckets[transfer.hash, default: []].append(transfer)
+    }
+    return order.compactMap { buckets[$0] }
+  }
+
+  /// Builds one `BuiltTransaction` from a hash group, or returns `nil`
+  /// when the group produces no usable legs (every transfer was unknown
+  /// category or malformed).
+  private func buildEvent(
+    events: [AlchemyTransfer],
+    context: BuildContext
+  ) async throws -> BuiltTransaction? {
+    var legs: [TransactionLeg] = []
+    var earliestTimestamp: Date?
+
+    for event in events {
+      try Task.checkCancellation()
+      guard let leg = try await makeTransferLeg(event: event, context: context) else {
+        continue
+      }
+      legs.append(leg)
+      if let timestamp = parseTimestamp(event.metadata.blockTimestamp) {
+        if let current = earliestTimestamp {
+          earliestTimestamp = min(current, timestamp)
+        } else {
+          earliestTimestamp = timestamp
+        }
+      }
+    }
+
+    guard !legs.isEmpty else { return nil }
+
+    // Date precedence: earliest block timestamp across the group, falling
+    // back to `importedAt` so the transaction never lands with a zero
+    // date if Alchemy omitted metadata for every event in this hash
+    // (possible only when `withMetadata: false`, which the production
+    // client doesn't request; guard anyway for defensiveness).
+    let date = earliestTimestamp ?? context.importOrigin.importedAt
+    let transaction = Transaction(
+      date: date,
+      legs: legs,
+      importOrigin: context.importOrigin)
+    return BuiltTransaction(
+      originAccountId: context.account.id,
+      transaction: transaction)
+  }
+
+  /// Builds a single `.transfer` leg for one Alchemy event, or returns
+  /// `nil` when the event is unusable (NFT category slipped through,
+  /// malformed amount, or a touched-but-not-on-this-wallet event that
+  /// doesn't apply to the synced account).
+  private func makeTransferLeg(
+    event: AlchemyTransfer,
+    context: BuildContext
+  ) async throws -> TransactionLeg? {
+    guard event.category != .unknown else {
+      Self.logger.notice(
+        "Skipping unknown-category transfer hash \(event.hash, privacy: .private)"
+      )
+      return nil
+    }
+
+    let direction = TransferDirection(
+      fromAddress: event.from,
+      toAddress: event.to,
+      walletAddress: context.walletAddress)
+    guard direction != .unrelated else {
+      // Defensive — Alchemy's two-pass query should never surface a
+      // transfer that doesn't touch this wallet, but a malformed reply
+      // shouldn't fail the whole sync.
+      Self.logger.notice(
+        "Skipping transfer not involving wallet for hash \(event.hash, privacy: .private)"
+      )
+      return nil
+    }
+
+    guard
+      let unsignedQuantity = scaledQuantity(
+        rawDecimalValue: event.rawContract.rawDecimalValue,
+        decimalsValue: event.rawContract.decimalsValue,
+        category: event.category,
+        chain: context.chain)
+    else {
+      Self.logger.notice(
+        "Skipping malformed-amount transfer hash \(event.hash, privacy: .private)"
+      )
+      return nil
+    }
+
+    let instrument = try await resolveInstrument(event: event, context: context)
+
+    let signedQuantity: Decimal
+    switch direction {
+    case .outbound:
+      signedQuantity = -unsignedQuantity
+    case .inbound, .selfSend:
+      signedQuantity = unsignedQuantity
+    case .unrelated:
+      // Already handled above; unreachable here. `precondition` would be
+      // overkill for a defensive branch, so re-route to nil.
+      return nil
+    }
+
+    return TransactionLeg(
+      accountId: context.account.id,
+      instrument: instrument,
+      quantity: signedQuantity,
+      externalId: event.hash,
+      type: .transfer)
+  }
+
+  /// Resolves the leg's `Instrument`. For native transfers (`.external`,
+  /// `.internal`) returns the chain's native instrument directly — no
+  /// discovery round-trip needed. For ERC-20 transfers, defers to
+  /// `CryptoTokenDiscoveryService` so concurrent build calls share the
+  /// same in-flight `Task` per `(chainId, contractAddress)` key.
+  private func resolveInstrument(
+    event: AlchemyTransfer,
+    context: BuildContext
+  ) async throws -> Instrument {
+    switch event.category {
+    case .external, .internal:
+      return context.chain.nativeInstrument
+    case .erc20:
+      let contract = event.rawContract.address
+      let decimals = event.rawContract.decimalsValue ?? 18
+      let symbol = event.asset ?? "TOKEN"
+      let registration = try await context.discovery.resolveOrLoad(
+        chain: context.chain,
+        contractAddress: contract,
+        symbol: symbol,
+        name: symbol,
+        decimals: decimals)
+      return registration.instrument
+    case .unknown:
+      // Filtered by caller; preserve the path so the type-checker keeps
+      // the switch exhaustive.
+      throw WalletSyncError.providerMalformedResponse(stage: "resolveInstrument-unknown")
+    }
+  }
+
+  /// Converts an integer-units token amount into a human-scaled
+  /// `Decimal`. Returns `nil` when the underlying hex parse failed (the
+  /// caller logs and skips).
+  ///
+  /// For native transfers Alchemy may omit `decimal` — we substitute the
+  /// chain's native decimals so a dropped field doesn't lose the row.
+  private func scaledQuantity(
+    rawDecimalValue: Decimal?,
+    decimalsValue: Int?,
+    category: AlchemyTransferCategory,
+    chain: ChainConfig
+  ) -> Decimal? {
+    guard let rawDecimalValue else { return nil }
+    let decimals: Int
+    switch category {
+    case .external, .internal:
+      decimals = decimalsValue ?? chain.nativeInstrument.decimals
+    case .erc20:
+      // ERC-20 with no decimals reported is essentially uninterpretable —
+      // refuse rather than guess.
+      guard let decimalsValue else { return nil }
+      decimals = decimalsValue
+    case .unknown:
+      return nil
+    }
+    guard decimals >= 0 else { return nil }
+    return rawDecimalValue / Decimal(sign: .plus, exponent: decimals, significand: 1)
+  }
+
+  /// Parses Alchemy's ISO-8601 block timestamp (`"2024-09-12T12:34:56.000Z"`).
+  /// Returns `nil` on malformed input — caller falls back to
+  /// `ImportOrigin.importedAt`.
+  ///
+  /// `ISO8601DateFormatter` is allocated per call to keep the builder a
+  /// pure `Sendable` value type (no `nonisolated(unsafe)` static state).
+  /// The build hot path is dominated by the Alchemy round-trip and the
+  /// discovery actor, so a per-row allocation here is a non-event.
+  private func parseTimestamp(_ raw: String?) -> Date? {
+    guard let raw else { return nil }
+    let withFraction = ISO8601DateFormatter()
+    withFraction.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    if let date = withFraction.date(from: raw) { return date }
+    let plain = ISO8601DateFormatter()
+    plain.formatOptions = [.withInternetDateTime]
+    return plain.date(from: raw)
+  }
+}
+
+/// Per-call context bundle so `TransferEventBuilder`'s helpers stay
+/// inside SwiftLint's parameter-count budget while still getting at the
+/// account, chain, discovery actor, and import audit fields. Built once
+/// in `build(...)` and passed by value down the call tree.
+private struct BuildContext: Sendable {
+  let account: Account
+  let walletAddress: String
+  let chain: ChainConfig
+  let discovery: CryptoTokenDiscoveryService
+  let importOrigin: ImportOrigin
+}
+
+/// Direction a single Alchemy transfer takes relative to the synced
+/// wallet. Computed from the lowercased `from` / `to` fields.
+private enum TransferDirection {
+  case outbound
+  case inbound
+  case selfSend
+  case unrelated
+
+  init(fromAddress: String, toAddress: String?, walletAddress: String) {
+    let from = fromAddress.lowercased()
+    let to = toAddress?.lowercased()
+    let fromIsUs = from == walletAddress
+    let toIsUs = to == walletAddress
+    switch (fromIsUs, toIsUs) {
+    case (true, true): self = .selfSend
+    case (true, false): self = .outbound
+    case (false, true): self = .inbound
+    case (false, false): self = .unrelated
+    }
+  }
+}

--- a/Shared/CryptoImport/WalletSyncEngine.swift
+++ b/Shared/CryptoImport/WalletSyncEngine.swift
@@ -1,0 +1,98 @@
+// Shared/CryptoImport/WalletSyncEngine.swift
+import Foundation
+import OSLog
+
+/// Per-account orchestrator of the build phase. **No repository writes.**
+/// Stage 7's apply pass consumes `[BuiltTransaction]` and persists.
+///
+/// The engine is a `Sendable` struct — every dependency is itself `Sendable`
+/// (actor or stateless) and there is no mutable state on `Self`. This makes
+/// it safe to call concurrently from `Stage 9`'s `withTaskGroup` parallel
+/// build phase.
+struct WalletSyncEngine: Sendable {
+  private let alchemy: any AlchemyClient
+  private let discovery: CryptoTokenDiscoveryService
+  private let walletSyncState: any WalletSyncStateRepository
+  private let importOriginFactory: @Sendable (UUID) -> ImportOrigin
+  /// Shared static `Logger` — `Logger` is `Sendable`, so a static let is
+  /// safe across actor boundaries without per-instance allocation.
+  private static let logger = Logger(
+    subsystem: "com.moolah.app", category: "WalletSyncEngine")
+
+  /// - Parameters:
+  ///   - alchemy: Stage 4's `AlchemyClient`. The engine itself doesn't
+  ///     hold the rate limiter — `LiveAlchemyClient` does, so callers
+  ///     don't need to plumb it through here.
+  ///   - discovery: Stage 5's actor-coalesced token registry resolver.
+  ///   - walletSyncState: Per-device sync checkpoint store. The engine
+  ///     reads `lastSyncedBlockNumber` to compute `fromBlock`; **it does
+  ///     not write back** — Stage 7's apply pass is the single writer.
+  ///   - importOriginFactory: Builds an `ImportOrigin` keyed to the
+  ///     account being synced. Stage 9 supplies a closure that captures
+  ///     the per-cycle session id; tests pass a deterministic factory.
+  init(
+    alchemy: any AlchemyClient,
+    discovery: CryptoTokenDiscoveryService,
+    walletSyncState: any WalletSyncStateRepository,
+    importOriginFactory: @Sendable @escaping (UUID) -> ImportOrigin
+  ) {
+    self.alchemy = alchemy
+    self.discovery = discovery
+    self.walletSyncState = walletSyncState
+    self.importOriginFactory = importOriginFactory
+  }
+
+  /// Runs the build phase for a single crypto account. Returns the list
+  /// of `BuiltTransaction`s the apply pass should consider. Throws on
+  /// transient failures (network, rate-limit, malformed account); the
+  /// orchestrator (Stage 9) handles per-account error containment so
+  /// other accounts still apply.
+  ///
+  /// Cancellation: respects `Task.checkCancellation()` between stages.
+  /// A cancelled task throws `CancellationError` and writes nothing
+  /// anywhere — the apply pass is the single writer regardless.
+  func build(account: Account, chain: ChainConfig) async throws -> [BuiltTransaction] {
+    // 1. Validate account is a crypto account with required fields.
+    guard
+      account.type == .crypto,
+      let walletAddress = account.walletAddress,
+      !walletAddress.isEmpty
+    else {
+      Self.logger.error(
+        "WalletSyncEngine: invalid account \(account.id, privacy: .public)"
+      )
+      throw WalletSyncError.providerMalformedResponse(stage: "account-validation")
+    }
+    try Task.checkCancellation()
+
+    // 2. Determine fromBlock (reorg window — re-fetch covers the last
+    //    32 blocks below the prior checkpoint).
+    let state = try await walletSyncState.load(accountId: account.id)
+    let fromBlock = state.map { Self.subtractingReorgWindow($0.lastSyncedBlockNumber) } ?? 0
+
+    // 3. Fetch transfers (rate-limited inside AlchemyClient).
+    try Task.checkCancellation()
+    let transfers = try await alchemy.getAssetTransfers(
+      chain: chain, walletAddress: walletAddress, fromBlock: fromBlock)
+    try Task.checkCancellation()
+
+    // 4. Build candidates. Discovery actor handles its own coalescing;
+    //    no repository writes happen here.
+    let builder = TransferEventBuilder()
+    let importOrigin = importOriginFactory(account.id)
+    let built = try await builder.build(
+      transfers: transfers,
+      account: account,
+      chain: chain,
+      discovery: discovery,
+      importOrigin: importOrigin)
+    return built
+  }
+
+  /// Per design: re-fetch covers `[lastSyncedBlockNumber - 32, head]`.
+  /// Returns 0 when the prior checkpoint sits inside the reorg window
+  /// (genesis-fetch on a new device).
+  static func subtractingReorgWindow(_ block: UInt64) -> UInt64 {
+    block > 32 ? block - 32 : 0
+  }
+}


### PR DESCRIPTION
## Summary

Stage 6 of [`plans/2026-05-05-crypto-wallet-import-plan.md`](https://github.com/ajsutton/moolah-native/blob/main/plans/2026-05-05-crypto-wallet-import-plan.md). Adds the per-account build phase that turns raw Alchemy transfers into `BuiltTransaction` candidates with multi-leg structure, ready for Stage 7's apply pass.

- **`BuiltTransaction`** — value type carrying a candidate `Transaction` plus the originating account id. Stage 7 merges these across accounts before persisting.
- **`TransferEventBuilder`** — stateless `Sendable` builder. Groups raw transfers by `hash`, emits a `.transfer` leg per token movement involving the wallet, sets `externalId` on every leg, lowercases the wallet address before comparison, preserves the sign convention (outbound = negative, inbound = positive — no `abs()`). Native transfers use the chain's native instrument; ERC-20 transfers route through `CryptoTokenDiscoveryService.resolveOrLoad(...)` so the actor's in-flight coalescer holds across concurrent build calls. Unknown / NFT-category rows are logged and skipped — they never crash the sync.
- **`WalletSyncEngine`** — per-account orchestrator. Validates the account, computes `fromBlock = lastSyncedBlockNumber - 32` (genesis-fetch when no prior state), fetches via `AlchemyClient`, hands off to the builder, and returns `[BuiltTransaction]`. **Zero repository writes.** Cancellation is honoured at every stage boundary so a cancelled sync writes nothing.

## Deferred — gas leg (#762)

The design's per-event `.expense` gas leg requires an `eth_getTransactionReceipt` round-trip that Stage 4's `AlchemyClient` doesn't expose yet. Stage 6 ships transfer-leg-only `BuiltTransaction`s. Follow-up tracked in [#762](https://github.com/ajsutton/moolah-native/issues/762); Stage 7's apply pass is unaffected (gas legs are additive per-event).

## Test plan

- [x] `TransferEventBuilderTests` — outbound native ETH (negative quantity), outbound ERC-20 (resolved instrument), inbound transfer, two transfers in one hash → one transaction with two legs, unknown-category skipped, internal category mapped to native instrument, missing wallet throws, 100 concurrent builders → single resolver call (coalescer holds).
- [x] `WalletSyncEngineTests` — happy path returns BuiltTransactions and writes nothing, `fromBlock = state - 32`, `fromBlock = 0` inside reorg window or with no state, cancellation between stages throws `CancellationError`, non-crypto / missing / empty wallet throws `WalletSyncError`, end-to-end run never writes to `WalletSyncStateRepository`.
- [x] `just test` (mac + iOS): 2268 tests in 364 suites passed (mac); 2243 tests in 359 suites passed (iOS).
- [x] `just format-check` clean. No SwiftLint baseline edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)