### PR TITLE
feat(networking): migrate 6 standard clients to RateLimitedHTTPClient

### DIFF
--- a/App/ProfileSession+Factories.swift
+++ b/App/ProfileSession+Factories.swift
@@ -27,13 +27,21 @@ extension ProfileSession {
   /// and assign the trio in one step. Each rate service persists to the
   /// supplied per-profile `database`.
   static func makeMarketDataServices(database: any DatabaseWriter) -> MarketDataServices {
-    let yahooClient = YahooFinanceClient()
+    // TODO(#938): replace with shared NetworkingServices once PR-5 lands.
+    //   https://github.com/ajsutton/moolah-native/issues/938
+    let yahooClient = YahooFinanceClient(
+      http: NetworkingServices().client(forHost: "query2.finance.yahoo.com"))
     let apiKeyStore = KeychainStore(
       service: KeychainServices.apiKeys, account: "coingecko", synchronizable: true
     )
     let coinGeckoApiKey = try? apiKeyStore.restoreString()
     return MarketDataServices(
-      exchangeRate: ExchangeRateService(client: FrankfurterClient(), database: database),
+      exchangeRate: ExchangeRateService(
+        // TODO(#938): replace with shared NetworkingServices once PR-5 lands.
+        //   https://github.com/ajsutton/moolah-native/issues/938
+        client: FrankfurterClient(
+          http: NetworkingServices().client(forHost: "api.frankfurter.app")),
+        database: database),
       stockPrice: StockPriceService(client: yahooClient, database: database),
       cryptoPrice: Self.makeCryptoPriceService(
         coinGeckoApiKey: coinGeckoApiKey, database: database),
@@ -52,26 +60,38 @@ extension ProfileSession {
     coinGeckoApiKey: String?,
     database: any DatabaseWriter
   ) -> CryptoPriceService {
-    let cryptoCompareClient = CryptoCompareClient()
-    let binanceClient = BinanceClient { date in
-      let usdtMapping = CryptoProviderMapping(
-        instrumentId: "1:0xdac17f958d2ee523a2206206994597c13d831ec7",
-        coingeckoId: "tether", cryptocompareSymbol: "USDT", binanceSymbol: nil
-      )
-      do {
-        return try await cryptoCompareClient.dailyPrice(for: usdtMapping, on: date)
-      } catch {
-        return Decimal(1)
-      }
-    }
+    // TODO(#938): replace with shared NetworkingServices once PR-5 lands.
+    //   https://github.com/ajsutton/moolah-native/issues/938
+    let cryptoCompareClient = CryptoCompareClient(
+      http: NetworkingServices().client(forHost: "min-api.cryptocompare.com"))
+    // TODO(#938): replace with shared NetworkingServices once PR-5 lands.
+    //   https://github.com/ajsutton/moolah-native/issues/938
+    let binanceClient = BinanceClient(
+      http: NetworkingServices().client(forHost: "api.binance.com"),
+      usdtRateLookup: { date in
+        let usdtMapping = CryptoProviderMapping(
+          instrumentId: "1:0xdac17f958d2ee523a2206206994597c13d831ec7",
+          coingeckoId: "tether", cryptocompareSymbol: "USDT", binanceSymbol: nil
+        )
+        do {
+          return try await cryptoCompareClient.dailyPrice(for: usdtMapping, on: date)
+        } catch {
+          return Decimal(1)
+        }
+      })
 
     // Empty key → CoinGeckoClient targets the free public host;
     // non-empty key → Pro host with `x_cg_pro_api_key`. Always included
     // so users without a Pro key still get coverage for tokens like
     // USDC that CryptoCompare omits from its contract index.
     let resolverApiKey = coinGeckoApiKey ?? ""
+    // TODO(#938): replace with shared NetworkingServices once PR-5 lands.
+    //   https://github.com/ajsutton/moolah-native/issues/938
+    let cgHost = resolverApiKey.isEmpty ? "api.coingecko.com" : "pro-api.coingecko.com"
     let priceClients: [CryptoPriceClient] = [
-      CoinGeckoClient(apiKey: resolverApiKey),
+      CoinGeckoClient(
+        apiKey: resolverApiKey,
+        http: NetworkingServices().client(forHost: cgHost)),
       cryptoCompareClient,
       binanceClient,
     ]
@@ -173,11 +193,14 @@ extension ProfileSession {
       cryptoPriceService: cryptoPriceService,
       conversionService: cloudBackend.conversionService,
       sharedStore: sharedRegistryStore)
+    // TODO(#938): replace with shared NetworkingServices once PR-5 lands.
+    //   https://github.com/ajsutton/moolah-native/issues/938
     let searchService = InstrumentSearchService(
       registry: cloudBackend.instrumentRegistry,
       catalog: catalog,
       resolutionClient: resolutionClient,
-      stockSearchClient: YahooFinanceStockSearchClient()
+      stockSearchClient: YahooFinanceStockSearchClient(
+        http: NetworkingServices().client(forHost: "query1.finance.yahoo.com"))
     )
     return RegistryWiring(
       registry: cloudBackend.instrumentRegistry,

--- a/Backends/Binance/BinanceClient.swift
+++ b/Backends/Binance/BinanceClient.swift
@@ -1,4 +1,3 @@
-// Backends/Binance/BinanceClient.swift
 import Foundation
 
 struct BinanceClient: CryptoPriceClient, Sendable {
@@ -7,21 +6,15 @@ struct BinanceClient: CryptoPriceClient, Sendable {
   private static let baseURLString = "https://api.binance.com"
   private static let baseURL =
     URL(string: baseURLString) ?? URL(fileURLWithPath: "/")
-  private let session: URLSession
+  private let http: RateLimitedHTTPClient
   private let usdtRateLookup: @Sendable (Date) async -> Decimal
-  private let rateLimitGate: RateLimitGate
-  private let failureCache: FailedRequestCache
 
   init(
-    session: URLSession = .shared,
-    usdtRateLookup: @escaping @Sendable (Date) async -> Decimal = { _ in Decimal(1) },
-    rateLimitGate: RateLimitGate = RateLimitGate(),
-    failureCache: FailedRequestCache = FailedRequestCache()
+    http: RateLimitedHTTPClient,
+    usdtRateLookup: @escaping @Sendable (Date) async -> Decimal = { _ in Decimal(1) }
   ) {
-    self.session = session
+    self.http = http
     self.usdtRateLookup = usdtRateLookup
-    self.rateLimitGate = rateLimitGate
-    self.failureCache = failureCache
   }
 
   func dailyPrice(for mapping: CryptoProviderMapping, on date: Date) async throws -> Decimal {
@@ -50,11 +43,7 @@ struct BinanceClient: CryptoPriceClient, Sendable {
         calendar.date(byAdding: .day, value: 999, to: chunkStart) ?? range.upperBound
       let chunkEnd = min(candleWindowEnd, range.upperBound)
       let url = Self.klinesURL(symbol: symbol, from: chunkStart, to: chunkEnd)
-      let (data, response) = try await session.dataRespectingRateLimit(
-        for: URLRequest(url: url), gate: rateLimitGate, failureCache: failureCache)
-      guard let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) else {
-        throw URLError(.badServerResponse)
-      }
+      let (data, _) = try await http.data(for: URLRequest(url: url))
       let chunk = try Self.parseKlinesResponse(data)
       for (key, value) in chunk { allPrices[key] = value }
       guard let next = calendar.date(byAdding: .day, value: 1, to: chunkEnd) else { break }

--- a/Backends/CoinGecko/CoinGeckoClient.swift
+++ b/Backends/CoinGecko/CoinGeckoClient.swift
@@ -1,4 +1,3 @@
-// Backends/CoinGecko/CoinGeckoClient.swift
 import Foundation
 
 struct CoinGeckoClient: CryptoPriceClient, Sendable {
@@ -14,21 +13,12 @@ struct CoinGeckoClient: CryptoPriceClient, Sendable {
   /// CryptoCompare / Binance if a request 429s.
   private static let publicBaseURL =
     URL(string: "https://api.coingecko.com/api/v3") ?? URL(fileURLWithPath: "/")
-  private let session: URLSession
+  private let http: RateLimitedHTTPClient
   private let apiKey: String
-  private let rateLimitGate: RateLimitGate
-  private let failureCache: FailedRequestCache
 
-  init(
-    session: URLSession = .shared,
-    apiKey: String,
-    rateLimitGate: RateLimitGate = RateLimitGate(),
-    failureCache: FailedRequestCache = FailedRequestCache()
-  ) {
-    self.session = session
+  init(apiKey: String, http: RateLimitedHTTPClient) {
     self.apiKey = apiKey
-    self.rateLimitGate = rateLimitGate
-    self.failureCache = failureCache
+    self.http = http
   }
 
   /// Resolves the base URL by key presence: non-empty → Pro host,
@@ -65,11 +55,7 @@ struct CoinGeckoClient: CryptoPriceClient, Sendable {
       calendar.dateComponents([.day], from: range.lowerBound, to: range.upperBound).day ?? 1
     )
     let url = Self.marketChartURL(coinId: coinId, days: days, apiKey: apiKey)
-    let (data, response) = try await session.dataRespectingRateLimit(
-      for: URLRequest(url: url), gate: rateLimitGate, failureCache: failureCache)
-    guard let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) else {
-      throw URLError(.badServerResponse)
-    }
+    let (data, _) = try await http.data(for: URLRequest(url: url))
     return try Self.parseMarketChartResponse(data)
   }
 
@@ -84,11 +70,7 @@ struct CoinGeckoClient: CryptoPriceClient, Sendable {
     guard !idToMapping.isEmpty else { return [:] }
 
     let url = Self.simplePriceURL(coinIds: Array(idToMapping.keys), apiKey: apiKey)
-    let (data, response) = try await session.dataRespectingRateLimit(
-      for: URLRequest(url: url), gate: rateLimitGate, failureCache: failureCache)
-    guard let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) else {
-      throw URLError(.badServerResponse)
-    }
+    let (data, _) = try await http.data(for: URLRequest(url: url))
     let coinPrices = try Self.parseSimplePriceResponse(data)
 
     var result: [String: Decimal] = [:]

--- a/Backends/CryptoCompare/CryptoCompareClient.swift
+++ b/Backends/CryptoCompare/CryptoCompareClient.swift
@@ -1,4 +1,3 @@
-// Backends/CryptoCompare/CryptoCompareClient.swift
 import Foundation
 
 struct CryptoCompareClient: CryptoPriceClient, Sendable {
@@ -6,18 +5,10 @@ struct CryptoCompareClient: CryptoPriceClient, Sendable {
 
   private static let baseURL =
     URL(string: "https://min-api.cryptocompare.com") ?? URL(fileURLWithPath: "/")
-  private let session: URLSession
-  private let rateLimitGate: RateLimitGate
-  private let failureCache: FailedRequestCache
+  private let http: RateLimitedHTTPClient
 
-  init(
-    session: URLSession = .shared,
-    rateLimitGate: RateLimitGate = RateLimitGate(),
-    failureCache: FailedRequestCache = FailedRequestCache()
-  ) {
-    self.session = session
-    self.rateLimitGate = rateLimitGate
-    self.failureCache = failureCache
+  init(http: RateLimitedHTTPClient) {
+    self.http = http
   }
 
   func dailyPrice(for mapping: CryptoProviderMapping, on date: Date) async throws -> Decimal {
@@ -37,11 +28,7 @@ struct CryptoCompareClient: CryptoPriceClient, Sendable {
         tokenId: mapping.instrumentId, provider: "CryptoCompare")
     }
     let url = Self.histodayURL(symbol: symbol, from: range.lowerBound, to: range.upperBound)
-    let (data, response) = try await session.dataRespectingRateLimit(
-      for: URLRequest(url: url), gate: rateLimitGate, failureCache: failureCache)
-    guard let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) else {
-      throw URLError(.badServerResponse)
-    }
+    let (data, _) = try await http.data(for: URLRequest(url: url))
     return try Self.parseHistodayResponse(data)
   }
 
@@ -56,11 +43,7 @@ struct CryptoCompareClient: CryptoPriceClient, Sendable {
     guard !symbolToMapping.isEmpty else { return [:] }
 
     let url = Self.priceMultiURL(symbols: Array(symbolToMapping.keys))
-    let (data, response) = try await session.dataRespectingRateLimit(
-      for: URLRequest(url: url), gate: rateLimitGate, failureCache: failureCache)
-    guard let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) else {
-      throw URLError(.badServerResponse)
-    }
+    let (data, _) = try await http.data(for: URLRequest(url: url))
     let symbolPrices = try Self.parsePriceMultiResponse(data)
 
     var result: [String: Decimal] = [:]

--- a/Backends/Frankfurter/FrankfurterClient.swift
+++ b/Backends/Frankfurter/FrankfurterClient.swift
@@ -1,6 +1,4 @@
-// Backends/Frankfurter/FrankfurterClient.swift
 import Foundation
-import OSLog
 
 /// Client for the public Frankfurter exchange-rate API.
 /// Uses the range endpoint `<from>..<to>?base=<code>` which returns rates
@@ -11,19 +9,10 @@ import OSLog
 struct FrankfurterClient: ExchangeRateClient, Sendable {
   private static let baseURL =
     URL(string: "https://api.frankfurter.app/") ?? URL(fileURLWithPath: "/")
-  private static let logger = Logger(subsystem: "com.moolah.app", category: "FrankfurterClient")
-  private let session: URLSession
-  private let rateLimitGate: RateLimitGate
-  private let failureCache: FailedRequestCache
+  private let http: RateLimitedHTTPClient
 
-  init(
-    session: URLSession = .shared,
-    rateLimitGate: RateLimitGate = RateLimitGate(),
-    failureCache: FailedRequestCache = FailedRequestCache()
-  ) {
-    self.session = session
-    self.rateLimitGate = rateLimitGate
-    self.failureCache = failureCache
+  init(http: RateLimitedHTTPClient) {
+    self.http = http
   }
 
   func fetchRates(
@@ -42,20 +31,7 @@ struct FrankfurterClient: ExchangeRateClient, Sendable {
 
     let requestURL = components.url ?? url
     let request = URLRequest(url: requestURL)
-    let (data, response) = try await session.dataRespectingRateLimit(
-      for: request, gate: rateLimitGate, failureCache: failureCache)
-
-    guard let httpResponse = response as? HTTPURLResponse,
-      (200...299).contains(httpResponse.statusCode)
-    else {
-      let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
-      let body = String(data: data, encoding: .utf8) ?? "<non-utf8>"
-      Self.logger.error(
-        "Exchange rate request failed: \(statusCode, privacy: .public) for \(requestURL.absoluteString, privacy: .public) — \(body, privacy: .public)"
-      )
-      throw URLError(.badServerResponse)
-    }
-
+    let (data, _) = try await http.data(for: request)
     return try Self.parseResponse(data)
   }
 

--- a/Backends/YahooFinance/YahooFinanceClient.swift
+++ b/Backends/YahooFinance/YahooFinanceClient.swift
@@ -1,4 +1,3 @@
-// Backends/YahooFinance/YahooFinanceClient.swift
 import Foundation
 
 enum YahooFinanceError: Error {
@@ -11,18 +10,10 @@ struct YahooFinanceClient: StockPriceClient, Sendable {
   private static let baseURL =
     URL(string: "https://query2.finance.yahoo.com/v8/finance/chart/")
     ?? URL(fileURLWithPath: "/")
-  private let session: URLSession
-  private let rateLimitGate: RateLimitGate
-  private let failureCache: FailedRequestCache
+  private let http: RateLimitedHTTPClient
 
-  init(
-    session: URLSession = .shared,
-    rateLimitGate: RateLimitGate = RateLimitGate(),
-    failureCache: FailedRequestCache = FailedRequestCache()
-  ) {
-    self.session = session
-    self.rateLimitGate = rateLimitGate
-    self.failureCache = failureCache
+  init(http: RateLimitedHTTPClient) {
+    self.http = http
   }
 
   func fetchDailyPrices(ticker: String, from: Date, to: Date) async throws -> StockPriceResponse {
@@ -41,15 +32,7 @@ struct YahooFinanceClient: StockPriceClient, Sendable {
       forHTTPHeaderField: "User-Agent"
     )
 
-    let (data, response) = try await session.dataRespectingRateLimit(
-      for: request, gate: rateLimitGate, failureCache: failureCache)
-
-    guard let httpResponse = response as? HTTPURLResponse,
-      (200...299).contains(httpResponse.statusCode)
-    else {
-      throw URLError(.badServerResponse)
-    }
-
+    let (data, _) = try await http.data(for: request)
     return try Self.parseResponse(data)
   }
 

--- a/Backends/YahooFinance/YahooFinanceStockSearchClient.swift
+++ b/Backends/YahooFinance/YahooFinanceStockSearchClient.swift
@@ -1,4 +1,3 @@
-// Backends/YahooFinance/YahooFinanceStockSearchClient.swift
 import Foundation
 
 /// Yahoo Finance `/v1/finance/search` name-search adapter.
@@ -8,23 +7,15 @@ import Foundation
 /// trailing spaces). Falls back to `longname` then `symbol` when
 /// `shortname` is missing or empty after trimming.
 struct YahooFinanceStockSearchClient: StockSearchClient {
-  private let session: URLSession
-  private let rateLimitGate: RateLimitGate
-  private let failureCache: FailedRequestCache
+  private let http: RateLimitedHTTPClient
   private static let baseURL: URL = {
     guard let url = URL(string: "https://query1.finance.yahoo.com/v1/finance/search")
     else { preconditionFailure("malformed Yahoo search URL — fix the literal") }
     return url
   }()
 
-  init(
-    session: URLSession = .shared,
-    rateLimitGate: RateLimitGate = RateLimitGate(),
-    failureCache: FailedRequestCache = FailedRequestCache()
-  ) {
-    self.session = session
-    self.rateLimitGate = rateLimitGate
-    self.failureCache = failureCache
+  init(http: RateLimitedHTTPClient) {
+    self.http = http
   }
 
   func search(query: String) async throws -> [StockSearchHit] {
@@ -39,12 +30,7 @@ struct YahooFinanceStockSearchClient: StockSearchClient {
     var request = URLRequest(url: url)
     request.setValue("Mozilla/5.0", forHTTPHeaderField: "User-Agent")
 
-    let (data, response) = try await session.dataRespectingRateLimit(
-      for: request, gate: rateLimitGate, failureCache: failureCache)
-    guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
-      throw URLError(.badServerResponse)
-    }
-
+    let (data, _) = try await http.data(for: request)
     let decoded = try JSONDecoder().decode(Wire.self, from: data)
     return decoded.quotes.compactMap { wire in
       guard let quoteType = QuoteType(rawValue: wire.quoteType) else { return nil }

--- a/MoolahTests/Backends/BinanceClientTests.swift
+++ b/MoolahTests/Backends/BinanceClientTests.swift
@@ -1,4 +1,3 @@
-// MoolahTests/Backends/BinanceClientTests.swift
 import Foundation
 import Testing
 
@@ -70,7 +69,11 @@ struct BinanceClientTests {
 
   @Test
   func initAcceptsDateAwareUsdtRateClosure() {
-    let client = BinanceClient(session: .shared) { _ in
+    let services = NetworkingServices(
+      session: URLSession(configuration: .ephemeral))
+    let client = BinanceClient(
+      http: services.client(forHost: "api.binance.com")
+    ) { _ in
       dec("0.998")
     }
     // Validates the closure init compiles
@@ -107,7 +110,9 @@ struct BinanceClientTests {
     let mapping = CryptoProviderMapping(
       instrumentId: "1:0xabc", coingeckoId: nil, cryptocompareSymbol: nil, binanceSymbol: nil
     )
-    let client = BinanceClient(session: URLSession.shared)
+    let services = NetworkingServices(
+      session: URLSession(configuration: .ephemeral))
+    let client = BinanceClient(http: services.client(forHost: "api.binance.com"))
     await #expect(throws: CryptoPriceError.self) {
       try await client.dailyPrice(for: mapping, on: Date())
     }

--- a/MoolahTests/Backends/CoinGeckoClientTests.swift
+++ b/MoolahTests/Backends/CoinGeckoClientTests.swift
@@ -1,4 +1,3 @@
-// MoolahTests/Backends/CoinGeckoClientTests.swift
 import Foundation
 import Testing
 
@@ -180,7 +179,10 @@ struct CoinGeckoClientTests {
     let mapping = CryptoProviderMapping(
       instrumentId: "1:0xabc", coingeckoId: nil, cryptocompareSymbol: nil, binanceSymbol: nil
     )
-    let client = CoinGeckoClient(session: URLSession.shared, apiKey: "key")
+    let services = NetworkingServices(
+      session: URLSession(configuration: .ephemeral))
+    let client = CoinGeckoClient(
+      apiKey: "key", http: services.client(forHost: "pro-api.coingecko.com"))
     await #expect(throws: CryptoPriceError.self) {
       try await client.dailyPrice(for: mapping, on: Date())
     }

--- a/MoolahTests/Backends/CryptoCompareClientTests.swift
+++ b/MoolahTests/Backends/CryptoCompareClientTests.swift
@@ -1,4 +1,3 @@
-// MoolahTests/Backends/CryptoCompareClientTests.swift
 import Foundation
 import Testing
 
@@ -260,7 +259,9 @@ struct CryptoCompareClientTests {
     let mapping = CryptoProviderMapping(
       instrumentId: "1:0xabc", coingeckoId: nil, cryptocompareSymbol: nil, binanceSymbol: nil
     )
-    let client = CryptoCompareClient(session: URLSession.shared)
+    let services = NetworkingServices(
+      session: URLSession(configuration: .ephemeral))
+    let client = CryptoCompareClient(http: services.client(forHost: "min-api.cryptocompare.com"))
     await #expect(throws: CryptoPriceError.self) {
       try await client.dailyPrice(for: mapping, on: Date())
     }

--- a/MoolahTests/Backends/FrankfurterClientTests.swift
+++ b/MoolahTests/Backends/FrankfurterClientTests.swift
@@ -1,4 +1,3 @@
-// MoolahTests/Backends/FrankfurterClientTests.swift
 import Foundation
 import Testing
 

--- a/MoolahTests/Backends/YahooFinanceStockSearchClientTests.swift
+++ b/MoolahTests/Backends/YahooFinanceStockSearchClientTests.swift
@@ -1,4 +1,3 @@
-// MoolahTests/Backends/YahooFinanceStockSearchClientTests.swift
 import Foundation
 import Testing
 
@@ -32,7 +31,9 @@ final class YahooFinanceStockSearchClientTests {
     StubURLProtocol.handlers["query1.finance.yahoo.com:/v1/finance/search"] = { _ in
       (HTTPURLResponse.ok(etag: ""), data)
     }
-    let client = YahooFinanceStockSearchClient(session: makeSession())
+    let services = NetworkingServices(session: makeSession())
+    let client = YahooFinanceStockSearchClient(
+      http: services.client(forHost: "query1.finance.yahoo.com"))
 
     let hits = try await client.search(query: "apple")
 
@@ -45,7 +46,9 @@ final class YahooFinanceStockSearchClientTests {
     StubURLProtocol.handlers["query1.finance.yahoo.com:/v1/finance/search"] = { _ in
       (HTTPURLResponse.ok(etag: ""), data)
     }
-    let client = YahooFinanceStockSearchClient(session: makeSession())
+    let services = NetworkingServices(session: makeSession())
+    let client = YahooFinanceStockSearchClient(
+      http: services.client(forHost: "query1.finance.yahoo.com"))
 
     let hits = try await client.search(query: "apple")
 
@@ -61,7 +64,9 @@ final class YahooFinanceStockSearchClientTests {
       captured.set(request.url)
       return (HTTPURLResponse.ok(etag: ""), data)
     }
-    let client = YahooFinanceStockSearchClient(session: makeSession())
+    let services = NetworkingServices(session: makeSession())
+    let client = YahooFinanceStockSearchClient(
+      http: services.client(forHost: "query1.finance.yahoo.com"))
 
     _ = try await client.search(query: "apple")
 

--- a/MoolahTests/Shared/YahooFinanceClientTests.swift
+++ b/MoolahTests/Shared/YahooFinanceClientTests.swift
@@ -1,4 +1,3 @@
-// MoolahTests/Shared/YahooFinanceClientTests.swift
 import Foundation
 import Testing
 
@@ -22,7 +21,9 @@ struct YahooFinanceClientTests {
     let config = URLSessionConfiguration.ephemeral
     config.protocolClasses = [URLProtocolStub.self]
     let session = URLSession(configuration: config)
-    let client = YahooFinanceClient(session: session)
+    let services = NetworkingServices(session: session)
+    let client = YahooFinanceClient(
+      http: services.client(forHost: "query2.finance.yahoo.com"))
     URLProtocolStub.lastRequest = nil
     URLProtocolStub.requestHandler = handler
     return (client, session)

--- a/Shared/PreviewBackend.swift
+++ b/Shared/PreviewBackend.swift
@@ -47,7 +47,10 @@ enum PreviewBackend {
     // tables.
     let marketDataDatabase = registry.database
     let exchangeRates = ExchangeRateService(
-      client: FrankfurterClient(),
+      // TODO(#938): replace with shared NetworkingServices once PR-5 lands.
+      //   https://github.com/ajsutton/moolah-native/issues/938
+      client: FrankfurterClient(
+        http: NetworkingServices().client(forHost: "api.frankfurter.app")),
       database: marketDataDatabase
     )
     let conversionService = FiatConversionService(


### PR DESCRIPTION
## Summary

Second PR for [#938](https://github.com/ajsutton/moolah-native/issues/938). Migrates the 6 single-host clients that share the `(URLSession, RateLimitGate, FailedRequestCache)` trio to the new `RateLimitedHTTPClient` API:

- `CryptoCompareClient` → `min-api.cryptocompare.com`
- `CoinGeckoClient` → `pro-api.coingecko.com` / `api.coingecko.com` (key-dependent)
- `BinanceClient` → `api.binance.com`
- `FrankfurterClient` → `api.frankfurter.app`
- `YahooFinanceClient` → `query2.finance.yahoo.com`
- `YahooFinanceStockSearchClient` → `query1.finance.yahoo.com`

Each client loses 3 lines of constructor boilerplate and 3 lines of `(200...299)` status-check boilerplate per request. Factory wiring uses inline `NetworkingServices()` with `TODO(#938)` markers — PR-5 replaces those with a shared instance threaded through the app, so 429s from one client cool down every other caller of the same host.

Also opportunistic cleanup: removed `// <path>` header comments and the dead `import OSLog` + `logger` left behind in `FrankfurterClient` after its non-2xx error-log block was excised. Switched 4 tests from `URLSession.shared` to ephemeral sessions (they were never making network requests).

## Test plan

- [x] `just test-mac` — full suite green (3185 tests, 556 suites).
- [x] `just validate-todos` — passes; all `TODO(#938)` markers reference the open issue.
- [x] `just format-check` — passes.
- [x] No `(200...299)` status check remains in any of the 6 migrated clients.

Refs #938
🤖 Generated with [Claude Code](https://claude.com/claude-code)