### PR TITLE
feat(crypto): wallet account view + transaction detail enhancements

### DIFF
--- a/App/ContentView.swift
+++ b/App/ContentView.swift
@@ -340,17 +340,33 @@ extension ContentView {
           investmentStore: investmentStore,
           transactionStore: transactionStore)
       } else {
-        TransactionListView(
-          title: account.name,
-          filter: TransactionFilter(accountId: account.id),
-          accounts: accountStore.accounts,
-          categories: categoryStore.categories,
-          earmarks: earmarkStore.earmarks,
-          transactionStore: transactionStore,
-          positions: accountStore.positions(for: account.id),
-          positionsHostCurrency: account.instrument,
-          positionsTitle: account.name,
-          conversionService: session.backend.conversionService)
+        VStack(spacing: 0) {
+          // Crypto wallets get a header bar above the transaction list
+          // showing the truncated address, chain, last-synced state,
+          // and a Sync now action. Skipped for non-crypto accounts and
+          // for crypto accounts whose `chainId` couldn't be resolved
+          // (defensive — surfaces a config gap rather than crashing).
+          if account.type == .crypto, let chainId = account.chainId,
+            let chain = ChainConfig.config(for: chainId),
+            let cryptoSyncStore = session.cryptoSyncStore
+          {
+            WalletAccountHeaderView(
+              account: account,
+              chain: chain,
+              cryptoSyncStore: cryptoSyncStore)
+          }
+          TransactionListView(
+            title: account.name,
+            filter: TransactionFilter(accountId: account.id),
+            accounts: accountStore.accounts,
+            categories: categoryStore.categories,
+            earmarks: earmarkStore.earmarks,
+            transactionStore: transactionStore,
+            positions: accountStore.positions(for: account.id),
+            positionsHostCurrency: account.instrument,
+            positionsTitle: account.name,
+            conversionService: session.backend.conversionService)
+        }
       }
     }
   }

