### PR TITLE
feat(transactions): hide spam-token transactions from the list

### DIFF
--- a/App/MoolahApp.swift
+++ b/App/MoolahApp.swift
@@ -177,7 +177,7 @@ struct MoolahApp: App {
         SidebarCommands()
         ToolbarCommands()
         InspectorCommands()
-        ShowHiddenCommands()
+        ViewMenuToggleCommands()
         MoolahDomainCommands()
       }
 
@@ -230,7 +230,7 @@ struct MoolahApp: App {
       .commands {
         NewItemCommands()
         RefreshCommands()
-        ShowHiddenCommands()
+        ViewMenuToggleCommands()
       }
     #endif
   }

--- a/App/MoolahDomainCommands.swift
+++ b/App/MoolahDomainCommands.swift
@@ -76,6 +76,38 @@ struct ShowHiddenCommands: Commands {
   }
 }
 
+/// View menu verb-pair for showing / hiding spam transactions.
+/// Mirrors `ShowHiddenCommands` (per UI_GUIDE §14 "Toggle State") —
+/// a Button whose label flips between "Show Spam Transactions" and
+/// "Hide Spam Transactions" rather than a `Toggle` with a checkmark.
+/// Stays visible when no window is focused; disabled per §14
+/// "Disable, don't hide".
+struct ShowSpamTransactionsCommands: Commands {
+  @FocusedValue(\.showSpamTransactions) private var showSpam
+
+  var body: some Commands {
+    CommandGroup(after: .sidebar) {
+      Button(
+        showSpam?.wrappedValue == true ? "Hide Spam Transactions" : "Show Spam Transactions"
+      ) {
+        showSpam?.wrappedValue.toggle()
+      }
+      .disabled(showSpam == nil)
+    }
+  }
+}
+
+/// Wrapper grouping the View-menu verb-pair toggles into a single
+/// Commands argument so the outer `.commands` block stays within
+/// `CommandsBuilder`'s 10-argument limit (mirrors the
+/// `MoolahDomainCommands` grouping rationale at the top of this file).
+struct ViewMenuToggleCommands: Commands {
+  var body: some Commands {
+    ShowHiddenCommands()
+    ShowSpamTransactionsCommands()
+  }
+}
+
 /// Moolah-specific top-level domain menus grouped into one Commands struct so
 /// the outer `.commands` block stays within `CommandsBuilder`'s 10-argument limit.
 /// CommandMenus are inlined here (rather than references to per-feature structs)

--- a/Domain/Models/Transaction.swift
+++ b/Domain/Models/Transaction.swift
@@ -82,3 +82,23 @@ struct Transaction: Codable, Sendable, Identifiable, Hashable {
   }
 
 }
+
+// MARK: - Spam Classification
+
+extension Transaction {
+  /// Whether every leg of this transaction references an instrument in
+  /// the supplied spam set. Returns `false` for a transaction with zero
+  /// legs — defensive, since an empty `allSatisfy` would otherwise
+  /// return `true` and quietly hide an unexpected shape.
+  ///
+  /// This is deliberately *stricter* than the row-level "⚠️ Spam"
+  /// indicator (`legs.contains { spamInstruments.contains($0.instrument) }`):
+  /// the indicator informs the user that *any* leg touched spam, while
+  /// this predicate gates the hide rule that *removes* the transaction
+  /// from the list. Mixed-leg transactions affected a real balance and
+  /// must remain visible. See
+  /// `plans/2026-05-20-hide-spam-transactions-design.md` §"Definition".
+  func isAllSpam(in spamInstruments: Set<Instrument>) -> Bool {
+    !legs.isEmpty && legs.allSatisfy { spamInstruments.contains($0.instrument) }
+  }
+}

--- a/Features/Navigation/SidebarView.swift
+++ b/Features/Navigation/SidebarView.swift
@@ -18,10 +18,13 @@ enum SidebarSelection: Hashable {
 }
 
 struct SidebarView: View {
+  // MARK: - Properties
+
   @Environment(AccountStore.self) private var accountStore
   @Environment(EarmarkStore.self) private var earmarkStore
   @Environment(ProfileSession.self) private var session
   @Environment(ImportStore.self) private var importStore
+  @Environment(TransactionStore.self) private var transactionStore
   @Binding var selection: SidebarSelection?
   @State private var showCreateEarmarkSheet = false
   @State private var showCreateAccountSheet = false
@@ -45,6 +48,8 @@ struct SidebarView: View {
     )
   }
 
+  // MARK: - Body
+
   var body: some View {
     List(selection: $selection) {
       currentAccountsSection
@@ -63,9 +68,13 @@ struct SidebarView: View {
       accountStore.showHidden = newValue
       earmarkStore.showHidden = newValue
     }
+    .onChange(of: showSpam) { _, newValue in
+      transactionStore.showSpam = newValue
+    }
     .onAppear {
       accountStore.showHidden = showHidden
       earmarkStore.showHidden = showHidden
+      transactionStore.showSpam = showSpam
     }
     #if os(iOS)
       .environment(\.editMode, $editMode)
@@ -133,6 +142,11 @@ struct SidebarView: View {
       perform: handleAccountEditRequest
     )
   }
+
+}
+
+extension SidebarView {
+  // MARK: - Sections
 
   private func handleAccountEditRequest(_ note: Notification) {
     guard let id = note.object as? UUID,
@@ -248,12 +262,32 @@ struct SidebarView: View {
       }
       .accessibilityIdentifier(UITestIdentifiers.Sidebar.view("allTransactions"))
       #if os(iOS)
-        Toggle(isOn: $showHidden) {
-          Label("Show Hidden", systemImage: "eye.slash")
-        }
+        navigationToggles
       #endif
     }
   }
+
+  #if os(iOS)
+    /// iOS-only visibility toggles shown at the bottom of the navigation
+    /// section. Extracted from `navigationSection` to keep its closure
+    /// within SwiftLint's `closure_body_length` budget.
+    @ViewBuilder private var navigationToggles: some View {
+      Toggle(isOn: $showHidden) {
+        Label(
+          showHidden ? "Hide Hidden" : "Show Hidden",
+          systemImage: showHidden ? "eye" : "eye.slash"
+        )
+      }
+      Toggle(isOn: $showSpam) {
+        Label(
+          showSpam ? "Hide Spam Transactions" : "Show Spam Transactions",
+          systemImage: showSpam ? "eye" : "eye.slash"
+        )
+      }
+    }
+  #endif
+
+  // MARK: - Helpers
 
   private func reorderCurrentAccounts(from source: IndexSet, to destination: Int) async {
     var accounts = accountStore.currentAccounts
@@ -285,11 +319,13 @@ struct SidebarView: View {
     await accountStore.reorderAccounts(
       accounts, positionOffset: accountStore.currentAccounts.count)
   }
-}
 
