### PR TITLE
refactor(catalog): apply pre-existing review findings on top of #814

### DIFF
--- a/App/ProfileSession+Factories.swift
+++ b/App/ProfileSession+Factories.swift
@@ -213,7 +213,7 @@ extension ProfileSession {
     let directory = URL.moolahScopedApplicationSupport
       .appending(path: "InstrumentRegistry", directoryHint: .isDirectory)
     do {
-      let catalog = try SQLiteCoinGeckoCatalog(directory: directory)
+      let catalog = try SQLiteCoinGeckoCatalog.make(directory: directory)
       // `SQLiteCoinGeckoCatalog` is an actor, so `await catalog.refreshIfStale()`
       // hops to the catalog's executor regardless of the enclosing Task's
       // isolation — no `Task.detached` needed (CONCURRENCY_GUIDE §8).

--- a/Backends/CoinGecko/SQLiteCoinGeckoCatalog+Refresh.swift
+++ b/Backends/CoinGecko/SQLiteCoinGeckoCatalog+Refresh.swift
@@ -19,9 +19,13 @@ extension SQLiteCoinGeckoCatalog {
   /// the next launch retries.
   func refreshIfStale() async {
     do {
+      // Capture `now` once so the staleness compare and the `writeMeta`
+      // timestamp use the same instant — avoids any drift if the body
+      // takes long enough that two `Date()` reads diverge.
+      let now = Date()
       let meta = try Self.readMeta(database: database)
       if let lastFetched = meta.lastFetched,
-        Date().timeIntervalSince(lastFetched) < Self.maxAge
+        now.timeIntervalSince(lastFetched) < Self.maxAge
       {
         return
       }
@@ -56,12 +60,12 @@ extension SQLiteCoinGeckoCatalog {
         database: database, coins: coinsUpdate, platforms: platformsUpdate)
       try Self.writeMeta(
         database: database,
-        lastFetched: Date(),
+        lastFetched: now,
         coinsEtag: newCoinsEtag,
         platformsEtag: newPlatformsEtag
       )
     } catch {
-      log.error("refresh failed: \(String(describing: error), privacy: .public)")
+      Self.log.error("refresh failed: \(String(describing: error), privacy: .public)")
     }
   }
 }
@@ -263,7 +267,7 @@ extension SQLiteCoinGeckoCatalog {
       try insertCoins(database: database, coins: coins)
       try exec(database: database, "COMMIT;")
     } catch {
-      try? exec(database: database, "ROLLBACK;")
+      rollback(database: database)
       throw error
     }
   }
@@ -277,7 +281,7 @@ extension SQLiteCoinGeckoCatalog {
       try insertPlatforms(database: database, platforms: platforms)
       try exec(database: database, "COMMIT;")
     } catch {
-      try? exec(database: database, "ROLLBACK;")
+      rollback(database: database)
       throw error
     }
   }
