### PR TITLE
fix(crypto): repair wire-format and externalId so wallet sync imports

### DIFF
--- a/Automation/AppleScript/Commands/SyncCryptoCommand.swift
+++ b/Automation/AppleScript/Commands/SyncCryptoCommand.swift
@@ -1,0 +1,35 @@
+#if os(macOS)
+  import AppKit
+  import Foundation
+  import OSLog
+
+  private let logger = Logger(subsystem: "com.moolah.app", category: "SyncCryptoCommand")
+
+  /// Handles: `sync crypto profile "X"` or `sync crypto`.
+  ///
+  /// Forces a crypto-account sync for a single profile (when given a
+  /// profile specifier) or every open profile. Equivalent to the user
+  /// hitting "Sync now" on every wallet account at once and bypasses
+  /// the staleness check, so automation and smoke tests can drive the
+  /// importer without waiting for the hourly timer.
+  class SyncCryptoCommand: AppLevelScriptCommand {
+    override func performDefaultImplementation() -> Any? {
+      let profileName = resolveProfileName()
+
+      let _: Void? = runBlockingWithError { @MainActor in
+        guard let service = ScriptingContext.automationService else {
+          throw AutomationError.operationFailed("Scripting not configured")
+        }
+
+        if let profileName {
+          try await service.syncCryptoAccounts(profileIdentifier: profileName)
+        } else {
+          for session in service.sessionManager.openProfiles {
+            try await service.syncCryptoAccounts(profileIdentifier: session.profile.label)
+          }
+        }
+      }
+      return nil
+    }
+  }
+#endif

--- a/Automation/AppleScript/Moolah.sdef
+++ b/Automation/AppleScript/Moolah.sdef
@@ -232,6 +232,11 @@
       <direct-parameter type="specifier" optional="yes" description="The profile to refresh."/>
     </command>
 
+    <command name="synchronize" code="Moolsync" description="Force a sync of every crypto account in a profile (bypasses the staleness timer).">
+      <cocoa class="Moolah.SyncCryptoCommand"/>
+      <direct-parameter type="specifier" optional="yes" description="The profile whose crypto accounts to sync. Defaults to all open profiles."/>
+    </command>
+
     <command name="navigate to" code="Moolnavt" description="Navigate to an object in the UI.">
       <cocoa class="Moolah.NavigateCommand"/>
       <direct-parameter type="specifier" description="The object to navigate to."/>

--- a/Automation/AutomationService+Earmarks.swift
+++ b/Automation/AutomationService+Earmarks.swift
@@ -238,4 +238,23 @@ extension AutomationService {
 
     _ = await (accountsLoad, categoriesLoad, earmarksLoad)
   }
+
+  // MARK: - Crypto sync
+
+  /// Forces a sync of every crypto account in the given profile, bypassing
+  /// the staleness check. Used by automation / smoke tests to drive the
+  /// importer end-to-end without waiting for the hourly stale timer or
+  /// scenePhase `.active` trigger. Throws when the profile cannot be
+  /// resolved or when the crypto-sync store is unavailable (degraded
+  /// launches without an instrument registry).
+  func syncCryptoAccounts(profileIdentifier: String) async throws {
+    let session = try resolveSession(for: profileIdentifier)
+    guard let cryptoSyncStore = session.cryptoSyncStore else {
+      throw AutomationError.operationFailed(
+        "Crypto sync is not available for this profile (instrument registry not configured).")
+    }
+    let cryptoAccounts = session.accountStore.accounts.filter { $0.type == .crypto }
+    guard !cryptoAccounts.isEmpty else { return }
+    await cryptoSyncStore.syncAccounts(cryptoAccounts)
+  }
 }

