### PR TITLE
test(sync): cross-profile spam propagation smoking-gun (stage 17)

### DIFF
--- a/App/MoolahApp+Setup.swift
+++ b/App/MoolahApp+Setup.swift
@@ -240,20 +240,45 @@ extension MoolahApp {
   }
 
   /// Constructs the app-level shared `GRDBInstrumentRegistryRepository`
-  /// pointed at the profile-index DB. Mutation hooks are no-ops in
-  /// this stage — the registry is wired into `SyncCoordinator` for
-  /// downlink dispatch only. Production mutations still flow through
-  /// the per-profile registry constructed by
-  /// `ProfileSession+CloudKitBackendBuild.makeInstrumentRegistry`
-  /// until a later stage migrates Settings views and the search
-  /// service to read from this shared instance.
-  ///
-  /// See `plans/2026-05-09-shared-instrument-registry-design.md` and
-  /// `plans/2026-05-09-shared-instrument-registry-plan.md` (Task 12).
+  /// pointed at the profile-index DB. Sync hooks are no-ops at
+  /// construction time and rotated in via
+  /// `attachSharedInstrumentRegistrySyncHooks` once the
+  /// `SyncCoordinator` exists (chicken-and-egg: the coordinator's
+  /// init takes the registry, so the registry can't capture the
+  /// coordinator at its own init).
   static func makeSharedInstrumentRegistry(
     database: any DatabaseWriter
   ) -> GRDBInstrumentRegistryRepository {
     GRDBInstrumentRegistryRepository(database: database)
+  }
+
+  /// Wires the shared registry's mutation hooks to the coordinator's
+  /// `queueSave` / `queueDeletion` against the profile-index zone.
+  /// Called immediately after `SyncCoordinator.init`, which takes the
+  /// registry as a constructor argument.
+  ///
+  /// The `Task { @MainActor in … }` hop matches the per-profile
+  /// pattern in `ProfileSession+CloudKitBackendBuild.makeInstrumentRegistry`:
+  /// registry callbacks fire on the GRDB serial executor
+  /// (off-MainActor) and `SyncCoordinator.queueSave/Deletion` is
+  /// `@MainActor`-isolated.
+  static func attachSharedInstrumentRegistrySyncHooks(
+    registry: GRDBInstrumentRegistryRepository,
+    coordinator: SyncCoordinator
+  ) {
+    let zoneID = CKRecordZone.ID(
+      zoneName: "profile-index", ownerName: CKCurrentUserDefaultName)
+    registry.attachSyncHooks(
+      onRecordChanged: { [weak coordinator] recordName in
+        Task { @MainActor [weak coordinator] in
+          coordinator?.queueSave(recordName: recordName, zoneID: zoneID)
+        }
+      },
+      onRecordDeleted: { [weak coordinator] recordName in
+        Task { @MainActor [weak coordinator] in
+          coordinator?.queueDeletion(recordName: recordName, zoneID: zoneID)
+        }
+      })
   }
 
   static func makeSessionManager(

--- a/App/MoolahApp+Setup.swift
+++ b/App/MoolahApp+Setup.swift
@@ -4,6 +4,7 @@
 
 import CloudKit
 import Foundation
+import GRDB
 import OSLog
 import SwiftData
 import SwiftUI
@@ -222,6 +223,39 @@ extension MoolahApp {
   /// hook closure captures the manager and coordinator weakly so a
   /// cleanup hop after profile deletion doesn't keep them alive past
   /// the app's lifetime.
+  /// Runs the SwiftData→GRDB profile-index migration and then the
+  /// shared-registry union runner, in that order, in a single
+  /// detached `Task`. Returned for tests that need to `await` first-
+  /// launch completion.
+  static func runProfileIndexAndUnionMigrations(
+    setup: ContainerSetup
+  ) -> Task<Void, Never> {
+    Task { [containerManager = setup.manager] in
+      await Self.runProfileIndexMigrationIfNeeded(setup: setup)
+      let profileIds = await containerManager.allProfileIds()
+      await SharedRegistryUnionRunner.run(
+        sharedQueue: containerManager.profileIndexDatabase,
+        profileIds: profileIds)
+    }
+  }
+
+  /// Constructs the app-level shared `GRDBInstrumentRegistryRepository`
+  /// pointed at the profile-index DB. Mutation hooks are no-ops in
+  /// this stage — the registry is wired into `SyncCoordinator` for
+  /// downlink dispatch only. Production mutations still flow through
+  /// the per-profile registry constructed by
+  /// `ProfileSession+CloudKitBackendBuild.makeInstrumentRegistry`
+  /// until a later stage migrates Settings views and the search
+  /// service to read from this shared instance.
+  ///
+  /// See `plans/2026-05-09-shared-instrument-registry-design.md` and
+  /// `plans/2026-05-09-shared-instrument-registry-plan.md` (Task 12).
+  static func makeSharedInstrumentRegistry(
+    database: any DatabaseWriter
+  ) -> GRDBInstrumentRegistryRepository {
+    GRDBInstrumentRegistryRepository(database: database)
+  }
+
   static func makeSessionManager(
     setup: ContainerSetup, store: ProfileStore, coordinator: SyncCoordinator
   ) -> SessionManager {

--- a/App/MoolahApp.swift
+++ b/App/MoolahApp.swift
@@ -111,6 +111,8 @@ struct MoolahApp: App {
     let coordinator = SyncCoordinator(
       containerManager: setup.manager,
       sharedInstrumentRegistry: sharedInstrumentRegistry)
+    Self.attachSharedInstrumentRegistrySyncHooks(
+      registry: sharedInstrumentRegistry, coordinator: coordinator)
     containerManager = setup.manager
     syncCoordinator = coordinator
     uiTestingProfileId = setup.uiTestingProfileId

--- a/App/MoolahApp.swift
+++ b/App/MoolahApp.swift
@@ -78,16 +78,39 @@ struct MoolahApp: App {
       Self.cleanupLegacyRateCachesOnce()
     }
     let setup = Self.makeContainerSetup(uiTestingSeed: uiTestingSeed)
+
+    // Shared instrument registry — one instance per app, pointed at
+    // the profile-index DB. Wired into the SyncCoordinator below so
+    // the profile-index zone can carry `InstrumentRecord` rows; later
+    // stages of the shared-registry plan migrate consumer code paths
+    // (Settings views, search service, conversion service) to read
+    // from this same instance instead of constructing per-profile
+    // registries.
+    //
+    // Mutation hooks queue saves / deletes against the profile-index
+    // zone. The hop to `@MainActor` mirrors the per-profile pattern
+    // in `makeInstrumentRegistry`.
+    let sharedInstrumentRegistry = Self.makeSharedInstrumentRegistry(
+      database: setup.manager.profileIndexDatabase)
+
     // Fire-and-forget: SwiftUI's `App` requires `init` to be non-async,
     // and the migration completes well before the user can navigate
     // from the welcome screen to any view that reads the GRDB
     // profile-index. Errors are logged inside the helper; the next
     // launch retries automatically. Held in `profileIndexMigrationTask`
     // so tests can `await` completion if needed.
-    profileIndexMigrationTask = Task {
-      await Self.runProfileIndexMigrationIfNeeded(setup: setup)
-    }
-    let coordinator = SyncCoordinator(containerManager: setup.manager)
+    //
+    // Runs (a) the SwiftData → GRDB migration that pre-dated the
+    // shared registry, then (b) the one-shot SharedRegistryUnionRunner
+    // that walks every per-profile DB and merges its instrument +
+    // price-cache rows into the shared profile-index DB. The runner
+    // is gated by a UserDefaults flag, so subsequent launches are
+    // no-ops.
+    profileIndexMigrationTask = Self.runProfileIndexAndUnionMigrations(
+      setup: setup)
+    let coordinator = SyncCoordinator(
+      containerManager: setup.manager,
+      sharedInstrumentRegistry: sharedInstrumentRegistry)
     containerManager = setup.manager
     syncCoordinator = coordinator
     uiTestingProfileId = setup.uiTestingProfileId

--- a/App/ProfileSession+CloudKitBackendBuild.swift
+++ b/App/ProfileSession+CloudKitBackendBuild.swift
@@ -26,14 +26,27 @@ extension ProfileSession {
     let zoneID = CKRecordZone.ID(
       zoneName: "profile-\(profile.id.uuidString)",
       ownerName: CKCurrentUserDefaultName)
-    let registry = makeInstrumentRegistry(
-      database: database, zoneID: zoneID, syncCoordinator: syncCoordinator)
-    // Wire the inverse direction: when the per-profile data handler
-    // applies a remote pull that touches `Instrument` rows, fan out to
-    // the registry's local subscribers so the picker UI refreshes
-    // without waiting for an app relaunch.
-    wireInstrumentRemoteChangeFanOut(
-      registry: registry, profileId: profile.id, syncCoordinator: syncCoordinator)
+    // Prefer the app-level shared registry when the coordinator was
+    // constructed with one. All sessions on the same iCloud account
+    // then share a single registry instance, so spam classifications
+    // and discovered-token resolutions propagate without per-profile
+    // duplication. Fall back to a per-profile registry for legacy
+    // callers (preview / tests) that didn't pass a shared instance
+    // through `SyncCoordinator.init`.
+    let registry: GRDBInstrumentRegistryRepository
+    if let shared = syncCoordinator?.sharedInstrumentRegistry {
+      registry = shared
+    } else {
+      registry = makeInstrumentRegistry(
+        database: database, zoneID: zoneID, syncCoordinator: syncCoordinator)
+      // Per-profile registry only — wire the legacy remote-change fan-out.
+      // Shared registries already get the equivalent fan-out from the
+      // profile-index handler's `onInstrumentRemoteChange` closure
+      // installed by `SyncCoordinator.init`, so this call would be
+      // redundant for them.
+      wireInstrumentRemoteChangeFanOut(
+        registry: registry, profileId: profile.id, syncCoordinator: syncCoordinator)
+    }
     // CloudKit profiles need full stock+crypto conversion support. The
     // closure reads the profile's registry on each conversion so
     // registrations added at runtime become usable without rebuilding the

--- a/App/SharedRegistryUnionRunner.swift
+++ b/App/SharedRegistryUnionRunner.swift
@@ -1,0 +1,254 @@
+// App/SharedRegistryUnionRunner.swift
+
+import Foundation
+import GRDB
+import OSLog
+
+/// One-shot data-union migration that walks every per-profile
+/// `data.sqlite` and merges its `instrument` + price-cache rows into
+/// the shared `profile-index.sqlite` tables added by the v3 schema
+/// migration. Gated by a `UserDefaults` flag — once set, the runner
+/// is a no-op forever.
+///
+/// **Per-profile isolation.** Each profile is processed in a separate
+/// shared-DB write transaction. A read failure on one profile (corrupt
+/// file, locked WAL) logs and skips that profile; previously-merged
+/// profiles stay merged. The flag is set after every profile has been
+/// attempted, so a partial run is observable as "some profiles missing
+/// from the shared registry" rather than as "migration retried forever".
+///
+/// **Merge rules.**
+/// * `instrument` rows: delegate to
+///   `GRDBInstrumentRegistryRepository.applyRemoteChangesSync`, which
+///   already enforces the spam-wins merge via `PricingStatusMerge.merge`.
+///   Per-profile sort order (ascending UUID) means later profiles see
+///   their rows applied last.
+/// * `crypto_price` / `stock_price` / `exchange_rate` body rows are
+///   content-addressable (same `(key, date)` ⇒ same value across
+///   profiles). `INSERT OR IGNORE` — first writer wins is fine.
+/// * `crypto_token_meta` / `stock_ticker_meta` / `exchange_rate_meta`:
+///   merge `(earliest_date, latest_date)` to the broadest span via
+///   explicit `ON CONFLICT(pk) DO UPDATE`.
+///
+/// **Concurrency.** `nonisolated`. DB I/O happens on GRDB's serial
+/// executor via `await database.write { … }`; the runner returns when
+/// every profile has been attempted. The caller awaits the runner from
+/// the app boot path before opening any session.
+///
+/// See `plans/2026-05-09-shared-instrument-registry-design.md` (Step
+/// 2 of §Migration) and the implementation plan (Task 11).
+enum SharedRegistryUnionRunner {
+  /// `UserDefaults` key gating the union. Once `true`, the runner is
+  /// a no-op forever.
+  static let unionFlagKey =
+    "com.moolah.migration.shared-registry-union.v1.completed"
+
+  /// Runs the union once. Calls past the first run are no-ops.
+  ///
+  /// - Parameters:
+  ///   - sharedQueue: The profile-index `DatabaseWriter` (e.g. a
+  ///     migrated `DatabaseQueue` from `ProfileIndexDatabase.open`).
+  ///   - profileIds: The ids of every profile whose per-profile DB
+  ///     should be unioned. Sorted ascending by `uuidString` to
+  ///     produce a deterministic merge order across re-runs.
+  ///   - perProfileDatabase: Opens the per-profile DB at the supplied
+  ///     id. Defaults to `ProfileSession.openProfileDatabase(profileId:)`.
+  ///     Tests pass a stub.
+  ///   - fileManager: Used to check that the per-profile DB file
+  ///     exists before attempting an open (so a missing file silently
+  ///     skips that profile rather than throwing).
+  ///   - defaults: The `UserDefaults` instance to read / write the
+  ///     gating flag.
+  static func run(
+    sharedQueue: any DatabaseWriter,
+    profileIds: [UUID],
+    perProfileDatabase: @Sendable (UUID) throws -> DatabaseQueue =
+      ProfileSession.openProfileDatabase(profileId:),
+    perProfileDatabaseURL: @Sendable (UUID) -> URL = { profileId in
+      ProfileSession.profileDatabaseDirectory(for: profileId)
+        .appendingPathComponent("data.sqlite")
+    },
+    fileManager: FileManager = .default,
+    defaults: UserDefaults = .standard
+  ) async {
+    let logger = Logger(
+      subsystem: "com.moolah.app", category: "SharedRegistryUnion")
+
+    if defaults.bool(forKey: unionFlagKey) {
+      logger.info("Shared-registry union already completed — skipping")
+      return
+    }
+
+    let sortedIds = profileIds.sorted { $0.uuidString < $1.uuidString }
+    var successfulCount = 0
+    var skippedCount = 0
+    let registry = GRDBInstrumentRegistryRepository(database: sharedQueue)
+
+    for profileId in sortedIds {
+      let url = perProfileDatabaseURL(profileId)
+      guard fileManager.fileExists(atPath: url.path) else {
+        logger.warning(
+          "Profile \(profileId, privacy: .public) has no data.sqlite — skipping"
+        )
+        skippedCount += 1
+        continue
+      }
+
+      do {
+        let snapshot = try await PerProfileSnapshot(
+          profileId: profileId, queue: try perProfileDatabase(profileId))
+        try await applySnapshot(
+          snapshot, sharedQueue: sharedQueue, registry: registry)
+        successfulCount += 1
+      } catch {
+        logger.error(
+          "Profile \(profileId, privacy: .public) union failed (\(error, privacy: .public)) — skipping"
+        )
+        skippedCount += 1
+      }
+    }
+
+    defaults.set(true, forKey: unionFlagKey)
+    logger.info(
+      """
+      Shared-registry union complete \
+      (successful=\(successfulCount), skipped=\(skippedCount))
+      """)
+  }
+
+  // MARK: - Apply
+
+  private static func applySnapshot(
+    _ snapshot: PerProfileSnapshot,
+    sharedQueue: any DatabaseWriter,
+    registry: GRDBInstrumentRegistryRepository
+  ) async throws {
+    // Instruments use the existing apply path so the spam-wins merge
+    // rule is shared, not duplicated. Each call opens its own write
+    // transaction; that's acceptable here because the per-profile
+    // batches are independent and a mid-batch failure is logged + the
+    // outer loop moves on to the next profile.
+    try registry.applyRemoteChangesSync(
+      saved: snapshot.instruments, deleted: [])
+
+    // Price-cache rows / meta rows in a single write per profile.
+    try await sharedQueue.write { database in
+      try mergeBodyRows(snapshot: snapshot, database: database)
+      try mergeMetaRows(snapshot: snapshot, database: database)
+    }
+  }
+
+  /// Body tables are content-addressable: `(key, date)` deterministic
+  /// ⇒ same value. `INSERT OR IGNORE` — first writer wins.
+  private static func mergeBodyRows(
+    snapshot: PerProfileSnapshot, database: Database
+  ) throws {
+    for row in snapshot.cryptoPrices {
+      try database.execute(
+        sql: """
+          INSERT OR IGNORE INTO crypto_price (token_id, date, price_usd)
+          VALUES (?, ?, ?)
+          """,
+        arguments: [row.tokenId, row.date, row.priceUsd])
+    }
+    for row in snapshot.stockPrices {
+      try database.execute(
+        sql: """
+          INSERT OR IGNORE INTO stock_price (ticker, date, price)
+          VALUES (?, ?, ?)
+          """,
+        arguments: [row.ticker, row.date, row.price])
+    }
+    for row in snapshot.exchangeRates {
+      try database.execute(
+        sql: """
+          INSERT OR IGNORE INTO exchange_rate (base, quote, date, rate)
+          VALUES (?, ?, ?, ?)
+          """,
+        arguments: [row.base, row.quote, row.date, row.rate])
+    }
+  }
+
+  /// Meta tables: merge the date span via `ON CONFLICT(pk) DO UPDATE`.
+  /// Earliest-date is the `MIN`; latest-date is the `MAX`.
+  private static func mergeMetaRows(
+    snapshot: PerProfileSnapshot, database: Database
+  ) throws {
+    for row in snapshot.cryptoTokenMeta {
+      try database.execute(
+        sql: """
+          INSERT INTO crypto_token_meta
+          (token_id, symbol, earliest_date, latest_date)
+          VALUES (?, ?, ?, ?)
+          ON CONFLICT(token_id) DO UPDATE SET
+            earliest_date = MIN(earliest_date, excluded.earliest_date),
+            latest_date = MAX(latest_date, excluded.latest_date)
+          """,
+        arguments: [row.tokenId, row.symbol, row.earliestDate, row.latestDate])
+    }
+    for row in snapshot.stockTickerMeta {
+      try database.execute(
+        sql: """
+          INSERT INTO stock_ticker_meta
+          (ticker, instrument_id, earliest_date, latest_date)
+          VALUES (?, ?, ?, ?)
+          ON CONFLICT(ticker) DO UPDATE SET
+            earliest_date = MIN(earliest_date, excluded.earliest_date),
+            latest_date = MAX(latest_date, excluded.latest_date)
+          """,
+        arguments: [
+          row.ticker, row.instrumentId, row.earliestDate, row.latestDate,
+        ])
+    }
+    for row in snapshot.exchangeRateMeta {
+      try database.execute(
+        sql: """
+          INSERT INTO exchange_rate_meta
+          (base, earliest_date, latest_date)
+          VALUES (?, ?, ?)
+          ON CONFLICT(base) DO UPDATE SET
+            earliest_date = MIN(earliest_date, excluded.earliest_date),
+            latest_date = MAX(latest_date, excluded.latest_date)
+          """,
+        arguments: [row.base, row.earliestDate, row.latestDate])
+    }
+  }
+}
+
+/// Snapshot of one per-profile DB. `Database` handles never escape
+/// the read closure; the snapshot is a `Sendable` value type.
+struct PerProfileSnapshot: Sendable {
+  let profileId: UUID
+  let instruments: [InstrumentRow]
+  let cryptoPrices: [CryptoPriceRecord]
+  let stockPrices: [StockPriceRecord]
+  let exchangeRates: [ExchangeRateRecord]
+  let cryptoTokenMeta: [CryptoTokenMetaRecord]
+  let stockTickerMeta: [StockTickerMetaRecord]
+  let exchangeRateMeta: [ExchangeRateMetaRecord]
+
+  /// Reads every relevant table from the per-profile queue into Swift
+  /// value types so the snapshot can be passed to the shared-DB write
+  /// transaction without a live `Database` handle escaping.
+  init(profileId: UUID, queue: DatabaseQueue) async throws {
+    self.profileId = profileId
+    let snapshot = try await queue.read { database in
+      try (
+        InstrumentRow.fetchAll(database),
+        CryptoPriceRecord.fetchAll(database),
+        StockPriceRecord.fetchAll(database),
+        ExchangeRateRecord.fetchAll(database),
+        CryptoTokenMetaRecord.fetchAll(database),
+        StockTickerMetaRecord.fetchAll(database),
+        ExchangeRateMetaRecord.fetchAll(database)
+      )
+    }
+    self.instruments = snapshot.0
+    self.cryptoPrices = snapshot.1
+    self.stockPrices = snapshot.2
+    self.exchangeRates = snapshot.3
+    self.cryptoTokenMeta = snapshot.4
+    self.stockTickerMeta = snapshot.5
+    self.exchangeRateMeta = snapshot.6
+  }
+}

--- a/Backends/CloudKit/Sync/ProfileIndexSyncHandler+Instruments.swift
+++ b/Backends/CloudKit/Sync/ProfileIndexSyncHandler+Instruments.swift
@@ -98,6 +98,28 @@ extension ProfileIndexSyncHandler {
     return freshRecord
   }
 
+  /// Returns CKRecord.IDs for every shared `instrument` row whose
+  /// `encoded_system_fields` is `NULL`. Used by the coordinator's
+  /// startup self-heal scan: rows that didn't sync-roundtrip (because
+  /// the union runner committed but CKSyncEngine state never
+  /// persisted, or because a registry mutation fired its hook before
+  /// the engine was ready) get re-queued on the next launch.
+  ///
+  /// Returns an empty list when no `instrumentRepository` is wired —
+  /// no shared registry to scan.
+  func queueUnsyncedSharedInstrumentRecords() -> [CKRecord.ID] {
+    guard let instrumentRepository else { return [] }
+    do {
+      let ids = try instrumentRepository.unsyncedRowIdsSync()
+      return ids.map { CKRecord.ID(recordName: $0, zoneID: zoneID) }
+    } catch {
+      logger.error(
+        "queueUnsyncedSharedInstrumentRecords: failed: \(error, privacy: .public)"
+      )
+      return []
+    }
+  }
+
   /// Applies the spam-wins conflict merge for `InstrumentRecord`
   /// when CKSyncEngine reports `.serverRecordChanged`. The merge
   /// rule is the same one the downlink path runs in

--- a/Backends/CloudKit/Sync/SyncCoordinator+Backfill.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+Backfill.swift
@@ -147,6 +147,32 @@ extension SyncCoordinator {
     return queued
   }
 
+  /// Re-queues shared `InstrumentRecord` rows whose
+  /// `encoded_system_fields` is `NULL`. Closes the residual idempotency
+  /// gap between "shared-registry GRDB write committed" and
+  /// "CKSyncEngine state file persisted" — if the app crashes between
+  /// those two events, the union-runner row still exists in the shared
+  /// DB but no pending change ever queued. The next launch catches it
+  /// here.
+  ///
+  /// Idempotent — CKSyncEngine dedupes against any pending changes
+  /// already in flight, and successful uploads stamp
+  /// `encoded_system_fields`, so subsequent scans skip the row.
+  /// Cheap: O(rows in shared `instrument` table) — typically a few
+  /// hundred.
+  @discardableResult
+  func queueUnsyncedSharedInstruments() -> [CKRecord.ID] {
+    let recordIDs = profileIndexHandler.queueUnsyncedSharedInstrumentRecords()
+    if !recordIDs.isEmpty {
+      syncEngine?.state.add(
+        pendingRecordZoneChanges: recordIDs.map { .saveRecord($0) })
+      refreshPendingUploadsMirror()
+      logger.info(
+        "Self-heal queued \(recordIDs.count) unsynced shared instrument(s)")
+    }
+    return recordIDs
+  }
+
   func queueAllExistingRecordsForAllZones() async {
     // Queue profile-index records
     let indexRecordIDs = profileIndexHandler.queueAllExistingRecords()

--- a/Backends/CloudKit/Sync/SyncCoordinator+Lifecycle.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+Lifecycle.swift
@@ -197,6 +197,12 @@ extension SyncCoordinator {
       // pending list dedupes against rows already queued via the new
       // hook plumbing.
       _ = await self.queueUnsyncedInstrumentsForAllProfiles()
+      // Shared-registry self-heal — re-queues any `instrument` row in
+      // the profile-index DB whose `encoded_system_fields` is NULL.
+      // Closes the gap between "union runner committed" and "engine
+      // state file persisted" by catching first-launch rows that
+      // never made it into the pending list. Cheap and idempotent.
+      _ = self.queueUnsyncedSharedInstruments()
       if self.hasPendingChanges {
         self.logger.info("Zones ready — sending pending changes")
         await self.sendChanges()

--- a/Backends/CloudKit/Sync/SyncCoordinator.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator.swift
@@ -157,6 +157,16 @@ final class SyncCoordinator {
   /// read the handler without a MainActor hop.
   nonisolated let profileIndexHandler: ProfileIndexSyncHandler
 
+  /// The app-level shared `GRDBInstrumentRegistryRepository`. Exposed
+  /// so `ProfileSession.makeCloudKitBackend` can hand the same instance
+  /// to every session's `CloudKitBackend`. Stage 12b migrates Settings
+  /// views, the search service, and the conversion service from
+  /// per-profile registries to this shared instance.
+  ///
+  /// `nil` for legacy callers (e.g. tests) that don't pass a shared
+  /// registry — those continue with the per-profile registry path.
+  nonisolated let sharedInstrumentRegistry: GRDBInstrumentRegistryRepository?
+
   // Cross-file-access note: members below this MARK that sibling extension
   // files (Lifecycle / Zones / Backfill / RecordChanges / Delegate) touch are
   // `internal` rather than `private`. Swift does not treat extensions in
@@ -319,6 +329,7 @@ final class SyncCoordinator {
     self.containerManager = containerManager
     self.userDefaults = userDefaults
     self.progress = SyncProgress(userDefaults: userDefaults)
+    self.sharedInstrumentRegistry = sharedInstrumentRegistry
     self.profileIndexHandler = ProfileIndexSyncHandler(
       repository: containerManager.profileIndexRepository,
       instrumentRepository: sharedInstrumentRegistry,

--- a/Backends/CloudKit/Sync/SyncCoordinator.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator.swift
@@ -313,13 +313,17 @@ final class SyncCoordinator {
   init(
     containerManager: ProfileContainerManager,
     userDefaults: UserDefaults = .standard,
-    isCloudKitAvailable: Bool = CloudKitAuthProvider.isCloudKitAvailable
+    isCloudKitAvailable: Bool = CloudKitAuthProvider.isCloudKitAvailable,
+    sharedInstrumentRegistry: GRDBInstrumentRegistryRepository? = nil
   ) {
     self.containerManager = containerManager
     self.userDefaults = userDefaults
     self.progress = SyncProgress(userDefaults: userDefaults)
     self.profileIndexHandler = ProfileIndexSyncHandler(
-      repository: containerManager.profileIndexRepository)
+      repository: containerManager.profileIndexRepository,
+      instrumentRepository: sharedInstrumentRegistry,
+      onInstrumentRemoteChange: Self.makeInstrumentRemoteChangeFanOut(
+        registry: sharedInstrumentRegistry))
     self.isCloudKitAvailable = isCloudKitAvailable
     if !isCloudKitAvailable {
       applyICloudAvailability(.unavailable(reason: .entitlementsMissing))
@@ -328,6 +332,26 @@ final class SyncCoordinator {
     // The closures it installs capture `[weak self]` and depend on every
     // stored property of SyncCoordinator being assigned.
     wireProfileIndexHooks()
+  }
+
+  /// Builds the `@Sendable` closure that the profile-index handler
+  /// fires after applying remote `InstrumentRecord` rows. The closure
+  /// hops to `@MainActor` to invoke `notifyExternalChange()` on the
+  /// `@MainActor`-isolated registry.
+  ///
+  /// `nil` registry → no-op closure. Keeps the handler's
+  /// `nonisolated let` non-optional shape with the existing safe-by-
+  /// default behaviour for legacy callers that don't wire a shared
+  /// registry.
+  private static func makeInstrumentRemoteChangeFanOut(
+    registry: GRDBInstrumentRegistryRepository?
+  ) -> @Sendable () -> Void {
+    guard let registry else { return {} }
+    return { [weak registry] in
+      Task { @MainActor [weak registry] in
+        registry?.notifyExternalChange()
+      }
+    }
   }
 
   // MARK: - Fetch-Session Book-keeping

--- a/Backends/GRDB/Repositories/GRDBInstrumentRegistryRepository+SyncEntryPoints.swift
+++ b/Backends/GRDB/Repositories/GRDBInstrumentRegistryRepository+SyncEntryPoints.swift
@@ -1,0 +1,89 @@
+// Backends/GRDB/Repositories/GRDBInstrumentRegistryRepository+SyncEntryPoints.swift
+
+import Foundation
+import GRDB
+
+/// Synchronous entry points consumed by `ProfileIndexSyncHandler` and
+/// the coordinator's startup self-heal scan. Extracted from the main
+/// repository file so it stays under SwiftLint's `file_length` and
+/// `type_body_length` thresholds.
+///
+/// These methods are called from the CKSyncEngine delegate executor
+/// on a non-MainActor context. `DatabaseWriter.write { db in … }` has
+/// both async and sync overloads; the sync form blocks the calling
+/// thread until the queue's serial executor admits the closure. Never
+/// call any of these from `@MainActor`.
+extension GRDBInstrumentRegistryRepository {
+
+  /// Writes (or clears) the cached system-fields blob on a single row.
+  /// Returns `true` when a row was found and updated.
+  @discardableResult
+  func setEncodedSystemFieldsSync(id: String, data: Data?) throws -> Bool {
+    try database.write { database in
+      try InstrumentRow
+        .filter(InstrumentRow.Columns.id == id)
+        .updateAll(database, [InstrumentRow.Columns.encodedSystemFields.set(to: data)])
+        > 0
+    }
+  }
+
+  /// Clears `encoded_system_fields` on every row. Used after an
+  /// `encryptedDataReset`.
+  func clearAllSystemFieldsSync() throws {
+    try database.write { database in
+      _ =
+        try InstrumentRow
+        .updateAll(
+          database,
+          [InstrumentRow.Columns.encodedSystemFields.set(to: nil)])
+    }
+  }
+
+  /// Returns IDs of rows whose `encoded_system_fields` is `NULL`.
+  func unsyncedRowIdsSync() throws -> [String] {
+    try database.read { database in
+      try InstrumentRow
+        .filter(InstrumentRow.Columns.encodedSystemFields == nil)
+        .select(InstrumentRow.Columns.id, as: String.self)
+        .fetchAll(database)
+    }
+  }
+
+  /// Returns IDs of every row in the table.
+  func allRowIdsSync() throws -> [String] {
+    try database.read { database in
+      try InstrumentRow
+        .select(InstrumentRow.Columns.id, as: String.self)
+        .fetchAll(database)
+    }
+  }
+
+  /// Looks up a single row by id. Used by the per-record upload path
+  /// in the sync handler.
+  func fetchRowSync(id: String) throws -> InstrumentRow? {
+    try database.read { database in
+      try InstrumentRow
+        .filter(InstrumentRow.Columns.id == id)
+        .fetchOne(database)
+    }
+  }
+
+  /// Batch lookup by ids — used by the batch-build phase of the sync
+  /// handler.
+  func fetchRowsSync(ids: [String]) throws -> [InstrumentRow] {
+    let idSet = Set(ids)
+    return try database.read { database in
+      try InstrumentRow
+        .filter(idSet.contains(InstrumentRow.Columns.id))
+        .fetchAll(database)
+    }
+  }
+
+  /// Deletes every row in the table. Used by `deleteLocalData` after
+  /// a remote zone deletion.
+  func deleteAllSync() throws {
+    try database.write { database in
+      _ = try InstrumentRow.deleteAll(database)
+    }
+  }
+}

--- a/Backends/GRDB/Repositories/GRDBInstrumentRegistryRepository+SyncHooks.swift
+++ b/Backends/GRDB/Repositories/GRDBInstrumentRegistryRepository+SyncHooks.swift
@@ -1,0 +1,45 @@
+// Backends/GRDB/Repositories/GRDBInstrumentRegistryRepository+SyncHooks.swift
+
+import Foundation
+import os
+
+/// Sync-hook plumbing for `GRDBInstrumentRegistryRepository`.
+///
+/// Extracted from the main file so it stays under SwiftLint's
+/// `file_length` and `type_body_length` thresholds. The shared
+/// instrument registry is constructed at app boot before
+/// `SyncCoordinator` exists; the coordinator rotates real hooks in
+/// via `attachSyncHooks` once both objects are available. Mirrors
+/// the lock-guarded `HookState` shape used by
+/// `GRDBProfileIndexRepository`.
+extension GRDBInstrumentRegistryRepository {
+  /// Replaces both hook closures atomically. Called by the
+  /// `SyncCoordinator` once it exists; before that the repo is using
+  /// the no-op closures from `init`.
+  func attachSyncHooks(
+    onRecordChanged: @escaping @Sendable (String) -> Void,
+    onRecordDeleted: @escaping @Sendable (String) -> Void
+  ) {
+    hooks.withLock { state in
+      state.onRecordChanged = onRecordChanged
+      state.onRecordDeleted = onRecordDeleted
+    }
+  }
+
+  /// Captures `onRecordChanged` under the lock, releases the lock,
+  /// then invokes the captured closure. Non-reentrant lock semantics
+  /// mean the client closure must never re-enter the repo while the
+  /// lock is held, so the read-then-call pattern is required.
+  func fireOnRecordChanged(_ id: String) {
+    let notify = hooks.withLock { $0.onRecordChanged }
+    notify(id)
+  }
+
+  /// Captures `onRecordDeleted` under the lock, releases the lock,
+  /// then invokes the captured closure. Same non-reentrancy rationale
+  /// as `fireOnRecordChanged`.
+  func fireOnRecordDeleted(_ id: String) {
+    let notify = hooks.withLock { $0.onRecordDeleted }
+    notify(id)
+  }
+}

--- a/Backends/GRDB/Repositories/GRDBInstrumentRegistryRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBInstrumentRegistryRepository.swift
@@ -3,6 +3,7 @@
 import Foundation
 import GRDB
 import OSLog
+import os
 
 /// GRDB-backed implementation of `InstrumentRegistryRepository`. Replaces
 /// the SwiftData-backed `CloudKitInstrumentRegistryRepository` for the
@@ -16,23 +17,12 @@ import OSLog
 /// mutations, and a non-protocol `notifyExternalChange()` method that the
 /// sync layer calls when remote pulls touch instrument rows.
 ///
-/// **`@unchecked Sendable` justification.** Unlike the all-`let`
-/// pattern of the other nine GRDB repositories, this one has a
-/// genuinely mutable stored property: `subscribers`, the
-/// `[UUID: AsyncStream<Void>.Continuation]` map that drives
-/// `observeChanges()`. That property is `@MainActor`-isolated, so
-/// every mutation (`observeChanges()`, the AsyncStream's
-/// `onTermination` callback, `notifyExternalChange()`) runs on the
-/// main actor. Swift can't propagate that property-level isolation
-/// into the enclosing class's `Sendable` check, so we use `@unchecked`
-/// to vouch for the runtime guarantee. The remaining stored
-/// properties are `let`: `database` (`any DatabaseWriter`) is itself
-/// `Sendable` (GRDB queue's serial executor mediates concurrent
-/// access); `onRecordChanged` / `onRecordDeleted` are `@Sendable`
-/// closures captured at init; `logger` is a value type. The
-/// `@MainActor`-confined dictionary plus the otherwise-immutable
-/// surface keeps the type race-free in practice.
-/// See `guides/CONCURRENCY_GUIDE.md` §2 "False Positives to Avoid",
+/// **`@unchecked Sendable` justification.** Has two mutable stored
+/// properties: `subscribers` (the `@MainActor`-confined
+/// AsyncStream-continuation map driving `observeChanges()`) and
+/// `hooks` (the lock-guarded `HookState` swapped in by
+/// `attachSyncHooks`). Both are race-free at runtime — see
+/// `guides/CONCURRENCY_GUIDE.md` §2 "False Positives to Avoid",
 /// Carve-out 3 (GRDB repositories).
 final class GRDBInstrumentRegistryRepository:
   InstrumentRegistryRepository, @unchecked Sendable
@@ -42,9 +32,26 @@ final class GRDBInstrumentRegistryRepository:
   // hosts `cryptoRegistration(byId:)` to keep this file under SwiftLint's
   // length budgets) can read from it. The other stored properties remain
   // private — only the database handle is shared across files.
+  /// Holds the post-init hook closures so they can be swapped in
+  /// atomically by `attachSyncHooks`. Mirrors the pattern used by
+  /// `GRDBProfileIndexRepository` — the shared registry is constructed
+  /// at app boot before the `SyncCoordinator` exists, so the hooks
+  /// arrive later via the lock-guarded swap.
+  ///
+  /// `internal` (default) so the sibling `+SyncHooks` extension file
+  /// can declare `attachSyncHooks` over it.
+  struct HookState {
+    var onRecordChanged: @Sendable (String) -> Void
+    var onRecordDeleted: @Sendable (String) -> Void
+  }
+
   let database: any DatabaseWriter
-  private let onRecordChanged: @Sendable (String) -> Void
-  private let onRecordDeleted: @Sendable (String) -> Void
+  // `internal` (default) so the sibling `+SyncHooks` extension file
+  // can read / mutate the lock-guarded hook closures. The lock itself
+  // is the threading primitive; the property's visibility is module-
+  // scoped because Swift extensions in separate files don't share
+  // `private` access.
+  let hooks: OSAllocatedUnfairLock<HookState>
   private let logger = Logger(
     subsystem: "com.moolah.app", category: "InstrumentRegistry")
 
@@ -63,9 +70,19 @@ final class GRDBInstrumentRegistryRepository:
     onRecordDeleted: @escaping @Sendable (String) -> Void = { _ in }
   ) {
     self.database = database
-    self.onRecordChanged = onRecordChanged
-    self.onRecordDeleted = onRecordDeleted
+    self.hooks = OSAllocatedUnfairLock(
+      initialState: HookState(
+        onRecordChanged: onRecordChanged,
+        onRecordDeleted: onRecordDeleted))
   }
+
+  // MARK: - Cross-extension internals
+  //
+  // `attachSyncHooks` and the `fireOnRecord*` helpers live in
+  // `GRDBInstrumentRegistryRepository+SyncHooks.swift` so this file
+  // stays under SwiftLint's `file_length` / `type_body_length`
+  // thresholds. They access `hooks` directly via the `internal`
+  // visibility implied by Swift's same-module-extension scope.
 
   // MARK: - InstrumentRegistryRepository conformance
 
@@ -105,7 +122,7 @@ final class GRDBInstrumentRegistryRepository:
       try Self.upsertCrypto(
         database: database, instrument: instrument, mapping: mapping)
     }
-    onRecordChanged(instrument.id)
+    fireOnRecordChanged(instrument.id)
     await notifySubscribers()
   }
 
@@ -114,7 +131,7 @@ final class GRDBInstrumentRegistryRepository:
     try await database.write { database in
       try Self.upsertStock(database: database, instrument: instrument)
     }
-    onRecordChanged(instrument.id)
+    fireOnRecordChanged(instrument.id)
     await notifySubscribers()
   }
 
@@ -131,7 +148,7 @@ final class GRDBInstrumentRegistryRepository:
       return try InstrumentRow.deleteOne(database, key: id)
     }
     guard didDelete else { return }
-    onRecordDeleted(id)
+    fireOnRecordDeleted(id)
     await notifySubscribers()
   }
 
@@ -312,83 +329,15 @@ final class GRDBInstrumentRegistryRepository:
         "InstrumentRegistry: no row registered for id '\(registration.instrument.id)'"
       )
     }
-    onRecordChanged(registration.instrument.id)
+    fireOnRecordChanged(registration.instrument.id)
     await notifySubscribers()
   }
 
-  /// Writes (or clears) the cached system-fields blob on a single row.
-  /// Returns `true` when a row was found and updated.
-  @discardableResult
-  func setEncodedSystemFieldsSync(id: String, data: Data?) throws -> Bool {
-    try database.write { database in
-      try InstrumentRow
-        .filter(InstrumentRow.Columns.id == id)
-        .updateAll(database, [InstrumentRow.Columns.encodedSystemFields.set(to: data)])
-        > 0
-    }
-  }
-
-  /// Clears `encoded_system_fields` on every row. Used after an
-  /// `encryptedDataReset`.
-  func clearAllSystemFieldsSync() throws {
-    try database.write { database in
-      _ =
-        try InstrumentRow
-        .updateAll(
-          database,
-          [InstrumentRow.Columns.encodedSystemFields.set(to: nil)])
-    }
-  }
-
-  /// Returns IDs of rows whose `encoded_system_fields` is `NULL`.
-  func unsyncedRowIdsSync() throws -> [String] {
-    try database.read { database in
-      try InstrumentRow
-        .filter(InstrumentRow.Columns.encodedSystemFields == nil)
-        .select(InstrumentRow.Columns.id, as: String.self)
-        .fetchAll(database)
-    }
-  }
-
-  // `unsyncedNonFiatRowIdsSync` lives in
-  // `GRDBInstrumentRegistryRepository+Lookup.swift` to keep this file
-  // under SwiftLint's `type_body_length` and `file_length` budgets.
-
-  /// Returns IDs of every row in the table.
-  func allRowIdsSync() throws -> [String] {
-    try database.read { database in
-      try InstrumentRow
-        .select(InstrumentRow.Columns.id, as: String.self)
-        .fetchAll(database)
-    }
-  }
-
-  /// Looks up a single row by id. Used by the per-record upload path in
-  /// the sync handler.
-  func fetchRowSync(id: String) throws -> InstrumentRow? {
-    try database.read { database in
-      try InstrumentRow
-        .filter(InstrumentRow.Columns.id == id)
-        .fetchOne(database)
-    }
-  }
-
-  /// Batch lookup by ids — used by the batch-build phase of the sync
-  /// handler.
-  func fetchRowsSync(ids: [String]) throws -> [InstrumentRow] {
-    let idSet = Set(ids)
-    return try database.read { database in
-      try InstrumentRow
-        .filter(idSet.contains(InstrumentRow.Columns.id))
-        .fetchAll(database)
-    }
-  }
-
-  /// Deletes every row in the table. Used by `deleteLocalData` after a
-  /// remote zone deletion.
-  func deleteAllSync() throws {
-    try database.write { database in
-      _ = try InstrumentRow.deleteAll(database)
-    }
-  }
+  // The synchronous entry points used by `ProfileIndexSyncHandler`
+  // (`setEncodedSystemFieldsSync`, `clearAllSystemFieldsSync`,
+  // `unsyncedRowIdsSync`, `allRowIdsSync`, `fetchRowSync`,
+  // `fetchRowsSync`, `deleteAllSync`) live in the sibling
+  // `+SyncEntryPoints` extension file so this file stays under
+  // SwiftLint's length thresholds.
+  // `unsyncedNonFiatRowIdsSync` similarly lives in `+Lookup`.
 }

--- a/MoolahTests/Backends/CloudKit/CrossProfileSpamPropagationTests.swift
+++ b/MoolahTests/Backends/CloudKit/CrossProfileSpamPropagationTests.swift
@@ -1,0 +1,100 @@
+// MoolahTests/Backends/CloudKit/CrossProfileSpamPropagationTests.swift
+
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+/// Smoking-gun test for the shared instrument registry. Two
+/// `GRDBInstrumentRegistryRepository` instances pointed at the same
+/// `profile-index.sqlite` (one per simulated profile session) must
+/// observe each other's spam classifications — the whole point of
+/// the design.
+///
+/// Before stage 12b: each profile session constructed its own
+/// per-profile registry pointed at its own per-profile DB. Marking
+/// `bitcoin` as spam in profile A's session left profile B's session
+/// reading from a different table, so the spam classification didn't
+/// propagate.
+///
+/// After stage 12b: every profile session points at the same shared
+/// registry instance backed by the profile-index DB, so a spam
+/// classification written by any session is visible to every session
+/// that reads it next.
+///
+/// This test simulates two sessions by constructing two registry
+/// instances against the same `profile-index.sqlite` queue (the
+/// production wiring constructs a single shared instance, but two
+/// instances pointing at the same DB is the equivalent observable
+/// behaviour from the consumer's point of view). The shared queue is
+/// the load-bearing invariant; the registry instance count is not.
+@Suite("Cross-profile spam propagation")
+struct CrossProfileSpamPropagationTests {
+
+  @Test("marking spam through one registry is visible through another against the same DB")
+  func spamMarkedInOneSessionIsVisibleToAnother() async throws {
+    let queue = try ProfileIndexDatabase.openInMemory()
+    let registryA = GRDBInstrumentRegistryRepository(database: queue)
+    let registryB = GRDBInstrumentRegistryRepository(database: queue)
+
+    // Profile A registers bitcoin as priced.
+    let bitcoin = Instrument.crypto(
+      chainId: 1,
+      contractAddress: nil,
+      symbol: "BTC",
+      name: "Bitcoin",
+      decimals: 8)
+    try await registryA.registerCrypto(
+      bitcoin,
+      mapping: CryptoProviderMapping(
+        instrumentId: bitcoin.id,
+        coingeckoId: "bitcoin",
+        cryptocompareSymbol: "BTC",
+        binanceSymbol: nil))
+
+    // Profile B sees the registration.
+    let beforeSpam = try #require(
+      try await registryB.cryptoRegistration(byId: bitcoin.id))
+    #expect(beforeSpam.pricingStatus == .priced)
+
+    // Profile A marks it spam (the user's "decide once, applies everywhere"
+    // gesture from §Motivation in the design doc).
+    var registration = beforeSpam
+    registration.pricingStatus = .spam
+    try await registryA.update(registration)
+
+    // Profile B sees the spam classification immediately — same DB,
+    // single source of truth.
+    let afterSpam = try #require(
+      try await registryB.cryptoRegistration(byId: bitcoin.id))
+    #expect(afterSpam.pricingStatus == .spam)
+  }
+
+  @Test("removing a registration through one registry is visible through another")
+  func removeIsVisibleAcrossSessions() async throws {
+    let queue = try ProfileIndexDatabase.openInMemory()
+    let registryA = GRDBInstrumentRegistryRepository(database: queue)
+    let registryB = GRDBInstrumentRegistryRepository(database: queue)
+
+    let usdc = Instrument.crypto(
+      chainId: 1,
+      contractAddress: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+      symbol: "USDC",
+      name: "USD Coin",
+      decimals: 6)
+    try await registryA.registerCrypto(
+      usdc,
+      mapping: CryptoProviderMapping(
+        instrumentId: usdc.id,
+        coingeckoId: "usd-coin",
+        cryptocompareSymbol: "USDC",
+        binanceSymbol: nil))
+    #expect(
+      try await registryB.cryptoRegistration(byId: usdc.id) != nil)
+
+    try await registryA.remove(id: usdc.id)
+    #expect(
+      try await registryB.cryptoRegistration(byId: usdc.id) == nil)
+  }
+}

