### PR TITLE
fix(profile-store): recover stale activeProfileID on initial load

### DIFF
--- a/Features/Profiles/ProfileStore+Cloud.swift
+++ b/Features/Profiles/ProfileStore+Cloud.swift
@@ -88,9 +88,9 @@ extension ProfileStore {
       )
     }
 
-    // Handle profiles deleted on another device. Skipped on the
-    // initial load for the same reason as the empty-result guard
-    // above: a stale-empty read could otherwise erase the active
+    // Tear down stores for profiles deleted on another device. Skipped
+    // on the initial load for the same reason as the empty-result
+    // guard above: a stale-empty read could otherwise erase the active
     // profile and tear down its store before later loads return the
     // real list.
     if !isInitialLoad {
@@ -101,16 +101,32 @@ extension ProfileStore {
         containerManager?.deleteStore(for: oldProfile.id)
         onProfileRemoved?(oldProfile.id)
       }
+    }
 
-      if let activeProfileID,
-        !profiles.contains(where: { $0.id == activeProfileID })
-      {
-        self.activeProfileID = profiles.first?.id
-        saveActiveProfileID()
-        logger.debug(
-          "Active profile was removed remotely, switched to: \(self.activeProfileID?.uuidString ?? "nil")"
-        )
-      }
+    // Recover from a stale `activeProfileID` that points to a profile
+    // not in the loaded set. Two ways to reach this state:
+    // (1) the profile was deleted on another device while this device
+    //     was offline; or
+    // (2) the user switched between Debug and Release builds — both
+    //     share the bundle id (and so the UserDefaults domain), but
+    //     they target different CloudKit containers
+    //     (`iCloud.rocks.moolah.app.test` vs `…app.v2`), so the saved
+    //     id can be valid in one container and unknown in the other.
+    // The recovery runs on the initial load too, gated on a non-empty
+    // result so a stale-empty initial read can't drop a legitimate
+    // active id. `welcomePhase != .creating` mirrors the auto-activate
+    // path's race protection so an in-flight WelcomeView "Create
+    // Profile" tap isn't overwritten by a concurrent cloud load.
+    if !profiles.isEmpty,
+      let staleID = activeProfileID,
+      !profiles.contains(where: { $0.id == staleID }),
+      welcomePhase != .creating
+    {
+      self.activeProfileID = profiles.first?.id
+      saveActiveProfileID()
+      logger.debug(
+        "stale activeProfileID \(staleID) → \(self.activeProfileID?.uuidString ?? "nil")"
+      )
     }
   }
 

--- a/MoolahTests/Features/ProfileStoreAutoActivateGuardTests.swift
+++ b/MoolahTests/Features/ProfileStoreAutoActivateGuardTests.swift
@@ -13,19 +13,6 @@ struct ProfileStoreAutoActivateGuardTests {
     return defaults
   }
 
-  private func seedCloudProfile(
-    _ container: ProfileContainerManager
-  ) async throws -> Profile {
-    let profile = Profile(
-      id: UUID(),
-      label: "Household",
-      currencyCode: "AUD",
-      financialYearStartMonth: 7
-    )
-    try await container.profileIndexRepository.upsert(profile)
-    return profile
-  }
-
   @Test("loadCloudProfiles auto-activates when welcomePhase == .landing")
   func autoActivatesWhenLanding() async throws {
     let manager = try ProfileContainerManager.forTesting()

--- a/MoolahTests/Features/ProfileStoreStaleActiveIDRecoveryTests.swift
+++ b/MoolahTests/Features/ProfileStoreStaleActiveIDRecoveryTests.swift
@@ -1,0 +1,100 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+/// Covers the stale-`activeProfileID` recovery path in
+/// `ProfileStore.applyLoadedProfiles(_:isInitialLoad:)`. A previously
+/// active profile may be deleted on another device — or the local
+/// `activeProfileID` UserDefault may simply not match the loaded set
+/// (e.g. switching between Debug and Release builds, which share a
+/// bundle id but talk to different CloudKit containers). On the next
+/// launch the initial load returns a non-empty profile list whose ids
+/// don't include the stale one, and without the recovery the store
+/// stays pinned to a phantom id forever — `SessionManager.sessions[id]`
+/// returns nil for the active id, which silently hides the per-profile
+/// Settings tabs (Crypto especially) even though the main app still
+/// renders via fallbacks.
+@Suite("ProfileStore — stale activeProfileID recovery")
+@MainActor
+struct ProfileStoreStaleActiveIDRecoveryTests {
+  private func makeDefaults(staleID: UUID? = nil) throws -> UserDefaults {
+    let suiteName = "com.moolah.test.\(UUID().uuidString)"
+    let defaults = try #require(UserDefaults(suiteName: suiteName))
+    defaults.removePersistentDomain(forName: suiteName)
+    if let staleID {
+      defaults.set(staleID.uuidString, forKey: ProfileStore.activeProfileKey)
+    }
+    return defaults
+  }
+
+  @Test("initial load with stale activeProfileID switches to first loaded profile")
+  func initialLoadRecoversFromStaleActiveID() async throws {
+    let manager = try ProfileContainerManager.forTesting()
+    let real = try await seedCloudProfile(manager)
+    let staleID = UUID()
+    #expect(staleID != real.id)
+    let defaults = try makeDefaults(staleID: staleID)
+
+    let store = ProfileStore(defaults: defaults, containerManager: manager)
+    await drainPendingMutations(store)
+
+    #expect(store.activeProfileID == real.id)
+    #expect(
+      defaults.string(forKey: ProfileStore.activeProfileKey) == real.id.uuidString
+    )
+  }
+
+  @Test("initial empty load preserves stale activeProfileID (stale-empty guard)")
+  func initialEmptyLoadDoesNotClearStaleID() async throws {
+    let manager = try ProfileContainerManager.forTesting()
+    let staleID = UUID()
+    let defaults = try makeDefaults(staleID: staleID)
+
+    // No profile seeded — initial load returns []. The recovery path
+    // must not fire here; an empty result during the launch race
+    // (SwiftData → GRDB profile-index migration in flight) is
+    // legitimately empty and is handled by `scheduleRetryIfNeeded()`.
+    let store = ProfileStore(defaults: defaults, containerManager: manager)
+    await drainPendingMutations(store)
+
+    #expect(store.activeProfileID == staleID)
+  }
+
+  @Test("initial load suppresses recovery while welcomePhase == .creating")
+  func initialLoadRespectsWelcomeCreatingRace() async throws {
+    let manager = try ProfileContainerManager.forTesting()
+    let real = try await seedCloudProfile(manager)
+    let staleID = UUID()
+    #expect(staleID != real.id)
+    let defaults = try makeDefaults(staleID: staleID)
+
+    let store = ProfileStore(defaults: defaults, containerManager: manager)
+    // Set the creating phase before the async load body finishes.
+    // `drainPendingMutations` waits for it to commit.
+    store.welcomePhase = .creating
+    await drainPendingMutations(store)
+
+    // The race-protection contract mirrors the auto-activate path:
+    // while WelcomeView is mid-create, the in-flight cloud load must
+    // not rewrite `activeProfileID` underneath the user's tap.
+    #expect(store.activeProfileID == staleID)
+  }
+
+  @Test("initial load with matching activeProfileID leaves it untouched")
+  func initialLoadKeepsValidActiveID() async throws {
+    let manager = try ProfileContainerManager.forTesting()
+    let real = try await seedCloudProfile(manager)
+    let defaults = try makeDefaults(staleID: real.id)
+
+    let store = ProfileStore(defaults: defaults, containerManager: manager)
+    await drainPendingMutations(store)
+
+    #expect(store.activeProfileID == real.id)
+    // The recovery branch must short-circuit before
+    // `saveActiveProfileID()`; the persisted value is unchanged.
+    #expect(
+      defaults.string(forKey: ProfileStore.activeProfileKey) == real.id.uuidString
+    )
+  }
+}

