### PR TITLE
fix(crypto): include .crypto in remaining .investment filters

### DIFF
--- a/Automation/Intents/ListAccountsIntent.swift
+++ b/Automation/Intents/ListAccountsIntent.swift
@@ -41,6 +41,7 @@ enum AccountTypeEnum: String, AppEnum {
   case creditCard
   case asset
   case investment
+  case crypto
 
   static let typeDisplayRepresentation = TypeDisplayRepresentation(
     name: "Account Type")
@@ -50,6 +51,7 @@ enum AccountTypeEnum: String, AppEnum {
     .creditCard: "Credit Card",
     .asset: "Asset",
     .investment: "Investment",
+    .crypto: "Crypto Wallet",
   ]
 
   var toDomainType: AccountType {
@@ -58,6 +60,7 @@ enum AccountTypeEnum: String, AppEnum {
     case .creditCard: .creditCard
     case .asset: .asset
     case .investment: .investment
+    case .crypto: .crypto
     }
   }
 }

--- a/Domain/Models/Accounts+SidebarOrdering.swift
+++ b/Domain/Models/Accounts+SidebarOrdering.swift
@@ -33,7 +33,7 @@ extension Accounts {
     for account in visible {
       if account.type.isCurrent {
         current.append(account)
-      } else {
+      } else if account.type.isInvestmentLike {
         investment.append(account)
       }
     }

--- a/Features/Accounts/AccountStore.swift
+++ b/Features/Accounts/AccountStore.swift
@@ -126,7 +126,7 @@ final class AccountStore {
   }
 
   var investmentAccounts: [Account] {
-    accounts.filter { $0.type == .investment && (showHidden || !$0.isHidden) }
+    accounts.filter { $0.type.isInvestmentLike && (showHidden || !$0.isHidden) }
   }
 
   /// The display balance for an account in its own instrument. Forwards to

--- a/Features/Crypto/CryptoAccountCreationView.swift
+++ b/Features/Crypto/CryptoAccountCreationView.swift
@@ -115,6 +115,7 @@ struct CryptoAccountCreationLogic {
       name: trimmedName,
       type: .crypto,
       instrument: chain.nativeInstrument,
+      valuationMode: .calculatedFromTrades,
       walletAddress: walletAddress,
       chainId: chain.chainId
     )

--- a/MoolahTests/Automation/ListAccountsIntentTypeMirrorTests.swift
+++ b/MoolahTests/Automation/ListAccountsIntentTypeMirrorTests.swift
@@ -1,0 +1,40 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+/// Regression guard for the App Intents `AccountTypeEnum` mirror of the
+/// domain `AccountType`. Adding a case to `AccountType` without adding
+/// the matching `AccountTypeEnum` case (and display representation) is
+/// silent at compile time — the mirror is a separate enum, so Swift's
+/// exhaustiveness check doesn't catch the gap. These tests fail loudly
+/// when the two drift apart so Siri / Shortcuts users can keep filtering
+/// by every supported account type.
+@Suite("ListAccountsIntent — AccountTypeEnum mirror")
+struct ListAccountsIntentTypeMirrorTests {
+  @Test("Every AccountType has a matching AccountTypeEnum case")
+  func everyDomainTypeMirrored() {
+    for domain in AccountType.allCases {
+      let matchingMirror = AccountTypeEnum.allCases.first(where: { $0.toDomainType == domain })
+      #expect(
+        matchingMirror != nil,
+        "AccountType.\(domain) has no matching AccountTypeEnum case — Shortcuts can't filter by it")
+    }
+  }
+
+  @Test("AccountTypeEnum has a display representation for every case")
+  func everyMirrorCaseHasDisplay() {
+    for mirror in AccountTypeEnum.allCases {
+      #expect(
+        AccountTypeEnum.caseDisplayRepresentations[mirror] != nil,
+        "AccountTypeEnum.\(mirror) is missing a caseDisplayRepresentation entry")
+    }
+  }
+
+  @Test("Crypto wallets are exposed via AccountTypeEnum")
+  func cryptoExposed() {
+    let cryptoMirror = AccountTypeEnum.allCases.first(where: { $0.toDomainType == .crypto })
+    #expect(cryptoMirror != nil)
+    #expect(AccountTypeEnum.caseDisplayRepresentations[.crypto] != nil)
+  }
+}

--- a/MoolahTests/Domain/AccountsSidebarOrderingTests.swift
+++ b/MoolahTests/Domain/AccountsSidebarOrderingTests.swift
@@ -34,6 +34,22 @@ struct AccountsSidebarOrderingTests {
     #expect(groups.investment.map(\.name) == ["Brokerage"])
   }
 
