### PR TITLE
perf(conversion): memoise FullConversionService unit factor per (source, target, UTC-day)

### DIFF
--- a/MoolahTests/Shared/FullConversionServiceCachingTests.swift
+++ b/MoolahTests/Shared/FullConversionServiceCachingTests.swift
@@ -1,0 +1,242 @@
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+/// Pins the per-(from, to, day) memoisation on `FullConversionService`.
+///
+/// Background: issue #868 documented a ~1400-call burst of identical
+/// `convert(_:from:to:on:)` calls within one second at cold app launch.
+/// `FullConversionService` is an actor — every call serialises through
+/// the executor and emits two `os_log` lines. Memoising the unit rate
+/// per `(source.id, target.id, calendar-day)` collapses N identical
+/// calls in a recompute cycle to one underlying lookup.
+@Suite("FullConversionService caching")
+struct FullConversionServiceCachingTests {
+  private let eth = Instrument.crypto(
+    chainId: 1, contractAddress: nil, symbol: "ETH", name: "Ethereum", decimals: 18
+  )
+  private let usd = Instrument.USD
+  private let aud = Instrument.AUD
+  private let eur = Instrument.fiat(code: "EUR")
+
+  private func date(_ string: String) throws -> Date {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withFullDate]
+    return try #require(formatter.date(from: string))
+  }
+
+  private struct Bundle {
+    let service: FullConversionService
+  }
+
+  private func makeService(
+    cryptoPrices: [String: [String: Decimal]] = [:],
+    exchangeRates: [String: [String: Decimal]] = [:],
+    registrations: [CryptoRegistration] = []
+  ) throws -> Bundle {
+    let database = try ProfileDatabase.openInMemory()
+    let cryptoService = CryptoPriceService(
+      clients: [FixedCryptoPriceClient(prices: cryptoPrices)],
+      database: database
+    )
+    let exchangeService = ExchangeRateService(
+      client: FixedRateClient(rates: exchangeRates),
+      database: database
+    )
+    let stockService = StockPriceService(client: FixedStockPriceClient(), database: database)
+    let service = FullConversionService(
+      exchangeRates: exchangeService,
+      stockPrices: stockService,
+      cryptoPrices: cryptoService,
+      cryptoRegistrations: { registrations }
+    )
+    return Bundle(service: service)
+  }
+
+  // MARK: - Fiat memoisation
+
+  /// Four identical fiat calls must populate exactly one cache entry —
+  /// the symptom in issue #868 was N redundant identical lookups in a
+  /// recompute burst.
+  @Test
+  func repeatedIdenticalFiatConvertsPopulateOneCacheEntry() async throws {
+    let day = try date("2025-06-15")
+    let bundle = try makeService(
+      exchangeRates: ["2025-06-15": ["AUD": dec("1.5385")]]
+    )
+
+    for _ in 0..<4 {
+      let result = try await bundle.service.convert(
+        dec("100"), from: usd, to: aud, on: day)
+      #expect(result == dec("100") * dec("1.5385"))
+    }
+
+    #expect(await bundle.service.cachedRateCount == 1)
+  }
+
+  /// Different `(from, to)` pairs on the same day are separate entries.
+  @Test
+  func distinctInstrumentPairsOnSameDayUseSeparateEntries() async throws {
+    let day = try date("2025-06-15")
+    let bundle = try makeService(
+      exchangeRates: ["2025-06-15": ["AUD": dec("1.5385"), "EUR": dec("0.92")]]
+    )
+
+    _ = try await bundle.service.convert(dec("1"), from: usd, to: aud, on: day)
+    _ = try await bundle.service.convert(dec("1"), from: usd, to: eur, on: day)
+
+    #expect(await bundle.service.cachedRateCount == 2)
+  }
+
+  /// Same `(from, to)` on distinct calendar days are separate entries.
+  @Test
+  func distinctDaysUseSeparateEntries() async throws {
+    let bundle = try makeService(
+      exchangeRates: [
+        "2025-06-15": ["AUD": dec("1.5385")],
+        "2025-06-16": ["AUD": dec("1.5400")],
+      ]
+    )
+
+    _ = try await bundle.service.convert(
+      dec("1"), from: usd, to: aud, on: try date("2025-06-15"))
+    _ = try await bundle.service.convert(
+      dec("1"), from: usd, to: aud, on: try date("2025-06-16"))
+
+    #expect(await bundle.service.cachedRateCount == 2)
+  }
+
+  /// Different times within the same UTC calendar day collapse to one
+  /// entry — the cache key buckets by UTC day so that recompute cycles
+  /// fired at arbitrary intra-day timestamps don't multiply entries.
+  /// UTC bucketing matches the underlying price services' day key.
+  @Test
+  func differentTimesOnSameDayShareOneEntry() async throws {
+    let bundle = try makeService(
+      exchangeRates: ["2025-06-15": ["AUD": dec("1.5385")]]
+    )
+    let utc = try #require(TimeZone(identifier: "UTC"))
+    var utcCalendar = Calendar(identifier: .gregorian)
+    utcCalendar.timeZone = utc
+    let morning = try #require(
+      utcCalendar.date(
+        from: DateComponents(timeZone: utc, year: 2025, month: 6, day: 15, hour: 9))
+    )
+    let evening = try #require(
+      utcCalendar.date(
+        from: DateComponents(timeZone: utc, year: 2025, month: 6, day: 15, hour: 21))
+    )
+
+    _ = try await bundle.service.convert(dec("1"), from: usd, to: aud, on: morning)
+    _ = try await bundle.service.convert(dec("1"), from: usd, to: aud, on: evening)
+
+    #expect(await bundle.service.cachedRateCount == 1)
+  }
+
+  /// Same-instrument identity short-circuit must NOT populate the cache:
+  /// it returns `quantity` unchanged with no provider work.
+  @Test
+  func sameInstrumentConvertDoesNotPopulateCache() async throws {
+    let bundle = try makeService()
+    let result = try await bundle.service.convert(
+      dec("100"), from: usd, to: usd, on: try date("2025-06-15"))
+    #expect(result == dec("100"))
+    #expect(await bundle.service.cachedRateCount == 0)
+  }
+
+  // MARK: - Future-date clamping interacts with the day bucket
+
+  /// Future dates clamp to "today" before the cache lookup, so two
+  /// distinct future timestamps land on the same cache entry. This is
+  /// the cold-launch case where forecast / scheduled transactions feed
+  /// future dates into convert calls.
+  @Test
+  func futureDatesShareTodaysCacheEntry() async throws {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withFullDate]
+    // Use UTC explicitly — both the memo bucket and `cappedToYesterday`
+    // in the underlying services key off UTC days, so the fixture date
+    // must agree by construction rather than depend on the host
+    // timezone matching UTC at the moment the test runs.
+    var calendar = Calendar(identifier: .gregorian)
+    calendar.timeZone = try #require(TimeZone(identifier: "UTC"))
+    let today = calendar.startOfDay(for: Date())
+    // Yesterday matches `cappedToYesterday`'s selection when the
+    // service receives a (future, clamped-to-today) request.
+    let yesterdayKey = try #require(
+      calendar.date(byAdding: .day, value: -1, to: today).map(formatter.string(from:))
+    )
+    let bundle = try makeService(
+      exchangeRates: [yesterdayKey: ["AUD": dec("1.5385")]]
+    )
+
+    let future1 = try #require(calendar.date(byAdding: .day, value: 7, to: today))
+    let future2 = try #require(calendar.date(byAdding: .day, value: 30, to: today))
+    _ = try await bundle.service.convert(dec("1"), from: usd, to: aud, on: future1)
+    _ = try await bundle.service.convert(dec("1"), from: usd, to: aud, on: future2)
+
+    #expect(await bundle.service.cachedRateCount == 1)
+  }
+
+  // MARK: - Invalidation
+
+  /// `invalidateCache(for:)` drops every cache entry mentioning the
+  /// instrument — required so a status-change on a crypto registration
+  /// (e.g. user-flagged spam) is honoured by the next aggregation pass.
+  @Test
+  func invalidateCacheRemovesEntriesInvolvingInstrument() async throws {
+    let registration = CryptoRegistration(
+      instrument: eth,
+      mapping: CryptoProviderMapping(
+        instrumentId: "1:native", coingeckoId: "ethereum",
+        cryptocompareSymbol: "ETH", binanceSymbol: "ETHUSDT"
+      ),
+      pricingStatus: .priced
+    )
+    let day = try date("2025-06-15")
+    let bundle = try makeService(
+      cryptoPrices: ["1:native": ["2025-06-15": dec("1600")]],
+      exchangeRates: ["2025-06-15": ["AUD": dec("1.5385")]],
+      registrations: [registration]
+    )
+
+    _ = try await bundle.service.convert(dec("1"), from: eth, to: usd, on: day)
+    _ = try await bundle.service.convert(dec("1"), from: usd, to: aud, on: day)
+    #expect(await bundle.service.cachedRateCount == 2)
+
+    await bundle.service.invalidateCache(for: eth)
+
+    // The ETH→USD entry is dropped; USD→AUD survives.
+    #expect(await bundle.service.cachedRateCount == 1)
+  }
+
+  // MARK: - Crypto unit-rate caching
+
+  @Test
+  func repeatedCryptoConvertsPopulateOneCacheEntry() async throws {
+    let registration = CryptoRegistration(
+      instrument: eth,
+      mapping: CryptoProviderMapping(
+        instrumentId: "1:native", coingeckoId: "ethereum",
+        cryptocompareSymbol: "ETH", binanceSymbol: "ETHUSDT"
+      ),
+      pricingStatus: .priced
+    )
+    let day = try date("2025-06-15")
+    let bundle = try makeService(
+      cryptoPrices: ["1:native": ["2025-06-15": dec("1600")]],
+      exchangeRates: ["2025-06-15": ["AUD": dec("1.5385")]],
+      registrations: [registration]
+    )
+
+    for _ in 0..<3 {
+      let result = try await bundle.service.convert(
+        dec("2"), from: eth, to: aud, on: day)
+      #expect(result == dec("2") * dec("1600") * dec("1.5385"))
+    }
+
+    #expect(await bundle.service.cachedRateCount == 1)
+  }
+}

