### PR TITLE
fix: deferred review findings from valuation-mode rollout (#739)

### DIFF
--- a/App/ProfileSession+Imports.swift
+++ b/App/ProfileSession+Imports.swift
@@ -85,6 +85,11 @@ extension ProfileSession {
   /// directory in the tmp dir (which cannot fail in practice on Apple
   /// platforms) if the real directory can't be opened, so the pipeline
   /// remains functional in the degraded mode.
+  ///
+  /// The tmp-dir fallback is itself fallible; if it raises (unwritable system
+  /// tmp directory or sandbox denial that also denies the fallback), the
+  /// failure is logged at fault level and the app crashes — there is no
+  /// further degradation path that keeps the user's data safe.
   static func makeImportStore(
     backend: BackendProvider,
     stagingDirectory: URL,
@@ -97,14 +102,17 @@ extension ProfileSession {
     } catch {
       let fallback = FileManager.default.temporaryDirectory
         .appendingPathComponent("csv-staging-fallback-\(profileId.uuidString)")
-      // Fallback in a tmp dir cannot fail in practice on Apple platforms.
-      // swiftlint:disable:next force_try
-      let staging = try! ImportStagingStore(directory: fallback)
-      let errDesc = error.localizedDescription
       let stagingPath = stagingDirectory.path
       logger.error(
-        "Failed to open CSV import staging at \(stagingPath, privacy: .public): \(errDesc, privacy: .public). Falling back to tmp."
+        "Failed to open CSV import staging at \(stagingPath, privacy: .public): \(error.localizedDescription, privacy: .public). Falling back to tmp."
       )
+      guard let staging = try? ImportStagingStore(directory: fallback) else {
+        logger.fault(
+          "Failed to open CSV import staging fallback at \(fallback.path, privacy: .public). Profile \(profileId, privacy: .public)."
+        )
+        fatalError(
+          "ImportStagingStore failed to open at both primary and tmp fallback paths.")
+      }
       return ImportStore(backend: backend, staging: staging)
     }
   }

--- a/App/SessionManager.swift
+++ b/App/SessionManager.swift
@@ -1,4 +1,5 @@
 import Foundation
+import OSLog
 import SwiftData
 
 /// Owns the mapping from Profile.ID to ProfileSession.
@@ -7,6 +8,9 @@ import SwiftData
 @Observable
 @MainActor
 final class SessionManager {
+  private static let logger = Logger(
+    subsystem: "com.moolah.app", category: "SessionManager")
+
   /// Map from `Profile.ID` to the live `ProfileSession`.
   ///
   /// **Mutation invariant:** any code path that drops or replaces a
@@ -50,7 +54,18 @@ final class SessionManager {
       fatalError("Failed to open profile database for \(profile.id): \(error)")
     }
     sessions[profile.id] = session
-    Task { try? await session.setUp() }
+    Task { [profileId = profile.id] in
+      do {
+        try await session.setUp()
+      } catch is CancellationError {
+        // Expected when `cleanupSync` cancels `setUpTask` during session
+        // teardown — not a failure.
+      } catch {
+        Self.logger.fault(
+          "ProfileSession.setUp() failed for \(profileId, privacy: .public): \(error.localizedDescription, privacy: .public)"
+        )
+      }
+    }
     return session
   }
 
@@ -95,6 +110,17 @@ final class SessionManager {
       fatalError("Failed to rebuild profile database for \(profile.id): \(error)")
     }
     sessions[profile.id] = session
-    Task { try? await session.setUp() }
+    Task { [profileId = profile.id] in
+      do {
+        try await session.setUp()
+      } catch is CancellationError {
+        // Expected when `cleanupSync` cancels `setUpTask` during session
+        // teardown — not a failure.
+      } catch {
+        Self.logger.fault(
+          "ProfileSession.setUp() failed for \(profileId, privacy: .public): \(error.localizedDescription, privacy: .public)"
+        )
+      }
+    }
   }
 }

--- a/Domain/Models/Account.swift
+++ b/Domain/Models/Account.swift
@@ -29,7 +29,7 @@ enum AccountType: String, Codable, Sendable, CaseIterable {
   }
 }
 
