### PR TITLE
feat(crypto): settings UI — API key, accounts, discovered tokens, spam

### DIFF
--- a/App/ProfileSession+CryptoSync.swift
+++ b/App/ProfileSession+CryptoSync.swift
@@ -15,9 +15,21 @@ extension ProfileSession {
     return try? store.restoreString()
   }
 
-  /// Builds the `CryptoSyncStore` for a profile. Returns `nil` when the
-  /// profile has no `instrumentRegistry` (preview / degraded launches);
-  /// the wallet-import feature is unavailable in that mode.
+  /// Output of `makeCryptoSyncWiring`. The discovery actor is plumbed
+  /// out alongside the store so the Stage 11 Discovered Tokens inbox
+  /// can drive `reResolve(_:chain:)` on the same actor instance the
+  /// sync engine uses — this preserves the in-flight coalescer's
+  /// "one round-trip per `(chainId, contractAddress)`" guarantee
+  /// across the manual + automatic re-resolution paths.
+  struct CryptoSyncWiring {
+    let store: CryptoSyncStore
+    let discovery: CryptoTokenDiscoveryService
+  }
+
+  /// Builds the `CryptoSyncStore` (and exposes the underlying
+  /// `CryptoTokenDiscoveryService`) for a profile. Returns `nil` when
+  /// the profile has no `instrumentRegistry` (preview / degraded
+  /// launches); the wallet-import feature is unavailable in that mode.
   ///
   /// Live wiring uses:
   ///
@@ -37,11 +49,11 @@ extension ProfileSession {
   /// them to set the key. This avoids a `nil`-AlchemyClient branch that
   /// would silently skip every crypto account.
   @MainActor
-  static func makeCryptoSyncStore(
+  static func makeCryptoSyncWiring(
     backend: BackendProvider,
     registry: (any InstrumentRegistryRepository)?,
     cryptoPriceService: CryptoPriceService
-  ) -> CryptoSyncStore? {
+  ) -> CryptoSyncWiring? {
     guard let registry else { return nil }
 
     let rateLimiter = RateLimiter(permitsPerSecond: 25)
@@ -67,10 +79,11 @@ extension ProfileSession {
       transactions: backend.transactions,
       walletSyncState: backend.walletSyncState,
       importRules: NoOpWalletImportRulesEngine())
-    return CryptoSyncStore(
+    let store = CryptoSyncStore(
       walletSyncEngine: walletSyncEngine,
       walletApplyEngine: walletApplyEngine,
       walletSyncState: backend.walletSyncState,
       accounts: backend.accounts)
+    return CryptoSyncWiring(store: store, discovery: discovery)
   }
 }

--- a/App/ProfileSession+ValuationMigration.swift
+++ b/App/ProfileSession+ValuationMigration.swift
@@ -1,0 +1,35 @@
+import Foundation
+import OSLog
+
+/// Local logger for the valuation-mode migration extension. Scoped to
+/// the extension file so the helper does not need access to
+/// `ProfileSession`'s private `logger`. Same subsystem / category for
+/// log-stream continuity.
+private let valuationMigrationLogger = Logger(
+  subsystem: "com.moolah.app", category: "ProfileSession")
+
+// `ValuationModeMigration` per-profile bootstrap. Lives here rather
+// than in the main `ProfileSession` body so the latter stays under
+// SwiftLint's `file_length` threshold. The migration itself is
+// non-fatal — auto-detect read sites are still in place at this
+// rollout stage, so a thrown error gets logged but never surfaces to
+// the caller.
+extension ProfileSession {
+  /// Runs `ValuationModeMigration` for this profile. Called from
+  /// `setUp()` after the SwiftData → GRDB migration so the account /
+  /// investment-value rows are visible to GRDB-backed repositories.
+  /// Module-internal so `setUp()` (which lives on the main session
+  /// type) can call it without bouncing through a closure.
+  func runValuationModeMigration() async {
+    let migration = ValuationModeMigration(
+      profileId: profile.id,
+      accountRepository: backend.accounts,
+      userDefaults: .standard)
+    do {
+      try await migration.run()
+    } catch {
+      valuationMigrationLogger.error(
+        "ValuationModeMigration failed: \(error.localizedDescription, privacy: .public)")
+    }
+  }
+}

--- a/App/ProfileSession.swift
+++ b/App/ProfileSession.swift
@@ -38,8 +38,15 @@ final class ProfileSession: Identifiable {
   let coinGeckoCatalog: (any CoinGeckoCatalog)?
   let tokenResolutionClient: (any TokenResolutionClient)?
   /// Orchestrator for crypto-wallet auto-import. `nil` when the profile
-  /// has no `instrumentRegistry` (preview / degraded launches).
-  let cryptoSyncStore: CryptoSyncStore?
+  /// has no `instrumentRegistry` (preview / degraded launches). Set
+  /// once in `finishInit` after `init` returns; effectively `let` from
+  /// the consumer's perspective. `private(set)` so callers cannot
+  /// reassign.
+  private(set) var cryptoSyncStore: CryptoSyncStore?
+
+  /// Token resolver shared with the inbox UI. Nil with `cryptoSyncStore`.
+  /// Same lifecycle pattern as `cryptoSyncStore`.
+  private(set) var cryptoTokenDiscovery: CryptoTokenDiscoveryService?
   let importStore: ImportStore
   let importRuleStore: ImportRuleStore
   let importPreferences: ImportPreferences
@@ -172,21 +179,28 @@ final class ProfileSession: Identifiable {
     self.folderScanner = importPipeline.scanner
     self.folderWatcher = importPipeline.watcher
 
-    // Crypto-wallet auto-import. Lifecycle hooks live in
-    // `MoolahApp+Lifecycle` and `cleanupSync`.
-    self.cryptoSyncStore = Self.makeCryptoSyncStore(
-      backend: backend,
-      registry: registryWiring.registry,
+    finishInit(
+      syncCoordinator: syncCoordinator,
+      cryptoRegistry: registryWiring.registry,
       cryptoPriceService: services.cryptoPrice)
-
-    finishInit(syncCoordinator: syncCoordinator)
   }
 
   /// Tail of the initialiser — kept as a separate method so `init`
   /// stays under SwiftLint's `function_body_length` threshold. Wires
-  /// cross-store side effects, registers with the sync coordinator,
-  /// and starts the hourly `PRAGMA optimize` tick (issue #576).
-  private func finishInit(syncCoordinator: SyncCoordinator?) {
+  /// the crypto-wallet sync stores, cross-store side effects, the
+  /// sync coordinator, and starts the hourly `PRAGMA optimize` tick
+  /// (issue #576).
+  private func finishInit(
+    syncCoordinator: SyncCoordinator?,
+    cryptoRegistry: (any InstrumentRegistryRepository)?,
+    cryptoPriceService: CryptoPriceService
+  ) {
+    let cryptoWiring = Self.makeCryptoSyncWiring(
+      backend: backend,
+      registry: cryptoRegistry,
+      cryptoPriceService: cryptoPriceService)
+    self.cryptoSyncStore = cryptoWiring?.store
+    self.cryptoTokenDiscovery = cryptoWiring?.discovery
     wireCrossStoreSideEffects()
     registerWithSyncCoordinator(syncCoordinator)
     startPeriodicPragmaOptimize()
@@ -378,23 +392,7 @@ final class ProfileSession: Identifiable {
     try await task.value
   }
 
-  /// Runs `ValuationModeMigration` for this profile. Non-fatal: any
-  /// thrown error is logged but does not surface to the caller because
-  /// auto-detect read sites are still in place at this rollout stage.
-  /// Called from `setUp()` after the SwiftData → GRDB migration so the
-  /// account / investment-value rows are visible to GRDB-backed
-  /// repositories.
-  private func runValuationModeMigration() async {
-    let migration = ValuationModeMigration(
-      profileId: profile.id,
-      accountRepository: backend.accounts,
-      userDefaults: .standard)
-    do {
-      try await migration.run()
-    } catch {
-      logger.error(
-        "ValuationModeMigration failed: \(error.localizedDescription, privacy: .public)")
-    }
-  }
-
+  // `runValuationModeMigration` lives in
+  // `ProfileSession+ValuationMigration.swift` so this file stays under
+  // SwiftLint's `file_length` threshold.
 }

--- a/Backends/GRDB/Records/InstrumentRow+Mapping.swift
+++ b/Backends/GRDB/Records/InstrumentRow+Mapping.swift
@@ -87,4 +87,17 @@ extension InstrumentRow {
       cryptocompareSymbol: cryptocompareSymbol,
       binanceSymbol: binanceSymbol)
   }
+
+  /// All-nil `CryptoProviderMapping` for the row's id. Used by the
+  /// inbox / spam paths in `allCryptoRegistrations()` so a `.unpriced`
+  /// or `.spam` row without any resolved provider is still surfaceable
+  /// in the Discovered Tokens UI. Matches the `emptyMapping(_:)` shape
+  /// the discovery service writes on these rows.
+  func emptyCryptoMapping() -> CryptoProviderMapping {
+    CryptoProviderMapping(
+      instrumentId: id,
+      coingeckoId: nil,
+      cryptocompareSymbol: nil,
+      binanceSymbol: nil)
+  }
 }

--- a/Backends/GRDB/Repositories/GRDBInstrumentRegistryRepository+Lookup.swift
+++ b/Backends/GRDB/Repositories/GRDBInstrumentRegistryRepository+Lookup.swift
@@ -5,10 +5,8 @@ import GRDB
 
 extension GRDBInstrumentRegistryRepository {
   /// Looks up a single crypto registration by id. Mirrors the row-shape
-  /// projection in `allCryptoRegistrations()` — rows whose three provider
-  /// columns are all `nil` (e.g. a CSV-imported placeholder that never
-  /// went through the picker) project to `nil` here, matching the
-  /// `cryptoMapping() != nil` filter on the bulk read.
+  /// projection in `allCryptoRegistrations()` — see `project(row:)`
+  /// below for the rule set.
   ///
   /// Lives in a sibling extension file so the main repository class body
   /// stays under SwiftLint's `type_body_length` and `file_length` budgets.
@@ -22,13 +20,33 @@ extension GRDBInstrumentRegistryRepository {
           .filter(InstrumentRow.Columns.kind == cryptoKind)
           .fetchOne(database)
       else { return nil }
-      guard let mapping = row.cryptoMapping() else { return nil }
-      let status =
-        TokenPricingStatus(rawValue: row.pricingStatus) ?? .priced
-      return CryptoRegistration(
-        instrument: try row.toDomain(),
-        mapping: mapping,
-        pricingStatus: status)
+      return try Self.project(row: row)
     }
+  }
+
+  /// Projects an `InstrumentRow` to a `CryptoRegistration`, applying the
+  /// inbox / spam visibility rules:
+  ///
+  /// - Rows with a recorded provider mapping return a registration with
+  ///   that mapping (regardless of status).
+  /// - Rows with no provider mapping but a non-`.priced` status (i.e.
+  ///   the discovery actor's `.unpriced` / `.spam` writes) return a
+  ///   registration with an all-nil mapping so the Discovered Tokens
+  ///   inbox + Spam Tokens management UI can render and act on them,
+  ///   and so the discovery actor's "is this row already registered?"
+  ///   fast path does not re-resolve them every cycle.
+  /// - Rows with no provider mapping AND default `.priced` status are
+  ///   legacy CSV-import placeholders (`ensureInstrument` auto-inserts
+  ///   from before the user resolved a mapping) and project to `nil`.
+  static func project(row: InstrumentRow) throws -> CryptoRegistration? {
+    let status =
+      TokenPricingStatus(rawValue: row.pricingStatus) ?? .priced
+    let mapping = row.cryptoMapping() ?? row.emptyCryptoMapping()
+    let hasMapping = row.cryptoMapping() != nil
+    guard hasMapping || status != .priced else { return nil }
+    return CryptoRegistration(
+      instrument: try row.toDomain(),
+      mapping: mapping,
+      pricingStatus: status)
   }
 }

--- a/Backends/GRDB/Repositories/GRDBInstrumentRegistryRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBInstrumentRegistryRepository.swift
@@ -89,15 +89,7 @@ final class GRDBInstrumentRegistryRepository:
         try InstrumentRow
         .filter(InstrumentRow.Columns.kind == cryptoKind)
         .fetchAll(database)
-      return try rows.compactMap { row -> CryptoRegistration? in
-        guard let mapping = row.cryptoMapping() else { return nil }
-        let status =
-          TokenPricingStatus(rawValue: row.pricingStatus) ?? .priced
-        return CryptoRegistration(
-          instrument: try row.toDomain(),
-          mapping: mapping,
-          pricingStatus: status)
-      }
+      return try rows.compactMap { row in try Self.project(row: row) }
     }
   }
 