@@ -291,18 +295,18 @@ extension SQLiteCoinGeckoCatalog {
     var statement: OpaquePointer?
     try prepare(
       database: database,
-      "UPDATE meta SET last_fetched = ?, coins_etag = ?, platforms_etag = ?;",
-      &statement
+      sql: "UPDATE meta SET last_fetched = ?, coins_etag = ?, platforms_etag = ?;",
+      into: &statement
     )
     defer { sqlite3_finalize(statement) }
     sqlite3_bind_double(statement, 1, lastFetched.timeIntervalSince1970)
     if let coinsEtag {
-      try bind(statement, 2, coinsEtag)
+      try bind(statement, at: 2, to: coinsEtag)
     } else {
       sqlite3_bind_null(statement, 2)
     }
     if let platformsEtag {
-      try bind(statement, 3, platformsEtag)
+      try bind(statement, at: 3, to: platformsEtag)
     } else {
       sqlite3_bind_null(statement, 3)
     }

--- a/Backends/CoinGecko/SQLiteCoinGeckoCatalog+SQLite.swift
+++ b/Backends/CoinGecko/SQLiteCoinGeckoCatalog+SQLite.swift
@@ -1,0 +1,125 @@
+// Backends/CoinGecko/SQLiteCoinGeckoCatalog+SQLite.swift
+import Foundation
+import SQLite3
+
+/// Thin SQLite C-API wrappers used by `SQLiteCoinGeckoCatalog`'s schema
+/// bootstrap, replace-all, and search/refresh extensions. All helpers are
+/// `static` (no actor state) so they compose cleanly from the actor's
+/// nonisolated `init` bootstrap and from actor-isolated runtime methods —
+/// see `SQLiteCoinGeckoCatalog.swift` for the closed-surface comment that
+/// pins which symbols leak across extension files.
+///
+/// Throw sites embed `sqlite3_errmsg(_:)` (resolved via `sqlite3_db_handle`
+/// for statement-only call sites) so logs read e.g.
+/// `step 2067: UNIQUE constraint failed: coin.coingecko_id` rather than
+/// bare `step 19`. Extended result codes are enabled in
+/// `SQLiteCoinGeckoCatalog.connect(_:)`.
+extension SQLiteCoinGeckoCatalog {
+  static func exec(database: OpaquePointer?, _ sql: String) throws {
+    var error: UnsafeMutablePointer<CChar>?
+    let result = sqlite3_exec(database, sql, nil, nil, &error)
+    if result != SQLITE_OK {
+      let message = error.map { String(cString: $0) } ?? "(no errmsg)"
+      sqlite3_free(error)
+      throw CatalogError.sqlite("exec \(result): \(message)")
+    }
+  }
+
+  static func prepare(
+    database: OpaquePointer?,
+    sql: String,
+    into statement: inout OpaquePointer?
+  ) throws {
+    let result = sqlite3_prepare_v2(database, sql, -1, &statement, nil)
+    guard result == SQLITE_OK else {
+      throw CatalogError.sqlite(
+        "prepare \(result): \(errorMessage(database: database)) — \(sql)")
+    }
+  }
+
+  static func bind(
+    _ statement: OpaquePointer?,
+    at index: Int32,
+    to value: String
+  ) throws {
+    let result = sqlite3_bind_text(
+      statement,
+      index,
+      value,
+      -1,
+      unsafeBitCast(Int(-1), to: sqlite3_destructor_type.self)
+    )
+    guard result == SQLITE_OK else {
+      throw CatalogError.sqlite(
+        "bind text \(result): \(errorMessage(statement: statement))")
+    }
+  }
+
+  static func bind(
+    _ statement: OpaquePointer?,
+    at index: Int32,
+    to value: Int
+  ) throws {
+    let result = sqlite3_bind_int64(statement, index, Int64(value))
+    guard result == SQLITE_OK else {
+      throw CatalogError.sqlite(
+        "bind int \(result): \(errorMessage(statement: statement))")
+    }
+  }
+
+  static func step(_ statement: OpaquePointer?) throws {
+    let result = sqlite3_step(statement)
+    guard result == SQLITE_DONE || result == SQLITE_ROW else {
+      throw CatalogError.sqlite(
+        "step \(result): \(errorMessage(statement: statement))")
+    }
+  }
+
+  /// Issues `ROLLBACK;` and logs (rather than rethrows) any failure. A
+  /// failed rollback indicates the connection is already in an undefined
+  /// transaction state — every subsequent write will fail anyway, so
+  /// surfacing the rollback error would mask the original cause; logging
+  /// it is the right balance per CODE_GUIDE §8 (no silent `try?`). Callers
+  /// must rethrow the original error after invoking this helper.
+  static func rollback(database: OpaquePointer?) {
+    do {
+      try exec(database: database, "ROLLBACK;")
+    } catch {
+      Self.log.error(
+        """
+        ROLLBACK failed: \(String(describing: error), privacy: .public) — \
+        connection may be in undefined transaction state
+        """
+      )
+    }
+  }
+
+  static func readText(_ statement: OpaquePointer?, column: Int32) -> String? {
+    guard let cString = sqlite3_column_text(statement, column) else { return nil }
+    return String(cString: cString)
+  }
+
+  /// Reads `sqlite3_errmsg(_:)` for the connection backing `statement`.
+  /// Empty/missing handle paths fall back to a sentinel so a throw site is
+  /// never silent — even a degraded message beats `step 19` alone.
+  private static func errorMessage(statement: OpaquePointer?) -> String {
+    errorMessage(database: statement.flatMap { sqlite3_db_handle($0) })
+  }
+
+  private static func errorMessage(database: OpaquePointer?) -> String {
+    guard let database, let cString = sqlite3_errmsg(database) else {
+      return "(no errmsg)"
+    }
+    return String(cString: cString)
+  }
+
+  static func scalarInt(database: OpaquePointer?, _ sql: String) throws -> Int {
+    var statement: OpaquePointer?
+    try prepare(database: database, sql: sql, into: &statement)
+    defer { sqlite3_finalize(statement) }
+    guard sqlite3_step(statement) == SQLITE_ROW else {
+      throw CatalogError.sqlite("scalar empty")
+    }
+    return Int(sqlite3_column_int64(statement, 0))
+  }
+}

--- a/Backends/CoinGecko/SQLiteCoinGeckoCatalog+Search.swift
+++ b/Backends/CoinGecko/SQLiteCoinGeckoCatalog+Search.swift
@@ -35,7 +35,7 @@ extension SQLiteCoinGeckoCatalog {
         )
       }
     } catch {
-      log.error("search failed: \(String(describing: error), privacy: .public)")
+      Self.log.error("search failed: \(String(describing: error), privacy: .public)")
       return []
     }
   }
