### PR TITLE
fix(crypto): collapse performResolution double-write into one registry write

### DIFF
--- a/Backends/GRDB/Repositories/GRDBInstrumentRegistryRepository+Upsert.swift
+++ b/Backends/GRDB/Repositories/GRDBInstrumentRegistryRepository+Upsert.swift
@@ -1,0 +1,112 @@
+// Backends/GRDB/Repositories/GRDBInstrumentRegistryRepository+Upsert.swift
+
+import Foundation
+import GRDB
+
+// The row-level upsert helpers live here, split out of
+// `GRDBInstrumentRegistryRepository.swift` so that file stays under
+// SwiftLint's `file_length` budget. They are `static` and module-scoped
+// (default `internal`) so the primary type's `register…` methods can call
+// `Self.upsertCrypto` / `Self.upsertStock` across the same-module
+// extension boundary — mirroring the `+SyncHooks` / `+Lookup` split.
+extension GRDBInstrumentRegistryRepository {
+  /// Inserts a new crypto row or updates the existing one in-place,
+  /// preserving `recordName` and `encodedSystemFields`. Mirrors
+  /// `CloudKitInstrumentRegistryRepository.upsertCrypto`.
+  ///
+  /// When `forcingStatus` is non-nil the row's `pricingStatus` is set to
+  /// that value in the same write; when nil an existing row keeps its
+  /// stored status and an insert takes the column default (`.priced`).
+  /// The forcing path lets `registerCrypto(_:mapping:forcingStatus:)`
+  /// land the mapping and a freshly-computed status in one transaction so
+  /// the sync-queue hook fires exactly once against the final state
+  /// (issue #895).
+  ///
+  /// The two branches apply the forced status differently: the
+  /// existing-row branch sets it *after* `mergeResolvedFields`, which is
+  /// safe only because that helper deliberately never writes
+  /// `pricingStatus`; the insert branch sets it during row construction,
+  /// overriding `InstrumentRow(domain:)`'s `.priced` column default
+  /// before the first `INSERT`.
+  static func upsertCrypto(
+    database: Database,
+    instrument: Instrument,
+    mapping: CryptoProviderMapping,
+    forcingStatus status: TokenPricingStatus? = nil
+  ) throws {
+    if var existing =
+      try InstrumentRow
+      .filter(InstrumentRow.Columns.id == instrument.id)
+      .fetchOne(database)
+    {
+      mergeResolvedFields(into: &existing, from: instrument, mapping: mapping)
+      if let status { existing.pricingStatus = status.rawValue }
+      try existing.update(database)
+    } else {
+      var row = InstrumentRow(domain: instrument)
+      row.coingeckoId = mapping.coingeckoId
+      row.cryptocompareSymbol = mapping.cryptocompareSymbol
+      row.binanceSymbol = mapping.binanceSymbol
+      if let status { row.pricingStatus = status.rawValue }
+      try row.insert(database)
+    }
+  }
+
+  /// Upgrade-only field merge: a nil/empty incoming column must never
+  /// downgrade a populated stored column.
+  ///
+  /// A thin ensureInstrument-style publish carries all-nil / empty identity
+  /// fields; allowing it to overwrite would destroy a richer
+  /// discovery-resolved row (e.g. Trust Wallet's ensureInstrument for
+  /// Ethereum clobbering the coingecko-resolved ticker/exchange). Every
+  /// identity column therefore requires a non-empty / non-zero incoming
+  /// value before overwriting; `kind` and `decimals` are always
+  /// authoritative and are updated unconditionally.
+  ///
+  /// Provider mapping columns are also merged: a nil incoming column must
+  /// not downgrade a populated stored column. See the shared-registry
+  /// clobber bug (Trust - Ethereum 1:native).
+  private static func mergeResolvedFields(
+    into existing: inout InstrumentRow,
+    from instrument: Instrument,
+    mapping: CryptoProviderMapping
+  ) {
+    existing.kind = instrument.kind.rawValue
+    if !instrument.name.isEmpty { existing.name = instrument.name }
+    existing.decimals = instrument.decimals
+    if let ticker = instrument.ticker, !ticker.isEmpty { existing.ticker = ticker }
+    if let exchange = instrument.exchange, !exchange.isEmpty { existing.exchange = exchange }
+    if let chainId = instrument.chainId, chainId != 0 { existing.chainId = chainId }
+    if let contractAddress = instrument.contractAddress, !contractAddress.isEmpty {
+      existing.contractAddress = contractAddress
+    }
+    existing.coingeckoId = mapping.coingeckoId ?? existing.coingeckoId
+    existing.cryptocompareSymbol = mapping.cryptocompareSymbol ?? existing.cryptocompareSymbol
+    existing.binanceSymbol = mapping.binanceSymbol ?? existing.binanceSymbol
+  }
+
+  /// Inserts a new stock row or updates the existing one in-place. Stock
+  /// upserts never touch the provider-mapping columns — they are written
+  /// only by `registerCrypto`. Mirrors
+  /// `CloudKitInstrumentRegistryRepository.upsertStock`.
+  static func upsertStock(
+    database: Database,
+    instrument: Instrument
+  ) throws {
+    if var existing =
+      try InstrumentRow
+      .filter(InstrumentRow.Columns.id == instrument.id)
+      .fetchOne(database)
+    {
+      existing.kind = instrument.kind.rawValue
+      existing.name = instrument.name
+      existing.decimals = instrument.decimals
+      existing.ticker = instrument.ticker
+      existing.exchange = instrument.exchange
+      try existing.update(database)
+    } else {
+      let row = InstrumentRow(domain: instrument)
+      try row.insert(database)
+    }
+  }
+}