--- a/Features/Settings/CryptoAccountsListSection.swift
+++ b/Features/Settings/CryptoAccountsListSection.swift
@@ -1,0 +1,150 @@
+// Features/Settings/CryptoAccountsListSection.swift
+import SwiftUI
+
+/// Section of the Crypto preferences tab listing every `Account` of
+/// `type == .crypto`. Each row exposes:
+///
+/// - The account name + chain.
+/// - "Synced 2h ago" relative timestamp (or "Never synced" when no
+///   `WalletSyncState` exists yet).
+/// - "Sync now" button that calls `CryptoSyncStore.syncAccount(_:)`. The
+///   button shows a spinner while the account is in flight and is
+///   disabled to prevent re-entrant taps.
+/// - Inline error caption when the most recent attempt failed
+///   (`WalletSyncState.lastError != nil`).
+///
+/// The section hides itself when there are no crypto accounts so users
+/// who haven't created one yet aren't confronted with an empty list.
+struct CryptoAccountsListSection: View {
+  let accountStore: AccountStore
+  @Bindable var syncStore: CryptoSyncStore
+
+  init(accountStore: AccountStore, syncStore: CryptoSyncStore) {
+    self.accountStore = accountStore
+    self.syncStore = syncStore
+  }
+
+  var body: some View {
+    if !cryptoAccounts.isEmpty {
+      Section {
+        ForEach(cryptoAccounts, id: \.id) { account in
+          accountRow(account)
+        }
+      } header: {
+        Text("Crypto Accounts")
+      } footer: {
+        Text(
+          "Crypto accounts auto-sync hourly while the app is open. "
+            + "Use \u{201C}Sync now\u{201D} to refresh on demand."
+        )
+      }
+    }
+  }
+
+  /// Filtered + sorted list of crypto accounts. Sorted by display
+  /// position so the order matches the sidebar — users build a mental
+  /// model of "first row in sidebar = first row here". `Accounts.ordered`
+  /// is already sorted by `position`, so this is just a filter.
+  private var cryptoAccounts: [Account] {
+    accountStore.accounts.ordered.filter { $0.type == .crypto }
+  }
+
+  // MARK: - Row
+
+  @ViewBuilder
+  private func accountRow(_ account: Account) -> some View {
+    let state = syncStore.statePerAccount[account.id]
+    let isInFlight = syncStore.inProgressAccountIds.contains(account.id)
+
+    HStack(alignment: .center, spacing: 12) {
+      VStack(alignment: .leading, spacing: 2) {
+        Text(account.name)
+          .font(.headline)
+        Text(chainSubtitle(for: account))
+          .font(.caption)
+          .foregroundStyle(.secondary)
+        if let state {
+          Text(lastSyncedCaption(for: state))
+            .font(.caption2)
+            .foregroundStyle(.secondary)
+            .monospacedDigit()
+        } else {
+          Text("Never synced")
+            .font(.caption2)
+            .foregroundStyle(.secondary)
+        }
+        if let error = state?.lastError {
+          Text(errorCaption(for: error))
+            .font(.caption2)
+            .foregroundStyle(.red)
+        }
+      }
+      Spacer()
+      syncNowButton(for: account, isInFlight: isInFlight)
+    }
+    .accessibilityIdentifier(UITestIdentifiers.CryptoSettings.accountRow(account.id))
+  }
+
+  /// Trailing "Sync now" affordance. While a sync is running we render a
+  /// `ProgressView` instead of the button so a second user tap can't
+  /// queue a duplicate request — `CryptoSyncStore.syncAccount` already
+  /// collapses duplicates internally, but hiding the button is the
+  /// clearer affordance.
+  @ViewBuilder
+  private func syncNowButton(for account: Account, isInFlight: Bool) -> some View {
+    if isInFlight {
+      ProgressView()
+        .controlSize(.small)
+        .accessibilityLabel("Syncing")
+    } else {
+      Button {
+        Task { await syncStore.syncAccount(account) }
+      } label: {
+        Label("Sync now", systemImage: "arrow.clockwise")
+      }
+      .buttonStyle(.bordered)
+      .controlSize(.small)
+      .accessibilityIdentifier(UITestIdentifiers.CryptoSettings.syncNowButton(account.id))
+    }
+  }
+
+  // MARK: - Caption formatting
+
+  private func chainSubtitle(for account: Account) -> String {
+    if let chainId = account.chainId {
+      return Instrument.chainName(for: chainId)
+    }
+    return account.instrument.displaySymbol ?? account.instrument.name
+  }
+
+  /// "Synced 2h ago" relative caption. Uses `RelativeDateTimeFormatter`
+  /// with `.short` units to match `ImportRulesSettingsView`'s existing
+  /// idiom — keeps the project's relative-date language consistent.
+  private func lastSyncedCaption(for state: WalletSyncState) -> String {
+    let formatter = RelativeDateTimeFormatter()
+    formatter.unitsStyle = .short
+    let relative = formatter.localizedString(for: state.lastSyncedAt, relativeTo: Date())
+    return "Synced \(relative)"
+  }
+
+  private func errorCaption(for error: WalletSyncError) -> String {
+    switch error {
+    case .missingApiKey:
+      return "Add an Alchemy API key to enable sync."
+    case .invalidApiKey:
+      return "Alchemy rejected the API key."
+    case .rateLimited(let retryAfter):
+      if let retryAfter {
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .short
+        return
+          "Rate-limited. Retry \(formatter.localizedString(for: retryAfter, relativeTo: Date()))."
+      }
+      return "Rate-limited. Retry shortly."
+    case .network(let underlying):
+      return "Network error: \(underlying)"
+    case .providerMalformedResponse(let stage):
+      return "Provider returned a malformed response (\(stage))."
+    }
+  }
+}

--- a/Features/Settings/CryptoRegistrationRow.swift
+++ b/Features/Settings/CryptoRegistrationRow.swift
@@ -1,0 +1,118 @@
+// Features/Settings/CryptoRegistrationRow.swift
+import SwiftUI
+
+/// Compact row used by the Registered Tokens, Discovered Tokens inbox,
+/// and Spam Tokens management lists. Renders the instrument's symbol,
+/// name, chain, optional truncated contract address, and the badge set
+/// derived from the row's `CryptoProviderMapping`.
+///
+/// `CryptoRegistrationRow` is read-only — actions (remove, mark-spam,
+/// re-resolve, restore) live as `contextMenu` / trailing buttons on the
+/// callsite so each list controls its own affordances. The row renders
+/// the same underlying data shape regardless of `pricingStatus`, which
+/// keeps the inbox + spam screens visually consistent with the main
+/// list.
+struct CryptoRegistrationRow: View {
+  let registration: CryptoRegistration
+  /// Whether to render the truncated contract address line. Off in the
+  /// main "Registered Tokens" list (the row is dense already) and on in
+  /// the inbox / spam views, where the address is the operative
+  /// disambiguator for tokens with shared symbols.
+  let showsContractAddress: Bool
+
+  init(registration: CryptoRegistration, showsContractAddress: Bool = false) {
+    self.registration = registration
+    self.showsContractAddress = showsContractAddress
+  }
+
+  var body: some View {
+    HStack(alignment: .center, spacing: 12) {
+      VStack(alignment: .leading, spacing: 2) {
+        Text(instrument.ticker ?? instrument.name)
+          .font(.headline)
+        Text(instrument.name)
+          .font(.caption)
+          .foregroundStyle(.secondary)
+        if showsContractAddress, let truncated = truncatedContractAddress {
+          Text(truncated)
+            .font(.caption2.monospaced())
+            .foregroundStyle(.secondary)
+            .lineLimit(1)
+        }
+      }
+      Spacer()
+      Text(Instrument.chainName(for: instrument.chainId ?? 0))
+        .font(.caption)
+        .foregroundStyle(.secondary)
+      providerIndicators(for: registration.mapping)
+    }
+    .accessibilityElement(children: .combine)
+    .accessibilityLabel(accessibilityLabel)
+  }
+
+  private var instrument: Instrument { registration.instrument }
+
+  /// Truncated `0xabcd…wxyz` style label for the contract address, or
+  /// `nil` for native gas tokens (no contract). 6+4 hex chars match the
+  /// design's truncation convention; full address is available in the
+  /// row's `accessibilityLabel`.
+  private var truncatedContractAddress: String? {
+    guard let address = instrument.contractAddress, address.count > 12 else {
+      return instrument.contractAddress
+    }
+    let prefix = address.prefix(6)
+    let suffix = address.suffix(4)
+    return "\(prefix)…\(suffix)"
+  }
+
+  private var accessibilityLabel: String {
+    let mapping = registration.mapping
+    var parts: [String] = [
+      instrument.ticker ?? instrument.name,
+      instrument.name,
+      Instrument.chainName(for: instrument.chainId ?? 0),
+    ]
+    if let address = instrument.contractAddress {
+      parts.append("contract \(address)")
+    }
+    parts.append(providersAccessibilityFragment(for: mapping))
+    return parts.filter { !$0.isEmpty }.joined(separator: ", ")
+  }
+
+  /// VoiceOver fragment listing the active price providers for a mapping.
+  /// The visual `CG`/`CC`/`BN` badges in `providerIndicators` would otherwise
+  /// be silent — a combined-element row reads only the outer label, so each
+  /// badge's individual `accessibilityLabel` doesn't surface.
+  private func providersAccessibilityFragment(for mapping: CryptoProviderMapping) -> String {
+    let names: [String] = [
+      mapping.coingeckoId != nil ? "CoinGecko" : nil,
+      mapping.cryptocompareSymbol != nil ? "CryptoCompare" : nil,
+      mapping.binanceSymbol != nil ? "Binance" : nil,
+    ].compactMap { $0 }
+    return names.isEmpty ? "" : "priced via " + names.joined(separator: ", ")
+  }
+
+  @ViewBuilder
+  private func providerIndicators(for mapping: CryptoProviderMapping) -> some View {
+    HStack(spacing: 4) {
+      if mapping.coingeckoId != nil {
+        providerBadge("CG", accessibilityLabel: "CoinGecko")
+      }
+      if mapping.cryptocompareSymbol != nil {
+        providerBadge("CC", accessibilityLabel: "CryptoCompare")
+      }
+      if mapping.binanceSymbol != nil {
+        providerBadge("BN", accessibilityLabel: "Binance")
+      }
+    }
+  }
+
+  private func providerBadge(_ text: String, accessibilityLabel: String) -> some View {
+    Text(text)
+      .font(.caption2)
+      .padding(.horizontal, 4)
+      .padding(.vertical, 1)
+      .background(.fill, in: RoundedRectangle(cornerRadius: 3))
+      .accessibilityLabel(accessibilityLabel)
+  }
+}

