### PR TITLE
fix(analysis): price wrapped-native tokens; stop WETH sync error nuking Analysis

### DIFF
--- a/Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesForecast.swift
+++ b/Backends/GRDB/Repositories/GRDBAnalysisRepository+DailyBalancesForecast.swift
@@ -57,12 +57,37 @@ extension GRDBAnalysisRepository {
     return try await withThrowingTaskGroup(of: (Int, Transaction).self) { group in
       for (index, instance) in instances.enumerated() {
         group.addTask {
-          let txn = try await convertLegsToProfileInstrument(
-            instance,
-            to: profileInstrument,
-            on: conversionDate,
-            conversionService: conversionService)
-          return (index, txn)
+          do {
+            let txn = try await convertLegsToProfileInstrument(
+              instance,
+              to: profileInstrument,
+              on: conversionDate,
+              conversionService: conversionService)
+            return (index, txn)
+          } catch let cancel as CancellationError {
+            // Cooperative cancellation surfaces unchanged — never
+            // folded into the per-day degradation path.
+            throw cancel
+          } catch {
+            // Rule 11 (`INSTRUMENT_CONVERSION_GUIDE.md`): a single
+            // instance's conversion failure must not abort the whole
+            // forecast (that surfaced on the Analysis page as a
+            // full-screen "WalletSyncError"). Pass the instance through
+            // *unconverted* and log here — the accumulator's per-day
+            // `catch` then drops that day, and every later occurrence
+            // of an unpriceable recurring leg drops the same way, so a
+            // day's total is never partial. Logging at the point of
+            // failure is required: the accumulator only logs if
+            // `dailyBalance` itself subsequently throws, which is not
+            // guaranteed for every degraded instance.
+            forecastLogger.warning(
+              """
+              Forecast pre-conversion failed for instance \(index, privacy: .public) — \
+              \(error.localizedDescription, privacy: .public). Passing it through \
+              unconverted; affected forecast days drop (Rule 11).
+              """)
+            return (index, instance)
+          }
         }
       }
       var out = Array(repeating: firstInstance, count: instances.count)

--- a/Domain/Models/WalletSyncError.swift
+++ b/Domain/Models/WalletSyncError.swift
@@ -70,6 +70,54 @@ extension WalletSyncError {
   }
 }
 
+// MARK: - LocalizedError
+
+// Account-NEUTRAL, provider-aware fallback message. The rich
+// account-type-aware caption lives in
+// `SyncedAccountHeaderLogic.errorCaption` (a synced-account header knows
+// whether it is crypto or an exchange and says "API token" for an
+// exchange). This conformance is the generic fallback for any *other*
+// surface that renders `error.localizedDescription` — e.g.
+// `AnalysisView`, whose conversion pipeline can surface a price-provider
+// failure. It says "API key" (the generic term, accurate for the
+// price-provider context this surface reports) rather than the NSError
+// bridge string "Moolah.WalletSyncError error 1", which conveys no
+// failure kind. The two surfaces are never shown together for the same
+// error, so the deliberate "key" vs "token" wording split is not
+// user-visible inconsistency.
+extension WalletSyncError: LocalizedError {
+  var errorDescription: String? { description(now: Date()) }
+
+  /// `now`-injectable backing for `errorDescription` so the
+  /// relative-time `.rateLimited(retryAfter:)` rendering is
+  /// deterministically testable (the `LocalizedError.errorDescription`
+  /// signature itself cannot take a parameter).
+  func description(now: Date) -> String {
+    let provider = provider?.displayName
+    switch kind {
+    case .missingApiKey:
+      return provider.map { "Add a \($0) API key to enable sync." }
+        ?? "An API key is required to fetch this data."
+    case .invalidApiKey:
+      return provider.map { "\($0) rejected the API key." }
+        ?? "The API key was rejected."
+    case .rateLimited(let retryAfter):
+      let who = provider ?? "The data provider"
+      guard let retryAfter else { return "\(who) is rate-limiting requests. Try again shortly." }
+      let formatter = RelativeDateTimeFormatter()
+      formatter.unitsStyle = .short
+      let relative = formatter.localizedString(for: retryAfter, relativeTo: now)
+      return "\(who) is rate-limiting requests. Try again \(relative)."
+    case .network(let underlying):
+      return provider.map { "\($0) network error: \(underlying)" }
+        ?? "Network error: \(underlying)"
+    case .providerMalformedResponse(let stage):
+      let who = provider ?? "The data provider"
+      return "\(who) returned a malformed response (\(stage))."
+    }
+  }
+}
+
 // MARK: - Codable with legacy-row migration
 
 // Persisted shape (new): {"provider": "alchemy"|null, "kind": <Kind JSON>}.

--- a/Domain/Models/WrappedNativeContracts.swift
+++ b/Domain/Models/WrappedNativeContracts.swift
@@ -1,0 +1,72 @@
+import Foundation
+
+/// Curated trust list of canonical *wrapped-native* token contracts
+/// (WETH, WMATIC, WAVAX, …) that are, by their official deployment,
+/// 1:1 redeemable for their chain's native asset.
+///
+/// Wrapped-native tokens have no third-party price feed of their own
+/// (no CoinGecko/CryptoCompare/Binance id), so without this they fail
+/// to price entirely — surfacing on the Analysis page as a sync error.
+/// They are economically identical to the native asset, so we price
+/// them as that chain's native instrument (`"<chainId>:native"`),
+/// reusing the native asset's working price feed.
+///
+/// **Trust model — exact `(chainId, address)` only.** Matching is on a
+/// hand-verified `(chainId, lowercased contractAddress)` pair, *never*
+/// on symbol or name. A token that merely calls itself "WETH" must not
+/// inherit the native asset's price: it could be a malicious look-alike
+/// that never returns the underlying ETH. The same logical asset has
+/// different contract addresses on different chains, and a chain can
+/// host multiple "WETH"-named contracts; only the canonical official
+/// deployment for a given chain is listed here. Adding an entry is a
+/// deliberate trust decision — verify the address against the chain's
+/// official documentation before extending this map.
+enum WrappedNativeContracts {
+  /// Canonical wrapped-native contract address (lowercased) per chain.
+  /// Each maps the wrapped token to its chain's native asset, which is
+  /// priced via the normal native registration.
+  private static let canonicalByChain: [Int: String] = [
+    // Ethereum — WETH
+    1: "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+    // Optimism — WETH (network predeploy)
+    10: "0x4200000000000000000000000000000000000006",
+    // Base — WETH (network predeploy)
+    8453: "0x4200000000000000000000000000000000000006",
+    // Arbitrum One — WETH
+    42161: "0x82af49447d8a07e3bd95bd0d56f35241523fbab1",
+    // Polygon — WMATIC
+    137: "0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270",
+    // Avalanche C-Chain — WAVAX
+    43114: "0xb31f66aa3c1e785363f0875a1b74e27b85fd66c7",
+  ]
+
+  /// If `(chainId, contractAddress)` is the canonical wrapped-native
+  /// contract for that chain, returns the chain's native instrument id
+  /// (`"<chainId>:native"`) so the caller can price the wrapped token
+  /// as the native asset. Returns `nil` for native instruments (no
+  /// contract address), unknown contracts, and right-address/wrong-chain
+  /// queries — the caller then prices the token normally.
+  static func nativePricingInstrumentId(
+    chainId: Int?, contractAddress: String?
+  ) -> String? {
+    guard let chainId,
+      let contractAddress,
+      let canonical = canonicalByChain[chainId],
+      contractAddress.lowercased() == canonical
+    else {
+      return nil
+    }
+    return "\(chainId):native"
+  }
+
+  /// Inverse of `nativePricingInstrumentId`: the canonical wrapped-native
+  /// instrument id for a chain (`"<chainId>:<address>"`), or `nil` when
+  /// the chain has no listed wrapper. A wrapped token is priced via the
+  /// chain's native asset but its conversion rate is memoised under the
+  /// *wrapper's* own id, so cache invalidation for the native asset must
+  /// also evict the wrapper — this accessor gives the id to evict.
+  static func canonicalWrappedInstrumentId(forChainId chainId: Int?) -> String? {
+    guard let chainId, let address = canonicalByChain[chainId] else { return nil }
+    return "\(chainId):\(address)"
+  }
+}

--- a/MoolahTests/Backends/GRDB/GRDBForecastRule11Tests.swift
+++ b/MoolahTests/Backends/GRDB/GRDBForecastRule11Tests.swift
@@ -1,0 +1,130 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+/// Rule 11 (`INSTRUMENT_CONVERSION_GUIDE.md`) for the forecast tail:
+/// a per-instance conversion failure during forecast pre-conversion
+/// must NOT abort the whole forecast. Every sibling analysis path
+/// (historic walk, investment values, trades-mode fold, forecast
+/// accumulator) already degrades per-unit; the forecast pre-conversion
+/// step was the one path that rethrew, surfacing on the Analysis page
+/// as a full-screen sync error.
+@Suite("GRDBAnalysisRepository.generateForecast — Rule 11 contract")
+struct GRDBForecastRule11Tests {
+  private func monthlyFrom(_ start: Date, leg: TransactionLeg) -> Transaction {
+    Transaction(
+      date: start,
+      payee: "Recurring",
+      recurPeriod: .month,
+      recurEvery: 1,
+      legs: [leg])
+  }
+
+  /// The regression: a recurring scheduled transaction whose leg can
+  /// never price (no provider mapping) made forecast pre-conversion
+  /// rethrow, escaping all the way to `AnalysisStore` as a full-screen
+  /// error. The fix degrades the failing instances per Rule 11 instead,
+  /// so the call returns normally (the affected forecast days simply
+  /// drop out, exactly like every sibling analysis path).
+  @Test("An unpriceable recurring leg degrades instead of aborting the forecast")
+  func unpriceableInstanceDoesNotAbortForecast() async throws {
+    let aud = Instrument.AUD
+    let unmapped = Instrument.crypto(
+      chainId: 1,
+      contractAddress: "0xabcabcabcabcabcabcabcabcabcabcabcabcabc0",
+      symbol: "ZZZ", name: "Unlisted Token", decimals: 18)
+
+    let start = Calendar.current.date(byAdding: .day, value: -1, to: Date()) ?? Date()
+    let endDate = Calendar.current.date(byAdding: .month, value: 4, to: Date()) ?? Date()
+
+    let failing = monthlyFrom(
+      start,
+      leg: TransactionLeg(
+        accountId: UUID(), instrument: unmapped, quantity: 1, type: .expense))
+
+    let conversion = FailingConversionService(failingInstrumentIds: [unmapped.id])
+    let context = GRDBAnalysisRepository.DailyBalancesAssemblyContext(
+      investmentAccountIds: [],
+      tradesModeInvestmentAccountIds: [],
+      instrumentMap: [unmapped.id: unmapped, aud.id: aud],
+      profileInstrument: aud,
+      conversionService: conversion)
+
+    // Before the fix this threw `FailingConversionError.unavailable`
+    // out of `preConvertForecastInstances`; the contract is that it
+    // returns normally (degraded) instead.
+    let result = try await GRDBAnalysisRepository.generateForecast(
+      scheduled: [failing],
+      startingBook: .empty,
+      endDate: endDate,
+      context: context)
+
+    // Every instance's day is dropped (Rule 11 — never a partial day),
+    // so the result is empty, but crucially the call did NOT throw.
+    #expect(result.isEmpty)
+  }
+
+  @Test("Cooperative cancellation still propagates from forecast pre-conversion")
+  func cancellationStillPropagates() async throws {
+    let aud = Instrument.AUD
+    let token = Instrument.crypto(
+      chainId: 1, contractAddress: "0xabcabcabcabcabcabcabcabcabcabcabcabcabc0",
+      symbol: "ZZZ", name: "Unlisted", decimals: 18)
+    let start = Calendar.current.date(byAdding: .day, value: -1, to: Date()) ?? Date()
+    let endDate = Calendar.current.date(byAdding: .month, value: 2, to: Date()) ?? Date()
+    let failing = monthlyFrom(
+      start,
+      leg: TransactionLeg(accountId: UUID(), instrument: token, quantity: 1, type: .expense))
+    let context = GRDBAnalysisRepository.DailyBalancesAssemblyContext(
+      investmentAccountIds: [],
+      tradesModeInvestmentAccountIds: [],
+      instrumentMap: [token.id: token, aud.id: aud],
+      profileInstrument: aud,
+      conversionService: CancellingConversionService())
+
+    await #expect(throws: CancellationError.self) {
+      _ = try await GRDBAnalysisRepository.generateForecast(
+        scheduled: [failing],
+        startingBook: .empty,
+        endDate: endDate,
+        context: context)
+    }
+  }
+}
+
+/// Conversion service that always reports cooperative cancellation, to
+/// pin the invariant that `CancellationError` is *not* folded into the
+/// per-instance degradation path.
+private actor CancellingConversionService: InstrumentConversionService {
+  func convert(
+    _ quantity: Decimal, from: Instrument, to: Instrument, on date: Date
+  ) async throws -> Decimal {
+    if from.id == to.id { return quantity }
+    throw CancellationError()
+  }
+
+  func convertAmount(
+    _ amount: InstrumentAmount, to instrument: Instrument, on date: Date
+  ) async throws -> InstrumentAmount {
+    guard amount.instrument != instrument else { return amount }
+    throw CancellationError()
+  }
+
+  func convertResult(
+    _ amount: InstrumentAmount, to instrument: Instrument, on date: Date
+  ) async throws -> ConversionResult {
+    guard amount.instrument != instrument else { return .value(amount) }
+    throw CancellationError()
+  }
+
+  func invalidateCache(for instrument: Instrument) async {}
+
+  nonisolated func observeRates() -> AsyncStream<Void> {
+    AsyncStream { $0.finish() }
+  }
+
+  nonisolated func observeErrors() -> AsyncStream<any Error> {
+    AsyncStream { $0.finish() }
+  }
+}

