### PR TITLE
perf(transfer-detection): O(1) dismissed-pair lookup

### DIFF
--- a/Domain/Models/DismissedTransferPair.swift
+++ b/Domain/Models/DismissedTransferPair.swift
@@ -13,15 +13,18 @@ struct DismissedTransferPair: Codable, Sendable, Identifiable, Hashable {
   init(transactionIds: Set<UUID>, dismissedAt: Date) {
     self.transactionIds = transactionIds
     self.dismissedAt = dismissedAt
-    self.id = Self.deterministicId(for: transactionIds)
+    self.id = Self.contentAddressedID(for: transactionIds)
   }
 
   func covers(_ first: UUID, and second: UUID) -> Bool {
     transactionIds == [first, second]
   }
 
-  private static func deterministicId(for ids: Set<UUID>) -> UUID {
-    let ordered = ids.map(\.uuidString).sorted().joined(separator: ":")
+  /// The content-addressed id this pair would carry, derived from the
+  /// unordered transaction-id set. Exposed so callers can build an O(1)
+  /// membership set keyed by id rather than scanning pairs linearly.
+  static func contentAddressedID(for transactionIds: Set<UUID>) -> UUID {
+    let ordered = transactionIds.map(\.uuidString).sorted().joined(separator: ":")
     return UUID.deterministic(from: "dismissed-transfer-pair:\(ordered)")
   }
 }

--- a/Features/TransferDetection/TransferDetectionCoordinator.swift
+++ b/Features/TransferDetection/TransferDetectionCoordinator.swift
@@ -91,9 +91,10 @@ final class TransferDetectionCoordinator {
           && transaction.accountIds.isDisjoint(with: participatingAccountIds)
       }
 
-      let dismissedSnapshot = try await self.dismissedPairs.fetchAll()
+      let dismissedIds = Set(try await self.dismissedPairs.fetchAll().map(\.id))
       let isDismissed: @Sendable (UUID, UUID) -> Bool = { first, second in
-        dismissedSnapshot.contains { $0.covers(first, and: second) }
+        dismissedIds.contains(
+          DismissedTransferPair.contentAddressedID(for: [first, second]))
       }
 
       let pairs = self.detector.detect(

--- a/MoolahTests/Domain/DismissedTransferPairTests.swift
+++ b/MoolahTests/Domain/DismissedTransferPairTests.swift
@@ -14,6 +14,15 @@ struct DismissedTransferPairTests {
     #expect(first.id == second.id)
   }
 
+  @Test("contentAddressedID(for:) matches the instance id and is order-independent")
+  func contentAddressedIDMatchesInstance() {
+    let idA = UUID()
+    let idB = UUID()
+    let instance = DismissedTransferPair(transactionIds: [idA, idB], dismissedAt: Date())
+    #expect(DismissedTransferPair.contentAddressedID(for: [idA, idB]) == instance.id)
+    #expect(DismissedTransferPair.contentAddressedID(for: [idB, idA]) == instance.id)
+  }
+
   @Test("covers a candidate pair regardless of order")
   func covers() {
     let idA = UUID()


### PR DESCRIPTION
## Summary

- `TransferDetectionCoordinator.runDetection` built an `isDismissed` closure that did a linear scan (`dismissedSnapshot.contains { $0.covers(...) }`) **inside the fuzzy detector's inner loop** — O(dismissedCount) per candidate comparison, degrading over time as the dismissed-pair table only ever grows.
- Exposes the existing content-addressed id derivation as `DismissedTransferPair.contentAddressedID(for:)` (the initializer already used the same derivation privately) and routes both the init and the coordinator through it.
- The coordinator now builds a `Set<UUID>` of dismissed ids once and does **O(1)** membership lookups keyed by the same derivation the init stored. Behaviour is unchanged.

## Test plan

- [x] New `DismissedTransferPairTests.contentAddressedIDMatchesInstance` proves the static derivation matches the instance `id` and is order-independent (failing-first, TDD).
- [x] Existing behavioural coverage `TransferDetectionScanTests.detectionSkipsDismissedPairs` still passes (dismissal filtering unchanged end-to-end).
- [x] `FuzzyTransferDetectorTests` + idempotency suite green (18 tests).
- [x] `just format-check` clean; `just build-mac` warning-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)