--- a/MoolahTests/Backends/CloudKit/SharedInstrumentSelfHealTests.swift
+++ b/MoolahTests/Backends/CloudKit/SharedInstrumentSelfHealTests.swift
@@ -1,0 +1,68 @@
+// MoolahTests/Backends/CloudKit/SharedInstrumentSelfHealTests.swift
+
+@preconcurrency import CloudKit
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+/// Confirms `ProfileIndexSyncHandler.queueUnsyncedSharedInstrumentRecords`
+/// returns string-keyed CKRecord.IDs for instrument rows whose
+/// `encoded_system_fields` is `NULL`, and skips rows that have already
+/// roundtripped.
+@MainActor
+@Suite("Shared registry self-heal")
+struct SharedInstrumentSelfHealTests {
+
+  @Test("self-heal scan returns IDs for unsynced instrument rows only")
+  func selfHealEnumeratesUnsyncedRowsOnly() async throws {
+    let queue = try ProfileIndexDatabase.openInMemory()
+    let profileRepo = GRDBProfileIndexRepository(database: queue)
+    let registry = GRDBInstrumentRegistryRepository(database: queue)
+    let handler = ProfileIndexSyncHandler(
+      repository: profileRepo, instrumentRepository: registry)
+
+    // One row that hasn't roundtripped (NULL encoded_system_fields):
+    try await registry.registerCrypto(
+      Instrument.crypto(
+        chainId: 1, contractAddress: "0xunsynced", symbol: "UNS", name: "Unsynced",
+        decimals: 18),
+      mapping: CryptoProviderMapping(
+        instrumentId: "1:0xunsynced",
+        coingeckoId: "unsynced",
+        cryptocompareSymbol: nil,
+        binanceSymbol: nil))
+
+    // Another row that has roundtripped (non-NULL):
+    try await registry.registerCrypto(
+      Instrument.crypto(
+        chainId: 1, contractAddress: "0xsynced", symbol: "SYN", name: "Synced",
+        decimals: 18),
+      mapping: CryptoProviderMapping(
+        instrumentId: "1:0xsynced",
+        coingeckoId: "synced",
+        cryptocompareSymbol: nil,
+        binanceSymbol: nil))
+    try await queue.write { database in
+      try database.execute(
+        sql: """
+          UPDATE instrument SET encoded_system_fields = ? WHERE id = ?
+          """,
+        arguments: [Data([0x01]), "1:0xsynced"])
+    }
+
+    let recordIDs = handler.queueUnsyncedSharedInstrumentRecords()
+    let names = Set(recordIDs.map(\.recordName))
+    #expect(names == ["1:0xunsynced"])
+    #expect(recordIDs.first?.zoneID == handler.zoneID)
+  }
+
+  @Test("self-heal scan returns empty when no instrument repository wired")
+  func selfHealReturnsEmptyWithoutInstrumentRepository() async throws {
+    let queue = try ProfileIndexDatabase.openInMemory()
+    let profileRepo = GRDBProfileIndexRepository(database: queue)
+    let handler = ProfileIndexSyncHandler(repository: profileRepo)
+    #expect(handler.queueUnsyncedSharedInstrumentRecords().isEmpty)
+  }
+}

