### PR TITLE
test(grdb-observation): de-flake retry-loop tests on contended CI

### DIFF
--- a/MoolahTests/Backends/GRDB/Observation/RetryingAsyncStreamTests.swift
+++ b/MoolahTests/Backends/GRDB/Observation/RetryingAsyncStreamTests.swift
@@ -29,6 +29,16 @@ struct RetryingAsyncStreamTests {
     .milliseconds(1), .milliseconds(2), .milliseconds(4),
   ]
 
+  // Upper bound on how long any single test will wait for its
+  // retry-loop work to complete. Locally each test finishes in a few
+  // ms, but CI runs the suite with ~3000 other tests competing for the
+  // cooperative thread pool; a 2 s bound has been observed to trip on
+  // contended runners with no actual bug present (the producer task
+  // simply did not get scheduled fast enough to push 5 emissions
+  // through). 30 s is 100× the worst plausible scheduler stall while
+  // still failing fast on a genuine hang.
+  private static let progressTimeout: Duration = .seconds(30)
+
   @Test("transient error triggers a restart and then emits successfully")
   func transientErrorRestarts() async throws {
     // Synthetic factory: first attempt fails immediately with
@@ -67,14 +77,15 @@ struct RetryingAsyncStreamTests {
         backoffs: Self.testBackoffs))
 
     // Read up to one value with a generous timeout; restart + 1 ms
-    // backoff should complete in well under a second.
+    // backoff should complete in well under a second. See
+    // `progressTimeout` for why the bound is generous.
     let result = try await withThrowingTaskGroup(of: Int?.self) { group in
       group.addTask {
         var iterator = stream.makeAsyncIterator()
         return await iterator.next()
       }
       group.addTask {
-        try await Task.sleep(for: .seconds(2))
+        try await Task.sleep(for: Self.progressTimeout)
         return nil  // timeout sentinel
       }
       let first = try await group.next() ?? nil
@@ -109,7 +120,8 @@ struct RetryingAsyncStreamTests {
         maxFailures: maxFailures,
         backoffs: Self.testBackoffs))
 
-    let done = await Self.drainUntilFinishedOrTimeout(stream, timeout: .seconds(2))
+    let done = await Self.drainUntilFinishedOrTimeout(
+      stream, timeout: Self.progressTimeout)
     #expect(done, "stream should have finished within timeout")
 
     let attemptsMade = attemptCounter.withLock { $0 }
@@ -171,7 +183,8 @@ struct RetryingAsyncStreamTests {
 
     // Collect five emissions. If the counter resets correctly we'll
     // get them; if it doesn't we'd hit budget exhaustion at the third
-    // failure (after three attempts).
+    // failure (after three attempts). See `progressTimeout` for why
+    // the bound is generous.
     let collected = try await withThrowingTaskGroup(of: [Int]?.self) { group in
       group.addTask {
         var values: [Int] = []
@@ -182,7 +195,7 @@ struct RetryingAsyncStreamTests {
         return values
       }
       group.addTask {
-        try await Task.sleep(for: .seconds(2))
+        try await Task.sleep(for: Self.progressTimeout)
         return nil
       }
       let first = try await group.next() ?? nil


### PR DESCRIPTION
## What

Bumps the race-with-timeout bound in `RetryingAsyncStreamTests` from 2 s
to a shared 30 s `progressTimeout` constant, applied to all three
race-with-timeout sites in the file.

## Why

On the `mq-spec-950` integration build ([run 26150034290](https://github.com/ajsutton/moolah-native/actions/runs/26150034290/job/76914824385)), `emissionResetsCounter`
failed with:

```
✘ Test "a successful emission resets the transient failure counter" recorded an issue at RetryingAsyncStreamTests.swift:192:5:
  Expectation failed: (collected → []) == [1, 2, 3, 4, 5]
✘ Test failed after 2.555 seconds with 1 issue.
```

An immediate re-run of the same commit ([run 26151116241](https://github.com/ajsutton/moolah-native/actions/runs/26151116241)) passed —
textbook timing flake. Locally the whole suite finishes in **0.008 s**;
on the failing CI run the producer Task simply did not get scheduled in
time to push five emissions through the retry loop within 2 s, because
the Test job was running ~3000 other tests in parallel and the
cooperative thread pool was saturated.

## How

- Introduce `progressTimeout: Duration = .seconds(30)` as a shared
  constant on the suite, with a comment explaining the contention
  rationale ("100× the worst plausible scheduler stall while still
  failing fast on a genuine hang").
- Replace the three `.seconds(2)` literals (`transientErrorRestarts`,
  `budgetExhaustion`, `emissionResetsCounter`) with `Self.progressTimeout`.

Per `guides/TEST_GUIDE.md` §3 the wait remains bounded — we widen the
bound, we do not remove it or introduce a retry. A genuine production
hang would still fail the test in 30 s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)