### PR TITLE
Coinstash instrument resolution via getCoinBySymbol token metadata

### DIFF
--- a/App/ProfileSession+CryptoSync.swift
+++ b/App/ProfileSession+CryptoSync.swift
@@ -67,6 +67,9 @@ extension ProfileSession {
     guard let registry else { return nil }
     let rateLimiter = RateLimiter(permitsPerSecond: 25)
     let alchemy: any AlchemyClient = LiveAlchemyClient(
+      // Closure (not a resolved value): a key entered in Settings after this
+      // wiring is built is visible on the next sync cycle without a rebuild,
+      // and the key never lives on the client object itself.
       apiKeyProvider: { ProfileSession.resolveAlchemyApiKey() },
       rateLimiter: rateLimiter)
     let discovery = CryptoTokenDiscoveryService(
@@ -143,11 +146,20 @@ extension ProfileSession {
           // non-AUD profile would otherwise mis-denominate.
           fiatInstrument: fiatInstrument,
           existingLegInstrumentIds: {
-            (try? await txRepo.distinctLegInstrumentIds()) ?? []
+            do {
+              return try await txRepo.distinctLegInstrumentIds()
+            } catch {
+              Self.logger.error(
+                "distinctLegInstrumentIds failed: \(error, privacy: .public)")
+              throw error
+            }
           }),
         discovery: discovery),
       metadataResolverFactory: { token in
         CoinstashAssetMetadataResolver(client: coinstashClient, token: token)
       })
   }
+
+  nonisolated private static let logger = Logger(
+    subsystem: "com.moolah.app", category: "CryptoSyncWiring")
 }

--- a/App/ProfileSession+CryptoSync.swift
+++ b/App/ProfileSession+CryptoSync.swift
@@ -65,18 +65,49 @@ extension ProfileSession {
     profileInstrument: Instrument
   ) -> CryptoSyncWiring? {
     guard let registry else { return nil }
-
     let rateLimiter = RateLimiter(permitsPerSecond: 25)
-    // Pass a closure rather than a resolved value so a key added in the
-    // settings UI *after* this wiring is built is visible on the next
-    // sync cycle, and so the key is never retained on the client itself
-    // — it lives only on the local stack frame of each in-flight
-    // request.
     let alchemy: any AlchemyClient = LiveAlchemyClient(
       apiKeyProvider: { ProfileSession.resolveAlchemyApiKey() },
       rateLimiter: rateLimiter)
     let discovery = CryptoTokenDiscoveryService(
       registry: registry, resolver: cryptoPriceService, alchemy: alchemy)
+    let walletSyncEngine = makeWalletSyncEngine(
+      alchemy: alchemy,
+      blockExplorer: makeLiveBlockExplorer(),
+      discovery: discovery,
+      backend: backend)
+    let walletApplyEngine = WalletApplyEngine(
+      transactions: backend.transactions,
+      walletSyncState: backend.walletSyncState,
+      importRules: NoOpWalletImportRulesEngine())
+    let coinstashSource = makeCoinstashSource(
+      registry: registry,
+      fiatInstrument: profileInstrument,
+      backend: backend,
+      discovery: discovery)
+    let store = SyncedAccountStore(
+      sources: [WalletSyncSource(engine: walletSyncEngine), coinstashSource],
+      walletApplyEngine: walletApplyEngine,
+      walletSyncState: backend.walletSyncState,
+      accounts: backend.accounts)
+    return CryptoSyncWiring(store: store, discovery: discovery)
+  }
+
+  // MARK: - Private helpers
+
+  @MainActor
+  private static func makeLiveBlockExplorer() -> any BlockExplorerClient {
+    // Blockscout public unauthenticated tier: ~5 req/s per IP.
+    LiveBlockscoutClient(rateLimiter: RateLimiter(permitsPerSecond: 5))
+  }
+
+  @MainActor
+  private static func makeWalletSyncEngine(
+    alchemy: any AlchemyClient,
+    blockExplorer: any BlockExplorerClient,
+    discovery: CryptoTokenDiscoveryService,
+    backend: BackendProvider
+  ) -> WalletSyncEngine {
     let importOriginFactory: @Sendable (UUID) -> ImportOrigin = { accountId in
       ImportOrigin(
         rawDescription: "wallet:\(accountId.uuidString)",
@@ -85,38 +116,38 @@ extension ProfileSession {
         importSessionId: UUID(),
         parserIdentifier: "alchemy-wallet-sync")
     }
-    // Blockscout public unauthenticated tier: ~5 req/s per IP.
-    let blockscoutRateLimiter = RateLimiter(permitsPerSecond: 5)
-    let blockExplorer: any BlockExplorerClient = LiveBlockscoutClient(
-      rateLimiter: blockscoutRateLimiter)
-    let walletSyncEngine = WalletSyncEngine(
+    return WalletSyncEngine(
       alchemy: alchemy,
       blockExplorer: blockExplorer,
       discovery: discovery,
       walletSyncState: backend.walletSyncState,
       importOriginFactory: importOriginFactory)
-    let walletApplyEngine = WalletApplyEngine(
-      transactions: backend.transactions,
-      walletSyncState: backend.walletSyncState,
-      importRules: NoOpWalletImportRulesEngine())
-    // Provider-neutral sources. The store asks each `handles(_:)` which
-    // accounts it can sync — it never branches on `account.type`.
-    // Future exchanges append their own `<Provider>SyncSource` here.
-    let walletSource = WalletSyncSource(engine: walletSyncEngine)
-    let coinstashSource = CoinstashSyncSource(
+  }
+
+  @MainActor
+  private static func makeCoinstashSource(
+    registry: any InstrumentRegistryRepository,
+    fiatInstrument: Instrument,
+    backend: BackendProvider,
+    discovery: CryptoTokenDiscoveryService
+  ) -> CoinstashSyncSource {
+    let coinstashClient = CoinstashClient()
+    let txRepo = backend.transactions
+    return CoinstashSyncSource(
       tokenStore: ExchangeTokenStore(synchronizable: true),
-      client: CoinstashClient(),
+      client: coinstashClient,
       engine: ExchangeSyncEngine(
         resolver: ExchangeInstrumentResolver(
           registry: registry,
           // The profile's own currency, NOT a hardcoded `.AUD` — a
           // non-AUD profile would otherwise mis-denominate.
-          fiatInstrument: profileInstrument)))
-    let store = SyncedAccountStore(
-      sources: [walletSource, coinstashSource],
-      walletApplyEngine: walletApplyEngine,
-      walletSyncState: backend.walletSyncState,
-      accounts: backend.accounts)
-    return CryptoSyncWiring(store: store, discovery: discovery)
+          fiatInstrument: fiatInstrument,
+          existingLegInstrumentIds: {
+            (try? await txRepo.distinctLegInstrumentIds()) ?? []
+          }),
+        discovery: discovery),
+      metadataResolverFactory: { token in
+        CoinstashAssetMetadataResolver(client: coinstashClient, token: token)
+      })
   }
 }

--- a/Backends/GRDB/Repositories/GRDBTransactionRepository+ExternalIdLookup.swift
+++ b/Backends/GRDB/Repositories/GRDBTransactionRepository+ExternalIdLookup.swift
@@ -78,4 +78,12 @@ extension GRDBTransactionRepository {
         > 0
     }
   }
+
+  func distinctLegInstrumentIds() async throws -> Set<String> {
+    try await database.read { database in
+      let rows = try String.fetchAll(
+        database, sql: "SELECT DISTINCT instrument_id FROM transaction_leg")
+      return Set(rows)
+    }
+  }
 }

--- a/Domain/Models/CryptoProviderMapping.swift
+++ b/Domain/Models/CryptoProviderMapping.swift
@@ -13,6 +13,15 @@ struct CryptoProviderMapping: Codable, Sendable, Hashable, Identifiable {
 
   var id: String { instrumentId }
 
+  /// Returns `true` when at least one provider identifier is populated —
+  /// i.e. this instrument has a price-provider mapping. The callers
+  /// (`ExchangeInstrumentResolver`, `CryptoTokenDiscoveryService`) use
+  /// this to distinguish a mapped/`.priced` registration from an
+  /// `.unpriced` stub.
+  var hasProviderMapping: Bool {
+    coingeckoId != nil || cryptocompareSymbol != nil || binanceSymbol != nil
+  }
+
   /// Built-in presets for common tokens.
   static let builtInPresets: [CryptoProviderMapping] =
     CryptoRegistration.builtInPresets.map(\.mapping)

--- a/Domain/Repositories/TransactionRepository.swift
+++ b/Domain/Repositories/TransactionRepository.swift
@@ -82,6 +82,10 @@ protocol TransactionRepository: Sendable {
   /// imported transactions, so each leg is checked against the partial
   /// unique index before insertion.
   func legExists(accountId: UUID, externalId: String) async throws -> Bool
+  /// Distinct instrument ids appearing on any persisted transaction leg.
+  /// Used only by exchange-import resolution's rare registry-fallback
+  /// tie-break; cheap (`SELECT DISTINCT`), not on a hot path.
+  func distinctLegInstrumentIds() async throws -> Set<String>
 }
 
 extension TransactionRepository {

--- a/MoolahTests/Backends/GRDB/GRDBCreatePathRegistersInstrumentTests.swift
+++ b/MoolahTests/Backends/GRDB/GRDBCreatePathRegistersInstrumentTests.swift
@@ -257,4 +257,55 @@ struct GRDBCreatePathRegistersInstrumentTests {
       absent,
       "resolution must come from the shared registry; the per-profile table is dropped")
   }
+
+  @Test("distinctLegInstrumentIds returns a de-duplicated set across all persisted legs")
+  func distinctLegInstrumentIdsReturnsDistinctSet() async throws {
+    let perProfile = try ProfileDatabase.openInMemory()
+    let sharedQueue = try ProfileIndexDatabase.openInMemory()
+    let registry = GRDBInstrumentRegistryRepository(database: sharedQueue)
+
+    let repo = GRDBTransactionRepository(
+      database: perProfile,
+      defaultInstrument: Instrument.fiat(code: "AUD"),
+      conversionService: FixedConversionService(),
+      instrumentResolver: registry,
+      instrumentRegistrar: registry)
+
+    let eth = Instrument.crypto(
+      chainId: 1, contractAddress: nil, symbol: "ETH", name: "Ethereum",
+      decimals: 18)
+    let aud = Instrument.fiat(code: "AUD")
+    let account = Account(
+      name: "Test Account", type: .crypto, instrument: eth,
+      valuationMode: .calculatedFromTrades, walletAddress: "0xtest",
+      chainId: 1)
+
+    // Seed the account row so FK-like constraints are satisfied, mirroring
+    // `sharedRegistryPreservesResolution` which inserts an `AccountRow`
+    // before creating any transactions.
+    try await perProfile.write { database in
+      try AccountRow(domain: account).insert(database)
+    }
+
+    // Two transactions: one with an ETH leg, one with an AUD leg and an ETH leg.
+    // Distinct ids should be exactly {eth.id, aud.id}, with no duplicates.
+    let txn1 = Transaction(
+      date: Date(), payee: "Buy ETH",
+      legs: [
+        TransactionLeg(accountId: account.id, instrument: eth, quantity: 1, type: .income)
+      ])
+    let txn2 = Transaction(
+      date: Date(), payee: "Fee",
+      legs: [
+        TransactionLeg(accountId: account.id, instrument: aud, quantity: -10, type: .expense),
+        TransactionLeg(accountId: account.id, instrument: eth, quantity: -1, type: .expense),
+      ])
+    _ = try await repo.create(txn1)
+    _ = try await repo.create(txn2)
+
+    let ids = try await repo.distinctLegInstrumentIds()
+    #expect(ids.contains(eth.id))
+    #expect(ids.contains(aud.id))
+    #expect(ids.count == 2)
+  }
 }

--- a/MoolahTests/Features/Sync/SyncedAccountStoreExchangeTests.swift
+++ b/MoolahTests/Features/Sync/SyncedAccountStoreExchangeTests.swift
@@ -68,13 +68,35 @@ struct SyncedAccountStoreExchangeTests {
   private func makeExchangeAccount(
     in fixture: Fixture, token: String
   ) throws -> Account {
+    try makeExchangeAccount(
+      in: fixture, token: token,
+      client: StubExchangeClient(deposit: 100),
+      metadataResolver: StubMetadataResolver([:]))
+  }
+
+  /// Seeds an `.exchange` account and registers a `CoinstashSyncSource`
+  /// wired with the supplied `client` and `metadataResolver`. Used by
+  /// tests that need to exercise the crypto (non-fiat) resolution path.
+  ///
+  /// Uses `fixture.backend.grdbInstruments` — the shared profile-index
+  /// registry — so instrument lookup/registration targets the correct DB
+  /// (the per-profile `data.sqlite` has no `instrument` table).
+  private func makeExchangeAccount(
+    in fixture: Fixture,
+    token: String,
+    client: any ExchangeClient,
+    metadataResolver: any ExchangeAssetMetadataResolving
+  ) throws -> Account {
     let account = Account(
       name: "Coinstash", type: .exchange, instrument: .AUD,
       valuationMode: .calculatedFromTrades, exchangeProvider: .coinstash)
     _ = TestBackend.seed(accounts: [account], in: fixture.database)
     let tokenStore = ExchangeTokenStore(synchronizable: false)
     try tokenStore.save(token: token, for: account.id)
-    let registry = GRDBInstrumentRegistryRepository(database: fixture.database)
+    // Instrument identity lives on the shared profile-index registry, not on
+    // the per-profile data.sqlite. Use the backend's own registry instance so
+    // crypto registrations land in the same DB the transaction reader resolves from.
+    let registry = fixture.backend.grdbInstruments
     let regResolver = CountingRegistrationResolver()
     regResolver.setDefault(.success(coingecko: "id", cryptocompare: nil, binance: nil))
     let discovery = CryptoTokenDiscoveryService(
@@ -82,13 +104,13 @@ struct SyncedAccountStoreExchangeTests {
     fixture.store.appendSourceForTesting(
       CoinstashSyncSource(
         tokenStore: tokenStore,
-        client: StubExchangeClient(deposit: 100),
+        client: client,
         engine: ExchangeSyncEngine(
           resolver: ExchangeInstrumentResolver(
             registry: registry, fiatInstrument: .AUD,
             existingLegInstrumentIds: { [] }),
           discovery: discovery),
-        metadataResolverFactory: { _ in StubMetadataResolver([:]) }))
+        metadataResolverFactory: { _ in metadataResolver }))
     return account
   }
 
@@ -112,5 +134,60 @@ struct SyncedAccountStoreExchangeTests {
     let txns = try await fixture.backend.transactions.fetchAll(
       filter: TransactionFilter())
     #expect(txns.contains { txn in txn.legs.contains { $0.externalId != nil } })
+  }
+
+  /// End-to-end: a crypto OP deposit resolves to the canonical Optimism
+  /// instrument id and is NOT spam-flagged.
+  @Test("Store syncs a crypto OP deposit to the correct instrument id")
+  func storeSyncsCryptoDepositToCorrectInstrumentId() async throws {
+    let fixture = try makeFixture()
+    let opTransaction = ExchangeImportedTransaction(
+      externalId: "op-dep-1",
+      occurredAt: Self.pinnedNow,
+      category: "DEPOSIT",
+      direction: .credit,
+      assetSymbol: "OP",
+      amount: 40167,
+      isFiat: false,
+      orderId: nil)
+    let opMetadata = StubMetadataResolver([
+      "OP": ExchangeAssetMetadata(
+        symbol: "OP", name: "Optimism",
+        chains: [
+          ExchangeAssetChain(
+            chainId: 10,
+            contractAddress: "0x4200000000000000000000000000000000000042",
+            decimals: 18)
+        ])
+    ])
+    let account = try makeExchangeAccount(
+      in: fixture, token: "TOK",
+      client: StubExchangeClient(transactions: [opTransaction]),
+      metadataResolver: opMetadata)
+    try await fixture.backend.walletSyncState.save(
+      WalletSyncState(
+        id: account.id, lastSyncedBlockNumber: 0,
+        lastSyncedAt: .distantPast, lastError: nil))
+    await fixture.store.loadInitialState()
+
+    await fixture.store.syncAccount(account)
+
+    // No error recorded — the crypto build + apply landed.
+    let state = try await fixture.backend.walletSyncState.load(accountId: account.id)
+    #expect(state?.lastError == nil)
+
+    let txns = try await fixture.backend.transactions.fetchAll(filter: TransactionFilter())
+    let leg = try #require(
+      txns.flatMap(\.legs).first { $0.externalId == "op-dep-1" },
+      "OP deposit leg must be persisted with its externalId")
+    #expect(
+      leg.instrument.id == "10:0x4200000000000000000000000000000000000042",
+      "leg must resolve to canonical Optimism OP instrument id")
+    // Verify it is not spam-flagged (CountingAlchemyClientStub returns isSpam=false).
+    let regs = try await fixture.backend.grdbInstruments.allCryptoRegistrations()
+    let opReg = try #require(
+      regs.first { $0.instrument.id == "10:0x4200000000000000000000000000000000000042" },
+      "OP instrument must be registered in the instrument registry")
+    #expect(opReg.pricingStatus != .spam)
   }
 }

--- a/MoolahTests/Features/Sync/SyncedAccountStoreExchangeTests.swift
+++ b/MoolahTests/Features/Sync/SyncedAccountStoreExchangeTests.swift
@@ -75,13 +75,20 @@ struct SyncedAccountStoreExchangeTests {
     let tokenStore = ExchangeTokenStore(synchronizable: false)
     try tokenStore.save(token: token, for: account.id)
     let registry = GRDBInstrumentRegistryRepository(database: fixture.database)
+    let regResolver = CountingRegistrationResolver()
+    regResolver.setDefault(.success(coingecko: "id", cryptocompare: nil, binance: nil))
+    let discovery = CryptoTokenDiscoveryService(
+      registry: registry, resolver: regResolver, alchemy: CountingAlchemyClientStub())
     fixture.store.appendSourceForTesting(
       CoinstashSyncSource(
         tokenStore: tokenStore,
         client: StubExchangeClient(deposit: 100),
         engine: ExchangeSyncEngine(
           resolver: ExchangeInstrumentResolver(
-            registry: registry, fiatInstrument: .AUD))))
+            registry: registry, fiatInstrument: .AUD,
+            existingLegInstrumentIds: { [] }),
+          discovery: discovery),
+        metadataResolverFactory: { _ in StubMetadata([:]) }))
     return account
   }
 

--- a/MoolahTests/Features/Sync/SyncedAccountStoreExchangeTests.swift
+++ b/MoolahTests/Features/Sync/SyncedAccountStoreExchangeTests.swift
@@ -88,7 +88,7 @@ struct SyncedAccountStoreExchangeTests {
             registry: registry, fiatInstrument: .AUD,
             existingLegInstrumentIds: { [] }),
           discovery: discovery),
-        metadataResolverFactory: { _ in StubMetadata([:]) }))
+        metadataResolverFactory: { _ in StubMetadataResolver([:]) }))
     return account
   }
 

--- a/MoolahTests/Features/Sync/SyncedAccountStoreGlobalErrorTests.swift
+++ b/MoolahTests/Features/Sync/SyncedAccountStoreGlobalErrorTests.swift
@@ -227,7 +227,7 @@ struct SyncedAccountStoreGlobalErrorTests {
             registry: registry, fiatInstrument: .AUD,
             existingLegInstrumentIds: { [] }),
           discovery: discovery),
-        metadataResolverFactory: { _ in StubMetadata([:]) }))
+        metadataResolverFactory: { _ in StubMetadataResolver([:]) }))
     return account
   }
 

--- a/MoolahTests/Features/Sync/SyncedAccountStoreGlobalErrorTests.swift
+++ b/MoolahTests/Features/Sync/SyncedAccountStoreGlobalErrorTests.swift
@@ -213,13 +213,21 @@ struct SyncedAccountStoreGlobalErrorTests {
     _ = TestBackend.seed(accounts: [account], in: fixture.database)
     let tokenStore = ExchangeTokenStore(synchronizable: false)
     try tokenStore.save(token: token, for: account.id)
+    let registry = StubInstrumentRegistry()
+    let regResolver = CountingRegistrationResolver()
+    regResolver.setDefault(.success(coingecko: "id", cryptocompare: nil, binance: nil))
+    let discovery = CryptoTokenDiscoveryService(
+      registry: registry, resolver: regResolver, alchemy: CountingAlchemyClientStub())
     fixture.store.appendSourceForTesting(
       CoinstashSyncSource(
         tokenStore: tokenStore,
         client: StubExchangeClient(error: error),
         engine: ExchangeSyncEngine(
           resolver: ExchangeInstrumentResolver(
-            registry: StubInstrumentRegistry(), fiatInstrument: .AUD))))
+            registry: registry, fiatInstrument: .AUD,
+            existingLegInstrumentIds: { [] }),
+          discovery: discovery),
+        metadataResolverFactory: { _ in StubMetadata([:]) }))
     return account
   }
 

--- a/MoolahTests/Features/TransactionStoreLoadRaceTests.swift
+++ b/MoolahTests/Features/TransactionStoreLoadRaceTests.swift
@@ -250,4 +250,5 @@ actor FirstFetchGatedTransactionRepository: TransactionRepository {
     []
   }
   func legExists(accountId: UUID, externalId: String) async throws -> Bool { false }
+  func distinctLegInstrumentIds() async throws -> Set<String> { [] }
 }

--- a/MoolahTests/Shared/CryptoImport/CryptoTokenDiscoveryServiceTests.swift
+++ b/MoolahTests/Shared/CryptoImport/CryptoTokenDiscoveryServiceTests.swift
@@ -198,7 +198,7 @@ struct CryptoTokenDiscoveryServiceTests {
     #expect(registration.instrument.id == "42161:0xff970a61a04b1ca14834a43f5de4533ebddb5cc8")
     #expect(registration.instrument.decimals == 6)
     #expect(registration.pricingStatus == .priced)
-    #expect(subject.alchemy.getTokenMetadataCallCount == 0)  // spam step skipped: no ChainConfig
+    #expect(subject.alchemy.tokenMetadataCallCount == 0)
     let snap = subject.registry.snapshot()
     #expect(snap.registeredCryptos.contains { $0.id == registration.instrument.id })
   }

--- a/MoolahTests/Shared/CryptoImport/CryptoTokenDiscoveryServiceTests.swift
+++ b/MoolahTests/Shared/CryptoImport/CryptoTokenDiscoveryServiceTests.swift
@@ -180,6 +180,29 @@ struct CryptoTokenDiscoveryServiceTests {
         for: .init(chainId: 1, contractAddress: Self.usdcAddress.lowercased())) == 0)
   }
 
+  // MARK: - Chain-id entry point
+
+  @Test("resolveOrLoad(chainId:) without ChainConfig skips Alchemy and registers")
+  func resolveByChainIdWithoutChainConfigSkipsAlchemyAndRegisters() async throws {
+    let subject = makeDiscoverySubject()
+    subject.resolver.setDefault(.success(coingecko: "usd-coin", cryptocompare: nil, binance: nil))
+
+    // Arbitrum (chain 42161) has no ChainConfig.
+    let registration = try await subject.service.resolveOrLoad(
+      chainId: 42161,
+      contractAddress: "0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
+      symbol: "USDC",
+      name: "USDC",
+      decimals: 6)
+
+    #expect(registration.instrument.id == "42161:0xff970a61a04b1ca14834a43f5de4533ebddb5cc8")
+    #expect(registration.instrument.decimals == 6)
+    #expect(registration.pricingStatus == .priced)
+    #expect(subject.alchemy.getTokenMetadataCallCount == 0)  // spam step skipped: no ChainConfig
+    let snap = subject.registry.snapshot()
+    #expect(snap.registeredCryptos.contains { $0.id == registration.instrument.id })
+  }
+
   // MARK: - Re-resolution
 
   @Test("reResolve(.unpriced → .priced) flips status when provider now succeeds")

