### PR TITLE
feat(crypto): cross-device leg deduper after CKSyncEngine fetch

### DIFF
--- a/Backends/CloudKit/Sync/SyncCoordinator+CrossDeviceLegDedup.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+CrossDeviceLegDedup.swift
@@ -1,0 +1,83 @@
+// Backends/CloudKit/Sync/SyncCoordinator+CrossDeviceLegDedup.swift
+
+@preconcurrency import CloudKit
+import Foundation
+import OSLog
+
+/// Cross-device leg dedup hook for the post-fetch path. Extracted from
+/// `SyncCoordinator+RecordChanges.swift` so each file stays under
+/// SwiftLint's `file_length` threshold and the dedup wiring sits next
+/// to its load-bearing comment instead of inside the apply-changes
+/// dispatcher.
+///
+/// Wiring contract:
+/// - `extractTouchedExternalIds(saved:)` runs **off-main** in the same
+///   pre-apply window that builds the handler, so the read happens
+///   before `applyRemoteChanges` mutates row state.
+/// - `runCrossDeviceLegDedup(profileId:touchedExternalIds:)` runs **on
+///   `@MainActor`** after the apply succeeds. It uses the cached
+///   `ProfileGRDBRepositories.transactions` (already populated by
+///   `resolveGRDBRepositories`) so there is no extra DI plumbing.
+/// - All deletes route through `TransactionRepository.delete(id:)`
+///   inside `CrossDeviceLegDeduper`. The repository's `onRecordDeleted`
+///   hook then propagates the change back through CKSyncEngine. See
+///   `plans/2026-05-05-crypto-wallet-import-design.md` §"Multi-device
+///   race window".
+extension SyncCoordinator {
+  /// Returns every non-nil `externalId` value carried by saved
+  /// `TransactionLegRecord` CKRecords. Drives the post-apply
+  /// `CrossDeviceLegDeduper` sweep — only legs whose key the
+  /// just-applied fetch could have touched are revisited.
+  ///
+  /// Reads `externalId` directly off the CKRecord rather than
+  /// re-decoding through `TransactionLegRecordCloudKitFields` because
+  /// the deduper only needs the externalId scope hint, not the full
+  /// row. The field name is part of the CloudKit wire contract — same
+  /// constant the GRDB sync layer uses on the write path.
+  nonisolated static func extractTouchedExternalIds(
+    saved: [CKRecord]
+  ) -> Set<String> {
+    var touched: Set<String> = []
+    for record in saved where record.recordType == TransactionLegRow.recordType {
+      if let externalId = record["externalId"] as? String {
+        touched.insert(externalId)
+      }
+    }
+    return touched
+  }
+
+  /// Runs `CrossDeviceLegDeduper` against the per-profile transaction
+  /// repository on `@MainActor`. The repository handle is fetched off
+  /// the cached `ProfileGRDBRepositories` bundle the apply path
+  /// already builds — no extra DI plumbing. Best-effort: the deduper
+  /// catches and logs any per-delete failure internally, so a thrown
+  /// error here is the rare case where even the touched-set query
+  /// failed and means the next fetch will retry the sweep.
+  @MainActor
+  func runCrossDeviceLegDedup(
+    profileId: UUID, touchedExternalIds: Set<String>
+  ) async {
+    guard !touchedExternalIds.isEmpty else { return }
+    guard let repositories = cachedGRDBRepositories[profileId] else {
+      // The bundle is populated on first apply via
+      // `resolveGRDBRepositories(for:)`; we just ran that path above
+      // to build the handler, so missing-here means the cache was
+      // evicted between the handler build and now (e.g. profile
+      // removal). Skip silently — there's nothing to clean up.
+      return
+    }
+    let deduper = CrossDeviceLegDeduper(transactions: repositories.transactions)
+    do {
+      let collapsed = try await deduper.dedup(touchedExternalIds: touchedExternalIds)
+      if collapsed > 0 {
+        logger.info(
+          "CrossDeviceLegDeduper collapsed \(collapsed, privacy: .public) duplicate transaction(s) for profile \(profileId, privacy: .public)"
+        )
+      }
+    } catch {
+      logger.error(
+        "CrossDeviceLegDeduper failed for profile \(profileId, privacy: .public): \(error, privacy: .public)"
+      )
+    }
+  }
+}

--- a/Backends/CloudKit/Sync/SyncCoordinator+RecordChanges.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+RecordChanges.swift
@@ -163,6 +163,13 @@ extension SyncCoordinator {
       savedNames.contains(recordName)
     }
 
+    // Extract every non-nil `externalId` from the just-applied
+    // `TransactionLegRecord` saves before handing off to the apply
+    // path. The deduper hook below uses this set to scope its sweep to
+    // legs the fetch could plausibly have introduced duplicates for —
+    // bounded work even when an unrelated zone push arrived.
+    let touchedExternalIds = Self.extractTouchedExternalIds(saved: saved)
+
     // Heavy upsert/delete/save runs off-main via nonisolated method
     let result = handler.applyRemoteChanges(
       saved: saved, deleted: deleted, preExtractedSystemFields: zonePreExtracted)
@@ -183,6 +190,13 @@ extension SyncCoordinator {
           }
         }
       }
+      // Run the cross-device leg deduper after the apply so any
+      // duplicates introduced by a multi-device race collapse to one
+      // canonical leg before observers see the post-fetch state.
+      // Best-effort — failures are logged inside the deduper and
+      // don't block observer notifications.
+      await runCrossDeviceLegDedup(
+        profileId: profileId, touchedExternalIds: touchedExternalIds)
     case .saveFailed(let errorDescription):
       logger.error(
         "Profile data save failed for \(profileId), scheduling re-fetch: \(errorDescription, privacy: .public)"

--- a/Backends/GRDB/Repositories/GRDBTransactionRepository+ExternalIdLookup.swift
+++ b/Backends/GRDB/Repositories/GRDBTransactionRepository+ExternalIdLookup.swift
@@ -24,6 +24,45 @@ extension GRDBTransactionRepository {
     }
   }
 
