### PR TITLE
fix(earmarks): drop colorOverride on detail Spent total

### DIFF
--- a/Features/Earmarks/Views/EarmarkDetailView.swift
+++ b/Features/Earmarks/Views/EarmarkDetailView.swift
@@ -110,8 +110,7 @@ struct EarmarkDetailView: View {
         label: "Spent",
         amount:
           -(earmarkStore.convertedSpent(for: earmark.id)
-          ?? .zero(instrument: earmark.instrument)),
-        colorOverride: .primary)
+          ?? .zero(instrument: earmark.instrument)))
     }
   }
 


### PR DESCRIPTION
## Summary
- The Spent summary item on the earmark detail view forced `.primary` colour, so the negated (negative) value was rendered indistinguishably from a positive figure.
- Removing the override lets `InstrumentAmountView` colour the negative amount red, matching how expenses appear in the transaction list.

## Test plan
- [x] `just format-check`
- [x] `just build-mac`
- [x] Open an earmark with spending in the running app and verify the Spent total renders red and negative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)