### PR TITLE
feat(crypto): cross-account merge + transfer-detection eligibility extension

### DIFF
--- a/Backends/GRDB/Repositories/GRDBTransactionRepository+ExternalIdLookup.swift
+++ b/Backends/GRDB/Repositories/GRDBTransactionRepository+ExternalIdLookup.swift
@@ -1,0 +1,36 @@
+// Backends/GRDB/Repositories/GRDBTransactionRepository+ExternalIdLookup.swift
+
+import Foundation
+import GRDB
+
+/// Wallet-importer dedup primitives. Both methods read against the
+/// partial unique index `idx_transaction_leg_external_id` defined in the
+/// crypto-wallet-fields migration, so even a million-row leg table
+/// resolves the lookup in O(log n).
+extension GRDBTransactionRepository {
+  func legs(matchingExternalId externalId: String) async throws -> [TransactionLeg] {
+    try await database.read { database in
+      let instruments = try Self.fetchInstrumentMap(database: database)
+      let rows =
+        try TransactionLegRow
+        .filter(TransactionLegRow.Columns.externalId == externalId)
+        .fetchAll(database)
+      return try rows.map { row in
+        let instrument =
+          instruments[row.instrumentId]
+          ?? Instrument.fiat(code: row.instrumentId)
+        return try row.toDomain(instrument: instrument)
+      }
+    }
+  }
+
+  func legExists(accountId: UUID, externalId: String) async throws -> Bool {
+    try await database.read { database in
+      try TransactionLegRow
+        .filter(TransactionLegRow.Columns.accountId == accountId)
+        .filter(TransactionLegRow.Columns.externalId == externalId)
+        .fetchCount(database)
+        > 0
+    }
+  }
+}

--- a/Domain/Models/Transaction+TransferDetection.swift
+++ b/Domain/Models/Transaction+TransferDetection.swift
@@ -1,0 +1,97 @@
+import Foundation
+
+// Transfer-detection eligibility predicate (Extension A from
+// `plans/2026-04-18-transfer-detection-design.md`, added alongside the
+// crypto wallet importer in `plans/2026-05-05-crypto-wallet-import-design.md`).
+//
+// Eligibility lets multi-leg crypto transactions (transfer leg + cross-
+// instrument fee leg) participate in the standard amount/instrument/date
+// suggestion pass without false-pairing trades or already-merged
+// transfers. Detection's amount/instrument matching always operates on
+// the value-bearing leg.
+extension Transaction {
+  /// `true` iff this transaction can participate in the transfer-
+  /// detection suggestion pass. Detection always operates on the value-
+  /// bearing leg.
+  ///
+  /// Eligible shapes:
+  /// - Exactly one `.transfer` leg (the value-bearing leg). Any number
+  ///   of additional `.expense` legs in a different instrument from the
+  ///   value-bearing leg are permitted (fees: gas, broker fees, …).
+  /// - Exactly one `.income` or `.expense` leg (legacy single-leg cash).
+  ///   Any number of additional `.expense` legs in a different instrument
+  ///   from the value-bearing leg are permitted.
+  ///
+  /// Ineligible shapes:
+  /// - Trades (two `.trade` legs).
+  /// - Already-merged transfers (two `.transfer` legs).
+  /// - Opening balances (`.openingBalance`).
+  /// - Anything else with multiple value-bearing legs or with extra legs
+  ///   in the same instrument as the value-bearing leg.
+  var isTransferDetectionEligible: Bool { transferDetectionValueLeg != nil }
+
+  /// The leg that detection should pair on, or `nil` when this
+  /// transaction is ineligible.
+  var transferDetectionValueLeg: TransactionLeg? {
+    let transferLegs = legs.filter { $0.type == .transfer }
+    if transferLegs.count == 1 {
+      return Self.valueLegIfFeesAreCrossInstrument(
+        valueLeg: transferLegs[0],
+        otherLegs: legs.filter { $0.type != .transfer })
+    }
+
+    if transferLegs.isEmpty {
+      let cashLegs = legs.filter { $0.type == .income || $0.type == .expense }
+      // Pick the single value-bearing leg as the largest-magnitude one
+      // so a value `.expense` paired with smaller `.expense` fee legs
+      // resolves correctly. If two or more cash legs share the same
+      // instrument, none of them is a fee — the transaction has
+      // multiple value-bearing legs and is ineligible.
+      if let valueLeg = Self.cashValueLeg(amongCashLegs: cashLegs) {
+        return Self.valueLegIfFeesAreCrossInstrument(
+          valueLeg: valueLeg,
+          otherLegs: legs.filter { $0 != valueLeg })
+      }
+    }
+    return nil
+  }
+
+  /// Selects the single value-bearing cash leg. Eligible cash shapes
+  /// are: one `.income`/`.expense` leg by itself, or one such leg
+  /// plus zero or more `.expense` fee legs in different instruments.
+  /// When two or more legs sit in the same instrument the value-leg is
+  /// ambiguous — caller treats the whole transaction as ineligible.
+  private static func cashValueLeg(amongCashLegs cashLegs: [TransactionLeg]) -> TransactionLeg? {
+    guard !cashLegs.isEmpty else { return nil }
+    if cashLegs.count == 1 { return cashLegs[0] }
+    // With ≥2 cash legs, the value leg is the unique-instrument one
+    // (every other cash leg sits in its own distinct instrument and
+    // is `.expense`-typed = a fee). If multiple cash legs share an
+    // instrument the value leg is ambiguous.
+    var byInstrument: [Instrument: [TransactionLeg]] = [:]
+    for leg in cashLegs {
+      byInstrument[leg.instrument, default: []].append(leg)
+    }
+    let dominant = byInstrument.values.filter { $0.count >= 2 }
+    guard dominant.isEmpty else { return nil }
+    // The value-bearing leg is the largest-magnitude cash leg; remaining
+    // cash legs must be `.expense` fee legs in a different instrument
+    // (validated by the cross-instrument predicate at the call site).
+    let sorted = cashLegs.sorted { abs($0.quantity) > abs($1.quantity) }
+    return sorted.first
+  }
+
+  /// Returns `valueLeg` when every other leg either is `.expense` and
+  /// sits in a different instrument from `valueLeg` (a fee leg), or
+  /// the leg list is empty. Returns `nil` otherwise — that shape isn't
+  /// detection-eligible.
+  private static func valueLegIfFeesAreCrossInstrument(
+    valueLeg: TransactionLeg,
+    otherLegs: [TransactionLeg]
+  ) -> TransactionLeg? {
+    let allFeeLegs = otherLegs.allSatisfy { leg in
+      leg.type == .expense && leg.instrument != valueLeg.instrument
+    }
+    return allFeeLegs ? valueLeg : nil
+  }
+}

