### PR TITLE
refactor: resolve instruments from shared registry — read paths (cutover PR 3/6)

### DIFF
--- a/Backends/CloudKit/CloudKitBackend.swift
+++ b/Backends/CloudKit/CloudKitBackend.swift
@@ -101,6 +101,7 @@ final class CloudKitBackend: BackendProvider, @unchecked Sendable {
       database: database,
       instrument: instrument,
       conversionService: conversionService,
+      instrumentResolver: instrumentRegistry,
       hooks: hooks)
 
     self.grdbAccounts = repos.accounts
@@ -149,6 +150,7 @@ final class CloudKitBackend: BackendProvider, @unchecked Sendable {
     database: any DatabaseWriter,
     instrument: Instrument,
     conversionService: any InstrumentConversionService,
+    instrumentResolver: any InstrumentMapResolving,
     hooks: CloudKitBackendHooks
   ) -> GRDBRepositoryBundle {
     GRDBRepositoryBundle(
@@ -161,6 +163,7 @@ final class CloudKitBackend: BackendProvider, @unchecked Sendable {
         database: database,
         defaultInstrument: instrument,
         conversionService: conversionService,
+        instrumentResolver: instrumentResolver,
         onRecordChanged: hooks.onTransactionChanged,
         onRecordDeleted: hooks.onTransactionDeleted,
         onInstrumentChanged: hooks.onInstrumentChanged),

--- a/Backends/CloudKit/CloudKitBackend.swift
+++ b/Backends/CloudKit/CloudKitBackend.swift
@@ -153,9 +153,71 @@ final class CloudKitBackend: BackendProvider, @unchecked Sendable {
     instrumentResolver: any InstrumentMapResolving,
     hooks: CloudKitBackendHooks
   ) -> GRDBRepositoryBundle {
-    GRDBRepositoryBundle(
+    // The instrument-resolving read repos (accounts, transactions,
+    // earmarks, investments, analysis) all take `instrumentResolver`;
+    // the remaining record-type repos don't, so the two groups are
+    // built by separate helpers to keep this function body under
+    // SwiftLint's `function_body_length` budget.
+    let resolving = makeResolvingRepositories(
+      database: database,
+      instrument: instrument,
+      conversionService: conversionService,
+      instrumentResolver: instrumentResolver,
+      hooks: hooks)
+    return GRDBRepositoryBundle(
+      accounts: resolving.accounts,
+      transactions: resolving.transactions,
+      categories: GRDBCategoryRepository(
+        database: database,
+        onRecordChanged: hooks.onCategoryChanged,
+        onRecordDeleted: hooks.onCategoryDeleted),
+      earmarks: resolving.earmarks,
+      earmarkBudgetItems: GRDBEarmarkBudgetItemRepository(
+        database: database,
+        onRecordChanged: hooks.onEarmarkBudgetItemChanged,
+        onRecordDeleted: hooks.onEarmarkBudgetItemDeleted),
+      investments: resolving.investments,
+      transactionLegs: GRDBTransactionLegRepository(
+        database: database,
+        onRecordChanged: hooks.onTransactionLegChanged,
+        onRecordDeleted: hooks.onTransactionLegDeleted),
+      analysis: resolving.analysis,
+      csvImportProfiles: GRDBCSVImportProfileRepository(
+        database: database,
+        onRecordChanged: hooks.onCSVImportProfileChanged,
+        onRecordDeleted: hooks.onCSVImportProfileDeleted),
+      importRules: GRDBImportRuleRepository(
+        database: database,
+        onRecordChanged: hooks.onImportRuleChanged,
+        onRecordDeleted: hooks.onImportRuleDeleted))
+  }
+
+  /// The five repositories that resolve instruments via the injected
+  /// `InstrumentMapResolving`. Split out of `makeRepositories` so
+  /// neither function body exceeds SwiftLint's
+  /// `function_body_length` budget after the resolver cutover. The
+  /// grouping is also semantic: resolver-dependent repositories belong
+  /// together so a future repository that needs the resolver is added
+  /// here, not back into the main `makeRepositories` body.
+  private struct ResolvingRepositories {
+    let accounts: GRDBAccountRepository
+    let transactions: GRDBTransactionRepository
+    let earmarks: GRDBEarmarkRepository
+    let investments: GRDBInvestmentRepository
+    let analysis: GRDBAnalysisRepository
+  }
+
+  private static func makeResolvingRepositories(
+    database: any DatabaseWriter,
+    instrument: Instrument,
+    conversionService: any InstrumentConversionService,
+    instrumentResolver: any InstrumentMapResolving,
+    hooks: CloudKitBackendHooks
+  ) -> ResolvingRepositories {
+    ResolvingRepositories(
       accounts: GRDBAccountRepository(
         database: database,
+        instrumentResolver: instrumentResolver,
         onRecordChanged: hooks.onAccountChanged,
         onRecordDeleted: hooks.onAccountDeleted,
         onInstrumentChanged: hooks.onInstrumentChanged),
@@ -167,39 +229,22 @@ final class CloudKitBackend: BackendProvider, @unchecked Sendable {
         onRecordChanged: hooks.onTransactionChanged,
         onRecordDeleted: hooks.onTransactionDeleted,
         onInstrumentChanged: hooks.onInstrumentChanged),
-      categories: GRDBCategoryRepository(
-        database: database,
-        onRecordChanged: hooks.onCategoryChanged,
-        onRecordDeleted: hooks.onCategoryDeleted),
       earmarks: GRDBEarmarkRepository(
         database: database,
         defaultInstrument: instrument,
+        instrumentResolver: instrumentResolver,
         onRecordChanged: hooks.onEarmarkChanged,
         onRecordDeleted: hooks.onEarmarkDeleted),
-      earmarkBudgetItems: GRDBEarmarkBudgetItemRepository(
-        database: database,
-        onRecordChanged: hooks.onEarmarkBudgetItemChanged,
-        onRecordDeleted: hooks.onEarmarkBudgetItemDeleted),
       investments: GRDBInvestmentRepository(
         database: database,
         defaultInstrument: instrument,
+        instrumentResolver: instrumentResolver,
         onRecordChanged: hooks.onInvestmentChanged,
         onRecordDeleted: hooks.onInvestmentDeleted),
-      transactionLegs: GRDBTransactionLegRepository(
-        database: database,
-        onRecordChanged: hooks.onTransactionLegChanged,
-        onRecordDeleted: hooks.onTransactionLegDeleted),
       analysis: GRDBAnalysisRepository(
         database: database,
         instrument: instrument,
-        conversionService: conversionService),
-      csvImportProfiles: GRDBCSVImportProfileRepository(
-        database: database,
-        onRecordChanged: hooks.onCSVImportProfileChanged,
-        onRecordDeleted: hooks.onCSVImportProfileDeleted),
-      importRules: GRDBImportRuleRepository(
-        database: database,
-        onRecordChanged: hooks.onImportRuleChanged,
-        onRecordDeleted: hooks.onImportRuleDeleted))
+        conversionService: conversionService,
+        instrumentResolver: instrumentResolver))
   }
 }

--- a/Backends/CloudKit/Sync/ProfileGRDBRepositories.swift
+++ b/Backends/CloudKit/Sync/ProfileGRDBRepositories.swift
@@ -48,6 +48,13 @@ extension ProfileGRDBRepositories {
   /// `applyRemoteChangesSync` and never invokes either placeholder; the
   /// session-side bundle owned by `CloudKitBackend` continues to carry
   /// real values for user-mutation paths.
+  ///
+  /// The `instrumentResolver` injected into each repository here is a fresh
+  /// `PerProfileInstrumentMapResolver` that is likewise never invoked by the
+  /// apply path: `applyRemoteChangesSync` writes raw Rows directly and never
+  /// calls `instrumentMap()`. Do NOT rewire these resolvers to the shared
+  /// registry without first auditing every apply-path caller — the apply path
+  /// currently carries no observation and assumes the resolver is a no-op.
   static func makeForApply(database: any GRDB.DatabaseWriter) -> ProfileGRDBRepositories {
     // USD is a stable, locale-independent fiat that satisfies
     // `Instrument.fiat(code:)`'s `isoCurrencies` lookup. The choice is
@@ -58,12 +65,18 @@ extension ProfileGRDBRepositories {
       importRules: GRDBImportRuleRepository(database: database),
       instruments: GRDBInstrumentRegistryRepository(database: database),
       categories: GRDBCategoryRepository(database: database),
-      accounts: GRDBAccountRepository(database: database),
+      accounts: GRDBAccountRepository(
+        database: database,
+        instrumentResolver: PerProfileInstrumentMapResolver(database: database)),
       earmarks: GRDBEarmarkRepository(
-        database: database, defaultInstrument: placeholderInstrument),
+        database: database,
+        defaultInstrument: placeholderInstrument,
+        instrumentResolver: PerProfileInstrumentMapResolver(database: database)),
       earmarkBudgetItems: GRDBEarmarkBudgetItemRepository(database: database),
       investmentValues: GRDBInvestmentRepository(
-        database: database, defaultInstrument: placeholderInstrument),
+        database: database,
+        defaultInstrument: placeholderInstrument,
+        instrumentResolver: PerProfileInstrumentMapResolver(database: database)),
       transactions: GRDBTransactionRepository(
         database: database,
         defaultInstrument: placeholderInstrument,

--- a/Backends/CloudKit/Sync/ProfileGRDBRepositories.swift
+++ b/Backends/CloudKit/Sync/ProfileGRDBRepositories.swift
@@ -67,7 +67,8 @@ extension ProfileGRDBRepositories {
       transactions: GRDBTransactionRepository(
         database: database,
         defaultInstrument: placeholderInstrument,
-        conversionService: ApplyPathConversionService()),
+        conversionService: ApplyPathConversionService(),
+        instrumentResolver: PerProfileInstrumentMapResolver(database: database)),
       transactionLegs: GRDBTransactionLegRepository(database: database),
       database: database)
   }

--- a/Backends/GRDB/Observation/InstrumentMapObservationBridge.swift
+++ b/Backends/GRDB/Observation/InstrumentMapObservationBridge.swift
@@ -1,0 +1,100 @@
+// Backends/GRDB/Observation/InstrumentMapObservationBridge.swift
+
+import Foundation
+import GRDB
+
+/// Bridges the async instrument-map resolution into a synchronous
+/// `ValueObservation` pipeline. Shared by every GRDB repository whose
+/// observation projection needs the resolved instrument map (account,
+/// earmark, transaction, investment daily balances) — one canonical
+/// definition rather than a per-repository copy.
+///
+/// **Why resolve before constructing the observation.** The canonical
+/// instrument registry lives on a *separate* (profile-index) database, so
+/// its lookup table cannot be joined into the per-profile
+/// `ValueObservation`: GRDB's `tracking(regions:fetch:)` closure is
+/// synchronous and cannot `await` a cross-database read. The map must
+/// therefore be resolved *before* the observation is constructed. The
+/// returned outer `AsyncStream`'s worker task is the async setup point:
+/// it `await`s `resolver.instrumentMap()`, then `build`s the inner
+/// retrying stream with the resolved map captured, and forwards every
+/// emission.
+///
+/// **Resolver failure.** A resolver error surfaces via the shared
+/// `errorChannel` (matching the observation error contract) and ends the
+/// stream — but only if the consumer is still alive. A cancelled
+/// subscription's transient resolver error must not permanently finish
+/// the single-shot channel for a later re-subscriber. Note that
+/// `errorChannel` is single-shot per repository instance: once a resolver
+/// error is surfaced, that channel is permanently finished, and any
+/// subsequent observation subscription on the same repository instance
+/// will produce an empty stream with no further error notification.
+/// Callers that need to re-subscribe after a resolver failure must obtain
+/// a fresh repository instance (or accept silent empty streams).
+///
+/// **Metadata re-resolution.** The map is a snapshot taken once at
+/// subscription start. An instrument-metadata edit does not live-refresh
+/// an already-open observation; re-resolution requires cancelling the
+/// prior subscription and re-subscribing. Cross-database
+/// instrument-metadata live-refresh via the shared registry's change
+/// stream is a follow-up.
+///
+/// **Cancellation.** Mirrors the inner-bridge discipline exactly: the
+/// outer stream's `onTermination` cancels the worker task; the worker
+/// checks `Task.isCancelled` after the resolver `await`, breaks out of
+/// the inner `for await` on cancellation, and finishes the continuation,
+/// which tears the inner retrying stream down via its own
+/// `onTermination`.
+///
+/// - Parameters:
+///   - resolver: Resolves the per-profile-id → `Instrument` map from the
+///     shared registry.
+///   - errorChannel: Where a non-recoverable resolver error surfaces.
+///     The same channel the repository's `observeErrors()` exposes.
+///   - database: The writer the inner observation runs against, passed
+///     through to `build` so call sites construct the inner stream
+///     without recapturing the repository.
+///   - build: Constructs the inner retrying observation stream with the
+///     resolved map. Receives the same `errorChannel` and `database`
+///     it should hand to `toRetryingAsyncStream(...)`.
+func resolvedInstrumentMapStream<Value: Sendable>(
+  resolver: any InstrumentMapResolving,
+  errorChannel: ObservationErrorChannel,
+  database: any DatabaseWriter,
+  build:
+    @escaping @Sendable (
+      _ instruments: [String: Instrument],
+      _ errorChannel: ObservationErrorChannel,
+      _ database: any DatabaseWriter
+    ) -> AsyncStream<Value>
+) -> AsyncStream<Value> {
+  AsyncStream { continuation in
+    let task = Task {
+      let instruments: [String: Instrument]
+      do {
+        instruments = try await resolver.instrumentMap()
+      } catch {
+        // Only surface to the shared (single-shot) errorChannel if the
+        // consumer is still alive — a cancelled subscription's transient
+        // resolver error must not permanently finish the channel for a
+        // later re-subscriber.
+        if !Task.isCancelled {
+          await errorChannel.surfaceAndFinish(error)
+        }
+        continuation.finish()
+        return
+      }
+      guard !Task.isCancelled else {
+        continuation.finish()
+        return
+      }
+      let inner = build(instruments, errorChannel, database)
+      for await value in inner {
+        if Task.isCancelled { break }
+        continuation.yield(value)
+      }
+      continuation.finish()
+    }
+    continuation.onTermination = { _ in task.cancel() }
+  }
+}

