### PR TITLE
fix(positions): collapse split when valuated rows reduce to host-only

### DIFF
--- a/Features/Transactions/Views/MultiInstrumentPositionsSplitModifier.swift
+++ b/Features/Transactions/Views/MultiInstrumentPositionsSplitModifier.swift
@@ -6,10 +6,13 @@ import SwiftUI
 /// valuator `.task(id:)` so the wrapping leaf doesn't need to manage
 /// the valuation lifecycle.
 ///
-/// **Decision predicate** — `shouldShow` returns true iff there are
-/// positions AND the set of non-zero instruments contains anything
-/// other than the host currency. This matches the predicate that used
-/// to live inside `TransactionListView.shouldShowPositionsSplit`.
+/// **Decision predicate** — see `shouldShow(rawPositions:hostCurrency:positionsInput:)`.
+/// Once the valuator has produced a `positionsInput`, that becomes
+/// authoritative because it has already dropped `.knownZero` (`.spam`
+/// / `.unpriced`) rows; relying on the raw-positions heuristic alone
+/// can otherwise leave the split rendered with an inner
+/// `PositionsView` that returns `EmptyView`, manifesting as a large
+/// blank pane above the transactions list.
 ///
 /// **Re-fire trigger** — the `.task(id:)` re-fires whenever the
 /// positions list changes OR the crypto-registry version bumps (e.g.
