### PR TITLE
fix(domain): correct InstrumentAmount.storageValue for large fractional amounts

### DIFF
--- a/Domain/Models/InstrumentAmount.swift
+++ b/Domain/Models/InstrumentAmount.swift
@@ -58,8 +58,16 @@ struct InstrumentAmount: Codable, Sendable, Hashable, Comparable {
   // MARK: - Storage (Int64 scaled by 10^8)
 
   var storageValue: Int64 {
-    let scaled = quantity * storageScale
-    return Int64(truncating: scaled as NSDecimalNumber)
+    var scaled = quantity * storageScale
+    // `NSDecimalNumber.int64Value` (what `Int64(truncating:)` calls)
+    // wraps mod 2^64 for a non-integer Decimal whose significand exceeds
+    // 64 bits, flipping the sign. Round to an integer Decimal first; the
+    // conversion is then exact. RoundingMode: `.down` = toward -∞,
+    // `.up` = toward +∞ — so this truncates toward zero (positive →
+    // floor, negative → ceiling; zero is already integral).
+    var rounded = Decimal()
+    NSDecimalRound(&rounded, &scaled, 0, scaled < 0 ? .up : .down)
+    return Int64(truncating: rounded as NSDecimalNumber)
   }
 
   init(quantity: Decimal, instrument: Instrument) {

--- a/MoolahTests/Domain/InstrumentAmountLargeStorageTests.swift
+++ b/MoolahTests/Domain/InstrumentAmountLargeStorageTests.swift
@@ -1,0 +1,42 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+/// Guards `storageValue` against `NSDecimalNumber.int64Value` overflow:
+/// for a non-integer Decimal whose scaled significand exceeds 64 bits
+/// the conversion wraps mod 2^64 and can flip sign. Large 18-decimal
+/// token balances (e.g. 24 752 OP at full precision) hit this; round
+/// amounts do not.
+@Suite("InstrumentAmount — large fractional storage")
+struct InstrumentAmountLargeStorageTests {
+  private static let opToken = Instrument.crypto(
+    chainId: 10,
+    contractAddress: "0x4200000000000000000000000000000000000042",
+    symbol: "OP", name: "Optimism", decimals: 18)
+
+  @Test
+  func largePositiveFractionalQuantityTruncatesToEightDecimalPlaces() {
+    // Real corrupted transfer: 24752.479166666627062700 OP.
+    // 8-dp storage truncates toward zero → 24752.47916666 × 1e8.
+    let amount = InstrumentAmount(
+      quantity: dec("24752.479166666627062700"), instrument: Self.opToken)
+    #expect(amount.storageValue == 2_475_247_916_666)
+  }
+
+  @Test
+  func largeNegativeFractionalQuantityTruncatesTowardZeroKeepingSign() {
+    let amount = InstrumentAmount(
+      quantity: dec("-40167.948970346473430700"), instrument: Self.opToken)
+    #expect(amount.storageValue == -4_016_794_897_034)
+  }
+
+  @Test
+  func largeFractionalQuantityRoundTripsThroughStorage() {
+    let amount = InstrumentAmount(
+      quantity: dec("24752.479166666627062700"), instrument: Self.opToken)
+    let restored = InstrumentAmount(
+      storageValue: amount.storageValue, instrument: Self.opToken)
+    #expect(restored.quantity == dec("24752.47916666"))
+  }
+}


### PR DESCRIPTION
## Problem

`InstrumentAmount.storageValue`:

```swift
let scaled = quantity * storageScale            // Decimal, e.g. 2475247916666.66270627
return Int64(truncating: scaled as NSDecimalNumber)
```

`Int64(truncating:)` calls `NSDecimalNumber.int64Value`, which for a **non-integer** `Decimal` whose scaled significand exceeds 64 bits **wraps mod 2⁶⁴ and can flip sign**. Integer-valued amounts (round numbers / trailing-zero raw values) convert fine, so corruption only hit some values.

This silently corrupts synced crypto balances — 18-decimal tokens almost always produce a fractional scaled value. Reproduced in the app's own code:

| scaled `Decimal` (correct) | `Int64(truncating:)` | should be |
|---|---|---|
| `2475247916666.66270627` | `77171187084` | `2475247916666` |
| `4016794897034.64734307` | `-41488799181` (sign-flipped) | `4016794897034` |
| `797714000000` (integer) | `797714000000` ✓ | `797714000000` |

### How it was found

"Large Test Profile" → "Trust - Optimism" wallet imported OP balance **61,499.38** vs on-chain **164,801.14**. Replaying the app's exact Alchemy `getAssetTransfers` (key supplied) returned the complete, correct transfer set (net OP = 164,801.14, matching `balanceOf` via Optimism RPC) — Moolah imported the **same 36 transfers** but stored wrong per-transfer quantities (e.g. a `24,752.479166666627` OP transfer → `771.71187084`; a `-40,167.948970` leg → `+414.88799181`). The wrong values were never in Alchemy's data and weren't `raw / 10^k` for any k — they were `int64Value` significand wraps.

This is **not** the pagination issue from #910 (that was a real latent bug, but the wallet has <1000 transfers/direction and `getAssetTransfers` returned 1 page — it was never this symptom). Apologies for the earlier misdiagnosis; the key/archive access needed to see Alchemy's raw response wasn't available until now.

## Fix

Round the scaled `Decimal` to an integer **toward zero** via `NSDecimalRound` before the `Int64` conversion (positive → floor, negative → ceiling; zero is already integral). The conversion is then exact and sign-preserving — consistent with the Monetary Sign Convention. Scope is limited to `Int64(truncating:)`; `Double(truncating:)` (display/charts) is correct and untouched. No other call site uses the broken integer pattern.

## Tests

New `InstrumentAmountLargeStorageTests` (Swift Testing) using the real corrupted production values: large positive/negative fractional quantities and a storage round-trip. Verified green alongside all existing `InstrumentAmount`, `WalletApplyEngine`, `TransferEventBuilder`, `TransactionLegSyncSemantic`, `TransactionStore`, and GRDB balance-aggregation suites; `just format-check` clean; `code-review` findings applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)