### PR TITLE
feat(registry): InstrumentMapResolving seam + memoized snapshot (cutover PR 2/6)

### DIFF
--- a/Backends/GRDB/Records/InstrumentRow+Mapping.swift
+++ b/Backends/GRDB/Records/InstrumentRow+Mapping.swift
@@ -12,15 +12,35 @@ extension InstrumentRow {
   /// ordering, mirroring `CloudKitInstrumentRegistryRepository.all()`.
   static func fetchInstrumentMap(database: Database) throws -> [String: Instrument] {
     let rows = try InstrumentRow.fetchAll(database)
-    var map: [String: Instrument] = [:]
+    // Start from the ambient ISO-fiat snapshot, then overlay stored rows
+    // so a stored row always wins over its ambient synthesis — identical
+    // outcome and ordering to the previous stored-then-fill loop, because
+    // a stored id either replaces its ambient entry or adds a new one.
+    var map = Self.ambientFiat
     for row in rows {
       map[row.id] = try row.toDomain()
     }
-    for code in Locale.Currency.isoCurrencies.map(\.identifier) where map[code] == nil {
+    return map
+  }
+
+  /// ISO-4217 fiat instruments synthesised once at first use.
+  ///
+  /// `fetchInstrumentMap` previously rebuilt this on every call —
+  /// ~150 `Instrument.fiat(code:)` constructions (each spinning up a
+  /// `NumberFormatter` to derive the currency's decimal places) over
+  /// `Locale.Currency.isoCurrencies`. On the cold-launch resolution
+  /// burst that dominated the call. The inputs are process-stable:
+  /// `Locale.Currency.isoCurrencies` is a fixed ISO table for the
+  /// process lifetime, and `Instrument.fiat(code:)` derives decimals
+  /// from the currency *code* (not the user's locale), so the synthesis
+  /// is deterministic and safe to compute once into a `static let`.
+  private static let ambientFiat: [String: Instrument] = {
+    var map: [String: Instrument] = [:]
+    for code in Locale.Currency.isoCurrencies.map(\.identifier) {
       map[code] = Instrument.fiat(code: code)
     }
     return map
-  }
+  }()
 
   /// The CloudKit recordType on the wire for this record. Frozen contract;
   /// existing iCloud zones reference this exact string regardless of how

--- a/Backends/GRDB/Repositories/GRDBInstrumentRegistryRepository+InstrumentMapResolving.swift
+++ b/Backends/GRDB/Repositories/GRDBInstrumentRegistryRepository+InstrumentMapResolving.swift
@@ -1,0 +1,14 @@
+// Backends/GRDB/Repositories/GRDBInstrumentRegistryRepository+InstrumentMapResolving.swift
+
+import GRDB
+
+extension GRDBInstrumentRegistryRepository: InstrumentMapResolving {
+  /// Stored rows first, ambient ISO fiat supplemented after — preserving
+  /// the ordering callers will see post-cutover so no read path changes
+  /// behaviour when it switches from per-profile to shared resolution.
+  func instrumentMap() async throws -> [String: Instrument] {
+    try await database.read { database in
+      try InstrumentRow.fetchInstrumentMap(database: database)
+    }
+  }
+}

--- a/Backends/GRDB/Repositories/GRDBInstrumentRegistryRepository+InstrumentMapResolving.swift
+++ b/Backends/GRDB/Repositories/GRDBInstrumentRegistryRepository+InstrumentMapResolving.swift
@@ -1,14 +1,107 @@
 // Backends/GRDB/Repositories/GRDBInstrumentRegistryRepository+InstrumentMapResolving.swift
 
 import GRDB
+import os
 
 extension GRDBInstrumentRegistryRepository: InstrumentMapResolving {
+  /// Returns the memoised `[String: Instrument]` snapshot, rebuilding it
+  /// from the database only when a mutation has invalidated the cache.
+  ///
+  /// The cutover routes every per-profile instrument resolution through
+  /// this single shared method on the serial profile-index queue (shared
+  /// across all profiles, the price caches, and sync apply). A per-call
+  /// `database.read` + full-map rebuild (incl. ~150 `Instrument.fiat`
+  /// constructions) on the cold-launch burst (~1400 calls/sec) would
+  /// serialise on that queue and regress badly. Steady state here is a
+  /// cached dictionary read behind one unfair-lock acquisition — cheaper
+  /// than today's per-call per-profile fetch.
+  ///
   /// Stored rows first, ambient ISO fiat supplemented after — preserving
   /// the ordering callers will see post-cutover so no read path changes
   /// behaviour when it switches from per-profile to shared resolution.
+  /// **Stale-read safety (bounded loop, not recursion).** The cold path
+  /// captures the invalidation generation, drops the lock, then
+  /// `await`s `database.read`. On commit it only adopts the rebuilt
+  /// snapshot if the generation is unchanged. If a mutation landed
+  /// during the await the generation moved on, the snapshot is *not*
+  /// committed, and — critically — this method does **not** return that
+  /// now-stale read. Instead it loops: the next iteration either finds a
+  /// fresh valid snapshot another caller committed in the meantime (and
+  /// returns it) or re-reads against the post-mutation database state.
+  ///
+  /// Termination: mutations never call `instrumentMap()`, so the loop
+  /// races only other readers and committed writes. Each iteration
+  /// either returns or observes a strictly greater generation; the
+  /// generation is monotone and a read is admitted by GRDB's serial
+  /// writer only after the write that bumped it has committed, so after
+  /// a bounded number of iterations a read sees the settled
+  /// post-mutation state and commits. The lock is never held across the
+  /// `await` (the read is issued with the lock released and re-acquired
+  /// only to inspect/commit) — preserve that.
   func instrumentMap() async throws -> [String: Instrument] {
-    try await database.read { database in
+    while true {
+      let snapshotRead = mapCache.withLock { state in
+        InstrumentMapSnapshotRead(
+          snapshot: state.snapshot,
+          isValid: state.isValid,
+          generation: state.generation)
+      }
+      if snapshotRead.isValid {
+        return snapshotRead.snapshot
+      }
+      let generationAtRead = snapshotRead.generation
+
+      // Cold / post-invalidation path: rebuild from the database. The
+      // signpost interval makes a regression here (a missed-invalidation
+      // rebuild storm, or the rebuild itself getting slow) attributable
+      // in Instruments under the `Repository` category.
+      let rebuilt = try await readInstrumentMapWithSignpost()
+
+      let committed = mapCache.withLock { state -> Bool in
+        state.dbReadCount += 1
+        // Only commit the rebuilt snapshot if no mutation invalidated
+        // the cache while the async `database.read` was in flight. If
+        // one did, the generation moved on; leave `isValid == false` and
+        // report not-committed so the caller re-loops rather than
+        // returning this now-stale read.
+        guard state.generation == generationAtRead else { return false }
+        state.snapshot = rebuilt
+        state.isValid = true
+        return true
+      }
+      if committed {
+        return rebuilt
+      }
+      // A mutation landed during the await; the rebuilt read is stale.
+      // Loop again: re-check the cache (a fresh valid snapshot may now
+      // exist) and otherwise re-read against the post-mutation state.
+    }
+  }
+
+  /// Reads the full instrument map from the database wrapped in the
+  /// `InstrumentRegistry.instrumentMap.rebuild` os_signpost interval so
+  /// a missed-invalidation rebuild storm is attributable in Instruments
+  /// under the `Repository` category.
+  private func readInstrumentMapWithSignpost() async throws -> [String: Instrument] {
+    let log = Signposts.repository
+    let name: StaticString = "InstrumentRegistry.instrumentMap.rebuild"
+    let signpostID = OSSignpostID(log: log)
+    os_signpost(.begin, log: log, name: name, signpostID: signpostID)
+    defer { os_signpost(.end, log: log, name: name, signpostID: signpostID) }
+    return try await database.read { database in
       try InstrumentRow.fetchInstrumentMap(database: database)
     }
   }
+}
+
+/// A consistent read of the memoised cache taken under a single lock
+/// acquisition: the snapshot itself, whether it is still valid, and the
+/// invalidation generation at the moment of the read. Named (rather than
+/// a tuple with an optional-collection member) so the lock closure's
+/// return type stays SwiftLint-clean and the validity check reads as a
+/// plain boolean at the call site.
+private struct InstrumentMapSnapshotRead {
+  let snapshot: [String: Instrument]
+  let isValid: Bool
+  let generation: Int
 }

--- a/Backends/GRDB/Repositories/GRDBInstrumentRegistryRepository+SyncEntryPoints.swift
+++ b/Backends/GRDB/Repositories/GRDBInstrumentRegistryRepository+SyncEntryPoints.swift
@@ -19,12 +19,18 @@ extension GRDBInstrumentRegistryRepository {
   /// Returns `true` when a row was found and updated.
   @discardableResult
   func setEncodedSystemFieldsSync(id: String, data: Data?) throws -> Bool {
-    try database.write { database in
+    let updated = try database.write { database in
       try InstrumentRow
         .filter(InstrumentRow.Columns.id == id)
         .updateAll(database, [InstrumentRow.Columns.encodedSystemFields.set(to: data)])
         > 0
     }
+    // System-fields-only writes don't change the domain `Instrument`,
+    // but a blanket invalidate-on-any-write keeps the staleness
+    // invariant simple and provably correct — the cost is one extra
+    // rebuild, never stale data.
+    invalidateInstrumentMapCache()
+    return updated
   }
 
   /// Clears `encoded_system_fields` on every row. Used after an
@@ -37,6 +43,7 @@ extension GRDBInstrumentRegistryRepository {
           database,
           [InstrumentRow.Columns.encodedSystemFields.set(to: nil)])
     }
+    invalidateInstrumentMapCache()
   }
 
   /// Returns IDs of rows whose `encoded_system_fields` is `NULL`.
@@ -85,5 +92,6 @@ extension GRDBInstrumentRegistryRepository {
     try database.write { database in
       _ = try InstrumentRow.deleteAll(database)
     }
+    invalidateInstrumentMapCache()
   }
 }

--- a/Backends/GRDB/Repositories/GRDBInstrumentRegistryRepository+SyncHooks.swift
+++ b/Backends/GRDB/Repositories/GRDBInstrumentRegistryRepository+SyncHooks.swift
@@ -13,6 +13,24 @@ import os
 /// the lock-guarded `HookState` shape used by
 /// `GRDBProfileIndexRepository`.
 extension GRDBInstrumentRegistryRepository {
+  /// Lock-guarded state behind the memoised instrument-map snapshot.
+  ///
+  /// `isValid == false` means "needs rebuild" (an empty `snapshot` is a
+  /// legitimate cached value, so a separate validity flag rather than an
+  /// optional-collection sentinel expresses the state). `generation` is
+  /// bumped by every invalidation; `instrumentMap()` reads the
+  /// generation before its `await database.read`, then only commits the
+  /// rebuilt snapshot if the generation is unchanged — so a mutation
+  /// that lands *during* the async read is never lost (it would
+  /// otherwise leave a stale-but-`isValid` snapshot). `dbReadCount`
+  /// counts only the branches that actually re-read the database.
+  struct MapCacheState {
+    var snapshot: [String: Instrument]
+    var isValid: Bool
+    var generation: Int
+    var dbReadCount: Int
+  }
+
   /// Replaces both hook closures atomically. Called by the
   /// `SyncCoordinator` once it exists; before that the repo is using
   /// the no-op closures from `init`.
@@ -41,5 +59,37 @@ extension GRDBInstrumentRegistryRepository {
   func fireOnRecordDeleted(_ id: String) {
     let notify = hooks.withLock { $0.onRecordDeleted }
     notify(id)
+  }
+
+  /// Drops the memoised instrument-map snapshot so the next
+  /// `instrumentMap()` call rebuilds it from the database. Called from
+  /// every mutation path — local writes, the `*Sync` entry points, and
+  /// the remote-apply path — at the point the row write has succeeded,
+  /// so a reader after a mutation can never observe stale data. A
+  /// blanket invalidate-on-any-write (even for metadata-only writes
+  /// like `setEncodedSystemFieldsSync`) keeps the invariant simple and
+  /// correct; the cost is one extra rebuild, not staleness.
+  func invalidateInstrumentMapCache() {
+    mapCache.withLock { state in
+      state.isValid = false
+      state.generation &+= 1
+    }
+  }
+
+  /// Number of times `instrumentMap()` actually re-read the database to
+  /// rebuild the memoised snapshot. Test-only accessor — kept with the
+  /// `ForTesting` suffix per `guides/DATABASE_CODE_GUIDE.md` §7 so the
+  /// production API surface stays clean. Exposed for the
+  /// cache-invariant tests in `GRDBInstrumentMapCacheTests` so they can
+  /// assert that repeated reads collapse to a single rebuild and that
+  /// every mutation path forces exactly one further rebuild.
+  ///
+  /// Under concurrent callers racing the cold path, every in-flight
+  /// `database.read` increments this counter, so it counts actual DB
+  /// rebuilds (which may exceed 1 per logical cache-miss when several
+  /// readers race a single invalidation) — it is a rebuild-storm canary,
+  /// not a strict logical-miss count.
+  var instrumentMapDBReadCountForTesting: Int {
+    mapCache.withLock { $0.dbReadCount }
   }
 }

--- a/Backends/GRDB/Repositories/GRDBInstrumentRegistryRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBInstrumentRegistryRepository.swift
@@ -17,11 +17,14 @@ import os
 /// mutations, and a non-protocol `notifyExternalChange()` method that the
 /// sync layer calls when remote pulls touch instrument rows.
 ///
-/// **`@unchecked Sendable` justification.** Has two mutable stored
+/// **`@unchecked Sendable` justification.** Has three mutable stored
 /// properties: `subscribers` (the `@MainActor`-confined
-/// AsyncStream-continuation map driving `observeChanges()`) and
+/// AsyncStream-continuation map driving `observeChanges()`),
 /// `hooks` (the lock-guarded `HookState` swapped in by
-/// `attachSyncHooks`). Both are race-free at runtime — see
+/// `attachSyncHooks`), and `mapCache` (the lock-guarded
+/// `MapCacheState` memoising the instrument-map snapshot; see
+/// `GRDBInstrumentRegistryRepository+InstrumentMapResolving.swift`).
+/// All three are race-free at runtime — see
 /// `guides/CONCURRENCY_GUIDE.md` §2 "False Positives to Avoid",
 /// Carve-out 3 (GRDB repositories).
 final class GRDBInstrumentRegistryRepository:
@@ -52,6 +55,20 @@ final class GRDBInstrumentRegistryRepository:
   // scoped because Swift extensions in separate files don't share
   // `private` access.
   let hooks: OSAllocatedUnfairLock<HookState>
+
+  /// Lock-guarded memoised instrument-map snapshot. The
+  /// `MapCacheState` type and the invalidation / test-accessor helpers
+  /// live in the sibling `+SyncHooks` extension file so this file stays
+  /// under SwiftLint's `file_length` / `type_body_length` thresholds;
+  /// only the stored property itself must be declared in the class
+  /// body. Guarded by the same `OSAllocatedUnfairLock` primitive the
+  /// type already uses for `hooks` — deliberately not a second,
+  /// divergent synchronisation mechanism. `internal` (default) so the
+  /// sibling `+InstrumentMapResolving` / `+SyncEntryPoints` extensions
+  /// can read and invalidate it.
+  let mapCache = OSAllocatedUnfairLock(
+    initialState: MapCacheState(
+      snapshot: [:], isValid: false, generation: 0, dbReadCount: 0))
   private let logger = Logger(
     subsystem: "com.moolah.app", category: "InstrumentRegistry")
 
@@ -122,6 +139,7 @@ final class GRDBInstrumentRegistryRepository:
       try Self.upsertCrypto(
         database: database, instrument: instrument, mapping: mapping)
     }
+    invalidateInstrumentMapCache()
     fireOnRecordChanged(instrument.id)
     await notifySubscribers()
   }
