### PR TITLE
fix(sync): drain legacy InstrumentRecord pending changes on coordinator start

### DIFF
--- a/Backends/CloudKit/Sync/SyncCoordinator+LegacyInstrumentDrain.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+LegacyInstrumentDrain.swift
@@ -1,0 +1,75 @@
+@preconcurrency import CloudKit
+import Foundation
+
+extension SyncCoordinator {
+  // MARK: - Legacy InstrumentRecord Drain
+
+  /// Returns the subset of `changes` that are leftover legacy
+  /// `InstrumentRecord` pending changes routed to a per-profile zone.
+  ///
+  /// Two shapes can survive the shared-instrument-registry rollout
+  /// (PR #861):
+  /// - Prefixed `"InstrumentRecord|<UUID>"` recordNames queued by a
+  ///   pre-rollout build.
+  /// - Bare string-keyed recordNames (`"AUD"`, `"0:native"`) queued by
+  ///   the even-older `<scope>:<id>` instrument shape — these have no
+  ///   `|` separator and don't parse as a UUID.
+  ///
+  /// Both shapes can only have come from a pre-rollout build: post-
+  /// rollout, every instrument upload routes through the shared
+  /// registry on the `profile-index` zone, and the DEBUG trap in
+  /// `ProfileDataSyncHandler.recordToSave` aborts the process if one
+  /// reaches the per-profile handler. Dropping these from
+  /// CKSyncEngine state at start lets upgraded peers self-heal on
+  /// next launch instead of crashing.
+  ///
+  /// Pure function: takes the input changes and returns the legacy
+  /// subset. Caller applies the removal via
+  /// `state.remove(pendingRecordZoneChanges:)`. Splitting the filter
+  /// keeps this testable without spinning up a real `CKSyncEngine`.
+  ///
+  /// Companion to `purgeStaleBareUUIDPendingChanges` (issue #416),
+  /// which targets the orthogonal bare-UUID legacy shape on UUID-
+  /// keyed records — running both at start covers every leftover
+  /// shape we know about.
+  nonisolated static func legacyInstrumentPendingChanges(
+    in changes: some Sequence<CKSyncEngine.PendingRecordZoneChange>
+  ) -> [CKSyncEngine.PendingRecordZoneChange] {
+    changes.compactMap { change in
+      let recordID: CKRecord.ID
+      switch change {
+      case .saveRecord(let id): recordID = id
+      case .deleteRecord(let id): recordID = id
+      @unknown default: return nil
+      }
+      guard case .profileData = parseZone(recordID.zoneID) else { return nil }
+      if recordID.prefixedRecordType == InstrumentRow.recordType {
+        return change
+      }
+      let name = recordID.recordName
+      if !name.contains("|"), UUID(uuidString: name) == nil {
+        return change
+      }
+      return nil
+    }
+  }
+
+  /// Removes any pending changes returned by
+  /// `legacyInstrumentPendingChanges(in:)` from the live engine state.
+  /// Called from `completeStart` next to
+  /// `purgeStaleBareUUIDPendingChanges()`. No-op when the engine isn't
+  /// running yet or when no legacy entries remain.
+  func purgeLegacyInstrumentPendingChanges() {
+    guard let syncEngine else { return }
+    let stale = Self.legacyInstrumentPendingChanges(
+      in: syncEngine.state.pendingRecordZoneChanges)
+    guard !stale.isEmpty else { return }
+    logger.warning(
+      """
+      Purging \(stale.count, privacy: .public) legacy InstrumentRecord \
+      pending changes routed to per-profile zones — every InstrumentRecord \
+      write now flows through the shared registry on the profile-index zone.
+      """)
+    syncEngine.state.remove(pendingRecordZoneChanges: stale)
+  }
+}

