### PR TITLE
feat(network): rate-limit gate for price-fetching clients

### DIFF
--- a/Backends/Binance/BinanceClient.swift
+++ b/Backends/Binance/BinanceClient.swift
@@ -7,13 +7,16 @@ struct BinanceClient: CryptoPriceClient, Sendable {
     URL(string: baseURLString) ?? URL(fileURLWithPath: "/")
   private let session: URLSession
   private let usdtRateLookup: @Sendable (Date) async -> Decimal
+  private let rateLimitGate: RateLimitGate
 
   init(
     session: URLSession = .shared,
-    usdtRateLookup: @escaping @Sendable (Date) async -> Decimal = { _ in Decimal(1) }
+    usdtRateLookup: @escaping @Sendable (Date) async -> Decimal = { _ in Decimal(1) },
+    rateLimitGate: RateLimitGate = RateLimitGate()
   ) {
     self.session = session
     self.usdtRateLookup = usdtRateLookup
+    self.rateLimitGate = rateLimitGate
   }
 
   func dailyPrice(for mapping: CryptoProviderMapping, on date: Date) async throws -> Decimal {
@@ -42,7 +45,8 @@ struct BinanceClient: CryptoPriceClient, Sendable {
         calendar.date(byAdding: .day, value: 999, to: chunkStart) ?? range.upperBound
       let chunkEnd = min(candleWindowEnd, range.upperBound)
       let url = Self.klinesURL(symbol: symbol, from: chunkStart, to: chunkEnd)
-      let (data, response) = try await session.data(for: URLRequest(url: url))
+      let (data, response) = try await session.dataRespectingRateLimit(
+        for: URLRequest(url: url), gate: rateLimitGate)
       guard let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) else {
         throw URLError(.badServerResponse)
       }

--- a/Backends/CoinGecko/CoinGeckoClient.swift
+++ b/Backends/CoinGecko/CoinGeckoClient.swift
@@ -14,10 +14,16 @@ struct CoinGeckoClient: CryptoPriceClient, Sendable {
     URL(string: "https://api.coingecko.com/api/v3") ?? URL(fileURLWithPath: "/")
   private let session: URLSession
   private let apiKey: String
+  private let rateLimitGate: RateLimitGate
 
-  init(session: URLSession = .shared, apiKey: String) {
+  init(
+    session: URLSession = .shared,
+    apiKey: String,
+    rateLimitGate: RateLimitGate = RateLimitGate()
+  ) {
     self.session = session
     self.apiKey = apiKey
+    self.rateLimitGate = rateLimitGate
   }
 
   /// Resolves the base URL by key presence: non-empty → Pro host,
@@ -54,7 +60,8 @@ struct CoinGeckoClient: CryptoPriceClient, Sendable {
       calendar.dateComponents([.day], from: range.lowerBound, to: range.upperBound).day ?? 1
     )
     let url = Self.marketChartURL(coinId: coinId, days: days, apiKey: apiKey)
-    let (data, response) = try await session.data(for: URLRequest(url: url))
+    let (data, response) = try await session.dataRespectingRateLimit(
+      for: URLRequest(url: url), gate: rateLimitGate)
     guard let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) else {
       throw URLError(.badServerResponse)
     }
@@ -72,7 +79,8 @@ struct CoinGeckoClient: CryptoPriceClient, Sendable {
     guard !idToMapping.isEmpty else { return [:] }
 
     let url = Self.simplePriceURL(coinIds: Array(idToMapping.keys), apiKey: apiKey)
-    let (data, response) = try await session.data(for: URLRequest(url: url))
+    let (data, response) = try await session.dataRespectingRateLimit(
+      for: URLRequest(url: url), gate: rateLimitGate)
     guard let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) else {
       throw URLError(.badServerResponse)
     }

--- a/Backends/CryptoCompare/CryptoCompareClient.swift
+++ b/Backends/CryptoCompare/CryptoCompareClient.swift
@@ -5,9 +5,11 @@ struct CryptoCompareClient: CryptoPriceClient, Sendable {
   private static let baseURL =
     URL(string: "https://min-api.cryptocompare.com") ?? URL(fileURLWithPath: "/")
   private let session: URLSession
+  private let rateLimitGate: RateLimitGate
 
-  init(session: URLSession = .shared) {
+  init(session: URLSession = .shared, rateLimitGate: RateLimitGate = RateLimitGate()) {
     self.session = session
+    self.rateLimitGate = rateLimitGate
   }
 
   func dailyPrice(for mapping: CryptoProviderMapping, on date: Date) async throws -> Decimal {
@@ -27,7 +29,8 @@ struct CryptoCompareClient: CryptoPriceClient, Sendable {
         tokenId: mapping.instrumentId, provider: "CryptoCompare")
     }
     let url = Self.histodayURL(symbol: symbol, from: range.lowerBound, to: range.upperBound)
-    let (data, response) = try await session.data(for: URLRequest(url: url))
+    let (data, response) = try await session.dataRespectingRateLimit(
+      for: URLRequest(url: url), gate: rateLimitGate)
     guard let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) else {
       throw URLError(.badServerResponse)
     }
@@ -45,7 +48,8 @@ struct CryptoCompareClient: CryptoPriceClient, Sendable {
     guard !symbolToMapping.isEmpty else { return [:] }
 
     let url = Self.priceMultiURL(symbols: Array(symbolToMapping.keys))
-    let (data, response) = try await session.data(for: URLRequest(url: url))
+    let (data, response) = try await session.dataRespectingRateLimit(
+      for: URLRequest(url: url), gate: rateLimitGate)
     guard let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) else {
       throw URLError(.badServerResponse)
     }

--- a/Backends/Frankfurter/FrankfurterClient.swift
+++ b/Backends/Frankfurter/FrankfurterClient.swift
@@ -13,9 +13,11 @@ struct FrankfurterClient: ExchangeRateClient, Sendable {
     URL(string: "https://api.frankfurter.app/") ?? URL(fileURLWithPath: "/")
   private static let logger = Logger(subsystem: "com.moolah.app", category: "FrankfurterClient")
   private let session: URLSession
+  private let rateLimitGate: RateLimitGate
 
-  init(session: URLSession = .shared) {
+  init(session: URLSession = .shared, rateLimitGate: RateLimitGate = RateLimitGate()) {
     self.session = session
+    self.rateLimitGate = rateLimitGate
   }
 
   func fetchRates(
@@ -34,7 +36,8 @@ struct FrankfurterClient: ExchangeRateClient, Sendable {
 
     let requestURL = components.url ?? url
     let request = URLRequest(url: requestURL)
-    let (data, response) = try await session.data(for: request)
+    let (data, response) = try await session.dataRespectingRateLimit(
+      for: request, gate: rateLimitGate)
 
     guard let httpResponse = response as? HTTPURLResponse,
       (200...299).contains(httpResponse.statusCode)

--- a/Backends/YahooFinance/YahooFinanceClient.swift
+++ b/Backends/YahooFinance/YahooFinanceClient.swift
@@ -12,9 +12,11 @@ struct YahooFinanceClient: StockPriceClient, Sendable {
     URL(string: "https://query2.finance.yahoo.com/v8/finance/chart/")
     ?? URL(fileURLWithPath: "/")
   private let session: URLSession
+  private let rateLimitGate: RateLimitGate
 
-  init(session: URLSession = .shared) {
+  init(session: URLSession = .shared, rateLimitGate: RateLimitGate = RateLimitGate()) {
     self.session = session
+    self.rateLimitGate = rateLimitGate
   }
 
   func fetchDailyPrices(ticker: String, from: Date, to: Date) async throws -> StockPriceResponse {
@@ -33,7 +35,8 @@ struct YahooFinanceClient: StockPriceClient, Sendable {
       forHTTPHeaderField: "User-Agent"
     )
 
-    let (data, response) = try await session.data(for: request)
+    let (data, response) = try await session.dataRespectingRateLimit(
+      for: request, gate: rateLimitGate)
 
     guard let httpResponse = response as? HTTPURLResponse,
       (200...299).contains(httpResponse.statusCode)

--- a/Backends/YahooFinance/YahooFinanceStockSearchClient.swift
+++ b/Backends/YahooFinance/YahooFinanceStockSearchClient.swift
@@ -9,14 +9,16 @@ import Foundation
 /// `shortname` is missing or empty after trimming.
 struct YahooFinanceStockSearchClient: StockSearchClient {
   private let session: URLSession
+  private let rateLimitGate: RateLimitGate
   private static let baseURL: URL = {
     guard let url = URL(string: "https://query1.finance.yahoo.com/v1/finance/search")
     else { preconditionFailure("malformed Yahoo search URL — fix the literal") }
     return url
   }()
 
-  init(session: URLSession = .shared) {
+  init(session: URLSession = .shared, rateLimitGate: RateLimitGate = RateLimitGate()) {
     self.session = session
+    self.rateLimitGate = rateLimitGate
   }
 
   func search(query: String) async throws -> [StockSearchHit] {
@@ -31,7 +33,8 @@ struct YahooFinanceStockSearchClient: StockSearchClient {
     var request = URLRequest(url: url)
     request.setValue("Mozilla/5.0", forHTTPHeaderField: "User-Agent")
 
-    let (data, response) = try await session.data(for: request)
+    let (data, response) = try await session.dataRespectingRateLimit(
+      for: request, gate: rateLimitGate)
     guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
       throw URLError(.badServerResponse)
     }

--- a/MoolahTests/Shared/RateLimitGateTests.swift
+++ b/MoolahTests/Shared/RateLimitGateTests.swift
@@ -1,0 +1,244 @@
+// MoolahTests/Shared/RateLimitGateTests.swift
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("RateLimitGate")
+struct RateLimitGateTests {
+
+  // MARK: - Clock helper
+
+  /// Hand-rolled monotonic clock so tests can advance "now" without
+  /// relying on `Task.sleep` and avoid wall-clock flake.
+  final class FakeClock: @unchecked Sendable {
+    private let lock = NSLock()
+    private var current: Date
+
+    init(start: Date = Date(timeIntervalSince1970: 1_700_000_000)) {
+      self.current = start
+    }
+
+    func now() -> Date {
+      lock.lock()
+      defer { lock.unlock() }
+      return current
+    }
+
+    func advance(_ seconds: TimeInterval) {
+      lock.lock()
+      defer { lock.unlock() }
+      current = current.addingTimeInterval(seconds)
+    }
+  }
+
+  // MARK: - Initial state
+
+  @Test
+  func freshGateIsOpen() async throws {
+    let gate = RateLimitGate(now: { Date() })
+    try await gate.ensureAvailable()
+  }
+
+  // MARK: - Retry-After path
+
+  @Test
+  func retryAfterSetsCooldownToServerSuppliedDeadline() async throws {
+    let clock = FakeClock()
+    let gate = RateLimitGate(now: { clock.now() })
+
+    let deadline = await gate.recordRateLimit(retryAfter: 60)
+
+    #expect(deadline == clock.now().addingTimeInterval(60))
+
+    // Just before the deadline — gate is closed.
+    clock.advance(59)
+    await #expect(throws: RateLimitGateError.self) {
+      try await gate.ensureAvailable()
+    }
+
+    // After the deadline — gate is open again.
+    clock.advance(2)
+    try await gate.ensureAvailable()
+  }
+
+  @Test
+  func retryAfterIsCappedAtMaxBackoff() async throws {
+    let clock = FakeClock()
+    let gate = RateLimitGate(maxBackoff: 120, now: { clock.now() })
+
+    let deadline = await gate.recordRateLimit(retryAfter: 9_999)
+
+    #expect(deadline == clock.now().addingTimeInterval(120))
+  }
+
+  // MARK: - Exponential fallback
+
+  @Test
+  func missingRetryAfterUsesBaseBackoff() async throws {
+    let clock = FakeClock()
+    let gate = RateLimitGate(baseBackoff: 30, maxBackoff: 600, now: { clock.now() })
+
+    let deadline = await gate.recordRateLimit(retryAfter: nil)
+
+    #expect(deadline == clock.now().addingTimeInterval(30))
+  }
+
+  @Test
+  func consecutiveFailuresGrowExponentially() async throws {
+    let clock = FakeClock()
+    let gate = RateLimitGate(baseBackoff: 30, maxBackoff: 600, now: { clock.now() })
+
+    let first = await gate.recordRateLimit()
+    #expect(first == clock.now().addingTimeInterval(30))
+
+    let second = await gate.recordRateLimit()
+    #expect(second == clock.now().addingTimeInterval(60))
+
+    let third = await gate.recordRateLimit()
+    #expect(third == clock.now().addingTimeInterval(120))
+  }
+
+  @Test
+  func exponentialBackoffSaturatesAtMax() async throws {
+    let clock = FakeClock()
+    let gate = RateLimitGate(baseBackoff: 30, maxBackoff: 100, now: { clock.now() })
+
+    _ = await gate.recordRateLimit()
+    _ = await gate.recordRateLimit()
+    let third = await gate.recordRateLimit()
+
+    #expect(third == clock.now().addingTimeInterval(100))
+  }
+
+  // MARK: - Reset on success
+
+  @Test
+  func successAfterCooldownClearsGateAndResetsCounter() async throws {
+    let clock = FakeClock()
+    let gate = RateLimitGate(baseBackoff: 30, maxBackoff: 600, now: { clock.now() })
+
+    _ = await gate.recordRateLimit()
+    _ = await gate.recordRateLimit()
+
+    // Wait past the cooldown so the next request is allowed; recording
+    // its success then resets state for the next failure cycle.
+    clock.advance(121)
+    try await gate.ensureAvailable()
+    await gate.recordSuccess()
+    try await gate.ensureAvailable()
+
+    // Counter reset — next failure starts at base backoff again.
+    let next = await gate.recordRateLimit()
+    #expect(next == clock.now().addingTimeInterval(30))
+  }
+
+  // MARK: - Concurrent-success-doesn't-erase-cooldown race
+
+  @Test
+  func successDoesNotClearActiveCooldown() async throws {
+    let clock = FakeClock()
+    let gate = RateLimitGate(baseBackoff: 30, maxBackoff: 600, now: { clock.now() })
+
+    // A racing 429 closes the gate. A different in-flight request that
+    // already passed `ensureAvailable` then completes 2xx and reports
+    // success. The cooldown set by the 429 must survive — otherwise the
+    // next caller would skip the cooldown that the gate just installed.
+    _ = await gate.recordRateLimit(retryAfter: 60)
+    await gate.recordSuccess()
+
+    await #expect(throws: RateLimitGateError.self) {
+      try await gate.ensureAvailable()
+    }
+
+    // The deadline survives, but the failure counter still resets — the
+    // 2xx is evidence the host is mostly healthy, so the next failure
+    // (after the cooldown expires) starts at base backoff again rather
+    // than continuing the exponential climb.
+    clock.advance(61)
+    try await gate.ensureAvailable()
+    let next = await gate.recordRateLimit()
+    #expect(next == clock.now().addingTimeInterval(30))
+  }
+
+  // MARK: - Cooldown clears on expiry
+
+  @Test
+  func ensureAvailableClearsExpiredCooldown() async throws {
+    let clock = FakeClock()
+    let gate = RateLimitGate(baseBackoff: 30, maxBackoff: 600, now: { clock.now() })
+
+    _ = await gate.recordRateLimit(retryAfter: 30)
+    clock.advance(31)
+    try await gate.ensureAvailable()
+
+    // The next failure progresses exponential backoff because the
+    // counter is cleared only on success — auto-reopen alone shouldn't
+    // forget that the host previously rate-limited us.
+    let next = await gate.recordRateLimit()
+    #expect(next == clock.now().addingTimeInterval(60))
+  }
+}
+
+// MARK: - Retry-After header parsing
+
+@Suite("HTTPURLResponse.retryAfterSeconds")
+struct RetryAfterSecondsTests {
+  private static let stubURL = URL(fileURLWithPath: "/")
+
+  // swiftlint:disable force_unwrapping
+  // `HTTPURLResponse(url:statusCode:httpVersion:headerFields:)` only fails on a
+  // malformed `httpVersion`, and `"HTTP/1.1"` is a hardcoded literal — so the
+  // force-unwrap below is provably safe. CODE_GUIDE §9 permits this in tests.
+  private func response(retryAfter value: String?) -> HTTPURLResponse {
+    var headers: [String: String] = [:]
+    if let value { headers["Retry-After"] = value }
+    return HTTPURLResponse(
+      url: Self.stubURL,
+      statusCode: 429,
+      httpVersion: "HTTP/1.1",
+      headerFields: headers
+    )!
+  }
+  // swiftlint:enable force_unwrapping
+
+  /// Fixed reference instant — anchor used by all tests that don't
+  /// otherwise care about the clock value. Pinned to a concrete second
+  /// so the parser's relative-seconds output is stable.
+  private static let referenceNow = Date(timeIntervalSince1970: 1_500_000_000)
+
+  @Test
+  func missingHeaderReturnsNil() {
+    #expect(response(retryAfter: nil).retryAfterSeconds(now: Self.referenceNow) == nil)
+  }
+
+  @Test
+  func deltaSecondsParse() {
+    #expect(response(retryAfter: "120").retryAfterSeconds(now: Self.referenceNow) == 120)
+  }
+
+  @Test
+  func deltaSecondsTrimsWhitespace() {
+    #expect(response(retryAfter: "  90 ").retryAfterSeconds(now: Self.referenceNow) == 90)
+  }
+
+  @Test
+  func httpDateInFutureReturnsRelativeSeconds() {
+    let now = Date(timeIntervalSince1970: 1_445_412_400)  // 2015-10-21 07:26:40 GMT
+    // 80 seconds in the future:
+    let future = "Wed, 21 Oct 2015 07:28:00 GMT"
+    let parsed = response(retryAfter: future).retryAfterSeconds(now: now)
+    #expect(parsed == 80)
+  }
+
+  @Test
+  func httpDateInPastClampsToZero() {
+    let past = "Wed, 21 Oct 2015 07:28:00 GMT"
+    #expect(response(retryAfter: past).retryAfterSeconds(now: Self.referenceNow) == 0)
+  }
+
+  @Test
+  func malformedReturnsNil() {
+    #expect(response(retryAfter: "garbage").retryAfterSeconds(now: Self.referenceNow) == nil)
+  }
+}

--- a/MoolahTests/Shared/URLSessionRateLimitTests.swift
+++ b/MoolahTests/Shared/URLSessionRateLimitTests.swift
@@ -1,0 +1,205 @@
+// MoolahTests/Shared/URLSessionRateLimitTests.swift
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("URLSession.dataRespectingRateLimit")
+struct URLSessionRateLimitTests {
+
+  // MARK: - Stub plumbing
+
+  /// `URLProtocol` stub local to this suite — the codebase uses
+  /// per-suite stubs (see `YahooFinanceClientTests`,
+  /// `AlchemyURLProtocolStub`) so the static handler doesn't collide
+  /// across files. Mirrors that pattern. Intentionally non-`final` so
+  /// SwiftLint's `static_over_final_class` rule does not apply to the
+  /// inherited overrides; `URLProtocol` already declares an unavailable
+  /// `Sendable` conformance, so the subclass can't add one — the
+  /// `nonisolated(unsafe)` static state is what actually keeps Swift 6
+  /// strict concurrency happy here.
+  class Stub: URLProtocol {
+    nonisolated(unsafe) static var handler:
+      (@Sendable (URLRequest) throws -> (HTTPURLResponse, Data))?
+    nonisolated(unsafe) static var requestCount: Int = 0
+    private static let lock = NSLock()
+
+    static func reset() {
+      lock.lock()
+      defer { lock.unlock() }
+      handler = nil
+      requestCount = 0
+    }
+
+    static func incrementRequestCount() {
+      lock.lock()
+      defer { lock.unlock() }
+      requestCount += 1
+    }
+
+    static func capturedRequestCount() -> Int {
+      lock.lock()
+      defer { lock.unlock() }
+      return requestCount
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+      Self.incrementRequestCount()
+      guard let handler = Self.handler else {
+        client?.urlProtocol(self, didFailWithError: URLError(.unknown))
+        return
+      }
+      do {
+        let (response, data) = try handler(request)
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: data)
+        client?.urlProtocolDidFinishLoading(self)
+      } catch {
+        client?.urlProtocol(self, didFailWithError: error)
+      }
+    }
+
+    override func stopLoading() {}
+  }
+
+  private static let stubURL = URL(fileURLWithPath: "/")
+
+  private func makeSession() -> URLSession {
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [Stub.self]
+    return URLSession(configuration: config)
+  }
+
+  // swiftlint:disable force_unwrapping
+  // `HTTPURLResponse(url:statusCode:httpVersion:headerFields:)` only fails on a
+  // malformed `httpVersion`, and `"HTTP/1.1"` is a hardcoded literal — so the
+  // force-unwrap below is provably safe. CODE_GUIDE §9 permits this in tests.
+  private func httpResponse(
+    statusCode: Int, headers: [String: String] = [:]
+  ) -> HTTPURLResponse {
+    HTTPURLResponse(
+      url: Self.stubURL,
+      statusCode: statusCode,
+      httpVersion: "HTTP/1.1",
+      headerFields: headers
+    )!
+  }
+  // swiftlint:enable force_unwrapping
+
+  private func request() -> URLRequest {
+    URLRequest(url: URL(string: "https://example.com/probe") ?? Self.stubURL)
+  }
+
+  // MARK: - 2xx success
+
+  @Test
+  func twoHundredReturnsDataAndKeepsGateOpen() async throws {
+    Stub.reset()
+    Stub.handler = { _ in (self.httpResponse(statusCode: 200), Data("OK".utf8)) }
+
+    let session = makeSession()
+    let gate = RateLimitGate()
+
+    let (data, _) = try await session.dataRespectingRateLimit(for: request(), gate: gate)
+    #expect(data == Data("OK".utf8))
+
+    // Gate still open — second call goes through.
+    Stub.handler = { _ in (self.httpResponse(statusCode: 200), Data()) }
+    _ = try await session.dataRespectingRateLimit(for: request(), gate: gate)
+  }
+
+  // MARK: - 429 trips the gate
+
+  @Test
+  func fourTwentyNineTripsGateAndThrowsCooldown() async throws {
+    Stub.reset()
+    Stub.handler = { _ in
+      (self.httpResponse(statusCode: 429, headers: ["Retry-After": "60"]), Data())
+    }
+
+    let session = makeSession()
+    let gate = RateLimitGate()
+
+    await #expect(throws: RateLimitGateError.self) {
+      try await session.dataRespectingRateLimit(for: self.request(), gate: gate)
+    }
+
+    // Subsequent call must fail fast — without hitting the network.
+    let countBefore = Stub.capturedRequestCount()
+    await #expect(throws: RateLimitGateError.self) {
+      try await session.dataRespectingRateLimit(for: self.request(), gate: gate)
+    }
+    #expect(Stub.capturedRequestCount() == countBefore)
+  }
+
+  // MARK: - 418 trips the gate (Binance ban)
+
+  @Test
+  func fourEighteenTripsGate() async throws {
+    Stub.reset()
+    Stub.handler = { _ in (self.httpResponse(statusCode: 418), Data()) }
+
+    let session = makeSession()
+    let gate = RateLimitGate()
+
+    await #expect(throws: RateLimitGateError.self) {
+      try await session.dataRespectingRateLimit(for: self.request(), gate: gate)
+    }
+  }
+
+  // MARK: - 503 with Retry-After trips, without doesn't
+
+  @Test
+  func fiveOhThreeWithRetryAfterTripsGate() async throws {
+    Stub.reset()
+    Stub.handler = { _ in
+      (self.httpResponse(statusCode: 503, headers: ["Retry-After": "10"]), Data())
+    }
+
+    let session = makeSession()
+    let gate = RateLimitGate()
+
+    await #expect(throws: RateLimitGateError.self) {
+      try await session.dataRespectingRateLimit(for: self.request(), gate: gate)
+    }
+  }
+
+  @Test
+  func fiveOhThreeWithoutRetryAfterDoesNotTripGate() async throws {
+    Stub.reset()
+    Stub.handler = { _ in (self.httpResponse(statusCode: 503), Data()) }
+
+    let session = makeSession()
+    let gate = RateLimitGate()
+
+    // Helper passes through — caller's own status check throws their
+    // existing transport error. Here we just verify the gate stays open.
+    let (_, response) = try await session.dataRespectingRateLimit(
+      for: request(), gate: gate)
+    #expect((response as? HTTPURLResponse)?.statusCode == 503)
+
+    // Gate still open — second call gets through to the stub.
+    let countBefore = Stub.capturedRequestCount()
+    Stub.handler = { _ in (self.httpResponse(statusCode: 200), Data()) }
+    _ = try await session.dataRespectingRateLimit(for: request(), gate: gate)
+    #expect(Stub.capturedRequestCount() == countBefore + 1)
+  }
+
+  // MARK: - Pass-through for other non-2xx
+
+  @Test
+  func nonRateLimitErrorPassesThrough() async throws {
+    Stub.reset()
+    Stub.handler = { _ in (self.httpResponse(statusCode: 500), Data()) }
+
+    let session = makeSession()
+    let gate = RateLimitGate()
+
+    let (_, response) = try await session.dataRespectingRateLimit(
+      for: request(), gate: gate)
+    #expect((response as? HTTPURLResponse)?.statusCode == 500)
+  }
+}

--- a/Shared/Networking/RateLimitGate.swift
+++ b/Shared/Networking/RateLimitGate.swift
@@ -1,0 +1,130 @@
+// Shared/Networking/RateLimitGate.swift
+import Foundation
+
+/// Thrown by `URLSession.dataRespectingRateLimit(for:gate:)` when the gate is
+/// in cooldown or when the just-completed response was a rate-limit. The
+/// `until` payload is the deadline after which the next request will be
+/// allowed through; callers can surface it for diagnostics or schedule a
+/// retry, but the standard pattern is to fall through to the next provider
+/// in a fallback chain.
+enum RateLimitGateError: Error, Equatable {
+  case cooldown(until: Date)
+}
+
+/// Per-client cooldown gate that prevents repeated requests to a remote
+/// API after it has rate-limited us.
+///
+/// Each upstream price client (CoinGecko, CryptoCompare, Binance, Yahoo
+/// Finance, Frankfurter) owns one gate. On a `429` (or `418`, or `503`
+/// carrying a `Retry-After` header) the gate is closed until a deadline:
+/// either the value of `Retry-After` or — if absent — an exponential
+/// backoff (`baseBackoff * 2^(failures-1)`, capped at `maxBackoff`).
+/// While the gate is closed, `checkAvailable()` throws
+/// `RateLimitGateError.cooldown(until:)` so the caller can fail fast and
+/// fall through to a fallback provider rather than continuing to spam
+/// the limited host. A successful response resets the failure count and
+/// reopens the gate.
+///
+/// Concurrency: this is an `actor` so multiple Tasks racing to the same
+/// upstream serialise through `checkAvailable` / `recordRateLimit` /
+/// `recordSuccess`. The clock is injected via `now` so tests can pin
+/// "current time" without relying on wall-clock progression.
+actor RateLimitGate {
+  private let baseBackoff: TimeInterval
+  private let maxBackoff: TimeInterval
+  private let now: @Sendable () -> Date
+  private var blockedUntil: Date?
+  private var consecutiveFailures: Int = 0
+
+  /// - Parameters:
+  ///   - baseBackoff: First-failure backoff when the server doesn't supply
+  ///     `Retry-After`. Defaults to 30s — long enough that a free-tier
+  ///     limiter (~30 req/min) can refill without a re-probe.
+  ///   - maxBackoff: Ceiling for both `Retry-After` and exponential
+  ///     backoff. Defaults to 10 minutes — beyond this the user is going
+  ///     to retry manually anyway, and indefinite blocks risk masking a
+  ///     mis-configured client (e.g. a permanently bad API key
+  ///     responding with 429 forever).
+  ///   - now: Closure returning the current time. Defaults to `Date()`.
+  init(
+    baseBackoff: TimeInterval = 30,
+    maxBackoff: TimeInterval = 600,
+    now: @Sendable @escaping () -> Date = { Date() }
+  ) {
+    self.baseBackoff = baseBackoff
+    self.maxBackoff = maxBackoff
+    self.now = now
+  }
+
+  /// Throws `RateLimitGateError.cooldown(until:)` when the gate is closed.
+  /// As a side effect, clears an expired cooldown so the next request
+  /// goes through cleanly.
+  func ensureAvailable() throws {
+    guard let deadline = blockedUntil else { return }
+    if now() < deadline {
+      throw RateLimitGateError.cooldown(until: deadline)
+    }
+    blockedUntil = nil
+  }
+
+  /// Marks the most recent call as successful. Resets failure tracking and
+  /// clears any **expired** cooldown — but never tramples an active
+  /// cooldown that a concurrent rate-limit response set after this call
+  /// began. Without that guard, a Task that already passed
+  /// `ensureAvailable` and won the race to a 200 would erase the
+  /// cooldown a sibling Task's 429 just established, defeating the
+  /// fail-fast contract for the next caller.
+  func recordSuccess() {
+    consecutiveFailures = 0
+    if let deadline = blockedUntil, now() < deadline { return }
+    blockedUntil = nil
+  }
+
+  /// Records a rate-limit response and computes the next cooldown deadline.
+  /// `retryAfter` is the server-supplied `Retry-After` value in seconds (or
+  /// `nil` when the header is absent / malformed). Returns the chosen
+  /// deadline so callers can include it in the thrown error or log line.
+  @discardableResult
+  func recordRateLimit(retryAfter: TimeInterval? = nil) -> Date {
+    consecutiveFailures += 1
+    let backoff: TimeInterval
+    if let retryAfter, retryAfter > 0 {
+      backoff = min(retryAfter, maxBackoff)
+    } else {
+      // 30s, 60s, 120s, ..., capped at `maxBackoff`. `pow` on `Double`
+      // is total — overflow saturates to `.infinity`, which `min(_:_:)`
+      // collapses back to the cap.
+      let exp = baseBackoff * pow(2.0, Double(max(0, consecutiveFailures - 1)))
+      backoff = min(exp, maxBackoff)
+    }
+    let deadline = now().addingTimeInterval(backoff)
+    blockedUntil = deadline
+    return deadline
+  }
+}
+
+extension HTTPURLResponse {
+  /// Parses the `Retry-After` header into a non-negative `TimeInterval`.
+  /// Supports both spec-defined forms: delta-seconds (e.g. `"120"`) and
+  /// HTTP-date (e.g. `"Wed, 21 Oct 2015 07:28:00 GMT"`). Returns `nil`
+  /// when the header is absent or malformed; clamps past dates to `0`.
+  ///
+  /// `now` is required (no default) so callers must thread their own
+  /// clock through. The HTTP-date branch needs a reference point to
+  /// compute relative seconds; the delta-seconds branch ignores `now`.
+  func retryAfterSeconds(now: Date) -> TimeInterval? {
+    guard let raw = value(forHTTPHeaderField: "Retry-After") else { return nil }
+    let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+    if let seconds = TimeInterval(trimmed), seconds >= 0 {
+      return seconds
+    }
+    let formatter = DateFormatter()
+    formatter.locale = Locale(identifier: "en_US_POSIX")
+    formatter.timeZone = TimeZone(identifier: "GMT")
+    formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss z"
+    if let date = formatter.date(from: trimmed) {
+      return max(0, date.timeIntervalSince(now))
+    }
+    return nil
+  }
+}

--- a/Shared/Networking/URLSession+RateLimited.swift
+++ b/Shared/Networking/URLSession+RateLimited.swift
@@ -1,0 +1,88 @@
+// Shared/Networking/URLSession+RateLimited.swift
+import Foundation
+import OSLog
+
+private let rateLimitedFetchLogger = Logger(
+  subsystem: "com.moolah.app", category: "RateLimitedFetch")
+
+extension URLSession {
+  /// Sends `request` while respecting `gate`. Wraps the standard
+  /// `data(for:)` call with a pre-flight gate check and post-flight
+  /// rate-limit detection.
+  ///
+  /// Pre-flight: if the gate is currently in cooldown, throws
+  /// `RateLimitGateError.cooldown(until:)` immediately without hitting
+  /// the network. This is what stops a price-fetch loop from continuing
+  /// to spam an upstream that has already 429ed us.
+  ///
+  /// Post-flight: classifies the response by status code:
+  ///
+  /// - `2xx`: records success on the gate and returns `(data, response)`
+  ///   so the caller's existing decode path runs.
+  /// - `429` (Too Many Requests) or `418` (Binance's "I'm a teapot",
+  ///   meaning "you ignored 429 and you're now temporarily banned"):
+  ///   trips the gate using `Retry-After` (or exponential backoff
+  ///   when the header is absent) and throws
+  ///   `RateLimitGateError.cooldown(until:)`.
+  /// - `503` (Service Unavailable) **with** a `Retry-After` header:
+  ///   trips the gate the same way. A 503 without `Retry-After` is
+  ///   treated as a transient server fault and propagated as-is —
+  ///   the next caller probes again rather than waiting blindly.
+  /// - Any other status: returns `(data, response)` unchanged. The
+  ///   caller's existing 2xx check fires its own error (typically
+  ///   `URLError(.badServerResponse)`); the gate state is left
+  ///   untouched because the error isn't rate-limit-related.
+  ///
+  /// The non-rate-limit-error pass-through deliberately does **not**
+  /// reset the failure counter — the counter only ever increments on a
+  /// rate-limit response and only ever resets on a 2xx, so a stretch of
+  /// 5xx errors between 429s doesn't reset the exponential backoff
+  /// progression.
+  ///
+  /// The `Retry-After` HTTP-date parser is anchored at `Date()` rather
+  /// than the gate's injected clock. The two are independent: the
+  /// parser only converts an HTTP-date into a relative-second offset
+  /// for the rare HTTP-date `Retry-After`, while the gate uses its own
+  /// clock to compute the cooldown deadline from that offset. Real
+  /// servers almost universally return delta-seconds, so the parser
+  /// branch that consults the clock is exercised in tests but rarely
+  /// in production.
+  func dataRespectingRateLimit(
+    for request: URLRequest,
+    gate: RateLimitGate
+  ) async throws -> (Data, URLResponse) {
+    try await gate.ensureAvailable()
+    let (data, response) = try await self.data(for: request)
+    guard let http = response as? HTTPURLResponse else {
+      return (data, response)
+    }
+    let retryAfter = http.retryAfterSeconds(now: Date())
+    let host = request.url?.host ?? "?"
+    switch http.statusCode {
+    case 200...299:
+      await gate.recordSuccess()
+    case 429, 418:
+      let deadline = await gate.recordRateLimit(retryAfter: retryAfter)
+      rateLimitedFetchLogger.warning(
+        """
+        Rate-limited (HTTP \(http.statusCode, privacy: .public)) by \
+        \(host, privacy: .public); cooldown until \
+        \(deadline.timeIntervalSince1970, privacy: .public)
+        """
+      )
+      throw RateLimitGateError.cooldown(until: deadline)
+    case 503 where retryAfter != nil:
+      let deadline = await gate.recordRateLimit(retryAfter: retryAfter)
+      rateLimitedFetchLogger.warning(
+        """
+        503 with Retry-After from \(host, privacy: .public); \
+        cooldown until \(deadline.timeIntervalSince1970, privacy: .public)
+        """
+      )
+      throw RateLimitGateError.cooldown(until: deadline)
+    default:
+      break
+    }
+    return (data, response)
+  }
+}


### PR DESCRIPTION
## Summary

- Adds a shared `RateLimitGate` actor (in `Shared/Networking/`) that fail-fasts during cooldown so price clients don't spam an upstream that has rate-limited us. On 429 / 418 / 503-with-Retry-After, the gate is closed until either the server-supplied `Retry-After` deadline (delta-seconds or HTTP-date) or — if absent — exponential backoff capped at 10 minutes.
- Wires the gate into all six price-fetching clients: Frankfurter (currency), Yahoo Finance (stocks + search), CoinGecko / CryptoCompare / Binance (crypto). Each client now owns one default `RateLimitGate` and routes its `session.data(for:)` call through `session.dataRespectingRateLimit(for:gate:)`.
- A concurrent 200 cannot erase a cooldown set by a sibling 429: `recordSuccess()` resets the failure counter but leaves the deadline alone while it's still in the future. Regression test included.

## Out of scope

- `Backends/CoinGecko/SQLiteCoinGeckoCatalog+Refresh.swift` still uses raw `session.data(for:)`; it's an ETag-gated metadata fetch, not a hot loop.
- The Alchemy client already has a proactive token-bucket `RateLimiter` and isn't touched.
- The pre-existing inline `: Protocol, Sendable` conformance pattern in the six client files matches the wider codebase (`CryptoPriceError: Error, Equatable` etc.) and is left untouched here.

## Test plan

- [x] `just format-check` — clean
- [x] `just test-mac` — 2624 tests pass
- [x] `just test-ios` (rate-limit suite) — 20 tests pass
- [ ] Live: confirm price-fetch loop falls through to fallback provider on a forced 429 (next free-tier-key sync)

🤖 Generated with [Claude Code](https://claude.com/claude-code)