@@ -131,6 +149,7 @@ final class GRDBInstrumentRegistryRepository:
     try await database.write { database in
       try Self.upsertStock(database: database, instrument: instrument)
     }
+    invalidateInstrumentMapCache()
     fireOnRecordChanged(instrument.id)
     await notifySubscribers()
   }
@@ -148,6 +167,7 @@ final class GRDBInstrumentRegistryRepository:
       return try InstrumentRow.deleteOne(database, key: id)
     }
     guard didDelete else { return }
+    invalidateInstrumentMapCache()
     fireOnRecordDeleted(id)
     await notifySubscribers()
   }
@@ -315,6 +335,10 @@ final class GRDBInstrumentRegistryRepository:
         _ = try InstrumentRow.deleteOne(database, key: id)
       }
     }
+    // Remote pulls mutate rows just like local writes; the memoised
+    // map must be rebuilt before the next reader (e.g. a price-cache
+    // resolution) observes it.
+    invalidateInstrumentMapCache()
   }
 
   /// Persists a new `pricingStatus` for the row identified by
@@ -352,6 +376,7 @@ final class GRDBInstrumentRegistryRepository:
         "InstrumentRegistry: no row registered for id '\(registration.instrument.id)'"
       )
     }
+    invalidateInstrumentMapCache()
     fireOnRecordChanged(registration.instrument.id)
     await notifySubscribers()
   }

