### PR TITLE
fix(investments): always show full positions surface for trade-calculated accounts

### DIFF
--- a/Domain/Models/PositionsViewInput.swift
+++ b/Domain/Models/PositionsViewInput.swift
@@ -32,20 +32,29 @@ struct PositionsViewInput: Sendable, Hashable {
   /// render. `hasAnyHistoricalActivity` survives that.
   let hasAnyHistoricalActivity: Bool
 
+  /// `true` for position-tracked investment-account hosts, where the full
+  /// surface (performance tiles, chart, positions table) is always shown
+  /// for layout consistency — even with no open positions — rather than
+  /// collapsing to a chart-only or transaction-only fallback. Other hosts
+  /// (the transaction-list embedding, previews) leave this `false` and
+  /// keep the `shouldHide` collapse.
+  let alwaysShowsFullSurface: Bool
+
   /// Single designated init with defaults so non-investment callers
   /// (the transaction list, all previews) only have to fill in the
   /// fields they care about. The investment-account path opts in to
-  /// `performance` and `hasAnyHistoricalActivity` explicitly. Declared
-  /// inside the struct body so it replaces Swift's synthesised
-  /// memberwise init rather than co-existing with it (which would make
-  /// every call ambiguous).
+  /// `performance`, `hasAnyHistoricalActivity`, and
+  /// `alwaysShowsFullSurface` explicitly. Declared inside the struct
+  /// body so it replaces Swift's synthesised memberwise init rather
+  /// than co-existing with it (which would make every call ambiguous).
   init(
     title: String,
     hostCurrency: Instrument,
     positions: [ValuedPosition],
     historicalValue: HistoricalValueSeries?,
     performance: AccountPerformance? = nil,
-    hasAnyHistoricalActivity: Bool = false
+    hasAnyHistoricalActivity: Bool = false,
+    alwaysShowsFullSurface: Bool = false
   ) {
     self.title = title
     self.hostCurrency = hostCurrency
@@ -53,6 +62,7 @@ struct PositionsViewInput: Sendable, Hashable {
     self.historicalValue = historicalValue
     self.performance = performance
     self.hasAnyHistoricalActivity = hasAnyHistoricalActivity
+    self.alwaysShowsFullSurface = alwaysShowsFullSurface
   }
 
   /// Sum of per-row values. `nil` if any row's `value` is `nil` — per the
@@ -137,5 +147,14 @@ struct PositionsViewInput: Sendable, Hashable {
       positions.lazy.filter { $0.quantity != 0 }.map(\.instrument)
     )
     return nonZeroInstruments == [hostCurrency]
+  }
+
+  /// `true` when `PositionsView` collapses to `EmptyView`. `shouldHide`
+  /// marks the positions list redundant with the host surface's balance,
+  /// but position-tracked investment-account hosts
+  /// (`alwaysShowsFullSurface`) override that and always render the full
+  /// tiles/chart/table surface for layout consistency.
+  var rendersNothing: Bool {
+    shouldHide && !alwaysShowsFullSurface
   }
 }

--- a/Features/Investments/InvestmentStore+PositionsInput.swift
+++ b/Features/Investments/InvestmentStore+PositionsInput.swift
@@ -47,7 +47,8 @@ extension InvestmentStore {
         hostCurrency: hostCurrency,
         positions: valuedPositions,
         historicalValue: nil,
-        performance: accountPerformance)
+        performance: accountPerformance,
+        alwaysShowsFullSurface: true)
     }
 
     let txns: [Transaction]
