### PR TITLE
perf(csv-import): persist all rows in a single atomic transaction

### DIFF
--- a/Backends/GRDB/Repositories/GRDBTransactionRepository+CreateMany.swift
+++ b/Backends/GRDB/Repositories/GRDBTransactionRepository+CreateMany.swift
@@ -1,0 +1,59 @@
+// Backends/GRDB/Repositories/GRDBTransactionRepository+CreateMany.swift
+
+import Foundation
+import GRDB
+
+extension GRDBTransactionRepository {
+  // MARK: - Bulk create pipeline
+
+  /// Bundle returned by `performCreateMany`'s write block: every
+  /// inserted leg id (flat, input order) and every non-fiat instrument
+  /// that `ensureInstrumentReadable` had to auto-insert across the
+  /// whole batch (deduped, first-seen wins). Mirrors the per-row
+  /// `CreateOutcome` so the post-commit hook fan-out runs the same
+  /// way regardless of batch size.
+  struct BulkCreateOutcome: Sendable {
+    let legIds: [UUID]
+    let instruments: [Instrument]
+  }
+
+  /// Inserts every transaction header and its legs inside one
+  /// `database.write { … }` transaction. On any throw the whole batch
+  /// rolls back; the caller in the main file fires `onRecordChanged` /
+  /// `onInstrumentChanged` only after the write commits — see
+  /// `GRDBTransactionRepository.createMany(_:)`.
+  static func performCreateMany(
+    database: Database,
+    transactions: [Transaction]
+  ) throws -> BulkCreateOutcome {
+    var legIds: [UUID] = []
+    legIds.reserveCapacity(transactions.reduce(0) { $0 + $1.legs.count })
+    var insertedInstruments: [Instrument] = []
+    var seenInstrumentIds: Set<String> = []
+
+    for transaction in transactions {
+      let txnRow = TransactionRow(domain: transaction)
+      try txnRow.insert(database)
+
+      for (index, leg) in transaction.legs.enumerated() {
+        // `ensureInstrumentReadable` is deduped per-batch — a non-fiat
+        // instrument referenced by N legs across N transactions still
+        // surfaces exactly once to the shared-registry hook.
+        if let inserted = try Self.ensureInstrumentReadable(
+          database: database, leg: leg),
+          seenInstrumentIds.insert(inserted.id).inserted
+        {
+          insertedInstruments.append(inserted)
+        }
+        let legRow = TransactionLegRow(
+          id: leg.id,
+          domain: leg,
+          transactionId: transaction.id,
+          sortOrder: index)
+        try legRow.insert(database)
+        legIds.append(leg.id)
+      }
+    }
+    return BulkCreateOutcome(legIds: legIds, instruments: insertedInstruments)
+  }
+}

--- a/Backends/GRDB/Repositories/GRDBTransactionRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBTransactionRepository.swift
@@ -193,6 +193,23 @@ final class GRDBTransactionRepository: TransactionRepository, @unchecked Sendabl
     let instruments: [Instrument]
   }
 