--- a/Backends/GRDB/Records/InstrumentRow+ObservableRegion.swift
+++ b/Backends/GRDB/Records/InstrumentRow+ObservableRegion.swift
@@ -8,6 +8,14 @@ extension InstrumentRow {
   /// `tracking(regions:fetch:)`. See
   /// `AccountRow+ObservableRegion.swift` for the shared pattern and
   /// issue #865 for the motivation.
+  ///
+  /// Retained even though no per-profile `ValueObservation` currently
+  /// tracks it: `PerProfileInstrumentMapResolver` and the apply path both
+  /// still read the per-profile `instrument` table, and the
+  /// `v10_drop_shared_instrument_legacy` migration will drop that table
+  /// (and this region) in a future release. Do not remove this property
+  /// until that migration lands and all callers have switched to the
+  /// shared `GRDBInstrumentRegistryRepository`.
   static var observableRegion: QueryInterfaceRequest<InstrumentRow> {
     let columns: [any SQLSelectable] = Columns.allCases
       .filter { $0 != .encodedSystemFields }

--- a/Backends/GRDB/Repositories/DailyBalanceCompute.swift
+++ b/Backends/GRDB/Repositories/DailyBalanceCompute.swift
@@ -33,21 +33,26 @@ enum DailyBalanceCompute {
 
   /// Reads booked legs (excluding scheduled recurrences), looks up
   /// their dates, and accumulates a per-instrument running balance,
-  /// returning one entry per (calendar-day, instrument) tuple.
+  /// returning one entry per (calendar-day, instrument) tuple. The
+  /// `instruments` lookup is resolved by the caller via the injected
+  /// `InstrumentMapResolving` *before* its `database.read` snapshot
+  /// opens (the canonical registry is a separate database, so it can't
+  /// be joined into this transaction); instrument identity is immutable
+  /// lookup data, so the non-atomic pairing is safe and intended.
   static func compute(
     database: Database,
     accountId: UUID,
+    instruments: [String: Instrument],
     defaultInstrument: Instrument
   ) throws -> [AccountDailyBalance] {
     let bookedLegs = try fetchBookedLegs(database: database, accountId: accountId)
     let dateById = try fetchTransactionDates(
       database: database, transactionIds: bookedLegs.map(\.transactionId))
-    let instrumentMap = try InstrumentRow.fetchInstrumentMap(database: database)
 
     let entries = sortedLegEntries(legs: bookedLegs, dateById: dateById)
     return aggregateByInstrument(
       entries: entries,
-      instrumentMap: instrumentMap,
+      instrumentMap: instruments,
       defaultInstrument: defaultInstrument)
   }
 

--- a/Backends/GRDB/Repositories/GRDBAccountRepository+Observation.swift
+++ b/Backends/GRDB/Repositories/GRDBAccountRepository+Observation.swift
@@ -21,53 +21,75 @@ import GRDB
 // transient I/O restarts the observation with backoff (1 s, 5 s, 30 s,
 // capped at 5 retries); budget exhaustion surfaces the most recent
 // error. See `guides/DATABASE_CODE_GUIDE.md` §2 convention 5.
+//
+// **Instrument-map snapshot.** The canonical instrument registry lives
+// on a separate (profile-index) database, so its lookup table cannot be
+// joined into the per-profile `ValueObservation` (the synchronous
+// `tracking(regions:fetch:)` closure cannot `await`). The observation
+// resolves the map once via `instrumentResolver` when the stream's
+// worker task starts, captures it into the tracking closure, and drops
+// `InstrumentRow.observableRegion` from the tracked regions (those rows
+// are no longer in this DB). An instrument-metadata edit therefore does
+// not live-refresh an already-open list until the next refetch
+// (re-subscribe); cross-database instrument-metadata live-refresh is
+// wired via the shared registry's change stream in a follow-up. The
+// async-resolve-then-observe bridge is `resolvedInstrumentMapStream`
+// (see `Backends/GRDB/Observation/InstrumentMapObservationBridge.swift`).
 extension GRDBAccountRepository {
 
-  /// Streams `[Account]` snapshots whenever `account`, `instrument`,
+  /// Streams `[Account]` snapshots whenever `account`,
   /// `transaction_leg`, or the joined `transaction` table changes.
-  /// Initial value is the current DB state. `removeDuplicates()` (applied
-  /// inside the retry helper) coalesces re-fetches that produce the same
-  /// domain value (e.g. a no-op write on an unrelated row).
+  /// Initial value is the current DB state. Instrument identity is
+  /// resolved once at subscription start via `instrumentResolver` and
+  /// captured into the stream; an instrument-metadata change does not
+  /// re-fire this observation until the subscription is cancelled and
+  /// restarted. `removeDuplicates()` (applied inside the retry helper)
+  /// coalesces re-fetches that produce the same domain value (e.g. a
+  /// no-op write on an unrelated row).
   func observeAll() -> AsyncStream<[Account]> {
-    ValueObservation
-      // Explicit-region form: every joined table's `observableRegion`
-      // excludes the sync-bookkeeping `encoded_system_fields` blob, so
-      // CKSyncEngine's per-batch system-fields write does not re-fire
-      // this observation. See issue #865 and
-      // `Records/AccountRow+ObservableRegion.swift`. The regions are
-      // pre-declared, so they are also empty-table-safe on a
-      // fresh-install profile — no row-decoder workaround needed.
-      //
-      // Projection parity with `fetchAll()`: instruments + ordered rows +
-      // computed positions, mapped to `Account` via `row.toDomain`. The
-      // retry helper re-runs this closure on each restart attempt, so
-      // the projection always reads the freshest DB state.
-      .tracking(
-        regions: [
-          AccountRow.observableRegion,
-          InstrumentRow.observableRegion,
-          TransactionRow.observableRegion,
-          TransactionLegRow.observableRegion,
-        ],
-        fetch: { database in
-          let instruments = try Self.fetchInstrumentMap(database: database)
-          let rows =
-            try AccountRow
-            .order(AccountRow.Columns.position.asc)
-            .fetchAll(database)
-          let positionsByAccount = try Self.computePositions(
-            database: database, instruments: instruments)
-          return try rows.map { row in
-            try row.toDomain(
-              instruments: instruments,
-              positions: positionsByAccount[row.id] ?? [])
+    resolvedInstrumentMapStream(
+      resolver: instrumentResolver,
+      errorChannel: errorChannel,
+      database: database
+    ) { instruments, errorChannel, database in
+      ValueObservation
+        // Explicit-region form: every joined table's `observableRegion`
+        // excludes the sync-bookkeeping `encoded_system_fields` blob, so
+        // CKSyncEngine's per-batch system-fields write does not re-fire
+        // this observation. See issue #865. `InstrumentRow` is no longer
+        // tracked here — those rows live on the separate profile-index
+        // database; the map is the captured `instruments` snapshot.
+        //
+        // Projection parity with `fetchAll()`: instruments + ordered
+        // rows + computed positions, mapped to `Account` via
+        // `row.toDomain`. The retry helper re-runs this closure on each
+        // restart attempt, so the projection always reads the freshest
+        // DB state.
+        .tracking(
+          regions: [
+            AccountRow.observableRegion,
+            TransactionRow.observableRegion,
+            TransactionLegRow.observableRegion,
+          ],
+          fetch: { database in
+            let rows =
+              try AccountRow
+              .order(AccountRow.Columns.position.asc)
+              .fetchAll(database)
+            let positionsByAccount = try Self.computePositions(
+              database: database, instruments: instruments)
+            return try rows.map { row in
+              try row.toDomain(
+                instruments: instruments,
+                positions: positionsByAccount[row.id] ?? [])
+            }
           }
-        }
-      )
-      .toRetryingAsyncStream(
-        in: database,
-        errorChannel: errorChannel,
-        repoMethod: "GRDBAccountRepository.observeAll")
+        )
+        .toRetryingAsyncStream(
+          in: database,
+          errorChannel: errorChannel,
+          repoMethod: "GRDBAccountRepository.observeAll")
+    }
   }
 
   /// Companion error stream — see protocol doc on `observeErrors()` and

--- a/Backends/GRDB/Repositories/GRDBAccountRepository+Positions.swift
+++ b/Backends/GRDB/Repositories/GRDBAccountRepository+Positions.swift
@@ -11,12 +11,6 @@ import GRDB
 // fallback). Mirrors the SwiftData-era
 // `CloudKitAccountRepository.computePositions(from:instruments:)`.
 extension GRDBAccountRepository {
-  /// Forwards to the shared `InstrumentRow.fetchInstrumentMap` so every
-  /// repository observes the same stored-then-ambient ordering.
-  static func fetchInstrumentMap(database: Database) throws -> [String: Instrument] {
-    try InstrumentRow.fetchInstrumentMap(database: database)
-  }
-
   /// Computes per-account, per-instrument position sums from the
   /// `transaction_leg` table, excluding scheduled (recurring) parents
   /// and account-less legs (e.g. category-only legs on transfers).

--- a/Backends/GRDB/Repositories/GRDBAccountRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBAccountRepository.swift
@@ -20,21 +20,44 @@ import GRDB
 /// commits — emitting hooks inside the write would publish changes that
 /// haven't yet been made durable.
 ///
+/// **Instrument resolution.** Positions resolve their `instrument` via
+/// the injected `instrumentResolver`. The instrument map is fetched
+/// once, *before* opening the per-profile read/write snapshot, because
+/// the canonical registry lives on a different (profile-index)
+/// database — a cross-database transaction is impossible. Instrument
+/// identity is immutable lookup data, so a read that is not atomic with
+/// the account/leg-row snapshot is safe and intended. Mirrors
+/// `GRDBTransactionRepository`.
+///
 /// **`@unchecked Sendable` justification.** All stored properties are
 /// `let`. `database` (`any DatabaseWriter`) is itself `Sendable` (GRDB
 /// protocol guarantee — the queue's serial executor mediates concurrent
-/// access). `onRecordChanged` and `onRecordDeleted` are `@Sendable`
-/// closures captured at init. Nothing mutates post-init, so the
-/// reference can be shared across actor boundaries without a data
-/// race; `@unchecked` only waives Swift's structural check that
-/// `final class` types meet `Sendable`'s requirements automatically.
+/// access). `instrumentResolver` is a `Sendable` protocol
+/// (`InstrumentMapResolving`) and immutable post-init. `onRecordChanged`
+/// and `onRecordDeleted` are `@Sendable` closures captured at init.
+/// Nothing mutates post-init, so the reference can be shared across
+/// actor boundaries without a data race; `@unchecked` only waives
+/// Swift's structural check that `final class` types meet `Sendable`'s
+/// requirements automatically.
 /// See `guides/CONCURRENCY_GUIDE.md` §2 "False Positives to Avoid",
 /// Carve-out 3 (GRDB repositories).
 final class GRDBAccountRepository: AccountRepository, @unchecked Sendable {
-  // `database` and `errorChannel` are deliberately not `private` so the
-  // sibling `+Observation.swift` extension can reach them. Treat them
-  // as private-by-convention from elsewhere in the module.
+  // `database`, `instrumentResolver`, and `errorChannel` are
+  // deliberately not `private` so the sibling `+Observation.swift`
+  // extension can reach them. Treat them as private-by-convention from
+  // elsewhere in the module.
   let database: any DatabaseWriter
+  /// Resolves the `[String: Instrument]` lookup table from the
+  /// canonical instrument registry. Fetched once per read/write
+  /// operation *before* the per-profile snapshot opens — the registry
+  /// lives on a separate (profile-index) database, so a cross-database
+  /// transaction is impossible. Instrument identity is immutable lookup
+  /// data. Production sessions inject the shared
+  /// `GRDBInstrumentRegistryRepository`; preview / test / apply callers
+  /// inject `PerProfileInstrumentMapResolver` over the same per-profile
+  /// DB so their behaviour is unchanged until the per-profile
+  /// `instrument` table is dropped.
+  let instrumentResolver: any InstrumentMapResolving
   /// Receives `(recordType, id)` so the opening-balance create path can
   /// tag its txn and leg writes with `TransactionRow.recordType` /
   /// `TransactionLegRow.recordType` instead of the account's own type —
@@ -62,11 +85,13 @@ final class GRDBAccountRepository: AccountRepository, @unchecked Sendable {
 
   init(
     database: any DatabaseWriter,
+    instrumentResolver: any InstrumentMapResolving,
     onRecordChanged: @escaping @Sendable (String, UUID) -> Void = { _, _ in },
     onRecordDeleted: @escaping @Sendable (String, UUID) -> Void = { _, _ in },
     onInstrumentChanged: @escaping @Sendable (Instrument) -> Void = { _ in }
   ) {
     self.database = database
+    self.instrumentResolver = instrumentResolver
     self.onRecordChanged = onRecordChanged
     self.onRecordDeleted = onRecordDeleted
     self.onInstrumentChanged = onInstrumentChanged
@@ -75,8 +100,14 @@ final class GRDBAccountRepository: AccountRepository, @unchecked Sendable {
   // MARK: - AccountRepository conformance
 
   func fetchAll() async throws -> [Account] {
-    try await database.read { database in
-      let instruments = try Self.fetchInstrumentMap(database: database)
+    // Resolve the instrument lookup table before opening the
+    // per-profile snapshot: the canonical registry is a separate
+    // database, so the map cannot be joined into this transaction.
+    // Instrument identity is immutable lookup data — a read not atomic
+    // with the row snapshot is safe and intended. Mirrors
+    // `GRDBTransactionRepository.fetchAll(filter:)`.
+    let instruments = try await instrumentResolver.instrumentMap()
+    return try await database.read { database in
       let rows =
         try AccountRow
         .order(AccountRow.Columns.position.asc)
@@ -139,6 +170,9 @@ final class GRDBAccountRepository: AccountRepository, @unchecked Sendable {
     // follow-up `database.read` would race with concurrent writers and
     // could observe positions from after the update commit, or — worse
     // — emit `onRecordChanged` before the second read settled.
+    // Hoisted ahead of the write snapshot for the same cross-database
+    // reason as `fetchAll()`.
+    let instruments = try await instrumentResolver.instrumentMap()
     let resolved = try await database.write { database -> Account in
       guard
         var existing =
@@ -156,7 +190,6 @@ final class GRDBAccountRepository: AccountRepository, @unchecked Sendable {
       existing.valuationMode = account.valuationMode.rawValue
       try existing.update(database)
 
-      let instruments = try Self.fetchInstrumentMap(database: database)
       let positions = try Self.computePositions(
         database: database, instruments: instruments, accountId: account.id)
       return try existing.toDomain(instruments: instruments, positions: positions)
@@ -199,6 +232,9 @@ final class GRDBAccountRepository: AccountRepository, @unchecked Sendable {
     // Rejects deletes against an account with non-zero positions —
     // mirrors the SwiftData-era contract enforced by
     // `CloudKitAccountRepository.delete(id:)`.
+    // Hoisted ahead of the write snapshot for the same cross-database
+    // reason as `fetchAll()`.
+    let instruments = try await instrumentResolver.instrumentMap()
     try await database.write { database in
       guard
         var existing =
@@ -208,7 +244,6 @@ final class GRDBAccountRepository: AccountRepository, @unchecked Sendable {
       else {
         throw BackendError.notFound("Account not found")
       }
-      let instruments = try Self.fetchInstrumentMap(database: database)
       let positions = try Self.computePositions(
         database: database, instruments: instruments, accountId: id)
       if positions.contains(where: { $0.quantity != 0 }) {

--- a/Backends/GRDB/Repositories/GRDBAnalysisRepository+CategoryBalances.swift
+++ b/Backends/GRDB/Repositories/GRDBAnalysisRepository+CategoryBalances.swift
@@ -27,9 +27,13 @@ extension GRDBAnalysisRepository {
     let qty: Int64
   }
 
-  /// Pair of SQL output rows and the instrument lookup, fetched in a
-  /// single MVCC snapshot so a concurrent writer can't drop a row's
-  /// `instrument_id` between the two reads.
+  /// Pair of SQL output rows and the instrument lookup. The lookup is
+  /// resolved via the injected `InstrumentMapResolving` *before* the
+  /// per-profile read snapshot opens (the canonical registry is a
+  /// separate database, so it can't be joined into this transaction);
+  /// the SQL rows come from the snapshot. Instrument identity is
+  /// immutable lookup data, so the non-atomic pairing is safe and
+  /// intended. Mirrors `GRDBTransactionRepository`'s hoisted-map shape.
   struct CategoryBalancesAggregation: Sendable {
     let rows: [CategoryBalancesRow]
     let instrumentMap: [String: Instrument]
@@ -97,6 +101,7 @@ extension GRDBAnalysisRepository {
   /// so the planner doesn't see a degenerate `IN ()`.
   static func fetchCategoryBalancesAggregation(
     database: any DatabaseReader,
+    instruments: [String: Instrument],
     args: CategoryBalancesFilterArgs
   ) async throws -> CategoryBalancesAggregation {
     try await database.read { database -> CategoryBalancesAggregation in
@@ -116,8 +121,7 @@ extension GRDBAnalysisRepository {
             instrumentId: instrumentId,
             qty: qty))
       }
-      let instrumentMap = try InstrumentRow.fetchInstrumentMap(database: database)
-      return CategoryBalancesAggregation(rows: rows, instrumentMap: instrumentMap)
+      return CategoryBalancesAggregation(rows: rows, instrumentMap: instruments)
     }
   }
 

--- a/Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesAggregation.swift
+++ b/Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesAggregation.swift
@@ -32,20 +32,30 @@ extension GRDBAnalysisRepository {
   /// appeared in the transaction list.
   static func fetchDailyBalancesAggregation(
     database: any DatabaseReader,
+    instruments: [String: Instrument],
     after: Date?,
     forecastUntil: Date?
   ) async throws -> DailyBalancesAggregation {
     try await database.read { database -> DailyBalancesAggregation in
       try Self.readDailyBalancesAggregation(
-        database: database, after: after, forecastUntil: forecastUntil)
+        database: database,
+        instruments: instruments,
+        after: after,
+        forecastUntil: forecastUntil)
     }
   }
 
   /// Synchronous read body for `fetchDailyBalancesAggregation`. Lifted
   /// out of the `database.read` closure so the closure body stays
-  /// under the SwiftLint `closure_body_length` budget.
+  /// under the SwiftLint `closure_body_length` budget. `instruments` is
+  /// resolved via the injected `InstrumentMapResolving` before this
+  /// snapshot opens (the canonical registry is a separate database) and
+  /// threaded in rather than re-read here.
   private static func readDailyBalancesAggregation(
-    database: Database, after: Date?, forecastUntil: Date?
+    database: Database,
+    instruments: [String: Instrument],
+    after: Date?,
+    forecastUntil: Date?
   ) throws -> DailyBalancesAggregation {
     let accountRows = try Self.fetchAccountDeltaRowsPostCutoff(
       database: database, after: after)
@@ -57,18 +67,20 @@ extension GRDBAnalysisRepository {
       database: database)
     let tradesModeInvestmentAccountIds =
       try Self.fetchTradesModeInvestmentAccountIds(database: database)
-    // Fetch `instrumentMap` before the investment-value snapshots so
-    // `fetchInvestmentValueSnapshots` can resolve each row's instrument
-    // to its registered `Instrument` (with the right `kind` for stock /
-    // crypto investments) instead of falling back to fiat-by-id.
-    let instrumentMap = try InstrumentRow.fetchInstrumentMap(database: database)
+    // `instruments` is resolved via the injected resolver before this
+    // snapshot opens so `fetchInvestmentValueSnapshots` can resolve each
+    // row's instrument to its registered `Instrument` (with the right
+    // `kind` for stock / crypto investments) instead of falling back to
+    // fiat-by-id.
+    let instrumentMap = instruments
     let investmentValues = try Self.fetchInvestmentValueSnapshots(
       database: database,
       investmentAccountIds: investmentAccountIds,
       instrumentMap: instrumentMap)
     let scheduled =
       forecastUntil != nil
-      ? try Self.fetchScheduledTransactions(database: database) : []
+      ? try Self.fetchScheduledTransactions(
+        database: database, instruments: instrumentMap) : []
     // Pre-filter trades-mode rows out of the already-fetched arrays.
     // Doing the filter inside the read closure (not later) keeps every
     // input the assembly walk needs inside one MVCC snapshot and saves
@@ -259,7 +271,9 @@ extension GRDBAnalysisRepository {
   /// extrapolate recurring patterns. Filters to `recur_period IS NOT
   /// NULL` via the partial `transaction_scheduled` index so the read
   /// stays off a full scan.
-  private static func fetchScheduledTransactions(database: Database) throws -> [Transaction] {
+  private static func fetchScheduledTransactions(
+    database: Database, instruments: [String: Instrument]
+  ) throws -> [Transaction] {
     let txnRows =
       try TransactionRow
       .filter(TransactionRow.Columns.recurPeriod != nil)
@@ -270,11 +284,6 @@ extension GRDBAnalysisRepository {
       try TransactionLegRow
       .filter(txnIds.contains(TransactionLegRow.Columns.transactionId))
       .fetchAll(database)
-    let instrumentRows = try InstrumentRow.fetchAll(database)
-    var instrumentLookup: [String: Instrument] = [:]
-    for row in instrumentRows {
-      instrumentLookup[row.id] = try row.toDomain()
-    }
     let legsByTxnId = Dictionary(grouping: legRows, by: \.transactionId)
     return try txnRows.map { row -> Transaction in
       let legs =
@@ -282,7 +291,7 @@ extension GRDBAnalysisRepository {
         .sorted { $0.sortOrder < $1.sortOrder }
         .map { legRow -> TransactionLeg in
           let legInstrument =
-            instrumentLookup[legRow.instrumentId]
+            instruments[legRow.instrumentId]
             ?? Instrument.fiat(code: legRow.instrumentId)
           return try legRow.toDomain(instrument: legInstrument)
         }

--- a/Backends/GRDB/Repositories/GRDBAnalysisRepository+ExpenseBreakdown.swift
+++ b/Backends/GRDB/Repositories/GRDBAnalysisRepository+ExpenseBreakdown.swift
@@ -21,9 +21,13 @@ extension GRDBAnalysisRepository {
     let qty: Int64
   }
 
-  /// Pair of SQL output rows and the instrument lookup, fetched in a
-  /// single MVCC snapshot so a concurrent writer can't drop a row's
-  /// `instrument_id` between the two reads.
+  /// Pair of SQL output rows and the instrument lookup. The lookup is
+  /// resolved via the injected `InstrumentMapResolving` *before* the
+  /// per-profile read snapshot opens (the canonical registry is a
+  /// separate database, so it can't be joined into this transaction);
+  /// the SQL rows come from the snapshot. Instrument identity is
+  /// immutable lookup data, so the non-atomic pairing is safe and
+  /// intended. Mirrors `GRDBTransactionRepository`'s hoisted-map shape.
   struct ExpenseBreakdownAggregation: Sendable {
     let rows: [ExpenseBreakdownRow]
     let instrumentMap: [String: Instrument]
@@ -71,6 +75,7 @@ extension GRDBAnalysisRepository {
   ///    `USING COVERING INDEX` to plain `USING INDEX`.
   static func fetchExpenseBreakdownAggregation(
     database: any DatabaseReader,
+    instruments: [String: Instrument],
     after: Date?
   ) async throws -> ExpenseBreakdownAggregation {
     try await database.read { database -> ExpenseBreakdownAggregation in
@@ -101,8 +106,7 @@ extension GRDBAnalysisRepository {
           ExpenseBreakdownRow(
             day: day, categoryId: categoryId, instrumentId: instrumentId, qty: qty))
       }
-      let instrumentMap = try InstrumentRow.fetchInstrumentMap(database: database)
-      return ExpenseBreakdownAggregation(rows: rows, instrumentMap: instrumentMap)
+      return ExpenseBreakdownAggregation(rows: rows, instrumentMap: instruments)
     }
   }
 

--- a/Backends/GRDB/Repositories/GRDBAnalysisRepository+IncomeAndExpense.swift
+++ b/Backends/GRDB/Repositories/GRDBAnalysisRepository+IncomeAndExpense.swift
@@ -47,9 +47,13 @@ extension GRDBAnalysisRepository {
     let investmentTransferOutQty: Int64
   }
 
-  /// Pair of SQL output rows and the instrument lookup, fetched in a
-  /// single MVCC snapshot so a concurrent writer can't drop a row's
-  /// `instrument_id` between the two reads.
+  /// Pair of SQL output rows and the instrument lookup. The lookup is
+  /// resolved via the injected `InstrumentMapResolving` *before* the
+  /// per-profile read snapshot opens (the canonical registry is a
+  /// separate database, so it can't be joined into this transaction);
+  /// the SQL rows come from the snapshot. Instrument identity is
+  /// immutable lookup data, so the non-atomic pairing is safe and
+  /// intended. Mirrors `GRDBTransactionRepository`'s hoisted-map shape.
   struct IncomeAndExpenseAggregation: Sendable {
     let rows: [IncomeAndExpenseRow]
     let instrumentMap: [String: Instrument]

--- a/Backends/GRDB/Repositories/GRDBAnalysisRepository+IncomeAndExpenseAggregation.swift
+++ b/Backends/GRDB/Repositories/GRDBAnalysisRepository+IncomeAndExpenseAggregation.swift
@@ -27,6 +27,7 @@ extension GRDBAnalysisRepository {
   /// writer commits between them.
   static func fetchIncomeAndExpenseAggregation(
     database: any DatabaseReader,
+    instruments: [String: Instrument],
     after: Date?
   ) async throws -> IncomeAndExpenseAggregation {
     try await database.read { database -> IncomeAndExpenseAggregation in
@@ -34,8 +35,7 @@ extension GRDBAnalysisRepository {
       let sqlRows = try Row.fetchAll(
         database, sql: incomeAndExpenseAggregationSQL, arguments: arguments)
       let rows = sqlRows.compactMap(Self.mapAggregationRow(_:))
-      let instrumentMap = try InstrumentRow.fetchInstrumentMap(database: database)
-      return IncomeAndExpenseAggregation(rows: rows, instrumentMap: instrumentMap)
+      return IncomeAndExpenseAggregation(rows: rows, instrumentMap: instruments)
     }
   }
 

--- a/Backends/GRDB/Repositories/GRDBAnalysisRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBAnalysisRepository.swift
@@ -90,17 +90,32 @@ final class GRDBAnalysisRepository: AnalysisRepository, @unchecked Sendable {
   private let database: any DatabaseWriter
   private let instrument: Instrument
   private let conversionService: any InstrumentConversionService
+  /// Resolves the `[String: Instrument]` lookup table from the
+  /// canonical instrument registry. Fetched once per aggregation
+  /// *before* the per-profile `database.read` snapshot opens — the
+  /// registry lives on a separate (profile-index) database, so a
+  /// cross-database transaction is impossible. Instrument identity is
+  /// immutable lookup data; a read that is not atomic with the
+  /// aggregation snapshot is safe and intended. Production sessions
+  /// inject the shared `GRDBInstrumentRegistryRepository`;
+  /// preview / test / apply callers inject
+  /// `PerProfileInstrumentMapResolver` over the same per-profile DB so
+  /// their behaviour is unchanged until the per-profile `instrument`
+  /// table is dropped. Mirrors `GRDBTransactionRepository`.
+  private let instrumentResolver: any InstrumentMapResolving
   private let logger = Logger(
     subsystem: "com.moolah.app", category: "GRDBAnalysisRepository")
 
   init(
     database: any DatabaseWriter,
     instrument: Instrument,
-    conversionService: any InstrumentConversionService
+    conversionService: any InstrumentConversionService,
+    instrumentResolver: any InstrumentMapResolving
   ) {
     self.database = database
     self.instrument = instrument
     self.conversionService = conversionService
+    self.instrumentResolver = instrumentResolver
   }
 
   // MARK: - AnalysisRepository conformance
@@ -125,8 +140,18 @@ final class GRDBAnalysisRepository: AnalysisRepository, @unchecked Sendable {
     after: Date?,
     forecastUntil: Date?
   ) async throws -> [DailyBalance] {
+    // Resolve the instrument lookup table before opening the
+    // per-profile snapshot: the canonical registry is a separate
+    // database, so the map cannot be joined into this transaction.
+    // Instrument identity is immutable lookup data — a read not atomic
+    // with the aggregation snapshot is safe and intended. Mirrors
+    // `GRDBTransactionRepository.fetchAll(filter:)`.
+    let instruments = try await instrumentResolver.instrumentMap()
     let aggregation = try await Self.fetchDailyBalancesAggregation(
-      database: database, after: after, forecastUntil: forecastUntil)
+      database: database,
+      instruments: instruments,
+      after: after,
+      forecastUntil: forecastUntil)
     let logger = self.logger
     let handlers = DailyBalancesHandlers(
       handleUnparseableDay: { day in
@@ -165,8 +190,11 @@ final class GRDBAnalysisRepository: AnalysisRepository, @unchecked Sendable {
     monthEnd: Int,
     after: Date?
   ) async throws -> [ExpenseBreakdown] {
+    // Hoisted ahead of the snapshot for the same cross-database reason
+    // as `fetchDailyBalances(after:forecastUntil:)`.
+    let instruments = try await instrumentResolver.instrumentMap()
     let aggregation = try await Self.fetchExpenseBreakdownAggregation(
-      database: database, after: after)
+      database: database, instruments: instruments, after: after)
     let logger = self.logger
     let handlers = ExpenseBreakdownHandlers(
       handleUnparseableDay: { day in
@@ -194,8 +222,11 @@ final class GRDBAnalysisRepository: AnalysisRepository, @unchecked Sendable {
     monthEnd: Int,
     after: Date?
   ) async throws -> [MonthlyIncomeExpense] {
+    // Hoisted ahead of the snapshot for the same cross-database reason
+    // as `fetchDailyBalances(after:forecastUntil:)`.
+    let instruments = try await instrumentResolver.instrumentMap()
     let aggregation = try await Self.fetchIncomeAndExpenseAggregation(
-      database: database, after: after)
+      database: database, instruments: instruments, after: after)
     let logger = self.logger
     let handlers = IncomeAndExpenseHandlers(
       handleUnparseableDay: { day in
@@ -231,8 +262,11 @@ final class GRDBAnalysisRepository: AnalysisRepository, @unchecked Sendable {
       earmarkId: filters?.earmarkId,
       payee: filters?.payee,
       categoryIds: filters?.categoryIds ?? [])
+    // Hoisted ahead of the snapshot for the same cross-database reason
+    // as `fetchDailyBalances(after:forecastUntil:)`.
+    let instruments = try await instrumentResolver.instrumentMap()
     let aggregation = try await Self.fetchCategoryBalancesAggregation(
-      database: database, args: args)
+      database: database, instruments: instruments, args: args)
     let logger = self.logger
     let handlers = CategoryBalancesHandlers(
       handleUnparseableDay: { day in

--- a/Backends/GRDB/Repositories/GRDBEarmarkRepository+Observation.swift
+++ b/Backends/GRDB/Repositories/GRDBEarmarkRepository+Observation.swift
@@ -25,56 +25,78 @@ import GRDB
 // transient I/O restarts the observation with backoff (1 s, 5 s, 30 s,
 // capped at 5 retries); budget exhaustion surfaces the most recent
 // error. See `guides/DATABASE_CODE_GUIDE.md` §2 convention 5.
+//
+// **Instrument-map snapshot.** The canonical instrument registry lives
+// on a separate (profile-index) database, so its lookup table cannot be
+// joined into the per-profile `ValueObservation` (the synchronous
+// `tracking(regions:fetch:)` closure cannot `await`). `observeAll()`
+// resolves the map once via `instrumentResolver` when the stream's
+// worker task starts, captures it into the tracking closure, and drops
+// `InstrumentRow.observableRegion` from the tracked regions (those rows
+// are no longer in this DB). An instrument-metadata edit therefore does
+// not live-refresh an already-open list until the next refetch
+// (re-subscribe). `observeBudget(earmarkId:)` does not consult the
+// instrument map (it labels items from the parent earmark's own
+// `instrument_id`), so it keeps the plain synchronous shape. The
+// async-resolve-then-observe bridge is `resolvedInstrumentMapStream`
+// (see `Backends/GRDB/Observation/InstrumentMapObservationBridge.swift`).
 extension GRDBEarmarkRepository {
 
-  /// Streams `[Earmark]` snapshots whenever `earmark`, `instrument`,
+  /// Streams `[Earmark]` snapshots whenever `earmark`,
   /// `transaction_leg`, or the joined `transaction` table changes.
-  /// Initial value is the current DB state. `removeDuplicates()` (applied
-  /// inside the retry helper) coalesces re-fetches that produce the same
-  /// domain value (e.g. a no-op write on an unrelated row).
+  /// Initial value is the current DB state. Instrument identity is
+  /// resolved once at subscription start via `instrumentResolver` and
+  /// captured into the stream; an instrument-metadata change does not
+  /// re-fire this observation until the subscription is cancelled and
+  /// restarted. `removeDuplicates()` (applied inside the retry helper)
+  /// coalesces re-fetches that produce the same domain value (e.g. a
+  /// no-op write on an unrelated row).
   func observeAll() -> AsyncStream<[Earmark]> {
     let defaultInstrument = self.defaultInstrument
-    return
+    return resolvedInstrumentMapStream(
+      resolver: instrumentResolver,
+      errorChannel: errorChannel,
+      database: database
+    ) { instruments, errorChannel, database in
       ValueObservation
-      // Explicit-region form: every joined table's `observableRegion`
-      // excludes the sync-bookkeeping `encoded_system_fields` blob, so
-      // CKSyncEngine's per-batch system-fields write does not re-fire
-      // this observation. See issue #865 and
-      // `Records/AccountRow+ObservableRegion.swift`. The regions are
-      // pre-declared, so they are also empty-table-safe on a
-      // fresh-install profile.
-      //
-      // Projection parity with `fetchAll()`: instruments + ordered rows +
-      // computed positions, mapped to `Earmark` via `row.toDomain`.
-      .tracking(
-        regions: [
-          EarmarkRow.observableRegion,
-          InstrumentRow.observableRegion,
-          TransactionRow.observableRegion,
-          TransactionLegRow.observableRegion,
-        ],
-        fetch: { database in
-          let instruments = try Self.fetchInstrumentMap(database: database)
-          let positionsByEarmark = try Self.computeEarmarkPositions(
-            database: database, instruments: instruments)
-          let rows =
-            try EarmarkRow
-            .order(EarmarkRow.Columns.position.asc)
-            .fetchAll(database)
-          return rows.map { row in
-            let lists = positionsByEarmark[row.id] ?? EarmarkPositionLists.empty
-            return row.toDomain(
-              defaultInstrument: defaultInstrument,
-              positions: lists.positions,
-              savedPositions: lists.savedPositions,
-              spentPositions: lists.spentPositions)
+        // Explicit-region form: every joined table's `observableRegion`
+        // excludes the sync-bookkeeping `encoded_system_fields` blob, so
+        // CKSyncEngine's per-batch system-fields write does not re-fire
+        // this observation. See issue #865. `InstrumentRow` is no longer
+        // tracked here — those rows live on the separate profile-index
+        // database; the map is the captured `instruments` snapshot.
+        //
+        // Projection parity with `fetchAll()`: instruments + ordered
+        // rows + computed positions, mapped to `Earmark` via
+        // `row.toDomain`.
+        .tracking(
+          regions: [
+            EarmarkRow.observableRegion,
+            TransactionRow.observableRegion,
+            TransactionLegRow.observableRegion,
+          ],
+          fetch: { database in
+            let positionsByEarmark = try Self.computeEarmarkPositions(
+              database: database, instruments: instruments)
+            let rows =
+              try EarmarkRow
+              .order(EarmarkRow.Columns.position.asc)
+              .fetchAll(database)
+            return rows.map { row in
+              let lists = positionsByEarmark[row.id] ?? EarmarkPositionLists.empty
+              return row.toDomain(
+                defaultInstrument: defaultInstrument,
+                positions: lists.positions,
+                savedPositions: lists.savedPositions,
+                spentPositions: lists.spentPositions)
+            }
           }
-        }
-      )
-      .toRetryingAsyncStream(
-        in: database,
-        errorChannel: errorChannel,
-        repoMethod: "GRDBEarmarkRepository.observeAll")
+        )
+        .toRetryingAsyncStream(
+          in: database,
+          errorChannel: errorChannel,
+          repoMethod: "GRDBEarmarkRepository.observeAll")
+    }
   }
 
   /// Streams `[EarmarkBudgetItem]` snapshots for a single earmark.

--- a/Backends/GRDB/Repositories/GRDBEarmarkRepository+Positions.swift
+++ b/Backends/GRDB/Repositories/GRDBEarmarkRepository+Positions.swift
@@ -23,12 +23,6 @@ extension GRDBEarmarkRepository {
       positions: [], savedPositions: [], spentPositions: [])
   }
 
-  /// Forwards to the shared `InstrumentRow.fetchInstrumentMap` so every
-  /// repository observes the same stored-then-ambient ordering.
-  static func fetchInstrumentMap(database: Database) throws -> [String: Instrument] {
-    try InstrumentRow.fetchInstrumentMap(database: database)
-  }
-
   /// Computes per-earmark, per-instrument position sums from the
   /// `transaction_leg` table, excluding scheduled (recurring) parents.
   /// Returns `[earmarkId: EarmarkPositionLists]`. Mirrors

--- a/Backends/GRDB/Repositories/GRDBEarmarkRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBEarmarkRepository.swift
@@ -23,24 +23,45 @@ import GRDB
 /// `spentPositions` (sign-flipped). Mirrors the SwiftData-era
 /// `CloudKitEarmarkRepository.computeEarmarkPositions`.
 ///
+/// **Instrument resolution.** Positions resolve their `instrument` via
+/// the injected `instrumentResolver`. The instrument map is fetched
+/// once, *before* opening the per-profile read snapshot, because the
+/// canonical registry lives on a different (profile-index) database — a
+/// cross-database transaction is impossible. Instrument identity is
+/// immutable lookup data, so a read that is not atomic with the
+/// earmark/leg-row snapshot is safe and intended. Mirrors
+/// `GRDBTransactionRepository`.
+///
 /// **`@unchecked Sendable` justification.** All stored properties are
 /// `let`. `database` (`any DatabaseWriter`) is itself `Sendable` (GRDB
 /// protocol guarantee — the queue's serial executor mediates concurrent
-/// access). `defaultInstrument` is a value type. `onRecordChanged` and
-/// `onRecordDeleted` are `@Sendable` closures captured at init. Nothing
-/// mutates post-init, so the reference can be shared across actor
-/// boundaries without a data race; `@unchecked` only waives Swift's
-/// structural check that `final class` types meet `Sendable`'s
-/// requirements automatically.
+/// access). `defaultInstrument` is a value type. `instrumentResolver`
+/// is a `Sendable` protocol (`InstrumentMapResolving`) and immutable
+/// post-init. `onRecordChanged` and `onRecordDeleted` are `@Sendable`
+/// closures captured at init. Nothing mutates post-init, so the
+/// reference can be shared across actor boundaries without a data race;
+/// `@unchecked` only waives Swift's structural check that `final class`
+/// types meet `Sendable`'s requirements automatically.
 /// See `guides/CONCURRENCY_GUIDE.md` §2 "False Positives to Avoid",
 /// Carve-out 3 (GRDB repositories).
 final class GRDBEarmarkRepository: EarmarkRepository, @unchecked Sendable {
-  // `database`, `defaultInstrument`, and `errorChannel` are deliberately
-  // not `private` so the sibling `+Observation.swift` extension can reach
-  // them. Treat them as private-by-convention from elsewhere in the
-  // module.
+  // `database`, `defaultInstrument`, `instrumentResolver`, and
+  // `errorChannel` are deliberately not `private` so the sibling
+  // `+Observation.swift` extension can reach them. Treat them as
+  // private-by-convention from elsewhere in the module.
   let database: any DatabaseWriter
   let defaultInstrument: Instrument
+  /// Resolves the `[String: Instrument]` lookup table from the
+  /// canonical instrument registry. Fetched once per read operation
+  /// *before* the per-profile snapshot opens — the registry lives on a
+  /// separate (profile-index) database, so a cross-database transaction
+  /// is impossible. Instrument identity is immutable lookup data.
+  /// Production sessions inject the shared
+  /// `GRDBInstrumentRegistryRepository`; preview / test / apply callers
+  /// inject `PerProfileInstrumentMapResolver` over the same per-profile
+  /// DB so their behaviour is unchanged until the per-profile
+  /// `instrument` table is dropped.
+  let instrumentResolver: any InstrumentMapResolving
   /// Receives `(recordType, id)` so budget-item upserts emit the
   /// `EarmarkBudgetItemRow.recordType` rather than being mis-tagged as
   /// `EarmarkRow.recordType`. See `RepositoryHookRecordTypeTests`.
@@ -58,11 +79,13 @@ final class GRDBEarmarkRepository: EarmarkRepository, @unchecked Sendable {
   init(
     database: any DatabaseWriter,
     defaultInstrument: Instrument,
+    instrumentResolver: any InstrumentMapResolving,
     onRecordChanged: @escaping @Sendable (String, UUID) -> Void = { _, _ in },
     onRecordDeleted: @escaping @Sendable (String, UUID) -> Void = { _, _ in }
   ) {
     self.database = database
     self.defaultInstrument = defaultInstrument
+    self.instrumentResolver = instrumentResolver
     self.onRecordChanged = onRecordChanged
     self.onRecordDeleted = onRecordDeleted
   }
@@ -71,8 +94,14 @@ final class GRDBEarmarkRepository: EarmarkRepository, @unchecked Sendable {
 
   func fetchAll() async throws -> [Earmark] {
     let defaultInstrument = self.defaultInstrument
+    // Resolve the instrument lookup table before opening the
+    // per-profile snapshot: the canonical registry is a separate
+    // database, so the map cannot be joined into this transaction.
+    // Instrument identity is immutable lookup data — a read not atomic
+    // with the row snapshot is safe and intended. Mirrors
+    // `GRDBTransactionRepository.fetchAll(filter:)`.
+    let instruments = try await instrumentResolver.instrumentMap()
     return try await database.read { database in
-      let instruments = try Self.fetchInstrumentMap(database: database)
       let positionsByEarmark = try Self.computeEarmarkPositions(
         database: database, instruments: instruments)
       let rows =

--- a/Backends/GRDB/Repositories/GRDBInvestmentRepository+Observation.swift
+++ b/Backends/GRDB/Repositories/GRDBInvestmentRepository+Observation.swift
@@ -24,6 +24,21 @@ import GRDB
 // transient I/O restarts the observation with backoff (1 s, 5 s, 30 s,
 // capped at 5 retries); budget exhaustion surfaces the most recent
 // error. See `guides/DATABASE_CODE_GUIDE.md` §2 convention 5.
+//
+// **Instrument-map snapshot.** The canonical instrument registry lives
+// on a separate (profile-index) database, so its lookup table cannot be
+// joined into the per-profile `ValueObservation` (the synchronous
+// `tracking(regions:fetch:)` closure cannot `await`).
+// `observeDailyBalances(accountId:)` resolves the map once via
+// `instrumentResolver` when the stream's worker task starts, captures it
+// into the tracking closure, and drops `InstrumentRow.observableRegion`
+// from the tracked regions (those rows are no longer in this DB). An
+// instrument-metadata edit therefore does not live-refresh an already-
+// open chart until the next refetch (re-subscribe). `observeValues` and
+// `observeAllValues` don't consult the instrument map, so they keep the
+// plain synchronous shape. The async-resolve-then-observe bridge is
+// `resolvedInstrumentMapStream` (see
+// `Backends/GRDB/Observation/InstrumentMapObservationBridge.swift`).
 extension GRDBInvestmentRepository {
 
   /// Streams `InvestmentValuePage` snapshots whenever `investment_value`
@@ -62,37 +77,49 @@ extension GRDBInvestmentRepository {
   }
 
   /// Streams `[AccountDailyBalance]` snapshots whenever the underlying
-  /// `transaction`, `transaction_leg`, or `instrument` tables change.
-  /// Mirrors the projection of `fetchDailyBalances(accountId:)`: one
-  /// entry per (calendar-day, instrument) tuple, sorted by date
-  /// ascending. Captures `accountId` into the tracking closure.
+  /// `transaction` or `transaction_leg` tables change. Mirrors the
+  /// projection of `fetchDailyBalances(accountId:)`: one entry per
+  /// (calendar-day, instrument) tuple, sorted by date ascending.
+  /// Captures `accountId` into the tracking closure. Instrument
+  /// identity is resolved once at subscription start via
+  /// `instrumentResolver` and captured into the stream; an
+  /// instrument-metadata change does not re-fire this observation until
+  /// the subscription is cancelled and restarted.
   func observeDailyBalances(
     accountId: UUID
   ) -> AsyncStream<[AccountDailyBalance]> {
     let defaultInstrument = self.defaultInstrument
-    return
+    return resolvedInstrumentMapStream(
+      resolver: instrumentResolver,
+      errorChannel: errorChannel,
+      database: database
+    ) { instruments, errorChannel, database in
       ValueObservation
-      // Explicit-region form so the sync-bookkeeping
-      // `encoded_system_fields` writes on the tables `DailyBalanceCompute`
-      // reads (transaction, transaction_leg, instrument) do not re-fire
-      // this observation. See issue #865.
-      .tracking(
-        regions: [
-          InstrumentRow.observableRegion,
-          TransactionRow.observableRegion,
-          TransactionLegRow.observableRegion,
-        ],
-        fetch: { [accountId, defaultInstrument] database in
-          try DailyBalanceCompute.compute(
-            database: database,
-            accountId: accountId,
-            defaultInstrument: defaultInstrument)
-        }
-      )
-      .toRetryingAsyncStream(
-        in: database,
-        errorChannel: errorChannel,
-        repoMethod: "GRDBInvestmentRepository.observeDailyBalances")
+        // Explicit-region form so the sync-bookkeeping
+        // `encoded_system_fields` writes on the tables
+        // `DailyBalanceCompute` reads (transaction, transaction_leg) do
+        // not re-fire this observation. See issue #865. `InstrumentRow`
+        // is no longer tracked here — those rows live on the separate
+        // profile-index database; the map is the captured `instruments`
+        // snapshot.
+        .tracking(
+          regions: [
+            TransactionRow.observableRegion,
+            TransactionLegRow.observableRegion,
+          ],
+          fetch: { [accountId, defaultInstrument] database in
+            try DailyBalanceCompute.compute(
+              database: database,
+              accountId: accountId,
+              instruments: instruments,
+              defaultInstrument: defaultInstrument)
+          }
+        )
+        .toRetryingAsyncStream(
+          in: database,
+          errorChannel: errorChannel,
+          repoMethod: "GRDBInvestmentRepository.observeDailyBalances")
+    }
   }
 
   /// Tick stream over all `investment_value` rows. Used by

--- a/Backends/GRDB/Repositories/GRDBInvestmentRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBInvestmentRepository.swift
@@ -13,27 +13,48 @@ import GRDB
 /// `SELECT … LIMIT 1` followed by `UPDATE` or `INSERT` so a same-day
 /// re-write replaces in place.
 ///
+/// **Instrument resolution.** `fetchDailyBalances(...)` resolves each
+/// leg's `instrument` via the injected `instrumentResolver`. The
+/// instrument map is fetched once, *before* opening the per-profile
+/// read snapshot, because the canonical registry lives on a different
+/// (profile-index) database — a cross-database transaction is
+/// impossible. Instrument identity is immutable lookup data, so a read
+/// that is not atomic with the leg-row snapshot is safe and intended.
+/// Mirrors `GRDBTransactionRepository`.
+///
 /// **`@unchecked Sendable` justification.** All stored properties are
 /// `let`. `database` (`any DatabaseWriter`) is itself `Sendable` (GRDB
 /// protocol guarantee — the queue's serial executor mediates concurrent
-/// access). `defaultInstrument` is a value type. `onRecordChanged` and
-/// `onRecordDeleted` are `@Sendable` closures captured at init. Nothing
-/// mutates post-init, so the reference can be shared across actor
-/// boundaries without a data race; `@unchecked` only waives Swift's
-/// structural check that `final class` types meet `Sendable`'s
-/// requirements automatically.
+/// access). `defaultInstrument` is a value type. `instrumentResolver`
+/// is a `Sendable` protocol (`InstrumentMapResolving`) and immutable
+/// post-init. `onRecordChanged` and `onRecordDeleted` are `@Sendable`
+/// closures captured at init. Nothing mutates post-init, so the
+/// reference can be shared across actor boundaries without a data race;
+/// `@unchecked` only waives Swift's structural check that `final class`
+/// types meet `Sendable`'s requirements automatically.
 /// See `guides/CONCURRENCY_GUIDE.md` §2 "False Positives to Avoid",
 /// Carve-out 3 (GRDB repositories).
 final class GRDBInvestmentRepository: InvestmentRepository, @unchecked Sendable {
-  // `database`, `defaultInstrument`, and `errorChannel` are deliberately
-  // not `private` so the sibling `+Observation.swift` extension can reach
-  // them. Treat them as private-by-convention from elsewhere in the
-  // module.
+  // `database`, `defaultInstrument`, `instrumentResolver`, and
+  // `errorChannel` are deliberately not `private` so the sibling
+  // `+Observation.swift` extension can reach them. Treat them as
+  // private-by-convention from elsewhere in the module.
   let database: any DatabaseWriter
   /// Used as the labelling instrument on `AccountDailyBalance` rows
   /// returned from `fetchDailyBalances(...)`. Mirrors
   /// `CloudKitInvestmentRepository.instrument`.
   let defaultInstrument: Instrument
+  /// Resolves the `[String: Instrument]` lookup table from the
+  /// canonical instrument registry. Fetched once per read operation
+  /// *before* the per-profile snapshot opens — the registry lives on a
+  /// separate (profile-index) database, so a cross-database transaction
+  /// is impossible. Instrument identity is immutable lookup data.
+  /// Production sessions inject the shared
+  /// `GRDBInstrumentRegistryRepository`; preview / test / apply callers
+  /// inject `PerProfileInstrumentMapResolver` over the same per-profile
+  /// DB so their behaviour is unchanged until the per-profile
+  /// `instrument` table is dropped.
+  let instrumentResolver: any InstrumentMapResolving
   private let onRecordChanged: @Sendable (String, UUID) -> Void
   private let onRecordDeleted: @Sendable (String, UUID) -> Void
   /// Single shared error channel for every `observeValues(...)` /
@@ -48,11 +69,13 @@ final class GRDBInvestmentRepository: InvestmentRepository, @unchecked Sendable 
   init(
     database: any DatabaseWriter,
     defaultInstrument: Instrument,
+    instrumentResolver: any InstrumentMapResolving,
     onRecordChanged: @escaping @Sendable (String, UUID) -> Void = { _, _ in },
     onRecordDeleted: @escaping @Sendable (String, UUID) -> Void = { _, _ in }
   ) {
     self.database = database
     self.defaultInstrument = defaultInstrument
+    self.instrumentResolver = instrumentResolver
     self.onRecordChanged = onRecordChanged
     self.onRecordDeleted = onRecordDeleted
   }
@@ -132,10 +155,18 @@ final class GRDBInvestmentRepository: InvestmentRepository, @unchecked Sendable 
 
   func fetchDailyBalances(accountId: UUID) async throws -> [AccountDailyBalance] {
     let defaultInstrument = self.defaultInstrument
+    // Resolve the instrument lookup table before opening the
+    // per-profile snapshot: the canonical registry is a separate
+    // database, so the map cannot be joined into this transaction.
+    // Instrument identity is immutable lookup data — a read not atomic
+    // with the leg-row snapshot is safe and intended. Mirrors
+    // `GRDBTransactionRepository.fetchAll(filter:)`.
+    let instruments = try await instrumentResolver.instrumentMap()
     return try await database.read { database in
       try DailyBalanceCompute.compute(
         database: database,
         accountId: accountId,
+        instruments: instruments,
         defaultInstrument: defaultInstrument)
     }
   }

--- a/Backends/GRDB/Repositories/GRDBTransactionRepository+ExternalIdLookup.swift
+++ b/Backends/GRDB/Repositories/GRDBTransactionRepository+ExternalIdLookup.swift
@@ -9,8 +9,11 @@ import GRDB
 /// resolves the lookup in O(log n).
 extension GRDBTransactionRepository {
   func legs(matchingExternalId externalId: String) async throws -> [TransactionLeg] {
-    try await database.read { database in
-      let instruments = try Self.fetchInstrumentMap(database: database)
+    // Resolve the instrument map before the per-profile snapshot — the
+    // canonical registry is a separate database. See
+    // `GRDBTransactionRepository.instrumentResolver`.
+    let instruments = try await instrumentResolver.instrumentMap()
+    return try await database.read { database in
       let rows =
         try TransactionLegRow
         .filter(TransactionLegRow.Columns.externalId == externalId)
@@ -39,6 +42,10 @@ extension GRDBTransactionRepository {
     -> [Transaction]
   {
     guard !externalIds.isEmpty else { return [] }
+    // Resolve the instrument map before the per-profile snapshot — the
+    // canonical registry is a separate database. See
+    // `GRDBTransactionRepository.instrumentResolver`.
+    let instruments = try await instrumentResolver.instrumentMap()
     return try await database.read { database in
       let matchingTxnIds =
         try TransactionLegRow
@@ -47,7 +54,6 @@ extension GRDBTransactionRepository {
         .distinct()
         .fetchAll(database)
       guard !matchingTxnIds.isEmpty else { return [] }
-      let instruments = try Self.fetchInstrumentMap(database: database)
       let txnIdSet = Set(matchingTxnIds)
       let txnRows =
         try TransactionRow

--- a/Backends/GRDB/Repositories/GRDBTransactionRepository+FKEnsure.swift
+++ b/Backends/GRDB/Repositories/GRDBTransactionRepository+FKEnsure.swift
@@ -33,8 +33,8 @@ extension GRDBTransactionRepository {
   /// returned `Instrument` through `registerStock` /
   /// `registerCrypto` so the row reaches CloudKit. Without the
   /// shared-registry fan-out, sibling devices would receive the leg
-  /// but no `InstrumentRecord`, `fetchInstrumentMap` would fall back
-  /// to `Instrument.fiat(code: id)`, and stock conversions would
+  /// but no `InstrumentRecord`, instrument-map resolution would fall
+  /// back to `Instrument.fiat(code: id)`, and stock conversions would
   /// route through the fiat-only Frankfurter API and 404.
   static func ensureInstrumentReadable(
     database: Database,

--- a/Backends/GRDB/Repositories/GRDBTransactionRepository+Fetch.swift
+++ b/Backends/GRDB/Repositories/GRDBTransactionRepository+Fetch.swift
@@ -32,14 +32,26 @@ extension GRDBTransactionRepository {
     let amount: InstrumentAmount
   }
 
+  /// Query-side inputs for `buildFetchSnapshot`. Bundled (rather than
+  /// passed as positional parameters) so the builder stays at
+  /// SwiftLint's `function_parameter_count` ceiling now that the
+  /// instrument map is resolved by the caller and threaded in.
+  /// `database` stays a separate argument — it is the live GRDB
+  /// connection for the read transaction, not a query parameter.
+  struct FetchSnapshotInput: Sendable {
+    let filter: TransactionFilter
+    let page: Int
+    let pageSize: Int
+    let defaultInstrument: Instrument
+    let instruments: [String: Instrument]
+  }
+
   static func buildFetchSnapshot(
     database: Database,
-    filter: TransactionFilter,
-    page: Int,
-    pageSize: Int,
-    defaultInstrument: Instrument
+    input: FetchSnapshotInput
   ) throws -> FetchSnapshot {
-    let instruments = try fetchInstrumentMap(database: database)
+    let filter = input.filter
+    let instruments = input.instruments
     let candidateRows = try candidateTransactionRows(
       database: database, filter: filter)
     let filteredRows = try applyLegFilters(
@@ -49,10 +61,10 @@ extension GRDBTransactionRepository {
       database: database,
       filter: filter,
       instruments: instruments,
-      defaultInstrument: defaultInstrument)
+      defaultInstrument: input.defaultInstrument)
 
     let totalCount = filteredRows.count
-    let offset = page * pageSize
+    let offset = input.page * input.pageSize
     guard offset < totalCount else {
       return FetchSnapshot(
         pageTransactions: [],
@@ -62,7 +74,7 @@ extension GRDBTransactionRepository {
         isPastEnd: true,
         afterPageSubtotals: [])
     }
-    let end = min(offset + pageSize, totalCount)
+    let end = min(offset + input.pageSize, totalCount)
     let pageRows = Array(filteredRows[offset..<end])
     let pageLegs = try fetchLegs(
       database: database,
@@ -268,13 +280,5 @@ extension GRDBTransactionRepository {
     return
       instruments[accountRow.instrumentId]
       ?? Instrument.fiat(code: accountRow.instrumentId)
-  }
-
-  /// Forwards to the shared `InstrumentRow.fetchInstrumentMap` so every
-  /// repository observes the same stored-then-ambient ordering.
-  static func fetchInstrumentMap(
-    database: Database
-  ) throws -> [String: Instrument] {
-    try InstrumentRow.fetchInstrumentMap(database: database)
   }
 }

--- a/Backends/GRDB/Repositories/GRDBTransactionRepository+Observation.swift
+++ b/Backends/GRDB/Repositories/GRDBTransactionRepository+Observation.swift
@@ -35,22 +35,39 @@ import GRDB
 //
 // **Cost note for measurement.** Both observation closures re-run the
 // full fetch / leg join / candidate filtering on every commit to any of
-// the tracked tables (`transaction`, `transaction_leg`, `instrument`,
-// `account` for the resolved-target lookup). A profile with many
-// transactions will pay the candidate-filter cost on every write. The
-// design's measure-first policy applies — measure under load before
+// the tracked tables (`transaction`, `transaction_leg`, `account` for
+// the resolved-target lookup). A profile with many transactions will
+// pay the candidate-filter cost on every write. The design's
+// measure-first policy applies — measure under load before
 // pre-optimising here.
+//
+// **Instrument-map snapshot.** The canonical instrument registry lives
+// on a separate (profile-index) database, so its lookup table cannot be
+// joined into the per-profile `ValueObservation` (the synchronous
+// `tracking(regions:fetch:)` closure cannot `await`). Each observation
+// instead resolves the map once via `instrumentResolver` when the
+// stream's worker task starts, captures it into the tracking closure,
+// and drops `InstrumentRow.observableRegion` from the tracked regions
+// (those rows are no longer in this DB). An instrument-metadata edit
+// therefore does not live-refresh an already-open list until the next
+// refetch (re-subscribe); cross-database instrument-metadata
+// live-refresh is wired via the shared registry's change stream in a
+// follow-up.
 extension GRDBTransactionRepository {
 
   /// Streams `TransactionPage` snapshots whenever `transaction`,
-  /// `transaction_leg`, `instrument`, or `account` changes. Initial
-  /// value is the current DB state. `removeDuplicates()` (applied
-  /// inside the retry helper) coalesces re-fetches that produce the
-  /// same page (e.g. a write to a row outside `[page * pageSize ..< end]`
-  /// that didn't change `totalCount`). The supplied `filter`, `page`,
-  /// and `pageSize` are captured into the tracking closure — changing
-  /// any of them requires cancelling the prior subscription and
-  /// starting a new one with the new values.
+  /// `transaction_leg`, or `account` changes. Initial value is the
+  /// current DB state. Instrument identity is resolved once at
+  /// subscription start via `instrumentResolver` and captured into the
+  /// stream; an instrument-metadata change does not re-fire this
+  /// observation until the subscription is cancelled and restarted.
+  /// `removeDuplicates()` (applied inside the retry helper) coalesces
+  /// re-fetches that produce the same page (e.g. a write to a row
+  /// outside `[page * pageSize ..< end]` that didn't change
+  /// `totalCount`). The supplied `filter`, `page`, and `pageSize` are
+  /// captured into the tracking closure — changing any of them requires
+  /// cancelling the prior subscription and starting a new one with the
+  /// new values.
   ///
   /// `priorBalance` is set to `nil` in the emitted page: the
   /// conversion-service hop is async and runs on the consumer's actor,
@@ -64,81 +81,150 @@ extension GRDBTransactionRepository {
     filter: TransactionFilter, page: Int, pageSize: Int
   ) -> AsyncStream<TransactionPage> {
     let defaultInstrument = self.defaultInstrument
-    return
+    return withResolvedInstrumentMap(
+      repoMethod: "GRDBTransactionRepository.observe"
+    ) { instruments, errorChannel, database in
       ValueObservation
-      // Explicit-region form: every joined table's `observableRegion`
-      // excludes the sync-bookkeeping `encoded_system_fields` blob, so
-      // CKSyncEngine's per-batch system-fields write does not re-fire
-      // this observation. See issue #865.
-      .tracking(
-        regions: [
-          TransactionRow.observableRegion,
-          TransactionLegRow.observableRegion,
-          InstrumentRow.observableRegion,
-          AccountRow.observableRegion,
-        ],
-        fetch: { [filter, page, pageSize] database in
-          let snapshot = try Self.buildFetchSnapshot(
-            database: database,
-            filter: filter,
-            page: page,
-            pageSize: pageSize,
-            defaultInstrument: defaultInstrument)
-          return TransactionPage(
-            transactions: snapshot.pageTransactions,
-            targetInstrument: snapshot.resolvedTarget,
-            priorBalance: nil,
-            totalCount: snapshot.totalCount)
-        }
-      )
-      .toRetryingAsyncStream(
-        in: database,
-        errorChannel: errorChannel,
-        repoMethod: "GRDBTransactionRepository.observe")
+        // Explicit-region form: every joined table's `observableRegion`
+        // excludes the sync-bookkeeping `encoded_system_fields` blob, so
+        // CKSyncEngine's per-batch system-fields write does not re-fire
+        // this observation. See issue #865. `InstrumentRow` is no longer
+        // tracked here — those rows live on the separate profile-index
+        // database; the map is the captured `instruments` snapshot.
+        .tracking(
+          regions: [
+            TransactionRow.observableRegion,
+            TransactionLegRow.observableRegion,
+            AccountRow.observableRegion,
+          ],
+          fetch: { [filter, page, pageSize] database in
+            let snapshot = try Self.buildFetchSnapshot(
+              database: database,
+              input: FetchSnapshotInput(
+                filter: filter,
+                page: page,
+                pageSize: pageSize,
+                defaultInstrument: defaultInstrument,
+                instruments: instruments))
+            return TransactionPage(
+              transactions: snapshot.pageTransactions,
+              targetInstrument: snapshot.resolvedTarget,
+              priorBalance: nil,
+              totalCount: snapshot.totalCount)
+          }
+        )
+        .toRetryingAsyncStream(
+          in: database,
+          errorChannel: errorChannel,
+          repoMethod: "GRDBTransactionRepository.observe")
+    }
   }
 
-  /// Streams `[Transaction]` snapshots whenever `transaction`,
-  /// `transaction_leg`, or `instrument` changes. Mirrors the projection
-  /// of `fetchAll(filter:)`: every matching transaction with its full
-  /// leg payload, ordered the same way (`date DESC, id ASC`). Captures
-  /// `filter` into the tracking closure — changing it requires
-  /// cancelling the prior subscription.
+  /// Streams `[Transaction]` snapshots whenever `transaction` or
+  /// `transaction_leg` changes. Mirrors the projection of
+  /// `fetchAll(filter:)`: every matching transaction with its full leg
+  /// payload, ordered the same way (`date DESC, id ASC`). Instrument
+  /// identity is resolved once at subscription start via
+  /// `instrumentResolver` and captured into the stream; an
+  /// instrument-metadata change does not re-fire this observation until
+  /// the subscription is cancelled and restarted. Captures `filter`
+  /// into the tracking closure — changing it requires cancelling the
+  /// prior subscription.
   func observeAll(filter: TransactionFilter) -> AsyncStream<[Transaction]> {
-    ValueObservation
-      // Explicit-region form: every joined table's `observableRegion`
-      // excludes the sync-bookkeeping `encoded_system_fields` blob, so
-      // CKSyncEngine's per-batch system-fields write does not re-fire
-      // this observation. See issue #865.
-      .tracking(
-        regions: [
-          TransactionRow.observableRegion,
-          TransactionLegRow.observableRegion,
-          InstrumentRow.observableRegion,
-        ],
-        fetch: { [filter] database in
-          let instruments = try Self.fetchInstrumentMap(database: database)
-          let candidateRows = try Self.candidateTransactionRows(
-            database: database, filter: filter)
-          let filteredRows = try Self.applyLegFilters(
-            rows: candidateRows, filter: filter, database: database)
-          let legsByTxnId = try Self.fetchLegs(
-            database: database,
-            transactionIds: filteredRows.map(\.id),
-            instruments: instruments)
-          return try filteredRows.map { row in
-            try row.toDomain(legs: legsByTxnId[row.id] ?? [])
+    withResolvedInstrumentMap(
+      repoMethod: "GRDBTransactionRepository.observeAll"
+    ) { instruments, errorChannel, database in
+      ValueObservation
+        // Explicit-region form: every joined table's `observableRegion`
+        // excludes the sync-bookkeeping `encoded_system_fields` blob, so
+        // CKSyncEngine's per-batch system-fields write does not re-fire
+        // this observation. See issue #865. `InstrumentRow` is no longer
+        // tracked here — those rows live on the separate profile-index
+        // database; the map is the captured `instruments` snapshot.
+        .tracking(
+          regions: [
+            TransactionRow.observableRegion,
+            TransactionLegRow.observableRegion,
+          ],
+          fetch: { [filter] database in
+            let candidateRows = try Self.candidateTransactionRows(
+              database: database, filter: filter)
+            let filteredRows = try Self.applyLegFilters(
+              rows: candidateRows, filter: filter, database: database)
+            let legsByTxnId = try Self.fetchLegs(
+              database: database,
+              transactionIds: filteredRows.map(\.id),
+              instruments: instruments)
+            return try filteredRows.map { row in
+              try row.toDomain(legs: legsByTxnId[row.id] ?? [])
+            }
           }
-        }
-      )
-      .toRetryingAsyncStream(
-        in: database,
-        errorChannel: errorChannel,
-        repoMethod: "GRDBTransactionRepository.observeAll")
+        )
+        .toRetryingAsyncStream(
+          in: database,
+          errorChannel: errorChannel,
+          repoMethod: "GRDBTransactionRepository.observeAll")
+    }
   }
 
   /// Companion error stream — see protocol doc on `observeErrors()` and
   /// the channel's docstring for the surface-then-finish contract.
   func observeErrors() -> AsyncStream<any Error> {
     errorChannel.stream
+  }
+
+  /// Bridges the async instrument-map resolution into the synchronous
+  /// `ValueObservation` pipeline. The canonical registry is on a
+  /// separate database and the `tracking(regions:fetch:)` closure is
+  /// synchronous, so the map must be resolved *before* the observation
+  /// is constructed. The returned outer `AsyncStream`'s worker task is
+  /// the async setup point: it `await`s `instrumentResolver`, then
+  /// `build`s the inner retrying stream with the resolved map captured,
+  /// and forwards every emission. A resolver failure surfaces via the
+  /// shared `errorChannel` (matching the observation error contract)
+  /// and ends the stream. Re-resolution on a metadata change requires a
+  /// re-subscribe; cross-database instrument-metadata live-refresh via
+  /// the shared registry's change stream is a follow-up.
+  private func withResolvedInstrumentMap<Value: Sendable>(
+    repoMethod: String,
+    build:
+      @escaping @Sendable (
+        _ instruments: [String: Instrument],
+        _ errorChannel: ObservationErrorChannel,
+        _ database: any DatabaseWriter
+      ) -> AsyncStream<Value>
+  ) -> AsyncStream<Value> {
+    let resolver = instrumentResolver
+    let errorChannel = errorChannel
+    let database = database
+    return AsyncStream { continuation in
+      let task = Task {
+        let instruments: [String: Instrument]
+        do {
+          instruments = try await resolver.instrumentMap()
+        } catch {
+          // Only surface to the shared (single-shot) errorChannel if the
+          // consumer is still alive — a cancelled subscription's transient
+          // resolver error must not permanently finish the channel for a
+          // later re-subscriber.
+          if !Task.isCancelled {
+            await errorChannel.surfaceAndFinish(error)
+          }
+          continuation.finish()
+          return
+        }
+        guard !Task.isCancelled else {
+          continuation.finish()
+          return
+        }
+        let inner = build(instruments, errorChannel, database)
+        for await value in inner {
+          if Task.isCancelled { break }
+          continuation.yield(value)
+        }
+        continuation.finish()
+      }
+      continuation.onTermination = { _ in task.cancel() }
+    }
   }
 }

--- a/Backends/GRDB/Repositories/GRDBTransactionRepository+Observation.swift
+++ b/Backends/GRDB/Repositories/GRDBTransactionRepository+Observation.swift
@@ -81,8 +81,10 @@ extension GRDBTransactionRepository {
     filter: TransactionFilter, page: Int, pageSize: Int
   ) -> AsyncStream<TransactionPage> {
     let defaultInstrument = self.defaultInstrument
-    return withResolvedInstrumentMap(
-      repoMethod: "GRDBTransactionRepository.observe"
+    return resolvedInstrumentMapStream(
+      resolver: instrumentResolver,
+      errorChannel: errorChannel,
+      database: database
     ) { instruments, errorChannel, database in
       ValueObservation
         // Explicit-region form: every joined table's `observableRegion`
@@ -131,8 +133,10 @@ extension GRDBTransactionRepository {
   /// into the tracking closure — changing it requires cancelling the
   /// prior subscription.
   func observeAll(filter: TransactionFilter) -> AsyncStream<[Transaction]> {
-    withResolvedInstrumentMap(
-      repoMethod: "GRDBTransactionRepository.observeAll"
+    resolvedInstrumentMapStream(
+      resolver: instrumentResolver,
+      errorChannel: errorChannel,
+      database: database
     ) { instruments, errorChannel, database in
       ValueObservation
         // Explicit-region form: every joined table's `observableRegion`
@@ -171,60 +175,5 @@ extension GRDBTransactionRepository {
   /// the channel's docstring for the surface-then-finish contract.
   func observeErrors() -> AsyncStream<any Error> {
     errorChannel.stream
-  }
-
-  /// Bridges the async instrument-map resolution into the synchronous
-  /// `ValueObservation` pipeline. The canonical registry is on a
-  /// separate database and the `tracking(regions:fetch:)` closure is
-  /// synchronous, so the map must be resolved *before* the observation
-  /// is constructed. The returned outer `AsyncStream`'s worker task is
-  /// the async setup point: it `await`s `instrumentResolver`, then
-  /// `build`s the inner retrying stream with the resolved map captured,
-  /// and forwards every emission. A resolver failure surfaces via the
-  /// shared `errorChannel` (matching the observation error contract)
-  /// and ends the stream. Re-resolution on a metadata change requires a
-  /// re-subscribe; cross-database instrument-metadata live-refresh via
-  /// the shared registry's change stream is a follow-up.
-  private func withResolvedInstrumentMap<Value: Sendable>(
-    repoMethod: String,
-    build:
-      @escaping @Sendable (
-        _ instruments: [String: Instrument],
-        _ errorChannel: ObservationErrorChannel,
-        _ database: any DatabaseWriter
-      ) -> AsyncStream<Value>
-  ) -> AsyncStream<Value> {
-    let resolver = instrumentResolver
-    let errorChannel = errorChannel
-    let database = database
-    return AsyncStream { continuation in
-      let task = Task {
-        let instruments: [String: Instrument]
-        do {
-          instruments = try await resolver.instrumentMap()
-        } catch {
-          // Only surface to the shared (single-shot) errorChannel if the
-          // consumer is still alive — a cancelled subscription's transient
-          // resolver error must not permanently finish the channel for a
-          // later re-subscriber.
-          if !Task.isCancelled {
-            await errorChannel.surfaceAndFinish(error)
-          }
-          continuation.finish()
-          return
-        }
-        guard !Task.isCancelled else {
-          continuation.finish()
-          return
-        }
-        let inner = build(instruments, errorChannel, database)
-        for await value in inner {
-          if Task.isCancelled { break }
-          continuation.yield(value)
-        }
-        continuation.finish()
-      }
-      continuation.onTermination = { _ in task.cancel() }
-    }
   }
 }

--- a/Backends/GRDB/Repositories/GRDBTransactionRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBTransactionRepository.swift
@@ -19,10 +19,14 @@ import OSLog
 /// partially committed header cannot leave orphaned legs. Rollback
 /// test mandatory; see `guides/DATABASE_CODE_GUIDE.md`.
 ///
-/// **Instrument resolution.** Each leg's `instrument` is resolved by
-/// reading the `instrument` table inside the same read transaction
-/// (matching `GRDBAccountRepository.fetchInstrumentMap`). Stored rows
-/// win over ambient fiat synthesised from `Locale.Currency.isoCurrencies`.
+/// **Instrument resolution.** Each leg's `instrument` is resolved via
+/// the injected `instrumentResolver`. The instrument map is fetched
+/// once, *before* opening the per-profile read snapshot, because the
+/// canonical registry lives on a different (profile-index) database —
+/// a cross-database transaction is impossible. Instrument identity is
+/// immutable lookup data, so a read that is not atomic with the
+/// transaction-row snapshot is safe and intended. Stored rows win over
+/// ambient fiat synthesised from `Locale.Currency.isoCurrencies`.
 /// Mirrors `CloudKitTransactionRepository.resolveInstrument(id:)`.
 ///
 /// **Running balance.** The repository does not compute running balances —
@@ -37,7 +41,9 @@ import OSLog
 /// `let`. `database` (`any DatabaseWriter`) is itself `Sendable` (GRDB
 /// protocol guarantee — the queue's serial executor mediates concurrent
 /// access). `defaultInstrument` is a value type. `conversionService` is
-/// a `Sendable` protocol. `onRecordChanged` and `onRecordDeleted` are
+/// a `Sendable` protocol. `instrumentResolver` is a `Sendable`
+/// protocol (`InstrumentMapResolving`) and immutable post-init.
+/// `onRecordChanged` and `onRecordDeleted` are
 /// `@Sendable` closures captured at init. Nothing mutates post-init, so
 /// the reference can be shared across actor boundaries without a data
 /// race; `@unchecked` only waives Swift's structural check that
@@ -45,9 +51,10 @@ import OSLog
 /// See `guides/CONCURRENCY_GUIDE.md` §2 "False Positives to Avoid",
 /// Carve-out 3 (GRDB repositories).
 final class GRDBTransactionRepository: TransactionRepository, @unchecked Sendable {
-  // `database`, `defaultInstrument`, `conversionService`, and
-  // `errorChannel` are deliberately not `private` so the sibling
-  // `+Observation.swift` extension can reach them. Treat them as
+  // `database`, `defaultInstrument`, `conversionService`,
+  // `instrumentResolver`, and `errorChannel` are deliberately not
+  // `private` so the sibling `+Observation.swift` /
+  // `+ExternalIdLookup.swift` extensions can reach them. Treat them as
   // private-by-convention from elsewhere in the module.
   let database: any DatabaseWriter
   /// Profile instrument used to label the running balance for global
@@ -55,6 +62,19 @@ final class GRDBTransactionRepository: TransactionRepository, @unchecked Sendabl
   /// `CloudKitTransactionRepository.instrument`.
   let defaultInstrument: Instrument
   let conversionService: any InstrumentConversionService
+  /// Resolves the `[String: Instrument]` lookup table from the
+  /// canonical instrument registry. Fetched once per read operation
+  /// *before* the per-profile `database.read` snapshot opens — the
+  /// registry lives on a separate (profile-index) database, so a
+  /// cross-database transaction is impossible. Instrument identity is
+  /// immutable lookup data; a read that is not atomic with the
+  /// transaction-row snapshot is safe and intended. Production sessions
+  /// inject the shared `GRDBInstrumentRegistryRepository`;
+  /// preview / test / apply callers inject
+  /// `PerProfileInstrumentMapResolver` over the same per-profile DB so
+  /// their behaviour is unchanged until the per-profile `instrument`
+  /// table is dropped.
+  let instrumentResolver: any InstrumentMapResolving
   /// Single shared error channel for every observation subscription
   /// returned by this repo instance. The bridge in
   /// `Backends/GRDB/Observation/AsyncValueObservation+AsyncStream.swift`
@@ -91,6 +111,7 @@ final class GRDBTransactionRepository: TransactionRepository, @unchecked Sendabl
     database: any DatabaseWriter,
     defaultInstrument: Instrument,
     conversionService: any InstrumentConversionService,
+    instrumentResolver: any InstrumentMapResolving,
     onRecordChanged: @escaping @Sendable (String, UUID) -> Void = { _, _ in },
     onRecordDeleted: @escaping @Sendable (String, UUID) -> Void = { _, _ in },
     onInstrumentChanged: @escaping @Sendable (Instrument) -> Void = { _ in }
@@ -98,6 +119,7 @@ final class GRDBTransactionRepository: TransactionRepository, @unchecked Sendabl
     self.database = database
     self.defaultInstrument = defaultInstrument
     self.conversionService = conversionService
+    self.instrumentResolver = instrumentResolver
     self.onRecordChanged = onRecordChanged
     self.onRecordDeleted = onRecordDeleted
     self.onInstrumentChanged = onInstrumentChanged
@@ -106,13 +128,21 @@ final class GRDBTransactionRepository: TransactionRepository, @unchecked Sendabl
   // MARK: - TransactionRepository conformance
 
   func fetch(filter: TransactionFilter, page: Int, pageSize: Int) async throws -> TransactionPage {
+    // Resolve the instrument lookup table before opening the per-profile
+    // snapshot: the canonical registry is a separate database, so the
+    // map cannot be joined into this transaction. Instrument identity is
+    // immutable lookup data — a read not atomic with the row snapshot is
+    // safe and intended.
+    let instruments = try await instrumentResolver.instrumentMap()
     let snapshot = try await database.read { database -> FetchSnapshot in
       try Self.buildFetchSnapshot(
         database: database,
-        filter: filter,
-        page: page,
-        pageSize: pageSize,
-        defaultInstrument: self.defaultInstrument)
+        input: FetchSnapshotInput(
+          filter: filter,
+          page: page,
+          pageSize: pageSize,
+          defaultInstrument: self.defaultInstrument,
+          instruments: instruments))
     }
     let priorBalance = await resolvePriorBalance(snapshot: snapshot)
     return TransactionPage(
@@ -123,8 +153,10 @@ final class GRDBTransactionRepository: TransactionRepository, @unchecked Sendabl
   }
 
   func fetchAll(filter: TransactionFilter) async throws -> [Transaction] {
-    try await database.read { database in
-      let instruments = try Self.fetchInstrumentMap(database: database)
+    // Hoisted ahead of the snapshot for the same cross-database reason
+    // as `fetch(filter:page:pageSize:)`.
+    let instruments = try await instrumentResolver.instrumentMap()
+    return try await database.read { database in
       let candidateRows = try Self.candidateTransactionRows(
         database: database, filter: filter)
       let filteredRows = try Self.applyLegFilters(
@@ -349,7 +381,7 @@ final class GRDBTransactionRepository: TransactionRepository, @unchecked Sendabl
   //     `GRDBTransactionRepository+Update.swift`
   //   `FetchSnapshot`, `buildFetchSnapshot(...)`,
   //   `candidateTransactionRows(...)`, `applyLegFilters(...)`,
-  //   `fetchLegs(...)`, `fetchInstrumentMap(...)` →
+  //   `fetchLegs(...)` →
   //     `GRDBTransactionRepository+Fetch.swift`
   //   `ensureInstrumentReadable(database:leg:)` →
   //     `GRDBTransactionRepository+FKEnsure.swift`

--- a/Backends/GRDB/Repositories/PerProfileInstrumentMapResolver.swift
+++ b/Backends/GRDB/Repositories/PerProfileInstrumentMapResolver.swift
@@ -8,6 +8,14 @@ import GRDB
 /// `v10_drop_shared_instrument_legacy` migration removes it. Production
 /// CloudKit sessions inject the shared `GRDBInstrumentRegistryRepository`
 /// instead (see ProfileSession+CloudKitBackendBuild).
+///
+/// Once `v10_drop_shared_instrument_legacy` drops the per-profile
+/// `instrument` table, any remaining caller of this resolver will receive
+/// an `SQLITE_ERROR` (no such table) from `InstrumentRow.fetchInstrumentMap`.
+/// That error is classified as a programmer bug and terminates the
+/// observation silently in release builds. All callers MUST therefore
+/// switch to `GRDBInstrumentRegistryRepository` at or before that migration —
+/// before the per-profile table disappears.
 struct PerProfileInstrumentMapResolver: InstrumentMapResolving {
   let database: any DatabaseReader
 

--- a/MoolahTests/Backends/GRDB/AcctRepoSharedInstrumentResolutionTests.swift
+++ b/MoolahTests/Backends/GRDB/AcctRepoSharedInstrumentResolutionTests.swift
@@ -1,0 +1,109 @@
+// MoolahTests/Backends/GRDB/AcctRepoSharedInstrumentResolutionTests.swift
+
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+/// Pins the architectural contract that `GRDBAccountRepository` resolves
+/// position instruments via the injected `InstrumentMapResolving` (the
+/// shared profile-index registry), not via a read of the per-profile
+/// `instrument` table inside its own snapshot.
+///
+/// The proof is constructed so per-profile resolution *cannot* succeed:
+/// the account, transaction, and leg rows are inserted directly into the
+/// per-profile database (raw row inserts, no `repo.create`, so no
+/// placeholder `instrument` row is planted). The per-profile `instrument`
+/// table therefore has **no** row for the crypto instrument. The
+/// instrument exists only in the shared registry. If `fetchAll` /
+/// `update` still resolve the position to the full crypto `Instrument`
+/// (kind `.cryptoToken`) rather than the `Instrument.fiat(code:)`
+/// fallback `computePositions` applies on a miss, resolution provably
+/// came from the injected resolver.
+@Suite("Account reads resolve instruments from the shared registry")
+struct AcctRepoSharedInstrumentResolutionTests {
+  @Test("fetchAll position instrument absent from per-profile table resolves via resolver")
+  func fetchAllResolvesFromSharedRegistry() async throws {
+    let perProfile = try ProfileDatabase.openInMemory()
+    let sharedQueue = try ProfileIndexDatabase.openInMemory()
+    let registry = GRDBInstrumentRegistryRepository(database: sharedQueue)
+    let eth = Instrument.crypto(
+      chainId: 1, contractAddress: nil, symbol: "ETH", name: "Ethereum",
+      decimals: 18)
+    try await registry.registerCrypto(
+      eth,
+      mapping: CryptoProviderMapping(
+        instrumentId: eth.id, coingeckoId: "ethereum",
+        cryptocompareSymbol: "ETH", binanceSymbol: "ETHUSDT"))
+
+    let repo = GRDBAccountRepository(
+      database: perProfile, instrumentResolver: registry)
+
+    let account = Account(
+      name: "Trust - Ethereum", type: .crypto, instrument: eth,
+      valuationMode: .calculatedFromTrades, walletAddress: "0xabc",
+      chainId: 1)
+    let leg = TransactionLeg(
+      accountId: account.id, instrument: eth, quantity: 5, type: .income)
+    let txn = Transaction(
+      date: Date(timeIntervalSince1970: 1_700_000_000), payee: "in",
+      legs: [leg])
+
+    // Raw row inserts only: the per-profile `instrument` table stays
+    // empty for `eth.id`, so any successful resolution must originate
+    // from the injected shared registry.
+    try await perProfile.write { database in
+      try AccountRow(domain: account).insert(database)
+      try TransactionRow(domain: txn).insert(database)
+      try TransactionLegRow(domain: leg, transactionId: txn.id, sortOrder: 0)
+        .insert(database)
+    }
+
+    let accounts = try await repo.fetchAll()
+    let resolved = try #require(accounts.first { $0.id == account.id })
+    let position = try #require(resolved.positions.first)
+    #expect(position.instrument == eth)
+    #expect(position.instrument.kind == .cryptoToken)
+  }
+
+  @Test("update position instrument absent from per-profile table resolves via resolver")
+  func updateResolvesFromSharedRegistry() async throws {
+    let perProfile = try ProfileDatabase.openInMemory()
+    let sharedQueue = try ProfileIndexDatabase.openInMemory()
+    let registry = GRDBInstrumentRegistryRepository(database: sharedQueue)
+    let eth = Instrument.crypto(
+      chainId: 1, contractAddress: nil, symbol: "ETH", name: "Ethereum",
+      decimals: 18)
+    try await registry.registerCrypto(
+      eth,
+      mapping: CryptoProviderMapping(
+        instrumentId: eth.id, coingeckoId: "ethereum",
+        cryptocompareSymbol: "ETH", binanceSymbol: "ETHUSDT"))
+
+    let repo = GRDBAccountRepository(
+      database: perProfile, instrumentResolver: registry)
+
+    let account = Account(
+      name: "Trust - Ethereum", type: .crypto, instrument: eth,
+      valuationMode: .calculatedFromTrades, walletAddress: "0xabc",
+      chainId: 1)
+    let leg = TransactionLeg(
+      accountId: account.id, instrument: eth, quantity: 5, type: .income)
+    let txn = Transaction(
+      date: Date(timeIntervalSince1970: 1_700_000_000), payee: "in",
+      legs: [leg])
+
+    try await perProfile.write { database in
+      try AccountRow(domain: account).insert(database)
+      try TransactionRow(domain: txn).insert(database)
+      try TransactionLegRow(domain: leg, transactionId: txn.id, sortOrder: 0)
+        .insert(database)
+    }
+
+    let updated = try await repo.update(account)
+    let position = try #require(updated.positions.first)
+    #expect(position.instrument == eth)
+    #expect(position.instrument.kind == .cryptoToken)
+  }
+}

--- a/MoolahTests/Backends/GRDB/AnlRepoSharedInstrumentResolutionTests.swift
+++ b/MoolahTests/Backends/GRDB/AnlRepoSharedInstrumentResolutionTests.swift
@@ -1,0 +1,81 @@
+// MoolahTests/Backends/GRDB/AnlRepoSharedInstrumentResolutionTests.swift
+
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+/// Pins the architectural contract that `GRDBAnalysisRepository` resolves
+/// the per-row instrument via the injected `InstrumentMapResolving` (the
+/// shared profile-index registry), not via a read of the per-profile
+/// `instrument` table inside its own aggregation snapshot.
+///
+/// The proof is constructed so per-profile resolution *cannot* succeed:
+/// the category, transaction, and leg rows are inserted directly into the
+/// per-profile database (raw row inserts, so no placeholder `instrument`
+/// row is planted). The per-profile `instrument` table therefore has
+/// **no** row for the crypto instrument; it exists only in the shared
+/// registry.
+///
+/// The distinguishing proof is the resolved instrument's *kind*.
+/// `InstrumentAmount`'s storage scale is a universal `10^8` constant
+/// independent of `Instrument.decimals` (see `InstrumentAmount.swift`
+/// `storageScale`), so the decoded `quantity` is `1` whether resolution
+/// found the registered crypto instrument *or* fell back to
+/// `Instrument.fiat(code:)` — `quantity` alone does not distinguish the
+/// two paths. What does distinguish them is `kind`: the registered
+/// instrument is `.cryptoToken`, while the on-miss fallback yields a
+/// `.fiatCurrency` instrument. Asserting `kind == .cryptoToken` (and
+/// equality with the shared `eth` instrument) therefore fails if
+/// resolution fell back to the per-profile fiat default, proving the
+/// value came from the injected resolver.
+@Suite("Analysis reads resolve instruments from the shared registry")
+struct AnlRepoSharedInstrumentResolutionTests {
+  @Test("category-balances instrument absent from per-profile table resolves via resolver")
+  func categoryBalancesResolvesFromSharedRegistry() async throws {
+    let perProfile = try ProfileDatabase.openInMemory()
+    let sharedQueue = try ProfileIndexDatabase.openInMemory()
+    let registry = GRDBInstrumentRegistryRepository(database: sharedQueue)
+    let eth = Instrument.crypto(
+      chainId: 1, contractAddress: nil, symbol: "ETH", name: "Ethereum",
+      decimals: 18)
+    try await registry.registerCrypto(
+      eth,
+      mapping: CryptoProviderMapping(
+        instrumentId: eth.id, coingeckoId: "ethereum",
+        cryptocompareSymbol: "ETH", binanceSymbol: "ETHUSDT"))
+
+    let repo = GRDBAnalysisRepository(
+      database: perProfile,
+      instrument: Instrument.fiat(code: "USD"),
+      conversionService: FixedConversionService(),
+      instrumentResolver: registry)
+
+    let categoryId = UUID()
+    let day = Date(timeIntervalSince1970: 1_700_000_000)
+    // One whole ETH at 18 decimals.
+    let oneEth = InstrumentAmount(quantity: 1, instrument: eth)
+    let leg = TransactionLeg(
+      accountId: UUID(), instrument: eth, quantity: oneEth.quantity,
+      type: .expense, categoryId: categoryId)
+    let txn = Transaction(date: day, payee: "buy", legs: [leg])
+
+    try await perProfile.write { database in
+      try TransactionRow(domain: txn).insert(database)
+      try TransactionLegRow(domain: leg, transactionId: txn.id, sortOrder: 0)
+        .insert(database)
+    }
+
+    let balances = try await repo.fetchCategoryBalances(
+      dateRange: day.addingTimeInterval(-86_400)...day.addingTimeInterval(86_400),
+      transactionType: .expense,
+      filters: nil,
+      targetInstrument: eth)
+
+    let amount = try #require(balances[categoryId])
+    #expect(amount.instrument == eth)
+    #expect(amount.instrument.kind == .cryptoToken)
+    #expect(amount.quantity == 1)
+  }
+}

--- a/MoolahTests/Backends/GRDB/CoreFinancialGraphRollbackTests.swift
+++ b/MoolahTests/Backends/GRDB/CoreFinancialGraphRollbackTests.swift
@@ -23,7 +23,9 @@ struct CoreFinancialGraphRollbackTests {
   @Test
   func accountCreateWithOpeningBalanceRollsBackOnFailure() async throws {
     let database = try ProfileDatabase.openInMemory()
-    let repo = GRDBAccountRepository(database: database)
+    let repo = GRDBAccountRepository(
+      database: database,
+      instrumentResolver: PerProfileInstrumentMapResolver(database: database))
 
     // Pre-seed an account whose row must remain untouched after the
     // failed second-account create — its existence pins the "no torn
@@ -239,7 +241,9 @@ struct CoreFinancialGraphRollbackTests {
   @Test
   func accountUpdateRollsBackOnFailure() async throws {
     let database = try ProfileDatabase.openInMemory()
-    let repo = GRDBAccountRepository(database: database)
+    let repo = GRDBAccountRepository(
+      database: database,
+      instrumentResolver: PerProfileInstrumentMapResolver(database: database))
 
     let id = UUID()
     let original = Account(id: id, name: "Original", type: .bank, instrument: .AUD)
@@ -282,7 +286,8 @@ struct CoreFinancialGraphRollbackTests {
   func earmarkSetBudgetRollsBackOnFailure() async throws {
     let database = try ProfileDatabase.openInMemory()
     let earmarkRepo = GRDBEarmarkRepository(
-      database: database, defaultInstrument: .AUD)
+      database: database, defaultInstrument: .AUD,
+      instrumentResolver: PerProfileInstrumentMapResolver(database: database))
     let categoryRepo = GRDBCategoryRepository(database: database)
 
     let earmarkId = UUID()

--- a/MoolahTests/Backends/GRDB/CoreFinancialGraphRollbackTests.swift
+++ b/MoolahTests/Backends/GRDB/CoreFinancialGraphRollbackTests.swift
@@ -94,7 +94,8 @@ struct CoreFinancialGraphRollbackTests {
     let txnRepo = GRDBTransactionRepository(
       database: database,
       defaultInstrument: .AUD,
-      conversionService: FixedConversionService())
+      conversionService: FixedConversionService(),
+      instrumentResolver: PerProfileInstrumentMapResolver(database: database))
     let accountId = UUID()
     let stub = Account(id: accountId, name: "Cash", type: .bank, instrument: .AUD)
     try await database.write { database in
@@ -147,7 +148,8 @@ struct CoreFinancialGraphRollbackTests {
     let txnRepo = GRDBTransactionRepository(
       database: database,
       defaultInstrument: .AUD,
-      conversionService: FixedConversionService())
+      conversionService: FixedConversionService(),
+      instrumentResolver: PerProfileInstrumentMapResolver(database: database))
     let accountId = UUID()
     try await seedAccountStub(in: database, accountId: accountId)
 

--- a/MoolahTests/Backends/GRDB/EmkRepoSharedInstrumentResolutionTests.swift
+++ b/MoolahTests/Backends/GRDB/EmkRepoSharedInstrumentResolutionTests.swift
@@ -1,0 +1,88 @@
+// MoolahTests/Backends/GRDB/EmkRepoSharedInstrumentResolutionTests.swift
+
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+/// Pins the architectural contract that `GRDBEarmarkRepository` resolves
+/// position instruments via the injected `InstrumentMapResolving` (the
+/// shared profile-index registry), not via a read of the per-profile
+/// `instrument` table inside its own `fetchAll` / `observeAll` snapshot.
+///
+/// The proof is constructed so per-profile resolution *cannot* succeed:
+/// the earmark, transaction, and leg rows are inserted directly into the
+/// per-profile database (raw row inserts, so no placeholder `instrument`
+/// row is planted). The per-profile `instrument` table therefore has
+/// **no** row for the crypto instrument; it exists only in the shared
+/// registry. If the read still resolves the position to the full crypto
+/// `Instrument` (kind `.cryptoToken`) rather than the
+/// `Instrument.fiat(code:)` fallback `computeEarmarkPositions` applies on
+/// a miss, resolution provably came from the injected resolver.
+@Suite("Earmark reads resolve instruments from the shared registry")
+struct EmkRepoSharedInstrumentResolutionTests {
+  /// Bundle returned by `makeSeededRepo` — replaces a 3-tuple to satisfy
+  /// SwiftLint's `large_tuple` policy.
+  private struct SeededRepo {
+    let repo: GRDBEarmarkRepository
+    let earmarkId: UUID
+    let eth: Instrument
+  }
+
+  private func makeSeededRepo() async throws -> SeededRepo {
+    let perProfile = try ProfileDatabase.openInMemory()
+    let sharedQueue = try ProfileIndexDatabase.openInMemory()
+    let registry = GRDBInstrumentRegistryRepository(database: sharedQueue)
+    let eth = Instrument.crypto(
+      chainId: 1, contractAddress: nil, symbol: "ETH", name: "Ethereum",
+      decimals: 18)
+    try await registry.registerCrypto(
+      eth,
+      mapping: CryptoProviderMapping(
+        instrumentId: eth.id, coingeckoId: "ethereum",
+        cryptocompareSymbol: "ETH", binanceSymbol: "ETHUSDT"))
+
+    let repo = GRDBEarmarkRepository(
+      database: perProfile,
+      defaultInstrument: Instrument.fiat(code: "USD"),
+      instrumentResolver: registry)
+
+    let earmark = Earmark(name: "Crypto savings", instrument: eth)
+    let leg = TransactionLeg(
+      accountId: nil, instrument: eth, quantity: 3, type: .income,
+      earmarkId: earmark.id)
+    let txn = Transaction(
+      date: Date(timeIntervalSince1970: 1_700_000_000), payee: "in",
+      legs: [leg])
+
+    try await perProfile.write { database in
+      try EarmarkRow(domain: earmark).insert(database)
+      try TransactionRow(domain: txn).insert(database)
+      try TransactionLegRow(domain: leg, transactionId: txn.id, sortOrder: 0)
+        .insert(database)
+    }
+    return SeededRepo(repo: repo, earmarkId: earmark.id, eth: eth)
+  }
+
+  @Test("fetchAll position instrument absent from per-profile table resolves via resolver")
+  func fetchAllResolvesFromSharedRegistry() async throws {
+    let seeded = try await makeSeededRepo()
+    let earmarks = try await seeded.repo.fetchAll()
+    let resolved = try #require(earmarks.first { $0.id == seeded.earmarkId })
+    let position = try #require(resolved.positions.first)
+    #expect(position.instrument == seeded.eth)
+    #expect(position.instrument.kind == .cryptoToken)
+  }
+
+  @Test("observeAll position instrument absent from per-profile table resolves via resolver")
+  func observeAllResolvesFromSharedRegistry() async throws {
+    let seeded = try await makeSeededRepo()
+    var iterator = seeded.repo.observeAll().makeAsyncIterator()
+    let first = try #require(await iterator.next())
+    let resolved = try #require(first.first { $0.id == seeded.earmarkId })
+    let position = try #require(resolved.positions.first)
+    #expect(position.instrument == seeded.eth)
+    #expect(position.instrument.kind == .cryptoToken)
+  }
+}

--- a/MoolahTests/Backends/GRDB/GRDBCreateManyTests.swift
+++ b/MoolahTests/Backends/GRDB/GRDBCreateManyTests.swift
@@ -72,7 +72,8 @@ struct GRDBCreateManyTests {
     let txnRepo = GRDBTransactionRepository(
       database: database,
       defaultInstrument: .AUD,
-      conversionService: FixedConversionService())
+      conversionService: FixedConversionService(),
+      instrumentResolver: PerProfileInstrumentMapResolver(database: database))
     let accountId = UUID()
     let stub = Account(id: accountId, name: "Cash", type: .bank, instrument: .AUD)
     try await database.write { database in
@@ -130,6 +131,7 @@ struct GRDBCreateManyTests {
       database: database,
       defaultInstrument: .AUD,
       conversionService: FixedConversionService(),
+      instrumentResolver: PerProfileInstrumentMapResolver(database: database),
       onRecordChanged: makeChangedHook(capture),
       onRecordDeleted: makeDeletedHook(capture),
       onInstrumentChanged: makeInstrumentHook(capture))

--- a/MoolahTests/Backends/GRDB/GRDBTransactionStableLegIdTests.swift
+++ b/MoolahTests/Backends/GRDB/GRDBTransactionStableLegIdTests.swift
@@ -153,7 +153,8 @@ struct GRDBTransactionStableLegIdTests {
     let txnRepo = GRDBTransactionRepository(
       database: database,
       defaultInstrument: .defaultTestInstrument,
-      conversionService: FixedConversionService())
+      conversionService: FixedConversionService(),
+      instrumentResolver: PerProfileInstrumentMapResolver(database: database))
     let accountId = UUID()
     let txn = try await txnRepo.create(
       Transaction(
@@ -225,7 +226,8 @@ struct GRDBTransactionStableLegIdTests {
     let txnRepo = GRDBTransactionRepository(
       database: database,
       defaultInstrument: .defaultTestInstrument,
-      conversionService: FixedConversionService())
+      conversionService: FixedConversionService(),
+      instrumentResolver: PerProfileInstrumentMapResolver(database: database))
     let accountId = UUID()
     let txn = try await txnRepo.create(
       Transaction(
@@ -256,7 +258,8 @@ struct GRDBTransactionStableLegIdTests {
     let txnRepo = GRDBTransactionRepository(
       database: database,
       defaultInstrument: .defaultTestInstrument,
-      conversionService: FixedConversionService())
+      conversionService: FixedConversionService(),
+      instrumentResolver: PerProfileInstrumentMapResolver(database: database))
     let accountId = UUID()
     let txn = try await txnRepo.create(
       Transaction(

--- a/MoolahTests/Backends/GRDB/InvRepoSharedInstrumentResolutionTests.swift
+++ b/MoolahTests/Backends/GRDB/InvRepoSharedInstrumentResolutionTests.swift
@@ -1,0 +1,80 @@
+// MoolahTests/Backends/GRDB/InvRepoSharedInstrumentResolutionTests.swift
+
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+/// Pins the architectural contract that
+/// `GRDBInvestmentRepository.fetchDailyBalances(accountId:)` (via
+/// `DailyBalanceCompute`) resolves each leg's instrument through the
+/// injected `InstrumentMapResolving` (the shared profile-index
+/// registry), not via a read of the per-profile `instrument` table
+/// inside its own snapshot.
+///
+/// The proof is constructed so per-profile resolution *cannot* succeed:
+/// the account, transaction, and leg rows are inserted directly into the
+/// per-profile database (raw row inserts, so no placeholder `instrument`
+/// row is planted). The per-profile `instrument` table therefore has
+/// **no** row for the crypto instrument; it exists only in the shared
+/// registry.
+///
+/// The distinguishing proof is the resolved instrument's *kind*.
+/// `InstrumentAmount`'s storage scale is a universal `10^8` constant
+/// independent of `Instrument.decimals` (see `InstrumentAmount.swift`
+/// `storageScale`), so the decoded balance `quantity` is `1` whether
+/// resolution found the registered crypto instrument *or* fell back to
+/// `Instrument.fiat(code:)` — `quantity` alone does not distinguish the
+/// two paths. What does distinguish them is `kind`: the registered
+/// instrument is `.cryptoToken`, while the on-miss fallback yields a
+/// `.fiatCurrency` instrument. Asserting `kind == .cryptoToken` (and
+/// equality with the shared `eth` instrument) therefore fails if
+/// resolution fell back to the per-profile default, proving the value
+/// came from the injected resolver.
+@Suite("Investment daily balances resolve instruments from the shared registry")
+struct InvRepoSharedInstrumentResolutionTests {
+  @Test("daily-balance leg instrument absent from per-profile table resolves via resolver")
+  func dailyBalancesResolveFromSharedRegistry() async throws {
+    let perProfile = try ProfileDatabase.openInMemory()
+    let sharedQueue = try ProfileIndexDatabase.openInMemory()
+    let registry = GRDBInstrumentRegistryRepository(database: sharedQueue)
+    let eth = Instrument.crypto(
+      chainId: 1, contractAddress: nil, symbol: "ETH", name: "Ethereum",
+      decimals: 18)
+    try await registry.registerCrypto(
+      eth,
+      mapping: CryptoProviderMapping(
+        instrumentId: eth.id, coingeckoId: "ethereum",
+        cryptocompareSymbol: "ETH", binanceSymbol: "ETHUSDT"))
+
+    let repo = GRDBInvestmentRepository(
+      database: perProfile,
+      defaultInstrument: Instrument.fiat(code: "USD"),
+      instrumentResolver: registry)
+
+    let account = Account(
+      name: "ETH", type: .crypto, instrument: eth,
+      valuationMode: .calculatedFromTrades, walletAddress: "0xabc",
+      chainId: 1)
+    let day = Date(timeIntervalSince1970: 1_700_000_000)
+    let leg = TransactionLeg(
+      accountId: account.id, instrument: eth,
+      quantity: InstrumentAmount(quantity: 1, instrument: eth).quantity,
+      type: .income)
+    let txn = Transaction(date: day, payee: "in", legs: [leg])
+
+    try await perProfile.write { database in
+      try AccountRow(domain: account).insert(database)
+      try TransactionRow(domain: txn).insert(database)
+      try TransactionLegRow(domain: leg, transactionId: txn.id, sortOrder: 0)
+        .insert(database)
+    }
+
+    let balances = try await repo.fetchDailyBalances(accountId: account.id)
+    let last = try #require(balances.last)
+    #expect(last.balance.instrument == eth)
+    #expect(last.balance.instrument.kind == .cryptoToken)
+    #expect(last.balance.quantity == 1)
+  }
+}

--- a/MoolahTests/Backends/GRDB/RepositorySyncCascadeRollbackTests.swift
+++ b/MoolahTests/Backends/GRDB/RepositorySyncCascadeRollbackTests.swift
@@ -21,7 +21,9 @@ struct RepositorySyncCascadeRollbackTests {
   @Test
   func accountSyncDeleteRollsBackInvestmentValueAndLegEdits() async throws {
     let database = try ProfileDatabase.openInMemory()
-    let accountRepo = GRDBAccountRepository(database: database)
+    let accountRepo = GRDBAccountRepository(
+      database: database,
+      instrumentResolver: PerProfileInstrumentMapResolver(database: database))
     let fixture = try await Self.seedAccountScenario(in: database)
 
     do {
@@ -37,7 +39,9 @@ struct RepositorySyncCascadeRollbackTests {
   @Test
   func earmarkSyncDeleteRollsBackBudgetItemAndLegEdits() async throws {
     let database = try ProfileDatabase.openInMemory()
-    let earmarkRepo = GRDBEarmarkRepository(database: database, defaultInstrument: .AUD)
+    let earmarkRepo = GRDBEarmarkRepository(
+      database: database, defaultInstrument: .AUD,
+      instrumentResolver: PerProfileInstrumentMapResolver(database: database))
     let fixture = try await Self.seedEarmarkScenario(in: database)
 
     do {

--- a/MoolahTests/Backends/GRDB/RepositorySyncCascadeTests.swift
+++ b/MoolahTests/Backends/GRDB/RepositorySyncCascadeTests.swift
@@ -65,7 +65,8 @@ struct RepositorySyncCascadeTests {
     let txRepo = GRDBTransactionRepository(
       database: database,
       defaultInstrument: .AUD,
-      conversionService: FixedConversionService())
+      conversionService: FixedConversionService(),
+      instrumentResolver: PerProfileInstrumentMapResolver(database: database))
     let txId = UUID()
     let leg1Id = UUID()
     let leg2Id = UUID()
@@ -105,7 +106,8 @@ struct RepositorySyncCascadeTests {
     let txRepo = GRDBTransactionRepository(
       database: database,
       defaultInstrument: .AUD,
-      conversionService: FixedConversionService())
+      conversionService: FixedConversionService(),
+      instrumentResolver: PerProfileInstrumentMapResolver(database: database))
     let txId = UUID()
     let legId = UUID()
 
@@ -243,7 +245,8 @@ struct RepositorySyncCascadeTests {
     let txRepo = GRDBTransactionRepository(
       database: database,
       defaultInstrument: .AUD,
-      conversionService: FixedConversionService())
+      conversionService: FixedConversionService(),
+      instrumentResolver: PerProfileInstrumentMapResolver(database: database))
 
     let orphanAccountId = UUID()
     let orphanCategoryId = UUID()

--- a/MoolahTests/Backends/GRDB/RepositorySyncCascadeTests.swift
+++ b/MoolahTests/Backends/GRDB/RepositorySyncCascadeTests.swift
@@ -15,7 +15,9 @@ struct RepositorySyncCascadeTests {
   @Test
   func accountSyncDeleteCascadesToInvestmentValuesAndNullsLegs() async throws {
     let database = try ProfileDatabase.openInMemory()
-    let accountRepo = GRDBAccountRepository(database: database)
+    let accountRepo = GRDBAccountRepository(
+      database: database,
+      instrumentResolver: PerProfileInstrumentMapResolver(database: database))
     let accountId = UUID()
     let legId = UUID()
     let txId = UUID()
@@ -144,7 +146,9 @@ struct RepositorySyncCascadeTests {
   @Test
   func earmarkSyncDeleteCascadesBudgetItemsAndNullsLegs() async throws {
     let database = try ProfileDatabase.openInMemory()
-    let earmarkRepo = GRDBEarmarkRepository(database: database, defaultInstrument: .AUD)
+    let earmarkRepo = GRDBEarmarkRepository(
+      database: database, defaultInstrument: .AUD,
+      instrumentResolver: PerProfileInstrumentMapResolver(database: database))
     let earmarkId = UUID()
     let categoryId = UUID()
     let budgetId = UUID()
@@ -198,7 +202,9 @@ struct RepositorySyncCascadeTests {
   @Test
   func setBudgetToleratesUnknownCategoryWithoutStubInsert() async throws {
     let database = try ProfileDatabase.openInMemory()
-    let earmarkRepo = GRDBEarmarkRepository(database: database, defaultInstrument: .USD)
+    let earmarkRepo = GRDBEarmarkRepository(
+      database: database, defaultInstrument: .USD,
+      instrumentResolver: PerProfileInstrumentMapResolver(database: database))
     let earmarkId = UUID()
     let unknownCategoryId = UUID()
 

--- a/MoolahTests/Backends/GRDB/SystemFieldsBatchTests.swift
+++ b/MoolahTests/Backends/GRDB/SystemFieldsBatchTests.swift
@@ -70,7 +70,8 @@ struct SystemFieldsBatchTests {
     let repo = GRDBTransactionRepository(
       database: database,
       defaultInstrument: .defaultTestInstrument,
-      conversionService: conversionService)
+      conversionService: conversionService,
+      instrumentResolver: PerProfileInstrumentMapResolver(database: database))
     return (repo, database)
   }
 

--- a/MoolahTests/Backends/GRDB/TransactionDeleteRollbackTests.swift
+++ b/MoolahTests/Backends/GRDB/TransactionDeleteRollbackTests.swift
@@ -14,7 +14,8 @@ struct TransactionDeleteRollbackTests {
     let txRepo = GRDBTransactionRepository(
       database: database,
       defaultInstrument: .AUD,
-      conversionService: FixedConversionService())
+      conversionService: FixedConversionService(),
+      instrumentResolver: PerProfileInstrumentMapResolver(database: database))
     let txId = UUID()
     let legId = UUID()
 

--- a/MoolahTests/Backends/GRDB/TxnRepoSharedInstrumentResolutionTests.swift
+++ b/MoolahTests/Backends/GRDB/TxnRepoSharedInstrumentResolutionTests.swift
@@ -1,0 +1,112 @@
+// MoolahTests/Backends/GRDB/TxnRepoSharedInstrumentResolutionTests.swift
+
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+/// `InstrumentMapResolving` whose resolution always fails. Used to drive
+/// the resolver-error path of `GRDBTransactionRepository`'s observation
+/// pipeline: the error must surface via `observeErrors()` and finish the
+/// observation stream.
+struct AlwaysThrowingInstrumentMapResolver: InstrumentMapResolving {
+  func instrumentMap() async throws -> [String: Instrument] {
+    throw CocoaError(.fileNoSuchFile)
+  }
+}
+
+/// Pins the architectural contract that `GRDBTransactionRepository`
+/// resolves leg / target instruments via the injected
+/// `InstrumentMapResolving` (the shared profile-index registry), not via
+/// a read of the per-profile `instrument` table inside its own snapshot.
+///
+/// The proof is constructed so per-profile resolution *cannot* succeed:
+/// the transaction header, leg, and account rows are inserted directly
+/// into the per-profile database (no `repo.create`, so
+/// `ensureInstrumentReadable` never plants a placeholder
+/// `instrument` row). The per-profile `instrument` table therefore has
+/// **no** row for the crypto instrument. The instrument exists only in
+/// the shared registry. If `fetch` still returns the full crypto
+/// `Instrument` (kind `.cryptoToken`) for both the leg and the page's
+/// `targetInstrument` — rather than the `Instrument.fiat(code:
+/// "1:native")` fallback `fetchLegs` / `resolveTargetInstrument` apply
+/// on a miss — resolution provably came from the injected resolver.
+@Suite("Transaction reads resolve instruments from the shared registry")
+struct TxnRepoSharedInstrumentResolutionTests {
+  @Test("leg instrument absent from per-profile table resolves via resolver")
+  func resolvesFromSharedRegistry() async throws {
+    let perProfile = try ProfileDatabase.openInMemory()
+    let sharedQueue = try ProfileIndexDatabase.openInMemory()
+    let registry = GRDBInstrumentRegistryRepository(database: sharedQueue)
+    let eth = Instrument.crypto(
+      chainId: 1, contractAddress: nil, symbol: "ETH", name: "Ethereum",
+      decimals: 18)
+    try await registry.registerCrypto(
+      eth,
+      mapping: CryptoProviderMapping(
+        instrumentId: eth.id, coingeckoId: "ethereum",
+        cryptocompareSymbol: "ETH", binanceSymbol: "ETHUSDT"))
+
+    let repo = GRDBTransactionRepository(
+      database: perProfile,
+      defaultInstrument: Instrument.fiat(code: "USD"),
+      conversionService: FixedConversionService(),
+      instrumentResolver: registry)
+
+    let account = Account(
+      name: "Trust - Ethereum", type: .crypto, instrument: eth,
+      valuationMode: .calculatedFromTrades, walletAddress: "0xabc",
+      chainId: 1)
+    let leg = TransactionLeg(
+      accountId: account.id, instrument: eth, quantity: 1, type: .income)
+    let txn = Transaction(date: .now, payee: "in", legs: [leg])
+
+    // Raw row inserts only: the per-profile `instrument` table stays
+    // empty for `eth.id`, so any successful resolution must originate
+    // from the injected shared registry.
+    try await perProfile.write { database in
+      try AccountRow(domain: account).insert(database)
+      try TransactionRow(domain: txn).insert(database)
+      try TransactionLegRow(domain: leg, transactionId: txn.id, sortOrder: 0)
+        .insert(database)
+    }
+
+    let page = try await repo.fetch(
+      filter: TransactionFilter(accountId: account.id), page: 0,
+      pageSize: 50)
+
+    let resolvedLeg = try #require(page.transactions.first?.legs.first)
+    #expect(resolvedLeg.instrument == eth)
+    #expect(resolvedLeg.instrument.kind == .cryptoToken)
+    #expect(page.targetInstrument == eth)
+    #expect(page.targetInstrument.kind == .cryptoToken)
+  }
+
+  @Test("resolver failure surfaces via observeErrors and finishes the stream")
+  func resolverFailureSurfacesAndFinishes() async throws {
+    let perProfile = try ProfileDatabase.openInMemory()
+    let repo = GRDBTransactionRepository(
+      database: perProfile,
+      defaultInstrument: Instrument.fiat(code: "USD"),
+      conversionService: FixedConversionService(),
+      instrumentResolver: AlwaysThrowingInstrumentMapResolver())
+
+    // Start consuming errors before subscribing so the single-shot
+    // channel emission cannot be missed.
+    var errorIterator = repo.observeErrors().makeAsyncIterator()
+
+    // The resolver throws before any value is produced, so the worker
+    // task surfaces the error to the shared channel and finishes the
+    // observation continuation — `next()` returns `nil` deterministically
+    // (no value is ever yielded), with no sleep required.
+    var pageIterator = repo.observe(
+      filter: TransactionFilter(), page: 0, pageSize: 50
+    ).makeAsyncIterator()
+    let firstPage = await pageIterator.next()
+    #expect(firstPage == nil, "observe stream must finish on resolver failure")
+
+    let surfaced = await errorIterator.next()
+    #expect(surfaced != nil, "resolver error must surface via observeErrors()")
+  }
+}

--- a/MoolahTests/Backends/GRDB/TxnRepoSharedInstrumentResolutionTests.swift
+++ b/MoolahTests/Backends/GRDB/TxnRepoSharedInstrumentResolutionTests.swift
@@ -60,7 +60,9 @@ struct TxnRepoSharedInstrumentResolutionTests {
       chainId: 1)
     let leg = TransactionLeg(
       accountId: account.id, instrument: eth, quantity: 1, type: .income)
-    let txn = Transaction(date: .now, payee: "in", legs: [leg])
+    let txn = Transaction(
+      date: Date(timeIntervalSince1970: 1_700_000_000), payee: "in",
+      legs: [leg])
 
     // Raw row inserts only: the per-profile `instrument` table stays
     // empty for `eth.id`, so any successful resolution must originate

--- a/MoolahTests/Support/CloudKitAnalysisTestBackend.swift
+++ b/MoolahTests/Support/CloudKitAnalysisTestBackend.swift
@@ -79,8 +79,15 @@ extension CloudKitAnalysisTestBackend {
   func fetchAggregationForTesting(
     after: Date?, forecastUntil: Date?
   ) async throws -> GRDBAnalysisRepository.DailyBalancesAggregation {
-    try await GRDBAnalysisRepository.fetchDailyBalancesAggregation(
+    // Behaviour-preserving: resolve the instrument map from the same
+    // per-profile DB the aggregation previously read inline, so this
+    // shim's contract is unchanged after the resolver cutover.
+    let instruments = try await PerProfileInstrumentMapResolver(
+      database: self.database
+    ).instrumentMap()
+    return try await GRDBAnalysisRepository.fetchDailyBalancesAggregation(
       database: self.database,
+      instruments: instruments,
       after: after,
       forecastUntil: forecastUntil)
   }

--- a/MoolahTests/Support/ProfileDataSyncHandlerTestSupport.swift
+++ b/MoolahTests/Support/ProfileDataSyncHandlerTestSupport.swift
@@ -248,7 +248,8 @@ enum ProfileDataSyncHandlerTestSupport {
       transactions: GRDBTransactionRepository(
         database: database,
         defaultInstrument: instrument,
-        conversionService: conversionService),
+        conversionService: conversionService,
+        instrumentResolver: PerProfileInstrumentMapResolver(database: database)),
       transactionLegs: GRDBTransactionLegRepository(database: database),
       database: database)
   }

--- a/MoolahTests/Support/ProfileDataSyncHandlerTestSupport.swift
+++ b/MoolahTests/Support/ProfileDataSyncHandlerTestSupport.swift
@@ -239,12 +239,18 @@ enum ProfileDataSyncHandlerTestSupport {
       importRules: GRDBImportRuleRepository(database: database),
       instruments: GRDBInstrumentRegistryRepository(database: database),
       categories: GRDBCategoryRepository(database: database),
-      accounts: GRDBAccountRepository(database: database),
+      accounts: GRDBAccountRepository(
+        database: database,
+        instrumentResolver: PerProfileInstrumentMapResolver(database: database)),
       earmarks: GRDBEarmarkRepository(
-        database: database, defaultInstrument: instrument),
+        database: database,
+        defaultInstrument: instrument,
+        instrumentResolver: PerProfileInstrumentMapResolver(database: database)),
       earmarkBudgetItems: GRDBEarmarkBudgetItemRepository(database: database),
       investmentValues: GRDBInvestmentRepository(
-        database: database, defaultInstrument: instrument),
+        database: database,
+        defaultInstrument: instrument,
+        instrumentResolver: PerProfileInstrumentMapResolver(database: database)),
       transactions: GRDBTransactionRepository(
         database: database,
         defaultInstrument: instrument,

--- a/MoolahTests/Sync/InstrumentLocalSyncQueueTests.swift
+++ b/MoolahTests/Sync/InstrumentLocalSyncQueueTests.swift
@@ -74,6 +74,7 @@ struct InstrumentLocalSyncQueueTests {
       database: database,
       defaultInstrument: .defaultTestInstrument,
       conversionService: FixedConversionService(),
+      instrumentResolver: PerProfileInstrumentMapResolver(database: database),
       onInstrumentChanged: makeInstrumentChangedHook(capture))
 
     let stock = makeStockInstrument(ticker: "IFRA")
@@ -95,6 +96,7 @@ struct InstrumentLocalSyncQueueTests {
       database: database,
       defaultInstrument: .defaultTestInstrument,
       conversionService: FixedConversionService(),
+      instrumentResolver: PerProfileInstrumentMapResolver(database: database),
       onInstrumentChanged: makeInstrumentChangedHook(capture))
 
     let txn = Transaction(
@@ -121,6 +123,7 @@ struct InstrumentLocalSyncQueueTests {
       database: database,
       defaultInstrument: .defaultTestInstrument,
       conversionService: FixedConversionService(),
+      instrumentResolver: PerProfileInstrumentMapResolver(database: database),
       onInstrumentChanged: makeInstrumentChangedHook(capture))
 
     let txn = Transaction(
@@ -141,6 +144,7 @@ struct InstrumentLocalSyncQueueTests {
       database: database,
       defaultInstrument: .defaultTestInstrument,
       conversionService: FixedConversionService(),
+      instrumentResolver: PerProfileInstrumentMapResolver(database: database),
       onInstrumentChanged: makeInstrumentChangedHook(capture))
 
     let stock = makeStockInstrument(ticker: "VGS")
@@ -170,6 +174,7 @@ struct InstrumentLocalSyncQueueTests {
       database: database,
       defaultInstrument: .defaultTestInstrument,
       conversionService: FixedConversionService(),
+      instrumentResolver: PerProfileInstrumentMapResolver(database: database),
       onInstrumentChanged: makeInstrumentChangedHook(capture))
 
     // Seed a fiat-only transaction first.

--- a/MoolahTests/Sync/InstrumentLocalSyncQueueTests.swift
+++ b/MoolahTests/Sync/InstrumentLocalSyncQueueTests.swift
@@ -209,6 +209,7 @@ struct InstrumentLocalSyncQueueTests {
     let capture = Capture()
     let repo = GRDBAccountRepository(
       database: database,
+      instrumentResolver: PerProfileInstrumentMapResolver(database: database),
       onInstrumentChanged: makeInstrumentChangedHook(capture))
 
     let stock = makeStockInstrument(ticker: "VAP")
@@ -226,6 +227,7 @@ struct InstrumentLocalSyncQueueTests {
     let capture = Capture()
     let repo = GRDBAccountRepository(
       database: database,
+      instrumentResolver: PerProfileInstrumentMapResolver(database: database),
       onInstrumentChanged: makeInstrumentChangedHook(capture))
 
     let account = Account(name: "Cash", type: .bank, instrument: .defaultTestInstrument)
@@ -245,6 +247,7 @@ struct InstrumentLocalSyncQueueTests {
     let capture = Capture()
     let repo = GRDBAccountRepository(
       database: database,
+      instrumentResolver: PerProfileInstrumentMapResolver(database: database),
       onInstrumentChanged: makeInstrumentChangedHook(capture))
 
     let account = Account(name: "VGS Holdings", type: .investment, instrument: stock)

--- a/MoolahTests/Sync/RepositoryHookRecordTypeTests.swift
+++ b/MoolahTests/Sync/RepositoryHookRecordTypeTests.swift
@@ -109,6 +109,7 @@ struct RepositoryHookRecordTypeTests {
     let capture = HookCapture()
     let repo = GRDBAccountRepository(
       database: database,
+      instrumentResolver: PerProfileInstrumentMapResolver(database: database),
       onRecordChanged: makeChangedHook(capture),
       onRecordDeleted: makeDeletedHook(capture))
 
@@ -139,6 +140,7 @@ struct RepositoryHookRecordTypeTests {
     let earmarkRepo = GRDBEarmarkRepository(
       database: database,
       defaultInstrument: .defaultTestInstrument,
+      instrumentResolver: PerProfileInstrumentMapResolver(database: database),
       onRecordChanged: makeChangedHook(capture),
       onRecordDeleted: makeDeletedHook(capture))
     let earmark = try await earmarkRepo.create(

--- a/MoolahTests/Sync/RepositoryHookRecordTypeTests.swift
+++ b/MoolahTests/Sync/RepositoryHookRecordTypeTests.swift
@@ -67,6 +67,7 @@ struct RepositoryHookRecordTypeTests {
       database: database,
       defaultInstrument: .defaultTestInstrument,
       conversionService: FixedConversionService(),
+      instrumentResolver: PerProfileInstrumentMapResolver(database: database),
       onRecordChanged: makeChangedHook(capture),
       onRecordDeleted: makeDeletedHook(capture))
     // Leg-level hooks are emitted via the txn repo's bundled write path;

--- a/MoolahTests/Sync/TransactionHookUpdateDeleteTests.swift
+++ b/MoolahTests/Sync/TransactionHookUpdateDeleteTests.swift
@@ -57,6 +57,7 @@ struct TransactionHookUpdateDeleteTests {
       database: database,
       defaultInstrument: .defaultTestInstrument,
       conversionService: FixedConversionService(),
+      instrumentResolver: PerProfileInstrumentMapResolver(database: database),
       onRecordChanged: makeChangedHook(capture),
       onRecordDeleted: makeDeletedHook(capture))
 
@@ -106,6 +107,7 @@ struct TransactionHookUpdateDeleteTests {
       database: database,
       defaultInstrument: .defaultTestInstrument,
       conversionService: FixedConversionService(),
+      instrumentResolver: PerProfileInstrumentMapResolver(database: database),
       onRecordChanged: makeChangedHook(capture),
       onRecordDeleted: makeDeletedHook(capture))
 
@@ -153,6 +155,7 @@ struct TransactionHookUpdateDeleteTests {
       database: database,
       defaultInstrument: .defaultTestInstrument,
       conversionService: FixedConversionService(),
+      instrumentResolver: PerProfileInstrumentMapResolver(database: database),
       onRecordChanged: makeChangedHook(capture),
       onRecordDeleted: makeDeletedHook(capture))
 

--- a/MoolahTests/Sync/TransactionLegSyncSemanticTests.swift
+++ b/MoolahTests/Sync/TransactionLegSyncSemanticTests.swift
@@ -18,7 +18,8 @@ struct TransactionLegSyncSemanticTests {
     let txnRepo = GRDBTransactionRepository(
       database: database,
       defaultInstrument: .defaultTestInstrument,
-      conversionService: FixedConversionService())
+      conversionService: FixedConversionService(),
+      instrumentResolver: PerProfileInstrumentMapResolver(database: database))
     let legRepo = GRDBTransactionLegRepository(database: database)
     let accountId = UUID()
     let txn = try await txnRepo.create(
@@ -65,7 +66,8 @@ struct TransactionLegSyncSemanticTests {
     let txnRepo = GRDBTransactionRepository(
       database: database,
       defaultInstrument: .defaultTestInstrument,
-      conversionService: FixedConversionService())
+      conversionService: FixedConversionService(),
+      instrumentResolver: PerProfileInstrumentMapResolver(database: database))
     let legRepo = GRDBTransactionLegRepository(database: database)
     let accountId = UUID()
     let txn = try await txnRepo.create(


### PR DESCRIPTION
**Cutover PR 3 of 6** — shared-instrument-registry cutover (plan: `plans/2026-05-15-shared-instrument-registry-cutover-plan.md`). Builds on PRs #896 + #897 (both merged to `main`). Two commits.

## What
Every per-profile financial-graph repository — `GRDBTransactionRepository`, `GRDBAccountRepository`, `GRDBEarmarkRepository`, `GRDBAnalysisRepository`, `GRDBInvestmentRepository`, `DailyBalanceCompute` — now resolves its `[String: Instrument]` map via an injected `InstrumentMapResolving` fetched **before** the per-profile `database.read` snapshot (the canonical registry is a separate DB; instrument identity is immutable lookup data, so the non-atomic read is safe and intended). Observation paths resolve the map once at subscription start via a single shared `resolvedInstrumentMapStream` bridge (`Backends/GRDB/Observation/`) and no longer track `InstrumentRow.observableRegion`. Production injects the shared `GRDBInstrumentRegistryRepository`; the sync apply path + preview/test inject the transitional `PerProfileInstrumentMapResolver` (behaviour-preserving until the per-profile table is dropped in PR 6). Per-profile `fetchInstrumentMap` forwarders deleted from every cut-over repo.

## Why
The fix for the `noProviderMapping` bug class: conversion / running-balance now reads instruments from the same registry discovery enriches, instead of a per-profile placeholder table that `project()` filters out.

## Tests / benchmark
Per-repo real-GRDB resolver-sourced-resolution tests (shared registry over `ProfileIndexDatabase.openInMemory()`, per-profile table empty for the crypto id, asserting `.kind == .cryptoToken` — a fiat fallback fails the test). Observation error/cancellation discipline deterministically unit-tested (single-shot `ObservationErrorChannel` not poisoned on cancel; post-await cancel guard). Full `just test` (iOS + macOS) green. **Benchmark gate PASS** — 0 regressions, stddev <6%: instrument-resolution 1400-call cold burst 1.5 ms; transaction-page fetch / prior-balance / analysis aggregation within tolerance (added memoized resolve ≈1 µs vs 28–1034 ms ops).

Reviewed: spec, concurrency, code-guide, database-code, sync — all clean (sync findings doc-only, applied).

🤖 Generated with [Claude Code](https://claude.com/claude-code)