@@ -66,17 +67,7 @@ extension InvestmentStore {
     let hostCurrency = loadedHostCurrency ?? valuedPositions.first?.value?.instrument ?? .AUD
     let costSnapshot = await costBasisSnapshot(
       transactions: txns, hostCurrency: hostCurrency)
-    let rowsWithCost: [ValuedPosition] = valuedPositions.map { row in
-      ValuedPosition(
-        instrument: row.instrument,
-        quantity: row.quantity,
-        unitPrice: row.unitPrice,
-        costBasis: costSnapshot[row.instrument.id].map {
-          InstrumentAmount(quantity: $0, instrument: hostCurrency)
-        },
-        value: row.value
-      )
-    }
+    let rowsWithCost = applyingCostBasis(costSnapshot, hostCurrency: hostCurrency)
 
     let series = await PositionsHistoryBuilder(conversionService: conversionService).build(
       transactions: txns,
@@ -92,12 +83,33 @@ extension InvestmentStore {
       historicalValue: series,
       performance: accountPerformance,
       hasAnyHistoricalActivity: Self.hasAnyTradeLeg(
-        in: txns, accountId: loadedAccountId, hostCurrency: hostCurrency))
+        in: txns, accountId: loadedAccountId, hostCurrency: hostCurrency),
+      alwaysShowsFullSurface: true)
+  }
+
+  /// Overlays a per-instrument cost-basis snapshot onto the already-loaded
+  /// `valuedPositions`, leaving quantity / unit price / value untouched.
+  /// An instrument absent from `costSnapshot` keeps a `nil` cost basis
+  /// (cost unavailable, not zero — see `costBasisSnapshot`).
+  func applyingCostBasis(
+    _ costSnapshot: [String: Decimal], hostCurrency: Instrument
+  ) -> [ValuedPosition] {
+    valuedPositions.map { row in
+      ValuedPosition(
+        instrument: row.instrument,
+        quantity: row.quantity,
+        unitPrice: row.unitPrice,
+        costBasis: costSnapshot[row.instrument.id].map {
+          InstrumentAmount(quantity: $0, instrument: hostCurrency)
+        },
+        value: row.value
+      )
+    }
   }
 
   /// Range-independent "did this account ever hold a non-host-currency
-  /// position" check used to gate the chart-only branch on accounts
-  /// whose last trade pre-dates the active range.
+  /// position" check used to keep the chart populated on accounts whose
+  /// last trade pre-dates the active range.
   static func hasAnyTradeLeg(
     in transactions: [Transaction], accountId: UUID?, hostCurrency: Instrument
   ) -> Bool {

--- a/Features/Investments/Views/InvestmentAccountView+Loading.swift
+++ b/Features/Investments/Views/InvestmentAccountView+Loading.swift
@@ -34,13 +34,13 @@ extension InvestmentAccountView {
     }
   }
 
-  /// If the account just loaded into a chart-only state but the active
+  /// If the account loaded with no remaining positions but the active
   /// range carries no points (the last trade pre-dates it), default the
   /// range to `.all` so the historic chart populates on first paint
   /// instead of stranding the user on "No chart data yet" with no
-  /// indication that widening the range would help. The chart-only
-  /// branch's range picker stays bound to `positionsRange`, so the user
-  /// can still narrow back to `.threeMonths` if they want.
+  /// indication that widening the range would help. The chart's range
+  /// picker stays bound to `positionsRange`, so the user can still
+  /// narrow back to `.threeMonths` if they want.
   ///
   /// Rebuilds `positionsInput` inline rather than waiting for
   /// `.task(id: positionsRange)` to land — flipping `positionsRange`

--- a/Features/Investments/Views/InvestmentAccountView.swift
+++ b/Features/Investments/Views/InvestmentAccountView.swift
@@ -89,35 +89,16 @@ struct InvestmentAccountView: View {
     )
   }
 
