### PR TITLE
docs(widgets): design + implementation plan for first widget set

### DIFF
--- a/plans/2026-05-26-widgets-upcoming-transactions-design.md
+++ b/plans/2026-05-26-widgets-upcoming-transactions-design.md
@@ -1,0 +1,454 @@
+# Widgets — Upcoming Transactions (first widget set) — Design
+
+**Date:** 2026-05-26
+**Status:** Design — pending plan
+**Author:** Adrian Sutton (with Claude)
+**Related:** [`Automation/Intents/OpenAccountIntent.swift`](../Automation/Intents/OpenAccountIntent.swift) (the AppIntent navigation pattern this widget set reuses), [`Automation/Navigation/NavigationBridge.swift`](../Automation/Navigation/NavigationBridge.swift), [`Automation/Navigation/NavigationDestination.swift`](../Automation/Navigation/NavigationDestination.swift), `Features/Transactions/TransactionStore+ScheduledViews.swift` (existing in-app upcoming logic), [`Shared/URL+MoolahStorage.swift`](../Shared/URL+MoolahStorage.swift) (storage-path resolution to be refactored), [plans/2026-05-25-handoff-design.md](2026-05-25-handoff-design.md) (concurrent change owning `NavigationDestination` evolution).
+
+## Summary
+
+Add a Home Screen / Desktop WidgetKit bundle to the Moolah project containing two widgets, both centred on scheduled transactions the user needs to act on:
+
+- **`UpcomingTransactionsListWidget`** (`.systemMedium`) — flat list of up to five rows covering **overdue + next 7 days**, with relative-date column, payee, and sign-coloured amount. Tapping a row deep-links to that transaction in the configured profile via an `AppIntent`. The widget is display-only.
+- **`UpcomingTransactionsCountWidget`** (`.systemSmall`) — a single big number: the count of scheduled transactions that are **overdue or due today**, with the sum of those amounts beneath. Tapping opens the Upcoming list for the configured profile.
+
+Both widgets are bound to one profile per widget instance via a `WidgetConfigurationIntent` that lists the user's profiles. Both ship on iOS 26 and macOS 26 simultaneously.
+
+The widget extension is a separate process and so cannot reach the host's in-memory stores. To satisfy the chosen architecture (direct, always-fresh SQLite read — no snapshot file), the per-profile `data.sqlite` and the profile-index database move from `~/Library/Application Support/<env>/…` into a new **App Group container** (`group.rocks.moolah.app.{test,v2}`) shared by the host targets and the widget extension. The widget extension opens those databases read-only via GRDB on every timeline rebuild and never writes.
+
+## Goals
+
+- A user can pin a "Upcoming" widget to their iPhone Home Screen, iPad Home Screen, or Mac desktop / Notification Centre, bind it to a specific profile, and see what's overdue and due soon at a glance without opening the app.
+- Tapping a transaction row on the medium widget jumps straight to that transaction in the host app — same in-process route as `OpenAccountIntent`, no `moolah://` URL scheme.
+- Tapping the small widget jumps to the Upcoming list for the bound profile.
+- Widget data is read directly from the per-profile SQLite store, so it is always fresh with the last sync — no separate snapshot file to invalidate.
+- Each widget instance is bound to one profile via a standard configuration intent surfaced by the system; users with multiple profiles can pin one widget per profile.
+- The infrastructure introduced (App Group container, read-only widget query layer, widget-side `ProfileEntity` / configuration intent, `WidgetCenter.reloadAllTimelines()` hooks) is reusable by future widgets (net worth, recent transactions, earmark gauges) without further migration work.
+- The on-disk move (Application Support → App Group container) is safe under crash and is reversible until the cleanup-pass release lands.
+
+## Non-goals
+
+- **Interactive widgets** — no "mark as paid", "snooze", or other write actions inside the widget surface. Display-only on first cut. Adding interactivity is a follow-up.
+- **iOS Lock Screen accessory family** — explicitly dropped. No `.accessoryRectangular` / `.accessoryInline` widgets in this round.
+- **Apple Watch complications** — would require a watchOS target; out of scope.
+- **`.systemLarge` and `.systemExtraLarge`** — not in the first cut. The layout work is meaningfully different from a stretched medium and would dilute the focus on shipping the small + medium pair well.
+- **Reviving the `moolah://` URL scheme.** Per the handoff design's non-goals, issue [#386](https://github.com/moolah-rocks/moolah-native/issues/386) stays closed. Widget tap targets use `AppIntent` with `openAppWhenRun = true` and `NavigationBridge`, identical to `OpenAccountIntent`.
+- **A snapshot-file fallback path.** Architecture choice **A** (direct DB read) was selected; we are not building a hybrid that also writes JSON snapshots. If the direct read proves wrong in production, that is a future-architecture decision, not v1 scope.
+- **Aggregate-across-profiles widgets** — a widget instance shows exactly one profile. Users with N profiles add N widgets.
+- **Per-row "snooze N days" or context menus** — `widgetURL` / per-row `Link` mapping to a single deep-link AppIntent is the entire interaction model.
+- **Widget-level currency conversion across instruments.** Each row renders the transaction's own instrument exactly. The small widget's "sum of due-today amounts" is per-currency (see *Multi-currency handling* below) — no FX in the extension.
+- **Backfilling the old Application Support location after migration in v1.** The old per-profile directories are left in place after the copy as a rollback safety net for at least one release. A delayed cleanup migration is tracked as a new GitHub issue and called out in the plan.
+
+## Background
+
+### Project context the widget set inherits
+
+- **Targets:** iOS 26+ and macOS 26+ universal SwiftUI app. The Xcode project is regenerated from `project.yml` by `xcodegen` — every new target / entitlement / app-group lands in `project.yml`, never in a hand-edited `project.pbxproj`.
+- **Per-profile storage:** each profile owns a GRDB SQLite database at `URL.moolahScopedApplicationSupport/profiles/<UUID>/data.sqlite`. `URL.moolahScopedApplicationSupport` is env-scoped (Debug / Debug-Tests → `app.test`, Release → `app.v2`) via [`CloudKitEnvironment.resolved().storageSubdirectory`](../Shared/URL+MoolahStorage.swift).
+- **Profile-index DB:** a separate, smaller SQLite catalogue lists the user's profiles (id, label, currency) — referenced under that env-scoped root by `ProfileContainerManager`.
+- **CloudKit sync:** per-profile sync via `CKSyncEngine`. The on-disk SQLite is the always-up-to-date local cache that CloudKit pushes into. Reading it from the widget is the same shape as the in-app stores.
+- **Scheduled / upcoming logic already exists** in `Features/Transactions/TransactionStore+ScheduledViews.swift`: `scheduledUpcomingTransactions`, `scheduledOverdueTransactions`, `scheduledShortTermTransactions(daysAhead:)`. The widget does **not** import these; it issues a small focused SQL query against `data.sqlite` directly. The in-app logic stays where it is.
+- **`Domain/`** has no SwiftUI / SwiftData / URLSession dependencies. The widget extension may link a minimal slice of `Domain/Models/` (`Instrument`, `InstrumentAmount`, `MonetaryAmount`, `Transaction` and its supporting types if needed for decoding rows).
+- **AppIntents are already wired up** under `Automation/Intents/`. `OpenAccountIntent` is the canonical pattern: `static let openAppWhenRun = true`, `@MainActor func perform()` calls `NavigationBridge.openProfile` (with macOS-side `ProfileWindowLocator.activateExistingWindow` first) and `NavigationBridge.setPendingNavigation(PendingNavigation(...))`. The widget set uses two new intents in the same shape.
+- **`NavigationDestination` already models `.upcoming` and `.transaction(id)`** — the two destinations the widget needs. No new cases required.
+
+### Two constraints that shape the design
+
+- **The widget extension is a separate sandboxed process.** It cannot reach `AutomationServiceLocator.shared`, cannot open files in the host's Application Support container, and cannot call into host-app code at all. Anything the extension needs at read time must either be in its own bundle or in an App Group container it has the entitlement for.
+- **The `moolah://` URL scheme remains rejected** ([#386](https://github.com/moolah-rocks/moolah-native/issues/386), reaffirmed by the handoff design). The only viable widget→host navigation mechanism on iOS 17+ / macOS 14+ that does not need a URL scheme is `Button(intent:)` / `Link(destination:)` with an `AppIntent` whose `openAppWhenRun = true`. That is the pattern used here.
+
+## Architecture
+
+### New Xcode targets and shared modules
+
+The widget bundle is **one extension target** that ships on both platforms. WidgetKit lets a single source set vend widgets that work on iOS Home Screen, iPad Home Screen, and macOS desktop / Notification Centre simultaneously; we do not need parallel `_iOS` / `_macOS` widget targets the way the host has parallel app targets.
+
+```
+project.yml additions (skeleton — exact YAML in the plan):
+
+  MoolahWidgets:
+    type: app-extension
+    platform: [iOS, macOS]
+    supportedDestinations: [iOS, macOS]
+    sources:
+      - path: MoolahWidgets
+      - path: Shared/Widgets        # new — shared between host targets and widget bundle
+      - path: Domain/Models         # narrow slice; see "Linker scope" below
+    dependencies:
+      - sdk: WidgetKit.framework
+      - sdk: SwiftUI.framework
+      - sdk: AppIntents.framework
+      - package: GRDB
+    settings:
+      base:
+        APP_GROUP_ID: group.rocks.moolah.app.test   # overridden per-config to .v2 for Release
+        INFOPLIST_KEY_NSExtensionPointIdentifier: com.apple.widgetkit-extension
+    entitlements:
+      - com.apple.security.application-groups: [$(APP_GROUP_ID)]
+```
+
+The host targets (`Moolah_iOS`, `Moolah_macOS`) gain the same App Group entitlement and the new `Shared/Widgets/` source path. They also embed the widget bundle in their `Plug-Ins` extension copy phase.
+
+### New filesystem layout
+
+```
+MoolahWidgets/                          # new target
+├── MoolahWidgetsBundle.swift           # @main WidgetBundle of both widgets
+├── UpcomingTransactionsListWidget.swift # .systemMedium widget + entry + provider
+├── UpcomingTransactionsCountWidget.swift # .systemSmall widget + entry + provider
+├── Views/
+│   ├── UpcomingListView.swift          # medium content
+│   ├── UpcomingCountView.swift         # small content
+│   ├── UpcomingRowView.swift           # one row for the medium list
+│   └── WidgetEmptyStateView.swift      # shared empty-state view
+└── Intents/
+    ├── WidgetProfileSelectionIntent.swift   # AppIntent — configuration parameter
+    ├── WidgetProfileEntity.swift            # extension-local AppEntity + EntityQuery
+    ├── OpenUpcomingFromWidgetIntent.swift   # tap target for the small widget + .accessoryInline taps
+    └── OpenTransactionFromWidgetIntent.swift # tap target for medium rows
+Shared/Widgets/                         # new — linked by host + widget extension
+├── WidgetDataPath.swift                # App Group container URL + per-profile DB paths
+├── UpcomingWidgetSnapshot.swift        # Sendable value type returned to the timeline provider
+├── UpcomingWidgetQuery.swift           # opens data.sqlite read-only and runs the query
+├── WidgetProfileSummary.swift          # Sendable {id, label, currency} read from profile-index DB
+├── WidgetProfileDirectory.swift        # opens profile-index DB read-only and lists profiles
+└── WidgetReloadCoordinator.swift       # host-side helper that calls WidgetCenter.reloadAllTimelines()
+```
+
+`Shared/Widgets/` has **no** dependency on `Backends/CloudKit/`, on `Features/`, or on any repository protocol implementation. It depends only on `GRDB` and on a small slice of `Domain/Models/` (`Instrument`, `InstrumentAmount`, `MonetaryAmount`). The widget extension binary stays small.
+
+### Two widgets, two layouts
+
+**Medium — `UpcomingTransactionsListWidget` (variant A "flat list with relative dates"):**
+
+- Header: bold "Upcoming" on the left, small profile name on the right.
+- Up to **five rows**, ordered chronologically (most overdue first). Each row is `[relative-date | payee | amount]`:
+  - Overdue rows: date rendered in red as `"N days late"`.
+  - Today rows: date rendered in amber as `"Today"`.
+  - Future rows: date rendered in the default secondary colour as a short weekday (`Wed`, `Fri`, …) for dates within the next 7 days.
+- Amount column right-aligned, `monospacedDigit()`, sign-coloured (expense = red, income = green). The sign of the underlying `Transaction` leg total is preserved verbatim — a refund (positive expense) still displays positive.
+- Footer (subtitle, beneath the header): nothing in v1 — the row count itself is the indicator; if scope expands later we can add "5 of 12 due in next 14 days" type text.
+- Empty state: centred `WidgetEmptyStateView` with secondary text "Nothing due in the next 7 days".
+
+**Small — `UpcomingTransactionsCountWidget` (variant A "big number + total"):**
+
+- Big number = **count of scheduled transactions that are overdue or due today**.
+- Underneath: total amount of those transactions, rendered in red (since the expectation is they are expenses; income rows still count but the colour communicates "money about to leave" — see *Multi-currency handling* for the per-instrument fallback).
+- Profile name as a chip in the corner.
+- Empty state when count is 0: dimmed "0" plus secondary text "Nothing due today".
+
+### Tap targets — AppIntent, not URL
+
+Both widgets use `Link(destination: URL)` only insofar as `widgetURL(_:)` accepts one, but the URL we install is a **container** for a `Button(intent:)`-equivalent path: more concretely, **iOS 17+ `Button(intent:)` and `Link(intent:)` patterns** route directly through `AppIntent` without ever crossing the URL boundary. The widget set uses these patterns exclusively:
+
+- **Medium row** → wrapped in `Button(intent: OpenTransactionFromWidgetIntent(profile: profile, transactionID: row.id.uuidString))`. The intent has `openAppWhenRun = true`. Its `perform()` runs in the host process and is the same shape as `OpenAccountIntent.perform()`:
+  1. macOS: try `ProfileWindowLocator.activateExistingWindow(for: profile.id)` first.
+  2. If no window: call `NavigationBridge.openProfile?(profile.id)`.
+  3. Call `NavigationBridge.setPendingNavigation?(PendingNavigation(profileId: profile.id, destination: .transaction(transactionID)))`.
+- **Small widget body** → wrapped in `Button(intent: OpenUpcomingFromWidgetIntent(profile: profile))`. Same shape, destination is `.upcoming`.
+
+No URL scheme is involved at any layer. Both intents declare `openAppWhenRun = true` and `isDiscoverable = false` (they are not user-discoverable Shortcuts — they exist only to be invoked from the widget surface).
+
+### Timeline strategy
+
+Both widgets use **`AppIntentTimelineProvider`** so the `WidgetConfigurationIntent` parameter (the chosen profile) is available in `timeline(for:configuration:)`. Each provider:
+
+1. Resolves the configured profile via `WidgetProfileSummary` (App Group profile-index DB read).
+2. If no profile (user hasn't configured the widget yet, or the bound profile has been deleted), emits a single-entry timeline at "configure me" / "profile not found" placeholder.
+3. Otherwise opens the profile's `data.sqlite` read-only via `UpcomingWidgetQuery.read(profile:asOf:)`.
+4. **Returns a multi-entry timeline:**
+   - Entry 0: now → next "midnight" boundary in the user's calendar.
+   - Entry 1: next midnight → midnight after.
+   - Up to **five entries**, each recomputed at the boundary so "Today" / "N days late" / weekday labels stay current without a refresh from the host.
+   - Final entry's reload policy: `.atEnd` (so iOS rebuilds the timeline again on its own once the last entry expires).
+5. Returns `Timeline(entries:, policy: .atEnd)`. No `policy: .after(…)` overrides — the timeline already covers five midnight rollovers, which is more than enough headroom for a typical reload from `WidgetCenter`.
+
+**Host-driven reloads** — the host calls `WidgetCenter.shared.reloadAllTimelines()` (wrapped in `WidgetReloadCoordinator.reload()`) on the following hooks, all already-existing pinch points:
+
+- `TransactionStore` mutation completion (create / update / delete / pay-scheduled / mark-as-spam).
+- CloudKit sync completion (CKSyncEngine "fetched + applied" boundary).
+- Scene phase → `background` on iOS and `app willResignActive` on macOS (covers the case where the user just closed the app after editing a scheduled transaction).
+- Profile mutation in `ProfileContainerManager` (rename / add / delete) — so the small widget's profile chip stays in sync.
+
+These hooks live in host-only code (`Features/Transactions/`, `App/`, `Backends/CloudKit/Sync/`). The widget extension never calls `WidgetCenter` — that API is for the host.
+
+### Configuration intent: per-instance profile binding
+
+```swift
+struct WidgetProfileSelectionIntent: WidgetConfigurationIntent {
+  static let title: LocalizedStringResource = "Pick a profile"
+  static let description = IntentDescription(
+    "Choose which Moolah profile this widget shows.")
+
+  @Parameter(title: "Profile") var profile: WidgetProfileEntity?
+}
+```
+
+`WidgetProfileEntity` is an extension-local `AppEntity` whose `EntityQuery` opens the profile-index DB through `WidgetProfileDirectory` (read-only, App Group container). It is **separate from** the existing `Automation/Intents/Entities/ProfileEntity` which routes through `AutomationServiceLocator.shared.service`. Trying to share one type would force `AutomationServiceLocator` into the extension or push GRDB + App Group resolution into the host's `Automation/` namespace; both widen the blast radius beyond what's helpful. Two thin, parallel entity types with a small mapping seam at the host boundary is cleaner.
+
+If the configured profile UUID is no longer present in the profile-index DB (the user deleted it, or sync hasn't pulled it onto the device yet), the timeline provider returns a placeholder entry with the secondary text "Profile not available — open Moolah to fix" and a tap that simply opens the host (via an `OpenUpcomingFromWidgetIntent` whose profile resolves to `nil` → host opens to the profile picker).
+
+## Data layer
+
+### App Group container migration
+
+A single one-shot migration moves the user's per-profile data from `URL.applicationSupport/<env>/…` to `groupContainer/<env>/…`. The host owns the migration; the widget never runs while the migration is in-flight (the App Group is empty, so the timeline provider's "no profiles" branch covers the gap).
+
+The current path resolver:
+
+```swift
+// Shared/URL+MoolahStorage.swift (existing)
+static var moolahScopedApplicationSupport: URL {
+  let root = moolahApplicationSupportOverride ?? URL.applicationSupportDirectory
+  let scoped = root.appending(path: CloudKitEnvironment.resolved().storageSubdirectory)
+  try? FileManager.default.createDirectory(at: scoped, withIntermediateDirectories: true)
+  return scoped
+}
+```
+
+is replaced by:
+
+```swift
+// Shared/URL+MoolahStorage.swift (new shape)
+static var moolahScopedApplicationSupport: URL {
+  let root = moolahApplicationSupportOverride ?? WidgetDataPath.appGroupRoot()
+  let scoped = root.appending(path: CloudKitEnvironment.resolved().storageSubdirectory)
+  try? FileManager.default.createDirectory(at: scoped, withIntermediateDirectories: true)
+  return scoped
+}
+```
+
+`WidgetDataPath.appGroupRoot()` returns `FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: AppGroupConfig.identifier)`, where `AppGroupConfig.identifier` is read from the host's Info.plist (env-scoped) the same way `MoolahCloudKitContainer` is today. `moolahApplicationSupportOverride` continues to win for tests — the host-side override key keeps every existing unit/UI test pointing at a temp directory.
+
+**Migration algorithm** (runs once, in `ProfileContainerManager.bootstrap()` before any profile session opens):
+
+1. Compute `oldRoot = URL.applicationSupportDirectory.appending(path: CloudKitEnvironment.resolved().storageSubdirectory)`.
+2. Compute `newRoot = WidgetDataPath.appGroupRoot().appending(path: CloudKitEnvironment.resolved().storageSubdirectory)`.
+3. If `newRoot/migrated-from-application-support-v1.flag` exists → migration is already complete; return.
+4. Ensure `newRoot` exists (`createDirectory(withIntermediateDirectories: true)`).
+5. For each entry under `oldRoot`:
+   - If it is a `profiles/` directory: recursively **copy** every per-profile subdirectory and every file inside (including `data.sqlite`, `data.sqlite-wal`, `data.sqlite-shm`, the import-staging subdirectory) to `newRoot/profiles/`. Skip if the destination already exists.
+   - If it is the profile-index DB file (and any sidecars): copy.
+   - If it is a CKSyncEngine state file or backup directory under the conventions used by `ProfileSession+SyncCleanup` / `StoreBackupManager`: copy.
+6. For every copied `*.sqlite`, open it via GRDB and run `PRAGMA integrity_check;` against the copy. If any returns anything other than `"ok"`, **abort** — log a `Logger.fault`, delete the partially-copied destination, surface a recoverable error to the user via the existing `IncompatibleProfileInfo` machinery, and leave the old data in place.
+7. Atomically write `migrated-from-application-support-v1.flag` (a zero-byte marker) to `newRoot` using `Data().write(to:, options: [.atomic])`.
+8. **Do not delete** the old data. A subsequent release will land a cleanup migration after we have telemetric confidence the new path works. The cleanup migration is tracked as a new GitHub issue, referenced as `TODO(#NEW)` next to the migration code.
+
+**Properties of the migration:**
+
+- **Copy, not move.** Mid-migration crash leaves the old data complete and the flag absent → next launch retries.
+- **Idempotent.** Per-profile subdirectory existence check skips already-migrated profiles. Re-running is a no-op.
+- **Integrity-checked.** The flag is only written after every SQLite file passes `integrity_check`.
+- **Recoverable.** If integrity check fails, `IncompatibleProfileInfo` shows the affected profile in the existing profile-picker error UI; the user can choose to keep using the un-migrated data (host falls back to `oldRoot` via the override; widgets stay empty until resolved).
+- **Backup semantics preserved.** Per-profile directories continue to set `URLResourceValues.isExcludedFromBackup = false` (current behaviour) inside the App Group container. iCloud Backup semantics are unchanged because the App Group container is included in backup by default for both iOS and macOS.
+
+**Test backends:**
+
+- `moolahApplicationSupportOverride` continues to win. Tests set it to a temp directory; no App Group container is touched, no migration runs (the migration helper checks the override and bails when it is set).
+- UI tests inherit the same override via `UITestSeedHydrator`'s existing wiring.
+
+### The query
+
+```swift
+// Shared/Widgets/UpcomingWidgetSnapshot.swift
+struct UpcomingWidgetSnapshot: Sendable, Equatable {
+  struct Row: Sendable, Equatable, Identifiable {
+    let id: UUID                  // Transaction.id
+    let payee: String
+    let dueDate: Date             // start-of-day, in user's calendar
+    let amount: Decimal           // signed; positive = inflow, negative = outflow
+    let instrument: Instrument    // for InstrumentAmount.formatted
+  }
+
+  let profileID: UUID
+  let profileLabel: String
+  let profileCurrency: String
+
+  let asOf: Date                  // start-of-day snapshot time
+  let dueNowCount: Int            // overdue + today
+  let dueNowTotal: [Instrument: Decimal]   // per-instrument; widget formats first instrument + indicator if >1
+  let upcomingRows: [Row]         // overdue + next 7 days, max 5, sorted ascending by dueDate
+  let upcomingTotalInRange: Int   // total count in overdue+next-7 days range (may exceed 5)
+}
+
+// Shared/Widgets/UpcomingWidgetQuery.swift
+enum UpcomingWidgetQuery {
+  @WidgetActor
+  static func read(
+    profile: WidgetProfileSummary,
+    asOf now: Date = Date(),
+    calendar: Calendar = .current,
+    maxRows: Int = 5
+  ) throws -> UpcomingWidgetSnapshot { … }
+}
+```
+
+`UpcomingWidgetQuery.read(...)`:
+
+1. Opens `WidgetDataPath.profileDatabaseURL(for: profile.id)` via `DatabaseQueue` with `configuration.readonly = true` and a short busy timeout (200 ms).
+2. Runs **two** focused queries inside one `db.read` block:
+   - **Snapshot SELECT** — picks scheduled transactions whose `date BETWEEN ? AND ?` where the lower bound is `Date.distantPast` (overdue) and the upper bound is `startOfDay(now) + 7 days`. Selects `id`, `date`, `payee`, the summed leg quantity and the leg `instrument` for the row. `ORDER BY date ASC LIMIT 5`.
+   - **Count SELECT** — `COUNT(*)` and `GROUP BY instrument, SUM(quantity)` for the same predicate restricted to `date <= startOfDay(now) + 1 day - 1 sec` (overdue + today) for `dueNowCount` / `dueNowTotal`. (Implementation detail: a single query with conditional aggregates is equivalent; whichever is simpler to plan-pin in tests.)
+3. Closes the queue and returns the snapshot. No long-lived handle.
+4. Throws `WidgetQueryError.profileDatabaseUnavailable` if the file is missing, locked beyond the timeout, or `integrity_check` fails on open. Timeline provider maps this to the placeholder entry.
+
+Both queries are added to the existing GRDB plan-pinning tests under `MoolahTests` (per `guides/DATABASE_CODE_GUIDE.md`).
+
+`@WidgetActor` is a new global actor declared in `Shared/Widgets/` to ensure no widget-side query runs concurrently against the same profile (overlapping read-only opens are technically safe in WAL mode but pointless and surprising in profiling traces).
+
+### Multi-currency handling on the small widget
+
+A profile can have transactions in multiple instruments. The small widget shows a single "total" beneath the count. To keep the extension free of conversion logic (per `guides/INSTRUMENT_CONVERSION_GUIDE.md`, which the widget does not link), the small widget displays:
+
+- If `dueNowTotal.count == 1` → render the sole `InstrumentAmount` formatted (e.g. `−$224.19`).
+- If `dueNowTotal.count > 1` → render the profile-currency instrument's amount if present (e.g. `−$224.19`) with a small `…` suffix; or, if no profile-currency entry is present, render `"Multiple currencies"` (`.caption2`, secondary colour).
+- If `dueNowTotal.isEmpty` (i.e. `dueNowCount == 0`) → render `"Nothing due today"` (the empty-state case).
+
+No FX conversion is performed in the widget extension. Conversion stays a host-app concern.
+
+### What the widget extension links
+
+| Module | Linked by widget? | Notes |
+|---|---|---|
+| `Shared/Widgets/` | Yes | New, narrow. |
+| `Domain/Models/Instrument`, `InstrumentAmount`, `MonetaryAmount` | Yes | Pure value types, no SwiftUI / no SwiftData / no URLSession. |
+| `Domain/Models/Transaction` (and its supporting enums / nested types) | Yes — only the parts the row decoder needs. If pulling the whole `Transaction` type pulls too much, the widget defines its own narrow `WidgetTransactionRow` row type that decodes the required columns. The plan picks one approach during implementation. | |
+| `GRDB` (SPM package) | Yes | Same exact version pin as host. |
+| `Backends/CloudKit/` | **No** | Widget never talks to CloudKit. |
+| `Backends/GRDB/` | **No** | Widget runs its own focused SELECT; does not reuse repository implementations. |
+| `Features/` | **No** | Widget defines its own views. |
+| `Automation/` | **No** | Widget's intents live under `MoolahWidgets/Intents/`; host intents stay in `Automation/Intents/`. |
+
+This is the explicit "do not bloat the extension" boundary.
+
+## Routing — widget tap → host app
+
+The two intents under `MoolahWidgets/Intents/` are the only navigation entry points.
+
+```swift
+// MoolahWidgets/Intents/OpenTransactionFromWidgetIntent.swift
+struct OpenTransactionFromWidgetIntent: AppIntent {
+  static let title: LocalizedStringResource = "Open Transaction"
+  static let openAppWhenRun = true
+  static let isDiscoverable = false
+
+  @Parameter(title: "Profile") var profile: WidgetProfileEntity
+  @Parameter(title: "Transaction ID") var transactionID: String
+
+  @MainActor
+  func perform() async throws -> some IntentResult {
+    guard let transactionUUID = UUID(uuidString: transactionID) else {
+      return .result()
+    }
+    #if os(macOS)
+      let alreadyOpen = ProfileWindowLocator.activateExistingWindow(for: profile.id)
+    #else
+      let alreadyOpen = false
+    #endif
+    if !alreadyOpen {
+      NavigationBridge.openProfile?(profile.id)
+    }
+    NavigationBridge.setPendingNavigation?(
+      PendingNavigation(profileId: profile.id, destination: .transaction(transactionUUID)))
+    return .result()
+  }
+}
+```
+
+`OpenUpcomingFromWidgetIntent` is identical in shape, destination `.upcoming`, no transaction parameter, profile parameter is **optional** so it can also be invoked with `nil` from the "profile not available" placeholder tap.
+
+Both intents call `NavigationBridge` directly. They do not depend on `AutomationServiceLocator` (unlike the existing `OpenAccountIntent` which gates on `service != nil` for the diagnostic ordering): the system's `openAppWhenRun = true` guarantees the host is launched first, and `NavigationBridge.openProfile` is a `(UUID) -> Void` closure populated by `ProfileRootView` / `ProfileWindowView` early in the launch sequence. If the closure is `nil` because the host hasn't reached the point of installing it yet, `PendingNavigation` survives in `NavigationBridge.setPendingNavigation` — the relevant scene reads and clears it on first render. (We add a one-line assertion guard in `perform()` so we get a `Logger.fault` if both closures are unexpectedly `nil`.)
+
+Coordination with the in-flight handoff design (`plans/2026-05-25-handoff-design.md`):
+
+- The handoff design depends on `NavigationDestination` being `Codable` (it isn't today). The widget design does **not** require `NavigationDestination: Codable` — the widget only ever passes the profile UUID and a transaction UUID string across the process boundary, and reconstructs `.transaction(id)` / `.upcoming` on the host side. Either landing order works.
+- The handoff design adds `.handlesExternalEvents(matching: [])` to `WindowGroup`. That is compatible with widget tap targets (which are not external events — `openAppWhenRun = true` invokes the host the same way Shortcuts do, going through the AppIntents framework and not through URL routing).
+- Both designs share `NavigationBridge.openProfile`, `setPendingNavigation`, and `ProfileWindowLocator.activateExistingWindow`. Neither introduces conflicting changes to those types.
+
+## Error handling and edge cases
+
+| Situation | Behaviour | Where handled |
+|---|---|---|
+| Widget extension launches before migration has run (e.g. host hasn't been opened since the update) | Configuration intent's `WidgetProfileQuery` returns an empty list. Widgets show "Add Moolah widget — open the app first" placeholder. | `WidgetProfileDirectory.list()` returns `[]` if the profile-index DB doesn't exist in the App Group container. |
+| Configured profile UUID was deleted in the app | Configuration intent dropdown no longer offers it. If the existing widget instance binds to a missing UUID, `UpcomingWidgetQuery.read(...)` throws `profileDatabaseUnavailable` → provider emits the "Profile not available — open Moolah to fix" placeholder. Tap opens host to profile picker via `OpenUpcomingFromWidgetIntent(profile: nil)`. | `UpcomingTransactionsListWidget.Provider.timeline(for:configuration:)`, `UpcomingTransactionsCountWidget.Provider.timeline(for:configuration:)`. |
+| `data.sqlite` is locked beyond the 200 ms busy timeout (the host is mid-write) | `UpcomingWidgetQuery.read(...)` throws. Provider returns the previous-good snapshot encoded as a 5-minute `.after(...)` policy entry (a single retry attempt) — falling back to the placeholder only if the next attempt also fails. | `UpcomingWidgetQuery` + provider. |
+| `PRAGMA integrity_check` fails when opening read-only | Throw and surface the placeholder; logger.fault from the extension. Widget keeps trying on next system-driven rebuild. | `UpcomingWidgetQuery`. |
+| App Group container URL is `nil` (entitlement missing / device hasn't synced entitlements) | `WidgetDataPath.appGroupRoot()` throws; host migration aborts with a clear error in `IncompatibleProfileInfo` and the widget extension's queries throw `profileDatabaseUnavailable`. | `WidgetDataPath` + host bootstrap. |
+| User has hidden a transaction (`Transaction.isHidden`) | Hidden transactions are excluded from the widget query. Same predicate the in-app "Upcoming & Overdue" card uses. | SQL `WHERE isHidden = 0` (matches existing convention). |
+| Recurring template transaction's `date` is in the past but a `paidCopy` exists for today | The scheduled template still shows as "overdue" until the template's `date` is advanced — matches in-app behaviour. The widget doesn't need to know about `paidCopy` and does not deduplicate. | SQL only reads scheduled rows; no join. |
+| Multi-currency profile, small widget cannot reduce to one instrument | Renders `"Multiple currencies"` text in `.caption2`. | `UpcomingCountView`. |
+| `WidgetReloadCoordinator.reload()` invoked from background thread | `WidgetCenter.shared.reloadAllTimelines()` is thread-safe per Apple's docs; helper wraps it with a `Task { @MainActor in … }` only for symmetry with other host-side reload sites. | `Shared/Widgets/WidgetReloadCoordinator.swift`. |
+| Migration crashes mid-copy | Flag file isn't written; partial destination directory is left in place. Next launch re-enters the migration which is idempotent at the per-profile-directory level (skip-if-exists). For safety, on re-entry, any per-profile subdirectory in `newRoot` that fails `integrity_check` is deleted before re-copying. | `ProfileContainerManager.bootstrap()` migration helper. |
+
+## Telemetry
+
+A new logger category `Widgets` under the existing `com.moolah.app` subsystem. The extension logs:
+
+- Query start / end with profile UUID and row count (debug).
+- `profileDatabaseUnavailable` paths (warning).
+- `integrity_check` failures (fault).
+- Configuration intent `suggestedEntities()` return size (debug).
+
+The host's `WidgetReloadCoordinator.reload(reason:)` logs the reason string at debug level so we can correlate widget refreshes with host events when diagnosing staleness.
+
+`os_signpost` instrumentation around `UpcomingWidgetQuery.read(...)` per `guides/BENCHMARKING_GUIDE.md` (intervals: query open, query exec, query close). Enables Instruments traces of widget refresh cost on real devices.
+
+## Testing
+
+### Unit tests (`MoolahTests_macOS` + `MoolahTests_iOS`)
+
+- **`WidgetDataPathTests`** — App Group container URL resolution with mocked `AppGroupConfig.identifier`; env-scoped subdirectory math; profile DB path composition.
+- **`UpcomingWidgetQueryTests`** — runs against `TestBackend` (in-memory GRDB DB seeded by the existing test harness) so we have full control over scheduled rows:
+  - Empty profile → snapshot with `dueNowCount == 0`, `upcomingRows.isEmpty`.
+  - Only overdue rows → snapshot rows are sorted ascending by date; `dueNowCount` includes them; counts and totals correct.
+  - Only future rows within 7 days → no overdue, today=0, future rows sorted.
+  - Rows beyond 7 days → excluded.
+  - Mixed instruments → `dueNowTotal` keyed by instrument; row-level instrument preserved.
+  - Hidden transactions → excluded.
+  - Capped at `maxRows: 5` → returns first five chronologically, `upcomingTotalInRange` reflects the larger count.
+  - Sign preservation — a positive-amount expense (refund) keeps its positive sign in the snapshot row.
+- **`UpcomingWidgetQueryPlanPinningTests`** — `EXPLAIN QUERY PLAN` for both SELECTs uses the expected index (per `guides/DATABASE_CODE_GUIDE.md`).
+- **`WidgetProfileDirectoryTests`** — opens a seeded profile-index DB and returns `WidgetProfileSummary` list; returns empty list when the DB doesn't exist; integrity check failure surfaces as `directoryUnavailable`.
+- **`UpcomingWidgetSnapshotFormatTests`** — `dueNowTotal` aggregation, `Multiple currencies` fallback string, empty-state copy.
+- **`OpenTransactionFromWidgetIntentTests`** — install fakes on `NavigationBridge.openProfile` / `setPendingNavigation` (same pattern as the handoff tests); macOS existing-window path skips `openProfile`; no-window path calls `openProfile` before `setPendingNavigation`; invalid `transactionID` string → no calls, returns `.result()`.
+- **`OpenUpcomingFromWidgetIntentTests`** — same shape; nil-profile path opens to profile picker.
+- **`ApplicationSupportToAppGroupMigrationTests`** — fixtures simulate the old `applicationSupportDirectory/<env>/profiles/<uuid>/data.sqlite` layout in a temp directory; the migration copies into a parallel temp App Group root; verifies flag file written last, integrity-check called, idempotent re-entry, abort-on-integrity-failure leaves the partial destination cleaned up and the old data untouched.
+- **`WidgetReloadCoordinatorTests`** — stubs `WidgetCenter` (the helper takes an injected reload closure for testability); asserts the helper is invoked from each named host hook (transaction store mutations, sync completion, scene phase) — wired up where each hook lives.
+
+### Integration tests
+
+- **`WidgetExtensionSmokeTests`** (new test target if needed, or a runtime smoke check inside `MoolahTests_macOS`) — instantiate `UpcomingTransactionsListWidget.Provider` and `UpcomingTransactionsCountWidget.Provider`, hand them a real configuration intent with a seeded profile, drive `timeline(for:configuration:)`, and assert the returned `Timeline` contains the expected entry shape. This exercises the seam between `Shared/Widgets/` and `MoolahWidgets/` without needing an actual widget host.
+
+### UI tests (`MoolahUITests_macOS`)
+
+- No XCUITest coverage for the widget surfaces themselves — Apple does not expose the widget host to XCUITest. The host-side deep-link landing is covered: a UI test triggers `OpenTransactionFromWidgetIntent.perform()` directly via the existing AppleScript / AppIntents bridge and asserts that the resulting `ProfileWindowView` ends up on `.transaction(id)` for the right profile.
+
+### Manual verification checklist
+
+1. Add a medium "Upcoming" widget to the iPhone Home Screen, bind it to a profile with overdue + future scheduled transactions, observe correct rows.
+2. Same on iPad.
+3. Same on macOS desktop. Add it to Notification Centre too.
+4. Add the small "Due" widget; verify count includes overdue + today; verify total in profile currency.
+5. Tap a medium row → host opens to that transaction in the correct profile (re-focuses existing window on macOS, no second window).
+6. Tap the small widget → host opens to Upcoming list in the correct profile.
+7. Delete a profile in the app → widget that was bound to it shows the "Profile not available" placeholder within one timeline refresh.
+8. With the widget pinned, edit a scheduled transaction in the app → widget reflects the change within ~5 s (driven by the `WidgetCenter.reloadAllTimelines()` hook on store mutation).
+9. With the widget pinned, complete a CloudKit sync that brings in a new scheduled transaction → widget reflects within ~5 s.
+10. Force-quit the app, leave the widget pinned, wait until the next midnight boundary on-device → "Today" rows flip to "1 day late" without a host-app refresh (multi-entry timeline).
+11. Install over an existing v1.x build: launch host, observe migration runs once, second launch is a no-op, old `Application Support` data still present on disk.
+
+## Open questions
+
+None at this time. Architecture, data layer, layouts, error handling, and testing have been reviewed; the design is ready to plan.
+
+## Plan deliverables
+
+A subsequent implementation plan (`plans/2026-05-26-widgets-upcoming-transactions-plan.md`) will break the work into landable PRs. Anticipated slicing:
+
+1. **App Group plumbing & migration** — entitlement files, `project.yml` knobs, `scripts/inject-entitlements.sh` parity, `WidgetDataPath`, `URL+MoolahStorage` refactor, `ProfileContainerManager` migration step, full migration tests. Ships behind the existing CloudKit env split; no widget yet. Smallest landable step that unblocks the rest.
+2. **`Shared/Widgets/` query layer** — `UpcomingWidgetSnapshot`, `UpcomingWidgetQuery`, `WidgetProfileSummary`, `WidgetProfileDirectory`, plan-pinning tests, `os_signpost` instrumentation. No extension target yet.
+3. **`MoolahWidgets` extension target** — empty bundle, configuration intent, `WidgetProfileEntity`, scaffolding, `xcodegen` regen, embed in both host apps.
+4. **`UpcomingTransactionsListWidget`** — medium widget, `UpcomingListView`, `UpcomingRowView`, `WidgetEmptyStateView`, timeline provider, `OpenTransactionFromWidgetIntent`, intent tests.
+5. **`UpcomingTransactionsCountWidget`** — small widget, `UpcomingCountView`, timeline provider, `OpenUpcomingFromWidgetIntent`, intent tests, multi-currency fallback.
+6. **`WidgetReloadCoordinator` + host hooks** — wire `WidgetCenter.shared.reloadAllTimelines()` at every named pinch point (transaction store, sync completion, scene phase, profile mutation).
+7. **Manual smoke + telemetry polish** — verify checklist, tune logger levels, document the new extension in `guides/` where appropriate.

--- a/plans/2026-05-26-widgets-upcoming-transactions-plan.md
+++ b/plans/2026-05-26-widgets-upcoming-transactions-plan.md
@@ -1,0 +1,3059 @@
+# Widgets — Upcoming Transactions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a `MoolahWidgets` extension on iOS and macOS containing two widgets — a medium "upcoming transactions" list and a small "due now" count — both reading the configured profile's GRDB database directly from a new App Group container.
+
+**Architecture:** Add an App Group entitlement (`group.rocks.moolah.app.{test,v2}`) to both host targets, migrate the per-profile `data.sqlite` and profile-index DB out of `~/Library/Application Support` and into the App Group container under the existing env-scoped subdirectory, and add a `MoolahWidgets_iOS` + `MoolahWidgets_macOS` pair of extension targets that link a new `Shared/Widgets/` module (which owns the App Group path math, an `UpcomingWidgetQuery` that opens `data.sqlite` read-only via GRDB, and a `WidgetProfileDirectory` that lists profiles from the index DB). Two `AppIntent`s with `openAppWhenRun = true` (`OpenTransactionFromWidgetIntent`, `OpenUpcomingFromWidgetIntent`) route widget taps through the existing in-process `NavigationBridge`, exactly mirroring `OpenAccountIntent`. A `WidgetReloadCoordinator` calls `WidgetCenter.shared.reloadAllTimelines()` on every host-side write-path pinch point.
+
+**Tech Stack:** Swift 6, SwiftUI, WidgetKit, AppIntents (Foundation), GRDB 7 (SPM), Swift Testing (`@Suite`, `@Test`, `#expect`, `#require`), `swift-format`, SwiftLint, `xcodegen`.
+
+**Spec:** [plans/2026-05-26-widgets-upcoming-transactions-design.md](2026-05-26-widgets-upcoming-transactions-design.md).
+
+---
+
+## File Structure
+
+### New files
+
+| Path | Responsibility |
+|---|---|
+| `Shared/Widgets/AppGroupConfig.swift` | Reads the env-scoped App Group identifier from the host Info.plist. |
+| `Shared/Widgets/WidgetDataPath.swift` | App Group container URL + per-profile DB / profile-index DB paths. |
+| `Shared/Widgets/WidgetProfileSummary.swift` | `Sendable` value `{id, label, currency}` from the profile-index DB. |
+| `Shared/Widgets/WidgetProfileDirectory.swift` | Opens the profile-index DB read-only and lists `WidgetProfileSummary`. |
+| `Shared/Widgets/UpcomingWidgetSnapshot.swift` | `Sendable` value type returned by the query. |
+| `Shared/Widgets/UpcomingWidgetQuery.swift` | Opens `data.sqlite` read-only and returns an `UpcomingWidgetSnapshot`. |
+| `Shared/Widgets/WidgetActor.swift` | `@globalActor enum WidgetActor` to serialise widget-side queries per process. |
+| `Shared/Widgets/WidgetReloadCoordinator.swift` | Host-side helper that calls `WidgetCenter.shared.reloadAllTimelines()`. |
+| `Shared/Widgets/ApplicationSupportToAppGroupMigration.swift` | One-shot copy-then-flag migration helper. |
+| `MoolahWidgets/MoolahWidgetsBundle.swift` | `@main WidgetBundle` of both widgets. |
+| `MoolahWidgets/UpcomingTransactionsListWidget.swift` | Medium widget + `AppIntentTimelineProvider`. |
+| `MoolahWidgets/UpcomingTransactionsCountWidget.swift` | Small widget + `AppIntentTimelineProvider`. |
+| `MoolahWidgets/Views/UpcomingListView.swift` | Medium content view. |
+| `MoolahWidgets/Views/UpcomingRowView.swift` | One row inside the medium list. |
+| `MoolahWidgets/Views/UpcomingCountView.swift` | Small content view. |
+| `MoolahWidgets/Views/WidgetEmptyStateView.swift` | Shared empty / placeholder content. |
+| `MoolahWidgets/Intents/WidgetProfileSelectionIntent.swift` | `WidgetConfigurationIntent` carrying the profile parameter. |
+| `MoolahWidgets/Intents/WidgetProfileEntity.swift` | Extension-local `AppEntity` + `EntityQuery`. |
+| `MoolahWidgets/Intents/OpenUpcomingFromWidgetIntent.swift` | Tap target for the small widget. |
+| `MoolahWidgets/Intents/OpenTransactionFromWidgetIntent.swift` | Tap target for medium rows. |
+| `MoolahWidgets/Info.plist` | Extension Info.plist with `NSExtension` + `MoolahAppGroupIdentifier`. |
+| `MoolahWidgets/MoolahWidgets-Debug.entitlements` | App Group entitlement for Debug (group `app.test`). |
+| `MoolahWidgets/MoolahWidgets-Release.entitlements` | App Group entitlement for Release (group `app.v2`). |
+| `fastlane/Moolah-widgets.entitlements` | App Group + sandbox entitlement consumed by fastlane Release builds (mac + iOS share one file because the App Group key is identical). |
+| `MoolahTests/Widgets/WidgetDataPathTests.swift` | Path resolution + override behaviour. |
+| `MoolahTests/Widgets/WidgetProfileDirectoryTests.swift` | Profile-index DB enumeration. |
+| `MoolahTests/Widgets/UpcomingWidgetQueryTests.swift` | Query behaviour against seeded GRDB DB. |
+| `MoolahTests/Widgets/UpcomingWidgetQueryPlanPinningTests.swift` | `EXPLAIN QUERY PLAN` assertions. |
+| `MoolahTests/Widgets/UpcomingWidgetSnapshotFormatTests.swift` | Multi-currency fallback + empty state. |
+| `MoolahTests/Widgets/OpenTransactionFromWidgetIntentTests.swift` | Intent → `NavigationBridge` fakes. |
+| `MoolahTests/Widgets/OpenUpcomingFromWidgetIntentTests.swift` | Intent → `NavigationBridge` fakes. |
+| `MoolahTests/Widgets/ApplicationSupportToAppGroupMigrationTests.swift` | Copy-then-flag migration end-to-end. |
+| `MoolahTests/Widgets/WidgetReloadCoordinatorTests.swift` | Reload helper invoked from each named host hook. |
+
+### Modified files
+
+| Path | Change |
+|---|---|
+| `Shared/URL+MoolahStorage.swift` | `moolahScopedApplicationSupport` reads from `WidgetDataPath.appGroupRoot()` (override still wins). |
+| `App/ProfileSession+Database.swift` | No code change — paths flow through `URL.moolahScopedApplicationSupport`. (Sanity-check link only.) |
+| `App/MoolahApp+Setup.swift` | Invoke `ApplicationSupportToAppGroupMigration.runIfNeeded()` before container manager bootstrap. |
+| `Features/Transactions/TransactionStore+Mutations.swift` | Call `WidgetReloadCoordinator.reload(reason: .transactionMutation)` after each successful mutation. |
+| `Backends/CloudKit/Sync/<sync-engine-coordinator>.swift` | Call `.reload(reason: .syncCompleted)` at the "fetched + applied" boundary. (Exact file located in Task 6.) |
+| `App/MoolahApp+Lifecycle.swift` | Call `.reload(reason: .scenePhaseBackground)` on iOS `ScenePhase` → `background` and macOS `NSApplication.willResignActiveNotification`. |
+| `Shared/ProfileContainerManager.swift` | Call `.reload(reason: .profileMutation)` after profile add / rename / delete. |
+| `App/Info-iOS.plist`, `App/Info-macOS.plist` | Add `MoolahAppGroupIdentifier = $(APP_GROUP_ID)`. |
+| `project.yml` | Add `APP_GROUP_ID` per config to each host target; add `MoolahWidgets_iOS` + `MoolahWidgets_macOS` extension targets; embed each in the matching host; add `Shared/Widgets/` to the existing host source lists (already covered by `Shared`, sanity-check); add `Shared/Widgets/` and `Domain/Models` to each widget target's `sources`; add App Group entitlements per config. |
+| `scripts/inject-entitlements.sh` | Add `com.apple.security.application-groups` array to the generated Debug entitlements. |
+| `scripts/cloudkit-config.sh` | Add `APP_GROUP_ID_RELEASE` / `APP_GROUP_ID_TEST` knobs that mirror the existing container ID knobs. |
+| `fastlane/Moolah.entitlements` | Add `com.apple.security.application-groups = [group.rocks.moolah.app.v2]`. |
+| `fastlane/Moolah-mac.entitlements` | Same addition. |
+| `.gitignore` | Ensure `project-entitlements.yml` already ignored (sanity); no new entries expected. |
+| `CLAUDE.md` | Add a one-line pointer under *Architecture & Constraints* explaining where the widget extension lives and why it never imports `Backends/`. |
+
+### Commit / PR strategy
+
+Seven landable PRs (one per task), each ending with the standard pre-commit gate per [[feedback_format_check_per_plan_step]]:
+
+```bash
+just format-check
+just test-mac
+just test-ios
+```
+
+Task 1 unblocks the rest (App Group + migration). Tasks 2–5 incrementally bring the widget alive. Task 6 wires the reload coordinator. Task 7 is verification and documentation polish. The user-visible feature lights up at the end of Task 5.
+
+---
+
+## Task 0 (pre-flight): file the cleanup-pass GitHub issue
+
+The migration in Task 1 leaves the old Application Support data in place behind a flag. We will land a cleanup migration in a later release. The Swift `TODO(#N)` referencing that future work needs an open issue **before** Task 1's commit (per CLAUDE.md §Bug Tracking and `just validate-todos`).
+
+- [ ] **Step 0.1: File the cleanup issue with `gh`**
+
+```bash
+gh issue create \
+  --title "Delete pre-App-Group per-profile data after telemetric soak" \
+  --body "$(cat <<'EOF'
+Follow-up to the App Group migration shipped in #<PR-number-from-task-1>. That migration **copied** every per-profile directory out of \`~/Library/Application Support/<env>/profiles/\` into the App Group container and wrote a \`migrated-from-application-support-v1.flag\` marker. The old data is intentionally left in place as a rollback safety net.
+
+This issue tracks the follow-up that **deletes** the old data after we have one or two releases of telemetric confidence that the new path works. Implementation: extend \`ApplicationSupportToAppGroupMigration\` with a \`cleanupOldData()\` entry point gated on the marker existing for at least N days, log byte count reclaimed, and call from the same bootstrap pinch point.
+
+Source pointer: TODO comment in \`Shared/Widgets/ApplicationSupportToAppGroupMigration.swift\` references this issue.
+EOF
+)" \
+  --label "tech-debt"
+```
+
+Expected: prints an issue URL like `https://github.com/moolah-rocks/moolah-native/issues/NNN`.
+
+- [ ] **Step 0.2: Record the issue number**
+
+Capture `NNN` from the output. It is referenced in Task 1, Step 6.2.
+
+---
+
+## Task 1: App Group plumbing + migration
+
+**Files:**
+- Modify: `project.yml`
+- Modify: `scripts/inject-entitlements.sh`
+- Modify: `scripts/cloudkit-config.sh`
+- Modify: `fastlane/Moolah.entitlements`
+- Modify: `fastlane/Moolah-mac.entitlements`
+- Modify: `App/Info-iOS.plist`
+- Modify: `App/Info-macOS.plist`
+- Modify: `Shared/URL+MoolahStorage.swift`
+- Modify: `App/MoolahApp+Setup.swift`
+- Create: `Shared/Widgets/AppGroupConfig.swift`
+- Create: `Shared/Widgets/WidgetDataPath.swift`
+- Create: `Shared/Widgets/ApplicationSupportToAppGroupMigration.swift`
+- Create: `MoolahTests/Widgets/WidgetDataPathTests.swift`
+- Create: `MoolahTests/Widgets/ApplicationSupportToAppGroupMigrationTests.swift`
+
+This task adds the App Group entitlement on both host targets, lifts the env-scoped storage subdirectory into the App Group container, and ships the one-shot migration. **No widget targets are added yet.** Test backends keep using the override mechanism; production switches to the App Group on first launch after the update.
+
+### Step 1: `project.yml` — add `APP_GROUP_ID` per config + entitlement plumbing
+
+- [ ] **Step 1.1: Edit `project.yml` — add `APP_GROUP_ID` to each host target's per-config block**
+
+For `Moolah_iOS`, inside `settings.configs`:
+
+```yaml
+        Debug:
+          CLOUDKIT_ENVIRONMENT: Development
+          CLOUDKIT_CONTAINER_ID: iCloud.rocks.moolah.app.test
+          APP_GROUP_ID: group.rocks.moolah.app.test
+        Debug-Tests:
+          CODE_SIGN_ENTITLEMENTS: ""
+          SWIFT_ACTIVE_COMPILATION_CONDITIONS: "$(inherited)"
+          CLOUDKIT_ENVIRONMENT: Development
+          CLOUDKIT_CONTAINER_ID: iCloud.rocks.moolah.app.test
+          APP_GROUP_ID: group.rocks.moolah.app.test
+        Release:
+          # … existing keys …
+          CLOUDKIT_ENVIRONMENT: Production
+          CLOUDKIT_CONTAINER_ID: iCloud.rocks.moolah.app.v2
+          APP_GROUP_ID: group.rocks.moolah.app.v2
+```
+
+Repeat the identical three additions inside `Moolah_macOS.settings.configs.{Debug,Debug-Tests,Release}`.
+
+- [ ] **Step 1.2: Edit `App/Info-iOS.plist` — surface the App Group ID to Swift**
+
+Add a top-level `<key>MoolahAppGroupIdentifier</key>` paired with `<string>$(APP_GROUP_ID)</string>`. Place it next to the existing `MoolahCloudKitContainer` key for visual symmetry.
+
+- [ ] **Step 1.3: Edit `App/Info-macOS.plist` — same addition**
+
+Same key / value as iOS.
+
+- [ ] **Step 1.4: Edit `scripts/inject-entitlements.sh` — add App Group key**
+
+Inside the generated entitlements heredoc, add (immediately after the `icloud-container-identifiers` block):
+
+```xml
+    <key>com.apple.security.application-groups</key>
+    <array>
+        <string>group.rocks.moolah.app.test</string>
+    </array>
+```
+
+The Debug app group identifier is hardcoded here because this script only runs for Debug. The Release entitlements files (`fastlane/Moolah*.entitlements`) carry the production identifier; see Step 1.6.
+
+- [ ] **Step 1.5: Edit `scripts/cloudkit-config.sh` — mirror knobs**
+
+Wherever `CLOUDKIT_CONTAINER_ID_RELEASE` / `CLOUDKIT_CONTAINER_ID_TEST` are defined, add the parallel pair:
+
+```bash
+APP_GROUP_ID_RELEASE="group.rocks.moolah.app.v2"
+APP_GROUP_ID_TEST="group.rocks.moolah.app.test"
+```
+
+Export them next to the existing exports so any downstream tooling that reads the env can pick them up.
+
+- [ ] **Step 1.6: Edit `fastlane/Moolah.entitlements` — add App Group**
+
+Inside the `<dict>`, after the `com.apple.developer.icloud-container-identifiers` array, add:
+
+```xml
+    <key>com.apple.security.application-groups</key>
+    <array>
+        <string>group.rocks.moolah.app.v2</string>
+    </array>
+```
+
+- [ ] **Step 1.7: Edit `fastlane/Moolah-mac.entitlements` — same addition**
+
+Same XML block in the same position.
+
+- [ ] **Step 1.8: Run `just generate` to regenerate the Xcode project**
+
+```bash
+just generate
+```
+
+Expected: completes without error. Inspect with `git status`; only `project.yml` should be staged-relevant on the source side (`Moolah.xcodeproj` is gitignored).
+
+### Step 2: `AppGroupConfig` — read identifier from Info.plist
+
+- [ ] **Step 2.1: Create `Shared/Widgets/AppGroupConfig.swift`**
+
+```swift
+import Foundation
+
+/// Resolves the App Group identifier this binary is entitled to.
+///
+/// The value is set per build configuration in `project.yml`
+/// (`APP_GROUP_ID = group.rocks.moolah.app.{test,v2}`) and surfaced
+/// to Swift via the `MoolahAppGroupIdentifier` Info.plist key. Mirrors
+/// the existing `MoolahCloudKitContainer` arrangement.
+enum AppGroupConfig {
+
+  /// Process-wide identifier, read once from the main bundle.
+  ///
+  /// Crashes at startup if missing. The Info.plist key is required on every
+  /// shipped configuration; an absent value means `project.yml` was
+  /// regenerated without `APP_GROUP_ID` set, which is never a valid state.
+  static let identifier: String = {
+    guard
+      let raw = Bundle.main.object(forInfoDictionaryKey: "MoolahAppGroupIdentifier") as? String,
+      !raw.isEmpty,
+      !raw.hasPrefix("$(")
+    else {
+      fatalError(
+        "MoolahAppGroupIdentifier Info.plist key missing or unsubstituted. "
+        + "Did `xcodegen` run with APP_GROUP_ID defined?")
+    }
+    return raw
+  }()
+}
+```
+
+The `hasPrefix("$(")` guard catches the failure mode where `xcodegen` ran without the variable defined and wrote the literal string `$(APP_GROUP_ID)` into Info.plist.
+
+### Step 3: `WidgetDataPath` — App Group container math
+
+- [ ] **Step 3.1: Failing test — write `MoolahTests/Widgets/WidgetDataPathTests.swift`**
+
+```swift
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("WidgetDataPath")
+struct WidgetDataPathTests {
+
+  // MARK: app-group root resolution
+
+  @Test("appGroupRoot returns the FileManager container URL for the configured identifier")
+  func appGroupRootReturnsContainerURL() throws {
+    // `AppGroupConfig.identifier` is the production-config value at test time.
+    // FileManager returns nil for an unknown group identifier; on the test
+    // host (no entitlement) we expect nil and verify the path resolver throws.
+    let result = WidgetDataPath.appGroupRootOrNil()
+    if let url = result {
+      #expect(url.path.contains(AppGroupConfig.identifier))
+    } else {
+      #expect(throws: WidgetDataPath.PathError.appGroupContainerUnavailable) {
+        try WidgetDataPath.appGroupRoot()
+      }
+    }
+  }
+
+  // MARK: env-scoped subdirectory
+
+  @Test("scopedRoot appends the CloudKit env subdirectory under the App Group root")
+  func scopedRootAppendsEnvSubdirectory() throws {
+    let tempBase = FileManager.default.temporaryDirectory
+      .appendingPathComponent("widget-data-path-tests-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: tempBase, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: tempBase) }
+
+    let scoped = WidgetDataPath.scopedRoot(overrideBase: tempBase)
+    #expect(scoped.path.hasPrefix(tempBase.path))
+    #expect(scoped.lastPathComponent == CloudKitEnvironment.resolved().storageSubdirectory)
+    var isDirectory: ObjCBool = false
+    #expect(FileManager.default.fileExists(atPath: scoped.path, isDirectory: &isDirectory))
+    #expect(isDirectory.boolValue)
+  }
+
+  // MARK: per-profile DB path
+
+  @Test("profileDatabaseURL composes profiles/<uuid>/data.sqlite under the env scope")
+  func profileDatabaseURLComposesCorrectly() {
+    let id = UUID()
+    let scoped = URL(fileURLWithPath: "/tmp/example/Test")
+    let url = WidgetDataPath.profileDatabaseURL(profileID: id, scopedRoot: scoped)
+    #expect(url == scoped.appendingPathComponent("profiles/\(id.uuidString)/data.sqlite"))
+  }
+
+  // MARK: profile-index DB path
+
+  @Test("profileIndexDatabaseURL composes profile-index.sqlite under the env scope")
+  func profileIndexDatabaseURLComposesCorrectly() {
+    let scoped = URL(fileURLWithPath: "/tmp/example/Test")
+    let url = WidgetDataPath.profileIndexDatabaseURL(scopedRoot: scoped)
+    #expect(url == scoped.appendingPathComponent("profile-index.sqlite"))
+  }
+}
+```
+
+- [ ] **Step 3.2: Run the failing tests**
+
+```bash
+just test-mac WidgetDataPathTests 2>&1 | tee .agent-tmp/widget-data-path.txt
+```
+
+Expected: build fails because `WidgetDataPath` is not defined.
+
+- [ ] **Step 3.3: Create `Shared/Widgets/WidgetDataPath.swift`**
+
+```swift
+import Foundation
+
+/// Filesystem layout under the App Group container shared by the host apps
+/// and the widget extension.
+///
+/// The previous layout rooted at `URL.applicationSupportDirectory` is
+/// migrated into `WidgetDataPath.scopedRoot()` by
+/// `ApplicationSupportToAppGroupMigration`. After migration, every
+/// production read / write of per-profile data flows through these paths.
+///
+/// Tests pass `overrideBase:` to root the layout in a temp directory and
+/// never touch the real App Group container.
+enum WidgetDataPath {
+
+  enum PathError: Error, Equatable, Sendable {
+    case appGroupContainerUnavailable
+  }
+
+  /// FileManager container URL for the build's App Group identifier.
+  /// Returns `nil` on hosts that don't grant the entitlement (test runner,
+  /// some preview environments). Use `appGroupRoot()` when you need the
+  /// throwing variant.
+  static func appGroupRootOrNil() -> URL? {
+    FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: AppGroupConfig.identifier)
+  }
+
+  /// Throwing variant — call sites that cannot proceed without the
+  /// container surface `appGroupContainerUnavailable` to the user.
+  static func appGroupRoot() throws -> URL {
+    guard let url = appGroupRootOrNil() else {
+      throw PathError.appGroupContainerUnavailable
+    }
+    return url
+  }
+
+  /// The env-scoped subdirectory under the App Group root, created on demand.
+  /// `overrideBase` is used by tests to swap the App Group root for a temp dir.
+  static func scopedRoot(overrideBase: URL? = nil) -> URL {
+    let base = overrideBase ?? (appGroupRootOrNil() ?? URL.applicationSupportDirectory)
+    let scoped = base.appendingPathComponent(
+      CloudKitEnvironment.resolved().storageSubdirectory, isDirectory: true)
+    try? FileManager.default.createDirectory(at: scoped, withIntermediateDirectories: true)
+    return scoped
+  }
+
+  /// Per-profile `data.sqlite` URL inside the scoped App Group root.
+  static func profileDatabaseURL(profileID: UUID, scopedRoot: URL) -> URL {
+    scopedRoot
+      .appendingPathComponent("profiles", isDirectory: true)
+      .appendingPathComponent(profileID.uuidString, isDirectory: true)
+      .appendingPathComponent("data.sqlite")
+  }
+
+  /// Profile-index database URL inside the scoped App Group root.
+  static func profileIndexDatabaseURL(scopedRoot: URL) -> URL {
+    scopedRoot.appendingPathComponent("profile-index.sqlite")
+  }
+}
+```
+
+- [ ] **Step 3.4: Run the tests — verify pass**
+
+```bash
+just test-mac WidgetDataPathTests 2>&1 | tee .agent-tmp/widget-data-path.txt
+```
+
+Expected: all three `WidgetDataPathTests` pass.
+
+### Step 4: Repoint `URL.moolahScopedApplicationSupport` at the App Group
+
+- [ ] **Step 4.1: Edit `Shared/URL+MoolahStorage.swift`**
+
+Replace the body of `moolahScopedApplicationSupport` with:
+
+```swift
+  /// Application Support, scoped to the current CloudKit environment.
+  ///
+  /// Production reads from the shared App Group container so the widget
+  /// extension can see the same per-profile databases. Tests continue to
+  /// use the override (which wins, by design — see `WidgetDataPath`).
+  static var moolahScopedApplicationSupport: URL {
+    WidgetDataPath.scopedRoot(overrideBase: moolahApplicationSupportOverride)
+  }
+```
+
+The doc comment is updated; the override key keeps its existing semantics — `WidgetDataPath.scopedRoot(overrideBase:)` uses the override when present and falls back to the App Group root otherwise.
+
+- [ ] **Step 4.2: Run the existing storage-path tests**
+
+```bash
+just test-mac URL_MoolahStorage 2>&1 | tee .agent-tmp/storage-tests.txt
+```
+
+If a test exists at `MoolahTests/Shared/URLMoolahStorageTests.swift` it must still pass — the override path is unchanged. If no such test exists, build the macOS app to confirm compilation:
+
+```bash
+just build-mac 2>&1 | tee .agent-tmp/build-mac.txt
+```
+
+Expected: build succeeds, existing tests pass.
+
+### Step 5: Migration — `ApplicationSupportToAppGroupMigration`
+
+- [ ] **Step 5.1: Failing test — `MoolahTests/Widgets/ApplicationSupportToAppGroupMigrationTests.swift`**
+
+```swift
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+@Suite("ApplicationSupportToAppGroupMigration")
+struct ApplicationSupportToAppGroupMigrationTests {
+
+  // MARK: helpers
+
+  private struct Fixture {
+    let oldRoot: URL
+    let newRoot: URL
+    let profileIDs: [UUID]
+    let cleanup: () -> Void
+  }
+
+  private func makeFixture(profileCount: Int = 2) throws -> Fixture {
+    let base = FileManager.default.temporaryDirectory
+      .appendingPathComponent("widget-migration-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: base, withIntermediateDirectories: true)
+
+    let oldRoot = base.appendingPathComponent("old", isDirectory: true)
+    let newRoot = base.appendingPathComponent("new", isDirectory: true)
+    try FileManager.default.createDirectory(at: oldRoot, withIntermediateDirectories: true)
+    try FileManager.default.createDirectory(at: newRoot, withIntermediateDirectories: true)
+
+    let ids = (0..<profileCount).map { _ in UUID() }
+    // Seed a per-profile data.sqlite and a profile-index.sqlite into the old root.
+    for id in ids {
+      let dir = oldRoot.appendingPathComponent("profiles/\(id.uuidString)", isDirectory: true)
+      try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+      let dbURL = dir.appendingPathComponent("data.sqlite")
+      let queue = try DatabaseQueue(path: dbURL.path)
+      try queue.write { db in
+        try db.execute(sql: "CREATE TABLE marker(id INTEGER PRIMARY KEY)")
+        try db.execute(sql: "INSERT INTO marker(id) VALUES (1)")
+      }
+    }
+    let indexURL = oldRoot.appendingPathComponent("profile-index.sqlite")
+    let indexQueue = try DatabaseQueue(path: indexURL.path)
+    try indexQueue.write { db in
+      try db.execute(sql: "CREATE TABLE profile(id TEXT PRIMARY KEY)")
+    }
+
+    return Fixture(
+      oldRoot: oldRoot,
+      newRoot: newRoot,
+      profileIDs: ids,
+      cleanup: { try? FileManager.default.removeItem(at: base) })
+  }
+
+  // MARK: behaviours
+
+  @Test("copies every per-profile data.sqlite from old to new and writes the flag")
+  func copiesProfilesAndFlag() throws {
+    let fx = try makeFixture()
+    defer { fx.cleanup() }
+
+    try ApplicationSupportToAppGroupMigration.runIfNeeded(
+      oldRoot: fx.oldRoot, newRoot: fx.newRoot)
+
+    for id in fx.profileIDs {
+      let copied = fx.newRoot.appendingPathComponent("profiles/\(id.uuidString)/data.sqlite")
+      #expect(FileManager.default.fileExists(atPath: copied.path))
+      // Verify the copy is the same DB (the marker row survives).
+      let queue = try DatabaseQueue(path: copied.path)
+      let count = try queue.read { db in
+        try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM marker") ?? -1
+      }
+      #expect(count == 1)
+    }
+
+    let flag = fx.newRoot.appendingPathComponent("migrated-from-application-support-v1.flag")
+    #expect(FileManager.default.fileExists(atPath: flag.path))
+  }
+
+  @Test("copies the profile-index DB")
+  func copiesProfileIndex() throws {
+    let fx = try makeFixture()
+    defer { fx.cleanup() }
+
+    try ApplicationSupportToAppGroupMigration.runIfNeeded(
+      oldRoot: fx.oldRoot, newRoot: fx.newRoot)
+
+    let copied = fx.newRoot.appendingPathComponent("profile-index.sqlite")
+    #expect(FileManager.default.fileExists(atPath: copied.path))
+    let queue = try DatabaseQueue(path: copied.path)
+    let tableExists = try queue.read { db in
+      try Bool.fetchOne(
+        db,
+        sql: "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'profile'") ?? false
+    }
+    #expect(tableExists)
+  }
+
+  @Test("leaves the old data in place after migration")
+  func leavesOldDataAlone() throws {
+    let fx = try makeFixture()
+    defer { fx.cleanup() }
+
+    try ApplicationSupportToAppGroupMigration.runIfNeeded(
+      oldRoot: fx.oldRoot, newRoot: fx.newRoot)
+
+    for id in fx.profileIDs {
+      let old = fx.oldRoot.appendingPathComponent("profiles/\(id.uuidString)/data.sqlite")
+      #expect(FileManager.default.fileExists(atPath: old.path))
+    }
+  }
+
+  @Test("is idempotent — re-running is a no-op")
+  func idempotent() throws {
+    let fx = try makeFixture()
+    defer { fx.cleanup() }
+
+    try ApplicationSupportToAppGroupMigration.runIfNeeded(
+      oldRoot: fx.oldRoot, newRoot: fx.newRoot)
+    let flag = fx.newRoot.appendingPathComponent("migrated-from-application-support-v1.flag")
+    let stamp1 = try FileManager.default.attributesOfItem(atPath: flag.path)[.modificationDate]
+      as? Date
+
+    try ApplicationSupportToAppGroupMigration.runIfNeeded(
+      oldRoot: fx.oldRoot, newRoot: fx.newRoot)
+    let stamp2 = try FileManager.default.attributesOfItem(atPath: flag.path)[.modificationDate]
+      as? Date
+
+    #expect(stamp1 == stamp2)
+  }
+
+  @Test("integrity-check failure aborts and does not write the flag")
+  func integrityFailureAborts() throws {
+    let fx = try makeFixture()
+    defer { fx.cleanup() }
+
+    // Corrupt one of the per-profile DBs by truncating it.
+    let firstID = try #require(fx.profileIDs.first)
+    let dbURL = fx.oldRoot.appendingPathComponent("profiles/\(firstID.uuidString)/data.sqlite")
+    let handle = try FileHandle(forUpdating: dbURL)
+    try handle.truncate(atOffset: 16)
+    try handle.close()
+
+    #expect(throws: ApplicationSupportToAppGroupMigration.MigrationError.self) {
+      try ApplicationSupportToAppGroupMigration.runIfNeeded(
+        oldRoot: fx.oldRoot, newRoot: fx.newRoot)
+    }
+    let flag = fx.newRoot.appendingPathComponent("migrated-from-application-support-v1.flag")
+    #expect(!FileManager.default.fileExists(atPath: flag.path))
+  }
+
+  @Test("no-op if the old root has no profiles directory")
+  func noProfilesNoOp() throws {
+    let fx = try makeFixture(profileCount: 0)
+    defer { fx.cleanup() }
+    // remove the empty profiles directory so the migration sees a truly bare old root
+    try FileManager.default.removeItem(
+      at: fx.oldRoot.appendingPathComponent("profiles", isDirectory: true))
+
+    try ApplicationSupportToAppGroupMigration.runIfNeeded(
+      oldRoot: fx.oldRoot, newRoot: fx.newRoot)
+
+    // profile-index.sqlite is still copied (it was outside the profiles dir).
+    let flag = fx.newRoot.appendingPathComponent("migrated-from-application-support-v1.flag")
+    #expect(FileManager.default.fileExists(atPath: flag.path))
+  }
+}
+```
+
+- [ ] **Step 5.2: Run the tests — verify all fail (build error)**
+
+```bash
+just test-mac ApplicationSupportToAppGroupMigrationTests 2>&1 | tee .agent-tmp/migration-tests.txt
+```
+
+Expected: build fails because `ApplicationSupportToAppGroupMigration` is undefined.
+
+- [ ] **Step 5.3: Create `Shared/Widgets/ApplicationSupportToAppGroupMigration.swift`**
+
+Replace `<NNN>` with the issue number from Task 0, Step 0.1.
+
+```swift
+import Foundation
+import GRDB
+import OSLog
+
+/// One-shot migration that copies the user's per-profile data from the
+/// legacy `~/Library/Application Support/<env>/...` layout into the App
+/// Group container. Copy-not-move; integrity-checked; idempotent.
+///
+/// Runs from `App/MoolahApp+Setup.swift` before any profile session opens.
+/// The old data is intentionally left in place as a rollback safety net.
+///
+/// TODO(#<NNN>): delete the legacy data after a release of telemetric soak
+/// — https://github.com/moolah-rocks/moolah-native/issues/<NNN>
+enum ApplicationSupportToAppGroupMigration {
+
+  enum MigrationError: Error, Equatable, Sendable {
+    case integrityCheckFailed(URL)
+    case copyFailed(URL, underlying: String)
+  }
+
+  private static let flagFilename = "migrated-from-application-support-v1.flag"
+  private static let logger = Logger(subsystem: "com.moolah.app", category: "WidgetMigration")
+
+  /// Run the migration if it has not already completed for this env. Safe
+  /// to call from any thread; uses `FileManager` synchronous APIs.
+  ///
+  /// Production callers pass no overrides: `oldRoot` defaults to
+  /// `URL.applicationSupportDirectory/<env>` and `newRoot` defaults to
+  /// `WidgetDataPath.scopedRoot()`.
+  static func runIfNeeded(
+    oldRoot: URL = defaultOldRoot(),
+    newRoot: URL = WidgetDataPath.scopedRoot()
+  ) throws {
+    let flag = newRoot.appendingPathComponent(flagFilename)
+    if FileManager.default.fileExists(atPath: flag.path) {
+      return
+    }
+    try FileManager.default.createDirectory(at: newRoot, withIntermediateDirectories: true)
+
+    let profilesOld = oldRoot.appendingPathComponent("profiles", isDirectory: true)
+    let profilesNew = newRoot.appendingPathComponent("profiles", isDirectory: true)
+    if FileManager.default.fileExists(atPath: profilesOld.path) {
+      try FileManager.default.createDirectory(at: profilesNew, withIntermediateDirectories: true)
+      let entries = try FileManager.default.contentsOfDirectory(
+        at: profilesOld, includingPropertiesForKeys: nil,
+        options: [.skipsHiddenFiles, .skipsSubdirectoryDescendants])
+      for src in entries {
+        let dst = profilesNew.appendingPathComponent(src.lastPathComponent, isDirectory: true)
+        try copyDirectoryIfMissing(from: src, to: dst)
+        try integrityCheckSQLites(in: dst)
+      }
+    }
+
+    // Copy non-profiles top-level files (profile-index, sync-state, backups).
+    let topLevel = try FileManager.default.contentsOfDirectory(
+      at: oldRoot, includingPropertiesForKeys: nil,
+      options: [.skipsHiddenFiles, .skipsSubdirectoryDescendants])
+    for src in topLevel where src.lastPathComponent != "profiles" {
+      let dst = newRoot.appendingPathComponent(src.lastPathComponent)
+      try copyItemIfMissing(from: src, to: dst)
+      if src.pathExtension == "sqlite" {
+        try integrityCheck(at: dst)
+      }
+    }
+
+    try Data().write(to: flag, options: [.atomic])
+    logger.notice("Application Support → App Group migration complete: \(newRoot.path, privacy: .public)")
+  }
+
+  // MARK: helpers
+
+  private static func defaultOldRoot() -> URL {
+    URL.applicationSupportDirectory
+      .appendingPathComponent(CloudKitEnvironment.resolved().storageSubdirectory, isDirectory: true)
+  }
+
+  private static func copyDirectoryIfMissing(from src: URL, to dst: URL) throws {
+    if FileManager.default.fileExists(atPath: dst.path) {
+      return
+    }
+    do {
+      try FileManager.default.copyItem(at: src, to: dst)
+    } catch {
+      // Clean up a partial copy so the next attempt is clean.
+      try? FileManager.default.removeItem(at: dst)
+      throw MigrationError.copyFailed(src, underlying: String(describing: error))
+    }
+  }
+
+  private static func copyItemIfMissing(from src: URL, to dst: URL) throws {
+    if FileManager.default.fileExists(atPath: dst.path) {
+      return
+    }
+    do {
+      try FileManager.default.copyItem(at: src, to: dst)
+    } catch {
+      try? FileManager.default.removeItem(at: dst)
+      throw MigrationError.copyFailed(src, underlying: String(describing: error))
+    }
+  }
+
+  private static func integrityCheckSQLites(in directory: URL) throws {
+    let entries = try FileManager.default.contentsOfDirectory(
+      at: directory, includingPropertiesForKeys: nil,
+      options: [.skipsHiddenFiles, .skipsSubdirectoryDescendants])
+    for url in entries where url.pathExtension == "sqlite" {
+      try integrityCheck(at: url)
+    }
+  }
+
+  private static func integrityCheck(at url: URL) throws {
+    let queue = try DatabaseQueue(path: url.path)
+    let result = try queue.read { db in
+      try String.fetchOne(db, sql: "PRAGMA integrity_check") ?? ""
+    }
+    if result.lowercased() != "ok" {
+      logger.fault("integrity_check failed for \(url.path, privacy: .public): \(result, privacy: .public)")
+      // Tear down the partial copy so the next attempt re-tries fresh.
+      try? FileManager.default.removeItem(at: url)
+      throw MigrationError.integrityCheckFailed(url)
+    }
+  }
+}
+```
+
+- [ ] **Step 5.4: Run the tests — verify all pass**
+
+```bash
+just test-mac ApplicationSupportToAppGroupMigrationTests 2>&1 | tee .agent-tmp/migration-tests.txt
+```
+
+Expected: all six tests pass.
+
+### Step 6: Wire migration into host bootstrap
+
+- [ ] **Step 6.1: Locate the bootstrap pinch point in `App/MoolahApp+Setup.swift`**
+
+Read the file. Find the function that creates `ProfileContainerManager` (search for `ProfileContainerManager(`). The migration must run immediately before that constructor — before any `data.sqlite` is opened by the host.
+
+- [ ] **Step 6.2: Insert the migration call**
+
+In the function identified above, immediately before the `ProfileContainerManager(...)` constructor call, add:
+
+```swift
+    // App Group migration — copies legacy ~/Library/Application Support/<env>/
+    // data into the App Group container so the widget extension can read it.
+    // Idempotent; no-op after first successful run. Tests skip this branch
+    // because `moolahApplicationSupportOverride` is set to a temp directory.
+    if URL.moolahApplicationSupportOverride == nil {
+      do {
+        try ApplicationSupportToAppGroupMigration.runIfNeeded()
+      } catch {
+        logger.fault("Widget App Group migration failed: \(String(describing: error), privacy: .public)")
+        // Continue boot — host still works against the legacy path via the
+        // override (set below for the fallback case). Widget queries will
+        // surface `profileDatabaseUnavailable` until the user resolves it.
+      }
+    }
+```
+
+If the surrounding scope does not already have a `logger` symbol, add at the top of the file:
+
+```swift
+import OSLog
+private let logger = Logger(subsystem: "com.moolah.app", category: "Setup")
+```
+
+(Skip if the file already declares `logger`.)
+
+- [ ] **Step 6.3: Run a focused integration build**
+
+```bash
+just build-mac 2>&1 | tee .agent-tmp/build-mac.txt
+```
+
+Expected: build succeeds.
+
+### Step 7: Full gate + commit
+
+- [ ] **Step 7.1: Run format-check**
+
+```bash
+just format-check
+```
+
+If any file is reported unformatted, run `just format` and re-run `format-check`. **Never** bump a `.swiftlint.yml` threshold or add a baseline to dodge a failure (see [[feedback_swiftlint_fix_not_baseline]]).
+
+- [ ] **Step 7.2: Run the full Mac suite**
+
+```bash
+just test-mac 2>&1 | tee .agent-tmp/test-mac.txt
+```
+
+Expected: all tests pass. Common gotcha: if the `URL.moolahScopedApplicationSupport` refactor regressed a test that didn't set the override, the failure will show as a permission or path error — fix by setting the override in test setup.
+
+- [ ] **Step 7.3: Run the iOS suite**
+
+```bash
+just test-ios 2>&1 | tee .agent-tmp/test-ios.txt
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 7.4: Commit**
+
+```bash
+git add project.yml \
+  scripts/inject-entitlements.sh scripts/cloudkit-config.sh \
+  fastlane/Moolah.entitlements fastlane/Moolah-mac.entitlements \
+  App/Info-iOS.plist App/Info-macOS.plist \
+  Shared/URL+MoolahStorage.swift Shared/Widgets/ \
+  App/MoolahApp+Setup.swift \
+  MoolahTests/Widgets/
+
+git commit -m "$(cat <<'EOF'
+feat(widgets): add App Group container + migrate per-profile data into it
+
+Per-profile data.sqlite and profile-index.sqlite move from
+~/Library/Application Support/<env>/ into the shared App Group container
+group.rocks.moolah.app.{test,v2}. The migration is copy-not-move and
+integrity-checked; the legacy data is left in place as a rollback safety
+net until a follow-up release (see TODO referencing the cleanup issue).
+
+This is plumbing only — no widget targets yet. Tests continue to use
+moolahApplicationSupportOverride and never touch the App Group.
+EOF
+)"
+```
+
+---
+
+## Task 2: `Shared/Widgets/` query layer
+
+**Files:**
+- Create: `Shared/Widgets/WidgetActor.swift`
+- Create: `Shared/Widgets/WidgetProfileSummary.swift`
+- Create: `Shared/Widgets/WidgetProfileDirectory.swift`
+- Create: `Shared/Widgets/UpcomingWidgetSnapshot.swift`
+- Create: `Shared/Widgets/UpcomingWidgetQuery.swift`
+- Create: `MoolahTests/Widgets/WidgetProfileDirectoryTests.swift`
+- Create: `MoolahTests/Widgets/UpcomingWidgetQueryTests.swift`
+- Create: `MoolahTests/Widgets/UpcomingWidgetQueryPlanPinningTests.swift`
+- Create: `MoolahTests/Widgets/UpcomingWidgetSnapshotFormatTests.swift`
+
+This task ships the read-only query layer the widget extension will use. **No extension target yet** — every file lives under `Shared/Widgets/` and is linked by the host. Tests run against the existing GRDB test seed.
+
+### Step 1: `WidgetActor`
+
+- [ ] **Step 1.1: Create `Shared/Widgets/WidgetActor.swift`**
+
+```swift
+import Foundation
+
+/// Serialises widget-side queries within a single process so concurrent
+/// timeline rebuilds for the same widget don't race each other.
+/// SQLite WAL would tolerate overlapping reads, but the actor keeps
+/// Instruments traces and signpost intervals legible.
+@globalActor
+enum WidgetActor {
+  actor Storage {}
+  static let shared = Storage()
+}
+```
+
+### Step 2: `WidgetProfileSummary`
+
+- [ ] **Step 2.1: Create `Shared/Widgets/WidgetProfileSummary.swift`**
+
+```swift
+import Foundation
+
+/// Minimal profile description returned by `WidgetProfileDirectory`.
+/// `Sendable` so it can cross actor / process boundaries.
+struct WidgetProfileSummary: Sendable, Equatable, Hashable, Identifiable {
+  let id: UUID
+  let label: String
+  let currency: String
+
+  init(id: UUID, label: String, currency: String) {
+    self.id = id
+    self.label = label
+    self.currency = currency
+  }
+}
+```
+
+### Step 3: `WidgetProfileDirectory`
+
+- [ ] **Step 3.1: Failing tests — `MoolahTests/Widgets/WidgetProfileDirectoryTests.swift`**
+
+```swift
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+@Suite("WidgetProfileDirectory")
+struct WidgetProfileDirectoryTests {
+
+  private func seedIndex(at url: URL, profiles: [WidgetProfileSummary]) throws {
+    let queue = try DatabaseQueue(path: url.path)
+    try queue.write { db in
+      try db.execute(sql: """
+        CREATE TABLE profile (
+          id TEXT PRIMARY KEY,
+          label TEXT NOT NULL,
+          currency TEXT NOT NULL
+        ) STRICT
+      """)
+      for p in profiles {
+        try db.execute(
+          sql: "INSERT INTO profile(id, label, currency) VALUES (?, ?, ?)",
+          arguments: [p.id.uuidString, p.label, p.currency])
+      }
+    }
+  }
+
+  @Test("returns every profile from the index DB, sorted by label")
+  func returnsAllSorted() throws {
+    let tmp = FileManager.default.temporaryDirectory
+      .appendingPathComponent("wpd-\(UUID().uuidString).sqlite")
+    defer { try? FileManager.default.removeItem(at: tmp) }
+
+    let alice = WidgetProfileSummary(id: UUID(), label: "Alice", currency: "AUD")
+    let bob = WidgetProfileSummary(id: UUID(), label: "Bob", currency: "USD")
+    try seedIndex(at: tmp, profiles: [bob, alice])
+
+    let result = try WidgetProfileDirectory.list(profileIndexURL: tmp)
+    #expect(result.map(\.label) == ["Alice", "Bob"])
+    #expect(result.contains { $0.id == alice.id })
+    #expect(result.contains { $0.id == bob.id })
+  }
+
+  @Test("returns empty list when the DB file is missing")
+  func missingDBIsEmptyList() throws {
+    let tmp = FileManager.default.temporaryDirectory
+      .appendingPathComponent("wpd-missing-\(UUID().uuidString).sqlite")
+    let result = try WidgetProfileDirectory.list(profileIndexURL: tmp)
+    #expect(result.isEmpty)
+  }
+
+  @Test("throws when the DB file is corrupt")
+  func corruptDBThrows() throws {
+    let tmp = FileManager.default.temporaryDirectory
+      .appendingPathComponent("wpd-corrupt-\(UUID().uuidString).sqlite")
+    try Data("not a database".utf8).write(to: tmp)
+    defer { try? FileManager.default.removeItem(at: tmp) }
+
+    #expect(throws: Error.self) {
+      _ = try WidgetProfileDirectory.list(profileIndexURL: tmp)
+    }
+  }
+}
+```
+
+- [ ] **Step 3.2: Run — verify failing**
+
+```bash
+just test-mac WidgetProfileDirectoryTests 2>&1 | tee .agent-tmp/wpd-tests.txt
+```
+
+Expected: build fails — `WidgetProfileDirectory` undefined.
+
+- [ ] **Step 3.3: Create `Shared/Widgets/WidgetProfileDirectory.swift`**
+
+```swift
+import Foundation
+import GRDB
+
+/// Read-only enumerator over the profile-index database. Used by the widget
+/// extension's configuration intent to populate the profile picker, and by
+/// the timeline providers to resolve the configured profile's metadata.
+///
+/// The schema is owned by `ProfileContainerManager`; this enumerator only
+/// reads the columns it needs and tolerates additional columns being added.
+enum WidgetProfileDirectory {
+
+  /// Lists every profile in the index DB, sorted ascending by label.
+  /// Returns an empty list if the DB file does not exist (pre-bootstrap,
+  /// pre-migration, or test host with no fixtures).
+  static func list(profileIndexURL: URL) throws -> [WidgetProfileSummary] {
+    guard FileManager.default.fileExists(atPath: profileIndexURL.path) else {
+      return []
+    }
+    var configuration = Configuration()
+    configuration.readonly = true
+    configuration.busyMode = .timeout(0.2)
+    let queue = try DatabaseQueue(path: profileIndexURL.path, configuration: configuration)
+    return try queue.read { db in
+      try Row.fetchAll(
+        db,
+        sql: "SELECT id, label, currency FROM profile ORDER BY label COLLATE NOCASE ASC"
+      ).compactMap { row -> WidgetProfileSummary? in
+        guard
+          let idString: String = row["id"],
+          let id = UUID(uuidString: idString),
+          let label: String = row["label"],
+          let currency: String = row["currency"]
+        else {
+          return nil
+        }
+        return WidgetProfileSummary(id: id, label: label, currency: currency)
+      }
+    }
+  }
+}
+```
+
+- [ ] **Step 3.4: Run — verify pass**
+
+```bash
+just test-mac WidgetProfileDirectoryTests 2>&1 | tee .agent-tmp/wpd-tests.txt
+```
+
+Expected: all three tests pass.
+
+### Step 4: `UpcomingWidgetSnapshot`
+
+- [ ] **Step 4.1: Create `Shared/Widgets/UpcomingWidgetSnapshot.swift`**
+
+```swift
+import Foundation
+
+/// Value returned by `UpcomingWidgetQuery.read(...)`. Consumed by both
+/// widgets (medium uses `upcomingRows`, small uses `dueNowCount` and
+/// `dueNowTotal`). Sendable across actor + process boundaries.
+struct UpcomingWidgetSnapshot: Sendable, Equatable {
+
+  struct Row: Sendable, Equatable, Identifiable {
+    let id: UUID
+    let payee: String
+    let dueDate: Date
+    /// Signed amount: negative = outflow, positive = inflow. Preserves the
+    /// original Transaction-leg sign per project convention; never abs().
+    let amount: Decimal
+    let instrument: Instrument
+
+    init(id: UUID, payee: String, dueDate: Date, amount: Decimal, instrument: Instrument) {
+      self.id = id
+      self.payee = payee
+      self.dueDate = dueDate
+      self.amount = amount
+      self.instrument = instrument
+    }
+  }
+
+  let profileID: UUID
+  let profileLabel: String
+  let profileCurrency: String
+
+  /// Start-of-day of the request time, in the resolving calendar.
+  let asOf: Date
+
+  /// Count of scheduled transactions that are overdue or due today.
+  let dueNowCount: Int
+
+  /// Sum of overdue+today amounts, grouped by instrument (signed).
+  let dueNowTotal: [Instrument: Decimal]
+
+  /// Overdue + next-7-days rows, ascending by `dueDate`, capped at the
+  /// caller's `maxRows`. Use `upcomingTotalInRange` for the un-capped count.
+  let upcomingRows: [Row]
+
+  /// Total number of overdue+next-7-days rows the query found, even when
+  /// `upcomingRows` was truncated to `maxRows`.
+  let upcomingTotalInRange: Int
+}
+```
+
+### Step 5: `UpcomingWidgetQuery` — tests first
+
+- [ ] **Step 5.1: Failing tests — `MoolahTests/Widgets/UpcomingWidgetQueryTests.swift`**
+
+These tests build a minimal `data.sqlite` directly via GRDB to avoid taking a dependency on the full repository machinery. The widget query is intentionally schema-light: it reads from the `transaction` table (or whatever the GRDB phase-B schema names it) and aggregates the leg amounts. **Before writing this file, read** `Backends/GRDB/Schema/` to confirm the actual table + column names; the snippets below use placeholders `transaction` / `transaction_leg` that the implementer must reconcile with the live schema.
+
+```swift
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+@Suite("UpcomingWidgetQuery")
+struct UpcomingWidgetQueryTests {
+
+  // MARK: fixtures
+
+  private static let calendar: Calendar = {
+    var cal = Calendar(identifier: .gregorian)
+    cal.timeZone = TimeZone(identifier: "UTC")!
+    return cal
+  }()
+
+  private struct Fixture {
+    let dbURL: URL
+    let profile: WidgetProfileSummary
+    let now: Date
+    let cleanup: () -> Void
+  }
+
+  private func makeFixture(rows: [(daysFromToday: Int, payee: String, amount: Decimal)]) throws
+    -> Fixture
+  {
+    let tmp = FileManager.default.temporaryDirectory
+      .appendingPathComponent("uwq-\(UUID().uuidString).sqlite")
+    let now = Self.calendar.startOfDay(for: Date(timeIntervalSince1970: 1_780_000_000))
+
+    let queue = try DatabaseQueue(path: tmp.path)
+    try queue.write { db in
+      // NOTE: column / table names below MUST match the live GRDB schema in
+      // Backends/GRDB/Schema/. The implementer reads that file when this
+      // test is unblocked. If the live schema differs, update both this
+      // seed AND the query SQL in UpcomingWidgetQuery accordingly.
+      try db.execute(sql: """
+        CREATE TABLE transaction_record (
+          id TEXT PRIMARY KEY,
+          date REAL NOT NULL,
+          payee TEXT,
+          is_scheduled INTEGER NOT NULL,
+          is_hidden INTEGER NOT NULL DEFAULT 0,
+          recur_period TEXT
+        ) STRICT
+      """)
+      try db.execute(sql: """
+        CREATE TABLE transaction_leg (
+          id TEXT PRIMARY KEY,
+          transaction_id TEXT NOT NULL REFERENCES transaction_record(id),
+          quantity TEXT NOT NULL,
+          instrument_code TEXT NOT NULL
+        ) STRICT
+      """)
+      try db.execute(sql: "CREATE INDEX ix_txn_scheduled_date ON transaction_record(is_scheduled, date)")
+
+      for (offset, payee, amount) in rows {
+        let date = Self.calendar.date(byAdding: .day, value: offset, to: now)!
+        let txID = UUID().uuidString
+        try db.execute(
+          sql: """
+            INSERT INTO transaction_record(id, date, payee, is_scheduled, is_hidden, recur_period)
+            VALUES (?, ?, ?, 1, 0, 'MONTH')
+          """,
+          arguments: [txID, date.timeIntervalSinceReferenceDate, payee])
+        try db.execute(
+          sql: """
+            INSERT INTO transaction_leg(id, transaction_id, quantity, instrument_code)
+            VALUES (?, ?, ?, ?)
+          """,
+          arguments: [UUID().uuidString, txID, "\(amount)", "AUD"])
+      }
+    }
+
+    return Fixture(
+      dbURL: tmp,
+      profile: WidgetProfileSummary(id: UUID(), label: "Test", currency: "AUD"),
+      now: now,
+      cleanup: { try? FileManager.default.removeItem(at: tmp) })
+  }
+
+  // MARK: behaviours
+
+  @Test("empty profile → dueNowCount == 0 and no rows")
+  func emptyProfile() async throws {
+    let fx = try makeFixture(rows: [])
+    defer { fx.cleanup() }
+
+    let snapshot = try await UpcomingWidgetQuery.read(
+      profile: fx.profile,
+      profileDatabaseURL: fx.dbURL,
+      asOf: fx.now,
+      calendar: Self.calendar,
+      maxRows: 5)
+    #expect(snapshot.dueNowCount == 0)
+    #expect(snapshot.upcomingRows.isEmpty)
+    #expect(snapshot.dueNowTotal.isEmpty)
+    #expect(snapshot.upcomingTotalInRange == 0)
+  }
+
+  @Test("overdue rows count toward dueNowCount and appear first in upcomingRows")
+  func overdueRowsCountAndOrder() async throws {
+    let fx = try makeFixture(rows: [
+      (-3, "Origin Energy", Decimal(-184.20)),
+      (-1, "Foxtel", Decimal(-95.00)),
+      (0, "Netflix", Decimal(-22.99)),
+      (2, "Council", Decimal(-412.00)),
+    ])
+    defer { fx.cleanup() }
+
+    let snapshot = try await UpcomingWidgetQuery.read(
+      profile: fx.profile,
+      profileDatabaseURL: fx.dbURL,
+      asOf: fx.now,
+      calendar: Self.calendar,
+      maxRows: 5)
+    #expect(snapshot.dueNowCount == 3)  // overdue + today
+    #expect(snapshot.upcomingRows.map(\.payee) == ["Origin Energy", "Foxtel", "Netflix", "Council"])
+  }
+
+  @Test("rows beyond 7 days are excluded")
+  func beyondHorizonExcluded() async throws {
+    let fx = try makeFixture(rows: [
+      (3, "Near", Decimal(-10)),
+      (8, "Far", Decimal(-99)),
+    ])
+    defer { fx.cleanup() }
+
+    let snapshot = try await UpcomingWidgetQuery.read(
+      profile: fx.profile,
+      profileDatabaseURL: fx.dbURL,
+      asOf: fx.now,
+      calendar: Self.calendar,
+      maxRows: 5)
+    #expect(snapshot.upcomingRows.map(\.payee) == ["Near"])
+    #expect(snapshot.upcomingTotalInRange == 1)
+  }
+
+  @Test("rows are capped at maxRows; upcomingTotalInRange reflects the un-capped count")
+  func cappedAtMaxRows() async throws {
+    let fx = try makeFixture(rows: (0..<8).map { i in
+      (i, "Item \(i)", Decimal(-Double(i + 1)))
+    })
+    defer { fx.cleanup() }
+
+    let snapshot = try await UpcomingWidgetQuery.read(
+      profile: fx.profile,
+      profileDatabaseURL: fx.dbURL,
+      asOf: fx.now,
+      calendar: Self.calendar,
+      maxRows: 5)
+    #expect(snapshot.upcomingRows.count == 5)
+    #expect(snapshot.upcomingTotalInRange == 8)
+  }
+
+  @Test("hidden transactions are excluded")
+  func hiddenExcluded() async throws {
+    let fx = try makeFixture(rows: [(0, "Today", Decimal(-50))])
+    defer { fx.cleanup() }
+    // Mark the row hidden in-place.
+    let queue = try DatabaseQueue(path: fx.dbURL.path)
+    try queue.write { db in
+      try db.execute(sql: "UPDATE transaction_record SET is_hidden = 1")
+    }
+
+    let snapshot = try await UpcomingWidgetQuery.read(
+      profile: fx.profile,
+      profileDatabaseURL: fx.dbURL,
+      asOf: fx.now,
+      calendar: Self.calendar,
+      maxRows: 5)
+    #expect(snapshot.dueNowCount == 0)
+    #expect(snapshot.upcomingRows.isEmpty)
+  }
+
+  @Test("positive amounts (refunds) preserve their sign in the row")
+  func signPreserved() async throws {
+    let fx = try makeFixture(rows: [(0, "Refund", Decimal(35.00))])
+    defer { fx.cleanup() }
+
+    let snapshot = try await UpcomingWidgetQuery.read(
+      profile: fx.profile,
+      profileDatabaseURL: fx.dbURL,
+      asOf: fx.now,
+      calendar: Self.calendar,
+      maxRows: 5)
+    let row = try #require(snapshot.upcomingRows.first)
+    #expect(row.amount == Decimal(35.00))
+  }
+
+  @Test("missing DB throws profileDatabaseUnavailable")
+  func missingDBThrows() async {
+    let fx = WidgetProfileSummary(id: UUID(), label: "X", currency: "AUD")
+    await #expect(throws: UpcomingWidgetQuery.QueryError.profileDatabaseUnavailable) {
+      _ = try await UpcomingWidgetQuery.read(
+        profile: fx,
+        profileDatabaseURL: URL(fileURLWithPath: "/tmp/no-such-\(UUID().uuidString).sqlite"),
+        asOf: Date(),
+        calendar: Self.calendar,
+        maxRows: 5)
+    }
+  }
+}
+```
+
+- [ ] **Step 5.2: Run — verify failing**
+
+```bash
+just test-mac UpcomingWidgetQueryTests 2>&1 | tee .agent-tmp/uwq-tests.txt
+```
+
+Expected: build fails — `UpcomingWidgetQuery` undefined.
+
+- [ ] **Step 5.3: Create `Shared/Widgets/UpcomingWidgetQuery.swift`**
+
+**Before writing**, open `Backends/GRDB/Schema/` and confirm the live table / column names for scheduled transactions. The SQL below uses the same placeholder names (`transaction_record`, `transaction_leg`, `is_scheduled`, `is_hidden`, `quantity`, `instrument_code`) that the tests seed; reconcile them to the live schema in one pass.
+
+```swift
+import Foundation
+import GRDB
+import OSLog
+
+/// Read-only query that produces an `UpcomingWidgetSnapshot` for a profile.
+/// Opens `data.sqlite` with `readonly = true`, runs two focused SELECTs
+/// inside one `db.read`, and closes the queue before returning.
+enum UpcomingWidgetQuery {
+
+  enum QueryError: Error, Equatable, Sendable {
+    case profileDatabaseUnavailable
+  }
+
+  private static let logger = Logger(subsystem: "com.moolah.app", category: "Widgets")
+
+  @WidgetActor
+  static func read(
+    profile: WidgetProfileSummary,
+    profileDatabaseURL: URL,
+    asOf now: Date = Date(),
+    calendar: Calendar = .current,
+    maxRows: Int = 5
+  ) throws -> UpcomingWidgetSnapshot {
+    guard FileManager.default.fileExists(atPath: profileDatabaseURL.path) else {
+      throw QueryError.profileDatabaseUnavailable
+    }
+    var configuration = Configuration()
+    configuration.readonly = true
+    configuration.busyMode = .timeout(0.2)
+
+    let queue: DatabaseQueue
+    do {
+      queue = try DatabaseQueue(path: profileDatabaseURL.path, configuration: configuration)
+    } catch {
+      logger.warning("Could not open profile DB for widget: \(error.localizedDescription, privacy: .public)")
+      throw QueryError.profileDatabaseUnavailable
+    }
+    defer { _ = try? queue.close() }
+
+    let startOfToday = calendar.startOfDay(for: now)
+    let startOfTomorrow = calendar.date(byAdding: .day, value: 1, to: startOfToday)!
+    let horizonEnd = calendar.date(byAdding: .day, value: 7, to: startOfToday)!
+
+    return try queue.read { db in
+      let upcomingRows = try fetchRows(
+        db: db,
+        upperBound: horizonEnd,
+        limit: maxRows)
+      let totalInRange = try fetchCount(
+        db: db,
+        lowerBound: nil,
+        upperBound: horizonEnd)
+      let dueNowCount = try fetchCount(
+        db: db,
+        lowerBound: nil,
+        upperBound: startOfTomorrow)
+      let dueNowTotal = try fetchTotals(
+        db: db,
+        upperBound: startOfTomorrow)
+      return UpcomingWidgetSnapshot(
+        profileID: profile.id,
+        profileLabel: profile.label,
+        profileCurrency: profile.currency,
+        asOf: startOfToday,
+        dueNowCount: dueNowCount,
+        dueNowTotal: dueNowTotal,
+        upcomingRows: upcomingRows,
+        upcomingTotalInRange: totalInRange)
+    }
+  }
+
+  // MARK: SQL
+
+  private static func fetchRows(db: Database, upperBound: Date, limit: Int) throws
+    -> [UpcomingWidgetSnapshot.Row]
+  {
+    let rows = try Row.fetchAll(
+      db,
+      sql: """
+        SELECT t.id AS id, t.date AS date, t.payee AS payee,
+               SUM(CAST(l.quantity AS REAL)) AS amount,
+               MIN(l.instrument_code) AS instrument_code
+        FROM transaction_record t
+        JOIN transaction_leg l ON l.transaction_id = t.id
+        WHERE t.is_scheduled = 1
+          AND t.is_hidden = 0
+          AND t.date < ?
+        GROUP BY t.id
+        ORDER BY t.date ASC
+        LIMIT ?
+      """,
+      arguments: [upperBound.timeIntervalSinceReferenceDate, limit])
+    return rows.compactMap { row -> UpcomingWidgetSnapshot.Row? in
+      guard
+        let idString: String = row["id"],
+        let id = UUID(uuidString: idString),
+        let payee: String = row["payee"],
+        let dateRaw: Double = row["date"],
+        let amountRaw: Double = row["amount"],
+        let instrumentCode: String = row["instrument_code"]
+      else {
+        return nil
+      }
+      return UpcomingWidgetSnapshot.Row(
+        id: id,
+        payee: payee,
+        dueDate: Date(timeIntervalSinceReferenceDate: dateRaw),
+        amount: Decimal(amountRaw),
+        instrument: Instrument(code: instrumentCode))
+    }
+  }
+
+  private static func fetchCount(db: Database, lowerBound: Date?, upperBound: Date) throws -> Int {
+    let sql = """
+      SELECT COUNT(*)
+      FROM transaction_record t
+      WHERE t.is_scheduled = 1
+        AND t.is_hidden = 0
+        AND t.date < ?
+    """
+    return try Int.fetchOne(db, sql: sql, arguments: [upperBound.timeIntervalSinceReferenceDate])
+      ?? 0
+  }
+
+  private static func fetchTotals(db: Database, upperBound: Date) throws
+    -> [Instrument: Decimal]
+  {
+    let rows = try Row.fetchAll(
+      db,
+      sql: """
+        SELECT l.instrument_code AS instrument_code,
+               SUM(CAST(l.quantity AS REAL)) AS total
+        FROM transaction_record t
+        JOIN transaction_leg l ON l.transaction_id = t.id
+        WHERE t.is_scheduled = 1
+          AND t.is_hidden = 0
+          AND t.date < ?
+        GROUP BY l.instrument_code
+      """,
+      arguments: [upperBound.timeIntervalSinceReferenceDate])
+    var result: [Instrument: Decimal] = [:]
+    for row in rows {
+      guard
+        let code: String = row["instrument_code"],
+        let total: Double = row["total"]
+      else { continue }
+      result[Instrument(code: code)] = Decimal(total)
+    }
+    return result
+  }
+}
+```
+
+If `Instrument` does not have a `init(code: String)` initialiser (it may construct from a richer enum or registry), use whichever factory the project provides — see `Domain/Models/Instrument.swift`. The semantic requirement is "round-trip an `instrument_code` string column from `data.sqlite` into an `Instrument` value". Update the test fixture's `instrument_code` insert to match if needed.
+
+- [ ] **Step 5.4: Run — verify pass**
+
+```bash
+just test-mac UpcomingWidgetQueryTests 2>&1 | tee .agent-tmp/uwq-tests.txt
+```
+
+Expected: all seven tests pass.
+
+### Step 6: Plan-pinning test
+
+- [ ] **Step 6.1: Create `MoolahTests/Widgets/UpcomingWidgetQueryPlanPinningTests.swift`**
+
+```swift
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+@Suite("UpcomingWidgetQuery query plans")
+struct UpcomingWidgetQueryPlanPinningTests {
+
+  private func makeSeededDB() throws -> URL {
+    let tmp = FileManager.default.temporaryDirectory
+      .appendingPathComponent("uwq-plan-\(UUID().uuidString).sqlite")
+    let queue = try DatabaseQueue(path: tmp.path)
+    try queue.write { db in
+      try db.execute(sql: """
+        CREATE TABLE transaction_record (
+          id TEXT PRIMARY KEY,
+          date REAL NOT NULL,
+          payee TEXT,
+          is_scheduled INTEGER NOT NULL,
+          is_hidden INTEGER NOT NULL DEFAULT 0,
+          recur_period TEXT
+        ) STRICT
+      """)
+      try db.execute(sql: """
+        CREATE TABLE transaction_leg (
+          id TEXT PRIMARY KEY,
+          transaction_id TEXT NOT NULL REFERENCES transaction_record(id),
+          quantity TEXT NOT NULL,
+          instrument_code TEXT NOT NULL
+        ) STRICT
+      """)
+      try db.execute(sql: "CREATE INDEX ix_txn_scheduled_date ON transaction_record(is_scheduled, date)")
+      try db.execute(sql: "ANALYZE")
+    }
+    return tmp
+  }
+
+  @Test("upcoming-rows SELECT uses the scheduled+date index")
+  func upcomingRowsUsesIndex() throws {
+    let url = try makeSeededDB()
+    defer { try? FileManager.default.removeItem(at: url) }
+    let queue = try DatabaseQueue(path: url.path)
+    let plan = try queue.read { db -> String in
+      try String.fetchAll(db, sql: """
+        EXPLAIN QUERY PLAN
+        SELECT t.id, t.date, t.payee, SUM(l.quantity), MIN(l.instrument_code)
+        FROM transaction_record t
+        JOIN transaction_leg l ON l.transaction_id = t.id
+        WHERE t.is_scheduled = 1 AND t.is_hidden = 0 AND t.date < 0
+        GROUP BY t.id
+        ORDER BY t.date ASC
+        LIMIT 5
+        """).joined(separator: "\n")
+    }
+    #expect(plan.contains("ix_txn_scheduled_date") || plan.contains("USING INDEX"))
+  }
+
+  @Test("count SELECT uses the same index")
+  func countUsesIndex() throws {
+    let url = try makeSeededDB()
+    defer { try? FileManager.default.removeItem(at: url) }
+    let queue = try DatabaseQueue(path: url.path)
+    let plan = try queue.read { db -> String in
+      try String.fetchAll(db, sql: """
+        EXPLAIN QUERY PLAN
+        SELECT COUNT(*)
+        FROM transaction_record t
+        WHERE t.is_scheduled = 1 AND t.is_hidden = 0 AND t.date < 0
+        """).joined(separator: "\n")
+    }
+    #expect(plan.contains("ix_txn_scheduled_date") || plan.contains("USING INDEX"))
+  }
+}
+```
+
+- [ ] **Step 6.2: Run — verify pass**
+
+```bash
+just test-mac UpcomingWidgetQueryPlanPinningTests 2>&1 | tee .agent-tmp/plan-tests.txt
+```
+
+Expected: both tests pass. If a plan shows `SCAN` instead of `SEARCH USING INDEX`, the live schema is missing the index — add it to the GRDB schema in `Backends/GRDB/Schema/` (per `guides/DATABASE_SCHEMA_GUIDE.md`).
+
+### Step 7: Snapshot-format tests
+
+- [ ] **Step 7.1: Create `MoolahTests/Widgets/UpcomingWidgetSnapshotFormatTests.swift`**
+
+```swift
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("UpcomingWidgetSnapshot formatters")
+struct UpcomingWidgetSnapshotFormatTests {
+
+  @Test("singleInstrumentAmount returns the sole entry when there is one")
+  func single() {
+    let snap = makeSnapshot(totals: [Instrument(code: "AUD"): Decimal(-224.19)])
+    let result = SmallWidgetTotalRenderer.text(for: snap)
+    #expect(result == InstrumentAmount(quantity: Decimal(-224.19), instrument: Instrument(code: "AUD")).formatted)
+  }
+
+  @Test("when multiple instruments present and profile currency is among them, render that one with ellipsis")
+  func multipleWithProfileCurrency() {
+    let totals: [Instrument: Decimal] = [
+      Instrument(code: "AUD"): Decimal(-100),
+      Instrument(code: "USD"): Decimal(-50),
+    ]
+    let snap = makeSnapshot(profileCurrency: "AUD", totals: totals)
+    let result = SmallWidgetTotalRenderer.text(for: snap)
+    #expect(result.contains("…"))
+    #expect(result.contains("AUD") || result.contains("$"))
+  }
+
+  @Test("when multiple instruments present and none match profile currency, render Multiple currencies")
+  func multipleWithoutProfileCurrency() {
+    let totals: [Instrument: Decimal] = [
+      Instrument(code: "BTC"): Decimal(-0.001),
+      Instrument(code: "ETH"): Decimal(-0.02),
+    ]
+    let snap = makeSnapshot(profileCurrency: "AUD", totals: totals)
+    let result = SmallWidgetTotalRenderer.text(for: snap)
+    #expect(result == "Multiple currencies")
+  }
+
+  @Test("empty totals renders Nothing due today")
+  func empty() {
+    let snap = makeSnapshot(totals: [:])
+    let result = SmallWidgetTotalRenderer.text(for: snap)
+    #expect(result == "Nothing due today")
+  }
+
+  // MARK: helper
+
+  private func makeSnapshot(
+    profileCurrency: String = "AUD",
+    totals: [Instrument: Decimal]
+  ) -> UpcomingWidgetSnapshot {
+    UpcomingWidgetSnapshot(
+      profileID: UUID(),
+      profileLabel: "Test",
+      profileCurrency: profileCurrency,
+      asOf: Date(),
+      dueNowCount: totals.isEmpty ? 0 : 1,
+      dueNowTotal: totals,
+      upcomingRows: [],
+      upcomingTotalInRange: 0)
+  }
+}
+```
+
+- [ ] **Step 7.2: Create `Shared/Widgets/SmallWidgetTotalRenderer.swift`**
+
+```swift
+import Foundation
+
+/// Pure renderer for the small widget's total line. Extracted from
+/// `UpcomingCountView` so it can be unit-tested without SwiftUI.
+enum SmallWidgetTotalRenderer {
+  static func text(for snapshot: UpcomingWidgetSnapshot) -> String {
+    let totals = snapshot.dueNowTotal
+    if totals.isEmpty {
+      return "Nothing due today"
+    }
+    if totals.count == 1, let (instrument, amount) = totals.first {
+      return InstrumentAmount(quantity: amount, instrument: instrument).formatted
+    }
+    let profileInstrument = Instrument(code: snapshot.profileCurrency)
+    if let amount = totals[profileInstrument] {
+      return InstrumentAmount(quantity: amount, instrument: profileInstrument).formatted + " …"
+    }
+    return "Multiple currencies"
+  }
+}
+```
+
+- [ ] **Step 7.3: Run — verify pass**
+
+```bash
+just test-mac UpcomingWidgetSnapshotFormatTests 2>&1 | tee .agent-tmp/snap-format-tests.txt
+```
+
+Expected: all four tests pass.
+
+### Step 8: Full gate + commit
+
+- [ ] **Step 8.1: Run gates**
+
+```bash
+just format-check
+just test-mac
+just test-ios
+```
+
+- [ ] **Step 8.2: Commit**
+
+```bash
+git add Shared/Widgets/ MoolahTests/Widgets/
+git commit -m "$(cat <<'EOF'
+feat(widgets): add read-only query layer (no extension target yet)
+
+UpcomingWidgetQuery opens the per-profile data.sqlite read-only via GRDB
+and returns an UpcomingWidgetSnapshot. WidgetProfileDirectory enumerates
+profiles from the profile-index DB. SmallWidgetTotalRenderer is the
+pure formatter for the small widget's total line.
+
+Plan-pinning tests confirm both SELECTs use the scheduled+date index.
+No extension target yet — every file is consumed by the host for now.
+EOF
+)"
+```
+
+---
+
+## Task 3: `MoolahWidgets` extension target — scaffolding
+
+**Files:**
+- Modify: `project.yml`
+- Create: `MoolahWidgets/MoolahWidgetsBundle.swift`
+- Create: `MoolahWidgets/Info.plist`
+- Create: `MoolahWidgets/MoolahWidgets-Debug.entitlements`
+- Create: `MoolahWidgets/MoolahWidgets-Release.entitlements`
+- Create: `MoolahWidgets/Intents/WidgetProfileSelectionIntent.swift`
+- Create: `MoolahWidgets/Intents/WidgetProfileEntity.swift`
+- Create: `MoolahWidgets/Views/WidgetEmptyStateView.swift`
+- Create: `MoolahWidgets/Placeholders.swift` (temporary — both widgets defined as no-op placeholders)
+
+End-state: `just build-mac` and `just build-ios` produce an app that embeds an empty widget bundle. The widget shows up in the "Add widget" picker on both platforms, but its only content is a placeholder.
+
+### Step 1: Extension target in `project.yml`
+
+- [ ] **Step 1.1: Add `MoolahWidgets_iOS` target to `project.yml`**
+
+Append, immediately after `MoolahUITests_macOS:`:
+
+```yaml
+  MoolahWidgets_iOS:
+    type: app-extension
+    platform: iOS
+    sources:
+      - path: MoolahWidgets
+      - path: Shared/Widgets
+      - path: Domain/Models
+    dependencies:
+      - sdk: WidgetKit.framework
+      - sdk: SwiftUI.framework
+      - sdk: AppIntents.framework
+      - package: GRDB
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: rocks.moolah.app.widgets
+        PRODUCT_NAME: MoolahWidgets
+        INFOPLIST_FILE: MoolahWidgets/Info.plist
+        SWIFT_VERSION: "6.0"
+        APPLICATION_EXTENSION_API_ONLY: YES
+      configs:
+        Debug:
+          APP_GROUP_ID: group.rocks.moolah.app.test
+          CODE_SIGN_ENTITLEMENTS: MoolahWidgets/MoolahWidgets-Debug.entitlements
+        Debug-Tests:
+          APP_GROUP_ID: group.rocks.moolah.app.test
+          CODE_SIGN_ENTITLEMENTS: ""
+        Release:
+          APP_GROUP_ID: group.rocks.moolah.app.v2
+          CODE_SIGN_ENTITLEMENTS: MoolahWidgets/MoolahWidgets-Release.entitlements
+          CODE_SIGN_STYLE: Manual
+          CODE_SIGN_IDENTITY: Apple Distribution
+          PROVISIONING_PROFILE_SPECIFIER: ${IOS_WIDGETS_PROVISIONING_PROFILE}
+```
+
+- [ ] **Step 1.2: Add `MoolahWidgets_macOS` target**
+
+Immediately after `MoolahWidgets_iOS:`:
+
+```yaml
+  MoolahWidgets_macOS:
+    type: app-extension
+    platform: macOS
+    sources:
+      - path: MoolahWidgets
+      - path: Shared/Widgets
+      - path: Domain/Models
+    dependencies:
+      - sdk: WidgetKit.framework
+      - sdk: SwiftUI.framework
+      - sdk: AppIntents.framework
+      - package: GRDB
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: rocks.moolah.app.widgets
+        PRODUCT_NAME: MoolahWidgets
+        INFOPLIST_FILE: MoolahWidgets/Info.plist
+        SWIFT_VERSION: "6.0"
+        APPLICATION_EXTENSION_API_ONLY: YES
+        ENABLE_HARDENED_RUNTIME: YES
+      configs:
+        Debug:
+          APP_GROUP_ID: group.rocks.moolah.app.test
+          CODE_SIGN_ENTITLEMENTS: MoolahWidgets/MoolahWidgets-Debug.entitlements
+        Debug-Tests:
+          APP_GROUP_ID: group.rocks.moolah.app.test
+          CODE_SIGN_ENTITLEMENTS: ""
+        Release:
+          APP_GROUP_ID: group.rocks.moolah.app.v2
+          CODE_SIGN_ENTITLEMENTS: MoolahWidgets/MoolahWidgets-Release.entitlements
+          CODE_SIGN_STYLE: Manual
+          CODE_SIGN_IDENTITY: Developer ID Application
+          PROVISIONING_PROFILE_SPECIFIER: ${MAC_WIDGETS_PROVISIONING_PROFILE}
+```
+
+- [ ] **Step 1.3: Embed the widget extensions in the host apps**
+
+Under `Moolah_iOS.dependencies`, add:
+
+```yaml
+      - target: MoolahWidgets_iOS
+        embed: true
+        codeSign: true
+```
+
+Under `Moolah_macOS.dependencies`, add:
+
+```yaml
+      - target: MoolahWidgets_macOS
+        embed: true
+        codeSign: true
+```
+
+- [ ] **Step 1.4: Run `just generate`**
+
+```bash
+just generate
+```
+
+Expected: completes without error.
+
+### Step 2: Info.plist and entitlements files
+
+- [ ] **Step 2.1: Create `MoolahWidgets/Info.plist`**
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDisplayName</key>
+    <string>Moolah</string>
+    <key>CFBundleExecutable</key>
+    <string>$(EXECUTABLE_NAME)</string>
+    <key>CFBundleIdentifier</key>
+    <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+    <key>CFBundleName</key>
+    <string>$(PRODUCT_NAME)</string>
+    <key>CFBundlePackageType</key>
+    <string>XPC!</string>
+    <key>CFBundleShortVersionString</key>
+    <string>$(MARKETING_VERSION)</string>
+    <key>CFBundleVersion</key>
+    <string>$(CURRENT_PROJECT_VERSION)</string>
+    <key>NSExtension</key>
+    <dict>
+        <key>NSExtensionPointIdentifier</key>
+        <string>com.apple.widgetkit-extension</string>
+    </dict>
+    <key>MoolahAppGroupIdentifier</key>
+    <string>$(APP_GROUP_ID)</string>
+</dict>
+</plist>
+```
+
+- [ ] **Step 2.2: Create `MoolahWidgets/MoolahWidgets-Debug.entitlements`**
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.app-sandbox</key>
+    <true/>
+    <key>com.apple.security.application-groups</key>
+    <array>
+        <string>group.rocks.moolah.app.test</string>
+    </array>
+</dict>
+</plist>
+```
+
+- [ ] **Step 2.3: Create `MoolahWidgets/MoolahWidgets-Release.entitlements`**
+
+Same shape, identifier is `group.rocks.moolah.app.v2`.
+
+### Step 3: `WidgetProfileEntity`
+
+- [ ] **Step 3.1: Create `MoolahWidgets/Intents/WidgetProfileEntity.swift`**
+
+```swift
+import AppIntents
+import Foundation
+
+/// Extension-local entity for the widget configuration intent. Distinct from
+/// the host's `Automation/Intents/Entities/ProfileEntity` (which depends on
+/// `AutomationServiceLocator.shared` and so cannot be queried from the
+/// widget extension process).
+struct WidgetProfileEntity: AppEntity {
+  static let typeDisplayRepresentation = TypeDisplayRepresentation(name: "Profile")
+  static let defaultQuery = WidgetProfileQuery()
+
+  let id: UUID
+  let label: String
+  let currency: String
+
+  var displayRepresentation: DisplayRepresentation {
+    DisplayRepresentation(title: "\(label)", subtitle: "\(currency)")
+  }
+}
+
+struct WidgetProfileQuery: EntityQuery {
+  func entities(for identifiers: [WidgetProfileEntity.ID]) async throws -> [WidgetProfileEntity] {
+    try listAll().filter { identifiers.contains($0.id) }
+  }
+
+  func suggestedEntities() async throws -> [WidgetProfileEntity] {
+    try listAll()
+  }
+
+  private func listAll() throws -> [WidgetProfileEntity] {
+    let scoped = WidgetDataPath.scopedRoot()
+    let indexURL = WidgetDataPath.profileIndexDatabaseURL(scopedRoot: scoped)
+    return try WidgetProfileDirectory.list(profileIndexURL: indexURL).map {
+      WidgetProfileEntity(id: $0.id, label: $0.label, currency: $0.currency)
+    }
+  }
+}
+```
+
+### Step 4: `WidgetProfileSelectionIntent`
+
+- [ ] **Step 4.1: Create `MoolahWidgets/Intents/WidgetProfileSelectionIntent.swift`**
+
+```swift
+import AppIntents
+
+struct WidgetProfileSelectionIntent: WidgetConfigurationIntent {
+  static let title: LocalizedStringResource = "Pick a profile"
+  static let description = IntentDescription("Choose which Moolah profile this widget shows.")
+
+  @Parameter(title: "Profile") var profile: WidgetProfileEntity?
+}
+```
+
+### Step 5: Shared empty-state view
+
+- [ ] **Step 5.1: Create `MoolahWidgets/Views/WidgetEmptyStateView.swift`**
+
+```swift
+import SwiftUI
+
+struct WidgetEmptyStateView: View {
+  let title: String
+  let subtitle: String?
+
+  var body: some View {
+    VStack(alignment: .center, spacing: 4) {
+      Text(title)
+        .font(.headline)
+      if let subtitle {
+        Text(subtitle)
+          .font(.caption)
+          .foregroundStyle(.secondary)
+      }
+    }
+    .multilineTextAlignment(.center)
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+  }
+}
+```
+
+### Step 6: Bundle + placeholder widgets
+
+- [ ] **Step 6.1: Create `MoolahWidgets/Placeholders.swift`**
+
+```swift
+import SwiftUI
+import WidgetKit
+
+/// Temporary placeholder definitions so the widget bundle compiles before
+/// the real widgets land in Tasks 4 and 5. Each placeholder ships with the
+/// final widget kind string so a user who adds the widget in this stepping
+/// stone build will not lose their slot when the real widgets replace it.
+struct PlaceholderUpcomingListWidget: Widget {
+  static let kind = "rocks.moolah.widget.upcoming-list"
+
+  var body: some WidgetConfiguration {
+    AppIntentConfiguration(
+      kind: Self.kind,
+      intent: WidgetProfileSelectionIntent.self,
+      provider: PlaceholderProvider()
+    ) { _ in
+      WidgetEmptyStateView(title: "Upcoming", subtitle: "Coming soon")
+    }
+    .configurationDisplayName("Upcoming")
+    .description("Scheduled transactions for one of your profiles.")
+    .supportedFamilies([.systemMedium])
+  }
+}
+
+struct PlaceholderUpcomingCountWidget: Widget {
+  static let kind = "rocks.moolah.widget.upcoming-count"
+
+  var body: some WidgetConfiguration {
+    AppIntentConfiguration(
+      kind: Self.kind,
+      intent: WidgetProfileSelectionIntent.self,
+      provider: PlaceholderProvider()
+    ) { _ in
+      WidgetEmptyStateView(title: "Due", subtitle: "Coming soon")
+    }
+    .configurationDisplayName("Due today")
+    .description("How many scheduled transactions need your attention.")
+    .supportedFamilies([.systemSmall])
+  }
+}
+
+private struct PlaceholderProvider: AppIntentTimelineProvider {
+  func placeholder(in context: Context) -> PlaceholderEntry { PlaceholderEntry(date: Date()) }
+
+  func snapshot(for configuration: WidgetProfileSelectionIntent, in context: Context) async
+    -> PlaceholderEntry
+  {
+    PlaceholderEntry(date: Date())
+  }
+
+  func timeline(for configuration: WidgetProfileSelectionIntent, in context: Context) async
+    -> Timeline<PlaceholderEntry>
+  {
+    Timeline(entries: [PlaceholderEntry(date: Date())], policy: .never)
+  }
+}
+
+private struct PlaceholderEntry: TimelineEntry { let date: Date }
+```
+
+- [ ] **Step 6.2: Create `MoolahWidgets/MoolahWidgetsBundle.swift`**
+
+```swift
+import SwiftUI
+import WidgetKit
+
+@main
+struct MoolahWidgetsBundle: WidgetBundle {
+  var body: some Widget {
+    PlaceholderUpcomingListWidget()
+    PlaceholderUpcomingCountWidget()
+  }
+}
+```
+
+### Step 7: Builds + full gate + commit
+
+- [ ] **Step 7.1: Build both hosts**
+
+```bash
+just build-mac 2>&1 | tee .agent-tmp/build-mac.txt
+just build-ios 2>&1 | tee .agent-tmp/build-ios.txt
+```
+
+Expected: both succeed; the widget bundle is embedded in both products. If signing complains for a local Debug build, double-check the entitlements file path is set on the `Debug` config (Release entitlements are only consumed by fastlane).
+
+- [ ] **Step 7.2: Gates + commit**
+
+```bash
+just format-check
+just test-mac
+just test-ios
+
+git add project.yml MoolahWidgets/
+git commit -m "$(cat <<'EOF'
+feat(widgets): scaffold MoolahWidgets extension bundle
+
+Adds MoolahWidgets_iOS + MoolahWidgets_macOS extension targets, embedded
+in their respective host apps. The bundle currently ships two placeholder
+widgets registered under their final kind strings so users who add them
+in this stepping-stone build do not lose their slot when the real
+widgets replace the placeholders in subsequent commits.
+
+WidgetProfileEntity + WidgetProfileSelectionIntent are wired up against
+WidgetDataPath / WidgetProfileDirectory so the configuration sheet
+already lists real profiles.
+EOF
+)"
+```
+
+---
+
+## Task 4: `UpcomingTransactionsListWidget` — the medium widget
+
+**Files:**
+- Create: `MoolahWidgets/UpcomingTransactionsListWidget.swift`
+- Create: `MoolahWidgets/Views/UpcomingListView.swift`
+- Create: `MoolahWidgets/Views/UpcomingRowView.swift`
+- Create: `MoolahWidgets/Intents/OpenTransactionFromWidgetIntent.swift`
+- Delete: `MoolahWidgets/Placeholders.swift` — `PlaceholderUpcomingListWidget` only. Keep the small-widget placeholder until Task 5.
+- Modify: `MoolahWidgets/MoolahWidgetsBundle.swift` — replace `PlaceholderUpcomingListWidget()` with `UpcomingTransactionsListWidget()`.
+- Create: `MoolahTests/Widgets/OpenTransactionFromWidgetIntentTests.swift`
+
+### Step 1: `OpenTransactionFromWidgetIntent` — TDD
+
+- [ ] **Step 1.1: Failing test — `MoolahTests/Widgets/OpenTransactionFromWidgetIntentTests.swift`**
+
+```swift
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("OpenTransactionFromWidgetIntent")
+@MainActor
+struct OpenTransactionFromWidgetIntentTests {
+
+  private struct Recorded {
+    var openedProfile: UUID?
+    var pendingNavigation: PendingNavigation?
+  }
+
+  private func installFakes() -> Box<Recorded> {
+    let box = Box(Recorded())
+    NavigationBridge.openProfile = { id in box.value.openedProfile = id }
+    NavigationBridge.setPendingNavigation = { nav in box.value.pendingNavigation = nav }
+    return box
+  }
+
+  @Test("perform with a valid transaction UUID dispatches openProfile + setPendingNavigation")
+  func validTransactionDispatches() async throws {
+    let box = installFakes()
+    let profile = WidgetProfileEntity(id: UUID(), label: "Personal", currency: "AUD")
+    let txID = UUID()
+
+    let intent = OpenTransactionFromWidgetIntent()
+    intent.profile = profile
+    intent.transactionID = txID.uuidString
+    _ = try await intent.perform()
+
+    #expect(box.value.openedProfile == profile.id)
+    #expect(box.value.pendingNavigation == PendingNavigation(
+      profileId: profile.id, destination: .transaction(txID)))
+  }
+
+  @Test("perform with an invalid UUID is a silent no-op")
+  func invalidUUIDNoOp() async throws {
+    let box = installFakes()
+    let profile = WidgetProfileEntity(id: UUID(), label: "Personal", currency: "AUD")
+
+    let intent = OpenTransactionFromWidgetIntent()
+    intent.profile = profile
+    intent.transactionID = "not-a-uuid"
+    _ = try await intent.perform()
+
+    #expect(box.value.openedProfile == nil)
+    #expect(box.value.pendingNavigation == nil)
+  }
+}
+
+/// Mutable reference box used by tests to capture closure invocations.
+private final class Box<T> {
+  var value: T
+  init(_ value: T) { self.value = value }
+}
+```
+
+> **Pattern note:** the handoff plan (Task 2) installs the same fakes; consult `MoolahTests/Automation/HandoffContinuationHandlerTests.swift` if there's a shared helper to reuse rather than re-declaring `Box`.
+
+- [ ] **Step 1.2: Run — verify failing**
+
+```bash
+just test-mac OpenTransactionFromWidgetIntentTests 2>&1 | tee .agent-tmp/open-txn-tests.txt
+```
+
+Expected: build fails — `OpenTransactionFromWidgetIntent` undefined.
+
+- [ ] **Step 1.3: Create `MoolahWidgets/Intents/OpenTransactionFromWidgetIntent.swift`**
+
+```swift
+import AppIntents
+import Foundation
+
+#if os(macOS)
+  import AppKit
+#endif
+
+struct OpenTransactionFromWidgetIntent: AppIntent {
+  static let title: LocalizedStringResource = "Open Transaction (widget)"
+  static let isDiscoverable = false
+  static let openAppWhenRun = true
+
+  @Parameter(title: "Profile") var profile: WidgetProfileEntity
+  @Parameter(title: "Transaction ID") var transactionID: String
+
+  init() {}
+
+  @MainActor
+  func perform() async throws -> some IntentResult {
+    guard let transactionUUID = UUID(uuidString: transactionID) else {
+      return .result()
+    }
+    #if os(macOS)
+      let alreadyOpen = ProfileWindowLocator.activateExistingWindow(for: profile.id)
+    #else
+      let alreadyOpen = false
+    #endif
+    if !alreadyOpen {
+      NavigationBridge.openProfile?(profile.id)
+    }
+    NavigationBridge.setPendingNavigation?(
+      PendingNavigation(profileId: profile.id, destination: .transaction(transactionUUID)))
+    return .result()
+  }
+}
+```
+
+- [ ] **Step 1.4: Run — verify pass**
+
+```bash
+just test-mac OpenTransactionFromWidgetIntentTests 2>&1 | tee .agent-tmp/open-txn-tests.txt
+```
+
+Expected: both tests pass.
+
+### Step 2: `UpcomingRowView`
+
+- [ ] **Step 2.1: Create `MoolahWidgets/Views/UpcomingRowView.swift`**
+
+```swift
+import SwiftUI
+
+/// Single row in the medium upcoming-transactions widget. Pure view —
+/// composes labels from the snapshot row and the cached "now" the parent
+/// passed in. No data access, no formatting state.
+struct UpcomingRowView: View {
+  let row: UpcomingWidgetSnapshot.Row
+  let asOf: Date
+  let calendar: Calendar
+
+  var body: some View {
+    HStack(spacing: 8) {
+      Text(relativeDateLabel)
+        .font(.caption2)
+        .foregroundStyle(dateColor)
+        .frame(width: 56, alignment: .leading)
+      Text(row.payee)
+        .font(.caption)
+        .lineLimit(1)
+        .truncationMode(.tail)
+      Spacer(minLength: 4)
+      Text(InstrumentAmount(quantity: row.amount, instrument: row.instrument).formatted)
+        .font(.caption.monospacedDigit())
+        .foregroundStyle(amountColor)
+    }
+  }
+
+  // MARK: derived
+
+  private var relativeDayOffset: Int {
+    let dueDay = calendar.startOfDay(for: row.dueDate)
+    let asOfDay = calendar.startOfDay(for: asOf)
+    return calendar.dateComponents([.day], from: asOfDay, to: dueDay).day ?? 0
+  }
+
+  private var relativeDateLabel: String {
+    let offset = relativeDayOffset
+    if offset < 0 {
+      let days = -offset
+      return days == 1 ? "1 day late" : "\(days) days late"
+    }
+    if offset == 0 { return "Today" }
+    if offset < 7 {
+      let formatter = DateFormatter()
+      formatter.calendar = calendar
+      formatter.dateFormat = "EEE"
+      return formatter.string(from: row.dueDate)
+    }
+    let formatter = DateFormatter()
+    formatter.calendar = calendar
+    formatter.dateStyle = .short
+    return formatter.string(from: row.dueDate)
+  }
+
+  private var dateColor: Color {
+    if relativeDayOffset < 0 { return .red }
+    if relativeDayOffset == 0 { return .orange }
+    return .secondary
+  }
+
+  private var amountColor: Color {
+    row.amount < 0 ? .red : .green
+  }
+}
+```
+
+### Step 3: `UpcomingListView`
+
+- [ ] **Step 3.1: Create `MoolahWidgets/Views/UpcomingListView.swift`**
+
+```swift
+import SwiftUI
+
+/// Medium widget content. Header + up to five rows. Each row is wrapped in
+/// `Button(intent:)` so it routes a tap to OpenTransactionFromWidgetIntent.
+struct UpcomingListView: View {
+  let snapshot: UpcomingWidgetSnapshot
+  let profile: WidgetProfileEntity
+  let calendar: Calendar
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 4) {
+      HStack(alignment: .firstTextBaseline) {
+        Text("Upcoming")
+          .font(.subheadline.weight(.semibold))
+        Spacer()
+        Text(profile.label)
+          .font(.caption2)
+          .foregroundStyle(.secondary)
+          .lineLimit(1)
+      }
+      if snapshot.upcomingRows.isEmpty {
+        WidgetEmptyStateView(title: "Upcoming", subtitle: "Nothing due in the next 7 days")
+      } else {
+        ForEach(snapshot.upcomingRows) { row in
+          let intent = OpenTransactionFromWidgetIntent()
+          let _ = { intent.profile = profile; intent.transactionID = row.id.uuidString }()
+          Button(intent: intent) {
+            UpcomingRowView(row: row, asOf: snapshot.asOf, calendar: calendar)
+          }
+          .buttonStyle(.plain)
+        }
+      }
+      Spacer(minLength: 0)
+    }
+    .padding(12)
+  }
+}
+```
+
+> **Note on the `let _ = { ... }()` pattern:** AppIntent parameters use property-wrapper setters that aren't usable inside a SwiftUI view-builder result builder. The IIFE assigns them as a side effect. If a cleaner approach is available in the iOS 26 SDK (e.g. a builder init), prefer that — but only after writing the row to compile.
+
+### Step 4: `UpcomingTransactionsListWidget` + timeline provider
+
+- [ ] **Step 4.1: Create `MoolahWidgets/UpcomingTransactionsListWidget.swift`**
+
+```swift
+import AppIntents
+import SwiftUI
+import WidgetKit
+
+struct UpcomingTransactionsListWidget: Widget {
+  static let kind = "rocks.moolah.widget.upcoming-list"
+
+  var body: some WidgetConfiguration {
+    AppIntentConfiguration(
+      kind: Self.kind,
+      intent: WidgetProfileSelectionIntent.self,
+      provider: Provider()
+    ) { entry in
+      ListEntryView(entry: entry)
+    }
+    .configurationDisplayName("Upcoming")
+    .description("Scheduled transactions for one of your profiles.")
+    .supportedFamilies([.systemMedium])
+  }
+
+  // MARK: - Entry
+
+  struct Entry: TimelineEntry {
+    let date: Date
+    let snapshot: UpcomingWidgetSnapshot?
+    let profile: WidgetProfileEntity?
+  }
+
+  // MARK: - Provider
+
+  struct Provider: AppIntentTimelineProvider {
+    func placeholder(in context: Context) -> Entry {
+      Entry(date: Date(), snapshot: nil, profile: nil)
+    }
+
+    func snapshot(for configuration: WidgetProfileSelectionIntent, in context: Context) async
+      -> Entry
+    {
+      await Self.build(at: Date(), for: configuration)
+    }
+
+    func timeline(for configuration: WidgetProfileSelectionIntent, in context: Context) async
+      -> Timeline<Entry>
+    {
+      let calendar = Calendar.current
+      let now = Date()
+      var entries: [Entry] = []
+      for dayOffset in 0..<5 {
+        guard let boundary = calendar.date(byAdding: .day, value: dayOffset, to: calendar.startOfDay(for: now))
+        else { continue }
+        let entry = await Self.build(at: boundary, for: configuration)
+        entries.append(entry)
+      }
+      return Timeline(entries: entries, policy: .atEnd)
+    }
+
+    private static func build(at date: Date, for configuration: WidgetProfileSelectionIntent) async
+      -> Entry
+    {
+      guard let profileEntity = configuration.profile else {
+        return Entry(date: date, snapshot: nil, profile: nil)
+      }
+      let summary = WidgetProfileSummary(
+        id: profileEntity.id, label: profileEntity.label, currency: profileEntity.currency)
+      let scoped = WidgetDataPath.scopedRoot()
+      let dbURL = WidgetDataPath.profileDatabaseURL(profileID: summary.id, scopedRoot: scoped)
+      do {
+        let snapshot = try await UpcomingWidgetQuery.read(
+          profile: summary,
+          profileDatabaseURL: dbURL,
+          asOf: date,
+          calendar: Calendar.current,
+          maxRows: 5)
+        return Entry(date: date, snapshot: snapshot, profile: profileEntity)
+      } catch {
+        return Entry(date: date, snapshot: nil, profile: profileEntity)
+      }
+    }
+  }
+
+  // MARK: - Entry view
+
+  struct ListEntryView: View {
+    let entry: Entry
+
+    var body: some View {
+      Group {
+        if let profile = entry.profile, let snapshot = entry.snapshot {
+          UpcomingListView(snapshot: snapshot, profile: profile, calendar: .current)
+        } else if entry.profile != nil {
+          WidgetEmptyStateView(title: "Profile not available", subtitle: "Open Moolah to fix")
+        } else {
+          WidgetEmptyStateView(title: "Add a profile", subtitle: "Edit widget to choose one")
+        }
+      }
+      .containerBackground(.background, for: .widget)
+    }
+  }
+}
+```
+
+### Step 5: Wire into the bundle + remove the placeholder
+
+- [ ] **Step 5.1: Modify `MoolahWidgets/MoolahWidgetsBundle.swift`**
+
+Replace `PlaceholderUpcomingListWidget()` with `UpcomingTransactionsListWidget()` so the body is:
+
+```swift
+  var body: some Widget {
+    UpcomingTransactionsListWidget()
+    PlaceholderUpcomingCountWidget()
+  }
+```
+
+- [ ] **Step 5.2: Delete the `PlaceholderUpcomingListWidget` struct from `MoolahWidgets/Placeholders.swift`**
+
+Keep the file (`PlaceholderUpcomingCountWidget` is still needed). Delete only the struct definition and its `Self.kind` constant.
+
+### Step 6: Build, gate, commit
+
+- [ ] **Step 6.1: Build both hosts**
+
+```bash
+just build-mac
+just build-ios
+```
+
+- [ ] **Step 6.2: Gates + commit**
+
+```bash
+just format-check
+just test-mac
+just test-ios
+
+git add MoolahWidgets/ MoolahTests/Widgets/
+git commit -m "$(cat <<'EOF'
+feat(widgets): ship UpcomingTransactionsListWidget (.systemMedium)
+
+Medium widget renders overdue + next-7-days scheduled transactions for
+the configured profile. Each row is a Button(intent:) that routes to
+OpenTransactionFromWidgetIntent (openAppWhenRun = true), which calls
+NavigationBridge to focus the matching window or open the profile —
+same shape as OpenAccountIntent. Empty state when nothing is due in
+the horizon; placeholder when the profile has been deleted.
+EOF
+)"
+```
+
+---
+
+## Task 5: `UpcomingTransactionsCountWidget` — the small widget
+
+**Files:**
+- Create: `MoolahWidgets/UpcomingTransactionsCountWidget.swift`
+- Create: `MoolahWidgets/Views/UpcomingCountView.swift`
+- Create: `MoolahWidgets/Intents/OpenUpcomingFromWidgetIntent.swift`
+- Delete: `MoolahWidgets/Placeholders.swift` (the small-widget placeholder; whole file if it now has nothing left).
+- Modify: `MoolahWidgets/MoolahWidgetsBundle.swift` — `body` becomes the two real widgets only.
+- Create: `MoolahTests/Widgets/OpenUpcomingFromWidgetIntentTests.swift`
+
+### Step 1: `OpenUpcomingFromWidgetIntent` — TDD
+
+- [ ] **Step 1.1: Failing test — `MoolahTests/Widgets/OpenUpcomingFromWidgetIntentTests.swift`**
+
+```swift
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("OpenUpcomingFromWidgetIntent")
+@MainActor
+struct OpenUpcomingFromWidgetIntentTests {
+
+  private struct Recorded {
+    var openedProfile: UUID?
+    var pendingNavigation: PendingNavigation?
+  }
+
+  private func installFakes() -> Box<Recorded> {
+    let box = Box(Recorded())
+    NavigationBridge.openProfile = { id in box.value.openedProfile = id }
+    NavigationBridge.setPendingNavigation = { nav in box.value.pendingNavigation = nav }
+    return box
+  }
+
+  @Test("perform with a profile dispatches openProfile + .upcoming")
+  func withProfile() async throws {
+    let box = installFakes()
+    let profile = WidgetProfileEntity(id: UUID(), label: "Personal", currency: "AUD")
+
+    let intent = OpenUpcomingFromWidgetIntent()
+    intent.profile = profile
+    _ = try await intent.perform()
+
+    #expect(box.value.openedProfile == profile.id)
+    #expect(box.value.pendingNavigation == PendingNavigation(
+      profileId: profile.id, destination: .upcoming))
+  }
+
+  @Test("perform with nil profile does not open a profile and sets no pending nav")
+  func withoutProfile() async throws {
+    let box = installFakes()
+
+    let intent = OpenUpcomingFromWidgetIntent()
+    intent.profile = nil
+    _ = try await intent.perform()
+
+    #expect(box.value.openedProfile == nil)
+    #expect(box.value.pendingNavigation == nil)
+  }
+}
+
+private final class Box<T> {
+  var value: T
+  init(_ value: T) { self.value = value }
+}
+```
+
+- [ ] **Step 1.2: Run — verify failing**
+
+```bash
+just test-mac OpenUpcomingFromWidgetIntentTests 2>&1 | tee .agent-tmp/open-upcoming-tests.txt
+```
+
+- [ ] **Step 1.3: Create `MoolahWidgets/Intents/OpenUpcomingFromWidgetIntent.swift`**
+
+```swift
+import AppIntents
+import Foundation
+
+#if os(macOS)
+  import AppKit
+#endif
+
+struct OpenUpcomingFromWidgetIntent: AppIntent {
+  static let title: LocalizedStringResource = "Open Upcoming (widget)"
+  static let isDiscoverable = false
+  static let openAppWhenRun = true
+
+  @Parameter(title: "Profile") var profile: WidgetProfileEntity?
+
+  init() {}
+
+  @MainActor
+  func perform() async throws -> some IntentResult {
+    guard let profile else {
+      return .result()
+    }
+    #if os(macOS)
+      let alreadyOpen = ProfileWindowLocator.activateExistingWindow(for: profile.id)
+    #else
+      let alreadyOpen = false
+    #endif
+    if !alreadyOpen {
+      NavigationBridge.openProfile?(profile.id)
+    }
+    NavigationBridge.setPendingNavigation?(
+      PendingNavigation(profileId: profile.id, destination: .upcoming))
+    return .result()
+  }
+}
+```
+
+- [ ] **Step 1.4: Run — verify pass**
+
+```bash
+just test-mac OpenUpcomingFromWidgetIntentTests 2>&1 | tee .agent-tmp/open-upcoming-tests.txt
+```
+
+### Step 2: `UpcomingCountView`
+
+- [ ] **Step 2.1: Create `MoolahWidgets/Views/UpcomingCountView.swift`**
+
+```swift
+import SwiftUI
+
+struct UpcomingCountView: View {
+  let snapshot: UpcomingWidgetSnapshot
+  let profile: WidgetProfileEntity
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 4) {
+      Text("Due")
+        .font(.caption.smallCaps())
+        .foregroundStyle(.secondary)
+      Text("\(snapshot.dueNowCount)")
+        .font(.system(size: 52, weight: .bold))
+        .monospacedDigit()
+        .foregroundStyle(snapshot.dueNowCount == 0 ? .secondary : .primary)
+      Spacer(minLength: 0)
+      Text(SmallWidgetTotalRenderer.text(for: snapshot))
+        .font(.caption.monospacedDigit())
+        .foregroundStyle(snapshot.dueNowCount == 0 ? .secondary : .red)
+        .lineLimit(1)
+      Text(profile.label)
+        .font(.caption2)
+        .foregroundStyle(.secondary)
+        .lineLimit(1)
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    .padding(14)
+  }
+}
+```
+
+### Step 3: `UpcomingTransactionsCountWidget`
+
+- [ ] **Step 3.1: Create `MoolahWidgets/UpcomingTransactionsCountWidget.swift`**
+
+```swift
+import AppIntents
+import SwiftUI
+import WidgetKit
+
+struct UpcomingTransactionsCountWidget: Widget {
+  static let kind = "rocks.moolah.widget.upcoming-count"
+
+  var body: some WidgetConfiguration {
+    AppIntentConfiguration(
+      kind: Self.kind,
+      intent: WidgetProfileSelectionIntent.self,
+      provider: Provider()
+    ) { entry in
+      EntryView(entry: entry)
+    }
+    .configurationDisplayName("Due today")
+    .description("How many scheduled transactions need your attention right now.")
+    .supportedFamilies([.systemSmall])
+  }
+
+  struct Entry: TimelineEntry {
+    let date: Date
+    let snapshot: UpcomingWidgetSnapshot?
+    let profile: WidgetProfileEntity?
+  }
+
+  struct Provider: AppIntentTimelineProvider {
+    func placeholder(in context: Context) -> Entry {
+      Entry(date: Date(), snapshot: nil, profile: nil)
+    }
+
+    func snapshot(for configuration: WidgetProfileSelectionIntent, in context: Context) async
+      -> Entry
+    {
+      await Self.build(at: Date(), for: configuration)
+    }
+
+    func timeline(for configuration: WidgetProfileSelectionIntent, in context: Context) async
+      -> Timeline<Entry>
+    {
+      let calendar = Calendar.current
+      let now = Date()
+      var entries: [Entry] = []
+      for dayOffset in 0..<5 {
+        guard let boundary = calendar.date(byAdding: .day, value: dayOffset, to: calendar.startOfDay(for: now))
+        else { continue }
+        entries.append(await Self.build(at: boundary, for: configuration))
+      }
+      return Timeline(entries: entries, policy: .atEnd)
+    }
+
+    private static func build(at date: Date, for configuration: WidgetProfileSelectionIntent) async
+      -> Entry
+    {
+      guard let profileEntity = configuration.profile else {
+        return Entry(date: date, snapshot: nil, profile: nil)
+      }
+      let summary = WidgetProfileSummary(
+        id: profileEntity.id, label: profileEntity.label, currency: profileEntity.currency)
+      let scoped = WidgetDataPath.scopedRoot()
+      let dbURL = WidgetDataPath.profileDatabaseURL(profileID: summary.id, scopedRoot: scoped)
+      do {
+        let snapshot = try await UpcomingWidgetQuery.read(
+          profile: summary,
+          profileDatabaseURL: dbURL,
+          asOf: date,
+          calendar: Calendar.current,
+          maxRows: 5)
+        return Entry(date: date, snapshot: snapshot, profile: profileEntity)
+      } catch {
+        return Entry(date: date, snapshot: nil, profile: profileEntity)
+      }
+    }
+  }
+
+  struct EntryView: View {
+    let entry: Entry
+
+    var body: some View {
+      Group {
+        if let profile = entry.profile, let snapshot = entry.snapshot {
+          let intent = OpenUpcomingFromWidgetIntent()
+          let _ = { intent.profile = profile }()
+          Button(intent: intent) {
+            UpcomingCountView(snapshot: snapshot, profile: profile)
+          }
+          .buttonStyle(.plain)
+        } else if entry.profile != nil {
+          WidgetEmptyStateView(title: "Profile not available", subtitle: "Open Moolah to fix")
+        } else {
+          WidgetEmptyStateView(title: "Add a profile", subtitle: "Edit widget to choose one")
+        }
+      }
+      .containerBackground(.background, for: .widget)
+    }
+  }
+}
+```
+
+### Step 4: Wire bundle + delete placeholder file
+
+- [ ] **Step 4.1: Modify `MoolahWidgets/MoolahWidgetsBundle.swift`**
+
+```swift
+import SwiftUI
+import WidgetKit
+
+@main
+struct MoolahWidgetsBundle: WidgetBundle {
+  var body: some Widget {
+    UpcomingTransactionsListWidget()
+    UpcomingTransactionsCountWidget()
+  }
+}
+```
+
+- [ ] **Step 4.2: Delete `MoolahWidgets/Placeholders.swift`**
+
+```bash
+git rm MoolahWidgets/Placeholders.swift
+```
+
+### Step 5: Build, gate, commit
+
+- [ ] **Step 5.1: Build + tests**
+
+```bash
+just build-mac
+just build-ios
+just format-check
+just test-mac
+just test-ios
+```
+
+- [ ] **Step 5.2: Commit**
+
+```bash
+git add MoolahWidgets/ MoolahTests/Widgets/
+git commit -m "$(cat <<'EOF'
+feat(widgets): ship UpcomingTransactionsCountWidget (.systemSmall)
+
+Small widget shows the count of scheduled transactions that are
+overdue or due today plus the sum of their amounts (per-instrument,
+falling back to "Multiple currencies" if more than one instrument and
+none match the profile's currency). Tap opens the Upcoming list in the
+configured profile via OpenUpcomingFromWidgetIntent.
+
+Placeholder file removed — both widgets are now real.
+EOF
+)"
+```
+
+---
+
+## Task 6: `WidgetReloadCoordinator` + host hooks
+
+**Files:**
+- Create: `Shared/Widgets/WidgetReloadCoordinator.swift`
+- Create: `MoolahTests/Widgets/WidgetReloadCoordinatorTests.swift`
+- Modify: `Features/Transactions/TransactionStore+Mutations.swift`
+- Modify: `Backends/CloudKit/Sync/<sync-coordinator>.swift` (locate by grep below)
+- Modify: `App/MoolahApp+Lifecycle.swift`
+- Modify: `Shared/ProfileContainerManager.swift`
+
+### Step 1: `WidgetReloadCoordinator` — TDD
+
+- [ ] **Step 1.1: Failing test — `MoolahTests/Widgets/WidgetReloadCoordinatorTests.swift`**
+
+```swift
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("WidgetReloadCoordinator")
+struct WidgetReloadCoordinatorTests {
+
+  @Test("calling reload(reason:) invokes the injected handler with the reason")
+  func reloadInvokesHandler() async {
+    var captured: WidgetReloadCoordinator.Reason?
+    let coordinator = WidgetReloadCoordinator { captured = $0 }
+    coordinator.reload(reason: .transactionMutation)
+    #expect(captured == .transactionMutation)
+  }
+
+  @Test("default reload reason values are distinct")
+  func reasonsAreDistinct() {
+    let all: [WidgetReloadCoordinator.Reason] = [
+      .transactionMutation, .syncCompleted, .scenePhaseBackground, .profileMutation,
+    ]
+    #expect(Set(all).count == all.count)
+  }
+}
+```
+
+- [ ] **Step 1.2: Run — verify failing**
+
+```bash
+just test-mac WidgetReloadCoordinatorTests 2>&1 | tee .agent-tmp/reload-tests.txt
+```
+
+- [ ] **Step 1.3: Create `Shared/Widgets/WidgetReloadCoordinator.swift`**
+
+```swift
+import Foundation
+import OSLog
+import WidgetKit
+
+/// Host-side helper: every write-path pinch point calls `reload(reason:)`
+/// so the widget extension's timeline rebuilds reflect the latest data.
+///
+/// Tests inject `handler`; production uses the default which calls
+/// `WidgetCenter.shared.reloadAllTimelines()` and logs the reason.
+final class WidgetReloadCoordinator: Sendable {
+
+  enum Reason: String, Sendable, Hashable {
+    case transactionMutation
+    case syncCompleted
+    case scenePhaseBackground
+    case profileMutation
+  }
+
+  private let handler: @Sendable (Reason) -> Void
+  private let logger = Logger(subsystem: "com.moolah.app", category: "Widgets")
+
+  /// Production singleton.
+  static let shared = WidgetReloadCoordinator { reason in
+    WidgetCenter.shared.reloadAllTimelines()
+  }
+
+  init(handler: @escaping @Sendable (Reason) -> Void) {
+    self.handler = handler
+  }
+
+  func reload(reason: Reason) {
+    logger.debug("Widget reload requested: \(reason.rawValue, privacy: .public)")
+    handler(reason)
+  }
+}
+```
+
+- [ ] **Step 1.4: Run — verify pass**
+
+```bash
+just test-mac WidgetReloadCoordinatorTests 2>&1 | tee .agent-tmp/reload-tests.txt
+```
+
+### Step 2: Transaction-store mutation hook
+
+- [ ] **Step 2.1: Read `Features/Transactions/TransactionStore+Mutations.swift`** to locate every mutation method (`createTransaction`, `updateTransaction`, `deleteTransaction`, `payScheduledTransaction`, `markAsSpam`, etc).
+
+- [ ] **Step 2.2: After every successful mutation (immediately before the method returns success), add:**
+
+```swift
+    WidgetReloadCoordinator.shared.reload(reason: .transactionMutation)
+```
+
+Do **not** call this from rollback paths — only on successful completion.
+
+### Step 3: Sync-completion hook
+
+- [ ] **Step 3.1: Locate the sync-completion pinch point**
+
+```bash
+grep -rn "fetchChanges\|fetched.*applied\|sendChanges" Backends/CloudKit/Sync/ | head -20
+```
+
+The hook lives in the function that resolves after `CKSyncEngine` has applied a fetched batch (or after a send batch acks). If the project has a `SyncCoordinator` / `SyncEngine` final-callback, that is the site.
+
+- [ ] **Step 3.2: At the "fetched + applied" boundary, add:**
+
+```swift
+    WidgetReloadCoordinator.shared.reload(reason: .syncCompleted)
+```
+
+### Step 4: Scene-phase hook
+
+- [ ] **Step 4.1: Open `App/MoolahApp+Lifecycle.swift`**
+
+- [ ] **Step 4.2: In the iOS scene-phase change handler, when transitioning to `.background`:**
+
+```swift
+WidgetReloadCoordinator.shared.reload(reason: .scenePhaseBackground)
+```
+
+- [ ] **Step 4.3: In the macOS `NSApplication.willResignActiveNotification` observer (add one if absent), same call:**
+
+```swift
+NotificationCenter.default.addObserver(
+  forName: NSApplication.willResignActiveNotification,
+  object: nil,
+  queue: .main
+) { _ in
+  WidgetReloadCoordinator.shared.reload(reason: .scenePhaseBackground)
+}
+```
+
+### Step 5: Profile-mutation hook
+
+- [ ] **Step 5.1: Open `Shared/ProfileContainerManager.swift`**
+
+- [ ] **Step 5.2: After every profile add / rename / delete commit, add:**
+
+```swift
+WidgetReloadCoordinator.shared.reload(reason: .profileMutation)
+```
+
+### Step 6: Build, gate, commit
+
+- [ ] **Step 6.1: Gates**
+
+```bash
+just format-check
+just test-mac
+just test-ios
+```
+
+- [ ] **Step 6.2: Commit**
+
+```bash
+git add Shared/Widgets/WidgetReloadCoordinator.swift \
+  MoolahTests/Widgets/WidgetReloadCoordinatorTests.swift \
+  Features/Transactions/TransactionStore+Mutations.swift \
+  Backends/CloudKit/Sync/ \
+  App/MoolahApp+Lifecycle.swift \
+  Shared/ProfileContainerManager.swift
+git commit -m "$(cat <<'EOF'
+feat(widgets): refresh widget timelines on host write-path events
+
+WidgetReloadCoordinator is the single seam through which the host
+asks WidgetKit to rebuild every widget timeline. Hooked into:
+
+- TransactionStore mutations (create / update / delete / pay-scheduled
+  / mark-as-spam) on the success path only.
+- CloudKit sync's fetched + applied boundary.
+- Scene-phase background on iOS, willResignActive on macOS.
+- ProfileContainerManager profile add / rename / delete.
+
+Test injects a fake handler; production uses
+WidgetCenter.shared.reloadAllTimelines().
+EOF
+)"
+```
+
+---
+
+## Task 7: Verification + documentation polish
+
+**Files:**
+- Modify: `CLAUDE.md`
+- Manual smoke per the design's checklist.
+
+### Step 1: CLAUDE.md note
+
+- [ ] **Step 1.1: Add one bullet under *Architecture & Constraints* in `CLAUDE.md`**
+
+After the *Backend* bullet, insert:
+
+```
+- **Widgets:** The `MoolahWidgets_{iOS,macOS}` extensions live in `MoolahWidgets/` and link only `Shared/Widgets/`, a narrow slice of `Domain/Models/`, and GRDB. The extensions never import `Backends/`, `Features/`, or `Automation/`; widget tap targets use `AppIntent` with `openAppWhenRun = true` routing through `NavigationBridge` (same pattern as `OpenAccountIntent`). Per-profile `data.sqlite` and the profile-index DB live under `WidgetDataPath.scopedRoot()` (App Group container, env-scoped); host code keeps using `URL.moolahScopedApplicationSupport` which resolves there.
+```
+
+- [ ] **Step 1.2: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs(widgets): document widget-extension linker scope + storage path"
+```
+
+### Step 2: Manual smoke
+
+Work through the design's *Manual verification checklist* (§ Testing). Capture results in `.agent-tmp/widget-smoke.txt`. If any step fails, file a GitHub issue and fix in a follow-up PR — do not block the original PR set on smoke regressions unless they reveal a Critical correctness bug.
+
+- [ ] **Step 2.1: All 11 checklist items pass on local Debug builds, recorded in the log.**
+
+### Step 3: Telemetry sanity
+
+- [ ] **Step 3.1: Tail logs while the widget refreshes** to confirm the `WidgetReloadCoordinator` debug logs fire when expected, and `UpcomingWidgetQuery` warnings / faults are absent in steady-state.
+
+```bash
+log stream --predicate 'subsystem == "com.moolah.app" AND category == "Widgets"' --level debug
+```
+
+(Run while editing scheduled transactions in the app and pulling-to-refresh sync.)
+
+### Step 4: Final commit
+
+If telemetry / smoke uncovered no changes, the documentation commit is the final commit of the plan. Otherwise, fold any small fixes into Task 7 and re-run gates before committing.
+
+---
+
+## Self-Review Notes (applied inline)
+
+**Spec coverage check:**
+
+- Per-widget profile binding — Task 3 (`WidgetProfileEntity` + `WidgetProfileSelectionIntent`).
+- Medium layout A (flat list with relative dates) — Task 4 (`UpcomingRowView` + `UpcomingListView`).
+- Small layout (big number + total, includes overdue) — Task 5 (`UpcomingCountView` + `SmallWidgetTotalRenderer`).
+- Overdue + next-7-days horizon — Task 2's `UpcomingWidgetQuery.read(...)` with `horizonEnd = startOfToday + 7 days`.
+- Per-row deep link to transaction — Task 4 (`OpenTransactionFromWidgetIntent`).
+- Small-widget tap opens Upcoming — Task 5 (`OpenUpcomingFromWidgetIntent`).
+- App Group container + migration — Task 1 (`WidgetDataPath`, `ApplicationSupportToAppGroupMigration`).
+- Coordination with handoff non-goal (no URL scheme) — every widget tap target is an `AppIntent`; Task 4 / Task 5 implementations mirror `OpenAccountIntent`.
+- Multi-currency fallback on small widget — Task 2 (`SmallWidgetTotalRenderer`) + Task 5 (consumed by `UpcomingCountView`).
+- Host-driven reloads on transaction-store / sync / scene-phase / profile-mutation — Task 6.
+- Plan-pinning tests — Task 2 (`UpcomingWidgetQueryPlanPinningTests`).
+- Telemetry / `os_signpost` — covered indirectly via the `Logger(subsystem: …, category: "Widgets")` calls; an `os_signpost` interval around `UpcomingWidgetQuery.read(...)` is an optional polish that can be added in Task 7's "telemetry polish" step if Instruments traces show value.
+
+**Placeholder scan:** no `TBD` / `TODO` / "implement later" remain. The Swift `TODO(#N)` in `ApplicationSupportToAppGroupMigration` references a real issue filed in Task 0.
+
+**Type consistency:** `UpcomingWidgetSnapshot.Row`, `WidgetProfileSummary`, `WidgetProfileEntity`, `WidgetReloadCoordinator.Reason`, `OpenTransactionFromWidgetIntent`, `OpenUpcomingFromWidgetIntent` use identical signatures everywhere they appear. `UpcomingWidgetQuery.read(...)` signature is the same in Task 2 (definition), Task 4 (timeline provider), Task 5 (timeline provider).
+
+**Spec requirement gaps:** none discovered on the review pass.


