### PR TITLE
fix(crypto): resolve Alchemy API key per-request via closure provider

### DIFF
--- a/App/ProfileSession+CryptoSync.swift
+++ b/App/ProfileSession+CryptoSync.swift
@@ -9,7 +9,13 @@ extension ProfileSession {
   /// strings match `plans/2026-05-05-crypto-wallet-import-design.md`
   /// §"API key management" so the eventual write side targets the same
   /// keychain entry.
-  static func resolveAlchemyApiKey() -> String? {
+  ///
+  /// `nonisolated` so it can be called from the `@Sendable` closure that
+  /// `LiveAlchemyClient` uses to resolve the key per-request — the work
+  /// itself is just a synchronous Keychain read, so it doesn't need
+  /// `@MainActor` isolation that the surrounding `ProfileSession`
+  /// extension inherits.
+  nonisolated static func resolveAlchemyApiKey() -> String? {
     let store = KeychainStore(
       service: "com.moolah.api-keys", account: "alchemy", synchronizable: true)
     return try? store.restoreString()
@@ -57,9 +63,14 @@ extension ProfileSession {
     guard let registry else { return nil }
 
     let rateLimiter = RateLimiter(permitsPerSecond: 25)
-    let apiKey = resolveAlchemyApiKey() ?? ""
+    // Pass a closure rather than a resolved value so a key added in the
+    // settings UI *after* this wiring is built is visible on the next
+    // sync cycle, and so the key is never retained on the client itself
+    // — it lives only on the local stack frame of each in-flight
+    // request.
     let alchemy: any AlchemyClient = LiveAlchemyClient(
-      apiKey: apiKey, rateLimiter: rateLimiter)
+      apiKeyProvider: { ProfileSession.resolveAlchemyApiKey() },
+      rateLimiter: rateLimiter)
     let discovery = CryptoTokenDiscoveryService(
       registry: registry, resolver: cryptoPriceService, alchemy: alchemy)
     let importOriginFactory: @Sendable (UUID) -> ImportOrigin = { accountId in

--- a/MoolahTests/Shared/CryptoImport/AlchemyTestSupport.swift
+++ b/MoolahTests/Shared/CryptoImport/AlchemyTestSupport.swift
@@ -18,6 +18,20 @@ enum AlchemyTestSupport {
     permitsPerSecond: Double = 1_000,
     handler: @escaping @Sendable (URLRequest) throws -> (HTTPURLResponse, Data)
   ) -> LiveAlchemyClient {
+    makeClient(
+      apiKeyProvider: { apiKey },
+      permitsPerSecond: permitsPerSecond,
+      handler: handler)
+  }
+
+  /// Variant that takes a `@Sendable` closure provider so tests can mutate
+  /// the returned key between calls (covering the key-set-after-launch
+  /// case where `LiveAlchemyClient` was previously stale).
+  static func makeClient(
+    apiKeyProvider: @escaping @Sendable () -> String?,
+    permitsPerSecond: Double = 1_000,
+    handler: @escaping @Sendable (URLRequest) throws -> (HTTPURLResponse, Data)
+  ) -> LiveAlchemyClient {
     let config = URLSessionConfiguration.ephemeral
     config.protocolClasses = [AlchemyURLProtocolStub.self]
     let session = URLSession(configuration: config)
@@ -25,7 +39,8 @@ enum AlchemyTestSupport {
     AlchemyURLProtocolStub.lastBodyJSON = [:]
     AlchemyURLProtocolStub.requestHandler = handler
     let limiter = RateLimiter(permitsPerSecond: permitsPerSecond)
-    return LiveAlchemyClient(session: session, apiKey: apiKey, rateLimiter: limiter)
+    return LiveAlchemyClient(
+      session: session, apiKeyProvider: apiKeyProvider, rateLimiter: limiter)
   }
 
   /// Build a 200 OK JSON response for the URL of an inbound request. The

--- a/MoolahTests/Shared/CryptoImport/LiveAlchemyClientKeyProviderTests.swift
+++ b/MoolahTests/Shared/CryptoImport/LiveAlchemyClientKeyProviderTests.swift
@@ -1,0 +1,133 @@
+// MoolahTests/Shared/CryptoImport/LiveAlchemyClientKeyProviderTests.swift
+import Foundation
+import Testing
+
+@testable import Moolah
+
+/// Pins the contract that `LiveAlchemyClient` resolves its API key from
+/// the injected closure on **every** request — never from a value
+/// captured at construction. Two properties both ride on this:
+///
+/// 1. **Freshness**: a key added in settings *after* the client was
+///    constructed becomes visible on the very next call. (Prior to
+///    Bug 5's fix, the client stored the key as a `let` field, so a
+///    user who added a valid key after launch still saw Sync now
+///    fail with HTTP 401 against the stale empty-string key.)
+/// 2. **Memory residency**: the resolved key only exists on the local
+///    stack frame of the in-flight request. The client deliberately
+///    has no instance-level field that could outlive the call. The
+///    `.missingApiKey` short-circuit happens before any network or
+///    URL-construction work, so an unset key is never even composed
+///    into a URL.
+///
+/// The tests assert (1) directly with a mutable provider; (2) is
+/// enforced structurally by the implementation and reviewed at PR
+/// time — there's nothing to assert about object lifetimes, but the
+/// freshness test catches any future regression that re-introduces
+/// instance-level caching.
+@Suite("LiveAlchemyClient — key provider freshness")
+struct LiveAlchemyClientKeyProviderTests {
+  @Test("Key added after construction is visible on the next call")
+  func keyAddedAfterConstructionVisibleOnNextCall() async throws {
+    let key = MutableKey()
+    let recorder = RequestURLRecorder()
+    let client = AlchemyTestSupport.makeClient(
+      apiKeyProvider: { key.value },
+      handler: { request in
+        recorder.record(request.url?.absoluteString ?? "")
+        let payload = #"{"jsonrpc":"2.0","id":1,"result":{"transfers":[]}}"#
+        return (
+          AlchemyTestSupport.okResponse(for: request),
+          Data(payload.utf8)
+        )
+      })
+    // Initial state: provider returns nil → first call short-circuits
+    // with `.missingApiKey` before any network work.
+    await #expect(throws: WalletSyncError.missingApiKey) {
+      _ = try await client.getAssetTransfers(
+        chain: .ethereum, walletAddress: "0xabc", fromBlock: 0)
+    }
+    #expect(recorder.urls.isEmpty, "Pre-flight should not touch the network")
+
+    // User adds a key in settings — provider now returns it. The next
+    // call must succeed without rebuilding the client.
+    key.set("freshly-added-key")
+    let transfers = try await client.getAssetTransfers(
+      chain: .ethereum, walletAddress: "0xabc", fromBlock: 0)
+    #expect(transfers.isEmpty)
+
+    // The request URL embedded the newly-resolved key — proves the
+    // provider was consulted on this call, not a captured stale value.
+    #expect(recorder.urls.allSatisfy { $0.contains("freshly-added-key") })
+    #expect(!recorder.urls.isEmpty)
+  }
+
+  @Test("Key removed after a successful call short-circuits the next one")
+  func keyRemovedAfterSuccessShortCircuitsNextCall() async throws {
+    let key = MutableKey(initial: "initially-valid")
+    let client = AlchemyTestSupport.makeClient(
+      apiKeyProvider: { key.value },
+      handler: { request in
+        let payload = #"{"jsonrpc":"2.0","id":1,"result":{"transfers":[]}}"#
+        return (
+          AlchemyTestSupport.okResponse(for: request),
+          Data(payload.utf8)
+        )
+      })
+    _ = try await client.getAssetTransfers(
+      chain: .ethereum, walletAddress: "0xabc", fromBlock: 0)
+
+    // Simulate a settings flow that clears the keychain.
+    key.set(nil)
+    await #expect(throws: WalletSyncError.missingApiKey) {
+      _ = try await client.getAssetTransfers(
+        chain: .ethereum, walletAddress: "0xabc", fromBlock: 0)
+    }
+  }
+}
+
+/// Lock-protected mutable container for the test's "key changes
+/// mid-session" scenario. The closure passed to `LiveAlchemyClient` must
+/// be `@Sendable`, so plain `var` capture won't compile under strict
+/// concurrency. Matches the lock-then-read pattern used by other
+/// recording test doubles in this directory.
+private final class MutableKey: @unchecked Sendable {
+  private let lock = NSLock()
+  private var stored: String?
+
+  init(initial: String? = nil) { self.stored = initial }
+
+  var value: String? {
+    lock.lock()
+    defer { lock.unlock() }
+    return stored
+  }
+
+  func set(_ newValue: String?) {
+    lock.lock()
+    defer { lock.unlock() }
+    stored = newValue
+  }
+}
+
+/// Lock-protected URL recorder for the freshness assertion. Avoids the
+/// shared `AlchemyURLProtocolStub.lastRequest` static (which only
+/// captures when handlers explicitly call `captureRequest`) and gives
+/// the test a deterministic, ordered list of URLs the request handler
+/// saw.
+private final class RequestURLRecorder: @unchecked Sendable {
+  private let lock = NSLock()
+  private var urlsBacking: [String] = []
+
+  func record(_ url: String) {
+    lock.lock()
+    defer { lock.unlock() }
+    urlsBacking.append(url)
+  }
+
+  var urls: [String] {
+    lock.lock()
+    defer { lock.unlock() }
+    return urlsBacking
+  }
+}

--- a/Shared/CryptoImport/AlchemyClient.swift
+++ b/Shared/CryptoImport/AlchemyClient.swift
@@ -78,23 +78,32 @@ extension AlchemyTokenMetadata {
 /// addresses → `.private`; the API key is never logged.
 struct LiveAlchemyClient: AlchemyClient {
   private let session: URLSession
-  private let apiKey: String
+  /// Closure that yields the current Alchemy API key, or `nil` when the
+  /// keychain has none. Resolved per-request inside each public method
+  /// so a key added in settings *after* the client was constructed is
+  /// visible on the next call, and so the client never retains the key
+  /// in an instance-level field. The resolved key only lives in the
+  /// local stack frame of the in-flight request.
+  private let apiKeyProvider: @Sendable () -> String?
   private let rateLimiter: RateLimiter
   private let logger: Logger
 
   /// - Parameters:
   ///   - session: `URLSession` for HTTP requests. Default is `.shared`;
   ///     tests inject an ephemeral session backed by `URLProtocol`.
-  ///   - apiKey: Alchemy API key. Never logged.
+  ///   - apiKeyProvider: Closure invoked at the start of every network
+  ///     method. Reads the keychain on each call so a freshly-added key
+  ///     is visible without rebuilding the client; never caches the
+  ///     value on the struct. Never logged.
   ///   - rateLimiter: Shared `RateLimiter` actor — caller is responsible
   ///     for sizing it to the Alchemy plan in use (25 req/s on free tier).
   init(
     session: URLSession = .shared,
-    apiKey: String,
+    apiKeyProvider: @escaping @Sendable () -> String?,
     rateLimiter: RateLimiter
   ) {
     self.session = session
-    self.apiKey = apiKey
+    self.apiKeyProvider = apiKeyProvider
     self.rateLimiter = rateLimiter
     self.logger = Logger(subsystem: "com.moolah.app", category: "AlchemyClient")
   }
@@ -104,7 +113,7 @@ struct LiveAlchemyClient: AlchemyClient {
     walletAddress: String,
     fromBlock: UInt64
   ) async throws -> [AlchemyTransfer] {
-    try requireApiKey()
+    let apiKey = try resolveApiKey()
     let signpostID = OSSignpostID(log: Signposts.cryptoSync)
     os_signpost(
       .begin,
@@ -126,7 +135,8 @@ struct LiveAlchemyClient: AlchemyClient {
         chain: chain,
         address: walletAddress,
         isFromAddress: true,
-        fromBlock: fromBlock
+        fromBlock: fromBlock,
+        apiKey: apiKey
       )
     )
     transfers.append(
@@ -134,7 +144,8 @@ struct LiveAlchemyClient: AlchemyClient {
         chain: chain,
         address: walletAddress,
         isFromAddress: false,
-        fromBlock: fromBlock
+        fromBlock: fromBlock,
+        apiKey: apiKey
       )
     )
     return transfers
@@ -144,13 +155,13 @@ struct LiveAlchemyClient: AlchemyClient {
     chain: ChainConfig,
     contractAddress: String
   ) async throws -> AlchemyTokenMetadata {
-    try requireApiKey()
+    let apiKey = try resolveApiKey()
     try await rateLimiter.acquire()
     let body = AlchemyJSONRPCRequest<AlchemyJSONRPCParams>(
       method: "alchemy_getTokenMetadata",
       params: .tokenMetadata(contractAddress: contractAddress)
     )
-    let request = try buildRequest(chain: chain, body: body)
+    let request = try buildRequest(chain: chain, body: body, apiKey: apiKey)
     logger.debug(
       "Alchemy token metadata: chain \(chain.chainId, privacy: .public) contract \(contractAddress, privacy: .private)"
     )
@@ -173,7 +184,7 @@ struct LiveAlchemyClient: AlchemyClient {
     chain: ChainConfig,
     hash: String
   ) async throws -> AlchemyTransactionReceipt {
-    try requireApiKey()
+    let apiKey = try resolveApiKey()
     let signpostID = OSSignpostID(log: Signposts.cryptoSync)
     os_signpost(
       .begin,
@@ -194,7 +205,7 @@ struct LiveAlchemyClient: AlchemyClient {
       method: "eth_getTransactionReceipt",
       params: .transactionReceipt(hash: hash)
     )
-    let request = try buildRequest(chain: chain, body: body)
+    let request = try buildRequest(chain: chain, body: body, apiKey: apiKey)
     // Hash is `.private` in logs — pairing a tx hash with the device
     // identifies wallet activity even though the chain itself is public.
     logger.debug(
@@ -228,24 +239,30 @@ struct LiveAlchemyClient: AlchemyClient {
 
   // MARK: - Internals
 
-  /// Pre-flight guard for every public method. The wiring at
-  /// `ProfileSession.makeCryptoSyncWiring` resolves the keychain key
-  /// best-effort and falls back to an empty string when nothing is
-  /// configured; without this guard the empty key would slot into the
-  /// URL path (`…/v2/`), Alchemy would respond 401, and the validator
-  /// would mis-classify the failure as `.invalidApiKey`. Surfacing
-  /// `.missingApiKey` here keeps the wiring's "construct unconditionally"
-  /// pattern intact while telling the user the truth — the key is
-  /// missing, not invalid — without a network round-trip.
-  private func requireApiKey() throws {
-    guard !apiKey.isEmpty else { throw WalletSyncError.missingApiKey }
+  /// Resolves the current API key from the closure provider and rejects
+  /// missing / empty values with `.missingApiKey`. Called at the top of
+  /// every public method; the returned string is held only on the local
+  /// stack frame and passed down to `fetchTransfers` / `buildRequest`.
+  /// The client never stores the resolved value on `self`.
+  ///
+  /// The wiring at `ProfileSession.makeCryptoSyncWiring` reads the
+  /// keychain on each call (rather than at construction) so a key added
+  /// in settings *after* the client was built is visible on the next
+  /// request. Without this freshness guarantee the user sees Sync now
+  /// 401 with a stale empty-string key even after configuring a valid
+  /// one.
+  private func resolveApiKey() throws -> String {
+    let key = apiKeyProvider() ?? ""
+    guard !key.isEmpty else { throw WalletSyncError.missingApiKey }
+    return key
   }
 
   private func fetchTransfers(
     chain: ChainConfig,
     address: String,
     isFromAddress: Bool,
-    fromBlock: UInt64
+    fromBlock: UInt64,
+    apiKey: String
   ) async throws -> [AlchemyTransfer] {
     try await rateLimiter.acquire()
 
@@ -267,7 +284,7 @@ struct LiveAlchemyClient: AlchemyClient {
         )
       )
     )
-    let request = try buildRequest(chain: chain, body: body)
+    let request = try buildRequest(chain: chain, body: body, apiKey: apiKey)
     logger.debug(
       """
       Alchemy getAssetTransfers: chain \(chain.chainId, privacy: .public) \
@@ -308,7 +325,8 @@ struct LiveAlchemyClient: AlchemyClient {
 
   private func buildRequest<Params: Encodable>(
     chain: ChainConfig,
-    body: AlchemyJSONRPCRequest<Params>
+    body: AlchemyJSONRPCRequest<Params>,
+    apiKey: String
   ) throws -> URLRequest {
     let urlString = "https://\(chain.alchemyNetworkSlug).g.alchemy.com/v2/\(apiKey)"
     guard let url = URL(string: urlString) else {


### PR DESCRIPTION
**Stacked on top of #787.** Base will auto-update to `main` when #787 lands.

A user who added a valid Alchemy key in settings *after* app launch still saw Sync now fail with HTTP 401 — even with #787's pre-flight \`.missingApiKey\` guard merged. The in-memory \`LiveAlchemyClient\` struct captured \`apiKey: String\` at construction time, so a key set after the wiring was built was invisible — the URL still embedded the empty string and Alchemy rejected it.

Two related fixes, layered on top of #787's pre-flight guard:

## 1. Freshness — closure provider replaces captured field
Replace \`private let apiKey: String\` with \`private let apiKeyProvider: @Sendable () -> String?\`. Resolve the value at the start of every public method (\`getAssetTransfers\`, \`getTokenMetadata\`, \`getTransactionReceipt\`) via a new \`resolveApiKey()\` helper that throws \`.missingApiKey\` on \`nil\`/\`""\`.

\`App/ProfileSession+CryptoSync.swift\` now passes a closure that reads the keychain on every call (\`{ ProfileSession.resolveAlchemyApiKey() }\`) instead of resolving once at wiring time. Keychain reads on \`kSecAttrAccessibleAfterFirstUnlock\` are fast and crypto sync is already capped at 25 req/s, so a per-call read is the right trade.

## 2. Minimise key residency
The resolved key never lives on the client struct — it's a local \`let\` in each public method's stack frame, threaded down to \`fetchTransfers\` and \`buildRequest\` as a parameter. The struct keeps no instance-level field that could outlive a call. \`requireApiKey()\` is replaced by \`resolveApiKey()\` so the value is materialised exactly once per public call (not re-read inside \`buildRequest\`), and the local goes out of scope when the method returns.

Side change: \`ProfileSession.resolveAlchemyApiKey()\` is now \`nonisolated\` so the \`@Sendable\` closure can call it without bouncing through \`MainActor\`. The work is just a synchronous keychain read; doesn't need actor isolation.

## Test plan
- [x] \`LiveAlchemyClientKeyProviderTests\` (new, 2 tests): pins freshness end-to-end. The first call short-circuits with \`.missingApiKey\` (provider returns \`nil\`); the test then mutates the provider's backing key; the next call reaches the network with the new value embedded in the URL. A second test covers key-removed-after-success.
- [x] \`AlchemyTestSupport.makeClient(apiKeyProvider:)\` overload added; the existing \`apiKey: String\` factory wraps the value in a closure so #787's tests keep working unchanged.
- [x] \`just format-check\` clean
- [x] full mac suite green locally
- [ ] CI green (gates on #787 landing first; merge queue handles ordering)

🤖 Generated with [Claude Code](https://claude.com/claude-code)