### PR TITLE
fix(crypto): meaningful message for CryptoPriceError

### DIFF
--- a/Domain/Repositories/CryptoPriceClient.swift
+++ b/Domain/Repositories/CryptoPriceClient.swift
@@ -7,6 +7,19 @@ enum CryptoPriceError: Error, Equatable {
   case allProvidersFailed(tokenId: String)
 }
 
+extension CryptoPriceError: LocalizedError {
+  var errorDescription: String? {
+    switch self {
+    case let .noPriceAvailable(tokenId, date):
+      return "No price available for \(tokenId) on \(date)."
+    case let .noProviderMapping(tokenId, provider):
+      return "No price source is configured for \(tokenId) (provider: \(provider))."
+    case let .allProvidersFailed(tokenId):
+      return "Unable to fetch a price for \(tokenId) from any source."
+    }
+  }
+}
+
 /// Abstraction for fetching cryptocurrency prices from an external source.
 /// Implementations: CryptoCompareClient (default), BinanceClient (fallback), CoinGeckoClient (premium).
 /// All prices are denominated in USD.

--- a/MoolahTests/Domain/CryptoPriceErrorTests.swift
+++ b/MoolahTests/Domain/CryptoPriceErrorTests.swift
@@ -1,0 +1,33 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("CryptoPriceError")
+struct CryptoPriceErrorTests {
+  @Test
+  func noPriceAvailableNamesTokenAndDate() {
+    let error = CryptoPriceError.noPriceAvailable(tokenId: "ETH", date: "2026-05-17")
+    let message = error.localizedDescription
+    #expect(message.contains("ETH"))
+    #expect(message.contains("2026-05-17"))
+    #expect(!message.contains("CryptoPriceError"))
+  }
+
+  @Test
+  func noProviderMappingNamesTokenAndProvider() {
+    let error = CryptoPriceError.noProviderMapping(tokenId: "SPAM", provider: "CryptoCompare")
+    let message = error.localizedDescription
+    #expect(message.contains("SPAM"))
+    #expect(message.contains("CryptoCompare"))
+    #expect(!message.contains("CryptoPriceError"))
+  }
+
+  @Test
+  func allProvidersFailedNamesToken() {
+    let error = CryptoPriceError.allProvidersFailed(tokenId: "BTC")
+    let message = error.localizedDescription
+    #expect(message.contains("BTC"))
+    #expect(!message.contains("CryptoPriceError"))
+  }
+}


### PR DESCRIPTION
## Problem

A running-balance conversion failure showed the user a cryptic dialog:

> Operation failed: Unable to convert a transaction to AUD. The running balance is unavailable until the rate source recovers. (The operation couldn't be completed. (Moolah.CryptoPriceError error 1.))

`CryptoPriceError` did not conform to `LocalizedError`, so `error.localizedDescription` (used when populating the prefetch failure description in `TransactionPage`) fell back to the opaque `NSError` default.

## Fix

Add a `LocalizedError` conformance to `CryptoPriceError` whose `errorDescription` names the token (and date / provider) that is missing a price:

- `.noPriceAvailable` → "No price available for ETH on 2026-05-17."
- `.noProviderMapping` → "No price source is configured for SPAM (provider: CryptoCompare)."
- `.allProvidersFailed` → "Unable to fetch a price for BTC from any source."

The wrapper message in `RunningBalanceConversionError` is unchanged; it now interpolates a readable underlying description instead of the enum code.

## Tests

New `CryptoPriceErrorTests` asserts each case's message names the token (and date/provider) and no longer contains the raw `CryptoPriceError` type name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)