### PR TITLE
feat(networking): thread shared NetworkingServices through app wiring

### DIFF
--- a/App/MoolahApp+SharedInstrumentScope.swift
+++ b/App/MoolahApp+SharedInstrumentScope.swift
@@ -12,7 +12,8 @@ extension MoolahApp {
   /// pointed at the profile-index DB, plus the constructed
   /// `SyncCoordinator` with the registry's sync hooks rotated in.
   static func bootstrapSyncCoordinator(setup: ContainerSetup) -> SyncCoordinator {
-    let scope = makeSharedInstrumentScope(setup: setup)
+    let networking = NetworkingServices()
+    let scope = makeSharedInstrumentScope(setup: setup, networking: networking)
     // App-level store of the registry data — every per-session
     // `CryptoTokenStore` proxies its `registrations` /
     // `instruments` / `providerMappings` / `registrationsVersion`
@@ -26,7 +27,8 @@ extension MoolahApp {
       containerManager: setup.manager,
       sharedInstrumentRegistry: scope.registry,
       sharedMarketData: scope.marketData,
-      sharedRegistryStore: registryStore)
+      sharedRegistryStore: registryStore,
+      sharedNetworking: networking)
     attachSharedInstrumentRegistrySyncHooks(
       registry: scope.registry, coordinator: coordinator)
     return coordinator
@@ -48,7 +50,8 @@ extension MoolahApp {
   /// Bundles the shared registry + market-data services, both pointed
   /// at the profile-index DB. Tuple shape keeps `MoolahApp.init` short.
   static func makeSharedInstrumentScope(
-    setup: ContainerSetup
+    setup: ContainerSetup,
+    networking: NetworkingServices
   ) -> (
     registry: GRDBInstrumentRegistryRepository,
     marketData: ProfileSession.MarketDataServices
@@ -56,7 +59,8 @@ extension MoolahApp {
     let database = setup.manager.profileIndexDatabase
     return (
       registry: makeSharedInstrumentRegistry(database: database),
-      marketData: ProfileSession.makeMarketDataServices(database: database)
+      marketData: ProfileSession.makeMarketDataServices(
+        database: database, networking: networking)
     )
   }
 

--- a/App/ProfileSession+Factories.swift
+++ b/App/ProfileSession+Factories.swift
@@ -26,25 +26,24 @@ extension ProfileSession {
   /// profile session. Standalone helper so `ProfileSession.init` can build
   /// and assign the trio in one step. Each rate service persists to the
   /// supplied per-profile `database`.
-  static func makeMarketDataServices(database: any DatabaseWriter) -> MarketDataServices {
-    // TODO(#938): replace with shared NetworkingServices once PR-5 lands.
-    //   https://github.com/ajsutton/moolah-native/issues/938
+  static func makeMarketDataServices(
+    database: any DatabaseWriter,
+    networking: NetworkingServices
+  ) -> MarketDataServices {
     let yahooClient = YahooFinanceClient(
-      http: NetworkingServices().client(forHost: "query2.finance.yahoo.com"))
+      http: networking.client(forHost: "query2.finance.yahoo.com"))
     let apiKeyStore = KeychainStore(
       service: KeychainServices.apiKeys, account: "coingecko", synchronizable: true
     )
     let coinGeckoApiKey = try? apiKeyStore.restoreString()
     return MarketDataServices(
       exchangeRate: ExchangeRateService(
-        // TODO(#938): replace with shared NetworkingServices once PR-5 lands.
-        //   https://github.com/ajsutton/moolah-native/issues/938
         client: FrankfurterClient(
-          http: NetworkingServices().client(forHost: "api.frankfurter.app")),
+          http: networking.client(forHost: "api.frankfurter.app")),
         database: database),
       stockPrice: StockPriceService(client: yahooClient, database: database),
       cryptoPrice: Self.makeCryptoPriceService(
-        coinGeckoApiKey: coinGeckoApiKey, database: database),
+        coinGeckoApiKey: coinGeckoApiKey, database: database, networking: networking),
       yahooPriceFetcher: yahooClient,
       coinGeckoApiKey: coinGeckoApiKey
     )
@@ -58,16 +57,19 @@ extension ProfileSession {
   /// via CryptoCompare/Binance.
   static func makeCryptoPriceService(
     coinGeckoApiKey: String?,
-    database: any DatabaseWriter
+    database: any DatabaseWriter,
+    networking: NetworkingServices
   ) -> CryptoPriceService {
-    // TODO(#938): replace with shared NetworkingServices once PR-5 lands.
-    //   https://github.com/ajsutton/moolah-native/issues/938
+    // Empty key → CoinGeckoClient targets the free public host;
+    // non-empty key → Pro host with `x_cg_pro_api_key`. Always included
+    // so users without a Pro key still get coverage for tokens like
+    // USDC that CryptoCompare omits from its contract index.
+    let resolverApiKey = coinGeckoApiKey ?? ""
+    let cgHost = resolverApiKey.isEmpty ? "api.coingecko.com" : "pro-api.coingecko.com"
     let cryptoCompareClient = CryptoCompareClient(
-      http: NetworkingServices().client(forHost: "min-api.cryptocompare.com"))
-    // TODO(#938): replace with shared NetworkingServices once PR-5 lands.
-    //   https://github.com/ajsutton/moolah-native/issues/938
+      http: networking.client(forHost: "min-api.cryptocompare.com"))
     let binanceClient = BinanceClient(
-      http: NetworkingServices().client(forHost: "api.binance.com"),
+      http: networking.client(forHost: "api.binance.com"),
       usdtRateLookup: { date in
         let usdtMapping = CryptoProviderMapping(
           instrumentId: "1:0xdac17f958d2ee523a2206206994597c13d831ec7",
@@ -79,19 +81,10 @@ extension ProfileSession {
           return Decimal(1)
         }
       })
-
-    // Empty key → CoinGeckoClient targets the free public host;
-    // non-empty key → Pro host with `x_cg_pro_api_key`. Always included
-    // so users without a Pro key still get coverage for tokens like
-    // USDC that CryptoCompare omits from its contract index.
-    let resolverApiKey = coinGeckoApiKey ?? ""
-    // TODO(#938): replace with shared NetworkingServices once PR-5 lands.
-    //   https://github.com/ajsutton/moolah-native/issues/938
-    let cgHost = resolverApiKey.isEmpty ? "api.coingecko.com" : "pro-api.coingecko.com"
     let priceClients: [CryptoPriceClient] = [
       CoinGeckoClient(
         apiKey: resolverApiKey,
-        http: NetworkingServices().client(forHost: cgHost)),
+        http: networking.client(forHost: cgHost)),
       cryptoCompareClient,
       binanceClient,
     ]
@@ -99,10 +92,8 @@ extension ProfileSession {
     return CryptoPriceService(
       clients: priceClients,
       database: database,
-      // TODO(#938): replace with shared NetworkingServices once PR-5 lands.
-      //   https://github.com/ajsutton/moolah-native/issues/938
       resolutionClient: CompositeTokenResolutionClient(
-        networking: NetworkingServices(), coinGeckoApiKey: resolverApiKey)
+        networking: networking, coinGeckoApiKey: resolverApiKey)
     )
   }
 
@@ -166,6 +157,7 @@ extension ProfileSession {
     cryptoPriceService: CryptoPriceService,
     yahooPriceFetcher: any YahooFinancePriceFetcher,
     coinGeckoApiKey: String?,
+    networking: NetworkingServices,
     sharedRegistryStore: SharedRegistryStore? = nil
   ) -> RegistryWiring {
     guard let cloudBackend = backend as? CloudKitBackend else {
@@ -180,15 +172,13 @@ extension ProfileSession {
       refreshTask = nil
       resolutionClient = overrides.resolutionClient
     } else {
-      let made = makeCoinGeckoCatalog()
+      let made = makeCoinGeckoCatalog(apiKey: coinGeckoApiKey, networking: networking)
       catalog = made.catalog
       refreshTask = made.refreshTask
       // Empty string when no key is configured so the resolver targets
       // the free public CoinGecko endpoint. See `makeCryptoPriceService`.
-      // TODO(#938): replace with shared NetworkingServices once PR-5 lands.
-      //   https://github.com/ajsutton/moolah-native/issues/938
       resolutionClient = CompositeTokenResolutionClient(
-        networking: NetworkingServices(), coinGeckoApiKey: coinGeckoApiKey ?? "")
+        networking: networking, coinGeckoApiKey: coinGeckoApiKey ?? "")
     }
     // Pass the shared registry store from the coordinator when
     // wired so cross-session mutations are observed transparently
@@ -199,14 +189,12 @@ extension ProfileSession {
       cryptoPriceService: cryptoPriceService,
       conversionService: cloudBackend.conversionService,
       sharedStore: sharedRegistryStore)
-    // TODO(#938): replace with shared NetworkingServices once PR-5 lands.
-    //   https://github.com/ajsutton/moolah-native/issues/938
     let searchService = InstrumentSearchService(
       registry: cloudBackend.instrumentRegistry,
       catalog: catalog,
       resolutionClient: resolutionClient,
       stockSearchClient: YahooFinanceStockSearchClient(
-        http: NetworkingServices().client(forHost: "query1.finance.yahoo.com"))
+        http: networking.client(forHost: "query1.finance.yahoo.com"))
     )
     return RegistryWiring(
       registry: cloudBackend.instrumentRegistry,
@@ -241,20 +229,17 @@ extension ProfileSession {
   /// search path. The returned `refreshTask` handle is stored on
   /// `ProfileSession` so it can be cancelled on teardown.
   @MainActor
-  private static func makeCoinGeckoCatalog()
-    -> (catalog: (any CoinGeckoCatalog)?, refreshTask: Task<Void, Never>?)
-  {
+  private static func makeCoinGeckoCatalog(
+    apiKey: String?,
+    networking: NetworkingServices
+  ) -> (catalog: (any CoinGeckoCatalog)?, refreshTask: Task<Void, Never>?) {
     let directory = URL.moolahScopedApplicationSupport
       .appending(path: "InstrumentRegistry", directoryHint: .isDirectory)
     do {
-      // TODO(#938): receive `networking: NetworkingServices` + the resolved
-      //   CoinGecko host as a parameter once PR-5 lands. For now the inline
-      //   NetworkingServices() instance is private to this factory call, so
-      //   the host string is a placeholder.
-      //   https://github.com/ajsutton/moolah-native/issues/938
+      let host = (apiKey ?? "").isEmpty ? "api.coingecko.com" : "pro-api.coingecko.com"
       let catalog = try SQLiteCoinGeckoCatalog.make(
         directory: directory,
-        http: NetworkingServices().client(forHost: "api.coingecko.com"))
+        http: networking.client(forHost: host))
       // `SQLiteCoinGeckoCatalog` is an actor, so `await catalog.refreshIfStale()`
       // hops to the catalog's executor regardless of the enclosing Task's
       // isolation — no `Task.detached` needed (CONCURRENCY_GUIDE §8).

--- a/App/ProfileSession.swift
+++ b/App/ProfileSession.swift
@@ -126,7 +126,8 @@ final class ProfileSession: Identifiable {
     profile: Profile,
     containerManager: ProfileContainerManager? = nil,
     syncCoordinator: SyncCoordinator? = nil,
-    database: DatabaseQueue? = nil
+    database: DatabaseQueue? = nil,
+    networking: NetworkingServices? = nil
   ) throws {
     self.profile = profile
     self.profileID = profile.id
@@ -134,6 +135,11 @@ final class ProfileSession: Identifiable {
     let resolvedDatabase = try Self.resolveDatabase(
       override: database, profile: profile, containerManager: containerManager)
     self.database = resolvedDatabase
+
+    // Prefer the app-level shared `NetworkingServices` via SyncCoordinator,
+    // fall back to the directly-injected one, then to a fresh instance for
+    // preview / test fixtures that didn't pass shared services through.
+    let resolvedNetworking = syncCoordinator?.sharedNetworking ?? networking ?? NetworkingServices()
 
     // Prefer the app-level shared `MarketDataServices` (pointed at
     // the profile-index DB) when the coordinator was constructed
@@ -144,7 +150,7 @@ final class ProfileSession: Identifiable {
     // pass shared services through `SyncCoordinator.init`.
     let services =
       syncCoordinator?.sharedMarketData
-      ?? Self.makeMarketDataServices(database: resolvedDatabase)
+      ?? Self.makeMarketDataServices(database: resolvedDatabase, networking: resolvedNetworking)
     self.exchangeRateService = services.exchangeRate
     self.stockPriceService = services.stockPrice
     self.cryptoPriceService = services.cryptoPrice
@@ -162,6 +168,7 @@ final class ProfileSession: Identifiable {
       cryptoPriceService: services.cryptoPrice,
       yahooPriceFetcher: services.yahooPriceFetcher,
       coinGeckoApiKey: services.coinGeckoApiKey,
+      networking: resolvedNetworking,
       sharedRegistryStore: syncCoordinator?.sharedRegistryStore
     )
     self.instrumentRegistry = registryWiring.registry

--- a/Backends/CloudKit/Sync/SyncCoordinator+BatchKind.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator+BatchKind.swift
@@ -1,0 +1,69 @@
+@preconcurrency import CloudKit
+import Foundation
+
+extension SyncCoordinator {
+
+  // MARK: - Batch Kind
+
+  /// Zone-kind bucket for a single `RecordZoneChangeBatch`.
+  ///
+  /// `nextRecordZoneChangeBatch` emits one bucket per call so `atomicByZone` can
+  /// be set per-kind: profile-index records are independent (no cascade on conflict),
+  /// while profile-data records within a zone must commit together.
+  /// See issue #61.
+  enum BatchKind: Equatable {
+    case profileIndex
+    case profileData
+
+    var atomicByZone: Bool {
+      switch self {
+      case .profileIndex: return false
+      case .profileData: return true
+      }
+    }
+  }
+
+  /// Picks the next batch kind to emit from a list of pending changes.
+  /// Profile-index wins when both kinds are pending so index conflicts drain first.
+  /// Returns `nil` if no changes belong to a known zone kind.
+  nonisolated static func selectBatchKind(
+    from changes: some Sequence<CKSyncEngine.PendingRecordZoneChange>
+  ) -> BatchKind? {
+    var sawData = false
+    for change in changes {
+      let zoneID: CKRecordZone.ID
+      switch change {
+      case .saveRecord(let id): zoneID = id.zoneID
+      case .deleteRecord(let id): zoneID = id.zoneID
+      @unknown default: continue
+      }
+      switch parseZone(zoneID) {
+      case .profileIndex: return .profileIndex
+      case .profileData: sawData = true
+      case .unknown: continue
+      }
+    }
+    return sawData ? .profileData : nil
+  }
+
+  /// Filters pending changes to those matching the given batch kind, preserving order.
+  nonisolated static func filterChanges(
+    _ changes: [CKSyncEngine.PendingRecordZoneChange],
+    matching kind: BatchKind
+  ) -> [CKSyncEngine.PendingRecordZoneChange] {
+    changes.filter { change in
+      let zoneID: CKRecordZone.ID
+      switch change {
+      case .saveRecord(let id): zoneID = id.zoneID
+      case .deleteRecord(let id): zoneID = id.zoneID
+      @unknown default: return false
+      }
+      switch (parseZone(zoneID), kind) {
+      case (.profileIndex, .profileIndex): return true
+      case (.profileData, .profileData): return true
+      default: return false
+      }
+    }
+  }
+
+}

--- a/Backends/CloudKit/Sync/SyncCoordinator.swift
+++ b/Backends/CloudKit/Sync/SyncCoordinator.swift
@@ -56,69 +56,6 @@ final class SyncCoordinator {
     let isFirstLaunch: Bool
   }
 
-  // MARK: - Batch Kind
-
-  /// Zone-kind bucket for a single `RecordZoneChangeBatch`.
-  ///
-  /// `nextRecordZoneChangeBatch` emits one bucket per call so `atomicByZone` can
-  /// be set per-kind: profile-index records are independent (no cascade on conflict),
-  /// while profile-data records within a zone must commit together.
-  /// See issue #61.
-  enum BatchKind: Equatable {
-    case profileIndex
-    case profileData
-
-    var atomicByZone: Bool {
-      switch self {
-      case .profileIndex: return false
-      case .profileData: return true
-      }
-    }
-  }
-
-  /// Picks the next batch kind to emit from a list of pending changes.
-  /// Profile-index wins when both kinds are pending so index conflicts drain first.
-  /// Returns `nil` if no changes belong to a known zone kind.
-  nonisolated static func selectBatchKind(
-    from changes: some Sequence<CKSyncEngine.PendingRecordZoneChange>
-  ) -> BatchKind? {
-    var sawData = false
-    for change in changes {
-      let zoneID: CKRecordZone.ID
-      switch change {
-      case .saveRecord(let id): zoneID = id.zoneID
-      case .deleteRecord(let id): zoneID = id.zoneID
-      @unknown default: continue
-      }
-      switch parseZone(zoneID) {
-      case .profileIndex: return .profileIndex
-      case .profileData: sawData = true
-      case .unknown: continue
-      }
-    }
-    return sawData ? .profileData : nil
-  }
-
-  /// Filters pending changes to those matching the given batch kind, preserving order.
-  nonisolated static func filterChanges(
-    _ changes: [CKSyncEngine.PendingRecordZoneChange],
-    matching kind: BatchKind
-  ) -> [CKSyncEngine.PendingRecordZoneChange] {
-    changes.filter { change in
-      let zoneID: CKRecordZone.ID
-      switch change {
-      case .saveRecord(let id): zoneID = id.zoneID
-      case .deleteRecord(let id): zoneID = id.zoneID
-      @unknown default: return false
-      }
-      switch (parseZone(zoneID), kind) {
-      case (.profileIndex, .profileIndex): return true
-      case (.profileData, .profileData): return true
-      default: return false
-      }
-    }
-  }
-
   // MARK: - Index Observer
 
   private struct IndexObserver {
@@ -173,6 +110,12 @@ final class SyncCoordinator {
   /// writes land in the same DB and feed the `notifyRateCacheChange`
   /// observation. `nil` for tests that don't pass shared services.
   nonisolated let sharedMarketData: ProfileSession.MarketDataServices?
+
+  /// App-level shared `NetworkingServices` instance. Vends per-host
+  /// `RateLimitedHTTPClient`s so a 429 from one caller cools down every
+  /// caller of that host. `nil` for preview / test callers that don't
+  /// pass shared services.
+  nonisolated let sharedNetworking: NetworkingServices?
 
   /// App-level shared `SharedRegistryStore` — owns the registry data
   /// (`registrations`, `instruments`, `providerMappings`,
@@ -344,7 +287,8 @@ final class SyncCoordinator {
     isCloudKitAvailable: Bool = CloudKitAuthProvider.isCloudKitAvailable,
     sharedInstrumentRegistry: GRDBInstrumentRegistryRepository? = nil,
     sharedMarketData: ProfileSession.MarketDataServices? = nil,
-    sharedRegistryStore: SharedRegistryStore? = nil
+    sharedRegistryStore: SharedRegistryStore? = nil,
+    sharedNetworking: NetworkingServices? = nil
   ) {
     self.containerManager = containerManager
     self.userDefaults = userDefaults
@@ -352,6 +296,7 @@ final class SyncCoordinator {
     self.sharedInstrumentRegistry = sharedInstrumentRegistry
     self.sharedMarketData = sharedMarketData
     self.sharedRegistryStore = sharedRegistryStore
+    self.sharedNetworking = sharedNetworking
     self.profileIndexHandler = ProfileIndexSyncHandler(
       repository: containerManager.profileIndexRepository,
       instrumentRepository: sharedInstrumentRegistry,

--- a/Shared/PreviewBackend.swift
+++ b/Shared/PreviewBackend.swift
@@ -46,11 +46,10 @@ enum PreviewBackend {
     // on `profileIndexDatabase`). There are no per-profile rate-cache
     // tables.
     let marketDataDatabase = registry.database
+    let networking = NetworkingServices()
     let exchangeRates = ExchangeRateService(
-      // TODO(#938): replace with shared NetworkingServices once PR-5 lands.
-      //   https://github.com/ajsutton/moolah-native/issues/938
       client: FrankfurterClient(
-        http: NetworkingServices().client(forHost: "api.frankfurter.app")),
+        http: networking.client(forHost: "api.frankfurter.app")),
       database: marketDataDatabase
     )
     let conversionService = FiatConversionService(


### PR DESCRIPTION
## Summary

Fifth PR for [#938](https://github.com/ajsutton/moolah-native/issues/938).

Replaces every inline `NetworkingServices()` placeholder (and the `TODO(#938)` markers PRs 2-4 left behind) with a single shared instance constructed in `MoolahApp+SharedInstrumentScope.bootstrapSyncCoordinator` and threaded through:

```
MoolahApp+Setup
  └─ NetworkingServices()
     ├─ SyncCoordinator.sharedNetworking
     └─ ProfileSession.makeMarketDataServices(database:networking:)
        └─ every standard client + Composite resolver + CoinGecko catalog
```

After this PR, gates are genuinely process-shared. A CryptoCompare 429 from one caller cools down every other caller of `min-api.cryptocompare.com` — across profiles, across stores, across fetchers.

### Code-review fix-ups applied

- Restored the `sharedRegistryStore` doc comment that was cosmetically shrunk to dodge the SwiftLint `file_length` warning. Extracted the `// MARK: - Batch Kind` section of `SyncCoordinator.swift` into a sibling file `SyncCoordinator+BatchKind.swift` so the file is genuinely under 400 lines (341 now).
- Dropped the premature `See guides/CONCURRENCY_GUIDE.md §4` reference from `sharedNetworking`'s doc comment (PR-6 adds the §4 content).
- Swapped `makeRegistryWiring` parameter ordering so the required `networking:` precedes the optional `sharedRegistryStore:`.

## Test plan

- [x] `grep TODO(#938)` returns zero matches in production code.
- [x] `grep NetworkingServices()` returns matches only in `bootstrapSyncCoordinator` (production), `ProfileSession.init`'s resolution-chain fallback (preview/test seam), and `PreviewBackend` (preview).
- [x] `just test-mac` — full suite green (3175 tests).
- [x] `just format-check` — passes.
- [x] `just validate-todos` — passes.

Refs #938
🤖 Generated with [Claude Code](https://claude.com/claude-code)