### PR TITLE
refactor: succinct, present-tense comments + CODE_GUIDE comment rules

### DIFF
--- a/App/MoolahApp+Lifecycle.swift
+++ b/App/MoolahApp+Lifecycle.swift
@@ -2,8 +2,7 @@ import Foundation
 import GRDB
 import SwiftUI
 
-// Scene-phase sync flushing and URL-scheme routing extracted from the main
-// `MoolahApp` body so it stays under SwiftLint's `type_body_length` threshold.
+// Scene-phase sync flushing and URL-scheme routing.
 extension MoolahApp {
 
   // MARK: - Background Sync

--- a/App/MoolahApp+Setup.swift
+++ b/App/MoolahApp+Setup.swift
@@ -8,9 +8,8 @@ import GRDB
 import OSLog
 import SwiftUI
 
-// Launch-time container/sync/automation configuration extracted from the main
-// `MoolahApp` body so it stays under SwiftLint's `type_body_length` threshold.
-// All members are static and referenced from `MoolahApp.init()`.
+// Launch-time container/sync/automation configuration. All members are
+// static and referenced from `MoolahApp.init()`.
 extension MoolahApp {
 
   struct ContainerSetup {
@@ -108,9 +107,8 @@ extension MoolahApp {
     // No launch-time data migration gates the engine start: the local
     // profile index is hydrated synchronously by `ProfileIndexDatabase.open`
     // before the coordinator exists, so `start()` can run immediately.
-    // `startAfter(profileIndexMigration: nil)` keeps the established
-    // launch path (the coordinator owns the spawned `launchTask` so
-    // `stop()` can still cancel a pending start on early teardown).
+    // The coordinator owns the spawned `launchTask` so `stop()` can
+    // cancel a pending start on early teardown.
     coordinator.startAfter(profileIndexMigration: nil)
     // Clean up the legacy CloudKit zone from SwiftData's automatic sync.
     LegacyZoneCleanup.performIfNeeded()
@@ -166,15 +164,12 @@ extension MoolahApp {
   // Shared-registry plumbing (`bootstrapSyncCoordinator`,
   // `makeSharedInstrumentRegistry`, `makeSharedInstrumentScope`,
   // `attachSharedInstrumentRegistrySyncHooks`) lives in the sibling
-  // `MoolahApp+SharedInstrumentScope.swift` file so this one stays
-  // under SwiftLint's `file_length` threshold.
+  // `MoolahApp+SharedInstrumentScope.swift` file.
 
   /// Build the `SessionManager` and wire its `onProfileRemoved` cleanup
-  /// hook. Extracted from `MoolahApp.init` so the initializer body
-  /// stays under SwiftLint's `function_body_length` threshold; the
-  /// hook closure captures the manager and coordinator weakly so a
-  /// cleanup hop after profile deletion doesn't keep them alive past
-  /// the app's lifetime.
+  /// hook. The hook closure captures the manager and coordinator weakly
+  /// so a cleanup hop after profile deletion doesn't keep them alive
+  /// past the app's lifetime.
   static func makeSessionManager(
     setup: ContainerSetup, store: ProfileStore, coordinator: SyncCoordinator
   ) -> SessionManager {
@@ -219,8 +214,8 @@ extension MoolahApp {
     #endif
   }
 
-  /// One-shot cleanup: removes the legacy gzipped JSON rate caches that
-  /// shipped before rate persistence moved to per-profile SQLite. Gated by
+  /// One-shot cleanup: removes the obsolete gzipped JSON rate caches
+  /// (rate persistence lives in per-profile SQLite). Gated by
   /// the `v2.rates.cache.cleared` `UserDefaults` flag so it runs at most
   /// once per install. Best-effort — failures are silent and the rate
   /// services repopulate from network on demand.
@@ -257,9 +252,9 @@ extension MoolahApp {
     defaults.set(true, forKey: key)
   }
 
-  /// One-shot cleanup: removes the legacy SwiftData profile-index and
-  /// per-profile data stores left behind after Phase A migrated every
-  /// record type to GRDB. Gated by the `v4.swiftDataStores.cleared`
+  /// One-shot cleanup: removes the obsolete SwiftData profile-index and
+  /// per-profile data stores (all record types live in GRDB). Gated by
+  /// the `v4.swiftDataStores.cleared`
   /// `UserDefaults` flag so it runs at most once per install. Best
   /// effort — a missing file is silent; other failures log at
   /// `.warning` and the flag is still set so we don't retry forever.

--- a/App/MoolahApp+SharedInstrumentScope.swift
+++ b/App/MoolahApp+SharedInstrumentScope.swift
@@ -5,9 +5,7 @@ import Foundation
 import GRDB
 
 /// Boot-time setup for the app-level shared instrument registry and
-/// the coordinated `MarketDataServices`. Extracted from
-/// `MoolahApp+Setup` so neither file overruns SwiftLint's
-/// `file_length` budget.
+/// the coordinated `MarketDataServices`.
 extension MoolahApp {
 
   /// Boot-time sync setup: shared registry + market-data services

--- a/App/MoolahApp.swift
+++ b/App/MoolahApp.swift
@@ -63,8 +63,8 @@ struct MoolahApp: App {
     // touch the user's iCloud. See guides/UI_TEST_GUIDE.md §6.
     let uiTestingSeed = Self.uiTestingSeed(from: CommandLine.arguments)
 
-    // One-shot removal of the legacy `Caches/{exchange,stock,crypto}` JSON
-    // cache directories now that rate caches live in per-profile SQLite.
+    // One-shot removal of the obsolete `Caches/{exchange,stock,crypto}`
+    // JSON cache directories; rate caches live in per-profile SQLite.
     // Skipped under UI testing where `Caches` is shared with the host
     // user's account and we must not mutate it.
     if uiTestingSeed == nil {

--- a/App/MoolahDomainCommands.swift
+++ b/App/MoolahDomainCommands.swift
@@ -1,9 +1,7 @@
 import SwiftUI
 
-// Command-menu definitions extracted from `MoolahApp.swift` so the app file
-// stays under SwiftLint's `file_length` threshold. Each struct remains a
-// top-level `Commands` type, preserving its role in `MoolahApp.body`'s
-// `.commands { ... }` builder.
+// Command-menu definitions. Each struct is a top-level `Commands` type
+// used in `MoolahApp.body`'s `.commands { ... }` builder.
 
 /// Combined File > New… commands (Transaction, Earmark, Account, Category).
 /// Grouping them into one Commands struct keeps the top-level `.commands` block

--- a/App/ProfileRootView.swift
+++ b/App/ProfileRootView.swift
@@ -77,7 +77,7 @@
         // Register in-process entry points for App Intents so
         // `OpenAccountIntent` can switch profile / set a pending navigation
         // without going through `UIApplication.shared.open(moolah://…)` —
-        // the URL scheme has been removed (issue #386).
+        // the URL scheme does not exist (issue #386).
         let pendingBinding = pendingNavigationBinding
         let store = profileStore
         NavigationBridge.openProfile = { id in store.setActiveProfile(id) }

--- a/App/ProfileSession+CloudKitBackendBuild.swift
+++ b/App/ProfileSession+CloudKitBackendBuild.swift
@@ -4,9 +4,8 @@ import GRDB
 
 extension ProfileSession {
   /// Bundle of the three market-data services consumed by the CloudKit
-  /// backend's `FullConversionService`. Lets `makeCloudKitBackend` take a
-  /// single value instead of three separate parameters so it stays at
-  /// SwiftLint's parameter-count policy.
+  /// backend's `FullConversionService`. Lets `makeCloudKitBackend` take
+  /// a single value instead of three separate parameters.
   struct CloudKitMarketDataServices {
     let exchangeRates: ExchangeRateService
     let stockPrices: StockPriceService
@@ -41,9 +40,8 @@ extension ProfileSession {
       registry = shared
     } else {
       // Preview / test fallback. The registry is built over a
-      // profile-index database — never the per-profile `data.sqlite`:
-      // the `v10_drop_shared_instrument_legacy` migration removed the
-      // per-profile `instrument` table, so instrument identity lives
+      // profile-index database — never the per-profile `data.sqlite`,
+      // which has no `instrument` table; instrument identity lives
       // solely on the profile-index registry. When a coordinator is
       // present its container manager's profile-index DB is reused;
       // otherwise a fresh in-memory profile-index DB stands in.
@@ -136,12 +134,10 @@ extension ProfileSession {
 
   /// Builds the preview/test-only `GRDBInstrumentRegistryRepository`,
   /// wiring its mutation hooks to the sync coordinator's per-zone queue
-  /// helpers. Extracted from `makeCloudKitBackend` so the per-mutation
-  /// closure definitions don't bloat its body length.
+  /// helpers.
   ///
   /// The registry is backed by a profile-index database, never the
-  /// per-profile `data.sqlite` (whose `instrument` table the
-  /// `v10_drop_shared_instrument_legacy` migration removed): the
+  /// per-profile `data.sqlite` (which has no `instrument` table): the
   /// coordinator's container-manager profile-index DB when a coordinator
   /// is present, otherwise a fresh in-memory profile-index DB. This
   /// branch is unreachable in production — see `makeCloudKitBackend` —

--- a/App/ProfileSession+Database.swift
+++ b/App/ProfileSession+Database.swift
@@ -2,10 +2,8 @@ import Foundation
 import GRDB
 
 // Filesystem layout helpers and the `DatabaseQueue` opener for a
-// profile session. Extracted from `ProfileSession.swift` so the main
-// file stays under SwiftLint's `file_length` threshold; every helper
-// here is `nonisolated static` and reaches none of the session's
-// private state.
+// profile session. Every helper here is `nonisolated static` and
+// reaches none of the session's private state.
 
 extension ProfileSession {
   /// Per-profile directory under Application Support where CSV import staging

--- a/App/ProfileSession+DatabaseMaintenance.swift
+++ b/App/ProfileSession+DatabaseMaintenance.swift
@@ -2,9 +2,7 @@ import Foundation
 import GRDB
 import OSLog
 
-// `PRAGMA optimize` cadence per `guides/DATABASE_SCHEMA_GUIDE.md` §5,
-// extracted from the main `ProfileSession` body so it stays under
-// SwiftLint's `type_body_length` and `file_length` thresholds.
+// `PRAGMA optimize` cadence per `guides/DATABASE_SCHEMA_GUIDE.md` §5.
 extension ProfileSession {
 
   // MARK: - Database maintenance
@@ -57,9 +55,9 @@ extension ProfileSession {
   /// (`MoolahApp+Lifecycle.runPragmaOptimizeOnAllSessions`) covers the
   /// "right now" case.
   ///
-  /// Replaces any previously-scheduled periodic task (the prior handle is
-  /// cancelled first) so callers can change the cadence without leaking
-  /// loops. The handle is tracked on `periodicPragmaOptimizeTask` and
+  /// Cancels any already-scheduled periodic task before scheduling a new
+  /// one so callers can change the cadence without leaking loops. The
+  /// handle is tracked on `periodicPragmaOptimizeTask` and
   /// cancelled in `cleanupSync(coordinator:)` per `guides/CONCURRENCY_GUIDE.md`
   /// §8.
   ///

--- a/App/ProfileSession+Factories.swift
+++ b/App/ProfileSession+Factories.swift
@@ -250,21 +250,20 @@ extension ProfileSession {
   }
 
   /// Builds all of the domain stores for a profile against a shared
-  /// `BackendProvider`. The construction order (accounts + earmarks before
-  /// transactions) is preserved to match the previous inline init sequence.
+  /// `BackendProvider`. Accounts and earmarks are constructed before
+  /// transactions because the transaction store depends on them.
   static func makeDomainStores(
     profile: Profile,
     backend: BackendProvider
   ) -> DomainStores {
-    // The per-profile list observations no longer track the
-    // `instrument` table — instrument identity is resolved once per
-    // fetch via the shared registry. Thread the registry's change
-    // stream into the affected stores so a shared-registry metadata
-    // edit live-refreshes an open list across the DB boundary. Derived
-    // from the backend (not a parameter) so `ProfileSession.init` stays
-    // within its body-length budget; nil for backends without a shared
-    // registry. Accessed via the `BackendProvider` seam — no downcast to
-    // a concrete backend type.
+    // Per-profile list observations don't track an `instrument` table;
+    // instrument identity is resolved once per fetch via the shared
+    // registry. Thread the registry's change stream into the affected
+    // stores so a shared-registry metadata edit live-refreshes an open
+    // list across the DB boundary. Derived from the backend (not a
+    // parameter); nil for backends without a shared registry. Accessed
+    // via the `BackendProvider` seam — no downcast to a concrete backend
+    // type.
     let instrumentChanges = backend.instrumentChangeObserver
     let auth = AuthStore(backend: backend)
     let account = AccountStore(

--- a/App/ProfileSession+SyncCleanup.swift
+++ b/App/ProfileSession+SyncCleanup.swift
@@ -1,11 +1,9 @@
 import Foundation
 
-// Sync teardown and the `updateProfile` mutator. Extracted from
-// `ProfileSession.swift` so the main file stays under SwiftLint's
-// `file_length` threshold. Reaches the session's module-internal task
-// state (`catalogRefreshTask`, `setUpTask`, etc.) — those properties
-// are deliberately module-internal in `ProfileSession.swift` so this
-// file can manage their lifecycle.
+// Sync teardown and the `updateProfile` mutator. Reaches the session's
+// module-internal task state (`catalogRefreshTask`, `setUpTask`, etc.) —
+// those properties are deliberately module-internal in
+// `ProfileSession.swift` so this file can manage their lifecycle.
 
 extension ProfileSession {
   // MARK: - Sync Cleanup

--- a/App/ProfileSession+ValuationMigration.swift
+++ b/App/ProfileSession+ValuationMigration.swift
@@ -8,12 +8,9 @@ import OSLog
 private let valuationMigrationLogger = Logger(
   subsystem: "com.moolah.app", category: "ProfileSession")
 
-// `ValuationModeMigration` per-profile bootstrap. Lives here rather
-// than in the main `ProfileSession` body so the latter stays under
-// SwiftLint's `file_length` threshold. The migration itself is
-// non-fatal — auto-detect read sites are still in place at this
-// rollout stage, so a thrown error gets logged but never surfaces to
-// the caller.
+// `ValuationModeMigration` per-profile bootstrap. The migration is
+// non-fatal — auto-detect read sites remain in place, so a thrown
+// error gets logged but never surfaces to the caller.
 extension ProfileSession {
   /// Runs `ValuationModeMigration` for this profile. Called from
   /// `setUp()` after the SwiftData → GRDB migration so the account /

--- a/App/ProfileSession.swift
+++ b/App/ProfileSession.swift
@@ -194,8 +194,7 @@ final class ProfileSession: Identifiable {
     finishInit()
   }
 
-  /// Tail of the initialiser — kept as a separate method so `init`
-  /// stays under SwiftLint's `function_body_length` threshold. Wires
+  /// Tail of the initialiser. Wires
   /// the crypto-wallet sync stores and starts the hourly
   /// `PRAGMA optimize` tick (issue #576). Reads everything it needs
   /// from `self` (every stored property is fully initialised by the
@@ -204,9 +203,9 @@ final class ProfileSession: Identifiable {
   /// Cross-store propagation is handled reactively: every store
   /// subscribes to its repository's GRDB `ValueObservation` stream in
   /// `init`, so remote-sync writes (and local writes) reach views
-  /// without an explicit reload step. The session no longer needs a
-  /// reference to `SyncCoordinator` here — apply still drives GRDB
-  /// writes and the observation streams take it from there.
+  /// without an explicit reload step. The session needs no reference
+  /// to `SyncCoordinator` here — apply drives GRDB writes and the
+  /// observation streams take it from there.
   private func finishInit() {
     let cryptoWiring = Self.makeCryptoSyncWiring(
       backend: backend,
@@ -243,9 +242,8 @@ final class ProfileSession: Identifiable {
   /// re-valuates so the spam position drops out of `valuedPositions`
   /// without the user having to navigate away and back. Issue #790.
   ///
-  /// The investment-store -> account-store fan-out (formerly
-  /// `onInvestmentValueChanged`) was removed when AccountStore
-  /// migrated to reactive observation: AccountStore now subscribes to
+  /// The investment-store -> account-store fan-out is reactive:
+  /// AccountStore subscribes to
   /// `investmentRepository.observeAllValues()` and refreshes its cache
   /// directly, so a write to `investment_value` reaches the sidebar
   /// without a callback. The spawned crypto-token Task is tracked in
@@ -292,8 +290,8 @@ final class ProfileSession: Identifiable {
   /// re-running anything.
   ///
   /// `ValuationModeMigration` is non-fatal: errors are logged but do
-  /// not propagate, because read sites still auto-detect at this
-  /// rollout stage and the next launch will retry.
+  /// not propagate, because read sites auto-detect and the next launch
+  /// will retry.
   func setUp() async throws {
     if let existing = setUpTask {
       return try await existing.value
@@ -306,6 +304,5 @@ final class ProfileSession: Identifiable {
   }
 
   // `runValuationModeMigration` lives in
-  // `ProfileSession+ValuationMigration.swift` so this file stays under
-  // SwiftLint's `file_length` threshold.
+  // `ProfileSession+ValuationMigration.swift`.
 }

--- a/App/ProfileWindowView.swift
+++ b/App/ProfileWindowView.swift
@@ -41,8 +41,8 @@
         if let resolved = resolvedProfile {
           sessionContent(for: resolved)
         } else if profileID != nil {
-          // This window was opened for a specific profile that no longer
-          // exists. Close it — the user will land on whichever window
+          // This window was opened for a specific profile that does not
+          // exist. Close it — the user will land on whichever window
           // SwiftUI brings forward next.
           Color.clear
             .onAppear {
@@ -92,9 +92,9 @@
         // Register in-process entry points for AppleScript/App Intents so
         // `NavigateCommand` / `OpenAccountIntent` don't need to round-trip
         // through `NSWorkspace.shared.open(moolah://…)` — SwiftUI's
-        // auto-spawn of a stray window on URL events (issue #378) — and
-        // since the URL scheme itself has been removed (issue #386),
-        // in-process is the only remaining path.
+        // auto-spawn of a stray window on URL events (issue #378). The
+        // URL scheme does not exist (issue #386), so in-process is the
+        // only path.
         let openAction = openWindow
         let pendingBinding = pendingNavigationBinding
         NavigationBridge.openProfile = { id in openAction(value: id) }
@@ -106,8 +106,7 @@
 
     /// Renders the per-session content area: the live session, the
     /// stop-the-world incompatible-profile screen, or a brief progress
-    /// indicator while the open is in flight. Extracted so the `body`
-    /// closure stays under the SwiftLint `closure_body_length` cap.
+    /// indicator while the open is in flight.
     @ViewBuilder
     private func sessionContent(for resolved: Profile) -> some View {
       switch sessionResult {

--- a/App/UITestSeedHydrator+TradeReady.swift
+++ b/App/UITestSeedHydrator+TradeReady.swift
@@ -1,8 +1,7 @@
 import Foundation
 import GRDB
 
-// Trade-Ready seed helpers split out of `UITestSeedHydrator` so the main enum
-// body stays under SwiftLint's `type_body_length` threshold.
+// Trade-Ready seed helpers for `UITestSeedHydrator`.
 extension UITestSeedHydrator {
   // MARK: - Specs
 

--- a/App/UITestSeedHydrator+Upserts.swift
+++ b/App/UITestSeedHydrator+Upserts.swift
@@ -1,8 +1,7 @@
 import Foundation
 import GRDB
 
-// Upsert helpers split out of `UITestSeedHydrator` so the main enum body stays
-// under SwiftLint's `type_body_length` threshold. Every helper is idempotent:
+// Upsert helpers for `UITestSeedHydrator`. Every helper is idempotent:
 // re-running the same seed (e.g. after a UI-testing re-launch) doesn't
 // double-insert records.
 //
@@ -12,9 +11,8 @@ import GRDB
 extension UITestSeedHydrator {
   // MARK: - Specs
   //
-  // Struct wrappers bundle the per-record fields callers provide. They keep
-  // the upsert call sites self-documenting while holding each helper's
-  // parameter count under SwiftLint's threshold.
+  // Struct wrappers bundle the per-record fields callers provide,
+  // keeping the upsert call sites self-documenting.
 
   struct AccountSpec {
     let id: UUID

--- a/App/UITestSeedHydrator.swift
+++ b/App/UITestSeedHydrator.swift
@@ -171,8 +171,8 @@ enum UITestSeedHydrator {
     instrument: Instrument, in database: Database
   ) throws {
     // Instruments are registered on the shared profile-index DB by the
-    // caller (`hydrateTradeBaseline`); the per-profile `instrument`
-    // table no longer exists post-v10.
+    // caller (`hydrateTradeBaseline`); the per-profile DB has no
+    // `instrument` table.
     let fixtures = UITestFixtures.TradeBaseline.self
     try upsertAccount(
       AccountSpec(

--- a/App/UITestingLauncherView.swift
+++ b/App/UITestingLauncherView.swift
@@ -12,13 +12,13 @@
   ///
   /// The launcher Window is `.defaultLaunchBehavior(.suppressed)` in
   /// production, so this view is never instantiated outside
-  /// `--ui-testing`. **Why we don't dismiss it:** earlier versions
-  /// dismissed the launcher immediately after `openWindow`, but on
-  /// cold-start CI runners the dismiss could race ahead of the
-  /// open's scene materialisation and leave the app windowless — the
-  /// launcher's Window goes away before the WindowGroup spawns its
-  /// own, and SwiftUI then has nothing to show (issue #493). Leaving
-  /// the launcher around eliminates the race deterministically: a
+  /// `--ui-testing`. **Why we don't dismiss it:** dismissing the
+  /// launcher immediately after `openWindow` lets the dismiss race
+  /// ahead of the open's scene materialisation on cold-start CI
+  /// runners and leave the app windowless — the launcher's Window
+  /// goes away before the WindowGroup spawns its own, and SwiftUI
+  /// then has nothing to show (issue #493). Leaving the launcher
+  /// around eliminates the race deterministically: a
   /// `Color.clear`/1×1 frame is invisible to users, and UI test
   /// drivers locate elements by accessibility identifier, so a second
   /// content-free window adds nothing to the tree they care about.

--- a/Automation/AutomationService+Earmarks.swift
+++ b/Automation/AutomationService+Earmarks.swift
@@ -1,9 +1,7 @@
 import Foundation
 
-// Earmark / category / investment / analysis / refresh handlers extracted
-// from the main `AutomationService` body so it stays under SwiftLint's
-// `type_body_length` threshold. All members are `@MainActor` via the
-// containing class.
+// Earmark / category / investment / analysis / refresh handlers. All
+// members are `@MainActor` via the containing class.
 extension AutomationService {
 
   // MARK: - Earmark Operations
@@ -232,10 +230,9 @@ extension AutomationService {
   /// `AccountStore`, `EarmarkStore`, and `CategoryStore` are all
   /// reactive — they self-load via `observeAll()` from `init`, so this
   /// method has no work to dispatch beyond resolving the session
-  /// (which still validates the identifier). Kept as part of the
-  /// AutomationService surface for backward compatibility with
-  /// scripts that call `refresh` defensively before reading store
-  /// state.
+  /// (which validates the identifier). Part of the AutomationService
+  /// surface for scripts that call `refresh` defensively before
+  /// reading store state.
   func refresh(profileIdentifier: String) async throws {
     _ = try resolveSession(for: profileIdentifier)
   }

--- a/Automation/Navigation/NavigationBridge.swift
+++ b/Automation/Navigation/NavigationBridge.swift
@@ -5,9 +5,9 @@ import Foundation
 /// (`ProfileWindowView` on macOS, `ProfileRootView` on iOS) as soon as its
 /// `.task` runs, so callers can open a profile or set a pending navigation
 /// without firing a URL event — which on macOS triggers SwiftUI's
-/// `WindowGroup(for:)` auto-spawn (issue #378), and since the
-/// `moolah://` URL scheme has been removed (issue #386) can no longer be
-/// routed back to the app at all.
+/// `WindowGroup(for:)` auto-spawn (issue #378). The `moolah://` URL
+/// scheme does not exist (issue #386), so a URL event cannot be routed
+/// back to the app at all.
 @MainActor
 enum NavigationBridge {
   /// Opens or focuses the window / session for the given profile. On macOS

--- a/Backends/CloudKit/CloudKitBackend.swift
+++ b/Backends/CloudKit/CloudKitBackend.swift
@@ -40,12 +40,11 @@ final class CloudKitBackend: BackendProvider, @unchecked Sendable {
   let grdbTransactionLegs: GRDBTransactionLegRepository
 
   /// Bundle of the change/delete hook closures the GRDB repos call on
-  /// each successful local mutation. Bundling them keeps the
-  /// `CloudKitBackend.init` parameter count under SwiftLint's
-  /// `function_parameter_count` threshold while still letting callers
-  /// inject distinct closures per repo if they need to (no current
-  /// caller does — `makeCloudKitBackend` shares one pair across every
-  /// repo).
+  /// each successful local mutation. Bundling keeps
+  /// `CloudKitBackend.init`'s parameter list small while still letting
+  /// callers inject distinct closures per repo if they need to (no
+  /// current caller does — `makeCloudKitBackend` shares one pair across
+  /// every repo).
   struct CloudKitBackendHooks {
     let onCSVImportProfileChanged: @Sendable (String, UUID) -> Void
     let onCSVImportProfileDeleted: @Sendable (String, UUID) -> Void
@@ -156,8 +155,7 @@ final class CloudKitBackend: BackendProvider, @unchecked Sendable {
     // The instrument-resolving read repos (accounts, transactions,
     // earmarks, investments, analysis) all take the instrument seams;
     // the remaining record-type repos don't, so the two groups are
-    // built by separate helpers to keep this function body under
-    // SwiftLint's `function_body_length` budget.
+    // built by separate helpers.
     let resolving = makeResolvingRepositories(
       database: database,
       instrument: instrument,
@@ -193,12 +191,10 @@ final class CloudKitBackend: BackendProvider, @unchecked Sendable {
   }
 
   /// The five repositories that resolve instruments via the injected
-  /// `InstrumentMapResolving`. Split out of `makeRepositories` so
-  /// neither function body exceeds SwiftLint's
-  /// `function_body_length` budget after the resolver cutover. The
-  /// grouping is also semantic: resolver-dependent repositories belong
-  /// together so a future repository that needs the resolver is added
-  /// here, not back into the main `makeRepositories` body.
+  /// `InstrumentMapResolving`. Grouped together semantically:
+  /// resolver-dependent repositories belong here, so a future repository
+  /// that needs the resolver is added here, not into the main
+  /// `makeRepositories` body.
   private struct ResolvingRepositories {
     let accounts: GRDBAccountRepository
     let transactions: GRDBTransactionRepository
@@ -208,10 +204,10 @@ final class CloudKitBackend: BackendProvider, @unchecked Sendable {
   }
 
   /// The read-side instrument resolver and the write-side registrar,
-  /// bundled so the repository-construction helpers stay within
-  /// SwiftLint's `function_parameter_count` budget. In production both
-  /// are the same shared `GRDBInstrumentRegistryRepository`; the type
-  /// keeps them distinct so the seams remain independently swappable.
+  /// bundled to keep the repository-construction helpers' parameter
+  /// lists small. In production both are the same shared
+  /// `GRDBInstrumentRegistryRepository`; the type keeps them distinct
+  /// so the seams remain independently swappable.
   struct InstrumentSeams {
     let resolver: any InstrumentMapResolving
     let registrar: any InstrumentRegistering

--- a/Backends/CloudKit/CloudKitDataImporter.swift
+++ b/Backends/CloudKit/CloudKitDataImporter.swift
@@ -21,16 +21,15 @@ struct ImportResult: Sendable {
 /// are queue-serialised inside `database.write`, so the importer itself
 /// does not need any actor isolation.
 ///
-/// Instrument identity is **not** written to `data.sqlite`: the
-/// `v10_drop_shared_instrument_legacy` migration removed the per-profile
-/// `instrument` table. Every non-fiat denomination the import
+/// Instrument identity is **not** written to `data.sqlite`: there is no
+/// per-profile `instrument` table. Every non-fiat denomination the import
 /// references is registered through the injected
 /// `InstrumentRegistering` (production = the shared profile-index
 /// registry) before the per-profile rows are written, so a read issued
 /// after the import resolves each leg / account instrument. Fiat is
 /// ambient (ISO fallback) and needs no registration. The registrar is
-/// optional only so legacy callers that never had a registry (a few
-/// older tests) still construct; production always injects one.
+/// optional only so callers without a registry (a few tests) still
+/// construct; production always injects one.
 struct CloudKitDataImporter {
   private let database: any DatabaseWriter
   private let currencyCode: String
@@ -90,9 +89,8 @@ struct CloudKitDataImporter {
   private func writeGRDB(data: ExportedData) async throws {
     // Register every non-fiat denomination on the shared registry
     // *before* the per-profile write so a read after import resolves
-    // each leg / account instrument. The per-profile `instrument` table
-    // no longer exists (`v10_drop_shared_instrument_legacy`); fiat is
-    // ambient and a no-op in `registerResolvable`.
+    // each leg / account instrument. There is no per-profile `instrument`
+    // table; fiat is ambient and a no-op in `registerResolvable`.
     try await registerInstruments(data: data)
     try await database.write { database in
       try Self.writeCategories(data: data, database: database)
@@ -178,8 +176,8 @@ struct CloudKitDataImporter {
       try TransactionRow(domain: txn).upsert(database)
       for (index, leg) in txn.legs.enumerated() {
         // Non-fiat denominations were registered on the shared registry
-        // by `registerInstruments` before this transaction; the
-        // per-profile `instrument` table no longer exists post-v10.
+        // by `registerInstruments` before this transaction; there is no
+        // per-profile `instrument` table.
         try TransactionLegRow(domain: leg, transactionId: txn.id, sortOrder: index)
           .upsert(database)
       }

--- a/Backends/CloudKit/Sync/CKRecordIDRecordName.swift
+++ b/Backends/CloudKit/Sync/CKRecordIDRecordName.swift
@@ -20,13 +20,12 @@ enum CKRecordIDRecordName {
 
   /// Returns `true` when a cached recordName is safe to reuse for upload.
   ///
-  /// Cached system fields produced by a build that pre-dated the
-  /// `<recordType>|<UUID>` prefix (issue #416) carry a bare-UUID recordID.
-  /// Reusing them would re-upload the record under the legacy recordName,
-  /// which the rest of the pipeline now treats as non-UUID and drops on
-  /// downlink — so a remote update would never round-trip back. Bare-UUID
-  /// caches are ignored so the next upload reissues a fresh prefixed
-  /// recordID. Instrument recordNames (e.g. `"AUD"`, `"ASX:BHP"`) are
+  /// Cached system fields from a build without the `<recordType>|<UUID>`
+  /// prefix (issue #416) carry a bare-UUID recordID. Reusing one would
+  /// re-upload the record under that bare recordName, which the rest of
+  /// the pipeline treats as non-UUID and drops on downlink — so a remote
+  /// update would never round-trip back. Bare-UUID caches are ignored so
+  /// the next upload reissues a fresh prefixed recordID. Instrument recordNames (e.g. `"AUD"`, `"ASX:BHP"`) are
   /// not UUID-shaped and pass through unchanged.
   static func isUsableCachedRecordName(_ recordName: String) -> Bool {
     if recordName.contains("|") { return true }

--- a/Backends/CloudKit/Sync/CloudKitRecordConvertible.swift
+++ b/Backends/CloudKit/Sync/CloudKitRecordConvertible.swift
@@ -72,7 +72,7 @@ extension CKRecord {
     return coder.encodedData
   }
 
-  /// Creates a CKRecord from previously cached system fields.
+  /// Creates a CKRecord from cached system fields.
   /// Returns nil if the data is invalid.
   static func fromEncodedSystemFields(_ data: Data) -> CKRecord? {
     guard let coder = try? NSKeyedUnarchiver(forReadingFrom: data) else { return nil }

--- a/Backends/CloudKit/Sync/LegacyZoneCleanup.swift
+++ b/Backends/CloudKit/Sync/LegacyZoneCleanup.swift
@@ -5,8 +5,8 @@ import OSLog
 /// One-time cleanup of the legacy `com.apple.coredata.cloudkit.zone` zone.
 ///
 /// SwiftData's automatic CloudKit sync used this hardcoded zone for all data.
-/// Since we've migrated to CKSyncEngine with per-profile zones, this old zone
-/// contains stale data that should be removed.
+/// CKSyncEngine uses per-profile zones, so this zone holds only stale data
+/// that should be removed.
 ///
 /// This is safe for a pre-release app — no backward compatibility needed.
 enum LegacyZoneCleanup {

--- a/Backends/CloudKit/Sync/ProfileDataSyncHandler+ApplyRemoteChanges.swift
+++ b/Backends/CloudKit/Sync/ProfileDataSyncHandler+ApplyRemoteChanges.swift
@@ -65,9 +65,9 @@ extension ProfileDataSyncHandler {
       signpostID: signpostID)
   }
 
-  /// Bundles per-batch timing markers so `reportSuccess` stays under
-  /// the SwiftLint parameter budget. Both fields are populated up front
-  /// in `applyRemoteChanges`; treat as an inline value, not shared state.
+  /// Bundles per-batch timing markers passed to `reportSuccess`. Both
+  /// fields are populated up front in `applyRemoteChanges`; treat as an
+  /// inline value, not shared state.
   nonisolated struct BatchTiming {
     let batchStart: ContinuousClock.Instant
     let upsertDuration: Duration
@@ -124,8 +124,7 @@ extension ProfileDataSyncHandler {
   }
 
   /// Records timings, fires the instrument-touched observer, and
-  /// returns the success outcome. Splitting this out keeps
-  /// `applyRemoteChanges` inside the SwiftLint body-length budget.
+  /// returns the success outcome.
   nonisolated private func reportSuccess(
     saved: [CKRecord],
     deleted: [(CKRecord.ID, String)],
@@ -139,13 +138,12 @@ extension ProfileDataSyncHandler {
       deleteCount: deleted.count)
     let changedTypes = Set(saved.map(\.recordType) + deleted.map(\.1))
     // No `onInstrumentRemoteChange()` fan-out from the per-profile
-    // path: every `InstrumentRecord` now flows through the shared
-    // registry on the profile-index zone. Any straggler delivery here
-    // from a not-yet-upgraded peer device is silently logged and
-    // skipped by `applyBatchSaveInstrument` / `applyGRDBBatchDeletion`
-    // — never applied to the per-profile `instrument` table that the
-    // `v10_drop_shared_instrument_legacy` migration removed. No UI
-    // consumer reads from that table anymore.
+    // path: every `InstrumentRecord` flows through the shared registry
+    // on the profile-index zone. Any straggler delivery here from a
+    // peer device on an older build is silently logged and skipped by
+    // `applyBatchSaveInstrument` / `applyGRDBBatchDeletion`. There is
+    // no per-profile `instrument` table, and no UI consumer reads from
+    // one.
     return .success(changedTypes: changedTypes)
   }
 

--- a/Backends/CloudKit/Sync/ProfileDataSyncHandler+GRDBDispatch.swift
+++ b/Backends/CloudKit/Sync/ProfileDataSyncHandler+GRDBDispatch.swift
@@ -104,8 +104,7 @@ extension ProfileDataSyncHandler {
 
   /// Returns the per-record-type UUID deleter as a curried function,
   /// or `nil` for record types not handled by the GRDB layer. Mirrors
-  /// the `saveHandler` shape so the dispatch table stays under
-  /// SwiftLint's `function_body_length` budget.
+  /// the `saveHandler` shape.
   nonisolated private func uuidDeleter(
     for recordType: String
   ) -> ((ProfileDataSyncHandler, [UUID], Database) throws -> Void)? {
@@ -198,7 +197,7 @@ extension ProfileDataSyncHandler {
   /// Companion to `applyGRDBBatchDeletion(recordType:ids:)` for record
   /// types keyed by string ID. `InstrumentRecord` lives on the
   /// profile-index zone only, so any per-profile-zone deletion is a
-  /// straggler from a pre-rollout peer device — we log and skip
+  /// straggler from a peer device on an older build — we log and skip
   /// rather than apply. The function returns `true` to claim the
   /// dispatch slot so the engine doesn't re-route the deletion
   /// through a fallback path.

--- a/Backends/CloudKit/Sync/ProfileDataSyncHandler+GRDBSaveHelpers.swift
+++ b/Backends/CloudKit/Sync/ProfileDataSyncHandler+GRDBSaveHelpers.swift
@@ -6,10 +6,9 @@ extension ProfileDataSyncHandler {
   // MARK: - Per-Record-Type Save Helpers
 
   /// Inputs to the per-record-type save helpers. Bundling them keeps
-  /// each helper signature compact and below SwiftLint's
-  /// `function_parameter_count` threshold; the underlying `mapRows`
-  /// dispatch uses the typed `Row` argument to recover the CKRecord
-  /// decoder and the per-row id key.
+  /// each helper signature compact; the underlying `mapRows` dispatch
+  /// uses the typed `Row` argument to recover the CKRecord decoder and
+  /// the per-row id key.
   struct GRDBBatchSaveContext {
     let ckRecords: [CKRecord]
     let systemFields: [String: Data]
@@ -53,13 +52,10 @@ extension ProfileDataSyncHandler {
   }
 
   /// **Decommissioned per-profile-zone apply path.** Every
-  /// `InstrumentRecord` save now lives on the profile-index zone (the
-  /// shared registry). A delivery on a per-profile zone is either
-  /// straggler state from a not-yet-upgraded peer device or a
-  /// pre-`v10_drop_shared_instrument_legacy` migration replay; either
-  /// way, applying it would write into the per-profile `instrument`
-  /// table that the v10 follow-up release deletes outright. Spec
-  /// §"Per-profile handler decommissioning" requires we silently log
+  /// `InstrumentRecord` save lives on the profile-index zone (the
+  /// shared registry). A delivery on a per-profile zone is straggler
+  /// state from a peer device on an older build; there is no
+  /// per-profile `instrument` table to apply it to, so silently log
   /// and skip — never apply.
   nonisolated func applyBatchSaveInstrument(
     ckRecords: [CKRecord], systemFields: [String: Data], in database: Database

--- a/Backends/CloudKit/Sync/ProfileDataSyncHandler+QueueAndDelete.swift
+++ b/Backends/CloudKit/Sync/ProfileDataSyncHandler+QueueAndDelete.swift
@@ -25,10 +25,8 @@ extension ProfileDataSyncHandler {
     return recordIDs
   }
 
-  // `queueUnsyncedInstrumentRecords` was removed alongside
-  // `SyncCoordinator.queueUnsyncedInstrumentsForAllProfiles`. Auto-
-  // inserted non-fiat instruments now publish through the shared registry
-  // on the profile-index zone: the create path calls
+  // Auto-inserted non-fiat instruments publish through the shared
+  // registry on the profile-index zone: the create path calls
   // `instrumentRegistrar.registerResolvable` (production = the shared
   // `GRDBInstrumentRegistryRepository`) → `registerStock`/`registerCrypto`
   // → `fireOnRecordChanged` → `queueSave(recordName:zoneID:)` on the
@@ -211,14 +209,12 @@ extension ProfileDataSyncHandler {
     // to leaving local data in an inconsistent state.
     var clearedAll = true
     let wipes: [(String, () throws -> Void)] = [
-      // No per-profile `instrument` wipe. Instrument data no longer
-      // lives in a per-profile table: it is owned by the shared,
-      // iCloud-account-scoped profile-index registry, and a
+      // No per-profile `instrument` wipe. Instrument data is owned by
+      // the shared, iCloud-account-scoped profile-index registry, and a
       // single-profile purge (sign-out / account-switch / zone purge)
-      // must NOT wipe instruments shared by every other profile. The
-      // per-profile `instrument` table was also removed by the
-      // `v10_drop_shared_instrument_legacy` migration, so a
-      // `deleteAllSync` against it would throw `no such table`.
+      // must NOT wipe instruments shared by every other profile. There
+      // is no per-profile `instrument` table, so a `deleteAllSync`
+      // against it would throw `no such table`.
       (CategoryRow.recordType, { try self.grdbRepositories.categories.deleteAllSync() }),
       (AccountRow.recordType, { try self.grdbRepositories.accounts.deleteAllSync() }),
       (EarmarkRow.recordType, { try self.grdbRepositories.earmarks.deleteAllSync() }),

--- a/Backends/CloudKit/Sync/ProfileDataSyncHandler+RecordLookup.swift
+++ b/Backends/CloudKit/Sync/ProfileDataSyncHandler+RecordLookup.swift
@@ -27,21 +27,17 @@ extension ProfileDataSyncHandler {
   /// treated as string IDs and routed to the Instrument lookup.
   ///
   /// **DEBUG trap for `InstrumentRecord` on per-profile zones.**
-  /// After the shared-instrument-registry rollout, every `InstrumentRecord`
-  /// upload routes through the shared registry on the profile-index
-  /// zone. A pending change for `InstrumentRecord` reaching this
-  /// per-profile handler is a programmer error: a callsite either
-  /// retained the legacy per-profile-zone queueing path or a regression
-  /// re-introduced one. The DEBUG `preconditionFailure` fails the test
-  /// suite immediately so the regression cannot land. Release builds
-  /// log the violation and return `nil`, letting CKSyncEngine drop the
-  /// change — the spec's audit-before-merge code-search is the primary
-  /// guard; this trap is the backstop.
+  /// Every `InstrumentRecord` upload routes through the shared registry
+  /// on the profile-index zone. A pending change for `InstrumentRecord`
+  /// reaching this per-profile handler is a programmer error: a callsite
+  /// queued it on the wrong zone. The DEBUG `preconditionFailure` fails
+  /// the test suite immediately so the regression cannot land. Release
+  /// builds log the violation and return `nil`, letting CKSyncEngine
+  /// drop the change.
   ///
-  /// String-keyed recordIDs (the bare `recordName` form previously
-  /// reserved for `InstrumentRecord`) are also caught here: they no
-  /// longer have a legitimate per-profile path either, so the same
-  /// trap applies symmetrically.
+  /// String-keyed recordIDs (the bare `recordName` form used for
+  /// `InstrumentRecord`) are also caught here: they have no legitimate
+  /// per-profile path, so the same trap applies symmetrically.
   func recordToSave(for recordID: CKRecord.ID) -> CKRecord? {
     if let recordType = recordID.prefixedRecordType, let uuid = recordID.uuid {
       if recordType == InstrumentRow.recordType {
@@ -218,11 +214,6 @@ extension ProfileDataSyncHandler {
   private func fetchInvestmentValueRow(id: UUID) -> InvestmentValueRow? {
     fetchRowOrLog { try grdbRepositories.investmentValues.fetchRowSync(id: id) }
   }
-
-  // `fetchInstrumentRow(id: String)` was the per-profile InstrumentRow
-  // string-keyed lookup. Removed when `recordToSave` swapped to a
-  // DEBUG trap on the per-profile zone — string-keyed instrument
-  // lookups no longer have a legitimate caller here.
 
   private func fetchCSVImportProfileRow(id: UUID) -> CSVImportProfileRow? {
     fetchRowOrLog { try grdbRepositories.csvImportProfiles.fetchRowSync(id: id) }

--- a/Backends/CloudKit/Sync/ProfileDataSyncHandler+SystemFields.swift
+++ b/Backends/CloudKit/Sync/ProfileDataSyncHandler+SystemFields.swift
@@ -20,14 +20,9 @@ extension ProfileDataSyncHandler {
   /// keeps a future maintainer from getting them out of step when a
   /// new record type is added.
   private func clearOperations() -> [(String, () throws -> Void)] {
-    // `InstrumentRow.recordType` intentionally omitted: the per-profile
-    // `instrument` table is decommissioned. System fields on those
-    // rows are never consulted by any upload path, and
-    // `queueAllExistingRecords()` no longer enumerates them — clearing
-    // the field on encrypted-data-reset would leave the table in a
-    // spuriously "unsynced" state with no upload path to resolve it.
-    // The `v10_drop_shared_instrument_legacy` migration has since
-    // dropped the table entirely.
+    // `InstrumentRow.recordType` intentionally omitted: there is no
+    // per-profile `instrument` table. No upload path consults system
+    // fields on instrument rows, so they have nothing to clear.
     [
       (CategoryRow.recordType, grdbRepositories.categories.clearAllSystemFieldsSync),
       (AccountRow.recordType, grdbRepositories.accounts.clearAllSystemFieldsSync),
@@ -123,10 +118,9 @@ extension ProfileDataSyncHandler {
 
   /// Groups `ckRecords` by recordType and runs one batch system-fields
   /// write per type. `InstrumentRecord` deliveries on a per-profile
-  /// zone are straggler state from before the shared-registry rollout
-  /// and are logged-and-skipped (the per-profile `instrument` table is
-  /// decommissioned). Records with non-UUID recordNames are also
-  /// skipped — same shape as the pre-batching per-record path.
+  /// zone are straggler state (there is no per-profile `instrument`
+  /// table) and are logged-and-skipped. Records with non-UUID
+  /// recordNames are also skipped.
   private func applySystemFieldsBatched(_ ckRecords: [CKRecord]) {
     var updatesByType: [String: [(id: UUID, data: Data?)]] = [:]
     for ckRecord in ckRecords {

--- a/Backends/CloudKit/Sync/ProfileDataSyncHandler.swift
+++ b/Backends/CloudKit/Sync/ProfileDataSyncHandler.swift
@@ -59,8 +59,8 @@ final class ProfileDataSyncHandler {
   /// avoid `.serverRecordChanged` conflicts. If the cached system
   /// fields reference a *different* zone than this handler's own zone,
   /// they are discarded and the record is uploaded as a fresh create
-  /// in the handler's zone — defence-in-depth against legacy
-  /// corruption from before per-zone fetches were introduced.
+  /// in the handler's zone — defence-in-depth against cross-zone
+  /// system-fields corruption.
   func buildCKRecord<T: CloudKitRecordConvertible>(
     from record: T, encodedSystemFields: Data?
   ) -> CKRecord {

--- a/Backends/CloudKit/Sync/ProfileGRDBRepositories.swift
+++ b/Backends/CloudKit/Sync/ProfileGRDBRepositories.swift
@@ -50,8 +50,8 @@ extension ProfileGRDBRepositories {
   /// real values for user-mutation paths.
   ///
   /// `sharedRegistry` (production CloudKit sync always passes
-  /// `SyncCoordinator.sharedInstrumentRegistry`; tests / previews now
-  /// pass an in-memory shared registry too) is injected as the
+  /// `SyncCoordinator.sharedInstrumentRegistry`; tests / previews
+  /// pass an in-memory shared registry) is injected as the
   /// `instrumentResolver` / `instrumentRegistrar` for every repo that
   /// takes one. The apply path never invokes either seam today —
   /// `applyRemoteChangesSync` writes raw Rows and never calls
@@ -59,20 +59,16 @@ extension ProfileGRDBRepositories {
   /// `create` / `createMany` / `update`, so `registerResolvable` is
   /// never reached — but pointing the seams at the shared profile-index
   /// registry guarantees that any future apply-time resolution can
-  /// never read or write the per-profile `instrument` table that the
-  /// `v10_drop_shared_instrument_legacy` migration removed.
-  /// There is no longer a per-profile fallback: the `PerProfile*`
-  /// shims have been removed because no production or test path may
-  /// read the now-removed per-profile `instrument` table.
+  /// never read or write a per-profile `instrument` table, which does
+  /// not exist. There is no per-profile fallback: no production or test
+  /// path may read a per-profile `instrument` table.
   ///
   /// The bundle's `instruments` member stays a per-profile
   /// `GRDBInstrumentRegistryRepository(database:)` deliberately: its
   /// only sync caller is `ProfileDataSyncHandler` system-fields
   /// clearing on zone purge / sign-out / account-switch. Pointing it
   /// at the shared, iCloud-account-scoped registry would let one
-  /// profile's zone purge mutate every profile's instruments. The
-  /// `v10_drop_shared_instrument_legacy` migration has since removed
-  /// the per-profile table.
+  /// profile's zone purge mutate every profile's instruments.
   static func makeForApply(
     database: any GRDB.DatabaseWriter,
     sharedRegistry: GRDBInstrumentRegistryRepository

--- a/Backends/CloudKit/Sync/ProfileIndexSyncHandler+Instruments.swift
+++ b/Backends/CloudKit/Sync/ProfileIndexSyncHandler+Instruments.swift
@@ -4,10 +4,8 @@
 import Foundation
 import OSLog
 
-/// Instrument-specific helpers for the profile-index zone. Hosts
-/// the partitioning, build, and conflict-merge shapes so the main
-/// `ProfileIndexSyncHandler` file stays under SwiftLint's
-/// `file_length` and `type_body_length` thresholds.
+/// Instrument-specific helpers for the profile-index zone: the
+/// partitioning, build, and conflict-merge shapes for instrument records.
 extension ProfileIndexSyncHandler {
 
   /// Partitions the fetched batch into `(profileRows, instrumentRows)`.
@@ -52,8 +50,8 @@ extension ProfileIndexSyncHandler {
   /// tombstones) and a bare string id (instrument tombstones; see
   /// `InstrumentRow+CloudKit.swift` — instruments use the bare-id
   /// recordName form on purpose). Anything else (an unknown prefixed
-  /// record type, or a hypothetical legacy bare-UUID profile tombstone
-  /// from a pre-prefix peer) is dropped with a logged warning so a
+  /// record type, or a bare-UUID profile tombstone from a peer on a
+  /// build without the prefix) is dropped with a logged warning so a
   /// future record type added to this zone can't silently misroute
   /// into the instrument bucket.
   static func partitionDeleted(
@@ -92,7 +90,7 @@ extension ProfileIndexSyncHandler {
 
   /// Looks up an `InstrumentRow` by string-keyed `recordID` and builds
   /// a CKRecord for upload. Returns `nil` when no `instrumentRepository`
-  /// is wired or the row no longer exists.
+  /// is wired or the row does not exist.
   func instrumentRecordToSave(for recordID: CKRecord.ID) -> CKRecord? {
     guard let instrumentRepository else { return nil }
     do {

--- a/Backends/CloudKit/Sync/ProfileIndexSyncHandler.swift
+++ b/Backends/CloudKit/Sync/ProfileIndexSyncHandler.swift
@@ -21,8 +21,8 @@ import OSLog
 /// shared instrument registry). When an `instrumentRepository` is
 /// supplied, instrument-shaped records are applied / built /
 /// system-field-managed via the dispatched paths; when nil, every
-/// instrument-shaped recordID is silently ignored (legacy callers who
-/// don't yet wire the registry to this zone).
+/// instrument-shaped recordID is silently ignored (callers that don't
+/// wire the registry to this zone, e.g. some test fixtures).
 ///
 /// **Concurrency.** Nonisolated and `Sendable`. Every synchronous method
 /// calls into the repository's `*Sync(...)` helpers which block the
@@ -38,10 +38,10 @@ final class ProfileIndexSyncHandler: Sendable {
   let repository: GRDBProfileIndexRepository
 
   /// Set when this handler is constructed by the shared-instrument
-  /// scope; nil for legacy fixtures that pre-date the dispatch
-  /// extension. When nil, every instrument-shaped record is silently
-  /// dropped (the path is unreachable in production once the boot
-  /// path wires the scope, by Task 12 of the plan).
+  /// scope; nil for test fixtures that don't wire it. When nil, every
+  /// instrument-shaped record is silently dropped; the production boot
+  /// path always wires the scope, so that path is unreachable in
+  /// production.
   let instrumentRepository: GRDBInstrumentRegistryRepository?
 
   /// Fired synchronously after `applyRemoteChanges` writes one or
@@ -49,7 +49,7 @@ final class ProfileIndexSyncHandler: Sendable {
   /// `@MainActor` (this handler is nonisolated `Sendable`) and call
   /// `GRDBInstrumentRegistryRepository.notifyExternalChange()` so
   /// `observeChanges()` subscribers fan out the signal. Default is
-  /// `{}` so the handler stays usable in legacy fixtures.
+  /// `{}` so the handler stays usable in test fixtures.
   ///
   /// Mirrors `ProfileDataSyncHandler.onInstrumentRemoteChange`'s
   /// shape exactly — same `nonisolated let @Sendable () -> Void`

--- a/Backends/CloudKit/Sync/SyncCoordinator+Backfill.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+Backfill.swift
@@ -102,13 +102,6 @@ extension SyncCoordinator {
     return queued
   }
 
-  // `queueUnsyncedInstrumentsForAllProfiles` was removed when the
-  // shared-instrument-registry rollout finished. It used to scan
-  // every per-profile `instrument` table for unsynced non-fiat rows
-  // and queue them for upload to each `profile-<UUID>` zone — a path
-  // the new shared registry on the profile-index zone owns end-to-end.
-  // The replacement is `queueUnsyncedSharedInstruments()` below.
-
   /// Re-queues shared `InstrumentRecord` rows whose
   /// `encoded_system_fields` is `NULL`. Closes the residual idempotency
   /// gap between "shared-registry GRDB write committed" and

--- a/Backends/CloudKit/Sync/SyncCoordinator+CrossDeviceLegDedup.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+CrossDeviceLegDedup.swift
@@ -4,11 +4,7 @@
 import Foundation
 import OSLog
 
-/// Cross-device leg dedup hook for the post-fetch path. Extracted from
-/// `SyncCoordinator+RecordChanges.swift` so each file stays under
-/// SwiftLint's `file_length` threshold and the dedup wiring sits next
-/// to its load-bearing comment instead of inside the apply-changes
-/// dispatcher.
+/// Cross-device leg dedup hook for the post-fetch path.
 ///
 /// Wiring contract:
 /// - `extractTouchedExternalIds(saved:)` runs **off-main** in the same

--- a/Backends/CloudKit/Sync/SyncCoordinator+Delegate.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+Delegate.swift
@@ -9,8 +9,7 @@ import os
 
 // `CKSyncEngineDelegate` conformance for `SyncCoordinator`. The delegate runs
 // on CKSyncEngine's internal executor; both entry points hop to `@MainActor`
-// for all state access. Helper methods extracted from `nextRecordZoneChangeBatch`
-// keep the parent under the SwiftLint complexity / body-length limits.
+// for all state access.
 extension SyncCoordinator: CKSyncEngineDelegate {
   nonisolated func handleEvent(_ event: CKSyncEngine.Event, syncEngine: CKSyncEngine) async {
     if case .fetchedRecordZoneChanges(let changes) = event {
@@ -129,8 +128,7 @@ extension SyncCoordinator: CKSyncEngineDelegate {
   }
 
   /// Splits a batch of pending changes into per-zone save IDs and a flat list of
-  /// delete IDs. Extracted from `nextRecordZoneChangeBatchOnMain` to keep that
-  /// function under the SwiftLint body-length limit.
+  /// delete IDs.
   @MainActor
   private func partitionBatch(
     _ batch: [CKSyncEngine.PendingRecordZoneChange]
@@ -161,8 +159,8 @@ extension SyncCoordinator: CKSyncEngineDelegate {
     )
   }
 
-  /// Counters captured at the end of one `nextBatch` call. Grouped so
-  /// `logBatchOutcome` can stay under the SwiftLint parameter-count limit.
+  /// Counters captured at the end of one `nextBatch` call, grouped for
+  /// `logBatchOutcome`.
   struct BatchOutcome {
     let rawPending: Int
     let deduped: Int
@@ -190,8 +188,7 @@ extension SyncCoordinator: CKSyncEngineDelegate {
 
   /// Returns pending changes filtered to the delegate's scope, deduplicated by
   /// record ID, with records in zones awaiting creation skipped (they'll be
-  /// re-queued by `ensureProfileZone` once the zone exists). Extracted so
-  /// `nextRecordZoneChangeBatchOnMain` stays under the complexity limit; see
+  /// re-queued by `ensureProfileZone` once the zone exists). See
   /// SYNC_GUIDE Rule 12.
   @MainActor
   private func dedupedPendingChanges(

--- a/Backends/CloudKit/Sync/SyncCoordinator+HandlerAccess.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+HandlerAccess.swift
@@ -48,9 +48,8 @@ extension SyncCoordinator {
     let database = try containerManager.database(for: profileId)
     // Production CloudKit sync always carries `sharedInstrumentRegistry`
     // (the profile-index registry); the apply bundle's resolver /
-    // registrar must therefore target it, never the per-profile
-    // `instrument` table that `v10_drop_shared_instrument_legacy`
-    // removed. Tests that build a `SyncCoordinator` without injecting a
+    // registrar must therefore target it. There is no per-profile
+    // `instrument` table. Tests that build a `SyncCoordinator` without injecting a
     // shared registry fall back to a registry over the container's own
     // profile-index DB — still the shared, account-scoped table, never
     // the per-profile one. The apply path never invokes the

--- a/Backends/CloudKit/Sync/SyncCoordinator+LegacyInstrumentDrain.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+LegacyInstrumentDrain.swift
@@ -7,17 +7,14 @@ extension SyncCoordinator {
   /// Returns the subset of `changes` that are leftover legacy
   /// `InstrumentRecord` pending changes routed to a per-profile zone.
   ///
-  /// Two shapes can survive the shared-instrument-registry rollout
-  /// (PR #861):
-  /// - Prefixed `"InstrumentRecord|<UUID>"` recordNames queued by a
-  ///   pre-rollout build.
-  /// - Bare string-keyed recordNames (`"AUD"`, `"0:native"`) queued by
-  ///   the even-older `<scope>:<id>` instrument shape — these have no
-  ///   `|` separator and don't parse as a UUID.
+  /// Two shapes can appear, both only from an older build:
+  /// - Prefixed `"InstrumentRecord|<UUID>"` recordNames.
+  /// - Bare string-keyed recordNames (`"AUD"`, `"0:native"`) from the
+  ///   `<scope>:<id>` instrument shape — these have no `|` separator
+  ///   and don't parse as a UUID.
   ///
-  /// Both shapes can only have come from a pre-rollout build: post-
-  /// rollout, every instrument upload routes through the shared
-  /// registry on the `profile-index` zone, and the DEBUG trap in
+  /// Every instrument upload routes through the shared registry on the
+  /// `profile-index` zone, and the DEBUG trap in
   /// `ProfileDataSyncHandler.recordToSave` aborts the process if one
   /// reaches the per-profile handler. Dropping these from
   /// CKSyncEngine state at start lets upgraded peers self-heal on
@@ -29,9 +26,8 @@ extension SyncCoordinator {
   /// keeps this testable without spinning up a real `CKSyncEngine`.
   ///
   /// Companion to `purgeStaleBareUUIDPendingChanges` (issue #416),
-  /// which targets the orthogonal bare-UUID legacy shape on UUID-
-  /// keyed records — running both at start covers every leftover
-  /// shape we know about.
+  /// which targets the orthogonal bare-UUID shape on UUID-keyed
+  /// records — running both at start covers every leftover shape.
   nonisolated static func legacyInstrumentPendingChanges(
     in changes: some Sequence<CKSyncEngine.PendingRecordZoneChange>
   ) -> [CKSyncEngine.PendingRecordZoneChange] {

--- a/Backends/CloudKit/Sync/SyncCoordinator+Lifecycle.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+Lifecycle.swift
@@ -106,11 +106,10 @@ extension SyncCoordinator {
   /// The body's heavy synchronous work (`NSKeyedUnarchiver` inside
   /// `CKSyncEngine.init`) must not run on the main thread. The
   /// `nonisolated async` hop from the `@MainActor`-originating `Task {}`
-  /// in `start()` is sufficient on current toolchain — verified empirically
-  /// (issue #565) by logging `Thread.isMainThread` at entry and observing
-  /// `false`, plus a different OS TID from the surrounding `@MainActor`
-  /// `completeStart`. Earlier toolchains required `Task.detached` here as
-  /// a waiver; that's no longer the case.
+  /// in `start()` is sufficient on the current toolchain — verified
+  /// empirically (issue #565) by logging `Thread.isMainThread` at entry
+  /// and observing `false`, plus a different OS TID from the surrounding
+  /// `@MainActor` `completeStart`. `Task.detached` is not required here.
   nonisolated static func prepareEngine(
     stateFileURL: URL,
     delegate: any CKSyncEngineDelegate & Sendable
@@ -130,7 +129,7 @@ extension SyncCoordinator {
   }
 
   /// Back-on-MainActor half of `start()`: installs the engine and kicks off
-  /// zone setup. Split from `start()` so the heavy init can run off-actor.
+  /// zone setup. Separate from `start()` so the heavy init can run off-actor.
   private func completeStart(
     prepared: PreparedEngine, signpostID: OSSignpostID
   ) {
@@ -156,12 +155,12 @@ extension SyncCoordinator {
     // below).
     purgeStaleBareUUIDPendingChanges()
     // Drop any leftover `InstrumentRecord` pending changes routed to a
-    // per-profile zone. Post-PR #861 the only legitimate path for an
-    // instrument write is the shared registry on the `profile-index`
-    // zone, and `ProfileDataSyncHandler.recordToSave` traps in DEBUG
-    // when one reaches the per-profile handler — left in the queue,
-    // a single such entry crashes the process the next time
-    // CKSyncEngine asks for the next batch. See
+    // per-profile zone. The only legitimate path for an instrument
+    // write is the shared registry on the `profile-index` zone, and
+    // `ProfileDataSyncHandler.recordToSave` traps in DEBUG when one
+    // reaches the per-profile handler — left in the queue, a single
+    // such entry crashes the process the next time CKSyncEngine asks
+    // for the next batch. See
     // `SyncCoordinator+LegacyInstrumentDrain.swift`.
     purgeLegacyInstrumentPendingChanges()
 
@@ -309,9 +308,8 @@ extension SyncCoordinator {
     syncEngine.state.remove(pendingRecordZoneChanges: stale)
   }
 
-  // The four `queueSave` / `queueDeletion` overloads have moved to
-  // `SyncCoordinator+QueueChanges.swift` — extracted to keep this file
-  // under SwiftLint's 400-line `file_length` threshold.
+  // The four `queueSave` / `queueDeletion` overloads live in
+  // `SyncCoordinator+QueueChanges.swift`.
 
   func sendChanges() async {
     guard let syncEngine, isRunning else { return }

--- a/Backends/CloudKit/Sync/SyncCoordinator+ProfileIndexHooks.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+ProfileIndexHooks.swift
@@ -1,11 +1,9 @@
 import CloudKit
 import Foundation
 
-// Profile-index repository hook wiring split out of the main
-// `SyncCoordinator` body so it stays under SwiftLint's `file_length`
-// threshold. The single entry point is invoked from
-// `SyncCoordinator.init`, so this file's only responsibility is the
-// closure plumbing.
+// Profile-index repository hook wiring for `SyncCoordinator`. The single
+// entry point is invoked from `SyncCoordinator.init`; this file's only
+// responsibility is the closure plumbing.
 extension SyncCoordinator {
 
   /// Installs repository-side hooks so app-side mutations (`upsert` /

--- a/Backends/CloudKit/Sync/SyncCoordinator+QueueChanges.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+QueueChanges.swift
@@ -1,11 +1,9 @@
 import CloudKit
 import Foundation
 
-// `queueSave` / `queueDeletion` overloads extracted from
-// `SyncCoordinator+Lifecycle.swift` so that file stays under SwiftLint's
-// 400-line `file_length` threshold. Same per-method behaviour: append a
-// `pendingRecordZoneChange` to the engine's state and refresh the
-// sidebar mirror so the pending-uploads counter stays in sync.
+// `queueSave` / `queueDeletion` overloads for `SyncCoordinator`. Each
+// appends a `pendingRecordZoneChange` to the engine's state and refreshes
+// the sidebar mirror so the pending-uploads counter stays in sync.
 extension SyncCoordinator {
 
   // MARK: - Pending Changes

--- a/Backends/CloudKit/Sync/SyncCoordinator+RecordChanges.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+RecordChanges.swift
@@ -56,9 +56,7 @@ extension SyncCoordinator {
   }
 
   /// Applies fetched changes for a single zone, wrapping the per-kind dispatch
-  /// in a signpost and slow-zone log. Extracted so
-  /// `handleFetchedRecordZoneChangesAsync` stays under the complexity / body
-  /// length limits.
+  /// in a signpost and slow-zone log.
   nonisolated private func applyFetchedZoneChanges(
     zoneID: CKRecordZone.ID,
     saved: [CKRecord],
@@ -254,8 +252,6 @@ extension SyncCoordinator {
 
   /// Runs one zone's sent-change results through the appropriate handler and
   /// handles any zone-not-found failures by creating the zone and re-queuing.
-  /// Extracted so `handleSentRecordZoneChanges` stays under the complexity /
-  /// body length limits.
   @MainActor
   private func processSentZone(
     zoneID: CKRecordZone.ID,

--- a/Backends/CloudKit/Sync/SyncCoordinator+Refetch.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+Refetch.swift
@@ -68,7 +68,7 @@ extension SyncCoordinator {
 
   /// Resets the re-fetch attempt counter and cancels any pending long-retry task.
   /// Called on every successful apply of fetched changes — a single successful apply
-  /// proves local writes are working, so the slow recovery timer is no longer needed.
+  /// proves local writes are working, so the slow recovery timer is unnecessary.
   func resetRefetchAttempts() {
     refetchAttempts = 0
     longRetryTask?.cancel()

--- a/Backends/CloudKit/Sync/SyncCoordinator+SceneActive.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+SceneActive.swift
@@ -1,7 +1,6 @@
 import Foundation
 
-// Scene-active scheduling extracted from `SyncCoordinator+Lifecycle.swift`
-// so each file stays under SwiftLint's `file_length` threshold. Owns the
+// Scene-active scheduling for `SyncCoordinator`. Owns the
 // cancel-and-replace pattern that `MoolahApp+Lifecycle` uses on
 // `.active` to avoid stacking concurrent fetches.
 extension SyncCoordinator {

--- a/Backends/CloudKit/Sync/SyncCoordinator+StatePersistence.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+StatePersistence.swift
@@ -3,12 +3,10 @@
 @preconcurrency import CloudKit
 import Foundation
 
-/// CKSyncEngine state-serialization persistence helpers, extracted
-/// from `SyncCoordinator.swift` so the main file stays under
-/// SwiftLint's `file_length` budget. Load of the state serialization
-/// happens off-actor in `prepareEngine` on `+Lifecycle`; this file
-/// owns the write / delete paths invoked from `CKSyncEngineDelegate`
-/// callbacks.
+/// CKSyncEngine state-serialization persistence helpers. Load of the
+/// state serialization happens off-actor in `prepareEngine` on
+/// `+Lifecycle`; this file owns the write / delete paths invoked from
+/// `CKSyncEngineDelegate` callbacks.
 extension SyncCoordinator {
 
   /// Atomically writes the engine's serialised state to disk so a

--- a/Backends/CloudKit/Sync/SyncCoordinator.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator.swift
@@ -162,8 +162,8 @@ final class SyncCoordinator {
   /// service, and the conversion service all read from this shared
   /// instance rather than per-profile registries.
   ///
-  /// `nil` for legacy callers (e.g. tests) that don't pass a shared
-  /// registry — those continue with the per-profile registry path.
+  /// `nil` for callers (e.g. tests) that don't pass a shared
+  /// registry — those use the per-profile registry path.
   nonisolated let sharedInstrumentRegistry: GRDBInstrumentRegistryRepository?
 
   /// App-level shared `MarketDataServices` (exchange / stock / crypto
@@ -183,7 +183,7 @@ final class SyncCoordinator {
   /// hold a reference and proxy data reads to this store; per-
   /// session UI state (`error`, `isLoading`) stays on the per-session
   /// store so a transient failure in one session doesn't leak onto
-  /// every Settings screen. `nil` for legacy callers (preview /
+  /// every Settings screen. `nil` for callers (preview /
   /// tests) that don't construct a shared store.
   ///
   /// Not `nonisolated`: `SharedRegistryStore` is `@MainActor
@@ -197,8 +197,7 @@ final class SyncCoordinator {
   // files (Lifecycle / Zones / Backfill / RecordChanges / Delegate) touch are
   // `internal` rather than `private`. Swift does not treat extensions in
   // separate files as part of the same scope, so `private` would make them
-  // unreachable. Public API surface is unchanged; no member here is reachable
-  // outside the module that wasn't already reachable before the split.
+  // unreachable. None is reachable outside the module.
 
   /// User defaults used to persist per-profile "backfill scan complete" flags so the
   /// scan runs at most once per profile across app launches. Injected for testing.

--- a/Backends/CloudKit/Sync/SyncErrorRecovery.swift
+++ b/Backends/CloudKit/Sync/SyncErrorRecovery.swift
@@ -45,7 +45,6 @@ enum SyncErrorRecovery {
   }
 
   /// Route one failed save into the appropriate `ClassifiedFailures` bucket.
-  /// Kept separate so `classify` stays below the cyclomatic-complexity threshold.
   private static func classifySaveFailure(
     _ failure: CKSyncEngine.Event.SentRecordZoneChanges.FailedRecordSave,
     into result: inout ClassifiedFailures,

--- a/Backends/CoinGecko/SQLiteCoinGeckoCatalog+Refresh.swift
+++ b/Backends/CoinGecko/SQLiteCoinGeckoCatalog+Refresh.swift
@@ -135,8 +135,7 @@ extension SQLiteCoinGeckoCatalog {
 
 // MARK: - JSON parsing
 
-/// Wire shape for one row of CoinGecko's `/coins/list` response. Top-level
-/// to keep SwiftLint's `nesting` rule (max one level deep) satisfied.
+/// Wire shape for one row of CoinGecko's `/coins/list` response.
 private struct CoinWire: Decodable {
   let id: String
   let symbol: String

--- a/Backends/GRDB/ProfileIndexSchema+SharedInstrumentRegistry.swift
+++ b/Backends/GRDB/ProfileIndexSchema+SharedInstrumentRegistry.swift
@@ -4,16 +4,16 @@ import Foundation
 import GRDB
 
 /// Body of the `v3_shared_instrument_registry` migration. Creates the
-/// `instrument` table (mirrors the post-v8 per-profile shape from
-/// `ProfileSchema+CoreFinancialGraph.swift` + `ProfileSchema+CryptoWalletFields.swift`)
-/// plus the six rate-cache tables (mirrors the post-v4 per-profile
-/// shape from `ProfileSchema+RateCaches.swift` and
+/// `instrument` table (same shape as the per-profile one in
+/// `ProfileSchema+CoreFinancialGraph.swift` +
+/// `ProfileSchema+CryptoWalletFields.swift`) plus the six rate-cache
+/// tables (same shape as the per-profile ones in
+/// `ProfileSchema+RateCaches.swift` and
 /// `ProfileSchema+RateCacheWithoutRowid.swift`).
 ///
 /// **Verbatim semantics.** Each `CREATE TABLE` reflects the table's
-/// current (post-v8 for `instrument`; post-v4 for rate caches) shape
-/// in a single statement; the historical per-profile evolution is not
-/// replayed here — fresh-table creation does not need it.
+/// final shape in a single statement; fresh-table creation does not
+/// replay per-profile migration steps.
 ///
 /// **`WITHOUT ROWID` decisions.**
 /// * `instrument` — **not** `WITHOUT ROWID`. The `encoded_system_fields`

--- a/Backends/GRDB/ProfileIndexSchema.swift
+++ b/Backends/GRDB/ProfileIndexSchema.swift
@@ -21,18 +21,16 @@ import GRDB
 /// `v1_initial`                    — the `profile` table.
 /// `v2_data_format_version`        — adds `data_format_version INTEGER NOT NULL DEFAULT 0`.
 /// `v3_shared_instrument_registry` — adds the shared `instrument` table
-///   (mirrors the per-profile post-v8 shape) plus the six rate-cache
-///   tables — moved here from per-profile so spam decisions,
-///   discovered-token resolutions, and price-cache rows propagate
-///   across every profile on the same iCloud account. See
+///   plus the six rate-cache tables, so spam decisions, discovered-token
+///   resolutions, and price-cache rows propagate across every profile on
+///   the same iCloud account. See
 ///   `ProfileIndexSchema+SharedInstrumentRegistry.swift`.
 ///
 /// Each migration body is registered here. Once shipped, migration IDs
 /// are frozen forever; splitting later is fine, merging post-ship is
-/// not. As the schema grows, future migration bodies will move into
-/// sibling `ProfileIndexSchema+<Name>.swift` extension files — matching
-/// the convention `ProfileSchema` evolved into — so this file stays a
-/// small index of registered migrations.
+/// not. Migration bodies live in sibling
+/// `ProfileIndexSchema+<Name>.swift` extension files so this file stays
+/// a small index of registered migrations.
 ///
 /// See `guides/DATABASE_SCHEMA_GUIDE.md` for the rules this schema
 /// follows.

--- a/Backends/GRDB/ProfileSchema+CoreFinancialGraph.swift
+++ b/Backends/GRDB/ProfileSchema+CoreFinancialGraph.swift
@@ -22,22 +22,21 @@ import GRDB
 //     `sort_order`) are non-negative or strictly positive as
 //     applicable.
 //
-// Foreign keys (current schema, post-v5): NONE. The eight FKs that
-// the v3 SQL below originally declared
+// Foreign keys: NONE are enforced. The eight FKs the v3 SQL below
+// declares
 // (`transaction_leg.transaction_id|account_id|category_id|earmark_id`,
 // `earmark_budget_item.earmark_id|category_id`,
 // `investment_value.account_id`, `category.parent_id`) are dropped
 // by `v5_drop_foreign_keys` before the database opens for use; the
-// `REFERENCES` clauses still appear in this file because v3 created
-// them and shipped migrations are immutable. CKSyncEngine does not
-// promise parent-before-child arrival across batches, and an
-// out-of-order child insert under enforced FKs would fault the
-// entire fetch transaction and trap the sync coordinator in an
-// infinite re-fetch loop. Integrity is enforced at the application
-// boundary: repository sync entry points (`applyRemoteChangesSync`)
-// and domain `delete(...)` methods replicate the cascade / null-out
-// semantics the FKs used to provide. See
-// `ProfileSchema+DropForeignKeys.swift` for the migration and
+// `REFERENCES` clauses still appear here because shipped migrations
+// are immutable. CKSyncEngine does not promise parent-before-child
+// arrival across batches, and an out-of-order child insert under
+// enforced FKs would fault the entire fetch transaction and trap the
+// sync coordinator in an infinite re-fetch loop. Integrity is
+// enforced at the application boundary: repository sync entry points
+// (`applyRemoteChangesSync`) and domain `delete(...)` methods
+// replicate the cascade / null-out semantics the FKs would provide.
+// See `ProfileSchema+DropForeignKeys.swift` for the migration and
 // `guides/SYNC_GUIDE.md` for the contract.
 //
 // Orphan child rows (a leg or budget item whose parent CKRecord was

--- a/Backends/GRDB/ProfileSchema+DropForeignKeys.swift
+++ b/Backends/GRDB/ProfileSchema+DropForeignKeys.swift
@@ -26,9 +26,8 @@ import GRDB
 //   transaction_leg.earmark_id           → SET NULL
 //   investment_value.account_id          → CASCADE
 //
-// Cascade behaviours that the FKs encoded are reproduced in repository
-// code (`applyRemoteChangesSync` and the domain `delete(...)` methods
-// that previously leaned on the FK).
+// Cascade behaviours the FKs encode are reproduced in repository code
+// (`applyRemoteChangesSync` and the domain `delete(...)` methods).
 
 extension ProfileSchema {
   static func dropForeignKeys(_ database: Database) throws {

--- a/Backends/GRDB/ProfileSchema+DropSharedInstrumentLegacy.swift
+++ b/Backends/GRDB/ProfileSchema+DropSharedInstrumentLegacy.swift
@@ -13,31 +13,28 @@ import GRDB
 // rule 7 — "drop-and-recreate is allowed only for derived caches
 // whose source of truth is elsewhere"):
 //
-// * `instrument` is no longer the source of truth. Instrument
-//   identity now lives on the shared `profile-index.sqlite`
-//   registry (`ProfileIndexSchema`'s `instrument` table), authored
-//   once per iCloud account and fanned out to every profile. The
-//   per-profile copy was a transitional duplicate; every device has
-//   completed the one-time union into the shared registry, so the
-//   per-profile rows have no remaining reader.
+// * `instrument`'s source of truth is the shared
+//   `profile-index.sqlite` registry (`ProfileIndexSchema`'s
+//   `instrument` table), authored once per iCloud account and fanned
+//   out to every profile. The per-profile copy is a duplicate with no
+//   reader.
 // * The six rate-cache tables (`exchange_rate{,_meta}`,
 //   `stock_price` / `stock_ticker_meta`, `crypto_price` /
 //   `crypto_token_meta`) are network-derived caches whose source of
-//   truth is the upstream price/FX APIs. They are now persisted on
-//   the shared profile-index DB so two profiles holding the same
-//   instrument share one cache; the per-profile copies are dead and
-//   re-fetch on demand if ever needed.
+//   truth is the upstream price/FX APIs. They are persisted on the
+//   shared profile-index DB so two profiles holding the same
+//   instrument share one cache; the per-profile copies have no reader
+//   and re-fetch on demand if ever needed.
 //
-// `DROP TABLE IF EXISTS` is idempotent, so a profile DB that somehow
-// never created one of these tables migrates cleanly. The whole
-// statement is one `database.execute(sql:)` — `DatabaseMigrator`
-// wraps every migration in a single transaction, so no explicit
-// BEGIN/COMMIT (a nested one would error).
+// `DROP TABLE IF EXISTS` is idempotent, so a profile DB that never
+// created one of these tables migrates cleanly. The whole statement
+// is one `database.execute(sql:)` — `DatabaseMigrator` wraps every
+// migration in a single transaction, so no explicit BEGIN/COMMIT (a
+// nested one would error).
 //
-// No FK / PRAGMA handling: the per-profile schema declares no
-// foreign keys (as of `v5_drop_foreign_keys`) and none of the seven
-// tables is an FK target, so `PRAGMA foreign_keys` toggling is
-// unnecessary.
+// No FK / PRAGMA handling: the per-profile schema declares no foreign
+// keys and none of the seven tables is an FK target, so
+// `PRAGMA foreign_keys` toggling is unnecessary.
 //
 // No sidecar / file cleanup: this migration only issues SQL inside
 // the migrator's transaction — it never touches the `*.sqlite` file

--- a/Backends/GRDB/ProfileSchema+RateCaches.swift
+++ b/Backends/GRDB/ProfileSchema+RateCaches.swift
@@ -5,13 +5,12 @@ import GRDB
 
 // MARK: - v1 migration body
 //
-// The three `*_meta` tables ship here as ROWID tables — the shape
-// originally chosen because GRDB 7's `PersistableRecord.upsert(_:)`
-// hard-codes `RETURNING "rowid"` and trips on `WITHOUT ROWID` tables.
-// `v4_rate_cache_without_rowid` rebuilds them as `WITHOUT ROWID`
-// (single-TEXT-PK lookup tables per
-// `guides/DATABASE_SCHEMA_GUIDE.md` §3) once the writers switched
-// away from `upsert` to `insert(onConflict: .replace)`. Editing this
+// The three `*_meta` tables ship here as ROWID tables because GRDB 7's
+// `PersistableRecord.upsert(_:)` hard-codes `RETURNING "rowid"` and
+// trips on `WITHOUT ROWID` tables. `v4_rate_cache_without_rowid`
+// rebuilds them as `WITHOUT ROWID` (single-TEXT-PK lookup tables per
+// `guides/DATABASE_SCHEMA_GUIDE.md` §3); writers use
+// `insert(onConflict: .replace)` rather than `upsert`. Editing this
 // body in place would violate §6 (frozen migrations).
 //
 // **`WITHOUT ROWID` and `ValueObservation`.** The three rate tables

--- a/Backends/GRDB/ProfileSchema.swift
+++ b/Backends/GRDB/ProfileSchema.swift
@@ -48,26 +48,24 @@ import GRDB
 /// `v10_drop_shared_instrument_legacy` — drops the seven legacy
 /// per-profile tables (`instrument`, `exchange_rate`,
 /// `exchange_rate_meta`, `stock_price`, `stock_ticker_meta`,
-/// `crypto_price`, `crypto_token_meta`). Every device has completed
-/// the one-time union into the shared profile-index registry, so the
-/// per-profile copies have no remaining reader. Permitted per
-/// `guides/DATABASE_SCHEMA_GUIDE.md` §1 rule 3 / §6 rule 7. See
-/// `ProfileSchema+DropSharedInstrumentLegacy.swift` for the full
-/// rationale.
+/// `crypto_price`, `crypto_token_meta`). Their data lives in the
+/// shared profile-index registry, so the per-profile copies have no
+/// reader. Permitted per `guides/DATABASE_SCHEMA_GUIDE.md` §1 rule 3 /
+/// §6 rule 7. See `ProfileSchema+DropSharedInstrumentLegacy.swift` for
+/// the full rationale.
 ///
 /// **Retention policy for the cache tables.** The six rate-cache
-/// tables originally created by `v1_initial` are kept forever — needed
-/// for historic-conversion correctness on reports older than the
-/// upstream rate APIs can serve (see `guides/DATABASE_SCHEMA_GUIDE.md`
-/// §9). As of `v10` that retained copy lives on the **shared**
-/// `profile-index.sqlite` DB, not per-profile; the per-profile copies
-/// are dropped because they are now duplicated derived caches.
+/// tables are kept forever — needed for historic-conversion
+/// correctness on reports older than the upstream rate APIs can serve
+/// (see `guides/DATABASE_SCHEMA_GUIDE.md` §9). The retained copy lives
+/// on the **shared** `profile-index.sqlite` DB, not per-profile; the
+/// per-profile copies are dropped as duplicated derived caches.
 ///
 /// Each migration body lives in its own sibling-extension file so
 /// `ProfileSchema.swift` stays a small index of registered migrations.
-/// New migrations get a new sibling file, registered here. Once
-/// shipped, migration IDs are frozen forever; splitting later is
-/// fine, merging post-ship is not.
+/// New migrations get a new sibling file, registered here. Migration
+/// IDs are frozen forever once shipped; splitting later is fine,
+/// merging post-ship is not.
 ///
 /// See `guides/DATABASE_SCHEMA_GUIDE.md` for the rules this schema
 /// follows.

--- a/Backends/GRDB/Records/InstrumentRow+Mapping.swift
+++ b/Backends/GRDB/Records/InstrumentRow+Mapping.swift
@@ -25,15 +25,15 @@ extension InstrumentRow {
 
   /// ISO-4217 fiat instruments synthesised once at first use.
   ///
-  /// `fetchInstrumentMap` previously rebuilt this on every call —
-  /// ~150 `Instrument.fiat(code:)` constructions (each spinning up a
-  /// `NumberFormatter` to derive the currency's decimal places) over
-  /// `Locale.Currency.isoCurrencies`. On the cold-launch resolution
-  /// burst that dominated the call. The inputs are process-stable:
+  /// Computed into a `static let` rather than per `fetchInstrumentMap`
+  /// call: ~150 `Instrument.fiat(code:)` constructions (each spinning
+  /// up a `NumberFormatter` to derive the currency's decimal places)
+  /// over `Locale.Currency.isoCurrencies` would otherwise dominate the
+  /// cold-launch resolution burst. The inputs are process-stable:
   /// `Locale.Currency.isoCurrencies` is a fixed ISO table for the
   /// process lifetime, and `Instrument.fiat(code:)` derives decimals
   /// from the currency *code* (not the user's locale), so the synthesis
-  /// is deterministic and safe to compute once into a `static let`.
+  /// is deterministic and safe to compute once.
   private static let ambientFiat: [String: Instrument] = {
     var map: [String: Instrument] = [:]
     for code in Locale.Currency.isoCurrencies.map(\.identifier) {

--- a/Backends/GRDB/Repositories/DailyBalanceCompute.swift
+++ b/Backends/GRDB/Repositories/DailyBalanceCompute.swift
@@ -4,19 +4,16 @@ import Foundation
 import GRDB
 
 /// Computes account-level daily cumulative balances from transaction
-/// legs for `GRDBInvestmentRepository.fetchDailyBalances`. Lifted out
-/// of the main repository file so the class body stays under the
-/// SwiftLint `type_body_length` budget.
+/// legs for `GRDBInvestmentRepository.fetchDailyBalances`.
 ///
 /// Returns one `AccountDailyBalance` per (calendar-day, instrument)
-/// tuple — multi-instrument legacy investment accounts no longer
-/// conflate quantities of different instruments under a single label
-/// (issue #579). The consuming `InvestmentStore` aggregates these into
-/// the host currency via `InstrumentConversionService`.
+/// tuple, so multi-instrument investment accounts do not conflate
+/// quantities of different instruments under a single label (issue
+/// #579). The consuming `InvestmentStore` aggregates these into the
+/// host currency via `InstrumentConversionService`.
 enum DailyBalanceCompute {
   /// One leg paired with its parent transaction's date — the unit of
-  /// work fed to `aggregateByInstrument`. Replaces an inline 3-tuple
-  /// (`large_tuple` SwiftLint violation).
+  /// work fed to `aggregateByInstrument`.
   private struct LegEntry {
     let date: Date
     let instrumentId: String

--- a/Backends/GRDB/Repositories/GRDBAccountRepository+Create.swift
+++ b/Backends/GRDB/Repositories/GRDBAccountRepository+Create.swift
@@ -3,15 +3,14 @@
 import Foundation
 import GRDB
 
-// `performAccountInsert` + `OpeningBalanceInserts` extracted from
-// `GRDBAccountRepository` so the main type body stays under SwiftLint's
-// `type_body_length` and `file_length` budgets.
+// Account-insert support (`performAccountInsert`,
+// `OpeningBalanceInserts`) for `GRDBAccountRepository`.
 extension GRDBAccountRepository {
   /// Captures the ids written by `create(_:openingBalance:)` so the
   /// caller can fan out hook fires after the write transaction commits.
   /// Non-fiat instrument registration is done by `create` itself via
   /// `instrumentRegistrar.registerResolvable` *before* this write — it
-  /// is no longer part of the per-profile insert.
+  /// is not part of the per-profile insert.
   struct OpeningBalanceInserts: Sendable {
     let transactionId: UUID?
     let legId: UUID?

--- a/Backends/GRDB/Repositories/GRDBAccountRepository+Observation.swift
+++ b/Backends/GRDB/Repositories/GRDBAccountRepository+Observation.swift
@@ -3,10 +3,7 @@
 import Foundation
 import GRDB
 
-// Reactive observation surface for `AccountRepository`. Split out of the
-// main class file to keep `GRDBAccountRepository.swift` under SwiftLint's
-// `file_length` warning threshold and to mirror the established
-// `+Positions.swift` companion-file pattern.
+// Reactive observation surface for `AccountRepository`.
 //
 // `observeAll()` returns the same domain projection as `fetchAll()`:
 // account rows ordered by `position`, each populated with its full
@@ -29,8 +26,8 @@ import GRDB
 // resolves the map once via `instrumentResolver` when the stream's
 // worker task starts, captures it into the tracking closure, and drops
 // `InstrumentRow.observableRegion` from the tracked regions (those rows
-// are no longer in this DB). An instrument-metadata edit therefore does
-// not live-refresh an already-open list until the next refetch
+// live on the separate profile-index DB). An instrument-metadata edit
+// therefore does not live-refresh an already-open list until the next refetch
 // (re-subscribe); cross-database instrument-metadata live-refresh is
 // wired via the shared registry's change stream in a follow-up. The
 // async-resolve-then-observe bridge is `resolvedInstrumentMapStream`
@@ -56,7 +53,7 @@ extension GRDBAccountRepository {
         // Explicit-region form: every joined table's `observableRegion`
         // excludes the sync-bookkeeping `encoded_system_fields` blob, so
         // CKSyncEngine's per-batch system-fields write does not re-fire
-        // this observation. See issue #865. `InstrumentRow` is no longer
+        // this observation. See issue #865. `InstrumentRow` is not
         // tracked here — those rows live on the separate profile-index
         // database; the map is the captured `instruments` snapshot.
         //

--- a/Backends/GRDB/Repositories/GRDBAccountRepository+Positions.swift
+++ b/Backends/GRDB/Repositories/GRDBAccountRepository+Positions.swift
@@ -3,12 +3,11 @@
 import Foundation
 import GRDB
 
-// Position-computation helpers split out of `GRDBAccountRepository` so
-// the main class body stays under SwiftLint's `type_body_length`
-// threshold. The SQL groups non-scheduled, account-bound legs by
+// Position-computation helpers for `GRDBAccountRepository`. The SQL
+// groups non-scheduled, account-bound legs by
 // `(account_id, instrument_id)`; rows resolve their full `Instrument`
 // value via the supplied lookup table (with ambient ISO fiat as a
-// fallback). Mirrors the SwiftData-era
+// fallback). Matches
 // `CloudKitAccountRepository.computePositions(from:instruments:)`.
 extension GRDBAccountRepository {
   /// Computes per-account, per-instrument position sums from the

--- a/Backends/GRDB/Repositories/GRDBAccountRepository+Sync.swift
+++ b/Backends/GRDB/Repositories/GRDBAccountRepository+Sync.swift
@@ -9,11 +9,7 @@ import GRDB
 // context. `DatabaseWriter.write { db in … }` has both async and sync
 // overloads; the sync form blocks the calling thread until the queue's
 // serial executor admits the closure. Never call these from
-// `@MainActor`.
-//
-// Extracted from `GRDBAccountRepository.swift` so the main type body
-// stays under SwiftLint's `file_length` budget — mirrors
-// `GRDBTransactionRepository+Sync.swift`.
+// `@MainActor`. Mirrors `GRDBTransactionRepository+Sync.swift`.
 
 extension GRDBAccountRepository {
   func applyRemoteChangesSync(saved rows: [AccountRow], deleted ids: [UUID]) throws {

--- a/Backends/GRDB/Repositories/GRDBAccountRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBAccountRepository.swift
@@ -10,8 +10,8 @@ import GRDB
 /// per-instrument `positions` populated. Positions are summed from
 /// non-scheduled `transaction_leg` rows grouped by
 /// `(account_id, instrument_id)` and resolved against the `instrument`
-/// registry (with ambient ISO fiat as a fallback). Mirrors the
-/// SwiftData-era `CloudKitAccountRepository.computePositions`.
+/// registry (with ambient ISO fiat as a fallback). Matches
+/// `CloudKitAccountRepository.computePositions`.
 ///
 /// **Opening balance.** `create(_:openingBalance:)` performs the account
 /// insert and the optional opening-balance transaction (one
@@ -165,8 +165,7 @@ final class GRDBAccountRepository: AccountRepository, @unchecked Sendable {
   }
 
   // `performAccountInsert` and `OpeningBalanceInserts` live in
-  // `GRDBAccountRepository+Create.swift` to keep this file under
-  // SwiftLint's `type_body_length` and `file_length` budgets.
+  // `GRDBAccountRepository+Create.swift`.
 
   func update(_ account: Account) async throws -> Account {
     guard !account.name.trimmingCharacters(in: .whitespaces).isEmpty else {
@@ -239,7 +238,7 @@ final class GRDBAccountRepository: AccountRepository, @unchecked Sendable {
   func delete(id: UUID) async throws {
     // Soft-delete: flip `is_hidden = true` on the matching row.
     // Rejects deletes against an account with non-zero positions —
-    // mirrors the SwiftData-era contract enforced by
+    // mirrors the contract enforced by
     // `CloudKitAccountRepository.delete(id:)`.
     // Hoisted ahead of the write snapshot for the same cross-database
     // reason as `fetchAll()`.
@@ -269,7 +268,6 @@ final class GRDBAccountRepository: AccountRepository, @unchecked Sendable {
   //
   // The synchronous, GRDB-queue-blocking sync entry points
   // (`applyRemoteChangesSync`, `setEncodedSystemFieldsSync` and
-  // siblings) live in `GRDBAccountRepository+Sync.swift` to keep this
-  // file under SwiftLint's `file_length` budget — mirrors
+  // siblings) live in `GRDBAccountRepository+Sync.swift`, mirroring
   // `GRDBTransactionRepository+Sync.swift`.
 }

--- a/Backends/GRDB/Repositories/GRDBAnalysisRepository+CategoryBalances.swift
+++ b/Backends/GRDB/Repositories/GRDBAnalysisRepository+CategoryBalances.swift
@@ -3,12 +3,10 @@ import GRDB
 
 /// SQL aggregation + Swift assembly helpers for `fetchCategoryBalances`.
 ///
-/// Lifted out of the main `GRDBAnalysisRepository` body to keep its
-/// `type_body_length` budget intact, mirroring the
-/// `+ExpenseBreakdown.swift` shape: every helper is `static` and takes
-/// its dependencies (database, instruments, conversion service) as
-/// parameters so it doesn't need access to the main class's `private`
-/// stored properties from a sibling-file extension.
+/// Mirrors the `+ExpenseBreakdown.swift` shape: every helper is
+/// `static` and takes its dependencies (database, instruments,
+/// conversion service) as parameters so this sibling-file extension
+/// doesn't reach into the main class's `private` stored properties.
 ///
 /// The SQL groups by `(DATE(t.date), category_id, instrument_id)` and
 /// the per-row conversion runs in Swift so the per-day rate-cache
@@ -52,20 +50,18 @@ extension GRDBAnalysisRepository {
   }
 
   /// Bundle of per-row diagnostic callbacks used by
-  /// `assembleCategoryBalances`. Grouped into a struct so the function
-  /// signature stays under SwiftLint's `function_parameter_count`
-  /// budget, matching `ExpenseBreakdownHandlers` on
-  /// `+ExpenseBreakdown.swift`.
+  /// `assembleCategoryBalances`, so `assembleCategoryBalances` takes
+  /// one parameter instead of several. Matches `ExpenseBreakdownHandlers`
+  /// on `+ExpenseBreakdown.swift`.
   struct CategoryBalancesHandlers: Sendable {
     let handleUnparseableDay: @Sendable (String) -> Void
     let handleConversionFailure: @Sendable (Error, CategoryBalancesFailureContext) -> Void
   }
 
   /// Bundle of optional filter values passed from the public
-  /// `fetchCategoryBalances` entry point down to the SQL composer. Keeps
-  /// the static helper's parameter count under SwiftLint's budget while
-  /// allowing each caller to surface its own `TransactionFilter`
-  /// projection.
+  /// `fetchCategoryBalances` entry point down to the SQL composer,
+  /// collapsing the static helper's parameter list while allowing each
+  /// caller to surface its own `TransactionFilter` projection.
   struct CategoryBalancesFilterArgs: Sendable {
     let dateRange: ClosedRange<Date>
     let transactionType: TransactionType

--- a/Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesAggregation.swift
+++ b/Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesAggregation.swift
@@ -4,9 +4,8 @@ import GRDB
 /// SQL-side helpers for the `fetchDailyBalances` aggregation. Holds
 /// the four query strings, the row decoders, scheduled-transaction
 /// loader, accounts/instrument-map fetch, and the `database.read`
-/// entry point — split out of `+DailyBalances.swift` so that file's
-/// Swift assembly path (the per-day position-book walk + forecast
-/// fold) stays under the SwiftLint `file_length` budget.
+/// entry point. The Swift assembly path (the per-day position-book
+/// walk + forecast fold) lives in `+DailyBalances.swift`.
 extension GRDBAnalysisRepository {
 
   // MARK: - Public read entry point

--- a/Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesForecast.swift
+++ b/Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesForecast.swift
@@ -9,9 +9,6 @@ import OSLog
 /// sources have no future rates), and the converted instances feed a
 /// sequential `PositionBook` walk that emits one forecast
 /// `DailyBalance` per instance day.
-///
-/// Split out of `+DailyBalances.swift` for the SwiftLint
-/// `file_length` budget.
 extension GRDBAnalysisRepository {
   /// Generate the forecast tail by extrapolating scheduled
   /// transactions and feeding each instance into a fresh

--- a/Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesInvestmentValues.swift
+++ b/Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesInvestmentValues.swift
@@ -8,8 +8,6 @@ import GRDB
 /// driving the `investmentValue` and `netWorth` fields. Also owns the
 /// SQL fetches that produce the inputs to that fold-in
 /// (`fetchInvestmentAccountIds`, `fetchInvestmentValueSnapshots`).
-/// Split out of `+DailyBalances.swift` for the SwiftLint `file_length`
-/// budget.
 extension GRDBAnalysisRepository {
 
   // MARK: - SQL fetches

--- a/Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesTradesMode.swift
+++ b/Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesTradesMode.swift
@@ -7,18 +7,15 @@ import Foundation
 /// other thrown error drops the day from `dailyBalances` and logs
 /// through `handleInvestmentValueFailure`.
 ///
-/// Split out of `+DailyBalancesInvestmentValues.swift` for the
-/// SwiftLint `file_length` budget — recorded-value (snapshot) and
-/// trades-mode (position) folds are conceptually paired but each is
-/// long enough to warrant its own file.
+/// Paired with the recorded-value (snapshot) fold in
+/// `+DailyBalancesInvestmentValues.swift`.
 extension GRDBAnalysisRepository {
 
   // MARK: - Trades-mode per-day fold
 
   /// One decoded entry in the trades-mode cursor walk — a per-day,
   /// per-account, per-instrument quantity ready to apply to the
-  /// cumulative `positions` dict. Four fields exceeds SwiftLint's
-  /// `large_tuple` error threshold, so a named struct is required.
+  /// cumulative `positions` dict.
   private struct TradesModePositionEntry {
     let dayKey: Date
     let accountId: UUID

--- a/Backends/GRDB/Repositories/GRDBAnalysisRepository+ExpenseBreakdown.swift
+++ b/Backends/GRDB/Repositories/GRDBAnalysisRepository+ExpenseBreakdown.swift
@@ -3,12 +3,11 @@ import GRDB
 
 /// SQL aggregation + Swift assembly helpers for `fetchExpenseBreakdown`.
 ///
-/// Lifted out of the main `GRDBAnalysisRepository` body to keep its
-/// `type_body_length` budget intact. Mirrors the
-/// `GRDBAccountRepository+Positions.swift` shape: every helper is `static`
-/// and takes its dependencies (database, instruments, conversion service)
-/// as parameters so it doesn't need access to the main class's `private`
-/// stored properties from a sibling-file extension.
+/// Mirrors the `GRDBAccountRepository+Positions.swift` shape: every
+/// helper is `static` and takes its dependencies (database,
+/// instruments, conversion service) as parameters so this sibling-file
+/// extension doesn't reach into the main class's `private` stored
+/// properties.
 extension GRDBAnalysisRepository {
   /// One row of the SQL aggregation that drives `fetchExpenseBreakdown`.
   /// `day` is the ISO-8601 `YYYY-MM-DD` string returned by `DATE(t.date)`
@@ -43,9 +42,8 @@ extension GRDBAnalysisRepository {
   }
 
   /// Bundle of per-row diagnostic callbacks used by
-  /// `assembleExpenseBreakdown`. Grouped into a struct so the function
-  /// signature stays under SwiftLint's `function_parameter_count`
-  /// budget, and so future analysis methods can share the same
+  /// `assembleExpenseBreakdown`, so its signature takes one parameter
+  /// instead of several and other analysis methods can share the same
   /// handler shape.
   struct ExpenseBreakdownHandlers: Sendable {
     let handleUnparseableDay: @Sendable (String) -> Void
@@ -183,8 +181,8 @@ extension GRDBAnalysisRepository {
   }
 
   /// Emits one `ExpenseBreakdown` per non-empty `(month, category)` bucket
-  /// and sorts months descending — matching the SwiftData-era contract
-  /// pinned by `AnalysisExpenseBreakdownTests.expenseBreakdownSortOrder`.
+  /// and sorts months descending — the contract pinned by
+  /// `AnalysisExpenseBreakdownTests.expenseBreakdownSortOrder`.
   private static func flattenExpenseBreakdownBuckets(
     _ buckets: [String: [UUID?: InstrumentAmount]]
   ) -> [ExpenseBreakdown] {

--- a/Backends/GRDB/Repositories/GRDBAnalysisRepository+IncomeAndExpense.swift
+++ b/Backends/GRDB/Repositories/GRDBAnalysisRepository+IncomeAndExpense.swift
@@ -3,9 +3,9 @@ import GRDB
 
 /// Swift assembly helpers and shared types for `fetchIncomeAndExpense`.
 /// The SQL aggregation itself lives in the sibling
-/// `+IncomeAndExpenseAggregation.swift` (split out for the SwiftLint
-/// `file_length` budget); this file fans the per-`(day, instrument)`
-/// rows it produces out into per-month income/expense buckets.
+/// `+IncomeAndExpenseAggregation.swift`; this file fans the
+/// per-`(day, instrument)` rows it produces out into per-month
+/// income/expense buckets.
 ///
 /// Mirrors the `+ExpenseBreakdown.swift` and `+CategoryBalances.swift`
 /// shapes: static helpers take their dependencies as parameters so
@@ -80,8 +80,8 @@ extension GRDBAnalysisRepository {
   /// outside `MonthlyIncomeExpense` (which has only `let` fields) so
   /// the loop can `+=` into each bucket without rebuilding the value
   /// type on every leg. `start` / `end` track the min/max parsed-day
-  /// `Date` so the resulting `MonthlyIncomeExpense` preserves the
-  /// SwiftData-era display behaviour.
+  /// `Date` so the resulting `MonthlyIncomeExpense` carries the
+  /// expected display range.
   private struct MonthBucket {
     var start: Date
     var end: Date
@@ -92,9 +92,8 @@ extension GRDBAnalysisRepository {
     var earmarkedProfit: InstrumentAmount
   }
 
-  /// Bundle of converted per-row sums fed into a month bucket. Lifted
-  /// out of the assembly loop so the bucket-update helper stays under
-  /// SwiftLint's `function_parameter_count` budget.
+  /// Bundle of converted per-row sums fed into a month bucket, so the
+  /// bucket-update helper takes one parameter instead of many.
   private struct ConvertedRowSums {
     let day: Date
     let income: InstrumentAmount

--- a/Backends/GRDB/Repositories/GRDBAnalysisRepository+IncomeAndExpenseAggregation.swift
+++ b/Backends/GRDB/Repositories/GRDBAnalysisRepository+IncomeAndExpenseAggregation.swift
@@ -3,9 +3,8 @@ import GRDB
 
 /// SQL-side helpers for the `fetchIncomeAndExpense` aggregation. Holds
 /// the query string, the row decoder, and the `database.read` entry
-/// point — split out of `+IncomeAndExpense.swift` so that file's Swift
-/// assembly path (the per-row conversion + month-bucket fold) stays
-/// under the SwiftLint `file_length` budget.
+/// point. The Swift assembly path (the per-row conversion +
+/// month-bucket fold) lives in `+IncomeAndExpense.swift`.
 extension GRDBAnalysisRepository {
   /// Runs the per-(day, instrument) conditional-sum aggregation
   /// pinned by
@@ -57,10 +56,9 @@ extension GRDBAnalysisRepository {
   }
 }
 
-/// File-private SQL for the per-(day, instrument) aggregation. Hoisted
-/// to file scope so the read closure body stays under SwiftLint's
-/// `closure_body_length` budget. The query's plan shape (index usage,
-/// absence of full-table scans) is pinned by
+/// File-private SQL for the per-(day, instrument) aggregation. The
+/// query's plan shape (index usage, absence of full-table scans) is
+/// pinned by
 /// `AnalysisAggregationPlanPinningTests.fetchIncomeAndExpenseUsesTypeAccountIndex`;
 /// structural changes here (WHERE predicates, JOIN reorders, GROUP BY)
 /// should be reflected in that test so the plan stays under EXPLAIN.

--- a/Backends/GRDB/Repositories/GRDBAnalysisRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBAnalysisRepository.swift
@@ -45,7 +45,6 @@ final class GRDBAnalysisRepository: AnalysisRepository, @unchecked Sendable {
   //
   // `+IncomeAndExpenseAggregation.swift` — `fetchIncomeAndExpenseAggregation`,
   // `mapAggregationRow`, file-private `incomeAndExpenseAggregationSQL`.
-  // Split out of `+IncomeAndExpense.swift` for `file_length` budget.
   //
   // `+DailyBalances.swift` — types (`DailyBalanceAccountRow`,
   // `DailyBalanceEarmarkRow`, `DailyBalancesAggregation`,

--- a/Backends/GRDB/Repositories/GRDBCSVImportProfileRepository+Observation.swift
+++ b/Backends/GRDB/Repositories/GRDBCSVImportProfileRepository+Observation.swift
@@ -3,11 +3,7 @@
 import Foundation
 import GRDB
 
-// Reactive observation surface for `CSVImportProfileRepository`. Split
-// out of the main class file to keep `GRDBCSVImportProfileRepository.swift`
-// under SwiftLint's `file_length` warning threshold and to mirror the
-// established `GRDBImportRuleRepository+Observation.swift` /
-// `GRDBCategoryRepository+Observation.swift` companion-file pattern.
+// Reactive observation surface for `CSVImportProfileRepository`.
 //
 // `observeAll()` returns the same domain projection as `fetchAll()`:
 // every `csv_import_profile` row, ordered by `created_at`, mapped

--- a/Backends/GRDB/Repositories/GRDBCategoryRepository+Observation.swift
+++ b/Backends/GRDB/Repositories/GRDBCategoryRepository+Observation.swift
@@ -3,11 +3,7 @@
 import Foundation
 import GRDB
 
-// Reactive observation surface for `CategoryRepository`. Split out of
-// the main class file to keep `GRDBCategoryRepository.swift` under
-// SwiftLint's `file_length` warning threshold and to mirror the
-// established `GRDBAccountRepository+Observation.swift` /
-// `GRDBEarmarkRepository+Observation.swift` companion-file pattern.
+// Reactive observation surface for `CategoryRepository`.
 //
 // `observeAll()` returns the same domain projection as `fetchAll()`:
 // every `category` row, ordered by `name`, mapped through `toDomain()`.

--- a/Backends/GRDB/Repositories/GRDBEarmarkRepository+Observation.swift
+++ b/Backends/GRDB/Repositories/GRDBEarmarkRepository+Observation.swift
@@ -3,10 +3,7 @@
 import Foundation
 import GRDB
 
-// Reactive observation surface for `EarmarkRepository`. Split out of the
-// main class file to keep `GRDBEarmarkRepository.swift` under SwiftLint's
-// `file_length` warning threshold and to mirror the established
-// `+Positions.swift` companion-file pattern.
+// Reactive observation surface for `EarmarkRepository`.
 //
 // `observeAll()` returns the same domain projection as `fetchAll()`:
 // earmark rows ordered by `position`, each populated with their full
@@ -33,8 +30,8 @@ import GRDB
 // resolves the map once via `instrumentResolver` when the stream's
 // worker task starts, captures it into the tracking closure, and drops
 // `InstrumentRow.observableRegion` from the tracked regions (those rows
-// are no longer in this DB). An instrument-metadata edit therefore does
-// not live-refresh an already-open list until the next refetch
+// live on the separate profile-index DB). An instrument-metadata edit
+// therefore does not live-refresh an already-open list until the next refetch
 // (re-subscribe). `observeBudget(earmarkId:)` does not consult the
 // instrument map (it labels items from the parent earmark's own
 // `instrument_id`), so it keeps the plain synchronous shape. The
@@ -62,7 +59,7 @@ extension GRDBEarmarkRepository {
         // Explicit-region form: every joined table's `observableRegion`
         // excludes the sync-bookkeeping `encoded_system_fields` blob, so
         // CKSyncEngine's per-batch system-fields write does not re-fire
-        // this observation. See issue #865. `InstrumentRow` is no longer
+        // this observation. See issue #865. `InstrumentRow` is not
         // tracked here — those rows live on the separate profile-index
         // database; the map is the captured `instruments` snapshot.
         //

--- a/Backends/GRDB/Repositories/GRDBEarmarkRepository+Positions.swift
+++ b/Backends/GRDB/Repositories/GRDBEarmarkRepository+Positions.swift
@@ -3,10 +3,8 @@
 import Foundation
 import GRDB
 
-// Position-computation helpers for `GRDBEarmarkRepository`. Split out of
-// the main file so the class body stays under SwiftLint's
-// `type_body_length` threshold. Three lists per earmark map the
-// SwiftData-era `CloudKitEarmarkRepository.computeEarmarkPositions`:
+// Position-computation helpers for `GRDBEarmarkRepository`. Three lists
+// per earmark, matching `CloudKitEarmarkRepository.computeEarmarkPositions`:
 // every leg contributes to `positions`; income/openingBalance/trade
 // legs contribute to `savedPositions`; expense/transfer legs
 // contribute to `spentPositions` (sign-flipped).

--- a/Backends/GRDB/Repositories/GRDBEarmarkRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBEarmarkRepository.swift
@@ -20,7 +20,7 @@ import GRDB
 /// `transaction_leg` rows grouped by instrument: every earmark-tagged
 /// leg contributes to `positions`; income/openingBalance/trade legs
 /// contribute to `savedPositions`; expense/transfer legs contribute to
-/// `spentPositions` (sign-flipped). Mirrors the SwiftData-era
+/// `spentPositions` (sign-flipped). Matches
 /// `CloudKitEarmarkRepository.computeEarmarkPositions`.
 ///
 /// **Instrument resolution.** Positions resolve their `instrument` via

--- a/Backends/GRDB/Repositories/GRDBImportRuleRepository+Observation.swift
+++ b/Backends/GRDB/Repositories/GRDBImportRuleRepository+Observation.swift
@@ -3,12 +3,7 @@
 import Foundation
 import GRDB
 
-// Reactive observation surface for `ImportRuleRepository`. Split out of
-// the main class file to keep `GRDBImportRuleRepository.swift` under
-// SwiftLint's `file_length` warning threshold and to mirror the
-// established `GRDBAccountRepository+Observation.swift` /
-// `GRDBEarmarkRepository+Observation.swift` /
-// `GRDBCategoryRepository+Observation.swift` companion-file pattern.
+// Reactive observation surface for `ImportRuleRepository`.
 //
 // `observeAll()` returns the same domain projection as `fetchAll()`:
 // every `import_rule` row, ordered by `position`, mapped through

--- a/Backends/GRDB/Repositories/GRDBInstrumentRegistryRepository+InstrumentMapResolving.swift
+++ b/Backends/GRDB/Repositories/GRDBInstrumentRegistryRepository+InstrumentMapResolving.swift
@@ -7,18 +7,15 @@ extension GRDBInstrumentRegistryRepository: InstrumentMapResolving {
   /// Returns the memoised `[String: Instrument]` snapshot, rebuilding it
   /// from the database only when a mutation has invalidated the cache.
   ///
-  /// The cutover routes every per-profile instrument resolution through
-  /// this single shared method on the serial profile-index queue (shared
-  /// across all profiles, the price caches, and sync apply). A per-call
+  /// Every per-profile instrument resolution routes through this single
+  /// shared method on the serial profile-index queue (shared across all
+  /// profiles, the price caches, and sync apply). A per-call
   /// `database.read` + full-map rebuild (incl. ~150 `Instrument.fiat`
   /// constructions) on the cold-launch burst (~1400 calls/sec) would
-  /// serialise on that queue and regress badly. Steady state here is a
-  /// cached dictionary read behind one unfair-lock acquisition — cheaper
-  /// than today's per-call per-profile fetch.
+  /// serialise on that queue and regress badly. Steady state is a
+  /// cached dictionary read behind one unfair-lock acquisition.
   ///
-  /// Stored rows first, ambient ISO fiat supplemented after — preserving
-  /// the ordering callers will see post-cutover so no read path changes
-  /// behaviour when it switches from per-profile to shared resolution.
+  /// Stored rows first, ambient ISO fiat supplemented after.
   /// **Stale-read safety (bounded loop, not recursion).** The cold path
   /// captures the invalidation generation, drops the lock, then
   /// `await`s `database.read`. On commit it only adopts the rebuilt

--- a/Backends/GRDB/Repositories/GRDBInstrumentRegistryRepository+Lookup.swift
+++ b/Backends/GRDB/Repositories/GRDBInstrumentRegistryRepository+Lookup.swift
@@ -7,9 +7,6 @@ extension GRDBInstrumentRegistryRepository {
   /// Looks up a single crypto registration by id. Mirrors the row-shape
   /// projection in `allCryptoRegistrations()` — see `project(row:)`
   /// below for the rule set.
-  ///
-  /// Lives in a sibling extension file so the main repository class body
-  /// stays under SwiftLint's `type_body_length` and `file_length` budgets.
   func cryptoRegistration(byId id: String) async throws -> CryptoRegistration? {
     try await database.read { database in
       let cryptoKind = Instrument.Kind.cryptoToken.rawValue

--- a/Backends/GRDB/Repositories/GRDBInstrumentRegistryRepository+SyncEntryPoints.swift
+++ b/Backends/GRDB/Repositories/GRDBInstrumentRegistryRepository+SyncEntryPoints.swift
@@ -4,9 +4,7 @@ import Foundation
 import GRDB
 
 /// Synchronous entry points consumed by `ProfileIndexSyncHandler` and
-/// the coordinator's startup self-heal scan. Extracted from the main
-/// repository file so it stays under SwiftLint's `file_length` and
-/// `type_body_length` thresholds.
+/// the coordinator's startup self-heal scan.
 ///
 /// These methods are called from the CKSyncEngine delegate executor
 /// on a non-MainActor context. `DatabaseWriter.write { db in … }` has

--- a/Backends/GRDB/Repositories/GRDBInstrumentRegistryRepository+SyncHooks.swift
+++ b/Backends/GRDB/Repositories/GRDBInstrumentRegistryRepository+SyncHooks.swift
@@ -5,9 +5,7 @@ import os
 
 /// Sync-hook plumbing for `GRDBInstrumentRegistryRepository`.
 ///
-/// Extracted from the main file so it stays under SwiftLint's
-/// `file_length` and `type_body_length` thresholds. The shared
-/// instrument registry is constructed at app boot before
+/// The shared instrument registry is constructed at app boot before
 /// `SyncCoordinator` exists; the coordinator rotates real hooks in
 /// via `attachSyncHooks` once both objects are available. Mirrors
 /// the lock-guarded `HookState` shape used by

--- a/Backends/GRDB/Repositories/GRDBInstrumentRegistryRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBInstrumentRegistryRepository.swift
@@ -31,10 +31,10 @@ final class GRDBInstrumentRegistryRepository:
   InstrumentRegistryRepository, @unchecked Sendable
 {
   // `database` is `internal` rather than `private` so the sibling
-  // extension file `GRDBInstrumentRegistryRepository+Lookup.swift` (which
-  // hosts `cryptoRegistration(byId:)` to keep this file under SwiftLint's
-  // length budgets) can read from it. The other stored properties remain
-  // private — only the database handle is shared across files.
+  // extension file `GRDBInstrumentRegistryRepository+Lookup.swift`
+  // (which hosts `cryptoRegistration(byId:)`) can read from it. The
+  // other stored properties remain private — only the database handle
+  // is shared across files.
   /// Holds the post-init hook closures so they can be swapped in
   /// atomically by `attachSyncHooks`. Mirrors the pattern used by
   /// `GRDBProfileIndexRepository` — the shared registry is constructed
@@ -58,10 +58,9 @@ final class GRDBInstrumentRegistryRepository:
 
   /// Lock-guarded memoised instrument-map snapshot. The
   /// `MapCacheState` type and the invalidation / test-accessor helpers
-  /// live in the sibling `+SyncHooks` extension file so this file stays
-  /// under SwiftLint's `file_length` / `type_body_length` thresholds;
-  /// only the stored property itself must be declared in the class
-  /// body. Guarded by the same `OSAllocatedUnfairLock` primitive the
+  /// live in the sibling `+SyncHooks` extension file; only the stored
+  /// property itself must be declared in the class body. Guarded by
+  /// the same `OSAllocatedUnfairLock` primitive the
   /// type already uses for `hooks` — deliberately not a second,
   /// divergent synchronisation mechanism. `internal` (default) so the
   /// sibling `+InstrumentMapResolving` / `+SyncEntryPoints` extensions
@@ -98,10 +97,9 @@ final class GRDBInstrumentRegistryRepository:
   // `attachSyncHooks` and the `fireOnRecord*` helpers live in
   // `GRDBInstrumentRegistryRepository+SyncHooks.swift`, and the row-level
   // upsert helpers (`upsertCrypto`, `upsertStock`) live in
-  // `GRDBInstrumentRegistryRepository+Upsert.swift`, so this file stays
-  // under SwiftLint's `file_length` / `type_body_length` thresholds. They
-  // access `hooks` / are called as `Self.upsert…` via the `internal`
-  // visibility implied by Swift's same-module-extension scope.
+  // `GRDBInstrumentRegistryRepository+Upsert.swift`. They access `hooks`
+  // / are called as `Self.upsert…` via the `internal` visibility implied
+  // by Swift's same-module-extension scope.
 
   // MARK: - InstrumentRegistryRepository conformance
 
@@ -130,8 +128,7 @@ final class GRDBInstrumentRegistryRepository:
   }
 
   // `cryptoRegistration(byId:)` lives in
-  // `GRDBInstrumentRegistryRepository+Lookup.swift` to keep this file
-  // under SwiftLint's `file_length` and `type_body_length` thresholds.
+  // `GRDBInstrumentRegistryRepository+Lookup.swift`.
 
   func registerCrypto(
     _ instrument: Instrument, mapping: CryptoProviderMapping
@@ -340,7 +337,6 @@ final class GRDBInstrumentRegistryRepository:
   // (`setEncodedSystemFieldsSync`, `clearAllSystemFieldsSync`,
   // `unsyncedRowIdsSync`, `allRowIdsSync`, `fetchRowSync`,
   // `fetchRowsSync`, `deleteAllSync`) live in the sibling
-  // `+SyncEntryPoints` extension file so this file stays under
-  // SwiftLint's length thresholds.
+  // `+SyncEntryPoints` extension file.
   // `unsyncedNonFiatRowIdsSync` similarly lives in `+Lookup`.
 }

--- a/Backends/GRDB/Repositories/GRDBInvestmentRepository+Observation.swift
+++ b/Backends/GRDB/Repositories/GRDBInvestmentRepository+Observation.swift
@@ -3,11 +3,7 @@
 import Foundation
 import GRDB
 
-// Reactive observation surface for `InvestmentRepository`. Split out of
-// the main class file to keep `GRDBInvestmentRepository.swift` under
-// SwiftLint's `file_length` warning threshold and to mirror the established
-// `+Observation.swift` companion-file pattern (account, earmark, category,
-// transaction, import-rule).
+// Reactive observation surface for `InvestmentRepository`.
 //
 // `observeValues(accountId:page:pageSize:)` mirrors the projection of
 // `fetchValues(accountId:page:pageSize:)`. `observeDailyBalances(accountId:)`
@@ -32,7 +28,8 @@ import GRDB
 // `observeDailyBalances(accountId:)` resolves the map once via
 // `instrumentResolver` when the stream's worker task starts, captures it
 // into the tracking closure, and drops `InstrumentRow.observableRegion`
-// from the tracked regions (those rows are no longer in this DB). An
+// from the tracked regions (those rows live on the separate
+// profile-index DB). An
 // instrument-metadata edit therefore does not live-refresh an already-
 // open chart until the next refetch (re-subscribe). `observeValues` and
 // `observeAllValues` don't consult the instrument map, so they keep the
@@ -99,7 +96,7 @@ extension GRDBInvestmentRepository {
         // `encoded_system_fields` writes on the tables
         // `DailyBalanceCompute` reads (transaction, transaction_leg) do
         // not re-fire this observation. See issue #865. `InstrumentRow`
-        // is no longer tracked here — those rows live on the separate
+        // is not tracked here — those rows live on the separate
         // profile-index database; the map is the captured `instruments`
         // snapshot.
         .tracking(

--- a/Backends/GRDB/Repositories/GRDBTransactionRepository+Observation.swift
+++ b/Backends/GRDB/Repositories/GRDBTransactionRepository+Observation.swift
@@ -3,10 +3,7 @@
 import Foundation
 import GRDB
 
-// Reactive observation surface for `TransactionRepository`. Split out of
-// the main class file to keep `GRDBTransactionRepository.swift` under
-// SwiftLint's `file_length` warning threshold and to mirror the established
-// `+Fetch.swift` / `+Sync.swift` companion-file pattern.
+// Reactive observation surface for `TransactionRepository`.
 //
 // `observe(filter:page:pageSize:)` mirrors `fetch(filter:page:pageSize:)`
 // — the read pipeline is reused via `buildFetchSnapshot(...)` so the
@@ -48,11 +45,11 @@ import GRDB
 // instead resolves the map once via `instrumentResolver` when the
 // stream's worker task starts, captures it into the tracking closure,
 // and drops `InstrumentRow.observableRegion` from the tracked regions
-// (those rows are no longer in this DB). An instrument-metadata edit
-// therefore does not live-refresh an already-open list until the next
-// refetch (re-subscribe); cross-database instrument-metadata
-// live-refresh is wired via the shared registry's change stream in a
-// follow-up.
+// (those rows live on the separate profile-index DB). An
+// instrument-metadata edit therefore does not live-refresh an
+// already-open list until the next refetch (re-subscribe);
+// cross-database instrument-metadata live-refresh is wired via the
+// shared registry's change stream.
 extension GRDBTransactionRepository {
 
   /// Streams `TransactionPage` snapshots whenever `transaction`,
@@ -90,7 +87,7 @@ extension GRDBTransactionRepository {
         // Explicit-region form: every joined table's `observableRegion`
         // excludes the sync-bookkeeping `encoded_system_fields` blob, so
         // CKSyncEngine's per-batch system-fields write does not re-fire
-        // this observation. See issue #865. `InstrumentRow` is no longer
+        // this observation. See issue #865. `InstrumentRow` is not
         // tracked here — those rows live on the separate profile-index
         // database; the map is the captured `instruments` snapshot.
         .tracking(
@@ -142,7 +139,7 @@ extension GRDBTransactionRepository {
         // Explicit-region form: every joined table's `observableRegion`
         // excludes the sync-bookkeeping `encoded_system_fields` blob, so
         // CKSyncEngine's per-batch system-fields write does not re-fire
-        // this observation. See issue #865. `InstrumentRow` is no longer
+        // this observation. See issue #865. `InstrumentRow` is not
         // tracked here — those rows live on the separate profile-index
         // database; the map is the captured `instruments` snapshot.
         .tracking(

--- a/Backends/GRDB/Repositories/GRDBTransactionRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBTransactionRepository.swift
@@ -11,12 +11,11 @@ import OSLog
 /// **Header + legs together.** Every write path (`create`, `update`,
 /// `delete`) inserts/deletes the `TransactionRow` and its
 /// `TransactionLegRow`s inside a single `database.write { … }`. On any
-/// throw the entire mutation rolls back. After
-/// `v5_drop_foreign_keys` the schema no longer enforces FK CASCADE on
-/// `transaction_leg.transaction_id`; `delete(id:)` and the sync
-/// `applyRemoteChangesSync` in `+Sync.swift` therefore delete legs
-/// explicitly before the parent, in the same write transaction, so a
-/// partially committed header cannot leave orphaned legs. Rollback
+/// throw the entire mutation rolls back. The schema does not enforce
+/// FK CASCADE on `transaction_leg.transaction_id`; `delete(id:)` and
+/// the sync `applyRemoteChangesSync` in `+Sync.swift` therefore delete
+/// legs explicitly before the parent, in the same write transaction,
+/// so a partially committed header cannot leave orphaned legs. Rollback
 /// test mandatory; see `guides/DATABASE_CODE_GUIDE.md`.
 ///
 /// **Instrument resolution.** Each leg's `instrument` is resolved via

--- a/Domain/Models/Accounts+SidebarOrdering.swift
+++ b/Domain/Models/Accounts+SidebarOrdering.swift
@@ -13,8 +13,8 @@ extension Accounts {
   ///     counterpart picker to remove the from-account from the
   ///     candidate list.
   ///   - alwaysInclude: Account id to keep visible even when hidden.
-  ///     Used by pickers so a previously-selected account that has
-  ///     since been hidden stays in the dropdown.
+  ///     Used by pickers so an already-selected account that is
+  ///     hidden stays in the dropdown.
   /// - Returns: Two arrays — `current` (bank, asset, credit card) and
   ///   `investment` — each sorted ascending by `Account.position`.
   /// - Note: When `excluding` and `alwaysInclude` reference the same

--- a/Domain/Models/CryptoRegistration.swift
+++ b/Domain/Models/CryptoRegistration.swift
@@ -4,13 +4,13 @@
 import Foundation
 
 /// Pairs a crypto instrument with its price provider mapping for persistence.
-/// Replaces the legacy CryptoToken type.
 struct CryptoRegistration: Codable, Sendable, Hashable, Identifiable {
   let instrument: Instrument
   let mapping: CryptoProviderMapping
   /// How aggregation should treat this token's fiat value. Distinct from
   /// "rate unavailable" — `.unpriced` and `.spam` are intentionally zero,
-  /// not errors. Defaults to `.priced` for legacy decode and built-in presets.
+  /// not errors. Defaults to `.priced` for rows decoded without the field
+  /// and for built-in presets.
   var pricingStatus: TokenPricingStatus
 
   init(

--- a/Domain/Models/Instrument.swift
+++ b/Domain/Models/Instrument.swift
@@ -187,7 +187,7 @@ extension Instrument {
   }
 
   /// Factory for cryptocurrency token instruments.
-  /// Uses the same `chainId:address` ID scheme as the legacy CryptoToken type.
+  /// Uses a `chainId:address` ID scheme.
   static func crypto(
     chainId: Int,
     contractAddress: String?,

--- a/Domain/Models/RunningBalanceResult.swift
+++ b/Domain/Models/RunningBalanceResult.swift
@@ -39,9 +39,9 @@ struct TransactionWithBalance: Sendable, Identifiable {
   /// all legs when unfiltered). Empty when conversion failed (paired with
   /// `displayAmount == nil`). See design §4.2.
   let displayAmounts: [InstrumentAmount]
-  /// Single scalar in the running-balance target instrument. Retained for
-  /// backwards-compatible diagnostics and any consumer that wants the
-  /// converted total; the row no longer reads it for rendering.
+  /// Single scalar in the running-balance target instrument. Used for
+  /// diagnostics and any consumer that wants the converted total; the
+  /// row does not read it for rendering.
   let displayAmount: InstrumentAmount?
   let balance: InstrumentAmount?
 

--- a/Domain/Models/ScheduledFilter.swift
+++ b/Domain/Models/ScheduledFilter.swift
@@ -1,10 +1,8 @@
 import Foundation
 
 /// Tri-state selector for whether scheduled transactions are included in a
-/// query. Replaces the previous `Bool?` tri-state where `nil` meant "all",
-/// `true` meant "scheduled only", and `false` meant "non-scheduled only".
-/// Named cases make intent readable at call sites and keep SwiftLint's
-/// `discouraged_optional_boolean` rule quiet.
+/// query. Named cases make intent readable at call sites and avoid an
+/// ambiguous optional `Bool`.
 enum ScheduledFilter: Sendable, Hashable {
   /// Include both scheduled and non-scheduled transactions.
   case all

--- a/Domain/Models/Transaction+Structure.swift
+++ b/Domain/Models/Transaction+Structure.swift
@@ -1,7 +1,6 @@
 import Foundation
 
 // Structural shape queries and display-amount computation for `Transaction`.
-// Kept here to keep `Transaction.swift` itself under the file_length threshold.
 extension Transaction {
   /// Whether this transaction has the structural shape of a trade per
   /// `plans/2026-04-28-trade-transaction-ui-design.md` §1.2:

--- a/Domain/Models/Transaction+TransferDetection.swift
+++ b/Domain/Models/Transaction+TransferDetection.swift
@@ -18,7 +18,7 @@ extension Transaction {
   /// - Exactly one `.transfer` leg (the value-bearing leg). Any number
   ///   of additional `.expense` legs in a different instrument from the
   ///   value-bearing leg are permitted (fees: gas, broker fees, …).
-  /// - Exactly one `.income` or `.expense` leg (legacy single-leg cash).
+  /// - Exactly one `.income` or `.expense` leg (single-leg cash).
   ///   Any number of additional `.expense` legs in a different instrument
   ///   from the value-bearing leg are permitted.
   ///

--- a/Domain/Models/TransactionLeg.swift
+++ b/Domain/Models/TransactionLeg.swift
@@ -13,8 +13,8 @@ struct TransactionLeg {
   ///
   /// Populated by `TransferEventBuilder` from the Alchemy transfer's
   /// `from` / `to` fields — whichever side is *not* this wallet. Decoded
-  /// with `decodeIfPresent` so legacy rows (pre-#754) round-trip with
-  /// `nil`.
+  /// with `decodeIfPresent` so rows persisted without the field
+  /// round-trip with `nil`.
   let counterpartyAddress: String?
   var type: TransactionType
   var categoryId: UUID?
@@ -69,8 +69,8 @@ extension TransactionLeg: Codable {
 
   init(from decoder: any Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
-    // Legacy rows (pre-stable-leg-id) round-trip with a freshly allocated id;
-    // newer rows persist a stable id assigned at creation time.
+    // Rows without a persisted id get a freshly allocated one; rows with a
+    // persisted id keep their stable id assigned at creation time.
     self.id = try container.decodeIfPresent(UUID.self, forKey: .id) ?? UUID()
     self.accountId = try container.decodeIfPresent(UUID.self, forKey: .accountId)
     self.instrument = try container.decode(Instrument.self, forKey: .instrument)

--- a/Domain/Models/ValuationMode.swift
+++ b/Domain/Models/ValuationMode.swift
@@ -2,7 +2,7 @@
 /// balance display, totals, and reports.
 ///
 /// - `recordedValue`: the latest user-entered `InvestmentValue` snapshot
-///   drives the displayed value. Snapshots are edited via the legacy
+///   drives the displayed value. Snapshots are edited via the
 ///   investment-account view.
 /// - `calculatedFromTrades`: the value is computed by summing positions
 ///   (derived from trade transactions) at current instrument prices.

--- a/Domain/Repositories/InstrumentRegistering.swift
+++ b/Domain/Repositories/InstrumentRegistering.swift
@@ -10,10 +10,9 @@
 /// `database.write` that inserts the txn / leg / account rows, so a read
 /// issued immediately after the method returns resolves the instrument.
 /// Every caller — production, preview, test, and the sync apply path
-/// — injects the shared profile-index registry (where the matching
-/// `InstrumentMapResolving` reads). Nothing writes the per-profile
-/// `instrument` table, which the `v10_drop_shared_instrument_legacy`
-/// migration removes.
+/// — injects the shared profile-index registry, where the matching
+/// `InstrumentMapResolving` reads. There is no per-profile `instrument`
+/// table.
 protocol InstrumentRegistering: Sendable {
   func registerResolvable(_ instrument: Instrument) async throws
 }

--- a/Domain/Repositories/InstrumentRegistryRepository.swift
+++ b/Domain/Repositories/InstrumentRegistryRepository.swift
@@ -108,9 +108,8 @@ protocol InstrumentRegistryRepository: InstrumentChangeObserving {
   // `registerStock`, `update`, `remove`) fan out synchronously inside
   // the corresponding method; remote-arriving rows from
   // `ProfileIndexSyncHandler.applyRemoteChanges` (the profile-index
-  // zone carries `InstrumentRecord` after the shared-instrument-
-  // registry rollout) fan out via the handler's injected
-  // `onInstrumentRemoteChange` closure, which calls
+  // zone carries `InstrumentRecord`) fan out via the handler's
+  // injected `onInstrumentRemoteChange` closure, which calls
   // `notifyExternalChange()` on the @MainActor-confined repository.
   // Subscribers see both directions through the single stream — no
   // second per-profile `SyncCoordinator` subscription is required.

--- a/Features/Accounts/AccountStore+ConvertedTotals.swift
+++ b/Features/Accounts/AccountStore+ConvertedTotals.swift
@@ -1,9 +1,8 @@
 import Foundation
 
-// On-demand total computations. Hoisted out of `AccountStore.swift` so
-// that file stays under `file_length` / `type_body_length`. These are
-// pure pass-throughs to the calculator and need no privileged access to
-// the store's `private(set)` setters.
+// On-demand total computations for `AccountStore`. Pure pass-throughs to
+// the calculator that need no privileged access to the store's
+// `private(set)` setters.
 extension AccountStore {
   /// Total value of `accountList` in `target`, summing positions directly.
   func computeConvertedTotal(for accountList: [Account], in target: Instrument) async throws

--- a/Features/Accounts/AccountStore+Mutations.swift
+++ b/Features/Accounts/AccountStore+Mutations.swift
@@ -1,8 +1,7 @@
 import Foundation
 import OSLog
 
-// Mutation surface for `AccountStore`. Hoisted out of `AccountStore.swift`
-// so that file stays under SwiftLint's `file_length` threshold.
+// Mutation surface for `AccountStore`.
 //
 // Mutations are pass-through under the reactive design: every method
 // calls the repository, the GRDB write commits, and

--- a/Features/Accounts/AccountStore+Observation.swift
+++ b/Features/Accounts/AccountStore+Observation.swift
@@ -1,8 +1,6 @@
 import Foundation
 
-// Reactive observation pipeline for `AccountStore`. Lives in an
-// extension so the main type body stays under SwiftLint's
-// `type_body_length` and `file_length` budgets.
+// Reactive observation pipeline for `AccountStore`.
 //
 // Three independent surfaces feed `AccountStore`:
 //   1. `repository.observeAll()` / `observeErrors()` — the accounts
@@ -11,18 +9,13 @@ import Foundation
 //      ticks that drive a balance recompute (no DB re-fetch needed).
 //   3. `investmentRepository.observeAllValues()` / `observeErrors()` —
 //      a tick stream over the `investment_value` table that drives a
-//      cache refresh + recompute. Replaces the cross-store
-//      `onInvestmentValueChanged` callback that previously lived on
-//      `InvestmentStore`.
+//      cache refresh + recompute.
 //
 // A fourth surface, the shared instrument registry's
 // `observeChanges()` stream, is owned by `instrumentChangeObservationTask`
 // (spawned from `init`) and drained by `observeInstrumentRegistryChanges`
 // below — kept separate from the always-on `TaskGroup` for the same
 // reason as the other stores.
-//
-// All `addTask` bodies are deliberately one-line so the enclosing
-// closure body stays under SwiftLint's `closure_body_length`.
 extension AccountStore {
 
   /// Subscribes to every reactive stream in parallel via a `TaskGroup`.

--- a/Features/Analysis/Views/NetWorthGraphCard+Marks.swift
+++ b/Features/Analysis/Views/NetWorthGraphCard+Marks.swift
@@ -1,9 +1,8 @@
 import Charts
 import SwiftUI
 
-/// Per-series chart-content builders. Split out so the main view's body
-/// stays focused on layout / accessibility / state, and the
-/// `type_body_length` budget isn't dominated by Swift Charts plumbing.
+/// Per-series chart-content builders, kept separate so the main view's
+/// body stays focused on layout / accessibility / state.
 extension NetWorthGraphCard {
   @ChartContentBuilder var availableFundsMarks: some ChartContent {
     if visibleSeries.contains(.availableFunds) {

--- a/Features/Analysis/Views/NetWorthGraphCard.swift
+++ b/Features/Analysis/Views/NetWorthGraphCard.swift
@@ -31,8 +31,7 @@ struct NetWorthGraphCard: View {
   let balances: [DailyBalance]
 
   @State private var selectedDate: Date?
-  // Internal so the chart-content builders in `+Marks.swift` can read
-  // it without the file going over `type_body_length`.
+  // Internal so the chart-content builders in `+Marks.swift` can read it.
   @State var visibleSeries: Set<ChartSeries> = Set(
     ChartSeries.allCases.filter(\.enabledByDefault))
 

--- a/Features/Crypto/CryptoSyncStore.swift
+++ b/Features/Crypto/CryptoSyncStore.swift
@@ -316,6 +316,5 @@ final class CryptoSyncStore {
   }
 
   // Implementation helpers (parallel build, apply pass, timer loop)
-  // live in `CryptoSyncStore+Internals.swift` so this file stays under
-  // SwiftLint's `file_length` and `type_body_length` budgets.
+  // live in `CryptoSyncStore+Internals.swift`.
 }

--- a/Features/Crypto/CryptoWalletAccountView.swift
+++ b/Features/Crypto/CryptoWalletAccountView.swift
@@ -5,21 +5,19 @@ import SwiftUI
 /// (full address, chain, last-synced state, Sync now button) above the
 /// transaction list as siblings in a `VStack(spacing: 0)`.
 ///
-/// This composition no longer goes through `TransactionListView`'s
-/// removed `topAccessory` slot — the leaf is its own `NavigationStack`
-/// (provided by `ContentView.detail`'s `.id(selection)` wrap), so the
-/// wallet header and the transaction list are structurally local to
-/// this leaf and cannot race against another leaf's `.toolbar` /
-/// `.searchable` registrations.
+/// The leaf is its own `NavigationStack` (provided by
+/// `ContentView.detail`'s `.id(selection)` wrap), so the wallet header
+/// and the transaction list are structurally local to this leaf and
+/// cannot race against another leaf's `.toolbar` / `.searchable`
+/// registrations.
 ///
 /// The header renders only when `chainId`, the chain config, AND a
 /// `cryptoSyncStore` all resolve; otherwise the `@ViewBuilder` returns
 /// `EmptyView`. Within this leaf's `NavigationStack` a
-/// `VStack(spacing: 0) { EmptyView; TransactionListView }` is safe —
-/// the previously-observed `safeAreaInset+EmptyView+NSHostingView`
-/// zero-size collapse fired only when the EmptyView-bearing layout
-/// crossed an `NSHostingView` column boundary (the
-/// `ResizableVSplit`'s arranged subviews used by
+/// `VStack(spacing: 0) { EmptyView; TransactionListView }` is safe: the
+/// `safeAreaInset+EmptyView+NSHostingView` zero-size collapse fires only
+/// when the EmptyView-bearing layout crosses an `NSHostingView` column
+/// boundary (the `ResizableVSplit`'s arranged subviews used by
 /// `InvestmentAccountView.calculatedFromTrades`). Inside a SwiftUI-
 /// owned `NavigationStack` column there is no NSHostingView wrapping
 /// at this level, so the bug does not apply.

--- a/Features/Earmarks/EarmarkStore+Budget.swift
+++ b/Features/Earmarks/EarmarkStore+Budget.swift
@@ -1,7 +1,6 @@
 import Foundation
 
-// Budget CRUD extracted from the main `EarmarkStore` body so it stays under
-// SwiftLint's `type_body_length` threshold. All methods use the same
+// Budget CRUD for `EarmarkStore`. All methods use the same
 // optimistic-update-then-rollback pattern as the rest of the store.
 extension EarmarkStore {
 

--- a/Features/Earmarks/EarmarkStore+Mutations.swift
+++ b/Features/Earmarks/EarmarkStore+Mutations.swift
@@ -1,7 +1,6 @@
 import Foundation
 
-// Mutation surface for `EarmarkStore`. Hoisted out of `EarmarkStore.swift`
-// so that file stays under SwiftLint's `file_length` threshold.
+// Mutation surface for `EarmarkStore`.
 //
 // Mutations are pass-through under the reactive design: every method
 // calls the repository, the GRDB write commits, and

--- a/Features/Earmarks/EarmarkStore+Observation.swift
+++ b/Features/Earmarks/EarmarkStore+Observation.swift
@@ -1,8 +1,6 @@
 import Foundation
 
-// Reactive observation pipeline for `EarmarkStore`. Lives in an
-// extension so the main type body stays under SwiftLint's
-// `type_body_length` and `file_length` budgets. `observe()` owns the
+// Reactive observation pipeline for `EarmarkStore`. `observe()` owns the
 // always-on streams (`repository.observeAll()` +
 // `conversionService.observeRates()`); the shared-registry change
 // stream is owned by `instrumentChangeObservationTask` and drained by

--- a/Features/Earmarks/EarmarkStore.swift
+++ b/Features/Earmarks/EarmarkStore.swift
@@ -43,7 +43,7 @@ final class EarmarkStore {
   private var observationTask: Task<Void, Never>?
 
   /// Narrow seam onto the shared instrument registry's change stream.
-  /// The earmarks observation no longer tracks the `instrument` table
+  /// The earmarks observation does not track the `instrument` table
   /// (identity resolved once per fetch via the shared registry), so a
   /// metadata edit there does not re-fire `observeAll()`. When wired,
   /// `instrumentChangeObservationTask` re-fetches earmarks and

--- a/Features/Import/CSVImportSetupStore.swift
+++ b/Features/Import/CSVImportSetupStore.swift
@@ -60,7 +60,7 @@ final class CSVImportSetupStore {
   /// `columnRoles` is seeded from the detected mapping in `regeneratePreview`,
   /// so this function derives the mapping purely from the roles array — a
   /// role set to `.ignore` (or simply left `nil`) means the column is unused,
-  /// even if the detector had originally picked it.
+  /// even if the detector picked it.
   ///
   /// Missing `.date` / `.description` columns resolve to `-1`; the parser's
   /// `safe(row:_:)` helper returns `""` for out-of-bounds indices, which is
@@ -285,7 +285,7 @@ final class CSVImportSetupStore {
     return columnRoles.map { $0?.rawValue }
   }
 
-  /// Pure seeding logic extracted so `regeneratePreview` and
+  /// Pure seeding logic shared so `regeneratePreview` and
   /// `columnRoleRawValuesForPersistence` stay in sync. Mirrors whatever
   /// the detector returned from `inferMapping`.
   static func seedColumnRoles(

--- a/Features/Import/ImportStore+Pipeline.swift
+++ b/Features/Import/ImportStore+Pipeline.swift
@@ -5,9 +5,8 @@ import OSLog
 import os
 
 // Pipeline-stage helpers (tokenize, parser selection, parse, dedup, persist)
-// extracted from the main `ImportStore` body so it stays under SwiftLint's
-// `type_body_length` threshold. Every helper is file-scoped to the store and
-// only mutates shared state via the public staging/backend accessors.
+// for `ImportStore`. Every helper is file-scoped to the store and only
+// mutates shared state via the public staging/backend accessors.
 extension ImportStore {
 
   // MARK: - Pipeline

--- a/Features/Import/ImportStore+ProfileResolution.swift
+++ b/Features/Import/ImportStore+ProfileResolution.swift
@@ -2,9 +2,7 @@
 
 import Foundation
 
-// Profile-matching and column-mapping-rebuild helpers extracted from
-// `ImportStore` so the main body stays under SwiftLint's `type_body_length`
-// threshold.
+// Profile-matching and column-mapping-rebuild helpers for `ImportStore`.
 extension ImportStore {
 
   // MARK: - Profile resolution

--- a/Features/Import/ImportStore+Transactions.swift
+++ b/Features/Import/ImportStore+Transactions.swift
@@ -3,8 +3,7 @@
 import Foundation
 import OSLog
 
-// Transaction-construction and staging helpers extracted from `ImportStore`
-// so the main body stays under SwiftLint's `type_body_length` threshold.
+// Transaction-construction and staging helpers for `ImportStore`.
 // `importStoreBackgroundLogger` is defined on the main `ImportStore.swift`
 // file; the delete helper references it via file-private visibility (same
 // module, so `static private` + sibling extension still works through
@@ -13,9 +12,9 @@ extension ImportStore {
 
   // MARK: - Transaction construction
 
-  /// Per-session fields that every candidate in an ingest run shares. Bundled
-  /// into a struct so `buildTransaction` stays under SwiftLint's parameter
-  /// limit and call sites don't repeat them once per candidate.
+  /// Per-session fields that every candidate in an ingest run shares.
+  /// Bundled into a struct so call sites don't repeat them once per
+  /// candidate.
   struct ImportBuildContext {
     let routedAccountId: UUID
     let accountInstrument: Instrument

--- a/Features/Import/ImportStore.swift
+++ b/Features/Import/ImportStore.swift
@@ -199,10 +199,10 @@ final class ImportStore {
     }
   }
 
-  /// Retry a previously-failed file: re-read the staged bytes, drop the
-  /// failed record, and send the bytes back through `ingest`. Works for
-  /// any file we staged (picker, drop, paste, folder-watch) because we
-  /// use the on-disk copy, not the original URL.
+  /// Retry a failed file: re-read the staged bytes, drop the failed
+  /// record, and send the bytes back through `ingest`. Works for any
+  /// file we staged (picker, drop, paste, folder-watch) because we use
+  /// the on-disk copy, not the original URL.
   @discardableResult
   func retryFailed(id: UUID) async -> ImportSessionResult {
     do {
@@ -234,7 +234,7 @@ final class ImportStore {
       }
       let originalFilename = pendingRecord?.originalFilename ?? "setup-\(pendingId.uuidString)"
       // Resolve the source bookmark (if any) so delete-after-import still
-      // works on the file the user originally picked.
+      // works on the file the user picked.
       let bookmark = pendingRecord?.sourceBookmark
       let sourceURL: URL? = {
         guard let bookmark else { return nil }

--- a/Features/Import/Views/RecentlyAddedDetailSheet.swift
+++ b/Features/Import/Views/RecentlyAddedDetailSheet.swift
@@ -2,9 +2,8 @@ import SwiftUI
 
 // Sheets presented by `RecentlyAddedView` — the read-only transaction
 // summary for the "Open" context-menu action and the search-to-rule
-// shortcut. Extracted from `RecentlyAddedView.swift` so the primary view
-// file stays under SwiftLint's `file_length` threshold. Both types are
-// file-visible to this feature and referenced only from `RecentlyAddedView`.
+// shortcut. Both types are file-visible to this feature and referenced
+// only from `RecentlyAddedView`.
 
 /// Thin read-only transaction summary for the Recently Added context-menu
 /// "Open" action. Shows date, amount, legs, and the raw import origin so

--- a/Features/Import/Views/RecentlyAddedNeedsSetupPanel.swift
+++ b/Features/Import/Views/RecentlyAddedNeedsSetupPanel.swift
@@ -3,10 +3,8 @@
 import SwiftUI
 
 // Needs Setup / Failed Files panel for the Recently Added screen, with its
-// two row types. Extracted from `RecentlyAddedView.swift` so the primary
-// view file stays under SwiftLint's `file_length` threshold. These types
-// are file-visible to this feature and referenced only from
-// `RecentlyAddedView`.
+// two row types. These types are file-visible to this feature and
+// referenced only from `RecentlyAddedView`.
 
 /// Needs Setup / Failed Files panel. Shown above the session list when either
 /// list is non-empty; fully hidden when both are empty.

--- a/Features/Import/Views/RuleEditorActionRow.swift
+++ b/Features/Import/Views/RuleEditorActionRow.swift
@@ -1,9 +1,8 @@
 import SwiftUI
 
 // Action-editor row for `RuleEditorView`, with its supporting `ActionKind`
-// picker enum. Extracted from `RuleEditorView.swift` so the primary view
-// file stays under SwiftLint's `file_length` threshold. These types are
-// file-visible to this feature and referenced only from `RuleEditorView`.
+// picker enum. These types are file-visible to this feature and
+// referenced only from `RuleEditorView`.
 
 struct RuleEditorActionRow: View {
   @Binding var action: RuleAction

--- a/Features/Import/Views/RuleEditorConditionRow.swift
+++ b/Features/Import/Views/RuleEditorConditionRow.swift
@@ -1,10 +1,8 @@
 import SwiftUI
 
 // Condition-editor row for `RuleEditorView`, with its supporting
-// `ConditionKind` picker enum. Extracted from `RuleEditorView.swift` so
-// the primary view file stays under SwiftLint's `file_length` threshold.
-// These types are file-visible to this feature and referenced only from
-// `RuleEditorView`.
+// `ConditionKind` picker enum. These types are file-visible to this
+// feature and referenced only from `RuleEditorView`.
 
 struct RuleEditorConditionRow: View {
   @Binding var condition: RuleCondition

--- a/Features/Investments/InvestmentStore+ComputedProperties.swift
+++ b/Features/Investments/InvestmentStore+ComputedProperties.swift
@@ -1,8 +1,7 @@
 import Foundation
 
-// Hoisted out of `InvestmentStore.swift` so that file stays under the
-// `file_length` budget. The computed properties are pure reads and need no
-// privileged access to `private(set)` setters.
+// Computed read-only properties for `InvestmentStore`. Pure reads that
+// need no privileged access to `private(set)` setters.
 extension InvestmentStore {
   /// Investment values filtered by the selected time period.
   var filteredValues: [InvestmentValue] {

--- a/Features/Investments/InvestmentStore+DailyBalanceAggregation.swift
+++ b/Features/Investments/InvestmentStore+DailyBalanceAggregation.swift
@@ -3,9 +3,7 @@
 import Foundation
 
 // Per-instrument forward-fill + host-currency aggregation for the
-// legacy investment-account chart, extracted from `InvestmentStore`
-// so the main store body stays under SwiftLint's `type_body_length`
-// budget after issue #579.
+// legacy investment-account chart (issue #579).
 
 extension InvestmentStore {
   /// Aggregates per-(date, instrument) entries into a single

--- a/Features/Investments/InvestmentStore+Loading.swift
+++ b/Features/Investments/InvestmentStore+Loading.swift
@@ -1,7 +1,6 @@
 import Foundation
 
-// Loading + mutation surface for `InvestmentStore`. Hoisted into an
-// extension so `InvestmentStore.swift` stays under `type_body_length`.
+// Loading + mutation surface for `InvestmentStore`.
 //
 // `loadValues` and `loadDailyBalances` paginate against the repository
 // and write into `values` / `dailyBalances`. `loadAllData` is the
@@ -47,9 +46,9 @@ extension InvestmentStore {
 
   /// Loads the legacy account-level cumulative-balance series.
   ///
-  /// The repository now returns one entry per (date, instrument) tuple
-  /// so multi-instrument legacy accounts no longer conflate quantities
-  /// of different instruments under one label (issue #579). This store
+  /// The repository returns one entry per (date, instrument) tuple so
+  /// multi-instrument legacy accounts do not conflate quantities of
+  /// different instruments under one label (issue #579). This store
   /// converts each per-instrument balance to `hostCurrency` on its own
   /// date and aggregates by date so the consuming chart sees a single
   /// series in the host currency.

--- a/Features/Investments/InvestmentStore+Observation.swift
+++ b/Features/Investments/InvestmentStore+Observation.swift
@@ -1,8 +1,6 @@
 import Foundation
 
-// Reactive observation pipeline for `InvestmentStore`. Lives in an
-// extension so the main type body stays under SwiftLint's
-// `type_body_length` and `file_length` budgets.
+// Reactive observation pipeline for `InvestmentStore`.
 //
 // Two observation surfaces participate:
 //   1. Always-on streams subscribed in `init`: `repository.observeErrors()`,

--- a/Features/Investments/InvestmentStore+Positions.swift
+++ b/Features/Investments/InvestmentStore+Positions.swift
@@ -1,8 +1,6 @@
 import Foundation
 
-// Position-tracking surface for `InvestmentStore`. Hoisted into an
-// extension so the main type body stays under SwiftLint's
-// `type_body_length` budget.
+// Position-tracking surface for `InvestmentStore`.
 //
 // `loadPositions` reads transaction legs for `accountId` and aggregates
 // them into per-instrument `Position`s. `valuatePositions` converts

--- a/Features/Investments/InvestmentStore+PositionsInput.swift
+++ b/Features/Investments/InvestmentStore+PositionsInput.swift
@@ -7,15 +7,14 @@
 import Foundation
 
 // `PositionsViewInput` assembly + trade-based cost-basis snapshotting
-// extracted from the main `InvestmentStore` body so it stays under
-// SwiftLint's `type_body_length` threshold.
+// for `InvestmentStore`.
 extension InvestmentStore {
   // MARK: - PositionsView Input
 
   /// Coordinates the two-step "load then build positions input" sequence
   /// that the `InvestmentAccountView` runs from its `.task` and
-  /// `.refreshable` modifiers. Hoisted out of the view so the view bodies
-  /// stay free of multi-step async coordination.
+  /// `.refreshable` modifiers, keeping the view bodies free of
+  /// multi-step async coordination.
   ///
   /// Errors from `positionsViewInput` propagate; `loadAllData` swallows
   /// its own errors into `self.error` so it never throws here.

--- a/Features/Investments/InvestmentStore.swift
+++ b/Features/Investments/InvestmentStore.swift
@@ -58,7 +58,7 @@ final class InvestmentStore {
   var perAccountObservationTask: Task<Void, Never>?
 
   /// Narrow seam onto the shared instrument registry's change stream.
-  /// The per-account values observation no longer tracks the
+  /// The per-account values observation does not track the
   /// `instrument` table (identity / valuation resolved via the shared
   /// registry), so a metadata edit there does not re-fire
   /// `observeValues(...)`. When wired,
@@ -212,5 +212,4 @@ final class InvestmentStore {
 //
 // `chartDataPoints` and the other pure-read computed properties live in
 // `InvestmentStore+ComputedProperties.swift`. `InvestmentChartData` (merge +
-// forward-fill helpers) lives in `InvestmentChartData.swift`. Both are
-// extracted so this file stays under the file_length budget.
+// forward-fill helpers) lives in `InvestmentChartData.swift`.

--- a/Features/Investments/Views/InvestmentAccountView+Loading.swift
+++ b/Features/Investments/Views/InvestmentAccountView+Loading.swift
@@ -1,10 +1,9 @@
 import Foundation
 
 // Private helpers driving the load/rebuild lifecycle of
-// `InvestmentAccountView`. Hoisted out of the main view file so it
-// stays under SwiftLint's `file_length` budget; the methods stay
-// `private` and remain part of the view's API surface only — they
-// continue to be testable indirectly through the view's behaviour.
+// `InvestmentAccountView`. The methods stay `private` and are part of
+// the view's API surface only — testable indirectly through the view's
+// behaviour.
 extension InvestmentAccountView {
   /// The profile's reporting currency — used for valuing positions and the
   /// chart series. NOT the account's own instrument: an investment account

--- a/Features/Navigation/SidebarView+Previews.swift
+++ b/Features/Navigation/SidebarView+Previews.swift
@@ -1,7 +1,6 @@
-// SidebarView previews live in their own file so SidebarView.swift stays
-// under SwiftLint's file_length budget. Both previews reference internal
-// SidebarView APIs and seed an in-memory PreviewBackend; nothing here is
-// referenced from production code.
+// SidebarView previews. Both previews reference internal SidebarView
+// APIs and seed an in-memory PreviewBackend; nothing here is referenced
+// from production code.
 
 import SwiftUI
 

--- a/Features/Profiles/ProfileStore+Cloud.swift
+++ b/Features/Profiles/ProfileStore+Cloud.swift
@@ -2,8 +2,7 @@ import CloudKit
 import Foundation
 
 // Cloud-profile loading, iCloud validation helpers, and UserDefaults
-// persistence extracted from the main `ProfileStore` body so it stays under
-// SwiftLint's `type_body_length` threshold. All members execute on the main
+// persistence for `ProfileStore`. All members execute on the main
 // actor (`ProfileStore` is `@MainActor`).
 extension ProfileStore {
 

--- a/Features/Profiles/Views/WelcomeStateResolver.swift
+++ b/Features/Profiles/Views/WelcomeStateResolver.swift
@@ -1,8 +1,8 @@
 import Foundation
 
-/// Pure-logic resolver for ``WelcomeView``'s state machine. Extracted
-/// so every branch is unit-testable without SwiftUI. Inputs are value
-/// types so this can stay nonisolated.
+/// Pure-logic resolver for ``WelcomeView``'s state machine, so every
+/// branch is unit-testable without SwiftUI. Inputs are value types so
+/// this can stay nonisolated.
 enum WelcomeStateResolver {
   enum ResolvedState: Equatable {
     case heroChecking

--- a/Features/Settings/CloudKitProfileDetailView.swift
+++ b/Features/Settings/CloudKitProfileDetailView.swift
@@ -1,9 +1,8 @@
 import SwiftUI
 
-// Profile detail views extracted from `SettingsView.swift` so the main
-// settings file stays under SwiftLint's `file_length` threshold.
-// `SettingsView.profileDetailView(for:)` routes here; each view maintains
-// its own form state and persists changes back through `ProfileStore`.
+// Profile detail views. `SettingsView.profileDetailView(for:)` routes
+// here; each view maintains its own form state and persists changes back
+// through `ProfileStore`.
 
 /// Settings detail for an iCloud profile. Shows label, currency, and financial year start.
 struct CloudKitProfileDetailView: View {

--- a/Features/Settings/CryptoSettingsView+TokenList.swift
+++ b/Features/Settings/CryptoSettingsView+TokenList.swift
@@ -2,11 +2,9 @@
 import SwiftUI
 
 /// "Registered Tokens" + "CoinGecko API Key" sections of the Crypto
-/// preferences tab. Extracted from `CryptoSettingsView.swift` so the
-/// main view body stays under SwiftLint's `type_body_length` and
-/// `file_length` thresholds. Every member here closes over the parent
-/// view's `store` / `showAddToken` / `coinGeckoApiKeyInput` bindings —
-/// no new state owned at this layer.
+/// preferences tab. Every member here closes over the parent view's
+/// `store` / `showAddToken` / `coinGeckoApiKeyInput` bindings — no new
+/// state owned at this layer.
 extension CryptoSettingsView {
 
   // MARK: - Registered Tokens

--- a/Features/Settings/CryptoSettingsView.swift
+++ b/Features/Settings/CryptoSettingsView.swift
@@ -215,6 +215,5 @@ struct CryptoSettingsView: View {
   }
 
   // The "Registered Tokens" + "CoinGecko API Key" sections live in
-  // `CryptoSettingsView+TokenList.swift` so this file stays under
-  // SwiftLint's `type_body_length` and `file_length` thresholds.
+  // `CryptoSettingsView+TokenList.swift`.
 }

--- a/Features/Settings/SettingsView+Actions.swift
+++ b/Features/Settings/SettingsView+Actions.swift
@@ -1,9 +1,7 @@
 import SwiftUI
 import UniformTypeIdentifiers
 
-// Import / export handlers and delete-alert chrome extracted from
-// `SettingsView` so the main struct body stays under SwiftLint's
-// `type_body_length` threshold.
+// Import / export handlers and delete-alert chrome for `SettingsView`.
 extension SettingsView {
 
   // MARK: - Import

--- a/Features/Settings/SettingsView+iOS.swift
+++ b/Features/Settings/SettingsView+iOS.swift
@@ -2,9 +2,8 @@
   import SwiftUI
   import UniformTypeIdentifiers
 
-  // iOS NavigationStack layout extracted from `SettingsView` so the main
-  // struct body stays under SwiftLint's `type_body_length` threshold. Every
-  // member is view composition over the main struct's shared state.
+  // iOS NavigationStack layout for `SettingsView`. Every member is view
+  // composition over the main struct's shared state.
   extension SettingsView {
 
     // MARK: - iOS: NavigationStack layout

--- a/Features/Settings/SettingsView+macOS.swift
+++ b/Features/Settings/SettingsView+macOS.swift
@@ -2,9 +2,8 @@
   import SwiftUI
   import UniformTypeIdentifiers
 
-  // macOS HSplitView/TabView layout extracted from `SettingsView` so the main
-  // struct body stays under SwiftLint's `type_body_length` threshold. Every
-  // member is view composition over the main struct's shared state.
+  // macOS HSplitView/TabView layout for `SettingsView`. Every member is view
+  // composition over the main struct's shared state.
   extension SettingsView {
 
     // MARK: - macOS: HSplitView / TabView layout

--- a/Features/Transactions/PayeeSuggestionSource.swift
+++ b/Features/Transactions/PayeeSuggestionSource.swift
@@ -4,8 +4,7 @@ import Observation
 
 /// Debounced autocomplete source for payee input. Owns a single in-flight
 /// fetch task so consecutive keystrokes cancel pending queries instead of
-/// racing them. Extracted from `TransactionStore` because the concern is
-/// input-field autocomplete — distinct from transaction CRUD — with its own
+/// racing them. A concern distinct from transaction CRUD, with its own
 /// state (`suggestions`) and lifecycle (debounce task).
 ///
 /// `@Observable` so views can bind to `suggestions` through

--- a/Features/Transactions/TransactionStore+Mutations.swift
+++ b/Features/Transactions/TransactionStore+Mutations.swift
@@ -1,8 +1,6 @@
 import Foundation
 
-// Mutation surface for `TransactionStore`. Hoisted out of
-// `TransactionStore.swift` so that file stays under SwiftLint's
-// `file_length` threshold.
+// Mutation surface for `TransactionStore`.
 //
 // Mutations are pass-through under the reactive design: every method
 // calls the repository, the GRDB write commits, and

--- a/Features/Transactions/TransactionStore+Observation.swift
+++ b/Features/Transactions/TransactionStore+Observation.swift
@@ -1,9 +1,7 @@
 import Foundation
 import OSLog
 
-// Reactive observation pipeline for `TransactionStore`. Lives in an
-// extension so the main type body stays under SwiftLint's
-// `type_body_length` budget.
+// Reactive observation pipeline for `TransactionStore`.
 //
 // Two observation surfaces participate:
 //   1. `repository.observe(filter:page:pageSize:)` — the per-filter

--- a/Features/Transactions/TransactionStore.swift
+++ b/Features/Transactions/TransactionStore.swift
@@ -24,8 +24,8 @@ final class TransactionStore {
   // pass-through writes.
   let repository: TransactionRepository
   /// Owns the payee-autocomplete debounce/fetch state and the autofill
-  /// lookup. Exposed directly so views bind through the dedicated type;
-  /// `TransactionStore` no longer mirrors its surface.
+  /// lookup. Exposed directly so views bind through the dedicated type
+  /// rather than a mirrored surface on `TransactionStore`.
   let payeeSuggestionSource: PayeeSuggestionSource
   // internal so the `+Observation` extension can prefetch rates for the
   // running-balance recompute on each emission.
@@ -98,7 +98,7 @@ final class TransactionStore {
   private var rateObservationTask: Task<Void, Never>?
 
   /// Narrow seam onto the shared instrument registry's change stream.
-  /// Per-profile list observations no longer track the `instrument`
+  /// Per-profile list observations do not track the `instrument`
   /// table (identity is resolved once per fetch via the shared
   /// registry), so a metadata edit there does not re-fire the data
   /// observation. When wired, `instrumentChangeObservationTask`

--- a/Features/Transactions/Views/TransactionListView+List.swift
+++ b/Features/Transactions/Views/TransactionListView+List.swift
@@ -198,9 +198,8 @@ extension TransactionListView {
     }
   }
 
-  /// Cached set of overdue transaction ids, hoisted out of
-  /// `scheduledRowConfig(for:)` so it's computed once per body evaluation
-  /// rather than per row. Empty for any non-scheduled grouping.
+  /// Cached set of overdue transaction ids, computed once per body
+  /// evaluation rather than per row. Empty for any non-scheduled grouping.
   private var overdueTransactionIds: Set<Transaction.ID> {
     Set(transactionStore.scheduledOverdueTransactions.map(\.transaction.id))
   }
@@ -269,10 +268,9 @@ private struct ScheduledRowConfig {
 }
 
 /// Groups the CSV-import-specific modifiers (create-rule sheet + drop
-/// target) so the main `body` chain stays within the Swift type checker's
-/// complexity budget. Extracting a modifier was the minimal change that
-/// kept these affordances without triggering a `too complex` compile
-/// error on the long `.onReceive` / `.sheet` chain.
+/// target) so the main `body` chain stays within the Swift type
+/// checker's complexity budget on the long `.onReceive` / `.sheet`
+/// chain.
 struct TransactionListCSVImportAddons: ViewModifier {
   @Binding var createRuleFromTransaction: Transaction?
   let corpusProvider: () -> [String]

--- a/MoolahBenchmarks/BalanceDeltaBenchmarks.swift
+++ b/MoolahBenchmarks/BalanceDeltaBenchmarks.swift
@@ -161,15 +161,13 @@ final class BalanceDeltaBenchmarks: XCTestCase {
     }
   }
 
-  // The legacy `testAccountReloadFromSync` benchmark was deleted along
-  // with `AccountStore.reloadFromSync()` in the reactive-sync migration.
-  // Equivalent observation-driven measurement lives in Stage 6 of
+  // `AccountStore` refresh is observation-driven; the equivalent
+  // measurement lives in
   // `plans/2026-05-06-reactive-sync-refresh-implementation.md`.
 
   // MARK: - Earmark Store
 
-  // The legacy `testEarmarkReloadFromSync` benchmark was deleted along
-  // with `EarmarkStore.reloadFromSync()` in the reactive-sync migration.
-  // Equivalent observation-driven measurement lives alongside the
-  // AccountStore reactivity benchmark in `SyncReactivityBenchmarks`.
+  // `EarmarkStore` refresh is observation-driven; the equivalent
+  // measurement lives alongside the AccountStore reactivity benchmark
+  // in `SyncReactivityBenchmarks`.
 }

--- a/MoolahBenchmarks/CryptoSyncBenchmarks.swift
+++ b/MoolahBenchmarks/CryptoSyncBenchmarks.swift
@@ -286,5 +286,4 @@ final class CryptoSyncBenchmarks: XCTestCase {
 }
 
 // Benchmark wallets, fixtures and scripted Alchemy / resolver stubs live
-// in `CryptoSyncBenchmarkSupport.swift` so this file stays under the
-// SwiftLint `file_length` budget.
+// in `CryptoSyncBenchmarkSupport.swift`.

--- a/MoolahBenchmarks/ImportPipelineBenchmarks.swift
+++ b/MoolahBenchmarks/ImportPipelineBenchmarks.swift
@@ -187,8 +187,8 @@ final class ImportPipelineBenchmarks: XCTestCase {
   }
 
   /// End-to-end: 10 files × 1 000 rows each against a fresh TestBackend per
-  /// iteration so numbers are comparable (earlier versions accumulated
-  /// transactions across iterations, inflating dedup cost).
+  /// iteration so numbers are comparable: accumulating transactions
+  /// across iterations would inflate dedup cost.
   /// Measures tokenize + parse + profile match + dedup + rules + persist +
   /// the cleanup steps. One of the most realistic benchmarks.
   func testImportPipelineEndToEnd10Files1000RowsEach() throws {

--- a/MoolahBenchmarks/InstrumentMapResolutionBenchmarks.swift
+++ b/MoolahBenchmarks/InstrumentMapResolutionBenchmarks.swift
@@ -4,19 +4,18 @@ import XCTest
 
 @testable import Moolah
 
-/// Benchmarks the cold-launch instrument-resolution burst that the
-/// shared-registry cutover routes through
-/// `GRDBInstrumentRegistryRepository.instrumentMap()`.
+/// Benchmarks the cold-launch instrument-resolution burst that routes
+/// through `GRDBInstrumentRegistryRepository.instrumentMap()`.
 ///
-/// Post-cutover every per-profile instrument resolution resolves against
-/// this single shared method on the serial profile-index queue (shared
-/// across all profiles, the price caches, and sync apply). The #868
-/// cold-launch path issues a burst on the order of ~1400 resolutions/sec.
-/// Before memoisation each call did a `database.read` + a full-map
+/// Every per-profile instrument resolution resolves against this single
+/// shared method on the serial profile-index queue (shared across all
+/// profiles, the price caches, and sync apply). The #868 cold-launch
+/// path issues a burst on the order of ~1400 resolutions/sec. Without
+/// memoisation each call would do a `database.read` + a full-map
 /// rebuild — including ~150 `Instrument.fiat(code:)` constructions (each
 /// spinning up a `NumberFormatter`) over `Locale.Currency.isoCurrencies`
-/// — and serialised on the shared queue. With the memoised,
-/// change-invalidated snapshot the steady-state cost is a single
+/// — serialised on the shared queue. The memoised,
+/// change-invalidated snapshot makes the steady-state cost a single
 /// unfair-lock-guarded dictionary read.
 ///
 /// `testColdLaunchBurst` measures 1400 sequential `instrumentMap()`

--- a/MoolahBenchmarks/Support/BenchmarkFixtures+Seeding.swift
+++ b/MoolahBenchmarks/Support/BenchmarkFixtures+Seeding.swift
@@ -3,11 +3,9 @@ import GRDB
 
 @testable import Moolah
 
-// Private seeding helpers extracted from `BenchmarkFixtures` so the main
-// enum body stays under SwiftLint's `type_body_length` threshold. All
-// members are `static` on the enum and remain `internal` to the benchmark
-// target (no new public surface — the only entry point is
-// `BenchmarkFixtures.seed`).
+// Private seeding helpers for `BenchmarkFixtures`. All members are
+// `static` on the enum and `internal` to the benchmark target; the only
+// entry point is `BenchmarkFixtures.seed`.
 extension BenchmarkFixtures {
 
   // MARK: - Private Helpers
@@ -153,11 +151,11 @@ extension BenchmarkFixtures {
     return ids
   }
 
-  /// Bundled identifier sets passed to `seedTransactions`. Holds the account,
-  /// category, and earmark UUIDs produced by earlier seeding passes so the
-  /// transaction seeder can reference them without threading three separate
-  /// `[UUID]` parameters through its signature (which would breach
-  /// SwiftLint's `function_parameter_count` limit).
+  /// Bundled identifier sets passed to `seedTransactions`. Holds the
+  /// account, category, and earmark UUIDs produced by the preceding
+  /// seeding passes so the transaction seeder can reference them
+  /// without threading three separate `[UUID]` parameters through its
+  /// signature.
   struct SeedIds {
     let accounts: [UUID]
     let categories: [UUID]

--- a/MoolahBenchmarks/Support/BenchmarkFixtures+SeedingTransactions.swift
+++ b/MoolahBenchmarks/Support/BenchmarkFixtures+SeedingTransactions.swift
@@ -3,8 +3,7 @@ import GRDB
 
 @testable import Moolah
 
-// Transaction-seeding helpers split out of `BenchmarkFixtures+Seeding.swift`
-// so the original file stays under SwiftLint's `file_length` threshold.
+// Transaction-seeding helpers for `BenchmarkFixtures`.
 extension BenchmarkFixtures {
 
   static func seedTransactions(
@@ -33,8 +32,7 @@ extension BenchmarkFixtures {
     }
   }
 
-  /// Bundles the inputs to `makeTransactionSpec` so the helper stays
-  /// under SwiftLint's `function_parameter_count` threshold.
+  /// Bundles the inputs to `makeTransactionSpec`.
   private struct TransactionSpecInputs {
     let scale: BenchmarkScale
     let ids: SeedIds

--- a/MoolahBenchmarks/SyncDownloadBenchmarks.swift
+++ b/MoolahBenchmarks/SyncDownloadBenchmarks.swift
@@ -163,8 +163,7 @@ final class SyncDownloadBenchmarks: XCTestCase {
 
   /// Seeds `count` transaction rows in `database` and returns the matching
   /// `(CKRecord.ID, recordType)` tuples so the deletion-benchmark loop can
-  /// hand them to `applyRemoteChanges`. Extracted from the `measure` body
-  /// to keep the closure under SwiftLint's `closure_body_length` ceiling.
+  /// hand them to `applyRemoteChanges`.
   private static func seedDeletionTargets(
     into database: DatabaseWriter, zone: CKRecordZone.ID, count: Int
   ) throws -> [(CKRecord.ID, String)] {

--- a/MoolahBenchmarks/SyncReactivityBenchmarks.swift
+++ b/MoolahBenchmarks/SyncReactivityBenchmarks.swift
@@ -76,9 +76,7 @@ final class SyncReactivityBenchmarks: XCTestCase {
   /// observer, seed accounts, drive an `AccountStore` through the
   /// bulk-write window, and return the cumulative MainActor nanoseconds
   /// the store spent inside `apply(accounts:)` over the bulk-sync slice.
-  /// Hoisted out of the `measure` closure so the latter stays under
-  /// SwiftLint's `closure_body_length` ceiling and so the per-iteration
-  /// teardown is trivially obvious.
+  /// A single helper so the per-iteration teardown is trivially obvious.
   @MainActor
   private static func runOneBulkSyncIteration() async throws -> UInt64 {
     let (backend, database) = try TestBackend.create()

--- a/MoolahTests/App/InstrumentRegistrationZoneRoutingTests.swift
+++ b/MoolahTests/App/InstrumentRegistrationZoneRoutingTests.swift
@@ -12,9 +12,9 @@ import Testing
 /// account writes take before their per-profile `database.write`)
 /// emits its `onRecordChanged` hook with a string-keyed recordName
 /// destined for the **profile-index zone** — never a `profile-<UUID>`
-/// zone. The legacy per-profile-zone instrument upload path is
-/// decommissioned (DEBUG trap in `ProfileDataSyncHandler.recordToSave`
-/// catches regressions); this test pins the positive contract
+/// zone. There is no per-profile-zone instrument upload path (a DEBUG
+/// trap in `ProfileDataSyncHandler.recordToSave` catches regressions);
+/// this test pins the positive contract
 /// end-to-end so a future refactor that loses the shared-registry
 /// routing fails here before hitting the trap in CI.
 @Suite("Instrument registration routes to the profile-index zone")

--- a/MoolahTests/App/ProfileSessionTests.swift
+++ b/MoolahTests/App/ProfileSessionTests.swift
@@ -66,10 +66,10 @@ struct ProfileSessionTests {
 
   // MARK: - setUp() — async SwiftData → GRDB migration entry point (#575)
 
-  /// `ProfileSession.init` no longer runs the SwiftData → GRDB
-  /// migration; that work moved into `setUp()` so the eight per-type
-  /// `database.write` calls dispatch to GRDB's writer queue rather than
-  /// blocking `@MainActor`. Calling `await session.setUp()` is
+  /// The SwiftData → GRDB migration runs in `setUp()`, not
+  /// `ProfileSession.init`, so the eight per-type `database.write`
+  /// calls dispatch to GRDB's writer queue rather than blocking
+  /// `@MainActor`. Calling `await session.setUp()` is
   /// idempotent — multiple awaits coalesce on the same in-flight task,
   /// which keeps view-side and caller-side awaits cheap and lets
   /// `SessionManager.session(for:)` fire-and-forget the first call

--- a/MoolahTests/Backends/CloudKit/ProfileIndexConflictResolutionTests.swift
+++ b/MoolahTests/Backends/CloudKit/ProfileIndexConflictResolutionTests.swift
@@ -7,8 +7,8 @@ import Testing
 
 @Suite("ProfileIndexSyncHandler — dataFormatVersion conflict resolution")
 struct ProfileIndexConflictResolutionTests {
-  /// Bundles the handler, the backing repository, and a fresh profile id
-  /// so the helper signature stays under SwiftLint's `large_tuple` ceiling.
+  /// Bundles the handler, the backing repository, and a fresh profile
+  /// id for the test helpers.
   private struct Fixture {
     let handler: ProfileIndexSyncHandler
     let repository: GRDBProfileIndexRepository

--- a/MoolahTests/Backends/CloudKit/ProfileIndexInstrumentDispatchTests.swift
+++ b/MoolahTests/Backends/CloudKit/ProfileIndexInstrumentDispatchTests.swift
@@ -7,12 +7,10 @@ import Testing
 
 @testable import Moolah
 
-/// Verifies the InstrumentRecord dispatch added to
-/// `ProfileIndexSyncHandler`: downlink apply, uplink build,
-/// `queueAllExistingRecords`, and the system-fields write path.
-/// Conflict and lifecycle paths live in
-/// `ProfileIndexInstrumentLifecycleTests` to keep this file under
-/// SwiftLint's `type_body_length` threshold.
+/// Verifies `ProfileIndexSyncHandler`'s InstrumentRecord dispatch:
+/// downlink apply, uplink build, `queueAllExistingRecords`, and the
+/// system-fields write path. Conflict and lifecycle paths live in
+/// `ProfileIndexInstrumentLifecycleTests`.
 @Suite("ProfileIndexSyncHandler — InstrumentRecord dispatch")
 struct ProfileIndexInstrumentDispatchTests {
   typealias Harness = ProfileIndexInstrumentTestSupport.Harness

--- a/MoolahTests/Backends/CloudKit/ProfileIndexInstrumentLifecycleTests.swift
+++ b/MoolahTests/Backends/CloudKit/ProfileIndexInstrumentLifecycleTests.swift
@@ -7,10 +7,9 @@ import Testing
 
 @testable import Moolah
 
-/// Verifies the conflict-merge and lifecycle-wipe behaviour added to
-/// `ProfileIndexSyncHandler` for `InstrumentRecord`. Split from
-/// `ProfileIndexInstrumentDispatchTests` to keep both files under
-/// SwiftLint's `type_body_length` threshold.
+/// Verifies `ProfileIndexSyncHandler`'s conflict-merge and
+/// lifecycle-wipe behaviour for `InstrumentRecord`. Dispatch paths
+/// live in `ProfileIndexInstrumentDispatchTests`.
 @Suite("ProfileIndexSyncHandler — InstrumentRecord conflict + lifecycle")
 struct ProfileIndexInstrumentLifecycleTests {
   typealias Harness = ProfileIndexInstrumentTestSupport.Harness

--- a/MoolahTests/Backends/CloudKit/Sync/InstrumentSyncPricingStatusMergeTests.swift
+++ b/MoolahTests/Backends/CloudKit/Sync/InstrumentSyncPricingStatusMergeTests.swift
@@ -20,9 +20,8 @@ struct InstrumentSyncPricingStatusMergeTests {
   /// Builds a fresh in-memory database + registry for one test.
   ///
   /// The registry is backed by a profile-index DB — instrument identity
-  /// lives there post-`v10_drop_shared_instrument_legacy`; the
-  /// per-profile `instrument` table no longer exists. The returned
-  /// handle is the registry's own DB, so the `InstrumentRow` read-backs
+  /// lives there; there is no per-profile `instrument` table. The
+  /// returned handle is the registry's own DB, so the `InstrumentRow` read-backs
   /// observe exactly what the registry persisted.
   private func makeRegistry() throws -> (
     database: any DatabaseWriter,

--- a/MoolahTests/Backends/GRDB/AnalysisAggregationPlanPinningTests.swift
+++ b/MoolahTests/Backends/GRDB/AnalysisAggregationPlanPinningTests.swift
@@ -7,9 +7,8 @@ import Testing
 /// `EXPLAIN QUERY PLAN`-pinning tests for the analysis aggregations and
 /// the still-intentional full-table reads on the analysis hot path.
 ///
-/// Split out of `AnalysisPlanPinningTests` so each file stays under the
-/// SwiftLint `type_body_length` budget. Same `EXPLAIN QUERY PLAN`
-/// methodology as the parent suite (see its file header).
+/// Same `EXPLAIN QUERY PLAN` methodology as `AnalysisPlanPinningTests`
+/// (see its file header).
 ///
 /// **Temp B-tree GROUP/ORDER lines are accepted across this whole
 /// file.** Aggregations group and order by `day = DATE(t.date)` — a
@@ -163,10 +162,10 @@ struct AnalysisAggregationPlanPinningTests {
     // `GRDBAnalysisRepository.fetchCategoryBalances(...)` with no
     // optional filters set: GROUP BY `(DATE(t.date), category_id,
     // instrument_id)` restricted to non-scheduled categorised legs of
-    // a given type in a date range. The aggregation no longer joins
+    // a given type in a date range. The aggregation does not join
     // to `account` — investment-account legs are intentionally
     // included alongside the rest (matches
-    // `fetchIncomeAndExpense`'s contract). With the LEFT JOIN gone
+    // `fetchIncomeAndExpense`'s contract). Without the LEFT JOIN
     // the plan resolves to `USING COVERING INDEX` on
     // `leg_analysis_by_type_category` because every leg column
     // touched (`type`, `category_id`, `instrument_id`,

--- a/MoolahTests/Backends/GRDB/AnalysisPlanPinningTests.swift
+++ b/MoolahTests/Backends/GRDB/AnalysisPlanPinningTests.swift
@@ -19,7 +19,7 @@ import Testing
 /// 2. The plan does **not** include a `SCAN` of the table — a SCAN is the
 ///    canonical regression signature when an index becomes unusable
 ///    (column rename, predicate drift, partial-index WHERE clause that
-///    no longer matches the predicate).
+///    fails to match the predicate).
 @Suite("Core financial graph plan-pinning")
 struct AnalysisPlanPinningTests {
 

--- a/MoolahTests/Backends/GRDB/CategoryRepositoryRollbackTests.swift
+++ b/MoolahTests/Backends/GRDB/CategoryRepositoryRollbackTests.swift
@@ -6,12 +6,11 @@ import Testing
 
 @testable import Moolah
 
-/// Rollback contract tests for `GRDBCategoryRepository.delete(id:withReplacement:)`
-/// — split out of `CoreFinancialGraphRollbackTests` so each file stays
-/// under SwiftLint's `file_length` ceiling. The repository's delete path
-/// touches three tables (categories, transaction legs, budget items)
-/// inside a single write transaction; these tests force a mid-write
-/// failure and assert the prior state survives byte-equal.
+/// Rollback contract tests for `GRDBCategoryRepository.delete(id:withReplacement:)`.
+/// The repository's delete path touches three tables (categories,
+/// transaction legs, budget items) inside a single write transaction;
+/// these tests force a mid-write failure and assert the prior state
+/// survives byte-equal.
 @Suite("Category repository rollback contracts")
 @MainActor
 struct CategoryRepositoryRollbackTests {

--- a/MoolahTests/Backends/GRDB/CoreFinancialGraphSyncRoundTripTests.swift
+++ b/MoolahTests/Backends/GRDB/CoreFinancialGraphSyncRoundTripTests.swift
@@ -60,9 +60,8 @@ struct CoreFinancialGraphSyncRoundTripTests {
       Issue.record("applyRemoteChanges reported saveFailed: \(message)")
     }
 
-    // Post-`v10_drop_shared_instrument_legacy` the per-profile
-    // `instrument` table no longer exists, so an apply to it is
-    // structurally impossible — a strictly stronger guarantee than
+    // There is no per-profile `instrument` table, so an apply to it
+    // is structurally impossible — a strictly stronger guarantee than
     // "the row wasn't written". Assert the table is absent.
     let perProfileInstrumentAbsent = try await harness.database.read { database in
       try

--- a/MoolahTests/Backends/GRDB/DailyBalancesPlanPinningTests.swift
+++ b/MoolahTests/Backends/GRDB/DailyBalancesPlanPinningTests.swift
@@ -7,10 +7,9 @@ import Testing
 /// `EXPLAIN QUERY PLAN`-pinning tests for the four SQL fetches that
 /// drive `GRDBAnalysisRepository.fetchDailyBalances`: the per-day
 /// account-dimension SUM, the per-day earmark-dimension SUM, and the
-/// investment-value latest-as-of-day lookup. Split out of
-/// `AnalysisAggregationPlanPinningTests` so each file stays under the
-/// SwiftLint `type_body_length` and `file_length` budgets — same
-/// methodology, different aggregation surface.
+/// investment-value latest-as-of-day lookup. Same methodology as
+/// `AnalysisAggregationPlanPinningTests`, different aggregation
+/// surface.
 ///
 /// **Temp B-tree GROUP/ORDER lines are accepted across this whole
 /// file.** Every aggregation here groups and orders by

--- a/MoolahTests/Backends/GRDB/EmkRepoSharedInstrumentResolutionTests.swift
+++ b/MoolahTests/Backends/GRDB/EmkRepoSharedInstrumentResolutionTests.swift
@@ -22,8 +22,7 @@ import Testing
 /// a miss, resolution provably came from the injected resolver.
 @Suite("Earmark reads resolve instruments from the shared registry")
 struct EmkRepoSharedInstrumentResolutionTests {
-  /// Bundle returned by `makeSeededRepo` — replaces a 3-tuple to satisfy
-  /// SwiftLint's `large_tuple` policy.
+  /// Bundle returned by `makeSeededRepo`.
   private struct SeededRepo {
     let repo: GRDBEarmarkRepository
     let earmarkId: UUID

--- a/MoolahTests/Backends/GRDB/GRDBCategoryBalancesConversionTests.swift
+++ b/MoolahTests/Backends/GRDB/GRDBCategoryBalancesConversionTests.swift
@@ -178,7 +178,7 @@ struct GRDBCategoryBalancesConversionTests {
   @Test("category balances include categorised legs without an account")
   func categoryBalancesIncludeAccountlessCategorisedLegs() async throws {
     // A categorised expense leg with `accountId == nil` is included.
-    // The SQL aggregation no longer joins to `account`, so account-less
+    // The SQL aggregation does not join to `account`, so account-less
     // legs naturally fall through the `leg.category_id IS NOT NULL`
     // guard and contribute to the breakdown.
     let day = try AnalysisTestHelpers.utcDate(year: 2025, month: 8, day: 12, hour: 12)

--- a/MoolahTests/Backends/GRDB/GRDBCreateManyTests.swift
+++ b/MoolahTests/Backends/GRDB/GRDBCreateManyTests.swift
@@ -54,11 +54,11 @@ struct GRDBCreateManyTests {
     try await Task.sleep(for: .milliseconds(50))
   }
 
-  /// Post-`v10_drop_shared_instrument_legacy` the per-profile
-  /// `instrument` table no longer exists, so the "create path must not
-  /// write a per-profile placeholder" contract is now the structural
-  /// fact that the table is absent — a strictly stronger guarantee than
-  /// "zero rows". Returns `true` when the table does not exist.
+  /// There is no per-profile `instrument` table, so the "create path
+  /// must not write a per-profile placeholder" contract is the
+  /// structural fact that the table is absent — a strictly stronger
+  /// guarantee than "zero rows". Returns `true` when the table does
+  /// not exist.
   private func perProfileInstrumentTableAbsent(
     _ database: any DatabaseWriter
   ) async throws -> Bool {

--- a/MoolahTests/Backends/GRDB/GRDBCreatePathRegistersInstrumentTests.swift
+++ b/MoolahTests/Backends/GRDB/GRDBCreatePathRegistersInstrumentTests.swift
@@ -6,14 +6,13 @@ import Testing
 
 @testable import Moolah
 
-/// Pins the cross-transaction atomicity boundary introduced by the write
-/// cutover: instrument registration commits in its OWN transaction BEFORE
-/// the per-profile write that inserts the transaction/leg rows. If the
-/// per-profile write later fails and rolls back, the instrument row
-/// persists — safe because `registerResolvable` is idempotent and a
-/// retry will succeed. No existing rollback test covers this asymmetric
-/// boundary because the existing fiat-only rollback tests go through
-/// `registerResolvable` as a no-op.
+/// Pins the cross-transaction atomicity boundary: instrument
+/// registration commits in its OWN transaction BEFORE the per-profile
+/// write that inserts the transaction/leg rows. If the per-profile
+/// write later fails and rolls back, the instrument row persists —
+/// safe because `registerResolvable` is idempotent and a retry will
+/// succeed. The fiat-only rollback tests don't cover this asymmetric
+/// boundary because they go through `registerResolvable` as a no-op.
 ///
 /// The in-transaction throw is forced by a `BEFORE INSERT ON "transaction"`
 /// SQLite trigger so the abort fires inside the per-profile write block,
@@ -100,11 +99,10 @@ struct GRDBInstrumentRegistrationRollbackTests {
   }
 }
 
-/// Pins the instrument write cutover: `create` (transaction and account) no
-/// longer plants a per-profile placeholder `instrument` row. Instead it
-/// awaits `InstrumentRegistering.registerResolvable` *before* the
-/// per-profile write, so an immediately-following read resolves the
-/// instrument.
+/// Pins that `create` (transaction and account) does not plant a
+/// per-profile placeholder `instrument` row. Instead it awaits
+/// `InstrumentRegistering.registerResolvable` *before* the per-profile
+/// write, so an immediately-following read resolves the instrument.
 ///
 /// Production-shaped wiring: a SHARED `GRDBInstrumentRegistryRepository`
 /// over `ProfileIndexDatabase.openInMemory()` is injected as BOTH the
@@ -119,15 +117,14 @@ struct GRDBInstrumentRegistrationRollbackTests {
 ///      `cryptoRegistration(byId:)` — that is the inbox projection — so
 ///      resolvability must be probed via the resolver the read paths
 ///      actually use.)
-///   2. the per-profile `instrument` table no longer exists at all
-///      (`v10_drop_shared_instrument_legacy` dropped it) — a strictly
+///   2. there is no per-profile `instrument` table at all — a strictly
 ///      stronger guarantee than "zero placeholder rows".
 @Suite("create registers the instrument via the shared registry, not a per-profile placeholder")
 struct GRDBCreatePathRegistersInstrumentTests {
-  /// Post-v10 the per-profile `instrument` table is dropped, so the
-  /// "no per-profile placeholder" contract is now the structural fact
-  /// that the table does not exist. Returns `true` when the table is
-  /// absent (the expected, stronger guarantee).
+  /// There is no per-profile `instrument` table, so the "no
+  /// per-profile placeholder" contract is the structural fact that the
+  /// table does not exist. Returns `true` when the table is absent
+  /// (the expected, stronger guarantee).
   private func perProfileInstrumentTableAbsent(
     _ database: any DatabaseWriter
   ) async throws -> Bool {

--- a/MoolahTests/Backends/GRDB/GRDBDailyBalancesTradesModeRule11Tests.swift
+++ b/MoolahTests/Backends/GRDB/GRDBDailyBalancesTradesModeRule11Tests.swift
@@ -5,10 +5,9 @@ import Testing
 
 /// Multi-day, Rule 11 failure-scoping, carry-forward, priors-seed, and
 /// end-to-end pipeline tests for
-/// `GRDBAnalysisRepository.applyTradesModePositionValuations`. Split
-/// out of `GRDBDailyBalancesTradesModeTests` for SwiftLint
-/// `file_length` / `type_body_length` budgets — same fold, same
-/// helpers (`TradesModeFoldTestSupport`), partitioned by topic.
+/// `GRDBAnalysisRepository.applyTradesModePositionValuations`. Same
+/// fold and helpers (`TradesModeFoldTestSupport`) as
+/// `GRDBDailyBalancesTradesModeTests`, partitioned by topic.
 @Suite("GRDBAnalysisRepository applyTradesModePositionValuations — Rule 11 / cross-day")
 struct GRDBDailyBalancesTradesModeRule11Tests {
 

--- a/MoolahTests/Backends/GRDB/GRDBDailyBalancesTradesModeTests.swift
+++ b/MoolahTests/Backends/GRDB/GRDBDailyBalancesTradesModeTests.swift
@@ -8,8 +8,7 @@ import Testing
 /// happy-path, single-day, and no-op cases. Multi-day failure
 /// scoping, cumulative carry-forward, priors-seeding, and the
 /// end-to-end pipeline pin live in `GRDBDailyBalancesTradesModeRule11Tests`
-/// (split for SwiftLint `file_length` / `type_body_length` budgets;
-/// shared helpers are in `TradesModeFoldTestSupport`).
+/// (shared helpers are in `TradesModeFoldTestSupport`).
 ///
 /// Tests construct `DailyBalancesAggregation` directly and seed
 /// `dailyBalances` with placeholder entries so the fold can be

--- a/MoolahTests/Backends/GRDB/GRDBInstrumentMapCacheTests.swift
+++ b/MoolahTests/Backends/GRDB/GRDBInstrumentMapCacheTests.swift
@@ -8,8 +8,8 @@ import Testing
 
 /// Verifies `GRDBInstrumentRegistryRepository.instrumentMap()` serves a
 /// memoised `[String: Instrument]` snapshot that is rebuilt from the
-/// database only when a registry mutation invalidates it. The cutover
-/// routes every per-profile instrument resolution through this single
+/// database only when a registry mutation invalidates it. Every
+/// per-profile instrument resolution routes through this single
 /// shared method on the serial profile-index queue; a per-call DB read
 /// would serialise and regress the cold-launch burst. The correctness
 /// invariant under test is that *every* mutation path (local writes,

--- a/MoolahTests/Backends/GRDB/NoLegacyTableAccessTests.swift
+++ b/MoolahTests/Backends/GRDB/NoLegacyTableAccessTests.swift
@@ -5,10 +5,10 @@ import Testing
 
 @testable import Moolah
 
-/// Documents the post-v10 contract: a fully-migrated per-profile
-/// `data.sqlite` no longer carries the legacy instrument / market-data
-/// tables, so any code that still tried to read them would fail loudly
-/// at the SQLite layer rather than silently see an empty result. The
+/// Documents the contract that a fully-migrated per-profile
+/// `data.sqlite` does not carry the legacy instrument / market-data
+/// tables, so any code that tries to read them fails loudly at the
+/// SQLite layer rather than silently seeing an empty result. The
 /// authoritative instrument registry is the shared profile-index DB;
 /// the price caches are network-derived and also live on the shared DB.
 @Suite("Legacy per-profile tables are inaccessible after v10")

--- a/MoolahTests/Backends/GRDB/Observation/ObservationRegionTests.swift
+++ b/MoolahTests/Backends/GRDB/Observation/ObservationRegionTests.swift
@@ -151,8 +151,6 @@ struct ObservationRegionTests {
   }
 
   /// Inserts a single bank account row into an empty profile database.
-  /// Extracted so `fetchClosureDoesNotRefireOnSystemFieldsWrite` stays
-  /// under SwiftLint's `function_body_length`.
   private func seedAccount(id accountId: UUID, in databaseQueue: DatabaseQueue) async throws {
     let recordName = "AccountRecord|\(accountId.uuidString.lowercased())"
     try await databaseQueue.write { database in

--- a/MoolahTests/Backends/GRDB/Observation/RetryingAsyncStreamTests.swift
+++ b/MoolahTests/Backends/GRDB/Observation/RetryingAsyncStreamTests.swift
@@ -7,9 +7,9 @@ import os
 
 // Unit tests for the retry-loop driver shared by every
 // `toRetryingAsyncStream(...)` caller. We exercise the loop through
-// `makeRetryingAsyncStream(makeAttempt:policy:)` — the test seam
-// pulled out of `ValueObservation.toRetryingAsyncStream`
-// — by passing a synthetic factory that emits canned errors. This lets
+// `makeRetryingAsyncStream(makeAttempt:policy:)` — the test seam for
+// `ValueObservation.toRetryingAsyncStream` — by passing a synthetic
+// factory that emits canned errors. This lets
 // us verify retry counting, backoff, budget exhaustion, and emission-
 // resets-counter behaviour without standing up a real GRDB
 // `ValueObservation` (injecting `SQLITE_FULL` into a live DB is

--- a/MoolahTests/Backends/GRDB/Observation/ValueObservationAsyncStreamTests.swift
+++ b/MoolahTests/Backends/GRDB/Observation/ValueObservationAsyncStreamTests.swift
@@ -117,7 +117,7 @@ struct ValueObservationAsyncStreamTests {
         try Int.fetchAll(database, sql: "SELECT id FROM missing_table")
       }
       .values(in: queue)
-      // `onError` is now `async` (the bridge awaits before completing the
+      // `onError` is `async` (the bridge awaits before completing the
       // stream); `LockedBox.set` is a synchronous lock-guarded mutator
       // that is callable from any context, so no extra async work needed.
       .toAsyncStream(onError: { error in errorBox.set(error) })

--- a/MoolahTests/Backends/GRDB/ProfileIndexSchemaV3Tests.swift
+++ b/MoolahTests/Backends/GRDB/ProfileIndexSchemaV3Tests.swift
@@ -7,7 +7,7 @@ import Testing
 @testable import Moolah
 
 /// Confirms `v3_shared_instrument_registry` creates the expected tables
-/// in their post-v8 / post-v4 final shape on `profile-index.sqlite`.
+/// in their final shape on `profile-index.sqlite`.
 @Suite("ProfileIndexSchema — v3_shared_instrument_registry")
 struct ProfileIndexSchemaV3Tests {
   private func makeMigratedDatabase() throws -> DatabaseQueue {

--- a/MoolahTests/Backends/GRDB/RateCacheSchemaTests.swift
+++ b/MoolahTests/Backends/GRDB/RateCacheSchemaTests.swift
@@ -14,13 +14,12 @@ import Testing
 /// would also reintroduce the `RETURNING "rowid"` upsert hazard
 /// described in #582).
 ///
-/// Pinned to the v9 era: `v10_drop_shared_instrument_legacy` later
-/// drops the six rate-cache tables (incl. all three `*_meta` tables)
-/// from the per-profile schema, so a full migration would leave them
-/// absent. The WITHOUT-ROWID contract is only observable while the
-/// tables exist, so the migrator is run `upTo:` the last migration
-/// before the v10 drop — each shipped migration keeps its own era's
-/// contract.
+/// Pinned to the v9 era: `v10_drop_shared_instrument_legacy` drops the
+/// six rate-cache tables (incl. all three `*_meta` tables) from the
+/// per-profile schema, so a full migration leaves them absent. The
+/// WITHOUT-ROWID contract is only observable while the tables exist,
+/// so the migrator is run `upTo:` the last migration that still has
+/// them — each shipped migration keeps its own era's contract.
 @Suite("Rate cache *_meta table schema")
 struct RateCacheSchemaTests {
   @Test

--- a/MoolahTests/Backends/GRDB/RepositorySyncCascadeTests.swift
+++ b/MoolahTests/Backends/GRDB/RepositorySyncCascadeTests.swift
@@ -10,8 +10,6 @@ import Testing
 struct RepositorySyncCascadeTests {
   /// Builds a `GRDBTransactionRepository` with the shared-registry
   /// resolver / registrar wiring shared by every test in this suite.
-  /// Factored out so the repeated construction doesn't push the type
-  /// body over SwiftLint's `type_body_length` budget.
   private func makeTxnRepo(
     _ database: any DatabaseWriter
   ) throws -> GRDBTransactionRepository {
@@ -198,9 +196,9 @@ struct RepositorySyncCascadeTests {
     }
   }
 
-  /// After v5, `performSetBudget` must NOT insert a stub `category` row
-  /// when the category doesn't exist yet — the FK that required the
-  /// workaround was dropped in v5_drop_foreign_keys.
+  /// `performSetBudget` must NOT insert a stub `category` row when the
+  /// category doesn't exist yet — the schema enforces no FK that would
+  /// require it.
   @Test
   func setBudgetToleratesUnknownCategoryWithoutStubInsert() async throws {
     let database = try ProfileDatabase.openInMemory()
@@ -255,8 +253,8 @@ struct RepositorySyncCascadeTests {
     let orphanEarmarkId = UUID()
 
     // No instrument seed: `.AUD` is an ambient fiat instrument resolved
-    // via the shared registry / fiat fallback, and the per-profile
-    // `instrument` table no longer exists post-v10.
+    // via the shared registry / fiat fallback, and there is no
+    // per-profile `instrument` table.
     let txId = UUID()
     let leg = TransactionLeg(
       accountId: orphanAccountId,

--- a/MoolahTests/Backends/GRDB/SyncRoundTripTransactionTests.swift
+++ b/MoolahTests/Backends/GRDB/SyncRoundTripTransactionTests.swift
@@ -67,14 +67,11 @@ struct SyncRoundTripTransactionTests {
   // MARK: - TransactionLegRow
 
   /// Seeds the `account` and `transaction` rows the leg references so
-  /// the test asserts a fully-resolved round-trip. Under v5 the schema
-  /// no longer enforces FKs (`v5_drop_foreign_keys`), so this seeding
-  /// is an *optional* setup detail — the apply path itself does not
-  /// require either parent to exist. New tests of leg sync apply
-  /// against missing parents live in
-  /// `MoolahTests/Sync/ApplyRemoteChangesOutOfOrderTests.swift`. Pulled
-  /// out of the test body to keep the test under the
-  /// function-body-length limit.
+  /// the test asserts a fully-resolved round-trip. The schema does not
+  /// enforce FKs, so this seeding is an *optional* setup detail — the
+  /// apply path itself does not require either parent to exist. Tests
+  /// of leg sync apply against missing parents live in
+  /// `MoolahTests/Sync/ApplyRemoteChangesOutOfOrderTests.swift`.
   private static func seedLegParents(
     database: any DatabaseWriter,
     txnId: UUID,

--- a/MoolahTests/Domain/AnalysisIncomeExpenseInvestmentTests.swift
+++ b/MoolahTests/Domain/AnalysisIncomeExpenseInvestmentTests.swift
@@ -8,9 +8,7 @@ import Testing
 /// in the monthly `income` / `expense` totals rather than silently
 /// dropped.
 ///
-/// Split out of `AnalysisIncomeExpenseTests` as a dedicated suite so the
-/// parent file stays under SwiftLint's `type_body_length` budget. The
-/// expected behaviour: `.income` / `.expense` legs only guard on
+/// The expected behaviour: `.income` / `.expense` legs only guard on
 /// `hasAccount` — there is NO investment-account exclusion. A backend
 /// that filtered investment-account income/expense legs out of the
 /// main totals would silently under-count user income.

--- a/MoolahTests/Domain/ConversionObservationContractTests.swift
+++ b/MoolahTests/Domain/ConversionObservationContractTests.swift
@@ -44,9 +44,9 @@ struct ConversionObservationContractTests {
   @Test("write to cache table emits a tick", arguments: CacheTable.allCases)
   func writeEmitsTick(table: CacheTable) async throws {
     let (backend, _) = try TestBackend.create()
-    // The rate caches live on the registry's profile-index DB post-v10
-    // — the per-profile rate-cache tables were dropped. The conversion
-    // service observes that DB, so the fixture write must land there.
+    // The rate caches live on the registry's profile-index DB. The
+    // conversion service observes that DB, so the fixture write must
+    // land there.
     let cacheDatabase = backend.grdbInstruments.database
     var iterator = backend.conversionService.observeRates().makeAsyncIterator()
     _ = await iterator.next()  // initial tick on subscription

--- a/MoolahTests/Domain/InstrumentRecordCryptoFieldsTests.swift
+++ b/MoolahTests/Domain/InstrumentRecordCryptoFieldsTests.swift
@@ -110,8 +110,8 @@ struct InstrumentRecordCryptoFieldsTests {
 
   @Test
   func decodingPreMigrationCKRecordLeavesMappingFieldsNil() throws {
-    // Simulate a record saved by an older version that didn't know about
-    // the three new fields. Only the legacy keys are present.
+    // A record saved by an older app version: only the pre-migration
+    // keys are present, none of the three mapping fields.
     let zoneID = CKRecordZone.ID(zoneName: "test", ownerName: CKCurrentUserDefaultName)
     let recordID = CKRecord.ID(recordName: "AUD", zoneID: zoneID)
     let ckRecord = CKRecord(recordType: "InstrumentRecord", recordID: recordID)

--- a/MoolahTests/Domain/InstrumentRegistryContractTests.swift
+++ b/MoolahTests/Domain/InstrumentRegistryContractTests.swift
@@ -27,11 +27,10 @@ struct InstrumentRegistryContractTests {
 
   @MainActor
   func makeSubject() throws -> Subject {
-    // The registry's canonical store is the profile-index DB — the
-    // per-profile `instrument` table was removed by
-    // `v10_drop_shared_instrument_legacy`. `subject.database` is the
-    // registry's own DB, so direct `InstrumentRow` seeding still
-    // observes exactly what the registry reads.
+    // The registry's canonical store is the profile-index DB; there is
+    // no per-profile `instrument` table. `subject.database` is the
+    // registry's own DB, so direct `InstrumentRow` seeding observes
+    // exactly what the registry reads.
     let database = try ProfileIndexDatabase.openInMemory()
     let hooks = HookCapture()
     let repo = GRDBInstrumentRegistryRepository(

--- a/MoolahTests/Domain/PositionsViewInputChartTests.swift
+++ b/MoolahTests/Domain/PositionsViewInputChartTests.swift
@@ -4,9 +4,7 @@ import Testing
 @testable import Moolah
 
 /// Tests for the chart-visibility predicates on `PositionsViewInput`
-/// (`showsChart`, `showsAggregateChart`, `hasHistoricalSeries`). Split
-/// from `PositionsViewInputTests` to keep each suite under SwiftLint's
-/// `type_body_length` budget.
+/// (`showsChart`, `showsAggregateChart`, `hasHistoricalSeries`).
 @Suite("PositionsViewInput chart visibility")
 struct PositionsViewInputChartTests {
   let aud = Instrument.AUD

--- a/MoolahTests/Export/ExportCoordinatorImportNewProfileTests.swift
+++ b/MoolahTests/Export/ExportCoordinatorImportNewProfileTests.swift
@@ -82,10 +82,9 @@ struct ExportCoordinatorImportNewProfileTests {
     let containerManager = try ProfileContainerManager.forTesting()
     let profileStore = try makeProfileStore(containerManager: containerManager)
 
-    // Instrument identity lives on the shared profile-index registry
-    // post-`v10_drop_shared_instrument_legacy`; the import registers
-    // non-fiat denominations there and the verification backend reads
-    // through the same instance.
+    // Instrument identity lives on the shared profile-index registry;
+    // the import registers non-fiat denominations there and the
+    // verification backend reads through the same instance.
     let registry = try SharedRegistryTestSupport.makeSharedRegistry()
     let newProfileId = try await exportCoordinator.importNewProfileFromFile(
       url: tempURL,

--- a/MoolahTests/Export/ExportImportIntegrationTests.swift
+++ b/MoolahTests/Export/ExportImportIntegrationTests.swift
@@ -75,9 +75,9 @@ struct ExportImportIntegrationTests {
     registry: GRDBInstrumentRegistryRepository,
     label: String = "Test Profile"
   ) -> CloudKitBackend {
-    // Instrument identity lives on the shared profile-index registry
-    // post-`v10_drop_shared_instrument_legacy`; the verification backend
-    // reads through the same instance the import registered into.
+    // Instrument identity lives on the shared profile-index registry;
+    // the verification backend reads through the same instance the
+    // import registered into.
     CloudKitBackend(
       database: database,
       instrument: instrument,
@@ -149,8 +149,8 @@ struct ExportImportIntegrationTests {
     )
 
     // Import into fresh database. Instrument identity lives on the
-    // shared profile-index registry post-`v10_drop_shared_instrument_legacy`;
-    // the verification backend reads through the same instance.
+    // shared profile-index registry; the verification backend reads
+    // through the same instance.
     let freshDatabase = try ProfileDatabase.openInMemory()
     let registry = try SharedRegistryTestSupport.makeSharedRegistry()
     let result = try await coordinator.importFromFile(

--- a/MoolahTests/Export/ExportImportIntegrationTests4.swift
+++ b/MoolahTests/Export/ExportImportIntegrationTests4.swift
@@ -51,10 +51,9 @@ struct ExportImportIntegrationTests4 {
     let exportedInstrumentIds = Set(decoded.instruments.map(\.id))
     #expect(exportedInstrumentIds == [aud.id, usd.id, bhp.id, eth.id])
 
-    // Instrument identity lives on the shared profile-index registry
-    // post-`v10_drop_shared_instrument_legacy`; the import registers the
-    // non-fiat BHP / ETH there and the verification backend reads
-    // through the same instance.
+    // Instrument identity lives on the shared profile-index registry;
+    // the import registers the non-fiat BHP / ETH there and the
+    // verification backend reads through the same instance.
     let freshDatabase = try ProfileDatabase.openInMemory()
     let registry = try SharedRegistryTestSupport.makeSharedRegistry()
     _ = try await coordinator.importFromFile(

--- a/MoolahTests/Features/AccountStoreConversionTestsMore.swift
+++ b/MoolahTests/Features/AccountStoreConversionTestsMore.swift
@@ -124,8 +124,8 @@ struct AccountStoreConversionTestsMore {
     #expect(store.convertedNetWorth == nil)
   }
 
-  /// After conversion service recovers, a retry populates the previously
-  /// failing account balance and the aggregate totals.
+  /// After the conversion service recovers, a retry populates the
+  /// failed account balance and the aggregate totals.
   @Test
   func conversionFailuresAreRetriedAfterDelay() async throws {
     let aud = Instrument.AUD

--- a/MoolahTests/Features/AccountStoreConversionTestsMoreExtra.swift
+++ b/MoolahTests/Features/AccountStoreConversionTestsMoreExtra.swift
@@ -72,13 +72,14 @@ struct AccountStoreConversionTestsMoreExtra {
 
   // MARK: - computeConvertedInvestmentTotal single-pass conversion
 
-  /// Issue #96: `computeConvertedInvestmentTotal` previously routed positions
-  /// through two conversions — positions → account instrument → target. For
-  /// asymmetric rates (which all real-world rates are), chaining conversions
-  /// compounds rounding error and produces a different result than summing
-  /// positions directly to `target`. This test uses an asymmetric rate table
-  /// where double-conversion and single-pass conversion produce distinct
-  /// numerical answers and asserts the single-pass answer is returned.
+  /// Issue #96: `computeConvertedInvestmentTotal` must convert positions
+  /// directly to `target` in a single pass, not chain positions → account
+  /// instrument → target. For asymmetric rates (which all real-world rates
+  /// are), chaining conversions compounds rounding error and produces a
+  /// different result than summing positions directly to `target`. This
+  /// test uses an asymmetric rate table where double-conversion and
+  /// single-pass conversion produce distinct numerical answers and asserts
+  /// the single-pass answer is returned.
   @Test
   func computeConvertedInvestmentTotalSumsPositionsDirectlyToTarget()
     async throws

--- a/MoolahTests/Features/Accounts/AccountStoreSyncRefreshTests.swift
+++ b/MoolahTests/Features/Accounts/AccountStoreSyncRefreshTests.swift
@@ -54,9 +54,9 @@ struct AccountStoreSyncRefreshTests {
     // (an unrelated emission from the account observation) and would
     // not catch a regression to the empty-table region inference bug.
     let (backend, _) = try TestBackend.create()
-    // The rate caches live on the registry's profile-index DB post-v10
-    // — the per-profile rate-cache tables were dropped. The conversion
-    // service observes that DB, so the fixture write must land there.
+    // The rate caches live on the registry's profile-index DB. The
+    // conversion service observes that DB, so the fixture write must
+    // land there.
     let cacheDatabase = backend.grdbInstruments.database
     let store = AccountStore(
       repository: backend.accounts,

--- a/MoolahTests/Features/Crypto/CryptoSyncPipelineStructureTests.swift
+++ b/MoolahTests/Features/Crypto/CryptoSyncPipelineStructureTests.swift
@@ -34,8 +34,8 @@ struct CryptoSyncPipelineStructureTests {
   private func makeFixture() throws -> Fixture {
     let (backend, database) = try TestBackend.create()
     let alchemy = RecordingAlchemyClientStub()
-    // Resolve through the backend's shared profile-index registry
-    // (per-profile `instrument` table removed by v10).
+    // Resolve through the backend's shared profile-index registry;
+    // there is no per-profile `instrument` table.
     let registry = backend.grdbInstruments
     let discovery = CryptoTokenDiscoveryService(
       registry: registry,

--- a/MoolahTests/Features/Crypto/CryptoSyncStoreGlobalErrorTests.swift
+++ b/MoolahTests/Features/Crypto/CryptoSyncStoreGlobalErrorTests.swift
@@ -10,13 +10,11 @@ import Testing
 /// build phase produces a process-wide failure (`.missingApiKey` /
 /// `.invalidApiKey`) — either of those means no account can sync, so
 /// the user needs the global affordance, not a per-account caption —
-/// and clear once a sync cycle runs without one. The "clear on apply
-/// success" behaviour the store originally shipped with cleared the
-/// banner even when every account failed in the build phase (because
-/// the apply pass succeeds with empty input), which left the user
-/// staring at a per-row error caption with no global affordance to
-/// fix the underlying problem. These tests pin the corrected
-/// contract.
+/// and clear once a sync cycle runs without one. It must NOT clear on
+/// apply success when every account failed in the build phase (the
+/// apply pass succeeds with empty input); doing so would leave the
+/// user staring at a per-row error caption with no global affordance
+/// to fix the underlying problem. These tests pin that contract.
 @Suite("CryptoSyncStore — globalError banner")
 @MainActor
 struct CryptoSyncStoreGlobalErrorTests {

--- a/MoolahTests/Features/Crypto/CryptoSyncStoreTests.swift
+++ b/MoolahTests/Features/Crypto/CryptoSyncStoreTests.swift
@@ -49,8 +49,8 @@ struct CryptoSyncStoreTests {
     let (backend, database) = try TestBackend.create()
     let alchemy = RecordingAlchemyClientStub()
     alchemy.setTransfersResponse(.transfers([]))
-    // Resolve through the backend's shared profile-index registry
-    // (per-profile `instrument` table removed by v10).
+    // Resolve through the backend's shared profile-index registry;
+    // there is no per-profile `instrument` table.
     let registry = backend.grdbInstruments
     let discovery = CryptoTokenDiscoveryService(
       registry: registry,
@@ -328,8 +328,7 @@ struct CryptoSyncStoreTests {
   }
 
   // The global-error-banner tests live in
-  // `CryptoSyncStoreGlobalErrorTests.swift` so this file stays under
-  // SwiftLint's `file_length` and `type_body_length` budgets.
+  // `CryptoSyncStoreGlobalErrorTests.swift`.
 
   // MARK: - No background tasks
   //

--- a/MoolahTests/Features/CryptoTokenStoreSetStatusTests.swift
+++ b/MoolahTests/Features/CryptoTokenStoreSetStatusTests.swift
@@ -28,8 +28,7 @@ struct CryptoTokenStoreSetStatusTests {
   /// Bundle returned from `makeStore` so tests can reach the registry
   /// (for direct read-back of persisted values) and the recording
   /// conversion service (for invalidation assertions) alongside the
-  /// store under test. Keeps the helper signature under SwiftLint's
-  /// `large_tuple` ceiling.
+  /// store under test.
   private struct Fixture {
     let store: CryptoTokenStore
     let registry: GRDBInstrumentRegistryRepository
@@ -39,7 +38,7 @@ struct CryptoTokenStoreSetStatusTests {
   /// Builds a fresh store backed by an in-memory GRDB database with
   /// `count` built-in presets registered so the store has rows to mutate.
   private func makeStore(presetCount: Int = 1) async throws -> Fixture {
-    // Registry + price cache live on the profile-index DB post-v10.
+    // Registry + price cache live on the profile-index DB.
     let database = try ProfileIndexDatabase.openInMemory()
     let registry = GRDBInstrumentRegistryRepository(database: database)
     for preset in CryptoRegistration.builtInPresets.prefix(presetCount) {

--- a/MoolahTests/Features/CryptoTokenStoreSpamInstrumentsTests.swift
+++ b/MoolahTests/Features/CryptoTokenStoreSpamInstrumentsTests.swift
@@ -16,7 +16,7 @@ struct CryptoTokenStoreSpamInstrumentsTests {
   /// `presetCount` built-in presets registered so the store has rows to
   /// flip to `.spam` and assert membership of `spamInstruments`.
   private func makeStore(presetCount: Int = 2) async throws -> Fixture {
-    // Registry + price cache live on the profile-index DB post-v10.
+    // Registry + price cache live on the profile-index DB.
     let database = try ProfileIndexDatabase.openInMemory()
     let registry = GRDBInstrumentRegistryRepository(database: database)
     for preset in CryptoRegistration.builtInPresets.prefix(presetCount) {

--- a/MoolahTests/Features/EarmarkStorePartialConversionTests.swift
+++ b/MoolahTests/Features/EarmarkStorePartialConversionTests.swift
@@ -71,8 +71,8 @@ struct EarmarkStorePartialConversionTests {
     #expect(store.convertedTotalBalance == nil)
   }
 
-  /// After conversion service recovers, retry populates the previously
-  /// failing earmark balance and the aggregate total.
+  /// After the conversion service recovers, a retry populates the
+  /// failed earmark balance and the aggregate total.
   @Test
   func conversionFailuresAreRetriedAfterDelay() async throws {
     let aud = Instrument.AUD

--- a/MoolahTests/Features/EarmarkStoreVisibilityTests.swift
+++ b/MoolahTests/Features/EarmarkStoreVisibilityTests.swift
@@ -74,10 +74,10 @@ struct EarmarkStoreVisibilityTests {
 
   @Test("convertedBalance is populated for hidden earmarks even when showHidden is false")
   func hiddenEarmarkConvertedBalancePopulated() async throws {
-    // Regression: toggling "Show Hidden" used to surface a permanent spinner
-    // on hidden earmark rows because runConversionAttempt only iterated
-    // visibleEarmarks. The store should populate convertedBalances for every
-    // earmark regardless of visibility — the filter is for what to display.
+    // The store must populate convertedBalances for every earmark
+    // regardless of visibility — the filter is only for what to display.
+    // If runConversionAttempt iterated only visibleEarmarks, toggling
+    // "Show Hidden" would surface a permanent spinner on hidden rows.
     let visible = Earmark(name: "Visible", instrument: .defaultTestInstrument)
     let hidden = Earmark(
       name: "Hidden", instrument: .defaultTestInstrument, isHidden: true)

--- a/MoolahTests/Features/InvestmentStoreTests.swift
+++ b/MoolahTests/Features/InvestmentStoreTests.swift
@@ -169,10 +169,9 @@ struct InvestmentStoreTests {
     #expect(store.error != nil)
   }
 
-  // The previous `onInvestmentValueChanged` callback is no longer part
-  // of `InvestmentStore` — cross-store fan-out to `AccountStore` happens
-  // via `AccountStore`'s `investmentRepository.observeAllValues()`
-  // subscription. See `AccountStoreSyncRefreshTests.investmentValueWriteReachesAccountStore`.
+  // Cross-store fan-out to `AccountStore` happens via `AccountStore`'s
+  // `investmentRepository.observeAllValues()` subscription. See
+  // `AccountStoreSyncRefreshTests.investmentValueWriteReachesAccountStore`.
 
   // MARK: - Daily Balances
 }

--- a/MoolahTests/Features/ProfileStoreStaleActiveIDRecoveryTests.swift
+++ b/MoolahTests/Features/ProfileStoreStaleActiveIDRecoveryTests.swift
@@ -4,8 +4,8 @@ import Testing
 @testable import Moolah
 
 /// Covers the stale-`activeProfileID` recovery path in
-/// `ProfileStore.applyLoadedProfiles(_:isInitialLoad:)`. A previously
-/// active profile may be deleted on another device — or the local
+/// `ProfileStore.applyLoadedProfiles(_:isInitialLoad:)`. The active
+/// profile may be deleted on another device — or the local
 /// `activeProfileID` UserDefault may simply not match the loaded set
 /// (e.g. switching between Debug and Release builds, which share a
 /// bundle id but talk to different CloudKit containers). On the next

--- a/MoolahTests/Features/ProfileStoreTests.swift
+++ b/MoolahTests/Features/ProfileStoreTests.swift
@@ -175,12 +175,10 @@ struct ProfileStoreTests {
 
   // MARK: - Initial-load race
 
-  /// Regression for the missing first-paint population: previously the
-  /// SwiftData profile-index fetch in `init` was synchronous, so
-  /// `profiles` was non-empty before any view rendered. After the GRDB
-  /// migration the load became async, leaving `profiles` empty for the
-  /// first scene tick — `ProfileWindowView.resolvedProfile` then fell
-  /// through to `WelcomeView` even though a profile existed on disk,
+  /// `init` must populate `profiles` synchronously from GRDB before any
+  /// await, so it is non-empty on the first scene tick. If `profiles`
+  /// were empty there, `ProfileWindowView.resolvedProfile` would fall
+  /// through to `WelcomeView` even though a profile exists on disk,
   /// breaking every UI test seed that relies on the seeded profile
   /// being immediately resolvable.
   @Test("init populates profiles synchronously from GRDB before any await")

--- a/MoolahTests/Features/Settings/CryptoSettingsAPIKeyTests.swift
+++ b/MoolahTests/Features/Settings/CryptoSettingsAPIKeyTests.swift
@@ -38,7 +38,7 @@ struct CryptoSettingsAPIKeyTests {
   /// ids. Returns the keychain handles too so tests can read the raw
   /// entry to confirm round-trips.
   private func makeFixture() throws -> Fixture {
-    // Registry + price cache live on the profile-index DB post-v10.
+    // Registry + price cache live on the profile-index DB.
     let database = try ProfileIndexDatabase.openInMemory()
     let registry = GRDBInstrumentRegistryRepository(database: database)
     let priceService = CryptoPriceService(

--- a/MoolahTests/Features/Settings/CryptoSettingsAccountsListTests.swift
+++ b/MoolahTests/Features/Settings/CryptoSettingsAccountsListTests.swift
@@ -36,9 +36,8 @@ struct CryptoSettingsAccountsListTests {
     let (backend, database) = try TestBackend.create()
     let alchemy = RecordingAlchemyClientStub()
     alchemy.setTransfersResponse(.transfers([]))
-    // Resolve through the backend's own shared profile-index registry —
-    // the per-profile `instrument` table was removed by
-    // `v10_drop_shared_instrument_legacy`.
+    // Resolve through the backend's own shared profile-index registry;
+    // there is no per-profile `instrument` table.
     let registry = backend.grdbInstruments
     let discovery = CryptoTokenDiscoveryService(
       registry: registry, resolver: CountingRegistrationResolver(), alchemy: alchemy)

--- a/MoolahTests/Features/Settings/DiscoveredTokensInboxTests.swift
+++ b/MoolahTests/Features/Settings/DiscoveredTokensInboxTests.swift
@@ -33,7 +33,7 @@ struct DiscoveredTokensInboxTests {
   /// in-memory GRDB database, so a write through any of them is visible
   /// to the others — the same coupling the production wiring has.
   private func makeFixture() async throws -> Fixture {
-    // Registry + price cache live on the profile-index DB post-v10.
+    // Registry + price cache live on the profile-index DB.
     let database = try ProfileIndexDatabase.openInMemory()
     let registry = GRDBInstrumentRegistryRepository(database: database)
     let priceService = CryptoPriceService(

--- a/MoolahTests/Features/Settings/SpamTokensViewTests.swift
+++ b/MoolahTests/Features/Settings/SpamTokensViewTests.swift
@@ -22,7 +22,7 @@ struct SpamTokensViewTests {
   }
 
   private func makeFixture() async throws -> Fixture {
-    // Registry + price cache live on the profile-index DB post-v10.
+    // Registry + price cache live on the profile-index DB.
     let database = try ProfileIndexDatabase.openInMemory()
     let registry = GRDBInstrumentRegistryRepository(database: database)
     let priceService = CryptoPriceService(

--- a/MoolahTests/Features/TransactionStoreEarmarkTests.swift
+++ b/MoolahTests/Features/TransactionStoreEarmarkTests.swift
@@ -229,8 +229,6 @@ struct TransactionStoreEarmarkTests {
     #expect(balance.quantity == Decimal(500))
   }
 
-  // `testRunningBalancesUpdateAfterAmountChange` was moved to
-  // `TransactionStoreRunningBalanceTests.swift` so this file's
-  // type body stays under the SwiftLint length budget after the
-  // reactive migration's emission-await call was added.
+  // Running-balance update tests live in
+  // `TransactionStoreRunningBalanceTests.swift`.
 }

--- a/MoolahTests/Features/TransactionStorePayScheduledTests.swift
+++ b/MoolahTests/Features/TransactionStorePayScheduledTests.swift
@@ -245,9 +245,8 @@ struct TransactionStorePayScheduledTests {
 
   // MARK: - Helpers
 
-  /// Builds a fully-populated scheduled transfer for the "preserves all fields"
-  /// assertion. Extracted so the test body stays under the function length
-  /// policy and the test reads top-down.
+  /// Builds a fully-populated scheduled transfer for the "preserves all
+  /// fields" assertion.
   private func makeScheduledTransfer(
     toAccountId: UUID,
     categoryId: UUID,

--- a/MoolahTests/Features/TransactionStoreRunningBalanceTests.swift
+++ b/MoolahTests/Features/TransactionStoreRunningBalanceTests.swift
@@ -3,10 +3,7 @@ import Testing
 
 @testable import Moolah
 
-/// Running-balance update tests for `TransactionStore`. Split from
-/// `TransactionStoreCRUDTests` to keep both files under SwiftLint's
-/// `type_body_length` budget once the reactive migration's
-/// emission-await calls were added inline.
+/// Running-balance update tests for `TransactionStore`.
 @Suite("TransactionStore/Running Balances")
 @MainActor
 struct TransactionStoreRunningBalanceTests {

--- a/MoolahTests/Features/Transactions/TransactionStoreRegistryRefreshTests.swift
+++ b/MoolahTests/Features/Transactions/TransactionStoreRegistryRefreshTests.swift
@@ -6,20 +6,19 @@ import Testing
 
 /// Cross-database refresh coverage for the reactive `TransactionStore`.
 ///
-/// Per-profile list observations stopped tracking the `instrument`
-/// table once instrument identity moved to the shared registry: the
-/// repository resolves it once per fetch via the shared
-/// `instrumentMap()` snapshot rather than joining `InstrumentRow` into
-/// the per-profile observation region. An instrument-METADATA edit
-/// (rename, ticker, pricing-status) applied to the shared registry
-/// therefore no longer re-fired the per-profile observation, so an
-/// already-open transaction list rendered stale instrument metadata
-/// until the subscription was torn down and recreated.
+/// Per-profile list observations do not track the `instrument` table:
+/// instrument identity lives in the shared registry, and the repository
+/// resolves it once per fetch via the shared `instrumentMap()` snapshot
+/// rather than joining `InstrumentRow` into the per-profile observation
+/// region. An instrument-METADATA edit (rename, ticker, pricing-status)
+/// applied to the shared registry therefore does not re-fire the
+/// per-profile observation on its own, which would leave an already-open
+/// transaction list rendering stale instrument metadata.
 ///
-/// These tests pin the closing of that gap: the store additionally
-/// consumes the shared registry's `observeChanges()` stream and, on
-/// each tick, re-runs its existing fetch + recompute path so the open
-/// list live-refreshes across the DB boundary.
+/// These tests pin that the store additionally consumes the shared
+/// registry's `observeChanges()` stream and, on each tick, re-runs its
+/// fetch + recompute path so the open list live-refreshes across the
+/// DB boundary.
 @Suite("TransactionStore registry refresh", .serialized)
 @MainActor
 struct TransactionStoreRegistryRefreshTests {

--- a/MoolahTests/Shared/CryptoImport/AlchemyTestSupport.swift
+++ b/MoolahTests/Shared/CryptoImport/AlchemyTestSupport.swift
@@ -26,7 +26,7 @@ enum AlchemyTestSupport {
 
   /// Variant that takes a `@Sendable` closure provider so tests can mutate
   /// the returned key between calls (covering the key-set-after-launch
-  /// case where `LiveAlchemyClient` was previously stale).
+  /// case).
   static func makeClient(
     apiKeyProvider: @escaping @Sendable () -> String?,
     permitsPerSecond: Double = 1_000,

--- a/MoolahTests/Shared/CryptoImport/CrossAccountTransferMergerTests.swift
+++ b/MoolahTests/Shared/CryptoImport/CrossAccountTransferMergerTests.swift
@@ -138,8 +138,8 @@ struct CrossAccountTransferMergerTests {
     #expect(merged.count == 1)
     let result = try #require(merged.first)
     // Filter by the `:gas` `externalId` suffix; value-bearing
-    // outbound legs are now `.expense` too, so type alone no longer
-    // disambiguates fee from value.
+    // outbound legs are `.expense` too, so type alone does not
+    // disambiguate fee from value.
     let feeLegs = result.transaction.legs.filter {
       $0.externalId?.hasSuffix(":gas") == true
     }

--- a/MoolahTests/Shared/CryptoImport/CrossDeviceLegDeduperEdgeCaseTests.swift
+++ b/MoolahTests/Shared/CryptoImport/CrossDeviceLegDeduperEdgeCaseTests.swift
@@ -5,10 +5,8 @@ import Testing
 @testable import Moolah
 
 /// Edge-case tests for `CrossDeviceLegDeduper`: mixed legs (one
-/// duplicate + one unique), determinism across input ordering. Split
-/// from `CrossDeviceLegDeduperTests` so each suite stays under
-/// SwiftLint's `type_body_length` threshold and convergence vs.
-/// edge-case scenarios remain independently scannable.
+/// duplicate + one unique), determinism across input ordering.
+/// Convergence tests live in `CrossDeviceLegDeduperTests`.
 @Suite("CrossDeviceLegDeduper — edge cases")
 @MainActor
 struct CrossDeviceLegDeduperEdgeCaseTests {

--- a/MoolahTests/Shared/CryptoImport/CryptoTokenDiscoveryServiceTests.swift
+++ b/MoolahTests/Shared/CryptoImport/CryptoTokenDiscoveryServiceTests.swift
@@ -5,8 +5,7 @@ import Testing
 @testable import Moolah
 
 /// Behavioural tests for `CryptoTokenDiscoveryService`. The in-flight
-/// coalescer / stress assertions live in `CryptoTokenDiscoveryCoalescerTests`
-/// to keep this file under SwiftLint's length thresholds.
+/// coalescer / stress assertions live in `CryptoTokenDiscoveryCoalescerTests`.
 @Suite("CryptoTokenDiscoveryService — Resolution")
 struct CryptoTokenDiscoveryServiceTests {
   // Reusable USDC-like contract for the ERC-20 paths.

--- a/MoolahTests/Shared/CryptoImport/IntraAccountSwapDetectorTests.swift
+++ b/MoolahTests/Shared/CryptoImport/IntraAccountSwapDetectorTests.swift
@@ -8,8 +8,7 @@ import Testing
 /// trigger cases (2-token swap, 3-leg basket, LP add) and the non-
 /// trigger cases (pure inbound, pure outbound, same instrument both
 /// sides, empty input). Field and order preservation, plus self-send
-/// co-existence, live in `SwapDetectorPreservationTests` to keep this
-/// file under SwiftLint's `type_body_length` budget.
+/// co-existence, live in `SwapDetectorPreservationTests`.
 @Suite("IntraAccountSwapDetector")
 struct IntraAccountSwapDetectorTests {
   private static let accountId = makeUUID("AAAAAAAA-0000-0000-0000-000000000001")

--- a/MoolahTests/Shared/CryptoImport/SwapDetectorPreservationTests.swift
+++ b/MoolahTests/Shared/CryptoImport/SwapDetectorPreservationTests.swift
@@ -5,9 +5,7 @@ import Testing
 @testable import Moolah
 
 /// Field-, order-, and self-send-preservation tests for
-/// `IntraAccountSwapDetector`. Lives in its own file so the predicate-
-/// logic suite (`IntraAccountSwapDetectorTests`) stays under SwiftLint's
-/// `type_body_length` budget. Asserts that the only field the detector
+/// `IntraAccountSwapDetector`. Asserts that the only field the detector
 /// rewrites is `type`, that input order survives a retype, and that
 /// self-send legs are never partitioned into the swap predicate.
 @Suite("IntraAccountSwapDetector — preservation")

--- a/MoolahTests/Shared/CryptoImport/TransferEventBuilderConcurrencyTests.swift
+++ b/MoolahTests/Shared/CryptoImport/TransferEventBuilderConcurrencyTests.swift
@@ -6,10 +6,8 @@ import Testing
 
 /// Concurrency-focused coverage for the parallel paths inside
 /// `TransferEventBuilder`: the token-discovery coalescer (verified by
-/// the 100-concurrent-builders test moved out of
-/// `TransferEventBuilderTests` to keep that suite under SwiftLint's
-/// `type_body_length` budget). The receipt-coalescing path lives in
-/// `TransferEventBuilderGasCoalescingTests`.
+/// the 100-concurrent-builders test). The receipt-coalescing path lives
+/// in `TransferEventBuilderGasCoalescingTests`.
 @Suite("TransferEventBuilder — concurrency")
 struct TransferEventBuilderConcurrencyTests {
   private static let wallet = "0x1111111111111111111111111111111111111111"

--- a/MoolahTests/Shared/CryptoImport/TransferEventBuilderGasAttributionTests.swift
+++ b/MoolahTests/Shared/CryptoImport/TransferEventBuilderGasAttributionTests.swift
@@ -5,10 +5,8 @@ import Testing
 @testable import Moolah
 
 /// Coverage for the gas-attribution gating predicate that suppresses
-/// the `:gas` leg when the wallet did not sign the outer tx. Split out
-/// of `TransferEventBuilderGasLegTests` so each suite stays inside
-/// SwiftLint's `type_body_length` budget. The two real-world
-/// misattribution paths covered here are:
+/// the `:gas` leg when the wallet did not sign the outer tx. The two
+/// real-world misattribution paths covered here are:
 ///
 /// - An `internal` sub-call inside someone else's tx where the wallet
 ///   appears as `from` of the inner call (not the outer signer).

--- a/MoolahTests/Shared/CryptoImport/TransferEventBuilderGasCoalescingTests.swift
+++ b/MoolahTests/Shared/CryptoImport/TransferEventBuilderGasCoalescingTests.swift
@@ -4,11 +4,9 @@ import Testing
 
 @testable import Moolah
 
-/// Coalescing-specific coverage for the gas-leg receipt fetches added
-/// in #762. Split out of `TransferEventBuilderGasLegTests` so each
-/// suite stays inside SwiftLint's `type_body_length` budget. Verifies
-/// the per-hash deduplication that keeps an N-leg outbound transaction
-/// to a single `eth_getTransactionReceipt` round-trip.
+/// Coalescing-specific coverage for the gas-leg receipt fetches.
+/// Verifies the per-hash deduplication that keeps an N-leg outbound
+/// transaction to a single `eth_getTransactionReceipt` round-trip.
 @Suite("TransferEventBuilder — gas leg coalescing")
 struct TransferEventBuilderGasCoalescingTests {
   private static let wallet = "0x1111111111111111111111111111111111111111"
@@ -147,7 +145,7 @@ struct TransferEventBuilderGasCoalescingTests {
     #expect(alchemy.recordedReceiptCalls == ["0xmulti"])
     let candidate = try #require(built.first)
     // Filter by the gas leg's `:gas` `externalId` suffix; outbound value
-    // legs are now `.expense` too, so type alone no longer disambiguates.
+    // legs are `.expense` too, so type alone does not disambiguate.
     let gasLegs = candidate.transaction.legs.filter {
       $0.externalId?.hasSuffix(":gas") == true
     }

--- a/MoolahTests/Shared/CryptoImport/TransferEventBuilderGasLegTests.swift
+++ b/MoolahTests/Shared/CryptoImport/TransferEventBuilderGasLegTests.swift
@@ -4,7 +4,7 @@ import Testing
 
 @testable import Moolah
 
-/// Behavioural coverage for the gas-leg construction added in #762.
+/// Behavioural coverage for the gas-leg construction.
 /// Lives in its own suite because the receipt-fetch coalescing is a
 /// distinct concern from transfer-leg construction (covered by
 /// `TransferEventBuilderTests`). All tests here use

--- a/MoolahTests/Shared/CryptoImport/TransferEventBuilderNativeRegTests.swift
+++ b/MoolahTests/Shared/CryptoImport/TransferEventBuilderNativeRegTests.swift
@@ -4,11 +4,7 @@ import Testing
 
 @testable import Moolah
 
-/// Coverage for the chain native-gas pre-registration introduced for
-/// issue #791. Lives in its own suite (split from
-/// `TransferEventBuilderTests`) so the parent file stays inside
-/// SwiftLint's `type_body_length` budget — the same split rationale
-/// used by `TransferEventBuilderGasLegTests`.
+/// Coverage for the chain native-gas pre-registration. See issue #791.
 @Suite("TransferEventBuilder — native instrument registration")
 struct TransferEventBuilderNativeRegTests {
   private static let wallet = "0x1111111111111111111111111111111111111111"

--- a/MoolahTests/Shared/CryptoPriceServicePersistenceTests.swift
+++ b/MoolahTests/Shared/CryptoPriceServicePersistenceTests.swift
@@ -5,13 +5,11 @@ import Testing
 
 @testable import Moolah
 
-/// Persistence tests live in their own suite so the main behavioural
-/// suite (`CryptoPriceServiceTests`) and the resolution / multi-token
-/// suite (`CryptoPriceServiceTestsMore`) stay under SwiftLint's
-/// `type_body_length` cap. Covers the SQL save/load round-trip, the
-/// rollback contract for `CryptoPriceService.persistDelta`, and the
-/// delta-write + in-range short-circuit semantics that keep chart
-/// renders off the GRDB serial queue.
+/// Persistence tests for `CryptoPriceService`. Covers the SQL save/load
+/// round-trip, the rollback contract for
+/// `CryptoPriceService.persistDelta`, and the delta-write + in-range
+/// short-circuit semantics that keep chart renders off the GRDB serial
+/// queue.
 @Suite("CryptoPriceService — Persistence")
 struct CryptoPriceServicePersistenceTests {
   private let ethInstrument = Instrument.crypto(

--- a/MoolahTests/Shared/CryptoPriceServiceTests.swift
+++ b/MoolahTests/Shared/CryptoPriceServiceTests.swift
@@ -265,6 +265,5 @@ struct CryptoPriceServiceTests {
   }
 
   // Rollback contract for `persistDelta` lives in `CryptoPriceServiceTestsMore.swift`
-  // and cap-at-yesterday tests live in `CryptoPriceServiceCapTests.swift`
-  // so this file stays under SwiftLint's `type_body_length` cap.
+  // and cap-at-yesterday tests live in `CryptoPriceServiceCapTests.swift`.
 }

--- a/MoolahTests/Shared/CryptoPriceServiceTestsMore.swift
+++ b/MoolahTests/Shared/CryptoPriceServiceTestsMore.swift
@@ -58,8 +58,7 @@ struct CryptoPriceServiceTestsMore {
   }
 
   // SQL round-trip + rollback + persistence-efficiency tests live in
-  // `CryptoPriceServicePersistenceTests` so this suite stays under
-  // SwiftLint's `type_body_length` cap.
+  // `CryptoPriceServicePersistenceTests`.
 
   // MARK: - Prefetch
 

--- a/MoolahTests/Shared/DateISO8601DateOnlyTests.swift
+++ b/MoolahTests/Shared/DateISO8601DateOnlyTests.swift
@@ -5,9 +5,7 @@ import Testing
 
 /// Tests for the `Date.iso8601DateOnly` format style extension.
 ///
-/// The shared formatter previously used `nonisolated(unsafe)` on a non-`Sendable`
-/// `ISO8601DateFormatter`. It has been replaced with a `Sendable`
-/// `Date.ISO8601FormatStyle`. These tests verify the output matches what
+/// Verifies the `Sendable` `Date.ISO8601FormatStyle` output matches what
 /// `ISO8601DateFormatter` with `[.withFullDate]` produces.
 @Suite("Date -- ISO8601 Date-Only")
 struct DateISO8601DateOnlyTests {

--- a/MoolahTests/Shared/ExchangeRateServicePersistenceTests.swift
+++ b/MoolahTests/Shared/ExchangeRateServicePersistenceTests.swift
@@ -5,8 +5,7 @@ import Testing
 
 @testable import Moolah
 
-/// Persistence tests live in their own suite so the main behavioural suite
-/// (`ExchangeRateServiceTests`) stays under the `type_body_length` cap.
+/// Persistence tests for `ExchangeRateService`.
 /// Covers the SQL save/load round-trip, the rollback contract for
 /// `ExchangeRateService.persistDelta`, and the delta-write semantics that
 /// keep chart renders off the GRDB serial queue.
@@ -20,8 +19,6 @@ struct ExchangeRateServicePersistenceTests {
 
   /// Two service instances sharing the same `DatabaseQueue` — the second
   /// must load rates persisted by the first without going to the network.
-  /// Renamed from `gzipRoundTripPreservesData` after the migration from
-  /// gzipped JSON cache files to GRDB.
   ///
   /// Rates are stored as `REAL` (`Double`) per the schema; the boundary
   /// conversion `Decimal → Double → Decimal` preserves source precision
@@ -168,14 +165,10 @@ struct ExchangeRateServicePersistenceTests {
   /// must not touch the database when they bring back nothing.
   ///
   /// We detect the unwanted write by installing an `AFTER INSERT ON
-  /// exchange_rate` counter trigger after priming. With the guard in
-  /// place the counter stays at zero. Without the guard, the legacy
-  /// `saveCache` rewrote every cached rate row on every fetch and the
-  /// counter would increment by one per primed row. The current
-  /// delta-based `persistDelta` would still increment the counter for
-  /// the same scenario only if a non-empty fetch produced a non-empty
-  /// delta — which is exactly what the sibling
-  /// `saveCacheWritesOnlyChangedRows` test pins.
+  /// exchange_rate` counter trigger after priming; with the guard in
+  /// place the counter stays at zero. `persistDelta` increments the
+  /// counter only when a non-empty fetch produces a non-empty delta —
+  /// which the sibling `saveCacheWritesOnlyChangedRows` test pins.
   @Test
   func emptyFetchResultDoesNotRewriteCache() async throws {
     let database = try ProfileIndexDatabase.openInMemory()
@@ -215,18 +208,14 @@ struct ExchangeRateServicePersistenceTests {
   }
 
   /// `saveCache` must persist only the rows that the latest fetch added
-  /// or changed — not the entire cache. Before this contract was added
-  /// the implementation deleted every cached row for the base and
-  /// re-inserted them one by one on every save, so a chart with N cached
-  /// rates paid O(N) inserts per single-day extension. The user-visible
-  /// effect was the GRDB serial queue saturating on `ExchangeRateRecord`
-  /// inserts during chart renders against a populated cache.
+  /// or changed — not the entire cache. Rewriting every cached row for
+  /// the base on every save costs O(N) inserts per single-day extension
+  /// and saturates the GRDB serial queue on `ExchangeRateRecord` inserts
+  /// during chart renders against a populated cache.
   ///
   /// The test primes a cache of three rates, then drives one forward
-  /// extension that adds one new (date, quote) row. With a delta-write
-  /// implementation the `AFTER INSERT` counter sees exactly 1 — the new
-  /// row. With the legacy delete-and-rewrite path it would see 4 (the
-  /// three priming rows plus the new one).
+  /// extension that adds one new (date, quote) row; the `AFTER INSERT`
+  /// counter must see exactly 1 (the new row), not 4.
   @Test
   func saveCacheWritesOnlyChangedRows() async throws {
     let database = try ProfileIndexDatabase.openInMemory()

--- a/MoolahTests/Shared/ExchangeRateServiceTests.swift
+++ b/MoolahTests/Shared/ExchangeRateServiceTests.swift
@@ -186,8 +186,8 @@ struct ExchangeRateServiceTests {
     #expect(rate == dec("0.632"))
   }
 
-  // SQL persistence tests live in `ExchangeRateServicePersistenceTests`
-  // (round-trip + rollback) so this file stays under `type_body_length`.
+  // SQL persistence tests (round-trip + rollback) live in
+  // `ExchangeRateServicePersistenceTests`.
 
   @Test
   func fallbackNeverUsesFutureDate() async throws {
@@ -335,6 +335,5 @@ struct ExchangeRateServiceTests {
     #expect(client.fetchCount == primedFetches)
   }
 
-  // Cap-at-yesterday tests live in `ExchangeRateServiceCapTests.swift`
-  // so this suite stays under SwiftLint's `type_body_length` cap.
+  // Cap-at-yesterday tests live in `ExchangeRateServiceCapTests.swift`.
 }

--- a/MoolahTests/Shared/InstrumentSearchServiceTests.swift
+++ b/MoolahTests/Shared/InstrumentSearchServiceTests.swift
@@ -136,9 +136,8 @@ struct InstrumentSearchServiceTests {
     // CSV import landed it before the picker had a chance to resolve(). On
     // the catalog path that case must surface as `isRegistered: false,
     // requiresResolution: true` — the picker will then run resolve() and
-    // promote it to a fully registered row. The legacy code marked it as
-    // `isRegistered: true` while still asking for resolution, which is a
-    // contradictory state.
+    // promote it to a fully registered row. Marking it `isRegistered:
+    // true` while still asking for resolution is a contradictory state.
     let preMappingInst = Instrument.crypto(
       chainId: 1,
       contractAddress: "0xfoo",

--- a/MoolahTests/Shared/StockPriceServicePersistenceTests.swift
+++ b/MoolahTests/Shared/StockPriceServicePersistenceTests.swift
@@ -5,9 +5,7 @@ import Testing
 
 @testable import Moolah
 
-/// Persistence tests live in their own suite so the main behavioural
-/// suite (`StockPriceServiceTests`) stays under SwiftLint's
-/// `type_body_length` and `file_length` caps. Covers the SQL save/load
+/// Persistence tests for `StockPriceService`. Covers the SQL save/load
 /// round-trip, the rollback contract for `StockPriceService.persistDelta`,
 /// and the delta-write semantics that keep chart renders off the GRDB
 /// serial queue.

--- a/MoolahTests/Shared/StockPriceServiceTests.swift
+++ b/MoolahTests/Shared/StockPriceServiceTests.swift
@@ -184,8 +184,7 @@ struct StockPriceServiceTests {
   }
 
   // SQL persistence tests (round-trip + rollback + delta-write contracts)
-  // live in `StockPriceServicePersistenceTests` so this suite stays under
-  // SwiftLint's `type_body_length` cap.
+  // live in `StockPriceServicePersistenceTests`.
 
   // MARK: - Cap-at-yesterday rule
 

--- a/MoolahTests/Support/AccountStoreTestSupport.swift
+++ b/MoolahTests/Support/AccountStoreTestSupport.swift
@@ -4,10 +4,8 @@ import os
 
 @testable import Moolah
 
-/// Shared helpers for the split AccountStore test suites. Extracted from the
-/// original monolithic `AccountStoreTests.swift` so the focused suites
-/// (`AccountStoreLoadingTests`, `AccountStoreApplyDeltaTests`, etc.) can share
-/// fixtures without duplicating private helpers across files.
+/// Shared fixtures for the AccountStore test suites
+/// (`AccountStoreLoadingTests`, `AccountStoreApplyDeltaTests`, etc.).
 @MainActor
 enum AccountStoreTestSupport {
   static func seedAccount(

--- a/MoolahTests/Support/AnalysisTestHelpers.swift
+++ b/MoolahTests/Support/AnalysisTestHelpers.swift
@@ -34,9 +34,9 @@ enum AnalysisTestHelpers {
   /// row.sampleDate)` math — required by Rule 10
   /// same-`startOfDay` normalization tests.
   ///
-  /// Renamed from the `date(...)` overload to make the calendar
-  /// asymmetry explicit at the call site: the prefix-shared
-  /// `date(year:month:day:)` is fixed-Gregorian; this is local.
+  /// Named to make the calendar asymmetry explicit at the call site:
+  /// the prefix-shared `date(year:month:day:)` is fixed-Gregorian;
+  /// this is local.
   static func localDate(
     year: Int, month: Int, day: Int, hour: Int
   ) throws -> Date {

--- a/MoolahTests/Support/CloudKitAnalysisTestBackend.swift
+++ b/MoolahTests/Support/CloudKitAnalysisTestBackend.swift
@@ -28,8 +28,8 @@ struct CloudKitAnalysisTestBackend: BackendProvider, @unchecked Sendable {
 
   /// The shared profile-index instrument registry every repository
   /// resolves and registers through. Pointed at its own in-memory
-  /// profile-index DB, never the per-profile `instrument` table the
-  /// `v10_drop_shared_instrument_legacy` migration removes. Exposed so
+  /// profile-index DB; there is no per-profile `instrument` table.
+  /// Exposed so
   /// `fetchAggregationForTesting` resolves the exact instrument map the
   /// repositories built during seeding.
   let instrumentRegistry: GRDBInstrumentRegistryRepository
@@ -52,9 +52,8 @@ struct CloudKitAnalysisTestBackend: BackendProvider, @unchecked Sendable {
       conversion = customConversion
     } else {
       let rateClient = FixedRateClient()
-      // The rate cache lives on the registry's profile-index DB — the
-      // per-profile rate-cache tables were removed by
-      // `v10_drop_shared_instrument_legacy`.
+      // The rate cache lives on the registry's profile-index DB;
+      // there are no per-profile rate-cache tables.
       let exchangeRates = ExchangeRateService(
         client: rateClient, database: registry.database)
       conversion = FiatConversionService(exchangeRates: exchangeRates)

--- a/MoolahTests/Support/DateFailingConversionService.swift
+++ b/MoolahTests/Support/DateFailingConversionService.swift
@@ -18,8 +18,8 @@ struct DateFailingConversionService: InstrumentConversionService {
   /// Entries must be `Calendar.current.startOfDay`-normalised so
   /// they line up with how production callers compute their
   /// `dayKey` (`applyInvestmentValues`,
-  /// `applyTradesModePositionValuations`). The service no longer
-  /// re-normalises the `on:` argument inside `convert(...)` — a
+  /// `applyTradesModePositionValuations`). The service does not
+  /// re-normalise the `on:` argument inside `convert(...)` — a
   /// second `startOfDay` call with a non-Gregorian calendar would
   /// silently disagree with the caller's `Calendar.current`-keyed
   /// `failingDates`, turning Rule 10 regressions into false-greens.

--- a/MoolahTests/Support/ProfileDataSyncHandlerTestSupport.swift
+++ b/MoolahTests/Support/ProfileDataSyncHandlerTestSupport.swift
@@ -20,9 +20,9 @@ enum ProfileDataSyncHandlerTestSupport {
     try makeHandlerAndDatabase()
   }
 
-  /// Same as `makeHandlerWithDatabase()` — retained as a separate name
-  /// for callers that historically distinguished "I only need the
-  /// handler" from "I need to verify GRDB state".
+  /// Same as `makeHandlerWithDatabase()` — a separate name for callers
+  /// that distinguish "I only need the handler" from "I need to verify
+  /// GRDB state".
   @MainActor
   static func makeHandlerAndDatabase() throws -> HandlerHarness {
     let database = try ProfileDatabase.openInMemory()
@@ -57,8 +57,7 @@ enum ProfileDataSyncHandlerTestSupport {
   // MARK: - Row builders
   //
   // Compact constructors for the most common per-record-type rows the
-  // sync-handler tests seed. Each builder mirrors the small fixture
-  // shape these tests previously inserted via SwiftData — name +
+  // sync-handler tests seed. Each builder is a small fixture — name +
   // type/instrument, with sensible defaults for the audit columns.
 
   static func accountRow(
@@ -236,9 +235,8 @@ enum ProfileDataSyncHandlerTestSupport {
   ) throws -> ProfileGRDBRepositories {
     let conversionService = FixedConversionService(rates: [:])
     // Shared profile-index registry over its own in-memory DB —
-    // mirrors production wiring and never touches the per-profile
-    // `instrument` table the `v10_drop_shared_instrument_legacy`
-    // migration removes.
+    // mirrors production wiring; there is no per-profile `instrument`
+    // table (dropped by `v10_drop_shared_instrument_legacy`).
     let registry = try SharedRegistryTestSupport.makeSharedRegistry()
     return ProfileGRDBRepositories(
       csvImportProfiles: GRDBCSVImportProfileRepository(database: database),

--- a/MoolahTests/Support/SharedRegistryTestSupport.swift
+++ b/MoolahTests/Support/SharedRegistryTestSupport.swift
@@ -10,15 +10,10 @@ import GRDB
 ///
 /// This is the test-side mirror of how production wires the
 /// shared registry (`MoolahApp.makeSharedInstrumentRegistry` over
-/// `ProfileContainerManager.profileIndexDatabase`). It replaces the
-/// retired per-profile `PerProfileInstrumentMapResolver` /
-/// `PerProfileInstrumentRegistrar` shims at every repository / sync /
-/// rollback test seam: those shims read and wrote the per-profile
-/// `instrument` table that the `v10_drop_shared_instrument_legacy`
-/// migration removes. Resolution semantics are unchanged for the
-/// suites that use it — none seeds the shared registry, so reads fall
-/// through to the same `Instrument.fiat(code:)` path the per-profile
-/// shim produced on an empty per-profile table, while the per-profile
+/// `ProfileContainerManager.profileIndexDatabase`). It is the instrument
+/// resolver / registrar seam for every repository / sync / rollback
+/// test. Suites that use it do not seed the shared registry, so reads
+/// fall through to the `Instrument.fiat(code:)` path; the per-profile
 /// rows those suites insert for FK / cascade structure stay untouched.
 enum SharedRegistryTestSupport {
   /// A fresh shared registry over its own in-memory profile-index DB.

--- a/MoolahTests/Support/TestBackend+SeedBulkLegs.swift
+++ b/MoolahTests/Support/TestBackend+SeedBulkLegs.swift
@@ -3,11 +3,7 @@ import GRDB
 
 @testable import Moolah
 
-// Bulk transaction-leg seeding for the sync-reactivity benchmarks. Lives
-// in a dedicated extension file (rather than `TestBackend.swift`) to keep
-// the parent enum body under SwiftLint's `type_body_length` threshold and
-// to mirror the existing `TestBackend+SeedEarmarkTransactions.swift`
-// pattern.
+// Bulk transaction-leg seeding for the sync-reactivity benchmarks.
 extension TestBackend {
 
   /// Seeds `count` transactions, each with one leg, distributed
@@ -48,8 +44,6 @@ extension TestBackend {
   }
 
   /// Inserts one transaction + one leg row for the bulk-seed loop.
-  /// Extracted from `seedBulkTransactionLegs` so the closure passed to
-  /// `database.write` stays under SwiftLint's `closure_body_length`.
   private static func insertBulkLeg(
     index i: Int,
     accountId: UUID,

--- a/MoolahTests/Support/TestBackend+SeedEarmarkTransactions.swift
+++ b/MoolahTests/Support/TestBackend+SeedEarmarkTransactions.swift
@@ -3,9 +3,7 @@ import GRDB
 
 @testable import Moolah
 
-// `seedWithTransactions(...)` and its private leg-insertion helper —
-// split out of `TestBackend.swift` so that file's enum body stays under
-// SwiftLint's `type_body_length` threshold.
+// `seedWithTransactions(...)` and its private leg-insertion helper.
 extension TestBackend {
   /// Identifies an earmark transaction leg to seed alongside its earmark row.
   /// Bundles the per-call parameters that vary between the saved/spent paths

--- a/MoolahTests/Support/TestBackend.swift
+++ b/MoolahTests/Support/TestBackend.swift
@@ -44,8 +44,7 @@ enum TestBackend {
   /// call constructs a fresh registry against its own in-memory
   /// profile-index DB (`SharedRegistryTestSupport.makeSharedRegistry()`)
   /// — the test-time analogue of production's shared registry. It is
-  /// never pointed at the per-profile `ProfileDatabase`: the
-  /// `v10_drop_shared_instrument_legacy` migration removes the
+  /// never pointed at the per-profile `ProfileDatabase`: there is no
   /// per-profile `instrument` table, so instrument identity lives only
   /// on the profile-index registry.
   ///
@@ -63,12 +62,10 @@ enum TestBackend {
     let rateClient = FixedRateClient(rates: exchangeRates)
     // The per-profile `data.sqlite` carries domain rows and the two
     // synced csv-import tables. Instrument identity and the rate /
-    // price caches no longer live here: the
-    // `v10_drop_shared_instrument_legacy` migration removed the
-    // per-profile `instrument` + six rate-cache tables, so they live
-    // solely on the shared profile-index DB. This mirrors production,
-    // where `SyncCoordinator.sharedMarketData` and the shared registry
-    // are both pointed at `ProfileContainerManager.profileIndexDatabase`.
+    // price caches live solely on the shared profile-index DB, not
+    // here. This mirrors production, where
+    // `SyncCoordinator.sharedMarketData` and the shared registry are
+    // both pointed at `ProfileContainerManager.profileIndexDatabase`.
     let database = try ProfileDatabase.openInMemory()
     let registry =
       try sharedRegistry
@@ -97,12 +94,12 @@ enum TestBackend {
   ///
   /// `seed(transactions:)` and friends materialise FK / cascade
   /// structure by writing raw Rows; they cannot write a non-fiat
-  /// `instrument` row because the `v10_drop_shared_instrument_legacy`
-  /// migration removed the per-profile `instrument` table. Instrument
-  /// identity now lives solely on the profile-index registry, so a test
-  /// that seeds a stock / crypto leg must register its denomination here
-  /// — the same `InstrumentRegistering` seam production's create path
-  /// uses. Fiat is ambient (resolved from ISO data) and a no-op here.
+  /// `instrument` row because there is no per-profile `instrument`
+  /// table. Instrument identity lives solely on the profile-index
+  /// registry, so a test that seeds a stock / crypto leg must register
+  /// its denomination here — the same `InstrumentRegistering` seam
+  /// production's create path uses. Fiat is ambient (resolved from ISO
+  /// data) and a no-op here.
   static func register(
     _ instrument: Instrument,
     in backend: CloudKitBackend
@@ -199,8 +196,8 @@ enum TestBackend {
   /// Seeds transactions into the in-memory store.
   ///
   /// Non-fiat denominations are NOT auto-registered: instrument identity
-  /// lives on the profile-index registry (the per-profile `instrument`
-  /// table was removed by `v10_drop_shared_instrument_legacy`). A test
+  /// lives on the profile-index registry (there is no per-profile
+  /// `instrument` table). A test
   /// seeding a stock / crypto leg must register it via
   /// `TestBackend.register(_:in:)` so the resolver resolves it on
   /// read-back; fiat is ambient and needs no registration.
@@ -236,16 +233,15 @@ enum TestBackend {
   /// `earmark`) referenced by a single leg, if any of them are missing
   /// in the test database.
   ///
-  /// Convenience for SwiftData-era tests that rarely pre-seed parents
-  /// before legs that reference them. Under v5 the schema no longer
-  /// enforces FKs (`v5_drop_foreign_keys`); the helper continues to
-  /// exist so those tests can read back fully-resolved domain
-  /// `Transaction` values with non-trivial parent rows for assertion
-  /// purposes. Tests that care about a specific parent shape seed it
-  /// explicitly; the `ensurePlaceholder*` helpers respect existing rows.
+  /// Convenience for tests that rarely pre-seed parents before legs
+  /// that reference them. The schema does not enforce FKs
+  /// (`v5_drop_foreign_keys`); the helper lets those tests read back
+  /// fully-resolved domain `Transaction` values with non-trivial parent
+  /// rows for assertion purposes. Tests that care about a specific
+  /// parent shape seed it explicitly; the `ensurePlaceholder*` helpers
+  /// respect existing rows.
   ///
-  /// It does **not** materialise an `instrument` row: the
-  /// `v10_drop_shared_instrument_legacy` migration removed the
+  /// It does **not** materialise an `instrument` row: there is no
   /// per-profile `instrument` table, so instrument identity lives only
   /// on the profile-index registry. A test that seeds a non-fiat leg
   /// must register its denomination via `TestBackend.register(_:in:)`

--- a/MoolahTests/Support/TradesModeFoldTestSupport.swift
+++ b/MoolahTests/Support/TradesModeFoldTestSupport.swift
@@ -2,11 +2,8 @@ import Foundation
 
 @testable import Moolah
 
-/// Shared helpers for the trades-mode position-valuation fold tests.
-/// Hoisted out of `GRDBDailyBalancesTradesModeTests` so the suite can be
-/// split across multiple files (SwiftLint `file_length` /
-/// `type_body_length`) while keeping the helper definitions in a
-/// single place.
+/// Shared helpers for the trades-mode position-valuation fold tests
+/// (`GRDBDailyBalancesTradesModeTests` and its sibling suites).
 enum TradesModeFoldTestSupport {
 
   /// Build the standard `DailyBalancesHandlers` for fold-contract

--- a/MoolahTests/Support/TransactionDraftTestSupport.swift
+++ b/MoolahTests/Support/TransactionDraftTestSupport.swift
@@ -2,10 +2,8 @@ import Foundation
 
 @testable import Moolah
 
-/// Shared helpers and fixtures for the split `TransactionDraft` test suites.
-/// Extracted from the original monolithic `TransactionDraftTests.swift` so the
-/// focused suites can share setup without re-declaring the same private helpers
-/// across files. Instantiate once per suite as `let support = TransactionDraftTestSupport()`.
+/// Shared helpers and fixtures for the `TransactionDraft` test suites.
+/// Instantiate once per suite as `let support = TransactionDraftTestSupport()`.
 struct TransactionDraftTestSupport {
   let instrument = Instrument.defaultTestInstrument
   let accountA = UUID()

--- a/MoolahTests/Support/TransactionStoreTestSupport.swift
+++ b/MoolahTests/Support/TransactionStoreTestSupport.swift
@@ -4,10 +4,8 @@ import Testing
 
 @testable import Moolah
 
-/// Shared helpers for the split TransactionStore test suites. Extracted from the
-/// original monolithic `TransactionStoreTests.swift` so the focused suites
-/// (`TransactionStoreLoadingTests`, `TransactionStoreCRUDTests`, etc.) can share
-/// fixtures without duplicating private helpers across files.
+/// Shared fixtures for the TransactionStore test suites
+/// (`TransactionStoreLoadingTests`, `TransactionStoreCRUDTests`, etc.).
 @MainActor
 enum TransactionStoreTestSupport {
   /// A seeded account paired with its opening balance. Used by `makeStores` to

--- a/MoolahTests/Sync/ApplyPathSharedRegistryResolutionTests.swift
+++ b/MoolahTests/Sync/ApplyPathSharedRegistryResolutionTests.swift
@@ -10,21 +10,16 @@ import Testing
 /// and registers instruments against the SHARED profile-index registry,
 /// not the per-profile `instrument` table.
 ///
-/// Earlier work moved every `InstrumentRecord` apply onto the
-/// profile-index zone (`ProfileIndexSyncHandler` + the shared registry);
-/// the per-profile `ProfileDataSyncHandler` traps/skips them. The
-/// remaining per-profile-`instrument`-table seam reachable from the
-/// apply bundle was the `instrumentResolver` / `instrumentRegistrar`
-/// injected into the txn/account/earmark/investment repos by
-/// `makeForApply`. The apply path never invokes them today (it writes
-/// raw Rows via `applyRemoteChangesSync`), but they were per-profile
-/// `PerProfile*` shims pointed at the per-profile `instrument` table —
-/// which the `v10_drop_shared_instrument_legacy` migration has now
-/// dropped. After the cutover the per-profile `instrument` table no
-/// longer exists at all, so when a shared registry is supplied the
-/// bundle's resolver/registrar are the shared registry and any
-/// apply-time instrument resolution lands against the profile-index
-/// DB — the per-profile table is structurally unreachable.
+/// Every `InstrumentRecord` apply lands on the profile-index zone
+/// (`ProfileIndexSyncHandler` + the shared registry); the per-profile
+/// `ProfileDataSyncHandler` traps/skips them. The
+/// `instrumentResolver` / `instrumentRegistrar` injected into the
+/// txn/account/earmark/investment repos by `makeForApply` are the
+/// shared registry. The apply path never invokes them (it writes raw
+/// Rows via `applyRemoteChangesSync`), and there is no per-profile
+/// `instrument` table, so any apply-time instrument resolution lands
+/// against the profile-index DB — the per-profile table is
+/// structurally unreachable.
 @MainActor
 @Suite("Apply-path bundle resolves via the shared registry")
 struct ApplyPathSharedRegistryResolutionTests {
@@ -32,8 +27,8 @@ struct ApplyPathSharedRegistryResolutionTests {
   @Test(
     "makeForApply resolver reads instruments from the shared registry, not the per-profile table")
   func resolverUsesSharedRegistry() async throws {
-    // Two distinct databases: the per-profile DB (whose `instrument`
-    // table v10 has dropped) and the shared profile-index DB.
+    // Two distinct databases: the per-profile DB (which has no
+    // `instrument` table) and the shared profile-index DB.
     let perProfile = try ProfileDatabase.openInMemory()
     let sharedDB = try ProfileIndexDatabase.openInMemory()
     let sharedRegistry = GRDBInstrumentRegistryRepository(database: sharedDB)
@@ -68,9 +63,9 @@ struct ApplyPathSharedRegistryResolutionTests {
     #expect(earmarkMap[crypto.id]?.kind == .cryptoToken)
     #expect(investmentMap[crypto.id]?.kind == .cryptoToken)
 
-    // Post-v10 the per-profile `instrument` table no longer exists —
-    // resolution through it is structurally impossible, a strictly
-    // stronger guarantee than "the table is empty".
+    // The per-profile `instrument` table does not exist — resolution
+    // through it is structurally impossible, a strictly stronger
+    // guarantee than "the table is empty".
     let perProfileTableExists = try await perProfile.read { database in
       try Bool.fetchOne(
         database,
@@ -89,9 +84,9 @@ struct ApplyPathSharedRegistryResolutionTests {
     let bundle = ProfileGRDBRepositories.makeForApply(
       database: perProfile, sharedRegistry: sharedRegistry)
 
-    // Post-v10 the per-profile `instrument` table is dropped, so it is
+    // The per-profile `instrument` table does not exist, so it is
     // structurally impossible for the bundle's resolver to fall back to
-    // a per-profile crypto row: the table simply does not exist.
+    // a per-profile crypto row.
     let perProfileTableExists = try await perProfile.read { database in
       try Bool.fetchOne(
         database,
@@ -103,7 +98,7 @@ struct ApplyPathSharedRegistryResolutionTests {
     #expect(perProfileTableExists == false)
 
     // A crypto id present in neither the per-profile DB nor the shared
-    // registry resolves to nothing — resolution is shared-only now.
+    // registry resolves to nothing — resolution is shared-only.
     let map = try await bundle.transactions.instrumentResolver.instrumentMap()
     #expect(
       map["1:native"] == nil,

--- a/MoolahTests/Sync/ApplyRemoteChangesOutOfOrderTests.swift
+++ b/MoolahTests/Sync/ApplyRemoteChangesOutOfOrderTests.swift
@@ -9,9 +9,9 @@ import Testing
 
 /// Reproduces the v1.1.0-rc.12 incident as a unit test: a single
 /// CKRecord for an `InvestmentValueRow` whose parent `account` row
-/// doesn't exist locally must succeed at apply time. Under v4 (FK
-/// enforced) the insert tripped SQLite-19 → `.saveFailed(...)` →
-/// infinite re-fetch loop. v5 dropped the FK; the row lands cleanly.
+/// doesn't exist locally must succeed at apply time. The schema does
+/// not enforce the FK, so the row lands cleanly instead of tripping
+/// SQLite-19 → `.saveFailed(...)` → an infinite re-fetch loop.
 @Suite("Sync apply tolerates out-of-order CKRecord delivery")
 struct ApplyRemoteChangesOutOfOrderTests {
 
@@ -65,11 +65,11 @@ struct ApplyRemoteChangesOutOfOrderTests {
     #expect(count == 1)
   }
 
-  /// Symmetric coverage for the `transaction_leg.transaction_id ON DELETE
-  /// CASCADE` FK that v3 enforced. Under v4 a `TransactionLegRow` arriving
-  /// before its parent `TransactionRow` would have produced the same
-  /// SQLite-19 error rc.12 produced for investment values. v5 dropped the
-  /// FK; the leg lands cleanly even with no parent transaction in GRDB.
+  /// Symmetric coverage for the `transaction_leg.transaction_id`
+  /// relationship. The schema does not enforce the FK, so a
+  /// `TransactionLegRow` arriving before its parent `TransactionRow`
+  /// lands cleanly instead of tripping the SQLite-19 error rc.12 seen
+  /// for investment values.
   @Test("TransactionLeg CKRecord landing before its parent transaction succeeds")
   func transactionLegArrivesBeforeTransaction() async throws {
     let harness = try await MainActor.run {

--- a/MoolahTests/Sync/InstrumentLocalSyncQueueTests.swift
+++ b/MoolahTests/Sync/InstrumentLocalSyncQueueTests.swift
@@ -16,8 +16,8 @@ import os
 /// `Instrument.fiat(code: id)` in `fetchInstrumentMap`, and route stock
 /// conversions through Frankfurter, which 404s.
 ///
-/// The write cutover routes that registration through the injected
-/// `InstrumentRegistering` seam, awaited *before* the per-profile write.
+/// Registration routes through the injected `InstrumentRegistering`
+/// seam, awaited *before* the per-profile write.
 /// Production injects the shared `GRDBInstrumentRegistryRepository`;
 /// these tests use the production-shaped wiring (shared registry as
 /// `instrumentRegistrar`) and assert the instrument is now both

--- a/MoolahTests/Sync/NewMissingDeleteIDsTests.swift
+++ b/MoolahTests/Sync/NewMissingDeleteIDsTests.swift
@@ -8,12 +8,10 @@ import Testing
 
 /// Pure-helper tests for `SyncCoordinator.newMissingDeleteIDs(among:pendingChanges:)`.
 ///
-/// This is the fix for the O(candidates × pending) scan in the old
-/// per-record `handleMissingRecordToSave` path: the helper builds the
-/// `Set<CKRecord.ID>` from pending `.deleteRecord` entries once and
-/// filters every candidate against the set, so the main thread can
-/// drain a queue with tens of thousands of stale records in linear
-/// time without re-scanning per record.
+/// The helper builds the `Set<CKRecord.ID>` from pending
+/// `.deleteRecord` entries once and filters every candidate against the
+/// set, so the main thread can drain a queue with tens of thousands of
+/// stale records in linear time rather than O(candidates × pending).
 @Suite("SyncCoordinator.newMissingDeleteIDs")
 struct NewMissingDeleteIDsTests {
 

--- a/MoolahTests/Sync/ProfileDataSyncHandlerLookupTests.swift
+++ b/MoolahTests/Sync/ProfileDataSyncHandlerLookupTests.swift
@@ -86,13 +86,11 @@ struct ProfileDataSyncHandlerLookupTests {
     #expect(result?["name"] as? String == "Found")
   }
 
-  // `recordToSaveFindsInstrumentByStringID` was removed when the
-  // shared-instrument-registry rollout decommissioned the per-profile
-  // `InstrumentRecord` upload path. `ProfileDataSyncHandler.recordToSave`
-  // now traps in DEBUG (logs+returns nil in release) for any
-  // InstrumentRecord routed to a per-profile zone — see
-  // `ProfileDataSyncHandler+RecordLookup.swift`. The replacement
-  // upload path is exercised by
+  // There is no per-profile `InstrumentRecord` upload path:
+  // `ProfileDataSyncHandler.recordToSave` traps in DEBUG (logs+returns
+  // nil in release) for any InstrumentRecord routed to a per-profile
+  // zone — see `ProfileDataSyncHandler+RecordLookup.swift`. The
+  // instrument upload path is exercised by
   // `ProfileIndexInstrumentDispatchTests`.
 
   @Test

--- a/MoolahTests/Sync/ProfileDataSyncHandlerQueueTests.swift
+++ b/MoolahTests/Sync/ProfileDataSyncHandlerQueueTests.swift
@@ -38,10 +38,9 @@ struct ProfileDataSyncHandlerQueueTests {
     // table — instrument data is owned by the shared,
     // iCloud-account-scoped profile-index registry and a single-profile
     // purge must not wipe instruments shared by every other profile.
-    // Post-`v10_drop_shared_instrument_legacy` the per-profile table is
-    // gone entirely, so a wipe against it would throw `no such table`;
-    // that the purge completes without error proves it leaves the
-    // (now-absent) per-profile instrument surface alone.
+    // The per-profile table does not exist, so a wipe against it would
+    // throw `no such table`; that the purge completes without error
+    // proves it leaves the absent per-profile instrument surface alone.
     let perProfileInstrumentAbsent = try await harness.database.read { database in
       try
         !(Bool.fetchOne(
@@ -122,8 +121,8 @@ struct ProfileDataSyncHandlerQueueTests {
     let recordIDs = handler.queueUnsyncedRecords()
     let recordNames = Set(recordIDs.map(\.recordName))
 
-    // The per-profile handler no longer enumerates instrument rows.
-    // The shared registry's
+    // The per-profile handler does not enumerate instrument rows; the
+    // shared registry's
     // `SyncCoordinator.queueUnsyncedSharedInstruments` covers them.
     #expect(
       recordNames.contains("\(AccountRow.recordType)|\(unsyncedAccountId.uuidString)"))
@@ -204,7 +203,7 @@ struct ProfileDataSyncHandlerQueueTests {
     let recordIDs = handler.queueUnsyncedRecords()
     let recordNames = Set(recordIDs.map(\.recordName))
 
-    // The per-profile handler no longer enumerates instrument rows
+    // The per-profile handler does not enumerate instrument rows
     // (count would be 8 if it did; the shared registry covers them).
     #expect(recordNames.count == 7)
     #expect(!recordNames.contains(seed.instrumentId))
@@ -260,10 +259,9 @@ struct ProfileDataSyncHandlerQueueTests {
 /// Per-table row counts for `deleteLocalDataRemovesAllRecordTypes`.
 /// Replaces a tuple to satisfy SwiftLint's `large_tuple` policy.
 ///
-/// No `instruments` count: the per-profile `instrument` table was
-/// removed by `v10_drop_shared_instrument_legacy`. Instrument identity
-/// lives solely on the shared profile-index registry, which a
-/// single-profile `deleteLocalData` must not wipe.
+/// No `instruments` count: there is no per-profile `instrument` table.
+/// Instrument identity lives solely on the shared profile-index
+/// registry, which a single-profile `deleteLocalData` must not wipe.
 private struct DeleteLocalDataCounts {
   let accounts: Int
   let transactions: Int

--- a/MoolahTests/Sync/RecordMappingTests.swift
+++ b/MoolahTests/Sync/RecordMappingTests.swift
@@ -261,10 +261,7 @@ struct RecordMappingTests {
 }
 
 /// Wire-format round-trip + boundary coverage for the GRDB `ProfileRow`
-/// `CloudKitRecordConvertible` conformance. Lives in its own suite so
-/// `RecordMappingTests`'s body stays under SwiftLint's
-/// `type_body_length` threshold; it would be a natural sibling section
-/// otherwise.
+/// `CloudKitRecordConvertible` conformance.
 @Suite("ProfileRowMapping")
 struct ProfileRowMappingTests {
 

--- a/MoolahTests/Sync/RepositoryHookRecordTypeTests.swift
+++ b/MoolahTests/Sync/RepositoryHookRecordTypeTests.swift
@@ -245,9 +245,8 @@ struct RepositoryHookRecordTypeTests {
   }
 
   /// Seeds a fixture covering every record type the category-delete
-  /// cascade fans out to. Splits the writes across small per-topic
-  /// transactions to keep the closure body under SwiftLint's length
-  /// budget; correctness only requires that all rows are present
+  /// cascade fans out to. Writes are split across small per-topic
+  /// transactions; correctness only requires that all rows are present
   /// before the test drives `delete`, not that they share a write.
   private func seedCategoryDeleteFixture(
     in database: any DatabaseWriter, ids: CategoryDeleteFixtureIds

--- a/MoolahTests/Sync/SyncCoordinatorBackfillFlagTests.swift
+++ b/MoolahTests/Sync/SyncCoordinatorBackfillFlagTests.swift
@@ -8,9 +8,7 @@ import Testing
 /// Tests covering the lifecycle of the per-profile "backfill scan
 /// complete" `UserDefaults` flag — when sign-out, encrypted-data
 /// reset, and server-side zone deletion clear it so the next session
-/// re-runs the unsynced-record scan. Split out of
-/// `SyncCoordinatorTestsExtra` to keep type bodies under the SwiftLint
-/// `type_body_length` threshold.
+/// re-runs the unsynced-record scan.
 @Suite("SyncCoordinator backfill flag lifecycle")
 @MainActor
 struct SyncCoordinatorBackfillFlagTests {

--- a/MoolahTests/Sync/SyncCoordinatorInstrumentDrainTests.swift
+++ b/MoolahTests/Sync/SyncCoordinatorInstrumentDrainTests.swift
@@ -8,9 +8,9 @@ import Testing
 /// drain that runs at coordinator startup. Catches both the prefixed
 /// `"InstrumentRecord|<UUID>"` form and the bare string-keyed legacy
 /// shape (e.g. `"0:native"`, `"AUD"`) — the only legitimate path for
-/// instrument writes is the shared registry on the profile-index zone
-/// (PR #861), so any pending change for an instrument on a per-profile
-/// zone is leftover state that must be dropped before
+/// instrument writes is the shared registry on the profile-index zone,
+/// so any pending change for an instrument on a per-profile zone is
+/// leftover state that must be dropped before
 /// `nextRecordZoneChangeBatch` materialises it and trips the DEBUG
 /// `preconditionFailure` in `ProfileDataSyncHandler.recordToSave`.
 @Suite("SyncCoordinator legacy-instrument drain")

--- a/MoolahTests/Sync/SyncCoordinatorTestsExtra.swift
+++ b/MoolahTests/Sync/SyncCoordinatorTestsExtra.swift
@@ -131,8 +131,7 @@ struct SyncCoordinatorTestsExtra {
 
   /// Registers a profile in the GRDB index and seeds its per-profile
   /// data DB via `seed`. Used by
-  /// `queueUnsyncedRecordsForAllProfilesSkipsSyncedRecords` to keep the
-  /// test body under SwiftLint's `function_body_length` cap.
+  /// `queueUnsyncedRecordsForAllProfilesSkipsSyncedRecords`.
   private func seedProfile(
     in manager: ProfileContainerManager,
     profile: Profile,
@@ -245,7 +244,6 @@ struct SyncCoordinatorTestsExtra {
     #expect(second.isEmpty)
   }
 
-  // (Sign-out / encryptedDataReset / zone-deleted backfill-flag tests
-  // live in `SyncCoordinatorBackfillFlagTests.swift` to keep the type
-  // body under the SwiftLint threshold.)
+  // Sign-out / encryptedDataReset / zone-deleted backfill-flag tests
+  // live in `SyncCoordinatorBackfillFlagTests.swift`.
 }

--- a/MoolahTests/Sync/TransactionHookUpdateDeleteTests.swift
+++ b/MoolahTests/Sync/TransactionHookUpdateDeleteTests.swift
@@ -6,8 +6,7 @@ import Testing
 
 /// Pins the per-leg multi-type hook contract for `GRDBTransactionRepository`
 /// `update(_:)` and `delete(id:)`. The header tests for `create(_:)` live
-/// in `RepositoryHookRecordTypeTests`; these are split out so neither
-/// file exceeds SwiftLint's 250-line `type_body_length` budget.
+/// in `RepositoryHookRecordTypeTests`.
 ///
 /// A regression that hard-coded `TransactionRow.recordType` on the leg
 /// emits in `update` / `delete` would upload leg records under the wrong

--- a/MoolahTests/Sync/TransactionLegSyncSemanticTests.swift
+++ b/MoolahTests/Sync/TransactionLegSyncSemanticTests.swift
@@ -85,12 +85,12 @@ struct TransactionLegSyncSemanticTests {
         ]))
 
     // A server-side orphan with a UUID that the local row does NOT
-    // share. Under the new stable-id design this can only happen if
-    // the original "leg removed from transaction" delete-uplink failed
-    // and the orphan stays on the server with a uuid the device never
-    // owned. Stable ids make this less likely (re-queued deletes hit
-    // the right record) but do not make it impossible. The user
-    // resolves manually (design Section 7).
+    // share. Under the stable-id design this can only happen if a
+    // "leg removed from transaction" delete-uplink failed and the
+    // orphan stays on the server with a uuid the device never owned.
+    // Stable ids make this less likely (re-queued deletes hit the
+    // right record) but do not make it impossible. The user resolves
+    // manually (design Section 7).
     let orphanId = UUID()
     let orphanRow = TransactionLegRow(
       id: orphanId,

--- a/MoolahTests/UITestSupport/UITestSeedHydratorTests.swift
+++ b/MoolahTests/UITestSupport/UITestSeedHydratorTests.swift
@@ -259,9 +259,8 @@ final class UITestSeedHydratorTests: XCTestCase {
     _ = try XCTUnwrap(
       try UITestSeedHydrator.hydrate(.tradeReady, into: containerManager))
 
-    // Instrument identity lives on the shared profile-index registry
-    // post-`v10_drop_shared_instrument_legacy`; the per-profile
-    // `instrument` table no longer exists.
+    // Instrument identity lives on the shared profile-index registry;
+    // there is no per-profile `instrument` table.
     let instruments = try containerManager.profileIndexDatabase.read { database in
       try InstrumentRow.fetchAll(database)
     }

--- a/MoolahUITests_macOS/Helpers/MoolahApp.swift
+++ b/MoolahUITests_macOS/Helpers/MoolahApp.swift
@@ -162,7 +162,7 @@ final class MoolahApp {
   /// whose teardown lags behind the SwiftUI sheet view's accessibility
   /// unmount: `application.popovers.firstMatch.exists` returns `false`
   /// only once the host NSWindow has fully closed, which is the
-  /// deterministic signal that residual modal state can no longer
+  /// deterministic signal that residual modal state cannot
   /// block hit-testing on the parent window. Routing the lookup
   /// through here preserves the single-resolver invariant
   /// (UI_TEST_GUIDE §3 #5).
@@ -203,9 +203,9 @@ final class MoolahApp {
   /// before SwiftUI's launcher → profile-window handoff completes (issue
   /// #493). The deterministic part of the fix is in
   /// `UITestingLauncherView`: keeping the launcher around eliminates the
-  /// open/dismiss race that previously left the app windowless. This
-  /// timeout is then the upper bound on launch-plus-render, not on a
-  /// race recovery window.
+  /// open/dismiss race that can leave the app windowless. This timeout
+  /// is then the upper bound on launch-plus-render, not on a race
+  /// recovery window.
   func expectMainWindowVisible(timeout: TimeInterval = 30) {
     if !application.windows.firstMatch.waitForExistence(timeout: timeout) {
       Trace.recordFailure("main window did not appear within \(timeout)s")

--- a/MoolahUITests_macOS/Helpers/Screens/TradeFormDriver.swift
+++ b/MoolahUITests_macOS/Helpers/Screens/TradeFormDriver.swift
@@ -316,12 +316,12 @@ struct TradeFormDriver {
   /// while it is alive its residual modal state can block hit-testing
   /// on the parent window — even for fields far from the popover
   /// anchor (e.g. the Received amount field after dismissing the Paid
-  /// instrument popover). Earlier revisions relied on the anchor being
-  /// hittable as a proxy, but the anchor sits adjacent to the popover
-  /// and can come back to life before the rest of the form does on
-  /// slow CI runners, leaving subsequent `setAmountField` calls with a
-  /// field that is in the AX tree but not yet hittable (observed on
-  /// GitHub macos-26 runners). Waiting for the host NSWindow itself to
+  /// instrument popover). The popover anchor is not a reliable proxy:
+  /// it sits adjacent to the popover and can come back to life before
+  /// the rest of the form does on slow CI runners, leaving subsequent
+  /// `setAmountField` calls with a field that is in the AX tree but
+  /// not yet hittable (observed on GitHub macos-26 runners). Waiting
+  /// for the host NSWindow itself to
   /// leave the application's window list — the positive signal — is
   /// what makes the form deterministically interactive again.
   ///

--- a/MoolahUITests_macOS/Tests/DetailColumnNavigationSweepTests.swift
+++ b/MoolahUITests_macOS/Tests/DetailColumnNavigationSweepTests.swift
@@ -2,15 +2,15 @@ import XCTest
 
 /// Smoke test for navigation across heterogeneous detail-column leaves.
 ///
-/// Originally written to reproduce the AppKit toolbar bridge crash
+/// This sweep does not reproduce the AppKit toolbar bridge crash
 /// (`NSInternalInconsistencyException: NSToolbar already contains an
 /// item with the identifier com.apple.SwiftUI.search`) that fires when
 /// SwiftUI re-mounts a `.searchable` / `.toolbar`-bearing leaf while
-/// the previous leaf's registration is still live. The crash fires
+/// the previous leaf's registration is still live: the crash fires
 /// during sub-second navigation in production, but XCUITest's natural
 /// `waitForExistence` pacing (~1-2 s per click) is too slow to surface
-/// the race in a deterministic test — the sweep takes ~110 s end to
-/// end and never reproduces. So this test serves a different role:
+/// the race deterministically — the sweep takes ~110 s end to end and
+/// never reproduces. So this test serves a different role:
 ///
 /// **As a navigation smoke test**, it catches accidental regressions
 /// to the navigation graph: a missing `accessibilityIdentifier`, a

--- a/MoolahUITests_macOS/UITestingLaunchSmokeTests.swift
+++ b/MoolahUITests_macOS/UITestingLaunchSmokeTests.swift
@@ -2,8 +2,8 @@ import XCTest
 
 /// Smoke test for the `--ui-testing` launch path: launches the app under
 /// the `.tradeBaseline` seed and verifies the main window appears.
-/// Originally added in PR #4; migrated to `MoolahUITestCase` in PR #5 so
-/// the failure-artefact regime kicks in if the launch ever stops working.
+/// Uses `MoolahUITestCase` so the failure-artefact regime kicks in if
+/// the launch ever stops working.
 ///
 /// `MoolahApp.launch(seed:)` itself runs `expectMainWindowVisible()` and
 /// fails the test if the window does not appear within 5 s, so the test

--- a/Shared/CSVImport/CSVDeduplicator.swift
+++ b/Shared/CSVImport/CSVDeduplicator.swift
@@ -95,9 +95,8 @@ enum CSVDeduplicator {
     return CSVDedupResult(kept: kept, skipped: skipped)
   }
 
-  /// Precomputed lookup tables reused across every candidate. Grouping the
-  /// inputs into one value keeps the per-candidate classifier's parameter
-  /// count low enough for SwiftLint's `function_parameter_count` rule.
+  /// Precomputed lookup tables reused across every candidate, grouped into
+  /// one value to keep the per-candidate classifier's parameter list small.
   private struct DedupIndex {
     let byRef: [String: Transaction]
     let byDate: [DateComponents: [Transaction]]

--- a/Shared/CSVImport/GenericBankCSVParser.swift
+++ b/Shared/CSVImport/GenericBankCSVParser.swift
@@ -306,8 +306,7 @@ struct GenericBankCSVParser: CSVParser, Sendable {
 
 }
 
-// Field-level parsing helpers extracted into an extension so the main struct
-// body stays under SwiftLint's `type_body_length` threshold.
+// Field-level parsing helpers for `GenericBankCSVParser`.
 extension GenericBankCSVParser {
   // MARK: - Parsing helpers
 

--- a/Shared/CSVImport/ImportStagingStore.swift
+++ b/Shared/CSVImport/ImportStagingStore.swift
@@ -16,7 +16,7 @@ struct PendingSetupFile: Codable, Sendable, Hashable, Identifiable {
   var detectedParserIdentifier: String?
   var detectedHeaders: [String]
   var parsedAt: Date
-  /// Bookmark to the source file the user originally picked. Used when
+  /// Bookmark to the source file the user picked. Used when
   /// `deleteAfterImport` is on and the user wants to retire the source after
   /// a successful import.
   var sourceBookmark: Data?
@@ -53,9 +53,9 @@ struct FailedImportFile: Codable, Sendable, Hashable, Identifiable {
     self.parsedAt = parsedAt
   }
 
-  /// Legacy-compatible decoder: older on-disk indexes stored
-  /// `offendingRow` as `[String]?`. Normalise `nil` to `[]` on read so
-  /// callers can treat the field as a plain `[String]`.
+  /// Some on-disk indexes store `offendingRow` as `[String]?`. Normalise
+  /// `nil` to `[]` on read so callers can treat the field as a plain
+  /// `[String]`.
   init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     self.id = try container.decode(UUID.self, forKey: .id)
@@ -153,7 +153,7 @@ actor ImportStagingStore {
     try save(index)
   }
 
-  /// Load the raw bytes of a previously staged pending file — used when the
+  /// Load the raw bytes of a staged pending file — used when the
   /// user confirms the setup and the pipeline re-runs.
   func data(for pendingId: UUID) throws -> Data {
     let index = try load()
@@ -163,7 +163,7 @@ actor ImportStagingStore {
     return try Data(contentsOf: match.stagingPath)
   }
 
-  /// Load the raw bytes of a previously staged failed file — used for the
+  /// Load the raw bytes of a staged failed file — used for the
   /// Retry action in the Failed Files panel.
   func data(forFailedId failedId: UUID) throws -> Data {
     let index = try load()

--- a/Shared/CSVImport/SelfWealthMovementsParser.swift
+++ b/Shared/CSVImport/SelfWealthMovementsParser.swift
@@ -86,8 +86,8 @@ struct SelfWealthMovementsParser: CSVParser, Sendable {
   }
 
   /// Common per-row state derived once and threaded through the action
-  /// dispatch + builders. Keeps `makeTradeRecord` / `makeTransferRecord`
-  /// under SwiftLint's `function_parameter_count` limit.
+  /// dispatch + builders, keeping `makeTradeRecord` / `makeTransferRecord`
+  /// parameter lists small.
   private struct RowContext {
     let row: [String]
     let rowIndex: Int

--- a/Shared/CryptoImport/AlchemyJSONRPCWireFormat.swift
+++ b/Shared/CryptoImport/AlchemyJSONRPCWireFormat.swift
@@ -4,13 +4,10 @@ import OSLog
 
 /// Namespace anchor matching the filename so SwiftLint's `file_name`
 /// rule stays satisfied alongside the loose top-level wire-format
-/// types declared below. Mirrors the pattern used in
-/// `WalletSyncTestDoubles.swift` etc.
+/// types declared below.
 enum AlchemyJSONRPCWireFormat {}
 
 /// JSON-RPC envelope and wire-format payloads used by `LiveAlchemyClient`.
-/// Lifted out of `AlchemyClient.swift` so the main client file stays
-/// inside SwiftLint's `file_length` / `type_body_length` budgets.
 ///
 /// Visibility: every type here is module-internal but unused outside
 /// `AlchemyClient.swift` and the test files. Keeping them at the file
@@ -93,8 +90,7 @@ struct AlchemyTransferResult: Decodable {
 
 /// HTTP response validator for `LiveAlchemyClient`. Maps status codes
 /// to `WalletSyncError` cases and parses `Retry-After` for the 429
-/// path. Lifted out of `AlchemyClient.swift` so the main client struct
-/// stays inside SwiftLint's `type_body_length` budget.
+/// path.
 enum AlchemyResponseValidator {
   /// Validates the HTTP response, throwing the appropriate
   /// `WalletSyncError` on non-2xx status. `logger` is the per-instance

--- a/Shared/CryptoImport/AlchemyTransfer.swift
+++ b/Shared/CryptoImport/AlchemyTransfer.swift
@@ -81,14 +81,12 @@ struct AlchemyTransfer: Sendable, Hashable, Decodable {
 
 extension AlchemyTransfer.RawContract {
   /// Custom decoder so `rawValue` (the Swift property) reads from the
-  /// `value` JSON key (Alchemy's actual wire-format name). The earlier
-  /// auto-synthesised conformance read JSON key `rawValue`, which is
-  /// what `RawRepresentable` enums use but not what Alchemy emits — so
-  /// every real response decoded with `rawValue == nil` and the
-  /// importer dropped every transfer at
+  /// `value` JSON key (Alchemy's actual wire-format name). An
+  /// auto-synthesised conformance would read JSON key `rawValue`, which
+  /// Alchemy never emits, so every transfer would decode with
+  /// `rawValue == nil` and be dropped at
   /// `TransferEventBuilder.scaledQuantity`. Defined out-of-line so
-  /// `RawContractCodingKeys` lives at file scope and stays inside
-  /// SwiftLint's `nesting` budget (max one level deep).
+  /// `RawContractCodingKeys` lives at file scope.
   init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: RawContractCodingKeys.self)
     self.address = try container.decodeIfPresent(String.self, forKey: .address)
@@ -98,9 +96,7 @@ extension AlchemyTransfer.RawContract {
 }
 
 /// Coding keys for `AlchemyTransfer.RawContract`. Lives at file scope
-/// rather than nested inside the struct so the type-nesting depth
-/// stays at one — SwiftLint's `nesting` rule rejects two-deep nested
-/// types here.
+/// rather than nested inside the struct.
 private enum RawContractCodingKeys: String, CodingKey {
   case address
   case decimal

--- a/Shared/CryptoImport/BuilderServices.swift
+++ b/Shared/CryptoImport/BuilderServices.swift
@@ -4,13 +4,8 @@ import Foundation
 /// Shared per-sync-cycle services the builder needs — the chain,
 /// the token-discovery actor, and the Alchemy client used for both
 /// transfer fetches and per-hash receipt lookups. Bundled into a
-/// single value so the public `build(...)` entry point stays inside
-/// SwiftLint's parameter-count budget without sacrificing call-site
-/// clarity.
-///
-/// Lives in its own file so `TransferEventBuilder.swift` stays under
-/// SwiftLint's `file_length` budget after the merge of
-/// `SignAndCounterparty` (issue #754) and `BuilderServices` (issue #762).
+/// single value so the public `build(...)` entry point takes one
+/// argument instead of three.
 struct BuilderServices: Sendable {
   let chain: ChainConfig
   let discovery: CryptoTokenDiscoveryService

--- a/Shared/CryptoImport/ChainConfig.swift
+++ b/Shared/CryptoImport/ChainConfig.swift
@@ -3,10 +3,9 @@ import Foundation
 
 /// Per-chain config for the crypto wallet importer.
 ///
-/// v1 covers Ethereum, OP Mainnet, Base, and Polygon. Extending to other EVM
+/// Covers Ethereum, OP Mainnet, Base, and Polygon. Extending to other EVM
 /// chains (Arbitrum, Avalanche, …) is purely additive — add a new entry to
-/// `all`. See `plans/2026-05-05-crypto-wallet-import-design.md` for the
-/// open question on `internal` transfer-category support across chains.
+/// `all`.
 struct ChainConfig: Sendable, Hashable {
   /// EVM chain identifier (e.g. 1 for Ethereum mainnet).
   let chainId: Int

--- a/Shared/CryptoImport/CrossAccountTransferMerger.swift
+++ b/Shared/CryptoImport/CrossAccountTransferMerger.swift
@@ -34,9 +34,8 @@ protocol CrossAccountTransferMerger: Sendable {
 
 /// Live cross-account merger. Pure / `Sendable` — no repository writes;
 /// no shared state. The single source of truth for the same-`externalId`
-/// channel from `plans/2026-04-18-transfer-detection-design.md`
-/// (Extension B): when the transfer-detection engine eventually runs, it
-/// shares this same merger rather than reimplementing the predicate.
+/// merge predicate; the transfer-detection engine shares this merger
+/// rather than reimplementing the predicate.
 struct LiveCrossAccountTransferMerger: CrossAccountTransferMerger {
 
   func merge(

--- a/Shared/CryptoImport/CrossDeviceLegDeduper.swift
+++ b/Shared/CryptoImport/CrossDeviceLegDeduper.swift
@@ -12,11 +12,9 @@ import os
 ///
 /// **All deletes route through `TransactionRepository.delete(id:)`**, not
 /// directly to GRDB, so the change propagates back through CKSyncEngine
-/// to other devices via the repository's existing `onRecordDeleted`
+/// to other devices via the repository's `onRecordDeleted`
 /// hook. Bypassing the repository would silently desync the deduper's
-/// local cleanup from CloudKit. (See
-/// `plans/2026-05-05-crypto-wallet-import-design.md` §"Multi-device race
-/// window — honest description".)
+/// local cleanup from CloudKit.
 ///
 /// **v1 scope.** A transaction whose every leg duplicates another
 /// transaction's legs is removed wholesale. Mixed transactions — one

--- a/Shared/CryptoImport/CryptoTokenDiscoveryService.swift
+++ b/Shared/CryptoImport/CryptoTokenDiscoveryService.swift
@@ -169,7 +169,7 @@ actor CryptoTokenDiscoveryService {
   /// Re-runs resolution for an `.unpriced` registration.
   ///
   /// Idempotent: re-reads the registry to find the *current* status before
-  /// deciding whether to re-resolve. If the live row is no longer
+  /// deciding whether to re-resolve. If the live row is not
   /// `.unpriced` (user marked it spam, or another path resolved it),
   /// returns that row without issuing any network calls. This preserves
   /// the design's "user intent wins" property — a spam classification

--- a/Shared/CryptoImport/TransferDirection.swift
+++ b/Shared/CryptoImport/TransferDirection.swift
@@ -3,10 +3,6 @@ import Foundation
 
 /// Direction a single Alchemy transfer takes relative to the synced
 /// wallet. Computed from the lowercased `from` / `to` fields.
-///
-/// Lives in its own file so `TransferEventBuilder.swift` stays under
-/// SwiftLint's `file_length` budget after the merge of issues #754
-/// (`SignAndCounterparty`) and #762 (`BuilderServices`).
 enum TransferDirection: Sendable {
   case outbound
   case inbound

--- a/Shared/CryptoImport/TransferEventBuilder.swift
+++ b/Shared/CryptoImport/TransferEventBuilder.swift
@@ -370,8 +370,7 @@ struct TransferEventBuilder: Sendable {
 
 }
 
-/// Per-call context bundle so `TransferEventBuilder`'s helpers stay
-/// inside SwiftLint's parameter-count budget while still getting at the
+/// Per-call context bundle giving `TransferEventBuilder`'s helpers the
 /// account, chain, discovery actor, and import audit fields. Built once
 /// in `build(...)` and passed by value down the call tree.
 private struct BuildContext: Sendable {
@@ -383,8 +382,7 @@ private struct BuildContext: Sendable {
 }
 
 /// Result of mapping a transfer's direction onto a leg's sign + the
-/// other-party address. Lives outside the builder so the helper that
-/// produces it stays small enough for SwiftLint's body-length budget.
+/// other-party address.
 private struct SignAndCounterparty {
   let signedQuantity: Decimal
   let counterpartyAddress: String?

--- a/Shared/CryptoImport/TransferReceiptCoalescer.swift
+++ b/Shared/CryptoImport/TransferReceiptCoalescer.swift
@@ -2,13 +2,10 @@
 import Foundation
 import OSLog
 
-/// Receipt coalescing + gas-leg construction helpers, factored out of
-/// `TransferEventBuilder.swift` so the main builder file stays inside
-/// SwiftLint's `file_length` / `type_body_length` budgets. Internal to
-/// the module — only the builder calls these — but file-private would
-/// hide them from `TransferEventBuilder.swift`. All functions are
-/// `Sendable`-pure (no captured state) so they're safe to call from
-/// inside the parallel build path.
+/// Receipt coalescing + gas-leg construction helpers for
+/// `TransferEventBuilder`. Module-internal — only the builder calls
+/// these. All functions are `Sendable`-pure (no captured state) so
+/// they're safe to call from inside the parallel build path.
 enum TransferReceiptCoalescer {
   /// Shared static `Logger`; matches the builder's pattern so receipt
   /// failures appear under the same subsystem in Console.app.

--- a/Shared/CryptoImport/WalletApplyEngine.swift
+++ b/Shared/CryptoImport/WalletApplyEngine.swift
@@ -7,10 +7,9 @@ import os
 /// merge, per-leg dedup, persistence, import rules, and per-account
 /// `WalletSyncState` updates.
 ///
-/// Per design (`plans/2026-05-05-crypto-wallet-import-design.md`
-/// §"Sync engine"): merge → dedup → persist → rules → sync-state
-/// update. This is the single writer in the build → apply pipeline;
-/// every other type produces value-shaped data only.
+/// Order: merge → dedup → persist → rules → sync-state update. This is
+/// the single writer in the build → apply pipeline; every other type
+/// produces value-shaped data only.
 ///
 /// Construction is `Sendable` despite `@MainActor` because every stored
 /// property is itself a `Sendable` reference.
@@ -166,10 +165,7 @@ final class WalletApplyEngine {
   // MARK: - Pipeline steps
 
   /// Captures the repository in a `@Sendable` closure so the merger can
-  /// look up prior-cycle legs by `externalId`. Extracted so the closure
-  /// body is short enough that swift-format keeps it on one line —
-  /// inline closure syntax with a multi-line body conflicts with
-  /// SwiftLint's `closure_parameter_position` rule.
+  /// look up prior-cycle legs by `externalId`.
   private func makeExistingLegLookup()
     -> @Sendable (String) async throws -> [TransactionLeg]
   {

--- a/Shared/CryptoPriceService+Live.swift
+++ b/Shared/CryptoPriceService+Live.swift
@@ -4,9 +4,7 @@ import Foundation
 
 // MARK: - CryptoPriceService live (current) prices
 
-// `currentPrices` lives in its own file so the main actor body stays
-// under SwiftLint's `type_body_length` and `file_length` thresholds.
-// This is the live / spot endpoint — distinct from the historical daily
+// `currentPrices`: the live / spot endpoint — distinct from the historical daily
 // bars handled in `CryptoPriceService.swift`'s `price(for:mapping:on:)`
 // path. The result is intentionally not persisted via the cap-at-yesterday
 // cache; `prefetchLatest` writes a single best-effort yesterday-tagged row

--- a/Shared/CryptoPriceService+Merge.swift
+++ b/Shared/CryptoPriceService+Merge.swift
@@ -4,10 +4,8 @@ import Foundation
 
 // MARK: - CryptoPriceService merge / delta computation
 
-// In-memory merge for `CryptoPriceService`. Lives in its own file so the
-// main actor body stays under SwiftLint's `type_body_length` and
-// `file_length` thresholds. The persistence-side companion is in
-// `CryptoPriceService+Persistence.swift`.
+// In-memory merge for `CryptoPriceService`. The persistence-side companion
+// is in `CryptoPriceService+Persistence.swift`.
 
 extension CryptoPriceService {
   /// Merges `newPrices` into `caches[tokenId]` and returns the rows that

--- a/Shared/CryptoPriceService+Persistence.swift
+++ b/Shared/CryptoPriceService+Persistence.swift
@@ -5,9 +5,7 @@ import GRDB
 
 // MARK: - CryptoPriceService SQL persistence
 
-// SQL persistence for `CryptoPriceService`. Lives in its own file so the
-// main actor body stays under SwiftLint's `type_body_length` and
-// `file_length` thresholds.
+// SQL persistence for `CryptoPriceService`.
 
 extension CryptoPriceService {
   /// Hydrates `caches[tokenId]` from `crypto_price` + `crypto_token_meta`.

--- a/Shared/CryptoPriceService+PriceLookup.swift
+++ b/Shared/CryptoPriceService+PriceLookup.swift
@@ -7,10 +7,8 @@ import Foundation
 // `priceLookup(for:on:)` honours `CryptoRegistration.pricingStatus` so
 // `.unpriced` / `.spam` tokens resolve to `.knownZero` without invoking
 // any provider, while a `.priced` registration goes through the
-// existing `price(for:mapping:on:)` path and surfaces provider failure
-// via `throw` (never collapsed to `.knownZero`). Lives in its own file
-// to keep `CryptoPriceService.swift` under SwiftLint's `file_length`
-// threshold.
+// `price(for:mapping:on:)` path and surfaces provider failure
+// via `throw` (never collapsed to `.knownZero`).
 
 extension CryptoPriceService {
   /// Discriminated price lookup. Honours `registration.pricingStatus`:

--- a/Shared/CryptoPriceService.swift
+++ b/Shared/CryptoPriceService.swift
@@ -80,8 +80,8 @@ actor CryptoPriceService {
 
   /// Drops any cached price data for the given instrument id — removes both
   /// the in-memory cache entry and the on-disk rows. Called when an
-  /// instrument is un-registered so we don't retain stale prices for
-  /// something the user no longer cares about.
+  /// instrument is un-registered so we don't retain stale prices for a
+  /// deregistered instrument.
   func purgeCache(instrumentId: String) async {
     caches.removeValue(forKey: instrumentId)
     hydratedTokenIds.remove(instrumentId)
@@ -294,8 +294,7 @@ actor CryptoPriceService {
   }
 
   // `currentPrices(for:)` (the live / spot endpoint) lives in
-  // `CryptoPriceService+Live.swift` so the main actor body stays under
-  // SwiftLint's `type_body_length` and `file_length` thresholds.
+  // `CryptoPriceService+Live.swift`.
 
   // MARK: - Prefetch
 
@@ -390,7 +389,5 @@ extension CryptoPriceService {
   }
 
   // `mergeReturningDelta` lives in `CryptoPriceService+Merge.swift` and
-  // `NoOpTokenResolutionClient` lives in its own sibling file so the
-  // main actor body stays under SwiftLint's `type_body_length` and
-  // `file_length` thresholds.
+  // `NoOpTokenResolutionClient` lives in its own sibling file.
 }

--- a/Shared/DataExporter.swift
+++ b/Shared/DataExporter.swift
@@ -40,9 +40,8 @@ actor DataExporter {
   }
 
   /// Holds the raw per-stage download output before it's assembled into an
-  /// `ExportedData`. Exists so `export()` can stay within SwiftLint's
-  /// function-body-length limit by delegating the download fan-out to a
-  /// helper and the assembly to another.
+  /// `ExportedData`, letting `export()` delegate the download fan-out and
+  /// the assembly to separate helpers.
   private struct StagedDownloads {
     let accounts: [Account]
     let categories: [Category]

--- a/Shared/ExchangeRateService+Persistence.swift
+++ b/Shared/ExchangeRateService+Persistence.swift
@@ -5,9 +5,7 @@ import GRDB
 
 // MARK: - ExchangeRateService SQL persistence
 
-// SQL persistence for `ExchangeRateService`. Lives in its own file so the
-// main actor body stays under SwiftLint's `type_body_length` and
-// `file_length` thresholds.
+// SQL persistence for `ExchangeRateService`.
 
 extension ExchangeRateService {
   /// Hydrates `caches[base]` from the GRDB-backed `exchange_rate` /

--- a/Shared/ExchangeRateService+Prefetch.swift
+++ b/Shared/ExchangeRateService+Prefetch.swift
@@ -5,9 +5,7 @@ import GRDB
 
 // MARK: - ExchangeRateService prefetch
 
-// `prefetchLatest` lives in its own file so the main actor body stays
-// under SwiftLint's `type_body_length` and `file_length` thresholds.
-// Best-effort warm-up of the latest rates for a base instrument; called
+// `prefetchLatest`: best-effort warm-up of the latest rates for a base instrument; called
 // on app start / profile open. Targets yesterday-UTC rather than today
 // (see `Shared/PriceCacheCap.swift`) and overlaps the existing latest
 // cached date by one day so a stale value gets re-validated.

--- a/Shared/ExchangeRateService.swift
+++ b/Shared/ExchangeRateService.swift
@@ -216,9 +216,7 @@ actor ExchangeRateService {
     return InstrumentAmount(quantity: converted, instrument: instrument)
   }
 
-  // `prefetchLatest(base:)` lives in `ExchangeRateService+Prefetch.swift`
-  // so the main actor body stays under SwiftLint's `type_body_length`
-  // and `file_length` thresholds.
+  // `prefetchLatest(base:)` lives in `ExchangeRateService+Prefetch.swift`.
 
   // MARK: - Private helpers
 
@@ -341,6 +339,5 @@ actor ExchangeRateService {
   }
 
   // SQL persistence (`loadCache` / `persistDelta`) lives in
-  // `ExchangeRateService+Persistence.swift` so this file stays under
-  // SwiftLint's `type_body_length` and `file_length` thresholds.
+  // `ExchangeRateService+Persistence.swift`.
 }

--- a/Shared/ExportCoordinator.swift
+++ b/Shared/ExportCoordinator.swift
@@ -89,9 +89,8 @@ final class ExportCoordinator {
   ///     are queued for upload so the profile syncs to CloudKit and other devices.
   ///   - instrumentRegistrar: The registry every non-fiat denomination is
   ///     registered into before the per-profile write — instrument
-  ///     identity lives on the shared profile-index registry
-  ///     (`v10_drop_shared_instrument_legacy` removed the per-profile
-  ///     `instrument` table). Defaults to the coordinator's shared
+  ///     identity lives on the shared profile-index registry, not a
+  ///     per-profile `instrument` table. Defaults to the coordinator's shared
   ///     registry; an explicit value lets coordinator-less callers
   ///     (some tests) supply a shared test registry.
   /// - Returns: The import result with counts of imported records
@@ -145,9 +144,8 @@ final class ExportCoordinator {
 
     state = .importing(step: "saving", progress: 0.3)
 
-    // Instrument identity lives on the shared profile-index registry —
-    // the per-profile `instrument` table was removed by
-    // `v10_drop_shared_instrument_legacy`. Production always has a
+    // Instrument identity lives on the shared profile-index registry,
+    // not a per-profile `instrument` table. Production always has a
     // coordinator carrying the shared registry; the importer registers
     // every non-fiat denomination there before the per-profile write.
     let importer = CloudKitDataImporter(

--- a/Shared/FiatConversionService.swift
+++ b/Shared/FiatConversionService.swift
@@ -11,9 +11,8 @@ actor FiatConversionService: InstrumentConversionService {
   /// subscription and `observeErrors()` returns an empty stream.
   private let database: (any DatabaseWriter)?
   /// Shared with every `observeRates()` subscription returned by this
-  /// instance. Per the Stage 1/3 convention, the channel is single-shot:
-  /// once `surfaceAndFinish(_:)` is called every observation surfaces
-  /// the same terminal error.
+  /// instance. The channel is single-shot: once `surfaceAndFinish(_:)`
+  /// is called every observation surfaces the same terminal error.
   private let errorChannel: ObservationErrorChannel?
 
   init(
@@ -81,7 +80,7 @@ actor FiatConversionService: InstrumentConversionService {
   }
 
   /// Reactive rate-tick stream. See protocol docs for the contract.
-  /// When constructed without a database (legacy test sites that don't
+  /// When constructed without a database (test sites that don't
   /// observe), emits a single tick on subscription and never again —
   /// stores subscribing fire `recomputeConvertedTotals` once and stop,
   /// which is harmless.

--- a/Shared/FinancialMonth.swift
+++ b/Shared/FinancialMonth.swift
@@ -19,8 +19,7 @@ enum FinancialMonth {
   /// `TimeZone(identifier: "UTC")` is documented to never return nil
   /// for the canonical `"UTC"` identifier; the `??` fallback uses the
   /// always-non-nil seconds-from-GMT initialiser so the resolved
-  /// constant is non-optional without an `as!` / `!` cast (keeping
-  /// SwiftLint's `force_unwrapping` rule satisfied).
+  /// constant is non-optional without a force-unwrap.
   ///
   /// Module-internal so sibling files (e.g.
   /// `GRDBAnalysisRepository+Conversion.swift`) can share the same

--- a/Shared/FullConversionService.swift
+++ b/Shared/FullConversionService.swift
@@ -258,7 +258,7 @@ actor FullConversionService: InstrumentConversionService {
   // MARK: - Observation
 
   /// Reactive rate-tick stream. See protocol docs for the contract.
-  /// When constructed without a database (legacy test sites that don't
+  /// When constructed without a database (test sites that don't
   /// observe), emits a single tick on subscription and never again —
   /// stores subscribing fire `recomputeConvertedTotals` once and stop,
   /// which is harmless.

--- a/Shared/IRRSolver.swift
+++ b/Shared/IRRSolver.swift
@@ -5,8 +5,7 @@ import Foundation
 /// bisection fallback for pathological multi-root cases.
 ///
 /// Day-precise: contribution exponents are `−tᵢ / 365` where `tᵢ` is days
-/// from the first flow. Replaces the legacy 30-day-month / monthly-rate-as-
-/// percent approximations from the prior monthly-rate-based binary search.
+/// from the first flow.
 ///
 /// **Returns `nil` when:**
 /// - `flows` is empty,

--- a/Shared/Models/ParentCategorySelection.swift
+++ b/Shared/Models/ParentCategorySelection.swift
@@ -53,7 +53,7 @@ struct ParentCategorySelection: Equatable {
   /// - Empty/whitespace text clears `id` — the picker treats an empty
   ///   field as "no parent → top-level category".
   /// - Anything else falls back to restoring the canonical path for
-  ///   `id`, or clearing both fields if `id` no longer resolves to a
+  ///   `id`, or clearing both fields if `id` doesn't resolve to a
   ///   live category.
   mutating func commitHighlightedOrNormalise(
     highlighted: CategorySuggestion?, in categories: Categories

--- a/Shared/Models/TransactionDraft+SimpleMode.swift
+++ b/Shared/Models/TransactionDraft+SimpleMode.swift
@@ -100,9 +100,9 @@ extension TransactionDraft {
   /// suggestion is highlighted. Called from the category field's blur
   /// handler so the suggestion the user navigated to with arrow keys is
   /// captured even when they Tab or click out instead of pressing Enter
-  /// (#509). Without this, blurring with a highlight pending dropped the
-  /// suggestion and then cleared the typed text because the unmatched
-  /// path didn't resolve to any `categoryId`.
+  /// (#509). Without this, blurring with a highlight pending drops the
+  /// suggestion and then clears the typed text because the unmatched
+  /// path doesn't resolve to any `categoryId`.
   mutating func commitHighlightedCategoryOrNormalise(
     highlighted: CategorySuggestion?, using categories: Categories
   ) {
@@ -130,10 +130,9 @@ extension TransactionDraft {
   /// `categoryId = …; categoryText = …` writes through a `@Binding`):
   /// SwiftUI snapshots the source between consecutive binding writes, so
   /// the second write is built from a snapshot taken before the first
-  /// landed and clobbers it. With two writes, `categoryId` would silently
-  /// revert to nil, then `normaliseCategoryText(using:)` on the next blur
-  /// would clear the field — the reopening of #509 reported by the user
-  /// after the original Tab-without-Enter fix.
+  /// landed and clobbers it. With two writes, `categoryId` silently
+  /// reverts to nil, then `normaliseCategoryText(using:)` on the next
+  /// blur clears the field (#509).
   mutating func commitCategorySelection(id: UUID, path: String) {
     categoryId = id
     categoryText = path

--- a/Shared/Networking/URLSession+RateLimited.swift
+++ b/Shared/Networking/URLSession+RateLimited.swift
@@ -99,9 +99,7 @@ extension URLSession {
   /// Records the `gate` and `failureCache` side effects for an HTTP
   /// response. Throws `RateLimitGateError.cooldown` for rate-limit
   /// responses; returns normally for everything else (including non-2xx
-  /// statuses that don't trip the gate). Extracted from the main
-  /// function to keep both inside SwiftLint's `function_body_length`
-  /// budget.
+  /// statuses that don't trip the gate).
   private static func classify(
     response: URLResponse,
     request: URLRequest,
@@ -146,9 +144,7 @@ extension URLSession {
     }
   }
 
-  /// Bundle of the per-response inputs `tripGate` needs, kept as a
-  /// nested struct so the surrounding function stays under SwiftLint's
-  /// `function_parameter_count` budget (5).
+  /// Bundle of the per-response inputs `tripGate` needs.
   private struct RateLimitOutcome {
     let retryAfter: TimeInterval?
     let statusCode: Int

--- a/Shared/PositionBook.swift
+++ b/Shared/PositionBook.swift
@@ -109,7 +109,7 @@ struct PositionBook: Equatable, Sendable {
   /// - Parameter asStartingBalance: Pass `true` for transactions that predate
   ///   the analysis window (`date < after`). This ensures the
   ///   `.investmentTransfersOnly` read rule sees the historical position as a
-  ///   baseline, matching the legacy `investmentTransfersOnly: false` behaviour
+  ///   baseline, matching the `investmentTransfersOnly: false` behaviour
   ///   for pre-`after` priors. Use `false` (the default) for transactions
   ///   inside the analysis window — only `.transfer` legs on investment
   ///   accounts contribute to the transfers-only view.
@@ -171,9 +171,8 @@ struct PositionBook: Equatable, Sendable {
   /// Per-pipeline inputs that stay constant across a sequence of
   /// `dailyBalance(on:context:isForecast:)` calls: which accounts are
   /// investments, the profile's instrument, the accumulation rule, and the
-  /// conversion service. Grouping them into a struct keeps the call's
-  /// parameter count under SwiftLint's threshold and hoists one allocation
-  /// outside the per-day loop at each caller.
+  /// conversion service. Grouping them into a struct hoists one
+  /// allocation outside the per-day loop at each caller.
   struct BalanceContext {
     let investmentAccountIds: Set<UUID>
     let profileInstrument: Instrument

--- a/Shared/PositionsHistoryBuilder.swift
+++ b/Shared/PositionsHistoryBuilder.swift
@@ -1,8 +1,6 @@
 // Reason: the apply() call sites and the per-day point emission both
-// pass enough labelled parameters to trigger SwiftLint's
-// multiline_arguments rule on layouts that fit within file_length, so
-// the disable is scoped to this file rather than reformatting every
-// call site to one-arg-per-line.
+// pass enough labelled parameters to trigger multiline_arguments;
+// scoped to this file rather than reformatting every call site.
 // swiftlint:disable multiline_arguments
 
 import Foundation

--- a/Shared/PreviewBackend.swift
+++ b/Shared/PreviewBackend.swift
@@ -20,9 +20,8 @@ enum PreviewBackend {
   /// preview backends to share one registry like production does.
   /// Defaults to a fresh per-call registry over its own in-memory
   /// profile-index DB (the preview analogue of production's shared
-  /// registry); it is never pointed at the per-profile `ProfileDatabase`
-  /// because `v10_drop_shared_instrument_legacy` removed the per-profile
-  /// `instrument` table.
+  /// registry); it is never pointed at the per-profile `ProfileDatabase`,
+  /// which has no `instrument` table.
   static func create(
     instrument: Instrument = .AUD,
     sharedRegistry: GRDBInstrumentRegistryRepository? = nil
@@ -44,8 +43,8 @@ enum PreviewBackend {
     }
     // The rate / price caches share the registry's profile-index DB,
     // mirroring production (`sharedMarketData` + shared registry both
-    // on `profileIndexDatabase`). The per-profile rate-cache tables
-    // were removed by `v10_drop_shared_instrument_legacy`.
+    // on `profileIndexDatabase`). There are no per-profile rate-cache
+    // tables.
     let marketDataDatabase = registry.database
     let exchangeRates = ExchangeRateService(
       client: FrankfurterClient(),

--- a/Shared/ProfileContainerManager.swift
+++ b/Shared/ProfileContainerManager.swift
@@ -182,8 +182,7 @@ final class ProfileContainerManager {
 
   /// Returns all known profile IDs from the GRDB profile-index DB.
   /// Reads through the repository's async helper so the calling thread
-  /// (typically `@MainActor`) doesn't block on the GRDB queue. Callers
-  /// that historically invoked the sync form must now `await`.
+  /// (typically `@MainActor`) doesn't block on the GRDB queue.
   func allProfileIds() async -> [UUID] {
     do {
       return try await profileIndexRepository.allRowIds()

--- a/Shared/ReactiveStoreSignposts.swift
+++ b/Shared/ReactiveStoreSignposts.swift
@@ -4,11 +4,8 @@ import Foundation
 import os.signpost
 
 // File-scope helpers used by every reactive store's Layer 7 signpost /
-// main-thread-time instrumentation. Originally lived in
-// `Features/Accounts/AccountStore+Signposts.swift`; lifted to `Shared/`
-// once a second reactive store (`EarmarkStore`) needed the same
-// primitives. Keeps each store's `+Signposts.swift` companion file from
-// duplicating the same five-line helper.
+// main-thread-time instrumentation. Shared so each store's
+// `+Signposts.swift` companion file doesn't duplicate the same helper.
 //
 // Pairs with `Shared/Signposts.swift`, which declares the
 // `Signposts.reactiveStore` `OSLog` consumed by `withReactiveStoreSignpost`.

--- a/Shared/Signposts.swift
+++ b/Shared/Signposts.swift
@@ -26,8 +26,7 @@ enum Signposts {
   /// via `BenchmarkGRDBCommitObserver.attach(to:)`). Marks the moment a
   /// GRDB write becomes observable to `ValueObservation`. Production code
   /// never attaches the observer, so the production app pays no cost
-  /// here. See `guides/BENCHMARKING_GUIDE.md` and Section 2 Layer 7 of
-  /// `plans/2026-05-06-reactive-sync-refresh-design.md`.
+  /// here. See `guides/BENCHMARKING_GUIDE.md`.
   static let grdbWrite = OSLog(subsystem: "com.moolah.app", category: "GRDBWrite")
   /// Begin/end pair around each value emitted by the
   /// `AsyncValueObservation → AsyncStream` bridge in
@@ -40,9 +39,8 @@ enum Signposts {
   static let grdbObservation = OSLog(
     subsystem: "com.moolah.app", category: "GRDBObservation")
   /// Begin/end pair around the work performed by a reactive store's
-  /// `apply(...)` / `recompute…` methods on `MainActor`. Stage 6 wires
-  /// this into `AccountStore` only; subsequent reactive store
-  /// migrations (Earmark, Transaction, …) follow the same pattern.
+  /// `apply(...)` / `recompute…` methods on `MainActor`. Each reactive
+  /// store (Account, Earmark, Transaction, …) wires this in the same way.
   /// Intervals here are the `mainThreadMs` cost measured by
   /// `SyncReactivityBenchmarks` against the `< 50 ms cumulative`
   /// acceptance criterion.

--- a/Shared/Views/InstrumentPickerSheet.swift
+++ b/Shared/Views/InstrumentPickerSheet.swift
@@ -14,8 +14,7 @@ import SwiftUI
 ///   `AddTokenSheet` where there's no pre-existing selection to bind.
 ///
 /// The actual rendering lives in `InstrumentPickerSheetCore`; this file
-/// dispatches between the two modes. The split keeps either file under the
-/// SwiftLint `file_length` ceiling.
+/// dispatches between the two modes.
 struct InstrumentPickerSheet: View {
   private let mode: Mode
 

--- a/Shared/Views/InstrumentPickerSheetCore.swift
+++ b/Shared/Views/InstrumentPickerSheetCore.swift
@@ -58,7 +58,7 @@ struct InstrumentPickerSheetCore: View {
       .task(id: ObjectIdentifier(store)) { await store.start() }
       .defaultFocus($focusedField, .search, priority: .userInitiated)
       .onChange(of: store.results.count) { _, _ in
-        // Drop the highlight if the result it pointed at is no longer visible.
+        // Drop the highlight if the result it pointed at is not in the results.
         if let current = highlightedID,
           !store.results.contains(where: { $0.instrument.id == current })
         {

--- a/Shared/Views/Positions/AccountPerformanceTiles.swift
+++ b/Shared/Views/Positions/AccountPerformanceTiles.swift
@@ -5,11 +5,10 @@ import SwiftUI
 /// from an `AccountPerformance`: Current Value, Profit / Loss (with %),
 /// and Annualised Return (with "since [first-flow-date]" subtitle).
 ///
-/// Replaces both the position-tracked single-row `PositionsHeader` (when
-/// a performance is supplied via `PositionsViewInput.performance`) and
-/// the legacy manual-valuation summary view. Each tile
-/// shows "—" / "Unavailable" rather than a partial sum when its source
-/// field is `nil` — see Rule 11 in
+/// Used for both position-tracked accounts (performance supplied via
+/// `PositionsViewInput.performance`) and manual-valuation accounts. Each
+/// tile shows "—" / "Unavailable" rather than a partial sum when its
+/// source field is `nil` — see Rule 11 in
 /// `guides/INSTRUMENT_CONVERSION_GUIDE.md`.
 struct AccountPerformanceTiles: View {
   let title: String

--- a/Shared/Views/Positions/PositionsChart.swift
+++ b/Shared/Views/Positions/PositionsChart.swift
@@ -120,10 +120,8 @@ struct PositionsChart: View {
     }
   }
 
-  /// Per-row mark emission. Factored out of `chartBody` so the
-  /// outer SwiftUI closure stays under SwiftLint's
-  /// `closure_body_length` threshold; pure presentational logic, no
-  /// state mutation.
+  /// Per-row mark emission. Pure presentational logic, no state
+  /// mutation.
   @ChartContentBuilder
   private func chartMarks(for row: PositionsChartRenderRow) -> some ChartContent {
     if let baseline = row.baseline {
@@ -133,9 +131,8 @@ struct PositionsChart: View {
       // zero height at every point on the wrong side of the
       // baseline. Without the `series:` discriminator, Swift Charts
       // groups all AreaMarks into a single shape and fills the
-      // entire region one colour — which is what the original
-      // gated emission produced (the bug visible in PR #743 review:
-      // green shading even where value < invested).
+      // entire region one colour (green shading even where
+      // value < invested).
       AreaMark(
         x: .value("Date", row.date),
         yStart: .value(

--- a/Shared/Views/Positions/PositionsChartLegendRow.swift
+++ b/Shared/Views/Positions/PositionsChartLegendRow.swift
@@ -1,9 +1,7 @@
 import SwiftUI
 
-/// Legend row + swatch helpers for `PositionsChart`. Lives in its own
-/// file so the parent view stays under SwiftLint's `file_length`
-/// budget; the helpers are private to the legend's rendering and do
-/// not need to be reused elsewhere.
+/// Legend row + swatch helpers for `PositionsChart`. Private to the
+/// legend's rendering; not reused elsewhere.
 struct PositionsChartLegendRow: View {
   let rows: [PositionsChartRenderRow]
   let mode: PositionsChartMode

--- a/Shared/Views/Positions/PositionsChartRenderRow.swift
+++ b/Shared/Views/Positions/PositionsChartRenderRow.swift
@@ -6,11 +6,8 @@ import Foundation
 /// `AreaMark` / `LineMark` per row; `legendUnavailable` on the last
 /// entry drives the legend swatch state.
 ///
-/// Lives in its own file (rather than nested inside
-/// `PositionsChart.swift`) because that view file is already at
-/// `file_length` budget and the rendering helper is plain Swift —
-/// a SwiftUI dependency is not required for the resolver, so it
-/// tests cleanly without `@MainActor` machinery.
+/// Plain Swift with no SwiftUI dependency, so the resolver tests
+/// cleanly without `@MainActor` machinery.
 struct PositionsChartRenderRow: Sendable, Hashable {
   let date: Date
   let value: Decimal

--- a/UITestSupport/UITestIdentifiers+WalletAccountHeader.swift
+++ b/UITestSupport/UITestIdentifiers+WalletAccountHeader.swift
@@ -2,10 +2,7 @@ import Foundation
 
 extension UITestIdentifiers {
   /// Identifier namespace for `WalletAccountHeaderView` — the bar that
-  /// renders above the transaction list on a `.crypto` account. Lives
-  /// in its own file (rather than alongside the rest of
-  /// `UITestIdentifiers`) so the parent file stays under SwiftLint's
-  /// `file_length` threshold.
+  /// renders above the transaction list on a `.crypto` account.
   public enum WalletAccountHeader {
     /// Container of the `WalletAccountHeaderView` bar shown above the
     /// transaction list on a `.crypto` account. Sentinel for "the

--- a/UITestSupport/UITestIdentifiers.swift
+++ b/UITestSupport/UITestIdentifiers.swift
@@ -251,8 +251,7 @@ public enum UITestIdentifiers {
   }
 
   // The `WalletAccountHeader` namespace lives in
-  // `UITestIdentifiers+WalletAccountHeader.swift` so this file stays
-  // under SwiftLint's `file_length` budget.
+  // `UITestIdentifiers+WalletAccountHeader.swift`.
 
   public enum CryptoSettings {
     /// Root container of the `CryptoSettingsView` Form. Sentinel for the

--- a/UITestSupport/UITestSeed.swift
+++ b/UITestSupport/UITestSeed.swift
@@ -46,7 +46,7 @@ public enum UITestSeed: String, CaseIterable, Sendable {
   case welcomeMultipleCloudProfiles
 
   /// Forces the Welcome screen into `.heroDownloading(received: 1234)` so
-  /// the new "Found data on iCloud · 1,234 records downloaded" copy and
+  /// the "Found data on iCloud · 1,234 records downloaded" copy and
   /// the de-emphasized "Create a new profile" button can be verified.
   case welcomeDownloading
 

--- a/guides/CODE_GUIDE.md
+++ b/guides/CODE_GUIDE.md
@@ -503,6 +503,18 @@ These rules concern Swift-language patterns in SwiftUI code. Layout, colour, and
 - **Attach doc comments directly to the declaration they describe.** SwiftLint's [`orphaned_doc_comment`](https://realm.github.io/SwiftLint/orphaned_doc_comment.html) rule flags `///` blocks separated from the next declaration by a blank line or an intervening `//` comment — the compiler treats those as orphans and drops them from DocC / Xcode Quick Help. If a doc comment isn't documenting the declaration that immediately follows, demote it to `//` (it's narrative, not API docs) or move it adjacent to the declaration it's actually describing. Never leave a blank line between `///` and the `func` / `var` / `let` / `class` it documents.
 - **No block comments** (`/* */`). SwiftLint's `NoBlockComments` rule enforces this.
 - **No commented-out code.** Delete it — `git log` has the history. Commented-out code rots, lies about intent, and triggers false-positive diffs.
+- **Succinct.** A comment earns its place by saying something the code can't. Cut filler that restates the next line (`// increment i`, `// return the result`). Tighten prose to the minimum that conveys the rationale.
+- **Present tense — describe the situation as it is now, never how it changed.** A comment is read by someone looking at today's code, not the diff that produced it. Strip time-travel framing (`no longer`, `previously`, `used to be`, `formerly`, `now that we`, `renamed from`) and state the current fact. Keep the explanatory value — *why* the code does or doesn't do something a reader would expect — without narrating the transition.
+
+  ```swift
+  // Avoid: The per-profile `instrument` table no longer exists post-v10,
+  //        so fiat is resolved via the shared registry.
+  // Prefer: There is no per-profile `instrument` table; fiat resolves
+  //         via the shared registry.
+  ```
+
+- **No PR or plan archaeology.** Don't reference PR numbers as history, plan slice numbers, or "as part of the X rollout/cutover". `git blame` carries that. Tracked-issue references (`See issue #865`, `TODO(#N)` per §20) are the exception and stay.
+- **Split-out file headers state purpose, not surgery.** A file carved off a larger one for §3 size reasons documents what it now holds, not the extraction or the threshold. `// Budget CRUD extracted from EarmarkStore so it stays under type_body_length` → `// Budget CRUD for \`EarmarkStore\`.`
 - **`// MARK:` for sections** inside files longer than 300 lines (cross-ref §2).
 
 ---


### PR DESCRIPTION
## What

Codebase-wide comment audit (9 parallel agents over disjoint slices) plus a style-guide update.

- Comments now explain **why** code exists, not restate **what** it does.
- Comments describe the **current** situation — time-travel framing removed (`no longer`, `previously`, `formerly`, migration-name narratives → present-tense facts).
- Split-out file headers state purpose, not the extraction or the SwiftLint threshold (`// X extracted from Y so it stays under type_body_length` → `// X for Y.`).
- PR/plan archaeology removed; redundant restatements deleted; verbose comments tightened.
- Preserved verbatim: tracked-issue refs (`See issue #N`, `TODO(#N)`), `// MARK:`, `swiftlint:` directives, domain-term "legacy", load-bearing pipeline-stage vocabulary, "used to" meaning "in order to".
- **Comment-only** — no code, identifier, or string-literal changes.

`guides/CODE_GUIDE.md` §19 now codifies these rules with before/after examples.

## Verification

- Full ~301-file diff confirmed comment-only.
- `just format-check` ✅ (no swift-format diff, no SwiftLint baseline growth, no orphaned doc comments).
- `just build-mac` ✅ BUILD SUCCEEDED (warnings-as-errors on).

🤖 Generated with [Claude Code](https://claude.com/claude-code)