--- a/Backends/GRDB/Repositories/GRDBInstrumentRegistryRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBInstrumentRegistryRepository.swift
@@ -96,9 +96,11 @@ final class GRDBInstrumentRegistryRepository:
   // MARK: - Cross-extension internals
   //
   // `attachSyncHooks` and the `fireOnRecord*` helpers live in
-  // `GRDBInstrumentRegistryRepository+SyncHooks.swift` so this file
-  // stays under SwiftLint's `file_length` / `type_body_length`
-  // thresholds. They access `hooks` directly via the `internal`
+  // `GRDBInstrumentRegistryRepository+SyncHooks.swift`, and the row-level
+  // upsert helpers (`upsertCrypto`, `upsertStock`) live in
+  // `GRDBInstrumentRegistryRepository+Upsert.swift`, so this file stays
+  // under SwiftLint's `file_length` / `type_body_length` thresholds. They
+  // access `hooks` / are called as `Self.upsert…` via the `internal`
   // visibility implied by Swift's same-module-extension scope.
 
   // MARK: - InstrumentRegistryRepository conformance
@@ -144,6 +146,27 @@ final class GRDBInstrumentRegistryRepository:
     await notifySubscribers()
   }
 
+  /// Single-write overload. See
+  /// `InstrumentRegistryRepository.registerCrypto(_:mapping:forcingStatus:)`
+  /// for the contract (one transaction, one `onRecordChanged`, issue #895).
+  func registerCrypto(
+    _ instrument: Instrument,
+    mapping: CryptoProviderMapping,
+    forcingStatus status: TokenPricingStatus
+  ) async throws {
+    precondition(instrument.kind == .cryptoToken)
+    try await database.write { database in
+      try Self.upsertCrypto(
+        database: database,
+        instrument: instrument,
+        mapping: mapping,
+        forcingStatus: status)
+    }
+    invalidateInstrumentMapCache()
+    fireOnRecordChanged(instrument.id)
+    await notifySubscribers()
+  }
+
   func registerStock(_ instrument: Instrument) async throws {
     precondition(instrument.kind == .stock)
     try await database.write { database in
@@ -172,89 +195,15 @@ final class GRDBInstrumentRegistryRepository:
     await notifySubscribers()
   }
 
-  // MARK: - Upsert helpers
-
-  /// Inserts a new crypto row or updates the existing one in-place,
-  /// preserving `recordName` and `encodedSystemFields`. Mirrors
-  /// `CloudKitInstrumentRegistryRepository.upsertCrypto`.
-  private static func upsertCrypto(
-    database: Database,
-    instrument: Instrument,
-    mapping: CryptoProviderMapping
-  ) throws {
-    if var existing =
-      try InstrumentRow
-      .filter(InstrumentRow.Columns.id == instrument.id)
-      .fetchOne(database)
-    {
-      mergeResolvedFields(into: &existing, from: instrument, mapping: mapping)
-      try existing.update(database)
-    } else {
-      var row = InstrumentRow(domain: instrument)
-      row.coingeckoId = mapping.coingeckoId
-      row.cryptocompareSymbol = mapping.cryptocompareSymbol
-      row.binanceSymbol = mapping.binanceSymbol
-      try row.insert(database)
-    }
-  }
-
-  /// Upgrade-only field merge: a nil/empty incoming column must never
-  /// downgrade a populated stored column.
-  ///
-  /// A thin ensureInstrument-style publish carries all-nil / empty identity
-  /// fields; allowing it to overwrite would destroy a richer
-  /// discovery-resolved row (e.g. Trust Wallet's ensureInstrument for
-  /// Ethereum clobbering the coingecko-resolved ticker/exchange). Every
-  /// identity column therefore requires a non-empty / non-zero incoming
-  /// value before overwriting; `kind` and `decimals` are always
-  /// authoritative and are updated unconditionally.
-  ///
-  /// Provider mapping columns are also merged: a nil incoming column must
-  /// not downgrade a populated stored column. See the shared-registry
-  /// clobber bug (Trust - Ethereum 1:native).
-  private static func mergeResolvedFields(
-    into existing: inout InstrumentRow,
-    from instrument: Instrument,
-    mapping: CryptoProviderMapping
-  ) {
-    existing.kind = instrument.kind.rawValue
-    if !instrument.name.isEmpty { existing.name = instrument.name }
-    existing.decimals = instrument.decimals
-    if let ticker = instrument.ticker, !ticker.isEmpty { existing.ticker = ticker }
-    if let exchange = instrument.exchange, !exchange.isEmpty { existing.exchange = exchange }
-    if let chainId = instrument.chainId, chainId != 0 { existing.chainId = chainId }
-    if let contractAddress = instrument.contractAddress, !contractAddress.isEmpty {
-      existing.contractAddress = contractAddress
-    }
-    existing.coingeckoId = mapping.coingeckoId ?? existing.coingeckoId
-    existing.cryptocompareSymbol = mapping.cryptocompareSymbol ?? existing.cryptocompareSymbol
-    existing.binanceSymbol = mapping.binanceSymbol ?? existing.binanceSymbol
-  }
-
-  /// Inserts a new stock row or updates the existing one in-place. Stock
-  /// upserts never touch the provider-mapping columns — they are written
-  /// only by `registerCrypto`. Mirrors
-  /// `CloudKitInstrumentRegistryRepository.upsertStock`.
-  private static func upsertStock(
-    database: Database,
-    instrument: Instrument
-  ) throws {
-    if var existing =
-      try InstrumentRow
-      .filter(InstrumentRow.Columns.id == instrument.id)
-      .fetchOne(database)
-    {
-      existing.kind = instrument.kind.rawValue
-      existing.name = instrument.name
-      existing.decimals = instrument.decimals
-      existing.ticker = instrument.ticker
-      existing.exchange = instrument.exchange
-      try existing.update(database)
-    } else {
-      let row = InstrumentRow(domain: instrument)
-      try row.insert(database)
-    }
-  }
+  // MARK: - Upsert helpers (see GRDBInstrumentRegistryRepository+Upsert.swift)
+  //
+  // The row-level upsert helpers (`upsertCrypto`, `mergeResolvedFields`,
+  // `upsertStock`) live in the sibling
+  // `GRDBInstrumentRegistryRepository+Upsert.swift` extension file so this
+  // file stays under SwiftLint's `file_length` budget. They are `static`
+  // and module-scoped so the `register…` methods above can call
+  // `Self.upsertCrypto` / `Self.upsertStock` across the extension
+  // boundary — same split rationale as `+SyncHooks` / `+Lookup`.
 
   // MARK: - Change fan-out
 

--- a/Domain/Repositories/InstrumentRegistryRepository.swift
+++ b/Domain/Repositories/InstrumentRegistryRepository.swift
@@ -45,6 +45,29 @@ protocol InstrumentRegistryRepository: InstrumentChangeObserving {
     _ instrument: Instrument, mapping: CryptoProviderMapping
   ) async throws
 
+  /// Registers (or upserts) a crypto instrument with its provider
+  /// mapping **and** sets `pricingStatus` to `status` — all in a single
+  /// backing-store write, so the implementation's sync-queue hook fires
+  /// exactly once against the final committed state.
+  ///
+  /// Differs from `registerCrypto(_:mapping:)`, which preserves an
+  /// existing row's `pricingStatus` (defaulting to `.priced` only on
+  /// insert) and therefore needs a follow-up `update(_:)` whenever the
+  /// caller has a freshly-computed status to enforce. The
+  /// discovery/resolution path (`CryptoTokenDiscoveryService`
+  /// `.performResolution`) routes through this overload so a newly
+  /// discovered token never produces two `onRecordChanged` fan-outs and
+  /// never exposes the narrow window where CKSyncEngine could upload the
+  /// row carrying a stale status. See issue #895.
+  ///
+  /// - Precondition: `instrument.kind == .cryptoToken`. Passing any other
+  ///   kind is a programmer error and traps.
+  func registerCrypto(
+    _ instrument: Instrument,
+    mapping: CryptoProviderMapping,
+    forcingStatus status: TokenPricingStatus
+  ) async throws
+
   /// Registers (or upserts) a stock instrument. Stock rows carry no
   /// provider-mapping fields; Yahoo's lookup key is the instrument's own
   /// ticker. Invokes the implementation's sync-queue hook after a

--- a/Features/Settings/DiscoveredTokensInboxView.swift
+++ b/Features/Settings/DiscoveredTokensInboxView.swift
@@ -128,7 +128,8 @@ struct DiscoveredTokensInboxView: View {
       }
       do {
         _ = try await tokenDiscovery.reResolve(registration, chain: chain)
-        // The actor's `reResolve` calls `registry.update(_:)` on the
+        // The actor's `reResolve` calls
+        // `registry.registerCrypto(_:mapping:forcingStatus:)` on the
         // shared repository, but the store's in-memory copy doesn't
         // see those mutations. Refresh the local cache so the row
         // disappears from the inbox once the status flips.

--- a/MoolahTests/Backends/GRDB/GRDBInstrumentRegistryRollbackTests.swift
+++ b/MoolahTests/Backends/GRDB/GRDBInstrumentRegistryRollbackTests.swift
@@ -86,4 +86,99 @@ struct GRDBInstrumentRegistryRollbackTests {
     #expect(try registry.fetchRowSync(id: "___FAIL___") == nil)
     #expect(try registry.allRowIdsSync() == [priorId])
   }
+
+  /// `registerCrypto(_:mapping:forcingStatus:)` does a fetch + UPDATE (or
+  /// INSERT) inside one `database.write`. A `BEFORE UPDATE` trigger that
+  /// aborts the existing-row UPDATE forces the throw mid-transaction, so
+  /// the pre-seeded status and mapping must survive byte-equal. The
+  /// post-write side effects (`fireOnRecordChanged` / `notifySubscribers`)
+  /// cannot run because `try await database.write` rethrows first — that
+  /// is what keeps a failed write from queuing a CKSyncEngine save.
+  @Test
+  func registerCryptoForcingStatusRollsBackOnFailure() async throws {
+    let database = try ProfileIndexDatabase.openInMemory()
+    let registry = GRDBInstrumentRegistryRepository(database: database)
+    let eth = Instrument.crypto(
+      chainId: 1, contractAddress: nil, symbol: "ETH", name: "Ethereum",
+      decimals: 18)
+    try await registry.registerCrypto(
+      eth,
+      mapping: CryptoProviderMapping(
+        instrumentId: eth.id, coingeckoId: "ethereum",
+        cryptocompareSymbol: nil, binanceSymbol: nil),
+      forcingStatus: .spam)
+
+    try await database.write { database in
+      try database.execute(
+        sql: """
+          CREATE TRIGGER fail_instrument_update
+          BEFORE UPDATE ON instrument
+          WHEN NEW.id = '\(eth.id)'
+          BEGIN
+              SELECT RAISE(ABORT, 'forced failure for rollback test');
+          END;
+          """)
+    }
+
+    do {
+      try await registry.registerCrypto(
+        eth,
+        mapping: CryptoProviderMapping(
+          instrumentId: eth.id, coingeckoId: "MUST-NOT-LAND",
+          cryptocompareSymbol: "MUST-NOT-LAND", binanceSymbol: nil),
+        forcingStatus: .priced)
+      Issue.record("registerCrypto(forcingStatus:) should have thrown")
+    } catch {
+      // Expected — trigger raises ABORT mid-transaction.
+    }
+
+    let surviving = try #require(try registry.fetchRowSync(id: eth.id))
+    #expect(surviving.pricingStatus == TokenPricingStatus.spam.rawValue)
+    #expect(surviving.coingeckoId == "ethereum")
+  }
+
+  /// Same rollback contract for the plain `registerCrypto(_:mapping:)`
+  /// overload — it shares the same fetch + UPDATE upsert path, so a
+  /// failed write must leave the prior status and mapping unchanged.
+  @Test
+  func registerCryptoPlainRollsBackOnFailure() async throws {
+    let database = try ProfileIndexDatabase.openInMemory()
+    let registry = GRDBInstrumentRegistryRepository(database: database)
+    let eth = Instrument.crypto(
+      chainId: 1, contractAddress: nil, symbol: "ETH", name: "Ethereum",
+      decimals: 18)
+    try await registry.registerCrypto(
+      eth,
+      mapping: CryptoProviderMapping(
+        instrumentId: eth.id, coingeckoId: "ethereum",
+        cryptocompareSymbol: nil, binanceSymbol: nil),
+      forcingStatus: .spam)
+
+    try await database.write { database in
+      try database.execute(
+        sql: """
+          CREATE TRIGGER fail_instrument_update
+          BEFORE UPDATE ON instrument
+          WHEN NEW.id = '\(eth.id)'
+          BEGIN
+              SELECT RAISE(ABORT, 'forced failure for rollback test');
+          END;
+          """)
+    }
+
+    do {
+      try await registry.registerCrypto(
+        eth,
+        mapping: CryptoProviderMapping(
+          instrumentId: eth.id, coingeckoId: "MUST-NOT-LAND",
+          cryptocompareSymbol: "MUST-NOT-LAND", binanceSymbol: nil))
+      Issue.record("registerCrypto(_:mapping:) should have thrown")
+    } catch {
+      // Expected — trigger raises ABORT mid-transaction.
+    }
+
+    let surviving = try #require(try registry.fetchRowSync(id: eth.id))
+    #expect(surviving.pricingStatus == TokenPricingStatus.spam.rawValue)
+    #expect(surviving.coingeckoId == "ethereum")
+  }
 }

--- a/MoolahTests/Backends/GRDB/GRDBInstrumentRegistryUpsertMergeTests.swift
+++ b/MoolahTests/Backends/GRDB/GRDBInstrumentRegistryUpsertMergeTests.swift
@@ -168,4 +168,32 @@ struct GRDBInstrumentRegistryUpsertMergeTests {
         binanceSymbol: nil))
     #expect(try registry.fetchRowSync(id: eth.id)?.encodedSystemFields == blob)
   }
