### PR TITLE
feat(migration): SharedRegistryUnionRunner (stage 11)

### DIFF
--- a/App/SharedRegistryUnionRunner.swift
+++ b/App/SharedRegistryUnionRunner.swift
@@ -1,0 +1,254 @@
+// App/SharedRegistryUnionRunner.swift
+
+import Foundation
+import GRDB
+import OSLog
+
+/// One-shot data-union migration that walks every per-profile
+/// `data.sqlite` and merges its `instrument` + price-cache rows into
+/// the shared `profile-index.sqlite` tables added by the v3 schema
+/// migration. Gated by a `UserDefaults` flag — once set, the runner
+/// is a no-op forever.
+///
+/// **Per-profile isolation.** Each profile is processed in a separate
+/// shared-DB write transaction. A read failure on one profile (corrupt
+/// file, locked WAL) logs and skips that profile; previously-merged
+/// profiles stay merged. The flag is set after every profile has been
+/// attempted, so a partial run is observable as "some profiles missing
+/// from the shared registry" rather than as "migration retried forever".
+///
+/// **Merge rules.**
+/// * `instrument` rows: delegate to
+///   `GRDBInstrumentRegistryRepository.applyRemoteChangesSync`, which
+///   already enforces the spam-wins merge via `PricingStatusMerge.merge`.
+///   Per-profile sort order (ascending UUID) means later profiles see
+///   their rows applied last.
+/// * `crypto_price` / `stock_price` / `exchange_rate` body rows are
+///   content-addressable (same `(key, date)` ⇒ same value across
+///   profiles). `INSERT OR IGNORE` — first writer wins is fine.
+/// * `crypto_token_meta` / `stock_ticker_meta` / `exchange_rate_meta`:
+///   merge `(earliest_date, latest_date)` to the broadest span via
+///   explicit `ON CONFLICT(pk) DO UPDATE`.
+///
+/// **Concurrency.** `nonisolated`. DB I/O happens on GRDB's serial
+/// executor via `await database.write { … }`; the runner returns when
+/// every profile has been attempted. The caller awaits the runner from
+/// the app boot path before opening any session.
+///
+/// See `plans/2026-05-09-shared-instrument-registry-design.md` (Step
+/// 2 of §Migration) and the implementation plan (Task 11).
+enum SharedRegistryUnionRunner {
+  /// `UserDefaults` key gating the union. Once `true`, the runner is
+  /// a no-op forever.
+  static let unionFlagKey =
+    "com.moolah.migration.shared-registry-union.v1.completed"
+
+  /// Runs the union once. Calls past the first run are no-ops.
+  ///
+  /// - Parameters:
+  ///   - sharedQueue: The profile-index `DatabaseWriter` (e.g. a
+  ///     migrated `DatabaseQueue` from `ProfileIndexDatabase.open`).
+  ///   - profileIds: The ids of every profile whose per-profile DB
+  ///     should be unioned. Sorted ascending by `uuidString` to
+  ///     produce a deterministic merge order across re-runs.
+  ///   - perProfileDatabase: Opens the per-profile DB at the supplied
+  ///     id. Defaults to `ProfileSession.openProfileDatabase(profileId:)`.
+  ///     Tests pass a stub.
+  ///   - fileManager: Used to check that the per-profile DB file
+  ///     exists before attempting an open (so a missing file silently
+  ///     skips that profile rather than throwing).
+  ///   - defaults: The `UserDefaults` instance to read / write the
+  ///     gating flag.
+  static func run(
+    sharedQueue: any DatabaseWriter,
+    profileIds: [UUID],
+    perProfileDatabase: @Sendable (UUID) throws -> DatabaseQueue =
+      ProfileSession.openProfileDatabase(profileId:),
+    perProfileDatabaseURL: @Sendable (UUID) -> URL = { profileId in
+      ProfileSession.profileDatabaseDirectory(for: profileId)
+        .appendingPathComponent("data.sqlite")
+    },
+    fileManager: FileManager = .default,
+    defaults: UserDefaults = .standard
+  ) async {
+    let logger = Logger(
+      subsystem: "com.moolah.app", category: "SharedRegistryUnion")
+
+    if defaults.bool(forKey: unionFlagKey) {
+      logger.info("Shared-registry union already completed — skipping")
+      return
+    }
+
+    let sortedIds = profileIds.sorted { $0.uuidString < $1.uuidString }
+    var successfulCount = 0
+    var skippedCount = 0
+    let registry = GRDBInstrumentRegistryRepository(database: sharedQueue)
+
+    for profileId in sortedIds {
+      let url = perProfileDatabaseURL(profileId)
+      guard fileManager.fileExists(atPath: url.path) else {
+        logger.warning(
+          "Profile \(profileId, privacy: .public) has no data.sqlite — skipping"
+        )
+        skippedCount += 1
+        continue
+      }
+
+      do {
+        let snapshot = try await PerProfileSnapshot(
+          profileId: profileId, queue: try perProfileDatabase(profileId))
+        try await applySnapshot(
+          snapshot, sharedQueue: sharedQueue, registry: registry)
+        successfulCount += 1
+      } catch {
+        logger.error(
+          "Profile \(profileId, privacy: .public) union failed (\(error, privacy: .public)) — skipping"
+        )
+        skippedCount += 1
+      }
+    }
+
+    defaults.set(true, forKey: unionFlagKey)
+    logger.info(
+      """
+      Shared-registry union complete \
+      (successful=\(successfulCount), skipped=\(skippedCount))
+      """)
+  }
+
+  // MARK: - Apply
+
+  private static func applySnapshot(
+    _ snapshot: PerProfileSnapshot,
+    sharedQueue: any DatabaseWriter,
+    registry: GRDBInstrumentRegistryRepository
+  ) async throws {
+    // Instruments use the existing apply path so the spam-wins merge
+    // rule is shared, not duplicated. Each call opens its own write
+    // transaction; that's acceptable here because the per-profile
+    // batches are independent and a mid-batch failure is logged + the
+    // outer loop moves on to the next profile.
+    try registry.applyRemoteChangesSync(
+      saved: snapshot.instruments, deleted: [])
+
+    // Price-cache rows / meta rows in a single write per profile.
+    try await sharedQueue.write { database in
+      try mergeBodyRows(snapshot: snapshot, database: database)
+      try mergeMetaRows(snapshot: snapshot, database: database)
+    }
+  }
+
+  /// Body tables are content-addressable: `(key, date)` deterministic
+  /// ⇒ same value. `INSERT OR IGNORE` — first writer wins.
+  private static func mergeBodyRows(
+    snapshot: PerProfileSnapshot, database: Database
+  ) throws {
+    for row in snapshot.cryptoPrices {
+      try database.execute(
+        sql: """
+          INSERT OR IGNORE INTO crypto_price (token_id, date, price_usd)
+          VALUES (?, ?, ?)
+          """,
+        arguments: [row.tokenId, row.date, row.priceUsd])
+    }
+    for row in snapshot.stockPrices {
+      try database.execute(
+        sql: """
+          INSERT OR IGNORE INTO stock_price (ticker, date, price)
+          VALUES (?, ?, ?)
+          """,
+        arguments: [row.ticker, row.date, row.price])
+    }
+    for row in snapshot.exchangeRates {
+      try database.execute(
+        sql: """
+          INSERT OR IGNORE INTO exchange_rate (base, quote, date, rate)
+          VALUES (?, ?, ?, ?)
+          """,
+        arguments: [row.base, row.quote, row.date, row.rate])
+    }
+  }
+
+  /// Meta tables: merge the date span via `ON CONFLICT(pk) DO UPDATE`.
+  /// Earliest-date is the `MIN`; latest-date is the `MAX`.
+  private static func mergeMetaRows(
+    snapshot: PerProfileSnapshot, database: Database
+  ) throws {
+    for row in snapshot.cryptoTokenMeta {
+      try database.execute(
+        sql: """
+          INSERT INTO crypto_token_meta
+          (token_id, symbol, earliest_date, latest_date)
+          VALUES (?, ?, ?, ?)
+          ON CONFLICT(token_id) DO UPDATE SET
+            earliest_date = MIN(earliest_date, excluded.earliest_date),
+            latest_date = MAX(latest_date, excluded.latest_date)
+          """,
+        arguments: [row.tokenId, row.symbol, row.earliestDate, row.latestDate])
+    }
+    for row in snapshot.stockTickerMeta {
+      try database.execute(
+        sql: """
+          INSERT INTO stock_ticker_meta
+          (ticker, instrument_id, earliest_date, latest_date)
+          VALUES (?, ?, ?, ?)
+          ON CONFLICT(ticker) DO UPDATE SET
+            earliest_date = MIN(earliest_date, excluded.earliest_date),
+            latest_date = MAX(latest_date, excluded.latest_date)
+          """,
+        arguments: [
+          row.ticker, row.instrumentId, row.earliestDate, row.latestDate,
+        ])
+    }
+    for row in snapshot.exchangeRateMeta {
+      try database.execute(
+        sql: """
+          INSERT INTO exchange_rate_meta
+          (base, earliest_date, latest_date)
+          VALUES (?, ?, ?)
+          ON CONFLICT(base) DO UPDATE SET
+            earliest_date = MIN(earliest_date, excluded.earliest_date),
+            latest_date = MAX(latest_date, excluded.latest_date)
+          """,
+        arguments: [row.base, row.earliestDate, row.latestDate])
+    }
+  }
+}
+
+/// Snapshot of one per-profile DB. `Database` handles never escape
+/// the read closure; the snapshot is a `Sendable` value type.
+struct PerProfileSnapshot: Sendable {
+  let profileId: UUID
+  let instruments: [InstrumentRow]
+  let cryptoPrices: [CryptoPriceRecord]
+  let stockPrices: [StockPriceRecord]
+  let exchangeRates: [ExchangeRateRecord]
+  let cryptoTokenMeta: [CryptoTokenMetaRecord]
+  let stockTickerMeta: [StockTickerMetaRecord]
+  let exchangeRateMeta: [ExchangeRateMetaRecord]
+
+  /// Reads every relevant table from the per-profile queue into Swift
+  /// value types so the snapshot can be passed to the shared-DB write
+  /// transaction without a live `Database` handle escaping.
+  init(profileId: UUID, queue: DatabaseQueue) async throws {
+    self.profileId = profileId
+    let snapshot = try await queue.read { database in
+      try (
+        InstrumentRow.fetchAll(database),
+        CryptoPriceRecord.fetchAll(database),
+        StockPriceRecord.fetchAll(database),
+        ExchangeRateRecord.fetchAll(database),
+        CryptoTokenMetaRecord.fetchAll(database),
+        StockTickerMetaRecord.fetchAll(database),
+        ExchangeRateMetaRecord.fetchAll(database)
+      )
+    }
+    self.instruments = snapshot.0
+    self.cryptoPrices = snapshot.1
+    self.stockPrices = snapshot.2
+    self.exchangeRates = snapshot.3
+    self.cryptoTokenMeta = snapshot.4
+    self.stockTickerMeta = snapshot.5
+    self.exchangeRateMeta = snapshot.6
+  }
+}

