### PR TITLE
perf(sync): batch missing-record-to-delete path off main-thread O(N²)

### DIFF
--- a/Backends/CloudKit/Sync/SyncCoordinator+Delegate.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+Delegate.swift
@@ -249,21 +249,22 @@ extension SyncCoordinator: CKSyncEngineDelegate {
   }
 
   /// Looks up each profile-index record by ID and either appends it to
-  /// `recordsToSave` or queues a server deletion if the local record has been
-  /// deleted since the pending change was queued.
+  /// `recordsToSave` or collects it for a single batched server-deletion
+  /// queue at the end (locally-deleted-before-batch path).
   @MainActor
   private func appendProfileIndexRecords(
     recordIDs: [CKRecord.ID],
     into recordsToSave: inout [CKRecord]
   ) {
+    var missing: [CKRecord.ID] = []
     for recordID in recordIDs {
       if let record = profileIndexHandler.recordToSave(for: recordID) {
         recordsToSave.append(record)
       } else {
-        // Bug fix #2: record deleted locally, queue server deletion
-        handleMissingRecordToSave(recordID)
+        missing.append(recordID)
       }
     }
+    handleMissingRecordsToSave(missing)
   }
 
   /// Looks up profile-data records using a batch UUID lookup (plus an
@@ -307,13 +308,14 @@ extension SyncCoordinator: CKSyncEngineDelegate {
     let groups = byRecordType.mapValues { Set($0.map(\.1)) }
     let recordLookup = handler.buildBatchRecordLookup(byRecordType: groups)
 
+    var missing: [CKRecord.ID] = []
     for (recordType, items) in byRecordType {
       let typeLookup = recordLookup[recordType] ?? [:]
       for (recordID, uuid) in items {
         if let record = typeLookup[uuid] {
           recordsToSave.append(record)
         } else {
-          handleMissingRecordToSave(recordID)
+          missing.append(recordID)
         }
       }
     }
@@ -324,24 +326,41 @@ extension SyncCoordinator: CKSyncEngineDelegate {
       if let record = handler.recordToSave(for: recordID) {
         recordsToSave.append(record)
       } else {
-        handleMissingRecordToSave(recordID)
+        missing.append(recordID)
       }
     }
+
+    handleMissingRecordsToSave(missing)
   }
 
-  /// Bug fix #2: When `recordToSave` returns nil (record deleted locally before batch built),
-  /// queue a `.deleteRecord` if one isn't already pending.
+  /// When `recordToSave` returns nil for one or more recordIDs (records
+  /// deleted locally before the batch was built), queue a single
+  /// `.deleteRecord` for each that isn't already pending — in one
+  /// `state.add(_:)` call.
+  ///
+  /// Prior history: this fired per-record and re-scanned the entire
+  /// pending queue every call (a Sequence.contains over an
+  /// `[CKSyncEngine.PendingRecordZoneChange]` is linear), so a batch
+  /// where N records were missing did N × pending equality checks on the
+  /// main thread. With a stale 50K-row queue left over from a deleted
+  /// profile, that's the source of the freeze observed during CSV import:
+  /// every `nextRecordZoneChangeBatch` cycle re-found the same 400
+  /// missing records, the scan was quadratic, and the synchronous
+  /// `state.add(_:)` hop to CloudKit's serial queue ran 400 times per
+  /// cycle. The batched call collapses all of that into one set-build,
+  /// one filter pass, and one engine hop.
   @MainActor
-  private func handleMissingRecordToSave(_ recordID: CKRecord.ID) {
-    guard let syncEngine else { return }
-    let hasPendingDelete = syncEngine.state.pendingRecordZoneChanges.contains(
-      .deleteRecord(recordID))
-    if !hasPendingDelete {
-      logger.info(
-        "Record \(recordID.recordName, privacy: .public) deleted locally before batch — queueing server deletion"
-      )
-      syncEngine.state.add(pendingRecordZoneChanges: [.deleteRecord(recordID)])
-      refreshPendingUploadsMirror()
-    }
+  private func handleMissingRecordsToSave(_ recordIDs: [CKRecord.ID]) {
+    guard let syncEngine, !recordIDs.isEmpty else { return }
+    let novel = Self.newMissingDeleteIDs(
+      among: recordIDs,
+      pendingChanges: syncEngine.state.pendingRecordZoneChanges)
+    guard !novel.isEmpty else { return }
+    logger.info(
+      "\(novel.count, privacy: .public) record(s) deleted locally before batch — queueing server deletion"
+    )
+    syncEngine.state.add(
+      pendingRecordZoneChanges: novel.map { .deleteRecord($0) })
+    refreshPendingUploadsMirror()
   }
 }