--- a/MoolahTests/Backends/SharedRateQueryPlanTests.swift
+++ b/MoolahTests/Backends/SharedRateQueryPlanTests.swift
@@ -1,0 +1,133 @@
+// MoolahTests/Backends/SharedRateQueryPlanTests.swift
+
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+/// Mirrored plan-pinning tests for the rate-cache tables on the
+/// **shared** profile-index DB (added by Stage 1's
+/// `v3_shared_instrument_registry` migration). `loadCache`-shaped
+/// queries against the shared tables must use the same primary-key
+/// scan as the per-profile equivalents — the per-profile
+/// `RateQueryPlanTests` confirms the per-profile shape; this suite
+/// confirms the shared shape.
+///
+/// Per `plans/2026-05-09-shared-instrument-registry-design.md`
+/// §"Local schema → Price-cache tables", the per-profile
+/// `exchange_rate_lookup` index on `(base, quote, date)` is
+/// intentionally **not** carried into the shared DB — `loadCache`
+/// fetches `WHERE base = ?` and resolves quote/date in-memory from
+/// the loaded `caches[base]` dictionary. This suite asserts the PK
+/// is the chosen access path and that no shared `exchange_rate_lookup`
+/// index exists.
+@Suite("Shared rate cache loadCache query plans")
+struct SharedRateQueryPlanTests {
+
+  @Test("WHERE base = ? on shared exchange_rate uses the primary key")
+  func exchangeRateLoadCacheUsesPrimaryKey() async throws {
+    let database = try ProfileIndexDatabase.openInMemory()
+    try await database.read { database in
+      let plan = try Row.fetchAll(
+        database,
+        sql: """
+          EXPLAIN QUERY PLAN
+          SELECT * FROM exchange_rate WHERE base = ?
+          """,
+        arguments: ["AUD"]
+      ).map { String(describing: $0["detail"] ?? "") }
+      #expect(plan.contains { $0.contains("SEARCH") && $0.contains("PRIMARY KEY") })
+      #expect(!plan.contains { $0.contains("SCAN") })
+      // The per-profile `exchange_rate_lookup` index is intentionally
+      // omitted from the shared DB; assert the planner cannot reach
+      // for it because it doesn't exist.
+      #expect(!plan.contains { $0.contains("exchange_rate_lookup") })
+    }
+  }
+
+  @Test("WHERE ticker = ? on shared stock_price uses the primary key")
+  func stockPriceLoadCacheUsesPrimaryKey() async throws {
+    let database = try ProfileIndexDatabase.openInMemory()
+    try await database.read { database in
+      let plan = try Row.fetchAll(
+        database,
+        sql: """
+          EXPLAIN QUERY PLAN
+          SELECT * FROM stock_price WHERE ticker = ?
+          """,
+        arguments: ["BHP.AX"]
+      ).map { String(describing: $0["detail"] ?? "") }
+      #expect(plan.contains { $0.contains("SEARCH") && $0.contains("PRIMARY KEY") })
+      #expect(!plan.contains { $0.contains("SCAN") })
+    }
+  }
+
+  @Test("WHERE token_id = ? on shared crypto_price uses the primary key")
+  func cryptoPriceLoadCacheUsesPrimaryKey() async throws {
+    let database = try ProfileIndexDatabase.openInMemory()
+    try await database.read { database in
+      let plan = try Row.fetchAll(
+        database,
+        sql: """
+          EXPLAIN QUERY PLAN
+          SELECT * FROM crypto_price WHERE token_id = ?
+          """,
+        arguments: ["1:native"]
+      ).map { String(describing: $0["detail"] ?? "") }
+      #expect(plan.contains { $0.contains("SEARCH") && $0.contains("PRIMARY KEY") })
+      #expect(!plan.contains { $0.contains("SCAN") })
+    }
+  }
+
+  @Test("WHERE base = ? on shared exchange_rate_meta uses the primary key")
+  func exchangeRateMetaLoadUsesPrimaryKey() async throws {
+    let database = try ProfileIndexDatabase.openInMemory()
+    try await database.read { database in
+      let plan = try Row.fetchAll(
+        database,
+        sql: """
+          EXPLAIN QUERY PLAN
+          SELECT * FROM exchange_rate_meta WHERE base = ?
+          """,
+        arguments: ["AUD"]
+      ).map { String(describing: $0["detail"] ?? "") }
+      #expect(plan.contains { $0.contains("SEARCH") && $0.contains("PRIMARY KEY") })
+      #expect(!plan.contains { $0.contains("SCAN") })
+    }
+  }
+
+  @Test("WHERE ticker = ? on shared stock_ticker_meta uses the primary key")
+  func stockTickerMetaLoadUsesPrimaryKey() async throws {
+    let database = try ProfileIndexDatabase.openInMemory()
+    try await database.read { database in
+      let plan = try Row.fetchAll(
+        database,
+        sql: """
+          EXPLAIN QUERY PLAN
+          SELECT * FROM stock_ticker_meta WHERE ticker = ?
+          """,
+        arguments: ["BHP.AX"]
+      ).map { String(describing: $0["detail"] ?? "") }
+      #expect(plan.contains { $0.contains("SEARCH") && $0.contains("PRIMARY KEY") })
+      #expect(!plan.contains { $0.contains("SCAN") })
+    }
+  }
+
+  @Test("WHERE token_id = ? on shared crypto_token_meta uses the primary key")
+  func cryptoTokenMetaLoadUsesPrimaryKey() async throws {
+    let database = try ProfileIndexDatabase.openInMemory()
+    try await database.read { database in
+      let plan = try Row.fetchAll(
+        database,
+        sql: """
+          EXPLAIN QUERY PLAN
+          SELECT * FROM crypto_token_meta WHERE token_id = ?
+          """,
+        arguments: ["bitcoin"]
+      ).map { String(describing: $0["detail"] ?? "") }
+      #expect(plan.contains { $0.contains("SEARCH") && $0.contains("PRIMARY KEY") })
+      #expect(!plan.contains { $0.contains("SCAN") })
+    }
+  }
+}

