### PR TITLE
ci: fix deploy-site failure — SHA-pin Pages actions (bump to latest)

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -29,13 +29,13 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Configure Pages
-        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
 
       - name: Upload site artifact
-        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: site
 
       - name: Deploy to GitHub Pages
         id: deploy
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0


### PR DESCRIPTION
## Problem

The `deploy-site` job [failed](https://github.com/ajsutton/moolah-native/actions/runs/25976420341/job/76357195707) the org policy check:

```
The action actions/upload-artifact@v4 is not allowed in ajsutton/moolah-native because all actions must be pinned to a full-length commit SHA.
```

All `uses:` in our workflow files were already SHA-pinned. The rejection is **transitive**: `actions/upload-pages-artifact@v3.0.1` internally calls the unpinned `actions/upload-artifact@v4`, and the org rule enforces SHA pinning on nested composite-action references too.

## Fix

`actions/upload-pages-artifact@v5.0.0` SHA-pins its internal `actions/upload-artifact` dependency (`@…f024f # v7.0.0`), which clears the policy. While here, the rest of the Pages action trio is bumped to latest (per request):

| Action | Before | After |
|---|---|---|
| `actions/configure-pages` | v5.0.0 | **v6.0.0** |
| `actions/upload-pages-artifact` | v3.0.1 | **v5.0.0** (required fix) |
| `actions/deploy-pages` | v4.0.5 | **v5.0.0** |

`actions/checkout` was already at the latest (v6.0.2). `configure-pages`/`deploy-pages` are JS actions with no sub-action `uses:`, so no further transitive exposure. `deploy-pages` v5.0.0 is a Node 24 bump only — no artifact-format break, consumes the v5 artifact fine.

All actions remain pinned to full-length commit SHAs with a version comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)