--- a/Backends/CloudKit/Sync/SyncCoordinator+QueueChanges.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+QueueChanges.swift
@@ -41,4 +41,34 @@ extension SyncCoordinator {
     syncEngine?.state.add(pendingRecordZoneChanges: [.deleteRecord(recordID)])
     refreshPendingUploadsMirror()
   }
+
+  /// Subset of `candidates` whose record IDs are NOT already queued for
+  /// deletion in `pendingChanges`. Builds a `Set<CKRecord.ID>` from the
+  /// pending `.deleteRecord` entries once (O(pending)) and then filters
+  /// `candidates` against it (O(candidates)). Replaces a prior per-record
+  /// `Sequence.contains(_:)` scan that was O(candidates × pending) on the
+  /// main thread — pathological when a deleted profile leaves tens of
+  /// thousands of stale uploads queued (the same record names re-surface
+  /// every `nextRecordZoneChangeBatch` cycle until the queue drains).
+  ///
+  /// Pending `.saveRecord` entries do not shadow a candidate: a stale
+  /// save and a fresh deletion can legitimately co-exist in the queue,
+  /// and CKSyncEngine resolves the order itself. We only dedup against
+  /// existing `.deleteRecord` entries so the same record-name isn't
+  /// queued for deletion twice.
+  nonisolated static func newMissingDeleteIDs(
+    among candidates: [CKRecord.ID],
+    pendingChanges: [CKSyncEngine.PendingRecordZoneChange]
+  ) -> [CKRecord.ID] {
+    guard !candidates.isEmpty else { return [] }
+    var pendingDeleteIds: Set<CKRecord.ID> = []
+    pendingDeleteIds.reserveCapacity(pendingChanges.count)
+    for change in pendingChanges {
+      if case .deleteRecord(let id) = change {
+        pendingDeleteIds.insert(id)
+      }
+    }
+    if pendingDeleteIds.isEmpty { return candidates }
+    return candidates.filter { !pendingDeleteIds.contains($0) }
+  }
 }

