### PR TITLE
perf(cache): sorted-array Int32-date price/rate caches (O(log n) fallback)

### DIFF
--- a/Domain/Models/CryptoPriceCache.swift
+++ b/Domain/Models/CryptoPriceCache.swift
@@ -7,5 +7,5 @@ struct CryptoPriceCache: Codable, Sendable, Equatable {
   let symbol: String  // e.g. "ETH" — display only
   var earliestDate: String  // ISO date string "YYYY-MM-DD"
   var latestDate: String  // ISO date string "YYYY-MM-DD"
-  var prices: [String: Decimal]  // date string -> daily closing price in USD
+  var prices: SortedDateSeries<Decimal>  // DateKey -> daily closing price in USD
 }

--- a/Domain/Models/ExchangeRateCache.swift
+++ b/Domain/Models/ExchangeRateCache.swift
@@ -6,5 +6,5 @@ struct ExchangeRateCache: Codable, Sendable, Equatable {
   let base: String
   var earliestDate: String  // ISO date string "YYYY-MM-DD"
   var latestDate: String  // ISO date string "YYYY-MM-DD"
-  var rates: [String: [String: Decimal]]  // date string -> { quote code -> rate }
+  var rates: SortedDateSeries<[String: Decimal]>  // day key -> { quote code -> rate }
 }

--- a/Domain/Models/StockPriceCache.swift
+++ b/Domain/Models/StockPriceCache.swift
@@ -7,5 +7,5 @@ struct StockPriceCache: Codable, Sendable, Equatable {
   let instrument: Instrument  // denomination discovered from API (e.g. .AUD)
   var earliestDate: String  // ISO date string "YYYY-MM-DD"
   var latestDate: String  // ISO date string "YYYY-MM-DD"
-  var prices: [String: Decimal]  // date string -> adjusted close price
+  var prices: SortedDateSeries<Decimal>  // DateKey -> adjusted close price
 }

--- a/MoolahTests/Backends/RateQueryPlanTests.swift
+++ b/MoolahTests/Backends/RateQueryPlanTests.swift
@@ -33,12 +33,16 @@ struct RateQueryPlanTests {
         database,
         sql: """
           EXPLAIN QUERY PLAN
-          SELECT * FROM exchange_rate WHERE base = ?
+          SELECT * FROM exchange_rate WHERE base = ? ORDER BY "date"
           """,
         arguments: ["AUD"]
       ).map { String(describing: $0["detail"] ?? "") }
       #expect(plan.contains { $0.contains("SEARCH") && $0.contains("PRIMARY KEY") })
       #expect(!plan.contains { $0.contains("SCAN") })
+      // `WHERE base = ? ORDER BY date` is a PK-prefix scan (PK is
+      // `(base, date, quote)`), so the planner satisfies the order
+      // directly from the index — no sort buffer.
+      #expect(!plan.contains { $0.contains("USE TEMP B-TREE") })
     }
   }
 
@@ -52,12 +56,16 @@ struct RateQueryPlanTests {
         database,
         sql: """
           EXPLAIN QUERY PLAN
-          SELECT * FROM stock_price WHERE ticker = ?
+          SELECT * FROM stock_price WHERE ticker = ? ORDER BY "date"
           """,
         arguments: ["BHP.AX"]
       ).map { String(describing: $0["detail"] ?? "") }
       #expect(plan.contains { $0.contains("SEARCH") && $0.contains("PRIMARY KEY") })
       #expect(!plan.contains { $0.contains("SCAN") })
+      // `WHERE ticker = ? ORDER BY date` is a PK-prefix scan (PK is
+      // `(ticker, date)`), so the planner satisfies the order directly
+      // from the index — no sort buffer.
+      #expect(!plan.contains { $0.contains("USE TEMP B-TREE") })
     }
   }
 
@@ -71,12 +79,16 @@ struct RateQueryPlanTests {
         database,
         sql: """
           EXPLAIN QUERY PLAN
-          SELECT * FROM crypto_price WHERE token_id = ?
+          SELECT * FROM crypto_price WHERE token_id = ? ORDER BY "date"
           """,
         arguments: ["1:native"]
       ).map { String(describing: $0["detail"] ?? "") }
       #expect(plan.contains { $0.contains("SEARCH") && $0.contains("PRIMARY KEY") })
       #expect(!plan.contains { $0.contains("SCAN") })
+      // `WHERE token_id = ? ORDER BY date` is a PK-prefix scan (PK is
+      // `(token_id, date)`), so the planner satisfies the order directly
+      // from the index — no sort buffer.
+      #expect(!plan.contains { $0.contains("USE TEMP B-TREE") })
     }
   }
 

--- a/MoolahTests/Backends/SharedRateQueryPlanTests.swift
+++ b/MoolahTests/Backends/SharedRateQueryPlanTests.swift
@@ -31,12 +31,16 @@ struct SharedRateQueryPlanTests {
         database,
         sql: """
           EXPLAIN QUERY PLAN
-          SELECT * FROM exchange_rate WHERE base = ?
+          SELECT * FROM exchange_rate WHERE base = ? ORDER BY "date"
           """,
         arguments: ["AUD"]
       ).map { String(describing: $0["detail"] ?? "") }
       #expect(plan.contains { $0.contains("SEARCH") && $0.contains("PRIMARY KEY") })
       #expect(!plan.contains { $0.contains("SCAN") })
+      // `WHERE base = ? ORDER BY date` is a PK-prefix scan (PK is
+      // `(base, date, quote)`), so the planner satisfies the order
+      // directly from the index — no sort buffer.
+      #expect(!plan.contains { $0.contains("USE TEMP B-TREE") })
       // The per-profile `exchange_rate_lookup` index is intentionally
       // omitted from the shared DB; assert the planner cannot reach
       // for it because it doesn't exist.
@@ -52,12 +56,16 @@ struct SharedRateQueryPlanTests {
         database,
         sql: """
           EXPLAIN QUERY PLAN
-          SELECT * FROM stock_price WHERE ticker = ?
+          SELECT * FROM stock_price WHERE ticker = ? ORDER BY "date"
           """,
         arguments: ["BHP.AX"]
       ).map { String(describing: $0["detail"] ?? "") }
       #expect(plan.contains { $0.contains("SEARCH") && $0.contains("PRIMARY KEY") })
       #expect(!plan.contains { $0.contains("SCAN") })
+      // `WHERE ticker = ? ORDER BY date` is a PK-prefix scan (PK is
+      // `(ticker, date)`), so the planner satisfies the order directly
+      // from the index — no sort buffer.
+      #expect(!plan.contains { $0.contains("USE TEMP B-TREE") })
     }
   }
 
@@ -69,12 +77,16 @@ struct SharedRateQueryPlanTests {
         database,
         sql: """
           EXPLAIN QUERY PLAN
-          SELECT * FROM crypto_price WHERE token_id = ?
+          SELECT * FROM crypto_price WHERE token_id = ? ORDER BY "date"
           """,
         arguments: ["1:native"]
       ).map { String(describing: $0["detail"] ?? "") }
       #expect(plan.contains { $0.contains("SEARCH") && $0.contains("PRIMARY KEY") })
       #expect(!plan.contains { $0.contains("SCAN") })
+      // `WHERE token_id = ? ORDER BY date` is a PK-prefix scan (PK is
+      // `(token_id, date)`), so the planner satisfies the order directly
+      // from the index — no sort buffer.
+      #expect(!plan.contains { $0.contains("USE TEMP B-TREE") })
     }
   }
 

--- a/MoolahTests/Shared/CryptoPriceServiceFallbackTests.swift
+++ b/MoolahTests/Shared/CryptoPriceServiceFallbackTests.swift
@@ -10,7 +10,8 @@ import Testing
 /// Mirrors the `CryptoPriceServiceCapTests` harness (`FixedCryptoPriceClient`
 /// + `ProfileIndexDatabase.openInMemory()` + injected `now` clock) — the
 /// real test double range-filters like the live providers do, so it is the
-/// faithful pin. Structure mirrors `StockPriceServiceFallbackTests`.
+/// faithful pin. Mirrors the intent/behaviour-matrix of
+/// `StockPriceServiceFallbackTests`.
 @Suite("CryptoPriceService fallback semantics")
 struct CryptoPriceServiceFallbackTests {
   private let ethInstrument = Instrument.crypto(

--- a/MoolahTests/Shared/CryptoPriceServiceFallbackTests.swift
+++ b/MoolahTests/Shared/CryptoPriceServiceFallbackTests.swift
@@ -1,0 +1,95 @@
+// MoolahTests/Shared/CryptoPriceServiceFallbackTests.swift
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+/// Behavior-preserving pin for the `CryptoPriceService` fallback semantics
+/// (exact / in-range gap-to-prior-day / post-latest / pre-history-throws).
+/// Mirrors the `CryptoPriceServiceCapTests` harness (`FixedCryptoPriceClient`
+/// + `ProfileIndexDatabase.openInMemory()` + injected `now` clock) — the
+/// real test double range-filters like the live providers do, so it is the
+/// faithful pin. Structure mirrors `StockPriceServiceFallbackTests`.
+@Suite("CryptoPriceService fallback semantics")
+struct CryptoPriceServiceFallbackTests {
+  private let ethInstrument = Instrument.crypto(
+    chainId: 1, contractAddress: nil, symbol: "ETH", name: "Ethereum", decimals: 18
+  )
+  private let ethMapping = CryptoProviderMapping(
+    instrumentId: "1:native", coingeckoId: "ethereum",
+    cryptocompareSymbol: "ETH", binanceSymbol: "ETHUSDT"
+  )
+
+  private func date(_ string: String) throws -> Date {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withFullDate]
+    return try #require(formatter.date(from: string))
+  }
+
+  private func makeService(
+    _ tokenPrices: [String: Decimal],
+    now: @Sendable @escaping () -> Date
+  ) throws -> CryptoPriceService {
+    let database = try ProfileIndexDatabase.openInMemory()
+    let client = FixedCryptoPriceClient(prices: ["1:native": tokenPrices], shouldFail: false)
+    return CryptoPriceService(
+      clients: [client],
+      database: database,
+      resolutionClient: nil,
+      now: now)
+  }
+
+  /// `exact` returns that day's price; an in-range gap (a date with no row,
+  /// bracketed by cached dates) falls back to the most recent prior cached
+  /// price; a post-latest date resolves to the latest cached price (the
+  /// service caps the fetch at yesterday).
+  @Test("exact, in-range gap (prior day), and post-latest all resolve")
+  func behaviorMatrix() async throws {
+    let frozen = try date("2024-02-01")
+    let svc = try makeService(
+      [
+        "2024-01-15": dec("10"),
+        "2024-01-16": dec("11"),
+        "2024-01-20": dec("12"),
+      ],
+      now: { frozen })
+
+    // Seed the cache by requesting the latest date first: the cold-cache
+    // extension window is a 30-day window ending at the requested date, so
+    // requesting 2024-01-20 pulls all three rows into the cache and pins
+    // earliestDate=2024-01-15 / latestDate=2024-01-20.
+    let latest = try await svc.price(
+      for: ethInstrument, mapping: ethMapping, on: try date("2024-01-20"))
+    #expect(latest == dec("12"))  // exact (latest)
+
+    let exact = try await svc.price(
+      for: ethInstrument, mapping: ethMapping, on: try date("2024-01-16"))
+    #expect(exact == dec("11"))  // exact
+
+    // True in-range gap: 2024-01-18 has no row but sits strictly between
+    // cached 2024-01-16 and 2024-01-20 — falls back to the prior day.
+    let gap = try await svc.price(
+      for: ethInstrument, mapping: ethMapping, on: try date("2024-01-18"))
+    #expect(gap == dec("11"))  // in-range gap → most recent prior cached price
+
+    // Post-latest: 2024-01-31 is after the latest cached row; the service
+    // caps the fetch at yesterday so it resolves to the latest cached price.
+    let postLatest = try await svc.price(
+      for: ethInstrument, mapping: ethMapping, on: try date("2024-01-31"))
+    #expect(postLatest == dec("12"))  // post-latest
+  }
+
+  @Test("pre-history date has no fallback")
+  func preHistory() async throws {
+    let frozen = try date("2024-02-01")
+    let svc = try makeService(["2024-01-15": dec("10")], now: { frozen })
+    _ = try await svc.price(
+      for: ethInstrument, mapping: ethMapping, on: try date("2024-01-15"))
+    let preHistoryDate = try date("2024-01-01")
+    await #expect(throws: (any Error).self) {
+      _ = try await svc.price(
+        for: ethInstrument, mapping: ethMapping, on: preHistoryDate)
+    }
+  }
+}