--- a/MoolahTests/Support/ProfileStoreTestSupport.swift
+++ b/MoolahTests/Support/ProfileStoreTestSupport.swift
@@ -20,3 +20,23 @@ func drainPendingMutations(_ store: ProfileStore) async {
     await Task.yield()
   }
 }
+
+/// Inserts a `Profile` row into the GRDB profile-index backing the
+/// supplied container. The default fields match the values most
+/// `ProfileStore` tests don't care about; pass an explicit `label` if
+/// the test seeds more than one profile and the assertions need to
+/// distinguish them.
+@discardableResult
+func seedCloudProfile(
+  _ container: ProfileContainerManager,
+  label: String = "Household"
+) async throws -> Profile {
+  let profile = Profile(
+    id: UUID(),
+    label: label,
+    currencyCode: "AUD",
+    financialYearStartMonth: 7
+  )
+  try await container.profileIndexRepository.upsert(profile)
+  return profile
+}


### PR DESCRIPTION
## Summary

- **Bug:** the macOS Settings → Crypto tab silently disappears for a profile when `UserDefaults["com.moolah.activeProfileID"]` doesn't match any profile in the loaded set. `SessionManager.sessions[activeProfileID]` then returns `nil` and `activeCryptoSession` short-circuits, even though the main app continues rendering via the `sessions.values.first` fallback. Easiest way to reproduce: switch between Debug and Release builds — they share `rocks.moolah.app` (and so the UserDefaults domain) but target different CloudKit containers (`iCloud.rocks.moolah.app.test` vs `…app.v2`), so the saved id is valid in one and unknown in the other.
- **Fix:** the recovery path that switches `activeProfileID` to `profiles.first?.id` when the saved id isn't in the loaded set was nested inside `if !isInitialLoad` alongside the deleted-profile teardown loop. The teardown gate is correct (a stale-empty initial read could otherwise tear down the active profile's store), but the active-id recovery should run on the initial load too, with `!profiles.isEmpty` to keep the stale-empty guard and `welcomePhase != .creating` to mirror the auto-activate path's WelcomeView race protection.
- **Tests:** new `ProfileStoreStaleActiveIDRecoveryTests` suite covers the four shapes (stale + non-empty initial → recovers; stale + empty initial → preserved; stale + creating phase → preserved; matching id → untouched, including UserDefaults). `seedCloudProfile` lifted from `ProfileStoreAutoActivateGuardTests` into `ProfileStoreTestSupport` so both files share the helper.

## Test plan

- [x] `just test-mac ProfileStoreStaleActiveIDRecoveryTests` — 4 new tests pass
- [x] `just test-mac ProfileStoreTests ProfileStoreTestsMore ProfileStoreTestsMoreSecondHalf ProfileStoreAvailabilityTests ProfileStoreAutoActivateGuardTests ProfileStoreStaleActiveIDRecoveryTests` — 36 tests pass, no regression in existing ProfileStore coverage
- [x] `just test-mac` — full macOS suite passes
- [x] `just format-check` — clean
- [ ] Manual verify on the affected device: launch the Debug build → confirm the Crypto tab now renders, then check the persisted `com.moolah.activeProfileID` matches the loaded profile id

🤖 Generated with [Claude Code](https://claude.com/claude-code)