### PR TITLE
feat(crypto): account creation UI for wallets

### DIFF
--- a/Features/Accounts/Views/CreateAccountView.swift
+++ b/Features/Accounts/Views/CreateAccountView.swift
@@ -14,20 +14,35 @@ struct CreateAccountView: View {
   @State private var errorMessage: String?
   @FocusState private var focusedField: Field?
 
+  // MARK: - Crypto-only form state
+  //
+  // Held at this level so the shared shell (Cancel + Save toolbar) and
+  // the shared name + type Picker keep one set of bindings regardless of
+  // which type is currently selected. Switching from `.crypto` back to
+  // `.bank` simply hides these fields; the values are preserved so the
+  // user can flip back without retyping.
+
+  @State private var cryptoChain: ChainConfig = .ethereum
+  @State private var cryptoWalletAddress = ""
+
   let instrument: Instrument
   let accountStore: AccountStore
+  let cryptoSyncStore: CryptoSyncStore?
 
   private enum Field: Hashable {
     case name
     case balance
+    case walletAddress
   }
 
   init(
     instrument: Instrument,
-    accountStore: AccountStore
+    accountStore: AccountStore,
+    cryptoSyncStore: CryptoSyncStore? = nil
   ) {
     self.instrument = instrument
     self.accountStore = accountStore
+    self.cryptoSyncStore = cryptoSyncStore
     _currency = State(initialValue: instrument)
   }
 
@@ -43,7 +58,12 @@ struct CreateAccountView: View {
   private var form: some View {
     Form {
       Section {
-        detailsFields
+        sharedFields
+        if type == .crypto {
+          cryptoFields
+        } else {
+          standardFields
+        }
       }
       if let errorMessage {
         Section {
@@ -72,10 +92,12 @@ struct CreateAccountView: View {
     }
   }
 
-  @ViewBuilder private var detailsFields: some View {
-    TextField("Name", text: $name, prompt: Text("e.g. MyBank - Savings"))
+  // Shared name + type picker. The crypto branch reuses both, so they
+  // live above the type-specific fork.
+  @ViewBuilder private var sharedFields: some View {
+    TextField("Name", text: $name, prompt: Text(namePrompt))
       .focused($focusedField, equals: .name)
-      .onSubmit { focusedField = .balance }
+      .onSubmit { focusedField = type == .crypto ? .walletAddress : .balance }
       .accessibilityLabel("Account name")
 
     Picker("Account Type", selection: $type) {
@@ -83,7 +105,9 @@ struct CreateAccountView: View {
         Text(type.displayName).tag(type)
       }
     }
+  }
 
+  @ViewBuilder private var standardFields: some View {
     InstrumentPickerField(label: "Currency", kinds: [.fiatCurrency], selection: $currency)
 
     TextField(
@@ -101,8 +125,26 @@ struct CreateAccountView: View {
     DatePicker("Opening Date", selection: $date, displayedComponents: .date)
   }
 
+  @ViewBuilder private var cryptoFields: some View {
+    CryptoAccountCreationView(
+      chain: $cryptoChain,
+      walletAddressInput: $cryptoWalletAddress)
+  }
+
+  private var namePrompt: String {
+    switch type {
+    case .crypto: return "e.g. Hardware Wallet — Ethereum"
+    default: return "e.g. MyBank - Savings"
+    }
+  }
+
   private var isValid: Bool {
-    !name.trimmingCharacters(in: .whitespaces).isEmpty
+    let trimmedName = name.trimmingCharacters(in: .whitespaces)
+    guard !trimmedName.isEmpty else { return false }
+    if type == .crypto {
+      return Account.validatedWalletAddress(cryptoWalletAddress) != nil
+    }
+    return true
   }
 
   private func submit() async {
@@ -110,6 +152,12 @@ struct CreateAccountView: View {
 
     isSubmitting = true
     errorMessage = nil
+
+    if type == .crypto {
+      await submitCrypto()
+      isSubmitting = false
+      return
+    }
 
     let selectedInstrument = currency
     let openingBalance = InstrumentAmount(quantity: balanceDecimal, instrument: selectedInstrument)
@@ -127,6 +175,21 @@ struct CreateAccountView: View {
     } catch {
       errorMessage = error.localizedDescription
       isSubmitting = false
+    }
+  }
+
+  private func submitCrypto() async {
+    let logic = CryptoAccountCreationLogic(
+      accountStore: accountStore, cryptoSyncStore: cryptoSyncStore)
+    let outcome = await logic.submit(
+      name: name, chain: cryptoChain, walletAddressInput: cryptoWalletAddress)
+    switch outcome {
+    case .created:
+      dismiss()
+    case .invalidAddress:
+      errorMessage = "Enter a valid 0x wallet address."
+    case .failure(let error):
+      errorMessage = error.localizedDescription
     }
   }
 }

--- a/Features/Crypto/CryptoAccountCreationView.swift
+++ b/Features/Crypto/CryptoAccountCreationView.swift
@@ -1,0 +1,176 @@
+// Features/Crypto/CryptoAccountCreationView.swift
+import Foundation
+import SwiftUI
+
+/// Form fields for creating a new `AccountType.crypto` account.
+///
+/// Renders the crypto-specific portion of the account-creation sheet:
+/// chain picker (ETH / OP / Base / Polygon) and a wallet-address text
+/// field. Per the design spec, the account's `instrument` is set
+/// automatically to the chain's native instrument (ETH for
+/// Ethereum/OP/Base, MATIC for Polygon); per-token positions emerge
+/// from leg aggregation as wallet syncs land.
+///
+/// Address validation:
+///
+/// - Trim whitespace; lowercase the result.
+/// - Accept anything matching `^0x[a-f0-9]{40}$` (canonical lowercase
+///   form). Mixed-case checksum input is tolerated and normalised down
+///   to lowercase.
+/// - Pasting an ENS name (`vitalik.eth`) shows the "ENS not supported"
+///   inline hint — v1 cannot resolve ENS to a 0x address.
+///
+/// The shared shell in `CreateAccountView` owns the Form / NavigationStack
+/// / toolbar. This view exposes:
+///
+/// - `body` — the chain picker and address field (rendered inside the
+///   parent `Form`).
+/// - `CryptoAccountCreationLogic` — pure form-logic type used by the
+///   parent's Save button to validate and submit; kept separate so
+///   `CryptoAccountCreationLogicTests` exercise the contract directly
+///   without spinning up a SwiftUI view.
+struct CryptoAccountCreationView: View {
+  @Binding var chain: ChainConfig
+  @Binding var walletAddressInput: String
+
+  var body: some View {
+    Picker("Chain", selection: $chain) {
+      ForEach(ChainConfig.all, id: \.chainId) { config in
+        Text(config.displayName).tag(config)
+      }
+    }
+    .accessibilityIdentifier(UITestIdentifiers.CryptoAccountCreation.chainPicker)
+
+    TextField(
+      "Wallet Address",
+      text: $walletAddressInput,
+      prompt: Text("0x…")
+    )
+    #if os(iOS)
+      .textInputAutocapitalization(.never)
+      .autocorrectionDisabled(true)
+    #endif
+    .accessibilityLabel("Wallet address")
+    .accessibilityIdentifier(UITestIdentifiers.CryptoAccountCreation.walletAddressField)
+
+    if let hint = Self.inlineAddressHint(for: walletAddressInput) {
+      Label(hint, systemImage: "info.circle")
+        .foregroundStyle(.secondary)
+        .font(.caption)
+    }
+  }
+
+  /// Inline hint shown beneath the address field when the user has
+  /// typed something that looks like an ENS name. v1 doesn't resolve
+  /// ENS — point the user at the underlying 0x address. `nonisolated`
+  /// so unit tests can call it directly without bouncing through the
+  /// `@MainActor` `View` protocol.
+  nonisolated static func inlineAddressHint(for raw: String) -> String? {
+    let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return nil }
+    if trimmed.lowercased().hasPrefix("0x") { return nil }
+    if trimmed.contains(".") {
+      return "ENS resolution not supported in v1 — paste a 0x address."
+    }
+    return nil
+  }
+}
+
+// MARK: - Submit logic
+
+/// Pure form-logic helper for the crypto branch of `CreateAccountView`.
+/// Owns the create-account + kick-off-sync sequence so the parent view
+/// can dispatch from its Save button without relying on a transient
+/// SwiftUI view instance, and so `CryptoAccountCreationLogicTests` can
+/// exercise the contract end-to-end against `TestBackend`.
+@MainActor
+struct CryptoAccountCreationLogic {
+  let accountStore: AccountStore
+  /// May be `nil` in degraded launches (preview / no instrument
+  /// registry). When `nil`, account creation still proceeds; the first
+  /// sync simply isn't kicked off — the next scenePhase `.active`
+  /// stale-check will pick it up.
+  let cryptoSyncStore: CryptoSyncStore?
+
+  /// Output of `submit(name:chain:walletAddressInput:)`. The parent
+  /// surface uses `.created` to dismiss the sheet and `.failure` /
+  /// `.invalidAddress` to show an inline error message.
+  enum Outcome: Sendable {
+    case created(Account)
+    case invalidAddress
+    case failure(Error)
+  }
+
+  /// Persists the new crypto account and kicks off its first sync.
+  /// Returns the outcome rather than mutating shared state directly so
+  /// the parent view can decide how to surface success vs failure.
+  func submit(name: String, chain: ChainConfig, walletAddressInput: String) async -> Outcome {
+    guard let walletAddress = Account.validatedWalletAddress(walletAddressInput) else {
+      return .invalidAddress
+    }
+    let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmedName.isEmpty else { return .invalidAddress }
+
+    let account = Account(
+      name: trimmedName,
+      type: .crypto,
+      instrument: chain.nativeInstrument,
+      walletAddress: walletAddress,
+      chainId: chain.chainId
+    )
+
+    do {
+      let created = try await accountStore.create(account)
+      // Kick off the initial sync so the wallet's history starts
+      // loading immediately. The store internally guards against
+      // duplicate in-flight syncs, so the next scenePhase `.active`
+      // trigger collapses with this dispatch rather than queueing a
+      // redundant pass. A `nil` `cryptoSyncStore` (degraded launch)
+      // leaves the account stale; the next stale-sync pass picks it
+      // up.
+      if let cryptoSyncStore {
+        await cryptoSyncStore.syncAccount(created)
+      }
+      return .created(created)
+    } catch {
+      return .failure(error)
+    }
+  }
+}
+
+// MARK: - Address validation
+
+extension Account {
+  /// Validates an EVM-style wallet address. Accepts the canonical
+  /// lowercase form and mixed-case checksum form; rejects anything
+  /// else (too short, missing `0x` prefix, ENS names, empty). Returns
+  /// the canonical lowercased form on success so callers can persist a
+  /// single normalised representation; returns `nil` otherwise.
+  ///
+  /// Trimming surrounding whitespace is part of the contract — paste
+  /// flows commonly include a trailing newline from the source string.
+  static func validatedWalletAddress(_ raw: String) -> String? {
+    let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    guard trimmed.count == 42, trimmed.hasPrefix("0x") else { return nil }
+    let suffix = trimmed.dropFirst(2)
+    let isHex = suffix.allSatisfy { character in
+      character.isASCII
+        && (character.isNumber
+          || ("a"..."f").contains(character))
+    }
+    return isHex ? trimmed : nil
+  }
+}
+
+#Preview {
+  @Previewable @State var chain: ChainConfig = .ethereum
+  @Previewable @State var address = ""
+
+  Form {
+    CryptoAccountCreationView(
+      chain: $chain,
+      walletAddressInput: $address)
+  }
+  .formStyle(.grouped)
+  .frame(width: 500, height: 320)
+}

--- a/Features/Navigation/SidebarView.swift
+++ b/Features/Navigation/SidebarView.swift
@@ -108,7 +108,9 @@ struct SidebarView: View {
     }
     .sheet(isPresented: $showCreateAccountSheet) {
       CreateAccountView(
-        instrument: session.profile.instrument, accountStore: accountStore)
+        instrument: session.profile.instrument,
+        accountStore: accountStore,
+        cryptoSyncStore: session.cryptoSyncStore)
     }
     .sheet(item: $accountToEdit) { account in
       EditAccountView(

--- a/MoolahTests/Features/Crypto/CryptoAccountCreationLogicTests.swift
+++ b/MoolahTests/Features/Crypto/CryptoAccountCreationLogicTests.swift
@@ -1,0 +1,79 @@
+// MoolahTests/Features/Crypto/CryptoAccountCreationLogicTests.swift
+import Foundation
+import Testing
+
+@testable import Moolah
+
+/// Pure-logic tests for `Account.validatedWalletAddress` — the
+/// trim/lowercase/regex contract powering the wallet-address field in
+/// `CryptoAccountCreationView`. The store-side flow (account creation
+/// + sync kick-off) lives in `CryptoAccountCreationStoreTests`.
+@Suite("Account.validatedWalletAddress")
+struct CryptoAccountCreationLogicTests {
+  // 40 hex characters following the `0x` prefix; matches the canonical
+  // form. Reused across happy-path tests so the assertion stays anchored
+  // on what's being validated rather than on a magic literal.
+  private static let canonicalLowercase = "0x" + String(repeating: "a", count: 40)
+
+  @Test("Canonical lowercase form passes through unchanged")
+  func canonicalLowercaseAddressIsAccepted() {
+    #expect(Account.validatedWalletAddress(Self.canonicalLowercase) == Self.canonicalLowercase)
+  }
+
+  @Test("Mixed-case checksum input is normalised to lowercase")
+  func mixedCaseChecksumIsLowercased() {
+    let mixedCase = "0xAbCdEf0123456789aBcDeF0123456789AbCdEf01"
+    let result = Account.validatedWalletAddress(mixedCase)
+    #expect(result == mixedCase.lowercased())
+  }
+
+  @Test("Surrounding whitespace is trimmed before validation")
+  func surroundingWhitespaceIsTrimmed() {
+    let padded = "   \(Self.canonicalLowercase)\n"
+    #expect(Account.validatedWalletAddress(padded) == Self.canonicalLowercase)
+  }
+
+  @Test("Too-short address is rejected")
+  func tooShortAddressIsRejected() {
+    #expect(Account.validatedWalletAddress("0x123") == nil)
+  }
+
+  @Test("ENS-style name is rejected")
+  func ensNameIsRejected() {
+    #expect(Account.validatedWalletAddress("vitalik.eth") == nil)
+  }
+
+  @Test("Empty string is rejected")
+  func emptyStringIsRejected() {
+    #expect(Account.validatedWalletAddress("") == nil)
+  }
+
+  @Test("42-character input without 0x prefix is rejected")
+  func missingPrefixIsRejected() {
+    let noPrefix = String(repeating: "a", count: 42)
+    #expect(Account.validatedWalletAddress(noPrefix) == nil)
+  }
+
+  @Test("Non-hex characters in the address are rejected")
+  func nonHexCharactersAreRejected() {
+    // Replace one digit with `g`, which is outside [0-9a-f].
+    let invalid = "0x" + String(repeating: "a", count: 39) + "g"
+    #expect(Account.validatedWalletAddress(invalid) == nil)
+  }
+
+  @Test("ENS-style hint surfaces for non-0x input containing a dot")
+  func ensInputProducesInlineHint() {
+    let hint = CryptoAccountCreationView.inlineAddressHint(for: "vitalik.eth")
+    #expect(hint != nil)
+  }
+
+  @Test("Inline hint is suppressed when the user has typed a 0x prefix")
+  func zeroXInputSuppressesInlineHint() {
+    #expect(CryptoAccountCreationView.inlineAddressHint(for: "0xabc") == nil)
+  }
+
+  @Test("Inline hint is suppressed for empty input")
+  func emptyInputProducesNoHint() {
+    #expect(CryptoAccountCreationView.inlineAddressHint(for: "") == nil)
+  }
+}

--- a/MoolahTests/Features/Crypto/CryptoAccountCreationStoreTests.swift
+++ b/MoolahTests/Features/Crypto/CryptoAccountCreationStoreTests.swift
@@ -1,0 +1,232 @@
+// MoolahTests/Features/Crypto/CryptoAccountCreationStoreTests.swift
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+/// End-to-end tests for `CryptoAccountCreationLogic.submit(...)`.
+///
+/// Drives the full create-and-sync sequence through real `AccountStore`
+/// and `CryptoSyncStore` instances backed by `TestBackend`. The Alchemy
+/// client is the only piece stubbed — these tests own the contract that
+/// a successful save kicks off the per-account sync, and a failed
+/// validation skips it.
+@Suite("CryptoAccountCreationLogic — submit")
+@MainActor
+struct CryptoAccountCreationStoreTests {
+  // Pinned clock matches the `CryptoSyncStore` test pattern; keeps
+  // `lastSyncedAt` deterministic when we assert against post-sync state.
+  nonisolated static let pinnedNow = Date(timeIntervalSince1970: 1_700_000_000)
+  // Canonical lowercase address used for happy-path tests; matches the
+  // 42-char `0x…` regex enforced by `Account.validatedWalletAddress`.
+  static let validAddress = "0x" + String(repeating: "a", count: 40)
+
+  private struct Fixture {
+    let accountStore: AccountStore
+    let cryptoSyncStore: CryptoSyncStore
+    let backend: CloudKitBackend
+    let database: DatabaseQueue
+    let alchemy: RecordingAlchemyClientStub
+  }
+
+  private func makeFixture() throws -> Fixture {
+    let (backend, database) = try TestBackend.create()
+    let alchemy = RecordingAlchemyClientStub()
+    alchemy.setTransfersResponse(.transfers([]))
+    let registry = GRDBInstrumentRegistryRepository(database: database)
+    let discovery = CryptoTokenDiscoveryService(
+      registry: registry,
+      resolver: CountingRegistrationResolver(),
+      alchemy: alchemy)
+    let walletSyncEngine = WalletSyncEngine(
+      alchemy: alchemy,
+      discovery: discovery,
+      walletSyncState: backend.walletSyncState,
+      importOriginFactory: { accountId in
+        ImportOrigin(
+          rawDescription: "wallet:\(accountId.uuidString)",
+          rawAmount: 0,
+          importedAt: Self.pinnedNow,
+          importSessionId: UUID(),
+          parserIdentifier: "alchemy-wallet-sync")
+      })
+    let walletApplyEngine = WalletApplyEngine(
+      transactions: backend.transactions,
+      walletSyncState: backend.walletSyncState,
+      importRules: NoOpWalletImportRulesEngine(),
+      clock: { Self.pinnedNow })
+    let cryptoSyncStore = CryptoSyncStore(
+      walletSyncEngine: walletSyncEngine,
+      walletApplyEngine: walletApplyEngine,
+      walletSyncState: backend.walletSyncState,
+      accounts: backend.accounts,
+      clock: { Self.pinnedNow })
+    let accountStore = AccountStore(
+      repository: backend.accounts,
+      conversionService: FixedConversionService(),
+      targetInstrument: .defaultTestInstrument)
+    return Fixture(
+      accountStore: accountStore,
+      cryptoSyncStore: cryptoSyncStore,
+      backend: backend,
+      database: database,
+      alchemy: alchemy)
+  }
+
+  @Test("Successful submit creates the account with the chain's native instrument")
+  func successfulSubmitCreatesCryptoAccount() async throws {
+    let fixture = try makeFixture()
+    let logic = CryptoAccountCreationLogic(
+      accountStore: fixture.accountStore,
+      cryptoSyncStore: fixture.cryptoSyncStore)
+
+    let outcome = await logic.submit(
+      name: "Hardware Wallet",
+      chain: .ethereum,
+      walletAddressInput: Self.validAddress)
+
+    guard case .created(let created) = outcome else {
+      Issue.record("Expected .created outcome, got \(outcome)")
+      return
+    }
+    #expect(created.type == .crypto)
+    #expect(created.walletAddress == Self.validAddress)
+    #expect(created.chainId == ChainConfig.ethereum.chainId)
+    #expect(created.instrument == ChainConfig.ethereum.nativeInstrument)
+    #expect(created.name == "Hardware Wallet")
+
+    // The store optimistically populates its observable list, so the
+    // new account is visible immediately without a reload round-trip.
+    #expect(fixture.accountStore.accounts.count == 1)
+    #expect(fixture.accountStore.accounts.first?.id == created.id)
+  }
+
+  @Test("Polygon chain produces a MATIC-native account")
+  func polygonChainSetsMaticInstrument() async throws {
+    let fixture = try makeFixture()
+    let logic = CryptoAccountCreationLogic(
+      accountStore: fixture.accountStore,
+      cryptoSyncStore: fixture.cryptoSyncStore)
+
+    let outcome = await logic.submit(
+      name: "Polygon Hot Wallet",
+      chain: .polygon,
+      walletAddressInput: Self.validAddress)
+
+    guard case .created(let created) = outcome else {
+      Issue.record("Expected .created outcome, got \(outcome)")
+      return
+    }
+    #expect(created.chainId == ChainConfig.polygon.chainId)
+    #expect(created.instrument == ChainConfig.polygon.nativeInstrument)
+    #expect(created.instrument.ticker == "MATIC")
+  }
+
+  @Test("Successful submit kicks off the initial Alchemy sync for the new account")
+  func successfulSubmitTriggersInitialSync() async throws {
+    let fixture = try makeFixture()
+    let logic = CryptoAccountCreationLogic(
+      accountStore: fixture.accountStore,
+      cryptoSyncStore: fixture.cryptoSyncStore)
+
+    let outcome = await logic.submit(
+      name: "Sync Wallet",
+      chain: .ethereum,
+      walletAddressInput: Self.validAddress)
+    guard case .created = outcome else {
+      Issue.record("Expected .created outcome, got \(outcome)")
+      return
+    }
+
+    // The store invokes the build phase exactly once for the newly-
+    // created account, with the canonical wallet address it persisted.
+    #expect(fixture.alchemy.recordedCalls.count == 1)
+    #expect(fixture.alchemy.recordedCalls.first?.walletAddress == Self.validAddress)
+  }
+
+  @Test("Invalid address aborts before any repository or sync work")
+  func invalidAddressShortCircuits() async throws {
+    let fixture = try makeFixture()
+    let logic = CryptoAccountCreationLogic(
+      accountStore: fixture.accountStore,
+      cryptoSyncStore: fixture.cryptoSyncStore)
+
+    let outcome = await logic.submit(
+      name: "Bad Address Wallet",
+      chain: .ethereum,
+      walletAddressInput: "vitalik.eth")
+
+    guard case .invalidAddress = outcome else {
+      Issue.record("Expected .invalidAddress, got \(outcome)")
+      return
+    }
+    // No account was persisted and the build phase was never invoked.
+    #expect(fixture.accountStore.accounts.isEmpty)
+    #expect(fixture.alchemy.recordedCalls.isEmpty)
+  }
+
+  @Test("Empty/whitespace-only name is rejected without persisting")
+  func emptyNameShortCircuits() async throws {
+    let fixture = try makeFixture()
+    let logic = CryptoAccountCreationLogic(
+      accountStore: fixture.accountStore,
+      cryptoSyncStore: fixture.cryptoSyncStore)
+
+    let outcome = await logic.submit(
+      name: "   ",
+      chain: .ethereum,
+      walletAddressInput: Self.validAddress)
+
+    guard case .invalidAddress = outcome else {
+      Issue.record("Expected .invalidAddress for empty name, got \(outcome)")
+      return
+    }
+    #expect(fixture.accountStore.accounts.isEmpty)
+    #expect(fixture.alchemy.recordedCalls.isEmpty)
+  }
+
+  @Test("Whitespace and mixed case in the address are normalised before persisting")
+  func addressIsTrimmedAndLowercased() async throws {
+    let fixture = try makeFixture()
+    let logic = CryptoAccountCreationLogic(
+      accountStore: fixture.accountStore,
+      cryptoSyncStore: fixture.cryptoSyncStore)
+
+    // Mix of leading whitespace, mixed case, and trailing newline.
+    let raw = "  0xABCDEF0123456789ABCDEF0123456789ABCDEF01\n"
+    let outcome = await logic.submit(
+      name: "Padded Address Wallet",
+      chain: .ethereum,
+      walletAddressInput: raw)
+
+    guard case .created(let created) = outcome else {
+      Issue.record("Expected .created outcome, got \(outcome)")
+      return
+    }
+    #expect(
+      created.walletAddress == raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased())
+  }
+
+  @Test("Nil cryptoSyncStore: account is created, sync is skipped")
+  func nilSyncStoreSkipsKickOff() async throws {
+    let fixture = try makeFixture()
+    let logic = CryptoAccountCreationLogic(
+      accountStore: fixture.accountStore,
+      cryptoSyncStore: nil)
+
+    let outcome = await logic.submit(
+      name: "Degraded Launch Wallet",
+      chain: .ethereum,
+      walletAddressInput: Self.validAddress)
+    guard case .created = outcome else {
+      Issue.record("Expected .created outcome, got \(outcome)")
+      return
+    }
+    // Account persisted but no sync work fired (the test's sync store
+    // exists but was never handed to the logic, so the alchemy stub
+    // saw no activity).
+    #expect(fixture.accountStore.accounts.count == 1)
+    #expect(fixture.alchemy.recordedCalls.isEmpty)
+  }
+}

--- a/UITestSupport/UITestIdentifiers.swift
+++ b/UITestSupport/UITestIdentifiers.swift
@@ -204,6 +204,18 @@ public enum UITestIdentifiers {
     public static let cryptoTabTitle = "Crypto"
   }
 
+  public enum CryptoAccountCreation {
+    /// Chain picker (Ethereum / OP Mainnet / Base / Polygon) inside the
+    /// crypto branch of `CreateAccountView`. Pinned so a UI test can
+    /// switch chains without depending on rendered display names.
+    public static let chainPicker = "createAccount.crypto.chainPicker"
+
+    /// Wallet-address text field inside the crypto branch of
+    /// `CreateAccountView`. The user pastes a `0x…` address here;
+    /// validation lives in `Account.validatedWalletAddress`.
+    public static let walletAddressField = "createAccount.crypto.walletAddress"
+  }
+
   public enum CryptoSettings {
     /// Root container of the `CryptoSettingsView` Form. Sentinel for the
     /// "Crypto tab is on screen" post-condition after switching tabs in the


### PR DESCRIPTION
## Summary

- Stage 10 of `plans/2026-05-05-crypto-wallet-import-plan.md`. Adds `CryptoAccountCreationView` (chain picker + wallet-address field) and the `CryptoAccountCreationLogic` helper that drives create-account + initial-sync.
- Branched into `CreateAccountView`: when the user picks **Crypto Wallet** from the type picker, the standard currency / opening-balance fields are replaced with chain (ETH / OP / Base / Polygon) + wallet address. The chain's native instrument (ETH or MATIC) is set automatically; per-token positions emerge from leg aggregation.
- On Save: persists the new `Account`, then awaits `CryptoSyncStore.syncAccount(...)` so the wallet's history starts loading immediately. Degraded launches (no `CryptoSyncStore`) still create the account; the next stale-sync pass picks it up.
- Inline hint when the user types something that looks like an ENS name ("ENS resolution not supported in v1 — paste a 0x address").

Stacked on top of Stage 9 ([PR #769](https://github.com/ajsutton/moolah-native/pull/769)) — already merged to `main`, so this PR targets `main` directly.

## Test plan
- [x] `just test` — 2318 tests on macOS, 2293 on iOS pass.
- [x] `just format-check` clean.
- [x] No SwiftLint baseline edits.
- [x] New unit tests cover address validation (canonical, mixed-case, whitespace, too-short, ENS, missing prefix, non-hex, empty, ENS hint, non-dotted hint).
- [x] New store-level tests cover happy path + sync kick-off, Polygon → MATIC instrument, invalid-address short circuit, empty-name rejection, address normalisation, nil-sync-store degraded launch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)