### PR TITLE
fix(export): make Import/Export Profile work with no windows open

### DIFF
--- a/Features/Export/ExportImportButtons.swift
+++ b/Features/Export/ExportImportButtons.swift
@@ -31,18 +31,12 @@
 
     @MainActor
     private func exportProfile(session: ProfileSession) async {
-      guard let window = NSApp.keyWindow ?? NSApp.mainWindow else {
-        logger.error("Export: no window available")
-        return
-      }
-
       let panel = NSSavePanel()
       panel.allowedContentTypes = [.json]
       panel.nameFieldStringValue = "\(session.profile.label).json"
       panel.canCreateDirectories = true
 
-      let result = await panel.beginSheetModal(for: window)
-      guard result == .OK, let url = panel.url else { return }
+      guard await present(panel) == .OK, let url = panel.url else { return }
 
       logger.info("Export: saving to \(url.path, privacy: .public)")
       session.activeExport = ActiveExport(
@@ -63,24 +57,18 @@
         logger.info("Export: complete — saved to \(url.path, privacy: .public)")
       } catch {
         logger.error("Export: failed — \(error)")
-        let alert = NSAlert(error: error)
-        await alert.beginSheetModal(for: window)
+        await present(NSAlert(error: error))
       }
     }
 
     @MainActor
     private func importProfile() async {
-      guard let window = NSApp.keyWindow ?? NSApp.mainWindow else {
-        logger.error("Import: no window available")
-        return
-      }
-
       let panel = NSOpenPanel()
       panel.allowedContentTypes = [.json]
       panel.allowsMultipleSelection = false
       panel.canChooseDirectories = false
 
-      guard await panel.beginSheetModal(for: window) == .OK, let url = panel.url else { return }
+      guard await present(panel) == .OK, let url = panel.url else { return }
 
       do {
         let coordinator = ExportCoordinator()
@@ -92,8 +80,29 @@
         )
         openWindow(value: newProfileId)
       } catch {
-        let alert = NSAlert(error: error)
-        await alert.beginSheetModal(for: window)
+        await present(NSAlert(error: error))
+      }
+    }
+
+    /// Presents `panel` as a sheet on the current key/main window, or as a
+    /// free-floating modal when no window is open (e.g. the user invoked the
+    /// menu item with every profile window closed). `beginSheetModal(for:)`
+    /// silently no-ops without a parent window, so the fallback is required
+    /// for the menu items to function in that state.
+    @MainActor
+    private func present(_ panel: NSSavePanel) async -> NSApplication.ModalResponse {
+      if let window = NSApp.keyWindow ?? NSApp.mainWindow {
+        return await panel.beginSheetModal(for: window)
+      }
+      return panel.runModal()
+    }
+
+    @MainActor
+    private func present(_ alert: NSAlert) async {
+      if let window = NSApp.keyWindow ?? NSApp.mainWindow {
+        _ = await alert.beginSheetModal(for: window)
+      } else {
+        alert.runModal()
       }
     }
   }


### PR DESCRIPTION
## Summary

- `File > Import Profile…` and `File > Export Profile…` silently no-op when the user closes every profile window — the menu items stay active, but `NSApp.keyWindow` and `NSApp.mainWindow` are both `nil`, so the upfront guard bails before the file panel is presented.
- Drop the guard and route panels and error alerts through a `present(_:)` helper that uses `beginSheetModal(for:)` when a window exists and falls back to `runModal()` otherwise.
- Successful import still calls `openWindow(value: newProfileId)`, so the new profile's window opens automatically after a window-less import.

## Test plan

- [ ] Launch the app; close every profile/settings window so only the menu bar remains.
- [ ] File > Import Profile… → open panel appears as a free-floating modal; pick a previously-exported `.json`; verify the new profile window opens automatically when import completes.
- [ ] With a session active but its window closed, File > Export Profile… → save panel appears; verify export succeeds.
- [ ] With a profile window open, repeat both menu items and confirm the panel still attaches as a sheet (no regression).
- [ ] Trigger an import failure (e.g. pick a non-Moolah JSON) with no windows open → error alert appears and dismisses cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)