### PR TITLE
fix(crypto): audit follow-ups — strict Codable, structural test, tighter timer cancellation

### DIFF
--- a/Domain/Models/Account.swift
+++ b/Domain/Models/Account.swift
@@ -91,14 +91,18 @@ extension Account: Codable {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     id = try container.decode(UUID.self, forKey: .id)
     name = try container.decode(String.self, forKey: .name)
-    // Defensive decode for `type`: an older build receiving an Account
-    // record from a newer device (e.g. with `type = "crypto"` before this
-    // build added the case, or any future type after) falls back to
-    // `.asset` rather than throwing — so archive/preview paths don't
-    // break on encountering a future type. The wire-layer mapper applies
-    // the same fallback for sync correctness.
-    let typeRaw = try container.decode(String.self, forKey: .type)
-    type = AccountType(rawValue: typeRaw) ?? .asset
+    // Strict decode for `type`: throws on unknown raw values. The
+    // forward-compat path for an older build encountering a future
+    // `AccountType` is the `Profile.dataFormatVersion` gate
+    // (`Domain/Models/DataFormatVersion.swift`) — a newer client must
+    // bump that field before writing records that use the new type, so
+    // an older build refuses to open the profile rather than silently
+    // misclassifying records. The wire-layer apply path
+    // (`AccountRow.safeAccountTypeRaw`) keeps a `"asset"` fallback to
+    // unblock GRDB persistence between record-arrival ordering, but
+    // the in-memory domain decode (used by tests, exports, archives)
+    // is strict.
+    type = try container.decode(AccountType.self, forKey: .type)
     instrument = try container.decodeIfPresent(Instrument.self, forKey: .instrument) ?? .AUD
     // positions are not persisted via Codable — they are computed by the
     // repository layer from transaction legs and injected at fetch time.

--- a/Features/Crypto/CryptoSyncStore+Internals.swift
+++ b/Features/Crypto/CryptoSyncStore+Internals.swift
@@ -220,22 +220,19 @@ extension CryptoSyncStore {
   }
 
   /// Hourly stale-check loop. Foreground only — entry/exit is gated by
-  /// `handleScenePhaseChange`. The loop checks `Task.isCancelled`
-  /// immediately after every `Task.sleep` suspension and before
-  /// dispatching the next sync, so a cancelled task exits without
-  /// writing state.
+  /// `handleScenePhaseChange`. `Task.sleep` itself throws on cancellation;
+  /// the explicit `Task.checkCancellation()` between sleep and dispatch
+  /// catches a late cancellation that arrives in the gap so a cancelled
+  /// task exits without leaking a fetch.
   func runTimerLoop() async {
     while !Task.isCancelled {
       do {
         try await Task.sleep(for: timerInterval)
-      } catch is CancellationError {
-        return
+        try Task.checkCancellation()
       } catch {
         return
       }
-      if Task.isCancelled { return }
       await syncStaleAccounts()
-      if Task.isCancelled { return }
     }
   }
 

--- a/MoolahTests/Domain/AccountTests.swift
+++ b/MoolahTests/Domain/AccountTests.swift
@@ -52,4 +52,20 @@ struct AccountTests {
     #expect(decoded.walletAddress == nil)
     #expect(decoded.chainId == nil)
   }
+
+  @Test
+  func unknownAccountTypeIsRejectedByCodable() {
+    // Forward-compat is the `Profile.dataFormatVersion` gate's job — a
+    // newer client must bump the gate before writing records that use a
+    // future `AccountType`. The in-memory `Account.Codable` decode is
+    // strict and throws on unknown values rather than silently
+    // misclassifying them as `.asset`.
+    let json = Data(
+      """
+      {"id":"\(UUID().uuidString)","name":"Future","type":"future-type","instrument":{"id":"AUD","kind":"fiatCurrency","name":"AUD","decimals":2},"position":0,"hidden":false}
+      """.utf8)
+    #expect(throws: DecodingError.self) {
+      _ = try JSONDecoder().decode(Account.self, from: json)
+    }
+  }
 }