-extension SidebarView {
+  // MARK: - Actions
+
   private func addAccountAction() { showCreateAccountSheet = true }
   private func addEarmarkAction() { showCreateEarmarkSheet = true }
+
+  // MARK: - Row Builders
 
   private var recentlyAddedLabel: some View {
     HStack {

--- a/Features/Navigation/SidebarView.swift
+++ b/Features/Navigation/SidebarView.swift
@@ -27,6 +27,7 @@ struct SidebarView: View {
   @State private var showCreateAccountSheet = false
   @State private var accountToEdit: Account?
   @AppStorage("showHiddenAccounts") private var showHidden = false
+  @AppStorage("showSpamTransactions") private var showSpam = false
 
   #if os(iOS)
     @State private var editMode: EditMode = .inactive
@@ -55,6 +56,7 @@ struct SidebarView: View {
     .listStyle(.sidebar)
     .navigationTitle("")
     .focusedSceneValue(\.showHiddenAccounts, $showHidden)
+    .focusedSceneValue(\.showSpamTransactions, $showSpam)
     .focusedSceneValue(\.sidebarSelection, $selection)
     .focusedSceneValue(\.selectedAccount, selectedAccountBinding)
     .onChange(of: showHidden) { _, newValue in
@@ -253,9 +255,6 @@ struct SidebarView: View {
     }
   }
 
-  private func addAccountAction() { showCreateAccountSheet = true }
-  private func addEarmarkAction() { showCreateEarmarkSheet = true }
-
   private func reorderCurrentAccounts(from source: IndexSet, to destination: Int) async {
     var accounts = accountStore.currentAccounts
     accounts.move(fromOffsets: source, toOffset: destination)
@@ -289,6 +288,9 @@ struct SidebarView: View {
 }
 
 extension SidebarView {
+  private func addAccountAction() { showCreateAccountSheet = true }
+  private func addEarmarkAction() { showCreateEarmarkSheet = true }
+
   private var recentlyAddedLabel: some View {
     HStack {
       Label("Recently Added", systemImage: "tray.full")

--- a/Features/Navigation/SidebarView.swift
+++ b/Features/Navigation/SidebarView.swift
@@ -274,7 +274,7 @@ extension SidebarView {
     @ViewBuilder private var navigationToggles: some View {
       Toggle(isOn: $showHidden) {
         Label(
-          showHidden ? "Hide Hidden" : "Show Hidden",
+          showHidden ? "Hide Hidden Accounts" : "Show Hidden Accounts",
           systemImage: showHidden ? "eye" : "eye.slash"
         )
       }

--- a/Features/Transactions/TransactionStore+Observation.swift
+++ b/Features/Transactions/TransactionStore+Observation.swift
@@ -273,4 +273,46 @@ extension TransactionStore {
       testObservationTickContinuation.yield(())
     }
   }
+
+  /// Subscribes to `conversionService.observeRates()` /
+  /// `…observeErrors()`. A rate tick recomputes the running-balance
+  /// column against the most recent snapshot (no DB re-fetch); an error
+  /// tick is surfaced on `self.error`. Spawned from `init`.
+  func observeRateChannels() async {
+    let rateStream = conversionService.observeRates()
+    let rateErrors = conversionService.observeErrors()
+    await withTaskGroup(of: Void.self) { group in
+      group.addTask { [self] in
+        for await _ in rateStream {
+          await self.recomputeBalances(reason: .rateTick)
+        }
+      }
+      group.addTask { [self] in
+        for await error in rateErrors {
+          await self.surface(observationError: error)
+        }
+      }
+    }
+  }
+
+  /// Consumes the shared registry's change stream. Each tick re-runs
+  /// the imperative reload for the active filter so an instrument-
+  /// metadata edit applied to the shared registry (which does not
+  /// re-fire the per-profile data observation) live-refreshes the
+  /// open list. No-op until a subscription has been started
+  /// (`lastSnapshotPage != nil`); the first `load`/`observe` will
+  /// fetch fresh data anyway. `Task.isCancelled` is re-checked after
+  /// the stream suspension so a teardown that races a tick exits
+  /// before issuing a fetch. Strong `self` capture matches
+  /// `observeRateChannels()` — the task's lifetime is gated by
+  /// `stopObserving()` / `deinit`.
+  func observeInstrumentRegistryChanges(
+    _ changes: AsyncStream<Void>
+  ) async {
+    for await _ in changes {
+      if Task.isCancelled { return }
+      guard lastSnapshotPage != nil else { continue }
+      await runImperativeReload(filter: currentFilter)
+    }
+  }
 }

--- a/Features/Transactions/TransactionStore+SpamFilter.swift
+++ b/Features/Transactions/TransactionStore+SpamFilter.swift
@@ -20,9 +20,15 @@ extension TransactionStore {
     publishFilteredTransactions()
   }
 
-  /// Recomputes `transactions` from `unfilteredTransactions` against
-  /// the current `showSpam` / `spamInstruments` inputs. Cheap when
-  /// `showSpam == true` or `spamInstruments.isEmpty` (no walk).
+  // Internal (not private) because it is called both from this extension
+  // AND from the `showSpam.didSet` observer in `TransactionStore.swift`.
+  // A stored property's `didSet` cannot live in an extension, and Swift
+  // `private` is file-scoped, so the observer in the main file cannot
+  // reach a `private` member declared here. Do not call from feature code.
+  //
+  // Recomputes `transactions` from `unfilteredTransactions` against
+  // the current `showSpam` / `spamInstruments` inputs. Cheap when
+  // `showSpam == true` or `spamInstruments.isEmpty` (no walk).
   func publishFilteredTransactions() {
     if showSpam || spamInstruments.isEmpty {
       setFilteredTransactions(unfilteredTransactions)

--- a/Features/Transactions/TransactionStore+SpamFilter.swift
+++ b/Features/Transactions/TransactionStore+SpamFilter.swift
@@ -11,6 +11,19 @@ import Foundation
 // See `plans/2026-05-20-hide-spam-transactions-design.md`.
 extension TransactionStore {
 
+  /// Primes both spam-filter inputs atomically on first mount. The
+  /// instrument set is written without publishing (via the internal
+  /// `setSpamInstrumentsValue(_:)` helper), then `showSpam`'s `didSet`
+  /// fires `publishFilteredTransactions()` exactly once with both
+  /// inputs in their final state. Use this from `.onAppear` rather
+  /// than two separate assignments — otherwise the intermediate state
+  /// transiently publishes with the new `showSpam` but the stale
+  /// `spamInstruments`.
+  func primeSpamFilter(instruments: Set<Instrument>, showSpam: Bool) {
+    setSpamInstrumentsValue(instruments)
+    self.showSpam = showSpam
+  }
+
   /// Updates `spamInstruments` and re-publishes the filtered
   /// `transactions` if the set actually changed. No-ops if the new
   /// value equals the current one (avoids spurious view re-renders).

--- a/Features/Transactions/TransactionStore+SpamFilter.swift
+++ b/Features/Transactions/TransactionStore+SpamFilter.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+// Spam-hiding filter surface for `TransactionStore`.
+//
+// The store keeps a raw `unfilteredTransactions` backing list and
+// re-publishes the view-visible `transactions` whenever any of the
+// three filter inputs change: the raw list itself (data path via
+// `setTransactions(_:)`), the `showSpam` toggle, or the set of
+// instruments currently flagged as spam (`spamInstruments`).
+//
+// See `plans/2026-05-20-hide-spam-transactions-design.md`.
+extension TransactionStore {
+
+  /// Updates `spamInstruments` and re-publishes the filtered
+  /// `transactions` if the set actually changed. No-ops if the new
+  /// value equals the current one (avoids spurious view re-renders).
+  func setSpamInstruments(_ value: Set<Instrument>) {
+    guard value != spamInstruments else { return }
+    setSpamInstrumentsValue(value)
+    publishFilteredTransactions()
+  }
+
+  /// Recomputes `transactions` from `unfilteredTransactions` against
+  /// the current `showSpam` / `spamInstruments` inputs. Cheap when
+  /// `showSpam == true` or `spamInstruments.isEmpty` (no walk).
+  func publishFilteredTransactions() {
+    if showSpam || spamInstruments.isEmpty {
+      setFilteredTransactions(unfilteredTransactions)
+    } else {
+      setFilteredTransactions(
+        unfilteredTransactions.filter {
+          !$0.transaction.isAllSpam(in: spamInstruments)
+        })
+    }
+  }
+}

--- a/Features/Transactions/TransactionStore.swift
+++ b/Features/Transactions/TransactionStore.swift
@@ -5,7 +5,24 @@ import Observation
 @Observable
 @MainActor
 final class TransactionStore {
+  /// View-visible list, spam-filtered from `unfilteredTransactions`.
+  /// Written only via `setTransactions(_:)` or `publishFilteredTransactions()`.
+  /// See `plans/2026-05-20-hide-spam-transactions-design.md`.
   private(set) var transactions: [TransactionWithBalance] = []
+  // internal so `+SpamFilter.swift` can read it in `publishFilteredTransactions`.
+  // Written only via `setTransactions(_:)`.
+  var unfilteredTransactions: [TransactionWithBalance] = []
+  /// When `true`, all-legs-spam transactions appear in `transactions`.
+  /// Bound to `@AppStorage("showSpamTransactions")` by sidebar / list views.
+  var showSpam: Bool = false {
+    didSet {
+      guard oldValue != showSpam else { return }
+      publishFilteredTransactions()
+    }
+  }
+  /// Instruments flagged as spam. Written via `setSpamInstruments(_:)`
+  /// in `+SpamFilter.swift`; drives `publishFilteredTransactions()`.
+  private(set) var spamInstruments: Set<Instrument> = []
   /// True until the active subscription's first emission settles.
   /// Distinguishes "still loading" from "loaded but empty" for the
   /// empty-state overlay and the load-more footer. Observed; never
@@ -329,48 +346,6 @@ final class TransactionStore {
     subscriptionTask = nil
   }
 
-  /// Consumes the shared registry's change stream. Each tick re-runs
-  /// the imperative reload for the active filter so an instrument-
-  /// metadata edit applied to the shared registry (which does not
-  /// re-fire the per-profile data observation) live-refreshes the
-  /// open list. No-op until a subscription has been started
-  /// (`lastSnapshotPage != nil`); the first `load`/`observe` will
-  /// fetch fresh data anyway. `Task.isCancelled` is re-checked after
-  /// the stream suspension so a teardown that races a tick exits
-  /// before issuing a fetch. Strong `self` capture matches
-  /// `observeRateChannels()` — the task's lifetime is gated by
-  /// `stopObserving()` / `deinit`.
-  private func observeInstrumentRegistryChanges(
-    _ changes: AsyncStream<Void>
-  ) async {
-    for await _ in changes {
-      if Task.isCancelled { return }
-      guard lastSnapshotPage != nil else { continue }
-      await runImperativeReload(filter: currentFilter)
-    }
-  }
-
-  /// Subscribes to `conversionService.observeRates()` /
-  /// `…observeErrors()`. A rate tick recomputes the running-balance
-  /// column against the most recent snapshot (no DB re-fetch); an error
-  /// tick is surfaced on `self.error`. Spawned from `init`.
-  private func observeRateChannels() async {
-    let rateStream = conversionService.observeRates()
-    let rateErrors = conversionService.observeErrors()
-    await withTaskGroup(of: Void.self) { group in
-      group.addTask { [self] in
-        for await _ in rateStream {
-          await self.recomputeBalances(reason: .rateTick)
-        }
-      }
-      group.addTask { [self] in
-        for await error in rateErrors {
-          await self.surface(observationError: error)
-        }
-      }
-    }
-  }
-
   // MARK: - Internal helpers used by `+Mutations.swift` and `+Observation.swift`
 
   func surface(observationError error: any Error) {
@@ -378,14 +353,22 @@ final class TransactionStore {
     self.error = error
   }
 
-  /// Mutator hooks invoked by `+Observation.swift` (which lives in the
-  /// same module but a separate file, so `private(set)` properties on
-  /// the main type are not directly assignable from there).
+  /// Mutator hooks invoked by extension files (which live in the same
+  /// module but separate files, so `private(set)` properties on the
+  /// main type are not directly assignable from there).
   func setCurrentFilter(_ filter: TransactionFilter) { currentFilter = filter }
   func setCurrentTargetInstrument(_ instrument: Instrument) {
     currentTargetInstrument = instrument
   }
-  func setTransactions(_ rows: [TransactionWithBalance]) { transactions = rows }
+  func setTransactions(_ rows: [TransactionWithBalance]) {
+    unfilteredTransactions = rows
+    publishFilteredTransactions()
+  }
+  // Used by `+SpamFilter.swift` to write `transactions` (private(set)).
+  func setFilteredTransactions(_ rows: [TransactionWithBalance]) { transactions = rows }
+  // Used by `+SpamFilter.swift` to write `spamInstruments` (private(set)).
+  func setSpamInstrumentsValue(_ value: Set<Instrument>) { spamInstruments = value }
+
   func setHasMore(_ value: Bool) { hasMore = value }
   func setError(_ error: (any Error)?) { self.error = error }
   func setLoadedCount(_ count: Int) { loadedCount = count }

--- a/Features/Transactions/TransactionStore.swift
+++ b/Features/Transactions/TransactionStore.swift
@@ -9,9 +9,10 @@ final class TransactionStore {
   /// Written only via `setTransactions(_:)` or `publishFilteredTransactions()`.
   /// See `plans/2026-05-20-hide-spam-transactions-design.md`.
   private(set) var transactions: [TransactionWithBalance] = []
-  // internal so `+SpamFilter.swift` can read it in `publishFilteredTransactions`.
-  // Written only via `setTransactions(_:)`.
-  var unfilteredTransactions: [TransactionWithBalance] = []
+  // private(set): `+SpamFilter.swift` only reads this via the property accessor
+  // in `publishFilteredTransactions`; `setTransactions(_:)` in this file is
+  // the sole writer.
+  private(set) var unfilteredTransactions: [TransactionWithBalance] = []
   /// When `true`, all-legs-spam transactions appear in `transactions`.
   /// Bound to `@AppStorage("showSpamTransactions")` by sidebar / list views.
   var showSpam: Bool = false {
@@ -104,6 +105,14 @@ final class TransactionStore {
   /// helpers in `MoolahTests/Support/TestableStoreObservation.swift` to
   /// await emissions deterministically. `internal` access is intentional;
   /// `@testable import Moolah` exposes it to the test target.
+  ///
+  /// **Spam-filter note:** the `publishFilteredTransactions()` re-publish
+  /// path does NOT yield a tick — ticks are emitted only for DB-driven
+  /// emissions (`applySnapshot`) and rate recomputes. Tests that toggle
+  /// `showSpam` or call `setSpamInstruments(_:)` must assert against
+  /// `store.transactions` synchronously (the property is updated
+  /// synchronously by `publishFilteredTransactions()`) rather than
+  /// awaiting a tick.
   let testObservationTickStream: AsyncStream<Void>
   // internal so `+Observation` and `+Mutations` can yield ticks after
   // mutating state.

--- a/Features/Transactions/Views/TransactionListView+List.swift
+++ b/Features/Transactions/Views/TransactionListView+List.swift
@@ -150,6 +150,20 @@ extension TransactionListView {
     ToolbarItem(placement: .primaryAction) {
       addToolbarButton
     }
+
+    #if os(iOS)
+      ToolbarItem(placement: .primaryAction) {
+        Button {
+          showSpamTransactions.toggle()
+        } label: {
+          Image(systemName: showSpamTransactions ? "eye" : "eye.slash")
+        }
+        .accessibilityLabel(
+          showSpamTransactions ? "Hide Spam Transactions" : "Show Spam Transactions"
+        )
+        .help(showSpamTransactions ? "Hide Spam Transactions" : "Show Spam Transactions")
+      }
+    #endif
   }
 
   // MARK: - List Content & Toolbar

--- a/Features/Transactions/Views/TransactionListView+List.swift
+++ b/Features/Transactions/Views/TransactionListView+List.swift
@@ -164,7 +164,6 @@ extension TransactionListView {
         .accessibilityLabel("Spam Transactions")
         .accessibilityValue(showSpamTransactions ? "shown" : "hidden")
         .accessibilityIdentifier(UITestIdentifiers.TransactionList.spamToggleButton)
-        .help(showSpamTransactions ? "Hide Spam Transactions" : "Show Spam Transactions")
       }
     #endif
   }

--- a/Features/Transactions/Views/TransactionListView+List.swift
+++ b/Features/Transactions/Views/TransactionListView+List.swift
@@ -156,11 +156,14 @@ extension TransactionListView {
         Button {
           showSpamTransactions.toggle()
         } label: {
-          Image(systemName: showSpamTransactions ? "eye" : "eye.slash")
+          Label(
+            showSpamTransactions ? "Hide Spam Transactions" : "Show Spam Transactions",
+            systemImage: showSpamTransactions ? "eye" : "eye.slash"
+          )
         }
-        .accessibilityLabel(
-          showSpamTransactions ? "Hide Spam Transactions" : "Show Spam Transactions"
-        )
+        .accessibilityLabel("Spam Transactions")
+        .accessibilityValue(showSpamTransactions ? "shown" : "hidden")
+        .accessibilityIdentifier(UITestIdentifiers.TransactionList.spamToggleButton)
         .help(showSpamTransactions ? "Hide Spam Transactions" : "Show Spam Transactions")
       }
     #endif

--- a/Features/Transactions/Views/TransactionListView.swift
+++ b/Features/Transactions/Views/TransactionListView.swift
@@ -1,6 +1,8 @@
 import SwiftUI
 
 struct TransactionListView: View {
+  // MARK: - Properties
+
   /// Grouping for the rendered list. Default `.flat` keeps existing
   /// callers unchanged. `.scheduledStatus` bundles a `pendingPayId`
   /// binding that the row's Pay action writes into; the binding is
@@ -142,15 +144,21 @@ struct TransactionListView: View {
   @State var transactionPendingUnmerge: Transaction.ID?
   @State var createRuleFromTransaction: Transaction?
 
-  /// Wraps `transactionsList` with the spam-filter sync modifiers so the
+  // MARK: - Body
+
+  /// Wraps `transactionsList` with the spam-filter priming modifiers so the
   /// `body` modifier chain stays within the Swift type-checker's expression
   /// complexity budget. Keeping these in a separate sub-expression lets the
   /// compiler resolve the view type in two passes rather than one giant chain.
-  private var spamSyncedList: some View {
+  private var spamFilteredList: some View {
     transactionsList
       .onAppear {
+        // Apply both filter inputs in one publish: setSpamInstrumentsValue
+        // writes the backing set without re-publishing, then assigning
+        // showSpam fires didSet → publishFilteredTransactions() once with
+        // both inputs in their final state.
+        transactionStore.setSpamInstrumentsValue(spamInstruments)
         transactionStore.showSpam = showSpamTransactions
-        transactionStore.setSpamInstruments(spamInstruments)
       }
       .onChange(of: showSpamTransactions) { _, newValue in
         transactionStore.showSpam = newValue
@@ -161,7 +169,7 @@ struct TransactionListView: View {
   }
 
   var body: some View {
-    spamSyncedList
+    spamFilteredList
       .modifier(
         OptionalTransactionInspector(
           enabled: handlesOwnInspector,
@@ -291,6 +299,8 @@ struct TransactionListView: View {
           forcedAccountId: filter.accountId,
           ingestDroppedURLs: ingestDroppedURLs))
   }
+
+  // MARK: - Helpers
 
   /// Mirror of `RecentlyAddedView.ingestDroppedURLs` but with a forced
   /// account. Kept here so the view can hand off to `ImportStore`

--- a/Features/Transactions/Views/TransactionListView.swift
+++ b/Features/Transactions/Views/TransactionListView.swift
@@ -153,12 +153,8 @@ struct TransactionListView: View {
   private var spamFilteredList: some View {
     transactionsList
       .onAppear {
-        // Apply both filter inputs in one publish: setSpamInstrumentsValue
-        // writes the backing set without re-publishing, then assigning
-        // showSpam fires didSet → publishFilteredTransactions() once with
-        // both inputs in their final state.
-        transactionStore.setSpamInstrumentsValue(spamInstruments)
-        transactionStore.showSpam = showSpamTransactions
+        transactionStore.primeSpamFilter(
+          instruments: spamInstruments, showSpam: showSpamTransactions)
       }
       .onChange(of: showSpamTransactions) { _, newValue in
         transactionStore.showSpam = newValue

--- a/Features/Transactions/Views/TransactionListView.swift
+++ b/Features/Transactions/Views/TransactionListView.swift
@@ -126,6 +126,14 @@ struct TransactionListView: View {
     self._activeFilter = State(initialValue: filter)
   }
 
+  // Widened from `private` to module-internal so the file-scope extension in
+  // `TransactionListView+List.swift` can sync these into `transactionStore`
+  // from `.onAppear` / `.onChange` modifiers and read them in the iOS toolbar.
+  // SwiftLint's `strict_fileprivate` rule disallows `fileprivate`, making
+  // `internal` the smallest legal cross-file scope.
+  @AppStorage("showSpamTransactions") var showSpamTransactions = false
+  @Environment(\.spamInstruments) var spamInstruments
+
   @State private var showError = false
   @State private var errorMessage = ""
   @State var searchText = ""
@@ -134,8 +142,26 @@ struct TransactionListView: View {
   @State var transactionPendingUnmerge: Transaction.ID?
   @State var createRuleFromTransaction: Transaction?
 
-  var body: some View {
+  /// Wraps `transactionsList` with the spam-filter sync modifiers so the
+  /// `body` modifier chain stays within the Swift type-checker's expression
+  /// complexity budget. Keeping these in a separate sub-expression lets the
+  /// compiler resolve the view type in two passes rather than one giant chain.
+  private var spamSyncedList: some View {
     transactionsList
+      .onAppear {
+        transactionStore.showSpam = showSpamTransactions
+        transactionStore.setSpamInstruments(spamInstruments)
+      }
+      .onChange(of: showSpamTransactions) { _, newValue in
+        transactionStore.showSpam = newValue
+      }
+      .onChange(of: spamInstruments) { _, newValue in
+        transactionStore.setSpamInstruments(newValue)
+      }
+  }
+
+  var body: some View {
+    spamSyncedList
       .modifier(
         OptionalTransactionInspector(
           enabled: handlesOwnInspector,

--- a/MoolahTests/Domain/TransactionIsAllSpamTests.swift
+++ b/MoolahTests/Domain/TransactionIsAllSpamTests.swift
@@ -1,0 +1,66 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("Transaction.isAllSpam(in:)")
+struct TransactionIsAllSpamTests {
+  let aud = Instrument.AUD
+  let usd = Instrument.fiat(code: "USD")
+  let spamA = Instrument.crypto(
+    chainId: 1, contractAddress: "0xspama", symbol: "SPAM", name: "Spam Token", decimals: 18)
+  let spamB = Instrument.crypto(
+    chainId: 1, contractAddress: "0xspamb", symbol: "SCAM", name: "Scam Token", decimals: 18)
+  let account = UUID()
+
+  private func leg(_ instrument: Instrument, quantity: Decimal) -> TransactionLeg {
+    TransactionLeg(
+      accountId: account, instrument: instrument, quantity: quantity, type: .trade)
+  }
+
+  private func transaction(legs: [TransactionLeg]) -> Transaction {
+    Transaction(date: Date(timeIntervalSince1970: 0), legs: legs)
+  }
+
+  @Test
+  func singleSpamLegIsAllSpam() {
+    let subject = transaction(legs: [leg(spamA, quantity: 100)])
+    #expect(subject.isAllSpam(in: [spamA]))
+  }
+
+  @Test
+  func multipleSpamLegsAllInSetIsAllSpam() {
+    let subject = transaction(legs: [leg(spamA, quantity: -50), leg(spamB, quantity: 50)])
+    #expect(subject.isAllSpam(in: [spamA, spamB]))
+  }
+
+  @Test
+  func mixedSpamAndNonSpamIsNotAllSpam() {
+    let subject = transaction(legs: [leg(spamA, quantity: -50), leg(usd, quantity: 100)])
+    #expect(!subject.isAllSpam(in: [spamA]))
+  }
+
+  @Test
+  func nonSpamOnlyIsNotAllSpam() {
+    let subject = transaction(legs: [leg(usd, quantity: 100)])
+    #expect(!subject.isAllSpam(in: [spamA]))
+  }
+
+  @Test
+  func emptyLegsIsNotAllSpam() {
+    let subject = transaction(legs: [])
+    #expect(!subject.isAllSpam(in: [spamA]))
+  }
+
+  @Test
+  func emptySpamSetIsNotAllSpam() {
+    let subject = transaction(legs: [leg(spamA, quantity: 100)])
+    #expect(!subject.isAllSpam(in: []))
+  }
+
+  @Test
+  func spamLegOutsideSpamSetIsNotAllSpam() {
+    let subject = transaction(legs: [leg(spamA, quantity: 100)])
+    #expect(!subject.isAllSpam(in: [spamB]))
+  }
+}

--- a/MoolahTests/Features/Transactions/TransactionStoreSpamFilterTests.swift
+++ b/MoolahTests/Features/Transactions/TransactionStoreSpamFilterTests.swift
@@ -1,0 +1,116 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("TransactionStore/SpamFilter")
+@MainActor
+struct TransactionStoreSpamFilterTests {
+  private let accountId = UUID()
+  private let spamA = Instrument.crypto(
+    chainId: 1,
+    contractAddress: "0xspamAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+    symbol: "SPAM", name: "Spam Token", decimals: 18)
+  private let spamB = Instrument.crypto(
+    chainId: 1,
+    contractAddress: "0xscamBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+    symbol: "SCAM", name: "Scam Token", decimals: 18)
+  private let usd = Instrument.fiat(code: "USD")
+
+  private func makeStore() throws -> (CloudKitBackend, TransactionStore) {
+    let (backend, _) = try TestBackend.create()
+    let store = TransactionStore(
+      repository: backend.transactions,
+      conversionService: FixedConversionService(),
+      targetInstrument: .defaultTestInstrument
+    )
+    return (backend, store)
+  }
+
+  private func leg(_ instrument: Instrument, quantity: Decimal) -> TransactionLeg {
+    TransactionLeg(
+      accountId: accountId, instrument: instrument, quantity: quantity, type: .trade)
+  }
+
+  private func makeTransaction(legs: [TransactionLeg]) throws -> Transaction {
+    Transaction(
+      date: try TransactionStoreTestSupport.makeDate("2024-01-15"),
+      payee: "test",
+      legs: legs)
+  }
+
+  @Test
+  func singleLegAllSpamIsHiddenByDefault() async throws {
+    let (_, store) = try makeStore()
+    store.setSpamInstruments([spamA])
+
+    _ = await store.create(try makeTransaction(legs: [leg(spamA, quantity: 100)]))
+    await store.load(filter: TransactionFilter(accountId: accountId))
+
+    #expect(store.transactions.isEmpty)
+  }
+
+  @Test
+  func multiLegAllSpamIsHiddenByDefault() async throws {
+    let (_, store) = try makeStore()
+    store.setSpamInstruments([spamA, spamB])
+
+    _ = await store.create(
+      try makeTransaction(legs: [leg(spamA, quantity: -50), leg(spamB, quantity: 50)]))
+    await store.load(filter: TransactionFilter(accountId: accountId))
+
+    #expect(store.transactions.isEmpty)
+  }
+
+  @Test
+  func mixedLegTransactionIsAlwaysVisible() async throws {
+    let (_, store) = try makeStore()
+    store.setSpamInstruments([spamA])
+
+    _ = await store.create(
+      try makeTransaction(legs: [leg(spamA, quantity: -50), leg(usd, quantity: 100)]))
+    await store.load(filter: TransactionFilter(accountId: accountId))
+
+    #expect(store.transactions.count == 1)
+  }
+
+  @Test
+  func togglingShowSpamRepublishesHiddenRows() async throws {
+    let (_, store) = try makeStore()
+    store.setSpamInstruments([spamA])
+
+    _ = await store.create(try makeTransaction(legs: [leg(spamA, quantity: 100)]))
+    await store.load(filter: TransactionFilter(accountId: accountId))
+    #expect(store.transactions.isEmpty)
+
+    store.showSpam = true
+    #expect(store.transactions.count == 1)
+
+    store.showSpam = false
+    #expect(store.transactions.isEmpty)
+  }
+
+  @Test
+  func changingSpamSetReFiltersLive() async throws {
+    let (_, store) = try makeStore()
+    // Start with empty spam set — transaction is visible.
+    _ = await store.create(try makeTransaction(legs: [leg(spamA, quantity: 100)]))
+    await store.load(filter: TransactionFilter(accountId: accountId))
+    #expect(store.transactions.count == 1)
+
+    // User marks spamA as spam — transaction should disappear.
+    store.setSpamInstruments([spamA])
+    #expect(store.transactions.isEmpty)
+  }
+
+  @Test
+  func emptySpamSetShowsAllTransactions() async throws {
+    let (_, store) = try makeStore()
+    // spamInstruments defaults to empty.
+    _ = await store.create(try makeTransaction(legs: [leg(spamA, quantity: 100)]))
+    _ = await store.create(try makeTransaction(legs: [leg(usd, quantity: 200)]))
+    await store.load(filter: TransactionFilter(accountId: accountId))
+
+    #expect(store.transactions.count == 2)
+  }
+}

--- a/Shared/FocusedValues.swift
+++ b/Shared/FocusedValues.swift
@@ -35,6 +35,11 @@ struct ShowHiddenAccountsKey: FocusedValueKey {
   typealias Value = Binding<Bool>
 }
 
+/// Binding to the View > Show / Hide Spam Transactions toggle.
+struct ShowSpamTransactionsKey: FocusedValueKey {
+  typealias Value = Binding<Bool>
+}
+
 /// The transaction currently selected in the focused window (for Transaction menu).
 struct SelectedTransactionKey: FocusedValueKey {
   typealias Value = Binding<Transaction?>
@@ -165,6 +170,10 @@ extension FocusedValues {
   var showHiddenAccounts: ShowHiddenAccountsKey.Value? {
     get { self[ShowHiddenAccountsKey.self] }
     set { self[ShowHiddenAccountsKey.self] = newValue }
+  }
+  var showSpamTransactions: ShowSpamTransactionsKey.Value? {
+    get { self[ShowSpamTransactionsKey.self] }
+    set { self[ShowSpamTransactionsKey.self] = newValue }
   }
   var selectedTransaction: SelectedTransactionKey.Value? {
     get { self[SelectedTransactionKey.self] }

--- a/UITestSupport/UITestIdentifiers.swift
+++ b/UITestSupport/UITestIdentifiers.swift
@@ -64,6 +64,11 @@ public enum UITestIdentifiers {
     public static func transaction(_ id: UUID) -> String {
       "transactionlist.transaction.\(id.uuidString.lowercased())"
     }
+
+    /// iOS-only toolbar button that toggles spam-transaction visibility.
+    /// Pinned so a UI test can drive the spam toggle without depending on
+    /// the rendered label text (which flips between states).
+    public static let spamToggleButton = "transactionlist.toolbar.spamToggle"
   }
 
   // MARK: - RecentlyAdded

--- a/guides/UI_GUIDE.md
+++ b/guides/UI_GUIDE.md
@@ -1424,6 +1424,7 @@ Assign shortcuts only when the action is **frequent** (used more than a few time
 | Show/Hide Sidebar | ⌃⌘S | View |
 | Show/Hide Inspector | ⌥⌘I | View |
 | Show/Hide Hidden Accounts | ⇧⌘H | View |
+| Show/Hide Spam Transactions | — | View |
 | Enter/Exit Full Screen | ⌃⌘F | View |
 | Go to Accounts / Transactions / … | ⌘1…⌘6 | Go |
 | Back / Forward | ⌘[ / ⌘] | Go |

--- a/plans/2026-05-20-hide-spam-transactions-design.md
+++ b/plans/2026-05-20-hide-spam-transactions-design.md
@@ -1,0 +1,240 @@
+# Hide Spam-Token Transactions From the Transaction List
+
+**Status:** Design — not yet implemented.
+**Date:** 2026-05-20.
+**Author:** brainstormed with Claude.
+
+## Problem
+
+Users with on-chain wallets accumulate airdrop "spam" — token transfers
+they did not initiate, from tokens with no real value, often used to
+phish or to clutter wallet history. The spam visual indicator
+(red "⚠️ Spam" badge on rows, shipped per
+`plans/completed/2026-05-10-spam-transaction-row-indicator-plan.md`) makes
+each spam-touching row identifiable, but the rows still occupy the list
+and dominate it for active wallet users. The user wants spam
+transactions hidden by default, with a one-click way to bring them back
+when needed.
+
+## Goal
+
+- Spam-only transactions (e.g. airdrop receives, the dominant case) are
+  hidden from every `TransactionListView` consumer by default.
+- A View menu item (macOS) or toolbar control (iOS) toggles the hide on
+  and off. The preference persists across launches and applies app-wide.
+- Mixed transactions — where at least one leg references a real
+  instrument — remain visible. The user explicitly does *not* want a
+  real-balance-affecting transaction disappearing just because one leg
+  happens to be a spam token.
+- Aggregate values (account balances, totals, reports) are unchanged.
+  In practice spam tokens are unpriced and contribute $0 anyway, but the
+  scope boundary is part of the spec.
+
+## Non-Goals
+
+- **No new spam detection.** The set of spam-flagged instruments
+  (`spamInstruments`, derived from `CryptoRegistration.pricingStatus ==
+  .spam`) already exists and is injected into the environment. This
+  feature consumes that set; it does not change how instruments become
+  spam-flagged.
+- **No per-token "always show this spam token" preference.** The toggle
+  is a single global Bool.
+- **No "N spam transactions hidden" footer.** Matches the "Show Hidden
+  Accounts" precedent; revisit only if user feedback says the empty
+  state confuses people.
+- **No change to the row-level "⚠️ Spam" indicator.** It continues to
+  flag *any* leg referencing a spam instrument — informational, not
+  removal. This intentionally differs from the hide rule (see below).
+
+## Definition: When Is a Transaction "Spam"?
+
+A transaction is hidden when, and only when:
+
+```
+!transaction.legs.isEmpty
+  && transaction.legs.allSatisfy { spamInstruments.contains($0.instrument) }
+```
+
+That is: at least one leg, and **every** leg references a spam
+instrument. Cases:
+
+| Legs | Spam? | Hidden by default? |
+|---|---|---|
+| Single leg, spam token (typical airdrop receive) | all spam | Yes |
+| Swap USDC → SPAM token (one spam, one not) | mixed | **No — visible** |
+| Swap SPAM → SPAM (rare) | all spam | Yes |
+| Multi-leg transfer of one spam token between wallets | all spam | Yes |
+| Fee paid in spam token while moving USDC | mixed | No — visible |
+| Zero legs (defensive — shouldn't occur in practice) | n/a | No — visible |
+
+This is intentionally **stricter** than the row indicator rule
+(`legs.contains { spamInstruments.contains($0.instrument) }`). The two
+serve different purposes:
+
+- **Indicator (any leg):** informs the user that a transaction touched a
+  spam token. Mixed-leg transactions still get the badge on the spam
+  leg.
+- **Hide rule (all legs):** removes pure noise. Anything touching a real
+  balance must remain visible so the user is not surprised by a missing
+  transaction in their account history.
+
+## User-Facing Behaviour
+
+### macOS — View menu item
+
+A `Button` in the View menu, immediately after the existing "Show
+Hidden Accounts" entry. Label flips between the two states per UI_GUIDE
+§14 "Toggle State" (mirrors `ShowHiddenCommands` at
+`App/MoolahDomainCommands.swift:63-77`):
+
+- Currently hidden (default): `"Show Spam Transactions"`
+- Currently shown: `"Hide Spam Transactions"`
+
+No keyboard shortcut in this iteration. (The Show Hidden Accounts
+shortcut is ⇧⌘H; if a follow-up issue requests one we can pick a free
+combination then. Not in scope for the first ship.)
+
+The menu item is disabled (`.disabled(showSpam == nil)`) when no scene
+provides the focused-value binding — same defensive pattern as
+`ShowHiddenCommands`.
+
+### iOS — toolbar item on `TransactionListView`
+
+A toolbar button (placement: `.primaryAction` next to the existing
+filter button) that toggles the same `@AppStorage` preference.
+
+- Hidden state (default): `eye.slash` SF Symbol,
+  `accessibilityLabel("Show Spam Transactions")`.
+- Shown state: `eye` SF Symbol,
+  `accessibilityLabel("Hide Spam Transactions")`.
+
+No textual label in the toolbar; icon-only with accessibility label is
+consistent with the other iOS toolbar controls.
+
+### Persistence
+
+- `@AppStorage("showSpamTransactions") private var showSpam = false`
+- macOS: bound in `SidebarView` and published via
+  `.focusedSceneValue(\.showSpamTransactions, $showSpam)` so the menu
+  command binds to the active scene's preference. Mirrors the
+  `showHiddenAccounts` wiring at `Features/Navigation/SidebarView.swift:29,57`.
+- iOS: read directly with `@AppStorage` inside `TransactionListView`,
+  no focused-value plumbing required.
+- `false` (default) = transactions hidden. `true` = transactions shown.
+
+## Architecture: Where the Filter Runs
+
+The filter runs in `TransactionStore`. It does **not** live in
+`TransactionFilter`, in `filteredTransactions`, or in any view-private
+computed property.
+
+### Wiring
+
+1. `TransactionStore` gains a `showSpam: Bool` property (defaults to
+   `false`) and a `spamInstruments: Set<Instrument>` property fed from
+   `CryptoTokenStore`.
+2. The store's published transactions list filters out any transaction
+   that satisfies the all-legs-spam predicate above, unless
+   `showSpam == true`.
+3. `SidebarView` syncs the `@AppStorage` preference into the store via
+   `.onChange(of: showSpam) { transactionStore.showSpam = newValue }`,
+   exactly like the existing `accountStore.showHidden = newValue` wiring
+   at `Features/Navigation/SidebarView.swift:60-66`.
+4. The store also observes `cryptoTokenStore.spamInstruments` (already
+   `@Observable`) and re-filters when the spam set changes — so marking
+   a new token as spam in Settings ripples through the list immediately.
+
+### Why the store and not the filter
+
+- Matches the **established precedent**: `accountStore.showHidden`
+  is a store-level property, not a field on a query filter, and is
+  exactly the analogous "global UI preference applied to a published
+  list" case.
+- Keeps `TransactionFilter` semantically about *what data to query*
+  (account, category, date range), not about *how to display* the
+  results. Spam-hiding is presentation, not query.
+- Logic in the store is unit-testable against `TestBackend` per
+  CLAUDE.md "Thin Views, Testable Stores".
+- The filter must run in memory regardless: spam membership is a
+  runtime set, not a database column. Pushing it into
+  `TransactionFilter` would not give it any database-index leverage.
+
+### Why not the view's `filteredTransactions`
+
+`TransactionListView.filteredTransactions` (currently a single payee
+search-text filter) is a thin presentation hook. Multi-condition,
+multi-input filtering (spam set + preference) is business logic and
+belongs in the store per CLAUDE.md §"Thin Views, Testable Stores".
+
+## Scope of the Effect
+
+The store-level filter applies wherever `TransactionStore`'s published
+list is consumed:
+
+- Main "All Transactions" list — affected.
+- Account-detail transaction list — affected.
+- `.searchable` payee search inside the list — affected (hidden spam
+  transactions also don't surface in search). Matches Show Hidden
+  Accounts behaviour: hidden things stay hidden, including from search.
+
+Out of scope and explicitly **unaffected**:
+
+- Account balances, sidebar totals, reports, dashboards.
+- Spam-token settings UI in `Features/Settings/SpamTokensView.swift` —
+  it lists registrations, not transactions, and is unaffected.
+
+## Tests
+
+Store tests live in `MoolahTests/Features/Transactions/`, run against
+`TestBackend` (CloudKitBackend + in-memory SwiftData), and use Swift
+Testing (`@Suite` / `@Test`) per the project's testing convention.
+
+Required cases:
+
+1. **Single-leg all-spam → hidden.** Default state (`showSpam == false`)
+   filters out a transaction with one leg referencing a spam instrument.
+2. **Multi-leg all-spam → hidden.** Default state filters out a
+   transaction whose every leg references a spam instrument.
+3. **Mixed-leg → always visible.** A transaction with at least one
+   non-spam leg is included regardless of `showSpam`.
+4. **Toggling `showSpam` republishes.** Setting `showSpam = true` causes
+   previously-hidden all-spam transactions to reappear in the published
+   list without requiring a re-`observe`.
+5. **`spamInstruments` change re-filters.** Marking a new instrument as
+   spam (so that a previously-visible all-spam transaction now meets the
+   hide predicate) updates the published list live.
+6. **Empty-legs transaction → visible.** Defensive: zero-legs cannot
+   satisfy the predicate (we require `!legs.isEmpty`).
+
+Optional UI test (`MoolahUITests_macOS`, gated by host availability):
+toggle the View menu item; assert visibility of a seeded
+spam-transaction row before and after, then again after relaunching
+the app to verify persistence.
+
+## Implementation Surface
+
+Concrete files to touch:
+
+| File | Change |
+|---|---|
+| `Domain/Models/Transaction.swift` | Add `func isAllSpam(in: Set<Instrument>) -> Bool` (or compute the predicate inline in the store; pick whichever the code-review agent prefers). |
+| `Features/Transactions/TransactionStore.swift` | Add `var showSpam: Bool`, `var spamInstruments: Set<Instrument>`, observation of spam-set changes, and apply the predicate when publishing transactions. |
+| `Features/Transactions/Views/TransactionListView.swift` | iOS: add toolbar button with flipped icon + a11y label, bound to `@AppStorage("showSpamTransactions")`. macOS: no change here — driven from sidebar. |
+| `Features/Navigation/SidebarView.swift` | Add `@AppStorage("showSpamTransactions") private var showSpam = false`, `.focusedSceneValue(\.showSpamTransactions, $showSpam)`, and `.onChange(of: showSpam) { transactionStore.showSpam = newValue }`. Mirror the `showHidden` block at lines 29, 57, 60-66. |
+| `Shared/FocusedValues.swift` | Add `ShowSpamTransactionsKey: FocusedValueKey` with `Value = Binding<Bool>`, plus the `FocusedValues` accessor extension. Place immediately after `ShowHiddenAccountsKey` at line 34. |
+| `App/MoolahDomainCommands.swift` | Add a `ShowSpamTransactionsCommands: Commands` struct alongside `ShowHiddenCommands` (lines 63-77), and register it in the app's `.commands` block where `ShowHiddenCommands` is registered. Button label flips per the verb-pair pattern. |
+| `MoolahTests/Features/Transactions/TransactionStoreTests.swift` (or a new file beside it) | Add the six store tests listed above. |
+
+No CloudKit schema changes. No new domain types beyond the optional
+`Transaction.isAllSpam(in:)` helper.
+
+## Open Questions
+
+None blocking. Two minor decisions deferred to implementation review:
+
+- Whether `isAllSpam(in:)` lives on `Transaction` as an extension, or as
+  a free private helper in `TransactionStore`. The `code-review` agent's
+  judgement on extension organisation (CODE_GUIDE.md §"one extension
+  per protocol/purpose") settles this; the spec does not pre-judge.
+- Whether the macOS menu item gets a keyboard shortcut in this
+  iteration. Default: no. Easy to add in a follow-up.

--- a/plans/2026-05-20-hide-spam-transactions-plan.md
+++ b/plans/2026-05-20-hide-spam-transactions-plan.md
@@ -1,0 +1,807 @@
+# Hide Spam-Token Transactions — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. Each task is self-contained; per-task verify is **build + tests + `just format-check`** per project memory `feedback_format_check_per_plan_step.md`.
+
+**Spec:** `plans/2026-05-20-hide-spam-transactions-design.md` (committed `97c0585e`).
+
+**Goal:** Hide transactions whose every leg references a spam-flagged instrument from every `TransactionListView` by default, with a macOS View menu item and an iOS toolbar item to flip the preference.
+
+**Architecture:** `@AppStorage("showSpamTransactions")` is the durable preference (default `false`). On macOS, `SidebarView` owns the storage and republishes it via `.focusedSceneValue(\.showSpamTransactions, …)` so a `ShowSpamTransactionsCommands` struct in the View menu can bind to it (verb-pair button label, per UI_GUIDE §14). On iOS, `TransactionListView` owns the same `@AppStorage` key (UserDefaults keeps it in sync) and exposes a toolbar toggle. `TransactionListView` mirrors the `@AppStorage` + `\.spamInstruments` environment into `TransactionStore.showSpam` / `TransactionStore.spamInstruments`; the store keeps an internal unfiltered list and republishes a filtered `transactions` view whenever either input changes. This deliberately mirrors the established `accountStore.showHidden` precedent at `Features/Accounts/AccountStore.swift:232-247`.
+
+**Tech Stack:** Swift 6, SwiftUI, Swift Testing (`@Suite` / `@Test`), `@Observable @MainActor` stores, `TestBackend` (CloudKitBackend + in-memory SwiftData).
+
+---
+
+## File Structure
+
+**Create:**
+
+- `MoolahTests/Domain/TransactionIsAllSpamTests.swift` — unit tests for the new `Transaction.isAllSpam(in:)` predicate. Mirrors `TransactionIsTradeTests.swift`.
+- `MoolahTests/Features/TransactionStoreSpamFilterTests.swift` — store-level tests for the spam-filter behaviour (6 cases from spec + change-of-set + change-of-flag).
+
+**Modify:**
+
+- `Domain/Models/Transaction.swift` — add `func isAllSpam(in:)` in a new extension at the bottom of the file (CODE_GUIDE.md: one extension per purpose).
+- `Features/Transactions/TransactionStore.swift` — add `showSpam`, `spamInstruments`, `unfilteredTransactions`, `setSpamInstruments(_:)`; rewrite `setTransactions(_:)` to route through `publishFilteredTransactions()`.
+- `Shared/FocusedValues.swift` — add `ShowSpamTransactionsKey` and the `FocusedValues` accessor.
+- `App/MoolahDomainCommands.swift` — add `ShowSpamTransactionsCommands: Commands`.
+- `App/MoolahApp.swift` — register `ShowSpamTransactionsCommands()` in both `.commands` blocks (lines 169-180 and 230-233 area), immediately after `ShowHiddenCommands()`.
+- `Features/Navigation/SidebarView.swift` — add `@AppStorage("showSpamTransactions") private var showSpam = false` and a `.focusedSceneValue(\.showSpamTransactions, $showSpam)` modifier next to the existing `showHiddenAccounts` modifier.
+- `Features/Transactions/Views/TransactionListView.swift` — add `@AppStorage("showSpamTransactions")`, an `@Environment(\.spamInstruments)`, `.onAppear` / `.onChange` blocks to push both into `transactionStore`, and an iOS-only toolbar `Button` toggling the preference.
+
+**Out of scope (verified):**
+
+- No CloudKit schema change.
+- No change to the row-level "⚠️ Spam" indicator in `TransactionRowView+Icon.swift` (still `any leg`, by design — see spec §"Definition").
+- No change to `TransactionFilter`, `TransactionRepository`, or any database code.
+
+---
+
+## Task 1 — Add `Transaction.isAllSpam(in:)` predicate
+
+**Files:**
+
+- Create: `MoolahTests/Domain/TransactionIsAllSpamTests.swift`
+- Modify: `Domain/Models/Transaction.swift`
+
+### Steps
+
+- [ ] **Step 1: Write the failing test file.**
+
+Create `MoolahTests/Domain/TransactionIsAllSpamTests.swift`:
+
+```swift
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("Transaction.isAllSpam(in:)")
+struct TransactionIsAllSpamTests {
+  let aud = Instrument.AUD
+  let usd = Instrument.fiat(code: "USD")
+  let spamA = Instrument.crypto(symbol: "SPAM", chain: "ethereum", address: "0xspamA")
+  let spamB = Instrument.crypto(symbol: "SCAM", chain: "ethereum", address: "0xspamB")
+  let account = UUID()
+
+  private func leg(_ instrument: Instrument, quantity: Decimal) -> TransactionLeg {
+    TransactionLeg(
+      accountId: account, instrument: instrument, quantity: quantity, type: .trade)
+  }
+
+  private func transaction(legs: [TransactionLeg]) -> Transaction {
+    Transaction(date: Date(timeIntervalSince1970: 0), legs: legs)
+  }
+
+  @Test
+  func singleSpamLegIsAllSpam() {
+    let tx = transaction(legs: [leg(spamA, quantity: 100)])
+    #expect(tx.isAllSpam(in: [spamA]))
+  }
+
+  @Test
+  func multipleSpamLegsAllInSetIsAllSpam() {
+    let tx = transaction(legs: [leg(spamA, quantity: -50), leg(spamB, quantity: 50)])
+    #expect(tx.isAllSpam(in: [spamA, spamB]))
+  }
+
+  @Test
+  func mixedSpamAndNonSpamIsNotAllSpam() {
+    let tx = transaction(legs: [leg(spamA, quantity: -50), leg(usd, quantity: 100)])
+    #expect(!tx.isAllSpam(in: [spamA]))
+  }
+
+  @Test
+  func nonSpamOnlyIsNotAllSpam() {
+    let tx = transaction(legs: [leg(usd, quantity: 100)])
+    #expect(!tx.isAllSpam(in: [spamA]))
+  }
+
+  @Test
+  func emptyLegsIsNotAllSpam() {
+    let tx = transaction(legs: [])
+    #expect(!tx.isAllSpam(in: [spamA]))
+  }
+
+  @Test
+  func emptySpamSetIsNotAllSpam() {
+    let tx = transaction(legs: [leg(spamA, quantity: 100)])
+    #expect(!tx.isAllSpam(in: []))
+  }
+
+  @Test
+  func spamLegOutsideSpamSetIsNotAllSpam() {
+    let tx = transaction(legs: [leg(spamA, quantity: 100)])
+    #expect(!tx.isAllSpam(in: [spamB]))
+  }
+}
+```
+
+> **Note on `Instrument.crypto(symbol:chain:address:)`:** if the actual initialiser signature in `Domain/Models/Instrument.swift` differs (e.g. uses different parameter names or an enum case), substitute the correct call but keep the test semantics identical. Inspect `Instrument.swift` first; do not invent a constructor.
+
+- [ ] **Step 2: Run the new tests to confirm they fail.**
+
+```bash
+just test TransactionIsAllSpamTests 2>&1 | tee .agent-tmp/task1-fail.txt
+grep -i 'isAllSpam' .agent-tmp/task1-fail.txt | head
+```
+
+Expected: compile error — `value of type 'Transaction' has no member 'isAllSpam'`.
+
+- [ ] **Step 3: Add the extension on `Transaction`.**
+
+Append to `Domain/Models/Transaction.swift`, after the closing brace of the existing `extension Transaction` blocks (so it sits as its own extension per CODE_GUIDE.md §"one extension per purpose"):
+
+```swift
+// MARK: - Spam Classification
+
+extension Transaction {
+  /// Whether every leg of this transaction references an instrument in
+  /// the supplied spam set. Returns `false` for a transaction with zero
+  /// legs — defensive, since an empty `allSatisfy` would otherwise
+  /// return `true` and quietly hide an unexpected shape.
+  ///
+  /// This is deliberately *stricter* than the row-level "⚠️ Spam"
+  /// indicator (`legs.contains { spamInstruments.contains($0.instrument) }`):
+  /// the indicator informs the user that *any* leg touched spam, while
+  /// this predicate gates the hide rule that *removes* the transaction
+  /// from the list. Mixed-leg transactions affected a real balance and
+  /// must remain visible. See
+  /// `plans/2026-05-20-hide-spam-transactions-design.md` §"Definition".
+  func isAllSpam(in spamInstruments: Set<Instrument>) -> Bool {
+    !legs.isEmpty && legs.allSatisfy { spamInstruments.contains($0.instrument) }
+  }
+}
+```
+
+- [ ] **Step 4: Re-run the tests, expect green.**
+
+```bash
+just test TransactionIsAllSpamTests 2>&1 | tee .agent-tmp/task1-pass.txt
+grep -E 'Test run|passed|failed' .agent-tmp/task1-pass.txt | tail
+rm .agent-tmp/task1-*.txt
+```
+
+Expected: all seven tests pass.
+
+- [ ] **Step 5: Format-check and build the macOS app.**
+
+```bash
+just format
+just format-check
+just build-mac
+```
+
+Expected: format-check exits 0; build-mac succeeds with no warnings.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git -C /Users/aj/Documents/code/moolah-project/moolah-native/.claude/worktrees/hide-spam-transactions add \
+  Domain/Models/Transaction.swift \
+  MoolahTests/Domain/TransactionIsAllSpamTests.swift
+git -C /Users/aj/Documents/code/moolah-project/moolah-native/.claude/worktrees/hide-spam-transactions commit -m "feat(domain): Transaction.isAllSpam(in:) predicate
+
+Strict 'every leg is spam' predicate. Distinct from the row-indicator
+rule (any leg). Returns false for empty legs (defensive)."
+```
+
+---
+
+## Task 2 — Wire spam filter into `TransactionStore`
+
+**Files:**
+
+- Create: `MoolahTests/Features/TransactionStoreSpamFilterTests.swift`
+- Modify: `Features/Transactions/TransactionStore.swift`
+
+### Steps
+
+- [ ] **Step 1: Write the failing test file.**
+
+Create `MoolahTests/Features/TransactionStoreSpamFilterTests.swift`:
+
+```swift
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("TransactionStore/SpamFilter")
+@MainActor
+struct TransactionStoreSpamFilterTests {
+  private let accountId = UUID()
+  private let spamA = Instrument.crypto(symbol: "SPAM", chain: "ethereum", address: "0xspamA")
+  private let spamB = Instrument.crypto(symbol: "SCAM", chain: "ethereum", address: "0xspamB")
+  private let usd = Instrument.fiat(code: "USD")
+
+  private func makeStore() throws -> (TestBackend, TransactionStore) {
+    let (backend, _) = try TestBackend.create()
+    let store = TransactionStore(
+      repository: backend.transactions,
+      conversionService: FixedConversionService(),
+      targetInstrument: .defaultTestInstrument
+    )
+    return (backend, store)
+  }
+
+  private func leg(_ instrument: Instrument, quantity: Decimal) -> TransactionLeg {
+    TransactionLeg(
+      accountId: accountId, instrument: instrument, quantity: quantity, type: .trade)
+  }
+
+  private func makeTransaction(legs: [TransactionLeg]) -> Transaction {
+    Transaction(
+      date: try! TransactionStoreTestSupport.makeDate("2024-01-15"),
+      payee: "test",
+      legs: legs)
+  }
+
+  @Test
+  func singleLegAllSpamIsHiddenByDefault() async throws {
+    let (_, store) = try makeStore()
+    store.setSpamInstruments([spamA])
+
+    _ = await store.create(makeTransaction(legs: [leg(spamA, quantity: 100)]))
+    try await store.awaitTransactionCount(0)
+
+    #expect(store.transactions.isEmpty)
+  }
+
+  @Test
+  func multiLegAllSpamIsHiddenByDefault() async throws {
+    let (_, store) = try makeStore()
+    store.setSpamInstruments([spamA, spamB])
+
+    _ = await store.create(
+      makeTransaction(legs: [leg(spamA, quantity: -50), leg(spamB, quantity: 50)]))
+    try await store.awaitTransactionCount(0)
+
+    #expect(store.transactions.isEmpty)
+  }
+
+  @Test
+  func mixedLegTransactionIsAlwaysVisible() async throws {
+    let (_, store) = try makeStore()
+    store.setSpamInstruments([spamA])
+
+    _ = await store.create(
+      makeTransaction(legs: [leg(spamA, quantity: -50), leg(usd, quantity: 100)]))
+    try await store.awaitTransactionCount(1)
+
+    #expect(store.transactions.count == 1)
+  }
+
+  @Test
+  func togglingShowSpamRepublishesHiddenRows() async throws {
+    let (_, store) = try makeStore()
+    store.setSpamInstruments([spamA])
+
+    _ = await store.create(makeTransaction(legs: [leg(spamA, quantity: 100)]))
+    try await store.awaitTransactionCount(0)
+    #expect(store.transactions.isEmpty)
+
+    store.showSpam = true
+    #expect(store.transactions.count == 1)
+
+    store.showSpam = false
+    #expect(store.transactions.isEmpty)
+  }
+
+  @Test
+  func changingSpamSetReFiltersLive() async throws {
+    let (_, store) = try makeStore()
+    // Start with empty spam set — transaction is visible.
+    _ = await store.create(makeTransaction(legs: [leg(spamA, quantity: 100)]))
+    try await store.awaitTransactionCount(1)
+    #expect(store.transactions.count == 1)
+
+    // User marks spamA as spam — transaction should disappear.
+    store.setSpamInstruments([spamA])
+    #expect(store.transactions.isEmpty)
+  }
+
+  @Test
+  func transactionsWithEmptySpamSetAreAllVisible() async throws {
+    let (_, store) = try makeStore()
+    // spamInstruments defaults to empty.
+    _ = await store.create(makeTransaction(legs: [leg(spamA, quantity: 100)]))
+    _ = await store.create(makeTransaction(legs: [leg(usd, quantity: 200)]))
+    try await store.awaitTransactionCount(2)
+
+    #expect(store.transactions.count == 2)
+  }
+}
+```
+
+> **Note:** `awaitTransactionCount` is the existing helper at `MoolahTests/Support/TestableStoreObservation.swift`. It already waits for the published `transactions` count to reach the expected value. Since our filter pipeline replaces `transactions` synchronously inside `publishFilteredTransactions()`, the helper will resolve as soon as the relevant snapshot has been applied AND filtered. If the helper signature differs in the local tree, inspect it before invoking and adjust the call site (do **not** redefine the helper).
+
+- [ ] **Step 2: Run the new tests, expect compile or semantic failures.**
+
+```bash
+just test TransactionStoreSpamFilterTests 2>&1 | tee .agent-tmp/task2-fail.txt
+grep -E 'error:|expected' .agent-tmp/task2-fail.txt | head
+```
+
+Expected: errors like `value of type 'TransactionStore' has no member 'setSpamInstruments'` and `… has no member 'showSpam'`.
+
+- [ ] **Step 3: Add the spam-filter machinery to `TransactionStore`.**
+
+In `Features/Transactions/TransactionStore.swift`:
+
+**3a.** Immediately after the existing `private(set) var transactions: [TransactionWithBalance] = []` declaration (currently around line 8), add the backing storage plus new observable properties. The exact patch (replace the single existing `transactions` declaration with the block below):
+
+```swift
+  /// View-visible transactions list. Computed by
+  /// `publishFilteredTransactions()` from `unfilteredTransactions`,
+  /// `showSpam`, and `spamInstruments`. Views observe this property —
+  /// writers must always go through `setTransactions(_:)` (data path)
+  /// or `publishFilteredTransactions()` (toggle path), never assign
+  /// directly. Per `plans/2026-05-20-hide-spam-transactions-design.md`.
+  private(set) var transactions: [TransactionWithBalance] = []
+
+  /// Unfiltered backing list. The observation pipeline writes here via
+  /// `setTransactions(_:)`; `publishFilteredTransactions()` consumes it
+  /// to recompute the spam-filtered `transactions`. Kept around so
+  /// flipping `showSpam` or `spamInstruments` can re-publish without
+  /// a re-fetch. Views must not read this directly.
+  private var unfilteredTransactions: [TransactionWithBalance] = []
+
+  /// Whether all-legs-spam transactions are visible in the published
+  /// list. Bound to the `@AppStorage("showSpamTransactions")`
+  /// preference by `SidebarView` (macOS) and `TransactionListView`
+  /// (iOS). Default `false` (hidden). See
+  /// `plans/2026-05-20-hide-spam-transactions-design.md` §"Persistence".
+  var showSpam: Bool = false {
+    didSet {
+      guard oldValue != showSpam else { return }
+      publishFilteredTransactions()
+    }
+  }
+
+  /// Set of instruments currently flagged as spam. Sourced from
+  /// `CryptoTokenStore.spamInstruments` via the `\.spamInstruments`
+  /// environment value. Drives the all-legs-spam predicate. Written
+  /// only by `setSpamInstruments(_:)` so the republish is coupled to
+  /// the change.
+  private(set) var spamInstruments: Set<Instrument> = []
+```
+
+**3b.** Replace the existing `setTransactions(_ rows:)` at line 388 with:
+
+```swift
+  func setTransactions(_ rows: [TransactionWithBalance]) {
+    unfilteredTransactions = rows
+    publishFilteredTransactions()
+  }
+
+  /// Updates `spamInstruments` and re-publishes the filtered
+  /// `transactions` if the set actually changed. No-ops if the new
+  /// value equals the current one (avoids spurious view re-renders).
+  func setSpamInstruments(_ value: Set<Instrument>) {
+    guard value != spamInstruments else { return }
+    spamInstruments = value
+    publishFilteredTransactions()
+  }
+
+  /// Recomputes `transactions` from `unfilteredTransactions` against
+  /// the current `showSpam` / `spamInstruments` inputs. Cheap when
+  /// `showSpam == true` or `spamInstruments.isEmpty` (no walk).
+  private func publishFilteredTransactions() {
+    if showSpam || spamInstruments.isEmpty {
+      transactions = unfilteredTransactions
+    } else {
+      transactions = unfilteredTransactions.filter {
+        !$0.transaction.isAllSpam(in: spamInstruments)
+      }
+    }
+  }
+```
+
+- [ ] **Step 4: Re-run the new tests, expect green; run the existing transaction-store suite to catch regressions.**
+
+```bash
+just test TransactionStoreSpamFilterTests 2>&1 | tee .agent-tmp/task2-spam-pass.txt
+just test-mac TransactionStoreCRUDTests TransactionStoreLoadingTests TransactionStoreRunningBalanceTests TransactionStorePayScheduledTests TransactionStoreLoadRaceTests TransactionStoreAccountBalanceTests TransactionStoreCategoryFilterTests TransactionStoreAutocompleteTests TransactionStoreManualMergeTests TransactionStoreTransferTests 2>&1 | tee .agent-tmp/task2-regression.txt
+grep -i 'failed\|error:' .agent-tmp/task2-*.txt | head
+rm .agent-tmp/task2-*.txt
+```
+
+Expected: all six new tests pass; all existing TransactionStore tests still pass.
+
+- [ ] **Step 5: Format-check and build.**
+
+```bash
+just format
+just format-check
+just build-mac
+```
+
+Expected: clean.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git -C /Users/aj/Documents/code/moolah-project/moolah-native/.claude/worktrees/hide-spam-transactions add \
+  Features/Transactions/TransactionStore.swift \
+  MoolahTests/Features/TransactionStoreSpamFilterTests.swift
+git -C /Users/aj/Documents/code/moolah-project/moolah-native/.claude/worktrees/hide-spam-transactions commit -m "feat(transactions): TransactionStore spam-hiding filter
+
+Adds showSpam + spamInstruments inputs and an unfiltered backing list.
+publishFilteredTransactions() drops all-legs-spam rows unless showSpam
+or the spam set is empty. Mirrors the accountStore.showHidden pattern."
+```
+
+---
+
+## Task 3 — Declare the `ShowSpamTransactions` focused-value key
+
+**Files:**
+
+- Modify: `Shared/FocusedValues.swift`
+
+### Steps
+
+- [ ] **Step 1: Add the key struct + accessor.**
+
+In `Shared/FocusedValues.swift`, immediately after the `ShowHiddenAccountsKey` declaration (line 34) insert:
+
+```swift
+/// Binding to the View > Show / Hide Spam Transactions toggle.
+struct ShowSpamTransactionsKey: FocusedValueKey {
+  typealias Value = Binding<Bool>
+}
+```
+
+And in the `extension FocusedValues { ... }` block (after the `showHiddenAccounts` accessor at line 165), insert:
+
+```swift
+  var showSpamTransactions: ShowSpamTransactionsKey.Value? {
+    get { self[ShowSpamTransactionsKey.self] }
+    set { self[ShowSpamTransactionsKey.self] = newValue }
+  }
+```
+
+- [ ] **Step 2: Build to verify the key compiles.**
+
+```bash
+just build-mac
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Format-check.**
+
+```bash
+just format
+just format-check
+```
+
+Expected: clean.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git -C /Users/aj/Documents/code/moolah-project/moolah-native/.claude/worktrees/hide-spam-transactions add Shared/FocusedValues.swift
+git -C /Users/aj/Documents/code/moolah-project/moolah-native/.claude/worktrees/hide-spam-transactions commit -m "feat(focused-values): ShowSpamTransactionsKey
+
+Focused-value key for the View > Show/Hide Spam Transactions menu
+binding. Mirrors ShowHiddenAccountsKey."
+```
+
+---
+
+## Task 4 — Bind the macOS preference from `SidebarView`
+
+**Files:**
+
+- Modify: `Features/Navigation/SidebarView.swift`
+
+### Steps
+
+- [ ] **Step 1: Add `@AppStorage` and `.focusedSceneValue`.**
+
+Right after the existing `@AppStorage("showHiddenAccounts") private var showHidden = false` at line 29, add:
+
+```swift
+  @AppStorage("showSpamTransactions") private var showSpam = false
+```
+
+In the modifier chain on `body`, immediately after `.focusedSceneValue(\.showHiddenAccounts, $showHidden)` (currently line 57), add:
+
+```swift
+    .focusedSceneValue(\.showSpamTransactions, $showSpam)
+```
+
+> **Why nothing else:** `SidebarView` does not own `TransactionStore`. The store-sync happens in `TransactionListView` (Task 6) — the `@AppStorage` key is the single source of truth, so both views see the same value automatically via UserDefaults.
+
+- [ ] **Step 2: Build.**
+
+```bash
+just build-mac
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Format-check.**
+
+```bash
+just format
+just format-check
+```
+
+Expected: clean.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git -C /Users/aj/Documents/code/moolah-project/moolah-native/.claude/worktrees/hide-spam-transactions add Features/Navigation/SidebarView.swift
+git -C /Users/aj/Documents/code/moolah-project/moolah-native/.claude/worktrees/hide-spam-transactions commit -m "feat(sidebar): publish showSpamTransactions focused value
+
+Reads the @AppStorage('showSpamTransactions') preference and republishes
+it via focused scene value so the View menu command can bind to it."
+```
+
+---
+
+## Task 5 — Add the macOS View menu command
+
+**Files:**
+
+- Modify: `App/MoolahDomainCommands.swift`
+- Modify: `App/MoolahApp.swift`
+
+### Steps
+
+- [ ] **Step 1: Add the command struct.**
+
+In `App/MoolahDomainCommands.swift`, immediately after the closing brace of `struct ShowHiddenCommands: Commands { … }` (around line 77), append:
+
+```swift
+/// View menu verb-pair for showing / hiding spam transactions.
+/// Mirrors `ShowHiddenCommands` (per UI_GUIDE §14 "Toggle State") —
+/// a Button whose label flips between "Show Spam Transactions" and
+/// "Hide Spam Transactions" rather than a `Toggle` with a checkmark.
+/// Stays visible when no window is focused; disabled per §14
+/// "Disable, don't hide".
+struct ShowSpamTransactionsCommands: Commands {
+  @FocusedValue(\.showSpamTransactions) private var showSpam
+
+  var body: some Commands {
+    CommandGroup(after: .sidebar) {
+      Button(
+        showSpam?.wrappedValue == true ? "Hide Spam Transactions" : "Show Spam Transactions"
+      ) {
+        showSpam?.wrappedValue.toggle()
+      }
+      .disabled(showSpam == nil)
+    }
+  }
+}
+```
+
+> **Why `CommandGroup(after: .sidebar)`** — matches `ShowHiddenCommands`. The two will appear next to each other in the View menu in declaration order, which is what we want (Show Hidden Accounts first, Show Spam Transactions second).
+
+- [ ] **Step 2: Register the command in `App/MoolahApp.swift`.**
+
+In `App/MoolahApp.swift`, find both occurrences of `ShowHiddenCommands()` (currently lines 180 and 233) and insert `ShowSpamTransactionsCommands()` on the line immediately after each:
+
+```swift
+        ShowHiddenCommands()
+        ShowSpamTransactionsCommands()
+```
+
+> **Note:** the `.commands { … }` builder has a 10-argument limit per the comment at `MoolahDomainCommands.swift:80`. If adding `ShowSpamTransactionsCommands()` pushes either site over the limit, fold both `ShowHiddenCommands` and `ShowSpamTransactionsCommands` into a single wrapper struct (e.g. `ViewMenuToggleCommands`). Check the count first; the existing layout has room.
+
+- [ ] **Step 3: Build and run the macOS app to verify the menu item appears.**
+
+```bash
+just build-mac
+just run-mac &
+```
+
+Then verify manually in the running app: View menu shows "Show Spam Transactions"; toggling it flips the label to "Hide Spam Transactions". (No persistence/sync check yet — those land in Task 6.) Quit the app after verification.
+
+- [ ] **Step 4: Format-check.**
+
+```bash
+just format
+just format-check
+```
+
+Expected: clean.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git -C /Users/aj/Documents/code/moolah-project/moolah-native/.claude/worktrees/hide-spam-transactions add \
+  App/MoolahDomainCommands.swift \
+  App/MoolahApp.swift
+git -C /Users/aj/Documents/code/moolah-project/moolah-native/.claude/worktrees/hide-spam-transactions commit -m "feat(commands): View > Show/Hide Spam Transactions menu item
+
+Verb-pair Button per UI_GUIDE §14 'Toggle State'. Bound to the
+showSpamTransactions focused value published by SidebarView."
+```
+
+---
+
+## Task 6 — Wire `TransactionListView` to push the preference into the store
+
+**Files:**
+
+- Modify: `Features/Transactions/Views/TransactionListView.swift`
+
+### Steps
+
+- [ ] **Step 1: Read the current top-of-view declarations.**
+
+`Features/Transactions/Views/TransactionListView.swift` lines 1–60 hold the imports and the view's stored properties. Locate the existing `@State` block and the `body` opening.
+
+- [ ] **Step 2: Add the storage and environment reads.**
+
+In the property block of `TransactionListView`, add:
+
+```swift
+  @AppStorage("showSpamTransactions") private var showSpamTransactions = false
+  @Environment(\.spamInstruments) private var spamInstruments
+```
+
+- [ ] **Step 3: Add the sync modifiers.**
+
+Inside the view's modifier chain (just before the existing `.searchable` modifier is fine — any location after the list/scroll content works), add:
+
+```swift
+    .onAppear {
+      transactionStore.showSpam = showSpamTransactions
+      transactionStore.setSpamInstruments(spamInstruments)
+    }
+    .onChange(of: showSpamTransactions) { _, newValue in
+      transactionStore.showSpam = newValue
+    }
+    .onChange(of: spamInstruments) { _, newValue in
+      transactionStore.setSpamInstruments(newValue)
+    }
+```
+
+> **Sequencing:** the order `showSpam` then `setSpamInstruments` in `onAppear` is deliberate — when both change in one render cycle, we'd rather show the (possibly stale) hide-all-spam set briefly than the inverted "all visible" set briefly. Either order is correct; this one matches the user expectation that "default state on launch is hidden".
+
+- [ ] **Step 4: Add the iOS toolbar item.**
+
+Inside the existing `.toolbar { … }` modifier (the project already has one in `TransactionListView+List.swift` based on the search above; if there is no `#if os(iOS)` branch yet, wrap the new item appropriately). Add:
+
+```swift
+    #if os(iOS)
+      .toolbar {
+        ToolbarItem(placement: .primaryAction) {
+          Button {
+            showSpamTransactions.toggle()
+          } label: {
+            Image(systemName: showSpamTransactions ? "eye" : "eye.slash")
+              .accessibilityLabel(
+                showSpamTransactions ? "Hide Spam Transactions" : "Show Spam Transactions")
+          }
+          .help(showSpamTransactions ? "Hide Spam Transactions" : "Show Spam Transactions")
+        }
+      }
+    #endif
+```
+
+> **If `TransactionListView` already has multiple `.toolbar` invocations on different platforms,** add this one alongside the existing iOS branch instead of introducing a duplicate `.toolbar` modifier — SwiftUI merges multiple `.toolbar` calls but a single iOS-scoped block is cleaner.
+
+- [ ] **Step 5: Build for both platforms.**
+
+```bash
+just build-mac
+just build-ios
+```
+
+Expected: clean for both.
+
+- [ ] **Step 6: Run the macOS app and verify end-to-end.**
+
+```bash
+just run-mac &
+```
+
+Manual check:
+
+1. Open the All Transactions list. Spam-token transactions (if any seeded in your active profile) should not appear.
+2. View menu → "Show Spam Transactions". Spam transactions appear; the menu label flips to "Hide Spam Transactions".
+3. Toggle again. Spam disappears.
+4. Quit and relaunch. The preference state survives (UserDefaults).
+5. Mark a new token as spam in Settings → Spam Tokens. With the preference off (default), any transaction whose every leg is in the spam set should immediately disappear from the open list.
+
+Quit the app after verification.
+
+- [ ] **Step 7: Format-check.**
+
+```bash
+just format
+just format-check
+```
+
+Expected: clean.
+
+- [ ] **Step 8: Commit.**
+
+```bash
+git -C /Users/aj/Documents/code/moolah-project/moolah-native/.claude/worktrees/hide-spam-transactions add \
+  Features/Transactions/Views/TransactionListView.swift
+git -C /Users/aj/Documents/code/moolah-project/moolah-native/.claude/worktrees/hide-spam-transactions commit -m "feat(transactions): hide spam transactions in the list
+
+Pushes the @AppStorage('showSpamTransactions') preference and the
+\\.spamInstruments environment value into TransactionStore on appear
+and on change. iOS gets a toolbar eye/eye.slash toggle with a flipped
+accessibility label; macOS is driven from the View menu (Task 5)."
+```
+
+---
+
+## Task 7 — Final regression sweep
+
+**Files:** none modified.
+
+### Steps
+
+- [ ] **Step 1: Run the full mac test suite and capture output.**
+
+```bash
+mkdir -p .agent-tmp
+just test-mac 2>&1 | tee .agent-tmp/full-mac.txt
+grep -i 'failed\|error:' .agent-tmp/full-mac.txt | head
+```
+
+Expected: no failures.
+
+- [ ] **Step 2: Run the iOS test suite and capture output.**
+
+```bash
+just test-ios 2>&1 | tee .agent-tmp/full-ios.txt
+grep -i 'failed\|error:' .agent-tmp/full-ios.txt | head
+```
+
+Expected: no failures.
+
+> **If the iOS simulator host wedges** (per memory `reference_macos_test_runner_hang.md`), `pkill` stale `Moolah` / `xctest` processes (including from other worktrees and Xcode) before retrying.
+
+- [ ] **Step 3: One last format-check + macOS build, to be absolutely sure the merged branch state is clean.**
+
+```bash
+just format-check
+just build-mac
+```
+
+- [ ] **Step 4: Clean up temp output.**
+
+```bash
+rm -f .agent-tmp/full-mac.txt .agent-tmp/full-ios.txt
+```
+
+- [ ] **Step 5: No new commit — Task 7 is a verify pass only.**
+
+---
+
+## Spec Coverage Check (self-review)
+
+| Spec Section | Implemented In |
+|---|---|
+| Definition: all-legs-spam predicate | Task 1 |
+| macOS View menu item, flipped label | Task 5 (command) + Task 4 (binding) |
+| iOS toolbar item with eye/eye.slash + a11y | Task 6 |
+| `@AppStorage("showSpamTransactions")` persistence | Task 4 (sidebar) + Task 6 (list view) |
+| Filter runs in `TransactionStore` | Task 2 |
+| `spamInstruments` change re-filters live | Task 2 (test #5), Task 6 (`.onChange`) |
+| Applies to account-detail + search results | Task 2 (filter at store; all consumers see the filtered list) |
+| Account balances / totals unaffected | Out of scope, no code path changed |
+| Row-level "⚠️ Spam" indicator unchanged | Verified: `TransactionRowView+Icon.swift` untouched |
+| Six store-level tests | Task 2 |
+| Optional UI test | Not in scope; deferred until host stability per `feedback_pr_ci_gate_when_ui_host_blocked.md` |
+| Open question: `isAllSpam(in:)` on Transaction extension vs free helper | Resolved: extension on Transaction (Task 1) |
+| Open question: keyboard shortcut | Resolved: no shortcut this iteration (spec) |
+
+## Placeholder & Consistency Scan
+
+- No TBDs, no TODOs left in plan text.
+- Property names used consistently: `showSpam`, `spamInstruments`, `setSpamInstruments(_:)`, `unfilteredTransactions`, `publishFilteredTransactions`, `isAllSpam(in:)`.
+- The `@AppStorage` key is `"showSpamTransactions"` everywhere (SidebarView, TransactionListView, focused-value docs). Not `showSpam`, not `hideSpamTransactions`.
+- macOS menu label text is exactly `"Show Spam Transactions"` / `"Hide Spam Transactions"`; iOS a11y label matches.


### PR DESCRIPTION
Hides transactions whose every leg references a spam-flagged instrument from every `TransactionListView` by default, with a macOS View menu item and an iOS toolbar item to flip the preference.

## What changed

- **`Transaction.isAllSpam(in:)`** predicate on the domain model. Strict definition: at least one leg AND every leg references a spam instrument. Defensive return-`false` on empty legs.
- **`TransactionStore`** keeps an unfiltered backing list plus `showSpam: Bool` and `spamInstruments: Set<Instrument>` inputs; `publishFilteredTransactions()` drops all-legs-spam rows unless `showSpam` is true or the set is empty. A new `primeSpamFilter(instruments:showSpam:)` method offers atomic priming (one publish per `.onAppear` rather than two).
- **`@AppStorage("showSpamTransactions")`** is the single durable preference, default `false` (hidden). `SidebarView` reads it on macOS to publish a focused-value binding for the View menu and to push the value into `TransactionStore` (mirroring the established `accountStore.showHidden` wiring at `SidebarView.swift:60-66`). `TransactionListView` reads it on iOS to drive the toolbar toggle and to sync `\.spamInstruments` into the store.
- **macOS View menu:** `ShowSpamTransactionsCommands` — a Button with a verb-pair label that flips between "Show Spam Transactions" / "Hide Spam Transactions" (UI_GUIDE §14 "Toggle State"). Grouped with `ShowHiddenCommands` behind a new `ViewMenuToggleCommands` wrapper so the `.commands` block stays under the 10-argument `CommandsBuilder` limit. No keyboard shortcut this iteration (documented as such in the shortcut map).
- **iOS toolbar item** on `TransactionListView` — `Label("...", systemImage: "eye"/"eye.slash")` with constant `.accessibilityLabel("Spam Transactions")` and flipping `.accessibilityValue("shown"/"hidden")`. Pinned identifier `UITestIdentifiers.TransactionList.spamToggleButton`.
- **iOS sidebar Toggles** — the existing `Show Hidden Accounts` and the new `Show Spam Transactions` both have flipping labels + flipping icons, fully descriptive nouns.

## Why the hide rule is stricter than the row indicator

The row-level "⚠️ Spam" indicator (shipped May 10) flags **any** leg referencing a spam instrument — informational. The hide rule flags only transactions where **every** leg is spam — removal. A swap of USDC → SPAM still shows the badge on the spam leg but stays visible because the USDC leg affected a real balance. Only pure-spam noise (airdrop receives, spam-to-spam transfers) disappears.

## Architecture

| Concern | Where | Why |
|---|---|---|
| Filter logic | `TransactionStore` (not `TransactionFilter`, not the view) | Matches the `accountStore.showHidden` precedent. Filter is in-memory anyway (spam membership is a runtime set, not a DB column). |
| Preference storage | `@AppStorage("showSpamTransactions")` | UserDefaults keeps it in sync across views; one source of truth. |
| Cross-view sync | `SidebarView` pushes `showSpam` into `TransactionStore`; `TransactionListView` pushes `spamInstruments` | Sidebar doesn't have `\.spamInstruments` (injected into the detail column), so the spam-set sync lives at the list. |

## Scope

Affected: every `TransactionListView` consumer (main list, account-detail list, `.searchable` search results).
Unaffected: account balances, sidebar totals, reports, dashboards. (Moot in practice — spam tokens are unpriced and contribute $0.)

## Reviewer iteration

The branch was reviewed by `code-review`, `ui-review`, and `concurrency-review` agents. Three iterations applied 13 distinct findings (Important + Minor) before all three came back clean. Documentation gap in the shortcut map was the final finding — fixed in `2af8aad5`.

## Tests

- Domain: `MoolahTests/Domain/TransactionIsAllSpamTests.swift` — 7 cases (single/multi-leg all-spam, mixed-leg, non-spam, empty legs, empty spam set, spam leg outside set).
- Store: `MoolahTests/Features/Transactions/TransactionStoreSpamFilterTests.swift` — 6 cases per the spec.
- Full sweep: **3162** macOS tests + **3133** iOS tests pass. `just format-check` clean.

## Out of scope (deliberately)

- No new spam-detection heuristic — consumes the existing `\.spamInstruments` set.
- No per-token "always show this spam token" override.
- No "N spam transactions hidden" footer — matches Show Hidden Accounts precedent.
- No keyboard shortcut — action is infrequent; row in the shortcut map carries `—` to document the decision.

## Documents

- Spec: `plans/2026-05-20-hide-spam-transactions-design.md`
- Plan: `plans/2026-05-20-hide-spam-transactions-plan.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
