### PR TITLE
fix(crypto): use free public CoinGecko endpoint when no API key set

### DIFF
--- a/App/ProfileSession+Factories.swift
+++ b/App/ProfileSession+Factories.swift
@@ -44,8 +44,11 @@ extension ProfileSession {
   }
 
   /// Builds the crypto-price service with its configured clients
-  /// (CoinGecko when an API key is present in the keychain, plus
-  /// CryptoCompare and Binance as fallbacks) and the token resolver.
+  /// (CoinGecko first — Pro tier when a key is set, otherwise the free
+  /// public endpoint — plus CryptoCompare and Binance as fallbacks) and
+  /// the token resolver. The price-service falls through to the next
+  /// client on any error, so an anonymous CoinGecko 429 still resolves
+  /// via CryptoCompare/Binance.
   static func makeCryptoPriceService(
     coinGeckoApiKey: String?,
     database: any DatabaseWriter
@@ -63,17 +66,21 @@ extension ProfileSession {
       }
     }
 
-    var priceClients: [CryptoPriceClient] = []
-    if let coinGeckoApiKey, !coinGeckoApiKey.isEmpty {
-      priceClients.append(CoinGeckoClient(apiKey: coinGeckoApiKey))
-    }
-    priceClients.append(cryptoCompareClient)
-    priceClients.append(binanceClient)
+    // Empty key → CoinGeckoClient targets the free public host;
+    // non-empty key → Pro host with `x_cg_pro_api_key`. Always included
+    // so users without a Pro key still get coverage for tokens like
+    // USDC that CryptoCompare omits from its contract index.
+    let resolverApiKey = coinGeckoApiKey ?? ""
+    let priceClients: [CryptoPriceClient] = [
+      CoinGeckoClient(apiKey: resolverApiKey),
+      cryptoCompareClient,
+      binanceClient,
+    ]
 
     return CryptoPriceService(
       clients: priceClients,
       database: database,
-      resolutionClient: CompositeTokenResolutionClient(coinGeckoApiKey: coinGeckoApiKey)
+      resolutionClient: CompositeTokenResolutionClient(coinGeckoApiKey: resolverApiKey)
     )
   }
 