--- a/Backends/GRDB/Repositories/PerProfileInstrumentMapResolver.swift
+++ b/Backends/GRDB/Repositories/PerProfileInstrumentMapResolver.swift
@@ -1,0 +1,19 @@
+// Backends/GRDB/Repositories/PerProfileInstrumentMapResolver.swift
+
+import GRDB
+
+/// `InstrumentMapResolving` over a per-profile database. Transitional:
+/// preview / test / apply callers that don't have the shared registry
+/// keep reading the per-profile `instrument` table until the
+/// `v10_drop_shared_instrument_legacy` migration removes it. Production
+/// CloudKit sessions inject the shared `GRDBInstrumentRegistryRepository`
+/// instead (see ProfileSession+CloudKitBackendBuild).
+struct PerProfileInstrumentMapResolver: InstrumentMapResolving {
+  let database: any DatabaseReader
+
+  func instrumentMap() async throws -> [String: Instrument] {
+    try await database.read { database in
+      try InstrumentRow.fetchInstrumentMap(database: database)
+    }
+  }
+}

--- a/Domain/Repositories/InstrumentMapResolving.swift
+++ b/Domain/Repositories/InstrumentMapResolving.swift
@@ -1,0 +1,12 @@
+// Domain/Repositories/InstrumentMapResolving.swift
+
+/// Resolves the full instrument lookup table (`id → Instrument`,
+/// including ambient ISO fiat) from the canonical instrument registry.
+///
+/// Replaces the per-profile `InstrumentRow.fetchInstrumentMap(database:)`
+/// read. The map is reference/lookup data with immutable identity, so it
+/// is fetched once per repository operation outside the per-profile
+/// transaction snapshot rather than joined into it.
+protocol InstrumentMapResolving: Sendable {
+  func instrumentMap() async throws -> [String: Instrument]
+}

