### PR TITLE
fix(crypto): always show full wallet address, never truncate

### DIFF
--- a/App/ContentView.swift
+++ b/App/ContentView.swift
@@ -343,7 +343,7 @@ extension ContentView {
       } else {
         VStack(spacing: 0) {
           // Crypto wallets get a header bar above the transaction list
-          // showing the truncated address, chain, last-synced state,
+          // showing the full wallet address, chain, last-synced state,
           // and a Sync now action. Skipped for non-crypto accounts and
           // for crypto accounts whose `chainId` couldn't be resolved
           // (defensive — surfaces a config gap rather than crashing).

--- a/Features/Crypto/WalletAccountHeaderView.swift
+++ b/Features/Crypto/WalletAccountHeaderView.swift
@@ -10,8 +10,10 @@ import SwiftUI
 
 /// Compact header for an `AccountType.crypto` account view. Renders:
 ///
-/// - Truncated wallet address (`0xabcd…wxyz`) rendered in a monospaced font
-///   with a copy button alongside.
+/// - Full wallet address rendered in a monospaced, selectable font with a
+///   copy button alongside. The address is **never** truncated — a
+///   truncated `0x1234…abcd` is unsafe to verify against because an
+///   attacker can mine a vanity address with matching prefix and suffix.
 /// - Chain display name (e.g. "Ethereum").
 /// - Last-synced relative timestamp ("Synced 2h ago") or "Never synced"
 ///   when the account has no checkpoint yet.
@@ -21,10 +23,9 @@ import SwiftUI
 ///   address URL in the user's default browser.
 ///
 /// Pure presentation: every piece of business logic that benefits from
-/// unit testing (truncation, last-synced formatting, sync button state)
-/// lives in `WalletAccountHeaderLogic` so
-/// `WalletAccountHeaderViewLogicTests` can exercise the contract without
-/// spinning up a SwiftUI view.
+/// unit testing (last-synced formatting, sync button state) lives in
+/// `WalletAccountHeaderLogic` so `WalletAccountHeaderViewLogicTests` can
+/// exercise the contract without spinning up a SwiftUI view.
 struct WalletAccountHeaderView: View {
   let account: Account
   let chain: ChainConfig
@@ -69,10 +70,6 @@ struct WalletAccountHeaderView: View {
 
   private var address: String { account.walletAddress ?? "" }
 
-  private var truncatedAddress: String {
-    WalletAccountHeaderLogic.truncateAddress(address)
-  }
-
   private var syncState: WalletSyncState? {
     cryptoSyncStore.statePerAccount[account.id]
   }
@@ -93,13 +90,13 @@ struct WalletAccountHeaderView: View {
 
   var body: some View {
     VStack(alignment: .leading, spacing: 4) {
+      addressSection
       HStack(spacing: 12) {
-        addressSection
-        Spacer(minLength: 12)
         Text(chain.displayName)
           .font(.subheadline)
           .foregroundStyle(.secondary)
           .accessibilityIdentifier(UITestIdentifiers.WalletAccountHeader.chainName)
+        Spacer(minLength: 12)
         Text(lastSyncedText)
           .font(.subheadline)
           .foregroundStyle(.secondary)
@@ -170,10 +167,11 @@ struct WalletAccountHeaderView: View {
   }
 
   private var addressSection: some View {
-    HStack(spacing: 6) {
-      Text(truncatedAddress)
+    HStack(alignment: .firstTextBaseline, spacing: 6) {
+      Text(address)
         .font(.body.monospaced())
-        .accessibilityIdentifier(UITestIdentifiers.WalletAccountHeader.truncatedAddress)
+        .textSelection(.enabled)
+        .accessibilityIdentifier(UITestIdentifiers.WalletAccountHeader.address)
         .accessibilityLabel("Wallet address \(address)")
       Button {
         copyToPasteboard(address)
@@ -186,6 +184,7 @@ struct WalletAccountHeaderView: View {
       .accessibilityLabel("Copy wallet address")
       .accessibilityIdentifier(UITestIdentifiers.WalletAccountHeader.copyAddressButton)
       .disabled(address.isEmpty)
+      Spacer(minLength: 0)
     }
   }
 
@@ -261,25 +260,11 @@ extension WalletAccountHeaderView {
 
 // MARK: - Pure logic
 
-/// Pure-logic helper for `WalletAccountHeaderView`. Owns the truncation
-/// rule, the relative-time formatting for the last-synced label, and the
-/// "is sync allowed" predicate so they are all unit-testable without
-/// instantiating a SwiftUI view.
+/// Pure-logic helper for `WalletAccountHeaderView`. Owns the relative-
+/// time formatting for the last-synced label, the "is sync allowed"
+/// predicate, and the user-facing error caption so they are all
+/// unit-testable without instantiating a SwiftUI view.
 enum WalletAccountHeaderLogic {
-  /// Truncates a `0x…` wallet address to a `0xabcd…wxyz` shape: 6 leading
-  /// characters (including the `0x` prefix), an ellipsis, and 4 trailing
-  /// characters. Same convention as Etherscan / wallet UIs.
-  ///
-  /// Addresses shorter than 11 characters fall through unchanged — they
-  /// can't be truncated in a way that adds clarity, and are treated as
-  /// already-displayable.
-  static func truncateAddress(_ address: String) -> String {
-    guard address.count >= 11 else { return address }
-    let prefix = address.prefix(6)
-    let suffix = address.suffix(4)
-    return "\(prefix)…\(suffix)"
-  }
-
   /// User-facing relative-time label for the wallet's last successful
   /// sync. `nil` state → "Never synced". Otherwise uses
   /// `RelativeDateTimeFormatter.short` and prefixes "Synced ".

--- a/Features/Transactions/Views/Detail/TransactionDetailCounterpartySection.swift
+++ b/Features/Transactions/Views/Detail/TransactionDetailCounterpartySection.swift
@@ -19,9 +19,9 @@ import SwiftUI
 /// affordance for the *transaction*; this section is just structured
 /// data the user might want to copy.
 ///
-/// Truncation matches `WalletAccountHeaderLogic.truncateAddress` —
-/// `0xabcd…wxyz` (6 leading + 4 trailing). The full address is in the
-/// VoiceOver label so screen-reader users hear the complete value.
+/// The address is rendered in full — never truncated. A `0xabcd…wxyz`
+/// abbreviation is unsafe to verify against because an attacker can
+/// vanity-mine an address whose prefix and suffix match a target.
 struct TransactionDetailCounterpartySection: View {
   let transaction: Transaction
 
@@ -60,8 +60,9 @@ struct TransactionDetailCounterpartySection: View {
             .font(.caption)
             .foregroundStyle(.secondary)
         }
-        Text(WalletAccountHeaderLogic.truncateAddress(entry.address))
+        Text(entry.address)
           .font(.body.monospaced())
+          .textSelection(.enabled)
       }
       Spacer()
       Button {

--- a/MoolahTests/Features/Crypto/WalletAccountHeaderViewLogicTests.swift
+++ b/MoolahTests/Features/Crypto/WalletAccountHeaderViewLogicTests.swift
@@ -4,45 +4,13 @@ import Testing
 
 @testable import Moolah
 
-/// Pure-logic tests for `WalletAccountHeaderLogic` — the truncation
-/// rule, the relative-time formatting for the last-synced label, and the
-/// "is sync allowed" predicate. These are the load-bearing pieces of the
-/// wallet-header view; the SwiftUI rendering itself is exercised via
-/// preview snapshots and the UI driver suite.
+/// Pure-logic tests for `WalletAccountHeaderLogic` — the relative-time
+/// formatting for the last-synced label, the "is sync allowed" predicate,
+/// and the user-facing error caption. These are the load-bearing pieces
+/// of the wallet-header view; the SwiftUI rendering itself is exercised
+/// via preview snapshots and the UI driver suite.
 @Suite("WalletAccountHeaderLogic")
 struct WalletAccountHeaderViewLogicTests {
-  // MARK: - Address truncation
-
-  @Test("Canonical 0x address truncates to first 6 + ellipsis + last 4")
-  func canonicalAddressTruncatesToShortForm() {
-    let address = "0xabcdef0123456789abcdef0123456789abcdwxyz"
-    let truncated = WalletAccountHeaderLogic.truncateAddress(address)
-    #expect(truncated == "0xabcd…wxyz")
-  }
-
-  @Test("0x + 40 hex chars produces 11-character truncated label")
-  func standardEvmAddressProducesElevenCharacterLabel() {
-    let address = "0x" + String(repeating: "f", count: 40)
-    let truncated = WalletAccountHeaderLogic.truncateAddress(address)
-    // 6 (prefix) + 1 (ellipsis) + 4 (suffix) = 11 grapheme clusters.
-    #expect(truncated.count == 11)
-    #expect(truncated.hasPrefix("0xffff"))
-    #expect(truncated.hasSuffix("ffff"))
-    #expect(truncated.contains("…"))
-  }
-
-  @Test("Address shorter than the truncation threshold passes through unchanged")
-  func shortAddressIsNotTruncated() {
-    // 10 chars — below the 11-char threshold; truncation can't add clarity.
-    let short = "0xabcd1234"
-    #expect(WalletAccountHeaderLogic.truncateAddress(short) == short)
-  }
-
-  @Test("Empty address passes through as empty string")
-  func emptyAddressIsUnchanged() {
-    #expect(WalletAccountHeaderLogic.truncateAddress("").isEmpty)
-  }
-
   // MARK: - Last-synced text
 
   @Test("Nil sync state renders as 'Never synced'")

--- a/UITestSupport/UITestIdentifiers+WalletAccountHeader.swift
+++ b/UITestSupport/UITestIdentifiers+WalletAccountHeader.swift
@@ -12,9 +12,11 @@ extension UITestIdentifiers {
     /// wallet header is on screen".
     public static let container = "wallet.header.container"
 
-    /// Truncated `0xabcd…wxyz` wallet-address label. The full address
-    /// is exposed via the row's `accessibilityLabel`.
-    public static let truncatedAddress = "wallet.header.address"
+    /// Full wallet-address label. Crypto addresses are never truncated
+    /// in the UI — verifying the entire string is what protects the
+    /// user from vanity-mined lookalike addresses, so prefix/suffix
+    /// abbreviation is unsafe even when it would fit better.
+    public static let address = "wallet.header.address"
 
     /// Copy-address button. Tapping copies the full lowercased
     /// wallet address to the system pasteboard.


### PR DESCRIPTION
## Summary

- The wallet-account header bar and the transaction-detail counterparty rows now render the **full** wallet address. Truncation (`0xabcd…wxyz`) is unsafe — an attacker can vanity-mine an address whose prefix and suffix match the target, so the only effective verification is reading the entire string.
- Address rendering picks up `.textSelection(.enabled)` so users can copy any portion to compare against an external source. The header layout is restructured so the address gets its own row above the chain/last-synced/sync controls — a 42-char hex address no longer competes for horizontal space with the sync button.
- Drops the now-unused `WalletAccountHeaderLogic.truncateAddress` helper and its four tests; renames accessibility identifier `truncatedAddress` → `address`.

## Test plan

- [x] `just format-check` clean
- [x] `just build-mac` succeeded
- [x] `just test-mac` — 2558 tests / 426 suites passed
- [ ] Manual: open a crypto account in the running app and confirm the full address renders in the header and is copy-selectable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)