### PR TITLE
fix(reports): include investment-account legs in category breakdown

### DIFF
--- a/Backends/GRDB/Repositories/GRDBAnalysisRepository+CategoryBalances.swift
+++ b/Backends/GRDB/Repositories/GRDBAnalysisRepository+CategoryBalances.swift
@@ -75,22 +75,17 @@ extension GRDBAnalysisRepository {
   /// pinned by
   /// `AnalysisAggregationPlanPinningTests.fetchCategoryBalancesUsesCategoryIndex`.
   ///
-  /// **Investment-account exclusion.** The LEFT JOIN to `account`
-  /// produces a NULL `a.type` for legs whose `account_id` is null
-  /// (treated as `isInvestmentAccount = false`); the
-  /// `(a.type IS NULL OR a.type <> 'investment')` predicate accepts
-  /// those rows and rejects investment-account legs. Account-less
-  /// categorised legs therefore surface in the breakdown — the
-  /// pre-SQL Swift accumulator never filtered on `accountId`, and
-  /// `GRDBCategoryBalancesConversionTests` pins the same behaviour.
-  ///
-  /// **Plan note.** The LEFT JOIN reads `leg.account_id` to drive the
-  /// join, but `account_id` is not in `leg_analysis_by_type_category`'s
-  /// column list. SQLite therefore has to fetch the leg's base row and
-  /// the plan resolves to plain `USING INDEX` (not COVERING). Adding
-  /// `account_id` to the composite would bloat every leg row to fix a
-  /// read-time concern; the plan-pinning test asserts no `SCAN` on the
-  /// leg or transaction tables but does NOT require COVERING here.
+  /// **Account-type neutral.** Every categorised income/expense leg
+  /// counts toward the breakdown regardless of which account holds it
+  /// — a dividend or brokerage fee booked against an investment
+  /// account belongs in the income/expense report just like a salary
+  /// or a grocery shop on a bank account. This matches
+  /// `fetchIncomeAndExpense`'s contract (see
+  /// `+IncomeAndExpenseAggregation.swift`). Trade and transfer legs
+  /// are excluded by `leg.type = ?` (the bound `transactionType` is
+  /// always `.income` or `.expense`); the `leg.category_id IS NOT NULL`
+  /// guard is a defensive filter for income/expense legs that happen
+  /// to lack a category.
   ///
   /// **`categoryIds` parameterisation.** SQLite cannot bind a
   /// variable-length array to a single named parameter; an
@@ -164,13 +159,12 @@ extension GRDBAnalysisRepository {
       ? SQL("")
       : SQL("AND leg.category_id IN \(args.categoryIds)")
 
-    // `leg.instrument_id` and `leg.category_id` must be table-qualified
-    // throughout because `account` exposes its own `instrument_id` column,
-    // and a bare `instrument_id` in the GROUP BY would be ambiguous to
-    // SQLite once the LEFT JOIN to `account` brings `a.instrument_id`
-    // into scope. The column-aliases (`AS day`, `AS category_id`,
-    // `AS instrument_id`) are fine in the SELECT list but cannot be
-    // referenced bare in GROUP BY for the same ambiguity reason.
+    // Columns are table-qualified (`leg.`, `t.`) defensively — none of
+    // the current tables in scope share a column name, but if a future
+    // filter fragment joins a table that exposes one of these columns,
+    // a bare reference in GROUP BY would silently become ambiguous.
+    // Keeping the qualifications now means a future join won't tip the
+    // SELECT/GROUP BY shape over.
     let literal: SQL = """
       SELECT DATE(t.date)        AS day,
              leg.category_id     AS category_id,
@@ -178,12 +172,10 @@ extension GRDBAnalysisRepository {
              SUM(leg.quantity)   AS qty
       FROM transaction_leg leg
       JOIN "transaction"    t ON leg.transaction_id = t.id
-      LEFT JOIN account     a ON leg.account_id = a.id
       WHERE t.recur_period IS NULL
         AND t.date >= \(lower) AND t.date <= \(upper)
         AND leg.type = \(typeRaw)
         AND leg.category_id IS NOT NULL
-        AND (a.type IS NULL OR a.type <> 'investment')
         \(accountClause)
         \(earmarkClause)
         \(payeeClause)

--- a/MoolahTests/Backends/GRDB/AnalysisAggregationPlanPinningTests.swift
+++ b/MoolahTests/Backends/GRDB/AnalysisAggregationPlanPinningTests.swift
@@ -156,28 +156,21 @@ struct AnalysisAggregationPlanPinningTests {
 
   // MARK: - fetchCategoryBalances
 
-  @Test("fetchCategoryBalances SQL uses leg_analysis_by_type_category index")
+  @Test("fetchCategoryBalances SQL uses leg_analysis_by_type_category covering index")
   func fetchCategoryBalancesUsesCategoryIndex() throws {
     let database = try makeDatabase()
     // Mirrors the exact SQL shape used by
     // `GRDBAnalysisRepository.fetchCategoryBalances(...)` with no
     // optional filters set: GROUP BY `(DATE(t.date), category_id,
-    // instrument_id)` restricted to non-scheduled categorised legs of a
-    // given type, in a date range, with the investment-account
-    // exclusion via a LEFT JOIN to `account`.
-    //
-    // Unlike `fetchExpenseBreakdown` we do NOT assert
-    // `USING COVERING INDEX`. The LEFT JOIN to `account` requires
-    // `leg.account_id` to drive the join, but `account_id` is not in
-    // `leg_analysis_by_type_category`'s column list. SQLite therefore
-    // fetches the leg's base row to read `account_id`, which flips the
-    // plan from `USING COVERING INDEX` to plain `USING INDEX`. The
-    // covering miss is unavoidable because the investment-account
-    // exclusion is a semantic requirement (mirrors
-    // `+IncomeExpense.applyByType`'s isInvestmentAccount guard) — it
-    // can't be expressed against the leg side alone, and adding
-    // `account_id` to the composite index would bloat every leg row
-    // for a feature that only matters at read time.
+    // instrument_id)` restricted to non-scheduled categorised legs of
+    // a given type in a date range. The aggregation no longer joins
+    // to `account` — investment-account legs are intentionally
+    // included alongside the rest (matches
+    // `fetchIncomeAndExpense`'s contract). With the LEFT JOIN gone
+    // the plan resolves to `USING COVERING INDEX` on
+    // `leg_analysis_by_type_category` because every leg column
+    // touched (`type`, `category_id`, `instrument_id`,
+    // `transaction_id`, `quantity`) sits in the composite.
     let detail = try planDetail(
       database,
       query: """
@@ -187,41 +180,35 @@ struct AnalysisAggregationPlanPinningTests {
                SUM(leg.quantity)   AS qty
         FROM transaction_leg leg
         JOIN "transaction"    t ON leg.transaction_id = t.id
-        LEFT JOIN account     a ON leg.account_id = a.id
         WHERE t.recur_period IS NULL
           AND t.date >= ? AND t.date <= ?
           AND leg.type = ?
           AND leg.category_id IS NOT NULL
-          AND (a.type IS NULL OR a.type <> 'investment')
         GROUP BY DATE(t.date), leg.category_id, leg.instrument_id
         ORDER BY DATE(t.date) ASC, leg.category_id ASC
         """,
       arguments: [Date(), Date(), "expense"])
     #expect(detail.contains("leg_analysis_by_type_category"))
+    #expect(detail.contains("USING COVERING INDEX"))
     // SQLite emits `SCAN <alias>` for aliased FROM clauses — here
     // `transaction_leg leg`. Pin against the alias rather than the
     // bare table name (which would never match this query's plan and
     // would silently pass even on a full scan).
     #expect(!PlanPinningTestHelpers.planHasFullTableScanOf(detail, alias: "leg"))
     #expect(!detail.contains("SCAN \"transaction\""))
-    // The LEFT JOIN to `account` should resolve via the PK
-    // (`sqlite_autoindex_account_1`) or `account_by_type` rather than a
-    // full scan — pin that no `SCAN account` line slips into the plan.
-    #expect(!detail.contains("SCAN account"))
   }
 
   @Test("fetchCategoryBalances with accountId filter consults leg_by_account")
   func fetchCategoryBalancesAccountFilterConsultsAccountIndex() throws {
     let database = try makeDatabase()
     // With the optional `accountId` filter set, the WHERE clause grows
-    // an `AND leg.account_id = ?` predicate. Either of the leg-side
-    // partial indexes — `leg_by_account` or the covering
-    // `leg_analysis_by_type_account` — is acceptable, both let SQLite
-    // narrow to the matching legs without scanning. The composite
-    // `leg_analysis_by_type_category` is still permitted to participate
-    // for the join+grouping side; we don't pin which one wins, only
-    // that one of the account-aware indexes is consulted somewhere in
-    // the plan.
+    // an `AND leg.account_id = ?` predicate. Any of the leg-side
+    // indexes that lets SQLite avoid a full scan is acceptable —
+    // `leg_by_account` or `leg_analysis_by_type_account` (both
+    // account-aware) or `leg_analysis_by_type_category` (which covers
+    // the SELECT and post-filters `account_id` against the base row).
+    // We don't pin which one the planner picks; the SCAN-rejection
+    // assertions below are what catch a regression.
     let detail = try planDetail(
       database,
       query: """
@@ -231,12 +218,10 @@ struct AnalysisAggregationPlanPinningTests {
                SUM(leg.quantity)   AS qty
         FROM transaction_leg leg
         JOIN "transaction"    t ON leg.transaction_id = t.id
-        LEFT JOIN account     a ON leg.account_id = a.id
         WHERE t.recur_period IS NULL
           AND t.date >= ? AND t.date <= ?
           AND leg.type = ?
           AND leg.category_id IS NOT NULL
-          AND (a.type IS NULL OR a.type <> 'investment')
           AND leg.account_id = ?
         GROUP BY DATE(t.date), leg.category_id, leg.instrument_id
         ORDER BY DATE(t.date) ASC, leg.category_id ASC
@@ -251,7 +236,6 @@ struct AnalysisAggregationPlanPinningTests {
     // `transaction_leg leg`. Pin against the alias.
     #expect(!PlanPinningTestHelpers.planHasFullTableScanOf(detail, alias: "leg"))
     #expect(!detail.contains("SCAN \"transaction\""))
-    #expect(!detail.contains("SCAN account"))
   }
 
   // MARK: - fetchIncomeAndExpense
@@ -357,12 +341,10 @@ struct AnalysisAggregationPlanPinningTests {
                SUM(leg.quantity)   AS qty
         FROM transaction_leg leg
         JOIN "transaction"    t ON leg.transaction_id = t.id
-        LEFT JOIN account     a ON leg.account_id = a.id
         WHERE t.recur_period IS NULL
           AND t.date >= ? AND t.date <= ?
           AND leg.type = ?
           AND leg.category_id IS NOT NULL
-          AND (a.type IS NULL OR a.type <> 'investment')
           AND leg.earmark_id = ?
         GROUP BY DATE(t.date), leg.category_id, leg.instrument_id
         ORDER BY DATE(t.date) ASC, leg.category_id ASC
@@ -377,6 +359,5 @@ struct AnalysisAggregationPlanPinningTests {
     // `transaction_leg leg`. Pin against the alias.
     #expect(!PlanPinningTestHelpers.planHasFullTableScanOf(detail, alias: "leg"))
     #expect(!detail.contains("SCAN \"transaction\""))
-    #expect(!detail.contains("SCAN account"))
   }
 }

--- a/MoolahTests/Backends/GRDB/GRDBCategoryBalancesConversionTests.swift
+++ b/MoolahTests/Backends/GRDB/GRDBCategoryBalancesConversionTests.swift
@@ -14,9 +14,9 @@ import Testing
 /// `InstrumentConversionService`, mirroring
 /// `GRDBExpenseBreakdownConversionTests`.
 ///
-/// The investment-account exclusion, account-less leg inclusion, and
-/// the `categoryIds` filter are also pinned here — semantic include
-/// rules that the SQL aggregation must continue to honour.
+/// Investment-account inclusion, account-less leg inclusion, and the
+/// `categoryIds` filter are also pinned here — semantic include rules
+/// that the SQL aggregation must continue to honour.
 @Suite("GRDBAnalysisRepository fetchCategoryBalances — date-sensitive conversion")
 struct GRDBCategoryBalancesConversionTests {
 
@@ -85,14 +85,13 @@ struct GRDBCategoryBalancesConversionTests {
         == InstrumentAmount(quantity: -350, instrument: .defaultTestInstrument))
   }
 
-  @Test("category balances exclude legs from investment accounts")
-  func categoryBalancesExcludeInvestmentAccountLegs() async throws {
+  @Test("category balances include expense legs from investment accounts")
+  func categoryBalancesIncludeInvestmentAccountExpenseLegs() async throws {
     // A categorised expense leg posted against an investment account
-    // is excluded from category totals; the same leg posted against a
-    // non-investment account IS included. Pin both halves so the SQL's
-    // LEFT JOIN to `account` and the
-    // `(a.type IS NULL OR a.type <> 'investment')` predicate are
-    // exercised.
+    // (e.g. a brokerage fee) lands in the breakdown alongside a leg of
+    // the same category posted against a regular bank account. This
+    // matches the contract on `fetchIncomeAndExpense`'s `expense_qty`
+    // sum, which also keeps investment-account expense legs.
     let day = try AnalysisTestHelpers.utcDate(year: 2025, month: 7, day: 5, hour: 12)
     let backend = try CloudKitAnalysisTestBackend()
 
@@ -131,19 +130,57 @@ struct GRDBCategoryBalancesConversionTests {
       targetInstrument: .defaultTestInstrument
     )
 
-    // Only the bank leg survives — the investment leg is excluded.
+    // Both legs count: -25 + -100 = -125.
     #expect(
       balances[category.id]
-        == InstrumentAmount(quantity: -25, instrument: .defaultTestInstrument))
+        == InstrumentAmount(quantity: -125, instrument: .defaultTestInstrument))
+  }
+
+  @Test("category balances include income legs from investment accounts")
+  func categoryBalancesIncludeInvestmentAccountIncomeLegs() async throws {
+    // A categorised income leg posted against an investment account
+    // (e.g. a dividend) lands in the income breakdown. Mirrors
+    // `categoryBalancesIncludeInvestmentAccountExpenseLegs` for the
+    // income side and matches `fetchIncomeAndExpense`'s `income_qty`
+    // contract.
+    let day = try AnalysisTestHelpers.utcDate(year: 2025, month: 7, day: 6, hour: 12)
+    let backend = try CloudKitAnalysisTestBackend()
+
+    let investment = Account(
+      id: UUID(), name: "Brokerage", type: .investment,
+      instrument: .defaultTestInstrument)
+    _ = try await backend.accounts.create(investment)
+
+    let dividends = Category(id: UUID(), name: "Dividends")
+    _ = try await backend.categories.create(dividends)
+
+    _ = try await backend.transactions.create(
+      Transaction(
+        date: day, payee: "Brokerage",
+        legs: [
+          TransactionLeg(
+            accountId: investment.id, instrument: .defaultTestInstrument,
+            quantity: 75, type: .income, categoryId: dividends.id)
+        ]))
+
+    let balances = try await backend.analysis.fetchCategoryBalances(
+      dateRange: day...day,
+      transactionType: .income,
+      filters: nil,
+      targetInstrument: .defaultTestInstrument
+    )
+
+    #expect(
+      balances[dividends.id]
+        == InstrumentAmount(quantity: 75, instrument: .defaultTestInstrument))
   }
 
   @Test("category balances include categorised legs without an account")
   func categoryBalancesIncludeAccountlessCategorisedLegs() async throws {
-    // A categorised expense leg with `accountId == nil` is included
-    // (`accountId == nil` is treated as `isInvestmentAccount = false`).
-    // The SQL's LEFT JOIN to `account` produces a NULL `a.type` for
-    // these legs, which the `(a.type IS NULL OR a.type <> 'investment')`
-    // predicate accepts.
+    // A categorised expense leg with `accountId == nil` is included.
+    // The SQL aggregation no longer joins to `account`, so account-less
+    // legs naturally fall through the `leg.category_id IS NOT NULL`
+    // guard and contribute to the breakdown.
     let day = try AnalysisTestHelpers.utcDate(year: 2025, month: 8, day: 12, hour: 12)
     let backend = try CloudKitAnalysisTestBackend()
 


### PR DESCRIPTION
## Summary

- Reports view's Income / Expenses by-category breakdown was silently dropping every leg whose account was `.investment`, so categorised dividends, interest, and brokerage fees never appeared.
- Root cause: `GRDBAnalysisRepository.fetchCategoryBalances`'s SQL had a `LEFT JOIN account` plus `AND (a.type IS NULL OR a.type <> 'investment')` predicate. The sibling `fetchIncomeAndExpense` aggregation deliberately keeps these legs in `income_qty`/`expense_qty` (see comment in `+IncomeAndExpenseAggregation.swift`), so the per-category breakdown was the only outlier and the dashboard totals disagreed with the category sums.
- Fix: drop the JOIN and the predicate. Trade and transfer legs stay out via `leg.type = ?` (bound to `.income` / `.expense`); the existing `leg.category_id IS NOT NULL` guard remains as a defensive filter.
- Side-benefit: removing the JOIN lets the plan resolve to `USING COVERING INDEX` on `leg_analysis_by_type_category` for the no-filter shape — the plan-pinning test now asserts it.

## Test plan

- [x] `just test-mac AnalysisAggregationPlanPinningTests GRDBCategoryBalancesConversionTests` — 12/12 pass, including the tightened `USING COVERING INDEX` assertion and the two new investment-account-inclusion cases.
- [x] `just test-mac AnalysisCategoryBalancesTests AnalysisIncomeExpenseTests AnalysisIncomeExpenseInvestmentTests AnalysisExpenseBreakdownTests EarmarkBudgetTests` — 28/28 pass (no regressions in adjacent analysis or earmark surfaces).
- [x] `just format-check` clean.
- [ ] Smoke-check Reports view in the running app: open with a profile that has dividends / brokerage fees on an investment account; confirm both surface in Income / Expenses tables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)