### PR TITLE
fix(stores): swallow CancellationError on .task-driven loads

### DIFF
--- a/Features/Analysis/AnalysisStore.swift
+++ b/Features/Analysis/AnalysisStore.swift
@@ -114,6 +114,16 @@ final class AnalysisStore {
       cachedHistoryMonths = historyMonths
       cachedForecastMonths = forecastMonths
       lastLoadedAt = Date()
+    } catch is CancellationError {
+      // View teardown / supersession — `AnalysisView`'s `.task` modifier
+      // is routinely cancelled during cold-launch state restoration and
+      // when navigating between sidebar items. The repository awaits
+      // rethrow `CancellationError` per their documented contract;
+      // surfacing it would render "Swift.CancellationError error 1" in
+      // the view, which sticks because the store outlives the view.
+      // A re-mount issues its own `loadAll()`.
+      isLoading = false
+      return
     } catch {
       logger.error("Failed to load analysis data: \(error)")
       self.error = error

--- a/Features/Auth/AuthStore.swift
+++ b/Features/Auth/AuthStore.swift
@@ -29,6 +29,11 @@ final class AuthStore {
       } else {
         state = .signedOut
       }
+    } catch is CancellationError {
+      // `.task`-driven load can be cancelled by view teardown; leave the
+      // existing `state` / `errorMessage` untouched so a re-mount can
+      // issue its own load.
+      return
     } catch {
       state = .signedOut
       errorMessage = error.localizedDescription
@@ -40,6 +45,8 @@ final class AuthStore {
       let user = try await backend.auth.signIn()
       state = .signedIn(user)
       errorMessage = nil
+    } catch is CancellationError {
+      return
     } catch {
       state = .signedOut
       errorMessage = error.localizedDescription
@@ -51,6 +58,8 @@ final class AuthStore {
       try await backend.auth.signOut()
       state = .signedOut
       errorMessage = nil
+    } catch is CancellationError {
+      return
     } catch {
       state = .signedOut
       errorMessage = error.localizedDescription

--- a/Features/Earmarks/EarmarkStore+Budget.swift
+++ b/Features/Earmarks/EarmarkStore+Budget.swift
@@ -12,6 +12,13 @@ extension EarmarkStore {
 
     do {
       budgetItems = try await repository.fetchBudget(earmarkId: earmarkId)
+    } catch is CancellationError {
+      // `EarmarkBudgetSectionView`'s `.task(id: earmark.id)` is cancelled
+      // when the user switches to a different earmark mid-fetch; the
+      // repository await rethrows `CancellationError`. Never surface —
+      // the re-keyed `.task` issues its own `loadBudget`.
+      isBudgetLoading = false
+      return
     } catch {
       logger.error("Failed to load budget: \(error.localizedDescription)")
       budgetError = error

--- a/Features/Reports/ReportingStore.swift
+++ b/Features/Reports/ReportingStore.swift
@@ -54,6 +54,15 @@ final class ReportingStore {
       )
       incomeBalances = result.income
       expenseBalances = result.expense
+    } catch is CancellationError {
+      // `ReportsView`'s `.task(id:)` is cancelled whenever the user
+      // changes the date range or navigates away; the cancellation
+      // propagates as `CancellationError` from the repository. Treat
+      // it as a normal lifecycle event — surfacing it would render
+      // "Swift.CancellationError error 1" in the view. A re-mount /
+      // re-keyed `.task` issues its own load.
+      isLoadingCategoryBalances = false
+      return
     } catch {
       logger.error("Failed to load category balances: \(error)")
       categoryBalancesError = error
@@ -72,6 +81,11 @@ final class ReportingStore {
         conversionService: conversionService,
         asOfDate: Date()
       )
+    } catch is CancellationError {
+      // View teardown / supersession — never surface; the next mount
+      // issues its own load.
+      isLoading = false
+      return
     } catch {
       logger.error("Failed to load P&L: \(error)")
       self.error = error
@@ -112,6 +126,11 @@ final class ReportingStore {
         totalGain: result.totalRealizedGain,
         eventCount: result.events.count
       )
+    } catch is CancellationError {
+      // View teardown / supersession — never surface; the next mount
+      // issues its own load.
+      isLoading = false
+      return
     } catch {
       logger.error("Failed to load capital gains: \(error)")
       self.error = error

--- a/Features/Settings/CryptoTokenStore.swift
+++ b/Features/Settings/CryptoTokenStore.swift
@@ -203,6 +203,10 @@ final class CryptoTokenStore {
         uniquingKeysWith: { _, last in last }
       )
       error = nil
+    } catch is CancellationError {
+      // `.task`-driven load cancelled by view teardown — never surface;
+      // a re-mount issues its own `loadRegistrations`.
+      return
     } catch {
       logger.error(
         "Failed to load crypto registrations: \(error, privacy: .public)")

--- a/MoolahTests/Features/AnalysisStoreLoadCancellationTests.swift
+++ b/MoolahTests/Features/AnalysisStoreLoadCancellationTests.swift
@@ -1,0 +1,41 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("AnalysisStore — load cancellation")
+@MainActor
+struct AnalysisStoreLoadCancellationTests {
+
+  private func makeDefaults() throws -> UserDefaults {
+    let suiteName = "com.moolah.test.\(UUID().uuidString)"
+    let defaults = try #require(UserDefaults(suiteName: suiteName))
+    defaults.removePersistentDomain(forName: suiteName)
+    return defaults
+  }
+
+  /// A `loadAll()` cancelled mid-fetch must NOT surface
+  /// `CancellationError` on `store.error`. `AnalysisView`'s `.task` is
+  /// routinely cancelled during cold-launch state restoration and when
+  /// navigating between sidebar items. Because `AnalysisStore` is owned
+  /// by `ProfileSession`, a leaked `CancellationError` persists past
+  /// the view tear-down and renders "Swift.CancellationError error 1"
+  /// on the next mount.
+  @Test
+  func cancelledLoadAllDoesNotSurfaceCancellationError() async throws {
+    let repository = GatedAnalysisRepository()
+    let store = AnalysisStore(
+      repository: repository, defaults: try makeDefaults())
+
+    let task = Task { @MainActor in
+      await store.loadAll()
+    }
+    await repository.waitUntilFetchStarted()
+    task.cancel()
+    await repository.releaseFetch()
+    await task.value
+
+    #expect(store.error == nil)
+    #expect(!store.isLoading)
+  }
+}

--- a/MoolahTests/Features/ReportingStoreLoadCancellationTests.swift
+++ b/MoolahTests/Features/ReportingStoreLoadCancellationTests.swift
@@ -1,0 +1,37 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("ReportingStore — load cancellation")
+@MainActor
+struct ReportingStoreLoadCancellationTests {
+
+  /// `loadCategoryBalances` cancelled mid-fetch must NOT surface
+  /// `CancellationError` on `categoryBalancesError`. `ReportsView`'s
+  /// `.task(id:)` is cancelled whenever the user switches date ranges;
+  /// leaking the cancellation rendered "Swift.CancellationError error 1"
+  /// where the report should be.
+  @Test
+  func cancelledLoadCategoryBalancesDoesNotSurfaceCancellationError() async throws {
+    let analysisRepository = GatedAnalysisRepository()
+    let store = ReportingStore(
+      transactionRepository: FailingTransactionRepository(),
+      analysisRepository: analysisRepository,
+      conversionService: FixedConversionService(),
+      profileCurrency: .defaultTestInstrument
+    )
+
+    let dateRange = Date().addingTimeInterval(-86_400)...Date()
+    let task = Task { @MainActor in
+      await store.loadCategoryBalances(dateRange: dateRange)
+    }
+    await analysisRepository.waitUntilFetchStarted()
+    task.cancel()
+    await analysisRepository.releaseFetch()
+    await task.value
+
+    #expect(store.categoryBalancesError == nil)
+    #expect(!store.isLoadingCategoryBalances)
+  }
+}

--- a/MoolahTests/Support/GatedAnalysisRepository.swift
+++ b/MoolahTests/Support/GatedAnalysisRepository.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+@testable import Moolah
+
+/// Test double for `AnalysisRepository` that suspends every async method
+/// inside an internal gate, giving tests a deterministic window in which
+/// to cancel the surrounding `Task` before letting the gated method
+/// resume. After release, the method calls `Task.checkCancellation()` so
+/// it throws `CancellationError` exactly the way the production GRDB
+/// repositories do (e.g. `GRDBAnalysisRepository+DailyBalances.swift`,
+/// which rethrows cancellation per its documented contract).
+///
+/// Used by the `*LoadCancellationTests` suites to prove a `.task`
+/// modifier's cancellation never surfaces as a user-facing error.
+actor GatedAnalysisRepository: AnalysisRepository {
+  private let fetchStarted = AsyncGate()
+  private let fetchRelease = AsyncGate()
+
+  /// Resolves once at least one repository method has reached the gate.
+  func waitUntilFetchStarted() async {
+    await fetchStarted.wait()
+  }
+
+  /// Wakes every gated waiter. Resumed methods re-check task
+  /// cancellation and rethrow `CancellationError` if applicable.
+  func releaseFetch() async {
+    await fetchRelease.open()
+  }
+
+  private func gateThenCancelCheck() async throws {
+    await fetchStarted.open()
+    await fetchRelease.wait()
+    try Task.checkCancellation()
+  }
+
+  func fetchDailyBalances(
+    after: Date?, forecastUntil: Date?
+  ) async throws -> [DailyBalance] {
+    try await gateThenCancelCheck()
+    return []
+  }
+
+  func fetchExpenseBreakdown(
+    monthEnd: Int, after: Date?
+  ) async throws -> [ExpenseBreakdown] {
+    try await gateThenCancelCheck()
+    return []
+  }
+
+  func fetchIncomeAndExpense(
+    monthEnd: Int, after: Date?
+  ) async throws -> [MonthlyIncomeExpense] {
+    try await gateThenCancelCheck()
+    return []
+  }
+
+  func fetchCategoryBalances(
+    dateRange: ClosedRange<Date>,
+    transactionType: TransactionType,
+    filters: TransactionFilter?,
+    targetInstrument: Instrument
+  ) async throws -> [UUID: InstrumentAmount] {
+    try await gateThenCancelCheck()
+    return [:]
+  }
+}


### PR DESCRIPTION
## Summary
- `AnalysisStore.loadAll()` caught every error generically and stored it on `self.error`, including `CancellationError`. SwiftUI cancels `.task` modifiers routinely (cold-launch state restoration, sidebar navigation), the GRDB analysis repositories rethrow `CancellationError` per their contract, and the store outlives the view — so the error stuck and rendered \"The operation couldn't be completed. (Swift.CancellationError error 1.)\" on the next mount.
- Fixed the same pattern in five other view-driven loaders (`ReportingStore.loadCategoryBalances/loadProfitLoss/loadCapitalGains`, `EarmarkStore.loadBudget`, `AuthStore.load/signIn/signOut`, `CryptoTokenStore.loadRegistrations`). Each now mirrors the `TransactionStore+Observation` pattern: `catch is CancellationError` swallows silently and lets the next mount issue its own load.
- Added a `GatedAnalysisRepository` test double and two regression tests modelled on `TransactionStoreLoadRaceTests.cancelledLoadDoesNotSurfaceCancellationError`.

The pre-existing comment at `App/MoolahApp.swift:170-175` referencing \"the Analysis view with a CancellationError\" acknowledged this bug — it worked around the UI-test side effect (stale window restoration) without fixing the underlying surface.

## Test plan
- [x] `just test` (2755 tests / 458 suites, mac + iOS) — green.
- [x] `just format-check` — clean.
- [x] New `AnalysisStoreLoadCancellationTests.cancelledLoadAllDoesNotSurfaceCancellationError` — passes.
- [x] New `ReportingStoreLoadCancellationTests.cancelledLoadCategoryBalancesDoesNotSurfaceCancellationError` — passes.
- [x] Existing `AnalysisStore*` / `ReportingStore*` / `AuthStoreTests` suites — unchanged behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)