### PR TITLE
ui(categories): autocomplete parent picker, polished create-category sheet

### DIFF
--- a/Features/Categories/Views/CategoriesView.swift
+++ b/Features/Categories/Views/CategoriesView.swift
@@ -88,6 +88,7 @@ struct CategoriesView: View {
       .sheet(isPresented: $showCreateSheet) {
         CreateCategorySheet(
           categories: categoryStore.categories,
+          initialParentId: selectedCategory?.id,
           onCreate: { newCategory in
             Task {
               _ = await categoryStore.create(newCategory)
@@ -194,49 +195,108 @@ private struct CategoryNodeView: View {
 
     if children.isEmpty {
       Label(category.name, systemImage: "tag")
-        .contentShape(Rectangle())
+        .contentShape(.rect)
     } else {
       DisclosureGroup {
         ForEach(children) { child in
           CategoryNodeView(category: child, categories: categories)
+            .contentShape(.rect)
             .tag(child)
         }
       } label: {
         Label(category.name, systemImage: "folder")
+          .contentShape(.rect)
       }
     }
   }
 }
 
 private struct CreateCategorySheet: View {
+  /// Single-enum focus model so Tab/Cmd+Return advance through Name →
+  /// Parent → Create in the order the form renders. UI_GUIDE §13
+  /// requires one optional enum per form with one case per focusable
+  /// field; multiple boolean `@FocusState`s don't compose.
+  private enum Field: Hashable { case name, parent }
+
   let categories: Categories
+  let initialParentId: UUID?
   let onCreate: (Category) -> Void
 
   @State private var name: String = ""
-  @State private var selectedParentId: UUID?
+  @State private var parent: ParentCategorySelection
+  @State private var pickerState = CategoryAutocompleteState()
+  @FocusState private var focusedField: Field?
   @Environment(\.dismiss) private var dismiss
+
+  init(
+    categories: Categories,
+    initialParentId: UUID? = nil,
+    onCreate: @escaping (Category) -> Void
+  ) {
+    self.categories = categories
+    self.initialParentId = initialParentId
+    self.onCreate = onCreate
+    _parent = State(
+      initialValue: ParentCategorySelection(
+        initialId: initialParentId, in: categories))
+  }
 
   var body: some View {
     NavigationStack {
       form
     }
     #if os(macOS)
-      .frame(minWidth: 400, minHeight: 300)
+      .frame(minWidth: 500, minHeight: 400)
     #endif
+  }
+
+  private var visibleSuggestions: [CategorySuggestion] {
+    pickerState.visibleSuggestions(for: parent.text, in: categories)
   }
 
   private var form: some View {
     Form {
       Section("Details") {
         TextField("Name", text: $name)
+          .accessibilityLabel("Category name")
+          .focused($focusedField, equals: .name)
+          .onSubmit { focusedField = .parent }
       }
 
       Section("Parent Category") {
-        Picker("Parent", selection: $selectedParentId) {
-          Text("None (Top-Level)").tag(nil as UUID?)
-          ForEach(allCategories) { category in
-            Text(category.name).tag(category.id as UUID?)
-          }
+        CategoryAutocompleteField(
+          placeholder: "Parent",
+          text: $parent.text,
+          highlightedIndex: $pickerState.highlightedIndex,
+          suggestionCount: visibleSuggestions.count,
+          onTextChange: { _ in openDropdownIfFocused() },
+          onAcceptHighlighted: acceptHighlightedParent,
+          onCancel: { pickerState.cancel() }
+        )
+        .focused($focusedField, equals: .parent)
+        .accessibilityLabel("Parent category")
+        .accessibilityIdentifier(UITestIdentifiers.CreateCategory.parentCategoryField)
+      }
+    }
+    .formStyle(.grouped)
+    #if os(macOS)
+      .defaultFocus($focusedField, .name)
+    #endif
+    .onChange(of: focusedField) { _, newField in
+      if newField != .parent { handleParentBlur() }
+    }
+    .overlayPreferenceValue(CategoryPickerAnchorKey.self) { anchor in
+      if pickerState.showSuggestions, !visibleSuggestions.isEmpty, let anchor {
+        GeometryReader { proxy in
+          let rect = proxy[anchor]
+          CategorySuggestionDropdown(
+            suggestions: visibleSuggestions,
+            searchText: parent.text,
+            highlightedIndex: $pickerState.highlightedIndex,
+            onSelect: selectParent(_:)
+          )
+          .frame(width: rect.width)
+          .offset(x: rect.minX, y: rect.maxY + 4)
         }
       }
     }
@@ -250,24 +310,48 @@ private struct CreateCategorySheet: View {
       }
       ToolbarItem(placement: .confirmationAction) {
         Button("Create") {
-          onCreate(Category(name: name, parentId: selectedParentId))
+          onCreate(Category(name: name, parentId: parent.id))
         }
         .disabled(name.isEmpty)
+        #if os(macOS)
+          .keyboardShortcut(.return, modifiers: .command)
+        #endif
       }
     }
   }
 
-  private var allCategories: [Category] {
-    var result: [Category] = []
-    for root in categories.roots {
-      result.append(root)
-      result.append(contentsOf: categories.children(of: root.id))
+  private func openDropdownIfFocused() {
+    guard focusedField == .parent else { return }
+    if pickerState.justSelected {
+      pickerState.justSelected = false
+    } else {
+      pickerState.showSuggestions = true
     }
-    return result
+  }
+
+  private func acceptHighlightedParent() {
+    guard
+      let index = pickerState.highlightedIndex,
+      index < visibleSuggestions.count
+    else { return }
+    selectParent(visibleSuggestions[index])
+  }
+
+  private func selectParent(_ suggestion: CategorySuggestion) {
+    pickerState.dismiss()
+    parent.commit(suggestion)
+  }
+
+  private func handleParentBlur() {
+    let highlighted = pickerState.highlightedSuggestion(
+      for: parent.text, in: categories)
+    pickerState.dismiss()
+    parent.commitHighlightedOrNormalise(
+      highlighted: highlighted, in: categories)
   }
 }
 
-#Preview {
+#Preview("Categories List") {
   let (backend, _) = PreviewBackend.create()
   let store = CategoryStore(repository: backend.categories)
 
@@ -288,4 +372,21 @@ private struct CreateCategorySheet: View {
     // CategoryStore is reactive — it'll see the seeded categories via
     // `observeAll()` without an explicit load() call.
   }
+}
+
+#Preview("Create Category Sheet") {
+  let groceriesId = UUID()
+  let categories = Categories(from: [
+    Category(id: groceriesId, name: "Groceries"),
+    Category(name: "Fruit", parentId: groceriesId),
+    Category(name: "Vegetables", parentId: groceriesId),
+    Category(name: "Transport"),
+    Category(name: "Entertainment"),
+  ])
+
+  CreateCategorySheet(
+    categories: categories,
+    initialParentId: groceriesId,
+    onCreate: { _ in }
+  )
 }

--- a/MoolahTests/Shared/ParentCategorySelectionTests.swift
+++ b/MoolahTests/Shared/ParentCategorySelectionTests.swift
@@ -1,0 +1,129 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+struct ParentCategorySelectionTests {
+  // MARK: Fixtures
+
+  private static let groceriesId = UUID()
+  private static let fruitId = UUID()
+  private static let transportId = UUID()
+
+  private static let categories = Categories(from: [
+    Category(id: groceriesId, name: "Groceries"),
+    Category(id: fruitId, name: "Fruit", parentId: groceriesId),
+    Category(id: transportId, name: "Transport"),
+  ])
+
+  // MARK: init(initialId:in:)
+
+  @Test
+  func initFromNilIdYieldsEmptySelection() {
+    let selection = ParentCategorySelection(
+      initialId: nil, in: Self.categories)
+    #expect(selection.id == nil)
+    #expect(selection.text.isEmpty)
+  }
+
+  @Test
+  func initFromTopLevelIdPopulatesPath() {
+    let selection = ParentCategorySelection(
+      initialId: Self.transportId, in: Self.categories)
+    #expect(selection.id == Self.transportId)
+    #expect(selection.text == "Transport")
+  }
+
+  @Test
+  func initFromNestedIdPopulatesFullPath() {
+    let selection = ParentCategorySelection(
+      initialId: Self.fruitId, in: Self.categories)
+    #expect(selection.id == Self.fruitId)
+    #expect(selection.text == "Groceries:Fruit")
+  }
+
+  @Test
+  func initFromUnknownIdClearsBoth() {
+    let strangerId = UUID()
+    let selection = ParentCategorySelection(
+      initialId: strangerId, in: Self.categories)
+    #expect(selection.id == nil)
+    #expect(selection.text.isEmpty)
+  }
+
+  // MARK: commit(_:)
+
+  @Test
+  func commitAssignsIdAndPath() {
+    var selection = ParentCategorySelection()
+    selection.commit(
+      CategorySuggestion(id: Self.fruitId, path: "Groceries:Fruit"))
+    #expect(selection.id == Self.fruitId)
+    #expect(selection.text == "Groceries:Fruit")
+  }
+
+  // MARK: commitHighlightedOrNormalise(highlighted:in:)
+
+  @Test
+  func highlightedSuggestionWinsOverTypedText() {
+    var selection = ParentCategorySelection(
+      id: nil, text: "stale-typed-text")
+    selection.commitHighlightedOrNormalise(
+      highlighted: CategorySuggestion(
+        id: Self.transportId, path: "Transport"),
+      in: Self.categories)
+    #expect(selection.id == Self.transportId)
+    #expect(selection.text == "Transport")
+  }
+
+  @Test
+  func emptyTextClearsBoth() {
+    var selection = ParentCategorySelection(
+      id: Self.transportId, text: "")
+    selection.commitHighlightedOrNormalise(
+      highlighted: nil, in: Self.categories)
+    #expect(selection.id == nil)
+    #expect(selection.text.isEmpty)
+  }
+
+  @Test
+  func whitespaceOnlyTextClearsBoth() {
+    var selection = ParentCategorySelection(
+      id: Self.transportId, text: "   ")
+    selection.commitHighlightedOrNormalise(
+      highlighted: nil, in: Self.categories)
+    #expect(selection.id == nil)
+    #expect(selection.text.isEmpty)
+  }
+
+  @Test
+  func unmatchedTextWithLiveIdRestoresCanonicalPath() {
+    var selection = ParentCategorySelection(
+      id: Self.fruitId, text: "Frui")
+    selection.commitHighlightedOrNormalise(
+      highlighted: nil, in: Self.categories)
+    #expect(selection.id == Self.fruitId)
+    #expect(selection.text == "Groceries:Fruit")
+  }
+
+  @Test
+  func unmatchedTextWithStaleIdClearsBoth() {
+    let staleId = UUID()
+    var selection = ParentCategorySelection(
+      id: staleId, text: "Whatever")
+    selection.commitHighlightedOrNormalise(
+      highlighted: nil, in: Self.categories)
+    #expect(selection.id == nil)
+    #expect(selection.text.isEmpty)
+  }
+
+  @Test
+  func unmatchedTextWithoutIdClearsBoth() {
+    var selection = ParentCategorySelection(
+      id: nil, text: "made-up")
+    selection.commitHighlightedOrNormalise(
+      highlighted: nil, in: Self.categories)
+    #expect(selection.id == nil)
+    #expect(selection.text.isEmpty)
+  }
+}

--- a/Shared/Models/ParentCategorySelection.swift
+++ b/Shared/Models/ParentCategorySelection.swift
@@ -1,0 +1,78 @@
+import Foundation
+
+/// Parent-category text + resolved id pair driven by the autocomplete
+/// field in the create-category sheet (and any future edit sheet that
+/// reparents an existing category). Bundles the two pieces so the blur
+/// normalisation rules live in one testable place rather than as a
+/// private method on the view.
+///
+/// Callers bind `text` to `CategoryAutocompleteField` and read `id`
+/// when constructing the new `Category`. On suggestion accept, call
+/// `commit(_:)`. On field blur, call `commitHighlightedOrNormalise(...)`.
+struct ParentCategorySelection: Equatable {
+  /// The resolved category id, or `nil` for a top-level category.
+  var id: UUID?
+  /// The text shown in the autocomplete field. Empty string means
+  /// "no parent" — the user explicitly cleared it or never typed one.
+  var text: String
+
+  init(id: UUID? = nil, text: String = "") {
+    self.id = id
+    self.text = text
+  }
+
+  /// Build an initial selection from a pre-existing parent id by
+  /// resolving its canonical path so the autocomplete field renders
+  /// the path on first show. If `initialId` does not resolve to a
+  /// live category — e.g. it was deleted on another device since the
+  /// caller cached it — both `id` and `text` are cleared, preventing
+  /// a submit from creating a new category with a dangling parent.
+  init(initialId: UUID?, in categories: Categories) {
+    if let id = initialId, let category = categories.by(id: id) {
+      self.id = id
+      self.text = categories.path(for: category)
+    } else {
+      self.id = nil
+      self.text = ""
+    }
+  }
+
+  /// Sets `id` and `text` to `suggestion` in a single mutating call.
+  /// `TransactionDraft.commitCategorySelection` documents the constraint:
+  /// SwiftUI snapshots between binding writes, so two separate writes
+  /// can clobber each other; one mutating method avoids that.
+  mutating func commit(_ suggestion: CategorySuggestion) {
+    id = suggestion.id
+    text = suggestion.path
+  }
+
+  /// Reconciles `text` with `id` on field blur. Three cases:
+  /// - A highlighted suggestion at blur time wins — committing matches
+  ///   the simple-mode category field's `commitHighlightedOrNormalise`
+  ///   behaviour that fixes Tab-from-highlight clearing the field (#509).
+  /// - Empty/whitespace text clears `id` — the picker treats an empty
+  ///   field as "no parent → top-level category".
+  /// - Anything else falls back to restoring the canonical path for
+  ///   `id`, or clearing both fields if `id` no longer resolves to a
+  ///   live category.
+  mutating func commitHighlightedOrNormalise(
+    highlighted: CategorySuggestion?, in categories: Categories
+  ) {
+    if let highlighted {
+      commit(highlighted)
+      return
+    }
+    let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+    if trimmed.isEmpty {
+      id = nil
+      text = ""
+      return
+    }
+    if let resolved = id.flatMap({ categories.by(id: $0) }) {
+      text = categories.path(for: resolved)
+    } else {
+      id = nil
+      text = ""
+    }
+  }
+}

--- a/Shared/Views/CategoryAutocompleteField.swift
+++ b/Shared/Views/CategoryAutocompleteField.swift
@@ -13,8 +13,11 @@ struct CategoryPickerAnchorKey: PreferenceKey {
 ///
 /// The text field shows the selected category path. Typing filters suggestions.
 /// The parent view owns `showSuggestions` and `highlightedIndex` state and wires
-/// the dropdown overlay on the Form.
+/// the dropdown overlay on the Form. `placeholder` defaults to "Category"
+/// for the transaction-detail use; pass a different label (e.g. "Parent")
+/// when the surrounding section already says "Category".
 struct CategoryAutocompleteField: View {
+  let placeholder: String
   @Binding var text: String
   @Binding var highlightedIndex: Int?
   let suggestionCount: Int
@@ -22,9 +25,27 @@ struct CategoryAutocompleteField: View {
   let onAcceptHighlighted: () -> Void
   let onCancel: () -> Void
 
+  init(
+    placeholder: String = "Category",
+    text: Binding<String>,
+    highlightedIndex: Binding<Int?>,
+    suggestionCount: Int,
+    onTextChange: @escaping (String) -> Void,
+    onAcceptHighlighted: @escaping () -> Void,
+    onCancel: @escaping () -> Void
+  ) {
+    self.placeholder = placeholder
+    self._text = text
+    self._highlightedIndex = highlightedIndex
+    self.suggestionCount = suggestionCount
+    self.onTextChange = onTextChange
+    self.onAcceptHighlighted = onAcceptHighlighted
+    self.onCancel = onCancel
+  }
+
   var body: some View {
     AutocompleteField(
-      placeholder: "Category",
+      placeholder: placeholder,
       text: $text,
       highlightedIndex: $highlightedIndex,
       suggestionCount: suggestionCount,

--- a/UITestSupport/UITestIdentifiers.swift
+++ b/UITestSupport/UITestIdentifiers.swift
@@ -239,6 +239,13 @@ public enum UITestIdentifiers {
     public static let walletAddressField = "createAccount.crypto.walletAddress"
   }
 
+  public enum CreateCategory {
+    /// Parent-category autocomplete field in the create-category sheet
+    /// reached from the Categories list "+". Pinned so a future UI test
+    /// can drive the create flow without depending on rendered text.
+    public static let parentCategoryField = "createCategory.parentCategory"
+  }
+
   // The `WalletAccountHeader` namespace lives in
   // `UITestIdentifiers+WalletAccountHeader.swift` so this file stays
   // under SwiftLint's `file_length` budget.


### PR DESCRIPTION
## Summary

- Replace the parent `Picker` in `CreateCategorySheet` with the same `CategoryAutocompleteField` pattern used by `TransactionDetailView` — typeable, filterable, dropdown overlay anchored on the form.
- Default the parent to the currently-selected category in the Categories list, so adding a child category from a selection row is a one-click flow.
- Polish pass driven by `@agent-ui-review` (two passes): grouped form style, 500×400 sheet frame, enum-based `@FocusState` with `defaultFocus` + `onSubmit`, ⌘↩ on Create, accessibility label + identifier, `.contentShape(.rect)` on `CategoryNodeView` rows, "Parent" placeholder so the label doesn't duplicate the section header.

## Notable internals

- New `ParentCategorySelection` struct (`Shared/Models/`) holds the autocomplete `text` + resolved `id` and owns the three-case blur normalisation (highlighted-wins → empty-clears-both → restore-canonical-or-clear). Extracted out of the view so it gets unit-test coverage; 11 tests in `MoolahTests/Shared/ParentCategorySelectionTests.swift`.
- `CategoryAutocompleteField` gains an optional `placeholder` parameter (default unchanged for existing call sites).
- Stale-id init now clears both fields rather than carrying a dangling parent id into the submit path.
- `UITestIdentifiers.CreateCategory.parentCategoryField` added for future UI-test coverage.

## Follow-up

- `AutocompleteSuggestionDropdown.highlightedText` bolds non-matched characters and de-emphasises matches — the inverse of the typical search-highlight convention. To be flipped in a separate PR (affects every autocomplete in the app, so it's its own change).

## Test plan

- [x] `just format-check`
- [x] `just test-mac` — all 2577 tests pass
- [x] Visual: rendered the `CreateCategorySheet` `#Preview` after the changes — autocomplete row reads "Parent | Groceries" inside the "Parent Category" section.
- [ ] In-app smoke: open Categories, select "Groceries", click "+", confirm parent prefills to "Groceries"; clear the field, confirm Create produces a top-level category.

🤖 Generated with [Claude Code](https://claude.com/claude-code)