### PR TITLE
fix(crypto): paginate Alchemy getAssetTransfers via pageKey

### DIFF
--- a/MoolahTests/Shared/CryptoImport/LiveAlchemyClientPaginationTests.swift
+++ b/MoolahTests/Shared/CryptoImport/LiveAlchemyClientPaginationTests.swift
@@ -1,0 +1,119 @@
+// MoolahTests/Shared/CryptoImport/LiveAlchemyClientPaginationTests.swift
+import Foundation
+import Testing
+
+@testable import Moolah
+
+/// `alchemy_getAssetTransfers` caps each response at 1000 transfers and
+/// returns a `pageKey` when more remain. `getAssetTransfers` must follow
+/// the `pageKey` until it is absent — otherwise wallets with heavy
+/// (often spam-airdrop) inbound history silently truncate at the oldest
+/// 1000 transfers per direction, producing wrong balances.
+@Suite("LiveAlchemyClient — pagination")
+struct LiveAlchemyClientPaginationTests {
+  /// One Alchemy `result` page: a single synthetic transfer plus an
+  /// optional `pageKey`. Distinct `uniqueId` per call so the test can
+  /// count concatenated transfers across pages and directions.
+  private static func pageJSON(uniqueId: String, pageKey: String?) -> Data {
+    let pageKeyField = pageKey.map { ",\"pageKey\":\"\($0)\"" } ?? ""
+    let json = """
+      {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "result": {
+          "transfers": [
+            {
+              "blockNum": "0x12d4f0a",
+              "uniqueId": "\(uniqueId)",
+              "hash": "0xabc123def456000000000000000000000000000000000000000000000000aaaa",
+              "from": "0x1111111111111111111111111111111111111111",
+              "to": "0x2222222222222222222222222222222222222222",
+              "value": 0.05,
+              "asset": "ETH",
+              "category": "external",
+              "rawContract": {
+                "value": "0xb1a2bc2ec50000",
+                "address": null,
+                "decimal": "0x12"
+              },
+              "metadata": {
+                "blockTimestamp": "2024-09-12T12:34:56.000Z"
+              }
+            }
+          ]\(pageKeyField)
+        }
+      }
+      """
+    return Data(json.utf8)
+  }
+
+  @Test
+  func followsPageKeyAcrossPagesAndBothDirectionsUntilAbsent() async throws {
+    let calls = TestCallRecorder()
+    let client = AlchemyTestSupport.makeClient { request in
+      calls.record(request: request)
+      let params = (calls.captured.last?["params"] as? [[String: Any]])?.first ?? [:]
+      let direction = params["fromAddress"] != nil ? "from" : "to"
+      let priorPageKey = params["pageKey"] as? String
+      if priorPageKey == nil {
+        // Page 1 of this direction → hand back a pageKey for page 2.
+        return (
+          AlchemyTestSupport.okResponse(for: request),
+          Self.pageJSON(uniqueId: "\(direction):0", pageKey: "\(direction)-PAGE2")
+        )
+      }
+      // Page 2 → no pageKey, pagination ends for this direction.
+      return (
+        AlchemyTestSupport.okResponse(for: request),
+        Self.pageJSON(uniqueId: "\(direction):1", pageKey: nil)
+      )
+    }
+
+    let transfers = try await client.getAssetTransfers(
+      chain: .optimism, walletAddress: "0xWALLET", fromBlock: 0
+    )
+
+    // 2 pages × 2 directions = 4 concatenated transfers.
+    #expect(transfers.count == 4)
+    #expect(Set(transfers.map(\.uniqueId)) == ["from:0", "from:1", "to:0", "to:1"])
+
+    let recorded = calls.captured
+    #expect(recorded.count == 4)
+    // The follow-up request in each direction must carry the page-1 pageKey.
+    let pageKeys = recorded.compactMap {
+      (($0["params"] as? [[String: Any]])?.first)?["pageKey"] as? String
+    }
+    #expect(Set(pageKeys) == ["from-PAGE2", "to-PAGE2"])
+  }
+
+  @Test
+  func stopsWhenProviderRepeatsAPageKeyRatherThanLoopingForever() async throws {
+    let calls = TestCallRecorder()
+    let client = AlchemyTestSupport.makeClient { request in
+      calls.record(request: request)
+      let params = (calls.captured.last?["params"] as? [[String: Any]])?.first ?? [:]
+      let direction = params["fromAddress"] != nil ? "from" : "to"
+      // A misbehaving provider hands back the SAME pageKey every time.
+      // Bounded at 4 pages so a non-terminating client fails the
+      // assertion instead of hanging the suite.
+      let key = direction == "from" ? "fromAddress" : "toAddress"
+      let n = calls.captured.filter {
+        ((($0["params"] as? [[String: Any]])?.first)?[key]) != nil
+      }.count
+      return (
+        AlchemyTestSupport.okResponse(for: request),
+        Self.pageJSON(uniqueId: "\(direction):\(n)", pageKey: n < 4 ? "LOOP" : nil)
+      )
+    }
+
+    let transfers = try await client.getAssetTransfers(
+      chain: .optimism, walletAddress: "0xWALLET", fromBlock: 0
+    )
+
+    // The client must stop the first time it is handed a pageKey it has
+    // already requested: 2 requests per direction (initial + the repeat
+    // that triggers the guard), 4 total — never the bounded 5/direction.
+    #expect(calls.captured.count == 4)
+    #expect(transfers.count == 4)
+  }
+}