--- a/MoolahTests/Shared/CryptoImport/CryptoTokenDiscoveryTestDoubles.swift
+++ b/MoolahTests/Shared/CryptoImport/CryptoTokenDiscoveryTestDoubles.swift
@@ -106,7 +106,7 @@ final class CountingAlchemyClientStub: AlchemyClient, @unchecked Sendable {
   private var totalGetTokenMetadataCalls: Int = 0
 
   /// Total number of `getTokenMetadata` calls across all keys.
-  var getTokenMetadataCallCount: Int {
+  var tokenMetadataCallCount: Int {
     lock.withLock { totalGetTokenMetadataCalls }
   }
 

--- a/MoolahTests/Shared/CryptoImport/CryptoTokenDiscoveryTestDoubles.swift
+++ b/MoolahTests/Shared/CryptoImport/CryptoTokenDiscoveryTestDoubles.swift
@@ -103,6 +103,12 @@ final class CountingAlchemyClientStub: AlchemyClient, @unchecked Sendable {
   private var responses: [Key: Response] = [:]
   private var callCounts: [Key: Int] = [:]
   private var defaultIsSpam: Bool = false
+  private var totalGetTokenMetadataCalls: Int = 0
+
+  /// Total number of `getTokenMetadata` calls across all keys.
+  var getTokenMetadataCallCount: Int {
+    lock.withLock { totalGetTokenMetadataCalls }
+  }
 
   func setDefaultSpam(_ isSpam: Bool) {
     lock.withLock { self.defaultIsSpam = isSpam }
@@ -131,6 +137,7 @@ final class CountingAlchemyClientStub: AlchemyClient, @unchecked Sendable {
     let key = Key(chainId: chain.chainId, contractAddress: contractAddress.lowercased())
     let (response, fallbackSpam): (Response?, Bool) = lock.withLock {
       callCounts[key, default: 0] += 1
+      totalGetTokenMetadataCalls += 1
       return (responses[key], defaultIsSpam)
     }
 

--- a/MoolahTests/Shared/CryptoImport/RecordingTransactionRepository.swift
+++ b/MoolahTests/Shared/CryptoImport/RecordingTransactionRepository.swift
@@ -77,4 +77,8 @@ actor RecordingTransactionRepository: TransactionRepository {
   func legExists(accountId: UUID, externalId: String) async throws -> Bool {
     try await wrapped.legExists(accountId: accountId, externalId: externalId)
   }
+
+  func distinctLegInstrumentIds() async throws -> Set<String> {
+    try await wrapped.distinctLegInstrumentIds()
+  }
 }

--- a/MoolahTests/Shared/Exchange/CoinstashCoinMetadataTests.swift
+++ b/MoolahTests/Shared/Exchange/CoinstashCoinMetadataTests.swift
@@ -49,3 +49,80 @@ struct CoinstashCoinMetadataDecodeTests {
     #expect(coin.defiAddresses.isEmpty)
   }
 }
+
+@Suite("CoinstashClient.coinMetadata mapping")
+struct CoinstashClientCoinMetadataTests {
+  private func makeOKResponse() throws -> HTTPURLResponse {
+    try #require(
+      HTTPURLResponse(
+        url: CoinstashGraphQL.endpoint, statusCode: 200,
+        httpVersion: nil, headerFields: nil))
+  }
+
+  private func makeClient(returning body: String) throws -> CoinstashClient {
+    let response = try makeOKResponse()
+    return CoinstashClient(transport: { _ in (Data(body.utf8), response) })
+  }
+
+  @Test
+  func mapsSingleChainOptimismToken() async throws {
+    let sut = try makeClient(
+      returning: """
+        {"data":{"getCoinBySymbol":{"symbol":"OP","name":"Optimism",
+        "defiAddresses":[{"chain":"OPTIMISM",
+        "address":"0x4200000000000000000000000000000000000042","decimals":18}]}}}
+        """)
+    let meta = try #require(try await sut.coinMetadata(symbol: "OP", token: "t"))
+    #expect(meta.symbol == "OP")
+    #expect(
+      meta.chains == [
+        ExchangeAssetChain(
+          chainId: 10,
+          contractAddress: "0x4200000000000000000000000000000000000042",
+          decimals: 18)
+      ])
+  }
+
+  @Test
+  func collapsesNativeSentinelToNilContract() async throws {
+    let sut = try makeClient(
+      returning: """
+        {"data":{"getCoinBySymbol":{"symbol":"ETH","name":"Ethereum",
+        "defiAddresses":[
+        {"chain":"ETHEREUM","address":"0xEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE","decimals":18},
+        {"chain":"SOLANA","address":"So111","decimals":9}]}}}
+        """)
+    let meta = try #require(try await sut.coinMetadata(symbol: "ETH", token: "t"))
+    #expect(
+      meta.chains == [
+        ExchangeAssetChain(chainId: 1, contractAddress: nil, decimals: 18)
+      ])
+  }
+
+  @Test
+  func unknownSymbolReturnsNil() async throws {
+    let sut = try makeClient(returning: #"{"data":{"getCoinBySymbol":null}}"#)
+    #expect(try await sut.coinMetadata(symbol: "ZZZ", token: "t") == nil)
+  }
+
+  @Test
+  func emptyDefiAddressesReturnsMetadataWithNoChains() async throws {
+    let sut = try makeClient(
+      returning: """
+        {"data":{"getCoinBySymbol":{"symbol":"BTC","name":"Bitcoin","defiAddresses":[]}}}
+        """)
+    let meta = try #require(try await sut.coinMetadata(symbol: "BTC", token: "t"))
+    #expect(meta.chains.isEmpty)
+  }
+
+  @Test
+  func providerErrorThrows() async throws {
+    let response = try makeOKResponse()
+    let sut = CoinstashClient(transport: { _ in
+      (Data(#"{"errors":[{"message":"boom"}]}"#.utf8), response)
+    })
+    await #expect(throws: ExchangeClientError.self) {
+      _ = try await sut.coinMetadata(symbol: "OP", token: "t")
+    }
+  }
+}

--- a/MoolahTests/Shared/Exchange/CoinstashCoinMetadataTests.swift
+++ b/MoolahTests/Shared/Exchange/CoinstashCoinMetadataTests.swift
@@ -117,10 +117,7 @@ struct CoinstashClientCoinMetadataTests {
 
   @Test
   func providerErrorThrows() async throws {
-    let response = try makeOKResponse()
-    let sut = CoinstashClient(transport: { _ in
-      (Data(#"{"errors":[{"message":"boom"}]}"#.utf8), response)
-    })
+    let sut = try makeClient(returning: #"{"errors":[{"message":"boom"}]}"#)
     await #expect(throws: ExchangeClientError.self) {
       _ = try await sut.coinMetadata(symbol: "OP", token: "t")
     }

--- a/MoolahTests/Shared/Exchange/CoinstashCoinMetadataTests.swift
+++ b/MoolahTests/Shared/Exchange/CoinstashCoinMetadataTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Testing
+import os
 
 @testable import Moolah
 
@@ -122,29 +123,117 @@ struct CoinstashClientCoinMetadataTests {
       _ = try await sut.coinMetadata(symbol: "OP", token: "t")
     }
   }
+
+  @Test
+  func avalanceMisspellingMapsToChainId43114() async throws {
+    // Coinstash spells it "AVALANCE" (missing the H). The client must still
+    // map it to EVM chain id 43114.
+    let sut = try makeClient(
+      returning: """
+        {"data":{"getCoinBySymbol":{"symbol":"AVAX","name":"Avalanche",
+        "defiAddresses":[{"chain":"AVALANCE",
+        "address":"0x1CE0c2827e2eF14D5C4f29a091d735A204794041","decimals":18}]}}}
+        """)
+    let meta = try #require(try await sut.coinMetadata(symbol: "AVAX", token: "t"))
+    #expect(
+      meta.chains == [
+        ExchangeAssetChain(
+          chainId: 43114,
+          contractAddress: "0x1CE0c2827e2eF14D5C4f29a091d735A204794041",
+          decimals: 18)
+      ])
+  }
 }
 
 @Suite("CoinstashAssetMetadataResolver")
 struct CoinstashAssetMetadataResolverTests {
-  @Test
-  func forwardsToClientWithBoundToken() async throws {
-    let response = try #require(
+  private func makeOKResponse() throws -> HTTPURLResponse {
+    try #require(
       HTTPURLResponse(
         url: CoinstashGraphQL.endpoint, statusCode: 200,
         httpVersion: nil, headerFields: nil))
+  }
+
+  private static let opBody = """
+    {"data":{"getCoinBySymbol":{"symbol":"OP","name":"Optimism",
+    "defiAddresses":[{"chain":"OPTIMISM",
+    "address":"0x4200000000000000000000000000000000000042","decimals":18}]}}}
+    """
+
+  @Test
+  func forwardsToClientWithBoundToken() async throws {
+    let response = try makeOKResponse()
     let client = CoinstashClient(transport: { _ in
-      (
-        Data(
-          """
-          {"data":{"getCoinBySymbol":{"symbol":"OP","name":"Optimism",
-          "defiAddresses":[{"chain":"OPTIMISM",
-          "address":"0x4200000000000000000000000000000000000042","decimals":18}]}}}
-          """.utf8), response
-      )
+      (Data(Self.opBody.utf8), response)
     })
     let resolver: any ExchangeAssetMetadataResolving =
       CoinstashAssetMetadataResolver(client: client, token: "secret")
     let meta = try #require(try await resolver.assetMetadata(forSymbol: "OP"))
     #expect(meta.chains.first?.chainId == 10)
+  }
+
+  /// The transport is invoked exactly once for two calls with the same symbol.
+  /// Both results must be identical (value returned from cache on second call).
+  @Test
+  func cachesResultsWithinOneBuildRun() async throws {
+    let response = try makeOKResponse()
+    let callCount = OSAllocatedUnfairLock<Int>(initialState: 0)
+    let client = CoinstashClient(transport: { _ in
+      callCount.withLock { $0 += 1 }
+      return (Data(Self.opBody.utf8), response)
+    })
+    let resolver = CoinstashAssetMetadataResolver(client: client, token: "t")
+
+    let first = try await resolver.assetMetadata(forSymbol: "OP")
+    let second = try await resolver.assetMetadata(forSymbol: "OP")
+
+    #expect(callCount.withLock { $0 } == 1, "transport should be called once")
+    #expect(first == second)
+    #expect(first?.symbol == "OP")
+  }
+
+  /// Uppercased key: calling with "op" and "OP" hits the transport only once.
+  @Test
+  func cachesSymbolCaseInsensitively() async throws {
+    let response = try makeOKResponse()
+    let callCount = OSAllocatedUnfairLock<Int>(initialState: 0)
+    let client = CoinstashClient(transport: { _ in
+      callCount.withLock { $0 += 1 }
+      return (Data(Self.opBody.utf8), response)
+    })
+    let resolver = CoinstashAssetMetadataResolver(client: client, token: "t")
+
+    _ = try await resolver.assetMetadata(forSymbol: "op")
+    _ = try await resolver.assetMetadata(forSymbol: "OP")
+
+    #expect(callCount.withLock { $0 } == 1, "transport should be called once for both cases")
+  }
+
+  /// A transient error (thrown by transport) must NOT be cached. The second
+  /// call must attempt the transport again and succeed.
+  @Test
+  func transientErrorIsNotCached() async throws {
+    struct TransportError: Error {}
+    let response = try makeOKResponse()
+    let callCount = OSAllocatedUnfairLock<Int>(initialState: 0)
+    let client = CoinstashClient(transport: { _ in
+      let count = callCount.withLock { count -> Int in
+        let current = count
+        count += 1
+        return current
+      }
+      if count == 0 { throw ExchangeClientError.providerError("transient") }
+      return (Data(Self.opBody.utf8), response)
+    })
+    let resolver = CoinstashAssetMetadataResolver(client: client, token: "t")
+
+    // First call throws.
+    await #expect(throws: ExchangeClientError.self) {
+      _ = try await resolver.assetMetadata(forSymbol: "OP")
+    }
+    // Second call must reach transport again (no poisoned cache entry).
+    let second = try await resolver.assetMetadata(forSymbol: "OP")
+    #expect(second?.symbol == "OP")
+    #expect(callCount.withLock { $0 } == 2, "transport must be called twice (no cached error)")
   }
 }

--- a/MoolahTests/Shared/Exchange/CoinstashCoinMetadataTests.swift
+++ b/MoolahTests/Shared/Exchange/CoinstashCoinMetadataTests.swift
@@ -1,0 +1,16 @@
+import Testing
+
+@testable import Moolah
+
+@Suite("ExchangeAssetMetadata value type")
+struct CoinstashCoinMetadataTests {
+  @Test
+  func chainStoresContractAndDecimals() {
+    let chain = ExchangeAssetChain(
+      chainId: 1, contractAddress: "0xA0B8…", decimals: 6)
+    let meta = ExchangeAssetMetadata(symbol: "USDC", name: "USDC", chains: [chain])
+    #expect(meta.symbol == "USDC")
+    #expect(meta.chains.first?.chainId == 1)
+    #expect(meta.chains.first?.decimals == 6)
+  }
+}

--- a/MoolahTests/Shared/Exchange/CoinstashCoinMetadataTests.swift
+++ b/MoolahTests/Shared/Exchange/CoinstashCoinMetadataTests.swift
@@ -123,3 +123,28 @@ struct CoinstashClientCoinMetadataTests {
     }
   }
 }
+
+@Suite("CoinstashAssetMetadataResolver")
+struct CoinstashAssetMetadataResolverTests {
+  @Test
+  func forwardsToClientWithBoundToken() async throws {
+    let response = try #require(
+      HTTPURLResponse(
+        url: CoinstashGraphQL.endpoint, statusCode: 200,
+        httpVersion: nil, headerFields: nil))
+    let client = CoinstashClient(transport: { _ in
+      (
+        Data(
+          """
+          {"data":{"getCoinBySymbol":{"symbol":"OP","name":"Optimism",
+          "defiAddresses":[{"chain":"OPTIMISM",
+          "address":"0x4200000000000000000000000000000000000042","decimals":18}]}}}
+          """.utf8), response
+      )
+    })
+    let resolver: any ExchangeAssetMetadataResolving =
+      CoinstashAssetMetadataResolver(client: client, token: "secret")
+    let meta = try #require(try await resolver.assetMetadata(forSymbol: "OP"))
+    #expect(meta.chains.first?.chainId == 10)
+  }
+}

--- a/MoolahTests/Shared/Exchange/CoinstashCoinMetadataTests.swift
+++ b/MoolahTests/Shared/Exchange/CoinstashCoinMetadataTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 
 @testable import Moolah
@@ -12,5 +13,39 @@ struct CoinstashCoinMetadataTests {
     #expect(meta.symbol == "USDC")
     #expect(meta.chains.first?.chainId == 1)
     #expect(meta.chains.first?.decimals == 6)
+  }
+}
+
+@Suite("CoinstashCoinMetadata decode")
+struct CoinstashCoinMetadataDecodeTests {
+  private func decode(_ json: String) throws -> CoinstashCoinData {
+    let response = try JSONDecoder().decode(
+      CoinstashGraphQLResponse<CoinstashCoinData>.self,
+      from: Data(json.utf8))
+    return try #require(response.data)  // test fixture is always a success shape
+  }
+
+  @Test
+  func decodesSingleChainToken() throws {
+    let json = """
+      {"data":{"getCoinBySymbol":{"symbol":"OP","name":"Optimism",
+      "defiAddresses":[{"chain":"OPTIMISM",
+      "address":"0x4200000000000000000000000000000000000042","decimals":18}]}}}
+      """
+    let coin = try #require(try decode(json).getCoinBySymbol)
+    #expect(coin.symbol == "OP")
+    #expect(coin.defiAddresses.count == 1)
+    #expect(coin.defiAddresses[0].chain == "OPTIMISM")
+    #expect(coin.defiAddresses[0].address == "0x4200000000000000000000000000000000000042")
+    #expect(coin.defiAddresses[0].decimals == 18)
+  }
+
+  @Test
+  func decodesEmptyDefiAddresses() throws {
+    let json = """
+      {"data":{"getCoinBySymbol":{"symbol":"BTC","name":"Bitcoin","defiAddresses":[]}}}
+      """
+    let coin = try #require(try decode(json).getCoinBySymbol)
+    #expect(coin.defiAddresses.isEmpty)
   }
 }

--- a/MoolahTests/Shared/Exchange/CoinstashSyncSourceTests.swift
+++ b/MoolahTests/Shared/Exchange/CoinstashSyncSourceTests.swift
@@ -13,16 +13,7 @@ struct CoinstashSyncSourceTests {
     chainId: 1, contractAddress: nil, symbol: "ETH", name: "Ethereum", decimals: 18)
 
   private func makeEngine() -> ExchangeSyncEngine {
-    let registry = StubInstrumentRegistry()
-    let regResolver = CountingRegistrationResolver()
-    regResolver.setDefault(.success(coingecko: "id", cryptocompare: nil, binance: nil))
-    let discovery = CryptoTokenDiscoveryService(
-      registry: registry, resolver: regResolver, alchemy: CountingAlchemyClientStub())
-    return ExchangeSyncEngine(
-      resolver: ExchangeInstrumentResolver(
-        registry: registry, fiatInstrument: .AUD,
-        existingLegInstrumentIds: { [] }),
-      discovery: discovery)
+    makeExchangeSyncEngine()
   }
 
   private func makeSource(
@@ -31,7 +22,7 @@ struct CoinstashSyncSourceTests {
     CoinstashSyncSource(
       tokenStore: store, client: client,
       engine: makeEngine(),
-      metadataResolverFactory: { _ in StubMetadata([:]) })
+      metadataResolverFactory: { _ in StubMetadataResolver([:]) })
   }
 
   @Test

--- a/MoolahTests/Shared/Exchange/CoinstashSyncSourceTests.swift
+++ b/MoolahTests/Shared/Exchange/CoinstashSyncSourceTests.swift
@@ -12,14 +12,26 @@ struct CoinstashSyncSourceTests {
   private let eth = Instrument.crypto(
     chainId: 1, contractAddress: nil, symbol: "ETH", name: "Ethereum", decimals: 18)
 
+  private func makeEngine() -> ExchangeSyncEngine {
+    let registry = StubInstrumentRegistry()
+    let regResolver = CountingRegistrationResolver()
+    regResolver.setDefault(.success(coingecko: "id", cryptocompare: nil, binance: nil))
+    let discovery = CryptoTokenDiscoveryService(
+      registry: registry, resolver: regResolver, alchemy: CountingAlchemyClientStub())
+    return ExchangeSyncEngine(
+      resolver: ExchangeInstrumentResolver(
+        registry: registry, fiatInstrument: .AUD,
+        existingLegInstrumentIds: { [] }),
+      discovery: discovery)
+  }
+
   private func makeSource(
     client: any ExchangeClient, store: ExchangeTokenStore
   ) -> CoinstashSyncSource {
     CoinstashSyncSource(
       tokenStore: store, client: client,
-      engine: ExchangeSyncEngine(
-        resolver: ExchangeInstrumentResolver(
-          registry: StubInstrumentRegistry(), fiatInstrument: .AUD)))
+      engine: makeEngine(),
+      metadataResolverFactory: { _ in StubMetadata([:]) })
   }
 
   @Test

