### PR TITLE
Scope UserDefaults & Keychain to CloudKit env

### DIFF
--- a/App/MoolahApp+Setup.swift
+++ b/App/MoolahApp+Setup.swift
@@ -44,7 +44,7 @@ extension MoolahApp {
       if let seed = uiTestingSeed {
         // Each `--ui-testing` launch starts from a fresh in-memory
         // `ProfileContainerManager` with a different seed, but
-        // `UserDefaults.standard` persists across xctest launches in
+        // `UserDefaults.moolahShared` persists across xctest launches in
         // the same runner. Without resetting the per-record-type
         // SwiftData → GRDB migration flags, the second launch's
         // migrator would skip and the seeded SwiftData rows would
@@ -55,10 +55,10 @@ extension MoolahApp {
         // second launch, but its key would persist and short-circuit
         // any newer profile that happens to reuse the same UUID
         // (rare) and — more importantly — leaves stale state visible
-        // to tests that read `UserDefaults.standard`. Production code
+        // to tests that read `UserDefaults.moolahShared`. Production code
         // paths never enter this branch.
         SwiftDataToGRDBMigrator.resetMigrationFlags()
-        ValuationModeMigration.resetGateFlags(in: .standard)
+        ValuationModeMigration.resetGateFlags(in: .moolahShared)
         let manager = try ProfileContainerManager.forTesting()
         let profile = try UITestSeedHydrator.hydrate(seed, into: manager)
         return ContainerSetup(manager: manager, uiTestingProfileId: profile?.id)
@@ -295,11 +295,11 @@ extension MoolahApp {
   /// once per install. Best-effort — failures are silent and the rate
   /// services repopulate from network on demand.
   ///
-  /// `defaults` is injected with a `.standard` default so production callers
+  /// `defaults` is injected with a `.moolahShared` default so production callers
   /// pass nothing while tests can supply an isolated suite — satisfies the
   /// `CODE_GUIDE.md` §17 "no direct singleton access" rule without
   /// inventing a wrapper type for a single call site.
-  static func cleanupLegacyRateCachesOnce(defaults: UserDefaults = .standard) {
+  static func cleanupLegacyRateCachesOnce(defaults: UserDefaults = .moolahShared) {
     let key = "v2.rates.cache.cleared"
     guard !defaults.bool(forKey: key) else { return }
     let logger = Logger(subsystem: "com.moolah.app", category: "LegacyCacheCleanup")
@@ -332,7 +332,7 @@ extension MoolahApp {
   /// empty and the next launch retries.
   static func runProfileIndexMigrationIfNeeded(
     setup: ContainerSetup,
-    defaults: UserDefaults = .standard
+    defaults: UserDefaults = .moolahShared
   ) async {
     do {
       try await SwiftDataToGRDBMigrator().migrateProfileIndexIfNeeded(

--- a/App/MoolahApp.swift
+++ b/App/MoolahApp.swift
@@ -103,7 +103,7 @@ struct MoolahApp: App {
       storeDefaults = UserDefaults(suiteName: suiteName) ?? .standard
       storeDefaults.removePersistentDomain(forName: suiteName)
     } else {
-      storeDefaults = .standard
+      storeDefaults = .moolahShared
     }
     let store = ProfileStore(
       defaults: storeDefaults,

--- a/App/ProfileSession+CryptoSync.swift
+++ b/App/ProfileSession+CryptoSync.swift
@@ -16,7 +16,7 @@ extension ProfileSession {
   /// extension inherits.
   nonisolated static func resolveAlchemyApiKey() -> String? {
     let store = KeychainStore(
-      service: "com.moolah.api-keys", account: "alchemy", synchronizable: true)
+      service: KeychainServices.apiKeys, account: "alchemy", synchronizable: true)
     return try? store.restoreString()
   }
 

--- a/App/ProfileSession+Factories.swift
+++ b/App/ProfileSession+Factories.swift
@@ -30,7 +30,7 @@ extension ProfileSession {
   static func makeMarketDataServices(database: any DatabaseWriter) -> MarketDataServices {
     let yahooClient = YahooFinanceClient()
     let apiKeyStore = KeychainStore(
-      service: "com.moolah.api-keys", account: "coingecko", synchronizable: true
+      service: KeychainServices.apiKeys, account: "coingecko", synchronizable: true
     )
     let coinGeckoApiKey = try? apiKeyStore.restoreString()
     return MarketDataServices(

--- a/App/ProfileSession+ValuationMigration.swift
+++ b/App/ProfileSession+ValuationMigration.swift
@@ -24,7 +24,7 @@ extension ProfileSession {
     let migration = ValuationModeMigration(
       profileId: profile.id,
       accountRepository: backend.accounts,
-      userDefaults: .standard)
+      userDefaults: .moolahShared)
     do {
       try await migration.run()
     } catch {

--- a/App/SharedRegistryUnionRunner.swift
+++ b/App/SharedRegistryUnionRunner.swift
@@ -69,7 +69,7 @@ enum SharedRegistryUnionRunner {
         .appendingPathComponent("data.sqlite")
     },
     fileManager: FileManager = .default,
-    defaults: UserDefaults = .standard
+    defaults: UserDefaults = .moolahShared
   ) async {
     let logger = Logger(
       subsystem: "com.moolah.app", category: "SharedRegistryUnion")

--- a/Backends/CloudKit/Sync/LegacyZoneCleanup.swift
+++ b/Backends/CloudKit/Sync/LegacyZoneCleanup.swift
@@ -21,7 +21,7 @@ enum LegacyZoneCleanup {
   ///   "cleanup done" flag. Tests can pass an isolated suite to avoid
   ///   touching the user's standard defaults.
   @MainActor
-  static func performIfNeeded(defaults: UserDefaults = .standard) {
+  static func performIfNeeded(defaults: UserDefaults = .moolahShared) {
     guard !defaults.bool(forKey: cleanupKey) else { return }
     Task { @MainActor in
       await deleteLegacyZone(defaults: defaults)

--- a/Backends/CloudKit/Sync/SyncCoordinator.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator.swift
@@ -342,7 +342,7 @@ final class SyncCoordinator {
 
   init(
     containerManager: ProfileContainerManager,
-    userDefaults: UserDefaults = .standard,
+    userDefaults: UserDefaults = .moolahShared,
     isCloudKitAvailable: Bool = CloudKitAuthProvider.isCloudKitAvailable,
     sharedInstrumentRegistry: GRDBInstrumentRegistryRepository? = nil,
     sharedMarketData: ProfileSession.MarketDataServices? = nil,

--- a/Backends/CloudKit/Sync/SyncProgress.swift
+++ b/Backends/CloudKit/Sync/SyncProgress.swift
@@ -39,7 +39,7 @@ final class SyncProgress {
 
   private static let lastSettledAtKey = "com.moolah.sync.lastSettledAt"
 
-  init(userDefaults: UserDefaults = .standard) {
+  init(userDefaults: UserDefaults = .moolahShared) {
     self.userDefaults = userDefaults
     if let stored = userDefaults.object(forKey: Self.lastSettledAtKey) as? Date {
       self.lastSettledAt = stored

--- a/Backends/GRDB/Migration/SwiftDataToGRDBMigrator.swift
+++ b/Backends/GRDB/Migration/SwiftDataToGRDBMigrator.swift
@@ -64,7 +64,7 @@ struct SwiftDataToGRDBMigrator {
   /// All `UserDefaults` keys that gate this migrator. Used by
   /// `resetMigrationFlags(in:)` to reset state between UI test launches —
   /// each test launches a fresh in-memory `ProfileContainerManager` with
-  /// new seed data, but `UserDefaults.standard` persists across xctest
+  /// new seed data, but `UserDefaults.moolahShared` persists across xctest
   /// launches in the same runner. Without resetting, the second test's
   /// migrator would skip and the seeded SwiftData rows would never reach
   /// GRDB. Production launches never call this reset.

--- a/Backends/GRDB/Migration/SwiftDataToGRDBMigrator.swift
+++ b/Backends/GRDB/Migration/SwiftDataToGRDBMigrator.swift
@@ -87,7 +87,7 @@ struct SwiftDataToGRDBMigrator {
   /// launches only: each UI test starts from a fresh in-memory profile
   /// container and must observe its own seeded rows in GRDB. No
   /// production code path should invoke this.
-  static func resetMigrationFlags(in defaults: UserDefaults = .standard) {
+  static func resetMigrationFlags(in defaults: UserDefaults = .moolahShared) {
     for key in allMigrationFlags {
       defaults.removeObject(forKey: key)
     }
@@ -99,7 +99,7 @@ struct SwiftDataToGRDBMigrator {
   /// Runs the one-shot migration for every record type. Each is gated
   /// independently; a previously-migrated record type is a no-op.
   ///
-  /// `defaults` is injected with a `.standard` default so production
+  /// `defaults` is injected with a `.moolahShared` default so production
   /// callers pass nothing while tests supply an isolated suite (avoids
   /// the `CODE_GUIDE.md` §17 "no direct singleton access" rule).
   ///
@@ -115,7 +115,7 @@ struct SwiftDataToGRDBMigrator {
   func migrateIfNeeded(
     modelContainer: ModelContainer,
     database: any DatabaseWriter,
-    defaults: UserDefaults = .standard
+    defaults: UserDefaults = .moolahShared
   ) async throws {
     let start = ContinuousClock.now
     defer {

--- a/Features/Analysis/AnalysisStore.swift
+++ b/Features/Analysis/AnalysisStore.swift
@@ -54,7 +54,7 @@ final class AnalysisStore {
 
   init(
     repository: AnalysisRepository,
-    defaults: UserDefaults = .standard,
+    defaults: UserDefaults = .moolahShared,
     monthEnd: Int = Calendar.current.component(.day, from: Date())
   ) {
     self.repository = repository

--- a/Features/Import/FolderScanService.swift
+++ b/Features/Import/FolderScanService.swift
@@ -24,7 +24,7 @@ final class FolderScanService {
     profileId: UUID,
     importStore: ImportStore,
     preferences: ImportPreferences,
-    defaults: UserDefaults = .standard,
+    defaults: UserDefaults = .moolahShared,
     fileManager: FileManager = .default
   ) {
     self.profileId = profileId

--- a/Features/Profiles/ProfileStore.swift
+++ b/Features/Profiles/ProfileStore.swift
@@ -90,7 +90,7 @@ final class ProfileStore {
   }
 
   init(
-    defaults: UserDefaults = .standard,
+    defaults: UserDefaults = .moolahShared,
     containerManager: ProfileContainerManager? = nil,
     syncCoordinator: SyncCoordinator? = nil
   ) {

--- a/Features/Settings/CryptoTokenStore.swift
+++ b/Features/Settings/CryptoTokenStore.swift
@@ -153,9 +153,9 @@ final class CryptoTokenStore {
       cryptoPriceService: cryptoPriceService,
       conversionService: conversionService,
       apiKeyStore: KeychainStore(
-        service: "com.moolah.api-keys", account: "coingecko", synchronizable: true),
+        service: KeychainServices.apiKeys, account: "coingecko", synchronizable: true),
       alchemyKeyStore: KeychainStore(
-        service: "com.moolah.api-keys", account: "alchemy", synchronizable: true),
+        service: KeychainServices.apiKeys, account: "alchemy", synchronizable: true),
       sharedStore: sharedStore)
   }
 

--- a/MoolahTests/Shared/KeychainServicesTests.swift
+++ b/MoolahTests/Shared/KeychainServicesTests.swift
@@ -6,14 +6,14 @@ import Testing
 @Suite("KeychainServices")
 struct KeychainServicesTests {
   @Test("makeApiKeysService(for: .development) returns dotted lowercase env suffix")
-  func testMakeApiKeysServiceForDevelopment() {
+  func testDevelopmentServiceStringFormat() {
     #expect(
       KeychainServices.makeApiKeysService(for: .development)
         == "com.moolah.api-keys.development")
   }
 
   @Test("makeApiKeysService(for: .production) returns dotted lowercase env suffix")
-  func testMakeApiKeysServiceForProduction() {
+  func testProductionServiceStringFormat() {
     #expect(
       KeychainServices.makeApiKeysService(for: .production)
         == "com.moolah.api-keys.production")

--- a/MoolahTests/Shared/KeychainServicesTests.swift
+++ b/MoolahTests/Shared/KeychainServicesTests.swift
@@ -1,0 +1,29 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("KeychainServices")
+struct KeychainServicesTests {
+  @Test("makeApiKeysService(for: .development) returns dotted lowercase env suffix")
+  func testMakeApiKeysServiceForDevelopment() {
+    #expect(
+      KeychainServices.makeApiKeysService(for: .development)
+        == "com.moolah.api-keys.development")
+  }
+
+  @Test("makeApiKeysService(for: .production) returns dotted lowercase env suffix")
+  func testMakeApiKeysServiceForProduction() {
+    #expect(
+      KeychainServices.makeApiKeysService(for: .production)
+        == "com.moolah.api-keys.production")
+  }
+
+  @Test("apiKeys uses the resolved environment")
+  func testApiKeysUsesResolvedEnvironment() {
+    let resolved = CloudKitEnvironment.resolved()
+    #expect(
+      KeychainServices.apiKeys
+        == KeychainServices.makeApiKeysService(for: resolved))
+  }
+}

--- a/MoolahTests/Shared/UserDefaultsMoolahSharedTests.swift
+++ b/MoolahTests/Shared/UserDefaultsMoolahSharedTests.swift
@@ -1,0 +1,47 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("UserDefaults+MoolahShared")
+struct UserDefaultsMoolahSharedTests {
+  @Test("sharedSuite(for: .development) uses dotted lowercase env suffix")
+  func testDevelopmentSuiteName() {
+    let suite = UserDefaults.sharedSuite(for: .development)
+    #expect(suite !== UserDefaults.standard)
+    let key = "moolah.test.\(UUID().uuidString)"
+    suite.set("dev", forKey: key)
+    defer { suite.removeObject(forKey: key) }
+    let mirror = UserDefaults(suiteName: "rocks.moolah.app.development")
+    #expect(mirror?.string(forKey: key) == "dev")
+  }
+
+  @Test("sharedSuite(for: .production) uses dotted lowercase env suffix")
+  func testProductionSuiteName() {
+    let suite = UserDefaults.sharedSuite(for: .production)
+    #expect(suite !== UserDefaults.standard)
+    let key = "moolah.test.\(UUID().uuidString)"
+    suite.set("prod", forKey: key)
+    defer { suite.removeObject(forKey: key) }
+    let mirror = UserDefaults(suiteName: "rocks.moolah.app.production")
+    #expect(mirror?.string(forKey: key) == "prod")
+  }
+
+  @Test("dev and prod suites are isolated from each other")
+  func testDevAndProdAreIsolated() {
+    let dev = UserDefaults.sharedSuite(for: .development)
+    let prod = UserDefaults.sharedSuite(for: .production)
+    let key = "moolah.test.\(UUID().uuidString)"
+    dev.set("dev-value", forKey: key)
+    defer {
+      dev.removeObject(forKey: key)
+      prod.removeObject(forKey: key)
+    }
+    #expect(prod.string(forKey: key) == nil)
+  }
+
+  @Test("moolahShared resolves to a suite, never .standard")
+  func testMoolahSharedIsNotStandard() {
+    #expect(UserDefaults.moolahShared !== UserDefaults.standard)
+  }
+}

--- a/MoolahTests/Shared/UserDefaultsMoolahSharedTests.swift
+++ b/MoolahTests/Shared/UserDefaultsMoolahSharedTests.swift
@@ -5,38 +5,46 @@ import Testing
 
 @Suite("UserDefaults+MoolahShared")
 struct UserDefaultsMoolahSharedTests {
-  @Test("sharedSuite(for: .development) uses dotted lowercase env suffix")
-  func testDevelopmentSuiteName() {
-    let suite = UserDefaults.sharedSuite(for: .development)
-    #expect(suite !== UserDefaults.standard)
+  @Test("makeSharedSuite(for: .development) is not UserDefaults.standard")
+  func testMakeSharedSuiteDevelopmentIsNotStandard() {
+    #expect(UserDefaults.makeSharedSuite(for: .development) !== UserDefaults.standard)
+  }
+
+  @Test("makeSharedSuite(for: .development) uses dotted lowercase env suffix")
+  func testMakeSharedSuiteDevelopmentSuiteName() {
+    let suite = UserDefaults.makeSharedSuite(for: .development)
     let key = "moolah.test.\(UUID().uuidString)"
-    suite.set("dev", forKey: key)
     defer { suite.removeObject(forKey: key) }
+    suite.set("dev", forKey: key)
     let mirror = UserDefaults(suiteName: "rocks.moolah.app.development")
     #expect(mirror?.string(forKey: key) == "dev")
   }
 
-  @Test("sharedSuite(for: .production) uses dotted lowercase env suffix")
-  func testProductionSuiteName() {
-    let suite = UserDefaults.sharedSuite(for: .production)
-    #expect(suite !== UserDefaults.standard)
+  @Test("makeSharedSuite(for: .production) is not UserDefaults.standard")
+  func testMakeSharedSuiteProductionIsNotStandard() {
+    #expect(UserDefaults.makeSharedSuite(for: .production) !== UserDefaults.standard)
+  }
+
+  @Test("makeSharedSuite(for: .production) uses dotted lowercase env suffix")
+  func testMakeSharedSuiteProductionSuiteName() {
+    let suite = UserDefaults.makeSharedSuite(for: .production)
     let key = "moolah.test.\(UUID().uuidString)"
-    suite.set("prod", forKey: key)
     defer { suite.removeObject(forKey: key) }
+    suite.set("prod", forKey: key)
     let mirror = UserDefaults(suiteName: "rocks.moolah.app.production")
     #expect(mirror?.string(forKey: key) == "prod")
   }
 
   @Test("dev and prod suites are isolated from each other")
   func testDevAndProdAreIsolated() {
-    let dev = UserDefaults.sharedSuite(for: .development)
-    let prod = UserDefaults.sharedSuite(for: .production)
+    let dev = UserDefaults.makeSharedSuite(for: .development)
+    let prod = UserDefaults.makeSharedSuite(for: .production)
     let key = "moolah.test.\(UUID().uuidString)"
-    dev.set("dev-value", forKey: key)
     defer {
       dev.removeObject(forKey: key)
       prod.removeObject(forKey: key)
     }
+    dev.set("dev-value", forKey: key)
     #expect(prod.string(forKey: key) == nil)
   }
 

--- a/Shared/KeychainServices.swift
+++ b/Shared/KeychainServices.swift
@@ -9,7 +9,7 @@ enum KeychainServices {
   /// Service string for API-key keychain rows (CoinGecko, Alchemy)
   /// scoped to the resolved CloudKit environment. Production code uses
   /// this in place of the previous `"com.moolah.api-keys"` literal.
-  static var apiKeys: String { makeApiKeysService(for: .resolved()) }
+  static let apiKeys: String = makeApiKeysService(for: .resolved())
 
   /// Factory used by `apiKeys`. Exposed so tests can verify the
   /// service-string format for both environments without process-level

--- a/Shared/KeychainServices.swift
+++ b/Shared/KeychainServices.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+/// Env-scoped keychain service strings. A Development build targets
+/// `com.moolah.api-keys.development`; a Production build targets
+/// `com.moolah.api-keys.production`. Splitting the service string per
+/// CloudKit env stops a Development build from overwriting a Production
+/// build's iCloud-Keychain-synced API key on every device.
+enum KeychainServices {
+  /// Service string for API-key keychain rows (CoinGecko, Alchemy)
+  /// scoped to the resolved CloudKit environment. Production code uses
+  /// this in place of the previous `"com.moolah.api-keys"` literal.
+  static var apiKeys: String { makeApiKeysService(for: .resolved()) }
+
+  /// Factory used by `apiKeys`. Exposed so tests can verify the
+  /// service-string format for both environments without process-level
+  /// Info.plist swapping. Mirrors `CloudKitEnvironment.resolve(from:)`
+  /// and the `makeSharedSuite(for:)` factory on `UserDefaults`.
+  static func makeApiKeysService(for env: CloudKitEnvironment) -> String {
+    "com.moolah.api-keys.\(env.storageSubdirectory.lowercased())"
+  }
+}

--- a/Shared/UserDefaults+MoolahShared.swift
+++ b/Shared/UserDefaults+MoolahShared.swift
@@ -11,13 +11,13 @@ extension UserDefaults {
   /// `Sendable` by Foundation but is documented as thread-safe. The
   /// instance is initialised once at first access and never reassigned,
   /// so concurrent access is sound.
-  nonisolated(unsafe) static let moolahShared: UserDefaults = sharedSuite(for: .resolved())
+  nonisolated(unsafe) static let moolahShared: UserDefaults = makeSharedSuite(for: .resolved())
 
-  /// Builder used by `moolahShared`. Exposed so tests can verify the
+  /// Factory used by `moolahShared`. Exposed so tests can verify the
   /// suite-name format for both environments without process-level
   /// Info.plist swapping. Mirrors the `CloudKitEnvironment.resolve(from:)`
   /// pattern that `CloudKitEnvironmentTests` uses.
-  static func sharedSuite(for env: CloudKitEnvironment) -> UserDefaults {
+  static func makeSharedSuite(for env: CloudKitEnvironment) -> UserDefaults {
     let suiteName = "rocks.moolah.app.\(env.storageSubdirectory.lowercased())"
     // `UserDefaults(suiteName:)` returns `nil` only for reserved suite
     // names (e.g. literal `"Apple Global Domain"`). Neither of our

--- a/Shared/UserDefaults+MoolahShared.swift
+++ b/Shared/UserDefaults+MoolahShared.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+extension UserDefaults {
+  /// Defaults suite scoped to the current CloudKit environment so a
+  /// Development build cannot read or write state owned by a Production
+  /// build (and vice versa). Production code paths inject this in place
+  /// of `.standard`. Tests continue to inject their own
+  /// `UserDefaults(suiteName:)` for isolation.
+  ///
+  /// `nonisolated(unsafe)` because `UserDefaults` itself is not declared
+  /// `Sendable` by Foundation but is documented as thread-safe. The
+  /// instance is initialised once at first access and never reassigned,
+  /// so concurrent access is sound.
+  nonisolated(unsafe) static let moolahShared: UserDefaults = sharedSuite(for: .resolved())
+
+  /// Builder used by `moolahShared`. Exposed so tests can verify the
+  /// suite-name format for both environments without process-level
+  /// Info.plist swapping. Mirrors the `CloudKitEnvironment.resolve(from:)`
+  /// pattern that `CloudKitEnvironmentTests` uses.
+  static func sharedSuite(for env: CloudKitEnvironment) -> UserDefaults {
+    let suiteName = "rocks.moolah.app.\(env.storageSubdirectory.lowercased())"
+    // `UserDefaults(suiteName:)` returns `nil` only for reserved suite
+    // names (e.g. literal `"Apple Global Domain"`). Neither of our
+    // env-suffixed names is reserved, so the fallback is unreachable in
+    // practice but keeps the return type non-optional.
+    return UserDefaults(suiteName: suiteName) ?? .standard
+  }
+}

--- a/Shared/Views/ResizableVSplit.swift
+++ b/Shared/Views/ResizableVSplit.swift
@@ -23,7 +23,7 @@ import SwiftUI
   ///   - minTopHeight: Minimum height of the top pane when dragging.
   ///   - minBottomHeight: Minimum height of the bottom pane.
   ///   - defaults: `UserDefaults` instance probed for an existing
-  ///     autosaved divider position. Defaults to `.standard`; tests can
+  ///     autosaved divider position. Defaults to `.moolahShared`; tests can
   ///     inject an isolated suite to avoid leaking saved frames between
   ///     runs.
   ///   - top: The top pane content.

--- a/Shared/Views/ResizableVSplit.swift
+++ b/Shared/Views/ResizableVSplit.swift
@@ -42,7 +42,7 @@ import SwiftUI
       initialTopHeight: CGFloat,
       minTopHeight: CGFloat = 80,
       minBottomHeight: CGFloat = 200,
-      defaults: UserDefaults = .standard,
+      defaults: UserDefaults = .moolahShared,
       @ViewBuilder top: @escaping () -> Top,
       @ViewBuilder bottom: @escaping () -> Bottom
     ) {

--- a/plans/2026-05-12-env-scoped-prefs-and-keychain-design.md
+++ b/plans/2026-05-12-env-scoped-prefs-and-keychain-design.md
@@ -1,0 +1,195 @@
+# Env-Scoped UserDefaults & Keychain
+
+## Goal
+
+A Development build of Moolah must be physically incapable of mutating any
+state that a Production build reads. Today on-disk SQL / SwiftData state is
+already scoped (under `Application Support/Development/` vs `…/Production/`)
+via `URL.moolahScopedApplicationSupport`, and the CloudKit container is split
+per build config (`iCloud.rocks.moolah.app.test` vs `…app.v2`). Two leak
+vectors remain:
+
+1. **`UserDefaults.standard`** — both builds use bundle id
+   `rocks.moolah.app`, so they share one prefs plist. A Dev build that toggles
+   any flag (sync state, migration gate, AnalysisStore last-used range) clobbers
+   the value the user's Production build will read on next launch.
+2. **`KeychainStore` API-key rows** — service `com.moolah.api-keys` is
+   hard-coded in four places, and both rows (`account: "alchemy"`,
+   `account: "coingecko"`) are `synchronizable: true`. A Dev build that writes
+   a test key overwrites the user's iCloud-Keychain-replicated production key
+   on every device.
+
+This design closes both vectors using the same lever as the file-system split:
+`CloudKitEnvironment.resolved()`.
+
+## Non-Goals
+
+- No migration of existing prefs / keychain content. Production users will
+  see settings reset on the upgrade and must re-enter API keys (see
+  *Consequences* below). This was an explicit user choice during brainstorming
+  to keep the change simple and deterministic.
+- No cleanup of legacy `.standard` plist entries or legacy
+  `com.moolah.api-keys` keychain rows. They are abandoned in place; both
+  builds stop reading and writing them on this version. A future release may
+  add a one-shot cleanup runner once we're confident no one downgrades.
+- Out of scope: `URLCache`, `HTTPCookieStorage` (no persistent cookies wired
+  up despite the doc comment in `KeychainStore.swift`), App Groups (none
+  configured), and anything already covered by
+  `URL.moolahScopedApplicationSupport`.
+
+## Mechanism
+
+### Env-scoped UserDefaults
+
+Add `Shared/UserDefaults+MoolahShared.swift`:
+
+```swift
+extension UserDefaults {
+  /// Defaults suite scoped to the current CloudKit environment so a
+  /// Development build cannot read or write state owned by a Production
+  /// build (and vice versa). Production code paths use this in place of
+  /// `.standard`. Tests continue to inject their own
+  /// `UserDefaults(suiteName:)` for isolation.
+  static let moolahShared: UserDefaults = {
+    let env = CloudKitEnvironment.resolved()
+    let suiteName = "rocks.moolah.app.\(env.storageSubdirectory.lowercased())"
+    return UserDefaults(suiteName: suiteName) ?? .standard
+  }()
+}
+```
+
+Suite names:
+
+- Production: `rocks.moolah.app.production`
+- Development: `rocks.moolah.app.development`
+
+These materialise as separate plists under `~/Library/Preferences/` on macOS,
+so OS-level isolation is enforced.
+
+The fallback to `.standard` exists only to preserve the type as
+non-optional; `UserDefaults(suiteName:)` returns `nil` only for reserved
+suite names (e.g. literal `"Apple Global Domain"`), which neither of our
+strings is. The fallback is unreachable in practice.
+
+### Defaults swap (production callers)
+
+Every call site that currently defaults a `UserDefaults` parameter to
+`.standard` is rerouted to `.moolahShared`. The full list is in *Affected
+Files* below. Test sites that already inject a per-test `UserDefaults` are
+unchanged. The UI-testing branch in `MoolahApp.init` (which builds a per-launch
+`moolah.uitests.<UUID>` suite) is also unchanged.
+
+### Env-scoped Keychain services
+
+Add `Shared/KeychainServices.swift`:
+
+```swift
+enum KeychainServices {
+  /// Service string for API-key keychain rows (CoinGecko, Alchemy).
+  /// Scoped to the current CloudKit environment so a Development build's
+  /// writes never replace a Production build's iCloud-Keychain-synced
+  /// row on any of the user's devices.
+  static var apiKeys: String {
+    let env = CloudKitEnvironment.resolved()
+    return "com.moolah.api-keys.\(env.storageSubdirectory.lowercased())"
+  }
+}
+```
+
+Service strings:
+
+- Production: `com.moolah.api-keys.production`
+- Development: `com.moolah.api-keys.development`
+
+Replace each of the four hard-coded `service: "com.moolah.api-keys"` literals
+(`App/ProfileSession+CryptoSync.swift`, `App/ProfileSession+Factories.swift`,
+two in `Features/Settings/CryptoTokenStore.swift`'s `makeProduction(...)`)
+with `service: KeychainServices.apiKeys`. The `synchronizable: true` flag is
+preserved on the API-key rows — a Production user's API key still
+replicates across their devices, just to a different service-keyed entry.
+
+## Consequences for Existing Production Users
+
+On first launch of the new Production build:
+
+| What was lost | Effect |
+|---|---|
+| `AnalysisStore` last-used `selectedDateRange`, `selectedAccount`, `selectedCurrency` | Dropdowns return to their first-launch defaults (cosmetic). |
+| `SyncProgress` "last received" timestamp + counters | Sidebar footer shows empty progress until the next sync round-trip completes. |
+| `SyncCoordinator` state (`v2.sync.engine.serializedState`, etc.) | `CKSyncEngine` reinitialises from a fresh state token; first launch fetches change tags but no extra payload. |
+| `LegacyZoneCleanup` "deleted" flag | Cleanup runner re-attempts the legacy-zone delete; idempotent. |
+| `SwiftDataToGRDBMigrator` per-record-type flags | Migrator re-runs; SwiftData source store is empty in Production by this point so each step no-ops. |
+| `SharedRegistryUnionRunner` flag | Re-runs against the live profile-index; produces the same union; idempotent. |
+| `ValuationModeMigration` per-profile gate flags | Re-runs the per-profile migration; safe because the migration writes idempotent values. |
+| `v2.rates.cache.cleared` flag | Re-attempts the legacy gzipped JSON rate cache delete; idempotent. |
+| API keys (CoinGecko, Alchemy) | Settings panes show empty fields; user must paste keys once. No background calls fail until the first crypto refresh attempt. |
+
+The implementation plan must include a one-pass audit of each migration-gate
+runner with an explicit "safe to re-run from a clean Production-scoped state"
+note. If any runner is *not* safely idempotent, the audit must fix it before
+the swap lands.
+
+## Tests
+
+- `MoolahTests/Shared/UserDefaultsMoolahSharedTests.swift` — verify the
+  suite name interpolates the resolved env's `storageSubdirectory` exactly
+  (analogous to `URLMoolahStorageTests`).
+- `MoolahTests/Shared/KeychainServicesTests.swift` — verify the
+  `apiKeys` service string format produces
+  `com.moolah.api-keys.development` / `com.moolah.api-keys.production` for
+  the two `CloudKitEnvironment` cases.
+- Per-runner audit: confirm each migration gate is idempotent under a
+  fresh-state UserDefaults. Add a test for any runner that lacks one.
+- Existing tests for `SyncProgress`, `AnalysisStore`,
+  `SwiftDataToGRDBMigrator`, `SharedRegistryUnionRunner`,
+  `LegacyZoneCleanup`, `ValuationModeMigration`,
+  `cleanupLegacyRateCachesOnce`, and `CryptoSettingsAPIKeyTests` already
+  inject their own `UserDefaults` / `KeychainStore` and need no change.
+
+## Affected Files
+
+### New
+
+- `Shared/UserDefaults+MoolahShared.swift`
+- `Shared/KeychainServices.swift`
+- `MoolahTests/Shared/UserDefaultsMoolahSharedTests.swift`
+- `MoolahTests/Shared/KeychainServicesTests.swift`
+
+### Edited (defaults swap: `= .standard` → `= .moolahShared`)
+
+- `App/MoolahApp+Setup.swift` — `cleanupLegacyRateCachesOnce`,
+  `runProfileIndexMigrationIfNeeded`.
+- `App/SharedRegistryUnionRunner.swift` — runner default.
+- `App/ValuationModeMigration.swift` — `userDefaults` field default and
+  `resetGateFlags(in:)` callers in production.
+- `Backends/CloudKit/Sync/SyncCoordinator.swift` — `userDefaults` init
+  default.
+- `Backends/CloudKit/Sync/SyncProgress.swift` — `userDefaults` init
+  default.
+- `Backends/CloudKit/Sync/LegacyZoneCleanup.swift` — `performIfNeeded`
+  default.
+- `Backends/GRDB/Migration/SwiftDataToGRDBMigrator.swift` and the four
+  `SwiftDataToGRDBMigrator+*.swift` extensions — every `defaults:
+  UserDefaults = .standard` parameter.
+- `Features/Analysis/AnalysisStore.swift` — `defaults: UserDefaults =
+  .standard` parameter.
+
+### Edited (keychain service)
+
+- `App/ProfileSession+CryptoSync.swift` — `service: "com.moolah.api-keys"`
+  → `service: KeychainServices.apiKeys`.
+- `App/ProfileSession+Factories.swift` — same.
+- `Features/Settings/CryptoTokenStore.swift` — both hard-coded service
+  literals in `makeProduction(...)` switch to `KeychainServices.apiKeys`.
+
+## Out of Scope (Verified)
+
+- `URL.moolahScopedApplicationSupport` consumers (SQL DBs, sync state,
+  backups) — already env-scoped.
+- CloudKit container — already env-scoped.
+- `URLCache`, `HTTPCookieStorage` — no persistent custom cache or cookie
+  storage wired up.
+- App Groups — none configured.
+- The UI-testing branch in `MoolahApp.init` that builds a
+  `moolah.uitests.<UUID>` suite — already isolated per launch and
+  preserved unchanged.

--- a/plans/2026-05-12-env-scoped-prefs-and-keychain-plan.md
+++ b/plans/2026-05-12-env-scoped-prefs-and-keychain-plan.md
@@ -41,6 +41,9 @@ Defaults swap (`= .standard` → `= .moolahShared`):
 | `Backends/GRDB/Migration/SwiftDataToGRDBMigrator+Transactions.swift` | Same. |
 | `Backends/GRDB/Migration/SwiftDataToGRDBMigrator+ProfileIndex.swift` | Same. |
 | `Features/Analysis/AnalysisStore.swift` | `init(...defaults:)` parameter. |
+| `Features/Import/FolderScanService.swift` | `init(...defaults:)` parameter. |
+| `Features/Profiles/ProfileStore.swift` | `init(...defaults:)` parameter — persists `activeProfileID`. |
+| `Shared/Views/ResizableVSplit.swift` | `init(...defaults:)` parameter (UI split-pane proportion). |
 
 Keychain swap (`service: "com.moolah.api-keys"` → `service: KeychainServices.apiKeys`):
 
@@ -467,6 +470,45 @@ to enumerate exact lines, then edit each one. Some files use `defaults: UserDefa
 +    defaults: UserDefaults = .moolahShared,
      monthEnd: Int = Calendar.current.component(.day, from: Date())
    ) {
+```
+
+`Features/Import/FolderScanService.swift` (around line 27):
+
+```diff
+   init(
+     profileId: UUID,
+     importStore: ImportStore,
+     preferences: ImportPreferences,
+-    defaults: UserDefaults = .standard,
++    defaults: UserDefaults = .moolahShared,
+     fileManager: FileManager = .default
+   ) {
+```
+
+`Features/Profiles/ProfileStore.swift` (around line 92):
+
+```diff
+   init(
+-    defaults: UserDefaults = .standard,
++    defaults: UserDefaults = .moolahShared,
+     containerManager: ProfileContainerManager? = nil,
+     syncCoordinator: SyncCoordinator? = nil
+   ) {
+```
+
+`Shared/Views/ResizableVSplit.swift` (around line 45):
+
+```diff
+     init(
+       autosaveName: String,
+       initialTopHeight: CGFloat,
+       minTopHeight: CGFloat = 80,
+       minBottomHeight: CGFloat = 200,
+-      defaults: UserDefaults = .standard,
++      defaults: UserDefaults = .moolahShared,
+       @ViewBuilder top: @escaping () -> Top,
+       @ViewBuilder bottom: @escaping () -> Bottom
+     ) {
 ```
 
 - [ ] **Step 3: Wire `ValuationModeMigration.userDefaults` from `.moolahShared`**

--- a/plans/2026-05-12-env-scoped-prefs-and-keychain-plan.md
+++ b/plans/2026-05-12-env-scoped-prefs-and-keychain-plan.md
@@ -238,14 +238,14 @@ import Testing
 @Suite("KeychainServices")
 struct KeychainServicesTests {
   @Test("makeApiKeysService(for: .development) returns dotted lowercase env suffix")
-  func testDevelopmentApiKeysService() {
+  func testDevelopmentServiceStringFormat() {
     #expect(
       KeychainServices.makeApiKeysService(for: .development)
         == "com.moolah.api-keys.development")
   }
 
   @Test("makeApiKeysService(for: .production) returns dotted lowercase env suffix")
-  func testProductionApiKeysService() {
+  func testProductionServiceStringFormat() {
     #expect(
       KeychainServices.makeApiKeysService(for: .production)
         == "com.moolah.api-keys.production")
@@ -285,7 +285,7 @@ enum KeychainServices {
   /// Service string for API-key keychain rows (CoinGecko, Alchemy)
   /// scoped to the resolved CloudKit environment. Production code uses
   /// this in place of the previous `"com.moolah.api-keys"` literal.
-  static var apiKeys: String { makeApiKeysService(for: .resolved()) }
+  static let apiKeys: String = makeApiKeysService(for: .resolved())
 
   /// Factory used by `apiKeys`. Exposed so tests can verify the
   /// service-string format for both environments without process-level
@@ -724,4 +724,4 @@ After the PR opens, follow the project's merge-queue convention — add it to th
 
 **Placeholder scan:** No "TBD", "implement later", or unspecified test bodies — every code step has full code or a precise diff.
 
-**Type consistency:** `moolahShared` (let) and `makeSharedSuite(for:)` (func) match across all references; `apiKeys` (var) and `makeApiKeysService(for:)` (func) match across all five references. Factory methods use `make` per `guides/CODE_GUIDE.md` §4.
+**Type consistency:** `moolahShared` (let) and `makeSharedSuite(for:)` (func) match across all references; `apiKeys` (let) and `makeApiKeysService(for:)` (func) match across all five references. Factory methods use `make` per `guides/CODE_GUIDE.md` §4.

--- a/plans/2026-05-12-env-scoped-prefs-and-keychain-plan.md
+++ b/plans/2026-05-12-env-scoped-prefs-and-keychain-plan.md
@@ -356,6 +356,7 @@ No commit — this is a read-only sign-off.
 ## Task 4: Defaults Swap (production callers)
 
 **Files:**
+- Modify: `App/MoolahApp.swift` — production branch of `MoolahApp.init` previously assigned `storeDefaults = .standard` explicitly; flip to `.moolahShared`. (Caught by the sharpened Task 6 grep, not the parameter-default form.)
 - Modify: `App/MoolahApp+Setup.swift`
 - Modify: `App/SharedRegistryUnionRunner.swift`
 - Modify: `Backends/CloudKit/Sync/SyncCoordinator.swift`
@@ -676,10 +677,17 @@ EOF
 - [ ] **Step 1: Confirm no `.standard` defaults survive in production code**
 
 ```bash
-grep -rn "UserDefaults = .standard\|UserDefaults\s*=\s*.standard" --include="*.swift" App Backends Features Shared
+# Catches both parameter-default form (`defaults: UserDefaults = .standard`)
+# and the assignment form (`storeDefaults = .standard`). The original review
+# round of this plan only had the first pattern, which silently missed
+# `App/MoolahApp.swift`'s explicit `storeDefaults = .standard` assignment in
+# the production branch of `MoolahApp.init` — re-introducing that exact bug
+# would slip past Step 1 if we kept the original pattern.
+grep -rn '= \.standard\|= UserDefaults\.standard' --include="*.swift" App Backends Features Shared \
+  | grep -v 'UserDefaults(suiteName: suiteName) ?? .standard'
 ```
 
-Expected: zero hits. Hits inside `MoolahTests/`, `MoolahUITests_macOS/`, `UITestSupport/` are fine. Hits inside `MoolahApp.swift`'s UI-testing branch (which uses `UserDefaults(suiteName: "moolah.uitests.<UUID>")`) are also fine — that branch never reads `.standard` as a fallback for production state.
+Expected: zero hits. The allow-listed pattern (`UserDefaults(suiteName: suiteName) ?? .standard`) is the unreachable fallback inside `MoolahApp.swift`'s UI-testing branch and inside `Shared/UserDefaults+MoolahShared.swift` itself — both are intentional. Hits inside `MoolahTests/`, `MoolahUITests_macOS/`, `UITestSupport/` are fine.
 
 - [ ] **Step 2: Confirm no remaining `com.moolah.api-keys` literal**
 

--- a/plans/2026-05-12-env-scoped-prefs-and-keychain-plan.md
+++ b/plans/2026-05-12-env-scoped-prefs-and-keychain-plan.md
@@ -65,8 +65,9 @@ The clean break means each migration-gate UserDefaults flag resets to absent on 
 | `SharedRegistryUnionRunner.run` | Body-row inserts use `INSERT OR IGNORE`; meta-row inserts use `ON CONFLICT(pk) DO UPDATE SET earliest_date = MIN(...), latest_date = MAX(...)` — both idempotent under repeated application of the same source rows. The instrument-apply path delegates to `GRDBInstrumentRegistryRepository.applyRemoteChangesSync`, which is the production sync apply path and is idempotent by construction. |
 | `ValuationModeMigration.run` | Calls `accountRepository.backfillValuationModeForUnsnapshotInvestmentAccounts()`, which only writes to investment accounts where `valuationMode` is unset; already-migrated accounts are untouched. |
 | `SyncProgress.lastSettledAt` | A purely cosmetic timestamp surfaced in the sidebar footer; missing → empty footer until next round-trip. No correctness impact. |
-| `SyncCoordinator` engine state | Missing `CKSyncEngine` state token causes the engine to reinitialise and re-fetch change tags. One-time fetch storm; no data loss. |
 | `AnalysisStore` last-used filters | Cosmetic (drop-down defaults). No correctness impact. |
+
+**Note on `SyncCoordinator` engine state.** The CKSyncEngine state token is persisted to a JSON file under `URL.moolahScopedApplicationSupport`, not to UserDefaults (see `SyncCoordinator.swift:151`, `SyncCoordinator+Lifecycle.swift:120–122`, `SyncCoordinator+StatePersistence.swift:19`). Because `URL.moolahScopedApplicationSupport` is already env-scoped, the Task 4 UserDefaults swap has no effect on engine state — Development and Production builds already write to separate state files.
 
 If the implementer finds any runner that does not match this analysis (e.g. file evolved since this plan was written), stop and update the plan / design before swapping.
 

--- a/plans/2026-05-12-env-scoped-prefs-and-keychain-plan.md
+++ b/plans/2026-05-12-env-scoped-prefs-and-keychain-plan.md
@@ -18,7 +18,7 @@
 
 | File | Responsibility |
 |---|---|
-| `Shared/UserDefaults+MoolahShared.swift` | Static `UserDefaults.moolahShared` returning a suite scoped to the resolved CloudKit env, plus `sharedSuite(for:)` so tests can verify both env cases without process-level Info.plist swapping. |
+| `Shared/UserDefaults+MoolahShared.swift` | Static `UserDefaults.moolahShared` returning a suite scoped to the resolved CloudKit env, plus `makeSharedSuite(for:)` factory so tests can verify both env cases without process-level Info.plist swapping. |
 | `Shared/KeychainServices.swift` | `enum KeychainServices` with `apiKeys` (env-scoped service string for the CoinGecko / Alchemy keychain rows) and `apiKeysService(for:)` for tests. |
 | `MoolahTests/Shared/UserDefaultsMoolahSharedTests.swift` | Verifies suite-name format (`rocks.moolah.app.development` / `rocks.moolah.app.production`) and that `moolahShared` is not `.standard`. |
 | `MoolahTests/Shared/KeychainServicesTests.swift` | Verifies service-string format for both env values. |
@@ -90,38 +90,46 @@ import Testing
 
 @Suite("UserDefaults+MoolahShared")
 struct UserDefaultsMoolahSharedTests {
-  @Test("sharedSuite(for: .development) uses dotted lowercase env suffix")
-  func testDevelopmentSuiteName() {
-    let suite = UserDefaults.sharedSuite(for: .development)
-    #expect(suite !== UserDefaults.standard)
+  @Test("makeSharedSuite(for: .development) is not UserDefaults.standard")
+  func testMakeSharedSuiteDevelopmentIsNotStandard() {
+    #expect(UserDefaults.makeSharedSuite(for: .development) !== UserDefaults.standard)
+  }
+
+  @Test("makeSharedSuite(for: .development) uses dotted lowercase env suffix")
+  func testMakeSharedSuiteDevelopmentSuiteName() {
+    let suite = UserDefaults.makeSharedSuite(for: .development)
     let key = "moolah.test.\(UUID().uuidString)"
-    suite.set("dev", forKey: key)
     defer { suite.removeObject(forKey: key) }
+    suite.set("dev", forKey: key)
     let mirror = UserDefaults(suiteName: "rocks.moolah.app.development")
     #expect(mirror?.string(forKey: key) == "dev")
   }
 
-  @Test("sharedSuite(for: .production) uses dotted lowercase env suffix")
-  func testProductionSuiteName() {
-    let suite = UserDefaults.sharedSuite(for: .production)
-    #expect(suite !== UserDefaults.standard)
+  @Test("makeSharedSuite(for: .production) is not UserDefaults.standard")
+  func testMakeSharedSuiteProductionIsNotStandard() {
+    #expect(UserDefaults.makeSharedSuite(for: .production) !== UserDefaults.standard)
+  }
+
+  @Test("makeSharedSuite(for: .production) uses dotted lowercase env suffix")
+  func testMakeSharedSuiteProductionSuiteName() {
+    let suite = UserDefaults.makeSharedSuite(for: .production)
     let key = "moolah.test.\(UUID().uuidString)"
-    suite.set("prod", forKey: key)
     defer { suite.removeObject(forKey: key) }
+    suite.set("prod", forKey: key)
     let mirror = UserDefaults(suiteName: "rocks.moolah.app.production")
     #expect(mirror?.string(forKey: key) == "prod")
   }
 
   @Test("dev and prod suites are isolated from each other")
   func testDevAndProdAreIsolated() {
-    let dev = UserDefaults.sharedSuite(for: .development)
-    let prod = UserDefaults.sharedSuite(for: .production)
+    let dev = UserDefaults.makeSharedSuite(for: .development)
+    let prod = UserDefaults.makeSharedSuite(for: .production)
     let key = "moolah.test.\(UUID().uuidString)"
-    dev.set("dev-value", forKey: key)
     defer {
       dev.removeObject(forKey: key)
       prod.removeObject(forKey: key)
     }
+    dev.set("dev-value", forKey: key)
     #expect(prod.string(forKey: key) == nil)
   }
 
@@ -132,13 +140,22 @@ struct UserDefaultsMoolahSharedTests {
 }
 ```
 
+The file contains 6 `@Test` methods total:
+
+1. `testMakeSharedSuiteDevelopmentIsNotStandard`
+2. `testMakeSharedSuiteDevelopmentSuiteName`
+3. `testMakeSharedSuiteProductionIsNotStandard`
+4. `testMakeSharedSuiteProductionSuiteName`
+5. `testDevAndProdAreIsolated`
+6. `testMoolahSharedIsNotStandard`
+
 - [ ] **Step 2: Run the test and confirm it fails**
 
 ```bash
 just test UserDefaultsMoolahSharedTests 2>&1 | tee .agent-tmp/test-output.txt
 ```
 
-Expected: build failure ("no member 'sharedSuite' / 'moolahShared'") or compile error referring to the missing extension.
+Expected: build failure ("no member 'makeSharedSuite' / 'moolahShared'") or compile error referring to the missing extension.
 
 - [ ] **Step 3: Implement the helper**
 
@@ -153,13 +170,18 @@ extension UserDefaults {
   /// build (and vice versa). Production code paths inject this in place
   /// of `.standard`. Tests continue to inject their own
   /// `UserDefaults(suiteName:)` for isolation.
-  static let moolahShared: UserDefaults = sharedSuite(for: .resolved())
+  ///
+  /// `nonisolated(unsafe)` because `UserDefaults` itself is not declared
+  /// `Sendable` by Foundation but is documented as thread-safe. The
+  /// instance is initialised once at first access and never reassigned,
+  /// so concurrent access is sound.
+  nonisolated(unsafe) static let moolahShared: UserDefaults = makeSharedSuite(for: .resolved())
 
-  /// Builder used by `moolahShared`. Exposed so tests can verify the
+  /// Factory used by `moolahShared`. Exposed so tests can verify the
   /// suite-name format for both environments without process-level
   /// Info.plist swapping. Mirrors the `CloudKitEnvironment.resolve(from:)`
   /// pattern that `CloudKitEnvironmentTests` uses.
-  static func sharedSuite(for env: CloudKitEnvironment) -> UserDefaults {
+  static func makeSharedSuite(for env: CloudKitEnvironment) -> UserDefaults {
     let suiteName = "rocks.moolah.app.\(env.storageSubdirectory.lowercased())"
     // `UserDefaults(suiteName:)` returns `nil` only for reserved suite
     // names (e.g. literal `"Apple Global Domain"`). Neither of our
@@ -177,7 +199,7 @@ just test UserDefaultsMoolahSharedTests 2>&1 | tee .agent-tmp/test-output.txt
 grep -E "Test Suite|passed|failed" .agent-tmp/test-output.txt | tail
 ```
 
-Expected: all four tests pass.
+Expected: all six tests pass.
 
 - [ ] **Step 5: Commit**
 
@@ -188,7 +210,7 @@ shared: add UserDefaults.moolahShared scoped to CloudKit env
 
 Suite name is `rocks.moolah.app.<env>` (lowercased) so Development and
 Production builds back to physically separate plists under
-~/Library/Preferences/. `sharedSuite(for:)` exposed for tests.
+~/Library/Preferences/. `makeSharedSuite(for:)` factory exposed for tests.
 
 Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
 EOF
@@ -701,4 +723,4 @@ After the PR opens, follow the project's merge-queue convention — add it to th
 
 **Placeholder scan:** No "TBD", "implement later", or unspecified test bodies — every code step has full code or a precise diff.
 
-**Type consistency:** `moolahShared` (let) and `sharedSuite(for:)` (func) match across all four references; `apiKeys` (var) and `apiKeysService(for:)` (func) match across all five references.
+**Type consistency:** `moolahShared` (let) and `makeSharedSuite(for:)` (func) match across all references; `apiKeys` (var) and `apiKeysService(for:)` (func) match across all five references. Factory methods use `make` per `guides/CODE_GUIDE.md` §4.

--- a/plans/2026-05-12-env-scoped-prefs-and-keychain-plan.md
+++ b/plans/2026-05-12-env-scoped-prefs-and-keychain-plan.md
@@ -19,7 +19,7 @@
 | File | Responsibility |
 |---|---|
 | `Shared/UserDefaults+MoolahShared.swift` | Static `UserDefaults.moolahShared` returning a suite scoped to the resolved CloudKit env, plus `makeSharedSuite(for:)` factory so tests can verify both env cases without process-level Info.plist swapping. |
-| `Shared/KeychainServices.swift` | `enum KeychainServices` with `apiKeys` (env-scoped service string for the CoinGecko / Alchemy keychain rows) and `apiKeysService(for:)` for tests. |
+| `Shared/KeychainServices.swift` | `enum KeychainServices` with `apiKeys` (env-scoped service string for the CoinGecko / Alchemy keychain rows) and `makeApiKeysService(for:)` for tests. |
 | `MoolahTests/Shared/UserDefaultsMoolahSharedTests.swift` | Verifies suite-name format (`rocks.moolah.app.development` / `rocks.moolah.app.production`) and that `moolahShared` is not `.standard`. |
 | `MoolahTests/Shared/KeychainServicesTests.swift` | Verifies service-string format for both env values. |
 
@@ -237,17 +237,17 @@ import Testing
 
 @Suite("KeychainServices")
 struct KeychainServicesTests {
-  @Test("apiKeysService(for: .development) returns dotted lowercase env suffix")
+  @Test("makeApiKeysService(for: .development) returns dotted lowercase env suffix")
   func testDevelopmentApiKeysService() {
     #expect(
-      KeychainServices.apiKeysService(for: .development)
+      KeychainServices.makeApiKeysService(for: .development)
         == "com.moolah.api-keys.development")
   }
 
-  @Test("apiKeysService(for: .production) returns dotted lowercase env suffix")
+  @Test("makeApiKeysService(for: .production) returns dotted lowercase env suffix")
   func testProductionApiKeysService() {
     #expect(
-      KeychainServices.apiKeysService(for: .production)
+      KeychainServices.makeApiKeysService(for: .production)
         == "com.moolah.api-keys.production")
   }
 
@@ -256,7 +256,7 @@ struct KeychainServicesTests {
     let resolved = CloudKitEnvironment.resolved()
     #expect(
       KeychainServices.apiKeys
-        == KeychainServices.apiKeysService(for: resolved))
+        == KeychainServices.makeApiKeysService(for: resolved))
   }
 }
 ```
@@ -285,12 +285,13 @@ enum KeychainServices {
   /// Service string for API-key keychain rows (CoinGecko, Alchemy)
   /// scoped to the resolved CloudKit environment. Production code uses
   /// this in place of the previous `"com.moolah.api-keys"` literal.
-  static var apiKeys: String { apiKeysService(for: .resolved()) }
+  static var apiKeys: String { makeApiKeysService(for: .resolved()) }
 
-  /// Builder used by `apiKeys`. Exposed so tests can verify the
+  /// Factory used by `apiKeys`. Exposed so tests can verify the
   /// service-string format for both environments without process-level
-  /// Info.plist swapping. Mirrors `CloudKitEnvironment.resolve(from:)`.
-  static func apiKeysService(for env: CloudKitEnvironment) -> String {
+  /// Info.plist swapping. Mirrors `CloudKitEnvironment.resolve(from:)`
+  /// and the `makeSharedSuite(for:)` factory on `UserDefaults`.
+  static func makeApiKeysService(for env: CloudKitEnvironment) -> String {
     "com.moolah.api-keys.\(env.storageSubdirectory.lowercased())"
   }
 }
@@ -723,4 +724,4 @@ After the PR opens, follow the project's merge-queue convention — add it to th
 
 **Placeholder scan:** No "TBD", "implement later", or unspecified test bodies — every code step has full code or a precise diff.
 
-**Type consistency:** `moolahShared` (let) and `makeSharedSuite(for:)` (func) match across all references; `apiKeys` (var) and `apiKeysService(for:)` (func) match across all five references. Factory methods use `make` per `guides/CODE_GUIDE.md` §4.
+**Type consistency:** `moolahShared` (let) and `makeSharedSuite(for:)` (func) match across all references; `apiKeys` (var) and `makeApiKeysService(for:)` (func) match across all five references. Factory methods use `make` per `guides/CODE_GUIDE.md` §4.

--- a/plans/2026-05-12-env-scoped-prefs-and-keychain-plan.md
+++ b/plans/2026-05-12-env-scoped-prefs-and-keychain-plan.md
@@ -1,0 +1,704 @@
+# Env-Scoped UserDefaults & Keychain Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop a Development build of Moolah from being able to read or write any `UserDefaults` value or any `KeychainStore` row that a Production build also touches.
+
+**Architecture:** Add two tiny helpers — `UserDefaults.moolahShared` and `KeychainServices.apiKeys` — that suffix the resolved `CloudKitEnvironment` onto a base name (suite name / service string). Replace every production-side default of `.standard` and every literal `"com.moolah.api-keys"` service string with these helpers. No migration of existing prefs / keychain content (clean break per design).
+
+**Tech Stack:** Swift 6, Swift Testing (`@Suite` / `@Test`), `UserDefaults`, `Security` framework (`SecItem` via `KeychainStore`), GRDB, CloudKit. Builds and tests run via `just` targets.
+
+**Spec:** `plans/2026-05-12-env-scoped-prefs-and-keychain-design.md`.
+
+---
+
+## File Structure
+
+### New
+
+| File | Responsibility |
+|---|---|
+| `Shared/UserDefaults+MoolahShared.swift` | Static `UserDefaults.moolahShared` returning a suite scoped to the resolved CloudKit env, plus `sharedSuite(for:)` so tests can verify both env cases without process-level Info.plist swapping. |
+| `Shared/KeychainServices.swift` | `enum KeychainServices` with `apiKeys` (env-scoped service string for the CoinGecko / Alchemy keychain rows) and `apiKeysService(for:)` for tests. |
+| `MoolahTests/Shared/UserDefaultsMoolahSharedTests.swift` | Verifies suite-name format (`rocks.moolah.app.development` / `rocks.moolah.app.production`) and that `moolahShared` is not `.standard`. |
+| `MoolahTests/Shared/KeychainServicesTests.swift` | Verifies service-string format for both env values. |
+
+### Modified
+
+Defaults swap (`= .standard` → `= .moolahShared`):
+
+| File | Symbol |
+|---|---|
+| `App/MoolahApp+Setup.swift` | `cleanupLegacyRateCachesOnce(defaults:)`, `runProfileIndexMigrationIfNeeded(setup:defaults:)`. |
+| `App/SharedRegistryUnionRunner.swift` | `run(...defaults:)` parameter. |
+| `App/ValuationModeMigration.swift` | `resetGateFlags(in:)` is callable from any defaults; no production default to swap (callers always pass an explicit `userDefaults` field assigned at construction time — verified in Task 5). |
+| `Backends/CloudKit/Sync/SyncCoordinator.swift` | `init(...userDefaults:)` parameter. |
+| `Backends/CloudKit/Sync/SyncProgress.swift` | `init(userDefaults:)` parameter. |
+| `Backends/CloudKit/Sync/LegacyZoneCleanup.swift` | `performIfNeeded(defaults:)` parameter. |
+| `Backends/GRDB/Migration/SwiftDataToGRDBMigrator.swift` | `migrateIfNeeded(...defaults:)`, `resetMigrationFlags(in:)`. |
+| `Backends/GRDB/Migration/SwiftDataToGRDBMigrator+CoreFinancialGraph.swift` | Every `defaults: UserDefaults` parameter that defaults to `.standard`. |
+| `Backends/GRDB/Migration/SwiftDataToGRDBMigrator+Earmarks.swift` | Same. |
+| `Backends/GRDB/Migration/SwiftDataToGRDBMigrator+Transactions.swift` | Same. |
+| `Backends/GRDB/Migration/SwiftDataToGRDBMigrator+ProfileIndex.swift` | Same. |
+| `Features/Analysis/AnalysisStore.swift` | `init(...defaults:)` parameter. |
+
+Keychain swap (`service: "com.moolah.api-keys"` → `service: KeychainServices.apiKeys`):
+
+| File | Sites |
+|---|---|
+| `App/ProfileSession+CryptoSync.swift` | `resolveAlchemyApiKey()` |
+| `App/ProfileSession+Factories.swift` | `makeMarketDataServices(database:)` |
+| `Features/Settings/CryptoTokenStore.swift` | `convenience init(...)` (two `KeychainStore(...)` constructions) |
+
+---
+
+## Idempotency Pre-Audit (Background Reading)
+
+The clean break means each migration-gate UserDefaults flag resets to absent on the new Production build's first launch. Before swapping, verify each runner is safe to re-run from a fresh-state defaults. No code changes expected — this is a sign-off step embedded in Task 4.
+
+| Runner | Why safe to re-run |
+|---|---|
+| `cleanupLegacyRateCachesOnce` | Wraps `removeItem` in a `NSFileNoSuchFileError` swallow; second run finds nothing and no-ops. |
+| `LegacyZoneCleanup.performIfNeeded` | Re-attempts `deleteRecordZone`; the zone-not-found path marks the flag done immediately. |
+| `SwiftDataToGRDBMigrator.migrateIfNeeded` | Each per-type migrator uses `insert(onConflict: .ignore)` and `defer { committed ? flag = true : () }` (see file header). For an existing Production user the SwiftData source store is empty by this version, so every per-type fetch returns zero rows and the flag is set with no DB writes. |
+| `SwiftDataToGRDBMigrator.migrateProfileIndexIfNeeded` | Same idempotency pattern as above. |
+| `SharedRegistryUnionRunner.run` | Body-row inserts use `INSERT OR IGNORE`; meta-row inserts use `ON CONFLICT(pk) DO UPDATE SET earliest_date = MIN(...), latest_date = MAX(...)` — both idempotent under repeated application of the same source rows. The instrument-apply path delegates to `GRDBInstrumentRegistryRepository.applyRemoteChangesSync`, which is the production sync apply path and is idempotent by construction. |
+| `ValuationModeMigration.run` | Calls `accountRepository.backfillValuationModeForUnsnapshotInvestmentAccounts()`, which only writes to investment accounts where `valuationMode` is unset; already-migrated accounts are untouched. |
+| `SyncProgress.lastSettledAt` | A purely cosmetic timestamp surfaced in the sidebar footer; missing → empty footer until next round-trip. No correctness impact. |
+| `SyncCoordinator` engine state | Missing `CKSyncEngine` state token causes the engine to reinitialise and re-fetch change tags. One-time fetch storm; no data loss. |
+| `AnalysisStore` last-used filters | Cosmetic (drop-down defaults). No correctness impact. |
+
+If the implementer finds any runner that does not match this analysis (e.g. file evolved since this plan was written), stop and update the plan / design before swapping.
+
+---
+
+## Task 1: `UserDefaults.moolahShared` Helper
+
+**Files:**
+- Create: `Shared/UserDefaults+MoolahShared.swift`
+- Test: `MoolahTests/Shared/UserDefaultsMoolahSharedTests.swift`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `MoolahTests/Shared/UserDefaultsMoolahSharedTests.swift`:
+
+```swift
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("UserDefaults+MoolahShared")
+struct UserDefaultsMoolahSharedTests {
+  @Test("sharedSuite(for: .development) uses dotted lowercase env suffix")
+  func testDevelopmentSuiteName() {
+    let suite = UserDefaults.sharedSuite(for: .development)
+    #expect(suite !== UserDefaults.standard)
+    let key = "moolah.test.\(UUID().uuidString)"
+    suite.set("dev", forKey: key)
+    defer { suite.removeObject(forKey: key) }
+    let mirror = UserDefaults(suiteName: "rocks.moolah.app.development")
+    #expect(mirror?.string(forKey: key) == "dev")
+  }
+
+  @Test("sharedSuite(for: .production) uses dotted lowercase env suffix")
+  func testProductionSuiteName() {
+    let suite = UserDefaults.sharedSuite(for: .production)
+    #expect(suite !== UserDefaults.standard)
+    let key = "moolah.test.\(UUID().uuidString)"
+    suite.set("prod", forKey: key)
+    defer { suite.removeObject(forKey: key) }
+    let mirror = UserDefaults(suiteName: "rocks.moolah.app.production")
+    #expect(mirror?.string(forKey: key) == "prod")
+  }
+
+  @Test("dev and prod suites are isolated from each other")
+  func testDevAndProdAreIsolated() {
+    let dev = UserDefaults.sharedSuite(for: .development)
+    let prod = UserDefaults.sharedSuite(for: .production)
+    let key = "moolah.test.\(UUID().uuidString)"
+    dev.set("dev-value", forKey: key)
+    defer {
+      dev.removeObject(forKey: key)
+      prod.removeObject(forKey: key)
+    }
+    #expect(prod.string(forKey: key) == nil)
+  }
+
+  @Test("moolahShared resolves to a suite, never .standard")
+  func testMoolahSharedIsNotStandard() {
+    #expect(UserDefaults.moolahShared !== UserDefaults.standard)
+  }
+}
+```
+
+- [ ] **Step 2: Run the test and confirm it fails**
+
+```bash
+just test UserDefaultsMoolahSharedTests 2>&1 | tee .agent-tmp/test-output.txt
+```
+
+Expected: build failure ("no member 'sharedSuite' / 'moolahShared'") or compile error referring to the missing extension.
+
+- [ ] **Step 3: Implement the helper**
+
+Create `Shared/UserDefaults+MoolahShared.swift`:
+
+```swift
+import Foundation
+
+extension UserDefaults {
+  /// Defaults suite scoped to the current CloudKit environment so a
+  /// Development build cannot read or write state owned by a Production
+  /// build (and vice versa). Production code paths inject this in place
+  /// of `.standard`. Tests continue to inject their own
+  /// `UserDefaults(suiteName:)` for isolation.
+  static let moolahShared: UserDefaults = sharedSuite(for: .resolved())
+
+  /// Builder used by `moolahShared`. Exposed so tests can verify the
+  /// suite-name format for both environments without process-level
+  /// Info.plist swapping. Mirrors the `CloudKitEnvironment.resolve(from:)`
+  /// pattern that `CloudKitEnvironmentTests` uses.
+  static func sharedSuite(for env: CloudKitEnvironment) -> UserDefaults {
+    let suiteName = "rocks.moolah.app.\(env.storageSubdirectory.lowercased())"
+    // `UserDefaults(suiteName:)` returns `nil` only for reserved suite
+    // names (e.g. literal `"Apple Global Domain"`). Neither of our
+    // env-suffixed names is reserved, so the fallback is unreachable in
+    // practice but keeps the return type non-optional.
+    return UserDefaults(suiteName: suiteName) ?? .standard
+  }
+}
+```
+
+- [ ] **Step 4: Run the test and confirm it passes**
+
+```bash
+just test UserDefaultsMoolahSharedTests 2>&1 | tee .agent-tmp/test-output.txt
+grep -E "Test Suite|passed|failed" .agent-tmp/test-output.txt | tail
+```
+
+Expected: all four tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C "$(pwd)" add Shared/UserDefaults+MoolahShared.swift MoolahTests/Shared/UserDefaultsMoolahSharedTests.swift
+git -C "$(pwd)" commit -m "$(cat <<'EOF'
+shared: add UserDefaults.moolahShared scoped to CloudKit env
+
+Suite name is `rocks.moolah.app.<env>` (lowercased) so Development and
+Production builds back to physically separate plists under
+~/Library/Preferences/. `sharedSuite(for:)` exposed for tests.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: `KeychainServices` Helper
+
+**Files:**
+- Create: `Shared/KeychainServices.swift`
+- Test: `MoolahTests/Shared/KeychainServicesTests.swift`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `MoolahTests/Shared/KeychainServicesTests.swift`:
+
+```swift
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("KeychainServices")
+struct KeychainServicesTests {
+  @Test("apiKeysService(for: .development) returns dotted lowercase env suffix")
+  func testDevelopmentApiKeysService() {
+    #expect(
+      KeychainServices.apiKeysService(for: .development)
+        == "com.moolah.api-keys.development")
+  }
+
+  @Test("apiKeysService(for: .production) returns dotted lowercase env suffix")
+  func testProductionApiKeysService() {
+    #expect(
+      KeychainServices.apiKeysService(for: .production)
+        == "com.moolah.api-keys.production")
+  }
+
+  @Test("apiKeys uses the resolved environment")
+  func testApiKeysUsesResolvedEnvironment() {
+    let resolved = CloudKitEnvironment.resolved()
+    #expect(
+      KeychainServices.apiKeys
+        == KeychainServices.apiKeysService(for: resolved))
+  }
+}
+```
+
+- [ ] **Step 2: Run the test and confirm it fails**
+
+```bash
+just test KeychainServicesTests 2>&1 | tee .agent-tmp/test-output.txt
+```
+
+Expected: build failure (`KeychainServices` undefined).
+
+- [ ] **Step 3: Implement the helper**
+
+Create `Shared/KeychainServices.swift`:
+
+```swift
+import Foundation
+
+/// Env-scoped keychain service strings. A Development build targets
+/// `com.moolah.api-keys.development`; a Production build targets
+/// `com.moolah.api-keys.production`. Splitting the service string per
+/// CloudKit env stops a Development build from overwriting a Production
+/// build's iCloud-Keychain-synced API key on every device.
+enum KeychainServices {
+  /// Service string for API-key keychain rows (CoinGecko, Alchemy)
+  /// scoped to the resolved CloudKit environment. Production code uses
+  /// this in place of the previous `"com.moolah.api-keys"` literal.
+  static var apiKeys: String { apiKeysService(for: .resolved()) }
+
+  /// Builder used by `apiKeys`. Exposed so tests can verify the
+  /// service-string format for both environments without process-level
+  /// Info.plist swapping. Mirrors `CloudKitEnvironment.resolve(from:)`.
+  static func apiKeysService(for env: CloudKitEnvironment) -> String {
+    "com.moolah.api-keys.\(env.storageSubdirectory.lowercased())"
+  }
+}
+```
+
+- [ ] **Step 4: Run the test and confirm it passes**
+
+```bash
+just test KeychainServicesTests 2>&1 | tee .agent-tmp/test-output.txt
+grep -E "Test Suite|passed|failed" .agent-tmp/test-output.txt | tail
+```
+
+Expected: all three tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C "$(pwd)" add Shared/KeychainServices.swift MoolahTests/Shared/KeychainServicesTests.swift
+git -C "$(pwd)" commit -m "$(cat <<'EOF'
+shared: add KeychainServices.apiKeys scoped to CloudKit env
+
+Service string is `com.moolah.api-keys.<env>` so Development and
+Production builds write to separate keychain rows. The
+`synchronizable: true` flag is preserved at the call sites in a
+follow-up — only the service-string namespace lands in this commit.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Pre-swap Idempotency Sign-off
+
+**Files:** None (read-only audit).
+
+- [ ] **Step 1: Re-read each runner against the audit table**
+
+For each row in the *Idempotency Pre-Audit* table above, open the named file and confirm the cited mechanism still exists and matches the description. The five runners that need confirmation:
+
+- `App/MoolahApp+Setup.swift` — `cleanupLegacyRateCachesOnce` (NSFileNoSuchFileError swallow at the `removeItem` site).
+- `Backends/CloudKit/Sync/LegacyZoneCleanup.swift` — `deleteLegacyZone` (zone-not-found marks done; thrown errors leave the flag unset).
+- `Backends/GRDB/Migration/SwiftDataToGRDBMigrator.swift` and the four extensions — every per-type migrator uses `insert(onConflict: .ignore)` and a `committed` deferred flag set.
+- `App/SharedRegistryUnionRunner.swift` — `mergeBodyRows` (`INSERT OR IGNORE`) and `mergeMetaRows` (`ON CONFLICT(pk) DO UPDATE SET earliest_date = MIN(...), latest_date = MAX(...)`).
+- `App/ValuationModeMigration.swift` — `accountRepository.backfillValuationModeForUnsnapshotInvestmentAccounts()` only touches accounts where `valuationMode` is unset.
+
+- [ ] **Step 2: If any runner has drifted from the audit, stop**
+
+If a runner no longer matches, do NOT proceed to Task 4. Update this plan's audit table (and the design doc) and either fix the runner's idempotency *first* or escalate to the user. Do not paper over with a defensive guard inside the swap task.
+
+- [ ] **Step 3: If everything matches, mark this task complete and proceed**
+
+No commit — this is a read-only sign-off.
+
+---
+
+## Task 4: Defaults Swap (production callers)
+
+**Files:**
+- Modify: `App/MoolahApp+Setup.swift`
+- Modify: `App/SharedRegistryUnionRunner.swift`
+- Modify: `Backends/CloudKit/Sync/SyncCoordinator.swift`
+- Modify: `Backends/CloudKit/Sync/SyncProgress.swift`
+- Modify: `Backends/CloudKit/Sync/LegacyZoneCleanup.swift`
+- Modify: `Backends/GRDB/Migration/SwiftDataToGRDBMigrator.swift`
+- Modify: `Backends/GRDB/Migration/SwiftDataToGRDBMigrator+CoreFinancialGraph.swift`
+- Modify: `Backends/GRDB/Migration/SwiftDataToGRDBMigrator+Earmarks.swift`
+- Modify: `Backends/GRDB/Migration/SwiftDataToGRDBMigrator+Transactions.swift`
+- Modify: `Backends/GRDB/Migration/SwiftDataToGRDBMigrator+ProfileIndex.swift`
+- Modify: `Features/Analysis/AnalysisStore.swift`
+
+This is a mechanical refactor: every production-side `defaults: UserDefaults = .standard` parameter becomes `defaults: UserDefaults = .moolahShared` (and the equivalent for `userDefaults:`). Test sites that *pass an explicit value* are unaffected; test sites that *rely on the default* are not expected (verified in Step 2 below).
+
+`ValuationModeMigration` is intentionally excluded: its `userDefaults` is a non-optional stored field (no production default) populated by the call site in `ProfileSession`. Update that call site instead — see Step 6.
+
+`MoolahApp.init`'s UI-testing branch that constructs `UserDefaults(suiteName: "moolah.uitests.<UUID>")` is preserved unchanged.
+
+- [ ] **Step 1: Audit existing test callers that rely on the production default**
+
+```bash
+grep -rn "performIfNeeded\b\|cleanupLegacyRateCachesOnce\b\|migrateIfNeeded\b\|SharedRegistryUnionRunner.run\b\|migrateProfileIndexIfNeeded\b\|AnalysisStore(\|SyncProgress(\|SyncCoordinator(" \
+  --include="*.swift" MoolahTests MoolahUITests_macOS UITestSupport 2>/dev/null
+```
+
+For each match, check that the call site passes its own `defaults:` / `userDefaults:` argument. If a test relies on the production default (i.e. hits `.standard`), flag it before continuing — flipping the default to `.moolahShared` would silently change which suite that test reads from. Expected: every existing test injects its own; this step is a guard against drift.
+
+- [ ] **Step 2: Apply the swap to every production parameter**
+
+For each file listed above, change `= .standard` to `= .moolahShared` for every `defaults:` / `userDefaults:` parameter. The full list of edits:
+
+`App/MoolahApp+Setup.swift`:
+
+```diff
+-  static func cleanupLegacyRateCachesOnce(defaults: UserDefaults = .standard) {
++  static func cleanupLegacyRateCachesOnce(defaults: UserDefaults = .moolahShared) {
+```
+
+```diff
+   static func runProfileIndexMigrationIfNeeded(
+     setup: ContainerSetup,
+-    defaults: UserDefaults = .standard
++    defaults: UserDefaults = .moolahShared
+   ) async {
+```
+
+`App/SharedRegistryUnionRunner.swift`:
+
+```diff
+     fileManager: FileManager = .default,
+-    defaults: UserDefaults = .standard
++    defaults: UserDefaults = .moolahShared
+   ) async {
+```
+
+`Backends/CloudKit/Sync/SyncCoordinator.swift` (around line 345):
+
+```diff
+-    userDefaults: UserDefaults = .standard,
++    userDefaults: UserDefaults = .moolahShared,
+```
+
+`Backends/CloudKit/Sync/SyncProgress.swift`:
+
+```diff
+-  init(userDefaults: UserDefaults = .standard) {
++  init(userDefaults: UserDefaults = .moolahShared) {
+```
+
+`Backends/CloudKit/Sync/LegacyZoneCleanup.swift`:
+
+```diff
+-  static func performIfNeeded(defaults: UserDefaults = .standard) {
++  static func performIfNeeded(defaults: UserDefaults = .moolahShared) {
+```
+
+`Backends/GRDB/Migration/SwiftDataToGRDBMigrator.swift`:
+
+```diff
+-  static func resetMigrationFlags(in defaults: UserDefaults = .standard) {
++  static func resetMigrationFlags(in defaults: UserDefaults = .moolahShared) {
+```
+
+```diff
+   func migrateIfNeeded(
+     modelContainer: ModelContainer,
+     database: any DatabaseWriter,
+-    defaults: UserDefaults = .standard
++    defaults: UserDefaults = .moolahShared
+   ) async throws {
+```
+
+`Backends/GRDB/Migration/SwiftDataToGRDBMigrator+CoreFinancialGraph.swift`,
+`Backends/GRDB/Migration/SwiftDataToGRDBMigrator+Earmarks.swift`,
+`Backends/GRDB/Migration/SwiftDataToGRDBMigrator+Transactions.swift`,
+`Backends/GRDB/Migration/SwiftDataToGRDBMigrator+ProfileIndex.swift`:
+
+For each file, replace every `defaults: UserDefaults` parameter that defaults to `.standard` with `.moolahShared`. Use:
+
+```bash
+grep -n "defaults: UserDefaults = .standard" Backends/GRDB/Migration/SwiftDataToGRDBMigrator+*.swift
+```
+
+to enumerate exact lines, then edit each one. Some files use `defaults: UserDefaults` without a default at all (parameter is *forwarded* from the top-level call) — leave those alone.
+
+`Features/Analysis/AnalysisStore.swift` (around line 57):
+
+```diff
+   init(
+     repository: AnalysisRepository,
+-    defaults: UserDefaults = .standard,
++    defaults: UserDefaults = .moolahShared,
+     monthEnd: Int = Calendar.current.component(.day, from: Date())
+   ) {
+```
+
+- [ ] **Step 3: Wire `ValuationModeMigration.userDefaults` from `.moolahShared`**
+
+`ValuationModeMigration` has no production default — its `userDefaults` is a stored property assigned at call site. Find the construction site and pass `.moolahShared`:
+
+```bash
+grep -n "ValuationModeMigration(" --include="*.swift" -r App Backends Features
+```
+
+Expected hit: a single production construction (in `ProfileSession`-related code). For that site:
+
+```diff
+   ValuationModeMigration(
+     profileId: ...,
+     accountRepository: ...,
+-    userDefaults: .standard
++    userDefaults: .moolahShared
+   )
+```
+
+If the existing call site already passes a non-`.standard` value (e.g. an injected suite from a test fixture), do not change it — the swap targets only the production call.
+
+- [ ] **Step 4: Build and run the full test suite**
+
+```bash
+mkdir -p .agent-tmp
+just build-mac 2>&1 | tee .agent-tmp/build-output.txt
+just test 2>&1 | tee .agent-tmp/test-output.txt
+grep -iE "failed|error:" .agent-tmp/test-output.txt | head -40 || echo "no failures"
+```
+
+Expected: clean build, full test pass. The swap is a refactor — it changes the default value of a parameter that all test sites were already injecting. Any test that relied on the production default will now read from `rocks.moolah.app.development` instead of `.standard` — Step 1 should have caught this.
+
+- [ ] **Step 5: Format and lint**
+
+```bash
+just format
+just format-check
+```
+
+Expected: no diffs after `format`; clean exit from `format-check`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C "$(pwd)" add -A
+git -C "$(pwd)" commit -m "$(cat <<'EOF'
+prefs: route production callers to UserDefaults.moolahShared
+
+Mechanical refactor of the `defaults: UserDefaults = .standard` /
+`userDefaults: UserDefaults = .standard` defaults across stores,
+sync coordinator, migration runners, and one-shot cleanup runners.
+Test sites already inject their own defaults and are unaffected.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Keychain Service Swap
+
+**Files:**
+- Modify: `App/ProfileSession+CryptoSync.swift`
+- Modify: `App/ProfileSession+Factories.swift`
+- Modify: `Features/Settings/CryptoTokenStore.swift`
+
+Four hard-coded `service: "com.moolah.api-keys"` literals become `service: KeychainServices.apiKeys`. The `synchronizable: true` flag stays.
+
+- [ ] **Step 1: Audit existing tests that wire keychain stores explicitly**
+
+```bash
+grep -rn "com.moolah.api-keys" --include="*.swift" .
+```
+
+Expected: four production hits (the ones we're swapping) plus zero or more test hits. Test hits — `MoolahTests/Features/Settings/CryptoSettingsAPIKeyTests.swift` builds its own `KeychainStore(service: "com.moolah.test...")` per the existing `KeychainStoreTests` pattern, not against `com.moolah.api-keys`, so it is unaffected. Any test that *does* use `com.moolah.api-keys` directly should be flagged before continuing — flipping production to the env-scoped service would silently break it.
+
+- [ ] **Step 2: Apply the swap**
+
+`App/ProfileSession+CryptoSync.swift`:
+
+```diff
+   nonisolated static func resolveAlchemyApiKey() -> String? {
+     let store = KeychainStore(
+-      service: "com.moolah.api-keys", account: "alchemy", synchronizable: true)
++      service: KeychainServices.apiKeys, account: "alchemy", synchronizable: true)
+     return try? store.restoreString()
+   }
+```
+
+`App/ProfileSession+Factories.swift` (in `makeMarketDataServices`):
+
+```diff
+     let yahooClient = YahooFinanceClient()
+     let apiKeyStore = KeychainStore(
+-      service: "com.moolah.api-keys", account: "coingecko", synchronizable: true
++      service: KeychainServices.apiKeys, account: "coingecko", synchronizable: true
+     )
+```
+
+`Features/Settings/CryptoTokenStore.swift` (in the production `convenience init`):
+
+```diff
+       apiKeyStore: KeychainStore(
+-        service: "com.moolah.api-keys", account: "coingecko", synchronizable: true),
++        service: KeychainServices.apiKeys, account: "coingecko", synchronizable: true),
+       alchemyKeyStore: KeychainStore(
+-        service: "com.moolah.api-keys", account: "alchemy", synchronizable: true),
++        service: KeychainServices.apiKeys, account: "alchemy", synchronizable: true),
+```
+
+- [ ] **Step 3: Re-run the audit grep to verify zero remaining production literals**
+
+```bash
+grep -rn "com.moolah.api-keys" --include="*.swift" App Features Backends
+```
+
+Expected: no hits.
+
+- [ ] **Step 4: Build and run the full test suite**
+
+```bash
+just build-mac 2>&1 | tee .agent-tmp/build-output.txt
+just test 2>&1 | tee .agent-tmp/test-output.txt
+grep -iE "failed|error:" .agent-tmp/test-output.txt | head -40 || echo "no failures"
+```
+
+Expected: clean build, full test pass.
+
+- [ ] **Step 5: Format and lint**
+
+```bash
+just format
+just format-check
+```
+
+Expected: no diffs after `format`; clean exit from `format-check`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C "$(pwd)" add -A
+git -C "$(pwd)" commit -m "$(cat <<'EOF'
+keychain: route api-key rows to KeychainServices.apiKeys
+
+Replaces the four hard-coded `service: "com.moolah.api-keys"` literals
+with the env-scoped `KeychainServices.apiKeys`. Production builds now
+read/write `com.moolah.api-keys.production`; Development builds use
+`com.moolah.api-keys.development`. iCloud-Keychain `synchronizable: true`
+flag is preserved on both rows.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: End-to-end Verification
+
+**Files:** None (verification only).
+
+- [ ] **Step 1: Confirm no `.standard` defaults survive in production code**
+
+```bash
+grep -rn "UserDefaults = .standard\|UserDefaults\s*=\s*.standard" --include="*.swift" App Backends Features Shared
+```
+
+Expected: zero hits. Hits inside `MoolahTests/`, `MoolahUITests_macOS/`, `UITestSupport/` are fine. Hits inside `MoolahApp.swift`'s UI-testing branch (which uses `UserDefaults(suiteName: "moolah.uitests.<UUID>")`) are also fine — that branch never reads `.standard` as a fallback for production state.
+
+- [ ] **Step 2: Confirm no remaining `com.moolah.api-keys` literal**
+
+```bash
+grep -rn "com.moolah.api-keys" --include="*.swift" App Backends Features Shared
+```
+
+Expected: zero hits.
+
+- [ ] **Step 3: Run the full test suite for both platforms**
+
+```bash
+mkdir -p .agent-tmp
+just test 2>&1 | tee .agent-tmp/test-output.txt
+grep -iE "failed|error:" .agent-tmp/test-output.txt | head -40 || echo "no failures"
+```
+
+Expected: clean pass on both `MoolahTests_iOS` and `MoolahTests_macOS`.
+
+- [ ] **Step 4: Manual smoke against a built app (Development build)**
+
+```bash
+just run-mac
+```
+
+Sanity checks once the app launches:
+
+1. The app boots into the welcome / profile screen without crashing.
+2. Add a profile, open it, and confirm sidebar / accounts render. (UserDefaults is empty for this env on first launch — `AnalysisStore` filter defaults, `SyncProgress.lastSettledAt` empty.)
+3. In Settings → Crypto, paste a dummy CoinGecko / Alchemy key and confirm it persists across app relaunch — read by the new `KeychainServices.apiKeys` service, account `coingecko` / `alchemy`. Use `Keychain Access.app` if you want visual confirmation: search for `com.moolah.api-keys.development`; the row should appear, and the legacy `com.moolah.api-keys` row (if you used the app pre-swap) should be untouched.
+
+Quit the app cleanly. There is no production-build smoke step in this plan — the production build cannot run without distribution signing.
+
+- [ ] **Step 5: Delete temp files**
+
+```bash
+rm -f .agent-tmp/test-output.txt .agent-tmp/build-output.txt
+```
+
+- [ ] **Step 6: Open the PR**
+
+```bash
+git -C "$(pwd)" log --oneline origin/main..HEAD
+git -C "$(pwd)" push -u origin worktree-env-scoped-prefs-and-keychain
+gh pr create --title "Scope UserDefaults & Keychain to CloudKit env" --body "$(cat <<'EOF'
+## Summary
+- Adds `UserDefaults.moolahShared` and `KeychainServices.apiKeys`, both env-scoped via `CloudKitEnvironment.resolved()`.
+- Swaps every production `defaults: UserDefaults = .standard` to `.moolahShared` and every `service: "com.moolah.api-keys"` literal to `KeychainServices.apiKeys`.
+- Closes the two remaining vectors that let a Development build mutate state a Production build reads. Mirrors the existing file-system split under `Application Support/<env>/`.
+
+Spec: `plans/2026-05-12-env-scoped-prefs-and-keychain-design.md`.
+Plan: `plans/2026-05-12-env-scoped-prefs-and-keychain-plan.md`.
+
+Clean-break: existing Production users will reset cosmetic prefs (last analysis filters, sync progress timestamps) and re-enter API keys on first launch of the new build. All migration-gate flags re-run idempotently per the audit in the plan.
+
+## Test plan
+- [ ] `just test` clean on both `MoolahTests_iOS` and `MoolahTests_macOS`.
+- [ ] `just format-check` clean.
+- [ ] Manual Development-build smoke: app launches, profile creation works, API-key entry round-trips through the new env-scoped keychain row.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+After the PR opens, follow the project's merge-queue convention — add it to the queue rather than merging manually.
+
+---
+
+## Self-Review Notes (in-plan)
+
+**Spec coverage:**
+
+| Spec section | Covered by |
+|---|---|
+| `UserDefaults.moolahShared` helper | Task 1 |
+| `KeychainServices.apiKeys` helper | Task 2 |
+| Defaults swap (8 files) | Task 4 |
+| Keychain swap (3 files, 4 sites) | Task 5 |
+| Idempotency audit per migration runner | Task 3 (sign-off) + plan-level audit table |
+| New tests for both helpers | Task 1 + Task 2 |
+| `ValuationModeMigration` call-site rewire | Task 4 Step 3 |
+| Verify legacy plist / keychain rows are abandoned (no cleanup runner) | Task 6 Step 1 + Step 2 grep guards |
+| Clean-break consequences for Production users | Task 6 Step 4 manual smoke |
+
+**Placeholder scan:** No "TBD", "implement later", or unspecified test bodies — every code step has full code or a precise diff.
+
+**Type consistency:** `moolahShared` (let) and `sharedSuite(for:)` (func) match across all four references; `apiKeys` (var) and `apiKeysService(for:)` (func) match across all five references.


### PR DESCRIPTION
## Summary

Closes the two remaining vectors that let a Development build mutate state a Production build reads. Mirrors the existing file-system split under `Application Support/<env>/` and the CloudKit container split per build config.

- **UserDefaults**: production callers now default to `UserDefaults.moolahShared` instead of `.standard`. Suite name is `rocks.moolah.app.<env>` (lowercased) so Development and Production builds back to physically separate plists under `~/Library/Preferences/`.
- **Keychain**: API-key rows (CoinGecko + Alchemy) now use `service: KeychainServices.apiKeys`. Production writes `com.moolah.api-keys.production`; Development writes `com.moolah.api-keys.development`. iCloud-Keychain `synchronizable: true` flag is preserved, so a user's API key still replicates across their devices — just to a different `(service, account)` row.

Spec: [`plans/2026-05-12-env-scoped-prefs-and-keychain-design.md`](https://github.com/ajsutton/moolah-native/blob/worktree-env-scoped-prefs-and-keychain/plans/2026-05-12-env-scoped-prefs-and-keychain-design.md).
Plan: [`plans/2026-05-12-env-scoped-prefs-and-keychain-plan.md`](https://github.com/ajsutton/moolah-native/blob/worktree-env-scoped-prefs-and-keychain/plans/2026-05-12-env-scoped-prefs-and-keychain-plan.md).

## Clean-break consequences for existing Production users

On first launch of the new Production build:

- AnalysisStore last-used date/range falls back to defaults (cosmetic).
- SyncProgress "last received" timestamp resets; sidebar footer shows empty until next sync round-trip.
- Migration-gate flags (`SwiftDataToGRDBMigrator`, `SharedRegistryUnionRunner`, `ValuationModeMigration`, `cleanupLegacyRateCachesOnce`, `LegacyZoneCleanup`) re-run idempotently per Task 3's audit — all use `INSERT OR IGNORE`, `ON CONFLICT(pk) DO UPDATE`, or no-op-on-already-done patterns.
- Active profile id (`ProfileStore.activeProfileID`) resets — user lands on the welcome screen on first launch, picks a profile again. **Most user-visible impact**.
- API keys (CoinGecko, Alchemy) reset; user must paste once in Settings → Crypto.

Legacy `UserDefaults.standard` plist and legacy `com.moolah.api-keys` keychain rows are left orphaned in place — both builds simply stop reading them. A future release can add a one-shot cleanup runner once we're confident no one's downgrading.

Note: `CKSyncEngine` state already lives in a file under `URL.moolahScopedApplicationSupport` (already env-scoped), so engine state is unaffected by this swap.

## Test plan

- [x] `just test` clean on both `MoolahTests_iOS` and `MoolahTests_macOS` (2781/2781).
- [x] `just format-check` clean.
- [x] Project-wide grep for `= .standard` / `= UserDefaults.standard` in `App` / `Backends` / `Features` / `Shared`: zero hits.
- [x] Project-wide grep for `com.moolah.api-keys"` in `App` / `Backends` / `Features`: zero hits.
- [x] `.swiftlint-baseline.yml` untouched.
- [ ] Manual smoke against a Development build: app launches into welcome screen; create a profile; paste a dummy CoinGecko / Alchemy key in Settings → Crypto; relaunch and confirm the key restores. Optional: open `Keychain Access.app` and search for `com.moolah.api-keys.development` to visually verify the env-suffixed row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)