--- a/MoolahTests/Domain/Models/WalletSyncErrorTests.swift
+++ b/MoolahTests/Domain/Models/WalletSyncErrorTests.swift
@@ -67,4 +67,54 @@ struct WalletSyncErrorTests {
     #expect(decoded == original)
     #expect(decoded.kind == .rateLimited(retryAfter: date))
   }
+
+  // MARK: - LocalizedError
+
+  /// Any surface that renders `error.localizedDescription` (e.g.
+  /// `AnalysisView`) must show a human-readable sentence, never the
+  /// `NSError` fallback "Moolah.WalletSyncError error 1" that hid the
+  /// real failure cause on the analysis page.
+  @Test("localizedDescription is human-readable, never the NSError fallback")
+  func localizedDescriptionIsHumanReadable() {
+    let cases: [WalletSyncError] = [
+      WalletSyncError(provider: nil, kind: .missingApiKey),
+      WalletSyncError(provider: .alchemy, kind: .invalidApiKey),
+      WalletSyncError(provider: .coinGecko, kind: .rateLimited(retryAfter: nil)),
+      WalletSyncError(provider: nil, kind: .network(underlyingDescription: "HTTP 500")),
+      WalletSyncError(
+        provider: .coinGecko, kind: .providerMalformedResponse(stage: "dailyPrices")),
+    ]
+    for error in cases {
+      let message = error.localizedDescription
+      #expect(!message.isEmpty)
+      #expect(!message.contains("WalletSyncError"))
+      #expect(!message.contains("error 1"))
+      #expect(!message.contains("couldn’t be completed"))
+    }
+  }
+
+  @Test("errorDescription names the attributed provider and the failure kind")
+  func errorDescriptionNamesProviderAndKind() throws {
+    let rateLimited = WalletSyncError(
+      provider: .coinGecko, kind: .rateLimited(retryAfter: nil))
+    let message = try #require(rateLimited.errorDescription)
+    #expect(message.contains("CoinGecko"))
+
+    let network = WalletSyncError(
+      provider: nil, kind: .network(underlyingDescription: "HTTP 503"))
+    let networkMessage = try #require(network.errorDescription)
+    #expect(networkMessage.contains("HTTP 503"))
+  }
+
+  @Test("rateLimited renders a deterministic relative retry time via injected now")
+  func rateLimitedRelativeTimeIsDeterministic() {
+    let now = Date(timeIntervalSince1970: 1_700_000_000)
+    let retryAfter = now.addingTimeInterval(3600)
+    let error = WalletSyncError(
+      provider: .coinGecko, kind: .rateLimited(retryAfter: retryAfter))
+    let message = error.description(now: now)
+    #expect(message.contains("CoinGecko"))
+    #expect(message.contains("1 hr") || message.contains("1 hour"))
+    #expect(!message.contains("WalletSyncError"))
+  }
 }