--- a/MoolahTests/Shared/Exchange/ExchangeInstrumentResolverTests.swift
+++ b/MoolahTests/Shared/Exchange/ExchangeInstrumentResolverTests.swift
@@ -4,35 +4,82 @@ import Testing
 
 @Suite("ExchangeInstrumentResolver")
 struct ExchangeInstrumentResolverTests {
-  @Test
-  func fiatResolvesToInjectedFiatInstrument() async throws {
-    let resolver = ExchangeInstrumentResolver(
-      registry: StubInstrumentRegistry(), fiatInstrument: .AUD)
-    #expect(try await resolver.instrument(forSymbol: nil, isFiat: true) == .AUD)
+  private func op(_ contract: String, spam: Bool = false, mapped: Bool = true)
+    -> CryptoRegistration
+  {
+    let inst = Instrument.crypto(
+      chainId: 10, contractAddress: contract, symbol: "OP",
+      name: "Optimism", decimals: 18)
+    return CryptoRegistration(
+      instrument: inst,
+      mapping: CryptoProviderMapping(
+        instrumentId: inst.id,
+        coingeckoId: mapped ? "optimism" : nil,
+        cryptocompareSymbol: nil, binanceSymbol: nil),
+      pricingStatus: spam ? .spam : (mapped ? .priced : .unpriced))
+  }
+
+  private func resolver(
+    _ regs: [CryptoRegistration],
+    used: Set<String> = []
+  ) -> ExchangeInstrumentResolver {
+    ExchangeInstrumentResolver(
+      registry: StubInstrumentRegistry(
+        instruments: regs.map(\.instrument),
+        cryptoRegistrations: regs),
+      fiatInstrument: .AUD,
+      existingLegInstrumentIds: { used })
   }
 
   @Test
-  func assetResolvesViaRegistry() async throws {
-    let optimism = Instrument.crypto(
-      chainId: 10, contractAddress: "0x4200000000000000000000000000000000000042",
-      symbol: "OP", name: "Optimism", decimals: 18)
-    let resolver = ExchangeInstrumentResolver(
-      registry: StubInstrumentRegistry(instruments: [optimism]), fiatInstrument: .AUD)
-    #expect(try await resolver.instrument(forSymbol: "OP", isFiat: false) == optimism)
+  func fiatAccessorReturnsInjectedInstrument() {
+    #expect(resolver([]).fiatInstrument == .AUD)
   }
 
   @Test
-  func unknownAssetReturnsNil() async throws {
-    let resolver = ExchangeInstrumentResolver(
-      registry: StubInstrumentRegistry(), fiatInstrument: .AUD)
-    #expect(try await resolver.instrument(forSymbol: "ZZZ", isFiat: false) == nil)
+  func fallbackExcludesSpamAndPicksRealOP() async throws {
+    let spam = op("0xdeadbeef00000000000000000000000000000000", spam: true)
+    let real = op("0x4200000000000000000000000000000000000042")
+    let got = try await resolver([spam, real]).fallbackInstrument(forSymbol: "OP")
+    #expect(got == real.instrument)
   }
 
   @Test
-  func fiatFlagShortCircuitsSymbolLookup() async throws {
-    let resolver = ExchangeInstrumentResolver(
-      registry: StubInstrumentRegistry(), fiatInstrument: .AUD)
-    // isFiat wins even when a symbol is supplied — no registry lookup.
-    #expect(try await resolver.instrument(forSymbol: "OP", isFiat: true) == .AUD)
+  func fallbackPrefersMappedOverUnpricedStub() async throws {
+    let stub = op("0x1111111111111111111111111111111111111111", mapped: false)
+    let mapped = op("0x4200000000000000000000000000000000000042")
+    let got = try await resolver([stub, mapped]).fallbackInstrument(forSymbol: "OP")
+    #expect(got == mapped.instrument)
+  }
+
+  @Test
+  func fallbackPrefersUsedThenLowestId() async throws {
+    let opA = op("0xaaaa000000000000000000000000000000000000")
+    let opB = op("0xbbbb000000000000000000000000000000000000")
+    let got = try await resolver([opA, opB], used: [opB.instrument.id])
+      .fallbackInstrument(forSymbol: "OP")
+    #expect(got == opB.instrument)
+  }
+
+  @Test
+  func fallbackDeterministicIdTieBreak() async throws {
+    let opA = op("0xaaaa000000000000000000000000000000000000")
+    let opB = op("0xbbbb000000000000000000000000000000000000")
+    let got = try await resolver([opB, opA]).fallbackInstrument(forSymbol: "OP")
+    #expect(got == opA.instrument)
+  }
+
+  @Test
+  func fallbackAllSpamReturnsNil() async throws {
+    let got = try await resolver([op("0xdead000000000000000000000000000000000000", spam: true)])
+      .fallbackInstrument(forSymbol: "OP")
+    #expect(got == nil)
+  }
+
+  @Test
+  func registeredInstrumentReturnsSeededRegistration() async throws {
+    let real = op("0x4200000000000000000000000000000000000042")
+    let got = try await resolver([real]).registeredInstrument(id: real.instrument.id)
+    #expect(got == real.instrument)
   }
 }

--- a/MoolahTests/Shared/Exchange/ExchangeInstrumentResolverTests.swift
+++ b/MoolahTests/Shared/Exchange/ExchangeInstrumentResolverTests.swift
@@ -33,7 +33,7 @@ struct ExchangeInstrumentResolverTests {
 
   @Test
   func fiatAccessorReturnsInjectedInstrument() {
-    #expect(resolver([]).fiatInstrument == .AUD)
+    #expect(resolver([]).fiatDenomination() == .AUD)
   }
 
   @Test

--- a/MoolahTests/Shared/Exchange/ExchangeSyncEngineResolutionTests.swift
+++ b/MoolahTests/Shared/Exchange/ExchangeSyncEngineResolutionTests.swift
@@ -1,0 +1,205 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+// MARK: - Shared helpers
+
+/// Thread-safe string accumulator used to assert that metadata callbacks
+/// are (or are not) invoked. Mirrors the lock-bracket pattern used in
+/// `CryptoTokenDiscoveryTestDoubles.swift`.
+final class CallTracker: @unchecked Sendable {
+  private let lock = NSLock()
+  private var calls: [String] = []
+
+  func append(_ symbol: String) {
+    lock.withLock { calls.append(symbol) }
+  }
+
+  var isEmpty: Bool { lock.withLock { calls.isEmpty } }
+  var all: [String] { lock.withLock { calls } }
+}
+
+// MARK: - Stub metadata resolver (internal so ExchangeSyncEngineTests can reuse)
+
+final class StubMetadata: ExchangeAssetMetadataResolving, @unchecked Sendable {
+  let map: [String: ExchangeAssetMetadata?]
+  let onCall: @Sendable (String) -> Void
+
+  init(
+    _ map: [String: ExchangeAssetMetadata?],
+    onCall: @escaping @Sendable (String) -> Void = { _ in }
+  ) {
+    self.map = map
+    self.onCall = onCall
+  }
+  func assetMetadata(forSymbol symbol: String) async throws -> ExchangeAssetMetadata? {
+    onCall(symbol)
+    guard let hit = map[symbol] else { return nil }
+    return hit
+  }
+}
+
+// MARK: - Test suite
+
+@Suite("ExchangeSyncEngine resolution")
+struct ExchangeSyncEngineResolutionTests {
+  private func makeEngine(
+    registry: StubInstrumentRegistry,
+    regResolver: CountingRegistrationResolver? = nil
+  ) -> ExchangeSyncEngine {
+    let resolverToUse: CountingRegistrationResolver
+    if let regResolver {
+      resolverToUse = regResolver
+    } else {
+      let defaultResolver = CountingRegistrationResolver()
+      defaultResolver.setDefault(.success(coingecko: "id", cryptocompare: nil, binance: nil))
+      resolverToUse = defaultResolver
+    }
+    let discovery = CryptoTokenDiscoveryService(
+      registry: registry, resolver: resolverToUse, alchemy: CountingAlchemyClientStub())
+    return ExchangeSyncEngine(
+      resolver: ExchangeInstrumentResolver(
+        registry: registry, fiatInstrument: .AUD,
+        existingLegInstrumentIds: { [] }),
+      discovery: discovery)
+  }
+
+  private func depositRow(_ symbol: String, _ amount: Decimal)
+    -> ExchangeImportedTransaction
+  {
+    ExchangeImportedTransaction(
+      externalId: "ext-\(symbol)",
+      occurredAt: Date(timeIntervalSince1970: 1_762_000_000),
+      category: "DEPOSIT", direction: .credit, assetSymbol: symbol,
+      amount: amount, isFiat: false, orderId: nil)
+  }
+
+  private func account() -> Account {
+    Account(
+      name: "Coinstash", type: .exchange,
+      instrument: .AUD, exchangeProvider: .coinstash)
+  }
+
+  @Test
+  func opDepositResolvesToRealOptimismOPNotSpam() async throws {
+    let registry = StubInstrumentRegistry()
+    let meta = StubMetadata([
+      "OP": ExchangeAssetMetadata(
+        symbol: "OP", name: "Optimism",
+        chains: [
+          ExchangeAssetChain(
+            chainId: 10,
+            contractAddress: "0x4200000000000000000000000000000000000042",
+            decimals: 18)
+        ])
+    ])
+    let result = try await makeEngine(registry: registry).build(
+      account: account(), imported: [depositRow("OP", 40167)], metadata: meta)
+    let leg = try #require(result.candidates.first?.transaction.legs.first)
+    #expect(leg.instrument.id == "10:0x4200000000000000000000000000000000000042")
+    #expect(leg.instrument.decimals == 18)
+  }
+
+  @Test
+  func btcShortCircuitsWithoutMetadataCall() async throws {
+    let registry = StubInstrumentRegistry(
+      cryptoRegistrations: CryptoRegistration.builtInPresets)
+    let tracker = CallTracker()
+    let meta = StubMetadata([:], onCall: { tracker.append($0) })
+    let result = try await makeEngine(registry: registry).build(
+      account: account(), imported: [depositRow("BTC", 1)], metadata: meta)
+    let leg = try #require(result.candidates.first?.transaction.legs.first)
+    #expect(leg.instrument.id == "0:native")
+    #expect(leg.instrument.decimals == 8)
+    #expect(tracker.isEmpty)
+  }
+
+  @Test
+  func multiChainPicksEthereumCanonical() async throws {
+    let registry = StubInstrumentRegistry()
+    let meta = StubMetadata([
+      "USDC": ExchangeAssetMetadata(
+        symbol: "USDC", name: "USDC",
+        chains: [
+          ExchangeAssetChain(
+            chainId: 10,
+            contractAddress: "0x7f5c764cbc14f9669b88837ca1490cca17c31607",
+            decimals: 6),
+          ExchangeAssetChain(
+            chainId: 1,
+            contractAddress: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+            decimals: 6),
+        ])
+    ])
+    let result = try await makeEngine(registry: registry).build(
+      account: account(), imported: [depositRow("USDC", 100)], metadata: meta)
+    let leg = try #require(result.candidates.first?.transaction.legs.first)
+    #expect(leg.instrument.id == "1:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48")
+  }
+
+  @Test
+  func nativeContractNilBuildsNativeInstrument() async throws {
+    let registry = StubInstrumentRegistry()
+    let meta = StubMetadata([
+      "ETH": ExchangeAssetMetadata(
+        symbol: "ETH", name: "Ethereum",
+        chains: [ExchangeAssetChain(chainId: 1, contractAddress: nil, decimals: 18)])
+    ])
+    let result = try await makeEngine(registry: registry).build(
+      account: account(), imported: [depositRow("ETH", 2)], metadata: meta)
+    let leg = try #require(result.candidates.first?.transaction.legs.first)
+    #expect(leg.instrument.id == "1:native")
+  }
+
+  @Test
+  func noEvmMetadataUsesRegistryFallback() async throws {
+    let real = CryptoRegistration(
+      instrument: .crypto(
+        chainId: 1399, contractAddress: nil, symbol: "SOL",
+        name: "Solana", decimals: 9),
+      mapping: CryptoProviderMapping(
+        instrumentId: "1399:native", coingeckoId: "solana",
+        cryptocompareSymbol: nil, binanceSymbol: nil))
+    let registry = StubInstrumentRegistry(
+      instruments: [real.instrument], cryptoRegistrations: [real])
+    let meta = StubMetadata([
+      "SOL": ExchangeAssetMetadata(symbol: "SOL", name: "Solana", chains: [])
+    ])
+    let result = try await makeEngine(registry: registry).build(
+      account: account(), imported: [depositRow("SOL", 5)], metadata: meta)
+    let leg = try #require(result.candidates.first?.transaction.legs.first)
+    #expect(leg.instrument.id == "1399:native")
+  }
+
+  @Test
+  func transientMetadataErrorThrows() async throws {
+    struct Boom: Error {}
+    final class Throwing: ExchangeAssetMetadataResolving {
+      func assetMetadata(forSymbol symbol: String) async throws
+        -> ExchangeAssetMetadata?
+      { throw Boom() }
+    }
+    let registry = StubInstrumentRegistry()
+    await #expect(throws: Boom.self) {
+      _ = try await makeEngine(registry: registry).build(
+        account: account(), imported: [depositRow("OP", 1)], metadata: Throwing())
+    }
+  }
+
+  @Test
+  func fiatLegSkipsMetadata() async throws {
+    let registry = StubInstrumentRegistry()
+    let tracker = CallTracker()
+    let meta = StubMetadata([:], onCall: { tracker.append($0) })
+    let row = ExchangeImportedTransaction(
+      externalId: "f1", occurredAt: Date(timeIntervalSince1970: 1_762_000_000),
+      category: "DEPOSIT", direction: .credit, assetSymbol: "AUD",
+      amount: 50, isFiat: true, orderId: nil)
+    let result = try await makeEngine(registry: registry).build(
+      account: account(), imported: [row], metadata: meta)
+    let leg = try #require(result.candidates.first?.transaction.legs.first)
+    #expect(leg.instrument == .AUD)
+    #expect(tracker.isEmpty)
+  }
+}

--- a/MoolahTests/Shared/Exchange/ExchangeSyncEngineResolutionTests.swift
+++ b/MoolahTests/Shared/Exchange/ExchangeSyncEngineResolutionTests.swift
@@ -136,9 +136,34 @@ struct ExchangeSyncEngineResolutionTests {
   }
 
   @Test
+  func multiChainNoEthereumPicksOptimismOverBase() async throws {
+    // Chain preference: Ethereum (1) first, then Optimism (10), then Base (8453).
+    // When Ethereum is absent, Optimism must win over Base.
+    let registry = StubInstrumentRegistry()
+    let meta = StubMetadataResolver([
+      "OP": ExchangeAssetMetadata(
+        symbol: "OP", name: "Optimism",
+        chains: [
+          ExchangeAssetChain(
+            chainId: 8453,
+            contractAddress: "0x4200000000000000000000000000000000000042",
+            decimals: 18),
+          ExchangeAssetChain(
+            chainId: 10,
+            contractAddress: "0x4200000000000000000000000000000000000042",
+            decimals: 18),
+        ])
+    ])
+    let result = try await makeExchangeSyncEngine(registry: registry).build(
+      account: account(), imported: [depositRow("OP", 5)], metadata: meta)
+    let leg = try #require(result.candidates.first?.transaction.legs.first)
+    #expect(leg.instrument.id.hasPrefix("10:"))
+  }
+
+  @Test
   func transientMetadataErrorThrows() async throws {
     struct Boom: Error {}
-    final class Throwing: ExchangeAssetMetadataResolving {
+    struct Throwing: ExchangeAssetMetadataResolving {
       func assetMetadata(forSymbol symbol: String) async throws
         -> ExchangeAssetMetadata?
       { throw Boom() }

--- a/MoolahTests/Shared/Exchange/ExchangeSyncEngineResolutionTests.swift
+++ b/MoolahTests/Shared/Exchange/ExchangeSyncEngineResolutionTests.swift
@@ -8,6 +8,9 @@ import Testing
 /// Thread-safe string accumulator used to assert that metadata callbacks
 /// are (or are not) invoked. Mirrors the lock-bracket pattern used in
 /// `CryptoTokenDiscoveryTestDoubles.swift`.
+///
+/// `@unchecked Sendable`: mutable state guarded by `NSLock`; lock-bracket
+/// pattern, the project convention for non-actor concurrent test stubs.
 final class CallTracker: @unchecked Sendable {
   private let lock = NSLock()
   private var calls: [String] = []
@@ -20,50 +23,10 @@ final class CallTracker: @unchecked Sendable {
   var all: [String] { lock.withLock { calls } }
 }
 
-// MARK: - Stub metadata resolver (internal so ExchangeSyncEngineTests can reuse)
-
-final class StubMetadata: ExchangeAssetMetadataResolving, @unchecked Sendable {
-  let map: [String: ExchangeAssetMetadata?]
-  let onCall: @Sendable (String) -> Void
-
-  init(
-    _ map: [String: ExchangeAssetMetadata?],
-    onCall: @escaping @Sendable (String) -> Void = { _ in }
-  ) {
-    self.map = map
-    self.onCall = onCall
-  }
-  func assetMetadata(forSymbol symbol: String) async throws -> ExchangeAssetMetadata? {
-    onCall(symbol)
-    guard let hit = map[symbol] else { return nil }
-    return hit
-  }
-}
-
 // MARK: - Test suite
 
 @Suite("ExchangeSyncEngine resolution")
 struct ExchangeSyncEngineResolutionTests {
-  private func makeEngine(
-    registry: StubInstrumentRegistry,
-    regResolver: CountingRegistrationResolver? = nil
-  ) -> ExchangeSyncEngine {
-    let resolverToUse: CountingRegistrationResolver
-    if let regResolver {
-      resolverToUse = regResolver
-    } else {
-      let defaultResolver = CountingRegistrationResolver()
-      defaultResolver.setDefault(.success(coingecko: "id", cryptocompare: nil, binance: nil))
-      resolverToUse = defaultResolver
-    }
-    let discovery = CryptoTokenDiscoveryService(
-      registry: registry, resolver: resolverToUse, alchemy: CountingAlchemyClientStub())
-    return ExchangeSyncEngine(
-      resolver: ExchangeInstrumentResolver(
-        registry: registry, fiatInstrument: .AUD,
-        existingLegInstrumentIds: { [] }),
-      discovery: discovery)
-  }
 
   private func depositRow(_ symbol: String, _ amount: Decimal)
     -> ExchangeImportedTransaction
@@ -84,7 +47,7 @@ struct ExchangeSyncEngineResolutionTests {
   @Test
   func opDepositResolvesToRealOptimismOPNotSpam() async throws {
     let registry = StubInstrumentRegistry()
-    let meta = StubMetadata([
+    let meta = StubMetadataResolver([
       "OP": ExchangeAssetMetadata(
         symbol: "OP", name: "Optimism",
         chains: [
@@ -94,7 +57,7 @@ struct ExchangeSyncEngineResolutionTests {
             decimals: 18)
         ])
     ])
-    let result = try await makeEngine(registry: registry).build(
+    let result = try await makeExchangeSyncEngine(registry: registry).build(
       account: account(), imported: [depositRow("OP", 40167)], metadata: meta)
     let leg = try #require(result.candidates.first?.transaction.legs.first)
     #expect(leg.instrument.id == "10:0x4200000000000000000000000000000000000042")
@@ -106,8 +69,8 @@ struct ExchangeSyncEngineResolutionTests {
     let registry = StubInstrumentRegistry(
       cryptoRegistrations: CryptoRegistration.builtInPresets)
     let tracker = CallTracker()
-    let meta = StubMetadata([:], onCall: { tracker.append($0) })
-    let result = try await makeEngine(registry: registry).build(
+    let meta = StubMetadataResolver([:], onCall: { tracker.append($0) })
+    let result = try await makeExchangeSyncEngine(registry: registry).build(
       account: account(), imported: [depositRow("BTC", 1)], metadata: meta)
     let leg = try #require(result.candidates.first?.transaction.legs.first)
     #expect(leg.instrument.id == "0:native")
@@ -118,7 +81,7 @@ struct ExchangeSyncEngineResolutionTests {
   @Test
   func multiChainPicksEthereumCanonical() async throws {
     let registry = StubInstrumentRegistry()
-    let meta = StubMetadata([
+    let meta = StubMetadataResolver([
       "USDC": ExchangeAssetMetadata(
         symbol: "USDC", name: "USDC",
         chains: [
@@ -132,7 +95,7 @@ struct ExchangeSyncEngineResolutionTests {
             decimals: 6),
         ])
     ])
-    let result = try await makeEngine(registry: registry).build(
+    let result = try await makeExchangeSyncEngine(registry: registry).build(
       account: account(), imported: [depositRow("USDC", 100)], metadata: meta)
     let leg = try #require(result.candidates.first?.transaction.legs.first)
     #expect(leg.instrument.id == "1:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48")
@@ -141,12 +104,12 @@ struct ExchangeSyncEngineResolutionTests {
   @Test
   func nativeContractNilBuildsNativeInstrument() async throws {
     let registry = StubInstrumentRegistry()
-    let meta = StubMetadata([
+    let meta = StubMetadataResolver([
       "ETH": ExchangeAssetMetadata(
         symbol: "ETH", name: "Ethereum",
         chains: [ExchangeAssetChain(chainId: 1, contractAddress: nil, decimals: 18)])
     ])
-    let result = try await makeEngine(registry: registry).build(
+    let result = try await makeExchangeSyncEngine(registry: registry).build(
       account: account(), imported: [depositRow("ETH", 2)], metadata: meta)
     let leg = try #require(result.candidates.first?.transaction.legs.first)
     #expect(leg.instrument.id == "1:native")
@@ -163,10 +126,10 @@ struct ExchangeSyncEngineResolutionTests {
         cryptocompareSymbol: nil, binanceSymbol: nil))
     let registry = StubInstrumentRegistry(
       instruments: [real.instrument], cryptoRegistrations: [real])
-    let meta = StubMetadata([
+    let meta = StubMetadataResolver([
       "SOL": ExchangeAssetMetadata(symbol: "SOL", name: "Solana", chains: [])
     ])
-    let result = try await makeEngine(registry: registry).build(
+    let result = try await makeExchangeSyncEngine(registry: registry).build(
       account: account(), imported: [depositRow("SOL", 5)], metadata: meta)
     let leg = try #require(result.candidates.first?.transaction.legs.first)
     #expect(leg.instrument.id == "1399:native")
@@ -182,7 +145,7 @@ struct ExchangeSyncEngineResolutionTests {
     }
     let registry = StubInstrumentRegistry()
     await #expect(throws: Boom.self) {
-      _ = try await makeEngine(registry: registry).build(
+      _ = try await makeExchangeSyncEngine(registry: registry).build(
         account: account(), imported: [depositRow("OP", 1)], metadata: Throwing())
     }
   }
@@ -191,12 +154,12 @@ struct ExchangeSyncEngineResolutionTests {
   func fiatLegSkipsMetadata() async throws {
     let registry = StubInstrumentRegistry()
     let tracker = CallTracker()
-    let meta = StubMetadata([:], onCall: { tracker.append($0) })
+    let meta = StubMetadataResolver([:], onCall: { tracker.append($0) })
     let row = ExchangeImportedTransaction(
       externalId: "f1", occurredAt: Date(timeIntervalSince1970: 1_762_000_000),
       category: "DEPOSIT", direction: .credit, assetSymbol: "AUD",
       amount: 50, isFiat: true, orderId: nil)
-    let result = try await makeEngine(registry: registry).build(
+    let result = try await makeExchangeSyncEngine(registry: registry).build(
       account: account(), imported: [row], metadata: meta)
     let leg = try #require(result.candidates.first?.transaction.legs.first)
     #expect(leg.instrument == .AUD)

--- a/MoolahTests/Shared/Exchange/ExchangeSyncEngineTests.swift
+++ b/MoolahTests/Shared/Exchange/ExchangeSyncEngineTests.swift
@@ -11,7 +11,7 @@ struct ExchangeSyncEngineTests {
 
   /// Metadata stub that returns real OP EVM chain data for "OP", and nil
   /// for anything else. Used by tests that include OP asset legs.
-  private static let opMetadata = StubMetadata([
+  private static let opMetadata = StubMetadataResolver([
     "OP": ExchangeAssetMetadata(
       symbol: "OP", name: "Optimism",
       chains: [
@@ -25,20 +25,12 @@ struct ExchangeSyncEngineTests {
   /// Empty metadata stub: returns nil for every symbol, so only the
   /// registry-fallback path is exercised (fiat legs still short-circuit
   /// before any metadata call).
-  private static let emptyMetadata = StubMetadata([:])
+  private static let emptyMetadata = StubMetadataResolver([:])
 
   private func makeEngine(
     registry: StubInstrumentRegistry = StubInstrumentRegistry()
   ) -> ExchangeSyncEngine {
-    let regResolver = CountingRegistrationResolver()
-    regResolver.setDefault(.success(coingecko: "id", cryptocompare: nil, binance: nil))
-    let discovery = CryptoTokenDiscoveryService(
-      registry: registry, resolver: regResolver, alchemy: CountingAlchemyClientStub())
-    return ExchangeSyncEngine(
-      resolver: ExchangeInstrumentResolver(
-        registry: registry, fiatInstrument: .AUD,
-        existingLegInstrumentIds: { [] }),
-      discovery: discovery)
+    makeExchangeSyncEngine(registry: registry)
   }
 
   private func tradeAndDepositResult() async throws -> WalletSyncBuildResult {

--- a/MoolahTests/Shared/Exchange/ExchangeSyncEngineTests.swift
+++ b/MoolahTests/Shared/Exchange/ExchangeSyncEngineTests.swift
@@ -9,10 +9,36 @@ struct ExchangeSyncEngineTests {
     chainId: 10, contractAddress: "0x4200000000000000000000000000000000000042",
     symbol: "OP", name: "Optimism", decimals: 18)
 
-  private func resolver(includeOP: Bool = false) -> ExchangeInstrumentResolver {
-    ExchangeInstrumentResolver(
-      registry: StubInstrumentRegistry(instruments: includeOP ? [Self.optimism] : []),
-      fiatInstrument: .AUD)
+  /// Metadata stub that returns real OP EVM chain data for "OP", and nil
+  /// for anything else. Used by tests that include OP asset legs.
+  private static let opMetadata = StubMetadata([
+    "OP": ExchangeAssetMetadata(
+      symbol: "OP", name: "Optimism",
+      chains: [
+        ExchangeAssetChain(
+          chainId: 10,
+          contractAddress: "0x4200000000000000000000000000000000000042",
+          decimals: 18)
+      ])
+  ])
+
+  /// Empty metadata stub: returns nil for every symbol, so only the
+  /// registry-fallback path is exercised (fiat legs still short-circuit
+  /// before any metadata call).
+  private static let emptyMetadata = StubMetadata([:])
+
+  private func makeEngine(
+    registry: StubInstrumentRegistry = StubInstrumentRegistry()
+  ) -> ExchangeSyncEngine {
+    let regResolver = CountingRegistrationResolver()
+    regResolver.setDefault(.success(coingecko: "id", cryptocompare: nil, binance: nil))
+    let discovery = CryptoTokenDiscoveryService(
+      registry: registry, resolver: regResolver, alchemy: CountingAlchemyClientStub())
+    return ExchangeSyncEngine(
+      resolver: ExchangeInstrumentResolver(
+        registry: registry, fiatInstrument: .AUD,
+        existingLegInstrumentIds: { [] }),
+      discovery: discovery)
   }
 
   private func tradeAndDepositResult() async throws -> WalletSyncBuildResult {
@@ -33,8 +59,8 @@ struct ExchangeSyncEngineTests {
         category: "DEPOSIT", direction: .credit, assetSymbol: nil, amount: 500,
         isFiat: true, orderId: nil),
     ]
-    return try await ExchangeSyncEngine(resolver: resolver(includeOP: true))
-      .build(account: account, imported: imported)
+    return try await makeEngine()
+      .build(account: account, imported: imported, metadata: Self.opMetadata)
   }
 
   @Test
@@ -66,8 +92,8 @@ struct ExchangeSyncEngineTests {
         category: "DEPOSIT", direction: .debit, assetSymbol: nil,
         amount: 100, isFiat: true, orderId: nil)
     ]
-    let engine = ExchangeSyncEngine(resolver: resolver())
-    let result = try await engine.build(account: account, imported: imported)
+    let result = try await makeEngine()
+      .build(account: account, imported: imported, metadata: Self.emptyMetadata)
     let leg = try #require(result.candidates.first?.transaction.legs.first)
     #expect(leg.quantity == -100)
   }
@@ -91,8 +117,8 @@ struct ExchangeSyncEngineTests {
         category: "TRADEFEE", direction: .debit, assetSymbol: nil, amount: 21.11,
         isFiat: true, orderId: "o1"),
     ]
-    let engine = ExchangeSyncEngine(resolver: resolver(includeOP: true))
-    let result = try await engine.build(account: account, imported: imported)
+    let result = try await makeEngine()
+      .build(account: account, imported: imported, metadata: Self.opMetadata)
     let legs = try #require(result.candidates.first?.transaction.legs)
     let feeLeg = try #require(legs.first { $0.externalId == "t3" })
     #expect(feeLeg.type == .expense)
@@ -118,8 +144,10 @@ struct ExchangeSyncEngineTests {
         category: "TRADE", direction: .debit, assetSymbol: nil,
         amount: 100, isFiat: true, orderId: "o1"),
     ]
-    let engine = ExchangeSyncEngine(resolver: resolver())
-    let result = try await engine.build(account: account, imported: imported)
+    // emptyMetadata returns nil for UNKNOWNCOIN; registry is empty too →
+    // fallbackInstrument returns nil → whole group is dropped.
+    let result = try await makeEngine()
+      .build(account: account, imported: imported, metadata: Self.emptyMetadata)
     #expect(result.candidates.isEmpty)
   }
 }

--- a/MoolahTests/Support/CancellablePagingTransactionRepository.swift
+++ b/MoolahTests/Support/CancellablePagingTransactionRepository.swift
@@ -77,6 +77,7 @@ actor CancellablePagingTransactionRepository: TransactionRepository {
     []
   }
   func legExists(accountId: UUID, externalId: String) async throws -> Bool { false }
+  func distinctLegInstrumentIds() async throws -> Set<String> { [] }
 }
 
 /// A simple one-shot gate that suspends waiters until `open()` is called.

--- a/MoolahTests/Support/ExchangeSyncEngineTestSupport.swift
+++ b/MoolahTests/Support/ExchangeSyncEngineTestSupport.swift
@@ -1,0 +1,34 @@
+// MoolahTests/Support/ExchangeSyncEngineTestSupport.swift
+import Foundation
+
+@testable import Moolah
+
+/// Builds a `ExchangeSyncEngine` wired against the provided registry and an
+/// optional `CountingRegistrationResolver`. When `regResolver` is `nil` a
+/// default resolver scripted with a `.success` response is created
+/// automatically. The Alchemy stub and discovery service are created fresh
+/// each call so tests that need to inspect them should pass an explicit
+/// `regResolver` or construct the engine manually.
+///
+/// `existingLegInstrumentIds` always returns `[]` — suitable for resolution
+/// tests that do not need to exercise the used-instrument preference ranking.
+func makeExchangeSyncEngine(
+  registry: StubInstrumentRegistry = StubInstrumentRegistry(),
+  regResolver: CountingRegistrationResolver? = nil
+) -> ExchangeSyncEngine {
+  let resolverToUse: CountingRegistrationResolver
+  if let regResolver {
+    resolverToUse = regResolver
+  } else {
+    let defaultResolver = CountingRegistrationResolver()
+    defaultResolver.setDefault(.success(coingecko: "id", cryptocompare: nil, binance: nil))
+    resolverToUse = defaultResolver
+  }
+  let discovery = CryptoTokenDiscoveryService(
+    registry: registry, resolver: resolverToUse, alchemy: CountingAlchemyClientStub())
+  return ExchangeSyncEngine(
+    resolver: ExchangeInstrumentResolver(
+      registry: registry, fiatInstrument: .AUD,
+      existingLegInstrumentIds: { [] }),
+    discovery: discovery)
+}

--- a/MoolahTests/Support/StubMetadataResolver.swift
+++ b/MoolahTests/Support/StubMetadataResolver.swift
@@ -1,0 +1,33 @@
+// MoolahTests/Support/StubMetadataResolver.swift
+import Foundation
+
+@testable import Moolah
+
+/// In-memory stub of `ExchangeAssetMetadataResolving` for engine and source
+/// unit tests. Returns a fixed dictionary mapping — `nil` for any symbol not
+/// in the map, or a scripted `ExchangeAssetMetadata` otherwise. An optional
+/// `onCall` hook lets tests assert which symbols were (or were not) looked up
+/// without needing to inspect returned values.
+///
+/// `@unchecked Sendable`: `map` and `onCall` are both immutable after init
+/// (all `let`); `onCall` itself is `@Sendable`. The class is `final` with
+/// no mutable state so the `@unchecked` annotation is safe — there is nothing
+/// to guard with a lock.
+final class StubMetadataResolver: ExchangeAssetMetadataResolving, @unchecked Sendable {
+  let map: [String: ExchangeAssetMetadata?]
+  let onCall: @Sendable (String) -> Void
+
+  init(
+    _ map: [String: ExchangeAssetMetadata?],
+    onCall: @escaping @Sendable (String) -> Void = { _ in }
+  ) {
+    self.map = map
+    self.onCall = onCall
+  }
+
+  func assetMetadata(forSymbol symbol: String) async throws -> ExchangeAssetMetadata? {
+    onCall(symbol)
+    guard let hit = map[symbol] else { return nil }
+    return hit
+  }
+}

--- a/MoolahTests/Support/TransactionStoreTestSupport.swift
+++ b/MoolahTests/Support/TransactionStoreTestSupport.swift
@@ -206,4 +206,8 @@ struct FailingTransactionRepository: TransactionRepository {
   func legExists(accountId: UUID, externalId: String) async throws -> Bool {
     throw BackendError.networkUnavailable
   }
+
+  func distinctLegInstrumentIds() async throws -> Set<String> {
+    throw BackendError.networkUnavailable
+  }
 }

--- a/Shared/CryptoImport/CryptoTokenDiscoveryService.swift
+++ b/Shared/CryptoImport/CryptoTokenDiscoveryService.swift
@@ -51,6 +51,9 @@ actor CryptoTokenDiscoveryService {
   /// `(chain, contractAddress)`, otherwise resolves and persists a new one.
   /// Concurrent callers for the same key all `await` the same in-flight
   /// `Task`; the underlying network round-trip executes once.
+  ///
+  /// Delegates to `resolveOrLoad(chainId:...)` with `chain.chainId` so all
+  /// wallet-import call sites are unchanged behaviourally.
   func resolveOrLoad(
     chain: ChainConfig,
     contractAddress: String?,
@@ -58,60 +61,82 @@ actor CryptoTokenDiscoveryService {
     name: String,
     decimals: Int
   ) async throws -> CryptoRegistration {
-    let id =
-      Instrument.crypto(
-        chainId: chain.chainId,
-        contractAddress: contractAddress,
-        symbol: symbol,
-        name: name,
-        decimals: decimals
-      ).id
+    try await resolveOrLoad(
+      chainId: chain.chainId,
+      contractAddress: contractAddress,
+      symbol: symbol,
+      name: name,
+      decimals: decimals)
+  }
 
-    if let existing = try await registry.cryptoRegistration(byId: id) {
+  /// Resolves by raw EVM chain id. For chains without a `ChainConfig`
+  /// (e.g. Arbitrum, Polygon, BSC) the Alchemy spam-flag step is skipped
+  /// because Alchemy has no network slug for those chains; CoinGecko
+  /// by-contract pricing still applies.
+  ///
+  /// Concurrent callers for the same `(chainId, contractAddress)` are
+  /// coalesced via the in-flight `Task` pattern — the actor serialises the
+  /// "check repository → launch resolution → store result" critical section
+  /// so at most one new row per unique key reaches the registry.
+  func resolveOrLoad(
+    chainId: Int,
+    contractAddress: String?,
+    symbol: String,
+    name: String,
+    decimals: Int
+  ) async throws -> CryptoRegistration {
+    let instrument = Instrument.crypto(
+      chainId: chainId,
+      contractAddress: contractAddress,
+      symbol: symbol,
+      name: name,
+      decimals: decimals)
+
+    if let existing = try await registry.cryptoRegistration(byId: instrument.id) {
       return existing
     }
-    if let task = inFlight[id] {
+    if let task = inFlight[instrument.id] {
       return try await task.value
     }
 
     let task = Task<CryptoRegistration, Error> { [self] in
       try await performResolution(
-        chain: chain,
-        contractAddress: contractAddress,
-        symbol: symbol,
-        name: name,
-        decimals: decimals)
+        instrument: instrument,
+        chain: ChainConfig.config(for: chainId))
     }
-    inFlight[id] = task
+    inFlight[instrument.id] = task
     do {
       let result = try await task.value
       // Actor-serialised — every coalesced waiter resumed before this
       // line, so clearing the slot now is race-free without a detached
       // cleanup task.
-      inFlight[id] = nil
+      inFlight[instrument.id] = nil
       return result
     } catch {
-      inFlight[id] = nil
+      inFlight[instrument.id] = nil
       throw error
     }
   }
 
   // MARK: - Resolution algorithm
 
+  /// Performs the full resolution algorithm for a token.
+  ///
+  /// - Parameters:
+  ///   - instrument: Pre-built crypto instrument (carries chainId,
+  ///     contractAddress, symbol, name, decimals).
+  ///   - chain: The `ChainConfig` for the instrument's chain, or `nil` for
+  ///     chains without a config (e.g. Arbitrum, Polygon, BSC). When `nil`
+  ///     the Alchemy spam-flag step is skipped because Alchemy has no
+  ///     network slug for those chains.
   private func performResolution(
-    chain: ChainConfig,
-    contractAddress: String?,
-    symbol: String,
-    name: String,
-    decimals: Int
+    instrument: Instrument,
+    chain: ChainConfig?
   ) async throws -> CryptoRegistration {
-    let isNative = contractAddress == nil
-    let instrument = Instrument.crypto(
-      chainId: chain.chainId,
-      contractAddress: contractAddress,
-      symbol: symbol,
-      name: name,
-      decimals: decimals)
+    let isNative = instrument.contractAddress == nil
+    // Crypto instruments always carry a non-nil chainId (set by
+    // `Instrument.crypto`); other kinds are never passed to this method.
+    let chainId = instrument.chainId ?? chain?.chainId ?? 0
 
     // Resolution via provider chain. A non-cancellation throw means "no
     // mapping" — a normal outcome (e.g. an obscure ERC-20 with no listing
@@ -119,15 +144,17 @@ actor CryptoTokenDiscoveryService {
     // `nil`; only `CancellationError` propagates so a cancelled sync
     // never writes a half-resolved row.
     let resolved = try await resolveSilently(
-      chainId: chain.chainId,
-      contractAddress: contractAddress,
-      symbol: symbol,
+      chainId: chainId,
+      contractAddress: instrument.contractAddress,
+      symbol: instrument.ticker ?? instrument.name,
       isNative: isNative)
 
     // Native gas tokens are never classified as spam — Alchemy's spam
     // database only covers token contracts. Skip the metadata round-trip.
+    // Also skip when there is no ChainConfig: Alchemy has no network slug
+    // for those chains (e.g. Arbitrum, Polygon, BSC).
     let isSpam: Bool
-    if let contractAddress, !isNative {
+    if let chain, let contractAddress = instrument.contractAddress, !isNative {
       isSpam = try await fetchSpamFlag(chain: chain, contractAddress: contractAddress)
     } else {
       isSpam = false
@@ -186,13 +213,7 @@ actor CryptoTokenDiscoveryService {
     let current = try await registry.cryptoRegistration(byId: id) ?? registration
     guard current.pricingStatus == .unpriced else { return current }
 
-    let instrument = current.instrument
-    return try await performResolution(
-      chain: chain,
-      contractAddress: instrument.contractAddress,
-      symbol: instrument.ticker ?? instrument.name,
-      name: instrument.name,
-      decimals: instrument.decimals)
+    return try await performResolution(instrument: current.instrument, chain: chain)
   }
 
   // MARK: - Helpers

--- a/Shared/CryptoImport/CryptoTokenDiscoveryService.swift
+++ b/Shared/CryptoImport/CryptoTokenDiscoveryService.swift
@@ -52,8 +52,8 @@ actor CryptoTokenDiscoveryService {
   /// Concurrent callers for the same key all `await` the same in-flight
   /// `Task`; the underlying network round-trip executes once.
   ///
-  /// Delegates to `resolveOrLoad(chainId:...)` with `chain.chainId` so all
-  /// wallet-import call sites are unchanged behaviourally.
+  /// Thin wrapper around `resolveOrLoad(chainId:...)` for callers that
+  /// already hold a `ChainConfig`.
   func resolveOrLoad(
     chain: ChainConfig,
     contractAddress: String?,
@@ -107,9 +107,9 @@ actor CryptoTokenDiscoveryService {
     inFlight[instrument.id] = task
     do {
       let result = try await task.value
-      // Actor-serialised — every coalesced waiter resumed before this
-      // line, so clearing the slot now is race-free without a detached
-      // cleanup task.
+      // Waiters capture the Task by value before awaiting `.value` and
+      // never re-read `inFlight` after resuming, so clearing the slot
+      // here is safe regardless of waiter resume order.
       inFlight[instrument.id] = nil
       return result
     } catch {
@@ -134,9 +134,12 @@ actor CryptoTokenDiscoveryService {
     chain: ChainConfig?
   ) async throws -> CryptoRegistration {
     let isNative = instrument.contractAddress == nil
-    // Crypto instruments always carry a non-nil chainId (set by
-    // `Instrument.crypto`); other kinds are never passed to this method.
-    let chainId = instrument.chainId ?? chain?.chainId ?? 0
+    // Crypto instruments always carry a non-nil chainId; non-crypto
+    // instruments must never be passed to this method.
+    guard let chainId = instrument.chainId else {
+      preconditionFailure(
+        "performResolution requires a crypto instrument with a chainId; got \(instrument.id)")
+    }
 
     // Resolution via provider chain. A non-cancellation throw means "no
     // mapping" — a normal outcome (e.g. an obscure ERC-20 with no listing
@@ -148,6 +151,10 @@ actor CryptoTokenDiscoveryService {
       contractAddress: instrument.contractAddress,
       symbol: instrument.ticker ?? instrument.name,
       isNative: isNative)
+
+    // Check cancellation before the Alchemy round-trip so a cancelled
+    // task skips the spam-flag network call entirely.
+    try Task.checkCancellation()
 
     // Native gas tokens are never classified as spam — Alchemy's spam
     // database only covers token contracts. Skip the metadata round-trip.
@@ -213,7 +220,24 @@ actor CryptoTokenDiscoveryService {
     let current = try await registry.cryptoRegistration(byId: id) ?? registration
     guard current.pricingStatus == .unpriced else { return current }
 
-    return try await performResolution(instrument: current.instrument, chain: chain)
+    // Coalescing mirrors `resolveOrLoad`: concurrent callers for the same
+    // instrument id share one in-flight resolution Task.
+    if let task = inFlight[id] { return try await task.value }
+    let task = Task<CryptoRegistration, Error> {
+      try await self.performResolution(instrument: current.instrument, chain: chain)
+    }
+    inFlight[id] = task
+    do {
+      let result = try await task.value
+      // Waiters capture the Task by value before awaiting `.value` and
+      // never re-read `inFlight` after resuming, so clearing the slot
+      // here is safe regardless of waiter resume order.
+      inFlight[id] = nil
+      return result
+    } catch {
+      inFlight[id] = nil
+      throw error
+    }
   }
 
   // MARK: - Helpers

--- a/Shared/CryptoImport/CryptoTokenDiscoveryService.swift
+++ b/Shared/CryptoImport/CryptoTokenDiscoveryService.swift
@@ -172,7 +172,7 @@ actor CryptoTokenDiscoveryService {
     if isSpam {
       status = .spam
       mapping = resolved?.mapping ?? emptyMapping(for: instrument.id)
-    } else if let resolved, hasAnyMapping(resolved.mapping) {
+    } else if let resolved, resolved.mapping.hasProviderMapping {
       status = .priced
       mapping = resolved.mapping
     } else {
@@ -293,9 +293,4 @@ actor CryptoTokenDiscoveryService {
       binanceSymbol: nil)
   }
 
-  private func hasAnyMapping(_ mapping: CryptoProviderMapping) -> Bool {
-    mapping.coingeckoId != nil
-      || mapping.cryptocompareSymbol != nil
-      || mapping.binanceSymbol != nil
-  }
 }

--- a/Shared/Exchange/CoinstashAssetMetadataResolver.swift
+++ b/Shared/Exchange/CoinstashAssetMetadataResolver.swift
@@ -1,12 +1,32 @@
 import Foundation
+import os
 
 /// Binds a `CoinstashClient` to a per-account bearer token so the
 /// provider-neutral `ExchangeAssetMetadataResolving` seam carries no
-/// token. Constructed per sync by `CoinstashSyncSource` once the
-/// account's token is read from the keychain.
-struct CoinstashAssetMetadataResolver: ExchangeAssetMetadataResolving, Sendable {
+/// token. Constructed fresh per build run by `CoinstashSyncSource` via
+/// `metadataResolverFactory`, so its lifetime equals one build run.
+///
+/// `getCoinBySymbol` results are cached for the duration of that build
+/// run to avoid N identical network round-trips when N rows share the same
+/// symbol. The cache is keyed by uppercased symbol and stores `nil` for
+/// definitive unknowns too, so a second call never re-hits the network.
+/// Transient errors are NOT cached — a throw leaves no cache entry so the
+/// next retry can succeed.
+///
+/// `Sendable` by design: all access to the mutable cache dictionary is
+/// guarded by `OSAllocatedUnfairLock`. The lock is never held across an
+/// `await`, so there is no deadlock risk. A benign double-fetch on a true
+/// concurrent miss (e.g. two async tasks calling for the same symbol at
+/// the same instant before either result is cached) is acceptable because
+/// build calls are sequential in practice; correctness > perfect coalescing.
+final class CoinstashAssetMetadataResolver: ExchangeAssetMetadataResolving, Sendable {
   private let client: CoinstashClient
   private let token: String
+  /// Lock-guarded per-build-run cache. `nil` as a value means "definitively
+  /// no usable EVM metadata for this symbol" and is stored so re-calls skip
+  /// the network. The key is always uppercased.
+  private let cache = OSAllocatedUnfairLock<[String: ExchangeAssetMetadata?]>(
+    initialState: [:])
 
   init(client: CoinstashClient, token: String) {
     self.client = client
@@ -14,6 +34,20 @@ struct CoinstashAssetMetadataResolver: ExchangeAssetMetadataResolving, Sendable 
   }
 
   func assetMetadata(forSymbol symbol: String) async throws -> ExchangeAssetMetadata? {
-    try await client.coinMetadata(symbol: symbol, token: token)
+    let key = symbol.uppercased()
+    // Read under lock; release before any await.
+    if let cached = cache.withLock({ $0[key] }) {
+      return cached
+    }
+    // Check whether the key itself is present (covers cached nil).
+    let hasEntry = cache.withLock { $0.keys.contains(key) }
+    if hasEntry {
+      return nil
+    }
+    // Cache miss: fetch from network (lock NOT held across await).
+    let result = try await client.coinMetadata(symbol: symbol, token: token)
+    // Store on success (including definitive nil); do not cache on throw.
+    cache.withLock { $0[key] = result }
+    return result
   }
 }

--- a/Shared/Exchange/CoinstashAssetMetadataResolver.swift
+++ b/Shared/Exchange/CoinstashAssetMetadataResolver.swift
@@ -4,7 +4,7 @@ import Foundation
 /// provider-neutral `ExchangeAssetMetadataResolving` seam carries no
 /// token. Constructed per sync by `CoinstashSyncSource` once the
 /// account's token is read from the keychain.
-struct CoinstashAssetMetadataResolver: ExchangeAssetMetadataResolving {
+struct CoinstashAssetMetadataResolver: ExchangeAssetMetadataResolving, Sendable {
   private let client: CoinstashClient
   private let token: String
 

--- a/Shared/Exchange/CoinstashAssetMetadataResolver.swift
+++ b/Shared/Exchange/CoinstashAssetMetadataResolver.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+/// Binds a `CoinstashClient` to a per-account bearer token so the
+/// provider-neutral `ExchangeAssetMetadataResolving` seam carries no
+/// token. Constructed per sync by `CoinstashSyncSource` once the
+/// account's token is read from the keychain.
+struct CoinstashAssetMetadataResolver: ExchangeAssetMetadataResolving {
+  private let client: CoinstashClient
+  private let token: String
+
+  init(client: CoinstashClient, token: String) {
+    self.client = client
+    self.token = token
+  }
+
+  func assetMetadata(forSymbol symbol: String) async throws -> ExchangeAssetMetadata? {
+    try await client.coinMetadata(symbol: symbol, token: token)
+  }
+}

--- a/Shared/Exchange/CoinstashClient.swift
+++ b/Shared/Exchange/CoinstashClient.swift
@@ -9,6 +9,19 @@ struct CoinstashClient: ExchangeClient, Sendable {
   private static let logger = Logger(
     subsystem: "com.moolah.app", category: "CoinstashClient")
 
+  // Coinstash `Chain` enum → EVM chain id. Non-EVM (SOLANA) and any
+  // value absent here are intentionally excluded: a symbol that lists
+  // only excluded chains falls through to the caller's registry
+  // fallback. `AVALANCE` is Coinstash's spelling.
+  private static let evmChainIds: [String: Int] = [
+    "ETHEREUM": 1, "OPTIMISM": 10, "BASE": 8453, "ARBITRUM": 42161,
+    "POLYGON": 137, "BSC": 56, "AVALANCE": 43114, "GNOSIS": 100,
+    "FANTOM": 250, "LINEA": 59144, "SONIC": 146,
+  ]
+
+  /// The well-known "native asset" sentinel address (`0x` + forty `e`).
+  private static let nativeSentinel = "0x" + String(repeating: "e", count: 40)
+
   init(
     transport: @escaping Transport = { try await URLSession.shared.data(for: $0) }
   ) {
@@ -58,6 +71,34 @@ struct CoinstashClient: ExchangeClient, Sendable {
       pageIndex += 1
     }
     return all.compactMap(Self.map(_:))
+  }
+
+  // MARK: - Coin metadata
+
+  /// Token metadata for `symbol`, or `nil` when Coinstash does not
+  /// recognise the symbol (definitive — caller takes the registry
+  /// fallback). Throws on transport / provider error (transient — the
+  /// sync retries). Non-EVM and unknown chains are dropped; the native
+  /// sentinel collapses to `contractAddress == nil`; Coinstash's listing
+  /// order is preserved.
+  func coinMetadata(symbol: String, token: String) async throws -> ExchangeAssetMetadata? {
+    let data = try await query(
+      CoinstashGraphQL.coinBySymbolQuery,
+      variables: ["s": .string(symbol)],
+      token: token,
+      decoding: CoinstashCoinData.self)
+    guard let coin = data.getCoinBySymbol else { return nil }
+
+    let chains: [ExchangeAssetChain] = coin.defiAddresses.compactMap { entry in
+      guard let chainId = Self.evmChainIds[entry.chain] else { return nil }
+      guard let address = entry.address else { return nil }
+      let isSentinel = address.caseInsensitiveCompare(Self.nativeSentinel) == .orderedSame
+      return ExchangeAssetChain(
+        chainId: chainId,
+        contractAddress: isSentinel ? nil : address,
+        decimals: entry.decimals ?? 18)
+    }
+    return ExchangeAssetMetadata(symbol: coin.symbol, name: coin.name, chains: chains)
   }
 
   // MARK: - Mapping

--- a/Shared/Exchange/CoinstashClient.swift
+++ b/Shared/Exchange/CoinstashClient.swift
@@ -96,7 +96,7 @@ struct CoinstashClient: ExchangeClient, Sendable {
       return ExchangeAssetChain(
         chainId: chainId,
         contractAddress: isSentinel ? nil : address,
-        decimals: entry.decimals ?? 18)
+        decimals: entry.decimals ?? 18)  // EVM default; most ERC-20s are 18-decimal
     }
     return ExchangeAssetMetadata(symbol: coin.symbol, name: coin.name, chains: chains)
   }

--- a/Shared/Exchange/CoinstashGraphQL.swift
+++ b/Shared/Exchange/CoinstashGraphQL.swift
@@ -44,6 +44,20 @@ enum CoinstashGraphQL {
       }
     }
     """
+
+  /// Token metadata for a Coinstash symbol. The per-transaction `chain`
+  /// field is unreliable (observed null/empty live 2026-05-17), so the
+  /// chain + contract come from here. `defiAddresses` is the per-chain
+  /// contract list; `[]` for non-EVM-modelled assets (e.g. BTC).
+  /// Decodes into `CoinstashGraphQLResponse<CoinstashCoinData>`.
+  static let coinBySymbolQuery = """
+    query Q($s: String!) {
+      getCoinBySymbol(symbol: $s) {
+        symbol name
+        defiAddresses { chain address decimals }
+      }
+    }
+    """
 }
 
 struct CoinstashGraphQLError: Decodable, Sendable { let message: String }
@@ -110,4 +124,22 @@ struct CoinstashTransactionsData: Decodable, Sendable {
   }
 
   let accountTransactions: Page
+}
+
+struct CoinstashDefiAddress: Decodable, Sendable, Hashable {
+  let chain: String
+  /// Optional defensively: a malformed row must not fail the whole decode.
+  let address: String?
+  let decimals: Int?
+}
+
+struct CoinstashCoinMetadata: Decodable, Sendable, Hashable {
+  let symbol: String
+  let name: String
+  let defiAddresses: [CoinstashDefiAddress]
+}
+
+struct CoinstashCoinData: Decodable, Sendable {
+  /// `null` when Coinstash does not recognise the symbol.
+  let getCoinBySymbol: CoinstashCoinMetadata?
 }

--- a/Shared/Exchange/CoinstashSyncSource.swift
+++ b/Shared/Exchange/CoinstashSyncSource.swift
@@ -11,17 +11,22 @@ struct CoinstashSyncSource: AccountSyncSource, Sendable {
   private let tokenStore: ExchangeTokenStore
   private let client: any ExchangeClient
   private let engine: ExchangeSyncEngine
+  private let metadataResolverFactory:
+    @Sendable (_ token: String) -> any ExchangeAssetMetadataResolving
   private static let logger = Logger(
     subsystem: "com.moolah.app", category: "CoinstashSyncSource")
 
   init(
     tokenStore: ExchangeTokenStore,
     client: any ExchangeClient,
-    engine: ExchangeSyncEngine
+    engine: ExchangeSyncEngine,
+    metadataResolverFactory:
+      @escaping @Sendable (_ token: String) -> any ExchangeAssetMetadataResolving
   ) {
     self.tokenStore = tokenStore
     self.client = client
     self.engine = engine
+    self.metadataResolverFactory = metadataResolverFactory
   }
 
   // Concrete provider check (not `!= nil`): with a second exchange's
@@ -52,7 +57,8 @@ struct CoinstashSyncSource: AccountSyncSource, Sendable {
     }
     do {
       let imported = try await client.fetchTransactions(token: token)
-      return try await engine.build(account: account, imported: imported)
+      let metadata = metadataResolverFactory(token)
+      return try await engine.build(account: account, imported: imported, metadata: metadata)
     } catch ExchangeClientError.unauthorized {
       throw WalletSyncError.invalidApiKey
     } catch let error as ExchangeClientError {

--- a/Shared/Exchange/ExchangeAssetMetadata.swift
+++ b/Shared/Exchange/ExchangeAssetMetadata.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+/// One chain on which a provider lists a token. `contractAddress == nil`
+/// means the chain's native asset (the provider's native-token sentinel
+/// has already been collapsed by the mapping layer).
+struct ExchangeAssetChain: Sendable, Hashable {
+  let chainId: Int
+  let contractAddress: String?
+  let decimals: Int
+}
+
+/// Provider-neutral token metadata. `chains` is restricted to
+/// EVM chains with a known chain id, in the provider's own listing order.
+struct ExchangeAssetMetadata: Sendable, Hashable {
+  let symbol: String
+  let name: String
+  let chains: [ExchangeAssetChain]
+}
+
+/// Resolves an exchange asset symbol to neutral token metadata.
+///
+/// Returns `nil` for a *definitive* "no usable EVM metadata" answer
+/// (symbol unknown to the provider, or it lists the token only on
+/// non-EVM chains). Throws for *transient* failures (network / provider
+/// error) so the caller's sync retries instead of mis-resolving.
+protocol ExchangeAssetMetadataResolving: Sendable {
+  func assetMetadata(forSymbol symbol: String) async throws -> ExchangeAssetMetadata?
+}

--- a/Shared/Exchange/ExchangeInstrumentResolver.swift
+++ b/Shared/Exchange/ExchangeInstrumentResolver.swift
@@ -7,7 +7,7 @@ import OSLog
 /// instrument, a registry lookup by id, and the *fallback* used when the
 /// provider gives no usable EVM metadata (e.g. non-EVM-modelled assets).
 struct ExchangeInstrumentResolver: Sendable {
-  let fiatInstrument: Instrument
+  private let fiat: Instrument
   private let registry: any InstrumentRegistryRepository
   private let existingLegInstrumentIds: @Sendable () async throws -> Set<String>
   private static let logger = Logger(
@@ -19,9 +19,13 @@ struct ExchangeInstrumentResolver: Sendable {
     existingLegInstrumentIds: @escaping @Sendable () async throws -> Set<String>
   ) {
     self.registry = registry
-    self.fiatInstrument = fiatInstrument
+    self.fiat = fiatInstrument
     self.existingLegInstrumentIds = existingLegInstrumentIds
   }
+
+  /// The profile's fiat denomination. Read by `ExchangeSyncEngine`'s
+  /// fiat-leg branch; intentional API surface, not raw field access.
+  func fiatDenomination() -> Instrument { fiat }
 
   /// The registered instrument for `id`, if any (used for the explicit
   /// non-EVM native short-circuit in `ExchangeSyncEngine`).
@@ -59,8 +63,12 @@ struct ExchangeInstrumentResolver: Sendable {
     }?.instrument
   }
 
-  /// Lexicographic rank comparison for fallback selection.
-  /// Priority: priced+mapped > unpriced; used id > unused; lower id > higher id.
+  /// Returns `true` when `lhs` is the better registry-fallback candidate.
+  /// Priced+mapped beats unpriced/unmapped (it has a visible price
+  /// history); an instrument already on an existing leg beats an unused
+  /// one (same coin resolves to the same registry entry across import
+  /// cycles — avoids phantom duplicates); lowest id breaks ties
+  /// deterministically across sync runs.
   private static func isBetterFallback(
     _ lhs: CryptoRegistration,
     than rhs: CryptoRegistration,

--- a/Shared/Exchange/ExchangeInstrumentResolver.swift
+++ b/Shared/Exchange/ExchangeInstrumentResolver.swift
@@ -1,46 +1,82 @@
 import Foundation
 import OSLog
 
-/// Resolves exchange symbols to Moolah `Instrument`s. The fiat denomination
-/// is injected (not hardcoded) so the resolver is reusable for a future
-/// non-AUD exchange; asset legs go through the instrument registry. `any
-/// InstrumentRegistryRepository` is intentional: there is exactly one
-/// concrete registry in the app; the existential avoids a generic parameter
-/// that would propagate to every call site without adding type safety.
+/// Fiat denomination + the registry fallback for exchange asset legs.
+/// The chain-pinned resolution (provider token metadata → discovery) is
+/// orchestrated by `ExchangeSyncEngine`; this type owns only the fiat
+/// instrument, a registry lookup by id, and the *fallback* used when the
+/// provider gives no usable EVM metadata (e.g. non-EVM-modelled assets).
 struct ExchangeInstrumentResolver: Sendable {
+  let fiatInstrument: Instrument
   private let registry: any InstrumentRegistryRepository
-  private let fiatInstrument: Instrument
+  private let existingLegInstrumentIds: @Sendable () async throws -> Set<String>
   private static let logger = Logger(
     subsystem: "com.moolah.app", category: "ExchangeInstrumentResolver")
 
-  init(registry: any InstrumentRegistryRepository, fiatInstrument: Instrument) {
+  init(
+    registry: any InstrumentRegistryRepository,
+    fiatInstrument: Instrument,
+    existingLegInstrumentIds: @escaping @Sendable () async throws -> Set<String>
+  ) {
     self.registry = registry
     self.fiatInstrument = fiatInstrument
+    self.existingLegInstrumentIds = existingLegInstrumentIds
   }
 
-  /// Returns the matching `Instrument`, or `nil` when the symbol is genuinely
-  /// unknown to the registry (the caller treats unknown groups as
-  /// unimportable and drops them).
+  /// The registered instrument for `id`, if any (used for the explicit
+  /// non-EVM native short-circuit in `ExchangeSyncEngine`).
+  func registeredInstrument(id: String) async throws -> Instrument? {
+    try await registry.cryptoRegistration(byId: id)?.instrument
+  }
+
+  /// Registry fallback for a crypto symbol with no usable EVM metadata.
+  /// Excludes `.spam`; prefers a mapped/`.priced` registration over an
+  /// `.unpriced` stub; then an instrument already used on an existing
+  /// leg; then the lowest `Instrument.id` (deterministic). `nil` when
+  /// every match is spam or none exist — caller drops + logs the group.
   ///
-  /// Throws on a registry failure rather than returning `nil`: a database
-  /// outage must surface as a transient error so the enclosing sync retries,
-  /// not as a silent "every instrument unknown" signal that would permanently
-  /// drop all imported transactions.
-  func instrument(forSymbol symbol: String?, isFiat: Bool) async throws -> Instrument? {
-    if isFiat { return fiatInstrument }
-    guard let symbol else { return nil }
+  /// Throws on registry failure (transient) so the sync retries rather
+  /// than silently dropping every leg.
+  func fallbackInstrument(forSymbol symbol: String) async throws -> Instrument? {
+    let regs: [CryptoRegistration]
     do {
-      // O(n) scan of the registry: the registry has no keyed by-ticker
-      // lookup and holds at most a few hundred entries; called per
-      // unresolved leg during a background sync, not on a hot UI path.
-      return try await registry.all().first {
-        $0.kind == .cryptoToken
-          && $0.ticker?.caseInsensitiveCompare(symbol) == .orderedSame
-      }
+      regs = try await registry.allCryptoRegistrations()
     } catch {
       Self.logger.error(
-        "Registry scan failed resolving '\(symbol, privacy: .public)': \(error, privacy: .public)")
+        "Registry scan failed for '\(symbol, privacy: .public)': \(error, privacy: .public)")
       throw error
     }
+    let candidates = regs.filter {
+      $0.instrument.kind == .cryptoToken
+        && $0.instrument.ticker?.caseInsensitiveCompare(symbol) == .orderedSame
+        && $0.pricingStatus != .spam
+    }
+    guard !candidates.isEmpty else { return nil }
+
+    let used = try await existingLegInstrumentIds()
+    return candidates.min { lhs, rhs in
+      Self.isBetterFallback(lhs, than: rhs, usedIds: used)
+    }?.instrument
+  }
+
+  /// Lexicographic rank comparison for fallback selection.
+  /// Priority: priced+mapped > unpriced; used id > unused; lower id > higher id.
+  private static func isBetterFallback(
+    _ lhs: CryptoRegistration,
+    than rhs: CryptoRegistration,
+    usedIds: Set<String>
+  ) -> Bool {
+    let lhsPriced = (lhs.pricingStatus == .priced && hasMapping(lhs.mapping)) ? 0 : 1
+    let rhsPriced = (rhs.pricingStatus == .priced && hasMapping(rhs.mapping)) ? 0 : 1
+    if lhsPriced != rhsPriced { return lhsPriced < rhsPriced }
+    let lhsUsed = usedIds.contains(lhs.instrument.id) ? 0 : 1
+    let rhsUsed = usedIds.contains(rhs.instrument.id) ? 0 : 1
+    if lhsUsed != rhsUsed { return lhsUsed < rhsUsed }
+    return lhs.instrument.id < rhs.instrument.id
+  }
+
+  private static func hasMapping(_ mapping: CryptoProviderMapping) -> Bool {
+    mapping.coingeckoId != nil || mapping.cryptocompareSymbol != nil
+      || mapping.binanceSymbol != nil
   }
 }

--- a/Shared/Exchange/ExchangeInstrumentResolver.swift
+++ b/Shared/Exchange/ExchangeInstrumentResolver.swift
@@ -74,17 +74,12 @@ struct ExchangeInstrumentResolver: Sendable {
     than rhs: CryptoRegistration,
     usedIds: Set<String>
   ) -> Bool {
-    let lhsPriced = (lhs.pricingStatus == .priced && hasMapping(lhs.mapping)) ? 0 : 1
-    let rhsPriced = (rhs.pricingStatus == .priced && hasMapping(rhs.mapping)) ? 0 : 1
+    let lhsPriced = (lhs.pricingStatus == .priced && lhs.mapping.hasProviderMapping) ? 0 : 1
+    let rhsPriced = (rhs.pricingStatus == .priced && rhs.mapping.hasProviderMapping) ? 0 : 1
     if lhsPriced != rhsPriced { return lhsPriced < rhsPriced }
     let lhsUsed = usedIds.contains(lhs.instrument.id) ? 0 : 1
     let rhsUsed = usedIds.contains(rhs.instrument.id) ? 0 : 1
     if lhsUsed != rhsUsed { return lhsUsed < rhsUsed }
     return lhs.instrument.id < rhs.instrument.id
-  }
-
-  private static func hasMapping(_ mapping: CryptoProviderMapping) -> Bool {
-    mapping.coingeckoId != nil || mapping.cryptocompareSymbol != nil
-      || mapping.binanceSymbol != nil
   }
 }

--- a/Shared/Exchange/ExchangeSyncEngine.swift
+++ b/Shared/Exchange/ExchangeSyncEngine.swift
@@ -146,7 +146,7 @@ struct ExchangeSyncEngine: Sendable {
     isFiat: Bool,
     metadata: any ExchangeAssetMetadataResolving
   ) async throws -> Instrument? {
-    if isFiat { return resolver.fiatInstrument }
+    if isFiat { return resolver.fiatDenomination() }
     guard let symbol else { return nil }
 
     if let native = Self.nonEvmNatives[symbol.uppercased()] {

--- a/Shared/Exchange/ExchangeSyncEngine.swift
+++ b/Shared/Exchange/ExchangeSyncEngine.swift
@@ -12,13 +12,32 @@ import OSLog
 /// is safe to call concurrently from the orchestrator's parallel build phase.
 struct ExchangeSyncEngine: Sendable {
   private let resolver: ExchangeInstrumentResolver
+  private let discovery: CryptoTokenDiscoveryService
   /// Shared static `Logger` — `Logger` is `Sendable`, so a static let is
   /// safe across actor boundaries without per-instance allocation.
   private static let logger = Logger(
     subsystem: "com.moolah.app", category: "ExchangeSyncEngine")
 
-  init(resolver: ExchangeInstrumentResolver) {
+  // Canonical multi-chain preference: Ethereum first (product
+  // decision), then the wallet-supported chains, then the rest.
+  private static let chainPreference: [Int] =
+    [1, 10, 8453, 42161, 137, 56, 43114, 100, 250, 59144, 146]
+
+  // Non-EVM natives the app pins by convention, keyed by uppercased
+  // symbol. Resolved directly (no getCoinBySymbol call) — these are
+  // `CryptoRegistration.builtInPresets` members.
+  private static let nonEvmNatives: [String: Instrument] = [
+    "BTC": .crypto(
+      chainId: 0,
+      contractAddress: nil,
+      symbol: "BTC",
+      name: "Bitcoin",
+      decimals: 8)
+  ]
+
+  init(resolver: ExchangeInstrumentResolver, discovery: CryptoTokenDiscoveryService) {
     self.resolver = resolver
+    self.discovery = discovery
   }
 
   // Coinstash category -> Moolah leg type. DEPOSIT/AWARD are inbound
@@ -44,7 +63,9 @@ struct ExchangeSyncEngine: Sendable {
   /// per row. A cancelled task throws `CancellationError` and writes nothing
   /// anywhere — the apply pass is the single writer regardless.
   func build(
-    account: Account, imported: [ExchangeImportedTransaction]
+    account: Account,
+    imported: [ExchangeImportedTransaction],
+    metadata: any ExchangeAssetMetadataResolving
   ) async throws -> WalletSyncBuildResult {
     // Trades share an `orderId`; deposits/withdrawals/awards have none, so
     // their `externalId` keys a singleton group (one single-leg transaction
@@ -54,7 +75,7 @@ struct ExchangeSyncEngine: Sendable {
     for (groupKey, rows) in groups {
       try Task.checkCancellation()
       if let candidate = try await buildCandidate(
-        groupKey: groupKey, rows: rows, account: account)
+        groupKey: groupKey, rows: rows, account: account, metadata: metadata)
       {
         candidates.append(candidate)
       }
@@ -72,14 +93,17 @@ struct ExchangeSyncEngine: Sendable {
   /// first row whose instrument is unresolvable — a partial, unbalanced
   /// trade is worse than no trade — and logs the drop for diagnosis.
   private func buildCandidate(
-    groupKey: String, rows: [ExchangeImportedTransaction], account: Account
+    groupKey: String,
+    rows: [ExchangeImportedTransaction],
+    account: Account,
+    metadata: any ExchangeAssetMetadataResolving
   ) async throws -> BuiltTransaction? {
     var legs: [TransactionLeg] = []
     for row in rows {
       try Task.checkCancellation()
       guard
-        let instrument = try await resolver.instrument(
-          forSymbol: row.assetSymbol, isFiat: row.isFiat)
+        let instrument = try await resolveInstrument(
+          symbol: row.assetSymbol, isFiat: row.isFiat, metadata: metadata)
       else {
         Self.logger.warning(
           """
@@ -108,5 +132,56 @@ struct ExchangeSyncEngine: Sendable {
     return BuiltTransaction(
       originAccountId: account.id,
       transaction: Transaction(date: date, legs: legs))
+  }
+
+  /// Resolution pipeline:
+  /// 1. Fiat flag → fiatInstrument.
+  /// 2. Non-EVM native (e.g. BTC) → builtInPresets / discovery (no metadata call).
+  /// 3. Provider metadata call → discovery with the canonical EVM chain.
+  /// 4. Empty chains in metadata → registry fallback (non-EVM, symbol scan).
+  /// 5. No metadata at all → registry fallback.
+  /// 6. Unresolved → nil (caller drops + logs the group).
+  private func resolveInstrument(
+    symbol: String?,
+    isFiat: Bool,
+    metadata: any ExchangeAssetMetadataResolving
+  ) async throws -> Instrument? {
+    if isFiat { return resolver.fiatInstrument }
+    guard let symbol else { return nil }
+
+    if let native = Self.nonEvmNatives[symbol.uppercased()] {
+      if let existing = try await resolver.registeredInstrument(id: native.id) {
+        return existing
+      }
+      let reg = try await discovery.resolveOrLoad(
+        chainId: native.chainId ?? 0,
+        contractAddress: nil,
+        symbol: native.ticker ?? symbol,
+        name: native.name,
+        decimals: native.decimals)
+      return reg.instrument
+    }
+
+    let meta = try await metadata.assetMetadata(forSymbol: symbol)
+
+    if let meta, let chosen = Self.canonical(meta.chains) {
+      let reg = try await discovery.resolveOrLoad(
+        chainId: chosen.chainId,
+        contractAddress: chosen.contractAddress,
+        symbol: meta.symbol,
+        name: meta.name,
+        decimals: chosen.decimals)
+      return reg.instrument
+    }
+
+    return try await resolver.fallbackInstrument(forSymbol: symbol)
+  }
+
+  private static func canonical(_ chains: [ExchangeAssetChain]) -> ExchangeAssetChain? {
+    guard !chains.isEmpty else { return nil }
+    for preferred in Self.chainPreference {
+      if let hit = chains.first(where: { $0.chainId == preferred }) { return hit }
+    }
+    return chains.first
   }
 }

--- a/Shared/Exchange/ExchangeSyncEngine.swift
+++ b/Shared/Exchange/ExchangeSyncEngine.swift
@@ -150,13 +150,17 @@ struct ExchangeSyncEngine: Sendable {
     guard let symbol else { return nil }
 
     if let native = Self.nonEvmNatives[symbol.uppercased()] {
+      guard let chainId = native.chainId, let ticker = native.ticker else {
+        preconditionFailure(
+          "nonEvmNatives entry \(native.id) must be a crypto instrument with chainId+ticker")
+      }
       if let existing = try await resolver.registeredInstrument(id: native.id) {
         return existing
       }
       let reg = try await discovery.resolveOrLoad(
-        chainId: native.chainId ?? 0,
+        chainId: chainId,
         contractAddress: nil,
-        symbol: native.ticker ?? symbol,
+        symbol: ticker,
         name: native.name,
         decimals: native.decimals)
       return reg.instrument

--- a/plans/2026-05-17-coinstash-instrument-resolution-design.md
+++ b/plans/2026-05-17-coinstash-instrument-resolution-design.md
@@ -1,0 +1,308 @@
+# Coinstash Instrument Resolution — Design Spec
+
+**Status:** Approved design · 2026-05-17
+**Branch:** `feat/exchange-accounts-coinstash`
+**Related:** Fuzzy cross-account transfer detection is **deferred** to
+[#928](https://github.com/ajsutton/moolah-native/issues/928) and is **out of
+scope** for this spec.
+
+---
+
+## Problem
+
+Coinstash imports resolve every crypto leg through
+`ExchangeInstrumentResolver.instrument(forSymbol:isFiat:)`, which does a
+symbol-only, case-insensitive `ticker` scan of the instrument registry and
+returns the first match:
+
+```swift
+return try await registry.all().first {
+  $0.kind == .cryptoToken && $0.ticker?.caseInsensitiveCompare(symbol) == .orderedSame
+}
+```
+
+When the registry holds more than one instrument with ticker `OP` — a spam
+`OP` discovered via wallet/Alchemy token scanning (`pricingStatus == .spam`)
+**and** the real Optimism `OP` (`10:0x4200…0042`) — scan order decides the
+result. In the large test profile it picks the spam token, so every imported
+`OP` row is mis-resolved and flagged spam (and Coinstash does not even list
+the spam token — it only trades the real one). The mis-resolved instrument
+also breaks any future cross-account transfer detection, because detection
+matches on instrument identity.
+
+Coinstash transaction rows carry only a `symbol` string. The per-row `chain`
+field exists in the schema but is **not reliably populated** (see
+Investigation), so the chain/contract must come from elsewhere.
+
+## Goal
+
+Resolve every Coinstash crypto leg to the correct chain-pinned `Instrument`
+using Coinstash's own authoritative token metadata, reusing the existing
+crypto discovery/registration path so the resolved instrument is priced and
+spam-classified consistently with wallet import. Fiat legs are unchanged.
+
+## Investigation (completed 2026-05-17, live API)
+
+Run against `https://graph.coinstash.com.au/graphql` with a read-only key.
+
+- **`getCoinBySymbol(symbol: String!, userId: ID)`** returns
+  `GetCoinResponse` with the fields we need:
+  `symbol`, `name`, `displaySymbol`, `coinId` (a Coinstash-internal id,
+  *not* a CoinGecko id), `blockchains: [String]`, and
+  **`defiAddresses: [{ chain: Chain, address: String, decimals: Int,
+  solanaTokenAccount: String? }]`**.
+- The `Chain` enum: `ETHEREUM, OPTIMISM, BSC, GNOSIS, POLYGON, SONIC,
+  FANTOM, BASE, SOLANA, ARBITRUM, AVALANCE, LINEA` (note Coinstash's
+  spelling `AVALANCE`).
+- Real `defiAddresses` shapes observed:
+  - **`OP`** → exactly one entry:
+    `OPTIMISM / 0x4200000000000000000000000000000000000042 / 18`. Single
+    chain — unambiguous. **This is the reported bug, deterministically
+    fixed.**
+  - **`USDC`** → 9 entries (Ethereum `0xa0b8…eb48` decimals 6, Optimism,
+    BSC, Gnosis, Polygon, Fantom, Arbitrum, Avalanche, Base). Multi-chain.
+  - **`ETH`** → 6 entries; ETHEREUM/OPTIMISM/ARBITRUM use the native
+    sentinel address `0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee` (40
+    lowercase `e`), i.e. *not* a real ERC-20 contract.
+  - **`BTC`** → `defiAddresses: []` (Bitcoin is not modelled as EVM).
+    The codebase already represents Bitcoin as
+    `Instrument.crypto(chainId: 0, contractAddress: nil, symbol: "BTC",
+    name: "Bitcoin", decimals: 8)` (id `0:native`) and ships it in
+    `CryptoRegistration.builtInPresets` with a CoinGecko mapping
+    (`coingeckoId: "bitcoin"`), seeded into every profile at session
+    start. `chainId == 0` is the established "Bitcoin" convention
+    (`Instrument.swift` display map; `CryptoRegistration.swift`
+    presets).
+  - **`SOL`** → one `SOLANA` entry with a base58 address (non-EVM).
+- The per-transaction `chain` field was `null` on 28/30 rows and `""` on
+  the two crypto deposits; `externalTxId` / `referenceTxId` / `scanUrl`
+  were all `null`. **Conclusion:** the transaction row cannot tell us the
+  chain; `getCoinBySymbol` is the source of truth. (The absence of an
+  on-chain hash also confirms #928's Coinstash↔wallet matching must be
+  fuzzy, not `externalId`-based.)
+- `getChain(chainId:)` keyed by the `Chain` enum name returned
+  `isSuccessful: false`; it expects a different identifier. We do **not**
+  depend on it — the `Chain` enum → EVM chain-id mapping is a small static
+  table (below).
+
+## Resolution policy
+
+For each imported leg in `ExchangeSyncEngine.buildCandidate`:
+
+- **Fiat leg** (`isFiat`): unchanged — the injected fiat instrument.
+- **Crypto leg** (symbol `S`):
+
+  0. **Explicit non-EVM natives.** First consult a small static table of
+     non-EVM native coins the app pins by convention, keyed by Coinstash
+     symbol (uppercased). v1 contains exactly one entry:
+     `BTC → Instrument.crypto(chainId: 0, contractAddress: nil,
+     symbol: "BTC", name: "Bitcoin", decimals: 8)` (id `0:native`). On a
+     hit, resolve directly to that instrument and **skip the
+     `getCoinBySymbol` call entirely** — it is a `builtInPresets` member,
+     already registered with a CoinGecko mapping at session start. If it
+     is somehow absent from the registry (defensive), register it through
+     the generalised discovery path (chain id 0, native, symbol `BTC`;
+     CoinGecko resolves `bitcoin`). This is the easy, exact match the
+     product wants for Bitcoin and removes BTC from the fuzzy fallback
+     entirely. (`SOL` and other non-EVM assets are *not* in this table
+     in v1 — no Solana instrument convention exists in the codebase yet;
+     they take the registry fallback, step 5.)
+
+  1. **Fetch metadata.** `meta = getCoinBySymbol(S)` via the Coinstash
+     client, cached for the duration of the build run keyed by `S`
+     uppercased (a sync touches only a handful of distinct symbols). A
+     *transient* failure (network/HTTP/GraphQL error) **throws** so the
+     enclosing sync retries — it must not silently fall through. Only a
+     *definitive* answer ("no usable EVM contract", below) takes the
+     registry fallback. This mirrors the existing resolver's "throw on
+     registry failure, never silently drop everything" rule.
+
+  2. **Select the canonical EVM entry.** From `meta.defiAddresses`, keep
+     entries whose `chain` maps to a known EVM chain id (table below);
+     drop `SOLANA` and any enum value not in the table. If ≥1 remain,
+     pick by this deterministic preference order (Ethereum-preferred per
+     product decision, then app-supported chains, then the rest):
+
+     ```
+     ETHEREUM, OPTIMISM, BASE, ARBITRUM, POLYGON, BSC,
+     AVALANCE, GNOSIS, FANTOM, LINEA, SONIC
+     ```
+
+  3. **Native vs token.** If the chosen `address` equals the native
+     sentinel `0x` + forty `e` (compared case-insensitively), build a
+     **native** instrument
+     `Instrument.crypto(chainId: c, contractAddress: nil,
+     symbol: meta.symbol, name: meta.name, decimals: chosen.decimals)`
+     (id `c:native`). Otherwise build a token instrument with
+     `contractAddress: chosen.address` (the factory normalises to
+     lowercase) and `decimals: chosen.decimals`.
+
+  4. **Resolve + register via the discovery path** (single source of
+     truth — see Discovery-path generalisation):
+     - If `ChainConfig.config(for: c) != nil` (Ethereum/OP/Base):
+       `CryptoTokenDiscoveryService.resolveOrLoad(...)` exactly as wallet
+       import does (provider mapping → Alchemy spam check → register).
+     - Else (EVM chain CoinGecko prices but the wallet importer doesn't
+       ingest — e.g. Arbitrum/Polygon/BSC): the generalised path — build
+       the instrument, resolve a provider mapping via
+       `CryptoPriceService.resolveRegistration(chainId:contractAddress:
+       symbol:isNative:)` (CoinGecko-by-contract is chain-id-keyed and
+       covers these), register via
+       `registry.registerCrypto(_:mapping:forcingStatus:)`. The Alchemy
+       spam step is **skipped** (no `ChainConfig` network slug; Coinstash
+       lists only real, tradable assets). Status `.priced` if a mapping
+       resolved, else `.unpriced`.
+     The leg uses the resolved registration's `Instrument`.
+
+  5. **Registry fallback** — taken only when the symbol is not an
+     explicit non-EVM native (step 0) **and** `getCoinBySymbol` returns a
+     *definitive* "no usable EVM contract": `defiAddresses` empty, or only
+     non-EVM/unknown entries (e.g. `SOL`). Disambiguate among
+     `kind == .cryptoToken && ticker.caseInsensitiveCompare(S) ==
+     .orderedSame`:
+     1. exclude `pricingStatus == .spam`;
+     2. prefer a registration with a provider mapping / `.priced` over an
+        unmapped `.unpriced` stub;
+     3. prefer an instrument already used on an existing `TransactionLeg`
+        in any of the profile's accounts;
+     4. deterministic tie-break: lowest `Instrument.id`.
+     Zero non-spam matches → unresolved; the group is dropped and logged
+     (current behaviour). The fallback never returns a `.spam`
+     instrument. This path is safe precisely because these symbols have
+     no chain to get wrong.
+
+### `Chain` enum → EVM chain id
+
+| Coinstash `Chain` | EVM chain id | `ChainConfig`? |
+|---|---|---|
+| `ETHEREUM` | 1 | yes |
+| `OPTIMISM` | 10 | yes |
+| `BASE` | 8453 | yes |
+| `ARBITRUM` | 42161 | no |
+| `POLYGON` | 137 | no |
+| `BSC` | 56 | no |
+| `AVALANCE` | 43114 | no |
+| `GNOSIS` | 100 | no |
+| `FANTOM` | 250 | no |
+| `LINEA` | 59144 | no |
+| `SONIC` | 146 | no |
+| `SOLANA` | — (non-EVM, excluded) | — |
+
+Any `Chain` value absent from this table is treated as "no usable EVM
+contract" → registry fallback (safe, conservative). The table is the only
+place to extend when Coinstash adds a chain we care to pin precisely.
+
+## Discovery-path generalisation
+
+`CryptoTokenDiscoveryService.resolveOrLoad(chain: ChainConfig, ...)` and
+its private `performResolution` currently require a `ChainConfig`, whose
+only `ChainConfig`-specific use is `fetchSpamFlag(chain:contractAddress:)`
+(Alchemy) — everything else (`resolver.resolveRegistration`, instrument
+construction, registry write) is already `chainId: Int`-keyed.
+
+Change the entry point to accept the chain id plus an **optional**
+`ChainConfig` (or derive `ChainConfig.config(for:)` internally). When no
+`ChainConfig` is available, skip `fetchSpamFlag` (treat `isSpam == false`)
+and keep the rest unchanged. The existing ETH/OP/Base call path stays
+behaviourally identical (a `ChainConfig` is still passed/derived, Alchemy
+spam check still runs). This preserves a single discovery/registration
+implementation rather than forking exchange-specific resolution logic.
+
+## GraphQL & client changes
+
+- **`CoinstashGraphQL`**: add a `getCoinBySymbol` query selecting
+  `symbol name defiAddresses { chain address decimals }`, plus Codable
+  models (`CoinstashCoinMetadata`, `CoinstashDefiAddress`,
+  `Chain`-as-`String`). Mirror the existing `CoinstashGraphQLResponse`
+  decoding and error handling.
+- **Provider-neutral seam**: introduce
+  `protocol ExchangeAssetMetadataResolving` (neutral, in `Shared/Exchange`)
+  with `func assetMetadata(forSymbol:) async throws ->
+  ExchangeAssetMetadata?` where `ExchangeAssetMetadata` is the neutral
+  shape (`symbol`, `name`, `[ (chainId: Int, contractAddress: String?,
+  decimals: Int) ]`, native-sentinel already collapsed to
+  `contractAddress: nil`). `CoinstashClient` implements it via
+  `getCoinBySymbol` and the enum→chain-id table. A future exchange
+  provides its own conformance. Keeps `ExchangeClient` unchanged and the
+  engine provider-agnostic.
+- **Caching**: the per-build-run symbol cache lives in the resolver layer
+  the engine calls, not in `CoinstashClient` (the client stays stateless,
+  matching its current design).
+
+## Wiring
+
+- `ExchangeSyncEngine.buildCandidate` resolves instruments through a new
+  resolver that, per leg: fiat → injected fiat; crypto → metadata path
+  (steps 1–4) with the `ExchangeInstrumentResolver` registry
+  disambiguation (step 5) as the definitive-miss fallback.
+- Construction (`App/ProfileSession+CryptoSync.swift`, where
+  `CoinstashSyncSource` / `ExchangeSyncEngine` are assembled): thread in
+  `CryptoTokenDiscoveryService`, the `ExchangeAssetMetadataResolving`
+  conformance, and a narrow "instruments appearing on existing legs"
+  lookup (used **only** by fallback step 5.3, so it runs only on genuine
+  ambiguity). The crypto wallet sync already builds a
+  `CryptoTokenDiscoveryService`; reuse the same instance.
+- `ExchangeInstrumentResolver` keeps its fiat handling and gains the
+  spam/priced/used disambiguation; its symbol-only first-match scan is
+  removed.
+- Group-drop behaviour in `ExchangeSyncEngine` is unchanged: an
+  unresolved leg still drops the whole `orderId`/`externalId` group with
+  a log line.
+
+## Remediation of already-imported rows
+
+Operational, not code. After this lands, use the `automate-app` skill to
+delete the Coinstash account's transactions and trigger a resync so they
+re-import through the corrected resolver. No migration/back-fill code.
+
+## Testing
+
+GraphQL decode fixtures use the real shapes captured during the
+investigation (OP single-chain; USDC 9-chain; ETH native-sentinel;
+BTC empty `defiAddresses`; SOL `SOLANA`-only).
+
+1. **Metadata decode**: `getCoinBySymbol` response → `ExchangeAssetMetadata`
+   for OP / USDC / ETH / BTC; native sentinel collapses to
+   `contractAddress: nil`; `AVALANCE` spelling handled.
+2. **Canonical selection**: USDC → Ethereum `1:0xa0b8…eb48` decimals 6;
+   a token listed on OP+Base but not Ethereum → OP (preference order);
+   determinism across input re-ordering.
+3. **OP regression**: registry seeded with spam `OP` + real OP →
+   resolves to `10:0x4200…0042`, `pricingStatus != .spam`.
+4. **Native**: ETH → `1:native` (sentinel detection, case-insensitive).
+5. **Discovery-path generalisation**: ChainConfig chain (OP) → Alchemy
+   spam step invoked; non-ChainConfig EVM chain (Arbitrum) → spam step
+   skipped, still registers with a CoinGecko-resolved mapping.
+6. **Explicit BTC**: symbol `BTC` → `0:native` (decimals 8) with **no**
+   `getCoinBySymbol` call (assert the metadata resolver is not invoked);
+   resolves to the seeded preset registration with its CoinGecko mapping;
+   defensive path registers it if absent.
+7. **Registry fallback**: `SOL` (only a `SOLANA` entry) and an
+   unknown-symbol case → fallback; spam excluded; `.priced` preferred
+   over `.unpriced` stub; used-in-accounts preferred; deterministic id
+   tie-break; all-spam → unresolved (group dropped + logged).
+8. **Transient failure**: `getCoinBySymbol` network/GraphQL error →
+   throws (sync retries); does not silently fall back or drop.
+9. **Fiat unchanged**: AUD/fiat legs still resolve to the injected fiat
+   instrument with no metadata call.
+10. **End-to-end** (`TestBackend`, stubbed Coinstash transport): profile
+    → accounts → transactions including an OP deposit → leg resolves to
+    real Optimism OP and is not spam-flagged.
+
+Tests follow `guides/TEST_GUIDE.md` (Swift Testing; one extension per
+protocol conformance; reuse `StubInstrumentRegistry`).
+
+## Out of scope
+
+All fuzzy cross-account transfer detection (Coinstash↔bank,
+Coinstash↔on-chain wallet, including the 40167 OP ↔ Trust-Optimism case)
+→ [#928](https://github.com/ajsutton/moolah-native/issues/928). Once
+instruments resolve correctly here, those pairs become detectable by that
+engine.
+
+## Open questions
+
+None blocking. `SONIC` chain id (146) is included for completeness but the
+user holds no Sonic assets; if it is ever wrong the conservative
+"unknown → registry fallback" behaviour bounds the blast radius, and the
+table is the single fix site.

--- a/plans/2026-05-17-coinstash-instrument-resolution-plan.md
+++ b/plans/2026-05-17-coinstash-instrument-resolution-plan.md
@@ -1,0 +1,1458 @@
+# Coinstash Instrument Resolution Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Resolve Coinstash crypto legs to the correct chain-pinned `Instrument` using Coinstash's `getCoinBySymbol` token metadata through the existing crypto discovery path, fixing the spam-OP mis-resolution.
+
+**Architecture:** A neutral `ExchangeAssetMetadataResolving` seam returns `(symbol, name, [chainId, contractAddress, decimals])` per token. `CoinstashClient` implements it via a `getCoinBySymbol` GraphQL query (collapsing the native-ETH sentinel and Coinstash's `Chain` enum to EVM chain ids). `ExchangeSyncEngine` picks a canonical chain (Ethereum-preferred), registers via the (generalised) `CryptoTokenDiscoveryService`, with an explicit BTC short-circuit and a non-spam registry fallback for tokens with no usable EVM metadata.
+
+**Tech Stack:** Swift 6, Swift Testing (`@Suite`/`@Test`), GraphQL over `URLSession`, GRDB. Build/test via `just`.
+
+**Spec:** `plans/2026-05-17-coinstash-instrument-resolution-design.md`. Fuzzy cross-account transfer detection is out of scope (deferred to [#928](https://github.com/ajsutton/moolah-native/issues/928)).
+
+**Conventions (apply to every task):**
+- TDD: write the failing test first, watch it fail, implement, watch it pass, commit.
+- Tests use Swift Testing (`import Testing`, `@testable import Moolah`, `@Suite`, `@Test`, `#expect`, `#require`) — never XCTest. One protocol conformance per `extension`.
+- Run tests with `just test-mac <ClassName>` and capture output: `mkdir -p .agent-tmp && just test-mac <Filter> 2>&1 | tee .agent-tmp/test-output.txt`, then `grep -i 'failed\|error:' .agent-tmp/test-output.txt`. Delete the temp file when done.
+- Before every commit: `just format` then `just format-check`. Never edit `.swiftlint-baseline.yml`.
+- Use `git -C <repo> ...` form is not needed here (commands run from the worktree root) — plain `git add`/`git commit` from the worktree is correct.
+- Commit messages: imperative, with the `Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>` trailer.
+
+---
+
+## File Structure
+
+**Create:**
+- `Shared/Exchange/ExchangeAssetMetadata.swift` — neutral metadata value type + `ExchangeAssetMetadataResolving` protocol.
+- `Shared/Exchange/CoinstashAssetMetadataResolver.swift` — token-bound adapter wrapping `CoinstashClient` + bearer token.
+- `MoolahTests/Shared/Exchange/CoinstashCoinMetadataTests.swift` — GraphQL decode + Coinstash→neutral mapping tests.
+- `MoolahTests/Shared/Exchange/ExchangeSyncEngineResolutionTests.swift` — canonical selection / BTC / native / fallback / transient tests.
+
+**Modify:**
+- `Shared/CryptoImport/CryptoTokenDiscoveryService.swift` — add `resolveOrLoad(chainId:contractAddress:symbol:name:decimals:)` overload; make Alchemy spam step conditional on `ChainConfig`.
+- `Shared/Exchange/CoinstashGraphQL.swift` — add `coinBySymbolQuery` + Codable models.
+- `Shared/Exchange/CoinstashClient.swift` — implement `coinMetadata(symbol:token:)` (query + Chain→chainId table + sentinel collapse).
+- `Shared/Exchange/ExchangeInstrumentResolver.swift` — replace symbol-only scan with `fiatInstrument` accessor + `fallbackInstrument(forSymbol:)` (non-spam → priced → used → id).
+- `Shared/Exchange/ExchangeSyncEngine.swift` — orchestrate resolution (BTC table → metadata → canonical → discovery → fallback); new `discovery` dependency; `build` gains `metadata:` param.
+- `Shared/Exchange/CoinstashSyncSource.swift` — build the token-bound metadata resolver, pass into `engine.build`.
+- `Domain/Repositories/TransactionRepository.swift` — add `distinctLegInstrumentIds()`.
+- `Backends/GRDB/Repositories/GRDBTransactionRepository+ExternalIdLookup.swift` — implement `distinctLegInstrumentIds()` (DISTINCT query).
+- `App/ProfileSession+CryptoSync.swift` — thread `discovery` + existing-leg lookup into the exchange wiring.
+
+---
+
+## Task 1: Generalise `CryptoTokenDiscoveryService.resolveOrLoad` to a chain id
+
+**Files:**
+- Modify: `Shared/CryptoImport/CryptoTokenDiscoveryService.swift`
+- Test: `MoolahTests/Shared/CryptoImport/CryptoTokenDiscoveryServiceTests.swift`
+
+The existing `resolveOrLoad(chain: ChainConfig, ...)` and private `performResolution(chain: ChainConfig, ...)` require a `ChainConfig`, used only for `fetchSpamFlag` (Alchemy). Add a `chainId: Int` entry point that derives `ChainConfig.config(for:)` and skips the Alchemy spam step when there is no config (CoinGecko-by-contract still resolves pricing for those chains). Keep the existing `chain:` API delegating to it so wallet-import call sites are unchanged.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `CryptoTokenDiscoveryServiceTests.swift` (reuse the suite's existing `CountingRegistrationResolver` / Alchemy stub setup pattern already in that file; mirror an existing test's construction of the service):
+
+```swift
+@Test
+func resolveByChainIdWithoutChainConfigSkipsAlchemyAndRegisters() async throws {
+  let registry = StubInstrumentRegistry()
+  let resolver = CountingRegistrationResolver()
+  resolver.setDefault(.success(coingecko: "usd-coin", cryptocompare: nil, binance: nil))
+  let alchemy = CountingAlchemyClient()  // existing stub in this test file's doubles
+  let service = CryptoTokenDiscoveryService(
+    registry: registry, resolver: resolver, alchemy: alchemy)
+
+  // Arbitrum (chain 42161) has no ChainConfig.
+  let registration = try await service.resolveOrLoad(
+    chainId: 42161,
+    contractAddress: "0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
+    symbol: "USDC",
+    name: "USDC",
+    decimals: 6)
+
+  #expect(registration.instrument.id == "42161:0xff970a61a04b1ca14834a43f5de4533ebddb5cc8")
+  #expect(registration.instrument.decimals == 6)
+  #expect(registration.pricingStatus == .priced)
+  #expect(alchemy.getTokenMetadataCallCount == 0)  // spam step skipped: no ChainConfig
+  let snap = registry.snapshot()
+  #expect(snap.registeredCryptos.contains { $0.id == registration.instrument.id })
+}
+```
+
+If the Alchemy stub in this file does not already expose a `getTokenMetadataCallCount`, add a thread-safe counter to that existing stub (it follows the lock-bracket pattern) — do not create a new stub class.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `mkdir -p .agent-tmp && just test-mac CryptoTokenDiscoveryServiceTests 2>&1 | tee .agent-tmp/test-output.txt; grep -i 'failed\|error:' .agent-tmp/test-output.txt`
+Expected: FAIL — `resolveOrLoad(chainId:...)` does not exist (compile error).
+
+- [ ] **Step 3: Implement the chain-id overload and conditional spam step**
+
+In `CryptoTokenDiscoveryService.swift`, change the public entry point and `performResolution` to key off `chainId: Int` plus an optional `ChainConfig`. Add this overload and refactor `performResolution`:
+
+```swift
+/// Resolve/register by raw EVM chain id. Derives `ChainConfig` when the
+/// chain is one the wallet importer supports (Ethereum/OP/Base) so the
+/// Alchemy spam check still runs; for other CoinGecko-priced EVM chains
+/// no `ChainConfig` exists, so the spam check is skipped (Alchemy has no
+/// network slug for them) and pricing still resolves by contract.
+func resolveOrLoad(
+  chainId: Int,
+  contractAddress: String?,
+  symbol: String,
+  name: String,
+  decimals: Int
+) async throws -> CryptoRegistration {
+  let id = Instrument.crypto(
+    chainId: chainId, contractAddress: contractAddress,
+    symbol: symbol, name: name, decimals: decimals).id
+  if let existing = try await registry.cryptoRegistration(byId: id) { return existing }
+  if let task = inFlight[id] { return try await task.value }
+
+  let task = Task<CryptoRegistration, Error> { [self] in
+    try await performResolution(
+      chainId: chainId,
+      chain: ChainConfig.config(for: chainId),
+      contractAddress: contractAddress,
+      symbol: symbol,
+      name: name,
+      decimals: decimals)
+  }
+  inFlight[id] = task
+  do {
+    let result = try await task.value
+    inFlight[id] = nil
+    return result
+  } catch {
+    inFlight[id] = nil
+    throw error
+  }
+}
+```
+
+Change the existing `resolveOrLoad(chain:...)` body to delegate:
+
+```swift
+func resolveOrLoad(
+  chain: ChainConfig,
+  contractAddress: String?,
+  symbol: String,
+  name: String,
+  decimals: Int
+) async throws -> CryptoRegistration {
+  try await resolveOrLoad(
+    chainId: chain.chainId,
+    contractAddress: contractAddress,
+    symbol: symbol,
+    name: name,
+    decimals: decimals)
+}
+```
+
+Change `performResolution`'s signature to `performResolution(chainId: Int, chain: ChainConfig?, contractAddress: String?, symbol: String, name: String, decimals: Int)`. Inside it, replace every `chain.chainId` with `chainId`, build the instrument with `chainId`, and gate the spam lookup:
+
+```swift
+let isSpam: Bool
+if let chain, let contractAddress, !isNative {
+  isSpam = try await fetchSpamFlag(chain: chain, contractAddress: contractAddress)
+} else {
+  isSpam = false
+}
+```
+
+Update the private `reResolve(_:chain:)` call into `performResolution` to pass `chainId: chain.chainId, chain: chain`. (It still receives a concrete `ChainConfig` from its caller; no behaviour change.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `just test-mac CryptoTokenDiscoveryServiceTests CryptoTokenDiscoveryCoalescerTests 2>&1 | tee .agent-tmp/test-output.txt; grep -i 'failed\|error:' .agent-tmp/test-output.txt`
+Expected: PASS (new test + all existing discovery tests still green — the `chain:` overload is behaviourally identical for Ethereum/OP/Base).
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+just format && just format-check
+git add Shared/CryptoImport/CryptoTokenDiscoveryService.swift MoolahTests/Shared/CryptoImport/CryptoTokenDiscoveryServiceTests.swift MoolahTests/Shared/CryptoImport/CryptoTokenDiscoveryTestDoubles.swift
+git commit -m "$(cat <<'EOF'
+feat: chain-id resolveOrLoad overload; skip Alchemy spam off-ChainConfig
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Neutral `ExchangeAssetMetadata` value type + resolver protocol
+
+**Files:**
+- Create: `Shared/Exchange/ExchangeAssetMetadata.swift`
+- Test: `MoolahTests/Shared/Exchange/CoinstashCoinMetadataTests.swift`
+
+Provider-neutral shape. `chains` is already filtered to EVM-mappable chains, native sentinel collapsed to `contractAddress == nil`, ordered as the provider listed them. `nil` from the resolver means a *definitive* "no usable EVM metadata" (BTC empty, non-EVM only, unknown symbol); a thrown error means *transient* (network/GraphQL) and must propagate so the sync retries.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `MoolahTests/Shared/Exchange/CoinstashCoinMetadataTests.swift`:
+
+```swift
+import Testing
+
+@testable import Moolah
+
+@Suite("ExchangeAssetMetadata value type")
+struct ExchangeAssetMetadataValueTests {
+  @Test
+  func chainStoresContractAndDecimals() {
+    let chain = ExchangeAssetChain(
+      chainId: 1, contractAddress: "0xA0B8…", decimals: 6)
+    let meta = ExchangeAssetMetadata(symbol: "USDC", name: "USDC", chains: [chain])
+    #expect(meta.symbol == "USDC")
+    #expect(meta.chains.first?.chainId == 1)
+    #expect(meta.chains.first?.decimals == 6)
+  }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `just test-mac ExchangeAssetMetadataValueTests 2>&1 | tee .agent-tmp/test-output.txt; grep -i 'failed\|error:' .agent-tmp/test-output.txt`
+Expected: FAIL — types not defined.
+
+- [ ] **Step 3: Implement the value type and protocol**
+
+Create `Shared/Exchange/ExchangeAssetMetadata.swift`:
+
+```swift
+import Foundation
+
+/// One chain on which a provider lists a token. `contractAddress == nil`
+/// means the chain's native asset (the provider's native-token sentinel
+/// has already been collapsed by the mapping layer).
+struct ExchangeAssetChain: Sendable, Hashable {
+  let chainId: Int
+  let contractAddress: String?
+  let decimals: Int
+}
+
+/// Provider-neutral token metadata. `chains` is restricted to
+/// EVM chains with a known chain id, in the provider's own listing order.
+struct ExchangeAssetMetadata: Sendable, Hashable {
+  let symbol: String
+  let name: String
+  let chains: [ExchangeAssetChain]
+}
+
+/// Resolves an exchange asset symbol to neutral token metadata.
+///
+/// Returns `nil` for a *definitive* "no usable EVM metadata" answer
+/// (symbol unknown to the provider, or it lists the token only on
+/// non-EVM chains). Throws for *transient* failures (network / provider
+/// error) so the caller's sync retries instead of mis-resolving.
+protocol ExchangeAssetMetadataResolving: Sendable {
+  func assetMetadata(forSymbol symbol: String) async throws -> ExchangeAssetMetadata?
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `just test-mac ExchangeAssetMetadataValueTests 2>&1 | tee .agent-tmp/test-output.txt; grep -i 'failed\|error:' .agent-tmp/test-output.txt`
+Expected: PASS.
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+just format && just format-check
+git add Shared/Exchange/ExchangeAssetMetadata.swift MoolahTests/Shared/Exchange/CoinstashCoinMetadataTests.swift
+git commit -m "$(cat <<'EOF'
+feat: neutral ExchangeAssetMetadata + resolver protocol
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Coinstash `getCoinBySymbol` GraphQL query + Codable models
+
+**Files:**
+- Modify: `Shared/Exchange/CoinstashGraphQL.swift`
+- Test: `MoolahTests/Shared/Exchange/CoinstashCoinMetadataTests.swift`
+
+Add the query and decode models only (mapping to neutral is Task 4).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `CoinstashCoinMetadataTests.swift`:
+
+```swift
+@Suite("CoinstashCoinMetadata decode")
+struct CoinstashCoinMetadataDecodeTests {
+  private func decode(_ json: String) throws -> CoinstashCoinData {
+    try JSONDecoder().decode(
+      CoinstashGraphQLResponse<CoinstashCoinData>.self,
+      from: Data(json.utf8)
+    ).data!  // test fixture is always a success shape
+  }
+
+  @Test
+  func decodesSingleChainToken() throws {
+    let json = """
+      {"data":{"getCoinBySymbol":{"symbol":"OP","name":"Optimism",
+      "defiAddresses":[{"chain":"OPTIMISM",
+      "address":"0x4200000000000000000000000000000000000042","decimals":18}]}}}
+      """
+    let coin = try #require(try decode(json).getCoinBySymbol)
+    #expect(coin.symbol == "OP")
+    #expect(coin.defiAddresses.count == 1)
+    #expect(coin.defiAddresses[0].chain == "OPTIMISM")
+    #expect(coin.defiAddresses[0].address == "0x4200000000000000000000000000000000000042")
+    #expect(coin.defiAddresses[0].decimals == 18)
+  }
+
+  @Test
+  func decodesEmptyDefiAddresses() throws {
+    let json = """
+      {"data":{"getCoinBySymbol":{"symbol":"BTC","name":"Bitcoin","defiAddresses":[]}}}
+      """
+    let coin = try #require(try decode(json).getCoinBySymbol)
+    #expect(coin.defiAddresses.isEmpty)
+  }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `just test-mac CoinstashCoinMetadataDecodeTests 2>&1 | tee .agent-tmp/test-output.txt; grep -i 'failed\|error:' .agent-tmp/test-output.txt`
+Expected: FAIL — `CoinstashCoinData` undefined.
+
+- [ ] **Step 3: Add the query and models**
+
+In `CoinstashGraphQL.swift`, add to the `CoinstashGraphQL` enum (after `transactionsQuery`):
+
+```swift
+/// Token metadata for a Coinstash symbol. The per-transaction `chain`
+/// field is unreliable (observed null/empty live 2026-05-17), so the
+/// chain + contract come from here. `defiAddresses` is the per-chain
+/// contract list; `[]` for non-EVM-modelled assets (e.g. BTC).
+/// Decodes into `CoinstashGraphQLResponse<CoinstashCoinData>`.
+static let coinBySymbolQuery = """
+  query Q($s: String!) {
+    getCoinBySymbol(symbol: $s) {
+      symbol name
+      defiAddresses { chain address decimals }
+    }
+  }
+  """
+```
+
+Add these models at file scope (after the existing transaction models):
+
+```swift
+struct CoinstashDefiAddress: Decodable, Sendable, Hashable {
+  let chain: String
+  /// Optional defensively: a malformed row must not fail the whole decode.
+  let address: String?
+  let decimals: Int?
+}
+
+struct CoinstashCoinMetadata: Decodable, Sendable, Hashable {
+  let symbol: String
+  let name: String
+  let defiAddresses: [CoinstashDefiAddress]
+}
+
+struct CoinstashCoinData: Decodable, Sendable {
+  /// `null` when Coinstash does not recognise the symbol.
+  let getCoinBySymbol: CoinstashCoinMetadata?
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `just test-mac CoinstashCoinMetadataDecodeTests 2>&1 | tee .agent-tmp/test-output.txt; grep -i 'failed\|error:' .agent-tmp/test-output.txt`
+Expected: PASS.
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+just format && just format-check
+git add Shared/Exchange/CoinstashGraphQL.swift MoolahTests/Shared/Exchange/CoinstashCoinMetadataTests.swift
+git commit -m "$(cat <<'EOF'
+feat: Coinstash getCoinBySymbol query + decode models
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: `CoinstashClient.coinMetadata` — query + Chain→chainId + sentinel collapse
+
+**Files:**
+- Modify: `Shared/Exchange/CoinstashClient.swift`
+- Test: `MoolahTests/Shared/Exchange/CoinstashCoinMetadataTests.swift`
+
+Map Coinstash's `Chain` enum to EVM chain ids, drop non-EVM/unknown chains, collapse the native sentinel `0x` + forty `e` (case-insensitive) to `contractAddress == nil`, and preserve Coinstash's listing order. Use the existing private `query(_:variables:token:decoding:)` transport.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `CoinstashCoinMetadataTests.swift`. Use the existing transport-stub pattern from `CoinstashClientTests.swift` (a `@Sendable (URLRequest) async throws -> (Data, URLResponse)` returning a canned 200 body); copy that helper's shape:
+
+```swift
+@Suite("CoinstashClient.coinMetadata mapping")
+struct CoinstashClientCoinMetadataTests {
+  private func client(returning body: String) -> CoinstashClient {
+    CoinstashClient(transport: { _ in
+      (Data(body.utf8),
+       HTTPURLResponse(
+        url: CoinstashGraphQL.endpoint, statusCode: 200,
+        httpVersion: nil, headerFields: nil)!)
+    })
+  }
+
+  @Test
+  func mapsSingleChainOptimismToken() async throws {
+    let c = client(returning: """
+      {"data":{"getCoinBySymbol":{"symbol":"OP","name":"Optimism",
+      "defiAddresses":[{"chain":"OPTIMISM",
+      "address":"0x4200000000000000000000000000000000000042","decimals":18}]}}}
+      """)
+    let meta = try #require(try await c.coinMetadata(symbol: "OP", token: "t"))
+    #expect(meta.symbol == "OP")
+    #expect(meta.chains == [
+      ExchangeAssetChain(
+        chainId: 10,
+        contractAddress: "0x4200000000000000000000000000000000000042",
+        decimals: 18)
+    ])
+  }
+
+  @Test
+  func collapsesNativeSentinelToNilContract() async throws {
+    let c = client(returning: """
+      {"data":{"getCoinBySymbol":{"symbol":"ETH","name":"Ethereum",
+      "defiAddresses":[
+      {"chain":"ETHEREUM","address":"0xEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE","decimals":18},
+      {"chain":"SOLANA","address":"So111","decimals":9}]}}}
+      """)
+    let meta = try #require(try await c.coinMetadata(symbol: "ETH", token: "t"))
+    // SOLANA dropped (non-EVM); sentinel → nil contract.
+    #expect(meta.chains == [
+      ExchangeAssetChain(chainId: 1, contractAddress: nil, decimals: 18)
+    ])
+  }
+
+  @Test
+  func unknownSymbolReturnsNil() async throws {
+    let c = client(returning: #"{"data":{"getCoinBySymbol":null}}"#)
+    #expect(try await c.coinMetadata(symbol: "ZZZ", token: "t") == nil)
+  }
+
+  @Test
+  func emptyDefiAddressesReturnsMetadataWithNoChains() async throws {
+    let c = client(returning: """
+      {"data":{"getCoinBySymbol":{"symbol":"BTC","name":"Bitcoin","defiAddresses":[]}}}
+      """)
+    let meta = try #require(try await c.coinMetadata(symbol: "BTC", token: "t"))
+    #expect(meta.chains.isEmpty)
+  }
+
+  @Test
+  func providerErrorThrows() async throws {
+    let c = CoinstashClient(transport: { _ in
+      (Data(#"{"errors":[{"message":"boom"}]}"#.utf8),
+       HTTPURLResponse(
+        url: CoinstashGraphQL.endpoint, statusCode: 200,
+        httpVersion: nil, headerFields: nil)!)
+    })
+    await #expect(throws: ExchangeClientError.self) {
+      _ = try await c.coinMetadata(symbol: "OP", token: "t")
+    }
+  }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `just test-mac CoinstashClientCoinMetadataTests 2>&1 | tee .agent-tmp/test-output.txt; grep -i 'failed\|error:' .agent-tmp/test-output.txt`
+Expected: FAIL — `coinMetadata(symbol:token:)` undefined.
+
+- [ ] **Step 3: Implement `coinMetadata` + the chain table + sentinel collapse**
+
+In `CoinstashClient.swift`, add the chain table and method (the chain id values come from the spec's `Chain` enum → EVM chain-id table):
+
+```swift
+// Coinstash `Chain` enum → EVM chain id. Non-EVM (SOLANA) and any
+// value absent here are intentionally excluded: a symbol that lists
+// only excluded chains falls through to the caller's registry
+// fallback. `AVALANCE` is Coinstash's spelling.
+private static let evmChainIds: [String: Int] = [
+  "ETHEREUM": 1, "OPTIMISM": 10, "BASE": 8453, "ARBITRUM": 42161,
+  "POLYGON": 137, "BSC": 56, "AVALANCE": 43114, "GNOSIS": 100,
+  "FANTOM": 250, "LINEA": 59144, "SONIC": 146,
+]
+
+/// The well-known "native asset" sentinel address (`0x` + forty `e`).
+private static let nativeSentinel = "0x" + String(repeating: "e", count: 40)
+
+/// Token metadata for `symbol`, or `nil` when Coinstash does not
+/// recognise the symbol (definitive — caller takes the registry
+/// fallback). Throws on transport / provider error (transient — the
+/// sync retries). Non-EVM and unknown chains are dropped; the native
+/// sentinel collapses to `contractAddress == nil`; Coinstash's listing
+/// order is preserved.
+func coinMetadata(symbol: String, token: String) async throws -> ExchangeAssetMetadata? {
+  let data = try await query(
+    CoinstashGraphQL.coinBySymbolQuery,
+    variables: ["s": .string(symbol)],
+    token: token,
+    decoding: CoinstashCoinData.self)
+  guard let coin = data.getCoinBySymbol else { return nil }
+
+  let chains: [ExchangeAssetChain] = coin.defiAddresses.compactMap { entry in
+    guard let chainId = Self.evmChainIds[entry.chain] else { return nil }
+    guard let address = entry.address else { return nil }
+    let isSentinel = address.caseInsensitiveCompare(Self.nativeSentinel) == .orderedSame
+    return ExchangeAssetChain(
+      chainId: chainId,
+      contractAddress: isSentinel ? nil : address,
+      decimals: entry.decimals ?? 18)
+  }
+  return ExchangeAssetMetadata(symbol: coin.symbol, name: coin.name, chains: chains)
+}
+```
+
+Add the protocol conformance in its own extension at the end of the file:
+
+```swift
+extension CoinstashClient {
+  // Token-bound conformance is provided by CoinstashAssetMetadataResolver
+  // (the protocol has no token parameter; the bearer token is per-account).
+}
+```
+
+(The `CoinstashClient` keeps `coinMetadata(symbol:token:)`; the protocol adapter is Task 5. The empty extension above is a placeholder comment only — omit it if SwiftLint flags an empty extension; the real conformance lives in Task 5.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `just test-mac CoinstashClientCoinMetadataTests 2>&1 | tee .agent-tmp/test-output.txt; grep -i 'failed\|error:' .agent-tmp/test-output.txt`
+Expected: PASS.
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+just format && just format-check
+git add Shared/Exchange/CoinstashClient.swift MoolahTests/Shared/Exchange/CoinstashCoinMetadataTests.swift
+git commit -m "$(cat <<'EOF'
+feat: CoinstashClient.coinMetadata with Chain→chainId + sentinel collapse
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: `CoinstashAssetMetadataResolver` token-bound adapter
+
+**Files:**
+- Create: `Shared/Exchange/CoinstashAssetMetadataResolver.swift`
+- Test: `MoolahTests/Shared/Exchange/CoinstashCoinMetadataTests.swift`
+
+`ExchangeAssetMetadataResolving` has no token parameter (it is provider-neutral; the Coinstash bearer token is per-account). This adapter binds a `CoinstashClient` + token.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `CoinstashCoinMetadataTests.swift`:
+
+```swift
+@Suite("CoinstashAssetMetadataResolver")
+struct CoinstashAssetMetadataResolverTests {
+  @Test
+  func forwardsToClientWithBoundToken() async throws {
+    let client = CoinstashClient(transport: { _ in
+      (Data("""
+        {"data":{"getCoinBySymbol":{"symbol":"OP","name":"Optimism",
+        "defiAddresses":[{"chain":"OPTIMISM",
+        "address":"0x4200000000000000000000000000000000000042","decimals":18}]}}}
+        """.utf8),
+       HTTPURLResponse(
+        url: CoinstashGraphQL.endpoint, statusCode: 200,
+        httpVersion: nil, headerFields: nil)!)
+    })
+    let resolver: any ExchangeAssetMetadataResolving =
+      CoinstashAssetMetadataResolver(client: client, token: "secret")
+    let meta = try #require(try await resolver.assetMetadata(forSymbol: "OP"))
+    #expect(meta.chains.first?.chainId == 10)
+  }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `just test-mac CoinstashAssetMetadataResolverTests 2>&1 | tee .agent-tmp/test-output.txt; grep -i 'failed\|error:' .agent-tmp/test-output.txt`
+Expected: FAIL — type undefined.
+
+- [ ] **Step 3: Implement the adapter**
+
+Create `Shared/Exchange/CoinstashAssetMetadataResolver.swift`:
+
+```swift
+import Foundation
+
+/// Binds a `CoinstashClient` to a per-account bearer token so the
+/// provider-neutral `ExchangeAssetMetadataResolving` seam carries no
+/// token. Constructed per sync by `CoinstashSyncSource` once the
+/// account's token is read from the keychain.
+struct CoinstashAssetMetadataResolver: ExchangeAssetMetadataResolving {
+  private let client: CoinstashClient
+  private let token: String
+
+  init(client: CoinstashClient, token: String) {
+    self.client = client
+    self.token = token
+  }
+
+  func assetMetadata(forSymbol symbol: String) async throws -> ExchangeAssetMetadata? {
+    try await client.coinMetadata(symbol: symbol, token: token)
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `just test-mac CoinstashAssetMetadataResolverTests 2>&1 | tee .agent-tmp/test-output.txt; grep -i 'failed\|error:' .agent-tmp/test-output.txt`
+Expected: PASS.
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+just format && just format-check
+git add Shared/Exchange/CoinstashAssetMetadataResolver.swift MoolahTests/Shared/Exchange/CoinstashCoinMetadataTests.swift
+git commit -m "$(cat <<'EOF'
+feat: CoinstashAssetMetadataResolver token-bound adapter
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: `distinctLegInstrumentIds()` repository read (used-in-accounts tie-break)
+
+**Files:**
+- Modify: `Domain/Repositories/TransactionRepository.swift`
+- Modify: `Backends/GRDB/Repositories/GRDBTransactionRepository+ExternalIdLookup.swift`
+- Test: an existing GRDB transaction-repository test suite under `MoolahTests/` (locate the suite that builds a `DatabaseQueue` and seeds legs — follow its existing setup helper exactly; add one `@Test` there).
+
+The registry fallback's tertiary tie-break ("prefer an instrument already used on an existing leg"). A focused `SELECT DISTINCT instrument_id FROM transaction_leg` — cheap, and only awaited when ≥2 non-spam same-ticker candidates survive (near-never).
+
+- [ ] **Step 1: Write the failing test**
+
+In the existing GRDB transaction-repository test suite (the one with a `makeRepository()`/`DatabaseQueue` helper that already creates transactions with legs), add:
+
+```swift
+@Test
+func distinctLegInstrumentIdsReturnsEachInstrumentOnce() async throws {
+  let repo = try makeRepository()  // existing suite helper
+  // Seed two transactions whose legs reference the same instrument id
+  // plus one other — reuse the suite's existing transaction-builder
+  // helper rather than hand-rolling Transaction values here.
+  try await seedTwoTxnsSharingAnInstrument(repo)  // existing/added suite helper
+  let ids = try await repo.distinctLegInstrumentIds()
+  #expect(ids.contains("10:0x4200000000000000000000000000000000000042"))
+  #expect(ids.contains("AUD"))
+}
+```
+
+If the suite has no leg-seeding helper, add a minimal private one in that test file using the project's existing `Transaction`/`TransactionLeg` initialisers (mirror another test in the same file that calls `repo.create(_:)`).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `just test-mac <ThatRepoSuiteName> 2>&1 | tee .agent-tmp/test-output.txt; grep -i 'failed\|error:' .agent-tmp/test-output.txt`
+Expected: FAIL — `distinctLegInstrumentIds()` undefined.
+
+- [ ] **Step 3: Add the protocol requirement and GRDB implementation**
+
+In `Domain/Repositories/TransactionRepository.swift`, add to the protocol (near `legs(matchingExternalId:)`):
+
+```swift
+/// Distinct instrument ids appearing on any persisted transaction leg.
+/// Used only by exchange-import resolution's rare registry-fallback
+/// tie-break; cheap (`SELECT DISTINCT`), not on a hot path.
+func distinctLegInstrumentIds() async throws -> Set<String>
+```
+
+In `GRDBTransactionRepository+ExternalIdLookup.swift`, add the implementation (mirror the `dbQueue.read { ... }` pattern already used by `legs(matchingExternalId:)` in this file; `TransactionLegRow.databaseTableName == "transaction_leg"`, column `instrument_id`):
+
+```swift
+func distinctLegInstrumentIds() async throws -> Set<String> {
+  try await dbQueue.read { db in
+    let rows = try String.fetchAll(
+      db, sql: "SELECT DISTINCT instrument_id FROM transaction_leg")
+    return Set(rows)
+  }
+}
+```
+
+If any other `TransactionRepository` conformance exists (e.g. a test/in-memory double in `MoolahTests/Support/`), add the same method there returning `Set(...)` over its in-memory legs so the project still compiles. Locate them with `grep -rl "TransactionRepository" MoolahTests/Support` and conform each.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `just test-mac <ThatRepoSuiteName> 2>&1 | tee .agent-tmp/test-output.txt; grep -i 'failed\|error:' .agent-tmp/test-output.txt`
+Expected: PASS.
+
+- [ ] **Step 5: Format, review, commit**
+
+```bash
+just format && just format-check
+```
+
+Then run the database review agents on the working tree (they operate pre-PR):
+`@database-code-review` and `@database-schema-review`. Address any Critical/Important findings before committing.
+
+```bash
+git add Domain/Repositories/TransactionRepository.swift Backends/GRDB/Repositories/GRDBTransactionRepository+ExternalIdLookup.swift MoolahTests/
+git commit -m "$(cat <<'EOF'
+feat: TransactionRepository.distinctLegInstrumentIds (DISTINCT read)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: `ExchangeInstrumentResolver` — fiat accessor + non-spam registry fallback
+
+**Files:**
+- Modify: `Shared/Exchange/ExchangeInstrumentResolver.swift`
+- Test: `MoolahTests/Shared/Exchange/ExchangeInstrumentResolverTests.swift`
+
+Replace the symbol-only first-match scan with: (a) a `fiatInstrument` accessor, (b) `fallbackInstrument(forSymbol:)` implementing exclude-spam → prefer-priced/mapped → prefer-used → deterministic-id. The "used" set is injected as a closure so unit tests stay trivial.
+
+- [ ] **Step 1: Write the failing tests**
+
+Replace the body of `ExchangeInstrumentResolverTests.swift` with (keep the fiat tests, retarget the asset tests to `fallbackInstrument`):
+
+```swift
+import Testing
+
+@testable import Moolah
+
+@Suite("ExchangeInstrumentResolver")
+struct ExchangeInstrumentResolverTests {
+  private func op(_ contract: String, spam: Bool = false, mapped: Bool = true)
+    -> CryptoRegistration
+  {
+    let inst = Instrument.crypto(
+      chainId: 10, contractAddress: contract, symbol: "OP",
+      name: "Optimism", decimals: 18)
+    return CryptoRegistration(
+      instrument: inst,
+      mapping: CryptoProviderMapping(
+        instrumentId: inst.id,
+        coingeckoId: mapped ? "optimism" : nil,
+        cryptocompareSymbol: nil, binanceSymbol: nil),
+      pricingStatus: spam ? .spam : (mapped ? .priced : .unpriced))
+  }
+
+  private func resolver(
+    _ regs: [CryptoRegistration],
+    used: Set<String> = []
+  ) -> ExchangeInstrumentResolver {
+    ExchangeInstrumentResolver(
+      registry: StubInstrumentRegistry(
+        instruments: regs.map(\.instrument),
+        cryptoRegistrations: regs),
+      fiatInstrument: .AUD,
+      existingLegInstrumentIds: { used })
+  }
+
+  @Test
+  func fiatAccessorReturnsInjectedInstrument() {
+    #expect(resolver([]).fiatInstrument == .AUD)
+  }
+
+  @Test
+  func fallbackExcludesSpamAndPicksRealOP() async throws {
+    let spam = op("0xdeadbeef00000000000000000000000000000000", spam: true)
+    let real = op("0x4200000000000000000000000000000000000042")
+    let got = try await resolver([spam, real]).fallbackInstrument(forSymbol: "OP")
+    #expect(got == real.instrument)
+  }
+
+  @Test
+  func fallbackPrefersMappedOverUnpricedStub() async throws {
+    let stub = op("0x1111111111111111111111111111111111111111", mapped: false)
+    let mapped = op("0x4200000000000000000000000000000000000042")
+    let got = try await resolver([stub, mapped]).fallbackInstrument(forSymbol: "OP")
+    #expect(got == mapped.instrument)
+  }
+
+  @Test
+  func fallbackPrefersUsedThenLowestId() async throws {
+    let a = op("0xaaaa000000000000000000000000000000000000")
+    let b = op("0xbbbb000000000000000000000000000000000000")
+    // Both priced+mapped; "used" picks b even though a's id sorts lower.
+    let got = try await resolver([a, b], used: [b.instrument.id])
+      .fallbackInstrument(forSymbol: "OP")
+    #expect(got == b.instrument)
+  }
+
+  @Test
+  func fallbackDeterministicIdTieBreak() async throws {
+    let a = op("0xaaaa000000000000000000000000000000000000")
+    let b = op("0xbbbb000000000000000000000000000000000000")
+    let got = try await resolver([b, a]).fallbackInstrument(forSymbol: "OP")
+    #expect(got == a.instrument)  // "10:0xaaaa…" < "10:0xbbbb…"
+  }
+
+  @Test
+  func fallbackAllSpamReturnsNil() async throws {
+    let got = try await resolver([op("0xdead000000000000000000000000000000000000", spam: true)])
+      .fallbackInstrument(forSymbol: "OP")
+    #expect(got == nil)
+  }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `just test-mac ExchangeInstrumentResolverTests 2>&1 | tee .agent-tmp/test-output.txt; grep -i 'failed\|error:' .agent-tmp/test-output.txt`
+Expected: FAIL — new init signature / `fiatInstrument` / `fallbackInstrument` undefined.
+
+- [ ] **Step 3: Rewrite the resolver**
+
+Replace `Shared/Exchange/ExchangeInstrumentResolver.swift` with:
+
+```swift
+import Foundation
+import OSLog
+
+/// Fiat denomination + the registry fallback for exchange asset legs.
+/// The chain-pinned resolution (provider token metadata → discovery) is
+/// orchestrated by `ExchangeSyncEngine`; this type owns only the fiat
+/// instrument and the *fallback* used when the provider gives no usable
+/// EVM metadata (e.g. non-EVM-modelled assets).
+struct ExchangeInstrumentResolver: Sendable {
+  let fiatInstrument: Instrument
+  private let registry: any InstrumentRegistryRepository
+  private let existingLegInstrumentIds: @Sendable () async throws -> Set<String>
+  private static let logger = Logger(
+    subsystem: "com.moolah.app", category: "ExchangeInstrumentResolver")
+
+  init(
+    registry: any InstrumentRegistryRepository,
+    fiatInstrument: Instrument,
+    existingLegInstrumentIds: @escaping @Sendable () async throws -> Set<String>
+  ) {
+    self.registry = registry
+    self.fiatInstrument = fiatInstrument
+    self.existingLegInstrumentIds = existingLegInstrumentIds
+  }
+
+  /// Registry fallback for a crypto symbol with no usable EVM metadata.
+  /// Excludes `.spam`; prefers a mapped/`.priced` registration over an
+  /// `.unpriced` stub; then an instrument already used on an existing
+  /// leg; then the lowest `Instrument.id` (deterministic). `nil` when
+  /// every match is spam or none exist — caller drops + logs the group.
+  ///
+  /// Throws on registry failure (transient) so the sync retries rather
+  /// than silently dropping every leg.
+  func fallbackInstrument(forSymbol symbol: String) async throws -> Instrument? {
+    let regs: [CryptoRegistration]
+    do {
+      regs = try await registry.allCryptoRegistrations()
+    } catch {
+      Self.logger.error(
+        "Registry scan failed for '\(symbol, privacy: .public)': \(error, privacy: .public)")
+      throw error
+    }
+    let candidates = regs.filter {
+      $0.instrument.kind == .cryptoToken
+        && $0.instrument.ticker?.caseInsensitiveCompare(symbol) == .orderedSame
+        && $0.pricingStatus != .spam
+    }
+    guard !candidates.isEmpty else { return nil }
+
+    let used = try await existingLegInstrumentIds()
+    func rank(_ r: CryptoRegistration) -> (Int, Int, String) {
+      let priced = (r.pricingStatus == .priced && hasMapping(r.mapping)) ? 0 : 1
+      let isUsed = used.contains(r.instrument.id) ? 0 : 1
+      return (priced, isUsed, r.instrument.id)
+    }
+    return candidates.min { rank($0) < rank($1) }?.instrument
+  }
+
+  private func hasMapping(_ m: CryptoProviderMapping) -> Bool {
+    m.coingeckoId != nil || m.cryptocompareSymbol != nil || m.binanceSymbol != nil
+  }
+}
+```
+
+(`(Int, Int, String)` tuples are `Comparable` via `<` lexicographically in Swift, so `rank($0) < rank($1)` orders priced-first, then used-first, then lowest id.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `just test-mac ExchangeInstrumentResolverTests 2>&1 | tee .agent-tmp/test-output.txt; grep -i 'failed\|error:' .agent-tmp/test-output.txt`
+Expected: PASS. (The project will not fully build yet — `ExchangeSyncEngine`/wiring still use the old API; that is fixed in Tasks 8–9. Running just this suite compiles the test target against the module; if the module fails to build because callers reference the removed `instrument(forSymbol:isFiat:)`, proceed to Task 8 which updates them, then re-run Tasks 7–8 tests together.)
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+just format && just format-check
+git add Shared/Exchange/ExchangeInstrumentResolver.swift MoolahTests/Shared/Exchange/ExchangeInstrumentResolverTests.swift
+git commit -m "$(cat <<'EOF'
+feat: ExchangeInstrumentResolver fiat accessor + non-spam fallback
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 8: `ExchangeSyncEngine` resolution orchestration
+
+**Files:**
+- Modify: `Shared/Exchange/ExchangeSyncEngine.swift`
+- Test: `MoolahTests/Shared/Exchange/ExchangeSyncEngineResolutionTests.swift`
+
+Add the resolution pipeline: fiat → BTC table → metadata canonical pick → discovery → registry fallback. New deps: `discovery: CryptoTokenDiscoveryService`; `build` gains `metadata: any ExchangeAssetMetadataResolving`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `MoolahTests/Shared/Exchange/ExchangeSyncEngineResolutionTests.swift`:
+
+```swift
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("ExchangeSyncEngine resolution")
+struct ExchangeSyncEngineResolutionTests {
+  // Scriptable neutral metadata resolver.
+  final class StubMetadata: ExchangeAssetMetadataResolving, @unchecked Sendable {
+    let map: [String: ExchangeAssetMetadata?]
+    let onCall: @Sendable (String) -> Void
+    init(_ map: [String: ExchangeAssetMetadata?], onCall: @escaping @Sendable (String) -> Void = { _ in }) {
+      self.map = map
+      self.onCall = onCall
+    }
+    func assetMetadata(forSymbol symbol: String) async throws -> ExchangeAssetMetadata? {
+      onCall(symbol)
+      guard let hit = map[symbol] else { return nil }
+      return hit
+    }
+  }
+
+  private func engine(
+    registry: StubInstrumentRegistry,
+    resolver: CountingRegistrationResolver = {
+      let r = CountingRegistrationResolver()
+      r.setDefault(.success(coingecko: "id", cryptocompare: nil, binance: nil))
+      return r
+    }()
+  ) -> ExchangeSyncEngine {
+    let discovery = CryptoTokenDiscoveryService(
+      registry: registry, resolver: resolver, alchemy: CountingAlchemyClient())
+    return ExchangeSyncEngine(
+      resolver: ExchangeInstrumentResolver(
+        registry: registry, fiatInstrument: .AUD,
+        existingLegInstrumentIds: { [] }),
+      discovery: discovery)
+  }
+
+  private func depositRow(_ symbol: String, _ amount: Decimal) -> ExchangeImportedTransaction {
+    ExchangeImportedTransaction(
+      externalId: "ext-\(symbol)", occurredAt: Date(timeIntervalSince1970: 1_762_000_000),
+      category: "DEPOSIT", direction: .credit, assetSymbol: symbol,
+      amount: amount, isFiat: false, orderId: nil)
+  }
+
+  private func account() -> Account {
+    // Reuse the project's exchange-account test factory if one exists in
+    // MoolahTests/Support; otherwise build a minimal .exchange Account
+    // mirroring an existing Coinstash test's account construction.
+    ExchangeCreationHarness.coinstashAccount()  // existing harness (see Task notes)
+  }
+
+  @Test
+  func opDepositResolvesToRealOptimismOPNotSpam() async throws {
+    let registry = StubInstrumentRegistry()
+    let meta = StubMetadata([
+      "OP": ExchangeAssetMetadata(
+        symbol: "OP", name: "Optimism",
+        chains: [ExchangeAssetChain(
+          chainId: 10,
+          contractAddress: "0x4200000000000000000000000000000000000042",
+          decimals: 18)])
+    ])
+    let result = try await engine(registry: registry).build(
+      account: account(), imported: [depositRow("OP", 40167)], metadata: meta)
+    let leg = try #require(result.candidates.first?.transaction.legs.first)
+    #expect(leg.instrument.id == "10:0x4200000000000000000000000000000000000042")
+    #expect(leg.instrument.decimals == 18)
+  }
+
+  @Test
+  func btcShortCircuitsWithoutMetadataCall() async throws {
+    let registry = StubInstrumentRegistry(
+      cryptoRegistrations: CryptoRegistration.builtInPresets)
+    var called: [String] = []
+    let meta = StubMetadata([:], onCall: { called.append($0) })
+    let result = try await engine(registry: registry).build(
+      account: account(), imported: [depositRow("BTC", 1)], metadata: meta)
+    let leg = try #require(result.candidates.first?.transaction.legs.first)
+    #expect(leg.instrument.id == "0:native")
+    #expect(leg.instrument.decimals == 8)
+    #expect(called.isEmpty)  // getCoinBySymbol not invoked for BTC
+  }
+
+  @Test
+  func multiChainPicksEthereumCanonical() async throws {
+    let registry = StubInstrumentRegistry()
+    let meta = StubMetadata([
+      "USDC": ExchangeAssetMetadata(
+        symbol: "USDC", name: "USDC",
+        chains: [
+          ExchangeAssetChain(chainId: 10,
+            contractAddress: "0x7f5c764cbc14f9669b88837ca1490cca17c31607", decimals: 6),
+          ExchangeAssetChain(chainId: 1,
+            contractAddress: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", decimals: 6),
+        ])
+    ])
+    let result = try await engine(registry: registry).build(
+      account: account(), imported: [depositRow("USDC", 100)], metadata: meta)
+    let leg = try #require(result.candidates.first?.transaction.legs.first)
+    #expect(leg.instrument.id == "1:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48")
+  }
+
+  @Test
+  func nativeContractNilBuildsNativeInstrument() async throws {
+    let registry = StubInstrumentRegistry()
+    let meta = StubMetadata([
+      "ETH": ExchangeAssetMetadata(
+        symbol: "ETH", name: "Ethereum",
+        chains: [ExchangeAssetChain(chainId: 1, contractAddress: nil, decimals: 18)])
+    ])
+    let result = try await engine(registry: registry).build(
+      account: account(), imported: [depositRow("ETH", 2)], metadata: meta)
+    let leg = try #require(result.candidates.first?.transaction.legs.first)
+    #expect(leg.instrument.id == "1:native")
+  }
+
+  @Test
+  func noEvmMetadataUsesRegistryFallback() async throws {
+    let real = CryptoRegistration(
+      instrument: .crypto(
+        chainId: 1399, contractAddress: nil, symbol: "SOL",
+        name: "Solana", decimals: 9),
+      mapping: CryptoProviderMapping(
+        instrumentId: "1399:native", coingeckoId: "solana",
+        cryptocompareSymbol: nil, binanceSymbol: nil))
+    let registry = StubInstrumentRegistry(
+      instruments: [real.instrument], cryptoRegistrations: [real])
+    let meta = StubMetadata([
+      "SOL": ExchangeAssetMetadata(symbol: "SOL", name: "Solana", chains: [])
+    ])
+    let result = try await engine(registry: registry).build(
+      account: account(), imported: [depositRow("SOL", 5)], metadata: meta)
+    let leg = try #require(result.candidates.first?.transaction.legs.first)
+    #expect(leg.instrument.id == "1399:native")
+  }
+
+  @Test
+  func transientMetadataErrorThrows() async throws {
+    struct Boom: Error {}
+    final class Throwing: ExchangeAssetMetadataResolving {
+      func assetMetadata(forSymbol symbol: String) async throws -> ExchangeAssetMetadata? {
+        throw Boom()
+      }
+    }
+    let registry = StubInstrumentRegistry()
+    await #expect(throws: Boom.self) {
+      _ = try await engine(registry: registry).build(
+        account: account(), imported: [depositRow("OP", 1)], metadata: Throwing())
+    }
+  }
+
+  @Test
+  func fiatLegSkipsMetadata() async throws {
+    let registry = StubInstrumentRegistry()
+    var called: [String] = []
+    let meta = StubMetadata([:], onCall: { called.append($0) })
+    let row = ExchangeImportedTransaction(
+      externalId: "f1", occurredAt: Date(timeIntervalSince1970: 1_762_000_000),
+      category: "DEPOSIT", direction: .credit, assetSymbol: "AUD",
+      amount: 50, isFiat: true, orderId: nil)
+    let result = try await engine(registry: registry).build(
+      account: account(), imported: [row], metadata: meta)
+    let leg = try #require(result.candidates.first?.transaction.legs.first)
+    #expect(leg.instrument == .AUD)
+    #expect(called.isEmpty)
+  }
+}
+```
+
+> Note on `account()` and stubs: reuse the existing `ExchangeCreationHarness` (referenced in recent commits) or whatever the existing Coinstash tests (`CoinstashSyncSourceTests`, `ExchangeSyncEngineTests`) use to build an `.exchange` `Account`; mirror that exactly. `CountingRegistrationResolver` and the Alchemy counting stub are the existing doubles in `MoolahTests/Shared/CryptoImport/CryptoTokenDiscoveryTestDoubles.swift` — import path is the same test module, no extra import needed.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `just test-mac ExchangeSyncEngineResolutionTests 2>&1 | tee .agent-tmp/test-output.txt; grep -i 'failed\|error:' .agent-tmp/test-output.txt`
+Expected: FAIL — `ExchangeSyncEngine` has no `discovery:` init param / `build(...metadata:)`.
+
+- [ ] **Step 3: Implement the orchestration**
+
+Rewrite `Shared/Exchange/ExchangeSyncEngine.swift`. Keep `legType(for:)`, the grouping, signpost/log, and group-drop behaviour; change `init`, `build`, and `buildCandidate`:
+
+```swift
+import Foundation
+import OSLog
+
+struct ExchangeSyncEngine: Sendable {
+  private let resolver: ExchangeInstrumentResolver
+  private let discovery: CryptoTokenDiscoveryService
+  private static let logger = Logger(
+    subsystem: "com.moolah.app", category: "ExchangeSyncEngine")
+
+  // Canonical multi-chain preference: Ethereum first (product
+  // decision), then the wallet-supported chains, then the rest.
+  private static let chainPreference: [Int] =
+    [1, 10, 8453, 42161, 137, 56, 43114, 100, 250, 59144, 146]
+
+  // Non-EVM natives the app pins by convention, keyed by uppercased
+  // symbol. Resolved directly (no getCoinBySymbol call) — these are
+  // `CryptoRegistration.builtInPresets` members.
+  private static let nonEvmNatives: [String: Instrument] = [
+    "BTC": .crypto(
+      chainId: 0, contractAddress: nil, symbol: "BTC",
+      name: "Bitcoin", decimals: 8)
+  ]
+
+  init(resolver: ExchangeInstrumentResolver, discovery: CryptoTokenDiscoveryService) {
+    self.resolver = resolver
+    self.discovery = discovery
+  }
+
+  private static func legType(for category: String) -> TransactionType {
+    switch category {
+    case "DEPOSIT", "AWARD": return .income
+    case "WITHDRAW", "TRADEFEE": return .expense
+    default: return .trade
+    }
+  }
+
+  func build(
+    account: Account,
+    imported: [ExchangeImportedTransaction],
+    metadata: any ExchangeAssetMetadataResolving
+  ) async throws -> WalletSyncBuildResult {
+    let groups = Dictionary(grouping: imported) { $0.orderId ?? $0.externalId }
+    var candidates: [BuiltTransaction] = []
+    for (groupKey, rows) in groups {
+      try Task.checkCancellation()
+      if let candidate = try await buildCandidate(
+        groupKey: groupKey, rows: rows, account: account, metadata: metadata)
+      {
+        candidates.append(candidate)
+      }
+    }
+    Self.logger.info(
+      "Built \(candidates.count, privacy: .public) candidates from \(imported.count, privacy: .public) rows"
+    )
+    return WalletSyncBuildResult(candidates: candidates, headBlockNumber: 0)
+  }
+
+  private func buildCandidate(
+    groupKey: String,
+    rows: [ExchangeImportedTransaction],
+    account: Account,
+    metadata: any ExchangeAssetMetadataResolving
+  ) async throws -> BuiltTransaction? {
+    var legs: [TransactionLeg] = []
+    for row in rows {
+      try Task.checkCancellation()
+      guard
+        let instrument = try await resolveInstrument(
+          symbol: row.assetSymbol, isFiat: row.isFiat, metadata: metadata)
+      else {
+        Self.logger.warning(
+          "Dropping group \(groupKey, privacy: .public): unresolvable instrument externalId=\(row.externalId, privacy: .public) symbol=\(row.assetSymbol ?? "nil", privacy: .public) isFiat=\(row.isFiat, privacy: .public)"
+        )
+        return nil
+      }
+      let quantity = row.direction.multiplier * row.amount
+      legs.append(
+        TransactionLeg(
+          accountId: account.id,
+          instrument: instrument,
+          quantity: quantity,
+          externalId: row.externalId,
+          type: Self.legType(for: row.category)))
+    }
+    guard let date = rows.map(\.occurredAt).min() else { return nil }
+    return BuiltTransaction(
+      originAccountId: account.id,
+      transaction: Transaction(date: date, legs: legs))
+  }
+
+  /// Resolution pipeline (spec §"Resolution policy").
+  private func resolveInstrument(
+    symbol: String?,
+    isFiat: Bool,
+    metadata: any ExchangeAssetMetadataResolving
+  ) async throws -> Instrument? {
+    if isFiat { return resolver.fiatInstrument }
+    guard let symbol else { return nil }
+
+    // 0. Explicit non-EVM natives (BTC) — skip the metadata call.
+    if let native = Self.nonEvmNatives[symbol.uppercased()] {
+      if let existing = try await registryInstrument(id: native.id) { return existing }
+      let reg = try await discovery.resolveOrLoad(
+        chainId: native.chainId ?? 0,
+        contractAddress: nil,
+        symbol: native.ticker ?? symbol,
+        name: native.name,
+        decimals: native.decimals)
+      return reg.instrument
+    }
+
+    // 1. Provider metadata (transient errors propagate).
+    let meta = try await metadata.assetMetadata(forSymbol: symbol)
+
+    // 2–4. Canonical EVM pick → discovery path.
+    if let meta, let chosen = Self.canonical(meta.chains) {
+      let reg = try await discovery.resolveOrLoad(
+        chainId: chosen.chainId,
+        contractAddress: chosen.contractAddress,
+        symbol: meta.symbol,
+        name: meta.name,
+        decimals: chosen.decimals)
+      return reg.instrument
+    }
+
+    // 5. Definitive "no usable EVM metadata" → registry fallback.
+    return try await resolver.fallbackInstrument(forSymbol: symbol)
+  }
+
+  private func canonical(_ chains: [ExchangeAssetChain]) -> ExchangeAssetChain? {
+    guard !chains.isEmpty else { return nil }
+    for preferred in Self.chainPreference {
+      if let hit = chains.first(where: { $0.chainId == preferred }) { return hit }
+    }
+    return chains.first  // EVM but outside the preference list: stable first-listed
+  }
+
+  private func registryInstrument(id: String) async throws -> Instrument? {
+    try await discovery.registry.cryptoRegistration(byId: id)?.instrument
+  }
+}
+```
+
+`discovery.registry` is not accessible (private). Instead, give the engine the registry directly via the resolver: add a method on `ExchangeInstrumentResolver` `func registeredInstrument(id: String) async throws -> Instrument?` returning `try await registry.cryptoRegistration(byId: id)?.instrument`, and call `resolver.registeredInstrument(id:)` from `registryInstrument(id:)`. Add that method to the resolver in this task (small addition to Task 7's file) and a one-line test in `ExchangeInstrumentResolverTests` asserting it returns a seeded registration's instrument.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `just test-mac ExchangeSyncEngineResolutionTests ExchangeInstrumentResolverTests 2>&1 | tee .agent-tmp/test-output.txt; grep -i 'failed\|error:' .agent-tmp/test-output.txt`
+Expected: PASS.
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+just format && just format-check
+git add Shared/Exchange/ExchangeSyncEngine.swift Shared/Exchange/ExchangeInstrumentResolver.swift MoolahTests/Shared/Exchange/ExchangeSyncEngineResolutionTests.swift MoolahTests/Shared/Exchange/ExchangeInstrumentResolverTests.swift
+git commit -m "$(cat <<'EOF'
+feat: ExchangeSyncEngine metadata-driven instrument resolution
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 9: Wire `CoinstashSyncSource` + `ProfileSession+CryptoSync`
+
+**Files:**
+- Modify: `Shared/Exchange/CoinstashSyncSource.swift`
+- Modify: `App/ProfileSession+CryptoSync.swift`
+- Test: `MoolahTests/Shared/Exchange/CoinstashSyncSourceTests.swift` (existing — update for the new `engine.build(...metadata:)` shape)
+
+`CoinstashSyncSource` already reads the per-account token. After fetching transactions, build a token-bound `CoinstashAssetMetadataResolver` and pass it into `engine.build`.
+
+- [ ] **Step 1: Update the existing failing test**
+
+In `CoinstashSyncSourceTests.swift`, the source is constructed with a `client:` and `engine:`. Update the construction so the engine is built with the new `init(resolver:discovery:)` and assert an OP deposit resolves to `10:0x4200…0042`. Mirror Task 8's `engine(...)` helper (a `CryptoTokenDiscoveryService` with `CountingRegistrationResolver` + `CountingAlchemyClient`, an `ExchangeInstrumentResolver` with `existingLegInstrumentIds: { [] }`). The Coinstash transport stub must answer **both** the transactions query and the `getCoinBySymbol` query — branch on whether the request body contains `"getCoinBySymbol"`:
+
+```swift
+let transport: CoinstashClient.Transport = { request in
+  let body = String(data: request.httpBody ?? Data(), encoding: .utf8) ?? ""
+  let json: String
+  if body.contains("getCoinBySymbol") {
+    json = """
+      {"data":{"getCoinBySymbol":{"symbol":"OP","name":"Optimism",
+      "defiAddresses":[{"chain":"OPTIMISM",
+      "address":"0x4200000000000000000000000000000000000042","decimals":18}]}}}
+      """
+  } else if body.contains("userProfile") {
+    json = #"{"data":{"userProfile":{"userId":"u1"}}}"#
+  } else if body.contains("getUserAccounts") {
+    json = #"{"data":{"getUserAccounts":{"accounts":[{"accountId":"a1","accountType":"TRADING"}]}}}"#
+  } else {
+    json = """
+      {"data":{"accountTransactions":{"isSuccessful":true,"errorMessage":null,
+      "totalRecordsFound":1,"result":[{"transactionId":"t1",
+      "transactedOn":"2025-11-01T00:00:00.000Z","category":"DEPOSIT","type":"CREDIT",
+      "symbol":"OP","amount":40167,"amountType":"ASSET","quoteBuyPrice":null,
+      "quoteSellPrice":null,"orderId":null,"orderType":null,
+      "transactionStatus":"COMPLETED"}]}}}
+      """
+  }
+  return (Data(json.utf8),
+    HTTPURLResponse(url: CoinstashGraphQL.endpoint, statusCode: 200,
+      httpVersion: nil, headerFields: nil)!)
+}
+```
+
+Assert the produced candidate's leg instrument id is `10:0x4200000000000000000000000000000000000042`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `just test-mac CoinstashSyncSourceTests 2>&1 | tee .agent-tmp/test-output.txt; grep -i 'failed\|error:' .agent-tmp/test-output.txt`
+Expected: FAIL — compile error on `engine.build` arity / `CoinstashSyncSource` not passing metadata.
+
+- [ ] **Step 3: Wire the source and production assembly**
+
+In `CoinstashSyncSource.swift`, the stored `client` is `any ExchangeClient`. Add a stored `coinstashClient: CoinstashClient` is **not** ideal (keeps neutrality). Instead, change `CoinstashSyncSource` to hold a `metadataResolverFactory: @Sendable (_ token: String) -> any ExchangeAssetMetadataResolving` injected at construction, and in `build(account:)` after the token is read:
+
+```swift
+let imported = try await client.fetchTransactions(token: token)
+let metadata = metadataResolverFactory(token)
+return try await engine.build(account: account, imported: imported, metadata: metadata)
+```
+
+Update `CoinstashSyncSource.init` to accept `metadataResolverFactory`. In `ProfileSession+CryptoSync.makeCryptoSyncWiring`, build a single `CoinstashClient()` and reuse it for both transports:
+
+```swift
+let coinstashClient = CoinstashClient()
+let coinstashSource = CoinstashSyncSource(
+  tokenStore: ExchangeTokenStore(synchronizable: true),
+  client: coinstashClient,
+  engine: ExchangeSyncEngine(
+    resolver: ExchangeInstrumentResolver(
+      registry: registry,
+      fiatInstrument: profileInstrument,
+      existingLegInstrumentIds: { [backend] in
+        (try? await backend.transactions.distinctLegInstrumentIds()) ?? []
+      }),
+    discovery: discovery),
+  metadataResolverFactory: { token in
+    CoinstashAssetMetadataResolver(client: coinstashClient, token: token)
+  })
+```
+
+`discovery` is the `CryptoTokenDiscoveryService` already created earlier in `makeCryptoSyncWiring` (line ~78) and reused by wallet sync — pass that same instance (do **not** construct a second one). `backend.transactions` is the `TransactionRepository` (confirm the accessor name on `BackendProvider`; it is used elsewhere in this file as `backend.transactions`).
+
+- [ ] **Step 4: Run tests + full build**
+
+Run:
+```bash
+just build-mac 2>&1 | tee .agent-tmp/build.txt; grep -i 'error:' .agent-tmp/build.txt
+just test-mac CoinstashSyncSourceTests ExchangeSyncEngineResolutionTests ExchangeInstrumentResolverTests CoinstashCoinMetadataTests 2>&1 | tee .agent-tmp/test-output.txt; grep -i 'failed\|error:' .agent-tmp/test-output.txt
+```
+Expected: clean build, all PASS.
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+just format && just format-check
+git add Shared/Exchange/CoinstashSyncSource.swift App/ProfileSession+CryptoSync.swift MoolahTests/Shared/Exchange/CoinstashSyncSourceTests.swift
+git commit -m "$(cat <<'EOF'
+feat: wire Coinstash token metadata resolution into sync
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 10: Regression sweep, reviews, full suite
+
+**Files:** none new — verification only.
+
+- [ ] **Step 1: Full exchange + crypto-import test sweep**
+
+Run:
+```bash
+just test-mac ExchangeSyncEngineTests CoinstashClientTests SyncedAccountStoreExchangeTests CryptoTokenDiscoveryServiceTests CryptoTokenDiscoveryCoalescerTests 2>&1 | tee .agent-tmp/test-output.txt
+grep -i 'failed\|error:' .agent-tmp/test-output.txt
+```
+Expected: all PASS. `ExchangeSyncEngineTests` (the pre-existing suite) likely constructs the engine with the old `init(resolver:)` / calls `build(account:imported:)` — update those call sites to the new `init(resolver:discovery:)` + `build(account:imported:metadata:)` using a stub metadata resolver that returns metadata for the symbols those tests use (or `nil` + a seeded registry where they assert fallback). Keep each existing test's intent; only adapt construction.
+
+- [ ] **Step 2: Compiler-warning check**
+
+Run `just build-mac` and confirm zero warnings in changed files (the project treats warnings as errors; a clean build is sufficient evidence).
+
+- [ ] **Step 3: Code reviews**
+
+Invoke `@code-review` and `@concurrency-review` on the changed Swift files (new actor-touching paths: `ExchangeSyncEngine` → `CryptoTokenDiscoveryService` actor; the injected `@Sendable` closure capturing `backend`). Address Critical/Important findings; re-run the relevant suite after any fix.
+
+- [ ] **Step 4: Whole-suite gate + cleanup**
+
+Run:
+```bash
+just test 2>&1 | tee .agent-tmp/test-output.txt
+grep -i 'failed\|error:' .agent-tmp/test-output.txt
+rm -f .agent-tmp/test-output.txt .agent-tmp/build.txt
+```
+Expected: full iOS + macOS suite green.
+
+- [ ] **Step 5: Final commit (if reviews produced fixes)**
+
+```bash
+just format && just format-check
+git add -A
+git commit -m "$(cat <<'EOF'
+chore: address review findings for Coinstash instrument resolution
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Manual remediation (operational, after merge — not a code task)
+
+The large test profile already has Coinstash rows resolved to the wrong OP instrument. Per the design, remediate via the `automate-app` skill: delete the Coinstash account's transactions, then trigger a resync so they re-import through the corrected resolver. Not part of this plan's automated steps.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Stage 0 explicit BTC → Task 8 (`nonEvmNatives`, no metadata call) ✓
+- `getCoinBySymbol` fetch + decode → Tasks 3–5 ✓
+- Canonical Ethereum-preferred order → Task 8 `chainPreference`/`canonical` ✓
+- Native sentinel → Task 4 collapse + Task 8 `contractAddress == nil` ✓
+- Discovery path, supported vs non-ChainConfig chains → Task 1 generalisation + Task 8 call ✓
+- Registry fallback (spam/priced/used/id) → Task 7; "used" data → Task 6 ✓
+- Transient throws vs definitive fallback → Task 4 (throw on provider error / `nil` on unknown), Task 8 (errors propagate) ✓
+- Fiat unchanged → Task 8 `isFiat` branch + Task 7 `fiatInstrument` ✓
+- Wiring → Task 9 ✓
+- End-to-end → Task 9 Step 1 + Task 10 ✓
+- Out of scope (transfer detection) → not in plan ✓ (correct)
+
+**Placeholder scan:** Task 4 Step 3 contains an explicitly-labelled placeholder extension comment with an instruction to delete it — acceptable (it is guidance, not shipped code). All other steps contain complete code. No "TBD"/"handle edge cases"/"similar to" left.
+
+**Type consistency:** `ExchangeAssetChain`/`ExchangeAssetMetadata`/`ExchangeAssetMetadataResolving` (Task 2) used identically in Tasks 4/5/8. `coinMetadata(symbol:token:)` (Task 4) called by Task 5. `resolveOrLoad(chainId:contractAddress:symbol:name:decimals:)` (Task 1) called by Task 8. `fallbackInstrument(forSymbol:)` / `fiatInstrument` / `registeredInstrument(id:)` (Task 7) called by Task 8. `distinctLegInstrumentIds()` (Task 6) used by Task 9's closure. `build(account:imported:metadata:)` (Task 8) called by Task 9. Consistent.
+
+**Known soft spots for the implementer to confirm against the live codebase (do not assume):** the exact `BackendProvider` accessor for the transaction repository (`backend.transactions`); the existing exchange-account test factory name (`ExchangeCreationHarness`); the existing Alchemy counting stub's name/counter in `CryptoTokenDiscoveryTestDoubles.swift`; the GRDB transaction-repo test suite's setup helper. Each task step says to mirror the existing pattern rather than invent.


### PR DESCRIPTION
## Summary

Fixes Coinstash exchange-import instrument resolution. Previously every crypto leg went through a symbol-only registry first-match scan, so `OP` could resolve to a spam token instead of the real Optimism OP (`10:0x4200…0042`) — and every imported Coinstash crypto leg was mis-resolved/spam-flagged.

Now resolution is driven by Coinstash's authoritative `getCoinBySymbol` token metadata:

- **New GraphQL path:** `getCoinBySymbol` query + decode models; `CoinstashClient.coinMetadata` maps Coinstash's `Chain` enum → EVM chain ids, collapses the native-asset sentinel to a native instrument, drops non-EVM/unknown chains, preserves listing order.
- **Pipeline** (`ExchangeSyncEngine`): fiat → explicit BTC native (`0:native`, no metadata call — it's a built-in preset) → `getCoinBySymbol` metadata → canonical EVM chain (Ethereum-preferred, then a fixed order) → register/resolve via the existing `CryptoTokenDiscoveryService` → non-spam/priced/used/id registry fallback only on a definitive "no usable EVM contract" answer. Transient errors throw so the sync retries; fiat path unchanged.
- **Discovery generalised:** `CryptoTokenDiscoveryService.resolveOrLoad` gains a `chainId:` overload that skips the Alchemy spam step for EVM chains with no `ChainConfig` (still priced via CoinGecko-by-contract).
- Per-build-run metadata cache (one `getCoinBySymbol` call per symbol per sync).
- `TransactionRepository.distinctLegInstrumentIds()` added for the fallback "already used" tie-break.

Fuzzy cross-account transfer detection was out of scope and split to #928 (e.g. Coinstash↔bank, Coinstash↔on-chain pairs that don't share an externalId).

Design: `plans/2026-05-17-coinstash-instrument-resolution-design.md` · Plan: `plans/2026-05-17-coinstash-instrument-resolution-plan.md`. Built via investigation of the live Coinstash GraphQL API.

## Test Plan

- [x] Full suite green: macOS 2974 / iOS 2945, 0 failures
- [x] `just build-mac` warning-free; `just format-check` clean; `.swiftlint-baseline.yml` untouched
- [x] Unit: OP→`10:0x4200…0042` (not spam); multi-chain→Ethereum canonical; ETH sentinel→`1:native`; BTC→`0:native` (no metadata call); SOL/no-EVM→registry fallback; transient metadata error throws; fiat skips metadata; metadata cache dedupes; `AVALANCE` spelling
- [x] End-to-end through `TestBackend`: OP crypto deposit persists to the correct instrument id, not spam-flagged
- [x] Remediation (operational, post-merge): reset the Coinstash account's transactions and resync so existing wrong-OP rows re-import correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)