--- a/MoolahTests/Shared/DateKeyTests.swift
+++ b/MoolahTests/Shared/DateKeyTests.swift
@@ -1,0 +1,29 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("DateKey")
+struct DateKeyTests {
+  @Test("iso string round-trips through Int32 yyyymmdd")
+  func roundTrip() {
+    #expect(DateKey.from(isoString: "2024-01-15") == 20_240_115)
+    #expect(DateKey.from(isoString: "1999-12-31") == 19_991_231)
+    #expect(DateKey.isoString(20_240_115) == "2024-01-15")
+    #expect(DateKey.isoString(19_991_231) == "1999-12-31")
+  }
+
+  @Test("malformed iso string returns nil")
+  func malformed() {
+    #expect(DateKey.from(isoString: "not-a-date") == nil)
+    #expect(DateKey.from(isoString: "2024-13") == nil)
+    #expect(DateKey.from(isoString: "") == nil)
+  }
+
+  @Test("yyyymmdd integer order equals chronological order")
+  func ordering() {
+    let a = DateKey.from(isoString: "2023-12-31")!
+    let b = DateKey.from(isoString: "2024-01-01")!
+    #expect(a < b)
+  }
+}

--- a/MoolahTests/Shared/DateKeyTests.swift
+++ b/MoolahTests/Shared/DateKeyTests.swift
@@ -21,9 +21,9 @@ struct DateKeyTests {
   }
 
   @Test("yyyymmdd integer order equals chronological order")
-  func ordering() {
-    let a = DateKey.from(isoString: "2023-12-31")!
-    let b = DateKey.from(isoString: "2024-01-01")!
-    #expect(a < b)
+  func ordering() throws {
+    let dec31 = try #require(DateKey.from(isoString: "2023-12-31"))
+    let jan01 = try #require(DateKey.from(isoString: "2024-01-01"))
+    #expect(dec31 < jan01)
   }
 }

--- a/MoolahTests/Shared/ExchangeRateServiceFallbackTests.swift
+++ b/MoolahTests/Shared/ExchangeRateServiceFallbackTests.swift
@@ -23,8 +23,10 @@ struct ExchangeRateServiceFallbackTests {
   private func date(_ string: String) -> Date {
     let formatter = ISO8601DateFormatter()
     formatter.formatOptions = [.withFullDate]
-    // swiftlint:disable:next force_unwrapping
-    return formatter.date(from: string)!
+    guard let result = formatter.date(from: string) else {
+      preconditionFailure("Invalid ISO date literal: \(string)")
+    }
+    return result
   }
 
   @Test("exact / gap / post-latest match prior-implementation semantics")
@@ -51,8 +53,7 @@ struct ExchangeRateServiceFallbackTests {
   /// Pins the IN-RANGE gap branch: a queried date that sits strictly
   /// between the cache's `earliestDate` and `latestDate` but is itself
   /// absent must be served from `fallbackRate` WITHOUT a network fetch
-  /// (the day-step `floorKey` probe loop in the rewrite; the
-  /// `keys.sorted().reversed()` scan in the original). Seeding mirrors
+  /// (the day-step `floorKey` probe loop). Seeding mirrors
   /// the sibling `ExchangeRateServiceTests.inRangeMissUsesFallback...`:
   /// prime two dates that bracket a deliberate hole so the cached range
   /// spans the gap, then query the hole. The unchanged `fetchCount`

--- a/MoolahTests/Shared/ExchangeRateServiceFallbackTests.swift
+++ b/MoolahTests/Shared/ExchangeRateServiceFallbackTests.swift
@@ -1,0 +1,63 @@
+// MoolahTests/Shared/ExchangeRateServiceFallbackTests.swift
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+/// Pins the exact / gap / post-latest / identity / pre-history semantics of
+/// `ExchangeRateService` so the `SortedDateSeries` migration is provably
+/// behavior-preserving. Mirrors the real FX test harness
+/// (`FixedRateClient` + `ProfileIndexDatabase.openInMemory()`).
+@Suite("ExchangeRateService fallback semantics")
+struct ExchangeRateServiceFallbackTests {
+  private func makeService(
+    _ rates: [String: [String: Decimal]]
+  ) throws -> ExchangeRateService {
+    let client = FixedRateClient(rates: rates)
+    let database = try ProfileIndexDatabase.openInMemory()
+    return ExchangeRateService(
+      client: client, database: database, now: { self.date("2024-02-01") })
+  }
+
+  private func date(_ string: String) -> Date {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withFullDate]
+    // swiftlint:disable:next force_unwrapping
+    return formatter.date(from: string)!
+  }
+
+  @Test("exact / gap / post-latest match prior-implementation semantics")
+  func behaviorMatrix() async throws {
+    let usd = Instrument.fiat(code: "USD")
+    let aud = Instrument.fiat(code: "AUD")
+    let service = try makeService([
+      "2024-01-15": ["AUD": dec("1.50")],
+      "2024-01-16": ["AUD": dec("1.51")],
+      "2024-01-17": ["AUD": dec("1.52")],
+    ])
+    _ = try await service.rate(from: usd, to: aud, on: date("2024-01-17"))
+    #expect(
+      try await service.rate(from: usd, to: aud, on: date("2024-01-16"))
+        == dec("1.51"))
+    #expect(
+      try await service.rate(from: usd, to: aud, on: date("2024-01-20"))
+        == dec("1.52"))
+    #expect(
+      try await service.rate(from: usd, to: aud, on: date("2024-01-31"))
+        == dec("1.52"))
+  }
+
+  @Test("identity rate is 1 and pre-history throws")
+  func identityAndPreHistory() async throws {
+    let usd = Instrument.fiat(code: "USD")
+    let aud = Instrument.fiat(code: "AUD")
+    let service = try makeService(["2024-01-15": ["AUD": dec("1.50")]])
+    #expect(
+      try await service.rate(from: usd, to: usd, on: date("2024-01-15")) == 1)
+    _ = try await service.rate(from: usd, to: aud, on: date("2024-01-15"))
+    await #expect(throws: (any Error).self) {
+      _ = try await service.rate(from: usd, to: aud, on: self.date("2024-01-01"))
+    }
+  }
+}

--- a/MoolahTests/Shared/ExchangeRateServiceFallbackTests.swift
+++ b/MoolahTests/Shared/ExchangeRateServiceFallbackTests.swift
@@ -48,6 +48,48 @@ struct ExchangeRateServiceFallbackTests {
         == dec("1.52"))
   }
 