--- a/Features/Crypto/WalletAccountHeaderView.swift
+++ b/Features/Crypto/WalletAccountHeaderView.swift
@@ -1,0 +1,222 @@
+// Features/Crypto/WalletAccountHeaderView.swift
+import Foundation
+import SwiftUI
+
+#if os(macOS)
+  import AppKit
+#else
+  import UIKit
+#endif
+
+/// Compact header for an `AccountType.crypto` account view. Renders:
+///
+/// - Truncated wallet address (`0xabcd…wxyz`) rendered in a monospaced font
+///   with a copy button alongside.
+/// - Chain display name (e.g. "Ethereum").
+/// - Last-synced relative timestamp ("Synced 2h ago") or "Never synced"
+///   when the account has no checkpoint yet.
+/// - "Sync now" button that calls `cryptoSyncStore.syncAccount(account)`
+///   and is disabled while a sync is in flight for this account.
+/// - Overflow menu with "View on block explorer" → opens the chain's
+///   address URL in the user's default browser.
+///
+/// Pure presentation: every piece of business logic that benefits from
+/// unit testing (truncation, last-synced formatting, sync button state)
+/// lives in `WalletAccountHeaderLogic` so
+/// `WalletAccountHeaderViewLogicTests` can exercise the contract without
+/// spinning up a SwiftUI view.
+struct WalletAccountHeaderView: View {
+  let account: Account
+  let chain: ChainConfig
+  let cryptoSyncStore: CryptoSyncStore
+
+  /// Closure used to copy the supplied string to the system pasteboard.
+  /// Defaulted to the platform's standard pasteboard so production code
+  /// has a single sensible default; tests / previews override.
+  /// `@MainActor` because the production defaults call `NSPasteboard` /
+  /// `UIPasteboard`, both of which are main-actor-isolated.
+  let copyToPasteboard: @MainActor (String) -> Void
+
+  /// Closure used to open a URL in the user's default browser.
+  /// Defaulted to the platform-standard handler; tests override.
+  /// `@MainActor` for the same reason as `copyToPasteboard`.
+  let openExternalURL: @MainActor (URL) -> Void
+
+  init(
+    account: Account,
+    chain: ChainConfig,
+    cryptoSyncStore: CryptoSyncStore,
+    copyToPasteboard: @escaping @MainActor (String) -> Void = WalletAccountHeaderView.defaultCopy,
+    openExternalURL: @escaping @MainActor (URL) -> Void = WalletAccountHeaderView.defaultOpen
+  ) {
+    self.account = account
+    self.chain = chain
+    self.cryptoSyncStore = cryptoSyncStore
+    self.copyToPasteboard = copyToPasteboard
+    self.openExternalURL = openExternalURL
+  }
+
+  private var address: String { account.walletAddress ?? "" }
+
+  private var truncatedAddress: String {
+    WalletAccountHeaderLogic.truncateAddress(address)
+  }
+
+  private var lastSyncedText: String {
+    WalletAccountHeaderLogic.lastSyncedText(
+      state: cryptoSyncStore.statePerAccount[account.id], now: Date())
+  }
+
+  private var isSyncing: Bool {
+    cryptoSyncStore.inProgressAccountIds.contains(account.id)
+  }
+
+  var body: some View {
+    HStack(spacing: 12) {
+      addressSection
+      Spacer(minLength: 12)
+      Text(chain.displayName)
+        .font(.subheadline)
+        .foregroundStyle(.secondary)
+        .accessibilityIdentifier(UITestIdentifiers.WalletAccountHeader.chainName)
+      Text(lastSyncedText)
+        .font(.subheadline)
+        .foregroundStyle(.secondary)
+        .monospacedDigit()
+        .accessibilityIdentifier(UITestIdentifiers.WalletAccountHeader.lastSynced)
+      syncButton
+      overflowMenu
+    }
+    .padding(.horizontal, 12)
+    .padding(.vertical, 8)
+    .background(.regularMaterial)
+    .accessibilityElement(children: .contain)
+    .accessibilityIdentifier(UITestIdentifiers.WalletAccountHeader.container)
+  }
+
+  private var addressSection: some View {
+    HStack(spacing: 6) {
+      Text(truncatedAddress)
+        .font(.body.monospaced())
+        .accessibilityIdentifier(UITestIdentifiers.WalletAccountHeader.truncatedAddress)
+        .accessibilityLabel("Wallet address \(address)")
+      Button {
+        copyToPasteboard(address)
+      } label: {
+        Label("Copy address", systemImage: "doc.on.doc")
+          .labelStyle(.iconOnly)
+      }
+      .buttonStyle(.borderless)
+      .help("Copy full wallet address")
+      .accessibilityLabel("Copy wallet address")
+      .accessibilityIdentifier(UITestIdentifiers.WalletAccountHeader.copyAddressButton)
+      .disabled(address.isEmpty)
+    }
+  }
+
+  private var syncButton: some View {
+    Button {
+      Task { await cryptoSyncStore.syncAccount(account) }
+    } label: {
+      if isSyncing {
+        ProgressView().controlSize(.small)
+      } else {
+        Label("Sync now", systemImage: "arrow.clockwise")
+      }
+    }
+    .disabled(isSyncing)
+    .help("Sync wallet now")
+    .accessibilityLabel("Sync wallet now")
+    .accessibilityIdentifier(UITestIdentifiers.WalletAccountHeader.syncButton)
+  }
+
+  private var overflowMenu: some View {
+    Menu {
+      Button {
+        guard
+          let chainId = account.chainId,
+          let url = BlockExplorerLink.addressURL(chainId: chainId, address: address)
+        else { return }
+        openExternalURL(url)
+      } label: {
+        Label("View on block explorer", systemImage: "arrow.up.right.square")
+      }
+      .disabled(account.chainId == nil || address.isEmpty)
+    } label: {
+      Label("More", systemImage: "ellipsis.circle")
+        .labelStyle(.iconOnly)
+    }
+    .menuStyle(.borderlessButton)
+    .help("More wallet actions")
+    .accessibilityLabel("More wallet actions")
+    .accessibilityIdentifier(UITestIdentifiers.WalletAccountHeader.overflowMenu)
+  }
+}
+
+// MARK: - Pasteboard / browser defaults
+
+extension WalletAccountHeaderView {
+  /// Platform-default clipboard write. Lives on the view so tests can
+  /// substitute a recording closure via the initialiser without touching
+  /// the system pasteboard.
+  static func defaultCopy(_ text: String) {
+    #if os(macOS)
+      NSPasteboard.general.clearContents()
+      NSPasteboard.general.setString(text, forType: .string)
+    #else
+      UIPasteboard.general.string = text
+    #endif
+  }
+
+  /// Platform-default URL opener. Lives on the view so tests can
+  /// substitute a recording closure without spawning a real browser.
+  static func defaultOpen(_ url: URL) {
+    #if os(macOS)
+      NSWorkspace.shared.open(url)
+    #else
+      UIApplication.shared.open(url)
+    #endif
+  }
+}
+
+// MARK: - Pure logic
+
+/// Pure-logic helper for `WalletAccountHeaderView`. Owns the truncation
+/// rule, the relative-time formatting for the last-synced label, and the
+/// "is sync allowed" predicate so they are all unit-testable without
+/// instantiating a SwiftUI view.
+enum WalletAccountHeaderLogic {
+  /// Truncates a `0x…` wallet address to a `0xabcd…wxyz` shape: 6 leading
+  /// characters (including the `0x` prefix), an ellipsis, and 4 trailing
+  /// characters. Same convention as Etherscan / wallet UIs.
+  ///
+  /// Addresses shorter than 11 characters fall through unchanged — they
+  /// can't be truncated in a way that adds clarity, and are treated as
+  /// already-displayable.
+  static func truncateAddress(_ address: String) -> String {
+    guard address.count >= 11 else { return address }
+    let prefix = address.prefix(6)
+    let suffix = address.suffix(4)
+    return "\(prefix)…\(suffix)"
+  }
+
+  /// User-facing relative-time label for the wallet's last successful
+  /// sync. `nil` state → "Never synced". Otherwise uses
+  /// `RelativeDateTimeFormatter.short` and prefixes "Synced ".
+  static func lastSyncedText(state: WalletSyncState?, now: Date) -> String {
+    guard let lastSyncedAt = state?.lastSyncedAt else { return "Never synced" }
+    let formatter = RelativeDateTimeFormatter()
+    formatter.unitsStyle = .short
+    let relative = formatter.localizedString(for: lastSyncedAt, relativeTo: now)
+    return "Synced \(relative)"
+  }
+
+  /// Whether the "Sync now" button should be enabled for the given
+  /// account, given the store's in-flight set. Mirrors
+  /// `CryptoSyncStore.syncAccount`'s own guard so the UI agrees with the
+  /// store's behaviour (a tap during sync is a no-op, so the button
+  /// shouldn't pretend otherwise).
+  static func isSyncEnabled(accountId: UUID, inProgress: Set<UUID>) -> Bool {
+    !inProgress.contains(accountId)
+  }
+}

