### PR TITLE
fix(registry): stop clobbering discovery-resolved provider mappings (cutover PR 1/6)

### DIFF
--- a/Backends/CloudKit/Sync/ProfileIndexSyncHandler+Instruments.swift
+++ b/Backends/CloudKit/Sync/ProfileIndexSyncHandler+Instruments.swift
@@ -136,7 +136,7 @@ extension ProfileIndexSyncHandler {
   func queueUnsyncedSharedInstrumentRecords() -> [CKRecord.ID] {
     guard let instrumentRepository else { return [] }
     do {
-      let ids = try instrumentRepository.unsyncedRowIdsSync()
+      let ids = try instrumentRepository.unsyncedNonFiatRowIdsSync()
       return ids.map { CKRecord.ID(recordName: $0, zoneID: zoneID) }
     } catch {
       logger.error(

--- a/Backends/GRDB/Repositories/GRDBInstrumentRegistryRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBInstrumentRegistryRepository.swift
@@ -167,16 +167,7 @@ final class GRDBInstrumentRegistryRepository:
       .filter(InstrumentRow.Columns.id == instrument.id)
       .fetchOne(database)
     {
-      existing.kind = instrument.kind.rawValue
-      existing.name = instrument.name
-      existing.decimals = instrument.decimals
-      existing.ticker = instrument.ticker
-      existing.exchange = instrument.exchange
-      existing.chainId = instrument.chainId
-      existing.contractAddress = instrument.contractAddress
-      existing.coingeckoId = mapping.coingeckoId
-      existing.cryptocompareSymbol = mapping.cryptocompareSymbol
-      existing.binanceSymbol = mapping.binanceSymbol
+      mergeResolvedFields(into: &existing, from: instrument, mapping: mapping)
       try existing.update(database)
     } else {
       var row = InstrumentRow(domain: instrument)
@@ -185,6 +176,39 @@ final class GRDBInstrumentRegistryRepository:
       row.binanceSymbol = mapping.binanceSymbol
       try row.insert(database)
     }
+  }
+
+  /// Upgrade-only field merge: a nil/empty incoming column must never
+  /// downgrade a populated stored column.
+  ///
+  /// A thin ensureInstrument-style publish carries all-nil / empty identity
+  /// fields; allowing it to overwrite would destroy a richer
+  /// discovery-resolved row (e.g. Trust Wallet's ensureInstrument for
+  /// Ethereum clobbering the coingecko-resolved ticker/exchange). Every
+  /// identity column therefore requires a non-empty / non-zero incoming
+  /// value before overwriting; `kind` and `decimals` are always
+  /// authoritative and are updated unconditionally.
+  ///
+  /// Provider mapping columns are also merged: a nil incoming column must
+  /// not downgrade a populated stored column. See the shared-registry
+  /// clobber bug (Trust - Ethereum 1:native).
+  private static func mergeResolvedFields(
+    into existing: inout InstrumentRow,
+    from instrument: Instrument,
+    mapping: CryptoProviderMapping
+  ) {
+    existing.kind = instrument.kind.rawValue
+    if !instrument.name.isEmpty { existing.name = instrument.name }
+    existing.decimals = instrument.decimals
+    if let ticker = instrument.ticker, !ticker.isEmpty { existing.ticker = ticker }
+    if let exchange = instrument.exchange, !exchange.isEmpty { existing.exchange = exchange }
+    if let chainId = instrument.chainId, chainId != 0 { existing.chainId = chainId }
+    if let contractAddress = instrument.contractAddress, !contractAddress.isEmpty {
+      existing.contractAddress = contractAddress
+    }
+    existing.coingeckoId = mapping.coingeckoId ?? existing.coingeckoId
+    existing.cryptocompareSymbol = mapping.cryptocompareSymbol ?? existing.cryptocompareSymbol
+    existing.binanceSymbol = mapping.binanceSymbol ?? existing.binanceSymbol
   }
 
   /// Inserts a new stock row or updates the existing one in-place. Stock

--- a/MoolahTests/Backends/GRDB/GRDBInstrumentRegistryUpsertMergeTests.swift
+++ b/MoolahTests/Backends/GRDB/GRDBInstrumentRegistryUpsertMergeTests.swift
@@ -1,0 +1,169 @@
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+@Suite("GRDBInstrumentRegistryRepository upsert preserves provider mapping")
+struct GRDBInstrumentRegistryUpsertMergeTests {
+  private func makeRegistry() throws -> GRDBInstrumentRegistryRepository {
+    let queue = try DatabaseQueue()
+    try ProfileSchema.migrator.migrate(queue)
+    return GRDBInstrumentRegistryRepository(database: queue)
+  }
+
+  private let eth = Instrument.crypto(
+    chainId: 1, contractAddress: nil, symbol: "ETH", name: "Ethereum", decimals: 18)
+
+  @Test("An empty-mapping re-register does not erase a resolved mapping")
+  func emptyMappingDoesNotClobber() async throws {
+    let registry = try makeRegistry()
+    try await registry.registerCrypto(
+      eth,
+      mapping: CryptoProviderMapping(
+        instrumentId: eth.id,
+        coingeckoId: "ethereum",
+        cryptocompareSymbol: "ETH",
+        binanceSymbol: "ETHUSDT"))
+
+    // Simulates publishToSharedRegistry's all-nil publish for the same id.
+    try await registry.registerCrypto(
+      eth,
+      mapping: CryptoProviderMapping(
+        instrumentId: eth.id,
+        coingeckoId: nil,
+        cryptocompareSymbol: nil,
+        binanceSymbol: nil))
+
+    let reg = try await registry.cryptoRegistration(byId: eth.id)
+    #expect(reg?.mapping.coingeckoId == "ethereum")
+    #expect(reg?.mapping.cryptocompareSymbol == "ETH")
+    #expect(reg?.mapping.binanceSymbol == "ETHUSDT")
+  }
+
+  @Test("A populated re-register still overwrites individual columns")
+  func populatedMappingStillUpdates() async throws {
+    let registry = try makeRegistry()
+    try await registry.registerCrypto(
+      eth,
+      mapping: CryptoProviderMapping(
+        instrumentId: eth.id, coingeckoId: "old", cryptocompareSymbol: nil, binanceSymbol: nil))
+    try await registry.registerCrypto(
+      eth,
+      mapping: CryptoProviderMapping(
+        instrumentId: eth.id, coingeckoId: "ethereum", cryptocompareSymbol: "ETH",
+        binanceSymbol: "ETHUSDT"))
+    let reg = try await registry.cryptoRegistration(byId: eth.id)
+    #expect(reg?.mapping.coingeckoId == "ethereum")
+    #expect(reg?.mapping.cryptocompareSymbol == "ETH")
+    #expect(reg?.mapping.binanceSymbol == "ETHUSDT")
+  }
+
+  @Test("Partial re-register updates one column and preserves the others")
+  func partialMappingPreservesOtherColumns() async throws {
+    let registry = try makeRegistry()
+    try await registry.registerCrypto(
+      eth,
+      mapping: CryptoProviderMapping(
+        instrumentId: eth.id, coingeckoId: "old-cg", cryptocompareSymbol: "ETH",
+        binanceSymbol: nil))
+    try await registry.registerCrypto(
+      eth,
+      mapping: CryptoProviderMapping(
+        instrumentId: eth.id, coingeckoId: "ethereum", cryptocompareSymbol: nil,
+        binanceSymbol: nil))
+    let reg = try await registry.cryptoRegistration(byId: eth.id)
+    #expect(reg?.mapping.coingeckoId == "ethereum")  // updated
+    #expect(reg?.mapping.cryptocompareSymbol == "ETH")  // preserved, not clobbered by nil
+    #expect(reg?.mapping.binanceSymbol == nil)  // stays nil
+  }
+
+  @Test("A thin re-register with empty name does not blank the stored name")
+  func emptyNameDoesNotBlankStoredName() async throws {
+    let registry = try makeRegistry()
+    try await registry.registerCrypto(
+      eth,
+      mapping: CryptoProviderMapping(
+        instrumentId: eth.id, coingeckoId: "ethereum", cryptocompareSymbol: nil,
+        binanceSymbol: nil))
+    let thin = Instrument(
+      id: eth.id, kind: .cryptoToken, name: "", decimals: 18,
+      ticker: nil, exchange: nil, chainId: 1, contractAddress: nil)
+    try await registry.registerCrypto(
+      thin,
+      mapping: CryptoProviderMapping(
+        instrumentId: eth.id, coingeckoId: nil, cryptocompareSymbol: nil,
+        binanceSymbol: nil))
+    let reg = try await registry.cryptoRegistration(byId: eth.id)
+    #expect(reg?.instrument.name == "Ethereum")  // preserved
+  }
+
+  @Test("A nil incoming ticker does not blank the stored ticker")
+  func nilTickerDoesNotBlankStoredTicker() async throws {
+    let registry = try makeRegistry()
+    try await registry.registerCrypto(
+      eth,
+      mapping: CryptoProviderMapping(
+        instrumentId: eth.id, coingeckoId: "ethereum", cryptocompareSymbol: nil,
+        binanceSymbol: nil))
+    let thin = Instrument(
+      id: eth.id, kind: .cryptoToken, name: "", decimals: 18,
+      ticker: nil, exchange: nil, chainId: 1, contractAddress: nil)
+    try await registry.registerCrypto(
+      thin,
+      mapping: CryptoProviderMapping(
+        instrumentId: eth.id, coingeckoId: nil, cryptocompareSymbol: nil,
+        binanceSymbol: nil))
+    let reg = try await registry.cryptoRegistration(byId: eth.id)
+    #expect(reg?.instrument.ticker == "ETH")  // preserved
+  }
+
+  // A real-mapping re-register makes a previously-clobbered
+  // (project-filtered) row visible again.
+  @Test(
+    "A clobbered priced+no-mapping row is invisible until a real mapping re-register repairs it")
+  func clobberedRowRepairedByReRegister() async throws {
+    let registry = try makeRegistry()
+    // Post-clobber state: priced (default) + all-nil provider mapping.
+    try await registry.registerCrypto(
+      eth,
+      mapping: CryptoProviderMapping(
+        instrumentId: eth.id, coingeckoId: nil, cryptocompareSymbol: nil,
+        binanceSymbol: nil))
+    // Precondition: project() filters this shape → invisible to conversion.
+    try #require(try await registry.cryptoRegistration(byId: eth.id) == nil)
+    try #require(!(try await registry.allCryptoRegistrations().contains { $0.id == eth.id }))
+
+    // Discovery re-resolves and re-registers with a real mapping. The
+    // merge rule (a nil incoming provider column never clobbers a
+    // populated stored one) means re-registering with a real mapping
+    // restores the row to a visible, conversion-usable state.
+    try await registry.registerCrypto(
+      eth,
+      mapping: CryptoProviderMapping(
+        instrumentId: eth.id, coingeckoId: "ethereum", cryptocompareSymbol: "ETH",
+        binanceSymbol: "ETHUSDT"))
+    let reg = try await registry.cryptoRegistration(byId: eth.id)
+    #expect(reg?.mapping.coingeckoId == "ethereum")
+    #expect(try await registry.allCryptoRegistrations().contains { $0.id == eth.id })
+  }
+
+  @Test("registerCrypto merge preserves encodedSystemFields (no spurious change-tag loss)")
+  func mergePreservesEncodedSystemFields() async throws {
+    let registry = try makeRegistry()
+    try await registry.registerCrypto(
+      eth,
+      mapping: CryptoProviderMapping(
+        instrumentId: eth.id, coingeckoId: "ethereum", cryptocompareSymbol: nil,
+        binanceSymbol: nil))
+    let blob = Data([0xCA, 0xFE, 0xBA, 0xBE])
+    _ = try registry.setEncodedSystemFieldsSync(id: eth.id, data: blob)
+    // All-nil publish (the publishToSharedRegistry pattern) must not blank it.
+    try await registry.registerCrypto(
+      eth,
+      mapping: CryptoProviderMapping(
+        instrumentId: eth.id, coingeckoId: nil, cryptocompareSymbol: nil,
+        binanceSymbol: nil))
+    #expect(try registry.fetchRowSync(id: eth.id)?.encodedSystemFields == blob)
+  }
+}


### PR DESCRIPTION
**Stacked PR 1 of 6** — shared-instrument-registry cutover (plan: `plans/2026-05-15-shared-instrument-registry-cutover-plan.md`). Branches off `main`; PRs 2–6 stack on this.

## Problem
Crypto accounts hit `ConversionError.noProviderMapping` ("Unable to convert a transaction to 1:native…"). One root contributor: `publishToSharedRegistry` fires an all-nil `registerCrypto` (via the `onInstrumentChanged` hook after an `ensureInstrument` auto-insert), and `upsertCrypto` unconditionally overwrote the existing row's `coingecko_id`/`cryptocompare_symbol`/`binance_symbol` — destroying a discovery-resolved provider mapping. The shared `1:native` row in a real profile was observed degraded exactly this way.

## Change
- `GRDBInstrumentRegistryRepository.upsertCrypto` existing-row branch now **merges** (extracted to `mergeResolvedFields`): a nil/empty incoming provider or identity column never downgrades a populated stored one; `kind`/`decimals` unconditional. An all-nil publish is now a safe no-op merge.
- Already-corrupted rows self-heal without new code: `project(row:)` filters a `priced`+no-mapping row, so `cryptoRegistration(byId:)` returns nil, `resolveOrLoad` falls through and re-resolves, and this merged re-register restores it. (An earlier guard approach in `CryptoTokenDiscoveryService` was implemented then dropped — it was a production no-op given `project()` filtering and risked an `.unpriced` re-resolution churn; the discovery files are unchanged vs `main`.)
- Routes the shared-instrument self-heal scan through `unsyncedNonFiatRowIdsSync()` so a stray fiat row can't be queued for upload as a user-registered instrument (sync-review M-1).

## Tests
7 Swift Testing cases against a **real** `GRDBInstrumentRegistryRepository` (no stubs): empty/populated/partial mapping merge, empty-name & nil-ticker identity preservation, a production-faithful clobber→repair test (asserts `project()` invisibility precondition then repair), and an `encodedSystemFields`-preservation test (Rule 5, sync-review I-1). Full `just test` (iOS + macOS) green.

## Follow-up
`performResolution` double-write race tracked in #895 (pre-existing; deferred by decision to keep this PR's scope minimal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)