### PR TITLE
feat(networking): migrate CompositeTokenResolutionClient to NetworkingServices

### DIFF
--- a/App/ProfileSession+Factories.swift
+++ b/App/ProfileSession+Factories.swift
@@ -99,7 +99,10 @@ extension ProfileSession {
     return CryptoPriceService(
       clients: priceClients,
       database: database,
-      resolutionClient: CompositeTokenResolutionClient(coinGeckoApiKey: resolverApiKey)
+      // TODO(#938): replace with shared NetworkingServices once PR-5 lands.
+      //   https://github.com/ajsutton/moolah-native/issues/938
+      resolutionClient: CompositeTokenResolutionClient(
+        networking: NetworkingServices(), coinGeckoApiKey: resolverApiKey)
     )
   }
 
@@ -182,7 +185,10 @@ extension ProfileSession {
       refreshTask = made.refreshTask
       // Empty string when no key is configured so the resolver targets
       // the free public CoinGecko endpoint. See `makeCryptoPriceService`.
-      resolutionClient = CompositeTokenResolutionClient(coinGeckoApiKey: coinGeckoApiKey ?? "")
+      // TODO(#938): replace with shared NetworkingServices once PR-5 lands.
+      //   https://github.com/ajsutton/moolah-native/issues/938
+      resolutionClient = CompositeTokenResolutionClient(
+        networking: NetworkingServices(), coinGeckoApiKey: coinGeckoApiKey ?? "")
     }
     // Pass the shared registry store from the coordinator when
     // wired so cross-session mutations are observed transparently

--- a/MoolahTests/Shared/CompositeTokenResolutionClientTests.swift
+++ b/MoolahTests/Shared/CompositeTokenResolutionClientTests.swift
@@ -1,4 +1,3 @@
-// MoolahTests/Shared/CompositeTokenResolutionClientTests.swift
 import Foundation
 import Testing
 
@@ -253,10 +252,11 @@ final class PostConfirmBySymbolTests {
     StubURLProtocol.handlers = [:]
   }
 
