### PR TITLE
fix(welcome): show Cancel/Create toolbar on iOS create-profile form

### DIFF
--- a/Backends/CloudKit/CloudKitAuthProvider.swift
+++ b/Backends/CloudKit/CloudKitAuthProvider.swift
@@ -55,7 +55,16 @@ final class CloudKitAuthProvider: AuthProvider, Sendable {
 
   static var isCloudKitAvailable: Bool {
     #if CLOUDKIT_ENABLED
-      return true
+      // The iOS Simulator doesn't apply iCloud entitlements at signing
+      // time even when the entitlements file specifies them, so any
+      // `CKContainer` access traps inside the framework. Treat the iOS
+      // sim as if CloudKit is unavailable so the app falls through to
+      // the local-only path — same as a device with no iCloud account.
+      #if targetEnvironment(simulator) && os(iOS)
+        return false
+      #else
+        return true
+      #endif
     #else
       return false
     #endif

--- a/Features/Profiles/Views/WelcomeView.swift
+++ b/Features/Profiles/Views/WelcomeView.swift
@@ -149,6 +149,7 @@ struct WelcomeView: View {
     .accessibilityHint(offHeroHint(for: reason))
   }
 
+  @ViewBuilder
   private func formView(
     banner: WelcomeStateResolver.BannerKind?
   ) -> some View {
@@ -156,7 +157,7 @@ struct WelcomeView: View {
       profileStore.iCloudAvailability == .available
       && !syncCoordinator.profileIndexFetchedAtLeastOnce
 
-    return CreateProfileFormView(
+    let form = CreateProfileFormView(
       name: $name,
       currency: $currency,
       financialYearStartMonth: $financialYearStartMonth,
@@ -167,6 +168,16 @@ struct WelcomeView: View {
       cancelAction: { phase = .landing },
       createAction: handleCreate
     )
+
+    // Toolbar items in `.cancellationAction`/`.confirmationAction` only
+    // render on iOS when there's a navigation bar to attach to. On macOS
+    // the toolbar binds to the window's NSToolbar, so the wrapper would
+    // double-render — keep the wrap iOS-only.
+    #if os(iOS)
+      NavigationStack { form }
+    #else
+      form
+    #endif
   }
 
   private var pickerView: some View {

--- a/Features/Profiles/Views/WelcomeView.swift
+++ b/Features/Profiles/Views/WelcomeView.swift
@@ -149,7 +149,6 @@ struct WelcomeView: View {
     .accessibilityHint(offHeroHint(for: reason))
   }
 
-  @ViewBuilder
   private func formView(
     banner: WelcomeStateResolver.BannerKind?
   ) -> some View {
@@ -157,26 +156,37 @@ struct WelcomeView: View {
       profileStore.iCloudAvailability == .available
       && !syncCoordinator.profileIndexFetchedAtLeastOnce
 
-    let form = CreateProfileFormView(
-      name: $name,
-      currency: $currency,
-      financialYearStartMonth: $financialYearStartMonth,
-      banner: banner.map(mapBanner),
-      onBannerPrimary: handleBannerPrimary,
-      onBannerDismiss: { bannerDismissed = true },
-      backgroundCheckingICloud: backgroundChecking,
-      cancelAction: { phase = .landing },
-      createAction: handleCreate
-    )
+    return formWrapper {
+      CreateProfileFormView(
+        name: $name,
+        currency: $currency,
+        financialYearStartMonth: $financialYearStartMonth,
+        banner: banner.map(mapBanner),
+        onBannerPrimary: handleBannerPrimary,
+        onBannerDismiss: { bannerDismissed = true },
+        backgroundCheckingICloud: backgroundChecking,
+        cancelAction: { phase = .landing },
+        createAction: handleCreate
+      )
+    }
+  }
 
-    // Toolbar items in `.cancellationAction`/`.confirmationAction` only
-    // render on iOS when there's a navigation bar to attach to. On macOS
-    // the toolbar binds to the window's NSToolbar, so the wrapper would
-    // double-render — keep the wrap iOS-only.
+  /// Toolbar items in `.cancellationAction`/`.confirmationAction` only
+  /// render on iOS when there's a navigation bar to attach to. On macOS
+  /// the toolbar binds to the window's NSToolbar, so the wrapper would
+  /// double-render — keep the wrap iOS-only.
+  @ViewBuilder
+  private func formWrapper<Content: View>(
+    @ViewBuilder content: () -> Content
+  ) -> some View {
     #if os(iOS)
-      NavigationStack { form }
+      NavigationStack {
+        content()
+          .navigationBarTitleDisplayMode(.inline)
+          .toolbar(.visible, for: .navigationBar)
+      }
     #else
-      form
+      content()
     #endif
   }
 


### PR DESCRIPTION
## Summary

Two fixes that together get the iOS first-run flow working again:

### 1. Cancel/Create toolbar missing on the iOS create-profile form

`CreateProfileFormView` declares Cancel and Create Profile as `.toolbar { ToolbarItem(placement: .cancellationAction/.confirmationAction) }`. On iOS those placements only render when there's a navigation bar to attach to. `WelcomeView` is hosted directly under `WindowGroup` with no `NavigationStack` ancestor, so the items were silently dropped — leaving the iPhone form with no Create button and no way to cancel back to the hero. macOS works because SwiftUI binds the same items to the window's `NSToolbar`.

iOS 26 also collapses an empty navigation bar (no `navigationTitle`) to nothing, which would still drop the toolbar items. Force the bar visible and pin it to inline.

### 2. Startup crash on the iOS Simulator

The iOS Simulator doesn't apply iCloud entitlements at signing time even when the build's entitlements file specifies them. Any `CKContainer` access — `LegacyZoneCleanup`, `SyncCoordinator.start`, `scheduleFetchChanges` — then traps inside the framework with `EXC_BREAKPOINT` and the warning *"your process must have a com.apple.developer.icloud-services entitlement"*. On a fresh sim install the trap fires before any UI renders, leaving the app stuck on the launch screen. This was a pre-existing issue surfaced by reinstalling during testing (`UserDefaults` reset re-armed `LegacyZoneCleanup.performIfNeeded`).

## Fix

- `Features/Profiles/Views/WelcomeView.swift` — wrap the form state in `NavigationStack` on iOS only with `.navigationBarTitleDisplayMode(.inline)` and `.toolbar(.visible, for: .navigationBar)`. Hero and picker stay outside the stack — they don't use `.toolbar`.
- `Backends/CloudKit/CloudKitAuthProvider.swift` — `isCloudKitAvailable` returns `false` under `targetEnvironment(simulator) && os(iOS)` so the app falls through to the local-only path. iOS device builds and macOS dev/release are unaffected.

Pressing Return in the Name field already worked via the existing `.submitLabel(.done) + .onSubmit(submit)` wiring in `CreateProfileFormView.swift:84-85`.

## Test plan

- [x] `just build-ios` succeeds
- [x] `just build-mac` succeeds (no regression on the macOS path)
- [x] `just format-check` clean
- [x] iPhone 17 Pro simulator (iOS 26.4): tap Get started → form shows with Cancel + Create Profile in the nav bar; profile creation submits and the app advances into the main dashboard. Confirmed by the user.
- [x] iPhone 17 Pro simulator: pressing Return in Name field creates the profile.
- [ ] Visual check on macOS: window-level toolbar still shows Cancel + Create Profile (no double bar). _(Build passes; macOS path unchanged.)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)