### PR TITLE
fix(transactions): guard leg-row body against stale index after delete

### DIFF
--- a/Features/Transactions/Views/Detail/TransactionDetailLegRow.swift
+++ b/Features/Transactions/Views/Detail/TransactionDetailLegRow.swift
@@ -21,30 +21,45 @@ struct TransactionDetailLegRow: View {
 
   @FocusState private var categoryFieldFocused: Bool
 
-  private var isEarmarkOnly: Bool { draft.legDrafts[index].isEarmarkOnly }
+  /// True when `index` still refers to a leg in `legDrafts`. SwiftUI
+  /// re-evaluates this view's body once after `removeLeg(at:)` has shrunk
+  /// `legDrafts` but before the surrounding `ForEach` finishes removing
+  /// the row, so a naive subscript would trap. Mirrors the same guard in
+  /// `TransactionDetailFeeSection`.
+  private var isLive: Bool {
+    draft.legDrafts.indices.contains(index)
+  }
+
+  private var isEarmarkOnly: Bool {
+    guard isLive else { return false }
+    return draft.legDrafts[index].isEarmarkOnly
+  }
 
   private var visibleSuggestions: [CategorySuggestion] {
-    categoryState.visibleSuggestions(
+    guard isLive else { return [] }
+    return categoryState.visibleSuggestions(
       for: draft.legDrafts[index].categoryText, in: categories)
   }
 
   var body: some View {
-    Section("Sub-transaction \(index + 1) of \(totalLegCount)") {
-      if !isEarmarkOnly {
-        typePicker
-      }
-      accountPicker
-      amountRow
-      if !isEarmarkOnly {
-        categoryField
-      }
-      earmarkPicker
-      if totalLegCount > 1 {
-        Button(role: .destructive) {
-          onRequestDelete()
-        } label: {
-          Text("Delete Sub-transaction")
-            .frame(maxWidth: .infinity)
+    if isLive {
+      Section("Sub-transaction \(index + 1) of \(totalLegCount)") {
+        if !isEarmarkOnly {
+          typePicker
+        }
+        accountPicker
+        amountRow
+        if !isEarmarkOnly {
+          categoryField
+        }
+        earmarkPicker
+        if totalLegCount > 1 {
+          Button(role: .destructive) {
+            onRequestDelete()
+          } label: {
+            Text("Delete Sub-transaction")
+              .frame(maxWidth: .infinity)
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary
- Custom-mode "Delete Sub-transaction" was crashing the app: `TransactionDetailLegRow` indexes `draft.legDrafts[index]` directly throughout its body and `onChange` blocks. After `removeLeg(at:)` shrinks the array, SwiftUI re-evaluates the now-stale row's body once before `ForEach` removes it, and the naive subscript traps.
- Wrap the body and the `isEarmarkOnly` / `visibleSuggestions` computed properties in an `isLive` guard so the row no-ops on the transitional render and SwiftUI removes it cleanly.
- Mirrors the same guard added to `TransactionDetailFeeSection` in [`55fbdc40`](https://github.com/ajsutton/moolah-native/commit/55fbdc40c82bf33e317dd51e32b13dced207d10a) ("fix(trades): guard fee section body against stale legIndex"); the leg-row equivalent had the same shape but never got the same fix.

## Test plan
- [x] `just format-check` clean
- [x] `just build-mac` succeeds with no new warnings in user code
- [x] `just test-mac TransactionDraftAccountTests` — `removeLeg` model behaviour still correct
- [ ] Manual: open a multi-leg upcoming transaction in Large Test, tap "Delete Sub-transaction", confirm — no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)