-  /// The positions/transactions composition for non-legacy accounts.
-  /// Three branches:
-  ///   - Positions exist (or are still loading): show the full
-  ///     `PositionsView` with header, optional chart, and table.
-  ///   - Positions empty (or all in host currency) but the account has
-  ///     historical investment activity: show a chart-only surface so
-  ///     the user can review prior performance. Gating uses
-  ///     `hasAnyHistoricalActivity` (range-independent) rather than
-  ///     `hasHistoricalSeries` (range-scoped) so an account whose last
-  ///     trade pre-dates the active range still surfaces the chart.
-  ///   - Positions empty and no historical activity: collapse to the
-  ///     bare transaction list, the same as today.
+  /// The positions/transactions composition for position-tracked
+  /// accounts. The full `PositionsView` surface — performance tiles,
+  /// chart, and positions table — always renders, even when every
+  /// holding has been sold (`positionsInput.alwaysShowsFullSurface`
+  /// keeps `PositionsView` from collapsing). This is deliberately
+  /// unconditional: a consistent layout across every account state is
+  /// simpler and more predictable than branching the surface on whether
+  /// positions remain. While the first load is still running and there
+  /// are no rows yet, a `ProgressView` stands in for the top pane.
   @ViewBuilder private var positionTrackedLayout: some View {
-    if positionsInput.shouldHide && !isLoadingPositions {
-      if positionsInput.hasAnyHistoricalActivity {
-        chartOnlySplit
-      } else {
-        makeAccountTransactionList()
-      }
-    } else {
-      standardPositionsSplit
-    }
-  }
-
-  /// Full positions surface — header (or performance tiles), optional
-  /// chart, and the responsive table. Used when current positions exist
-  /// or while positions are still loading (renders a `ProgressView` in
-  /// the top pane until `isLoadingPositions` clears).
-  @ViewBuilder private var standardPositionsSplit: some View {
     PositionsTransactionsSplit(
       defaultTab: .positions,
       // Distinct autosave key from the chartless multi-currency split so
@@ -136,29 +117,6 @@ struct InvestmentAccountView: View {
       } else {
         PositionsView(input: positionsInput, range: $positionsRange)
       }
-    } transactions: {
-      makeAccountTransactionList()
-    }
-  }
-
-  /// Chart-only top pane for a position-tracked account whose positions
-  /// table is empty (all holdings closed out, or every non-zero position
-  /// is in host currency) but that has historical activity worth reviewing.
-  /// Reuses the same `autosaveName` as `standardPositionsSplit` so the
-  /// divider position the user has chosen for this account shape
-  /// persists across the two branches. `selectedInstrument` is pinned to
-  /// `.constant(nil)` — there are no positions to filter to, so the
-  /// per-instrument selection chip would never appear.
-  @ViewBuilder private var chartOnlySplit: some View {
-    PositionsTransactionsSplit(
-      defaultTab: .positions,
-      autosaveName: "positions-transactions-split.with-chart",
-      initialTopHeight: 540
-    ) {
-      PositionsChart(
-        input: positionsInput,
-        range: $positionsRange,
-        selectedInstrument: .constant(nil))
     } transactions: {
       makeAccountTransactionList()
     }

--- a/MoolahTests/Domain/PositionsViewInputShouldHideTests.swift
+++ b/MoolahTests/Domain/PositionsViewInputShouldHideTests.swift
@@ -86,4 +86,24 @@ struct PositionsViewInputShouldHideTests {
       title: "x", hostCurrency: aud, positions: [], historicalValue: nil)
     #expect(input.shouldHide)
   }
+
+  @Test("rendersNothing mirrors shouldHide when alwaysShowsFullSurface is false")
+  func rendersNothingMirrorsShouldHideByDefault() {
+    let input = PositionsViewInput(
+      title: "x", hostCurrency: aud, positions: [], historicalValue: nil)
+    #expect(input.shouldHide)
+    #expect(input.rendersNothing)
+  }
+
+  @Test("rendersNothing is false when alwaysShowsFullSurface overrides an empty surface")
+  func alwaysShowsFullSurfaceForcesRender() {
+    // A position-tracked investment account whose holdings are all sold:
+    // shouldHide stays true (the list is redundant) but the view must
+    // still render the full tiles/chart/table surface.
+    let input = PositionsViewInput(
+      title: "x", hostCurrency: aud, positions: [], historicalValue: nil,
+      alwaysShowsFullSurface: true)
+    #expect(input.shouldHide)
+    #expect(!input.rendersNothing)
+  }
 }

