### PR TITLE
perf(crypto-import): batch wallet persist into one atomic createMany

### DIFF
--- a/Shared/CryptoImport/WalletApplyEngine.swift
+++ b/Shared/CryptoImport/WalletApplyEngine.swift
@@ -223,14 +223,17 @@ final class WalletApplyEngine {
     return legs
   }
 
+  /// Persists the deduped survivors in a single atomic bulk insert.
+  ///
+  /// `createMany` writes every transaction (with its legs) inside one
+  /// write transaction; on any failure none persist. That all-or-nothing
+  /// boundary is safe here because the apply pipeline dedups exactly on
+  /// `(accountId, externalId)` — a rolled-back batch is re-fetched within
+  /// the reorg window next cycle and every already-landed leg dedups to a
+  /// no-op. It also avoids the per-`create` commit/fsync that made a busy
+  /// wallet's persist pass O(transactions) write transactions.
   private func persist(_ candidates: [BuiltTransaction]) async throws -> [Transaction] {
-    var persisted: [Transaction] = []
-    persisted.reserveCapacity(candidates.count)
-    for candidate in candidates {
-      let saved = try await transactions.create(candidate.transaction)
-      persisted.append(saved)
-    }
-    return persisted
+    try await transactions.createMany(candidates.map(\.transaction))
   }
 
   private func updateSyncState(for perAccount: [AccountInput]) async throws {


### PR DESCRIPTION
## What

`WalletApplyEngine.persist()` looped calling `transactions.create()` once per candidate transaction — each call its own GRDB `database.write` (a separate commit + fsync). For a busy wallet, the persist pass was O(transactions) write transactions.

This swaps the loop for a single `transactions.createMany()` — one atomic write for the whole sync cycle.

## Why it's a behaviour-preserving swap

`createMany`'s documented contract returns the inserted transactions in input order and fires change / instrument hooks once per inserted row after the write commits — identical to the prior per-`create` fan-out. It's the same path the CSV importer already uses.

## Why all-or-nothing is safe here

The CSV importer adopted batch atomicity reluctantly (a half-imported CSV is hard to reconcile because its dedup window is fuzzy). Crypto has no such problem: the apply pipeline dedups exactly on `(accountId, externalId)` — the on-chain tx hash / log index. A rolled-back batch is simply re-fetched within the reorg window on the next sync cycle, and every already-landed leg dedups to a no-op. This change also *removes* the prior partial-write failure mode where `persist()` threw mid-loop, leaving some rows persisted while the sync watermark stayed unadvanced.

Streaming per-fetch-batch writes was considered and rejected: the cross-account transfer merge (`CrossAccountTransferMerger`) needs all candidates in memory before any write, so the whole sync cycle is the correct batch unit.

> Note: the >1000-transfer Alchemy pagination/truncation issue is being handled separately in another change — out of scope here.

## Tests

- `WalletApplyEngineTests` — 5/5 (directly covers the modified `persist()` path: dedup-prevents-duplicate-write, per-account sync-state, rules invocation, merge→persist collapse)
- `CryptoSyncStoreTests`, `CryptoSyncPipelineStructureTests`, `CryptoSyncStoreGlobalErrorTests`, `CrossDeviceLegDeduperPlanPinningTests` — 18/18 (downstream consumers)
- Clean compile on macOS + iOS under Swift 6 / `-warnings-as-errors`

🤖 Generated with [Claude Code](https://claude.com/claude-code)