--- a/MoolahTests/Features/Crypto/CryptoSyncPipelineStructureTests.swift
+++ b/MoolahTests/Features/Crypto/CryptoSyncPipelineStructureTests.swift
@@ -1,0 +1,173 @@
+// MoolahTests/Features/Crypto/CryptoSyncPipelineStructureTests.swift
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+/// Asserts the *structural* property of the wallet-sync pipeline that
+/// `CrossAccountTransferMergerTests` only checks indirectly via merged
+/// outcomes: the cross-account merger runs **exactly once** per sync,
+/// **after** the parallel build TaskGroup has completed, with the
+/// **union** of every participating account's candidates.
+///
+/// If a future refactor moved the apply pass inside the per-account
+/// TaskGroup (one merger call per account, each with partial input),
+/// `CrossAccountTransferMergerTests`'s outcome assertions would still
+/// pass for unmergeable inputs and only fail probabilistically on the
+/// mergeable cases. This test makes the structural contract explicit
+/// using a recording merger that captures every invocation.
+@Suite("CryptoSyncStore — pipeline structure")
+@MainActor
+struct CryptoSyncPipelineStructureTests {
+  nonisolated static let pinnedNow = Date(timeIntervalSince1970: 1_700_000_000)
+  static let counterparty = "0x9999999999999999999999999999999999999999"
+
+  private struct Fixture {
+    let store: CryptoSyncStore
+    let backend: CloudKitBackend
+    let database: DatabaseQueue
+    let alchemy: RecordingAlchemyClientStub
+    let merger: RecordingCrossAccountTransferMerger
+  }
+
+  private func makeFixture() throws -> Fixture {
+    let (backend, database) = try TestBackend.create()
+    let alchemy = RecordingAlchemyClientStub()
+    let registry = GRDBInstrumentRegistryRepository(database: database)
+    let discovery = CryptoTokenDiscoveryService(
+      registry: registry,
+      resolver: CountingRegistrationResolver(),
+      alchemy: alchemy)
+    let walletSyncEngine = WalletSyncEngine(
+      alchemy: alchemy,
+      discovery: discovery,
+      walletSyncState: backend.walletSyncState,
+      importOriginFactory: { accountId in
+        ImportOrigin(
+          rawDescription: "wallet:\(accountId.uuidString)",
+          rawAmount: 0,
+          importedAt: Self.pinnedNow,
+          importSessionId: UUID(),
+          parserIdentifier: "alchemy-wallet-sync")
+      })
+    let merger = RecordingCrossAccountTransferMerger()
+    let walletApplyEngine = WalletApplyEngine(
+      transactions: backend.transactions,
+      walletSyncState: backend.walletSyncState,
+      importRules: NoOpWalletImportRulesEngine(),
+      merger: merger,
+      clock: { Self.pinnedNow })
+    let store = CryptoSyncStore(
+      walletSyncEngine: walletSyncEngine,
+      walletApplyEngine: walletApplyEngine,
+      walletSyncState: backend.walletSyncState,
+      accounts: backend.accounts,
+      clock: { Self.pinnedNow },
+      staleThreshold: 86_400,
+      timerInterval: .seconds(3_600),
+      maxConcurrentBuilds: 4)
+    return Fixture(
+      store: store, backend: backend, database: database, alchemy: alchemy, merger: merger)
+  }
+
+  @Test("Merger is called exactly once with the union of every account's candidates")
+  func mergerSeesUnionAfterParallelBuilds() async throws {
+    let fixture = try makeFixture()
+    // Two distinct wallets; each receives one inbound transfer with its
+    // own hash so both per-account builds produce a candidate without
+    // pairing into a merged transaction (we're testing the *call shape*,
+    // not the merge outcome).
+    let walletA = "0x1111111111111111111111111111111111111111"
+    let walletB = "0x2222222222222222222222222222222222222222"
+    let accountA = seedCryptoAccount(in: fixture.database, walletAddress: walletA)
+    let accountB = seedCryptoAccount(in: fixture.database, walletAddress: walletB)
+    fixture.alchemy.setTransfersResponse(
+      .transfers([
+        makeAlchemyTransfer(
+          hash: "0xa", from: Self.counterparty, to: walletA, category: .external)
+      ]),
+      for: walletA)
+    fixture.alchemy.setTransfersResponse(
+      .transfers([
+        makeAlchemyTransfer(
+          hash: "0xb", from: Self.counterparty, to: walletB, category: .external)
+      ]),
+      for: walletB)
+    try await fixture.backend.walletSyncState.save(
+      WalletSyncState(
+        id: accountA.id, lastSyncedBlockNumber: 0, lastSyncedAt: .distantPast, lastError: nil))
+    try await fixture.backend.walletSyncState.save(
+      WalletSyncState(
+        id: accountB.id, lastSyncedBlockNumber: 0, lastSyncedAt: .distantPast, lastError: nil))
+    await fixture.store.loadInitialState()
+
+    await fixture.store.syncStaleAccounts()
+
+    let invocations = fixture.merger.invocations
+    #expect(invocations.count == 1)
+    let invocation = try #require(invocations.first)
+    let originIds = Set(invocation.candidates.map(\.originAccountId))
+    #expect(originIds == Set([accountA.id, accountB.id]))
+  }
+
+  @Test("Throttling one build doesn't split the merger call into two")
+  func throttledBuildStillProducesSingleMergerCall() async throws {
+    let fixture = try makeFixture()
+    let walletA = "0x3333333333333333333333333333333333333333"
+    let walletB = "0x4444444444444444444444444444444444444444"
+    let accountA = seedCryptoAccount(in: fixture.database, walletAddress: walletA)
+    let accountB = seedCryptoAccount(in: fixture.database, walletAddress: walletB)
+    fixture.alchemy.setTransfersResponse(
+      .transfers([
+        makeAlchemyTransfer(
+          hash: "0xc", from: Self.counterparty, to: walletA, category: .external)
+      ]),
+      for: walletA)
+    fixture.alchemy.setTransfersResponse(
+      .transfers([
+        makeAlchemyTransfer(
+          hash: "0xd", from: Self.counterparty, to: walletB, category: .external)
+      ]),
+      for: walletB)
+    // Delay every Alchemy fetch a touch so the two per-account builds
+    // genuinely interleave on the TaskGroup. The structural guarantee is
+    // independent of completion order — the apply pass must not run
+    // until both have returned regardless.
+    fixture.alchemy.setBeforeAssetTransfers {
+      try? await Task.sleep(for: .milliseconds(20))
+    }
+    try await fixture.backend.walletSyncState.save(
+      WalletSyncState(
+        id: accountA.id, lastSyncedBlockNumber: 0, lastSyncedAt: .distantPast, lastError: nil))
+    try await fixture.backend.walletSyncState.save(
+      WalletSyncState(
+        id: accountB.id, lastSyncedBlockNumber: 0, lastSyncedAt: .distantPast, lastError: nil))
+    await fixture.store.loadInitialState()
+
+    await fixture.store.syncStaleAccounts()
+
+    let invocations = fixture.merger.invocations
+    #expect(invocations.count == 1)
+    let invocation = try #require(invocations.first)
+    let originIds = Set(invocation.candidates.map(\.originAccountId))
+    #expect(originIds == Set([accountA.id, accountB.id]))
+  }
+
+  /// Seeds a crypto account directly into GRDB.
+  private func seedCryptoAccount(
+    in database: DatabaseQueue,
+    walletAddress: String,
+    chain: ChainConfig = .ethereum
+  ) -> Account {
+    let account = Account(
+      name: "Wallet \(walletAddress.suffix(4))",
+      type: .crypto,
+      instrument: chain.nativeInstrument,
+      valuationMode: .calculatedFromTrades,
+      walletAddress: walletAddress.lowercased(),
+      chainId: chain.chainId)
+    _ = TestBackend.seed(accounts: [account], in: database)
+    return account
+  }
+}