@@ -59,18 +59,18 @@ extension SQLiteCoinGeckoCatalog {
     var statement: OpaquePointer?
     try prepare(
       database: database,
-      """
-      SELECT c.coingecko_id, c.symbol, c.name
-      FROM coin_fts JOIN coin c ON c.rowid = coin_fts.rowid
-      WHERE coin_fts MATCH ?
-      ORDER BY rank
-      LIMIT ?;
-      """,
-      &statement
+      sql: """
+        SELECT c.coingecko_id, c.symbol, c.name
+        FROM coin_fts JOIN coin c ON c.rowid = coin_fts.rowid
+        WHERE coin_fts MATCH ?
+        ORDER BY rank
+        LIMIT ?;
+        """,
+      into: &statement
     )
     defer { sqlite3_finalize(statement) }
-    try bind(statement, 1, ftsQuery)
-    try bind(statement, 2, limit)
+    try bind(statement, at: 1, to: ftsQuery)
+    try bind(statement, at: 2, to: limit)
     var rows: [RankedCoin] = []
     while sqlite3_step(statement) == SQLITE_ROW {
       let id = readText(statement, column: 0) ?? ""
@@ -91,17 +91,17 @@ extension SQLiteCoinGeckoCatalog {
     var statement: OpaquePointer?
     try prepare(
       database: database,
-      """
-      SELECT cp.coingecko_id, cp.platform_slug, cp.contract_address, p.chain_id
-      FROM coin_platform cp
-      LEFT JOIN platform p ON p.slug = cp.platform_slug
-      WHERE cp.coingecko_id IN (\(placeholders));
-      """,
-      &statement
+      sql: """
+        SELECT cp.coingecko_id, cp.platform_slug, cp.contract_address, p.chain_id
+        FROM coin_platform cp
+        LEFT JOIN platform p ON p.slug = cp.platform_slug
+        WHERE cp.coingecko_id IN (\(placeholders));
+        """,
+      into: &statement
     )
     defer { sqlite3_finalize(statement) }
     for (offset, id) in coingeckoIds.enumerated() {
-      try bind(statement, Int32(offset + 1), id)
+      try bind(statement, at: Int32(offset + 1), to: id)
     }
     var bindingsById: [String: [PlatformBinding]] = [:]
     while sqlite3_step(statement) == SQLITE_ROW {

--- a/Backends/CoinGecko/SQLiteCoinGeckoCatalog.swift
+++ b/Backends/CoinGecko/SQLiteCoinGeckoCatalog.swift
@@ -8,35 +8,57 @@ import os
 /// work runs on the actor's serial executor so the connection is never
 /// shared across threads. See design §4.1 / §6.
 actor SQLiteCoinGeckoCatalog: CoinGeckoCatalog {
+  /// Stateless `Logger`; `static` so the nonisolated bootstrap path and the
+  /// `static` SQLite helpers can both emit on the same subsystem/category
+  /// without each call site rebuilding the logger.
+  static let log = Logger(subsystem: "moolah.instrument-registry", category: "catalog")
+
   private let directory: URL
   let session: URLSession
-  let log = Logger(subsystem: "moolah.instrument-registry", category: "catalog")
   private(set) var database: OpaquePointer?
 
   // MARK: - Cross-extension internals
   //
   // Swift's `private` doesn't reach across files, so members called from
-  // `+Search.swift` or `+Refresh.swift` drop their `private` keyword and
-  // become module-internal. This is the closed surface — callers outside
-  // `Backends/CoinGecko/` MUST NOT use them.
+  // `+Search.swift`, `+Refresh.swift`, or `+SQLite.swift` drop their
+  // `private` keyword and become module-internal. This is the closed
+  // surface — callers outside `Backends/CoinGecko/` MUST NOT use them.
   //
-  // Used by +Search.swift only:    `readText`
-  // Used by +Refresh.swift only:   `session`, `exec`, `step`,
-  //                                `replaceAll`, `insertCoins`,
+  // Most low-level SQLite helpers (`exec`, `prepare`, `bind` ×2, `step`,
+  // `rollback`, `readText`, `errorMessage` ×2, `scalarInt`) live in
+  // `+SQLite.swift`.
+  //
+  // Used by +Search.swift only:    nothing in this file
+  // Used by +Refresh.swift only:   `session`, `replaceAll`, `insertCoins`,
   //                                `insertPlatforms`, `readMeta`
-  // Used by both extensions:       `log`, `database` (read-only),
-  //                                `prepare`, `bind` (×2)
+  // Used by both extensions:       `log` (static), `database` (read-only)
 
-  init(
+  /// Opens or creates the on-disk catalog at `<directory>/catalog.sqlite`,
+  /// then constructs the actor with the prepared handle. Factored out as a
+  /// `static func` per CODE_GUIDE §10 so `init` can stay a memberwise
+  /// property assignment — keeping all the I/O and schema bootstrap
+  /// (directory creation, SQLite open, version check, drop-and-recreate)
+  /// in one named place.
+  static func make(
     directory: URL,
     session: URLSession = .shared
-  ) throws {
-    self.directory = directory
-    self.session = session
+  ) throws -> SQLiteCoinGeckoCatalog {
     try FileManager.default.createDirectory(
       at: directory, withIntermediateDirectories: true
     )
-    self.database = try Self.open(dbURL: directory.appendingPathComponent("catalog.sqlite"))
+    let database = try open(dbURL: directory.appendingPathComponent("catalog.sqlite"))
+    return SQLiteCoinGeckoCatalog(
+      directory: directory, session: session, database: database)
+  }
+
+  private init(
+    directory: URL,
+    session: URLSession,
+    database: OpaquePointer
+  ) {
+    self.directory = directory
+    self.session = session
+    self.database = database
   }
 
   isolated deinit {
@@ -123,7 +145,7 @@ actor SQLiteCoinGeckoCatalog: CoinGeckoCatalog {
       try insertPlatforms(database: database, platforms: platforms)
       try exec(database: database, "COMMIT;")
     } catch {
-      try? exec(database: database, "ROLLBACK;")
+      rollback(database: database)
       throw error
     }
   }
@@ -133,28 +155,28 @@ actor SQLiteCoinGeckoCatalog: CoinGeckoCatalog {
     var insertCoin: OpaquePointer?
     try prepare(
       database: database,
-      "INSERT INTO coin (coingecko_id, symbol, name) VALUES (?, ?, ?);",
-      &insertCoin)
+      sql: "INSERT INTO coin (coingecko_id, symbol, name) VALUES (?, ?, ?);",
+      into: &insertCoin)
     defer { sqlite3_finalize(insertCoin) }
     var insertCoinPlatform: OpaquePointer?
     try prepare(
       database: database,
-      "INSERT INTO coin_platform (coingecko_id, platform_slug, contract_address) "
+      sql: "INSERT INTO coin_platform (coingecko_id, platform_slug, contract_address) "
         + "VALUES (?, ?, ?);",
-      &insertCoinPlatform)
+      into: &insertCoinPlatform)
     defer { sqlite3_finalize(insertCoinPlatform) }
 
     for coin in coins {
-      try bind(insertCoin, 1, coin.id)
-      try bind(insertCoin, 2, coin.symbol)
-      try bind(insertCoin, 3, coin.name)
+      try bind(insertCoin, at: 1, to: coin.id)
+      try bind(insertCoin, at: 2, to: coin.symbol)
+      try bind(insertCoin, at: 3, to: coin.name)
       try step(insertCoin)
       sqlite3_reset(insertCoin)
 
       for (slug, contract) in coin.platforms where !contract.isEmpty {
-        try bind(insertCoinPlatform, 1, coin.id)
-        try bind(insertCoinPlatform, 2, slug)
-        try bind(insertCoinPlatform, 3, contract.lowercased())
+        try bind(insertCoinPlatform, at: 1, to: coin.id)
+        try bind(insertCoinPlatform, at: 2, to: slug)
+        try bind(insertCoinPlatform, at: 3, to: contract.lowercased())
         try step(insertCoinPlatform)
         sqlite3_reset(insertCoinPlatform)
       }
@@ -169,17 +191,17 @@ actor SQLiteCoinGeckoCatalog: CoinGeckoCatalog {
     var insertPlatform: OpaquePointer?
     try prepare(
       database: database,
-      "INSERT INTO platform (slug, chain_id, name) VALUES (?, ?, ?);",
-      &insertPlatform)
+      sql: "INSERT INTO platform (slug, chain_id, name) VALUES (?, ?, ?);",
+      into: &insertPlatform)
     defer { sqlite3_finalize(insertPlatform) }
     for platform in platforms {
-      try bind(insertPlatform, 1, platform.slug)
+      try bind(insertPlatform, at: 1, to: platform.slug)
       if let chainId = platform.chainId {
-        try bind(insertPlatform, 2, chainId)
+        try bind(insertPlatform, at: 2, to: chainId)
       } else {
         sqlite3_bind_null(insertPlatform, 2)
       }
-      try bind(insertPlatform, 3, platform.name)
+      try bind(insertPlatform, at: 3, to: platform.name)
       try step(insertPlatform)
       sqlite3_reset(insertPlatform)
     }
@@ -191,8 +213,8 @@ actor SQLiteCoinGeckoCatalog: CoinGeckoCatalog {
     var statement: OpaquePointer?
     try prepare(
       database: database,
-      "SELECT schema_version, last_fetched, coins_etag, platforms_etag FROM meta LIMIT 1;",
-      &statement)
+      sql: "SELECT schema_version, last_fetched, coins_etag, platforms_etag FROM meta LIMIT 1;",
+      into: &statement)
     defer { sqlite3_finalize(statement) }
     guard sqlite3_step(statement) == SQLITE_ROW else {
       throw CatalogError.sqlite("meta table empty")
@@ -214,95 +236,8 @@ actor SQLiteCoinGeckoCatalog: CoinGeckoCatalog {
   }
 
   // MARK: - Low-level SQLite helpers
-
-  static func exec(database: OpaquePointer?, _ sql: String) throws {
-    var error: UnsafeMutablePointer<CChar>?
-    let result = sqlite3_exec(database, sql, nil, nil, &error)
-    if result != SQLITE_OK {
-      let message = error.map { String(cString: $0) } ?? "(no errmsg)"
-      sqlite3_free(error)
-      throw CatalogError.sqlite("exec \(result): \(message)")
-    }
-  }
-
-  static func prepare(
-    database: OpaquePointer?,
-    _ sql: String,
-    _ statement: inout OpaquePointer?
-  ) throws {
-    let result = sqlite3_prepare_v2(database, sql, -1, &statement, nil)
-    guard result == SQLITE_OK else {
-      throw CatalogError.sqlite(
-        "prepare \(result): \(errorMessage(database: database)) — \(sql)")
-    }
-  }
-
-  static func bind(
-    _ statement: OpaquePointer?,
-    _ index: Int32,
-    _ value: String
-  ) throws {
-    let result = sqlite3_bind_text(
-      statement,
-      index,
-      value,
-      -1,
-      unsafeBitCast(Int(-1), to: sqlite3_destructor_type.self)
-    )
-    guard result == SQLITE_OK else {
-      throw CatalogError.sqlite(
-        "bind text \(result): \(errorMessage(statement: statement))")
-    }
-  }
-
-  static func bind(
-    _ statement: OpaquePointer?,
-    _ index: Int32,
-    _ value: Int
-  ) throws {
-    let result = sqlite3_bind_int64(statement, index, Int64(value))
-    guard result == SQLITE_OK else {
-      throw CatalogError.sqlite(
-        "bind int \(result): \(errorMessage(statement: statement))")
-    }
-  }
-
-  static func step(_ statement: OpaquePointer?) throws {
-    let result = sqlite3_step(statement)
-    guard result == SQLITE_DONE || result == SQLITE_ROW else {
-      throw CatalogError.sqlite(
-        "step \(result): \(errorMessage(statement: statement))")
-    }
-  }
-
-  /// Reads `sqlite3_errmsg(_:)` for the connection backing `statement`.
-  /// Empty/missing handle paths fall back to a sentinel so a throw site is
-  /// never silent — even a degraded message beats `step 19` alone.
-  private static func errorMessage(statement: OpaquePointer?) -> String {
-    errorMessage(database: statement.flatMap { sqlite3_db_handle($0) })
-  }
-
-  private static func errorMessage(database: OpaquePointer?) -> String {
-    guard let database, let cString = sqlite3_errmsg(database) else {
-      return "(no errmsg)"
-    }
-    return String(cString: cString)
-  }
-
-  private static func scalarInt(database: OpaquePointer?, _ sql: String) throws -> Int {
-    var statement: OpaquePointer?
-    try prepare(database: database, sql, &statement)
-    defer { sqlite3_finalize(statement) }
-    guard sqlite3_step(statement) == SQLITE_ROW else {
-      throw CatalogError.sqlite("scalar empty")
-    }
-    return Int(sqlite3_column_int64(statement, 0))
-  }
-
-  static func readText(_ statement: OpaquePointer?, column: Int32) -> String? {
-    guard let cString = sqlite3_column_text(statement, column) else { return nil }
-    return String(cString: cString)
-  }
+  //
+  // Live in `SQLiteCoinGeckoCatalog+SQLite.swift`.
 
   enum CatalogError: Error, Equatable {
     case sqlite(String)
@@ -371,9 +306,9 @@ extension SQLiteCoinGeckoCatalog {
   func writeMetaSchemaVersionForTesting(_ version: Int) throws {
     var statement: OpaquePointer?
     try Self.prepare(
-      database: database, "UPDATE meta SET schema_version = ?;", &statement)
+      database: database, sql: "UPDATE meta SET schema_version = ?;", into: &statement)
     defer { sqlite3_finalize(statement) }
-    try Self.bind(statement, 1, version)
+    try Self.bind(statement, at: 1, to: version)
     try Self.step(statement)
   }
 }

--- a/MoolahTests/Backends/SQLiteCoinGeckoCatalogRefreshTests.swift
+++ b/MoolahTests/Backends/SQLiteCoinGeckoCatalogRefreshTests.swift
@@ -45,7 +45,7 @@ final class SQLiteCoinGeckoCatalogRefreshTests {
       (HTTPURLResponse.ok(etag: "W/\"p1\""), platformsData)
     }
 
-    let catalog = try SQLiteCoinGeckoCatalog(directory: tempDir, session: makeSession())
+    let catalog = try SQLiteCoinGeckoCatalog.make(directory: tempDir, session: makeSession())
     await catalog.refreshIfStale()
 
     let count = try await catalog.coinCountForTesting()
@@ -68,7 +68,7 @@ final class SQLiteCoinGeckoCatalogRefreshTests {
     StubURLProtocol.handlers["api.coingecko.com:/api/v3/asset_platforms"] = { _ in
       (HTTPURLResponse.ok(etag: "W/\"p1\""), platformsData)
     }
-    let catalog = try SQLiteCoinGeckoCatalog(directory: tempDir, session: makeSession())
+    let catalog = try SQLiteCoinGeckoCatalog.make(directory: tempDir, session: makeSession())
     await catalog.refreshIfStale()
 
     // Fast-forward `last_fetched` so the next call is "stale".
@@ -106,7 +106,7 @@ final class SQLiteCoinGeckoCatalogRefreshTests {
     StubURLProtocol.handlers["api.coingecko.com:/api/v3/asset_platforms"] = { _ in
       (HTTPURLResponse.ok(etag: "W/\"p1\""), platformsData)
     }
-    let catalog = try SQLiteCoinGeckoCatalog(directory: tempDir, session: makeSession())
+    let catalog = try SQLiteCoinGeckoCatalog.make(directory: tempDir, session: makeSession())
     await catalog.refreshIfStale()
     await catalog.refreshIfStale()
 
@@ -123,7 +123,7 @@ final class SQLiteCoinGeckoCatalogRefreshTests {
     StubURLProtocol.handlers["api.coingecko.com:/api/v3/asset_platforms"] = { _ in
       (HTTPURLResponse.ok(etag: "W/\"p1\""), platformsData)
     }
-    let catalog = try SQLiteCoinGeckoCatalog(directory: tempDir, session: makeSession())
+    let catalog = try SQLiteCoinGeckoCatalog.make(directory: tempDir, session: makeSession())
     await catalog.refreshIfStale()
     try await catalog.bumpLastFetchedBackwardForTesting(by: 25 * 3600)
 
@@ -150,7 +150,7 @@ final class SQLiteCoinGeckoCatalogRefreshTests {
     StubURLProtocol.handlers["api.coingecko.com:/api/v3/asset_platforms"] = { _ in
       (HTTPURLResponse.ok(etag: "W/\"p1\""), platforms)
     }
-    let catalog = try SQLiteCoinGeckoCatalog(directory: tempDir, session: makeSession())
+    let catalog = try SQLiteCoinGeckoCatalog.make(directory: tempDir, session: makeSession())
     await catalog.refreshIfStale()
     try await catalog.bumpLastFetchedBackwardForTesting(by: 25 * 3600)
 

--- a/MoolahTests/Backends/SQLiteCoinGeckoCatalogSearchTests.swift
+++ b/MoolahTests/Backends/SQLiteCoinGeckoCatalogSearchTests.swift
@@ -16,7 +16,7 @@ final class SQLiteCoinGeckoCatalogSearchTests {
     tempDir = URL(fileURLWithPath: NSTemporaryDirectory())
       .appendingPathComponent("search-\(UUID().uuidString)", isDirectory: true)
     try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-    catalog = try SQLiteCoinGeckoCatalog(directory: tempDir)
+    catalog = try SQLiteCoinGeckoCatalog.make(directory: tempDir)
   }
 
   deinit {

--- a/MoolahTests/Backends/SQLiteCoinGeckoCatalogStorageTests.swift
+++ b/MoolahTests/Backends/SQLiteCoinGeckoCatalogStorageTests.swift
@@ -23,7 +23,7 @@ final class SQLiteCoinGeckoCatalogStorageTests {
 
   @Test
   func openCreatesFreshSchema() async throws {
-    let catalog = try SQLiteCoinGeckoCatalog(directory: tempDir)
+    let catalog = try SQLiteCoinGeckoCatalog.make(directory: tempDir)
     let dbURL = tempDir.appendingPathComponent("catalog.sqlite")
     #expect(FileManager.default.fileExists(atPath: dbURL.path))
     let meta = try await catalog.readMetaForTesting()
@@ -35,7 +35,7 @@ final class SQLiteCoinGeckoCatalogStorageTests {
 
   @Test
   func replaceAllCoinsAndPlatformsCommitsAtomically() async throws {
-    let catalog = try SQLiteCoinGeckoCatalog(directory: tempDir)
+    let catalog = try SQLiteCoinGeckoCatalog.make(directory: tempDir)
     let coins: [SQLiteCoinGeckoCatalog.RawCoin] = [
       .init(id: "bitcoin", symbol: "BTC", name: "Bitcoin", platforms: [:]),
       .init(
@@ -58,7 +58,7 @@ final class SQLiteCoinGeckoCatalogStorageTests {
 
   @Test
   func replaceAllReplacesPriorContent() async throws {
-    let catalog = try SQLiteCoinGeckoCatalog(directory: tempDir)
+    let catalog = try SQLiteCoinGeckoCatalog.make(directory: tempDir)
     let first: [SQLiteCoinGeckoCatalog.RawCoin] = [
       .init(id: "bitcoin", symbol: "BTC", name: "Bitcoin", platforms: [:])
     ]
@@ -75,7 +75,7 @@ final class SQLiteCoinGeckoCatalogStorageTests {
 
   @Test
   func constraintFailureIncludesSqliteErrorMessage() async throws {
-    let catalog = try SQLiteCoinGeckoCatalog(directory: tempDir)
+    let catalog = try SQLiteCoinGeckoCatalog.make(directory: tempDir)
     let withDuplicate: [SQLiteCoinGeckoCatalog.RawCoin] = [
       .init(id: "tether", symbol: "USDT", name: "Tether", platforms: [:]),
       .init(id: "tether", symbol: "USDT", name: "Tether (dup)", platforms: [:]),
@@ -98,7 +98,7 @@ final class SQLiteCoinGeckoCatalogStorageTests {
 
   @Test
   func replaceAllRollsBackOnConstraintFailure() async throws {
-    let catalog = try SQLiteCoinGeckoCatalog(directory: tempDir)
+    let catalog = try SQLiteCoinGeckoCatalog.make(directory: tempDir)
 
     // Seed a successful first batch so we have prior state to preserve.
     let first: [SQLiteCoinGeckoCatalog.RawCoin] = [
@@ -128,15 +128,15 @@ final class SQLiteCoinGeckoCatalogStorageTests {
 
   @Test
   func schemaVersionMismatchRecreatesFile() async throws {
-    _ = try SQLiteCoinGeckoCatalog(directory: tempDir)
+    _ = try SQLiteCoinGeckoCatalog.make(directory: tempDir)
     let dbURL = tempDir.appendingPathComponent("catalog.sqlite")
     let creationOriginal =
       try FileManager.default.attributesOfItem(atPath: dbURL.path)[.creationDate] as? Date
 
-    let stale = try SQLiteCoinGeckoCatalog(directory: tempDir)
+    let stale = try SQLiteCoinGeckoCatalog.make(directory: tempDir)
     try await stale.writeMetaSchemaVersionForTesting(999)
 
-    let reopened = try SQLiteCoinGeckoCatalog(directory: tempDir)
+    let reopened = try SQLiteCoinGeckoCatalog.make(directory: tempDir)
     let metaAfter = try await reopened.readMetaForTesting()
     #expect(metaAfter.schemaVersion == CoinGeckoCatalogSchema.version)
 


### PR DESCRIPTION
## Summary

Follow-up to [#814](https://github.com/ajsutton/moolah-native/pull/814). Addresses the four pre-existing items the previous code-review flagged. Stacked on \`fix/coingecko-catalog-resilience\` — when #814 lands, GitHub will auto-retarget this PR to \`main\`.

- **Silent ROLLBACK** (CODE_GUIDE §8). \`try? exec(database:, \"ROLLBACK;\")\` → new \`rollback(database:)\` helper that exec's the rollback and *logs* (rather than rethrows) any failure. Original error still propagates from the catch arm.
- **bind / prepare labels.** \`bind(_:_:_:)\` → \`bind(_:at:to:)\`; \`prepare(database:_:_:)\` → \`prepare(database:sql:into:)\`. Call sites read as phrases.
- **\`init\` → \`make\` factory** (CODE_GUIDE §10). Directory creation, SQLite open, version check, drop-and-recreate now live in \`static func make(directory:session:)\`. The \`init\` is a private memberwise constructor.
- **\`Date()\` captured once** at the top of \`refreshIfStale\`'s do-block.
- **Bonus**: low-level SQLite helpers extracted to a new \`SQLiteCoinGeckoCatalog+SQLite.swift\` extension so the parent file fits SwiftLint's \`file_length\` (400) and \`type_body_length\` (250) budgets without touching the baseline. \`Logger\` lifted to \`static let log\` so the extracted helpers can use it without \`self\`.

## Reviews applied (pre-PR)

- **code-review** Important: \`errorMessage\` overloads → reduced from \`static\` to \`private static\` (only used in \`+SQLite.swift\`).
- **code-review** Minor: \`prepare\` labels for consistency with \`bind\`.
- **concurrency-review** Minor: \`log\` → \`Self.log\` in \`rollback\` for consistency with \`+Search.swift\` / \`+Refresh.swift\`.

## Test plan

- [x] \`just format-check\` clean
- [x] \`just test-mac\` green (full suite, 14+ catalog tests)
- [x] \`just test-ios\` green (full suite)
- [x] \`.swiftlint-baseline.yml\` not touched