### PR TITLE
chore: update repo URL references after org transfer

### DIFF
--- a/.claude/skills/automate-app/SKILL.md
+++ b/.claude/skills/automate-app/SKILL.md
@@ -147,7 +147,7 @@ moolah-tell 'pay txn id "UUID-HERE" of profile "Test"'
 > `count txns of profile "…"`,
 > `create txn in profile "…" with payee "…" amount …`. The four-char
 > code `'Txn '` is unchanged, so compiled `.scpt` files keep working.
-> See [#923](https://github.com/ajsutton/moolah-native/issues/923) for background on the reserved-word constraint.
+> See [#923](https://github.com/moolah-rocks/moolah-native/issues/923) for background on the reserved-word constraint.
 
 ### Earmark Operations
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
       - main
       - 'mq-spec-*'   # speculative merge-queue branches; CI runs without a PR
   pull_request:
+  merge_group:     # native GitHub merge queue; CI runs against gh-readonly-queue/* branches
 
 jobs:
   test:
@@ -38,10 +39,10 @@ jobs:
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
         run: bash scripts/check-todos.sh --format-only
 
-      # Trusted events only (pushes to origin branches, same-repo PRs):
-      # full check including liveness against the GitHub API.
+      # Trusted events only (pushes to origin branches, same-repo PRs, merge
+      # queue groups): full check including liveness against the GitHub API.
       - name: Validate TODO references (liveness)
-        if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
+        if: github.event_name == 'push' || github.event_name == 'merge_group' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: just validate-todos

--- a/App/MoolahDomainCommands.swift
+++ b/App/MoolahDomainCommands.swift
@@ -249,7 +249,7 @@ struct MoolahDomainCommands: Commands {
       }
 
       Button("Report a Bug") {
-        if let url = URL(string: "https://github.com/ajsutton/moolah-native/issues/new") {
+        if let url = URL(string: "https://github.com/moolah-rocks/moolah-native/issues/new") {
           openURL(url)
         }
       }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -215,9 +215,9 @@ Views must be thin wrappers that bind state, dispatch actions, and render. **All
 
 ## Bug Tracking
 
-- **Known bugs and feature issues** are tracked as GitHub issues at https://github.com/ajsutton/moolah-native/issues.
+- **Known bugs and feature issues** are tracked as GitHub issues at https://github.com/moolah-rocks/moolah-native/issues.
 - When fixing a bug, close the corresponding issue from the PR (e.g. `Fixes #123` in the commit or PR body).
-- When adding a TODO or FIXME in Swift source, reference an open GitHub issue: `TODO(#N): reason — https://github.com/ajsutton/moolah-native/issues/N`. Bare `TODO:` / `FIXME:` without an issue reference is disallowed.
+- When adding a TODO or FIXME in Swift source, reference an open GitHub issue: `TODO(#N): reason — https://github.com/moolah-rocks/moolah-native/issues/N`. Bare `TODO:` / `FIXME:` without an issue reference is disallowed.
 - CI blocks merging a PR that introduces a bare `TODO` or a `TODO(#N)` pointing at a closed/missing issue (`just validate-todos`). A nightly watchdog reopens any issue that gets closed while live references still exist and reconciles a `has-todos` label. See `guides/CODE_GUIDE.md` §20.
 
 ## Planning & Documentation

--- a/MoolahTests/Backends/CryptoCompareClientTests.swift
+++ b/MoolahTests/Backends/CryptoCompareClientTests.swift
@@ -155,7 +155,7 @@ struct CryptoCompareClientTests {
   // CryptoCompare occasionally ships entries with missing fields (e.g. an MLS
   // row missing `CoinName`). A single malformed row must not kill the entire
   // list — token resolution would otherwise fail for every crypto.
-  // See https://github.com/ajsutton/moolah-native/issues/746.
+  // See https://github.com/moolah-rocks/moolah-native/issues/746.
   @Test
   func parseCoinListResponse_skipsMalformedEntries() throws {
     let json = Data(

--- a/MoolahTests/Shared/TransactionDraftCategoryTests.swift
+++ b/MoolahTests/Shared/TransactionDraftCategoryTests.swift
@@ -127,7 +127,7 @@ struct TransactionDraftCategoryTests {
     #expect(draft.legDrafts[0].categoryText.isEmpty)
   }
 
-  // Per https://github.com/ajsutton/moolah-native/issues/509 reopening:
+  // Per https://github.com/moolah-rocks/moolah-native/issues/509 reopening:
   // `commitCategorySelection(id:path:)` must set both fields in a single
   // mutation so call sites doing `draft.commitCategorySelection(...)`
   // through a `@Binding` produce one read-modify-write rather than two

--- a/MoolahUITests_macOS/Tests/TransactionDetail/TransactionDetailCategoryTests.swift
+++ b/MoolahUITests_macOS/Tests/TransactionDetail/TransactionDetailCategoryTests.swift
@@ -6,7 +6,7 @@ import XCTest
 /// matches and the prefix "Gro" matches exactly one.
 @MainActor
 final class TransactionDetailCategoryTests: MoolahUITestCase {
-  /// Per [#509](https://github.com/ajsutton/moolah-native/issues/509),
+  /// Per [#509](https://github.com/moolah-rocks/moolah-native/issues/509),
   /// arrow-key highlighting + Tab must commit the highlighted suggestion
   /// — the same as Enter or clicking the suggestion. Without this, the
   /// blur handler would dismiss the highlight, then the typed text would
@@ -32,7 +32,7 @@ final class TransactionDetailCategoryTests: MoolahUITestCase {
     app.transactionDetail.category.expectSuggestionsHidden()
   }
 
-  /// Regression for [#509](https://github.com/ajsutton/moolah-native/issues/509)
+  /// Regression for [#509](https://github.com/moolah-rocks/moolah-native/issues/509)
   /// reopening: pressing Enter to commit the highlighted suggestion and then
   /// Tabbing to the next field must keep the committed value. The original
   /// fix only handled the "Tab without Enter" path; this case (Enter then Tab)

--- a/MoolahUITests_macOS/Tests/TransactionDetail/TransactionDetailPayeeAutocompleteTests.swift
+++ b/MoolahUITests_macOS/Tests/TransactionDetail/TransactionDetailPayeeAutocompleteTests.swift
@@ -54,7 +54,7 @@ final class TransactionDetailPayeeAutocompleteTests: MoolahUITestCase {
   }
 
   /// Escape closes the dropdown but must leave the user's typed text
-  /// alone. Per [#510](https://github.com/ajsutton/moolah-native/issues/510),
+  /// alone. Per [#510](https://github.com/moolah-rocks/moolah-native/issues/510),
   /// the user is in control of what is in the payee field — autocomplete
   /// is an aid, not a constraint, so dismissing the dropdown without a
   /// commit must not also wipe what the user has typed.

--- a/Shared/AppStoreURL.swift
+++ b/Shared/AppStoreURL.swift
@@ -8,5 +8,5 @@ enum AppStoreURL {
   // error, not a runtime condition. Force-unwrap is the idiomatic shape
   // for this case; any typo lands on the first call site in development.
   static let update = URL(
-    string: "https://github.com/ajsutton/moolah-native/releases/latest")!  // swiftlint:disable:this force_unwrapping
+    string: "https://github.com/moolah-rocks/moolah-native/releases/latest")!  // swiftlint:disable:this force_unwrapping
 }

--- a/Shared/CryptoImport/BlockscoutWireFormat.swift
+++ b/Shared/CryptoImport/BlockscoutWireFormat.swift
@@ -92,7 +92,7 @@ struct BlockscoutAddress: Decodable, Sendable, Hashable {
 /// One item from the address `transactions` endpoint. `value` is wei as
 /// a decimal string. Success is derived from `status`/`result` so a
 /// reverted tx is still enumerated (it paid gas —
-/// https://github.com/ajsutton/moolah-native/issues/919).
+/// https://github.com/moolah-rocks/moolah-native/issues/919).
 struct BlockscoutTransaction: Decodable, Sendable, Hashable {
   let hash: String
   let blockNumber: Int

--- a/Shared/CryptoImport/TransferEventBuilder+GasOnly.swift
+++ b/Shared/CryptoImport/TransferEventBuilder+GasOnly.swift
@@ -4,7 +4,7 @@ import Foundation
 extension TransferEventBuilder {
   /// Fetches receipts, builds a transaction per transfer-event group, then
   /// appends a gas-leg-only transaction for every signed hash that produced
-  /// no transfer event (#919 — https://github.com/ajsutton/moolah-native/issues/919).
+  /// no transfer event (#919 — https://github.com/moolah-rocks/moolah-native/issues/919).
   /// Invoked by build(_:) after it validates the wallet and assembles the BuildContext.
   func buildTransactions(
     transfers: [AlchemyTransfer],
@@ -57,7 +57,7 @@ extension TransferEventBuilder {
   /// whether any `AlchemyTransfer` row exists for it. `signedGasTxs` carries
   /// the hashes from Blockscout's account tx list; `groupedHashes` is the
   /// set already covered by transfer-event groups so we don't double-emit.
-  /// See https://github.com/ajsutton/moolah-native/issues/919.
+  /// See https://github.com/moolah-rocks/moolah-native/issues/919.
   private func buildGasOnlyTransactions(
     signedGasTxs: [SignedGasTx],
     groupedHashes: Set<String>,

--- a/guides/CODE_GUIDE.md
+++ b/guides/CODE_GUIDE.md
@@ -547,7 +547,7 @@ Every `TODO` or `FIXME` **must reference a tracked GitHub issue**. Bare `TODO:` 
 
   ```swift
   // TODO(#123): drop legacy import path once sync v2 ships
-  //             — https://github.com/ajsutton/moolah-native/issues/123
+  //             — https://github.com/moolah-rocks/moolah-native/issues/123
   ```
 
 Enforcement is automated:

--- a/scripts/release-preflight.sh
+++ b/scripts/release-preflight.sh
@@ -30,7 +30,7 @@ fi
 git fetch origin main --quiet
 # Sync tags so downstream tag-based logic (e.g. release-next-version) sees the
 # same set as origin — otherwise stale local state can produce a wrong "next"
-# version. See https://github.com/ajsutton/moolah-native/issues/498.
+# version. See https://github.com/moolah-rocks/moolah-native/issues/498.
 git fetch --tags --prune --force origin --quiet
 local_sha=$(git rev-parse HEAD)
 remote_sha=$(git rev-parse origin/main)

--- a/site/index.html
+++ b/site/index.html
@@ -185,7 +185,7 @@
       />
       <p>
         &copy; 2026 moolah.rocks ·
-        <a href="https://github.com/ajsutton/moolah-native"
+        <a href="https://github.com/moolah-rocks/moolah-native"
           >moolah-native on GitHub</a
         >
       </p>

--- a/site/styles.css
+++ b/site/styles.css
@@ -1,7 +1,4 @@
-/* moolah.rocks — static site styles.
-   Ported from the legacy Welcome.vue <style lang="scss"> (ajsutton/moolah):
-   SCSS nesting flattened to plain CSS, sign-in removed, header/footer/CTA
-   added. Colours/type follow guides/BRAND_GUIDE.md. */
+/* moolah.rocks — static site styles. Colours/type follow guides/BRAND_GUIDE.md. */
 
 * {
   box-sizing: border-box;


### PR DESCRIPTION
## Summary

- Replaces hardcoded `github.com/ajsutton/moolah-native` paths after the repo transfer to `moolah-rocks/moolah-native`.
- Touches source, tests, docs, scripts, and the marketing site:
  - `App/MoolahDomainCommands.swift` — in-app "Report a Bug" URL (ships in binaries).
  - `Shared/AppStoreURL.swift` — "check for updates" / Releases URL.
  - `CLAUDE.md` — issue tracker URL and `TODO(#N)` convention.
  - `guides/CODE_GUIDE.md` — TODO format example.
  - `.claude/skills/automate-app/SKILL.md` — historical PR citation.
  - 7 source/test files — comment citations of issues #498, #509, #510, #746, #919.
  - `site/index.html` — public "View on GitHub" link.
  - `site/styles.css` — drops the legacy `ajsutton/moolah` (v1 Vue SPA) attribution; the site stands on its own.
- Leaves `plans/*.md` alone — historical artefacts; GitHub's permanent redirect handles them.

## Test plan

- [x] `just format-check` passes
- [x] `just build-mac` succeeds with no new warnings
- [ ] First exercise of native merge queue (replaces the retired `mq-spec-*` custom train).

## Notes

The original migration audit's file-glob filter was too narrow; this PR also picks up the 10 references it missed (issue citations in test/source comments, the live `Releases` URL in `AppStoreURL.swift`, the site footer link). Found via a second grep after the audit. Fix-all-in-one-pass per project convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)