### PR TITLE
fix(crypto): point Optimism Blockscout at explorer.optimism.io

### DIFF
--- a/MoolahTests/Shared/CryptoImport/ChainConfigTests.swift
+++ b/MoolahTests/Shared/CryptoImport/ChainConfigTests.swift
@@ -29,7 +29,7 @@ struct ChainConfigTests {
     #expect(config.supportsInternalTransfers == false)
     #expect(config.displayName == "OP Mainnet")
     #expect(config.blockExplorerBaseURL.absoluteString == "https://optimistic.etherscan.io")
-    #expect(config.blockscoutAPIBaseURL.absoluteString == "https://optimism.blockscout.com")
+    #expect(config.blockscoutAPIBaseURL.absoluteString == "https://explorer.optimism.io")
     #expect(config.nativeInstrument.ticker == "ETH")
     #expect(config.nativeInstrument.chainId == 10)
   }

--- a/MoolahTests/Shared/CryptoImport/LiveBlockscoutClientTests.swift
+++ b/MoolahTests/Shared/CryptoImport/LiveBlockscoutClientTests.swift
@@ -43,7 +43,7 @@ struct LiveBlockscoutClientTests {
     _ = try await client.internalTransactions(
       chain: .optimism, walletAddress: "0xABC", fromBlock: 0)
     let url = try #require(BlockscoutURLProtocolStub.lastRequest?.url)
-    #expect(url.host == "optimism.blockscout.com")
+    #expect(url.host == "explorer.optimism.io")
     #expect(url.path == "/api/v2/addresses/0xABC/internal-transactions")
   }
 

--- a/Shared/CryptoImport/ChainConfig.swift
+++ b/Shared/CryptoImport/ChainConfig.swift
@@ -92,7 +92,10 @@ extension ChainConfig {
     supportsInternalTransfers: false,
     chargesL1DataFee: true,
     blockExplorerBaseURL: requireURL("https://optimistic.etherscan.io"),
-    blockscoutAPIBaseURL: requireURL("https://optimism.blockscout.com"),
+    // Optimism's Blockscout instance was rehosted: optimism.blockscout.com
+    // now 301-redirects every path to explorer.optimism.io. Point directly
+    // at the canonical host (Ethereum/Base still use *.blockscout.com).
+    blockscoutAPIBaseURL: requireURL("https://explorer.optimism.io"),
     displayName: "OP Mainnet"
   )
 


### PR DESCRIPTION
## Summary

- `optimism.blockscout.com` (hard-coded in `ChainConfig.optimism`) now issues an HTTP **301** redirecting every path to `explorer.optimism.io` — the rehosted canonical Optimism Blockscout instance.
- The redirect surfaced as a `WalletSyncError.network("retry exhausted (server error)")` on **every** Optimism account sync (e.g. "Ledger 1 - Optimism"), persisted to `wallet_sync_state.last_error_json`.
- This points `blockscoutAPIBaseURL` directly at the canonical host and updates the two tests that pinned the old host. Ethereum (`eth.blockscout.com`) and Base (`base.blockscout.com`) are unaffected — no redirect, still 200.

## Notes / known limitation

The new host's `/api/v2/addresses/{addr}/transactions` and `/internal-transactions` endpoints currently return **HTTP 500 / timeouts** server-side (other v2 endpoints like `/addresses/{addr}` and `/stats` return 200, and the legacy `/api?module=account&action=txlist` works). This PR is the correct config fix — it stops chasing a stale host and a redirect — but Optimism sync will only fully recover once Blockscout fixes the v2 list endpoints on `explorer.optimism.io`, or we add a fallback (tracked separately).

## Test plan

- [x] `just format-check` clean
- [x] `just test-mac ChainConfigTests LiveBlockscoutClientTests` — 14/14 pass, build clean
- [x] Verified via `curl` that `eth`/`base` Blockscout hosts still 200 with no redirect

🤖 Generated with [Claude Code](https://claude.com/claude-code)