### PR TITLE
feat(import): support custom trade CSV format

### DIFF
--- a/MoolahTests/Shared/CSVImport/CustomTradeCSVParserTests.swift
+++ b/MoolahTests/Shared/CSVImport/CustomTradeCSVParserTests.swift
@@ -30,44 +30,46 @@ struct CustomTradeCSVParserTests {
     #expect(results.count == 4)
 
     // Row 1: Deposit (Buy AUD)
-    if case .transaction(let t1) = results[0] {
-      #expect(t1.legs.count == 1)
-      #expect(t1.legs[0].instrument == .AUD)
-      #expect(t1.legs[0].quantity == 1)
-      #expect(t1.rawDescription == "Deposit")
+    if case .transaction(let transaction) = results[0] {
+      #expect(transaction.legs.count == 1)
+      #expect(transaction.legs[0].instrument == .AUD)
+      #expect(transaction.legs[0].quantity == 1)
+      #expect(transaction.rawDescription == "Deposit")
     } else {
       Issue.record("Expected transaction for row 1")
     }
 
     // Row 2: PMA Participation (Sell AUD)
-    if case .transaction(let t2) = results[1] {
-      #expect(t2.legs.count == 1)
-      #expect(t2.legs[0].instrument == .AUD)
-      #expect(t2.legs[0].quantity == -1)
-      #expect(t2.rawDescription == "PMA Participation")
+    if case .transaction(let transaction) = results[1] {
+      #expect(transaction.legs.count == 1)
+      #expect(transaction.legs[0].instrument == .AUD)
+      #expect(transaction.legs[0].quantity == -1)
+      #expect(transaction.rawDescription == "PMA Participation")
     } else {
       Issue.record("Expected transaction for row 2")
     }
 
     // Row 3: Large Deposit
-    if case .transaction(let t3) = results[2] {
-      #expect(t3.legs[0].quantity == 64999)
+    if case .transaction(let transaction) = results[2] {
+      #expect(transaction.legs[0].quantity == 64999)
     } else {
       Issue.record("Expected transaction for row 3")
     }
 
     // Row 4: Trade (Sell AUD, Buy IAF, Fee AUD)
-    if case .transaction(let t4) = results[3] {
-      #expect(t4.legs.count == 3)
+    if case .transaction(let transaction) = results[3] {
+      #expect(transaction.legs.count == 3)
 
-      let audSell = t4.legs.first { $0.instrument == .AUD && $0.quantity < 0 && $0.type == .trade }
-      let iafBuy = t4.legs.first { $0.instrument.ticker == "IAF.AX" }
-      let fee = t4.legs.first { $0.type == .expense }
+      let audSell = transaction.legs.first {
+        $0.instrument == .AUD && $0.quantity < 0 && $0.type == .trade
+      }
+      let iafBuy = transaction.legs.first { $0.instrument.ticker == "IAF.AX" }
+      let fee = transaction.legs.first { $0.type == .expense }
 
       #expect(audSell?.quantity == -1387.8)
       #expect(iafBuy?.quantity == 12)
       #expect(fee?.quantity == -5.50)
-      #expect(t4.rawAmount == -1387.8)
+      #expect(transaction.rawAmount == -1387.8)
     } else {
       Issue.record("Expected transaction for row 4")
     }

--- a/MoolahTests/Shared/CSVImport/CustomTradeCSVParserTests.swift
+++ b/MoolahTests/Shared/CSVImport/CustomTradeCSVParserTests.swift
@@ -1,0 +1,75 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+struct CustomTradeCSVParserTests {
+
+  @Test("Recognizes custom trade CSV headers")
+  func testRecognizes() {
+    let parser = CustomTradeCSVParser()
+    let headers = [
+      "Date", "Sell", "Sell Unit", "Buy", "Buy Unit", "Fee (AUD)", "Avg. Cost", "Broker", "Type",
+    ]
+    #expect(parser.recognizes(headers: headers))
+  }
+
+  @Test("Parses sample rows correctly")
+  func testParseSample() throws {
+    let csv = """
+      Date,Sell,Sell Unit,Buy,Buy Unit,Fee (AUD),Avg. Cost,Broker,Type
+      2021-01-19,,,1,AUD,$\t0.00,$\t1,InvestSMART,Deposit
+      2021-01-19,1,AUD,,,$\t0.00,$\t1,InvestSMART,PMA Participation 
+      2021-01-20,,,"64,999",AUD,$\t0.00,$\t1,InvestSMART,Deposit
+      2021-01-21,"1,387.8",AUD,12,IAF,$\t5.50,$\t115.65,InvestSMART,Trade
+      """
+    let rows = CSVTokenizer.parse(csv)
+    let parser = CustomTradeCSVParser()
+    let results = try parser.parse(rows: rows)
+
+    #expect(results.count == 4)
+
+    // Row 1: Deposit (Buy AUD)
+    if case .transaction(let t1) = results[0] {
+      #expect(t1.legs.count == 1)
+      #expect(t1.legs[0].instrument == .AUD)
+      #expect(t1.legs[0].quantity == 1)
+      #expect(t1.rawDescription == "Deposit")
+    } else {
+      Issue.record("Expected transaction for row 1")
+    }
+
+    // Row 2: PMA Participation (Sell AUD)
+    if case .transaction(let t2) = results[1] {
+      #expect(t2.legs.count == 1)
+      #expect(t2.legs[0].instrument == .AUD)
+      #expect(t2.legs[0].quantity == -1)
+      #expect(t2.rawDescription == "PMA Participation")
+    } else {
+      Issue.record("Expected transaction for row 2")
+    }
+
+    // Row 3: Large Deposit
+    if case .transaction(let t3) = results[2] {
+      #expect(t3.legs[0].quantity == 64999)
+    } else {
+      Issue.record("Expected transaction for row 3")
+    }
+
+    // Row 4: Trade (Sell AUD, Buy IAF, Fee AUD)
+    if case .transaction(let t4) = results[3] {
+      #expect(t4.legs.count == 3)
+
+      let audSell = t4.legs.first { $0.instrument == .AUD && $0.quantity < 0 && $0.type == .trade }
+      let iafBuy = t4.legs.first { $0.instrument.ticker == "IAF.AX" }
+      let fee = t4.legs.first { $0.type == .expense }
+
+      #expect(audSell?.quantity == -1387.8)
+      #expect(iafBuy?.quantity == 12)
+      #expect(fee?.quantity == -5.50)
+      #expect(t4.rawAmount == -1387.8)
+    } else {
+      Issue.record("Expected transaction for row 4")
+    }
+  }
+}

--- a/Shared/CSVImport/CSVParserRegistry.swift
+++ b/Shared/CSVImport/CSVParserRegistry.swift
@@ -17,6 +17,7 @@ struct CSVParserRegistry: Sendable {
   static let `default` = CSVParserRegistry(parsers: [
     SelfWealthMovementsParser(),
     SelfWealthCashReportParser(),
+    CustomTradeCSVParser(),
     GenericBankCSVParser(),
   ])
 

--- a/Shared/CSVImport/CustomTradeCSVParser.swift
+++ b/Shared/CSVImport/CustomTradeCSVParser.swift
@@ -1,5 +1,3 @@
-// swiftlint:disable multiline_arguments
-
 import Foundation
 
 /// Parser for a custom trade CSV format.
@@ -91,59 +89,22 @@ struct CustomTradeCSVParser: CSVParser, Sendable {
     let buyUnit = safe(row, columns.buyUnit).trimmingCharacters(in: .whitespaces)
     let fee = parseDecimal(safe(row, columns.fee)) ?? 0
 
-    var legs: [ParsedLeg] = []
-
-    // Sell side
-    if sellAmount != 0 {
-      legs.append(
-        ParsedLeg(
-          accountId: nil,
-          instrument: instrument(for: sellUnit),
-          quantity: -sellAmount,
-          type: .trade,
-          isInstrumentPlaceholder: sellUnit == "AUD"
-        ))
-    }
-
-    // Buy side
-    if buyAmount != 0 {
-      legs.append(
-        ParsedLeg(
-          accountId: nil,
-          instrument: instrument(for: buyUnit),
-          quantity: buyAmount,
-          type: .trade,
-          isInstrumentPlaceholder: buyUnit == "AUD"
-        ))
-    }
-
-    // Fee
-    if fee != 0 {
-      legs.append(
-        ParsedLeg(
-          accountId: nil,
-          instrument: .AUD,
-          quantity: -fee,
-          type: .expense,
-          isInstrumentPlaceholder: true
-        ))
-    }
+    let legs = buildLegs(
+      sellAmount: sellAmount,
+      sellUnit: sellUnit,
+      buyAmount: buyAmount,
+      buyUnit: buyUnit,
+      fee: fee)
 
     if legs.isEmpty {
       return .skip(reason: "row has no amounts")
     }
 
-    // Determine rawAmount for display/dedupe logic.
-    // If it's a trade involving AUD, use the AUD magnitude as the "amount".
-    let rawAmount: Decimal
-    if buyUnit == "AUD" {
-      rawAmount = buyAmount
-    } else if sellUnit == "AUD" {
-      rawAmount = -sellAmount
-    } else {
-      // Non-AUD trade (rare for this source), pick buy side.
-      rawAmount = buyAmount != 0 ? buyAmount : -sellAmount
-    }
+    let rawAmount = calculateRawAmount(
+      buyAmount: buyAmount,
+      buyUnit: buyUnit,
+      sellAmount: sellAmount,
+      sellUnit: sellUnit)
 
     return .transaction(
       ParsedTransaction(
@@ -157,7 +118,69 @@ struct CustomTradeCSVParser: CSVParser, Sendable {
       ))
   }
 
+  private func buildLegs(
+    sellAmount: Decimal,
+    sellUnit: String,
+    buyAmount: Decimal,
+    buyUnit: String,
+    fee: Decimal
+  ) -> [ParsedLeg] {
+    var legs: [ParsedLeg] = []
+
+    if sellAmount != 0 {
+      legs.append(
+        ParsedLeg(
+          accountId: nil,
+          instrument: instrument(for: sellUnit),
+          quantity: -sellAmount,
+          type: .trade,
+          isInstrumentPlaceholder: sellUnit == "AUD"
+        ))
+    }
+
+    if buyAmount != 0 {
+      legs.append(
+        ParsedLeg(
+          accountId: nil,
+          instrument: instrument(for: buyUnit),
+          quantity: buyAmount,
+          type: .trade,
+          isInstrumentPlaceholder: buyUnit == "AUD"
+        ))
+    }
+
+    if fee != 0 {
+      legs.append(
+        ParsedLeg(
+          accountId: nil,
+          instrument: .AUD,
+          quantity: -fee,
+          type: .expense,
+          isInstrumentPlaceholder: true
+        ))
+    }
+
+    return legs
+  }
+
+  private func calculateRawAmount(
+    buyAmount: Decimal,
+    buyUnit: String,
+    sellAmount: Decimal,
+    sellUnit: String
+  ) -> Decimal {
+    if buyUnit == "AUD" {
+      return buyAmount
+    } else if sellUnit == "AUD" {
+      return -sellAmount
+    } else {
+      // Non-AUD trade (rare for this source), pick buy side.
+      return buyAmount != 0 ? buyAmount : -sellAmount
+    }
+  }
+
   private func instrument(for unit: String) -> Instrument {
+
     if unit == "AUD" {
       return .AUD
     }

--- a/Shared/CSVImport/CustomTradeCSVParser.swift
+++ b/Shared/CSVImport/CustomTradeCSVParser.swift
@@ -1,0 +1,194 @@
+// swiftlint:disable multiline_arguments
+
+import Foundation
+
+/// Parser for a custom trade CSV format.
+///
+/// Each row can represent a Deposit, Trade, or other transaction types.
+/// The CSV uses Sell/Buy pairs to represent exchanges.
+///
+/// Typical Trade row:
+/// Date,Sell,Sell Unit,Buy,Buy Unit,Fee (AUD),Avg. Cost,Broker,Type
+/// 2021-01-21,"1,387.8",AUD,12,IAF,$\t5.50,$\t115.65,InvestSMART,Trade
+///
+/// This maps to:
+/// - AUD Sell leg (negative)
+/// - IAF Buy leg (positive)
+/// - AUD Fee leg (negative)
+struct CustomTradeCSVParser: CSVParser, Sendable {
+
+  let identifier = "custom-trade-csv"
+
+  private static let requiredHeaders: Set<String> = [
+    "date", "sell", "sell unit", "buy", "buy unit", "fee (aud)", "avg. cost", "broker", "type",
+  ]
+
+  func recognizes(headers: [String]) -> Bool {
+    let normalised = Set(headers.map { $0.trimmingCharacters(in: .whitespaces).lowercased() })
+    return Self.requiredHeaders.isSubset(of: normalised)
+  }
+
+  func parse(rows: [[String]]) throws -> [ParsedRecord] {
+    guard let headers = rows.first else { throw CSVParserError.emptyFile }
+    guard recognizes(headers: headers) else { throw CSVParserError.headerMismatch }
+    let columns = try columnIndex(headers)
+
+    var results: [ParsedRecord] = []
+    for (offset, row) in rows.dropFirst().enumerated() {
+      let rowIndex = offset + 1
+      if row.allSatisfy({ $0.trimmingCharacters(in: .whitespaces).isEmpty }) {
+        results.append(.skip(reason: "blank row"))
+        continue
+      }
+      results.append(try parseDataRow(row, columns: columns, rowIndex: rowIndex))
+    }
+    return results
+  }
+
+  // MARK: - Private
+
+  private struct Columns {
+    let date: Int
+    let sell: Int
+    let sellUnit: Int
+    let buy: Int
+    let buyUnit: Int
+    let fee: Int
+    let type: Int
+  }
+
+  private func columnIndex(_ headers: [String]) throws -> Columns {
+    let normalised = headers.map { $0.trimmingCharacters(in: .whitespaces).lowercased() }
+    func find(_ name: String) -> Int? { normalised.firstIndex(of: name) }
+    guard let date = find("date"),
+      let sell = find("sell"),
+      let sellUnit = find("sell unit"),
+      let buy = find("buy"),
+      let buyUnit = find("buy unit"),
+      let fee = find("fee (aud)"),
+      let type = find("type")
+    else {
+      throw CSVParserError.headerMismatch
+    }
+    return Columns(
+      date: date, sell: sell, sellUnit: sellUnit, buy: buy, buyUnit: buyUnit, fee: fee, type: type)
+  }
+
+  private func parseDataRow(
+    _ row: [String], columns: Columns, rowIndex: Int
+  ) throws -> ParsedRecord {
+    let dateField = safe(row, columns.date).trimmingCharacters(in: .whitespaces)
+    let type = safe(row, columns.type).trimmingCharacters(in: .whitespaces)
+
+    guard let date = parseDate(dateField) else {
+      throw CSVParserError.malformedRow(
+        index: rowIndex, reason: "invalid date: \(dateField)", row: row)
+    }
+
+    let sellAmount = parseDecimal(safe(row, columns.sell)) ?? 0
+    let sellUnit = safe(row, columns.sellUnit).trimmingCharacters(in: .whitespaces)
+    let buyAmount = parseDecimal(safe(row, columns.buy)) ?? 0
+    let buyUnit = safe(row, columns.buyUnit).trimmingCharacters(in: .whitespaces)
+    let fee = parseDecimal(safe(row, columns.fee)) ?? 0
+
+    var legs: [ParsedLeg] = []
+
+    // Sell side
+    if sellAmount != 0 {
+      legs.append(
+        ParsedLeg(
+          accountId: nil,
+          instrument: instrument(for: sellUnit),
+          quantity: -sellAmount,
+          type: .trade,
+          isInstrumentPlaceholder: sellUnit == "AUD"
+        ))
+    }
+
+    // Buy side
+    if buyAmount != 0 {
+      legs.append(
+        ParsedLeg(
+          accountId: nil,
+          instrument: instrument(for: buyUnit),
+          quantity: buyAmount,
+          type: .trade,
+          isInstrumentPlaceholder: buyUnit == "AUD"
+        ))
+    }
+
+    // Fee
+    if fee != 0 {
+      legs.append(
+        ParsedLeg(
+          accountId: nil,
+          instrument: .AUD,
+          quantity: -fee,
+          type: .expense,
+          isInstrumentPlaceholder: true
+        ))
+    }
+
+    if legs.isEmpty {
+      return .skip(reason: "row has no amounts")
+    }
+
+    // Determine rawAmount for display/dedupe logic.
+    // If it's a trade involving AUD, use the AUD magnitude as the "amount".
+    let rawAmount: Decimal
+    if buyUnit == "AUD" {
+      rawAmount = buyAmount
+    } else if sellUnit == "AUD" {
+      rawAmount = -sellAmount
+    } else {
+      // Non-AUD trade (rare for this source), pick buy side.
+      rawAmount = buyAmount != 0 ? buyAmount : -sellAmount
+    }
+
+    return .transaction(
+      ParsedTransaction(
+        date: date,
+        legs: legs,
+        rawRow: row,
+        rawDescription: type,
+        rawAmount: rawAmount,
+        rawBalance: nil,
+        bankReference: nil
+      ))
+  }
+
+  private func instrument(for unit: String) -> Instrument {
+    if unit == "AUD" {
+      return .AUD
+    }
+    // Assume ASX-based for non-AUD units
+    return Instrument.stock(ticker: "\(unit).AX", exchange: "ASX", name: unit)
+  }
+
+  private func safe(_ row: [String], _ index: Int) -> String {
+    index >= 0 && index < row.count ? row[index] : ""
+  }
+
+  private func parseDecimal(_ field: String) -> Decimal? {
+    var value = field.trimmingCharacters(in: .whitespaces)
+    if value.isEmpty { return nil }
+    value = value.replacingOccurrences(of: "$", with: "")
+    value = value.replacingOccurrences(of: ",", with: "")
+    value = value.trimmingCharacters(in: .whitespaces)
+    return Decimal(string: value)
+  }
+
+  private func parseDate(_ field: String) -> Date? {
+    let trimmed = field.trimmingCharacters(in: .whitespaces)
+    if trimmed.isEmpty { return nil }
+    return dateFormatter.date(from: trimmed)
+  }
+
+  private let dateFormatter: DateFormatter = {
+    let formatter = DateFormatter()
+    formatter.locale = Locale(identifier: "en_US_POSIX")
+    formatter.timeZone = TimeZone(identifier: "UTC")
+    formatter.dateFormat = "yyyy-MM-dd"
+    return formatter
+  }()
+}


### PR DESCRIPTION
Implements support for a custom trade CSV format with buy/sell pairs and breakout fees. Verified with unit tests.