### PR TITLE
test(infra): capture os.Logger emissions in tests

### DIFF
--- a/MoolahTests/Support/LogCapture.swift
+++ b/MoolahTests/Support/LogCapture.swift
@@ -1,0 +1,106 @@
+// MoolahTests/Support/LogCapture.swift
+import Foundation
+import OSLog
+
+/// Test seam for asserting `os.Logger` emissions.
+///
+/// `Logger` does not expose a public sink for in-process inspection, so
+/// production code is never asked to log through an indirection. Instead,
+/// tests retrieve emissions after the fact via `OSLogStore` scoped to the
+/// current process. The helper records the position of the unified log
+/// before `body` runs and reads back the entries written between that
+/// position and the end of the body.
+///
+/// Scope is `.currentProcessIdentifier` (no `com.apple.logging.local-store`
+/// entitlement required) and works on macOS and the iOS Simulator.
+enum LogCapture {
+  /// One captured log entry. Equatable so tests can assert against an
+  /// expected list with `#expect(captured == [...])`.
+  struct Entry: Sendable, Equatable {
+    /// `OSLogEntryLog.Level` — `.debug`, `.info`, `.notice`, `.error`,
+    /// `.fault`. `Logger.warning(_:)` emits at level `.error`; `.notice`
+    /// is the default level for `Logger.notice(_:)`. See
+    /// `developer.apple.com/documentation/oslog/oslogentrylog/level`.
+    let level: OSLogEntryLog.Level
+    let subsystem: String
+    let category: String
+    let message: String
+  }
+
+  /// Captures `os.Logger` entries emitted by `body` for the given
+  /// `subsystem`. When `category` is non-`nil`, entries from other
+  /// categories on the same subsystem are filtered out.
+  ///
+  /// Entries are returned in the order they were written.
+  ///
+  /// - Note: `os.Logger` flushes asynchronously. The helper polls the
+  ///   store for up to `flushTimeout` after `body` returns, returning as
+  ///   soon as the count stops changing for two consecutive reads. The
+  ///   default of 250 ms is comfortably above what we observe on M-series
+  ///   Macs and the iOS Simulator (typical settle: 5–30 ms).
+  static func capture(
+    subsystem: String,
+    category: String? = nil,
+    flushTimeout: Duration = .milliseconds(250),
+    during body: () async throws -> Void
+  ) async throws -> [Entry] {
+    let store = try OSLogStore(scope: .currentProcessIdentifier)
+    let startPosition = store.position(timeIntervalSinceEnd: 0)
+    try await body()
+    return try await readEntriesWhenSettled(
+      store: store,
+      from: startPosition,
+      subsystem: subsystem,
+      category: category,
+      flushTimeout: flushTimeout)
+  }
+
+  /// Polls `store.getEntries(at:matching:)` until the matching entry
+  /// count is stable across two consecutive reads, or `flushTimeout`
+  /// elapses. Returns the most recent matching list.
+  ///
+  /// The predicate filters on `subsystem` (and `category`, when provided)
+  /// at the storage level — without it, the unified log forces the caller
+  /// to iterate every entry produced by the test process, which on a
+  /// busy iOS Simulator can stall for tens of seconds and trip the test
+  /// runner's hang detector.
+  private static func readEntriesWhenSettled(
+    store: OSLogStore,
+    from startPosition: OSLogPosition,
+    subsystem: String,
+    category: String?,
+    flushTimeout: Duration
+  ) async throws -> [Entry] {
+    let predicate = matchPredicate(subsystem: subsystem, category: category)
+    let pollInterval: Duration = .milliseconds(20)
+    let deadline = ContinuousClock.now.advanced(by: flushTimeout)
+    var lastCount = -1
+    var matched: [Entry] = []
+    while ContinuousClock.now < deadline {
+      try await Task.sleep(for: pollInterval)
+      let entries = try store.getEntries(at: startPosition, matching: predicate)
+      matched = entries.compactMap { entry -> Entry? in
+        guard let log = entry as? OSLogEntryLog else { return nil }
+        return Entry(
+          level: log.level,
+          subsystem: log.subsystem,
+          category: log.category,
+          message: log.composedMessage)
+      }
+      if matched.count == lastCount { return matched }
+      lastCount = matched.count
+    }
+    return matched
+  }
+
+  /// Builds an NSPredicate matching `subsystem == X` (and `category == Y`
+  /// when a category is supplied). The unified log evaluates the predicate
+  /// against `OSLogEntry`-derived attributes (`subsystem`, `category`).
+  private static func matchPredicate(subsystem: String, category: String?) -> NSPredicate {
+    if let category {
+      return NSPredicate(
+        format: "subsystem == %@ AND category == %@", subsystem, category)
+    }
+    return NSPredicate(format: "subsystem == %@", subsystem)
+  }
+}

