### PR TITLE
fix(applescript): rename transaction class to txn (#923)

### DIFF
--- a/.claude/skills/automate-app/SKILL.md
+++ b/.claude/skills/automate-app/SKILL.md
@@ -147,7 +147,7 @@ moolah-tell 'pay txn id "UUID-HERE" of profile "Test"'
 > `count txns of profile "…"`,
 > `create txn in profile "…" with payee "…" amount …`. The four-char
 > code `'Txn '` is unchanged, so compiled `.scpt` files keep working.
-> Fixed in [#923](https://github.com/ajsutton/moolah-native/issues/923).
+> See [#923](https://github.com/ajsutton/moolah-native/issues/923) for background on the reserved-word constraint.
 
 ### Earmark Operations
 

--- a/.claude/skills/automate-app/SKILL.md
+++ b/.claude/skills/automate-app/SKILL.md
@@ -115,37 +115,39 @@ moolah-tell 'delete account "New Account" of profile "Test"'
 
 ```bash
 # Create a simple expense
-moolah-tell 'tell profile "Test" to create transaction with payee "Woolworths" amount -42.50 account "Everyday" category "Groceries"'
+moolah-tell 'tell profile "Test" to create txn with payee "Woolworths" amount -42.50 account "Everyday" category "Groceries"'
 
 # Create with date and notes
-moolah-tell 'tell profile "Test" to create transaction with payee "Rent" amount -2000.00 account "Everyday" date (date "2026-04-01") notes "April rent"'
+moolah-tell 'tell profile "Test" to create txn with payee "Rent" amount -2000.00 account "Everyday" date (date "2026-04-01") notes "April rent"'
 
 # Create income
-moolah-tell 'tell profile "Test" to create transaction with payee "Employer" amount 5000.00 account "Everyday" category "Salary"'
+moolah-tell 'tell profile "Test" to create txn with payee "Employer" amount 5000.00 account "Everyday" category "Salary"'
 
-# List transactions (payee and amount)
-moolah-tell 'get {payee, amount} of every transaction of profile "Test"'
+# List txns (payee and amount)
+moolah-tell 'get {payee, amount} of every txn of profile "Test"'
 
-# Get transaction details
-moolah-tell 'get {payee, date, amount, transaction type} of every transaction of profile "Test"'
+# Get txn details
+moolah-tell 'get {payee, date, amount, transaction type} of every txn of profile "Test"'
 
-# Delete a transaction
-moolah-tell 'delete transaction id "UUID-HERE" of profile "Test"'
+# Delete a txn
+moolah-tell 'delete txn id "UUID-HERE" of profile "Test"'
 
-# Pay a scheduled transaction
-moolah-tell 'pay transaction id "UUID-HERE" of profile "Test"'
+# Pay a scheduled txn
+moolah-tell 'pay txn id "UUID-HERE" of profile "Test"'
 ```
 
-> **Caveat — the singular `transaction` class term is shadowed.** The
-> dictionary defines a `transaction type` *property*, which the AppleScript
-> parser prefers over the `transaction` *class*. As a result, specifiers that
-> use the bare class term — `every transaction whose …`, `transaction id "…"`
-> in some positions — can fail to parse ("Expected class name but found
-> transaction"). `count transactions of profile …` (plural element) and
-> `get … of every transaction of profile …` work. To clear a synced
-> account's imported data, prefer `reset import` (below) over deleting each
-> transaction by id. Tracked in
-> [#923](https://github.com/ajsutton/moolah-native/issues/923).
+> **The transaction class is named `txn` in AppleScript.** The word
+> "transaction" is reserved in AppleScript itself (System Events ships
+> `begin transaction`/`end transaction`/`abort transaction` in its
+> `misc` suite), so the bare class term cannot resolve as a class name
+> in `every transaction`/`transaction id "…"`/`whose` contexts —
+> the parser tokenises it as a keyword. Use `txn` instead:
+> `every txn of profile "…" whose id is "…"`,
+> `delete txn id "…" of profile "…"`,
+> `count txns of profile "…"`,
+> `create txn in profile "…" with payee "…" amount …`. The four-char
+> code `'Txn '` is unchanged, so compiled `.scpt` files keep working.
+> Fixed in [#923](https://github.com/ajsutton/moolah-native/issues/923).
 
 ### Earmark Operations
 
@@ -303,8 +305,8 @@ moolah-tell 'navigate to earmark "Holiday" of profile "Test"'
 # 1. Check initial balance
 moolah-tell 'get balance of account "Everyday" of profile "Test"'
 
-# 2. Create a transaction
-moolah-tell 'tell profile "Test" to create transaction with payee "Test Purchase" amount -25.00 account "Everyday"'
+# 2. Create a txn
+moolah-tell 'tell profile "Test" to create txn with payee "Test Purchase" amount -25.00 account "Everyday"'
 
 # 3. Verify balance changed
 moolah-tell 'get balance of account "Everyday" of profile "Test"'
@@ -332,9 +334,9 @@ tell profile "AI Test"
   create category name "Transport"
   create category name "Salary"
   create earmark name "Emergency Fund" target 10000.00
-  create transaction with payee "Employer" amount 5000.00 account "Checking" category "Salary"
-  create transaction with payee "Groceries" amount -150.00 account "Checking" category "Food"
-  create transaction with payee "Gas" amount -60.00 account "Credit Card" category "Transport"
+  create txn with payee "Employer" amount 5000.00 account "Checking" category "Salary"
+  create txn with payee "Groceries" amount -150.00 account "Checking" category "Food"
+  create txn with payee "Gas" amount -60.00 account "Credit Card" category "Transport"
 end tell
 EOF
 ```

--- a/Automation/AppleScript/Commands/CreateTransactionCommand.swift
+++ b/Automation/AppleScript/Commands/CreateTransactionCommand.swift
@@ -5,7 +5,7 @@
 
   private let logger = Logger(subsystem: "com.moolah.app", category: "CreateTransactionCommand")
 
-  /// Handles: `create transaction profile "X" with payee "Store" amount -42.50 account "Checking"`
+  /// Handles: `create txn in profile "X" with payee "Store" amount -42.50 account "Checking"`
   class CreateTransactionCommand: AppLevelScriptCommand {
     override func performDefaultImplementation() -> Any? {
       guard let profileName = resolveProfileName() else {

--- a/Automation/AppleScript/Commands/PayScheduledCommand.swift
+++ b/Automation/AppleScript/Commands/PayScheduledCommand.swift
@@ -5,7 +5,7 @@
 
   private let logger = Logger(subsystem: "com.moolah.app", category: "PayScheduledCommand")
 
-  /// Handles: `pay transaction id "uuid" of profile "X"`
+  /// Handles: `pay txn id "uuid" of profile "X"`
   class PayScheduledCommand: AppLevelScriptCommand {
     override func performDefaultImplementation() -> Any? {
       guard let specifier = directParameter as? NSScriptObjectSpecifier else {

--- a/Automation/AppleScript/Commands/ResetImportCommand.swift
+++ b/Automation/AppleScript/Commands/ResetImportCommand.swift
@@ -7,9 +7,11 @@
 
   /// Handles: `reset import of account "Coinstash" of profile "X"`
   ///
-  /// Deletes every transaction with a leg on the account so a subsequent
-  /// `synchronize` re-imports it from scratch. Uses an account specifier
-  /// rather than iterating by `txn id` for efficiency.
+  /// Deletes every transaction with a leg on the account in a single
+  /// operation so a subsequent `synchronize` re-imports it from scratch.
+  /// Prefer this over iterating `delete txn id` when you want to clear an
+  /// entire synced account — the bulk path is atomic and avoids O(n)
+  /// AppleScript round trips.
   class ResetImportCommand: AppLevelScriptCommand {
     override func performDefaultImplementation() -> Any? {
       guard let specifier = directParameter as? NSScriptObjectSpecifier else {

--- a/Automation/AppleScript/Commands/ResetImportCommand.swift
+++ b/Automation/AppleScript/Commands/ResetImportCommand.swift
@@ -8,10 +8,8 @@
   /// Handles: `reset import of account "Coinstash" of profile "X"`
   ///
   /// Deletes every transaction with a leg on the account so a subsequent
-  /// `synchronize` re-imports it from scratch. A per-transaction `id`
-  /// specifier can't be used here: the `transaction` class term is shadowed
-  /// by the `transaction type` property in the dictionary, so an account
-  /// specifier (which parses cleanly) is the workable handle.
+  /// `synchronize` re-imports it from scratch. Uses an account specifier
+  /// rather than iterating by `txn id` for efficiency.
   class ResetImportCommand: AppLevelScriptCommand {
     override func performDefaultImplementation() -> Any? {
       guard let specifier = directParameter as? NSScriptObjectSpecifier else {

--- a/Automation/AppleScript/Moolah.sdef
+++ b/Automation/AppleScript/Moolah.sdef
@@ -48,7 +48,7 @@
       <element type="account" access="r">
         <cocoa key="scriptableAccounts"/>
       </element>
-      <element type="transaction" access="r">
+      <element type="txn" access="r">
         <cocoa key="scriptableTransactions"/>
       </element>
       <element type="earmark" access="r">
@@ -85,7 +85,7 @@
       </property>
     </class>
 
-    <class name="transaction" code="Txn " description="A financial transaction." plural="transactions">
+    <class name="txn" code="Txn " description="A financial transaction." plural="txns">
       <cocoa class="Moolah.ScriptableTransaction"/>
       <property name="id" code="ID  " type="text" access="r" description="The unique identifier of the transaction.">
         <cocoa key="uniqueID"/>
@@ -172,7 +172,7 @@
       <result type="account" description="The created account."/>
     </command>
 
-    <command name="create transaction" code="Moolcrtx" description="Create a new transaction in a profile.">
+    <command name="create txn" code="Moolcrtx" description="Create a new txn in a profile.">
       <cocoa class="Moolah.CreateTransactionCommand"/>
       <direct-parameter type="specifier" description="The profile to create the transaction in."/>
       <parameter name="with payee" code="Cpay" type="text" description="The payee for the transaction.">
@@ -193,7 +193,7 @@
       <parameter name="notes" code="Cnts" type="text" optional="yes" description="Notes for the transaction.">
         <cocoa key="notes"/>
       </parameter>
-      <result type="transaction" description="The created transaction."/>
+      <result type="txn" description="The created txn."/>
     </command>
 
     <command name="create earmark" code="Moolcrem" description="Create a new earmark in a profile.">
@@ -233,7 +233,7 @@
     <command name="pay" code="Moolpays" description="Pay a scheduled transaction.">
       <cocoa class="Moolah.PayScheduledCommand"/>
       <direct-parameter type="specifier" description="The scheduled transaction to pay."/>
-      <result type="transaction" description="The paid transaction."/>
+      <result type="txn" description="The paid txn."/>
     </command>
 
     <command name="refresh" code="Moolrefr" description="Refresh all data for a profile.">

--- a/plans/2026-05-21-applescript-txn-rename-design.md
+++ b/plans/2026-05-21-applescript-txn-rename-design.md
@@ -1,0 +1,173 @@
+# AppleScript `transaction` Class Rename to `txn` (#923)
+
+**Issue:** [#923](https://github.com/ajsutton/moolah-native/issues/923).
+**Status:** Design — not yet implemented.
+**Date:** 2026-05-21.
+
+## Problem
+
+`Automation/AppleScript/Moolah.sdef` defines a class with `name="transaction"`.
+The word "transaction" is **reserved in the AppleScript language itself** —
+System Events ships three compound commands using it (`begin transaction`,
+`end transaction`, `abort transaction`, from the `misc` suite). The
+AppleScript parser tokenises any bare `transaction` as a keyword, not a
+class-name token. As a result, every specifier that asks for `transaction`
+in a class-name position fails to parse:
+
+```
+get id of every transaction of profile "X"
+   → syntax error: Expected class name but found "transaction". (-2741)
+every transaction of profile "X" whose id is "<uuid>"
+   → syntax error.
+delete transaction id "<uuid>" of profile "X"
+   → syntax error.
+```
+
+The same error reproduces inside `tell application "Finder"` with no
+Moolah involved at all, confirming the term is poisoned globally and not
+by anything Moolah does in its terminology table.
+
+This makes the singular class addressing — the canonical way to delete or
+mutate one row by id, or to filter a list by a `whose` predicate — entirely
+unavailable for transactions. Other Moolah classes (`account`, `earmark`,
+`category`) work fine: their human terms are not reserved.
+
+## Initial Misdiagnosis (Recorded for Context)
+
+The issue text and an earlier draft of this spec hypothesised that the
+problem was the `transaction type` property's name shadowing the class
+term, and proposed renaming `transaction type` → `type`. That fix was
+implemented and verified against the running app — it had no effect on
+the parse error. The property rename was a defensible cleanup (the new
+`type` is consistent with `leg.type`) but not the cause of #923. Reverted
+before this revised spec.
+
+The actual root cause was found by removing each of `create transaction`,
+`<result type="transaction">`, and other transaction-touching terminology
+in turn and confirming no change in parser behaviour. The parse error
+reproduces against Finder, so the reservation is in the AppleScript
+language, not in Moolah's dictionary.
+
+## Goal
+
+Make every singular `transaction`-class specifier parse correctly —
+including the bare class form in `every X`, `X id "…"`, and
+`X whose …` positions — without touching the Swift handlers
+(`ScriptableTransaction`, `CreateTransactionCommand`, etc.) and without
+changing the four-char code (`Txn `) that compiled scripts may depend on.
+
+## Fix
+
+Rename the class in `Automation/AppleScript/Moolah.sdef`:
+
+| Was | Becomes |
+|---|---|
+| `<class name="transaction" code="Txn " plural="transactions">` | `<class name="txn" code="Txn " plural="txns">` |
+| `<element type="transaction" …>` on `profile` | `<element type="txn" …>` |
+| `<command name="create transaction" code="Moolcrtx" …>` | `<command name="create txn" code="Moolcrtx" …>` |
+| `<result type="transaction" …>` on `create transaction` | `<result type="txn" …>` |
+| `<result type="transaction" …>` on `pay` | `<result type="txn" …>` |
+
+The four-char code (`Txn `), the cocoa class (`Moolah.ScriptableTransaction`),
+the cocoa key (`scriptableTransactions` on profile's element), the
+cocoa command class (`Moolah.CreateTransactionCommand`), and every Swift
+file under `Automation/AppleScript/` stay untouched. Only the AppleScript-
+visible terms change.
+
+### Why `txn`
+
+- Short, unambiguous, and obviously the abbreviation of `transaction` —
+  scripters reading existing internal automation will recognise it
+  immediately.
+- Not reserved anywhere in AppleScript's standard suites or in System
+  Events' command set. Verified by the diagnostic agent's probe.
+- Other candidates considered and rejected:
+  - `entry` — generic; collides with vague mental model around
+    dictionary entries and could read awkwardly in `whose` clauses.
+  - `payment` — semantically wrong; income transactions are not
+    payments.
+  - `record` — generic AppleScript value-type term; would confuse
+    scripters expecting a dictionary record.
+  - `ledger entry` — two-word term reintroduces multi-word-class
+    fragility.
+  - Keep `transaction` and add a synonym — leaves a known-broken
+    term in the public dictionary as a footgun; user prefers a clean
+    rename.
+
+### Why the Plural `txns` (Not `transactions`)
+
+The plural form is what AppleScript exposes in `every txns` (parser
+internally maps `every X` to the class's `plural=`). Keeping the plural
+as `transactions` would defeat the purpose — `every transactions of
+profile "X"` would still trip the parser's reserved-word lookup on the
+stem. `txns` is the natural plural of the new singular and is not
+reserved.
+
+## Compatibility Notes
+
+The user has explicitly waived AppleScript back-compat for human-typed
+scripts as part of fixing this issue. Concretely:
+
+- **Existing AppleScripts** that mention `transaction` or
+  `transactions` by name must update to `txn` / `txns`. The
+  `automate-app` skill doc is the largest consumer; its examples are
+  updated in the same commit as the sdef change.
+- **Compiled `.scpt` files** that store the class as a four-char code
+  (`'Txn '`) continue to resolve correctly — the code is unchanged.
+- **The Cocoa Scripting bridge** is untouched: `ScriptableTransaction`,
+  `transactionType` `@objc` property, `CreateTransactionCommand`, and
+  every other Swift handler keep their names. Only the human-readable
+  AppleScript term changes; nothing in Swift moves.
+
+## Verification
+
+1. `just build-mac` and launch the app.
+2. Run the previously-failing repros from the issue with the new term:
+   - `get id of every txn of profile "X"` → returns a list.
+   - `delete txn id "<uuid>" of profile "X"` → succeeds (row vanishes
+     from the UI on the next tick).
+   - `every txn of profile "X" whose id is "<uuid>"` → returns a list
+     of one.
+3. Negative-control: the old form still errors (confirming we didn't
+   somehow silently keep the broken term):
+   - `every transaction of profile "X"` → `-2741`.
+4. Regression: previously-working forms keep working with the new
+   terms:
+   - `count txns of profile "X"` → returns the same integer as
+     `count transactions of profile "X"` would have prior to the
+     rename.
+   - `get {payee, amount} of every txn of profile "X"` → list of pairs.
+5. Verify `create txn` works:
+   - `create txn in profile "X" with payee "Coffee" amount -5.0 account "Checking"`
+     → returns a txn reference.
+
+The sdef is bundled at build time and read by Cocoa Scripting at
+runtime; there is no Swift compile-time check for AppleScript term
+names. Verification is via the live app and the `moolah-tell` helper.
+
+## Implementation Surface
+
+| File | Change |
+|---|---|
+| `Automation/AppleScript/Moolah.sdef` | Rename five terminology entries listed in the table above. ~5 single-line edits. |
+| `.claude/skills/automate-app/SKILL.md` | Replace the existing shadow caveat with a short note documenting the rename and the four-char-code stability. Update all example commands using `transaction` / `transactions` to `txn` / `txns`. |
+| `Automation/AppleScript/Commands/ResetImportCommand.swift` (doc comment only) | The stale shadow-justification comment can be dropped — but the command itself stays useful as a bulk-clear primitive on synced accounts. |
+
+No CloudKit schema change, no GRDB schema change, no `project.yml`
+change, no test file change (no unit tests exist for the sdef;
+verification is manual against the live app per existing project
+pattern).
+
+## Out of Scope
+
+- The previous draft's `transaction type` → `type` property rename.
+  Defensible standalone cleanup (matches `leg.type`) but not part of
+  #923's actual fix. A separate PR can address it later if anyone wants
+  the symmetry.
+- No new commands. No new properties. No four-char-code changes.
+- No Swift refactor.
+
+## Open Questions
+
+None. User has confirmed `txn` and approved a full rename over the
+synonym approach.

--- a/plans/2026-05-21-applescript-txn-rename-plan.md
+++ b/plans/2026-05-21-applescript-txn-rename-plan.md
@@ -1,0 +1,462 @@
+# AppleScript `txn` Rename — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` to implement this plan task-by-task. Per-task verify includes `just format-check` plus the live AppleScript repros listed in the verification task.
+
+**Spec:** `plans/2026-05-21-applescript-txn-rename-design.md` (commit `e5815c86`).
+**Issue:** [#923](https://github.com/ajsutton/moolah-native/issues/923).
+
+**Goal:** Rename the AppleScript `transaction` class to `txn` in `Moolah.sdef` so the bare class term parses (the previous name was poisoned by AppleScript's reserved `transaction` keyword from System Events). Four-char code `Txn ` and all Swift handlers stay untouched.
+
+**Architecture:** Five-line edit in the `.sdef` (class name, profile element, create command name, two result types) plus a doc sweep in `automate-app/SKILL.md`. Cocoa keys / Swift classes are unchanged; the bridge to `Moolah.ScriptableTransaction` etc. still works through the unchanged four-char codes and cocoa-key strings.
+
+**Tech Stack:** Apple Cocoa Scripting (`.sdef`), bundled into the macOS app at build time. Verification is via the live app using `.claude/skills/automate-app/scripts/moolah-tell`.
+
+---
+
+## File Structure
+
+**Modify:**
+
+- `Automation/AppleScript/Moolah.sdef` — five terminology edits (class `name=` / `plural=`, profile `<element type=>`, `create transaction` command `name=`, two `<result type=>` attributes).
+- `.claude/skills/automate-app/SKILL.md` — replace the obsolete `#923` caveat with a short rename note; rewrite every example using `transaction` / `transactions` to `txn` / `txns`.
+- `Automation/AppleScript/Commands/ResetImportCommand.swift` — drop the stale "shadow workaround" doc comment that justified the command's existence.
+
+**Create:** None.
+
+**Out of scope:**
+
+- No Swift handler code changes. The `@objc var transactionType` on `ScriptableTransaction`, the `CreateTransactionCommand` class, etc. all keep their names.
+- No four-char code changes — `Txn `, `Mtty`, `Maty`, `Moolcrtx`, all unchanged. Compiled `.scpt` files referencing the codes continue to resolve.
+- No `project.yml`, no CloudKit/GRDB schema, no unit-test changes.
+
+---
+
+## Task 1 — Rename the class and related terminology in the sdef
+
+**File:** `Automation/AppleScript/Moolah.sdef`
+
+### Steps
+
+- [ ] **Step 1: Read the current state.**
+
+Open `Automation/AppleScript/Moolah.sdef` and locate the five edit sites. (If unrelated commits land on main while this PR is in flight, the line numbers may shift; grep for the exact strings before each edit rather than relying on positional offsets.)
+
+- [ ] **Step 2: Rename the class declaration (around line 88).**
+
+Replace:
+
+```xml
+    <class name="transaction" code="Txn " description="A financial transaction." plural="transactions">
+```
+
+with:
+
+```xml
+    <class name="txn" code="Txn " description="A financial transaction." plural="txns">
+```
+
+The four-char code (`Txn `), the description, and the `<cocoa class="Moolah.ScriptableTransaction"/>` child stay exactly as-is. Only `name=` and `plural=` change.
+
+- [ ] **Step 3: Rename the element on the `profile` class (around line 51).**
+
+Replace:
+
+```xml
+      <element type="transaction" access="r">
+        <cocoa key="scriptableTransactions"/>
+      </element>
+```
+
+with:
+
+```xml
+      <element type="txn" access="r">
+        <cocoa key="scriptableTransactions"/>
+      </element>
+```
+
+Only `type="transaction"` → `type="txn"`. The cocoa key stays `scriptableTransactions` (it's the Swift binding key — that property exists on `ScriptableProfile` in Swift).
+
+- [ ] **Step 4: Rename the `create transaction` command (around line 175).**
+
+Replace:
+
+```xml
+    <command name="create transaction" code="Moolcrtx" description="Create a new transaction in a profile.">
+      <cocoa class="Moolah.CreateTransactionCommand"/>
+```
+
+with:
+
+```xml
+    <command name="create txn" code="Moolcrtx" description="Create a new txn in a profile.">
+      <cocoa class="Moolah.CreateTransactionCommand"/>
+```
+
+The cocoa class (Swift) stays. The four-char code (`Moolcrtx`) stays. Only the human term and the description's word change.
+
+- [ ] **Step 5: Rename the result type on `create transaction` (around line 196).**
+
+Replace:
+
+```xml
+      <result type="transaction" description="The created transaction."/>
+```
+
+with:
+
+```xml
+      <result type="txn" description="The created txn."/>
+```
+
+- [ ] **Step 6: Rename the result type on `pay` (around line 236).**
+
+Replace:
+
+```xml
+      <result type="transaction" description="The paid transaction."/>
+```
+
+with:
+
+```xml
+      <result type="txn" description="The paid txn."/>
+```
+
+- [ ] **Step 7: Sanity-grep the modified sdef.**
+
+```bash
+grep -nE 'type="transaction"|name="transaction"|name="create transaction"' Automation/AppleScript/Moolah.sdef
+# Expected: no matches.
+
+grep -cE 'type="txn"|name="txn"|name="create txn"' Automation/AppleScript/Moolah.sdef
+# Expected: 4
+#   - 1 × class name="txn"
+#   - 1 × element type="txn" on profile
+#   - 1 × command name="create txn"
+#   - 2 × result type="txn"  (create txn + pay)
+# Total: 5 — but `name=` matches only count as one of the "name=…" tests; the
+# four-line count = 1(class) + 1(element) + 1(command) + 2(results) = 5.
+# If the count is 4, you missed one site. If 6+, an unrelated `type="txn"`
+# slipped in.
+
+grep -E 'plural="transactions"' Automation/AppleScript/Moolah.sdef
+# Expected: no matches (the plural is now "txns").
+```
+
+If any of these come back with the wrong count, locate the missing or extra edit and fix it before moving on.
+
+- [ ] **Step 8: Build the macOS app.**
+
+```bash
+just build-mac
+```
+
+Expected: `** BUILD SUCCEEDED **`, no warnings. The sdef is XML — xcodebuild's resource-copy step parses it during build and will flag malformed XML.
+
+- [ ] **Step 9: Verify the bundled sdef.**
+
+```bash
+grep -E 'name="(transaction|txn)"' .DerivedData-mac/Build/Products/Debug/Moolah.app/Contents/Resources/Moolah.sdef
+# Expected: exactly one match — name="txn" on the class.
+# `name="transaction"` should NOT appear anywhere.
+```
+
+- [ ] **Step 10: format-check.**
+
+```bash
+just format-check
+```
+
+Expected: `All Swift files are correctly formatted.` (non-Swift files pass through.)
+
+- [ ] **Step 11: Commit.**
+
+```bash
+git -C /Users/aj/Documents/code/moolah-project/moolah-native/.claude/worktrees/applescript-shadow-923 add Automation/AppleScript/Moolah.sdef
+git -C /Users/aj/Documents/code/moolah-project/moolah-native/.claude/worktrees/applescript-shadow-923 commit -m "fix(applescript): rename transaction class to txn (#923)
+
+The word 'transaction' is reserved in the AppleScript language itself
+(System Events ships begin/end/abort transaction in its 'misc' suite),
+so the bare class term could never resolve in 'every transaction',
+'transaction id', or 'whose' contexts — the parser tokenises it as a
+keyword. Confirmed by reproducing the same -2741 'Expected class name
+but found transaction' error inside tell application 'Finder' with no
+Moolah involved.
+
+Rename the class to 'txn' (and 'transactions' → 'txns', 'create
+transaction' → 'create txn'). Four-char codes (Txn , Moolcrtx) and
+cocoa keys / class names (Moolah.ScriptableTransaction, Moolah.Create
+TransactionCommand, transactionType, scriptableTransactions) are all
+unchanged; only the AppleScript-visible terms move. Compiled scripts
+using the codes continue to resolve.
+
+Fixes #923."
+```
+
+---
+
+## Task 2 — Update the `automate-app` skill doc
+
+**File:** `.claude/skills/automate-app/SKILL.md`
+
+### Steps
+
+- [ ] **Step 1: Find the existing #923 caveat block.**
+
+Open `.claude/skills/automate-app/SKILL.md` and find the block starting `> **Caveat — the singular \`transaction\` class term is shadowed.**` (around line 139, runs through ~line 148).
+
+- [ ] **Step 2: Replace the caveat with a rename note.**
+
+Replace the whole block with:
+
+```markdown
+> **The transaction class is named `txn` in AppleScript.** The word
+> "transaction" is reserved in AppleScript itself (System Events ships
+> `begin transaction`/`end transaction`/`abort transaction` in its
+> `misc` suite), so the bare class term cannot resolve as a class name
+> in `every transaction`/`transaction id "…"`/`whose` contexts —
+> the parser tokenises it as a keyword. Use `txn` instead:
+> `every txn of profile "…" whose id is "…"`,
+> `delete txn id "…" of profile "…"`,
+> `count txns of profile "…"`,
+> `create txn in profile "…" with payee "…" amount …`. The four-char
+> code `'Txn '` is unchanged, so compiled `.scpt` files keep working.
+> Fixed in [#923](https://github.com/ajsutton/moolah-native/issues/923).
+```
+
+Preserve one blank line before and after.
+
+- [ ] **Step 3: Rewrite every example in the doc that uses `transaction` or `transactions`.**
+
+First, locate every example:
+
+```bash
+grep -n -E '\btransaction[s]?\b' .claude/skills/automate-app/SKILL.md
+```
+
+For each line, decide whether the use is a code/example reference (should change to `txn`/`txns`) or prose narrative (leave alone or rephrase as needed). Be specific:
+
+| Old text in example | New text |
+|---|---|
+| `count transactions of profile` | `count txns of profile` |
+| `every transaction of profile` | `every txn of profile` |
+| `delete transaction id "…"` | `delete txn id "…"` |
+| `create transaction in profile` | `create txn in profile` |
+| `get {payee, amount} of every transaction` | `get {payee, amount} of every txn` |
+| `pay <transaction-specifier>` | `pay <txn-specifier>` |
+
+Prose like "the transaction subsystem" or "transaction history" describing user-facing concepts can stay — those don't refer to the AppleScript term. Use judgement; keep the doc readable.
+
+- [ ] **Step 4: Re-grep to confirm.**
+
+```bash
+grep -n -E '\btransaction[s]?\b' .claude/skills/automate-app/SKILL.md
+```
+
+Inspect the remaining hits. Only the new caveat-replacement note (which mentions the reserved word) and any pure-prose uses should remain. No example commands should still use the old terms.
+
+- [ ] **Step 5: Sanity-grep the repo for any other consumer.**
+
+```bash
+grep -rn -E '\bcreate transaction\b|every transaction|count transactions|delete transaction' \
+  .claude/skills/ Automation/ plans/ guides/ 2>/dev/null \
+  | grep -v 'plans/2026-05-21-applescript-txn-rename'
+```
+
+The plan and spec for this work are excluded by the `grep -v`. Any other match is a stale reference to update. If a Swift doc-comment mentions an AppleScript example using the old terms, update it. Common sites:
+- `Automation/AppleScript/Commands/*.swift` — class-level doc comments often quote the AppleScript form they handle.
+- `guides/` — may have user-facing automation doc.
+
+- [ ] **Step 6: format-check.**
+
+```bash
+just format-check
+```
+
+- [ ] **Step 7: Commit.**
+
+```bash
+git -C /Users/aj/Documents/code/moolah-project/moolah-native/.claude/worktrees/applescript-shadow-923 add .claude/skills/automate-app/SKILL.md
+# If you also updated other docs (Step 5), add them in the same commit:
+# git -C <worktree> add <other-files>
+git -C /Users/aj/Documents/code/moolah-project/moolah-native/.claude/worktrees/applescript-shadow-923 commit -m "docs(automate-app): switch examples from transaction to txn (#923)
+
+The AppleScript class was renamed to txn (Task 1). Update every example
+in the skill doc to the new term, and replace the shadow caveat with a
+short note pointing scripters at the rename and the underlying
+reserved-word cause."
+```
+
+---
+
+## Task 3 — Drop the stale ResetImport doc comment
+
+**File:** `Automation/AppleScript/Commands/ResetImportCommand.swift`
+
+### Steps
+
+- [ ] **Step 1: Read the current doc comment.**
+
+The doc comment above `class ResetImportCommand` previously justified the command as a workaround for the shadow bug (it said per-transaction id specifiers couldn't be used because of the shadow). That justification is obsolete now — `delete txn id "…"` works.
+
+- [ ] **Step 2: Trim the comment to describe what the command does, not why it was needed.**
+
+Locate the comment block above `class ResetImportCommand`. Keep the "Handles: …" line and the description of what the command does. Drop any lines that read like "we needed this because the per-id specifier was broken". If the surviving comment reads naturally, leave it alone — minimal edits only.
+
+Suggested final shape (adapt to whatever the surviving text needs):
+
+```swift
+  /// Handles: `reset import of account "Coinstash" of profile "X"`
+  ///
+  /// Deletes every transaction with a leg on the account so a subsequent
+  /// `synchronize` re-imports it from scratch.
+```
+
+- [ ] **Step 3: Build and format-check.**
+
+```bash
+just build-mac
+just format-check
+```
+
+Expected: clean.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git -C /Users/aj/Documents/code/moolah-project/moolah-native/.claude/worktrees/applescript-shadow-923 add Automation/AppleScript/Commands/ResetImportCommand.swift
+git -C /Users/aj/Documents/code/moolah-project/moolah-native/.claude/worktrees/applescript-shadow-923 commit -m "docs(applescript): drop stale shadow justification from ResetImportCommand (#923)
+
+The command was originally framed as a workaround for the bare-class
+shadow. The shadow is gone (Task 1 renamed the class to txn). Trim
+the doc comment to describe what the command does, not why we used to
+need it. The command itself stays — it's still a useful bulk-clear
+primitive for synced-account testing."
+```
+
+---
+
+## Task 4 — End-to-end verification against the running app
+
+**Files:** none modified.
+
+### Steps
+
+- [ ] **Step 1: Build and launch.**
+
+```bash
+just build-mac
+pkill -f 'Moolah.app' 2>/dev/null || true
+just run-mac &
+sleep 5
+```
+
+(Kill stale Moolah processes first per memory `reference_macos_test_runner_hang.md`.)
+
+- [ ] **Step 2: List profiles and pick one with at least one transaction.**
+
+```bash
+.claude/skills/automate-app/scripts/moolah-tell 'get name of every profile'
+```
+
+Pick a profile (prefer "Large Test Profile" if listed) — call its name `<profile>` in the steps below.
+
+- [ ] **Step 3: Confirm the new bare-class form parses (the primary acceptance criterion for #923).**
+
+```bash
+.claude/skills/automate-app/scripts/moolah-tell \
+  'get id of every txn of profile "<profile>"'
+```
+
+Pass condition: parses, returns a list of UUIDs. **If this still errors with `-2741 Expected class name but found "txn"`, the rename did not take. Stop, re-check the sdef, rebuild.**
+
+Save the first UUID as `<uuid>` for the next steps.
+
+- [ ] **Step 4: Run the issue's three previously-failing repros with the new term.**
+
+```bash
+# Repro 1 — predicate addressing
+.claude/skills/automate-app/scripts/moolah-tell \
+  'every txn of profile "<profile>" whose id is "<uuid>"'
+# Expected: a list of one reference.
+
+# Repro 2 — id-addressed delete with a FAKE uuid (parse-only check; we do
+# not actually want to delete a real row in the test profile)
+.claude/skills/automate-app/scripts/moolah-tell \
+  'delete txn id "00000000-0000-0000-0000-000000000000" of profile "<profile>"'
+# Pass condition: parses; runtime "no such object" or silent success are
+# both acceptable. -2741 is NOT acceptable.
+
+# Repro 3 — every-id (also covered in Step 3, but logged here for the
+# verification record).
+.checked-as-step-3
+```
+
+- [ ] **Step 5: Negative-control — confirm the old `transaction` term now errors at a parser level.**
+
+```bash
+.claude/skills/automate-app/scripts/moolah-tell \
+  'get id of every transaction of profile "<profile>"' 2>&1 | head -3
+```
+
+Expected: still errors with `-2741 Expected class name but found "transaction"` (or similar). This confirms we actually changed the term — not just added an alias. If THIS form mysteriously starts working, something else changed.
+
+- [ ] **Step 6: Regression check — previously-working plural / aggregate forms work with the new plural.**
+
+```bash
+.claude/skills/automate-app/scripts/moolah-tell \
+  'count txns of profile "<profile>"'
+# Expected: a positive integer.
+
+.claude/skills/automate-app/scripts/moolah-tell \
+  'get {payee, amount} of every txn of profile "<profile>"'
+# Expected: a list of payee/amount pairs.
+```
+
+- [ ] **Step 7: Verify `create txn` still works.**
+
+```bash
+.claude/skills/automate-app/scripts/moolah-tell \
+  'create txn in profile "<profile>" with payee "Plan Test" amount -1.23 account "<account-name>"'
+# Expected: returns a txn reference. Pick `<account-name>` from the
+# profile's accounts (e.g. `get name of every account of profile "X"`).
+```
+
+(Optional: clean up the test row afterwards via `delete txn id "…" of profile "…"` using the returned UUID.)
+
+- [ ] **Step 8: Quit the app.**
+
+```bash
+.claude/skills/automate-app/scripts/moolah-tell 'quit'
+```
+
+- [ ] **Step 9: No commit — Task 4 is a verify pass only.**
+
+If anything in Steps 3-7 produces a `-2741` parse error on a NEW (`txn`) form, return to Task 1 and inspect the sdef. The most common cause of a partial-rename: missing one of the five edit sites in the sdef. The grep counts in Task 1 step 7 are the safety net for that.
+
+---
+
+## Spec Coverage Check (self-review)
+
+| Spec Section | Implemented In |
+|---|---|
+| Class `transaction` → `txn` rename | Task 1 steps 2-3 |
+| `create transaction` → `create txn` | Task 1 step 4 |
+| Result-type renames (`create txn` + `pay`) | Task 1 steps 5-6 |
+| Plural `transactions` → `txns` | Task 1 step 2 |
+| Four-char code unchanged | Enforced by Task 1's edit instructions (only `name=` / `plural=` / `type=` change). |
+| Cocoa class / cocoa key unchanged | Enforced by the same instructions. |
+| SKILL.md caveat replacement | Task 2 step 2 |
+| Doc example sweep | Task 2 step 3-5 |
+| Drop stale ResetImport justification | Task 3 |
+| Live verification of previously-failing repros | Task 4 steps 3-4 |
+| Negative-control of old term | Task 4 step 5 |
+| Regression of plural / aggregate forms | Task 4 step 6 |
+| `create txn` still works | Task 4 step 7 |
+
+## Placeholder & Consistency Scan
+
+- No TBDs / TODOs in the plan body.
+- The new class name (`txn`), plural (`txns`), command (`create txn`), and four-char code (`Txn `) are used consistently across all tasks.
+- File paths absolute or repo-rooted; git commands use `git -C <worktree>` explicitly per the project rule.


### PR DESCRIPTION
Fixes #923.

## Root cause

The word `transaction` is **reserved in the AppleScript language itself** — System Events ships `begin transaction`, `end transaction`, and `abort transaction` in its `misc` suite. The parser tokenises any bare `transaction` as a keyword, so it cannot resolve as a class name in `every transaction …`, `transaction id "…"`, or `… whose …` positions, regardless of what's in our terminology table. Reproduced inside `tell application "Finder"` with no Moolah involved at all.

The issue's original hypothesis (and an earlier draft of this fix) attributed the symptom to the `transaction type` property shadowing the class. That was a misdiagnosis: a property rename to `type` was attempted, verified against the running app, and had **no effect** on the parse error. Diagnosis was redone — see the spec for the full evidence trail.

## What changes

Rename the class to `txn` in `Automation/AppleScript/Moolah.sdef` — five edit sites:

| Was | Becomes |
|---|---|
| `<class name="transaction" code="Txn " plural="transactions">` | `<class name="txn" code="Txn " plural="txns">` |
| `<element type="transaction" …>` on `profile` | `<element type="txn" …>` |
| `<command name="create transaction" code="Moolcrtx" …>` | `<command name="create txn" code="Moolcrtx" …>` |
| `<result type="transaction" …>` on `create transaction` | `<result type="txn" …>` |
| `<result type="transaction" …>` on `pay` | `<result type="txn" …>` |

**Unchanged** (intentionally): four-char codes (`Txn `, `Moolcrtx`), cocoa class names (`Moolah.ScriptableTransaction`, `Moolah.CreateTransactionCommand`), cocoa keys (`scriptableTransactions`, `transactionType`, ...), every Swift file under `Automation/AppleScript/`. Only the AppleScript-visible terms move.

Plus a doc sweep:

- `.claude/skills/automate-app/SKILL.md` — every example using `transaction`/`transactions` updated to `txn`/`txns`; the old `#923` shadow caveat replaced with a present-tense rename note that explains the reserved-word cause.
- `Automation/AppleScript/Commands/CreateTransactionCommand.swift` — `/// Handles:` example quotes `create txn …`.
- `Automation/AppleScript/Commands/PayScheduledCommand.swift` — `/// Handles:` example quotes `pay txn id "…" …`.
- `Automation/AppleScript/Commands/ResetImportCommand.swift` — stale "shadow workaround" justification dropped; replaced with a `why-not-what` note about the command's bulk-clear-for-resync utility.

## Compatibility

Per the issue's resolution direction, AppleScript back-compat at the human-term level is **not** required:

- Existing human-typed AppleScripts mentioning `transaction` / `transactions` must update to `txn` / `txns`. The `automate-app` skill is the main consumer and is updated in this PR.
- Compiled `.scpt` files referring to the four-char code `'Txn '` continue to resolve — the code is unchanged.
- The Cocoa Scripting bridge is untouched, so the Swift handlers and any other in-process AppleScript consumer continue to work without modification.

## Verification

Manual against the running macOS app via `.claude/skills/automate-app/scripts/moolah-tell` (sdef-bundled terms aren't checked at build time, so verification is necessarily live):

- ✅ `get id of every txn of profile "X"` — parses; returns the full UUID list (was `-2741`).
- ✅ `every txn of profile "X" whose id is "<uuid>"` — parses; returns one reference (was `-2741`).
- ✅ `delete txn id "<uuid>" of profile "X"` — parses; runs (was `-2741`).
- ✅ `create txn in profile "X" with payee "..." amount ... account "..."` — parses; creates the row; returns a `txn id …` reference.
- ✅ `count txns of profile "X"` — returns the same integer the old plural would have.
- ✅ Negative control: `every transaction of profile "X"` STILL errors with `-2741 Expected class name but found "transaction"` (confirms we changed the term rather than added a synonym).

The `code-review` agent ran twice; first pass found 3 findings (one stale `/// Handles:` in `PayScheduledCommand`, one weak `ResetImportCommand` doc justification, one CODE_GUIDE §19 time-travel-framing nit in the skill caveat). All three applied; second pass clean.

## Documents

- Spec: `plans/2026-05-21-applescript-txn-rename-design.md`
- Plan: `plans/2026-05-21-applescript-txn-rename-plan.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
