### PR TITLE
fix(crypto): register chain native gas instrument during wallet sync

### DIFF
--- a/MoolahTests/Shared/CryptoImport/TransferEventBuilderNativeRegTests.swift
+++ b/MoolahTests/Shared/CryptoImport/TransferEventBuilderNativeRegTests.swift
@@ -1,0 +1,93 @@
+// MoolahTests/Shared/CryptoImport/TransferEventBuilderNativeRegTests.swift
+import Foundation
+import Testing
+
+@testable import Moolah
+
+/// Coverage for the chain native-gas pre-registration introduced for
+/// issue #791. Lives in its own suite (split from
+/// `TransferEventBuilderTests`) so the parent file stays inside
+/// SwiftLint's `type_body_length` budget — the same split rationale
+/// used by `TransferEventBuilderGasLegTests`.
+@Suite("TransferEventBuilder — native instrument registration")
+struct TransferEventBuilderNativeRegTests {
+  private static let wallet = "0x1111111111111111111111111111111111111111"
+  private static let counterparty = "0x2222222222222222222222222222222222222222"
+  private static let usdcAddress = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+
+  /// Build must route the chain's native gas instrument through
+  /// `discovery.resolveOrLoad` so the registry stores a row with a
+  /// real provider mapping. Otherwise `ensureInstrumentReadable`
+  /// inserts a placeholder row with no mapping and default
+  /// `pricingStatus=.priced`, which `allCryptoRegistrations()`
+  /// projects to nil — and downstream conversion of `10:native`
+  /// (and other native gas tokens) throws
+  /// `ConversionError.noProviderMapping`.
+  @Test("Building a native transfer registers the chain's native instrument with a mapping")
+  func nativeTransferRegistersChainNativeInstrument() async throws {
+    let subject = makeDiscoverySubject()
+    let account = makeCryptoAccount(walletAddress: Self.wallet, chain: .optimism)
+    let origin = makeWalletImportOrigin(for: account.id)
+    let transfer = makeAlchemyTransfer(
+      hash: "0xnative-send",
+      from: Self.wallet,
+      to: Self.counterparty,
+      category: .external)
+
+    _ = try await TransferEventBuilder().build(
+      transfers: [transfer],
+      account: account,
+      services: BuilderServices(
+        chain: .optimism,
+        discovery: subject.service,
+        alchemy: ZeroReceiptAlchemyStub()),
+      importOrigin: origin)
+
+    let registration = try #require(
+      try await subject.registry.cryptoRegistration(byId: "10:native"))
+    // Default resolver scripts `coingecko: "default-id"` for unscripted
+    // keys; the assertion is on "mapping populated", not on a specific
+    // provider id.
+    #expect(registration.mapping.coingeckoId == "default-id")
+    #expect(registration.pricingStatus == .priced)
+  }
+
+  /// Outbound ERC-20 transfers also pay gas in the native instrument.
+  /// Even though `resolveInstrument` doesn't go through the native
+  /// branch for the transfer leg here, the gas leg appended in
+  /// `buildEvent` references `chain.nativeInstrument` directly — so
+  /// the registry still needs the native row populated with a
+  /// mapping for the gas leg's later conversion to succeed.
+  @Test("Building an ERC-20 transfer also registers the chain's native instrument")
+  func erc20TransferRegistersChainNativeInstrument() async throws {
+    let subject = makeDiscoverySubject()
+    subject.resolver.script(
+      .init(chainId: 10, contractAddress: Self.usdcAddress.lowercased()),
+      .success(coingecko: "usd-coin", cryptocompare: nil, binance: nil))
+    let account = makeCryptoAccount(walletAddress: Self.wallet, chain: .optimism)
+    let origin = makeWalletImportOrigin(for: account.id)
+    let transfer = makeAlchemyTransfer(
+      hash: "0xerc20-send",
+      from: Self.wallet,
+      to: Self.counterparty,
+      category: .erc20,
+      asset: "USDC",
+      contractAddress: Self.usdcAddress,
+      decimalsHex: "0x6",
+      rawValueHex: "0x5f5e100")
+
+    _ = try await TransferEventBuilder().build(
+      transfers: [transfer],
+      account: account,
+      services: BuilderServices(
+        chain: .optimism,
+        discovery: subject.service,
+        alchemy: ZeroReceiptAlchemyStub()),
+      importOrigin: origin)
+
+    let native = try #require(
+      try await subject.registry.cryptoRegistration(byId: "10:native"))
+    #expect(native.mapping.coingeckoId == "default-id")
+    #expect(native.pricingStatus == .priced)
+  }
+}

