### PR TITLE
docs(plan): responsive investment load — spec + Plan A (responsiveness)

### DIFF
--- a/plans/2026-05-16-responsive-investment-load-design.md
+++ b/plans/2026-05-16-responsive-investment-load-design.md
@@ -1,0 +1,312 @@
+# Responsive Investment Load + Sorted-Array Price Caches — Design
+
+**Date:** 2026-05-16
+**Status:** Approved (pending spec review)
+**Scope:** Approach 2 — decouple the historic-graph build from the investment
+account screen so it stays responsive, *plus* fix the quadratic price/rate
+fallback lookup that makes the build slow. Day-by-day chart granularity is
+retained (no coarsening).
+
+## Problem
+
+Navigating to an investment account with a long trade history (reproduced on
+the "Shares" account in the "Large Test Profile") freezes the screen for
+several seconds.
+
+### Root cause (profiled)
+
+Stack sampling during the navigation showed:
+
+```
+InvestmentAccountView.body closure #3            (InvestmentAccountView.swift:212)
+ → maybeAutoWidenRange()                          (InvestmentAccountView+Loading.swift:59)
+  → InvestmentStore.positionsViewInput(range:.all)
+   → PositionsHistoryBuilder.build(…)             (PositionsHistoryBuilder.swift:93)
+    → emitDailyPoints(for: day, …)                (per calendar day, line 171)
+     → convertValue → FullConversionService.convert
+      → … → StockPriceService.price(ticker:on:)   (StockPriceService.swift:73)
+       → StockPriceService.fallbackPrice(…)        (StockPriceService.swift:198)
+        → Sequence.sorted()                        ← 2701 / 2884 samples
+```
+
+Two compounding defects:
+
+1. **The whole screen is gated on the slow build.** `InvestmentAccountView.body`
+   renders a full-screen `ProgressView` while `!initialLoadComplete`
+   (`InvestmentAccountView.swift:180`). `initialLoadComplete` only flips `true`
+   *after* `reloadPositions()` **and** `maybeAutoWidenRange()` finish
+   (lines 209–217), and that chain runs the full-history (`.all`) series build.
+   The transaction list is independent of `positionsInput` (its own
+   `transactionStore`) but never gets to render because the entire body is
+   behind the gate.
+
+2. **The build does an O(n log n) sort on every price/rate lookup.**
+   `PositionsHistoryBuilder` walks **every calendar day** from the range start
+   to today and converts every held instrument on each day. Markets are closed
+   on weekends/holidays (~2/7 of calendar days), so for every non-trading day
+   `StockPriceService.price(ticker:on:)` falls through to `fallbackPrice`
+   (line 73 → 198), which re-sorts the *entire* price-history key set on every
+   single call:
+
+   ```swift
+   private func fallbackPrice(ticker: String, dateString: String) -> Decimal? {
+     guard let cache = caches[ticker] else { return nil }
+     let sortedDates = cache.prices.keys.sorted().reversed()   // O(n log n) per call
+     for cachedDate in sortedDates where cachedDate <= dateString { return cache.prices[cachedDate] }
+     return nil
+   }
+   ```
+
+   Over a multi-year `.all` range this is roughly
+   `O(instruments × days × days log days)` — the multi-second hang. The
+   currency-conversion fan-out and the day-keyed rate cache in
+   `FullConversionService` are merely the *driver* that calls this ~10,000
+   times; the quadratic blow-up is the per-call re-sort.
+
+The same antipattern exists verbatim in all three price/rate caches:
+
+| Cache model            | Service method                          |
+|------------------------|------------------------------------------|
+| `StockPriceCache.prices`     | `StockPriceService.fallbackPrice` (~:198)  |
+| `ExchangeRateCache.rates`    | `ExchangeRateService.fallbackRate` (~:231) |
+| `CryptoPriceCache.prices`    | `CryptoPriceService.fallbackPrice` (~:348) |
+
+A stock→AUD conversion hits both the stock cache and the FX (listing-currency
+→ host) cache; crypto accounts hit the crypto cache identically. All three are
+fixed together (the "fix all instances" rule).
+
+## Goals
+
+- The investment account screen is interactive immediately: transactions list
+  and positions table render without waiting for the historic graph.
+- The chart area shows a loading indicator until its series is built, then
+  the chart appears (no progressive fill-in — confirmed UX choice).
+- The historic-series build itself is fast: price/rate fallback lookups become
+  O(log n) instead of O(n log n) per call.
+- Lower steady-state memory than today's dictionary caches, important on
+  mobile where many instruments × long histories may be cached at once.
+- Day-by-day chart point granularity is **retained** (no coarsening — out of
+  scope for Approach 2).
+
+## Non-goals
+
+- Coarsening chart resolution / down-sampling long ranges (Approach 1 only).
+- Restructuring `FullConversionService`'s day-keyed rate cache or introducing a
+  batched factor-series API (the fallback fix removes the dominant cost without
+  it).
+- Persisting / showing a last-known series on revisit (rejected — "spinner
+  until complete" UX).
+- Changing the on-disk database schema or adding a migration.
+
+## Design
+
+### 1. Two-phase load (responsiveness)
+
+Split `InvestmentStore`'s monolithic `positionsViewInput(title:range:)` into
+two store calls:
+
+- **`loadPositionsInput(account:profileCurrency:) async throws -> PositionsViewInput`**
+  — the fast part: `loadAllData` + `fetchAllTransactions` + `costBasisSnapshot`
+  + `applyingCostBasis` + `hasAnyHistoricalActivity`. Returns a
+  `PositionsViewInput` with `historicalValue: nil` and `historyLoading: true`.
+  The fetched transactions are cached on the store (new `loadedTransactions:
+  [Transaction]`, keyed implicitly by `loadedAccountId`) so phase 2 does not
+  re-fetch.
+
+- **`historicalSeries(range:) async -> HistoricalValueSeries?`**
+  — the slow part: runs `PositionsHistoryBuilder.build` against the cached
+  `loadedTransactions` / `loadedHostCurrency`. Returns the series; the caller
+  merges it into the existing `positionsInput` (producing a copy with
+  `historicalValue` set and `historyLoading: false`).
+
+`positionsViewInput(title:range:)` is retained as a thin composition of the two
+(load then build then merge) so existing callers/tests keep working.
+
+`InvestmentAccountView` changes:
+
+- `.task(id: LoadKey)`: run phase 1, set `initialLoadComplete = true`
+  immediately (screen interactive), then continue in the same task to run
+  phase 2 for the current `positionsRange`, merge the series into
+  `positionsInput`, then run the auto-widen check.
+- `.task(id: positionsRange)`: rebuilds **only** phase 2 (positions and cost
+  basis are range-independent), merging the new series in.
+- `maybeAutoWidenRange()`: moves into phase 2. It now operates on the
+  phase-2 series result — if the account has historical activity but the
+  built series for the active range is empty (last trade pre-dates the
+  range), rebuild phase 2 with `.all` and set `positionsRange = .all`. It no
+  longer runs before `initialLoadComplete`, so it cannot block first paint.
+
+The transaction list (`makeAccountTransactionList()`, driven by
+`transactionStore`) is already independent of `positionsInput`; once the
+full-screen gate flips after phase 1 it renders and is interactive while
+phase 2 is still running.
+
+### 2. Chart loading contract
+
+Add one field to `PositionsViewInput`:
+
+```swift
+let historyLoading: Bool   // default false in the designated init
+```
+
+`PositionsView` (`Shared/Views/Positions/PositionsView.swift:35`): when
+`input.historyLoading` is `true`, render a chart-height container with a
+centered `ProgressView` in place of the chart; otherwise the existing
+`if input.showsChart { PositionsChart(...) }` logic is unchanged. The
+placeholder occupies the same vertical space the chart would, so the layout
+does not jump when the series lands. No other view changes.
+
+`historyLoading` does not affect any existing computed property
+(`showsChart`, `hasHistoricalSeries`, etc.); those continue to key off
+`historicalValue`. Non-investment callers and previews leave it `false` via
+the default.
+
+### 3. Sorted-array price/rate caches (all three services)
+
+Replace the date-keyed dictionaries with date-sorted contiguous arrays. This
+removes the per-call sort, makes lookups O(log n), and uses strictly less RAM
+than `Dictionary` (no hash-bucket over-allocation, no duplicate key storage,
+no separate index).
+
+Date representation: **`Int32` in `yyyymmdd` form** (e.g. `2024-01-15` →
+`20240115`). `yyyymmdd` integer ordering equals chronological ordering, so
+binary search is correct. Integer comparison is faster than the current
+string comparison.
+
+In-memory model changes (the `Codable` domain models):
+
+```swift
+struct DatedPrice: Codable, Sendable, Equatable {
+  let date: Int32          // yyyymmdd
+  let price: Decimal
+}
+
+struct DatedQuotes: Codable, Sendable, Equatable {
+  let date: Int32          // yyyymmdd
+  var quotes: [String: Decimal]   // quote code -> rate (small, stays a dict)
+}
+
+struct StockPriceCache  { … var prices: [DatedPrice]  … }   // sorted asc by .date
+struct CryptoPriceCache { … var prices: [DatedPrice]  … }   // sorted asc by .date
+struct ExchangeRateCache{ … var rates:  [DatedQuotes] … }   // sorted asc by .date
+```
+
+- `earliestDate` / `latestDate` **remain `String`** fields on each cache.
+  They are only 2 per cache, are persisted as meta columns, and are compared
+  as ISO strings throughout the fetch-gap logic
+  (`StockPriceService` lines ~98/107/168, `ExchangeRateService` ~118/173,
+  crypto equivalent). Keeping them avoids rewriting that broad logic and
+  bounds the blast radius. (They could later be derived from
+  `first`/`last`; out of scope here.)
+
+- Shared helpers (one implementation, reused by all three services):
+  - `exactIndex(_ date: Int32) -> Int?` — binary search for an exact entry.
+  - `floorIndex(_ date: Int32) -> Int?` — binary search for the newest entry
+    with `entry.date <= date` (replaces the `fallback*` linear-after-sort).
+  - `merge(_ incoming:)` — sorted-merge of a fetched, date-contiguous chunk;
+    later values overwrite earlier ones for the same date (preserving the
+    current `existing.prices[dateKey] != price` overwrite semantics).
+
+- Each service's `lookup*`, `fallback*`, `prices(…in:)` / `rates(…in:)`
+  range builders, `*Merge`, and hydrate paths are rewritten against the
+  array + helpers. Behavior is preserved exactly:
+  - exact-date hit → same value as `prices[dateString]` today;
+  - non-trading / gap date → same prior-trading-day value the
+    sort-then-scan produced;
+  - pre-history date → `nil` as today.
+
+- **On-disk schema is unchanged.** The persistence/record-mapping layer
+  (`*+Persistence.swift`, GRDB records) converts between the stored ISO date
+  string (or existing column type) and the in-memory `Int32` at hydrate and
+  write. Loading with `ORDER BY date` yields the sorted array directly,
+  removing any hydrate-time sort as a side benefit. No `DatabaseMigrator`
+  change.
+
+This change touches GRDB record mapping → the implementation plan routes the
+relevant steps through the `database-code-review` agent (and
+`database-schema-review` if any record/PRAGMA file is touched, even though no
+migration is added).
+
+### 4. Error handling & cancellation
+
+- **Phase 1 failure:** unchanged. `loadAllData` already swallows into
+  `self.error`; `costBasisSnapshot` already degrades (omits instruments with
+  failed classification). If phase 1 throws, the existing error surface shows.
+- **Phase 2 failure:** the chart area shows the existing no-series state
+  (`historyLoading` cleared, `historicalValue` nil); the rest of the screen
+  stays usable; logged at `.error` (existing log call retained).
+- **Cancellation:** navigating away or changing range mid-phase-2 throws
+  `CancellationError`, which is ignored exactly as today. Because phase 1 has
+  already returned, the screen was usable throughout. `PositionsHistoryBuilder`
+  already checks `Task.isCancelled` per day and returns the partial series.
+
+### 5. Testing
+
+Per `guides/TEST_GUIDE.md` (Swift Testing; one-extension-per-protocol;
+`TestBackend`, never mock the repository):
+
+- **`InvestmentStore` split** (against `TestBackend`):
+  - `loadPositionsInput` returns positions + cost basis with
+    `historicalValue == nil` and `historyLoading == true`, and does **not**
+    invoke `PositionsHistoryBuilder` (assert via a seam, e.g. a build counter
+    or by asserting no series side-effects).
+  - `historicalSeries(range:)` reuses `loadedTransactions` — assert the
+    transaction repository is **not** fetched a second time after phase 1
+    (fetch-count assertion).
+  - The composed `positionsViewInput` still returns the fully-populated input
+    (regression cover for existing callers).
+- **All three `fallback*`** (behavior-preserving, table-driven):
+  exact-date, weekend/holiday gap, pre-history, and post-latest dates return
+  the same value the old sort-then-scan returned, for stock, FX, and crypto.
+- **Plan-pinning performance test:** a multi-year daily walk over a seeded
+  cache performs no per-call sort and a bounded number of comparisons
+  (inject a comparison/lookup counter into the cache helper; assert it scales
+  ~`O(queries · log n)`, not `O(queries · n log n)`).
+- **No new UI test required.** Existing `InvestmentAccountView` coverage
+  exercises the load path. Optional, if cheap: a UI-test driver assertion
+  that the transaction list is hittable before the chart appears (validates
+  the responsiveness goal end-to-end). Treated as a stretch item, not a gate.
+
+## Affected files (indicative, not exhaustive)
+
+- `Domain/Models/StockPriceCache.swift`,
+  `Domain/Models/CryptoPriceCache.swift`,
+  `Domain/Models/ExchangeRateCache.swift` — model shape + `DatedPrice` /
+  `DatedQuotes`.
+- New: `Shared/SortedDateSeries.swift` — a small generic sorted-by-`Int32`-date
+  collection (`exactIndex` / `floorIndex` / `merge`), reused by all three
+  services. (Final name/location may be adjusted in the plan, but it is a
+  single shared type, not duplicated per service.)
+- `Shared/StockPriceService.swift`, `Shared/ExchangeRateService.swift`,
+  `Shared/CryptoPriceService*.swift` — rewrite lookup/fallback/merge/range
+  builders against the array.
+- `Shared/StockPriceService` / `ExchangeRateService+Persistence.swift` /
+  `CryptoPriceService+Persistence.swift` + GRDB records — String↔Int32
+  mapping at the persistence boundary.
+- `Domain/Models/PositionsViewInput.swift` — `historyLoading` field.
+- `Shared/Views/Positions/PositionsView.swift` — chart-loading placeholder.
+- `Features/Investments/InvestmentStore+PositionsInput.swift`,
+  `InvestmentStore+Loading.swift` — two-phase API + `loadedTransactions`.
+- `Features/Investments/Views/InvestmentAccountView.swift`,
+  `InvestmentAccountView+Loading.swift` — task wiring, gate, auto-widen
+  relocation.
+
+## Risks & mitigations
+
+- **Behavior drift in fallback semantics.** Mitigated by table-driven
+  behavior-preserving tests written *before* the rewrite (TDD), covering the
+  exact/gap/pre-history/post-latest cases for all three services.
+- **Persistence mapping bug (String↔Int32).** Mitigated by round-trip
+  persistence tests and routing through `database-code-review`.
+- **Auto-widen regression** (now in phase 2): covered by store tests for the
+  "last trade pre-dates default range → widens to `.all`" case.
+- **Layout jump when the chart lands.** Mitigated by the fixed-height
+  placeholder occupying the chart's space while `historyLoading`.
+
+## Verification
+
+After implementation, re-profile the original repro (Shares account, Large
+Test Profile) via the `profile-performance` + `automate-app` skills and
+confirm: (a) the transaction list is visible/interactive within a frame or
+two of navigation; (b) the per-call `.sorted()` no longer dominates the
+sample; (c) the `⚠️ PERF` / conversion log volume drops accordingly.

--- a/plans/2026-05-16-responsive-investment-load-plan-A-responsiveness.md
+++ b/plans/2026-05-16-responsive-investment-load-plan-A-responsiveness.md
@@ -1,0 +1,716 @@
+# Responsive Investment Load (Plan A — Responsiveness) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the investment account screen interactive immediately — the transactions list and positions table render without waiting for the historic chart, which loads behind a spinner.
+
+**Architecture:** Split `InvestmentStore`'s monolithic `positionsViewInput` into a fast phase 1 (positions + cost basis, no history) and a slow phase 2 (`PositionsHistoryBuilder` series, reusing transactions cached by phase 1). `InvestmentAccountView` flips its full-screen gate after phase 1; `PositionsView` shows a chart-area spinner while `PositionsViewInput.historyLoading` is true. No price-cache changes here — that is Plan B.
+
+**Tech Stack:** Swift 6, SwiftUI, Swift Testing (`import Testing`), GRDB-backed `TestBackend`. Build/test via `just`.
+
+**Scope note:** This is Plan A of two. Plan B (sorted-array price/rate caches) is independent and tracked separately. This plan delivers the responsiveness win even with the current (slow) cache — the slow build just moves off the critical path.
+
+**Spec:** `plans/2026-05-16-responsive-investment-load-design.md`
+
+---
+
+### Task 1: `PositionsViewInput.historyLoading` + `applyingHistory`
+
+**Files:**
+- Modify: `Domain/Models/PositionsViewInput.swift`
+- Test: `MoolahTests/Domain/PositionsViewInputHistoryLoadingTests.swift` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `MoolahTests/Domain/PositionsViewInputHistoryLoadingTests.swift`:
+
+```swift
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("PositionsViewInput history loading")
+struct PositionsViewInputHistoryLoadingTests {
+  private let aud = Instrument.AUD
+
+  @Test("historyLoading defaults to false")
+  func defaultsFalse() {
+    let input = PositionsViewInput(
+      title: "X", hostCurrency: aud, positions: [], historicalValue: nil)
+    #expect(input.historyLoading == false)
+  }
+
+  @Test("historyLoading can be set true via the designated init")
+  func canBeTrue() {
+    let input = PositionsViewInput(
+      title: "X", hostCurrency: aud, positions: [], historicalValue: nil,
+      historyLoading: true)
+    #expect(input.historyLoading == true)
+  }
+
+  @Test("applyingHistory merges the series and clears the loading flag")
+  func applyingHistoryMergesAndClears() {
+    let loading = PositionsViewInput(
+      title: "X", hostCurrency: aud, positions: [], historicalValue: nil,
+      hasAnyHistoricalActivity: true, alwaysShowsFullSurface: true,
+      historyLoading: true)
+    let series = HistoricalValueSeries(
+      perInstrument: [:],
+      total: [
+        HistoricalValueSeries.Point(
+          date: Date(), value: 100, cost: 80, contributions: nil)
+      ])
+
+    let merged = loading.applyingHistory(series)
+
+    #expect(merged.historyLoading == false)
+    #expect(merged.historicalValue != nil)
+    #expect(merged.hasAnyHistoricalActivity == true)
+    #expect(merged.alwaysShowsFullSurface == true)
+    #expect(merged.title == "X")
+  }
+
+  @Test("applyingHistory with nil keeps no series and clears loading")
+  func applyingNilClearsLoading() {
+    let loading = PositionsViewInput(
+      title: "X", hostCurrency: aud, positions: [], historicalValue: nil,
+      historyLoading: true)
+
+    let merged = loading.applyingHistory(nil)
+
+    #expect(merged.historyLoading == false)
+    #expect(merged.historicalValue == nil)
+  }
+}
+```
+
+> Note: confirm `HistoricalValueSeries` / `HistoricalValueSeries.Point` initializer argument labels against `Domain/Models/HistoricalValueSeries.swift` when writing the test; the snippet uses `perInstrument:` / `total:` and `Point(date:value:cost:contributions:)` (the shape `PositionsHistoryBuilder` builds). Adjust labels if the source differs — do not change the production types.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `just test-mac PositionsViewInputHistoryLoadingTests 2>&1 | tee .agent-tmp/t1.txt`
+Expected: FAIL — `value of type 'PositionsViewInput' has no member 'historyLoading'` / `no member 'applyingHistory'`.
+
+- [ ] **Step 3: Add the field, init parameter, and helper**
+
+In `Domain/Models/PositionsViewInput.swift`, add the stored property after `alwaysShowsFullSurface` (after line 41):
+
+```swift
+  /// `true` while phase 2 (the historic-series build) is still running.
+  /// Phase 1 returns the input with this `true`; `applyingHistory(_:)`
+  /// clears it once the series lands (or fails). `PositionsView` renders
+  /// a chart-area spinner while it is `true`. Defaults to `false` so
+  /// non-investment callers and previews are unaffected.
+  let historyLoading: Bool
+```
+
+Add `historyLoading: Bool = false` as the final parameter of the designated init (after `alwaysShowsFullSurface: Bool = false`) and assign it. The init becomes:
+
+```swift
+  init(
+    title: String,
+    hostCurrency: Instrument,
+    positions: [ValuedPosition],
+    historicalValue: HistoricalValueSeries?,
+    performance: AccountPerformance? = nil,
+    hasAnyHistoricalActivity: Bool = false,
+    alwaysShowsFullSurface: Bool = false,
+    historyLoading: Bool = false
+  ) {
+    self.title = title
+    self.hostCurrency = hostCurrency
+    self.positions = positions
+    self.historicalValue = historicalValue
+    self.performance = performance
+    self.hasAnyHistoricalActivity = hasAnyHistoricalActivity
+    self.alwaysShowsFullSurface = alwaysShowsFullSurface
+    self.historyLoading = historyLoading
+  }
+```
+
+Add this method inside the struct body, after `rendersNothing` (after line 159):
+
+```swift
+  /// Returns a copy with the historic series merged in and the loading
+  /// flag cleared. Used by the two-phase investment load: phase 1 returns
+  /// the input with `historyLoading == true`; phase 2 calls this once the
+  /// `PositionsHistoryBuilder` series is ready (or `nil` on failure).
+  func applyingHistory(_ series: HistoricalValueSeries?) -> PositionsViewInput {
+    PositionsViewInput(
+      title: title,
+      hostCurrency: hostCurrency,
+      positions: positions,
+      historicalValue: series,
+      performance: performance,
+      hasAnyHistoricalActivity: hasAnyHistoricalActivity,
+      alwaysShowsFullSurface: alwaysShowsFullSurface,
+      historyLoading: false)
+  }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `just test-mac PositionsViewInputHistoryLoadingTests 2>&1 | tee .agent-tmp/t1.txt`
+Expected: PASS (all 4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C "$PWD" add Domain/Models/PositionsViewInput.swift MoolahTests/Domain/PositionsViewInputHistoryLoadingTests.swift
+git -C "$PWD" commit -m "feat(positions): add PositionsViewInput.historyLoading + applyingHistory"
+```
+
+---
+
+### Task 2: `InvestmentStore.loadedTransactions` cache state
+
+**Files:**
+- Modify: `Features/Investments/InvestmentStore.swift`
+
+- [ ] **Step 1: Add the stored property**
+
+In `Features/Investments/InvestmentStore.swift`, add after `loadedHostCurrency` (after line 29):
+
+```swift
+  /// Transactions fetched by phase 1 (`loadPositionsInput`) and reused by
+  /// phase 2 (`historicalSeries`) so the series build does not re-fetch.
+  /// Implicitly scoped to `loadedAccountId`; overwritten on each phase-1
+  /// load.
+  private(set) var loadedTransactions: [Transaction] = []
+```
+
+- [ ] **Step 2: Add the setter**
+
+Add next to the other setters (after `setLoadedHostCurrency`, after line 197):
+
+```swift
+  func setLoadedTransactions(_ transactions: [Transaction]) {
+    loadedTransactions = transactions
+  }
+```
+
+- [ ] **Step 3: Build to verify it compiles**
+
+Run: `just build-mac 2>&1 | tail -5`
+Expected: build succeeds (no callers yet — this is plumbing for Task 3).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C "$PWD" add Features/Investments/InvestmentStore.swift
+git -C "$PWD" commit -m "feat(investments): cache loadedTransactions on InvestmentStore"
+```
+
+---
+
+### Task 3: Split `positionsViewInput` into phase 1 + phase 2
+
+**Files:**
+- Modify: `Features/Investments/InvestmentStore+PositionsInput.swift:39-88`
+- Test: `MoolahTests/Features/InvestmentStoreTwoPhaseLoadTests.swift` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `MoolahTests/Features/InvestmentStoreTwoPhaseLoadTests.swift`:
+
+```swift
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@MainActor
+@Suite("InvestmentStore two-phase load")
+struct InvestmentStoreTwoPhaseLoadTests {
+  let aud = Instrument.AUD
+  let bhp = Instrument.stock(ticker: "BHP.AX", exchange: "ASX", name: "BHP")
+
+  private func makeStoreWithTrade() async throws -> (InvestmentStore, Account) {
+    let (backend, _) = try TestBackend.create()
+    let store = InvestmentStore(
+      repository: backend.investments,
+      transactionRepository: backend.transactions,
+      conversionService: backend.conversionService
+    )
+    let account = Account(
+      name: "Brokerage", type: .investment, instrument: aud,
+      valuationMode: .calculatedFromTrades)
+    _ = try await backend.accounts.create(
+      account, openingBalance: InstrumentAmount(quantity: 0, instrument: aud))
+    _ = try await backend.transactions.create(
+      Transaction(
+        date: Date(),
+        legs: [
+          TransactionLeg(accountId: account.id, instrument: bhp, quantity: 100, type: .trade),
+          TransactionLeg(accountId: account.id, instrument: aud, quantity: -4_000, type: .trade),
+        ]
+      )
+    )
+    return (store, account)
+  }
+
+  @Test("phase 1 returns positions+cost basis, no series, history loading")
+  func phase1FastInput() async throws {
+    let (store, account) = try await makeStoreWithTrade()
+
+    let input = try await store.loadPositionsInput(
+      account: account, profileCurrency: aud)
+
+    #expect(input.historicalValue == nil)
+    #expect(input.historyLoading == true)
+    #expect(input.positions.contains(where: { $0.instrument == bhp }))
+    let bhpRow = input.positions.first(where: { $0.instrument == bhp })!
+    #expect(bhpRow.costBasis == InstrumentAmount(quantity: 4_000, instrument: aud))
+    #expect(store.loadedTransactions.count == 1)
+  }
+
+  @Test("historicalSeries is nil without a transaction repository")
+  func historicalSeriesNilWithoutRepo() async throws {
+    let (backend, _) = try TestBackend.create()
+    let store = InvestmentStore(
+      repository: backend.investments,
+      transactionRepository: nil,
+      conversionService: backend.conversionService
+    )
+    let series = await store.historicalSeries(range: .all)
+    #expect(series == nil)
+  }
+
+  @Test("composed positionsViewInput still returns a built input, not loading")
+  func composedStillWorks() async throws {
+    let (store, account) = try await makeStoreWithTrade()
+    await store.loadAllData(account: account, profileCurrency: aud)
+
+    let input = try await store.positionsViewInput(
+      title: account.name, range: .threeMonths)
+
+    #expect(input.historyLoading == false)
+    #expect(input.positions.contains(where: { $0.instrument == bhp }))
+  }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `just test-mac InvestmentStoreTwoPhaseLoadTests 2>&1 | tee .agent-tmp/t3.txt`
+Expected: FAIL — `value of type 'InvestmentStore' has no member 'loadPositionsInput'` / `'historicalSeries'`.
+
+- [ ] **Step 3: Replace `positionsViewInput` with the split implementation**
+
+In `Features/Investments/InvestmentStore+PositionsInput.swift`, replace the entire `positionsViewInput(title:range:)` method (lines 31–88, the doc comment through the closing brace of the method) with:
+
+```swift
+  /// Phase 1 of the two-phase load: runs `loadAllData` then assembles the
+  /// positions/cost-basis half of the input. No historic series — the
+  /// returned input has `historicalValue == nil` and (for hosts that
+  /// will build a series) `historyLoading == true`. The caller runs
+  /// phase 2 (`historicalSeries`) off the critical path.
+  func loadPositionsInput(
+    account: Account,
+    profileCurrency: Instrument
+  ) async throws -> PositionsViewInput {
+    await loadAllData(account: account, profileCurrency: profileCurrency)
+    return try await positionsInputWithoutHistory(title: account.name)
+  }
+
+  /// Builds the positions + cost-basis half of `PositionsViewInput` from
+  /// the already-loaded `valuedPositions` and a fresh transaction fetch.
+  /// Caches the fetched transactions on the store so phase 2 reuses them.
+  /// `historicalValue` is `nil`; `historyLoading` is `true` whenever a
+  /// series build will follow (a transaction repository exists).
+  func positionsInputWithoutHistory(
+    title: String
+  ) async throws -> PositionsViewInput {
+    guard let transactionRepository else {
+      let hostCurrency = loadedHostCurrency ?? .AUD
+      return PositionsViewInput(
+        title: title,
+        hostCurrency: hostCurrency,
+        positions: valuedPositions,
+        historicalValue: nil,
+        performance: accountPerformance,
+        alwaysShowsFullSurface: true)
+    }
+
+    let txns: [Transaction]
+    do {
+      txns = try await fetchAllTransactions(
+        repository: transactionRepository,
+        accountId: loadedAccountId ?? UUID())
+    } catch is CancellationError {
+      setLoadedTransactions([])
+      throw CancellationError()
+    } catch {
+      logger.warning(
+        "fetchAllTransactions failed, cost basis will be empty: \(error.localizedDescription, privacy: .public)"
+      )
+      txns = []
+    }
+    setLoadedTransactions(txns)
+    let hostCurrency = loadedHostCurrency ?? valuedPositions.first?.value?.instrument ?? .AUD
+    let costSnapshot = await costBasisSnapshot(
+      transactions: txns, hostCurrency: hostCurrency)
+    let rowsWithCost = applyingCostBasis(costSnapshot, hostCurrency: hostCurrency)
+
+    return PositionsViewInput(
+      title: title,
+      hostCurrency: hostCurrency,
+      positions: rowsWithCost,
+      historicalValue: nil,
+      performance: accountPerformance,
+      hasAnyHistoricalActivity: Self.hasAnyTradeLeg(
+        in: txns, accountId: loadedAccountId, hostCurrency: hostCurrency),
+      alwaysShowsFullSurface: true,
+      historyLoading: true)
+  }
+
+  /// Phase 2 of the two-phase load: builds the historic chart series from
+  /// the transactions cached by phase 1. Returns `nil` for hosts without
+  /// a transaction repository (previews / embeddings). Range-only — does
+  /// not re-fetch transactions or re-run `loadAllData`.
+  func historicalSeries(
+    range: PositionsTimeRange
+  ) async -> HistoricalValueSeries? {
+    guard transactionRepository != nil else { return nil }
+    let hostCurrency = loadedHostCurrency ?? valuedPositions.first?.value?.instrument ?? .AUD
+    return await PositionsHistoryBuilder(conversionService: conversionService).build(
+      transactions: loadedTransactions,
+      accountId: loadedAccountId ?? UUID(),
+      hostCurrency: hostCurrency,
+      range: range
+    )
+  }
+
+  /// Backwards-compatible composition of phase 1 + phase 2. Retained so
+  /// existing callers/tests (`loadAndBuildPositionsInput`, store tests)
+  /// keep returning a fully-built input. The two-phase view path calls
+  /// `loadPositionsInput` / `historicalSeries` directly instead.
+  func positionsViewInput(
+    title: String,
+    range: PositionsTimeRange
+  ) async throws -> PositionsViewInput {
+    let base = try await positionsInputWithoutHistory(title: title)
+    let series = await historicalSeries(range: range)
+    return base.applyingHistory(series)
+  }
+```
+
+> `loadAndBuildPositionsInput` (lines 22–29) is unchanged: it still calls `loadAllData` then the composed `positionsViewInput`, which now routes through the split internally. `applyingCostBasis`, `hasAnyTradeLeg`, `fetchAllTransactions`, `costBasisSnapshot` are unchanged and remain in this file.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `just test-mac InvestmentStoreTwoPhaseLoadTests InvestmentStorePositionsInputTests 2>&1 | tee .agent-tmp/t3.txt`
+Expected: PASS — new suite passes and the pre-existing `InvestmentStorePositionsInputTests` still passes (composed-path regression).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C "$PWD" add Features/Investments/InvestmentStore+PositionsInput.swift MoolahTests/Features/InvestmentStoreTwoPhaseLoadTests.swift
+git -C "$PWD" commit -m "feat(investments): split positionsViewInput into fast phase 1 + phase 2"
+```
+
+---
+
+### Task 4: `PositionsView` chart-loading placeholder
+
+**Files:**
+- Modify: `Shared/Views/Positions/PositionsView.swift:35-43`
+
+- [ ] **Step 1: Add the loading branch**
+
+In `Shared/Views/Positions/PositionsView.swift`, replace the chart block (lines 35–43, the `if input.showsChart { … }` block) with:
+
+```swift
+        if input.historyLoading {
+          Divider()
+          ProgressView()
+            .controlSize(.small)
+            .frame(maxWidth: .infinity)
+            .frame(height: 260)
+            .padding(.vertical, 8)
+            .accessibilityLabel("Loading chart")
+        } else if input.showsChart {
+          Divider()
+          PositionsChart(
+            input: input,
+            range: $range,
+            selectedInstrument: $selection
+          )
+          .padding(.vertical, 8)
+        }
+```
+
+> The fixed 260 pt height ≈ the chart's rendered height (`InvestmentAccountView` budgets "chart (~250pt with padding)") so the layout does not jump when phase 2 lands and the real chart replaces the spinner.
+
+- [ ] **Step 2: Build to verify it compiles**
+
+Run: `just build-mac 2>&1 | tail -5`
+Expected: build succeeds.
+
+- [ ] **Step 3: Visual check via preview (optional but recommended)**
+
+Render the existing `PositionsView` preview that has a chart, plus a temporary preview passing `historyLoading: true`, using `mcp__xcode__RenderPreview` (worktree-aware: `just generate` then open the worktree's `Moolah.xcodeproj` per CLAUDE.md). Confirm the spinner occupies the chart's space without layout jump. Remove the temporary preview before committing if added.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C "$PWD" add Shared/Views/Positions/PositionsView.swift
+git -C "$PWD" commit -m "feat(positions): show chart-area spinner while history loads"
+```
+
+---
+
+### Task 5: Rewire `InvestmentAccountView+Loading` for two-phase load
+
+**Files:**
+- Modify: `Features/Investments/Views/InvestmentAccountView+Loading.swift:20-69`
+
+- [ ] **Step 1: Replace `reloadPositions` and `maybeAutoWidenRange`, add `loadHistory`**
+
+In `Features/Investments/Views/InvestmentAccountView+Loading.swift`, replace `reloadPositions()` (lines 20–35) and `maybeAutoWidenRange()` (lines 52–69) and insert `loadHistory(range:)` between them. The extension body becomes:
+
+```swift
+  /// Phase 1 of the two-phase load (positions + cost basis only). Sets
+  /// `isLoadingPositions` across the work so progress UI binds correctly.
+  /// The historic series is built separately by `loadHistory(range:)`.
+  func reloadPositions() async {
+    isLoadingPositions = true
+    defer { isLoadingPositions = false }
+    do {
+      positionsInput = try await investmentStore.loadPositionsInput(
+        account: account,
+        profileCurrency: profileCurrencyInstrument)
+    } catch is CancellationError {
+      return
+    } catch {
+      Self.logger.error(
+        "Unexpected error from loadPositionsInput: \(error.localizedDescription, privacy: .public)"
+      )
+    }
+  }
+
+  /// Phase 2: build the historic chart series off the critical path and
+  /// merge it into `positionsInput`. The screen is already interactive by
+  /// the time this runs; the chart pane shows a spinner
+  /// (`PositionsViewInput.historyLoading`) until this lands. A
+  /// `CancellationError` (navigation away / range change) is observed via
+  /// `Task.isCancelled` and drops the stale result.
+  func loadHistory(range: PositionsTimeRange) async {
+    guard investmentStore.loadedAccountId != nil else { return }
+    let series = await investmentStore.historicalSeries(range: range)
+    if Task.isCancelled { return }
+    positionsInput = positionsInput.applyingHistory(series)
+  }
+
+  /// If the account loaded with no remaining positions but the active
+  /// range carries no points (the last trade pre-dates it), default the
+  /// range to `.all` so the historic chart populates instead of stranding
+  /// the user on "No chart data yet". Runs in phase 2 — it no longer
+  /// blocks first paint. The chart's range picker stays bound to
+  /// `positionsRange`, so the user can still narrow back afterwards.
+  ///
+  /// Flipping `positionsRange` also fires `.task(id: positionsRange)`,
+  /// which rebuilds the `.all` series a second time; for the expected
+  /// use case (idle, conversion cache warm) it is sub-second. This
+  /// redundancy pre-dates this change and is intentionally preserved.
+  func maybeAutoWidenRange() async {
+    guard positionsInput.shouldHide,
+      positionsInput.hasAnyHistoricalActivity,
+      !positionsInput.hasHistoricalSeries,
+      positionsRange != .all
+    else { return }
+    let series = await investmentStore.historicalSeries(range: .all)
+    if Task.isCancelled { return }
+    positionsInput = positionsInput.applyingHistory(series)
+    positionsRange = .all
+  }
+```
+
+> `profileCurrencyInstrument` and `Self.logger` are existing members of this extension / the view; unchanged. `reloadPositions` no longer reads `positionsRange` (phase 1 is range-independent).
+
+- [ ] **Step 2: Build to verify it compiles**
+
+Run: `just build-mac 2>&1 | tail -5`
+Expected: FAIL — `InvestmentAccountView.swift` still calls the old single-phase `.task` flow referencing `positionsViewInput`; fixed in Task 6. (If it compiles because the call sites still resolve, proceed; the behavior wiring is Task 6.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C "$PWD" add Features/Investments/Views/InvestmentAccountView+Loading.swift
+git -C "$PWD" commit -m "feat(investments): two-phase reloadPositions + loadHistory + phase-2 auto-widen"
+```
+
+---
+
+### Task 6: Rewire `InvestmentAccountView` task flow
+
+**Files:**
+- Modify: `Features/Investments/Views/InvestmentAccountView.swift:209-233`
+
+- [ ] **Step 1: Replace the two `.task` modifiers**
+
+In `Features/Investments/Views/InvestmentAccountView.swift`, replace the `.task(id: LoadKey…)` block (lines 209–217) and the `.task(id: positionsRange)` block (lines 218–233) with:
+
+```swift
+    .task(id: LoadKey(id: account.id, mode: account.valuationMode)) {
+      initialLoadComplete = false
+      await reloadPositions()
+      // Screen is now interactive — transactions list + positions table
+      // render while the historic series builds in phase 2 below.
+      initialLoadComplete = true
+      focusAnchor = .content
+      await loadHistory(range: positionsRange)
+      await maybeAutoWidenRange()
+    }
+    .task(id: positionsRange) {
+      // Skip until phase 1 has populated the store; the `.task(id:)` keyed
+      // on (account.id, valuationMode) runs the first history build. We
+      // only fire phase-2 rebuilds for subsequent range changes here.
+      guard investmentStore.loadedAccountId != nil else { return }
+      await loadHistory(range: positionsRange)
+    }
+```
+
+- [ ] **Step 2: Build to verify it compiles**
+
+Run: `just build-mac 2>&1 | tail -5`
+Expected: build succeeds.
+
+- [ ] **Step 3: Run the investment view + store regression suites**
+
+Run: `just test-mac InvestmentStoreTwoPhaseLoadTests InvestmentStorePositionsInputTests InvestmentStoreTests InvestmentStoreFullySoldChartTests 2>&1 | tee .agent-tmp/t6.txt`
+Expected: PASS (all suites). The fully-sold/auto-widen suite pins the relocated `maybeAutoWidenRange` behavior.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C "$PWD" add Features/Investments/Views/InvestmentAccountView.swift
+git -C "$PWD" commit -m "feat(investments): flip the screen gate after phase 1, build history in phase 2"
+```
+
+---
+
+### Task 7: Full verification, format, agent reviews
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Format**
+
+Run: `just format`
+Then: `just format-check`
+Expected: `format-check` exits 0 (no diff, no new SwiftLint violations beyond baseline). If it fails, fix the underlying code — never edit `.swiftlint-baseline.yml`.
+
+- [ ] **Step 2: Compiler warnings check**
+
+Run: `just build-mac 2>&1 | grep -i "warning:" | grep -v "#Preview" || echo "no warnings"`
+Expected: `no warnings` (project treats warnings as errors).
+
+- [ ] **Step 3: Full investment + positions test sweep, both platforms**
+
+Run: `just test InvestmentStoreTwoPhaseLoadTests InvestmentStorePositionsInputTests InvestmentStoreTests PositionsViewInputHistoryLoadingTests PositionsViewInputChartTests PositionsHistoryBuilderTests 2>&1 | tee .agent-tmp/t7.txt`
+Then check: `grep -i 'failed\|error:' .agent-tmp/t7.txt || echo "all green"`
+Expected: `all green`.
+
+- [ ] **Step 4: Agent reviews**
+
+Run, in order, and address every Critical/Important/Minor finding before proceeding (do not rationalise findings away):
+- `@code-review` — naming, thin-view discipline, optional/error handling, `TODO(#N)` format on the changed Swift files.
+- `@concurrency-review` — `InvestmentStore` is `@MainActor`; verify the new `async` methods and the `Task.isCancelled` checks in `loadHistory`/`maybeAutoWidenRange` follow `guides/CONCURRENCY_GUIDE.md`.
+- `@ui-review` — `PositionsView` chart-loading placeholder (accessibility label, no layout jump, HIG).
+
+- [ ] **Step 5: Re-profile the original repro (responsiveness verification)**
+
+Using the `profile-performance` + `automate-app` skills (worktree app build): `just run-mac-with-logs`, navigate to "Shares" in "Large Test Profile", and confirm the transactions list is visible and interactive within a frame or two of navigation (the chart shows a spinner and fills in afterward). Capture a stack sample during the chart build to confirm the slow build is now off the main critical path. Note: the build itself is still slow until Plan B — that is expected and acceptable for Plan A.
+
+- [ ] **Step 6: Commit any review fixes**
+
+```bash
+git -C "$PWD" add -A
+git -C "$PWD" commit -m "chore(investments): address review findings for two-phase load"
+```
+
+---
+
+### Task 8: Open PR and queue it
+
+**Files:** none
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+git -C "$PWD" push origin perf/responsive-investment-load:perf/responsive-investment-load
+```
+
+- [ ] **Step 2: Open the PR**
+
+```bash
+gh pr create --title "perf(investments): responsive two-phase investment account load" \
+  --body "$(cat <<'EOF'
+Decouples the historic-graph build from the investment account screen so
+transactions/positions render immediately and the chart loads behind a
+spinner. Approach 2, Plan A (responsiveness).
+
+Spec: plans/2026-05-16-responsive-investment-load-design.md
+Plan: plans/2026-05-16-responsive-investment-load-plan-A-responsiveness.md
+
+Plan B (sorted-array price/rate caches — the build-speed fix) is a
+separate follow-up PR.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Add the PR to the merge queue**
+
+Use the `merge-queue` skill to enqueue the new PR (never merge manually).
+
+---
+
+### Task 9: Move spec + plan to `plans/completed/` when merged
+
+**Files:**
+- Move: `plans/2026-05-16-responsive-investment-load-plan-A-responsiveness.md` → `plans/completed/`
+- Move: `plans/2026-05-16-responsive-investment-load-design.md` → `plans/completed/` **only if Plan B is also complete** (the spec covers both plans; if Plan B is still outstanding, leave the spec in `plans/` and move only this plan).
+
+- [ ] **Step 1: After this PR merges, move this plan doc**
+
+```bash
+git -C "$PWD" mv plans/2026-05-16-responsive-investment-load-plan-A-responsiveness.md plans/completed/
+```
+
+- [ ] **Step 2: Move the spec only if Plan B is done**
+
+If Plan B (`plans/2026-05-16-responsive-investment-load-plan-B-caches.md`) has also merged:
+
+```bash
+git -C "$PWD" mv plans/2026-05-16-responsive-investment-load-design.md plans/completed/
+```
+
+Otherwise leave the spec in `plans/` for Plan B to reference, and Plan B's final task moves it.
+
+- [ ] **Step 3: Commit and ship via the normal PR + merge-queue flow**
+
+```bash
+git -C "$PWD" commit -m "chore(plans): move responsive investment load plan A to completed"
+```
+
+(Push + PR + merge-queue as in Task 8; a docs-only PR.)
+
+---
+
+## Self-Review
+
+**Spec coverage (Plan A subset):**
+- Spec §1 "Two-phase load" → Tasks 2, 3, 5, 6. ✓
+- Spec §2 "Chart loading contract" (`historyLoading` + `PositionsView` placeholder) → Tasks 1, 4. ✓
+- Spec §4 "Error handling & cancellation" → Task 3 (CancellationError rethrow), Task 5 (`Task.isCancelled` in `loadHistory`/`maybeAutoWidenRange`), Task 6 (gate after phase 1). ✓
+- Spec §5 "Testing" — store split + composed regression + model helper → Tasks 1, 3; relocated auto-widen pinned by existing `InvestmentStoreFullySoldChartTests` in Task 6; optional UI-test stretch item intentionally omitted (spec marks it non-gating). ✓
+- Spec §3 "Sorted-array caches" → **out of scope for Plan A**; Plan B. Stated in the header. ✓
+- Spec "Verification" → Task 7 Step 5. ✓
+- User instruction "move plans + spec to completed when done" → Task 9. ✓
+
+**Placeholder scan:** No TBD/TODO/"handle errors"/"similar to". The one annotated caveat (HistoricalValueSeries init labels in Task 1 Step 1) instructs verification against a named source file, not deferred work. ✓
+
+**Type consistency:** `historyLoading` (Bool, default false) and `applyingHistory(_:) -> PositionsViewInput` defined in Task 1 and used identically in Tasks 3, 5. `loadPositionsInput(account:profileCurrency:) async throws`, `positionsInputWithoutHistory(title:) async throws`, `historicalSeries(range:) async -> HistoricalValueSeries?` defined in Task 3 and called with matching signatures in Tasks 5/6. `setLoadedTransactions(_:)` / `loadedTransactions` defined Task 2, used Task 3. ✓


### PR DESCRIPTION
Design spec + Plan A implementation plan for the slow "Shares" investment
account load (profiled: a synchronous, screen-blocking `.all` history build
doing ~10k O(n log n)-per-call price/rate fallback lookups).

**Docs only — no code changes.** Implementation lands via a separate PR.

- `plans/2026-05-16-responsive-investment-load-design.md` — approved spec
  (Approach 2: decouple the build for responsiveness + sorted-array Int32
  price/rate caches for speed/memory).
- `plans/2026-05-16-responsive-investment-load-plan-A-responsiveness.md` —
  TDD plan for the responsiveness half (two-phase load, chart-area spinner).

Plan B (sorted-array price/rate caches) is a separate follow-up docs PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)