### PR TITLE
feat(crypto): wallet sync gas leg via eth_getTransactionReceipt

### DIFF
--- a/MoolahTests/Shared/CryptoImport/AlchemyTransactionReceiptDecodingTests.swift
+++ b/MoolahTests/Shared/CryptoImport/AlchemyTransactionReceiptDecodingTests.swift
@@ -1,0 +1,145 @@
+// MoolahTests/Shared/CryptoImport/AlchemyTransactionReceiptDecodingTests.swift
+import Foundation
+import Testing
+
+@testable import Moolah
+
+/// Decoding-level coverage for `AlchemyTransactionReceipt` and the
+/// `eth_getTransactionReceipt` wire shape. Exercises the receipt
+/// envelope through `LiveAlchemyClient` (the only public surface that
+/// constructs the value) so the test path matches production decoding
+/// rather than re-implementing the parse out-of-band.
+@Suite("AlchemyTransactionReceipt decoding")
+struct AlchemyTransactionReceiptDecodingTests {
+  private static let ethSendHash =
+    "0xabc123def456000000000000000000000000000000000000000000000000aaaa"
+  private static let opErc20Hash =
+    "0xfeedface00000000000000000000000000000000000000000000000000000001"
+
+  @Test
+  func ethSendReceiptDecodesAndComputesTotalGasFee() async throws {
+    let fixture = try AlchemyTestSupport.loadFixture("eth-receipt-simple-send")
+    let client = AlchemyTestSupport.makeClient { request in
+      (AlchemyTestSupport.okResponse(for: request), fixture)
+    }
+
+    let receipt = try await client.getTransactionReceipt(
+      chain: .ethereum, hash: Self.ethSendHash)
+
+    #expect(receipt.hash == Self.ethSendHash)
+    // gasUsed = 0x5208 = 21,000.
+    #expect(receipt.gasUsed == Decimal(21_000))
+    // effectiveGasPrice = 0x59682f00 = 1,500,000,000 wei (1.5 gwei).
+    #expect(receipt.effectiveGasPrice == Decimal(1_500_000_000))
+    // 21,000 * 1,500,000,000 = 31,500,000,000,000 wei.
+    #expect(receipt.totalGasFeeWei == Decimal(31_500_000_000_000))
+  }
+
+  @Test
+  func opErc20ReceiptDecodesWithChainSpecificValues() async throws {
+    let fixture = try AlchemyTestSupport.loadFixture("op-receipt-erc20-transfer")
+    let client = AlchemyTestSupport.makeClient { request in
+      (AlchemyTestSupport.okResponse(for: request), fixture)
+    }
+
+    let receipt = try await client.getTransactionReceipt(
+      chain: .optimism, hash: Self.opErc20Hash)
+
+    // gasUsed = 0xfde8 = 65,000.
+    #expect(receipt.gasUsed == Decimal(65_000))
+    // effectiveGasPrice = 0xfaaa = 64,170 wei.
+    #expect(receipt.effectiveGasPrice == Decimal(64_170))
+    // 65,000 * 64,170 = 4,171,050,000 wei.
+    #expect(receipt.totalGasFeeWei == Decimal(4_171_050_000))
+  }
+
+  @Test
+  func nullResultEnvelopeMapsToProviderMalformedResponse() async throws {
+    let payload = Data(
+      """
+      { "jsonrpc": "2.0", "id": 1, "result": null }
+      """.utf8)
+    let client = AlchemyTestSupport.makeClient { request in
+      (AlchemyTestSupport.okResponse(for: request), payload)
+    }
+    await #expect(throws: WalletSyncError.providerMalformedResponse(stage: "getTransactionReceipt"))
+    {
+      _ = try await client.getTransactionReceipt(
+        chain: .ethereum, hash: "0xnope")
+    }
+  }
+
+  @Test
+  func missingFieldsMapsToProviderMalformedResponse() async throws {
+    // Receipt envelope present but `gasUsed` and `effectiveGasPrice`
+    // are missing. Decoder must not silently zero them out — a zero
+    // gas leg would corrupt the user's ledger.
+    let payload = Data(
+      """
+      {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "result": {
+          "transactionHash": "0xnope",
+          "blockNumber": "0x1"
+        }
+      }
+      """.utf8)
+    let client = AlchemyTestSupport.makeClient { request in
+      (AlchemyTestSupport.okResponse(for: request), payload)
+    }
+    await #expect(throws: WalletSyncError.providerMalformedResponse(stage: "getTransactionReceipt"))
+    {
+      _ = try await client.getTransactionReceipt(
+        chain: .ethereum, hash: "0xnope")
+    }
+  }
+
+  @Test
+  func malformedHexInGasUsedMapsToProviderMalformedResponse() async throws {
+    let payload = Data(
+      """
+      {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "result": {
+          "gasUsed": "0xZZZ",
+          "effectiveGasPrice": "0x59682f00"
+        }
+      }
+      """.utf8)
+    let client = AlchemyTestSupport.makeClient { request in
+      (AlchemyTestSupport.okResponse(for: request), payload)
+    }
+    await #expect(throws: WalletSyncError.providerMalformedResponse(stage: "getTransactionReceipt"))
+    {
+      _ = try await client.getTransactionReceipt(
+        chain: .ethereum, hash: "0xnope")
+    }
+  }
+
+  @Test
+  func unprefixedHexAlsoDecodesForLeniency() async throws {
+    // The wire spec mandates 0x prefixes, but a node that omits them
+    // shouldn't fail the whole sync — the lenient parser strips the
+    // optional prefix and decodes either form.
+    let payload = Data(
+      """
+      {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "result": {
+          "gasUsed": "5208",
+          "effectiveGasPrice": "59682f00"
+        }
+      }
+      """.utf8)
+    let client = AlchemyTestSupport.makeClient { request in
+      (AlchemyTestSupport.okResponse(for: request), payload)
+    }
+    let receipt = try await client.getTransactionReceipt(
+      chain: .ethereum, hash: "0xunprefixed")
+    #expect(receipt.gasUsed == Decimal(21_000))
+    #expect(receipt.effectiveGasPrice == Decimal(1_500_000_000))
+  }
+}

--- a/MoolahTests/Shared/CryptoImport/CryptoTokenDiscoveryTestDoubles.swift
+++ b/MoolahTests/Shared/CryptoImport/CryptoTokenDiscoveryTestDoubles.swift
@@ -94,6 +94,10 @@ final class CountingAlchemyClientStub: AlchemyClient, @unchecked Sendable {
   }
 
   struct UnexpectedTransfersCall: Error {}
+  /// Thrown when an unrelated test path triggers a receipt fetch. The
+  /// discovery service never calls `getTransactionReceipt`, so any
+  /// invocation here is a wiring bug worth surfacing.
+  struct UnexpectedReceiptCall: Error {}
 
   private let lock = NSLock()
   private var responses: [Key: Response] = [:]
@@ -139,6 +143,13 @@ final class CountingAlchemyClientStub: AlchemyClient, @unchecked Sendable {
       return AlchemyTokenMetadata(
         symbol: nil, name: nil, decimals: nil, logo: nil, isSpam: fallbackSpam)
     }
+  }
+
+  func getTransactionReceipt(
+    chain: ChainConfig,
+    hash: String
+  ) async throws -> AlchemyTransactionReceipt {
+    throw UnexpectedReceiptCall()
   }
 }
 

--- a/MoolahTests/Shared/CryptoImport/LiveAlchemyClientReceiptTests.swift
+++ b/MoolahTests/Shared/CryptoImport/LiveAlchemyClientReceiptTests.swift
@@ -1,0 +1,120 @@
+// MoolahTests/Shared/CryptoImport/LiveAlchemyClientReceiptTests.swift
+import Foundation
+import Testing
+
+@testable import Moolah
+
+/// Request-shape and HTTP-error coverage for the new
+/// `getTransactionReceipt` method on `LiveAlchemyClient`. Mirrors the
+/// existing `LiveAlchemyClientRequestTests` /
+/// `LiveAlchemyClientErrorTests` suites — same stub plumbing, same
+/// HTTP-status coverage.
+@Suite("LiveAlchemyClient — receipt request and error mapping")
+struct LiveAlchemyClientReceiptTests {
+  @Test
+  func receiptRequestUsesEthGetTransactionReceiptMethodAndPassesHash() async throws {
+    let fixture = try AlchemyTestSupport.loadFixture("eth-receipt-simple-send")
+    let client = AlchemyTestSupport.makeClient { request in
+      AlchemyURLProtocolStub.captureRequest(request)
+      return (AlchemyTestSupport.okResponse(for: request), fixture)
+    }
+    _ = try await client.getTransactionReceipt(
+      chain: .ethereum,
+      hash: "0xabc"
+    )
+
+    let url = try #require(AlchemyURLProtocolStub.lastRequest?.url)
+    #expect(url.host == "eth-mainnet.g.alchemy.com")
+    #expect(url.path == "/v2/test-key")
+    let body = AlchemyURLProtocolStub.lastBodyJSON
+    #expect(body["method"] as? String == "eth_getTransactionReceipt")
+    let paramsArray = try #require(body["params"] as? [String])
+    #expect(paramsArray.first == "0xabc")
+  }
+
+  @Test
+  func receiptRequestUsesPerChainSlug() async throws {
+    let fixture = try AlchemyTestSupport.loadFixture("op-receipt-erc20-transfer")
+    let client = AlchemyTestSupport.makeClient { request in
+      AlchemyURLProtocolStub.captureRequest(request)
+      return (AlchemyTestSupport.okResponse(for: request), fixture)
+    }
+    _ = try await client.getTransactionReceipt(
+      chain: .optimism, hash: "0xfeedface")
+    let url = try #require(AlchemyURLProtocolStub.lastRequest?.url)
+    #expect(url.host == "opt-mainnet.g.alchemy.com")
+  }
+
+  @Test
+  func httpUnauthorizedMapsToInvalidApiKey() async throws {
+    let client = AlchemyTestSupport.makeClient { request in
+      let response = AlchemyTestSupport.response(for: request, statusCode: 401)
+      return (response, Data())
+    }
+    await #expect(throws: WalletSyncError.invalidApiKey) {
+      _ = try await client.getTransactionReceipt(
+        chain: .ethereum, hash: "0xabc")
+    }
+  }
+
+  @Test
+  func httpForbiddenMapsToInvalidApiKey() async throws {
+    let client = AlchemyTestSupport.makeClient { request in
+      let response = AlchemyTestSupport.response(for: request, statusCode: 403)
+      return (response, Data())
+    }
+    await #expect(throws: WalletSyncError.invalidApiKey) {
+      _ = try await client.getTransactionReceipt(
+        chain: .ethereum, hash: "0xabc")
+    }
+  }
+
+  @Test
+  func httpTooManyRequestsMapsToRateLimited() async throws {
+    let client = AlchemyTestSupport.makeClient { request in
+      let response = AlchemyTestSupport.response(
+        for: request,
+        statusCode: 429,
+        headerFields: ["Retry-After": "10"]
+      )
+      return (response, Data())
+    }
+    do {
+      _ = try await client.getTransactionReceipt(
+        chain: .ethereum, hash: "0xabc")
+      Issue.record("Expected WalletSyncError.rateLimited")
+    } catch let WalletSyncError.rateLimited(retryAfter) {
+      let date = try #require(retryAfter)
+      #expect(date.timeIntervalSinceNow > 5)
+      #expect(date.timeIntervalSinceNow < 15)
+    }
+  }
+
+  @Test
+  func httpServerErrorMapsToNetworkError() async throws {
+    let client = AlchemyTestSupport.makeClient { request in
+      let response = AlchemyTestSupport.response(for: request, statusCode: 503)
+      return (response, Data())
+    }
+    do {
+      _ = try await client.getTransactionReceipt(
+        chain: .ethereum, hash: "0xabc")
+      Issue.record("Expected WalletSyncError.network")
+    } catch let WalletSyncError.network(description) {
+      #expect(description.contains("503"))
+    }
+  }
+
+  @Test
+  func malformedJSONMapsToProviderMalformedResponse() async throws {
+    let client = AlchemyTestSupport.makeClient { request in
+      let response = AlchemyTestSupport.okResponse(for: request)
+      return (response, Data("not json".utf8))
+    }
+    await #expect(throws: WalletSyncError.providerMalformedResponse(stage: "getTransactionReceipt"))
+    {
+      _ = try await client.getTransactionReceipt(
+        chain: .ethereum, hash: "0xabc")
+    }
+  }
+}

