### PR TITLE
feat(transactions): stable TransactionLeg.id ends leg-churn-on-update

### DIFF
--- a/Backends/CloudKit/Models/TransactionLegRecord.swift
+++ b/Backends/CloudKit/Models/TransactionLegRecord.swift
@@ -55,6 +55,7 @@ final class TransactionLegRecord {
   /// `TransactionType.decoded(rawValue:)`.
   func toDomain(instrument: Instrument) throws -> TransactionLeg {
     TransactionLeg(
+      id: id,
       accountId: accountId,
       instrument: instrument,
       quantity: InstrumentAmount(storageValue: quantity, instrument: instrument).quantity,
@@ -70,6 +71,7 @@ final class TransactionLegRecord {
     -> TransactionLegRecord
   {
     TransactionLegRecord(
+      id: leg.id,
       transactionId: transactionId,
       accountId: leg.accountId,
       instrumentId: leg.instrument.id,

--- a/Backends/GRDB/Records/TransactionLegRow+Mapping.swift
+++ b/Backends/GRDB/Records/TransactionLegRow+Mapping.swift
@@ -11,20 +11,23 @@ extension TransactionLegRow {
     "\(recordType)|\(id.uuidString)"
   }
 
-  /// Builds a row from a domain `TransactionLeg`. Mirrors
-  /// `TransactionLegRecord.from(_:transactionId:sortOrder:)`.
-  /// `TransactionLeg` does not own its own UUID, so the caller supplies
-  /// `id`, `transactionId`, and `sortOrder`. Pass an existing leg id
-  /// when round-tripping (replace-legs path); pass a fresh `UUID()` on
-  /// initial create.
+  /// Builds a row from a domain `TransactionLeg`. The row's `id` defaults
+  /// to `leg.id` (the leg's stable domain id). Callers can override `id`
+  /// only if they need a row id that differs from the leg's own stable
+  /// id — no in-tree callsite needs that. Passing `leg.id` explicitly
+  /// (as `create(_:)` does, for callsite-clarity) is also fine; the
+  /// default and the explicit value are identical. The CK-ingestion
+  /// path constructs `TransactionLegRow` via the memberwise init in
+  /// `TransactionLegRow+CloudKit.fieldValues(from:)`, not this factory.
   init(
-    id: UUID = UUID(),
+    id: UUID? = nil,
     domain leg: TransactionLeg,
     transactionId: UUID,
     sortOrder: Int
   ) {
-    self.id = id
-    self.recordName = Self.recordName(for: id)
+    let resolvedId = id ?? leg.id
+    self.id = resolvedId
+    self.recordName = Self.recordName(for: resolvedId)
     self.transactionId = transactionId
     self.accountId = leg.accountId
     self.instrumentId = leg.instrument.id
@@ -48,6 +51,7 @@ extension TransactionLegRow {
   /// `TransactionType.decoded(rawValue:)`.
   func toDomain(instrument: Instrument) throws -> TransactionLeg {
     TransactionLeg(
+      id: id,
       accountId: accountId,
       instrument: instrument,
       quantity: InstrumentAmount(storageValue: quantity, instrument: instrument).quantity,

--- a/Backends/GRDB/Repositories/GRDBTransactionRepository+Update.swift
+++ b/Backends/GRDB/Repositories/GRDBTransactionRepository+Update.swift
@@ -1,0 +1,138 @@
+// Backends/GRDB/Repositories/GRDBTransactionRepository+Update.swift
+
+import Foundation
+import GRDB
+
+extension GRDBTransactionRepository {
+  // MARK: - Update pipeline
+
+  struct UpdateOutcome: Sendable {
+    let deletedLegIds: [UUID]
+    let upsertedLegIds: [UUID]
+  }
+
+  private struct LegDiff: Sendable {
+    let deletedIds: [UUID]
+    let existingFieldsByLegId: [UUID: Data?]
+  }
+
+  /// Fetches the persisted leg rows for `transactionId`, snapshots their
+  /// `encodedSystemFields` blobs by id, deletes any legs absent from
+  /// `newLegIds`, and returns the deleted ids plus the field map so the
+  /// upsert pass can re-attach each surviving leg's blob.
+  private static func computeLegDiff(
+    database: Database,
+    transactionId: UUID,
+    newLegIds: Set<UUID>
+  ) throws -> LegDiff {
+    let existingRows =
+      try TransactionLegRow
+      .filter(TransactionLegRow.Columns.transactionId == transactionId)
+      .fetchAll(database)
+    let oldLegIds: Set<UUID> = Set(existingRows.map(\.id))
+    let existingFieldsByLegId: [UUID: Data?] = Dictionary(
+      uniqueKeysWithValues: existingRows.map { ($0.id, $0.encodedSystemFields) })
+    let deletedLegIds = oldLegIds.subtracting(newLegIds)
+
+    if !deletedLegIds.isEmpty {
+      _ =
+        try TransactionLegRow
+        .filter(deletedLegIds.contains(TransactionLegRow.Columns.id))
+        .deleteAll(database)
+    }
+
+    return LegDiff(
+      deletedIds: Array(deletedLegIds),
+      existingFieldsByLegId: existingFieldsByLegId)
+  }
+
+  /// Single-statement body of `update`'s `database.write { … }`
+  /// closure. Looks up the existing header row, applies the domain
+  /// fields, diffs the supplied legs against the persisted set by
+  /// stable id, and returns the deleted/upserted leg ids so the caller
+  /// can fan out the right hooks after the transaction commits.
+  ///
+  /// Diff-by-id (rather than delete-then-insert with fresh UUIDs)
+  /// preserves leg `id`s and each leg's cached
+  /// `encoded_system_fields` blob across saves. Without that
+  /// preservation, every header-only edit would tear down the leg
+  /// rows, drop their CK system fields, and the next sync pass would
+  /// re-upload the whole thing as if unsynced
+  /// (`unsyncedRowIdsSync` filters on `encoded_system_fields IS NULL`).
+  static func performUpdate(
+    database: Database,
+    transaction: Transaction
+  ) throws -> UpdateOutcome {
+    guard
+      var existing =
+        try TransactionRow
+        .filter(TransactionRow.Columns.id == transaction.id)
+        .fetchOne(database)
+    else {
+      throw BackendError.notFound("Transaction not found")
+    }
+    applyMetadata(of: transaction, to: &existing)
+    try existing.update(database)
+
+    let newLegIds: Set<UUID> = Set(transaction.legs.map(\.id))
+    let diff = try Self.computeLegDiff(
+      database: database,
+      transactionId: transaction.id,
+      newLegIds: newLegIds)
+
+    // Upsert every leg in the new array. Idempotent for unchanged
+    // rows; updates `sort_order` for legs that moved; inserts new
+    // legs. Order: deletions first so the
+    // `(transaction_id, sort_order)` pair is never transiently
+    // duplicated by a moving leg landing on a soon-to-be-deleted
+    // leg's slot. There is no UNIQUE(transaction_id, sort_order)
+    // constraint so this is defensive rather than required, but it
+    // keeps the intermediate state consistent for any future
+    // debugger snapshot.
+    var upsertedLegIds: [UUID] = []
+    upsertedLegIds.reserveCapacity(transaction.legs.count)
+    for (index, leg) in transaction.legs.enumerated() {
+      try Self.ensureInstrumentReadable(database: database, leg: leg)
+      var legRow = TransactionLegRow(
+        id: leg.id,
+        domain: leg,
+        transactionId: transaction.id,
+        sortOrder: index)
+      // Re-attach the cached CK system fields blob for legs that
+      // already existed; new legs land with `nil` and the sync layer
+      // stamps them after the first successful upload.
+      if let existingFields = diff.existingFieldsByLegId[leg.id] {
+        legRow.encodedSystemFields = existingFields
+      }
+      try legRow.upsert(database)
+      upsertedLegIds.append(leg.id)
+    }
+
+    return UpdateOutcome(
+      deletedLegIds: diff.deletedIds,
+      upsertedLegIds: upsertedLegIds)
+  }
+
+  /// Mirrors `CloudKitTransactionRepository.applyMetadata`. Copies the
+  /// header fields (including the eight denormalised
+  /// `import_origin_*` columns) from the domain object onto the
+  /// existing row.
+  private static func applyMetadata(
+    of transaction: Transaction, to row: inout TransactionRow
+  ) {
+    let fresh = TransactionRow(domain: transaction)
+    row.date = fresh.date
+    row.payee = fresh.payee
+    row.notes = fresh.notes
+    row.recurPeriod = fresh.recurPeriod
+    row.recurEvery = fresh.recurEvery
+    row.importOriginRawDescription = fresh.importOriginRawDescription
+    row.importOriginBankReference = fresh.importOriginBankReference
+    row.importOriginRawAmount = fresh.importOriginRawAmount
+    row.importOriginRawBalance = fresh.importOriginRawBalance
+    row.importOriginImportedAt = fresh.importOriginImportedAt
+    row.importOriginImportSessionId = fresh.importOriginImportSessionId
+    row.importOriginSourceFilename = fresh.importOriginSourceFilename
+    row.importOriginParserIdentifier = fresh.importOriginParserIdentifier
+  }
+}

--- a/Backends/GRDB/Repositories/GRDBTransactionRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBTransactionRepository.swift
@@ -128,14 +128,13 @@ final class GRDBTransactionRepository: TransactionRepository, @unchecked Sendabl
         try Self.ensureInstrumentReadable(
           database: database,
           leg: leg)
-        let legId = UUID()
         let legRow = TransactionLegRow(
-          id: legId,
+          id: leg.id,
           domain: leg,
           transactionId: transaction.id,
           sortOrder: index)
         try legRow.insert(database)
-        legIds.append(legId)
+        legIds.append(leg.id)
       }
       return legIds
     }

--- a/Backends/GRDB/Repositories/GRDBTransactionRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBTransactionRepository.swift
@@ -154,7 +154,7 @@ final class GRDBTransactionRepository: TransactionRepository, @unchecked Sendabl
     }
 
     onRecordChanged(TransactionRow.recordType, transaction.id)
-    for legId in outcome.insertedLegIds {
+    for legId in outcome.upsertedLegIds {
       onRecordChanged(TransactionLegRow.recordType, legId)
     }
     for legId in outcome.deletedLegIds {
@@ -238,57 +238,6 @@ final class GRDBTransactionRepository: TransactionRepository, @unchecked Sendabl
 
   // MARK: - Private helpers
 
-  private struct UpdateOutcome {
-    let deletedLegIds: [UUID]
-    let insertedLegIds: [UUID]
-  }
-
-  /// Single-statement body of `update`'s `database.write { … }`
-  /// closure. Looks up the existing header row, applies the domain
-  /// fields, replaces every leg, and returns the deleted/inserted leg
-  /// ids so the caller can fan out the right hooks after the
-  /// transaction commits.
-  private static func performUpdate(
-    database: Database,
-    transaction: Transaction
-  ) throws -> UpdateOutcome {
-    guard
-      var existing =
-        try TransactionRow
-        .filter(TransactionRow.Columns.id == transaction.id)
-        .fetchOne(database)
-    else {
-      throw BackendError.notFound("Transaction not found")
-    }
-    applyMetadata(of: transaction, to: &existing)
-    try existing.update(database)
-
-    let oldLegs =
-      try TransactionLegRow
-      .filter(TransactionLegRow.Columns.transactionId == transaction.id)
-      .fetchAll(database)
-    let oldLegIds = oldLegs.map(\.id)
-    _ =
-      try TransactionLegRow
-      .filter(TransactionLegRow.Columns.transactionId == transaction.id)
-      .deleteAll(database)
-
-    var newLegIds: [UUID] = []
-    newLegIds.reserveCapacity(transaction.legs.count)
-    for (index, leg) in transaction.legs.enumerated() {
-      try Self.ensureInstrumentReadable(database: database, leg: leg)
-      let legId = UUID()
-      let legRow = TransactionLegRow(
-        id: legId,
-        domain: leg,
-        transactionId: transaction.id,
-        sortOrder: index)
-      try legRow.insert(database)
-      newLegIds.append(legId)
-    }
-    return UpdateOutcome(deletedLegIds: oldLegIds, insertedLegIds: newLegIds)
-  }
-
   /// Converts the snapshot's per-instrument after-page subtotals to a
   /// single `priorBalance` on the target instrument. Returns `nil` on
   /// any conversion failure so callers can mark the running-balance
@@ -325,27 +274,16 @@ final class GRDBTransactionRepository: TransactionRepository, @unchecked Sendabl
     return total
   }
 
-  /// Mirrors `CloudKitTransactionRepository.applyMetadata`. Copies the
-  /// header fields (including the eight denormalised
-  /// `import_origin_*` columns) from the domain object onto the
-  /// existing row.
-  private static func applyMetadata(
-    of transaction: Transaction, to row: inout TransactionRow
-  ) {
-    let fresh = TransactionRow(domain: transaction)
-    row.date = fresh.date
-    row.payee = fresh.payee
-    row.notes = fresh.notes
-    row.recurPeriod = fresh.recurPeriod
-    row.recurEvery = fresh.recurEvery
-    row.importOriginRawDescription = fresh.importOriginRawDescription
-    row.importOriginBankReference = fresh.importOriginBankReference
-    row.importOriginRawAmount = fresh.importOriginRawAmount
-    row.importOriginRawBalance = fresh.importOriginRawBalance
-    row.importOriginImportedAt = fresh.importOriginImportedAt
-    row.importOriginImportSessionId = fresh.importOriginImportSessionId
-    row.importOriginSourceFilename = fresh.importOriginSourceFilename
-    row.importOriginParserIdentifier = fresh.importOriginParserIdentifier
-  }
-
+  // MARK: - Cross-extension internals
+  //
+  // The following types and helpers are defined in peer extension files
+  // and consumed by methods in this file:
+  //   `UpdateOutcome`, `performUpdate(database:transaction:)` →
+  //     `GRDBTransactionRepository+Update.swift`
+  //   `FetchSnapshot`, `buildFetchSnapshot(...)`,
+  //   `candidateTransactionRows(...)`, `applyLegFilters(...)`,
+  //   `fetchLegs(...)`, `fetchInstrumentMap(...)` →
+  //     `GRDBTransactionRepository+Fetch.swift`
+  //   `ensureInstrumentReadable(database:leg:)` →
+  //     `GRDBTransactionRepository+FKEnsure.swift`
 }

--- a/Domain/Models/Transaction+Defaults.swift
+++ b/Domain/Models/Transaction+Defaults.swift
@@ -56,7 +56,18 @@ extension Transaction {
       date: scheduled.date,
       payee: scheduled.payee,
       notes: scheduled.notes,
-      legs: scheduled.legs
+      legs: scheduled.legs.map { source in
+        TransactionLeg(
+          id: UUID(),
+          accountId: source.accountId,
+          instrument: source.instrument,
+          quantity: source.quantity,
+          externalId: source.externalId,
+          counterpartyAddress: source.counterpartyAddress,
+          type: source.type,
+          categoryId: source.categoryId,
+          earmarkId: source.earmarkId)
+      }
     )
   }
 

--- a/Domain/Models/TransactionLeg.swift
+++ b/Domain/Models/TransactionLeg.swift
@@ -1,6 +1,7 @@
 import Foundation
 
-struct TransactionLeg: Codable, Sendable, Hashable {
+struct TransactionLeg {
+  let id: UUID
   let accountId: UUID?
   let instrument: Instrument
   let quantity: Decimal
@@ -20,6 +21,7 @@ struct TransactionLeg: Codable, Sendable, Hashable {
   var earmarkId: UUID?
 
   init(
+    id: UUID = UUID(),
     accountId: UUID?,
     instrument: Instrument,
     quantity: Decimal,
@@ -29,6 +31,7 @@ struct TransactionLeg: Codable, Sendable, Hashable {
     categoryId: UUID? = nil,
     earmarkId: UUID? = nil
   ) {
+    self.id = id
     self.accountId = accountId
     self.instrument = instrument
     self.quantity = quantity
@@ -42,5 +45,41 @@ struct TransactionLeg: Codable, Sendable, Hashable {
   /// Convenience: the quantity as an InstrumentAmount.
   var amount: InstrumentAmount {
     InstrumentAmount(quantity: quantity, instrument: instrument)
+  }
+}
+
+extension TransactionLeg: Sendable {}
+
+extension TransactionLeg: Identifiable {}
+
+extension TransactionLeg: Hashable {}
+
+extension TransactionLeg: Codable {
+  private enum CodingKeys: String, CodingKey {
+    case id
+    case accountId
+    case instrument
+    case quantity
+    case externalId
+    case counterpartyAddress
+    case type
+    case categoryId
+    case earmarkId
+  }
+
+  init(from decoder: any Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    // Legacy rows (pre-stable-leg-id) round-trip with a freshly allocated id;
+    // newer rows persist a stable id assigned at creation time.
+    self.id = try container.decodeIfPresent(UUID.self, forKey: .id) ?? UUID()
+    self.accountId = try container.decodeIfPresent(UUID.self, forKey: .accountId)
+    self.instrument = try container.decode(Instrument.self, forKey: .instrument)
+    self.quantity = try container.decode(Decimal.self, forKey: .quantity)
+    self.externalId = try container.decodeIfPresent(String.self, forKey: .externalId)
+    self.counterpartyAddress = try container.decodeIfPresent(
+      String.self, forKey: .counterpartyAddress)
+    self.type = try container.decode(TransactionType.self, forKey: .type)
+    self.categoryId = try container.decodeIfPresent(UUID.self, forKey: .categoryId)
+    self.earmarkId = try container.decodeIfPresent(UUID.self, forKey: .earmarkId)
   }
 }

--- a/MoolahTests/Backends/GRDB/CoreFinancialGraphRollbackTests.swift
+++ b/MoolahTests/Backends/GRDB/CoreFinancialGraphRollbackTests.swift
@@ -159,10 +159,14 @@ struct CoreFinancialGraphRollbackTests {
     let priorLegs = try await fetchLegs(in: database, transactionId: txn.id)
     #expect(priorLegs.count == 1)
 
-    // Install a trigger that aborts every leg insert. The update path
-    // deletes existing legs, then re-inserts the new ones — the trigger
-    // fires on the first re-insert, and the header update plus the
-    // pre-update leg deletes must roll back.
+    // Install a trigger that aborts any INSERT attempt on transaction_leg.
+    // `performUpdate` now diffs legs by id: it deletes only legs absent
+    // from the new array, then upserts each surviving/new leg via
+    // `INSERT ... ON CONFLICT DO UPDATE`. SQLite fires `BEFORE INSERT`
+    // for the upsert path, so the trigger raises ABORT on the first
+    // upsert attempt; GRDB propagates the error and rolls the entire
+    // write transaction back — undoing both the partial leg delete and
+    // the header UPDATE.
     try await database.write { database in
       try database.execute(
         sql: """

--- a/MoolahTests/Backends/GRDB/GRDBTransactionStableLegIdTests.swift
+++ b/MoolahTests/Backends/GRDB/GRDBTransactionStableLegIdTests.swift
@@ -1,0 +1,284 @@
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+@Suite("GRDBTransactionRepository preserves leg ids across update")
+@MainActor
+struct GRDBTransactionStableLegIdTests {
+
+  /// Reload a single transaction by id via `fetchAll`, since
+  /// `TransactionRepository` exposes only filter/pagination fetches.
+  /// Returns `nil` if the row is no longer present.
+  private func reload(
+    _ repo: any TransactionRepository, id: UUID
+  ) async throws -> Transaction? {
+    let all = try await repo.fetchAll(filter: TransactionFilter())
+    return all.first(where: { $0.id == id })
+  }
+
+  @Test("editing only the parent header keeps every leg id stable")
+  func headerOnlyEditPreservesLegIds() async throws {
+    let (backend, _) = try TestBackend.create()
+    let accountId = UUID()
+    _ = try await backend.accounts.create(
+      Account(
+        id: accountId,
+        name: "Cash",
+        type: .bank,
+        instrument: Instrument.defaultTestInstrument,
+        positions: []))
+    let original = try await backend.transactions.create(
+      Transaction(
+        date: Date(), payee: "Coffee",
+        legs: [
+          TransactionLeg(
+            accountId: accountId,
+            instrument: Instrument.defaultTestInstrument,
+            quantity: -10, type: .expense)
+        ]))
+    let originalLegIds = original.legs.map(\.id)
+
+    var edited = original
+    edited.payee = "Espresso"
+    _ = try await backend.transactions.update(edited)
+
+    let reloaded = try await reload(backend.transactions, id: original.id)
+    let reloadedLegIds = try #require(reloaded).legs.map(\.id)
+    #expect(reloadedLegIds == originalLegIds)
+  }
+
+  @Test("removing one leg from a two-leg transaction keeps the surviving leg's id")
+  func removeOneLegPreservesSurvivor() async throws {
+    let (backend, _) = try TestBackend.create()
+    let acctA = UUID()
+    let acctB = UUID()
+    for id in [acctA, acctB] {
+      _ = try await backend.accounts.create(
+        Account(
+          id: id, name: id.uuidString, type: .bank,
+          instrument: Instrument.defaultTestInstrument, positions: []))
+    }
+    let original = try await backend.transactions.create(
+      Transaction(
+        date: Date(), payee: "Move",
+        legs: [
+          TransactionLeg(
+            accountId: acctA, instrument: Instrument.defaultTestInstrument,
+            quantity: -50, type: .transfer),
+          TransactionLeg(
+            accountId: acctB, instrument: Instrument.defaultTestInstrument,
+            quantity: 50, type: .transfer),
+        ]))
+    let survivorId = original.legs[0].id
+
+    var edited = original
+    edited.legs = [original.legs[0]]  // drop the second leg
+    _ = try await backend.transactions.update(edited)
+
+    let reloaded = try #require(try await reload(backend.transactions, id: original.id))
+    #expect(reloaded.legs.map(\.id) == [survivorId])
+  }
+
+  @Test("create(_:) writes the caller-supplied leg id, not a fresh UUID")
+  func createUsesCallerSuppliedLegId() async throws {
+    // Without this test, a regression that leaves
+    // `let legId = UUID()` in `create(_:)` (while only fixing
+    // `performUpdate`) would not be caught by the round-trip / reorder
+    // / remove tests below — those capture `original.legs.map(\.id)`
+    // *after* `create`, so they verify update-stability but not
+    // create-stability. Pin the create-time id explicitly.
+    let (backend, _) = try TestBackend.create()
+    let accountId = UUID()
+    _ = try await backend.accounts.create(
+      Account(
+        id: accountId, name: "Cash", type: .bank,
+        instrument: Instrument.defaultTestInstrument, positions: []))
+    let preassignedLegId = UUID()
+    let txn = try await backend.transactions.create(
+      Transaction(
+        date: Date(), payee: "Tagged",
+        legs: [
+          TransactionLeg(
+            id: preassignedLegId,
+            accountId: accountId,
+            instrument: Instrument.defaultTestInstrument,
+            quantity: -7, type: .expense)
+        ]))
+    // Returned domain object reflects the caller's id.
+    #expect(txn.legs.first?.id == preassignedLegId)
+    // Re-fetched row from GRDB also uses the caller's id.
+    let reloaded = try #require(try await reload(backend.transactions, id: txn.id))
+    #expect(reloaded.legs.map(\.id) == [preassignedLegId])
+  }
+
+  @Test("reordering legs rewrites sort_order but keeps ids")
+  func reorderRewritesSortOrderKeepsIds() async throws {
+    let (backend, _) = try TestBackend.create()
+    let acctA = UUID()
+    let acctB = UUID()
+    for id in [acctA, acctB] {
+      _ = try await backend.accounts.create(
+        Account(
+          id: id, name: id.uuidString, type: .bank,
+          instrument: Instrument.defaultTestInstrument, positions: []))
+    }
+    let original = try await backend.transactions.create(
+      Transaction(
+        date: Date(), payee: "Swap",
+        legs: [
+          TransactionLeg(
+            accountId: acctA, instrument: Instrument.defaultTestInstrument,
+            quantity: -25, type: .transfer),
+          TransactionLeg(
+            accountId: acctB, instrument: Instrument.defaultTestInstrument,
+            quantity: 25, type: .transfer),
+        ]))
+    let firstId = original.legs[0].id
+    let secondId = original.legs[1].id
+
+    var edited = original
+    edited.legs = [original.legs[1], original.legs[0]]  // swap
+    _ = try await backend.transactions.update(edited)
+
+    let reloaded = try #require(try await reload(backend.transactions, id: original.id))
+    #expect(reloaded.legs.map(\.id) == [secondId, firstId])
+  }
+
+  @Test(
+    "header-only update preserves each leg's encodedSystemFields blob")
+  func headerOnlyEditPreservesEncodedSystemFields() async throws {
+    let database = try ProfileDatabase.openInMemory()
+    let txnRepo = GRDBTransactionRepository(
+      database: database,
+      defaultInstrument: .defaultTestInstrument,
+      conversionService: FixedConversionService())
+    let accountId = UUID()
+    let txn = try await txnRepo.create(
+      Transaction(
+        date: Date(), payee: "Coffee",
+        legs: [
+          makeContractTestLeg(accountId: accountId, quantity: -10, type: .expense)
+        ]))
+    let legId = txn.legs[0].id
+
+    // Simulate a successful CK round-trip stamping the leg with its
+    // cached system fields blob. `try await` selects the async overload
+    // of `DatabaseWriter.write` — calling the synchronous overload from
+    // an async test silently blocks the cooperative thread pool.
+    let stampedFields = Data([0xCA, 0xFE, 0xBA, 0xBE])
+    try await database.write { database in
+      _ =
+        try TransactionLegRow
+        .filter(TransactionLegRow.Columns.id == legId)
+        .updateAll(
+          database,
+          [TransactionLegRow.Columns.encodedSystemFields.set(to: stampedFields)])
+    }
+
+    // Header-only edit. After Reference R1's preservation pass, the
+    // leg's cached blob must survive verbatim — otherwise the next sync
+    // pass treats the leg as unsynced and re-uploads it.
+    var edited = txn
+    edited.payee = "Espresso"
+    _ = try await txnRepo.update(edited)
+
+    let reloadedFields: Data? = try await database.read { database in
+      // fetchOne on `Data?.self` returns `Data??`; flatMap collapses
+      // outer-Optional("row missing") to inner-Optional("blob nil") for
+      // a single-layer comparison against `stampedFields`.
+      try TransactionLegRow
+        .filter(TransactionLegRow.Columns.id == legId)
+        .select(TransactionLegRow.Columns.encodedSystemFields, as: Data?.self)
+        .fetchOne(database)
+        .flatMap { $0 }
+    }
+    #expect(reloadedFields == stampedFields)
+  }
+
+  /// Installs a `BEFORE UPDATE` trigger on the header table that aborts
+  /// every header `UPDATE`. The trigger fires inside `performUpdate`'s
+  /// write closure after the header `UPDATE` is issued and before any
+  /// leg upserts run; SQLite raises ABORT, which propagates out as a
+  /// Swift error, and the surrounding `database.write { … }` rolls the
+  /// entire transaction back per §5 of DATABASE_CODE_GUIDE. Same
+  /// pattern as `TransactionDeleteRollbackTests`.
+  private func triggerForcedUpdateFailure(
+    on database: any DatabaseWriter
+  ) async throws {
+    try await database.write { database in
+      try database.execute(
+        sql: """
+          CREATE TRIGGER force_update_failure
+          BEFORE UPDATE ON "transaction"
+          BEGIN
+            SELECT RAISE(ABORT, 'forced failure for rollback test');
+          END;
+          """)
+    }
+  }
+
+  @Test("performUpdate rolls back the header on a mid-write throw")
+  func performUpdateRollsBackHeaderOnFailure() async throws {
+    let database = try ProfileDatabase.openInMemory()
+    let txnRepo = GRDBTransactionRepository(
+      database: database,
+      defaultInstrument: .defaultTestInstrument,
+      conversionService: FixedConversionService())
+    let accountId = UUID()
+    let txn = try await txnRepo.create(
+      Transaction(
+        date: Date(), payee: "Original",
+        legs: [
+          makeContractTestLeg(accountId: accountId, quantity: -10, type: .expense)
+        ]))
+
+    try await triggerForcedUpdateFailure(on: database)
+
+    var brokenUpdate = txn
+    brokenUpdate.payee = "Should not land"
+
+    do {
+      _ = try await txnRepo.update(brokenUpdate)
+      Issue.record("Expected update to throw — rollback test cannot proceed")
+    } catch {
+      // Expected: SQLite ABORT propagates out as a Swift error.
+    }
+
+    let reloaded = try #require(try await reload(txnRepo, id: txn.id))
+    #expect(reloaded.payee == "Original")
+  }
+
+  @Test("performUpdate rolls back the legs on a mid-write throw")
+  func performUpdateRollsBackLegsOnFailure() async throws {
+    let database = try ProfileDatabase.openInMemory()
+    let txnRepo = GRDBTransactionRepository(
+      database: database,
+      defaultInstrument: .defaultTestInstrument,
+      conversionService: FixedConversionService())
+    let accountId = UUID()
+    let txn = try await txnRepo.create(
+      Transaction(
+        date: Date(), payee: "Original",
+        legs: [
+          makeContractTestLeg(accountId: accountId, quantity: -10, type: .expense)
+        ]))
+    let originalLegId = txn.legs[0].id
+
+    try await triggerForcedUpdateFailure(on: database)
+
+    var brokenUpdate = txn
+    brokenUpdate.payee = "Should not land"
+
+    do {
+      _ = try await txnRepo.update(brokenUpdate)
+      Issue.record("Expected update to throw — rollback test cannot proceed")
+    } catch {
+      // Expected.
+    }
+
+    let reloaded = try #require(try await reload(txnRepo, id: txn.id))
+    #expect(reloaded.legs.map(\.id) == [originalLegId])
+  }
+}

--- a/MoolahTests/Backends/GRDB/TransactionLegRowMappingTests.swift
+++ b/MoolahTests/Backends/GRDB/TransactionLegRowMappingTests.swift
@@ -1,0 +1,63 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("TransactionLegRow mapping round-trip")
+struct TransactionLegRowMappingTests {
+
+  @Test("factory init defaults to leg.id; toDomain round-trips it back")
+  func legIdRoundTripsThroughMappingFactory() throws {
+    let stableId = UUID()
+    let leg = TransactionLeg(
+      id: stableId,
+      accountId: nil,
+      instrument: Instrument.defaultTestInstrument,
+      quantity: Decimal(-10),
+      type: .expense)
+
+    let row = TransactionLegRow(
+      domain: leg,
+      transactionId: UUID(),
+      sortOrder: 0)
+    #expect(row.id == stableId)
+
+    let domain = try row.toDomain(instrument: Instrument.defaultTestInstrument)
+    #expect(domain.id == stableId)
+  }
+
+  @Test("factory init explicit id overrides leg.id")
+  func explicitIdOverridesLegId() {
+    let overrideId = UUID()
+    let leg = TransactionLeg(
+      accountId: nil,
+      instrument: Instrument.defaultTestInstrument,
+      quantity: Decimal(-10),
+      type: .expense)
+
+    let row = TransactionLegRow(
+      id: overrideId,
+      domain: leg,
+      transactionId: UUID(),
+      sortOrder: 0)
+    #expect(row.id == overrideId)
+    #expect(row.id != leg.id)
+  }
+
+  @Test("factory init derives recordName from the resolved id")
+  func recordNameDerivesFromResolvedId() {
+    let stableId = UUID()
+    let leg = TransactionLeg(
+      id: stableId,
+      accountId: nil,
+      instrument: Instrument.defaultTestInstrument,
+      quantity: Decimal(-10),
+      type: .expense)
+
+    let row = TransactionLegRow(
+      domain: leg,
+      transactionId: UUID(),
+      sortOrder: 0)
+    #expect(row.recordName == TransactionLegRow.recordName(for: stableId))
+  }
+}

--- a/MoolahTests/Domain/ScheduledTransactionTestsMore.swift
+++ b/MoolahTests/Domain/ScheduledTransactionTestsMore.swift
@@ -103,12 +103,11 @@ struct ScheduledTransactionTestsMore {
       filter: TransactionFilter(scheduled: .scheduledOnly), page: 0, pageSize: 50)
     #expect(page1.transactions.count == 1)
 
-    // Create paid transaction (simulating the pay action)
-    let paid = Transaction(
-      date: Date(),
-      payee: scheduled.payee,
-      legs: scheduled.legs
-    )
+    // Create paid transaction (simulating the pay action). Use
+    // `paidCopy(of:)` so the copy gets fresh leg ids — leg ids are PKs
+    // on `transaction_leg`, and reusing `scheduled.legs` verbatim
+    // would duplicate-key on insert.
+    let paid = Transaction.paidCopy(of: scheduled)
     _ = try await backend.transactions.create(paid)
 
     // For .once, the scheduled transaction should be deleted
@@ -144,12 +143,10 @@ struct ScheduledTransactionTestsMore {
     let (backend, database) = try TestBackend.create()
     _ = TestBackend.seed(transactions: [scheduled], in: database)
 
-    // Create paid transaction
-    let paid = Transaction(
-      date: Date(),
-      payee: scheduled.payee,
-      legs: scheduled.legs
-    )
+    // Create paid transaction. Use `paidCopy(of:)` so the copy gets
+    // fresh leg ids — leg ids are PKs on `transaction_leg`, and
+    // reusing `scheduled.legs` verbatim would duplicate-key on insert.
+    let paid = Transaction.paidCopy(of: scheduled)
     _ = try await backend.transactions.create(paid)
 
     // For recurring, update the scheduled transaction's date to next occurrence

--- a/MoolahTests/Domain/TransactionLegIdentityTests.swift
+++ b/MoolahTests/Domain/TransactionLegIdentityTests.swift
@@ -1,0 +1,68 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("TransactionLeg identity")
+struct TransactionLegIdentityTests {
+
+  @Test("default initializer allocates a fresh id per call")
+  func defaultIdIsUnique() {
+    let legA = TransactionLeg(
+      accountId: nil,
+      instrument: Instrument.defaultTestInstrument,
+      quantity: Decimal(0), type: .expense)
+    let legB = TransactionLeg(
+      accountId: nil,
+      instrument: Instrument.defaultTestInstrument,
+      quantity: Decimal(0), type: .expense)
+    #expect(legA.id != legB.id)
+  }
+
+  @Test("explicit id round-trips through init")
+  func explicitIdRoundTrips() {
+    let id = UUID()
+    let leg = TransactionLeg(
+      id: id,
+      accountId: nil,
+      instrument: Instrument.defaultTestInstrument,
+      quantity: Decimal(0), type: .expense)
+    #expect(leg.id == id)
+  }
+
+  @Test("two legs with same content but different ids are not equal")
+  func differentIdsBreakEquality() {
+    let legA = TransactionLeg(
+      accountId: nil,
+      instrument: Instrument.defaultTestInstrument,
+      quantity: Decimal(0), type: .expense)
+    let legB = TransactionLeg(
+      accountId: nil,
+      instrument: Instrument.defaultTestInstrument,
+      quantity: Decimal(0), type: .expense)
+    // Same content, distinct identities: must compare unequal.
+    // Downstream callers (e.g. diff-by-id update flows) rely on Equatable
+    // (satisfied via Hashable) to detect that two legs with the same
+    // content but different ids are not interchangeable.
+    #expect(legA != legB)
+  }
+
+  @Test("legacy JSON without id decodes with a fresh non-nil id")
+  func legacyJSONWithoutIdDecodesWithFreshId() throws {
+    // Mirrors the legacy-row JSON shape from `TransactionLegTests`'s
+    // backward-compat decode tests but specifically pins the `id` field
+    // behaviour: the custom `init(from:)` must allocate a fresh UUID
+    // when `id` is absent, not throw `keyNotFound`.
+    let json = Data(
+      """
+      {"accountId":"\(UUID().uuidString)",\
+      "instrument":{"id":"AUD","kind":"fiatCurrency","name":"AUD","decimals":2},\
+      "quantity":100,"type":"income"}
+      """.utf8)
+    let decoded = try JSONDecoder().decode(TransactionLeg.self, from: json)
+    // Two decodes of the same legacy payload must produce different ids
+    // (each fresh allocation), ruling out the "constant default" trap.
+    let secondDecode = try JSONDecoder().decode(TransactionLeg.self, from: json)
+    #expect(decoded.id != secondDecode.id)
+  }
+}

--- a/MoolahTests/Domain/TransactionLegIdentityTests.swift
+++ b/MoolahTests/Domain/TransactionLegIdentityTests.swift
@@ -65,4 +65,28 @@ struct TransactionLegIdentityTests {
     let secondDecode = try JSONDecoder().decode(TransactionLeg.self, from: json)
     #expect(decoded.id != secondDecode.id)
   }
+
+  @Test("paidCopy(of:) allocates fresh ids for every leg")
+  func paidCopyAllocatesFreshLegIds() {
+    let scheduled = Transaction(
+      date: Date(), payee: "Rent",
+      legs: [
+        TransactionLeg(
+          accountId: UUID(),
+          instrument: Instrument.defaultTestInstrument,
+          quantity: Decimal(-1000), type: .expense),
+        TransactionLeg(
+          accountId: UUID(),
+          instrument: Instrument.defaultTestInstrument,
+          quantity: Decimal(1000), type: .transfer),
+      ])
+    let copy = Transaction.paidCopy(of: scheduled)
+    let scheduledIds = Set(scheduled.legs.map(\.id))
+    let copyIds = Set(copy.legs.map(\.id))
+    // Different transactions, distinct leg rows: ids must not collide.
+    #expect(scheduledIds.isDisjoint(with: copyIds))
+    #expect(copy.legs.count == scheduled.legs.count)
+    // Content is preserved.
+    #expect(copy.legs.map(\.quantity) == scheduled.legs.map(\.quantity))
+  }
 }

--- a/MoolahTests/Shared/TransactionDraftLegIdTests.swift
+++ b/MoolahTests/Shared/TransactionDraftLegIdTests.swift
@@ -49,4 +49,32 @@ struct TransactionDraftLegIdTests {
     #expect(rebuilt.legs[0].id == leg.id)
     #expect(rebuilt.legs[1].id != leg.id)
   }
+
+  @Test("applyAutofill clears legId so saving does not collide with the source's leg rows")
+  func applyAutofillClearsLegIds() throws {
+    let sourceLeg = TransactionLeg(
+      accountId: UUID(),
+      instrument: Instrument.defaultTestInstrument,
+      quantity: Decimal(-25), type: .expense,
+      categoryId: UUID())
+    let source = Transaction(
+      date: Date(timeIntervalSince1970: 0),
+      payee: "Coffee",
+      legs: [sourceLeg])
+
+    // A fresh draft is a brand-new transaction in progress.
+    var draft = TransactionDraft(accountId: nil, instrument: Instrument.defaultTestInstrument)
+
+    draft.applyAutofill(
+      from: source, categories: Categories(from: []), accounts: Accounts(from: []))
+
+    // The carried leg's content matches `source` but its id is regenerated
+    // at save time so it does not collide with `source.legs[0].id` in
+    // GRDB's primary key.
+    #expect(draft.legDrafts.allSatisfy { $0.legId == nil })
+
+    let savedNewId = UUID()
+    let saved = try #require(draft.toTransaction(id: savedNewId))
+    #expect(saved.legs.first?.id != sourceLeg.id)
+  }
 }

--- a/MoolahTests/Shared/TransactionDraftLegIdTests.swift
+++ b/MoolahTests/Shared/TransactionDraftLegIdTests.swift
@@ -1,0 +1,52 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("TransactionDraft preserves leg ids end-to-end")
+struct TransactionDraftLegIdTests {
+
+  @Test("init(from:) populates legId from each source leg")
+  func initFromTransactionPopulatesLegId() {
+    let leg = TransactionLeg(
+      accountId: UUID(),
+      instrument: Instrument.defaultTestInstrument,
+      quantity: Decimal(-10), type: .expense)
+    let txn = Transaction(date: Date(), payee: "Coffee", legs: [leg])
+    let draft = TransactionDraft(from: txn)
+    #expect(draft.legDrafts.first?.legId == leg.id)
+  }
+
+  @Test("toTransaction(id:) round-trips legId for legs that came from a transaction")
+  func toTransactionRoundTripsLegId() throws {
+    let leg = TransactionLeg(
+      accountId: UUID(),
+      instrument: Instrument.defaultTestInstrument,
+      quantity: Decimal(-10), type: .expense)
+    let txn = Transaction(date: Date(), payee: "Coffee", legs: [leg])
+    let draft = TransactionDraft(from: txn)
+    let rebuilt = try #require(draft.toTransaction(id: txn.id))
+    #expect(rebuilt.legs.map(\.id) == [leg.id])
+  }
+
+  @Test("addLeg leaves the new draft's legId nil; saving allocates a fresh id")
+  func addLegAllocatesFreshIdAtSave() throws {
+    let leg = TransactionLeg(
+      accountId: UUID(),
+      instrument: Instrument.defaultTestInstrument,
+      quantity: Decimal(-10), type: .expense)
+    let txn = Transaction(date: Date(), payee: "Coffee", legs: [leg])
+    var draft = TransactionDraft(from: txn)
+    // `isCustom` is the precondition for `toTransaction(id:)` to accept
+    // a multi-leg non-transfer draft below; without it `isValid` would
+    // refuse the second leg and `toTransaction` would return nil.
+    draft.isCustom = true
+    draft.addLeg(defaultAccountId: leg.accountId, instrument: Instrument.defaultTestInstrument)
+    #expect(draft.legDrafts.last?.legId == nil)
+
+    let rebuilt = try #require(draft.toTransaction(id: txn.id))
+    #expect(rebuilt.legs.count == 2)
+    #expect(rebuilt.legs[0].id == leg.id)
+    #expect(rebuilt.legs[1].id != leg.id)
+  }
+}

--- a/MoolahTests/Sync/TransactionHookUpdateDeleteTests.swift
+++ b/MoolahTests/Sync/TransactionHookUpdateDeleteTests.swift
@@ -71,10 +71,13 @@ struct TransactionHookUpdateDeleteTests {
     capture.changed.removeAll()
     capture.deleted.removeAll()
 
-    // Update with a fresh 2-leg set. `performUpdate` always replaces
-    // every leg row (new UUIDs assigned inside the repo) so the hook
-    // fan-out is: 1 TransactionRow change, 2 TransactionLegRow changes
-    // for the new legs, 2 TransactionLegRow deletes for the old legs.
+    // Update with a fresh 2-leg set (legs carry newly allocated ids —
+    // makeContractTestLeg assigns UUID() each call). performUpdate diffs
+    // the new ids against the persisted set; since none of the new ids
+    // match the originals, the diff treats both old legs as deleted and
+    // both new legs as inserts. Hook fan-out: 1 TransactionRow change,
+    // 2 TransactionLegRow changes (the inserts), 2 TransactionLegRow
+    // deletes (the now-absent originals).
     let updated = Transaction(
       id: txn.id, date: txn.date, payee: "Trade",
       legs: [

--- a/MoolahTests/Sync/TransactionHookUpdateDeleteTests.swift
+++ b/MoolahTests/Sync/TransactionHookUpdateDeleteTests.swift
@@ -48,7 +48,8 @@ struct TransactionHookUpdateDeleteTests {
     try await Task.sleep(for: .milliseconds(50))
   }
 
-  @Test("update(_:) emits TransactionRecord change plus per-leg LegRecord changes/deletes")
+  @Test(
+    "update(_:) preserving leg ids emits TransactionRow change + per-leg upserts, no deletes")
   func transactionUpdateEmitsLegRecordType() async throws {
     let database = try ProfileDatabase.openInMemory()
     let capture = HookCapture()
@@ -71,32 +72,77 @@ struct TransactionHookUpdateDeleteTests {
     capture.changed.removeAll()
     capture.deleted.removeAll()
 
-    // Update with a fresh 2-leg set (legs carry newly allocated ids —
-    // makeContractTestLeg assigns UUID() each call). performUpdate diffs
-    // the new ids against the persisted set; since none of the new ids
-    // match the originals, the diff treats both old legs as deleted and
-    // both new legs as inserts. Hook fan-out: 1 TransactionRow change,
-    // 2 TransactionLegRow changes (the inserts), 2 TransactionLegRow
-    // deletes (the now-absent originals).
-    let updated = Transaction(
-      id: txn.id, date: txn.date, payee: "Trade",
-      legs: [
-        makeContractTestLeg(accountId: accountId, quantity: -50, type: .transfer),
-        makeContractTestLeg(accountId: accountId, quantity: 50, type: .transfer),
-      ])
+    // Update with the same legs (preserving ids) but a different payee.
+    // Expected hook fan-out: 1 TransactionRow change, N TransactionLegRow
+    // changes (one upsert per leg), 0 TransactionLegRow deletes.
+    var updated = txn
+    updated.payee = "Renamed Trade"
     _ = try await txnRepo.update(updated)
     try await drainHookHops()
 
     let txnEmits = capture.changed.filter { $0.recordType == TransactionRow.recordType }
     #expect(txnEmits.map(\.id) == [txn.id])
     let legChanges = capture.changed.filter { $0.recordType == TransactionLegRow.recordType }
-    // A regression that mis-tagged the per-leg insert emit with the
-    // TransactionRow.recordType would drop this count to 0.
-    #expect(legChanges.count == 2)
+    // Identity check: the upsert must emit the *original* leg ids — not
+    // freshly-allocated ones. A regression that reintroduces fresh-UUID
+    // allocation in performUpdate would still emit two leg-changes
+    // (passing a count-only assertion) while churning the recordName.
+    let emittedLegIds = Set(legChanges.map(\.id))
+    let originalLegIds = Set(txn.legs.map(\.id))
+    #expect(emittedLegIds == originalLegIds)
+    // Crucially: no leg-delete events when the leg array is preserved by id.
     let legDeletes = capture.deleted.filter { $0.recordType == TransactionLegRow.recordType }
-    #expect(legDeletes.count == 2)
+    #expect(legDeletes.isEmpty)
     let txnDeletes = capture.deleted.filter { $0.recordType == TransactionRow.recordType }
     #expect(txnDeletes.isEmpty)
+  }
+
+  @Test(
+    "update(_:) replacing legs (different ids) emits per-leg upserts + per-leg deletes")
+  func transactionUpdateWithReplacedLegsEmitsDeletes() async throws {
+    let database = try ProfileDatabase.openInMemory()
+    let capture = HookCapture()
+    let txnRepo = GRDBTransactionRepository(
+      database: database,
+      defaultInstrument: .defaultTestInstrument,
+      conversionService: FixedConversionService(),
+      onRecordChanged: makeChangedHook(capture),
+      onRecordDeleted: makeDeletedHook(capture))
+
+    let accountId = UUID()
+    let txn = try await txnRepo.create(
+      Transaction(
+        date: Date(), payee: "Trade",
+        legs: [
+          makeContractTestLeg(accountId: accountId, quantity: -100, type: .transfer),
+          makeContractTestLeg(accountId: accountId, quantity: 100, type: .transfer),
+        ]))
+    try await drainHookHops()
+    capture.changed.removeAll()
+    capture.deleted.removeAll()
+
+    // Replace the leg array entirely — every leg has a fresh id.
+    // Expected: 2 leg-upserts (the new ids) + 2 leg-deletes (the old ids).
+    let replacement = Transaction(
+      id: txn.id, date: txn.date, payee: txn.payee,
+      legs: [
+        makeContractTestLeg(accountId: accountId, quantity: -50, type: .transfer),
+        makeContractTestLeg(accountId: accountId, quantity: 50, type: .transfer),
+      ])
+    _ = try await txnRepo.update(replacement)
+    try await drainHookHops()
+
+    let legChanges = capture.changed.filter { $0.recordType == TransactionLegRow.recordType }
+    // Identity check on the upsert side: emitted ids match the *replacement*
+    // legs, not the originals.
+    let replacementIds = Set(replacement.legs.map(\.id))
+    let changedIds = Set(legChanges.map(\.id))
+    #expect(changedIds == replacementIds)
+    let legDeletes = capture.deleted.filter { $0.recordType == TransactionLegRow.recordType }
+    // The deleted ids are the original legs', not the replacement's.
+    let originalIds = Set(txn.legs.map(\.id))
+    let deletedIds = Set(legDeletes.map(\.id))
+    #expect(deletedIds == originalIds)
   }
 
   @Test("delete(id:) emits TransactionRecord delete plus per-leg LegRecord deletes")

--- a/MoolahTests/Sync/TransactionLegSyncSemanticTests.swift
+++ b/MoolahTests/Sync/TransactionLegSyncSemanticTests.swift
@@ -1,0 +1,207 @@
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+// Suite is intentionally non-isolated. The tests are `async throws` and
+// touch no main-actor state, so adding `@MainActor` would be a no-op.
+// `applyRemoteChangesSync` itself is synchronous — its file-header
+// comment in `GRDBTransactionLegRepository.swift` documents that it is
+// called from the CKSyncEngine delegate executor in production.
+@Suite("TransactionLeg sync ingestion semantics")
+struct TransactionLegSyncSemanticTests {
+
+  @Test("applyRemoteChangesSync with same-id leg row is idempotent — no duplicate")
+  func sameLegIdUpsertIsIdempotent() async throws {
+    let database = try ProfileDatabase.openInMemory()
+    let txnRepo = GRDBTransactionRepository(
+      database: database,
+      defaultInstrument: .defaultTestInstrument,
+      conversionService: FixedConversionService())
+    let legRepo = GRDBTransactionLegRepository(database: database)
+    let accountId = UUID()
+    let txn = try await txnRepo.create(
+      Transaction(
+        date: Date(), payee: "Rent",
+        legs: [
+          TransactionLeg(
+            accountId: accountId,
+            instrument: Instrument.defaultTestInstrument,
+            quantity: Decimal(-1000), type: .expense)
+        ]))
+    let originalLegId = txn.legs[0].id
+
+    // Simulate the server re-delivering the same leg (e.g. a re-fetch
+    // after a network blip, or the originating device's own queued
+    // record bouncing back). Same id ⇒ upsert lands on the existing row.
+    let phantomRow = TransactionLegRow(
+      id: originalLegId,
+      recordName: TransactionLegRow.recordName(for: originalLegId),
+      transactionId: txn.id,
+      accountId: accountId,
+      instrumentId: Instrument.defaultTestInstrument.id,
+      quantity:
+        InstrumentAmount(
+          quantity: Decimal(-1000), instrument: Instrument.defaultTestInstrument
+        ).storageValue,
+      type: TransactionType.expense.rawValue,
+      categoryId: nil, earmarkId: nil, sortOrder: 0,
+      encodedSystemFields: nil, externalId: nil, counterpartyAddress: nil)
+    try legRepo.applyRemoteChangesSync(saved: [phantomRow], deleted: [])
+
+    let reloaded = try #require(try await fetchTransaction(txn.id, via: txnRepo))
+    #expect(
+      reloaded.legs.count == 1,
+      "Same-id re-delivery must not duplicate legs — count was \(reloaded.legs.count)")
+    #expect(reloaded.legs[0].id == originalLegId)
+  }
+
+  @Test(
+    "applyRemoteChangesSync with a different-id orphan leg lands as a second row — documents residual race"
+  )
+  func differentIdOrphanLandsAsSecondRow() async throws {
+    let database = try ProfileDatabase.openInMemory()
+    let txnRepo = GRDBTransactionRepository(
+      database: database,
+      defaultInstrument: .defaultTestInstrument,
+      conversionService: FixedConversionService())
+    let legRepo = GRDBTransactionLegRepository(database: database)
+    let accountId = UUID()
+    let txn = try await txnRepo.create(
+      Transaction(
+        date: Date(), payee: "Rent",
+        legs: [
+          TransactionLeg(
+            accountId: accountId,
+            instrument: Instrument.defaultTestInstrument,
+            quantity: Decimal(-1000), type: .expense)
+        ]))
+
+    // A server-side orphan with a UUID that the local row does NOT
+    // share. Under the new stable-id design this can only happen if
+    // the original "leg removed from transaction" delete-uplink failed
+    // and the orphan stays on the server with a uuid the device never
+    // owned. Stable ids make this less likely (re-queued deletes hit
+    // the right record) but do not make it impossible. The user
+    // resolves manually (design Section 7).
+    let orphanId = UUID()
+    let orphanRow = TransactionLegRow(
+      id: orphanId,
+      recordName: TransactionLegRow.recordName(for: orphanId),
+      transactionId: txn.id,
+      accountId: accountId,
+      instrumentId: Instrument.defaultTestInstrument.id,
+      quantity:
+        InstrumentAmount(
+          quantity: Decimal(-1000), instrument: Instrument.defaultTestInstrument
+        ).storageValue,
+      type: TransactionType.expense.rawValue,
+      categoryId: nil, earmarkId: nil, sortOrder: 1,
+      encodedSystemFields: nil, externalId: nil, counterpartyAddress: nil)
+    try legRepo.applyRemoteChangesSync(saved: [orphanRow], deleted: [])
+
+    let reloaded = try #require(try await fetchTransaction(txn.id, via: txnRepo))
+    #expect(
+      reloaded.legs.count == 2,
+      "Different-id orphan must land as a second row — documents residual race")
+  }
+
+  @Test("applyRemoteChangesSync rolls back when an upsert in the batch fails")
+  func applyRemoteChangesSyncRollsBackOnFailure() throws {
+    let database = try ProfileDatabase.openInMemory()
+    let legRepo = GRDBTransactionLegRepository(database: database)
+
+    // Seed a transaction header + one leg, plus a `BEFORE INSERT` trigger
+    // on `transaction_leg` that fires only when `sort_order = 99` so a
+    // later good leg can land but the badly-marked leg blows up. The
+    // single multi-statement write that batches `[good, bad]` upserts
+    // must roll back atomically — neither row may persist.
+    let txId = UUID()
+    let originalLegId = UUID()
+    try seedRollbackFixture(database: database, txId: txId, originalLegId: originalLegId)
+
+    let goodRow = makeRollbackTestLeg(transactionId: txId, quantity: 200, sortOrder: 1)
+    let badRow = makeRollbackTestLeg(transactionId: txId, quantity: 300, sortOrder: 99)
+
+    do {
+      try legRepo.applyRemoteChangesSync(saved: [goodRow, badRow], deleted: [])
+      Issue.record("Expected applyRemoteChangesSync to throw — rollback test cannot proceed")
+    } catch {
+      // Expected.
+    }
+
+    // Only the original seeded leg may remain; the good row must not have
+    // been committed.
+    try database.read { database in
+      let count = try TransactionLegRow.fetchCount(database)
+      #expect(count == 1, "Multi-statement write must roll back — good row must not persist")
+      let surviving =
+        try TransactionLegRow
+        .select(TransactionLegRow.Columns.id, as: UUID.self)
+        .fetchAll(database)
+      #expect(surviving == [originalLegId])
+    }
+  }
+
+  /// Seeds an instrument + transaction + one leg, then installs a
+  /// `BEFORE INSERT` trigger that aborts when `sort_order = 99`. Used by
+  /// `applyRemoteChangesSyncRollsBackOnFailure` to force a mid-batch
+  /// failure inside the multi-statement write.
+  private func seedRollbackFixture(
+    database: any DatabaseWriter, txId: UUID, originalLegId: UUID
+  ) throws {
+    try database.write { database in
+      try database.execute(
+        sql: """
+          INSERT INTO instrument (id, record_name, kind, name, decimals)
+            VALUES ('AUD', 'instrument-AUD', 'fiatCurrency', 'AUD', 2);
+          INSERT INTO "transaction" (id, record_name, date)
+            VALUES (?, 'tx-rollback', '2026-01-01');
+          INSERT INTO transaction_leg
+            (id, record_name, transaction_id, instrument_id,
+             quantity, type, sort_order)
+            VALUES (?, ?, ?, 'AUD', 100, 'expense', 0);
+          CREATE TRIGGER fail_sort_99
+          BEFORE INSERT ON transaction_leg
+          WHEN NEW.sort_order = 99
+          BEGIN
+            SELECT RAISE(ABORT, 'forced rollback for sync test');
+          END;
+          """,
+        arguments: [
+          txId,
+          originalLegId, TransactionLegRow.recordName(for: originalLegId), txId,
+        ])
+    }
+  }
+
+  /// Builds a `TransactionLegRow` for the rollback test. `sortOrder = 99`
+  /// is the trigger-armed marker that forces the row's upsert to abort.
+  private func makeRollbackTestLeg(
+    transactionId: UUID, quantity: Int64, sortOrder: Int
+  ) -> TransactionLegRow {
+    let legId = UUID()
+    return TransactionLegRow(
+      id: legId,
+      recordName: TransactionLegRow.recordName(for: legId),
+      transactionId: transactionId,
+      accountId: nil,
+      instrumentId: "AUD",
+      quantity: quantity,
+      type: TransactionType.expense.rawValue,
+      categoryId: nil, earmarkId: nil, sortOrder: sortOrder,
+      encodedSystemFields: nil, externalId: nil, counterpartyAddress: nil)
+  }
+
+  /// Fetch a single transaction by id via the protocol's `fetchAll(filter:)`.
+  /// The `TransactionRepository` protocol does not expose a `fetch(id:)`, so
+  /// this helper unfilters and picks by id — mirrors the same pattern in
+  /// `GRDBTransactionStableLegIdTests`.
+  private func fetchTransaction(
+    _ id: UUID, via repo: GRDBTransactionRepository
+  ) async throws -> Transaction? {
+    let all = try await repo.fetchAll(filter: TransactionFilter())
+    return all.first(where: { $0.id == id })
+  }
+}

--- a/Shared/Models/TransactionDraft+Autofill.swift
+++ b/Shared/Models/TransactionDraft+Autofill.swift
@@ -32,6 +32,13 @@ extension TransactionDraft {
       }
     }
 
+    // Autofill copies content from a different transaction; legs save
+    // into *this* transaction so they need new ids — preserving the
+    // source's leg ids would PK-collide on the GRDB upsert against the
+    // source's own row. `clearingLegId()` owns the rebuild so a future
+    // `LegDraft` field addition can't silently drop its value here.
+    newDraft.legDrafts = newDraft.legDrafts.map { $0.clearingLegId() }
+
     // Preserve the viewed account. Skip custom mode: a complex match has no
     // single "viewed" leg, and adopting its structure means the user is
     // already accepting whatever accounts it references.

--- a/Shared/Models/TransactionDraft+Negation.swift
+++ b/Shared/Models/TransactionDraft+Negation.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+// MARK: - Negation Helpers
+
+extension TransactionDraft {
+  /// Whether a leg type uses negated display (expense, transfer → negate; income, openingBalance → as-is).
+  static func displaysNegated(_ type: TransactionType) -> Bool {
+    switch type {
+    case .expense, .transfer: return true
+    case .income, .openingBalance, .trade: return false
+    }
+  }
+
+  /// Convert a leg quantity to display text using the negation rule.
+  static func displayText(quantity: Decimal, type: TransactionType, decimals: Int) -> String {
+    let displayValue = displaysNegated(type) ? -quantity : quantity
+    if displayValue == .zero {
+      return "0"
+    }
+    return displayValue.formatted(.number.precision(.fractionLength(decimals)).grouping(.never))
+  }
+
+  /// Parse display text back to a signed quantity using the negation rule.
+  /// Returns nil if the text can't be parsed.
+  static func parseDisplayText(_ text: String, type: TransactionType, decimals: Int) -> Decimal? {
+    guard let parsed = InstrumentAmount.parseQuantity(from: text, decimals: decimals) else {
+      return nil
+    }
+    return displaysNegated(type) ? -parsed : parsed
+  }
+}

--- a/Shared/Models/TransactionDraft+Negation.swift
+++ b/Shared/Models/TransactionDraft+Negation.swift
@@ -1,7 +1,5 @@
 import Foundation
 
-// MARK: - Negation Helpers
-
 extension TransactionDraft {
   /// Whether a leg type uses negated display (expense, transfer → negate; income, openingBalance → as-is).
   static func displaysNegated(_ type: TransactionType) -> Bool {

--- a/Shared/Models/TransactionDraft+SimpleMode.swift
+++ b/Shared/Models/TransactionDraft+SimpleMode.swift
@@ -179,6 +179,7 @@ extension TransactionDraft {
       let counterpartAmount = negatedAmountText(relevantLeg.amountText)
 
       let counterpartLeg = LegDraft(
+        legId: nil,
         type: .transfer,
         accountId: defaultAccount?.id,
         amountText: counterpartAmount,

--- a/Shared/Models/TransactionDraft+TradeMode.swift
+++ b/Shared/Models/TransactionDraft+TradeMode.swift
@@ -42,6 +42,7 @@ extension TransactionDraft {
   mutating func appendFee(defaultInstrument: Instrument) {
     legDrafts.append(
       LegDraft(
+        legId: nil,
         type: .expense,
         accountId: paidLegIndex.flatMap { legDrafts[$0].accountId },
         amountText: "0",
@@ -125,6 +126,7 @@ extension TransactionDraft {
     accountId: UUID?, amountText: String, instrument: Instrument?
   ) -> LegDraft {
     LegDraft(
+      legId: nil,
       type: .trade,
       accountId: accountId,
       amountText: amountText,
@@ -171,6 +173,7 @@ extension TransactionDraft {
   private mutating func applyIncomeLeg(from source: LegDraft) {
     legDrafts = [
       LegDraft(
+        legId: nil,
         type: .income,
         accountId: source.accountId,
         amountText: Self.adjustAmountText(source.amountText, from: .trade, to: .income),
@@ -185,6 +188,7 @@ extension TransactionDraft {
   private mutating func applyExpenseLeg(from source: LegDraft) {
     legDrafts = [
       LegDraft(
+        legId: nil,
         type: .expense,
         accountId: source.accountId,
         amountText: Self.adjustAmountText(source.amountText, from: .trade, to: .expense),
@@ -200,6 +204,7 @@ extension TransactionDraft {
     let primaryText = Self.adjustAmountText(paidLeg.amountText, from: .trade, to: .transfer)
     let other = accounts.sidebarOrdered(excluding: paidLeg.accountId).first
     let counterpart = LegDraft(
+      legId: nil,
       type: .transfer,
       accountId: other?.id,
       amountText: negatedAmountText(primaryText),
@@ -208,6 +213,7 @@ extension TransactionDraft {
       earmarkId: nil,
       instrument: other?.instrument ?? paidLeg.instrument)
     let primary = LegDraft(
+      legId: nil,
       type: .transfer,
       accountId: paidLeg.accountId,
       amountText: primaryText,

--- a/Shared/Models/TransactionDraft.swift
+++ b/Shared/Models/TransactionDraft.swift
@@ -96,6 +96,23 @@ struct TransactionDraft: Sendable, Equatable {
       accountId == nil && earmarkId != nil
     }
 
+    /// Returns a copy of this leg draft with `legId` cleared. Used by
+    /// `applyAutofill` to detach legs carried in from another
+    /// transaction so they save into a new `transaction_leg.id` and do
+    /// not PK-collide with the source. `legId` is `let`, so a new
+    /// value must be returned.
+    func clearingLegId() -> LegDraft {
+      LegDraft(
+        legId: nil,
+        type: type,
+        accountId: accountId,
+        amountText: amountText,
+        categoryId: categoryId,
+        categoryText: categoryText,
+        earmarkId: earmarkId,
+        instrument: instrument)
+    }
+
     /// The instrument the editor should default to for this leg when the
     /// leg has no explicit instrument override stored. Resolves through
     /// the leg's account, then its earmark, then falls back to AUD as a
@@ -119,35 +136,9 @@ struct TransactionDraft: Sendable, Equatable {
     }
   }
 
-  // MARK: - Negation Helpers
-
-  /// Whether a leg type uses negated display (expense, transfer → negate; income, openingBalance → as-is).
-  static func displaysNegated(_ type: TransactionType) -> Bool {
-    switch type {
-    case .expense, .transfer: return true
-    case .income, .openingBalance, .trade: return false
-    }
-  }
-
-  /// Convert a leg quantity to display text using the negation rule.
-  static func displayText(quantity: Decimal, type: TransactionType, decimals: Int) -> String {
-    let displayValue = displaysNegated(type) ? -quantity : quantity
-    if displayValue == .zero {
-      return "0"
-    }
-    return displayValue.formatted(.number.precision(.fractionLength(decimals)).grouping(.never))
-  }
-
-  /// Parse display text back to a signed quantity using the negation rule.
-  /// Returns nil if the text can't be parsed.
-  static func parseDisplayText(_ text: String, type: TransactionType, decimals: Int) -> Decimal? {
-    guard let parsed = InstrumentAmount.parseQuantity(from: text, decimals: decimals) else {
-      return nil
-    }
-    return displaysNegated(type) ? -parsed : parsed
-  }
 }
 
+// Negation helpers live in `TransactionDraft+Negation.swift`.
 // Computed accessors, editing methods, and mode-switching helpers for simple mode
 // live in `TransactionDraft+SimpleMode.swift`.
 

--- a/Shared/Models/TransactionDraft.swift
+++ b/Shared/Models/TransactionDraft.swift
@@ -55,6 +55,10 @@ struct TransactionDraft: Sendable, Equatable {
 
   /// A draft for a single leg in a transaction.
   struct LegDraft: Sendable, Equatable {
+    /// Stable id of the leg this draft maps back to in
+    /// `transaction_leg.id`. `nil` for legs added during this draft
+    /// session — `toTransaction(id:)` allocates a fresh id at save time.
+    let legId: UUID?
     var type: TransactionType
     var accountId: UUID?
     /// The display value — negated for expense/transfer types.
@@ -68,6 +72,7 @@ struct TransactionDraft: Sendable, Equatable {
     var instrument: Instrument?
 
     init(
+      legId: UUID? = nil,
       type: TransactionType,
       accountId: UUID?,
       amountText: String,
@@ -76,6 +81,7 @@ struct TransactionDraft: Sendable, Equatable {
       earmarkId: UUID?,
       instrument: Instrument? = nil
     ) {
+      self.legId = legId
       self.type = type
       self.accountId = accountId
       self.amountText = amountText
@@ -160,6 +166,7 @@ extension TransactionDraft {
     // cross-currency trade booked against a single investment account).
     let drafts = transaction.legs.map { leg in
       LegDraft(
+        legId: leg.id,
         type: leg.type,
         accountId: leg.accountId,
         amountText: Self.displayText(
@@ -217,6 +224,7 @@ extension TransactionDraft {
       isCustom: false,
       legDrafts: [
         LegDraft(
+          legId: nil,
           type: .income, accountId: nil, amountText: "0",
           categoryId: nil, categoryText: "", earmarkId: earmarkId,
           instrument: instrument)
@@ -238,6 +246,7 @@ extension TransactionDraft {
       isCustom: false,
       legDrafts: [
         LegDraft(
+          legId: nil,
           type: .expense, accountId: accountId, amountText: "0",
           categoryId: nil, categoryText: "", earmarkId: nil,
           instrument: instrument)
@@ -321,6 +330,7 @@ extension TransactionDraft {
 
       legs.append(
         TransactionLeg(
+          id: legDraft.legId ?? UUID(),
           accountId: legDraft.accountId,
           instrument: instrument,
           quantity: quantity,
@@ -363,6 +373,7 @@ extension TransactionDraft {
   mutating func addLeg(defaultAccountId: UUID? = nil, instrument: Instrument? = nil) {
     legDrafts.append(
       LegDraft(
+        legId: nil,
         type: .expense, accountId: defaultAccountId, amountText: "0",
         categoryId: nil, categoryText: "", earmarkId: nil,
         instrument: instrument


### PR DESCRIPTION
## Summary

Implements [`plans/2026-05-08-stable-transaction-leg-id-implementation-plan.md`](https://github.com/ajsutton/moolah-native/blob/main/plans/2026-05-08-stable-transaction-leg-id-implementation-plan.md). See [`plans/2026-05-08-stable-transaction-leg-id-design.md`](https://github.com/ajsutton/moolah-native/blob/main/plans/2026-05-08-stable-transaction-leg-id-design.md) for the design rationale.

`TransactionLeg` now carries a stable `let id: UUID`. `GRDBTransactionRepository.update(_:)` switches from "delete every old leg, insert with fresh UUIDs" to diff-by-id (delete legs whose id disappeared, upsert the rest in place, re-attaching cached `encodedSystemFields`). `record_name` on `transaction_leg` is now stable across writes — closing the class of bugs where a dropped leg-delete uplink left orphan legs on the CloudKit server which propagated back as duplicates on later edits (production symptom: 5 scheduled transactions in the Large Test profile).

Per the design's out-of-scope clause: no dedup utility for the existing in-the-wild duplicates. User cleans them up manually.

## Commits (10)

1. `feat(domain): TransactionLeg gains stable id`
2. `feat(swiftdata): TransactionLegRecord round-trips leg id`
3. `feat(grdb): TransactionLegRow round-trips leg id`
4. `feat(grdb): diff-by-id update preserves stable leg ids`
5. `feat(domain): paidCopy allocates fresh leg ids`
6. `feat(transactions): LegDraft carries stable legId through edits`
7. `feat(transactions): autofill clears legId so saves do not PK-collide`
8. `test(sync): hook fan-out reflects diff-by-id update semantics`
9. `test(sync): pin leg ingestion idempotence and residual-race semantics`
10. `style(transactions): drop unnecessary // MARK: from short Negation file`

## Tests added

- `TransactionLegIdentityTests` — domain-level identity (default unique, explicit id round-trips, paidCopy fresh ids, legacy-JSON-without-id decodes with fresh id)
- `TransactionLegRowMappingTests` — row mapper round-trip + override semantics
- `GRDBTransactionStableLegIdTests` — repository round-trip stability (header-only edit, leg removal, reorder, create with pre-assigned id, encodedSystemFields preservation, rollback on mid-write throw)
- `TransactionDraftLegIdTests` — draft round-trip + applyAutofill
- `TransactionHookUpdateDeleteTests` — id-set equality on hook fan-out for both preserve-ids and replace-ids paths
- `TransactionLegSyncSemanticTests` — sync ingestion idempotence (same-id phantom upserts in place), residual-race documentation (different-id orphan lands as second row), multi-statement-write rollback

## Test plan

- [x] `just format-check` clean
- [x] `just build-mac` succeeds with no new warnings in user code
- [x] `just test-mac` (full suite) passes
- [x] `code-review`, `database-code-review`, `sync-review`, `concurrency-review` all "no remaining issues" on the cross-cutting final pass

## Reviews

Each stage was reviewed by all relevant agents and iterated until clean. Final cross-cutting pass also clean. Total review iterations across the implementation: ~16 review/fix cycles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)