### PR TITLE
ui(charts): tone down dark-mode chart colours

### DIFF
--- a/Features/Analysis/Views/CategoriesOverTimeCard.swift
+++ b/Features/Analysis/Views/CategoriesOverTimeCard.swift
@@ -139,7 +139,8 @@ struct CategoriesOverTimeCard: View {
   }
 
   private static let chartPalette: [Color] = [
-    .blue, .green, .orange, .purple, .red, .teal, .indigo, .pink, .mint, .cyan, .brown, .yellow,
+    .chartBlue, .chartGreen, .chartOrange, .chartPurple, .chartRed, .chartTeal,
+    .chartIndigo, .chartPink, .chartMint, .chartCyan, .chartBrown, .chartYellow,
   ]
 
   private func categoryColor(for id: UUID?) -> Color {

--- a/Features/Analysis/Views/NetWorthGraphCard.swift
+++ b/Features/Analysis/Views/NetWorthGraphCard.swift
@@ -13,11 +13,11 @@ enum ChartSeries: String, CaseIterable, Identifiable {
 
   var color: Color {
     switch self {
-    case .availableFunds: .green
-    case .currentFunds: .orange
-    case .investedAmount: .purple
-    case .investmentValue: .indigo
-    case .netWorth: .blue
+    case .availableFunds: .chartGreen
+    case .currentFunds: .chartOrange
+    case .investedAmount: .chartPurple
+    case .investmentValue: .chartIndigo
+    case .netWorth: .chartBlue
     case .bestFit: .gray
     }
   }

--- a/Features/Investments/Views/InvestmentChartView.swift
+++ b/Features/Investments/Views/InvestmentChartView.swift
@@ -50,7 +50,7 @@ struct InvestmentChartView: View {
         x: .value("Date", point.date),
         y: .value("Profit/Loss", Double(truncating: profitLoss as NSDecimalNumber))
       )
-      .foregroundStyle(.orange.opacity(0.2))
+      .foregroundStyle(Color.chartOrange.opacity(0.2))
       .interpolationMethod(.catmullRom)
     }
     // Investment Value line (blue)
@@ -60,7 +60,7 @@ struct InvestmentChartView: View {
         y: .value("Value", Double(truncating: value as NSDecimalNumber)),
         series: .value("Series", "Value")
       )
-      .foregroundStyle(.blue)
+      .foregroundStyle(Color.chartBlue)
       .lineStyle(StrokeStyle(lineWidth: 2))
       .interpolationMethod(.catmullRom)
     }
@@ -134,7 +134,7 @@ struct InvestmentChartView: View {
         detailItem(
           label: "Value",
           amount: InstrumentAmount(quantity: value, instrument: instrument),
-          color: .blue)
+          color: .chartBlue)
       }
 
       if let balance = point.balance {
@@ -148,7 +148,7 @@ struct InvestmentChartView: View {
         detailItem(
           label: "P/L",
           amount: InstrumentAmount(quantity: profitLoss, instrument: instrument),
-          color: .orange)
+          color: .chartOrange)
       }
     }
     .font(.caption)
@@ -169,9 +169,9 @@ struct InvestmentChartView: View {
 
   private var legend: some View {
     HStack(spacing: 16) {
-      LegendItem(color: .blue, label: "Investment Value")
+      LegendItem(color: .chartBlue, label: "Investment Value")
       LegendItem(color: .gray, label: "Invested Amount")
-      LegendItem(color: .orange, label: "Profit/Loss")
+      LegendItem(color: .chartOrange, label: "Profit/Loss")
     }
     .font(.caption)
   }

--- a/Features/Investments/Views/InvestmentValuesView.swift
+++ b/Features/Investments/Views/InvestmentValuesView.swift
@@ -67,14 +67,14 @@ struct InvestmentValuesView: View {
           x: .value("Date", value.date),
           y: .value("Value", Double(truncating: value.value.quantity as NSDecimalNumber))
         )
-        .foregroundStyle(Color.blue)
+        .foregroundStyle(Color.chartBlue)
         .interpolationMethod(.catmullRom)
 
         AreaMark(
           x: .value("Date", value.date),
           y: .value("Value", Double(truncating: value.value.quantity as NSDecimalNumber))
         )
-        .foregroundStyle(Color.blue.opacity(0.1))
+        .foregroundStyle(Color.chartBlue.opacity(0.1))
         .interpolationMethod(.catmullRom)
       }
     }