--- a/Shared/FullConversionService.swift
+++ b/Shared/FullConversionService.swift
@@ -22,6 +22,49 @@ actor FullConversionService: InstrumentConversionService {
   /// `ObservationErrorChannel` doc for the surface-then-finish contract.
   private let errorChannel: ObservationErrorChannel?
 
+  /// Per-(source, target, day) memo of the unit conversion factor.
+  /// `convert(quantity:)` applies it as `(quantity * multiplier) /
+  /// divisor` so that paths whose closed form is a division (fiat →
+  /// crypto, crypto → crypto) preserve `Decimal` precision — eagerly
+  /// computing `multiplier / divisor` would truncate at 38 digits and
+  /// produce `0.99999…` for inputs that should give exactly `1`.
+  ///
+  /// Collapses the cold-launch burst of N identical convert calls
+  /// (≈1400 in 1 s on a populated profile, issue #868) to one
+  /// underlying lookup per distinct triple, skipping both the actor
+  /// hop into the price services and the per-call `os_log` pair. Same
+  /// staleness model as the underlying services' in-memory caches —
+  /// cleared by `invalidateCache(for:)` for entries mentioning the
+  /// instrument.
+  private struct RateCacheKey: Hashable {
+    let fromId: String
+    let toId: String
+    let day: Date
+  }
+
+  private struct UnitFactor {
+    let multiplier: Decimal
+    let divisor: Decimal
+  }
+
+  private var rateCache: [RateCacheKey: UnitFactor] = [:]
+
+  /// UTC calendar — the underlying price services key their stored
+  /// rates by UTC day, so the memo bucket must agree to avoid
+  /// returning a stale rate across a UTC midnight boundary that's
+  /// still "the same day" in the user's local timezone.
+  private let calendar: Calendar = {
+    var calendar = Calendar(identifier: .gregorian)
+    calendar.timeZone = TimeZone(identifier: "UTC") ?? .current
+    return calendar
+  }()
+
+  /// Number of distinct `(source, target, day)` triples currently
+  /// memoised. Exposed for the caching-invariant tests in
+  /// `FullConversionServiceCachingTests` so they can assert that
+  /// repeated identical calls collapse to a single cache entry.
+  var cachedRateCount: Int { rateCache.count }
+
   /// - Parameter cryptoRegistrations: Closure invoked on each crypto
   ///   conversion to obtain the current set of crypto registrations. Tokens
   ///   registered via `CryptoPriceService` after service construction become
@@ -64,46 +107,90 @@ actor FullConversionService: InstrumentConversionService {
     // we resolve against the latest available rate instead of throwing.
     // See guides/INSTRUMENT_CONVERSION_GUIDE.md Rule 7.
     let effectiveDate = min(date, Date())
+    let factor = try await unitFactor(from: source, to: target, on: effectiveDate)
+    return (quantity * factor.multiplier) / factor.divisor
+  }
 
-    logger.info(
-      "Converting \(quantity, privacy: .public) from \(source.id, privacy: .public) (\(String(describing: source.kind), privacy: .public)) to \(target.id, privacy: .public) (\(String(describing: target.kind), privacy: .public))"
+  /// Resolves the per-unit conversion factor for `source → target` on
+  /// `date`, caching the result keyed by `(source.id, target.id,
+  /// calendar-day)`. Cache misses log at `.debug`; cache hits are
+  /// silent. Logging at `.info` for every call (the historic shape)
+  /// cost ≈2800 `os_log` lines in <1 s during the cold-launch burst
+  /// documented in issue #868.
+  private func unitFactor(
+    from source: Instrument,
+    to target: Instrument,
+    on date: Date
+  ) async throws -> UnitFactor {
+    let key = RateCacheKey(
+      fromId: source.id,
+      toId: target.id,
+      day: calendar.startOfDay(for: date)
     )
-
-    let result: Decimal
-    switch (source.kind, target.kind) {
-    case (.fiatCurrency, .fiatCurrency):
-      let rate = try await exchangeRates.rate(from: source, to: target, on: effectiveDate)
-      result = quantity * rate
-
-    case (.stock, .fiatCurrency):
-      result = try await convertStockToFiat(
-        quantity, stock: source, fiat: target, on: effectiveDate)
-
-    case (.cryptoToken, .fiatCurrency):
-      result = try await convertCryptoToFiat(
-        quantity, crypto: source, fiat: target, on: effectiveDate)
-
-    case (.fiatCurrency, .cryptoToken):
-      let oneUnitInFiat = try await convertCryptoToFiat(
-        Decimal(1), crypto: target, fiat: source, on: effectiveDate)
-      result = quantity / oneUnitInFiat
-
-    case (.cryptoToken, .cryptoToken):
-      let sourceUsdPrice = try await cryptoUsdPrice(for: source, on: effectiveDate)
-      let targetUsdPrice = try await cryptoUsdPrice(for: target, on: effectiveDate)
-      result = (quantity * sourceUsdPrice) / targetUsdPrice
-
-    case (.stock, .cryptoToken), (.cryptoToken, .stock):
-      // Chain through USD as intermediate
-      let sourceUsd = try await toUsd(quantity, instrument: source, on: effectiveDate)
-      result = try await fromUsd(sourceUsd, instrument: target, on: effectiveDate)
-
-    case (.fiatCurrency, .stock), (.stock, .stock):
-      throw ConversionError.unsupportedConversion(from: source.id, to: target.id)
+    if let cached = rateCache[key] {
+      return cached
     }
 
-    logger.info("Conversion result: \(result, privacy: .public) \(target.id, privacy: .public)")
-    return result
+    logger.debug(
+      "Converting 1 from \(source.id, privacy: .public) (\(String(describing: source.kind), privacy: .public)) to \(target.id, privacy: .public) (\(String(describing: target.kind), privacy: .public))"
+    )
+
+    let factor = try await computeUnitFactor(from: source, to: target, on: date)
+
+    logger.debug(
+      "Conversion factor: ×\(factor.multiplier, privacy: .public) ÷\(factor.divisor, privacy: .public) for \(target.id, privacy: .public)"
+    )
+    rateCache[key] = factor
+    return factor
+  }
+
+  private func computeUnitFactor(
+    from source: Instrument,
+    to target: Instrument,
+    on date: Date
+  ) async throws -> UnitFactor {
+    switch (source.kind, target.kind) {
+    case (.fiatCurrency, .fiatCurrency):
+      let rate = try await exchangeRates.rate(from: source, to: target, on: date)
+      return UnitFactor(multiplier: rate, divisor: Decimal(1))
+
+    case (.stock, .fiatCurrency):
+      let perUnit = try await convertStockToFiat(
+        Decimal(1), stock: source, fiat: target, on: date)
+      return UnitFactor(multiplier: perUnit, divisor: Decimal(1))
+
+    case (.cryptoToken, .fiatCurrency):
+      let perUnit = try await convertCryptoToFiat(
+        Decimal(1), crypto: source, fiat: target, on: date)
+      return UnitFactor(multiplier: perUnit, divisor: Decimal(1))
+
+    case (.fiatCurrency, .cryptoToken):
+      // Defer division so `300_000 JPY → ETH` at `1 ETH = 300_000 JPY`
+      // yields exactly `Decimal(1)` instead of `0.999…`.
+      let oneUnitInFiat = try await convertCryptoToFiat(
+        Decimal(1), crypto: target, fiat: source, on: date)
+      return UnitFactor(multiplier: Decimal(1), divisor: oneUnitInFiat)
+
+    case (.cryptoToken, .cryptoToken):
+      // Same precision concern: keep numerator and denominator separate
+      // so `(quantity * sourceUsdPrice) / targetUsdPrice` matches the
+      // original closed form.
+      let sourceUsdPrice = try await cryptoUsdPrice(for: source, on: date)
+      let targetUsdPrice = try await cryptoUsdPrice(for: target, on: date)
+      return UnitFactor(multiplier: sourceUsdPrice, divisor: targetUsdPrice)
+
+    case (.stock, .cryptoToken):
+      // `result = quantity * stockUsdValueAt1 / cryptoUsdPrice(target)`.
+      let stockUsdValueAt1 = try await convertStockToFiat(
+        Decimal(1), stock: source, fiat: Instrument.USD, on: date)
+      let targetUsdPrice = try await cryptoUsdPrice(for: target, on: date)
+      return UnitFactor(multiplier: stockUsdValueAt1, divisor: targetUsdPrice)
+
+    case (.cryptoToken, .stock),
+      (.fiatCurrency, .stock),
+      (.stock, .stock):
+      throw ConversionError.unsupportedConversion(from: source.id, to: target.id)
+    }
   }
 
   func convertAmount(
@@ -152,13 +239,16 @@ actor FullConversionService: InstrumentConversionService {
     return .value(converted)
   }
 
-  /// Invalidate any cached state held about `instrument`. For crypto
-  /// instruments this clears the in-memory and on-disk price rows in
-  /// `CryptoPriceService` so the next conversion fetches fresh data —
-  /// required after any user mutation that changes
-  /// `pricingStatus` for the instrument's registration. No-op for
-  /// fiat / stock instruments and when no `CryptoPriceService` is wired.
+  /// Invalidate any cached state held about `instrument`. Drops every
+  /// memoised unit rate that mentions the instrument (either side), so
+  /// the next aggregation re-fetches under the new pricing. For crypto
+  /// instruments additionally clears the in-memory and on-disk price
+  /// rows in `CryptoPriceService` — required after any user mutation
+  /// that changes `pricingStatus` for the instrument's registration.
   func invalidateCache(for instrument: Instrument) async {
+    rateCache = rateCache.filter { key, _ in
+      key.fromId != instrument.id && key.toId != instrument.id
+    }
     guard instrument.kind == .cryptoToken, let cryptoPrices else { return }
     await cryptoPrices.purgeCache(instrumentId: instrument.id)
   }
@@ -236,36 +326,4 @@ actor FullConversionService: InstrumentConversionService {
       for: registration.instrument, mapping: registration.mapping, on: date)
   }
 
-  // MARK: - USD intermediary helpers
-
-  private func toUsd(
-    _ quantity: Decimal, instrument: Instrument, on date: Date
-  ) async throws -> Decimal {
-    switch instrument.kind {
-    case .fiatCurrency:
-      if instrument.id == "USD" { return quantity }
-      let rate = try await exchangeRates.rate(from: instrument, to: .USD, on: date)
-      return quantity * rate
-    case .cryptoToken:
-      return try await convertCryptoToFiat(quantity, crypto: instrument, fiat: .USD, on: date)
-    case .stock:
-      return try await convertStockToFiat(quantity, stock: instrument, fiat: .USD, on: date)
-    }
-  }
-
-  private func fromUsd(
-    _ usdValue: Decimal, instrument: Instrument, on date: Date
-  ) async throws -> Decimal {
-    switch instrument.kind {
-    case .fiatCurrency:
-      if instrument.id == "USD" { return usdValue }
-      let rate = try await exchangeRates.rate(from: .USD, to: instrument, on: date)
-      return usdValue * rate
-    case .cryptoToken:
-      let oneUnitInUsd = try await cryptoUsdPrice(for: instrument, on: date)
-      return usdValue / oneUnitInUsd
-    case .stock:
-      throw ConversionError.unsupportedConversion(from: "USD", to: instrument.id)
-    }
-  }
 }


### PR DESCRIPTION
## Summary

- Collapses the cold-launch burst of ~1400 identical `FullConversionService.convert(_:from:to:on:)` calls into one underlying lookup per `(source, target, UTC-day)` triple.
- Stores a `UnitFactor(multiplier, divisor)` rather than a pre-divided rate so fiat→crypto and crypto→crypto paths preserve `Decimal` precision (eager division truncates at 38 digits and turns `300_000 JPY → ETH` at `1 ETH = 300_000 JPY` into `0.999…`).
- Per-call `Converting…` / `Conversion result…` logs drop from `.info` to `.debug` and fire only on cache miss — keeps the diagnostic signal for rate failures, drops ≈2800 `os_log` lines/s the burst was generating.
- UTC-day bucket matches `cappedToYesterday` and the underlying price services' date keys, so the memo doesn't go stale across a UTC midnight inside the user's local day.
- `invalidateCache(for:)` drops every entry mentioning the instrument on either side, so a crypto pricing-status change (`.priced` → `.spam`) still propagates on the next aggregation.

Fixes #868.

## Test plan

- [x] New `FullConversionServiceCachingTests` suite (8 tests) pins the caching invariants: repeated identical calls share one entry; distinct pairs/days don't share; intra-UTC-day timestamps share; same-instrument identity doesn't populate the cache; future dates clamp into today's bucket; `invalidateCache(for:)` evicts entries mentioning the instrument; crypto path also memoises.
- [x] Full suite green: `just test` (2759 tests / 458 suites passing on macOS + iOS).
- [x] `just format-check` clean.
- [x] `instrument-conversion-review` agent: Rule 7 clamping preserved, Rule 11 graceful-degradation intact (provider errors throw through the cache layer; nothing stale is cached), Rule 10 UTC-day consistency satisfied.