### PR TITLE
Fix investment chart for fully-sold accounts whose sales pre-date the range

### DIFF
--- a/Domain/Models/PositionsViewInput.swift
+++ b/Domain/Models/PositionsViewInput.swift
@@ -19,6 +19,42 @@ struct PositionsViewInput: Sendable, Hashable {
   /// this `nil` and keep the existing header layout.
   let performance: AccountPerformance?
 
+  /// `true` iff the account has ever held a non-host-currency position
+  /// — i.e. the user's transactions include at least one trade leg in
+  /// an instrument other than `hostCurrency`. Range-independent: derived
+  /// from the full transaction set, not the current chart range.
+  ///
+  /// The view layer reads this to decide whether to render the chart-only
+  /// surface when `shouldHide` is `true`. `hasHistoricalSeries` only
+  /// answers "does the active range carry points right now"; that flips
+  /// to `false` when the user opens an account whose last trade
+  /// pre-dates the default range, so the chart never gets a chance to
+  /// render. `hasAnyHistoricalActivity` survives that.
+  let hasAnyHistoricalActivity: Bool
+
+  /// Single designated init with defaults so non-investment callers
+  /// (the transaction list, all previews) only have to fill in the
+  /// fields they care about. The investment-account path opts in to
+  /// `performance` and `hasAnyHistoricalActivity` explicitly. Declared
+  /// inside the struct body so it replaces Swift's synthesised
+  /// memberwise init rather than co-existing with it (which would make
+  /// every call ambiguous).
+  init(
+    title: String,
+    hostCurrency: Instrument,
+    positions: [ValuedPosition],
+    historicalValue: HistoricalValueSeries?,
+    performance: AccountPerformance? = nil,
+    hasAnyHistoricalActivity: Bool = false
+  ) {
+    self.title = title
+    self.hostCurrency = hostCurrency
+    self.positions = positions
+    self.historicalValue = historicalValue
+    self.performance = performance
+    self.hasAnyHistoricalActivity = hasAnyHistoricalActivity
+  }
+
   /// Sum of per-row values. `nil` if any row's `value` is `nil` — per the
   /// project rule "never display a partial aggregate", a single conversion
   /// failure marks the whole total unavailable.
@@ -101,27 +137,5 @@ struct PositionsViewInput: Sendable, Hashable {
       positions.lazy.filter { $0.quantity != 0 }.map(\.instrument)
     )
     return nonZeroInstruments == [hostCurrency]
-  }
-}
-
-extension PositionsViewInput {
-  /// Backward-compat init for the four-arg shape that pre-dates
-  /// `performance`. Lets non-investment-account callers (the
-  /// transaction list, all previews) keep their existing
-  /// `PositionsViewInput(title:hostCurrency:positions:historicalValue:)`
-  /// invocation unchanged. The investment-account path opts in via
-  /// the synthesised memberwise init.
-  init(
-    title: String,
-    hostCurrency: Instrument,
-    positions: [ValuedPosition],
-    historicalValue: HistoricalValueSeries?
-  ) {
-    self.init(
-      title: title,
-      hostCurrency: hostCurrency,
-      positions: positions,
-      historicalValue: historicalValue,
-      performance: nil)
   }
 }

