### PR TITLE
feat(network): mute repeated failing requests via per-URL cache

### DIFF
--- a/Backends/Binance/BinanceClient.swift
+++ b/Backends/Binance/BinanceClient.swift
@@ -8,15 +8,18 @@ struct BinanceClient: CryptoPriceClient, Sendable {
   private let session: URLSession
   private let usdtRateLookup: @Sendable (Date) async -> Decimal
   private let rateLimitGate: RateLimitGate
+  private let failureCache: FailedRequestCache
 
   init(
     session: URLSession = .shared,
     usdtRateLookup: @escaping @Sendable (Date) async -> Decimal = { _ in Decimal(1) },
-    rateLimitGate: RateLimitGate = RateLimitGate()
+    rateLimitGate: RateLimitGate = RateLimitGate(),
+    failureCache: FailedRequestCache = FailedRequestCache()
   ) {
     self.session = session
     self.usdtRateLookup = usdtRateLookup
     self.rateLimitGate = rateLimitGate
+    self.failureCache = failureCache
   }
 
   func dailyPrice(for mapping: CryptoProviderMapping, on date: Date) async throws -> Decimal {
@@ -46,7 +49,7 @@ struct BinanceClient: CryptoPriceClient, Sendable {
       let chunkEnd = min(candleWindowEnd, range.upperBound)
       let url = Self.klinesURL(symbol: symbol, from: chunkStart, to: chunkEnd)
       let (data, response) = try await session.dataRespectingRateLimit(
-        for: URLRequest(url: url), gate: rateLimitGate)
+        for: URLRequest(url: url), gate: rateLimitGate, failureCache: failureCache)
       guard let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) else {
         throw URLError(.badServerResponse)
       }

--- a/Backends/CoinGecko/CoinGeckoClient.swift
+++ b/Backends/CoinGecko/CoinGeckoClient.swift
@@ -15,15 +15,18 @@ struct CoinGeckoClient: CryptoPriceClient, Sendable {
   private let session: URLSession
   private let apiKey: String
   private let rateLimitGate: RateLimitGate
+  private let failureCache: FailedRequestCache
 
   init(
     session: URLSession = .shared,
     apiKey: String,
-    rateLimitGate: RateLimitGate = RateLimitGate()
+    rateLimitGate: RateLimitGate = RateLimitGate(),
+    failureCache: FailedRequestCache = FailedRequestCache()
   ) {
     self.session = session
     self.apiKey = apiKey
     self.rateLimitGate = rateLimitGate
+    self.failureCache = failureCache
   }
 
   /// Resolves the base URL by key presence: non-empty → Pro host,
@@ -61,7 +64,7 @@ struct CoinGeckoClient: CryptoPriceClient, Sendable {
     )
     let url = Self.marketChartURL(coinId: coinId, days: days, apiKey: apiKey)
     let (data, response) = try await session.dataRespectingRateLimit(
-      for: URLRequest(url: url), gate: rateLimitGate)
+      for: URLRequest(url: url), gate: rateLimitGate, failureCache: failureCache)
     guard let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) else {
       throw URLError(.badServerResponse)
     }
@@ -80,7 +83,7 @@ struct CoinGeckoClient: CryptoPriceClient, Sendable {
 
     let url = Self.simplePriceURL(coinIds: Array(idToMapping.keys), apiKey: apiKey)
     let (data, response) = try await session.dataRespectingRateLimit(
-      for: URLRequest(url: url), gate: rateLimitGate)
+      for: URLRequest(url: url), gate: rateLimitGate, failureCache: failureCache)
     guard let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) else {
       throw URLError(.badServerResponse)
     }

--- a/Backends/CryptoCompare/CryptoCompareClient.swift
+++ b/Backends/CryptoCompare/CryptoCompareClient.swift
@@ -6,10 +6,16 @@ struct CryptoCompareClient: CryptoPriceClient, Sendable {
     URL(string: "https://min-api.cryptocompare.com") ?? URL(fileURLWithPath: "/")
   private let session: URLSession
   private let rateLimitGate: RateLimitGate
+  private let failureCache: FailedRequestCache
 
-  init(session: URLSession = .shared, rateLimitGate: RateLimitGate = RateLimitGate()) {
+  init(
+    session: URLSession = .shared,
+    rateLimitGate: RateLimitGate = RateLimitGate(),
+    failureCache: FailedRequestCache = FailedRequestCache()
+  ) {
     self.session = session
     self.rateLimitGate = rateLimitGate
+    self.failureCache = failureCache
   }
 
   func dailyPrice(for mapping: CryptoProviderMapping, on date: Date) async throws -> Decimal {
@@ -30,7 +36,7 @@ struct CryptoCompareClient: CryptoPriceClient, Sendable {
     }
     let url = Self.histodayURL(symbol: symbol, from: range.lowerBound, to: range.upperBound)
     let (data, response) = try await session.dataRespectingRateLimit(
-      for: URLRequest(url: url), gate: rateLimitGate)
+      for: URLRequest(url: url), gate: rateLimitGate, failureCache: failureCache)
     guard let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) else {
       throw URLError(.badServerResponse)
     }
@@ -49,7 +55,7 @@ struct CryptoCompareClient: CryptoPriceClient, Sendable {
 
     let url = Self.priceMultiURL(symbols: Array(symbolToMapping.keys))
     let (data, response) = try await session.dataRespectingRateLimit(
-      for: URLRequest(url: url), gate: rateLimitGate)
+      for: URLRequest(url: url), gate: rateLimitGate, failureCache: failureCache)
     guard let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) else {
       throw URLError(.badServerResponse)
     }