--- a/MoolahTests/Shared/CryptoImport/CrossAccountTransferMergerTests.swift
+++ b/MoolahTests/Shared/CryptoImport/CrossAccountTransferMergerTests.swift
@@ -39,7 +39,7 @@ struct CrossAccountTransferMergerTests {
       quantity: 1,
       date: Self.dateB)
 
-    let merged = try await CrossAccountTransferMerger().merge(
+    let merged = try await LiveCrossAccountTransferMerger().merge(
       candidates: [outbound, inbound],
       existingLegLookup: { _ in [] })
 
@@ -61,7 +61,7 @@ struct CrossAccountTransferMergerTests {
       accountId: Self.accountB, hash: Self.hash,
       instrument: TestInstruments.ethereum, quantity: 1)
 
-    let merged = try await CrossAccountTransferMerger().merge(
+    let merged = try await LiveCrossAccountTransferMerger().merge(
       candidates: [firstInbound, secondInbound],
       existingLegLookup: { _ in [] })
 
@@ -77,7 +77,7 @@ struct CrossAccountTransferMergerTests {
       accountId: Self.accountB, hash: Self.hash,
       instrument: TestInstruments.polygon, quantity: 1)
 
-    let merged = try await CrossAccountTransferMerger().merge(
+    let merged = try await LiveCrossAccountTransferMerger().merge(
       candidates: [outbound, inbound],
       existingLegLookup: { _ in [] })
 
@@ -93,7 +93,7 @@ struct CrossAccountTransferMergerTests {
       accountId: Self.accountA, hash: Self.hash,
       instrument: TestInstruments.ethereum, quantity: 1)
 
-    let merged = try await CrossAccountTransferMerger().merge(
+    let merged = try await LiveCrossAccountTransferMerger().merge(
       candidates: [outbound, inbound],
       existingLegLookup: { _ in [] })
 
@@ -129,7 +129,7 @@ struct CrossAccountTransferMergerTests {
       instrument: gasInstrument, quantity: 1,
       extraLegs: [inboundFee])
 
-    let merged = try await CrossAccountTransferMerger().merge(
+    let merged = try await LiveCrossAccountTransferMerger().merge(
       candidates: [outbound, inbound],
       existingLegLookup: { _ in [] })
 
@@ -154,7 +154,7 @@ struct CrossAccountTransferMergerTests {
       accountId: Self.accountB, hash: Self.hash,
       instrument: TestInstruments.ethereum, quantity: 1)
 
-    let merged = try await CrossAccountTransferMerger().merge(
+    let merged = try await LiveCrossAccountTransferMerger().merge(
       candidates: [inbound],
       existingLegLookup: { externalId in
         externalId == Self.hash ? [priorCycleLeg] : []
@@ -182,7 +182,7 @@ struct CrossAccountTransferMergerTests {
       accountId: Self.accountA, hash: Self.hash,
       instrument: TestInstruments.ethereum, quantity: 1, date: Self.dateA)
 
-    let merged = try await CrossAccountTransferMerger().merge(
+    let merged = try await LiveCrossAccountTransferMerger().merge(
       candidates: [outbound, inbound],
       existingLegLookup: { _ in [] })
 
@@ -199,7 +199,7 @@ struct CrossAccountTransferMergerTests {
       accountId: Self.accountB, hash: Self.hash,
       instrument: TestInstruments.ethereum, quantity: 1, date: Self.dateA)
 
-    let merged = try await CrossAccountTransferMerger().merge(
+    let merged = try await LiveCrossAccountTransferMerger().merge(
       candidates: [outbound, inbound],
       existingLegLookup: { _ in [] })
 

--- a/MoolahTests/Shared/CryptoImport/WalletSyncTestDoubles.swift
+++ b/MoolahTests/Shared/CryptoImport/WalletSyncTestDoubles.swift
@@ -287,3 +287,39 @@ func makeCryptoAccount(
     walletAddress: walletAddress.lowercased(),
     chainId: chain.chainId)
 }
+
+/// Records every `merge(...)` invocation and delegates to a live merger
+/// so the produced output is real. Used by the structural test that
+/// asserts the apply pass calls the merger exactly once after the
+/// parallel build TaskGroup completes — i.e. with the union of every
+/// participating account's candidates, not once-per-account with
+/// partial input.
+final class RecordingCrossAccountTransferMerger:
+  CrossAccountTransferMerger, @unchecked Sendable
+{
+  struct Invocation: Sendable {
+    let candidates: [BuiltTransaction]
+  }
+
+  private let lock = NSLock()
+  private var invocationsBacking: [Invocation] = []
+  private let inner: any CrossAccountTransferMerger
+
+  init(delegateTo inner: any CrossAccountTransferMerger = LiveCrossAccountTransferMerger()) {
+    self.inner = inner
+  }
+
+  var invocations: [Invocation] {
+    lock.withLock { invocationsBacking }
+  }
+
+  func merge(
+    candidates: [BuiltTransaction],
+    existingLegLookup: @Sendable (_ externalId: String) async throws -> [TransactionLeg]
+  ) async throws -> [BuiltTransaction] {
+    lock.withLock {
+      invocationsBacking.append(Invocation(candidates: candidates))
+    }
+    return try await inner.merge(candidates: candidates, existingLegLookup: existingLegLookup)
+  }
+}

--- a/Shared/CryptoImport/CrossAccountTransferMerger.swift
+++ b/Shared/CryptoImport/CrossAccountTransferMerger.swift
@@ -8,13 +8,12 @@ import os
 /// after Stage 6's parallel build TaskGroup has fully completed — no
 /// concurrent path can produce duplicate merged transactions.
 ///
-/// Pure / `Sendable` — no repository writes; no shared state. The single
-/// source of truth for the same-`externalId` channel from
-/// `plans/2026-04-18-transfer-detection-design.md` (Extension B): when
-/// the transfer-detection engine eventually runs, it shares this same
-/// merger rather than reimplementing the predicate.
-struct CrossAccountTransferMerger: Sendable {
-
+/// The protocol exists so tests can substitute a recording wrapper that
+/// asserts the merger ran exactly once with both accounts' candidates,
+/// proving the structural property (apply runs after parallel-build
+/// TaskGroup completion) rather than just the merged-shape outcome. v1
+/// ships `LiveCrossAccountTransferMerger` plus per-test recorders.
+protocol CrossAccountTransferMerger: Sendable {
   /// Returns the input set with same-`externalId` opposing-leg pairs
   /// collapsed into single multi-leg transactions whose legs union both
   /// sides. Gas / fee legs preserved on the merged transaction. Pairs
@@ -27,6 +26,19 @@ struct CrossAccountTransferMerger: Sendable {
   ///     can also pair against legs already persisted on prior cycles.
   ///     The lookup key is the leg's `externalId`. Callers in production
   ///     route this through `TransactionRepository.legs(matchingExternalId:)`.
+  func merge(
+    candidates: [BuiltTransaction],
+    existingLegLookup: @Sendable (_ externalId: String) async throws -> [TransactionLeg]
+  ) async throws -> [BuiltTransaction]
+}
+
+/// Live cross-account merger. Pure / `Sendable` — no repository writes;
+/// no shared state. The single source of truth for the same-`externalId`
+/// channel from `plans/2026-04-18-transfer-detection-design.md`
+/// (Extension B): when the transfer-detection engine eventually runs, it
+/// shares this same merger rather than reimplementing the predicate.
+struct LiveCrossAccountTransferMerger: CrossAccountTransferMerger {
+
   func merge(
     candidates: [BuiltTransaction],
     existingLegLookup: @Sendable (_ externalId: String) async throws -> [TransactionLeg]

--- a/Shared/CryptoImport/WalletApplyEngine.swift
+++ b/Shared/CryptoImport/WalletApplyEngine.swift
@@ -30,14 +30,14 @@ final class WalletApplyEngine {
   private let transactions: any TransactionRepository
   private let walletSyncState: any WalletSyncStateRepository
   private let importRules: any WalletImportRulesEngine
-  private let merger: CrossAccountTransferMerger
+  private let merger: any CrossAccountTransferMerger
   private let clock: @Sendable () -> Date
 
   init(
     transactions: any TransactionRepository,
     walletSyncState: any WalletSyncStateRepository,
     importRules: any WalletImportRulesEngine,
-    merger: CrossAccountTransferMerger = CrossAccountTransferMerger(),
+    merger: any CrossAccountTransferMerger = LiveCrossAccountTransferMerger(),
     clock: @Sendable @escaping () -> Date = { Date() }
   ) {
     self.transactions = transactions


### PR DESCRIPTION
Three loose ends from the wallet-import audit, bundled into one PR.

## 1. Stage 1 — drop the silent `.asset` fallback in `Account.Codable`
The original design called for a `?? .asset` fallback so an older build wouldn't crash on a future `AccountType`. The `Profile.dataFormatVersion` gate (landed later) is the right mechanism for that — a newer client bumps the gate before writing records that use new types, and the older build refuses to open the profile rather than silently misclassifying records.

- `Account.Codable.init(from:)` now decodes `type` strictly and throws on unknown raw values.
- The wire-layer apply path (`AccountRow.safeAccountTypeRaw`) keeps a `"asset"` fallback to avoid blocking GRDB persistence between Account-record arrival and Profile-record arrival in the same sync batch — that's a record-ordering safety net, separate from the in-memory domain decode.
- New test `unknownAccountTypeIsRejectedByCodable` asserts the throw.

## 2. Stage 7 — structural test for the cross-account merger
`CrossAccountTransferMergerTests` covers the merge outcome; the structural property (merger runs exactly once, after the parallel build TaskGroup completes, with the union of every account's candidates) was unverified. A future refactor that moved apply inside the per-account TaskGroup would slip past those tests on unmergeable inputs.

- Extracted `protocol CrossAccountTransferMerger` and renamed the concrete type to `LiveCrossAccountTransferMerger` (matches `AlchemyClient` / `LiveAlchemyClient`).
- Added `RecordingCrossAccountTransferMerger` test double recording every invocation.
- New `CryptoSyncPipelineStructureTests` drives `CryptoSyncStore.syncStaleAccounts` with two accounts and asserts the recorder shows one invocation containing both accounts' `originAccountId`s. Includes a throttled-build variant that interleaves the two builds and confirms ordering doesn't change the call shape.

## 3. Stage 9 — tighter `runTimerLoop` cancellation
The design specified `Task.checkCancellation()` between sleep and dispatch; the loop was using two post-sleep / post-dispatch `if Task.isCancelled { return }` checks which had the same effect but were noisier. Replaced with one `try Task.checkCancellation()` between sleep and dispatch; the next iteration's top-of-loop `while !Task.isCancelled` covers the post-dispatch case. Outcome unchanged; the existing "Timer cancellation honoured" test still passes.

## Test plan
- [x] `just format-check` clean
- [x] full mac suite green locally (2450+ tests)
- [x] new `CryptoSyncPipelineStructureTests` covers both `mergerSeesUnionAfterParallelBuilds` and the throttled-build variant
- [x] new `unknownAccountTypeIsRejectedByCodable` asserts strict decode
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)