--- a/MoolahBenchmarks/InstrumentMapResolutionBenchmarks.swift
+++ b/MoolahBenchmarks/InstrumentMapResolutionBenchmarks.swift
@@ -1,0 +1,149 @@
+import Foundation
+import GRDB
+import XCTest
+
+@testable import Moolah
+
+/// Benchmarks the cold-launch instrument-resolution burst that the
+/// shared-registry cutover routes through
+/// `GRDBInstrumentRegistryRepository.instrumentMap()`.
+///
+/// Post-cutover every per-profile instrument resolution resolves against
+/// this single shared method on the serial profile-index queue (shared
+/// across all profiles, the price caches, and sync apply). The #868
+/// cold-launch path issues a burst on the order of ~1400 resolutions/sec.
+/// Before memoisation each call did a `database.read` + a full-map
+/// rebuild — including ~150 `Instrument.fiat(code:)` constructions (each
+/// spinning up a `NumberFormatter`) over `Locale.Currency.isoCurrencies`
+/// — and serialised on the shared queue. With the memoised,
+/// change-invalidated snapshot the steady-state cost is a single
+/// unfair-lock-guarded dictionary read.
+///
+/// `testColdLaunchBurst` measures 1400 sequential `instrumentMap()`
+/// calls against a populated registry: one cold rebuild then 1399 cache
+/// hits. `testColdLaunchBurstWithMutation` interleaves a single
+/// `registerCrypto` mutation to exercise exactly one mid-burst rebuild.
+/// The `InstrumentRegistry.instrumentMap.rebuild` os_signpost (category
+/// `Repository`) wraps the rebuild branch so a missed-invalidation
+/// rebuild storm is attributable in Instruments rather than showing up
+/// only as an opaque wall-clock blowup here.
+final class InstrumentMapResolutionBenchmarks: XCTestCase {
+
+  /// Cold-launch burst size — a one-second proxy for the #868 burst.
+  private static let burstCallCount = 1400
+
+  nonisolated(unsafe) private static var _registry: GRDBInstrumentRegistryRepository?
+  nonisolated(unsafe) private static var _database: DatabaseQueue?
+
+  override static func setUp() {
+    super.setUp()
+    let database = expecting("benchmark ProfileIndexDatabase.openInMemory failed") {
+      try ProfileIndexDatabase.openInMemory()
+    }
+    _database = database
+    let registry = GRDBInstrumentRegistryRepository(database: database)
+
+    // Populate ~80 crypto + stock rows so the rebuild path realises a
+    // representative stored-over-ambient merge, not just bare ambient
+    // fiat. The cache-hit path is independent of row count, but the cold
+    // rebuild this benchmark also pays once should be realistic.
+    awaitSyncExpecting {
+      for index in 0..<80 {
+        let token = Instrument.crypto(
+          chainId: 1,
+          contractAddress: "0x\(String(format: "%040x", index))",
+          symbol: "TK\(index)",
+          name: "Token \(index)",
+          decimals: 18)
+        try await registry.registerCrypto(
+          token,
+          mapping: CryptoProviderMapping(
+            instrumentId: token.id,
+            coingeckoId: "token-\(index)",
+            cryptocompareSymbol: nil,
+            binanceSymbol: nil))
+      }
+    }
+    _registry = registry
+  }
+
+  override static func tearDown() {
+    _registry = nil
+    _database = nil
+    super.tearDown()
+  }
+
+  private var registry: GRDBInstrumentRegistryRepository {
+    guard let registry = Self._registry else {
+      preconditionFailure("setUp must initialise _registry before tests run")
+    }
+    return registry
+  }
+
+  private var metrics: [XCTMetric] { [XCTClockMetric(), XCTMemoryMetric()] }
+  private var options: XCTMeasureOptions {
+    let opts = XCTMeasureOptions()
+    opts.iterationCount = 10
+    return opts
+  }
+
+  /// 1400 sequential `instrumentMap()` calls — one cold rebuild then
+  /// 1399 memoised cache hits. Approximates the #868 cold-launch
+  /// resolution burst once it routes through the shared registry.
+  func testColdLaunchBurst() {
+    let registry = self.registry
+    let count = Self.burstCallCount
+    measure(metrics: metrics, options: options) {
+      // `measure` runs the block `iterationCount` (10) times; without
+      // resetting the cache, iterations 2–10 would be pure warm-cache
+      // hits and wouldn't measure the cold rebuild the test name
+      // promises. Invalidate first so every iteration is a genuine
+      // "1 cold rebuild + 1399 hits" burst.
+      registry.invalidateInstrumentMapCache()
+      autoreleasepool {
+        _ = awaitSyncExpecting {
+          var total = 0
+          for _ in 0..<count {
+            total += try await registry.instrumentMap().count
+          }
+          return total
+        }
+      }
+    }
+  }
+
+  /// Same burst, but a single `registerCrypto` mutation is interleaved
+  /// at the midpoint so exactly one mid-burst cache invalidation +
+  /// rebuild is exercised alongside the cache-hit steady state.
+  func testColdLaunchBurstWithMutation() {
+    let registry = self.registry
+    let count = Self.burstCallCount
+    let midpoint = count / 2
+    measure(metrics: metrics, options: options) {
+      autoreleasepool {
+        _ = awaitSyncExpecting {
+          var total = 0
+          for index in 0..<count {
+            if index == midpoint {
+              let token = Instrument.crypto(
+                chainId: 1,
+                contractAddress: nil,
+                symbol: "MID",
+                name: "Mid-burst token",
+                decimals: 18)
+              try await registry.registerCrypto(
+                token,
+                mapping: CryptoProviderMapping(
+                  instrumentId: token.id,
+                  coingeckoId: "mid-burst",
+                  cryptocompareSymbol: nil,
+                  binanceSymbol: nil))
+            }
+            total += try await registry.instrumentMap().count
+          }
+          return total
+        }
+      }
+    }
+  }
+}