@@ -26,12 +29,37 @@ struct MultiInstrumentPositionsSplitModifier: ViewModifier {
   @State private var positionsInput: PositionsViewInput?
   @State private var positionsRange: PositionsTimeRange = .threeMonths
 
-  private var shouldShow: Bool {
-    guard !positions.isEmpty else { return false }
+  /// Pure decision helper. Once the valuator produces a
+  /// `positionsInput`, that becomes authoritative — its `shouldHide`
+  /// has already filtered out `.knownZero` (spam / unpriced) positions
+  /// and so agrees with what the inner `PositionsView` will actually
+  /// render. Pre-valuation, fall back to a heuristic on raw positions
+  /// so the split can render with a `ProgressView` while the valuator
+  /// works.
+  ///
+  /// `nonisolated` so unit tests can call this without spinning up a
+  /// `@MainActor` context — the body touches only value-type inputs
+  /// (no view state, no actor-isolated dependencies).
+  nonisolated static func shouldShow(
+    rawPositions: [Position],
+    hostCurrency: Instrument,
+    positionsInput: PositionsViewInput?
+  ) -> Bool {
+    if let positionsInput {
+      return !positionsInput.shouldHide
+    }
+    guard !rawPositions.isEmpty else { return false }
     let nonZeroInstruments = Set(
-      positions.lazy.filter { $0.quantity != 0 }.map(\.instrument)
+      rawPositions.lazy.filter { $0.quantity != 0 }.map(\.instrument)
     )
     return nonZeroInstruments != [hostCurrency]
+  }
+
+  private var shouldShow: Bool {
+    Self.shouldShow(
+      rawPositions: positions,
+      hostCurrency: hostCurrency,
+      positionsInput: positionsInput)
   }
 
   func body(content: Content) -> some View {

--- a/MoolahTests/Features/Transactions/MultiInstrumentSplitShouldShowTests.swift
+++ b/MoolahTests/Features/Transactions/MultiInstrumentSplitShouldShowTests.swift
@@ -1,0 +1,141 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+/// Tests for `MultiInstrumentPositionsSplitModifier.shouldShow`. The
+/// modifier wraps a transaction list in a positions/transactions split
+/// only when the account has positions worth surfacing alongside the
+/// transactions. Two inputs feed the decision:
+///
+/// - Raw `[Position]` from the repository (pre-valuation).
+/// - The valuated `PositionsViewInput`, populated asynchronously by
+///   `PositionsValuator` after the modifier mounts. The valuator drops
+///   `.knownZero` (`.unpriced` / `.spam` crypto) entries, so its
+///   `shouldHide` agrees with what `PositionsView` will actually
+///   render.
+///
+/// Once `positionsInput` is available it is authoritative: relying on
+/// the raw heuristic alone could leave the split allocated for content
+/// the inner `PositionsView` will refuse to render — manifesting as a
+/// large blank section above the transactions list (the case fixed by
+/// this suite).
+@Suite("MultiInstrumentPositionsSplitModifier.shouldShow")
+struct MultiInstrumentSplitShouldShowTests {
+  let aud = Instrument.AUD
+  let usd = Instrument.USD
+  let eth = Instrument.crypto(
+    chainId: 1, contractAddress: nil, symbol: "ETH", name: "Ethereum", decimals: 18)
+  let spam = Instrument.crypto(
+    chainId: 1,
+    contractAddress: "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+    symbol: "SPAM", name: "Spam Airdrop", decimals: 18)
+
+  // MARK: - Authoritative path (positionsInput available)
+
+  /// Spam-airdrop scenario: an Ethereum wallet (`hostCurrency = ETH`)
+  /// holds an ETH balance plus a `.spam`-marked airdrop token. The raw
+  /// positions list still contains both, but the valuator drops the
+  /// spam token to `.knownZero`, so the valuated input ends up with
+  /// only ETH — making the split redundant with the wallet header's
+  /// already-visible balance. The modifier must collapse the split or
+  /// the user sees a blank pane where positions would have rendered.
+  @Test("hides when positionsInput.shouldHide is true even if raw positions look multi-instrument")
+  func hidesWhenInputSaysShouldHide() {
+    let rawPositions = [
+      Position(instrument: eth, quantity: Decimal(string: "0.5") ?? 0),
+      Position(instrument: spam, quantity: 1_000_000),
+    ]
+    // Simulating the post-valuation state: spam dropped to `.knownZero`,
+    // only the ETH row survived.
+    let input = PositionsViewInput(
+      title: "Trust Ethereum 2",
+      hostCurrency: eth,
+      positions: [
+        ValuedPosition(
+          instrument: eth, quantity: Decimal(string: "0.5") ?? 0,
+          unitPrice: nil, costBasis: nil,
+          value: InstrumentAmount(quantity: Decimal(string: "0.5") ?? 0, instrument: eth))
+      ],
+      historicalValue: nil)
+    #expect(input.shouldHide)
+    #expect(
+      !MultiInstrumentPositionsSplitModifier.shouldShow(
+        rawPositions: rawPositions, hostCurrency: eth, positionsInput: input))
+  }
+
+  /// The genuinely-multi-instrument case after valuation: both legs
+  /// survived, so the input does NOT report shouldHide and the split
+  /// continues to render.
+  @Test("shows when positionsInput contains a non-host-currency row")
+  func showsWhenInputHasNonHostInstrument() {
+    let input = PositionsViewInput(
+      title: "Brokerage",
+      hostCurrency: aud,
+      positions: [
+        ValuedPosition(
+          instrument: aud, quantity: 1_000, unitPrice: nil, costBasis: nil,
+          value: InstrumentAmount(quantity: 1_000, instrument: aud)),
+        ValuedPosition(
+          instrument: usd, quantity: 200, unitPrice: nil, costBasis: nil,
+          value: InstrumentAmount(quantity: 304, instrument: aud)),
+      ],
+      historicalValue: nil)
+    #expect(
+      MultiInstrumentPositionsSplitModifier.shouldShow(
+        rawPositions: [
+          Position(instrument: aud, quantity: 1_000),
+          Position(instrument: usd, quantity: 200),
+        ],
+        hostCurrency: aud, positionsInput: input))
+  }
+
+  // MARK: - Pre-valuation fallback (positionsInput == nil)
+
+  /// Before the valuator has produced a `positionsInput`, fall back to
+  /// the raw-positions heuristic so the split can render with a
+  /// `ProgressView` while the valuator works.
+  @Test("falls back to raw heuristic when positionsInput is nil — multi-instrument shows split")
+  func fallbackShowsForMultiInstrumentRaw() {
+    #expect(
+      MultiInstrumentPositionsSplitModifier.shouldShow(
+        rawPositions: [
+          Position(instrument: aud, quantity: 1_000),
+          Position(instrument: usd, quantity: 200),
+        ],
+        hostCurrency: aud, positionsInput: nil))
+  }
+
+  /// Single host-currency position pre-valuation: redundant with the
+  /// host's balance, no split.
+  @Test(
+    "falls back to raw heuristic when positionsInput is nil — single host instrument hides split")
+  func fallbackHidesForHostOnlyRaw() {
+    #expect(
+      !MultiInstrumentPositionsSplitModifier.shouldShow(
+        rawPositions: [Position(instrument: aud, quantity: 1_000)],
+        hostCurrency: aud, positionsInput: nil))
+  }
+
+  /// Empty raw positions pre-valuation: no content for the split.
+  @Test("falls back to raw heuristic when positionsInput is nil — empty positions hides split")
+  func fallbackHidesForEmptyRaw() {
+    #expect(
+      !MultiInstrumentPositionsSplitModifier.shouldShow(
+        rawPositions: [], hostCurrency: aud, positionsInput: nil))
+  }
+
+  /// Zero-quantity rows in the raw positions don't fool the heuristic
+  /// into rendering the split — only non-zero quantities count toward
+  /// the instrument set.
+  @Test("falls back to raw heuristic when positionsInput is nil — zero-qty rows are ignored")
+  func fallbackIgnoresZeroQuantities() {
+    #expect(
+      !MultiInstrumentPositionsSplitModifier.shouldShow(
+        rawPositions: [
+          Position(instrument: aud, quantity: 1_000),
+          Position(instrument: usd, quantity: 0),
+        ],
+        hostCurrency: aud, positionsInput: nil))
+  }
+}


