### PR TITLE
fix(crypto): seed built-in crypto presets at profile startup

### DIFF
--- a/App/ProfileSession.swift
+++ b/App/ProfileSession.swift
@@ -219,9 +219,28 @@ final class ProfileSession: Identifiable {
       cryptoPriceService: cryptoPriceService)
     self.cryptoSyncStore = cryptoWiring?.store
     self.cryptoTokenDiscovery = cryptoWiring?.discovery
+    seedBuiltInCryptoPresets(registry: cryptoRegistry)
     wireCrossStoreSideEffects()
     registerWithSyncCoordinator(syncCoordinator)
     startPeriodicPragmaOptimize()
+  }
+
+  /// Fires `registerBuiltInPresetsIfMissing` on the profile's registry
+  /// so chain native gas tokens (ETH on Ethereum / OP / Base; MATIC on
+  /// Polygon) and well-known ERC-20s carry a real provider mapping
+  /// before any conversion path consults the registry. Without this,
+  /// transaction detail / running-balance render fails for crypto legs
+  /// the very first time a profile reads them — issue #791. Tracked in
+  /// `crossStoreUpdateTasks` so `cleanupSync` cancels in-flight seeds
+  /// when the session tears down.
+  private func seedBuiltInCryptoPresets(
+    registry: (any InstrumentRegistryRepository)?
+  ) {
+    guard let registry else { return }
+    let task = Task {
+      await registry.registerBuiltInPresetsIfMissing()
+    }
+    crossStoreUpdateTasks.append(task)
   }
 
   /// Wires the investment-store -> account-store callback. The spawned

--- a/Domain/Models/CryptoRegistration.swift
+++ b/Domain/Models/CryptoRegistration.swift
@@ -39,6 +39,16 @@ struct CryptoRegistration: Codable, Sendable, Hashable, Identifiable {
       try container.decodeIfPresent(TokenPricingStatus.self, forKey: .pricingStatus) ?? .priced
   }
 