--- a/Domain/Repositories/TransactionRepository.swift
+++ b/Domain/Repositories/TransactionRepository.swift
@@ -17,6 +17,23 @@ protocol TransactionRepository: Sendable {
   /// unsaved drafts — leave the unfiltered list intact.
   func fetchPayeeSuggestions(prefix: String, excludingTransactionId: UUID?) async throws
     -> [String]
+  /// Returns every persisted leg whose `external_id` equals `externalId`.
+  /// Used by the wallet importer's cross-account merge pass to pair an
+  /// in-batch candidate against legs already persisted on a prior cycle
+  /// (so the same on-chain hash arriving via two accounts on different
+  /// devices still merges into one transaction).
+  ///
+  /// Domain return type — the leg's instrument is resolved during the
+  /// fetch the same way `fetch(filter:…)` and `fetchAll(filter:)` resolve
+  /// it. The schema's partial unique index on
+  /// `(account_id, external_id)` keeps this lookup cheap.
+  func legs(matchingExternalId externalId: String) async throws -> [TransactionLeg]
+  /// `true` iff the wallet importer has already persisted a leg keyed by
+  /// `(accountId, externalId)`. Used by the per-leg dedup step of the
+  /// apply pass — re-fetches that span the reorg window cover already-
+  /// imported transactions, so each leg is checked against the partial
+  /// unique index before insertion.
+  func legExists(accountId: UUID, externalId: String) async throws -> Bool
 }
 
 extension TransactionRepository {

--- a/MoolahTests/Features/TransactionStoreLoadRaceTests.swift
+++ b/MoolahTests/Features/TransactionStoreLoadRaceTests.swift
@@ -234,4 +234,6 @@ actor FirstFetchGatedTransactionRepository: TransactionRepository {
   func fetchPayeeSuggestions(
     prefix: String, excludingTransactionId: UUID?
   ) async throws -> [String] { [] }
+  func legs(matchingExternalId externalId: String) async throws -> [TransactionLeg] { [] }
+  func legExists(accountId: UUID, externalId: String) async throws -> Bool { false }
 }

--- a/MoolahTests/Shared/CryptoImport/CrossAccountTransferMergerTests.swift
+++ b/MoolahTests/Shared/CryptoImport/CrossAccountTransferMergerTests.swift
@@ -1,0 +1,246 @@
+// MoolahTests/Shared/CryptoImport/CrossAccountTransferMergerTests.swift
+import Foundation
+import Testing
+
+@testable import Moolah
+
+/// Behavioural tests for `CrossAccountTransferMerger`. The merger is
+/// pure — no repository writes, no shared state — so every test
+/// constructs `BuiltTransaction`s in-line and feeds them through
+/// `merge(candidates:existingLegLookup:)` with a closure that supplies
+/// any prior-cycle legs the test wants the merger to see.
+@Suite("CrossAccountTransferMerger")
+struct CrossAccountTransferMergerTests {
+  // Two stable account ids — A < B by UUID-string lex order so the
+  // determinism tests can assert on the lower-UUID-wins rule. Stamping
+  // them as raw UUIDs (not generated per-call) keeps the suite
+  // reproducible.
+  private static let accountA = makeUUID("00000000-0000-0000-0000-0000000000A1")
+  private static let accountB = makeUUID("00000000-0000-0000-0000-0000000000B2")
+  private static let hash = "0xdeadbeef"
+
+  private static let dateA = Date(timeIntervalSince1970: 1_700_000_000)
+  private static let dateB = Date(timeIntervalSince1970: 1_700_000_500)
+
+  // MARK: - Pair predicate
+
+  @Test("Same hash + opposing legs collapses to a single multi-leg transaction")
+  func mergesOpposingPairOnSameExternalId() async throws {
+    let outbound = makeBuiltTransaction(
+      accountId: Self.accountA,
+      hash: Self.hash,
+      instrument: TestInstruments.ethereum,
+      quantity: -1,
+      date: Self.dateA)
+    let inbound = makeBuiltTransaction(
+      accountId: Self.accountB,
+      hash: Self.hash,
+      instrument: TestInstruments.ethereum,
+      quantity: 1,
+      date: Self.dateB)
+
+    let merged = try await CrossAccountTransferMerger().merge(
+      candidates: [outbound, inbound],
+      existingLegLookup: { _ in [] })
+
+    #expect(merged.count == 1)
+    let result = try #require(merged.first)
+    #expect(result.transaction.legs.count == 2)
+    let signs = result.transaction.legs.map { $0.quantity > 0 ? "+" : "-" }
+    #expect(Set(signs) == Set(["+", "-"]))
+    let externalIds = Set(result.transaction.legs.compactMap(\.externalId))
+    #expect(externalIds == [Self.hash])
+  }
+
+  @Test("Same hash + same-sign legs are NOT merged (multi-recipient airdrop, issue #750)")
+  func skipsSameSignPair() async throws {
+    let firstInbound = makeBuiltTransaction(
+      accountId: Self.accountA, hash: Self.hash,
+      instrument: TestInstruments.ethereum, quantity: 1)
+    let secondInbound = makeBuiltTransaction(
+      accountId: Self.accountB, hash: Self.hash,
+      instrument: TestInstruments.ethereum, quantity: 1)
+
+    let merged = try await CrossAccountTransferMerger().merge(
+      candidates: [firstInbound, secondInbound],
+      existingLegLookup: { _ in [] })
+
+    #expect(merged.count == 2)
+  }
+
+  @Test("Same hash + different instruments are NOT merged (cross-chain bridge)")
+  func skipsDifferentInstrumentPair() async throws {
+    let outbound = makeBuiltTransaction(
+      accountId: Self.accountA, hash: Self.hash,
+      instrument: TestInstruments.ethereum, quantity: -1)
+    let inbound = makeBuiltTransaction(
+      accountId: Self.accountB, hash: Self.hash,
+      instrument: TestInstruments.polygon, quantity: 1)
+
+    let merged = try await CrossAccountTransferMerger().merge(
+      candidates: [outbound, inbound],
+      existingLegLookup: { _ in [] })
+
+    #expect(merged.count == 2)
+  }
+
+  @Test("Same hash + same account is NOT merged (self-send)")
+  func skipsSameAccountPair() async throws {
+    let outbound = makeBuiltTransaction(
+      accountId: Self.accountA, hash: Self.hash,
+      instrument: TestInstruments.ethereum, quantity: -1)
+    let inbound = makeBuiltTransaction(
+      accountId: Self.accountA, hash: Self.hash,
+      instrument: TestInstruments.ethereum, quantity: 1)
+
+    let merged = try await CrossAccountTransferMerger().merge(
+      candidates: [outbound, inbound],
+      existingLegLookup: { _ in [] })
+
+    #expect(merged.count == 2)
+  }
+
+  // MARK: - Fee legs
+
+  @Test("Fee legs from both sides are preserved on the merged transaction")
+  func preservesFeeLegsOnMerge() async throws {
+    let gasInstrument = TestInstruments.ethereum
+    let outboundFee = TransactionLeg(
+      accountId: Self.accountA,
+      instrument: gasInstrument,
+      quantity: try #require(Decimal(string: "-0.001")),
+      externalId: Self.hash,
+      type: .expense)
+    let outbound = makeBuiltTransaction(
+      accountId: Self.accountA, hash: Self.hash,
+      instrument: gasInstrument, quantity: -1,
+      extraLegs: [outboundFee])
+
+    // Inbound side — different chain native, different fee instrument
+    // to keep the value vs. fee distinction obvious.
+    let inboundFee = TransactionLeg(
+      accountId: Self.accountB,
+      instrument: gasInstrument,
+      quantity: try #require(Decimal(string: "-0.0005")),
+      externalId: Self.hash,
+      type: .expense)
+    let inbound = makeBuiltTransaction(
+      accountId: Self.accountB, hash: Self.hash,
+      instrument: gasInstrument, quantity: 1,
+      extraLegs: [inboundFee])
+
+    let merged = try await CrossAccountTransferMerger().merge(
+      candidates: [outbound, inbound],
+      existingLegLookup: { _ in [] })
+
+    #expect(merged.count == 1)
+    let result = try #require(merged.first)
+    let feeLegs = result.transaction.legs.filter { $0.type == .expense }
+    #expect(feeLegs.count == 2)
+  }
+
+  // MARK: - Existing-leg lookup
+
+  @Test("In-batch candidate pairs against a leg already persisted on a prior cycle")
+  func mergesAgainstExistingPersistedLeg() async throws {
+    let priorCycleLeg = TransactionLeg(
+      accountId: Self.accountA,
+      instrument: TestInstruments.ethereum,
+      quantity: -1,
+      externalId: Self.hash,
+      type: .transfer)
+
+    let inbound = makeBuiltTransaction(
+      accountId: Self.accountB, hash: Self.hash,
+      instrument: TestInstruments.ethereum, quantity: 1)
+
+    let merged = try await CrossAccountTransferMerger().merge(
+      candidates: [inbound],
+      existingLegLookup: { externalId in
+        externalId == Self.hash ? [priorCycleLeg] : []
+      })
+
+    #expect(merged.count == 1)
+    let result = try #require(merged.first)
+    #expect(result.transaction.legs.count == 2)
+    // Both the in-batch candidate's leg and the persisted leg surface;
+    // dedup at the apply layer drops the persisted one when the candidate
+    // is rewritten — the merger's contract is just to expose the merged
+    // shape so the transfer-detection engine sees one event, not two.
+    let externalIds = result.transaction.legs.compactMap(\.externalId)
+    #expect(externalIds.allSatisfy { $0 == Self.hash })
+  }
+
+  // MARK: - Determinism
+
+  @Test("originAccountId on the merged value is the lower-UUID side")
+  func mergedOriginIsLowerUuid() async throws {
+    let outbound = makeBuiltTransaction(
+      accountId: Self.accountB, hash: Self.hash,
+      instrument: TestInstruments.ethereum, quantity: -1, date: Self.dateB)
+    let inbound = makeBuiltTransaction(
+      accountId: Self.accountA, hash: Self.hash,
+      instrument: TestInstruments.ethereum, quantity: 1, date: Self.dateA)
+
+    let merged = try await CrossAccountTransferMerger().merge(
+      candidates: [outbound, inbound],
+      existingLegLookup: { _ in [] })
+
+    let result = try #require(merged.first)
+    #expect(result.originAccountId == Self.accountA)
+  }
+
+  @Test("Date on the merged transaction is the earlier of the two")
+  func mergedDateIsEarlier() async throws {
+    let outbound = makeBuiltTransaction(
+      accountId: Self.accountA, hash: Self.hash,
+      instrument: TestInstruments.ethereum, quantity: -1, date: Self.dateB)
+    let inbound = makeBuiltTransaction(
+      accountId: Self.accountB, hash: Self.hash,
+      instrument: TestInstruments.ethereum, quantity: 1, date: Self.dateA)
+
+    let merged = try await CrossAccountTransferMerger().merge(
+      candidates: [outbound, inbound],
+      existingLegLookup: { _ in [] })
+
+    let result = try #require(merged.first)
+    #expect(result.transaction.date == Self.dateA)
+  }
+
+  // MARK: - Helpers
+
+  private func makeBuiltTransaction(
+    accountId: UUID,
+    hash: String,
+    instrument: Instrument,
+    quantity: Decimal,
+    date: Date = Date(timeIntervalSince1970: 1_700_000_000),
+    extraLegs: [TransactionLeg] = []
+  ) -> BuiltTransaction {
+    let transferLeg = TransactionLeg(
+      accountId: accountId,
+      instrument: instrument,
+      quantity: quantity,
+      externalId: hash,
+      type: .transfer)
+    let transaction = Transaction(
+      date: date,
+      legs: [transferLeg] + extraLegs,
+      importOrigin: ImportOrigin(
+        rawDescription: "wallet:\(accountId.uuidString)",
+        rawAmount: 0,
+        importedAt: date,
+        importSessionId: UUID(),
+        parserIdentifier: "alchemy-wallet-sync"))
+    return BuiltTransaction(originAccountId: accountId, transaction: transaction)
+  }
+}
+
+/// Native instruments for the chains the merger tests reuse across
+/// cases. File-scoped helpers avoid extending `Instrument` with
+/// fileprivate test-only members (which conflict with `swift-format`'s
+/// hoisting of `fileprivate` out of `private extension`).
+private enum TestInstruments {
+  static let ethereum: Instrument = ChainConfig.ethereum.nativeInstrument
+  static let polygon: Instrument = ChainConfig.polygon.nativeInstrument
+}

--- a/MoolahTests/Shared/CryptoImport/TransferDetectionEligibilityTests.swift
+++ b/MoolahTests/Shared/CryptoImport/TransferDetectionEligibilityTests.swift
@@ -1,0 +1,126 @@
+// MoolahTests/Shared/CryptoImport/TransferDetectionEligibilityTests.swift
+import Foundation
+import Testing
+
+@testable import Moolah
+
+/// Tests for `Transaction.isTransferDetectionEligible` (Extension A from
+/// `plans/2026-04-18-transfer-detection-design.md`). The predicate gates
+/// the standard amount/instrument/date suggestion pass; eligible
+/// transactions surface their value-bearing leg via
+/// `Transaction.transferDetectionValueLeg`.
+@Suite("Transaction.isTransferDetectionEligible — Extension A")
+struct TransferDetectionEligibilityTests {
+  private static let accountId = UUID()
+  private static let valueInstrument = ChainConfig.ethereum.nativeInstrument
+  // A different instrument so fee legs satisfy the cross-instrument predicate.
+  private static let feeInstrument = Instrument.fiat(code: "USD")
+
+  // MARK: - Eligible shapes
+
+  @Test("Single transfer leg is eligible")
+  func singleTransferLegEligible() {
+    let transaction = Transaction(
+      date: Date(),
+      legs: [
+        TransactionLeg(
+          accountId: Self.accountId, instrument: Self.valueInstrument,
+          quantity: -1, type: .transfer)
+      ])
+    #expect(transaction.isTransferDetectionEligible)
+    #expect(transaction.transferDetectionValueLeg?.type == .transfer)
+  }
+
+  @Test("Single income leg is eligible (legacy single-leg cash)")
+  func singleIncomeLegEligible() {
+    let transaction = Transaction(
+      date: Date(),
+      legs: [
+        TransactionLeg(
+          accountId: Self.accountId, instrument: Self.valueInstrument,
+          quantity: 100, type: .income)
+      ])
+    #expect(transaction.isTransferDetectionEligible)
+    #expect(transaction.transferDetectionValueLeg?.type == .income)
+  }
+
+  @Test("Transfer leg + cross-instrument expense fee leg is eligible")
+  func transferWithFeeLegEligible() {
+    let transaction = Transaction(
+      date: Date(),
+      legs: [
+        TransactionLeg(
+          accountId: Self.accountId, instrument: Self.valueInstrument,
+          quantity: -1, type: .transfer),
+        TransactionLeg(
+          accountId: Self.accountId, instrument: Self.feeInstrument,
+          quantity: -2, type: .expense),
+      ])
+    #expect(transaction.isTransferDetectionEligible)
+    let valueLeg = transaction.transferDetectionValueLeg
+    #expect(valueLeg?.type == .transfer)
+    #expect(valueLeg?.instrument == Self.valueInstrument)
+  }
+
+  // MARK: - Ineligible shapes
+
+  @Test("Two trade legs (trade) is ineligible")
+  func twoTradeLegsIneligible() {
+    let transaction = Transaction(
+      date: Date(),
+      legs: [
+        TransactionLeg(
+          accountId: Self.accountId, instrument: Self.valueInstrument,
+          quantity: -1, type: .trade),
+        TransactionLeg(
+          accountId: Self.accountId, instrument: Self.feeInstrument,
+          quantity: 1000, type: .trade),
+      ])
+    #expect(!transaction.isTransferDetectionEligible)
+    #expect(transaction.transferDetectionValueLeg == nil)
+  }
+
+  @Test("Two transfer legs (already-merged transfer) is ineligible")
+  func twoTransferLegsIneligible() {
+    let other = UUID()
+    let transaction = Transaction(
+      date: Date(),
+      legs: [
+        TransactionLeg(
+          accountId: Self.accountId, instrument: Self.valueInstrument,
+          quantity: -1, type: .transfer),
+        TransactionLeg(
+          accountId: other, instrument: Self.valueInstrument,
+          quantity: 1, type: .transfer),
+      ])
+    #expect(!transaction.isTransferDetectionEligible)
+  }
+
+  @Test("Transfer leg + same-instrument extra leg is ineligible (fee predicate fails)")
+  func transferWithSameInstrumentExtraLegIneligible() {
+    let transaction = Transaction(
+      date: Date(),
+      legs: [
+        TransactionLeg(
+          accountId: Self.accountId, instrument: Self.valueInstrument,
+          quantity: -1, type: .transfer),
+        // Same instrument as the value leg → not a fee leg.
+        TransactionLeg(
+          accountId: Self.accountId, instrument: Self.valueInstrument,
+          quantity: -2, type: .expense),
+      ])
+    #expect(!transaction.isTransferDetectionEligible)
+  }
+
+  @Test("Opening balance is ineligible")
+  func openingBalanceIneligible() {
+    let transaction = Transaction(
+      date: Date(),
+      legs: [
+        TransactionLeg(
+          accountId: Self.accountId, instrument: Self.valueInstrument,
+          quantity: 100, type: .openingBalance)
+      ])
+    #expect(!transaction.isTransferDetectionEligible)
+  }
+}

--- a/MoolahTests/Shared/CryptoImport/WalletApplyEngineTests.swift
+++ b/MoolahTests/Shared/CryptoImport/WalletApplyEngineTests.swift
@@ -1,0 +1,220 @@
+// MoolahTests/Shared/CryptoImport/WalletApplyEngineTests.swift
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+/// Behavioural tests for `WalletApplyEngine`. Uses `TestBackend` (real
+/// `CloudKitBackend` + in-memory GRDB) so per-leg dedup, persistence,
+/// and `WalletSyncState` updates are exercised end-to-end without
+/// mocking the repositories.
+@Suite("WalletApplyEngine — Sequential apply pass")
+@MainActor
+struct WalletApplyEngineTests {
+  // Pinned clock value tests assert against. `nonisolated` so the
+  // `@Sendable` clock closure passed to `WalletApplyEngine` can read
+  // it without crossing the suite's `@MainActor` boundary.
+  nonisolated static let pinnedNow = Date(timeIntervalSince1970: 1_700_000_000)
+
+  // MARK: - Happy path
+
+  @Test("Two accounts, one candidate each → merger collapses → one transaction persisted")
+  func happyPath() async throws {
+    let setup = try makeSetup()
+    let accountA = try setup.seedCryptoAccount()
+    let accountB = try setup.seedCryptoAccount()
+    let hash = "0xa-merge-this"
+
+    let outbound = makeBuilt(
+      accountId: accountA.id, hash: hash, quantity: -1)
+    let inbound = makeBuilt(
+      accountId: accountB.id, hash: hash, quantity: 1)
+
+    let persisted = try await setup.engine.apply(perAccount: [
+      .init(account: accountA, headBlockNumber: 100, candidates: [outbound]),
+      .init(account: accountB, headBlockNumber: 200, candidates: [inbound]),
+    ])
+
+    #expect(persisted.count == 1)
+    let stored = try await setup.backend.transactions.fetchAll(filter: .init())
+    #expect(stored.count == 1)
+    let result = try #require(stored.first)
+    #expect(result.legs.count == 2)
+    let signs = result.legs.map { $0.quantity > 0 ? "+" : "-" }
+    #expect(Set(signs) == Set(["+", "-"]))
+  }
+
+  // MARK: - Dedup
+
+  @Test("Pre-seeded leg with the same (accountId, externalId) prevents a duplicate write")
+  func perLegDedupSkipsExisting() async throws {
+    let setup = try makeSetup()
+    let accountA = try setup.seedCryptoAccount()
+    let hash = "0xseen-before"
+
+    // Pre-seed a transaction with the same `(accountId, externalId)`
+    // pair so the dedup step has something to find.
+    let priorLeg = TransactionLeg(
+      accountId: accountA.id,
+      instrument: ChainConfig.ethereum.nativeInstrument,
+      quantity: -1,
+      externalId: hash,
+      type: .transfer)
+    _ = try await setup.backend.transactions.create(
+      Transaction(
+        date: Self.pinnedNow.addingTimeInterval(-3_600),
+        legs: [priorLeg]))
+
+    let candidate = makeBuilt(
+      accountId: accountA.id, hash: hash, quantity: -1)
+
+    let persisted = try await setup.engine.apply(perAccount: [
+      .init(account: accountA, headBlockNumber: 50, candidates: [candidate])
+    ])
+
+    #expect(persisted.isEmpty)
+    let stored = try await setup.backend.transactions.fetchAll(filter: .init())
+    #expect(stored.count == 1)  // Only the pre-seeded one.
+  }
+
+  // MARK: - WalletSyncState
+
+  @Test("WalletSyncState is updated per account with pinned clock + headBlockNumber")
+  func updatesWalletSyncStatePerAccount() async throws {
+    let setup = try makeSetup()
+    let accountA = try setup.seedCryptoAccount()
+    let accountB = try setup.seedCryptoAccount()
+
+    _ = try await setup.engine.apply(perAccount: [
+      .init(account: accountA, headBlockNumber: 100, candidates: []),
+      .init(account: accountB, headBlockNumber: 250, candidates: []),
+    ])
+
+    let stateA = try #require(
+      try await setup.backend.walletSyncState.load(accountId: accountA.id))
+    #expect(stateA.lastSyncedBlockNumber == 100)
+    #expect(stateA.lastSyncedAt == Self.pinnedNow)
+    #expect(stateA.lastError == nil)
+
+    let stateB = try #require(
+      try await setup.backend.walletSyncState.load(accountId: accountB.id))
+    #expect(stateB.lastSyncedBlockNumber == 250)
+    #expect(stateB.lastSyncedAt == Self.pinnedNow)
+  }
+
+  // MARK: - Import rules
+
+  @Test("WalletImportRulesEngine is invoked exactly once with the persisted transactions")
+  func importRulesInvoked() async throws {
+    let recordingRules = RecordingWalletImportRulesEngine()
+    let setup = try makeSetup(importRules: recordingRules)
+    let accountA = try setup.seedCryptoAccount()
+    let candidate = makeBuilt(
+      accountId: accountA.id, hash: "0xrule", quantity: 1)
+
+    let persisted = try await setup.engine.apply(perAccount: [
+      .init(account: accountA, headBlockNumber: 1, candidates: [candidate])
+    ])
+
+    #expect(persisted.count == 1)
+    let calls = await recordingRules.calls
+    #expect(calls.count == 1)
+    #expect(calls[0].count == 1)
+  }
+
+  // MARK: - Empty-candidate accounts
+
+  @Test("Account with no candidates still updates WalletSyncState; other accounts persist")
+  func emptyCandidateAccountIsolated() async throws {
+    let setup = try makeSetup()
+    let failedAccount = try setup.seedCryptoAccount()
+    let workingAccount = try setup.seedCryptoAccount()
+    let candidate = makeBuilt(
+      accountId: workingAccount.id, hash: "0xworks", quantity: 1)
+
+    let persisted = try await setup.engine.apply(perAccount: [
+      .init(account: failedAccount, headBlockNumber: 0, candidates: []),
+      .init(account: workingAccount, headBlockNumber: 75, candidates: [candidate]),
+    ])
+
+    #expect(persisted.count == 1)
+    // `failedAccount` participated even though it produced nothing.
+    let failedState = try #require(
+      try await setup.backend.walletSyncState.load(accountId: failedAccount.id))
+    #expect(failedState.lastSyncedBlockNumber == 0)
+    let workingState = try #require(
+      try await setup.backend.walletSyncState.load(accountId: workingAccount.id))
+    #expect(workingState.lastSyncedBlockNumber == 75)
+  }
+
+  // MARK: - Helpers
+
+  private struct Setup {
+    let backend: CloudKitBackend
+    let database: DatabaseQueue
+    let engine: WalletApplyEngine
+
+    func seedCryptoAccount(
+      walletAddress: String = "0x" + String(UUID().uuidString.prefix(40))
+    ) throws -> Account {
+      let account = Account(
+        name: "Wallet \(walletAddress.suffix(4))",
+        type: .crypto,
+        instrument: ChainConfig.ethereum.nativeInstrument,
+        walletAddress: walletAddress.lowercased(),
+        chainId: ChainConfig.ethereum.chainId)
+      _ = TestBackend.seed(accounts: [account], in: database)
+      return account
+    }
+  }
+
+  private func makeSetup(
+    importRules: any WalletImportRulesEngine = NoOpWalletImportRulesEngine()
+  ) throws -> Setup {
+    let (backend, database) = try TestBackend.create()
+    let engine = WalletApplyEngine(
+      transactions: backend.transactions,
+      walletSyncState: backend.walletSyncState,
+      importRules: importRules,
+      clock: { Self.pinnedNow })
+    return Setup(backend: backend, database: database, engine: engine)
+  }
+
+  private func makeBuilt(
+    accountId: UUID,
+    hash: String,
+    quantity: Decimal
+  ) -> BuiltTransaction {
+    let leg = TransactionLeg(
+      accountId: accountId,
+      instrument: ChainConfig.ethereum.nativeInstrument,
+      quantity: quantity,
+      externalId: hash,
+      type: .transfer)
+    let transaction = Transaction(
+      date: Self.pinnedNow,
+      legs: [leg],
+      importOrigin: ImportOrigin(
+        rawDescription: "wallet:\(accountId.uuidString)",
+        rawAmount: 0,
+        importedAt: Self.pinnedNow,
+        importSessionId: UUID(),
+        parserIdentifier: "alchemy-wallet-sync"))
+    return BuiltTransaction(originAccountId: accountId, transaction: transaction)
+  }
+}
+
+/// Recording stub for `WalletImportRulesEngine`. Captures every `apply`
+/// call so tests can assert on call count and the transactions passed.
+///
+/// `actor` so the recorded calls can be observed from `@MainActor` tests
+/// without tripping Sendable diagnostics.
+actor RecordingWalletImportRulesEngine: WalletImportRulesEngine {
+  private(set) var calls: [[Transaction]] = []
+
+  func apply(transactions: [Transaction]) async throws -> [Transaction] {
+    calls.append(transactions)
+    return transactions
+  }
+}