--- a/MoolahTests/Shared/CryptoImport/TransferEventBuilderConcurrencyTests.swift
+++ b/MoolahTests/Shared/CryptoImport/TransferEventBuilderConcurrencyTests.swift
@@ -1,0 +1,76 @@
+// MoolahTests/Shared/CryptoImport/TransferEventBuilderConcurrencyTests.swift
+import Foundation
+import Testing
+
+@testable import Moolah
+
+/// Concurrency-focused coverage for the parallel paths inside
+/// `TransferEventBuilder`: the token-discovery coalescer (verified by
+/// the 100-concurrent-builders test moved out of
+/// `TransferEventBuilderTests` to keep that suite under SwiftLint's
+/// `type_body_length` budget). The receipt-coalescing path lives in
+/// `TransferEventBuilderGasCoalescingTests`.
+@Suite("TransferEventBuilder — concurrency")
+struct TransferEventBuilderConcurrencyTests {
+  private static let wallet = "0x1111111111111111111111111111111111111111"
+  private static let counterparty = "0x2222222222222222222222222222222222222222"
+  private static let usdcAddress = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+
+  @Test("100 concurrent builders → single resolver call (coalescer holds)")
+  func concurrentBuildersCoalesceInstrumentResolution() async throws {
+    let subject = makeDiscoverySubject()
+    subject.resolver.script(
+      .init(chainId: 1, contractAddress: Self.usdcAddress.lowercased()),
+      .success(coingecko: "usd-coin", cryptocompare: nil, binance: nil))
+
+    let account = makeCryptoAccount(walletAddress: Self.wallet, chain: .ethereum)
+    let origin = makeWalletImportOrigin(for: account.id)
+    let template = makeAlchemyTransfer(
+      hash: "0xshared",
+      from: Self.wallet,
+      to: Self.counterparty,
+      category: .erc20,
+      asset: "USDC",
+      contractAddress: Self.usdcAddress,
+      decimalsHex: "0x6",
+      rawValueHex: "0x5f5e100")
+
+    // Each task uses a unique hash so the builder doesn't collapse into
+    // a single transaction; the discovery key is the same so the
+    // coalescer is the load-bearing claim.
+    try await withThrowingTaskGroup(of: Set<String>.self) { group in
+      for index in 0..<100 {
+        let hash = "0x\(String(format: "%064x", index))"
+        let transfer = makeAlchemyTransfer(
+          hash: hash,
+          from: template.from,
+          to: template.to,
+          category: .erc20,
+          asset: "USDC",
+          contractAddress: Self.usdcAddress,
+          decimalsHex: "0x6",
+          rawValueHex: "0x5f5e100")
+        group.addTask {
+          let built = try await TransferEventBuilder().build(
+            transfers: [transfer],
+            account: account,
+            services: BuilderServices(
+              chain: .ethereum,
+              discovery: subject.service,
+              alchemy: ZeroReceiptAlchemyStub()),
+            importOrigin: origin)
+          return Set(built.flatMap { $0.transaction.legs.map(\.instrument.id) })
+        }
+      }
+      var observed: Set<String> = []
+      for try await ids in group {
+        observed.formUnion(ids)
+      }
+      #expect(observed.count == 1)
+    }
+
+    let resolverKey = CountingRegistrationResolver.Key(
+      chainId: 1, contractAddress: Self.usdcAddress.lowercased())
+    #expect(subject.resolver.callCount(for: resolverKey) == 1)
+  }
+}