--- a/MoolahTests/Support/LogCaptureTests.swift
+++ b/MoolahTests/Support/LogCaptureTests.swift
@@ -1,0 +1,112 @@
+// MoolahTests/Support/LogCaptureTests.swift
+import Foundation
+import OSLog
+import Testing
+
+@testable import Moolah
+
+@Suite("LogCapture")
+struct LogCaptureTests {
+  /// Each test uses a fresh subsystem/category so concurrent test runs
+  /// can't observe each other's emissions.
+  private let subsystem = "com.moolah.tests.logcapture"
+
+  @Test
+  func capturesSingleWarning() async throws {
+    let category = uniqueCategory()
+    let logger = Logger(subsystem: subsystem, category: category)
+
+    let entries = try await LogCapture.capture(
+      subsystem: subsystem, category: category
+    ) {
+      logger.warning("\("a single warning", privacy: .public)")
+    }
+
+    #expect(entries.count == 1)
+    #expect(entries.first?.message == "a single warning")
+    // `Logger.warning` emits at level `.error` — see Apple docs for
+    // `OSLogEntryLog.Level` (warning is mapped to error).
+    #expect(entries.first?.level == .error)
+    #expect(entries.first?.category == category)
+  }
+
+  @Test
+  func returnsEmptyListWhenNothingLogged() async throws {
+    let category = uniqueCategory()
+    let entries = try await LogCapture.capture(
+      subsystem: subsystem, category: category
+    ) {
+      // No emissions.
+    }
+    #expect(entries.isEmpty)
+  }
+
+  @Test
+  func capturesEmissionsInOrder() async throws {
+    let category = uniqueCategory()
+    let logger = Logger(subsystem: subsystem, category: category)
+
+    let entries = try await LogCapture.capture(
+      subsystem: subsystem, category: category
+    ) {
+      logger.notice("\("first", privacy: .public)")
+      logger.warning("\("second", privacy: .public)")
+      logger.error("\("third", privacy: .public)")
+    }
+
+    #expect(entries.map(\.message) == ["first", "second", "third"])
+  }
+
+  @Test
+  func filtersOutOtherCategoriesOnSameSubsystem() async throws {
+    let wantedCategory = uniqueCategory()
+    let unwantedCategory = uniqueCategory()
+    let wanted = Logger(subsystem: subsystem, category: wantedCategory)
+    let unwanted = Logger(subsystem: subsystem, category: unwantedCategory)
+
+    let entries = try await LogCapture.capture(
+      subsystem: subsystem, category: wantedCategory
+    ) {
+      wanted.warning("\("kept", privacy: .public)")
+      unwanted.warning("\("dropped", privacy: .public)")
+    }
+
+    #expect(entries.map(\.message) == ["kept"])
+  }
+
+  @Test
+  func filtersOutOtherSubsystems() async throws {
+    let category = uniqueCategory()
+    let wanted = Logger(subsystem: subsystem, category: category)
+    let unwanted = Logger(subsystem: "com.moolah.tests.other", category: category)
+
+    let entries = try await LogCapture.capture(
+      subsystem: subsystem, category: category
+    ) {
+      wanted.warning("\("kept", privacy: .public)")
+      unwanted.warning("\("dropped", privacy: .public)")
+    }
+
+    #expect(entries.map(\.message) == ["kept"])
+  }
+
+  @Test
+  func capturesAllCategoriesWhenCategoryIsNil() async throws {
+    // Use a fresh subsystem so emissions from concurrent tests sharing
+    // the suite-level `subsystem` can't leak into this one.
+    let scopedSubsystem = "\(subsystem).any-category-\(UUID().uuidString)"
+    let categoryA = uniqueCategory()
+    let categoryB = uniqueCategory()
+    let loggerA = Logger(subsystem: scopedSubsystem, category: categoryA)
+    let loggerB = Logger(subsystem: scopedSubsystem, category: categoryB)
+
+    let entries = try await LogCapture.capture(subsystem: scopedSubsystem) {
+      loggerA.warning("\("from-a", privacy: .public)")
+      loggerB.warning("\("from-b", privacy: .public)")
+    }
+
+    #expect(Set(entries.map(\.message)) == ["from-a", "from-b"])
+  }
+
+  private func uniqueCategory() -> String { "case-\(UUID().uuidString)" }
+}


### PR DESCRIPTION
Closes #752.

## Summary

Adds a test-only `LogCapture` helper that uses `OSLogStore(scope: .currentProcessIdentifier)` to read back `os.Logger` emissions during a test body. Tests can now assert specific `Logger.warning` / `.notice` / `.error` / `.info` calls without modifying production loggers.

```swift
let entries = try await LogCapture.capture(
  subsystem: "com.moolah.app", category: "Sync"
) {
  await store.runFailingOperation()
}
#expect(entries.count == 1)
#expect(entries.first?.message.contains("expected reason"))
```

## Implementation choice

`OSLogStore(scope: .currentProcessIdentifier)` was picked over `OSLogStore.local()`: process-scoped retrieval works on macOS unit-test hosts and the iOS Simulator without the `com.apple.logging.local-store` entitlement. A spike against both platforms confirmed the approach reads back its own emissions.

The `getEntries(at:matching:)` path uses an `NSPredicate` to filter on `subsystem` (and `category`, when provided) at the storage layer. The unfiltered variant stalled the iOS Simulator runner under parallel test pressure (the unified log was iterating every entry from the test process); the predicate variant settles in 5–30 ms typical, well under the 250 ms `flushTimeout`.

## What's not changed

The original deferred TODO mentioned in #752 — backfilling `AccountRowDefensiveDecodeTests` with a "warning emitted" assertion — does not apply. The actual implementation in `Backends/GRDB/Records/AccountRow+Mapping.swift` uses `AccountType.decoded(rawValue:)` which **throws** `BackendError.dataCorrupted` on unknown raw values per `guides/DATABASE_CODE_GUIDE.md` §3, rather than the fallback-with-warning shape the crypto-wallet-import plan originally drafted. The `AccountRowDefensiveDecodeTests.swift` file was never created because there is no defensive-decode warning to assert against — `UnknownEnumRawValueTests.grdbAccountRowThrowsOnUnknownType` already covers the strict path. The seam is now available for future warning sites that genuinely need the assertion.

## Test plan

- [x] `just test LogCaptureTests` passes on macOS and iOS Simulator (6 cases each).
- [x] `just test` (full suite) passes on both platforms; predicate filter prevents iOS Simulator hang previously seen under parallel pressure.
- [x] `just format-check` clean.
- [x] No SwiftLint baseline edits.
- [x] No compiler warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)