--- a/Shared/Color+ChartPalette.swift
+++ b/Shared/Color+ChartPalette.swift
@@ -1,0 +1,125 @@
+import SwiftUI
+
+#if canImport(AppKit)
+  import AppKit
+#endif
+#if canImport(UIKit)
+  import UIKit
+#endif
+
+extension Color {
+  /// Cross-platform light/dark `Color` factory. The system normally
+  /// resolves the semantic colours (`.green`, `.red`, …) at draw time
+  /// using the trait collection / appearance, but Apple's dark-mode
+  /// variants are deliberately chroma-boosted to keep contrast against
+  /// dark backgrounds — which reads as fluorescent inside chart areas
+  /// where there's no surrounding text to anchor expectations. This
+  /// initialiser lets us hand-pick a softer dark variant while keeping
+  /// the familiar light-mode look.
+  private init(light: Color, dark: Color) {
+    #if canImport(UIKit)
+      self.init(
+        uiColor: UIColor { traits in
+          traits.userInterfaceStyle == .dark ? UIColor(dark) : UIColor(light)
+        })
+    #elseif canImport(AppKit)
+      self.init(
+        nsColor: NSColor(name: nil) { appearance in
+          appearance.bestMatch(from: [.darkAqua, .vibrantDark]) != nil
+            ? NSColor(dark) : NSColor(light)
+        })
+    #endif
+  }
+}
+
+/// Chart series palette. In **light** mode each colour equals the
+/// matching system semantic (`.green`, `.blue`, …) so chart marks stay
+/// in family with the rest of the UI. In **dark** mode the variant is
+/// slightly less luminous and less chroma-boosted than Apple's default
+/// systemColor dark variant, so chart marks read as a colour against a
+/// dark surface rather than as a glowing light source.
+///
+/// This is a documented exception to UI_GUIDE §5's "system semantic
+/// colours only" rule (see also the focused-sidebar selected-row
+/// override in `AccountSidebarRow`). Charts are the only context in
+/// the app where multiple saturated colours sit side-by-side on a dark
+/// surface; in regular UI the surrounding `.background` / `.secondary`
+/// chrome moderates how saturated a `.green` looks, but inside a chart
+/// area the marks ARE the surface, so the standard treatment over-fires.
+///
+/// All call sites for chart series colour MUST resolve through this
+/// palette rather than using the system semantic colour directly, so a
+/// future tuning pass is one file.
+extension Color {
+  /// Used for positive / available-funds / gain series.
+  static let chartGreen = Color(
+    light: .green,
+    dark: Color(red: 0.34, green: 0.71, blue: 0.41)
+  )
+
+  /// Used for net worth / value / primary line series.
+  static let chartBlue = Color(
+    light: .blue,
+    dark: Color(red: 0.30, green: 0.55, blue: 0.90)
+  )
+
+  /// Used for current-funds / P/L series.
+  static let chartOrange = Color(
+    light: .orange,
+    dark: Color(red: 0.90, green: 0.60, blue: 0.18)
+  )
+
+  /// Used for invested-amount series.
+  static let chartPurple = Color(
+    light: .purple,
+    dark: Color(red: 0.67, green: 0.45, blue: 0.80)
+  )
+
+  /// Used for investment-value series.
+  static let chartIndigo = Color(
+    light: .indigo,
+    dark: Color(red: 0.45, green: 0.45, blue: 0.82)
+  )
+
+  /// Used for loss / negative / expense series.
+  static let chartRed = Color(
+    light: .red,
+    dark: Color(red: 0.87, green: 0.36, blue: 0.34)
+  )
+
+  /// Used for stacked-category rotation.
+  static let chartTeal = Color(
+    light: .teal,
+    dark: Color(red: 0.36, green: 0.72, blue: 0.84)
+  )
+
+  /// Used for stacked-category rotation.
+  static let chartPink = Color(
+    light: .pink,
+    dark: Color(red: 0.87, green: 0.36, blue: 0.50)
+  )
+
+  /// Used for stacked-category rotation.
+  static let chartMint = Color(
+    light: .mint,
+    dark: Color(red: 0.40, green: 0.75, blue: 0.71)
+  )
+
+  /// Used for stacked-category rotation.
+  static let chartCyan = Color(
+    light: .cyan,
+    dark: Color(red: 0.36, green: 0.71, blue: 0.84)
+  )
+
+  /// Used for stacked-category rotation.
+  static let chartBrown = Color(
+    light: .brown,
+    dark: Color(red: 0.65, green: 0.55, blue: 0.42)
+  )
+
+  /// Used for stacked-category rotation.
+  static let chartYellow = Color(
+    light: .yellow,
+    dark: Color(red: 0.88, green: 0.74, blue: 0.18)
+  )
+}

