### PR TITLE
chore(lint): exclude .DerivedData-bench from swiftlint

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -5,6 +5,7 @@
 
 excluded:
   - .build
+  - .DerivedData-bench
   - .DerivedData-ios
   - .DerivedData-mac
   - .worktrees


### PR DESCRIPTION
## Summary

- Adds `.DerivedData-bench` to `.swiftlint.yml`'s `excluded:` list, alongside the existing `.DerivedData-ios` and `.DerivedData-mac` entries.
- The directory is created locally by `scripts/benchmark.sh` and contains GRDB.swift's checkout source, which trips SwiftLint violations (`identifier_name`, `nesting`, `strict_fileprivate`) that are not actionable for this project.
- CI doesn't have this directory, so this is a developer-experience fix only — no behaviour change.

## Test plan

- [x] `git diff` shows a single insertion to `.swiftlint.yml`.
- [ ] Locally, `just format-check` no longer reports `.DerivedData-bench/` violations after a benchmark run.