### PR DESCRIPTION
## Summary

- `MultiInstrumentPositionsSplitModifier.shouldShow` now consults `positionsInput.shouldHide` once the valuator has produced one, rather than deciding visibility solely from the raw `[Position]` list.
- The raw-positions heuristic is kept as a pre-valuation fallback so the split can still render a `ProgressView` while the valuator runs on the cold path.
- The predicate is extracted to a `nonisolated static func` so it is unit-testable without spinning up a `@MainActor` SwiftUI context — six tests in `MultiInstrumentSplitShouldShowTests` cover the spam-drop case plus the pre-valuation fallback paths.

## Why

`PositionsValuator` drops `.knownZero` rows (`.spam` / `.unpriced` crypto registrations — see issue #790) before the result reaches the inner `PositionsView`. The valuated `PositionsViewInput.shouldHide` is therefore computed against the surviving rows, while the modifier's pre-fix `shouldShow` predicate looked at the raw `[Position]`. When raw positions had ETH + spam airdrops but the valuator left only ETH, the two predicates disagreed: the modifier kept the `PositionsTransactionsSplit` allocated, but the inner `PositionsView` returned `EmptyView`. The user saw a large blank pane above the transactions list.

Reproducible on a Trust-Ethereum-style wallet whose chain history includes spam airdrops:

- Account balance (computed via `AccountBalanceCalculator.displayBalance`) folded `.knownZero` to zero, so it correctly read the ETH amount.
- The inner positions table was empty (`shouldHide == true`).
- The split's top pane stayed allocated for the missing positions content.

## Test plan

- [x] `MultiInstrumentSplitShouldShowTests` — six new tests covering: spam-drop case (the bug), genuine multi-instrument case, and the four pre-valuation fallback paths (multi-instrument shows, host-only hides, empty hides, zero-quantity rows are ignored).
- [x] `just test-mac` — full macOS suite (2687 tests in 444 suites) passes.
- [x] `just test-ios MultiInstrumentSplitShouldShowTests` — iOS build also passes the new suite.
- [x] `just format-check` clean.
- [ ] Manual verification on the running app with the affected Trust Ethereum 2 wallet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)