--- a/Shared/CryptoImport/AlchemyClient.swift
+++ b/Shared/CryptoImport/AlchemyClient.swift
@@ -70,13 +70,24 @@ extension AlchemyTokenMetadata {
   }
 }
 
+/// The fixed inputs for one direction's paginated transfer fetch.
+/// Bundled into a value so the page loop and the per-page round-trip
+/// share one parameter instead of threading the same five arguments.
+private struct AlchemyTransferQuery: Sendable {
+  let chain: ChainConfig
+  let address: String
+  let isFromAddress: Bool
+  let fromBlock: UInt64
+  let apiKey: String
+}
+
 /// Live `AlchemyClient` over `URLSession`. Sendable struct — no mutable
 /// state; mirrors the shape of `Backends/CoinGecko/CoinGeckoClient.swift`.
 ///
 /// Privacy classifications follow the design table:
 /// `chainId` and block numbers → `.public`; wallet addresses and contract
 /// addresses → `.private`; the API key is never logged.
-struct LiveAlchemyClient: AlchemyClient {
+struct LiveAlchemyClient: AlchemyClient, Sendable {
   private let session: URLSession
   /// Closure that yields the current Alchemy API key, or `nil` when the
   /// keychain has none. Resolved per-request inside each public method
@@ -130,24 +141,16 @@ struct LiveAlchemyClient: AlchemyClient {
         signpostID: signpostID)
     }
     var transfers: [AlchemyTransfer] = []
-    transfers.append(
-      contentsOf: try await fetchTransfers(
-        chain: chain,
-        address: walletAddress,
-        isFromAddress: true,
-        fromBlock: fromBlock,
-        apiKey: apiKey
-      )
-    )
-    transfers.append(
-      contentsOf: try await fetchTransfers(
-        chain: chain,
-        address: walletAddress,
-        isFromAddress: false,
-        fromBlock: fromBlock,
-        apiKey: apiKey
-      )
-    )
+    for isFromAddress in [true, false] {
+      transfers.append(
+        contentsOf: try await fetchTransfers(
+          AlchemyTransferQuery(
+            chain: chain,
+            address: walletAddress,
+            isFromAddress: isFromAddress,
+            fromBlock: fromBlock,
+            apiKey: apiKey)))
+    }
     return transfers
   }
 
@@ -257,47 +260,77 @@ struct LiveAlchemyClient: AlchemyClient {
     return key
   }
 
+  /// Fetches every transfer for one direction. Alchemy caps
+  /// `alchemy_getAssetTransfers` at `maxCount` (1000) transfers per
+  /// response, oldest-block-first, and returns a `pageKey` when more
+  /// remain. This follows the cursor until it is absent — otherwise a
+  /// wallet with heavy (often spam-airdrop) history truncates at the
+  /// oldest 1000 per direction and the balance is wrong.
   private func fetchTransfers(
-    chain: ChainConfig,
-    address: String,
-    isFromAddress: Bool,
-    fromBlock: UInt64,
-    apiKey: String
+    _ query: AlchemyTransferQuery
   ) async throws -> [AlchemyTransfer] {
-    try await rateLimiter.acquire()
+    var collected: [AlchemyTransfer] = []
+    var pageKey: String?
+    // Guards against a misbehaving provider that returns a `pageKey`
+    // already used: re-requesting it would loop forever. Stop before
+    // re-fetching a continuation cursor that has already been requested.
+    var requestedPageKeys: Set<String> = []
+    while true {
+      if let pageKey, !requestedPageKeys.insert(pageKey).inserted {
+        break
+      }
+      let result = try await fetchTransferPage(query, pageKey: pageKey)
+      collected.append(contentsOf: result.transfers)
+      pageKey = result.pageKey
+      if pageKey == nil { break }
+    }
+    return collected
+  }
 
