### PR TITLE
fix(coinstash): show in Recently Added; detect transfers in historical syncs

### DIFF
--- a/App/ProfileSession+CryptoSync.swift
+++ b/App/ProfileSession+CryptoSync.swift
@@ -139,6 +139,21 @@ extension ProfileSession {
   ) -> CoinstashSyncSource {
     let coinstashClient = CoinstashClient()
     let txRepo = backend.transactions
+    // Per-account-pass origin. Mirrors the wallet factory in
+    // `makeWalletSyncEngine` so Coinstash imports show up in
+    // `RecentlyAddedView` (which short-circuits on a nil `singleOrigin`)
+    // and group as one import session. Explicitly `@Sendable` for parity
+    // with the wallet site — keeps the Sendable constraint visible at
+    // the binding so a future captured variable trips the compiler
+    // rather than silently losing the guarantee.
+    let importOriginFactory: @Sendable (UUID) -> ImportOrigin = { accountId in
+      ImportOrigin(
+        rawDescription: "exchange:\(accountId.uuidString)",
+        rawAmount: 0,
+        importedAt: Date(),
+        importSessionId: UUID(),
+        parserIdentifier: "coinstash")
+    }
     return CoinstashSyncSource(
       tokenStore: ExchangeTokenStore(synchronizable: true),
       client: coinstashClient,
@@ -157,7 +172,8 @@ extension ProfileSession {
               throw error
             }
           }),
-        discovery: discovery),
+        discovery: discovery,
+        importOriginFactory: importOriginFactory),
       metadataResolverFactory: { token in
         CoinstashAssetMetadataResolver(client: coinstashClient, token: token)
       })

--- a/Features/Sync/SyncedAccountStore+Internals.swift
+++ b/Features/Sync/SyncedAccountStore+Internals.swift
@@ -309,8 +309,16 @@ extension SyncedAccountStore {
       return
     }
     let eligible = genuinelyNew.filter { $0.transferDetectionValueLeg != nil }
-    guard !eligible.isEmpty else { return }
-    let windowLowerBound = clock().addingTimeInterval(-FuzzyTransferDetector.windowSeconds)
+    // Anchor on the earliest eligible transaction's `date` (the trade /
+    // transfer date), not `clock()` — a bulk historical exchange import
+    // produces survivors dated months or years in the past, and a
+    // wall-clock floor would drop every peer candidate before the
+    // detector ever saw them. Same pattern as `ImportStore.ingest`.
+    guard let earliest = eligible.min(by: { $0.date < $1.date }) else {
+      return
+    }
+    let windowLowerBound = earliest.date.addingTimeInterval(
+      -FuzzyTransferDetector.windowSeconds)
     await transferDetection.runDetection(
       newlyImported: eligible,
       participatingAccountIds: participatingAccountIds,

--- a/MoolahTests/Features/Sync/SyncedAccountStoreExchangeTests.swift
+++ b/MoolahTests/Features/Sync/SyncedAccountStoreExchangeTests.swift
@@ -113,7 +113,15 @@ struct SyncedAccountStoreExchangeTests {
           resolver: ExchangeInstrumentResolver(
             registry: registry, fiatInstrument: .AUD,
             existingLegInstrumentIds: { [] }),
-          discovery: discovery),
+          discovery: discovery,
+          importOriginFactory: { accountId in
+            ImportOrigin(
+              rawDescription: "exchange:\(accountId.uuidString)",
+              rawAmount: 0,
+              importedAt: Self.pinnedNow,
+              importSessionId: UUID(),
+              parserIdentifier: "coinstash")
+          }),
         metadataResolverFactory: { _ in metadataResolver }))
     return account
   }

--- a/MoolahTests/Features/Sync/SyncedAccountStoreGlobalErrorTests.swift
+++ b/MoolahTests/Features/Sync/SyncedAccountStoreGlobalErrorTests.swift
@@ -243,7 +243,15 @@ struct SyncedAccountStoreGlobalErrorTests {
           resolver: ExchangeInstrumentResolver(
             registry: registry, fiatInstrument: .AUD,
             existingLegInstrumentIds: { [] }),
-          discovery: discovery),
+          discovery: discovery,
+          importOriginFactory: { accountId in
+            ImportOrigin(
+              rawDescription: "exchange:\(accountId.uuidString)",
+              rawAmount: 0,
+              importedAt: Self.pinnedNow,
+              importSessionId: UUID(),
+              parserIdentifier: "coinstash")
+          }),
         metadataResolverFactory: { _ in StubMetadataResolver([:]) }))
     return account
   }