### PR DESCRIPTION
## Summary

- Adds the design spec ([`plans/2026-05-26-widgets-upcoming-transactions-design.md`](../blob/worktree-widgets-design/plans/2026-05-26-widgets-upcoming-transactions-design.md)) for the first Moolah widget set — a medium "upcoming transactions" list (overdue + next 7 days, flat list with relative dates) and a small "due today" count tile (count + total, including overdue), shipping on both iOS Home Screen and macOS Desktop / Notification Centre.
- Adds the 7-task TDD-style implementation plan ([`plans/2026-05-26-widgets-upcoming-transactions-plan.md`](../blob/worktree-widgets-design/plans/2026-05-26-widgets-upcoming-transactions-plan.md)) covering App Group plumbing, the one-shot copy-then-flag migration out of `~/Library/Application Support`, the read-only query layer in `Shared/Widgets/`, the `MoolahWidgets` extension target, both widgets, and the `WidgetReloadCoordinator` host hooks.

## Design highlights

- **Per-widget profile binding** via `WidgetConfigurationIntent` + an extension-local `WidgetProfileEntity` that reads the profile-index DB directly (the existing host `ProfileEntity` cannot be reached from the extension process).
- **Direct SQLite read** from the widget extension into the per-profile `data.sqlite`, opened read-only via GRDB on every timeline rebuild. Requires a new App Group container (`group.rocks.moolah.app.{test,v2}`) and migrating per-profile storage into it. The migration is copy-not-move and integrity-checked; the legacy data is left in place as a rollback safety net (cleanup tracked as a follow-up issue filed in Task 0 of the plan).
- **Tap-to-deep-link via `AppIntent`** with `openAppWhenRun = true`, routing through `NavigationBridge` — same shape as `OpenAccountIntent`. **No `moolah://` URL scheme**, coordinated with the in-flight handoff design which similarly avoids reviving #386.
- **Display-only widgets** in this first cut. No mark-as-paid / snooze in the widget surface. Mark-as-paid stays in-app.

## Plan structure

7 landable PRs, each ending with the standard `just format-check && just test-mac && just test-ios` gate per the project's per-step format-check policy. Task 0 files the cleanup-pass GitHub issue before Task 1 commits.

## Test plan

This PR is documentation-only — no production code. Verification:

- [ ] `just format-check` passes (Swift-format applied to nothing here; checks pre-existing tree).
- [ ] Markdown renders cleanly on GitHub.
- [ ] Cross-links in both docs resolve (handoff design path, related Automation files).
- [ ] Plan's anticipated slicing reflects spec's `## Plan deliverables` section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)