--- a/Backends/Frankfurter/FrankfurterClient.swift
+++ b/Backends/Frankfurter/FrankfurterClient.swift
@@ -14,10 +14,16 @@ struct FrankfurterClient: ExchangeRateClient, Sendable {
   private static let logger = Logger(subsystem: "com.moolah.app", category: "FrankfurterClient")
   private let session: URLSession
   private let rateLimitGate: RateLimitGate
+  private let failureCache: FailedRequestCache
 
-  init(session: URLSession = .shared, rateLimitGate: RateLimitGate = RateLimitGate()) {
+  init(
+    session: URLSession = .shared,
+    rateLimitGate: RateLimitGate = RateLimitGate(),
+    failureCache: FailedRequestCache = FailedRequestCache()
+  ) {
     self.session = session
     self.rateLimitGate = rateLimitGate
+    self.failureCache = failureCache
   }
 
   func fetchRates(
@@ -37,7 +43,7 @@ struct FrankfurterClient: ExchangeRateClient, Sendable {
     let requestURL = components.url ?? url
     let request = URLRequest(url: requestURL)
     let (data, response) = try await session.dataRespectingRateLimit(
-      for: request, gate: rateLimitGate)
+      for: request, gate: rateLimitGate, failureCache: failureCache)
 
     guard let httpResponse = response as? HTTPURLResponse,
       (200...299).contains(httpResponse.statusCode)

--- a/Backends/YahooFinance/YahooFinanceClient.swift
+++ b/Backends/YahooFinance/YahooFinanceClient.swift
@@ -13,10 +13,16 @@ struct YahooFinanceClient: StockPriceClient, Sendable {
     ?? URL(fileURLWithPath: "/")
   private let session: URLSession
   private let rateLimitGate: RateLimitGate
+  private let failureCache: FailedRequestCache
 
-  init(session: URLSession = .shared, rateLimitGate: RateLimitGate = RateLimitGate()) {
+  init(
+    session: URLSession = .shared,
+    rateLimitGate: RateLimitGate = RateLimitGate(),
+    failureCache: FailedRequestCache = FailedRequestCache()
+  ) {
     self.session = session
     self.rateLimitGate = rateLimitGate
+    self.failureCache = failureCache
   }
 
   func fetchDailyPrices(ticker: String, from: Date, to: Date) async throws -> StockPriceResponse {
@@ -36,7 +42,7 @@ struct YahooFinanceClient: StockPriceClient, Sendable {
     )
 
     let (data, response) = try await session.dataRespectingRateLimit(
-      for: request, gate: rateLimitGate)
+      for: request, gate: rateLimitGate, failureCache: failureCache)
 
     guard let httpResponse = response as? HTTPURLResponse,
       (200...299).contains(httpResponse.statusCode)

--- a/Backends/YahooFinance/YahooFinanceStockSearchClient.swift
+++ b/Backends/YahooFinance/YahooFinanceStockSearchClient.swift
@@ -10,15 +10,21 @@ import Foundation
 struct YahooFinanceStockSearchClient: StockSearchClient {
   private let session: URLSession
   private let rateLimitGate: RateLimitGate
+  private let failureCache: FailedRequestCache
   private static let baseURL: URL = {
     guard let url = URL(string: "https://query1.finance.yahoo.com/v1/finance/search")
     else { preconditionFailure("malformed Yahoo search URL — fix the literal") }
     return url
   }()
 
-  init(session: URLSession = .shared, rateLimitGate: RateLimitGate = RateLimitGate()) {
+  init(
+    session: URLSession = .shared,
+    rateLimitGate: RateLimitGate = RateLimitGate(),
+    failureCache: FailedRequestCache = FailedRequestCache()
+  ) {
     self.session = session
     self.rateLimitGate = rateLimitGate
+    self.failureCache = failureCache
   }
 
   func search(query: String) async throws -> [StockSearchHit] {
@@ -34,7 +40,7 @@ struct YahooFinanceStockSearchClient: StockSearchClient {
     request.setValue("Mozilla/5.0", forHTTPHeaderField: "User-Agent")
 
     let (data, response) = try await session.dataRespectingRateLimit(
-      for: request, gate: rateLimitGate)
+      for: request, gate: rateLimitGate, failureCache: failureCache)
     guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
       throw URLError(.badServerResponse)
     }

--- a/MoolahTests/Shared/FailedRequestCacheTests.swift
+++ b/MoolahTests/Shared/FailedRequestCacheTests.swift
@@ -1,0 +1,153 @@
+// MoolahTests/Shared/FailedRequestCacheTests.swift
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("FailedRequestCache")
+struct FailedRequestCacheTests {
+
+  // MARK: - Clock helper
+
+  /// Hand-rolled monotonic clock so tests can advance "now" without
+  /// relying on `Task.sleep` and avoid wall-clock flake. Same pattern
+  /// as `RateLimitGateTests.FakeClock`.
+  final class FakeClock: @unchecked Sendable {
+    private let lock = NSLock()
+    private var current: Date
+
+    init(start: Date = Date(timeIntervalSince1970: 1_700_000_000)) {
+      self.current = start
+    }
+
+    func now() -> Date {
+      lock.lock()
+      defer { lock.unlock() }
+      return current
+    }
+
+    func advance(_ seconds: TimeInterval) {
+      lock.lock()
+      defer { lock.unlock() }
+      current = current.addingTimeInterval(seconds)
+    }
+  }
+
+  // MARK: - Initial state
+
+  @Test
+  func freshCacheIsOpen() async throws {
+    let cache = FailedRequestCache()
+    try await cache.ensureAvailable(for: "https://example.com/x")
+  }
+
+  // MARK: - Failure muting
+
+  @Test
+  func recordedFailureIsMutedUntilCooldownExpires() async throws {
+    let clock = FakeClock()
+    let cache = FailedRequestCache(cooldownDuration: 60, now: { clock.now() })
+
+    let deadline = await cache.recordFailure(for: "https://example.com/x")
+    #expect(deadline == clock.now().addingTimeInterval(60))
+
+    // Just before expiry — still muted.
+    clock.advance(59)
+    await #expect(throws: FailedRequestCacheError.self) {
+      try await cache.ensureAvailable(for: "https://example.com/x")
+    }
+
+    // After expiry — request goes through cleanly again.
+    clock.advance(2)
+    try await cache.ensureAvailable(for: "https://example.com/x")
+  }
+
+  @Test
+  func differentKeysAreIndependent() async throws {
+    let clock = FakeClock()
+    let cache = FailedRequestCache(cooldownDuration: 60, now: { clock.now() })
+
+    _ = await cache.recordFailure(for: "https://example.com/a")
+
+    // A different URL must NOT be affected — this is the entire point
+    // of a per-URL cache versus a host-wide gate.
+    try await cache.ensureAvailable(for: "https://example.com/b")
+  }
+
+  @Test
+  func recordSuccessClearsEntry() async throws {
+    let clock = FakeClock()
+    let cache = FailedRequestCache(cooldownDuration: 60, now: { clock.now() })
+
+    _ = await cache.recordFailure(for: "https://example.com/x")
+    await cache.recordSuccess(for: "https://example.com/x")
+
+    // The 2xx is evidence that the resource is reachable; cooldown
+    // dropped immediately so the next caller goes through.
+    try await cache.ensureAvailable(for: "https://example.com/x")
+  }
+
+  // MARK: - Bounded growth
+
+  @Test
+  func boundedByMaxEntriesViaPruningExpired() async throws {
+    let clock = FakeClock()
+    let cache = FailedRequestCache(
+      cooldownDuration: 60, maxEntries: 2, now: { clock.now() })
+
+    _ = await cache.recordFailure(for: "https://example.com/a")
+    _ = await cache.recordFailure(for: "https://example.com/b")
+
+    // Both entries are still within their cooldowns. Letting them
+    // expire and then inserting a third lets the cache prune.
+    clock.advance(61)
+    _ = await cache.recordFailure(for: "https://example.com/c")
+
+    // The expired ones are gone — open again.
+    try await cache.ensureAvailable(for: "https://example.com/a")
+    try await cache.ensureAvailable(for: "https://example.com/b")
+    // And the new one is muted as expected.
+    await #expect(throws: FailedRequestCacheError.self) {
+      try await cache.ensureAvailable(for: "https://example.com/c")
+    }
+  }
+
+  @Test
+  func boundedByMaxEntriesViaOldestEviction() async throws {
+    let clock = FakeClock()
+    let cache = FailedRequestCache(
+      cooldownDuration: 600, maxEntries: 2, now: { clock.now() })
+
+    _ = await cache.recordFailure(for: "https://example.com/a")
+    clock.advance(1)
+    _ = await cache.recordFailure(for: "https://example.com/b")
+    clock.advance(1)
+    // All three are within their (long) cooldown; nothing to prune.
+    // The oldest (`a`) gets evicted to make room for `c`.
+    _ = await cache.recordFailure(for: "https://example.com/c")
+
+    try await cache.ensureAvailable(for: "https://example.com/a")
+    await #expect(throws: FailedRequestCacheError.self) {
+      try await cache.ensureAvailable(for: "https://example.com/b")
+    }
+    await #expect(throws: FailedRequestCacheError.self) {
+      try await cache.ensureAvailable(for: "https://example.com/c")
+    }
+  }
+
+  // MARK: - ensureAvailable side-effect
+
+  @Test
+  func ensureAvailableClearsExpiredEntry() async throws {
+    let clock = FakeClock()
+    let cache = FailedRequestCache(cooldownDuration: 60, now: { clock.now() })
+
+    _ = await cache.recordFailure(for: "https://example.com/x")
+    clock.advance(61)
+    try await cache.ensureAvailable(for: "https://example.com/x")
+    // After the side-effect prune, a subsequent failure starts a fresh
+    // cooldown anchored at the current clock — same shape as the gate.
+    let next = await cache.recordFailure(for: "https://example.com/x")
+    #expect(next == clock.now().addingTimeInterval(60))
+  }
+}

--- a/MoolahTests/Shared/URLSessionRateLimitTests.swift
+++ b/MoolahTests/Shared/URLSessionRateLimitTests.swift
@@ -89,8 +89,8 @@ struct URLSessionRateLimitTests {
   }
   // swiftlint:enable force_unwrapping
 
-  private func request() -> URLRequest {
-    URLRequest(url: URL(string: "https://example.com/probe") ?? Self.stubURL)
+  private func request(path: String = "/probe") -> URLRequest {
+    URLRequest(url: URL(string: "https://example.com\(path)") ?? Self.stubURL)
   }
 
   // MARK: - 2xx success
@@ -102,13 +102,16 @@ struct URLSessionRateLimitTests {
 
     let session = makeSession()
     let gate = RateLimitGate()
+    let cache = FailedRequestCache()
 
-    let (data, _) = try await session.dataRespectingRateLimit(for: request(), gate: gate)
+    let (data, _) = try await session.dataRespectingRateLimit(
+      for: request(), gate: gate, failureCache: cache)
     #expect(data == Data("OK".utf8))
 
     // Gate still open — second call goes through.
     Stub.handler = { _ in (self.httpResponse(statusCode: 200), Data()) }
-    _ = try await session.dataRespectingRateLimit(for: request(), gate: gate)
+    _ = try await session.dataRespectingRateLimit(
+      for: request(), gate: gate, failureCache: cache)
   }
 
   // MARK: - 429 trips the gate
@@ -122,15 +125,18 @@ struct URLSessionRateLimitTests {
 
     let session = makeSession()
     let gate = RateLimitGate()
+    let cache = FailedRequestCache()
 
     await #expect(throws: RateLimitGateError.self) {
-      try await session.dataRespectingRateLimit(for: self.request(), gate: gate)
+      try await session.dataRespectingRateLimit(
+        for: self.request(), gate: gate, failureCache: cache)
     }
 
     // Subsequent call must fail fast — without hitting the network.
     let countBefore = Stub.capturedRequestCount()
-    await #expect(throws: RateLimitGateError.self) {
-      try await session.dataRespectingRateLimit(for: self.request(), gate: gate)
+    await #expect(throws: (any Error).self) {
+      try await session.dataRespectingRateLimit(
+        for: self.request(), gate: gate, failureCache: cache)
     }
     #expect(Stub.capturedRequestCount() == countBefore)
   }
@@ -144,9 +150,11 @@ struct URLSessionRateLimitTests {
 
     let session = makeSession()
     let gate = RateLimitGate()
+    let cache = FailedRequestCache()
 
     await #expect(throws: RateLimitGateError.self) {
-      try await session.dataRespectingRateLimit(for: self.request(), gate: gate)
+      try await session.dataRespectingRateLimit(
+        for: self.request(), gate: gate, failureCache: cache)
     }
   }
 
@@ -161,9 +169,11 @@ struct URLSessionRateLimitTests {
 
     let session = makeSession()
     let gate = RateLimitGate()
+    let cache = FailedRequestCache()
 
     await #expect(throws: RateLimitGateError.self) {
-      try await session.dataRespectingRateLimit(for: self.request(), gate: gate)
+      try await session.dataRespectingRateLimit(
+        for: self.request(), gate: gate, failureCache: cache)
     }
   }
 