-  private func makeSession() -> URLSession {
+  private func makeNetworking() -> NetworkingServices {
     let config = URLSessionConfiguration.ephemeral
     config.protocolClasses = [StubURLProtocol.self]
-    return URLSession(configuration: config)
+    let session = URLSession(configuration: config)
+    return NetworkingServices(session: session)
   }
 
   private func stubAssetPlatforms(_ json: String) {
@@ -297,7 +297,7 @@ final class PostConfirmBySymbolTests {
       coinListData: ccCoinList,
       exchangeInfoData: binanceInfo,
       coinGeckoApiKey: "",
-      session: makeSession()
+      networking: makeNetworking()
     )
     let result = try await client.resolve(
       chainId: 1,
@@ -341,7 +341,7 @@ final class PostConfirmBySymbolTests {
       coinListData: ccCoinList,
       exchangeInfoData: binanceInfo,
       coinGeckoApiKey: "",
-      session: makeSession()
+      networking: makeNetworking()
     )
     let result = try await client.resolve(
       chainId: 10,

--- a/Shared/CompositeTokenResolutionClient.swift
+++ b/Shared/CompositeTokenResolutionClient.swift
@@ -1,34 +1,32 @@
-// Shared/CompositeTokenResolutionClient.swift
 import Foundation
 
 /// Production token resolution client that queries CryptoCompare, Binance, and optionally CoinGecko
 /// to populate provider-specific identifiers for a token.
 struct CompositeTokenResolutionClient: TokenResolutionClient, Sendable {
-  private let session: URLSession
+  private let networking: NetworkingServices
   private let coinGeckoApiKey: String?
 
   // For testing: inject pre-parsed reference data
   private let preloadedCoinList: Data?
   private let preloadedExchangeInfo: Data?
 
-  init(session: URLSession = .shared, coinGeckoApiKey: String? = nil) {
-    self.session = session
+  init(networking: NetworkingServices, coinGeckoApiKey: String? = nil) {
+    self.networking = networking
     self.coinGeckoApiKey = coinGeckoApiKey
     self.preloadedCoinList = nil
     self.preloadedExchangeInfo = nil
   }
 
   /// Test initializer with pre-loaded reference data. Accepts an optional
-  /// `session` so tests that exercise the CoinGecko-dependent paths (e.g.
-  /// the post-confirm CryptoCompare by-symbol fallback) can plug a
-  /// `StubURLProtocol`-backed session in.
+  /// `networking` so tests that exercise the CoinGecko-dependent paths can
+  /// plug a `StubURLProtocol`-backed `NetworkingServices` in.
   init(
     coinListData: Data,
     exchangeInfoData: Data,
     coinGeckoApiKey: String?,
-    session: URLSession = .shared
+    networking: NetworkingServices = NetworkingServices()
   ) {
-    self.session = session
+    self.networking = networking
     self.coinGeckoApiKey = coinGeckoApiKey
     self.preloadedCoinList = coinListData
     self.preloadedExchangeInfo = exchangeInfoData
@@ -104,9 +102,9 @@ struct CompositeTokenResolutionClient: TokenResolutionClient, Sendable {
       guard let platformSlug = platformMapping[chainId] else { return }
       let url = CoinGeckoClient.contractLookupURL(
         platformId: platformSlug, contractAddress: contractAddress, apiKey: apiKey)
-      let (data, response) = try await session.data(for: URLRequest(url: url))
-      guard let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode)
-      else { return }
+      let host = apiKey.isEmpty ? "api.coingecko.com" : "pro-api.coingecko.com"
+      let http = networking.client(forHost: host)
+      let (data, _) = try await http.data(for: URLRequest(url: url))
       let lookup = try CoinGeckoClient.parseContractLookupResponse(data)
       result.coingeckoId = lookup.id
       result.resolvedName = lookup.name
@@ -166,29 +164,24 @@ struct CompositeTokenResolutionClient: TokenResolutionClient, Sendable {
   private func fetchCoinListData() async throws -> Data {
     if let preloaded = preloadedCoinList { return preloaded }
     let url = CryptoCompareClient.coinListURL()
-    let (data, response) = try await session.data(for: URLRequest(url: url))
-    guard let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) else {
-      throw URLError(.badServerResponse)
-    }
+    let http = networking.client(forHost: "min-api.cryptocompare.com")
+    let (data, _) = try await http.data(for: URLRequest(url: url))
     return data
   }
 
   private func fetchExchangeInfoData() async throws -> Data {
     if let preloaded = preloadedExchangeInfo { return preloaded }
     let url = BinanceClient.exchangeInfoURL()
-    let (data, response) = try await session.data(for: URLRequest(url: url))
-    guard let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) else {
-      throw URLError(.badServerResponse)
-    }
+    let http = networking.client(forHost: "api.binance.com")
+    let (data, _) = try await http.data(for: URLRequest(url: url))
     return data
   }
 
   private func fetchAssetPlatforms(apiKey: String) async throws -> [Int: String] {
     let url = CoinGeckoClient.assetPlatformsURL(apiKey: apiKey)
-    let (data, response) = try await session.data(for: URLRequest(url: url))
-    guard let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) else {
-      throw URLError(.badServerResponse)
-    }
+    let host = apiKey.isEmpty ? "api.coingecko.com" : "pro-api.coingecko.com"
+    let http = networking.client(forHost: host)
+    let (data, _) = try await http.data(for: URLRequest(url: url))
     return try CoinGeckoClient.parseAssetPlatformsResponse(data)
   }
 }


### PR DESCRIPTION
## Summary

Third PR for [#938](https://github.com/ajsutton/moolah-native/issues/938). Stacked on #958.

Migrates `CompositeTokenResolutionClient` (the one multi-host caller) to inject `NetworkingServices` and resolve `client(forHost:)` per request. Drops the 4 bare `session.data(for:)` call sites and their `(200...299)` status checks:

- `fetchCoinListData` → `min-api.cryptocompare.com`
- `fetchExchangeInfoData` → `api.binance.com`
- `fetchAssetPlatforms` → `api.coingecko.com` / `pro-api.coingecko.com` (key-dependent)
- inline contract lookup in `resolveFromCoinGecko` → same Pro/free split

Effect: a CryptoCompare 429 on the price-fetch path now cools down Composite's coin-list fetch on the same host, and vice versa — closing the gap that motivated bringing this client into scope.

Factory wiring uses inline `NetworkingServices()` with `TODO(#938)`; PR-5 replaces with the shared instance.

## Test plan

- [x] `just test-mac CompositeTokenResolutionClientTests` — green (8 tests).
- [x] `just test-mac` — full suite green (3185 tests).
- [x] `just validate-todos` — passes.
- [x] `just format-check` — passes.

Refs #938
🤖 Generated with [Claude Code](https://claude.com/claude-code)