--- a/MoolahTests/Migration/SharedRegistryUnionRunnerTests.swift
+++ b/MoolahTests/Migration/SharedRegistryUnionRunnerTests.swift
@@ -1,0 +1,204 @@
+// MoolahTests/Migration/SharedRegistryUnionRunnerTests.swift
+
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+/// Confirms the shared-registry union runner walks every per-profile
+/// DB, merges instrument + price-cache rows into the shared DB, and
+/// gates re-runs via the UserDefaults flag.
+@MainActor
+@Suite("SharedRegistryUnionRunner", .serialized)
+struct SharedRegistryUnionRunnerTests {
+
+  // MARK: - Fixtures
+
+  private struct Fixture {
+    let sharedQueue: DatabaseQueue
+    let profileQueues: [UUID: DatabaseQueue]
+    let defaults: UserDefaults
+
+    init(perProfileSeeds: [(UUID, (Database) throws -> Void)]) throws {
+      self.sharedQueue = try ProfileIndexDatabase.openInMemory()
+      var queues: [UUID: DatabaseQueue] = [:]
+      for (id, seed) in perProfileSeeds {
+        let queue = try ProfileDatabase.openInMemory()
+        try queue.write { database in try seed(database) }
+        queues[id] = queue
+      }
+      self.profileQueues = queues
+      let suite = "shared-registry-union-tests-\(UUID().uuidString)"
+      // `UserDefaults(suiteName:)` returns nil only for the reserved
+      // names `kCFPreferencesCurrentApplication` and an empty string;
+      // the unique suite generated above guarantees neither.
+      // swiftlint:disable:next force_unwrapping
+      self.defaults = UserDefaults(suiteName: suite)!
+    }
+
+  }
+
+  /// Builds a `@Sendable` closure that opens a fixture's per-profile
+  /// `DatabaseQueue`. Captures only the queues dictionary (a value-
+  /// type `Dictionary` of `Sendable` `DatabaseQueue` references), not
+  /// the `~Copyable` `Fixture`.
+  private static func makeOpener(
+    profileQueues: [UUID: DatabaseQueue]
+  ) -> @Sendable (UUID) throws -> DatabaseQueue {
+    let queues = profileQueues
+    return { id in
+      guard let queue = queues[id] else {
+        struct MissingFixture: Error {}
+        throw MissingFixture()
+      }
+      return queue
+    }
+  }
+
+  /// `FileManager` stand-in that always reports the per-profile DB
+  /// exists. Tests use in-memory queues so the real path doesn't.
+  private final class AlwaysExistsFileManager: FileManager, @unchecked Sendable {
+    override func fileExists(atPath _: String) -> Bool { true }
+  }
+
+  private static func seedInstrument(
+    _ database: Database,
+    id: String,
+    coingeckoId: String,
+    pricingStatus: String = "priced"
+  ) throws {
+    try database.execute(
+      sql: """
+        INSERT INTO instrument
+        (id, record_name, kind, name, decimals, coingecko_id, pricing_status)
+        VALUES (?, ?, 'cryptoToken', ?, 18, ?, ?)
+        """,
+      arguments: [id, id, "Token \(id)", coingeckoId, pricingStatus])
+  }
+
+  // MARK: - Tests
+
+  @Test("union merges instrument rows from every profile DB into the shared registry")
+  func unionMergesInstrumentRows() async throws {
+    let profileA = try #require(UUID(uuidString: "00000000-0000-0000-0000-00000000000a"))
+    let profileB = try #require(UUID(uuidString: "00000000-0000-0000-0000-00000000000b"))
+    let fixture = try Fixture(perProfileSeeds: [
+      (profileA, { try Self.seedInstrument($0, id: "1:0xaaa", coingeckoId: "aaa") }),
+      (profileB, { try Self.seedInstrument($0, id: "1:0xbbb", coingeckoId: "bbb") }),
+    ])
+
+    await SharedRegistryUnionRunner.run(
+      sharedQueue: fixture.sharedQueue,
+      profileIds: [profileA, profileB],
+      perProfileDatabase: Self.makeOpener(profileQueues: fixture.profileQueues),
+      perProfileDatabaseURL: { _ in URL(fileURLWithPath: "/tmp/fake.sqlite") },
+      fileManager: AlwaysExistsFileManager(),
+      defaults: fixture.defaults)
+
+    let ids: Set<String> = try await fixture.sharedQueue.read { database in
+      Set(try String.fetchAll(database, sql: "SELECT id FROM instrument"))
+    }
+    #expect(ids.contains("1:0xaaa"))
+    #expect(ids.contains("1:0xbbb"))
+  }
+
+  @Test("union applies spam-wins merge across profiles")
+  func unionAppliesSpamWinsAcrossProfiles() async throws {
+    // Profile A has bitcoin priced; profile B has bitcoin spam.
+    // Result: spam wins regardless of iteration order.
+    let profileA = try #require(UUID(uuidString: "00000000-0000-0000-0000-00000000000a"))
+    let profileB = try #require(UUID(uuidString: "00000000-0000-0000-0000-00000000000b"))
+    let fixture = try Fixture(perProfileSeeds: [
+      (profileA, { try Self.seedInstrument($0, id: "bitcoin", coingeckoId: "bitcoin") }),
+      (
+        profileB,
+        {
+          try Self.seedInstrument(
+            $0, id: "bitcoin", coingeckoId: "bitcoin", pricingStatus: "spam")
+        }
+      ),
+    ])
+
+    await SharedRegistryUnionRunner.run(
+      sharedQueue: fixture.sharedQueue,
+      profileIds: [profileA, profileB],
+      perProfileDatabase: Self.makeOpener(profileQueues: fixture.profileQueues),
+      perProfileDatabaseURL: { _ in URL(fileURLWithPath: "/tmp/fake.sqlite") },
+      fileManager: AlwaysExistsFileManager(),
+      defaults: fixture.defaults)
+
+    let status: String? = try await fixture.sharedQueue.read { database in
+      try String.fetchOne(
+        database,
+        sql: "SELECT pricing_status FROM instrument WHERE id = 'bitcoin'")
+    }
+    #expect(status == "spam")
+  }
+
+  @Test("re-running with the flag set is a no-op")
+  func reRunningIsNoOpWhenFlagAlreadySet() async throws {
+    let profileA = try #require(UUID(uuidString: "00000000-0000-0000-0000-00000000000a"))
+    let fixture = try Fixture(perProfileSeeds: [
+      (profileA, { try Self.seedInstrument($0, id: "1:0xaaa", coingeckoId: "aaa") })
+    ])
+    fixture.defaults.set(true, forKey: SharedRegistryUnionRunner.unionFlagKey)
+
+    await SharedRegistryUnionRunner.run(
+      sharedQueue: fixture.sharedQueue,
+      profileIds: [profileA],
+      perProfileDatabase: Self.makeOpener(profileQueues: fixture.profileQueues),
+      perProfileDatabaseURL: { _ in URL(fileURLWithPath: "/tmp/fake.sqlite") },
+      fileManager: AlwaysExistsFileManager(),
+      defaults: fixture.defaults)
+
+    let count: Int? = try await fixture.sharedQueue.read { database in
+      try Int.fetchOne(database, sql: "SELECT COUNT(*) FROM instrument")
+    }
+    #expect(count == 0, "instrument table should still be empty when flag pre-set")
+  }
+
+  @Test("flag is set after run completes so subsequent runs are no-ops")
+  func flagIsSetAfterRun() async throws {
+    let profileA = try #require(UUID(uuidString: "00000000-0000-0000-0000-00000000000a"))
+    let fixture = try Fixture(perProfileSeeds: [
+      (profileA, { try Self.seedInstrument($0, id: "1:0xaaa", coingeckoId: "aaa") })
+    ])
+    #expect(fixture.defaults.bool(forKey: SharedRegistryUnionRunner.unionFlagKey) == false)
+
+    await SharedRegistryUnionRunner.run(
+      sharedQueue: fixture.sharedQueue,
+      profileIds: [profileA],
+      perProfileDatabase: Self.makeOpener(profileQueues: fixture.profileQueues),
+      perProfileDatabaseURL: { _ in URL(fileURLWithPath: "/tmp/fake.sqlite") },
+      fileManager: AlwaysExistsFileManager(),
+      defaults: fixture.defaults)
+
+    #expect(fixture.defaults.bool(forKey: SharedRegistryUnionRunner.unionFlagKey))
+  }
+
+  @Test("a profile DB that fails to open is skipped without losing other profiles")
+  func failingProfileIsSkippedAndOthersStillMerge() async throws {
+    let profileA = try #require(UUID(uuidString: "00000000-0000-0000-0000-00000000000a"))
+    let profileFail = try #require(UUID(uuidString: "00000000-0000-0000-0000-00000000000f"))
+    let fixture = try Fixture(perProfileSeeds: [
+      (profileA, { try Self.seedInstrument($0, id: "1:0xaaa", coingeckoId: "aaa") })
+      // profileFail is intentionally not registered → throws on open
+    ])
+
+    await SharedRegistryUnionRunner.run(
+      sharedQueue: fixture.sharedQueue,
+      profileIds: [profileA, profileFail],
+      perProfileDatabase: Self.makeOpener(profileQueues: fixture.profileQueues),
+      perProfileDatabaseURL: { _ in URL(fileURLWithPath: "/tmp/fake.sqlite") },
+      fileManager: AlwaysExistsFileManager(),
+      defaults: fixture.defaults)
+
+    let count: Int? = try await fixture.sharedQueue.read { database in
+      try Int.fetchOne(
+        database, sql: "SELECT COUNT(*) FROM instrument WHERE id = '1:0xaaa'")
+    }
+    #expect(count == 1, "profile A's row should still be merged despite profile-F failing")
+    #expect(fixture.defaults.bool(forKey: SharedRegistryUnionRunner.unionFlagKey))
+  }
+}

