### PR TITLE
feat(app): SharedInstrumentScope holder (stage 2)

### DIFF
--- a/App/SharedInstrumentScope.swift
+++ b/App/SharedInstrumentScope.swift
@@ -1,0 +1,81 @@
+// App/SharedInstrumentScope.swift
+
+import Foundation
+import Observation
+
+/// App-level holder for the shared instrument registry and the
+/// price-cache / search / discovery services that go with it. One
+/// instance per app; injected into every `ProfileSession` so all
+/// profiles see the same registry data and share price-cache rows.
+///
+/// This stage stands the holder up as a passive container: the app
+/// boot path (a later stage) constructs the dependencies and hands
+/// them in. The holder does not currently wire any sync hooks,
+/// observation closures, or remote-change fan-out — those land in
+/// later stages once the consumers exist.
+///
+/// **Isolation: `@MainActor`.** UI consumers (Settings, sidebar
+/// widgets, sync stores) are all `@MainActor`-isolated; the actor
+/// types this class owns (`CryptoPriceService`, `StockPriceService`,
+/// `ExchangeRateService`, `CryptoTokenDiscoveryService`) are accessed
+/// via `await` and are themselves `Sendable`. `@MainActor`
+/// confinement avoids the `@unchecked Sendable` carve-out that would
+/// otherwise be required.
+///
+/// **`@Observable`** is applied even though every property is `let`
+/// today — the convention for `@MainActor` holders that participate
+/// in SwiftUI dependency injection is to be observable, so a future
+/// stage adding a mutable counter or `Bool` flag triggers view
+/// updates without a separate refactor.
+///
+/// See `plans/2026-05-09-shared-instrument-registry-design.md` and
+/// `plans/2026-05-09-shared-instrument-registry-plan.md` (Task 2).
+@MainActor
+@Observable
+final class SharedInstrumentScope {
+  /// Authoritative source of instrument identity, shared across every
+  /// profile session on the same iCloud account. All registry
+  /// mutations flow through this single instance so spam decisions,
+  /// discovered-token resolutions, and provider mappings propagate
+  /// to every profile without per-session re-load.
+  let instrumentRegistry: any InstrumentRegistryRepository
+
+  /// Single price-cache service per app — the shared backing DB
+  /// dedupes API calls that two profiles holding the same crypto
+  /// token would otherwise issue independently.
+  let cryptoPriceService: CryptoPriceService
+
+  /// Single stock-price service per app, sharing the cache for the
+  /// same reason as `cryptoPriceService`.
+  let stockPriceService: StockPriceService
+
+  /// Single FX-rate service per app — exchange rates are user-scoped,
+  /// not profile-scoped.
+  let exchangeRateService: ExchangeRateService
+
+  /// Search service composing the registry, CoinGecko catalog, and
+  /// resolution client. Shared so search results match the registry
+  /// state visible to every profile.
+  let instrumentSearchService: InstrumentSearchService
+
+  /// Per-(chain, contractAddress) discovery actor. Sharing the actor
+  /// across sessions coalesces concurrent resolves of the same key
+  /// from different profiles into one network round-trip.
+  let cryptoTokenDiscovery: CryptoTokenDiscoveryService
+
+  init(
+    instrumentRegistry: any InstrumentRegistryRepository,
+    cryptoPriceService: CryptoPriceService,
+    stockPriceService: StockPriceService,
+    exchangeRateService: ExchangeRateService,
+    instrumentSearchService: InstrumentSearchService,
+    cryptoTokenDiscovery: CryptoTokenDiscoveryService
+  ) {
+    self.instrumentRegistry = instrumentRegistry
+    self.cryptoPriceService = cryptoPriceService
+    self.stockPriceService = stockPriceService
+    self.exchangeRateService = exchangeRateService
+    self.instrumentSearchService = instrumentSearchService
+    self.cryptoTokenDiscovery = cryptoTokenDiscovery
+  }
+}

