### PR TITLE
feat(domain): introduce AccountBucket; replace isInvestmentLike/isCurrent

### DIFF
--- a/Domain/Models/Account.swift
+++ b/Domain/Models/Account.swift
@@ -9,17 +9,6 @@ enum AccountType: String, Codable, Sendable, CaseIterable {
   case crypto
   case exchange
 
-  var isCurrent: Bool {
-    self == .bank || self == .asset || self == .creditCard
-  }
-
-  /// Whether this type should be treated as an investment account for sidebar
-  /// grouping and any query that filters investments. `true` for `.investment`,
-  /// `.crypto`, and `.exchange`.
-  var isInvestmentLike: Bool {
-    self == .investment || self == .crypto || self == .exchange
-  }
-
   /// Whether this account type is populated by an external sync source
   /// (crypto wallets via `WalletSyncSource`, exchange accounts via a
   /// provider source such as `CoinstashSyncSource`) rather than manual
@@ -44,6 +33,8 @@ enum AccountType: String, Codable, Sendable, CaseIterable {
     }
   }
 
+  /// Human-readable type label shown in account creation, edit, and
+  /// sidebar grouping UI.
   var displayName: String {
     switch self {
     case .bank: return "Bank Account"

--- a/Domain/Models/Account.swift
+++ b/Domain/Models/Account.swift
@@ -34,6 +34,16 @@ enum AccountType: String, Codable, Sendable, CaseIterable {
     }
   }
 
+  /// Sidebar bucket this type belongs to. Exhaustive switch so a new
+  /// `AccountType` case (a SyncBoundary change) is forced to make a
+  /// bucket decision here.
+  var bucket: AccountBucket {
+    switch self {
+    case .bank, .creditCard, .asset: return .current
+    case .investment, .crypto, .exchange: return .investments
+    }
+  }
+
   var displayName: String {
     switch self {
     case .bank: return "Bank Account"

--- a/Domain/Models/Account.swift
+++ b/Domain/Models/Account.swift
@@ -196,6 +196,15 @@ extension Account: Comparable {
   }
 }
 
+extension Account {
+  /// The sidebar bucket this account belongs to.
+  ///
+  /// Canonical property for all bucket decisions on an `Account`. Indirects
+  /// through `type.bucket` so a future per-account `bucketOverride` field
+  /// can be introduced without changing callsites.
+  var bucket: AccountBucket { type.bucket }
+}
+
 struct Accounts: RandomAccessCollection, Sendable {
   let startIndex: Int = 0
 

--- a/Domain/Models/AccountBucket.swift
+++ b/Domain/Models/AccountBucket.swift
@@ -1,0 +1,12 @@
+// SyncBoundary — adding a case requires bumping DataFormatVersion.current.
+/// Sidebar bucket that an account (or group of accounts) lives in.
+///
+/// Designed for future extension: additional cases (`.savings`,
+/// `.retirement`, `.liabilities`) can be added when the product wants
+/// them; the raw-value tokens are stable wire identifiers and must not
+/// be renamed. Long-term, this may become a value type referencing
+/// user-defined buckets — adding the abstraction now is YAGNI.
+enum AccountBucket: String, Codable, Sendable, CaseIterable {
+  case current
+  case investments
+}

--- a/Domain/Models/AccountBucket.swift
+++ b/Domain/Models/AccountBucket.swift
@@ -1,4 +1,3 @@
-// SyncBoundary — adding a case requires bumping DataFormatVersion.current.
 /// Sidebar bucket that an account (or group of accounts) lives in.
 ///
 /// Designed for future extension: additional cases (`.savings`,

--- a/Domain/Models/Accounts+SidebarOrdering.swift
+++ b/Domain/Models/Accounts+SidebarOrdering.swift
@@ -3,7 +3,7 @@ import Foundation
 extension Accounts {
   struct SidebarGroups: Equatable {
     let current: [Account]
-    let investment: [Account]
+    let investments: [Account]
   }
 
   /// Accounts grouped and sorted the way the sidebar shows them.
@@ -16,7 +16,7 @@ extension Accounts {
   ///     Used by pickers so an already-selected account that is
   ///     hidden stays in the dropdown.
   /// - Returns: Two arrays — `current` (bank, asset, credit card) and
-  ///   `investment` — each sorted ascending by `Account.position`.
+  ///   `investments` — each sorted ascending by `Account.position`.
   /// - Note: When `excluding` and `alwaysInclude` reference the same
   ///   id, exclusion wins.
   func sidebarGrouped(
@@ -29,16 +29,16 @@ extension Accounts {
       return true
     }
     var current: [Account] = []
-    var investment: [Account] = []
+    var investments: [Account] = []
     for account in visible {
       switch account.bucket {
       case .current:
         current.append(account)
       case .investments:
-        investment.append(account)
+        investments.append(account)
       }
     }
-    return SidebarGroups(current: current, investment: investment)
+    return SidebarGroups(current: current, investments: investments)
   }
 
   /// Flat sidebar-ordered list (current first, then investment) with
@@ -48,6 +48,6 @@ extension Accounts {
     alwaysInclude: UUID? = nil
   ) -> [Account] {
     let groups = sidebarGrouped(excluding: excluding, alwaysInclude: alwaysInclude)
-    return groups.current + groups.investment
+    return groups.current + groups.investments
   }
 }

--- a/Domain/Models/Accounts+SidebarOrdering.swift
+++ b/Domain/Models/Accounts+SidebarOrdering.swift
@@ -31,9 +31,10 @@ extension Accounts {
     var current: [Account] = []
     var investment: [Account] = []
     for account in visible {
-      if account.type.isCurrent {
+      switch account.bucket {
+      case .current:
         current.append(account)
-      } else if account.type.isInvestmentLike {
+      case .investments:
         investment.append(account)
       }
     }

--- a/Features/Accounts/AccountStore.swift
+++ b/Features/Accounts/AccountStore.swift
@@ -240,11 +240,11 @@ final class AccountStore {
   }
 
   var currentAccounts: [Account] {
-    accounts.filter { $0.type.isCurrent && (showHidden || !$0.isHidden) }
+    accounts.filter { $0.bucket == .current && (showHidden || !$0.isHidden) }
   }
 
   var investmentAccounts: [Account] {
-    accounts.filter { $0.type.isInvestmentLike && (showHidden || !$0.isHidden) }
+    accounts.filter { $0.bucket == .investments && (showHidden || !$0.isHidden) }
   }
 
   // Read-only query helpers (`displayBalance`, `hasUnrecordedValue`,

--- a/Features/Accounts/Views/Account+Icon.swift
+++ b/Features/Accounts/Views/Account+Icon.swift
@@ -9,12 +9,12 @@ extension Account {
     case .creditCard: return "creditcard"
     case .investment: return "chart.line.uptrend.xyaxis"
     // Sharing the .investment chart icon for now: the design treats
-    // crypto wallets as investment-like for sidebar grouping. A
-    // dedicated crypto SF Symbol can land in a UI follow-up once the
-    // wallet feature surfaces a distinct visual identity.
+    // crypto wallets as in the `.investments` bucket. A dedicated crypto
+    // SF Symbol can land in a UI follow-up once the wallet feature
+    // surfaces a distinct visual identity.
     case .crypto: return "chart.line.uptrend.xyaxis"
-    // Exchange accounts share the investment-like chart icon; a
-    // dedicated exchange SF Symbol can land in a UI follow-up.
+    // Exchange accounts share the chart icon (also in the `.investments`
+    // bucket); a dedicated exchange SF Symbol can land in a UI follow-up.
     case .exchange: return "chart.line.uptrend.xyaxis"
     }
   }

--- a/Features/Accounts/Views/AccountPickerOptions.swift
+++ b/Features/Accounts/Views/AccountPickerOptions.swift
@@ -36,9 +36,9 @@ struct AccountPickerOptions: View {
         }
       }
     }
-    if !groups.investment.isEmpty {
+    if !groups.investments.isEmpty {
       Section("Investments") {
-        ForEach(groups.investment) { account in
+        ForEach(groups.investments) { account in
           Label(account.name, systemImage: account.sidebarIcon)
             .tag(UUID?.some(account.id))
         }

--- a/MoolahTests/Domain/AccountBucketTests.swift
+++ b/MoolahTests/Domain/AccountBucketTests.swift
@@ -1,0 +1,33 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("AccountBucket")
+struct AccountBucketTests {
+  @Test
+  func rawValuesAreStableTokens() {
+    #expect(AccountBucket.current.rawValue == "current")
+    #expect(AccountBucket.investments.rawValue == "investments")
+  }
+
+  @Test
+  func allCasesIsExhaustive() {
+    #expect(Set(AccountBucket.allCases) == [.current, .investments])
+  }
+
+  @Test
+  func decodesFromStableTokens() throws {
+    let json = Data(#"["current","investments"]"#.utf8)
+    let buckets = try JSONDecoder().decode([AccountBucket].self, from: json)
+    #expect(buckets == [.current, .investments])
+  }
+
+  @Test
+  func throwsOnUnknownRawValue() {
+    let json = Data(#""savings""#.utf8)
+    #expect(throws: DecodingError.self) {
+      _ = try JSONDecoder().decode(AccountBucket.self, from: json)
+    }
+  }
+}

--- a/MoolahTests/Domain/AccountTests.swift
+++ b/MoolahTests/Domain/AccountTests.swift
@@ -68,4 +68,18 @@ struct AccountTests {
       _ = try JSONDecoder().decode(Account.self, from: json)
     }
   }
+
+  @Test
+  func accountBucketForwardsToType() {
+    let bank = Account(name: "Chequing", type: .bank, instrument: .AUD)
+    let crypto = Account(
+      name: "ETH Wallet", type: .crypto, instrument: .AUD,
+      walletAddress: "0x" + String(repeating: "a", count: 40), chainId: 1)
+    let exchange = Account(
+      name: "Coinstash", type: .exchange, instrument: .AUD,
+      exchangeProvider: .coinstash)
+    #expect(bank.bucket == .current)
+    #expect(crypto.bucket == .investments)
+    #expect(exchange.bucket == .investments)
+  }
 }

--- a/MoolahTests/Domain/AccountTypeTests.swift
+++ b/MoolahTests/Domain/AccountTypeTests.swift
@@ -6,20 +6,6 @@ import Testing
 @Suite("AccountType")
 struct AccountTypeTests {
   @Test
-  func cryptoAndInvestmentBothInvestmentLike() {
-    #expect(AccountType.crypto.isInvestmentLike)
-    #expect(AccountType.investment.isInvestmentLike)
-    #expect(!AccountType.bank.isInvestmentLike)
-    #expect(!AccountType.creditCard.isInvestmentLike)
-    #expect(!AccountType.asset.isInvestmentLike)
-  }
-
-  @Test
-  func cryptoIsNotIsCurrent() {
-    #expect(!AccountType.crypto.isCurrent)
-  }
-
-  @Test
   func syncedTypesAreExactlyCryptoAndExchange() {
     #expect(AccountType.crypto.isSynced)
     #expect(AccountType.exchange.isSynced)

--- a/MoolahTests/Domain/AccountTypeTests.swift
+++ b/MoolahTests/Domain/AccountTypeTests.swift
@@ -73,4 +73,5 @@ struct AccountTypeTests {
       AccountType.allCases.filter { $0.bucket == .investments }
         == [.investment, .crypto, .exchange])
   }
+
 }

--- a/MoolahTests/Domain/AccountTypeTests.swift
+++ b/MoolahTests/Domain/AccountTypeTests.swift
@@ -44,4 +44,33 @@ struct AccountTypeTests {
       _ = try JSONDecoder().decode(AccountType.self, from: json)
     }
   }
+
+  @Test
+  func bucketMapsCurrentTypesToCurrent() {
+    #expect(AccountType.bank.bucket == .current)
+    #expect(AccountType.creditCard.bucket == .current)
+    #expect(AccountType.asset.bucket == .current)
+  }
+
+  @Test
+  func bucketMapsInvestmentTypesToInvestments() {
+    #expect(AccountType.investment.bucket == .investments)
+    #expect(AccountType.crypto.bucket == .investments)
+    #expect(AccountType.exchange.bucket == .investments)
+  }
+
+  @Test
+  func bucketCoversEveryAccountType() {
+    // Regression guard: every AccountType case must map to the right
+    // bucket. Pinning the full expected output mirrors the
+    // `syncedTypesAreExactlyCryptoAndExchange` style — a new case added
+    // without a bucket decision (or assigned to the wrong bucket)
+    // fails this test with a meaningful diff.
+    #expect(
+      AccountType.allCases.filter { $0.bucket == .current }
+        == [.bank, .creditCard, .asset])
+    #expect(
+      AccountType.allCases.filter { $0.bucket == .investments }
+        == [.investment, .crypto, .exchange])
+  }
 }

--- a/MoolahTests/Domain/AccountsSidebarOrderingTests.swift
+++ b/MoolahTests/Domain/AccountsSidebarOrderingTests.swift
@@ -31,7 +31,7 @@ struct AccountsSidebarOrderingTests {
     let groups = accounts.sidebarGrouped()
 
     #expect(groups.current.map(\.name) == ["Chequing", "House", "Card"])
-    #expect(groups.investment.map(\.name) == ["Brokerage"])
+    #expect(groups.investments.map(\.name) == ["Brokerage"])
   }
 
   @Test("Crypto wallets land in the investments bucket")
@@ -47,7 +47,7 @@ struct AccountsSidebarOrderingTests {
     let groups = accounts.sidebarGrouped()
 
     #expect(groups.current.map(\.name) == ["Chequing"])
-    #expect(groups.investment.map(\.name) == ["Brokerage", "ETH Wallet"])
+    #expect(groups.investments.map(\.name) == ["Brokerage", "ETH Wallet"])
   }
 
   @Test("Sorts within each group by position ascending")

--- a/MoolahTests/Domain/AccountsSidebarOrderingTests.swift
+++ b/MoolahTests/Domain/AccountsSidebarOrderingTests.swift
@@ -34,7 +34,7 @@ struct AccountsSidebarOrderingTests {
     #expect(groups.investment.map(\.name) == ["Brokerage"])
   }
 
-  @Test("Crypto wallets land in the investment group (isInvestmentLike)")
+  @Test("Crypto wallets land in the investments bucket")
   func cryptoWalletsGroupedAsInvestment() {
     let chequing = bank("Chequing", position: 0)
     let brokerage = investment("Brokerage", position: 0)

--- a/MoolahTests/Domain/ExchangeAccountModelTests.swift
+++ b/MoolahTests/Domain/ExchangeAccountModelTests.swift
@@ -5,8 +5,7 @@ import Testing
 struct ExchangeAccountModelTests {
   @Test
   func exchangeTypeIsSidebarGroupedWithInvestments() {
-    #expect(AccountType.exchange.isInvestmentLike)
-    #expect(!AccountType.exchange.isCurrent)
+    #expect(AccountType.exchange.bucket == .investments)
   }
 
   @Test

--- a/MoolahTests/Features/AccountStoreMutationsTests.swift
+++ b/MoolahTests/Features/AccountStoreMutationsTests.swift
@@ -98,11 +98,11 @@ struct AccountStoreMutationsTests {
     )
   }
 
-  @Test("investmentAccounts includes crypto accounts (isInvestmentLike)")
+  @Test("investmentAccounts includes crypto accounts")
   func investmentAccountsIncludesCrypto() async throws {
     // Sidebar feeds its "Investments" section from `investmentAccounts`. A
     // strict `type == .investment` filter would silently drop newly-created
-    // crypto wallets — the acceptance criterion is to use `isInvestmentLike`
+    // crypto wallets — the acceptance criterion is .bucket == .investments
     // so both kinds appear together.
     let (backend, database) = try TestBackend.create()
     _ = AccountStoreTestSupport.seedAccount(


### PR DESCRIPTION
## Summary

- Add `AccountBucket` enum (cases: `current`, `investments`) with stable raw values, `Codable`, `Sendable`, `CaseIterable`.
- Add `bucket` accessor on `AccountType` (exhaustive switch) and forwarding `bucket` on `Account`.
- Sweep production callsites (`Accounts+SidebarOrdering.swift`, `AccountStore.swift`) and tests to use `.bucket`.
- Remove `AccountType.isCurrent` and `AccountType.isInvestmentLike` entirely.
- Rename `SidebarGroups.investment` → `.investments` for vocabulary consistency.

## Why

First phase of the Account Groups feature (spec: `plans/2026-05-26-account-groups-design.md`). The upcoming `AccountGroup` entity needs to expose a `bucket` that matches what individual accounts expose. Making `bucket` first-class on `AccountType` now avoids two derivation paths — `.bucket == .investments` becomes the single API for sidebar partitioning.

The `Account.bucket` accessor is intentionally a separate forwarding extension rather than inlined `type.bucket` at callsites: a future per-account `bucketOverride: AccountBucket?` field can be introduced without changing any caller (additive migration).

## Test plan

- [x] `just test AccountBucketTests` — new enum tests pass (raw-value stability, exhaustive cases, Codable round-trip, strict-decode on unknown raw values).
- [x] `just test AccountTypeTests` — bucket mapping + exhaustive-coverage regression guard.
- [x] `just test AccountTests` — `Account.bucket` forwarding across bank / crypto / exchange shapes.
- [x] `just test AccountsSidebarOrderingTests AccountStoreMutationsTests ExchangeAccountModelTests` — pre-existing tests preserved after callsite sweep.
- [x] Full `just test` suite green on macOS and iOS Simulator.
- [x] `just format-check` exits clean.

## Notes on deferred review findings

The code-review agent suggested adding `@available(*, deprecated, renamed: \"bucket\")` to the legacy booleans in Task 4 (the sweep commit) to signal their transitional status. That fix was deferred: the `SWIFT_TREAT_WARNINGS_AS_ERRORS: YES` setting would have turned deprecation warnings in the test files into build errors between Task 4 and Task 5 (the test sweep), breaking intermediate commits in this same PR. The transitional state was instead documented in the Task 4 commit message; Task 6 deletes the properties outright, making the deprecation moot.

## Out of scope

This PR only paves the way. `AccountGroup` itself, the sidebar grouping UX, the CKDB schema additions, and the GRDB migration land in subsequent phases — see the design doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)