### PR TITLE
fix(crypto): point block-explorer link at the bare on-chain hash

### DIFF
--- a/Features/Transactions/Views/Detail/TransactionDetailBlockExplorerSection.swift
+++ b/Features/Transactions/Views/Detail/TransactionDetailBlockExplorerSection.swift
@@ -3,9 +3,11 @@ import SwiftUI
 /// "Block explorer" section in the transaction detail. Shown when at
 /// least one of the transaction's legs has an `externalId` (the on-chain
 /// tx hash recorded by the wallet importer) and a resolvable chain id.
-/// One link per qualifying leg — for a multi-leg merged transfer with
-/// gas + value legs sharing the same hash, both legs render their own
-/// row so the user can see explicit per-leg provenance.
+/// One link per **unique on-chain hash**: a wallet-imported transaction
+/// typically has multiple legs (e.g. transfer + gas) that all share the
+/// same hash, so a single explorer link covers the whole transaction.
+/// On the rare path where legs span multiple hashes, each unique URL
+/// renders once.
 ///
 /// We deliberately render this as plain `Link` rows rather than a
 /// stylised "Open in Etherscan" pill: explorers across chains use
@@ -14,55 +16,49 @@ import SwiftUI
 struct TransactionDetailBlockExplorerSection: View {
   let transaction: Transaction
 
-  /// Legs with both an `externalId` and a chain id resolvable via
-  /// `ChainConfig`, paired with their canonical explorer URL.
-  /// Computed once per render so the body is straight-line code.
-  private var entries: [Entry] {
-    transaction.legs.enumerated().compactMap { index, leg -> Entry? in
-      guard let externalId = leg.externalId,
-        let chainId = leg.instrument.chainId,
-        let url = BlockExplorerLink.transactionURL(chainId: chainId, hash: externalId)
-      else { return nil }
-      return Entry(legIndex: index, url: url, ticker: leg.instrument.displayLabel)
-    }
-  }
-
-  /// Whether the section should render at all. Hidden when no leg has a
-  /// usable explorer link so the section header doesn't appear empty.
-  var isApplicable: Bool { !entries.isEmpty }
+  /// Whether the section should render at all. Hidden when no leg has
+  /// a usable explorer link so the section header doesn't appear empty.
+  var isApplicable: Bool { !Self.explorerURLs(for: transaction.legs).isEmpty }
 
   var body: some View {
-    if isApplicable {
-      let legs = entries
+    let urls = Self.explorerURLs(for: transaction.legs)
+    if !urls.isEmpty {
       Section("Block Explorer") {
-        ForEach(legs) { entry in
-          Link(destination: entry.url) {
+        ForEach(urls, id: \.self) { url in
+          Link(destination: url) {
             Label("View on block explorer", systemImage: "arrow.up.right.square")
-              .accessibilityLabel(accessibilityLabel(for: entry, totalLegs: legs.count))
           }
-          .accessibilityIdentifier(
-            UITestIdentifiers.Detail.blockExplorerLink(legIndex: entry.legIndex))
+          .accessibilityIdentifier(UITestIdentifiers.Detail.blockExplorerLink)
         }
       }
     }
   }
 
-  /// VoiceOver label that disambiguates per-leg links in the multi-leg
-  /// case ("View ETH leg on block explorer") and stays terse in the
-  /// common single-leg case ("View on block explorer").
-  private func accessibilityLabel(for entry: Entry, totalLegs: Int) -> String {
-    totalLegs == 1
-      ? "View on block explorer"
-      : "View \(entry.ticker) leg on block explorer"
-  }
-
-  /// One renderable row. `legIndex` doubles as the `Identifiable` id —
-  /// stable across re-renders because the leg order is fixed by the
-  /// transaction.
-  private struct Entry: Identifiable {
-    let legIndex: Int
-    let url: URL
-    let ticker: String
-    var id: Int { legIndex }
+  /// Distinct block-explorer URLs for the supplied legs in first-seen
+  /// order. The `externalId` overload strips the `<category>:<index>`
+  /// (transfer leg) or `gas` (gas leg) suffix to recover the bare
+  /// on-chain hash the explorer expects — issue #848. The per-URL
+  /// dedup collapses the usual transfer-plus-gas pair (sharing one
+  /// hash) down to a single row, matching the user's mental model
+  /// that one transaction = one explorer link.
+  ///
+  /// `nonisolated` so the dedup logic is testable from a non-MainActor
+  /// suite without spinning up a SwiftUI context. Also exposed as a
+  /// static helper because the view is `@MainActor` and the body's
+  /// "is the section worth rendering" guard wants to share the same
+  /// computation that produces the rows.
+  nonisolated static func explorerURLs(for legs: [TransactionLeg]) -> [URL] {
+    var seen: Set<URL> = []
+    var result: [URL] = []
+    for leg in legs {
+      guard let externalId = leg.externalId,
+        let chainId = leg.instrument.chainId,
+        let url = BlockExplorerLink.transactionURL(chainId: chainId, externalId: externalId)
+      else { continue }
+      if seen.insert(url).inserted {
+        result.append(url)
+      }
+    }
+    return result
   }
 }

--- a/MoolahTests/Features/Transactions/BlockExplorerSectionDedupTests.swift
+++ b/MoolahTests/Features/Transactions/BlockExplorerSectionDedupTests.swift
@@ -1,0 +1,121 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+/// Tests for `TransactionDetailBlockExplorerSection.explorerURLs(for:)`.
+///
+/// A wallet-imported transaction typically has multiple legs (e.g. an
+/// outbound transfer plus its gas leg) that all carry the same on-chain
+/// hash, so the canonical block-explorer URL is the same. The detail
+/// section must collapse those to a single row — the user thinks of
+/// the transaction as one event with one explorer link, not one link
+/// per leg.
+@Suite("TransactionDetailBlockExplorerSection.explorerURLs")
+struct BlockExplorerSectionDedupTests {
+  private let eth = Instrument.crypto(
+    chainId: 1, contractAddress: nil, symbol: "ETH", name: "Ethereum", decimals: 18)
+  private let usdc = Instrument.crypto(
+    chainId: 1,
+    contractAddress: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+    symbol: "USDC", name: "USD Coin", decimals: 6)
+  private static let txHash =
+    "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+  private static let otherTxHash =
+    "0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd"
+
+  /// Outbound ERC-20 transfer + gas leg sharing the same on-chain
+  /// hash: collapsed to a single explorer URL. Reproduces the user-
+  /// reported "two links per transaction" symptom.
+  @Test("collapses transfer + gas legs sharing one hash to one URL")
+  func collapsesTransferAndGasLegs() {
+    let transferLeg = TransactionLeg(
+      accountId: UUID(),
+      instrument: usdc, quantity: -100,
+      externalId: "\(Self.txHash):erc20:0",
+      type: .expense)
+    let gasLeg = TransactionLeg(
+      accountId: UUID(),
+      instrument: eth, quantity: Decimal(string: "-0.0015") ?? 0,
+      externalId: "\(Self.txHash):gas",
+      type: .expense)
+    let urls = TransactionDetailBlockExplorerSection.explorerURLs(
+      for: [transferLeg, gasLeg])
+    #expect(urls.count == 1)
+    #expect(urls.first?.absoluteString == "https://etherscan.io/tx/\(Self.txHash)")
+  }
+
+  /// Multi-event transfer (e.g. swap-like contract emitting two
+  /// transfer events to this wallet) plus the gas leg, all sharing a
+  /// single hash: still one URL.
+  @Test("collapses multiple transfer events from one hash to one URL")
+  func collapsesMultipleTransferEvents() {
+    let event0 = TransactionLeg(
+      accountId: UUID(),
+      instrument: usdc, quantity: -100,
+      externalId: "\(Self.txHash):erc20:0",
+      type: .expense)
+    let event1 = TransactionLeg(
+      accountId: UUID(),
+      instrument: eth, quantity: Decimal(string: "0.05") ?? 0,
+      externalId: "\(Self.txHash):external:1",
+      type: .income)
+    let gasLeg = TransactionLeg(
+      accountId: UUID(),
+      instrument: eth, quantity: Decimal(string: "-0.0015") ?? 0,
+      externalId: "\(Self.txHash):gas",
+      type: .expense)
+    let urls = TransactionDetailBlockExplorerSection.explorerURLs(
+      for: [event0, event1, gasLeg])
+    #expect(urls.count == 1)
+    #expect(urls.first?.absoluteString == "https://etherscan.io/tx/\(Self.txHash)")
+  }
+
+  /// Defensive: should the rare path land here where legs span two
+  /// distinct on-chain hashes (e.g. a manual merge of two crypto
+  /// transactions), each unique URL renders once. Order is first-seen.
+  @Test("keeps distinct URLs when legs span more than one hash")
+  func keepsDistinctHashes() {
+    let legA = TransactionLeg(
+      accountId: UUID(),
+      instrument: eth, quantity: Decimal(string: "-0.5") ?? 0,
+      externalId: "\(Self.txHash):external:0",
+      type: .expense)
+    let legB = TransactionLeg(
+      accountId: UUID(),
+      instrument: eth, quantity: Decimal(string: "-0.0015") ?? 0,
+      externalId: "\(Self.otherTxHash):gas",
+      type: .expense)
+    let urls = TransactionDetailBlockExplorerSection.explorerURLs(for: [legA, legB])
+    #expect(urls.count == 2)
+    #expect(urls[0].absoluteString == "https://etherscan.io/tx/\(Self.txHash)")
+    #expect(urls[1].absoluteString == "https://etherscan.io/tx/\(Self.otherTxHash)")
+  }
+
+  /// Legs without an `externalId` (manually-entered cash transactions)
+  /// or without a chain id (non-crypto legs) contribute no rows.
+  @Test("skips legs without externalId or chain id")
+  func skipsNonCryptoLegs() {
+    let manualCashLeg = TransactionLeg(
+      accountId: UUID(), instrument: .AUD, quantity: 100, type: .income)
+    let cryptoLeg = TransactionLeg(
+      accountId: UUID(),
+      instrument: eth, quantity: Decimal(string: "-0.5") ?? 0,
+      externalId: "\(Self.txHash):external:0",
+      type: .expense)
+    let urls = TransactionDetailBlockExplorerSection.explorerURLs(
+      for: [manualCashLeg, cryptoLeg])
+    #expect(urls.count == 1)
+    #expect(urls.first?.absoluteString == "https://etherscan.io/tx/\(Self.txHash)")
+  }
+
+  /// All-non-crypto transaction → no rows, section collapses entirely.
+  @Test("returns empty when no leg has an explorer URL")
+  func returnsEmptyForNonCryptoTransaction() {
+    let leg1 = TransactionLeg(
+      accountId: UUID(), instrument: .AUD, quantity: -50, type: .expense)
+    let leg2 = TransactionLeg(
+      accountId: UUID(), instrument: .AUD, quantity: 50, type: .income)
+    #expect(TransactionDetailBlockExplorerSection.explorerURLs(for: [leg1, leg2]).isEmpty)
+  }
+}

--- a/MoolahTests/Shared/CryptoImport/BlockExplorerLinkTests.swift
+++ b/MoolahTests/Shared/CryptoImport/BlockExplorerLinkTests.swift
@@ -99,4 +99,58 @@ struct BlockExplorerLinkTests {
       #expect((addressURL?.absoluteString.components(separatedBy: "//").count ?? 0) == 2)
     }
   }
+
+  // MARK: - transactionURL(chainId:externalId:)
+
+  /// Wallet-importer transfer legs persist `externalId` in Alchemy's
+  /// `uniqueId` form `<hash>:<category>:<index>` so a multi-event
+  /// transaction can produce multiple legs without tripping the
+  /// schema's partial unique index. The transaction-detail "View on
+  /// block explorer" link must strip the `:<suffix>` to recover the
+  /// bare hash — passing the full `externalId` to the explorer
+  /// produced a 404 (issue #848).
+  @Test("strips Alchemy transfer-leg uniqueId suffix to recover bare hash")
+  func stripsTransferLegUniqueIdSuffix() {
+    let externalId = "\(Self.txHash):external:0"
+    let url = BlockExplorerLink.transactionURL(chainId: 1, externalId: externalId)
+    #expect(url?.absoluteString == "https://etherscan.io/tx/\(Self.txHash)")
+  }
+
+  /// `TransferReceiptCoalescer` tags the gas leg `<hash>:gas` so it
+  /// shares the `(accountId, externalId)` namespace with the transfer
+  /// legs. The strip rule must cover this form too.
+  @Test("strips gas-leg :gas suffix to recover bare hash")
+  func stripsGasLegSuffix() {
+    let externalId = "\(Self.txHash):gas"
+    let url = BlockExplorerLink.transactionURL(chainId: 137, externalId: externalId)
+    #expect(url?.absoluteString == "https://polygonscan.com/tx/\(Self.txHash)")
+  }
+
+  /// A bare hash (no colon) is valid input — the wallet importer is
+  /// the only producer of the `<hash>:<suffix>` form today, but
+  /// callers passing the bare hash should get the correct URL too.
+  @Test("accepts a bare hash with no suffix")
+  func acceptsBareHash() {
+    let url = BlockExplorerLink.transactionURL(chainId: 1, externalId: Self.txHash)
+    #expect(url?.absoluteString == "https://etherscan.io/tx/\(Self.txHash)")
+  }
+
+  /// An empty externalId — or one whose hash portion is empty
+  /// (`":gas"`) — has nothing to link to. Return `nil` so the caller
+  /// can omit the row rather than building a malformed URL.
+  @Test("returns nil for empty externalId / empty hash before colon")
+  func returnsNilForEmptyHash() {
+    #expect(BlockExplorerLink.transactionURL(chainId: 1, externalId: "") == nil)
+    #expect(BlockExplorerLink.transactionURL(chainId: 1, externalId: ":gas") == nil)
+  }
+
+  /// Unsupported chains continue to return `nil` even when the
+  /// externalId is well-formed — the chain-config gate happens after
+  /// the suffix strip.
+  @Test("returns nil for unsupported chain even with well-formed externalId")
+  func returnsNilForUnsupportedChain() {
+    #expect(
+      BlockExplorerLink.transactionURL(chainId: 42_161, externalId: "\(Self.txHash):external:0")
+        == nil)
+  }
 }

--- a/Shared/CryptoImport/BlockExplorerLink.swift
+++ b/Shared/CryptoImport/BlockExplorerLink.swift
@@ -39,4 +39,22 @@ enum BlockExplorerLink {
       .appendingPathComponent("address", isDirectory: false)
       .appendingPathComponent(address, isDirectory: false)
   }
+
+  /// Convenience for the per-leg "View on block explorer" link in the
+  /// transaction detail. Wallet-importer legs persist `externalId` in
+  /// Alchemy's `uniqueId` form `<hash>:<category>:<index>` (transfer
+  /// legs) or `<hash>:gas` (gas legs) — the suffix scopes the
+  /// `(accountId, externalId)` namespace so a multi-event transaction
+  /// can persist multiple legs from one on-chain hash. The explorer
+  /// expects the bare hash, so this method strips the first `:` and
+  /// everything after before forwarding to
+  /// `transactionURL(chainId:hash:)`. A bare hash (no `:`) is accepted
+  /// unchanged for non-importer call sites. An empty hash portion
+  /// returns `nil`. See issue #848.
+  static func transactionURL(chainId: Int, externalId: String) -> URL? {
+    let parts = externalId.split(
+      separator: ":", maxSplits: 1, omittingEmptySubsequences: false)
+    guard let first = parts.first, !first.isEmpty else { return nil }
+    return transactionURL(chainId: chainId, hash: String(first))
+  }
 }