--- a/MoolahTests/Shared/CryptoImport/TransferEventBuilderCounterpartyTests.swift
+++ b/MoolahTests/Shared/CryptoImport/TransferEventBuilderCounterpartyTests.swift
@@ -34,8 +34,10 @@ struct TransferEventBuilderCounterpartyTests {
     let built = try await TransferEventBuilder().build(
       transfers: [transfer],
       account: account,
-      chain: .ethereum,
-      discovery: subject.service,
+      services: BuilderServices(
+        chain: .ethereum,
+        discovery: subject.service,
+        alchemy: ZeroReceiptAlchemyStub()),
       importOrigin: origin)
     let leg = try #require(built.first?.transaction.legs.first)
     #expect(leg.counterpartyAddress == Self.counterparty)
@@ -55,8 +57,10 @@ struct TransferEventBuilderCounterpartyTests {
     let built = try await TransferEventBuilder().build(
       transfers: [transfer],
       account: account,
-      chain: .ethereum,
-      discovery: subject.service,
+      services: BuilderServices(
+        chain: .ethereum,
+        discovery: subject.service,
+        alchemy: ZeroReceiptAlchemyStub()),
       importOrigin: origin)
     let leg = try #require(built.first?.transaction.legs.first)
     #expect(leg.counterpartyAddress == Self.counterparty)
@@ -76,8 +80,10 @@ struct TransferEventBuilderCounterpartyTests {
     let built = try await TransferEventBuilder().build(
       transfers: [transfer],
       account: account,
-      chain: .ethereum,
-      discovery: subject.service,
+      services: BuilderServices(
+        chain: .ethereum,
+        discovery: subject.service,
+        alchemy: ZeroReceiptAlchemyStub()),
       importOrigin: origin)
     let leg = try #require(built.first?.transaction.legs.first)
     #expect(leg.counterpartyAddress == nil)
@@ -98,8 +104,10 @@ struct TransferEventBuilderCounterpartyTests {
     let built = try await TransferEventBuilder().build(
       transfers: [transfer],
       account: account,
-      chain: .ethereum,
-      discovery: subject.service,
+      services: BuilderServices(
+        chain: .ethereum,
+        discovery: subject.service,
+        alchemy: ZeroReceiptAlchemyStub()),
       importOrigin: origin)
     let leg = try #require(built.first?.transaction.legs.first)
     #expect(leg.counterpartyAddress == mixedCase.lowercased())

--- a/MoolahTests/Shared/CryptoImport/TransferEventBuilderGasCoalescingTests.swift
+++ b/MoolahTests/Shared/CryptoImport/TransferEventBuilderGasCoalescingTests.swift
@@ -1,0 +1,149 @@
+// MoolahTests/Shared/CryptoImport/TransferEventBuilderGasCoalescingTests.swift
+import Foundation
+import Testing
+
+@testable import Moolah
+
+/// Coalescing-specific coverage for the gas-leg receipt fetches added
+/// in #762. Split out of `TransferEventBuilderGasLegTests` so each
+/// suite stays inside SwiftLint's `type_body_length` budget. Verifies
+/// the per-hash deduplication that keeps an N-leg outbound transaction
+/// to a single `eth_getTransactionReceipt` round-trip.
+@Suite("TransferEventBuilder — gas leg coalescing")
+struct TransferEventBuilderGasCoalescingTests {
+  private static let wallet = "0x1111111111111111111111111111111111111111"
+  private static let counterparty = "0x2222222222222222222222222222222222222222"
+  private static let usdcAddress = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+
+  private static let gasUsed = Decimal(21_000)
+  private static let gasPrice = Decimal(1_500_000_000)
+
+  @Test("1 outbound + 4 inbound across distinct hashes → exactly 1 receipt fetch")
+  func oneOutboundFourInboundCoalescesToSingleReceipt() async throws {
+    let subject = makeDiscoverySubject()
+    let alchemy = RecordingAlchemyClientStub()
+    alchemy.setReceiptResponse(
+      .receipt(
+        AlchemyTransactionReceipt(
+          hash: "0xout",
+          gasUsed: Self.gasUsed,
+          effectiveGasPrice: Self.gasPrice)
+      ),
+      for: "0xout")
+
+    let account = makeCryptoAccount(walletAddress: Self.wallet, chain: .ethereum)
+    let origin = makeWalletImportOrigin(for: account.id)
+    var transfers: [AlchemyTransfer] = [
+      makeAlchemyTransfer(
+        hash: "0xout", from: Self.wallet, to: Self.counterparty,
+        category: .external)
+    ]
+    for index in 0..<4 {
+      transfers.append(
+        makeAlchemyTransfer(
+          hash: "0xin\(index)",
+          from: Self.counterparty,
+          to: Self.wallet,
+          category: .external))
+    }
+
+    _ = try await TransferEventBuilder().build(
+      transfers: transfers,
+      account: account,
+      services: BuilderServices(
+        chain: .ethereum,
+        discovery: subject.service,
+        alchemy: alchemy),
+      importOrigin: origin)
+
+    #expect(alchemy.recordedReceiptCalls == ["0xout"])
+  }
+
+  @Test("5 outbound across 5 distinct hashes → 5 receipt fetches")
+  func fiveOutboundDistinctHashesFetchFiveReceipts() async throws {
+    let subject = makeDiscoverySubject()
+    let alchemy = RecordingAlchemyClientStub()
+    for index in 0..<5 {
+      alchemy.setReceiptResponse(
+        .receipt(
+          AlchemyTransactionReceipt(
+            hash: "0xout\(index)",
+            gasUsed: Self.gasUsed,
+            effectiveGasPrice: Self.gasPrice)
+        ),
+        for: "0xout\(index)")
+    }
+
+    let account = makeCryptoAccount(walletAddress: Self.wallet, chain: .ethereum)
+    let origin = makeWalletImportOrigin(for: account.id)
+    var transfers: [AlchemyTransfer] = []
+    for index in 0..<5 {
+      transfers.append(
+        makeAlchemyTransfer(
+          hash: "0xout\(index)",
+          from: Self.wallet,
+          to: Self.counterparty,
+          category: .external))
+    }
+
+    _ = try await TransferEventBuilder().build(
+      transfers: transfers,
+      account: account,
+      services: BuilderServices(
+        chain: .ethereum,
+        discovery: subject.service,
+        alchemy: alchemy),
+      importOrigin: origin)
+
+    #expect(Set(alchemy.recordedReceiptCalls).count == 5)
+    #expect(alchemy.recordedReceiptCalls.count == 5)
+  }
+
+  @Test("Two outbound legs sharing one hash → exactly 1 receipt fetch")
+  func twoOutboundLegsSameHashFetchOnce() async throws {
+    let subject = makeDiscoverySubject()
+    subject.resolver.script(
+      .init(chainId: 1, contractAddress: Self.usdcAddress.lowercased()),
+      .success(coingecko: "usd-coin", cryptocompare: nil, binance: nil))
+    let alchemy = RecordingAlchemyClientStub()
+    alchemy.setReceiptResponse(
+      .receipt(
+        AlchemyTransactionReceipt(
+          hash: "0xmulti",
+          gasUsed: Self.gasUsed,
+          effectiveGasPrice: Self.gasPrice)
+      ),
+      for: "0xmulti")
+
+    let account = makeCryptoAccount(walletAddress: Self.wallet, chain: .ethereum)
+    let origin = makeWalletImportOrigin(for: account.id)
+    let nativeLeg = makeAlchemyTransfer(
+      hash: "0xmulti",
+      from: Self.wallet,
+      to: Self.counterparty,
+      category: .external)
+    let erc20Leg = makeAlchemyTransfer(
+      hash: "0xmulti",
+      from: Self.wallet,
+      to: Self.counterparty,
+      category: .erc20,
+      asset: "USDC",
+      contractAddress: Self.usdcAddress,
+      decimalsHex: "0x6",
+      rawValueHex: "0x5f5e100")
+
+    let built = try await TransferEventBuilder().build(
+      transfers: [nativeLeg, erc20Leg],
+      account: account,
+      services: BuilderServices(
+        chain: .ethereum,
+        discovery: subject.service,
+        alchemy: alchemy),
+      importOrigin: origin)
+
+    #expect(alchemy.recordedReceiptCalls == ["0xmulti"])
+    let candidate = try #require(built.first)
+    let gasLegs = candidate.transaction.legs.filter { $0.type == .expense }
+    #expect(gasLegs.count == 1)
+  }
+}

--- a/MoolahTests/Shared/CryptoImport/TransferEventBuilderGasLegTests.swift
+++ b/MoolahTests/Shared/CryptoImport/TransferEventBuilderGasLegTests.swift
@@ -1,0 +1,239 @@
+// MoolahTests/Shared/CryptoImport/TransferEventBuilderGasLegTests.swift
+import Foundation
+import Testing
+
+@testable import Moolah
+
+/// Behavioural coverage for the gas-leg construction added in #762.
+/// Lives in its own suite because the receipt-fetch coalescing is a
+/// distinct concern from transfer-leg construction (covered by
+/// `TransferEventBuilderTests`). All tests here use
+/// `RecordingAlchemyClientStub.setReceiptResponse(_:for:)` to script
+/// per-hash receipts so the coalescing assertions stay precise.
+@Suite("TransferEventBuilder — gas leg")
+struct TransferEventBuilderGasLegTests {
+  private static let wallet = "0x1111111111111111111111111111111111111111"
+  private static let counterparty = "0x2222222222222222222222222222222222222222"
+  private static let usdcAddress = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+
+  // 21_000 gas * 1.5 gwei = 31_500_000_000_000 wei = 0.0000315 ETH.
+  private static let gasUsed = Decimal(21_000)
+  private static let gasPrice = Decimal(1_500_000_000)
+  private static let expectedFeeEth = dec("0.0000315")
+
+  // MARK: - Native send + gas leg
+
+  @Test("Outbound native ETH + receipt → 2 legs (transfer + gas), same externalId")
+  func outboundNativeSendAttachesGasLeg() async throws {
+    let subject = makeDiscoverySubject()
+    let alchemy = RecordingAlchemyClientStub()
+    alchemy.setReceiptResponse(
+      .receipt(
+        AlchemyTransactionReceipt(
+          hash: "0xeth-send",
+          gasUsed: Self.gasUsed,
+          effectiveGasPrice: Self.gasPrice)
+      ),
+      for: "0xeth-send")
+
+    let account = makeCryptoAccount(walletAddress: Self.wallet, chain: .ethereum)
+    let origin = makeWalletImportOrigin(for: account.id)
+    let transfer = makeAlchemyTransfer(
+      hash: "0xeth-send",
+      from: Self.wallet,
+      to: Self.counterparty,
+      category: .external)
+
+    let built = try await TransferEventBuilder().build(
+      transfers: [transfer],
+      account: account,
+      services: BuilderServices(
+        chain: .ethereum,
+        discovery: subject.service,
+        alchemy: alchemy),
+      importOrigin: origin)
+
+    let candidate = try #require(built.first)
+    #expect(candidate.transaction.legs.count == 2)
+    let transferLeg = try #require(
+      candidate.transaction.legs.first(where: { $0.type == .transfer }))
+    let gasLeg = try #require(
+      candidate.transaction.legs.first(where: { $0.type == .expense }))
+    #expect(transferLeg.externalId == "0xeth-send")
+    #expect(gasLeg.externalId == "0xeth-send")
+    #expect(gasLeg.instrument == ChainConfig.ethereum.nativeInstrument)
+    #expect(gasLeg.quantity == -Self.expectedFeeEth)
+    #expect(gasLeg.accountId == account.id)
+  }
+
+  @Test("Outbound ERC-20 + receipt → 2 legs (token transfer + native gas)")
+  func outboundErc20AttachesGasLegInNativeInstrument() async throws {
+    let subject = makeDiscoverySubject()
+    subject.resolver.script(
+      .init(chainId: 1, contractAddress: Self.usdcAddress.lowercased()),
+      .success(coingecko: "usd-coin", cryptocompare: nil, binance: nil))
+    let alchemy = RecordingAlchemyClientStub()
+    alchemy.setReceiptResponse(
+      .receipt(
+        AlchemyTransactionReceipt(
+          hash: "0xerc20-send",
+          gasUsed: Self.gasUsed,
+          effectiveGasPrice: Self.gasPrice)
+      ),
+      for: "0xerc20-send")
+
+    let account = makeCryptoAccount(walletAddress: Self.wallet, chain: .ethereum)
+    let origin = makeWalletImportOrigin(for: account.id)
+    let transfer = makeAlchemyTransfer(
+      hash: "0xerc20-send",
+      from: Self.wallet,
+      to: Self.counterparty,
+      category: .erc20,
+      asset: "USDC",
+      contractAddress: Self.usdcAddress,
+      decimalsHex: "0x6",
+      rawValueHex: "0x5f5e100")
+
+    let built = try await TransferEventBuilder().build(
+      transfers: [transfer],
+      account: account,
+      services: BuilderServices(
+        chain: .ethereum,
+        discovery: subject.service,
+        alchemy: alchemy),
+      importOrigin: origin)
+
+    let candidate = try #require(built.first)
+    #expect(candidate.transaction.legs.count == 2)
+    let transferLeg = try #require(
+      candidate.transaction.legs.first(where: { $0.type == .transfer }))
+    let gasLeg = try #require(
+      candidate.transaction.legs.first(where: { $0.type == .expense }))
+    #expect(transferLeg.instrument.contractAddress == Self.usdcAddress.lowercased())
+    #expect(gasLeg.instrument == ChainConfig.ethereum.nativeInstrument)
+    #expect(gasLeg.quantity == -Self.expectedFeeEth)
+    #expect(gasLeg.externalId == "0xerc20-send")
+  }
+
+  // MARK: - Inbound never gets a gas leg
+
+  @Test("Inbound transfer → no gas leg, no receipt fetch")
+  func inboundTransferDoesNotFetchReceipt() async throws {
+    let subject = makeDiscoverySubject()
+    let alchemy = RecordingAlchemyClientStub()
+    let account = makeCryptoAccount(walletAddress: Self.wallet, chain: .ethereum)
+    let origin = makeWalletImportOrigin(for: account.id)
+    let transfer = makeAlchemyTransfer(
+      hash: "0xreceive",
+      from: Self.counterparty,
+      to: Self.wallet,
+      category: .external)
+
+    let built = try await TransferEventBuilder().build(
+      transfers: [transfer],
+      account: account,
+      services: BuilderServices(
+        chain: .ethereum,
+        discovery: subject.service,
+        alchemy: alchemy),
+      importOrigin: origin)
+
+    let candidate = try #require(built.first)
+    #expect(candidate.transaction.legs.count == 1)
+    #expect(candidate.transaction.legs.allSatisfy { $0.type == .transfer })
+    #expect(alchemy.recordedReceiptCalls.isEmpty)
+  }
+
+  // MARK: - Self-send still pays gas
+
+  @Test("Self-send → transfer leg + gas leg (gas is paid even on self-send)")
+  func selfSendStillProducesGasLeg() async throws {
+    let subject = makeDiscoverySubject()
+    let alchemy = RecordingAlchemyClientStub()
+    alchemy.setReceiptResponse(
+      .receipt(
+        AlchemyTransactionReceipt(
+          hash: "0xself",
+          gasUsed: Self.gasUsed,
+          effectiveGasPrice: Self.gasPrice)
+      ),
+      for: "0xself")
+
+    let account = makeCryptoAccount(walletAddress: Self.wallet, chain: .ethereum)
+    let origin = makeWalletImportOrigin(for: account.id)
+    let transfer = makeAlchemyTransfer(
+      hash: "0xself",
+      from: Self.wallet,
+      to: Self.wallet,
+      category: .external)
+
+    let built = try await TransferEventBuilder().build(
+      transfers: [transfer],
+      account: account,
+      services: BuilderServices(
+        chain: .ethereum,
+        discovery: subject.service,
+        alchemy: alchemy),
+      importOrigin: origin)
+
+    let candidate = try #require(built.first)
+    let types = candidate.transaction.legs.map(\.type)
+    #expect(types.filter { $0 == .transfer }.count == 1)
+    #expect(types.filter { $0 == .expense }.count == 1)
+  }
+
+  // MARK: - Receipt fetch failure on one hash doesn't fail the account
+
+  @Test("Receipt fetch failure on one hash → other events still build")
+  func receiptFetchFailureOnOneHashDoesNotPropagate() async throws {
+    let subject = makeDiscoverySubject()
+    let alchemy = RecordingAlchemyClientStub()
+    alchemy.setReceiptResponse(
+      .receipt(
+        AlchemyTransactionReceipt(
+          hash: "0xgood",
+          gasUsed: Self.gasUsed,
+          effectiveGasPrice: Self.gasPrice)
+      ),
+      for: "0xgood")
+    alchemy.setReceiptResponse(
+      .failure(WalletSyncError.network(underlyingDescription: "transient")),
+      for: "0xbad")
+
+    let account = makeCryptoAccount(walletAddress: Self.wallet, chain: .ethereum)
+    let origin = makeWalletImportOrigin(for: account.id)
+    let goodTransfer = makeAlchemyTransfer(
+      hash: "0xgood", from: Self.wallet, to: Self.counterparty,
+      category: .external)
+    let badTransfer = makeAlchemyTransfer(
+      hash: "0xbad", from: Self.wallet, to: Self.counterparty,
+      category: .external)
+
+    let built = try await TransferEventBuilder().build(
+      transfers: [goodTransfer, badTransfer],
+      account: account,
+      services: BuilderServices(
+        chain: .ethereum,
+        discovery: subject.service,
+        alchemy: alchemy),
+      importOrigin: origin)
+
+    #expect(built.count == 2)
+    let goodCandidate = try #require(
+      built.first { candidate in
+        candidate.transaction.legs.contains { $0.externalId == "0xgood" }
+      })
+    let badCandidate = try #require(
+      built.first { candidate in
+        candidate.transaction.legs.contains { $0.externalId == "0xbad" }
+      })
+    // Good event keeps both legs.
+    #expect(goodCandidate.transaction.legs.count == 2)
+    #expect(goodCandidate.transaction.legs.contains { $0.type == .expense })
+    // Bad event keeps the transfer leg but skips gas — receipt failure
+    // must not corrupt the account-level result.
+    #expect(badCandidate.transaction.legs.count == 1)
+    #expect(badCandidate.transaction.legs.allSatisfy { $0.type == .transfer })
+  }
+
+}

