### PR TITLE
fix(transactions): skip safeAreaInset when topAccessory is EmptyView

### DIFF
--- a/Features/Transactions/Views/TransactionListView.swift
+++ b/Features/Transactions/Views/TransactionListView.swift
@@ -34,6 +34,12 @@ struct TransactionListView<TopAccessory: View>: View {
   /// duplicate `com.apple.SwiftUI.search` item the next time the parent's
   /// body re-evaluates. See `guides/UI_GUIDE.md` §3 — view-tree stability
   /// for views with toolbars.
+  ///
+  /// When `TopAccessory == EmptyView` (the no-arg convenience init),
+  /// `safeAreaInset` is skipped entirely. Applying the inset with an
+  /// `EmptyView` payload trips a SwiftUI/AppKit interop bug that
+  /// collapses the modified view to zero size when it's hosted inside
+  /// an `NSHostingView` — see `listWithOptionalTopAccessory`.
   let topAccessory: TopAccessory
 
   /// When non-nil, the parent owns the selection and handles the inspector.
@@ -159,9 +165,27 @@ struct TransactionListView<TopAccessory: View>: View {
   @State var transactionPendingDelete: Transaction.ID?
   @State var createRuleFromTransaction: Transaction?
 
+  /// `listView` with `safeAreaInset` applied only when there is a real
+  /// accessory to render. Skipping the inset when `TopAccessory == EmptyView`
+  /// works around a SwiftUI/AppKit interop bug where
+  /// `safeAreaInset(edge: .top, spacing: 0) { EmptyView() }` collapses the
+  /// modified view to zero size when hosted inside an `NSHostingView`
+  /// (`ResizableVSplit`'s arranged subviews) — the symptom is the embedded
+  /// transactions list disappearing entirely in
+  /// `InvestmentAccountView.positionTrackedLayout`. `_ConditionalContent`
+  /// branches are constant for a given concrete `TransactionListView<T>`
+  /// because `T` doesn't change at runtime, so SwiftUI's view-tree identity
+  /// for `listView` is stable across re-renders.
+  @ViewBuilder private var listWithOptionalTopAccessory: some View {
+    if TopAccessory.self == EmptyView.self {
+      listView
+    } else {
+      listView.safeAreaInset(edge: .top, spacing: 0) { topAccessory }
+    }
+  }
+
   var body: some View {
-    listView
-      .safeAreaInset(edge: .top, spacing: 0) { topAccessory }
+    listWithOptionalTopAccessory
       .modifier(
         OptionalTransactionInspector(
           enabled: handlesOwnInspector,


### PR DESCRIPTION
## Summary

- `InvestmentAccountView`'s `.calculatedFromTrades` layout hosts the embedded `TransactionListView` inside `ResizableVSplit` — an `NSHostingView` arranged subview of `NSSplitView`. In that hosting context, `safeAreaInset(edge: .top, spacing: 0) { EmptyView() }` collapses the modified view to **zero size**, so the bottom pane renders empty.
- Symptom: investment accounts in trades mode with multi-instrument positions (e.g. Trust Shares) had their transactions list entirely missing — no rows, no empty state, just blank space.
- Fix: skip `safeAreaInset` when `TopAccessory == EmptyView`. The crypto-wallet path (`WalletAccountHeaderView`) is unaffected because the inset has real content; the bug fires only with an `EmptyView` payload.
- Preserves the original commit ([08a99a2d](https://github.com/ajsutton/moolah-native/commit/08a99a2d)) view-tree-stability rationale: `TopAccessory` is a generic parameter that doesn't change at runtime for a given concrete `TransactionListView<T>`, so SwiftUI's identity for `listView` is stable across re-renders.

## Test plan

- [x] Manual: Trust Shares (calculatedFromTrades, multi-instrument) now shows transactions under positions split. (Was: blank.)
- [x] Manual: Trust Ethereum (crypto, wallet header path) — wallet header + positions + transactions all render. (No regression.)
- [x] Manual: CommBank (regular bank, EmptyView accessory in NavigationSplitView, not NSHostingView) — list renders. (No regression.)
- [x] `just test-mac` — 2614 tests pass.
- [x] `just build-ios` — clean.
- [x] `just format-check` — clean.

## Follow-up

The `tradeBaseline` UI test seed currently has no calculatedFromTrades account with non-host-currency positions (the conditions required to trigger the split + NSHostingView code path), so this fix is verified manually rather than via XCUITest. A follow-up PR could extend the seed with such an account and add a regression test like \`InvestmentAccountTradesModeTransactionsTests\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)