### PR TITLE
perf(sync): exclude encoded_system_fields from UI ValueObservation regions

### DIFF
--- a/Backends/GRDB/Records/AccountRow+ObservableRegion.swift
+++ b/Backends/GRDB/Records/AccountRow+ObservableRegion.swift
@@ -1,0 +1,19 @@
+// Backends/GRDB/Records/AccountRow+ObservableRegion.swift
+
+import Foundation
+import GRDB
+
+extension AccountRow {
+  /// Column-restricted region UI `ValueObservation`s pass to
+  /// `tracking(regions:fetch:)`. Excludes `encoded_system_fields` so the
+  /// per-batch sync-bookkeeping write CKSyncEngine performs after a
+  /// successful send does not re-fire UI observers. See issue #865.
+  /// `Columns: CaseIterable` means new columns auto-enrol — no
+  /// duplicate allowlist to maintain.
+  static var observableRegion: QueryInterfaceRequest<AccountRow> {
+    let columns: [any SQLSelectable] = Columns.allCases
+      .filter { $0 != .encodedSystemFields }
+      .map { $0 as any SQLSelectable }
+    return select(columns)
+  }
+}

--- a/Backends/GRDB/Records/CSVImportProfileRow+ObservableRegion.swift
+++ b/Backends/GRDB/Records/CSVImportProfileRow+ObservableRegion.swift
@@ -1,0 +1,17 @@
+// Backends/GRDB/Records/CSVImportProfileRow+ObservableRegion.swift
+
+import Foundation
+import GRDB
+
+extension CSVImportProfileRow {
+  /// Column-restricted region UI `ValueObservation`s pass to
+  /// `tracking(regions:fetch:)`. See
+  /// `AccountRow+ObservableRegion.swift` for the shared pattern and
+  /// issue #865 for the motivation.
+  static var observableRegion: QueryInterfaceRequest<CSVImportProfileRow> {
+    let columns: [any SQLSelectable] = Columns.allCases
+      .filter { $0 != .encodedSystemFields }
+      .map { $0 as any SQLSelectable }
+    return select(columns)
+  }
+}

--- a/Backends/GRDB/Records/CategoryRow+ObservableRegion.swift
+++ b/Backends/GRDB/Records/CategoryRow+ObservableRegion.swift
@@ -1,0 +1,18 @@
+// Backends/GRDB/Records/CategoryRow+ObservableRegion.swift
+
+import Foundation
+import GRDB
+
+extension CategoryRow {
+  /// Column-restricted region UI `ValueObservation`s pass to
+  /// `tracking(regions:fetch:)`. Excludes `encoded_system_fields` so
+  /// CKSyncEngine's per-batch sync-bookkeeping write does not re-fire
+  /// UI observers. See `AccountRow+ObservableRegion.swift` for the
+  /// shared pattern and issue #865 for the motivation.
+  static var observableRegion: QueryInterfaceRequest<CategoryRow> {
+    let columns: [any SQLSelectable] = Columns.allCases
+      .filter { $0 != .encodedSystemFields }
+      .map { $0 as any SQLSelectable }
+    return select(columns)
+  }
+}

--- a/Backends/GRDB/Records/EarmarkBudgetItemRow+ObservableRegion.swift
+++ b/Backends/GRDB/Records/EarmarkBudgetItemRow+ObservableRegion.swift
@@ -1,0 +1,17 @@
+// Backends/GRDB/Records/EarmarkBudgetItemRow+ObservableRegion.swift
+
+import Foundation
+import GRDB
+
+extension EarmarkBudgetItemRow {
+  /// Column-restricted region UI `ValueObservation`s pass to
+  /// `tracking(regions:fetch:)`. See
+  /// `AccountRow+ObservableRegion.swift` for the shared pattern and
+  /// issue #865 for the motivation.
+  static var observableRegion: QueryInterfaceRequest<EarmarkBudgetItemRow> {
+    let columns: [any SQLSelectable] = Columns.allCases
+      .filter { $0 != .encodedSystemFields }
+      .map { $0 as any SQLSelectable }
+    return select(columns)
+  }
+}

--- a/Backends/GRDB/Records/EarmarkRow+ObservableRegion.swift
+++ b/Backends/GRDB/Records/EarmarkRow+ObservableRegion.swift
@@ -1,0 +1,17 @@
+// Backends/GRDB/Records/EarmarkRow+ObservableRegion.swift
+
+import Foundation
+import GRDB
+
+extension EarmarkRow {
+  /// Column-restricted region UI `ValueObservation`s pass to
+  /// `tracking(regions:fetch:)`. See
+  /// `AccountRow+ObservableRegion.swift` for the shared pattern and
+  /// issue #865 for the motivation.
+  static var observableRegion: QueryInterfaceRequest<EarmarkRow> {
+    let columns: [any SQLSelectable] = Columns.allCases
+      .filter { $0 != .encodedSystemFields }
+      .map { $0 as any SQLSelectable }
+    return select(columns)
+  }
+}

--- a/Backends/GRDB/Records/ImportRuleRow+ObservableRegion.swift
+++ b/Backends/GRDB/Records/ImportRuleRow+ObservableRegion.swift
@@ -1,0 +1,17 @@
+// Backends/GRDB/Records/ImportRuleRow+ObservableRegion.swift
+
+import Foundation
+import GRDB
+
+extension ImportRuleRow {
+  /// Column-restricted region UI `ValueObservation`s pass to
+  /// `tracking(regions:fetch:)`. See
+  /// `AccountRow+ObservableRegion.swift` for the shared pattern and
+  /// issue #865 for the motivation.
+  static var observableRegion: QueryInterfaceRequest<ImportRuleRow> {
+    let columns: [any SQLSelectable] = Columns.allCases
+      .filter { $0 != .encodedSystemFields }
+      .map { $0 as any SQLSelectable }
+    return select(columns)
+  }
+}

--- a/Backends/GRDB/Records/InstrumentRow+ObservableRegion.swift
+++ b/Backends/GRDB/Records/InstrumentRow+ObservableRegion.swift
@@ -1,0 +1,17 @@
+// Backends/GRDB/Records/InstrumentRow+ObservableRegion.swift
+
+import Foundation
+import GRDB
+
+extension InstrumentRow {
+  /// Column-restricted region UI `ValueObservation`s pass to
+  /// `tracking(regions:fetch:)`. See
+  /// `AccountRow+ObservableRegion.swift` for the shared pattern and
+  /// issue #865 for the motivation.
+  static var observableRegion: QueryInterfaceRequest<InstrumentRow> {
+    let columns: [any SQLSelectable] = Columns.allCases
+      .filter { $0 != .encodedSystemFields }
+      .map { $0 as any SQLSelectable }
+    return select(columns)
+  }
+}