-struct Account: Codable, Sendable, Identifiable, Hashable, Comparable {
+struct Account {
   let id: UUID
   var name: String
   var type: AccountType
@@ -67,7 +67,13 @@ struct Account: Codable, Sendable, Identifiable, Hashable, Comparable {
     self.walletAddress = walletAddress
     self.chainId = chainId
   }
+}
 
+extension Account: Sendable {}
+
+extension Account: Identifiable {}
+
+extension Account: Codable {
   private enum CodingKeys: String, CodingKey {
     case id
     case name
@@ -116,7 +122,9 @@ struct Account: Codable, Sendable, Identifiable, Hashable, Comparable {
     try container.encodeIfPresent(walletAddress, forKey: .walletAddress)
     try container.encodeIfPresent(chainId, forKey: .chainId)
   }
+}
 
+extension Account: Hashable {
   static func == (lhs: Account, rhs: Account) -> Bool {
     lhs.id == rhs.id && lhs.name == rhs.name && lhs.type == rhs.type
       && lhs.instrument == rhs.instrument
@@ -136,7 +144,9 @@ struct Account: Codable, Sendable, Identifiable, Hashable, Comparable {
     hasher.combine(walletAddress)
     hasher.combine(chainId)
   }
+}
 
+extension Account: Comparable {
   static func < (lhs: Account, rhs: Account) -> Bool {
     lhs.position < rhs.position
   }

--- a/Features/Accounts/AccountStore+ConvertedTotals.swift
+++ b/Features/Accounts/AccountStore+ConvertedTotals.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+// On-demand total computations. Hoisted out of `AccountStore.swift` so
+// that file stays under `file_length` / `type_body_length`. These are
+// pure pass-throughs to the calculator and need no privileged access to
+// the store's `private(set)` setters.
+extension AccountStore {
+  /// Total value of `accountList` in `target`, summing positions directly.
+  func computeConvertedTotal(for accountList: [Account], in target: Instrument) async throws
+    -> InstrumentAmount
+  {
+    try await balanceCalculator.totalConverted(for: accountList, to: target)
+  }
+
+  /// Total value of current accounts in `target`.
+  func computeConvertedCurrentTotal(in target: Instrument) async throws -> InstrumentAmount {
+    try await balanceCalculator.totalConverted(for: currentAccounts, to: target)
+  }
+
+  /// Total value of investment accounts in `target`. Uses cached external
+  /// values when present; otherwise sums positions. Single-pass to avoid
+  /// the double-conversion a two-phase approach would chain.
+  func computeConvertedInvestmentTotal(in target: Instrument) async throws -> InstrumentAmount {
+    try await balanceCalculator.totalConverted(
+      for: investmentAccounts, to: target, using: investmentValueCache)
+  }
+
+  /// Net worth (current + investment) in `target`.
+  func computeConvertedNetWorth(in target: Instrument) async throws -> InstrumentAmount {
+    let current = try await computeConvertedCurrentTotal(in: target)
+    let investment = try await computeConvertedInvestmentTotal(in: target)
+    return current + investment
+  }
+}

--- a/Features/Accounts/AccountStore.swift
+++ b/Features/Accounts/AccountStore.swift
@@ -32,8 +32,14 @@ final class AccountStore {
   private let repository: AccountRepository
   private let conversionService: any InstrumentConversionService
   private let targetInstrument: Instrument
-  private let investmentValueCache: InvestmentValueCache
-  private let balanceCalculator: AccountBalanceCalculator
+  /// Read-through cache of externally-set investment values. `internal`
+  /// (rather than `private`) so the `+ConvertedTotals.swift` extension
+  /// file can pass it to the balance calculator without a wrapper.
+  let investmentValueCache: InvestmentValueCache
+  /// `internal` so the `+ConvertedTotals.swift` extension can call the
+  /// calculator directly. Stays `let` — mutating it externally would
+  /// invalidate the retry loop's invariants.
+  let balanceCalculator: AccountBalanceCalculator
   /// Delay between retry attempts after a conversion failure. Production
   /// uses ~30s; tests pass a small value to keep retries snappy.
   private let retryDelay: Duration
@@ -134,6 +140,19 @@ final class AccountStore {
       for: account, investmentValue: investmentValueCache.value(for: accountId))
   }
 
+  /// Whether the sidebar should show "Not set" instead of `$0` for an
+  /// investment account in `.recordedValue` mode (no snapshot recorded;
+  /// initial conversion already completed). See
+  /// `INSTRUMENT_CONVERSION_GUIDE.md` Rule 11 — `$0` would otherwise roll
+  /// into net-worth as a real number.
+  func hasUnrecordedValue(_ account: Account) -> Bool {
+    guard hasCompletedInitialConversion else { return false }
+    guard account.type == .investment, account.valuationMode == .recordedValue else {
+      return false
+    }
+    return investmentValueCache.value(for: account.id) == nil
+  }
+
   /// Whether an account can be deleted (all positions are zero or empty).
   func canDelete(_ accountId: UUID) -> Bool {
     guard let account = accounts.by(id: accountId) else { return false }
@@ -143,33 +162,6 @@ final class AccountStore {
   /// Positions for a given account. Returns empty array if not loaded.
   func positions(for accountId: UUID) -> [Position] {
     accounts.by(id: accountId)?.positions ?? []
-  }
-
-  /// Total value of `accountList` in `target`, summing positions directly.
-  func computeConvertedTotal(for accountList: [Account], in target: Instrument) async throws
-    -> InstrumentAmount
-  {
-    try await balanceCalculator.totalConverted(for: accountList, to: target)
-  }
-
-  /// Total value of current accounts in `target`.
-  func computeConvertedCurrentTotal(in target: Instrument) async throws -> InstrumentAmount {
-    try await balanceCalculator.totalConverted(for: currentAccounts, to: target)
-  }
-
-  /// Total value of investment accounts in `target`. Uses cached external
-  /// values when present; otherwise sums positions. Single-pass to avoid
-  /// the double-conversion a two-phase approach would chain.
-  func computeConvertedInvestmentTotal(in target: Instrument) async throws -> InstrumentAmount {
-    try await balanceCalculator.totalConverted(
-      for: investmentAccounts, to: target, using: investmentValueCache)
-  }
-
-  /// Net worth (current + investment) in `target`.
-  func computeConvertedNetWorth(in target: Instrument) async throws -> InstrumentAmount {
-    let current = try await computeConvertedCurrentTotal(in: target)
-    let investment = try await computeConvertedInvestmentTotal(in: target)
-    return current + investment
   }
 
   /// Recompute per-account balances and aggregate totals via

--- a/Features/Accounts/Views/AccountSidebarRow.swift
+++ b/Features/Accounts/Views/AccountSidebarRow.swift
@@ -15,6 +15,13 @@ struct SidebarRowView: View {
   let name: String
   let amount: InstrumentAmount?
   var isSelected: Bool = false
+  /// When non-nil, the row replaces the amount with this short label
+  /// (e.g. "Not set") and the accompanying VoiceOver phrase. Used by
+  /// `AccountSidebarRow` for recorded-value investment accounts that have
+  /// no recorded snapshot, so the sidebar doesn't roll a synthetic `$0` into
+  /// the user's mental model of the column. See guides/UI_GUIDE.md §"Not set"
+  /// and `INSTRUMENT_CONVERSION_GUIDE.md` Rule 11 for the rationale.
+  var unsetIndicator: String?
 
   @Environment(\.backgroundProminence) private var backgroundProminence
 
@@ -45,18 +52,27 @@ struct SidebarRowView: View {
 
       Spacer()
 
-      if let amount {
-        InstrumentAmountView(amount: amount, colorOverride: amountColorOverride)
-      } else {
-        ProgressView()
-          .controlSize(.small)
-      }
+      trailingValue
     }
     .accessibilityElement(children: .ignore)
     .accessibilityLabel(accessibilitySummary)
   }
 
+  @ViewBuilder private var trailingValue: some View {
+    if let unsetIndicator {
+      Text(unsetIndicator)
+        .font(.caption)
+        .foregroundStyle(.secondary)
+    } else if let amount {
+      InstrumentAmountView(amount: amount, colorOverride: amountColorOverride)
+    } else {
+      ProgressView()
+        .controlSize(.small)
+    }
+  }
+
   private var accessibilitySummary: String {
+    if let unsetIndicator { return "\(name), \(unsetIndicator)" }
     guard let amount else { return "\(name), balance loading" }
     return "\(name), \(amount.formatted)"
   }
@@ -65,6 +81,13 @@ struct SidebarRowView: View {
 /// Sidebar row for an account. Reads the converted balance from
 /// `AccountStore.convertedBalances` (populated and retried by the store
 /// when conversions fail). Shows a spinner while no balance is available.
+///
+/// Recorded-value investment accounts with no externally-set value render
+/// "Not set" instead of `$0` once the initial conversion pass has completed
+/// — `$0` would be indistinguishable from "user entered zero" and would
+/// roll into net-worth as a real number rather than a missing one. See
+/// `INSTRUMENT_CONVERSION_GUIDE.md` Rule 11 and the design note in
+/// `plans/per-account-valuation-mode.md`.
 struct AccountSidebarRow: View {
   let account: Account
   var isSelected: Bool = false
@@ -75,7 +98,8 @@ struct AccountSidebarRow: View {
       icon: account.sidebarIcon,
       name: account.name,
       amount: accountStore.convertedBalances[account.id],
-      isSelected: isSelected
+      isSelected: isSelected,
+      unsetIndicator: accountStore.hasUnrecordedValue(account) ? "Not set" : nil
     )
   }
 }
@@ -116,6 +140,26 @@ struct AccountSidebarRow: View {
       isSelected: true
     )
     .tag("selected")
+  }
+  .listStyle(.sidebar)
+}
+
+#Preview("Sidebar row — Not set indicator") {
+  List(selection: .constant(Optional("loaded"))) {
+    SidebarRowView(
+      icon: "chart.line.uptrend.xyaxis",
+      name: "Brokerage (no value)",
+      amount: InstrumentAmount(quantity: 0, instrument: .AUD),
+      unsetIndicator: "Not set"
+    )
+    .tag("loaded")
+
+    SidebarRowView(
+      icon: "chart.line.uptrend.xyaxis",
+      name: "Brokerage (loading)",
+      amount: nil
+    )
+    .tag("loading")
   }
   .listStyle(.sidebar)
 }

--- a/Features/Investments/InvestmentStore+ComputedProperties.swift
+++ b/Features/Investments/InvestmentStore+ComputedProperties.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+// Hoisted out of `InvestmentStore.swift` so that file stays under the
+// `file_length` budget. The computed properties are pure reads and need no
+// privileged access to `private(set)` setters.
+extension InvestmentStore {
+  /// Investment values filtered by the selected time period.
+  var filteredValues: [InvestmentValue] {
+    guard let startDate = selectedPeriod.startDate else { return values }
+    return values.filter { $0.date >= startDate }
+  }
+
+  /// Daily balances filtered by the selected time period.
+  var filteredBalances: [AccountDailyBalance] {
+    guard let startDate = selectedPeriod.startDate else { return dailyBalances }
+    return dailyBalances.filter { $0.date >= startDate }
+  }
+
+  /// Forward-fills gaps so the chart renders a continuous P/L line on
+  /// days that received neither a snapshot nor a derived balance. See
+  /// `InvestmentChartData.merge` for the algorithm.
+  var chartDataPoints: [InvestmentChartDataPoint] {
+    InvestmentChartData.merge(
+      values: values,
+      balances: dailyBalances,
+      period: selectedPeriod
+    )
+  }
+}

--- a/Features/Investments/InvestmentStore.swift
+++ b/Features/Investments/InvestmentStore.swift
@@ -120,9 +120,18 @@ final class InvestmentStore {
     accountPerformance = nil  // clear stale data immediately
     switch account.valuationMode {
     case .recordedValue:
-      await loadValues(accountId: account.id)
-      guard !Task.isCancelled else { return }
-      await loadDailyBalances(accountId: account.id, hostCurrency: profileCurrency)
+      // `loadValues` and `loadDailyBalances` each paginate against the
+      // backend (potentially many round-trips on accounts with long
+      // history) and write disjoint state (`self.values` vs
+      // `self.dailyBalances`). Running them in parallel turns the
+      // wall-clock latency from `t(values) + t(balances)` to `max(...)`
+      // — measurable on accounts with multi-page history. Both methods
+      // are `@MainActor`-isolated, so the actual writes still serialise
+      // on the main actor.
+      async let loadedValues: Void = loadValues(accountId: account.id)
+      async let loadedBalances: Void = loadDailyBalances(
+        accountId: account.id, hostCurrency: profileCurrency)
+      _ = await (loadedValues, loadedBalances)
       guard !Task.isCancelled else { return }
       accountPerformance = AccountPerformanceCalculator.computeLegacy(
         dailyBalances: dailyBalances,
@@ -365,35 +374,7 @@ extension InvestmentStore {
   }
 }
 
-// MARK: - Computed Properties
-
-// Hoisted into an extension so the `InvestmentStore` class body stays
-// under the type_body_length budget; the computed properties are pure
-// reads and need no privileged access to `private(set)` setters.
-extension InvestmentStore {
-  /// Investment values filtered by the selected time period.
-  var filteredValues: [InvestmentValue] {
-    guard let startDate = selectedPeriod.startDate else { return values }
-    return values.filter { $0.date >= startDate }
-  }
-
-  /// Daily balances filtered by the selected time period.
-  var filteredBalances: [AccountDailyBalance] {
-    guard let startDate = selectedPeriod.startDate else { return dailyBalances }
-    return dailyBalances.filter { $0.date >= startDate }
-  }
-
-  /// Merged chart data points combining values and balances.
-  /// Follows the web app's algorithm: merge by date, forward-fill gaps, compute profit/loss.
-  var chartDataPoints: [InvestmentChartDataPoint] {
-    InvestmentChartData.merge(
-      values: values,
-      balances: dailyBalances,
-      period: selectedPeriod
-    )
-  }
-}
-
-// `InvestmentChartData` (the merge + forward-fill helpers used by
-// `chartDataPoints`) lives in `InvestmentChartData.swift` so this file
-// stays under the file_length budget.
+// `chartDataPoints` and the other pure-read computed properties live in
+// `InvestmentStore+ComputedProperties.swift`. `InvestmentChartData` (merge +
+// forward-fill helpers) lives in `InvestmentChartData.swift`. Both are
+// extracted so this file stays under the file_length budget.

--- a/Features/Investments/Views/InvestmentAccountView.swift
+++ b/Features/Investments/Views/InvestmentAccountView.swift
@@ -1,6 +1,28 @@
 import OSLog
 import SwiftUI
 
+/// Anchor `@AccessibilityFocusState` reads/writes inside
+/// `InvestmentAccountView`. File-private so the type's body stays focused
+/// on layout; only one case is required because every relayout target is
+/// the same logical "content has just (re-)mounted" event.
+private enum InvestmentAccountFocusAnchor: Hashable {
+  case content
+}
+
+/// Enforces Apple's iOS HIG 44×44 pt minimum touch target on the
+/// time-period picker buttons. macOS uses pointer precision so the
+/// modifier is a no-op there; the wrapping lets the call site stay
+/// declarative without `#if` clutter.
+private struct TimePeriodHitTarget: ViewModifier {
+  func body(content: Content) -> some View {
+    #if os(iOS)
+      content.frame(minHeight: 44).contentShape(Rectangle())
+    #else
+      content
+    #endif
+  }
+}
+
 /// Combined investment account view showing summary panels, chart with valuations list,
 /// and an embedded transaction list.
 struct InvestmentAccountView: View {
@@ -40,17 +62,18 @@ struct InvestmentAccountView: View {
   /// (e.g. Test Profile → Crypto).
   @State private var initialLoadComplete = false
 
-  /// The profile's reporting currency — used for valuing positions and the
-  /// chart series. NOT the account's own instrument: an investment account
-  /// can be denominated in a non-fiat instrument (e.g., a crypto wallet),
-  /// but valuations should always roll up into the user's fiat currency.
-  private var profileCurrencyInstrument: Instrument {
-    session.profile.instrument
-  }
+  /// Anchor VoiceOver moves to whenever the layout changes — initial-load
+  /// completion or a switch between `recordedValue` / `calculatedFromTrades`.
+  /// Without this, focus lingers on a button or row from the previous layout
+  /// and reads back unrelated content.
+  @AccessibilityFocusState private var focusAnchor: InvestmentAccountFocusAnchor?
 
-  /// Embedded transaction list for this account. Factored out because three
-  /// layout branches reuse it verbatim.
-  @ViewBuilder private var accountTransactionList: some View {
+  /// Embedded transaction list for this account. Each call site builds a
+  /// fresh `TransactionListView`; this is a method (not a `@ViewBuilder`
+  /// computed property) so the per-call instantiation is explicit at the
+  /// call site rather than masquerading as a stable view value.
+  @ViewBuilder
+  private func makeAccountTransactionList() -> some View {
     TransactionListView(
       title: "",
       filter: TransactionFilter(accountId: account.id),
@@ -67,7 +90,7 @@ struct InvestmentAccountView: View {
   /// the host's already-visible account balance (see `shouldHide`).
   @ViewBuilder private var positionTrackedLayout: some View {
     if positionsInput.shouldHide && !isLoadingPositions {
-      accountTransactionList
+      makeAccountTransactionList()
     } else {
       PositionsTransactionsSplit(
         defaultTab: .positions,
@@ -88,7 +111,7 @@ struct InvestmentAccountView: View {
           PositionsView(input: positionsInput, range: $positionsRange)
         }
       } transactions: {
-        accountTransactionList
+        makeAccountTransactionList()
       }
     }
   }
@@ -98,7 +121,7 @@ struct InvestmentAccountView: View {
       legacySummary
       legacyChartAndValuations
       Divider()
-      accountTransactionList
+      makeAccountTransactionList()
     }
   }
 
@@ -162,6 +185,7 @@ struct InvestmentAccountView: View {
         }
       }
     }
+    .accessibilityFocused($focusAnchor, equals: .content)
     .transactionInspector(
       selectedTransaction: $selectedTransaction,
       accounts: accounts,
@@ -177,21 +201,11 @@ struct InvestmentAccountView: View {
     }
     .task(id: LoadKey(id: account.id, mode: account.valuationMode)) {
       initialLoadComplete = false
-      isLoadingPositions = true
-      defer { isLoadingPositions = false }
-      do {
-        positionsInput = try await investmentStore.loadAndBuildPositionsInput(
-          account: account,
-          profileCurrency: profileCurrencyInstrument,
-          range: positionsRange)
-      } catch is CancellationError {
-        return
-      } catch {
-        Self.logger.error(
-          "Unexpected error from positionsViewInput: \(error.localizedDescription, privacy: .public)"
-        )
-      }
+      await reloadPositions()
       initialLoadComplete = true
+      // Move VoiceOver focus to the now-rendered content layout once the
+      // initial-load gate flips. Mirrored on layout-mode flips below.
+      focusAnchor = .content
     }
     .task(id: positionsRange) {
       // Skip until loadAllData has populated the store; the .task(id:) keyed
@@ -209,21 +223,16 @@ struct InvestmentAccountView: View {
         )
       }
     }
+    .onChange(of: account.valuationMode) {
+      // Layout-mode flip: reanchor VoiceOver after the new layout mounts.
+      // The `.task(id:)` above also fires (LoadKey carries `mode`), so
+      // `focusAnchor = .content` is set there once the data load
+      // completes — but the reassignment here additionally guarantees a
+      // focus move when the data load is a no-op (already cached).
+      focusAnchor = .content
+    }
     .refreshable {
-      isLoadingPositions = true
-      defer { isLoadingPositions = false }
-      do {
-        positionsInput = try await investmentStore.loadAndBuildPositionsInput(
-          account: account,
-          profileCurrency: profileCurrencyInstrument,
-          range: positionsRange)
-      } catch is CancellationError {
-        return
-      } catch {
-        Self.logger.error(
-          "Unexpected error from positionsViewInput: \(error.localizedDescription, privacy: .public)"
-        )
-      }
+      await reloadPositions()
     }
   }
 
@@ -248,6 +257,10 @@ struct InvestmentAccountView: View {
           .labelStyle(.iconOnly)
       }
       .help("Record Value")
+      // `.iconOnly` style hides the title from screen readers on iOS, which
+      // then announce the SF Symbol name ("plus") instead of the action.
+      // Pin the action label explicitly so VoiceOver reads "Record Value".
+      .accessibilityLabel("Record Value")
     }
     .padding(.horizontal)
     .padding(.vertical, 12)
@@ -295,6 +308,7 @@ struct InvestmentAccountView: View {
                   : Color.clear
               )
               .cornerRadius(8)
+              .modifier(TimePeriodHitTarget())
           }
           .buttonStyle(.plain)
           .accessibilityLabel("Show \(period.label) history")
@@ -302,6 +316,38 @@ struct InvestmentAccountView: View {
             investmentStore.selectedPeriod == period ? .isSelected : [])
         }
       }
+    }
+  }
+}
+
+// MARK: - Private helpers
+
+extension InvestmentAccountView {
+  /// The profile's reporting currency — used for valuing positions and the
+  /// chart series. NOT the account's own instrument: an investment account
+  /// can be denominated in a non-fiat instrument (e.g., a crypto wallet),
+  /// but valuations should always roll up into the user's fiat currency.
+  private var profileCurrencyInstrument: Instrument {
+    session.profile.instrument
+  }
+
+  /// Drives the full `loadAllData → positionsViewInput` rebuild used by
+  /// both `.task(id:)` and `.refreshable`. Sets `isLoadingPositions`
+  /// across the work so progress UI binds correctly.
+  private func reloadPositions() async {
+    isLoadingPositions = true
+    defer { isLoadingPositions = false }
+    do {
+      positionsInput = try await investmentStore.loadAndBuildPositionsInput(
+        account: account,
+        profileCurrency: profileCurrencyInstrument,
+        range: positionsRange)
+    } catch is CancellationError {
+      return
+    } catch {
+      Self.logger.error(
+        "Unexpected error from positionsViewInput: \(error.localizedDescription, privacy: .public)"
+      )
     }
   }
 }