@@ -153,7 +160,9 @@ extension ProfileSession {
       let made = makeCoinGeckoCatalog()
       catalog = made.catalog
       refreshTask = made.refreshTask
-      resolutionClient = CompositeTokenResolutionClient(coinGeckoApiKey: coinGeckoApiKey)
+      // Empty string when no key is configured so the resolver targets
+      // the free public CoinGecko endpoint. See `makeCryptoPriceService`.
+      resolutionClient = CompositeTokenResolutionClient(coinGeckoApiKey: coinGeckoApiKey ?? "")
     }
     let store = CryptoTokenStore(
       registry: cloudBackend.instrumentRegistry,

--- a/Backends/CoinGecko/CoinGeckoClient.swift
+++ b/Backends/CoinGecko/CoinGeckoClient.swift
@@ -2,14 +2,35 @@
 import Foundation
 
 struct CoinGeckoClient: CryptoPriceClient, Sendable {
-  private static let baseURL =
+  /// Pro-tier base URL. Used whenever the user has supplied a CoinGecko
+  /// Pro API key. Authenticated via the `x_cg_pro_api_key` query item.
+  private static let proBaseURL =
     URL(string: "https://pro-api.coingecko.com/api/v3") ?? URL(fileURLWithPath: "/")
+  /// Public free-tier base URL. Used when no API key is configured; no
+  /// auth query item is sent. Subject to CoinGecko's anonymous rate
+  /// limits (~30 req/min) — the price-service falls back to
+  /// CryptoCompare / Binance if a request 429s.
+  private static let publicBaseURL =
+    URL(string: "https://api.coingecko.com/api/v3") ?? URL(fileURLWithPath: "/")
   private let session: URLSession
   private let apiKey: String
 
   init(session: URLSession = .shared, apiKey: String) {
     self.session = session
     self.apiKey = apiKey
+  }
+
+  /// Resolves the base URL by key presence: non-empty → Pro host,
+  /// empty → public host. Static so the URL builders can call it
+  /// without an instance.
+  private static func baseURL(apiKey: String) -> URL {
+    apiKey.isEmpty ? publicBaseURL : proBaseURL
+  }
+
+  /// `x_cg_pro_api_key` query item, or `nil` when no key is supplied
+  /// (free public endpoint accepts the request without auth).
+  private static func authQueryItem(apiKey: String) -> URLQueryItem? {
+    apiKey.isEmpty ? nil : URLQueryItem(name: "x_cg_pro_api_key", value: apiKey)
   }
 
   func dailyPrice(for mapping: CryptoProviderMapping, on date: Date) async throws -> Decimal {
@@ -69,51 +90,50 @@ struct CoinGeckoClient: CryptoPriceClient, Sendable {
   // MARK: - URL builders (internal for testing)
 
   static func marketChartURL(coinId: String, days: Int, apiKey: String) -> URL {
-    let pathURL = baseURL.appendingPathComponent("coins/\(coinId)/market_chart")
+    let pathURL = baseURL(apiKey: apiKey).appendingPathComponent(
+      "coins/\(coinId)/market_chart")
     var components =
       URLComponents(url: pathURL, resolvingAgainstBaseURL: false) ?? URLComponents()
-    components.queryItems = [
+    var items: [URLQueryItem] = [
       URLQueryItem(name: "vs_currency", value: "usd"),
       URLQueryItem(name: "days", value: String(days)),
       URLQueryItem(name: "interval", value: "daily"),
-      URLQueryItem(name: "x_cg_pro_api_key", value: apiKey),
     ]
+    if let auth = authQueryItem(apiKey: apiKey) { items.append(auth) }
+    components.queryItems = items
     return components.url ?? pathURL
   }
 
   // MARK: - Token resolution
 
   static func assetPlatformsURL(apiKey: String) -> URL {
-    let pathURL = baseURL.appendingPathComponent("asset_platforms")
+    let pathURL = baseURL(apiKey: apiKey).appendingPathComponent("asset_platforms")
     var components =
       URLComponents(url: pathURL, resolvingAgainstBaseURL: false) ?? URLComponents()
-    components.queryItems = [
-      URLQueryItem(name: "x_cg_pro_api_key", value: apiKey)
-    ]
+    components.queryItems = authQueryItem(apiKey: apiKey).map { [$0] }
     return components.url ?? pathURL
   }
 
   static func contractLookupURL(platformId: String, contractAddress: String, apiKey: String) -> URL
   {
-    let pathURL = baseURL.appendingPathComponent(
+    let pathURL = baseURL(apiKey: apiKey).appendingPathComponent(
       "coins/\(platformId)/contract/\(contractAddress.lowercased())")
     var components =
       URLComponents(url: pathURL, resolvingAgainstBaseURL: false) ?? URLComponents()
-    components.queryItems = [
-      URLQueryItem(name: "x_cg_pro_api_key", value: apiKey)
-    ]
+    components.queryItems = authQueryItem(apiKey: apiKey).map { [$0] }
     return components.url ?? pathURL
   }
 
   static func simplePriceURL(coinIds: [String], apiKey: String) -> URL {
-    let pathURL = baseURL.appendingPathComponent("simple/price")
+    let pathURL = baseURL(apiKey: apiKey).appendingPathComponent("simple/price")
     var components =
       URLComponents(url: pathURL, resolvingAgainstBaseURL: false) ?? URLComponents()
-    components.queryItems = [
+    var items: [URLQueryItem] = [
       URLQueryItem(name: "ids", value: coinIds.joined(separator: ",")),
       URLQueryItem(name: "vs_currencies", value: "usd"),
-      URLQueryItem(name: "x_cg_pro_api_key", value: apiKey),
     ]
+    if let auth = authQueryItem(apiKey: apiKey) { items.append(auth) }
+    components.queryItems = items
     return components.url ?? pathURL
   }
 

--- a/MoolahTests/Backends/CoinGeckoClientTests.swift
+++ b/MoolahTests/Backends/CoinGeckoClientTests.swift
@@ -47,6 +47,51 @@ struct CoinGeckoClientTests {
     #expect(queryItems["vs_currencies"] == "usd")
   }
 
+  // MARK: - Public free-tier fallback (no API key)
+
+  @Test
+  func marketChartURLUsesPublicHostWhenApiKeyIsEmpty() throws {
+    let url = CoinGeckoClient.marketChartURL(coinId: "ethereum", days: 1, apiKey: "")
+    let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
+    #expect(components.host == "api.coingecko.com")
+    let names = Set((components.queryItems ?? []).map(\.name))
+    #expect(!names.contains("x_cg_pro_api_key"))
+  }
+
+  @Test
+  func simplePriceURLUsesPublicHostWhenApiKeyIsEmpty() throws {
+    let url = CoinGeckoClient.simplePriceURL(coinIds: ["ethereum"], apiKey: "")
+    let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
+    #expect(components.host == "api.coingecko.com")
+    let names = Set((components.queryItems ?? []).map(\.name))
+    #expect(!names.contains("x_cg_pro_api_key"))
+  }
+
+  @Test
+  func contractLookupURLUsesPublicHostWhenApiKeyIsEmpty() throws {
+    let url = CoinGeckoClient.contractLookupURL(
+      platformId: "ethereum",
+      contractAddress: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+      apiKey: ""
+    )
+    let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
+    #expect(components.host == "api.coingecko.com")
+    #expect(
+      components.path
+        == "/api/v3/coins/ethereum/contract/0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+    )
+    #expect((components.queryItems ?? []).isEmpty)
+  }
+
+  @Test
+  func assetPlatformsURLUsesPublicHostWhenApiKeyIsEmpty() throws {
+    let url = CoinGeckoClient.assetPlatformsURL(apiKey: "")
+    let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
+    #expect(components.host == "api.coingecko.com")
+    #expect(components.path == "/api/v3/asset_platforms")
+    #expect((components.queryItems ?? []).isEmpty)
+  }
+
   // MARK: - Response parsing
 
   @Test

--- a/Shared/CompositeTokenResolutionClient.swift
+++ b/Shared/CompositeTokenResolutionClient.swift
@@ -52,8 +52,12 @@ struct CompositeTokenResolutionClient: TokenResolutionClient, Sendable {
 
     // 2. CoinGecko — contract-based lookup for ERC-20s only. Runs before
     //    Binance so a CG-confirmed symbol can authorise the Binance pair
-    //    attribution (issue #790).
-    if let apiKey = coinGeckoApiKey, !apiKey.isEmpty, !isNative, let contractAddress {
+    //    attribution (issue #790). An empty `apiKey` falls through to the
+    //    free public CoinGecko endpoint (`api.coingecko.com`) so users
+    //    without a Pro key still get tokens like USDC priced. Production
+    //    passes empty string in that case; tests that pass `nil` opt out
+    //    of CoinGecko entirely so they don't hit the network.
+    if let apiKey = coinGeckoApiKey, !isNative, let contractAddress {
       do {
         let platformMapping = try await fetchAssetPlatforms(apiKey: apiKey)
         if let platformSlug = platformMapping[chainId] {


### PR DESCRIPTION
## Summary
The token resolver and the price-client list were both gated on the user having a CoinGecko **Pro** API key, so users without one got zero CoinGecko coverage. That left CryptoCompare as the only contract-aware resolver — and CryptoCompare's coin list omits the `SmartContractAddress` for major stablecoins like **USDC** (`0xA0b86991…eB48`), so they ended up unpriced even though every public catalog has them.

## Changes
- **`CoinGeckoClient`** picks its base URL by key presence:
  - empty key → `https://api.coingecko.com/api/v3` with no auth query item (free public tier)
  - non-empty key → existing `https://pro-api.coingecko.com/api/v3` with `x_cg_pro_api_key` (Pro tier)
- **`CompositeTokenResolutionClient`** drops the `!apiKey.isEmpty` gate. Tests passing `nil` still opt out of the CoinGecko branch and stay off the network; production passes empty string when no key is configured so the free endpoint is reached.
- **`ProfileSession+Factories`** always includes `CoinGeckoClient` in the price-client list. `CryptoPriceService` falls back to CryptoCompare/Binance on errors, so an anonymous 429 doesn't break price discovery.
- New unit tests cover the four URL builders (`marketChart`, `simplePrice`, `contractLookup`, `assetPlatforms`) when called with an empty API key.

## Risk
The free public CoinGecko endpoint has aggressive rate limits (~30 req/min). Mitigations:
- Resolver lookups happen once per token at registration and the result is cached in the registry.
- Price polling falls through to CryptoCompare/Binance on any error — so a CG 429 just slips to the next provider, exactly like a network error today.

## Test plan
- [x] `just test-mac CoinGeckoClientTests CompositeTokenResolutionClientTests CryptoPriceServiceTests` — green (29 tests).
- [ ] Smoke: register USDC on Ethereum without a CoinGecko API key configured; expect it to land in Registered Tokens with a CG badge and a price.

🤖 Generated with [Claude Code](https://claude.com/claude-code)