### PR TITLE
refactor: replace transaction NotificationCenter dispatch with focusedSceneValue (closes #826)

### DIFF
--- a/App/MoolahDomainCommands.swift
+++ b/App/MoolahDomainCommands.swift
@@ -83,7 +83,6 @@ struct ShowHiddenCommands: Commands {
 /// CommandMenus are inlined here (rather than references to per-feature structs)
 /// to keep the opaque `some Commands` return type inferable.
 struct MoolahDomainCommands: Commands {
-  @FocusedValue(\.selectedTransaction) private var selectedTransaction
   @FocusedValue(\.selectedAccount) private var selectedAccount
   @FocusedValue(\.selectedEarmark) private var selectedEarmark
   @FocusedValue(\.selectedCategory) private var selectedCategory
@@ -92,18 +91,16 @@ struct MoolahDomainCommands: Commands {
   @FocusedValue(\.goForwardAction) private var goForwardAction
   @FocusedValue(\.findInListAction) private var findInListAction
   @FocusedValue(\.setTransactionTypeAction) private var setTransactionTypeAction
+  @FocusedValue(\.editTransactionAction) private var editTransactionAction
+  @FocusedValue(\.deleteTransactionAction) private var deleteTransactionAction
+  @FocusedValue(\.payTransactionAction) private var payTransactionAction
   @Environment(\.openWindow) private var openWindow
   @Environment(\.openURL) private var openURL
 
   var body: some Commands {
     CommandMenu("Transaction") {
-      Button("Edit Transaction\u{2026}") {
-        NotificationCenter.default.post(
-          name: .requestTransactionEdit,
-          object: selectedTransaction?.wrappedValue?.id
-        )
-      }
-      .disabled(selectedTransaction?.wrappedValue == nil)
+      Button("Edit Transaction\u{2026}") { editTransactionAction?() }
+        .disabled(editTransactionAction == nil)
 
       Button("Duplicate Transaction") {}.disabled(true)
 
@@ -112,23 +109,13 @@ struct MoolahDomainCommands: Commands {
       }
       .disabled(setTransactionTypeAction == nil)
 
-      Button("Pay Scheduled Transaction") {
-        NotificationCenter.default.post(
-          name: .requestTransactionPay,
-          object: selectedTransaction?.wrappedValue?.id
-        )
-      }
-      .disabled(selectedTransaction?.wrappedValue?.recurPeriod == nil)
+      Button("Pay Scheduled Transaction") { payTransactionAction?() }
+        .disabled(payTransactionAction == nil)
 
       Divider()
 
-      Button("Delete Transaction\u{2026}", role: .destructive) {
-        NotificationCenter.default.post(
-          name: .requestTransactionDelete,
-          object: selectedTransaction?.wrappedValue?.id
-        )
-      }
-      .disabled(selectedTransaction?.wrappedValue == nil)
+      Button("Delete Transaction\u{2026}", role: .destructive) { deleteTransactionAction?() }
+        .disabled(deleteTransactionAction == nil)
     }
 
     CommandMenu("Go") {

--- a/Features/Transactions/Views/TransactionListView.swift
+++ b/Features/Transactions/Views/TransactionListView.swift
@@ -143,6 +143,23 @@ struct TransactionListView: View {
         if new != nil { searchFieldFocused = false }
       }
       .focusedSceneValue(\.selectedTransaction, selectedTransactionBinding)
+      .focusedSceneValue(
+        \.editTransactionAction,
+        selectedTransaction != nil
+          ? {
+            // Re-asserting the binding is a stable no-op when the inspector
+            // is already open; when it's closed (e.g. after the user dismissed
+            // it but selection was preserved), this re-opens it.
+            selectedTransaction = selectedTransaction
+          }
+          : nil
+      )
+      .focusedSceneValue(
+        \.deleteTransactionAction,
+        selectedTransaction != nil
+          ? { transactionPendingDelete = selectedTransaction?.id }
+          : nil
+      )
       .alert("Error", isPresented: $showError) {
         Button("OK", role: .cancel) {}
       } message: {
@@ -178,18 +195,6 @@ struct TransactionListView: View {
         Button("Cancel", role: .cancel) { transactionPendingDelete = nil }
       } message: {
         Text("This action cannot be undone.")
-      }
-      .onReceive(NotificationCenter.default.publisher(for: .requestTransactionEdit)) { note in
-        guard let id = note.object as? Transaction.ID,
-          let entry = filteredTransactions.first(where: { $0.transaction.id == id })
-        else { return }
-        selectedTransaction = entry.transaction
-      }
-      .onReceive(NotificationCenter.default.publisher(for: .requestTransactionDelete)) { note in
-        guard let id = note.object as? Transaction.ID,
-          filteredTransactions.contains(where: { $0.transaction.id == id })
-        else { return }
-        transactionPendingDelete = id
       }
       .modifier(
         TransactionListCSVImportAddons(

--- a/Features/Transactions/Views/TransactionListView.swift
+++ b/Features/Transactions/Views/TransactionListView.swift
@@ -147,9 +147,14 @@ struct TransactionListView: View {
         \.editTransactionAction,
         selectedTransaction != nil
           ? {
-            // Re-asserting the binding is a stable no-op when the inspector
-            // is already open; when it's closed (e.g. after the user dismissed
-            // it but selection was preserved), this re-opens it.
+            // Discoverability affordance: under the current architecture
+            // dismissing the inspector clears `selectedTransaction` (see
+            // `TransactionInspectorModifier.isPresented`), so this action is
+            // only published when the inspector is already open and the
+            // self-assign is a no-op. The menu item exists so users can
+            // discover that Edit is available without right-clicking the row.
+            // If the inspector ever stops clearing selection on dismissal,
+            // this self-assign needs to become an explicit reopen path.
             selectedTransaction = selectedTransaction
           }
           : nil

--- a/Features/Transactions/Views/UpcomingView.swift
+++ b/Features/Transactions/Views/UpcomingView.swift
@@ -45,17 +45,16 @@ struct UpcomingView: View {
         pendingPayId = nil
       }
     }
-    // `.requestTransactionPay` handler is genuinely additive — there is no
-    // counterpart inside `TransactionListView` (Pay is unique to the
-    // scheduled-status grouping). Window-menu commands need a path to
-    // trigger Pay on the visible leaf, and routing through `pendingPayId`
-    // keeps the in-progress visual firing regardless of trigger source.
-    .onReceive(NotificationCenter.default.publisher(for: .requestTransactionPay)) { note in
-      guard let id = note.object as? Transaction.ID,
-        transactionStore.transactions.contains(where: { $0.transaction.id == id })
-      else { return }
-      pendingPayId = id
-    }
+    // Routing the menu Pay command through `pendingPayId` keeps the
+    // in-progress visual firing regardless of trigger source (toolbar,
+    // row swipe, or menu). Published only when a recurring transaction
+    // is selected so the menu item disables otherwise.
+    .focusedSceneValue(
+      \.payTransactionAction,
+      (selectedTransaction != nil && selectedTransaction?.recurPeriod != nil)
+        ? { pendingPayId = selectedTransaction?.id }
+        : nil
+    )
   }
 
   private func payTransaction(_ scheduledTransaction: Transaction) async {

--- a/Features/Transactions/Views/UpcomingView.swift
+++ b/Features/Transactions/Views/UpcomingView.swift
@@ -51,7 +51,7 @@ struct UpcomingView: View {
     // is selected so the menu item disables otherwise.
     .focusedSceneValue(
       \.payTransactionAction,
-      (selectedTransaction != nil && selectedTransaction?.recurPeriod != nil)
+      selectedTransaction?.recurPeriod != nil
         ? { pendingPayId = selectedTransaction?.id }
         : nil
     )

--- a/Shared/FocusedValues.swift
+++ b/Shared/FocusedValues.swift
@@ -40,6 +40,27 @@ struct SelectedTransactionKey: FocusedValueKey {
   typealias Value = Binding<Transaction?>
 }
 
+/// Trigger action for Transaction > Edit Transaction… Published by the
+/// leaf that owns the transaction selection; `nil` when no transaction is
+/// selected (which disables the menu item).
+struct EditTransactionActionKey: FocusedValueKey {
+  typealias Value = () -> Void
+}
+
+/// Trigger action for Transaction > Delete Transaction… Published by the
+/// leaf that owns the transaction selection; `nil` when no transaction is
+/// selected (which disables the menu item).
+struct DeleteTransactionActionKey: FocusedValueKey {
+  typealias Value = () -> Void
+}
+
+/// Trigger action for Transaction > Pay Scheduled Transaction. Published
+/// by the Upcoming leaf when a scheduled (recurring) transaction is
+/// selected; `nil` otherwise (which disables the menu item).
+struct PayTransactionActionKey: FocusedValueKey {
+  typealias Value = () -> Void
+}
+
 /// The account currently selected in the focused window (for Account menu items).
 struct SelectedAccountKey: FocusedValueKey {
   typealias Value = Binding<Account?>
@@ -122,6 +143,18 @@ extension FocusedValues {
   var selectedTransaction: SelectedTransactionKey.Value? {
     get { self[SelectedTransactionKey.self] }
     set { self[SelectedTransactionKey.self] = newValue }
+  }
+  var editTransactionAction: EditTransactionActionKey.Value? {
+    get { self[EditTransactionActionKey.self] }
+    set { self[EditTransactionActionKey.self] = newValue }
+  }
+  var deleteTransactionAction: DeleteTransactionActionKey.Value? {
+    get { self[DeleteTransactionActionKey.self] }
+    set { self[DeleteTransactionActionKey.self] = newValue }
+  }
+  var payTransactionAction: PayTransactionActionKey.Value? {
+    get { self[PayTransactionActionKey.self] }
+    set { self[PayTransactionActionKey.self] = newValue }
   }
   var selectedAccount: SelectedAccountKey.Value? {
     get { self[SelectedAccountKey.self] }

--- a/Shared/Notification.Name+Requests.swift
+++ b/Shared/Notification.Name+Requests.swift
@@ -1,13 +1,16 @@
 import Foundation
 
-/// Cross-platform `Notification.Name` constants used by menu-bar commands to request
-/// actions from the focused window's views. The commands (macOS-only) post these
-/// notifications; the views (shared) listen via `.onReceive`. Keeping the names
-/// outside `#if os(macOS)` lets both compile.
+/// Cross-platform `Notification.Name` constants used by macOS menu-bar
+/// commands to request actions from the focused window's views via
+/// `.onReceive`. Transaction-list actions (Edit / Delete / Pay) were
+/// migrated off this pattern in issue #826 and are now routed through
+/// `focusedSceneValue` (see `Shared/FocusedValues.swift`); the names
+/// below cover Account / Earmark / Category commands and the Finder
+/// "Open with Moolah" CSV pipeline. Future commands should prefer
+/// `focusedSceneValue` over a new notification entry — the typed
+/// action-binding pattern is `Sendable`-clean and per-leaf scoped,
+/// where notifications are untyped and module-global.
 extension Notification.Name {
-  // Transaction commands
-  static let requestTransactionDuplicate = Notification.Name("requestTransactionDuplicate")
-
   // Category commands
   static let requestCategoryEdit = Notification.Name("requestCategoryEdit")
 

--- a/Shared/Notification.Name+Requests.swift
+++ b/Shared/Notification.Name+Requests.swift
@@ -6,10 +6,7 @@ import Foundation
 /// outside `#if os(macOS)` lets both compile.
 extension Notification.Name {
   // Transaction commands
-  static let requestTransactionEdit = Notification.Name("requestTransactionEdit")
   static let requestTransactionDuplicate = Notification.Name("requestTransactionDuplicate")
-  static let requestTransactionDelete = Notification.Name("requestTransactionDelete")
-  static let requestTransactionPay = Notification.Name("requestTransactionPay")
 
   // Category commands
   static let requestCategoryEdit = Notification.Name("requestCategoryEdit")


### PR DESCRIPTION
## Summary

Closes #826.

Replaces the three transaction-list `NotificationCenter` cross-view commands with typed `focusedSceneValue` actions, matching the established pattern in this codebase (see `Shared/FocusedValues.swift` for prior keys like \`newTransactionAction\`, \`findInListAction\`, etc.).

- **Three new `FocusedValueKey`s** in \`Shared/FocusedValues.swift\`: \`EditTransactionActionKey\`, \`DeleteTransactionActionKey\`, \`PayTransactionActionKey\`. All are \`() -> Void\` actions; the publishing leaf decides what they mean for its own selection state.
- **\`TransactionListView\`** publishes \`editTransactionAction\` and \`deleteTransactionAction\`, gated on \`selectedTransaction != nil\`.
- **\`UpcomingView\`** publishes \`payTransactionAction\`, gated on the selected transaction having a non-nil \`recurPeriod\`.
- **\`MoolahDomainCommands\`** consumes the three actions via \`@FocusedValue\` and disables the menu items when the action is \`nil\` — matching how every other action in that file is gated. \`@FocusedValue(\.selectedTransaction)\` was removed from this struct because it has zero remaining uses there (the \`SelectedTransactionKey\` and the publisher in \`TransactionListView\` remain — they're used elsewhere).
- **Three \`Notification.Name\` constants removed** (\`requestTransactionEdit\`, \`requestTransactionDelete\`, \`requestTransactionPay\`); the unused-everywhere \`requestTransactionDuplicate\` is also dropped (the Duplicate menu item is a permanent-disabled placeholder).
- **The remaining notifications** (\`requestAccountEdit\`, \`requestEarmarkEdit\`, \`requestEarmarkToggleHidden\`, \`requestCategoryEdit\`, \`openCSVFile\`) are out of scope per the issue's explicit framing — they go to non-transaction-list views and would need separate refactors. The file's doc comment is updated to reflect the new scope and to recommend \`focusedSceneValue\` for any future commands.

Closes the **\`CONCURRENCY_GUIDE.md\` §8** anti-pattern flag the original \`@concurrency-review\` agent raised on PR-4 about the transaction Pay notification.

## Stacking

This branch stacks on [#837](https://github.com/ajsutton/moolah-native/pull/837) (RecentlyAddedView searchable hoist, closes #824), which itself stacks on the five-PR detail-view structural fix series (#827 → #829 → #830 → #834 → #835). Diff against \`main\` includes all of the above until they merge.

## Test plan

- [x] \`just test\` green: 2629 iOS + 2654 macOS unit tests.
- [x] \`just format-check\` clean.
- [x] Final grep across \`Features\`, \`App\`, \`Shared\` for \`requestTransactionEdit|requestTransactionDelete|requestTransactionPay|requestTransactionDuplicate\`: zero matches.
- [x] \`@code-review\` agent: all Critical / Important / Minor findings applied (orphan Duplicate notification dropped, doc comment narrowed, Edit-action comment expanded, UpcomingView nil-guard simplified).
- [ ] Manual macOS verification — Transaction menu's Edit / Pay / Delete items enable when a transaction is selected in the list and trigger the same effects as before (open inspector / start pay flow / open delete confirmation).

Generated with [Claude Code](https://claude.com/claude-code)