### PR TITLE
fix(csv-import): type single-leg custom-trade rows as income/expense

### DIFF
--- a/MoolahTests/Shared/CSVImport/CustomTradeCSVParserTests.swift
+++ b/MoolahTests/Shared/CSVImport/CustomTradeCSVParserTests.swift
@@ -29,34 +29,37 @@ struct CustomTradeCSVParserTests {
 
     #expect(results.count == 4)
 
-    // Row 1: Deposit (Buy AUD)
+    // Row 1: Deposit (Buy AUD only) — single buy leg is income.
     if case .transaction(let transaction) = results[0] {
       #expect(transaction.legs.count == 1)
       #expect(transaction.legs[0].instrument == .AUD)
       #expect(transaction.legs[0].quantity == 1)
+      #expect(transaction.legs[0].type == .income)
       #expect(transaction.rawDescription == "Deposit")
     } else {
       Issue.record("Expected transaction for row 1")
     }
 
-    // Row 2: PMA Participation (Sell AUD)
+    // Row 2: PMA Participation (Sell AUD only) — single sell leg is expense.
     if case .transaction(let transaction) = results[1] {
       #expect(transaction.legs.count == 1)
       #expect(transaction.legs[0].instrument == .AUD)
       #expect(transaction.legs[0].quantity == -1)
+      #expect(transaction.legs[0].type == .expense)
       #expect(transaction.rawDescription == "PMA Participation")
     } else {
       Issue.record("Expected transaction for row 2")
     }
 
-    // Row 3: Large Deposit
+    // Row 3: Large Deposit — single buy leg is income.
     if case .transaction(let transaction) = results[2] {
       #expect(transaction.legs[0].quantity == 64999)
+      #expect(transaction.legs[0].type == .income)
     } else {
       Issue.record("Expected transaction for row 3")
     }
 
-    // Row 4: Trade (Sell AUD, Buy IAF, Fee AUD)
+    // Row 4: Trade (Sell AUD, Buy IAF, Fee AUD) — both sides present, so trade.
     if case .transaction(let transaction) = results[3] {
       #expect(transaction.legs.count == 3)
 
@@ -68,6 +71,7 @@ struct CustomTradeCSVParserTests {
 
       #expect(audSell?.quantity == -1387.8)
       #expect(iafBuy?.quantity == 12)
+      #expect(iafBuy?.type == .trade)
       #expect(fee?.quantity == -5.50)
       #expect(transaction.rawAmount == -1387.8)
     } else {

--- a/Shared/CSVImport/CustomTradeCSVParser.swift
+++ b/Shared/CSVImport/CustomTradeCSVParser.swift
@@ -127,13 +127,18 @@ struct CustomTradeCSVParser: CSVParser, Sendable {
   ) -> [ParsedLeg] {
     var legs: [ParsedLeg] = []
 
+    // Single-sided rows (deposits, dividends, withdrawals) aren't trades —
+    // type them as income or expense so downstream icons, category rules,
+    // and reporting treat them correctly.
+    let isTrade = sellAmount != 0 && buyAmount != 0
+
     if sellAmount != 0 {
       legs.append(
         ParsedLeg(
           accountId: nil,
           instrument: instrument(for: sellUnit),
           quantity: -sellAmount,
-          type: .trade,
+          type: isTrade ? .trade : .expense,
           isInstrumentPlaceholder: sellUnit == "AUD"
         ))
     }
@@ -144,7 +149,7 @@ struct CustomTradeCSVParser: CSVParser, Sendable {
           accountId: nil,
           instrument: instrument(for: buyUnit),
           quantity: buyAmount,
-          type: .trade,
+          type: isTrade ? .trade : .income,
           isInstrumentPlaceholder: buyUnit == "AUD"
         ))
     }


### PR DESCRIPTION
## Summary

- `CustomTradeCSVParser` previously typed every leg as `.trade`, so single-sided rows (deposits, dividends, withdrawals, PMA-style participations) imported as one-leg "trades".
- Downstream impact: `TransactionRowView+Icon` picks by leg type (wrong icon), and `ImportStore+Transactions` only attaches rule-assigned categories to `.expense` legs (skipped the row entirely).
- Fix: when only the buy side has a value, type that leg `.income`; when only the sell side has a value, type it `.expense`. Rows with both sides remain `.trade`. The fee leg is unchanged.

## Test plan

- [x] `just test-mac CustomTradeCSVParserTests` — updated `testParseSample` to assert `.type` on the three single-leg rows and the trade row; failing baseline reproduced before the fix, passing afterwards.
- [x] `just test-mac ImportStoreTests CSVTokenizerTests SelfWealthMovementsParserTests SelfWealthCashReportParserTests` — 44 tests, no regressions.
- [x] `just format-check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)