--- a/MoolahTests/Support/CancellablePagingTransactionRepository.swift
+++ b/MoolahTests/Support/CancellablePagingTransactionRepository.swift
@@ -60,6 +60,8 @@ actor CancellablePagingTransactionRepository: TransactionRepository {
   func fetchPayeeSuggestions(
     prefix: String, excludingTransactionId: UUID?
   ) async throws -> [String] { [] }
+  func legs(matchingExternalId externalId: String) async throws -> [TransactionLeg] { [] }
+  func legExists(accountId: UUID, externalId: String) async throws -> Bool { false }
 }
 
 /// A simple one-shot gate that suspends waiters until `open()` is called.

--- a/MoolahTests/Support/TransactionStoreTestSupport.swift
+++ b/MoolahTests/Support/TransactionStoreTestSupport.swift
@@ -130,4 +130,12 @@ struct FailingTransactionRepository: TransactionRepository {
   ) async throws -> [String] {
     throw BackendError.networkUnavailable
   }
+
+  func legs(matchingExternalId externalId: String) async throws -> [TransactionLeg] {
+    throw BackendError.networkUnavailable
+  }
+
+  func legExists(accountId: UUID, externalId: String) async throws -> Bool {
+    throw BackendError.networkUnavailable
+  }
 }

--- a/Shared/CryptoImport/CrossAccountTransferMerger.swift
+++ b/Shared/CryptoImport/CrossAccountTransferMerger.swift
@@ -1,0 +1,254 @@
+// Shared/CryptoImport/CrossAccountTransferMerger.swift
+import Foundation
+
+/// Cross-account merge stage. Pairs `BuiltTransaction`s sharing a non-nil
+/// `externalId` on opposing-sign value-bearing legs of the same instrument
+/// across different accounts. Stage 7's apply pass calls this **once**
+/// after Stage 6's parallel build TaskGroup has fully completed — no
+/// concurrent path can produce duplicate merged transactions.
+///
+/// Pure / `Sendable` — no repository writes; no shared state. The single
+/// source of truth for the same-`externalId` channel from
+/// `plans/2026-04-18-transfer-detection-design.md` (Extension B): when
+/// the transfer-detection engine eventually runs, it shares this same
+/// merger rather than reimplementing the predicate.
+struct CrossAccountTransferMerger: Sendable {
+
+  /// Returns the input set with same-`externalId` opposing-leg pairs
+  /// collapsed into single multi-leg transactions whose legs union both
+  /// sides. Gas / fee legs preserved on the merged transaction. Pairs
+  /// that don't satisfy the predicate are returned unchanged.
+  ///
+  /// - Parameters:
+  ///   - candidates: candidates from Stage 6's per-account build phase,
+  ///     possibly across multiple accounts in this sync cycle.
+  ///   - existingLegLookup: caller-supplied async lookup so the merger
+  ///     can also pair against legs already persisted on prior cycles.
+  ///     The lookup key is the leg's `externalId`. Callers in production
+  ///     route this through `TransactionRepository.legs(matchingExternalId:)`.
+  func merge(
+    candidates: [BuiltTransaction],
+    existingLegLookup: @Sendable (_ externalId: String) async throws -> [TransactionLeg]
+  ) async throws -> [BuiltTransaction] {
+    // Walk candidates in order; for each, decide whether it can be paired
+    // with a later candidate (in-batch pair) or with an existing
+    // persisted leg (prior-cycle pair). The single-pass walk keeps the
+    // merger deterministic regardless of input ordering — ties on
+    // multiple opposing candidates always pick the lower-UUID leg by
+    // sorting candidate indices ascending and existing legs by
+    // `(accountId, externalId)` lex order.
+    var consumed: Set<Int> = []
+    var output: [BuiltTransaction] = []
+    output.reserveCapacity(candidates.count)
+
+    for (index, candidate) in candidates.enumerated() {
+      if consumed.contains(index) { continue }
+
+      guard let valueLeg = Self.valueBearingTransferLeg(of: candidate) else {
+        output.append(candidate)
+        continue
+      }
+      guard let externalId = valueLeg.externalId else {
+        output.append(candidate)
+        continue
+      }
+
+      if let mateIndex = Self.findInBatchMate(
+        startingAfter: index,
+        in: candidates,
+        consumed: consumed,
+        valueLeg: valueLeg)
+      {
+        consumed.insert(index)
+        consumed.insert(mateIndex)
+        output.append(Self.merge(candidate, candidates[mateIndex]))
+        continue
+      }
+
+      let existingLegs = try await existingLegLookup(externalId)
+      if let mate = Self.findExistingMate(legs: existingLegs, valueLeg: valueLeg) {
+        consumed.insert(index)
+        output.append(Self.merge(candidate, withExistingPersistedLeg: mate))
+        continue
+      }
+
+      output.append(candidate)
+    }
+    return output
+  }
+
+  // MARK: - Pairing predicate
+
+  /// Both legs are `.transfer`, share an `externalId`, share an
+  /// instrument, sit on different accounts, and carry equal-magnitude
+  /// opposite-sign quantities. Strict equality on magnitude — if a real
+  /// decimal-precision-drift case arises a small epsilon could be added,
+  /// but ETH / ERC-20 amounts are exact decimals reconstructed from the
+  /// same hex value on each side, so drift is not expected.
+  ///
+  /// Magnitude comparison uses `abs` only on the *comparison* of
+  /// quantities; the original signs are preserved on the merged legs.
+  /// Per-project convention `.trade` legs preserve user-entered signs;
+  /// here we're working with `.transfer` legs and the rule is the same —
+  /// don't normalise.
+  static func isPair(_ leg: TransactionLeg, _ other: TransactionLeg) -> Bool {
+    guard leg.type == .transfer, other.type == .transfer else { return false }
+    guard let legId = leg.externalId, let otherId = other.externalId else { return false }
+    guard legId == otherId else { return false }
+    guard leg.instrument == other.instrument else { return false }
+    guard let legAcct = leg.accountId, let otherAcct = other.accountId else { return false }
+    guard legAcct != otherAcct else { return false }
+    let legSign = Self.signValue(of: leg.quantity)
+    let otherSign = Self.signValue(of: other.quantity)
+    guard legSign != 0, otherSign != 0, legSign != otherSign else { return false }
+    return abs(leg.quantity) == abs(other.quantity)
+  }
+
+  // MARK: - Search
+
+  private static func findInBatchMate(
+    startingAfter index: Int,
+    in candidates: [BuiltTransaction],
+    consumed: Set<Int>,
+    valueLeg: TransactionLeg
+  ) -> Int? {
+    var search = index + 1
+    while search < candidates.count {
+      defer { search += 1 }
+      if consumed.contains(search) { continue }
+      guard let otherValue = valueBearingTransferLeg(of: candidates[search]) else { continue }
+      if isPair(valueLeg, otherValue) { return search }
+    }
+    return nil
+  }
+
+  private static func findExistingMate(
+    legs: [TransactionLeg],
+    valueLeg: TransactionLeg
+  ) -> TransactionLeg? {
+    // Deterministic tiebreak when more than one matching leg exists:
+    // lowest accountId UUID lex order. The merge result therefore
+    // converges across replays of the same input.
+    legs
+      .filter { isPair(valueLeg, $0) }
+      .min { ($0.accountId?.uuidString ?? "") < ($1.accountId?.uuidString ?? "") }
+  }
+
+  // MARK: - Merge construction
+
+  /// Merges two `BuiltTransaction`s known to share an `externalId` on
+  /// opposing-sign value-bearing legs.
+  private static func merge(
+    _ first: BuiltTransaction, _ second: BuiltTransaction
+  ) -> BuiltTransaction {
+    let lower: BuiltTransaction
+    let upper: BuiltTransaction
+    if first.originAccountId.uuidString <= second.originAccountId.uuidString {
+      lower = first
+      upper = second
+    } else {
+      lower = second
+      upper = first
+    }
+
+    // Date: earliest of the two — canonical convention for cross-account
+    // transfers (matches Extension B / the existing transfer-detection
+    // design's merge rule).
+    let date = min(first.transaction.date, second.transaction.date)
+    let legs = lower.transaction.legs + upper.transaction.legs
+    let importOrigin = mergedImportOrigin(
+      lower: lower.transaction.importOrigin,
+      upper: upper.transaction.importOrigin)
+
+    let merged = Transaction(
+      id: lower.transaction.id,
+      date: date,
+      payee: lower.transaction.payee ?? upper.transaction.payee,
+      notes: mergedNotes(lower.transaction.notes, upper.transaction.notes),
+      legs: legs,
+      importOrigin: importOrigin)
+    return BuiltTransaction(
+      originAccountId: lower.originAccountId,
+      transaction: merged)
+  }
+
+  /// Variant of `merge` used when the in-batch candidate pairs against
+  /// an already-persisted leg from a prior cycle. The merged
+  /// `BuiltTransaction` keeps the in-batch candidate's transaction id
+  /// and origin; Stage 7's apply pass will resolve the duplicate
+  /// against the existing transaction during the per-leg dedup step
+  /// (the existing leg is already persisted, so dedup will drop it from
+  /// the new transaction's legs and the surviving rows are the existing
+  /// transaction plus the new candidate's own legs).
+  ///
+  /// Why surface a merged shape at all if dedup will collapse it again?
+  /// Because the *transfer-detection engine* (Extension B) consumes the
+  /// same merger output to suppress its suggestion pass — it sees one
+  /// merged transaction rather than two unrelated single-leg events,
+  /// and that suppression is the point of the same-`externalId`
+  /// channel.
+  private static func merge(
+    _ candidate: BuiltTransaction,
+    withExistingPersistedLeg leg: TransactionLeg
+  ) -> BuiltTransaction {
+    let date = candidate.transaction.date
+    let legs = candidate.transaction.legs + [leg]
+    let merged = Transaction(
+      id: candidate.transaction.id,
+      date: date,
+      payee: candidate.transaction.payee,
+      notes: candidate.transaction.notes,
+      legs: legs,
+      importOrigin: candidate.transaction.importOrigin)
+    return BuiltTransaction(
+      originAccountId: candidate.originAccountId,
+      transaction: merged)
+  }
+
+  private static func mergedImportOrigin(
+    lower: ImportOrigin?,
+    upper: ImportOrigin?
+  ) -> ImportOrigin? {
+    // Prefer the lower-UUID side's ImportOrigin so the merge is
+    // deterministic across replays. v1 of the crypto importer doesn't
+    // require a `MergedImportOrigin` wrapper — `Transaction.importOrigin`
+    // is still a single value — so the upper side's origin is dropped
+    // here. Once the transfer-detection design's `MergedImportOrigin`
+    // landing covers crypto (issue #762 cluster), this can be revisited.
+    lower ?? upper
+  }
+
+  private static func mergedNotes(_ first: String?, _ second: String?) -> String? {
+    switch (first, second) {
+    case (nil, nil): return nil
+    case let (firstNotes?, nil): return firstNotes
+    case let (nil, secondNotes?): return secondNotes
+    case let (firstNotes?, secondNotes?):
+      if firstNotes == secondNotes { return firstNotes }
+      return "\(firstNotes)\n\(secondNotes)"
+    }
+  }
+
+  // MARK: - Helpers
+
+  /// The single value-bearing transfer leg, when this candidate is
+  /// shaped for cross-account pairing — exactly one `.transfer` leg
+  /// whose `externalId` keys the on-chain hash. Returns `nil` for
+  /// trades or already-merged multi-transfer-leg transactions; the
+  /// merger leaves those untouched.
+  private static func valueBearingTransferLeg(
+    of candidate: BuiltTransaction
+  ) -> TransactionLeg? {
+    let transferLegs = candidate.transaction.legs.filter { $0.type == .transfer }
+    return transferLegs.count == 1 ? transferLegs.first : nil
+  }
+
+  /// `1` for positive, `-1` for negative, `0` for zero. Local helper so
+  /// the call sites read clearly without scattering `Decimal(0)`
+  /// comparisons.
+  private static func signValue(of decimal: Decimal) -> Int {
+    if decimal > 0 { return 1 }
+    if decimal < 0 { return -1 }
+    return 0
+  }
+}