@@ -174,32 +184,161 @@ struct URLSessionRateLimitTests {
 
     let session = makeSession()
     let gate = RateLimitGate()
+    // Use a fresh cache scoped to this test; the per-URL cache *does*
+    // record on a 503-without-Retry-After (it's a failure) so a follow-up
+    // to the *same* URL fails fast. To verify the gate stays open we
+    // probe a different URL on the second call instead.
+    let cache = FailedRequestCache()
 
-    // Helper passes through — caller's own status check throws their
-    // existing transport error. Here we just verify the gate stays open.
     let (_, response) = try await session.dataRespectingRateLimit(
-      for: request(), gate: gate)
+      for: request(path: "/probe-1"), gate: gate, failureCache: cache)
     #expect((response as? HTTPURLResponse)?.statusCode == 503)
 
-    // Gate still open — second call gets through to the stub.
     let countBefore = Stub.capturedRequestCount()
     Stub.handler = { _ in (self.httpResponse(statusCode: 200), Data()) }
-    _ = try await session.dataRespectingRateLimit(for: request(), gate: gate)
+    _ = try await session.dataRespectingRateLimit(
+      for: request(path: "/probe-2"), gate: gate, failureCache: cache)
     #expect(Stub.capturedRequestCount() == countBefore + 1)
   }
 
