### PR TITLE
fix(crypto): dismiss create-account sheet without waiting for first sync

### DIFF
--- a/Features/Crypto/CryptoAccountCreationView.swift
+++ b/Features/Crypto/CryptoAccountCreationView.swift
@@ -122,16 +122,15 @@ struct CryptoAccountCreationLogic {
 
     do {
       let created = try await accountStore.create(account)
-      // Kick off the initial sync so the wallet's history starts
-      // loading immediately. The store internally guards against
-      // duplicate in-flight syncs, so the next scenePhase `.active`
-      // trigger collapses with this dispatch rather than queueing a
-      // redundant pass. A `nil` `cryptoSyncStore` (degraded launch)
-      // leaves the account stale; the next stale-sync pass picks it
-      // up.
-      if let cryptoSyncStore {
-        await cryptoSyncStore.syncAccount(created)
-      }
+      // Kick off the initial sync without awaiting so the parent sheet
+      // can `dismiss()` the moment the account is persisted instead of
+      // sitting open through the entire network round-trip. The store
+      // tracks the spawned task so it's cancelled on profile teardown
+      // and collapses with the next scenePhase `.active` trigger
+      // rather than queueing a redundant pass. A `nil` `cryptoSyncStore`
+      // (degraded launch) leaves the account stale; the next
+      // stale-sync pass picks it up.
+      cryptoSyncStore?.scheduleInitialSync(for: created)
       return .created(created)
     } catch {
       return .failure(error)

--- a/Features/Crypto/CryptoSyncStore.swift
+++ b/Features/Crypto/CryptoSyncStore.swift
@@ -81,6 +81,17 @@ final class CryptoSyncStore {
   /// tracked so teardown can cancel them.
   var sceneActiveSyncTask: Task<Void, Never>?
 
+  /// Fire-and-forget initial-sync tasks dispatched by the create-account
+  /// form, keyed by account id. The form spawns one of these per newly
+  /// created crypto account (via `scheduleInitialSync(for:)`) so the
+  /// sheet can dismiss the moment the account is persisted instead of
+  /// awaiting the network round-trip. Tracked here per
+  /// `guides/CONCURRENCY_GUIDE.md` §8 so `cancelTimer()` (called from
+  /// `ProfileSession.cleanupSync`) can cancel any in-flight sync that
+  /// outlives the form, and so tests can await completion via
+  /// `waitForPendingInitialSyncs()`.
+  private(set) var initialSyncTasks: [UUID: Task<Void, Never>] = [:]
+
   private static let logger = Logger(
     subsystem: "com.moolah.app", category: "CryptoSyncStore")
 
@@ -151,6 +162,34 @@ final class CryptoSyncStore {
     await syncAccounts([account])
   }
 
+  /// Fire-and-forget kick-off of `syncAccount(_:)` for a newly created
+  /// crypto account. Returns immediately so the create-account sheet
+  /// can `dismiss()` the moment the account is persisted; the network
+  /// sync continues in the spawned task, which is tracked in
+  /// `initialSyncTasks` so `cancelTimer()` can tear it down on profile
+  /// teardown. A second call for an account that already has a pending
+  /// initial-sync task is a no-op — the original task wins, mirroring
+  /// the duplicate-collapse rule on `syncAccount(_:)` itself.
+  func scheduleInitialSync(for account: Account) {
+    let id = account.id
+    guard initialSyncTasks[id] == nil else { return }
+    initialSyncTasks[id] = Task { [weak self] in
+      await self?.syncAccount(account)
+      self?.initialSyncTasks.removeValue(forKey: id)
+    }
+  }
+
+  /// Test seam — awaits every tracked initial-sync task to completion.
+  /// Production code never needs this: the sheet dismisses on
+  /// `.created` and the sync runs out-of-band. Tests use it to
+  /// synchronise on the post-sync state (e.g. asserting that the
+  /// alchemy stub recorded the build call).
+  func waitForPendingInitialSyncs() async {
+    while let task = initialSyncTasks.first?.value {
+      await task.value
+    }
+  }
+
   // MARK: - Lifecycle
 
   /// Call from `.onChange(of: scenePhase)` in the root scene. Owns the
@@ -171,15 +210,18 @@ final class CryptoSyncStore {
     }
   }
 
-  /// Cancels and clears the hourly stale-check timer plus any
-  /// in-flight scene-active sync. Safe to call when no task is
-  /// running. Exposed for `ProfileSession.cleanupSync` so neither task
-  /// outlives a profile teardown.
+  /// Cancels and clears the hourly stale-check timer, any in-flight
+  /// scene-active sync, and any pending initial-sync tasks scheduled by
+  /// the create-account form. Safe to call when no task is running.
+  /// Exposed for `ProfileSession.cleanupSync` so no task outlives a
+  /// profile teardown.
   func cancelTimer() {
     timerTask?.cancel()
     timerTask = nil
     sceneActiveSyncTask?.cancel()
     sceneActiveSyncTask = nil
+    for task in initialSyncTasks.values { task.cancel() }
+    initialSyncTasks.removeAll()
   }
 
   // MARK: - Sync algorithm (parallel build → sequential apply)

--- a/MoolahTests/Features/Crypto/CryptoAccountCreationStoreTests.swift
+++ b/MoolahTests/Features/Crypto/CryptoAccountCreationStoreTests.swift
@@ -144,10 +144,54 @@ struct CryptoAccountCreationStoreTests {
       return
     }
 
+    // The kick-off is fire-and-forget so the create-account sheet can
+    // dismiss immediately; await the spawned task before asserting on
+    // the alchemy stub.
+    await fixture.cryptoSyncStore.waitForPendingInitialSyncs()
+
     // The store invokes the build phase exactly once for the newly-
     // created account, with the canonical wallet address it persisted.
     #expect(fixture.alchemy.recordedCalls.count == 1)
     #expect(fixture.alchemy.recordedCalls.first?.walletAddress == Self.validAddress)
+  }
+
+  @Test("Submit returns immediately rather than blocking on the wallet sync")
+  func submitDoesNotBlockOnSync() async throws {
+    let fixture = try makeFixture()
+    // Park the sync indefinitely so we can prove `submit` returns
+    // without waiting for it. Without the fix, `submit` awaited
+    // `syncAccount`, leaving the create-account sheet open until the
+    // entire network round-trip finished — visible to the user as
+    // "the new account appears in the sidebar but the form sticks
+    // around".
+    fixture.alchemy.setBeforeAssetTransfers { @Sendable in
+      try? await Task.sleep(for: .seconds(30))
+    }
+    let logic = CryptoAccountCreationLogic(
+      accountStore: fixture.accountStore,
+      cryptoSyncStore: fixture.cryptoSyncStore)
+
+    let start = ContinuousClock.now
+    let outcome = await logic.submit(
+      name: "Fast Dismiss Wallet",
+      chain: .ethereum,
+      walletAddressInput: Self.validAddress)
+    let elapsed = ContinuousClock.now - start
+
+    guard case .created = outcome else {
+      Issue.record("Expected .created outcome, got \(outcome)")
+      fixture.cryptoSyncStore.cancelTimer()
+      return
+    }
+    // The fire-and-forget sync is still parked at the alchemy hook;
+    // submit must already be back so the sheet can dismiss. Allow a
+    // generous budget — only scheduling overhead should land between
+    // create and return.
+    #expect(elapsed < .seconds(1))
+
+    // Cancel the parked sync so the spawned 30-second sleep doesn't
+    // outlive the test.
+    fixture.cryptoSyncStore.cancelTimer()
   }
 
   @Test("Invalid address aborts before any repository or sync work")

--- a/MoolahTests/Features/Crypto/CryptoAccountCreationStoreTests.swift
+++ b/MoolahTests/Features/Crypto/CryptoAccountCreationStoreTests.swift
@@ -101,8 +101,15 @@ struct CryptoAccountCreationStoreTests {
     // on `valuationMode` would see the wrong intent.
     #expect(created.valuationMode == .calculatedFromTrades)
 
-    // The store optimistically populates its observable list, so the
-    // new account is visible immediately without a reload round-trip.
+    // `AccountStore` mirrors the repository through reactive observation
+    // — there is no optimistic insert, so the new account lands in
+    // `accounts` only once the GRDB write commits and `observeAll()`
+    // emits. Wait for that emission before asserting the store's view
+    // of the world.
+    try await fixture.accountStore.waitForNextEmission(
+      matching: { $0.accounts.contains(where: { $0.id == created.id }) },
+      description: "newly-created crypto account observed in store"
+    )
     #expect(fixture.accountStore.accounts.count == 1)
     #expect(fixture.accountStore.accounts.first?.id == created.id)
   }


### PR DESCRIPTION
## Summary

- `CryptoAccountCreationLogic.submit` awaited the per-account wallet sync after persisting the new account, so the sheet stayed open for the full network round-trip even though the account was already saved and visible in the sidebar — user had to click Cancel to close a form whose Create button had effectively succeeded.
- Added `CryptoSyncStore.scheduleInitialSync(for:)` (fire-and-forget, tracked per `guides/CONCURRENCY_GUIDE.md` §8 alongside `sceneActiveSyncTask`); `submit` now returns `.created` immediately and the sheet dismisses while the sync continues out-of-band.
- `cancelTimer()` extended to tear down spawned syncs on profile teardown; new `waitForPendingInitialSyncs()` test seam lets store tests synchronise post-sync.

## Test plan

- [x] `just test-mac CryptoAccountCreationStoreTests CryptoSyncStoreTests CryptoSyncStoreGlobalErrorTests CryptoSyncPipelineStructureTests` — 25 tests pass, including new `submitDoesNotBlockOnSync` regression that parks the alchemy stub for 30 s and asserts `submit` returns in <1 s
- [x] `just format-check` clean
- [ ] Manual: create a new crypto account in the macOS app — sheet dismisses immediately on Create; sidebar shows the new account; sync completes in the background

🤖 Generated with [Claude Code](https://claude.com/claude-code)