### PR TITLE
fix(tests): widen PRAGMA optimize tick timeouts for slow CI

### DIFF
--- a/MoolahTests/App/ProfileSessionPragmaOptimizeTests.swift
+++ b/MoolahTests/App/ProfileSessionPragmaOptimizeTests.swift
@@ -39,8 +39,11 @@ struct ProfileSessionPragmaOptimizeTests {
 
     session.startPeriodicPragmaOptimize(interval: .milliseconds(20))
 
-    // Wait long enough for at least three ticks to fire.
-    try await waitUntil(timeout: .seconds(2)) {
+    // Wait long enough for at least three ticks to fire. Timeout is
+    // generous because heavily-loaded CI (iOS Simulator under merge-queue
+    // contention) can drag the 20 ms cadence into seconds-range; we only
+    // need *eventually*-fires, not tight cadence (#884).
+    try await waitUntil(timeout: .seconds(10)) {
       session.pragmaOptimizeRunCount >= baseline + 3
     }
 
@@ -63,7 +66,7 @@ struct ProfileSessionPragmaOptimizeTests {
     // takes effect.
     session.startPeriodicPragmaOptimize(interval: .milliseconds(20))
 
-    try await waitUntil(timeout: .seconds(2)) {
+    try await waitUntil(timeout: .seconds(10)) {
       session.pragmaOptimizeRunCount >= baselineAfterFirstStart + 2
     }
 
@@ -84,7 +87,7 @@ struct ProfileSessionPragmaOptimizeTests {
     session.startPeriodicPragmaOptimize(interval: .milliseconds(20))
 
     // Let it fire at least once so we know the loop is running.
-    try await waitUntil(timeout: .seconds(2)) {
+    try await waitUntil(timeout: .seconds(10)) {
       session.pragmaOptimizeRunCount >= 1
     }
 


### PR DESCRIPTION
## Summary

- Three tests in `ProfileSessionPragmaOptimizeTests` drive the periodic
  PRAGMA-optimize tick with a 20 ms interval and wait up to 2 s for it to fire
  a handful of times. On a heavily-loaded iOS Simulator runner (merge-queue
  speculative CI) the scheduler can drag that cadence into the seconds range,
  occasionally timing the wait out — observed in [PR #883's queue run](https://github.com/ajsutton/moolah-native/actions/runs/25849849395).
- Widen the deadlines to 10 s in all three periodic-tick tests. We're still
  pinning *eventually*-fires semantics, not tight cadence — locally the tests
  pass in ~0.1 s on both macOS and iOS Simulator either way.

Fixes #884

## Test plan
- [x] `just test ProfileSessionPragmaOptimizeTests` passes on both macOS and iOS Simulator (~0.1 s per test)
- [x] `just format-check` clean
- [ ] CI green on the PR