+  func createMany(_ transactions: [Transaction]) async throws -> [Transaction] {
+    guard !transactions.isEmpty else { return [] }
+    let outcome = try await database.write { database -> BulkCreateOutcome in
+      try Self.performCreateMany(database: database, transactions: transactions)
+    }
+    for transaction in transactions {
+      onRecordChanged(TransactionRow.recordType, transaction.id)
+    }
+    for legId in outcome.legIds {
+      onRecordChanged(TransactionLegRow.recordType, legId)
+    }
+    for instrument in outcome.instruments {
+      onInstrumentChanged(instrument)
+    }
+    return transactions
+  }
+
   func update(_ transaction: Transaction) async throws -> Transaction {
     let outcome = try await database.write { database -> UpdateOutcome in
       try Self.performUpdate(

--- a/Domain/Repositories/TransactionRepository.swift
+++ b/Domain/Repositories/TransactionRepository.swift
@@ -37,6 +37,13 @@ protocol TransactionRepository: Sendable {
   /// typically surface this to a banner / log path.
   func observeErrors() -> AsyncStream<any Error>
   func create(_ transaction: Transaction) async throws -> Transaction
+  /// Atomic bulk insert. Inserts every transaction (with its legs) inside
+  /// a single write transaction; on any failure none of the transactions
+  /// persist. Returns the inserted transactions in input order. Change /
+  /// instrument hooks fire once per inserted row after the write commits,
+  /// matching the per-row fan-out of `create(_:)`. Used by the CSV import
+  /// pipeline so a half-written session can never be left on disk.
+  func createMany(_ transactions: [Transaction]) async throws -> [Transaction]
   func update(_ transaction: Transaction) async throws -> Transaction
   func delete(id: UUID) async throws
   /// Frequency-sorted payee strings beginning with `prefix`. When

--- a/Features/Import/ImportStore+Pipeline.swift
+++ b/Features/Import/ImportStore+Pipeline.swift
@@ -197,12 +197,19 @@ extension ImportStore {
   }
 
   /// Evaluate import rules against each surviving candidate and persist
-  /// the resulting transactions. Fetches every account once and builds a
-  /// `{ id → instrument }` map so `buildTransaction` can stamp each leg
-  /// with its own account's instrument — in particular the destination
-  /// leg of a `.markAsTransfer` rule, which may target an account in a
-  /// different instrument than the source (Rule 11a — never write a leg
-  /// with the wrong instrument).
+  /// the resulting transactions in a single atomic write. Fetches every
+  /// account once and builds a `{ id → instrument }` map so
+  /// `buildTransaction` can stamp each leg with its own account's
+  /// instrument — in particular the destination leg of a
+  /// `.markAsTransfer` rule, which may target an account in a different
+  /// instrument than the source (Rule 11a — never write a leg with the
+  /// wrong instrument).
+  ///
+  /// On any backend failure during the bulk insert, **no** transactions
+  /// from this session persist. A half-imported CSV is hard to reconcile
+  /// against on a retry — the dedup window would have to be narrowed
+  /// manually to skip the rows that did land. Failing the whole session
+  /// instead keeps re-running the same file safe.
   func persistCandidates(
     dedup: CSVDedupResult,
     resolvedProfile: CSVImportProfile,
@@ -226,28 +233,20 @@ extension ImportStore {
         "Account \(resolvedProfile.accountId) not found; cannot resolve its instrument.")
     }
 
-    var persisted: [Transaction] = []
-    for candidate in dedup.kept {
+    let buildContext = ImportBuildContext(
+      routedAccountId: resolvedProfile.accountId,
+      accountInstrument: routedInstrument,
+      accountInstruments: accountInstruments,
+      sessionId: sessionId,
+      source: source,
+      parserIdentifier: parserIdentifier)
+    let transactions: [Transaction] = dedup.kept.compactMap { candidate in
       let evaluation = ImportRulesEngine.evaluate(
         candidate, routedAccountId: resolvedProfile.accountId, rules: rules)
-      if evaluation.isSkipped { continue }
-      let transaction = buildTransaction(
-        from: evaluation,
-        context: ImportBuildContext(
-          routedAccountId: resolvedProfile.accountId,
-          accountInstrument: routedInstrument,
-          accountInstruments: accountInstruments,
-          sessionId: sessionId,
-          source: source,
-          parserIdentifier: parserIdentifier))
-      do {
-        persisted.append(try await backend.transactions.create(transaction))
-      } catch {
-        logger.error(
-          "Create failed for candidate at \(candidate.date): \(error.localizedDescription)")
-      }
+      if evaluation.isSkipped { return nil }
+      return buildTransaction(from: evaluation, context: buildContext)
     }
-    return persisted
+    return try await backend.transactions.createMany(transactions)
   }
 
   func touchProfileLastUsedAt(_ resolvedProfile: CSVImportProfile) async {

--- a/MoolahTests/Backends/GRDB/GRDBCreateManyTests.swift
+++ b/MoolahTests/Backends/GRDB/GRDBCreateManyTests.swift
@@ -1,0 +1,187 @@
+// MoolahTests/Backends/GRDB/GRDBCreateManyTests.swift
+
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+/// GRDB-specific contract for the bulk `createMany(_:)` path:
+///
+/// 1. Atomicity. A failure on any leg insert rolls back every header,
+///    every leg, and every auto-inserted instrument across the whole
+///    input array — leaving the DB byte-equal to the pre-call state.
+/// 2. Hook fan-out. After the write commits, `onRecordChanged` fires
+///    exactly once per transaction header and once per leg;
+///    `onInstrumentChanged` fires once per unique new instrument across
+///    the whole batch (regardless of how many legs reference it).
+///
+/// The per-row pattern is already covered by
+/// `CoreFinancialGraphRollbackTests.transactionCreateRollsBackOnLegFailure`
+/// and `TransactionHookUpdateDeleteTests`; this file pins the bulk path.
+@Suite("GRDBTransactionRepository.createMany — atomicity + hook fan-out")
+@MainActor
+struct GRDBCreateManyTests {
+
+  @MainActor
+  final class HookCapture {
+    var changed: [(recordType: String, id: UUID)] = []
+    var deleted: [(recordType: String, id: UUID)] = []
+    var instruments: [Instrument] = []
+  }
+
+  private func makeChangedHook(
+    _ capture: HookCapture
+  ) -> @Sendable (String, UUID) -> Void {
+    { recordType, id in
+      Task { @MainActor in
+        capture.changed.append((recordType, id))
+      }
+    }
+  }
+
+  private func makeDeletedHook(
+    _ capture: HookCapture
+  ) -> @Sendable (String, UUID) -> Void {
+    { recordType, id in
+      Task { @MainActor in
+        capture.deleted.append((recordType, id))
+      }
+    }
+  }
+
+  private func makeInstrumentHook(
+    _ capture: HookCapture
+  ) -> @Sendable (Instrument) -> Void {
+    { instrument in
+      Task { @MainActor in
+        capture.instruments.append(instrument)
+      }
+    }
+  }
+
+  private func drainHookHops() async throws {
+    try await Task.sleep(for: .milliseconds(50))
+  }
+
+  // MARK: - Atomicity
+
+  @Test("createMany rolls back every header + leg if any leg insert fails")
+  func createManyRollsBackOnLegFailure() async throws {
+    let database = try ProfileDatabase.openInMemory()
+    let txnRepo = GRDBTransactionRepository(
+      database: database,
+      defaultInstrument: .AUD,
+      conversionService: FixedConversionService())
+    let accountId = UUID()
+    let stub = Account(id: accountId, name: "Cash", type: .bank, instrument: .AUD)
+    try await database.write { database in
+      try AccountRow(domain: stub).insert(database)
+    }
+
+    // Trigger fires on any leg insert. The first transaction's first leg
+    // will trip it — the entire batch (including the headers of every
+    // subsequent transaction in the input array) must roll back.
+    try await database.write { database in
+      try database.execute(
+        sql: """
+          CREATE TRIGGER fail_create_many_leg
+          BEFORE INSERT ON transaction_leg
+          BEGIN
+              SELECT RAISE(ABORT, 'forced failure for rollback test');
+          END;
+          """)
+    }
+
+    let inputs = (0..<3).map { index in
+      Transaction(
+        date: Date(),
+        payee: "Payee \(index)",
+        legs: [
+          TransactionLeg(
+            accountId: accountId, instrument: .AUD,
+            quantity: Decimal(-(index + 1) * 10), type: .expense)
+        ])
+    }
+    do {
+      _ = try await txnRepo.createMany(inputs)
+      Issue.record("createMany should have thrown but did not")
+    } catch {
+      // Expected.
+    }
+
+    let txnRows = try await database.read { database in
+      try TransactionRow.fetchAll(database)
+    }
+    let legRows = try await database.read { database in
+      try TransactionLegRow.fetchAll(database)
+    }
+    #expect(txnRows.isEmpty)
+    #expect(legRows.isEmpty)
+  }
+
+  // MARK: - Hook fan-out
+
+  @Test("createMany fan-out: 1 hook per txn + 1 per leg + 1 per unique instrument")
+  func createManyHookFanOut() async throws {
+    let database = try ProfileDatabase.openInMemory()
+    let capture = HookCapture()
+    let txnRepo = GRDBTransactionRepository(
+      database: database,
+      defaultInstrument: .AUD,
+      conversionService: FixedConversionService(),
+      onRecordChanged: makeChangedHook(capture),
+      onRecordDeleted: makeDeletedHook(capture),
+      onInstrumentChanged: makeInstrumentHook(capture))
+    let accountId = UUID()
+    let stub = Account(id: accountId, name: "Cash", type: .bank, instrument: .AUD)
+    try await database.write { database in
+      try AccountRow(domain: stub).insert(database)
+    }
+
+    // Three transactions. The middle two reference a shared non-fiat
+    // instrument (BTC); the others are fiat. Expected hook fan-out:
+    //   - 3 TransactionRow change emits (one per header)
+    //   - 4 TransactionLegRow change emits (1 + 1 + 2)
+    //   - 1 onInstrumentChanged for BTC (shared between legs in txn 2 + txn 3)
+    let btc = Instrument.crypto(
+      chainId: 1, contractAddress: nil, symbol: "BTC", name: "Bitcoin", decimals: 8)
+    let inputs: [Transaction] = [
+      Transaction(
+        date: Date(), payee: "Coffee",
+        legs: [
+          TransactionLeg(
+            accountId: accountId, instrument: .AUD, quantity: -5, type: .expense)
+        ]),
+      Transaction(
+        date: Date(), payee: "BTC buy",
+        legs: [
+          TransactionLeg(
+            accountId: accountId, instrument: btc, quantity: 1, type: .income)
+        ]),
+      Transaction(
+        date: Date(), payee: "BTC swap",
+        legs: [
+          TransactionLeg(
+            accountId: accountId, instrument: btc, quantity: -1, type: .transfer),
+          TransactionLeg(
+            accountId: accountId, instrument: .AUD, quantity: 100, type: .transfer),
+        ]),
+    ]
+
+    _ = try await txnRepo.createMany(inputs)
+    try await drainHookHops()
+
+    let txnChanges = capture.changed.filter { $0.recordType == TransactionRow.recordType }
+    #expect(txnChanges.map(\.id) == inputs.map(\.id))
+    let legChanges = capture.changed.filter { $0.recordType == TransactionLegRow.recordType }
+    let expectedLegIds = inputs.flatMap { $0.legs.map(\.id) }
+    #expect(Set(legChanges.map(\.id)) == Set(expectedLegIds))
+    #expect(legChanges.count == expectedLegIds.count)
+    #expect(capture.deleted.isEmpty)
+    // Exactly one instrument-change emit for BTC across the whole batch
+    // even though two separate transactions reference it.
+    #expect(capture.instruments.count == 1)
+    #expect(capture.instruments.first?.id == btc.id)
+  }
+}

--- a/MoolahTests/Domain/CreateManyContractTests.swift
+++ b/MoolahTests/Domain/CreateManyContractTests.swift
@@ -1,0 +1,65 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+/// Contract tests for the `createMany(_:)` bulk-insert path on
+/// `TransactionRepository`. Insertion is atomic: every input transaction
+/// and its legs persist together, or — on any failure — none of them do.
+/// Used by the CSV import pipeline.
+@Suite("TransactionRepository — createMany contract")
+struct CreateManyContractTests {
+
+  @Test("createMany persists every transaction and its legs")
+  func createManyPersistsEverything() async throws {
+    let repository = try makeContractCloudKitTransactionRepository()
+    let accountId = UUID()
+    let inputs = (0..<5).map { index in
+      Transaction(
+        date: Date(),
+        payee: "Payee \(index)",
+        legs: [
+          makeContractTestLeg(
+            accountId: accountId,
+            quantity: Decimal(-(index + 1) * 10),
+            type: .expense)
+        ])
+    }
+
+    let created = try await repository.createMany(inputs)
+
+    #expect(created.count == inputs.count)
+    #expect(created.map(\.id) == inputs.map(\.id))
+    let fetched = try await repository.fetchAll(
+      filter: TransactionFilter(accountId: accountId))
+    let fetchedIds = Set(fetched.map(\.id))
+    let inputIds = Set(inputs.map(\.id))
+    #expect(fetchedIds == inputIds)
+    #expect(fetched.allSatisfy { $0.legs.count == 1 })
+  }
+
+  @Test("createMany with empty input is a no-op and returns []")
+  func createManyEmptyIsNoop() async throws {
+    let repository = try makeContractCloudKitTransactionRepository()
+    let result = try await repository.createMany([])
+    #expect(result.isEmpty)
+  }
+
+  @Test("createMany returns the transactions in input order")
+  func createManyPreservesInputOrder() async throws {
+    let repository = try makeContractCloudKitTransactionRepository()
+    let accountId = UUID()
+    let inputs = ["A", "B", "C", "D"].map { payee in
+      Transaction(
+        date: Date(), payee: payee,
+        legs: [
+          makeContractTestLeg(accountId: accountId, quantity: -1, type: .expense)
+        ])
+    }
+
+    let created = try await repository.createMany(inputs)
+
+    #expect(created.map(\.payee) == ["A", "B", "C", "D"])
+    #expect(created.map(\.id) == inputs.map(\.id))
+  }
+}

--- a/MoolahTests/Features/Import/ImportStoreAtomicityTests.swift
+++ b/MoolahTests/Features/Import/ImportStoreAtomicityTests.swift
@@ -1,0 +1,83 @@
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+/// All-or-nothing contract for `ImportStore.ingest(_:source:)`. The CSV
+/// pipeline persists every surviving candidate in a single bulk write
+/// (`TransactionRepository.createMany`); a failure mid-write must roll
+/// back so the user can simply re-run the same file. A half-written
+/// session is hard to reconcile against on retry — the dedup window
+/// would have to be narrowed manually to skip the rows that did land.
+@Suite("ImportStore — atomic ingest")
+@MainActor
+struct ImportStoreAtomicityTests {
+
+  private func tempStagingDirectory() -> URL {
+    FileManager.default.temporaryDirectory
+      .appendingPathComponent("import-store-\(UUID().uuidString)", isDirectory: true)
+  }
+
+  private func makeStore(
+    backend: any BackendProvider
+  ) throws -> (ImportStore, URL) {
+    let dir = tempStagingDirectory()
+    let staging = try ImportStagingStore(directory: dir)
+    return (ImportStore(backend: backend, staging: staging), dir)
+  }
+
+  @Test("ingest fails atomically when the bulk insert throws — no rows land")
+  func ingestFailsAtomically() async throws {
+    let (backend, database) = try TestBackend.create()
+    let accountId = UUID()
+    _ = try await backend.accounts.create(
+      Account(
+        id: accountId, name: "Cash", type: .bank, instrument: .AUD,
+        positions: [], position: 0, isHidden: false),
+      openingBalance: nil)
+    _ = try await backend.csvImportProfiles.create(
+      CSVImportProfile(
+        accountId: accountId,
+        parserIdentifier: "generic-bank",
+        headerSignature: ["date", "description", "debit", "credit", "balance"]))
+
+    // ABORT trigger on `transaction_leg` insert — the bulk-insert path
+    // builds N transactions and inserts their legs in one write block;
+    // the trigger fires on the first leg insert and the whole write
+    // transaction must roll back. Installed AFTER profile / account
+    // seeding so those upstream inserts are not disturbed.
+    try await database.write { database in
+      try database.execute(
+        sql: """
+          CREATE TRIGGER fail_import_legs
+          BEFORE INSERT ON transaction_leg
+          BEGIN
+              SELECT RAISE(ABORT, 'forced failure for rollback test');
+          END;
+          """)
+    }
+
+    let (store, dir) = try makeStore(backend: backend)
+    defer { try? FileManager.default.removeItem(at: dir) }
+
+    let data = try CSVFixtureLoader.data("cba-everyday-standard")
+    let result = await store.ingest(
+      data: data,
+      source: .pickedFile(url: URL(fileURLWithPath: "/tmp/cba.csv"), securityScoped: false))
+
+    // The fixture would land 4 transactions on the happy path. Under
+    // the failing trigger we expect `.failed` and an empty backend.
+    guard case .failed = result else {
+      Issue.record("expected .failed but got \(result)")
+      return
+    }
+    let page = try await backend.transactions.fetch(
+      filter: TransactionFilter(accountId: accountId), page: 0, pageSize: 50)
+    #expect(page.transactions.isEmpty)
+    let allLegs = try await database.read { database in
+      try TransactionLegRow.fetchAll(database)
+    }
+    #expect(allLegs.isEmpty)
+  }
+}

--- a/MoolahTests/Features/TransactionStoreLoadRaceTests.swift
+++ b/MoolahTests/Features/TransactionStoreLoadRaceTests.swift
@@ -239,6 +239,7 @@ actor FirstFetchGatedTransactionRepository: TransactionRepository {
     AsyncStream { $0.finish() }
   }
   func create(_ transaction: Transaction) async throws -> Transaction { transaction }
+  func createMany(_ transactions: [Transaction]) async throws -> [Transaction] { transactions }
   func update(_ transaction: Transaction) async throws -> Transaction { transaction }
   func delete(id: UUID) async throws {}
   func fetchPayeeSuggestions(

--- a/MoolahTests/Shared/CryptoImport/RecordingTransactionRepository.swift
+++ b/MoolahTests/Shared/CryptoImport/RecordingTransactionRepository.swift
@@ -46,6 +46,10 @@ actor RecordingTransactionRepository: TransactionRepository {
     try await wrapped.create(transaction)
   }
 
+  func createMany(_ transactions: [Transaction]) async throws -> [Transaction] {
+    try await wrapped.createMany(transactions)
+  }
+
   func update(_ transaction: Transaction) async throws -> Transaction {
     try await wrapped.update(transaction)
   }

--- a/MoolahTests/Support/CancellablePagingTransactionRepository.swift
+++ b/MoolahTests/Support/CancellablePagingTransactionRepository.swift
@@ -66,6 +66,7 @@ actor CancellablePagingTransactionRepository: TransactionRepository {
     AsyncStream { $0.finish() }
   }
   func create(_ transaction: Transaction) async throws -> Transaction { transaction }
+  func createMany(_ transactions: [Transaction]) async throws -> [Transaction] { transactions }
   func update(_ transaction: Transaction) async throws -> Transaction { transaction }
   func delete(id: UUID) async throws {}
   func fetchPayeeSuggestions(

--- a/MoolahTests/Support/TransactionStoreTestSupport.swift
+++ b/MoolahTests/Support/TransactionStoreTestSupport.swift
@@ -179,6 +179,10 @@ struct FailingTransactionRepository: TransactionRepository {
     throw BackendError.networkUnavailable
   }
 
+  func createMany(_ transactions: [Transaction]) async throws -> [Transaction] {
+    throw BackendError.networkUnavailable
+  }
+
   func update(_ transaction: Transaction) async throws -> Transaction {
     throw BackendError.networkUnavailable
   }


### PR DESCRIPTION
## Summary

- CSV import was visibly slow on large files — main thread held one row at a time while the sync engine churned. Root cause: `ImportStore.persistCandidates` awaited `backend.transactions.create(...)` per row, opening a fresh `database.write { … }` per row and triggering a sync-engine batch-build cycle on the main thread between every insert.
- Adds `TransactionRepository.createMany(_:)` — atomic bulk insert in a single `database.write`. On any failure **no** rows persist, so a re-run is safe (no half-imported state to reconcile against).
- Updates `ImportStore.persistCandidates` to build all `Transaction` values up front and call `createMany` once. Best-effort per-row logging is gone — a failure now propagates to `.failed(message:)` and the user can retry the same file.

## Why atomic (not best-effort)

A partial import is harder to recover from than a clean failure: the dedup window would have to be narrowed by hand to skip the rows that already landed. Re-running the same file after a failed atomic ingest is safe by construction.

## Test plan

- [x] `just format-check` clean
- [x] `just test-mac` — all 2761 tests pass, including the four new ones:
  - `TransactionRepository — createMany contract` (protocol-level contract: every txn + legs persists, empty input is a no-op, input order preserved)
  - `GRDBTransactionRepository.createMany — atomicity + hook fan-out` (rolls back the whole batch on leg-insert failure; `onRecordChanged` fires once per txn + once per leg; `onInstrumentChanged` deduped across the whole batch)
  - `ImportStore — atomic ingest` (an SQLite ABORT trigger on `transaction_leg` insert → ingest returns `.failed` and zero transactions / legs land)

## Follow-up

There is a separate sync-engine pathology that the same import session surfaced — `SyncCoordinator.handleMissingRecordToSave` does an O(N) `contains()` scan and a synchronous-queue hop **per missing record on the main thread**, which becomes O(N²) when the pending queue is large (e.g. left over from a deleted profile that hadn't finished uploading). That will land as a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)