--- a/MoolahTests/Backends/GRDB/GRDBInstrumentMapCacheTests.swift
+++ b/MoolahTests/Backends/GRDB/GRDBInstrumentMapCacheTests.swift
@@ -1,0 +1,212 @@
+// MoolahTests/Backends/GRDB/GRDBInstrumentMapCacheTests.swift
+
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+/// Verifies `GRDBInstrumentRegistryRepository.instrumentMap()` serves a
+/// memoised `[String: Instrument]` snapshot that is rebuilt from the
+/// database only when a registry mutation invalidates it. The cutover
+/// routes every per-profile instrument resolution through this single
+/// shared method on the serial profile-index queue; a per-call DB read
+/// would serialise and regress the cold-launch burst. The correctness
+/// invariant under test is that *every* mutation path (local writes,
+/// `*Sync` mutators, and the remote-apply path) invalidates the cache so
+/// a reader after a mutation never observes stale instrument data.
+@Suite("Shared registry memoises the instrument map until a mutation")
+struct GRDBInstrumentMapCacheTests {
+  private func makeRegistry() throws -> (
+    GRDBInstrumentRegistryRepository, any DatabaseWriter
+  ) {
+    let queue = try ProfileIndexDatabase.openInMemory()
+    return (GRDBInstrumentRegistryRepository(database: queue), queue)
+  }
+
+  private func sampleCrypto() -> Instrument {
+    Instrument.crypto(
+      chainId: 1, contractAddress: nil, symbol: "ETH", name: "Ethereum", decimals: 18)
+  }
+
+  @Test("memoised until a mutation; first read hits the DB once")
+  func memoizedUntilMutation() async throws {
+    let (registry, _) = try makeRegistry()
+
+    #expect(registry.instrumentMapDBReadCountForTesting == 0)
+
+    let first = try await registry.instrumentMap()
+    #expect(registry.instrumentMapDBReadCountForTesting == 1)
+    #expect(first["USD"]?.kind == .fiatCurrency)
+
+    // Repeated reads are served from the cache — no further DB rebuilds.
+    _ = try await registry.instrumentMap()
+    _ = try await registry.instrumentMap()
+    #expect(registry.instrumentMapDBReadCountForTesting == 1)
+
+    // A mutation invalidates; the next read rebuilds exactly once and
+    // reflects the new row while ambient fiat is still present.
+    let eth = sampleCrypto()
+    try await registry.registerCrypto(
+      eth,
+      mapping: CryptoProviderMapping(
+        instrumentId: eth.id, coingeckoId: "ethereum", cryptocompareSymbol: nil,
+        binanceSymbol: nil))
+
+    let afterMutation = try await registry.instrumentMap()
+    #expect(registry.instrumentMapDBReadCountForTesting == 2)
+    #expect(afterMutation[eth.id]?.kind == .cryptoToken)
+    #expect(afterMutation["USD"]?.kind == .fiatCurrency)
+  }
+
+  @Test("update(_:) invalidates the cache")
+  func invalidatedByUpdate() async throws {
+    let (registry, _) = try makeRegistry()
+    let eth = sampleCrypto()
+    try await registry.registerCrypto(
+      eth,
+      mapping: CryptoProviderMapping(
+        instrumentId: eth.id, coingeckoId: "ethereum", cryptocompareSymbol: nil,
+        binanceSymbol: nil))
+
+    // Prime the cache.
+    _ = try await registry.instrumentMap()
+    let primedCount = registry.instrumentMapDBReadCountForTesting
+
+    try await registry.update(
+      CryptoRegistration(
+        instrument: eth,
+        mapping: CryptoProviderMapping(
+          instrumentId: eth.id, coingeckoId: "ethereum", cryptocompareSymbol: nil,
+          binanceSymbol: nil),
+        pricingStatus: .spam))
+
+    let rebuilt = try await registry.instrumentMap()
+    #expect(registry.instrumentMapDBReadCountForTesting == primedCount + 1)
+    #expect(rebuilt[eth.id]?.kind == .cryptoToken)
+  }
+
+  @Test("sync-apply path (applyRemoteChangesSync) invalidates the cache")
+  func invalidatedBySyncApply() async throws {
+    let (registry, _) = try makeRegistry()
+
+    // Prime the cache before the remote apply.
+    _ = try await registry.instrumentMap()
+    let primedCount = registry.instrumentMapDBReadCountForTesting
+    #expect(primedCount == 1)
+
+    let eth = sampleCrypto()
+    var row = InstrumentRow(domain: eth)
+    row.coingeckoId = "ethereum"
+    try registry.applyRemoteChangesSync(saved: [row], deleted: [])
+
+    let rebuilt = try await registry.instrumentMap()
+    #expect(registry.instrumentMapDBReadCountForTesting == primedCount + 1)
+    #expect(rebuilt[eth.id]?.kind == .cryptoToken)
+  }
+
+  @Test("metadata-only *Sync mutator still invalidates the cache")
+  func invalidatedBySystemFieldsWrite() async throws {
+    let (registry, _) = try makeRegistry()
+    let eth = sampleCrypto()
+    try await registry.registerCrypto(
+      eth,
+      mapping: CryptoProviderMapping(
+        instrumentId: eth.id, coingeckoId: "ethereum", cryptocompareSymbol: nil,
+        binanceSymbol: nil))
+
+    _ = try await registry.instrumentMap()
+    let primedCount = registry.instrumentMapDBReadCountForTesting
+
+    // System-fields-only writes don't change the domain `Instrument`,
+    // but a blanket invalidate-on-any-write is the safe simple invariant
+    // — assert the rebuild still happens.
+    let updated = try registry.setEncodedSystemFieldsSync(
+      id: eth.id, data: Data([0x01, 0x02]))
+    #expect(updated)
+
+    _ = try await registry.instrumentMap()
+    #expect(registry.instrumentMapDBReadCountForTesting == primedCount + 1)
+  }
+
+  @Test("registerStock(_:) invalidates the cache")
+  func invalidatedByRegisterStock() async throws {
+    let (registry, _) = try makeRegistry()
+
+    _ = try await registry.instrumentMap()
+    let primedCount = registry.instrumentMapDBReadCountForTesting
+
+    let bhp = Instrument.stock(ticker: "BHP", exchange: "ASX", name: "BHP Group")
+    try await registry.registerStock(bhp)
+
+    let rebuilt = try await registry.instrumentMap()
+    #expect(registry.instrumentMapDBReadCountForTesting == primedCount + 1)
+    #expect(rebuilt[bhp.id]?.kind == .stock)
+  }
+
+  @Test("remove(id:) invalidates the cache")
+  func invalidatedByRemove() async throws {
+    let (registry, _) = try makeRegistry()
+    let eth = sampleCrypto()
+    try await registry.registerCrypto(
+      eth,
+      mapping: CryptoProviderMapping(
+        instrumentId: eth.id, coingeckoId: "ethereum", cryptocompareSymbol: nil,
+        binanceSymbol: nil))
+
+    let primed = try await registry.instrumentMap()
+    #expect(primed[eth.id]?.kind == .cryptoToken)
+    let primedCount = registry.instrumentMapDBReadCountForTesting
+
+    try await registry.remove(id: eth.id)
+
+    let rebuilt = try await registry.instrumentMap()
+    #expect(registry.instrumentMapDBReadCountForTesting == primedCount + 1)
+    #expect(rebuilt[eth.id] == nil)
+  }
+
+  @Test("clearAllSystemFieldsSync() invalidates the cache")
+  func invalidatedByClearAllSystemFields() async throws {
+    let (registry, _) = try makeRegistry()
+    let eth = sampleCrypto()
+    try await registry.registerCrypto(
+      eth,
+      mapping: CryptoProviderMapping(
+        instrumentId: eth.id, coingeckoId: "ethereum", cryptocompareSymbol: nil,
+        binanceSymbol: nil))
+
+    _ = try await registry.instrumentMap()
+    let primedCount = registry.instrumentMapDBReadCountForTesting
+
+    // Metadata-only write, but the blanket invalidate-on-any-write
+    // invariant means the next read must still rebuild exactly once.
+    try registry.clearAllSystemFieldsSync()
+
+    let rebuilt = try await registry.instrumentMap()
+    #expect(registry.instrumentMapDBReadCountForTesting == primedCount + 1)
+    #expect(rebuilt[eth.id]?.kind == .cryptoToken)
+  }
+
+  @Test("deleteAllSync() invalidates the cache")
+  func invalidatedByDeleteAll() async throws {
+    let (registry, _) = try makeRegistry()
+    let eth = sampleCrypto()
+    try await registry.registerCrypto(
+      eth,
+      mapping: CryptoProviderMapping(
+        instrumentId: eth.id, coingeckoId: "ethereum", cryptocompareSymbol: nil,
+        binanceSymbol: nil))
+
+    let primed = try await registry.instrumentMap()
+    #expect(primed[eth.id]?.kind == .cryptoToken)
+    let primedCount = registry.instrumentMapDBReadCountForTesting
+
+    try registry.deleteAllSync()
+
+    let rebuilt = try await registry.instrumentMap()
+    #expect(registry.instrumentMapDBReadCountForTesting == primedCount + 1)
+    #expect(rebuilt[eth.id] == nil)
+    // Ambient ISO fiat survives a stored-row wipe.
+    #expect(rebuilt["USD"]?.kind == .fiatCurrency)
+  }
+}

