### PR TITLE
fix(conversion): friendlier running-balance error + don't blame Binance for stablecoin mapping gaps

### DIFF
--- a/Domain/Models/RunningBalanceResult.swift
+++ b/Domain/Models/RunningBalanceResult.swift
@@ -15,14 +15,23 @@ struct RunningBalanceResult: Sendable {
 /// A typed, Sendable wrapper around the first conversion error encountered
 /// during running-balance computation. Carries the failing transaction id so
 /// diagnostics can correlate logs with the surfaced user-visible error.
+///
+/// `errorDescription` is the user-facing copy and stays free of the raw
+/// `underlyingDescription` — the provider's raw text leaks Swift enum
+/// case names, contract addresses and provider identifiers that are
+/// noise to the user (and often misleadingly attribute the failure,
+/// e.g. blaming Binance for a stablecoin it can't trade).
+/// `underlyingDescription` remains a stored property so the diagnostic
+/// logger in `TransactionStore+Observation` can record the full provider
+/// detail without it ever reaching the alert.
 struct RunningBalanceConversionError: LocalizedError, Sendable {
   let transactionId: UUID
   let targetInstrumentId: String
   let underlyingDescription: String
 
   var errorDescription: String? {
-    "Unable to convert a transaction to \(targetInstrumentId). The running balance is "
-      + "unavailable until the rate source recovers. (\(underlyingDescription))"
+    "Couldn't update the running balance in \(targetInstrumentId). "
+      + "A price source is temporarily unavailable — try again in a moment."
   }
 }
 

--- a/MoolahTests/Domain/RunningBalanceConversionErrorTests.swift
+++ b/MoolahTests/Domain/RunningBalanceConversionErrorTests.swift
@@ -1,0 +1,54 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+/// `RunningBalanceConversionError.errorDescription` is surfaced verbatim
+/// through `Error.userMessage` into the running-balance error banner, so
+/// it must be user-readable. It must NOT leak the raw underlying error
+/// description (Swift enum names, contract addresses, provider names
+/// from the price provider's internal failure surface), but it MUST
+/// name the target instrument so the user understands which conversion
+/// is unavailable.
+@Suite("RunningBalanceConversionError user-facing text")
+struct RunningBalanceConversionErrorTests {
+  private let realisticUnderlying =
+    "noProviderMapping(tokenId: \"1:0xdac17f958d2ee523a2206206994597c13d831ec7\", "
+    + "provider: \"Binance\")"
+
+  @Test
+  func errorDescriptionDoesNotLeakUnderlyingDetail() throws {
+    let error = RunningBalanceConversionError(
+      transactionId: UUID(),
+      targetInstrumentId: "AUD",
+      underlyingDescription: realisticUnderlying)
+    let text = try #require(error.errorDescription)
+    #expect(!text.contains("noProviderMapping"))
+    #expect(!text.contains("Binance"))
+    #expect(!text.contains("0xdac17"))
+    #expect(!text.contains("tokenId"))
+  }
+
+  @Test
+  func errorDescriptionNamesTargetInstrument() throws {
+    let error = RunningBalanceConversionError(
+      transactionId: UUID(),
+      targetInstrumentId: "AUD",
+      underlyingDescription: realisticUnderlying)
+    let text = try #require(error.errorDescription)
+    #expect(text.contains("AUD"))
+  }
+
+  /// `underlyingDescription` is still useful for log diagnostics —
+  /// `TransactionStore+Observation` logs the full text at `.error` so
+  /// support can see provider details — so keep it as a stored property
+  /// even though we no longer interpolate it into `errorDescription`.
+  @Test
+  func underlyingDescriptionRemainsAccessibleForLogging() {
+    let error = RunningBalanceConversionError(
+      transactionId: UUID(),
+      targetInstrumentId: "AUD",
+      underlyingDescription: realisticUnderlying)
+    #expect(error.underlyingDescription == realisticUnderlying)
+  }
+}

--- a/MoolahTests/Shared/CryptoPriceServiceAttributionTests.swift
+++ b/MoolahTests/Shared/CryptoPriceServiceAttributionTests.swift
@@ -71,4 +71,69 @@ struct CryptoPriceServiceAttributionTests {
       Issue.record("Expected WalletSyncError, got \(error)")
     }
   }