--- a/Features/Settings/CryptoSettingsView+TokenList.swift
+++ b/Features/Settings/CryptoSettingsView+TokenList.swift
@@ -1,0 +1,124 @@
+// Features/Settings/CryptoSettingsView+TokenList.swift
+import SwiftUI
+
+/// "Registered Tokens" + "CoinGecko API Key" sections of the Crypto
+/// preferences tab. Extracted from `CryptoSettingsView.swift` so the
+/// main view body stays under SwiftLint's `type_body_length` and
+/// `file_length` thresholds. Every member here closes over the parent
+/// view's `store` / `showAddToken` / `coinGeckoApiKeyInput` bindings —
+/// no new state owned at this layer.
+extension CryptoSettingsView {
+
+  // MARK: - Registered Tokens
+
+  @ViewBuilder var tokenListSection: some View {
+    Section {
+      tokenListContent
+    } header: {
+      tokenListHeader
+    }
+  }
+
+  @ViewBuilder var tokenListContent: some View {
+    if store.isLoading && store.registrations.isEmpty {
+      HStack {
+        Spacer()
+        ProgressView()
+        Spacer()
+      }
+    } else if pricedRegistrations.isEmpty {
+      ContentUnavailableView(
+        "No Tokens",
+        systemImage: "bitcoinsign.circle",
+        description: Text("Add crypto tokens to track their prices.")
+      )
+      .frame(maxWidth: .infinity)
+    } else {
+      ForEach(pricedRegistrations) { registration in
+        CryptoRegistrationRow(registration: registration)
+          .contextMenu {
+            Button(role: .destructive) {
+              Task { await store.removeRegistration(registration) }
+            } label: {
+              Label("Remove", systemImage: "trash")
+            }
+          }
+      }
+      .onDelete { indexSet in
+        let visible = pricedRegistrations
+        Task {
+          for index in indexSet {
+            await store.removeRegistration(visible[index])
+          }
+        }
+      }
+    }
+  }
+
+  @ViewBuilder var tokenListHeader: some View {
+    HStack {
+      Text("Registered Tokens")
+      Spacer()
+      Button {
+        showAddToken = true
+      } label: {
+        Image(systemName: "plus")
+      }
+      .buttonStyle(.borderless)
+      .accessibilityLabel("Add token")
+      .accessibilityIdentifier(UITestIdentifiers.CryptoSettings.addTokenButton)
+    }
+  }
+
+  /// Tokens that are neither `.unpriced` nor `.spam` — i.e. the set the
+  /// "Registered Tokens" list shows. Filtering at the view layer keeps
+  /// the store's `registrations` a single source of truth that the
+  /// inbox + spam views can also read.
+  var pricedRegistrations: [CryptoRegistration] {
+    store.registrations.filter { $0.pricingStatus == .priced }
+  }
+
+  // MARK: - CoinGecko API Key
+
+  var coinGeckoApiKeySection: some View {
+    Section {
+      coinGeckoApiKeyControl
+    } header: {
+      Text("CoinGecko")
+    } footer: {
+      Text(
+        "Optional. Enables CoinGecko as the highest-priority price provider. "
+          + "Requires a free Demo API key from coingecko.com."
+      )
+    }
+  }
+
+  @ViewBuilder var coinGeckoApiKeyControl: some View {
+    if store.hasApiKey {
+      HStack {
+        Label("CoinGecko API Key", systemImage: "key")
+        Spacer()
+        Text("Configured")
+          .foregroundStyle(.secondary)
+        Button("Remove", role: .destructive) {
+          store.clearApiKey()
+        }
+        .buttonStyle(.bordered)
+        .controlSize(.small)
+      }
+    } else {
+      HStack {
+        SecureField("CoinGecko API Key", text: $coinGeckoApiKeyInput)
+        Button("Save") {
+          let trimmed = coinGeckoApiKeyInput.trimmingCharacters(in: .whitespaces)
+          guard !trimmed.isEmpty else { return }
+          store.saveApiKey(trimmed)
+          coinGeckoApiKeyInput = ""
+        }
+        .buttonStyle(.bordered)
+        .controlSize(.small)
+        .disabled(coinGeckoApiKeyInput.trimmingCharacters(in: .whitespaces).isEmpty)
+      }
+    }
+  }
+}

