### PR TITLE
Use relative asset paths so the site previews from any base

### DIFF
--- a/site/404.html
+++ b/site/404.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Page not found — moolah.rocks</title>
     <meta name="robots" content="noindex" />
-    <link rel="icon" href="/favicon.ico" sizes="any" />
-    <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+    <link rel="icon" href="favicon.ico" sizes="any" />
+    <link rel="apple-touch-icon" href="apple-touch-icon.png" />
     <meta name="theme-color" content="#07102E" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -14,17 +14,17 @@
       href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="/styles.css" />
+    <link rel="stylesheet" href="styles.css" />
   </head>
   <body>
     <main>
       <section class="hero">
-        <img src="/assets/icon.svg" alt="" class="hero-icon" />
+        <img src="assets/icon.svg" alt="" class="hero-icon" />
         <h1>Nothing&nbsp;here.</h1>
         <p class="hero-sub">
           That page rocked off somewhere. Let's get you back to solid ground.
         </p>
-        <a class="cta-button" href="/">Back to moolah.rocks</a>
+        <a class="cta-button" href=".">Back to moolah.rocks</a>
       </section>
     </main>
   </body>

--- a/site/index.html
+++ b/site/index.html
@@ -9,11 +9,11 @@
       content="Personal finance for iPhone, iPad, and Mac. Lock down the money stuff so the rest of your life stays wide open. Private, powerful, yours. Currently in private beta."
     />
 
-    <link rel="icon" href="/favicon.ico" sizes="any" />
-    <link rel="icon" type="image/png" sizes="32x32" href="/icon-32.png" />
-    <link rel="icon" type="image/png" sizes="16x16" href="/icon-16.png" />
-    <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
-    <link rel="manifest" href="/site.webmanifest" />
+    <link rel="icon" href="favicon.ico" sizes="any" />
+    <link rel="icon" type="image/png" sizes="32x32" href="icon-32.png" />
+    <link rel="icon" type="image/png" sizes="16x16" href="icon-16.png" />
+    <link rel="apple-touch-icon" href="apple-touch-icon.png" />
+    <link rel="manifest" href="site.webmanifest" />
     <meta name="apple-mobile-web-app-title" content="moolah.rocks" />
     <meta name="application-name" content="moolah.rocks" />
     <meta name="theme-color" content="#07102E" />
@@ -46,7 +46,7 @@
       href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700;800&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="/styles.css" />
+    <link rel="stylesheet" href="styles.css" />
   </head>
   <body>
     <!--
@@ -54,9 +54,9 @@
       404.html) with the real address once moolah.rocks email is set up.
     -->
     <header class="site-header">
-      <a class="site-header-brand" href="/" aria-label="moolah.rocks home">
+      <a class="site-header-brand" href="." aria-label="moolah.rocks home">
         <img
-          src="/assets/lockup-horizontal-on-dark.png"
+          src="assets/lockup-horizontal-on-dark.png"
           alt="moolah.rocks"
           height="28"
         />
@@ -65,7 +65,7 @@
 
     <main>
       <section class="hero">
-        <img src="/assets/icon.svg" alt="" class="hero-icon" />
+        <img src="assets/icon.svg" alt="" class="hero-icon" />
         <h1>
           Your <span class="accent-blue">money</span>,
           rock&nbsp;<span class="accent-gold">solid</span>.
@@ -179,7 +179,7 @@
 
     <footer class="site-footer">
       <img
-        src="/assets/lockup-horizontal-on-dark.png"
+        src="assets/lockup-horizontal-on-dark.png"
         alt="moolah.rocks"
         height="22"
       />

--- a/site/site.webmanifest
+++ b/site/site.webmanifest
@@ -2,14 +2,15 @@
   "name": "Moolah.rocks",
   "short_name": "Moolah",
   "description": "Personal finance that rocks \u2014 track income, expenses, and net balance.",
+  "start_url": ".",
   "icons": [
     {
-      "src": "/android-chrome-192x192.png",
+      "src": "android-chrome-192x192.png",
       "sizes": "192x192",
       "type": "image/png"
     },
     {
-      "src": "/android-chrome-512x512.png",
+      "src": "android-chrome-512x512.png",
       "sizes": "512x512",
       "type": "image/png"
     }


### PR DESCRIPTION
## Summary

The deployed site uses root-relative paths (`/styles.css`,
`/assets/...`, `/favicon.ico`, etc.), so styles and images 404 when it
is served under a path prefix — e.g. the GitHub Pages **project** URL
`https://ajsutton.github.io/moolah-native/`. This makes it impossible to
preview before the `moolah.rocks` domain cutover.

This PR converts every in-page reference to a relative path so the site
renders correctly from any base (project pages, apex domain, or a local
folder):

- `site/index.html` — icons, manifest, stylesheet, hero/footer/header
  images now relative; the home link is `.`.
- `site/404.html` — same; "Back to moolah.rocks" link is `.`.
- `site/site.webmanifest` — icon `src` values relative; added
  `"start_url": "."` so the installed PWA also works under a subpath.

Left intentionally absolute: the `og:url` / `og:image` / `twitter:image`
meta tags — social-card crawlers require absolute URLs, and these point
at the production `https://moolah.rocks/...` which is correct post-cutover
and irrelevant to preview.

## Test plan

- [ ] After merge, the **Deploy site** workflow runs on `main`.
- [ ] Open `https://ajsutton.github.io/moolah-native/` — styles, fonts,
      hero icon, lockup images, and favicon all load (no 404s in the
      network panel).
- [ ] `https://ajsutton.github.io/moolah-native/site.webmanifest`
      resolves and its icon URLs resolve relative to it.
- [ ] Paths still resolve correctly when later served from the
      `moolah.rocks` apex.

## Notes

`404.html` is served by GitHub Pages for unknown paths at any depth;
relative paths resolve correctly for this single-page site (no nested
routes), which is the realistic case.

https://claude.ai/code/session_01TAcF2RJbEdG6sRfDKkjjS8

---
_Generated by [Claude Code](https://claude.ai/code/session_01TAcF2RJbEdG6sRfDKkjjS8)_