### PR TITLE
Fix hidden earmark balances showing permanent spinner under Show Hidden

### DIFF
--- a/Features/Accounts/AccountStore+Queries.swift
+++ b/Features/Accounts/AccountStore+Queries.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+extension AccountStore {
+  // The members below are module-internal (not `private`) only because
+  // `AccountStore.swift` and the SwiftUI views need them across file
+  // boundaries. Treat them as the store's read-only query surface.
+
+  /// The display balance for an account in its own instrument. Forwards to
+  /// `balanceCalculator`, passing the cached externally-set investment value
+  /// when the account is an investment account.
+  func displayBalance(for accountId: UUID) async throws -> InstrumentAmount {
+    guard let account = accounts.by(id: accountId) else {
+      return .zero(instrument: targetInstrument)
+    }
+    return try await balanceCalculator.displayBalance(
+      for: account, investmentValue: investmentValueCache.value(for: accountId))
+  }
+
+  /// Whether the sidebar should show "Not set" instead of `$0` for an
+  /// investment account in `.recordedValue` mode (no snapshot recorded;
+  /// initial conversion already completed). See
+  /// `INSTRUMENT_CONVERSION_GUIDE.md` Rule 11 — `$0` would otherwise roll
+  /// into net-worth as a real number.
+  func hasUnrecordedValue(_ account: Account) -> Bool {
+    guard hasCompletedInitialConversion else { return false }
+    guard account.type == .investment, account.valuationMode == .recordedValue else {
+      return false
+    }
+    return investmentValueCache.value(for: account.id) == nil
+  }
+
+  /// Whether an account can be deleted (all positions are zero or empty).
+  func canDelete(_ accountId: UUID) -> Bool {
+    guard let account = accounts.by(id: accountId) else { return false }
+    return account.positions.isEmpty || account.positions.allSatisfy { $0.quantity == 0 }
+  }
+
+  /// Positions for a given account. Returns empty array if not loaded.
+  func positions(for accountId: UUID) -> [Position] {
+    accounts.by(id: accountId)?.positions ?? []
+  }
+}