+
+  @Test("registerCrypto(forcingStatus:) preserves encodedSystemFields on the UPDATE path")
+  func forcingStatusPreservesEncodedSystemFields() async throws {
+    // The forcing overload's UPDATE branch fetches the full stored row,
+    // merges resolved fields, sets `pricingStatus`, and writes it back.
+    // The CloudKit change-tag (`encodedSystemFields`) must ride through
+    // untouched — otherwise every discovery-driven status flip would
+    // provoke a `serverRecordChanged` conflict on the next upload.
+    let registry = try makeRegistry()
+    try await registry.registerCrypto(
+      eth,
+      mapping: CryptoProviderMapping(
+        instrumentId: eth.id, coingeckoId: "ethereum", cryptocompareSymbol: nil,
+        binanceSymbol: nil))
+    let blob = Data([0xCA, 0xFE, 0xBA, 0xBE])
+    _ = try registry.setEncodedSystemFieldsSync(id: eth.id, data: blob)
+
+    try await registry.registerCrypto(
+      eth,
+      mapping: CryptoProviderMapping(
+        instrumentId: eth.id, coingeckoId: "ethereum", cryptocompareSymbol: "ETH",
+        binanceSymbol: nil),
+      forcingStatus: .spam)
+
+    let row = try #require(try registry.fetchRowSync(id: eth.id))
+    #expect(row.encodedSystemFields == blob)
+    #expect(row.pricingStatus == TokenPricingStatus.spam.rawValue)
+  }
 }