+  /// Set-scoped sweep used by `CrossDeviceLegDeduper`: returns every
+  /// `Transaction` that has at least one leg whose `external_id` is in
+  /// `externalIds`, with all of that transaction's legs loaded so the
+  /// deduper can pick a canonical winner per `(accountId, externalId)`
+  /// group and route losers through `delete(id:)`.
+  ///
+  /// The leg-side `IN` filter rides the partial unique index
+  /// `leg_dedup_by_account_external`. Per-transaction leg fetch reuses
+  /// the same `fetchLegs` helper as `fetchAll(filter:)`. Empty input
+  /// short-circuits — `IN ()` is a syntax error and a full table scan
+  /// would silently waste work.
+  func transactions(touchingExternalIds externalIds: Set<String>) async throws
+    -> [Transaction]
+  {
+    guard !externalIds.isEmpty else { return [] }
+    return try await database.read { database in
+      let matchingTxnIds =
+        try TransactionLegRow
+        .select(TransactionLegRow.Columns.transactionId, as: UUID.self)
+        .filter(externalIds.contains(TransactionLegRow.Columns.externalId))
+        .distinct()
+        .fetchAll(database)
+      guard !matchingTxnIds.isEmpty else { return [] }
+      let instruments = try Self.fetchInstrumentMap(database: database)
+      let txnIdSet = Set(matchingTxnIds)
+      let txnRows =
+        try TransactionRow
+        .filter(txnIdSet.contains(TransactionRow.Columns.id))
+        .fetchAll(database)
+      let legsByTxnId = try Self.fetchLegs(
+        database: database,
+        transactionIds: txnRows.map(\.id),
+        instruments: instruments)
+      return try txnRows.map { row in
+        try row.toDomain(legs: legsByTxnId[row.id] ?? [])
+      }
+    }
+  }
+
   func legExists(accountId: UUID, externalId: String) async throws -> Bool {
     try await database.read { database in
       try TransactionLegRow

--- a/Domain/Repositories/TransactionRepository.swift
+++ b/Domain/Repositories/TransactionRepository.swift
@@ -28,6 +28,18 @@ protocol TransactionRepository: Sendable {
   /// it. The schema's partial unique index on
   /// `(account_id, external_id)` keeps this lookup cheap.
   func legs(matchingExternalId externalId: String) async throws -> [TransactionLeg]
+  /// Returns every transaction that has at least one leg whose
+  /// `external_id` matches any value in `externalIds`, with full leg
+  /// payloads loaded. Used by `CrossDeviceLegDeduper` to scope its post-
+  /// CKSyncEngine sweep to transactions that the just-applied fetch could
+  /// have touched — the deduper needs each leg's parent `Transaction.id`
+  /// to know which row to route through `delete(id:)`. Empty input
+  /// returns an empty result without hitting the database. The schema's
+  /// partial unique index `leg_dedup_by_account_external` covers the
+  /// underlying leg-side `IN` predicate, so even thousand-id sweeps stay
+  /// cheap.
+  func transactions(touchingExternalIds externalIds: Set<String>) async throws
+    -> [Transaction]
   /// `true` iff the wallet importer has already persisted a leg keyed by
   /// `(accountId, externalId)`. Used by the per-leg dedup step of the
   /// apply pass — re-fetches that span the reorg window cover already-

--- a/MoolahTests/Backends/GRDB/CrossDeviceLegDeduperPlanPinningTests.swift
+++ b/MoolahTests/Backends/GRDB/CrossDeviceLegDeduperPlanPinningTests.swift
@@ -1,0 +1,36 @@
+// MoolahTests/Backends/GRDB/CrossDeviceLegDeduperPlanPinningTests.swift
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+/// `EXPLAIN QUERY PLAN`-pinning tests for the GRDB query that backs
+/// `CrossDeviceLegDeduper`'s touched-set sweep. Per
+/// `guides/DATABASE_CODE_GUIDE.md` §6 every perf-critical query must
+/// have a paired plan-pinning test so an index regression breaks the
+/// build immediately.
+///
+/// Pinned: the leg-side `IN`-predicate on `external_id` used by
+/// `GRDBTransactionRepository.transactions(touchingExternalIds:)`. Must
+/// hit the partial unique index `leg_dedup_by_account_external` (the
+/// same index `WalletApplyEngine` reads through).
+@Suite("CrossDeviceLegDeduper GRDB query plan")
+struct CrossDeviceLegDeduperPlanPinningTests {
+  @Test
+  func touchedExternalIdLookupUsesPartialIndex() throws {
+    let database = try PlanPinningTestHelpers.makeDatabase()
+    // Single-arg form is the cheap canary: `IN (?)` resolves to the
+    // same index walk as the multi-arg form, and SQLite reports the
+    // index in the plan either way.
+    let detail = try PlanPinningTestHelpers.planDetail(
+      database,
+      query: """
+        SELECT transaction_id FROM transaction_leg
+        WHERE external_id IN (?)
+        """,
+      arguments: ["0xseed"])
+    #expect(detail.contains("USING INDEX leg_dedup_by_account_external"))
+    #expect(!PlanPinningTestHelpers.planHasFullTableScanOf(detail, alias: "transaction_leg"))
+  }
+}

--- a/MoolahTests/Features/TransactionStoreLoadRaceTests.swift
+++ b/MoolahTests/Features/TransactionStoreLoadRaceTests.swift
@@ -235,5 +235,8 @@ actor FirstFetchGatedTransactionRepository: TransactionRepository {
     prefix: String, excludingTransactionId: UUID?
   ) async throws -> [String] { [] }
   func legs(matchingExternalId externalId: String) async throws -> [TransactionLeg] { [] }
+  func transactions(touchingExternalIds externalIds: Set<String>) async throws -> [Transaction] {
+    []
+  }
   func legExists(accountId: UUID, externalId: String) async throws -> Bool { false }
 }

--- a/MoolahTests/Shared/CryptoImport/CrossDeviceLegDeduperEdgeCaseTests.swift
+++ b/MoolahTests/Shared/CryptoImport/CrossDeviceLegDeduperEdgeCaseTests.swift
@@ -1,0 +1,81 @@
+// MoolahTests/Shared/CryptoImport/CrossDeviceLegDeduperEdgeCaseTests.swift
+import Foundation
+import Testing
+
+@testable import Moolah
+
+/// Edge-case tests for `CrossDeviceLegDeduper`: mixed legs (one
+/// duplicate + one unique), determinism across input ordering. Split
+/// from `CrossDeviceLegDeduperTests` so each suite stays under
+/// SwiftLint's `type_body_length` threshold and convergence vs.
+/// edge-case scenarios remain independently scannable.
+@Suite("CrossDeviceLegDeduper — edge cases")
+@MainActor
+struct CrossDeviceLegDeduperEdgeCaseTests {
+  private typealias Support = CrossDeviceLegDeduperTestSupport
+
+  @Test("Mixed transaction (one duplicate leg + one unique leg) is skipped, not deleted")
+  func mixedTransactionsAreSkipped() async throws {
+    let setup = try Support.makeSetup()
+    setup.seedAccount(Support.accountA)
+    setup.seedAccount(Support.accountB)
+
+    // Transaction A: one leg with the shared hash on account A.
+    try await setup.create(
+      Support.makeSingleLegTransaction(
+        id: Support.txnA, accountId: Support.accountA, externalId: Support.hash))
+    // Transaction B: one duplicate leg on account A AND one unique
+    // leg on account B that is NOT shared with anyone — deleting B
+    // would lose the unique leg.
+    try await setup.create(
+      Transaction(
+        id: Support.txnB,
+        date: Support.date,
+        legs: [
+          Support.makeLeg(
+            accountId: Support.accountA,
+            quantity: -1,
+            externalId: Support.hash,
+            type: .transfer),
+          Support.makeLeg(
+            accountId: Support.accountB,
+            quantity: 5,
+            externalId: "0xunique",
+            type: .transfer),
+        ]))
+
+    let recording = RecordingTransactionRepository(wrapping: setup.backend.transactions)
+    let deduper = CrossDeviceLegDeduper(transactions: recording)
+    let collapsed = try await deduper.dedup(touchedExternalIds: [Support.hash])
+
+    #expect(collapsed == 0)
+    let stored = try await setup.backend.transactions.fetchAll(filter: .init())
+    let storedIds = stored.map(\.id).sorted { $0.uuidString < $1.uuidString }
+    #expect(storedIds == [Support.txnA, Support.txnB])
+    let recordedDeletes = await recording.deletedIds
+    #expect(recordedDeletes.isEmpty)
+  }
+
+  @Test("Same canonical wins regardless of input ordering")
+  func deterministicAcrossInputOrder() async throws {
+    // Build three transactions all sharing one (account, externalId)
+    // group. The lex-min UUID (txnA) must always survive regardless
+    // of which order the deduper sees them in.
+    for ordering in Support.permutations(
+      of: [Support.txnA, Support.txnB, Support.txnC])
+    {
+      let setup = try Support.makeSetup()
+      setup.seedAccount(Support.accountA)
+      for txnId in ordering {
+        try await setup.create(
+          Support.makeSingleLegTransaction(
+            id: txnId, accountId: Support.accountA, externalId: Support.hash))
+      }
+      let deduper = CrossDeviceLegDeduper(transactions: setup.backend.transactions)
+      let collapsed = try await deduper.dedup(touchedExternalIds: [Support.hash])
+      #expect(collapsed == 2)
+      let stored = try await setup.backend.transactions.fetchAll(filter: .init())
+      #expect(stored.map(\.id) == [Support.txnA])
+    }
+  }
+}

--- a/MoolahTests/Shared/CryptoImport/CrossDeviceLegDeduperTestSupport.swift
+++ b/MoolahTests/Shared/CryptoImport/CrossDeviceLegDeduperTestSupport.swift
@@ -1,0 +1,125 @@
+// MoolahTests/Shared/CryptoImport/CrossDeviceLegDeduperTestSupport.swift
+import Foundation
+import GRDB
+
+@testable import Moolah
+
+/// Shared fixtures for the `CrossDeviceLegDeduper*Tests` suites. Lives
+/// outside any one suite so the convergence, scoping, and determinism
+/// tests can split into focused files without duplicating the seeding /
+/// permutation glue.
+///
+/// Case-less enum used as a namespace per `guides/CODE_GUIDE.md` §5.
+enum CrossDeviceLegDeduperTestSupport {
+  /// Two stable transaction ids — `txnA < txnB < txnC` by lex order of
+  /// the lowercase UUID string. The deduper picks the lowest UUID as
+  /// canonical, so pinning these literals lets the suite assert on
+  /// exact survivors.
+  static let txnA = makeUUID("11111111-1111-1111-1111-111111111111")
+  static let txnB = makeUUID("22222222-2222-2222-2222-222222222222")
+  static let txnC = makeUUID("33333333-3333-3333-3333-333333333333")
+  static let accountA = makeUUID("AAAAAAAA-0000-0000-0000-000000000001")
+  static let accountB = makeUUID("BBBBBBBB-0000-0000-0000-000000000002")
+  static let hash = "0xshared-on-chain-hash"
+  static let date = Date(timeIntervalSince1970: 1_700_000_000)
+
+  /// Backend + database pair plus the seeding helpers each test uses.
+  /// Holding onto the database queue is required: `TestBackend.seed`
+  /// writes through it, and the in-memory queue would be deallocated
+  /// between operations otherwise.
+  struct Setup {
+    let backend: CloudKitBackend
+    let database: DatabaseQueue
+
+    func seedAccount(_ id: UUID) {
+      let account = Account(
+        id: id,
+        name: "Account \(id.uuidString.prefix(4))",
+        type: .crypto,
+        instrument: ChainConfig.ethereum.nativeInstrument,
+        walletAddress: "0x" + String(repeating: "1", count: 40),
+        chainId: ChainConfig.ethereum.chainId)
+      _ = TestBackend.seed(accounts: [account], in: database)
+    }
+
+    func create(_ transaction: Transaction) async throws {
+      _ = try await backend.transactions.create(transaction)
+    }
+  }
+
+  /// Builds a `TestBackend` and **drops the partial unique index**
+  /// `leg_dedup_by_account_external` so the test can seed two
+  /// `TransactionLeg` rows sharing `(accountId, externalId)`. In
+  /// production the index is the device-local guard against duplicate
+  /// imports; the cross-device race the deduper exists to clean up
+  /// would have been blocked by it on the apply path. The deduper is
+  /// designed to be defensive even when duplicates do land — the
+  /// design (`plans/2026-05-05-crypto-wallet-import-design.md`
+  /// §"Multi-device race window") explicitly calls out the upsert
+  /// path not re-running the dedup. Dropping the index in tests lets
+  /// the suite exercise the deduper's algorithm against the same
+  /// shape of state the post-CKSyncEngine sweep would face.
+  ///
+  /// The deduper itself only performs `SELECT` and `delete(id:)`
+  /// calls, never inserts that would otherwise re-tripped the index,
+  /// so leaving the index dropped for the rest of the test is safe.
+  static func makeSetup() throws -> Setup {
+    let (backend, database) = try TestBackend.create()
+    try database.write { database in
+      try database.execute(sql: "DROP INDEX IF EXISTS leg_dedup_by_account_external")
+    }
+    return Setup(backend: backend, database: database)
+  }
+
+  static func makeLeg(
+    accountId: UUID,
+    quantity: Decimal,
+    externalId: String,
+    type: TransactionType
+  ) -> TransactionLeg {
+    TransactionLeg(
+      accountId: accountId,
+      instrument: ChainConfig.ethereum.nativeInstrument,
+      quantity: quantity,
+      externalId: externalId,
+      type: type)
+  }
+
+  /// Returns a transaction with one leg shaped for the cross-device
+  /// duplicate scenarios. Most tests need exactly this shape — pulling
+  /// it into a helper keeps the suites focused on what they're
+  /// actually asserting.
+  static func makeSingleLegTransaction(
+    id: UUID,
+    accountId: UUID,
+    externalId: String,
+    quantity: Decimal = -1
+  ) -> Transaction {
+    Transaction(
+      id: id,
+      date: Self.date,
+      legs: [
+        makeLeg(
+          accountId: accountId,
+          quantity: quantity,
+          externalId: externalId,
+          type: .transfer)
+      ])
+  }
+
+  /// Generates every permutation of an input array — used to exercise
+  /// the deterministic-across-input-order invariant exhaustively for
+  /// small inputs without relying on a randomness seed.
+  static func permutations<Element>(of input: [Element]) -> [[Element]] {
+    guard input.count > 1 else { return [input] }
+    var result: [[Element]] = []
+    for index in input.indices {
+      var rest = input
+      let pivot = rest.remove(at: index)
+      for tail in permutations(of: rest) {
+        result.append([pivot] + tail)
+      }
+    }
+    return result
+  }
+}

--- a/MoolahTests/Shared/CryptoImport/CrossDeviceLegDeduperTests.swift
+++ b/MoolahTests/Shared/CryptoImport/CrossDeviceLegDeduperTests.swift
@@ -1,0 +1,151 @@
+// MoolahTests/Shared/CryptoImport/CrossDeviceLegDeduperTests.swift
+import Foundation
+import Testing
+
+@testable import Moolah
+
+/// Behavioural tests for `CrossDeviceLegDeduper`. The deduper runs after
+/// every CKSyncEngine `fetchedRecordZoneChanges` callback to collapse
+/// cross-device duplicate `TransactionLeg` rows into one canonical leg
+/// per `(accountId, externalId)` group. Tests use `TestBackend`
+/// (`CloudKitBackend` + in-memory GRDB) so the dedup pass exercises the
+/// real `delete(id:)` plumbing that propagates back through CKSyncEngine,
+/// not a mock.
+///
+/// Shared fixtures (`Setup`, `makeLeg`, ids, `permutations`) live in
+/// `CrossDeviceLegDeduperTestSupport.swift`. Determinism / mixed-leg
+/// cases live in `CrossDeviceLegDeduperEdgeCaseTests.swift`.
+@Suite("CrossDeviceLegDeduper — convergence")
+@MainActor
+struct CrossDeviceLegDeduperTests {
+  private typealias Support = CrossDeviceLegDeduperTestSupport
+
+  @Test("Two transactions sharing (accountId, externalId) collapse to the lower-UUID survivor")
+  func twoDeviceRaceConverges() async throws {
+    let setup = try Support.makeSetup()
+    setup.seedAccount(Support.accountA)
+    try await setup.create(
+      Support.makeSingleLegTransaction(
+        id: Support.txnA, accountId: Support.accountA, externalId: Support.hash))
+    try await setup.create(
+      Support.makeSingleLegTransaction(
+        id: Support.txnB, accountId: Support.accountA, externalId: Support.hash))
+
+    let recording = RecordingTransactionRepository(wrapping: setup.backend.transactions)
+    let deduper = CrossDeviceLegDeduper(transactions: recording)
+
+    let collapsed = try await deduper.dedup(touchedExternalIds: [Support.hash])
+
+    #expect(collapsed == 1)
+    let stored = try await setup.backend.transactions.fetchAll(filter: .init())
+    #expect(stored.map(\.id) == [Support.txnA])
+    let recordedDeletes = await recording.deletedIds
+    #expect(recordedDeletes == [Support.txnB])
+  }
+
+  @Test("Both devices' deduper independently reach the same canonical winner")
+  func bothDevicesConvergeToSameCanonical() async throws {
+    let setupDeviceA = try Support.makeSetup()
+    let setupDeviceB = try Support.makeSetup()
+    for setup in [setupDeviceA, setupDeviceB] {
+      setup.seedAccount(Support.accountA)
+      try await setup.create(
+        Support.makeSingleLegTransaction(
+          id: Support.txnA, accountId: Support.accountA, externalId: Support.hash))
+      try await setup.create(
+        Support.makeSingleLegTransaction(
+          id: Support.txnB, accountId: Support.accountA, externalId: Support.hash))
+    }
+
+    let dedupedA = CrossDeviceLegDeduper(transactions: setupDeviceA.backend.transactions)
+    let dedupedB = CrossDeviceLegDeduper(transactions: setupDeviceB.backend.transactions)
+
+    _ = try await dedupedA.dedup(touchedExternalIds: [Support.hash])
+    _ = try await dedupedB.dedup(touchedExternalIds: [Support.hash])
+
+    let storedA = try await setupDeviceA.backend.transactions.fetchAll(filter: .init())
+    let storedB = try await setupDeviceB.backend.transactions.fetchAll(filter: .init())
+    #expect(storedA.map(\.id) == [Support.txnA])
+    #expect(storedB.map(\.id) == [Support.txnA])
+  }
+
+  @Test("Idempotent: running again on a converged state is a no-op")
+  func idempotentOnConvergedState() async throws {
+    let setup = try Support.makeSetup()
+    setup.seedAccount(Support.accountA)
+    try await setup.create(
+      Support.makeSingleLegTransaction(
+        id: Support.txnA, accountId: Support.accountA, externalId: Support.hash))
+
+    let deduper = CrossDeviceLegDeduper(transactions: setup.backend.transactions)
+    let firstRun = try await deduper.dedup(touchedExternalIds: [Support.hash])
+    let secondRun = try await deduper.dedup(touchedExternalIds: [Support.hash])
+
+    #expect(firstRun == 0)
+    #expect(secondRun == 0)
+    let stored = try await setup.backend.transactions.fetchAll(filter: .init())
+    #expect(stored.count == 1)
+  }
+
+  @Test("Touched set excluding the duplicate's externalId leaves the duplicate in place")
+  func touchedSetScopingSkipsUnrelatedDuplicates() async throws {
+    let setup = try Support.makeSetup()
+    setup.seedAccount(Support.accountA)
+    try await setup.create(
+      Support.makeSingleLegTransaction(
+        id: Support.txnA, accountId: Support.accountA, externalId: Support.hash))
+    try await setup.create(
+      Support.makeSingleLegTransaction(
+        id: Support.txnB, accountId: Support.accountA, externalId: Support.hash))
+
+    let deduper = CrossDeviceLegDeduper(transactions: setup.backend.transactions)
+    let collapsed = try await deduper.dedup(touchedExternalIds: ["0xunrelated"])
+
+    #expect(collapsed == 0)
+    let stored = try await setup.backend.transactions.fetchAll(filter: .init())
+    #expect(stored.count == 2)
+  }
+
+  @Test("Empty touched set is a no-op (no DB query)")
+  func emptyTouchedSetIsNoOp() async throws {
+    let setup = try Support.makeSetup()
+    setup.seedAccount(Support.accountA)
+    try await setup.create(
+      Support.makeSingleLegTransaction(
+        id: Support.txnA, accountId: Support.accountA, externalId: Support.hash))
+    try await setup.create(
+      Support.makeSingleLegTransaction(
+        id: Support.txnB, accountId: Support.accountA, externalId: Support.hash))
+
+    let deduper = CrossDeviceLegDeduper(transactions: setup.backend.transactions)
+    let collapsed = try await deduper.dedup(touchedExternalIds: [])
+
+    #expect(collapsed == 0)
+    let stored = try await setup.backend.transactions.fetchAll(filter: .init())
+    #expect(stored.count == 2)
+  }
+
+  @Test("Deletes route through TransactionRepository.delete(id:), not directly to GRDB")
+  func deletesRouteThroughRepository() async throws {
+    let setup = try Support.makeSetup()
+    setup.seedAccount(Support.accountA)
+    try await setup.create(
+      Support.makeSingleLegTransaction(
+        id: Support.txnA, accountId: Support.accountA, externalId: Support.hash))
+    try await setup.create(
+      Support.makeSingleLegTransaction(
+        id: Support.txnB, accountId: Support.accountA, externalId: Support.hash))
+
+    let recording = RecordingTransactionRepository(wrapping: setup.backend.transactions)
+    let deduper = CrossDeviceLegDeduper(transactions: recording)
+    _ = try await deduper.dedup(touchedExternalIds: [Support.hash])
+
+    let recordedDeletes = await recording.deletedIds
+    #expect(recordedDeletes == [Support.txnB])
+    // Cross-check: the underlying database is in lock-step (the
+    // recording wrapper forwards `delete(id:)` to the GRDB repo, so a
+    // bypass would leave the DB out of sync with the recorded count).
+    let stored = try await setup.backend.transactions.fetchAll(filter: .init())
+    #expect(stored.count == 1)
+  }
+}

--- a/MoolahTests/Shared/CryptoImport/RecordingTransactionRepository.swift
+++ b/MoolahTests/Shared/CryptoImport/RecordingTransactionRepository.swift
@@ -1,0 +1,62 @@
+// MoolahTests/Shared/CryptoImport/RecordingTransactionRepository.swift
+import Foundation
+
+@testable import Moolah
+
+/// Recording wrapper around a `TransactionRepository`. Forwards every
+/// call to the wrapped repository while remembering which `delete(id:)`
+/// calls a unit-under-test made — used by `CrossDeviceLegDeduperTests`
+/// to verify the repository-routed delete invariant. Forwards every
+/// other method directly so the wrapped `CloudKitBackend` does the
+/// actual persistence work.
+///
+/// `actor` so `deletedIds` can be observed from `@MainActor` tests
+/// without tripping Sendable diagnostics.
+actor RecordingTransactionRepository: TransactionRepository {
+  private let wrapped: any TransactionRepository
+  private(set) var deletedIds: [UUID] = []
+
+  init(wrapping wrapped: any TransactionRepository) {
+    self.wrapped = wrapped
+  }
+
+  func fetch(filter: TransactionFilter, page: Int, pageSize: Int) async throws -> TransactionPage {
+    try await wrapped.fetch(filter: filter, page: page, pageSize: pageSize)
+  }
+
+  func fetchAll(filter: TransactionFilter) async throws -> [Transaction] {
+    try await wrapped.fetchAll(filter: filter)
+  }
+
+  func create(_ transaction: Transaction) async throws -> Transaction {
+    try await wrapped.create(transaction)
+  }
+
+  func update(_ transaction: Transaction) async throws -> Transaction {
+    try await wrapped.update(transaction)
+  }
+
+  func delete(id: UUID) async throws {
+    deletedIds.append(id)
+    try await wrapped.delete(id: id)
+  }
+
+  func fetchPayeeSuggestions(
+    prefix: String, excludingTransactionId: UUID?
+  ) async throws -> [String] {
+    try await wrapped.fetchPayeeSuggestions(
+      prefix: prefix, excludingTransactionId: excludingTransactionId)
+  }
+
+  func legs(matchingExternalId externalId: String) async throws -> [TransactionLeg] {
+    try await wrapped.legs(matchingExternalId: externalId)
+  }
+
+  func transactions(touchingExternalIds externalIds: Set<String>) async throws -> [Transaction] {
+    try await wrapped.transactions(touchingExternalIds: externalIds)
+  }
+
+  func legExists(accountId: UUID, externalId: String) async throws -> Bool {
+    try await wrapped.legExists(accountId: accountId, externalId: externalId)
+  }
+}

--- a/MoolahTests/Support/CancellablePagingTransactionRepository.swift
+++ b/MoolahTests/Support/CancellablePagingTransactionRepository.swift
@@ -61,6 +61,9 @@ actor CancellablePagingTransactionRepository: TransactionRepository {
     prefix: String, excludingTransactionId: UUID?
   ) async throws -> [String] { [] }
   func legs(matchingExternalId externalId: String) async throws -> [TransactionLeg] { [] }
+  func transactions(touchingExternalIds externalIds: Set<String>) async throws -> [Transaction] {
+    []
+  }
   func legExists(accountId: UUID, externalId: String) async throws -> Bool { false }
 }
 

--- a/MoolahTests/Support/TransactionStoreTestSupport.swift
+++ b/MoolahTests/Support/TransactionStoreTestSupport.swift
@@ -135,6 +135,10 @@ struct FailingTransactionRepository: TransactionRepository {
     throw BackendError.networkUnavailable
   }
 
+  func transactions(touchingExternalIds externalIds: Set<String>) async throws -> [Transaction] {
+    throw BackendError.networkUnavailable
+  }
+
   func legExists(accountId: UUID, externalId: String) async throws -> Bool {
     throw BackendError.networkUnavailable
   }

--- a/Shared/CryptoImport/CrossDeviceLegDeduper.swift
+++ b/Shared/CryptoImport/CrossDeviceLegDeduper.swift
@@ -1,0 +1,225 @@
+// Shared/CryptoImport/CrossDeviceLegDeduper.swift
+import Foundation
+import OSLog
+
+/// Post-CKSyncEngine reconciliation pass. Runs on `@MainActor` after every
+/// CKSyncEngine `fetchedRecordZoneChanges` callback applies cleanly. Scans
+/// transactions whose legs share a non-nil `(accountId, externalId)` pair
+/// with another transaction and reduces each group to a single canonical
+/// leg using deterministic UUID lex-order tiebreak — both devices reach
+/// the same end state independently without further coordination.
+///
+/// **All deletes route through `TransactionRepository.delete(id:)`**, not
+/// directly to GRDB, so the change propagates back through CKSyncEngine
+/// to other devices via the repository's existing `onRecordDeleted`
+/// hook. Bypassing the repository would silently desync the deduper's
+/// local cleanup from CloudKit. (See
+/// `plans/2026-05-05-crypto-wallet-import-design.md` §"Multi-device race
+/// window — honest description".)
+///
+/// **v1 scope.** A transaction whose every leg duplicates another
+/// transaction's legs is removed wholesale. Mixed transactions — one
+/// duplicate leg plus one unique leg — are unusual in the wallet-import
+/// shape (each on-chain event yields one `externalId`); the deduper logs
+/// a warning and skips them. Per-leg dedup within a single transaction
+/// is intentionally out of scope and tracked separately if it ever
+/// surfaces.
+@MainActor
+struct CrossDeviceLegDeduper {
+  private let transactions: any TransactionRepository
+  private let logger = Logger(
+    subsystem: "com.moolah.app", category: "CrossDeviceLegDeduper")
+
+  init(transactions: any TransactionRepository) {
+    self.transactions = transactions
+  }
+
+  /// Runs the dedup sweep over the transactions touched by the most
+  /// recent CKSyncEngine fetch. Idempotent — repeated calls on a
+  /// converged state are a no-op. Bounded — the leg-side IN predicate
+  /// rides the `leg_dedup_by_account_external` partial unique index, so
+  /// even thousand-id sweeps stay cheap. Returns the count of
+  /// duplicate-transaction deletions actually performed (useful for
+  /// logging and metrics).
+  ///
+  /// - Parameter touchedExternalIds: the set of non-nil `externalId`s
+  ///   the just-applied CK batch carried on `TransactionLegRecord`
+  ///   saves. Empty input short-circuits — `IN ()` would be a syntax
+  ///   error and a full table scan is the wrong default for a
+  ///   per-fetch hook.
+  @discardableResult
+  func dedup(touchedExternalIds: Set<String>) async throws -> Int {
+    guard !touchedExternalIds.isEmpty else { return 0 }
+    let candidates = try await transactions.transactions(
+      touchingExternalIds: touchedExternalIds)
+    guard candidates.count > 1 else { return 0 }
+
+    let plan = Self.planCollapse(
+      candidates: candidates, touchedExternalIds: touchedExternalIds)
+
+    var deletedCount = 0
+    for transactionId in plan.transactionsToDelete {
+      do {
+        try await transactions.delete(id: transactionId)
+        deletedCount += 1
+      } catch {
+        // A transient delete failure leaves the duplicate in place. The
+        // next CKSyncEngine fetch will re-run the deduper and try
+        // again, and the deterministic tiebreak guarantees the same
+        // canonical wins on retry. Don't propagate — the rest of the
+        // sweep should still make progress on independent groups.
+        logger.error(
+          "Failed to delete duplicate transaction \(transactionId, privacy: .public): \(error, privacy: .public)"
+        )
+      }
+    }
+    if !plan.skippedMixed.isEmpty {
+      logger.warning(
+        """
+        Skipped \(plan.skippedMixed.count, privacy: .public) transaction(s) \
+        with mixed duplicate + unique legs — per-leg dedup within a single \
+        transaction is out of scope for v1
+        """)
+    }
+    return deletedCount
+  }
+
+  // MARK: - Planning
+
+  /// Group key used to detect cross-device duplicate legs. Both fields
+  /// must be non-nil for a leg to participate — manual transactions
+  /// (no `externalId`) and orphaned legs (no `accountId`) are immune.
+  struct GroupKey: Hashable {
+    let accountId: UUID
+    let externalId: String
+  }
+
+  /// The output of `planCollapse`: which transactions to route through
+  /// `delete(id:)` and which were skipped because they have a mix of
+  /// duplicate and unique legs (out of scope for v1).
+  struct CollapsePlan: Equatable {
+    var transactionsToDelete: [UUID]
+    var skippedMixed: [UUID]
+  }
+
+  /// Decides which transactions are duplicates ready for deletion vs.
+  /// which are mixed (one duplicate leg + a non-duplicate leg).
+  ///
+  /// **Algorithm:**
+  /// 1. Build groups keyed by `(accountId, externalId)` over candidate
+  ///    legs whose `externalId` is in `touchedExternalIds`. Each group
+  ///    holds the set of transaction ids whose legs land there.
+  /// 2. For groups with more than one transaction, the canonical
+  ///    winner is the lowest `Transaction.id` by lex-order of the
+  ///    lowercase UUID string. Every device runs the same tiebreak
+  ///    over the same set of UUIDs and therefore picks the same
+  ///    survivor.
+  /// 3. A transaction is *wholly* duplicate (safe to delete) when every
+  ///    one of its legs is a participant of some multi-transaction
+  ///    group that it lost. A transaction with even one leg outside
+  ///    any duplicate group — for example, a unique-`externalId` leg
+  ///    or a leg without an `externalId` at all — is *mixed* and
+  ///    skipped: deleting it would lose the unique leg.
+  ///
+  /// Output is sorted by `uuidString.lowercased()` so the operation
+  /// order is stable across runs (deterministic-across-run-order test
+  /// invariant). Sorting is locale-independent because the lowercase
+  /// hex-only alphabet is unaffected by locale rules.
+  static func planCollapse(
+    candidates: [Transaction],
+    touchedExternalIds: Set<String>
+  ) -> CollapsePlan {
+    let groups = Self.buildGroups(
+      candidates: candidates, touchedExternalIds: touchedExternalIds)
+
+    // For each multi-transaction group, find the canonical winner and
+    // mark the rest as "lost this group".
+    var lossesByTxn: [UUID: Int] = [:]
+    for (_, txnIds) in groups where txnIds.count > 1 {
+      let canonical = canonicalWinner(among: txnIds)
+      for txnId in txnIds where txnId != canonical {
+        lossesByTxn[txnId, default: 0] += 1
+      }
+    }
+
+    // A losing transaction is wholly-duplicate iff every one of its
+    // legs is a duplicate (lost-group participant) — i.e. no unique
+    // legs would be lost by deleting it. Walking the candidates'
+    // legs gives us the per-transaction leg count; comparing it to
+    // the lost-group count classifies the transaction.
+    var toDelete: [UUID] = []
+    var skipped: [UUID] = []
+    for transaction in candidates {
+      let losses = lossesByTxn[transaction.id, default: 0]
+      guard losses > 0 else { continue }
+      let duplicateLegCount = duplicateLegCount(
+        transaction: transaction,
+        groups: groups,
+        touchedExternalIds: touchedExternalIds)
+      if duplicateLegCount == transaction.legs.count {
+        toDelete.append(transaction.id)
+      } else {
+        skipped.append(transaction.id)
+      }
+    }
+    toDelete.sort { $0.uuidString.lowercased() < $1.uuidString.lowercased() }
+    skipped.sort { $0.uuidString.lowercased() < $1.uuidString.lowercased() }
+    return CollapsePlan(transactionsToDelete: toDelete, skippedMixed: skipped)
+  }
+
+  /// Builds the `(accountId, externalId) → {transactionIds}` map
+  /// scoped to legs whose `externalId` is in `touchedExternalIds`.
+  static func buildGroups(
+    candidates: [Transaction],
+    touchedExternalIds: Set<String>
+  ) -> [GroupKey: Set<UUID>] {
+    var groups: [GroupKey: Set<UUID>] = [:]
+    for transaction in candidates {
+      for leg in transaction.legs {
+        guard let accountId = leg.accountId,
+          let externalId = leg.externalId,
+          touchedExternalIds.contains(externalId)
+        else { continue }
+        let key = GroupKey(accountId: accountId, externalId: externalId)
+        groups[key, default: []].insert(transaction.id)
+      }
+    }
+    return groups
+  }
+
+  /// Counts a transaction's legs that participate in a multi-
+  /// transaction group keyed by `(accountId, externalId)`. Used to
+  /// distinguish wholly-duplicate transactions from mixed ones.
+  private static func duplicateLegCount(
+    transaction: Transaction,
+    groups: [GroupKey: Set<UUID>],
+    touchedExternalIds: Set<String>
+  ) -> Int {
+    var count = 0
+    for leg in transaction.legs {
+      guard let accountId = leg.accountId,
+        let externalId = leg.externalId,
+        touchedExternalIds.contains(externalId)
+      else { continue }
+      let key = GroupKey(accountId: accountId, externalId: externalId)
+      if let groupTxns = groups[key], groupTxns.count > 1 {
+        count += 1
+      }
+    }
+    return count
+  }
+
+  /// Lex-min `transaction.id.uuidString.lowercased()`. UUIDv4 ids on
+  /// every device share the same alphabet, and `lowercased()` is
+  /// locale-independent for the hex-only character set, so every
+  /// device's deduper picks the same survivor.
+  static func canonicalWinner(among ids: Set<UUID>) -> UUID {
+    // `Set` is unordered; pick the lex-min explicitly so the result is
+    // deterministic. Force-unwrap: callers gate on `txnIds.count > 1`.
+    guard let winner = ids.min(by: { $0.uuidString.lowercased() < $1.uuidString.lowercased() })
+    else {
+      preconditionFailure("canonicalWinner called with empty id set")
+    }
+    return winner
+  }
+}


### PR DESCRIPTION
## Summary
- Stage 8 of [plans/2026-05-05-crypto-wallet-import-plan.md](plans/2026-05-05-crypto-wallet-import-plan.md). Adds `CrossDeviceLegDeduper`, a post-CKSyncEngine reconciliation pass that collapses cross-device duplicate `TransactionLeg` rows into one canonical leg per `(accountId, externalId)` using deterministic UUID lex-order tiebreak — both devices converge independently without further coordination.
- All deletes route through `TransactionRepository.delete(id:)` (the load-bearing detail from the design's §"Multi-device race window") so the change propagates back through CKSyncEngine to other devices via the repository's existing `onRecordDeleted` hook.
- New `TransactionRepository.transactions(touchingExternalIds:)` returns full `Transaction` shapes scoped to the `externalIds` carried by the just-applied CK batch, so the deduper has the parent-id info `delete(id:)` needs. Plan-pinning test verifies the underlying query rides the `leg_dedup_by_account_external` partial unique index.

## Implementation choices
- The deduper is `@MainActor`, takes a `TransactionRepository`, and is wired in via `SyncCoordinator+CrossDeviceLegDedup` after `applyRemoteChanges` returns success. Touched-set extraction (`extractTouchedExternalIds(saved:)`) reads `externalId` directly off `TransactionLegRecord` CKRecords pre-apply.
- Mixed transactions — one duplicate leg + one unique leg — are skipped and logged. Per-leg dedup within a single transaction is out of scope for v1 per the design.
- Test fixture drops the partial unique index in `TestBackend` so the suite can seed two transactions sharing `(accountId, externalId)`. The deduper itself only does `SELECT` and `delete(id:)`, never re-inserts that would re-trip the index.

## Test plan
- [x] `just test` clean on both iOS Simulator and macOS (2297 tests).
- [x] `just format-check` clean.
- [x] New `CrossDeviceLegDeduperTests` cover: two-device race converges; both devices independently pick the same canonical; idempotent on converged state; touched-set scoping; empty touched set is a no-op; deletes route through `TransactionRepository.delete(id:)` (verified via `RecordingTransactionRepository`).
- [x] New `CrossDeviceLegDeduperEdgeCaseTests` cover: mixed transactions skipped, deterministic across input ordering (every permutation of three duplicate transactions picks the same canonical).
- [x] New `CrossDeviceLegDeduperPlanPinningTests` pins the `IN`-on-`external_id` query to the partial unique index `leg_dedup_by_account_external`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)