-  // MARK: - Pass-through for other non-2xx
+  // MARK: - 404 path
 
   @Test
-  func nonRateLimitErrorPassesThrough() async throws {
+  func fourOhFourMutesUrlForFailureCacheCooldown() async throws {
+    Stub.reset()
+    Stub.handler = { _ in (self.httpResponse(statusCode: 404), Data()) }
+
+    let session = makeSession()
+    let gate = RateLimitGate()
+    let cache = FailedRequestCache()
+
+    // First call: helper passes through (caller's status-code check
+    // would normally throw). Cache records the failure as a side effect.
+    let (_, response) = try await session.dataRespectingRateLimit(
+      for: request(), gate: gate, failureCache: cache)
+    #expect((response as? HTTPURLResponse)?.statusCode == 404)
+
+    // Second call to the *same* URL: must fail fast without hitting the
+    // network — this is the spam-loop fix.
+    let countBefore = Stub.capturedRequestCount()
+    await #expect(throws: FailedRequestCacheError.self) {
+      try await session.dataRespectingRateLimit(
+        for: self.request(), gate: gate, failureCache: cache)
+    }
+    #expect(Stub.capturedRequestCount() == countBefore)
+  }
+
+  @Test
+  func fourOhFourDoesNotAffectOtherUrls() async throws {
+    Stub.reset()
+    Stub.handler = { request in
+      let path = request.url?.path ?? ""
+      if path.contains("missing") {
+        return (self.httpResponse(statusCode: 404), Data())
+      }
+      return (self.httpResponse(statusCode: 200), Data("OK".utf8))
+    }
+
+    let session = makeSession()
+    let gate = RateLimitGate()
+    let cache = FailedRequestCache()
+
+    // First request 404s and gets muted.
+    _ = try await session.dataRespectingRateLimit(
+      for: request(path: "/missing"), gate: gate, failureCache: cache)
+
+    // A different URL on the same host must NOT be muted — only the
+    // exact failing URL is throttled, so legitimate fetches continue.
+    let (data, _) = try await session.dataRespectingRateLimit(
+      for: request(path: "/found"), gate: gate, failureCache: cache)
+    #expect(data == Data("OK".utf8))
+  }
+
+  // MARK: - 5xx path
+
+  @Test
+  func fiveHundredAlsoMutesUrl() async throws {
     Stub.reset()
     Stub.handler = { _ in (self.httpResponse(statusCode: 500), Data()) }
 
     let session = makeSession()
     let gate = RateLimitGate()
+    let cache = FailedRequestCache()
 
     let (_, response) = try await session.dataRespectingRateLimit(
-      for: request(), gate: gate)
+      for: request(), gate: gate, failureCache: cache)
     #expect((response as? HTTPURLResponse)?.statusCode == 500)