--- a/Shared/CryptoImport/WalletApplyEngine.swift
+++ b/Shared/CryptoImport/WalletApplyEngine.swift
@@ -1,0 +1,164 @@
+// Shared/CryptoImport/WalletApplyEngine.swift
+import Foundation
+
+/// Sequential `@MainActor` apply pass for the crypto-wallet importer.
+/// Runs after Stage 6's parallel build phase. Owns: cross-account
+/// merge, per-leg dedup, persistence, import rules, and per-account
+/// `WalletSyncState` updates.
+///
+/// Per design (`plans/2026-05-05-crypto-wallet-import-design.md`
+/// §"Sync engine"): merge → dedup → persist → rules → sync-state
+/// update. This is the single writer in the build → apply pipeline;
+/// every other type produces value-shaped data only.
+///
+/// Construction is `Sendable` despite `@MainActor` because every stored
+/// property is itself a `Sendable` reference.
+@MainActor
+final class WalletApplyEngine {
+
+  /// Per-account input to the apply pass. Stage 9's `CryptoSyncStore`
+  /// builds one entry per account that completed Stage 6 successfully;
+  /// failed accounts produce no entry and have their `lastError` set
+  /// elsewhere.
+  struct AccountInput: Sendable {
+    let account: Account
+    let headBlockNumber: UInt64
+    let candidates: [BuiltTransaction]
+  }
+
+  private let transactions: any TransactionRepository
+  private let walletSyncState: any WalletSyncStateRepository
+  private let importRules: any WalletImportRulesEngine
+  private let merger: CrossAccountTransferMerger
+  private let clock: @Sendable () -> Date
+
+  init(
+    transactions: any TransactionRepository,
+    walletSyncState: any WalletSyncStateRepository,
+    importRules: any WalletImportRulesEngine,
+    merger: CrossAccountTransferMerger = CrossAccountTransferMerger(),
+    clock: @Sendable @escaping () -> Date = { Date() }
+  ) {
+    self.transactions = transactions
+    self.walletSyncState = walletSyncState
+    self.importRules = importRules
+    self.merger = merger
+    self.clock = clock
+  }
+
+  /// Applies the build-phase output for a single sync cycle.
+  ///
+  /// Steps:
+  /// 1. Cross-account merge — pair same-`externalId` opposing legs.
+  /// 2. Per-leg dedup against persisted legs (drops legs already in the
+  ///    repository; whole transactions drop when every leg is dropped).
+  /// 3. Persist remaining transactions through `TransactionRepository`.
+  /// 4. Run `WalletImportRulesEngine` over the persisted set.
+  /// 5. Update `WalletSyncState` for every account that participated.
+  ///
+  /// Returns the transactions actually persisted (the merged-and-deduped
+  /// survivors). Failed accounts that arrived with empty `candidates`
+  /// still get their `WalletSyncState` updated so the next cycle's
+  /// `fromBlock` advances.
+  ///
+  /// Throws on repository failure during merge / dedup / persist /
+  /// sync-state. Stage 9's orchestrator owns per-account error
+  /// containment; this method either succeeds or throws as a unit.
+  func apply(perAccount: [AccountInput]) async throws -> [Transaction] {
+    let allCandidates = perAccount.flatMap { $0.candidates }
+    let lookup = makeExistingLegLookup()
+    let merged = try await merger.merge(
+      candidates: allCandidates, existingLegLookup: lookup)
+    let deduped = try await dedup(merged)
+    let persisted = try await persist(deduped)
+    let ruled = try await importRules.apply(transactions: persisted)
+    try await updateSyncState(for: perAccount)
+    return ruled
+  }
+
+  // MARK: - Pipeline steps
+
+  /// Captures the repository in a `@Sendable` closure so the merger can
+  /// look up prior-cycle legs by `externalId`. Extracted so the closure
+  /// body is short enough that swift-format keeps it on one line —
+  /// inline closure syntax with a multi-line body conflicts with
+  /// SwiftLint's `closure_parameter_position` rule.
+  private func makeExistingLegLookup()
+    -> @Sendable (String) async throws -> [TransactionLeg]
+  {
+    let transactions = self.transactions
+    return { externalId in
+      try await transactions.legs(matchingExternalId: externalId)
+    }
+  }
+
+  /// Drops legs that already exist in the repository (matched by
+  /// `(accountId, externalId)`). When every leg of a transaction is
+  /// dropped the whole transaction is skipped.
+  private func dedup(_ candidates: [BuiltTransaction]) async throws -> [BuiltTransaction] {
+    var output: [BuiltTransaction] = []
+    output.reserveCapacity(candidates.count)
+    for candidate in candidates {
+      let surviving = try await survivingLegs(for: candidate)
+      guard !surviving.isEmpty else { continue }
+      let pruned = Transaction(
+        id: candidate.transaction.id,
+        date: candidate.transaction.date,
+        payee: candidate.transaction.payee,
+        notes: candidate.transaction.notes,
+        recurPeriod: candidate.transaction.recurPeriod,
+        recurEvery: candidate.transaction.recurEvery,
+        legs: surviving,
+        importOrigin: candidate.transaction.importOrigin)
+      output.append(
+        BuiltTransaction(
+          originAccountId: candidate.originAccountId,
+          transaction: pruned))
+    }
+    return output
+  }
+
+  private func survivingLegs(
+    for candidate: BuiltTransaction
+  ) async throws -> [TransactionLeg] {
+    var legs: [TransactionLeg] = []
+    legs.reserveCapacity(candidate.transaction.legs.count)
+    for leg in candidate.transaction.legs {
+      guard
+        let externalId = leg.externalId,
+        let accountId = leg.accountId
+      else {
+        legs.append(leg)
+        continue
+      }
+      let exists = try await transactions.legExists(
+        accountId: accountId, externalId: externalId)
+      if !exists {
+        legs.append(leg)
+      }
+    }
+    return legs
+  }
+
+  private func persist(_ candidates: [BuiltTransaction]) async throws -> [Transaction] {
+    var persisted: [Transaction] = []
+    persisted.reserveCapacity(candidates.count)
+    for candidate in candidates {
+      let saved = try await transactions.create(candidate.transaction)
+      persisted.append(saved)
+    }
+    return persisted
+  }
+
+  private func updateSyncState(for perAccount: [AccountInput]) async throws {
+    let now = clock()
+    for input in perAccount {
+      let state = WalletSyncState(
+        id: input.account.id,
+        lastSyncedBlockNumber: input.headBlockNumber,
+        lastSyncedAt: now,
+        lastError: nil)
+      try await walletSyncState.save(state)
+    }
+  }
+}

