### PR TITLE
fix(sync): drive SyncedAccountHeaderView last-synced label off a timeline clock

### DIFF
--- a/Features/Sync/SyncedAccountHeaderView.swift
+++ b/Features/Sync/SyncedAccountHeaderView.swift
@@ -82,11 +82,13 @@ struct SyncedAccountHeaderView: View {
     syncStore.statePerAccount[account.id]
   }
 
-  private var lastSyncedText: String {
-    // TODO(#933): inline Date() makes the relative time stale between
-    // renders and unpinnable in view tests — drive `now` from a clock /
-    // timeline. https://github.com/ajsutton/moolah-native/issues/933
-    SyncedAccountHeaderLogic.lastSyncedText(state: syncState, now: Date())
+  /// Relative last-synced label for a given clock instant. `now` is
+  /// supplied by the enclosing `TimelineView` (see `statusRow`) so the
+  /// label ticks on the timeline's cadence rather than being frozen at
+  /// the last unrelated re-render. The formatting itself stays in the
+  /// unit-tested `SyncedAccountHeaderLogic`.
+  private func lastSyncedText(now: Date) -> String {
+    SyncedAccountHeaderLogic.lastSyncedText(state: syncState, now: now)
   }
 
   private var isSyncing: Bool {
@@ -164,11 +166,18 @@ struct SyncedAccountHeaderView: View {
           .font(.caption)
       }
       Spacer(minLength: 12)
-      Text(lastSyncedText)
-        .font(.subheadline)
-        .foregroundStyle(.secondary)
-        .monospacedDigit()
-        .accessibilityIdentifier(UITestIdentifiers.WalletAccountHeader.lastSynced)
+      // `context.date` ticks every 60s on the timeline's schedule, so
+      // the relative label ("Synced 3 min ago") stays fresh without an
+      // unrelated re-render. `.id(context.date)` forces the `Text` to
+      // re-evaluate on each tick. Mirrors `SyncProgressFooter`.
+      TimelineView(.periodic(from: .now, by: 60)) { context in
+        Text(lastSyncedText(now: context.date))
+          .font(.subheadline)
+          .foregroundStyle(.secondary)
+          .monospacedDigit()
+          .accessibilityIdentifier(UITestIdentifiers.WalletAccountHeader.lastSynced)
+          .id(context.date)
+      }
       syncButton(presentation)
     }
   }


### PR DESCRIPTION
Fixes #933.

`SyncedAccountHeaderView.lastSyncedText` read `Date()` inline in a computed property evaluated on every `body` render. Consequences (per the issue):

1. The relative timestamp ("Synced 3 min ago") was only as fresh as the last *unrelated* re-render — it did not tick.
2. The view layer could not be exercised at a pinned clock.

## Fix

Wrap the timestamp `Text` in `TimelineView(.periodic(from: .now, by: 60))` and feed `context.date` to the already-unit-tested `SyncedAccountHeaderLogic.lastSyncedText(state:now:)`, with `.id(context.date)` forcing re-evaluation each tick.

This mirrors the established pattern already used by `SyncProgressFooter` (`Features/Sync/SyncProgressFooter.swift:52`) and aligns with the "`Date()` only at boundaries" convention (CODE_GUIDE.md §17). The pure formatting logic stays in `SyncedAccountHeaderLogic`, which already takes an injected `now:` and is covered by `SyncedAccountHeaderLogicTests`.

## Acceptance

- ✅ Relative time updates without an unrelated re-render — driven by the 60s timeline schedule.
- ✅ Refresh cadence is a declarative `TimelineSchedule`, not an inline `Date()`; the formatting seam is clock-pinnable and unit-tested.

## Verification

- `just build-mac` — BUILD SUCCEEDED
- `just test-mac SyncedAccountHeaderLogicTests` — all 15 tests pass
- `just format-check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)