--- a/MoolahUITests_macOS/Helpers/Screens/EditAccountScreen.swift
+++ b/MoolahUITests_macOS/Helpers/Screens/EditAccountScreen.swift
@@ -158,6 +158,55 @@ struct EditAccountScreen {
     }
   }
 
+  // MARK: - Mutations
+
+  /// Click the picker, choose `mode`, and assert the selection updated.
+  /// Caller must have already invoked `open(account:)`. Resolves the
+  /// menu-item by user-visible label via `MoolahApp.menuItem(label:)`,
+  /// because `NSMenuItem` does not inherit the SwiftUI accessibility
+  /// identifier on macOS.
+  func selectValuationMode(_ mode: Mode) {
+    Trace.record(#function, detail: "mode=\(mode)")
+    let picker = app.element(for: UITestIdentifiers.EditAccount.valuationModePicker)
+    if !picker.waitForExistence(timeout: 3) {
+      Trace.recordFailure(
+        "editAccount.valuationMode picker did not appear; cannot change selection")
+      XCTFail("Valuation picker did not appear within 3s")
+      return
+    }
+    picker.click()
+    let label = displayLabel(for: mode)
+    let item = app.menuItem(label: label)
+    if !item.waitForExistence(timeout: 3) {
+      Trace.recordFailure(
+        "Picker option '\(label)' did not appear after clicking valuation picker")
+      XCTFail("Picker option '\(label)' did not appear within 3s")
+      return
+    }
+    item.click()
+    expectValuationMode(mode)
+  }
+
+  /// Click the Save toolbar button. Returns once the dialog dismisses
+  /// (the Cancel button — which doubles as the dialog presence sentinel
+  /// — disappears).
+  func save() {
+    Trace.record(#function)
+    let saveButton = app.element(for: UITestIdentifiers.EditAccount.saveButton)
+    if !saveButton.waitForExistence(timeout: 3) {
+      Trace.recordFailure("editAccount.save button did not appear")
+      XCTFail("Save button did not appear within 3s")
+      return
+    }
+    saveButton.click()
+    let cancelButton = app.element(for: UITestIdentifiers.EditAccount.cancelButton)
+    if !cancelButton.waitForNonExistence(timeout: 3) {
+      Trace.recordFailure(
+        "editAccount.cancel did not disappear after Save click; sheet still open")
+      XCTFail("EditAccountView dialog did not disappear within 3s of Save")
+    }
+  }
+
   // MARK: - Helpers
 
   /// Maps `Mode` to the user-visible Picker label produced by

--- a/MoolahUITests_macOS/Tests/EditAccountValuationPickerTests.swift
+++ b/MoolahUITests_macOS/Tests/EditAccountValuationPickerTests.swift
@@ -49,4 +49,23 @@ final class EditAccountValuationPickerTests: MoolahUITestCase {
     app.editAccount.expectValuationSectionAbsent()
     app.editAccount.cancel()
   }
+
+  /// End-to-end coverage for flipping the picker. Brokerage starts in
+  /// `.recordedValue` mode (one snapshot in the seed). Flipping it to
+  /// `.calculatedFromTrades` and saving must persist — re-opening shows
+  /// the new selection. Pairs with `AccountStoreUpdateValuationTests` at
+  /// the store layer; this test exercises the picker click path the
+  /// store-level test does not cover.
+  func testFlippingValuationModePersists() {
+    let app = launch(seed: .tradeBaseline)
+
+    app.editAccount.open(account: .brokerage)
+    app.editAccount.expectValuationMode(EditAccountScreen.Mode.recordedValue)
+    app.editAccount.selectValuationMode(EditAccountScreen.Mode.calculatedFromTrades)
+    app.editAccount.save()
+
+    app.editAccount.open(account: .brokerage)
+    app.editAccount.expectValuationMode(EditAccountScreen.Mode.calculatedFromTrades)
+    app.editAccount.cancel()
+  }
 }


### PR DESCRIPTION
## Summary

Closes the consolidated tracking issue for findings deferred during the per-account valuation-mode rollout (PRs #730–#736). Every checkbox in #739 is addressed.

### Pre-existing in unrelated files

- [x] `SessionManager.session(for:)` replaced `Task { try? await session.setUp() }` with explicit do/catch + `logger.fault`. `CancellationError` is swallowed silently (it's expected during teardown via `cleanupSync` cancelling the inner `setUpTask`).
- [x] `ProfileSession+Imports.swift:102` `try!` → `guard let staging = try? ImportStagingStore(directory: fallback) else { logger.fault; fatalError }`. The fallback's-fallback failure is genuinely unrecoverable (sandbox denial of `tmp`); `fatalError` after `logger.fault` preserves diagnostic visibility.
- [x] `Account` `Codable, Sendable, Identifiable, Hashable, Comparable` split into one extension per protocol per CODE_GUIDE §2.

### Phase 3 — UX decision

- [x] **Spec disagreement (option a):** Kept `displayBalance` returning `$0` for unset recorded-mode investment accounts; surfaced unset-state via a new "Not set" indicator in the sidebar. The predicate lives on `AccountStore.hasUnrecordedValue(_:)` (gated on `hasCompletedInitialConversion`) rather than as a private view computed property — keeps it testable per CLAUDE.md "Thin Views, Testable Stores".

### Phase 4 — UI polish

- [x] Time-period picker buttons: `TimePeriodHitTarget` `ViewModifier` enforces 44×44 pt hit target on iOS (HIG); macOS keeps the existing tight visual via a no-op modifier branch.
- [x] `@AccessibilityFocusState` anchor re-focuses VoiceOver on `.content` after initial-load completion and on `valuationMode` flip (cached + non-cached paths both covered).
- [x] `#Preview` blocks: investigated, no crash reproducer in available workspaces; the existing `.id(account.valuationMode)` + `initialLoadComplete` gates already prevent the toolbar bridge issue the comment references. Left previews in their original `.task`-driven form.
- [x] Shared `reloadPositions()` private async helper called from both `.task(id:)` and `.refreshable`.
- [x] Explicit `.accessibilityLabel("Record Value")` on the icon-only Record Value toolbar button (iOS would otherwise read "plus").
- [x] `accountTransactionList` ViewBuilder var → `makeAccountTransactionList()` method (call-site instantiation now explicit).

### Phase 4 — concurrency

- [x] `InvestmentStore.loadAllData` `.recordedValue` branch parallelises `loadValues` and `loadDailyBalances` via `async let`. Both writers are `@MainActor`-isolated so the writes serialise; the network round-trips can paginate concurrently.

### Phase 6 — UI tests

- [x] `EditAccountScreen` driver gained `selectValuationMode(_:)` and `save()`. New `testFlippingValuationModePersists` opens Brokerage in `.recordedValue`, flips it to `.calculatedFromTrades`, saves, reopens, and verifies the new selection persisted.
- [x] Release-build mode-flip smoke test: not run locally — there is no local Release path (fastlane-only). Release-config compile verified clean. The existing `.id(account.valuationMode)` + `initialLoadComplete` gates already mediate the toolbar-bridge crash the smoke test guards against; the manual flip-test remains a one-off the user can run from a fastlane build.

## Refactors triggered by review

- Computed properties extracted to `InvestmentStore+ComputedProperties.swift`.
- `compute*` total methods extracted to `AccountStore+ConvertedTotals.swift`.
- `balanceCalculator` and `investmentValueCache` widened from `private` to internal `let` so the extension file can read them.

## Test plan

- [x] `just format-check` clean
- [x] `just build-mac` clean (no Swift warnings)
- [x] `just test` — 2251 tests pass
- [x] `just test-ui EditAccountValuationPickerTests` — all 4 tests pass (3 existing + 1 new)
- [x] Release-config compile clean

Fixes #739

🤖 Generated with [Claude Code](https://claude.com/claude-code)