### PR TITLE
fix(landing-prs): guard empty REPO_FLAG expansion for bash 3.2

### DIFF
--- a/.claude/skills/landing-prs/scripts/land-pr.sh
+++ b/.claude/skills/landing-prs/scripts/land-pr.sh
@@ -55,15 +55,22 @@ done
 REPO_FLAG=()
 [[ -n "$REPO" ]] && REPO_FLAG=(--repo "$REPO")
 
+# `${REPO_FLAG[@]+"${REPO_FLAG[@]}"}` — guard required because macOS ships
+# bash 3.2, where `set -u` treats `"${arr[@]}"` of an empty array as
+# "unbound variable". The `+` form returns the alternate value only when
+# the array has at least one element, and produces zero positional args
+# otherwise. Bash 4.4+ handles the unguarded form, but we cannot rely on
+# Homebrew bash being on PATH.
+
 # Resolve the PR's base. gh exits non-zero if the PR doesn't exist.
-base=$(gh pr view "$PR" "${REPO_FLAG[@]}" --json baseRefName --jq '.baseRefName')
+base=$(gh pr view "$PR" ${REPO_FLAG[@]+"${REPO_FLAG[@]}"} --json baseRefName --jq '.baseRefName')
 
 if [[ "$base" == "main" || "$base" == "master" ]]; then
   echo "PR #$PR targets '$base' → enabling automerge (rebase)."
   # The merge method is overridden by the queue's configured method on this
   # repo (REBASE), but we pass --rebase to be explicit. gh prints a harmless
   # warning if it conflicts; we don't gate on it.
-  gh pr merge "$PR" "${REPO_FLAG[@]}" --auto --rebase
+  gh pr merge "$PR" ${REPO_FLAG[@]+"${REPO_FLAG[@]}"} --auto --rebase
   echo "Done. Native merge queue will land it when checks pass."
   exit 0
 fi
@@ -71,7 +78,7 @@ fi
 echo "PR #$PR targets '$base' (stacked) — looking up parent PR."
 
 # Find the open PR whose head ref matches the child's base ref.
-parent=$(gh pr list "${REPO_FLAG[@]}" --head "$base" --state open --json number --jq '.[0].number // empty')
+parent=$(gh pr list ${REPO_FLAG[@]+"${REPO_FLAG[@]}"} --head "$base" --state open --json number --jq '.[0].number // empty')
 
 if [[ -z "$parent" ]]; then
   cat >&2 <<EOF

--- a/.claude/skills/landing-prs/scripts/watch-stacked-pr.sh
+++ b/.claude/skills/landing-prs/scripts/watch-stacked-pr.sh
@@ -54,6 +54,11 @@ PARENT="${positional[1]}"
 REPO_FLAG=()
 [[ -n "$REPO" ]] && REPO_FLAG=(--repo "$REPO")
 
+# `${REPO_FLAG[@]+"${REPO_FLAG[@]}"}` is required because macOS ships bash
+# 3.2, where `set -u` treats `"${arr[@]}"` of an empty array as unbound.
+# Don't simplify the expansion below to the unguarded form — it works on
+# bash 4.4+ only.
+
 POLL_INTERVAL="${POLL_INTERVAL:-60}"
 
 log() {
@@ -73,7 +78,7 @@ fetch_pr_json() {
   local pr="$1"
   local fields="$2"
   local out
-  if out=$(gh pr view "$pr" "${REPO_FLAG[@]}" --json "$fields" 2>/dev/null); then
+  if out=$(gh pr view "$pr" ${REPO_FLAG[@]+"${REPO_FLAG[@]}"} --json "$fields" 2>/dev/null); then
     echo "$out"
   else
     echo ""  # Empty = "unknown this tick"; caller continues polling.
@@ -130,7 +135,7 @@ while true; do
 
     if [[ "$child_base" != "main" && "$child_base" != "master" ]]; then
       log "Retargeting child #$CHILD: base '$child_base' → main"
-      if ! gh pr edit "$CHILD" "${REPO_FLAG[@]}" --base main >/dev/null 2>&1; then
+      if ! gh pr edit "$CHILD" ${REPO_FLAG[@]+"${REPO_FLAG[@]}"} --base main >/dev/null 2>&1; then
         notify "Retarget of #$CHILD failed. Manual intervention needed."
         exit 1
       fi
@@ -140,7 +145,7 @@ while true; do
     fi
 
     log "Enabling automerge on #$CHILD"
-    if ! gh pr merge "$CHILD" "${REPO_FLAG[@]}" --auto --rebase >/dev/null 2>&1; then
+    if ! gh pr merge "$CHILD" ${REPO_FLAG[@]+"${REPO_FLAG[@]}"} --auto --rebase >/dev/null 2>&1; then
       notify "Failed to enable automerge on #$CHILD. Manual intervention needed."
       exit 1
     fi


### PR DESCRIPTION
## Summary

`land-pr.sh` and `watch-stacked-pr.sh` both initialise `REPO_FLAG=()` and only populate it when `--repo` is passed. On macOS (which ships bash 3.2), `set -u` treats `"${arr[@]}"` of an empty array as "unbound variable", so every invocation **without** `--repo` crashed at the first `gh` call:

```
.claude/skills/landing-prs/scripts/land-pr.sh: line 59: REPO_FLAG[@]: unbound variable
```

This affected the common path — `--repo` is rarely needed when running from inside a repo checkout. Reproduced on this machine while landing #974.

## Fix

Switch every `"${REPO_FLAG[@]}"` to `${REPO_FLAG[@]+"${REPO_FLAG[@]}"}` — the `+` form returns the array's elements when set and zero positional args otherwise, on every bash since 3.x. Each site keeps a one-line comment so a future cleanup doesn't strip the guard back to the cleaner-but-broken form.

## Test plan

Verified locally on bash 3.2.57(1)-release (arm64-apple-darwin25):

- [x] `land-pr.sh` → exits 2 with usage (was: unbound-variable crash)
- [x] `land-pr.sh 99999999` → exits 1 with gh's "PR not found" — proves we get past the guard
- [x] `watch-stacked-pr.sh` → exits 2 with usage
- [x] `just format-check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)