### PR TITLE
fix(crypto): tighten resolver, decouple balances from spam tokens (#790)

### DIFF
--- a/App/ContentView.swift
+++ b/App/ContentView.swift
@@ -366,7 +366,10 @@ extension ContentView {
             positions: accountStore.positions(for: account.id),
             positionsHostCurrency: account.instrument,
             positionsTitle: account.name,
-            conversionService: session.backend.conversionService)
+            conversionService: session.backend.conversionService,
+            // Drives a re-fire of the per-row valuator when the user
+            // marks a token as `.spam` from preferences — issue #790.
+            registrationsVersion: session.cryptoTokenStore?.registrationsVersion ?? 0)
         }
       }
     }

--- a/App/ProfileSession.swift
+++ b/App/ProfileSession.swift
@@ -227,11 +227,24 @@ final class ProfileSession: Identifiable {
   /// Wires the investment-store -> account-store callback. The spawned
   /// Task is appended to `crossStoreUpdateTasks` so `cleanupSync` can
   /// cancel in-flight updates if the session is torn down.
+  ///
+  /// Also wires the crypto-token-store -> investment-store hook: when a
+  /// registration's `pricingStatus` flips (e.g. user marks a token as
+  /// `.spam` from preferences), the loaded investment account
+  /// re-valuates so the spam position drops out of `valuedPositions`
+  /// without the user having to navigate away and back. Issue #790.
   private func wireCrossStoreSideEffects() {
     let accountStore = self.accountStore
     self.investmentStore.onInvestmentValueChanged = { [weak self] accountId, latestValue in
       let task = Task { @MainActor in
         await accountStore.updateInvestmentValue(accountId: accountId, value: latestValue)
+      }
+      self?.crossStoreUpdateTasks.append(task)
+    }
+    let investmentStore = self.investmentStore
+    self.cryptoTokenStore?.onRegistrationsChanged = { [weak self] in
+      let task = Task { @MainActor in
+        await investmentStore.revaluateLoadedPositions()
       }
       self?.crossStoreUpdateTasks.append(task)
     }

--- a/Backends/GRDB/Repositories/GRDBAnalysisRepository+Conversion.swift
+++ b/Backends/GRDB/Repositories/GRDBAnalysisRepository+Conversion.swift
@@ -73,6 +73,12 @@ extension GRDBAnalysisRepository {
   /// `TransactionLeg` because rows arrive as already-summed
   /// `(storageValue, instrumentId)` tuples from the GROUP BY — no leg
   /// is available to project from.
+  ///
+  /// `.knownZero` source instruments (`.unpriced` / `.spam` crypto
+  /// registrations) fold to `.zero(target)` rather than failing the
+  /// row, so income/expense, breakdown and category aggregations omit
+  /// the unpriced contribution but still render the rest of the day.
+  /// Issue #790. A real provider error still throws.
   @concurrent
   static func convertedQuantity(
     storageValue: Int64,
@@ -85,8 +91,10 @@ extension GRDBAnalysisRepository {
     if instrument.id == target.id {
       return amount
     }
-    let converted = try await conversionService.convert(
-      amount.quantity, from: instrument, to: target, on: day)
-    return InstrumentAmount(quantity: converted, instrument: target)
+    let result = try await conversionService.convertResult(amount, to: target, on: day)
+    switch result {
+    case .value(let converted): return converted
+    case .knownZero: return .zero(instrument: target)
+    }
   }
 }

--- a/Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesForecast.swift
+++ b/Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesForecast.swift
@@ -163,8 +163,19 @@ extension GRDBAnalysisRepository {
         convertedLegs.append(leg)
         continue
       }
-      let convertedQty = try await conversionService.convert(
-        leg.quantity, from: leg.instrument, to: instrument, on: date)
+      // `.knownZero` source legs (`.unpriced` / `.spam` crypto) fold to
+      // a zero-quantity leg rather than aborting the forecast day —
+      // issue #790. Real provider errors still throw so a transient
+      // rate failure preserves Rule 11 (mark the day unavailable).
+      let conversionResult = try await conversionService.convertResult(
+        InstrumentAmount(quantity: leg.quantity, instrument: leg.instrument),
+        to: instrument,
+        on: date)
+      let convertedQty: Decimal
+      switch conversionResult {
+      case .value(let amount): convertedQty = amount.quantity
+      case .knownZero: convertedQty = 0
+      }
       convertedLegs.append(
         TransactionLeg(
           accountId: leg.accountId,

--- a/Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesInvestmentValues.swift
+++ b/Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesInvestmentValues.swift
@@ -235,8 +235,14 @@ extension GRDBAnalysisRepository {
         total += value.quantity
         continue
       }
-      total += try await conversionService.convert(
-        value.quantity, from: value.instrument, to: profileInstrument, on: date)
+      // `.knownZero` (e.g. an `.unpriced` / `.spam` crypto investment
+      // value) contributes zero rather than failing the day —
+      // issue #790.
+      let result = try await conversionService.convertResult(
+        value, to: profileInstrument, on: date)
+      if case .value(let converted) = result {
+        total += converted.quantity
+      }
     }
     return InstrumentAmount(quantity: total, instrument: profileInstrument)
   }

--- a/Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesTradesMode.swift
+++ b/Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesTradesMode.swift
@@ -205,8 +205,15 @@ extension GRDBAnalysisRepository {
           total += quantity
           continue
         }
-        total += try await conversionService.convert(
-          quantity, from: instrument, to: profileInstrument, on: date)
+        // `.knownZero` (e.g. an `.unpriced` / `.spam` crypto position)
+        // contributes zero rather than failing the day's investment
+        // aggregation — issue #790.
+        let amount = InstrumentAmount(quantity: quantity, instrument: instrument)
+        let result = try await conversionService.convertResult(
+          amount, to: profileInstrument, on: date)
+        if case .value(let converted) = result {
+          total += converted.quantity
+        }
       }
     }
     return InstrumentAmount(quantity: total, instrument: profileInstrument)

--- a/Domain/Models/TransactionPage.swift
+++ b/Domain/Models/TransactionPage.swift
@@ -84,16 +84,25 @@ struct TransactionPage: Sendable {
 
   /// Outcome of a single per-instrument rate prefetch. Sendable so it can
   /// flow out of a `TaskGroup` child task.
+  ///
+  /// `knownZero` is distinct from `failure`: it means the conversion
+  /// service intentionally resolved the source instrument to a zero
+  /// contribution (e.g. an `.unpriced` or `.spam` crypto registration —
+  /// see `ConversionResult.knownZero`). A `failure` is a transient
+  /// rate-source outage that must blank the running balance per Rule 11
+  /// of `guides/INSTRUMENT_CONVERSION_GUIDE.md`.
   private enum RatePrefetch: Sendable {
     case rate(Decimal)
+    case knownZero
     case failure(String)
   }
 
-  /// Fetched rates and per-instrument failures, keyed by source instrument.
-  /// Returned by `prefetchRates(...)` and consumed by
-  /// `accumulateRunningBalances(...)`.
+  /// Fetched rates, intentional-zero instruments, and per-instrument
+  /// failures, keyed by source instrument. Returned by `prefetchRates(...)`
+  /// and consumed by `accumulateRunningBalances(...)`.
   private struct PrefetchedRates {
     let rates: [Instrument: Decimal]
+    let knownZero: Set<Instrument>
     let failures: [Instrument: String]
   }
 
@@ -109,38 +118,69 @@ struct TransactionPage: Sendable {
         sources.insert(leg.instrument)
       }
     }
-    if sources.isEmpty { return PrefetchedRates(rates: [:], failures: [:]) }
+    if sources.isEmpty {
+      return PrefetchedRates(rates: [:], knownZero: [], failures: [:])
+    }
 
     let asOf = Date()
     return await withTaskGroup(of: (Instrument, RatePrefetch).self) { group in
       for instrument in sources {
         group.addTask {
-          do {
-            let rate = try await conversionService.convert(
-              Decimal(1), from: instrument, to: targetInstrument, on: asOf)
-            return (instrument, .rate(rate))
-          } catch {
-            transactionLogger.warning(
-              """
-              Failed to fetch rate \(instrument.id, privacy: .public) → \
-              \(targetInstrument.id, privacy: .public): \
-              \(error.localizedDescription, privacy: .public). Every \
-              transaction with a \(instrument.id, privacy: .public) leg will \
-              have an unavailable running balance until the rate source recovers.
-              """)
-            return (instrument, .failure(error.localizedDescription))
-          }
+          let outcome = await fetchOneRate(
+            for: instrument,
+            targetInstrument: targetInstrument,
+            asOf: asOf,
+            conversionService: conversionService)
+          return (instrument, outcome)
         }
       }
       var rates: [Instrument: Decimal] = [:]
+      var knownZero: Set<Instrument> = []
       var failures: [Instrument: String] = [:]
       for await (instrument, outcome) in group {
         switch outcome {
         case .rate(let rate): rates[instrument] = rate
+        case .knownZero: knownZero.insert(instrument)
         case .failure(let description): failures[instrument] = description
         }
       }
-      return PrefetchedRates(rates: rates, failures: failures)
+      return PrefetchedRates(rates: rates, knownZero: knownZero, failures: failures)
+    }
+  }
+
+  /// Fetch the conversion outcome for a single source instrument. Use
+  /// `convertResult` rather than `convert` so the `.knownZero` outcome
+  /// (an `.unpriced` / `.spam` crypto token) is preserved as an
+  /// intentional zero rather than being misapplied as a real rate or
+  /// thrown as a failure. Issue #790: a spam ERC-20 with a copied
+  /// ticker must contribute zero to the running balance, not poison it.
+  private static func fetchOneRate(
+    for instrument: Instrument,
+    targetInstrument: Instrument,
+    asOf: Date,
+    conversionService: InstrumentConversionService
+  ) async -> RatePrefetch {
+    do {
+      let result = try await conversionService.convertResult(
+        InstrumentAmount(quantity: Decimal(1), instrument: instrument),
+        to: targetInstrument,
+        on: asOf)
+      switch result {
+      case .value(let amount):
+        return .rate(amount.quantity)
+      case .knownZero:
+        return .knownZero
+      }
+    } catch {
+      transactionLogger.warning(
+        """
+        Failed to fetch rate \(instrument.id, privacy: .public) → \
+        \(targetInstrument.id, privacy: .public): \
+        \(error.localizedDescription, privacy: .public). Every \
+        transaction with a \(instrument.id, privacy: .public) leg will \
+        have an unavailable running balance until the rate source recovers.
+        """)
+      return .failure(error.localizedDescription)
     }
   }
 