+
+    // Same URL repeat — fails fast.
+    let countBefore = Stub.capturedRequestCount()
+    await #expect(throws: FailedRequestCacheError.self) {
+      try await session.dataRespectingRateLimit(
+        for: self.request(), gate: gate, failureCache: cache)
+    }
+    #expect(Stub.capturedRequestCount() == countBefore)
+  }
+
+  // MARK: - Transport-error path
+
+  @Test
+  func transportErrorMutesUrl() async throws {
+    Stub.reset()
+    Stub.handler = { _ in throw URLError(.notConnectedToInternet) }
+
+    let session = makeSession()
+    let gate = RateLimitGate()
+    let cache = FailedRequestCache()
+
+    await #expect(throws: (any Error).self) {
+      try await session.dataRespectingRateLimit(
+        for: self.request(), gate: gate, failureCache: cache)
+    }
+
+    // Same URL repeated — fails fast from the cache, no second network hit.
+    let countBefore = Stub.capturedRequestCount()
+    await #expect(throws: FailedRequestCacheError.self) {
+      try await session.dataRespectingRateLimit(
+        for: self.request(), gate: gate, failureCache: cache)
+    }
+    #expect(Stub.capturedRequestCount() == countBefore)
+  }
+
+  @Test
+  func cancellationDoesNotMuteUrl() async throws {
+    Stub.reset()
+    Stub.handler = { _ in throw URLError(.cancelled) }
+
+    let session = makeSession()
+    let gate = RateLimitGate()
+    let cache = FailedRequestCache()
+
+    await #expect(throws: (any Error).self) {
+      try await session.dataRespectingRateLimit(
+        for: self.request(), gate: gate, failureCache: cache)
+    }
+
+    // Cancellation is user intent, not a real failure — the URL must
+    // remain available so a subsequent retry isn't blocked.
+    try await cache.ensureAvailable(for: "https://example.com/probe")
+  }
+
+  // MARK: - Success after a failure clears the URL
+
+  @Test
+  func twoHundredAfterFailureClearsTheUrl() async throws {
+    Stub.reset()
+    Stub.handler = { _ in (self.httpResponse(statusCode: 404), Data()) }
+
+    let session = makeSession()
+    let gate = RateLimitGate()
+    let cache = FailedRequestCache()
+
+    _ = try await session.dataRespectingRateLimit(
+      for: request(), gate: gate, failureCache: cache)
+
+    // Manually clear (simulating a successful retry after the cooldown
+    // expires) — verifies the path the helper itself takes on a 200.
+    await cache.recordSuccess(for: "https://example.com/probe")
+    try await cache.ensureAvailable(for: "https://example.com/probe")
   }
 }