--- a/MoolahTests/Features/Investments/InvestmentStoreFullySoldChartTests.swift
+++ b/MoolahTests/Features/Investments/InvestmentStoreFullySoldChartTests.swift
@@ -15,8 +15,10 @@ struct InvestmentStoreFullySoldChartTests {
   let buyDate = Date(timeIntervalSinceReferenceDate: 599_616_000)  // 2020-01-01
   let sellDate = Date(timeIntervalSinceReferenceDate: 601_430_400)  // 2020-01-21
 
-  @Test("fully-sold account still surfaces the historical chart")
-  func fullySoldAccountSurfacesChart() async throws {
+  /// Builds a position-tracked account that bought then fully sold 100
+  /// BHP (a buy @ 40 AUD then sell-all @ 50 AUD, both in 2020). Returns
+  /// the store + account ready for a `loadAndBuildPositionsInput` call.
+  private func makeFullySoldAccount() async throws -> (InvestmentStore, Account) {
     let (backend, _) = try TestBackend.create()
     let conversionService = FixedConversionService(rates: [bhp.id: Decimal(50)])
     let store = InvestmentStore(
@@ -29,8 +31,6 @@ struct InvestmentStoreFullySoldChartTests {
       valuationMode: .calculatedFromTrades)
     _ = try await backend.accounts.create(
       account, openingBalance: InstrumentAmount(quantity: 0, instrument: aud))
-
-    // Buy 100 BHP @ 40 AUD on 2020-01-01.
     _ = try await backend.transactions.create(
       Transaction(
         date: buyDate,
@@ -38,7 +38,6 @@ struct InvestmentStoreFullySoldChartTests {
           TransactionLeg(accountId: account.id, instrument: bhp, quantity: 100, type: .trade),
           TransactionLeg(accountId: account.id, instrument: aud, quantity: -4_000, type: .trade),
         ]))
-    // Sell all 100 BHP @ 50 AUD on 2020-01-21.
     _ = try await backend.transactions.create(
       Transaction(
         date: sellDate,
@@ -46,13 +45,18 @@ struct InvestmentStoreFullySoldChartTests {
           TransactionLeg(accountId: account.id, instrument: bhp, quantity: -100, type: .trade),
           TransactionLeg(accountId: account.id, instrument: aud, quantity: 5_000, type: .trade),
         ]))
+    return (store, account)
+  }
 
+  @Test("fully-sold account still surfaces the historical chart")
+  func fullySoldAccountSurfacesChart() async throws {
+    let (store, account) = try await makeFullySoldAccount()
     let input = try await store.loadAndBuildPositionsInput(
       account: account, profileCurrency: aud, range: .all)
 
     // A sell-for-profit leaves the net cash leg as a host-currency
-    // position; `loadPositions` keeps non-zero rows. `shouldHide`
-    // collapses this into the chart-only path.
+    // position; `loadPositions` keeps non-zero rows, so `shouldHide`
+    // stays true even though the full surface still renders.
     let nonHostPositions = input.positions.filter { $0.instrument != aud }
     #expect(
       nonHostPositions.isEmpty,
@@ -72,41 +76,21 @@ struct InvestmentStoreFullySoldChartTests {
     #expect(
       input.hasAnyHistoricalActivity,
       "non-host trade legs in the transaction set should set hasAnyHistoricalActivity")
+    #expect(
+      input.alwaysShowsFullSurface,
+      "trade-calculated investment accounts always render the full surface")
+    #expect(
+      !input.rendersNothing,
+      "the full surface must render even though shouldHide is true")
   }
 
   @Test("fully-sold account reports hasAnyHistoricalActivity even on a narrow range")
   func fullySoldAccountReportsActivityOnNarrowRange() async throws {
     // Regression for the production bug: the user's last sale predates the
     // default `.threeMonths` window, so `hasHistoricalSeries` is false. The
-    // view layer needs a range-independent signal to still take the
-    // chart-only branch — `hasAnyHistoricalActivity`.
-    let (backend, _) = try TestBackend.create()
-    let conversionService = FixedConversionService(rates: [bhp.id: Decimal(50)])
-    let store = InvestmentStore(
-      repository: backend.investments,
-      transactionRepository: backend.transactions,
-      conversionService: conversionService
-    )
-    let account = Account(
-      name: "Brokerage", type: .investment, instrument: aud,
-      valuationMode: .calculatedFromTrades)
-    _ = try await backend.accounts.create(
-      account, openingBalance: InstrumentAmount(quantity: 0, instrument: aud))
-    _ = try await backend.transactions.create(
-      Transaction(
-        date: buyDate,
-        legs: [
-          TransactionLeg(accountId: account.id, instrument: bhp, quantity: 100, type: .trade),
-          TransactionLeg(accountId: account.id, instrument: aud, quantity: -4_000, type: .trade),
-        ]))
-    _ = try await backend.transactions.create(
-      Transaction(
-        date: sellDate,
-        legs: [
-          TransactionLeg(accountId: account.id, instrument: bhp, quantity: -100, type: .trade),
-          TransactionLeg(accountId: account.id, instrument: aud, quantity: 5_000, type: .trade),
-        ]))
-
+    // view layer needs a range-independent signal to keep the chart
+    // populated on a narrow range — `hasAnyHistoricalActivity`.
+    let (store, account) = try await makeFullySoldAccount()
     let input = try await store.loadAndBuildPositionsInput(
       account: account, profileCurrency: aud, range: .threeMonths)
 
@@ -119,6 +103,10 @@ struct InvestmentStoreFullySoldChartTests {
     #expect(
       input.hasAnyHistoricalActivity,
       "the non-host trade legs make the account chart-worthy even on a narrow range")
+    #expect(
+      input.alwaysShowsFullSurface,
+      "trade-calculated investment accounts always render the full surface")
+    #expect(!input.rendersNothing)
   }
 
   @Test("empty account with no trade history hides the chart")