--- a/Shared/Views/Positions/PositionsChart.swift
+++ b/Shared/Views/Positions/PositionsChart.swift
@@ -142,7 +142,7 @@ struct PositionsChart: View {
           Double(truncating: (baseline + row.gainSegment) as NSDecimalNumber)),
         series: .value("Series", "Gain")
       )
-      .foregroundStyle(.green.opacity(Self.gainLossOpacity))
+      .foregroundStyle(Color.chartGreen.opacity(Self.gainLossOpacity))
 
       AreaMark(
         x: .value("Date", row.date),
@@ -153,7 +153,7 @@ struct PositionsChart: View {
           "Baseline", Double(truncating: baseline as NSDecimalNumber)),
         series: .value("Series", "Loss")
       )
-      .foregroundStyle(.red.opacity(Self.gainLossOpacity))
+      .foregroundStyle(Color.chartRed.opacity(Self.gainLossOpacity))
     }
     LineMark(
       x: .value("Date", row.date),

--- a/Shared/Views/Positions/PositionsChartLegendRow.swift
+++ b/Shared/Views/Positions/PositionsChartLegendRow.swift
@@ -82,14 +82,14 @@ private struct ProfitLossLegendSwatch: View {
           .fill(
             unavailable
               ? Color.gray.opacity(opacity)
-              : Color.green.opacity(opacity)
+              : Color.chartGreen.opacity(opacity)
           )
           .frame(width: 14, height: 4)
         Rectangle()
           .fill(
             unavailable
               ? Color.gray.opacity(opacity)
-              : Color.red.opacity(opacity)
+              : Color.chartRed.opacity(opacity)
           )
           .frame(width: 14, height: 4)
       }


### PR DESCRIPTION
Apple's dark-mode system colours (`.green`, `.blue`, `.purple`, …) are deliberately chroma-boosted to keep contrast against dark backgrounds. Inside a chart area — where the marks _are_ the surface, with no surrounding `.background` / `.secondary` chrome to anchor expectations — this over-fires. The colours read as fluorescent on the dark background rather than as a colour applied to a surface.

## What changed

Introduce a `Color.chartGreen` / `chartBlue` / `chartOrange` / `chartPurple` / `chartIndigo` / `chartRed` / `chartTeal` / `chartPink` / `chartMint` / `chartCyan` / `chartBrown` / `chartYellow` palette in `Shared/Color+ChartPalette.swift`. Each entry resolves to Apple's system semantic in light mode and to a hand-tuned, less chroma-boosted variant in dark mode, via a cross-platform `Color(light:dark:)` helper.

Routed five chart views and their legend swatches through it:

- `NetWorthGraphCard` — the central `ChartSeries` enum (was the only existing centralised palette).
- `CategoriesOverTimeCard` — the rotating 12-colour stacked-area palette.
- `PositionsChart` + `PositionsChartLegendRow` — gain/loss area fills.
- `InvestmentChartView` — value / P/L lines + legend + selection detail swatches.
- `InvestmentValuesView` — investment line + area fill.

`Color.accentColor`, `Color.gray`, and `.secondary` are left unchanged — they were already adaptive.

## Light vs dark

Light mode is unchanged (still Apple's system semantics). In dark mode each chart colour drops ~10–30% chroma and a small amount of luminance, varying per hue — green and red were the most chroma-boosted and got the largest drop; orange/indigo the smallest.

## UI guide

Charts are now a documented exception to UI_GUIDE §5's "system semantic colours only" rule, alongside the existing focused-sidebar selected-row override. The rationale is captured in the file-level doc comment on `Shared/Color+ChartPalette.swift`.

## Verification

- `just format-check` ✅
- `just build-mac` ✅
- Visually verified against the running macOS app in dark mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)