--- a/Features/Accounts/AccountStore.swift
+++ b/Features/Accounts/AccountStore.swift
@@ -34,7 +34,7 @@ final class AccountStore {
   // private-by-convention from elsewhere in the module.
   let repository: AccountRepository
   let conversionService: any InstrumentConversionService
-  private let targetInstrument: Instrument
+  let targetInstrument: Instrument
   /// Investment repository — captured separately from the read-through
   /// cache so the observation pipeline can subscribe to its
   /// `observeAllValues()` tick stream. `nil` in tests / previews that
@@ -129,6 +129,7 @@ final class AccountStore {
     MainActor.assumeIsolated {
       observationTask?.cancel()
       conversionTask?.cancel()
+      showHiddenTask?.cancel()
       testObservationTickContinuation.finish()
     }
   }
@@ -193,6 +194,8 @@ final class AccountStore {
     observationTask = nil
     conversionTask?.cancel()
     conversionTask = nil
+    showHiddenTask?.cancel()
+    showHiddenTask = nil
   }
 
   /// Asks `investmentValueCache` to hydrate itself with the latest value for
@@ -211,7 +214,21 @@ final class AccountStore {
     await investmentValueCache.preload(for: investmentAccountIds)
   }
 
-  var showHidden: Bool = false
+  /// Recompute task spawned by the `showHidden` `didSet`. Tracked (not
+  /// fire-and-forget) so `stopObserving()` and `deinit` can cancel an
+  /// in-flight recompute. A rapid double-toggle cancels the prior task
+  /// before spawning the next, narrowing the window for stale writes.
+  private var showHiddenTask: Task<Void, Never>?
+
+  var showHidden: Bool = false {
+    didSet {
+      // Aggregate totals filter on `showHidden`; without this recompute they
+      // stay pinned to the previous visibility's sum until the next tick.
+      guard oldValue != showHidden else { return }
+      showHiddenTask?.cancel()
+      showHiddenTask = Task { await recomputeConvertedTotals() }
+    }
+  }
 
   var currentAccounts: [Account] {
     accounts.filter { $0.type.isCurrent && (showHidden || !$0.isHidden) }
@@ -221,40 +238,8 @@ final class AccountStore {
     accounts.filter { $0.type.isInvestmentLike && (showHidden || !$0.isHidden) }
   }
 
-  /// The display balance for an account in its own instrument. Forwards to
-  /// `balanceCalculator`, passing the cached externally-set investment value
-  /// when the account is an investment account.
-  func displayBalance(for accountId: UUID) async throws -> InstrumentAmount {
-    guard let account = accounts.by(id: accountId) else {
-      return .zero(instrument: targetInstrument)
-    }
-    return try await balanceCalculator.displayBalance(
-      for: account, investmentValue: investmentValueCache.value(for: accountId))
-  }
-
-  /// Whether the sidebar should show "Not set" instead of `$0` for an
-  /// investment account in `.recordedValue` mode (no snapshot recorded;
-  /// initial conversion already completed). See
-  /// `INSTRUMENT_CONVERSION_GUIDE.md` Rule 11 — `$0` would otherwise roll
-  /// into net-worth as a real number.
-  func hasUnrecordedValue(_ account: Account) -> Bool {
-    guard hasCompletedInitialConversion else { return false }
-    guard account.type == .investment, account.valuationMode == .recordedValue else {
-      return false
-    }
-    return investmentValueCache.value(for: account.id) == nil
-  }
-
-  /// Whether an account can be deleted (all positions are zero or empty).
-  func canDelete(_ accountId: UUID) -> Bool {
-    guard let account = accounts.by(id: accountId) else { return false }
-    return account.positions.isEmpty || account.positions.allSatisfy { $0.quantity == 0 }
-  }
-
-  /// Positions for a given account. Returns empty array if not loaded.
-  func positions(for accountId: UUID) -> [Position] {
-    accounts.by(id: accountId)?.positions ?? []
-  }
+  // Read-only query helpers (`displayBalance`, `hasUnrecordedValue`,
+  // `canDelete`, `positions(for:)`) live in `AccountStore+Queries.swift`.
 
   /// Recompute per-account balances and aggregate totals via
   /// `balanceCalculator`. Driven by emissions from either

--- a/Features/Earmarks/EarmarkStore+Conversion.swift
+++ b/Features/Earmarks/EarmarkStore+Conversion.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+extension EarmarkStore {
+  // The members below are module-internal (not `private`) only because
+  // `EarmarkStore.swift` calls them across the file boundary. They are
+  // not intended as API for any other type — treat them as `private` to
+  // the `EarmarkStore` family.
+
+  /// Per-earmark conversion result: the three position-list totals,
+  /// each expressed in the earmark's own instrument.
+  struct ConvertedEarmarkTotals {
+    let balance: InstrumentAmount
+    let saved: InstrumentAmount
+    let spent: InstrumentAmount
+  }
+
+  /// Sums an earmark's three position lists, each converted to the
+  /// earmark's own instrument. `.knownZero` positions (an `.unpriced`
+  /// / `.spam` crypto registration) contribute zero rather than
+  /// failing the earmark — issue #790. A real provider failure still
+  /// throws so the caller treats the whole earmark as failed (we never
+  /// display a partial earmark balance under transient outage).
+  func convertEarmarkPositions(_ earmark: Earmark) async throws
+    -> ConvertedEarmarkTotals
+  {
+    let date = Date()
+    var balance = InstrumentAmount.zero(instrument: earmark.instrument)
+    var saved = InstrumentAmount.zero(instrument: earmark.instrument)
+    var spent = InstrumentAmount.zero(instrument: earmark.instrument)
+    for position in earmark.positions {
+      balance += try await convertPositionOrZero(
+        position.amount, to: earmark.instrument, on: date)
+    }
+    for position in earmark.savedPositions {
+      saved += try await convertPositionOrZero(
+        position.amount, to: earmark.instrument, on: date)
+    }
+    for position in earmark.spentPositions {
+      spent += try await convertPositionOrZero(
+        position.amount, to: earmark.instrument, on: date)
+    }
+    return ConvertedEarmarkTotals(balance: balance, saved: saved, spent: spent)
+  }
+
+  /// Convert `amount` to `target` on `date`, folding `.knownZero` (an
+  /// `.unpriced` / `.spam` crypto source) to zero in `target`.
+  /// Issue #790.
+  func convertPositionOrZero(
+    _ amount: InstrumentAmount, to target: Instrument, on date: Date
+  ) async throws -> InstrumentAmount {
+    let result = try await conversionService.convertResult(
+      amount, to: target, on: date)
+    switch result {
+    case .value(let converted): return converted
+    case .knownZero: return .zero(instrument: target)
+    }
+  }
+}

--- a/Features/Earmarks/EarmarkStore.swift
+++ b/Features/Earmarks/EarmarkStore.swift
@@ -21,10 +21,11 @@ final class EarmarkStore {
   private(set) var convertedSavedAmounts: [UUID: InstrumentAmount] = [:]
   private(set) var convertedSpentAmounts: [UUID: InstrumentAmount] = [:]
 
-  // internal (not `private`) so the `+Budget` and `+Mutations` extensions
-  // can reach the repository for budget CRUD and pass-through writes.
+  // internal (not `private`): `repository` is used by `+Budget` and
+  // `+Mutations`; `conversionService` is used by `+Conversion`. All three
+  // extensions need cross-file access that `private` would block.
   let repository: EarmarkRepository
-  private let conversionService: any InstrumentConversionService
+  let conversionService: any InstrumentConversionService
   let targetInstrument: Instrument
   /// Delay between retry attempts after a conversion failure. Production
   /// uses ~30s; tests pass a small value to keep retries snappy.
@@ -93,6 +94,7 @@ final class EarmarkStore {
     MainActor.assumeIsolated {
       observationTask?.cancel()
       conversionTask?.cancel()
+      showHiddenTask?.cancel()
       testObservationTickContinuation.finish()
     }
   }
@@ -162,6 +164,8 @@ final class EarmarkStore {
     observationTask = nil
     conversionTask?.cancel()
     conversionTask = nil
+    showHiddenTask?.cancel()
+    showHiddenTask = nil
   }
 
   func convertedBalance(for earmarkId: UUID) -> InstrumentAmount? {
@@ -176,7 +180,22 @@ final class EarmarkStore {
     convertedSpentAmounts[earmarkId]
   }
 
-  var showHidden: Bool = false
+  /// Recompute task spawned by the `showHidden` `didSet`. Tracked (not
+  /// fire-and-forget) so `stopObserving()` and `deinit` can cancel an
+  /// in-flight recompute. A rapid double-toggle cancels the prior task
+  /// before spawning the next, narrowing the window for stale writes.
+  private var showHiddenTask: Task<Void, Never>?
+
+  var showHidden: Bool = false {
+    didSet {
+      // The grand total sums only `visibleEarmarks`; without this recompute
+      // the "Earmarked Total" stays pinned to the previous visibility's sum
+      // until the next observation tick.
+      guard oldValue != showHidden else { return }
+      showHiddenTask?.cancel()
+      showHiddenTask = Task { await recomputeConvertedTotals() }
+    }
+  }
 
   var visibleEarmarks: [Earmark] {
     earmarks.filter { showHidden || !$0.isHidden }
@@ -278,9 +297,14 @@ final class EarmarkStore {
     await task.value
   }
 
-  /// Single pass over all visible earmarks; returns `true` if any
-  /// conversion failed. Always publishes the latest computed state,
-  /// even if partial.
+  /// Single pass over every earmark; returns `true` if any conversion
+  /// failed. Always publishes the latest computed state, even if partial.
+  ///
+  /// Iterates all earmarks (not just `visibleEarmarks`) so per-earmark
+  /// balances populate regardless of `showHidden` — otherwise toggling
+  /// "Show Hidden" surfaces a permanent spinner on hidden rows that no
+  /// recompute ever filled in. The grand total still sums only visible
+  /// earmarks so it matches what the user sees.
   private func runConversionAttempt() async -> Bool {
     var anyFailed = false
     var balances: [UUID: InstrumentAmount] = [:]
@@ -290,7 +314,8 @@ final class EarmarkStore {
     var grandTotalValid = true
     let zeroInTarget = InstrumentAmount.zero(instrument: targetInstrument)
 
-    for earmark in visibleEarmarks {
+    for earmark in earmarks {
+      let isVisible = showHidden || !earmark.isHidden
       do {
         let totals = try await convertEarmarkPositions(earmark)
         guard !Task.isCancelled else { return false }
@@ -298,17 +323,21 @@ final class EarmarkStore {
         saved[earmark.id] = totals.saved
         spent[earmark.id] = totals.spent
 
-        // Convert earmark balance to target instrument for grand total.
+        // Only visible earmarks contribute to the displayed grand total.
         // Clamp negative balances to zero so they don't reduce the total.
-        let convertedToTarget = try await conversionService.convertAmount(
-          totals.balance, to: targetInstrument, on: Date())
-        guard !Task.isCancelled else { return false }
-        if grandTotalValid {
+        if isVisible, grandTotalValid {
+          let convertedToTarget = try await conversionService.convertAmount(
+            totals.balance, to: targetInstrument, on: Date())
+          guard !Task.isCancelled else { return false }
           grandTotal += max(convertedToTarget, zeroInTarget)
         }
       } catch {
         anyFailed = true
-        grandTotalValid = false
+        // A failure on a hidden earmark shouldn't blank the total — only
+        // visible earmarks contribute to it. Hidden-earmark failures still
+        // mark `anyFailed` so the retry loop kicks in (and a later toggle
+        // doesn't surface a spinner because no retry was scheduled).
+        if isVisible { grandTotalValid = false }
         logger.warning(
           "Conversion failed for earmark \(earmark.name): \(error.localizedDescription)")
       }
@@ -324,56 +353,7 @@ final class EarmarkStore {
     return anyFailed
   }
 
-  /// Per-earmark conversion result: the three position-list totals,
-  /// each expressed in the earmark's own instrument.
-  private struct ConvertedEarmarkTotals {
-    let balance: InstrumentAmount
-    let saved: InstrumentAmount
-    let spent: InstrumentAmount
-  }
-
-  /// Sums an earmark's three position lists, each converted to the
-  /// earmark's own instrument. `.knownZero` positions (an `.unpriced`
-  /// / `.spam` crypto registration) contribute zero rather than
-  /// failing the earmark — issue #790. A real provider failure still
-  /// throws so the caller treats the whole earmark as failed (we never
-  /// display a partial earmark balance under transient outage).
-  private func convertEarmarkPositions(_ earmark: Earmark) async throws
-    -> ConvertedEarmarkTotals
-  {
-    let date = Date()
-    var balance = InstrumentAmount.zero(instrument: earmark.instrument)
-    var saved = InstrumentAmount.zero(instrument: earmark.instrument)
-    var spent = InstrumentAmount.zero(instrument: earmark.instrument)
-    for position in earmark.positions {
-      balance += try await convertPositionOrZero(
-        position.amount, to: earmark.instrument, on: date)
-    }
-    for position in earmark.savedPositions {
-      saved += try await convertPositionOrZero(
-        position.amount, to: earmark.instrument, on: date)
-    }
-    for position in earmark.spentPositions {
-      spent += try await convertPositionOrZero(
-        position.amount, to: earmark.instrument, on: date)
-    }
-    return ConvertedEarmarkTotals(balance: balance, saved: saved, spent: spent)
-  }
-
-  /// Convert `amount` to `target` on `date`, folding `.knownZero` (an
-  /// `.unpriced` / `.spam` crypto source) to zero in `target`.
-  /// Issue #790.
-  private func convertPositionOrZero(
-    _ amount: InstrumentAmount, to target: Instrument, on date: Date
-  ) async throws -> InstrumentAmount {
-    let result = try await conversionService.convertResult(
-      amount, to: target, on: date)
-    switch result {
-    case .value(let converted): return converted
-    case .knownZero: return .zero(instrument: target)
-    }
-  }
-
+  // Per-earmark conversion helpers live in `EarmarkStore+Conversion.swift`.
   // Mutation methods live in `EarmarkStore+Mutations.swift`.
   // Budget CRUD lives in `EarmarkStore+Budget.swift`.
 

--- a/MoolahTests/Features/AccountStoreMutationsTests.swift
+++ b/MoolahTests/Features/AccountStoreMutationsTests.swift
@@ -72,6 +72,33 @@ struct AccountStoreMutationsTests {
     #expect(store.investmentAccounts.count == 2)
   }
 
+  @Test("convertedCurrentTotal refreshes when showHidden toggles to include hidden accounts")
+  func convertedCurrentTotalRefreshesOnShowHiddenToggle() async throws {
+    // Without a recompute on toggle the sidebar shows hidden account rows
+    // (filter is computed from showHidden) but the "Current Total" stays
+    // pinned to the visible-only sum until the next emission.
+    let (backend, database) = try TestBackend.create()
+    _ = AccountStoreTestSupport.seedAccount(
+      name: "Visible", balance: Decimal(100000) / 100, in: database)
+    _ = AccountStoreTestSupport.seedAccount(
+      name: "Hidden", balance: Decimal(50000) / 100, isHidden: true, in: database)
+    let store = AccountStore(
+      repository: backend.accounts, conversionService: FixedConversionService(),
+      targetInstrument: .defaultTestInstrument)
+
+    try await store.waitForNextEmission(
+      matching: { $0.convertedCurrentTotal?.quantity == Decimal(100000) / 100 },
+      description: "initial total reflects visible account only"
+    )
+
+    store.showHidden = true
+
+    try await store.waitForNextEmission(
+      matching: { $0.convertedCurrentTotal?.quantity == Decimal(150000) / 100 },
+      description: "total recomputes to include hidden account"
+    )
+  }
+
   @Test("investmentAccounts includes crypto accounts (isInvestmentLike)")
   func investmentAccountsIncludesCrypto() async throws {
     // Sidebar feeds its "Investments" section from `investmentAccounts`. A

--- a/MoolahTests/Features/EarmarkStoreVisibilityTests.swift
+++ b/MoolahTests/Features/EarmarkStoreVisibilityTests.swift
@@ -72,6 +72,81 @@ struct EarmarkStoreVisibilityTests {
     #expect(store.visibleEarmarks.count == 2)
   }
 
+  @Test("convertedBalance is populated for hidden earmarks even when showHidden is false")
+  func hiddenEarmarkConvertedBalancePopulated() async throws {
+    // Regression: toggling "Show Hidden" used to surface a permanent spinner
+    // on hidden earmark rows because runConversionAttempt only iterated
+    // visibleEarmarks. The store should populate convertedBalances for every
+    // earmark regardless of visibility — the filter is for what to display.
+    let visible = Earmark(name: "Visible", instrument: .defaultTestInstrument)
+    let hidden = Earmark(
+      name: "Hidden", instrument: .defaultTestInstrument, isHidden: true)
+    let accountId = UUID()
+    let (backend, database) = try TestBackend.create()
+    TestBackend.seed(
+      accounts: [
+        Account(
+          id: accountId, name: "Test", type: .bank, instrument: .defaultTestInstrument)
+      ], in: database)
+    TestBackend.seedWithTransactions(
+      earmarks: [visible, hidden],
+      amounts: [
+        visible.id: (saved: 500, spent: 0),
+        hidden.id: (saved: 300, spent: 0),
+      ],
+      accountId: accountId, in: database)
+    let store = EarmarkStore(
+      repository: backend.earmarks, conversionService: FixedConversionService(),
+      targetInstrument: .defaultTestInstrument)
+
+    try await store.waitForNextEmission(
+      matching: { $0.convertedBalance(for: hidden.id) != nil },
+      description: "hidden earmark balance populated despite showHidden=false"
+    )
+
+    let hiddenBalance = try #require(store.convertedBalance(for: hidden.id))
+    #expect(hiddenBalance.quantity == 300)
+  }
+
+  @Test("convertedTotalBalance refreshes when showHidden toggles to include hidden earmarks")
+  func convertedTotalBalanceRefreshesOnShowHiddenToggle() async throws {
+    // With showHidden=false the grand total reflects only visible earmarks.
+    // Toggling showHidden=true must trigger a recompute so the visible
+    // "Earmarked Total" stays consistent with the rows the user now sees.
+    let visible = Earmark(name: "Visible", instrument: .defaultTestInstrument)
+    let hidden = Earmark(
+      name: "Hidden", instrument: .defaultTestInstrument, isHidden: true)
+    let accountId = UUID()
+    let (backend, database) = try TestBackend.create()
+    TestBackend.seed(
+      accounts: [
+        Account(
+          id: accountId, name: "Test", type: .bank, instrument: .defaultTestInstrument)
+      ], in: database)
+    TestBackend.seedWithTransactions(
+      earmarks: [visible, hidden],
+      amounts: [
+        visible.id: (saved: 500, spent: 0),
+        hidden.id: (saved: 300, spent: 0),
+      ],
+      accountId: accountId, in: database)
+    let store = EarmarkStore(
+      repository: backend.earmarks, conversionService: FixedConversionService(),
+      targetInstrument: .defaultTestInstrument)
+
+    try await store.waitForNextEmission(
+      matching: { $0.convertedTotalBalance?.quantity == 500 },
+      description: "initial total reflects visible earmark only"
+    )
+
+    store.showHidden = true
+
+    try await store.waitForNextEmission(
+      matching: { $0.convertedTotalBalance?.quantity == 800 },
+      description: "total recomputes to include hidden earmark"
+    )
+  }
+
   // MARK: - Multi-instrument earmarks
 
   @Test("USD earmark is loaded with USD instrument intact")


### PR DESCRIPTION
## Summary
- **Bug:** With "Show Hidden" enabled, hidden earmark rows in the sidebar showed an indeterminate `ProgressView()` spinner forever.
- **Root cause:** `EarmarkStore.runConversionAttempt` only iterated `visibleEarmarks`, so `convertedBalances` had no entry for hidden earmark IDs. Toggling visibility surfaced the row but `convertedBalance(for:)` returned `nil`, and nothing ever recomputed.
- **Related staleness:** `showHidden` was a plain stored property on both `EarmarkStore` and `AccountStore` — toggling it left aggregate totals (Earmarked Total / Current Total / Net Worth) pinned to the previous visibility's sum until the next rate or data emission. Same root cause, same fix shape.
- **Fix:** Iterate every earmark in `runConversionAttempt` (only visible ones contribute to the grand total); add `didSet` on `showHidden` in both stores that spawns a tracked `showHiddenTask` so `stopObserving()` and `deinit` can cancel it (matching the existing observation/conversion task lifecycle).

## Refactor
Per-earmark conversion helpers (`ConvertedEarmarkTotals`, `convertEarmarkPositions`, `convertPositionOrZero`) extracted to `EarmarkStore+Conversion.swift`, and read-only account query helpers (`displayBalance`, `hasUnrecordedValue`, `canDelete`, `positions(for:)`) extracted to `AccountStore+Queries.swift`. Mirrors the existing `+Mutations` / `+Budget` extension pattern and keeps both store files under the SwiftLint 400-line cap.

## Test plan
- [x] New regression tests:
    - `EarmarkStoreVisibilityTests.hiddenEarmarkConvertedBalancePopulated` — proves per-earmark balance populates regardless of `showHidden`.
    - `EarmarkStoreVisibilityTests.convertedTotalBalanceRefreshesOnShowHiddenToggle` — proves the grand total recomputes on toggle.
    - `AccountStoreMutationsTests.convertedCurrentTotalRefreshesOnShowHiddenToggle` — same shape for the account store.
- [x] Confirmed the three new tests time out against `main` and pass with the fix.
- [x] `just test` — full suite passes on macOS (2569 tests) and iOS (2544 tests).
- [x] `just format-check` clean; `.swiftlint-baseline.yml` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)