### PR TITLE
feat(skill): add landing-prs skill for native merge queue + stacked PRs

### DIFF
--- a/.claude/skills/landing-prs/SKILL.md
+++ b/.claude/skills/landing-prs/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: landing-prs
+description: Use when landing a PR in this repo — setting it to merge, "queuing it", enabling automerge, or shipping a stacked PR. Anything that lands code on main goes through this skill. Covers the simple case (`gh pr merge --auto --rebase`) and the stacked case (autonomous watcher that retargets to main and enqueues once the parent merges). Use when the user says "land", "ship", "queue", "merge", "set to automerge", or opens a PR targeting a non-main base.
+---
+
+# Landing PRs
+
+This repo uses **GitHub's native merge queue** on `main`. The repo's branch ruleset on `main` requires the merge queue for every merge — direct push is rejected, "Merge" / "Rebase" / "Squash" buttons on PRs route through the queue, and CI runs on `gh-readonly-queue/main/pr-<N>-...` branches via the workflow's `merge_group:` trigger.
+
+There is no project-level custom merge-train daemon any more. The user-level `~/.claude/skills/merge-queue/` skill exists but is **not for this repo** — it's reserved for projects without native merge queue access (e.g. a public repo on a personal account, where the feature is org-only).
+
+## TL;DR
+
+| Situation | Action |
+|---|---|
+| PR base is `main`, you want it to land | `gh pr merge <N> --auto --rebase` (or just run `land-pr.sh <N>`) |
+| PR base is another feature branch (stacked) | `./.claude/skills/landing-prs/scripts/land-pr.sh <N>` — it starts a watcher that auto-retargets + auto-enqueues once the parent merges |
+| You want to cancel automerge / pull a PR out of the queue | `gh pr merge <N> --disable-auto`; or, if it's currently in the queue, click "Remove from queue" in the GitHub UI |
+| Watcher running for a stacked PR, you want to kill it | `pkill -f 'watch-stacked-pr.sh <N>'`; logs are in `.agent-tmp/landing-prs/watch-<N>.log` |
+
+Always invoke `land-pr.sh` instead of `gh pr merge --auto --rebase` directly when the PR might be stacked — `land-pr.sh` detects the case automatically and falls through to the simple path when the PR targets `main`.
+
+## Why a watcher is needed for stacked PRs
+
+GitHub's automerge has a footgun for stacked PRs: **it merges the PR into whatever branch it currently targets**, not into `main`.
+
+Concretely: if you open child PR #B with `--base feat/parent-branch` (because it stacks on PR #A which is open at that branch), and then you call `gh pr merge B --auto`, the moment checks pass, **#B merges into `feat/parent-branch`**. The child's commits become part of the parent's PR. The parent's diff balloons. The parent's CI re-runs against the combined diff. You then have to recover by extracting the child's commits to a new branch and force-pushing the parent back to its pre-merge state — exactly the recovery flow documented in `CLAUDE.md` under "Stacked-PR worktrees".
+
+The fix: **never enable automerge on a stacked PR until its base has been retargeted to `main`**, which can only safely happen after the parent has merged. The watcher in this skill enforces that ordering.
+
+(Native merge queue does NOT prevent this on its own. The queue's "Require merge queue" rule applies to `main`. A merge into `feat/parent-branch` doesn't go through the queue — branch protection doesn't apply — and the merge happens directly.)
+
+## Procedure: regular PR (base = main)
+
+```bash
+./.claude/skills/landing-prs/scripts/land-pr.sh <N>
+```
+
+Detects `base == main`, runs `gh pr merge <N> --auto --rebase`. That enables automerge, which queues the PR with GitHub's native merge queue. When checks pass on the PR head, GitHub creates a `gh-readonly-queue/main/pr-<N>-...` branch with the PR rebased on top of main, runs CI on it (via the `merge_group:` trigger in `.github/workflows/ci.yml`), and fast-forwards `main` once green.
+
+You don't have to wait. The script exits immediately after enabling automerge. The queue handles the rest.
+
+## Procedure: stacked PR (base = another feature branch)
+
+```bash
+./.claude/skills/landing-prs/scripts/land-pr.sh <N>
+```
+
+Detects `base != main`, looks up the parent PR (the open PR whose `headRefName` matches the child's `baseRefName`), and backgrounds `watch-stacked-pr.sh` to poll both PRs every 60 seconds. The watcher:
+
+- **Parent merged** → retargets child to `main` (`gh pr edit <N> --base main`), then enables automerge on the child. Exits.
+- **Parent closed unmerged** → notifies via `osascript` and exits (child can't auto-proceed).
+- **Child CI failed / merge conflict / closed** → notifies and exits. You fix and re-run `land-pr.sh <N>`.
+
+The watcher survives `nohup` past the launching shell, so closing the terminal is safe. Its log lives at `.agent-tmp/landing-prs/watch-<N>.log`.
+
+## Scripts
+
+### `scripts/land-pr.sh <PR> [--repo OWNER/REPO]`
+
+Entry point. Detects regular vs stacked and dispatches.
+
+- `--repo` is optional; defaults to the current repo (from `gh`'s context). Useful when running from outside a checkout.
+- Exit codes:
+  - `0` — automerge enabled successfully, or watcher backgrounded successfully.
+  - `1` — couldn't find parent PR for a stacked child (refuses to guess).
+  - `2` — usage error.
+
+### `scripts/watch-stacked-pr.sh <CHILD-PR> <PARENT-PR> [--repo OWNER/REPO]`
+
+Background watcher. Not normally invoked directly — `land-pr.sh` calls it under `nohup`. You can invoke it manually if you need to resume watching after a session restart.
+
+Polls every 60s. Emits one-line status updates to its log file. On terminal state, sends a desktop notification (via `osascript`) and exits.
+
+Foreground use: omit `nohup` and run directly — log lines go to stdout. Useful for `Monitor` integration if you want Claude to react to events:
+
+```bash
+./.claude/skills/landing-prs/scripts/watch-stacked-pr.sh 42 41
+```
+
+## Common operations
+
+**List active watchers:**
+```
+pgrep -af watch-stacked-pr.sh
+```
+
+**Tail a watcher's log:**
+```
+tail -f .agent-tmp/landing-prs/watch-<N>.log
+```
+
+**Cancel a watcher:**
+```
+pkill -f 'watch-stacked-pr.sh <N> '
+```
+(Note the trailing space — pgrep/pkill regex anchors on the child PR number, not the parent's.)
+
+**Re-arm a watcher** (e.g. after a session restart where the background process died):
+```
+./.claude/skills/landing-prs/scripts/watch-stacked-pr.sh <CHILD> <PARENT> &
+```
+
+## Failure modes and recovery
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `land-pr.sh` says "No open PR found for branch 'X'" | The PR has been opened against a base whose head PR doesn't exist or is closed. | Open the parent PR first, or manually retarget the child to `main` (`gh pr edit <N> --base main`) if the stacking is no longer needed. |
+| Watcher running but the child PR's base never changed when the parent merged | The watcher process died (e.g. machine restart). | `pgrep -af watch-stacked-pr.sh` to check; re-arm via the "Re-arm" command above. |
+| Child PR merged into the parent's branch instead of main | Automerge was enabled on the child before its base was retargeted (the very footgun this skill exists to prevent). | Follow the recovery in `CLAUDE.md` § "Stacked-PR worktrees: don't accidentally push into the parent PR". |
+| Native merge queue is BLOCKED with all PR-level checks green | The queue branch's CI hasn't run, or hasn't passed. Likely the workflow doesn't subscribe to `merge_group:`. | Verify `.github/workflows/ci.yml` has `merge_group:` in `on:`. If a workflow change is needed, push a fix to the same PR (auto-removes from queue), re-enable automerge after CI passes on the new head. |
+| `mergeStateStatus: BEHIND` | Branch is behind base; native MQ doesn't auto-rebase. | Either rebase locally + force-push (rebase merge method), or `gh pr update-branch <N>` for merge-commit method. |
+
+## Why no auto-cleanup of worktrees / branches
+
+This skill stops at "PR landed on main". Worktree removal, local branch deletion, and follow-on tasks are out of scope — the user has their own cleanup habits, and the cost of being wrong on cleanup is high (lost work) compared to the small inconvenience of doing it manually.
+
+If you need merge-event-driven cleanup, layer it on top using the user-level `monitoring-pr-status` skill, which exposes merge / failure events as a stream of stdout lines suitable for `Monitor`-based integration.

--- a/.claude/skills/landing-prs/scripts/land-pr.sh
+++ b/.claude/skills/landing-prs/scripts/land-pr.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+#
+# land-pr.sh — land a PR via GitHub's native merge queue.
+#
+# Detects whether the PR targets main (queue directly) or a feature branch
+# (kicks off a background watcher that auto-retargets + auto-enqueues once
+# the parent merges). See SKILL.md alongside this script for details.
+
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+usage: land-pr.sh <PR> [--repo OWNER/REPO]
+
+  PR              Pull request number to land.
+  --repo          Repository in OWNER/REPO form. Defaults to the gh CLI's
+                  current-context repo.
+
+Behaviour:
+  base == main:    enables automerge (rebase) immediately. Exits.
+  base != main:    finds the parent PR (the open PR whose head matches the
+                   child's base), starts watch-stacked-pr.sh under nohup,
+                   and exits. The watcher retargets the child to main and
+                   enables automerge once the parent merges.
+
+Exit codes:
+  0   success (automerge enabled, or watcher backgrounded)
+  1   couldn't find a parent PR for a stacked child
+  2   usage error
+USAGE
+}
+
+PR=""
+REPO=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help) usage; exit 0 ;;
+    --repo)
+      [[ -n "${2:-}" ]] || { echo "land-pr.sh: --repo needs a value" >&2; exit 2; }
+      REPO="$2"; shift 2
+      ;;
+    --repo=*) REPO="${1#--repo=}"; shift ;;
+    -*) echo "land-pr.sh: unknown flag '$1'" >&2; usage >&2; exit 2 ;;
+    *)
+      [[ -z "$PR" ]] || { echo "land-pr.sh: unexpected extra argument '$1'" >&2; exit 2; }
+      PR="$1"; shift
+      ;;
+  esac
+done
+
+[[ -n "$PR" ]] || { usage >&2; exit 2; }
+[[ "$PR" =~ ^[0-9]+$ ]] || { echo "land-pr.sh: PR must be a number, got '$PR'" >&2; exit 2; }
+
+REPO_FLAG=()
+[[ -n "$REPO" ]] && REPO_FLAG=(--repo "$REPO")
+
+# Resolve the PR's base. gh exits non-zero if the PR doesn't exist.
+base=$(gh pr view "$PR" "${REPO_FLAG[@]}" --json baseRefName --jq '.baseRefName')
+
+if [[ "$base" == "main" || "$base" == "master" ]]; then
+  echo "PR #$PR targets '$base' → enabling automerge (rebase)."
+  # The merge method is overridden by the queue's configured method on this
+  # repo (REBASE), but we pass --rebase to be explicit. gh prints a harmless
+  # warning if it conflicts; we don't gate on it.
+  gh pr merge "$PR" "${REPO_FLAG[@]}" --auto --rebase
+  echo "Done. Native merge queue will land it when checks pass."
+  exit 0
+fi
+
+echo "PR #$PR targets '$base' (stacked) — looking up parent PR."
+
+# Find the open PR whose head ref matches the child's base ref.
+parent=$(gh pr list "${REPO_FLAG[@]}" --head "$base" --state open --json number --jq '.[0].number // empty')
+
+if [[ -z "$parent" ]]; then
+  cat >&2 <<EOF
+land-pr.sh: no open PR found whose head is '$base'.
+
+The child PR (#$PR) targets a branch that doesn't have an open parent PR.
+Either:
+  - Open the parent PR first, then re-run this script, OR
+  - If the stacking is no longer needed, retarget the child to main with:
+      gh pr edit $PR ${REPO_FLAG[*]:-} --base main
+    then re-run this script.
+EOF
+  exit 1
+fi
+
+echo "Parent: PR #$parent → child: PR #$PR"
+
+# Background the watcher. State / logs in .agent-tmp/landing-prs/ (gitignored).
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+log_dir=".agent-tmp/landing-prs"
+mkdir -p "$log_dir"
+log_file="$log_dir/watch-$PR.log"
+
+watcher_args=("$PR" "$parent")
+[[ -n "$REPO" ]] && watcher_args+=(--repo "$REPO")
+
+nohup bash "$script_dir/watch-stacked-pr.sh" "${watcher_args[@]}" \
+  >"$log_file" 2>&1 &
+watcher_pid=$!
+
+# Detach from the parent shell so the watcher survives session exit.
+disown "$watcher_pid" 2>/dev/null || true
+
+echo "Watcher started (PID=$watcher_pid)."
+echo "Log: $log_file"
+echo "Tail with: tail -f $log_file"
+echo "Cancel with: kill $watcher_pid  (or: pkill -f 'watch-stacked-pr.sh $PR ')"

--- a/.claude/skills/landing-prs/scripts/watch-stacked-pr.sh
+++ b/.claude/skills/landing-prs/scripts/watch-stacked-pr.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+#
+# watch-stacked-pr.sh — wait for a parent PR to merge, then auto-retarget
+# the child PR to main and enable automerge on it.
+#
+# Not normally invoked directly; land-pr.sh starts it via nohup. See the
+# adjacent SKILL.md for the full procedure.
+
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+usage: watch-stacked-pr.sh <CHILD-PR> <PARENT-PR> [--repo OWNER/REPO]
+
+  Polls every 60s. Emits status lines to stdout. On terminal state, sends a
+  desktop notification (osascript on macOS; falls back to log-only) and exits.
+
+  Terminal states (with exit codes):
+    Parent merged       → retarget child + enable automerge → exit 0
+    Parent closed       → cannot proceed                    → exit 1
+    Child merged        → nothing left to do                → exit 0
+    Child closed        → user gave up                      → exit 0
+    Child CI failed     → user needs to fix                 → exit 1
+    Child conflict      → user needs to rebase              → exit 1
+USAGE
+}
+
+CHILD=""
+PARENT=""
+REPO=""
+
+# Positional args first, then flags. Accept --repo anywhere.
+positional=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help) usage; exit 0 ;;
+    --repo)
+      [[ -n "${2:-}" ]] || { echo "watch-stacked-pr.sh: --repo needs a value" >&2; exit 2; }
+      REPO="$2"; shift 2
+      ;;
+    --repo=*) REPO="${1#--repo=}"; shift ;;
+    -*) echo "watch-stacked-pr.sh: unknown flag '$1'" >&2; exit 2 ;;
+    *) positional+=("$1"); shift ;;
+  esac
+done
+
+[[ ${#positional[@]} -eq 2 ]] || { usage >&2; exit 2; }
+CHILD="${positional[0]}"
+PARENT="${positional[1]}"
+
+[[ "$CHILD" =~ ^[0-9]+$ ]] || { echo "watch-stacked-pr.sh: CHILD-PR must be a number" >&2; exit 2; }
+[[ "$PARENT" =~ ^[0-9]+$ ]] || { echo "watch-stacked-pr.sh: PARENT-PR must be a number" >&2; exit 2; }
+
+REPO_FLAG=()
+[[ -n "$REPO" ]] && REPO_FLAG=(--repo "$REPO")
+
+POLL_INTERVAL="${POLL_INTERVAL:-60}"
+
+log() {
+  echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*"
+}
+
+notify() {
+  local msg="$1"
+  log "NOTIFY: $msg"
+  if command -v osascript >/dev/null 2>&1; then
+    osascript -e "display notification \"$msg\" with title \"Landing PR #$CHILD\"" 2>/dev/null || true
+  fi
+}
+
+# Robust fetch: gh occasionally hiccups; treat single failures as transient.
+fetch_pr_json() {
+  local pr="$1"
+  local fields="$2"
+  local out
+  if out=$(gh pr view "$pr" "${REPO_FLAG[@]}" --json "$fields" 2>/dev/null); then
+    echo "$out"
+  else
+    echo ""  # Empty = "unknown this tick"; caller continues polling.
+  fi
+}
+
+log "Watching parent PR #$PARENT → child PR #$CHILD (poll every ${POLL_INTERVAL}s)"
+
+while true; do
+  parent_json=$(fetch_pr_json "$PARENT" 'state,mergedAt')
+  child_json=$(fetch_pr_json "$CHILD" 'state,mergedAt,baseRefName,mergeStateStatus,statusCheckRollup')
+
+  if [[ -z "$parent_json" || -z "$child_json" ]]; then
+    log "gh fetch hiccup; will retry next tick"
+    sleep "$POLL_INTERVAL"
+    continue
+  fi
+
+  parent_state=$(jq -r '.state // "UNKNOWN"' <<<"$parent_json")
+  parent_merged_at=$(jq -r '.mergedAt // empty' <<<"$parent_json")
+
+  child_state=$(jq -r '.state // "UNKNOWN"' <<<"$child_json")
+  child_merged_at=$(jq -r '.mergedAt // empty' <<<"$child_json")
+  child_base=$(jq -r '.baseRefName // ""' <<<"$child_json")
+  child_merge_state=$(jq -r '.mergeStateStatus // "UNKNOWN"' <<<"$child_json")
+  child_failed_checks=$(jq -r '[.statusCheckRollup[]? | select(.conclusion == "FAILURE" or .conclusion == "CANCELLED" or .conclusion == "TIMED_OUT" or .conclusion == "ACTION_REQUIRED")] | length' <<<"$child_json")
+
+  # --- Child-side terminal states first (exit immediately if any apply) ---
+
+  if [[ -n "$child_merged_at" ]]; then
+    notify "Child #$CHILD already merged. Nothing to do."
+    exit 0
+  fi
+
+  if [[ "$child_state" == "CLOSED" ]]; then
+    notify "Child #$CHILD closed unmerged. Exiting."
+    exit 0
+  fi
+
+  if [[ "$child_failed_checks" -gt 0 ]]; then
+    notify "Child #$CHILD has CI failures. Fix and re-run land-pr.sh."
+    exit 1
+  fi
+
+  if [[ "$child_merge_state" == "DIRTY" ]]; then
+    notify "Child #$CHILD has merge conflicts. Rebase and re-run land-pr.sh."
+    exit 1
+  fi
+
+  # --- Parent-side state ---
+
+  if [[ -n "$parent_merged_at" ]]; then
+    log "Parent #$PARENT merged at $parent_merged_at — proceeding"
+
+    if [[ "$child_base" != "main" && "$child_base" != "master" ]]; then
+      log "Retargeting child #$CHILD: base '$child_base' → main"
+      if ! gh pr edit "$CHILD" "${REPO_FLAG[@]}" --base main >/dev/null 2>&1; then
+        notify "Retarget of #$CHILD failed. Manual intervention needed."
+        exit 1
+      fi
+      log "Retargeted #$CHILD to main"
+    else
+      log "Child #$CHILD already targets '$child_base'; no retarget needed"
+    fi
+
+    log "Enabling automerge on #$CHILD"
+    if ! gh pr merge "$CHILD" "${REPO_FLAG[@]}" --auto --rebase >/dev/null 2>&1; then
+      notify "Failed to enable automerge on #$CHILD. Manual intervention needed."
+      exit 1
+    fi
+
+    notify "Child #$CHILD retargeted to main + automerge enabled."
+    exit 0
+  fi
+
+  if [[ "$parent_state" == "CLOSED" ]]; then
+    notify "Parent #$PARENT closed unmerged. Child #$CHILD can't auto-proceed."
+    exit 1
+  fi
+
+  # Still waiting — log a heartbeat and sleep
+  log "Waiting: parent=$parent_state child=$child_state child_base=$child_base child_merge_state=$child_merge_state"
+  sleep "$POLL_INTERVAL"
+done


### PR DESCRIPTION
## Summary

Adds a project-level skill that documents and automates landing PRs via GitHub's native merge queue, with first-class support for stacked PRs.

**Files:**

- `.claude/skills/landing-prs/SKILL.md` — procedure + footgun docs, when to invoke, common operations, recovery flows.
- `.claude/skills/landing-prs/scripts/land-pr.sh` — entry point. Detects regular vs stacked PR and dispatches.
- `.claude/skills/landing-prs/scripts/watch-stacked-pr.sh` — autonomous background watcher: when the parent PR merges, retargets the child to `main` and enables automerge on it; also detects CI failures, conflicts, and parent-closed-unmerged on either side.

## Why

`gh pr merge --auto` on a stacked PR merges the child into its parent's branch — the well-known footgun documented in `CLAUDE.md` § "Stacked-PR worktrees: don't accidentally push into the parent PR". Native merge queue doesn't prevent it (the queue's "Require merge queue" rule applies to `main`; a merge into a feature branch bypasses it). This skill makes the safe procedure the easy procedure.

## Dogfooding

This PR will be landed via `land-pr.sh` itself — its own first real exercise. Since the PR targets `main`, `land-pr.sh` takes the simple path: `gh pr merge --auto --rebase`.

## Test plan

- [x] Both scripts pass `bash -n` and `shellcheck`.
- [x] `--help` output for both scripts is sensible.
- [x] `just format-check` passes (no Swift changes; scripts + markdown only).
- [ ] Dogfood: PR lands via native MQ.

## Out of scope

- Deprecating / removing the user-level `~/.claude/skills/merge-queue/` daemon. SKILL.md notes it's retained for projects without native MQ access.
- Auto-cleanup of worktrees / branches after merge — explicitly out of scope (high cost on getting it wrong).

🤖 Generated with [Claude Code](https://claude.com/claude-code)