### PR TITLE
fix(sync): queue auto-inserted non-fiat instruments for CloudKit

### DIFF
--- a/App/ProfileSession+CloudKitBackendBuild.swift
+++ b/App/ProfileSession+CloudKitBackendBuild.swift
@@ -72,8 +72,32 @@ extension ProfileSession {
         onTransactionChanged: hooks.changed,
         onTransactionDeleted: hooks.deleted,
         onTransactionLegChanged: hooks.changed,
-        onTransactionLegDeleted: hooks.deleted)
+        onTransactionLegDeleted: hooks.deleted,
+        onInstrumentChanged: makeInstrumentChangedHook(
+          zoneID: zoneID, syncCoordinator: syncCoordinator))
     )
+  }
+
+  /// Builds the closure `GRDBTransactionRepository` /
+  /// `GRDBAccountRepository` fire whenever they auto-insert a non-fiat
+  /// `InstrumentRow` to satisfy a leg or account denomination. Routes
+  /// through the same recordName-keyed `queueSave` path
+  /// `GRDBInstrumentRegistryRepository.registerStock` already uses so
+  /// the row reaches CloudKit on the next batch. Without this, an
+  /// instrument introduced by SelfWealth import or a stock-account
+  /// create would live only on the device that wrote it (sibling
+  /// devices fall back to `Instrument.fiat(code: id)` and stock
+  /// conversions 404 against the fiat-only Frankfurter API). Returns a
+  /// no-op closure when no coordinator is wired (preview / test
+  /// backends).
+  private static func makeInstrumentChangedHook(
+    zoneID: CKRecordZone.ID, syncCoordinator: SyncCoordinator?
+  ) -> @Sendable (String) -> Void {
+    { [weak syncCoordinator] recordName in
+      Task { @MainActor [weak syncCoordinator] in
+        syncCoordinator?.queueSave(recordName: recordName, zoneID: zoneID)
+      }
+    }
   }
 
   /// Bundle of the change/delete closures the GRDB repos call on each