--- a/Backends/GRDB/Records/InvestmentValueRow+ObservableRegion.swift
+++ b/Backends/GRDB/Records/InvestmentValueRow+ObservableRegion.swift
@@ -1,0 +1,17 @@
+// Backends/GRDB/Records/InvestmentValueRow+ObservableRegion.swift
+
+import Foundation
+import GRDB
+
+extension InvestmentValueRow {
+  /// Column-restricted region UI `ValueObservation`s pass to
+  /// `tracking(regions:fetch:)`. See
+  /// `AccountRow+ObservableRegion.swift` for the shared pattern and
+  /// issue #865 for the motivation.
+  static var observableRegion: QueryInterfaceRequest<InvestmentValueRow> {
+    let columns: [any SQLSelectable] = Columns.allCases
+      .filter { $0 != .encodedSystemFields }
+      .map { $0 as any SQLSelectable }
+    return select(columns)
+  }
+}

--- a/Backends/GRDB/Records/TransactionLegRow+ObservableRegion.swift
+++ b/Backends/GRDB/Records/TransactionLegRow+ObservableRegion.swift
@@ -1,0 +1,17 @@
+// Backends/GRDB/Records/TransactionLegRow+ObservableRegion.swift
+
+import Foundation
+import GRDB
+
+extension TransactionLegRow {
+  /// Column-restricted region UI `ValueObservation`s pass to
+  /// `tracking(regions:fetch:)`. See
+  /// `AccountRow+ObservableRegion.swift` for the shared pattern and
+  /// issue #865 for the motivation.
+  static var observableRegion: QueryInterfaceRequest<TransactionLegRow> {
+    let columns: [any SQLSelectable] = Columns.allCases
+      .filter { $0 != .encodedSystemFields }
+      .map { $0 as any SQLSelectable }
+    return select(columns)
+  }
+}

--- a/Backends/GRDB/Records/TransactionRow+ObservableRegion.swift
+++ b/Backends/GRDB/Records/TransactionRow+ObservableRegion.swift
@@ -1,0 +1,17 @@
+// Backends/GRDB/Records/TransactionRow+ObservableRegion.swift
+
+import Foundation
+import GRDB
+
+extension TransactionRow {
+  /// Column-restricted region UI `ValueObservation`s pass to
+  /// `tracking(regions:fetch:)`. See
+  /// `AccountRow+ObservableRegion.swift` for the shared pattern and
+  /// issue #865 for the motivation.
+  static var observableRegion: QueryInterfaceRequest<TransactionRow> {
+    let columns: [any SQLSelectable] = Columns.allCases
+      .filter { $0 != .encodedSystemFields }
+      .map { $0 as any SQLSelectable }
+    return select(columns)
+  }
+}

