### PR TITLE
ui(autocomplete): bold the matched characters, dim the rest

### DIFF
--- a/Shared/Views/AutocompleteField.swift
+++ b/Shared/Views/AutocompleteField.swift
@@ -190,7 +190,7 @@ struct AutocompleteSuggestionDropdown<Item: Identifiable>: View {
     }
 
     var attributed = AttributedString(text)
-    attributed.font = .body.bold()
+    attributed.foregroundColor = .secondary
     let chars = Array(text)
     var i = 0
     while i < chars.count {
@@ -199,8 +199,8 @@ struct AutocompleteSuggestionDropdown<Item: Identifiable>: View {
         while j < chars.count && matched[j] { j += 1 }
         let startIdx = attributed.characters.index(attributed.startIndex, offsetBy: i)
         let endIdx = attributed.characters.index(attributed.startIndex, offsetBy: j)
-        attributed[startIdx..<endIdx].font = .body
-        attributed[startIdx..<endIdx].foregroundColor = .secondary
+        attributed[startIdx..<endIdx].font = .body.bold()
+        attributed[startIdx..<endIdx].foregroundColor = .primary
         i = j
       } else {
         i += 1


### PR DESCRIPTION
## Summary

Follow-up to [#809](https://github.com/ajsutton/moolah-native/pull/809).

`AutocompleteSuggestionDropdown.highlightedText` was rendering the match-highlight backwards: matched characters were drawn in regular weight + secondary colour, non-matched in bold + primary. Typing "Gro" against "Groceries:Fruit" made the typed "Gro" fade and "ceries:Fruit" pop — the opposite of Spotlight / Xcode Open Quickly / every other macOS autocomplete users have muscle memory for.

Flip it: default the whole string to regular + secondary, bold the matched ranges back to primary. One small change in `Shared/Views/AutocompleteField.swift`.

## Affects

Every autocomplete dropdown in the app — payee, simple-mode category, leg category, parent-category picker.

## Test plan

- [x] `just format-check`
- [x] `just test-mac` — 2584 tests pass
- [ ] Visual: open Transactions, focus the Payee field, type a prefix; matched characters should be bold/primary while the rest dim.
- [ ] Visual: same for the Category field.
- [ ] Visual: open Categories → "+", focus the Parent field, type a prefix; same behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)