--- a/MoolahTests/App/SharedInstrumentScopeTests.swift
+++ b/MoolahTests/App/SharedInstrumentScopeTests.swift
@@ -1,0 +1,120 @@
+// MoolahTests/App/SharedInstrumentScopeTests.swift
+
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+/// Confirms `SharedInstrumentScope` constructs a passive holder of the
+/// shared registry and price-cache / search / discovery services and
+/// exposes them via its public surface.
+///
+/// See `plans/2026-05-09-shared-instrument-registry-design.md` and
+/// `plans/2026-05-09-shared-instrument-registry-plan.md` (Task 2).
+@MainActor
+@Suite("SharedInstrumentScope holder")
+struct SharedInstrumentScopeTests {
+
+  @Test("holds the registry and exposes shared price-cache through the same DB")
+  func scopeHoldsSharedRegistryWiredToProfileIndexDatabase() async throws {
+    let queue = try ProfileIndexDatabase.openInMemory()
+    let registry = GRDBInstrumentRegistryRepository(database: queue)
+
+    let scope = makeScope(database: queue, registry: registry)
+
+    // Registry round-trip: register an instrument via the holder's
+    // registry, observe the row in the same shared DB.
+    try await scope.instrumentRegistry.registerCrypto(
+      Instrument.crypto(
+        chainId: 1,
+        contractAddress: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+        symbol: "USDC",
+        name: "USD Coin",
+        decimals: 6),
+      mapping: CryptoProviderMapping(
+        instrumentId:
+          "1:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+        coingeckoId: "usd-coin",
+        cryptocompareSymbol: "USDC",
+        binanceSymbol: nil))
+
+    let stored = try await queue.read { database in
+      try Int.fetchOne(database, sql: "SELECT COUNT(*) FROM instrument") ?? 0
+    }
+    #expect(stored == 1)
+  }
+
+  @Test("exposes price-cache and discovery services as the same instances handed in")
+  func scopeExposesInjectedServicesByIdentity() async throws {
+    let queue = try ProfileIndexDatabase.openInMemory()
+    let registry = GRDBInstrumentRegistryRepository(database: queue)
+    let cryptoPriceService = CryptoPriceService(
+      clients: [],
+      database: queue,
+      resolutionClient: FixedTokenResolutionClient())
+    let stockPriceService = StockPriceService(
+      client: FixedStockPriceClient(), database: queue)
+    let exchangeRateService = ExchangeRateService(
+      client: FixedRateClient(), database: queue)
+    let searchService = InstrumentSearchService(
+      registry: registry,
+      catalog: nil,
+      resolutionClient: FixedTokenResolutionClient(),
+      stockSearchClient: NoOpStockSearchClient())
+    let discovery = CryptoTokenDiscoveryService(
+      registry: registry,
+      resolver: CountingRegistrationResolver(),
+      alchemy: ZeroReceiptAlchemyStub())
+
+    let scope = SharedInstrumentScope(
+      instrumentRegistry: registry,
+      cryptoPriceService: cryptoPriceService,
+      stockPriceService: stockPriceService,
+      exchangeRateService: exchangeRateService,
+      instrumentSearchService: searchService,
+      cryptoTokenDiscovery: discovery)
+
+    #expect(scope.cryptoPriceService === cryptoPriceService)
+    #expect(scope.stockPriceService === stockPriceService)
+    #expect(scope.exchangeRateService === exchangeRateService)
+    #expect(scope.cryptoTokenDiscovery === discovery)
+    // `instrumentRegistry` and `searchService` are protocol / value
+    // types — equality by content not reference.
+  }
+
+  // MARK: - Helpers
+
+  @MainActor
+  private func makeScope(
+    database: any DatabaseWriter,
+    registry: any InstrumentRegistryRepository
+  ) -> SharedInstrumentScope {
+    SharedInstrumentScope(
+      instrumentRegistry: registry,
+      cryptoPriceService: CryptoPriceService(
+        clients: [],
+        database: database,
+        resolutionClient: FixedTokenResolutionClient()),
+      stockPriceService: StockPriceService(
+        client: FixedStockPriceClient(), database: database),
+      exchangeRateService: ExchangeRateService(
+        client: FixedRateClient(), database: database),
+      instrumentSearchService: InstrumentSearchService(
+        registry: registry,
+        catalog: nil,
+        resolutionClient: FixedTokenResolutionClient(),
+        stockSearchClient: NoOpStockSearchClient()),
+      cryptoTokenDiscovery: CryptoTokenDiscoveryService(
+        registry: registry,
+        resolver: CountingRegistrationResolver(),
+        alchemy: ZeroReceiptAlchemyStub()))
+  }
+}
+
+/// Minimal `StockSearchClient` stub for unit tests that only need the
+/// `SharedInstrumentScope`'s wiring to compile and execute. Returns no
+/// results for every query.
+private struct NoOpStockSearchClient: StockSearchClient {
+  func search(query: String) async throws -> [StockSearchHit] { [] }
+}


### PR DESCRIPTION
## Summary

Stage 2 of the [shared instrument registry implementation plan](plans/2026-05-09-shared-instrument-registry-plan.md) (Task 2).

Adds an `@MainActor @Observable final class SharedInstrumentScope` that holds the shared registry, the three price-cache services, the search service, and the discovery actor. Stage 2 is a passive container — DI-style: the boot path (a later stage) constructs the dependencies and hands them in.

## Stacking

Stacked on [#841 (stage 1 schema)](https://github.com/ajsutton/moolah-native/pull/841). Base branch is `feat/shared-registry-stage1-schema`; the merge queue rebases automatically once #841 lands.

## Why this is safe to land alone

- The holder type exists but nothing constructs it from the boot path yet.
- No existing call site is changed.

## Review process

Two reviewer rounds (`concurrency-review`, `code-review`); all findings addressed:
- Added `@Observable` so a future stage adding a mutable property triggers SwiftUI updates without a separate refactor.
- Removed unused `import GRDB` (the holder takes pre-built services; no GRDB type is referenced in code).
- Replaced what-style property doc comments with why-style ones explaining the sharing rationale.
- Removed redundant `Sendable` conformance on the test `NoOpStockSearchClient` (the protocol already requires `Sendable`).
- Annotated the test's `makeScope` helper as `@MainActor` for explicit isolation under non-default-MainActor builds.

## Test plan

- [x] `just format-check` — clean.
- [x] `just test-mac SharedInstrumentScopeTests` — 2 tests pass.
- [x] `just build-mac` — clean.
- [ ] CI on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)