--- a/Backends/CloudKit/CloudKitBackend.swift
+++ b/Backends/CloudKit/CloudKitBackend.swift
@@ -56,6 +56,13 @@ final class CloudKitBackend: BackendProvider, @unchecked Sendable {
     let onTransactionDeleted: @Sendable (String, UUID) -> Void
     let onTransactionLegChanged: @Sendable (String, UUID) -> Void
     let onTransactionLegDeleted: @Sendable (String, UUID) -> Void
+    /// Fires when an account / transaction write auto-inserts a non-fiat
+    /// `InstrumentRow` to satisfy a leg or account denomination. Carries
+    /// the instrument id (which doubles as the InstrumentRecord
+    /// recordName) — the registry's own `register*` paths fire this
+    /// from a separate hook, so this surface only covers the
+    /// auto-insert path inside the transaction / account repositories.
+    let onInstrumentChanged: @Sendable (String) -> Void
 
     static let noop = CloudKitBackendHooks(
       onCSVImportProfileChanged: { _, _ in },
@@ -75,7 +82,8 @@ final class CloudKitBackend: BackendProvider, @unchecked Sendable {
       onTransactionChanged: { _, _ in },
       onTransactionDeleted: { _, _ in },
       onTransactionLegChanged: { _, _ in },
-      onTransactionLegDeleted: { _, _ in })
+      onTransactionLegDeleted: { _, _ in },
+      onInstrumentChanged: { _ in })
   }
 
   init(
@@ -145,13 +153,15 @@ final class CloudKitBackend: BackendProvider, @unchecked Sendable {
       accounts: GRDBAccountRepository(
         database: database,
         onRecordChanged: hooks.onAccountChanged,
-        onRecordDeleted: hooks.onAccountDeleted),
+        onRecordDeleted: hooks.onAccountDeleted,
+        onInstrumentChanged: hooks.onInstrumentChanged),
       transactions: GRDBTransactionRepository(
         database: database,
         defaultInstrument: instrument,
         conversionService: conversionService,
         onRecordChanged: hooks.onTransactionChanged,
-        onRecordDeleted: hooks.onTransactionDeleted),
+        onRecordDeleted: hooks.onTransactionDeleted,
+        onInstrumentChanged: hooks.onInstrumentChanged),
       categories: GRDBCategoryRepository(
         database: database,
         onRecordChanged: hooks.onCategoryChanged,

--- a/Backends/CloudKit/Sync/ProfileDataSyncHandler+QueueAndDelete.swift
+++ b/Backends/CloudKit/Sync/ProfileDataSyncHandler+QueueAndDelete.swift
@@ -25,6 +25,42 @@ extension ProfileDataSyncHandler {
     return recordIDs
   }
 
+  /// Scans the `instrument` table only and returns CKRecord.IDs for
+  /// non-fiat rows that have never been successfully sent to CloudKit
+  /// (i.e. `encodedSystemFields == nil` AND `kind != 'fiatCurrency'`).
+  /// Run unconditionally on every coordinator start by
+  /// `queueUnsyncedInstrumentsForAllProfiles` so a row inserted by a
+  /// build that predated the `onInstrumentChanged` plumbing eventually
+  /// reaches CloudKit, even on profiles whose flag-gated full backfill
+  /// has already completed.
+  func queueUnsyncedInstrumentRecords() -> [CKRecord.ID] {
+    let signpostID = OSSignpostID(log: Signposts.sync)
+    os_signpost(
+      .begin,
+      log: Signposts.sync,
+      name: "queueUnsyncedInstrumentRecords",
+      signpostID: signpostID)
+    defer {
+      os_signpost(
+        .end,
+        log: Signposts.sync,
+        name: "queueUnsyncedInstrumentRecords",
+        signpostID: signpostID)
+    }
+
+    var recordIDs: [CKRecord.ID] = []
+    let repo = grdbRepositories.instruments
+    collectAllGRDBStrings(
+      ids: { try repo.unsyncedNonFiatRowIdsSync() },
+      recordType: InstrumentRow.recordType,
+      into: &recordIDs)
+    if !recordIDs.isEmpty {
+      logger.info(
+        "Collected \(recordIDs.count) unsynced non-fiat instrument records for upload")
+    }
+    return recordIDs
+  }
+
   /// Scans all record types and returns CKRecord.IDs for records that have never been
   /// successfully sent to CloudKit (i.e. `encodedSystemFields == nil`). Used on startup
   /// to backfill uploads for profiles whose data landed via migration or any other path

--- a/Backends/CloudKit/Sync/SyncCoordinator+Backfill.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+Backfill.swift
@@ -103,6 +103,50 @@ extension SyncCoordinator {
     return queued
   }
 
+  /// Targeted reconciliation that scans every cloud profile's
+  /// `instrument` table for non-fiat rows whose `encoded_system_fields`
+  /// is `NULL` and queues them for upload. Runs on every coordinator
+  /// start — *unconditionally*, not gated by the per-profile backfill
+  /// flag — because the bug it fixes (auto-inserted stock/crypto rows
+  /// that never reached CloudKit, see
+  /// `GRDBTransactionRepository+FKEnsure.ensureInstrumentReadable`)
+  /// produced state that the flag-gated `queueUnsyncedRecordsForAllProfiles`
+  /// has already skipped on every prior launch. The instrument table is
+  /// small (typically <100 rows) so the scan is cheap, and CKSyncEngine
+  /// dedupes against any row that's already in the pending list — so
+  /// running this alongside the regular hooks is idempotent.
+  ///
+  /// Returns the record IDs that were queued (empty if every profile
+  /// already had its non-fiat rows synced).
+  @discardableResult
+  func queueUnsyncedInstrumentsForAllProfiles() async -> [CKRecord.ID] {
+    var queued: [CKRecord.ID] = []
+    let allProfiles = await containerManager.allProfileIds()
+    for profileId in allProfiles {
+      let zoneID = CKRecordZone.ID(
+        zoneName: "profile-\(profileId.uuidString)",
+        ownerName: CKCurrentUserDefaultName)
+      guard let handler = try? handlerForProfileZone(profileId: profileId, zoneID: zoneID)
+      else {
+        logger.error(
+          "Failed to get handler for instrument backfill, profile \(profileId)")
+        continue
+      }
+      let recordIDs = handler.queueUnsyncedInstrumentRecords()
+      if !recordIDs.isEmpty {
+        syncEngine?.state.add(
+          pendingRecordZoneChanges: recordIDs.map { .saveRecord($0) })
+        refreshPendingUploadsMirror()
+        queued.append(contentsOf: recordIDs)
+      }
+    }
+    if !queued.isEmpty {
+      logger.info(
+        "Instrument-backfill scan queued \(queued.count) unsynced non-fiat instruments")
+    }
+    return queued
+  }
+
   func queueAllExistingRecordsForAllZones() async {
     // Queue profile-index records
     let indexRecordIDs = profileIndexHandler.queueAllExistingRecords()

--- a/Backends/CloudKit/Sync/SyncCoordinator+Lifecycle.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+Lifecycle.swift
@@ -188,6 +188,15 @@ extension SyncCoordinator {
       if shouldBackfillUnsynced {
         _ = await self.queueUnsyncedRecordsForAllProfiles()
       }
+      // Targeted instrument-only reconciliation. Runs unconditionally
+      // because the bug it fixes (auto-inserted stock/crypto rows that
+      // never reached CloudKit due to `ensureInstrumentReadable` not
+      // firing the sync hook) produces state that the flag-gated
+      // backfill above has already skipped on every prior launch.
+      // Idempotent: the instrument table is small and CKSyncEngine's
+      // pending list dedupes against rows already queued via the new
+      // hook plumbing.
+      _ = await self.queueUnsyncedInstrumentsForAllProfiles()
       if self.hasPendingChanges {
         self.logger.info("Zones ready — sending pending changes")
         await self.sendChanges()

--- a/Backends/GRDB/Repositories/GRDBAccountRepository+Create.swift
+++ b/Backends/GRDB/Repositories/GRDBAccountRepository+Create.swift
@@ -1,0 +1,114 @@
+// Backends/GRDB/Repositories/GRDBAccountRepository+Create.swift
+
+import Foundation
+import GRDB
+
+// `performAccountInsert` + `OpeningBalanceInserts` extracted from
+// `GRDBAccountRepository` so the main type body stays under SwiftLint's
+// `type_body_length` and `file_length` budgets after the
+// `onInstrumentChanged` hook plumbing widened the create flow.
+extension GRDBAccountRepository {
+  /// Captures the ids written by `create(_:openingBalance:)` so the
+  /// caller can fan out hook fires after the write transaction commits.
+  /// `instrumentId` is non-nil only when the account's instrument was
+  /// non-fiat AND no row existed for it in the registry — the create
+  /// path auto-inserted one and the caller must queue it for sync.
+  struct OpeningBalanceInserts: Sendable {
+    let transactionId: UUID?
+    let legId: UUID?
+    let instrumentId: String?
+  }
+
+  /// Single-statement body of `create(_:openingBalance:)`'s
+  /// `database.write { … }` block. Inserts the account row, and — when
+  /// the caller passes a non-zero opening balance — a one-leg
+  /// `TransactionRow` + `TransactionLegRow` to seed the account's
+  /// initial position. Returns the ids the caller fans out as hooks.
+  static func performAccountInsert(
+    database: Database,
+    account: Account,
+    openingBalance: InstrumentAmount?,
+    openingBalanceDate: Date
+  ) throws -> OpeningBalanceInserts {
+    let insertedInstrumentId = try ensureNonFiatInstrumentRow(
+      database: database, instrument: account.instrument)
+    let accountRow = AccountRow(domain: account)
+    try accountRow.insert(database)
+
+    // No opening balance — only the account row was inserted.
+    guard let openingBalance, !openingBalance.isZero else {
+      return OpeningBalanceInserts(
+        transactionId: nil, legId: nil, instrumentId: insertedInstrumentId)
+    }
+
+    let txnId = UUID()
+    try makeOpeningBalanceTxnRow(id: txnId, date: openingBalanceDate).insert(database)
+    let legId = UUID()
+    try makeOpeningBalanceLegRow(
+      id: legId, transactionId: txnId, account: account, openingBalance: openingBalance
+    ).insert(database)
+    return OpeningBalanceInserts(
+      transactionId: txnId, legId: legId, instrumentId: insertedInstrumentId)
+  }
+
+  /// Inserts the placeholder `instrument` row for stocks / crypto if it
+  /// isn't already present. Fiat is ambient — synthesised from
+  /// `Locale.Currency.isoCurrencies` in `fetchInstrumentMap`. Returns
+  /// the inserted instrument id (or `nil` for fiat / pre-existing rows)
+  /// so the caller's hook fan-out can queue the row for CloudKit upload
+  /// — without that, the row stays local-only and sibling devices fall
+  /// back to `Instrument.fiat(code: id)` for a stock (see
+  /// `InstrumentLocalSyncQueueTests`).
+  private static func ensureNonFiatInstrumentRow(
+    database: Database, instrument: Instrument
+  ) throws -> String? {
+    guard instrument.kind != .fiatCurrency else { return nil }
+    let exists =
+      try InstrumentRow
+      .filter(InstrumentRow.Columns.id == instrument.id)
+      .fetchOne(database)
+    guard exists == nil else { return nil }
+    try InstrumentRow(domain: instrument).insert(database)
+    return instrument.id
+  }
+
+  private static func makeOpeningBalanceTxnRow(id: UUID, date: Date) -> TransactionRow {
+    TransactionRow(
+      id: id,
+      recordName: TransactionRow.recordName(for: id),
+      date: date,
+      payee: nil,
+      notes: nil,
+      recurPeriod: nil,
+      recurEvery: nil,
+      importOriginRawDescription: nil,
+      importOriginBankReference: nil,
+      importOriginRawAmount: nil,
+      importOriginRawBalance: nil,
+      importOriginImportedAt: nil,
+      importOriginImportSessionId: nil,
+      importOriginSourceFilename: nil,
+      importOriginParserIdentifier: nil,
+      encodedSystemFields: nil)
+  }
+
+  private static func makeOpeningBalanceLegRow(
+    id: UUID,
+    transactionId: UUID,
+    account: Account,
+    openingBalance: InstrumentAmount
+  ) -> TransactionLegRow {
+    TransactionLegRow(
+      id: id,
+      recordName: TransactionLegRow.recordName(for: id),
+      transactionId: transactionId,
+      accountId: account.id,
+      instrumentId: account.instrument.id,
+      quantity: openingBalance.storageValue,
+      type: TransactionType.openingBalance.rawValue,
+      categoryId: nil,
+      earmarkId: nil,
+      sortOrder: 0,
+      encodedSystemFields: nil)
+  }
+}

--- a/Backends/GRDB/Repositories/GRDBAccountRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBAccountRepository.swift
@@ -41,6 +41,14 @@ final class GRDBAccountRepository: AccountRepository, @unchecked Sendable {
   /// see `RepositoryHookRecordTypeTests`.
   private let onRecordChanged: @Sendable (String, UUID) -> Void
   private let onRecordDeleted: @Sendable (String, UUID) -> Void
+  /// Receives the `Instrument.id` (which doubles as the InstrumentRow's
+  /// CloudKit recordName) of any non-fiat instrument that
+  /// `performAccountInsert` had to auto-insert into the registry to
+  /// satisfy a stock / crypto account's denomination. Without this hook
+  /// the auto-inserted row never reaches CloudKit and sibling devices
+  /// fall back to `Instrument.fiat(code: id)` — see
+  /// `InstrumentLocalSyncQueueTests`.
+  private let onInstrumentChanged: @Sendable (String) -> Void
   /// Single shared error channel for every `observeAll()` subscription
   /// returned by this repo instance. The bridge in
   /// `Backends/GRDB/Observation/AsyncValueObservation+AsyncStream.swift`
@@ -53,11 +61,13 @@ final class GRDBAccountRepository: AccountRepository, @unchecked Sendable {
   init(
     database: any DatabaseWriter,
     onRecordChanged: @escaping @Sendable (String, UUID) -> Void = { _, _ in },
-    onRecordDeleted: @escaping @Sendable (String, UUID) -> Void = { _, _ in }
+    onRecordDeleted: @escaping @Sendable (String, UUID) -> Void = { _, _ in },
+    onInstrumentChanged: @escaping @Sendable (String) -> Void = { _ in }
   ) {
     self.database = database
     self.onRecordChanged = onRecordChanged
     self.onRecordDeleted = onRecordDeleted
+    self.onInstrumentChanged = onInstrumentChanged
   }
 
   // MARK: - AccountRepository conformance
@@ -106,81 +116,15 @@ final class GRDBAccountRepository: AccountRepository, @unchecked Sendable {
     if let legId = inserts.legId {
       onRecordChanged(TransactionLegRow.recordType, legId)
     }
+    if let instrumentId = inserts.instrumentId {
+      onInstrumentChanged(instrumentId)
+    }
     return account
   }
 
-  /// Single-statement body of `create(_:openingBalance:)`'s
-  /// `database.write { … }` block. Inserts the account row, and — when
-  /// the caller passes a non-zero opening balance — a one-leg
-  /// `TransactionRow` + `TransactionLegRow` to seed the account's
-  /// initial position. Returns the ids the caller fans out as hooks.
-  private static func performAccountInsert(
-    database: Database,
-    account: Account,
-    openingBalance: InstrumentAmount?,
-    openingBalanceDate: Date
-  ) throws -> OpeningBalanceInserts {
-    // Non-fiat instruments (stocks, crypto) must have a row in the
-    // `instrument` table so `fetchAll` can resolve the full
-    // `Instrument` value (kind, ticker, exchange, chainId, decimals).
-    // Fiat is ambient — synthesised from `Locale.Currency.isoCurrencies`
-    // by `fetchInstrumentMap`. Mirrors the SwiftData-era
-    // `CloudKitAccountRepository.ensureInstrument`.
-    if account.instrument.kind != .fiatCurrency {
-      let exists =
-        try InstrumentRow
-        .filter(InstrumentRow.Columns.id == account.instrument.id)
-        .fetchOne(database)
-      if exists == nil {
-        try InstrumentRow(domain: account.instrument).insert(database)
-      }
-    }
-
-    let accountRow = AccountRow(domain: account)
-    try accountRow.insert(database)
-
-    // No opening balance — only the account row was inserted.
-    guard let openingBalance, !openingBalance.isZero else {
-      return OpeningBalanceInserts(transactionId: nil, legId: nil)
-    }
-
-    let txnId = UUID()
-    let txnRow = TransactionRow(
-      id: txnId,
-      recordName: TransactionRow.recordName(for: txnId),
-      date: openingBalanceDate,
-      payee: nil,
-      notes: nil,
-      recurPeriod: nil,
-      recurEvery: nil,
-      importOriginRawDescription: nil,
-      importOriginBankReference: nil,
-      importOriginRawAmount: nil,
-      importOriginRawBalance: nil,
-      importOriginImportedAt: nil,
-      importOriginImportSessionId: nil,
-      importOriginSourceFilename: nil,
-      importOriginParserIdentifier: nil,
-      encodedSystemFields: nil)
-    try txnRow.insert(database)
-
-    let legId = UUID()
-    let legRow = TransactionLegRow(
-      id: legId,
-      recordName: TransactionLegRow.recordName(for: legId),
-      transactionId: txnId,
-      accountId: account.id,
-      instrumentId: account.instrument.id,
-      quantity: openingBalance.storageValue,
-      type: TransactionType.openingBalance.rawValue,
-      categoryId: nil,
-      earmarkId: nil,
-      sortOrder: 0,
-      encodedSystemFields: nil)
-    try legRow.insert(database)
-
-    return OpeningBalanceInserts(transactionId: txnId, legId: legId)
-  }
+  // `performAccountInsert` and `OpeningBalanceInserts` live in
+  // `GRDBAccountRepository+Create.swift` to keep this file under
+  // SwiftLint's `type_body_length` and `file_length` budgets.
 
   func update(_ account: Account) async throws -> Account {
     guard !account.name.trimmingCharacters(in: .whitespaces).isEmpty else {
@@ -273,15 +217,6 @@ final class GRDBAccountRepository: AccountRepository, @unchecked Sendable {
       try existing.update(database)
     }
     onRecordChanged(AccountRow.recordType, id)
-  }
-
-  // MARK: - Helpers
-
-  /// Captures the ids written by `create(_:openingBalance:)` so the
-  /// caller can fan out hook fires after the write transaction commits.
-  private struct OpeningBalanceInserts {
-    let transactionId: UUID?
-    let legId: UUID?
   }
 
   // MARK: - Sync entry points (synchronous, GRDB-queue-blocking)

--- a/Backends/GRDB/Repositories/GRDBInstrumentRegistryRepository+Lookup.swift
+++ b/Backends/GRDB/Repositories/GRDBInstrumentRegistryRepository+Lookup.swift
@@ -24,6 +24,27 @@ extension GRDBInstrumentRegistryRepository {
     }
   }
 
+  /// Returns IDs of non-fiat rows (stocks, crypto tokens) whose
+  /// `encoded_system_fields` is `NULL`. Used by the per-startup
+  /// targeted reconciliation in `SyncCoordinator+Backfill` (which runs
+  /// unconditionally — *not* gated by the per-profile backfill flag) so
+  /// rows inserted by a build that predated the `onInstrumentChanged`
+  /// plumbing eventually reach CloudKit. Fiat is filtered out because
+  /// synthetic fiat rows shouldn't normally be persisted — they're
+  /// synthesised at read time via `Locale.Currency.isoCurrencies` —
+  /// and a stale one slipping into the table must not be uploaded as
+  /// if user-registered.
+  func unsyncedNonFiatRowIdsSync() throws -> [String] {
+    let fiatKind = Instrument.Kind.fiatCurrency.rawValue
+    return try database.read { database in
+      try InstrumentRow
+        .filter(InstrumentRow.Columns.encodedSystemFields == nil)
+        .filter(InstrumentRow.Columns.kind != fiatKind)
+        .select(InstrumentRow.Columns.id, as: String.self)
+        .fetchAll(database)
+    }
+  }
+
   /// Projects an `InstrumentRow` to a `CryptoRegistration`, applying the
   /// inbox / spam visibility rules:
   ///

--- a/Backends/GRDB/Repositories/GRDBInstrumentRegistryRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBInstrumentRegistryRepository.swift
@@ -350,6 +350,10 @@ final class GRDBInstrumentRegistryRepository:
     }
   }
 
+  // `unsyncedNonFiatRowIdsSync` lives in
+  // `GRDBInstrumentRegistryRepository+Lookup.swift` to keep this file
+  // under SwiftLint's `type_body_length` and `file_length` budgets.
+
   /// Returns IDs of every row in the table.
   func allRowIdsSync() throws -> [String] {
     try database.read { database in

--- a/Backends/GRDB/Repositories/GRDBTransactionRepository+FKEnsure.swift
+++ b/Backends/GRDB/Repositories/GRDBTransactionRepository+FKEnsure.swift
@@ -20,19 +20,30 @@ import GRDB
 // `ProfileSchema+DropForeignKeys.swift`.
 extension GRDBTransactionRepository {
   /// Inserts a placeholder `instrument` row for any non-fiat
-  /// instrument a leg references that isn't already present. Required
-  /// so `fetchAll` can resolve the full `Instrument` domain value on
-  /// read.
+  /// instrument a leg references that isn't already present. Returns
+  /// the instrument id when an insert actually happened so the caller
+  /// can fan out the sync hook AFTER the surrounding write commits;
+  /// returns `nil` for fiat legs and for legs whose instrument was
+  /// already in the registry.
+  ///
+  /// Required so `fetchAll` can resolve the full `Instrument` domain
+  /// value on read AND so the new row reaches CloudKit — without the
+  /// hook fan-out the row would live only on the device that created
+  /// it. Sibling devices would receive the leg but no `InstrumentRow`,
+  /// `fetchInstrumentMap` would fall back to
+  /// `Instrument.fiat(code: id)`, and stock conversions would route
+  /// through the fiat-only Frankfurter API and 404.
   static func ensureInstrumentReadable(
     database: Database,
     leg: TransactionLeg
-  ) throws {
-    guard leg.instrument.kind != .fiatCurrency else { return }
+  ) throws -> String? {
+    guard leg.instrument.kind != .fiatCurrency else { return nil }
     let exists =
       try InstrumentRow
       .filter(InstrumentRow.Columns.id == leg.instrument.id)
       .fetchOne(database)
-    guard exists == nil else { return }
+    guard exists == nil else { return nil }
     try InstrumentRow(domain: leg.instrument).insert(database)
+    return leg.instrument.id
   }
 }

--- a/Backends/GRDB/Repositories/GRDBTransactionRepository+Update.swift
+++ b/Backends/GRDB/Repositories/GRDBTransactionRepository+Update.swift
@@ -9,6 +9,11 @@ extension GRDBTransactionRepository {
   struct UpdateOutcome: Sendable {
     let deletedLegIds: [UUID]
     let upsertedLegIds: [UUID]
+    /// Non-fiat instrument ids `ensureInstrumentReadable` auto-inserted
+    /// while upserting legs — the caller fans these out via
+    /// `onInstrumentChanged` after the write commits so each new
+    /// `InstrumentRow` reaches CloudKit.
+    let insertedInstrumentIds: [String]
   }
 
   private struct LegDiff: Sendable {
@@ -91,8 +96,15 @@ extension GRDBTransactionRepository {
     // debugger snapshot.
     var upsertedLegIds: [UUID] = []
     upsertedLegIds.reserveCapacity(transaction.legs.count)
+    var insertedInstrumentIds: [String] = []
+    var seenInstrumentIds: Set<String> = []
     for (index, leg) in transaction.legs.enumerated() {
-      try Self.ensureInstrumentReadable(database: database, leg: leg)
+      if let inserted = try Self.ensureInstrumentReadable(
+        database: database, leg: leg),
+        seenInstrumentIds.insert(inserted).inserted
+      {
+        insertedInstrumentIds.append(inserted)
+      }
       var legRow = TransactionLegRow(
         id: leg.id,
         domain: leg,
@@ -110,7 +122,8 @@ extension GRDBTransactionRepository {
 
     return UpdateOutcome(
       deletedLegIds: diff.deletedIds,
-      upsertedLegIds: upsertedLegIds)
+      upsertedLegIds: upsertedLegIds,
+      insertedInstrumentIds: insertedInstrumentIds)
   }
 
   /// Mirrors `CloudKitTransactionRepository.applyMetadata`. Copies the

--- a/Backends/GRDB/Repositories/GRDBTransactionRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBTransactionRepository.swift
@@ -71,6 +71,14 @@ final class GRDBTransactionRepository: TransactionRepository, @unchecked Sendabl
   /// `RepositoryHookRecordTypeTests`.
   private let onRecordChanged: @Sendable (String, UUID) -> Void
   private let onRecordDeleted: @Sendable (String, UUID) -> Void
+  /// Receives the `Instrument.id` (which doubles as the InstrumentRow's
+  /// CloudKit recordName) of any non-fiat instrument that
+  /// `ensureInstrumentReadable` had to auto-insert into the registry to
+  /// satisfy a leg referenced by `create` / `update`. Without this hook
+  /// the auto-inserted row never reaches CloudKit and sibling devices
+  /// fall back to `Instrument.fiat(code: id)` — see
+  /// `InstrumentLocalSyncQueueTests`.
+  private let onInstrumentChanged: @Sendable (String) -> Void
 
   private let logger = Logger(
     subsystem: "com.moolah.app", category: "GRDBTransactionRepository")
@@ -80,13 +88,15 @@ final class GRDBTransactionRepository: TransactionRepository, @unchecked Sendabl
     defaultInstrument: Instrument,
     conversionService: any InstrumentConversionService,
     onRecordChanged: @escaping @Sendable (String, UUID) -> Void = { _, _ in },
-    onRecordDeleted: @escaping @Sendable (String, UUID) -> Void = { _, _ in }
+    onRecordDeleted: @escaping @Sendable (String, UUID) -> Void = { _, _ in },
+    onInstrumentChanged: @escaping @Sendable (String) -> Void = { _ in }
   ) {
     self.database = database
     self.defaultInstrument = defaultInstrument
     self.conversionService = conversionService
     self.onRecordChanged = onRecordChanged
     self.onRecordDeleted = onRecordDeleted
+    self.onInstrumentChanged = onInstrumentChanged
   }
 
   // MARK: - TransactionRepository conformance
@@ -126,20 +136,28 @@ final class GRDBTransactionRepository: TransactionRepository, @unchecked Sendabl
   }
 
   func create(_ transaction: Transaction) async throws -> Transaction {
-    let insertedLegIds = try await database.write { database -> [UUID] in
+    let result = try await database.write { database -> CreateOutcome in
       let txnRow = TransactionRow(domain: transaction)
       try txnRow.insert(database)
 
       var legIds: [UUID] = []
       legIds.reserveCapacity(transaction.legs.count)
+      // De-dup so two legs sharing one new instrument fire the hook
+      // exactly once. Order-preserving — the first occurrence wins so
+      // the hook order is stable for tests.
+      var insertedInstrumentIds: [String] = []
+      var seenInstrumentIds: Set<String> = []
       for (index, leg) in transaction.legs.enumerated() {
         // Ensure non-fiat instrument rows exist so `fetchAll` can resolve
         // the full `Instrument` value on read. After v5 dropped FKs, a leg
         // referencing an account/category/earmark that hasn't arrived yet
         // is allowed to land as-is — see `+FKEnsure.swift` and SYNC_GUIDE.
-        try Self.ensureInstrumentReadable(
-          database: database,
-          leg: leg)
+        if let inserted = try Self.ensureInstrumentReadable(
+          database: database, leg: leg),
+          seenInstrumentIds.insert(inserted).inserted
+        {
+          insertedInstrumentIds.append(inserted)
+        }
         let legRow = TransactionLegRow(
           id: leg.id,
           domain: leg,
@@ -148,14 +166,27 @@ final class GRDBTransactionRepository: TransactionRepository, @unchecked Sendabl
         try legRow.insert(database)
         legIds.append(leg.id)
       }
-      return legIds
+      return CreateOutcome(legIds: legIds, instrumentIds: insertedInstrumentIds)
     }
 
     onRecordChanged(TransactionRow.recordType, transaction.id)
-    for legId in insertedLegIds {
+    for legId in result.legIds {
       onRecordChanged(TransactionLegRow.recordType, legId)
     }
+    for instrumentId in result.instrumentIds {
+      onInstrumentChanged(instrumentId)
+    }
     return transaction
+  }
+
+  /// Bundle returned by `create`'s write block: the legs that were
+  /// inserted (for the per-leg sync hook) and the instrument ids that
+  /// the leg-level `ensureInstrumentReadable` had to auto-insert (for
+  /// the new instrument-side sync hook). Replaces a tuple to satisfy
+  /// SwiftLint's `large_tuple` policy.
+  private struct CreateOutcome: Sendable {
+    let legIds: [UUID]
+    let instrumentIds: [String]
   }
 
   func update(_ transaction: Transaction) async throws -> Transaction {
@@ -171,6 +202,9 @@ final class GRDBTransactionRepository: TransactionRepository, @unchecked Sendabl
     }
     for legId in outcome.deletedLegIds {
       onRecordDeleted(TransactionLegRow.recordType, legId)
+    }
+    for instrumentId in outcome.insertedInstrumentIds {
+      onInstrumentChanged(instrumentId)
     }
     return transaction
   }

--- a/MoolahTests/Sync/InstrumentLocalSyncQueueTests.swift
+++ b/MoolahTests/Sync/InstrumentLocalSyncQueueTests.swift
@@ -1,0 +1,297 @@
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+/// Pins the contract that local mutations which auto-insert non-fiat
+/// `InstrumentRow`s into the `instrument` table also queue those records
+/// for CloudKit upload. Without this, instruments created by paths that
+/// don't go through `InstrumentRegistryRepository.registerStock /
+/// registerCrypto` (e.g. SelfWealth CSV import or any
+/// `transactionRepository.create` whose leg references a not-yet-known
+/// stock) live only on the device that created them — sibling devices
+/// see the legs but no `InstrumentRow`, fall back to
+/// `Instrument.fiat(code: id)` in `fetchInstrumentMap`, and route stock
+/// conversions through Frankfurter, which 404s.
+@Suite("Local mutations queue auto-inserted instruments for sync")
+@MainActor
+struct InstrumentLocalSyncQueueTests {
+
+  // MARK: - Capture helpers
+
+  /// Confined to `@MainActor` so the (non-Sendable) closures wired to
+  /// the repository can append into the buffer without crossing actors.
+  @MainActor
+  final class Capture {
+    var instrumentIds: [String] = []
+  }
+
+  private func makeInstrumentChangedHook(
+    _ capture: Capture
+  ) -> @Sendable (String) -> Void {
+    { instrumentId in
+      Task { @MainActor in
+        capture.instrumentIds.append(instrumentId)
+      }
+    }
+  }
+
+  /// Drains queued main-actor hops so callers can read the capture state
+  /// after a repository write completes. Mirrors
+  /// `RepositoryHookRecordTypeTests.drainHookHops`.
+  private func drainHookHops() async throws {
+    try await Task.sleep(for: .milliseconds(50))
+  }
+
+  private func makeStockInstrument(ticker: String) -> Instrument {
+    Instrument.stock(ticker: "\(ticker).AX", exchange: "ASX", name: ticker)
+  }
+
+  private func makeStockLeg(
+    instrument: Instrument,
+    accountId: UUID,
+    quantity: Decimal = 100
+  ) -> TransactionLeg {
+    TransactionLeg(
+      accountId: accountId,
+      instrument: instrument,
+      quantity: quantity,
+      type: .trade,
+      categoryId: nil,
+      earmarkId: nil)
+  }
+
+  // MARK: - GRDBTransactionRepository.create
+
+  @Test("create fires onInstrumentChanged once for a new non-fiat leg instrument")
+  func createFiresHookForNewStockLeg() async throws {
+    let database = try ProfileDatabase.openInMemory()
+    let capture = Capture()
+    let repo = GRDBTransactionRepository(
+      database: database,
+      defaultInstrument: .defaultTestInstrument,
+      conversionService: FixedConversionService(),
+      onInstrumentChanged: makeInstrumentChangedHook(capture))
+
+    let stock = makeStockInstrument(ticker: "IFRA")
+    let txn = Transaction(
+      date: Date(), payee: "Buy IFRA",
+      legs: [makeStockLeg(instrument: stock, accountId: UUID())])
+
+    _ = try await repo.create(txn)
+    try await drainHookHops()
+
+    #expect(capture.instrumentIds == [stock.id])
+  }
+
+  @Test("create does not fire onInstrumentChanged for fiat legs")
+  func createDoesNotFireHookForFiatLeg() async throws {
+    let database = try ProfileDatabase.openInMemory()
+    let capture = Capture()
+    let repo = GRDBTransactionRepository(
+      database: database,
+      defaultInstrument: .defaultTestInstrument,
+      conversionService: FixedConversionService(),
+      onInstrumentChanged: makeInstrumentChangedHook(capture))
+
+    let txn = Transaction(
+      date: Date(), payee: "Coffee",
+      legs: [
+        makeContractTestLeg(accountId: UUID(), quantity: -5, type: .expense)
+      ])
+
+    _ = try await repo.create(txn)
+    try await drainHookHops()
+
+    #expect(capture.instrumentIds.isEmpty)
+  }
+
+  @Test("create does not fire onInstrumentChanged when the instrument row already exists")
+  func createDoesNotFireHookWhenInstrumentAlreadyRegistered() async throws {
+    let database = try ProfileDatabase.openInMemory()
+    let stock = makeStockInstrument(ticker: "VAS")
+    try await database.write { database in
+      try InstrumentRow(domain: stock).insert(database)
+    }
+    let capture = Capture()
+    let repo = GRDBTransactionRepository(
+      database: database,
+      defaultInstrument: .defaultTestInstrument,
+      conversionService: FixedConversionService(),
+      onInstrumentChanged: makeInstrumentChangedHook(capture))
+
+    let txn = Transaction(
+      date: Date(), payee: "Buy VAS",
+      legs: [makeStockLeg(instrument: stock, accountId: UUID())])
+
+    _ = try await repo.create(txn)
+    try await drainHookHops()
+
+    #expect(capture.instrumentIds.isEmpty)
+  }
+
+  @Test("create dedupes the hook for two legs sharing one new instrument")
+  func createDedupesHookForRepeatedInstrument() async throws {
+    let database = try ProfileDatabase.openInMemory()
+    let capture = Capture()
+    let repo = GRDBTransactionRepository(
+      database: database,
+      defaultInstrument: .defaultTestInstrument,
+      conversionService: FixedConversionService(),
+      onInstrumentChanged: makeInstrumentChangedHook(capture))
+
+    let stock = makeStockInstrument(ticker: "VGS")
+    let accountId = UUID()
+    // Two legs on the same stock — only the first insert actually
+    // writes the InstrumentRow; the hook should fire once, not twice.
+    let txn = Transaction(
+      date: Date(), payee: "Trade",
+      legs: [
+        makeStockLeg(instrument: stock, accountId: accountId, quantity: 10),
+        makeStockLeg(instrument: stock, accountId: accountId, quantity: -5),
+      ])
+
+    _ = try await repo.create(txn)
+    try await drainHookHops()
+
+    #expect(capture.instrumentIds == [stock.id])
+  }
+
+  // MARK: - GRDBTransactionRepository.update
+
+  @Test("update fires onInstrumentChanged for a new non-fiat instrument added to a leg")
+  func updateFiresHookForNewlyAddedStockLeg() async throws {
+    let database = try ProfileDatabase.openInMemory()
+    let capture = Capture()
+    let repo = GRDBTransactionRepository(
+      database: database,
+      defaultInstrument: .defaultTestInstrument,
+      conversionService: FixedConversionService(),
+      onInstrumentChanged: makeInstrumentChangedHook(capture))
+
+    // Seed a fiat-only transaction first.
+    let accountId = UUID()
+    let original = Transaction(
+      date: Date(), payee: "Setup",
+      legs: [
+        makeContractTestLeg(accountId: accountId, quantity: -100, type: .expense)
+      ])
+    _ = try await repo.create(original)
+    try await drainHookHops()
+    capture.instrumentIds.removeAll()
+
+    // Replace with a stock leg, which should auto-insert the InstrumentRow
+    // and fire the hook.
+    let stock = makeStockInstrument(ticker: "IOZ")
+    let updated = Transaction(
+      id: original.id,
+      date: original.date, payee: "Buy IOZ",
+      legs: [makeStockLeg(instrument: stock, accountId: accountId)])
+    _ = try await repo.update(updated)
+    try await drainHookHops()
+
+    #expect(capture.instrumentIds == [stock.id])
+  }
+
+  // MARK: - GRDBAccountRepository.create
+
+  @Test("account create fires onInstrumentChanged for a new non-fiat account instrument")
+  func accountCreateFiresHookForNewStockAccountInstrument() async throws {
+    let database = try ProfileDatabase.openInMemory()
+    let capture = Capture()
+    let repo = GRDBAccountRepository(
+      database: database,
+      onInstrumentChanged: makeInstrumentChangedHook(capture))
+
+    let stock = makeStockInstrument(ticker: "VAP")
+    let account = Account(name: "VAP Holdings", type: .investment, instrument: stock)
+
+    _ = try await repo.create(account)
+    try await drainHookHops()
+
+    #expect(capture.instrumentIds == [stock.id])
+  }
+
+  @Test("account create does not fire onInstrumentChanged for fiat accounts")
+  func accountCreateDoesNotFireHookForFiatAccount() async throws {
+    let database = try ProfileDatabase.openInMemory()
+    let capture = Capture()
+    let repo = GRDBAccountRepository(
+      database: database,
+      onInstrumentChanged: makeInstrumentChangedHook(capture))
+
+    let account = Account(name: "Cash", type: .bank, instrument: .defaultTestInstrument)
+    _ = try await repo.create(account)
+    try await drainHookHops()
+
+    #expect(capture.instrumentIds.isEmpty)
+  }
+
+  @Test("account create does not fire onInstrumentChanged when the row already exists")
+  func accountCreateDoesNotFireHookWhenInstrumentAlreadyRegistered() async throws {
+    let database = try ProfileDatabase.openInMemory()
+    let stock = makeStockInstrument(ticker: "VGS")
+    try await database.write { database in
+      try InstrumentRow(domain: stock).insert(database)
+    }
+    let capture = Capture()
+    let repo = GRDBAccountRepository(
+      database: database,
+      onInstrumentChanged: makeInstrumentChangedHook(capture))
+
+    let account = Account(name: "VGS Holdings", type: .investment, instrument: stock)
+    _ = try await repo.create(account)
+    try await drainHookHops()
+
+    #expect(capture.instrumentIds.isEmpty)
+  }
+
+  // MARK: - Reconciliation: existing unsynced non-fiat rows
+
+  @Test("unsyncedNonFiatRowIdsSync returns non-fiat rows with null encoded_system_fields")
+  func unsyncedNonFiatRowIdsSyncReturnsUnsyncedStocks() async throws {
+    let database = try ProfileDatabase.openInMemory()
+    let stock = Instrument.stock(ticker: "IFRA.AX", exchange: "ASX", name: "IFRA")
+    try await database.write { database in
+      try InstrumentRow(domain: stock).insert(database)
+    }
+    let registry = GRDBInstrumentRegistryRepository(database: database)
+
+    let ids = try registry.unsyncedNonFiatRowIdsSync()
+
+    #expect(ids == [stock.id])
+  }
+
+  @Test("unsyncedNonFiatRowIdsSync excludes rows whose encoded_system_fields is non-null")
+  func unsyncedNonFiatRowIdsSyncExcludesSyncedRows() async throws {
+    let database = try ProfileDatabase.openInMemory()
+    let stock = Instrument.stock(ticker: "IOZ.AX", exchange: "ASX", name: "IOZ")
+    try await database.write { database in
+      var row = InstrumentRow(domain: stock)
+      row.encodedSystemFields = Data(count: 4)  // sentinel: anything non-nil
+      try row.insert(database)
+    }
+    let registry = GRDBInstrumentRegistryRepository(database: database)
+
+    let ids = try registry.unsyncedNonFiatRowIdsSync()
+
+    #expect(ids.isEmpty)
+  }
+
+  @Test("unsyncedNonFiatRowIdsSync excludes fiat rows even when unsynced")
+  func unsyncedNonFiatRowIdsSyncExcludesFiat() async throws {
+    let database = try ProfileDatabase.openInMemory()
+    // Synthetic fiat rows aren't normally written, but the migration
+    // boundary means a stale row might exist; the helper must filter
+    // them out so the reconciliation pass doesn't try to upload AUD.
+    try await database.write { database in
+      try InstrumentRow(domain: .AUD).insert(database)
+    }
+    let registry = GRDBInstrumentRegistryRepository(database: database)
+
+    let ids = try registry.unsyncedNonFiatRowIdsSync()
+
+    #expect(ids.isEmpty)
+  }
+}


### PR DESCRIPTION
## Summary

- Stock investment accounts on sibling devices showed a spinner forever — `convertedBalances[id]` never set, `loadAndBuildPositionsInput` walking ~90 days × N tickers of failed conversions. Caused by `ensureInstrumentReadable` / `performAccountInsert` inserting placeholder `InstrumentRow`s without firing a sync hook, so they lived only on the device that wrote them. Sibling devices fell back to `Instrument.fiat(code: "ASX:IFRA.AX")` and routed conversions through Frankfurter, which 404s.
- Adds a string-keyed `onInstrumentChanged` hook to `GRDBTransactionRepository` and `GRDBAccountRepository`, plumbed through `CloudKitBackendHooks` and wired in `ProfileSession+CloudKitBackendBuild` to the same recordName-keyed `queueSave` path `GRDBInstrumentRegistryRepository.registerStock` already uses. Hook dedupes per-instrument inside a single `create` / `update` and fires after the write commits.
- Targeted backfill `queueUnsyncedInstrumentsForAllProfiles` runs unconditionally on every coordinator start so existing un-synced rows on already-affected devices reach CloudKit. Idempotent: CKSyncEngine's pending list dedupes against rows queued by the new hook.

## Test plan

- [x] `just format-check` — clean.
- [x] `just test` — full mac+iOS suite passes (2609 tests). New `InstrumentLocalSyncQueueTests` suite passes on both targets.
  - txn create fires `onInstrumentChanged` for new non-fiat legs; doesn't fire for fiat or already-registered stocks; dedupes when two legs share one new instrument.
  - txn update fires when a stock leg is added to a previously fiat-only transaction.
  - Account create fires for new non-fiat denominations; doesn't fire for fiat or already-registered stocks.
  - `unsyncedNonFiatRowIdsSync` returns unsynced non-fiat rows, excludes synced rows (non-nil `encoded_system_fields`) and fiat rows.
- [ ] Smoke check: open `Real Profile` on Mac, verify the four ASX rows (`ASX:IFRA.AX` / `ASX:IOZ.AX` / `ASX:VAP.AX` / `ASX:VGS.AX`) get system-fields stamped after the next sync cycle.
- [ ] Smoke check: re-open the profile on iPhone, verify Trust Shares balance and positions load (no Frankfurter 404s for those tickers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)