--- a/Backends/GRDB/Repositories/GRDBAccountRepository+Observation.swift
+++ b/Backends/GRDB/Repositories/GRDBAccountRepository+Observation.swift
@@ -30,34 +30,40 @@ extension GRDBAccountRepository {
   /// domain value (e.g. a no-op write on an unrelated row).
   func observeAll() -> AsyncStream<[Account]> {
     ValueObservation
-      // Region inference is empty-table-safe here: `AccountRow.fetchAll`,
-      // `InstrumentRow.fetchAll`, and the `transaction_leg`/`transaction`
-      // joins in `computePositions` all access columns via the row
-      // decoders, so GRDB registers each table's region during the first
-      // fetch even on a fresh-install profile with zero rows. Tick
-      // streams that emit `Void` over `SELECT 1 FROM … LIMIT 1` (e.g.
-      // `observeRates` in Stage 4) need the explicit-region form because
-      // those reads never touch a column. See `DATABASE_CODE_GUIDE.md`
-      // §2 convention 1 for the empty-table caveat.
+      // Explicit-region form: every joined table's `observableRegion`
+      // excludes the sync-bookkeeping `encoded_system_fields` blob, so
+      // CKSyncEngine's per-batch system-fields write does not re-fire
+      // this observation. See issue #865 and
+      // `Records/AccountRow+ObservableRegion.swift`. The regions are
+      // pre-declared, so they are also empty-table-safe on a
+      // fresh-install profile — no row-decoder workaround needed.
       //
       // Projection parity with `fetchAll()`: instruments + ordered rows +
-      // computed positions, mapped to `Account` via `row.toDomain`.
-      // The retry helper re-runs this closure on each restart attempt,
-      // so the projection always reads the freshest DB state.
-      .tracking { database in
-        let instruments = try Self.fetchInstrumentMap(database: database)
-        let rows =
-          try AccountRow
-          .order(AccountRow.Columns.position.asc)
-          .fetchAll(database)
-        let positionsByAccount = try Self.computePositions(
-          database: database, instruments: instruments)
-        return try rows.map { row in
-          try row.toDomain(
-            instruments: instruments,
-            positions: positionsByAccount[row.id] ?? [])
+      // computed positions, mapped to `Account` via `row.toDomain`. The
+      // retry helper re-runs this closure on each restart attempt, so
+      // the projection always reads the freshest DB state.
+      .tracking(
+        regions: [
+          AccountRow.observableRegion,
+          InstrumentRow.observableRegion,
+          TransactionRow.observableRegion,
+          TransactionLegRow.observableRegion,
+        ],
+        fetch: { database in
+          let instruments = try Self.fetchInstrumentMap(database: database)
+          let rows =
+            try AccountRow
+            .order(AccountRow.Columns.position.asc)
+            .fetchAll(database)
+          let positionsByAccount = try Self.computePositions(
+            database: database, instruments: instruments)
+          return try rows.map { row in
+            try row.toDomain(
+              instruments: instruments,
+              positions: positionsByAccount[row.id] ?? [])
+          }
         }
-      }
+      )
       .toRetryingAsyncStream(
         in: database,
         errorChannel: errorChannel,

--- a/Backends/GRDB/Repositories/GRDBCSVImportProfileRepository+Observation.swift
+++ b/Backends/GRDB/Repositories/GRDBCSVImportProfileRepository+Observation.swift
@@ -32,18 +32,22 @@ extension GRDBCSVImportProfileRepository {
   /// no-op write on an unrelated row).
   func observeAll() -> AsyncStream<[CSVImportProfile]> {
     ValueObservation
-      // Region inference is empty-table-safe here:
-      // `CSVImportProfileRow.fetchAll` accesses columns via the row
-      // decoder, so GRDB registers the `csv_import_profile` table's
-      // region during the first fetch even on a fresh-install profile
-      // with zero rows. See `GRDBAccountRepository+Observation.swift`
-      // for the identical caveat applied to accounts.
-      .tracking { database in
-        try CSVImportProfileRow
-          .order(CSVImportProfileRow.Columns.createdAt.asc)
-          .fetchAll(database)
-          .map { $0.toDomain() }
-      }
+      // Explicit-region form via `CSVImportProfileRow.observableRegion`
+      // so the sync-bookkeeping `encoded_system_fields` writes that
+      // land after every successful CKSyncEngine send do not re-fire
+      // this observation. See issue #865 and
+      // `Records/AccountRow+ObservableRegion.swift`. The region is
+      // pre-declared, so it is also empty-table-safe on a fresh-install
+      // profile.
+      .tracking(
+        regions: [CSVImportProfileRow.observableRegion],
+        fetch: { database in
+          try CSVImportProfileRow
+            .order(CSVImportProfileRow.Columns.createdAt.asc)
+            .fetchAll(database)
+            .map { $0.toDomain() }
+        }
+      )
       .toRetryingAsyncStream(
         in: database,
         errorChannel: errorChannel,

--- a/Backends/GRDB/Repositories/GRDBCategoryRepository+Observation.swift
+++ b/Backends/GRDB/Repositories/GRDBCategoryRepository+Observation.swift
@@ -31,18 +31,23 @@ extension GRDBCategoryRepository {
   /// the same domain value (e.g. a no-op write on an unrelated row).
   func observeAll() -> AsyncStream<[Moolah.Category]> {
     ValueObservation
-      // Region inference is empty-table-safe here: `CategoryRow.fetchAll`
-      // accesses columns via the row decoder, so GRDB registers the
-      // `category` table's region during the first fetch even on a
-      // fresh-install profile with zero rows. See
-      // `GRDBAccountRepository+Observation.swift` for the identical
-      // caveat applied to accounts.
-      .tracking { database in
-        try CategoryRow
-          .order(CategoryRow.Columns.name.asc)
-          .fetchAll(database)
-          .map { $0.toDomain() }
-      }
+      // Explicit-region form via `CategoryRow.observableRegion` so the
+      // sync-bookkeeping `encoded_system_fields` writes that land after
+      // every successful CKSyncEngine send do not re-fire this
+      // observation. See issue #865 and
+      // `Records/AccountRow+ObservableRegion.swift`. The region is
+      // pre-declared, so it is also empty-table-safe on a fresh-install
+      // profile — no need for the row-decoder workaround the inferred
+      // form depended on.
+      .tracking(
+        regions: [CategoryRow.observableRegion],
+        fetch: { database in
+          try CategoryRow
+            .order(CategoryRow.Columns.name.asc)
+            .fetchAll(database)
+            .map { $0.toDomain() }
+        }
+      )
       .toRetryingAsyncStream(
         in: database,
         errorChannel: errorChannel,

--- a/Backends/GRDB/Repositories/GRDBEarmarkRepository+Observation.swift
+++ b/Backends/GRDB/Repositories/GRDBEarmarkRepository+Observation.swift
@@ -36,33 +36,41 @@ extension GRDBEarmarkRepository {
     let defaultInstrument = self.defaultInstrument
     return
       ValueObservation
-      // Region inference is empty-table-safe here: `EarmarkRow.fetchAll`,
-      // `InstrumentRow.fetchAll`, and the `transaction_leg` /
-      // `transaction` joins inside `computeEarmarkPositions` all access
-      // columns via the row decoders, so GRDB registers each table's
-      // region during the first fetch even on a fresh-install profile
-      // with zero rows. See `GRDBAccountRepository+Observation.swift`
-      // for the identical caveat applied to accounts.
+      // Explicit-region form: every joined table's `observableRegion`
+      // excludes the sync-bookkeeping `encoded_system_fields` blob, so
+      // CKSyncEngine's per-batch system-fields write does not re-fire
+      // this observation. See issue #865 and
+      // `Records/AccountRow+ObservableRegion.swift`. The regions are
+      // pre-declared, so they are also empty-table-safe on a
+      // fresh-install profile.
       //
       // Projection parity with `fetchAll()`: instruments + ordered rows +
       // computed positions, mapped to `Earmark` via `row.toDomain`.
-      .tracking { database in
-        let instruments = try Self.fetchInstrumentMap(database: database)
-        let positionsByEarmark = try Self.computeEarmarkPositions(
-          database: database, instruments: instruments)
-        let rows =
-          try EarmarkRow
-          .order(EarmarkRow.Columns.position.asc)
-          .fetchAll(database)
-        return rows.map { row in
-          let lists = positionsByEarmark[row.id] ?? EarmarkPositionLists.empty
-          return row.toDomain(
-            defaultInstrument: defaultInstrument,
-            positions: lists.positions,
-            savedPositions: lists.savedPositions,
-            spentPositions: lists.spentPositions)
+      .tracking(
+        regions: [
+          EarmarkRow.observableRegion,
+          InstrumentRow.observableRegion,
+          TransactionRow.observableRegion,
+          TransactionLegRow.observableRegion,
+        ],
+        fetch: { database in
+          let instruments = try Self.fetchInstrumentMap(database: database)
+          let positionsByEarmark = try Self.computeEarmarkPositions(
+            database: database, instruments: instruments)
+          let rows =
+            try EarmarkRow
+            .order(EarmarkRow.Columns.position.asc)
+            .fetchAll(database)
+          return rows.map { row in
+            let lists = positionsByEarmark[row.id] ?? EarmarkPositionLists.empty
+            return row.toDomain(
+              defaultInstrument: defaultInstrument,
+              positions: lists.positions,
+              savedPositions: lists.savedPositions,
+              spentPositions: lists.spentPositions)
+          }
         }
-      }
+      )
       .toRetryingAsyncStream(
         in: database,
         errorChannel: errorChannel,
@@ -79,28 +87,38 @@ extension GRDBEarmarkRepository {
     let defaultInstrument = self.defaultInstrument
     return
       ValueObservation
-      .tracking { database in
-        // Resolve the earmark's instrument first so budget items inherit
-        // the same instrument label — mirrors `fetchBudget(earmarkId:)`.
-        let earmarkInstrument: Instrument
-        if let earmarkRow =
-          try EarmarkRow
-          .filter(EarmarkRow.Columns.id == earmarkId)
-          .fetchOne(database)
-        {
-          earmarkInstrument =
-            earmarkRow.instrumentId.map { Instrument.fiat(code: $0) }
-            ?? defaultInstrument
-        } else {
-          earmarkInstrument = defaultInstrument
-        }
+      // Explicit-region form so the sync-bookkeeping
+      // `encoded_system_fields` writes on `earmark` and
+      // `earmark_budget_item` do not re-fire this observation. See
+      // issue #865.
+      .tracking(
+        regions: [
+          EarmarkRow.observableRegion,
+          EarmarkBudgetItemRow.observableRegion,
+        ],
+        fetch: { [earmarkId, defaultInstrument] database in
+          // Resolve the earmark's instrument first so budget items inherit
+          // the same instrument label — mirrors `fetchBudget(earmarkId:)`.
+          let earmarkInstrument: Instrument
+          if let earmarkRow =
+            try EarmarkRow
+            .filter(EarmarkRow.Columns.id == earmarkId)
+            .fetchOne(database)
+          {
+            earmarkInstrument =
+              earmarkRow.instrumentId.map { Instrument.fiat(code: $0) }
+              ?? defaultInstrument
+          } else {
+            earmarkInstrument = defaultInstrument
+          }
 
-        let rows =
-          try EarmarkBudgetItemRow
-          .filter(EarmarkBudgetItemRow.Columns.earmarkId == earmarkId)
-          .fetchAll(database)
-        return rows.map { $0.toDomain(earmarkInstrument: earmarkInstrument) }
-      }
+          let rows =
+            try EarmarkBudgetItemRow
+            .filter(EarmarkBudgetItemRow.Columns.earmarkId == earmarkId)
+            .fetchAll(database)
+          return rows.map { $0.toDomain(earmarkInstrument: earmarkInstrument) }
+        }
+      )
       .toRetryingAsyncStream(
         in: database,
         errorChannel: errorChannel,

--- a/Backends/GRDB/Repositories/GRDBImportRuleRepository+Observation.swift
+++ b/Backends/GRDB/Repositories/GRDBImportRuleRepository+Observation.swift
@@ -41,18 +41,22 @@ extension GRDBImportRuleRepository {
   /// imperative path would.
   func observeAll() -> AsyncStream<[ImportRule]> {
     ValueObservation
-      // Region inference is empty-table-safe here: `ImportRuleRow.fetchAll`
-      // accesses columns via the row decoder, so GRDB registers the
-      // `import_rule` table's region during the first fetch even on a
-      // fresh-install profile with zero rows. See
-      // `GRDBAccountRepository+Observation.swift` for the identical
-      // caveat applied to accounts.
-      .tracking { database in
-        try ImportRuleRow
-          .order(ImportRuleRow.Columns.position.asc)
-          .fetchAll(database)
-          .map { try $0.toDomain() }
-      }
+      // Explicit-region form via `ImportRuleRow.observableRegion` so the
+      // sync-bookkeeping `encoded_system_fields` writes that land after
+      // every successful CKSyncEngine send do not re-fire this
+      // observation. See issue #865 and
+      // `Records/AccountRow+ObservableRegion.swift`. The region is
+      // pre-declared, so it is also empty-table-safe on a fresh-install
+      // profile.
+      .tracking(
+        regions: [ImportRuleRow.observableRegion],
+        fetch: { database in
+          try ImportRuleRow
+            .order(ImportRuleRow.Columns.position.asc)
+            .fetchAll(database)
+            .map { try $0.toDomain() }
+        }
+      )
       .toRetryingAsyncStream(
         in: database,
         errorChannel: errorChannel,

--- a/Backends/GRDB/Repositories/GRDBInvestmentRepository+Observation.swift
+++ b/Backends/GRDB/Repositories/GRDBInvestmentRepository+Observation.swift
@@ -38,23 +38,23 @@ extension GRDBInvestmentRepository {
     accountId: UUID, page: Int, pageSize: Int
   ) -> AsyncStream<InvestmentValuePage> {
     ValueObservation
-      // Region inference is empty-table-safe here: `InvestmentValueRow`'s
-      // row decoder accesses every column it returns, so GRDB registers
-      // the `investment_value` table region during the first fetch even
-      // on a fresh-install profile with zero rows. See
-      // `GRDBAccountRepository+Observation.swift` for the identical
-      // caveat.
-      .tracking { [accountId, page, pageSize] database in
-        let rows =
-          try InvestmentValueRow
-          .filter(InvestmentValueRow.Columns.accountId == accountId)
-          .order(InvestmentValueRow.Columns.date.desc)
-          .limit(pageSize + 1, offset: page * pageSize)
-          .fetchAll(database)
-        let hasMore = rows.count > pageSize
-        let values = rows.prefix(pageSize).map { $0.toDomain() }
-        return InvestmentValuePage(values: Array(values), hasMore: hasMore)
-      }
+      // Explicit-region form via `InvestmentValueRow.observableRegion`
+      // so the sync-bookkeeping `encoded_system_fields` writes do not
+      // re-fire this observation. See issue #865.
+      .tracking(
+        regions: [InvestmentValueRow.observableRegion],
+        fetch: { [accountId, page, pageSize] database in
+          let rows =
+            try InvestmentValueRow
+            .filter(InvestmentValueRow.Columns.accountId == accountId)
+            .order(InvestmentValueRow.Columns.date.desc)
+            .limit(pageSize + 1, offset: page * pageSize)
+            .fetchAll(database)
+          let hasMore = rows.count > pageSize
+          let values = rows.prefix(pageSize).map { $0.toDomain() }
+          return InvestmentValuePage(values: Array(values), hasMore: hasMore)
+        }
+      )
       .toRetryingAsyncStream(
         in: database,
         errorChannel: errorChannel,
@@ -72,12 +72,23 @@ extension GRDBInvestmentRepository {
     let defaultInstrument = self.defaultInstrument
     return
       ValueObservation
-      .tracking { [accountId] database in
-        try DailyBalanceCompute.compute(
-          database: database,
-          accountId: accountId,
-          defaultInstrument: defaultInstrument)
-      }
+      // Explicit-region form so the sync-bookkeeping
+      // `encoded_system_fields` writes on the tables `DailyBalanceCompute`
+      // reads (transaction, transaction_leg, instrument) do not re-fire
+      // this observation. See issue #865.
+      .tracking(
+        regions: [
+          InstrumentRow.observableRegion,
+          TransactionRow.observableRegion,
+          TransactionLegRow.observableRegion,
+        ],
+        fetch: { [accountId, defaultInstrument] database in
+          try DailyBalanceCompute.compute(
+            database: database,
+            accountId: accountId,
+            defaultInstrument: defaultInstrument)
+        }
+      )
       .toRetryingAsyncStream(
         in: database,
         errorChannel: errorChannel,
@@ -95,8 +106,14 @@ extension GRDBInvestmentRepository {
   /// Mirrors the rate-tick stream's region-pre-declaration idiom — see
   /// `RateCacheTickStream.swift` for the rationale.
   func observeAllValues() -> AsyncStream<Void> {
+    // Region-pre-declared form via `InvestmentValueRow.observableRegion`
+    // — narrower than `Table("investment_value")` because it excludes
+    // the sync-bookkeeping `encoded_system_fields` column. `Void`-valued
+    // streams can't use `removeDuplicates`, so the region trim is the
+    // only defence against system-fields writes producing spurious
+    // ticks. See issue #865.
     let observation = ValueObservation.tracking(
-      regions: [Table("investment_value")],
+      regions: [InvestmentValueRow.observableRegion],
       fetch: { _ in () }
     )
     let database = self.database

--- a/Backends/GRDB/Repositories/GRDBProfileIndexRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBProfileIndexRepository.swift
@@ -308,18 +308,34 @@ final class GRDBProfileIndexRepository {
   func deleteAllProfileIndexDataSync() throws {
     try database.write { database in
       _ = try ProfileRow.deleteAll(database)
+      // Typed `deleteAll` per record type avoids the `sql:` interpolation
+      // the loop form needed. `sqlite_master` is still consulted so a
+      // pre-v3 fixture without these tables passes through without
+      // throwing `SQLITE_ERROR: no such table`.
       let existingTables = try Set(
         String.fetchAll(
           database,
           sql: "SELECT name FROM sqlite_master WHERE type='table'"))
-      let candidates = [
-        "instrument",
-        "exchange_rate", "exchange_rate_meta",
-        "stock_price", "stock_ticker_meta",
-        "crypto_price", "crypto_token_meta",
-      ]
-      for table in candidates where existingTables.contains(table) {
-        try database.execute(sql: "DELETE FROM \(table)")
+      if existingTables.contains(InstrumentRow.databaseTableName) {
+        _ = try InstrumentRow.deleteAll(database)
+      }
+      if existingTables.contains(ExchangeRateRecord.databaseTableName) {
+        _ = try ExchangeRateRecord.deleteAll(database)
+      }
+      if existingTables.contains(ExchangeRateMetaRecord.databaseTableName) {
+        _ = try ExchangeRateMetaRecord.deleteAll(database)
+      }
+      if existingTables.contains(StockPriceRecord.databaseTableName) {
+        _ = try StockPriceRecord.deleteAll(database)
+      }
+      if existingTables.contains(StockTickerMetaRecord.databaseTableName) {
+        _ = try StockTickerMetaRecord.deleteAll(database)
+      }
+      if existingTables.contains(CryptoPriceRecord.databaseTableName) {
+        _ = try CryptoPriceRecord.deleteAll(database)
+      }
+      if existingTables.contains(CryptoTokenMetaRecord.databaseTableName) {
+        _ = try CryptoTokenMetaRecord.deleteAll(database)
       }
     }
   }

--- a/Backends/GRDB/Repositories/GRDBTransactionRepository+Observation.swift
+++ b/Backends/GRDB/Repositories/GRDBTransactionRepository+Observation.swift
@@ -66,27 +66,31 @@ extension GRDBTransactionRepository {
     let defaultInstrument = self.defaultInstrument
     return
       ValueObservation
-      // Region inference is empty-table-safe here: every fetch in the
-      // pipeline (`InstrumentRow.fetchAll`, `TransactionRow.fetchAll`,
-      // `TransactionLegRow.fetchAll`, the `account` lookup for the
-      // target instrument) accesses columns via the row decoders, so
-      // GRDB registers each table's region during the first fetch even
-      // on a fresh-install profile with zero rows. See
-      // `GRDBAccountRepository+Observation.swift` for the identical
-      // caveat.
-      .tracking { [filter, page, pageSize] database in
-        let snapshot = try Self.buildFetchSnapshot(
-          database: database,
-          filter: filter,
-          page: page,
-          pageSize: pageSize,
-          defaultInstrument: defaultInstrument)
-        return TransactionPage(
-          transactions: snapshot.pageTransactions,
-          targetInstrument: snapshot.resolvedTarget,
-          priorBalance: nil,
-          totalCount: snapshot.totalCount)
-      }
+      // Explicit-region form: every joined table's `observableRegion`
+      // excludes the sync-bookkeeping `encoded_system_fields` blob, so
+      // CKSyncEngine's per-batch system-fields write does not re-fire
+      // this observation. See issue #865.
+      .tracking(
+        regions: [
+          TransactionRow.observableRegion,
+          TransactionLegRow.observableRegion,
+          InstrumentRow.observableRegion,
+          AccountRow.observableRegion,
+        ],
+        fetch: { [filter, page, pageSize] database in
+          let snapshot = try Self.buildFetchSnapshot(
+            database: database,
+            filter: filter,
+            page: page,
+            pageSize: pageSize,
+            defaultInstrument: defaultInstrument)
+          return TransactionPage(
+            transactions: snapshot.pageTransactions,
+            targetInstrument: snapshot.resolvedTarget,
+            priorBalance: nil,
+            totalCount: snapshot.totalCount)
+        }
+      )
       .toRetryingAsyncStream(
         in: database,
         errorChannel: errorChannel,
@@ -101,20 +105,31 @@ extension GRDBTransactionRepository {
   /// cancelling the prior subscription.
   func observeAll(filter: TransactionFilter) -> AsyncStream<[Transaction]> {
     ValueObservation
-      .tracking { [filter] database in
-        let instruments = try Self.fetchInstrumentMap(database: database)
-        let candidateRows = try Self.candidateTransactionRows(
-          database: database, filter: filter)
-        let filteredRows = try Self.applyLegFilters(
-          rows: candidateRows, filter: filter, database: database)
-        let legsByTxnId = try Self.fetchLegs(
-          database: database,
-          transactionIds: filteredRows.map(\.id),
-          instruments: instruments)
-        return try filteredRows.map { row in
-          try row.toDomain(legs: legsByTxnId[row.id] ?? [])
+      // Explicit-region form: every joined table's `observableRegion`
+      // excludes the sync-bookkeeping `encoded_system_fields` blob, so
+      // CKSyncEngine's per-batch system-fields write does not re-fire
+      // this observation. See issue #865.
+      .tracking(
+        regions: [
+          TransactionRow.observableRegion,
+          TransactionLegRow.observableRegion,
+          InstrumentRow.observableRegion,
+        ],
+        fetch: { [filter] database in
+          let instruments = try Self.fetchInstrumentMap(database: database)
+          let candidateRows = try Self.candidateTransactionRows(
+            database: database, filter: filter)
+          let filteredRows = try Self.applyLegFilters(
+            rows: candidateRows, filter: filter, database: database)
+          let legsByTxnId = try Self.fetchLegs(
+            database: database,
+            transactionIds: filteredRows.map(\.id),
+            instruments: instruments)
+          return try filteredRows.map { row in
+            try row.toDomain(legs: legsByTxnId[row.id] ?? [])
+          }
         }
-      }
+      )
       .toRetryingAsyncStream(
         in: database,
         errorChannel: errorChannel,

--- a/MoolahTests/Backends/GRDB/Observation/ObservationRegionTests.swift
+++ b/MoolahTests/Backends/GRDB/Observation/ObservationRegionTests.swift
@@ -1,0 +1,241 @@
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+/// Verifies that every row whose table carries an `encoded_system_fields`
+/// column exposes an `observableRegion` request that excludes that column,
+/// and that `ValueObservation`s tracked over those regions do not re-fire
+/// on sync-bookkeeping writes. See issue #865.
+@Suite("Observation regions exclude encoded_system_fields")
+struct ObservationRegionTests {
+
+  // MARK: - Static region tests
+  //
+  // Each row type that has a CKSyncEngine `encoded_system_fields` column
+  // must expose an `observableRegion` request that ValueObservation can
+  // use as a `DatabaseRegionConvertible`. The region must include every
+  // domain-relevant column but exclude `encoded_system_fields`, so writes
+  // landing only on the system-fields blob do not re-fire the observation
+  // fetch closure.
+
+  @Test("AccountRow.observableRegion excludes encoded_system_fields")
+  func accountRowRegion() throws {
+    try assertProfileRegionExcludesSystemFields(AccountRow.observableRegion)
+  }
+
+  @Test("CategoryRow.observableRegion excludes encoded_system_fields")
+  func categoryRowRegion() throws {
+    try assertProfileRegionExcludesSystemFields(CategoryRow.observableRegion)
+  }
+
+  @Test("EarmarkRow.observableRegion excludes encoded_system_fields")
+  func earmarkRowRegion() throws {
+    try assertProfileRegionExcludesSystemFields(EarmarkRow.observableRegion)
+  }
+
+  @Test("EarmarkBudgetItemRow.observableRegion excludes encoded_system_fields")
+  func earmarkBudgetItemRowRegion() throws {
+    try assertProfileRegionExcludesSystemFields(EarmarkBudgetItemRow.observableRegion)
+  }
+
+  @Test("TransactionRow.observableRegion excludes encoded_system_fields")
+  func transactionRowRegion() throws {
+    try assertProfileRegionExcludesSystemFields(TransactionRow.observableRegion)
+  }
+
+  @Test("TransactionLegRow.observableRegion excludes encoded_system_fields")
+  func transactionLegRowRegion() throws {
+    try assertProfileRegionExcludesSystemFields(TransactionLegRow.observableRegion)
+  }
+
+  @Test("InstrumentRow.observableRegion excludes encoded_system_fields")
+  func instrumentRowRegion() throws {
+    try assertProfileRegionExcludesSystemFields(InstrumentRow.observableRegion)
+  }
+
+  @Test("InvestmentValueRow.observableRegion excludes encoded_system_fields")
+  func investmentValueRowRegion() throws {
+    try assertProfileRegionExcludesSystemFields(InvestmentValueRow.observableRegion)
+  }
+
+  @Test("CSVImportProfileRow.observableRegion excludes encoded_system_fields")
+  func csvImportProfileRowRegion() throws {
+    try assertProfileRegionExcludesSystemFields(CSVImportProfileRow.observableRegion)
+  }
+
+  @Test("ImportRuleRow.observableRegion excludes encoded_system_fields")
+  func importRuleRowRegion() throws {
+    try assertProfileRegionExcludesSystemFields(ImportRuleRow.observableRegion)
+  }
+
+  // MARK: - End-to-end fetch-count assertion
+  //
+  // The repository observations bridge to `AsyncStream` via the retrying
+  // wrapper, so we can't directly count fetches against them. Instead we
+  // build a `ValueObservation` using the same `*.observableRegion`
+  // requests the production observations now pass to
+  // `tracking(regions:fetch:)`, instrument the fetch closure with a
+  // counter, and verify the counter does not advance when only
+  // `encoded_system_fields` is written.
+
+  @Test("fetch closure does not re-fire on encoded_system_fields write")
+  func fetchClosureDoesNotRefireOnSystemFieldsWrite() async throws {
+    let databaseQueue = try ProfileDatabase.openInMemory()
+    let accountId = UUID()
+    try await seedAccount(id: accountId, in: databaseQueue)
+
+    let fetchCount = LockedBox<Int>(0)
+    let observation = makeAccountObservation(fetchCount: fetchCount)
+    let task = drainObservation(observation, in: databaseQueue)
+    defer { task.cancel() }
+
+    // Wait for the initial fetch to land.
+    try await waitForCount(fetchCount, equals: 1, within: .milliseconds(500))
+    let initialCount = fetchCount.get()
+
+    // Sync-bookkeeping write — only touches encoded_system_fields.
+    try await writeSystemFields(of: accountId, in: databaseQueue)
+    // Give the observation 200ms to fire if it would. (It must not.)
+    try await Task.sleep(for: .milliseconds(200))
+    #expect(
+      fetchCount.get() == initialCount,
+      "fetch closure must NOT re-fire on encoded_system_fields write (issue #865)")
+
+    // Sanity: writing a real column must trigger a re-fetch.
+    try await renameAccount(id: accountId, in: databaseQueue)
+    try await waitForCount(fetchCount, equals: initialCount + 1, within: .milliseconds(500))
+  }
+
+  // MARK: - Helpers
+
+  /// Opens a fresh in-memory profile database and asserts the supplied
+  /// request's tracked region does not include `encoded_system_fields`.
+  /// Works for any row whose table lives in `ProfileDatabase` (every
+  /// affected table in #865).
+  private func assertProfileRegionExcludesSystemFields<R: DatabaseRegionConvertible>(
+    _ request: R
+  ) throws {
+    let databaseQueue = try ProfileDatabase.openInMemory()
+    try databaseQueue.read { database in
+      let region = try request.databaseRegion(database)
+      let description = String(describing: region)
+      #expect(
+        !description.contains("encoded_system_fields"),
+        "tracked region must exclude encoded_system_fields, was: \(description)")
+    }
+  }
+
+  /// Inserts a single bank account row into an empty profile database.
+  /// Extracted so `fetchClosureDoesNotRefireOnSystemFieldsWrite` stays
+  /// under SwiftLint's `function_body_length`.
+  private func seedAccount(id accountId: UUID, in databaseQueue: DatabaseQueue) async throws {
+    let recordName = "AccountRecord|\(accountId.uuidString.lowercased())"
+    try await databaseQueue.write { database in
+      try AccountRow(
+        id: accountId,
+        recordName: recordName,
+        name: "A",
+        type: "bank",
+        instrumentId: "USD",
+        position: 0,
+        isHidden: false,
+        encodedSystemFields: nil,
+        valuationMode: "recordedValue",
+        walletAddress: nil,
+        chainId: nil
+      ).insert(database)
+    }
+  }
+
+  /// Builds a `ValueObservation` over `AccountRow.observableRegion` whose
+  /// fetch closure bumps `fetchCount` on every invocation. The test uses
+  /// this counter to detect whether a sync-bookkeeping write re-triggers
+  /// the closure (it must not).
+  private func makeAccountObservation(
+    fetchCount: LockedBox<Int>
+  ) -> ValueObservation<ValueReducers.Fetch<[AccountRow]>> {
+    ValueObservation.tracking(
+      regions: [AccountRow.observableRegion],
+      fetch: { database in
+        fetchCount.set(fetchCount.get() + 1)
+        return try AccountRow.fetchAll(database)
+      }
+    )
+  }
+
+  /// Subscribes to `observation` against `databaseQueue` and discards
+  /// every emission. Cancellation throws inside the `for try await` loop;
+  /// the catch swallows it so the spawned `Task` always completes
+  /// normally when its parent `defer` cancels it.
+  private func drainObservation(
+    _ observation: ValueObservation<ValueReducers.Fetch<[AccountRow]>>,
+    in databaseQueue: DatabaseQueue
+  ) -> Task<Void, Never> {
+    Task<Void, Never> {
+      do {
+        for try await _ in observation.values(in: databaseQueue) {
+          // drain — we only care about fetchCount
+        }
+      } catch {
+        // Cancellation throws; ignore.
+      }
+    }
+  }
+
+  /// Writes a synthetic `encoded_system_fields` blob to the account row,
+  /// mirroring `ProfileDataSyncHandler.updateSystemFieldsForSaved`'s
+  /// per-batch update.
+  private func writeSystemFields(of accountId: UUID, in databaseQueue: DatabaseQueue) async throws {
+    try await databaseQueue.write { database in
+      _ =
+        try AccountRow
+        .filter(AccountRow.Columns.id == accountId)
+        .updateAll(
+          database,
+          [AccountRow.Columns.encodedSystemFields.set(to: Data([1, 2, 3]))])
+    }
+  }
+
+  /// Writes a real (non-bookkeeping) column on the account row so the
+  /// test's sanity assertion can confirm the observation still fires on
+  /// legitimate writes.
+  private func renameAccount(id accountId: UUID, in databaseQueue: DatabaseQueue) async throws {
+    try await databaseQueue.write { database in
+      _ =
+        try AccountRow
+        .filter(AccountRow.Columns.id == accountId)
+        .updateAll(database, [AccountRow.Columns.name.set(to: "Renamed")])
+    }
+  }
+
+  /// Polls `box` until it equals `target` or `timeout` elapses. Used by
+  /// observation tests to wait for the next fetch closure invocation
+  /// without sleeping past it (the fetch arrives via a Task-scheduled
+  /// callback whose timing the test cannot drive directly).
+  private func waitForCount(
+    _ box: LockedBox<Int>,
+    equals target: Int,
+    within timeout: Duration
+  ) async throws {
+    let deadline = ContinuousClock().now.advanced(by: timeout)
+    while box.get() != target {
+      if ContinuousClock().now >= deadline {
+        throw WaitForCountTimedOut(actual: box.get(), expected: target)
+      }
+      try await Task.sleep(for: .milliseconds(10))
+      // CONCURRENCY_GUIDE §8: check cancellation after every suspension
+      // point in polling loops so a cancelled test doesn't busy-spin.
+      if Task.isCancelled { return }
+    }
+  }
+
+  private struct WaitForCountTimedOut: Error, CustomStringConvertible {
+    let actual: Int
+    let expected: Int
+    var description: String {
+      "timed out waiting for fetch count to reach \(expected); was \(actual)"
+    }
+  }
+}

--- a/plans/2026-05-12-observation-region-trim-design.md
+++ b/plans/2026-05-12-observation-region-trim-design.md
@@ -1,0 +1,169 @@
+# Observation Region Trim — Exclude `encoded_system_fields` from Tracked Regions
+
+**Issue:** [#865](https://github.com/ajsutton/moolah-native/issues/865)
+**Companion:** [#864](https://github.com/ajsutton/moolah-native/pull/864) (per-recordType batching of system-fields writes)
+
+## Problem
+
+`ValueObservation.tracking { db in … }` in every GRDB `+Observation.swift` uses
+GRDB's auto-region inference. The inference includes **every column on every
+table fetched** — including `encoded_system_fields`, which is pure
+CKSyncEngine bookkeeping that no UI consumer reads.
+
+After CKSyncEngine reports a successful 400-record send, the
+`ProfileDataSyncHandler` writes the new `encoded_system_fields` blob back
+onto each saved row. Even with the #864 batching follow-up collapsing 400
+per-row writes into ~9 (one per recordType), each commit still fires every
+`ValueObservation` whose tracked region intersects the affected table. A
+sample(1) profile of a ~8000-record upload showed the main thread dominated
+by GRDB observer re-fetches re-firing on every sync-fields write.
+
+## Goal
+
+Switch the affected observation closures to a tracked region that **excludes
+`encoded_system_fields`**, so a sync-fields write commits without re-firing
+any UI observer. Sync uploads become invisible to the UI thread.
+
+## Approach
+
+GRDB's `ValueObservation.tracking(regions:fetch:)` decouples the **tracked
+region** from the **fetched projection**:
+
+- `regions:` — what we observe. Each element is `DatabaseRegionConvertible`.
+  Passing a column-restricted `QueryInterfaceRequest`
+  (`AccountRow.select(AccountRow.observableColumns)`) produces a region
+  scoped to the named columns only.
+- `fetch:` — what we read on each fire. Unchanged: same projection as today.
+
+This is the same shape used by `RateCacheTickStream` (which passes
+`[Table("exchange_rate"), …]`); we just take it further by passing
+column-restricted requests instead of whole tables.
+
+### Per-row `observableRegion`
+
+For each `*Row` type whose table has an `encoded_system_fields` column,
+add a column-restricted request in a sibling `+ObservableRegion.swift`
+file (one extension per Row, to satisfy SwiftLint's `file_name` rule):
+
+```swift
+extension AccountRow {
+  /// Column-restricted region UI `ValueObservation`s pass to
+  /// `tracking(regions:fetch:)`. Excludes `encoded_system_fields` so
+  /// the per-batch sync-bookkeeping write CKSyncEngine performs after
+  /// a successful send does not re-fire UI observers. See issue #865.
+  static var observableRegion: QueryInterfaceRequest<AccountRow> {
+    let columns: [any SQLSelectable] = Columns.allCases
+      .filter { $0 != .encodedSystemFields }
+      .map { $0 as any SQLSelectable }
+    return select(columns)
+  }
+}
+```
+
+`Columns: CaseIterable` already; this is the same boilerplate per Row.
+
+### Observation closures
+
+Each affected `+Observation.swift` swaps:
+
+```swift
+ValueObservation.tracking { db in … }
+```
+
+for:
+
+```swift
+ValueObservation.tracking(
+  regions: [
+    AccountRow.observableRegion,
+    InstrumentRow.observableRegion,
+    // … one entry per table read by the fetch closure
+  ],
+  fetch: { db in
+    // unchanged
+  }
+)
+```
+
+`fetch:` continues to decode full rows; only the **observed** region is
+trimmed.
+
+## Scope — Affected Files
+
+Every `+Observation.swift` whose tracking closure reads at least one table
+with an `encoded_system_fields` column:
+
+| Repository | Tables observed |
+|---|---|
+| `GRDBTransactionRepository+Observation.swift` | `transaction`, `transaction_leg`, `instrument`, `account` |
+| `GRDBAccountRepository+Observation.swift` | `account`, `instrument`, `transaction_leg`, `transaction` |
+| `GRDBEarmarkRepository+Observation.swift` (`observeAll`, `observeBudget`) | `earmark`, `earmark_budget_item`, `instrument`, `transaction_leg`, `transaction` |
+| `GRDBCategoryRepository+Observation.swift` | `category` |
+| `GRDBInvestmentRepository+Observation.swift` (`observeValues`, `observeDailyBalances`) | `investment_value`, `transaction`, `transaction_leg`, `instrument` |
+| `GRDBCSVImportProfileRepository+Observation.swift` | `csv_import_profile` |
+| `GRDBImportRuleRepository+Observation.swift` | `import_rule` |
+
+`GRDBInvestmentRepository.observeAllValues` already uses the explicit-region
+form with `[Table("investment_value")]`; we narrow it to
+`investment_value.select(observableColumns)` for the same reason.
+
+### Out of scope
+
+- `GRDBInstrumentRegistryRepository.observeChanges` — manual subscriber
+  pattern, not `ValueObservation`. Already unaffected.
+- The issue's scope list mentions `GRDBTransactionLegRepository` and
+  `GRDBEarmarkBudgetItemRepository`, but neither has an observation method;
+  the `transaction_leg` and `earmark_budget_item` tables are observed
+  transitively through `GRDBTransactionRepository` and
+  `GRDBEarmarkRepository.observeBudget`. Both are covered.
+
+## Tests
+
+For each affected repo, add two test cases to the existing
+`*RepoObservationContractTests` suite (under `MoolahTests/Domain/`):
+
+1. **`encodedSystemFieldsWriteDoesNotEmit`** — subscribe to `observeAll(…)`,
+   call `setEncodedSystemFieldsSync(id:data:)` on an existing row, expect no
+   re-emission within the standard 200 ms poll window. Uses the same
+   `LockedBox<Bool>` + cancellable poll-task pattern as the existing
+   `noOpUpdateDoesNotReEmit` test (`removeDuplicates()` is in play, but
+   the cleaner positive assertion is "the observation never fires at all"
+   because the tracked region itself excludes the column).
+2. **`nonBookkeepingColumnEmits`** — same setup, mutate a real domain
+   column (e.g. `update(…)` with a changed `name` / `amount`), expect one
+   emission. Confirms the region trim hasn't accidentally muted real
+   writes.
+
+The transaction suite covers both `observe(filter:page:pageSize:)` and
+`observeAll(filter:)` because the column set is identical.
+
+## Risks & Mitigations
+
+- **Forgotten column.** If a new column is added to `AccountRow` etc. and
+  the writer of `observableColumns` doesn't notice, the new column won't
+  be tracked. Mitigation: implement `observableColumns` as `Columns.allCases
+  - { .encodedSystemFields }` rather than an explicit allowlist, so any
+  new case auto-enrols. `CaseIterable` is already present on every
+  affected row's `Columns` enum.
+- **Empty-table caveat.** Doesn't apply: explicit regions are registered
+  unconditionally, whether or not the table has rows. This is in fact
+  cleaner than the current inferred form, which the existing comments
+  acknowledge as "empty-table-safe because the row decoder touches columns".
+- **`WITHOUT ROWID` caveat.** Doesn't apply: none of the listed tables are
+  `WITHOUT ROWID` (only the rate-cache tables and `instrument` in the
+  shared-registry index are; neither carries `encoded_system_fields` in the
+  affected set).
+- **Region union behaviour.** GRDB unions the tracked regions, so passing
+  multiple column-restricted requests for the same table is well-defined
+  — but no repo does that here.
+
+## Acceptance
+
+- After change, writing `encoded_system_fields` on any row in any of the 7
+  tables produces **zero** UI re-emissions across all 7 observation
+  surfaces.
+- Writing any other column produces exactly one re-emission (modulo
+  `removeDuplicates` for no-op writes).
+- Sync upload of N records produces zero UI re-fetches in the consumer
+  stores (`TransactionStore`, `AccountStore`, `EarmarkStore`, etc.).
+- All existing observation contract tests still pass.


### PR DESCRIPTION
## Summary

- Every UI `ValueObservation` in `Backends/GRDB/Repositories/*+Observation.swift` used `tracking { db in … }` (auto-region inference), which registered every column on every fetched table — including `encoded_system_fields`. CKSyncEngine's per-batch system-fields write therefore re-fired every UI observer for nothing. Under heavy sync (an ~8000-record upload) the main thread was dominated by these re-fetches.
- Switches every UI observation to `tracking(regions:fetch:)` with per-row column-restricted requests (`AccountRow.observableRegion` etc.) that exclude `encoded_system_fields`. Fetch closures are unchanged. Combined with PR #866's batching, sync uploads now produce **zero** UI re-fetches.
- Fixes a pre-existing Critical SQL-injection rule violation in `GRDBProfileIndexRepository.deleteAllProfileIndexDataSync` (surfaced by `@database-code-review`): the `DELETE FROM \(table)` loop is replaced with typed `*Row.deleteAll(database)` calls gated on `sqlite_master`.

Fixes #865

## Implementation Notes

- `*Row.observableRegion` lives in per-row `+ObservableRegion.swift` files (10 files; one extension each to satisfy SwiftLint's `file_name` rule). Columns are derived from `Columns.allCases.filter { $0 != .encodedSystemFields }`, so any new column auto-enrols — no duplicate allowlist to maintain.
- Region declarations per observation are checked against the tables each `fetch:` closure actually reads (audited by `@database-code-review`).

## Test Plan

- [x] New `MoolahTests/Backends/GRDB/Observation/ObservationRegionTests.swift` — 10 static region tests (one per affected `*Row`) and an instrumented end-to-end fetch-count test that:
  - asserts the fetch closure does **not** re-fire on an `encoded_system_fields`-only write
  - sanity-asserts the fetch closure **does** re-fire on a real-column write
- [x] All existing `*RepoObservationContractTests` still pass
- [x] `just test-mac` (full suite) — passes
- [x] `just test-ios` (full suite) — passes
- [x] `just format-check` — clean
- [x] `@code-review`, `@database-code-review`, `@concurrency-review` — findings applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)