+  /// Pins the IN-RANGE gap branch: a queried date that sits strictly
+  /// between the cache's `earliestDate` and `latestDate` but is itself
+  /// absent must be served from `fallbackRate` WITHOUT a network fetch
+  /// (the day-step `floorKey` probe loop in the rewrite; the
+  /// `keys.sorted().reversed()` scan in the original). Seeding mirrors
+  /// the sibling `ExchangeRateServiceTests.inRangeMissUsesFallback...`:
+  /// prime two dates that bracket a deliberate hole so the cached range
+  /// spans the gap, then query the hole. The unchanged `fetchCount`
+  /// after the gap query is the proof the in-range short-circuit
+  /// (`dateString >= earliestDate && <= latestDate`) fired rather than
+  /// the post-latest extension/fetch path.
+  @Test("in-range gap resolves via fallback without fetching")
+  func inRangeGapUsesFallback() async throws {
+    let usd = Instrument.fiat(code: "USD")
+    let aud = Instrument.fiat(code: "AUD")
+    let client = CountingRateClient(
+      FixedRateClient(rates: [
+        "2024-01-15": ["AUD": dec("1.50")],
+        "2024-01-17": ["AUD": dec("1.52")],
+      ]))
+    let database = try ProfileIndexDatabase.openInMemory()
+    let service = ExchangeRateService(
+      client: client, database: database, now: { self.date("2024-02-01") })
+
+    // Prime so the cached range brackets the hole: 2024-01-15 (cold
+    // surrounding fetch) then 2024-01-17 (forward extension). 2024-01-16
+    // is never seeded, so earliestDate == "2024-01-15" and
+    // latestDate == "2024-01-17" with no row for the middle day.
+    _ = try await service.rate(from: usd, to: aud, on: date("2024-01-15"))
+    _ = try await service.rate(from: usd, to: aud, on: date("2024-01-17"))
+    let primedFetches = client.fetchCount
+
+    // 2024-01-16 is strictly inside ["2024-01-15", "2024-01-17"]. The
+    // exact tuple is absent; the in-range short-circuit resolves it to
+    // the newest cached day <= target carrying AUD, i.e. 2024-01-15.
+    let gapRate = try await service.rate(
+      from: usd, to: aud, on: date("2024-01-16"))
+
+    #expect(gapRate == dec("1.50"))
+    #expect(client.fetchCount == primedFetches)
+  }
+
   @Test("identity rate is 1 and pre-history throws")
   func identityAndPreHistory() async throws {
     let usd = Instrument.fiat(code: "USD")

--- a/MoolahTests/Shared/SortedDateSeriesTests.swift
+++ b/MoolahTests/Shared/SortedDateSeriesTests.swift
@@ -3,13 +3,13 @@ import Testing
 
 @testable import Moolah
 
-@Suite("SortedDateSeries")
+@Suite("SortedDateSeries", .serialized)
 struct SortedDateSeriesTests {
   @Test("exact returns the value only for an exact key match")
   func exact() {
     var series = SortedDateSeries<Int>()
-    series.upsert(20_240_101, 1)
-    series.upsert(20_240_103, 3)
+    series.upsert(1, forKey: 20_240_101)
+    series.upsert(3, forKey: 20_240_103)
     #expect(series.exact(20_240_101) == 1)
     #expect(series.exact(20_240_103) == 3)
     #expect(series.exact(20_240_102) == nil)
@@ -18,9 +18,9 @@ struct SortedDateSeriesTests {
   @Test("floor returns the newest entry on or before the key")
   func floor() {
     var series = SortedDateSeries<Int>()
-    series.upsert(20_240_101, 1)
-    series.upsert(20_240_105, 5)
-    series.upsert(20_240_110, 10)
+    series.upsert(1, forKey: 20_240_101)
+    series.upsert(5, forKey: 20_240_105)
+    series.upsert(10, forKey: 20_240_110)
     #expect(series.floor(20_240_100) == nil)  // before first
     #expect(series.floor(20_240_101) == 1)  // exact
     #expect(series.floor(20_240_107) == 5)  // gap → prior
@@ -30,9 +30,9 @@ struct SortedDateSeriesTests {
   @Test("upsert keeps entries sorted and replaces duplicates")
   func upsertReplaces() {
     var series = SortedDateSeries<Int>()
-    series.upsert(20_240_103, 3)
-    series.upsert(20_240_101, 1)
-    series.upsert(20_240_103, 33)  // replace
+    series.upsert(3, forKey: 20_240_103)
+    series.upsert(1, forKey: 20_240_101)
+    series.upsert(33, forKey: 20_240_103)  // replace
     #expect(series.sortedKeys == [20_240_101, 20_240_103])
     #expect(series.exact(20_240_103) == 33)
   }
@@ -50,8 +50,8 @@ struct SortedDateSeriesTests {
   func bounds() {
     var series = SortedDateSeries<Int>()
     #expect(series.isEmpty)
-    series.upsert(20_240_105, 5)
-    series.upsert(20_240_101, 1)
+    series.upsert(5, forKey: 20_240_105)
+    series.upsert(1, forKey: 20_240_101)
     #expect(series.first?.key == 20_240_101)
     #expect(series.last?.key == 20_240_105)
     #expect(!series.isEmpty)
@@ -60,7 +60,7 @@ struct SortedDateSeriesTests {
   @Test("plan-pin: floor does not scan linearly")
   func floorIsLogarithmic() {
     var series = SortedDateSeries<Int>()
-    for offset in 0..<4_000 { series.upsert(Int32(20_000_000 + offset), offset) }
+    for offset in 0..<4_000 { series.upsert(offset, forKey: Int32(20_000_000 + offset)) }
     SortedDateSeries<Int>.probeCount = 0
     // 1,000 mixed queries (gaps + exacts) over a 4,000-entry series.
     for query in 0..<1_000 { _ = series.floor(Int32(20_000_000 + query * 4)) }
@@ -72,8 +72,8 @@ struct SortedDateSeriesTests {
   @Test("Codable round-trips")
   func codable() throws {
     var series = SortedDateSeries<Int>()
-    series.upsert(20_240_101, 1)
-    series.upsert(20_240_103, 3)
+    series.upsert(1, forKey: 20_240_101)
+    series.upsert(3, forKey: 20_240_103)
     let data = try JSONEncoder().encode(series)
     let back = try JSONDecoder().decode(SortedDateSeries<Int>.self, from: data)
     #expect(back == series)

--- a/MoolahTests/Shared/SortedDateSeriesTests.swift
+++ b/MoolahTests/Shared/SortedDateSeriesTests.swift
@@ -1,0 +1,81 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("SortedDateSeries")
+struct SortedDateSeriesTests {
+  @Test("exact returns the value only for an exact key match")
+  func exact() {
+    var s = SortedDateSeries<Int>()
+    s.upsert(20_240_101, 1)
+    s.upsert(20_240_103, 3)
+    #expect(s.exact(20_240_101) == 1)
+    #expect(s.exact(20_240_103) == 3)
+    #expect(s.exact(20_240_102) == nil)
+  }
+
+  @Test("floor returns the newest entry on or before the key")
+  func floor() {
+    var s = SortedDateSeries<Int>()
+    s.upsert(20_240_101, 1)
+    s.upsert(20_240_105, 5)
+    s.upsert(20_240_110, 10)
+    #expect(s.floor(20_240_100) == nil)  // before first
+    #expect(s.floor(20_240_101) == 1)  // exact
+    #expect(s.floor(20_240_107) == 5)  // gap → prior
+    #expect(s.floor(20_240_999) == 10)  // after last → last
+  }
+
+  @Test("upsert keeps entries sorted and replaces duplicates")
+  func upsertReplaces() {
+    var s = SortedDateSeries<Int>()
+    s.upsert(20_240_103, 3)
+    s.upsert(20_240_101, 1)
+    s.upsert(20_240_103, 33)  // replace
+    #expect(s.sortedKeys == [20_240_101, 20_240_103])
+    #expect(s.exact(20_240_103) == 33)
+  }
+
+  @Test("init(unsorted:) sorts and de-duplicates last-wins")
+  func initUnsorted() {
+    let s = SortedDateSeries<Int>(unsorted: [
+      (20_240_103, 3), (20_240_101, 1), (20_240_103, 33),
+    ])
+    #expect(s.sortedKeys == [20_240_101, 20_240_103])
+    #expect(s.exact(20_240_103) == 33)
+  }
+
+  @Test("first/last/isEmpty")
+  func bounds() {
+    var s = SortedDateSeries<Int>()
+    #expect(s.isEmpty)
+    s.upsert(20_240_105, 5)
+    s.upsert(20_240_101, 1)
+    #expect(s.first?.key == 20_240_101)
+    #expect(s.last?.key == 20_240_105)
+    #expect(!s.isEmpty)
+  }
+
+  @Test("plan-pin: floor does not scan linearly")
+  func floorIsLogarithmic() {
+    var s = SortedDateSeries<Int>()
+    for d in 0..<4_000 { s.upsert(Int32(20_000_000 + d), d) }
+    SortedDateSeries<Int>.probeCount = 0
+    // 1,000 mixed queries (gaps + exacts) over a 4,000-entry series.
+    for q in 0..<1_000 { _ = s.floor(Int32(20_000_000 + q * 4)) }
+    // Linear-scan-after-sort would be >> 1_000 * 4_000 probes. A binary
+    // search is ~1_000 * ceil(log2(4_000)) ≈ 12_000. Cap generously.
+    #expect(SortedDateSeries<Int>.probeCount < 40_000)
+  }
+
+  @Test("Codable round-trips")
+  func codable() throws {
+    var s = SortedDateSeries<Int>()
+    s.upsert(20_240_101, 1)
+    s.upsert(20_240_103, 3)
+    let data = try JSONEncoder().encode(s)
+    let back = try JSONDecoder().decode(SortedDateSeries<Int>.self, from: data)
+    #expect(back == s)
+  }
+}

--- a/MoolahTests/Shared/SortedDateSeriesTests.swift
+++ b/MoolahTests/Shared/SortedDateSeriesTests.swift
@@ -7,63 +7,63 @@ import Testing
 struct SortedDateSeriesTests {
   @Test("exact returns the value only for an exact key match")
   func exact() {
-    var s = SortedDateSeries<Int>()
-    s.upsert(20_240_101, 1)
-    s.upsert(20_240_103, 3)
-    #expect(s.exact(20_240_101) == 1)
-    #expect(s.exact(20_240_103) == 3)
-    #expect(s.exact(20_240_102) == nil)
+    var series = SortedDateSeries<Int>()
+    series.upsert(20_240_101, 1)
+    series.upsert(20_240_103, 3)
+    #expect(series.exact(20_240_101) == 1)
+    #expect(series.exact(20_240_103) == 3)
+    #expect(series.exact(20_240_102) == nil)
   }
 
   @Test("floor returns the newest entry on or before the key")
   func floor() {
-    var s = SortedDateSeries<Int>()
-    s.upsert(20_240_101, 1)
-    s.upsert(20_240_105, 5)
-    s.upsert(20_240_110, 10)
-    #expect(s.floor(20_240_100) == nil)  // before first
-    #expect(s.floor(20_240_101) == 1)  // exact
-    #expect(s.floor(20_240_107) == 5)  // gap → prior
-    #expect(s.floor(20_240_999) == 10)  // after last → last
+    var series = SortedDateSeries<Int>()
+    series.upsert(20_240_101, 1)
+    series.upsert(20_240_105, 5)
+    series.upsert(20_240_110, 10)
+    #expect(series.floor(20_240_100) == nil)  // before first
+    #expect(series.floor(20_240_101) == 1)  // exact
+    #expect(series.floor(20_240_107) == 5)  // gap → prior
+    #expect(series.floor(20_240_999) == 10)  // after last → last
   }
 
   @Test("upsert keeps entries sorted and replaces duplicates")
   func upsertReplaces() {
-    var s = SortedDateSeries<Int>()
-    s.upsert(20_240_103, 3)
-    s.upsert(20_240_101, 1)
-    s.upsert(20_240_103, 33)  // replace
-    #expect(s.sortedKeys == [20_240_101, 20_240_103])
-    #expect(s.exact(20_240_103) == 33)
+    var series = SortedDateSeries<Int>()
+    series.upsert(20_240_103, 3)
+    series.upsert(20_240_101, 1)
+    series.upsert(20_240_103, 33)  // replace
+    #expect(series.sortedKeys == [20_240_101, 20_240_103])
+    #expect(series.exact(20_240_103) == 33)
   }
 
   @Test("init(unsorted:) sorts and de-duplicates last-wins")
   func initUnsorted() {
-    let s = SortedDateSeries<Int>(unsorted: [
+    let series = SortedDateSeries<Int>(unsorted: [
       (20_240_103, 3), (20_240_101, 1), (20_240_103, 33),
     ])
-    #expect(s.sortedKeys == [20_240_101, 20_240_103])
-    #expect(s.exact(20_240_103) == 33)
+    #expect(series.sortedKeys == [20_240_101, 20_240_103])
+    #expect(series.exact(20_240_103) == 33)
   }
 
   @Test("first/last/isEmpty")
   func bounds() {
-    var s = SortedDateSeries<Int>()
-    #expect(s.isEmpty)
-    s.upsert(20_240_105, 5)
-    s.upsert(20_240_101, 1)
-    #expect(s.first?.key == 20_240_101)
-    #expect(s.last?.key == 20_240_105)
-    #expect(!s.isEmpty)
+    var series = SortedDateSeries<Int>()
+    #expect(series.isEmpty)
+    series.upsert(20_240_105, 5)
+    series.upsert(20_240_101, 1)
+    #expect(series.first?.key == 20_240_101)
+    #expect(series.last?.key == 20_240_105)
+    #expect(!series.isEmpty)
   }
 
   @Test("plan-pin: floor does not scan linearly")
   func floorIsLogarithmic() {
-    var s = SortedDateSeries<Int>()
-    for d in 0..<4_000 { s.upsert(Int32(20_000_000 + d), d) }
+    var series = SortedDateSeries<Int>()
+    for offset in 0..<4_000 { series.upsert(Int32(20_000_000 + offset), offset) }
     SortedDateSeries<Int>.probeCount = 0
     // 1,000 mixed queries (gaps + exacts) over a 4,000-entry series.
-    for q in 0..<1_000 { _ = s.floor(Int32(20_000_000 + q * 4)) }
+    for query in 0..<1_000 { _ = series.floor(Int32(20_000_000 + query * 4)) }
     // Linear-scan-after-sort would be >> 1_000 * 4_000 probes. A binary
     // search is ~1_000 * ceil(log2(4_000)) ≈ 12_000. Cap generously.
     #expect(SortedDateSeries<Int>.probeCount < 40_000)
@@ -71,11 +71,19 @@ struct SortedDateSeriesTests {
 
   @Test("Codable round-trips")
   func codable() throws {
-    var s = SortedDateSeries<Int>()
-    s.upsert(20_240_101, 1)
-    s.upsert(20_240_103, 3)
-    let data = try JSONEncoder().encode(s)
+    var series = SortedDateSeries<Int>()
+    series.upsert(20_240_101, 1)
+    series.upsert(20_240_103, 3)
+    let data = try JSONEncoder().encode(series)
     let back = try JSONDecoder().decode(SortedDateSeries<Int>.self, from: data)
-    #expect(back == s)
+    #expect(back == series)
+  }
+
+  @Test("empty series returns nil for all lookup methods")
+  func emptySeriesLookup() {
+    let series = SortedDateSeries<Int>()
+    #expect(series.exact(20_240_101) == nil)
+    #expect(series.floor(20_240_101) == nil)
+    #expect(series.floorKey(20_240_101) == nil)
   }
 }

--- a/MoolahTests/Shared/StockPriceServiceFallbackTests.swift
+++ b/MoolahTests/Shared/StockPriceServiceFallbackTests.swift
@@ -13,21 +13,23 @@ import Testing
 /// range-filters like Yahoo does, so it is the more faithful pin.
 @Suite("StockPriceService fallback semantics")
 struct StockPriceServiceFallbackTests {
+  nonisolated(unsafe) private static let isoFormatter: ISO8601DateFormatter = {
+    let fmt = ISO8601DateFormatter()
+    fmt.formatOptions = [.withFullDate]
+    return fmt
+  }()
+
   /// Non-throwing parse used for the pinned `now` clock. The ISO literals
   /// here are compile-time constants; a `nil` is a programmer error.
   private static func parse(_ iso: String) -> Date {
-    let formatter = ISO8601DateFormatter()
-    formatter.formatOptions = [.withFullDate]
-    guard let result = formatter.date(from: iso) else {
+    guard let result = isoFormatter.date(from: iso) else {
       preconditionFailure("Invalid ISO date literal: \(iso)")
     }
     return result
   }
 
   private func date(_ iso: String) throws -> Date {
-    let formatter = ISO8601DateFormatter()
-    formatter.formatOptions = [.withFullDate]
-    return try #require(formatter.date(from: iso))
+    try #require(Self.isoFormatter.date(from: iso))
   }
 
   private func makeService(_ prices: [String: Decimal]) throws -> StockPriceService {

--- a/MoolahTests/Shared/StockPriceServiceFallbackTests.swift
+++ b/MoolahTests/Shared/StockPriceServiceFallbackTests.swift
@@ -1,0 +1,70 @@
+// MoolahTests/Shared/StockPriceServiceFallbackTests.swift
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+/// Behavior-preserving pin for the `StockPriceService` fallback semantics
+/// (exact / gap-to-prior-trading-day / post-latest / pre-history-throws).
+/// Mirrors the `StockPriceServiceTests` harness (`FixedStockPriceClient` +
+/// `ProfileIndexDatabase.openInMemory()`); the plan's inline stub returned
+/// the whole series regardless of range, but the real test double
+/// range-filters like Yahoo does, so it is the more faithful pin.
+@Suite("StockPriceService fallback semantics")
+struct StockPriceServiceFallbackTests {
+  /// Non-throwing parse used for the pinned `now` clock. The ISO literals
+  /// here are compile-time constants; a `nil` is a programmer error.
+  private static func parse(_ iso: String) -> Date {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withFullDate]
+    guard let result = formatter.date(from: iso) else {
+      preconditionFailure("Invalid ISO date literal: \(iso)")
+    }
+    return result
+  }
+
+  private func date(_ iso: String) throws -> Date {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withFullDate]
+    return try #require(formatter.date(from: iso))
+  }
+
+  private func makeService(_ prices: [String: Decimal]) throws -> StockPriceService {
+    let database = try ProfileIndexDatabase.openInMemory()
+    let client = FixedStockPriceClient(
+      responses: ["BHP.AX": StockPriceResponse(instrument: .AUD, prices: prices)]
+    )
+    return StockPriceService(
+      client: client,
+      database: database,
+      now: { Self.parse("2024-02-01") }
+    )
+  }
+
+  @Test("exact, gap (prior trading day), and post-latest all resolve")
+  func behaviorMatrix() async throws {
+    let svc = try makeService([
+      "2024-01-15": dec("10"),
+      "2024-01-16": dec("11"),
+      "2024-01-17": dec("12"),
+    ])
+    _ = try await svc.price(ticker: "BHP.AX", on: try date("2024-01-17"))  // seed
+    let exact = try await svc.price(ticker: "BHP.AX", on: try date("2024-01-16"))
+    #expect(exact == dec("11"))  // exact
+    let gap = try await svc.price(ticker: "BHP.AX", on: try date("2024-01-20"))
+    #expect(gap == dec("12"))  // gap (prior trading day)
+    let postLatest = try await svc.price(ticker: "BHP.AX", on: try date("2024-01-31"))
+    #expect(postLatest == dec("12"))  // post-latest
+  }
+
+  @Test("pre-history date has no fallback")
+  func preHistory() async throws {
+    let svc = try makeService(["2024-01-15": dec("10")])
+    _ = try await svc.price(ticker: "BHP.AX", on: try date("2024-01-15"))
+    let preHistoryDate = try date("2024-01-01")
+    await #expect(throws: (any Error).self) {
+      _ = try await svc.price(ticker: "BHP.AX", on: preHistoryDate)
+    }
+  }
+}

--- a/Shared/CryptoPriceService+Merge.swift
+++ b/Shared/CryptoPriceService+Merge.swift
@@ -18,8 +18,7 @@ extension CryptoPriceService {
     tokenId: String, symbol: String, newPrices: [String: Decimal]
   ) -> [CryptoPriceRecord] {
     guard !newPrices.isEmpty else { return [] }
-    let sortedDates = newPrices.keys.sorted()
-    guard let earliest = sortedDates.first, let latest = sortedDates.last else { return [] }
+    guard let earliest = newPrices.keys.min(), let latest = newPrices.keys.max() else { return [] }
 
     var deltaRecords: [CryptoPriceRecord] = []
 
@@ -28,7 +27,7 @@ extension CryptoPriceService {
         guard let key = DateKey.from(isoString: dateKey) else { continue }  // malformed wire date — unusable as a sorted key; skip
         if existing.prices.exact(key) != price {
           deltaRecords.append(priceRecord(tokenId: tokenId, date: dateKey, price: price))
-          existing.prices.upsert(key, price)
+          existing.prices.upsert(price, forKey: key)
         }
       }
       if earliest < existing.earliestDate {
@@ -42,7 +41,7 @@ extension CryptoPriceService {
       var series = SortedDateSeries<Decimal>()
       for (dateKey, price) in newPrices {
         guard let key = DateKey.from(isoString: dateKey) else { continue }  // malformed wire date — unusable as a sorted key; skip
-        series.upsert(key, price)
+        series.upsert(price, forKey: key)
         deltaRecords.append(priceRecord(tokenId: tokenId, date: dateKey, price: price))
       }
       caches[tokenId] = CryptoPriceCache(

--- a/Shared/CryptoPriceService+Merge.swift
+++ b/Shared/CryptoPriceService+Merge.swift
@@ -24,9 +24,12 @@ extension CryptoPriceService {
     var deltaRecords: [CryptoPriceRecord] = []
 
     if var existing = caches[tokenId] {
-      for (dateKey, price) in newPrices where existing.prices[dateKey] != price {
-        deltaRecords.append(priceRecord(tokenId: tokenId, date: dateKey, price: price))
-        existing.prices[dateKey] = price
+      for (dateKey, price) in newPrices {
+        guard let key = DateKey.from(isoString: dateKey) else { continue }  // malformed wire date — unusable as a sorted key; skip
+        if existing.prices.exact(key) != price {
+          deltaRecords.append(priceRecord(tokenId: tokenId, date: dateKey, price: price))
+          existing.prices.upsert(key, price)
+        }
       }
       if earliest < existing.earliestDate {
         existing.earliestDate = earliest
@@ -36,16 +39,19 @@ extension CryptoPriceService {
       }
       caches[tokenId] = existing
     } else {
+      var series = SortedDateSeries<Decimal>()
+      for (dateKey, price) in newPrices {
+        guard let key = DateKey.from(isoString: dateKey) else { continue }  // malformed wire date — unusable as a sorted key; skip
+        series.upsert(key, price)
+        deltaRecords.append(priceRecord(tokenId: tokenId, date: dateKey, price: price))
+      }
       caches[tokenId] = CryptoPriceCache(
         tokenId: tokenId,
         symbol: symbol,
         earliestDate: earliest,
         latestDate: latest,
-        prices: newPrices
+        prices: series
       )
-      for (dateKey, price) in newPrices {
-        deltaRecords.append(priceRecord(tokenId: tokenId, date: dateKey, price: price))
-      }
     }
 
     return deltaRecords

--- a/Shared/CryptoPriceService+Persistence.swift
+++ b/Shared/CryptoPriceService+Persistence.swift
@@ -24,20 +24,24 @@ extension CryptoPriceService {
       let priceRecords =
         try CryptoPriceRecord
         .filter(CryptoPriceRecord.Columns.tokenId == tokenId)
+        .order(CryptoPriceRecord.Columns.date)
         .fetchAll(database)
       // See `ExchangeRateService.loadCache` for the rationale on the
       // String-via-Decimal round-trip; preserves source precision instead
       // of inheriting the binary `Decimal(_: Double)` tail.
-      var prices: [String: Decimal] = [:]
+      var entries: [SortedDateSeries<Decimal>.Entry] = []
+      entries.reserveCapacity(priceRecords.count)
       for record in priceRecords {
-        prices[record.date] = Decimal(string: String(record.priceUsd)) ?? Decimal(record.priceUsd)
+        guard let key = DateKey.from(isoString: record.date) else { continue }  // malformed wire date — unusable as a sorted key; skip
+        let value = Decimal(string: String(record.priceUsd)) ?? Decimal(record.priceUsd)
+        entries.append(.init(key: key, value: value))
       }
       return CryptoPriceCache(
         tokenId: tokenId,
         symbol: metaRecord.symbol,
         earliestDate: metaRecord.earliestDate,
         latestDate: metaRecord.latestDate,
-        prices: prices
+        prices: SortedDateSeries(sortedEntries: entries)
       )
     }
     if let snapshot { caches[tokenId] = snapshot }

--- a/Shared/CryptoPriceService+Persistence.swift
+++ b/Shared/CryptoPriceService+Persistence.swift
@@ -29,6 +29,7 @@ extension CryptoPriceService {
       // See `ExchangeRateService.loadCache` for the rationale on the
       // String-via-Decimal round-trip; preserves source precision instead
       // of inheriting the binary `Decimal(_: Double)` tail.
+      // `.order(date)` ascending satisfies `init(sortedEntries:)`.
       var entries: [SortedDateSeries<Decimal>.Entry] = []
       entries.reserveCapacity(priceRecords.count)
       for record in priceRecords {

--- a/Shared/CryptoPriceService.swift
+++ b/Shared/CryptoPriceService.swift
@@ -282,7 +282,9 @@ actor CryptoPriceService {
 
     for date in dates {
       let dateString = dateFormatter.string(from: date)
-      if let price = caches[tokenId]?.prices[dateString] {
+      if let key = DateKey.from(isoString: dateString),
+        let price = caches[tokenId]?.prices.exact(key)
+      {
         lastKnownPrice = price
         results.append((date, price))
       } else if let fallback = lastKnownPrice {
@@ -339,16 +341,15 @@ actor CryptoPriceService {
 
 extension CryptoPriceService {
   private func lookupPrice(tokenId: String, dateString: String) -> Decimal? {
-    caches[tokenId]?.prices[dateString]
+    guard let key = DateKey.from(isoString: dateString) else { return nil }
+    return caches[tokenId]?.prices.exact(key)
   }
 
   private func fallbackPrice(tokenId: String, dateString: String) -> Decimal? {
-    guard let cache = caches[tokenId] else { return nil }
-    let sortedDates = cache.prices.keys.sorted().reversed()
-    for cachedDate in sortedDates where cachedDate <= dateString {
-      return cache.prices[cachedDate]
-    }
-    return nil
+    guard let key = DateKey.from(isoString: dateString),
+      let cache = caches[tokenId]
+    else { return nil }
+    return cache.prices.floor(key)
   }
 
   private func generateDateSeries(in range: ClosedRange<Date>) -> [Date] {

--- a/Shared/DateKey.swift
+++ b/Shared/DateKey.swift
@@ -25,10 +25,10 @@ enum DateKey {
 
   /// Formats `yyyymmdd` back into a zero-padded `"YYYY-MM-DD"` string.
   static func isoString(_ key: Int32) -> String {
-    let v = Int(key)
-    let year = v / 10_000
-    let month = (v / 100) % 100
-    let day = v % 100
+    let raw = Int(key)
+    let year = raw / 10_000
+    let month = (raw / 100) % 100
+    let day = raw % 100
     return String(format: "%04d-%02d-%02d", year, month, day)
   }
 }

--- a/Shared/DateKey.swift
+++ b/Shared/DateKey.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+/// Compact comparable date key: a `yyyymmdd` `Int32` (e.g. `2024-01-15`
+/// → `20240115`). Integer ordering equals chronological ordering, so a
+/// binary search over `Int32` keys is correct. Used by the price/rate
+/// caches instead of `"YYYY-MM-DD"` `String` keys: ~12 bytes smaller per
+/// entry and integer-fast comparisons.
+///
+/// Conversion goes through the existing ISO `"YYYY-MM-DD"` string the
+/// services already compute (`ISO8601DateFormatter` `.withFullDate`,
+/// UTC), so day bucketing is identical to the previous behaviour — no
+/// timezone/calendar re-derivation.
+enum DateKey {
+  /// Parses `"YYYY-MM-DD"` into `yyyymmdd`. Returns `nil` for any string
+  /// that is not exactly three `-`-separated integer fields with a
+  /// 1...12 month and 1...31 day.
+  static func from(isoString: String) -> Int32? {
+    let parts = isoString.split(separator: "-", omittingEmptySubsequences: false)
+    guard parts.count == 3,
+      let year = Int(parts[0]), let month = Int(parts[1]), let day = Int(parts[2]),
+      year > 0, (1...12).contains(month), (1...31).contains(day)
+    else { return nil }
+    return Int32(year * 10_000 + month * 100 + day)
+  }
+
+  /// Formats `yyyymmdd` back into a zero-padded `"YYYY-MM-DD"` string.
+  static func isoString(_ key: Int32) -> String {
+    let v = Int(key)
+    let year = v / 10_000
+    let month = (v / 100) % 100
+    let day = v % 100
+    return String(format: "%04d-%02d-%02d", year, month, day)
+  }
+}

--- a/Shared/ExchangeRateService+Persistence.swift
+++ b/Shared/ExchangeRateService+Persistence.swift
@@ -38,6 +38,7 @@ extension ExchangeRateService {
       // `SortedDateSeries(sortedEntries:)`'s precondition.
       typealias Entry = SortedDateSeries<[String: Decimal]>.Entry
       var entries: [Entry] = []
+      entries.reserveCapacity(rateRecords.count)
       for record in rateRecords {
         guard let key = DateKey.from(isoString: record.date) else { continue }
         let value = Decimal(string: String(record.rate)) ?? Decimal(record.rate)

--- a/Shared/ExchangeRateService+Persistence.swift
+++ b/Shared/ExchangeRateService+Persistence.swift
@@ -25,21 +25,33 @@ extension ExchangeRateService {
       let rateRecords =
         try ExchangeRateRecord
         .filter(ExchangeRateRecord.Columns.base == base)
+        .order(ExchangeRateRecord.Columns.date)
         .fetchAll(database)
       // Decode via the `String` form of the stored `Double` so we recover
       // the source decimal exactly (e.g. `0.581`), avoiding the precision
       // tail that `Decimal(_: Double)` would introduce
       // (`0.5810000000000001024`).
-      var rates: [String: [String: Decimal]] = [:]
+      //
+      // `.order(date)` ascending → keys appear ascending and grouped, so
+      // building `Entry` values in iteration order yields a list that is
+      // already sorted ascending with no duplicate keys, satisfying
+      // `SortedDateSeries(sortedEntries:)`'s precondition.
+      typealias Entry = SortedDateSeries<[String: Decimal]>.Entry
+      var entries: [Entry] = []
       for record in rateRecords {
+        guard let key = DateKey.from(isoString: record.date) else { continue }
         let value = Decimal(string: String(record.rate)) ?? Decimal(record.rate)
-        rates[record.date, default: [:]][record.quote] = value
+        if entries.last?.key == key {
+          entries[entries.count - 1].value[record.quote] = value
+        } else {
+          entries.append(Entry(key: key, value: [record.quote: value]))
+        }
       }
       return ExchangeRateCache(
         base: base,
         earliestDate: metaRecord.earliestDate,
         latestDate: metaRecord.latestDate,
-        rates: rates
+        rates: SortedDateSeries(sortedEntries: entries)
       )
     }
     if let snapshot { caches[base] = snapshot }

--- a/Shared/ExchangeRateService.swift
+++ b/Shared/ExchangeRateService.swift
@@ -195,7 +195,9 @@ actor ExchangeRateService {
 
     for date in dates {
       let dateString = dateFormatter.string(from: date)
-      if let rate = caches[base]?.rates[dateString]?[quote] {
+      if let key = DateKey.from(isoString: dateString),
+        let rate = caches[base]?.rates.exact(key)?[quote]
+      {
         lastKnownRate = rate
         results.append((date, rate))
       } else if let fallback = lastKnownRate {
@@ -221,16 +223,22 @@ actor ExchangeRateService {
   // MARK: - Private helpers
 
   private func lookupRate(base: String, quote: String, dateString: String) -> Decimal? {
-    caches[base]?.rates[dateString]?[quote]
+    guard let key = DateKey.from(isoString: dateString) else { return nil }
+    return caches[base]?.rates.exact(key)?[quote]
   }
 
   private func fallbackRate(base: String, quote: String, dateString: String) -> Decimal? {
-    guard let cache = caches[base] else { return nil }
-    let sortedDates = cache.rates.keys.sorted().reversed()
-    for cachedDate in sortedDates {
-      if cachedDate <= dateString, let rate = cache.rates[cachedDate]?[quote] {
-        return rate
-      }
+    guard let key = DateKey.from(isoString: dateString),
+      let cache = caches[base]
+    else { return nil }
+    // Step day-by-day toward the past: the original scanned the newest day
+    // <= target that actually carries `quote` (a day map may exist without
+    // this quote), so skip days lacking the quote and keep probing older
+    // days. `floorKey` makes each hop O(log n).
+    var probe = key
+    while let dayKey = cache.rates.floorKey(probe) {
+      if let rate = cache.rates.exact(dayKey)?[quote] { return rate }
+      probe = dayKey - 1
     }
     return nil
   }
@@ -289,16 +297,8 @@ actor ExchangeRateService {
     let sortedDates = newRates.keys.sorted()
     guard let earliest = sortedDates.first, let latest = sortedDates.last else { return [] }
 
-    var deltaRecords: [ExchangeRateRecord] = []
-
     if var existing = caches[base] {
-      for (dateKey, dayRates) in newRates {
-        let existingDayRates = existing.rates[dateKey] ?? [:]
-        for (quote, rate) in dayRates where existingDayRates[quote] != rate {
-          deltaRecords.append(rateRecord(base: base, quote: quote, date: dateKey, rate: rate))
-        }
-        existing.rates[dateKey] = dayRates
-      }
+      let deltaRecords = mergeIntoExisting(&existing, base: base, newRates: newRates)
       if earliest < existing.earliestDate {
         existing.earliestDate = earliest
       }
@@ -306,21 +306,55 @@ actor ExchangeRateService {
         existing.latestDate = latest
       }
       caches[base] = existing
-    } else {
-      caches[base] = ExchangeRateCache(
-        base: base,
-        earliestDate: earliest,
-        latestDate: latest,
-        rates: newRates
-      )
-      for (dateKey, dayRates) in newRates {
-        for (quote, rate) in dayRates {
-          deltaRecords.append(rateRecord(base: base, quote: quote, date: dateKey, rate: rate))
-        }
-      }
+      return deltaRecords
     }
 
+    let (series, deltaRecords) = buildFreshSeries(base: base, newRates: newRates)
+    caches[base] = ExchangeRateCache(
+      base: base,
+      earliestDate: earliest,
+      latestDate: latest,
+      rates: series
+    )
     return deltaRecords
+  }
+
+  /// Whole-day merge of `newRates` into an existing cache entry, returning
+  /// only the per-(date, quote) rows that actually changed. The entire day
+  /// map is overwritten (matches the original `existing.rates[dateKey] =
+  /// dayRates`), not per-quote merged into the existing day.
+  private func mergeIntoExisting(
+    _ existing: inout ExchangeRateCache,
+    base: String,
+    newRates: [String: [String: Decimal]]
+  ) -> [ExchangeRateRecord] {
+    var deltaRecords: [ExchangeRateRecord] = []
+    for (dateKey, dayRates) in newRates {
+      guard let key = DateKey.from(isoString: dateKey) else { continue }  // malformed wire date — unusable as a sorted key; skip
+      let existingDayRates = existing.rates.exact(key) ?? [:]
+      for (quote, rate) in dayRates where existingDayRates[quote] != rate {
+        deltaRecords.append(rateRecord(base: base, quote: quote, date: dateKey, rate: rate))
+      }
+      existing.rates.upsert(key, dayRates)
+    }
+    return deltaRecords
+  }
+
+  /// Builds a fresh `SortedDateSeries` for a base with no existing cache
+  /// entry; every fetched (date, quote) rate is a delta row.
+  private func buildFreshSeries(
+    base: String, newRates: [String: [String: Decimal]]
+  ) -> (SortedDateSeries<[String: Decimal]>, [ExchangeRateRecord]) {
+    var series = SortedDateSeries<[String: Decimal]>()
+    var deltaRecords: [ExchangeRateRecord] = []
+    for (dateKey, dayRates) in newRates {
+      guard let key = DateKey.from(isoString: dateKey) else { continue }  // malformed wire date — unusable as a sorted key; skip
+      series.upsert(key, dayRates)
+      for (quote, rate) in dayRates {
+        deltaRecords.append(rateRecord(base: base, quote: quote, date: dateKey, rate: rate))
+      }
+    }
+    return (series, deltaRecords)
   }
 
   /// Marshalls a `(date, quote, rate)` triple into the GRDB record shape.

--- a/Shared/ExchangeRateService.swift
+++ b/Shared/ExchangeRateService.swift
@@ -231,10 +231,9 @@ actor ExchangeRateService {
     guard let key = DateKey.from(isoString: dateString),
       let cache = caches[base]
     else { return nil }
-    // Step day-by-day toward the past: the original scanned the newest day
-    // <= target that actually carries `quote` (a day map may exist without
-    // this quote), so skip days lacking the quote and keep probing older
-    // days. `floorKey` makes each hop O(log n).
+    // Finds the newest day on or before `target` carrying `quote`, skipping
+    // day maps that lack it (a day map may exist without this quote) and
+    // probing older days. `floorKey` makes each hop O(log n).
     var probe = key
     while let dayKey = cache.rates.floorKey(probe) {
       if let rate = cache.rates.exact(dayKey)?[quote] { return rate }
@@ -267,6 +266,7 @@ actor ExchangeRateService {
     }
   }
 
+  // internal: called from `ExchangeRateService+Prefetch.swift` and tests.
   func fetchAndMerge(base: String, from: Date, to: Date) async throws {
     let fetched = try await client.fetchRates(base: base, from: from, to: to)
     // Frankfurter (and the chunked extension call sites in this service)
@@ -294,8 +294,7 @@ actor ExchangeRateService {
     base: String, newRates: [String: [String: Decimal]]
   ) -> [ExchangeRateRecord] {
     guard !newRates.isEmpty else { return [] }
-    let sortedDates = newRates.keys.sorted()
-    guard let earliest = sortedDates.first, let latest = sortedDates.last else { return [] }
+    guard let earliest = newRates.keys.min(), let latest = newRates.keys.max() else { return [] }
 
     if var existing = caches[base] {
       let deltaRecords = mergeIntoExisting(&existing, base: base, newRates: newRates)
@@ -320,9 +319,8 @@ actor ExchangeRateService {
   }
 
   /// Whole-day merge of `newRates` into an existing cache entry, returning
-  /// only the per-(date, quote) rows that actually changed. The entire day
-  /// map is overwritten (matches the original `existing.rates[dateKey] =
-  /// dayRates`), not per-quote merged into the existing day.
+  /// only the per-(date, quote) rows that actually changed. Replaces the
+  /// entire day map (no per-quote merge into the existing day).
   private func mergeIntoExisting(
     _ existing: inout ExchangeRateCache,
     base: String,
@@ -335,7 +333,7 @@ actor ExchangeRateService {
       for (quote, rate) in dayRates where existingDayRates[quote] != rate {
         deltaRecords.append(rateRecord(base: base, quote: quote, date: dateKey, rate: rate))
       }
-      existing.rates.upsert(key, dayRates)
+      existing.rates.upsert(dayRates, forKey: key)
     }
     return deltaRecords
   }
@@ -349,7 +347,7 @@ actor ExchangeRateService {
     var deltaRecords: [ExchangeRateRecord] = []
     for (dateKey, dayRates) in newRates {
       guard let key = DateKey.from(isoString: dateKey) else { continue }  // malformed wire date — unusable as a sorted key; skip
-      series.upsert(key, dayRates)
+      series.upsert(dayRates, forKey: key)
       for (quote, rate) in dayRates {
         deltaRecords.append(rateRecord(base: base, quote: quote, date: dateKey, rate: rate))
       }

--- a/Shared/SortedDateSeries.swift
+++ b/Shared/SortedDateSeries.swift
@@ -1,18 +1,18 @@
-/// Test-only backing store for `SortedDateSeries.probeCount`.
-/// Swift does not allow stored static properties in generic types, so the
-/// counter lives here as a module-level global instead.
-nonisolated(unsafe) var sortedDateSeriesProbeCount: Int = 0
+#if DEBUG
+  /// Test-only backing store for `SortedDateSeries.probeCount`.
+  /// Swift does not allow stored static properties in generic types, so the
+  /// counter lives here as a module-level global instead.
+  nonisolated(unsafe) var sortedDateSeriesProbeCount: Int = 0
+#endif
 
-/// A date-sorted contiguous store keyed by `DateKey` (`Int32` yyyymmdd).
-/// Replaces the `[String: Value]` price/rate caches: O(log n) `exact`
-/// and `floor` (the prior-trading-day fallback), strictly less RAM than
-/// `Dictionary` (no hash slack, no duplicate key storage, no separate
+/// A date-sorted contiguous store keyed by `DateKey` (`Int32` yyyymmdd):
+/// O(log n) `exact` and `floor` (the prior-trading-day fallback), less RAM
+/// than a `Dictionary` (no hash slack, no duplicate key storage, no separate
 /// sorted index), and a `Codable` shape that loads pre-sorted from an
 /// `ORDER BY date` query.
 ///
 /// Entries are kept sorted ascending by `key` at all times. `upsert`
-/// replaces an existing same-key value (last-wins), matching the old
-/// `dict[date] = value` overwrite semantics.
+/// replaces an existing same-key value (last-wins).
 struct SortedDateSeries<Value: Codable & Sendable & Equatable>: Sendable {
   struct Entry: Sendable {
     var key: Int32
@@ -21,21 +21,23 @@ struct SortedDateSeries<Value: Codable & Sendable & Equatable>: Sendable {
 
   private(set) var entries: [Entry]
 
-  /// Test-only probe counter incremented once per binary-search step in
-  /// `exact` / `floor`. Lets the plan-pinning test assert logarithmic
-  /// behaviour.
-  ///
-  /// Stored as a global because Swift does not allow stored static properties
-  /// in generic types. Accessed via the computed static property
-  /// `SortedDateSeries<V>.probeCount`; all specialisations share the same
-  /// backing global.
-  ///
-  /// Incremented by the production binary-search paths but has no effect on
-  /// their output; only test code reads it.
-  static var probeCount: Int {
-    get { sortedDateSeriesProbeCount }
-    set { sortedDateSeriesProbeCount = newValue }
-  }
+  #if DEBUG
+    /// Test-only probe counter incremented once per binary-search step in
+    /// `exact` / `floor`. Lets the plan-pinning test assert logarithmic
+    /// behaviour.
+    ///
+    /// Stored as a global because Swift does not allow stored static
+    /// properties in generic types. Accessed via the computed static property
+    /// `SortedDateSeries<V>.probeCount`; all specialisations share the same
+    /// backing global.
+    ///
+    /// Incremented by the binary-search paths but has no effect on their
+    /// output; only test code reads it.
+    static var probeCount: Int {
+      get { sortedDateSeriesProbeCount }
+      set { sortedDateSeriesProbeCount = newValue }
+    }
+  #endif
 
   init() { self.entries = [] }
 
@@ -60,7 +62,9 @@ struct SortedDateSeries<Value: Codable & Sendable & Equatable>: Sendable {
     var low = 0
     var high = entries.count - 1
     while low <= high {
-      Self.probeCount += 1
+      #if DEBUG
+        Self.probeCount += 1
+      #endif
       let mid = (low + high) / 2
       let candidate = entries[mid].key
       if candidate == key { return mid }
@@ -76,7 +80,9 @@ struct SortedDateSeries<Value: Codable & Sendable & Equatable>: Sendable {
     var high = entries.count - 1
     var result: Int?
     while low <= high {
-      Self.probeCount += 1
+      #if DEBUG
+        Self.probeCount += 1
+      #endif
       let mid = (low + high) / 2
       if entries[mid].key <= target {
         result = mid
@@ -104,9 +110,10 @@ struct SortedDateSeries<Value: Codable & Sendable & Equatable>: Sendable {
     floorIndex(target).map { entries[$0].key }
   }
 
-  /// Inserts `value` at `key`, or replaces the existing same-key value.
-  /// Keeps the array sorted. O(log n) search + O(n) shift on insert.
-  mutating func upsert(_ key: Int32, _ value: Value) {
+  /// Inserts `value` at `key`, or replaces the existing same-key value
+  /// (last-wins). Keeps the array sorted. O(log n) search + O(n) shift on
+  /// insert.
+  mutating func upsert(_ value: Value, forKey key: Int32) {
     var low = 0
     var high = entries.count - 1
     while low <= high {

--- a/Shared/SortedDateSeries.swift
+++ b/Shared/SortedDateSeries.swift
@@ -1,0 +1,121 @@
+import Foundation
+
+/// Test-only backing store for `SortedDateSeries.probeCount`.
+/// Swift does not allow stored static properties in generic types, so the
+/// counter lives here as a module-level global instead.
+nonisolated(unsafe) var _sortedDateSeriesProbeCount: Int = 0
+
+/// A date-sorted contiguous store keyed by `DateKey` (`Int32` yyyymmdd).
+/// Replaces the `[String: Value]` price/rate caches: O(log n) `exact`
+/// and `floor` (the prior-trading-day fallback), strictly less RAM than
+/// `Dictionary` (no hash slack, no duplicate key storage, no separate
+/// sorted index), and a `Codable` shape that loads pre-sorted from an
+/// `ORDER BY date` query.
+///
+/// Entries are kept sorted ascending by `key` at all times. `upsert`
+/// replaces an existing same-key value (last-wins), matching the old
+/// `dict[date] = value` overwrite semantics.
+struct SortedDateSeries<Value: Codable & Sendable & Equatable>: Codable, Sendable, Equatable {
+  struct Entry: Codable, Sendable, Equatable {
+    var key: Int32
+    var value: Value
+  }
+
+  private(set) var entries: [Entry]
+
+  /// Test-only probe counter incremented once per binary-search step in
+  /// `exact` / `floor`. Lets the plan-pinning test assert logarithmic
+  /// behaviour. Not used in production logic.
+  ///
+  /// Stored as a global because Swift does not allow stored static properties
+  /// in generic types. Accessed via the type alias `SortedDateSeries<V>.probeCount`
+  /// which delegates to this global.
+  static var probeCount: Int {
+    get { _sortedDateSeriesProbeCount }
+    set { _sortedDateSeriesProbeCount = newValue }
+  }
+
+  init() { self.entries = [] }
+
+  /// Precondition: `entries` is already sorted ascending by key with no
+  /// duplicate keys. Used by `loadCache` after an `ORDER BY date` fetch.
+  init(sortedEntries: [Entry]) { self.entries = sortedEntries }
+
+  /// Sorts and de-duplicates (last value wins for a repeated key).
+  init(unsorted pairs: [(Int32, Value)]) {
+    var map: [Int32: Value] = [:]
+    for (k, v) in pairs { map[k] = v }
+    self.entries = map.keys.sorted().map { Entry(key: $0, value: map[$0]!) }
+  }
+
+  var isEmpty: Bool { entries.isEmpty }
+  var first: Entry? { entries.first }
+  var last: Entry? { entries.last }
+  var sortedKeys: [Int32] { entries.map(\.key) }
+
+  /// Index of an exact key match, or `nil`. O(log n).
+  private func index(of key: Int32) -> Int? {
+    var lo = 0
+    var hi = entries.count - 1
+    while lo <= hi {
+      Self.probeCount += 1
+      let mid = (lo + hi) / 2
+      let k = entries[mid].key
+      if k == key { return mid }
+      if k < key { lo = mid + 1 } else { hi = mid - 1 }
+    }
+    return nil
+  }
+
+  /// Index of the newest entry with `key <= target`, or `nil` when the
+  /// target precedes every entry. O(log n).
+  private func floorIndex(_ target: Int32) -> Int? {
+    var lo = 0
+    var hi = entries.count - 1
+    var result: Int?
+    while lo <= hi {
+      Self.probeCount += 1
+      let mid = (lo + hi) / 2
+      if entries[mid].key <= target {
+        result = mid
+        lo = mid + 1
+      } else {
+        hi = mid - 1
+      }
+    }
+    return result
+  }
+
+  /// Value for an exact key match, else `nil`.
+  func exact(_ key: Int32) -> Value? {
+    index(of: key).map { entries[$0].value }
+  }
+
+  /// Value of the newest entry on or before `key` (the prior-trading-day
+  /// fallback), else `nil`.
+  func floor(_ key: Int32) -> Value? {
+    floorIndex(key).map { entries[$0].value }
+  }
+
+  /// Key of the newest entry on or before `target`, else `nil`.
+  func floorKey(_ target: Int32) -> Int32? {
+    floorIndex(target).map { entries[$0].key }
+  }
+
+  /// Inserts `value` at `key`, or replaces the existing same-key value.
+  /// Keeps the array sorted. O(log n) search + O(n) shift on insert.
+  mutating func upsert(_ key: Int32, _ value: Value) {
+    var lo = 0
+    var hi = entries.count - 1
+    while lo <= hi {
+      let mid = (lo + hi) / 2
+      let k = entries[mid].key
+      if k == key {
+        entries[mid].value = value
+        return
+      }
+      if k < key { lo = mid + 1 } else { hi = mid - 1 }
+    }
+    entries.insert(Entry(key: key, value: value), at: lo)
+  }
+}

--- a/Shared/SortedDateSeries.swift
+++ b/Shared/SortedDateSeries.swift
@@ -1,9 +1,7 @@
-import Foundation
-
 /// Test-only backing store for `SortedDateSeries.probeCount`.
 /// Swift does not allow stored static properties in generic types, so the
 /// counter lives here as a module-level global instead.
-nonisolated(unsafe) var _sortedDateSeriesProbeCount: Int = 0
+nonisolated(unsafe) var sortedDateSeriesProbeCount: Int = 0
 
 /// A date-sorted contiguous store keyed by `DateKey` (`Int32` yyyymmdd).
 /// Replaces the `[String: Value]` price/rate caches: O(log n) `exact`
@@ -15,8 +13,8 @@ nonisolated(unsafe) var _sortedDateSeriesProbeCount: Int = 0
 /// Entries are kept sorted ascending by `key` at all times. `upsert`
 /// replaces an existing same-key value (last-wins), matching the old
 /// `dict[date] = value` overwrite semantics.
-struct SortedDateSeries<Value: Codable & Sendable & Equatable>: Codable, Sendable, Equatable {
-  struct Entry: Codable, Sendable, Equatable {
+struct SortedDateSeries<Value: Codable & Sendable & Equatable>: Sendable {
+  struct Entry: Sendable {
     var key: Int32
     var value: Value
   }
@@ -25,14 +23,18 @@ struct SortedDateSeries<Value: Codable & Sendable & Equatable>: Codable, Sendabl
 
   /// Test-only probe counter incremented once per binary-search step in
   /// `exact` / `floor`. Lets the plan-pinning test assert logarithmic
-  /// behaviour. Not used in production logic.
+  /// behaviour.
   ///
   /// Stored as a global because Swift does not allow stored static properties
-  /// in generic types. Accessed via the type alias `SortedDateSeries<V>.probeCount`
-  /// which delegates to this global.
+  /// in generic types. Accessed via the computed static property
+  /// `SortedDateSeries<V>.probeCount`; all specialisations share the same
+  /// backing global.
+  ///
+  /// Incremented by the production binary-search paths but has no effect on
+  /// their output; only test code reads it.
   static var probeCount: Int {
-    get { _sortedDateSeriesProbeCount }
-    set { _sortedDateSeriesProbeCount = newValue }
+    get { sortedDateSeriesProbeCount }
+    set { sortedDateSeriesProbeCount = newValue }
   }
 
   init() { self.entries = [] }
@@ -44,8 +46,8 @@ struct SortedDateSeries<Value: Codable & Sendable & Equatable>: Codable, Sendabl
   /// Sorts and de-duplicates (last value wins for a repeated key).
   init(unsorted pairs: [(Int32, Value)]) {
     var map: [Int32: Value] = [:]
-    for (k, v) in pairs { map[k] = v }
-    self.entries = map.keys.sorted().map { Entry(key: $0, value: map[$0]!) }
+    for (dateKey, val) in pairs { map[dateKey] = val }
+    self.entries = map.sorted(by: { $0.key < $1.key }).map { Entry(key: $0.key, value: $0.value) }
   }
 
   var isEmpty: Bool { entries.isEmpty }
@@ -55,14 +57,14 @@ struct SortedDateSeries<Value: Codable & Sendable & Equatable>: Codable, Sendabl
 
   /// Index of an exact key match, or `nil`. O(log n).
   private func index(of key: Int32) -> Int? {
-    var lo = 0
-    var hi = entries.count - 1
-    while lo <= hi {
+    var low = 0
+    var high = entries.count - 1
+    while low <= high {
       Self.probeCount += 1
-      let mid = (lo + hi) / 2
-      let k = entries[mid].key
-      if k == key { return mid }
-      if k < key { lo = mid + 1 } else { hi = mid - 1 }
+      let mid = (low + high) / 2
+      let candidate = entries[mid].key
+      if candidate == key { return mid }
+      if candidate < key { low = mid + 1 } else { high = mid - 1 }
     }
     return nil
   }
@@ -70,17 +72,17 @@ struct SortedDateSeries<Value: Codable & Sendable & Equatable>: Codable, Sendabl
   /// Index of the newest entry with `key <= target`, or `nil` when the
   /// target precedes every entry. O(log n).
   private func floorIndex(_ target: Int32) -> Int? {
-    var lo = 0
-    var hi = entries.count - 1
+    var low = 0
+    var high = entries.count - 1
     var result: Int?
-    while lo <= hi {
+    while low <= high {
       Self.probeCount += 1
-      let mid = (lo + hi) / 2
+      let mid = (low + high) / 2
       if entries[mid].key <= target {
         result = mid
-        lo = mid + 1
+        low = mid + 1
       } else {
-        hi = mid - 1
+        high = mid - 1
       }
     }
     return result
@@ -105,17 +107,25 @@ struct SortedDateSeries<Value: Codable & Sendable & Equatable>: Codable, Sendabl
   /// Inserts `value` at `key`, or replaces the existing same-key value.
   /// Keeps the array sorted. O(log n) search + O(n) shift on insert.
   mutating func upsert(_ key: Int32, _ value: Value) {
-    var lo = 0
-    var hi = entries.count - 1
-    while lo <= hi {
-      let mid = (lo + hi) / 2
-      let k = entries[mid].key
-      if k == key {
+    var low = 0
+    var high = entries.count - 1
+    while low <= high {
+      let mid = (low + high) / 2
+      let candidate = entries[mid].key
+      if candidate == key {
         entries[mid].value = value
         return
       }
-      if k < key { lo = mid + 1 } else { hi = mid - 1 }
+      if candidate < key { low = mid + 1 } else { high = mid - 1 }
     }
-    entries.insert(Entry(key: key, value: value), at: lo)
+    entries.insert(Entry(key: key, value: value), at: low)
   }
 }
+
+extension SortedDateSeries: Codable {}
+
+extension SortedDateSeries.Entry: Codable {}
+
+extension SortedDateSeries: Equatable {}
+
+extension SortedDateSeries.Entry: Equatable {}

--- a/Shared/StockPriceService+Merge.swift
+++ b/Shared/StockPriceService+Merge.swift
@@ -4,9 +4,7 @@ import Foundation
 
 // MARK: - StockPriceService merge / delta computation
 
-// In-memory merge for `StockPriceService`. Split out of
-// `StockPriceService.swift` to keep that file within the type/file
-// length budget, mirroring the `CryptoPriceService+Merge.swift` split.
+// In-memory merge logic for `StockPriceService`.
 
 extension StockPriceService {
   /// Merges `newPrices` into `caches[ticker]` and returns the rows that
@@ -21,8 +19,7 @@ extension StockPriceService {
     ticker: String, instrument: Instrument, newPrices: [String: Decimal]
   ) -> [StockPriceRecord] {
     guard !newPrices.isEmpty else { return [] }
-    let sortedDates = newPrices.keys.sorted()
-    guard let earliest = sortedDates.first, let latest = sortedDates.last else { return [] }
+    guard let earliest = newPrices.keys.min(), let latest = newPrices.keys.max() else { return [] }
 
     var deltaRecords: [StockPriceRecord] = []
 
@@ -31,7 +28,7 @@ extension StockPriceService {
         guard let key = DateKey.from(isoString: dateKey) else { continue }  // malformed wire date — unusable as a sorted key; skip
         if existing.prices.exact(key) != price {
           deltaRecords.append(priceRecord(ticker: ticker, date: dateKey, price: price))
-          existing.prices.upsert(key, price)
+          existing.prices.upsert(price, forKey: key)
         }
       }
       if earliest < existing.earliestDate {
@@ -45,7 +42,7 @@ extension StockPriceService {
       var series = SortedDateSeries<Decimal>()
       for (dateKey, price) in newPrices {
         guard let key = DateKey.from(isoString: dateKey) else { continue }  // malformed wire date — unusable as a sorted key; skip
-        series.upsert(key, price)
+        series.upsert(price, forKey: key)
         deltaRecords.append(priceRecord(ticker: ticker, date: dateKey, price: price))
       }
       caches[ticker] = StockPriceCache(

--- a/Shared/StockPriceService+Merge.swift
+++ b/Shared/StockPriceService+Merge.swift
@@ -28,7 +28,7 @@ extension StockPriceService {
 
     if var existing = caches[ticker] {
       for (dateKey, price) in newPrices {
-        guard let key = DateKey.from(isoString: dateKey) else { continue }
+        guard let key = DateKey.from(isoString: dateKey) else { continue }  // malformed wire date — unusable as a sorted key; skip
         if existing.prices.exact(key) != price {
           deltaRecords.append(priceRecord(ticker: ticker, date: dateKey, price: price))
           existing.prices.upsert(key, price)
@@ -44,7 +44,7 @@ extension StockPriceService {
     } else {
       var series = SortedDateSeries<Decimal>()
       for (dateKey, price) in newPrices {
-        guard let key = DateKey.from(isoString: dateKey) else { continue }
+        guard let key = DateKey.from(isoString: dateKey) else { continue }  // malformed wire date — unusable as a sorted key; skip
         series.upsert(key, price)
         deltaRecords.append(priceRecord(ticker: ticker, date: dateKey, price: price))
       }

--- a/Shared/StockPriceService+Merge.swift
+++ b/Shared/StockPriceService+Merge.swift
@@ -1,0 +1,74 @@
+// Shared/StockPriceService+Merge.swift
+
+import Foundation
+
+// MARK: - StockPriceService merge / delta computation
+
+// In-memory merge for `StockPriceService`. Split out of
+// `StockPriceService.swift` to keep that file within the type/file
+// length budget, mirroring the `CryptoPriceService+Merge.swift` split.
+
+extension StockPriceService {
+  /// Merges `newPrices` into `caches[ticker]` and returns the rows that
+  /// actually changed so the persistence layer can `INSERT OR REPLACE`
+  /// only those (rather than rewriting every cached row for the ticker
+  /// on every fetch).
+  ///
+  /// The comparison is per-date so a fetch that returns the same prices
+  /// already in cache produces an empty delta. This is what lets
+  /// `fetchAndMerge` skip the disk write on a no-op extension probe.
+  func mergeReturningDelta(
+    ticker: String, instrument: Instrument, newPrices: [String: Decimal]
+  ) -> [StockPriceRecord] {
+    guard !newPrices.isEmpty else { return [] }
+    let sortedDates = newPrices.keys.sorted()
+    guard let earliest = sortedDates.first, let latest = sortedDates.last else { return [] }
+
+    var deltaRecords: [StockPriceRecord] = []
+
+    if var existing = caches[ticker] {
+      for (dateKey, price) in newPrices {
+        guard let key = DateKey.from(isoString: dateKey) else { continue }
+        if existing.prices.exact(key) != price {
+          deltaRecords.append(priceRecord(ticker: ticker, date: dateKey, price: price))
+          existing.prices.upsert(key, price)
+        }
+      }
+      if earliest < existing.earliestDate {
+        existing.earliestDate = earliest
+      }
+      if latest > existing.latestDate {
+        existing.latestDate = latest
+      }
+      caches[ticker] = existing
+    } else {
+      var series = SortedDateSeries<Decimal>()
+      for (dateKey, price) in newPrices {
+        guard let key = DateKey.from(isoString: dateKey) else { continue }
+        series.upsert(key, price)
+        deltaRecords.append(priceRecord(ticker: ticker, date: dateKey, price: price))
+      }
+      caches[ticker] = StockPriceCache(
+        ticker: ticker,
+        instrument: instrument,
+        earliestDate: earliest,
+        latestDate: latest,
+        prices: series
+      )
+    }
+
+    return deltaRecords
+  }
+
+  /// Marshalls a `(date, price)` pair into the GRDB record shape.
+  /// `Decimal → Double` round-trips via `NSDecimalNumber` (the same path
+  /// GRDB itself takes), keeping the precision-preservation contract in
+  /// sync with `loadCache`'s decode.
+  private func priceRecord(ticker: String, date: String, price: Decimal) -> StockPriceRecord {
+    StockPriceRecord(
+      ticker: ticker,
+      date: date,
+      price: NSDecimalNumber(decimal: price).doubleValue
+    )
+  }
+}

--- a/Shared/StockPriceService.swift
+++ b/Shared/StockPriceService.swift
@@ -11,7 +11,13 @@ enum StockPriceError: Error, Equatable {
 
 actor StockPriceService {
   private let client: StockPriceClient
-  private var caches: [String: StockPriceCache] = [:]
+  // `caches` is accessed by the merge extension in
+  // `StockPriceService+Merge.swift` (which defines
+  // `mergeReturningDelta(ticker:instrument:newPrices:)`, called from this
+  // file), so it is `internal` rather than `private`. It remains
+  // actor-isolated; the access modifier is internal only so the
+  // sibling-file extension can see it.
+  var caches: [String: StockPriceCache] = [:]
   /// Loaded tickers — set on first hydration so we don't re-read SQL when
   /// the cache is genuinely empty.
   private var hydratedTickers: Set<String> = []
@@ -121,7 +127,9 @@ actor StockPriceService {
 
     for date in dates {
       let dateString = dateFormatter.string(from: date)
-      if let price = caches[ticker]?.prices[dateString] {
+      if let key = DateKey.from(isoString: dateString),
+        let price = caches[ticker]?.prices.exact(key)
+      {
         lastKnownPrice = price
         results.append((date, price))
       } else if let fallback = lastKnownPrice {
@@ -190,16 +198,15 @@ actor StockPriceService {
   }
 
   private func lookupPrice(ticker: String, dateString: String) -> Decimal? {
-    caches[ticker]?.prices[dateString]
+    guard let key = DateKey.from(isoString: dateString) else { return nil }
+    return caches[ticker]?.prices.exact(key)
   }
 
   private func fallbackPrice(ticker: String, dateString: String) -> Decimal? {
-    guard let cache = caches[ticker] else { return nil }
-    let sortedDates = cache.prices.keys.sorted().reversed()
-    for cachedDate in sortedDates where cachedDate <= dateString {
-      return cache.prices[cachedDate]
-    }
-    return nil
+    guard let key = DateKey.from(isoString: dateString),
+      let cache = caches[ticker]
+    else { return nil }
+    return cache.prices.floor(key)
   }
 
   private func generateDateSeries(in range: ClosedRange<Date>) -> [Date] {
@@ -242,63 +249,6 @@ actor StockPriceService {
     try await persistDelta(ticker: ticker, deltaRecords: delta)
   }
 
-  /// Merges `newPrices` into `caches[ticker]` and returns the rows that
-  /// actually changed so the persistence layer can `INSERT OR REPLACE`
-  /// only those (rather than rewriting every cached row for the ticker
-  /// on every fetch).
-  ///
-  /// The comparison is per-date so a fetch that returns the same prices
-  /// already in cache produces an empty delta. This is what lets
-  /// `fetchAndMerge` skip the disk write on a no-op extension probe.
-  private func mergeReturningDelta(
-    ticker: String, instrument: Instrument, newPrices: [String: Decimal]
-  ) -> [StockPriceRecord] {
-    guard !newPrices.isEmpty else { return [] }
-    let sortedDates = newPrices.keys.sorted()
-    guard let earliest = sortedDates.first, let latest = sortedDates.last else { return [] }
-
-    var deltaRecords: [StockPriceRecord] = []
-
-    if var existing = caches[ticker] {
-      for (dateKey, price) in newPrices where existing.prices[dateKey] != price {
-        deltaRecords.append(priceRecord(ticker: ticker, date: dateKey, price: price))
-        existing.prices[dateKey] = price
-      }
-      if earliest < existing.earliestDate {
-        existing.earliestDate = earliest
-      }
-      if latest > existing.latestDate {
-        existing.latestDate = latest
-      }
-      caches[ticker] = existing
-    } else {
-      caches[ticker] = StockPriceCache(
-        ticker: ticker,
-        instrument: instrument,
-        earliestDate: earliest,
-        latestDate: latest,
-        prices: newPrices
-      )
-      for (dateKey, price) in newPrices {
-        deltaRecords.append(priceRecord(ticker: ticker, date: dateKey, price: price))
-      }
-    }
-
-    return deltaRecords
-  }
-
-  /// Marshalls a `(date, price)` pair into the GRDB record shape.
-  /// `Decimal → Double` round-trips via `NSDecimalNumber` (the same path
-  /// GRDB itself takes), keeping the precision-preservation contract in
-  /// sync with `loadCache`'s decode.
-  private func priceRecord(ticker: String, date: String, price: Decimal) -> StockPriceRecord {
-    StockPriceRecord(
-      ticker: ticker,
-      date: date,
-      price: NSDecimalNumber(decimal: price).doubleValue
-    )
-  }
-
   // MARK: - SQL persistence
 
   /// Hydrates `caches[ticker]` from `stock_price` + `stock_ticker_meta`.
@@ -319,20 +269,25 @@ actor StockPriceService {
       let priceRecords =
         try StockPriceRecord
         .filter(StockPriceRecord.Columns.ticker == ticker)
+        .order(StockPriceRecord.Columns.date)
         .fetchAll(database)
       // See `ExchangeRateService.loadCache` for the rationale on the
       // String-via-Decimal round-trip; preserves source precision instead
       // of inheriting the binary `Decimal(_: Double)` tail.
-      var prices: [String: Decimal] = [:]
+      // `.order(date)` ascending satisfies `init(sortedEntries:)`.
+      var entries: [SortedDateSeries<Decimal>.Entry] = []
+      entries.reserveCapacity(priceRecords.count)
       for record in priceRecords {
-        prices[record.date] = Decimal(string: String(record.price)) ?? Decimal(record.price)
+        guard let key = DateKey.from(isoString: record.date) else { continue }
+        let value = Decimal(string: String(record.price)) ?? Decimal(record.price)
+        entries.append(.init(key: key, value: value))
       }
       return StockPriceCache(
         ticker: ticker,
         instrument: Instrument.fiat(code: metaRecord.instrumentId),
         earliestDate: metaRecord.earliestDate,
         latestDate: metaRecord.latestDate,
-        prices: prices
+        prices: SortedDateSeries(sortedEntries: entries)
       )
     }
     if let snapshot { caches[ticker] = snapshot }


### PR DESCRIPTION
Replaces the per-call `keys.sorted()` in `StockPriceService` /
`ExchangeRateService` / `CryptoPriceService` with a shared sorted-array
`SortedDateSeries<Value>` keyed by `Int32` yyyymmdd (`DateKey`). O(log n)
`exact`/`floor` lookups, less RAM than the dictionaries, on-disk schema /
GRDB records / migrations / PRAGMAs unchanged (String↔Int32 conversion only
at the persistence boundary). Behaviour-preserving — table-driven fallback
tests pin exact / in-range-gap / pre-history / post-latest for all three
services, each proven green against the pre-rewrite code before the rewrite.
Approach 2, Plan B (Plan A — responsive two-phase load — shipped separately).

Spec: `plans/2026-05-16-responsive-investment-load-design.md`
Plan: `plans/2026-05-16-responsive-investment-load-plan-B-caches.md`

## Before/after profile (Shares / Large Test Profile)

**Before** (design-spec profile): navigating to the account froze the screen
for several seconds; a stack sample showed `StockPriceService.fallbackPrice`
→ `Sequence.sorted()` at ~2701 of ~2884 samples (~94%), the `.all` historic
chart taking seconds to populate.

**After** (re-profiled on this branch, same profile/account): the per-call
`keys.sorted()` is entirely gone from the sample. Price resolution now goes
through `SortedDateSeries` binary search (O(log n)); the whole
`StockPriceService.price` path is ~23 of ~45,900 samples and
`Sequence.sorted()` does not appear anywhere under the price/rate services.
The chart build runs off the main thread with no main-thread-hang warnings;
the screen stays responsive. Behaviour is preserved — conversion count and
log volume are unchanged by design; only the per-lookup sort cost was removed
(the stack sample is the proof of the win).

## Reviews

Per-task spec-compliance + code-quality reviews, plus final
`@database-code-review` / `@concurrency-review` / `@code-review` passes; every
Critical/Important/Minor finding fixed and re-verified (DEBUG-gated probe
seam, `ORDER BY "date"` query-plan pins with no `USE TEMP B-TREE`, `min/max`
over wasted sorts, `upsert(_:forKey:)` API label, present-tense docs).
`just format-check` clean, no Swift warnings, full cross-platform test sweep
green (incl. `RateQueryPlanTests`/`SharedRateQueryPlanTests`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)