--- a/Features/Investments/InvestmentStore+PositionsInput.swift
+++ b/Features/Investments/InvestmentStore+PositionsInput.swift
@@ -90,7 +90,24 @@ extension InvestmentStore {
       hostCurrency: hostCurrency,
       positions: rowsWithCost,
       historicalValue: series,
-      performance: accountPerformance)
+      performance: accountPerformance,
+      hasAnyHistoricalActivity: Self.hasAnyTradeLeg(
+        in: txns, accountId: loadedAccountId, hostCurrency: hostCurrency))
+  }
+
+  /// Range-independent "did this account ever hold a non-host-currency
+  /// position" check used to gate the chart-only branch on accounts
+  /// whose last trade pre-dates the active range.
+  static func hasAnyTradeLeg(
+    in transactions: [Transaction], accountId: UUID?, hostCurrency: Instrument
+  ) -> Bool {
+    transactions.contains { txn in
+      txn.legs.contains { leg in
+        leg.accountId == accountId
+          && leg.type == .trade
+          && leg.instrument != hostCurrency
+      }
+    }
   }
 
   func fetchAllTransactions(

--- a/Features/Investments/Views/InvestmentAccountView+Loading.swift
+++ b/Features/Investments/Views/InvestmentAccountView+Loading.swift
@@ -1,0 +1,70 @@
+import Foundation
+
+// Private helpers driving the load/rebuild lifecycle of
+// `InvestmentAccountView`. Hoisted out of the main view file so it
+// stays under SwiftLint's `file_length` budget; the methods stay
+// `private` and remain part of the view's API surface only — they
+// continue to be testable indirectly through the view's behaviour.
+extension InvestmentAccountView {
+  /// The profile's reporting currency — used for valuing positions and the
+  /// chart series. NOT the account's own instrument: an investment account
+  /// can be denominated in a non-fiat instrument (e.g., a crypto wallet),
+  /// but valuations should always roll up into the user's fiat currency.
+  var profileCurrencyInstrument: Instrument {
+    session.profile.instrument
+  }
+
+  /// Drives the full `loadAllData → positionsViewInput` rebuild used by
+  /// both `.task(id:)` and `.refreshable`. Sets `isLoadingPositions`
+  /// across the work so progress UI binds correctly.
+  func reloadPositions() async {
+    isLoadingPositions = true
+    defer { isLoadingPositions = false }
+    do {
+      positionsInput = try await investmentStore.loadAndBuildPositionsInput(
+        account: account,
+        profileCurrency: profileCurrencyInstrument,
+        range: positionsRange)
+    } catch is CancellationError {
+      return
+    } catch {
+      Self.logger.error(
+        "Unexpected error from positionsViewInput: \(error.localizedDescription, privacy: .public)"
+      )
+    }
+  }
+
+  /// If the account just loaded into a chart-only state but the active
+  /// range carries no points (the last trade pre-dates it), default the
+  /// range to `.all` so the historic chart populates on first paint
+  /// instead of stranding the user on "No chart data yet" with no
+  /// indication that widening the range would help. The chart-only
+  /// branch's range picker stays bound to `positionsRange`, so the user
+  /// can still narrow back to `.threeMonths` if they want.
+  ///
+  /// Rebuilds `positionsInput` inline rather than waiting for
+  /// `.task(id: positionsRange)` to land — flipping `positionsRange`
+  /// without first widening `positionsInput` would briefly render the
+  /// chart-only branch with stale (empty) data before the task settles.
+  /// The cost is one redundant `positionsViewInput` call when the
+  /// `.task(id: positionsRange)` fire eventually arrives; for the
+  /// expected use case (idle, conversion cache warm) it is sub-second.
+  func maybeAutoWidenRange() async {
+    guard positionsInput.shouldHide,
+      positionsInput.hasAnyHistoricalActivity,
+      !positionsInput.hasHistoricalSeries,
+      positionsRange != .all
+    else { return }
+    do {
+      positionsInput = try await investmentStore.positionsViewInput(
+        title: account.name, range: .all)
+      positionsRange = .all
+    } catch is CancellationError {
+      return
+    } catch {
+      Self.logger.error(
+        "Auto-widen rebuild failed: \(error.localizedDescription, privacy: .public)"
+      )
+    }
+  }
+}

--- a/Features/Investments/Views/InvestmentAccountView.swift
+++ b/Features/Investments/Views/InvestmentAccountView.swift
@@ -35,7 +35,11 @@ struct InvestmentAccountView: View {
     let mode: ValuationMode
   }
 
-  private static let logger = Logger(
+  // Properties accessed by the sibling `InvestmentAccountView+Loading.swift`
+  // extension are `internal` (no `private`) — Swift's `private` is
+  // file-scoped, so a cross-file extension can't reach a `private` member
+  // even on the same type.
+  static let logger = Logger(
     subsystem: "com.moolah.app", category: "InvestmentAccountView")
 
   let account: Account
@@ -45,13 +49,13 @@ struct InvestmentAccountView: View {
   let investmentStore: InvestmentStore
   let transactionStore: TransactionStore
 
-  @Environment(ProfileSession.self) private var session
+  @Environment(ProfileSession.self) var session
   @State private var showingAddValue = false
   @State private var selectedTransaction: Transaction?
-  @State private var positionsInput = PositionsViewInput(
+  @State var positionsInput = PositionsViewInput(
     title: "", hostCurrency: .AUD, positions: [], historicalValue: nil)
-  @State private var positionsRange: PositionsTimeRange = .threeMonths
-  @State private var isLoadingPositions = false
+  @State var positionsRange: PositionsTimeRange = .threeMonths
+  @State var isLoadingPositions = false
   /// Tracks whether `loadAllData` has run at least once for this account.
   /// Gates the body so `legacyValuationsLayout` vs `positionTrackedLayout`
   /// is chosen *after* `investmentStore.values` is known — otherwise the
@@ -89,14 +93,17 @@ struct InvestmentAccountView: View {
   /// Three branches:
   ///   - Positions exist (or are still loading): show the full
   ///     `PositionsView` with header, optional chart, and table.
-  ///   - Positions empty (or all in host currency) but historic series
-  ///     has points: show a chart-only surface so the user can review
-  ///     prior performance.
-  ///   - Positions empty and no history: collapse to the bare transaction
-  ///     list, the same as today.
+  ///   - Positions empty (or all in host currency) but the account has
+  ///     historical investment activity: show a chart-only surface so
+  ///     the user can review prior performance. Gating uses
+  ///     `hasAnyHistoricalActivity` (range-independent) rather than
+  ///     `hasHistoricalSeries` (range-scoped) so an account whose last
+  ///     trade pre-dates the active range still surfaces the chart.
+  ///   - Positions empty and no historical activity: collapse to the
+  ///     bare transaction list, the same as today.
   @ViewBuilder private var positionTrackedLayout: some View {
     if positionsInput.shouldHide && !isLoadingPositions {
-      if positionsInput.hasHistoricalSeries {
+      if positionsInput.hasAnyHistoricalActivity {
         chartOnlySplit
       } else {
         makeAccountTransactionList()
@@ -244,6 +251,7 @@ struct InvestmentAccountView: View {
     .task(id: LoadKey(id: account.id, mode: account.valuationMode)) {
       initialLoadComplete = false
       await reloadPositions()
+      await maybeAutoWidenRange()
       initialLoadComplete = true
       // Move VoiceOver focus to the now-rendered content layout once the
       // initial-load gate flips. Mirrored on layout-mode flips below.
@@ -362,36 +370,5 @@ struct InvestmentAccountView: View {
   }
 }
 
-// MARK: - Private helpers
-
-extension InvestmentAccountView {
-  /// The profile's reporting currency — used for valuing positions and the
-  /// chart series. NOT the account's own instrument: an investment account
-  /// can be denominated in a non-fiat instrument (e.g., a crypto wallet),
-  /// but valuations should always roll up into the user's fiat currency.
-  private var profileCurrencyInstrument: Instrument {
-    session.profile.instrument
-  }
-
-  /// Drives the full `loadAllData → positionsViewInput` rebuild used by
-  /// both `.task(id:)` and `.refreshable`. Sets `isLoadingPositions`
-  /// across the work so progress UI binds correctly.
-  private func reloadPositions() async {
-    isLoadingPositions = true
-    defer { isLoadingPositions = false }
-    do {
-      positionsInput = try await investmentStore.loadAndBuildPositionsInput(
-        account: account,
-        profileCurrency: profileCurrencyInstrument,
-        range: positionsRange)
-    } catch is CancellationError {
-      return
-    } catch {
-      Self.logger.error(
-        "Unexpected error from positionsViewInput: \(error.localizedDescription, privacy: .public)"
-      )
-    }
-  }
-}
-
-// Preview seeds and `#Preview` blocks live in InvestmentAccountView+Previews.swift
+// Private load/rebuild helpers live in `InvestmentAccountView+Loading.swift`.
+// Preview seeds and `#Preview` blocks live in `InvestmentAccountView+Previews.swift`.

--- a/MoolahTests/Features/Investments/InvestmentStoreFullySoldChartTests.swift
+++ b/MoolahTests/Features/Investments/InvestmentStoreFullySoldChartTests.swift
@@ -69,6 +69,56 @@ struct InvestmentStoreFullySoldChartTests {
     #expect(
       input.showsAggregateChart,
       "aggregate chart line should render when totalValue is available")
+    #expect(
+      input.hasAnyHistoricalActivity,
+      "non-host trade legs in the transaction set should set hasAnyHistoricalActivity")
+  }
+
+  @Test("fully-sold account reports hasAnyHistoricalActivity even on a narrow range")
+  func fullySoldAccountReportsActivityOnNarrowRange() async throws {
+    // Regression for the production bug: the user's last sale predates the
+    // default `.threeMonths` window, so `hasHistoricalSeries` is false. The
+    // view layer needs a range-independent signal to still take the
+    // chart-only branch — `hasAnyHistoricalActivity`.
+    let (backend, _) = try TestBackend.create()
+    let conversionService = FixedConversionService(rates: [bhp.id: Decimal(50)])
+    let store = InvestmentStore(
+      repository: backend.investments,
+      transactionRepository: backend.transactions,
+      conversionService: conversionService
+    )
+    let account = Account(
+      name: "Brokerage", type: .investment, instrument: aud,
+      valuationMode: .calculatedFromTrades)
+    _ = try await backend.accounts.create(
+      account, openingBalance: InstrumentAmount(quantity: 0, instrument: aud))
+    _ = try await backend.transactions.create(
+      Transaction(
+        date: buyDate,
+        legs: [
+          TransactionLeg(accountId: account.id, instrument: bhp, quantity: 100, type: .trade),
+          TransactionLeg(accountId: account.id, instrument: aud, quantity: -4_000, type: .trade),
+        ]))
+    _ = try await backend.transactions.create(
+      Transaction(
+        date: sellDate,
+        legs: [
+          TransactionLeg(accountId: account.id, instrument: bhp, quantity: -100, type: .trade),
+          TransactionLeg(accountId: account.id, instrument: aud, quantity: 5_000, type: .trade),
+        ]))
+
+    let input = try await store.loadAndBuildPositionsInput(
+      account: account, profileCurrency: aud, range: .threeMonths)
+
+    #expect(
+      input.shouldHide,
+      "host-currency-only positions should still trigger shouldHide")
+    #expect(
+      !input.hasHistoricalSeries,
+      "trades from 2020 fall outside .threeMonths so the series is empty")
+    #expect(
+      input.hasAnyHistoricalActivity,
+      "the non-host trade legs make the account chart-worthy even on a narrow range")
   }
 
   @Test("empty account with no trade history hides the chart")
@@ -92,5 +142,8 @@ struct InvestmentStoreFullySoldChartTests {
     #expect(input.shouldHide)
     #expect(!input.hasHistoricalSeries)
     #expect(!input.showsChart)
+    #expect(
+      !input.hasAnyHistoricalActivity,
+      "no transactions at all means no historical activity to surface")
   }
 }


### PR DESCRIPTION
## Summary
Follow-up to [#889](https://github.com/ajsutton/moolah-native/pull/889). On any production account where the most recent sale falls outside the chart's default `.threeMonths` window, the historic chart still didn't render — `PositionsHistoryBuilder` emits no points for a range with no holdings, `hasHistoricalSeries` is `false`, and the view fell back to the bare transaction list.

- Adds `PositionsViewInput.hasAnyHistoricalActivity` — range-independent signal computed from "any `.trade` leg on the account in a non-`hostCurrency` instrument". The view gates the chart-only branch on this instead of `hasHistoricalSeries`, so the chart surface renders whenever the account has ever held non-host-currency positions.
- Auto-widens `positionsRange` to `.all` when the account loads into chart-only state but the active range carries no points — rebuilt inline before the initial-load gate flips so the chart paints populated on first render rather than empty-state + manual click. The picker stays bound to `positionsRange`, so the user can narrow back to a shorter window after.

Plus housekeeping: `PositionsViewInput`'s init moves into the struct body (the extension-init was being synthesised alongside the memberwise init, making every call site ambiguous); `InvestmentAccountView`'s private loading helpers move to a sibling `+Loading.swift` so the main view stays under SwiftLint's `file_length` threshold; the `hasAnyTradeLeg` predicate is hoisted out of `positionsViewInput` to keep that method under `function_body_length`.

## Test plan
- [x] `just test` passes locally (full suite).
- [x] `just format-check` passes.
- [x] New regression test `fullySoldAccountReportsActivityOnNarrowRange`: seeds 2020 trades; asserts that on `.threeMonths`, `hasHistoricalSeries` is `false` (the symptom from #889) while `hasAnyHistoricalActivity` is `true` (the new gating signal).
- [ ] Manual: navigate to a fully-sold position-tracked account whose sales pre-date the default range and confirm the chart appears at the top, auto-widened to "All".
- [ ] Manual: confirm the range picker still lets the user narrow back to `.threeMonths` (will show "No chart data yet" — that's expected, since the underlying data is also empty in that window).
- [ ] Manual: confirm a position-tracked account with current holdings still renders the full tiles + chart + positions table (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)