### PR TITLE
fix(catalog): survive duplicate CoinGecko rows + emit specific SQLite errors

### DIFF
--- a/Backends/CoinGecko/SQLiteCoinGeckoCatalog+Refresh.swift
+++ b/Backends/CoinGecko/SQLiteCoinGeckoCatalog+Refresh.swift
@@ -172,29 +172,62 @@ private struct PlatformWire: Decodable {
 }
 
 extension SQLiteCoinGeckoCatalog {
+  /// Decodes CoinGecko's `/coins/list` payload, collapsing duplicate `id`s
+  /// to their first occurrence. CoinGecko occasionally lists the same id
+  /// more than once (typically around delistings or rebrandings); a dupe
+  /// would otherwise trip the `coin.coingecko_id UNIQUE` constraint mid-
+  /// transaction and roll the whole refresh back. Dedupe at the seam keeps
+  /// the on-disk constraints strict so genuine bugs in our insert path
+  /// still trap.
   static func parseCoins(_ data: Data) throws -> [RawCoin] {
     let decoded = try JSONDecoder().decode([CoinWire].self, from: data)
-    return decoded.map { wire in
-      var platforms: [String: String] = [:]
-      for (slug, contract) in wire.platforms {
-        if let contract, !contract.isEmpty {
-          platforms[slug] = contract
-        }
-      }
-      return RawCoin(
-        id: wire.id,
-        symbol: wire.symbol.uppercased(),
-        name: wire.name,
-        platforms: platforms
+    var seen: Set<String> = []
+    seen.reserveCapacity(decoded.count)
+    var coins: [RawCoin] = []
+    coins.reserveCapacity(decoded.count)
+    for wire in decoded where seen.insert(wire.id).inserted {
+      coins.append(
+        RawCoin(
+          id: wire.id,
+          symbol: wire.symbol.uppercased(),
+          name: wire.name,
+          platforms: compactPlatforms(wire.platforms)
+        )
       )
     }
+    return coins
   }
 
+  /// Drops `null` and empty contract addresses from a `CoinWire.platforms`
+  /// dict. CoinGecko sometimes maps a known platform slug to `null` for de-
+  /// listed tokens; only mappings with a non-empty contract make it into
+  /// `coin_platform`.
+  static func compactPlatforms(_ raw: [String: String?]) -> [String: String] {
+    var compacted: [String: String] = [:]
+    compacted.reserveCapacity(raw.count)
+    for (slug, contract) in raw {
+      if let contract, !contract.isEmpty {
+        compacted[slug] = contract
+      }
+    }
+    return compacted
+  }
+
+  /// Decodes `/asset_platforms`, collapsing duplicate slugs to their first
+  /// occurrence for the same reason as `parseCoins(_:)` — keeps the
+  /// `platform.slug PRIMARY KEY` constraint strict at the DB layer.
   static func parsePlatforms(_ data: Data) throws -> [RawPlatform] {
     let decoded = try JSONDecoder().decode([PlatformWire].self, from: data)
-    return decoded.map {
-      RawPlatform(slug: $0.id, chainId: $0.chainIdentifier, name: $0.name)
+    var seen: Set<String> = []
+    seen.reserveCapacity(decoded.count)
+    var platforms: [RawPlatform] = []
+    platforms.reserveCapacity(decoded.count)
+    for wire in decoded where seen.insert(wire.id).inserted {
+      platforms.append(
+        RawPlatform(slug: wire.id, chainId: wire.chainIdentifier, name: wire.name)
+      )
     }
+    return platforms
   }
 }
 

--- a/Backends/CoinGecko/SQLiteCoinGeckoCatalog.swift
+++ b/Backends/CoinGecko/SQLiteCoinGeckoCatalog.swift
@@ -90,6 +90,13 @@ actor SQLiteCoinGeckoCatalog: CoinGeckoCatalog {
     guard result == SQLITE_OK, let handle else {
       throw CatalogError.sqlite("open failed: \(result)")
     }
+    // Promote bare codes (e.g. `19 SQLITE_CONSTRAINT`) into specific
+    // extended codes (e.g. `2067 SQLITE_CONSTRAINT_UNIQUE`) so log lines
+    // pinpoint the actual failure mode. Combined with `sqlite3_errmsg(_:)`
+    // pulled into our throw sites, a constraint violation surfaces as
+    // `step 2067: UNIQUE constraint failed: coin.coingecko_id` instead of
+    // bare `step 19`.
+    sqlite3_extended_result_codes(handle, 1)
     return handle
   }
 
@@ -212,9 +219,9 @@ actor SQLiteCoinGeckoCatalog: CoinGeckoCatalog {
     var error: UnsafeMutablePointer<CChar>?
     let result = sqlite3_exec(database, sql, nil, nil, &error)
     if result != SQLITE_OK {
-      let message = error.map { String(cString: $0) } ?? "code \(result)"
+      let message = error.map { String(cString: $0) } ?? "(no errmsg)"
       sqlite3_free(error)
-      throw CatalogError.sqlite("exec failed: \(message)")
+      throw CatalogError.sqlite("exec \(result): \(message)")
     }
   }
 
@@ -225,7 +232,8 @@ actor SQLiteCoinGeckoCatalog: CoinGeckoCatalog {
   ) throws {
     let result = sqlite3_prepare_v2(database, sql, -1, &statement, nil)
     guard result == SQLITE_OK else {
-      throw CatalogError.sqlite("prepare failed: \(result) for \(sql)")
+      throw CatalogError.sqlite(
+        "prepare \(result): \(errorMessage(database: database)) — \(sql)")
     }
   }
 
@@ -241,7 +249,10 @@ actor SQLiteCoinGeckoCatalog: CoinGeckoCatalog {
       -1,
       unsafeBitCast(Int(-1), to: sqlite3_destructor_type.self)
     )
-    guard result == SQLITE_OK else { throw CatalogError.sqlite("bind text \(result)") }
+    guard result == SQLITE_OK else {
+      throw CatalogError.sqlite(
+        "bind text \(result): \(errorMessage(statement: statement))")
+    }
   }
 
   static func bind(
@@ -250,14 +261,32 @@ actor SQLiteCoinGeckoCatalog: CoinGeckoCatalog {
     _ value: Int
   ) throws {
     let result = sqlite3_bind_int64(statement, index, Int64(value))
-    guard result == SQLITE_OK else { throw CatalogError.sqlite("bind int \(result)") }
+    guard result == SQLITE_OK else {
+      throw CatalogError.sqlite(
+        "bind int \(result): \(errorMessage(statement: statement))")
+    }
   }
 
   static func step(_ statement: OpaquePointer?) throws {
     let result = sqlite3_step(statement)
     guard result == SQLITE_DONE || result == SQLITE_ROW else {
-      throw CatalogError.sqlite("step \(result)")
+      throw CatalogError.sqlite(
+        "step \(result): \(errorMessage(statement: statement))")
     }
+  }
+
+  /// Reads `sqlite3_errmsg(_:)` for the connection backing `statement`.
+  /// Empty/missing handle paths fall back to a sentinel so a throw site is
+  /// never silent — even a degraded message beats `step 19` alone.
+  private static func errorMessage(statement: OpaquePointer?) -> String {
+    errorMessage(database: statement.flatMap { sqlite3_db_handle($0) })
+  }
+
+  private static func errorMessage(database: OpaquePointer?) -> String {
+    guard let database, let cString = sqlite3_errmsg(database) else {
+      return "(no errmsg)"
+    }
+    return String(cString: cString)
   }
 
   private static func scalarInt(database: OpaquePointer?, _ sql: String) throws -> Int {

--- a/MoolahTests/Backends/SQLiteCoinGeckoCatalogParseTests.swift
+++ b/MoolahTests/Backends/SQLiteCoinGeckoCatalogParseTests.swift
@@ -1,0 +1,79 @@
+// MoolahTests/Backends/SQLiteCoinGeckoCatalogParseTests.swift
+import Foundation
+import Testing
+
+@testable import Moolah
+
+/// Parser dedupe behaviour. CoinGecko's `/coins/list` and `/asset_platforms`
+/// endpoints occasionally include the same `id` / `slug` more than once
+/// (typically around delistings or platform renames). The downstream tables
+/// have UNIQUE/PRIMARY-KEY constraints, so a duplicate row would abort the
+/// `replaceAll` transaction and freeze the catalog at its prior snapshot.
+/// Dedupe in the parser keeps the on-disk constraints strict (so genuine
+/// bugs in our insert path still trap) without letting a single bad upstream
+/// row take out the whole refresh.
+@Suite("SQLiteCoinGeckoCatalog parse")
+struct SQLiteCoinGeckoCatalogParseTests {
+  @Test
+  func parseCoinsKeepsFirstOccurrenceWhenIdRepeats() throws {
+    let json = Data(
+      """
+      [
+        {"id": "tether", "symbol": "usdt", "name": "Tether", "platforms": {}},
+        {"id": "bitcoin", "symbol": "btc", "name": "Bitcoin", "platforms": {}},
+        {"id": "tether", "symbol": "usdt", "name": "Tether (dup)", "platforms": {}}
+      ]
+      """.utf8)
+
+    let coins = try SQLiteCoinGeckoCatalog.parseCoins(json)
+
+    #expect(coins.map(\.id) == ["tether", "bitcoin"])
+    #expect(coins.first(where: { $0.id == "tether" })?.name == "Tether")
+  }
+
+  @Test
+  func parsePlatformsKeepsFirstOccurrenceWhenSlugRepeats() throws {
+    let json = Data(
+      """
+      [
+        {"id": "ethereum", "chain_identifier": 1, "name": "Ethereum"},
+        {"id": "polygon-pos", "chain_identifier": 137, "name": "Polygon POS"},
+        {"id": "ethereum", "chain_identifier": 1, "name": "Ethereum (dup)"}
+      ]
+      """.utf8)
+
+    let platforms = try SQLiteCoinGeckoCatalog.parsePlatforms(json)
+
+    #expect(platforms.map(\.slug) == ["ethereum", "polygon-pos"])
+    #expect(platforms.first(where: { $0.slug == "ethereum" })?.name == "Ethereum")
+  }
+
+  @Test
+  func compactPlatformsDropsNullAndEmptyContracts() {
+    let raw: [String: String?] = [
+      "ethereum": "0xabc",
+      "polygon-pos": nil,
+      "binance-smart-chain": "",
+      "arbitrum-one": "0xdef",
+    ]
+
+    let compacted = SQLiteCoinGeckoCatalog.compactPlatforms(raw)
+
+    #expect(compacted == ["ethereum": "0xabc", "arbitrum-one": "0xdef"])
+  }
+
+  @Test
+  func parseCoinsLeavesUniqueIdsUntouched() throws {
+    let json = Data(
+      """
+      [
+        {"id": "bitcoin", "symbol": "btc", "name": "Bitcoin", "platforms": {}},
+        {"id": "ethereum", "symbol": "eth", "name": "Ethereum", "platforms": {}}
+      ]
+      """.utf8)
+
+    let coins = try SQLiteCoinGeckoCatalog.parseCoins(json)
+
+    #expect(coins.map(\.id) == ["bitcoin", "ethereum"])
+  }
+}

--- a/MoolahTests/Backends/SQLiteCoinGeckoCatalogStorageTests.swift
+++ b/MoolahTests/Backends/SQLiteCoinGeckoCatalogStorageTests.swift
@@ -74,6 +74,29 @@ final class SQLiteCoinGeckoCatalogStorageTests {
   }
 
   @Test
+  func constraintFailureIncludesSqliteErrorMessage() async throws {
+    let catalog = try SQLiteCoinGeckoCatalog(directory: tempDir)
+    let withDuplicate: [SQLiteCoinGeckoCatalog.RawCoin] = [
+      .init(id: "tether", symbol: "USDT", name: "Tether", platforms: [:]),
+      .init(id: "tether", symbol: "USDT", name: "Tether (dup)", platforms: [:]),
+    ]
+    do {
+      try await catalog.replaceAllForTesting(coins: withDuplicate, platforms: [])
+      Issue.record("expected constraint failure")
+    } catch let SQLiteCoinGeckoCatalog.CatalogError.sqlite(message) {
+      // Extended result codes turn bare `step 19` into the specific
+      // `SQLITE_CONSTRAINT_UNIQUE (2067)` plus the human-readable errmsg
+      // "UNIQUE constraint failed: coin.coingecko_id". Without both pieces
+      // a real-world refresh failure can't be diagnosed from logs alone.
+      #expect(message.contains("UNIQUE constraint failed"))
+      #expect(message.contains("coin.coingecko_id"))
+      #expect(message.contains("2067"))
+    } catch {
+      Issue.record("unexpected error type: \(error)")
+    }
+  }
+
+  @Test
   func replaceAllRollsBackOnConstraintFailure() async throws {
     let catalog = try SQLiteCoinGeckoCatalog(directory: tempDir)
 


### PR DESCRIPTION
## Summary

- **Root cause:** A single duplicate `coingecko_id` (or `asset_platforms.id`) from CoinGecko trips `coin.coingecko_id UNIQUE` / `platform.slug PK` mid-`BEGIN IMMEDIATE`. `applyUpdates` rolls back, `writeMeta` is skipped, `last_fetched` never advances — every subsequent launch refetches the same payload, fails identically, and the catalog freezes at its prior snapshot. The original symptom (\`refresh failed: sqlite(\"step 19\")\` repeated across PIDs) was code 19 = `SQLITE_CONSTRAINT`, not `SQLITE_BUSY` — extended codes would have said so directly.
- **Fix 1 — Tolerant parser.** `parseCoins(_:)` and `parsePlatforms(_:)` now collapse duplicate ids/slugs to first occurrence. The DB's UNIQUE / PRIMARY-KEY constraints stay strict so a real bug in the insert path still traps; only the known upstream noise is filtered. `compactPlatforms(_:)` extracted as a static helper so the nil/empty-contract drop-rule is directly testable.
- **Fix 2 — Better diagnostics.** `connect(_:)` enables `sqlite3_extended_result_codes`. `exec`/`prepare`/`bind`/`step` throw helpers now embed `sqlite3_errmsg(_:)` (resolved via `sqlite3_db_handle(_:)` for statement-only sites). Logs now read \`step 2067: UNIQUE constraint failed: coin.coingecko_id\` instead of bare \`step 19\`.

## Tests

- `SQLiteCoinGeckoCatalogParseTests` (new): dedupe by id/slug, compactPlatforms drops null/empty, no-op on unique input.
- `SQLiteCoinGeckoCatalogStorageTests.constraintFailureIncludesSqliteErrorMessage` (new): pins extended-code (\`2067\`) + errmsg (\`UNIQUE constraint failed: coin.coingecko_id\`) shape so a regression that loses either piece fails loudly. Tail \`catch\` rejects unexpected error types.

## Test plan

- [x] \`just format-check\` clean
- [x] \`just test-mac\` green (full suite)
- [x] \`just test-ios\` green (full suite)
- [x] code-review / concurrency-review / database-code-review pre-PR

## Out of scope (flagged by reviewers)

Pre-existing items — not bundled with this fix to keep the diff focused:
- silent \`try?\` on \`ROLLBACK;\` in \`replaceAll\` / \`replaceCoinsOnly\` / \`replacePlatformsOnly\` (CODE_GUIDE §8)
- unlabelled parameters on \`bind\` overloads (call sites read as three positional args)
- \`init\` does I/O + opens SQLite — would benefit from a \`static func open(...)\` factory (CODE_GUIDE §10)
- two separate \`Date()\` reads in \`refreshIfStale\` (capture once)