--- a/MoolahTests/Domain/Models/WrappedNativeContractsTests.swift
+++ b/MoolahTests/Domain/Models/WrappedNativeContractsTests.swift
@@ -1,0 +1,71 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+/// The wrapped-native trust list must match ONLY on an exact
+/// `(chainId, contractAddress)` pair — never on symbol/name. A token
+/// that merely calls itself "WETH" must not be treated as 1:1
+/// redeemable for the chain's native asset (it could be a malicious
+/// look-alike that never returns the ETH).
+@Suite("WrappedNativeContracts")
+struct WrappedNativeContractsTests {
+  @Test("Canonical Ethereum WETH resolves to the chain's native id")
+  func canonicalWethEthereum() {
+    let id = WrappedNativeContracts.nativePricingInstrumentId(
+      chainId: 1, contractAddress: "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2")
+    #expect(id == "1:native")
+  }
+
+  @Test("Address match is case-insensitive (checksummed input)")
+  func checksummedAddressStillMatches() {
+    let id = WrappedNativeContracts.nativePricingInstrumentId(
+      chainId: 1, contractAddress: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2")
+    #expect(id == "1:native")
+  }
+
+  @Test("Canonical Polygon WMATIC resolves to Polygon native id")
+  func canonicalWmaticPolygon() {
+    let id = WrappedNativeContracts.nativePricingInstrumentId(
+      chainId: 137, contractAddress: "0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270")
+    #expect(id == "137:native")
+  }
+
+  @Test("A non-canonical address on a known chain does NOT match (anti-spoof)")
+  func lookAlikeContractRejected() {
+    let id = WrappedNativeContracts.nativePricingInstrumentId(
+      chainId: 1, contractAddress: "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
+    #expect(id == nil)
+  }
+
+  @Test("Right address but wrong chain does NOT match")
+  func addressOnWrongChainRejected() {
+    // Ethereum WETH address queried as if on Polygon — not the
+    // canonical Polygon wrapped-native, so no 1:1 native guarantee.
+    let id = WrappedNativeContracts.nativePricingInstrumentId(
+      chainId: 137, contractAddress: "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2")
+    #expect(id == nil)
+  }
+
+  @Test("Native instruments (no contract address) are not remapped")
+  func nativeIsNotRemapped() {
+    #expect(
+      WrappedNativeContracts.nativePricingInstrumentId(chainId: 1, contractAddress: nil) == nil)
+  }
+
+  @Test("Inverse accessor yields the canonical wrapper id for cache eviction")
+  func inverseAccessorForKnownChain() {
+    #expect(
+      WrappedNativeContracts.canonicalWrappedInstrumentId(forChainId: 1)
+        == "1:0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2")
+    #expect(
+      WrappedNativeContracts.canonicalWrappedInstrumentId(forChainId: 137)
+        == "137:0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270")
+  }
+
+  @Test("Inverse accessor is nil for chains with no listed wrapper")
+  func inverseAccessorForUnknownChain() {
+    #expect(WrappedNativeContracts.canonicalWrappedInstrumentId(forChainId: 999) == nil)
+    #expect(WrappedNativeContracts.canonicalWrappedInstrumentId(forChainId: nil) == nil)
+  }
+}