@@ -145,5 +133,11 @@ struct InvestmentStoreFullySoldChartTests {
     #expect(
       !input.hasAnyHistoricalActivity,
       "no transactions at all means no historical activity to surface")
+    #expect(
+      input.alwaysShowsFullSurface,
+      "even a trade-calculated account with no trades renders the full surface")
+    #expect(
+      !input.rendersNothing,
+      "the surface (tiles + empty table) renders for consistency")
   }
 }

--- a/Shared/Views/Positions/PositionsView.swift
+++ b/Shared/Views/Positions/PositionsView.swift
@@ -8,9 +8,11 @@ import SwiftUI
 
 /// Unified container for displaying positions across the app. Composes a
 /// header, optional chart, and responsive table from a single
-/// `PositionsViewInput`. Renders nothing when `input.shouldHide` is true
-/// (empty input, or a single-instrument holding that matches the host's own
-/// instrument) — callers decide whether to show context-specific empty state.
+/// `PositionsViewInput`. Renders nothing when `input.rendersNothing` is
+/// true (empty input, or a single-instrument holding that matches the
+/// host's own instrument, unless the host opts into
+/// `alwaysShowsFullSurface`) — callers decide whether to show
+/// context-specific empty state.
 ///
 /// Selection: a single tap on a row filters the chart to that instrument.
 /// Tapping again, the chip's ✕, or pressing Escape clears the selection.
@@ -21,7 +23,7 @@ struct PositionsView: View {
   @Binding var range: PositionsTimeRange
 
   var body: some View {
-    if input.shouldHide {
+    if input.rendersNothing {
       EmptyView()
     } else {
       VStack(spacing: 0) {


### PR DESCRIPTION
## Summary
- A position-tracked (`.calculatedFromTrades`) investment account with no remaining positions collapsed to a chart-only pane, leaving dead white space where the performance tiles and positions table would be (see the reported "Shares" account: chart visible, blank gaps above/below).
- Now the full surface — performance tiles + chart + positions table — always renders for trade-calculated accounts. Simpler and more predictable than branching the layout on whether positions remain.
- Adds `PositionsViewInput.alwaysShowsFullSurface` (set only by `InvestmentStore.positionsViewInput`, so the transaction-list embedding is unaffected) plus a `rendersNothing` gate. `shouldHide`/`showsChart` semantics are deliberately **unchanged**, so the fully-sold chart auto-widen behaviour from #889/#890 keeps working. Deletes the now-unreachable `chartOnlySplit` branch (net ~50 fewer view lines).

Behavioural note: a trade-calculated account with zero trades ever still won't draw a chart (no data to plot) — it shows the tiles + an empty positions table. The reported scenario (sold everything, has history) now shows tiles + chart + table with no leftover white space.

## Test plan
- [x] TDD: new tests written first, watched fail (missing members), then pass
- [x] `just build-mac` succeeds; `just format-check` clean (two `function_body_length` hits fixed by genuine extraction, not re-baselining)
- [x] Pass: `PositionsViewInputShouldHideTests` (+ new `rendersNothing` cases), `PositionsViewInput*`, `InvestmentStoreFullySoldChartTests` (+ new `alwaysShowsFullSurface` assertions), `InvestmentStorePositionsInputTests`, `InvestmentStoreTests`, `InvestmentStorePerformanceTests`, `InvestmentStoreValuationModeTests`
- [ ] Manual: open a fully-sold trade-calculated account → tiles + chart + table render, no white space

🤖 Generated with [Claude Code](https://claude.com/claude-code)