### PR TITLE
fix(crypto): emit .income / .expense for unpaired wallet legs (and crash fix)

### DIFF
--- a/Features/Transactions/Views/Detail/TransactionDetailAccountSection.swift
+++ b/Features/Transactions/Views/Detail/TransactionDetailAccountSection.swift
@@ -36,14 +36,19 @@ struct TransactionDetailAccountSection: View {
         }
       }
 
-      if draft.type == .transfer {
-        transferRows
+      if draft.type == .transfer, let counterpartIndex = draft.counterpartLegIndex {
+        transferRows(counterpartIndex: counterpartIndex)
       }
     }
   }
 
-  @ViewBuilder private var transferRows: some View {
-    let counterpartIndex = draft.relevantLegIndex == 0 ? 1 : 0
+  /// Renders the counterpart-account picker (and, when cross-currency,
+  /// the converted-amount row) for a two-leg transfer. Wallet-imported
+  /// transfers have only one leg (the counterparty is an external
+  /// chain address, not a moolah account), so the call site guards on
+  /// `counterpartLegIndex != nil` before invoking — see issue #791.
+  @ViewBuilder
+  private func transferRows(counterpartIndex: Int) -> some View {
     let toAccountLabel = draft.showFromAccount ? "From Account" : "To Account"
     let currentAccountId = draft.legDrafts[draft.relevantLegIndex].accountId
     let counterpartId = draft.legDrafts[counterpartIndex].accountId

--- a/MoolahTests/Shared/CryptoImport/CrossAccountTransferMergerTests.swift
+++ b/MoolahTests/Shared/CryptoImport/CrossAccountTransferMergerTests.swift
@@ -105,24 +105,26 @@ struct CrossAccountTransferMergerTests {
   @Test("Fee legs from both sides are preserved on the merged transaction")
   func preservesFeeLegsOnMerge() async throws {
     let gasInstrument = TestInstruments.ethereum
+    // Fee legs use the `:gas` `externalId` suffix per
+    // `TransferReceiptCoalescer.gasLegExternalId(hash:)` so they're
+    // distinguishable from the value-bearing leg by externalId alone —
+    // both legs are `.expense`-typed when the value side is outbound.
     let outboundFee = TransactionLeg(
       accountId: Self.accountA,
       instrument: gasInstrument,
       quantity: try #require(Decimal(string: "-0.001")),
-      externalId: Self.hash,
+      externalId: "\(Self.hash):gas",
       type: .expense)
     let outbound = makeBuiltTransaction(
       accountId: Self.accountA, hash: Self.hash,
       instrument: gasInstrument, quantity: -1,
       extraLegs: [outboundFee])
 
-    // Inbound side — different chain native, different fee instrument
-    // to keep the value vs. fee distinction obvious.
     let inboundFee = TransactionLeg(
       accountId: Self.accountB,
       instrument: gasInstrument,
       quantity: try #require(Decimal(string: "-0.0005")),
-      externalId: Self.hash,
+      externalId: "\(Self.hash):gas",
       type: .expense)
     let inbound = makeBuiltTransaction(
       accountId: Self.accountB, hash: Self.hash,
@@ -135,7 +137,12 @@ struct CrossAccountTransferMergerTests {
 
     #expect(merged.count == 1)
     let result = try #require(merged.first)
-    let feeLegs = result.transaction.legs.filter { $0.type == .expense }
+    // Filter by the `:gas` `externalId` suffix; value-bearing
+    // outbound legs are now `.expense` too, so type alone no longer
+    // disambiguates fee from value.
+    let feeLegs = result.transaction.legs.filter {
+      $0.externalId?.hasSuffix(":gas") == true
+    }
     #expect(feeLegs.count == 2)
   }
 
@@ -143,12 +150,15 @@ struct CrossAccountTransferMergerTests {
 
   @Test("In-batch candidate pairs against a leg already persisted on a prior cycle")
   func mergesAgainstExistingPersistedLeg() async throws {
+    // Prior-cycle outbound leg, persisted by an earlier sync. The
+    // wallet importer would have written this as `.expense` per its
+    // per-account type rule.
     let priorCycleLeg = TransactionLeg(
       accountId: Self.accountA,
       instrument: TestInstruments.ethereum,
       quantity: -1,
       externalId: Self.hash,
-      type: .transfer)
+      type: .expense)
 
     let inbound = makeBuiltTransaction(
       accountId: Self.accountB, hash: Self.hash,
@@ -217,12 +227,16 @@ struct CrossAccountTransferMergerTests {
     date: Date = Date(timeIntervalSince1970: 1_700_000_000),
     extraLegs: [TransactionLeg] = []
   ) -> BuiltTransaction {
+    // Wallet importer types: outbound (negative qty) → `.expense`,
+    // inbound (positive qty) → `.income`. The merger then pairs
+    // (.income, .expense) tuples on opposing-sign quantities.
+    let legType: TransactionType = quantity >= 0 ? .income : .expense
     let transferLeg = TransactionLeg(
       accountId: accountId,
       instrument: instrument,
       quantity: quantity,
       externalId: hash,
-      type: .transfer)
+      type: legType)
     let transaction = Transaction(
       date: date,
       legs: [transferLeg] + extraLegs,

--- a/MoolahTests/Shared/CryptoImport/CrossDeviceLegDeduperTestSupport.swift
+++ b/MoolahTests/Shared/CryptoImport/CrossDeviceLegDeduperTestSupport.swift
@@ -95,7 +95,10 @@ enum CrossDeviceLegDeduperTestSupport {
     externalId: String,
     quantity: Decimal = -1
   ) -> Transaction {
-    Transaction(
+    // Mirror `TransferEventBuilder`'s per-account types: positive
+    // quantity → `.income`, negative → `.expense`.
+    let legType: TransactionType = quantity >= 0 ? .income : .expense
+    return Transaction(
       id: id,
       date: Self.date,
       legs: [
@@ -103,7 +106,7 @@ enum CrossDeviceLegDeduperTestSupport {
           accountId: accountId,
           quantity: quantity,
           externalId: externalId,
-          type: .transfer)
+          type: legType)
       ])
   }
 

--- a/MoolahTests/Shared/CryptoImport/TransferEventBuilderGasCoalescingTests.swift
+++ b/MoolahTests/Shared/CryptoImport/TransferEventBuilderGasCoalescingTests.swift
@@ -143,7 +143,11 @@ struct TransferEventBuilderGasCoalescingTests {
 
     #expect(alchemy.recordedReceiptCalls == ["0xmulti"])
     let candidate = try #require(built.first)
-    let gasLegs = candidate.transaction.legs.filter { $0.type == .expense }
+    // Filter by the gas leg's `:gas` `externalId` suffix; outbound value
+    // legs are now `.expense` too, so type alone no longer disambiguates.
+    let gasLegs = candidate.transaction.legs.filter {
+      $0.externalId?.hasSuffix(":gas") == true
+    }
     #expect(gasLegs.count == 1)
   }
 }

--- a/MoolahTests/Shared/CryptoImport/TransferEventBuilderGasLegTests.swift
+++ b/MoolahTests/Shared/CryptoImport/TransferEventBuilderGasLegTests.swift
@@ -55,12 +55,15 @@ struct TransferEventBuilderGasLegTests {
 
     let candidate = try #require(built.first)
     #expect(candidate.transaction.legs.count == 2)
+    // Outbound + gas: both legs are `.expense` per the wallet
+    // importer's per-account types — disambiguate by the gas leg's
+    // `:gas` `externalId` suffix.
     let transferLeg = try #require(
-      candidate.transaction.legs.first(where: { $0.type == .transfer }))
+      candidate.transaction.legs.first(where: { $0.externalId == "0xeth-send:0" }))
     let gasLeg = try #require(
-      candidate.transaction.legs.first(where: { $0.type == .expense }))
-    #expect(transferLeg.externalId == "0xeth-send:0")
-    #expect(gasLeg.externalId == "0xeth-send:gas")
+      candidate.transaction.legs.first(where: { $0.externalId == "0xeth-send:gas" }))
+    #expect(transferLeg.type == .expense)
+    #expect(gasLeg.type == .expense)
     #expect(gasLeg.instrument == ChainConfig.ethereum.nativeInstrument)
     #expect(gasLeg.quantity == -Self.expectedFeeEth)
     #expect(gasLeg.accountId == account.id)
@@ -106,14 +109,14 @@ struct TransferEventBuilderGasLegTests {
     let candidate = try #require(built.first)
     #expect(candidate.transaction.legs.count == 2)
     let transferLeg = try #require(
-      candidate.transaction.legs.first(where: { $0.type == .transfer }))
+      candidate.transaction.legs.first(where: { $0.externalId == "0xerc20-send:0" }))
     let gasLeg = try #require(
-      candidate.transaction.legs.first(where: { $0.type == .expense }))
+      candidate.transaction.legs.first(where: { $0.externalId == "0xerc20-send:gas" }))
+    #expect(transferLeg.type == .expense)
+    #expect(gasLeg.type == .expense)
     #expect(transferLeg.instrument.contractAddress == Self.usdcAddress.lowercased())
     #expect(gasLeg.instrument == ChainConfig.ethereum.nativeInstrument)
     #expect(gasLeg.quantity == -Self.expectedFeeEth)
-    #expect(gasLeg.externalId == "0xerc20-send:gas")
-    #expect(transferLeg.externalId == "0xerc20-send:0")
   }
 
   // MARK: - Inbound never gets a gas leg