--- a/MoolahTests/Migration/SharedRegistryUnionRunnerTests.swift
+++ b/MoolahTests/Migration/SharedRegistryUnionRunnerTests.swift
@@ -15,7 +15,12 @@ struct SharedRegistryUnionRunnerTests {
 
   // MARK: - Fixtures
 
-  private struct Fixture {
+  // `UserDefaults` is thread-safe but not declared `Sendable` in
+  // Foundation, so opt out of the auto-derived check. The fixture
+  // itself escapes to `nonisolated SharedRegistryUnionRunner.run` and
+  // we touch `fixture.defaults` again on the main actor afterwards;
+  // the underlying Obj-C class handles concurrent access internally.
+  private struct Fixture: @unchecked Sendable {
     let sharedQueue: DatabaseQueue
     let profileQueues: [UUID: DatabaseQueue]
     let defaults: UserDefaults


### PR DESCRIPTION
## Summary

Stage 11 of the shared instrument registry plan. One-shot data-union runner that walks every per-profile `data.sqlite` and merges its `instrument` + price-cache rows into the shared `profile-index.sqlite` tables. `UserDefaults`-flag-gated so re-runs are no-ops.

Built on stages 1–10 (PRs #841–#844; all merged). The runner has no caller yet — Stage 12 (app-boot rewiring) will wire it in before any session opens.

## Merge rules

- `instrument` rows delegate to `GRDBInstrumentRegistryRepository.applyRemoteChangesSync`, which already enforces the spam-wins merge via `PricingStatusMerge.merge`.
- `crypto_price` / `stock_price` / `exchange_rate` body rows are content-addressable; `INSERT OR IGNORE` (first writer wins) is correct.
- `*_meta` rows merge `(earliest_date, latest_date)` to the broadest span via explicit `ON CONFLICT(pk) DO UPDATE`.

## Per-profile isolation

Each profile is processed in a separate shared-DB write transaction. A read failure on one profile logs and skips it; previously-merged profiles stay merged. The flag is set after every profile has been attempted.

## Test plan

- [x] `just format-check` clean.
- [x] `just test-mac SharedRegistryUnionRunnerTests` — 5 tests pass.
- [ ] CI on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)