### PR TITLE
refactor(instruments): remove dead onInstrumentChanged hook plumbing (#899)

### DIFF
--- a/App/ProfileSession+CloudKitBackendBuild.swift
+++ b/App/ProfileSession+CloudKitBackendBuild.swift
@@ -1,7 +1,6 @@
 import CloudKit
 import Foundation
 import GRDB
-import OSLog
 
 extension ProfileSession {
   /// Bundle of the three market-data services consumed by the CloudKit
@@ -103,80 +102,8 @@ extension ProfileSession {
         onTransactionChanged: hooks.changed,
         onTransactionDeleted: hooks.deleted,
         onTransactionLegChanged: hooks.changed,
-        onTransactionLegDeleted: hooks.deleted,
-        onInstrumentChanged: makeInstrumentChangedHook(
-          syncCoordinator: syncCoordinator))
+        onTransactionLegDeleted: hooks.deleted)
     )
-  }
-
-  /// Builds the closure `GRDBTransactionRepository` /
-  /// `GRDBAccountRepository` fire whenever they auto-insert a non-fiat
-  /// `InstrumentRow` to satisfy a leg or account denomination. Routes
-  /// through the **shared** registry's `registerStock` /
-  /// `registerCrypto`, which writes to the profile-index DB and queues
-  /// the upload to the profile-index zone — never to a per-profile
-  /// zone. Without this, an instrument introduced by SelfWealth import
-  /// or a stock-account create would live only on the device that
-  /// wrote it (sibling devices fall back to `Instrument.fiat(code:
-  /// id)` and stock conversions 404 against the fiat-only Frankfurter
-  /// API). Returns a no-op closure when no shared registry is wired
-  /// (preview / legacy-test backends without `SharedInstrumentScope`).
-  private static func makeInstrumentChangedHook(
-    syncCoordinator: SyncCoordinator?
-  ) -> @Sendable (Instrument) -> Void {
-    { [weak syncCoordinator] instrument in
-      // Fiat doesn't go through the registry; defensively no-op even
-      // though `ensureInstrumentReadable` already filters fiat out.
-      guard instrument.kind != .fiatCurrency else { return }
-      Task { [weak syncCoordinator] in
-        guard let registry = syncCoordinator?.sharedInstrumentRegistry else { return }
-        await Self.publishToSharedRegistry(instrument: instrument, registry: registry)
-      }
-    }
-  }
-
-  /// Publishes an auto-inserted `Instrument` to the shared registry.
-  /// Stocks go through `registerStock`; crypto rows go through
-  /// `registerCrypto` with an empty provider mapping (the discovery
-  /// service fills the mapping in later via `resolveOrLoad`). Both
-  /// register methods are idempotent — they upsert by id and preserve
-  /// existing system fields, so a redundant publish from
-  /// `ensureInstrumentReadable` after the row already reached the
-  /// shared zone is a no-op merge.
-  private static func publishToSharedRegistry(
-    instrument: Instrument,
-    registry: GRDBInstrumentRegistryRepository
-  ) async {
-    do {
-      switch instrument.kind {
-      case .stock:
-        try await registry.registerStock(instrument)
-      case .cryptoToken:
-        try await registry.registerCrypto(
-          instrument,
-          mapping: CryptoProviderMapping(
-            instrumentId: instrument.id,
-            coingeckoId: nil,
-            cryptocompareSymbol: nil,
-            binanceSymbol: nil))
-      case .fiatCurrency:
-        // Filtered out at the call site; defensive no-op.
-        return
-      }
-    } catch {
-      // Best-effort publish — a failure here leaves the per-profile
-      // copy intact and the next session boot's self-heal scan
-      // (`SyncCoordinator.queueUnsyncedSharedInstruments`) re-attempts
-      // upload. Logging keeps the failure observable without breaking
-      // the surrounding write.
-      Logger(subsystem: "com.moolah.app", category: "ProfileSession")
-        .warning(
-          """
-          Shared-registry publish failed for \(instrument.id, privacy: .public): \
-          \(error.localizedDescription, privacy: .public)
-          """
-        )
-    }
   }
 
   /// Bundle of the change/delete closures the GRDB repos call on each

