### PR TITLE
fix(sync): collapse synced-account header onto a single status line

### DIFF
--- a/Features/Sync/SyncableAccountPresentation.swift
+++ b/Features/Sync/SyncableAccountPresentation.swift
@@ -7,11 +7,11 @@ import Foundation
 /// from `Account`.
 struct SyncableAccountPresentation: Sendable {
   let identifier: String
-  /// Secondary line (crypto: chain name, e.g. "Ethereum" — preserves the
-  /// context the removed `Text(chain.displayName)` row gave; exchange: nil).
+  /// Leading label of the header's status row (crypto: chain name,
+  /// e.g. "Ethereum"; exchange: nil — the provider name is used as the
+  /// `identifier` instead). The crypto address is shown untruncated on
+  /// its own line, never here.
   let secondaryIdentifier: String?
-  /// Crypto addresses are copyable (security-critical); a provider name is not.
-  let isSelectableIdentifier: Bool
   let externalURL: URL?
   /// `nil` when there is no external action (no empty-string sentinel).
   let externalActionTitle: String?
@@ -31,7 +31,6 @@ struct SyncableAccountPresentation: Sendable {
       secondaryIdentifier =
         account.chainId
         .flatMap(ChainConfig.config(for:))?.displayName
-      isSelectableIdentifier = true
       externalActionTitle = "Open in block explorer"
       if let chainId = account.chainId, !addr.isEmpty {
         // Reuse the existing helper (handles isDirectory:false / trailing
@@ -49,7 +48,6 @@ struct SyncableAccountPresentation: Sendable {
         ? nil : "Add an Alchemy key in Crypto preferences to enable sync."
     case .exchange:
       secondaryIdentifier = nil
-      isSelectableIdentifier = false
       if let provider = account.exchangeProvider {
         identifier = provider.displayName
         externalActionTitle = "Open \(provider.displayName)"
@@ -66,7 +64,6 @@ struct SyncableAccountPresentation: Sendable {
     case .bank, .creditCard, .asset, .investment:
       identifier = ""
       secondaryIdentifier = nil
-      isSelectableIdentifier = false
       externalActionTitle = nil
       externalURL = nil
       missingCredentialHint = nil

--- a/Features/Sync/SyncedAccountHeaderView.swift
+++ b/Features/Sync/SyncedAccountHeaderView.swift
@@ -18,13 +18,13 @@ import SwiftUI
 ///   that section — a truncated `0x1234…abcd` is unsafe to verify
 ///   against because an attacker can mine a vanity address with
 ///   matching prefix and suffix.
-/// - A presentation identifier row: a truncated copyable address +
-///   chain name for crypto, or the (non-copyable) provider name for
-///   exchange, plus an inline "open externally" link (block explorer /
-///   provider website).
-/// - Last-synced relative timestamp ("Synced 2h ago") or "Never synced"
-///   when the account has no checkpoint yet.
-/// - "Sync now" button that calls `syncStore.syncAccount(account)` and
+/// - A single status row: a context label (chain name for crypto — the
+///   untruncated address already appears above, so no truncated copy is
+///   shown here; provider name for exchange) and an inline "open
+///   externally" link (block explorer / provider website) on the
+///   leading edge, with the last-synced relative timestamp ("Synced 2h
+///   ago" / "Never synced") and the "Sync now" button trailing on the
+///   *same* line. The button calls `syncStore.syncAccount(account)` and
 ///   is disabled while a sync is in flight or the account's credential
 ///   is missing.
 ///
@@ -83,6 +83,9 @@ struct SyncedAccountHeaderView: View {
   }
 
   private var lastSyncedText: String {
+    // TODO(#933): inline Date() makes the relative time stale between
+    // renders and unpinnable in view tests — drive `now` from a clock /
+    // timeline. https://github.com/ajsutton/moolah-native/issues/933
     SyncedAccountHeaderLogic.lastSyncedText(state: syncState, now: Date())
   }
 
@@ -105,16 +108,7 @@ struct SyncedAccountHeaderView: View {
       if account.type == .crypto {
         addressSection
       }
-      identifierRow(presentation)
-      HStack(spacing: 12) {
-        Spacer(minLength: 12)
-        Text(lastSyncedText)
-          .font(.subheadline)
-          .foregroundStyle(.secondary)
-          .monospacedDigit()
-          .accessibilityIdentifier(UITestIdentifiers.WalletAccountHeader.lastSynced)
-        syncButton(presentation)
-      }
+      statusRow(presentation)
       // Status bar below the header showing whichever of (a) the per-
       // account sync error and (b) the missing-credential hint applies.
       // The hint takes precedence: if no credential is configured the
@@ -139,55 +133,43 @@ struct SyncedAccountHeaderView: View {
     }
   }
 
-  /// Identifier + secondary line + "open externally" link. The whole
-  /// row is suppressed for non-syncable account types (presentation
-  /// identifier is `""` there) so an empty `Text` doesn't occupy layout.
-  @ViewBuilder
-  private func identifierRow(_ presentation: SyncableAccountPresentation) -> some View {
-    if !presentation.identifier.isEmpty {
-      HStack {
-        // Identifier + chain name form one VoiceOver stop. Only this
-        // text subgroup is combined so the external Link below stays a
-        // separate focusable action, and `.textSelection` on the crypto
-        // address remains reachable to VoiceOver.
-        HStack(spacing: 4) {
-          identifierText(presentation)
-          if let secondary = presentation.secondaryIdentifier {
-            Text(secondary)
-              .font(.caption)
-              .foregroundStyle(.secondary)
-              .accessibilityIdentifier(UITestIdentifiers.WalletAccountHeader.chainName)
-          }
-        }
-        .accessibilityElement(children: .combine)
-        if let url = presentation.externalURL,
-          let title = presentation.externalActionTitle
-        {
-          Link(title, destination: url)
-            .font(.caption)
-        }
+  /// Single-line status row. Leading edge: a context label + the
+  /// inline "open externally" link. Trailing edge: the last-synced
+  /// timestamp and the "Sync now" button — all on one line, so the
+  /// header is a single row for exchange and exactly two for crypto
+  /// (the extra row being only the untruncated address).
+  ///
+  /// For crypto the label is the chain name: the untruncated wallet
+  /// address is shown on its own line by `addressSection`, so repeating
+  /// a *truncated* copy here would be both redundant and (truncated)
+  /// unsafe to verify against. For exchange there is no address line,
+  /// so the label is the provider name. `secondaryIdentifier ??
+  /// identifier` resolves to the chain for crypto and the provider for
+  /// exchange (and degrades to the truncated address only if a crypto
+  /// account has no recognised chain) without the view branching on
+  /// `account.type` — that branching stays in
+  /// `SyncableAccountPresentation`.
+  private func statusRow(_ presentation: SyncableAccountPresentation) -> some View {
+    HStack(spacing: 12) {
+      // The label is its own VoiceOver stop; the external Link stays a
+      // separate focusable action rather than being folded into it.
+      Text(presentation.secondaryIdentifier ?? presentation.identifier)
+        .font(.caption)
+        .foregroundStyle(.secondary)
+        .accessibilityIdentifier(UITestIdentifiers.WalletAccountHeader.chainName)
+      if let url = presentation.externalURL,
+        let title = presentation.externalActionTitle
+      {
+        Link(title, destination: url)
+          .font(.caption)
       }
-    }
-  }
-
-  /// The identifier label. Crypto addresses are copyable
-  /// (security-critical — the user must be able to verify them); a
-  /// provider name is not. `TextSelectability`'s `.enabled` / `.disabled`
-  /// are distinct types, so the two cases are separate `Text` views in a
-  /// `@ViewBuilder` (not a ternary on a single `.textSelection`, which
-  /// does not type-check).
-  @ViewBuilder
-  private func identifierText(_ presentation: SyncableAccountPresentation) -> some View {
-    if presentation.isSelectableIdentifier {
-      Text(presentation.identifier)
-        .font(.caption)
+      Spacer(minLength: 12)
+      Text(lastSyncedText)
+        .font(.subheadline)
         .foregroundStyle(.secondary)
-        .textSelection(.enabled)
-    } else {
-      Text(presentation.identifier)
-        .font(.caption)
-        .foregroundStyle(.secondary)
-        .textSelection(.disabled)
+        .monospacedDigit()
+        .accessibilityIdentifier(UITestIdentifiers.WalletAccountHeader.lastSynced)
+      syncButton(presentation)
     }
   }
 
@@ -235,6 +217,10 @@ struct SyncedAccountHeaderView: View {
     Text(caption)
       .font(.caption)
       .foregroundStyle(.red)
+      // Sighted users get the error affordance from the red colour;
+      // give VoiceOver the same signal since the message text itself
+      // carries no "error" marker.
+      .accessibilityLabel("Error: \(caption)")
       .accessibilityIdentifier(UITestIdentifiers.WalletAccountHeader.errorCaption)
   }
 
@@ -276,12 +262,13 @@ struct SyncedAccountHeaderView: View {
         inProgress: syncStore.inProgressAccountIds,
         hasCredential: presentation.hasCredential)
     )
+    .buttonStyle(.borderless)
     .help(
       presentation.hasCredential
         ? "Sync account now"
         : (presentation.missingCredentialHint ?? "Configure this account to enable sync")
     )
-    .accessibilityLabel("Sync account now")
+    .accessibilityLabel(isSyncing ? "Syncing in progress" : "Sync account now")
     .accessibilityIdentifier(UITestIdentifiers.WalletAccountHeader.syncButton)
   }
 }
@@ -314,10 +301,67 @@ extension SyncedAccountHeaderView {
 
 // MARK: - Previews
 //
-// `SyncedAccountHeaderView` has no standalone `#Preview`: it requires a
-// non-optional `SyncedAccountStore`, which `ProfileSession.preview()`
-// leaves `nil` (its crypto wiring is intentionally absent in previews —
-// see the `CryptoWalletAccountView` preview comment). The header is
-// exercised in canvas through its parents instead — the crypto path via
-// `CryptoWalletAccountView`'s `#Preview` and the exchange path via
-// `ExchangeAccountView`'s `#Preview`.
+// The parent `CryptoWalletAccountView` / `ExchangeAccountView` previews
+// render this header as `EmptyView` (their `ProfileSession.preview()`
+// leaves crypto wiring `nil`), so this standalone `#Preview` is the only
+// canvas path that exercises the layout. The header reads only
+// `SyncedAccountStore`'s observable `statePerAccount` /
+// `inProgressAccountIds`, so a minimal store over the in-memory preview
+// backend (no sync sources) covers the full layout. No checkpoint is
+// seeded, so both rows read "Never synced" — sufficient to verify the
+// single-line layout (the timestamp string does not affect the row's
+// line count). `hasCredential` resolves `false` in canvas (no
+// keychain), so each variant also shows its missing-credential hint
+// *below* the status row; that is a real state and does not change
+// whether the status row itself is a single line.
+
+#Preview("Synced account header") {
+  syncedAccountHeaderPreview()
+}
+
+// Builds the standalone-preview content. Extracted from the `#Preview`
+// closure so the (unavoidably verbose) store wiring is governed by
+// `function_body_length` rather than the stricter `closure_body_length`.
+@MainActor
+private func syncedAccountHeaderPreview() -> some View {
+  // `ProfileSession.preview()` throws only if the in-memory SwiftData
+  // container can't be created — a programmer error; crashing is correct.
+  // swiftlint:disable:next force_try
+  let session = try! ProfileSession.preview()
+  let store = SyncedAccountStore(
+    sources: [],
+    walletApplyEngine: WalletApplyEngine(
+      transactions: session.backend.transactions,
+      walletSyncState: session.backend.walletSyncState,
+      importRules: NoOpWalletImportRulesEngine()),
+    walletSyncState: session.backend.walletSyncState,
+    accounts: session.backend.accounts)
+  let exchangeTokenStore = ExchangeTokenStore()
+  let cryptoAccount = Account(
+    name: "Preview Wallet",
+    type: .crypto,
+    instrument: .AUD,
+    valuationMode: .calculatedFromTrades,
+    walletAddress: "0xa4b572ea1b6f734fc88a0a004c5301f8dad54d60",
+    chainId: 10)
+  let exchangeAccount = Account(
+    name: "Coinstash",
+    type: .exchange,
+    instrument: .AUD,
+    valuationMode: .calculatedFromTrades,
+    exchangeProvider: .coinstash)
+  return VStack(spacing: 24) {
+    SyncedAccountHeaderView(
+      account: cryptoAccount,
+      syncStore: store,
+      cryptoTokenStore: nil,
+      exchangeTokenStore: exchangeTokenStore)
+    SyncedAccountHeaderView(
+      account: exchangeAccount,
+      syncStore: store,
+      cryptoTokenStore: nil,
+      exchangeTokenStore: exchangeTokenStore)
+  }
+  .frame(width: 720)
+  .padding()
+}

--- a/MoolahTests/Features/Sync/SyncableAccountPresentationTests.swift
+++ b/MoolahTests/Features/Sync/SyncableAccountPresentationTests.swift
@@ -13,7 +13,7 @@ struct SyncableAccountPresentationTests {
     chainId: 1, contractAddress: nil, symbol: "ETH", name: "Ethereum", decimals: 18)
 
   @Test
-  func cryptoShowsTruncatedSelectableAddressAndExplorer() {
+  func cryptoShowsTruncatedAddressAndExplorer() {
     let addr = "0x" + String(repeating: "a", count: 40)
     let account = Account(
       name: "W", type: .crypto, instrument: eth,
@@ -21,7 +21,6 @@ struct SyncableAccountPresentationTests {
     let presentation = SyncableAccountPresentation(account: account, hasCredential: true)
     #expect(presentation.identifier.hasPrefix("0xaa"))
     #expect(presentation.identifier.contains("…"))
-    #expect(presentation.isSelectableIdentifier)
     #expect(presentation.externalActionTitle == "Open in block explorer")
     #expect(presentation.externalURL?.absoluteString.contains(addr) == true)
     #expect(presentation.missingCredentialHint == nil)
@@ -29,13 +28,12 @@ struct SyncableAccountPresentationTests {
   }
 
   @Test
-  func exchangeShowsProviderWebsiteAndNonSelectableID() {
+  func exchangeShowsProviderWebsiteAndIdentifier() {
     let account = Account(
       name: "C", type: .exchange, instrument: .AUD,
       exchangeProvider: .coinstash)
     let presentation = SyncableAccountPresentation(account: account, hasCredential: false)
     #expect(presentation.identifier == "Coinstash")
-    #expect(!presentation.isSelectableIdentifier)
     #expect(presentation.externalActionTitle == "Open Coinstash")
     #expect(presentation.externalURL?.host?.contains("coinstash") == true)
     #expect(presentation.secondaryIdentifier == nil)


### PR DESCRIPTION
## Problem

The synced-account header (shown above the transaction list for crypto/exchange accounts) wrapped the sync source + external link onto a separate line from the last-synced timestamp + **Sync now** button — a two/three-deep `VStack` where the original `WalletAccountHeaderView` design (commit `a23fd779`) was a single `HStack`. The generalisation refactor (`b93501b4`) regressed it. Exchange accounts wasted a whole row on `Coinstash  Open Coinstash`; crypto additionally showed a redundant truncated address.

Reported with screenshots for both the exchange and crypto cases.

## Fix

Merge the identifier row and the sync-status row into one `statusRow(_:)`: leading label (chain name for crypto, provider name for exchange) + external link, `Spacer`, last-synced, **Sync now**. The untruncated wallet address keeps its **own line** for crypto (deliberate anti vanity-address-spoofing safeguard — confirmed with the reporter). Result: **exchange = one line, crypto = two lines (full address + status), never three.**

- Removed the now-dead `identifierRow` / `identifierText` helpers and the orphaned `SyncableAccountPresentation.isSelectableIdentifier` field (+ its test assertions).
- Added a standalone `#Preview`. The parent `CryptoWalletAccountView` / `ExchangeAccountView` previews render this header as `EmptyView` (`ProfileSession.preview()` leaves crypto wiring `nil`) — that canvas blind-spot is why the regression shipped uncaught.
- Accessibility (from `ui-review`): VoiceOver `Error: …` label on the sync-error caption, explicit `.borderless` sync button, syncing-state accessibility label.
- Comment/lint hygiene (from `code-review`): present-tense doc framing, `swiftlint:disable` now carries a reason.

## Verification

- `just build-mac` ✅, `just format-check` ✅, `just validate-todos` ✅
- `SyncableAccountPresentationTests` ✅ (4/4)
- Layout visually confirmed via `RenderPreview` (single line for exchange; full-address line + single status line for crypto).

## Follow-ups (pre-existing, found in review — not in scope here)

- #932 — no Dynamic Type clamp; address line & status row clip at accessibility sizes
- #933 — `lastSyncedText` calls `Date()` in a computed property (stale/untestable); `TODO(#933)` added at the site

🤖 Generated with [Claude Code](https://claude.com/claude-code)