--- a/MoolahTests/Shared/CryptoImport/TransferEventBuilderTests.swift
+++ b/MoolahTests/Shared/CryptoImport/TransferEventBuilderTests.swift
@@ -8,10 +8,10 @@ import Testing
 /// transfer-leg construction, hash grouping, sign convention, and the
 /// `unknown`-category skip path.
 ///
-/// Gas-leg construction is deferred — see issue #762. The "ETH send"
-/// and "ERC-20 send" tests therefore assert on a single transfer leg
-/// rather than the design's eventual transfer + gas pair; the gas-leg
-/// path will gain its own tests once the receipt-fetch wiring lands.
+/// Gas-leg construction is covered separately in
+/// `TransferEventBuilderGasLegTests`; tests here use a
+/// `ZeroReceiptAlchemyStub` whose receipts produce a non-positive total
+/// (and so emit no gas leg) to keep transfer-leg assertions focused.
 @Suite("TransferEventBuilder")
 struct TransferEventBuilderTests {
   // Reusable addresses.
@@ -35,8 +35,10 @@ struct TransferEventBuilderTests {
     let built = try await TransferEventBuilder().build(
       transfers: [transfer],
       account: account,
-      chain: .ethereum,
-      discovery: subject.service,
+      services: BuilderServices(
+        chain: .ethereum,
+        discovery: subject.service,
+        alchemy: ZeroReceiptAlchemyStub()),
       importOrigin: origin)
 
     #expect(built.count == 1)
@@ -77,8 +79,10 @@ struct TransferEventBuilderTests {
     let built = try await TransferEventBuilder().build(
       transfers: [transfer],
       account: account,
-      chain: .ethereum,
-      discovery: subject.service,
+      services: BuilderServices(
+        chain: .ethereum,
+        discovery: subject.service,
+        alchemy: ZeroReceiptAlchemyStub()),
       importOrigin: origin)
 
     let candidate = try #require(built.first)
@@ -108,8 +112,10 @@ struct TransferEventBuilderTests {
     let built = try await TransferEventBuilder().build(
       transfers: [transfer],
       account: account,
-      chain: .ethereum,
-      discovery: subject.service,
+      services: BuilderServices(
+        chain: .ethereum,
+        discovery: subject.service,
+        alchemy: ZeroReceiptAlchemyStub()),
       importOrigin: origin)
 
     let candidate = try #require(built.first)
@@ -154,8 +160,10 @@ struct TransferEventBuilderTests {
     let built = try await TransferEventBuilder().build(
       transfers: [first, second],
       account: account,
-      chain: .ethereum,
-      discovery: subject.service,
+      services: BuilderServices(
+        chain: .ethereum,
+        discovery: subject.service,
+        alchemy: ZeroReceiptAlchemyStub()),
       importOrigin: origin)
 
     #expect(built.count == 1)
@@ -199,69 +207,16 @@ struct TransferEventBuilderTests {
     let built = try await TransferEventBuilder().build(
       transfers: [nftTransfer],
       account: account,
-      chain: .ethereum,
-      discovery: subject.service,
+      services: BuilderServices(
+        chain: .ethereum,
+        discovery: subject.service,
+        alchemy: ZeroReceiptAlchemyStub()),
       importOrigin: origin)
     #expect(built.isEmpty)
   }
 
-  // MARK: - Stable instrument across builds
-
-  @Test("100 concurrent builders → single resolver call (coalescer holds)")
-  func concurrentBuildersCoalesceInstrumentResolution() async throws {
-    let subject = makeDiscoverySubject()
-    subject.resolver.script(
-      .init(chainId: 1, contractAddress: Self.usdcAddress.lowercased()),
-      .success(coingecko: "usd-coin", cryptocompare: nil, binance: nil))
-
-    let account = makeCryptoAccount(walletAddress: Self.wallet, chain: .ethereum)
-    let origin = makeWalletImportOrigin(for: account.id)
-    let template = makeAlchemyTransfer(
-      hash: "0xshared",
-      from: Self.wallet,
-      to: Self.counterparty,
-      category: .erc20,
-      asset: "USDC",
-      contractAddress: Self.usdcAddress,
-      decimalsHex: "0x6",
-      rawValueHex: "0x5f5e100")
-
-    // Each task uses a unique hash so the builder doesn't collapse into
-    // a single transaction; the discovery key is the same so the
-    // coalescer is the load-bearing claim.
-    try await withThrowingTaskGroup(of: Set<String>.self) { group in
-      for index in 0..<100 {
-        let hash = "0x\(String(format: "%064x", index))"
-        let transfer = makeAlchemyTransfer(
-          hash: hash,
-          from: template.from,
-          to: template.to,
-          category: .erc20,
-          asset: "USDC",
-          contractAddress: Self.usdcAddress,
-          decimalsHex: "0x6",
-          rawValueHex: "0x5f5e100")
-        group.addTask {
-          let built = try await TransferEventBuilder().build(
-            transfers: [transfer],
-            account: account,
-            chain: .ethereum,
-            discovery: subject.service,
-            importOrigin: origin)
-          return Set(built.flatMap { $0.transaction.legs.map(\.instrument.id) })
-        }
-      }
-      var observed: Set<String> = []
-      for try await ids in group {
-        observed.formUnion(ids)
-      }
-      #expect(observed.count == 1)
-    }
-
-    let resolverKey = CountingRegistrationResolver.Key(
-      chainId: 1, contractAddress: Self.usdcAddress.lowercased())
-    #expect(subject.resolver.callCount(for: resolverKey) == 1)
-  }
+  // Token-discovery coalescing across 100 concurrent builders is
+  // exercised in `TransferEventBuilderConcurrencyTests`.
 
   // MARK: - Other edge cases
 
@@ -282,8 +237,10 @@ struct TransferEventBuilderTests {
     let built = try await TransferEventBuilder().build(
       transfers: [transfer],
       account: account,
-      chain: .ethereum,
-      discovery: subject.service,
+      services: BuilderServices(
+        chain: .ethereum,
+        discovery: subject.service,
+        alchemy: ZeroReceiptAlchemyStub()),
       importOrigin: origin)
     let leg = try #require(built.first?.transaction.legs.first)
     #expect(leg.instrument == ChainConfig.ethereum.nativeInstrument)
@@ -301,8 +258,10 @@ struct TransferEventBuilderTests {
       _ = try await TransferEventBuilder().build(
         transfers: [],
         account: account,
-        chain: .ethereum,
-        discovery: subject.service,
+        services: BuilderServices(
+          chain: .ethereum,
+          discovery: subject.service,
+          alchemy: ZeroReceiptAlchemyStub()),
         importOrigin: origin)
     }
   }

--- a/MoolahTests/Shared/CryptoImport/WalletSyncTestDoubles.swift
+++ b/MoolahTests/Shared/CryptoImport/WalletSyncTestDoubles.swift
@@ -26,15 +26,31 @@ final class RecordingAlchemyClientStub: AlchemyClient, @unchecked Sendable {
     case failure(any Error)
   }
 
+  /// Scripted reply for a `getTransactionReceipt` call. Tests that
+  /// exercise the gas-leg path script success on the hashes they care
+  /// about and (optionally) failure on others to verify the
+  /// per-receipt error containment.
+  enum ReceiptResponse: Sendable {
+    case receipt(AlchemyTransactionReceipt)
+    case failure(any Error)
+  }
+
   /// Errors thrown when scripting hooks are unset and a test path hits
   /// the stub anyway. Keeps the failure message specific to the path.
   struct UnscriptedTransfersCall: Error { let chainId: Int }
   struct UnexpectedTokenMetadataCall: Error {}
+  /// Thrown when `getTransactionReceipt` is called for a hash that
+  /// hasn't been scripted on this stub. Tests that exercise the
+  /// receipt path script per-hash responses; tests that don't stay on
+  /// the inbound-only path which never triggers a receipt fetch.
+  struct UnscriptedReceiptCall: Error { let hash: String }
 
   private let lock = NSLock()
   private var transfersResponse: Response?
   private var perAddressResponses: [String: Response] = [:]
   private var assetTransfersCalls: [AssetTransfersCall] = []
+  private var receiptResponses: [String: ReceiptResponse] = [:]
+  private var receiptCalls: [String] = []
   /// Optional hook fired before the response is returned — the
   /// cancellation test installs a closure here that cancels the parent
   /// task so the engine throws on the next `checkCancellation()`.
@@ -91,6 +107,39 @@ final class RecordingAlchemyClientStub: AlchemyClient, @unchecked Sendable {
     contractAddress: String
   ) async throws -> AlchemyTokenMetadata {
     throw UnexpectedTokenMetadataCall()
+  }
+
+  /// Scripts a receipt response for a given on-chain hash. The lookup
+  /// is exact-match — production callers always pass the same casing
+  /// they read off `AlchemyTransfer.hash`, so tests can use the same
+  /// values verbatim.
+  func setReceiptResponse(_ response: ReceiptResponse, for hash: String) {
+    lock.withLock { receiptResponses[hash] = response }
+  }
+
+  /// Recorded list of every `getTransactionReceipt` invocation, in
+  /// call order. Used by the coalescing tests to assert that one
+  /// outbound + four inbound triggers exactly one fetch.
+  var recordedReceiptCalls: [String] {
+    lock.withLock { receiptCalls }
+  }
+
+  func getTransactionReceipt(
+    chain: ChainConfig,
+    hash: String
+  ) async throws -> AlchemyTransactionReceipt {
+    let response: ReceiptResponse? = lock.withLock {
+      receiptCalls.append(hash)
+      return receiptResponses[hash]
+    }
+    switch response {
+    case .none:
+      throw UnscriptedReceiptCall(hash: hash)
+    case let .failure(error):
+      throw error
+    case let .receipt(receipt):
+      return receipt
+    }
   }
 }
 
@@ -178,6 +227,50 @@ func makeWalletImportOrigin(
     importedAt: importedAt,
     importSessionId: sessionId,
     parserIdentifier: "alchemy-wallet-sync")
+}
+
+/// `AlchemyClient` that returns a zero-cost receipt for every receipt
+/// fetch and traps on the unrelated `getAssetTransfers` /
+/// `getTokenMetadata` paths. Used by `TransferEventBuilder` tests that
+/// only care about transfer-leg construction — a zero receipt produces
+/// no gas leg (the builder drops a non-positive total) so the legs the
+/// test actually inspects stay deterministic without extra plumbing.
+final class ZeroReceiptAlchemyStub: AlchemyClient, @unchecked Sendable {
+  struct UnexpectedAssetTransfersCall: Error {}
+  struct UnexpectedTokenMetadataCall: Error {}
+
+  private let lock = NSLock()
+  private var receiptHashes: [String] = []
+
+  /// Hashes the builder has asked for receipts on, in call order. Lets
+  /// tests assert that their inbound-only path didn't trigger a fetch.
+  var recordedReceiptCalls: [String] {
+    lock.withLock { receiptHashes }
+  }
+
+  func getAssetTransfers(
+    chain: ChainConfig,
+    walletAddress: String,
+    fromBlock: UInt64
+  ) async throws -> [AlchemyTransfer] {
+    throw UnexpectedAssetTransfersCall()
+  }
+
+  func getTokenMetadata(
+    chain: ChainConfig,
+    contractAddress: String
+  ) async throws -> AlchemyTokenMetadata {
+    throw UnexpectedTokenMetadataCall()
+  }
+
+  func getTransactionReceipt(
+    chain: ChainConfig,
+    hash: String
+  ) async throws -> AlchemyTransactionReceipt {
+    lock.withLock { receiptHashes.append(hash) }
+    return AlchemyTransactionReceipt(
+      hash: hash, gasUsed: 0, effectiveGasPrice: 0)
+  }
 }
 
 /// Builds a crypto `Account` for a given chain + wallet address.

--- a/MoolahTests/Support/Fixtures/alchemy/eth-receipt-simple-send.json
+++ b/MoolahTests/Support/Fixtures/alchemy/eth-receipt-simple-send.json
@@ -1,0 +1,20 @@
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "blockHash": "0x9d22844c10ee9deef27c0fbe1a04ab09c8c2bb91f8de14e62cd7d1ec4c2f9001",
+    "blockNumber": "0x12d4f0a",
+    "contractAddress": null,
+    "cumulativeGasUsed": "0x1d2c0f",
+    "effectiveGasPrice": "0x59682f00",
+    "from": "0x1111111111111111111111111111111111111111",
+    "gasUsed": "0x5208",
+    "logs": [],
+    "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+    "status": "0x1",
+    "to": "0x2222222222222222222222222222222222222222",
+    "transactionHash": "0xabc123def456000000000000000000000000000000000000000000000000aaaa",
+    "transactionIndex": "0x4f",
+    "type": "0x2"
+  }
+}

--- a/MoolahTests/Support/Fixtures/alchemy/op-receipt-erc20-transfer.json
+++ b/MoolahTests/Support/Fixtures/alchemy/op-receipt-erc20-transfer.json
@@ -1,0 +1,20 @@
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "blockHash": "0x4c2ad9ab4af43c5be36fd7cdc5fbf5a7b3f2c7bbab8a1adfaadbeef0a0a0a0a0",
+    "blockNumber": "0x6b0a35d",
+    "contractAddress": null,
+    "cumulativeGasUsed": "0xa5b412",
+    "effectiveGasPrice": "0xfaaa",
+    "from": "0x1111111111111111111111111111111111111111",
+    "gasUsed": "0xfde8",
+    "logs": [],
+    "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+    "status": "0x1",
+    "to": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+    "transactionHash": "0xfeedface00000000000000000000000000000000000000000000000000000001",
+    "transactionIndex": "0x10",
+    "type": "0x2"
+  }
+}

