### PR TITLE
refactor(sync): apply path resolves/registers via the shared registry (cutover PR 5/6)

### DIFF
--- a/Backends/CloudKit/Sync/ProfileGRDBRepositories.swift
+++ b/Backends/CloudKit/Sync/ProfileGRDBRepositories.swift
@@ -49,20 +49,44 @@ extension ProfileGRDBRepositories {
   /// session-side bundle owned by `CloudKitBackend` continues to carry
   /// real values for user-mutation paths.
   ///
-  /// The `instrumentResolver` injected into each repository here is a fresh
-  /// `PerProfileInstrumentMapResolver` that is likewise never invoked by the
-  /// apply path: `applyRemoteChangesSync` writes raw Rows directly and never
-  /// calls `instrumentMap()`. The `instrumentRegistrar` is a fresh
-  /// `PerProfileInstrumentRegistrar` for the same reason — the apply path
-  /// never calls `create` / `createMany` / `update`, so `registerResolvable`
-  /// is never invoked. Do NOT rewire these to the shared registry without
-  /// first auditing every apply-path caller — the apply path currently
-  /// carries no observation and assumes both seams are no-ops.
-  static func makeForApply(database: any GRDB.DatabaseWriter) -> ProfileGRDBRepositories {
+  /// `sharedRegistry`, when supplied (production CloudKit sync always
+  /// passes `SyncCoordinator.sharedInstrumentRegistry`), is injected as
+  /// the `instrumentResolver` / `instrumentRegistrar` for every repo
+  /// that takes one. The apply path never invokes either seam today —
+  /// `applyRemoteChangesSync` writes raw Rows and never calls
+  /// `instrumentMap()`, and the apply path never calls
+  /// `create` / `createMany` / `update`, so `registerResolvable` is
+  /// never reached — but pointing the seams at the shared profile-index
+  /// registry instead of a per-profile `PerProfile*` shim guarantees
+  /// that any future apply-time resolution can never read or write the
+  /// per-profile `instrument` table that the follow-up
+  /// `v10_drop_shared_instrument_legacy` migration drops.
+  ///
+  /// When `sharedRegistry` is `nil` (preview / legacy callers / tests
+  /// that don't construct a shared registry) the `PerProfile*` shims
+  /// are kept so create→read behaviour stays byte-for-byte preserved
+  /// until that migration removes the per-profile table.
+  ///
+  /// The bundle's `instruments` member stays a per-profile
+  /// `GRDBInstrumentRegistryRepository(database:)` deliberately: its
+  /// only sync caller is `ProfileDataSyncHandler.deleteLocalData`,
+  /// which wipes a *single profile's* local rows on zone purge /
+  /// sign-out / account-switch. Pointing it at the shared, iCloud-
+  /// account-scoped registry would let one profile's zone purge wipe
+  /// every profile's instruments. The per-profile rows survive on disk
+  /// until `v10_drop_shared_instrument_legacy` drops the table.
+  static func makeForApply(
+    database: any GRDB.DatabaseWriter,
+    sharedRegistry: GRDBInstrumentRegistryRepository? = nil
+  ) -> ProfileGRDBRepositories {
     // USD is a stable, locale-independent fiat that satisfies
     // `Instrument.fiat(code:)`'s `isoCurrencies` lookup. The choice is
     // arbitrary — only the type matters for the apply path.
     let placeholderInstrument = Instrument.fiat(code: "USD")
+    let resolver: any InstrumentMapResolving =
+      sharedRegistry ?? PerProfileInstrumentMapResolver(database: database)
+    let registrar: any InstrumentRegistering =
+      sharedRegistry ?? PerProfileInstrumentRegistrar(database: database)
     return ProfileGRDBRepositories(
       csvImportProfiles: GRDBCSVImportProfileRepository(database: database),
       importRules: GRDBImportRuleRepository(database: database),
@@ -70,30 +94,30 @@ extension ProfileGRDBRepositories {
       categories: GRDBCategoryRepository(database: database),
       accounts: GRDBAccountRepository(
         database: database,
-        instrumentResolver: PerProfileInstrumentMapResolver(database: database),
-        instrumentRegistrar: PerProfileInstrumentRegistrar(database: database)),
+        instrumentResolver: resolver,
+        instrumentRegistrar: registrar),
       earmarks: GRDBEarmarkRepository(
         database: database,
         defaultInstrument: placeholderInstrument,
-        instrumentResolver: PerProfileInstrumentMapResolver(database: database)),
+        instrumentResolver: resolver),
       earmarkBudgetItems: GRDBEarmarkBudgetItemRepository(database: database),
       investmentValues: GRDBInvestmentRepository(
         database: database,
         defaultInstrument: placeholderInstrument,
-        instrumentResolver: PerProfileInstrumentMapResolver(database: database)),
+        instrumentResolver: resolver),
       transactions: GRDBTransactionRepository(
         database: database,
         defaultInstrument: placeholderInstrument,
         conversionService: ApplyPathConversionService(),
-        instrumentResolver: PerProfileInstrumentMapResolver(database: database),
-        instrumentRegistrar: PerProfileInstrumentRegistrar(database: database)),
+        instrumentResolver: resolver,
+        instrumentRegistrar: registrar),
       transactionLegs: GRDBTransactionLegRepository(database: database),
       database: database)
   }
 }
 
 /// Placeholder `InstrumentConversionService` for the apply-path bundle.