--- a/MoolahTests/Shared/FullConversionServiceConvertResultTests.swift
+++ b/MoolahTests/Shared/FullConversionServiceConvertResultTests.swift
@@ -171,4 +171,49 @@ struct FullConversionServiceConvertResultTests {
 
     #expect(result == .value(InstrumentAmount(quantity: dec("100") * dec("1.58"), instrument: aud)))
   }
+
+  // MARK: - Native gas instruments — issue #791
+
+  /// Pins the `(.cryptoToken, .fiatCurrency)` dispatch for an Optimism
+  /// native ETH (`10:native`) → AUD conversion through `convertResult`,
+  /// covering the full `.priced` branch — `convertResult` is the
+  /// aggregation entry point on which downstream callers depend per
+  /// `INSTRUMENT_CONVERSION_GUIDE.md` Rule 11.
+  ///
+  /// The bug in #791 surfaced because wallet sync inserted a
+  /// `10:native` row without a provider mapping (`hasMapping=false`,
+  /// default `pricingStatus=.priced`), which `allCryptoRegistrations()`
+  /// projects to nil — so `cryptoUsdPrice` then threw
+  /// `ConversionError.noProviderMapping`. The fix lives in
+  /// `TransferEventBuilder.build(...)`; this test pins the
+  /// FullConversionService side of the contract.
+  @Test
+  func nativeGasInstrumentConvertsToFiat() async throws {
+    let optimismEth = Instrument.crypto(
+      chainId: 10, contractAddress: nil, symbol: "ETH", name: "Ethereum", decimals: 18)
+    let registration = CryptoRegistration(
+      instrument: optimismEth,
+      mapping: CryptoProviderMapping(
+        instrumentId: "10:native",
+        coingeckoId: nil,
+        cryptocompareSymbol: "ETH",
+        binanceSymbol: "ETHUSDT"),
+      pricingStatus: .priced)
+    let bundle = try makeService(
+      cryptoPrices: ["10:native": ["2026-04-10": dec("1623.45")]],
+      exchangeRates: ["2026-04-10": ["AUD": dec("1.58")]],
+      registrations: [registration]
+    )
+    let amount = InstrumentAmount(quantity: dec("0.5"), instrument: optimismEth)
+
+    let result = try await bundle.service.convertResult(
+      amount, to: aud, on: try date("2026-04-10"))
+
+    // 0.5 ETH * 1623.45 USD/ETH * 1.58 AUD/USD
+    #expect(
+      result
+        == .value(
+          InstrumentAmount(
+            quantity: dec("0.5") * dec("1623.45") * dec("1.58"), instrument: aud)))
+  }
 }