--- a/MoolahTests/Backends/GRDB/GRDBInstrumentMapResolvingTests.swift
+++ b/MoolahTests/Backends/GRDB/GRDBInstrumentMapResolvingTests.swift
@@ -1,0 +1,34 @@
+// MoolahTests/Backends/GRDB/GRDBInstrumentMapResolvingTests.swift
+
+import GRDB
+import Testing
+
+@testable import Moolah
+
+@Suite("Shared registry resolves the full instrument map")
+struct GRDBInstrumentMapResolvingTests {
+  private func resolvedMap() async throws -> [String: Instrument] {
+    let queue = try ProfileIndexDatabase.openInMemory()
+    let registry = GRDBInstrumentRegistryRepository(database: queue)
+    let eth = Instrument.crypto(
+      chainId: 1, contractAddress: nil, symbol: "ETH", name: "Ethereum", decimals: 18)
+    try await registry.registerCrypto(
+      eth,
+      mapping: CryptoProviderMapping(
+        instrumentId: eth.id, coingeckoId: "ethereum", cryptocompareSymbol: nil,
+        binanceSymbol: nil))
+    return try await (registry as any InstrumentMapResolving).instrumentMap()
+  }
+
+  @Test("stored crypto row appears in the map")
+  func storedCryptoRowAppearsInMap() async throws {
+    let map = try await resolvedMap()
+    #expect(map["1:native"]?.kind == .cryptoToken)
+  }
+
+  @Test("ambient ISO fiat is supplemented in the map")
+  func ambientFiatIsSupplemented() async throws {
+    let map = try await resolvedMap()
+    #expect(map["USD"]?.kind == .fiatCurrency)
+  }
+}

