### PR TITLE
perf(tests): cache just generate; drop 500ms sleep from debounce test

### DIFF
--- a/Features/Transactions/TransactionStore.swift
+++ b/Features/Transactions/TransactionStore.swift
@@ -105,11 +105,18 @@ final class TransactionStore {
   /// change. internal so `+Observation` can manage the lifecycle.
   var subscriptionTask: Task<Void, Never>?
 
+  /// Interval that `debouncedSave` waits before invoking the action.
+  /// Production wires this from the default; tests pass `.zero` so the
+  /// debounced task completes as soon as it's scheduled and can be
+  /// awaited deterministically rather than via a wall-clock sleep.
+  private let debounceInterval: Duration
+
   init(
     repository: TransactionRepository,
     conversionService: any InstrumentConversionService,
     targetInstrument: Instrument,
-    pageSize: Int = 50
+    pageSize: Int = 50,
+    debounceInterval: Duration = .milliseconds(300)
   ) {
     self.repository = repository
     self.payeeSuggestionSource = PayeeSuggestionSource(repository: repository)
@@ -117,6 +124,7 @@ final class TransactionStore {
     self.targetInstrument = targetInstrument
     self.currentTargetInstrument = targetInstrument
     self.pageSize = pageSize
+    self.debounceInterval = debounceInterval
     let pair = AsyncStream<Void>.makeStream()
     self.testObservationTickStream = pair.stream
     self.testObservationTickContinuation = pair.continuation
@@ -282,15 +290,21 @@ final class TransactionStore {
 
   private var saveTask: Task<Void, Never>?
 
-  /// Debounces save calls: cancels any pending save, waits 300ms, then calls the callback.
-  /// The callback is invoked on the main actor after the debounce delay.
-  func debouncedSave(perform action: @escaping @MainActor () -> Void) {
+  /// Debounces save calls: cancels any pending save, waits
+  /// `debounceInterval` (300ms in production), then calls the callback
+  /// on the main actor. Returns the spawned task so tests can await
+  /// the live (uncancelled) save deterministically; callers in
+  /// production fire-and-forget.
+  @discardableResult
+  func debouncedSave(perform action: @escaping @MainActor () -> Void) -> Task<Void, Never> {
     saveTask?.cancel()
-    saveTask = Task {
-      try? await Task.sleep(nanoseconds: 300_000_000)  // 300ms debounce
+    let task = Task { [debounceInterval] in
+      try? await Task.sleep(for: debounceInterval)
       guard !Task.isCancelled else { return }
       action()
     }
+    saveTask = task
+    return task
   }
 
   enum PayResult {

--- a/MoolahTests/Features/TransactionStoreAutocompleteTests.swift
+++ b/MoolahTests/Features/TransactionStoreAutocompleteTests.swift
@@ -128,16 +128,22 @@ struct TransactionStoreAutocompleteTests {
   @Test
   func testDebouncedSaveOnlyCallsLastAction() async throws {
     let (backend, _) = try TestBackend.create()
+    // `.zero` short-circuits the production 300ms wait — the debounced
+    // task still hops the executor, so cancellation still cancels
+    // earlier saves before they run, but we don't burn wall-clock time.
     let store = TransactionStore(
       repository: backend.transactions,
       conversionService: FixedConversionService(),
-      targetInstrument: .defaultTestInstrument
+      targetInstrument: .defaultTestInstrument,
+      debounceInterval: .zero
     )
 
     var callCount = 0
     var lastValue = ""
 
-    // Rapidly call debouncedSave 3 times — only the last should fire
+    // Rapidly call debouncedSave 3 times — only the last should fire.
+    // Discard the first two tasks; they're cancelled by the time we
+    // await the third.
     store.debouncedSave {
       callCount += 1
       lastValue = "first"
@@ -146,13 +152,13 @@ struct TransactionStoreAutocompleteTests {
       callCount += 1
       lastValue = "second"
     }
-    store.debouncedSave {
+    let liveSave = store.debouncedSave {
       callCount += 1
       lastValue = "third"
     }
 
-    // Wait for the debounce delay (300ms) plus a small buffer
-    try await Task.sleep(nanoseconds: 500_000_000)
+    // Await the live save's completion directly — no sleep needed.
+    await liveSave.value
 
     #expect(callCount == 1)
     #expect(lastValue == "third")

--- a/justfile
+++ b/justfile
@@ -143,29 +143,88 @@ build-ios: generate
         CODE_SIGNING_ALLOWED=NO
 
 # Regenerate the CloudKit wire-struct layer from CloudKit/schema.ckdb,
-# then regenerate Moolah.xcodeproj from project.yml.
+# then regenerate Moolah.xcodeproj from project.yml. Stamp-gated: each
+# sub-step is skipped when its inputs are unchanged since the last
+# successful run, so `just test` / `just build-mac` don't pay the
+# xcodegen + swift-run cost on every invocation. Force a full regen
+# with `rm -rf .build/stamps`.
 generate:
     #!/usr/bin/env bash
     set -euo pipefail
 
-    swift run --package-path tools/CKDBSchemaGen ckdb-schema-gen generate \
-        --input CloudKit/schema.ckdb \
-        --output Backends/CloudKit/Sync/Generated
+    STAMP_DIR=".build/stamps"
+    SCHEMA_STAMP="$STAMP_DIR/ckdb-schema-gen.stamp"
+    XCODEGEN_MODE_FILE="$STAMP_DIR/xcodegen.mode"
+    mkdir -p "$STAMP_DIR"
+
+    # ---- ckdb-schema-gen ----
+    # Regenerate when the schema, the generator's sources, or the output
+    # directory itself has gone missing. The output dir is gitignored, so
+    # a fresh checkout always misses the stamp and regenerates.
+    needs_schema_gen=0
+    if [ ! -f "$SCHEMA_STAMP" ]; then
+        needs_schema_gen=1
+    elif [ ! -d "Backends/CloudKit/Sync/Generated" ] \
+        || [ -z "$(ls -A Backends/CloudKit/Sync/Generated 2>/dev/null)" ]; then
+        needs_schema_gen=1
+    elif [ "CloudKit/schema.ckdb" -nt "$SCHEMA_STAMP" ]; then
+        needs_schema_gen=1
+    elif find tools/CKDBSchemaGen/Sources -type f -name '*.swift' \
+        -newer "$SCHEMA_STAMP" 2>/dev/null | grep -q .; then
+        needs_schema_gen=1
+    fi
+
+    if [ "$needs_schema_gen" -eq 1 ]; then
+        swift run --package-path tools/CKDBSchemaGen ckdb-schema-gen generate \
+            --input CloudKit/schema.ckdb \
+            --output Backends/CloudKit/Sync/Generated
+        touch "$SCHEMA_STAMP"
+    fi
 
     # Provide default
     export CODE_SIGN_STYLE="${CODE_SIGN_STYLE:-Automatic}"
 
+    # ---- xcodegen ----
     # Optionally inject Debug-config entitlements for local CloudKit development.
     # Set ENABLE_ENTITLEMENTS=1 to make `just build-mac` / `just run-mac` produce
     # a Debug binary signed with the test container's iCloud entitlement. Release
     # builds are produced by fastlane lanes (no entitlement injection here) and
     # shipped via the GitHub release artefact — there is no local Release path.
+    #
+    # Both modes are cached. Regenerate when `project.yml` (or, in the
+    # injection path, `scripts/inject-entitlements.sh`) is newer than
+    # `Moolah.xcodeproj/project.pbxproj`, when the project file is
+    # missing, or when the mode flipped between injected and non-injected
+    # since the last successful run (so the project picks up / drops the
+    # entitlement keys).
+    last_mode="$(cat "$XCODEGEN_MODE_FILE" 2>/dev/null || echo "")"
     if [ "${ENABLE_ENTITLEMENTS:-}" = "1" ]; then
-        SPEC=$(bash scripts/inject-entitlements.sh)
-        trap "rm -f $SPEC" EXIT
-        xcodegen generate --spec "$SPEC"
+        current_mode="1"
     else
-        xcodegen generate
+        current_mode="0"
+    fi
+
+    needs_xcodegen=0
+    if [ ! -f "Moolah.xcodeproj/project.pbxproj" ]; then
+        needs_xcodegen=1
+    elif [ "project.yml" -nt "Moolah.xcodeproj/project.pbxproj" ]; then
+        needs_xcodegen=1
+    elif [ "$last_mode" != "$current_mode" ]; then
+        needs_xcodegen=1
+    elif [ "$current_mode" = "1" ] \
+        && [ "scripts/inject-entitlements.sh" -nt "Moolah.xcodeproj/project.pbxproj" ]; then
+        needs_xcodegen=1
+    fi
+
+    if [ "$needs_xcodegen" -eq 1 ]; then
+        if [ "$current_mode" = "1" ]; then
+            SPEC=$(bash scripts/inject-entitlements.sh)
+            trap "rm -f $SPEC" EXIT
+            xcodegen generate --spec "$SPEC"
+        else
+            xcodegen generate
+        fi
+        echo "$current_mode" > "$XCODEGEN_MODE_FILE"
     fi
 
 # Verify CloudKit/schema.ckdb is additive over the committed Production


### PR DESCRIPTION
## Summary

- **`just generate`**: stamp-gate `ckdb-schema-gen` and `xcodegen` so a no-op run drops from ~1.7s to ~0.17s. Every `just test` / `just build-mac` / `just run-mac` benefits. Bust with `rm -rf .build/stamps`.
- **Debounce test**: replace a hard-coded 500ms `Task.sleep` with an injectable debounce interval + `Task` return from `debouncedSave`. Production keeps its 300ms default; the test now uses `.zero` and awaits the live save's `.value`. 500ms → 9ms.

## Details

### `just generate` cache

Both sub-steps are independently invalidated.

**ckdb-schema-gen** regenerates when any of these hold:
- stamp `.build/stamps/ckdb-schema-gen.stamp` is missing
- `Backends/CloudKit/Sync/Generated/` is missing or empty
- `CloudKit/schema.ckdb` is newer than the stamp
- any `tools/CKDBSchemaGen/Sources/**/*.swift` is newer than the stamp

**xcodegen** regenerates when any of these hold:
- `Moolah.xcodeproj/project.pbxproj` is missing
- `project.yml` is newer than the project file
- the entitlements mode (`ENABLE_ENTITLEMENTS=1` ↔ unset) flipped since the last run
- in the injecting path, `scripts/inject-entitlements.sh` is newer than the project file

Mode is tracked in `.build/stamps/xcodegen.mode` so a mode flip in either direction forces a regen (the injected spec adds CloudKit entitlement keys that need to be dropped when switching back, and vice versa).

### Debounce test

- `TransactionStore.init` gains `debounceInterval: Duration = .milliseconds(300)`. Production behaviour unchanged; all existing call sites are untouched.
- `debouncedSave(perform:)` now returns `Task<Void, Never>` (with `@discardableResult` so fire-and-forget callers compile unchanged).
- The test passes `.zero` and awaits the live save's `.value` directly — deterministic, no wall-clock sleep. Cancellation semantics still verified (`callCount == 1`, `lastValue == "third"`).

## Test plan

- [x] `just format-check` clean
- [x] `just test TransactionStoreAutocompleteTests` passes on both platforms (9ms for the debounce test; suite 89ms)
- [x] Manually verified cache: cold ~1.7s, warm ~0.17s, touching `project.yml` correctly invalidates xcodegen, touching `CloudKit/schema.ckdb` correctly invalidates schema-gen

🤖 Generated with [Claude Code](https://claude.com/claude-code)