### PR TITLE
feat(crypto): denominate new crypto accounts in the profile currency

### DIFF
--- a/Features/Accounts/AccountBalanceCalculator.swift
+++ b/Features/Accounts/AccountBalanceCalculator.swift
@@ -145,6 +145,13 @@ struct AccountBalanceCalculator {
   /// balance; a thrown conversion error still propagates so the balance
   /// is marked unavailable per Rule 11. See issue #790.
   ///
+  /// A `.crypto` account's `instrument` is the profile currency (set at
+  /// creation), so this loop converts each native-token position into the
+  /// profile currency on `date` — the current-value read the user expects
+  /// for a wallet's worth. The native token is never the account
+  /// instrument, so the same-instrument fast path below only fires for a
+  /// position that already happens to be in the profile currency.
+  ///
   /// Pass `date` to share a conversion timestamp across a multi-account
   /// pass; defaults to `Date()` for one-shot callers.
   func displayBalance(

--- a/Features/Accounts/Views/CreateAccountView.swift
+++ b/Features/Accounts/Views/CreateAccountView.swift
@@ -180,7 +180,8 @@ struct CreateAccountView: View {
 
   private func submitCrypto() async {
     let logic = CryptoAccountCreationLogic(
-      accountStore: accountStore, cryptoSyncStore: cryptoSyncStore)
+      accountStore: accountStore, cryptoSyncStore: cryptoSyncStore,
+      accountInstrument: instrument)
     let outcome = await logic.submit(
       name: name, chain: cryptoChain, walletAddressInput: cryptoWalletAddress)
     switch outcome {

--- a/Features/Crypto/CryptoAccountCreationLogic.swift
+++ b/Features/Crypto/CryptoAccountCreationLogic.swift
@@ -1,0 +1,69 @@
+// Features/Crypto/CryptoAccountCreationLogic.swift
+import Foundation
+
+/// Pure form-logic helper for the crypto branch of `CreateAccountView`.
+/// Owns the create-account + kick-off-sync sequence so the parent view
+/// can dispatch from its Save button without relying on a transient
+/// SwiftUI view instance, and so `CryptoAccountCreationStoreTests` can
+/// exercise the contract end-to-end against `TestBackend`.
+@MainActor
+struct CryptoAccountCreationLogic {
+  let accountStore: AccountStore
+  /// May be `nil` in degraded launches (preview / no instrument
+  /// registry). When `nil`, account creation still proceeds; the first
+  /// sync simply isn't kicked off — the next scenePhase `.active`
+  /// stale-check will pick it up.
+  let cryptoSyncStore: CryptoSyncStore?
+  /// Denominating the account in the profile currency (rather than the
+  /// chain's native token) lets a wallet's reported value sit alongside
+  /// every other account in one currency, and lets a single account
+  /// span multiple tokens without picking an arbitrary "primary" token.
+  /// The native-token positions still accrue from leg aggregation; they
+  /// are converted into this instrument for the account's reported value.
+  let accountInstrument: Instrument
+
+  /// Output of `submit(name:chain:walletAddressInput:)`. The parent
+  /// surface uses `.created` to dismiss the sheet and `.failure` /
+  /// `.invalidAddress` to show an inline error message.
+  enum Outcome: Sendable {
+    case created(Account)
+    case invalidAddress
+    case failure(Error)
+  }
+
+  /// Persists the new crypto account and kicks off its first sync.
+  /// Returns the outcome rather than mutating shared state directly so
+  /// the parent view can decide how to surface success vs failure.
+  func submit(name: String, chain: ChainConfig, walletAddressInput: String) async -> Outcome {
+    guard let walletAddress = Account.validatedWalletAddress(walletAddressInput) else {
+      return .invalidAddress
+    }
+    let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmedName.isEmpty else { return .invalidAddress }
+
+    let account = Account(
+      name: trimmedName,
+      type: .crypto,
+      instrument: accountInstrument,
+      valuationMode: .calculatedFromTrades,
+      walletAddress: walletAddress,
+      chainId: chain.chainId
+    )
+
+    do {
+      let created = try await accountStore.create(account)
+      // Kick off the initial sync without awaiting so the parent sheet
+      // can `dismiss()` the moment the account is persisted instead of
+      // sitting open through the entire network round-trip. The store
+      // tracks the spawned task so it's cancelled on profile teardown
+      // and collapses with the next scenePhase `.active` trigger
+      // rather than queueing a redundant pass. A `nil` `cryptoSyncStore`
+      // (degraded launch) leaves the account stale; the next
+      // stale-sync pass picks it up.
+      cryptoSyncStore?.scheduleInitialSync(for: created)
+      return .created(created)
+    } catch {
+      return .failure(error)
+    }
+  }
+}

--- a/Features/Crypto/CryptoAccountCreationView.swift
+++ b/Features/Crypto/CryptoAccountCreationView.swift
@@ -6,10 +6,11 @@ import SwiftUI
 ///
 /// Renders the crypto-specific portion of the account-creation sheet:
 /// chain picker (ETH / OP / Base / Polygon) and a wallet-address text
-/// field. Per the design spec, the account's `instrument` is set
-/// automatically to the chain's native instrument (ETH for
-/// Ethereum/OP/Base, MATIC for Polygon); per-token positions emerge
-/// from leg aggregation as wallet syncs land.
+/// field. The account is denominated in the profile currency (not the
+/// chain's native token); per-token positions emerge from leg
+/// aggregation, converted into the profile currency as wallet syncs
+/// land. The selected chain still drives `chainId` — i.e. which network
+/// the wallet sync queries.
 ///
 /// Address validation:
 ///
@@ -21,14 +22,11 @@ import SwiftUI
 ///   inline hint — v1 cannot resolve ENS to a 0x address.
 ///
 /// The shared shell in `CreateAccountView` owns the Form / NavigationStack
-/// / toolbar. This view exposes:
-///
-/// - `body` — the chain picker and address field (rendered inside the
-///   parent `Form`).
-/// - `CryptoAccountCreationLogic` — pure form-logic type used by the
-///   parent's Save button to validate and submit; kept separate so
-///   `CryptoAccountCreationLogicTests` exercise the contract directly
-///   without spinning up a SwiftUI view.
+/// / toolbar. This view renders only `body` — the chain picker and
+/// address field inside the parent `Form`. The validate-and-submit
+/// contract lives in `CryptoAccountCreationLogic` (its own file) so
+/// `CryptoAccountCreationStoreTests` can exercise it without spinning up
+/// a SwiftUI view.
 struct CryptoAccountCreationView: View {
   @Binding var chain: ChainConfig
   @Binding var walletAddressInput: String
@@ -73,68 +71,6 @@ struct CryptoAccountCreationView: View {
       return "ENS resolution not supported in v1 — paste a 0x address."
     }
     return nil
-  }
-}
-
-// MARK: - Submit logic
-
-/// Pure form-logic helper for the crypto branch of `CreateAccountView`.
-/// Owns the create-account + kick-off-sync sequence so the parent view
-/// can dispatch from its Save button without relying on a transient
-/// SwiftUI view instance, and so `CryptoAccountCreationLogicTests` can
-/// exercise the contract end-to-end against `TestBackend`.
-@MainActor
-struct CryptoAccountCreationLogic {
-  let accountStore: AccountStore
-  /// May be `nil` in degraded launches (preview / no instrument
-  /// registry). When `nil`, account creation still proceeds; the first
-  /// sync simply isn't kicked off — the next scenePhase `.active`
-  /// stale-check will pick it up.
-  let cryptoSyncStore: CryptoSyncStore?
-
-  /// Output of `submit(name:chain:walletAddressInput:)`. The parent
-  /// surface uses `.created` to dismiss the sheet and `.failure` /
-  /// `.invalidAddress` to show an inline error message.
-  enum Outcome: Sendable {
-    case created(Account)
-    case invalidAddress
-    case failure(Error)
-  }
-
-  /// Persists the new crypto account and kicks off its first sync.
-  /// Returns the outcome rather than mutating shared state directly so
-  /// the parent view can decide how to surface success vs failure.
-  func submit(name: String, chain: ChainConfig, walletAddressInput: String) async -> Outcome {
-    guard let walletAddress = Account.validatedWalletAddress(walletAddressInput) else {
-      return .invalidAddress
-    }
-    let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
-    guard !trimmedName.isEmpty else { return .invalidAddress }
-
-    let account = Account(
-      name: trimmedName,
-      type: .crypto,
-      instrument: chain.nativeInstrument,
-      valuationMode: .calculatedFromTrades,
-      walletAddress: walletAddress,
-      chainId: chain.chainId
-    )
-
-    do {
-      let created = try await accountStore.create(account)
-      // Kick off the initial sync without awaiting so the parent sheet
-      // can `dismiss()` the moment the account is persisted instead of
-      // sitting open through the entire network round-trip. The store
-      // tracks the spawned task so it's cancelled on profile teardown
-      // and collapses with the next scenePhase `.active` trigger
-      // rather than queueing a redundant pass. A `nil` `cryptoSyncStore`
-      // (degraded launch) leaves the account stale; the next
-      // stale-sync pass picks it up.
-      cryptoSyncStore?.scheduleInitialSync(for: created)
-      return .created(created)
-    } catch {
-      return .failure(error)
-    }
   }
 }
 

--- a/Features/Crypto/CryptoWalletAccountView.swift
+++ b/Features/Crypto/CryptoWalletAccountView.swift
@@ -81,7 +81,10 @@ struct CryptoWalletAccountView: View {
     id: UUID(),
     name: "Preview Wallet",
     type: .crypto,
-    instrument: ChainConfig.ethereum.nativeInstrument,
+    // Crypto accounts are denominated in the profile currency, not the
+    // chain's native token — match production so the preview exercises
+    // the real `multiInstrumentPositionsSplit` branch.
+    instrument: .AUD,
     valuationMode: .calculatedFromTrades,
     walletAddress: "0x0000000000000000000000000000000000000000",
     chainId: 1)

--- a/MoolahTests/Features/AccountStorePreloadFilterTests.swift
+++ b/MoolahTests/Features/AccountStorePreloadFilterTests.swift
@@ -38,6 +38,44 @@ struct AccountStorePreloadFilterTests {
     #expect(store.investmentValues[trades.id] == nil)
   }
 
+  @Test("crypto accounts are never preloaded into the investment snapshot cache")
+  func cryptoAccountNeverPreloaded() async throws {
+    let (backend, _) = try TestBackend.create()
+    let recorded = try await backend.accounts.create(
+      Account(
+        name: "R", type: .investment, instrument: .AUD,
+        valuationMode: .recordedValue))
+    // A crypto account is `.calculatedFromTrades` and denominated in the
+    // profile currency; its worth comes from leg aggregation, never the
+    // investment-value snapshot. A stray snapshot in the repo must not
+    // leak into `investmentValues` for it.
+    let wallet = try await backend.accounts.create(
+      Account(
+        name: "Hardware Wallet", type: .crypto, instrument: .AUD,
+        valuationMode: .calculatedFromTrades,
+        walletAddress: "0x" + String(repeating: "a", count: 40),
+        chainId: 1))
+    try await backend.investments.setValue(
+      accountId: recorded.id, date: Date(timeIntervalSince1970: 1_700_000_000),
+      value: InstrumentAmount(quantity: 100, instrument: .AUD))
+    try await backend.investments.setValue(
+      accountId: wallet.id, date: Date(timeIntervalSince1970: 1_700_000_000),
+      value: InstrumentAmount(quantity: 777, instrument: .AUD))
+
+    let store = AccountStore(
+      repository: backend.accounts,
+      conversionService: FixedConversionService(),
+      targetInstrument: .AUD,
+      investmentRepository: backend.investments)
+    try await store.waitForNextEmission(
+      matching: { $0.investmentValues[recorded.id] != nil },
+      description: "investment values preloaded"
+    )
+
+    #expect(store.investmentValues[recorded.id] != nil)
+    #expect(store.investmentValues[wallet.id] == nil)
+  }
+
   @Test("flipping mode to recordedValue triggers a snapshot preload")
   func updateToRecordedValuePreloadsSnapshot() async throws {
     let (backend, _) = try TestBackend.create()

--- a/MoolahTests/Features/BalanceCalculatorValuationModeTests.swift
+++ b/MoolahTests/Features/BalanceCalculatorValuationModeTests.swift
@@ -97,6 +97,50 @@ struct BalanceCalculatorValuationModeTests {
     #expect(total == InstrumentAmount(quantity: 500, instrument: .AUD))
   }
 
+  // MARK: - Crypto account conversion date
+
+  /// A crypto account is denominated in the profile currency, so its
+  /// worth is "what are my tokens worth *today*". `displayBalance`
+  /// defaults to `Date()`, so the default path must pick the current
+  /// rate; pinning a historic date must pick the historic rate. This
+  /// pins the conversion-date semantic the crypto-account change relies
+  /// on (a regression to a historic date would silently misvalue every
+  /// wallet).
+  @Test(
+    "crypto account: native-token positions convert to the profile currency at the current date")
+  func cryptoAccountConvertsPositionsAtCurrentDate() async throws {
+    let eth = Instrument.crypto(
+      chainId: 1,
+      contractAddress: "0x0000000000000000000000000000000000000000",
+      symbol: "ETH",
+      name: "Ether",
+      decimals: 18)
+    let historic = Date(timeIntervalSince1970: 1_577_836_800)  // 2020-01-01
+    let recent = Date(timeIntervalSince1970: 1_704_067_200)  // 2024-01-01
+    let conversion = DateBasedFixedConversionService(rates: [
+      historic: [eth.id: 1000],
+      recent: [eth.id: 4000],
+    ])
+    let calculator = AccountBalanceCalculator(
+      conversionService: conversion, targetInstrument: .AUD)
+    var account = Account(
+      name: "Hardware Wallet", type: .crypto, instrument: .AUD,
+      valuationMode: .calculatedFromTrades)
+    account.positions = [Position(instrument: eth, quantity: 2)]
+
+    // Default path uses `Date()` (well past `recent`): the wallet reflects
+    // today's rate — 2 ETH × 4000 — not the historic 1000.
+    let current = try await calculator.displayBalance(
+      for: account, investmentValue: nil)
+    #expect(current == InstrumentAmount(quantity: 8000, instrument: .AUD))
+
+    // Pinning a historic date selects the historic rate, proving the
+    // conversion is genuinely date-driven and the default really is "now".
+    let asOfHistoric = try await calculator.displayBalance(
+      for: account, investmentValue: nil, date: historic)
+    #expect(asOfHistoric == InstrumentAmount(quantity: 2000, instrument: .AUD))
+  }
+
   // MARK: - .knownZero positions (issue #790)
 
   /// Issue #790: positions whose conversion resolves to `.knownZero`

--- a/MoolahTests/Features/Crypto/CryptoAccountCreationStoreTests.swift
+++ b/MoolahTests/Features/Crypto/CryptoAccountCreationStoreTests.swift
@@ -74,12 +74,19 @@ struct CryptoAccountCreationStoreTests {
       alchemy: alchemy)
   }
 
-  @Test("Successful submit creates the account with the chain's native instrument")
+  /// Profile currency handed to the create flow. A new crypto account is
+  /// denominated in the profile currency (not the chain's native token);
+  /// per-token positions emerge from leg aggregation converted into this
+  /// instrument as wallet syncs land.
+  nonisolated static let profileInstrument: Instrument = .defaultTestInstrument
+
+  @Test("Successful submit creates the account denominated in the profile currency")
   func successfulSubmitCreatesCryptoAccount() async throws {
     let fixture = try makeFixture()
     let logic = CryptoAccountCreationLogic(
       accountStore: fixture.accountStore,
-      cryptoSyncStore: fixture.cryptoSyncStore)
+      cryptoSyncStore: fixture.cryptoSyncStore,
+      accountInstrument: Self.profileInstrument)
 
     let outcome = await logic.submit(
       name: "Hardware Wallet",
@@ -93,7 +100,7 @@ struct CryptoAccountCreationStoreTests {
     #expect(created.type == .crypto)
     #expect(created.walletAddress == Self.validAddress)
     #expect(created.chainId == ChainConfig.ethereum.chainId)
-    #expect(created.instrument == ChainConfig.ethereum.nativeInstrument)
+    #expect(created.instrument == Self.profileInstrument)
     #expect(created.name == "Hardware Wallet")
     // Crypto wallets compute balance from leg aggregation, so they ship
     // as `.calculatedFromTrades` from creation. The `Account` default is
@@ -114,12 +121,15 @@ struct CryptoAccountCreationStoreTests {
     #expect(fixture.accountStore.accounts.first?.id == created.id)
   }
 
-  @Test("Polygon chain produces a MATIC-native account")
-  func polygonChainSetsMaticInstrument() async throws {
+  @Test(
+    "Chain selection does not change the account instrument — Polygon still uses the profile currency"
+  )
+  func chainDoesNotOverrideProfileInstrument() async throws {
     let fixture = try makeFixture()
     let logic = CryptoAccountCreationLogic(
       accountStore: fixture.accountStore,
-      cryptoSyncStore: fixture.cryptoSyncStore)
+      cryptoSyncStore: fixture.cryptoSyncStore,
+      accountInstrument: Self.profileInstrument)
 
     let outcome = await logic.submit(
       name: "Polygon Hot Wallet",
@@ -130,9 +140,12 @@ struct CryptoAccountCreationStoreTests {
       Issue.record("Expected .created outcome, got \(outcome)")
       return
     }
+    // The chain still drives `chainId` (and therefore which network the
+    // wallet sync queries), but the account is denominated in the
+    // profile currency regardless of the chain's native token.
     #expect(created.chainId == ChainConfig.polygon.chainId)
-    #expect(created.instrument == ChainConfig.polygon.nativeInstrument)
-    #expect(created.instrument.ticker == "MATIC")
+    #expect(created.instrument == Self.profileInstrument)
+    #expect(created.instrument != ChainConfig.polygon.nativeInstrument)
   }
 
   @Test("Successful submit kicks off the initial Alchemy sync for the new account")
@@ -140,7 +153,8 @@ struct CryptoAccountCreationStoreTests {
     let fixture = try makeFixture()
     let logic = CryptoAccountCreationLogic(
       accountStore: fixture.accountStore,
-      cryptoSyncStore: fixture.cryptoSyncStore)
+      cryptoSyncStore: fixture.cryptoSyncStore,
+      accountInstrument: Self.profileInstrument)
 
     let outcome = await logic.submit(
       name: "Sync Wallet",
@@ -176,7 +190,8 @@ struct CryptoAccountCreationStoreTests {
     }
     let logic = CryptoAccountCreationLogic(
       accountStore: fixture.accountStore,
-      cryptoSyncStore: fixture.cryptoSyncStore)
+      cryptoSyncStore: fixture.cryptoSyncStore,
+      accountInstrument: Self.profileInstrument)
 
     let start = ContinuousClock.now
     let outcome = await logic.submit(
@@ -206,7 +221,8 @@ struct CryptoAccountCreationStoreTests {
     let fixture = try makeFixture()
     let logic = CryptoAccountCreationLogic(
       accountStore: fixture.accountStore,
-      cryptoSyncStore: fixture.cryptoSyncStore)
+      cryptoSyncStore: fixture.cryptoSyncStore,
+      accountInstrument: Self.profileInstrument)
 
     let outcome = await logic.submit(
       name: "Bad Address Wallet",
@@ -227,7 +243,8 @@ struct CryptoAccountCreationStoreTests {
     let fixture = try makeFixture()
     let logic = CryptoAccountCreationLogic(
       accountStore: fixture.accountStore,
-      cryptoSyncStore: fixture.cryptoSyncStore)
+      cryptoSyncStore: fixture.cryptoSyncStore,
+      accountInstrument: Self.profileInstrument)
 
     let outcome = await logic.submit(
       name: "   ",
@@ -247,7 +264,8 @@ struct CryptoAccountCreationStoreTests {
     let fixture = try makeFixture()
     let logic = CryptoAccountCreationLogic(
       accountStore: fixture.accountStore,
-      cryptoSyncStore: fixture.cryptoSyncStore)
+      cryptoSyncStore: fixture.cryptoSyncStore,
+      accountInstrument: Self.profileInstrument)
 
     // Mix of leading whitespace, mixed case, and trailing newline.
     let raw = "  0xABCDEF0123456789ABCDEF0123456789ABCDEF01\n"
@@ -269,7 +287,8 @@ struct CryptoAccountCreationStoreTests {
     let fixture = try makeFixture()
     let logic = CryptoAccountCreationLogic(
       accountStore: fixture.accountStore,
-      cryptoSyncStore: nil)
+      cryptoSyncStore: nil,
+      accountInstrument: Self.profileInstrument)
 
     let outcome = await logic.submit(
       name: "Degraded Launch Wallet",


### PR DESCRIPTION
## What

A newly-created crypto account now takes the **profile currency** as its account instrument instead of the selected chain's native token (ETH for Ethereum/OP/Base, MATIC for Polygon).

## Why

Crypto accounts use `.calculatedFromTrades`, so per-token positions accrue from leg aggregation regardless of the account instrument. Denominating the account in the profile currency:

- lets a wallet's worth sit alongside every other account in one currency (no per-chain conversion at read time), and
- lets a single account span multiple tokens without picking an arbitrary "primary" token.

The selected chain still drives `chainId` — i.e. which network the wallet sync queries.

## Changes

- `CryptoAccountCreationLogic` now takes an injected `accountInstrument`, threaded from `CreateAccountView` (which already receives the profile currency). Extracted to its own file (`CryptoAccountCreationLogic.swift`) now that it carries a standalone, separately-tested contract.
- Fixed the `CryptoWalletAccountView` `#Preview` to use a fiat instrument so it exercises the real production rendering branch.
- Documented the conversion-date invariant in `AccountBalanceCalculator.displayBalance`.

## Tests

- Profile-currency invariant on creation; chain selection does not override the account instrument.
- Crypto-account positions convert to the profile currency at the **current** date (regression guard via `DateBasedFixedConversionService`).
- Crypto accounts are never preloaded into the investment snapshot cache.

All affected suites pass on macOS; `just format-check` clean. Reviewed via `code-review` and `instrument-conversion-review` agents; findings applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)