--- a/MoolahTests/Backends/GRDB/GRDBInstrumentRegistryRollbackTests.swift
+++ b/MoolahTests/Backends/GRDB/GRDBInstrumentRegistryRollbackTests.swift
@@ -1,0 +1,89 @@
+// MoolahTests/Backends/GRDB/GRDBInstrumentRegistryRollbackTests.swift
+
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+/// Rollback contract test for the multi-statement write on
+/// `GRDBInstrumentRegistryRepository.applyRemoteChangesSync`. Mirrors
+/// `ProfileIndexRollbackTests` / `CSVImportRollbackTests` — per
+/// `guides/DATABASE_CODE_GUIDE.md` §5 every multi-statement write must
+/// roll back atomically when any statement throws, so prior on-disk
+/// state survives byte-equal and no partial write lands.
+///
+/// `applyRemoteChangesSync` upserts every saved row and then deletes
+/// every id inside a single `database.write` closure. A `BEFORE INSERT`
+/// trigger that aborts on a sentinel `id` forces the second saved row's
+/// INSERT to throw *inside* that transaction, so the first row's upsert
+/// (which already mutated a pre-seeded row via the UPDATE side of the
+/// conflict resolution) must roll back with it.
+@Suite("Shared instrument-registry GRDB rollback contracts")
+struct GRDBInstrumentRegistryRollbackTests {
+
+  @Test
+  func applyRemoteChangesSyncRollsBackOnFailure() async throws {
+    let database = try ProfileIndexDatabase.openInMemory()
+    let registry = GRDBInstrumentRegistryRepository(database: database)
+
+    // Seed an initial stored row whose ticker we'll attempt (and fail)
+    // to mutate via the failing batch.
+    let priorId = "1:0xabc"
+    let prior = InstrumentRow(
+      domain: Instrument.crypto(
+        chainId: 1, contractAddress: "0xabc", symbol: "PRE", name: "Prior",
+        decimals: 18))
+    try await database.write { database in
+      try prior.insert(database)
+    }
+
+    // Trigger that aborts any INSERT whose id matches the sentinel. The
+    // first batch row upserts successfully (its id already exists, so
+    // SQLite resolves the conflict via UPDATE); the second row's INSERT
+    // trips the trigger inside `applyRemoteChangesSync`'s single
+    // transaction, so every statement — including the upsert that
+    // already touched `priorId` — must roll back.
+    try await database.write { database in
+      try database.execute(
+        sql: """
+          CREATE TRIGGER fail_instrument_upsert
+          BEFORE INSERT ON instrument
+          WHEN NEW.id = '___FAIL___'
+          BEGIN
+              SELECT RAISE(ABORT, 'forced failure for rollback test');
+          END;
+          """)
+    }
+
+    // Saved batch: a row that mutates the prior row's name (UPDATE side
+    // of upsert) followed by a brand-new row that trips the trigger on
+    // INSERT.
+    var mutating = InstrumentRow(
+      domain: Instrument.crypto(
+        chainId: 1, contractAddress: "0xabc", symbol: "MUT",
+        name: "MUTATED NAME THAT MUST NOT LAND", decimals: 18))
+    mutating.recordName = prior.recordName
+    var failing = InstrumentRow(
+      domain: Instrument.crypto(
+        chainId: 9, contractAddress: nil, symbol: "FAIL", name: "Fail",
+        decimals: 18))
+    failing.id = "___FAIL___"
+    failing.recordName = "___FAIL___"
+
+    do {
+      try registry.applyRemoteChangesSync(saved: [mutating, failing], deleted: [])
+      Issue.record("applyRemoteChangesSync should have thrown but did not")
+    } catch {
+      // Expected — trigger raises ABORT mid-transaction.
+    }
+
+    // The prior row's name survives byte-equal: the mutating upsert
+    // never committed.
+    let surviving = try #require(try registry.fetchRowSync(id: priorId))
+    #expect(surviving.name == "Prior")
+    // And the failing row was NOT persisted — no partial write.
+    #expect(try registry.fetchRowSync(id: "___FAIL___") == nil)
+    #expect(try registry.allRowIdsSync() == [priorId])
+  }
+}