--- a/MoolahTests/Features/Sync/SyncedAccountStoreTransferDetectionTests.swift
+++ b/MoolahTests/Features/Sync/SyncedAccountStoreTransferDetectionTests.swift
@@ -113,7 +113,15 @@ struct SyncedAccountStoreTransferDetectionTests {
           resolver: ExchangeInstrumentResolver(
             registry: registry, fiatInstrument: .AUD,
             existingLegInstrumentIds: { [] }),
-          discovery: discovery),
+          discovery: discovery,
+          importOriginFactory: { accountId in
+            ImportOrigin(
+              rawDescription: "exchange:\(accountId.uuidString)",
+              rawAmount: 0,
+              importedAt: Self.pinnedNow,
+              importSessionId: UUID(),
+              parserIdentifier: "coinstash")
+          }),
         metadataResolverFactory: { _ in StubMetadataResolver([:]) }))
     return (accountA, accountB)
   }

--- a/MoolahTests/Features/SyncedAccountTransferTriggerTests.swift
+++ b/MoolahTests/Features/SyncedAccountTransferTriggerTests.swift
@@ -23,8 +23,8 @@ import Testing
 /// - A second sync pass whose exchange client returns nothing (apply
 ///   persists nothing → empty survivor set) creates NO suggestion even
 ///   though a separate pre-existing opposing pair sits inside the
-///   window. The deleted date-window behaviour would have re-suggested
-///   it.
+///   window. Detection only ever evaluates genuinely-new survivors;
+///   pre-existing pairs are never re-scanned.
 ///
 /// Mirrors `SyncedAccountStoreTransferDetectionTests`' exchange harness;
 /// the coordinator is constructed with the current
@@ -110,7 +110,15 @@ struct SyncedAccountTransferTriggerTests {
           resolver: ExchangeInstrumentResolver(
             registry: registry, fiatInstrument: .AUD,
             existingLegInstrumentIds: { [] }),
-          discovery: discovery),
+          discovery: discovery,
+          importOriginFactory: { accountId in
+            ImportOrigin(
+              rawDescription: "exchange:\(accountId.uuidString)",
+              rawAmount: 0,
+              importedAt: Self.pinnedNow,
+              importSessionId: UUID(),
+              parserIdentifier: "coinstash")
+          }),
         metadataResolverFactory: { _ in StubMetadataResolver([:]) }))
     return account
   }
@@ -185,14 +193,73 @@ struct SyncedAccountTransferTriggerTests {
     #expect(suggestion.suggestedAt == Self.pinnedNow)
   }
 
