### PR TITLE
fix(justfile): detect added/deleted source files in generate target

### DIFF
--- a/justfile
+++ b/justfile
@@ -154,7 +154,6 @@ generate:
 
     STAMP_DIR=".build/stamps"
     SCHEMA_STAMP="$STAMP_DIR/ckdb-schema-gen.stamp"
-    XCODEGEN_MODE_FILE="$STAMP_DIR/xcodegen.mode"
     mkdir -p "$STAMP_DIR"
 
     # ---- ckdb-schema-gen ----
@@ -191,40 +190,21 @@ generate:
     # builds are produced by fastlane lanes (no entitlement injection here) and
     # shipped via the GitHub release artefact — there is no local Release path.
     #
-    # Both modes are cached. Regenerate when `project.yml` (or, in the
-    # injection path, `scripts/inject-entitlements.sh`) is newer than
-    # `Moolah.xcodeproj/project.pbxproj`, when the project file is
-    # missing, or when the mode flipped between injected and non-injected
-    # since the last successful run (so the project picks up / drops the
-    # entitlement keys).
-    last_mode="$(cat "$XCODEGEN_MODE_FILE" 2>/dev/null || echo "")"
+    # xcodegen's own `--use-cache` keys on the resolved spec — the parsed
+    # `project.yml` *and* the full set of source files it globs in. That
+    # makes it skip regeneration when nothing changed and regenerate when
+    # a file is added or deleted under one of project.yml's directory
+    # paths (the case a `project.yml` mtime check misses) or when the
+    # injected-entitlements spec content differs. The cache lives inside
+    # the worktree's `.build`, so it is not shared between worktrees and
+    # is removed along with the worktree.
+    XCODEGEN_CACHE=".build/xcodegen.cache"
     if [ "${ENABLE_ENTITLEMENTS:-}" = "1" ]; then
-        current_mode="1"
+        SPEC=$(bash scripts/inject-entitlements.sh)
+        trap "rm -f $SPEC" EXIT
+        xcodegen generate --use-cache --cache-path "$XCODEGEN_CACHE" --spec "$SPEC"
     else
-        current_mode="0"
-    fi
-
-    needs_xcodegen=0
-    if [ ! -f "Moolah.xcodeproj/project.pbxproj" ]; then
-        needs_xcodegen=1
-    elif [ "project.yml" -nt "Moolah.xcodeproj/project.pbxproj" ]; then
-        needs_xcodegen=1
-    elif [ "$last_mode" != "$current_mode" ]; then
-        needs_xcodegen=1
-    elif [ "$current_mode" = "1" ] \
-        && [ "scripts/inject-entitlements.sh" -nt "Moolah.xcodeproj/project.pbxproj" ]; then
-        needs_xcodegen=1
-    fi
-
-    if [ "$needs_xcodegen" -eq 1 ]; then
-        if [ "$current_mode" = "1" ]; then
-            SPEC=$(bash scripts/inject-entitlements.sh)
-            trap "rm -f $SPEC" EXIT
-            xcodegen generate --spec "$SPEC"
-        else
-            xcodegen generate
-        fi
-        echo "$current_mode" > "$XCODEGEN_MODE_FILE"
+        xcodegen generate --use-cache --cache-path "$XCODEGEN_CACHE"
     fi
 
 # Removes:


### PR DESCRIPTION
## Summary
- The `generate` target's `needs_xcodegen` stamp logic only compared `project.yml`'s mtime against the generated project. Because `project.yml` declares source roots as directory paths, creating or deleting a file under one of them changed the resolved project without touching `project.yml`, leaving a stale `Moolah.xcodeproj` that omitted/retained the file.
- Replaced the hand-rolled stamp gating (and the `XCODEGEN_MODE_FILE` mode-flip stamp) with xcodegen's own `--use-cache --cache-path .build/xcodegen.cache`. xcodegen keys its cache on the resolved spec — the parsed `project.yml` *plus* the full globbed source-file set — so add/delete now triggers regeneration, and an unchanged tree is still a no-op.
- The cache lives in the worktree's gitignored `.build`, so it is not shared between worktrees and is removed with the worktree. The injected-entitlements path is preserved; spec-content changes (mode flip or `inject-entitlements.sh` edits) invalidate the cache automatically.
- `ckdb-schema-gen` stamp gating is untouched and still runs before xcodegen so freshly generated wire structs are included in the cache hash.

## Test plan
- [x] `just generate` populates `.build/xcodegen.cache`
- [x] Re-running with no changes is a no-op (`Project Moolah has not changed since cache was written`)
- [x] Adding a file under a source dir (`Shared/`) regenerates the project
- [x] Deleting that file regenerates the project

🤖 Generated with [Claude Code](https://claude.com/claude-code)