@@ -212,6 +252,12 @@ struct TransactionPage: Sendable {
   /// Apply prefetched rates to each leg of `transaction`. Returns
   /// `.failure` on the first leg whose source instrument has no rate
   /// (failed prefetch) so the caller can mark the row unavailable.
+  ///
+  /// Legs whose source instrument resolved to `.knownZero` (an
+  /// `.unpriced` / `.spam` crypto registration) fold to a zero
+  /// `convertedAmount` in the target instrument — the leg keeps its
+  /// native quantity for display but contributes zero to the running
+  /// balance, per issue #790.
   private static func convert(
     legsOf transaction: Transaction,
     targetInstrument: Instrument,
@@ -225,6 +271,9 @@ struct TransactionPage: Sendable {
       } else if let rate = prefetched.rates[leg.instrument] {
         let amount = InstrumentAmount(
           quantity: leg.amount.quantity * rate, instrument: targetInstrument)
+        legs.append(ConvertedTransactionLeg(leg: leg, convertedAmount: amount))
+      } else if prefetched.knownZero.contains(leg.instrument) {
+        let amount = InstrumentAmount.zero(instrument: targetInstrument)
         legs.append(ConvertedTransactionLeg(leg: leg, convertedAmount: amount))
       } else {
         let description =

--- a/Features/Accounts/AccountBalanceCalculator.swift
+++ b/Features/Accounts/AccountBalanceCalculator.swift
@@ -93,6 +93,11 @@ struct AccountBalanceCalculator {
   /// zero when none is set); every other account sums positions directly to
   /// `target` in one pass — avoiding the double-conversion a naive
   /// `positions → account instrument → target` implementation would incur.
+  ///
+  /// Positions whose conversion resolves to `.knownZero` (an `.unpriced`
+  /// / `.spam` crypto registration) contribute zero to the total; a
+  /// thrown conversion error still propagates as before, marking the
+  /// total unavailable per Rule 11. See issue #790.
   func totalConverted(
     for accounts: [Account],
     to target: Instrument,
@@ -118,8 +123,11 @@ struct AccountBalanceCalculator {
         if position.amount.instrument == target {
           total += position.amount
         } else {
-          total += try await conversionService.convertAmount(
+          let result = try await conversionService.convertResult(
             position.amount, to: target, on: date)
+          if case .value(let converted) = result {
+            total += converted
+          }
         }
         try Task.checkCancellation()
       }
@@ -131,6 +139,11 @@ struct AccountBalanceCalculator {
   /// accounts in `recordedValue` mode return the externally-provided
   /// snapshot (or zero when absent); all other accounts sum every position
   /// converted via the conversion service.
+  ///
+  /// Positions whose conversion resolves to `.knownZero` (an `.unpriced`
+  /// / `.spam` crypto registration) contribute zero to the displayed
+  /// balance; a thrown conversion error still propagates so the balance
+  /// is marked unavailable per Rule 11. See issue #790.
   ///
   /// Pass `date` to share a conversion timestamp across a multi-account
   /// pass; defaults to `Date()` for one-shot callers.
@@ -145,8 +158,11 @@ struct AccountBalanceCalculator {
       if position.amount.instrument == account.instrument {
         total += position.amount
       } else {
-        total += try await conversionService.convertAmount(
+        let result = try await conversionService.convertResult(
           position.amount, to: account.instrument, on: date)
+        if case .value(let converted) = result {
+          total += converted
+        }
       }
       try Task.checkCancellation()
     }

--- a/Features/Earmarks/EarmarkStore.swift
+++ b/Features/Earmarks/EarmarkStore.swift
@@ -220,9 +220,11 @@ final class EarmarkStore {
   }
 
   /// Sums an earmark's three position lists, each converted to the
-  /// earmark's own instrument. Throws if any conversion fails so the
-  /// caller treats the whole earmark as failed (we never display a
-  /// partial earmark balance).
+  /// earmark's own instrument. `.knownZero` positions (an `.unpriced`
+  /// / `.spam` crypto registration) contribute zero rather than
+  /// failing the earmark — issue #790. A real provider failure still
+  /// throws so the caller treats the whole earmark as failed (we never
+  /// display a partial earmark balance under transient outage).
   private func convertEarmarkPositions(_ earmark: Earmark) async throws
     -> ConvertedEarmarkTotals
   {
@@ -231,18 +233,32 @@ final class EarmarkStore {
     var saved = InstrumentAmount.zero(instrument: earmark.instrument)
     var spent = InstrumentAmount.zero(instrument: earmark.instrument)
     for position in earmark.positions {
-      balance += try await conversionService.convertAmount(
+      balance += try await convertPositionOrZero(
         position.amount, to: earmark.instrument, on: date)
     }
     for position in earmark.savedPositions {
-      saved += try await conversionService.convertAmount(
+      saved += try await convertPositionOrZero(
         position.amount, to: earmark.instrument, on: date)
     }
     for position in earmark.spentPositions {
-      spent += try await conversionService.convertAmount(
+      spent += try await convertPositionOrZero(
         position.amount, to: earmark.instrument, on: date)
     }
     return ConvertedEarmarkTotals(balance: balance, saved: saved, spent: spent)
+  }
+
+  /// Convert `amount` to `target` on `date`, folding `.knownZero` (an
+  /// `.unpriced` / `.spam` crypto source) to zero in `target`.
+  /// Issue #790.
+  private func convertPositionOrZero(
+    _ amount: InstrumentAmount, to target: Instrument, on date: Date
+  ) async throws -> InstrumentAmount {
+    let result = try await conversionService.convertResult(
+      amount, to: target, on: date)
+    switch result {
+    case .value(let converted): return converted
+    case .knownZero: return .zero(instrument: target)
+    }
   }
 
   /// Reorders the visible earmarks, persisting each new position to the

--- a/Features/Investments/InvestmentStore.swift
+++ b/Features/Investments/InvestmentStore.swift
@@ -210,6 +210,16 @@ final class InvestmentStore {
       accountId: account.id, profileCurrency: profileCurrency)
   }
 
+  /// Re-runs `valuatePositions` against the most recently loaded
+  /// account. `ProfileSession` calls this from
+  /// `CryptoTokenStore.onRegistrationsChanged` so a freshly-marked
+  /// `.spam` token drops out of `valuedPositions` without the user
+  /// having to navigate away and back. Issue #790.
+  func revaluateLoadedPositions() async {
+    guard let profileCurrency = loadedHostCurrency else { return }
+    await valuatePositions(profileCurrency: profileCurrency, on: Date())
+  }
+
   func setValue(accountId: UUID, date: Date, value: InstrumentAmount) async {
     error = nil
     do {
@@ -286,14 +296,12 @@ final class InvestmentStore {
     }
   }
 
-  /// Valuate all loaded positions using current market prices.
-  ///
-  /// Per Rule 11 in `guides/INSTRUMENT_CONVERSION_GUIDE.md`: if any
-  /// position's conversion fails, the aggregate `totalPortfolioValue`
-  /// is marked unavailable (`nil`) and `error` is set so the view can
-  /// surface a retry affordance. Per-position `ValuedPosition`s still
-  /// render individually — the failing position appears with a `nil`
-  /// `value` and sibling positions with their successful values.
+  /// Valuate all loaded positions using current market prices. Per
+  /// Rule 11 in `guides/INSTRUMENT_CONVERSION_GUIDE.md`: a failed
+  /// conversion marks the aggregate `totalPortfolioValue` unavailable
+  /// and sets `error`; sibling rows still render with their successful
+  /// values. `.knownZero` positions drop out of `valuedPositions`
+  /// entirely (issue #790).
   func valuatePositions(profileCurrency: Instrument, on date: Date) async {
     var valued: [ValuedPosition] = []
     var total: Decimal = 0
@@ -302,10 +310,12 @@ final class InvestmentStore {
     for position in positions {
       let (entry, outcome) = await valuate(
         position: position, profileCurrency: profileCurrency, on: date)
-      valued.append(entry)
+      if let entry { valued.append(entry) }
       switch outcome {
       case .success(let value):
         total += value
+      case .knownZero:
+        continue
       case .failure(let error):
         if firstFailure == nil { firstFailure = error }
       }
@@ -329,12 +339,15 @@ final class InvestmentStore {
 extension InvestmentStore {
   private enum ValuationOutcome {
     case success(Decimal)
+    /// `.unpriced` / `.spam` crypto source — drop the position from
+    /// `valuedPositions`. Issue #790.
+    case knownZero
     case failure(Error)
   }
 
   private func valuate(
     position: Position, profileCurrency: Instrument, on date: Date
-  ) async -> (ValuedPosition, ValuationOutcome) {
+  ) async -> (ValuedPosition?, ValuationOutcome) {
     if position.instrument.id == profileCurrency.id {
       let entry = ValuedPosition(
         instrument: position.instrument,
@@ -345,20 +358,27 @@ extension InvestmentStore {
       return (entry, .success(position.quantity))
     }
     do {
-      let value = try await conversionService.convert(
-        position.quantity, from: position.instrument, to: profileCurrency, on: date
-      )
-      let unit =
-        position.quantity == 0
-        ? nil
-        : InstrumentAmount(quantity: value / position.quantity, instrument: profileCurrency)
-      let entry = ValuedPosition(
-        instrument: position.instrument,
-        quantity: position.quantity,
-        unitPrice: unit,
-        costBasis: nil,
-        value: InstrumentAmount(quantity: value, instrument: profileCurrency))
-      return (entry, .success(value))
+      let amount = InstrumentAmount(
+        quantity: position.quantity, instrument: position.instrument)
+      let result = try await conversionService.convertResult(
+        amount, to: profileCurrency, on: date)
+      switch result {
+      case .knownZero:
+        return (nil, .knownZero)
+      case .value(let converted):
+        let value = converted.quantity
+        let unit =
+          position.quantity == 0
+          ? nil
+          : InstrumentAmount(quantity: value / position.quantity, instrument: profileCurrency)
+        let entry = ValuedPosition(
+          instrument: position.instrument,
+          quantity: position.quantity,
+          unitPrice: unit,
+          costBasis: nil,
+          value: converted)
+        return (entry, .success(value))
+      }
     } catch {
       logger.warning(
         "Failed to valuate position \(position.instrument.id, privacy: .public): \(error.localizedDescription, privacy: .public)"

--- a/Features/Settings/CryptoSettingsView+TokenList.swift
+++ b/Features/Settings/CryptoSettingsView+TokenList.swift
@@ -35,25 +35,11 @@ extension CryptoSettingsView {
       .frame(maxWidth: .infinity)
     } else {
       ForEach(pricedRegistrations) { registration in
-        CryptoRegistrationRow(registration: registration)
-          .accessibilityIdentifier(
-            UITestIdentifiers.CryptoSettings.registrationRow(registration.id)
-          )
-          .contextMenu {
-            Button(role: .destructive) {
-              Task { await store.removeRegistration(registration) }
-            } label: {
-              Label("Remove", systemImage: "trash")
-            }
-          }
-      }
-      .onDelete { indexSet in
-        let visible = pricedRegistrations
-        Task {
-          for index in indexSet {
-            await store.removeRegistration(visible[index])
-          }
-        }
+        // `showsContractAddress: true` — wallets with copied tickers
+        // (issue #790) need the truncated address visible so a
+        // legitimate token can be told apart from a spam contract
+        // claiming the same symbol.
+        registrationRow(for: registration)
       }
     }
   }
@@ -79,6 +65,44 @@ extension CryptoSettingsView {
   /// inbox + spam views can also read.
   var pricedRegistrations: [CryptoRegistration] {
     store.registrations.filter { $0.pricingStatus == .priced }
+  }
+
+  /// One row in the Registered Tokens list, with an inline ellipsis
+  /// `Menu` carrying both per-row actions. The earlier `.contextMenu`
+  /// + `.swipeActions` + `.onDelete` stack triggered a SwiftUI
+  /// `ForEachState` crash on macOS — a single inline `Menu` is the
+  /// proven primitive used elsewhere in the app's Form-style preferences.
+  ///
+  /// "Mark as Spam" calls the same `setStatus(.spam, for:)` plumbing
+  /// the Discovered Tokens inbox uses. It exists here so the user can
+  /// un-poison registrations the pre-#790 broken resolver wrote as
+  /// `.priced` with a spoofed mapping.
+  @ViewBuilder
+  func registrationRow(for registration: CryptoRegistration) -> some View {
+    HStack {
+      CryptoRegistrationRow(registration: registration, showsContractAddress: true)
+      Menu {
+        Button(role: .destructive) {
+          Task { await store.setStatus(.spam, for: registration) }
+        } label: {
+          Label("Mark as Spam", systemImage: "trash")
+        }
+        .accessibilityIdentifier(
+          UITestIdentifiers.CryptoSettings.markSpamButton(registration.id))
+        Button(role: .destructive) {
+          Task { await store.removeRegistration(registration) }
+        } label: {
+          Label("Remove", systemImage: "minus.circle")
+        }
+      } label: {
+        Image(systemName: "ellipsis.circle")
+          .accessibilityLabel("Token actions")
+      }
+      .menuStyle(.borderlessButton)
+      .fixedSize()
+    }
+    .accessibilityIdentifier(
+      UITestIdentifiers.CryptoSettings.registrationRow(registration.id))
   }
 
   // MARK: - CoinGecko API Key

--- a/Features/Settings/CryptoTokenStore.swift
+++ b/Features/Settings/CryptoTokenStore.swift
@@ -13,6 +13,21 @@ final class CryptoTokenStore {
 
   private(set) var error: String?
 
+  /// Fired after a successful registry mutation that may change a
+  /// registration's `pricingStatus` or remove a row. Wired by
+  /// `ProfileSession` to drive the per-store re-aggregation that
+  /// otherwise wouldn't observe registry changes — e.g. so the
+  /// `InvestmentStore`'s `valuedPositions` drops a freshly-marked
+  /// `.spam` token from the account's position list. Issue #790.
+  var onRegistrationsChanged: (@MainActor () -> Void)?
+
+  /// Monotonic version bumped after every successful registry mutation
+  /// (`setStatus`, `removeRegistration`). Views that derive per-account
+  /// valued positions pin a `.task(id:)` against this so a `.spam` flip
+  /// in preferences re-fires the per-row valuator without the user
+  /// having to navigate away. Issue #790.
+  private(set) var registrationsVersion: Int = 0
+
   private let registry: any InstrumentRegistryRepository
   private let cryptoPriceService: CryptoPriceService
   private let conversionService: any InstrumentConversionService
@@ -118,6 +133,8 @@ final class CryptoTokenStore {
       registrations.removeAll { $0.id == registration.id }
       instruments.removeAll { $0.id == registration.id }
       providerMappings.removeValue(forKey: registration.id)
+      registrationsVersion &+= 1
+      onRegistrationsChanged?()
     } catch {
       logger.error("Failed to remove registration: \(error, privacy: .public)")
       self.error = error.localizedDescription
@@ -154,6 +171,8 @@ final class CryptoTokenStore {
         registrations[index] = updated
       }
       error = nil
+      registrationsVersion &+= 1
+      onRegistrationsChanged?()
     } catch {
       logger.error("Failed to set pricing status: \(error, privacy: .public)")
       self.error = error.localizedDescription

--- a/Features/Transactions/Views/TransactionListView+List.swift
+++ b/Features/Transactions/Views/TransactionListView+List.swift
@@ -114,7 +114,12 @@ extension TransactionListView {
           filter: activeFilter)
       }
     }
-    .task(id: positions) {
+    // Composite id: re-fire when the raw positions list changes, AND
+    // when the registry version bumps (e.g. user marks a token as
+    // `.spam`). Without the version dimension a spam flip in
+    // preferences leaves a stale `valuedPositions` on screen until the
+    // user navigates away and back. Issue #790.
+    .task(id: PositionsTaskKey(positions: positions, registrationsVersion: registrationsVersion)) {
       guard let conversionService, !positions.isEmpty else {
         positionsInput = nil
         return
@@ -291,4 +296,13 @@ struct TransactionListCSVImportAddons: ViewModifier {
         return !urls.isEmpty
       }
   }
+}
+
+/// Composite id for the position-valuation `.task(id:)`. Rebuilds the
+/// valued rows when either the raw positions list changes OR the
+/// crypto registry version bumps (a `.spam` flip in preferences).
+/// Issue #790.
+private struct PositionsTaskKey: Hashable {
+  let positions: [Position]
+  let registrationsVersion: Int
 }

--- a/Features/Transactions/Views/TransactionListView.swift
+++ b/Features/Transactions/Views/TransactionListView.swift
@@ -18,6 +18,12 @@ struct TransactionListView: View {
   var positionsHostCurrency: Instrument = .AUD
   var positionsTitle: String = "Balances"
   var conversionService: (any InstrumentConversionService)?
+  /// Bumped on every successful crypto-registration mutation so the
+  /// `.task(id:)` driving the per-row valuator re-fires when the user
+  /// flips a token's `pricingStatus` (e.g. "Mark as Spam"). Drives the
+  /// drop-spam-from-positions UX of issue #790. Optional with a default
+  /// of `0` so non-crypto call sites need not thread it through.
+  var registrationsVersion: Int = 0
 
   /// When non-nil, the parent owns the selection and handles the inspector.
   /// When nil, TransactionListView manages its own selection and inspector.
@@ -72,7 +78,8 @@ struct TransactionListView: View {
     positions: [Position] = [],
     positionsHostCurrency: Instrument = .AUD,
     positionsTitle: String = "Balances",
-    conversionService: (any InstrumentConversionService)? = nil
+    conversionService: (any InstrumentConversionService)? = nil,
+    registrationsVersion: Int = 0
   ) {
     self.title = title
     self.baseFilter = filter
@@ -84,6 +91,7 @@ struct TransactionListView: View {
     self.positionsHostCurrency = positionsHostCurrency
     self.positionsTitle = positionsTitle
     self.conversionService = conversionService
+    self.registrationsVersion = registrationsVersion
     self._externalSelection = nil
     self._activeFilter = State(initialValue: filter)
   }
@@ -100,6 +108,7 @@ struct TransactionListView: View {
     positionsHostCurrency: Instrument = .AUD,
     positionsTitle: String = "Balances",
     conversionService: (any InstrumentConversionService)? = nil,
+    registrationsVersion: Int = 0,
     selectedTransaction: Binding<Transaction?>
   ) {
     self.title = title
@@ -112,6 +121,7 @@ struct TransactionListView: View {
     self.positionsHostCurrency = positionsHostCurrency
     self.positionsTitle = positionsTitle
     self.conversionService = conversionService
+    self.registrationsVersion = registrationsVersion
     self._externalSelection = selectedTransaction
     self._activeFilter = State(initialValue: filter)
   }

--- a/MoolahTests/Domain/TransactionRunningBalanceTests.swift
+++ b/MoolahTests/Domain/TransactionRunningBalanceTests.swift
@@ -186,4 +186,74 @@ struct TransactionRunningBalanceTests {
     #expect(error.transactionId == oldestFailingId)
     #expect(error.targetInstrumentId == target.id)
   }
+
+  // MARK: - .knownZero legs (issue #790)
+
+  /// Issue #790: a leg whose conversion resolves to `.knownZero` (an
+  /// `.unpriced` / `.spam` crypto registration) contributes zero to the
+  /// running balance — it does NOT mark the row unavailable. This is
+  /// distinct from a transient rate-source failure, which still blanks
+  /// the row and surfaces an error.
+  @Test
+  func knownZeroLegContributesZeroAndDoesNotBreakBalance() async {
+    let accountId = UUID()
+    let spam = foreign  // pretend `foreign` is the `.unpriced` / `.spam` token
+    // newest → oldest. The middle leg is in the spam instrument and must
+    // contribute zero rather than failing the chain.
+    let transactions = [
+      tx(daysFromEpoch: 3, accountId: accountId, quantity: -30, instrument: target),
+      tx(daysFromEpoch: 2, accountId: accountId, quantity: -20, instrument: spam),
+      tx(daysFromEpoch: 1, accountId: accountId, quantity: -10, instrument: target),
+    ]
+
+    let response = await TransactionPage.withRunningBalances(
+      transactions: transactions,
+      priorBalance: .zero(instrument: target),
+      accountId: accountId,
+      targetInstrument: target,
+      conversionService: FixedConversionService(knownZeroInstrumentIds: [spam.id])
+    )
+
+    #expect(response.rows.count == 3)
+    // No error surfaces — `.knownZero` is intentional, not a failure.
+    #expect(response.firstConversionError == nil)
+    // Every row has a balance — the spam leg folds to zero rather than
+    // breaking the chain.
+    #expect(response.rows.allSatisfy { $0.balance != nil })
+    // Running balance accumulates only the priced contributions:
+    // -10 (oldest) + 0 (spam) + -30 (newest) = -40.
+    let oldestBalance = response.rows.last?.balance?.quantity
+    let middleBalance = response.rows[1].balance?.quantity
+    let newestBalance = response.rows.first?.balance?.quantity
+    #expect(oldestBalance == -10)
+    #expect(middleBalance == -10)  // spam leg contributed zero
+    #expect(newestBalance == -40)
+  }
+
+  /// Issue #790: an account with a `.knownZero` source whose
+  /// account-scoped display amount sits cleanly at zero in the target
+  /// instrument. Per the issue's "or surface them as 'value unknown'"
+  /// permission, zero-contribution is the chosen UX.
+  @Test
+  func knownZeroLeg_displayAmountIsZero() async {
+    let accountId = UUID()
+    let spam = foreign
+    let transactions = [
+      tx(daysFromEpoch: 1, accountId: accountId, quantity: -10, instrument: spam)
+    ]
+
+    let response = await TransactionPage.withRunningBalances(
+      transactions: transactions,
+      priorBalance: .zero(instrument: target),
+      accountId: accountId,
+      targetInstrument: target,
+      conversionService: FixedConversionService(knownZeroInstrumentIds: [spam.id])
+    )
+
+    #expect(response.rows.count == 1)
+    #expect(response.firstConversionError == nil)
+    let row = response.rows[0]
+    #expect(row.balance == .zero(instrument: target))
+    #expect(row.displayAmount == .zero(instrument: target))
+  }
 }

--- a/MoolahTests/Features/BalanceCalculatorValuationModeTests.swift
+++ b/MoolahTests/Features/BalanceCalculatorValuationModeTests.swift
@@ -96,4 +96,85 @@ struct BalanceCalculatorValuationModeTests {
       for: [account], to: .AUD, using: cache)
     #expect(total == InstrumentAmount(quantity: 500, instrument: .AUD))
   }
+
+  // MARK: - .knownZero positions (issue #790)
+
+  /// Issue #790: positions whose conversion resolves to `.knownZero`
+  /// (an `.unpriced` / `.spam` crypto registration) contribute zero to
+  /// `displayBalance`, mixed with other priced positions. The balance
+  /// is computed (not throwing) so the user sees the priced portion.
+  @Test("displayBalance: .knownZero positions contribute zero alongside priced positions")
+  func displayBalance_knownZeroPositionsFoldToZero() async throws {
+    let spam = Instrument.crypto(
+      chainId: 10,
+      contractAddress: "0x7e087b1c173441f6c96b00231c1eab9e59f9a5a7",
+      symbol: "OP",
+      name: "Spam OP",
+      decimals: 18)
+    let calculator = AccountBalanceCalculator(
+      conversionService: FixedConversionService(
+        rates: ["USD": Decimal(15) / Decimal(10)],
+        knownZeroInstrumentIds: [spam.id]),
+      targetInstrument: .AUD)
+    var account = Account(
+      name: "Wallet", type: .crypto, instrument: .AUD,
+      valuationMode: .calculatedFromTrades)
+    account.positions = [
+      Position(instrument: .AUD, quantity: 100),
+      Position(instrument: .USD, quantity: 200),  // → 300 AUD via rate 1.5
+      Position(instrument: spam, quantity: 1_000_000),  // → 0
+    ]
+
+    let balance = try await calculator.displayBalance(
+      for: account, investmentValue: nil)
+    #expect(balance == InstrumentAmount(quantity: 400, instrument: .AUD))
+  }
+
+  /// Issue #790: a transient conversion failure (real provider outage)
+  /// must still throw — `.knownZero` is not a fallback for failed
+  /// conversions, only for intentionally-unpriced sources.
+  @Test("displayBalance: transient rate failure still throws")
+  func displayBalance_transientFailureStillThrows() async {
+    let usd = Instrument.USD
+    let conversion = FailingConversionService(failingInstrumentIds: [usd.id])
+    let calculator = AccountBalanceCalculator(
+      conversionService: conversion, targetInstrument: .AUD)
+    var account = Account(
+      name: "Bank", type: .bank, instrument: .AUD)
+    account.positions = [
+      Position(instrument: .AUD, quantity: 100),
+      Position(instrument: usd, quantity: 50),
+    ]
+
+    await #expect(throws: (any Error).self) {
+      _ = try await calculator.displayBalance(
+        for: account, investmentValue: nil)
+    }
+  }
+
+  /// Issue #790: `totalConverted` direct path (used by the sidebar's
+  /// per-account-positions aggregation) also folds `.knownZero` to zero.
+  @Test("totalConverted: .knownZero positions contribute zero")
+  func totalConverted_knownZeroFoldsToZero() async throws {
+    let spam = Instrument.crypto(
+      chainId: 10,
+      contractAddress: "0x7e087b1c173441f6c96b00231c1eab9e59f9a5a7",
+      symbol: "OP",
+      name: "Spam OP",
+      decimals: 18)
+    let calculator = AccountBalanceCalculator(
+      conversionService: FixedConversionService(
+        knownZeroInstrumentIds: [spam.id]),
+      targetInstrument: .AUD)
+    var account = Account(
+      name: "Wallet", type: .crypto, instrument: .AUD,
+      valuationMode: .calculatedFromTrades)
+    account.positions = [
+      Position(instrument: .AUD, quantity: 50),
+      Position(instrument: spam, quantity: 1_000_000),
+    ]
+    let total = try await calculator.totalConverted(
+      for: [account], to: .AUD)
+    #expect(total == InstrumentAmount(quantity: 50, instrument: .AUD))
+  }
 }

--- a/MoolahTests/Features/InvestmentStoreSpamFilterTests.swift
+++ b/MoolahTests/Features/InvestmentStoreSpamFilterTests.swift
@@ -1,0 +1,187 @@
+import Foundation
+import SwiftData
+import Testing
+
+@testable import Moolah
+
+/// Issue #790 — `.unpriced` / `.spam` crypto positions must not appear
+/// in the account's position list. Splits two scenarios that share the
+/// same fixture shape:
+///
+/// 1. Initial load: a position whose conversion already resolves to
+///    `.knownZero` is dropped from `valuedPositions` immediately.
+/// 2. Mid-session flip: marking a registration `.spam` from the
+///    Registered Tokens list fires `CryptoTokenStore.onRegistrationsChanged`,
+///    which `ProfileSession` wires to
+///    `InvestmentStore.revaluateLoadedPositions()`. The store
+///    recomputes against the freshly-updated registry and the spam
+///    position drops out without the user having to navigate away
+///    and back.
+@Suite("InvestmentStore — Spam / Unpriced Filter")
+@MainActor
+struct InvestmentStoreSpamFilterTests {
+
+  private func date(daysFromEpoch days: Int) -> Date {
+    Date(timeIntervalSince1970: TimeInterval(days * 86_400))
+  }
+
+  private let realOp = Instrument.crypto(
+    chainId: 10,
+    contractAddress: "0x4200000000000000000000000000000000000042",
+    symbol: "OP", name: "Optimism", decimals: 18)
+  private let spamOp = Instrument.crypto(
+    chainId: 10,
+    contractAddress: "0x7e087b1c173441f6c96b00231c1eab9e59f9a5a7",
+    symbol: "OP", name: "Spam OP", decimals: 18)
+
+  /// Sibling priced positions render normally and the portfolio total
+  /// excludes the unpriced contribution (zero by design).
+  @Test
+  func valuatePositions_dropsKnownZeroSpamFromList() async throws {
+    let accountId = UUID()
+    let aud = Instrument.AUD
+
+    let (backend, database) = try TestBackend.create()
+    TestBackend.seed(
+      accounts: [
+        Account(
+          id: accountId, name: "OP Wallet", type: .crypto, instrument: aud,
+          valuationMode: .calculatedFromTrades)
+      ], in: database)
+    TestBackend.seed(
+      transactions: [
+        Transaction(
+          date: date(daysFromEpoch: 19_900),
+          legs: [
+            TransactionLeg(
+              accountId: accountId, instrument: realOp,
+              quantity: Decimal(100), type: .transfer)
+          ]),
+        Transaction(
+          date: date(daysFromEpoch: 19_901),
+          legs: [
+            TransactionLeg(
+              accountId: accountId, instrument: spamOp,
+              quantity: Decimal(1_000_000), type: .transfer)
+          ]),
+      ], in: database)
+
+    let conversion = FixedConversionService(
+      rates: [realOp.id: Decimal(5)],
+      knownZeroInstrumentIds: [spamOp.id])
+    let store = InvestmentStore(
+      repository: backend.investments,
+      transactionRepository: backend.transactions,
+      conversionService: conversion)
+
+    await store.loadPositions(accountId: accountId)
+    #expect(store.positions.count == 2)  // Both legs land in `positions`.
+
+    await store.valuatePositions(profileCurrency: aud, on: Date())
+
+    // Only the priced position survives into `valuedPositions`.
+    #expect(store.valuedPositions.count == 1)
+    let surviving = try #require(store.valuedPositions.first)
+    #expect(surviving.instrument == realOp)
+    #expect(surviving.value?.quantity == Decimal(500))  // 100 * 5
+
+    #expect(store.totalPortfolioValue == Decimal(500))
+    #expect(store.error == nil)
+  }
+
+  @Test
+  func revaluateLoadedPositions_dropsNewlySpamMarkedFromList() async throws {
+    let accountId = UUID()
+    let aud = Instrument.AUD
+
+    let (backend, database) = try TestBackend.create()
+    let account = Account(
+      id: accountId, name: "OP Wallet", type: .crypto, instrument: aud,
+      valuationMode: .calculatedFromTrades)
+    TestBackend.seed(accounts: [account], in: database)
+    TestBackend.seed(
+      transactions: [
+        Transaction(
+          date: date(daysFromEpoch: 19_900),
+          legs: [
+            TransactionLeg(
+              accountId: accountId, instrument: realOp,
+              quantity: Decimal(100), type: .transfer)
+          ]),
+        Transaction(
+          date: date(daysFromEpoch: 19_901),
+          legs: [
+            TransactionLeg(
+              accountId: accountId, instrument: spamOp,
+              quantity: Decimal(1_000_000), type: .transfer)
+          ]),
+      ], in: database)
+
+    // Mutable stub modelling the `setStatus(.spam)` flip — both tokens
+    // start priced; the test flips spamOp to `.knownZero` mid-session.
+    let conversion = MutableKnownZeroConversionService(
+      rates: [realOp.id: Decimal(5), spamOp.id: Decimal(7)])
+    let store = InvestmentStore(
+      repository: backend.investments,
+      transactionRepository: backend.transactions,
+      conversionService: conversion)
+
+    await store.loadAllData(account: account, profileCurrency: aud)
+    #expect(store.valuedPositions.count == 2)
+
+    // ProfileSession's `onRegistrationsChanged` callback fires this
+    // method when a `setStatus(.spam)` lands in the registry.
+    await conversion.markKnownZero(spamOp.id)
+    await store.revaluateLoadedPositions()
+
+    #expect(store.valuedPositions.count == 1)
+    #expect(store.valuedPositions.first?.instrument == realOp)
+  }
+}
+
+/// Actor-isolated test stub modelling the `.knownZero` flip a
+/// `setStatus(.spam)` produces in production.
+private actor MutableKnownZeroConversionService: InstrumentConversionService {
+  private let rates: [String: Decimal]
+  private var knownZeroIds: Set<String> = []
+
+  init(rates: [String: Decimal] = [:]) {
+    self.rates = rates
+  }
+
+  func markKnownZero(_ id: String) {
+    knownZeroIds.insert(id)
+  }
+
+  func convert(
+    _ quantity: Decimal, from: Instrument, to: Instrument, on date: Date
+  ) async throws -> Decimal {
+    if from.id == to.id { return quantity }
+    if knownZeroIds.contains(from.id) {
+      throw ConversionError.noProviderMapping(instrumentId: from.id)
+    }
+    return quantity * (rates[from.id] ?? 1)
+  }
+
+  func convertAmount(
+    _ amount: InstrumentAmount, to instrument: Instrument, on date: Date
+  ) async throws -> InstrumentAmount {
+    guard amount.instrument != instrument else { return amount }
+    let converted = try await convert(
+      amount.quantity, from: amount.instrument, to: instrument, on: date)
+    return InstrumentAmount(quantity: converted, instrument: instrument)
+  }
+
+  func convertResult(
+    _ amount: InstrumentAmount, to instrument: Instrument, on date: Date
+  ) async throws -> ConversionResult {
+    if amount.instrument == instrument { return .value(amount) }
+    if knownZeroIds.contains(amount.instrument.id) {
+      return .knownZero(targetInstrument: instrument)
+    }
+    let converted = try await convertAmount(amount, to: instrument, on: date)
+    return .value(converted)
+  }
+
+  func invalidateCache(for instrument: Instrument) async {}
+}

--- a/MoolahTests/Shared/CompositeTokenResolutionClientTests.swift
+++ b/MoolahTests/Shared/CompositeTokenResolutionClientTests.swift
@@ -143,6 +143,70 @@ struct CompositeTokenResolutionClientTests {
     #expect(result.cryptocompareSymbol == "UNI")
   }
 
+  /// Issue #790: a spam ERC-20 whose user-supplied ticker collides with a
+  /// real token on Binance must NOT inherit that token's `<TICKER>USDT`
+  /// pair. The resolver's contract-based providers (CryptoCompare's
+  /// SmartContractAddress index, CoinGecko's `(platform, contract)`
+  /// lookup) are the only authority for ERC-20 identity; ticker-only
+  /// matches against Binance are forbidden.
+  @Test
+  func resolve_spamErc20WithCopiedTicker_doesNotInheritBinancePair() async throws {
+    // CryptoCompare lists the legitimate OP contract on OP-mainnet. The
+    // spam contract is intentionally absent.
+    let ccCoinList = Data(
+      """
+      {
+          "Data": {
+              "OP": {
+                  "Symbol": "OP",
+                  "CoinName": "Optimism",
+                  "SmartContractAddress": "0x4200000000000000000000000000000000000042"
+              }
+          }
+      }
+      """.utf8)
+
+    // Binance lists OPUSDT — the legitimate trading pair the spam token
+    // must not inherit.
+    let binanceInfo = Data(
+      """
+      {
+          "symbols": [
+              { "symbol": "OPUSDT", "baseAsset": "OP", "quoteAsset": "USDT", "status": "TRADING" }
+          ]
+      }
+      """.utf8)
+
+    let client = CompositeTokenResolutionClient(
+      coinListData: ccCoinList,
+      exchangeInfoData: binanceInfo,
+      coinGeckoApiKey: nil
+    )
+
+    // The spam contract from the issue's repro wallet, sharing ticker
+    // "OP" with the legitimate token.
+    let spam = try await client.resolve(
+      chainId: 10,
+      contractAddress: "0x7e087b1c173441f6c96b00231c1eab9e59f9a5a7",
+      symbol: "OP",
+      isNative: false
+    )
+    #expect(spam.cryptocompareSymbol == nil)
+    #expect(spam.binanceSymbol == nil)
+    #expect(spam.coingeckoId == nil)
+    #expect(!spam.hasAnyProviderId)
+
+    // Sanity: the legitimate contract still resolves cleanly.
+    let real = try await client.resolve(
+      chainId: 10,
+      contractAddress: "0x4200000000000000000000000000000000000042",
+      symbol: "OP",
+      isNative: false
+    )
+    #expect(real.cryptocompareSymbol == "OP")
+    #expect(real.binanceSymbol == "OPUSDT")
+  }
+
   @Test
   func resolve_nativeOnDifferentChainsAreDistinct() async throws {
     // Resolving native tokens on two different chainIds should not conflate them —

--- a/MoolahTests/Support/FixedConversionService.swift
+++ b/MoolahTests/Support/FixedConversionService.swift
@@ -3,17 +3,29 @@ import Foundation
 @testable import Moolah
 
 /// Test double for InstrumentConversionService. Returns fixed rates for non-profile instruments.
+///
+/// Pass `knownZeroInstrumentIds` to mark source instruments whose
+/// `convertResult(...)` should return `.knownZero` — modelling
+/// `.unpriced` / `.spam` crypto registrations under issue #790. Their
+/// `convert(...)` / `convertAmount(...)` calls still throw to keep the
+/// "real provider failure" path distinct, mirroring how a registration
+/// without a provider mapping behaves in production.
 struct FixedConversionService: InstrumentConversionService {
   let rates: [String: Decimal]
+  let knownZeroInstrumentIds: Set<String>
 
-  init(rates: [String: Decimal] = [:]) {
+  init(rates: [String: Decimal] = [:], knownZeroInstrumentIds: Set<String> = []) {
     self.rates = rates
+    self.knownZeroInstrumentIds = knownZeroInstrumentIds
   }
 
   func convert(
     _ quantity: Decimal, from: Instrument, to: Instrument, on date: Date
   ) async throws -> Decimal {
     if from.id == to.id { return quantity }
+    if knownZeroInstrumentIds.contains(from.id) {
+      throw FixedConversionError.knownZeroSource(instrumentId: from.id)
+    }
     guard let rate = rates[from.id] else {
       return quantity  // Default: 1:1
     }
@@ -33,9 +45,23 @@ struct FixedConversionService: InstrumentConversionService {
   func convertResult(
     _ amount: InstrumentAmount, to instrument: Instrument, on date: Date
   ) async throws -> ConversionResult {
+    if amount.instrument == instrument {
+      return .value(amount)
+    }
+    if knownZeroInstrumentIds.contains(amount.instrument.id) {
+      return .knownZero(targetInstrument: instrument)
+    }
     let converted = try await convertAmount(amount, to: instrument, on: date)
     return .value(converted)
   }
 
   func invalidateCache(for instrument: Instrument) async {}
+}
+
+/// Surfaces only when a test marks an instrument as `.knownZero` and a
+/// caller invokes `convert` / `convertAmount` rather than `convertResult`.
+/// Mirrors the production "no provider mapping" failure for
+/// `.unpriced` / `.spam` registrations.
+enum FixedConversionError: Error, Equatable {
+  case knownZeroSource(instrumentId: String)
 }

--- a/Shared/CompositeTokenResolutionClient.swift
+++ b/Shared/CompositeTokenResolutionClient.swift
@@ -31,7 +31,10 @@ struct CompositeTokenResolutionClient: TokenResolutionClient, Sendable {
   ) async throws -> TokenResolutionResult {
     var result = TokenResolutionResult()
 
-    // 1. CryptoCompare coin list
+    // 1. CryptoCompare coin list — natives match by symbol; ERC-20s match
+    //    only by `(chainId, contractAddress)`. The user-supplied ticker is
+    //    untrusted for ERC-20s (a spam contract can claim any ticker), so a
+    //    ticker-only fallback is intentionally excluded.
     let coinListData = try await fetchCoinListData()
     if isNative, let symbol {
       let nativeSymbols = try CryptoCompareClient.parseNativeSymbols(coinListData)
@@ -47,16 +50,9 @@ struct CompositeTokenResolutionClient: TokenResolutionClient, Sendable {
       }
     }
 
-    // 2. Binance exchange info
-    let exchangeInfoData = try await fetchExchangeInfoData()
-    let pairs = try BinanceClient.parseExchangeInfoResponse(exchangeInfoData)
-    let pairSymbol = (result.resolvedSymbol ?? symbol ?? "").uppercased()
-    let candidate = "\(pairSymbol)USDT"
-    if pairs.contains(candidate) {
-      result.binanceSymbol = candidate
-    }
-
-    // 3. CoinGecko (only with API key, only for contract tokens)
+    // 2. CoinGecko — contract-based lookup for ERC-20s only. Runs before
+    //    Binance so a CG-confirmed symbol can authorise the Binance pair
+    //    attribution (issue #790).
     if let apiKey = coinGeckoApiKey, !apiKey.isEmpty, !isNative, let contractAddress {
       do {
         let platformMapping = try await fetchAssetPlatforms(apiKey: apiKey)
@@ -77,6 +73,26 @@ struct CompositeTokenResolutionClient: TokenResolutionClient, Sendable {
         }
       } catch {
         // CoinGecko resolution is best-effort
+      }
+    }
+
+    // 3. Binance exchange info. Binance has no notion of `(chainId,
+    //    contractAddress)`, so for ERC-20s we only attempt the lookup when
+    //    a contract-based provider (CryptoCompare or CoinGecko) has
+    //    already confirmed the symbol's identity for this exact contract.
+    //    Without that gate, a spam ERC-20 with a copied ticker (e.g. a
+    //    fake "OP" on OP-mainnet) inherits the legitimate token's
+    //    `OPUSDT` mapping and poisons the running balance — see issue
+    //    #790. Native tokens may fall back to the input symbol because
+    //    `(chainId, isNative)` already pins identity.
+    let pairSymbolBase: String? =
+      isNative ? (result.resolvedSymbol ?? symbol) : result.resolvedSymbol
+    if let baseSymbol = pairSymbolBase?.uppercased(), !baseSymbol.isEmpty {
+      let exchangeInfoData = try await fetchExchangeInfoData()
+      let pairs = try BinanceClient.parseExchangeInfoResponse(exchangeInfoData)
+      let candidate = "\(baseSymbol)USDT"
+      if pairs.contains(candidate) {
+        result.binanceSymbol = candidate
       }
     }
 

--- a/Shared/PositionBook.swift
+++ b/Shared/PositionBook.swift
@@ -262,10 +262,11 @@ struct PositionBook: Equatable, Sendable {
   /// using the conversion service for non-target instruments. Single-instrument
   /// positions skip the conversion call.
   ///
-  /// Per-failure diagnostics: callers that swallow the thrown error (e.g. the
-  /// analysis pipeline skipping a day's balance) leave no trail of which
-  /// instrument/date failed. Log here so production diagnosis can identify
-  /// the offending conversion before re-throwing.
+  /// `.knownZero` source instruments (`.unpriced` / `.spam` crypto
+  /// registrations) contribute zero rather than failing the day's
+  /// aggregation — issue #790. Real provider errors keep their
+  /// per-instrument/date diagnostic log here (callers swallow the
+  /// thrown error in the analysis pipeline) before re-throwing.
   private func convert(
     _ positions: [Instrument: Decimal],
     to target: Instrument,
@@ -276,20 +277,25 @@ struct PositionBook: Equatable, Sendable {
     for (instrument, quantity) in positions {
       if instrument == target {
         total += quantity
-      } else {
-        do {
-          total += try await service.convert(quantity, from: instrument, to: target, on: date)
-        } catch {
-          logger.warning(
-            """
-            PositionBook conversion failed: \
-            \(quantity, privacy: .public) \(instrument.id, privacy: .public) \
-            → \(target.id, privacy: .public) on \(date, privacy: .public): \
-            \(error.localizedDescription, privacy: .public)
-            """
-          )
-          throw error
+        continue
+      }
+      do {
+        let amount = InstrumentAmount(quantity: quantity, instrument: instrument)
+        let result = try await service.convertResult(amount, to: target, on: date)
+        switch result {
+        case .value(let converted): total += converted.quantity
+        case .knownZero: continue
         }
+      } catch {
+        logger.warning(
+          """
+          PositionBook conversion failed: \
+          \(quantity, privacy: .public) \(instrument.id, privacy: .public) \
+          → \(target.id, privacy: .public) on \(date, privacy: .public): \
+          \(error.localizedDescription, privacy: .public)
+          """
+        )
+        throw error
       }
     }
     return total

--- a/Shared/PositionsValuator.swift
+++ b/Shared/PositionsValuator.swift
@@ -12,12 +12,18 @@ import OSLog
 ///   a row with `value == nil`. Sibling rows still receive their successful
 ///   values. The aggregate visibility of the total / chart is the caller's
 ///   responsibility (see `PositionsViewInput.totalValue`).
+///
+/// `.knownZero` source instruments (`.unpriced` / `.spam` crypto
+/// registrations) are dropped from the result entirely — issue #790. The
+/// user triaged them via the inbox / "Mark as Spam" affordance and
+/// shouldn't see them resurface in the account's positions table.
 struct PositionsValuator: Sendable {
   let conversionService: any InstrumentConversionService
   private let logger = Logger(
     subsystem: "com.moolah.app", category: "PositionsValuator")
 
-  /// Build one `ValuedPosition` per input position.
+  /// Build one `ValuedPosition` per input position whose conversion did
+  /// not resolve to `.knownZero`.
   ///
   /// - Parameters:
   ///   - positions: raw quantities per instrument (zeroes filtered upstream).
@@ -25,8 +31,8 @@ struct PositionsValuator: Sendable {
   ///   - costBasis: remaining cost basis per instrument id, expressed in
   ///     `hostCurrency`. Use `[:]` when no cost basis is known (flow context).
   ///   - on: valuation date.
-  /// - Returns: rows in input order. Never throws — failures map to
-  ///   `value == nil` per row.
+  /// - Returns: surviving rows in input order. Failures map to `value == nil`;
+  ///   `.knownZero` sources are dropped. Never throws.
   func valuate(
     positions: [Position],
     hostCurrency: Instrument,
@@ -41,8 +47,11 @@ struct PositionsValuator: Sendable {
     // of positions per account this view targets. If profiling later shows cold
     // loads are user-visible, switching to withTaskGroup is a self-contained change.
     for position in positions {
-      rows.append(
-        await row(for: position, hostCurrency: hostCurrency, costBasis: costBasis, on: date))
+      if let entry = await row(
+        for: position, hostCurrency: hostCurrency, costBasis: costBasis, on: date)
+      {
+        rows.append(entry)
+      }
     }
     return rows
   }
@@ -52,7 +61,7 @@ struct PositionsValuator: Sendable {
     hostCurrency: Instrument,
     costBasis: [String: Decimal],
     on date: Date
-  ) async -> ValuedPosition {
+  ) async -> ValuedPosition? {
     let cost: InstrumentAmount? = costBasis[position.instrument.id].map {
       InstrumentAmount(quantity: $0, instrument: hostCurrency)
     }
@@ -68,26 +77,36 @@ struct PositionsValuator: Sendable {
     }
 
     do {
-      let total = try await conversionService.convert(
-        position.quantity, from: position.instrument, to: hostCurrency, on: date
-      )
-      // For short positions (negative quantity), `total` and `position.quantity`
-      // share the negative sign, so the quotient yields a positive per-unit price
-      // — the natural reading of "what one share is worth right now". The zero
-      // guard prevents NaN from propagating into the rendered amount; we accept
-      // that a service returning total == 0 yields unitPrice == 0 (which is rare
-      // and visually obvious as "free", which is correct for the data we have).
-      let unit: InstrumentAmount? =
-        position.quantity == 0
-        ? nil
-        : InstrumentAmount(quantity: total / position.quantity, instrument: hostCurrency)
-      return ValuedPosition(
-        instrument: position.instrument,
-        quantity: position.quantity,
-        unitPrice: unit,
-        costBasis: cost,
-        value: InstrumentAmount(quantity: total, instrument: hostCurrency)
-      )
+      let amount = InstrumentAmount(
+        quantity: position.quantity, instrument: position.instrument)
+      let result = try await conversionService.convertResult(
+        amount, to: hostCurrency, on: date)
+      switch result {
+      case .knownZero:
+        // `.unpriced` / `.spam` crypto source — drop the row entirely
+        // so it stops appearing in the account's positions table.
+        // Issue #790.
+        return nil
+      case .value(let converted):
+        let total = converted.quantity
+        // For short positions (negative quantity), `total` and `position.quantity`
+        // share the negative sign, so the quotient yields a positive per-unit price
+        // — the natural reading of "what one share is worth right now". The zero
+        // guard prevents NaN from propagating into the rendered amount; we accept
+        // that a service returning total == 0 yields unitPrice == 0 (which is rare
+        // and visually obvious as "free", which is correct for the data we have).
+        let unit: InstrumentAmount? =
+          position.quantity == 0
+          ? nil
+          : InstrumentAmount(quantity: total / position.quantity, instrument: hostCurrency)
+        return ValuedPosition(
+          instrument: position.instrument,
+          quantity: position.quantity,
+          unitPrice: unit,
+          costBasis: cost,
+          value: converted
+        )
+      }
     } catch {
       logger.warning(
         "Failed to valuate position \(position.instrument.id, privacy: .public): \(error.localizedDescription, privacy: .public)"


### PR DESCRIPTION
## Summary

Fixes [#790](https://github.com/ajsutton/moolah-native/issues/790) in three layers:

- **Resolver tightened** — `CompositeTokenResolutionClient` no longer ticker-fallbacks Binance lookups for ERC-20 sources. A spam OP contract on OP-mainnet now lands as `.unpriced` instead of inheriting the legitimate `OPUSDT` mapping. Native tokens still fall back to the input symbol since `(chainId, isNative)` already pins identity.
- **Aggregations honour `.knownZero`** — running balance, account-balance calculator, daily / forecast / income-expense analysis, `PositionBook`, earmark balances, and `InvestmentStore.valuedPositions` now route through `convertResult`. `.unpriced` / `.spam` sources fold to zero rather than poisoning the day or blanking the whole total. Genuine rate-fetch failures still throw and surface "unavailable" per Rule 11 of `INSTRUMENT_CONVERSION_GUIDE.md`.
- **UI** — Registered Tokens preferences row gains an inline `Menu` (`⊙` button) with **Mark as Spam** + **Remove**, plus a truncated contract address so wallets with copied tickers can be told apart. `CryptoTokenStore.registrationsVersion` ticks on every mutation; `TransactionListView` keys its position-valuator `.task(id:)` on `(positions, registrationsVersion)` so a spam flip refreshes the visible position list immediately. `ProfileSession` wires `onRegistrationsChanged → InvestmentStore.revaluateLoadedPositions()` for the same reason.

`PositionsValuator.valuate` and `InvestmentStore.valuate` now drop `.knownZero` rows from the visible positions table — the user explicitly triaged the token; it shouldn't reappear.

## Test plan

- [x] `just format-check` clean
- [x] Full unit suite — 2476 tests pass on macOS
- [x] New tests:
  - `CompositeTokenResolutionClientTests.resolve_spamErc20WithCopiedTicker_doesNotInheritBinancePair` — spam contract from the issue's repro wallet
  - `TransactionRunningBalanceTests.knownZeroLegContributesZeroAndDoesNotBreakBalance` + `_displayAmountIsZero`
  - `BalanceCalculatorValuationModeTests` — `.knownZero` positions, transient-failure still throws, `totalConverted` `.knownZero`
  - `InvestmentStoreSpamFilterTests.valuatePositions_dropsKnownZeroSpamFromList` + `revaluateLoadedPositions_dropsNewlySpamMarkedFromList`
- [x] Manual verification with the OP-mainnet repro wallet: spam OPs disappear from the positions list immediately after **Mark as Spam**.
- [x] Earlier `.contextMenu` + `.swipeActions` + `.onDelete` stack on the Registered Tokens row crashed `ForEachState`; the `Menu` rewrite avoids it.

## Notes

- An earlier follow-on bug ([#791](https://github.com/ajsutton/moolah-native/issues/791) — `10:native` failing `unsupportedConversion`) was filed and shipped separately as [#792](https://github.com/ajsutton/moolah-native/pull/792); this branch is rebased on that fix.
- Existing pre-#790 wallets have `.priced` rows for spam contracts on disk. The new contract-address column + Mark-as-Spam menu lets users clean those up; resolver tightening prevents new ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)