+  @Test(
+    "Historical-dated genuinely-new survivor still pairs with a same-date pre-existing leg"
+  )
+  func historicalSurvivorPairsWithSameDateExistingLeg() async throws {
+    let fixture = try makeFixture()
+
+    // Both legs are dated 30 days before `pinnedNow` — well outside the
+    // 3-day window from "now", but exactly the same day as each other
+    // (per-pair gap = 0d, inside the detector's ±3-day tolerance). This
+    // is what a bulk historical Coinstash import looks like: the trade
+    // dates are old, but they still pair with bank-account transfers on
+    // the same dates. `windowLowerBound` is anchored on the earliest
+    // survivor's date, so historical imports pair correctly with
+    // same-date counterparts regardless of how far back the survivors
+    // are dated.
+    let historicalDate = Self.pinnedNow.addingTimeInterval(-30 * 86_400)
+    let manualAccountId = UUID()
+    let existingOutgoing = Transaction(
+      id: UUID(),
+      date: historicalDate,
+      legs: [
+        TransactionLeg(
+          accountId: manualAccountId,
+          instrument: .AUD,
+          quantity: -250,
+          type: .expense)
+      ])
+    TestBackend.seed(transactions: [existingOutgoing], in: fixture.database)
+
+    let deposit = ExchangeImportedTransaction(
+      externalId: "synced-historical-deposit",
+      occurredAt: historicalDate,
+      category: "DEPOSIT",
+      direction: .credit,
+      assetSymbol: "AUD",
+      amount: 250,
+      isFiat: true,
+      orderId: nil)
+    let syncedAccount = try seedSyncedExchangeAccount(
+      in: fixture, token: "TOK-HIST", rows: [deposit])
+    try await seedFreshSyncState(for: syncedAccount, in: fixture)
+    await fixture.store.loadInitialState()
+
+    await fixture.store.syncAccounts([syncedAccount])
+
+    let txns = try await fixture.backend.transactions.fetchAll(
+      filter: TransactionFilter())
+    #expect(txns.count == 2)
+    let imported = try #require(
+      txns.first {
+        $0.legs.contains { $0.externalId == "synced-historical-deposit" }
+      })
+
+    let suggestions = try await fixture.backend.transferSuggestions.fetchAll()
+    #expect(suggestions.count == 1)
+    let suggestion = try #require(suggestions.first)
+    #expect(suggestion.transactionIds == [imported.id, existingOutgoing.id])
+  }
+
   @Test("A sync that persists nothing makes no suggestion for a pre-existing window pair")
   func emptySurvivorSetDoesNotReSuggestPreExistingWindowPair() async throws {
     let fixture = try makeFixture()
 
     // A complete opposing pair already exists, both legs on non-synced
-    // manual accounts, both dated inside the 3-day window. The deleted
-    // date-window scan would have re-evaluated these and produced a
-    // suggestion; the survivor-driven trigger must not.
+    // manual accounts, both dated inside the 3-day window. Pre-existing
+    // rows are outside the genuinely-new survivor set, so detection
+    // never sees them and produces no suggestion.
     let manualA = UUID()
     let manualB = UUID()
     let existingOut = cashTx(account: manualA, amount: -250, type: .expense)

--- a/MoolahTests/Shared/Exchange/ExchangeSyncEngineTests.swift
+++ b/MoolahTests/Shared/Exchange/ExchangeSyncEngineTests.swift
@@ -121,6 +121,47 @@ struct ExchangeSyncEngineTests {
     #expect(tradeLeg.type == .trade)
   }
 
+  @Test("Built transactions carry the factory-supplied .single import origin")
+  func builtTransactionsCarryImportOrigin() async throws {
+    let account = Account(
+      name: "Coinstash", type: .exchange,
+      instrument: .AUD, exchangeProvider: .coinstash)
+    let imported = [
+      ExchangeImportedTransaction(
+        externalId: "t1", occurredAt: Date(timeIntervalSince1970: 100),
+        category: "DEPOSIT", direction: .credit, assetSymbol: nil,
+        amount: 500, isFiat: true, orderId: nil),
+      ExchangeImportedTransaction(
+        externalId: "t2", occurredAt: Date(timeIntervalSince1970: 200),
+        category: "WITHDRAW", direction: .debit, assetSymbol: nil,
+        amount: 100, isFiat: true, orderId: nil),
+    ]
+    let pinnedNow = Date(timeIntervalSince1970: 1_700_000_000)
+    let pinnedSessionId = UUID()
+    let engine = makeExchangeSyncEngine(
+      importOriginFactory: { accountId in
+        ImportOrigin(
+          rawDescription: "exchange:\(accountId.uuidString)",
+          rawAmount: 0,
+          importedAt: pinnedNow,
+          importSessionId: pinnedSessionId,
+          parserIdentifier: "coinstash")
+      })
+    let result = try await engine.build(
+      account: account, imported: imported, metadata: Self.emptyMetadata)
+    #expect(result.candidates.count == 2)
+    // Both candidates carry a `.single` ImportOrigin populated by the
+    // factory — gated on the `importedAt` clock and the per-pass session
+    // id so `RecentlyAddedViewModel.filter` (which short-circuits on a
+    // nil `singleOrigin`) surfaces them.
+    for candidate in result.candidates {
+      let origin = try #require(candidate.transaction.importOrigin?.singleOrigin)
+      #expect(origin.importedAt == pinnedNow)
+      #expect(origin.importSessionId == pinnedSessionId)
+      #expect(origin.parserIdentifier == "coinstash")
+    }
+  }
+
   @Test
   func dropsEntireGroupWhenAnyLegUnresolvable() async throws {
     let account = Account(

--- a/MoolahTests/Support/ExchangeSyncEngineTestSupport.swift
+++ b/MoolahTests/Support/ExchangeSyncEngineTestSupport.swift
@@ -12,9 +12,22 @@ import Foundation
 ///
 /// `existingLegInstrumentIds` always returns `[]` — suitable for resolution
 /// tests that do not need to exercise the used-instrument preference ranking.
+///
+/// `importOriginFactory` defaults to a fixed test origin so resolution /
+/// grouping tests that only care about `legs` and `date` need not think
+/// about it; tests that assert ImportOrigin propagation pass an explicit
+/// pinned factory.
 func makeExchangeSyncEngine(
   registry: StubInstrumentRegistry = StubInstrumentRegistry(),
-  regResolver: CountingRegistrationResolver? = nil
+  regResolver: CountingRegistrationResolver? = nil,
+  importOriginFactory: @Sendable @escaping (UUID) -> ImportOrigin = { accountId in
+    ImportOrigin(
+      rawDescription: "exchange:\(accountId.uuidString)",
+      rawAmount: 0,
+      importedAt: Date(timeIntervalSince1970: 0),
+      importSessionId: UUID(),
+      parserIdentifier: "coinstash")
+  }
 ) -> ExchangeSyncEngine {
   let resolverToUse: CountingRegistrationResolver
   if let regResolver {
@@ -30,5 +43,6 @@ func makeExchangeSyncEngine(
     resolver: ExchangeInstrumentResolver(
       registry: registry, fiatInstrument: .AUD,
       existingLegInstrumentIds: { [] }),
-    discovery: discovery)
+    discovery: discovery,
+    importOriginFactory: importOriginFactory)
 }

--- a/Shared/Exchange/ExchangeSyncEngine.swift
+++ b/Shared/Exchange/ExchangeSyncEngine.swift
@@ -13,6 +13,7 @@ import OSLog
 struct ExchangeSyncEngine: Sendable {
   private let resolver: ExchangeInstrumentResolver
   private let discovery: CryptoTokenDiscoveryService
+  private let importOriginFactory: @Sendable (UUID) -> ImportOrigin
   /// Shared static `Logger` — `Logger` is `Sendable`, so a static let is
   /// safe across actor boundaries without per-instance allocation.
   private static let logger = Logger(
@@ -35,9 +36,25 @@ struct ExchangeSyncEngine: Sendable {
       decimals: 8)
   ]
 
-  init(resolver: ExchangeInstrumentResolver, discovery: CryptoTokenDiscoveryService) {
+  /// - Parameters:
+  ///   - resolver: Maps imported asset symbols to canonical `Instrument`s.
+  ///   - discovery: Actor-coalesced token registry resolver.
+  ///   - importOriginFactory: Builds the `.single` `ImportOrigin` attached
+  ///     to every built `Transaction` for one account-sync. Called once
+  ///     per `build(account:imported:metadata:)` invocation, so every
+  ///     candidate in the same pass shares one `importSessionId` and a
+  ///     single `importedAt`. Required (no default): callers must decide
+  ///     what audit context the rows carry — production uses
+  ///     `parserIdentifier == "coinstash"`, tests pin a deterministic
+  ///     clock + session id.
+  init(
+    resolver: ExchangeInstrumentResolver,
+    discovery: CryptoTokenDiscoveryService,
+    importOriginFactory: @Sendable @escaping (UUID) -> ImportOrigin
+  ) {
     self.resolver = resolver
     self.discovery = discovery
+    self.importOriginFactory = importOriginFactory
   }
 
   // Coinstash category -> Moolah leg type. DEPOSIT/AWARD are inbound
@@ -71,11 +88,20 @@ struct ExchangeSyncEngine: Sendable {
     // their `externalId` keys a singleton group (one single-leg transaction
     // each).
     let groups = Dictionary(grouping: imported) { $0.orderId ?? $0.externalId }
+    // One origin per account-sync: every candidate this pass produces
+    // shares the same `importSessionId`, so `RecentlyAddedViewModel`
+    // groups them as one session. Built once, before the per-group
+    // loop, mirroring `WalletSyncEngine.run(account:)`.
+    let importOrigin = importOriginFactory(account.id)
     var candidates: [BuiltTransaction] = []
     for (groupKey, rows) in groups {
       try Task.checkCancellation()
       if let candidate = try await buildCandidate(
-        groupKey: groupKey, rows: rows, account: account, metadata: metadata)
+        groupKey: groupKey,
+        rows: rows,
+        account: account,
+        metadata: metadata,
+        importOrigin: importOrigin)
       {
         candidates.append(candidate)
       }
@@ -92,11 +118,14 @@ struct ExchangeSyncEngine: Sendable {
   /// `externalId` group. Returns `nil` (dropping the WHOLE group) on the
   /// first row whose instrument is unresolvable — a partial, unbalanced
   /// trade is worse than no trade — and logs the drop for diagnosis.
+  /// `importOrigin` is the per-account-pass origin built by `build`;
+  /// every candidate from the same pass shares it.
   private func buildCandidate(
     groupKey: String,
     rows: [ExchangeImportedTransaction],
     account: Account,
-    metadata: any ExchangeAssetMetadataResolving
+    metadata: any ExchangeAssetMetadataResolving,
+    importOrigin: ImportOrigin
   ) async throws -> BuiltTransaction? {
     var legs: [TransactionLeg] = []
     for row in rows {
@@ -131,7 +160,8 @@ struct ExchangeSyncEngine: Sendable {
     guard let date = rows.map(\.occurredAt).min() else { return nil }
     return BuiltTransaction(
       originAccountId: account.id,
-      transaction: Transaction(date: date, legs: legs))
+      transaction: Transaction(
+        date: date, legs: legs, importOrigin: .single(importOrigin)))
   }
 
   /// Resolution pipeline:


### PR DESCRIPTION
## Summary

Two independent bugs in the Coinstash / exchange sync path, reported together:
"When importing transactions from Coinstash, they don't appear in 'Recently Added' and transfer detection didn't pick up the transfers."

### Bug A — Recently Added empty for Coinstash

`ExchangeSyncEngine.buildCandidate` was constructing `Transaction(date:legs:)` with no `importOrigin`. `RecentlyAddedViewModel.filter` short-circuits on `guard ... = transaction.importOrigin?.singleOrigin`, so every Coinstash row was silently excluded.

The wallet sibling (`WalletSyncEngine`) already had an `importOriginFactory` threaded through. The exchange engine just never grew one. Fix mirrors the wallet pattern — call the factory once per `build(account:)`, share one `importSessionId` across the pass, and attach `.single(origin)` to every built `Transaction`.

### Bug B — Historical syncs miss transfer suggestions (all sync sources, not just Coinstash)

`SyncedAccountStore+Internals.runTransferDetection` was anchoring its `existingNearby` counterpart fetch window on `clock() - 3 days`. A bulk historical Coinstash import produces survivors dated months in the past; both they and their bank-account peers then sit below the floor and are silently excluded from the candidate fetch.

Anchor on `eligible.min { \$0.date < \$1.date }?.date` instead — the same formula `ImportStore.ingest` uses for CSV imports. Affects **every** sync source (crypto wallets too), not only Coinstash; just unmasked by Coinstash because the exchange API yields years of history on first sync.

## Tests

- `ExchangeSyncEngineTests.builtTransactionsCarryImportOrigin` — asserts factory-supplied `importedAt` and `importSessionId` reach every built candidate.
- `SyncedAccountTransferTriggerTests.historicalSurvivorPairsWithSameDateExistingLeg` — seeds a 30-days-ago manual leg + a same-date Coinstash deposit; fails under the clock-anchored bound, passes under the data-anchored fix.

All 3151 macOS tests pass; 2188 iOS tests pass.

## Review iterations applied (in this PR)

- `code-review`, `concurrency-review`, `sync-review` agents all flagged the same dead-code `?? clock()` fallback after a non-empty `guard` — collapsed to a `guard let` matching the `ImportStore` pattern.
- Hoisted the inline `importOriginFactory` closure in `makeCoinstashSource` into a named `@Sendable` binding for parity with `makeWalletSyncEngine`.
- Cleaned up three time-travel comments in `SyncedAccountTransferTriggerTests` ("the deleted date-window would have…") to state the current invariant.

## Follow-up not in this PR

`importSessionId` is generated per-account inside the factory, matching the wallet site. A user who syncs N exchange accounts in one cycle still sees N separate "Recently Added" sessions. Sync-review raised this as a design decision worth a later PR if the UX fragmentation proves user-visible — not changing it here to keep the bug fix small and to keep parity with the wallet engine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)