+  @Test("Crypto wallets land in the investment group (isInvestmentLike)")
+  func cryptoWalletsGroupedAsInvestment() {
+    let chequing = bank("Chequing", position: 0)
+    let brokerage = investment("Brokerage", position: 0)
+    let wallet = Account(
+      id: UUID(), name: "ETH Wallet", type: .crypto, instrument: .AUD,
+      positions: [], position: 1, isHidden: false,
+      walletAddress: "0x" + String(repeating: "a", count: 40), chainId: 1)
+    let accounts = Accounts(from: [brokerage, chequing, wallet])
+
+    let groups = accounts.sidebarGrouped()
+
+    #expect(groups.current.map(\.name) == ["Chequing"])
+    #expect(groups.investment.map(\.name) == ["Brokerage", "ETH Wallet"])
+  }
+
   @Test("Sorts within each group by position ascending")
   func sortsByPosition() {
     let acct1 = bank("A", position: 2)

--- a/MoolahTests/Features/AccountStoreMutationsTests.swift
+++ b/MoolahTests/Features/AccountStoreMutationsTests.swift
@@ -63,6 +63,27 @@ struct AccountStoreMutationsTests {
     #expect(store.investmentAccounts.count == 2)
   }
 
+  @Test("investmentAccounts includes crypto accounts (isInvestmentLike)")
+  func investmentAccountsIncludesCrypto() async throws {
+    // Sidebar feeds its "Investments" section from `investmentAccounts`. A
+    // strict `type == .investment` filter would silently drop newly-created
+    // crypto wallets — the Stage 1 acceptance criterion is to use
+    // `isInvestmentLike` so both kinds appear together.
+    let (backend, database) = try TestBackend.create()
+    _ = AccountStoreTestSupport.seedAccount(
+      name: "Brokerage", type: .investment, balance: 0, in: database)
+    _ = AccountStoreTestSupport.seedAccount(
+      name: "ETH Wallet", type: .crypto,
+      valuationMode: .calculatedFromTrades, in: database)
+    let store = AccountStore(
+      repository: backend.accounts, conversionService: FixedConversionService(),
+      targetInstrument: .defaultTestInstrument)
+
+    await store.load()
+
+    #expect(store.investmentAccounts.map(\.name).sorted() == ["Brokerage", "ETH Wallet"])
+  }
+
   // MARK: - Instrument Persistence
 
   @Test

--- a/MoolahTests/Features/Crypto/CryptoAccountCreationStoreTests.swift
+++ b/MoolahTests/Features/Crypto/CryptoAccountCreationStoreTests.swift
@@ -95,6 +95,11 @@ struct CryptoAccountCreationStoreTests {
     #expect(created.chainId == ChainConfig.ethereum.chainId)
     #expect(created.instrument == ChainConfig.ethereum.nativeInstrument)
     #expect(created.name == "Hardware Wallet")
+    // Crypto wallets compute balance from leg aggregation, so they ship
+    // as `.calculatedFromTrades` from creation. The `Account` default is
+    // `.recordedValue`; without an explicit mode every reader that gates
+    // on `valuationMode` would see the wrong intent.
+    #expect(created.valuationMode == .calculatedFromTrades)
 
     // The store optimistically populates its observable list, so the
     // new account is visible immediately without a reload round-trip.


### PR DESCRIPTION
## Summary
Crypto wallets created on `main` today don't appear in the sidebar — the Stage 1 acceptance criterion of the wallet-import plan ("every site comparing \`account.type == .investment\` is updated to use \`isInvestmentLike\`") was missed in four places.

- **`AccountStore.investmentAccounts`** strict-filtered on `.investment`. This is the property `SidebarView.investmentsSection` iterates and `reorderInvestmentAccounts` mutates, so crypto wallets were silently absent from the sidebar. **User-visible regression.**
- **`Accounts.sidebarGrouped`** worked for crypto only by an `else` fall-through. Made the second branch explicit (`isInvestmentLike`) so a future non-current / non-investment-like type can't silently land in the investment bucket. Used by account pickers, transaction-detail leg defaults, simple/trade transaction-draft helpers.
- **`AccountTypeEnum`** (the App Intents mirror used by Siri / Shortcuts via `ListAccountsIntent`) didn't have `.crypto`, so Shortcuts couldn't filter to crypto wallets. The mirror is a separate enum, so Swift's exhaustiveness check didn't catch the drift.
- **`CryptoAccountCreationLogic.submit`** didn't pass `valuationMode`, so crypto accounts persisted with the `.recordedValue` default. Today every reader gates on `.investment` first so the wrong mode never surfaced — but it was a latent landmine inconsistent with the design (crypto positions emerge from leg aggregation, not snapshots).

## Test plan
- [x] `AccountStoreMutationsTests`: new test asserts `investmentAccounts` includes a `.crypto` account
- [x] `AccountsSidebarOrderingTests`: new test asserts a crypto wallet lands in `groups.investment`
- [x] `CryptoAccountCreationStoreTests`: extended the happy-path test to assert persisted `valuationMode == .calculatedFromTrades`
- [x] new `ListAccountsIntentTypeMirrorTests`: regression guard verifying every `AccountType` has a matching `AccountTypeEnum` case + display representation
- [x] `just format-check` clean
- [x] full mac suite green locally (2448 tests, 397 suites)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)