--- a/MoolahTests/Sync/NewMissingDeleteIDsTests.swift
+++ b/MoolahTests/Sync/NewMissingDeleteIDsTests.swift
@@ -1,0 +1,74 @@
+// MoolahTests/Sync/NewMissingDeleteIDsTests.swift
+
+@preconcurrency import CloudKit
+import Foundation
+import Testing
+
+@testable import Moolah
+
+/// Pure-helper tests for `SyncCoordinator.newMissingDeleteIDs(among:pendingChanges:)`.
+///
+/// This is the fix for the O(candidates × pending) scan in the old
+/// per-record `handleMissingRecordToSave` path: the helper builds the
+/// `Set<CKRecord.ID>` from pending `.deleteRecord` entries once and
+/// filters every candidate against the set, so the main thread can
+/// drain a queue with tens of thousands of stale records in linear
+/// time without re-scanning per record.
+@Suite("SyncCoordinator.newMissingDeleteIDs")
+struct NewMissingDeleteIDsTests {
+
+  private static let zone = CKRecordZone.ID(
+    zoneName: "test-zone", ownerName: CKCurrentUserDefaultName)
+
+  private static func recordID(_ name: String) -> CKRecord.ID {
+    CKRecord.ID(recordName: name, zoneID: zone)
+  }
+
+  @Test("records already queued for deletion are excluded")
+  func excludesIdsAlreadyPendingDelete() {
+    let already = Self.recordID("already")
+    let novel = Self.recordID("novel")
+    let pending: [CKSyncEngine.PendingRecordZoneChange] = [.deleteRecord(already)]
+    let result = SyncCoordinator.newMissingDeleteIDs(
+      among: [already, novel], pendingChanges: pending)
+    #expect(result == [novel])
+  }
+
+  @Test("pending .saveRecord entries do not shadow a candidate")
+  func saveRecordDoesNotShadow() {
+    let target = Self.recordID("target")
+    let pending: [CKSyncEngine.PendingRecordZoneChange] = [.saveRecord(target)]
+    let result = SyncCoordinator.newMissingDeleteIDs(
+      among: [target], pendingChanges: pending)
+    #expect(result == [target])
+  }
+
+  @Test("empty pending changes returns the input unchanged")
+  func emptyPendingReturnsInput() {
+    let first = Self.recordID("a")
+    let second = Self.recordID("b")
+    let result = SyncCoordinator.newMissingDeleteIDs(
+      among: [first, second], pendingChanges: [])
+    #expect(result == [first, second])
+  }
+
+  @Test("empty candidate list returns []")
+  func emptyCandidatesReturnsEmpty() {
+    let pending: [CKSyncEngine.PendingRecordZoneChange] = [
+      .deleteRecord(Self.recordID("a"))
+    ]
+    let result = SyncCoordinator.newMissingDeleteIDs(
+      among: [], pendingChanges: pending)
+    #expect(result.isEmpty)
+  }
+
+  @Test("result preserves input order")
+  func preservesInputOrder() {
+    let first = Self.recordID("a")
+    let second = Self.recordID("b")
+    let third = Self.recordID("c")
+    let result = SyncCoordinator.newMissingDeleteIDs(
+      among: [third, first, second], pendingChanges: [])
+    #expect(result == [third, first, second])
+  }
+}


### PR DESCRIPTION
## Summary

- `SyncCoordinator.handleMissingRecordToSave(_:)` fired per-recordID and re-scanned the entire `pendingRecordZoneChanges` array on every call (a `Sequence.contains(_:)` over `[CKSyncEngine.PendingRecordZoneChange]` uses `NSObject ==`, so it's O(pending) per record).
- Each invocation also did a synchronous `syncEngine.state.add(pendingRecordZoneChanges: [.deleteRecord(id)])` — a hop to CloudKit's serial queue blocking the main thread.
- With a stale 50K-row pending queue (e.g. left from a profile deleted before iCloud finished uploading it), every `nextRecordZoneChangeBatch` cycle found 400 missing records and ran 400 × 50K equality checks on the main thread → freeze.

Fix: collect missing recordIDs into a local array, run a single `Set<CKRecord.ID>`-backed dedup pass (`SyncCoordinator.newMissingDeleteIDs(among:pendingChanges:)`), and add them all to the engine in one `state.add(_:)` call. Per-record `os_log` spam (one line per missing record) collapsed to one line carrying the count.

## Diagnosis

3-second main-thread sample during the import freeze reported by the user:

\`\`\`
2166 Thread: Main Thread
+ … SyncCoordinator.nextRecordZoneChangeBatch
+   2166 SyncCoordinator.handleMissingRecordToSave …
+     1702 CKSyncEngine.State.add(pendingRecordZoneChanges:) … ck_call_or_dispatch_sync_if_not_key → _dispatch_sync_f_slow → kevent_id
+     245 Sequence<>.contains(_:) … static CKSyncEngine.PendingRecordZoneChange.== infix → NSObject.== infix
\`\`\`

## Test plan

- [x] \`just format-check\` clean
- [x] \`just test-mac\` — 2760 tests pass, including the 5 new \`SyncCoordinator.newMissingDeleteIDs\` cases:
  - records already queued for deletion are excluded
  - pending \`.saveRecord\` entries do not shadow a candidate (CKSyncEngine resolves order itself)
  - empty pending changes returns the input unchanged
  - empty candidate list returns \`[]\`
  - result preserves input order

## Note

A separate pathology is *why* tens of thousands of pending uploads have no local row — most likely a profile was deleted before its initial sync uploaded. That cleanup is out of scope for this PR; the queue still drains correctly via the batched delete path, just much faster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)