--- a/MoolahTests/Domain/InstrumentRegistryContractTests.swift
+++ b/MoolahTests/Domain/InstrumentRegistryContractTests.swift
@@ -114,6 +114,112 @@ struct InstrumentRegistryContractTests {
     #expect(regs.first?.mapping.binanceSymbol == "ETHUSDT")
   }
 
+  @Test("registerCrypto(forcingStatus:) inserts a new row with the forced status + mapping")
+  func registerCryptoForcingStatusInserts() async throws {
+    let subject = try makeSubject()
+    let repo = subject.repo
+    let hooks = subject.hooks
+    let eth = Instrument.crypto(
+      chainId: 1, contractAddress: nil, symbol: "ETH",
+      name: "Ethereum", decimals: 18)
+    let mapping = CryptoProviderMapping(
+      instrumentId: eth.id,
+      coingeckoId: "ethereum", cryptocompareSymbol: nil, binanceSymbol: nil)
+
+    try await repo.registerCrypto(eth, mapping: mapping, forcingStatus: .unpriced)
+
+    let regs = try await repo.allCryptoRegistrations()
+    let reg = try #require(regs.first { $0.id == eth.id })
+    // The forced status must win over the column default (`.priced`),
+    // and the mapping must round-trip in the same write.
+    #expect(reg.pricingStatus == .unpriced)
+    #expect(reg.mapping.coingeckoId == "ethereum")
+
+    // The whole point of #895: exactly one onRecordChanged fan-out for
+    // the single backing-store write — never two. The count-of-one
+    // assertion below is the test of record for the issue.
+    //
+    // Drain pending @MainActor hops from the sync-queue hook closures.
+    // Not strictly deterministic — the closure dispatches via
+    // `Task { @MainActor … }`, so the 50ms is a best-effort drain, not a
+    // barrier. If CI flakes, make the hooks async/awaitable so this can
+    // `await` them directly rather than tightening the sleep.
+    try await Task.sleep(for: .milliseconds(50))
+    #expect(hooks.changedIds == [eth.id])
+  }
+
+  @Test("registerCrypto(forcingStatus:) overwrites an existing row's mapping + status in one write")
+  func registerCryptoForcingStatusUpserts() async throws {
+    let subject = try makeSubject()
+    let repo = subject.repo
+    let hooks = subject.hooks
+    let eth = Instrument.crypto(
+      chainId: 1, contractAddress: nil, symbol: "ETH",
+      name: "Ethereum", decimals: 18)
+    // Seed an existing row via the plain upsert (defaults to `.priced`).
+    try await repo.registerCrypto(
+      eth,
+      mapping: CryptoProviderMapping(
+        instrumentId: eth.id, coingeckoId: "old", cryptocompareSymbol: nil,
+        binanceSymbol: nil))
+    try await Task.sleep(for: .milliseconds(50))
+    hooks.changedIds.removeAll()
+
+    try await repo.registerCrypto(
+      eth,
+      mapping: CryptoProviderMapping(
+        instrumentId: eth.id, coingeckoId: "new", cryptocompareSymbol: "ETH",
+        binanceSymbol: nil),
+      forcingStatus: .spam)
+
+    let regs = try await repo.allCryptoRegistrations()
+    #expect(regs.count == 1)
+    let reg = try #require(regs.first { $0.id == eth.id })
+    #expect(reg.pricingStatus == .spam)
+    #expect(reg.mapping.coingeckoId == "new")
+    #expect(reg.mapping.cryptocompareSymbol == "ETH")
+
+    // Still exactly one fan-out for the upsert call — the stale-status
+    // window the issue describes cannot exist. Not strictly
+    // deterministic (see `registerCryptoForcingStatusInserts` for the
+    // same @MainActor-hop drain caveat); make the hooks awaitable if CI
+    // flakes here.
+    try await Task.sleep(for: .milliseconds(50))
+    #expect(hooks.changedIds == [eth.id])
+  }
+
+  @Test("plain registerCrypto(_:mapping:) preserves an existing row's pricingStatus")
+  func registerCryptoPreservesStatusOnUpsert() async throws {
+    // Load-bearing invariant: `registerCrypto(_:mapping:forcingStatus:)`
+    // exists precisely because the plain overload must NOT change a
+    // stored status. If a future `mergeResolvedFields` refactor started
+    // writing `pricingStatus`, the discovery path's status decision
+    // would silently leak into unrelated mapping-only re-registers.
+    let repo = try makeSubject().repo
+    let eth = Instrument.crypto(
+      chainId: 1, contractAddress: nil, symbol: "ETH",
+      name: "Ethereum", decimals: 18)
+    // Establish a non-default stored status via the forcing overload.
+    try await repo.registerCrypto(
+      eth,
+      mapping: CryptoProviderMapping(
+        instrumentId: eth.id, coingeckoId: "ethereum",
+        cryptocompareSymbol: nil, binanceSymbol: nil),
+      forcingStatus: .spam)
+
+    // A plain mapping-only re-register must leave `.spam` intact.
+    try await repo.registerCrypto(
+      eth,
+      mapping: CryptoProviderMapping(
+        instrumentId: eth.id, coingeckoId: "ethereum",
+        cryptocompareSymbol: "ETH", binanceSymbol: nil))
+
+    let regs = try await repo.allCryptoRegistrations()
+    let reg = try #require(regs.first { $0.id == eth.id })
+    #expect(reg.pricingStatus == .spam)
+    #expect(reg.mapping.cryptocompareSymbol == "ETH")
+  }
+
   @Test("allCryptoRegistrations skips rows whose three mapping fields are all nil")
   func allCryptoSkipsMissingMapping() async throws {
     let subject = try makeSubject()

--- a/MoolahTests/Features/CryptoTokenStoreTests.swift
+++ b/MoolahTests/Features/CryptoTokenStoreTests.swift
@@ -150,6 +150,11 @@ private struct FailingRegistry: InstrumentRegistryRepository, @unchecked Sendabl
   func registerCrypto(
     _ instrument: Instrument, mapping: CryptoProviderMapping
   ) async throws { throw BoomError() }
+  func registerCrypto(
+    _ instrument: Instrument,
+    mapping: CryptoProviderMapping,
+    forcingStatus status: TokenPricingStatus
+  ) async throws { throw BoomError() }
   func registerStock(_ instrument: Instrument) async throws { throw BoomError() }
   func update(_ registration: CryptoRegistration) async throws { throw BoomError() }
   func remove(id: String) async throws { throw BoomError() }

--- a/MoolahTests/Shared/CryptoImport/CryptoTokenDiscoveryServiceTests.swift
+++ b/MoolahTests/Shared/CryptoImport/CryptoTokenDiscoveryServiceTests.swift
@@ -38,6 +38,34 @@ struct CryptoTokenDiscoveryServiceTests {
     #expect(stored?.mapping.coingeckoId == "usd-coin")
   }
 
+  @Test("performResolution persists the final state in a single registry write (#895)")
+  func performResolutionSingleWrite() async throws {
+    let subject = makeDiscoverySubject()
+    // Scripting the resolver to fail yields `.unpriced`, which differs
+    // from the upsert's would-be default (`.priced`) — the exact
+    // condition that drove the old `registerCrypto` + `update`
+    // double-write.
+    struct ProviderFailed: Error {}
+    subject.resolver.script(
+      .init(chainId: 1, contractAddress: Self.usdcAddress.lowercased()),
+      .failure(ProviderFailed()))
+
+    let registration = try await subject.service.resolveOrLoad(
+      chain: .ethereum,
+      contractAddress: Self.usdcAddress,
+      symbol: "USDC",
+      name: "USD Coin",
+      decimals: 6)
+
+    #expect(registration.pricingStatus == .unpriced)
+    let snapshot = subject.registry.snapshot()
+    // Exactly one registry write, carrying the final status — never a
+    // follow-up `update(_:)`.
+    #expect(snapshot.registeredCryptos.count == 1)
+    #expect(snapshot.registeredCryptos.first?.pricingStatus == .unpriced)
+    #expect(snapshot.updateCallCount == 0)
+  }
+
   @Test("isSpam metadata wins over a successful provider resolution")
   func spamWinsOverResolution() async throws {
     let subject = makeDiscoverySubject()

--- a/MoolahTests/Support/StubInstrumentRegistry.swift
+++ b/MoolahTests/Support/StubInstrumentRegistry.swift
@@ -19,6 +19,11 @@ final class StubInstrumentRegistry: InstrumentRegistryRepository, Sendable {
     var registeredCryptos: [CryptoRegistration]
     var removedIds: [String]
     var shouldThrowOnRegister: Bool
+    /// Number of `update(_:)` calls. Lets tests assert that a flow
+    /// reached the registry in a single write (e.g. #895's
+    /// `performResolution` routing through `registerCrypto(forcingStatus:)`
+    /// instead of `registerCrypto` + `update`).
+    var updateCallCount: Int = 0
   }
 
   /// Errors thrown by the stub when `shouldThrowOnRegister` is set. Lets
@@ -82,6 +87,23 @@ extension StubInstrumentRegistry {
     }
   }
 
+  func registerCrypto(
+    _ instrument: Instrument,
+    mapping: CryptoProviderMapping,
+    forcingStatus status: TokenPricingStatus
+  ) async throws {
+    try state.withLock { state in
+      if state.shouldThrowOnRegister { throw RegisterError.cryptoFailed }
+      let registration = CryptoRegistration(
+        instrument: instrument, mapping: mapping, pricingStatus: status)
+      state.registeredCryptos.append(registration)
+      state.cryptoRegistrations.removeAll { $0.id == registration.id }
+      state.cryptoRegistrations.append(registration)
+      state.instruments.removeAll { $0.id == instrument.id }
+      state.instruments.append(instrument)
+    }
+  }
+
   func registerStock(_ instrument: Instrument) async throws {
     try state.withLock { state in
       if state.shouldThrowOnRegister { throw RegisterError.stockFailed }
@@ -94,6 +116,7 @@ extension StubInstrumentRegistry {
   func update(_ registration: CryptoRegistration) async throws {
     try state.withLock { state in
       if state.shouldThrowOnRegister { throw RegisterError.updateFailed }
+      state.updateCallCount += 1
       guard
         let index = state.cryptoRegistrations.firstIndex(where: { $0.id == registration.id })
       else { return }

--- a/Shared/CryptoImport/CryptoTokenDiscoveryService.swift
+++ b/Shared/CryptoImport/CryptoTokenDiscoveryService.swift
@@ -151,19 +151,17 @@ actor CryptoTokenDiscoveryService {
       mapping: mapping,
       pricingStatus: status)
 
-    // `registerCrypto` upserts the mapping but preserves the prior
-    // `pricingStatus` on an existing row (default `.priced` only on
-    // insert). When the resolved status differs from what the upsert
-    // would leave behind, follow up with `update(_:)` to enforce this
-    // discovery pass's decision. Read the prior row once so the check is
-    // a single registry round-trip rather than two.
-    let priorStatus = try await registry.cryptoRegistration(
-      byId: instrument.id)?.pricingStatus
-    try await registry.registerCrypto(instrument, mapping: mapping)
-    let upsertedStatus: TokenPricingStatus = priorStatus ?? .priced
-    if upsertedStatus != status {
-      try await registry.update(registration)
-    }
+    // Land the mapping and this discovery pass's status decision in a
+    // single registry write. The plain `registerCrypto(_:mapping:)`
+    // preserves an existing row's `pricingStatus` (default `.priced`
+    // only on insert), so enforcing a freshly-computed status used to
+    // need a follow-up `update(_:)` — two writes, two `onRecordChanged`
+    // fan-outs, and a narrow window where CKSyncEngine could upload the
+    // row with a stale status. `forcingStatus:` collapses that to one
+    // write that fires the hook exactly once against the final state
+    // (issue #895).
+    try await registry.registerCrypto(
+      instrument, mapping: mapping, forcingStatus: status)
 
     return registration
   }


### PR DESCRIPTION
## Summary

Closes #895.

`CryptoTokenDiscoveryService.performResolution` wrote a newly discovered token twice: `registerCrypto(_:mapping:)` (which preserves an existing row's `pricingStatus`, defaulting to `.priced` only on insert) followed by a conditional `update(_:)` to enforce the resolved status. That produced **two `onRecordChanged` fan-outs per new token** (inflating the CKSyncEngine pending-uploads mirror / state file under concurrent discovery) and a **narrow race**: a sync batch built in the window between the two writes could upload the row carrying a stale `pricingStatus` until the next sync reconciled it.

### Fix

- New protocol method `InstrumentRegistryRepository.registerCrypto(_:mapping:forcingStatus:)` — merges the mapping **and** sets `pricingStatus` in a single `database.write`, so the sync-queue hook fires **exactly once** against the final committed state.
- `performResolution` now routes through it (one `await`, no prior-status read, no follow-up `update(_:)`).
- Behaviour is otherwise unchanged — this is write-coalescing only; the net committed state was already `status` before and after (issue notes it is pre-existing behaviour).
- GRDB upsert helpers (`upsertCrypto` / `mergeResolvedFields` / `upsertStock`) extracted to a sibling `GRDBInstrumentRegistryRepository+Upsert.swift` to stay under the SwiftLint `file_length` budget (same split rationale as `+SyncHooks` / `+Lookup`).

### Tests

- Contract tests: forced status on insert and upsert, each asserting a single `onRecordChanged` fan-out.
- Service-level test: `performResolution` issues exactly one registry write and never calls `update(_:)`.
- Rollback contracts for **both** `registerCrypto` overloads (multi-statement write must roll back atomically — DATABASE_CODE_GUIDE §5).
- `encodedSystemFields` preservation test for the forcing UPDATE path (no spurious change-tag loss → no `serverRecordChanged` conflict).
- A test pinning the load-bearing invariant that the plain overload still preserves a stored status.

### Verification

- `just format-check` clean.
- Full macOS suite green: **2822 tests / 479 suites passed**.
- Reviewed by `code-review`, `concurrency-review`, `database-code-review`, `sync-review`; all findings (incl. a stale comment in `DiscoveredTokensInboxView`) applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)