--- a/Features/Transactions/Views/Detail/TransactionDetailBlockExplorerSection.swift
+++ b/Features/Transactions/Views/Detail/TransactionDetailBlockExplorerSection.swift
@@ -1,0 +1,68 @@
+import SwiftUI
+
+/// "Block explorer" section in the transaction detail. Shown when at
+/// least one of the transaction's legs has an `externalId` (the on-chain
+/// tx hash recorded by the wallet importer) and a resolvable chain id.
+/// One link per qualifying leg — for a multi-leg merged transfer with
+/// gas + value legs sharing the same hash, both legs render their own
+/// row so the user can see explicit per-leg provenance.
+///
+/// We deliberately render this as plain `Link` rows rather than a
+/// stylised "Open in Etherscan" pill: explorers across chains use
+/// different domains, and the brand-neutral "View on block explorer"
+/// label avoids privileging any one service in our UI.
+struct TransactionDetailBlockExplorerSection: View {
+  let transaction: Transaction
+
+  /// Legs with both an `externalId` and a chain id resolvable via
+  /// `ChainConfig`, paired with their canonical explorer URL.
+  /// Computed once per render so the body is straight-line code.
+  private var entries: [Entry] {
+    transaction.legs.enumerated().compactMap { index, leg -> Entry? in
+      guard let externalId = leg.externalId,
+        let chainId = leg.instrument.chainId,
+        let url = BlockExplorerLink.transactionURL(chainId: chainId, hash: externalId)
+      else { return nil }
+      return Entry(legIndex: index, url: url, ticker: leg.instrument.displayLabel)
+    }
+  }
+
+  /// Whether the section should render at all. Hidden when no leg has a
+  /// usable explorer link so the section header doesn't appear empty.
+  var isApplicable: Bool { !entries.isEmpty }
+
+  var body: some View {
+    if isApplicable {
+      let legs = entries
+      Section("Block Explorer") {
+        ForEach(legs) { entry in
+          Link(destination: entry.url) {
+            Label("View on block explorer", systemImage: "arrow.up.right.square")
+              .accessibilityLabel(accessibilityLabel(for: entry, totalLegs: legs.count))
+          }
+          .accessibilityIdentifier(
+            UITestIdentifiers.Detail.blockExplorerLink(legIndex: entry.legIndex))
+        }
+      }
+    }
+  }
+
+  /// VoiceOver label that disambiguates per-leg links in the multi-leg
+  /// case ("View ETH leg on block explorer") and stays terse in the
+  /// common single-leg case ("View on block explorer").
+  private func accessibilityLabel(for entry: Entry, totalLegs: Int) -> String {
+    totalLegs == 1
+      ? "View on block explorer"
+      : "View \(entry.ticker) leg on block explorer"
+  }
+
+  /// One renderable row. `legIndex` doubles as the `Identifiable` id —
+  /// stable across re-renders because the leg order is fixed by the
+  /// transaction.
+  private struct Entry: Identifiable {
+    let legIndex: Int
+    let url: URL
+    let ticker: String
+    var id: Int { legIndex }
+  }
+}