--- a/MoolahTests/Backends/GRDB/InstrumentRegistryPlanPinningTests.swift
+++ b/MoolahTests/Backends/GRDB/InstrumentRegistryPlanPinningTests.swift
@@ -1,0 +1,48 @@
+// MoolahTests/Backends/GRDB/InstrumentRegistryPlanPinningTests.swift
+
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+/// `EXPLAIN QUERY PLAN`-pinning test for the shared instrument
+/// registry's full-map rebuild query. Per
+/// `guides/DATABASE_CODE_GUIDE.md` §6 every perf-relevant query gets a
+/// paired plan-pinning test so a future schema edit that changes the
+/// planner's strategy breaks the build immediately rather than
+/// silently regressing.
+///
+/// `InstrumentRow.fetchInstrumentMap` issues a bare
+/// `SELECT * FROM instrument` (via `InstrumentRow.fetchAll`) to load
+/// every row and overlay it on the ambient ISO-fiat snapshot. A full
+/// `SCAN instrument` is *intentional and correct* here: building the
+/// snapshot requires the entire table, the table is small (a few
+/// stored rows plus ambient fiat is synthesised in memory, not from
+/// SQL), and the query runs only on a cold cache rebuild — never on
+/// the memoised steady-state read path. The pin exists so that the
+/// scan stays a deliberate full-table read and a future index/`WHERE`
+/// edit that turns it into something else is a conscious decision.
+@Suite("Shared instrument-registry GRDB query plans")
+struct InstrumentRegistryPlanPinningTests {
+  private func makeDatabase() throws -> DatabaseQueue {
+    try ProfileIndexDatabase.openInMemory()
+  }
+
+  @Test("fetchInstrumentMap SELECT * FROM instrument is an intentional full scan")
+  func fetchInstrumentMapIsIntentionalFullScan() throws {
+    let database = try makeDatabase()
+    let detail = try PlanPinningTestHelpers.planDetail(
+      database,
+      query: """
+        SELECT * FROM instrument
+        """)
+    // The whole-table read is required to build the `[String:
+    // Instrument]` snapshot; there is no `WHERE`/`ORDER BY` to drive an
+    // index, and one shouldn't be added — the table is small and this
+    // runs only on a cache rebuild. Pin the bare `SCAN instrument` so a
+    // future schema change that (e.g.) silently routes this through a
+    // partial index has to update this test deliberately.
+    #expect(PlanPinningTestHelpers.planHasFullTableScanOf(detail, alias: "instrument"))
+  }
+}

--- a/MoolahTests/Backends/GRDB/PerProfileInstrumentMapResolverTests.swift
+++ b/MoolahTests/Backends/GRDB/PerProfileInstrumentMapResolverTests.swift
@@ -11,11 +11,11 @@ struct PerProfileInstrumentMapResolverTests {
   func readsPerProfileTable() async throws {
     let queue = try DatabaseQueue()
     try ProfileSchema.migrator.migrate(queue)
-    try await queue.write { db in
+    try await queue.write { database in
       try InstrumentRow(
         domain: Instrument.crypto(
           chainId: 1, contractAddress: nil, symbol: "ETH", name: "Ethereum", decimals: 18)
-      ).insert(db)
+      ).insert(database)
     }
     let resolver = PerProfileInstrumentMapResolver(database: queue)
     let map = try await resolver.instrumentMap()

--- a/MoolahTests/Backends/GRDB/PerProfileInstrumentMapResolverTests.swift
+++ b/MoolahTests/Backends/GRDB/PerProfileInstrumentMapResolverTests.swift
@@ -1,0 +1,24 @@
+// MoolahTests/Backends/GRDB/PerProfileInstrumentMapResolverTests.swift
+
+import GRDB
+import Testing
+
+@testable import Moolah
+
+@Suite("PerProfileInstrumentMapResolver reads the per-profile instrument table")
+struct PerProfileInstrumentMapResolverTests {
+  @Test("returns rows from the supplied per-profile database")
+  func readsPerProfileTable() async throws {
+    let queue = try DatabaseQueue()
+    try ProfileSchema.migrator.migrate(queue)
+    try await queue.write { db in
+      try InstrumentRow(
+        domain: Instrument.crypto(
+          chainId: 1, contractAddress: nil, symbol: "ETH", name: "Ethereum", decimals: 18)
+      ).insert(db)
+    }
+    let resolver = PerProfileInstrumentMapResolver(database: queue)
+    let map = try await resolver.instrumentMap()
+    #expect(map["1:native"]?.kind == .cryptoToken)
+  }
+}


### PR DESCRIPTION
**Stacked PR 2 of 6** — shared-instrument-registry cutover (plan: `plans/2026-05-15-shared-instrument-registry-cutover-plan.md`). **Base: `fix/instrument-registry-clobber` (PR #896)** — review/merge PR #896 first. No behaviour change; pure seam + perf safeguard.

## What
- `InstrumentMapResolving` — narrow `Sendable` Domain protocol (`func instrumentMap() async throws -> [String: Instrument]`); the shared `GRDBInstrumentRegistryRepository` conforms (stored rows + ambient ISO fiat, same ordering as the retired per-profile `fetchInstrumentMap`).
- `PerProfileInstrumentMapResolver` — transitional read-only shim for preview/test/apply callers until the per-profile `instrument` table is dropped (Phase 6).
- **Perf-critical:** `instrumentMap()` serves an `OSAllocatedUnfairLock`-guarded memoized snapshot (same primitive as the repo's existing `hooks` state), rebuilt only when a mutation invalidates it. All **8** instrument-table mutation paths (local writes + `applyRemoteChangesSync` + the `*Sync` entry points) invalidate; a generation guard + bounded retry loop guarantees a reader racing a mutation never returns or caches stale data, with the lock never held across the `await`. Ambient ISO fiat is synthesised once into a `static let` instead of per call.

## Why
Phase 3 routes every per-profile instrument resolution through the shared registry (the single serial profile-index queue). Without memoization the #868 cold-launch burst (~1400 calls/s) would serialize + rebuild the full map (+~150 NumberFormatter fiat constructions) each call. Memoized steady state = a cached dict read behind one actor hop — strictly cheaper than today's per-call per-profile read.

## Tests / benchmark
Real-GRDB Swift Testing against the shared profile-index in-memory schema: all 8 invalidation paths, memoization, `EXPLAIN QUERY PLAN` pin (intentional `SCAN instrument`), and an `applyRemoteChangesSync` in-transaction-rollback test. New `InstrumentMapResolutionBenchmarks` (1400-call cold-burst, `os_signpost` on the rebuild branch) — establishes the baseline for Phase 3's benchmark gate; observed ~1.5 ms / 1400 calls (cached path). Full `just test` (iOS + macOS) green; `format-check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)