--- a/Backends/CloudKit/CloudKitBackend.swift
+++ b/Backends/CloudKit/CloudKitBackend.swift
@@ -65,15 +65,6 @@ final class CloudKitBackend: BackendProvider, @unchecked Sendable {
     let onTransactionDeleted: @Sendable (String, UUID) -> Void
     let onTransactionLegChanged: @Sendable (String, UUID) -> Void
     let onTransactionLegDeleted: @Sendable (String, UUID) -> Void
-    /// Fires when an account / transaction write auto-inserts a non-fiat
-    /// `InstrumentRow` to satisfy a leg or account denomination.
-    /// Carries the full `Instrument` value so the production hook can
-    /// publish it to the shared registry (`registerStock` /
-    /// `registerCrypto`). The registry's own register paths fire a
-    /// separate hook on shared-DB writes, so this surface only covers
-    /// the auto-insert path inside the transaction / account
-    /// repositories.
-    let onInstrumentChanged: @Sendable (Instrument) -> Void
 
     static let noop = CloudKitBackendHooks(
       onCSVImportProfileChanged: { _, _ in },
@@ -93,8 +84,7 @@ final class CloudKitBackend: BackendProvider, @unchecked Sendable {
       onTransactionChanged: { _, _ in },
       onTransactionDeleted: { _, _ in },
       onTransactionLegChanged: { _, _ in },
-      onTransactionLegDeleted: { _, _ in },
-      onInstrumentChanged: { (_: Instrument) in })
+      onTransactionLegDeleted: { _, _ in })
   }
 
   init(
@@ -241,8 +231,7 @@ final class CloudKitBackend: BackendProvider, @unchecked Sendable {
         instrumentResolver: resolver,
         instrumentRegistrar: instrumentSeams.registrar,
         onRecordChanged: hooks.onAccountChanged,
-        onRecordDeleted: hooks.onAccountDeleted,
-        onInstrumentChanged: hooks.onInstrumentChanged),
+        onRecordDeleted: hooks.onAccountDeleted),
       transactions: GRDBTransactionRepository(
         database: database,
         defaultInstrument: instrument,
@@ -250,8 +239,7 @@ final class CloudKitBackend: BackendProvider, @unchecked Sendable {
         instrumentResolver: resolver,
         instrumentRegistrar: instrumentSeams.registrar,
         onRecordChanged: hooks.onTransactionChanged,
-        onRecordDeleted: hooks.onTransactionDeleted,
-        onInstrumentChanged: hooks.onInstrumentChanged),
+        onRecordDeleted: hooks.onTransactionDeleted),
       earmarks: GRDBEarmarkRepository(
         database: database,
         defaultInstrument: instrument,

--- a/Backends/CloudKit/Sync/ProfileDataSyncHandler+ApplyRemoteChanges.swift
+++ b/Backends/CloudKit/Sync/ProfileDataSyncHandler+ApplyRemoteChanges.swift
@@ -144,8 +144,8 @@ extension ProfileDataSyncHandler {
     // from a not-yet-upgraded peer device is silently logged and
     // skipped by `applyBatchSaveInstrument` / `applyGRDBBatchDeletion`
     // — never applied to the per-profile `instrument` table that the
-    // follow-up `v10_drop_shared_instrument_legacy` migration will
-    // drop. No UI consumer reads from that table anymore.
+    // `v10_drop_shared_instrument_legacy` migration removed. No UI
+    // consumer reads from that table anymore.
     return .success(changedTypes: changedTypes)
   }
 

--- a/Backends/CloudKit/Sync/ProfileDataSyncHandler+QueueAndDelete.swift
+++ b/Backends/CloudKit/Sync/ProfileDataSyncHandler+QueueAndDelete.swift
@@ -216,9 +216,9 @@ extension ProfileDataSyncHandler {
       // iCloud-account-scoped profile-index registry, and a
       // single-profile purge (sign-out / account-switch / zone purge)
       // must NOT wipe instruments shared by every other profile. The
-      // per-profile `instrument` table is also about to be removed by
-      // the `v10_drop_shared_instrument_legacy` migration, after which
-      // a `deleteAllSync` against it would throw `no such table`.
+      // per-profile `instrument` table was also removed by the
+      // `v10_drop_shared_instrument_legacy` migration, so a
+      // `deleteAllSync` against it would throw `no such table`.
       (CategoryRow.recordType, { try self.grdbRepositories.categories.deleteAllSync() }),
       (AccountRow.recordType, { try self.grdbRepositories.accounts.deleteAllSync() }),
       (EarmarkRow.recordType, { try self.grdbRepositories.earmarks.deleteAllSync() }),

--- a/Backends/CloudKit/Sync/ProfileDataSyncHandler+SystemFields.swift
+++ b/Backends/CloudKit/Sync/ProfileDataSyncHandler+SystemFields.swift
@@ -26,8 +26,8 @@ extension ProfileDataSyncHandler {
     // `queueAllExistingRecords()` no longer enumerates them — clearing
     // the field on encrypted-data-reset would leave the table in a
     // spuriously "unsynced" state with no upload path to resolve it.
-    // The follow-up `v10_drop_shared_instrument_legacy` migration
-    // drops the table entirely.
+    // The `v10_drop_shared_instrument_legacy` migration has since
+    // dropped the table entirely.
     [
       (CategoryRow.recordType, grdbRepositories.categories.clearAllSystemFieldsSync),
       (AccountRow.recordType, grdbRepositories.accounts.clearAllSystemFieldsSync),

--- a/Backends/CloudKit/Sync/ProfileGRDBRepositories.swift
+++ b/Backends/CloudKit/Sync/ProfileGRDBRepositories.swift
@@ -60,10 +60,10 @@ extension ProfileGRDBRepositories {
   /// never reached — but pointing the seams at the shared profile-index
   /// registry guarantees that any future apply-time resolution can
   /// never read or write the per-profile `instrument` table that the
-  /// follow-up `v10_drop_shared_instrument_legacy` migration drops.
+  /// `v10_drop_shared_instrument_legacy` migration removed.
   /// There is no longer a per-profile fallback: the `PerProfile*`
   /// shims have been removed because no production or test path may
-  /// read the soon-to-be-dropped per-profile `instrument` table.
+  /// read the now-removed per-profile `instrument` table.
   ///
   /// The bundle's `instruments` member stays a per-profile
   /// `GRDBInstrumentRegistryRepository(database:)` deliberately: its
@@ -71,8 +71,8 @@ extension ProfileGRDBRepositories {
   /// clearing on zone purge / sign-out / account-switch. Pointing it
   /// at the shared, iCloud-account-scoped registry would let one
   /// profile's zone purge mutate every profile's instruments. The
-  /// per-profile rows survive on disk until
-  /// `v10_drop_shared_instrument_legacy` drops the table.
+  /// `v10_drop_shared_instrument_legacy` migration has since removed
+  /// the per-profile table.
   static func makeForApply(
     database: any GRDB.DatabaseWriter,
     sharedRegistry: GRDBInstrumentRegistryRepository

--- a/Backends/CloudKit/Sync/SyncCoordinator+HandlerAccess.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+HandlerAccess.swift
@@ -50,7 +50,7 @@ extension SyncCoordinator {
     // (the profile-index registry); the apply bundle's resolver /
     // registrar must therefore target it, never the per-profile
     // `instrument` table that `v10_drop_shared_instrument_legacy`
-    // drops. Tests that build a `SyncCoordinator` without injecting a
+    // removed. Tests that build a `SyncCoordinator` without injecting a
     // shared registry fall back to a registry over the container's own
     // profile-index DB — still the shared, account-scoped table, never
     // the per-profile one. The apply path never invokes the

--- a/Backends/GRDB/Records/InstrumentRow+ObservableRegion.swift
+++ b/Backends/GRDB/Records/InstrumentRow+ObservableRegion.swift
@@ -11,7 +11,8 @@ extension InstrumentRow {
   ///
   /// `InstrumentRow` now maps only the shared profile-index
   /// `instrument` table (the per-profile readers/writers were removed
-  /// ahead of the `v10_drop_shared_instrument_legacy` migration). This
+  /// and `v10_drop_shared_instrument_legacy` then dropped the
+  /// per-profile table). This
   /// region is consumed by the shared `GRDBInstrumentRegistryRepository`
   /// observation; it stays valid against the shared table.
   static var observableRegion: QueryInterfaceRequest<InstrumentRow> {

--- a/Backends/GRDB/Repositories/GRDBAccountRepository+Create.swift
+++ b/Backends/GRDB/Repositories/GRDBAccountRepository+Create.swift
@@ -5,8 +5,7 @@ import GRDB
 
 // `performAccountInsert` + `OpeningBalanceInserts` extracted from
 // `GRDBAccountRepository` so the main type body stays under SwiftLint's
-// `type_body_length` and `file_length` budgets after the
-// `onInstrumentChanged` hook plumbing widened the create flow.
+// `type_body_length` and `file_length` budgets.
 extension GRDBAccountRepository {
   /// Captures the ids written by `create(_:openingBalance:)` so the
   /// caller can fan out hook fires after the write transaction commits.

--- a/Backends/GRDB/Repositories/GRDBAccountRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBAccountRepository.swift
@@ -35,8 +35,8 @@ import GRDB
 /// access). `instrumentResolver` is a `Sendable` protocol
 /// (`InstrumentMapResolving`) and immutable post-init.
 /// `instrumentRegistrar` is a `Sendable` protocol
-/// (`InstrumentRegistering`) and immutable post-init. `onRecordChanged`,
-/// `onRecordDeleted`, and `onInstrumentChanged` are `@Sendable` closures
+/// (`InstrumentRegistering`) and immutable post-init. `onRecordChanged`
+/// and `onRecordDeleted` are `@Sendable` closures
 /// captured at init. Nothing mutates post-init, so the reference can be shared across
 /// actor boundaries without a data race; `@unchecked` only waives
 /// Swift's structural check that `final class` types meet `Sendable`'s
@@ -57,8 +57,8 @@ final class GRDBAccountRepository: AccountRepository, @unchecked Sendable {
   /// data. Every caller — production, preview, test, and the sync
   /// apply path — injects the shared `GRDBInstrumentRegistryRepository`
   /// (the profile-index registry). Nothing reads the per-profile
-  /// `instrument` table any more, ahead of the
-  /// `v10_drop_shared_instrument_legacy` migration.
+  /// `instrument` table any more; `v10_drop_shared_instrument_legacy`
+  /// removed it.
   let instrumentResolver: any InstrumentMapResolving
   /// Registers a non-fiat account denomination so it becomes resolvable
   /// by `instrumentResolver` before `create` returns. Awaited *before*
@@ -69,8 +69,8 @@ final class GRDBAccountRepository: AccountRepository, @unchecked Sendable {
   /// per-profile placeholder `instrument` insert. Every caller —
   /// production, preview, test, and the sync apply path — injects the
   /// shared `GRDBInstrumentRegistryRepository`, so registration always
-  /// lands on the profile-index registry, never the soon-to-be-dropped
-  /// per-profile `instrument` table.
+  /// lands on the profile-index registry, never the per-profile
+  /// `instrument` table `v10_drop_shared_instrument_legacy` removed.
   private let instrumentRegistrar: any InstrumentRegistering
   /// Receives `(recordType, id)` so the opening-balance create path can
   /// tag its txn and leg writes with `TransactionRow.recordType` /
@@ -78,16 +78,6 @@ final class GRDBAccountRepository: AccountRepository, @unchecked Sendable {
   /// see `RepositoryHookRecordTypeTests`.
   private let onRecordChanged: @Sendable (String, UUID) -> Void
   private let onRecordDeleted: @Sendable (String, UUID) -> Void
-  /// Legacy hook fired when a non-fiat account denomination was
-  /// auto-inserted by the removed per-profile placeholder path. The
-  /// write cutover routes registration through `instrumentRegistrar`
-  /// (`registerResolvable`) instead — for production the shared
-  /// `GRDBInstrumentRegistryRepository`, whose register methods already
-  /// invalidate the map cache and drive the CloudKit upload fan-out, so
-  /// this hook is no longer fired from `create`. Retained (plumbed but
-  /// unused here) to avoid touching the surrounding sync wiring in this
-  /// change; a follow-up can remove the now-dead hook end to end.
-  private let onInstrumentChanged: @Sendable (Instrument) -> Void
   /// Single shared error channel for every `observeAll()` subscription
   /// returned by this repo instance. The bridge in
   /// `Backends/GRDB/Observation/AsyncValueObservation+AsyncStream.swift`
@@ -102,15 +92,13 @@ final class GRDBAccountRepository: AccountRepository, @unchecked Sendable {
     instrumentResolver: any InstrumentMapResolving,
     instrumentRegistrar: any InstrumentRegistering,
     onRecordChanged: @escaping @Sendable (String, UUID) -> Void = { _, _ in },
-    onRecordDeleted: @escaping @Sendable (String, UUID) -> Void = { _, _ in },
-    onInstrumentChanged: @escaping @Sendable (Instrument) -> Void = { _ in }
+    onRecordDeleted: @escaping @Sendable (String, UUID) -> Void = { _, _ in }
   ) {
     self.database = database
     self.instrumentResolver = instrumentResolver
     self.instrumentRegistrar = instrumentRegistrar
     self.onRecordChanged = onRecordChanged
     self.onRecordDeleted = onRecordDeleted
-    self.onInstrumentChanged = onInstrumentChanged
   }
 
   // MARK: - AccountRepository conformance

--- a/Backends/GRDB/Repositories/GRDBAnalysisRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBAnalysisRepository.swift
@@ -99,8 +99,8 @@ final class GRDBAnalysisRepository: AnalysisRepository, @unchecked Sendable {
   /// aggregation snapshot is safe and intended. Every caller —
   /// production, preview, test, and the sync apply path — injects the
   /// shared `GRDBInstrumentRegistryRepository`; nothing reads the
-  /// soon-to-be-dropped per-profile `instrument` table. Mirrors
-  /// `GRDBTransactionRepository`.
+  /// per-profile `instrument` table `v10_drop_shared_instrument_legacy`
+  /// removed. Mirrors `GRDBTransactionRepository`.
   private let instrumentResolver: any InstrumentMapResolving
   private let logger = Logger(
     subsystem: "com.moolah.app", category: "GRDBAnalysisRepository")

--- a/Backends/GRDB/Repositories/GRDBEarmarkRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBEarmarkRepository.swift
@@ -58,7 +58,8 @@ final class GRDBEarmarkRepository: EarmarkRepository, @unchecked Sendable {
   /// is impossible. Instrument identity is immutable lookup data.
   /// Every caller — production, preview, test, and the sync apply path
   /// — injects the shared `GRDBInstrumentRegistryRepository`; nothing
-  /// reads the soon-to-be-dropped per-profile `instrument` table.
+  /// reads the per-profile `instrument` table
+  /// `v10_drop_shared_instrument_legacy` removed.
   let instrumentResolver: any InstrumentMapResolving
   /// Receives `(recordType, id)` so budget-item upserts emit the
   /// `EarmarkBudgetItemRow.recordType` rather than being mis-tagged as

--- a/Backends/GRDB/Repositories/GRDBInstrumentRegistryRepository+InstrumentRegistering.swift
+++ b/Backends/GRDB/Repositories/GRDBInstrumentRegistryRepository+InstrumentRegistering.swift
@@ -18,8 +18,8 @@ extension GRDBInstrumentRegistryRepository: InstrumentRegistering {
   /// discovery service's `resolveOrLoad` later enriches it), while a
   /// redundant call for an already-resolved instrument is a no-op merge.
   /// Both register methods additionally invalidate the instrument-map
-  /// cache and fire the sync fan-out, so the row reaches CloudKit — the
-  /// work the create-path `onInstrumentChanged` hook used to do.
+  /// cache and fire the sync fan-out, so the registered row reaches
+  /// CloudKit and propagates to sibling devices.
   func registerResolvable(_ instrument: Instrument) async throws {
     switch instrument.kind {
     case .fiatCurrency:

--- a/Backends/GRDB/Repositories/GRDBInstrumentRegistryRepository+Lookup.swift
+++ b/Backends/GRDB/Repositories/GRDBInstrumentRegistryRepository+Lookup.swift
@@ -28,12 +28,12 @@ extension GRDBInstrumentRegistryRepository {
   /// `encoded_system_fields` is `NULL`. Used by the per-startup
   /// targeted reconciliation in `SyncCoordinator+Backfill` (which runs
   /// unconditionally — *not* gated by the per-profile backfill flag) so
-  /// rows inserted by a build that predated the `onInstrumentChanged`
-  /// plumbing eventually reach CloudKit. Fiat is filtered out because
-  /// synthetic fiat rows shouldn't normally be persisted — they're
-  /// synthesised at read time via `Locale.Currency.isoCurrencies` —
-  /// and a stale one slipping into the table must not be uploaded as
-  /// if user-registered.
+  /// rows inserted by a build that predated the shared-registry
+  /// `registerResolvable` path eventually reach CloudKit. Fiat is
+  /// filtered out because synthetic fiat rows shouldn't normally be
+  /// persisted — they're synthesised at read time via
+  /// `Locale.Currency.isoCurrencies` — and a stale one slipping into
+  /// the table must not be uploaded as if user-registered.
   func unsyncedNonFiatRowIdsSync() throws -> [String] {
     let fiatKind = Instrument.Kind.fiatCurrency.rawValue
     return try database.read { database in

--- a/Backends/GRDB/Repositories/GRDBInvestmentRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBInvestmentRepository.swift
@@ -51,7 +51,8 @@ final class GRDBInvestmentRepository: InvestmentRepository, @unchecked Sendable 
   /// is impossible. Instrument identity is immutable lookup data.
   /// Every caller — production, preview, test, and the sync apply path
   /// — injects the shared `GRDBInstrumentRegistryRepository`; nothing
-  /// reads the soon-to-be-dropped per-profile `instrument` table.
+  /// reads the per-profile `instrument` table
+  /// `v10_drop_shared_instrument_legacy` removed.
   let instrumentResolver: any InstrumentMapResolving
   private let onRecordChanged: @Sendable (String, UUID) -> Void
   private let onRecordDeleted: @Sendable (String, UUID) -> Void

--- a/Backends/GRDB/Repositories/GRDBTransactionRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBTransactionRepository.swift
@@ -45,7 +45,7 @@ import OSLog
 /// protocol (`InstrumentMapResolving`) and immutable post-init.
 /// `instrumentRegistrar` is a `Sendable` protocol
 /// (`InstrumentRegistering`) and immutable post-init.
-/// `onRecordChanged`, `onRecordDeleted`, and `onInstrumentChanged` are
+/// `onRecordChanged` and `onRecordDeleted` are
 /// `@Sendable` closures captured at init. Nothing mutates post-init, so
 /// the reference can be shared across actor boundaries without a data
 /// race; `@unchecked` only waives Swift's structural check that
@@ -73,7 +73,8 @@ final class GRDBTransactionRepository: TransactionRepository, @unchecked Sendabl
   /// transaction-row snapshot is safe and intended. Every caller —
   /// production, preview, test, and the sync apply path — injects the
   /// shared `GRDBInstrumentRegistryRepository`; nothing reads the
-  /// soon-to-be-dropped per-profile `instrument` table.
+  /// per-profile `instrument` table
+  /// `v10_drop_shared_instrument_legacy` removed.
   let instrumentResolver: any InstrumentMapResolving
   /// Registers a non-fiat leg instrument so it becomes resolvable by
   /// `instrumentResolver` before `create` / `createMany` / `update`
@@ -85,7 +86,8 @@ final class GRDBTransactionRepository: TransactionRepository, @unchecked Sendabl
   /// production, preview, test, and the sync apply path — injects the
   /// shared `GRDBInstrumentRegistryRepository` (so the row reaches the
   /// canonical registry and CloudKit); nothing writes the
-  /// soon-to-be-dropped per-profile `instrument` table.
+  /// per-profile `instrument` table
+  /// `v10_drop_shared_instrument_legacy` removed.
   private let instrumentRegistrar: any InstrumentRegistering
   /// Single shared error channel for every observation subscription
   /// returned by this repo instance. The bridge in
@@ -103,17 +105,6 @@ final class GRDBTransactionRepository: TransactionRepository, @unchecked Sendabl
   /// `RepositoryHookRecordTypeTests`.
   private let onRecordChanged: @Sendable (String, UUID) -> Void
   private let onRecordDeleted: @Sendable (String, UUID) -> Void
-  /// Legacy hook fired when a non-fiat instrument was auto-inserted by
-  /// the removed per-profile placeholder path. The write cutover routes
-  /// instrument registration through `instrumentRegistrar`
-  /// (`registerResolvable`) instead — for production that is the shared
-  /// `GRDBInstrumentRegistryRepository`, whose `registerStock` /
-  /// `registerCrypto` already invalidate the map cache and drive the
-  /// CloudKit upload fan-out, so this hook is no longer fired from the
-  /// create / update paths. Retained (plumbed but unused here) to avoid
-  /// touching the surrounding sync wiring in this change; a follow-up
-  /// can remove the now-dead hook end to end.
-  private let onInstrumentChanged: @Sendable (Instrument) -> Void
 
   private let logger = Logger(
     subsystem: "com.moolah.app", category: "GRDBTransactionRepository")
@@ -125,8 +116,7 @@ final class GRDBTransactionRepository: TransactionRepository, @unchecked Sendabl
     instrumentResolver: any InstrumentMapResolving,
     instrumentRegistrar: any InstrumentRegistering,
     onRecordChanged: @escaping @Sendable (String, UUID) -> Void = { _, _ in },
-    onRecordDeleted: @escaping @Sendable (String, UUID) -> Void = { _, _ in },
-    onInstrumentChanged: @escaping @Sendable (Instrument) -> Void = { _ in }
+    onRecordDeleted: @escaping @Sendable (String, UUID) -> Void = { _, _ in }
   ) {
     self.database = database
     self.defaultInstrument = defaultInstrument
@@ -135,7 +125,6 @@ final class GRDBTransactionRepository: TransactionRepository, @unchecked Sendabl
     self.instrumentRegistrar = instrumentRegistrar
     self.onRecordChanged = onRecordChanged
     self.onRecordDeleted = onRecordDeleted
-    self.onInstrumentChanged = onInstrumentChanged
   }
 
   // MARK: - TransactionRepository conformance

--- a/MoolahTests/App/InstrumentRegistrationZoneRoutingTests.swift
+++ b/MoolahTests/App/InstrumentRegistrationZoneRoutingTests.swift
@@ -1,4 +1,4 @@
-// MoolahTests/App/InstrumentChangedHookZoneRoutingTests.swift
+// MoolahTests/App/InstrumentRegistrationZoneRoutingTests.swift
 
 import CloudKit
 import Foundation
@@ -7,8 +7,9 @@ import Testing
 
 @testable import Moolah
 
-/// Pins that the auto-publish path for `ensureInstrumentReadable`'s
-/// non-fiat instruments routes through the **shared registry** and
+/// Pins that registering a non-fiat instrument through the **shared
+/// registry** (the `registerResolvable` path the create / update /
+/// account writes take before their per-profile `database.write`)
 /// emits its `onRecordChanged` hook with a string-keyed recordName
 /// destined for the **profile-index zone** — never a `profile-<UUID>`
 /// zone. The legacy per-profile-zone instrument upload path is
@@ -16,9 +17,9 @@ import Testing
 /// catches regressions); this test pins the positive contract
 /// end-to-end so a future refactor that loses the shared-registry
 /// routing fails here before hitting the trap in CI.
-@Suite("Instrument auto-publish hook routes to the profile-index zone")
+@Suite("Instrument registration routes to the profile-index zone")
 @MainActor
-struct InstrumentChangedHookZoneRoutingTests {
+struct InstrumentRegistrationZoneRoutingTests {
 
   @Test(
     "registerStock on the shared registry fires onRecordChanged with the bare instrument id"
@@ -42,9 +43,9 @@ struct InstrumentChangedHookZoneRoutingTests {
       },
       onRecordDeleted: { _ in })
 
-    // Register a stock instrument — the same call the auto-publish
-    // hook in `ProfileSession+CloudKitBackendBuild.publishToSharedRegistry`
-    // makes when `ensureInstrumentReadable` auto-inserts a non-fiat row.
+    // Register a stock instrument — the same call `registerResolvable`
+    // makes (via `registerStock`) when a create / update / account write
+    // registers a non-fiat denomination before its per-profile write.
     let bhp = Instrument.stock(
       ticker: "BHP.AX", exchange: "ASX", name: "BHP Group")
     try await registry.registerStock(bhp)

--- a/MoolahTests/Backends/GRDB/GRDBCreateManyTests.swift
+++ b/MoolahTests/Backends/GRDB/GRDBCreateManyTests.swift
@@ -12,9 +12,10 @@ import Testing
 ///    every leg, and every auto-inserted instrument across the whole
 ///    input array — leaving the DB byte-equal to the pre-call state.
 /// 2. Hook fan-out. After the write commits, `onRecordChanged` fires
-///    exactly once per transaction header and once per leg;
-///    `onInstrumentChanged` fires once per unique new instrument across
-///    the whole batch (regardless of how many legs reference it).
+///    exactly once per transaction header and once per leg. Each unique
+///    non-fiat leg instrument is registered (batch-deduped) through the
+///    injected registrar *before* the write, so it is resolvable
+///    afterwards without any per-profile placeholder.
 ///
 /// The per-row pattern is already covered by
 /// `CoreFinancialGraphRollbackTests.transactionCreateRollsBackOnLegFailure`
@@ -27,7 +28,6 @@ struct GRDBCreateManyTests {
   final class HookCapture {
     var changed: [(recordType: String, id: UUID)] = []
     var deleted: [(recordType: String, id: UUID)] = []
-    var instruments: [Instrument] = []
   }
 
   private func makeChangedHook(
@@ -46,16 +46,6 @@ struct GRDBCreateManyTests {
     { recordType, id in
       Task { @MainActor in
         capture.deleted.append((recordType, id))
-      }
-    }
-  }
-
-  private func makeInstrumentHook(
-    _ capture: HookCapture
-  ) -> @Sendable (Instrument) -> Void {
-    { instrument in
-      Task { @MainActor in
-        capture.instruments.append(instrument)
       }
     }
   }
@@ -187,8 +177,7 @@ struct GRDBCreateManyTests {
       instrumentResolver: registry,
       instrumentRegistrar: registry,
       onRecordChanged: makeChangedHook(capture),
-      onRecordDeleted: makeDeletedHook(capture),
-      onInstrumentChanged: makeInstrumentHook(capture))
+      onRecordDeleted: makeDeletedHook(capture))
     let accountId = UUID()
     let stub = Account(id: accountId, name: "Cash", type: .bank, instrument: .AUD)
     try await database.write { database in
@@ -217,10 +206,6 @@ struct GRDBCreateManyTests {
     #expect(Set(legChanges.map(\.id)) == Set(expectedLegIds))
     #expect(legChanges.count == expectedLegIds.count)
     #expect(capture.deleted.isEmpty)
-    // The legacy `onInstrumentChanged` hook is no longer fired from the
-    // create path — registration now goes through the injected
-    // registrar before the write.
-    #expect(capture.instruments.isEmpty)
     // BTC is resolvable from the shared registry across the whole
     // batch even though two separate transactions reference it: the
     // per-batch dedup registered it once and the registrar is

--- a/MoolahTests/Backends/GRDB/GRDBInstrumentRegistryUpsertMergeTests.swift
+++ b/MoolahTests/Backends/GRDB/GRDBInstrumentRegistryUpsertMergeTests.swift
@@ -28,7 +28,7 @@ struct GRDBInstrumentRegistryUpsertMergeTests {
         cryptocompareSymbol: "ETH",
         binanceSymbol: "ETHUSDT"))
 
-    // Simulates publishToSharedRegistry's all-nil publish for the same id.
+    // Simulates `registerResolvable`'s all-nil crypto publish for the same id.
     try await registry.registerCrypto(
       eth,
       mapping: CryptoProviderMapping(
@@ -160,7 +160,7 @@ struct GRDBInstrumentRegistryUpsertMergeTests {
         binanceSymbol: nil))
     let blob = Data([0xCA, 0xFE, 0xBA, 0xBE])
     _ = try registry.setEncodedSystemFieldsSync(id: eth.id, data: blob)
-    // All-nil publish (the publishToSharedRegistry pattern) must not blank it.
+    // All-nil publish (the `registerResolvable` crypto pattern) must not blank it.
     try await registry.registerCrypto(
       eth,
       mapping: CryptoProviderMapping(


### PR DESCRIPTION
Closes #899.

## Why

The shared-instrument-registry cutover (PRs 1–6, all landed) moved the create / update / account / bulk `createMany` paths onto `instrumentRegistrar.registerResolvable(...)`, **awaited before** the per-profile `database.write`. `registerResolvable` performs the identical `registerStock` / `registerCrypto` shared-zone fan-out the post-write `onInstrumentChanged` hook used to do (byte-for-byte the same dispatch), only synchronously and durably-before-observable. Verified: `onInstrumentChanged` had **zero invocation sites** anywhere on `main` — pure dead plumbing.

## What

- Delete `makeInstrumentChangedHook`, `publishToSharedRegistry`, the `CloudKitBackendHooks.onInstrumentChanged` field + `.noop` default, and the unused `import OSLog`.
- Delete the `onInstrumentChanged` init param / stored field / assignment on `GRDBTransactionRepository` and `GRDBAccountRepository`, plus the two `CloudKitBackend` pass-through sites.
- Reword doc comments that named the removed symbol to describe the surviving `registerResolvable` mechanism.
- Rename `InstrumentChangedHookZoneRoutingTests` → `InstrumentRegistrationZoneRoutingTests` (it pins the `registerStock`/`registerCrypto` recordName contract `registerResolvable` depends on — **assertions unchanged**); trim `GRDBCreateManyTests`' now-vacuous hook-silence capture (registrar + `onRecordChanged` assertions kept).
- **Folded-in doc cleanup** (per review): `v10_drop_shared_instrument_legacy` has shipped, so future/imminent tense ("soon-to-be-dropped", "migration will drop", "ahead of the migration") is corrected to past tense across the GRDB repos and sync handlers.

## Verification

- Full `just test` (iOS + macOS) — green.
- `just build-mac`, `just format-check` — clean.
- `code-review` agent — no Critical/Important findings; the one Minor (a comment line-wrap) is fixed.
- No behaviour change: pure dead-code removal + comment accuracy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)