### PR TITLE
Show value-over-time chart for fully-sold position-tracked accounts

### DIFF
--- a/Domain/Models/PositionsViewInput.swift
+++ b/Domain/Models/PositionsViewInput.swift
@@ -62,6 +62,16 @@ struct PositionsViewInput: Sendable, Hashable {
   /// misleading.
   var showsAggregateChart: Bool { showsChart && totalValue != nil }
 
+  /// `true` iff `historicalValue` exists and its aggregate `total` series
+  /// has at least one point. The view layer reads this to decide whether
+  /// a chart-only surface is worth rendering when `shouldHide` is true —
+  /// e.g. a position-tracked investment account where every holding has
+  /// been sold but the historical performance is still meaningful.
+  var hasHistoricalSeries: Bool {
+    guard let series = historicalValue else { return false }
+    return !series.total.isEmpty
+  }
+
   /// `true` iff more than one `Instrument.Kind` is represented. Drives whether
   /// the table renders per-group subtotals.
   var showsGroupSubtotals: Bool {

--- a/Domain/Models/PositionsViewInput.swift
+++ b/Domain/Models/PositionsViewInput.swift
@@ -52,15 +52,16 @@ struct PositionsViewInput: Sendable, Hashable {
 
   /// `true` iff the chart container is rendered at all. The aggregate
   /// historical series must be non-empty. Beyond that, either:
-  /// - `positions` is empty (every holding has been sold but history
-  ///   is still meaningful), or
+  /// - `shouldHide` is `true` (every remaining position is in
+  ///   `hostCurrency` or no positions remain — the historical series
+  ///   alone justifies the chart for a closed-out account), or
   /// - at least one current position carries cost basis.
   ///
   /// This is intentionally more permissive than `showsPLPill`, which
   /// additionally requires `totalValue` to be non-nil.
   var showsChart: Bool {
     guard let series = historicalValue, !series.total.isEmpty else { return false }
-    return positions.isEmpty || positions.contains(where: { $0.hasCostBasis })
+    return shouldHide || positions.contains(where: { $0.hasCostBasis })
   }
 
   /// `true` iff the all-positions chart line should render. False when any

--- a/Domain/Models/PositionsViewInput.swift
+++ b/Domain/Models/PositionsViewInput.swift
@@ -50,12 +50,14 @@ struct PositionsViewInput: Sendable, Hashable {
     return positions.contains(where: { $0.hasCostBasis })
   }
 
-  /// `true` iff the chart container is rendered at all. Requires a
-  /// non-empty aggregate historical series, and — when current positions
-  /// exist — at least one of them carrying cost basis. An empty `positions`
-  /// array is allowed (the historic series alone is sufficient): supports
-  /// position-tracked investment accounts where every holding has been
-  /// sold but the user still wants to inspect prior performance.
+  /// `true` iff the chart container is rendered at all. The aggregate
+  /// historical series must be non-empty. Beyond that, either:
+  /// - `positions` is empty (every holding has been sold but history
+  ///   is still meaningful), or
+  /// - at least one current position carries cost basis.
+  ///
+  /// This is intentionally more permissive than `showsPLPill`, which
+  /// additionally requires `totalValue` to be non-nil.
   var showsChart: Bool {
     guard let series = historicalValue, !series.total.isEmpty else { return false }
     return positions.isEmpty || positions.contains(where: { $0.hasCostBasis })

--- a/Domain/Models/PositionsViewInput.swift
+++ b/Domain/Models/PositionsViewInput.swift
@@ -50,11 +50,15 @@ struct PositionsViewInput: Sendable, Hashable {
     return positions.contains(where: { $0.hasCostBasis })
   }
 
-  /// `true` iff the chart container is rendered at all (a historical series
-  /// exists and at least one row carries cost basis).
+  /// `true` iff the chart container is rendered at all. Requires a
+  /// non-empty aggregate historical series, and — when current positions
+  /// exist — at least one of them carrying cost basis. An empty `positions`
+  /// array is allowed (the historic series alone is sufficient): supports
+  /// position-tracked investment accounts where every holding has been
+  /// sold but the user still wants to inspect prior performance.
   var showsChart: Bool {
-    guard historicalValue != nil else { return false }
-    return positions.contains(where: { $0.hasCostBasis })
+    guard let series = historicalValue, !series.total.isEmpty else { return false }
+    return positions.isEmpty || positions.contains(where: { $0.hasCostBasis })
   }
 
   /// `true` iff the all-positions chart line should render. False when any

--- a/Domain/Models/PositionsViewInput.swift
+++ b/Domain/Models/PositionsViewInput.swift
@@ -64,7 +64,7 @@ struct PositionsViewInput: Sendable, Hashable {
 
   /// `true` iff `historicalValue` exists and its aggregate `total` series
   /// has at least one point. The view layer reads this to decide whether
-  /// a chart-only surface is worth rendering when `shouldHide` is true —
+  /// a chart-only surface is worth rendering when `shouldHide` is `true` —
   /// e.g. a position-tracked investment account where every holding has
   /// been sold but the historical performance is still meaningful.
   var hasHistoricalSeries: Bool {

--- a/Features/Investments/Views/InvestmentAccountView+Previews.swift
+++ b/Features/Investments/Views/InvestmentAccountView+Previews.swift
@@ -94,3 +94,60 @@ private func seedPositionValuations(backend: any BackendProvider, account: Accou
   .frame(width: 720, height: 600)
   .task { await seedPositionValuations(backend: backend, account: account) }
 }
+
+@MainActor
+private func seedFullySoldPositions(backend: any BackendProvider, account: Account) async {
+  let bhp = Instrument.stock(ticker: "BHP.AX", exchange: "ASX", name: "BHP")
+  _ = try? await backend.accounts.create(
+    account, openingBalance: InstrumentAmount(quantity: 0, instrument: .AUD))
+  // Buy 100 BHP @ 40 AUD on day -45.
+  _ = try? await backend.transactions.create(
+    Transaction(
+      date: Date().addingTimeInterval(-86_400 * 45),
+      legs: [
+        TransactionLeg(accountId: account.id, instrument: bhp, quantity: 100, type: .trade),
+        TransactionLeg(accountId: account.id, instrument: .AUD, quantity: -4_000, type: .trade),
+      ]))
+  // Sell all 100 BHP @ 50 AUD on day -15.
+  _ = try? await backend.transactions.create(
+    Transaction(
+      date: Date().addingTimeInterval(-86_400 * 15),
+      legs: [
+        TransactionLeg(accountId: account.id, instrument: bhp, quantity: -100, type: .trade),
+        TransactionLeg(accountId: account.id, instrument: .AUD, quantity: 5_000, type: .trade),
+      ]))
+}
+
+#Preview("Position-tracked (fully sold)") {
+  let backend = PreviewBackend.create()
+  let investmentStore = InvestmentStore(
+    repository: backend.investments,
+    transactionRepository: backend.transactions,
+    conversionService: backend.conversionService)
+  let transactionStore = TransactionStore(
+    repository: backend.transactions,
+    conversionService: backend.conversionService,
+    targetInstrument: .AUD)
+  // In-memory preview session can't fail in practice: opens an ephemeral
+  // GRDB queue with no disk access. A trap here is acceptable in #Preview.
+  // swiftlint:disable:next force_try
+  let session = try! ProfileSession.preview()
+  let account = Account(
+    name: "Brokerage",
+    type: .investment,
+    instrument: .AUD,
+    valuationMode: .calculatedFromTrades)
+  return NavigationStack {
+    InvestmentAccountView(
+      account: account,
+      accounts: Accounts(from: [account]),
+      categories: Categories(from: []),
+      earmarks: Earmarks(from: []),
+      investmentStore: investmentStore,
+      transactionStore: transactionStore
+    )
+  }
+  .previewProfileEnvironment(session: session)
+  .frame(width: 720, height: 600)
+  .task { await seedFullySoldPositions(backend: backend, account: account) }
+}

--- a/Features/Investments/Views/InvestmentAccountView+Previews.swift
+++ b/Features/Investments/Views/InvestmentAccountView+Previews.swift
@@ -26,8 +26,8 @@ private func seedPositionValuations(backend: any BackendProvider, account: Accou
     Transaction(
       date: Date().addingTimeInterval(-86_400 * 30),
       legs: [
-        TransactionLeg(accountId: account.id, instrument: bhp, quantity: 100, type: .income),
-        TransactionLeg(accountId: account.id, instrument: .AUD, quantity: -4_000, type: .expense),
+        TransactionLeg(accountId: account.id, instrument: bhp, quantity: 100, type: .trade),
+        TransactionLeg(accountId: account.id, instrument: .AUD, quantity: -4_000, type: .trade),
       ]))
 }
 

--- a/Features/Investments/Views/InvestmentAccountView.swift
+++ b/Features/Investments/Views/InvestmentAccountView.swift
@@ -85,34 +85,72 @@ struct InvestmentAccountView: View {
     )
   }
 
-  /// The positions/transactions composition for non-legacy accounts. Collapses
-  /// to a bare transaction list when `PositionsView` would be redundant with
-  /// the host's already-visible account balance (see `shouldHide`).
+  /// The positions/transactions composition for non-legacy accounts.
+  /// Three branches:
+  ///   - Positions exist (or are still loading): show the full
+  ///     `PositionsView` with header, optional chart, and table.
+  ///   - Positions empty (or all in host currency) but historic series
+  ///     has points: show a chart-only surface so the user can review
+  ///     prior performance after closing out every holding.
+  ///   - Positions empty and no history: collapse to the bare transaction
+  ///     list, the same as today.
   @ViewBuilder private var positionTrackedLayout: some View {
     if positionsInput.shouldHide && !isLoadingPositions {
-      makeAccountTransactionList()
-    } else {
-      PositionsTransactionsSplit(
-        defaultTab: .positions,
-        // Distinct autosave key from the chartless multi-currency split so
-        // the saved divider position from each layout doesn't bleed into
-        // the other; the chart pushes the table off-screen at the
-        // chartless 180pt default.
-        autosaveName: "positions-transactions-split.with-chart",
-        // Header (~50pt) + chart (~250pt with padding) + a few table rows
-        // need ~530pt to render comfortably without the user dragging.
-        initialTopHeight: 540
-      ) {
-        if isLoadingPositions && positionsInput.positions.isEmpty {
-          ProgressView()
-            .frame(maxWidth: .infinity)
-            .padding()
-        } else {
-          PositionsView(input: positionsInput, range: $positionsRange)
-        }
-      } transactions: {
+      if positionsInput.hasHistoricalSeries {
+        chartOnlySplit
+      } else {
         makeAccountTransactionList()
       }
+    } else {
+      standardPositionsSplit
+    }
+  }
+
+  /// Full positions surface — header (or performance tiles), optional
+  /// chart, and the responsive table. Used when current positions exist.
+  @ViewBuilder private var standardPositionsSplit: some View {
+    PositionsTransactionsSplit(
+      defaultTab: .positions,
+      // Distinct autosave key from the chartless multi-currency split so
+      // the saved divider position from each layout doesn't bleed into
+      // the other; the chart pushes the table off-screen at the
+      // chartless 180pt default.
+      autosaveName: "positions-transactions-split.with-chart",
+      // Header (~50pt) + chart (~250pt with padding) + a few table rows
+      // need ~530pt to render comfortably without the user dragging.
+      initialTopHeight: 540
+    ) {
+      if isLoadingPositions && positionsInput.positions.isEmpty {
+        ProgressView()
+          .frame(maxWidth: .infinity)
+          .padding()
+      } else {
+        PositionsView(input: positionsInput, range: $positionsRange)
+      }
+    } transactions: {
+      makeAccountTransactionList()
+    }
+  }
+
+  /// Chart-only top pane for a position-tracked account that no longer
+  /// holds anything non-host-currency but has historical activity.
+  /// Reuses the same `autosaveName` as `standardPositionsSplit` so the
+  /// divider position the user has chosen for this account shape
+  /// persists across the two branches. `selectedInstrument` is pinned to
+  /// `.constant(nil)` — there are no positions to filter to, so the
+  /// per-instrument selection chip would never appear.
+  @ViewBuilder private var chartOnlySplit: some View {
+    PositionsTransactionsSplit(
+      defaultTab: .positions,
+      autosaveName: "positions-transactions-split.with-chart",
+      initialTopHeight: 540
+    ) {
+      PositionsChart(
+        input: positionsInput,
+        range: $positionsRange,
+        selectedInstrument: .constant(nil))
+    } transactions: {
+      makeAccountTransactionList()
     }
   }
 

--- a/Features/Investments/Views/InvestmentAccountView.swift
+++ b/Features/Investments/Views/InvestmentAccountView.swift
@@ -91,7 +91,7 @@ struct InvestmentAccountView: View {
   ///     `PositionsView` with header, optional chart, and table.
   ///   - Positions empty (or all in host currency) but historic series
   ///     has points: show a chart-only surface so the user can review
-  ///     prior performance after closing out every holding.
+  ///     prior performance.
   ///   - Positions empty and no history: collapse to the bare transaction
   ///     list, the same as today.
   @ViewBuilder private var positionTrackedLayout: some View {
@@ -107,7 +107,9 @@ struct InvestmentAccountView: View {
   }
 
   /// Full positions surface — header (or performance tiles), optional
-  /// chart, and the responsive table. Used when current positions exist.
+  /// chart, and the responsive table. Used when current positions exist
+  /// or while positions are still loading (renders a `ProgressView` in
+  /// the top pane until `isLoadingPositions` clears).
   @ViewBuilder private var standardPositionsSplit: some View {
     PositionsTransactionsSplit(
       defaultTab: .positions,
@@ -132,8 +134,9 @@ struct InvestmentAccountView: View {
     }
   }
 
-  /// Chart-only top pane for a position-tracked account that no longer
-  /// holds anything non-host-currency but has historical activity.
+  /// Chart-only top pane for a position-tracked account whose positions
+  /// table is empty (all holdings closed out, or every non-zero position
+  /// is in host currency) but that has historical activity worth reviewing.
   /// Reuses the same `autosaveName` as `standardPositionsSplit` so the
   /// divider position the user has chosen for this account shape
   /// persists across the two branches. `selectedInstrument` is pinned to

--- a/MoolahTests/Domain/PositionsViewInputChartTests.swift
+++ b/MoolahTests/Domain/PositionsViewInputChartTests.swift
@@ -1,0 +1,150 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+/// Tests for the chart-visibility predicates on `PositionsViewInput`
+/// (`showsChart`, `showsAggregateChart`, `hasHistoricalSeries`). Split
+/// from `PositionsViewInputTests` to keep each suite under SwiftLint's
+/// `type_body_length` budget.
+@Suite("PositionsViewInput chart visibility")
+struct PositionsViewInputChartTests {
+  let aud = Instrument.AUD
+  let bhp = Instrument.stock(ticker: "BHP.AX", exchange: "ASX", name: "BHP")
+  let fixedTestDate = Date(timeIntervalSinceReferenceDate: 0)
+
+  private func amount(_ quantity: Decimal) -> InstrumentAmount {
+    InstrumentAmount(quantity: quantity, instrument: aud)
+  }
+
+  @Test("showsChart is false when historicalValue is nil")
+  func chartHiddenWithoutSeries() {
+    let input = PositionsViewInput(
+      title: "x", hostCurrency: aud,
+      positions: [
+        ValuedPosition(
+          instrument: bhp, quantity: 1, unitPrice: nil,
+          costBasis: amount(50), value: amount(60))
+      ],
+      historicalValue: nil
+    )
+    #expect(!input.showsChart)
+  }
+
+  @Test("showsChart is false when no row carries cost basis")
+  func chartHiddenWithoutAnyCostBasis() {
+    let point = HistoricalValueSeries.Point(
+      date: fixedTestDate, value: 60, cost: 50, contributions: 50)
+    let input = PositionsViewInput(
+      title: "x", hostCurrency: aud,
+      positions: [
+        ValuedPosition(
+          instrument: bhp, quantity: 1, unitPrice: nil,
+          costBasis: nil, value: amount(100))
+      ],
+      historicalValue: HistoricalValueSeries(
+        hostCurrency: aud, total: [point], perInstrument: [:])
+    )
+    #expect(!input.showsChart)
+  }
+
+  @Test("showsAggregateChart is false when any row's value is nil")
+  func aggregateChartHiddenOnFailure() {
+    let point = HistoricalValueSeries.Point(
+      date: fixedTestDate, value: 60, cost: 50, contributions: 50)
+    let input = PositionsViewInput(
+      title: "x", hostCurrency: aud,
+      positions: [
+        ValuedPosition(
+          instrument: bhp, quantity: 1, unitPrice: nil,
+          costBasis: amount(50), value: amount(60)),
+        ValuedPosition(
+          instrument: bhp, quantity: 1, unitPrice: nil,
+          costBasis: amount(40), value: nil),
+      ],
+      historicalValue: HistoricalValueSeries(
+        hostCurrency: aud, total: [point], perInstrument: [:])
+    )
+    #expect(!input.showsAggregateChart)
+    #expect(input.showsChart)  // chart can still render for working instruments
+  }
+
+  @Test(
+    "showsChart is true when historicalValue has points and at least one row carries cost basis")
+  func chartVisibleWithSeriesAndCostBasis() {
+    let point = HistoricalValueSeries.Point(
+      date: fixedTestDate, value: 60, cost: 50, contributions: 50)
+    let input = PositionsViewInput(
+      title: "x", hostCurrency: aud,
+      positions: [
+        ValuedPosition(
+          instrument: bhp, quantity: 1, unitPrice: nil,
+          costBasis: amount(50), value: amount(60))
+      ],
+      historicalValue: HistoricalValueSeries(
+        hostCurrency: aud, total: [point], perInstrument: [:])
+    )
+    #expect(input.showsChart)
+  }
+
+  @Test("hasHistoricalSeries is false when historicalValue is nil")
+  func historicalSeriesAbsentWhenNoSeries() {
+    let input = PositionsViewInput(
+      title: "x", hostCurrency: aud, positions: [], historicalValue: nil)
+    #expect(!input.hasHistoricalSeries)
+  }
+
+  @Test("hasHistoricalSeries is false when total is empty")
+  func historicalSeriesAbsentWhenTotalEmpty() {
+    let input = PositionsViewInput(
+      title: "x", hostCurrency: aud, positions: [],
+      historicalValue: HistoricalValueSeries(
+        hostCurrency: aud, total: [], perInstrument: [:]))
+    #expect(!input.hasHistoricalSeries)
+  }
+
+  @Test("hasHistoricalSeries is true when total has at least one point")
+  func historicalSeriesPresentWhenTotalHasPoints() {
+    let point = HistoricalValueSeries.Point(
+      date: fixedTestDate, value: 100, cost: 80, contributions: 80)
+    let input = PositionsViewInput(
+      title: "x", hostCurrency: aud, positions: [],
+      historicalValue: HistoricalValueSeries(
+        hostCurrency: aud, total: [point], perInstrument: [:]))
+    #expect(input.hasHistoricalSeries)
+  }
+
+  @Test("showsChart is true when positions is empty but historical total has points")
+  func chartVisibleForEmptyPositionsWithHistory() {
+    let point = HistoricalValueSeries.Point(
+      date: fixedTestDate, value: 100, cost: 80, contributions: 80)
+    let input = PositionsViewInput(
+      title: "x", hostCurrency: aud, positions: [],
+      historicalValue: HistoricalValueSeries(
+        hostCurrency: aud, total: [point], perInstrument: [:]))
+    #expect(input.showsChart)
+  }
+
+  @Test("showsChart is false when positions is empty and historical total is empty")
+  func chartHiddenForEmptyPositionsWithoutHistory() {
+    let input = PositionsViewInput(
+      title: "x", hostCurrency: aud, positions: [],
+      historicalValue: HistoricalValueSeries(
+        hostCurrency: aud, total: [], perInstrument: [:]))
+    #expect(!input.showsChart)
+  }
+
+  @Test("showsChart is false when positions has cost basis but historical total is empty")
+  func chartHiddenWhenCostBasisButNoHistoricalPoints() {
+    let input = PositionsViewInput(
+      title: "x", hostCurrency: aud,
+      positions: [
+        ValuedPosition(
+          instrument: bhp, quantity: 1, unitPrice: nil,
+          costBasis: amount(50), value: amount(60))
+      ],
+      historicalValue: HistoricalValueSeries(
+        hostCurrency: aud, total: [], perInstrument: [:]))
+    #expect(!input.showsChart)
+  }
+}

--- a/MoolahTests/Domain/PositionsViewInputChartTests.swift
+++ b/MoolahTests/Domain/PositionsViewInputChartTests.swift
@@ -31,7 +31,7 @@ struct PositionsViewInputChartTests {
     #expect(!input.showsChart)
   }
 
-  @Test("showsChart is false when no row carries cost basis")
+  @Test("showsChart is false when non-host positions have no cost basis and shouldHide is false")
   func chartHiddenWithoutAnyCostBasis() {
     let point = HistoricalValueSeries.Point(
       date: fixedTestDate, value: 60, cost: 50, contributions: 50)
@@ -112,6 +112,25 @@ struct PositionsViewInputChartTests {
       historicalValue: HistoricalValueSeries(
         hostCurrency: aud, total: [point], perInstrument: [:]))
     #expect(input.hasHistoricalSeries)
+  }
+
+  @Test("showsChart is true when all positions are in host currency but history has points")
+  func chartVisibleForHostCurrencyOnlyPositionsWithHistory() {
+    let point = HistoricalValueSeries.Point(
+      date: fixedTestDate, value: 100, cost: 80, contributions: 80)
+    let input = PositionsViewInput(
+      title: "x", hostCurrency: aud,
+      positions: [
+        // AUD position (host currency) — `shouldHide` fires via the
+        // host-currency-only branch, NOT via `positions.isEmpty`.
+        ValuedPosition(
+          instrument: aud, quantity: 5_000, unitPrice: nil,
+          costBasis: nil, value: amount(5_000))
+      ],
+      historicalValue: HistoricalValueSeries(
+        hostCurrency: aud, total: [point], perInstrument: [:]))
+    #expect(input.shouldHide)
+    #expect(input.showsChart)
   }
 
   @Test("showsChart is true when positions is empty but historical total has points")

--- a/MoolahTests/Domain/PositionsViewInputTests.swift
+++ b/MoolahTests/Domain/PositionsViewInputTests.swift
@@ -94,58 +94,6 @@ struct PositionsViewInputTests {
     #expect(!input.showsPLPill)
   }
 
-  @Test("showsChart is false when historicalValue is nil")
-  func chartHiddenWithoutSeries() {
-    let input = PositionsViewInput(
-      title: "x", hostCurrency: aud,
-      positions: [
-        ValuedPosition(
-          instrument: bhp, quantity: 1, unitPrice: nil,
-          costBasis: amount(50), value: amount(60))
-      ],
-      historicalValue: nil
-    )
-    #expect(!input.showsChart)
-  }
-
-  @Test("showsChart is false when no row carries cost basis")
-  func chartHiddenWithoutAnyCostBasis() {
-    let point = HistoricalValueSeries.Point(
-      date: fixedTestDate, value: 60, cost: 50, contributions: 50)
-    let input = PositionsViewInput(
-      title: "x", hostCurrency: aud,
-      positions: [
-        ValuedPosition(
-          instrument: bhp, quantity: 1, unitPrice: nil,
-          costBasis: nil, value: amount(100))
-      ],
-      historicalValue: HistoricalValueSeries(
-        hostCurrency: aud, total: [point], perInstrument: [:])
-    )
-    #expect(!input.showsChart)
-  }
-
-  @Test("showsAggregateChart is false when any row's value is nil")
-  func aggregateChartHiddenOnFailure() {
-    let point = HistoricalValueSeries.Point(
-      date: fixedTestDate, value: 60, cost: 50, contributions: 50)
-    let input = PositionsViewInput(
-      title: "x", hostCurrency: aud,
-      positions: [
-        ValuedPosition(
-          instrument: bhp, quantity: 1, unitPrice: nil,
-          costBasis: amount(50), value: amount(60)),
-        ValuedPosition(
-          instrument: bhp, quantity: 1, unitPrice: nil,
-          costBasis: amount(40), value: nil),
-      ],
-      historicalValue: HistoricalValueSeries(
-        hostCurrency: aud, total: [point], perInstrument: [:])
-    )
-    #expect(!input.showsAggregateChart)
-    #expect(input.showsChart)  // chart can still render for working instruments
-  }
-
   @Test("totalValue is zero (not nil) for empty positions")
   func totalValueEmptyPositions() {
     let input = PositionsViewInput(
@@ -168,24 +116,6 @@ struct PositionsViewInputTests {
       historicalValue: nil
     )
     #expect(input.showsPLPill)
-  }
-
-  @Test(
-    "showsChart is true when historicalValue has points and at least one row carries cost basis")
-  func chartVisibleWithSeriesAndCostBasis() {
-    let point = HistoricalValueSeries.Point(
-      date: fixedTestDate, value: 60, cost: 50, contributions: 50)
-    let input = PositionsViewInput(
-      title: "x", hostCurrency: aud,
-      positions: [
-        ValuedPosition(
-          instrument: bhp, quantity: 1, unitPrice: nil,
-          costBasis: amount(50), value: amount(60))
-      ],
-      historicalValue: HistoricalValueSeries(
-        hostCurrency: aud, total: [point], perInstrument: [:])
-    )
-    #expect(input.showsChart)
   }
 
   @Test("showsGroupSubtotals is true only when more than one kind is present")
@@ -214,67 +144,6 @@ struct PositionsViewInputTests {
       historicalValue: nil
     )
     #expect(mixed.showsGroupSubtotals)
-  }
-
-  @Test("hasHistoricalSeries is false when historicalValue is nil")
-  func historicalSeriesAbsentWhenNoSeries() {
-    let input = PositionsViewInput(
-      title: "x", hostCurrency: aud, positions: [], historicalValue: nil)
-    #expect(!input.hasHistoricalSeries)
-  }
-
-  @Test("hasHistoricalSeries is false when total is empty")
-  func historicalSeriesAbsentWhenTotalEmpty() {
-    let input = PositionsViewInput(
-      title: "x", hostCurrency: aud, positions: [],
-      historicalValue: HistoricalValueSeries(
-        hostCurrency: aud, total: [], perInstrument: [:]))
-    #expect(!input.hasHistoricalSeries)
-  }
-
-  @Test("hasHistoricalSeries is true when total has at least one point")
-  func historicalSeriesPresentWhenTotalHasPoints() {
-    let point = HistoricalValueSeries.Point(
-      date: fixedTestDate, value: 100, cost: 80, contributions: 80)
-    let input = PositionsViewInput(
-      title: "x", hostCurrency: aud, positions: [],
-      historicalValue: HistoricalValueSeries(
-        hostCurrency: aud, total: [point], perInstrument: [:]))
-    #expect(input.hasHistoricalSeries)
-  }
-
-  @Test("showsChart is true when positions is empty but historical total has points")
-  func chartVisibleForEmptyPositionsWithHistory() {
-    let point = HistoricalValueSeries.Point(
-      date: fixedTestDate, value: 100, cost: 80, contributions: 80)
-    let input = PositionsViewInput(
-      title: "x", hostCurrency: aud, positions: [],
-      historicalValue: HistoricalValueSeries(
-        hostCurrency: aud, total: [point], perInstrument: [:]))
-    #expect(input.showsChart)
-  }
-
-  @Test("showsChart is false when positions is empty and historical total is empty")
-  func chartHiddenForEmptyPositionsWithoutHistory() {
-    let input = PositionsViewInput(
-      title: "x", hostCurrency: aud, positions: [],
-      historicalValue: HistoricalValueSeries(
-        hostCurrency: aud, total: [], perInstrument: [:]))
-    #expect(!input.showsChart)
-  }
-
-  @Test("showsChart is false when positions has cost basis but historical total is empty")
-  func chartHiddenWhenCostBasisButNoHistoricalPoints() {
-    let input = PositionsViewInput(
-      title: "x", hostCurrency: aud,
-      positions: [
-        ValuedPosition(
-          instrument: bhp, quantity: 1, unitPrice: nil,
-          costBasis: amount(50), value: amount(60))
-      ],
-      historicalValue: HistoricalValueSeries(
-        hostCurrency: aud, total: [], perInstrument: [:]))
-    #expect(!input.showsChart)
   }
 
 }

--- a/MoolahTests/Domain/PositionsViewInputTests.swift
+++ b/MoolahTests/Domain/PositionsViewInputTests.swift
@@ -116,7 +116,7 @@ struct PositionsViewInputTests {
       title: "x", hostCurrency: aud,
       positions: [
         ValuedPosition(
-          instrument: aud, quantity: 1, unitPrice: nil,
+          instrument: bhp, quantity: 1, unitPrice: nil,
           costBasis: nil, value: amount(100))
       ],
       historicalValue: HistoricalValueSeries(

--- a/MoolahTests/Domain/PositionsViewInputTests.swift
+++ b/MoolahTests/Domain/PositionsViewInputTests.swift
@@ -124,6 +124,8 @@ struct PositionsViewInputTests {
 
   @Test("showsAggregateChart is false when any row's value is nil")
   func aggregateChartHiddenOnFailure() {
+    let point = HistoricalValueSeries.Point(
+      date: Date(), value: 60, cost: 50, contributions: 50)
     let input = PositionsViewInput(
       title: "x", hostCurrency: aud,
       positions: [
@@ -135,7 +137,7 @@ struct PositionsViewInputTests {
           costBasis: amount(40), value: nil),
       ],
       historicalValue: HistoricalValueSeries(
-        hostCurrency: aud, total: [], perInstrument: [:])
+        hostCurrency: aud, total: [point], perInstrument: [:])
     )
     #expect(!input.showsAggregateChart)
     #expect(input.showsChart)  // chart can still render for working instruments
@@ -165,8 +167,11 @@ struct PositionsViewInputTests {
     #expect(input.showsPLPill)
   }
 
-  @Test("showsChart is true when historicalValue exists and at least one row carries cost basis")
+  @Test(
+    "showsChart is true when historicalValue has points and at least one row carries cost basis")
   func chartVisibleWithSeriesAndCostBasis() {
+    let point = HistoricalValueSeries.Point(
+      date: Date(), value: 60, cost: 50, contributions: 50)
     let input = PositionsViewInput(
       title: "x", hostCurrency: aud,
       positions: [
@@ -175,7 +180,7 @@ struct PositionsViewInputTests {
           costBasis: amount(50), value: amount(60))
       ],
       historicalValue: HistoricalValueSeries(
-        hostCurrency: aud, total: [], perInstrument: [:])
+        hostCurrency: aud, total: [point], perInstrument: [:])
     )
     #expect(input.showsChart)
   }
@@ -233,6 +238,40 @@ struct PositionsViewInputTests {
       historicalValue: HistoricalValueSeries(
         hostCurrency: aud, total: [point], perInstrument: [:]))
     #expect(input.hasHistoricalSeries)
+  }
+
+  @Test("showsChart is true when positions is empty but historical total has points")
+  func chartVisibleForEmptyPositionsWithHistory() {
+    let point = HistoricalValueSeries.Point(
+      date: Date(), value: 100, cost: 80, contributions: 80)
+    let input = PositionsViewInput(
+      title: "x", hostCurrency: aud, positions: [],
+      historicalValue: HistoricalValueSeries(
+        hostCurrency: aud, total: [point], perInstrument: [:]))
+    #expect(input.showsChart)
+  }
+
+  @Test("showsChart is false when positions is empty and historical total is empty")
+  func chartHiddenForEmptyPositionsWithoutHistory() {
+    let input = PositionsViewInput(
+      title: "x", hostCurrency: aud, positions: [],
+      historicalValue: HistoricalValueSeries(
+        hostCurrency: aud, total: [], perInstrument: [:]))
+    #expect(!input.showsChart)
+  }
+
+  @Test("showsChart is false when positions has cost basis but historical total is empty")
+  func chartHiddenWhenCostBasisButNoHistoricalPoints() {
+    let input = PositionsViewInput(
+      title: "x", hostCurrency: aud,
+      positions: [
+        ValuedPosition(
+          instrument: bhp, quantity: 1, unitPrice: nil,
+          costBasis: amount(50), value: amount(60))
+      ],
+      historicalValue: HistoricalValueSeries(
+        hostCurrency: aud, total: [], perInstrument: [:]))
+    #expect(!input.showsChart)
   }
 
 }

--- a/MoolahTests/Domain/PositionsViewInputTests.swift
+++ b/MoolahTests/Domain/PositionsViewInputTests.swift
@@ -208,4 +208,31 @@ struct PositionsViewInputTests {
     #expect(mixed.showsGroupSubtotals)
   }
 
+  @Test("hasHistoricalSeries is false when historicalValue is nil")
+  func historicalSeriesAbsentWhenNoSeries() {
+    let input = PositionsViewInput(
+      title: "x", hostCurrency: aud, positions: [], historicalValue: nil)
+    #expect(!input.hasHistoricalSeries)
+  }
+
+  @Test("hasHistoricalSeries is false when total is empty")
+  func historicalSeriesAbsentWhenTotalEmpty() {
+    let input = PositionsViewInput(
+      title: "x", hostCurrency: aud, positions: [],
+      historicalValue: HistoricalValueSeries(
+        hostCurrency: aud, total: [], perInstrument: [:]))
+    #expect(!input.hasHistoricalSeries)
+  }
+
+  @Test("hasHistoricalSeries is true when total has at least one point")
+  func historicalSeriesPresentWhenTotalHasPoints() {
+    let point = HistoricalValueSeries.Point(
+      date: Date(), value: 100, cost: 80, contributions: 80)
+    let input = PositionsViewInput(
+      title: "x", hostCurrency: aud, positions: [],
+      historicalValue: HistoricalValueSeries(
+        hostCurrency: aud, total: [point], perInstrument: [:]))
+    #expect(input.hasHistoricalSeries)
+  }
+
 }

--- a/MoolahTests/Domain/PositionsViewInputTests.swift
+++ b/MoolahTests/Domain/PositionsViewInputTests.swift
@@ -7,6 +7,7 @@ import Testing
 struct PositionsViewInputTests {
   let aud = Instrument.AUD
   let bhp = Instrument.stock(ticker: "BHP.AX", exchange: "ASX", name: "BHP")
+  let fixedTestDate = Date(timeIntervalSinceReferenceDate: 0)
 
   private func amount(_ quantity: Decimal) -> InstrumentAmount {
     InstrumentAmount(quantity: quantity, instrument: aud)
@@ -109,6 +110,8 @@ struct PositionsViewInputTests {
 
   @Test("showsChart is false when no row carries cost basis")
   func chartHiddenWithoutAnyCostBasis() {
+    let point = HistoricalValueSeries.Point(
+      date: fixedTestDate, value: 60, cost: 50, contributions: 50)
     let input = PositionsViewInput(
       title: "x", hostCurrency: aud,
       positions: [
@@ -117,7 +120,7 @@ struct PositionsViewInputTests {
           costBasis: nil, value: amount(100))
       ],
       historicalValue: HistoricalValueSeries(
-        hostCurrency: aud, total: [], perInstrument: [:])
+        hostCurrency: aud, total: [point], perInstrument: [:])
     )
     #expect(!input.showsChart)
   }
@@ -125,7 +128,7 @@ struct PositionsViewInputTests {
   @Test("showsAggregateChart is false when any row's value is nil")
   func aggregateChartHiddenOnFailure() {
     let point = HistoricalValueSeries.Point(
-      date: Date(), value: 60, cost: 50, contributions: 50)
+      date: fixedTestDate, value: 60, cost: 50, contributions: 50)
     let input = PositionsViewInput(
       title: "x", hostCurrency: aud,
       positions: [
@@ -171,7 +174,7 @@ struct PositionsViewInputTests {
     "showsChart is true when historicalValue has points and at least one row carries cost basis")
   func chartVisibleWithSeriesAndCostBasis() {
     let point = HistoricalValueSeries.Point(
-      date: Date(), value: 60, cost: 50, contributions: 50)
+      date: fixedTestDate, value: 60, cost: 50, contributions: 50)
     let input = PositionsViewInput(
       title: "x", hostCurrency: aud,
       positions: [
@@ -232,7 +235,7 @@ struct PositionsViewInputTests {
   @Test("hasHistoricalSeries is true when total has at least one point")
   func historicalSeriesPresentWhenTotalHasPoints() {
     let point = HistoricalValueSeries.Point(
-      date: Date(), value: 100, cost: 80, contributions: 80)
+      date: fixedTestDate, value: 100, cost: 80, contributions: 80)
     let input = PositionsViewInput(
       title: "x", hostCurrency: aud, positions: [],
       historicalValue: HistoricalValueSeries(
@@ -243,7 +246,7 @@ struct PositionsViewInputTests {
   @Test("showsChart is true when positions is empty but historical total has points")
   func chartVisibleForEmptyPositionsWithHistory() {
     let point = HistoricalValueSeries.Point(
-      date: Date(), value: 100, cost: 80, contributions: 80)
+      date: fixedTestDate, value: 100, cost: 80, contributions: 80)
     let input = PositionsViewInput(
       title: "x", hostCurrency: aud, positions: [],
       historicalValue: HistoricalValueSeries(

--- a/MoolahTests/Features/Investments/InvestmentStoreFullySoldChartTests.swift
+++ b/MoolahTests/Features/Investments/InvestmentStoreFullySoldChartTests.swift
@@ -9,7 +9,13 @@ struct InvestmentStoreFullySoldChartTests {
   let aud = Instrument.AUD
   let bhp = Instrument.stock(ticker: "BHP.AX", exchange: "ASX", name: "BHP")
 
-  @Test("fully-sold account yields shouldHide + hasHistoricalSeries + showsChart")
+  // Fixed historical anchor dates so the suite is independent of the
+  // wall-clock. `PositionsTimeRange.all` is used at the call site so the
+  // history builder doesn't filter these out.
+  let buyDate = Date(timeIntervalSinceReferenceDate: 599_616_000)  // 2020-01-01
+  let sellDate = Date(timeIntervalSinceReferenceDate: 601_430_400)  // 2020-01-21
+
+  @Test("fully-sold account still surfaces the historical chart")
   func fullySoldAccountSurfacesChart() async throws {
     let (backend, _) = try TestBackend.create()
     let conversionService = FixedConversionService(rates: [bhp.id: Decimal(50)])
@@ -24,39 +30,49 @@ struct InvestmentStoreFullySoldChartTests {
     _ = try await backend.accounts.create(
       account, openingBalance: InstrumentAmount(quantity: 0, instrument: aud))
 
-    // Buy 100 BHP @ 40 AUD on day -30.
+    // Buy 100 BHP @ 40 AUD on 2020-01-01.
     _ = try await backend.transactions.create(
       Transaction(
-        date: Date(timeIntervalSinceNow: -86_400 * 30),
+        date: buyDate,
         legs: [
           TransactionLeg(accountId: account.id, instrument: bhp, quantity: 100, type: .trade),
           TransactionLeg(accountId: account.id, instrument: aud, quantity: -4_000, type: .trade),
         ]))
-    // Sell all 100 BHP @ 50 AUD on day -10.
+    // Sell all 100 BHP @ 50 AUD on 2020-01-21.
     _ = try await backend.transactions.create(
       Transaction(
-        date: Date(timeIntervalSinceNow: -86_400 * 10),
+        date: sellDate,
         legs: [
           TransactionLeg(accountId: account.id, instrument: bhp, quantity: -100, type: .trade),
           TransactionLeg(accountId: account.id, instrument: aud, quantity: 5_000, type: .trade),
         ]))
 
     let input = try await store.loadAndBuildPositionsInput(
-      account: account, profileCurrency: aud, range: .threeMonths)
+      account: account, profileCurrency: aud, range: .all)
 
     // A sell-for-profit leaves the net cash leg as a host-currency
     // position; `loadPositions` keeps non-zero rows. `shouldHide`
     // collapses this into the chart-only path.
     let nonHostPositions = input.positions.filter { $0.instrument != aud }
-    #expect(nonHostPositions.isEmpty)
-    #expect(input.shouldHide)
-    #expect(input.hasHistoricalSeries)
-    #expect(input.showsChart)
-    #expect(input.showsAggregateChart)
+    #expect(
+      nonHostPositions.isEmpty,
+      "sell-for-profit should leave only the host-currency cash leg in positions")
+    #expect(
+      input.shouldHide,
+      "cash-only positions should trigger shouldHide")
+    #expect(
+      input.hasHistoricalSeries,
+      "trade history should produce a non-empty historical series")
+    #expect(
+      input.showsChart,
+      "chart should surface when shouldHide is true and history is non-empty")
+    #expect(
+      input.showsAggregateChart,
+      "aggregate chart line should render when totalValue is available")
   }
 
-  @Test("brand-new account with no transactions still falls back to bare transactions path")
-  func emptyAccountStillHidesChart() async throws {
+  @Test("empty account with no trade history hides the chart")
+  func emptyAccountHidesChart() async throws {
     let (backend, _) = try TestBackend.create()
     let store = InvestmentStore(
       repository: backend.investments,

--- a/MoolahTests/Features/Investments/InvestmentStoreFullySoldChartTests.swift
+++ b/MoolahTests/Features/Investments/InvestmentStoreFullySoldChartTests.swift
@@ -1,0 +1,80 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@MainActor
+@Suite("InvestmentStore fully-sold account chart")
+struct InvestmentStoreFullySoldChartTests {
+  let aud = Instrument.AUD
+  let bhp = Instrument.stock(ticker: "BHP.AX", exchange: "ASX", name: "BHP")
+
+  @Test("fully-sold account yields shouldHide + hasHistoricalSeries + showsChart")
+  func fullySoldAccountSurfacesChart() async throws {
+    let (backend, _) = try TestBackend.create()
+    let conversionService = FixedConversionService(rates: [bhp.id: Decimal(50)])
+    let store = InvestmentStore(
+      repository: backend.investments,
+      transactionRepository: backend.transactions,
+      conversionService: conversionService
+    )
+    let account = Account(
+      name: "Brokerage", type: .investment, instrument: aud,
+      valuationMode: .calculatedFromTrades)
+    _ = try await backend.accounts.create(
+      account, openingBalance: InstrumentAmount(quantity: 0, instrument: aud))
+
+    // Buy 100 BHP @ 40 AUD on day -30.
+    _ = try await backend.transactions.create(
+      Transaction(
+        date: Date(timeIntervalSinceNow: -86_400 * 30),
+        legs: [
+          TransactionLeg(accountId: account.id, instrument: bhp, quantity: 100, type: .trade),
+          TransactionLeg(accountId: account.id, instrument: aud, quantity: -4_000, type: .trade),
+        ]))
+    // Sell all 100 BHP @ 50 AUD on day -10.
+    _ = try await backend.transactions.create(
+      Transaction(
+        date: Date(timeIntervalSinceNow: -86_400 * 10),
+        legs: [
+          TransactionLeg(accountId: account.id, instrument: bhp, quantity: -100, type: .trade),
+          TransactionLeg(accountId: account.id, instrument: aud, quantity: 5_000, type: .trade),
+        ]))
+
+    let input = try await store.loadAndBuildPositionsInput(
+      account: account, profileCurrency: aud, range: .threeMonths)
+
+    // A sell-for-profit leaves the net cash leg as a host-currency
+    // position; `loadPositions` keeps non-zero rows. `shouldHide`
+    // collapses this into the chart-only path.
+    let nonHostPositions = input.positions.filter { $0.instrument != aud }
+    #expect(nonHostPositions.isEmpty)
+    #expect(input.shouldHide)
+    #expect(input.hasHistoricalSeries)
+    #expect(input.showsChart)
+    #expect(input.showsAggregateChart)
+  }
+
+  @Test("brand-new account with no transactions still falls back to bare transactions path")
+  func emptyAccountStillHidesChart() async throws {
+    let (backend, _) = try TestBackend.create()
+    let store = InvestmentStore(
+      repository: backend.investments,
+      transactionRepository: backend.transactions,
+      conversionService: backend.conversionService
+    )
+    let account = Account(
+      name: "Brokerage", type: .investment, instrument: aud,
+      valuationMode: .calculatedFromTrades)
+    _ = try await backend.accounts.create(
+      account, openingBalance: InstrumentAmount(quantity: 0, instrument: aud))
+
+    let input = try await store.loadAndBuildPositionsInput(
+      account: account, profileCurrency: aud, range: .threeMonths)
+
+    #expect(input.positions.isEmpty)
+    #expect(input.shouldHide)
+    #expect(!input.hasHistoricalSeries)
+    #expect(!input.showsChart)
+  }
+}

--- a/plans/2026-05-15-fully-sold-investment-chart-design.md
+++ b/plans/2026-05-15-fully-sold-investment-chart-design.md
@@ -1,0 +1,159 @@
+# Show historic value chart for fully-sold position-tracked investment accounts
+
+**Status:** Approved 2026-05-15
+**Scope:** UX fix in `Features/Investments/` + `Domain/Models/PositionsViewInput.swift`
+
+## Problem
+
+In a position-tracked investment account (`valuationMode == .calculatedFromTrades`), once the user has sold every holding the current value is zero and `valuedPositions` is empty. `PositionsViewInput.shouldHide` returns `true` (its rule includes "positions is empty"), which causes `InvestmentAccountView.positionTrackedLayout` to collapse to a bare transaction list. The historic value-over-time chart vanishes, even though the account still has meaningful historical performance data the user wants to review.
+
+`PositionsHistoryBuilder.build` already emits historical points correctly for these accounts — it walks transactions chronologically and emits a point for every day a non-zero quantity existed. The data is there; only the view-layer gating hides it.
+
+## Goal
+
+When all positions in a position-tracked account have been sold:
+
+- Show the value-over-time chart at the top of the account view.
+- Do **not** show the three performance tiles (`AccountPerformanceTiles`) or the positions table — both are about "now", which is empty.
+- Keep the transaction list below, unchanged.
+
+When the account is truly empty (no historical positions either), keep today's behaviour: render just the bare transaction list.
+
+## Non-goals
+
+- Changing the default time range (`.threeMonths`). If every sale happened more than three months ago, the chart will show its existing "No chart data yet" empty state until the user picks `.allTime`. Worth a follow-up but not in scope here.
+- Changing `PositionsView`'s rendering behaviour — it continues to short-circuit on `shouldHide`. The new "chart-only" path is a sibling at the view layer, not a new internal mode.
+- Changing `PositionsHistoryBuilder` — it already produces the correct series for these accounts.
+- Changing the legacy `.recordedValue` valuation path. This change is isolated to the position-tracked layout.
+
+## Design
+
+### 1. `Domain/Models/PositionsViewInput.swift`
+
+Add a computed property:
+
+```swift
+/// `true` iff `historicalValue` exists and its aggregate series has at
+/// least one point. Lets the view layer decide whether to render a
+/// chart-only surface when `shouldHide` is true but historical
+/// performance data is available.
+var hasHistoricalSeries: Bool {
+  guard let series = historicalValue else { return false }
+  return !series.total.isEmpty
+}
+```
+
+Relax `showsChart` so an empty `positions` array with a non-empty historical series still renders the chart:
+
+```swift
+var showsChart: Bool {
+  guard let series = historicalValue, !series.total.isEmpty else { return false }
+  return positions.isEmpty || positions.contains(where: { $0.hasCostBasis })
+}
+```
+
+Rationale:
+
+- When `positions` is non-empty, keep the existing rule (at least one row must have cost basis — distinguishes "investment" from "cash-only" accounts).
+- When `positions` is empty but the historical series has points, the account previously held investments. The series itself is the relevant signal.
+
+`showsAggregateChart` (`showsChart && totalValue != nil`) does not need a separate change: when `positions` is empty, `totalValue` returns `InstrumentAmount.zero(hostCurrency)` (not `nil`), so it stays compatible with the relaxed `showsChart`.
+
+`shouldHide` is **not** changed. Its contract — "the positions table component should render nothing" — stays accurate. The chart is composed at the view layer alongside `PositionsView`, not inside it.
+
+### 2. `Features/Investments/Views/InvestmentAccountView.swift`
+
+Modify `positionTrackedLayout`. Today:
+
+```swift
+@ViewBuilder private var positionTrackedLayout: some View {
+  if positionsInput.shouldHide && !isLoadingPositions {
+    makeAccountTransactionList()
+  } else {
+    PositionsTransactionsSplit(
+      defaultTab: .positions,
+      autosaveName: "positions-transactions-split.with-chart",
+      initialTopHeight: 540
+    ) {
+      if isLoadingPositions && positionsInput.positions.isEmpty {
+        ProgressView()...
+      } else {
+        PositionsView(input: positionsInput, range: $positionsRange)
+      }
+    } transactions: {
+      makeAccountTransactionList()
+    }
+  }
+}
+```
+
+After:
+
+```swift
+@ViewBuilder private var positionTrackedLayout: some View {
+  if positionsInput.shouldHide && !isLoadingPositions {
+    if positionsInput.hasHistoricalSeries {
+      chartOnlySplit
+    } else {
+      makeAccountTransactionList()
+    }
+  } else {
+    standardPositionsSplit
+  }
+}
+```
+
+Where `chartOnlySplit` reuses the same `PositionsTransactionsSplit` shape (same `autosaveName`, same `initialTopHeight`) but the top pane is the chart on its own:
+
+```swift
+@ViewBuilder private var chartOnlySplit: some View {
+  PositionsTransactionsSplit(
+    defaultTab: .positions,
+    autosaveName: "positions-transactions-split.with-chart",
+    initialTopHeight: 540
+  ) {
+    PositionsChart(
+      input: positionsInput,
+      range: $positionsRange,
+      selectedInstrument: .constant(nil)
+    )
+  } transactions: {
+    makeAccountTransactionList()
+  }
+}
+```
+
+`selectedInstrument` is bound to `.constant(nil)` because there are no positions to filter to; per-instrument selection chips are meaningless in this state. `PositionsChart`'s body already renders its own range picker and an empty-state message ("No chart data yet") when `visiblePoints` is empty for the active range.
+
+`standardPositionsSplit` is the existing `PositionsTransactionsSplit { PositionsView }` body, hoisted into its own `@ViewBuilder` so the if/else above stays readable.
+
+### 3. Tests
+
+Add to `MoolahTests/Domain/PositionsViewInputTests.swift` (Swift Testing):
+
+- `hasHistoricalSeries` returns `false` when `historicalValue` is `nil`.
+- `hasHistoricalSeries` returns `false` when `historicalValue?.total.isEmpty == true`.
+- `hasHistoricalSeries` returns `true` when `historicalValue?.total` has at least one point.
+- `showsChart` returns `true` when `positions.isEmpty` and the historical aggregate series has points.
+- `showsChart` continues to return `false` when `positions.isEmpty` and `historicalValue` is `nil` or has empty `total`.
+- Existing positive/negative cases for `showsChart` with non-empty `positions` continue to pass unchanged.
+
+Add `MoolahTests/Features/Investments/InvestmentStoreFullySoldChartTests.swift` (Swift Testing):
+
+- Seed a position-tracked account on `TestBackend`: buys + matching sells so every position quantity returns to zero.
+- Call `investmentStore.loadAndBuildPositionsInput(account:profileCurrency:range:)` with `range: .allTime`.
+- Assert on the returned `PositionsViewInput`:
+  - `shouldHide == true` (no current positions)
+  - `hasHistoricalSeries == true`
+  - `showsChart == true`
+  - `showsAggregateChart == true`
+- Companion case: an account with no transactions at all → `shouldHide == true`, `hasHistoricalSeries == false`, `showsChart == false`. Confirms the "bare transactions" path is still chosen.
+
+UI test coverage is out of scope. The store-level test plus the existing screen driver are sufficient — the view-layer wiring is a thin pass-through into `PositionsChart`, which already has its own previews and tests.
+
+## Verification
+
+- `just test` passes.
+- Manual: load a position-tracked account with all positions sold and confirm the chart renders at the top with transactions below. Range picker still works.
+- Manual: load a brand-new position-tracked account with no transactions and confirm the bare transaction list still appears.
+- Manual: load a position-tracked account with open positions and confirm the existing chart + tiles + positions table layout is unchanged.

--- a/plans/2026-05-15-fully-sold-investment-chart-plan.md
+++ b/plans/2026-05-15-fully-sold-investment-chart-plan.md
@@ -1,0 +1,816 @@
+# Fully-Sold Investment Chart — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show the value-over-time chart at the top of a position-tracked investment account view even when all positions have been sold (current value = 0).
+
+**Architecture:** Two surgical changes — relax `PositionsViewInput.showsChart` to allow rendering when current positions is empty but the historical aggregate series has points, plus add a `hasHistoricalSeries` helper; wire `InvestmentAccountView.positionTrackedLayout` to render `PositionsChart` (no header/tiles/table) in a new chart-only branch when `shouldHide` is true but `hasHistoricalSeries` is true.
+
+**Tech Stack:** Swift 6, SwiftUI (iOS 26 / macOS 26), Swift Testing (`@Suite` / `@Test`), GRDB-backed `TestBackend`, xcodegen project generation, `just` build targets.
+
+**Working directory:** All paths in this plan are relative to the worktree root `/Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/investment-chart-fully-sold`. Run every `just` and `git` command via `just -d <root>` or `git -C <root>` — never `cd`.
+
+**Pre-task setup (run once before Task 1):**
+
+```bash
+mkdir -p /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/investment-chart-fully-sold/.agent-tmp
+```
+
+The `.agent-tmp/` directory is gitignored and is where test output gets captured per project rules.
+
+---
+
+## File map
+
+- Modify: `Domain/Models/PositionsViewInput.swift` — add `hasHistoricalSeries`; relax `showsChart`.
+- Modify: `MoolahTests/Domain/PositionsViewInputTests.swift` — add new cases; update the two existing cases that exercised the old "non-empty positions + empty `total`" path.
+- Create: `MoolahTests/Features/Investments/InvestmentStoreFullySoldChartTests.swift` — store-level integration coverage.
+- Modify: `Features/Investments/Views/InvestmentAccountView.swift` — split `positionTrackedLayout` into a `chartOnlySplit` / `standardPositionsSplit` pair, gated on `hasHistoricalSeries`.
+- Modify: `Features/Investments/Views/InvestmentAccountView+Previews.swift` — add a "Position-tracked (fully sold)" preview that seeds matched buy + sell pairs.
+
+`PositionsView`, `PositionsChart`, `PositionsTransactionsSplit`, `PositionsHistoryBuilder`, and the legacy `recordedValue` layout are **not** touched.
+
+---
+
+## Task 1: Add `hasHistoricalSeries` to `PositionsViewInput`
+
+**Files:**
+
+- Modify: `Domain/Models/PositionsViewInput.swift`
+- Modify: `MoolahTests/Domain/PositionsViewInputTests.swift`
+
+- [ ] **Step 1: Add three failing tests for `hasHistoricalSeries`**
+
+Append to `MoolahTests/Domain/PositionsViewInputTests.swift` immediately after the final closing `}` of the `subtotalsRequireMultipleKinds` test (around line 209), before the suite's closing `}`:
+
+```swift
+  @Test("hasHistoricalSeries is false when historicalValue is nil")
+  func historicalSeriesAbsentWhenNoSeries() {
+    let input = PositionsViewInput(
+      title: "x", hostCurrency: aud, positions: [], historicalValue: nil)
+    #expect(!input.hasHistoricalSeries)
+  }
+
+  @Test("hasHistoricalSeries is false when total is empty")
+  func historicalSeriesAbsentWhenTotalEmpty() {
+    let input = PositionsViewInput(
+      title: "x", hostCurrency: aud, positions: [],
+      historicalValue: HistoricalValueSeries(
+        hostCurrency: aud, total: [], perInstrument: [:]))
+    #expect(!input.hasHistoricalSeries)
+  }
+
+  @Test("hasHistoricalSeries is true when total has at least one point")
+  func historicalSeriesPresentWhenTotalHasPoints() {
+    let point = HistoricalValueSeries.Point(
+      date: Date(), value: 100, cost: 80, contributions: 80)
+    let input = PositionsViewInput(
+      title: "x", hostCurrency: aud, positions: [],
+      historicalValue: HistoricalValueSeries(
+        hostCurrency: aud, total: [point], perInstrument: [:]))
+    #expect(input.hasHistoricalSeries)
+  }
+```
+
+- [ ] **Step 2: Run the new tests to verify they fail to compile**
+
+```bash
+just -d /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/investment-chart-fully-sold test PositionsViewInputTests 2>&1 | tee .agent-tmp/test-output.txt
+```
+
+Expected: build fails with three errors of the form `value of type 'PositionsViewInput' has no member 'hasHistoricalSeries'`. Confirm by grepping:
+
+```bash
+grep -F "has no member 'hasHistoricalSeries'" /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/investment-chart-fully-sold/.agent-tmp/test-output.txt
+```
+
+Expected: three matches.
+
+- [ ] **Step 3: Implement `hasHistoricalSeries`**
+
+In `Domain/Models/PositionsViewInput.swift`, immediately after `showsAggregateChart` (around line 63) and before `showsGroupSubtotals`, insert:
+
+```swift
+  /// `true` iff `historicalValue` exists and its aggregate `total` series
+  /// has at least one point. The view layer reads this to decide whether
+  /// a chart-only surface is worth rendering when `shouldHide` is true —
+  /// e.g. a position-tracked investment account where every holding has
+  /// been sold but the historical performance is still meaningful.
+  var hasHistoricalSeries: Bool {
+    guard let series = historicalValue else { return false }
+    return !series.total.isEmpty
+  }
+```
+
+- [ ] **Step 4: Run the new tests to verify they pass**
+
+```bash
+just -d /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/investment-chart-fully-sold test PositionsViewInputTests 2>&1 | tee .agent-tmp/test-output.txt
+```
+
+Expected: build succeeds, all `PositionsViewInputTests` cases pass. Confirm:
+
+```bash
+grep -E "Test run with [0-9]+ tests passed" /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/investment-chart-fully-sold/.agent-tmp/test-output.txt
+grep -i "failed" /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/investment-chart-fully-sold/.agent-tmp/test-output.txt
+```
+
+Expected: first grep matches at least once; second grep returns no lines.
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+just -d /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/investment-chart-fully-sold format
+git -C /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/investment-chart-fully-sold add Domain/Models/PositionsViewInput.swift MoolahTests/Domain/PositionsViewInputTests.swift
+git -C /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/investment-chart-fully-sold commit -m "$(cat <<'EOF'
+feat(positions): add PositionsViewInput.hasHistoricalSeries
+
+True iff `historicalValue` exists and its `total` series has at least one
+point. Lets the view layer decide whether to render a chart-only surface
+when `shouldHide` is true — used in the next step for fully-sold
+position-tracked investment accounts.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+```bash
+rm /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/investment-chart-fully-sold/.agent-tmp/test-output.txt
+```
+
+---
+
+## Task 2: Relax `PositionsViewInput.showsChart`
+
+**Files:**
+
+- Modify: `Domain/Models/PositionsViewInput.swift`
+- Modify: `MoolahTests/Domain/PositionsViewInputTests.swift`
+
+This task changes the contract of `showsChart`. New rule:
+
+- The chart renders when `historicalValue` exists **and** its `total` series has at least one point.
+- When `positions` is non-empty, at least one row must carry cost basis (preserves "this is an investment account" check).
+- When `positions` is empty, the historical series alone is sufficient (the new behaviour).
+
+Two existing tests in `PositionsViewInputTests.swift` rely on the old looser definition of `historicalValue != nil` regardless of `total`. They must be updated to provide a non-empty `total` so their original intent ("show chart when conditions are met") still holds.
+
+- [ ] **Step 1: Add new failing tests for the relaxed contract**
+
+Append three new tests inside the `@Suite("PositionsViewInput")` body (after the `hasHistoricalSeries` tests added in Task 1):
+
+```swift
+  @Test("showsChart is true when positions is empty but historical total has points")
+  func chartVisibleForEmptyPositionsWithHistory() {
+    let point = HistoricalValueSeries.Point(
+      date: Date(), value: 100, cost: 80, contributions: 80)
+    let input = PositionsViewInput(
+      title: "x", hostCurrency: aud, positions: [],
+      historicalValue: HistoricalValueSeries(
+        hostCurrency: aud, total: [point], perInstrument: [:]))
+    #expect(input.showsChart)
+  }
+
+  @Test("showsChart is false when positions is empty and historical total is empty")
+  func chartHiddenForEmptyPositionsWithoutHistory() {
+    let input = PositionsViewInput(
+      title: "x", hostCurrency: aud, positions: [],
+      historicalValue: HistoricalValueSeries(
+        hostCurrency: aud, total: [], perInstrument: [:]))
+    #expect(!input.showsChart)
+  }
+
+  @Test("showsChart is false when positions has cost basis but historical total is empty")
+  func chartHiddenWhenCostBasisButNoHistoricalPoints() {
+    let input = PositionsViewInput(
+      title: "x", hostCurrency: aud,
+      positions: [
+        ValuedPosition(
+          instrument: bhp, quantity: 1, unitPrice: nil,
+          costBasis: amount(50), value: amount(60))
+      ],
+      historicalValue: HistoricalValueSeries(
+        hostCurrency: aud, total: [], perInstrument: [:]))
+    #expect(!input.showsChart)
+  }
+```
+
+- [ ] **Step 2: Update the two existing tests that used empty `total` with non-empty positions**
+
+In `MoolahTests/Domain/PositionsViewInputTests.swift`, locate the `chartVisibleWithSeriesAndCostBasis` test (around line 168). Its body currently constructs `HistoricalValueSeries(hostCurrency: aud, total: [], perInstrument: [:])`. Replace the body so it supplies a non-empty `total`:
+
+```swift
+  @Test("showsChart is true when historicalValue has points and at least one row carries cost basis")
+  func chartVisibleWithSeriesAndCostBasis() {
+    let point = HistoricalValueSeries.Point(
+      date: Date(), value: 60, cost: 50, contributions: 50)
+    let input = PositionsViewInput(
+      title: "x", hostCurrency: aud,
+      positions: [
+        ValuedPosition(
+          instrument: bhp, quantity: 1, unitPrice: nil,
+          costBasis: amount(50), value: amount(60))
+      ],
+      historicalValue: HistoricalValueSeries(
+        hostCurrency: aud, total: [point], perInstrument: [:])
+    )
+    #expect(input.showsChart)
+  }
+```
+
+Then locate `aggregateChartHiddenOnFailure` (around line 125). Its body also uses empty `total` and asserts `input.showsChart == true`; replace it with a non-empty `total` so the intent (aggregate hidden but chart container still shown) survives:
+
+```swift
+  @Test("showsAggregateChart is false when any row's value is nil")
+  func aggregateChartHiddenOnFailure() {
+    let point = HistoricalValueSeries.Point(
+      date: Date(), value: 60, cost: 50, contributions: 50)
+    let input = PositionsViewInput(
+      title: "x", hostCurrency: aud,
+      positions: [
+        ValuedPosition(
+          instrument: bhp, quantity: 1, unitPrice: nil,
+          costBasis: amount(50), value: amount(60)),
+        ValuedPosition(
+          instrument: bhp, quantity: 1, unitPrice: nil,
+          costBasis: amount(40), value: nil),
+      ],
+      historicalValue: HistoricalValueSeries(
+        hostCurrency: aud, total: [point], perInstrument: [:])
+    )
+    #expect(!input.showsAggregateChart)
+    #expect(input.showsChart)  // chart can still render for working instruments
+  }
+```
+
+The two existing tests that already used `historicalValue: nil` (`chartHiddenWithoutSeries`) or already pass through the new logic (`chartHiddenWithoutAnyCostBasis`) are left untouched.
+
+- [ ] **Step 3: Run the suite to verify the failures**
+
+```bash
+just -d /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/investment-chart-fully-sold test PositionsViewInputTests 2>&1 | tee .agent-tmp/test-output.txt
+```
+
+Expected: at least `chartVisibleForEmptyPositionsWithHistory` fails (it expects `showsChart == true` for empty positions but the old code returns false). Confirm:
+
+```bash
+grep "chartVisibleForEmptyPositionsWithHistory" /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/investment-chart-fully-sold/.agent-tmp/test-output.txt
+```
+
+Expected: at least one line containing "failed" near the test name.
+
+- [ ] **Step 4: Implement the relaxed `showsChart`**
+
+In `Domain/Models/PositionsViewInput.swift`, locate `showsChart` (currently around lines 55-58):
+
+```swift
+  var showsChart: Bool {
+    guard historicalValue != nil else { return false }
+    return positions.contains(where: { $0.hasCostBasis })
+  }
+```
+
+Replace with:
+
+```swift
+  /// `true` iff the chart container is rendered at all. Requires a
+  /// non-empty aggregate historical series, and — when current positions
+  /// exist — at least one of them carrying cost basis. An empty `positions`
+  /// array is allowed (the historic series alone is sufficient): supports
+  /// position-tracked investment accounts where every holding has been
+  /// sold but the user still wants to inspect prior performance.
+  var showsChart: Bool {
+    guard let series = historicalValue, !series.total.isEmpty else { return false }
+    return positions.isEmpty || positions.contains(where: { $0.hasCostBasis })
+  }
+```
+
+- [ ] **Step 5: Run the suite to verify all tests pass**
+
+```bash
+just -d /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/investment-chart-fully-sold test PositionsViewInputTests 2>&1 | tee .agent-tmp/test-output.txt
+grep -i "failed" /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/investment-chart-fully-sold/.agent-tmp/test-output.txt
+```
+
+Expected: second grep returns no lines.
+
+- [ ] **Step 6: Run the wider domain suite to catch any indirect regressions**
+
+```bash
+just -d /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/investment-chart-fully-sold test PositionsViewInputShouldHideTests 2>&1 | tee .agent-tmp/test-output.txt
+grep -i "failed" /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/investment-chart-fully-sold/.agent-tmp/test-output.txt
+```
+
+Expected: no failures. `shouldHide` was not changed, so this should be a no-op safety check.
+
+- [ ] **Step 7: Format and commit**
+
+```bash
+just -d /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/investment-chart-fully-sold format
+git -C /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/investment-chart-fully-sold add Domain/Models/PositionsViewInput.swift MoolahTests/Domain/PositionsViewInputTests.swift
+git -C /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/investment-chart-fully-sold commit -m "$(cat <<'EOF'
+feat(positions): allow showsChart with empty positions and non-empty history
+
+`showsChart` previously required a current position with cost basis. For a
+position-tracked investment account where every holding has been sold the
+positions array is empty, even though the historic value series still
+carries meaningful points. Relaxing the rule — non-empty `historicalValue.total`
+plus either an empty positions array OR a cost-basis row — lets the view
+layer expose that history. Empty `total` now also fails the chart gate, so
+two existing tests that constructed an empty total are tightened.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+```bash
+rm /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/investment-chart-fully-sold/.agent-tmp/test-output.txt
+```
+
+---
+
+## Task 3: Integration test — fully-sold account end-to-end
+
+**Files:**
+
+- Create: `MoolahTests/Features/Investments/InvestmentStoreFullySoldChartTests.swift`
+- Modify: `project.yml` (only if `MoolahTests/Features/Investments/` is not already wildcarded as a sources entry — verify in Step 0)
+
+After Tasks 1-2 the underlying contract is in place. This task adds a store-level test that exercises the real path `InvestmentStore.loadAndBuildPositionsInput` takes for a fully-sold account, against `TestBackend` (GRDB-backed in-memory store).
+
+- [ ] **Step 0: Confirm `project.yml` already includes `MoolahTests/Features/Investments/`**
+
+```bash
+grep -n "Features/Investments" /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/investment-chart-fully-sold/project.yml
+```
+
+Expected: at least one match showing `MoolahTests/Features/Investments` (or a parent wildcard like `MoolahTests`). The peer file `MoolahTests/Features/Investments/InvestmentStoreSyncRefreshTests.swift` already exists, so the directory is already in sources and no `project.yml` edit is needed. If the grep returns nothing, stop and add `MoolahTests/Features/Investments` under the test target's `sources:` block and re-run `just generate`.
+
+- [ ] **Step 1: Write the new test file**
+
+Create `MoolahTests/Features/Investments/InvestmentStoreFullySoldChartTests.swift`:
+
+```swift
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@MainActor
+@Suite("InvestmentStore fully-sold account chart")
+struct InvestmentStoreFullySoldChartTests {
+  let aud = Instrument.AUD
+  let bhp = Instrument.stock(ticker: "BHP.AX", exchange: "ASX", name: "BHP")
+
+  @Test("fully-sold account yields shouldHide + hasHistoricalSeries + showsChart")
+  func fullySoldAccountSurfacesChart() async throws {
+    let (backend, _) = try TestBackend.create()
+    let conversionService = FixedConversionService(rates: [bhp.id: Decimal(50)])
+    let store = InvestmentStore(
+      repository: backend.investments,
+      transactionRepository: backend.transactions,
+      conversionService: conversionService
+    )
+    let account = Account(
+      name: "Brokerage", type: .investment, instrument: aud,
+      valuationMode: .calculatedFromTrades)
+    _ = try await backend.accounts.create(
+      account, openingBalance: InstrumentAmount(quantity: 0, instrument: aud))
+
+    // Buy 100 BHP @ 40 AUD on day -30.
+    _ = try await backend.transactions.create(
+      Transaction(
+        date: Date(timeIntervalSinceNow: -86_400 * 30),
+        legs: [
+          TransactionLeg(accountId: account.id, instrument: bhp, quantity: 100, type: .trade),
+          TransactionLeg(accountId: account.id, instrument: aud, quantity: -4_000, type: .trade),
+        ]))
+    // Sell all 100 BHP @ 50 AUD on day -10.
+    _ = try await backend.transactions.create(
+      Transaction(
+        date: Date(timeIntervalSinceNow: -86_400 * 10),
+        legs: [
+          TransactionLeg(accountId: account.id, instrument: bhp, quantity: -100, type: .trade),
+          TransactionLeg(accountId: account.id, instrument: aud, quantity: 5_000, type: .trade),
+        ]))
+
+    let input = try await store.loadAndBuildPositionsInput(
+      account: account, profileCurrency: aud, range: .threeMonths)
+
+    #expect(input.positions.isEmpty)
+    #expect(input.shouldHide)
+    #expect(input.hasHistoricalSeries)
+    #expect(input.showsChart)
+    #expect(input.showsAggregateChart)
+  }
+
+  @Test("brand-new account with no transactions still falls back to bare transactions path")
+  func emptyAccountStillHidesChart() async throws {
+    let (backend, _) = try TestBackend.create()
+    let store = InvestmentStore(
+      repository: backend.investments,
+      transactionRepository: backend.transactions,
+      conversionService: backend.conversionService
+    )
+    let account = Account(
+      name: "Brokerage", type: .investment, instrument: aud,
+      valuationMode: .calculatedFromTrades)
+    _ = try await backend.accounts.create(
+      account, openingBalance: InstrumentAmount(quantity: 0, instrument: aud))
+
+    let input = try await store.loadAndBuildPositionsInput(
+      account: account, profileCurrency: aud, range: .threeMonths)
+
+    #expect(input.positions.isEmpty)
+    #expect(input.shouldHide)
+    #expect(!input.hasHistoricalSeries)
+    #expect(!input.showsChart)
+  }
+}
+```
+
+- [ ] **Step 2: Regenerate the Xcode project so the new file is picked up**
+
+```bash
+just -d /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/investment-chart-fully-sold generate
+```
+
+Expected: `xcodegen` reports success; `Moolah.xcodeproj` is rewritten.
+
+- [ ] **Step 3: Run the new suite**
+
+```bash
+just -d /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/investment-chart-fully-sold test InvestmentStoreFullySoldChartTests 2>&1 | tee .agent-tmp/test-output.txt
+grep -i "failed\|error:" /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/investment-chart-fully-sold/.agent-tmp/test-output.txt
+```
+
+Expected: grep returns no lines. Both cases should pass on the first run — the relaxations from Tasks 1-2 already enable this behaviour at the model level.
+
+- [ ] **Step 4: Format and commit**
+
+```bash
+just -d /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/investment-chart-fully-sold format
+git -C /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/investment-chart-fully-sold add MoolahTests/Features/Investments/InvestmentStoreFullySoldChartTests.swift
+git -C /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/investment-chart-fully-sold commit -m "$(cat <<'EOF'
+test(investments): integration coverage for fully-sold chart-only path
+
+Pins the contract the view layer relies on: a position-tracked account
+whose holdings have all been sold reports `shouldHide` (no positions) AND
+`hasHistoricalSeries` AND `showsChart`, while a brand-new account with no
+transactions still reports `shouldHide` without `hasHistoricalSeries`.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+```bash
+rm /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/investment-chart-fully-sold/.agent-tmp/test-output.txt
+```
+
+---
+
+## Task 4: View wiring — chart-only branch in `InvestmentAccountView`
+
+**Files:**
+
+- Modify: `Features/Investments/Views/InvestmentAccountView.swift`
+
+The current `positionTrackedLayout` (lines 91-117) collapses to the bare transaction list when `shouldHide && !isLoadingPositions`. Split it so a non-empty historical series instead routes to a chart-only `PositionsTransactionsSplit`.
+
+- [ ] **Step 1: Replace `positionTrackedLayout` and add the two sibling layouts**
+
+In `Features/Investments/Views/InvestmentAccountView.swift`, locate the existing `positionTrackedLayout` declaration (around line 91). It currently reads:
+
+```swift
+  @ViewBuilder private var positionTrackedLayout: some View {
+    if positionsInput.shouldHide && !isLoadingPositions {
+      makeAccountTransactionList()
+    } else {
+      PositionsTransactionsSplit(
+        defaultTab: .positions,
+        // Distinct autosave key from the chartless multi-currency split so
+        // the saved divider position from each layout doesn't bleed into
+        // the other; the chart pushes the table off-screen at the
+        // chartless 180pt default.
+        autosaveName: "positions-transactions-split.with-chart",
+        // Header (~50pt) + chart (~250pt with padding) + a few table rows
+        // need ~530pt to render comfortably without the user dragging.
+        initialTopHeight: 540
+      ) {
+        if isLoadingPositions && positionsInput.positions.isEmpty {
+          ProgressView()
+            .frame(maxWidth: .infinity)
+            .padding()
+        } else {
+          PositionsView(input: positionsInput, range: $positionsRange)
+        }
+      } transactions: {
+        makeAccountTransactionList()
+      }
+    }
+  }
+```
+
+Replace this single declaration with the following three:
+
+```swift
+  /// The positions/transactions composition for non-legacy accounts.
+  /// Three branches:
+  ///   - Positions exist (or are still loading): show the full
+  ///     `PositionsView` with header, optional chart, and table.
+  ///   - Positions empty but historic series has points: show a chart-only
+  ///     surface so the user can review prior performance.
+  ///   - Positions empty and no history: collapse to the bare transaction
+  ///     list, the same as today.
+  @ViewBuilder private var positionTrackedLayout: some View {
+    if positionsInput.shouldHide && !isLoadingPositions {
+      if positionsInput.hasHistoricalSeries {
+        chartOnlySplit
+      } else {
+        makeAccountTransactionList()
+      }
+    } else {
+      standardPositionsSplit
+    }
+  }
+
+  /// Full positions surface — header (or performance tiles), optional
+  /// chart, and the responsive table. Used when current positions exist.
+  @ViewBuilder private var standardPositionsSplit: some View {
+    PositionsTransactionsSplit(
+      defaultTab: .positions,
+      // Distinct autosave key from the chartless multi-currency split so
+      // the saved divider position from each layout doesn't bleed into
+      // the other; the chart pushes the table off-screen at the
+      // chartless 180pt default.
+      autosaveName: "positions-transactions-split.with-chart",
+      // Header (~50pt) + chart (~250pt with padding) + a few table rows
+      // need ~530pt to render comfortably without the user dragging.
+      initialTopHeight: 540
+    ) {
+      if isLoadingPositions && positionsInput.positions.isEmpty {
+        ProgressView()
+          .frame(maxWidth: .infinity)
+          .padding()
+      } else {
+        PositionsView(input: positionsInput, range: $positionsRange)
+      }
+    } transactions: {
+      makeAccountTransactionList()
+    }
+  }
+
+  /// Chart-only top pane for a position-tracked account that currently
+  /// holds nothing but has historical activity. Reuses the same
+  /// `autosaveName` as `standardPositionsSplit` so the divider position
+  /// the user has chosen for this account shape persists across the two
+  /// branches. `selectedInstrument` is pinned to `.constant(nil)` —
+  /// there are no positions to filter to, so the per-instrument selection
+  /// chip would never appear.
+  @ViewBuilder private var chartOnlySplit: some View {
+    PositionsTransactionsSplit(
+      defaultTab: .positions,
+      autosaveName: "positions-transactions-split.with-chart",
+      initialTopHeight: 540
+    ) {
+      PositionsChart(
+        input: positionsInput,
+        range: $positionsRange,
+        selectedInstrument: .constant(nil))
+    } transactions: {
+      makeAccountTransactionList()
+    }
+  }
+```
+
+No other part of the file changes. In particular, `body`, `legacyValuationsLayout`, `legacySummary`, `legacyChartAndValuations`, the `valuationsList`/`valuationsHeader`/`valuationsBody` group, and the `timePeriodPicker` are unchanged.
+
+- [ ] **Step 2: Build for macOS to confirm the changes compile**
+
+```bash
+just -d /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/investment-chart-fully-sold build-mac 2>&1 | tee .agent-tmp/build.txt
+grep -E "error:|warning:" /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/investment-chart-fully-sold/.agent-tmp/build.txt
+```
+
+Expected: no `error:` lines; no new `warning:` lines (preview-macro warnings emitted from `#Preview` blocks are fine and can be ignored per CLAUDE.md).
+
+- [ ] **Step 3: Re-run the investment-related test suites**
+
+```bash
+just -d /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/investment-chart-fully-sold test InvestmentStoreFullySoldChartTests PositionsViewInputTests PositionsViewInputShouldHideTests InvestmentStorePositionsInputTests 2>&1 | tee .agent-tmp/test-output.txt
+grep -i "failed\|error:" /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/investment-chart-fully-sold/.agent-tmp/test-output.txt
+```
+
+Expected: grep returns no lines. The view change is data-driven via `hasHistoricalSeries` / `shouldHide` — the existing suites still cover the model semantics.
+
+- [ ] **Step 4: Format and commit**
+
+```bash
+just -d /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/investment-chart-fully-sold format
+git -C /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/investment-chart-fully-sold add Features/Investments/Views/InvestmentAccountView.swift
+git -C /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/investment-chart-fully-sold commit -m "$(cat <<'EOF'
+feat(investments): show value-over-time chart when positions all sold
+
+`positionTrackedLayout` now routes through a third branch: when
+`positionsInput.shouldHide` (no current positions) but
+`hasHistoricalSeries` is true, the top pane renders just `PositionsChart`
+— no performance tiles, no positions table — so the user can still review
+prior performance after closing out every holding. Truly empty accounts
+(no historic data) keep today's bare transaction list. Reuses the existing
+`positions-transactions-split.with-chart` autosave key so the divider
+position persists across the two branches.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+```bash
+rm /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/investment-chart-fully-sold/.agent-tmp/build.txt /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/investment-chart-fully-sold/.agent-tmp/test-output.txt
+```
+
+---
+
+## Task 5: Preview for fully-sold state
+
+**Files:**
+
+- Modify: `Features/Investments/Views/InvestmentAccountView+Previews.swift`
+
+Adds a third `#Preview` so the chart-only path is visible in Xcode's canvas. Useful both for review and for future UI work.
+
+- [ ] **Step 1: Add a `seedFullySoldPositions` helper and a `#Preview` entry**
+
+At the bottom of `Features/Investments/Views/InvestmentAccountView+Previews.swift`, after the existing `seedPositionValuations` helper and `#Preview("Position-tracked")` block, append:
+
+```swift
+@MainActor
+private func seedFullySoldPositions(backend: any BackendProvider, account: Account) async {
+  let bhp = Instrument.stock(ticker: "BHP.AX", exchange: "ASX", name: "BHP")
+  _ = try? await backend.accounts.create(
+    account, openingBalance: InstrumentAmount(quantity: 0, instrument: .AUD))
+  // Buy 100 BHP @ 40 AUD on day -45.
+  _ = try? await backend.transactions.create(
+    Transaction(
+      date: Date().addingTimeInterval(-86_400 * 45),
+      legs: [
+        TransactionLeg(accountId: account.id, instrument: bhp, quantity: 100, type: .trade),
+        TransactionLeg(accountId: account.id, instrument: .AUD, quantity: -4_000, type: .trade),
+      ]))
+  // Sell all 100 BHP @ 50 AUD on day -15.
+  _ = try? await backend.transactions.create(
+    Transaction(
+      date: Date().addingTimeInterval(-86_400 * 15),
+      legs: [
+        TransactionLeg(accountId: account.id, instrument: bhp, quantity: -100, type: .trade),
+        TransactionLeg(accountId: account.id, instrument: .AUD, quantity: 5_000, type: .trade),
+      ]))
+}
+
+#Preview("Position-tracked (fully sold)") {
+  let backend = PreviewBackend.create()
+  let investmentStore = InvestmentStore(
+    repository: backend.investments,
+    transactionRepository: backend.transactions,
+    conversionService: backend.conversionService)
+  let transactionStore = TransactionStore(
+    repository: backend.transactions,
+    conversionService: backend.conversionService,
+    targetInstrument: .AUD)
+  // In-memory preview session can't fail in practice: opens an ephemeral
+  // GRDB queue with no disk access. A trap here is acceptable in #Preview.
+  // swiftlint:disable:next force_try
+  let session = try! ProfileSession.preview()
+  let account = Account(
+    name: "Brokerage",
+    type: .investment,
+    instrument: .AUD,
+    valuationMode: .calculatedFromTrades)
+  return NavigationStack {
+    InvestmentAccountView(
+      account: account,
+      accounts: Accounts(from: [account]),
+      categories: Categories(from: []),
+      earmarks: Earmarks(from: []),
+      investmentStore: investmentStore,
+      transactionStore: transactionStore
+    )
+  }
+  .previewProfileEnvironment(session: session)
+  .frame(width: 720, height: 600)
+  .task { await seedFullySoldPositions(backend: backend, account: account) }
+}
+```
+
+- [ ] **Step 2: Build to confirm the preview compiles**
+
+```bash
+just -d /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/investment-chart-fully-sold build-mac 2>&1 | tee .agent-tmp/build.txt
+grep -E "error:" /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/investment-chart-fully-sold/.agent-tmp/build.txt
+```
+
+Expected: no `error:` lines.
+
+- [ ] **Step 3: Format and commit**
+
+```bash
+just -d /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/investment-chart-fully-sold format
+git -C /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/investment-chart-fully-sold add Features/Investments/Views/InvestmentAccountView+Previews.swift
+git -C /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/investment-chart-fully-sold commit -m "$(cat <<'EOF'
+chore(investments): preview for fully-sold position-tracked account
+
+Seeds a matched buy + sell pair so positions return to zero, demonstrating
+the chart-only branch added to `positionTrackedLayout`.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+```bash
+rm /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/investment-chart-fully-sold/.agent-tmp/build.txt
+```
+
+---
+
+## Task 6: Full pre-PR verification
+
+- [ ] **Step 1: Full format-check**
+
+```bash
+just -d /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/investment-chart-fully-sold format-check
+```
+
+Expected: exit code 0, no diff suggestions.
+
+- [ ] **Step 2: Full test suite (iOS + macOS)**
+
+```bash
+just -d /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/investment-chart-fully-sold test 2>&1 | tee .agent-tmp/test-output.txt
+grep -i "failed\|error:" /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/investment-chart-fully-sold/.agent-tmp/test-output.txt
+```
+
+Expected: grep returns no lines. If anything fails, do NOT amend earlier commits — debug, fix, and add a new commit.
+
+- [ ] **Step 3: Manual macOS verification**
+
+Open the project in Xcode (`open /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/investment-chart-fully-sold/Moolah.xcodeproj`) and render each preview in `InvestmentAccountView+Previews.swift`:
+
+- **Default** (legacy recorded-value): existing behaviour, no change expected.
+- **Position-tracked**: existing behaviour — tiles + chart + positions table + transactions.
+- **Position-tracked (fully sold)** (new): chart at the top with a populated curve, transactions below; no tiles, no positions table.
+
+If `mcp__xcode__RenderPreview` is being used, point it at the worktree's `Moolah.xcodeproj` per the project's worktree preview rules (CLAUDE.md §Xcode previews and the RenderPreview tool from a worktree).
+
+- [ ] **Step 4: Clean up `.agent-tmp/`**
+
+```bash
+rm -rf /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/investment-chart-fully-sold/.agent-tmp
+```
+
+- [ ] **Step 5: Push the branch and open the PR**
+
+```bash
+git -C /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/investment-chart-fully-sold push origin fix/investment-chart-fully-sold:fix/investment-chart-fully-sold
+gh pr create --repo ajsutton/moolah-native --base main --head fix/investment-chart-fully-sold \
+  --title "Show value-over-time chart for fully-sold position-tracked accounts" \
+  --body "$(cat <<'EOF'
+## Summary
+- Adds `PositionsViewInput.hasHistoricalSeries` and relaxes `showsChart` so the chart container renders when current positions are empty but the historic aggregate series has points.
+- `InvestmentAccountView.positionTrackedLayout` gains a chart-only branch: when every holding has been sold, the top pane renders just `PositionsChart` — no performance tiles, no positions table — so prior performance is still visible. Truly empty accounts (no history) keep today's bare transaction list.
+- Adds an `InvestmentStoreFullySoldChartTests` suite + a `#Preview("Position-tracked (fully sold)")` for canvas review.
+
+Design spec: `plans/2026-05-15-fully-sold-investment-chart-design.md`.
+
+## Test plan
+- [ ] `just test` passes on macOS and iOS.
+- [ ] `just format-check` passes.
+- [ ] Manual: position-tracked account with all positions sold renders chart at the top, transactions below.
+- [ ] Manual: position-tracked account with open positions still renders tiles + chart + positions table (no regression).
+- [ ] Manual: brand-new position-tracked account with no transactions still renders the bare transaction list.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+After the PR is open, hand it off to the merge-queue per the user's standing preference (do not merge manually).
+
+---
+
+## Self-review
+
+**Spec coverage:**
+
+- Spec §Design.1 (`hasHistoricalSeries` + relaxed `showsChart`) → Tasks 1 + 2.
+- Spec §Design.2 (`InvestmentAccountView.positionTrackedLayout` chart-only branch) → Task 4.
+- Spec §Tests (PositionsViewInput cases + InvestmentStoreFullySoldChartTests) → Tasks 1, 2, 3.
+- Spec §Verification (full suite + manual cases) → Task 6.
+- Spec §"What is not changed" (PositionsView, PositionsChart, PositionsHistoryBuilder, shouldHide, legacy layout) — none of those files are touched in any task; verified by file map.
+
+**Placeholder scan:** No "TBD", "add appropriate error handling", or "similar to Task N" placeholders. Every step has either exact code, an exact command, or both.
+
+**Type consistency:** `hasHistoricalSeries` is the same name in Tasks 1, 2, 3, 4. `chartOnlySplit` / `standardPositionsSplit` are introduced together in Task 4 and referenced consistently in `positionTrackedLayout`. `PositionsChart(input:range:selectedInstrument:)` matches the existing initializer at `Shared/Views/Positions/PositionsChart.swift:18-22`. `loadAndBuildPositionsInput(account:profileCurrency:range:)` matches `Features/Investments/InvestmentStore+PositionsInput.swift:22-29`. `HistoricalValueSeries.Point(date:value:cost:contributions:)` matches `Domain/Models/HistoricalValueSeries.swift:18-33`. `FixedConversionService(rates:)` matches `MoolahTests/Support/FixedConversionService.swift:17`.


### PR DESCRIPTION
## Summary
- Adds `PositionsViewInput.hasHistoricalSeries` and relaxes `showsChart` so the chart container renders when the positions table would be hidden (`shouldHide`) but the historic aggregate series has points.
- `InvestmentAccountView.positionTrackedLayout` gains a third branch: when every holding has been closed out — including the realistic case where a sell-for-profit leaves a host-currency cash leg — the top pane renders just `PositionsChart` (no performance tiles, no positions table). Truly empty accounts (no historic data) keep today's bare transaction list.
- Adds `InvestmentStoreFullySoldChartTests` (end-to-end on `TestBackend` + `FixedConversionService`) and `PositionsViewInputChartTests` (chart-visibility unit coverage, hoisted out of the now-too-large `PositionsViewInputTests`).
- Fixes a pre-existing `seedPositionValuations` preview that seeded `.income`/`.expense` legs on a `calculatedFromTrades` account, so the cost-basis engine never saw the trade.

Design spec: [`plans/2026-05-15-fully-sold-investment-chart-design.md`](https://github.com/ajsutton/moolah-native/blob/fix/investment-chart-fully-sold/plans/2026-05-15-fully-sold-investment-chart-design.md).
Implementation plan: [`plans/2026-05-15-fully-sold-investment-chart-plan.md`](https://github.com/ajsutton/moolah-native/blob/fix/investment-chart-fully-sold/plans/2026-05-15-fully-sold-investment-chart-plan.md).

## Test plan
- [x] `just test` passes (2774 tests / 464 suites on macOS + iOS).
- [x] `just format-check` passes.
- [ ] Manual: open a position-tracked account whose holdings have all been sold and confirm the chart renders at the top with transactions below.
- [ ] Manual: position-tracked account with open positions still renders tiles + chart + positions table (no regression).
- [ ] Manual: brand-new position-tracked account with no transactions still renders the bare transaction list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)