--- a/Features/Transactions/Views/TransactionDetailView.swift
+++ b/Features/Transactions/Views/TransactionDetailView.swift
@@ -154,6 +154,10 @@ extension TransactionDetailView {
   private var formContent: some View {
     Form {
       modeAwareSections
+      // Per-leg block-explorer links for any leg with an externalId
+      // (on-chain tx hash). Skipped when no leg qualifies — the section
+      // hides itself rather than rendering an empty header.
+      TransactionDetailBlockExplorerSection(transaction: transaction)
       if isScheduled {
         TransactionDetailPaySection(
           transaction: transaction,

--- a/MoolahTests/Features/Crypto/WalletAccountHeaderViewLogicTests.swift
+++ b/MoolahTests/Features/Crypto/WalletAccountHeaderViewLogicTests.swift
@@ -1,0 +1,95 @@
+// MoolahTests/Features/Crypto/WalletAccountHeaderViewLogicTests.swift
+import Foundation
+import Testing
+
+@testable import Moolah
+
+/// Pure-logic tests for `WalletAccountHeaderLogic` — the truncation
+/// rule, the relative-time formatting for the last-synced label, and the
+/// "is sync allowed" predicate. These are the load-bearing pieces of the
+/// wallet-header view; the SwiftUI rendering itself is exercised via
+/// preview snapshots and the UI driver suite.
+@Suite("WalletAccountHeaderLogic")
+struct WalletAccountHeaderViewLogicTests {
+  // MARK: - Address truncation
+
+  @Test("Canonical 0x address truncates to first 6 + ellipsis + last 4")
+  func canonicalAddressTruncatesToShortForm() {
+    let address = "0xabcdef0123456789abcdef0123456789abcdwxyz"
+    let truncated = WalletAccountHeaderLogic.truncateAddress(address)
+    #expect(truncated == "0xabcd…wxyz")
+  }
+
+  @Test("0x + 40 hex chars produces 11-character truncated label")
+  func standardEvmAddressProducesElevenCharacterLabel() {
+    let address = "0x" + String(repeating: "f", count: 40)
+    let truncated = WalletAccountHeaderLogic.truncateAddress(address)
+    // 6 (prefix) + 1 (ellipsis) + 4 (suffix) = 11 grapheme clusters.
+    #expect(truncated.count == 11)
+    #expect(truncated.hasPrefix("0xffff"))
+    #expect(truncated.hasSuffix("ffff"))
+    #expect(truncated.contains("…"))
+  }
+
+  @Test("Address shorter than the truncation threshold passes through unchanged")
+  func shortAddressIsNotTruncated() {
+    // 10 chars — below the 11-char threshold; truncation can't add clarity.
+    let short = "0xabcd1234"
+    #expect(WalletAccountHeaderLogic.truncateAddress(short) == short)
+  }
+
+  @Test("Empty address passes through as empty string")
+  func emptyAddressIsUnchanged() {
+    #expect(WalletAccountHeaderLogic.truncateAddress("").isEmpty)
+  }
+
+  // MARK: - Last-synced text
+
+  @Test("Nil sync state renders as 'Never synced'")
+  func neverSyncedWhenStateAbsent() {
+    let label = WalletAccountHeaderLogic.lastSyncedText(state: nil, now: Date())
+    #expect(label == "Never synced")
+  }
+
+  @Test("Recent sync renders with the 'Synced ' prefix")
+  func recentSyncIsPrefixedWithSynced() {
+    let now = Date(timeIntervalSince1970: 1_700_000_000)
+    let oneMinuteAgo = now.addingTimeInterval(-60)
+    let state = WalletSyncState(
+      id: UUID(), lastSyncedBlockNumber: 0, lastSyncedAt: oneMinuteAgo, lastError: nil)
+    let label = WalletAccountHeaderLogic.lastSyncedText(state: state, now: now)
+    #expect(label.hasPrefix("Synced "))
+    // The locale-specific RelativeDateTimeFormatter output isn't a stable
+    // assertion target across CI environments — we pin only the prefix
+    // and that the label is non-empty after the space.
+    #expect(label.count > "Synced ".count)
+  }
+
+  @Test("Two-hour-old sync uses a non-empty relative description")
+  func twoHourOldSyncHasNonEmptyDescription() {
+    let now = Date(timeIntervalSince1970: 1_700_000_000)
+    let twoHoursAgo = now.addingTimeInterval(-7_200)
+    let state = WalletSyncState(
+      id: UUID(), lastSyncedBlockNumber: 1_234, lastSyncedAt: twoHoursAgo, lastError: nil)
+    let label = WalletAccountHeaderLogic.lastSyncedText(state: state, now: now)
+    #expect(label.hasPrefix("Synced "))
+    let trailing = label.dropFirst("Synced ".count)
+    #expect(!trailing.isEmpty)
+  }
+
+  // MARK: - Sync-now enabled state
+
+  @Test("Sync-now button enabled when account is not in flight")
+  func syncEnabledWhenNotInFlight() {
+    let id = UUID()
+    #expect(WalletAccountHeaderLogic.isSyncEnabled(accountId: id, inProgress: []))
+    #expect(
+      WalletAccountHeaderLogic.isSyncEnabled(accountId: id, inProgress: [UUID()]))
+  }
+
+  @Test("Sync-now button disabled while account is in flight")
+  func syncDisabledWhenInFlight() {
+    let id = UUID()
+    #expect(!WalletAccountHeaderLogic.isSyncEnabled(accountId: id, inProgress: [id]))
+  }
+}

--- a/MoolahTests/Shared/CryptoImport/BlockExplorerLinkTests.swift
+++ b/MoolahTests/Shared/CryptoImport/BlockExplorerLinkTests.swift
@@ -1,0 +1,102 @@
+// MoolahTests/Shared/CryptoImport/BlockExplorerLinkTests.swift
+import Foundation
+import Testing
+
+@testable import Moolah
+
+/// URL-builder contract tests for `BlockExplorerLink`. Asserts the exact
+/// canonical form per chain (Etherscan / Optimistic Etherscan / BaseScan
+/// / PolygonScan) and the `nil` defensive return for unsupported chains.
+@Suite("BlockExplorerLink")
+struct BlockExplorerLinkTests {
+  /// 32-byte tx hash (64 hex chars + `0x` prefix). Reused so the
+  /// assertion stays anchored on the URL shape rather than literals.
+  private static let txHash =
+    "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+  private static let address = "0x1234567890abcdef1234567890abcdef12345678"
+
+  // MARK: - transactionURL
+
+  @Test("Ethereum transaction URL points at etherscan.io/tx/<hash>")
+  func ethereumTransactionURL() {
+    let url = BlockExplorerLink.transactionURL(chainId: 1, hash: Self.txHash)
+    #expect(url?.absoluteString == "https://etherscan.io/tx/\(Self.txHash)")
+  }
+
+  @Test("OP Mainnet transaction URL points at optimistic.etherscan.io/tx/<hash>")
+  func optimismTransactionURL() {
+    let url = BlockExplorerLink.transactionURL(chainId: 10, hash: Self.txHash)
+    #expect(url?.absoluteString == "https://optimistic.etherscan.io/tx/\(Self.txHash)")
+  }
+
+  @Test("Base transaction URL points at basescan.org/tx/<hash>")
+  func baseTransactionURL() {
+    let url = BlockExplorerLink.transactionURL(chainId: 8453, hash: Self.txHash)
+    #expect(url?.absoluteString == "https://basescan.org/tx/\(Self.txHash)")
+  }
+
+  @Test("Polygon transaction URL points at polygonscan.com/tx/<hash>")
+  func polygonTransactionURL() {
+    let url = BlockExplorerLink.transactionURL(chainId: 137, hash: Self.txHash)
+    #expect(url?.absoluteString == "https://polygonscan.com/tx/\(Self.txHash)")
+  }
+
+  @Test("Unknown chain id returns nil for transactionURL")
+  func unknownChainTransactionURLIsNil() {
+    #expect(BlockExplorerLink.transactionURL(chainId: 0, hash: Self.txHash) == nil)
+    #expect(BlockExplorerLink.transactionURL(chainId: 42_161, hash: Self.txHash) == nil)
+    #expect(BlockExplorerLink.transactionURL(chainId: 999_999, hash: Self.txHash) == nil)
+  }
+
+  // MARK: - addressURL
+
+  @Test("Ethereum address URL points at etherscan.io/address/<addr>")
+  func ethereumAddressURL() {
+    let url = BlockExplorerLink.addressURL(chainId: 1, address: Self.address)
+    #expect(url?.absoluteString == "https://etherscan.io/address/\(Self.address)")
+  }
+
+  @Test("OP Mainnet address URL points at optimistic.etherscan.io/address/<addr>")
+  func optimismAddressURL() {
+    let url = BlockExplorerLink.addressURL(chainId: 10, address: Self.address)
+    #expect(url?.absoluteString == "https://optimistic.etherscan.io/address/\(Self.address)")
+  }
+
+  @Test("Base address URL points at basescan.org/address/<addr>")
+  func baseAddressURL() {
+    let url = BlockExplorerLink.addressURL(chainId: 8453, address: Self.address)
+    #expect(url?.absoluteString == "https://basescan.org/address/\(Self.address)")
+  }
+
+  @Test("Polygon address URL points at polygonscan.com/address/<addr>")
+  func polygonAddressURL() {
+    let url = BlockExplorerLink.addressURL(chainId: 137, address: Self.address)
+    #expect(url?.absoluteString == "https://polygonscan.com/address/\(Self.address)")
+  }
+
+  @Test("Unknown chain id returns nil for addressURL")
+  func unknownChainAddressURLIsNil() {
+    #expect(BlockExplorerLink.addressURL(chainId: 0, address: Self.address) == nil)
+    #expect(BlockExplorerLink.addressURL(chainId: 42_161, address: Self.address) == nil)
+  }
+
+  // MARK: - URL well-formedness
+
+  @Test("Generated URLs have exactly one slash between segments (no doubles)")
+  func urlsAreWellFormed() {
+    // Smoke test against every supported chain — the appendingPathComponent
+    // contract guarantees this, but the test pins it so a future
+    // refactor that switches to string concatenation can't silently
+    // regress double-slash handling.
+    for chain in ChainConfig.all {
+      let txURL = BlockExplorerLink.transactionURL(chainId: chain.chainId, hash: Self.txHash)
+      let addressURL = BlockExplorerLink.addressURL(
+        chainId: chain.chainId, address: Self.address)
+      #expect(txURL?.absoluteString.contains("//tx/") == false)
+      #expect(addressURL?.absoluteString.contains("//address/") == false)
+      // The `https://` prefix is the only legitimate `//` in the URL.
+      #expect((txURL?.absoluteString.components(separatedBy: "//").count ?? 0) == 2)
+      #expect((addressURL?.absoluteString.components(separatedBy: "//").count ?? 0) == 2)
+    }
+  }
+}

--- a/Shared/CryptoImport/BlockExplorerLink.swift
+++ b/Shared/CryptoImport/BlockExplorerLink.swift
@@ -1,0 +1,42 @@
+// Shared/CryptoImport/BlockExplorerLink.swift
+import Foundation
+
+/// Per-chain block-explorer URL builder. Maps a chain ID + on-chain hash
+/// or address to the canonical explorer URL for that chain.
+///
+/// Returns `nil` if the chain id is unknown — callers (the wallet account
+/// header, the per-leg link in the transaction detail) can omit the link
+/// rather than crashing on a future chain that ships before its
+/// `ChainConfig` entry. Adding a new chain to `ChainConfig.all` is the
+/// only change required for both `transactionURL` and `addressURL` to
+/// pick it up.
+///
+/// Foundation-only by design: this lives next to `ChainConfig` in
+/// `Shared/CryptoImport` and is intentionally usable from any layer
+/// (Domain, Features) without dragging in SwiftUI.
+enum BlockExplorerLink {
+  /// Canonical transaction URL for the given chain — e.g.
+  /// `https://etherscan.io/tx/<hash>`,
+  /// `https://optimistic.etherscan.io/tx/<hash>`,
+  /// `https://basescan.org/tx/<hash>`,
+  /// `https://polygonscan.com/tx/<hash>`.
+  ///
+  /// `hash` is the lowercased on-chain transaction hash recorded as
+  /// `TransactionLeg.externalId` at import time.
+  static func transactionURL(chainId: Int, hash: String) -> URL? {
+    guard let chain = ChainConfig.config(for: chainId) else { return nil }
+    return chain.blockExplorerBaseURL
+      .appendingPathComponent("tx", isDirectory: false)
+      .appendingPathComponent(hash, isDirectory: false)
+  }
+
+  /// Canonical address URL for the given chain — e.g.
+  /// `https://etherscan.io/address/<addr>`. Used by the wallet-account
+  /// header's "View on block explorer" overflow menu item.
+  static func addressURL(chainId: Int, address: String) -> URL? {
+    guard let chain = ChainConfig.config(for: chainId) else { return nil }
+    return chain.blockExplorerBaseURL
+      .appendingPathComponent("address", isDirectory: false)
+      .appendingPathComponent(address, isDirectory: false)
+  }
+}

--- a/UITestSupport/UITestIdentifiers.swift
+++ b/UITestSupport/UITestIdentifiers.swift
@@ -119,6 +119,14 @@ public enum UITestIdentifiers {
     public static func tradeFeeRemove(_ index: Int) -> String {
       "transactionDetail.trade.feeRemove.\(index)"
     }
+
+    /// "View on block explorer" link for the leg at the given index.
+    /// Only rendered when the leg has a non-nil `externalId` (the on-chain
+    /// transaction hash recorded by the wallet importer) and a chain id
+    /// resolvable through `ChainConfig`.
+    public static func blockExplorerLink(legIndex: Int) -> String {
+      "detail.leg.\(legIndex).blockExplorer"
+    }
   }
 
   public enum SyncFooter {
@@ -214,6 +222,35 @@ public enum UITestIdentifiers {
     /// `CreateAccountView`. The user pastes a `0x…` address here;
     /// validation lives in `Account.validatedWalletAddress`.
     public static let walletAddressField = "createAccount.crypto.walletAddress"
+  }
+
+  public enum WalletAccountHeader {
+    /// Container of the `WalletAccountHeaderView` bar shown above the
+    /// transaction list on a `.crypto` account. Sentinel for "the
+    /// wallet header is on screen".
+    public static let container = "wallet.header.container"
+
+    /// Truncated `0xabcd…wxyz` wallet-address label. The full address
+    /// is exposed via the row's `accessibilityLabel`.
+    public static let truncatedAddress = "wallet.header.address"
+
+    /// Copy-address button. Tapping copies the full lowercased
+    /// wallet address to the system pasteboard.
+    public static let copyAddressButton = "wallet.header.copyAddress"
+
+    /// Chain display-name label (e.g. "Ethereum").
+    public static let chainName = "wallet.header.chain"
+
+    /// Last-synced relative-time label (e.g. "Synced 2h ago" or
+    /// "Never synced").
+    public static let lastSynced = "wallet.header.lastSynced"
+
+    /// "Sync now" button. Disabled while the account is in-flight.
+    public static let syncButton = "wallet.header.syncNow"
+
+    /// Overflow menu button (ellipsis). Holds the
+    /// "View on block explorer" action.
+    public static let overflowMenu = "wallet.header.overflowMenu"
   }
 
   public enum CryptoSettings {


### PR DESCRIPTION
## Summary

Stage 12 of `plans/2026-05-05-crypto-wallet-import-plan.md`. Adds the visible surface of a tracked wallet:

- **`WalletAccountHeaderView`** (new, `Features/Crypto/`): compact bar above the transaction list on `.crypto` accounts. Truncated wallet address (`0xabcd…wxyz`) in monospaced font with a copy button, chain name, last-synced relative timestamp, "Sync now" button (disabled while sync is in flight), and an overflow menu with "View on block explorer" → opens the chain's address URL.
- **`BlockExplorerLink`** (new, `Shared/CryptoImport/`): Foundation-only per-chain URL builder. Maps `(chainId, hash)` → `etherscan.io/tx/<hash>` (or `optimistic.etherscan.io`, `basescan.org`, `polygonscan.com`); same for `address` URLs. Returns `nil` for unknown chains so the UI can hide the link rather than crash.
- **`TransactionDetailBlockExplorerSection`** (new): per-leg "View on block explorer" link for any leg with a non-nil `externalId`. Single section appended to the form across simple / trade / custom modes; one row per qualifying leg. VoiceOver label disambiguates by token ticker in the multi-leg case.

The header is wired through `App/ContentView.accountDetail(id:)` only when the account is `.crypto`, has a `chainId`, and the profile has a `cryptoSyncStore` available. Non-crypto accounts are unaffected.

Counterparty address still rides on `Transaction.notes` (per design §"Transaction detail (crypto)") — not surfaced as a clickable URL. The structured `counterpartyAddress` field on `TransactionLeg` is deferred to issue #754.

Pure-logic helpers (`WalletAccountHeaderLogic`) keep the SwiftUI view thin: address truncation, last-synced relative formatting, and the "is sync allowed" predicate are all unit-testable without instantiating the view.

## Test plan

- [x] `BlockExplorerLinkTests` — URL shape per chain (ETH/OP/Base/Polygon) for both `tx/` and `address/` paths; unknown chain id returns `nil`; URLs are well-formed (no double slashes).
- [x] `WalletAccountHeaderViewLogicTests` — address truncation (`0x…40 hex` → 11-char `0xabcd…wxyz`), short addresses pass through, empty string handled; last-synced text (`nil` → "Never synced", recent → "Synced …" prefix); sync-button enabled state mirrors `inProgressAccountIds`.
- [x] `just format-check` clean.
- [x] `just test` — 2313 iOS + 2338 macOS tests pass.
- [x] Zero compiler warnings on macOS build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)