-/// Reachable only from `ProfileGRDBRepositories.makeForApply(database:)`;
+/// Reachable only from `ProfileGRDBRepositories.makeForApply`;
 /// every method throws `ConversionError.unsupportedConversion` because
 /// the apply path never reads through the conversion service. If a
 /// future code change starts invoking it from the apply path, the

--- a/Backends/CloudKit/Sync/SyncCoordinator+HandlerAccess.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+HandlerAccess.swift
@@ -9,7 +9,7 @@ extension SyncCoordinator {
   ///
   /// Bundle resolution is delegated to `resolveGRDBRepositories(for:)`, which
   /// returns a cached bundle if one was built before, or constructs a fresh
-  /// apply-path bundle via `ProfileGRDBRepositories.makeForApply(database:)` backed
+  /// apply-path bundle via `ProfileGRDBRepositories.makeForApply` backed
   /// by `containerManager.database(for:)`. This allows sync apply for
   /// un-sessionized profiles (multi-profile background apply, pre-render race,
   /// encrypted reset on an unopened profile) — the scenario that motivated
@@ -31,7 +31,7 @@ extension SyncCoordinator {
 
   /// Returns the per-profile GRDB repository bundle, constructing and caching
   /// it on first access. The bundle is built via
-  /// `ProfileGRDBRepositories.makeForApply(database:)` backed by
+  /// `ProfileGRDBRepositories.makeForApply` backed by
   /// `containerManager.database(for:)`, which allows sync apply for
   /// un-sessionized profiles — see issue #619.
   ///
@@ -46,7 +46,14 @@ extension SyncCoordinator {
       return cached
     }
     let database = try containerManager.database(for: profileId)
-    let bundle = ProfileGRDBRepositories.makeForApply(database: database)
+    // Production CloudKit sync always carries `sharedInstrumentRegistry`
+    // (the profile-index registry); the apply bundle's resolver /
+    // registrar must therefore target it, never the per-profile
+    // `instrument` table that `v10_drop_shared_instrument_legacy`
+    // drops. `nil` only for legacy callers (tests without a shared
+    // registry) — those keep the per-profile shim.
+    let bundle = ProfileGRDBRepositories.makeForApply(
+      database: database, sharedRegistry: sharedInstrumentRegistry)
     cachedGRDBRepositories[profileId] = bundle
     return bundle
   }

--- a/MoolahTests/Sync/ApplyPathSharedRegistryResolutionTests.swift
+++ b/MoolahTests/Sync/ApplyPathSharedRegistryResolutionTests.swift
@@ -1,0 +1,96 @@
+// MoolahTests/Sync/ApplyPathSharedRegistryResolutionTests.swift
+
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+/// Pins the contract that the sync apply-path repository bundle resolves
+/// and registers instruments against the SHARED profile-index registry,
+/// not the per-profile `instrument` table.
+///
+/// Earlier work moved every `InstrumentRecord` apply onto the
+/// profile-index zone (`ProfileIndexSyncHandler` + the shared registry);
+/// the per-profile `ProfileDataSyncHandler` traps/skips them. The
+/// remaining per-profile-`instrument`-table seam reachable from the
+/// apply bundle was the `instrumentResolver` / `instrumentRegistrar`
+/// injected into the txn/account/earmark/investment repos by
+/// `makeForApply`. The apply path never invokes them today (it writes
+/// raw Rows via `applyRemoteChangesSync`), but they were per-profile
+/// `PerProfile*` shims pointed at the per-profile `instrument` table —
+/// which the follow-up `v10_drop_shared_instrument_legacy` migration
+/// drops. After this cutover, when a shared registry is supplied the
+/// bundle's resolver/registrar are the shared registry, so any
+/// apply-time instrument resolution lands against the profile-index DB
+/// and never the per-profile table.
+@MainActor
+@Suite("Apply-path bundle resolves via the shared registry")
+struct ApplyPathSharedRegistryResolutionTests {
+
+  @Test(
+    "makeForApply resolver reads instruments from the shared registry, not the per-profile table")
+  func resolverUsesSharedRegistry() async throws {
+    // Two distinct databases: the per-profile DB (whose `instrument`
+    // table v10 will drop) and the shared profile-index DB.
+    let perProfile = try ProfileDatabase.openInMemory()
+    let sharedDB = try ProfileIndexDatabase.openInMemory()
+    let sharedRegistry = GRDBInstrumentRegistryRepository(database: sharedDB)
+
+    // A crypto instrument that exists ONLY in the shared registry.
+    let crypto = Instrument.crypto(
+      chainId: 1,
+      contractAddress: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+      symbol: "USDC",
+      name: "USD Coin",
+      decimals: 6)
+    try await sharedRegistry.registerCrypto(
+      crypto,
+      mapping: CryptoProviderMapping(
+        instrumentId: crypto.id,
+        coingeckoId: "usd-coin",
+        cryptocompareSymbol: "USDC",
+        binanceSymbol: nil))
+
+    let bundle = ProfileGRDBRepositories.makeForApply(
+      database: perProfile, sharedRegistry: sharedRegistry)
+
+    // All four repos resolve the crypto instrument because their injected
+    // resolver is the shared registry, not the per-profile shim.
+    let txnMap = try await bundle.transactions.instrumentResolver.instrumentMap()
+    let accountMap = try await bundle.accounts.instrumentResolver.instrumentMap()
+    let earmarkMap = try await bundle.earmarks.instrumentResolver.instrumentMap()
+    let investmentMap =
+      try await bundle.investmentValues.instrumentResolver.instrumentMap()
+    #expect(txnMap[crypto.id]?.kind == .cryptoToken)
+    #expect(accountMap[crypto.id]?.kind == .cryptoToken)
+    #expect(earmarkMap[crypto.id]?.kind == .cryptoToken)
+    #expect(investmentMap[crypto.id]?.kind == .cryptoToken)
+
+    // The per-profile `instrument` table was never read or written for
+    // this id — it stays empty.
+    let perProfileCount = try await perProfile.read { database in
+      try Int.fetchOne(database, sql: "SELECT COUNT(*) FROM instrument") ?? 0
+    }
+    #expect(perProfileCount == 0)
+  }
+
+  @Test("no shared registry (legacy/preview) keeps the per-profile shim")
+  func legacyPathKeepsPerProfileShim() async throws {
+    let perProfile = try ProfileDatabase.openInMemory()
+    let bundle = ProfileGRDBRepositories.makeForApply(
+      database: perProfile, sharedRegistry: nil)
+
+    // Seed the per-profile `instrument` table directly; the legacy
+    // shim resolver must still read it (byte-for-byte preserved until
+    // the per-profile table is dropped).
+    let row = ProfileDataSyncHandlerTestSupport.instrumentRow(
+      id: "AUD", kind: "fiatCurrency", name: "Australian Dollar")
+    try await perProfile.write { database in
+      try row.insert(database)
+    }
+
+    let map = try await bundle.transactions.instrumentResolver.instrumentMap()
+    #expect(map["AUD"] != nil)
+  }
+}


### PR DESCRIPTION
**Cutover PR 5 of 6** — shared-instrument-registry cutover (plan: `plans/2026-05-15-shared-instrument-registry-cutover-plan.md`). Builds on PRs #896/#897/#898/#900 (all merged to `main`). One commit.

## What
`ProfileGRDBRepositories.makeForApply(database:)` → `makeForApply(database:sharedRegistry:)`. Production sync now injects the shared profile-index `GRDBInstrumentRegistryRepository` as the apply bundle's `instrumentResolver`/`instrumentRegistrar` (for txn/account/earmark/investment repos) instead of the per-profile `PerProfile*` shims; `SyncCoordinator+HandlerAccess` passes `sharedInstrumentRegistry`. Legacy/preview/test (no shared registry) keep the per-profile shims byte-for-byte until the per-profile table is dropped (PR 6).

## Why / scope honesty
Phases 3–4 had already eliminated the *live* sync→per-profile-`instrument`-table data path (`applyRemoteChangesSync` is raw-Row only; `InstrumentRecord` apply moved to the profile-index zone; the per-profile handler traps/skips it). So this PR's resolver/registrar swap is **defensive hardening** — the injected seam is provably never invoked by the apply path today — guaranteeing no future apply-time resolution can reach the per-profile table.

**Deliberately NOT changed** (sync-correctness): the bundle's `instruments:` member and `ProfileDataSyncHandler.deleteLocalData()`'s per-profile `instruments.deleteAllSync()` stay per-profile — the shared registry is iCloud-account-scoped, so a single-profile zone purge / sign-out must not wipe all profiles' instruments. **PR 6 prerequisite:** when v10 drops the per-profile `instrument` table, that `deleteAllSync()` wipe entry must be removed (it would otherwise throw `no such table: instrument`); the v10 migration PR will self-fail tests if the call survives.

## Tests
`ApplyPathSharedRegistryResolutionTests` (real GRDB, deterministic): a crypto instrument registered only in the shared registry resolves via the apply bundle's transactions/accounts/earmarks/investmentValues resolvers AND the per-profile `instrument` table stays empty; the legacy nil-path still reads the per-profile shim. Full `just test` (iOS + macOS) green; format clean. Reviewed: spec + sync — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)