@@ -141,13 +144,15 @@ struct TransferEventBuilderGasLegTests {
 
     let candidate = try #require(built.first)
     #expect(candidate.transaction.legs.count == 1)
-    #expect(candidate.transaction.legs.allSatisfy { $0.type == .transfer })
+    // Inbound from a non-moolah address: the leg is `.income`, not
+    // `.transfer` — `.transfer` is reserved for cross-account pairs.
+    #expect(candidate.transaction.legs.allSatisfy { $0.type == .income })
     #expect(alchemy.recordedReceiptCalls.isEmpty)
   }
 
   // MARK: - Self-send still pays gas
 
-  @Test("Self-send → transfer leg + gas leg (gas is paid even on self-send)")
+  @Test("Self-send → income leg + gas leg (gas is paid even on self-send)")
   func selfSendStillProducesGasLeg() async throws {
     let subject = makeDiscoverySubject()
     let alchemy = RecordingAlchemyClientStub()
@@ -179,7 +184,9 @@ struct TransferEventBuilderGasLegTests {
 
     let candidate = try #require(built.first)
     let types = candidate.transaction.legs.map(\.type)
-    #expect(types.filter { $0 == .transfer }.count == 1)
+    // Self-send: value leg is typed `.income` (positive quantity), gas
+    // leg is `.expense`.
+    #expect(types.filter { $0 == .income }.count == 1)
     #expect(types.filter { $0 == .expense }.count == 1)
   }
 
@@ -228,13 +235,13 @@ struct TransferEventBuilderGasLegTests {
       built.first { candidate in
         candidate.transaction.legs.contains { $0.externalId == "0xbad:0" }
       })
-    // Good event keeps both legs.
+    // Good event keeps both legs (value + gas, both `.expense`).
     #expect(goodCandidate.transaction.legs.count == 2)
-    #expect(goodCandidate.transaction.legs.contains { $0.type == .expense })
-    // Bad event keeps the transfer leg but skips gas — receipt failure
+    #expect(goodCandidate.transaction.legs.allSatisfy { $0.type == .expense })
+    // Bad event keeps the value leg but skips gas — receipt failure
     // must not corrupt the account-level result.
     #expect(badCandidate.transaction.legs.count == 1)
-    #expect(badCandidate.transaction.legs.allSatisfy { $0.type == .transfer })
+    #expect(badCandidate.transaction.legs.allSatisfy { $0.type == .expense })
   }
 
 }