--- a/Shared/Networking/FailedRequestCache.swift
+++ b/Shared/Networking/FailedRequestCache.swift
@@ -1,0 +1,104 @@
+// Shared/Networking/FailedRequestCache.swift
+import Foundation
+
+/// Thrown by `URLSession.dataRespectingRateLimit(for:gate:failureCache:)`
+/// when a recently-failed request is repeated before its cooldown
+/// expires. The `until` payload is the deadline after which the same
+/// request will be allowed through again.
+enum FailedRequestCacheError: Error, Equatable {
+  case cooldown(until: Date)
+}
+
+/// Per-URL cooldown so a request that just failed isn't re-issued in a
+/// hot loop.
+///
+/// Complements `RateLimitGate`: the gate is host-wide and trips only on
+/// `429` / `418` / `503-Retry-After` (so other URLs to the same host
+/// keep working); this cache is per-URL and trips on **any** non-2xx
+/// (so a different URL to the same host is unaffected). Together they
+/// handle the two common "spam loop" shapes:
+///
+/// - The host has rate-limited us → host-wide gate → fall through to
+///   the next provider in the price-service chain.
+/// - A specific resource permanently 404s (deleted ticker, unknown
+///   coin, malformed symbol) → per-URL cache → that one provider stops
+///   probing for that one resource until the cooldown lapses.
+///
+/// Concurrency: actor. The internal map is bounded by `maxEntries`;
+/// when full, expired entries are pruned in bulk before inserting a
+/// new entry. There is no per-eviction LRU because the typical working
+/// set (failing tickers / coin ids per session) is far below the
+/// default ceiling.
+actor FailedRequestCache {
+  private let cooldownDuration: TimeInterval
+  private let maxEntries: Int
+  private let now: @Sendable () -> Date
+  private var deadlines: [String: Date] = [:]
+
+  /// - Parameters:
+  ///   - cooldownDuration: How long a failed request is muted for.
+  ///     Defaults to 5 minutes — long enough that a chart redraw / live
+  ///     price tick won't re-probe immediately, short enough that a
+  ///     user fixing a typo and resubmitting still sees a fresh attempt.
+  ///   - maxEntries: Soft cap on the cache size. When exceeded, expired
+  ///     entries are pruned; if all entries are still active, the new
+  ///     entry replaces the oldest deadline. Defaults to 256 — covers a
+  ///     plausible session-worth of failing tickers without unbounded
+  ///     growth.
+  ///   - now: Closure returning the current time. Defaults to `Date()`.
+  init(
+    cooldownDuration: TimeInterval = 300,
+    maxEntries: Int = 256,
+    now: @Sendable @escaping () -> Date = { Date() }
+  ) {
+    self.cooldownDuration = cooldownDuration
+    self.maxEntries = maxEntries
+    self.now = now
+  }
+
+  /// Throws `FailedRequestCacheError.cooldown(until:)` when `key` is
+  /// still within its failure window. As a side effect, clears an
+  /// expired entry so the next call goes through cleanly.
+  func ensureAvailable(for key: String) throws {
+    guard let deadline = deadlines[key] else { return }
+    if now() < deadline {
+      throw FailedRequestCacheError.cooldown(until: deadline)
+    }
+    deadlines.removeValue(forKey: key)
+  }
+
+  /// Drops `key`'s entry. Called after a 2xx so a transient failure
+  /// doesn't outlive the recovery.
+  func recordSuccess(for key: String) {
+    deadlines.removeValue(forKey: key)
+  }
+
+  /// Records a failure for `key` and arms the cooldown.
+  @discardableResult
+  func recordFailure(for key: String) -> Date {
+    if deadlines.count >= maxEntries {
+      pruneExpired()
+      if deadlines.count >= maxEntries {
+        evictOldest()
+      }
+    }
+    let deadline = now().addingTimeInterval(cooldownDuration)
+    deadlines[key] = deadline
+    return deadline
+  }
+
+  private func pruneExpired() {
+    let currentTime = now()
+    deadlines = deadlines.filter { $0.value > currentTime }
+  }
+
+  /// Removes the entry with the smallest deadline so the cache can
+  /// accept a new entry under sustained-failure pressure. Picks one
+  /// deterministically; a tie on deadline removes whichever
+  /// `min(by:)` selects first, which is acceptable because both
+  /// entries have identical staleness.
+  private func evictOldest() {
+    guard let oldestKey = deadlines.min(by: { $0.value < $1.value })?.key else { return }
+    deadlines.removeValue(forKey: oldestKey)
+  }
+}