--- a/Shared/CryptoImport/AlchemyClient.swift
+++ b/Shared/CryptoImport/AlchemyClient.swift
@@ -26,6 +26,21 @@ protocol AlchemyClient: Sendable {
     chain: ChainConfig,
     contractAddress: String
   ) async throws -> AlchemyTokenMetadata
+
+  /// Fetches the on-chain receipt for `hash` so the wallet sync
+  /// pipeline can compute the gas-leg quantity (`gasUsed *
+  /// effectiveGasPrice`). Alchemy's `alchemy_getAssetTransfers` doesn't
+  /// include gas-cost data per transfer, so callers fetch one receipt
+  /// per unique outbound `txHash`.
+  ///
+  /// Throws `WalletSyncError.providerMalformedResponse(stage:
+  /// "getTransactionReceipt")` when the JSON-RPC `result` is `null`
+  /// (rare — only when the hash isn't on chain yet, or the node has
+  /// pruned it) or when the response payload can't be decoded.
+  func getTransactionReceipt(
+    chain: ChainConfig,
+    hash: String
+  ) async throws -> AlchemyTransactionReceipt
 }
 
 /// Token metadata returned by Alchemy's `alchemy_getTokenMetadata` JSON-RPC
@@ -129,7 +144,7 @@ struct LiveAlchemyClient: AlchemyClient {
     contractAddress: String
   ) async throws -> AlchemyTokenMetadata {
     try await rateLimiter.acquire()
-    let body = JSONRPCRequest<AlchemyParams>(
+    let body = AlchemyJSONRPCRequest<AlchemyJSONRPCParams>(
       method: "alchemy_getTokenMetadata",
       params: .tokenMetadata(contractAddress: contractAddress)
     )
@@ -140,7 +155,7 @@ struct LiveAlchemyClient: AlchemyClient {
     let data = try await send(request: request, stage: "getTokenMetadata")
     do {
       let envelope = try JSONDecoder().decode(
-        JSONRPCResponse<AlchemyTokenMetadata>.self,
+        AlchemyJSONRPCResponse<AlchemyTokenMetadata>.self,
         from: data
       )
       return envelope.result
@@ -149,6 +164,62 @@ struct LiveAlchemyClient: AlchemyClient {
         "Alchemy token metadata decode failed for chain \(chain.chainId, privacy: .public): \(error.localizedDescription, privacy: .public)"
       )
       throw WalletSyncError.providerMalformedResponse(stage: "getTokenMetadata")
+    }
+  }
+
+  func getTransactionReceipt(
+    chain: ChainConfig,
+    hash: String
+  ) async throws -> AlchemyTransactionReceipt {
+    let signpostID = OSSignpostID(log: Signposts.cryptoSync)
+    os_signpost(
+      .begin,
+      log: Signposts.cryptoSync,
+      name: "alchemy.getTransactionReceipt",
+      signpostID: signpostID,
+      "chain %{public}d",
+      chain.chainId)
+    defer {
+      os_signpost(
+        .end,
+        log: Signposts.cryptoSync,
+        name: "alchemy.getTransactionReceipt",
+        signpostID: signpostID)
+    }
+    try await rateLimiter.acquire()
+    let body = AlchemyJSONRPCRequest<AlchemyJSONRPCParams>(
+      method: "eth_getTransactionReceipt",
+      params: .transactionReceipt(hash: hash)
+    )
+    let request = try buildRequest(chain: chain, body: body)
+    // Hash is `.private` in logs — pairing a tx hash with the device
+    // identifies wallet activity even though the chain itself is public.
+    logger.debug(
+      "Alchemy getTransactionReceipt: chain \(chain.chainId, privacy: .public) hash \(hash, privacy: .private)"
+    )
+    let data = try await send(request: request, stage: "getTransactionReceipt")
+    do {
+      let envelope = try JSONDecoder().decode(
+        AlchemyJSONRPCNullableResponse<AlchemyTransactionReceiptPayload>.self,
+        from: data
+      )
+      guard let payload = envelope.result else {
+        // `result: null` — happens when the hash isn't on chain (yet) or
+        // the node has pruned it. Surface as a malformed-response error
+        // so the orchestrator's per-account containment can decide.
+        logger.notice(
+          "Alchemy getTransactionReceipt returned null result for chain \(chain.chainId, privacy: .public) hash \(hash, privacy: .private)"
+        )
+        throw WalletSyncError.providerMalformedResponse(stage: "getTransactionReceipt")
+      }
+      return try payload.toReceipt(hash: hash)
+    } catch let error as WalletSyncError {
+      throw error
+    } catch {
+      logger.error(
+        "Alchemy getTransactionReceipt decode failed for chain \(chain.chainId, privacy: .public): \(error.localizedDescription, privacy: .public)"
+      )
+      throw WalletSyncError.providerMalformedResponse(stage: "getTransactionReceipt")
     }
   }
 
@@ -166,10 +237,10 @@ struct LiveAlchemyClient: AlchemyClient {
     if chain.supportsInternalTransfers {
       categories.append(.internal)
     }
-    let body = JSONRPCRequest<AlchemyParams>(
+    let body = AlchemyJSONRPCRequest<AlchemyJSONRPCParams>(
       method: "alchemy_getAssetTransfers",
       params: .assetTransfers(
-        AssetTransfersParams(
+        AlchemyAssetTransfersParams(
           fromBlock: "0x" + String(fromBlock, radix: 16),
           toBlock: "latest",
           fromAddress: isFromAddress ? address : nil,
@@ -221,7 +292,7 @@ struct LiveAlchemyClient: AlchemyClient {
 
   private func buildRequest<Params: Encodable>(
     chain: ChainConfig,
-    body: JSONRPCRequest<Params>
+    body: AlchemyJSONRPCRequest<Params>
   ) throws -> URLRequest {
     let urlString = "https://\(chain.alchemyNetworkSlug).g.alchemy.com/v2/\(apiKey)"
     guard let url = URL(string: urlString) else {
@@ -242,113 +313,7 @@ struct LiveAlchemyClient: AlchemyClient {
   }
 
   private func validate(response: URLResponse, stage: String) throws {
-    guard let http = response as? HTTPURLResponse else {
-      logger.error(
-        "Alchemy \(stage, privacy: .public): non-HTTP response"
-      )
-      throw WalletSyncError.network(underlyingDescription: "No HTTP response")
-    }
-    switch http.statusCode {
-    case 200...299:
-      return
-    case 401, 403:
-      logger.error(
-        "Alchemy \(stage, privacy: .public): API key rejected (HTTP \(http.statusCode, privacy: .public))"
-      )
-      throw WalletSyncError.invalidApiKey
-    case 429:
-      let retryAfter = parseRetryAfter(http: http)
-      logger.notice(
-        "Alchemy \(stage, privacy: .public): rate limited (HTTP 429)"
-      )
-      throw WalletSyncError.rateLimited(retryAfter: retryAfter)
-    default:
-      logger.error(
-        "Alchemy \(stage, privacy: .public): HTTP \(http.statusCode, privacy: .public)"
-      )
-      throw WalletSyncError.network(
-        underlyingDescription: "HTTP \(http.statusCode)"
-      )
-    }
+    try AlchemyResponseValidator.validate(
+      response: response, stage: stage, logger: logger)
   }
-
-  /// Parses `Retry-After` per RFC 7231: either a non-negative integer
-  /// seconds value or an HTTP-date. Returns `nil` when the header is
-  /// absent or unparseable.
-  private func parseRetryAfter(http: HTTPURLResponse) -> Date? {
-    guard let header = http.value(forHTTPHeaderField: "Retry-After") else {
-      return nil
-    }
-    let trimmed = header.trimmingCharacters(in: .whitespaces)
-    if let seconds = TimeInterval(trimmed) {
-      return Date().addingTimeInterval(seconds)
-    }
-    let formatter = DateFormatter()
-    formatter.locale = Locale(identifier: "en_US_POSIX")
-    formatter.timeZone = TimeZone(identifier: "GMT")
-    formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
-    return formatter.date(from: trimmed)
-  }
-}
-
-// MARK: - JSON-RPC envelope
-
-/// Outer JSON-RPC 2.0 request envelope. `id` is fixed at 1 — Alchemy
-/// echoes it back, but our requests are single-shot so we don't correlate.
-private struct JSONRPCRequest<Params: Encodable>: Encodable {
-  let jsonrpc: String
-  let id: Int
-  let method: String
-  let params: Params
-
-  init(method: String, params: Params) {
-    self.jsonrpc = "2.0"
-    self.id = 1
-    self.method = method
-    self.params = params
-  }
-}
-
-/// Outer JSON-RPC 2.0 response envelope, generic over the result body.
-private struct JSONRPCResponse<Result: Decodable>: Decodable {
-  let result: Result
-}
-
-/// Discriminated `params` payload — covers the two JSON-RPC methods this
-/// client makes today. Each case encodes as the JSON-RPC convention of a
-/// one-element array around the parameter object (or address string).
-private enum AlchemyParams: Encodable {
-  case assetTransfers(AssetTransfersParams)
-  case tokenMetadata(contractAddress: String)
-
-  func encode(to encoder: Encoder) throws {
-    var container = encoder.unkeyedContainer()
-    switch self {
-    case .assetTransfers(let params):
-      try container.encode(params)
-    case .tokenMetadata(let address):
-      try container.encode(address)
-    }
-  }
-}
-
-/// Body for the `params[0]` object of `alchemy_getAssetTransfers`.
-private struct AssetTransfersParams: Encodable {
-  let fromBlock: String
-  let toBlock: String
-  let fromAddress: String?
-  let toAddress: String?
-  let category: [String]
-  let withMetadata: Bool
-  let excludeZeroValue: Bool
-}
-
-/// Decodes the `result` object of `alchemy_getAssetTransfers`. The
-/// outer envelope wraps this in `JSONRPCResponse<AlchemyTransferResult>`.
-private struct AlchemyTransferEnvelope: Decodable {
-  let result: AlchemyTransferResult
-}
-
-private struct AlchemyTransferResult: Decodable {
-  let transfers: [AlchemyTransfer]
 }

--- a/Shared/CryptoImport/AlchemyJSONRPCWireFormat.swift
+++ b/Shared/CryptoImport/AlchemyJSONRPCWireFormat.swift
@@ -1,0 +1,185 @@
+// Shared/CryptoImport/AlchemyJSONRPCWireFormat.swift
+import Foundation
+import OSLog
+
+/// Namespace anchor matching the filename so SwiftLint's `file_name`
+/// rule stays satisfied alongside the loose top-level wire-format
+/// types declared below. Mirrors the pattern used in
+/// `WalletSyncTestDoubles.swift` etc.
+enum AlchemyJSONRPCWireFormat {}
+
+/// JSON-RPC envelope and wire-format payloads used by `LiveAlchemyClient`.
+/// Lifted out of `AlchemyClient.swift` so the main client file stays
+/// inside SwiftLint's `file_length` / `type_body_length` budgets.
+///
+/// Visibility: every type here is module-internal but unused outside
+/// `AlchemyClient.swift` and the test files. Keeping them at the file
+/// scope (rather than nested inside `LiveAlchemyClient`) lets the
+/// generic `JSONRPCRequest` / `JSONRPCResponse` envelopes stay shared
+/// across the three JSON-RPC methods without re-declaring the wrapper.
+
+/// Outer JSON-RPC 2.0 request envelope. `id` is fixed at 1 — Alchemy
+/// echoes it back, but our requests are single-shot so we don't
+/// correlate.
+struct AlchemyJSONRPCRequest<Params: Encodable>: Encodable {
+  let jsonrpc: String
+  let id: Int
+  let method: String
+  let params: Params
+
+  init(method: String, params: Params) {
+    self.jsonrpc = "2.0"
+    self.id = 1
+    self.method = method
+    self.params = params
+  }
+}
+
+/// Outer JSON-RPC 2.0 response envelope, generic over the result body.
+struct AlchemyJSONRPCResponse<Result: Decodable>: Decodable {
+  let result: Result
+}
+
+/// JSON-RPC 2.0 envelope variant that allows `result: null`. Used by
+/// `eth_getTransactionReceipt` because the spec returns `null` for
+/// hashes the node hasn't seen yet (instead of an error envelope).
+struct AlchemyJSONRPCNullableResponse<Result: Decodable>: Decodable {
+  let result: Result?
+}
+
+/// Discriminated `params` payload — covers the JSON-RPC methods this
+/// client makes today. Each case encodes as the JSON-RPC convention of
+/// a one-element array around the parameter object (or address /
+/// hash string).
+enum AlchemyJSONRPCParams: Encodable {
+  case assetTransfers(AlchemyAssetTransfersParams)
+  case tokenMetadata(contractAddress: String)
+  case transactionReceipt(hash: String)
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.unkeyedContainer()
+    switch self {
+    case .assetTransfers(let params):
+      try container.encode(params)
+    case .tokenMetadata(let address):
+      try container.encode(address)
+    case .transactionReceipt(let hash):
+      try container.encode(hash)
+    }
+  }
+}
+
+/// Body for the `params[0]` object of `alchemy_getAssetTransfers`.
+struct AlchemyAssetTransfersParams: Encodable {
+  let fromBlock: String
+  let toBlock: String
+  let fromAddress: String?
+  let toAddress: String?
+  let category: [String]
+  let withMetadata: Bool
+  let excludeZeroValue: Bool
+}
+
+/// Decodes the `result` object of `alchemy_getAssetTransfers`. The
+/// outer envelope wraps this in
+/// `AlchemyJSONRPCResponse<AlchemyTransferResult>`.
+struct AlchemyTransferEnvelope: Decodable {
+  let result: AlchemyTransferResult
+}
+
+struct AlchemyTransferResult: Decodable {
+  let transfers: [AlchemyTransfer]
+}
+
+/// HTTP response validator for `LiveAlchemyClient`. Maps status codes
+/// to `WalletSyncError` cases and parses `Retry-After` for the 429
+/// path. Lifted out of `AlchemyClient.swift` so the main client struct
+/// stays inside SwiftLint's `type_body_length` budget.
+enum AlchemyResponseValidator {
+  /// Validates the HTTP response, throwing the appropriate
+  /// `WalletSyncError` on non-2xx status. `logger` is the per-instance
+  /// `Logger` from the calling client; passed in so log messages remain
+  /// attributed to the same subsystem/category as the rest of the
+  /// client's output.
+  static func validate(
+    response: URLResponse,
+    stage: String,
+    logger: Logger
+  ) throws {
+    guard let http = response as? HTTPURLResponse else {
+      logger.error(
+        "Alchemy \(stage, privacy: .public): non-HTTP response"
+      )
+      throw WalletSyncError.network(underlyingDescription: "No HTTP response")
+    }
+    switch http.statusCode {
+    case 200...299:
+      return
+    case 401, 403:
+      logger.error(
+        "Alchemy \(stage, privacy: .public): API key rejected (HTTP \(http.statusCode, privacy: .public))"
+      )
+      throw WalletSyncError.invalidApiKey
+    case 429:
+      let retryAfter = parseRetryAfter(http: http)
+      logger.notice(
+        "Alchemy \(stage, privacy: .public): rate limited (HTTP 429)"
+      )
+      throw WalletSyncError.rateLimited(retryAfter: retryAfter)
+    default:
+      logger.error(
+        "Alchemy \(stage, privacy: .public): HTTP \(http.statusCode, privacy: .public)"
+      )
+      throw WalletSyncError.network(
+        underlyingDescription: "HTTP \(http.statusCode)"
+      )
+    }
+  }
+
+  /// Parses `Retry-After` per RFC 7231: either a non-negative integer
+  /// seconds value or an HTTP-date. Returns `nil` when the header is
+  /// absent or unparseable.
+  private static func parseRetryAfter(http: HTTPURLResponse) -> Date? {
+    guard let header = http.value(forHTTPHeaderField: "Retry-After") else {
+      return nil
+    }
+    let trimmed = header.trimmingCharacters(in: .whitespaces)
+    if let seconds = TimeInterval(trimmed) {
+      return Date().addingTimeInterval(seconds)
+    }
+    let formatter = DateFormatter()
+    formatter.locale = Locale(identifier: "en_US_POSIX")
+    formatter.timeZone = TimeZone(identifier: "GMT")
+    formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
+    return formatter.date(from: trimmed)
+  }
+}
+
+/// Wire-format payload for `eth_getTransactionReceipt`. We only decode
+/// the two fields the gas-leg builder needs (`gasUsed`,
+/// `effectiveGasPrice`); everything else on the receipt is ignored.
+///
+/// Hex parsing happens in `toReceipt(hash:)` rather than in a custom
+/// `init(from:)` so the throw-site stays close to the call. Both
+/// fields are required — the JSON-RPC spec mandates them on a non-null
+/// receipt, so a missing one is a malformed response we reject rather
+/// than silently zero out (a zero gas leg would look like a free
+/// transaction and corrupt the user's ledger).
+struct AlchemyTransactionReceiptPayload: Decodable {
+  let gasUsed: String
+  let effectiveGasPrice: String
+
+  func toReceipt(hash: String) throws -> AlchemyTransactionReceipt {
+    guard
+      let gasUsedValue = HexDecimal.parse(gasUsed),
+      let effectiveGasPriceValue = HexDecimal.parse(effectiveGasPrice)
+    else {
+      throw WalletSyncError.providerMalformedResponse(stage: "getTransactionReceipt")
+    }
+    return AlchemyTransactionReceipt(
+      hash: hash,
+      gasUsed: gasUsedValue,
+      effectiveGasPrice: effectiveGasPriceValue
+    )
+  }
+}

--- a/Shared/CryptoImport/AlchemyTransactionReceipt.swift
+++ b/Shared/CryptoImport/AlchemyTransactionReceipt.swift
@@ -1,0 +1,69 @@
+// Shared/CryptoImport/AlchemyTransactionReceipt.swift
+import Foundation
+
+/// Decoded subset of Alchemy `eth_getTransactionReceipt` response.
+/// Used to compute the gas leg on outbound transfers — Alchemy's
+/// transfer endpoint doesn't include gas-cost data per transfer, so
+/// the wallet sync pipeline fetches the receipt for any unique
+/// outbound `txHash`.
+///
+/// `gasUsed` is the actual amount of gas consumed (post-execution).
+/// `effectiveGasPrice` is the per-gas price actually paid (post-EIP-1559
+/// — handles base fee + priority tip). Multiplying gives wei spent on gas.
+///
+/// Both fields decode from `0x`-prefixed hex strings; we normalise to
+/// `Decimal` to preserve precision (256-bit values overflow `UInt64`).
+struct AlchemyTransactionReceipt: Sendable, Hashable {
+  /// On-chain transaction hash (`0x`-prefixed). Used by the builder to
+  /// key receipts back to the originating event.
+  let hash: String
+  /// Gas units actually consumed by the transaction. Decoded from the
+  /// `gasUsed` 0x-hex field on the receipt.
+  let gasUsed: Decimal
+  /// Effective per-gas price actually paid in wei. Decoded from the
+  /// `effectiveGasPrice` 0x-hex field; covers both base fee and priority
+  /// tip post-EIP-1559.
+  let effectiveGasPrice: Decimal
+
+  /// `gasUsed * effectiveGasPrice` in wei. Caller divides by
+  /// `10 ** chain.nativeInstrument.decimals` to get native units.
+  var totalGasFeeWei: Decimal {
+    gasUsed * effectiveGasPrice
+  }
+}
+
+/// Lenient `0x`-prefixed hex parser shared by the `AlchemyClient`
+/// receipt decoder and the `AlchemyTransfer.RawContract` value
+/// accessors. Returns `nil` on malformed input so callers can log and
+/// skip without failing the whole sync.
+///
+/// `Decimal` is the target type because 256-bit on-chain integers
+/// overflow `UInt64` (gas-fee products in particular routinely exceed
+/// 64 bits once `gasUsed * effectiveGasPrice` lands in wei).
+enum HexDecimal {
+  /// Parses a 0x-prefixed (or unprefixed) hex string into a `Decimal`.
+  /// Returns `nil` on empty input or any non-hex character.
+  static func parse(_ string: String) -> Decimal? {
+    let trimmed = stripHexPrefix(string)
+    guard !trimmed.isEmpty else { return nil }
+    var result: Decimal = 0
+    for char in trimmed {
+      guard let nibble = char.hexDigitValue else { return nil }
+      result = result * 16 + Decimal(nibble)
+    }
+    return result
+  }
+
+  /// Parses a 0x-prefixed hex string into an `Int`. Returns `nil` on
+  /// malformed input or values that exceed `Int.max`.
+  static func parseInt(_ string: String) -> Int? {
+    let trimmed = stripHexPrefix(string)
+    return Int(trimmed, radix: 16)
+  }
+
+  private static func stripHexPrefix(_ string: String) -> String {
+    string.hasPrefix("0x") || string.hasPrefix("0X")
+      ? String(string.dropFirst(2))
+      : string
+  }
+}

--- a/Shared/CryptoImport/AlchemyTransfer.swift
+++ b/Shared/CryptoImport/AlchemyTransfer.swift
@@ -51,42 +51,17 @@ struct AlchemyTransfer: Sendable, Hashable, Decodable {
     let rawValue: String?
 
     /// Parses `decimal` from 0x-hex into an `Int`. Returns `nil` if the
-    /// field is missing or malformed.
+    /// field is missing or malformed. Defers to `HexDecimal.parseInt`.
     var decimalsValue: Int? {
-      decimal.flatMap { Self.parseHexInt($0) }
+      decimal.flatMap { HexDecimal.parseInt($0) }
     }
 
     /// Parses `rawValue` from 0x-hex into a `Decimal`. Returns `nil` if
     /// the field is missing or malformed. `Decimal` is used because
-    /// 256-bit token amounts overflow `UInt64`.
+    /// 256-bit token amounts overflow `UInt64`. Defers to
+    /// `HexDecimal.parse`.
     var rawDecimalValue: Decimal? {
-      rawValue.flatMap { Self.parseHexDecimal($0) }
-    }
-
-    private static func parseHexInt(_ string: String) -> Int? {
-      let trimmed = stripHexPrefix(string)
-      return Int(trimmed, radix: 16)
-    }
-
-    /// Parses a 0x-prefixed hex string into a `Decimal`. Loops over each
-    /// nibble multiplying by 16 — accumulator-based because `Decimal`
-    /// has no built-in radix-16 initializer and we need the full
-    /// 256-bit range.
-    private static func parseHexDecimal(_ string: String) -> Decimal? {
-      let trimmed = stripHexPrefix(string)
-      guard !trimmed.isEmpty else { return nil }
-      var result: Decimal = 0
-      for char in trimmed {
-        guard let nibble = char.hexDigitValue else { return nil }
-        result = result * 16 + Decimal(nibble)
-      }
-      return result
-    }
-
-    private static func stripHexPrefix(_ string: String) -> String {
-      string.hasPrefix("0x") || string.hasPrefix("0X")
-        ? String(string.dropFirst(2))
-        : string
+      rawValue.flatMap { HexDecimal.parse($0) }
     }
   }
 

--- a/Shared/CryptoImport/BuilderServices.swift
+++ b/Shared/CryptoImport/BuilderServices.swift
@@ -1,0 +1,18 @@
+// Shared/CryptoImport/BuilderServices.swift
+import Foundation
+
+/// Shared per-sync-cycle services the builder needs — the chain,
+/// the token-discovery actor, and the Alchemy client used for both
+/// transfer fetches and per-hash receipt lookups. Bundled into a
+/// single value so the public `build(...)` entry point stays inside
+/// SwiftLint's parameter-count budget without sacrificing call-site
+/// clarity.
+///
+/// Lives in its own file so `TransferEventBuilder.swift` stays under
+/// SwiftLint's `file_length` budget after the merge of
+/// `SignAndCounterparty` (issue #754) and `BuilderServices` (issue #762).
+struct BuilderServices: Sendable {
+  let chain: ChainConfig
+  let discovery: CryptoTokenDiscoveryService
+  let alchemy: any AlchemyClient
+}

--- a/Shared/CryptoImport/TransferDirection.swift
+++ b/Shared/CryptoImport/TransferDirection.swift
@@ -1,0 +1,28 @@
+// Shared/CryptoImport/TransferDirection.swift
+import Foundation
+
+/// Direction a single Alchemy transfer takes relative to the synced
+/// wallet. Computed from the lowercased `from` / `to` fields.
+///
+/// Lives in its own file so `TransferEventBuilder.swift` stays under
+/// SwiftLint's `file_length` budget after the merge of issues #754
+/// (`SignAndCounterparty`) and #762 (`BuilderServices`).
+enum TransferDirection: Sendable {
+  case outbound
+  case inbound
+  case selfSend
+  case unrelated
+
+  init(fromAddress: String, toAddress: String?, walletAddress: String) {
+    let from = fromAddress.lowercased()
+    let to = toAddress?.lowercased()
+    let fromIsUs = from == walletAddress
+    let toIsUs = to == walletAddress
+    switch (fromIsUs, toIsUs) {
+    case (true, true): self = .selfSend
+    case (true, false): self = .outbound
+    case (false, true): self = .inbound
+    case (false, false): self = .unrelated
+    }
+  }
+}

--- a/Shared/CryptoImport/TransferEventBuilder.swift
+++ b/Shared/CryptoImport/TransferEventBuilder.swift
@@ -383,37 +383,3 @@ private struct SignAndCounterparty {
   let signedQuantity: Decimal
   let counterpartyAddress: String?
 }
-
-/// Shared per-sync-cycle services the builder needs — the chain,
-/// the token-discovery actor, and the Alchemy client used for both
-/// transfer fetches and per-hash receipt lookups. Bundled into a
-/// single value so the public `build(...)` entry point stays inside
-/// SwiftLint's parameter-count budget without sacrificing call-site
-/// clarity.
-struct BuilderServices: Sendable {
-  let chain: ChainConfig
-  let discovery: CryptoTokenDiscoveryService
-  let alchemy: any AlchemyClient
-}
-
-/// Direction a single Alchemy transfer takes relative to the synced
-/// wallet. Computed from the lowercased `from` / `to` fields.
-private enum TransferDirection {
-  case outbound
-  case inbound
-  case selfSend
-  case unrelated
-
-  init(fromAddress: String, toAddress: String?, walletAddress: String) {
-    let from = fromAddress.lowercased()
-    let to = toAddress?.lowercased()
-    let fromIsUs = from == walletAddress
-    let toIsUs = to == walletAddress
-    switch (fromIsUs, toIsUs) {
-    case (true, true): self = .selfSend
-    case (true, false): self = .outbound
-    case (false, true): self = .inbound
-    case (false, false): self = .unrelated
-    }
-  }
-}

--- a/Shared/CryptoImport/TransferEventBuilder.swift
+++ b/Shared/CryptoImport/TransferEventBuilder.swift
@@ -10,12 +10,11 @@ import os
 /// Produces multi-leg transactions:
 /// - One `.transfer` leg in the value token per token movement involving
 ///   this wallet (negative quantity outbound; positive inbound).
-/// - The gas leg (`.expense` in the chain native token, on the from-side
-///   wallet only) is **deferred to a follow-up** — it requires an
-///   `eth_getTransactionReceipt` round-trip that Stage 4's `AlchemyClient`
-///   does not yet expose. See issue #762. Stage 6 ships transfer-leg-only
-///   `BuiltTransaction`s and the gas leg is added once that client method
-///   lands.
+/// - One `.expense` gas leg in the chain native token, on the from-side
+///   wallet only, when this wallet is the sender of an `external`
+///   transfer. The receipt fetch is coalesced per unique outbound
+///   `txHash` so a single complex transaction with N transfer legs only
+///   triggers one `eth_getTransactionReceipt` round-trip.
 ///
 /// Each leg's `externalId` is set to the event's `hash`. The `counterpartyAddress`
 /// is the lowercased on-chain address on the *other* side of the transfer:
@@ -41,13 +40,22 @@ struct TransferEventBuilder: Sendable {
   /// `to` lowercased but callers may have stored the address in
   /// checksummed form. Transfers where `from` matches the wallet are
   /// outbound; matches on `to` are inbound. A self-send (both sides on
-  /// this wallet) emits a single inbound leg — Stage 7's apply pass
-  /// pairs the matching outbound from the build phase if the user
-  /// happens to track the same wallet under two accounts (rare).
+  /// this wallet) emits a single inbound leg plus the gas leg — Stage
+  /// 7's apply pass pairs the matching outbound from the build phase if
+  /// the user happens to track the same wallet under two accounts
+  /// (rare).
   ///
   /// `importOrigin` carries the per-import audit context (sync session
   /// id, parser identifier). Caller supplies; the builder echoes it on
   /// every produced transaction.
+  ///
+  /// `alchemy` is the same client used by `WalletSyncEngine` to fetch
+  /// transfers. The builder uses it to fetch one `eth_getTransactionReceipt`
+  /// per unique outbound `txHash` so it can attach the gas leg. Receipt
+  /// fetches run in parallel via a `TaskGroup`; the rate limiter inside
+  /// the live client handles throttling. A receipt-fetch failure for one
+  /// hash logs and continues — the affected event ships without a gas
+  /// leg rather than failing the whole account.
   ///
   /// Throws: surfaces only `CancellationError` from the discovery actor
   /// and `WalletSyncError.providerMalformedResponse` when a transfer
@@ -58,10 +66,12 @@ struct TransferEventBuilder: Sendable {
   func build(
     transfers: [AlchemyTransfer],
     account: Account,
-    chain: ChainConfig,
-    discovery: CryptoTokenDiscoveryService,
+    services: BuilderServices,
     importOrigin: ImportOrigin
   ) async throws -> [BuiltTransaction] {
+    let chain = services.chain
+    let discovery = services.discovery
+    let alchemy = services.alchemy
     let signpostID = OSSignpostID(log: Signposts.cryptoSync)
     os_signpost(
       .begin,
@@ -90,12 +100,24 @@ struct TransferEventBuilder: Sendable {
     // Stable order: group preserves first-seen order so test fixtures
     // and signposts are deterministic.
     let groups = groupByHash(transfers)
+    let receipts = try await TransferReceiptCoalescer.fetchReceipts(
+      groups: groups,
+      walletAddress: context.walletAddress,
+      chain: chain,
+      alchemy: alchemy)
+
     var results: [BuiltTransaction] = []
     results.reserveCapacity(groups.count)
 
     for events in groups {
       try Task.checkCancellation()
-      guard let built = try await buildEvent(events: events, context: context) else {
+      let receipt = events.first.flatMap { receipts[$0.hash] }
+      guard
+        let built = try await buildEvent(
+          events: events,
+          receipt: receipt,
+          context: context)
+      else {
         continue
       }
       results.append(built)
@@ -125,8 +147,16 @@ struct TransferEventBuilder: Sendable {
   /// Builds one `BuiltTransaction` from a hash group, or returns `nil`
   /// when the group produces no usable legs (every transfer was unknown
   /// category or malformed).
+  ///
+  /// `receipt` is the pre-fetched `eth_getTransactionReceipt` for this
+  /// hash, present only when at least one event is an outbound
+  /// `external` transfer for this wallet. When present the builder
+  /// appends a single `.expense` gas leg in the chain's native token
+  /// using the same `externalId` as the transfer legs, so dedup against
+  /// existing storage stays on `(accountId, externalId)`.
   private func buildEvent(
     events: [AlchemyTransfer],
+    receipt: AlchemyTransactionReceipt?,
     context: BuildContext
   ) async throws -> BuiltTransaction? {
     var legs: [TransactionLeg] = []
@@ -148,6 +178,13 @@ struct TransferEventBuilder: Sendable {
     }
 
     guard !legs.isEmpty else { return nil }
+
+    if let receipt,
+      let gasLeg = TransferReceiptCoalescer.makeGasLeg(
+        receipt: receipt, accountId: context.account.id, chain: context.chain)
+    {
+      legs.append(gasLeg)
+    }
 
     // Date precedence: earliest block timestamp across the group, falling
     // back to `importedAt` so the transaction never lands with a zero
@@ -345,6 +382,18 @@ private struct BuildContext: Sendable {
 private struct SignAndCounterparty {
   let signedQuantity: Decimal
   let counterpartyAddress: String?
+}
+
+/// Shared per-sync-cycle services the builder needs — the chain,
+/// the token-discovery actor, and the Alchemy client used for both
+/// transfer fetches and per-hash receipt lookups. Bundled into a
+/// single value so the public `build(...)` entry point stays inside
+/// SwiftLint's parameter-count budget without sacrificing call-site
+/// clarity.
+struct BuilderServices: Sendable {
+  let chain: ChainConfig
+  let discovery: CryptoTokenDiscoveryService
+  let alchemy: any AlchemyClient
 }
 
 /// Direction a single Alchemy transfer takes relative to the synced

--- a/Shared/CryptoImport/TransferReceiptCoalescer.swift
+++ b/Shared/CryptoImport/TransferReceiptCoalescer.swift
@@ -1,0 +1,143 @@
+// Shared/CryptoImport/TransferReceiptCoalescer.swift
+import Foundation
+import OSLog
+
+/// Receipt coalescing + gas-leg construction helpers, factored out of
+/// `TransferEventBuilder.swift` so the main builder file stays inside
+/// SwiftLint's `file_length` / `type_body_length` budgets. Internal to
+/// the module — only the builder calls these — but file-private would
+/// hide them from `TransferEventBuilder.swift`. All functions are
+/// `Sendable`-pure (no captured state) so they're safe to call from
+/// inside the parallel build path.
+enum TransferReceiptCoalescer {
+  /// Shared static `Logger`; matches the builder's pattern so receipt
+  /// failures appear under the same subsystem in Console.app.
+  static let logger = Logger(
+    subsystem: "com.moolah.app", category: "TransferEventBuilder")
+
+  /// Fetches `eth_getTransactionReceipt` for every unique outbound
+  /// transfer hash in `groups`, in parallel via a `TaskGroup`. Coalescing
+  /// happens at the hash level: a transaction with N outbound transfer
+  /// legs (e.g. a multi-token swap) triggers exactly one receipt fetch.
+  /// Inbound-only events don't trigger fetches — gas-leg construction
+  /// is restricted to the from-side wallet per the design's "from-side
+  /// wallet only" rule.
+  ///
+  /// Per-receipt fetch failures (network blip, rate limit on a single
+  /// hash, malformed response) log and are dropped from the returned
+  /// dictionary; affected events ship without a gas leg. This keeps a
+  /// single bad receipt from failing the whole account, mirroring the
+  /// builder's per-row decode-failure policy elsewhere. Cancellation is
+  /// re-thrown so the group cancels every sibling and the caller sees
+  /// the cancellation rather than a missing leg.
+  static func fetchReceipts(
+    groups: [[AlchemyTransfer]],
+    walletAddress: String,
+    chain: ChainConfig,
+    alchemy: any AlchemyClient
+  ) async throws -> [String: AlchemyTransactionReceipt] {
+    let hashes = outboundHashes(in: groups, walletAddress: walletAddress)
+    guard !hashes.isEmpty else { return [:] }
+    var receipts: [String: AlchemyTransactionReceipt] = [:]
+    receipts.reserveCapacity(hashes.count)
+    try await withThrowingTaskGroup(of: AlchemyTransactionReceipt?.self) { group in
+      for hash in hashes {
+        group.addTask {
+          try await fetchOne(hash: hash, chain: chain, alchemy: alchemy)
+        }
+      }
+      for try await maybeReceipt in group {
+        if let receipt = maybeReceipt {
+          receipts[receipt.hash] = receipt
+        }
+      }
+    }
+    return receipts
+  }
+
+  /// Single-hash receipt fetch with the per-hash error-containment
+  /// policy. `CancellationError` re-throws so the enclosing `TaskGroup`
+  /// (and the outer build) terminate cleanly; every other failure logs
+  /// and returns `nil` so the affected event ships without a gas leg.
+  /// This keeps a transient receipt failure from blocking the rest of
+  /// the account's sync.
+  private static func fetchOne(
+    hash: String,
+    chain: ChainConfig,
+    alchemy: any AlchemyClient
+  ) async throws -> AlchemyTransactionReceipt? {
+    do {
+      return try await alchemy.getTransactionReceipt(chain: chain, hash: hash)
+    } catch is CancellationError {
+      throw CancellationError()
+    } catch {
+      logger.notice(
+        "Skipping gas leg for hash \(hash, privacy: .private) — receipt fetch failed: \(error.localizedDescription, privacy: .public)"
+      )
+      return nil
+    }
+  }
+
+  /// Walks the grouped transfers and returns the set of `txHash` values
+  /// that have at least one outbound transfer for this wallet —
+  /// `external` for native sends, `erc20` (or `internal`) where this
+  /// wallet is the from-side token sender. The Alchemy transfer
+  /// endpoint reports `from` as the EOA on a top-level call
+  /// (`external`) and as the token sender on an `erc20` row; in the
+  /// simple `transfer()` case those are the same address, so a `from ==
+  /// walletAddress` match across any accepted category is a reliable
+  /// signal that this wallet paid the gas. NFT (`unknown`) categories
+  /// are filtered out — gas-leg attribution is only meaningful for
+  /// accepted categories.
+  ///
+  /// The walk preserves first-seen order so receipt fetches retire in a
+  /// deterministic sequence (helps with signpost tracing).
+  static func outboundHashes(
+    in groups: [[AlchemyTransfer]],
+    walletAddress: String
+  ) -> [String] {
+    var seen: Set<String> = []
+    var ordered: [String] = []
+    for events in groups {
+      guard let first = events.first else { continue }
+      let isOutbound = events.contains { event in
+        event.category != .unknown
+          && event.from.lowercased() == walletAddress
+      }
+      guard isOutbound, seen.insert(first.hash).inserted else { continue }
+      ordered.append(first.hash)
+    }
+    return ordered
+  }
+
+  /// Builds the gas leg for an outbound transaction from a fetched
+  /// receipt. The leg is `.expense` typed, denominated in the chain's
+  /// native instrument, and carries a negative quantity — gas is always
+  /// paid out (this wallet is the sender). Per the project sign rule
+  /// (CLAUDE.md "Monetary Sign Convention") the negative is preserved
+  /// rather than `abs()`-stripped; downstream display logic handles the
+  /// sign.
+  ///
+  /// Returns `nil` when the receipt's `gasUsed` or `effectiveGasPrice`
+  /// produces a non-positive product (e.g. a zero-gas synthetic). A
+  /// zero gas leg would clutter the transaction without representing
+  /// any real expense, so we drop it rather than persist a noise row.
+  static func makeGasLeg(
+    receipt: AlchemyTransactionReceipt,
+    accountId: UUID,
+    chain: ChainConfig
+  ) -> TransactionLeg? {
+    let gasFeeWei = receipt.totalGasFeeWei
+    guard gasFeeWei > 0 else { return nil }
+    let nativeDecimals = chain.nativeInstrument.decimals
+    guard nativeDecimals >= 0 else { return nil }
+    let scale = Decimal(sign: .plus, exponent: nativeDecimals, significand: 1)
+    let gasFeeNative = gasFeeWei / scale
+    return TransactionLeg(
+      accountId: accountId,
+      instrument: chain.nativeInstrument,
+      quantity: -gasFeeNative,
+      externalId: receipt.hash,
+      type: .expense)
+  }
+}

--- a/Shared/CryptoImport/WalletSyncEngine.swift
+++ b/Shared/CryptoImport/WalletSyncEngine.swift
@@ -110,8 +110,8 @@ struct WalletSyncEngine: Sendable {
     let built = try await builder.build(
       transfers: transfers,
       account: account,
-      chain: chain,
-      discovery: discovery,
+      services: BuilderServices(
+        chain: chain, discovery: discovery, alchemy: alchemy),
       importOrigin: importOrigin)
     return WalletSyncBuildResult(candidates: built, headBlockNumber: headBlock)
   }


### PR DESCRIPTION
## Summary

Closes [#762](https://github.com/ajsutton/moolah-native/issues/762). Stage 6 shipped wallet auto-import without gas legs because Alchemy's `getAssetTransfers` doesn't include gas-cost data; this PR closes the gap by fetching `eth_getTransactionReceipt` once per unique outbound `txHash` and attaching a negative-quantity `.expense` leg in the chain's native token.

- New `AlchemyClient.getTransactionReceipt(chain:hash:)` + `LiveAlchemyClient` implementation. Hash is `.private` in logs; null `result` envelopes map to `WalletSyncError.providerMalformedResponse(stage: \"getTransactionReceipt\")`.
- `AlchemyTransactionReceipt` decodes `gasUsed` and `effectiveGasPrice` from `0x`-hex via a shared `HexDecimal` helper (preserves 256-bit precision; `AlchemyTransfer.RawContract` now reuses the same parser).
- `TransferReceiptCoalescer` (factored out of `TransferEventBuilder` to keep the file inside the `file_length` budget) deduplicates receipt fetches per outbound `txHash` using a `TaskGroup`. One outbound + four inbound → one fetch; five outbound across five hashes → five fetches; two outbound legs sharing one hash → one fetch.
- Gas leg sign is always negative (sign preserved per CLAUDE.md "Monetary Sign Convention" — never `abs()`); per-receipt fetch failures log and drop only the affected gas leg, mirroring existing per-row decode-failure policy. `CancellationError` re-throws so the parent `TaskGroup` and outer build cancel cleanly.
- Plumbing: `TransferEventBuilder.build(...)` now takes a `BuilderServices` bundle (chain + discovery + alchemy) so the public signature stays inside the SwiftLint parameter-count budget.

Per [design §"Sync algorithm"](../blob/main/plans/completed/2026-05-05-crypto-wallet-import-design.md).

## Test plan

- [x] New suites: `AlchemyTransactionReceiptDecodingTests`, `LiveAlchemyClientReceiptTests`, `TransferEventBuilderGasLegTests`, `TransferEventBuilderGasCoalescingTests` (and `TransferEventBuilderConcurrencyTests` to keep the existing 100-builder coalescing test out of the size budget).
- [x] Fixtures: `eth-receipt-simple-send.json` and `op-receipt-erc20-transfer.json`.
- [x] `RecordingAlchemyClientStub.setReceiptResponse(_:for:)` lets tests script per-hash receipts; `ZeroReceiptAlchemyStub` keeps the existing transfer-leg suites focused (zero gas-fee → no leg appended).
- [x] `just format-check` clean.
- [x] `just test` passes (2363 tests on iOS, 2388 on macOS).
- [x] No SwiftLint baseline edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)