### PR TITLE
feat: reusable HTTP timeout + retry; fix Blockscout sync timeout

### DIFF
--- a/MoolahTests/Shared/BlockExplorerClientRetryTests.swift
+++ b/MoolahTests/Shared/BlockExplorerClientRetryTests.swift
@@ -1,0 +1,132 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+/// One scripted transport outcome for `BlockscoutRetryStubURLProtocol`.
+enum BlockscoutRetryStep: Sendable {
+  case fail(URLError.Code)
+  case respond(status: Int, body: Data, headers: [String: String])
+}
+
+/// Thread-safe FIFO of scripted transport outcomes, recording call count.
+final class BlockscoutRetryScript: @unchecked Sendable {
+  private let lock = NSLock()
+  private var steps: [BlockscoutRetryStep]
+  private(set) var calls = 0
+
+  init(_ steps: [BlockscoutRetryStep]) { self.steps = steps }
+
+  func next() -> BlockscoutRetryStep {
+    lock.lock()
+    defer { lock.unlock() }
+    calls += 1
+    precondition(
+      !steps.isEmpty, "StubURLProtocol called more times than scripted")
+    return steps.removeFirst()
+  }
+}
+
+/// `URLProtocol` stub driven by a `BlockscoutRetryScript`. Each request pops
+/// the next scripted step: a transport failure or a synthetic HTTP response.
+class BlockscoutRetryStubURLProtocol: URLProtocol {
+  nonisolated(unsafe) static var script: BlockscoutRetryScript?
+
+  override class func canInit(with request: URLRequest) -> Bool { true }
+
+  override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    request
+  }
+
+  override func startLoading() {
+    guard let script = Self.script, let url = request.url else {
+      client?.urlProtocol(self, didFailWithError: URLError(.unknown))
+      return
+    }
+    switch script.next() {
+    case .fail(let code):
+      client?.urlProtocol(self, didFailWithError: URLError(code))
+    case let .respond(status, body, headers):
+      guard
+        let response = HTTPURLResponse(
+          url: url, statusCode: status,
+          httpVersion: "HTTP/1.1", headerFields: headers)
+      else {
+        client?.urlProtocol(self, didFailWithError: URLError(.unknown))
+        return
+      }
+      client?.urlProtocol(
+        self, didReceive: response, cacheStoragePolicy: .notAllowed)
+      client?.urlProtocol(self, didLoad: body)
+      client?.urlProtocolDidFinishLoading(self)
+    }
+  }
+
+  override func stopLoading() {}
+}
+
+@Suite("LiveBlockscoutClient retry")
+struct BlockExplorerClientRetryTests {
+  private func makeSession() -> URLSession {
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [BlockscoutRetryStubURLProtocol.self]
+    return URLSession(configuration: config)
+  }
+
+  private static let emptyPage = Data(
+    #"{"items":[],"next_page_params":null}"#.utf8)
+
+  @Test
+  func transientTimeoutIsRetriedThenSucceeds() async throws {
+    let script = BlockscoutRetryScript([
+      .fail(.timedOut),
+      .respond(status: 200, body: Self.emptyPage, headers: [:]),
+    ])
+    BlockscoutRetryStubURLProtocol.script = script
+    let client = LiveBlockscoutClient(
+      session: makeSession(),
+      rateLimiter: RateLimiter(permitsPerSecond: 1000),
+      retryPolicy: HTTPRetryPolicy(),
+      sleeper: { _ in })
+    let txs = try await client.nativeTransactions(
+      chain: .ethereum, walletAddress: "0xabc", fromBlock: 0)
+    #expect(txs.isEmpty)
+    #expect(script.calls == 2)
+  }
+
+  @Test
+  func longRetryAfterFailsCleanly() async throws {
+    let script = BlockscoutRetryScript([
+      .respond(status: 429, body: Data(), headers: ["Retry-After": "999"])
+    ])
+    BlockscoutRetryStubURLProtocol.script = script
+    let client = LiveBlockscoutClient(
+      session: makeSession(),
+      rateLimiter: RateLimiter(permitsPerSecond: 1000),
+      retryPolicy: HTTPRetryPolicy(honorsRetryAfterInPlace: true),
+      sleeper: { _ in })
+    await #expect(throws: WalletSyncError.self) {
+      _ = try await client.nativeTransactions(
+        chain: .ethereum, walletAddress: "0xabc", fromBlock: 0)
+    }
+    #expect(script.calls == 1)
+  }
+
+  @Test
+  func shortRetryAfterIsWaitedOutThenSucceeds() async throws {
+    let script = BlockscoutRetryScript([
+      .respond(status: 429, body: Data(), headers: ["Retry-After": "5"]),
+      .respond(status: 200, body: Self.emptyPage, headers: [:]),
+    ])
+    BlockscoutRetryStubURLProtocol.script = script
+    let client = LiveBlockscoutClient(
+      session: makeSession(),
+      rateLimiter: RateLimiter(permitsPerSecond: 1000),
+      retryPolicy: HTTPRetryPolicy(honorsRetryAfterInPlace: true),
+      sleeper: { _ in })
+    let txs = try await client.nativeTransactions(
+      chain: .ethereum, walletAddress: "0xabc", fromBlock: 0)
+    #expect(txs.isEmpty)
+    #expect(script.calls == 2)
+  }
+}