--- a/MoolahTests/Shared/CryptoImport/TransferEventBuilderTests.swift
+++ b/MoolahTests/Shared/CryptoImport/TransferEventBuilderTests.swift
@@ -46,7 +46,11 @@ struct TransferEventBuilderTests {
     #expect(candidate.originAccountId == account.id)
     #expect(candidate.transaction.legs.count == 1)
     let leg = try #require(candidate.transaction.legs.first)
-    #expect(leg.type == .transfer)
+    // Outbound external transfer to a non-moolah address: from this
+    // account's perspective the wallet paid out (= `.expense`). The
+    // cross-account merger promotes paired (.income, .expense) shapes
+    // when the counterparty *is* a moolah-tracked account.
+    #expect(leg.type == .expense)
     #expect(leg.accountId == account.id)
     #expect(leg.externalId == "0xeth-send:0")
     #expect(leg.instrument == ChainConfig.ethereum.nativeInstrument)
@@ -88,7 +92,7 @@ struct TransferEventBuilderTests {
     let candidate = try #require(built.first)
     #expect(candidate.transaction.legs.count == 1)
     let leg = try #require(candidate.transaction.legs.first)
-    #expect(leg.type == .transfer)
+    #expect(leg.type == .expense)
     #expect(leg.externalId == "0xerc20-send:0")
     #expect(leg.instrument.kind == .cryptoToken)
     #expect(leg.instrument.contractAddress == Self.usdcAddress.lowercased())
@@ -121,7 +125,8 @@ struct TransferEventBuilderTests {
     let candidate = try #require(built.first)
     #expect(candidate.transaction.legs.count == 1)
     let leg = try #require(candidate.transaction.legs.first)
-    #expect(leg.type == .transfer)
+    // Inbound from a non-moolah address: the wallet received (= `.income`).
+    #expect(leg.type == .income)
     #expect(leg.quantity == Decimal(1))
     #expect(leg.externalId == "0xreceive:0")
   }

--- a/MoolahTests/Shared/CryptoImport/WalletApplyEngineTests.swift
+++ b/MoolahTests/Shared/CryptoImport/WalletApplyEngineTests.swift
@@ -54,13 +54,14 @@ struct WalletApplyEngineTests {
     let hash = "0xseen-before"
 
     // Pre-seed a transaction with the same `(accountId, externalId)`
-    // pair so the dedup step has something to find.
+    // pair so the dedup step has something to find. Wallet importer's
+    // per-account leg type is `.expense` for outbound (negative qty).
     let priorLeg = TransactionLeg(
       accountId: accountA.id,
       instrument: ChainConfig.ethereum.nativeInstrument,
       quantity: -1,
       externalId: hash,
-      type: .transfer)
+      type: .expense)
     _ = try await setup.backend.transactions.create(
       Transaction(
         date: Self.pinnedNow.addingTimeInterval(-3_600),
@@ -186,12 +187,15 @@ struct WalletApplyEngineTests {
     hash: String,
     quantity: Decimal
   ) -> BuiltTransaction {
+    // Mirror `TransferEventBuilder`'s per-account types: positive
+    // quantity (inbound) → `.income`, negative (outbound) → `.expense`.
+    let legType: TransactionType = quantity >= 0 ? .income : .expense
     let leg = TransactionLeg(
       accountId: accountId,
       instrument: ChainConfig.ethereum.nativeInstrument,
       quantity: quantity,
       externalId: hash,
-      type: .transfer)
+      type: legType)
     let transaction = Transaction(
       date: Self.pinnedNow,
       legs: [leg],

--- a/Shared/CryptoImport/CrossAccountTransferMerger.swift
+++ b/Shared/CryptoImport/CrossAccountTransferMerger.swift
@@ -107,20 +107,25 @@ struct LiveCrossAccountTransferMerger: CrossAccountTransferMerger {
 
   // MARK: - Pairing predicate
 
-  /// Both legs are `.transfer`, share an `externalId`, share an
-  /// instrument, sit on different accounts, and carry equal-magnitude
-  /// opposite-sign quantities. Strict equality on magnitude — if a real
-  /// decimal-precision-drift case arises a small epsilon could be added,
-  /// but ETH / ERC-20 amounts are exact decimals reconstructed from the
-  /// same hex value on each side, so drift is not expected.
+  /// One leg is `.income`, the other is `.expense` (the per-account
+  /// types that `TransferEventBuilder` emits before pairing). Both
+  /// share an `externalId`, share an instrument, sit on different
+  /// accounts, and carry equal-magnitude opposite-sign quantities.
+  /// Strict equality on magnitude — if a real decimal-precision-drift
+  /// case arises a small epsilon could be added, but ETH / ERC-20
+  /// amounts are exact decimals reconstructed from the same hex value
+  /// on each side, so drift is not expected.
   ///
   /// Magnitude comparison uses `abs` only on the *comparison* of
-  /// quantities; the original signs are preserved on the merged legs.
-  /// Per-project convention `.trade` legs preserve user-entered signs;
-  /// here we're working with `.transfer` legs and the rule is the same —
+  /// quantities; the original signs are preserved on the merged legs
+  /// (which `merge(...)` then promotes to `.transfer`). Per-project
+  /// convention `.trade` legs preserve user-entered signs; here we're
+  /// working with the wallet importer's legs and the rule is the same —
   /// don't normalise.
   static func isPair(_ leg: TransactionLeg, _ other: TransactionLeg) -> Bool {
-    guard leg.type == .transfer, other.type == .transfer else { return false }
+    guard pairableTypes.contains(leg.type), pairableTypes.contains(other.type) else {
+      return false
+    }
     guard let legId = leg.externalId, let otherId = other.externalId else { return false }
     guard legId == otherId else { return false }
     guard leg.instrument == other.instrument else { return false }
@@ -131,6 +136,12 @@ struct LiveCrossAccountTransferMerger: CrossAccountTransferMerger {
     guard legSign != 0, otherSign != 0, legSign != otherSign else { return false }
     return abs(leg.quantity) == abs(other.quantity)
   }
+
+  /// Leg types `TransferEventBuilder` emits per account before pairing.
+  /// `.income` (inbound) and `.expense` (outbound) — a cross-account
+  /// moolah-tracked transfer surfaces as one of each, paired by
+  /// `externalId` and opposing-sign quantities.
+  private static let pairableTypes: Set<TransactionType> = [.income, .expense]
 
   // MARK: - Search
 
@@ -259,16 +270,21 @@ struct LiveCrossAccountTransferMerger: CrossAccountTransferMerger {
 
   // MARK: - Helpers
 
-  /// The single value-bearing transfer leg, when this candidate is
-  /// shaped for cross-account pairing — exactly one `.transfer` leg
-  /// whose `externalId` keys the on-chain hash. Returns `nil` for
-  /// trades or already-merged multi-transfer-leg transactions; the
-  /// merger leaves those untouched.
+  /// The single value-bearing leg, when this candidate is shaped for
+  /// cross-account pairing — exactly one `.income` or `.expense` leg
+  /// whose `externalId` keys the on-chain hash. Skips the gas leg
+  /// (whose `externalId` carries the `":gas"` suffix per
+  /// `TransferReceiptCoalescer.gasLegExternalId(hash:)`). Returns nil
+  /// for trades, gas-only candidates, or already-paired transactions
+  /// carrying multiple value legs; the merger leaves those untouched.
   private static func valueBearingTransferLeg(
     of candidate: BuiltTransaction
   ) -> TransactionLeg? {
-    let transferLegs = candidate.transaction.legs.filter { $0.type == .transfer }
-    return transferLegs.count == 1 ? transferLegs.first : nil
+    let valueLegs = candidate.transaction.legs.filter { leg in
+      guard pairableTypes.contains(leg.type), let id = leg.externalId else { return false }
+      return !id.hasSuffix(":gas")
+    }
+    return valueLegs.count == 1 ? valueLegs.first : nil
   }
 
   /// `1` for positive, `-1` for negative, `0` for zero. Local helper so

--- a/Shared/CryptoImport/TransferEventBuilder+NativeRegistration.swift
+++ b/Shared/CryptoImport/TransferEventBuilder+NativeRegistration.swift
@@ -2,6 +2,26 @@
 import Foundation
 
 extension TransferEventBuilder {
+  /// Maps a transfer's direction onto the leg type the wallet importer
+  /// emits per account. `.transfer` is reserved for cross-account
+  /// pairs that `CrossAccountTransferMerger` pairs by `externalId` —
+  /// individual wallet movements still bookkeep as income / expense
+  /// from the synced account's perspective (see issue #791).
+  /// - `.outbound`: this wallet paid out → `.expense`
+  /// - `.inbound`: this wallet received → `.income`
+  /// - `.selfSend`: net-zero against this wallet; positive quantity
+  ///   per `signAndCounterparty`, typed as `.income`.
+  /// - `.unrelated`: filtered upstream, `signAndCounterparty` returns
+  ///   nil before this is reached.
+  static func legType(for direction: TransferDirection) -> TransactionType {
+    switch direction {
+    case .outbound: .expense
+    case .inbound: .income
+    case .selfSend: .income
+    case .unrelated: .income  // unreachable, signAndCounterparty filters it
+    }
+  }
+
   /// Pre-register the chain's native gas instrument via discovery so
   /// the registry stores a row carrying a real provider mapping.
   ///

--- a/Shared/CryptoImport/TransferEventBuilder.swift
+++ b/Shared/CryptoImport/TransferEventBuilder.swift
@@ -266,7 +266,7 @@ struct TransferEventBuilder: Sendable {
       quantity: resolution.signedQuantity,
       externalId: event.uniqueId,
       counterpartyAddress: resolution.counterpartyAddress,
-      type: .transfer)
+      type: TransferEventBuilder.legType(for: direction))
   }
 
   /// Resolves a transfer's direction into the leg's signed quantity and


### PR DESCRIPTION
## Summary

Follow-up to #794. Two related fixes:

### Wallet leg types

`TransferEventBuilder` typed every per-account leg as `.transfer` regardless of direction. That conflated genuine cross-account transfers (between two moolah-tracked wallets) with external transactions (to / from a non-moolah address). External transactions are income (inbound) or expense (outbound) from the synced account's perspective — calling them `.transfer` was wrong.

- The builder now derives leg type from `TransferDirection` via a static `legType(for:)` helper: outbound → `.expense`, inbound → `.income`, self-send → `.income`.
- `CrossAccountTransferMerger.isPair` matches the new shape — one `.income`, one `.expense` on different accounts with opposing-sign quantities. Pair detection still works for the cross-account case.
- `valueBearingTransferLeg(of:)` filters by the gas-leg `":gas"` `externalId` suffix (since outbound value legs and gas legs are now both `.expense`).

### Transaction detail crash

`TransactionDetailAccountSection.transferRows` unconditionally accessed `legDrafts[1]` whenever `draft.type == .transfer`. With pre-fix wallet-imported transactions the draft had a single `.transfer` leg, so SwiftUI crashed with an array OOB at line 49.

`transferRows` is now guarded by `draft.counterpartLegIndex != nil` — defense in depth, even though production wallet-imported drafts no longer have `draft.type == .transfer` after the leg-type fix above.

Crash backtrace: `Array._checkSubscript` ← `TransactionDetailAccountSection.transferRows.getter` (line 49) ← `TransactionDetailAccountSection.body.getter`.

## Refs

- Builds on #794
- Issue #791

## Test plan

- [x] Tests updated across `TransferEventBuilderTests`, `TransferEventBuilderGasLegTests`, `TransferEventBuilderGasCoalescingTests`, `CrossAccountTransferMergerTests`, `WalletApplyEngineTests`, `CrossDeviceLegDeduperTestSupport`.
- [x] `just test` (mac + iOS) — 2471/2471 mac, 2446/2446 iOS pass.
- [x] `just format-check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)