--- a/MoolahTests/Shared/WrappedNativeConversionTests.swift
+++ b/MoolahTests/Shared/WrappedNativeConversionTests.swift
@@ -1,0 +1,136 @@
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+/// Wrapped-native (WETH/WMATIC/…) pricing: a canonical wrapped-native
+/// contract has no price feed of its own but is 1:1 redeemable for the
+/// chain's native asset, so it must price via the native registration.
+/// A spoofed look-alike contract must NOT inherit that price.
+///
+/// Split into its own suite (rather than living in
+/// `InstrumentConversionServiceCryptoTests`) so neither type exceeds
+/// the body-length budget — the wrapped-native rule is a self-contained
+/// concern with its own harness.
+@Suite("InstrumentConversionService — Wrapped-native")
+struct WrappedNativeConversionTests {
+  private let usd = Instrument.USD
+
+  private func date(_ string: String) throws -> Date {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withFullDate]
+    return try #require(
+      formatter.date(from: string),
+      "Could not parse ISO8601 full-date string: \(string)")
+  }
+
+  /// Minimal `FullConversionService` wired with a fixed crypto price
+  /// feed and a registration set. No exchange-rate client is needed —
+  /// both tests convert to USD.
+  private func makeService(
+    cryptoPrices: [String: [String: Decimal]],
+    providerMappings: [CryptoProviderMapping]
+  ) throws -> FullConversionService {
+    let database = try ProfileIndexDatabase.openInMemory()
+    let cryptoService = CryptoPriceService(
+      clients: [FixedCryptoPriceClient(prices: cryptoPrices)],
+      database: database)
+    let exchangeService = ExchangeRateService(
+      client: FixedRateClient(rates: [:]), database: database)
+    let stockService = StockPriceService(
+      client: FixedStockPriceClient(), database: database)
+    let registrations = providerMappings.map { mapping in
+      CryptoRegistration(
+        instrument: Self.instrument(forMappingId: mapping.instrumentId),
+        mapping: mapping)
+    }
+    return FullConversionService(
+      exchangeRates: exchangeService,
+      stockPrices: stockService,
+      cryptoPrices: cryptoService,
+      cryptoRegistrations: { registrations })
+  }
+
+  private static func instrument(forMappingId id: String) -> Instrument {
+    let parts = id.split(separator: ":", maxSplits: 1).map(String.init)
+    let chainId = Int(parts.first ?? "") ?? 0
+    let contract = parts.count > 1 ? parts[1] : "native"
+    let isNative = contract == "native"
+    return .crypto(
+      chainId: chainId,
+      contractAddress: isNative ? nil : contract,
+      symbol: isNative ? "NATIVE" : contract,
+      name: isNative ? "NATIVE" : contract,
+      decimals: 18)
+  }
+
+  private func nativeEthRegistration() -> CryptoProviderMapping {
+    CryptoProviderMapping(
+      instrumentId: "1:native", coingeckoId: "ethereum",
+      cryptocompareSymbol: "ETH", binanceSymbol: "ETHUSDT")
+  }
+
+  /// Canonical Ethereum WETH has no price feed of its own but is 1:1
+  /// redeemable for ETH, so it must price via the `1:native`
+  /// registration. Regression: previously this failed with a
+  /// `noProviderMapping`-wrapped sync error and broke the Analysis page.
+  @Test("Canonical WETH prices via the native ETH registration")
+  func canonicalWrappedEthPricesAsNative() async throws {
+    let weth = Instrument.crypto(
+      chainId: 1,
+      contractAddress: "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+      symbol: "WETH", name: "Wrapped Ether", decimals: 18)
+    let service = try makeService(
+      cryptoPrices: ["1:native": ["2026-04-10": dec("1623.45")]],
+      // NOTE: no mapping registered for the WETH contract id itself.
+      providerMappings: [nativeEthRegistration()])
+    let result = try await service.convert(
+      dec("2"), from: weth, to: usd, on: try date("2026-04-10"))
+    #expect(result == dec("2") * dec("1623.45"))
+  }
+
+  /// A non-canonical contract that merely calls itself "WETH" must NOT
+  /// inherit ETH's price — it could be a malicious look-alike. With no
+  /// registration of its own it fails to price (anti-spoof).
+  @Test("A look-alike WETH contract is not priced as native")
+  func lookAlikeWrappedEthIsNotPricedAsNative() async throws {
+    let fakeWeth = Instrument.crypto(
+      chainId: 1,
+      contractAddress: "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+      symbol: "WETH", name: "Wrapped Ether", decimals: 18)
+    let service = try makeService(
+      cryptoPrices: ["1:native": ["2026-04-10": dec("1623.45")]],
+      providerMappings: [nativeEthRegistration()])
+    await #expect(throws: (any Error).self) {
+      _ = try await service.convert(
+        dec("2"), from: fakeWeth, to: usd, on: try date("2026-04-10"))
+    }
+  }
+
+  /// A wrapped-native rate is memoised under the *wrapper's* id, but the
+  /// price comes from the native asset. Invalidating the native asset
+  /// must therefore also evict the wrapper's cached factor — otherwise
+  /// WETH keeps converting at the pre-update ETH rate.
+  @Test("invalidateCache(for: native) evicts the wrapped-native cached rate")
+  func invalidateCacheForNativeEvictsWrappedEntry() async throws {
+    let weth = Instrument.crypto(
+      chainId: 1,
+      contractAddress: "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+      symbol: "WETH", name: "Wrapped Ether", decimals: 18)
+    let ethNative = Instrument.crypto(
+      chainId: 1, contractAddress: nil, symbol: "ETH", name: "Ethereum", decimals: 18)
+    let service = try makeService(
+      cryptoPrices: ["1:native": ["2026-04-10": dec("1623.45")]],
+      providerMappings: [nativeEthRegistration()])
+
+    _ = try await service.convert(
+      dec("1"), from: weth, to: usd, on: try date("2026-04-10"))
+    let warmedCount = await service.cachedRateCountForTesting
+    #expect(warmedCount == 1)
+
+    await service.invalidateCache(for: ethNative)
+    let evictedCount = await service.cachedRateCountForTesting
+    #expect(evictedCount == 0)
+  }
+}

--- a/Shared/FullConversionService.swift
+++ b/Shared/FullConversionService.swift
@@ -248,8 +248,19 @@ actor FullConversionService: InstrumentConversionService {
   /// rows in `CryptoPriceService` — required after any user mutation
   /// that changes `pricingStatus` for the instrument's registration.
   func invalidateCache(for instrument: Instrument) async {
+    var staleIds: Set<String> = [instrument.id]
+    // A wrapped-native token is priced via its chain's native asset but
+    // its unit rate is memoised under the wrapper's own id, so
+    // invalidating the native asset must also evict the wrapper —
+    // otherwise WETH keeps converting at the pre-update ETH rate.
+    if instrument.kind == .cryptoToken, instrument.contractAddress == nil,
+      let wrapperId = WrappedNativeContracts.canonicalWrappedInstrumentId(
+        forChainId: instrument.chainId)
+    {
+      staleIds.insert(wrapperId)
+    }
     rateCache = rateCache.filter { key, _ in
-      key.fromId != instrument.id && key.toId != instrument.id
+      !staleIds.contains(key.fromId) && !staleIds.contains(key.toId)
     }
     guard instrument.kind == .cryptoToken, let cryptoPrices else { return }
     await cryptoPrices.purgeCache(instrumentId: instrument.id)
@@ -321,7 +332,16 @@ actor FullConversionService: InstrumentConversionService {
       throw ConversionError.noCryptoPriceService
     }
     let registrations = try await cryptoRegistrations()
-    guard let registration = registrations.first(where: { $0.id == instrument.id }) else {
+    // Canonical wrapped-native tokens (WETH, WMATIC, …) have no price
+    // feed of their own but are 1:1 redeemable for the chain's native
+    // asset, so price them via the native registration. The match is an
+    // exact `(chainId, contractAddress)` trust-list lookup — never by
+    // symbol — so a spoofed look-alike cannot inherit the native price.
+    let lookupId =
+      WrappedNativeContracts.nativePricingInstrumentId(
+        chainId: instrument.chainId, contractAddress: instrument.contractAddress)
+      ?? instrument.id
+    guard let registration = registrations.first(where: { $0.id == lookupId }) else {
       throw ConversionError.noProviderMapping(instrumentId: instrument.id)
     }
     return try await cryptoPrices.price(


### PR DESCRIPTION
## Problem

The Analysis page failed **consistently** with `Moolah.WalletSyncError error 1` in the Large Test Profile (and any profile holding WETH). Reported by the user, who correctly noted their Alchemy key is valid — Alchemy is **not** used for crypto prices, so the key was a red herring.

## Root cause (evidence-gathered from the running app)

`PositionBook conversion failed: 0.0000001 1:0xc02aaa39…756cc2 → AUD … noProviderMapping(provider: "Binance")`

- The profile holds a dust **WETH** (Wrapped Ether, Ethereum mainnet) position. WETH has **no CoinGecko/CryptoCompare/Binance price mapping**, so it can never price.
- The historic chart path degrades that per-day (Rule 11), but the **forecast pre-conversion path rethrew** it → `AnalysisStore.error` → full-screen error.
- `WalletSyncError` had no `LocalizedError`, so it rendered as the opaque `NSError` bridge string — which actively hid the real failure kind.

## Fix (three defects + review hardening)

1. **Display** — `WalletSyncError: LocalizedError` with an account-neutral, provider-aware message. The account-aware caption stays in `SyncedAccountHeaderLogic`.
2. **Root cause** — `WrappedNativeContracts`: a curated trust list keyed on the exact `(chainId, contractAddress)` pair (**never** symbol/name — a spoofed look-alike must not inherit ETH's price). Canonical wrapped-native tokens price as their chain's native asset via the existing native registration.
3. **Containment** — forecast pre-conversion now degrades a per-instance failure per Rule 11 (pass-through unconverted + log; the existing per-day catch drops the day) instead of aborting the whole page. Cancellation still propagates.
4. **Cache correctness** (from instrument-conversion review) — invalidating a native asset's price now also evicts the wrapped-native cache entries derived from it.

## Verification

- End-to-end in the Large Test Profile: **0** `WalletSyncError`, **0** analysis-load failures, WETH converts via ETH (101 conversions, 0 failures).
- New tests: trust-list (incl. anti-spoof + wrong-chain), WETH-prices-as-native + look-alike-rejected conversion tests, forecast Rule 11 degradation + cancellation-propagation, deterministic rate-limited message, native→wrapper cache eviction.
- `code-review`, `concurrency-review`, `instrument-conversion-review` run; all findings applied (the one place a suggested fix would introduce a silent-wrong-number risk is documented in-code instead).
- Full conversion/analysis regression: 74 tests / 11 suites green. `just format-check` clean; no `.swiftlint.yml`/baseline changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)