--- a/UITestSupport/UITestIdentifiers.swift
+++ b/UITestSupport/UITestIdentifiers.swift
@@ -126,13 +126,11 @@ public enum UITestIdentifiers {
       "transactionDetail.trade.feeRemove.\(index)"
     }
 
-    /// "View on block explorer" link for the leg at the given index.
-    /// Only rendered when the leg has a non-nil `externalId` (the on-chain
-    /// transaction hash recorded by the wallet importer) and a chain id
-    /// resolvable through `ChainConfig`.
-    public static func blockExplorerLink(legIndex: Int) -> String {
-      "detail.leg.\(legIndex).blockExplorer"
-    }
+    /// "View on block explorer" link in the transaction detail. One
+    /// row per unique on-chain hash carried by the transaction — for
+    /// the typical wallet-imported transaction (transfer + gas legs
+    /// sharing one hash), this resolves to a single row.
+    public static let blockExplorerLink = "detail.blockExplorer"
 
     /// Truncated on-chain counterparty address row for the leg at the
     /// given index. Only rendered when the leg has a non-nil


### PR DESCRIPTION
## Summary

- The "View on block explorer" link in the transaction detail was 404'ing on every supported explorer because the call site passed the leg's `externalId` (Alchemy's `uniqueId` form `<hash>:<category>:<index>`, or `<hash>:gas` for gas legs) as the URL's hash component.
- New `BlockExplorerLink.transactionURL(chainId:externalId:)` strips the first `:` and everything after before delegating to the bare-hash overload. Empty hash portions return `nil`.
- Per a follow-up from the user — "each tx is one transaction, so there should only be one link" — `TransactionDetailBlockExplorerSection.explorerURLs(for:)` dedupes by URL, collapsing the typical transfer-plus-gas pair down to a single row.
- `UITestIdentifiers.Detail.blockExplorerLink` becomes a constant (`detail.blockExplorer`) since rows are no longer indexed per leg.

## Why

`TransferEventBuilder` writes `externalId` in Alchemy's `uniqueId` form so the schema's `(accountId, externalId)` partial unique index doesn't reject a multi-event transaction. The doc-comment on the builder explicitly notes "the hash itself remains the `BlockExplorerLink.transactionURL` key, so dedup on `externalId` and 'open in explorer' deliberately differ" — the consumer just wasn't honouring that contract. Result on a Trust Ethereum 2 wallet was `https://etherscan.io/tx/0xabc…:external:0`, which Etherscan rejects.

The dedup change addresses a separate UX issue surfaced in the same review pass: the section was rendering one row per qualifying leg, so a wallet-imported transaction with one transfer + one gas leg showed two identical "View on block explorer" links.

Closes #848.

## Test plan

- [x] `BlockExplorerLinkTests` — five new tests covering transfer-leg suffix strip, gas-leg suffix strip, bare-hash pass-through, empty-hash `nil` return, and unsupported-chain `nil` return.
- [x] `BlockExplorerSectionDedupTests` (new) — five tests covering transfer+gas collapse, multi-event collapse, distinct-hash preservation, non-crypto-leg skip, and all-non-crypto empty result.
- [x] `just test-mac` — full macOS suite (2691 tests in 444 suites) passes.
- [x] `just format-check` clean.
- [ ] Manual verification on the affected Trust Ethereum 2 wallet: open a transaction, confirm a single "View on block explorer" row that opens the correct etherscan.io page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)