--- a/Shared/CryptoImport/WalletImportRulesEngine.swift
+++ b/Shared/CryptoImport/WalletImportRulesEngine.swift
@@ -1,0 +1,30 @@
+// Shared/CryptoImport/WalletImportRulesEngine.swift
+import Foundation
+
+/// Rules pass over a batch of fully-built crypto-imported transactions.
+/// Distinct from the CSV `ImportRulesEngine` (which evaluates rules
+/// against `ParsedTransaction` raw fields pre-build) — wallet-imported
+/// transactions arrive at the apply engine already structured, with
+/// resolved instruments and on-chain `externalId`s on every leg, so the
+/// rules pass operates on `Transaction` directly.
+///
+/// `Sendable` so it can be supplied to the `@MainActor`
+/// `WalletApplyEngine` from a non-isolated factory.
+///
+/// v1 of the apply pass ships with a no-op implementation; richer
+/// rules — payee normalisation, category assignment from token / address
+/// patterns — land in a follow-up alongside the wallet import-rules UI.
+protocol WalletImportRulesEngine: Sendable {
+  /// Returns the input transactions, possibly modified by rule actions
+  /// (assigned payee, category, notes). The default implementation
+  /// returns the input unchanged so apply-pipeline tests don't need to
+  /// stub a no-op explicitly.
+  func apply(transactions: [Transaction]) async throws -> [Transaction]
+}
+
+/// No-op implementation. Returns the input unchanged.
+struct NoOpWalletImportRulesEngine: WalletImportRulesEngine {
+  func apply(transactions: [Transaction]) async throws -> [Transaction] {
+    transactions
+  }
+}

