### PR TITLE
fix(profile): update session in place on rename instead of rebuilding

### DIFF
--- a/App/ProfileRootView.swift
+++ b/App/ProfileRootView.swift
@@ -56,8 +56,11 @@
         updateSession(for: newID)
       }
       .onChange(of: profileStore.activeProfile?.label) { _, _ in
-        // Update cached profile in session when label changes
-        rebuildSessionIfNeeded()
+        // A rename updates the cached session's profile in place — no
+        // teardown, no data reload. `ProfileSession.profile` is
+        // `@Observable`, so label-bound UI refreshes off that single
+        // assignment without rebuilding the session.
+        refreshSessionProfile()
       }
       .onChange(of: profileStore.profiles) { _, _ in
         // Cloud profiles may arrive late (SwiftData/CloudKit not ready at startup).
@@ -103,15 +106,15 @@
       }
     }
 
-    /// Recreates the session if the active profile's properties changed (e.g. label edited in Settings).
-    private func rebuildSessionIfNeeded() {
+    /// Propagates a metadata edit (e.g. label changed in Settings)
+    /// into the live session in place. No teardown — the session is
+    /// `@Observable`, so label-bound UI updates off the assignment.
+    /// Remote `dataFormatVersion` bumps that could make the profile
+    /// incompatible are handled separately by `SessionManager`'s index
+    /// observer, so a rename must not rebuild the session.
+    private func refreshSessionProfile() {
       guard let profile = profileStore.activeProfile else { return }
-      if let session = activeSession, session.profile.id == profile.id {
-        Task {
-          let result = await sessionManager.rebuildSession(for: profile)
-          applyOpenResult(result)
-        }
-      }
+      sessionManager.refreshProfile(profile)
     }
 
     private func applyOpenResult(_ result: SessionOpenResult) {

--- a/App/ProfileWindowView.swift
+++ b/App/ProfileWindowView.swift
@@ -78,13 +78,15 @@
         }
       }
       .onChange(of: resolvedProfile?.label) { _, _ in
-        // Label edits flow through `rebuildSession(for:)` so the cached
-        // session picks up the new value (and the gate re-fires in case
-        // a remote profile-version bump arrived alongside the rename).
+        // A rename updates the cached session's profile in place — no
+        // teardown, no data reload. `ProfileSession.profile` is
+        // `@Observable`, so label-bound UI refreshes off that single
+        // assignment. Remote `dataFormatVersion` bumps that could make
+        // the profile incompatible are handled separately by
+        // `SessionManager`'s index observer, so the rename path must
+        // not rebuild the session.
         guard let profile = resolvedProfile else { return }
-        Task {
-          sessionResult = await sessionManager.rebuildSession(for: profile)
-        }
+        sessionManager.refreshProfile(profile)
       }
       .task {
         // Register in-process entry points for AppleScript/App Intents so

--- a/App/SessionManager.swift
+++ b/App/SessionManager.swift
@@ -10,11 +10,11 @@ import SwiftData
 final class SessionManager {
   /// Live sessions keyed by profile id.
   ///
-  /// **Mutation invariant:** any code path that drops or replaces a
-  /// session **must** go through `removeSession(for:)` or
-  /// `rebuildSession(for:)` so the session's `cleanupSync(coordinator:)`
-  /// runs first. `cleanupSync` is the only place that cancels the
-  /// session's tracked tasks (`catalogRefreshTask`, `pragmaOptimizeTask`,
+  /// **Mutation invariant:** any code path that drops a session
+  /// **must** go through `removeSession(for:)` so the session's
+  /// `cleanupSync(coordinator:)` runs first. `cleanupSync` is the
+  /// only place that cancels the session's tracked tasks
+  /// (`catalogRefreshTask`, `pragmaOptimizeTask`,
   /// `periodicPragmaOptimizeTask`, `setUpTask`); a direct mutation to
   /// `sessions` would leak any of those that happen to be in flight.
   /// Adding new tracked tasks to `ProfileSession`? Cancel them in
@@ -29,15 +29,6 @@ final class SessionManager {
   /// Cleared on a successful `.ready` open for the same profile id, so
   /// after an app update the entry doesn't linger.
   private(set) var incompatibleProfiles: [UUID: IncompatibleProfileInfo] = [:]
-
-  /// Per-profile rebuild-task registry. `rebuildSession(for:)` cancels
-  /// any prior in-flight rebuild for the same profile id before
-  /// starting a new one — so rapid `onChange`-driven rebuilds (e.g.
-  /// label edits arriving via sync) don't race writes back into the
-  /// view's `sessionResult`. Storing the handle here (not in view
-  /// `@State`) survives view-identity changes — see
-  /// `guides/CONCURRENCY_GUIDE.md` §8 ("Store tasks in the store").
-  private var rebuildTasks: [UUID: Task<SessionOpenResult, Never>] = [:]
 
   /// Token returned by `SyncCoordinator.addIndexObserver` when
   /// `installIndexObserver` registers the mid-session bump-arrival
@@ -210,34 +201,22 @@ final class SessionManager {
     Array(sessions.values)
   }
 
-  /// Replaces the session for a profile with a fresh instance — runs
-  /// `cleanupSync` on the prior session and re-opens through
-  /// `session(for:)` so the gate fires again. Returns the same
-  /// `SessionOpenResult` shape as `session(for:)`.
+  /// Propagates a profile-metadata edit (label, currency code,
+  /// financial-year start) into the live session **in place** — no
+  /// teardown, no data reload, no sync restart. This is the path a
+  /// rename takes: `ProfileSession.profile` is `@Observable`, so the
+  /// window title and any label-bound UI update reactively off the
+  /// single assignment. Mirrors the bump-on-write in-place update
+  /// (`bumpDataFormatVersionIfNeeded`).
   ///
-  /// `cleanupSync` runs unconditionally (see `removeSession` for the
-  /// rationale on no-coordinator builds). Cancels any prior rebuild
-  /// task for the same profile id before starting a new one.
-  func rebuildSession(for profile: Profile) async -> SessionOpenResult {
-    rebuildTasks[profile.id]?.cancel()
-    if let oldSession = sessions.removeValue(forKey: profile.id) {
-      oldSession.cleanupSync(coordinator: syncCoordinator)
-      syncCoordinator?.removeDataHandler(for: profile.id)
-    }
-    let task = Task { await self.session(for: profile) }
-    rebuildTasks[profile.id] = task
-    defer {
-      // Identity-guard the eviction: a later concurrent caller may
-      // have already replaced this slot with its own task. Removing
-      // unconditionally would leave a third caller unable to cancel
-      // the (still-running) replacement, breaking the cancel-prior
-      // invariant. `Task` is a value type wrapping a stable handle, so
-      // `==` compares the underlying continuation identity.
-      if rebuildTasks[profile.id] == task {
-        rebuildTasks.removeValue(forKey: profile.id)
-      }
-    }
-    return await task.value
+  /// No-op when no session is open for the profile — the next
+  /// `session(for:)` reads the fresh value from the profile index.
+  /// A remote `dataFormatVersion` bump that would make the profile
+  /// incompatible is handled independently by the index observer
+  /// (`installIndexObserver` / `reconcileIncompatibilityFromIndex`),
+  /// so a metadata edit must not trigger `rebuildSession`.
+  func refreshProfile(_ profile: Profile) {
+    sessions[profile.id]?.updateProfile(profile)
   }
 
   // MARK: - Mid-session compatibility reconcile

--- a/MoolahTests/App/SessionManagerTests.swift
+++ b/MoolahTests/App/SessionManagerTests.swift
@@ -65,18 +65,31 @@ struct SessionManagerTests {
     #expect(manager.sessions.isEmpty)
   }
 
-  @Test("rebuildSession replaces existing session with new instance")
-  func rebuildsSession() async throws {
+  @Test("refreshProfile updates the live session in place without rebuilding")
+  func refreshProfileUpdatesInPlace() async throws {
     let manager = try makeManager()
-    let profile = makeProfile()
+    let profile = makeProfile(label: "Before")
 
     let original = try await openSession(manager, for: profile)
-    _ = await manager.rebuildSession(for: profile)
-    let rebuilt = manager.sessions[profile.id]
 
-    #expect(rebuilt !== original)
-    #expect(rebuilt?.profile.id == profile.id)
+    var renamed = profile
+    renamed.label = "After"
+    manager.refreshProfile(renamed)
+
+    let current = manager.sessions[profile.id]
+    #expect(current === original)
+    #expect(current?.profile.label == "After")
     #expect(manager.sessions.count == 1)
+  }
+
+  @Test("refreshProfile is a no-op when no session is open for the profile")
+  func refreshProfileNoOpWhenNoSession() throws {
+    let manager = try makeManager()
+    var renamed = makeProfile(label: "Ghost")
+    renamed.label = "Renamed"
+
+    manager.refreshProfile(renamed)
+    #expect(manager.sessions.isEmpty)
   }
 
   @Test("multiple profiles get independent sessions")


### PR DESCRIPTION
## Summary

Renaming a profile that is open in a window caused the window to flash and reload all its data.

**Root cause:** `ProfileWindowView` (macOS) and `ProfileRootView` (iOS) watched the profile's `label` and, on change, called `SessionManager.rebuildSession(for:)`. `rebuildSession` fully tears the session down — `cleanupSync` stops all six store observers, the session and its sync data handler are dropped — then rebuilds it from scratch (`session(for:)` re-reads the profile index, re-runs `setUp()`, reloads all data). That teardown/rebuild *is* the flash.

The two stated reasons for the rebuild were already satisfied without it:
- *Cached label refresh* — `ProfileSession.profile` is `@Observable` with an in-place `updateProfile(_:)`; the bump-on-write path already uses exactly this pattern.
- *Re-firing the data-format gate for a remote version bump* — remote `dataFormatVersion` bumps are owned independently by the `SessionManager` index observer (`installIndexObserver` / `reconcileIncompatibilityFromIndex`). A local rename never changes `dataFormatVersion`.

## Changes

- Add `SessionManager.refreshProfile(_:)` — in-place update of the cached session, mirroring the bump-on-write reference pattern.
- Route the macOS (`ProfileWindowView`) and iOS (`ProfileRootView`) rename paths through `refreshProfile` instead of `rebuildSession`.
- Remove `rebuildSession(for:)` and its `rebuildTasks` serialization registry — both existed solely for the rapid rename-driven rebuilds this change eliminates, and now have zero callers (dead code).

## Test plan

- [x] New `SessionManager` tests: `refreshProfile` keeps the same session instance with an updated label, and is a no-op when no session is open.
- [x] `SessionManagerTests` / `SessionManagerCompatibilityTests` / `SessionManagerMidSessionBumpTests` / `DataFormatVersionBumpTests` pass — the incompatible-profile gate is unaffected.
- [x] macOS + iOS builds succeed; `just format-check` clean.
- [x] Manually verified in the running app: renaming an open profile no longer flashes or reloads data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)