+
+  /// `noProviderMapping` is a routing decision (the client has no
+  /// symbol for the token), not a runtime failure — USDT, for instance,
+  /// has no USDT/USDT pair on Binance, so the Binance leg ALWAYS throws
+  /// `noProviderMapping` even when the network is healthy. Attribution
+  /// must fall to a real failure (here, CoinGecko's network error), not
+  /// to the trailing `noProviderMapping`-only leg.
+  @Test("noProviderMapping is not surfaced as a provider failure for price(...)")
+  func singlePriceSkipsNoProviderMappingAttribution() async throws {
+    let frozen = try date("2024-02-01")
+    let database = try ProfileIndexDatabase.openInMemory()
+    let noMapping: any Error = CryptoPriceError.noProviderMapping(
+      tokenId: ethMapping.instrumentId, provider: "Binance")
+    let clients: [CryptoPriceClient] = [
+      FixedCryptoPriceClient(shouldFail: true, syncProvider: .coinGecko),
+      FixedCryptoPriceClient(
+        shouldFail: true, failureError: noMapping, syncProvider: .cryptoCompare),
+      FixedCryptoPriceClient(
+        shouldFail: true, failureError: noMapping, syncProvider: .binance),
+    ]
+    let svc = CryptoPriceService(
+      clients: clients, database: database, resolutionClient: nil, now: { frozen })
+    do {
+      _ = try await svc.price(
+        for: ethInstrument, mapping: ethMapping, on: try date("2024-01-15"))
+      Issue.record("Expected a thrown error, got a value")
+    } catch let error as WalletSyncError {
+      #expect(error.provider == .coinGecko)
+      if case .network(let underlying) = error.kind {
+        #expect(!underlying.contains("noProviderMapping"))
+      }
+    } catch {
+      Issue.record("Expected WalletSyncError, got \(error)")
+    }
+  }
+
+  @Test("noProviderMapping is not surfaced as a provider failure for prices(in:)")
+  func rangePricesSkipsNoProviderMappingAttribution() async throws {
+    let frozen = try date("2024-02-01")
+    let database = try ProfileIndexDatabase.openInMemory()
+    let noMapping: any Error = CryptoPriceError.noProviderMapping(
+      tokenId: ethMapping.instrumentId, provider: "Binance")
+    let clients: [CryptoPriceClient] = [
+      FixedCryptoPriceClient(shouldFail: true, syncProvider: .coinGecko),
+      FixedCryptoPriceClient(
+        shouldFail: true, failureError: noMapping, syncProvider: .cryptoCompare),
+      FixedCryptoPriceClient(
+        shouldFail: true, failureError: noMapping, syncProvider: .binance),
+    ]
+    let svc = CryptoPriceService(
+      clients: clients, database: database, resolutionClient: nil, now: { frozen })
+    do {
+      _ = try await svc.prices(
+        for: ethInstrument, mapping: ethMapping,
+        in: try date("2024-01-10")...(try date("2024-01-20")))
+      Issue.record("Expected a thrown error, got a value")
+    } catch let error as WalletSyncError {
+      #expect(error.provider == .coinGecko)
+      if case .network(let underlying) = error.kind {
+        #expect(!underlying.contains("noProviderMapping"))
+      }
+    } catch {
+      Issue.record("Expected WalletSyncError, got \(error)")
+    }
+  }
 }