--- a/Backends/CloudKit/Sync/SyncCoordinator+Lifecycle.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+Lifecycle.swift
@@ -157,6 +157,15 @@ extension SyncCoordinator {
     // by the repository mutation hooks (or will be by the unsynced backfill
     // below).
     purgeStaleBareUUIDPendingChanges()
+    // Drop any leftover `InstrumentRecord` pending changes routed to a
+    // per-profile zone. Post-PR #861 the only legitimate path for an
+    // instrument write is the shared registry on the `profile-index`
+    // zone, and `ProfileDataSyncHandler.recordToSave` traps in DEBUG
+    // when one reaches the per-profile handler — left in the queue,
+    // a single such entry crashes the process the next time
+    // CKSyncEngine asks for the next batch. See
+    // `SyncCoordinator+LegacyInstrumentDrain.swift`.
+    purgeLegacyInstrumentPendingChanges()
 
     let shouldBackfillUnsynced = !isFirstLaunch
     let runFirstLaunchQueue = isFirstLaunch

--- a/MoolahTests/Sync/SyncCoordinatorInstrumentDrainTests.swift
+++ b/MoolahTests/Sync/SyncCoordinatorInstrumentDrainTests.swift
@@ -1,0 +1,146 @@
+@preconcurrency import CloudKit
+import Foundation
+import Testing
+
+@testable import Moolah
+
+/// Pure-function tests for the legacy-`InstrumentRecord` pending-change
+/// drain that runs at coordinator startup. Catches both the prefixed
+/// `"InstrumentRecord|<UUID>"` form and the bare string-keyed legacy
+/// shape (e.g. `"0:native"`, `"AUD"`) — the only legitimate path for
+/// instrument writes is the shared registry on the profile-index zone
+/// (PR #861), so any pending change for an instrument on a per-profile
+/// zone is leftover state that must be dropped before
+/// `nextRecordZoneChangeBatch` materialises it and trips the DEBUG
+/// `preconditionFailure` in `ProfileDataSyncHandler.recordToSave`.
+@Suite("SyncCoordinator legacy-instrument drain")
+struct SyncCoordinatorInstrumentDrainTests {
+
+  // MARK: - Helpers
+
+  private static func dataZone() -> CKRecordZone.ID {
+    CKRecordZone.ID(
+      zoneName: "profile-\(UUID().uuidString)",
+      ownerName: CKCurrentUserDefaultName)
+  }
+
+  private static let indexZone = CKRecordZone.ID(
+    zoneName: "profile-index", ownerName: CKCurrentUserDefaultName)
+
+  // MARK: - Match cases
+
+  @Test("Drops bare string-keyed pending change on per-profile zone")
+  func dropsBareStringKeyedOnDataZone() {
+    let zone = Self.dataZone()
+    let stale: CKSyncEngine.PendingRecordZoneChange =
+      .saveRecord(CKRecord.ID(recordName: "0:native", zoneID: zone))
+    let result = SyncCoordinator.legacyInstrumentPendingChanges(in: [stale])
+    #expect(result.count == 1)
+    #expect(result.first == stale)
+  }
+
+  @Test("Drops bare instrument-id pending change on per-profile zone")
+  func dropsBareInstrumentIdOnDataZone() {
+    let zone = Self.dataZone()
+    let stale: CKSyncEngine.PendingRecordZoneChange =
+      .saveRecord(CKRecord.ID(recordName: "AUD", zoneID: zone))
+    let result = SyncCoordinator.legacyInstrumentPendingChanges(in: [stale])
+    #expect(result.count == 1)
+    #expect(result.first == stale)
+  }
+
+  @Test("Drops prefixed InstrumentRecord pending change on per-profile zone")
+  func dropsPrefixedInstrumentOnDataZone() {
+    let zone = Self.dataZone()
+    let recordID = CKRecord.ID(
+      recordName: "\(InstrumentRow.recordType)|\(UUID().uuidString)",
+      zoneID: zone)
+    let stale: CKSyncEngine.PendingRecordZoneChange = .saveRecord(recordID)
+    let result = SyncCoordinator.legacyInstrumentPendingChanges(in: [stale])
+    #expect(result.count == 1)
+    #expect(result.first == stale)
+  }
+
+  @Test("Drops delete-flavoured legacy instrument pending change")
+  func dropsDeleteFlavouredLegacyInstrument() {
+    let zone = Self.dataZone()
+    let stale: CKSyncEngine.PendingRecordZoneChange =
+      .deleteRecord(CKRecord.ID(recordName: "0:native", zoneID: zone))
+    let result = SyncCoordinator.legacyInstrumentPendingChanges(in: [stale])
+    #expect(result == [stale])
+  }
+
+  // MARK: - Skip cases
+
+  @Test("Keeps prefixed transaction-leg pending change on per-profile zone")
+  func keepsPrefixedTransactionLegOnDataZone() {
+    let zone = Self.dataZone()
+    let recordID = CKRecord.ID(
+      recordName: "\(TransactionLegRow.recordType)|\(UUID().uuidString)",
+      zoneID: zone)
+    let kept: CKSyncEngine.PendingRecordZoneChange = .saveRecord(recordID)
+    let result = SyncCoordinator.legacyInstrumentPendingChanges(in: [kept])
+    #expect(result.isEmpty)
+  }
+
+  @Test("Keeps prefixed InstrumentRecord pending change on profile-index zone")
+  func keepsPrefixedInstrumentOnIndexZone() {
+    let recordID = CKRecord.ID(
+      recordName: "\(InstrumentRow.recordType)|\(UUID().uuidString)",
+      zoneID: Self.indexZone)
+    let kept: CKSyncEngine.PendingRecordZoneChange = .saveRecord(recordID)
+    let result = SyncCoordinator.legacyInstrumentPendingChanges(in: [kept])
+    #expect(result.isEmpty)
+  }
+
+  @Test("Keeps bare-UUID pending change (handled by sibling purge)")
+  func keepsBareUUIDOnDataZone() {
+    let zone = Self.dataZone()
+    let kept: CKSyncEngine.PendingRecordZoneChange =
+      .saveRecord(CKRecord.ID(recordName: UUID().uuidString, zoneID: zone))
+    let result = SyncCoordinator.legacyInstrumentPendingChanges(in: [kept])
+    #expect(result.isEmpty)
+  }
+
+  @Test("Keeps pending change on unknown-shaped zone")
+  func keepsUnknownZone() {
+    let zone = CKRecordZone.ID(
+      zoneName: "some-other-zone", ownerName: CKCurrentUserDefaultName)
+    let kept: CKSyncEngine.PendingRecordZoneChange =
+      .saveRecord(CKRecord.ID(recordName: "0:native", zoneID: zone))
+    let result = SyncCoordinator.legacyInstrumentPendingChanges(in: [kept])
+    #expect(result.isEmpty)
+  }
+
+  // MARK: - Mixed input
+
+  @Test("Returns only the legacy entries from a mixed input")
+  func mixedInputReturnsOnlyLegacy() {
+    let dataZone = Self.dataZone()
+    let legacyBare: CKSyncEngine.PendingRecordZoneChange =
+      .saveRecord(CKRecord.ID(recordName: "0:native", zoneID: dataZone))
+    let legacyPrefixed: CKSyncEngine.PendingRecordZoneChange = .saveRecord(
+      CKRecord.ID(
+        recordName: "\(InstrumentRow.recordType)|\(UUID().uuidString)",
+        zoneID: dataZone))
+    let validLeg: CKSyncEngine.PendingRecordZoneChange = .saveRecord(
+      CKRecord.ID(
+        recordName: "\(TransactionLegRow.recordType)|\(UUID().uuidString)",
+        zoneID: dataZone))
+    let validIndexInstrument: CKSyncEngine.PendingRecordZoneChange = .saveRecord(
+      CKRecord.ID(
+        recordName: "\(InstrumentRow.recordType)|\(UUID().uuidString)",
+        zoneID: Self.indexZone))
+    let result = SyncCoordinator.legacyInstrumentPendingChanges(
+      in: [legacyBare, validLeg, legacyPrefixed, validIndexInstrument])
+    #expect(result.count == 2)
+    #expect(result.contains(legacyBare))
+    #expect(result.contains(legacyPrefixed))
+  }
+
+  @Test("Empty input returns empty")
+  func emptyInputReturnsEmpty() {
+    let result = SyncCoordinator.legacyInstrumentPendingChanges(in: [])
+    #expect(result.isEmpty)
+  }
+}


### PR DESCRIPTION
## Summary

A device that ran the app before [#861](https://github.com/ajsutton/moolah-native/pull/861) (shared-instrument-registry rollout)
can carry leftover `InstrumentRecord` pending changes in its local
CKSyncEngine state, routed to a per-profile zone. Symptom: the dev
build crashes ~2 seconds after `Zones ready — sending pending changes`
with

```
ProfileDataSyncHandler+RecordLookup.swift:65: Fatal error:
InstrumentRecord upload routed to per-profile zone profile-…
(string-keyed recordName 0:native) — every InstrumentRecord write
must go through the shared registry on the profile-index zone.
```

The DEBUG `preconditionFailure` aborts the process the moment
CKSyncEngine asks `recordToSave` to materialise the legacy entry.
Release builds already log + drop (return `nil`), but a DEBUG dev
build is effectively unrunnable against the user's personal data.

## Fix

`SyncCoordinator.completeStart` now calls
`purgeLegacyInstrumentPendingChanges()` next to the existing
`purgeStaleBareUUIDPendingChanges()` step. The new step removes any
entry on a per-profile zone whose recordName is:

- prefixed `InstrumentRecord|<UUID>` (queued by a pre-rollout build), or
- bare string-keyed (no `|`, not a UUID — e.g. `"AUD"`, `"0:native"`,
  matching the even-older `<scope>:<id>` instrument shape).

Companion to `purgeStaleBareUUIDPendingChanges` (issue #416), which
targets the orthogonal bare-UUID legacy shape on UUID-keyed records.
Running both at start covers every leftover shape we know about.

The filter logic lives in `nonisolated static` `legacyInstrumentPendingChanges(in:)` so it can
be unit-tested without spinning up a real `CKSyncEngine`. The runtime
wrapper `purgeLegacyInstrumentPendingChanges()` calls the static and
applies the removal via `state.remove(pendingRecordZoneChanges:)`.

## Test plan

- [x] 8 new unit tests cover prefixed/bare-string-keyed/delete/profile-index/bare-UUID/unknown-zone shapes plus a mixed input.
- [x] `just test-mac` — 2743 tests pass.
- [x] `just test-ios` (targeted) passes.
- [x] `just format-check` clean.
- [ ] On the user's device with a queued 0:native legacy entry, app launches past Zones ready without aborting and the warning log line "Purging N legacy InstrumentRecord pending changes routed to per-profile zones" appears once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)