--- a/Shared/Networking/URLSession+RateLimited.swift
+++ b/Shared/Networking/URLSession+RateLimited.swift
@@ -6,83 +6,180 @@ private let rateLimitedFetchLogger = Logger(
   subsystem: "com.moolah.app", category: "RateLimitedFetch")
 
 extension URLSession {
-  /// Sends `request` while respecting `gate`. Wraps the standard
-  /// `data(for:)` call with a pre-flight gate check and post-flight
-  /// rate-limit detection.
+  /// Sends `request` while respecting `gate` and `failureCache`. Wraps
+  /// the standard `data(for:)` call with two pre-flight checks (host
+  /// rate-limit, per-URL recent-failure) and post-flight bookkeeping.
   ///
-  /// Pre-flight: if the gate is currently in cooldown, throws
-  /// `RateLimitGateError.cooldown(until:)` immediately without hitting
-  /// the network. This is what stops a price-fetch loop from continuing
-  /// to spam an upstream that has already 429ed us.
+  /// **Pre-flight:**
   ///
-  /// Post-flight: classifies the response by status code:
+  /// - If `gate` is in cooldown, throws
+  ///   `RateLimitGateError.cooldown(until:)` immediately. This is what
+  ///   stops a price-fetch loop from continuing to spam an upstream
+  ///   that has already 429ed us.
+  /// - If `failureCache` has a live entry for this request's URL,
+  ///   throws `FailedRequestCacheError.cooldown(until:)` immediately.
+  ///   This is what stops a hot loop from re-issuing the same failed
+  ///   request tens of times per session.
   ///
-  /// - `2xx`: records success on the gate and returns `(data, response)`
-  ///   so the caller's existing decode path runs.
-  /// - `429` (Too Many Requests) or `418` (Binance's "I'm a teapot",
-  ///   meaning "you ignored 429 and you're now temporarily banned"):
-  ///   trips the gate using `Retry-After` (or exponential backoff
-  ///   when the header is absent) and throws
-  ///   `RateLimitGateError.cooldown(until:)`.
-  /// - `503` (Service Unavailable) **with** a `Retry-After` header:
-  ///   trips the gate the same way. A 503 without `Retry-After` is
-  ///   treated as a transient server fault and propagated as-is —
-  ///   the next caller probes again rather than waiting blindly.
-  /// - Any other status: returns `(data, response)` unchanged. The
-  ///   caller's existing 2xx check fires its own error (typically
-  ///   `URLError(.badServerResponse)`); the gate state is left
-  ///   untouched because the error isn't rate-limit-related.
+  /// **Post-flight:** classifies the outcome.
+  ///
+  /// - Network call threw (DNS failure, offline, timeout, server hang
+  ///   up, etc., except cancellation): records the URL as failing in
+  ///   `failureCache` and rethrows. Cancellation propagates without
+  ///   muting — it is user-driven, not a real failure.
+  /// - Response is `2xx`: records success on both `gate` and
+  ///   `failureCache`, returns `(data, response)` for the caller's
+  ///   existing decode path.
+  /// - Response is `429` / `418`: trips the host-wide gate (via
+  ///   `Retry-After` or exponential backoff), records into
+  ///   `failureCache`, throws `RateLimitGateError.cooldown`.
+  /// - Response is `503` with `Retry-After`: trips the gate the same
+  ///   way and records into `failureCache`. A `503` without
+  ///   `Retry-After` doesn't trip the gate (the host as a whole is
+  ///   still responding) but still records to `failureCache` so the
+  ///   next caller doesn't immediately re-probe.
+  /// - Any other non-2xx (e.g. `404`, `400`, `500`): records to
+  ///   `failureCache` and returns `(data, response)` so the caller's
+  ///   existing status-check throws its usual error.
+  /// - Non-`HTTPURLResponse`: returns `(data, response)` unchanged
+  ///   without recording (extremely unlikely for HTTP requests).
   ///
   /// The non-rate-limit-error pass-through deliberately does **not**
-  /// reset the failure counter — the counter only ever increments on a
-  /// rate-limit response and only ever resets on a 2xx, so a stretch of
-  /// 5xx errors between 429s doesn't reset the exponential backoff
-  /// progression.
+  /// reset the gate's failure counter — the counter only ever increments
+  /// on a rate-limit response and only ever resets on a 2xx, so a
+  /// stretch of 5xx errors between 429s doesn't reset the exponential
+  /// backoff progression.
   ///
   /// The `Retry-After` HTTP-date parser is anchored at `Date()` rather
   /// than the gate's injected clock. The two are independent: the
   /// parser only converts an HTTP-date into a relative-second offset
   /// for the rare HTTP-date `Retry-After`, while the gate uses its own
-  /// clock to compute the cooldown deadline from that offset. Real
-  /// servers almost universally return delta-seconds, so the parser
-  /// branch that consults the clock is exercised in tests but rarely
-  /// in production.
+  /// clock to compute the cooldown deadline from that offset.
   func dataRespectingRateLimit(
     for request: URLRequest,
-    gate: RateLimitGate
+    gate: RateLimitGate,
+    failureCache: FailedRequestCache
   ) async throws -> (Data, URLResponse) {
     try await gate.ensureAvailable()
-    let (data, response) = try await self.data(for: request)
-    guard let http = response as? HTTPURLResponse else {
-      return (data, response)
+    let cacheKey = request.url?.absoluteString
+    if let cacheKey {
+      try await failureCache.ensureAvailable(for: cacheKey)
     }
+    let data: Data
+    let response: URLResponse
+    do {
+      (data, response) = try await self.data(for: request)
+    } catch {
+      if !Self.isCancellation(error), let cacheKey {
+        let deadline = await failureCache.recordFailure(for: cacheKey)
+        rateLimitedFetchLogger.notice(
+          """
+          Transport failure for \(request.url?.host ?? "?", privacy: .public): \
+          \(error.localizedDescription, privacy: .public); URL muted \
+          until \(deadline.timeIntervalSince1970, privacy: .public)
+          """
+        )
+      }
+      throw error
+    }
+    try await Self.classify(
+      response: response,
+      request: request,
+      cacheKey: cacheKey,
+      gate: gate,
+      failureCache: failureCache
+    )
+    return (data, response)
+  }
+
+  /// Records the `gate` and `failureCache` side effects for an HTTP
+  /// response. Throws `RateLimitGateError.cooldown` for rate-limit
+  /// responses; returns normally for everything else (including non-2xx
+  /// statuses that don't trip the gate). Extracted from the main
+  /// function to keep both inside SwiftLint's `function_body_length`
+  /// budget.
+  private static func classify(
+    response: URLResponse,
+    request: URLRequest,
+    cacheKey: String?,
+    gate: RateLimitGate,
+    failureCache: FailedRequestCache
+  ) async throws {
+    guard let http = response as? HTTPURLResponse else { return }
     let retryAfter = http.retryAfterSeconds(now: Date())
     let host = request.url?.host ?? "?"
     switch http.statusCode {
     case 200...299:
       await gate.recordSuccess()
+      if let cacheKey {
+        await failureCache.recordSuccess(for: cacheKey)
+      }
     case 429, 418:
-      let deadline = await gate.recordRateLimit(retryAfter: retryAfter)
-      rateLimitedFetchLogger.warning(
-        """
-        Rate-limited (HTTP \(http.statusCode, privacy: .public)) by \
-        \(host, privacy: .public); cooldown until \
-        \(deadline.timeIntervalSince1970, privacy: .public)
-        """
+      try await tripGate(
+        outcome: .init(retryAfter: retryAfter, statusCode: http.statusCode, host: host),
+        cacheKey: cacheKey,
+        gate: gate,
+        failureCache: failureCache
       )
-      throw RateLimitGateError.cooldown(until: deadline)
     case 503 where retryAfter != nil:
-      let deadline = await gate.recordRateLimit(retryAfter: retryAfter)
-      rateLimitedFetchLogger.warning(
-        """
-        503 with Retry-After from \(host, privacy: .public); \
-        cooldown until \(deadline.timeIntervalSince1970, privacy: .public)
-        """
+      try await tripGate(
+        outcome: .init(retryAfter: retryAfter, statusCode: http.statusCode, host: host),
+        cacheKey: cacheKey,
+        gate: gate,
+        failureCache: failureCache
       )
-      throw RateLimitGateError.cooldown(until: deadline)
     default:
-      break
+      if let cacheKey {
+        let deadline = await failureCache.recordFailure(for: cacheKey)
+        rateLimitedFetchLogger.notice(
+          """
+          Request failed (HTTP \(http.statusCode, privacy: .public)) for \
+          \(host, privacy: .public); URL muted until \
+          \(deadline.timeIntervalSince1970, privacy: .public)
+          """
+        )
+      }
     }
-    return (data, response)
+  }
+
+  /// Bundle of the per-response inputs `tripGate` needs, kept as a
+  /// nested struct so the surrounding function stays under SwiftLint's
+  /// `function_parameter_count` budget (5).
+  private struct RateLimitOutcome {
+    let retryAfter: TimeInterval?
+    let statusCode: Int
+    let host: String
+  }
+
+  private static func tripGate(
+    outcome: RateLimitOutcome,
+    cacheKey: String?,
+    gate: RateLimitGate,
+    failureCache: FailedRequestCache
+  ) async throws {
+    let deadline = await gate.recordRateLimit(retryAfter: outcome.retryAfter)
+    if let cacheKey {
+      await failureCache.recordFailure(for: cacheKey)
+    }
+    rateLimitedFetchLogger.warning(
+      """
+      Rate-limited (HTTP \(outcome.statusCode, privacy: .public)) by \
+      \(outcome.host, privacy: .public); cooldown until \
+      \(deadline.timeIntervalSince1970, privacy: .public)
+      """
+    )
+    throw RateLimitGateError.cooldown(until: deadline)
+  }
+
+  /// `URLSession.data(for:)` throws `URLError(.cancelled)` when the
+  /// request is explicitly cancelled, while `Task.cancel()` propagates
+  /// `CancellationError` through the `try await`. Neither is a real
+  /// network failure — they reflect user intent and shouldn't mute the
+  /// URL. Anything else (DNS failure, offline, timeout, server hangup)
+  /// counts as a failure for the per-URL cache.
+  private static func isCancellation(_ error: any Error) -> Bool {
+    if error is CancellationError { return true }
+    if let urlError = error as? URLError, urlError.code == .cancelled { return true }
+    return false
   }
 }


### PR DESCRIPTION
## Summary

Extends [#819](https://github.com/ajsutton/moolah-native/pull/819) with a per-URL `FailedRequestCache` so that **any** failing request — not just `429` / `418` / `503-Retry-After` — is muted for a short cooldown before the same URL is hit again. Pairs with the existing host-wide `RateLimitGate`:

- Host-wide gate: *this provider is rate-limited* → fall through to the next provider.
- Per-URL cache: *this specific resource keeps failing* → that one provider stops probing for that one resource for the cooldown window.

Trips on:

- HTTP 4xx (e.g. `404` for a deleted ticker / unknown coin id) and 5xx
- Transport errors (DNS, offline, timeout, server hangup)
- All rate-limit responses already handled by the gate (defence in depth)

Skips on `URLError(.cancelled)` / `CancellationError` — user-driven, not a real failure.

Default cooldown is 5 minutes; cache is bounded at 256 entries with expired-first pruning and oldest-eviction fallback.

## Test plan

- [x] 33 rate-limit tests (`FailedRequestCacheTests`, `URLSessionRateLimitTests`, `RateLimitGateTests`, `RetryAfterSecondsTests`) on macOS and iOS
- [x] `just format-check` clean
- [x] `just test-mac` 2647 tests pass
- [ ] Live: confirm a 404'd ticker stops being re-probed on subsequent chart refreshes

🤖 Generated with [Claude Code](https://claude.com/claude-code)