### PR TITLE
revert: PR #822 (reintroduces AppKit toolbar crash)

### DIFF
--- a/Features/Transactions/Views/TransactionListView.swift
+++ b/Features/Transactions/Views/TransactionListView.swift
@@ -34,12 +34,6 @@ struct TransactionListView<TopAccessory: View>: View {
   /// duplicate `com.apple.SwiftUI.search` item the next time the parent's
   /// body re-evaluates. See `guides/UI_GUIDE.md` §3 — view-tree stability
   /// for views with toolbars.
-  ///
-  /// When `TopAccessory == EmptyView` (the no-arg convenience init),
-  /// `safeAreaInset` is skipped entirely. Applying the inset with an
-  /// `EmptyView` payload trips a SwiftUI/AppKit interop bug that
-  /// collapses the modified view to zero size when it's hosted inside
-  /// an `NSHostingView` — see `listWithOptionalTopAccessory`.
   let topAccessory: TopAccessory
 
   /// When non-nil, the parent owns the selection and handles the inspector.
@@ -165,27 +159,9 @@ struct TransactionListView<TopAccessory: View>: View {
   @State var transactionPendingDelete: Transaction.ID?
   @State var createRuleFromTransaction: Transaction?
 
-  /// `listView` with `safeAreaInset` applied only when there is a real
-  /// accessory to render. Skipping the inset when `TopAccessory == EmptyView`
-  /// works around a SwiftUI/AppKit interop bug where
-  /// `safeAreaInset(edge: .top, spacing: 0) { EmptyView() }` collapses the
-  /// modified view to zero size when hosted inside an `NSHostingView`
-  /// (`ResizableVSplit`'s arranged subviews) — the symptom is the embedded
-  /// transactions list disappearing entirely in
-  /// `InvestmentAccountView.positionTrackedLayout`. `_ConditionalContent`
-  /// branches are constant for a given concrete `TransactionListView<T>`
-  /// because `T` doesn't change at runtime, so SwiftUI's view-tree identity
-  /// for `listView` is stable across re-renders.
-  @ViewBuilder private var listWithOptionalTopAccessory: some View {
-    if TopAccessory.self == EmptyView.self {
-      listView
-    } else {
-      listView.safeAreaInset(edge: .top, spacing: 0) { topAccessory }
-    }
-  }
-
   var body: some View {
-    listWithOptionalTopAccessory
+    listView
+      .safeAreaInset(edge: .top, spacing: 0) { topAccessory }
       .modifier(
         OptionalTransactionInspector(
           enabled: handlesOwnInspector,


### PR DESCRIPTION
## Summary

Reverts [#822](https://github.com/ajsutton/moolah-native/pull/822) which fixed the trades-mode transactions-list collapse but reintroduced the AppKit \`com.apple.SwiftUI.search\` duplicate-toolbar-item crash that [#08a99a2d](https://github.com/ajsutton/moolah-native/commit/08a99a2d) was added to prevent.

The conditional \`safeAreaInset\` introduced in #822 made the body's structural shape differ between concrete \`TransactionListView<T>\` types, so when navigating rapidly between accounts (investment / crypto / bank) \`.searchable\` re-mounted and double-registered against \`NSToolbar\`.

Reproduced via a 5×8 navigation sweep across investment / crypto / bank accounts:
- pre-revert main (\`#822\` applied): app crashed every run, typically by sweep 2–5
- pre-#822 main (\`bb67a3db\`): completed all 5 sweeps with no crash

## What this re-exposes

The original underlying bug — \`safeAreaInset(edge: .top, spacing: 0) { EmptyView() }\` collapsing the host view to zero size when hosted inside an \`NSHostingView\` (the \`ResizableVSplit\` used by trades-mode investment accounts) — re-emerges. Symptom: transactions list missing under the positions split for accounts in \`.calculatedFromTrades\` mode with multi-instrument positions.

This will be addressed in a structural follow-up — lifting \`.toolbar\` / \`.searchable\` to a common container so navigation between detail kinds doesn't re-mount the registrations and we can stop fighting AppKit's toolbar bridge with per-leaf modifier patches.

## Test plan

- [x] 5×8 navigation sweep on the post-revert build — no crashes
- [x] \`just format-check\` clean (single-commit revert)

🤖 Generated with [Claude Code](https://claude.com/claude-code)