--- a/MoolahTests/Migration/SharedRegistryUnionRunnerTests.swift
+++ b/MoolahTests/Migration/SharedRegistryUnionRunnerTests.swift
@@ -1,0 +1,204 @@
+// MoolahTests/Migration/SharedRegistryUnionRunnerTests.swift
+
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+/// Confirms the shared-registry union runner walks every per-profile
+/// DB, merges instrument + price-cache rows into the shared DB, and
+/// gates re-runs via the UserDefaults flag.
+@MainActor
+@Suite("SharedRegistryUnionRunner", .serialized)
+struct SharedRegistryUnionRunnerTests {
+
+  // MARK: - Fixtures
+
+  private struct Fixture {
+    let sharedQueue: DatabaseQueue
+    let profileQueues: [UUID: DatabaseQueue]
+    let defaults: UserDefaults
+
+    init(perProfileSeeds: [(UUID, (Database) throws -> Void)]) throws {
+      self.sharedQueue = try ProfileIndexDatabase.openInMemory()
+      var queues: [UUID: DatabaseQueue] = [:]
+      for (id, seed) in perProfileSeeds {
+        let queue = try ProfileDatabase.openInMemory()
+        try queue.write { database in try seed(database) }
+        queues[id] = queue
+      }
+      self.profileQueues = queues
+      let suite = "shared-registry-union-tests-\(UUID().uuidString)"
+      // `UserDefaults(suiteName:)` returns nil only for the reserved
+      // names `kCFPreferencesCurrentApplication` and an empty string;
+      // the unique suite generated above guarantees neither.
+      // swiftlint:disable:next force_unwrapping
+      self.defaults = UserDefaults(suiteName: suite)!
+    }
+
+  }
+
+  /// Builds a `@Sendable` closure that opens a fixture's per-profile
+  /// `DatabaseQueue`. Captures only the queues dictionary (a value-
+  /// type `Dictionary` of `Sendable` `DatabaseQueue` references), not
+  /// the `~Copyable` `Fixture`.
+  private static func makeOpener(
+    profileQueues: [UUID: DatabaseQueue]
+  ) -> @Sendable (UUID) throws -> DatabaseQueue {
+    let queues = profileQueues
+    return { id in
+      guard let queue = queues[id] else {
+        struct MissingFixture: Error {}
+        throw MissingFixture()
+      }
+      return queue
+    }
+  }
+
+  /// `FileManager` stand-in that always reports the per-profile DB
+  /// exists. Tests use in-memory queues so the real path doesn't.
+  private final class AlwaysExistsFileManager: FileManager, @unchecked Sendable {
+    override func fileExists(atPath _: String) -> Bool { true }
+  }
+
+  private static func seedInstrument(
+    _ database: Database,
+    id: String,
+    coingeckoId: String,
+    pricingStatus: String = "priced"
+  ) throws {
+    try database.execute(
+      sql: """
+        INSERT INTO instrument
+        (id, record_name, kind, name, decimals, coingecko_id, pricing_status)
+        VALUES (?, ?, 'cryptoToken', ?, 18, ?, ?)
+        """,
+      arguments: [id, id, "Token \(id)", coingeckoId, pricingStatus])
+  }
+
+  // MARK: - Tests
+
+  @Test("union merges instrument rows from every profile DB into the shared registry")
+  func unionMergesInstrumentRows() async throws {
+    let profileA = try #require(UUID(uuidString: "00000000-0000-0000-0000-00000000000a"))
+    let profileB = try #require(UUID(uuidString: "00000000-0000-0000-0000-00000000000b"))
+    let fixture = try Fixture(perProfileSeeds: [
+      (profileA, { try Self.seedInstrument($0, id: "1:0xaaa", coingeckoId: "aaa") }),
+      (profileB, { try Self.seedInstrument($0, id: "1:0xbbb", coingeckoId: "bbb") }),
+    ])
+
+    await SharedRegistryUnionRunner.run(
+      sharedQueue: fixture.sharedQueue,
+      profileIds: [profileA, profileB],
+      perProfileDatabase: Self.makeOpener(profileQueues: fixture.profileQueues),
+      perProfileDatabaseURL: { _ in URL(fileURLWithPath: "/tmp/fake.sqlite") },
+      fileManager: AlwaysExistsFileManager(),
+      defaults: fixture.defaults)
+
+    let ids: Set<String> = try await fixture.sharedQueue.read { database in
+      Set(try String.fetchAll(database, sql: "SELECT id FROM instrument"))
+    }
+    #expect(ids.contains("1:0xaaa"))
+    #expect(ids.contains("1:0xbbb"))
+  }
+
+  @Test("union applies spam-wins merge across profiles")
+  func unionAppliesSpamWinsAcrossProfiles() async throws {
+    // Profile A has bitcoin priced; profile B has bitcoin spam.
+    // Result: spam wins regardless of iteration order.
+    let profileA = try #require(UUID(uuidString: "00000000-0000-0000-0000-00000000000a"))
+    let profileB = try #require(UUID(uuidString: "00000000-0000-0000-0000-00000000000b"))
+    let fixture = try Fixture(perProfileSeeds: [
+      (profileA, { try Self.seedInstrument($0, id: "bitcoin", coingeckoId: "bitcoin") }),
+      (
+        profileB,
+        {
+          try Self.seedInstrument(
+            $0, id: "bitcoin", coingeckoId: "bitcoin", pricingStatus: "spam")
+        }
+      ),
+    ])
+
+    await SharedRegistryUnionRunner.run(
+      sharedQueue: fixture.sharedQueue,
+      profileIds: [profileA, profileB],
+      perProfileDatabase: Self.makeOpener(profileQueues: fixture.profileQueues),
+      perProfileDatabaseURL: { _ in URL(fileURLWithPath: "/tmp/fake.sqlite") },
+      fileManager: AlwaysExistsFileManager(),
+      defaults: fixture.defaults)
+
+    let status: String? = try await fixture.sharedQueue.read { database in
+      try String.fetchOne(
+        database,
+        sql: "SELECT pricing_status FROM instrument WHERE id = 'bitcoin'")
+    }
+    #expect(status == "spam")
+  }
+
+  @Test("re-running with the flag set is a no-op")
+  func reRunningIsNoOpWhenFlagAlreadySet() async throws {
+    let profileA = try #require(UUID(uuidString: "00000000-0000-0000-0000-00000000000a"))
+    let fixture = try Fixture(perProfileSeeds: [
+      (profileA, { try Self.seedInstrument($0, id: "1:0xaaa", coingeckoId: "aaa") })
+    ])
+    fixture.defaults.set(true, forKey: SharedRegistryUnionRunner.unionFlagKey)
+
+    await SharedRegistryUnionRunner.run(
+      sharedQueue: fixture.sharedQueue,
+      profileIds: [profileA],
+      perProfileDatabase: Self.makeOpener(profileQueues: fixture.profileQueues),
+      perProfileDatabaseURL: { _ in URL(fileURLWithPath: "/tmp/fake.sqlite") },
+      fileManager: AlwaysExistsFileManager(),
+      defaults: fixture.defaults)
+
+    let count: Int? = try await fixture.sharedQueue.read { database in
+      try Int.fetchOne(database, sql: "SELECT COUNT(*) FROM instrument")
+    }
+    #expect(count == 0, "instrument table should still be empty when flag pre-set")
+  }
+
+  @Test("flag is set after run completes so subsequent runs are no-ops")
+  func flagIsSetAfterRun() async throws {
+    let profileA = try #require(UUID(uuidString: "00000000-0000-0000-0000-00000000000a"))
+    let fixture = try Fixture(perProfileSeeds: [
+      (profileA, { try Self.seedInstrument($0, id: "1:0xaaa", coingeckoId: "aaa") })
+    ])
+    #expect(fixture.defaults.bool(forKey: SharedRegistryUnionRunner.unionFlagKey) == false)
+
+    await SharedRegistryUnionRunner.run(
+      sharedQueue: fixture.sharedQueue,
+      profileIds: [profileA],
+      perProfileDatabase: Self.makeOpener(profileQueues: fixture.profileQueues),
+      perProfileDatabaseURL: { _ in URL(fileURLWithPath: "/tmp/fake.sqlite") },
+      fileManager: AlwaysExistsFileManager(),
+      defaults: fixture.defaults)
+
+    #expect(fixture.defaults.bool(forKey: SharedRegistryUnionRunner.unionFlagKey))
+  }
+
+  @Test("a profile DB that fails to open is skipped without losing other profiles")
+  func failingProfileIsSkippedAndOthersStillMerge() async throws {
+    let profileA = try #require(UUID(uuidString: "00000000-0000-0000-0000-00000000000a"))
+    let profileFail = try #require(UUID(uuidString: "00000000-0000-0000-0000-00000000000f"))
+    let fixture = try Fixture(perProfileSeeds: [
+      (profileA, { try Self.seedInstrument($0, id: "1:0xaaa", coingeckoId: "aaa") })
+      // profileFail is intentionally not registered → throws on open
+    ])
+
+    await SharedRegistryUnionRunner.run(
+      sharedQueue: fixture.sharedQueue,
+      profileIds: [profileA, profileFail],
+      perProfileDatabase: Self.makeOpener(profileQueues: fixture.profileQueues),
+      perProfileDatabaseURL: { _ in URL(fileURLWithPath: "/tmp/fake.sqlite") },
+      fileManager: AlwaysExistsFileManager(),
+      defaults: fixture.defaults)
+
+    let count: Int? = try await fixture.sharedQueue.read { database in
+      try Int.fetchOne(
+        database, sql: "SELECT COUNT(*) FROM instrument WHERE id = '1:0xaaa'")
+    }
+    #expect(count == 1, "profile A's row should still be merged despite profile-F failing")
+    #expect(fixture.defaults.bool(forKey: SharedRegistryUnionRunner.unionFlagKey))
+  }
+}


### PR DESCRIPTION
## Summary

Stage 17 of the shared instrument registry plan. Two `GRDBInstrumentRegistryRepository` instances pointed at the same `profile-index.sqlite` must observe each other's spam classifications — the smoking-gun test for the whole feature.

Built on stages 1–18 + 12b (PRs #841–#853).

## What's covered

Two tests cover the user-facing invariants:
- marking spam through one session is visible through another
- removing a registration through one session is visible through another

These prove that the post-stage-12b production wiring delivers the design's headline promise: a user marks a token spam in profile A, switches to profile B, and the token is already classified as spam there.

## Test plan

- [x] `just format-check` clean.
- [x] `just test-mac CrossProfileSpamPropagationTests` — 2 tests pass.
- [ ] CI on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)