--- a/MoolahTests/Support/FixedCryptoPriceClient.swift
+++ b/MoolahTests/Support/FixedCryptoPriceClient.swift
@@ -11,6 +11,13 @@ struct FixedCryptoPriceClient: CryptoPriceClient, Sendable {
   /// If true, throws on any fetch call (simulates network failure).
   let shouldFail: Bool
 
+  /// Specific error to throw when `shouldFail` is true. Defaults to a
+  /// network error so existing tests retain their behaviour; provider-
+  /// attribution tests pass `CryptoPriceError.noProviderMapping` to model
+  /// a client that legitimately has no symbol for the token (e.g. USDT
+  /// on Binance).
+  let failureError: any Error
+
   /// Provider identity this stub reports — lets attribution tests order
   /// stubs so a known provider is last in the fallback chain.
   let syncProvider: SyncProvider
@@ -18,15 +25,17 @@ struct FixedCryptoPriceClient: CryptoPriceClient, Sendable {
   init(
     prices: [String: [String: Decimal]] = [:],
     shouldFail: Bool = false,
+    failureError: (any Error)? = nil,
     syncProvider: SyncProvider = .coinGecko
   ) {
     self.prices = prices
     self.shouldFail = shouldFail
+    self.failureError = failureError ?? URLError(.notConnectedToInternet)
     self.syncProvider = syncProvider
   }
 
   func dailyPrice(for mapping: CryptoProviderMapping, on date: Date) async throws -> Decimal {
-    if shouldFail { throw URLError(.notConnectedToInternet) }
+    if shouldFail { throw failureError }
     let dateString = Self.dateFormatter.string(from: date)
     guard let price = prices[mapping.instrumentId]?[dateString] else {
       throw CryptoPriceError.noPriceAvailable(tokenId: mapping.instrumentId, date: dateString)
@@ -37,7 +46,7 @@ struct FixedCryptoPriceClient: CryptoPriceClient, Sendable {
   func dailyPrices(
     for mapping: CryptoProviderMapping, in range: ClosedRange<Date>
   ) async throws -> [String: Decimal] {
-    if shouldFail { throw URLError(.notConnectedToInternet) }
+    if shouldFail { throw failureError }
     guard let tokenPrices = prices[mapping.instrumentId] else { return [:] }
 
     let calendar = Calendar(identifier: .gregorian)
@@ -55,7 +64,7 @@ struct FixedCryptoPriceClient: CryptoPriceClient, Sendable {
   }
 
   func currentPrices(for mappings: [CryptoProviderMapping]) async throws -> [String: Decimal] {
-    if shouldFail { throw URLError(.notConnectedToInternet) }
+    if shouldFail { throw failureError }
     var result: [String: Decimal] = [:]
     for mapping in mappings {
       if let tokenPrices = prices[mapping.instrumentId],

--- a/Shared/CryptoPriceService+FetchRange.swift
+++ b/Shared/CryptoPriceService+FetchRange.swift
@@ -2,9 +2,64 @@
 
 import Foundation
 
-// MARK: - CryptoPriceService range-fetch fallback
+// MARK: - CryptoPriceService provider fallback
 
 extension CryptoPriceService {
+  /// Runs the provider fallback chain
+  /// (CoinGecko → CryptoCompare → Binance) for the date enclosed by
+  /// `dateString`, persists any new prices, and returns the requested
+  /// day's value (or the prior-trading-day fallback). Throws a
+  /// `WalletSyncError` attributed to the most recent *real* provider
+  /// failure when no provider could fill the date — `noProviderMapping`
+  /// errors are routing decisions (e.g. USDT has no Binance pair), not
+  /// runtime failures, so they never become the attribution.
+  func fetchAndExtendCache(
+    instrument: Instrument,
+    mapping: CryptoProviderMapping,
+    fetchInterval: ClosedRange<Date>,
+    dateString: String
+  ) async throws -> Decimal {
+    let tokenId = instrument.id
+    let symbol = instrument.ticker ?? instrument.name
+    var lastError: (any Error)?
+    var lastProvider: SyncProvider?
+    for client in clients {
+      do {
+        let fetched = try await client.dailyPrices(for: mapping, in: fetchInterval)
+        if !fetched.isEmpty {
+          let delta = mergeReturningDelta(
+            tokenId: tokenId, symbol: symbol, newPrices: fetched)
+          if !delta.isEmpty {
+            try await persistDelta(tokenId: tokenId, deltaRecords: delta)
+          }
+          if let price = lookupPrice(tokenId: tokenId, dateString: dateString) {
+            return price
+          }
+        }
+      } catch CryptoPriceError.noProviderMapping {
+        // Routing decision — this client has no symbol for the token
+        // (e.g. USDT on Binance). Skip silently rather than attributing
+        // a non-existent outage to a provider that's behaving as designed.
+        continue
+      } catch {
+        lastError = error
+        lastProvider = client.syncProvider
+        continue
+      }
+    }
+    if let fallback = fallbackPrice(tokenId: tokenId, dateString: dateString) {
+      return fallback
+    }
+    let underlyingDescription =
+      lastError.map { String(describing: $0) }
+      ?? String(
+        describing: CryptoPriceError.noPriceAvailable(
+          tokenId: tokenId, date: dateString))
+    throw WalletSyncError(
+      provider: lastProvider,
+      kind: .network(underlyingDescription: underlyingDescription))
+  }
+
   /// Runs the provider fallback chain
   /// (CoinGecko → CryptoCompare → Binance) for a date range, tolerating
   /// per-provider failures and only throwing when every client errored.
@@ -19,7 +74,6 @@ extension CryptoPriceService {
     var lastError: (any Error)?
     var lastProvider: SyncProvider?
     for client in clients {
-      lastProvider = client.syncProvider
       do {
         let fetched = try await client.dailyPrices(for: mapping, in: from...to)
         if !fetched.isEmpty {
@@ -30,8 +84,14 @@ extension CryptoPriceService {
           }
           return
         }
+      } catch CryptoPriceError.noProviderMapping {
+        // Routing decision — this client has no symbol for the token
+        // (e.g. USDT on Binance). Skip silently rather than attributing
+        // a non-existent outage to a provider that's behaving as designed.
+        continue
       } catch {
         lastError = error
+        lastProvider = client.syncProvider
         continue
       }
     }

--- a/Shared/CryptoPriceService.swift
+++ b/Shared/CryptoPriceService.swift
@@ -138,43 +138,13 @@ actor CryptoPriceService {
     // each provider in order. Continues past providers that return
     // empty so a fallback chain (CoinGecko → CryptoCompare → Binance)
     // can collectively fill in the dates one of them has.
-    let symbol = instrument.ticker ?? instrument.name
     let fetchInterval = extensionWindow(
       for: tokenId, requestedDate: date, dateString: dateString)
-    var lastError: (any Error)?
-    var lastProvider: SyncProvider?
-    for client in clients {
-      lastProvider = client.syncProvider
-      do {
-        let fetched = try await client.dailyPrices(for: mapping, in: fetchInterval)
-        if !fetched.isEmpty {
-          let delta = mergeReturningDelta(
-            tokenId: tokenId, symbol: symbol, newPrices: fetched)
-          if !delta.isEmpty {
-            try await persistDelta(tokenId: tokenId, deltaRecords: delta)
-          }
-          if let price = lookupPrice(tokenId: tokenId, dateString: dateString) {
-            return price
-          }
-        }
-      } catch {
-        lastError = error
-        continue
-      }
-    }
-
-    if let fallback = fallbackPrice(tokenId: tokenId, dateString: dateString) {
-      return fallback
-    }
-
-    let underlyingDescription =
-      lastError.map { String(describing: $0) }
-      ?? String(
-        describing: CryptoPriceError.noPriceAvailable(
-          tokenId: tokenId, date: dateString))
-    throw WalletSyncError(
-      provider: lastProvider,
-      kind: .network(underlyingDescription: underlyingDescription))
+    return try await fetchAndExtendCache(
+      instrument: instrument,
+      mapping: mapping,
+      fetchInterval: fetchInterval,
+      dateString: dateString)
   }
 
   /// Resolves the request from the in-memory cache when the requested
@@ -349,12 +319,15 @@ actor CryptoPriceService {
 // MARK: - Cache lookup & merge
 
 extension CryptoPriceService {
-  private func lookupPrice(tokenId: String, dateString: String) -> Decimal? {
+  /// Internal (not private) so `fetchAndExtendCache` in
+  /// `CryptoPriceService+FetchRange.swift` can call it from the sibling
+  /// extension — same actor isolation, just different file.
+  func lookupPrice(tokenId: String, dateString: String) -> Decimal? {
     guard let key = DateKey.from(isoString: dateString) else { return nil }
     return caches[tokenId]?.prices.exact(key)
   }
 
-  private func fallbackPrice(tokenId: String, dateString: String) -> Decimal? {
+  func fallbackPrice(tokenId: String, dateString: String) -> Decimal? {
     guard let key = DateKey.from(isoString: dateString),
       let cache = caches[tokenId]
     else { return nil }
@@ -373,8 +346,9 @@ extension CryptoPriceService {
     return dates
   }
 
-  // `fetchRange(instrument:mapping:from:to:)` lives in
-  // `CryptoPriceService+FetchRange.swift`, `mergeReturningDelta` lives in
-  // `CryptoPriceService+Merge.swift`, and `NoOpTokenResolutionClient`
+  // `fetchAndExtendCache(instrument:mapping:fetchInterval:dateString:)`
+  // and `fetchRange(instrument:mapping:from:to:)` live in
+  // `CryptoPriceService+FetchRange.swift`, `mergeReturningDelta` lives
+  // in `CryptoPriceService+Merge.swift`, and `NoOpTokenResolutionClient`
   // lives in its own sibling file.
 }


### PR DESCRIPTION
## Summary

- The running-balance banner used to surface raw provider internals — e.g.
  `Binance network error: noProviderMapping(tokenId: "1:0xdac17...", provider: "Binance")` — after importing a USDT transaction.
- `CryptoPriceError.noProviderMapping` is a routing decision (USDT genuinely has no USDT/USDT pair on Binance), not a runtime outage. The `CryptoPriceService.price(...)` / `fetchRange(...)` fallback loops now catch it separately and skip silently, so attribution falls to the most recent *real* provider error rather than the trailing-by-design Binance leg.
- `RunningBalanceConversionError.errorDescription` no longer interpolates the underlying description into the alert. The stored `underlyingDescription` field stays so `TransactionStore+Observation` can keep logging the full provider detail for diagnostics.
- Extracted `fetchAndExtendCache` into the `CryptoPriceService+FetchRange.swift` sibling to keep the main file under SwiftLint's `file_length` cap; bumped `lookupPrice` / `fallbackPrice` from `private` to actor-isolated internal so the sibling extension can call them.

This is the UX/attribution half of the issue. A separate dig into why USDT is missing from the discovered tokens list (a registration / resolver bug in the Coinstash import path) is in progress.

## Test plan

- [x] `just test-mac` — 3154 tests, 0 failures.
- [x] `just format-check` — clean.
- [x] New tests for the noProviderMapping attribution skip in `CryptoPriceServiceAttributionTests` (price + range).
- [x] New tests pinning the user-facing copy of `RunningBalanceConversionError` (no leak of provider names, contract addresses, or enum case names; target instrument still named).

🤖 Generated with [Claude Code](https://claude.com/claude-code)