--- a/plans/2026-04-18-transfer-detection-design.md
+++ b/plans/2026-04-18-transfer-detection-design.md
@@ -1,6 +1,6 @@
 # Transfer Detection & Merge — Design Spec
 
-**Status:** Draft · 2026-04-18
+**Status:** Implemented (eligibility predicate + same-`externalId` channel ship alongside `plans/2026-05-05-crypto-wallet-import-plan.md` Stage 7) · 2026-05-05
 **Depends on:** `plans/2026-04-18-csv-import-design.md` (CSV import pipeline, `ImportOrigin` on each transaction).
 
 ---
@@ -208,3 +208,41 @@ Fixture files live alongside the CSV import fixtures; the tests use paired CSVs 
 1. **Currency mismatch handling.** If the user has accounts in different currencies, the transfer still happens (convert-on-debit) but the amounts aren't numerically opposite. v1 explicitly skips currency-mismatched pairs. A future v2 could attempt to pair using FX-rate heuristics, but it's noisy — easy to skip in v1 and revisit if users ask.
 2. **Detection window beyond ±3 days.** Some pending transfers (Friday outgoing, Tuesday incoming because of weekends + public holiday) might exceed ±3 days. If this comes up, we widen; v1 errs tight because false positives annoy more than false negatives.
 3. **UI for bulk dismissal.** If a user has lots of suggestions from a large migration, we may want a "Dismiss all in this session" affordance. Punt until data shows it matters.