--- a/MoolahTests/Shared/CryptoImport/AlchemyTransferDecodingTests.swift
+++ b/MoolahTests/Shared/CryptoImport/AlchemyTransferDecodingTests.swift
@@ -116,7 +116,7 @@ struct AlchemyTransferDecodingTests {
         "asset": null,
         "category": "external",
         "rawContract": {
-          "rawValue": "0x0",
+          "value": "0x0",
           "address": null,
           "decimal": null
         },
@@ -139,6 +139,68 @@ struct AlchemyTransferDecodingTests {
   }
 
   @Test
+  func rawContractValueDecodesFromAlchemyKeyValue() throws {
+    // Regression: the JSON key for the precise integer-units transfer
+    // amount is `value` (inside `rawContract`). An earlier wire format
+    // hand-rolled the key as `rawValue` to match the Swift property
+    // name, which silently produced `rawDecimalValue == nil` against
+    // every real Alchemy response and broke the importer end-to-end —
+    // every transfer dropped at `TransferEventBuilder.scaledQuantity`
+    // with no user-visible error. This test pins the canonical
+    // wire-format key so the regression cannot recur invisibly.
+    let json = Data(
+      """
+      {
+        "blockNum": "0x100",
+        "uniqueId": "0xcafe:log:0",
+        "hash": "0xcafe",
+        "from": "0x1111111111111111111111111111111111111111",
+        "to": "0x2222222222222222222222222222222222222222",
+        "value": 0.5,
+        "asset": "ETH",
+        "category": "external",
+        "rawContract": {
+          "value": "0xb1a2bc2ec50000",
+          "address": null,
+          "decimal": "0x12"
+        },
+        "metadata": { "blockTimestamp": "2024-09-12T12:34:56.000Z" }
+      }
+      """.utf8)
+    let transfer = try JSONDecoder().decode(AlchemyTransfer.self, from: json)
+    #expect(transfer.rawContract.rawDecimalValue == Decimal(0x00b1_a2bc_2ec5_0000))
+    #expect(transfer.rawContract.decimalsValue == 18)
+  }
+
+  @Test
+  func rawContractValueIgnoresLegacyRawValueKey() throws {
+    // Defensive: a fixture or upstream wrapper that still emits the old
+    // `rawValue` key must NOT be silently parsed — otherwise the bug
+    // could hide again behind divergent producer/consumer schemas.
+    let json = Data(
+      """
+      {
+        "blockNum": "0x100",
+        "uniqueId": "0xbabe:log:0",
+        "hash": "0xbabe",
+        "from": "0x1111111111111111111111111111111111111111",
+        "to": "0x2222222222222222222222222222222222222222",
+        "value": null,
+        "asset": null,
+        "category": "external",
+        "rawContract": {
+          "rawValue": "0xb1a2bc2ec50000",
+          "address": null,
+          "decimal": "0x12"
+        },
+        "metadata": { "blockTimestamp": null }
+      }
+      """.utf8)
+    let transfer = try JSONDecoder().decode(AlchemyTransfer.self, from: json)
+    #expect(transfer.rawContract.rawDecimalValue == nil)
+  }
+
+  @Test
   func malformedHexFieldsReturnNilInsteadOfThrowing() throws {
     let json = Data(
       """
@@ -150,7 +212,7 @@ struct AlchemyTransferDecodingTests {
         "to": "0x2",
         "category": "erc20",
         "rawContract": {
-          "rawValue": "0xZZZ",
+          "value": "0xZZZ",
           "address": "0xabc",
           "decimal": "not-hex"
         },

--- a/MoolahTests/Shared/CryptoImport/TransferEventBuilderGasLegTests.swift
+++ b/MoolahTests/Shared/CryptoImport/TransferEventBuilderGasLegTests.swift
@@ -59,8 +59,8 @@ struct TransferEventBuilderGasLegTests {
       candidate.transaction.legs.first(where: { $0.type == .transfer }))
     let gasLeg = try #require(
       candidate.transaction.legs.first(where: { $0.type == .expense }))
-    #expect(transferLeg.externalId == "0xeth-send")
-    #expect(gasLeg.externalId == "0xeth-send")
+    #expect(transferLeg.externalId == "0xeth-send:0")
+    #expect(gasLeg.externalId == "0xeth-send:gas")
     #expect(gasLeg.instrument == ChainConfig.ethereum.nativeInstrument)
     #expect(gasLeg.quantity == -Self.expectedFeeEth)
     #expect(gasLeg.accountId == account.id)
@@ -112,7 +112,8 @@ struct TransferEventBuilderGasLegTests {
     #expect(transferLeg.instrument.contractAddress == Self.usdcAddress.lowercased())
     #expect(gasLeg.instrument == ChainConfig.ethereum.nativeInstrument)
     #expect(gasLeg.quantity == -Self.expectedFeeEth)
-    #expect(gasLeg.externalId == "0xerc20-send")
+    #expect(gasLeg.externalId == "0xerc20-send:gas")
+    #expect(transferLeg.externalId == "0xerc20-send:0")
   }
 
   // MARK: - Inbound never gets a gas leg
@@ -221,11 +222,11 @@ struct TransferEventBuilderGasLegTests {
     #expect(built.count == 2)
     let goodCandidate = try #require(
       built.first { candidate in
-        candidate.transaction.legs.contains { $0.externalId == "0xgood" }
+        candidate.transaction.legs.contains { $0.externalId == "0xgood:0" }
       })
     let badCandidate = try #require(
       built.first { candidate in
-        candidate.transaction.legs.contains { $0.externalId == "0xbad" }
+        candidate.transaction.legs.contains { $0.externalId == "0xbad:0" }
       })
     // Good event keeps both legs.
     #expect(goodCandidate.transaction.legs.count == 2)

--- a/MoolahTests/Shared/CryptoImport/TransferEventBuilderTests.swift
+++ b/MoolahTests/Shared/CryptoImport/TransferEventBuilderTests.swift
@@ -48,7 +48,7 @@ struct TransferEventBuilderTests {
     let leg = try #require(candidate.transaction.legs.first)
     #expect(leg.type == .transfer)
     #expect(leg.accountId == account.id)
-    #expect(leg.externalId == "0xeth-send")
+    #expect(leg.externalId == "0xeth-send:0")
     #expect(leg.instrument == ChainConfig.ethereum.nativeInstrument)
     // 1 ETH outbound → -1
     #expect(leg.quantity == Decimal(-1))
@@ -89,7 +89,7 @@ struct TransferEventBuilderTests {
     #expect(candidate.transaction.legs.count == 1)
     let leg = try #require(candidate.transaction.legs.first)
     #expect(leg.type == .transfer)
-    #expect(leg.externalId == "0xerc20-send")
+    #expect(leg.externalId == "0xerc20-send:0")
     #expect(leg.instrument.kind == .cryptoToken)
     #expect(leg.instrument.contractAddress == Self.usdcAddress.lowercased())
     #expect(leg.instrument.decimals == 6)
@@ -123,7 +123,7 @@ struct TransferEventBuilderTests {
     let leg = try #require(candidate.transaction.legs.first)
     #expect(leg.type == .transfer)
     #expect(leg.quantity == Decimal(1))
-    #expect(leg.externalId == "0xreceive")
+    #expect(leg.externalId == "0xreceive:0")
   }
 
   // MARK: - Coincident events on same hash
@@ -145,7 +145,8 @@ struct TransferEventBuilderTests {
       asset: "USDC",
       contractAddress: Self.usdcAddress,
       decimalsHex: "0x6",
-      rawValueHex: "0x5f5e100")
+      rawValueHex: "0x5f5e100",
+      uniqueIdSuffix: "log:5")
     let second = makeAlchemyTransfer(
       hash: "0xcomplex",
       from: Self.counterparty,
@@ -155,7 +156,8 @@ struct TransferEventBuilderTests {
       contractAddress: Self.usdcAddress,
       decimalsHex: "0x6",
       // 25 USDC in raw integer units
-      rawValueHex: "0x17d7840")
+      rawValueHex: "0x17d7840",
+      uniqueIdSuffix: "log:8")
 
     let built = try await TransferEventBuilder().build(
       transfers: [first, second],
@@ -170,7 +172,7 @@ struct TransferEventBuilderTests {
     let candidate = try #require(built.first)
     #expect(candidate.transaction.legs.count == 2)
     let externalIds = Set(candidate.transaction.legs.compactMap(\.externalId))
-    #expect(externalIds == ["0xcomplex"])
+    #expect(externalIds == ["0xcomplex:log:5", "0xcomplex:log:8"])
     let signs = candidate.transaction.legs.map { $0.quantity.sign }
     #expect(signs.contains(.minus))
     #expect(signs.contains(.plus))
@@ -194,7 +196,7 @@ struct TransferEventBuilderTests {
         "asset": null,
         "category": "erc721",
         "rawContract": {
-          "rawValue": "0x0",
+          "value": "0x0",
           "address": "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
           "decimal": null
         },

--- a/MoolahTests/Shared/CryptoImport/WalletSyncTestDoubles.swift
+++ b/MoolahTests/Shared/CryptoImport/WalletSyncTestDoubles.swift
@@ -186,7 +186,10 @@ final class RecordingWalletSyncStateRepository: WalletSyncStateRepository, @unch
 /// Constructs an `AlchemyTransfer` with the fields tests inspect — `hash`,
 /// `from`, `to`, `category`, `asset`, contract address / decimals, raw
 /// hex amount. Defaults match a typical native ETH send so cases that
-/// only change one or two fields read concisely.
+/// only change one or two fields read concisely. `uniqueIdSuffix` lets
+/// tests model multiple events on a single hash without colliding on
+/// `uniqueId` (production uses Alchemy's `:log:N` index — tests just
+/// need any distinct suffix per event).
 func makeAlchemyTransfer(
   hash: String,
   from: String,
@@ -197,11 +200,12 @@ func makeAlchemyTransfer(
   decimalsHex: String? = "0x12",  // 18
   rawValueHex: String = "0x0de0b6b3a7640000",  // 1.0 * 10^18
   blockTimestamp: String? = "2024-09-12T12:34:56.000Z",
-  blockNum: String = "0x12d4f0a"
+  blockNum: String = "0x12d4f0a",
+  uniqueIdSuffix: String = "0"
 ) -> AlchemyTransfer {
   AlchemyTransfer(
     hash: hash,
-    uniqueId: "\(hash):0",
+    uniqueId: "\(hash):\(uniqueIdSuffix)",
     from: from,
     to: to,
     category: category,

--- a/MoolahTests/Support/Fixtures/alchemy/eth-erc20-transfer.json
+++ b/MoolahTests/Support/Fixtures/alchemy/eth-erc20-transfer.json
@@ -13,7 +13,7 @@
         "asset": "USDC",
         "category": "erc20",
         "rawContract": {
-          "rawValue": "0x3b9bca00",
+          "value": "0x3b9bca00",
           "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
           "decimal": "0x6"
         },
@@ -31,7 +31,7 @@
         "asset": "ETH",
         "category": "internal",
         "rawContract": {
-          "rawValue": "0x0",
+          "value": "0x0",
           "address": null,
           "decimal": "0x12"
         },

--- a/MoolahTests/Support/Fixtures/alchemy/eth-simple-eth-send.json
+++ b/MoolahTests/Support/Fixtures/alchemy/eth-simple-eth-send.json
@@ -13,7 +13,7 @@
         "asset": "ETH",
         "category": "external",
         "rawContract": {
-          "rawValue": "0xb1a2bc2ec50000",
+          "value": "0xb1a2bc2ec50000",
           "address": null,
           "decimal": "0x12"
         },

--- a/MoolahTests/Support/Fixtures/alchemy/polygon-spam-airdrop.json
+++ b/MoolahTests/Support/Fixtures/alchemy/polygon-spam-airdrop.json
@@ -13,7 +13,7 @@
         "asset": "VISIT-AIRDROP-SITE.COM",
         "category": "erc20",
         "rawContract": {
-          "rawValue": "0xd3c21bcecceda1000000",
+          "value": "0xd3c21bcecceda1000000",
           "address": "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
           "decimal": "0x12"
         },
@@ -31,7 +31,7 @@
         "asset": "Spam NFT",
         "category": "specialnft",
         "rawContract": {
-          "rawValue": "0x1",
+          "value": "0x1",
           "address": "0xcafebabecafebabecafebabecafebabecafebabe",
           "decimal": null
         },

--- a/Shared/CryptoImport/AlchemyTransfer.swift
+++ b/Shared/CryptoImport/AlchemyTransfer.swift
@@ -16,10 +16,13 @@ import Foundation
 /// - `rawContract.address` — `nil` for native transfers; the ERC-20
 ///   contract address otherwise. Used as part of the instrument key.
 /// - `rawContract.decimal` — token decimals as a 0x-prefixed hex string.
-///   Required to convert `rawValue` into a human-scaled `Decimal`.
-/// - `rawContract.rawValue` — exact integer-units value as a 0x-prefixed
-///   hex string. Source-of-truth for arithmetic; the JSON `value` field
-///   is a lossy IEEE-754 representation that rounds large amounts.
+///   Required to convert the raw value into a human-scaled `Decimal`.
+/// - `rawContract.value` — exact integer-units value as a 0x-prefixed
+///   hex string. Source-of-truth for arithmetic; the top-level `value`
+///   field on the transfer is a lossy IEEE-754 representation that
+///   rounds large amounts. Mapped onto the Swift property `rawValue`
+///   via `CodingKeys` so the local name doesn't shadow the
+///   `RawRepresentable.rawValue` requirement on neighbouring enums.
 /// - `metadata.blockTimestamp` — ISO-8601 timestamp of the block that
 ///   contains this transfer. Used for the transaction date.
 /// - `blockNum` — 0x-prefixed hex block number; persisted as the
@@ -47,7 +50,10 @@ struct AlchemyTransfer: Sendable, Hashable, Decodable {
     /// be missing on native transfers — Alchemy then omits the field.
     let decimal: String?
     /// 0x-prefixed hex of the integer-units transfer amount. Always
-    /// present for transfers Alchemy returns.
+    /// present for transfers Alchemy returns. Decoded from JSON key
+    /// `value` (the wire-format name) but bound to a Swift property
+    /// called `rawValue` to keep call sites unambiguous next to `decimal`
+    /// and to avoid shadowing the IEEE-754 top-level `value` field.
     let rawValue: String?
 
     /// Parses `decimal` from 0x-hex into an `Int`. Returns `nil` if the
@@ -71,6 +77,34 @@ struct AlchemyTransfer: Sendable, Hashable, Decodable {
     /// ISO-8601 block timestamp (e.g. `"2024-09-12T12:34:56.000Z"`).
     let blockTimestamp: String?
   }
+}
+
+extension AlchemyTransfer.RawContract {
+  /// Custom decoder so `rawValue` (the Swift property) reads from the
+  /// `value` JSON key (Alchemy's actual wire-format name). The earlier
+  /// auto-synthesised conformance read JSON key `rawValue`, which is
+  /// what `RawRepresentable` enums use but not what Alchemy emits — so
+  /// every real response decoded with `rawValue == nil` and the
+  /// importer dropped every transfer at
+  /// `TransferEventBuilder.scaledQuantity`. Defined out-of-line so
+  /// `RawContractCodingKeys` lives at file scope and stays inside
+  /// SwiftLint's `nesting` budget (max one level deep).
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: RawContractCodingKeys.self)
+    self.address = try container.decodeIfPresent(String.self, forKey: .address)
+    self.decimal = try container.decodeIfPresent(String.self, forKey: .decimal)
+    self.rawValue = try container.decodeIfPresent(String.self, forKey: .rawValue)
+  }
+}
+
+/// Coding keys for `AlchemyTransfer.RawContract`. Lives at file scope
+/// rather than nested inside the struct so the type-nesting depth
+/// stays at one — SwiftLint's `nesting` rule rejects two-deep nested
+/// types here.
+private enum RawContractCodingKeys: String, CodingKey {
+  case address
+  case decimal
+  case rawValue = "value"
 }
 
 /// Subset of Alchemy's transfer categories we accept.

--- a/Shared/CryptoImport/TransferEventBuilder.swift
+++ b/Shared/CryptoImport/TransferEventBuilder.swift
@@ -16,7 +16,14 @@ import os
 ///   `txHash` so a single complex transaction with N transfer legs only
 ///   triggers one `eth_getTransactionReceipt` round-trip.
 ///
-/// Each leg's `externalId` is set to the event's `hash`. The `counterpartyAddress`
+/// Each transfer leg's `externalId` is set to the Alchemy `uniqueId`
+/// (`"<hash>:<category>:<index>"`) so a multi-event transaction can
+/// produce multiple legs without colliding on the schema's partial
+/// unique index `UNIQUE(account_id, external_id)`. The gas leg (built
+/// from a single receipt per hash, not from a transfer event) uses
+/// `"<hash>:gas"` for the same reason. The hash itself remains the
+/// `BlockExplorerLink.transactionURL` key, so dedup on `externalId`
+/// and "open in explorer" deliberately differ. The `counterpartyAddress`
 /// is the lowercased on-chain address on the *other* side of the transfer:
 /// the `to` address for outbound legs, the `from` address for inbound legs,
 /// and `nil` for self-sends (where both sides are this wallet) and unknown
@@ -152,8 +159,9 @@ struct TransferEventBuilder: Sendable {
   /// hash, present only when at least one event is an outbound
   /// `external` transfer for this wallet. When present the builder
   /// appends a single `.expense` gas leg in the chain's native token
-  /// using the same `externalId` as the transfer legs, so dedup against
-  /// existing storage stays on `(accountId, externalId)`.
+  /// with `externalId = "<hash>:gas"` — distinct from every transfer
+  /// leg's per-event `uniqueId` so the schema's partial unique index
+  /// on `(accountId, externalId)` doesn't reject the second insert.
   private func buildEvent(
     events: [AlchemyTransfer],
     receipt: AlchemyTransactionReceipt?,
@@ -255,7 +263,7 @@ struct TransferEventBuilder: Sendable {
       accountId: context.account.id,
       instrument: instrument,
       quantity: resolution.signedQuantity,
-      externalId: event.hash,
+      externalId: event.uniqueId,
       counterpartyAddress: resolution.counterpartyAddress,
       type: .transfer)
   }

--- a/Shared/CryptoImport/TransferReceiptCoalescer.swift
+++ b/Shared/CryptoImport/TransferReceiptCoalescer.swift
@@ -137,7 +137,18 @@ enum TransferReceiptCoalescer {
       accountId: accountId,
       instrument: chain.nativeInstrument,
       quantity: -gasFeeNative,
-      externalId: receipt.hash,
+      externalId: Self.gasLegExternalId(hash: receipt.hash),
       type: .expense)
+  }
+
+  /// Builds the gas-leg's `externalId` from the transaction hash. The
+  /// `":gas"` suffix is intentional — every transfer leg already uses
+  /// Alchemy's `uniqueId` (`"<hash>:<category>:<index>"`), so the gas
+  /// leg needs its own tag to share the namespace without colliding
+  /// on the schema's partial unique index `(accountId, externalId)`.
+  /// Exposed so the deduper / merger tests can build the same string
+  /// without re-deriving the format.
+  static func gasLegExternalId(hash: String) -> String {
+    "\(hash):gas"
   }
 }

--- a/Shared/CryptoImport/WalletSyncEngine.swift
+++ b/Shared/CryptoImport/WalletSyncEngine.swift
@@ -12,7 +12,12 @@ import OSLog
 /// fetched transfers. When the fetch returns no transfers (e.g. account
 /// has no recent activity), the value falls back to the prior
 /// `lastSyncedBlockNumber` so the next cycle's reorg-window math still
-/// holds, or `0` on a genesis-style fetch.
+/// holds, or `0` on a genesis-style fetch. The watermark is intentionally
+/// advanced even when the builder dropped every transfer — holding it
+/// would make inactive accounts re-query an ever-growing range. The
+/// "raw transfers returned but zero candidates produced" pattern is
+/// instead surfaced as a `warning` log so a wire-format regression is
+/// visible without stranding inactive wallets.
 struct WalletSyncBuildResult: Sendable, Hashable {
   let candidates: [BuiltTransaction]
   let headBlockNumber: UInt64
@@ -113,6 +118,25 @@ struct WalletSyncEngine: Sendable {
       services: BuilderServices(
         chain: chain, discovery: discovery, alchemy: alchemy),
       importOrigin: importOrigin)
+
+    // 6. Observability for wire-format regressions: if Alchemy returned
+    //    rows but every one dropped at the builder, that's the symptom
+    //    of a decoder bug (malformed amount, unknown category…). Log
+    //    loudly so the next regression doesn't recreate the silent
+    //    "synced ok, zero transactions" failure mode that hid the
+    //    `rawContract.value` JSON-key mismatch in production.
+    if !transfers.isEmpty, built.isEmpty {
+      Self.logger.warning(
+        """
+        WalletSyncEngine: builder dropped all \
+        \(transfers.count, privacy: .public) transfers for account \
+        \(account.id, privacy: .public) on chain \
+        \(chain.chainId, privacy: .public) — possible wire-format \
+        regression. Watermark still advances; check earlier \
+        TransferEventBuilder notices for the per-row reason.
+        """
+      )
+    }
     return WalletSyncBuildResult(candidates: built, headBlockNumber: headBlock)
   }
 


### PR DESCRIPTION
## Summary

The crypto-wallet importer has been silently broken since ship — every Alchemy transfer dropped at the builder, no error surfaced, and any account that synced once advanced its watermark past its own history. Diagnosis and three interlocking bugs:

1. **Wire-format JSON-key mismatch** — `AlchemyTransfer.RawContract` decoded the JSON key `rawValue`, but Alchemy's wire format uses `value` inside `rawContract`. Every real response decoded with `rawValue == nil` and the builder skipped each transfer as "malformed amount". Fixed via a custom `init(from:)` keyed to `value` (file-scope `RawContractCodingKeys` to satisfy SwiftLint nesting).
2. **Test fixtures used a made-up key** — every fixture under `MoolahTests/Support/Fixtures/alchemy/` plus a few inline JSON literals used the same wrong `rawValue` key, so CI passed against a wire format that doesn't exist. Repointed every fixture and inline JSON to `value`.
3. **`externalId` collided across legs** — `TransferEventBuilder` set `externalId = event.hash` for every leg, but the schema enforces `UNIQUE(account_id, external_id) WHERE external_id IS NOT NULL`. Multi-event transactions tripped the constraint and the apply pass threw, leaving accounts stuck at "Never synced". Switched transfer legs to `event.uniqueId` (Alchemy's `<hash>:<category>:<index>`) and the gas leg to `<hash>:gas`.

Plus:

- `Logger.warning` in `WalletSyncEngine.build` when Alchemy returns rows but every one drops at the builder, so future wire-format regressions are observable instead of silent.
- New `synchronize` AppleScript verb (`Moolsync` event code) that forces a crypto sync on every account in a profile, bypassing the 24-hour staleness check. Lets automation / smoke tests drive the importer without waiting for the timer.

## Out of scope (separate issue)

Confirmed end-to-end on OP-mainnet — 163 transactions / 215 legs imported. **However**, a follow-on bug surfaces once real data lands: the resolver matches tokens on ticker alone, so spam ERC-20s that copy a real ticker (`OP`, etc.) inherit the legitimate token's Binance/CoinGecko mapping and corrupt the running balance. Tracked separately so this PR can ship.

## Test plan

- [x] `just format-check`
- [x] `just test-mac` — all 2468 tests in 400 suites pass
- [x] Live sync against OP-mainnet wallet `0xa1eaee65…` — 163 transactions import; `wallet_sync_state.last_synced_at` updates
- [x] `osascript -e 'tell application "Moolah" to synchronize'` exits 0 and triggers `getAssetTransfers`

🤖 Generated with [Claude Code](https://claude.com/claude-code)