--- a/Shared/CryptoImport/TransferEventBuilder+NativeRegistration.swift
+++ b/Shared/CryptoImport/TransferEventBuilder+NativeRegistration.swift
@@ -1,0 +1,34 @@
+// Shared/CryptoImport/TransferEventBuilder+NativeRegistration.swift
+import Foundation
+
+extension TransferEventBuilder {
+  /// Pre-register the chain's native gas instrument via discovery so
+  /// the registry stores a row carrying a real provider mapping.
+  ///
+  /// Both transfer-leg construction (`.external` / `.internal` cases
+  /// of `resolveInstrument`) and gas-leg construction
+  /// (`TransferReceiptCoalescer.makeGasLeg`) use
+  /// `chain.nativeInstrument` directly. Without this pre-registration,
+  /// `ensureInstrumentReadable` inserts a placeholder `InstrumentRow`
+  /// with default `pricingStatus=.priced` and no provider mapping,
+  /// which `allCryptoRegistrations()` then projects to nil — and the
+  /// downstream conversion of `10:native` (and other native gas
+  /// tokens like `1:native`, `137:native`, `8453:native`) throws
+  /// `ConversionError.noProviderMapping`. See issue #791.
+  ///
+  /// Idempotent at the discovery actor: when a registration already
+  /// exists for the chain's native id, `resolveOrLoad` short-circuits
+  /// to the registry and skips network resolution.
+  static func preregisterChainNativeInstrument(
+    chain: ChainConfig,
+    discovery: CryptoTokenDiscoveryService
+  ) async throws {
+    let nativeInstrument = chain.nativeInstrument
+    _ = try await discovery.resolveOrLoad(
+      chain: chain,
+      contractAddress: nil,
+      symbol: nativeInstrument.ticker ?? nativeInstrument.name,
+      name: nativeInstrument.name,
+      decimals: nativeInstrument.decimals)
+  }
+}

--- a/Shared/CryptoImport/TransferEventBuilder.swift
+++ b/Shared/CryptoImport/TransferEventBuilder.swift
@@ -103,6 +103,7 @@ struct TransferEventBuilder: Sendable {
       chain: chain,
       discovery: discovery,
       importOrigin: importOrigin)
+    try await Self.preregisterChainNativeInstrument(chain: chain, discovery: discovery)
 
     // Stable order: group preserves first-seen order so test fixtures
     // and signposts are deterministic.


### PR DESCRIPTION
## Summary

Fixes #791 — wallet sync was leaving the chain's native gas instrument (`10:native`, `1:native`, `137:native`, `8453:native`) registered without a provider mapping, breaking every downstream conversion.

### Root cause

`TransferEventBuilder` built transactions whose `.external` / `.internal` legs and gas legs reference `chain.nativeInstrument` directly. When the row didn't exist locally, `GRDBTransactionRepository.ensureInstrumentReadable` inserted an `InstrumentRow` with default `pricingStatus=.priced` and no provider mapping. `GRDBInstrumentRegistryRepository+Lookup.project(row:)`'s `hasMapping || status != .priced` guard projected that row to nil, so `allCryptoRegistrations()` excluded it. `FullConversionService.cryptoUsdPrice` then couldn't find the registration and threw `ConversionError.noProviderMapping`.

The reporter's "error 1" is `.noProviderMapping`, not `.unsupportedConversion` as the issue title suggests — Swift bridges payload-less enum cases to lower NSError codes first, which inverted the surface mapping vs. source order.

### Fix

Pre-register the chain's native instrument through `discovery.resolveOrLoad(...)` once at the start of `TransferEventBuilder.build(...)`. Both transfer-leg construction and gas-leg construction reference the same canonical native instrument id, so a single registration covers both paths. Idempotent at the discovery actor — subsequent build calls hit the registry's existing-row fast path.

The helper sits in a sibling extension file (`TransferEventBuilder+NativeRegistration.swift`) following the project's `TransferReceiptCoalescer.swift` pattern, keeping the primary file inside SwiftLint's `file_length` budget.

## Test plan

- [x] New test pins `10:native` → AUD via `FullConversionService.convertResult` (per issue acceptance criterion).
- [x] New `TransferEventBuilderNativeRegTests` suite asserts both native and ERC-20 transfers populate the chain native registration.
- [x] `just test` (mac + iOS) — 2471/2471 pass in 401 suites.
- [x] `just format-check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)