+  /// Hand-curated registrations seeded into every profile at session
+  /// startup so common chain native gas tokens (ETH on Ethereum / OP /
+  /// Base; MATIC on Polygon) and well-known ERC-20s (OP, UNI, ENS, plus
+  /// the canonical BTC entry) carry a real provider mapping before any
+  /// transaction references them. Without this seed, wallet sync's
+  /// `ensureInstrumentReadable` would land a placeholder
+  /// `InstrumentRow` with `pricingStatus=.priced` and no mapping —
+  /// which `allCryptoRegistrations()` projects to nil and which
+  /// `cryptoUsdPrice` then can't resolve, throwing
+  /// `ConversionError.noProviderMapping`. See issue #791.
   static let builtInPresets: [CryptoRegistration] = [
     CryptoRegistration(
       instrument: .crypto(
@@ -54,6 +64,30 @@ struct CryptoRegistration: Codable, Sendable, Hashable, Identifiable {
       mapping: CryptoProviderMapping(
         instrumentId: "1:native", coingeckoId: "ethereum",
         cryptocompareSymbol: "ETH", binanceSymbol: "ETHUSDT"
+      )
+    ),
+    CryptoRegistration(
+      instrument: .crypto(
+        chainId: 10, contractAddress: nil, symbol: "ETH", name: "Ethereum", decimals: 18),
+      mapping: CryptoProviderMapping(
+        instrumentId: "10:native", coingeckoId: "ethereum",
+        cryptocompareSymbol: "ETH", binanceSymbol: "ETHUSDT"
+      )
+    ),
+    CryptoRegistration(
+      instrument: .crypto(
+        chainId: 8453, contractAddress: nil, symbol: "ETH", name: "Ethereum", decimals: 18),
+      mapping: CryptoProviderMapping(
+        instrumentId: "8453:native", coingeckoId: "ethereum",
+        cryptocompareSymbol: "ETH", binanceSymbol: "ETHUSDT"
+      )
+    ),
+    CryptoRegistration(
+      instrument: .crypto(
+        chainId: 137, contractAddress: nil, symbol: "MATIC", name: "Polygon", decimals: 18),
+      mapping: CryptoProviderMapping(
+        instrumentId: "137:native", coingeckoId: "matic-network",
+        cryptocompareSymbol: "MATIC", binanceSymbol: "MATICUSDT"
       )
     ),
     CryptoRegistration(

--- a/Domain/Repositories/InstrumentRegistryRepository+Presets.swift
+++ b/Domain/Repositories/InstrumentRegistryRepository+Presets.swift
@@ -1,0 +1,40 @@
+// Domain/Repositories/InstrumentRegistryRepository+Presets.swift
+import Foundation
+import OSLog
+
+extension InstrumentRegistryRepository {
+  /// Seed every `CryptoRegistration.builtInPresets` entry that is not
+  /// already registered with a provider mapping. Idempotent: presets
+  /// whose `cryptoRegistration(byId:)` resolves to a non-nil
+  /// registration are skipped — the existing mapping wins.
+  ///
+  /// Provides the offline-first, no-network path that lets transaction
+  /// detail / running-balance / aggregation render correctly the very
+  /// first time a profile session reads a crypto leg, without waiting
+  /// for wallet sync to fire (issue #791). Per-preset failures are
+  /// logged and skipped so a single bad row doesn't block the rest.
+  ///
+  /// Cancellation propagates immediately. Best-effort otherwise.
+  func registerBuiltInPresetsIfMissing() async {
+    let logger = Logger(
+      subsystem: "com.moolah.app", category: "InstrumentRegistryPresets")
+    for preset in CryptoRegistration.builtInPresets {
+      do {
+        try Task.checkCancellation()
+        if try await cryptoRegistration(byId: preset.id) != nil {
+          continue
+        }
+        try await registerCrypto(preset.instrument, mapping: preset.mapping)
+      } catch is CancellationError {
+        return
+      } catch {
+        logger.warning(
+          """
+          registerBuiltInPresetsIfMissing: \(preset.id, privacy: .public): \
+          \(error.localizedDescription, privacy: .public)
+          """
+        )
+      }
+    }
+  }
+}

--- a/MoolahTests/Domain/CryptoProviderMappingTests.swift
+++ b/MoolahTests/Domain/CryptoProviderMappingTests.swift
@@ -59,13 +59,21 @@ struct CryptoProviderMappingTests {
   // MARK: - Built-in presets
 
   @Test
-  func builtInPresetsContainExpectedTokens() {
+  func builtInPresetsContainExpectedTokens() throws {
     let presets = CryptoProviderMapping.builtInPresets
-    #expect(presets.count == 5)
 
-    let btc = presets.first { $0.instrumentId == "0:native" }!
+    let btc = try #require(presets.first { $0.instrumentId == "0:native" })
     #expect(btc.coingeckoId == "bitcoin")
     #expect(btc.cryptocompareSymbol == "BTC")
     #expect(btc.binanceSymbol == "BTCUSDT")
+
+    // Every chain native gas instrument carries a real provider
+    // mapping so transaction detail / running-balance / aggregation
+    // resolves them from session start (issue #791).
+    for id in ["1:native", "10:native", "137:native", "8453:native"] {
+      let preset = try #require(presets.first { $0.instrumentId == id })
+      #expect(preset.cryptocompareSymbol != nil, "missing CC mapping for \(id)")
+      #expect(preset.binanceSymbol != nil, "missing Binance mapping for \(id)")
+    }
   }
 }


### PR DESCRIPTION
## Summary

Follow-up to #792. Test profiles that synced before #792 landed still carry buggy `InstrumentRow`s — `pricingStatus=.priced` with no provider mapping for `10:native`, `137:native`, etc. — and read-time paths (transaction detail, running balance) keep tripping `ConversionError.noProviderMapping` even though wallet sync would now register them correctly.

Seed `CryptoRegistration.builtInPresets` into the registry on every profile session start. The preset list grows to cover every chain native supported by `ChainConfig.all` (ETH on 1 / 10 / 8453, MATIC on 137) alongside the existing curated ERC-20s (BTC, OP, UNI, ENS). The seed runs as a tracked, cancellable `Task<Void, Never>` and is idempotent — `cryptoRegistration(byId:)` fast-paths over rows that already carry a real mapping, so the seed only writes when the registry is missing one. User-flagged `.unpriced` / `.spam` classifications stay untouched.

This handles both "never seen" and "seen-but-buggy" rows without a one-shot migration, and gives the running-balance / transaction-detail conversion paths a populated registry the very first time they read a crypto leg.

## Refs
- Builds on #792
- Issue #791

## Test plan

- [x] `MoolahTests/Domain/CryptoProviderMappingTests/builtInPresetsContainExpectedTokens` updated to assert chain-native entries carry CryptoCompare + Binance mappings.
- [x] `just test-mac` — 2471/2471 pass in 401 suites.
- [x] `just format-check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)