### PR TITLE
fix(sync): apply remote changes in a single GRDB write (#872)

### DIFF
--- a/Backends/CloudKit/Sync/ProfileDataSyncHandler+ApplyRemoteChanges.swift
+++ b/Backends/CloudKit/Sync/ProfileDataSyncHandler+ApplyRemoteChanges.swift
@@ -4,6 +4,7 @@
 
 @preconcurrency import CloudKit
 import Foundation
+import GRDB
 import OSLog
 import SwiftData
 import os
@@ -37,19 +38,25 @@ extension ProfileDataSyncHandler {
 
     // GRDB-routed batches throw on write failure so CKSyncEngine refetches
     // instead of advancing past a dropped record (silent data loss).
+    //
+    // Saves and deletions run inside a single outer `database.write` so
+    // `databaseDidCommit` (and the UI `ValueObservation` re-fetches it
+    // drives) fires once for the whole fetched-changes batch. Before
+    // issue #872 each per-record-type group opened its own write, and a
+    // single fetched batch that swapped a leg (save L_new + delete L_old)
+    // surfaced an intermediate state in which both legs coexisted —
+    // doubling the displayed amount in the row and the sidebar balance
+    // until the next observation tick landed.
     let upsertStart = ContinuousClock.now
-    if let failure = runBatchSavesPhase(
-      saved: saved, systemFields: systemFields, signpostID: signpostID)
+    if let failure = runBatchApplyPhase(
+      saved: saved,
+      systemFields: systemFields,
+      deleted: deleted,
+      signpostID: signpostID)
     {
       return failure
     }
     let upsertDuration = ContinuousClock.now - upsertStart
-
-    if let failure = runBatchDeletionsPhase(
-      deleted: deleted, signpostID: signpostID)
-    {
-      return failure
-    }
 
     return reportSuccess(
       saved: saved,
@@ -66,52 +73,49 @@ extension ProfileDataSyncHandler {
     let upsertDuration: Duration
   }
 
-  /// Wraps `applyBatchSaves` in its signpost + signpost-on-throw cleanup
-  /// and converts a thrown error into a `.saveFailed(...)` result.
-  /// Returns `nil` on success so the caller falls through to the next
-  /// phase. Extracted from `applyRemoteChanges` to keep that function
-  /// inside the SwiftLint body-length budget.
-  nonisolated private func runBatchSavesPhase(
+  /// Runs `applyBatchSaves` and `applyBatchDeletions` inside a single
+  /// outer `database.write { ... }` (issue #872), wraps each in its
+  /// signpost interval for Instruments traces, and converts a thrown
+  /// error into a `.saveFailed(...)` result so CKSyncEngine refetches
+  /// rather than dropping a record silently. Returns `nil` on success.
+  nonisolated private func runBatchApplyPhase(
     saved: [CKRecord],
     systemFields: [String: Data],
-    signpostID: OSSignpostID
-  ) -> ApplyResult? {
-    os_signpost(
-      .begin, log: Signposts.sync, name: "applyBatchSaves", signpostID: signpostID,
-      "%{public}d records", saved.count)
-    do {
-      try applyBatchSaves(saved, systemFields: systemFields)
-      os_signpost(.end, log: Signposts.sync, name: "applyBatchSaves", signpostID: signpostID)
-      return nil
-    } catch {
-      os_signpost(.end, log: Signposts.sync, name: "applyBatchSaves", signpostID: signpostID)
-      logger.error(
-        """
-        GRDB write failed during applyBatchSaves for profile \
-        \(self.profileId, privacy: .public): \
-        \(error.localizedDescription, privacy: .public)
-        """)
-      return .saveFailed(error.localizedDescription)
-    }
-  }
-
-  /// Companion to `runBatchSavesPhase` for the deletions branch.
-  nonisolated private func runBatchDeletionsPhase(
     deleted: [(CKRecord.ID, String)],
     signpostID: OSSignpostID
   ) -> ApplyResult? {
-    os_signpost(
-      .begin, log: Signposts.sync, name: "applyBatchDeletions", signpostID: signpostID,
-      "%{public}d records", deleted.count)
     do {
-      try applyBatchDeletions(deleted)
-      os_signpost(.end, log: Signposts.sync, name: "applyBatchDeletions", signpostID: signpostID)
+      try grdbRepositories.database.write { database in
+        os_signpost(
+          .begin, log: Signposts.sync, name: "applyBatchSaves", signpostID: signpostID,
+          "%{public}d records", saved.count)
+        do {
+          try applyBatchSaves(saved, systemFields: systemFields, in: database)
+        } catch {
+          os_signpost(
+            .end, log: Signposts.sync, name: "applyBatchSaves", signpostID: signpostID)
+          throw error
+        }
+        os_signpost(.end, log: Signposts.sync, name: "applyBatchSaves", signpostID: signpostID)
+
+        os_signpost(
+          .begin, log: Signposts.sync, name: "applyBatchDeletions", signpostID: signpostID,
+          "%{public}d records", deleted.count)
+        do {
+          try applyBatchDeletions(deleted, in: database)
+        } catch {
+          os_signpost(
+            .end, log: Signposts.sync, name: "applyBatchDeletions", signpostID: signpostID)
+          throw error
+        }
+        os_signpost(
+          .end, log: Signposts.sync, name: "applyBatchDeletions", signpostID: signpostID)
+      }
       return nil
     } catch {
-      os_signpost(.end, log: Signposts.sync, name: "applyBatchDeletions", signpostID: signpostID)
       logger.error(
         """
-        GRDB write failed during applyBatchDeletions for profile \
+        GRDB write failed during applyRemoteChanges for profile \
         \(self.profileId, privacy: .public): \
         \(error.localizedDescription, privacy: .public)
         """)
@@ -150,18 +154,23 @@ extension ProfileDataSyncHandler {
   /// Groups saved records by type and routes each group through the
   /// GRDB dispatch table. Unknown record types are logged and skipped
   /// (`ProfileRecord` is handled by `ProfileIndexSyncHandler`, not this
-  /// type).
+  /// type). `database` is the active write transaction supplied by the
+  /// caller — every per-record-type group runs against it directly so
+  /// the whole batch lands in one commit (issue #872).
   ///
   /// Throws when a GRDB-routed batch fails to write so the caller can
   /// return `.saveFailed(...)` and CKSyncEngine refetches instead of
   /// advancing past the dropped record (silent data loss).
   nonisolated func applyBatchSaves(
-    _ records: [CKRecord], systemFields: [String: Data]
+    _ records: [CKRecord], systemFields: [String: Data], in database: Database
   ) throws {
     let grouped = Dictionary(grouping: records, by: \.recordType)
     for (recordType, ckRecords) in grouped {
       if try applyGRDBBatchSave(
-        recordType: recordType, ckRecords: ckRecords, systemFields: systemFields)
+        recordType: recordType,
+        ckRecords: ckRecords,
+        systemFields: systemFields,
+        in: database)
       {
         continue
       }
@@ -174,13 +183,14 @@ extension ProfileDataSyncHandler {
   }
 
   /// Handles batch deletions. Groups by record type then routes through
-  /// the GRDB dispatch tables.
+  /// the GRDB dispatch tables. `database` is the active write
+  /// transaction supplied by the caller (see `applyBatchSaves`).
   ///
   /// Throws when a GRDB-routed deletion batch fails. See `applyBatchSaves`
   /// for the rationale: propagating the failure ensures CKSyncEngine
   /// refetches rather than dropping the deletion record silently.
   nonisolated func applyBatchDeletions(
-    _ deletions: [(CKRecord.ID, String)]
+    _ deletions: [(CKRecord.ID, String)], in database: Database
   ) throws {
     var uuidGrouped: [String: [UUID]] = [:]
     var stringGrouped: [String: [String]] = [:]
@@ -194,7 +204,7 @@ extension ProfileDataSyncHandler {
     }
 
     for (recordType, ids) in uuidGrouped {
-      if try applyGRDBBatchDeletion(recordType: recordType, ids: ids) {
+      if try applyGRDBBatchDeletion(recordType: recordType, ids: ids, in: database) {
         continue
       }
       if recordType != ProfileRecord.recordType {
@@ -203,6 +213,11 @@ extension ProfileDataSyncHandler {
       }
     }
     for (recordType, names) in stringGrouped {
+      // String-keyed deletions are write-free in the current dispatch
+      // (only `InstrumentRow` is string-keyed, and the per-profile zone
+      // drops the deletion with a warning). No `Database` argument is
+      // needed; if a future record type starts writing here it should
+      // accept the active `database` and stay inside this write.
       if try applyGRDBBatchDeletion(recordType: recordType, names: names) {
         continue
       }

--- a/Backends/CloudKit/Sync/ProfileDataSyncHandler+GRDBDispatch.swift
+++ b/Backends/CloudKit/Sync/ProfileDataSyncHandler+GRDBDispatch.swift
@@ -1,5 +1,6 @@
 @preconcurrency import CloudKit
 import Foundation
+import GRDB
 
 extension ProfileDataSyncHandler {
   // MARK: - GRDB Dispatch (saves)
@@ -9,6 +10,12 @@ extension ProfileDataSyncHandler {
   /// (caller skips the SwiftData path for this group), `false` for any
   /// type not covered by the GRDB layer.
   ///
+  /// `database` is the active write transaction supplied by the outer
+  /// `database.write { ... }` that `applyRemoteChanges` opens for the
+  /// whole fetched-changes batch (issue #872). Each per-record-type
+  /// helper performs its work against this `Database` directly — no
+  /// nested writes — so the entire apply lands in one commit.
+  ///
   /// Throws when the GRDB write fails. The caller (`applyBatchSaves`)
   /// rethrows so `applyRemoteChanges` returns `.saveFailed(...)` and the
   /// CKSyncEngine change-token does not advance past the dropped record —
@@ -16,10 +23,11 @@ extension ProfileDataSyncHandler {
   nonisolated func applyGRDBBatchSave(
     recordType: String,
     ckRecords: [CKRecord],
-    systemFields: [String: Data]
+    systemFields: [String: Data],
+    in database: Database
   ) throws -> Bool {
     guard let handler = saveHandler(for: recordType) else { return false }
-    try handler(self)(ckRecords, systemFields)
+    try handler(self)(ckRecords, systemFields, database)
     return true
   }
 
@@ -32,23 +40,23 @@ extension ProfileDataSyncHandler {
   /// switch breaches the complexity ceiling.
   nonisolated private func saveHandler(
     for recordType: String
-  ) -> ((ProfileDataSyncHandler) -> ([CKRecord], [String: Data]) throws -> Void)? {
+  ) -> ((ProfileDataSyncHandler) -> ([CKRecord], [String: Data], Database) throws -> Void)? {
     referenceSaveHandler(for: recordType) ?? domainSaveHandler(for: recordType)
   }
 
   /// Reference-data side of the `saveHandler` lookup.
   nonisolated private func referenceSaveHandler(
     for recordType: String
-  ) -> ((ProfileDataSyncHandler) -> ([CKRecord], [String: Data]) throws -> Void)? {
+  ) -> ((ProfileDataSyncHandler) -> ([CKRecord], [String: Data], Database) throws -> Void)? {
     switch recordType {
     case CSVImportProfileRow.recordType:
-      return { handler in handler.applyBatchSaveCSVImportProfile(ckRecords:systemFields:) }
+      return { handler in handler.applyBatchSaveCSVImportProfile(ckRecords:systemFields:in:) }
     case ImportRuleRow.recordType:
-      return { handler in handler.applyBatchSaveImportRule(ckRecords:systemFields:) }
+      return { handler in handler.applyBatchSaveImportRule(ckRecords:systemFields:in:) }
     case InstrumentRow.recordType:
-      return { handler in handler.applyBatchSaveInstrument(ckRecords:systemFields:) }
+      return { handler in handler.applyBatchSaveInstrument(ckRecords:systemFields:in:) }
     case CategoryRow.recordType:
-      return { handler in handler.applyBatchSaveCategory(ckRecords:systemFields:) }
+      return { handler in handler.applyBatchSaveCategory(ckRecords:systemFields:in:) }
     default:
       return nil
     }
@@ -57,20 +65,20 @@ extension ProfileDataSyncHandler {
   /// Financial-graph side of the `saveHandler` lookup.
   nonisolated private func domainSaveHandler(
     for recordType: String
-  ) -> ((ProfileDataSyncHandler) -> ([CKRecord], [String: Data]) throws -> Void)? {
+  ) -> ((ProfileDataSyncHandler) -> ([CKRecord], [String: Data], Database) throws -> Void)? {
     switch recordType {
     case AccountRow.recordType:
-      return { handler in handler.applyBatchSaveAccount(ckRecords:systemFields:) }
+      return { handler in handler.applyBatchSaveAccount(ckRecords:systemFields:in:) }
     case EarmarkRow.recordType:
-      return { handler in handler.applyBatchSaveEarmark(ckRecords:systemFields:) }
+      return { handler in handler.applyBatchSaveEarmark(ckRecords:systemFields:in:) }
     case EarmarkBudgetItemRow.recordType:
-      return { handler in handler.applyBatchSaveEarmarkBudgetItem(ckRecords:systemFields:) }
+      return { handler in handler.applyBatchSaveEarmarkBudgetItem(ckRecords:systemFields:in:) }
     case InvestmentValueRow.recordType:
-      return { handler in handler.applyBatchSaveInvestmentValue(ckRecords:systemFields:) }
+      return { handler in handler.applyBatchSaveInvestmentValue(ckRecords:systemFields:in:) }
     case TransactionRow.recordType:
-      return { handler in handler.applyBatchSaveTransaction(ckRecords:systemFields:) }
+      return { handler in handler.applyBatchSaveTransaction(ckRecords:systemFields:in:) }
     case TransactionLegRow.recordType:
-      return { handler in handler.applyBatchSaveTransactionLeg(ckRecords:systemFields:) }
+      return { handler in handler.applyBatchSaveTransactionLeg(ckRecords:systemFields:in:) }
     default:
       return nil
     }
@@ -83,58 +91,107 @@ extension ProfileDataSyncHandler {
   /// handled here, `false` for any type not covered by the GRDB layer.
   /// Throws on GRDB write failure so the caller can surface
   /// `.saveFailed(...)` upstream — see `applyGRDBBatchSave` for the
-  /// data-loss rationale.
+  /// data-loss rationale. `database` is the active write transaction
+  /// from the single outer `database.write` opened by
+  /// `applyRemoteChanges` (issue #872).
   nonisolated func applyGRDBBatchDeletion(
-    recordType: String, ids: [UUID]
+    recordType: String, ids: [UUID], in database: Database
   ) throws -> Bool {
+    guard let deleter = uuidDeleter(for: recordType) else { return false }
+    try deleter(self, ids, database)
+    return true
+  }
+
+  /// Returns the per-record-type UUID deleter as a curried function,
+  /// or `nil` for record types not handled by the GRDB layer. Mirrors
+  /// the `saveHandler` shape so the dispatch table stays under
+  /// SwiftLint's `function_body_length` budget.
+  nonisolated private func uuidDeleter(
+    for recordType: String
+  ) -> ((ProfileDataSyncHandler, [UUID], Database) throws -> Void)? {
+    referenceDeleter(for: recordType) ?? domainDeleter(for: recordType)
+  }
+
+  /// Reference-data side of the `uuidDeleter` lookup.
+  nonisolated private func referenceDeleter(
+    for recordType: String
+  ) -> ((ProfileDataSyncHandler, [UUID], Database) throws -> Void)? {
     switch recordType {
     case CSVImportProfileRow.recordType:
-      try writeRemote(site: "applyGRDBBatchDeletion[CSVImportProfile]") {
-        try grdbRepositories.csvImportProfiles.applyRemoteChangesSync(saved: [], deleted: ids)
+      return { handler, ids, database in
+        try handler.writeRemote(site: "applyGRDBBatchDeletion[CSVImportProfile]") {
+          try handler.grdbRepositories.csvImportProfiles.applyRemoteChangesSync(
+            saved: [], deleted: ids, in: database)
+        }
       }
-      return true
     case ImportRuleRow.recordType:
-      try writeRemote(site: "applyGRDBBatchDeletion[ImportRule]") {
-        try grdbRepositories.importRules.applyRemoteChangesSync(saved: [], deleted: ids)
+      return { handler, ids, database in
+        try handler.writeRemote(site: "applyGRDBBatchDeletion[ImportRule]") {
+          try handler.grdbRepositories.importRules.applyRemoteChangesSync(
+            saved: [], deleted: ids, in: database)
+        }
       }
-      return true
-    case AccountRow.recordType:
-      try writeRemote(site: "applyGRDBBatchDeletion[Account]") {
-        try grdbRepositories.accounts.applyRemoteChangesSync(saved: [], deleted: ids)
-      }
-      return true
     case CategoryRow.recordType:
-      try writeRemote(site: "applyGRDBBatchDeletion[Category]") {
-        try grdbRepositories.categories.applyRemoteChangesSync(saved: [], deleted: ids)
+      return { handler, ids, database in
+        try handler.writeRemote(site: "applyGRDBBatchDeletion[Category]") {
+          try handler.grdbRepositories.categories.applyRemoteChangesSync(
+            saved: [], deleted: ids, in: database)
+        }
       }
-      return true
-    case EarmarkRow.recordType:
-      try writeRemote(site: "applyGRDBBatchDeletion[Earmark]") {
-        try grdbRepositories.earmarks.applyRemoteChangesSync(saved: [], deleted: ids)
-      }
-      return true
-    case EarmarkBudgetItemRow.recordType:
-      try writeRemote(site: "applyGRDBBatchDeletion[EarmarkBudgetItem]") {
-        try grdbRepositories.earmarkBudgetItems.applyRemoteChangesSync(saved: [], deleted: ids)
-      }
-      return true
-    case InvestmentValueRow.recordType:
-      try writeRemote(site: "applyGRDBBatchDeletion[InvestmentValue]") {
-        try grdbRepositories.investmentValues.applyRemoteChangesSync(saved: [], deleted: ids)
-      }
-      return true
-    case TransactionRow.recordType:
-      try writeRemote(site: "applyGRDBBatchDeletion[Transaction]") {
-        try grdbRepositories.transactions.applyRemoteChangesSync(saved: [], deleted: ids)
-      }
-      return true
-    case TransactionLegRow.recordType:
-      try writeRemote(site: "applyGRDBBatchDeletion[TransactionLeg]") {
-        try grdbRepositories.transactionLegs.applyRemoteChangesSync(saved: [], deleted: ids)
-      }
-      return true
     default:
-      return false
+      return nil
+    }
+  }
+
+  /// Financial-graph side of the `uuidDeleter` lookup.
+  nonisolated private func domainDeleter(
+    for recordType: String
+  ) -> ((ProfileDataSyncHandler, [UUID], Database) throws -> Void)? {
+    switch recordType {
+    case AccountRow.recordType:
+      return { handler, ids, database in
+        try handler.writeRemote(site: "applyGRDBBatchDeletion[Account]") {
+          try handler.grdbRepositories.accounts.applyRemoteChangesSync(
+            saved: [], deleted: ids, in: database)
+        }
+      }
+    case EarmarkRow.recordType:
+      return { handler, ids, database in
+        try handler.writeRemote(site: "applyGRDBBatchDeletion[Earmark]") {
+          try handler.grdbRepositories.earmarks.applyRemoteChangesSync(
+            saved: [], deleted: ids, in: database)
+        }
+      }
+    case EarmarkBudgetItemRow.recordType:
+      return { handler, ids, database in
+        try handler.writeRemote(site: "applyGRDBBatchDeletion[EarmarkBudgetItem]") {
+          try handler.grdbRepositories.earmarkBudgetItems.applyRemoteChangesSync(
+            saved: [], deleted: ids, in: database)
+        }
+      }
+    case InvestmentValueRow.recordType:
+      return { handler, ids, database in
+        try handler.writeRemote(site: "applyGRDBBatchDeletion[InvestmentValue]") {
+          try handler.grdbRepositories.investmentValues.applyRemoteChangesSync(
+            saved: [], deleted: ids, in: database)
+        }
+      }
+    case TransactionRow.recordType:
+      return { handler, ids, database in
+        try handler.writeRemote(site: "applyGRDBBatchDeletion[Transaction]") {
+          try handler.grdbRepositories.transactions.applyRemoteChangesSync(
+            saved: [], deleted: ids, in: database)
+        }
+      }
+    case TransactionLegRow.recordType:
+      return { handler, ids, database in
+        try handler.writeRemote(site: "applyGRDBBatchDeletion[TransactionLeg]") {
+          try handler.grdbRepositories.transactionLegs.applyRemoteChangesSync(
+            saved: [], deleted: ids, in: database)
+        }
+      }
+    default:
+      return nil
     }
   }
 

--- a/Backends/CloudKit/Sync/ProfileDataSyncHandler+GRDBSaveHelpers.swift
+++ b/Backends/CloudKit/Sync/ProfileDataSyncHandler+GRDBSaveHelpers.swift
@@ -1,5 +1,6 @@
 @preconcurrency import CloudKit
 import Foundation
+import GRDB
 
 extension ProfileDataSyncHandler {
   // MARK: - Per-Record-Type Save Helpers
@@ -16,7 +17,7 @@ extension ProfileDataSyncHandler {
   }
 
   nonisolated func applyBatchSaveCSVImportProfile(
-    ckRecords: [CKRecord], systemFields: [String: Data]
+    ckRecords: [CKRecord], systemFields: [String: Data], in database: Database
   ) throws {
     let context = GRDBBatchSaveContext(
       ckRecords: ckRecords,
@@ -28,12 +29,13 @@ extension ProfileDataSyncHandler {
       idKey: { $0.id.uuidString },
       stamp: stampSystemFields)
     try writeRemote(site: context.site) {
-      try grdbRepositories.csvImportProfiles.applyRemoteChangesSync(saved: rows, deleted: [])
+      try grdbRepositories.csvImportProfiles.applyRemoteChangesSync(
+        saved: rows, deleted: [], in: database)
     }
   }
 
   nonisolated func applyBatchSaveImportRule(
-    ckRecords: [CKRecord], systemFields: [String: Data]
+    ckRecords: [CKRecord], systemFields: [String: Data], in database: Database
   ) throws {
     let context = GRDBBatchSaveContext(
       ckRecords: ckRecords,
@@ -45,7 +47,8 @@ extension ProfileDataSyncHandler {
       idKey: { $0.id.uuidString },
       stamp: stampSystemFields)
     try writeRemote(site: context.site) {
-      try grdbRepositories.importRules.applyRemoteChangesSync(saved: rows, deleted: [])
+      try grdbRepositories.importRules.applyRemoteChangesSync(
+        saved: rows, deleted: [], in: database)
     }
   }
 
@@ -59,7 +62,7 @@ extension ProfileDataSyncHandler {
   /// §"Per-profile handler decommissioning" requires we silently log
   /// and skip — never apply.
   nonisolated func applyBatchSaveInstrument(
-    ckRecords: [CKRecord], systemFields: [String: Data]
+    ckRecords: [CKRecord], systemFields: [String: Data], in database: Database
   ) throws {
     guard !ckRecords.isEmpty else { return }
     logger.warning(
@@ -73,7 +76,7 @@ extension ProfileDataSyncHandler {
   }
 
   nonisolated func applyBatchSaveAccount(
-    ckRecords: [CKRecord], systemFields: [String: Data]
+    ckRecords: [CKRecord], systemFields: [String: Data], in database: Database
   ) throws {
     let context = GRDBBatchSaveContext(
       ckRecords: ckRecords,
@@ -85,12 +88,13 @@ extension ProfileDataSyncHandler {
       idKey: { $0.id.uuidString },
       stamp: stampSystemFields)
     try writeRemote(site: context.site) {
-      try grdbRepositories.accounts.applyRemoteChangesSync(saved: rows, deleted: [])
+      try grdbRepositories.accounts.applyRemoteChangesSync(
+        saved: rows, deleted: [], in: database)
     }
   }
 
   nonisolated func applyBatchSaveCategory(
-    ckRecords: [CKRecord], systemFields: [String: Data]
+    ckRecords: [CKRecord], systemFields: [String: Data], in database: Database
   ) throws {
     let context = GRDBBatchSaveContext(
       ckRecords: ckRecords,
@@ -102,12 +106,13 @@ extension ProfileDataSyncHandler {
       idKey: { $0.id.uuidString },
       stamp: stampSystemFields)
     try writeRemote(site: context.site) {
-      try grdbRepositories.categories.applyRemoteChangesSync(saved: rows, deleted: [])
+      try grdbRepositories.categories.applyRemoteChangesSync(
+        saved: rows, deleted: [], in: database)
     }
   }
 
   nonisolated func applyBatchSaveEarmark(
-    ckRecords: [CKRecord], systemFields: [String: Data]
+    ckRecords: [CKRecord], systemFields: [String: Data], in database: Database
   ) throws {
     let context = GRDBBatchSaveContext(
       ckRecords: ckRecords,
@@ -119,12 +124,13 @@ extension ProfileDataSyncHandler {
       idKey: { $0.id.uuidString },
       stamp: stampSystemFields)
     try writeRemote(site: context.site) {
-      try grdbRepositories.earmarks.applyRemoteChangesSync(saved: rows, deleted: [])
+      try grdbRepositories.earmarks.applyRemoteChangesSync(
+        saved: rows, deleted: [], in: database)
     }
   }
 
   nonisolated func applyBatchSaveEarmarkBudgetItem(
-    ckRecords: [CKRecord], systemFields: [String: Data]
+    ckRecords: [CKRecord], systemFields: [String: Data], in database: Database
   ) throws {
     let context = GRDBBatchSaveContext(
       ckRecords: ckRecords,
@@ -136,12 +142,13 @@ extension ProfileDataSyncHandler {
       idKey: { $0.id.uuidString },
       stamp: stampSystemFields)
     try writeRemote(site: context.site) {
-      try grdbRepositories.earmarkBudgetItems.applyRemoteChangesSync(saved: rows, deleted: [])
+      try grdbRepositories.earmarkBudgetItems.applyRemoteChangesSync(
+        saved: rows, deleted: [], in: database)
     }
   }
 
   nonisolated func applyBatchSaveInvestmentValue(
-    ckRecords: [CKRecord], systemFields: [String: Data]
+    ckRecords: [CKRecord], systemFields: [String: Data], in database: Database
   ) throws {
     let context = GRDBBatchSaveContext(
       ckRecords: ckRecords,
@@ -153,12 +160,13 @@ extension ProfileDataSyncHandler {
       idKey: { $0.id.uuidString },
       stamp: stampSystemFields)
     try writeRemote(site: context.site) {
-      try grdbRepositories.investmentValues.applyRemoteChangesSync(saved: rows, deleted: [])
+      try grdbRepositories.investmentValues.applyRemoteChangesSync(
+        saved: rows, deleted: [], in: database)
     }
   }
 
   nonisolated func applyBatchSaveTransaction(
-    ckRecords: [CKRecord], systemFields: [String: Data]
+    ckRecords: [CKRecord], systemFields: [String: Data], in database: Database
   ) throws {
     let context = GRDBBatchSaveContext(
       ckRecords: ckRecords,
@@ -170,12 +178,13 @@ extension ProfileDataSyncHandler {
       idKey: { $0.id.uuidString },
       stamp: stampSystemFields)
     try writeRemote(site: context.site) {
-      try grdbRepositories.transactions.applyRemoteChangesSync(saved: rows, deleted: [])
+      try grdbRepositories.transactions.applyRemoteChangesSync(
+        saved: rows, deleted: [], in: database)
     }
   }
 
   nonisolated func applyBatchSaveTransactionLeg(
-    ckRecords: [CKRecord], systemFields: [String: Data]
+    ckRecords: [CKRecord], systemFields: [String: Data], in database: Database
   ) throws {
     let context = GRDBBatchSaveContext(
       ckRecords: ckRecords,
@@ -187,7 +196,8 @@ extension ProfileDataSyncHandler {
       idKey: { $0.id.uuidString },
       stamp: stampSystemFields)
     try writeRemote(site: context.site) {
-      try grdbRepositories.transactionLegs.applyRemoteChangesSync(saved: rows, deleted: [])
+      try grdbRepositories.transactionLegs.applyRemoteChangesSync(
+        saved: rows, deleted: [], in: database)
     }
   }
 

--- a/Backends/CloudKit/Sync/ProfileGRDBRepositories.swift
+++ b/Backends/CloudKit/Sync/ProfileGRDBRepositories.swift
@@ -30,6 +30,14 @@ struct ProfileGRDBRepositories: Sendable {
   let investmentValues: GRDBInvestmentRepository
   let transactions: GRDBTransactionRepository
   let transactionLegs: GRDBTransactionLegRepository
+  /// Shared writer used by `ProfileDataSyncHandler.applyRemoteChanges` to
+  /// open one outer `database.write { ... }` for the whole fetched-changes
+  /// batch — saves + deletions across every per-record-type repo land in a
+  /// single commit, so `databaseDidCommit` (and the UI `ValueObservation`
+  /// re-fetches it drives) fires once. Every repository in this bundle
+  /// must already be backed by this same writer; the apply path relies on
+  /// that invariant to avoid nested or cross-queue writes. Issue #872.
+  let database: any GRDB.DatabaseWriter
 }
 
 extension ProfileGRDBRepositories {
@@ -60,7 +68,8 @@ extension ProfileGRDBRepositories {
         database: database,
         defaultInstrument: placeholderInstrument,
         conversionService: ApplyPathConversionService()),
-      transactionLegs: GRDBTransactionLegRepository(database: database))
+      transactionLegs: GRDBTransactionLegRepository(database: database),
+      database: database)
   }
 }
 

--- a/Backends/GRDB/Repositories/GRDBAccountRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBAccountRepository.swift
@@ -231,27 +231,35 @@ final class GRDBAccountRepository: AccountRepository, @unchecked Sendable {
 
   func applyRemoteChangesSync(saved rows: [AccountRow], deleted ids: [UUID]) throws {
     try database.write { database in
-      for row in rows {
-        try row.upsert(database)
-      }
-      for id in ids {
-        // Replicates the v3-era ON DELETE CASCADE on
-        // `investment_value.account_id` and ON DELETE SET NULL on
-        // `transaction_leg.account_id` after `v5_drop_foreign_keys`
-        // removed the FKs. Same write transaction so the cascade is
-        // atomic with the parent delete.
-        _ =
-          try InvestmentValueRow
-          .filter(InvestmentValueRow.Columns.accountId == id)
-          .deleteAll(database)
-        _ =
-          try TransactionLegRow
-          .filter(TransactionLegRow.Columns.accountId == id)
-          .updateAll(
-            database,
-            [TransactionLegRow.Columns.accountId.set(to: nil)])
-        _ = try AccountRow.deleteOne(database, id: id)
-      }
+      try applyRemoteChangesSync(saved: rows, deleted: ids, in: database)
+    }
+  }
+
+  /// In-transaction variant — see `GRDBCSVImportProfileRepository.applyRemoteChangesSync(...:in:)`
+  /// for the rationale (one commit per `applyRemoteChanges` batch, issue #872).
+  func applyRemoteChangesSync(
+    saved rows: [AccountRow], deleted ids: [UUID], in database: Database
+  ) throws {
+    for row in rows {
+      try row.upsert(database)
+    }
+    for id in ids {
+      // Replicates the v3-era ON DELETE CASCADE on
+      // `investment_value.account_id` and ON DELETE SET NULL on
+      // `transaction_leg.account_id` after `v5_drop_foreign_keys`
+      // removed the FKs. Same write transaction so the cascade is
+      // atomic with the parent delete.
+      _ =
+        try InvestmentValueRow
+        .filter(InvestmentValueRow.Columns.accountId == id)
+        .deleteAll(database)
+      _ =
+        try TransactionLegRow
+        .filter(TransactionLegRow.Columns.accountId == id)
+        .updateAll(
+          database,
+          [TransactionLegRow.Columns.accountId.set(to: nil)])
+      _ = try AccountRow.deleteOne(database, id: id)
     }
   }
 

--- a/Backends/GRDB/Repositories/GRDBCSVImportProfileRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBCSVImportProfileRepository.swift
@@ -126,16 +126,27 @@ final class GRDBCSVImportProfileRepository: CSVImportProfileRepository, @uncheck
 
   func applyRemoteChangesSync(saved rows: [CSVImportProfileRow], deleted ids: [UUID]) throws {
     try database.write { database in
-      for row in rows {
-        // `upsert` matches on the PK conflict (`id`). Because
-        // `recordName(for: id)` is total over `id`, the implied UNIQUE
-        // conflict on `record_name` is satisfied by the same row, so a
-        // single conflict target suffices.
-        try row.upsert(database)
-      }
-      for id in ids {
-        _ = try CSVImportProfileRow.deleteOne(database, id: id)
-      }
+      try applyRemoteChangesSync(saved: rows, deleted: ids, in: database)
+    }
+  }
+
+  /// In-transaction variant used by `ProfileDataSyncHandler.applyRemoteChanges`
+  /// to batch every per-record-type apply into one outer `database.write`
+  /// — so `databaseDidCommit` (and the UI `ValueObservation` re-fetches
+  /// it triggers) fires once per fetched-changes batch rather than once
+  /// per record type. See issue #872 / `ApplyRemoteChangesAtomicityTests`.
+  func applyRemoteChangesSync(
+    saved rows: [CSVImportProfileRow], deleted ids: [UUID], in database: Database
+  ) throws {
+    for row in rows {
+      // `upsert` matches on the PK conflict (`id`). Because
+      // `recordName(for: id)` is total over `id`, the implied UNIQUE
+      // conflict on `record_name` is satisfied by the same row, so a
+      // single conflict target suffices.
+      try row.upsert(database)
+    }
+    for id in ids {
+      _ = try CSVImportProfileRow.deleteOne(database, id: id)
     }
   }
 

--- a/Backends/GRDB/Repositories/GRDBCategoryRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBCategoryRepository.swift
@@ -251,36 +251,44 @@ final class GRDBCategoryRepository: CategoryRepository, @unchecked Sendable {
 
   func applyRemoteChangesSync(saved rows: [CategoryRow], deleted ids: [UUID]) throws {
     try database.write { database in
-      for row in rows {
-        try row.upsert(database)
-      }
-      for id in ids {
-        // Replaces v3 FKs (transaction_leg.category_id ON DELETE SET NULL,
-        // earmark_budget_item.category_id ON DELETE NO ACTION). Sync deletes
-        // are server-authoritative, so we cannot fail on surviving children
-        // the way NO ACTION did; we delete the budget items (matching the
-        // domain delete-without-replacement path in `reassignBudgets`).
-        _ =
-          try TransactionLegRow
-          .filter(TransactionLegRow.Columns.categoryId == id)
-          .updateAll(
-            database,
-            [TransactionLegRow.Columns.categoryId.set(to: nil)])
-        _ =
-          try EarmarkBudgetItemRow
-          .filter(EarmarkBudgetItemRow.Columns.categoryId == id)
-          .deleteAll(database)
-        // category.parent_id was ON DELETE NO ACTION — children are
-        // orphaned (set to NULL) in CategoryRepository.delete via
-        // `orphanChildren`. Sync apply mirrors that for consistency.
-        _ =
-          try CategoryRow
-          .filter(CategoryRow.Columns.parentId == id)
-          .updateAll(
-            database,
-            [CategoryRow.Columns.parentId.set(to: nil)])
-        _ = try CategoryRow.deleteOne(database, id: id)
-      }
+      try applyRemoteChangesSync(saved: rows, deleted: ids, in: database)
+    }
+  }
+
+  /// In-transaction variant — see `GRDBCSVImportProfileRepository.applyRemoteChangesSync(...:in:)`
+  /// for the rationale (one commit per `applyRemoteChanges` batch, issue #872).
+  func applyRemoteChangesSync(
+    saved rows: [CategoryRow], deleted ids: [UUID], in database: Database
+  ) throws {
+    for row in rows {
+      try row.upsert(database)
+    }
+    for id in ids {
+      // Replaces v3 FKs (transaction_leg.category_id ON DELETE SET NULL,
+      // earmark_budget_item.category_id ON DELETE NO ACTION). Sync deletes
+      // are server-authoritative, so we cannot fail on surviving children
+      // the way NO ACTION did; we delete the budget items (matching the
+      // domain delete-without-replacement path in `reassignBudgets`).
+      _ =
+        try TransactionLegRow
+        .filter(TransactionLegRow.Columns.categoryId == id)
+        .updateAll(
+          database,
+          [TransactionLegRow.Columns.categoryId.set(to: nil)])
+      _ =
+        try EarmarkBudgetItemRow
+        .filter(EarmarkBudgetItemRow.Columns.categoryId == id)
+        .deleteAll(database)
+      // category.parent_id was ON DELETE NO ACTION — children are
+      // orphaned (set to NULL) in CategoryRepository.delete via
+      // `orphanChildren`. Sync apply mirrors that for consistency.
+      _ =
+        try CategoryRow
+        .filter(CategoryRow.Columns.parentId == id)
+        .updateAll(
+          database,
+          [CategoryRow.Columns.parentId.set(to: nil)])
+      _ = try CategoryRow.deleteOne(database, id: id)
     }
   }
 

--- a/Backends/GRDB/Repositories/GRDBEarmarkBudgetItemRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBEarmarkBudgetItemRepository.swift
@@ -54,12 +54,20 @@ final class GRDBEarmarkBudgetItemRepository: @unchecked Sendable {
     saved rows: [EarmarkBudgetItemRow], deleted ids: [UUID]
   ) throws {
     try database.write { database in
-      for row in rows {
-        try row.upsert(database)
-      }
-      for id in ids {
-        _ = try EarmarkBudgetItemRow.deleteOne(database, id: id)
-      }
+      try applyRemoteChangesSync(saved: rows, deleted: ids, in: database)
+    }
+  }
+
+  /// In-transaction variant — see `GRDBCSVImportProfileRepository.applyRemoteChangesSync(...:in:)`
+  /// for the rationale (one commit per `applyRemoteChanges` batch, issue #872).
+  func applyRemoteChangesSync(
+    saved rows: [EarmarkBudgetItemRow], deleted ids: [UUID], in database: Database
+  ) throws {
+    for row in rows {
+      try row.upsert(database)
+    }
+    for id in ids {
+      _ = try EarmarkBudgetItemRow.deleteOne(database, id: id)
     }
   }
 

--- a/Backends/GRDB/Repositories/GRDBEarmarkRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBEarmarkRepository.swift
@@ -255,23 +255,31 @@ final class GRDBEarmarkRepository: EarmarkRepository, @unchecked Sendable {
 
   func applyRemoteChangesSync(saved rows: [EarmarkRow], deleted ids: [UUID]) throws {
     try database.write { database in
-      for row in rows { try row.upsert(database) }
-      for id in ids {
-        // Replaces v3's ON DELETE CASCADE on earmark_budget_item.earmark_id
-        // and ON DELETE SET NULL on transaction_leg.earmark_id (both
-        // dropped in v5_drop_foreign_keys).
-        _ =
-          try EarmarkBudgetItemRow
-          .filter(EarmarkBudgetItemRow.Columns.earmarkId == id)
-          .deleteAll(database)
-        _ =
-          try TransactionLegRow
-          .filter(TransactionLegRow.Columns.earmarkId == id)
-          .updateAll(
-            database,
-            [TransactionLegRow.Columns.earmarkId.set(to: nil)])
-        _ = try EarmarkRow.deleteOne(database, id: id)
-      }
+      try applyRemoteChangesSync(saved: rows, deleted: ids, in: database)
+    }
+  }
+
+  /// In-transaction variant — see `GRDBCSVImportProfileRepository.applyRemoteChangesSync(...:in:)`
+  /// for the rationale (one commit per `applyRemoteChanges` batch, issue #872).
+  func applyRemoteChangesSync(
+    saved rows: [EarmarkRow], deleted ids: [UUID], in database: Database
+  ) throws {
+    for row in rows { try row.upsert(database) }
+    for id in ids {
+      // Replaces v3's ON DELETE CASCADE on earmark_budget_item.earmark_id
+      // and ON DELETE SET NULL on transaction_leg.earmark_id (both
+      // dropped in v5_drop_foreign_keys).
+      _ =
+        try EarmarkBudgetItemRow
+        .filter(EarmarkBudgetItemRow.Columns.earmarkId == id)
+        .deleteAll(database)
+      _ =
+        try TransactionLegRow
+        .filter(TransactionLegRow.Columns.earmarkId == id)
+        .updateAll(
+          database,
+          [TransactionLegRow.Columns.earmarkId.set(to: nil)])
+      _ = try EarmarkRow.deleteOne(database, id: id)
     }
   }
 

--- a/Backends/GRDB/Repositories/GRDBImportRuleRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBImportRuleRepository.swift
@@ -141,16 +141,24 @@ final class GRDBImportRuleRepository: ImportRuleRepository, @unchecked Sendable 
 
   func applyRemoteChangesSync(saved rows: [ImportRuleRow], deleted ids: [UUID]) throws {
     try database.write { database in
-      for row in rows {
-        // `upsert` matches on the PK conflict (`id`). Because
-        // `recordName(for: id)` is total over `id`, the implied UNIQUE
-        // conflict on `record_name` is satisfied by the same row, so a
-        // single conflict target suffices.
-        try row.upsert(database)
-      }
-      for id in ids {
-        _ = try ImportRuleRow.deleteOne(database, id: id)
-      }
+      try applyRemoteChangesSync(saved: rows, deleted: ids, in: database)
+    }
+  }
+
+  /// In-transaction variant — see `GRDBCSVImportProfileRepository.applyRemoteChangesSync(...:in:)`
+  /// for the rationale (one commit per `applyRemoteChanges` batch, issue #872).
+  func applyRemoteChangesSync(
+    saved rows: [ImportRuleRow], deleted ids: [UUID], in database: Database
+  ) throws {
+    for row in rows {
+      // `upsert` matches on the PK conflict (`id`). Because
+      // `recordName(for: id)` is total over `id`, the implied UNIQUE
+      // conflict on `record_name` is satisfied by the same row, so a
+      // single conflict target suffices.
+      try row.upsert(database)
+    }
+    for id in ids {
+      _ = try ImportRuleRow.deleteOne(database, id: id)
     }
   }
 

--- a/Backends/GRDB/Repositories/GRDBInvestmentRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBInvestmentRepository.swift
@@ -152,12 +152,20 @@ final class GRDBInvestmentRepository: InvestmentRepository, @unchecked Sendable 
     saved rows: [InvestmentValueRow], deleted ids: [UUID]
   ) throws {
     try database.write { database in
-      for row in rows {
-        try row.upsert(database)
-      }
-      for id in ids {
-        _ = try InvestmentValueRow.deleteOne(database, id: id)
-      }
+      try applyRemoteChangesSync(saved: rows, deleted: ids, in: database)
+    }
+  }
+
+  /// In-transaction variant — see `GRDBCSVImportProfileRepository.applyRemoteChangesSync(...:in:)`
+  /// for the rationale (one commit per `applyRemoteChanges` batch, issue #872).
+  func applyRemoteChangesSync(
+    saved rows: [InvestmentValueRow], deleted ids: [UUID], in database: Database
+  ) throws {
+    for row in rows {
+      try row.upsert(database)
+    }
+    for id in ids {
+      _ = try InvestmentValueRow.deleteOne(database, id: id)
     }
   }
 

--- a/Backends/GRDB/Repositories/GRDBProfileIndexRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBProfileIndexRepository.swift
@@ -305,37 +305,40 @@ final class GRDBProfileIndexRepository {
   /// Tables that don't exist yet (i.e. when this repository is opened
   /// against a DB that hasn't run the v3 migration) are skipped via a
   /// `sqlite_master` lookup so legacy fixtures continue to work.
+  ///
+  /// Per-table deletes use typed `*Row.deleteAll(database)` (not a
+  /// generic `DELETE FROM \(table)` interpolation) so the call satisfies
+  /// `guides/DATABASE_CODE_GUIDE.md` §4 — no `sql:` argument carries a
+  /// `\(...)` interpolation at all. Adding a new cache table is a
+  /// matter of registering its `Row` type below alongside its
+  /// `databaseTableName`.
   func deleteAllProfileIndexDataSync() throws {
     try database.write { database in
       _ = try ProfileRow.deleteAll(database)
-      // Typed `deleteAll` per record type avoids the `sql:` interpolation
-      // the loop form needed. `sqlite_master` is still consulted so a
-      // pre-v3 fixture without these tables passes through without
-      // throwing `SQLITE_ERROR: no such table`.
       let existingTables = try Set(
         String.fetchAll(
           database,
           sql: "SELECT name FROM sqlite_master WHERE type='table'"))
-      if existingTables.contains(InstrumentRow.databaseTableName) {
-        _ = try InstrumentRow.deleteAll(database)
-      }
-      if existingTables.contains(ExchangeRateRecord.databaseTableName) {
-        _ = try ExchangeRateRecord.deleteAll(database)
-      }
-      if existingTables.contains(ExchangeRateMetaRecord.databaseTableName) {
-        _ = try ExchangeRateMetaRecord.deleteAll(database)
-      }
-      if existingTables.contains(StockPriceRecord.databaseTableName) {
-        _ = try StockPriceRecord.deleteAll(database)
-      }
-      if existingTables.contains(StockTickerMetaRecord.databaseTableName) {
-        _ = try StockTickerMetaRecord.deleteAll(database)
-      }
-      if existingTables.contains(CryptoPriceRecord.databaseTableName) {
-        _ = try CryptoPriceRecord.deleteAll(database)
-      }
-      if existingTables.contains(CryptoTokenMetaRecord.databaseTableName) {
-        _ = try CryptoTokenMetaRecord.deleteAll(database)
+      let candidates: [(name: String, deleteAll: (Database) throws -> Void)] = [
+        (InstrumentRow.databaseTableName, { _ = try InstrumentRow.deleteAll($0) }),
+        (ExchangeRateRecord.databaseTableName, { _ = try ExchangeRateRecord.deleteAll($0) }),
+        (
+          ExchangeRateMetaRecord.databaseTableName,
+          { _ = try ExchangeRateMetaRecord.deleteAll($0) }
+        ),
+        (StockPriceRecord.databaseTableName, { _ = try StockPriceRecord.deleteAll($0) }),
+        (
+          StockTickerMetaRecord.databaseTableName,
+          { _ = try StockTickerMetaRecord.deleteAll($0) }
+        ),
+        (CryptoPriceRecord.databaseTableName, { _ = try CryptoPriceRecord.deleteAll($0) }),
+        (
+          CryptoTokenMetaRecord.databaseTableName,
+          { _ = try CryptoTokenMetaRecord.deleteAll($0) }
+        ),
+      ]
+      for entry in candidates where existingTables.contains(entry.name) {
+        try entry.deleteAll(database)
       }
     }
   }

--- a/Backends/GRDB/Repositories/GRDBTransactionLegRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBTransactionLegRepository.swift
@@ -52,12 +52,20 @@ final class GRDBTransactionLegRepository: @unchecked Sendable {
     saved rows: [TransactionLegRow], deleted ids: [UUID]
   ) throws {
     try database.write { database in
-      for row in rows {
-        try row.upsert(database)
-      }
-      for id in ids {
-        _ = try TransactionLegRow.deleteOne(database, id: id)
-      }
+      try applyRemoteChangesSync(saved: rows, deleted: ids, in: database)
+    }
+  }
+
+  /// In-transaction variant — see `GRDBCSVImportProfileRepository.applyRemoteChangesSync(...:in:)`
+  /// for the rationale (one commit per `applyRemoteChanges` batch, issue #872).
+  func applyRemoteChangesSync(
+    saved rows: [TransactionLegRow], deleted ids: [UUID], in database: Database
+  ) throws {
+    for row in rows {
+      try row.upsert(database)
+    }
+    for id in ids {
+      _ = try TransactionLegRow.deleteOne(database, id: id)
     }
   }
 

--- a/Backends/GRDB/Repositories/GRDBTransactionRepository+Sync.swift
+++ b/Backends/GRDB/Repositories/GRDBTransactionRepository+Sync.swift
@@ -14,16 +14,24 @@ import GRDB
 extension GRDBTransactionRepository {
   func applyRemoteChangesSync(saved rows: [TransactionRow], deleted ids: [UUID]) throws {
     try database.write { database in
-      for row in rows {
-        try row.upsert(database)
-      }
-      for id in ids {
-        _ =
-          try TransactionLegRow
-          .filter(TransactionLegRow.Columns.transactionId == id)
-          .deleteAll(database)
-        _ = try TransactionRow.deleteOne(database, id: id)
-      }
+      try applyRemoteChangesSync(saved: rows, deleted: ids, in: database)
+    }
+  }
+
+  /// In-transaction variant — see `GRDBCSVImportProfileRepository.applyRemoteChangesSync(...:in:)`
+  /// for the rationale (one commit per `applyRemoteChanges` batch, issue #872).
+  func applyRemoteChangesSync(
+    saved rows: [TransactionRow], deleted ids: [UUID], in database: Database
+  ) throws {
+    for row in rows {
+      try row.upsert(database)
+    }
+    for id in ids {
+      _ =
+        try TransactionLegRow
+        .filter(TransactionLegRow.Columns.transactionId == id)
+        .deleteAll(database)
+      _ = try TransactionRow.deleteOne(database, id: id)
     }
   }
 

--- a/MoolahBenchmarks/SyncDownloadBenchmarks.swift
+++ b/MoolahBenchmarks/SyncDownloadBenchmarks.swift
@@ -45,7 +45,8 @@ final class SyncDownloadBenchmarks: XCTestCase {
       earmarkBudgetItems: result.backend.grdbEarmarkBudgetItems,
       investmentValues: result.backend.grdbInvestments,
       transactions: result.backend.grdbTransactions,
-      transactionLegs: result.backend.grdbTransactionLegs)
+      transactionLegs: result.backend.grdbTransactionLegs,
+      database: result.database)
     _handler = MainActor.assumeIsolated {
       ProfileDataSyncHandler(
         profileId: profileId, zoneID: zoneID, modelContainer: container,

--- a/MoolahBenchmarks/SyncUploadBenchmarks.swift
+++ b/MoolahBenchmarks/SyncUploadBenchmarks.swift
@@ -46,7 +46,8 @@ final class SyncUploadBenchmarks: XCTestCase {
       earmarkBudgetItems: result.backend.grdbEarmarkBudgetItems,
       investmentValues: result.backend.grdbInvestments,
       transactions: result.backend.grdbTransactions,
-      transactionLegs: result.backend.grdbTransactionLegs)
+      transactionLegs: result.backend.grdbTransactionLegs,
+      database: result.database)
     _handler = MainActor.assumeIsolated {
       ProfileDataSyncHandler(
         profileId: profileId, zoneID: zoneID, modelContainer: container,

--- a/MoolahTests/Backends/GRDB/ApplyRemoteChangesAtomicityTests.swift
+++ b/MoolahTests/Backends/GRDB/ApplyRemoteChangesAtomicityTests.swift
@@ -1,0 +1,227 @@
+// MoolahTests/Backends/GRDB/ApplyRemoteChangesAtomicityTests.swift
+
+import CloudKit
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+/// Verifies that `ProfileDataSyncHandler.applyRemoteChanges` commits its
+/// per-record-type saves and deletions inside a single GRDB transaction,
+/// so `ValueObservation` consumers only see the final consistent state.
+///
+/// Regression test for the "transaction shows two legs briefly" bug:
+/// when an iCloud fetch coalesces a leg-swap (save L_new + delete
+/// L_old) into one `applyRemoteChanges` call, the prior implementation
+/// committed each per-record-type group in its own write transaction
+/// and produced a transient state where both legs were present in the
+/// `transaction_leg` table. UI observers fired on the intermediate
+/// commit, doubled the displayed amount, then settled on the next.
+@Suite("ProfileDataSyncHandler.applyRemoteChanges atomicity")
+@MainActor
+struct ApplyRemoteChangesAtomicityTests {
+
+  nonisolated private static let zoneID = CKRecordZone.ID(
+    zoneName: "TestZone", ownerName: CKCurrentUserDefaultName)
+
+  /// Counts post-commit hook invocations on a GRDB writer. Used to
+  /// pin the number of `databaseDidCommit` events `applyRemoteChanges`
+  /// produces — the same trigger `ValueObservation` listens on.
+  private final class CommitCounter: TransactionObserver, @unchecked Sendable {
+    var commits: Int = 0
+
+    func observes(eventsOfKind: DatabaseEventKind) -> Bool { true }
+    func databaseDidChange(with event: DatabaseEvent) {}
+    func databaseWillCommit() throws {}
+    func databaseDidCommit(_ database: Database) { commits += 1 }
+    func databaseDidRollback(_ database: Database) {}
+  }
+
+  @Test("Mixed save + delete batch fires exactly one commit")
+  func mixedSaveDeleteBatchFiresOneCommit() async throws {
+    let harness = try ProfileDataSyncHandlerTestSupport.makeHandlerAndDatabase()
+    let txnId = UUID()
+    let oldLegId = UUID()
+    let newLegId = UUID()
+    let seedTxn = Self.makeTxn(id: txnId)
+    let newLeg = Self.makeLeg(id: newLegId, transactionId: txnId)
+
+    // Seed the local DB with the transaction header and the leg the
+    // local update has already committed (mirrors the post-edit state).
+    try await harness.database.write { database in
+      try seedTxn.upsert(database)
+      try newLeg.upsert(database)
+    }
+
+    // Attach the counter *after* seeding so the seed write is not
+    // counted. The registration write is dropped by resetting the
+    // counter right after.
+    let counter = CommitCounter()
+    try await harness.database.write { database in
+      database.add(transactionObserver: counter, extent: .observerLifetime)
+    }
+    counter.commits = 0
+
+    // Build the incoming fetch payload that triggered the bug:
+    //   - saved: the parent transaction (echoed unchanged) + the
+    //     ORIGINAL leg that local has already deleted. The fetch is
+    //     replaying server-state that lags one update behind the
+    //     local DB.
+    //   - deleted: the original leg's recordID (the subsequent update
+    //     deletion confirmed in the same fetch).
+    let oldLegOnServer = Self.makeLeg(
+      id: oldLegId, transactionId: txnId, like: newLeg)
+    let savedRecords: [CKRecord] = [
+      seedTxn.toCKRecord(in: Self.zoneID),
+      oldLegOnServer.toCKRecord(in: Self.zoneID),
+    ]
+    let deleted: [(CKRecord.ID, String)] = [Self.legDeletion(id: oldLegId)]
+
+    let result = harness.handler.applyRemoteChanges(saved: savedRecords, deleted: deleted)
+    if case .saveFailed(let message) = result {
+      Issue.record("applyRemoteChanges reported saveFailed: \(message)")
+    }
+
+    #expect(
+      counter.commits == 1,
+      "applyRemoteChanges must commit once; got \(counter.commits) commits")
+
+    // Final state sanity: the deletion phase has run, so only the
+    // local `newLegId` remains.
+    let legCount = try await harness.database.read { database in
+      try TransactionLegRow
+        .filter(TransactionLegRow.Columns.transactionId == txnId)
+        .fetchCount(database)
+    }
+    #expect(legCount == 1, "Final leg count must be 1; got \(legCount)")
+  }
+
+  @Test("Mid-batch failure rolls back every save in the same outer transaction")
+  func midBatchFailureRollsBackEverything() async throws {
+    let harness = try ProfileDataSyncHandlerTestSupport.makeHandlerAndDatabase()
+    let txnId = UUID()
+    let existingLegId = UUID()
+    let failingLegId = UUID()
+    let originalPayee = "Coffee"
+    let mutatedPayee = "PAYEE THAT MUST NOT LAND"
+
+    // Seed: one transaction header + one leg representing the state
+    // before the fetched batch arrives.
+    try await harness.database.write { database in
+      try Self.makeTxn(id: txnId, payee: originalPayee).upsert(database)
+      try Self.makeLeg(id: existingLegId, transactionId: txnId).upsert(database)
+    }
+
+    // Force the second leg in the batch to fail via a `BEFORE INSERT`
+    // trigger keyed on a sentinel quantity. Without the single-outer-
+    // write refactor, the header upsert and the first leg upsert would
+    // have committed before the failure — and the regression we're
+    // pinning is exactly that they DON'T.
+    try await harness.database.write { database in
+      try database.execute(
+        sql: """
+          CREATE TRIGGER fail_apply_remote_changes
+          BEFORE INSERT ON transaction_leg
+          WHEN NEW.quantity = -99999
+          BEGIN
+              SELECT RAISE(ABORT, 'forced failure mid-batch');
+          END;
+          """)
+    }
+
+    let mutatedTxn = Self.makeTxn(id: txnId, payee: mutatedPayee)
+    let goodLeg = Self.makeLeg(id: UUID(), transactionId: txnId, quantity: -500)
+    let failingLeg = Self.makeLeg(
+      id: failingLegId, transactionId: txnId, quantity: -99999)
+    let savedRecords: [CKRecord] = [
+      mutatedTxn.toCKRecord(in: Self.zoneID),
+      goodLeg.toCKRecord(in: Self.zoneID),
+      failingLeg.toCKRecord(in: Self.zoneID),
+    ]
+    let deleted: [(CKRecord.ID, String)] = [Self.legDeletion(id: existingLegId)]
+
+    let result = harness.handler.applyRemoteChanges(saved: savedRecords, deleted: deleted)
+    guard case .saveFailed = result else {
+      Issue.record("Expected .saveFailed; got \(result)")
+      return
+    }
+
+    // Header payee is unchanged — the upsert that would have rewritten
+    // it never committed.
+    let txn = try await harness.database.read { database in
+      try TransactionRow.filter(TransactionRow.Columns.id == txnId).fetchOne(database)
+    }
+    #expect(txn?.payee == originalPayee)
+
+    // The pre-existing leg survives byte-equal AND no partial new legs
+    // landed. The deletion in the batch never committed either.
+    let legs = try await harness.database.read { database in
+      try TransactionLegRow
+        .filter(TransactionLegRow.Columns.transactionId == txnId)
+        .fetchAll(database)
+    }
+    #expect(legs.count == 1, "Pre-existing leg must survive; got \(legs.count) legs")
+    #expect(legs.first?.id == existingLegId)
+  }
+
+  // MARK: - Fixture Helpers
+
+  nonisolated private static func makeTxn(
+    id: UUID, payee: String = "Coffee"
+  ) -> TransactionRow {
+    TransactionRow(
+      id: id,
+      recordName: TransactionRow.recordName(for: id),
+      date: Date(timeIntervalSince1970: 1_700_000_000),
+      payee: payee,
+      notes: nil,
+      recurPeriod: nil,
+      recurEvery: nil,
+      importOriginRawDescription: nil,
+      importOriginBankReference: nil,
+      importOriginRawAmount: nil,
+      importOriginRawBalance: nil,
+      importOriginImportedAt: nil,
+      importOriginImportSessionId: nil,
+      importOriginSourceFilename: nil,
+      importOriginParserIdentifier: nil,
+      encodedSystemFields: nil)
+  }
+
+  /// Builds a leg with default per-test fields. When `like` is supplied
+  /// the account, instrument, quantity, and type are copied so the
+  /// server-orphan leg matches the local leg's "shape" — that's the
+  /// scenario that doubled the displayed amount.
+  nonisolated private static func makeLeg(
+    id: UUID,
+    transactionId: UUID,
+    quantity: Int64? = nil,
+    like template: TransactionLegRow? = nil
+  ) -> TransactionLegRow {
+    TransactionLegRow(
+      id: id,
+      recordName: TransactionLegRow.recordName(for: id),
+      transactionId: transactionId,
+      accountId: template?.accountId ?? UUID(),
+      instrumentId: template?.instrumentId ?? Instrument.defaultTestInstrument.id,
+      quantity: quantity ?? template?.quantity ?? -1000,
+      type: template?.type ?? "expense",
+      categoryId: nil,
+      earmarkId: nil,
+      sortOrder: 0,
+      encodedSystemFields: nil,
+      externalId: nil,
+      counterpartyAddress: nil)
+  }
+
+  nonisolated private static func legDeletion(id: UUID) -> (CKRecord.ID, String) {
+    (
+      CKRecord.ID(
+        recordType: TransactionLegRow.recordType,
+        uuid: id,
+        zoneID: Self.zoneID),
+      TransactionLegRow.recordType
+    )
+  }
+}

--- a/MoolahTests/Shared/FullConversionServiceCachingTests.swift
+++ b/MoolahTests/Shared/FullConversionServiceCachingTests.swift
@@ -73,7 +73,7 @@ struct FullConversionServiceCachingTests {
       #expect(result == dec("100") * dec("1.5385"))
     }
 
-    #expect(await bundle.service.cachedRateCount == 1)
+    #expect(await bundle.service.cachedRateCountForTesting == 1)
   }
 
   /// Different `(from, to)` pairs on the same day are separate entries.
@@ -87,7 +87,7 @@ struct FullConversionServiceCachingTests {
     _ = try await bundle.service.convert(dec("1"), from: usd, to: aud, on: day)
     _ = try await bundle.service.convert(dec("1"), from: usd, to: eur, on: day)
 
-    #expect(await bundle.service.cachedRateCount == 2)
+    #expect(await bundle.service.cachedRateCountForTesting == 2)
   }
 
   /// Same `(from, to)` on distinct calendar days are separate entries.
@@ -105,7 +105,7 @@ struct FullConversionServiceCachingTests {
     _ = try await bundle.service.convert(
       dec("1"), from: usd, to: aud, on: try date("2025-06-16"))
 
-    #expect(await bundle.service.cachedRateCount == 2)
+    #expect(await bundle.service.cachedRateCountForTesting == 2)
   }
 
   /// Different times within the same UTC calendar day collapse to one
@@ -132,7 +132,7 @@ struct FullConversionServiceCachingTests {
     _ = try await bundle.service.convert(dec("1"), from: usd, to: aud, on: morning)
     _ = try await bundle.service.convert(dec("1"), from: usd, to: aud, on: evening)
 
-    #expect(await bundle.service.cachedRateCount == 1)
+    #expect(await bundle.service.cachedRateCountForTesting == 1)
   }
 
   /// Same-instrument identity short-circuit must NOT populate the cache:
@@ -143,7 +143,7 @@ struct FullConversionServiceCachingTests {
     let result = try await bundle.service.convert(
       dec("100"), from: usd, to: usd, on: try date("2025-06-15"))
     #expect(result == dec("100"))
-    #expect(await bundle.service.cachedRateCount == 0)
+    #expect(await bundle.service.cachedRateCountForTesting == 0)
   }
 
   // MARK: - Future-date clamping interacts with the day bucket
@@ -177,7 +177,7 @@ struct FullConversionServiceCachingTests {
     _ = try await bundle.service.convert(dec("1"), from: usd, to: aud, on: future1)
     _ = try await bundle.service.convert(dec("1"), from: usd, to: aud, on: future2)
 
-    #expect(await bundle.service.cachedRateCount == 1)
+    #expect(await bundle.service.cachedRateCountForTesting == 1)
   }
 
   // MARK: - Invalidation
@@ -204,12 +204,12 @@ struct FullConversionServiceCachingTests {
 
     _ = try await bundle.service.convert(dec("1"), from: eth, to: usd, on: day)
     _ = try await bundle.service.convert(dec("1"), from: usd, to: aud, on: day)
-    #expect(await bundle.service.cachedRateCount == 2)
+    #expect(await bundle.service.cachedRateCountForTesting == 2)
 
     await bundle.service.invalidateCache(for: eth)
 
     // The ETH→USD entry is dropped; USD→AUD survives.
-    #expect(await bundle.service.cachedRateCount == 1)
+    #expect(await bundle.service.cachedRateCountForTesting == 1)
   }
 
   // MARK: - Crypto unit-rate caching
@@ -237,6 +237,6 @@ struct FullConversionServiceCachingTests {
       #expect(result == dec("2") * dec("1600") * dec("1.5385"))
     }
 
-    #expect(await bundle.service.cachedRateCount == 1)
+    #expect(await bundle.service.cachedRateCountForTesting == 1)
   }
 }

--- a/MoolahTests/Support/ProfileDataSyncHandlerTestSupport.swift
+++ b/MoolahTests/Support/ProfileDataSyncHandlerTestSupport.swift
@@ -263,6 +263,7 @@ enum ProfileDataSyncHandlerTestSupport {
         database: database,
         defaultInstrument: instrument,
         conversionService: conversionService),
-      transactionLegs: GRDBTransactionLegRepository(database: database))
+      transactionLegs: GRDBTransactionLegRepository(database: database),
+      database: database)
   }
 }

--- a/Shared/FullConversionService.swift
+++ b/Shared/FullConversionService.swift
@@ -60,10 +60,12 @@ actor FullConversionService: InstrumentConversionService {
   }()
 
   /// Number of distinct `(source, target, day)` triples currently
-  /// memoised. Exposed for the caching-invariant tests in
+  /// memoised. Test-only accessor — kept with the `ForTesting` suffix
+  /// per `guides/DATABASE_CODE_GUIDE.md` §7 so the production API
+  /// surface stays clean. Exposed for the caching-invariant tests in
   /// `FullConversionServiceCachingTests` so they can assert that
   /// repeated identical calls collapse to a single cache entry.
-  var cachedRateCount: Int { rateCache.count }
+  var cachedRateCountForTesting: Int { rateCache.count }
 
   /// - Parameter cryptoRegistrations: Closure invoked on each crypto
   ///   conversion to obtain the current set of crypto registrations. Tokens


### PR DESCRIPTION
## Summary

- Wrap `ProfileDataSyncHandler.applyRemoteChanges` in **one** outer `database.write { db in ... }` so every fetched-changes batch (saves + deletions across every record type) commits exactly once. `databaseDidCommit` — and the UI `ValueObservation` re-fetches it drives — fires once per batch instead of N times.
- Pins the new invariant with `ApplyRemoteChangesAtomicityTests` (one-commit guarantee + mid-batch rollback).
- Folds in two pre-existing `database-code-review` findings on the touched files: `cachedRateCount` → `cachedRateCountForTesting` (DATABASE_CODE_GUIDE.md §7), and `deleteAllProfileIndexDataSync` switches from `DELETE FROM \(table)` interpolation to typed `*Record.deleteAll(database)` calls (DATABASE_CODE_GUIDE.md §4).

Fixes #872.

## Why

When editing a transaction (typical repro: new transaction → autofill payee → edit amount/date), the UI transiently rendered the transaction as a custom tx with "2 sub-transactions", with the row amount and the affected account's sidebar balance both doubled. After >1 s it settled to one leg. Root cause: the saves phase upserted the server-orphan leg before the deletions phase removed it, and `ValueObservation` fired between the two commits.

`TransactionDraft+Autofill.applyAutofill` clears `legId` to avoid PK collisions against the source transaction, so each subsequent save mints a fresh leg UUID — that's why autofill is the trigger; it makes the eventual CK echo a leg-swap rather than an idempotent upsert.

## Test plan

- [x] New atomicity test: `mixedSaveDeleteBatchFiresOneCommit` — counts `databaseDidCommit` events via a `TransactionObserver`. Asserts exactly 1 (was 3 before).
- [x] New rollback test: `midBatchFailureRollsBackEverything` — `BEFORE INSERT` trigger aborts the second leg; asserts `.saveFailed` returns and pre-existing rows survive byte-equal (the deletion in the same batch is rolled back too).
- [x] Full macOS suite green (2772/2772).
- [x] Full iOS suite green.
- [x] `just format-check` clean; no SwiftLint baseline change.
- [x] `database-code-review` and `sync-review` agents clean on the final diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)