--- a/Features/Settings/CryptoSettingsView+TokenList.swift
+++ b/Features/Settings/CryptoSettingsView+TokenList.swift
@@ -36,6 +36,9 @@ extension CryptoSettingsView {
     } else {
       ForEach(pricedRegistrations) { registration in
         CryptoRegistrationRow(registration: registration)
+          .accessibilityIdentifier(
+            UITestIdentifiers.CryptoSettings.registrationRow(registration.id)
+          )
           .contextMenu {
             Button(role: .destructive) {
               Task { await store.removeRegistration(registration) }

--- a/Features/Settings/CryptoSettingsView.swift
+++ b/Features/Settings/CryptoSettingsView.swift
@@ -1,15 +1,52 @@
 // Features/Settings/CryptoSettingsView.swift
 import SwiftUI
 
+/// Crypto preferences tab. Surfaces every user-facing control for the
+/// wallet auto-import: Alchemy API key, CoinGecko API key, the list of
+/// registered tokens, the list of crypto accounts (with last-sync
+/// timestamps + per-account "Sync now"), the Discovered Tokens inbox
+/// and the Spam tokens management view.
+///
+/// `cryptoSyncStore` and `tokenDiscovery` are optional so the view can
+/// still render in degraded launches (preview / no `instrumentRegistry`)
+/// where the wallet-import feature is unavailable. Sections that depend
+/// on them (the accounts list, the inbox actions) hide themselves when
+/// the dependency is missing.
 struct CryptoSettingsView: View {
   @Bindable var store: CryptoTokenStore
-  @State private var showAddToken = false
-  @State private var apiKeyInput = ""
+  let cryptoSyncStore: CryptoSyncStore?
+  let tokenDiscovery: CryptoTokenDiscoveryService?
+  let accountStore: AccountStore?
+
+  // Module-internal so the sibling extension file
+  // `CryptoSettingsView+TokenList.swift` can read / mutate the same
+  // local UI state. Not part of the public surface.
+  @State var coinGeckoApiKeyInput = ""
+  @State var alchemyApiKeyInput = ""
+  @State var showAddToken = false
+
+  init(
+    store: CryptoTokenStore,
+    cryptoSyncStore: CryptoSyncStore? = nil,
+    tokenDiscovery: CryptoTokenDiscoveryService? = nil,
+    accountStore: AccountStore? = nil
+  ) {
+    self.store = store
+    self.cryptoSyncStore = cryptoSyncStore
+    self.tokenDiscovery = tokenDiscovery
+    self.accountStore = accountStore
+  }
 
   var body: some View {
     Form {
+      alchemyApiKeySection
+      if let accountStore, let cryptoSyncStore {
+        CryptoAccountsListSection(
+          accountStore: accountStore, syncStore: cryptoSyncStore)
+      }
+      tokenInboxNavigationSection
       tokenListSection
-      apiKeySection
+      coinGeckoApiKeySection
     }
     .formStyle(.grouped)
     .navigationTitle("Crypto Tokens")
@@ -22,162 +59,162 @@ struct CryptoSettingsView: View {
     }
   }
 
-  // MARK: - Token List
+  // MARK: - Alchemy API Key
+  //
+  // Status precedence (most-specific wins):
+  //
+  // 1. `globalError == .invalidApiKey` — key was rejected by Alchemy.
+  //    Show "Invalid" with a red exclamation mark.
+  // 2. Key configured (`hasAlchemyApiKey == true`) and no global error
+  //    — show "Configured" with a green checkmark.
+  // 3. No key — show "Not set" with a neutral icon. The footer copy
+  //    nudges the user to add one.
+  //
+  // `globalError == .missingApiKey` is folded into case 3 since the
+  // store will set it whenever a sync runs without a key configured.
 
-  @ViewBuilder private var tokenListSection: some View {
+  @ViewBuilder private var alchemyApiKeySection: some View {
     Section {
-      if store.isLoading && store.registrations.isEmpty {
-        HStack {
-          Spacer()
-          ProgressView()
-          Spacer()
-        }
-      } else if store.registrations.isEmpty {
-        ContentUnavailableView(
-          "No Tokens",
-          systemImage: "bitcoinsign.circle",
-          description: Text("Add crypto tokens to track their prices.")
-        )
-        .frame(maxWidth: .infinity)
+      if store.hasAlchemyApiKey {
+        configuredAlchemyRow
       } else {
-        ForEach(store.registrations) { registration in
-          registrationRow(registration)
-        }
-        .onDelete { indexSet in
-          Task {
-            for index in indexSet {
-              await store.removeRegistration(store.registrations[index])
-            }
-          }
-        }
+        alchemyEntryRow
       }
+      Link(
+        "How to get an Alchemy API key",
+        destination: alchemySignupURL
+      )
+      .font(.caption)
     } header: {
       HStack {
-        Text("Registered Tokens")
+        Text("Alchemy")
         Spacer()
-        Button {
-          showAddToken = true
-        } label: {
-          Image(systemName: "plus")
-        }
-        .buttonStyle(.borderless)
-        .accessibilityLabel("Add token")
-        .accessibilityIdentifier(UITestIdentifiers.CryptoSettings.addTokenButton)
+        alchemyStatusBadge
       }
-    }
-  }
-
-  private func registrationRow(_ registration: CryptoRegistration) -> some View {
-    let instrument = registration.instrument
-    let mapping = registration.mapping
-    return HStack {
-      VStack(alignment: .leading, spacing: 2) {
-        Text(instrument.ticker ?? instrument.name)
-          .font(.headline)
-        Text(instrument.name)
-          .font(.caption)
-          .foregroundStyle(.secondary)
-      }
-      Spacer()
-      Text(Instrument.chainName(for: instrument.chainId ?? 0))
-        .font(.caption)
-        .foregroundStyle(.secondary)
-      providerIndicators(for: mapping)
-    }
-    .accessibilityElement(children: .combine)
-    .accessibilityIdentifier(UITestIdentifiers.CryptoSettings.registrationRow(registration.id))
-    .accessibilityLabel(
-      "\(instrument.ticker ?? instrument.name), \(instrument.name), "
-        + "\(Instrument.chainName(for: instrument.chainId ?? 0))"
-        + providersAccessibilityFragment(for: mapping)
-    )
-    .contextMenu {
-      Button(role: .destructive) {
-        Task { await store.removeRegistration(registration) }
-      } label: {
-        Label("Remove", systemImage: "trash")
-      }
-    }
-  }
-
-  /// VoiceOver fragment listing the active price providers for a mapping.
-  /// The visual `CG`/`CC`/`BN` badges in `providerIndicators` would otherwise
-  /// be silent — a combined-element row reads only the outer label, so each
-  /// badge's individual `accessibilityLabel` doesn't surface.
-  private func providersAccessibilityFragment(for mapping: CryptoProviderMapping) -> String {
-    let names: [String] = [
-      mapping.coingeckoId != nil ? "CoinGecko" : nil,
-      mapping.cryptocompareSymbol != nil ? "CryptoCompare" : nil,
-      mapping.binanceSymbol != nil ? "Binance" : nil,
-    ].compactMap { $0 }
-    return names.isEmpty ? "" : ", priced via " + names.joined(separator: ", ")
-  }
-
-  private func providerIndicators(for mapping: CryptoProviderMapping) -> some View {
-    HStack(spacing: 4) {
-      if mapping.coingeckoId != nil {
-        Text("CG")
-          .font(.caption2)
-          .padding(.horizontal, 4)
-          .padding(.vertical, 1)
-          .background(.fill, in: RoundedRectangle(cornerRadius: 3))
-          .accessibilityLabel("CoinGecko")
-      }
-      if mapping.cryptocompareSymbol != nil {
-        Text("CC")
-          .font(.caption2)
-          .padding(.horizontal, 4)
-          .padding(.vertical, 1)
-          .background(.fill, in: RoundedRectangle(cornerRadius: 3))
-          .accessibilityLabel("CryptoCompare")
-      }
-      if mapping.binanceSymbol != nil {
-        Text("BN")
-          .font(.caption2)
-          .padding(.horizontal, 4)
-          .padding(.vertical, 1)
-          .background(.fill, in: RoundedRectangle(cornerRadius: 3))
-          .accessibilityLabel("Binance")
-      }
-    }
-  }
-
-  // MARK: - API Key
-
-  private var apiKeySection: some View {
-    Section {
-      if store.hasApiKey {
-        HStack {
-          Label("CoinGecko API Key", systemImage: "key")
-          Spacer()
-          Text("Configured")
-            .foregroundStyle(.secondary)
-          Button("Remove", role: .destructive) {
-            store.clearApiKey()
-          }
-          .buttonStyle(.bordered)
-          .controlSize(.small)
-        }
-      } else {
-        HStack {
-          SecureField("CoinGecko API Key", text: $apiKeyInput)
-          Button("Save") {
-            let trimmed = apiKeyInput.trimmingCharacters(in: .whitespaces)
-            guard !trimmed.isEmpty else { return }
-            store.saveApiKey(trimmed)
-            apiKeyInput = ""
-          }
-          .buttonStyle(.bordered)
-          .controlSize(.small)
-          .disabled(apiKeyInput.trimmingCharacters(in: .whitespaces).isEmpty)
-        }
-      }
-    } header: {
-      Text("CoinGecko")
     } footer: {
       Text(
-        "Optional. Enables CoinGecko as the highest-priority price provider. Requires a free Demo API key from coingecko.com."
+        "Required to auto-import on-chain transactions for crypto wallet accounts. "
+          + "A free Alchemy key is sufficient for personal use."
       )
     }
   }
+
+  @ViewBuilder private var configuredAlchemyRow: some View {
+    HStack {
+      Label("Alchemy API Key", systemImage: "key")
+      Spacer()
+      Text("Configured")
+        .foregroundStyle(.secondary)
+      Button("Remove", role: .destructive) {
+        store.clearAlchemyApiKey()
+      }
+      .buttonStyle(.bordered)
+      .controlSize(.small)
+      .accessibilityIdentifier(UITestIdentifiers.CryptoSettings.alchemyApiKeyRemoveButton)
+    }
+  }
+
+  @ViewBuilder private var alchemyEntryRow: some View {
+    HStack {
+      SecureField("Alchemy API Key", text: $alchemyApiKeyInput)
+        .accessibilityIdentifier(UITestIdentifiers.CryptoSettings.alchemyApiKeyField)
+      Button("Save") {
+        let trimmed = alchemyApiKeyInput.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else { return }
+        store.saveAlchemyApiKey(trimmed)
+        alchemyApiKeyInput = ""
+      }
+      .buttonStyle(.bordered)
+      .controlSize(.small)
+      .disabled(alchemyApiKeyInput.trimmingCharacters(in: .whitespaces).isEmpty)
+      .accessibilityIdentifier(UITestIdentifiers.CryptoSettings.alchemyApiKeySaveButton)
+    }
+  }
+
+  /// Coloured status indicator next to the section header. Encodes the
+  /// status precedence described in the comment above
+  /// `alchemyApiKeySection`. Returned as `some View` rather than three
+  /// inline branches so the header layout stays readable.
+  @ViewBuilder private var alchemyStatusBadge: some View {
+    if cryptoSyncStore?.globalError == .invalidApiKey {
+      Label("Invalid", systemImage: "exclamationmark.circle.fill")
+        .labelStyle(.titleAndIcon)
+        .foregroundStyle(.red)
+        .font(.caption)
+    } else if store.hasAlchemyApiKey {
+      Label("Configured", systemImage: "checkmark.circle.fill")
+        .labelStyle(.titleAndIcon)
+        .foregroundStyle(.green)
+        .font(.caption)
+    } else {
+      Label("Not set", systemImage: "circle")
+        .labelStyle(.titleAndIcon)
+        .foregroundStyle(.secondary)
+        .font(.caption)
+    }
+  }
+
+  /// Alchemy's free-tier signup landing page. Hard-coded constant rather
+  /// than environment / config because the URL is a public resource and
+  /// keeping it inline keeps the link a one-line `Link(...)` call.
+  /// `URL(string:)`'s force-unwrap is gated by a known-good literal so a
+  /// `nil` here is a programmer error, not a runtime failure mode.
+  private var alchemySignupURL: URL {
+    guard let url = URL(string: "https://www.alchemy.com/pricing") else {
+      preconditionFailure("CryptoSettingsView: malformed Alchemy signup URL literal")
+    }
+    return url
+  }
+
+  // MARK: - Token inbox navigation
+
+  @ViewBuilder private var tokenInboxNavigationSection: some View {
+    Section {
+      discoveredTokensNavigationLink
+      spamTokensNavigationLink
+    } header: {
+      Text("Token Management")
+    }
+  }
+
+  @ViewBuilder private var discoveredTokensNavigationLink: some View {
+    NavigationLink {
+      DiscoveredTokensInboxView(store: store, tokenDiscovery: tokenDiscovery)
+    } label: {
+      HStack {
+        Label("Discovered Tokens", systemImage: "tray")
+        Spacer()
+        if store.unpricedCount > 0 {
+          Text("\(store.unpricedCount)")
+            .font(.caption)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(.tint, in: Capsule())
+            .foregroundStyle(.white)
+        }
+      }
+    }
+    .accessibilityIdentifier(UITestIdentifiers.CryptoSettings.discoveredTokensRow)
+  }
+
+  @ViewBuilder private var spamTokensNavigationLink: some View {
+    NavigationLink {
+      SpamTokensView(store: store)
+    } label: {
+      HStack {
+        Label("Spam Tokens", systemImage: "trash")
+        Spacer()
+        if !store.spamRegistrations.isEmpty {
+          Text("\(store.spamRegistrations.count)")
+            .font(.caption)
+            .foregroundStyle(.secondary)
+        }
+      }
+    }
+    .accessibilityIdentifier(UITestIdentifiers.CryptoSettings.spamTokensRow)
+  }
+
+  // The "Registered Tokens" + "CoinGecko API Key" sections live in
+  // `CryptoSettingsView+TokenList.swift` so this file stays under
+  // SwiftLint's `type_body_length` and `file_length` thresholds.
 }

--- a/Features/Settings/CryptoTokenStore.swift
+++ b/Features/Settings/CryptoTokenStore.swift
@@ -19,18 +19,77 @@ final class CryptoTokenStore {
   private let logger = Logger(
     subsystem: "com.moolah.app", category: "CryptoTokenStore")
 
-  private let apiKeyStore = KeychainStore(
-    service: "com.moolah.api-keys", account: "coingecko", synchronizable: true
-  )
+  private let apiKeyStore: KeychainStore
 
+  /// Keychain entry for the Alchemy API key, used by the crypto-wallet
+  /// auto-import (Stage 9 onward). Service / account strings match
+  /// `plans/2026-05-05-crypto-wallet-import-design.md` §"API key
+  /// management" so reads from `ProfileSession+CryptoSync` pick up the
+  /// value the settings UI writes here. Production wires this to the
+  /// iCloud-synced keychain (`synchronizable: true`); tests inject a
+  /// non-synced `KeychainStore` since the test runner cannot write to
+  /// the synced keychain in CI.
+  private let alchemyKeyStore: KeychainStore
+
+  /// Designated initialiser — accepts the keychain stores explicitly.
+  /// Production constructs both stores against the iCloud-synced
+  /// keychain at the canonical service / account ids (see the
+  /// `convenience init` below). Tests inject non-synchronisable
+  /// instances since the macOS test runner cannot write to the synced
+  /// keychain. Internal access (not `private`) so tests in the same
+  /// module can reach it; the production convenience initialiser stays
+  /// the public surface.
   init(
     registry: any InstrumentRegistryRepository,
     cryptoPriceService: CryptoPriceService,
-    conversionService: any InstrumentConversionService
+    conversionService: any InstrumentConversionService,
+    apiKeyStore: KeychainStore,
+    alchemyKeyStore: KeychainStore
   ) {
     self.registry = registry
     self.cryptoPriceService = cryptoPriceService
     self.conversionService = conversionService
+    self.apiKeyStore = apiKeyStore
+    self.alchemyKeyStore = alchemyKeyStore
+  }
+
+  /// Production convenience initialiser — wires both keychain stores
+  /// to the iCloud-synced keychain at the canonical service / account
+  /// ids. The shape mirrors `ProfileSession.resolveAlchemyApiKey()`'s
+  /// keychain coordinates so a write from settings is picked up by
+  /// the next sync cycle without further plumbing.
+  convenience init(
+    registry: any InstrumentRegistryRepository,
+    cryptoPriceService: CryptoPriceService,
+    conversionService: any InstrumentConversionService
+  ) {
+    self.init(
+      registry: registry,
+      cryptoPriceService: cryptoPriceService,
+      conversionService: conversionService,
+      apiKeyStore: KeychainStore(
+        service: "com.moolah.api-keys", account: "coingecko", synchronizable: true),
+      alchemyKeyStore: KeychainStore(
+        service: "com.moolah.api-keys", account: "alchemy", synchronizable: true)
+    )
+  }
+
+  // MARK: - Filtered registrations
+
+  /// Subset of `registrations` with `pricingStatus == .unpriced`. Drives
+  /// the Discovered Tokens inbox row count + the sidebar badge.
+  var unpricedRegistrations: [CryptoRegistration] {
+    registrations.filter { $0.pricingStatus == .unpriced }
+  }
+
+  /// Convenience for the sidebar / preferences badge — number of
+  /// unresolved tokens awaiting user attention.
+  var unpricedCount: Int { unpricedRegistrations.count }
+
+  /// Subset of `registrations` with `pricingStatus == .spam`. Drives the
+  /// Spam tokens management list.
+  var spamRegistrations: [CryptoRegistration] {
+    registrations.filter { $0.pricingStatus == .spam }
   }
 
   func loadRegistrations() async {
@@ -101,7 +160,7 @@ final class CryptoTokenStore {
     }
   }
 
-  // MARK: - API Key
+  // MARK: - CoinGecko API Key
 
   var hasApiKey: Bool {
     do {
@@ -122,5 +181,44 @@ final class CryptoTokenStore {
 
   func clearApiKey() {
     apiKeyStore.clear()
+  }
+
+  // MARK: - Alchemy API Key
+  //
+  // The Alchemy key drives the wallet auto-import (Stage 9 onward).
+  // `ProfileSession.resolveAlchemyApiKey()` reads from the same
+  // `(service, account)` keychain entry, so a write here is picked up
+  // by the next sync cycle without further plumbing. Privacy: never
+  // logged. Failures surface via the store's `error` string only —
+  // the underlying `OSStatus` never appears in `os.Logger`.
+
+  /// `true` when an Alchemy API key is configured in the synced
+  /// Keychain. Read on every UI render to drive the status badge —
+  /// the keychain read is cheap (~µs) and consulting a cached `Bool`
+  /// would require an explicit invalidation hook on save / clear.
+  var hasAlchemyApiKey: Bool {
+    do {
+      return try alchemyKeyStore.restoreString() != nil
+    } catch {
+      logger.error("keychain read failed: \(error.localizedDescription)")
+      return false
+    }
+  }
+
+  /// Persists the Alchemy API key to the synced Keychain. Sets
+  /// `error` (without logging the key) on failure.
+  func saveAlchemyApiKey(_ key: String) {
+    do {
+      try alchemyKeyStore.saveString(key)
+    } catch {
+      self.error = "Failed to save Alchemy API key: \(error.localizedDescription)"
+    }
+  }
+
+  /// Removes the Alchemy API key from the synced Keychain. Subsequent
+  /// sync cycles will produce `WalletSyncError.missingApiKey` until a
+  /// new key is saved.
+  func clearAlchemyApiKey() {
+    alchemyKeyStore.clear()
   }
 }

--- a/Features/Settings/DiscoveredTokensInboxView.swift
+++ b/Features/Settings/DiscoveredTokensInboxView.swift
@@ -1,0 +1,152 @@
+// Features/Settings/DiscoveredTokensInboxView.swift
+import OSLog
+import SwiftUI
+
+/// Lists every `CryptoRegistration` whose `pricingStatus == .unpriced`.
+///
+/// "Unpriced" is the design's term for a token whose contract was found
+/// on-chain but no price provider was able to resolve it — the row's
+/// fiat contribution is intentionally zero, NOT a conversion error
+/// (see `TokenPricingStatus`). The user can:
+///
+/// - **Mark as spam** — flips status to `.spam`, removing it from
+///   aggregation and hiding it across the UI. Cache invalidation is
+///   wired through `CryptoTokenStore.setStatus(_:for:)`.
+/// - **Re-resolve now** — re-runs the resolver via
+///   `CryptoTokenDiscoveryService.reResolve(_:chain:)`. The actor
+///   coalesces concurrent resolves for the same key, so a user
+///   spamming the button cannot launch duplicate network round-trips.
+///
+/// "Held by N accounts · X transactions" copy is intentionally left as
+/// a placeholder ("Held by — accounts") in this stage — Stage 12's
+/// wallet-account view introduces the leg-aggregation surface that
+/// will feed this metric. Once that's available we'll thread the count
+/// through the registry repository rather than inline a SQL query in
+/// the view layer.
+struct DiscoveredTokensInboxView: View {
+  @Bindable var store: CryptoTokenStore
+  let tokenDiscovery: CryptoTokenDiscoveryService?
+
+  @State private var inFlightIds: Set<String> = []
+  private let logger = Logger(
+    subsystem: "com.moolah.app", category: "DiscoveredTokensInbox")
+
+  var body: some View {
+    Form {
+      if store.unpricedRegistrations.isEmpty {
+        emptyState
+      } else {
+        Section {
+          ForEach(store.unpricedRegistrations) { registration in
+            row(for: registration)
+          }
+        } footer: {
+          Text(
+            "Tokens land here when an on-chain contract is found but no price "
+              + "provider can resolve it. Mark obvious junk as spam; tap "
+              + "\u{201C}Re-resolve\u{201D} to retry resolution for the rest."
+          )
+        }
+      }
+    }
+    .formStyle(.grouped)
+    .navigationTitle("Discovered Tokens")
+  }
+
+  @ViewBuilder private var emptyState: some View {
+    Section {
+      ContentUnavailableView(
+        "Inbox Zero",
+        systemImage: "tray",
+        description: Text(
+          "No unresolved tokens. New on-chain tokens that can't be priced will land here.")
+      )
+      .frame(maxWidth: .infinity)
+    }
+  }
+
+  // MARK: - Row
+
+  @ViewBuilder
+  private func row(for registration: CryptoRegistration) -> some View {
+    let isInFlight = inFlightIds.contains(registration.id)
+    VStack(alignment: .leading, spacing: 6) {
+      CryptoRegistrationRow(registration: registration, showsContractAddress: true)
+      Text("Held by \u{2014} accounts")
+        .font(.caption2)
+        .foregroundStyle(.secondary)
+      HStack(spacing: 8) {
+        Spacer()
+        Button(role: .destructive) {
+          Task { await store.setStatus(.spam, for: registration) }
+        } label: {
+          Label("Mark as spam", systemImage: "trash")
+        }
+        .buttonStyle(.bordered)
+        .controlSize(.small)
+        .accessibilityIdentifier(UITestIdentifiers.CryptoSettings.markSpamButton(registration.id))
+
+        Button {
+          reResolve(registration)
+        } label: {
+          if isInFlight {
+            ProgressView().controlSize(.small)
+          } else {
+            Label("Re-resolve", systemImage: "arrow.clockwise")
+          }
+        }
+        .buttonStyle(.bordered)
+        .controlSize(.small)
+        .disabled(isInFlight || tokenDiscovery == nil)
+        .accessibilityIdentifier(UITestIdentifiers.CryptoSettings.reResolveButton(registration.id))
+      }
+    }
+    .padding(.vertical, 4)
+    .accessibilityIdentifier(UITestIdentifiers.CryptoSettings.discoveredRow(registration.id))
+  }
+
+  // MARK: - Actions
+
+  /// Drives `CryptoTokenDiscoveryService.reResolve(_:chain:)`. Tracks
+  /// per-row in-flight state so the button shows a spinner while a
+  /// resolution is running. Errors are logged at `.error` level via
+  /// `os.Logger` (the contract address is `.public` here because it's
+  /// already on-screen in the row's truncated label) and otherwise
+  /// dropped — the design treats resolve failures as a normal outcome
+  /// (the row stays `.unpriced` and the user can retry).
+  private func reResolve(_ registration: CryptoRegistration) {
+    guard let tokenDiscovery else { return }
+    guard let chain = chainConfig(for: registration) else {
+      logger.error(
+        "Re-resolve skipped — unsupported chainId for \(registration.id, privacy: .public)"
+      )
+      return
+    }
+    inFlightIds.insert(registration.id)
+    Task { [tokenDiscovery, store, logger] in
+      defer {
+        Task { @MainActor in inFlightIds.remove(registration.id) }
+      }
+      do {
+        _ = try await tokenDiscovery.reResolve(registration, chain: chain)
+        // The actor's `reResolve` calls `registry.update(_:)` on the
+        // shared repository, but the store's in-memory copy doesn't
+        // see those mutations. Refresh the local cache so the row
+        // disappears from the inbox once the status flips.
+        await store.loadRegistrations()
+      } catch {
+        logger.error(
+          "Re-resolve failed for \(registration.id, privacy: .public): \(error.localizedDescription, privacy: .public)"
+        )
+      }
+    }
+  }
+
+  /// Look up the supported `ChainConfig` for a registration. Returns
+  /// `nil` for chains the wallet importer doesn't yet target (so the
+  /// row's button is disabled rather than crashing on a forced unwrap).
+  private func chainConfig(for registration: CryptoRegistration) -> ChainConfig? {
+    guard let chainId = registration.instrument.chainId else { return nil }
+    return ChainConfig.config(for: chainId)
+  }
+}

--- a/Features/Settings/SettingsView+iOS.swift
+++ b/Features/Settings/SettingsView+iOS.swift
@@ -122,13 +122,18 @@
       {
         Section {
           NavigationLink {
-            CryptoSettingsView(store: store)
-              // The embedded `AddTokenSheet` opens an `InstrumentPickerSheet`
-              // whose callback variant pulls its search service, registry,
-              // and resolution client from `@Environment(ProfileSession.self)`.
-              // Without this injection the picker silently falls back to the
-              // static fiat list and crypto search returns no results.
-              .environment(session)
+            CryptoSettingsView(
+              store: store,
+              cryptoSyncStore: session.cryptoSyncStore,
+              tokenDiscovery: session.cryptoTokenDiscovery,
+              accountStore: session.accountStore
+            )
+            // The embedded `AddTokenSheet` opens an `InstrumentPickerSheet`
+            // whose callback variant pulls its search service, registry,
+            // and resolution client from `@Environment(ProfileSession.self)`.
+            // Without this injection the picker silently falls back to the
+            // static fiat list and crypto search returns no results.
+            .environment(session)
           } label: {
             Label("Crypto Tokens", systemImage: "bitcoinsign.circle")
           }

--- a/Features/Settings/SettingsView+macOS.swift
+++ b/Features/Settings/SettingsView+macOS.swift
@@ -51,13 +51,22 @@
           // `UITestIdentifiers.Settings.cryptoTabTitle` so there is one
           // source of truth.
           Tab(UITestIdentifiers.Settings.cryptoTabTitle, systemImage: "bitcoinsign.circle") {
-            CryptoSettingsView(store: store)
+            // Wrap in a NavigationStack so the Discovered Tokens inbox
+            // and Spam Tokens views can be pushed via NavigationLink.
+            NavigationStack {
+              CryptoSettingsView(
+                store: store,
+                cryptoSyncStore: session.cryptoSyncStore,
+                tokenDiscovery: session.cryptoTokenDiscovery,
+                accountStore: session.accountStore
+              )
               // The embedded `AddTokenSheet` opens an `InstrumentPickerSheet`
               // whose callback variant pulls its search service, registry,
               // and resolution client from `@Environment(ProfileSession.self)`.
               // Without this injection the picker silently falls back to
               // the static fiat list and crypto search returns no results.
               .environment(session)
+            }
           }
         }
         // macOS Settings tabs host the Form / List directly — the window

--- a/Features/Settings/SpamTokensView.swift
+++ b/Features/Settings/SpamTokensView.swift
@@ -1,0 +1,72 @@
+// Features/Settings/SpamTokensView.swift
+import SwiftUI
+
+/// Lists every `CryptoRegistration` whose `pricingStatus == .spam`.
+///
+/// Spam classification can come from three sources, all surfaced
+/// through the same list:
+///
+/// - Alchemy's `isSpam` flag set during initial discovery.
+/// - The user's "Mark as spam" action in the Discovered Tokens inbox.
+/// - A spam classification synced from another device.
+///
+/// The single per-row action is **Restore** — flips the status back to
+/// `.unpriced` so the row returns to the Discovered Tokens inbox. From
+/// there the user can either re-resolve manually or wait for the next
+/// daily auto-resolution cycle to pick it back up. We deliberately do
+/// not jump directly to `.priced` because the resolver hasn't been
+/// re-run; the canonical "make this a priced token" path stays
+/// `Inbox → Re-resolve`.
+///
+/// Cache invalidation is wired through `CryptoTokenStore.setStatus(_:for:)`,
+/// so historical balances recompute the moment a row is restored.
+struct SpamTokensView: View {
+  @Bindable var store: CryptoTokenStore
+
+  var body: some View {
+    Form {
+      if store.spamRegistrations.isEmpty {
+        Section {
+          ContentUnavailableView(
+            "No Spam Tokens",
+            systemImage: "trash",
+            description: Text("Tokens marked as spam (by you or by Alchemy) will appear here.")
+          )
+          .frame(maxWidth: .infinity)
+        }
+      } else {
+        Section {
+          ForEach(store.spamRegistrations) { registration in
+            row(for: registration)
+          }
+        } footer: {
+          Text(
+            "Spam tokens contribute zero to fiat balances and are hidden across the app. "
+              + "Restore a row to move it back to the Discovered Tokens inbox."
+          )
+        }
+      }
+    }
+    .formStyle(.grouped)
+    .navigationTitle("Spam Tokens")
+  }
+
+  // MARK: - Row
+
+  @ViewBuilder
+  private func row(for registration: CryptoRegistration) -> some View {
+    HStack(alignment: .center, spacing: 12) {
+      CryptoRegistrationRow(registration: registration, showsContractAddress: true)
+      Button {
+        Task { await store.setStatus(.unpriced, for: registration) }
+      } label: {
+        Label("Restore", systemImage: "arrow.uturn.backward")
+      }
+      .buttonStyle(.bordered)
+      .controlSize(.small)
+      .accessibilityIdentifier(UITestIdentifiers.CryptoSettings.restoreButton(registration.id))
+    }
+    .padding(.vertical, 4)
+    .accessibilityIdentifier(UITestIdentifiers.CryptoSettings.spamRow(registration.id))
+  }
+}

--- a/MoolahTests/Features/Settings/CryptoSettingsAPIKeyTests.swift
+++ b/MoolahTests/Features/Settings/CryptoSettingsAPIKeyTests.swift
@@ -1,0 +1,125 @@
+// MoolahTests/Features/Settings/CryptoSettingsAPIKeyTests.swift
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+/// Tests for the Stage 11 Alchemy API key UI surface on
+/// `CryptoTokenStore`. The store wraps a `KeychainStore` keyed on
+/// (`com.moolah.api-keys`, `alchemy`) — the same entry
+/// `ProfileSession.resolveAlchemyApiKey()` reads on the sync side, so
+/// a write here must round-trip through the keychain to be picked up
+/// by the next sync cycle.
+///
+/// Production uses the iCloud-synced keychain
+/// (`synchronizable: true`), but the macOS test runner cannot write to
+/// it (the runner isn't part of an iCloud-signed-in user session). We
+/// inject a per-test, non-synchronisable `KeychainStore` instance via
+/// the store's test seam initialiser. Each test uses a unique service
+/// id (`UUID()` in the prefix) so concurrent test runs cannot collide
+/// on the same keychain row, mirroring `KeychainStoreTests`.
+///
+/// We still cover the "production wires the iCloud-synced keychain at
+/// the canonical service / account" claim via a separate test that
+/// inspects the production initialiser's plumbing without depending on
+/// a successful save.
+@Suite("CryptoTokenStore — Alchemy API key")
+@MainActor
+struct CryptoSettingsAPIKeyTests {
+  private struct Fixture {
+    let store: CryptoTokenStore
+    let alchemyKeychain: KeychainStore
+    let coingeckoKeychain: KeychainStore
+  }
+
+  /// Builds a store whose Alchemy + CoinGecko keychain entries are
+  /// non-synchronisable and namespaced under per-test unique service
+  /// ids. Returns the keychain handles too so tests can read the raw
+  /// entry to confirm round-trips.
+  private func makeFixture() throws -> Fixture {
+    let database = try ProfileDatabase.openInMemory()
+    let registry = GRDBInstrumentRegistryRepository(database: database)
+    let priceService = CryptoPriceService(
+      clients: [FixedCryptoPriceClient()], database: database)
+    let alchemyService = "com.moolah.test.alchemy.\(UUID().uuidString)"
+    let coingeckoService = "com.moolah.test.coingecko.\(UUID().uuidString)"
+    let alchemyKeychain = KeychainStore(
+      service: alchemyService, account: "alchemy", synchronizable: false)
+    let coingeckoKeychain = KeychainStore(
+      service: coingeckoService, account: "coingecko", synchronizable: false)
+    let store = CryptoTokenStore(
+      registry: registry,
+      cryptoPriceService: priceService,
+      conversionService: RecordingConversionService(),
+      apiKeyStore: coingeckoKeychain,
+      alchemyKeyStore: alchemyKeychain)
+    return Fixture(
+      store: store,
+      alchemyKeychain: alchemyKeychain,
+      coingeckoKeychain: coingeckoKeychain)
+  }
+
+  // MARK: - Save / read round-trip
+
+  @Test("saveAlchemyApiKey persists through KeychainStore")
+  func saveAlchemyApiKeyPersists() throws {
+    let fixture = try makeFixture()
+    defer { fixture.alchemyKeychain.clear() }
+
+    fixture.store.saveAlchemyApiKey("alch_test_round_trip_abc")
+
+    #expect(fixture.store.hasAlchemyApiKey == true)
+    let restored = try fixture.alchemyKeychain.restoreString()
+    #expect(restored == "alch_test_round_trip_abc")
+  }
+
+  @Test("hasAlchemyApiKey is false on a fresh keychain entry")
+  func hasAlchemyApiKeyIsFalseWhenEmpty() throws {
+    let fixture = try makeFixture()
+    #expect(fixture.store.hasAlchemyApiKey == false)
+  }
+
+  @Test("clearAlchemyApiKey removes the keychain entry")
+  func clearAlchemyApiKeyRemovesEntry() throws {
+    let fixture = try makeFixture()
+    fixture.store.saveAlchemyApiKey("alch_test_clear_me")
+    fixture.store.clearAlchemyApiKey()
+    #expect(fixture.store.hasAlchemyApiKey == false)
+  }
+
+  // MARK: - Service / account isolation
+
+  @Test("saveAlchemyApiKey writes to the alchemy keychain, not coingecko")
+  func saveAlchemyApiKeyTargetsAlchemyAccount() throws {
+    let fixture = try makeFixture()
+    defer {
+      fixture.alchemyKeychain.clear()
+      fixture.coingeckoKeychain.clear()
+    }
+
+    fixture.store.saveAlchemyApiKey("alch_isolation_test_xyz")
+
+    #expect(try fixture.alchemyKeychain.restoreString() == "alch_isolation_test_xyz")
+    // The write must not spill into the CoinGecko slot. With per-test
+    // unique service ids this is guaranteed by construction; the
+    // assertion documents the contract for future readers.
+    #expect(try fixture.coingeckoKeychain.restoreString() == nil)
+  }
+
+  // MARK: - Privacy
+
+  @Test("saveAlchemyApiKey does not surface the key in store.error on success")
+  func saveAlchemyApiKeyNeverLogsKeyOnSuccess() throws {
+    let fixture = try makeFixture()
+    defer { fixture.alchemyKeychain.clear() }
+
+    let secret = "alch_privacy_canary_should_not_appear"
+    fixture.store.saveAlchemyApiKey(secret)
+
+    // The store's `error` should not contain the secret value on
+    // either path. (On success it's nil; we still check just in case
+    // a future refactor sets an info string with the key inside.)
+    #expect(fixture.store.error?.contains(secret) != true)
+  }
+}

--- a/MoolahTests/Features/Settings/CryptoSettingsAccountsListTests.swift
+++ b/MoolahTests/Features/Settings/CryptoSettingsAccountsListTests.swift
@@ -1,0 +1,150 @@
+// MoolahTests/Features/Settings/CryptoSettingsAccountsListTests.swift
+import Foundation
+import GRDB
+import SwiftUI
+import Testing
+
+@testable import Moolah
+
+/// Behavioural tests for the Crypto Accounts list section. Per CLAUDE.md
+/// the testable surface is the data — what `AccountStore.accounts`
+/// exposes after a load, which entries the view filters in, and
+/// whether `CryptoSyncStore.syncAccount(_:)` actually fires when the
+/// "Sync now" button is tapped (the view is a thin shell that calls
+/// straight through).
+///
+/// `CryptoSyncStore.syncAccount` is exercised against a `TestBackend`
+/// fixture identical to the existing `CryptoSyncStoreTests` setup so
+/// the behaviour we verify here is the same one that runs in
+/// production.
+@Suite("Crypto Accounts list — data behaviour")
+@MainActor
+struct CryptoSettingsAccountsListTests {
+  nonisolated static let pinnedNow = Date(timeIntervalSince1970: 1_700_000_000)
+
+  private struct Fixture {
+    let syncStore: CryptoSyncStore
+    let backend: CloudKitBackend
+    let database: DatabaseQueue
+    let alchemy: RecordingAlchemyClientStub
+  }
+
+  /// Builds a `CryptoSyncStore` against `TestBackend` so the apply pass
+  /// writes through the real repositories. Only Alchemy is stubbed —
+  /// the same shape the existing Stage 9 tests use.
+  private func makeFixture() throws -> Fixture {
+    let (backend, database) = try TestBackend.create()
+    let alchemy = RecordingAlchemyClientStub()
+    alchemy.setTransfersResponse(.transfers([]))
+    let registry = GRDBInstrumentRegistryRepository(database: database)
+    let discovery = CryptoTokenDiscoveryService(
+      registry: registry, resolver: CountingRegistrationResolver(), alchemy: alchemy)
+    let walletSyncEngine = WalletSyncEngine(
+      alchemy: alchemy, discovery: discovery,
+      walletSyncState: backend.walletSyncState,
+      importOriginFactory: { accountId in
+        ImportOrigin(
+          rawDescription: "wallet:\(accountId.uuidString)",
+          rawAmount: 0,
+          importedAt: Self.pinnedNow,
+          importSessionId: UUID(),
+          parserIdentifier: "alchemy-wallet-sync")
+      })
+    let walletApplyEngine = WalletApplyEngine(
+      transactions: backend.transactions,
+      walletSyncState: backend.walletSyncState,
+      importRules: NoOpWalletImportRulesEngine(),
+      clock: { Self.pinnedNow })
+    let store = CryptoSyncStore(
+      walletSyncEngine: walletSyncEngine,
+      walletApplyEngine: walletApplyEngine,
+      walletSyncState: backend.walletSyncState,
+      accounts: backend.accounts,
+      clock: { Self.pinnedNow })
+    return Fixture(
+      syncStore: store, backend: backend, database: database, alchemy: alchemy)
+  }
+
+  /// Seeds a crypto account so `accounts.fetchAll()` returns it.
+  @discardableResult
+  private func seedCryptoAccount(
+    in backend: CloudKitBackend,
+    walletAddress: String = "0x" + String(repeating: "a", count: 40),
+    chain: ChainConfig = .ethereum
+  ) async throws -> Account {
+    let account = Account(
+      name: "Wallet \(walletAddress.suffix(4))",
+      type: .crypto,
+      instrument: chain.nativeInstrument,
+      walletAddress: walletAddress.lowercased(),
+      chainId: chain.chainId)
+    return try await backend.accounts.create(account, openingBalance: nil)
+  }
+
+  /// Seeds a non-crypto account to assert the filter excludes it.
+  @discardableResult
+  private func seedAssetAccount(in backend: CloudKitBackend) async throws -> Account {
+    let account = Account(
+      name: "Savings",
+      type: .asset,
+      instrument: .AUD)
+    return try await backend.accounts.create(account, openingBalance: nil)
+  }
+
+  // MARK: - Filtering
+
+  @Test("Crypto filter surfaces only crypto-typed accounts")
+  func filterSurfacesOnlyCryptoAccounts() async throws {
+    let fixture = try makeFixture()
+    let crypto = try await seedCryptoAccount(in: fixture.backend)
+    _ = try await seedAssetAccount(in: fixture.backend)
+    let all = try await fixture.backend.accounts.fetchAll()
+
+    let cryptoOnly = all.filter { $0.type == .crypto }
+    #expect(cryptoOnly.count == 1)
+    #expect(cryptoOnly.first?.id == crypto.id)
+  }
+
+  // MARK: - Sync now action
+
+  @Test("syncAccount fires for a crypto account regardless of stale threshold")
+  func syncNowDispatchesEvenWhenFresh() async throws {
+    let fixture = try makeFixture()
+    let account = try await seedCryptoAccount(in: fixture.backend)
+
+    await fixture.syncStore.syncAccount(account)
+
+    // The recording stub sees one transfers call per (account, chain).
+    #expect(fixture.alchemy.recordedCalls.count >= 1)
+    // Per-account state is now populated.
+    #expect(fixture.syncStore.statePerAccount[account.id] != nil)
+  }
+
+  @Test("syncAccount is a no-op for non-crypto accounts")
+  func syncIgnoresNonCryptoAccounts() async throws {
+    let fixture = try makeFixture()
+    let asset = try await seedAssetAccount(in: fixture.backend)
+
+    await fixture.syncStore.syncAccount(asset)
+
+    #expect(fixture.alchemy.recordedCalls.isEmpty)
+    #expect(fixture.syncStore.statePerAccount[asset.id] == nil)
+  }
+
+  // MARK: - Last-synced state
+
+  @Test("After a successful sync, statePerAccount records lastSyncedAt")
+  func lastSyncedTimestampPopulatedOnSuccess() async throws {
+    let fixture = try makeFixture()
+    let account = try await seedCryptoAccount(in: fixture.backend)
+
+    await fixture.syncStore.syncAccount(account)
+
+    let state = try #require(fixture.syncStore.statePerAccount[account.id])
+    // Apply pass uses the injected clock; we pinned it to `pinnedNow`,
+    // so the timestamp should equal that. Comparing equality (not
+    // "approximate") catches drift if the clock injection regresses.
+    #expect(state.lastSyncedAt == Self.pinnedNow)
+    #expect(state.lastError == nil)
+  }
+}

--- a/MoolahTests/Features/Settings/DiscoveredTokensInboxTests.swift
+++ b/MoolahTests/Features/Settings/DiscoveredTokensInboxTests.swift
@@ -1,0 +1,183 @@
+// MoolahTests/Features/Settings/DiscoveredTokensInboxTests.swift
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+/// Tests for the data the Discovered Tokens inbox renders. The view
+/// itself is a thin SwiftUI shell (per CLAUDE.md "Thin Views, Testable
+/// Stores") — the testable surface is:
+///
+/// 1. `CryptoTokenStore.unpricedRegistrations` filters by status.
+/// 2. `CryptoTokenStore.setStatus(.spam, for:)` removes the row from
+///    the inbox.
+/// 3. `CryptoTokenDiscoveryService.reResolve(_:chain:)` flips an
+///    `.unpriced` row to a non-unpriced status when resolution
+///    succeeds, which makes the row drop out of the inbox after the
+///    store reloads.
+@Suite("Discovered Tokens inbox — data behaviour")
+@MainActor
+struct DiscoveredTokensInboxTests {
+  /// Bundle so tests can address every collaborator without re-deriving
+  /// it from the store. Mirrors `CryptoTokenStoreSetStatusTests.Fixture`.
+  private struct Fixture {
+    let store: CryptoTokenStore
+    let registry: GRDBInstrumentRegistryRepository
+    let resolver: CountingRegistrationResolver
+    let alchemy: CountingAlchemyClientStub
+    let discovery: CryptoTokenDiscoveryService
+  }
+
+  /// Builds a store + registry + discovery actor sharing a single
+  /// in-memory GRDB database, so a write through any of them is visible
+  /// to the others — the same coupling the production wiring has.
+  private func makeFixture() async throws -> Fixture {
+    let database = try ProfileDatabase.openInMemory()
+    let registry = GRDBInstrumentRegistryRepository(database: database)
+    let priceService = CryptoPriceService(
+      clients: [FixedCryptoPriceClient()], database: database)
+    let store = CryptoTokenStore(
+      registry: registry,
+      cryptoPriceService: priceService,
+      conversionService: RecordingConversionService())
+    let resolver = CountingRegistrationResolver()
+    let alchemy = CountingAlchemyClientStub()
+    let discovery = CryptoTokenDiscoveryService(
+      registry: registry, resolver: resolver, alchemy: alchemy)
+    return Fixture(
+      store: store, registry: registry, resolver: resolver,
+      alchemy: alchemy, discovery: discovery)
+  }
+
+  /// Seeds an unpriced registration directly through the registry — no
+  /// provider mappings, status forced to `.unpriced` via the
+  /// `update(_:)` path.
+  @discardableResult
+  private func seedUnpriced(
+    in registry: GRDBInstrumentRegistryRepository,
+    chainId: Int = 1,
+    contractAddress: String = "0xabcdef0123456789abcdef0123456789abcdef01",
+    symbol: String = "JUNK"
+  ) async throws -> CryptoRegistration {
+    let instrument = Instrument.crypto(
+      chainId: chainId, contractAddress: contractAddress,
+      symbol: symbol, name: symbol, decimals: 18)
+    let mapping = CryptoProviderMapping(
+      instrumentId: instrument.id, coingeckoId: nil,
+      cryptocompareSymbol: nil, binanceSymbol: nil)
+    try await registry.registerCrypto(instrument, mapping: mapping)
+    let registration = CryptoRegistration(
+      instrument: instrument, mapping: mapping, pricingStatus: .unpriced)
+    try await registry.update(registration)
+    return registration
+  }
+
+  // MARK: - Filtering
+
+  @Test("unpricedRegistrations surfaces only .unpriced rows")
+  func surfacesOnlyUnpricedRows() async throws {
+    let fixture = try await makeFixture()
+    // Seed one .unpriced + one .priced (a built-in preset).
+    _ = try await seedUnpriced(in: fixture.registry)
+    let priced = CryptoRegistration.builtInPresets[1]  // ETH preset
+    try await fixture.registry.registerCrypto(priced.instrument, mapping: priced.mapping)
+    await fixture.store.loadRegistrations()
+
+    let inbox = fixture.store.unpricedRegistrations
+    #expect(inbox.count == 1)
+    #expect(inbox.allSatisfy { $0.pricingStatus == .unpriced })
+  }
+
+  @Test("unpricedCount mirrors unpricedRegistrations count")
+  func unpricedCountMatchesArrayCount() async throws {
+    let fixture = try await makeFixture()
+    _ = try await seedUnpriced(
+      in: fixture.registry, contractAddress: "0x0000000000000000000000000000000000000001")
+    _ = try await seedUnpriced(
+      in: fixture.registry, contractAddress: "0x0000000000000000000000000000000000000002")
+    await fixture.store.loadRegistrations()
+
+    #expect(fixture.store.unpricedCount == 2)
+    #expect(fixture.store.unpricedCount == fixture.store.unpricedRegistrations.count)
+  }
+
+  @Test("Empty store surfaces zero unpriced registrations")
+  func emptyStoreYieldsZero() async throws {
+    let fixture = try await makeFixture()
+    await fixture.store.loadRegistrations()
+    #expect(fixture.store.unpricedRegistrations.isEmpty)
+    #expect(fixture.store.unpricedCount == 0)
+  }
+
+  // MARK: - Mark as spam
+
+  @Test("Marking spam removes the row from unpricedRegistrations")
+  func markSpamRemovesFromInbox() async throws {
+    let fixture = try await makeFixture()
+    let seeded = try await seedUnpriced(in: fixture.registry)
+    await fixture.store.loadRegistrations()
+    let registration = try #require(
+      fixture.store.unpricedRegistrations.first { $0.id == seeded.id })
+
+    await fixture.store.setStatus(.spam, for: registration)
+
+    #expect(fixture.store.unpricedRegistrations.isEmpty)
+    #expect(fixture.store.spamRegistrations.contains { $0.id == seeded.id })
+  }
+
+  // MARK: - Re-resolve
+
+  @Test("reResolve transitions an .unpriced row to .priced on resolver success")
+  func reResolveTransitionsUnpricedToPriced() async throws {
+    let fixture = try await makeFixture()
+    let seeded = try await seedUnpriced(in: fixture.registry, symbol: "RESOLVE")
+    await fixture.store.loadRegistrations()
+
+    // Script the resolver to succeed for this address.
+    let key = CountingRegistrationResolver.Key(
+      chainId: 1, contractAddress: seeded.instrument.contractAddress?.lowercased())
+    fixture.resolver.script(
+      key,
+      .success(coingecko: "resolve-ok", cryptocompare: nil, binance: nil))
+
+    let resolved = try await fixture.discovery.reResolve(seeded, chain: .ethereum)
+
+    #expect(resolved.pricingStatus == .priced)
+    // The store hasn't reloaded yet — confirm the registry reflects the
+    // change so the next `loadRegistrations()` call drops the row from
+    // the inbox.
+    let reloaded = try await fixture.registry.allCryptoRegistrations()
+    let updated = try #require(reloaded.first { $0.id == seeded.id })
+    #expect(updated.pricingStatus == .priced)
+  }
+
+  @Test("reResolve keeps the row .unpriced when no provider resolves it")
+  func reResolveLeavesUnpricedOnFailure() async throws {
+    let fixture = try await makeFixture()
+    let seeded = try await seedUnpriced(in: fixture.registry, symbol: "STILL")
+    await fixture.store.loadRegistrations()
+    fixture.resolver.setDefault(.failure(StubResolverFailure()))
+
+    let resolved = try await fixture.discovery.reResolve(seeded, chain: .ethereum)
+    #expect(resolved.pricingStatus == .unpriced)
+  }
+
+  @Test("reResolve issues exactly one resolver call per invocation")
+  func reResolveCallsResolverOnce() async throws {
+    let fixture = try await makeFixture()
+    let seeded = try await seedUnpriced(in: fixture.registry, symbol: "ONCE")
+    await fixture.store.loadRegistrations()
+
+    _ = try await fixture.discovery.reResolve(seeded, chain: .ethereum)
+
+    let key = CountingRegistrationResolver.Key(
+      chainId: 1, contractAddress: seeded.instrument.contractAddress?.lowercased())
+    #expect(fixture.resolver.callCount(for: key) == 1)
+  }
+
+  /// Locally-defined error type so tests don't depend on a particular
+  /// resolver-internal failure shape; `CountingRegistrationResolver`
+  /// rethrows whatever it's scripted with.
+  private struct StubResolverFailure: Error {}
+}

--- a/MoolahTests/Features/Settings/SpamTokensViewTests.swift
+++ b/MoolahTests/Features/Settings/SpamTokensViewTests.swift
@@ -1,0 +1,122 @@
+// MoolahTests/Features/Settings/SpamTokensViewTests.swift
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+/// Tests for the data the Spam Tokens view renders. Like the
+/// Discovered Tokens inbox, the testable surface is the store rather
+/// than the SwiftUI view:
+///
+/// 1. `CryptoTokenStore.spamRegistrations` filters by status.
+/// 2. `setStatus(.unpriced, for:)` (the "Restore" action) flips a
+///    spam row back to the inbox.
+@Suite("Spam Tokens view — data behaviour")
+@MainActor
+struct SpamTokensViewTests {
+  private struct Fixture {
+    let store: CryptoTokenStore
+    let registry: GRDBInstrumentRegistryRepository
+    let conversionService: RecordingConversionService
+  }
+
+  private func makeFixture() async throws -> Fixture {
+    let database = try ProfileDatabase.openInMemory()
+    let registry = GRDBInstrumentRegistryRepository(database: database)
+    let priceService = CryptoPriceService(
+      clients: [FixedCryptoPriceClient()], database: database)
+    let conversionService = RecordingConversionService()
+    let store = CryptoTokenStore(
+      registry: registry,
+      cryptoPriceService: priceService,
+      conversionService: conversionService)
+    return Fixture(
+      store: store, registry: registry, conversionService: conversionService)
+  }
+
+  /// Seed a registration with the given pricing status. Two-step write
+  /// because `registerCrypto` always inserts as `.priced` on first
+  /// write — `update(_:)` then forces the desired status.
+  @discardableResult
+  private func seed(
+    in registry: GRDBInstrumentRegistryRepository,
+    status: TokenPricingStatus,
+    contractAddress: String,
+    symbol: String
+  ) async throws -> CryptoRegistration {
+    let instrument = Instrument.crypto(
+      chainId: 1, contractAddress: contractAddress,
+      symbol: symbol, name: symbol, decimals: 18)
+    let mapping = CryptoProviderMapping(
+      instrumentId: instrument.id, coingeckoId: nil,
+      cryptocompareSymbol: nil, binanceSymbol: nil)
+    try await registry.registerCrypto(instrument, mapping: mapping)
+    let registration = CryptoRegistration(
+      instrument: instrument, mapping: mapping, pricingStatus: status)
+    try await registry.update(registration)
+    return registration
+  }
+
+  // MARK: - Filtering
+
+  @Test("spamRegistrations surfaces only .spam rows")
+  func surfacesOnlySpamRows() async throws {
+    let fixture = try await makeFixture()
+    _ = try await seed(
+      in: fixture.registry, status: .spam,
+      contractAddress: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", symbol: "SPAM")
+    _ = try await seed(
+      in: fixture.registry, status: .unpriced,
+      contractAddress: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", symbol: "UNPR")
+    let priced = CryptoRegistration.builtInPresets[1]
+    try await fixture.registry.registerCrypto(priced.instrument, mapping: priced.mapping)
+    await fixture.store.loadRegistrations()
+
+    let spam = fixture.store.spamRegistrations
+    #expect(spam.count == 1)
+    #expect(spam.allSatisfy { $0.pricingStatus == .spam })
+    #expect(spam.first?.instrument.ticker == "SPAM")
+  }
+
+  @Test("Empty store surfaces zero spam registrations")
+  func emptyStoreYieldsZero() async throws {
+    let fixture = try await makeFixture()
+    await fixture.store.loadRegistrations()
+    #expect(fixture.store.spamRegistrations.isEmpty)
+  }
+
+  // MARK: - Restore
+
+  @Test("Restore (setStatus(.unpriced)) moves the row out of spamRegistrations")
+  func restoreMovesRowOutOfSpamList() async throws {
+    let fixture = try await makeFixture()
+    let seeded = try await seed(
+      in: fixture.registry, status: .spam,
+      contractAddress: "0xcccccccccccccccccccccccccccccccccccccccc", symbol: "REST")
+    await fixture.store.loadRegistrations()
+    let registration = try #require(
+      fixture.store.spamRegistrations.first { $0.id == seeded.id })
+
+    await fixture.store.setStatus(.unpriced, for: registration)
+
+    #expect(fixture.store.spamRegistrations.isEmpty)
+    #expect(fixture.store.unpricedRegistrations.contains { $0.id == seeded.id })
+  }
+
+  @Test("Restore invalidates the conversion cache for the restored instrument")
+  func restoreInvalidatesConversionCache() async throws {
+    let fixture = try await makeFixture()
+    let seeded = try await seed(
+      in: fixture.registry, status: .spam,
+      contractAddress: "0xdddddddddddddddddddddddddddddddddddddddd", symbol: "INV")
+    await fixture.store.loadRegistrations()
+    let registration = try #require(
+      fixture.store.spamRegistrations.first { $0.id == seeded.id })
+
+    await fixture.store.setStatus(.unpriced, for: registration)
+
+    let invalidated = fixture.conversionService.invalidatedInstruments
+    #expect(invalidated.contains { $0.id == seeded.instrument.id })
+  }
+}

--- a/UITestSupport/UITestIdentifiers.swift
+++ b/UITestSupport/UITestIdentifiers.swift
@@ -270,6 +270,61 @@ public enum UITestIdentifiers {
     public static func registrationRow(_ id: String) -> String {
       "crypto.settings.registration.\(id)"
     }
+
+    /// Secure field for the Alchemy API key. Pinned so a UI test can
+    /// drive the Stage 11 settings flow end-to-end.
+    public static let alchemyApiKeyField = "crypto.settings.alchemy.field"
+
+    /// "Save" button next to the Alchemy API key entry field.
+    public static let alchemyApiKeySaveButton = "crypto.settings.alchemy.save"
+
+    /// "Remove" button shown when an Alchemy key is already configured.
+    public static let alchemyApiKeyRemoveButton = "crypto.settings.alchemy.remove"
+
+    /// A crypto account row in the accounts list. Qualifier is the
+    /// `Account.id` UUID.
+    public static func accountRow(_ id: UUID) -> String {
+      "crypto.settings.account.\(id.uuidString)"
+    }
+
+    /// Per-row "Sync now" button. Qualifier is the `Account.id` UUID.
+    public static func syncNowButton(_ id: UUID) -> String {
+      "crypto.settings.account.sync.\(id.uuidString)"
+    }
+
+    /// Navigation row that opens the Discovered Tokens inbox.
+    public static let discoveredTokensRow = "crypto.settings.discoveredTokens"
+
+    /// Navigation row that opens the Spam Tokens management view.
+    public static let spamTokensRow = "crypto.settings.spamTokens"
+
+    /// A row inside the Discovered Tokens inbox. Qualifier is the
+    /// `CryptoRegistration.id`.
+    public static func discoveredRow(_ id: String) -> String {
+      "crypto.settings.discovered.\(id)"
+    }
+
+    /// "Mark as spam" button on a Discovered Tokens row.
+    public static func markSpamButton(_ id: String) -> String {
+      "crypto.settings.discovered.spam.\(id)"
+    }
+
+    /// "Re-resolve" button on a Discovered Tokens row.
+    public static func reResolveButton(_ id: String) -> String {
+      "crypto.settings.discovered.reresolve.\(id)"
+    }
+
+    /// A row inside the Spam Tokens management view. Qualifier is the
+    /// `CryptoRegistration.id`.
+    public static func spamRow(_ id: String) -> String {
+      "crypto.settings.spam.\(id)"
+    }
+
+    /// "Restore" button on a Spam Tokens row — flips status back to
+    /// `.unpriced` so the row returns to the Discovered Tokens inbox.
+    public static func restoreButton(_ id: String) -> String {
+      "crypto.settings.spam.restore.\(id)"
+    }
   }
 
   public enum EditAccount {


### PR DESCRIPTION
## Summary

Stage 11 of `plans/2026-05-05-crypto-wallet-import-plan.md`. Adds the user-facing controls for the wallet auto-import on top of Stage 9's `CryptoSyncStore` (PR [#769](https://github.com/ajsutton/moolah-native/pull/769) — already merged, so this targets `main` directly).

- **Alchemy API key** — `SecureField` + status badge (Configured / Invalid / Not set) backed by the synced Keychain at `(com.moolah.api-keys, alchemy)`. The status badge reads `CryptoSyncStore.globalError`. Includes a "How to get an Alchemy API key" link.
- **Crypto Accounts list** — every `Account` of `type == .crypto` with relative last-synced timestamp + per-account "Sync now" button (calls `CryptoSyncStore.syncAccount(_:)`). Inline error caption when `WalletSyncState.lastError != nil`.
- **Discovered Tokens inbox** — new `DiscoveredTokensInboxView` listing `.unpriced` registrations. Per-row "Mark as spam" calls `CryptoTokenStore.setStatus(.spam, for:)`; "Re-resolve" drives `CryptoTokenDiscoveryService.reResolve(_:chain:)` (the same actor instance the sync engine uses, so the in-flight coalescer's one-round-trip-per-key guarantee is preserved).
- **Spam Tokens view** — new `SpamTokensView` listing `.spam` registrations. Per-row "Restore" calls `setStatus(.unpriced, ...)` so the row returns to the inbox.
- **Sidebar / preferences badge** — `CryptoTokenStore.unpricedCount` (computed from current registrations). Surfaced as a count pill on the Discovered Tokens row.

Privacy: API keys are never logged; `os.Logger` only sees keychain `OSStatus` codes on failure.

## Pre-existing fix

`GRDBInstrumentRegistryRepository.allCryptoRegistrations()` and `cryptoRegistration(byId:)` previously filtered out rows with all-nil provider mappings. That meant the `.unpriced` and `.spam` rows the discovery actor writes were invisible to the inbox + spam UI (the very surfaces this stage delivers). The filter now includes mapping-less rows when their `pricingStatus` is non-default; legacy CSV-import placeholders (`.priced` + no mapping) remain hidden.

## Test plan

- [x] `just format-check` clean.
- [x] `just test` — 2321 macOS / 2296 iOS tests pass.
- [x] New tests:
  - `CryptoSettingsAPIKeyTests` — keychain round-trip, account isolation, privacy.
  - `DiscoveredTokensInboxTests` — `.unpriced` filter, mark-as-spam, re-resolve flips `.unpriced` → `.priced` on resolver success.
  - `SpamTokensViewTests` — `.spam` filter, restore flips back to `.unpriced` and invalidates conversion cache.
  - `CryptoSettingsAccountsListTests` — crypto-only filter, `syncAccount` dispatches, `lastSyncedAt` populated.
- [x] Self-reviewed against `ui-review` and `code-review` agent specs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)