### PR TITLE
ui(settings): resizable window + scroll pane for token list, full token addresses

### DIFF
--- a/App/MoolahApp.swift
+++ b/App/MoolahApp.swift
@@ -206,6 +206,7 @@ struct MoolahApp: App {
           .environment(syncCoordinator)
           .modelContainer(containerManager.indexContainer)
       }
+      .windowResizability(.contentMinSize)
 
       // Auto-open the main window on `--ui-testing` launches.
       // `WindowGroup(for: Profile.ID.self)` does not present without an

--- a/Features/Settings/CryptoRegistrationRow.swift
+++ b/Features/Settings/CryptoRegistrationRow.swift
@@ -3,7 +3,8 @@ import SwiftUI
 
 /// Compact row used by the Registered Tokens, Discovered Tokens inbox,
 /// and Spam Tokens management lists. Renders the instrument's symbol,
-/// name, chain, optional truncated contract address, and the badge set
+/// name, chain, optional contract address (shown in full so a spoofed
+/// contract can't hide behind a truncation ellipsis), and the badge set
 /// derived from the row's `CryptoProviderMapping`.
 ///
 /// `CryptoRegistrationRow` is read-only — actions (remove, mark-spam,
@@ -33,11 +34,15 @@ struct CryptoRegistrationRow: View {
         Text(instrument.name)
           .font(.caption)
           .foregroundStyle(.secondary)
-        if showsContractAddress, let truncated = truncatedContractAddress {
-          Text(truncated)
+        if showsContractAddress, let address = instrument.contractAddress {
+          // Full address — never truncated. A trailing-ellipsis form
+          // can hide the only character that distinguishes a legitimate
+          // contract from a spoofed one (issue #790). `.textSelection`
+          // lets the user copy it to compare against an explorer.
+          Text(address)
             .font(.caption2.monospaced())
             .foregroundStyle(.secondary)
-            .lineLimit(1)
+            .textSelection(.enabled)
         }
       }
       Spacer()
@@ -51,19 +56,6 @@ struct CryptoRegistrationRow: View {
   }
 
   private var instrument: Instrument { registration.instrument }
-
-  /// Truncated `0xabcd…wxyz` style label for the contract address, or
-  /// `nil` for native gas tokens (no contract). 6+4 hex chars match the
-  /// design's truncation convention; full address is available in the
-  /// row's `accessibilityLabel`.
-  private var truncatedContractAddress: String? {
-    guard let address = instrument.contractAddress, address.count > 12 else {
-      return instrument.contractAddress
-    }
-    let prefix = address.prefix(6)
-    let suffix = address.suffix(4)
-    return "\(prefix)…\(suffix)"
-  }
 
   private var accessibilityLabel: String {
     let mapping = registration.mapping

--- a/Features/Settings/CryptoSettingsView+TokenList.swift
+++ b/Features/Settings/CryptoSettingsView+TokenList.swift
@@ -34,13 +34,33 @@ extension CryptoSettingsView {
       )
       .frame(maxWidth: .infinity)
     } else {
-      ForEach(pricedRegistrations) { registration in
-        // `showsContractAddress: true` — wallets with copied tickers
-        // (issue #790) need the truncated address visible so a
-        // legitimate token can be told apart from a spam contract
-        // claiming the same symbol.
-        registrationRow(for: registration)
-      }
+      // `showsContractAddress: true` — wallets with copied tickers
+      // (issue #790) need the full contract address visible so a
+      // legitimate token can be told apart from a spam contract
+      // claiming the same symbol.
+      #if os(macOS)
+        // Cap the section's height so a long token list scrolls within
+        // its own pane instead of pushing the CoinGecko / API-key
+        // sections off-screen.
+        ScrollView {
+          LazyVStack(spacing: 0) {
+            ForEach(
+              Array(pricedRegistrations.enumerated()), id: \.element.id
+            ) { index, registration in
+              if index > 0 {
+                Divider()
+              }
+              registrationRow(for: registration)
+                .padding(.vertical, 4)
+            }
+          }
+        }
+        .frame(maxHeight: 280)
+      #else
+        ForEach(pricedRegistrations) { registration in
+          registrationRow(for: registration)
+        }
+      #endif
     }
   }
 

--- a/Features/Settings/SettingsView+macOS.swift
+++ b/Features/Settings/SettingsView+macOS.swift
@@ -79,7 +79,8 @@
           rulesTabContent
         }
       }
-      .frame(minWidth: 600, minHeight: 400)
+      .frame(minWidth: 600, idealWidth: 700, minHeight: 400, idealHeight: 560)
+      .frame(maxWidth: .infinity, maxHeight: .infinity)
       .sheet(isPresented: $showAddProfile) {
         ProfileFormView()
           .environment(profileStore)


### PR DESCRIPTION
## Summary
- macOS Settings window is now resizable past its ideal size (was fixed-size). Adds `windowResizability(.contentMinSize)` plus a `maxWidth/maxHeight: .infinity` on the layout so it grows to fill the window.
- Registered Tokens list on macOS is wrapped in a height-capped `ScrollView` so a long list doesn't push the CoinGecko / API-key sections off-screen.
- Token contract addresses now render in **full** with `.textSelection(.enabled)`. The previous `0xabcd…wxyz` truncation could hide the one character that distinguishes a legitimate contract from a spoofed one (issue #790).

iOS path is unchanged (the form already scrolls inside its NavigationStack page).

## Test plan
- [ ] Open Settings → drag the bottom edge: window resizes vertically.
- [ ] Add many tokens → Registered Tokens scrolls within its pane; CoinGecko section stays visible without scrolling the outer form.
- [ ] Token rows show the full `0x…` contract address, selectable for copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)