### PR TITLE
fix(crypto): attach gas leg when wallet signs a receive-only tx

### DIFF
--- a/MoolahTests/Shared/CryptoImport/TransferEventBuilderGasAttributionTests.swift
+++ b/MoolahTests/Shared/CryptoImport/TransferEventBuilderGasAttributionTests.swift
@@ -19,6 +19,13 @@ import Testing
 /// In both cases `receipt.from != walletAddress`, and
 /// `TransferReceiptCoalescer.makeGasLeg` returns `nil`. The transfer
 /// leg is still produced; only the gas leg is suppressed.
+///
+/// The third path here is the *positive* case: the wallet signs a tx
+/// that only emits inbound (`to = wallet`) ERC-20 / internal events —
+/// e.g. a contract call that mints, claims, or buys a token for the
+/// wallet. The earlier predicate keyed receipt eligibility off "any
+/// transfer event has `from == wallet`" and missed these, dropping the
+/// gas leg even though the wallet paid the fee.
 @Suite("TransferEventBuilder — gas attribution gating")
 struct TransferEventBuilderGasAttributionTests {
   private static let wallet = "0x1111111111111111111111111111111111111111"
@@ -27,6 +34,7 @@ struct TransferEventBuilderGasAttributionTests {
 
   private static let gasUsed = Decimal(21_000)
   private static let gasPrice = Decimal(1_500_000_000)
+  private static let expectedFeeEth = dec("0.0000315")
 
   // MARK: - Outer-tx signed by someone else → no gas leg
 
@@ -36,9 +44,10 @@ struct TransferEventBuilderGasAttributionTests {
   func internalTransferSignedBySomeoneElseDoesNotEmitGasLeg() async throws {
     let subject = makeDiscoverySubject()
     let alchemy = RecordingAlchemyClientStub()
-    // Receipt is fetched (the outboundHashes heuristic still trips on
-    // `from == wallet` for any non-NFT transfer), but the EOA that
-    // signed the tx is the counterparty — wallet did not pay gas.
+    // Receipt is fetched — the wallet appears as `from` of a non-NFT
+    // event so the cheap pre-filter can't rule out wallet-signed. The
+    // authoritative gate is `receipt.from`: here the EOA that signed
+    // the tx is the counterparty, so the gas leg is suppressed.
     alchemy.setReceiptResponse(
       .receipt(
         AlchemyTransactionReceipt(
@@ -132,5 +141,102 @@ struct TransferEventBuilderGasAttributionTests {
         $0.externalId?.hasSuffix(":gas") == false
       })
     #expect(alchemy.recordedReceiptCalls == ["0xtransferfrom"])
+  }
+
+  // MARK: - Wallet-signed tx with only inbound events → gas leg attached
+
+  @Test(
+    "Inbound-only ERC-20 (wallet calls a contract that mints/claims tokens to it) → gas leg attached"
+  )
+  func inboundOnlyErc20WithWalletSignedReceiptEmitsGasLeg() async throws {
+    let subject = makeDiscoverySubject()
+    subject.resolver.script(
+      .init(chainId: 1, contractAddress: Self.usdcAddress.lowercased()),
+      .success(coingecko: "usd-coin", cryptocompare: nil, binance: nil))
+    let alchemy = RecordingAlchemyClientStub()
+    // Wallet signed the outer tx and paid the fee. The on-chain shape:
+    // wallet calls a contract; the contract emits an ERC-20 `Transfer`
+    // log with `to = wallet`. No transfer event has `from = wallet`,
+    // so the earlier `from == walletAddress` predicate skipped the
+    // receipt fetch and dropped the gas leg.
+    alchemy.setReceiptResponse(
+      .receipt(
+        AlchemyTransactionReceipt(
+          hash: "0xclaim",
+          gasUsed: Self.gasUsed,
+          effectiveGasPrice: Self.gasPrice,
+          from: Self.wallet)
+      ),
+      for: "0xclaim")
+
+    let account = makeCryptoAccount(walletAddress: Self.wallet, chain: .ethereum)
+    let origin = makeWalletImportOrigin(for: account.id)
+    let transfer = makeAlchemyTransfer(
+      hash: "0xclaim",
+      from: Self.counterparty,
+      to: Self.wallet,
+      category: .erc20,
+      asset: "USDC",
+      contractAddress: Self.usdcAddress,
+      decimalsHex: "0x6",
+      rawValueHex: "0x5f5e100")
+
+    let built = try await TransferEventBuilder().build(
+      transfers: [transfer],
+      account: account,
+      services: BuilderServices(
+        chain: .ethereum,
+        discovery: subject.service,
+        alchemy: alchemy),
+      importOrigin: origin)
+
+    let candidate = try #require(built.first)
+    let transferLeg = try #require(
+      candidate.transaction.legs.first(where: { $0.externalId == "0xclaim:0" }))
+    let gasLeg = try #require(
+      candidate.transaction.legs.first(where: { $0.externalId == "0xclaim:gas" }))
+    #expect(candidate.transaction.legs.count == 2)
+    #expect(transferLeg.type == .income)
+    #expect(transferLeg.instrument.contractAddress == Self.usdcAddress.lowercased())
+    #expect(gasLeg.type == .expense)
+    #expect(gasLeg.instrument == ChainConfig.ethereum.nativeInstrument)
+    #expect(gasLeg.quantity == -Self.expectedFeeEth)
+    #expect(alchemy.recordedReceiptCalls == ["0xclaim"])
+  }
+
+  @Test(
+    "Inbound-only `.external` (someone else sends ETH to wallet) → no receipt fetch, no gas leg"
+  )
+  func inboundExternalDoesNotTriggerReceiptFetch() async throws {
+    let subject = makeDiscoverySubject()
+    let alchemy = RecordingAlchemyClientStub()
+    // No receipt scripted — wallet was never the signer here, so the
+    // predicate must not request a receipt for this hash. `.external`
+    // is always a top-level call: `from` is the EOA, so we can prove
+    // the wallet didn't sign without a round-trip.
+    let account = makeCryptoAccount(walletAddress: Self.wallet, chain: .ethereum)
+    let origin = makeWalletImportOrigin(for: account.id)
+    let transfer = makeAlchemyTransfer(
+      hash: "0xpayme",
+      from: Self.counterparty,
+      to: Self.wallet,
+      category: .external)
+
+    let built = try await TransferEventBuilder().build(
+      transfers: [transfer],
+      account: account,
+      services: BuilderServices(
+        chain: .ethereum,
+        discovery: subject.service,
+        alchemy: alchemy),
+      importOrigin: origin)
+
+    let candidate = try #require(built.first)
+    #expect(candidate.transaction.legs.count == 1)
+    #expect(
+      candidate.transaction.legs.allSatisfy {
+        $0.externalId?.hasSuffix(":gas") == false
+      })
+    #expect(alchemy.recordedReceiptCalls.isEmpty)
   }
 }

--- a/Shared/CryptoImport/TransferReceiptCoalescer.swift
+++ b/Shared/CryptoImport/TransferReceiptCoalescer.swift
@@ -79,16 +79,29 @@ enum TransferReceiptCoalescer {
   }
 
   /// Walks the grouped transfers and returns the set of `txHash` values
-  /// that have at least one outbound transfer for this wallet —
-  /// `external` for native sends, `erc20` (or `internal`) where this
-  /// wallet is the from-side token sender. The Alchemy transfer
-  /// endpoint reports `from` as the EOA on a top-level call
-  /// (`external`) and as the token sender on an `erc20` row; in the
-  /// simple `transfer()` case those are the same address, so a `from ==
-  /// walletAddress` match across any accepted category is a reliable
-  /// signal that this wallet paid the gas. NFT (`unknown`) categories
-  /// are filtered out — gas-leg attribution is only meaningful for
-  /// accepted categories.
+  /// for which we need to fetch the receipt to decide gas attribution.
+  /// The authoritative gate (`receipt.from == walletAddress`) lives in
+  /// `makeGasLeg`; this predicate is just the cheap pre-filter that
+  /// avoids a network round-trip for hashes we can already prove the
+  /// wallet didn't sign.
+  ///
+  /// A hash is eligible when any non-NFT event in the group either:
+  ///
+  /// - has `from == walletAddress` — the wallet may be the signer
+  ///   (`.external`), or appears as the token-sender row of a contract
+  ///   call (`.erc20` / `.internal`), and we can't tell from the
+  ///   transfer alone whether the wallet itself or a third-party router
+  ///   signed; or
+  /// - has any non-`.external` category, regardless of direction —
+  ///   `.erc20` and `.internal` rows can come from a contract call the
+  ///   wallet signed even when every transfer event has the wallet as
+  ///   `to` (a mint, claim, or contract-buy). `.external` is the only
+  ///   category that's always a top-level call: its `from` is the EOA,
+  ///   so an `.external` row with `from != walletAddress` proves the
+  ///   wallet didn't sign and a receipt fetch is unnecessary.
+  ///
+  /// NFT (`unknown`) categories are filtered out — gas-leg attribution
+  /// is only meaningful for accepted categories.
   ///
   /// The walk preserves first-seen order so receipt fetches retire in a
   /// deterministic sequence (helps with signpost tracing).
@@ -100,11 +113,12 @@ enum TransferReceiptCoalescer {
     var ordered: [String] = []
     for events in groups {
       guard let first = events.first else { continue }
-      let isOutbound = events.contains { event in
-        event.category != .unknown
-          && event.from.lowercased() == walletAddress
+      let needsReceipt = events.contains { event in
+        guard event.category != .unknown else { return false }
+        if event.from.lowercased() == walletAddress { return true }
+        return event.category != .external
       }
-      guard isOutbound, seen.insert(first.hash).inserted else { continue }
+      guard needsReceipt, seen.insert(first.hash).inserted else { continue }
       ordered.append(first.hash)
     }
     return ordered


### PR DESCRIPTION
## Summary

- Broaden the `eth_getTransactionReceipt` pre-filter in `TransferReceiptCoalescer.outboundHashes` so a hash whose only non-NFT events have the wallet as `to` (mint, claim, contract-buy) still triggers the receipt fetch when the event is `.erc20` / `.internal`. `.external`-only inbound stays gated out — it's provably not wallet-signed.
- Production wallet `0xa1eaee65…` (Trust Ethereum 3 in Large Test Profile) was missing the gas leg of one such tx (`0x48b9993f…`). The reconciled balance now matches the on-chain balance to display precision.
- `makeGasLeg`'s `receipt.from == walletAddress` check stays the authoritative gate, so the broader pre-filter never produces a false-positive gas leg — at worst it costs one extra receipt fetch per inbound-only contract-call hash.

Fixes [#859](https://github.com/ajsutton/moolah-native/issues/859).

## Test plan

- [x] New positive case in `TransferEventBuilderGasAttributionTests`: inbound-only ERC-20 with `receipt.from == wallet` → 2 legs (income + `:gas`), receipt fetched.
- [x] New negative case: inbound-only `.external` (someone else sent ETH to wallet) → no receipt fetch, no gas leg.
- [x] Existing `TransferEventBuilderGasLegTests`, `TransferEventBuilderGasCoalescingTests`, `TransferEventBuilderGasAttributionTests`, `TransferEventBuilderTests`, swap / merger / dedup / apply-engine suites all green via `just test-mac`.
- [x] `just format-check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)