--- a/MoolahTests/Shared/BlockExplorerClientRetryTests.swift
+++ b/MoolahTests/Shared/BlockExplorerClientRetryTests.swift
@@ -188,7 +188,7 @@ struct BlockExplorerClientRetryTests {
         chain: .ethereum, walletAddress: "0xabc", fromBlock: 0)
       Issue.record("expected a thrown error")
     } catch let error as WalletSyncError {
-      guard case .rateLimited = error else {
+      guard case .rateLimited = error.kind else {
         Issue.record("expected .rateLimited, got \(error)")
         return
       }
@@ -216,7 +216,7 @@ struct BlockExplorerClientRetryTests {
       Issue.record("expected a thrown error")
     } catch let error as WalletSyncError {
       guard
-        case .network(let description) = error,
+        case .network(let description) = error.kind,
         description == "retry exhausted (server error)"
       else {
         Issue.record(

--- a/MoolahTests/Shared/BlockExplorerClientRetryTests.swift
+++ b/MoolahTests/Shared/BlockExplorerClientRetryTests.swift
@@ -65,7 +65,7 @@ class BlockscoutRetryStubURLProtocol: URLProtocol {
   override func stopLoading() {}
 }
 
-@Suite("LiveBlockscoutClient retry")
+@Suite("LiveBlockscoutClient retry", .serialized)
 struct BlockExplorerClientRetryTests {
   private func makeSession() -> URLSession {
     let config = URLSessionConfiguration.ephemeral
@@ -78,6 +78,7 @@ struct BlockExplorerClientRetryTests {
 
   @Test
   func transientTimeoutIsRetriedThenSucceeds() async throws {
+    defer { BlockscoutRetryStubURLProtocol.script = nil }
     let script = BlockscoutRetryScript([
       .fail(.timedOut),
       .respond(status: 200, body: Self.emptyPage, headers: [:]),
@@ -96,6 +97,7 @@ struct BlockExplorerClientRetryTests {
 
   @Test
   func longRetryAfterFailsCleanly() async throws {
+    defer { BlockscoutRetryStubURLProtocol.script = nil }
     let script = BlockscoutRetryScript([
       .respond(status: 429, body: Data(), headers: ["Retry-After": "999"])
     ])
@@ -114,6 +116,7 @@ struct BlockExplorerClientRetryTests {
 
   @Test
   func shortRetryAfterIsWaitedOutThenSucceeds() async throws {
+    defer { BlockscoutRetryStubURLProtocol.script = nil }
     let script = BlockscoutRetryScript([
       .respond(status: 429, body: Data(), headers: ["Retry-After": "5"]),
       .respond(status: 200, body: Self.emptyPage, headers: [:]),
@@ -128,5 +131,68 @@ struct BlockExplorerClientRetryTests {
       chain: .ethereum, walletAddress: "0xabc", fromBlock: 0)
     #expect(txs.isEmpty)
     #expect(script.calls == 2)
+  }
+
+  @Test
+  func transientServerErrorIsRetriedThenSucceeds() async throws {
+    defer { BlockscoutRetryStubURLProtocol.script = nil }
+    let script = BlockscoutRetryScript([
+      .respond(status: 500, body: Data(), headers: [:]),
+      .respond(status: 200, body: Self.emptyPage, headers: [:]),
+    ])
+    BlockscoutRetryStubURLProtocol.script = script
+    let client = LiveBlockscoutClient(
+      session: makeSession(),
+      rateLimiter: RateLimiter(permitsPerSecond: 1000),
+      retryPolicy: HTTPRetryPolicy(),
+      sleeper: { _ in })
+    let txs = try await client.nativeTransactions(
+      chain: .ethereum, walletAddress: "0xabc", fromBlock: 0)
+    #expect(txs.isEmpty)
+    #expect(script.calls == 2)
+  }
+
+  @Test
+  func urlCancellationSurfacesAsCancellationError() async throws {
+    defer { BlockscoutRetryStubURLProtocol.script = nil }
+    let script = BlockscoutRetryScript([.fail(.cancelled)])
+    BlockscoutRetryStubURLProtocol.script = script
+    let client = LiveBlockscoutClient(
+      session: makeSession(),
+      rateLimiter: RateLimiter(permitsPerSecond: 1000),
+      retryPolicy: HTTPRetryPolicy(),
+      sleeper: { _ in })
+    await #expect(throws: CancellationError.self) {
+      _ = try await client.nativeTransactions(
+        chain: .ethereum, walletAddress: "0xabc", fromBlock: 0)
+    }
+    #expect(script.calls == 1)
+  }
+
+  @Test
+  func exhaustedRateLimitMapsToRateLimited() async throws {
+    defer { BlockscoutRetryStubURLProtocol.script = nil }
+    let script = BlockscoutRetryScript([
+      .respond(status: 429, body: Data(), headers: ["Retry-After": "5"]),
+      .respond(status: 429, body: Data(), headers: ["Retry-After": "5"]),
+      .respond(status: 429, body: Data(), headers: ["Retry-After": "5"]),
+    ])
+    BlockscoutRetryStubURLProtocol.script = script
+    let client = LiveBlockscoutClient(
+      session: makeSession(),
+      rateLimiter: RateLimiter(permitsPerSecond: 1000),
+      retryPolicy: HTTPRetryPolicy(honorsRetryAfterInPlace: true),
+      sleeper: { _ in })
+    do {
+      _ = try await client.nativeTransactions(
+        chain: .ethereum, walletAddress: "0xabc", fromBlock: 0)
+      Issue.record("expected a thrown error")
+    } catch let error as WalletSyncError {
+      guard case .rateLimited = error else {
+        Issue.record("expected .rateLimited, got \(error)")
+        return
+      }
+    }
+    #expect(script.calls == 3)
   }
 }

--- a/MoolahTests/Shared/BlockExplorerClientRetryTests.swift
+++ b/MoolahTests/Shared/BlockExplorerClientRetryTests.swift
@@ -195,4 +195,35 @@ struct BlockExplorerClientRetryTests {
     }
     #expect(script.calls == 3)
   }
+
+  @Test
+  func exhaustedServerErrorMapsToNetwork() async throws {
+    defer { BlockscoutRetryStubURLProtocol.script = nil }
+    let script = BlockscoutRetryScript([
+      .respond(status: 500, body: Data(), headers: [:]),
+      .respond(status: 500, body: Data(), headers: [:]),
+      .respond(status: 500, body: Data(), headers: [:]),
+    ])
+    BlockscoutRetryStubURLProtocol.script = script
+    let client = LiveBlockscoutClient(
+      session: makeSession(),
+      rateLimiter: RateLimiter(permitsPerSecond: 1000),
+      retryPolicy: HTTPRetryPolicy(),
+      sleeper: { _ in })
+    do {
+      _ = try await client.nativeTransactions(
+        chain: .ethereum, walletAddress: "0xabc", fromBlock: 0)
+      Issue.record("expected a thrown error")
+    } catch let error as WalletSyncError {
+      guard
+        case .network(let description) = error,
+        description == "retry exhausted (server error)"
+      else {
+        Issue.record(
+          "expected .network(retry exhausted (server error)), got \(error)")
+        return
+      }
+    }
+    #expect(script.calls == 3)
+  }
 }

--- a/MoolahTests/Shared/HTTPRetryClassifierTests.swift
+++ b/MoolahTests/Shared/HTTPRetryClassifierTests.swift
@@ -5,30 +5,47 @@ import Testing
 
 @Suite("HTTPRetryClassifier")
 struct HTTPRetryClassifierTests {
-  @Test
-  func transientTransportErrorsRetryWhenIdempotent() {
-    for code in [
+  @Test(
+    arguments: [
       URLError.timedOut, .networkConnectionLost, .cannotConnectToHost,
       .dnsLookupFailed, .notConnectedToInternet,
-    ] {
-      let decision = HTTPRetryClassifier.decision(
-        for: URLError(code), idempotent: true)
-      #expect(decision == .retryAfterBackoff)
-    }
+    ])
+  func transientTransportErrorRetriesWhenIdempotent(_ code: URLError.Code) {
+    #expect(
+      HTTPRetryClassifier.decision(for: URLError(code), idempotent: true)
+        == .retryAfterBackoff)
   }
 
   @Test
   func transientTransportErrorsDoNotRetryWhenNotIdempotent() {
-    let decision = HTTPRetryClassifier.decision(
-      for: URLError(.timedOut), idempotent: false)
-    #expect(decision == .doNotRetry)
+    for code in [URLError.timedOut, .networkConnectionLost] {
+      let decision = HTTPRetryClassifier.decision(
+        for: URLError(code), idempotent: false)
+      #expect(decision == .doNotRetry)
+    }
   }
 
   @Test
-  func cancellationNeverRetries() {
+  func retrySignalIgnoresIdempotency() {
+    #expect(
+      HTTPRetryClassifier.decision(
+        for: HTTPRetrySignal(retryAfter: nil), idempotent: false)
+        == .retryAfterBackoff)
+    #expect(
+      HTTPRetryClassifier.decision(
+        for: HTTPRetrySignal(retryAfter: 9), idempotent: false)
+        == .retryAfter(9))
+  }
+
+  @Test
+  func swiftCancellationErrorNeverRetries() {
     #expect(
       HTTPRetryClassifier.decision(for: CancellationError(), idempotent: true)
         == .doNotRetry)
+  }
+
+  @Test
+  func urlErrorCancelledNeverRetries() {
     #expect(
       HTTPRetryClassifier.decision(for: URLError(.cancelled), idempotent: true)
         == .doNotRetry)

--- a/MoolahTests/Shared/HTTPRetryClassifierTests.swift
+++ b/MoolahTests/Shared/HTTPRetryClassifierTests.swift
@@ -1,0 +1,67 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("HTTPRetryClassifier")
+struct HTTPRetryClassifierTests {
+  @Test
+  func transientTransportErrorsRetryWhenIdempotent() {
+    for code in [
+      URLError.timedOut, .networkConnectionLost, .cannotConnectToHost,
+      .dnsLookupFailed, .notConnectedToInternet,
+    ] {
+      let decision = HTTPRetryClassifier.decision(
+        for: URLError(code), idempotent: true)
+      #expect(decision == .retryAfterBackoff)
+    }
+  }
+
+  @Test
+  func transientTransportErrorsDoNotRetryWhenNotIdempotent() {
+    let decision = HTTPRetryClassifier.decision(
+      for: URLError(.timedOut), idempotent: false)
+    #expect(decision == .doNotRetry)
+  }
+
+  @Test
+  func cancellationNeverRetries() {
+    #expect(
+      HTTPRetryClassifier.decision(for: CancellationError(), idempotent: true)
+        == .doNotRetry)
+    #expect(
+      HTTPRetryClassifier.decision(for: URLError(.cancelled), idempotent: true)
+        == .doNotRetry)
+  }
+
+  @Test
+  func retrySignalWithoutDelayUsesBackoff() {
+    #expect(
+      HTTPRetryClassifier.decision(
+        for: HTTPRetrySignal(retryAfter: nil), idempotent: true)
+        == .retryAfterBackoff)
+  }
+
+  @Test
+  func retrySignalWithDelayHonorsServerDelay() {
+    #expect(
+      HTTPRetryClassifier.decision(
+        for: HTTPRetrySignal(retryAfter: 12), idempotent: true)
+        == .retryAfter(12))
+  }
+
+  @Test
+  func unknownErrorsDoNotRetry() {
+    struct Other: Error {}
+    #expect(
+      HTTPRetryClassifier.decision(for: Other(), idempotent: true)
+        == .doNotRetry)
+  }
+
+  @Test
+  func nonTransientURLErrorDoesNotRetry() {
+    #expect(
+      HTTPRetryClassifier.decision(
+        for: URLError(.badServerResponse), idempotent: true) == .doNotRetry)
+  }
+}

--- a/MoolahTests/Shared/HTTPRetryPolicyTests.swift
+++ b/MoolahTests/Shared/HTTPRetryPolicyTests.swift
@@ -22,11 +22,13 @@ struct HTTPRetryPolicyTests {
     let blockscout = HTTPRetryPolicy(honorsRetryAfterInPlace: true)
     #expect(blockscout.honorsRetryAfterInPlace == true)
     #expect(blockscout.requestTimeout == 120)
+    #expect(blockscout.maxRateLimitWait == 60)
     #expect(HTTPRetryPolicy().honorsRetryAfterInPlace == false)
   }
 
   @Test
-  func backoffIsExponentialJitteredAndCapped() {
+  func backoffCeilingIsExponentialAndCapped() {
+    // backoffCeiling returns the pre-jitter upper bound; withRetry applies jitter.
     let policy = HTTPRetryPolicy()
     #expect(policy.backoffCeiling(forAttempt: 1) == 0.5)
     #expect(policy.backoffCeiling(forAttempt: 2) == 1.0)

--- a/MoolahTests/Shared/HTTPRetryPolicyTests.swift
+++ b/MoolahTests/Shared/HTTPRetryPolicyTests.swift
@@ -1,0 +1,36 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("HTTPRetryPolicy")
+struct HTTPRetryPolicyTests {
+  @Test
+  func defaultsMatchApprovedDesign() {
+    let policy = HTTPRetryPolicy()
+    #expect(policy.requestTimeout == 120)
+    #expect(policy.maxAttempts == 3)
+    #expect(policy.backoffBase == 0.5)
+    #expect(policy.backoffCap == 5)
+    #expect(policy.totalBudget == 300)
+    #expect(policy.honorsRetryAfterInPlace == false)
+    #expect(policy.maxRateLimitWait == 60)
+  }
+
+  @Test
+  func perClientOverridesAreIndependent() {
+    let blockscout = HTTPRetryPolicy(honorsRetryAfterInPlace: true)
+    #expect(blockscout.honorsRetryAfterInPlace == true)
+    #expect(blockscout.requestTimeout == 120)
+    #expect(HTTPRetryPolicy().honorsRetryAfterInPlace == false)
+  }
+
+  @Test
+  func backoffIsExponentialJitteredAndCapped() {
+    let policy = HTTPRetryPolicy()
+    #expect(policy.backoffCeiling(forAttempt: 1) == 0.5)
+    #expect(policy.backoffCeiling(forAttempt: 2) == 1.0)
+    #expect(policy.backoffCeiling(forAttempt: 3) == 2.0)
+    #expect(policy.backoffCeiling(forAttempt: 10) == 5.0)
+  }
+}

--- a/MoolahTests/Shared/HTTPRetryTests.swift
+++ b/MoolahTests/Shared/HTTPRetryTests.swift
@@ -1,0 +1,164 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("withRetry")
+struct HTTPRetryTests {
+  /// Deterministic clock + sleeper: `sleep` advances the clock instead of
+  /// blocking, and records every requested delay.
+  final class FakeScheduler: @unchecked Sendable {
+    private let lock = NSLock()
+    private var current = Date(timeIntervalSince1970: 1_700_000_000)
+    private(set) var sleeps: [TimeInterval] = []
+
+    func now() -> Date {
+      lock.withLock { current }
+    }
+
+    func sleep(_ seconds: TimeInterval) async throws {
+      try Task.checkCancellation()
+      lock.withLock {
+        sleeps.append(seconds)
+        current = current.addingTimeInterval(seconds)
+      }
+    }
+  }
+
+  @Test
+  func succeedsOnFirstTryWithoutSleeping() async throws {
+    let sched = FakeScheduler()
+    let result = try await withRetry(
+      policy: HTTPRetryPolicy(),
+      isRetryable: { HTTPRetryClassifier.decision(for: $0, idempotent: true) },
+      clock: { sched.now() },
+      sleep: { try await sched.sleep($0) },
+      jitter: { $0 },
+      operation: { 42 })
+    #expect(result == 42)
+    #expect(sched.sleeps.isEmpty)
+  }
+
+  @Test
+  func retriesTransientThenSucceeds() async throws {
+    let sched = FakeScheduler()
+    let attempts = Counter()
+    let result = try await withRetry(
+      policy: HTTPRetryPolicy(),
+      isRetryable: { HTTPRetryClassifier.decision(for: $0, idempotent: true) },
+      clock: { sched.now() },
+      sleep: { try await sched.sleep($0) },
+      jitter: { $0 },
+      operation: {
+        if await attempts.next() < 2 { throw URLError(.timedOut) }
+        return "ok"
+      })
+    #expect(result == "ok")
+    #expect(sched.sleeps == [0.5, 1.0])
+  }
+
+  @Test
+  func exhaustsAndRethrowsLastError() async throws {
+    let sched = FakeScheduler()
+    await #expect(throws: URLError.self) {
+      try await withRetry(
+        policy: HTTPRetryPolicy(),
+        isRetryable: {
+          HTTPRetryClassifier.decision(for: $0, idempotent: true)
+        },
+        clock: { sched.now() },
+        sleep: { try await sched.sleep($0) },
+        jitter: { $0 },
+        operation: { throw URLError(.timedOut) })
+    }
+    #expect(sched.sleeps == [0.5, 1.0])
+  }
+
+  @Test
+  func nonRetryableErrorIsNotRetried() async throws {
+    let sched = FakeScheduler()
+    struct Boom: Error, Equatable {}
+    await #expect(throws: Boom.self) {
+      try await withRetry(
+        policy: HTTPRetryPolicy(),
+        isRetryable: {
+          HTTPRetryClassifier.decision(for: $0, idempotent: true)
+        },
+        clock: { sched.now() },
+        sleep: { try await sched.sleep($0) },
+        jitter: { $0 },
+        operation: { throw Boom() })
+    }
+    #expect(sched.sleeps.isEmpty)
+  }
+
+  @Test
+  func honorsServerRetryAfterDelay() async throws {
+    let sched = FakeScheduler()
+    let attempts = Counter()
+    _ = try await withRetry(
+      policy: HTTPRetryPolicy(honorsRetryAfterInPlace: true),
+      isRetryable: { HTTPRetryClassifier.decision(for: $0, idempotent: true) },
+      clock: { sched.now() },
+      sleep: { try await sched.sleep($0) },
+      jitter: { $0 },
+      operation: { () async throws -> Int in
+        if await attempts.next() < 1 { throw HTTPRetrySignal(retryAfter: 7) }
+        return 1
+      })
+    #expect(sched.sleeps == [7])
+  }
+
+  @Test
+  func stopsWhenTotalBudgetWouldBeExceeded() async throws {
+    let sched = FakeScheduler()
+    var policy = HTTPRetryPolicy()
+    policy.backoffBase = 1000
+    policy.backoffCap = 1000
+    policy.totalBudget = 10
+    await #expect(throws: URLError.self) {
+      try await withRetry(
+        policy: policy,
+        isRetryable: {
+          HTTPRetryClassifier.decision(for: $0, idempotent: true)
+        },
+        clock: { sched.now() },
+        sleep: { try await sched.sleep($0) },
+        jitter: { $0 },
+        operation: { throw URLError(.timedOut) })
+    }
+    #expect(sched.sleeps.isEmpty)
+  }
+
+  @Test
+  func stopsOnCancellationMidBackoff() async throws {
+    let sched = FakeScheduler()
+    let task = Task {
+      try await withRetry(
+        policy: HTTPRetryPolicy(),
+        isRetryable: {
+          HTTPRetryClassifier.decision(for: $0, idempotent: true)
+        },
+        clock: { sched.now() },
+        sleep: { _ in
+          try Task.checkCancellation()
+          throw URLError(.timedOut)
+        },
+        jitter: { $0 },
+        operation: { throw URLError(.timedOut) })
+    }
+    task.cancel()
+    await #expect(throws: (any Error).self) { try await task.value }
+  }
+
+  /// Minimal async counter so the closures stay `Sendable`.
+  actor Counter {
+
+    private var value = 0
+
+    func next() -> Int {
+      defer { value += 1 }
+      return value
+    }
+  }
+}

--- a/MoolahTests/Shared/HTTPRetryTests.swift
+++ b/MoolahTests/Shared/HTTPRetryTests.swift
@@ -131,34 +131,61 @@ struct HTTPRetryTests {
   }
 
   @Test
-  func stopsOnCancellationMidBackoff() async throws {
-    let sched = FakeScheduler()
+  func cancellationDuringBackoffStopsBeforeNextOperation() async throws {
+    let opCount = Counter()
+    let sleepEntered = Gate()
     let task = Task {
       try await withRetry(
         policy: HTTPRetryPolicy(),
-        isRetryable: {
-          HTTPRetryClassifier.decision(for: $0, idempotent: true)
-        },
-        clock: { sched.now() },
+        isRetryable: { HTTPRetryClassifier.decision(for: $0, idempotent: true) },
+        clock: { Date() },
         sleep: { _ in
-          try Task.checkCancellation()
-          throw URLError(.timedOut)
+          await sleepEntered.signal()
+          // Long real sleep so the only way out is cancellation arriving
+          // mid-backoff.
+          try await Task.sleep(nanoseconds: 10_000_000_000)
         },
         jitter: { $0 },
-        operation: { throw URLError(.timedOut) })
+        operation: {
+          _ = await opCount.next()
+          throw URLError(.timedOut)
+        }
+      )
     }
-    task.cancel()
-    await #expect(throws: (any Error).self) { try await task.value }
+    await sleepEntered.wait()  // first operation ran; we are now in backoff
+    task.cancel()  // cancel mid-backoff
+    await #expect(throws: CancellationError.self) { try await task.value }
+    let count = await opCount.value()
+    #expect(count == 1)  // operation NOT retried after cancellation
   }
 
   /// Minimal async counter so the closures stay `Sendable`.
   actor Counter {
 
-    private var value = 0
+    private var count = 0
 
     func next() -> Int {
-      defer { value += 1 }
-      return value
+      defer { count += 1 }
+      return count
+    }
+
+    func value() -> Int { count }
+  }
+
+  /// One-shot async rendezvous: `wait()` suspends until `signal()` fires.
+  actor Gate {
+    private var continuations: [CheckedContinuation<Void, Never>] = []
+    private var signaled = false
+
+    func signal() {
+      signaled = true
+      for continuation in continuations { continuation.resume() }
+      continuations.removeAll()
+    }
+
+    func wait() async {
+      if signaled { return }
+      await withCheckedContinuation { continuations.append($0) }
     }
   }
 }

--- a/MoolahTests/Shared/HTTPRetryTests.swift
+++ b/MoolahTests/Shared/HTTPRetryTests.swift
@@ -30,7 +30,7 @@ struct HTTPRetryTests {
     let sched = FakeScheduler()
     let result = try await withRetry(
       policy: HTTPRetryPolicy(),
-      isRetryable: { HTTPRetryClassifier.decision(for: $0, idempotent: true) },
+      classify: { HTTPRetryClassifier.decision(for: $0, idempotent: true) },
       clock: { sched.now() },
       sleep: { try await sched.sleep($0) },
       jitter: { $0 },
@@ -45,7 +45,7 @@ struct HTTPRetryTests {
     let attempts = Counter()
     let result = try await withRetry(
       policy: HTTPRetryPolicy(),
-      isRetryable: { HTTPRetryClassifier.decision(for: $0, idempotent: true) },
+      classify: { HTTPRetryClassifier.decision(for: $0, idempotent: true) },
       clock: { sched.now() },
       sleep: { try await sched.sleep($0) },
       jitter: { $0 },
@@ -63,7 +63,7 @@ struct HTTPRetryTests {
     await #expect(throws: URLError.self) {
       try await withRetry(
         policy: HTTPRetryPolicy(),
-        isRetryable: {
+        classify: {
           HTTPRetryClassifier.decision(for: $0, idempotent: true)
         },
         clock: { sched.now() },
@@ -81,7 +81,7 @@ struct HTTPRetryTests {
     await #expect(throws: Boom.self) {
       try await withRetry(
         policy: HTTPRetryPolicy(),
-        isRetryable: {
+        classify: {
           HTTPRetryClassifier.decision(for: $0, idempotent: true)
         },
         clock: { sched.now() },
@@ -98,7 +98,7 @@ struct HTTPRetryTests {
     let attempts = Counter()
     _ = try await withRetry(
       policy: HTTPRetryPolicy(honorsRetryAfterInPlace: true),
-      isRetryable: { HTTPRetryClassifier.decision(for: $0, idempotent: true) },
+      classify: { HTTPRetryClassifier.decision(for: $0, idempotent: true) },
       clock: { sched.now() },
       sleep: { try await sched.sleep($0) },
       jitter: { $0 },
@@ -119,7 +119,7 @@ struct HTTPRetryTests {
     await #expect(throws: URLError.self) {
       try await withRetry(
         policy: policy,
-        isRetryable: {
+        classify: {
           HTTPRetryClassifier.decision(for: $0, idempotent: true)
         },
         clock: { sched.now() },
@@ -137,7 +137,7 @@ struct HTTPRetryTests {
     let task = Task {
       try await withRetry(
         policy: HTTPRetryPolicy(),
-        isRetryable: { HTTPRetryClassifier.decision(for: $0, idempotent: true) },
+        classify: { HTTPRetryClassifier.decision(for: $0, idempotent: true) },
         clock: { Date() },
         sleep: { _ in
           await sleepEntered.signal()

--- a/Shared/CryptoImport/BlockExplorerClient.swift
+++ b/Shared/CryptoImport/BlockExplorerClient.swift
@@ -180,13 +180,18 @@ struct LiveBlockscoutClient: Sendable {
     } catch let walletError as WalletSyncError {
       throw walletError
     } catch let signal as HTTPRetrySignal {
-      let reason =
-        signal.retryAfter.map { "Retry-After \($0)s" } ?? "server error"
+      if let retryAfter = signal.retryAfter {
+        logger.error(
+          "Blockscout \(stage, privacy: .public) rate-limit retry exhausted (Retry-After \(retryAfter, privacy: .public)s)"
+        )
+        throw WalletSyncError.rateLimited(
+          retryAfter: Date().addingTimeInterval(retryAfter))
+      }
       logger.error(
-        "Blockscout \(stage, privacy: .public) retry exhausted (\(reason, privacy: .public))"
+        "Blockscout \(stage, privacy: .public) retry exhausted (server error)"
       )
       throw WalletSyncError.network(
-        underlyingDescription: "retry exhausted (\(reason))")
+        underlyingDescription: "retry exhausted (server error)")
     } catch {
       logger.error(
         "Blockscout \(stage, privacy: .public) network failure: \(error.localizedDescription, privacy: .public)"

--- a/Shared/CryptoImport/BlockExplorerClient.swift
+++ b/Shared/CryptoImport/BlockExplorerClient.swift
@@ -167,9 +167,9 @@ struct LiveBlockscoutClient: Sendable {
     do {
       return try await withRetry(
         policy: retryPolicy,
-        isRetryable: { HTTPRetryClassifier.decision(for: $0, idempotent: true) },
+        classify: { HTTPRetryClassifier.decision(for: $0, idempotent: true) },
         sleep: sleeper,
-        operation: {
+        operation: { @Sendable in
           try await self.attempt(request: timed, stage: stage)
         }
       )
@@ -210,9 +210,9 @@ struct LiveBlockscoutClient: Sendable {
     return data
   }
 
-  /// Blockscout-specific status classification. Mirrors the old
-  /// `AlchemyResponseValidator` mapping but converts retryable statuses into
-  /// `HTTPRetrySignal` so `withRetry` can act on them.
+  /// Blockscout-specific HTTP status classification: 2xx is success;
+  /// 429/418/503 (and other 5xx) become an `HTTPRetrySignal` so `withRetry`
+  /// can retry or wait; everything else is a terminal `WalletSyncError`.
   private func classifyBlockscout(
     response: URLResponse, stage: String
   ) throws {

--- a/Shared/CryptoImport/BlockExplorerClient.swift
+++ b/Shared/CryptoImport/BlockExplorerClient.swift
@@ -242,8 +242,11 @@ struct LiveBlockscoutClient: Sendable {
       {
         throw HTTPRetrySignal(retryAfter: wait)
       }
-      if retryAfter == nil { throw HTTPRetrySignal(retryAfter: nil) }
-      throw WalletSyncError.network(underlyingDescription: "HTTP 503")
+      if let retryAfter {
+        throw WalletSyncError.rateLimited(
+          retryAfter: Date().addingTimeInterval(retryAfter))
+      }
+      throw HTTPRetrySignal(retryAfter: nil)
     case 500...599:
       throw HTTPRetrySignal(retryAfter: nil)
     default:

--- a/Shared/CryptoImport/BlockExplorerClient.swift
+++ b/Shared/CryptoImport/BlockExplorerClient.swift
@@ -31,11 +31,23 @@ protocol BlockExplorerClient: Sendable {
 struct LiveBlockscoutClient: Sendable {
   private let session: URLSession
   private let rateLimiter: RateLimiter
+  private let retryPolicy: HTTPRetryPolicy
+  private let sleeper: @Sendable (TimeInterval) async throws -> Void
   private let logger: Logger
 
-  init(session: URLSession = .shared, rateLimiter: RateLimiter) {
+  init(
+    session: URLSession = .shared,
+    rateLimiter: RateLimiter,
+    retryPolicy: HTTPRetryPolicy = HTTPRetryPolicy(
+      honorsRetryAfterInPlace: true),
+    sleeper: @escaping @Sendable (TimeInterval) async throws -> Void = {
+      try await Task.sleep(nanoseconds: UInt64(max(0, $0) * 1_000_000_000))
+    }
+  ) {
     self.session = session
     self.rateLimiter = rateLimiter
+    self.retryPolicy = retryPolicy
+    self.sleeper = sleeper
     self.logger = Logger(subsystem: "com.moolah.app", category: "BlockscoutClient")
   }
 
@@ -147,26 +159,95 @@ struct LiveBlockscoutClient: Sendable {
   }
 
   private func send(request: URLRequest, stage: String) async throws -> Data {
-    let data: Data
-    let response: URLResponse
+    let timed: URLRequest = {
+      var request = request
+      request.timeoutInterval = retryPolicy.requestTimeout
+      return request
+    }()
     do {
-      (data, response) = try await session.data(for: request)
+      return try await withRetry(
+        policy: retryPolicy,
+        isRetryable: { HTTPRetryClassifier.decision(for: $0, idempotent: true) },
+        sleep: sleeper,
+        operation: {
+          try await self.attempt(request: timed, stage: stage)
+        }
+      )
     } catch let urlError as URLError where urlError.code == .cancelled {
       throw CancellationError()
+    } catch is CancellationError {
+      throw CancellationError()
+    } catch let walletError as WalletSyncError {
+      throw walletError
+    } catch let signal as HTTPRetrySignal {
+      let reason =
+        signal.retryAfter.map { "Retry-After \($0)s" } ?? "server error"
+      logger.error(
+        "Blockscout \(stage, privacy: .public) retry exhausted (\(reason, privacy: .public))"
+      )
+      throw WalletSyncError.network(
+        underlyingDescription: "retry exhausted (\(reason))")
     } catch {
       logger.error(
         "Blockscout \(stage, privacy: .public) network failure: \(error.localizedDescription, privacy: .public)"
       )
-      throw WalletSyncError.network(underlyingDescription: error.localizedDescription)
+      throw WalletSyncError.network(
+        underlyingDescription: error.localizedDescription)
     }
-    do {
-      try AlchemyResponseValidator.validate(response: response, stage: stage, logger: logger)
-    } catch let error as WalletSyncError where error.kind == .invalidApiKey {
-      logger.error(
-        "Blockscout \(stage, privacy: .public): HTTP 401/403 (public API expects no auth)")
-      throw WalletSyncError.network(underlyingDescription: "HTTP 401/403")
-    }
+  }
+
+  /// One transport attempt. Returns body on 2xx; throws `HTTPRetrySignal` when
+  /// the response is retryable, or a terminal `WalletSyncError` otherwise. A
+  /// raw transient `URLError` propagates so the classifier can retry it.
+  private func attempt(request: URLRequest, stage: String) async throws -> Data {
+    let (data, response) = try await session.data(for: request)
+    try classifyBlockscout(response: response, stage: stage)
     return data
+  }
+
+  /// Blockscout-specific status classification. Mirrors the old
+  /// `AlchemyResponseValidator` mapping but converts retryable statuses into
+  /// `HTTPRetrySignal` so `withRetry` can act on them.
+  private func classifyBlockscout(
+    response: URLResponse, stage: String
+  ) throws {
+    guard let http = response as? HTTPURLResponse else {
+      throw WalletSyncError.network(underlyingDescription: "No HTTP response")
+    }
+    let retryAfter = http.retryAfterSeconds(now: Date())
+    switch http.statusCode {
+    case 200...299:
+      return
+    case 401, 403:
+      logger.error(
+        "Blockscout \(stage, privacy: .public): HTTP 401/403 (public API expects no auth)"
+      )
+      throw WalletSyncError.network(underlyingDescription: "HTTP 401/403")
+    case 429, 418:
+      if retryPolicy.honorsRetryAfterInPlace, let wait = retryAfter,
+        wait <= retryPolicy.maxRateLimitWait
+      {
+        throw HTTPRetrySignal(retryAfter: wait)
+      }
+      throw WalletSyncError.rateLimited(
+        retryAfter: retryAfter.map { Date().addingTimeInterval($0) })
+    case 503:
+      if retryPolicy.honorsRetryAfterInPlace, let wait = retryAfter,
+        wait <= retryPolicy.maxRateLimitWait
+      {
+        throw HTTPRetrySignal(retryAfter: wait)
+      }
+      if retryAfter == nil { throw HTTPRetrySignal(retryAfter: nil) }
+      throw WalletSyncError.network(underlyingDescription: "HTTP 503")
+    case 500...599:
+      throw HTTPRetrySignal(retryAfter: nil)
+    default:
+      logger.error(
+        "Blockscout \(stage, privacy: .public): HTTP \(http.statusCode, privacy: .public)"
+      )
+      throw WalletSyncError.network(
+        underlyingDescription: "HTTP \(http.statusCode)")
+    }
   }
 }
 

--- a/Shared/Networking/HTTPRetry.swift
+++ b/Shared/Networking/HTTPRetry.swift
@@ -7,7 +7,7 @@ private let retryLogger = Logger(
 /// Runs `operation`, retrying per `policy` while `isRetryable` says so.
 ///
 /// - Backoff is the policy's exponential ceiling passed through `jitter`
-///   (default: uniform full jitter in `0...ceiling`; tests pass identity).
+///   (default: uniform full jitter in `0...ceiling` — `0...0` is a valid closed range, so a zero ceiling collapses to 0; tests pass identity).
 /// - `clock` / `sleep` are injected so tests advance a fake clock and never
 ///   block. The default `sleep` is `Task.sleep`, which throws on cancellation.
 /// - Stops when `maxAttempts` is reached, when the next delay would exceed

--- a/Shared/Networking/HTTPRetry.swift
+++ b/Shared/Networking/HTTPRetry.swift
@@ -1,0 +1,61 @@
+import Foundation
+import OSLog
+
+private let retryLogger = Logger(
+  subsystem: "com.moolah.app", category: "HTTPRetry")
+
+/// Runs `operation`, retrying per `policy` while `isRetryable` says so.
+///
+/// - Backoff is the policy's exponential ceiling passed through `jitter`
+///   (default: uniform full jitter in `0...ceiling`; tests pass identity).
+/// - `clock` / `sleep` are injected so tests advance a fake clock and never
+///   block. The default `sleep` is `Task.sleep`, which throws on cancellation.
+/// - Stops when `maxAttempts` is reached, when the next delay would exceed
+///   `totalBudget`, when the error is not retryable, or on cancellation. On
+///   any stop the **last** thrown error propagates unchanged.
+func withRetry<T: Sendable>(
+  policy: HTTPRetryPolicy,
+  isRetryable: @Sendable (any Error) -> HTTPRetryDecision,
+  clock: @Sendable () -> Date = { Date() },
+  sleep: @Sendable (TimeInterval) async throws -> Void = {
+    try await Task.sleep(nanoseconds: UInt64(max(0, $0) * 1_000_000_000))
+  },
+  jitter: @Sendable (TimeInterval) -> TimeInterval = {
+    TimeInterval.random(in: 0...max(0, $0))
+  },
+  operation: @Sendable () async throws -> T
+) async throws -> T {
+  let start = clock()
+  var attempt = 1
+  while true {
+    do {
+      return try await operation()
+    } catch {
+      // A cancellation thrown by the operation is terminal.
+      try Task.checkCancellation()
+      let decision = isRetryable(error)
+      let delay: TimeInterval
+      switch decision {
+      case .doNotRetry:
+        throw error
+      case .retryAfterBackoff:
+        delay = jitter(policy.backoffCeiling(forAttempt: attempt))
+      case .retryAfter(let serverDelay):
+        delay = max(0, serverDelay)
+      }
+      guard attempt < policy.maxAttempts else { throw error }
+      let elapsed = clock().timeIntervalSince(start)
+      guard elapsed + delay <= policy.totalBudget else { throw error }
+      retryLogger.notice(
+        """
+        Retry attempt \(attempt + 1, privacy: .public) of \
+        \(policy.maxAttempts, privacy: .public) after \
+        \(delay, privacy: .public)s: \
+        \(error.localizedDescription, privacy: .public)
+        """
+      )
+      try await sleep(delay)
+      attempt += 1
+    }
+  }
+}

--- a/Shared/Networking/HTTPRetryClassifier.swift
+++ b/Shared/Networking/HTTPRetryClassifier.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+/// Maps a thrown error to an `HTTPRetryDecision`. Pure and synchronous so it
+/// is trivially unit-testable.
+enum HTTPRetryClassifier {
+  /// `URLError` codes that represent a transient transport failure worth
+  /// retrying on an idempotent request.
+  private static let retryableTransportCodes: Set<URLError.Code> = [
+    .timedOut, .networkConnectionLost, .cannotConnectToHost,
+    .dnsLookupFailed, .notConnectedToInternet,
+  ]
+
+  static func decision(
+    for error: any Error, idempotent: Bool
+  ) -> HTTPRetryDecision {
+    // Cancellation is user-driven and never a retry, regardless of method.
+    if error is CancellationError { return .doNotRetry }
+    if let urlError = error as? URLError, urlError.code == .cancelled {
+      return .doNotRetry
+    }
+    // Explicit retry request from the integration layer.
+    if let signal = error as? HTTPRetrySignal {
+      if let delay = signal.retryAfter { return .retryAfter(delay) }
+      return .retryAfterBackoff
+    }
+    guard idempotent else { return .doNotRetry }
+    if let urlError = error as? URLError,
+      retryableTransportCodes.contains(urlError.code)
+    {
+      return .retryAfterBackoff
+    }
+    return .doNotRetry
+  }
+}

--- a/Shared/Networking/HTTPRetryDecision.swift
+++ b/Shared/Networking/HTTPRetryDecision.swift
@@ -4,10 +4,21 @@ import OSLog
 private let retryLogger = Logger(
   subsystem: "com.moolah.app", category: "HTTPRetry")
 
-/// Runs `operation`, retrying per `policy` while `isRetryable` says so.
+/// What `withRetry` should do with a thrown error.
+enum HTTPRetryDecision: Sendable, Equatable {
+  /// Surface the error to the caller now.
+  case doNotRetry
+  /// Retry after the policy's jittered exponential backoff.
+  case retryAfterBackoff
+  /// Retry after a server-specified delay (a vetted `Retry-After`).
+  case retryAfter(TimeInterval)
+}
+
+/// Runs `operation`, retrying per `policy` while `classify` says so.
 ///
 /// - Backoff is the policy's exponential ceiling passed through `jitter`
-///   (default: uniform full jitter in `0...ceiling` — `0...0` is a valid closed range, so a zero ceiling collapses to 0; tests pass identity).
+///   (default: uniform full jitter in `0...ceiling` — `0...0` is a valid
+///   closed range, so a zero ceiling collapses to 0; tests pass identity).
 /// - `clock` / `sleep` are injected so tests advance a fake clock and never
 ///   block. The default `sleep` is `Task.sleep`, which throws on cancellation.
 /// - Stops when `maxAttempts` is reached, when the next delay would exceed
@@ -15,7 +26,7 @@ private let retryLogger = Logger(
 ///   any stop the **last** thrown error propagates unchanged.
 func withRetry<T: Sendable>(
   policy: HTTPRetryPolicy,
-  isRetryable: @Sendable (any Error) -> HTTPRetryDecision,
+  classify: @Sendable (any Error) -> HTTPRetryDecision,
   clock: @Sendable () -> Date = { Date() },
   sleep: @Sendable (TimeInterval) async throws -> Void = {
     try await Task.sleep(nanoseconds: UInt64(max(0, $0) * 1_000_000_000))
@@ -33,7 +44,7 @@ func withRetry<T: Sendable>(
     } catch {
       // A cancellation thrown by the operation is terminal.
       try Task.checkCancellation()
-      let decision = isRetryable(error)
+      let decision = classify(error)
       let delay: TimeInterval
       switch decision {
       case .doNotRetry:
@@ -55,6 +66,7 @@ func withRetry<T: Sendable>(
         """
       )
       try await sleep(delay)
+      try Task.checkCancellation()
       attempt += 1
     }
   }

--- a/Shared/Networking/HTTPRetryPolicy.swift
+++ b/Shared/Networking/HTTPRetryPolicy.swift
@@ -14,6 +14,7 @@ struct HTTPRetryPolicy: Sendable, Equatable {
   /// Exponential backoff base; ceiling for attempt `n` is
   /// `min(backoffCap, backoffBase * 2^(n-1))`, then jittered.
   var backoffBase: TimeInterval = 0.5
+  /// Upper bound for the pre-jitter backoff ceiling; see `backoffBase`.
   var backoffCap: TimeInterval = 5
   /// Hard ceiling across all attempts so a dead provider cannot stall one
   /// request for `maxAttempts * requestTimeout`. Retrying stops when either

--- a/Shared/Networking/HTTPRetryPolicy.swift
+++ b/Shared/Networking/HTTPRetryPolicy.swift
@@ -34,16 +34,6 @@ struct HTTPRetryPolicy: Sendable, Equatable {
   }
 }
 
-/// What `withRetry` should do with a thrown error.
-enum HTTPRetryDecision: Sendable, Equatable {
-  /// Surface the error to the caller now.
-  case doNotRetry
-  /// Retry after the policy's jittered exponential backoff.
-  case retryAfterBackoff
-  /// Retry after a server-specified delay (a vetted `Retry-After`).
-  case retryAfter(TimeInterval)
-}
-
 /// Internal error an operation throws to ask `withRetry` for a retry. The
 /// integration layer (e.g. `LiveBlockscoutClient`) only throws this when it
 /// has *decided* a retry is wanted; a terminal error is thrown directly so it

--- a/Shared/Networking/HTTPRetryPolicy.swift
+++ b/Shared/Networking/HTTPRetryPolicy.swift
@@ -1,0 +1,55 @@
+// Shared/Networking/HTTPRetryPolicy.swift
+import Foundation
+
+/// Tunable, per-call HTTP retry/timeout policy. A plain value so each client
+/// can hold its own and tests can construct variants freely. See
+/// `plans/2026-05-17-http-timeout-retry-design.md`.
+struct HTTPRetryPolicy: Sendable, Equatable {
+  /// Applied via `URLRequest.timeoutInterval`. Default is deliberately long
+  /// (Blockscout's public instances are slow — the goal is to *extend* the
+  /// effective timeout, not shorten it).
+  var requestTimeout: TimeInterval = 120
+  /// Total attempts including the first (1 initial + `maxAttempts - 1` retries).
+  var maxAttempts: Int = 3
+  /// Exponential backoff base; ceiling for attempt `n` is
+  /// `min(backoffCap, backoffBase * 2^(n-1))`, then jittered.
+  var backoffBase: TimeInterval = 0.5
+  var backoffCap: TimeInterval = 5
+  /// Hard ceiling across all attempts so a dead provider cannot stall one
+  /// request for `maxAttempts * requestTimeout`. Retrying stops when either
+  /// `maxAttempts` or `totalBudget` is exhausted, whichever comes first.
+  var totalBudget: TimeInterval = 300
+  /// When true, a rate-limit response carrying a `Retry-After` no longer than
+  /// `maxRateLimitWait` is waited out and the (idempotent) request retried
+  /// in-place instead of failing. Default false preserves the fallback-chain
+  /// clients' behavior.
+  var honorsRetryAfterInPlace: Bool = false
+  /// `Retry-After` longer than this is not waited out in-place.
+  var maxRateLimitWait: TimeInterval = 60
+
+  /// Pre-jitter backoff ceiling for a 1-based attempt number.
+  func backoffCeiling(forAttempt attempt: Int) -> TimeInterval {
+    let raw = backoffBase * pow(2, Double(max(0, attempt - 1)))
+    return min(backoffCap, raw)
+  }
+}
+
+/// What `withRetry` should do with a thrown error.
+enum HTTPRetryDecision: Sendable, Equatable {
+  /// Surface the error to the caller now.
+  case doNotRetry
+  /// Retry after the policy's jittered exponential backoff.
+  case retryAfterBackoff
+  /// Retry after a server-specified delay (a vetted `Retry-After`).
+  case retryAfter(TimeInterval)
+}
+
+/// Internal error an operation throws to ask `withRetry` for a retry. The
+/// integration layer (e.g. `LiveBlockscoutClient`) only throws this when it
+/// has *decided* a retry is wanted; a terminal error is thrown directly so it
+/// propagates unchanged on exhaustion.
+struct HTTPRetrySignal: Error, Sendable, Equatable {
+  /// `nil` → use policy backoff (e.g. 5xx without `Retry-After`).
+  /// non-`nil` → server-requested delay already vetted against the policy.
+  let retryAfter: TimeInterval?
+}

--- a/Shared/Networking/HTTPRetryPolicy.swift
+++ b/Shared/Networking/HTTPRetryPolicy.swift
@@ -1,4 +1,3 @@
-// Shared/Networking/HTTPRetryPolicy.swift
 import Foundation
 
 /// Tunable, per-call HTTP retry/timeout policy. A plain value so each client

--- a/plans/2026-05-17-http-timeout-retry-design.md
+++ b/plans/2026-05-17-http-timeout-retry-design.md
@@ -1,0 +1,190 @@
+# HTTP Timeout + Retry Component — Design
+
+**Date:** 2026-05-17
+**Status:** Approved (design), pending implementation plan
+**Motivation:** Account-history sync fails with "The request timed out" because
+every external-provider HTTP call relies on `URLSession.shared`'s ~60s default
+request timeout and nothing retries a transient failure. Blockscout's public
+instances are slow enough that a single page request can exceed 60s, aborting
+the entire sync.
+
+## Goal
+
+A reusable HTTP timeout + retry component that any external-provider client can
+adopt to automatically get a configurable per-request timeout and bounded
+retry-with-backoff for transient failures. Integrate it into the Blockscout
+client first; design it so the 6 clients already on the shared networking layer
+can inherit it later with minimal friction.
+
+## Context
+
+The codebase already has a shared networking layer in `Shared/Networking/`:
+
+- `RateLimitGate.swift` — actor; host-wide reactive cooldown on 429/418/503 with
+  `Retry-After` or exponential backoff.
+- `FailedRequestCache.swift` — actor; per-URL cooldown (fixed 5 min for HTTP
+  errors, exponential backoff for transport errors).
+- `URLSession+RateLimited.swift` — `dataRespectingRateLimit(for:gate:failureCache:)`
+  wraps `data(for:)` with pre-flight gate/cache checks and post-flight
+  classification.
+
+Adoption today:
+
+- **Price / FX / stock clients** (CoinGecko, CryptoCompare, Binance,
+  Frankfurter, YahooFinance, YahooFinanceStockSearch) — already route through
+  `dataRespectingRateLimit`; rely on an orchestrated fallback chain when a
+  provider is rate-limited.
+- **Wallet-sync clients** (`LiveAlchemyClient`, `LiveBlockscoutClient`) — use
+  their own proactive `RateLimiter` actor (Blockscout: 5 req/s, a deliberate
+  choice for the unauthenticated public API) and `AlchemyResponseValidator`;
+  **not** on the gate/cache path.
+- **Coinstash** — custom `Transport` closure, no rate limiting.
+
+Gaps the existing layer does **not** close: no per-request timeout is ever
+configured anywhere, and nothing *retries* — the gate/cache only *suppress*
+repeats via cooldown.
+
+## Decisions (from brainstorming)
+
+| Question | Decision |
+|---|---|
+| Component scope | Extend the existing `Shared/Networking` layer; one unified policy; the 6 gate/cache clients inherit retry over time. |
+| Retry triggers | Transient transport errors + 5xx without `Retry-After`. 429/418/503+`Retry-After` keep today's throw-cooldown-and-fall-back behavior **by default**. |
+| Idempotency | Explicit per-call `idempotent` flag; default derived from HTTP method (GET/HEAD → true, others → false). Read-only POST clients (Alchemy JSON-RPC, Coinstash GraphQL) opt in explicitly later. |
+| Policy defaults | `requestTimeout` = **120s** (Blockscout is slow — the point is to *extend* the timeout, not shorten it), 3 attempts, exponential backoff + jitter. |
+| Integration approach | **A** — shared retry/timeout core + retry-aware `dataRespectingRateLimit`; Blockscout keeps its proactive `RateLimiter` + `AlchemyResponseValidator`, gains timeout + retry. |
+| Blockscout rate-limits | Blockscout must **also** honor reactive `Retry-After` in-place (wait + retry the idempotent GET) because it has no fallback provider — a rate-limit must be waited out, not hard-failed. Enabled via a per-call policy capability that stays **off** for the fallback-chain clients. |
+
+## Architecture & Components
+
+Three new pieces under `Shared/Networking/`, all pure value/function types,
+unit-testable with an injected clock (no real sleeping, no simulator).
+
+### `HTTPRetryPolicy` (`Sendable` struct)
+
+Per-call, overridable per client.
+
+- `requestTimeout: TimeInterval = 120` — applied via `URLRequest.timeoutInterval`.
+- `maxAttempts: Int = 3` — 1 initial + 2 retries.
+- `backoffBase: TimeInterval = 0.5`, `backoffCap: TimeInterval = 5` —
+  exponential `backoffBase · 2^(n-1)`, capped at `backoffCap`, with full jitter.
+- `totalBudget: TimeInterval = 300` — hard ceiling across all attempts so a
+  dead provider cannot stall a single page for `3 × 120s`. Retrying stops when
+  **either** `maxAttempts` or `totalBudget` is exhausted, whichever comes first.
+- `honorsRetryAfterInPlace: Bool = false` — when true, a `429/418/503` with a
+  `Retry-After` ≤ `maxRateLimitWait` is waited out and the (idempotent) request
+  retried in-place instead of throwing cooldown. Default false preserves the
+  fallback-chain clients' behavior exactly.
+- `maxRateLimitWait: TimeInterval = 60` — `Retry-After` longer than this is not
+  waited out; the existing throw-cooldown path is used so the caller fails
+  cleanly rather than stalling.
+
+### `withRetry(policy:isRetryable:clock:operation:)`
+
+Generic async executor:
+
+- Runs `operation`; on a thrown error consults `isRetryable`.
+- If retryable and budget/attempts remain: sleeps the jittered backoff (or the
+  capped `Retry-After`), checks `Task.isCancelled` and the elapsed total budget
+  between attempts, then retries.
+- On exhaustion: rethrows the **last** error unchanged.
+- Clock and sleeper are injected (`@Sendable`) so tests advance a fake clock
+  and never sleep for real.
+
+### `HTTPRetryClassifier`
+
+Decides whether an error/response is retryable:
+
+- Retryable transport: `URLError` codes `.timedOut`,
+  `.networkConnectionLost`, `.cannotConnectToHost`, `.dnsLookupFailed`,
+  `.notConnectedToInternet`.
+- Retryable HTTP: 5xx **without** a `Retry-After`.
+- Only when `idempotent == true`.
+- Never retryable: `CancellationError`, `URLError(.cancelled)` — user-driven,
+  propagate immediately.
+
+## Integration Points
+
+### `URLSession.dataRespectingRateLimit`
+
+Gains `retry: HTTPRetryPolicy? = nil` and `idempotent: Bool? = nil`
+(default derived from the request's HTTP method).
+
+- Retry is woven **inside**, around the raw `self.data(for:)`, **before**
+  `FailedRequestCache` muting. This is essential: today the method records a
+  transport failure and rethrows on timeout, so a naive retry *wrapped around*
+  it would immediately trip the per-URL cooldown on attempt 2. Failure is
+  recorded/muted only after retries are exhausted; gate bookkeeping and
+  `classify()` run once on the final outcome.
+- `retry: nil` ⇒ byte-for-byte today's behavior (backward compatible
+  regression guard in tests).
+- The 6 price/FX/stock clients adopt `retry:` opt-in, one at a time, later
+  (out of scope for the first implementation).
+
+### Blockscout (`LiveBlockscoutClient`) — first adopter
+
+- Keeps its proactive `RateLimiter` (5 req/s) and `AlchemyResponseValidator`.
+- Routes the transport call (`send`) through the retry path with policy
+  `requestTimeout: 120`, `honorsRetryAfterInPlace: true`,
+  `maxRateLimitWait: 60`, `idempotent: true` (all Blockscout calls are GETs).
+- Because Blockscout has no fallback provider, a 429/503+`Retry-After`
+  within `maxRateLimitWait` is waited out and the page re-fetched; a longer
+  `Retry-After` surfaces as the existing error so the sync fails cleanly
+  instead of hanging.
+
+## Data Flow (Blockscout page fetch)
+
+```
+paginate loop
+  → rateLimiter.acquire()                      (proactive 5 req/s, unchanged)
+  → withRetry:
+      attempt:
+        session.data(for:) with timeoutInterval = 120
+        ├─ .timedOut / transient transport / 5xx-no-Retry-After
+        │     → jittered backoff, budget+cancel check → retry
+        ├─ 429/503 + Retry-After ≤ 60s
+        │     → sleep Retry-After → retry
+        ├─ 429/503 + Retry-After > 60s
+        │     → throw (existing cooldown path; sync fails cleanly)
+        └─ success / other non-2xx
+              → return to AlchemyResponseValidator (validated as today)
+      exhaustion → rethrow last error → mapped to WalletSyncError.network
+```
+
+## Error Handling
+
+- No new error types. Retries are transparent; on exhaustion the **original**
+  error propagates and is mapped by each client's existing validator
+  (`WalletSyncError.network` for Blockscout).
+- Cancellation propagates immediately, untouched, and never mutes a URL.
+- The retry executor logs each retry at `.notice` with attempt number, delay,
+  reason, and host. Address/hash stays `.private` per the existing privacy
+  table in the Blockscout/Alchemy clients.
+
+## Testing
+
+TDD — test file before implementation, per project rules; follows
+`guides/TEST_GUIDE.md`.
+
+- **`HTTPRetryPolicy`** — defaults; per-client override semantics.
+- **`withRetry`** — succeeds first try; retries then succeeds; exhausts and
+  rethrows the last error; stops at `totalBudget` before `maxAttempts`; stops
+  on cancellation mid-backoff; honors capped `Retry-After`; does not retry when
+  not idempotent. All with an injected fake clock — zero real sleeping.
+- **`HTTPRetryClassifier`** — table test over URLError codes and HTTP status
+  codes × `idempotent` flag.
+- **`dataRespectingRateLimit` with `retry:`** — a transport failure is retried
+  *before* `FailedRequestCache` mutes the URL; gate/cache bookkeeping runs once
+  on the final outcome; `retry: nil` path is unchanged (regression guard).
+- **Blockscout** — stubbed `URLProtocol`/transport returning timeout-then-success
+  proves a page survives a transient timeout; 429 + short `Retry-After` is
+  waited out and succeeds; 429 + long `Retry-After` still fails cleanly.
+
+## Out of Scope
+
+- Migrating the 6 price/FX/stock clients onto `retry:` (they inherit it later,
+  opt-in, one at a time).
+- Migrating Alchemy or Coinstash (read-only POST) onto the component — they can
+  opt in later via the explicit `idempotent: true` flag.
+- Any change to `RateLimitGate` / `FailedRequestCache` semantics, or to
+  Blockscout's proactive 5 req/s rate.

--- a/plans/2026-05-17-http-timeout-retry-implementation.md
+++ b/plans/2026-05-17-http-timeout-retry-implementation.md
@@ -1,0 +1,986 @@
+# HTTP Timeout + Retry Component Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a reusable HTTP timeout + retry-with-backoff component under `Shared/Networking/` and adopt it in `LiveBlockscoutClient` so a slow Blockscout page no longer aborts the whole account-history sync.
+
+**Architecture:** A `Sendable` `HTTPRetryPolicy` value, a pure generic `withRetry` async executor with injected clock/sleeper/jitter (deterministic tests, no real sleeping), and an `HTTPRetryClassifier` that decides retryability. Blockscout keeps its proactive `RateLimiter` and `AlchemyResponseValidator`; its `send` sets `request.timeoutInterval` and wraps the transport call in `withRetry`, throwing an internal `HTTPRetrySignal` to request a retry for transient transport errors, 5xx-without-Retry-After, and (because Blockscout has no fallback provider) short `Retry-After` waits.
+
+**Tech Stack:** Swift 6, Swift Testing (`import Testing`, `@Suite`, `@Test`, `#expect`), `URLSession`, `OSLog`. `xcodegen` (`just generate`), `just` build/test/format targets.
+
+**Scope note (deliberate deferral):** The approved spec lists `URLSession.dataRespectingRateLimit` gaining `retry:`/`idempotent:` so the 6 price/FX/stock clients can inherit retry later. That weaving (retry *before* `FailedRequestCache` muting) is intricate and has **no consumer** until one of those clients adopts it — adding it now is YAGNI and the risky part is unneeded for Blockscout, which is not on the gate/cache path. This plan delivers **the reusable core + Blockscout only**, exactly the spec's "first implementation" scope. The `dataRespectingRateLimit` change is a separate future plan, written when the first of the 6 clients adopts the core.
+
+**Reference:** `plans/2026-05-17-http-timeout-retry-design.md` (approved design).
+
+**Conventions (verified in codebase):**
+- Tests live in `MoolahTests/Shared/`; macOS target `MoolahTests_macOS`; run a suite with `just test-mac <SuiteName>`.
+- Test style: `import Foundation` / `import Testing` / `@testable import Moolah`, `@Suite("Name") struct …`, `@Test func … async throws`, `#expect(…)`. Fake-clock pattern is a `final class … : @unchecked Sendable` with an `NSLock` (see `MoolahTests/Shared/RateLimitGateTests.swift`).
+- New `.swift` files in already-globbed dirs (`Shared/Networking/`, `MoolahTests/Shared/`) are picked up by `just generate`. Run `just generate` before the first build.
+- One extension per protocol; thin types; follow `guides/CODE_GUIDE.md`. Run `just format` before every commit; `just format-check` must pass.
+- `just` is invoked from the worktree with `just -d <worktree>` only if cwd differs; the executing session's cwd is the worktree root, so plain `just …` is correct.
+
+---
+
+## File Structure
+
+**Create:**
+- `Shared/Networking/HTTPRetryPolicy.swift` — `HTTPRetryPolicy`, `HTTPRetryDecision`, `HTTPRetrySignal` (pure value types).
+- `Shared/Networking/HTTPRetryClassifier.swift` — `HTTPRetryClassifier` (pure decision function).
+- `Shared/Networking/HTTPRetry.swift` — `withRetry` generic async executor.
+- `MoolahTests/Shared/HTTPRetryPolicyTests.swift`
+- `MoolahTests/Shared/HTTPRetryClassifierTests.swift`
+- `MoolahTests/Shared/HTTPRetryTests.swift`
+- `MoolahTests/Shared/BlockExplorerClientRetryTests.swift`
+
+**Modify:**
+- `Shared/CryptoImport/BlockExplorerClient.swift` — add a `retryPolicy` stored property + init param; rewrite `send(request:stage:)` to set the timeout, wrap in `withRetry`, and classify the response for retry; add a private `classifyBlockscout` helper.
+
+---
+
+## Task 1: `HTTPRetryPolicy`, `HTTPRetryDecision`, `HTTPRetrySignal`
+
+**Files:**
+- Create: `Shared/Networking/HTTPRetryPolicy.swift`
+- Test: `MoolahTests/Shared/HTTPRetryPolicyTests.swift`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `MoolahTests/Shared/HTTPRetryPolicyTests.swift`:
+
+```swift
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("HTTPRetryPolicy")
+struct HTTPRetryPolicyTests {
+  @Test
+  func defaultsMatchApprovedDesign() {
+    let policy = HTTPRetryPolicy()
+    #expect(policy.requestTimeout == 120)
+    #expect(policy.maxAttempts == 3)
+    #expect(policy.backoffBase == 0.5)
+    #expect(policy.backoffCap == 5)
+    #expect(policy.totalBudget == 300)
+    #expect(policy.honorsRetryAfterInPlace == false)
+    #expect(policy.maxRateLimitWait == 60)
+  }
+
+  @Test
+  func perClientOverridesAreIndependent() {
+    let blockscout = HTTPRetryPolicy(honorsRetryAfterInPlace: true)
+    #expect(blockscout.honorsRetryAfterInPlace == true)
+    #expect(blockscout.requestTimeout == 120)
+    #expect(HTTPRetryPolicy().honorsRetryAfterInPlace == false)
+  }
+
+  @Test
+  func backoffIsExponentialJitteredAndCapped() {
+    let policy = HTTPRetryPolicy()
+    // Jitter closure of identity yields the deterministic ceiling.
+    #expect(policy.backoffCeiling(forAttempt: 1) == 0.5)
+    #expect(policy.backoffCeiling(forAttempt: 2) == 1.0)
+    #expect(policy.backoffCeiling(forAttempt: 3) == 2.0)
+    #expect(policy.backoffCeiling(forAttempt: 10) == 5.0)  // capped
+  }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `just test-mac HTTPRetryPolicyTests`
+Expected: FAIL — `cannot find 'HTTPRetryPolicy' in scope`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `Shared/Networking/HTTPRetryPolicy.swift`:
+
+```swift
+// Shared/Networking/HTTPRetryPolicy.swift
+import Foundation
+
+/// Tunable, per-call HTTP retry/timeout policy. A plain value so each client
+/// can hold its own and tests can construct variants freely. See
+/// `plans/2026-05-17-http-timeout-retry-design.md`.
+struct HTTPRetryPolicy: Sendable, Equatable {
+  /// Applied via `URLRequest.timeoutInterval`. Default is deliberately long
+  /// (Blockscout's public instances are slow — the goal is to *extend* the
+  /// effective timeout, not shorten it).
+  var requestTimeout: TimeInterval = 120
+  /// Total attempts including the first (1 initial + `maxAttempts - 1` retries).
+  var maxAttempts: Int = 3
+  /// Exponential backoff base; ceiling for attempt `n` is
+  /// `min(backoffCap, backoffBase * 2^(n-1))`, then jittered.
+  var backoffBase: TimeInterval = 0.5
+  var backoffCap: TimeInterval = 5
+  /// Hard ceiling across all attempts so a dead provider cannot stall one
+  /// request for `maxAttempts * requestTimeout`. Retrying stops when either
+  /// `maxAttempts` or `totalBudget` is exhausted, whichever comes first.
+  var totalBudget: TimeInterval = 300
+  /// When true, a rate-limit response carrying a `Retry-After` no longer than
+  /// `maxRateLimitWait` is waited out and the (idempotent) request retried
+  /// in-place instead of failing. Default false preserves the fallback-chain
+  /// clients' behavior.
+  var honorsRetryAfterInPlace: Bool = false
+  /// `Retry-After` longer than this is not waited out in-place.
+  var maxRateLimitWait: TimeInterval = 60
+
+  /// Pre-jitter backoff ceiling for a 1-based attempt number.
+  func backoffCeiling(forAttempt attempt: Int) -> TimeInterval {
+    let raw = backoffBase * pow(2, Double(max(0, attempt - 1)))
+    return min(backoffCap, raw)
+  }
+}
+
+/// What `withRetry` should do with a thrown error.
+enum HTTPRetryDecision: Sendable, Equatable {
+  /// Surface the error to the caller now.
+  case doNotRetry
+  /// Retry after the policy's jittered exponential backoff.
+  case retryAfterBackoff
+  /// Retry after a server-specified delay (a vetted `Retry-After`).
+  case retryAfter(TimeInterval)
+}
+
+/// Internal error an operation throws to ask `withRetry` for a retry. The
+/// integration layer (e.g. `LiveBlockscoutClient`) only throws this when it
+/// has *decided* a retry is wanted; a terminal error is thrown directly so it
+/// propagates unchanged on exhaustion.
+struct HTTPRetrySignal: Error, Sendable, Equatable {
+  /// `nil` → use policy backoff (e.g. 5xx without `Retry-After`).
+  /// non-`nil` → server-requested delay already vetted against the policy.
+  let retryAfter: TimeInterval?
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `just test-mac HTTPRetryPolicyTests`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Format, lint, commit**
+
+```bash
+just generate
+just format
+just format-check
+git add Shared/Networking/HTTPRetryPolicy.swift MoolahTests/Shared/HTTPRetryPolicyTests.swift Moolah.xcodeproj 2>/dev/null; git add Shared/Networking/HTTPRetryPolicy.swift MoolahTests/Shared/HTTPRetryPolicyTests.swift
+git commit -m "feat(networking): add HTTPRetryPolicy value type
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+(`Moolah.xcodeproj` is gitignored — the `git add` of it is a no-op safety net; the real adds are the two source files.)
+
+---
+
+## Task 2: `HTTPRetryClassifier`
+
+**Files:**
+- Create: `Shared/Networking/HTTPRetryClassifier.swift`
+- Test: `MoolahTests/Shared/HTTPRetryClassifierTests.swift`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `MoolahTests/Shared/HTTPRetryClassifierTests.swift`:
+
+```swift
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("HTTPRetryClassifier")
+struct HTTPRetryClassifierTests {
+  @Test
+  func transientTransportErrorsRetryWhenIdempotent() {
+    for code in [
+      URLError.timedOut, .networkConnectionLost, .cannotConnectToHost,
+      .dnsLookupFailed, .notConnectedToInternet,
+    ] {
+      let decision = HTTPRetryClassifier.decision(
+        for: URLError(code), idempotent: true)
+      #expect(decision == .retryAfterBackoff)
+    }
+  }
+
+  @Test
+  func transientTransportErrorsDoNotRetryWhenNotIdempotent() {
+    let decision = HTTPRetryClassifier.decision(
+      for: URLError(.timedOut), idempotent: false)
+    #expect(decision == .doNotRetry)
+  }
+
+  @Test
+  func cancellationNeverRetries() {
+    #expect(
+      HTTPRetryClassifier.decision(for: CancellationError(), idempotent: true)
+        == .doNotRetry)
+    #expect(
+      HTTPRetryClassifier.decision(for: URLError(.cancelled), idempotent: true)
+        == .doNotRetry)
+  }
+
+  @Test
+  func retrySignalWithoutDelayUsesBackoff() {
+    #expect(
+      HTTPRetryClassifier.decision(
+        for: HTTPRetrySignal(retryAfter: nil), idempotent: true)
+        == .retryAfterBackoff)
+  }
+
+  @Test
+  func retrySignalWithDelayHonorsServerDelay() {
+    #expect(
+      HTTPRetryClassifier.decision(
+        for: HTTPRetrySignal(retryAfter: 12), idempotent: true)
+        == .retryAfter(12))
+  }
+
+  @Test
+  func unknownErrorsDoNotRetry() {
+    struct Other: Error {}
+    #expect(
+      HTTPRetryClassifier.decision(for: Other(), idempotent: true)
+        == .doNotRetry)
+  }
+
+  @Test
+  func nonTransientURLErrorDoesNotRetry() {
+    #expect(
+      HTTPRetryClassifier.decision(
+        for: URLError(.badServerResponse), idempotent: true) == .doNotRetry)
+  }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `just test-mac HTTPRetryClassifierTests`
+Expected: FAIL — `cannot find 'HTTPRetryClassifier' in scope`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `Shared/Networking/HTTPRetryClassifier.swift`:
+
+```swift
+// Shared/Networking/HTTPRetryClassifier.swift
+import Foundation
+
+/// Maps a thrown error to an `HTTPRetryDecision`. Pure and synchronous so it
+/// is trivially unit-testable.
+enum HTTPRetryClassifier {
+  /// `URLError` codes that represent a transient transport failure worth
+  /// retrying on an idempotent request.
+  private static let retryableTransportCodes: Set<URLError.Code> = [
+    .timedOut, .networkConnectionLost, .cannotConnectToHost,
+    .dnsLookupFailed, .notConnectedToInternet,
+  ]
+
+  static func decision(
+    for error: any Error, idempotent: Bool
+  ) -> HTTPRetryDecision {
+    // Cancellation is user-driven and never a retry, regardless of method.
+    if error is CancellationError { return .doNotRetry }
+    if let urlError = error as? URLError, urlError.code == .cancelled {
+      return .doNotRetry
+    }
+    // Explicit retry request from the integration layer.
+    if let signal = error as? HTTPRetrySignal {
+      if let delay = signal.retryAfter { return .retryAfter(delay) }
+      return .retryAfterBackoff
+    }
+    guard idempotent else { return .doNotRetry }
+    if let urlError = error as? URLError,
+      retryableTransportCodes.contains(urlError.code)
+    {
+      return .retryAfterBackoff
+    }
+    return .doNotRetry
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `just test-mac HTTPRetryClassifierTests`
+Expected: PASS (7 tests).
+
+- [ ] **Step 5: Format, lint, commit**
+
+```bash
+just format
+just format-check
+git add Shared/Networking/HTTPRetryClassifier.swift MoolahTests/Shared/HTTPRetryClassifierTests.swift
+git commit -m "feat(networking): add HTTPRetryClassifier
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: `withRetry` executor
+
+**Files:**
+- Create: `Shared/Networking/HTTPRetry.swift`
+- Test: `MoolahTests/Shared/HTTPRetryTests.swift`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `MoolahTests/Shared/HTTPRetryTests.swift`:
+
+```swift
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("withRetry")
+struct HTTPRetryTests {
+  /// Deterministic clock + sleeper: `sleep` advances the clock instead of
+  /// blocking, and records every requested delay.
+  final class FakeScheduler: @unchecked Sendable {
+    private let lock = NSLock()
+    private var current = Date(timeIntervalSince1970: 1_700_000_000)
+    private(set) var sleeps: [TimeInterval] = []
+
+    func now() -> Date {
+      lock.lock(); defer { lock.unlock() }
+      return current
+    }
+
+    func sleep(_ seconds: TimeInterval) async throws {
+      try Task.checkCancellation()
+      lock.lock()
+      sleeps.append(seconds)
+      current = current.addingTimeInterval(seconds)
+      lock.unlock()
+    }
+  }
+
+  @Test
+  func succeedsOnFirstTryWithoutSleeping() async throws {
+    let sched = FakeScheduler()
+    let result = try await withRetry(
+      policy: HTTPRetryPolicy(),
+      isRetryable: { HTTPRetryClassifier.decision(for: $0, idempotent: true) },
+      clock: { sched.now() },
+      sleep: { try await sched.sleep($0) },
+      jitter: { $0 }
+    ) { 42 }
+    #expect(result == 42)
+    #expect(sched.sleeps.isEmpty)
+  }
+
+  @Test
+  func retriesTransientThenSucceeds() async throws {
+    let sched = FakeScheduler()
+    let attempts = Counter()
+    let result = try await withRetry(
+      policy: HTTPRetryPolicy(),
+      isRetryable: { HTTPRetryClassifier.decision(for: $0, idempotent: true) },
+      clock: { sched.now() },
+      sleep: { try await sched.sleep($0) },
+      jitter: { $0 }
+    ) {
+      if await attempts.next() < 2 { throw URLError(.timedOut) }
+      return "ok"
+    }
+    #expect(result == "ok")
+    // Two failures → two backoff sleeps at the deterministic ceilings.
+    #expect(sched.sleeps == [0.5, 1.0])
+  }
+
+  @Test
+  func exhaustsAndRethrowsLastError() async throws {
+    let sched = FakeScheduler()
+    await #expect(throws: URLError.self) {
+      try await withRetry(
+        policy: HTTPRetryPolicy(),
+        isRetryable: {
+          HTTPRetryClassifier.decision(for: $0, idempotent: true)
+        },
+        clock: { sched.now() },
+        sleep: { try await sched.sleep($0) },
+        jitter: { $0 }
+      ) { throw URLError(.timedOut) }
+    }
+    // 3 attempts → 2 backoff sleeps.
+    #expect(sched.sleeps == [0.5, 1.0])
+  }
+
+  @Test
+  func nonRetryableErrorIsNotRetried() async throws {
+    let sched = FakeScheduler()
+    struct Boom: Error, Equatable {}
+    await #expect(throws: Boom.self) {
+      try await withRetry(
+        policy: HTTPRetryPolicy(),
+        isRetryable: {
+          HTTPRetryClassifier.decision(for: $0, idempotent: true)
+        },
+        clock: { sched.now() },
+        sleep: { try await sched.sleep($0) },
+        jitter: { $0 }
+      ) { throw Boom() }
+    }
+    #expect(sched.sleeps.isEmpty)
+  }
+
+  @Test
+  func honorsServerRetryAfterDelay() async throws {
+    let sched = FakeScheduler()
+    let attempts = Counter()
+    _ = try await withRetry(
+      policy: HTTPRetryPolicy(honorsRetryAfterInPlace: true),
+      isRetryable: { HTTPRetryClassifier.decision(for: $0, idempotent: true) },
+      clock: { sched.now() },
+      sleep: { try await sched.sleep($0) },
+      jitter: { $0 }
+    ) { () async throws -> Int in
+      if await attempts.next() < 1 { throw HTTPRetrySignal(retryAfter: 7) }
+      return 1
+    }
+    #expect(sched.sleeps == [7])
+  }
+
+  @Test
+  func stopsWhenTotalBudgetWouldBeExceeded() async throws {
+    let sched = FakeScheduler()
+    // backoffBase huge so the first backoff alone exceeds the budget.
+    var policy = HTTPRetryPolicy()
+    policy.backoffBase = 1000
+    policy.backoffCap = 1000
+    policy.totalBudget = 10
+    await #expect(throws: URLError.self) {
+      try await withRetry(
+        policy: policy,
+        isRetryable: {
+          HTTPRetryClassifier.decision(for: $0, idempotent: true)
+        },
+        clock: { sched.now() },
+        sleep: { try await sched.sleep($0) },
+        jitter: { $0 }
+      ) { throw URLError(.timedOut) }
+    }
+    // Budget tripped before the first sleep.
+    #expect(sched.sleeps.isEmpty)
+  }
+
+  @Test
+  func stopsOnCancellationMidBackoff() async throws {
+    let sched = FakeScheduler()
+    let task = Task {
+      try await withRetry(
+        policy: HTTPRetryPolicy(),
+        isRetryable: {
+          HTTPRetryClassifier.decision(for: $0, idempotent: true)
+        },
+        clock: { sched.now() },
+        sleep: { _ in
+          try Task.checkCancellation()
+          throw URLError(.timedOut)
+        },
+        jitter: { $0 }
+      ) { throw URLError(.timedOut) }
+    }
+    task.cancel()
+    await #expect(throws: (any Error).self) { try await task.value }
+  }
+
+  /// Minimal async counter so the closures stay `Sendable`.
+  actor Counter {
+    private var value = 0
+    func next() -> Int { defer { value += 1 }; return value }
+  }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `just test-mac HTTPRetryTests`
+Expected: FAIL — `cannot find 'withRetry' in scope`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `Shared/Networking/HTTPRetry.swift`:
+
+```swift
+// Shared/Networking/HTTPRetry.swift
+import Foundation
+import OSLog
+
+private let retryLogger = Logger(
+  subsystem: "com.moolah.app", category: "HTTPRetry")
+
+/// Runs `operation`, retrying per `policy` while `isRetryable` says so.
+///
+/// - Backoff is the policy's exponential ceiling passed through `jitter`
+///   (default: uniform full jitter in `0...ceiling`; tests pass identity).
+/// - `clock` / `sleep` are injected so tests advance a fake clock and never
+///   block. The default `sleep` is `Task.sleep`, which throws on cancellation.
+/// - Stops when `maxAttempts` is reached, when the next delay would exceed
+///   `totalBudget`, when the error is not retryable, or on cancellation. On
+///   any stop the **last** thrown error propagates unchanged.
+func withRetry<T: Sendable>(
+  policy: HTTPRetryPolicy,
+  isRetryable: @Sendable (any Error) -> HTTPRetryDecision,
+  clock: @Sendable () -> Date = { Date() },
+  sleep: @Sendable (TimeInterval) async throws -> Void = {
+    try await Task.sleep(nanoseconds: UInt64(max(0, $0) * 1_000_000_000))
+  },
+  jitter: @Sendable (TimeInterval) -> TimeInterval = {
+    TimeInterval.random(in: 0...max(0, $0))
+  },
+  operation: @Sendable () async throws -> T
+) async throws -> T {
+  let start = clock()
+  var attempt = 1
+  while true {
+    do {
+      return try await operation()
+    } catch {
+      // A cancellation thrown by the operation is terminal.
+      try Task.checkCancellation()
+      let decision = isRetryable(error)
+      let delay: TimeInterval
+      switch decision {
+      case .doNotRetry:
+        throw error
+      case .retryAfterBackoff:
+        delay = jitter(policy.backoffCeiling(forAttempt: attempt))
+      case .retryAfter(let serverDelay):
+        delay = max(0, serverDelay)
+      }
+      guard attempt < policy.maxAttempts else { throw error }
+      let elapsed = clock().timeIntervalSince(start)
+      guard elapsed + delay <= policy.totalBudget else { throw error }
+      retryLogger.notice(
+        """
+        Retry attempt \(attempt + 1, privacy: .public) of \
+        \(policy.maxAttempts, privacy: .public) after \
+        \(delay, privacy: .public)s: \
+        \(error.localizedDescription, privacy: .public)
+        """
+      )
+      try await sleep(delay)
+      attempt += 1
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `just test-mac HTTPRetryTests`
+Expected: PASS (7 tests).
+
+- [ ] **Step 5: Format, lint, commit**
+
+```bash
+just format
+just format-check
+git add Shared/Networking/HTTPRetry.swift MoolahTests/Shared/HTTPRetryTests.swift
+git commit -m "feat(networking): add withRetry executor with injected clock/sleeper
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Adopt timeout + retry in `LiveBlockscoutClient`
+
+**Files:**
+- Modify: `Shared/CryptoImport/BlockExplorerClient.swift` (the `LiveBlockscoutClient` struct: `init` lines 36–40, `send(request:stage:)` lines 149–170)
+- Test: `MoolahTests/Shared/BlockExplorerClientRetryTests.swift`
+
+Background — current code (verbatim, do not keep as-is):
+
+```swift
+init(session: URLSession = .shared, rateLimiter: RateLimiter) {
+  self.session = session
+  self.rateLimiter = rateLimiter
+  self.logger = Logger(subsystem: "com.moolah.app", category: "BlockscoutClient")
+}
+
+private func send(request: URLRequest, stage: String) async throws -> Data {
+  let data: Data
+  let response: URLResponse
+  do {
+    (data, response) = try await session.data(for: request)
+  } catch let urlError as URLError where urlError.code == .cancelled {
+    throw CancellationError()
+  } catch {
+    logger.error(
+      "Blockscout \(stage, privacy: .public) network failure: \(error.localizedDescription, privacy: .public)"
+    )
+    throw WalletSyncError.network(underlyingDescription: error.localizedDescription)
+  }
+  do {
+    try AlchemyResponseValidator.validate(response: response, stage: stage, logger: logger)
+  } catch WalletSyncError.invalidApiKey {
+    logger.error(
+      "Blockscout \(stage, privacy: .public): HTTP 401/403 (public API expects no auth)")
+    throw WalletSyncError.network(underlyingDescription: "HTTP 401/403")
+  }
+  return data
+}
+```
+
+- [ ] **Step 1: Write the failing test**
+
+Create `MoolahTests/Shared/BlockExplorerClientRetryTests.swift`:
+
+```swift
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("LiveBlockscoutClient retry")
+struct BlockExplorerClientRetryTests {
+  /// Per-test scripted responses keyed by call order. Each element is either
+  /// a thrown `URLError` or an `(status, body, headers)` response.
+  final class Script: @unchecked Sendable {
+    enum Step: Sendable {
+      case fail(URLError.Code)
+      case respond(status: Int, body: Data, headers: [String: String])
+    }
+    private let lock = NSLock()
+    private var steps: [Step]
+    private(set) var calls = 0
+    init(_ steps: [Step]) { self.steps = steps }
+    func next() -> Step {
+      lock.lock(); defer { lock.unlock() }
+      calls += 1
+      precondition(!steps.isEmpty, "StubURLProtocol called more times than scripted")
+      return steps.removeFirst()
+    }
+  }
+
+  /// `URLProtocol` stub driven by a `Script` shared via a thread-safe box.
+  final class StubURLProtocol: URLProtocol {
+    nonisolated(unsafe) static var script: Script!
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest
+    { request }
+    override func startLoading() {
+      switch Self.script.next() {
+      case .fail(let code):
+        client?.urlProtocol(self, didFailWithError: URLError(code))
+      case .respond(let status, let body, let headers):
+        let response = HTTPURLResponse(
+          url: request.url!, statusCode: status,
+          httpVersion: "HTTP/1.1", headerFields: headers)!
+        client?.urlProtocol(
+          self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: body)
+        client?.urlProtocolDidFinishLoading(self)
+      }
+    }
+    override func stopLoading() {}
+  }
+
+  private func makeSession() -> URLSession {
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [StubURLProtocol.self]
+    return URLSession(configuration: config)
+  }
+
+  private static let emptyPage = Data(
+    #"{"items":[],"next_page_params":null}"#.utf8)
+
+  @Test
+  func transientTimeoutIsRetriedThenSucceeds() async throws {
+    StubURLProtocol.script = Script([
+      .fail(.timedOut),
+      .respond(status: 200, body: Self.emptyPage, headers: [:]),
+    ])
+    let client = LiveBlockscoutClient(
+      session: makeSession(),
+      rateLimiter: RateLimiter(permitsPerSecond: 1000),
+      retryPolicy: HTTPRetryPolicy(),
+      sleeper: { _ in })  // no real backoff sleep in tests
+    let txs = try await client.nativeTransactions(
+      chain: .ethereum, walletAddress: "0xabc", fromBlock: 0)
+    #expect(txs.isEmpty)
+    #expect(StubURLProtocol.script.calls == 2)
+  }
+
+  @Test
+  func longRetryAfterFailsCleanly() async throws {
+    StubURLProtocol.script = Script([
+      .respond(
+        status: 429, body: Data(), headers: ["Retry-After": "999"]),
+    ])
+    let client = LiveBlockscoutClient(
+      session: makeSession(),
+      rateLimiter: RateLimiter(permitsPerSecond: 1000),
+      retryPolicy: HTTPRetryPolicy(honorsRetryAfterInPlace: true),
+      sleeper: { _ in })
+    await #expect(throws: WalletSyncError.self) {
+      _ = try await client.nativeTransactions(
+        chain: .ethereum, walletAddress: "0xabc", fromBlock: 0)
+    }
+    #expect(StubURLProtocol.script.calls == 1)  // not retried
+  }
+
+  @Test
+  func shortRetryAfterIsWaitedOutThenSucceeds() async throws {
+    StubURLProtocol.script = Script([
+      .respond(status: 429, body: Data(), headers: ["Retry-After": "5"]),
+      .respond(status: 200, body: Self.emptyPage, headers: [:]),
+    ])
+    let client = LiveBlockscoutClient(
+      session: makeSession(),
+      rateLimiter: RateLimiter(permitsPerSecond: 1000),
+      retryPolicy: HTTPRetryPolicy(honorsRetryAfterInPlace: true),
+      sleeper: { _ in })
+    let txs = try await client.nativeTransactions(
+      chain: .ethereum, walletAddress: "0xabc", fromBlock: 0)
+    #expect(txs.isEmpty)
+    #expect(StubURLProtocol.script.calls == 2)
+  }
+}
+```
+
+> Note: `ChainConfig.ethereum` is the existing Ethereum chain config used elsewhere in the Blockscout tests. If the accessor differs, mirror whatever `BlockExplorerClient`'s existing test/suite uses to build a `ChainConfig` for chain 1 — do not invent a new one.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `just test-mac BlockExplorerClientRetryTests`
+Expected: FAIL — `extra argument 'retryPolicy' in call` (init does not yet take the new params).
+
+- [ ] **Step 3: Modify `LiveBlockscoutClient`**
+
+In `Shared/CryptoImport/BlockExplorerClient.swift`, add stored properties and extend `init`. Replace the existing `init` (lines 36–40) with:
+
+```swift
+private let session: URLSession
+private let rateLimiter: RateLimiter
+private let retryPolicy: HTTPRetryPolicy
+private let sleeper: @Sendable (TimeInterval) async throws -> Void
+private let logger: Logger
+
+init(
+  session: URLSession = .shared,
+  rateLimiter: RateLimiter,
+  retryPolicy: HTTPRetryPolicy = HTTPRetryPolicy(
+    honorsRetryAfterInPlace: true),
+  sleeper: @escaping @Sendable (TimeInterval) async throws -> Void = {
+    try await Task.sleep(nanoseconds: UInt64(max(0, $0) * 1_000_000_000))
+  }
+) {
+  self.session = session
+  self.rateLimiter = rateLimiter
+  self.retryPolicy = retryPolicy
+  self.sleeper = sleeper
+  self.logger = Logger(
+    subsystem: "com.moolah.app", category: "BlockscoutClient")
+}
+```
+
+> If `private let session` / `private let rateLimiter` / `private let logger` are already declared as standalone stored properties above the old `init` (they are — lines 32–34), delete those three old declarations so the five-property block above is the single source. Do not duplicate them.
+
+Replace the existing `send(request:stage:)` (lines 149–170) with:
+
+```swift
+private func send(request: URLRequest, stage: String) async throws -> Data {
+  var timed = request
+  timed.timeoutInterval = retryPolicy.requestTimeout
+  do {
+    return try await withRetry(
+      policy: retryPolicy,
+      isRetryable: { HTTPRetryClassifier.decision(for: $0, idempotent: true) },
+      sleep: sleeper
+    ) {
+      try await self.attempt(request: timed, stage: stage)
+    }
+  } catch let urlError as URLError where urlError.code == .cancelled {
+    throw CancellationError()
+  } catch is CancellationError {
+    throw CancellationError()
+  } catch let walletError as WalletSyncError {
+    throw walletError
+  } catch let signal as HTTPRetrySignal {
+    let reason =
+      signal.retryAfter.map { "Retry-After \($0)s" } ?? "server error"
+    logger.error(
+      "Blockscout \(stage, privacy: .public) retry exhausted (\(reason, privacy: .public))"
+    )
+    throw WalletSyncError.network(
+      underlyingDescription: "retry exhausted (\(reason))")
+  } catch {
+    logger.error(
+      "Blockscout \(stage, privacy: .public) network failure: \(error.localizedDescription, privacy: .public)"
+    )
+    throw WalletSyncError.network(
+      underlyingDescription: error.localizedDescription)
+  }
+}
+
+/// One transport attempt. Returns body on 2xx; throws `HTTPRetrySignal` when
+/// the response is retryable, or a terminal `WalletSyncError` otherwise. A
+/// raw transient `URLError` propagates so the classifier can retry it.
+private func attempt(request: URLRequest, stage: String) async throws -> Data {
+  let (data, response) = try await session.data(for: request)
+  try classifyBlockscout(response: response, stage: stage)
+  return data
+}
+
+/// Blockscout-specific status classification. Mirrors the old
+/// `AlchemyResponseValidator` mapping but converts retryable statuses into
+/// `HTTPRetrySignal` so `withRetry` can act on them.
+private func classifyBlockscout(
+  response: URLResponse, stage: String
+) throws {
+  guard let http = response as? HTTPURLResponse else {
+    throw WalletSyncError.network(underlyingDescription: "No HTTP response")
+  }
+  let retryAfter = http.retryAfterSeconds(now: Date())
+  switch http.statusCode {
+  case 200...299:
+    return
+  case 401, 403:
+    logger.error(
+      "Blockscout \(stage, privacy: .public): HTTP 401/403 (public API expects no auth)"
+    )
+    throw WalletSyncError.network(underlyingDescription: "HTTP 401/403")
+  case 429, 418:
+    if retryPolicy.honorsRetryAfterInPlace, let wait = retryAfter,
+      wait <= retryPolicy.maxRateLimitWait
+    {
+      throw HTTPRetrySignal(retryAfter: wait)
+    }
+    throw WalletSyncError.rateLimited(
+      retryAfter: retryAfter.map { Date().addingTimeInterval($0) })
+  case 503:
+    if retryPolicy.honorsRetryAfterInPlace, let wait = retryAfter,
+      wait <= retryPolicy.maxRateLimitWait
+    {
+      throw HTTPRetrySignal(retryAfter: wait)
+    }
+    if retryAfter == nil { throw HTTPRetrySignal(retryAfter: nil) }
+    throw WalletSyncError.network(underlyingDescription: "HTTP 503")
+  case 500...599:
+    throw HTTPRetrySignal(retryAfter: nil)
+  default:
+    logger.error(
+      "Blockscout \(stage, privacy: .public): HTTP \(http.statusCode, privacy: .public)"
+    )
+    throw WalletSyncError.network(
+      underlyingDescription: "HTTP \(http.statusCode)")
+  }
+}
+```
+
+> The old `send` caught `URLError(.cancelled)` *before* anything else. Here, `attempt` lets a raw `URLError` propagate; the outer `do/catch` in `send` still maps `.cancelled` → `CancellationError` first, so cancellation behavior is preserved. A transient `URLError` (e.g. `.timedOut`) is not caught by `attempt`, so the classifier sees it and retries.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `just test-mac BlockExplorerClientRetryTests`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Run the full Blockscout suite for regressions**
+
+Run: `just test-mac BlockExplorerClientTests` (the pre-existing suite — exact name may be `BlockExplorerClientTests` or similar; run whatever the existing Blockscout suite is called).
+Expected: PASS — no regressions in existing pagination/decoding tests.
+
+- [ ] **Step 6: Build, format, lint, commit**
+
+```bash
+just build-mac
+just format
+just format-check
+git add Shared/CryptoImport/BlockExplorerClient.swift MoolahTests/Shared/BlockExplorerClientRetryTests.swift
+git commit -m "feat(crypto): add timeout + retry to Blockscout client
+
+Sets request.timeoutInterval to 120s and wraps the transport in
+withRetry, retrying transient transport failures and 5xx, and
+waiting out short Retry-After in-place (Blockscout has no fallback
+provider). Keeps the proactive RateLimiter unchanged.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Verification & review
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Full macOS networking + crypto regression**
+
+Run: `mkdir -p .agent-tmp && just test-mac HTTPRetryPolicyTests HTTPRetryClassifierTests HTTPRetryTests BlockExplorerClientRetryTests 2>&1 | tee .agent-tmp/retry-tests.txt`
+Expected: all suites PASS, 0 failures. Then `grep -i 'failed\|error:' .agent-tmp/retry-tests.txt` shows no test failures; `rm .agent-tmp/retry-tests.txt`.
+
+- [ ] **Step 2: Full build + format gate**
+
+Run: `just build-mac && just format-check`
+Expected: build succeeds with zero warnings (project treats warnings as errors); `format-check` exits 0.
+
+- [ ] **Step 3: Compiler-warning sweep**
+
+Use `mcp__xcode__XcodeListNavigatorIssues` with `severity: "warning"`. Expected: no warnings in the new/modified files (preview-macro warnings excluded).
+
+- [ ] **Step 4: Code review**
+
+Invoke the `code-review` agent on `Shared/Networking/HTTPRetryPolicy.swift`, `Shared/Networking/HTTPRetryClassifier.swift`, `Shared/Networking/HTTPRetry.swift`, and the `LiveBlockscoutClient` changes in `Shared/CryptoImport/BlockExplorerClient.swift`. Address every Critical/Important/Minor finding (per project policy: pre-existing-in-another-file is not a skip reason; ask before deferring any).
+
+- [ ] **Step 5: Concurrency review**
+
+Invoke the `concurrency-review` agent on the same four files (new networking code + Blockscout client touch `async`/`Sendable`/closures).
+
+- [ ] **Step 6: Final commit if review changes were made**
+
+```bash
+just format && just format-check
+git add -A
+git commit -m "fix: address code/concurrency review findings
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+- [ ] **Step 7: Push and open PR**
+
+```bash
+git -C $(git rev-parse --show-toplevel) push origin feat/http-timeout-retry:feat/http-timeout-retry
+gh pr create --title "feat: reusable HTTP timeout + retry; fix Blockscout sync timeout" \
+  --body "$(cat <<'EOF'
+Adds a reusable `Shared/Networking` timeout + retry component
+(`HTTPRetryPolicy`, `HTTPRetryClassifier`, `withRetry`) and adopts it
+in `LiveBlockscoutClient`: a 120s request timeout plus bounded
+retry-with-backoff for transient transport failures and 5xx, and
+in-place waiting for short `Retry-After` (Blockscout has no fallback
+provider). Fixes account-history sync aborting with "The request
+timed out" on slow Blockscout instances.
+
+Design: `plans/2026-05-17-http-timeout-retry-design.md`.
+The 6 price/FX/stock clients and the POST clients (Alchemy/Coinstash)
+inherit the core later, opt-in — out of scope here.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Then add the PR to the merge queue per the `merge-queue` skill (project policy: every PR goes through the merge queue, not manual merge).
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- `HTTPRetryPolicy` (timeout/attempts/backoff/budget/Retry-After fields + defaults) → Task 1 ✓
+- `withRetry` executor (injected clock/sleeper, budget, cancellation, exhaustion rethrows last) → Task 3 ✓
+- `HTTPRetryClassifier` (transient URLError set, 5xx-no-Retry-After via signal, idempotent gate, cancellation never) → Task 2 ✓
+- Blockscout adoption: 120s timeout, keep RateLimiter + validator behavior, honor short Retry-After in-place, long Retry-After fails cleanly, transient timeout retried → Task 4 ✓
+- Error handling: original error mapped to `WalletSyncError.network`; cancellation untouched → Task 4 `send` catch ladder ✓
+- Testing: policy defaults, withRetry matrix with fake clock, classifier table, Blockscout timeout-then-success / short vs long Retry-After → Tasks 1–4 ✓
+- Deferred per spec "out of scope": `dataRespectingRateLimit` param + the 6 clients + Alchemy/Coinstash → stated in Scope note, not a gap ✓
+
+**Placeholder scan:** No TBD/TODO/"handle edge cases"; every code step shows full code; commands have expected output. The one soft spot (`ChainConfig.ethereum` accessor name and the existing Blockscout suite name) is explicitly flagged with an instruction to mirror the existing test rather than invent — acceptable because the exact symbol is environment-local and the fallback is unambiguous.
+
+**Type consistency:** `HTTPRetryPolicy`, `HTTPRetryDecision`, `HTTPRetrySignal`, `HTTPRetryClassifier.decision(for:idempotent:)`, `withRetry(policy:isRetryable:clock:sleep:jitter:operation:)`, `backoffCeiling(forAttempt:)`, and the `LiveBlockscoutClient` init signature (`session:rateLimiter:retryPolicy:sleeper:`) are used identically across Tasks 1–4. ✓


### PR DESCRIPTION
## Summary

Adds a reusable `Shared/Networking` timeout + retry component and adopts it in `LiveBlockscoutClient`, fixing account-history sync aborting with **"The request timed out"** on slow Blockscout public instances (no per-request timeout was ever set — `URLSession.shared`'s ~60s default — and nothing retried transient failures).

**New component (`Shared/Networking/`):**
- `HTTPRetryPolicy` — tunable per-call policy (120s request timeout, 3 attempts, exponential backoff + jitter, 300s total budget, opt-in in-place `Retry-After` honouring).
- `HTTPRetryDecision` / `HTTPRetrySignal` / `HTTPRetryClassifier` — pure retry-decision logic.
- `withRetry(policy:classify:clock:sleep:jitter:operation:)` — generic async executor with injected clock/sleeper/jitter (deterministic tests, no real sleeping), cooperative cancellation, last-error propagation.

**Blockscout adoption:** sets `request.timeoutInterval = 120s`, wraps the transport in `withRetry`; retries transient transport failures and 5xx; because Blockscout has **no fallback provider**, a short `Retry-After` is waited out in-place while a long / exhausted rate-limit maps to `WalletSyncError.rateLimited`. The proactive 5 req/s `RateLimiter` and `AlchemyResponseValidator` behaviour are unchanged.

**Scope:** core + Blockscout only, per the approved design. The 6 price/FX/stock clients, Alchemy, Coinstash, and `dataRespectingRateLimit` inherit the core later (opt-in) — explicitly out of scope.

Design: `plans/2026-05-17-http-timeout-retry-design.md` · Plan: `plans/2026-05-17-http-timeout-retry-implementation.md`

A pre-existing `CONCURRENCY_GUIDE.md` §4 vs. architecture mismatch (no `APIClient` exists; all 11 clients inject `URLSession`) was surfaced and deferred to #938 (codebase-wide, out of scope here).

## Test Plan
- [x] `just build-mac` — BUILD SUCCEEDED, zero source warnings (warnings-as-errors)
- [x] `just test-mac` — 31 tests across 5 new/affected suites pass; `LiveBlockscoutClientTests` regression 5/5
- [x] `just format-check` — clean; `.swiftlint-baseline.yml` unchanged
- [x] code-review + concurrency-review agents run; all Critical/Important/Minor findings addressed
- [ ] Full CI suite (iOS + macOS) via merge queue

🤖 Generated with [Claude Code](https://claude.com/claude-code)