### PR TITLE
feat(network): exponential backoff for transport-error retries

### DIFF
--- a/MoolahTests/Shared/FailedRequestCacheTests.swift
+++ b/MoolahTests/Shared/FailedRequestCacheTests.swift
@@ -41,14 +41,14 @@ struct FailedRequestCacheTests {
     try await cache.ensureAvailable(for: "https://example.com/x")
   }
 
-  // MARK: - Failure muting
+  // MARK: - HTTP failure cooldown (fixed)
 
   @Test
-  func recordedFailureIsMutedUntilCooldownExpires() async throws {
+  func httpFailureIsMutedUntilFixedCooldownExpires() async throws {
     let clock = FakeClock()
-    let cache = FailedRequestCache(cooldownDuration: 60, now: { clock.now() })
+    let cache = FailedRequestCache(httpCooldownDuration: 60, now: { clock.now() })
 
-    let deadline = await cache.recordFailure(for: "https://example.com/x")
+    let deadline = await cache.recordHTTPFailure(for: "https://example.com/x")
     #expect(deadline == clock.now().addingTimeInterval(60))
 
     // Just before expiry — still muted.
@@ -63,11 +63,122 @@ struct FailedRequestCacheTests {
   }
 
   @Test
+  func repeatedHTTPFailuresKeepFixedCooldown() async throws {
+    let clock = FakeClock()
+    let cache = FailedRequestCache(httpCooldownDuration: 60, now: { clock.now() })
+
+    // The HTTP path is intentionally not exponential — every recorded
+    // failure resets to a fresh fixed cooldown anchored at "now".
+    _ = await cache.recordHTTPFailure(for: "https://example.com/x")
+    clock.advance(30)
+    let second = await cache.recordHTTPFailure(for: "https://example.com/x")
+    #expect(second == clock.now().addingTimeInterval(60))
+  }
+
+  // MARK: - Transport failure cooldown (exponential)
+
+  @Test
+  func transportFailureUsesBaseBackoff() async throws {
+    let clock = FakeClock()
+    let cache = FailedRequestCache(
+      transportBaseBackoff: 5, transportMaxBackoff: 120, now: { clock.now() })
+
+    let deadline = await cache.recordTransportFailure(for: "https://example.com/x")
+    #expect(deadline == clock.now().addingTimeInterval(5))
+  }
+
+  @Test
+  func consecutiveTransportFailuresGrowExponentially() async throws {
+    let clock = FakeClock()
+    let cache = FailedRequestCache(
+      transportBaseBackoff: 5, transportMaxBackoff: 120, now: { clock.now() })
+
+    let first = await cache.recordTransportFailure(for: "https://example.com/x")
+    #expect(first == clock.now().addingTimeInterval(5))
+
+    let second = await cache.recordTransportFailure(for: "https://example.com/x")
+    #expect(second == clock.now().addingTimeInterval(10))
+
+    let third = await cache.recordTransportFailure(for: "https://example.com/x")
+    #expect(third == clock.now().addingTimeInterval(20))
+
+    let fourth = await cache.recordTransportFailure(for: "https://example.com/x")
+    #expect(fourth == clock.now().addingTimeInterval(40))
+  }
+
+  @Test
+  func transportBackoffSaturatesAtMax() async throws {
+    let clock = FakeClock()
+    let cache = FailedRequestCache(
+      transportBaseBackoff: 5, transportMaxBackoff: 30, now: { clock.now() })
+
+    _ = await cache.recordTransportFailure(for: "https://example.com/x")
+    _ = await cache.recordTransportFailure(for: "https://example.com/x")
+    _ = await cache.recordTransportFailure(for: "https://example.com/x")
+    let fourth = await cache.recordTransportFailure(for: "https://example.com/x")
+
+    #expect(fourth == clock.now().addingTimeInterval(30))
+  }
+
+  @Test
+  func transportFailuresAreTrackedPerURL() async throws {
+    let clock = FakeClock()
+    let cache = FailedRequestCache(
+      transportBaseBackoff: 5, transportMaxBackoff: 120, now: { clock.now() })
+
+    // URL `a` racks up two transport failures.
+    _ = await cache.recordTransportFailure(for: "https://example.com/a")
+    _ = await cache.recordTransportFailure(for: "https://example.com/a")
+
+    // URL `b`'s first failure is still at base backoff — counters are
+    // independent, otherwise an unrelated URL would inherit punishment.
+    let bFirst = await cache.recordTransportFailure(for: "https://example.com/b")
+    #expect(bFirst == clock.now().addingTimeInterval(5))
+  }
+
+  @Test
+  func httpFailureResetsTransportCounter() async throws {
+    let clock = FakeClock()
+    let cache = FailedRequestCache(
+      httpCooldownDuration: 60,
+      transportBaseBackoff: 5,
+      transportMaxBackoff: 120,
+      now: { clock.now() })
+
+    _ = await cache.recordTransportFailure(for: "https://example.com/x")
+    _ = await cache.recordTransportFailure(for: "https://example.com/x")
+    // Server then responds with a 4xx/5xx — proves the transport path
+    // is healthy, so subsequent transport failures should restart at
+    // base backoff rather than continue the exponential climb.
+    _ = await cache.recordHTTPFailure(for: "https://example.com/x")
+
+    clock.advance(61)  // wait out the HTTP cooldown
+    let next = await cache.recordTransportFailure(for: "https://example.com/x")
+    #expect(next == clock.now().addingTimeInterval(5))
+  }
+
+  @Test
+  func successResetsTransportCounter() async throws {
+    let clock = FakeClock()
+    let cache = FailedRequestCache(
+      transportBaseBackoff: 5, transportMaxBackoff: 120, now: { clock.now() })
+
+    _ = await cache.recordTransportFailure(for: "https://example.com/x")
+    _ = await cache.recordTransportFailure(for: "https://example.com/x")
+    await cache.recordSuccess(for: "https://example.com/x")
+
+    let next = await cache.recordTransportFailure(for: "https://example.com/x")
+    #expect(next == clock.now().addingTimeInterval(5))
+  }
+
+  // MARK: - Cross-cutting
+
+  @Test
   func differentKeysAreIndependent() async throws {
     let clock = FakeClock()
-    let cache = FailedRequestCache(cooldownDuration: 60, now: { clock.now() })
+    let cache = FailedRequestCache(httpCooldownDuration: 60, now: { clock.now() })
 
-    _ = await cache.recordFailure(for: "https://example.com/a")
+    _ = await cache.recordHTTPFailure(for: "https://example.com/a")
 
     // A different URL must NOT be affected — this is the entire point
     // of a per-URL cache versus a host-wide gate.
@@ -77,9 +188,9 @@ struct FailedRequestCacheTests {
   @Test
   func recordSuccessClearsEntry() async throws {
     let clock = FakeClock()
-    let cache = FailedRequestCache(cooldownDuration: 60, now: { clock.now() })
+    let cache = FailedRequestCache(httpCooldownDuration: 60, now: { clock.now() })
 
-    _ = await cache.recordFailure(for: "https://example.com/x")
+    _ = await cache.recordHTTPFailure(for: "https://example.com/x")
     await cache.recordSuccess(for: "https://example.com/x")
 
     // The 2xx is evidence that the resource is reachable; cooldown
@@ -93,15 +204,15 @@ struct FailedRequestCacheTests {
   func boundedByMaxEntriesViaPruningExpired() async throws {
     let clock = FakeClock()
     let cache = FailedRequestCache(
-      cooldownDuration: 60, maxEntries: 2, now: { clock.now() })
+      httpCooldownDuration: 60, maxEntries: 2, now: { clock.now() })
 
-    _ = await cache.recordFailure(for: "https://example.com/a")
-    _ = await cache.recordFailure(for: "https://example.com/b")
+    _ = await cache.recordHTTPFailure(for: "https://example.com/a")
+    _ = await cache.recordHTTPFailure(for: "https://example.com/b")
 
     // Both entries are still within their cooldowns. Letting them
     // expire and then inserting a third lets the cache prune.
     clock.advance(61)
-    _ = await cache.recordFailure(for: "https://example.com/c")
+    _ = await cache.recordHTTPFailure(for: "https://example.com/c")
 
     // The expired ones are gone — open again.
     try await cache.ensureAvailable(for: "https://example.com/a")
@@ -116,15 +227,15 @@ struct FailedRequestCacheTests {
   func boundedByMaxEntriesViaOldestEviction() async throws {
     let clock = FakeClock()
     let cache = FailedRequestCache(
-      cooldownDuration: 600, maxEntries: 2, now: { clock.now() })
+      httpCooldownDuration: 600, maxEntries: 2, now: { clock.now() })
 
-    _ = await cache.recordFailure(for: "https://example.com/a")
+    _ = await cache.recordHTTPFailure(for: "https://example.com/a")
     clock.advance(1)
-    _ = await cache.recordFailure(for: "https://example.com/b")
+    _ = await cache.recordHTTPFailure(for: "https://example.com/b")
     clock.advance(1)
     // All three are within their (long) cooldown; nothing to prune.
     // The oldest (`a`) gets evicted to make room for `c`.
-    _ = await cache.recordFailure(for: "https://example.com/c")
+    _ = await cache.recordHTTPFailure(for: "https://example.com/c")
 
     try await cache.ensureAvailable(for: "https://example.com/a")
     await #expect(throws: FailedRequestCacheError.self) {
@@ -140,14 +251,14 @@ struct FailedRequestCacheTests {
   @Test
   func ensureAvailableClearsExpiredEntry() async throws {
     let clock = FakeClock()
-    let cache = FailedRequestCache(cooldownDuration: 60, now: { clock.now() })
+    let cache = FailedRequestCache(httpCooldownDuration: 60, now: { clock.now() })
 
-    _ = await cache.recordFailure(for: "https://example.com/x")
+    _ = await cache.recordHTTPFailure(for: "https://example.com/x")
     clock.advance(61)
     try await cache.ensureAvailable(for: "https://example.com/x")
     // After the side-effect prune, a subsequent failure starts a fresh
     // cooldown anchored at the current clock — same shape as the gate.
-    let next = await cache.recordFailure(for: "https://example.com/x")
+    let next = await cache.recordHTTPFailure(for: "https://example.com/x")
     #expect(next == clock.now().addingTimeInterval(60))
   }
 }

--- a/Shared/Networking/FailedRequestCache.swift
+++ b/Shared/Networking/FailedRequestCache.swift
@@ -14,15 +14,25 @@ enum FailedRequestCacheError: Error, Equatable {
 ///
 /// Complements `RateLimitGate`: the gate is host-wide and trips only on
 /// `429` / `418` / `503-Retry-After` (so other URLs to the same host
-/// keep working); this cache is per-URL and trips on **any** non-2xx
+/// keep working); this cache is per-URL and trips on **any** failure
 /// (so a different URL to the same host is unaffected). Together they
 /// handle the two common "spam loop" shapes:
 ///
 /// - The host has rate-limited us → host-wide gate → fall through to
 ///   the next provider in the price-service chain.
-/// - A specific resource permanently 404s (deleted ticker, unknown
-///   coin, malformed symbol) → per-URL cache → that one provider stops
-///   probing for that one resource until the cooldown lapses.
+/// - A specific resource keeps failing (deleted ticker, unknown coin,
+///   network blip) → per-URL cache → that one provider stops probing
+///   for that one resource until the cooldown lapses.
+///
+/// **Two failure modes, two cadences.** HTTP failures (`4xx` / `5xx`
+/// responses from the server) get a fixed cooldown — if the server
+/// says "no" once, it'll probably say "no" for a while, so the wait is
+/// long enough to break a refresh loop but short enough that a user
+/// fixing a typo still sees a fresh attempt. Transport failures (DNS,
+/// offline, timeout, server hangup) get **per-URL exponential backoff
+/// capped at 2 minutes** instead — the network coming back is a
+/// matter of seconds, not minutes, so the first retry is fast and
+/// only a sustained outage drags out the wait.
 ///
 /// Concurrency: actor. The internal map is bounded by `maxEntries`;
 /// when full, expired entries are pruned in bulk before inserting a
@@ -30,28 +40,49 @@ enum FailedRequestCacheError: Error, Equatable {
 /// set (failing tickers / coin ids per session) is far below the
 /// default ceiling.
 actor FailedRequestCache {
-  private let cooldownDuration: TimeInterval
+  private struct Entry {
+    var deadline: Date
+    /// Number of consecutive transport failures recorded for this URL.
+    /// Used to compute the next exponential backoff. Reset to 0 on
+    /// `recordHTTPFailure` (the host responded — transport is fine)
+    /// and on `recordSuccess` (entry removed entirely).
+    var consecutiveTransportFailures: Int
+  }
+
+  private let httpCooldownDuration: TimeInterval
+  private let transportBaseBackoff: TimeInterval
+  private let transportMaxBackoff: TimeInterval
   private let maxEntries: Int
   private let now: @Sendable () -> Date
-  private var deadlines: [String: Date] = [:]
+  private var entries: [String: Entry] = [:]
 
   /// - Parameters:
-  ///   - cooldownDuration: How long a failed request is muted for.
-  ///     Defaults to 5 minutes — long enough that a chart redraw / live
-  ///     price tick won't re-probe immediately, short enough that a
-  ///     user fixing a typo and resubmitting still sees a fresh attempt.
-  ///   - maxEntries: Soft cap on the cache size. When exceeded, expired
-  ///     entries are pruned; if all entries are still active, the new
-  ///     entry replaces the oldest deadline. Defaults to 256 — covers a
-  ///     plausible session-worth of failing tickers without unbounded
-  ///     growth.
+  ///   - httpCooldownDuration: How long a `4xx` / `5xx` response keeps
+  ///     a URL muted. Defaults to 5 minutes — long enough that a
+  ///     chart redraw / live price tick won't re-probe immediately,
+  ///     short enough that a user fixing a typo and resubmitting
+  ///     still sees a fresh attempt.
+  ///   - transportBaseBackoff: First-failure backoff for transport
+  ///     errors. Defaults to 5 seconds — short enough that a
+  ///     transient blip clears almost immediately on the user's next
+  ///     interaction.
+  ///   - transportMaxBackoff: Ceiling for transport-error backoff.
+  ///     Defaults to 2 minutes — beyond this the user is going to
+  ///     retry manually anyway.
+  ///   - maxEntries: Soft cap on the cache size. When exceeded,
+  ///     expired entries are pruned; if all entries are still active,
+  ///     the new entry replaces the oldest deadline. Defaults to 256.
   ///   - now: Closure returning the current time. Defaults to `Date()`.
   init(
-    cooldownDuration: TimeInterval = 300,
+    httpCooldownDuration: TimeInterval = 300,
+    transportBaseBackoff: TimeInterval = 5,
+    transportMaxBackoff: TimeInterval = 120,
     maxEntries: Int = 256,
     now: @Sendable @escaping () -> Date = { Date() }
   ) {
-    self.cooldownDuration = cooldownDuration
+    self.httpCooldownDuration = httpCooldownDuration
+    self.transportBaseBackoff = transportBaseBackoff
+    self.transportMaxBackoff = transportMaxBackoff
     self.maxEntries = maxEntries
     self.now = now
   }
@@ -60,36 +91,65 @@ actor FailedRequestCache {
   /// still within its failure window. As a side effect, clears an
   /// expired entry so the next call goes through cleanly.
   func ensureAvailable(for key: String) throws {
-    guard let deadline = deadlines[key] else { return }
-    if now() < deadline {
-      throw FailedRequestCacheError.cooldown(until: deadline)
+    guard let entry = entries[key] else { return }
+    if now() < entry.deadline {
+      throw FailedRequestCacheError.cooldown(until: entry.deadline)
     }
-    deadlines.removeValue(forKey: key)
+    entries.removeValue(forKey: key)
   }
 
-  /// Drops `key`'s entry. Called after a 2xx so a transient failure
+  /// Drops `key`'s entry — both the deadline and the transport
+  /// failure counter. Called after a 2xx so a transient failure
   /// doesn't outlive the recovery.
   func recordSuccess(for key: String) {
-    deadlines.removeValue(forKey: key)
+    entries.removeValue(forKey: key)
   }
 
-  /// Records a failure for `key` and arms the cooldown.
+  /// Records an HTTP-level failure (4xx / 5xx) for `key`. Uses a fixed
+  /// cooldown — if the server has explicitly said "no", a brief wait
+  /// and an immediate retry are equally likely to produce the same
+  /// "no", so polling sooner doesn't help.
+  ///
+  /// Resets the transport failure counter on the assumption that the
+  /// host responding at all means the network path is healthy.
   @discardableResult
-  func recordFailure(for key: String) -> Date {
-    if deadlines.count >= maxEntries {
-      pruneExpired()
-      if deadlines.count >= maxEntries {
-        evictOldest()
-      }
-    }
-    let deadline = now().addingTimeInterval(cooldownDuration)
-    deadlines[key] = deadline
+  func recordHTTPFailure(for key: String) -> Date {
+    boundIfNeeded()
+    let deadline = now().addingTimeInterval(httpCooldownDuration)
+    entries[key] = Entry(deadline: deadline, consecutiveTransportFailures: 0)
     return deadline
+  }
+
+  /// Records a transport-level failure (DNS, offline, timeout) for
+  /// `key`. Uses **per-URL exponential backoff** — `base * 2^(n-1)`,
+  /// capped at `transportMaxBackoff`. The first retry is fast (a
+  /// transient connectivity blip clears in seconds) and the wait
+  /// only grows when the outage is sustained.
+  @discardableResult
+  func recordTransportFailure(for key: String) -> Date {
+    boundIfNeeded()
+    let consecutive = (entries[key]?.consecutiveTransportFailures ?? 0) + 1
+    // 5s, 10s, 20s, ..., capped at `transportMaxBackoff`. `pow` on
+    // `Double` is total — overflow saturates to `.infinity`, which
+    // `min(_:_:)` collapses back to the cap.
+    let exp = transportBaseBackoff * pow(2.0, Double(max(0, consecutive - 1)))
+    let backoff = min(exp, transportMaxBackoff)
+    let deadline = now().addingTimeInterval(backoff)
+    entries[key] = Entry(deadline: deadline, consecutiveTransportFailures: consecutive)
+    return deadline
+  }
+
+  private func boundIfNeeded() {
+    guard entries.count >= maxEntries else { return }
+    pruneExpired()
+    if entries.count >= maxEntries {
+      evictOldest()
+    }
   }
 
   private func pruneExpired() {
     let currentTime = now()
-    deadlines = deadlines.filter { $0.value > currentTime }
+    entries = entries.filter { $0.value.deadline > currentTime }
   }
 
   /// Removes the entry with the smallest deadline so the cache can
@@ -98,7 +158,9 @@ actor FailedRequestCache {
   /// `min(by:)` selects first, which is acceptable because both
   /// entries have identical staleness.
   private func evictOldest() {
-    guard let oldestKey = deadlines.min(by: { $0.value < $1.value })?.key else { return }
-    deadlines.removeValue(forKey: oldestKey)
+    guard
+      let oldestKey = entries.min(by: { $0.value.deadline < $1.value.deadline })?.key
+    else { return }
+    entries.removeValue(forKey: oldestKey)
   }
 }

--- a/Shared/Networking/URLSession+RateLimited.swift
+++ b/Shared/Networking/URLSession+RateLimited.swift
@@ -21,26 +21,30 @@ extension URLSession {
   ///   This is what stops a hot loop from re-issuing the same failed
   ///   request tens of times per session.
   ///
-  /// **Post-flight:** classifies the outcome.
+  /// **Post-flight:** classifies the outcome and records into the
+  /// failure cache using the variant that matches the error class —
+  /// HTTP failures get a fixed-length cooldown, transport failures
+  /// get per-URL exponential backoff (capped at 2 minutes by default).
   ///
   /// - Network call threw (DNS failure, offline, timeout, server hang
-  ///   up, etc., except cancellation): records the URL as failing in
-  ///   `failureCache` and rethrows. Cancellation propagates without
-  ///   muting — it is user-driven, not a real failure.
+  ///   up, etc., except cancellation): records via
+  ///   `failureCache.recordTransportFailure(for:)` and rethrows.
+  ///   Cancellation propagates without muting — it is user-driven,
+  ///   not a real failure.
   /// - Response is `2xx`: records success on both `gate` and
   ///   `failureCache`, returns `(data, response)` for the caller's
   ///   existing decode path.
   /// - Response is `429` / `418`: trips the host-wide gate (via
-  ///   `Retry-After` or exponential backoff), records into
-  ///   `failureCache`, throws `RateLimitGateError.cooldown`.
+  ///   `Retry-After` or exponential backoff), records via
+  ///   `recordHTTPFailure`, throws `RateLimitGateError.cooldown`.
   /// - Response is `503` with `Retry-After`: trips the gate the same
-  ///   way and records into `failureCache`. A `503` without
+  ///   way and records via `recordHTTPFailure`. A `503` without
   ///   `Retry-After` doesn't trip the gate (the host as a whole is
-  ///   still responding) but still records to `failureCache` so the
-  ///   next caller doesn't immediately re-probe.
-  /// - Any other non-2xx (e.g. `404`, `400`, `500`): records to
-  ///   `failureCache` and returns `(data, response)` so the caller's
-  ///   existing status-check throws its usual error.
+  ///   still responding) but still records via `recordHTTPFailure` so
+  ///   the next caller doesn't immediately re-probe.
+  /// - Any other non-2xx (e.g. `404`, `400`, `500`): records via
+  ///   `recordHTTPFailure` and returns `(data, response)` so the
+  ///   caller's existing status-check throws its usual error.
   /// - Non-`HTTPURLResponse`: returns `(data, response)` unchanged
   ///   without recording (extremely unlikely for HTTP requests).
   ///
@@ -71,7 +75,7 @@ extension URLSession {
       (data, response) = try await self.data(for: request)
     } catch {
       if !Self.isCancellation(error), let cacheKey {
-        let deadline = await failureCache.recordFailure(for: cacheKey)
+        let deadline = await failureCache.recordTransportFailure(for: cacheKey)
         rateLimitedFetchLogger.notice(
           """
           Transport failure for \(request.url?.host ?? "?", privacy: .public): \
@@ -130,7 +134,7 @@ extension URLSession {
       )
     default:
       if let cacheKey {
-        let deadline = await failureCache.recordFailure(for: cacheKey)
+        let deadline = await failureCache.recordHTTPFailure(for: cacheKey)
         rateLimitedFetchLogger.notice(
           """
           Request failed (HTTP \(http.statusCode, privacy: .public)) for \
@@ -159,7 +163,7 @@ extension URLSession {
   ) async throws {
     let deadline = await gate.recordRateLimit(retryAfter: outcome.retryAfter)
     if let cacheKey {
-      await failureCache.recordFailure(for: cacheKey)
+      await failureCache.recordHTTPFailure(for: cacheKey)
     }
     rateLimitedFetchLogger.warning(
       """


### PR DESCRIPTION
## Summary

Splits `FailedRequestCache` into two failure modes so the cooldown matches the failure shape rather than treating every error the same:

| Failure | Cooldown | Why |
|---|---|---|
| HTTP `4xx` / `5xx` | Fixed 5 min | The server explicitly said "no" — that response isn't going to change in seconds. |
| Transport (DNS, offline, timeout, hangup) | Per-URL exponential `5s → 10s → 20s → 40s → 80s → 120s` | The network coming back is a matter of seconds, so the first retry is fast; only a sustained outage drags the wait out. |

`recordFailure` is replaced by `recordHTTPFailure` and `recordTransportFailure`. An HTTP failure resets the per-URL transport counter (the host responded — transport is fine), success clears the entry entirely.

Pairs with [#819](https://github.com/ajsutton/moolah-native/pull/819) (host-wide gate for `429` / `418` / `503-Retry-After`) and [#820](https://github.com/ajsutton/moolah-native/pull/820) (per-URL muting for any failure).

## Test plan

- [x] 40 rate-limit tests on macOS and iOS (existing 33 + 7 new transport-backoff tests covering exponential growth, max cap, per-URL counters, HTTP-resets-transport, success-resets-transport)
- [x] `just format-check` clean
- [x] `just test-mac` 2654 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)