+
+---
+
+## Extensions A & B (added 2026-05-05 alongside crypto wallet import)
+
+The original draft constrained pairing candidates to single-leg transactions. A wallet-side multi-leg event (transfer leg + gas/fee leg) would have been excluded, and on-chain transactions arriving via two tracked accounts would have produced a suggestion rather than auto-merging. Two extensions, both required by the crypto importer in `plans/2026-05-05-crypto-wallet-import-design.md` Stage 7, are added here as normative additions to the design.
+
+### Extension A — eligibility predicate
+
+> A transaction is *transfer-detection-eligible* iff it has exactly one leg of type `.transfer` (the **value-bearing leg**) **or** exactly one leg of type `.income`/`.expense` (legacy single-leg cash). Any number of additional `.expense` legs in a different instrument from the value-bearing leg are permitted (these are fees: gas, broker fees, …).
+
+This preserves the existing intent (exclude trades — they have two `.trade` legs and don't meet the new criterion either) while enabling on-chain transfers with gas, and brokerage cash transactions that happen to carry an attached fee leg, to participate. Detection's amount/instrument matching always operates on the **value-bearing leg**.
+
+The predicate is implemented as `Transaction.isTransferDetectionEligible: Bool` (exposed via `Transaction.transferDetectionValueLeg: TransactionLeg?` for callers that need the leg). Algorithm replaces the `tx.legs.count == 1` check in §Algorithm above; everything else (instrument match, sign match, ±3-day window, dismissal-aware skip) operates on the value-bearing leg.
+
+### Extension B — deterministic same-`externalId` channel
+
+> Before the standard amount/instrument/date suggestion pass runs, the importer (CSV or crypto) checks for cross-account legs with matching `externalId`. When two transfer-detection-eligible transactions on different tracked accounts have value-bearing legs with the same non-nil `externalId`, the same instrument, and opposite-sign quantities, they are merged immediately into a single multi-leg transfer transaction with **no suggestion** and no inbox row. Each side's fee legs (gas) are preserved on the merged transaction.
+
+A merged on-chain transfer therefore has shape `[transfer leg from A, transfer leg from B, optional gas leg from A, optional gas leg from B]` — the existing multi-leg storage handles this directly.
+
+The standard suggestion flow continues to handle fuzzy matches (CSV from an exchange ↔ on-chain wallet, where the on-chain hash isn't on both sides). Shared `externalId` is a strict superset of the existing pairing — there's no false-positive channel to add.
+
+**Single source of truth.** Extension B is implemented as `CrossAccountTransferMerger` (`Shared/CryptoImport/CrossAccountTransferMerger.swift`). Both the wallet importer's apply pass and the future transfer-detection engine call this same merger; neither reimplements the predicate. The merger:
+
+- Pairs candidates by `externalId == otherLeg.externalId`, `instrument == otherLeg.instrument`, `accountId != otherLeg.accountId`, opposite-sign quantities of equal magnitude.
+- Resolves cross-cycle pairs via an injected `existingLegLookup`: an in-batch candidate can pair against a leg already persisted on a prior cycle, on a different account.
+- Picks the lower-UUID side as `originAccountId` on the merged result and the earliest of the two source dates — both deterministic.
+- Preserves fee legs from both sides (the merge unions, not replaces).
+- Is pure / `Sendable` — no repository writes; the apply engine is the single writer.
+
+**Unmerge / dismissed-pair semantics** carry over from the body of this design unchanged — Extension B is an auto-merge channel, but the resulting transfer is unmergeable like any other transfer transaction.
+
+### Acceptance
+
+These extensions are normative. The transfer-detection engine, when it lands, must:
+- Use `Transaction.isTransferDetectionEligible` (Extension A) as the candidate filter, replacing the `legs.count == 1` check in §Algorithm.
+- Call `CrossAccountTransferMerger` (Extension B) before its amount/instrument/date suggestion pass and skip any pair the merger has already collapsed.


### PR DESCRIPTION
## Summary

Stage 7 of [`plans/2026-05-05-crypto-wallet-import-plan.md`](https://github.com/ajsutton/moolah-native/blob/main/plans/2026-05-05-crypto-wallet-import-plan.md). Lands:

- **`CrossAccountTransferMerger`** — pure `Sendable` struct that pairs `BuiltTransaction`s sharing a non-nil `externalId` on opposing-sign value-bearing legs across different accounts. Single source of truth for the same-`externalId` channel that both the wallet apply pass and the future transfer-detection engine call into.
- **`WalletApplyEngine`** — sequential `@MainActor` apply pass that runs after Stage 6's parallel build phase: merge → dedup → persist → rules → sync-state update. The single writer in the pipeline.
- **`TransactionRepository.legs(matchingExternalId:)` + `legExists(accountId:externalId:)`** — per-leg dedup primitives backed by the partial unique index from Stage 1.
- **`Transaction.isTransferDetectionEligible`** — Extension A predicate for multi-leg transactions (one transfer / cash leg + cross-instrument fee legs).
- **Transfer-detection design updated** with Extensions A and B inline; `Status:` flipped off Draft.

The merger and engine intersect through `CrossAccountTransferMerger`: the apply engine calls it once per cycle to collapse same-hash opposing pairs, and the (future) transfer-detection engine will share the same merger to suppress its suggestion pass for the same hashes — so the two pipelines never disagree on whether a pair is a transfer.

## Test plan

- [x] `just format-check` clean.
- [x] `just test` passes (2 288 tests across iOS + macOS).
- [x] 20 new tests covering: same-hash opposing pair → merge; same-sign / different-instrument / same-account → not merged; gas legs preserved; existing-leg lookup; lower-UUID determinism; per-leg dedup; sync-state update with pinned clock; rules engine invocation; empty-candidate-account isolation; Extension A eligibility shapes (eligible: single transfer / single cash / transfer + cross-instrument fee; ineligible: trade / two-transfer / same-instrument extra leg / opening balance).
- [x] Zero compiler warnings introduced.
- [x] No SwiftLint baseline edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)