### PR TITLE
fix(crypto): show "Never synced" instead of "Synced 2025 years ago"

### DIFF
--- a/Features/Crypto/WalletAccountHeaderView.swift
+++ b/Features/Crypto/WalletAccountHeaderView.swift
@@ -266,10 +266,15 @@ extension WalletAccountHeaderView {
 /// unit-testable without instantiating a SwiftUI view.
 enum WalletAccountHeaderLogic {
   /// User-facing relative-time label for the wallet's last successful
-  /// sync. `nil` state → "Never synced". Otherwise uses
-  /// `RelativeDateTimeFormatter.short` and prefixes "Synced ".
+  /// sync. A `nil` state — or a state whose checkpoint is still the
+  /// `.distantPast` sentinel that `persistError` writes for an account
+  /// that has never had a successful sync — renders as "Never synced".
+  /// Otherwise uses `RelativeDateTimeFormatter.short` and prefixes
+  /// "Synced ".
   static func lastSyncedText(state: WalletSyncState?, now: Date) -> String {
-    guard let lastSyncedAt = state?.lastSyncedAt else { return "Never synced" }
+    guard let lastSyncedAt = state?.lastSyncedAt, lastSyncedAt != .distantPast else {
+      return "Never synced"
+    }
     let formatter = RelativeDateTimeFormatter()
     formatter.unitsStyle = .short
     let relative = formatter.localizedString(for: lastSyncedAt, relativeTo: now)

--- a/Features/Settings/CryptoAccountsListSection.swift
+++ b/Features/Settings/CryptoAccountsListSection.swift
@@ -117,14 +117,14 @@ struct CryptoAccountsListSection: View {
     return account.instrument.displaySymbol ?? account.instrument.name
   }
 
-  /// "Synced 2h ago" relative caption. Uses `RelativeDateTimeFormatter`
-  /// with `.short` units to match `ImportRulesSettingsView`'s existing
-  /// idiom — keeps the project's relative-date language consistent.
+  /// "Synced 2h ago" relative caption. Delegates to
+  /// `WalletAccountHeaderLogic.lastSyncedText` so the settings pane and
+  /// the wallet header share one formatter — including its
+  /// `.distantPast`-sentinel "Never synced" handling for an account that
+  /// has never had a successful sync (matches the `errorCaption`
+  /// delegation below; avoids drift if the wording changes).
   private func lastSyncedCaption(for state: WalletSyncState) -> String {
-    let formatter = RelativeDateTimeFormatter()
-    formatter.unitsStyle = .short
-    let relative = formatter.localizedString(for: state.lastSyncedAt, relativeTo: Date())
-    return "Synced \(relative)"
+    WalletAccountHeaderLogic.lastSyncedText(state: state, now: Date())
   }
 
   /// Delegates to `WalletAccountHeaderLogic.errorCaption(for:)` so the

--- a/MoolahTests/Features/Crypto/WalletAccountHeaderViewLogicTests.swift
+++ b/MoolahTests/Features/Crypto/WalletAccountHeaderViewLogicTests.swift
@@ -45,6 +45,17 @@ struct WalletAccountHeaderViewLogicTests {
     #expect(!trailing.isEmpty)
   }
 
+  @Test("State with a .distantPast checkpoint renders as 'Never synced'")
+  func neverSyncedWhenCheckpointIsDistantPast() {
+    // persistError writes lastSyncedAt: .distantPast for an account that
+    // has never had a successful sync (e.g. the first attempt failed).
+    // That sentinel must read as "Never synced", not "Synced 2025 years ago".
+    let state = WalletSyncState(
+      id: UUID(), lastSyncedBlockNumber: 0, lastSyncedAt: .distantPast, lastError: nil)
+    let label = WalletAccountHeaderLogic.lastSyncedText(state: state, now: Date())
+    #expect(label == "Never synced")
+  }
+
   // MARK: - Sync-now enabled state
 
   @Test("Sync-now button enabled when account is not in flight and a key is configured")


### PR DESCRIPTION
## Problem

A crypto account whose first sync attempt failed displays **"Synced 2,025 yrs ago"** instead of "Never synced".

## Root cause

`WalletSyncState.lastSyncedAt` is a non-optional `Date`. When a sync fails before any successful sync, `MoolahSyncInternals.persistError` writes a state row with `lastSyncedAt: .distantPast` — the established "never synced" sentinel that the staleness check (`CryptoSyncStore+Internals.swift:40`) already relies on. But the two last-synced display formatters only treated a *nil* state as "never synced"; a non-nil state with `lastSyncedAt == .distantPast` was fed straight into `RelativeDateTimeFormatter`, producing "Synced 2,025 yrs ago" (≈ year 1 AD relative to 2026).

## Fix

- `WalletAccountHeaderLogic.lastSyncedText` now treats the `.distantPast` checkpoint as "Never synced", alongside the existing `nil`-state case.
- `CryptoAccountsListSection.lastSyncedCaption` now delegates to that shared logic (mirroring the existing `errorCaption` delegation), removing the duplicated formatter so the two surfaces can't drift.

## Tests

Added a failing-then-passing `WalletAccountHeaderLogic` test asserting a `.distantPast` checkpoint renders as "Never synced". Full `WalletAccountHeaderViewLogicTests` suite (10 tests) green; `just format-check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)