+  /// One rate-limited `alchemy_getAssetTransfers` round-trip for a
+  /// single direction and page. `pageKey` is `nil` for the first page;
+  /// the caller threads back `result.pageKey` for subsequent pages.
+  private func fetchTransferPage(
+    _ query: AlchemyTransferQuery,
+    pageKey: String?
+  ) async throws -> AlchemyTransferResult {
+    let chain = query.chain
     var categories: [AlchemyTransferCategory] = [.external, .erc20]
     if chain.supportsInternalTransfers {
       categories.append(.internal)
     }
+    try await rateLimiter.acquire()
     let body = AlchemyJSONRPCRequest<AlchemyJSONRPCParams>(
       method: "alchemy_getAssetTransfers",
       params: .assetTransfers(
         AlchemyAssetTransfersParams(
-          fromBlock: "0x" + String(fromBlock, radix: 16),
+          fromBlock: "0x" + String(query.fromBlock, radix: 16),
           toBlock: "latest",
-          fromAddress: isFromAddress ? address : nil,
-          toAddress: isFromAddress ? nil : address,
+          fromAddress: query.isFromAddress ? query.address : nil,
+          toAddress: query.isFromAddress ? nil : query.address,
           category: categories.map(\.rawValue),
           withMetadata: true,
-          excludeZeroValue: true
+          excludeZeroValue: true,
+          pageKey: pageKey
         )
       )
     )
-    let request = try buildRequest(chain: chain, body: body, apiKey: apiKey)
+    let request = try buildRequest(chain: chain, body: body, apiKey: query.apiKey)
     logger.debug(
       """
       Alchemy getAssetTransfers: chain \(chain.chainId, privacy: .public) \
-      direction \(isFromAddress ? "from" : "to", privacy: .public) \
-      address \(address, privacy: .private) \
-      fromBlock \(fromBlock, privacy: .public)
+      direction \(query.isFromAddress ? "from" : "to", privacy: .public) \
+      address \(query.address, privacy: .private) \
+      fromBlock \(query.fromBlock, privacy: .public) \
+      continuation \(pageKey != nil, privacy: .public)
       """
     )
 
     let data = try await send(request: request, stage: "getAssetTransfers")
     do {
-      let envelope = try JSONDecoder().decode(AlchemyTransferEnvelope.self, from: data)
-      return envelope.result.transfers
+      return try JSONDecoder().decode(
+        AlchemyTransferEnvelope.self, from: data
+      ).result
     } catch {
       logger.error(
         "Alchemy getAssetTransfers decode failed for chain \(chain.chainId, privacy: .public): \(error.localizedDescription, privacy: .public)"

--- a/Shared/CryptoImport/AlchemyJSONRPCWireFormat.swift
+++ b/Shared/CryptoImport/AlchemyJSONRPCWireFormat.swift
@@ -44,11 +44,18 @@ struct AlchemyJSONRPCNullableResponse<Result: Decodable>: Decodable {
   let result: Result?
 }
 
+// These envelopes are created and decoded across the `await` in
+// `LiveAlchemyClient.send`, so they cross actor boundaries; their
+// instances are safe to send whenever the generic body is.
+extension AlchemyJSONRPCRequest: Sendable where Params: Sendable {}
+extension AlchemyJSONRPCResponse: Sendable where Result: Sendable {}
+extension AlchemyJSONRPCNullableResponse: Sendable where Result: Sendable {}
+
 /// Discriminated `params` payload — covers the JSON-RPC methods this
 /// client makes today. Each case encodes as the JSON-RPC convention of
 /// a one-element array around the parameter object (or address /
 /// hash string).
-enum AlchemyJSONRPCParams: Encodable {
+enum AlchemyJSONRPCParams: Encodable, Sendable {
   case assetTransfers(AlchemyAssetTransfersParams)
   case tokenMetadata(contractAddress: String)
   case transactionReceipt(hash: String)
@@ -67,7 +74,7 @@ enum AlchemyJSONRPCParams: Encodable {
 }
 
 /// Body for the `params[0]` object of `alchemy_getAssetTransfers`.
-struct AlchemyAssetTransfersParams: Encodable {
+struct AlchemyAssetTransfersParams: Encodable, Sendable {
   let fromBlock: String
   let toBlock: String
   let fromAddress: String?
@@ -75,6 +82,12 @@ struct AlchemyAssetTransfersParams: Encodable {
   let category: [String]
   let withMetadata: Bool
   let excludeZeroValue: Bool
+  /// Cursor for the next page. `nil` (and therefore omitted by the
+  /// synthesised encoder, like the other optional fields) on the first
+  /// request; set to the prior response's `pageKey` to fetch the next
+  /// page. Without this, Alchemy returns only the oldest `maxCount`
+  /// (1000) transfers per direction and the rest are silently lost.
+  let pageKey: String?
 }
 
 /// Decodes the `result` object of `alchemy_getAssetTransfers`. The
@@ -84,8 +97,12 @@ struct AlchemyTransferEnvelope: Decodable {
   let result: AlchemyTransferResult
 }
 
-struct AlchemyTransferResult: Decodable {
+struct AlchemyTransferResult: Decodable, Sendable {
   let transfers: [AlchemyTransfer]
+  /// Absent when all remaining transfers fit in this page. See
+  /// `AlchemyAssetTransfersParams.pageKey`. The synthesised decoder
+  /// maps a missing key to `nil`.
+  let pageKey: String?
 }
 
 /// HTTP response validator for `LiveAlchemyClient`. Maps status codes
@@ -163,7 +180,7 @@ enum AlchemyResponseValidator {
 /// than silently zero out (a zero gas leg would look like a free
 /// transaction; a missing `from` would always fail the wallet-match
 /// check and drop legitimate gas legs).
-struct AlchemyTransactionReceiptPayload: Decodable {
+struct AlchemyTransactionReceiptPayload: Decodable, Sendable {
   let gasUsed: String
   let effectiveGasPrice: String
   /// EOA that signed the transaction. Decoded raw; lowercased at


### PR DESCRIPTION
## Problem

`AlchemyClient.getAssetTransfers` did exactly two single round-trips per chain (one `fromAddress`, one `toAddress`) and concatenated them. The request set no `maxCount`/`order` and the result decoder ignored `pageKey`, so Alchemy's defaults applied: **`maxCount = 1000`, `order = "asc"`**. Any wallet/direction with >1000 transfers since `fromBlock` was silently truncated to the **oldest 1000**; later genuine transfers were never fetched. There is no start-block gap — initial sync fetches from block 0.

### Evidence (how this was found)

"Large Test Profile" → "Trust - Optimism" account, wallet `0xa1eaee65e5fb8f05cca1cc2b9126550e23513511`, chain 10. Compared Moolah's summed transfer legs against on-chain truth via an Optimism RPC `balanceOf`/`getBalance`:

| Holding | On-chain | Moolah (Σ legs) | Error |
|---|---|---|---|
| ETH | 0.11466524 | 0.11466524 | ✓ (storage rounding only) |
| **OP `0x4200…0042`** (real, priced) | **164,801.14** | **61,499.38** | **−103,301.77 (−63%)** |
| `0x7e08…a5a7` (spam honeypot) | balanceOf reverts | −1,321,777 | n/a (spam, filtered in positions view) |
| `0xd01f…43c2` (spam) | 15,304 | −1,442,278 | n/a (spam) |

ETH (few transfers) is correct to the rounding digit. The real OP token is short by ~103k because the inbound (`toAddress`) direction is flooded by spam-airdrop `Transfer` events that consumed the 1000-row ascending budget, pushing the genuine later OP receipts past the cap where they were never requested.

## Fix

- Decode `pageKey` on `AlchemyTransferResult`; send it on `AlchemyAssetTransfersParams` (nil omitted by the synthesised encoder). Follow `pageKey` across pages, **per direction**, until absent.
- Cycle guard: a set of already-requested `pageKey`s stops a misbehaving provider that repeats a cursor rather than looping forever. Cancellation still propagates via `RateLimiter.acquire()` and the `URLError.cancelled → CancellationError` mapping in `send()`.
- Extract `fetchTransferPage` for the single round-trip; bundle the fixed per-direction inputs into a `Sendable` `AlchemyTransferQuery` value.
- Add explicit `Sendable` to the wire-format value types and `LiveAlchemyClient` (conditional conformance for the generic JSON-RPC envelopes).

## Tests

New `LiveAlchemyClientPaginationTests` (Swift Testing):
- follows `pageKey` across pages and both directions until absent (2 pages × 2 directions = 4 transfers; follow-up requests carry the prior cursor);
- terminates when a provider repeats a `pageKey` instead of looping forever.

Full Alchemy + wallet-sync pipeline suites (69 tests, 10 suites) pass; `just format-check` clean. Reviewed with `code-review` and `concurrency-review`; all findings applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)