### PR TITLE
fix(handoff): restore .handlesExternalEvents([]) to block #386 auto-spawn

### DIFF
--- a/App/MoolahApp.swift
+++ b/App/MoolahApp.swift
@@ -196,16 +196,26 @@ struct MoolahApp: App {
         MoolahDomainCommands()
       }
 
+      // The auxiliary Windows below all opt out of SwiftUI's external-event
+      // auto-spawn for the same reason as the main `WindowGroup` above
+      // (`#386`). When the main group declines an incoming `NSUserActivity`,
+      // SwiftUI falls through to the next scene in declaration order whose
+      // match set still accepts it — without this opt-out, every Handoff
+      // continuation would spawn the About window (or whichever scene came
+      // next). `openWindow(id:)` from menu items is unaffected, since it
+      // does not route through external-event matching.
       Window("About Moolah", id: "about") {
         AboutView()
       }
       .windowResizability(.contentSize)
       .windowStyle(.hiddenTitleBar)
+      .handlesExternalEvents(matching: [])
 
       Window("Keyboard Shortcuts", id: "keyboard-shortcuts") {
         KeyboardShortcutsView()
       }
       .windowResizability(.contentSize)
+      .handlesExternalEvents(matching: [])
 
       Settings {
         SettingsView()
@@ -229,6 +239,7 @@ struct MoolahApp: App {
       }
       .windowResizability(.contentSize)
       .defaultLaunchBehavior(isUITesting ? .presented : .suppressed)
+      .handlesExternalEvents(matching: [])
     #else
       WindowGroup {
         ProfileRootView(activeSession: $activeSession)

--- a/App/MoolahApp.swift
+++ b/App/MoolahApp.swift
@@ -27,7 +27,8 @@ struct MoolahApp: App {
   private let isUITesting: Bool
   /// Stable identifier for the primary `WindowGroup(for:)`. Exposed so
   /// `UITestingLauncherView` can call `openWindow(id:)` to open a default
-  /// instance with a nil binding (for Welcome seeds that have no profile).
+  /// instance with a nil binding — `ProfileWindowView` resolves the
+  /// seeded profile (or falls back to `WelcomeView`) on its own.
   static let mainWindowID = "profile-window"
   @State var profileStore: ProfileStore
   // internal (was private) so `+Lifecycle` can log under the shared
@@ -157,6 +158,20 @@ struct MoolahApp: App {
             }
           }
       }
+      // Opt out of SwiftUI's external-event auto-spawn. `WindowGroup(for:)`
+      // listens to incoming `NSUserActivity` continuations on a channel
+      // that is independent of `NSApplicationDelegate.application(_:continue:)`
+      // — returning `true` from the delegate signals AppKit but does NOT
+      // suppress this channel, so without the opt-out every Handoff
+      // continuation spawns a second window behind the active one
+      // (`#386`). Handoff payloads are routed in-process through
+      // `ScriptingBridge.application(_:continue:)` → `HandoffContinuationHandler`
+      // → `NavigationBridge`, so the WindowGroup never needs to handle
+      // external events itself. `UITestingLauncherView` deliberately uses
+      // `openWindow(id:)` rather than `openWindow(value:)` because the
+      // empty match set also blocks cross-scene `openWindow(value:)`
+      // routing into this group.
+      .handlesExternalEvents(matching: [])
       // Opt out of NSWindow state restoration under `--ui-testing` so a
       // stale window from a previous test (e.g. one that ended on the
       // Analysis view with a CancellationError) cannot get restored into
@@ -210,7 +225,7 @@ struct MoolahApp: App {
       // `WelcomeView` still gets a window to render into. Suppressed in
       // production, where normal scene restoration opens the window.
       Window("UI Testing Launcher", id: "ui-testing-launcher") {
-        UITestingLauncherView(profileId: uiTestingProfileId)
+        UITestingLauncherView()
       }
       .windowResizability(.contentSize)
       .defaultLaunchBehavior(isUITesting ? .presented : .suppressed)

--- a/App/UITestingLauncherView.swift
+++ b/App/UITestingLauncherView.swift
@@ -3,12 +3,18 @@
 
   /// Hidden view hosted by the launcher Window. On `.task` it opens the
   /// main `ProfileWindowView` window and then stays around as a 1×1
-  /// invisible window for the lifetime of the test process. When a
-  /// specific profile was seeded (`profileId != nil`) the window is
-  /// opened with that value so the scene binds directly to it; when the
-  /// seed produced no profile (Welcome seeds) `openWindow(id:)` opens
-  /// the default `WindowGroup(for:)` window with a nil binding so
-  /// `WelcomeView` renders inside it.
+  /// invisible window for the lifetime of the test process. Both seeded
+  /// and Welcome (no-profile) launches use `openWindow(id:)`: the
+  /// `WindowGroup(for:)` window opens with a nil binding, and
+  /// `ProfileWindowView(profileID: uiTestingProfileId ?? profileID)`
+  /// in `MoolahApp` pins the window to the seeded profile when one
+  /// exists and falls back to `WelcomeView` otherwise.
+  ///
+  /// We avoid `openWindow(value:)` here because `MoolahApp`'s main
+  /// `WindowGroup` uses `.handlesExternalEvents(matching: [])` to block
+  /// SwiftUI's `#386` Handoff auto-spawn, and the empty match set also
+  /// blocks cross-scene `openWindow(value:)` routing into that group —
+  /// see the rationale comment above the modifier in `MoolahApp.swift`.
   ///
   /// The launcher Window is `.defaultLaunchBehavior(.suppressed)` in
   /// production, so this view is never instantiated outside
@@ -23,18 +29,13 @@
   /// drivers locate elements by accessibility identifier, so a second
   /// content-free window adds nothing to the tree they care about.
   struct UITestingLauncherView: View {
-    let profileId: UUID?
     @Environment(\.openWindow) private var openWindow
 
     var body: some View {
       Color.clear
         .frame(width: 1, height: 1)
         .task {
-          if let profileId {
-            openWindow(value: profileId)
-          } else {
-            openWindow(id: MoolahApp.mainWindowID)
-          }
+          openWindow(id: MoolahApp.mainWindowID)
         }
     }
   }

--- a/Automation/AppleScript/ScriptingBridge.swift
+++ b/Automation/AppleScript/ScriptingBridge.swift
@@ -23,10 +23,13 @@
     ///
     /// Returns `true` for every activity whose `activityType` matches
     /// `HandoffActivity.continueActivityType`, even when the payload is
-    /// missing or undecodable — that prevents AppKit from falling through
-    /// to SwiftUI's `WindowGroup` external-event routing, which would
-    /// auto-spawn a phantom window (the #386 class of bug). Activities of
-    /// other types return `false` so the OS can route them elsewhere.
+    /// missing or undecodable — that signals AppKit we've consumed the
+    /// activity rather than leaving it to default handling. SwiftUI's
+    /// `WindowGroup` auto-spawn (the `#386` class of bug) is suppressed
+    /// independently by `.handlesExternalEvents(matching: [])` on the
+    /// `WindowGroup` in `MoolahApp`; returning `true` here does NOT stop
+    /// it. Activities of other types return `false` so the OS can route
+    /// them elsewhere.
     @MainActor
     func application(
       _ application: NSApplication,

--- a/MoolahTests/Automation/ScriptingBridgeHandoffTests.swift
+++ b/MoolahTests/Automation/ScriptingBridgeHandoffTests.swift
@@ -80,9 +80,10 @@
           NSApp,
           continue: activity,
           restorationHandler: { _ in })
-        // Returns true so AppKit doesn't fall through to SwiftUI's
-        // WindowGroup external-event routing (which would spawn a phantom
-        // window per #386). No bridge calls.
+        // Returns true to signal AppKit we've consumed the activity. The
+        // `#386` auto-spawn guard lives on the WindowGroup itself
+        // (`.handlesExternalEvents(matching: [])`), not here. No bridge
+        // calls because the payload was malformed.
         #expect(handled)
         #expect(recorder.openedProfiles.isEmpty)
         #expect(recorder.setNavigations.isEmpty)


### PR DESCRIPTION
## Summary

Every Handoff continuation currently spawns a second window behind the already-focused one. Restores the `.handlesExternalEvents(matching: [])` modifier that ff4ac411 incorrectly dropped, and rewires the UI-test launcher so the original CI failure that motivated ff4ac411 does not return.

## Root cause

ff4ac411 removed `.handlesExternalEvents(matching: [])` on the main macOS `WindowGroup` on the premise that returning `true` from `ScriptingBridge.application(_:continue:)` would suppress SwiftUI's auto-spawn for incoming Handoff `NSUserActivity` continuations. That premise is wrong — `WindowGroup(for:)` listens to incoming activities on a channel that is independent of the AppKit delegate's return value. As a result every Handoff continuation now fires both paths simultaneously:

1. **AppKit delegate path** — `application(_:continue:)` → `HandoffContinuationHandler` → `ProfileWindowLocator.activateExistingWindow` brings the existing window forward, then `setPendingNavigation` triggers the navigation. ⇒ **window 1 (front, navigated).**
2. **SwiftUI WindowGroup auto-spawn** — `WindowGroup(for: Profile.ID.self)` sees the incoming activity, materialises a second window, which resolves the same profile and reads the shared `@State pendingNavigation`. ⇒ **window 2 (behind, also navigated).**

This is precisely the `#386` failure mode the original design called out (`plans/2026-05-25-handoff-design.md` §35–38).

## Changes

- `App/MoolahApp.swift` — Restore `.handlesExternalEvents(matching: [])` on the main WindowGroup with an explicit rationale comment so it isn't dropped a third time. Drop `profileId` from the launcher call site.
- `App/UITestingLauncherView.swift` — Always use `openWindow(id: MoolahApp.mainWindowID)`. Under `--ui-testing`, `ProfileWindowView(profileID: uiTestingProfileId ?? profileID)` pins the window to the seeded profile anyway, so the per-window binding was redundant. Drops the unused `profileId` parameter. This is what addresses the original ff4ac411 motivation: `testFirstLaunchWithOneCloudProfile_autoOpens` failed because the empty match set blocks cross-scene `openWindow(value:)` routing into the WindowGroup; `openWindow(id:)` is unaffected.
- `Automation/AppleScript/ScriptingBridge.swift` + `MoolahTests/Automation/ScriptingBridgeHandoffTests.swift` — Update stale rationale comments. The delegate still returns `true` for matching activity types (good AppKit hygiene), but it is no longer load-bearing for `#386`; the real guard is back to being the scene-level opt-out.

## Test plan

- [x] `just build-mac` succeeds.
- [x] `just format-check` clean.
- [x] `just test-mac ScriptingBridgeHandoffTests HandoffContinuationHandlerTests ProfileWindowLocatorTests` — 12/12 pass.
- [x] `just test-ui WelcomeViewTests` — 3/3 pass, including `testFirstLaunchWithOneCloudProfile_autoOpens` (the test that motivated ff4ac411). Confirms the new launcher path works end-to-end.
- [ ] **Manual:** iPhone → Mac Handoff with an existing window for the target profile open ⇒ existing window is brought forward, no second window spawns.
- [ ] **Manual:** iPhone → Mac Handoff with no Mac window open ⇒ exactly one window opens and navigates to the destination.
- [ ] **Manual:** Mac → iPhone Handoff still works (no regression on the iOS receiving side, which uses `.onContinueUserActivity`).

The OS-level routing that produces the regression can only be reproduced with two paired devices, so manual verification is required before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)