### PR TITLE
docs: account groups — Phases 4, 5, 6, 8 plans

### DIFF
--- a/plans/2026-05-26-account-groups-phase-4-sidebar-ux-plan.md
+++ b/plans/2026-05-26-account-groups-phase-4-sidebar-ux-plan.md
@@ -1,0 +1,580 @@
+# Account Groups — Phase 4 Implementation Plan: Sidebar UX
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+> **Initial-version plan.** Written ahead of Phases 2 and 3 landing on main. Open the codebase fresh at execution time and reconcile any drift; in particular, `SidebarView.swift` is the largest churn surface and other in-flight PRs may have moved things. The skeleton + decisions + acceptance criteria here are stable; the exact line numbers and surrounding code are advisory.
+
+**Goal:** Render `AccountGroup`s in the sidebar as composite rows with optional expand/collapse, intermixed with standalone accounts by `position`. Drop semantics distinguish reorder (between rows / in gaps) from group-on (middle 50% of a row). Creation flows: drag account onto another account → new group, or right-click → "Group ▸" submenu with existing groups + "New Group…". Member auto-extract on drag-out; auto-delete on 0 members. All membership operations are persisted via the stores; inline rename reuses the Phase 2 component.
+
+**Architecture:** New `AccountGroupStore` (parallel to `AccountStore`/`EarmarkStore`) provides reactive group state and the membership-mutation surface (add member, remove member, move group, create-from-account, create-from-pair). A new `Accounts+SidebarOrdering` overload returns a structured list of `SidebarBucketEntry`s (groups + standalone accounts intermixed). `SidebarView` renders the new structure, owns drop handlers, and dispatches actions to the stores. New `AccountGroupSidebarRow` and reuse of `AccountSidebarRow` (with a `member` styling hint) handle row visuals. `isExpandedInSidebar` is in-memory only this phase (per-process `@State`); Phase 8 adds persistence.
+
+**Tech Stack:** SwiftUI (`.dropDestination`, `.draggable`, `Transferable`, `DisclosureGroup` or hand-rolled equivalent for fine drop-zone control), Swift Testing.
+
+**Spec:** `/Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/account-groups-design/plans/2026-05-26-account-groups-design.md` — see "Sidebar UX" in full.
+
+**Phase ordering:** Depends on **Phase 2** (inline rename component) AND **Phase 3** (`AccountGroup` model + `GRDBAccountGroupRepository`). Either base off `origin/main` if both have merged, or off whichever lands later. Independent of Phases 5 / 6 / 7 / 8.
+
+---
+
+## Worktree setup
+
+- [ ] **Step 1: Create the worktree off the latest common base**
+
+```bash
+# Whichever of Phase 2 / Phase 3 merges later defines the base. If both
+# are on main, use main.
+git -C /Users/aj/Documents/code/moolah-project/moolah-native worktree add --no-track \
+  .worktrees/sidebar-groups -b sidebar-groups origin/main
+```
+
+If Phase 2 or Phase 3 has not yet merged, base off the later-landing branch. Stacked-PR conventions per `CLAUDE.md`.
+
+- [ ] **Step 2: Generate Xcode project + clean build**
+
+```bash
+just -d /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/sidebar-groups \
+     --justfile /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/sidebar-groups/justfile generate
+just -d /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/sidebar-groups \
+     --justfile /Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/sidebar-groups/justfile build-mac 2>&1 | tail -5
+```
+
+Expected: clean build with Phase 2 + Phase 3 already in.
+
+---
+
+## Task 1: `AccountGroupStore` (membership state + mutations)
+
+**Files:**
+- Create: `Features/Accounts/AccountGroupStore.swift`
+- Create: `Features/Accounts/AccountGroupStore+Mutations.swift`
+- Create: `MoolahTests/Features/AccountGroupStoreTests.swift`
+- Create: `MoolahTests/Features/AccountGroupStoreMutationsTests.swift`
+
+Mirror `EarmarkStore` / `AccountStore`. Reactive — subscribes to `repository.observeAll()` in `init`, exposes `groups: [AccountGroup]`, surfaces errors via `error: Error?`.
+
+- [ ] **Step 1: Tests first (initial loading + observe path)**
+
+```swift
+@Suite("AccountGroupStore — load & observe")
+@MainActor
+struct AccountGroupStoreTests {
+  @Test
+  func initialLoadEmitsEmptyThenSeededRows() async throws {
+    let (backend, _) = try TestBackend.create()
+    let store = AccountGroupStore(repository: backend.accountGroups)
+    try await store.waitForFirstEmission()
+
+    #expect(store.groups.isEmpty)
+
+    _ = try await backend.accountGroups.create(
+      AccountGroup(name: "Trust Fund Crypto", bucket: .investments, instrument: .defaultTestInstrument))
+
+    try await store.waitForNextEmission(matching: { $0.groups.count == 1 }, description: "create observed")
+    #expect(store.groups.first?.name == "Trust Fund Crypto")
+  }
+
+  @Test
+  func groupsAreOrderedByPositionAscending() async throws {
+    let (backend, _) = try TestBackend.create()
+    let store = AccountGroupStore(repository: backend.accountGroups)
+    try await store.waitForFirstEmission()
+
+    _ = try await backend.accountGroups.create(AccountGroup(name: "B", bucket: .investments, instrument: .defaultTestInstrument, position: 2))
+    _ = try await backend.accountGroups.create(AccountGroup(name: "A", bucket: .investments, instrument: .defaultTestInstrument, position: 1))
+
+    try await store.waitForNextEmission(matching: { $0.groups.count == 2 }, description: "creates observed")
+    #expect(store.groups.map(\.name) == ["A", "B"])
+  }
+}
+```
+
+Add a sibling test file for mutations covering:
+- `addAccount(_:to:)` — sets `Account.groupId` and re-positions within group
+- `removeAccount(_:)` — clears `Account.groupId`; auto-deletes group if it was the last member
+- `createGroup(from:)` — single-member group from an existing account, returns the new group
+- `createGroup(joining:and:)` — two-member group from two existing accounts
+- `moveGroup(_:to:)` — sets `AccountGroup.position`
+- `reorderMembers(of:to:)` — updates each member's `position` within the group
+
+- [ ] **Step 2: Implement `AccountGroupStore`**
+
+Skeleton (mirroring `EarmarkStore`'s reactive shape):
+
+```swift
+import Foundation
+import OSLog
+import Observation
+
+@Observable
+@MainActor
+final class AccountGroupStore {
+  private(set) var groups: [AccountGroup] = []
+  private(set) var error: Error?
+
+  let repository: any AccountGroupRepository
+  private let logger = Logger(subsystem: "com.moolah.app", category: "AccountGroupStore")
+  private var observationTask: Task<Void, Never>?
+
+  init(repository: any AccountGroupRepository) {
+    self.repository = repository
+    self.observationTask = Task { [weak self] in
+      await self?.observe()
+    }
+  }
+
+  private func observe() async {
+    do {
+      for try await snapshot in repository.observeAll() {
+        groups = snapshot
+      }
+    } catch {
+      surface(error: error)
+    }
+  }
+
+  func stopObserving() { observationTask?.cancel() }
+  deinit { MainActor.assumeIsolated { observationTask?.cancel() } }
+
+  func by(id: UUID) -> AccountGroup? { groups.first { $0.id == id } }
+  func members(of groupId: UUID, in accounts: Accounts) -> [Account] {
+    accounts.ordered
+      .filter { $0.groupId == groupId }
+      .sorted(by: { $0.position < $1.position })
+  }
+}
+```
+
+Mutation surface in `AccountGroupStore+Mutations.swift` — depends on `AccountStore` for the `Account.groupId` writes (cross-store coordination; pass `AccountStore` as a dependency, or inject a smaller `accountMutator` protocol). Recommended: take `AccountStore` directly in the mutation methods rather than holding a reference — keeps the dependency direction explicit.
+
+Key methods:
+
+```swift
+extension AccountGroupStore {
+  @discardableResult
+  func createGroup(from account: Account, name: String, accountStore: AccountStore) async throws -> AccountGroup {
+    // 1. Create the group with derived bucket/instrument.
+    let group = AccountGroup(
+      name: name, bucket: account.bucket,
+      instrument: accountStore.targetInstrument,
+      position: nextPositionInBucket(account.bucket, accountStore: accountStore))
+    let created = try await repository.create(group)
+    // 2. Set the account's groupId.
+    var moved = account
+    moved.groupId = created.id
+    moved.position = 0   // first member
+    _ = try await accountStore.update(moved)
+    return created
+  }
+
+  @discardableResult
+  func createGroup(joining accountA: Account, and accountB: Account, name: String, accountStore: AccountStore) async throws -> AccountGroup {
+    precondition(accountA.bucket == accountB.bucket, "cross-bucket grouping prohibited")
+    let group = AccountGroup(/* … */)
+    let created = try await repository.create(group)
+    for (idx, var member) in [accountA, accountB].enumerated() {
+      member.groupId = created.id
+      member.position = idx
+      _ = try await accountStore.update(member)
+    }
+    return created
+  }
+
+  func addAccount(_ account: Account, to group: AccountGroup, accountStore: AccountStore) async throws {
+    precondition(account.bucket == group.bucket, "cross-bucket grouping prohibited")
+    var member = account
+    member.groupId = group.id
+    member.position = membersCount(of: group.id, in: accountStore)
+    _ = try await accountStore.update(member)
+  }
+
+  func removeAccount(_ account: Account, accountStore: AccountStore) async throws {
+    guard let groupId = account.groupId else { return }
+    var member = account
+    member.groupId = nil
+    member.position = nextPositionInBucket(account.bucket, accountStore: accountStore)
+    _ = try await accountStore.update(member)
+    // Auto-delete empty group
+    let remaining = accountStore.accounts.ordered.contains { $0.groupId == groupId }
+    if !remaining {
+      try await repository.delete(id: groupId)
+    }
+  }
+}
+```
+
+The `nextPositionInBucket` / `membersCount` helpers compute positions consistently — be careful to use the same sorting key everywhere (`position` ascending) and tie-break by insertion order (e.g. `id` for determinism).
+
+- [ ] **Step 3: Run tests + commit**
+
+```bash
+just test AccountGroupStoreTests AccountGroupStoreMutationsTests
+just format-check
+git ... commit -m "feat(accounts): AccountGroupStore + membership mutations"
+```
+
+---
+
+## Task 2: Extend `Accounts+SidebarOrdering` for group-aware rendering
+
+**Files:**
+- Modify: `Domain/Models/Accounts+SidebarOrdering.swift`
+- Modify: `MoolahTests/Domain/AccountsSidebarOrderingTests.swift`
+
+The current return type is `SidebarGroups { current: [Account], investment: [Account] }`. Extend with a structured intermixed-entry list per bucket:
+
+```swift
+enum SidebarBucketEntry: Equatable {
+  case account(Account)
+  case group(AccountGroup, members: [Account])
+}
+
+extension Accounts {
+  struct GroupAwareSidebarGroups: Equatable {
+    let current: [SidebarBucketEntry]
+    let investment: [SidebarBucketEntry]
+  }
+
+  /// Returns standalone accounts (groupId == nil) and groups intermixed
+  /// per bucket, sorted by their shared `position`. Members of a group
+  /// are returned alongside their group entry, sorted by member
+  /// `position`. Honours the same hidden / exclusion rules as
+  /// `sidebarGrouped(excluding:alwaysInclude:)`.
+  func groupAwareSidebar(
+    groups: [AccountGroup],
+    excluding: UUID? = nil,
+    alwaysInclude: UUID? = nil
+  ) -> GroupAwareSidebarGroups
+}
+```
+
+Implementation:
+
+1. Filter `ordered` for visibility (existing logic).
+2. Partition by `bucket`.
+3. Within each bucket:
+   - Find groups in this bucket (`groups.filter { $0.bucket == bucket }`).
+   - Build standalone-account list: visible accounts with `groupId == nil`.
+   - Build group entries: `(group, members)` where members are visible accounts with `groupId == group.id`, sorted by member `position`.
+   - Combine standalone accounts + group entries; sort by their respective `position` (both compete in the same number space).
+
+Tests cover:
+- Empty groups list returns the existing shape (just standalone accounts).
+- Standalone account and group with same `position` — tie-break by group-first (or test the deterministic order and lock it in).
+- Group with a hidden member doesn't show that member but still rolls up balance (balance rollup is Phase 5; for now just confirm hidden members are excluded from the returned `members` array).
+- Cross-bucket invariant: a group with bucket `.investments` only appears in the investment bucket even if a hypothetical member had a different bucket.
+
+---
+
+## Task 3: New row component — `AccountGroupSidebarRow`
+
+**Files:**
+- Create: `Features/Accounts/Views/AccountGroupSidebarRow.swift`
+- Modify: `Features/Accounts/Views/AccountSidebarRow.swift` (add `isMember: Bool` style hint)
+
+Group row renders:
+- Disclosure triangle (▸ collapsed / ▾ expanded) bound to a `Binding<Bool>` for the group's expand state.
+- Group icon (use a folder-like SF Symbol, e.g. `folder.fill` or `square.stack.3d.up.fill` — pick one that works visually beside `Account+Icon`).
+- Group name (renders via inline-rename from Phase 2 — reuse `SidebarRowView`'s `isEditing` / `onRename`).
+- Aggregated balance (Phase 5 wires this; for now use `nil` so the row shows a `ProgressView`, then Phase 5 substitutes the real aggregate).
+
+```swift
+struct AccountGroupSidebarRow: View {
+  let group: AccountGroup
+  let isSelected: Bool
+  @Binding var isExpanded: Bool
+  var aggregateBalance: InstrumentAmount?  // nil = ProgressView; Phase 5 wires this
+  var isEditing: Binding<Bool>? = nil
+  var onRename: ((String) -> Void)? = nil
+
+  var body: some View {
+    HStack(spacing: 4) {
+      Button {
+        isExpanded.toggle()
+      } label: {
+        Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
+          .font(.system(size: 10, weight: .semibold))
+          .foregroundStyle(.secondary)
+          .frame(width: 12)
+      }
+      .buttonStyle(.plain)
+      .accessibilityHidden(true)
+
+      SidebarRowView(
+        icon: "folder.fill",
+        name: group.name,
+        amount: aggregateBalance,
+        isSelected: isSelected,
+        isEditing: isEditing,
+        onRename: onRename
+      )
+    }
+  }
+}
+```
+
+Member rows use the existing `AccountSidebarRow` with a small style hint (`isMember: Bool = false`) that adjusts indentation / secondary text. Member rows show a secondary line below the name with chain / address / exchange-provider context — extend `AccountSidebarRow` to render an optional secondary line.
+
+Tests via SwiftUI `#Preview` only (the canvas exercise). No XCUITest in this phase.
+
+---
+
+## Task 4: Wire group rendering into `SidebarView`
+
+**Files:**
+- Modify: `Features/Navigation/SidebarView.swift` (substantial — both sections that render accounts become group-aware)
+- Modify: `Features/Navigation/SidebarView+Previews.swift` (add a preview that seeds a group)
+
+The two account-rendering sections (`currentAccountsSection`, `investmentsSection`) change shape: instead of `ForEach(accountStore.currentAccounts)`, iterate over the structured `[SidebarBucketEntry]` and switch on each entry:
+
+```swift
+private var investmentsSection: some View {
+  let entries = accountStore.accounts.groupAwareSidebar(
+    groups: groupStore.groups
+  ).investment
+
+  return Section("Investments") {
+    ForEach(entries, id: \.sidebarKey) { entry in
+      switch entry {
+      case .account(let account):
+        accountRow(account)
+      case .group(let group, let members):
+        groupRow(group, members: members)
+      }
+    }
+    .onMove { /* reorder within bucket — see Task 5 */ }
+    totalRow(label: "Investment Total", value: accountStore.convertedInvestmentTotal)
+  }
+}
+
+@ViewBuilder
+private func groupRow(_ group: AccountGroup, members: [Account]) -> some View {
+  let expandBinding = Binding<Bool>(
+    get: { expandedGroupIds.contains(group.id) },
+    set: { isExpanded in
+      if isExpanded { expandedGroupIds.insert(group.id) }
+      else { expandedGroupIds.remove(group.id) }
+    }
+  )
+  NavigationLink(value: SidebarSelection.group(group.id)) {
+    AccountGroupSidebarRow(
+      group: group,
+      isSelected: selection == .group(group.id),
+      isExpanded: expandBinding,
+      aggregateBalance: nil,  // Phase 5 wires this
+      isEditing: renameBinding(for: group.id),
+      onRename: { newName in
+        Task { _ = try? await groupStore.rename(id: group.id, to: newName) }
+      })
+  }
+  .contextMenu { groupContextMenu(for: group) }
+
+  if expandBinding.wrappedValue {
+    ForEach(members) { member in
+      memberRow(member)
+    }
+  }
+}
+```
+
+Add new state on `SidebarView`:
+
+```swift
+@State private var expandedGroupIds: Set<UUID> = []  // Phase 8 persists; in-memory for now
+```
+
+Add `SidebarSelection.group(UUID)` case (in the existing enum). The Phase 5 plan will need to know the new case exists — leave a TODO comment for any feature that depends on the selection shape (the `transactionDescription` rule, for instance).
+
+Add `groupContextMenu(for:)`:
+
+```swift
+@ViewBuilder
+private func groupContextMenu(for group: AccountGroup) -> some View {
+  Button("Rename", systemImage: "character.cursor.ibeam") {
+    editingRowId = group.id
+  }
+  .accessibilityIdentifier(UITestIdentifiers.Sidebar.renameContextMenuItem)
+}
+```
+
+(No Hide, no Delete per spec.)
+
+Update the account context menu (Phase 2's `accountContextMenu`) to add the "Group ▸" submenu — see Task 6.
+
+---
+
+## Task 5: Drop semantics + creation flows
+
+**Files:**
+- Modify: `Features/Navigation/SidebarView.swift`
+- Create: `Features/Navigation/SidebarDropZone.swift` (drop-zone shape constants + helpers)
+
+This is the spiciest piece — SwiftUI's `.dropDestination` doesn't natively distinguish "middle 50%" from "edge 25%"; you implement it via the row's geometry + a `DropProposal` returned from the proposal callback.
+
+The cleanest approach uses a custom modifier per row that observes the drop location:
+
+```swift
+/// Returns a Transferable-conforming wrapper around an Account / Group
+/// so SwiftUI's drag-drop system can shuttle ids.
+struct DraggableSidebarItem: Codable, Transferable {
+  enum Kind: String, Codable { case account, group }
+  let kind: Kind
+  let id: UUID
+
+  static var transferRepresentation: some TransferRepresentation {
+    CodableRepresentation(contentType: .moolahSidebarItem)
+  }
+}
+
+extension UTType {
+  static var moolahSidebarItem = UTType(exportedAs: "com.moolah.sidebar-item")
+}
+```
+
+For each row, attach `.draggable(DraggableSidebarItem(kind: ..., id: ...))` and `.dropDestination(for: DraggableSidebarItem.self)` with a proposal callback:
+
+```swift
+.dropDestination(for: DraggableSidebarItem.self) { items, location in
+  guard let item = items.first else { return false }
+  // Determine drop mode from `location` relative to the row bounds.
+  // location.y in 0..rowHeight; middle 50% = ~0.25..0.75; edges = reorder.
+  let mode = dropMode(at: location, rowHeight: ROW_HEIGHT)
+  Task { await handleDrop(item, mode: mode, targetAccount: account) }
+  return true
+} isTargeted: { isTargeted in
+  // Show full-row highlight for .on mode, no indicator for .reorder modes.
+}
+```
+
+`handleDrop(item:mode:targetAccount:)` is the policy gate:
+1. Source = account, target = account, mode = `.on` → `createGroup(joining: source, and: target, name: "New Group", accountStore: ...)`; enter rename mode on the new group via `editingRowId = createdGroup.id`.
+2. Source = account, target = group, mode = `.on` → `addAccount(source, to: group, accountStore: ...)`. Reject if source.bucket ≠ group.bucket.
+3. Source = group, target = anything, mode = `.on` → reject (no nesting).
+4. Any source, mode = `.reorder above` → mutate `position` to one less than target's, persist via the relevant store.
+5. Cross-bucket → reject early.
+
+This is the highest-risk piece of Phase 4. Pre-existing tests should cover policy via `AccountGroupStore` mutations (Task 1). UX is exercised manually in Xcode + previews. If `.dropDestination` proves too lossy, fall back to a small AppKit `NSView` overlay for accurate hit-testing — but try the SwiftUI path first.
+
+For the **right-click "Group ▸" submenu**, extend `accountContextMenu(for:)` from Phase 2:
+
+```swift
+@ViewBuilder
+private func accountContextMenu(for account: Account) -> some View {
+  Button("Rename", systemImage: "character.cursor.ibeam") {
+    editingRowId = account.id
+  }
+  .accessibilityIdentifier(UITestIdentifiers.Sidebar.renameContextMenuItem)
+
+  Menu("Group", systemImage: "folder") {
+    let groupsInBucket = groupStore.groups
+      .filter { $0.bucket == account.bucket && $0.id != account.groupId }
+    ForEach(groupsInBucket) { group in
+      Button(group.name) {
+        Task {
+          try? await groupStore.addAccount(account, to: group, accountStore: accountStore)
+        }
+      }
+    }
+    if !groupsInBucket.isEmpty { Divider() }
+    Button("New Group\u{2026}") {
+      Task {
+        let created = try? await groupStore.createGroup(from: account, name: "New Group", accountStore: accountStore)
+        if let created { editingRowId = created.id }
+      }
+    }
+    if account.groupId != nil {
+      Divider()
+      Button("Remove from Group") {
+        Task { try? await groupStore.removeAccount(account, accountStore: accountStore) }
+      }
+    }
+  }
+
+  // Existing items (Edit Account, View Transactions, etc.) follow.
+}
+```
+
+---
+
+## Task 6: Wire `AccountGroupStore` into `ProfileSession` + every consumer
+
+**Files:**
+- Modify: wherever `EarmarkStore` is constructed in the profile session (search for `EarmarkStore(repository:`)
+- Modify: `SidebarView` (add `@Environment(AccountGroupStore.self)`)
+- Modify: any preview / test entry points
+
+The store is a `MainActor` `@Observable`; it gets injected into the SwiftUI environment alongside `EarmarkStore`. Find every site that constructs the stores together and add the new line. Mirror the rename mutation method (`rename(id:to:)`) on the store — Phase 2 added the `rename` shape on `AccountStore` / `EarmarkStore`; mirror it here.
+
+---
+
+## Task 7: UITestIdentifiers for groups
+
+**Files:**
+- Modify: `UITestSupport/UITestIdentifiers.swift`
+
+Add:
+
+```swift
+extension UITestIdentifiers.Sidebar {
+  /// Sidebar row for a specific group. `id` is the group's UUID, lowercased.
+  public static func group(_ id: UUID) -> String {
+    "sidebar.group.\(id.uuidString.lowercased())"
+  }
+
+  /// "Group ▸" submenu trigger in the account context menu.
+  public static let groupSubmenu = "sidebar.contextMenu.groupSubmenu"
+}
+```
+
+Apply `.accessibilityIdentifier(UITestIdentifiers.Sidebar.group(group.id))` to each group row in `SidebarView`.
+
+---
+
+## Task 8: Manual exercise + sidebar preview
+
+Verify in Xcode:
+1. Create two accounts in the same bucket; drag one onto the other → new group appears with both as members, rename field auto-focused.
+2. Drag a third account onto the group → member added.
+3. Drag a member out → reverts to standalone; group remains (1-member groups allowed).
+4. Drag the last member out → group disappears.
+5. Right-click an account → "Group ▸" submenu lists existing groups + "New Group…".
+6. Cross-bucket drag (drag a bank account onto a crypto account) → drop indicator does not appear; nothing happens on release.
+7. Click a group row → selection changes to `.group(id)`; detail view is empty / placeholder (Phase 5 wires this).
+8. Click a member row → selection changes to `.account(id)`; standard detail view (unchanged from today).
+9. Press Return on a selected group row → enters inline rename (Phase 2 path).
+10. Disclosure triangle expands / collapses; state persists across navigation within the same process (lost on app restart — Phase 8 persists).
+
+Document any deviation in the PR description as a known issue + follow-up.
+
+---
+
+## Task 9: Final verify + open PR
+
+- [ ] Full `just test`; `just format-check`.
+- [ ] Push and `gh pr create` — include the manual exercise checklist in the PR body.
+- [ ] `./.claude/skills/landing-prs/scripts/land-pr.sh <N>`.
+
+---
+
+## Acceptance criteria for Phase 4
+
+- `AccountGroupStore` exists with reactive observe + mutation surface (create, add, remove, rename, reorder).
+- `Accounts.groupAwareSidebar(groups:)` returns intermixed `[SidebarBucketEntry]` per bucket.
+- Sidebar renders group rows with disclosure + inline rename; members appear indented when expanded.
+- Drop on middle 50% of an account creates / joins a group; drops in gaps reorder; cross-bucket rejected.
+- "Group ▸" submenu on account right-click lists existing groups + "New Group…" + "Remove from Group" when applicable.
+- 1-member groups allowed; 0-member groups auto-delete.
+- `expandedGroupIds` in-memory state (Phase 8 persists later).
+- `SidebarSelection.group(UUID)` case added.
+- `UITestIdentifiers.Sidebar.group(id)` and `.groupSubmenu` available.
+- All store mutations covered by tests.
+- Sidebar group detail view selection routes to whatever placeholder Phase 5 will fill in (unblocked; can be empty for this PR).
+- Full `just test` passes; `just format-check` clean.
+
+---
+
+## What's NOT in this phase
+
+- **Phase 5** — composite detail view (the group's right-pane render).
+- **Phase 6** — description rendering for group transactions.
+- **Phase 7** — sync (groups still local-only).
+- **Phase 8** — `isExpandedInSidebar` persistence.

--- a/plans/2026-05-26-account-groups-phase-5-account-view-context-plan.md
+++ b/plans/2026-05-26-account-groups-phase-5-account-view-context-plan.md
@@ -1,0 +1,289 @@
+# Account Groups — Phase 5 Implementation Plan: `AccountViewContext` + detail view
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+> **Initial-version plan.** Written before Phase 4 lands on main. The detail-view file layout (`InvestmentAccountView`, `StandardAccountView`) is likely to evolve. Verify at execution time which view types still exist and update the file lists accordingly. The *seam* this plan introduces (`AccountViewContext`) is stable; the *which-view-binds-to-it* part is the part to recheck.
+
+**Goal:** Single detail view, single query shape — selecting either an `Account` or an `AccountGroup` in the sidebar produces the same rendering surface. The detail view binds to an `AccountViewContext` value built by the sidebar's selection logic; everything downstream (header, chart, positions, transactions, sync status) treats the context's `accountIds: [UUID]` set as the source of truth and never knows whether it came from one account or a group.
+
+**Architecture:** New `AccountViewContext` value type abstracts "what's selected and what does the detail view render". A new `AccountViewContextBuilder` (lives on `AccountStore` or as a free function) resolves `SidebarSelection → AccountViewContext`. Existing detail view (`InvestmentAccountView` and `StandardAccountView`) is refactored to consume the context rather than reading `Account` directly. A new `AggregatedSyncStatus` value collapses N per-member sync states into one. Group selection produces a context with `accountIds = members`; single-account selection produces a 1-element list — the same code path serves both.
+
+**Tech Stack:** SwiftUI, Swift Testing.
+
+**Spec:** `/Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/account-groups-design/plans/2026-05-26-account-groups-design.md` — see "Composite detail view".
+
+**Phase ordering:** Depends on **Phase 3** (`AccountGroup`) AND **Phase 4** (`SidebarSelection.group` case + `AccountGroupStore`). Independent of Phases 6 / 7 / 8 (Phase 6 builds on top of the context shape this phase introduces — but Phase 5 ships without it; descriptions stay account-centric until Phase 6).
+
+---
+
+## Worktree setup
+
+- [ ] Base off whichever of Phase 3 / Phase 4 merges later (or `origin/main` if both have merged). Worktree at `.worktrees/account-view-context`. Generate Xcode project.
+
+---
+
+## Task 1: Define `AccountViewContext`
+
+**Files:**
+- Create: `Features/Accounts/Models/AccountViewContext.swift`
+- Create: `MoolahTests/Features/AccountViewContextTests.swift`
+
+```swift
+import Foundation
+
+/// What the detail view renders. Built from `SidebarSelection`; the
+/// detail view binds to this rather than reading `Account` directly.
+/// Selecting a group produces a context with N member ids; selecting
+/// a single account produces a 1-element list. Same code path either
+/// way.
+struct AccountViewContext: Sendable, Equatable {
+  enum Kind: Sendable, Equatable { case account, group }
+
+  let kind: Kind
+  let displayName: String
+  /// The instrument the detail view displays totals in. For accounts
+  /// this is the account's `instrument`; for groups it's the group's
+  /// `instrument` (defaults to the profile's currency in Phase 3).
+  let displayInstrument: Instrument
+  /// The bucket the entity lives in. Drives any UI affordances that
+  /// differ across buckets (e.g. valuation-mode toggle only shows for
+  /// `.investments`).
+  let bucket: AccountBucket
+  /// The set of accounts whose data the detail view aggregates over.
+  /// Single account → `[account.id]`. Group → member ids.
+  /// **Order is preserved** so the "first account in this context"
+  /// (e.g. default for the New-Transaction button) is deterministic.
+  let accountIds: [UUID]
+  /// Aggregated sync status across `accountIds`. A 1-element input
+  /// collapses to the underlying per-account status unchanged.
+  let syncStatus: AggregatedSyncStatus
+
+  /// True when this context represents a single account that is
+  /// itself synced (crypto / exchange) — used to gate per-account
+  /// sync-config UI (retry button, last-sync indicator) that doesn't
+  /// make sense for groups.
+  var supportsPerAccountSyncControls: Bool {
+    if case .account = kind, accountIds.count == 1 { return true }
+    return false
+  }
+}
+```
+
+Add an `AggregatedSyncStatus` enum (separate file or in the same):
+
+```swift
+enum AggregatedSyncStatus: Sendable, Equatable {
+  case allSynced
+  case syncing(done: Int, total: Int)
+  case failed(memberIds: [UUID])
+
+  /// Collapses an array of per-member statuses to a single aggregate.
+  /// 1-element input returns the original (`.allSynced` if synced,
+  /// `.syncing(0,1)` if in progress, etc.) — same path serves single-
+  /// account headers.
+  static func aggregate(_ statuses: [AccountSyncStatus]) -> AggregatedSyncStatus {
+    if statuses.isEmpty { return .allSynced }
+    let failed = statuses.compactMap { /* extract member ids of failed accounts */ }
+    if !failed.isEmpty { return .failed(memberIds: failed) }
+    let pending = statuses.filter { $0.isInProgress }.count
+    if pending > 0 { return .syncing(done: statuses.count - pending, total: statuses.count) }
+    return .allSynced
+  }
+}
+```
+
+The exact shape of `AccountSyncStatus` already exists in the codebase (search `AccountSyncStatus` to find its declaration); the aggregator is a pure function over it.
+
+Tests:
+- `accountIds.count == 1, kind == .account` collapses correctly.
+- `accountIds.count > 1, kind == .group` produces the expected shape.
+- `supportsPerAccountSyncControls` is true only for single-account.
+- `AggregatedSyncStatus.aggregate(_:)` for: all-synced, one failed, all in-progress, mix.
+
+---
+
+## Task 2: Selection → context builder
+
+**Files:**
+- Modify: `Features/Accounts/AccountStore.swift` (add `func viewContext(for: SidebarSelection) -> AccountViewContext?`), or
+- Create: `Features/Accounts/AccountViewContextBuilder.swift` (free function / namespace)
+- Tests: `MoolahTests/Features/AccountViewContextBuilderTests.swift`
+
+The builder is a pure function over `(SidebarSelection, Accounts, [AccountGroup], per-account sync states)` → `AccountViewContext?` (nil for selections that don't render a detail view: `.allTransactions`, `.reports`, etc.).
+
+```swift
+enum AccountViewContextBuilder {
+  static func build(
+    for selection: SidebarSelection,
+    accounts: Accounts,
+    groups: [AccountGroup],
+    syncStatuses: [UUID: AccountSyncStatus]
+  ) -> AccountViewContext? {
+    switch selection {
+    case .account(let id):
+      guard let account = accounts.by(id: id) else { return nil }
+      return AccountViewContext(
+        kind: .account,
+        displayName: account.name,
+        displayInstrument: account.instrument,
+        bucket: account.bucket,
+        accountIds: [account.id],
+        syncStatus: AggregatedSyncStatus.aggregate([syncStatuses[account.id]].compactMap { $0 })
+      )
+    case .group(let id):
+      guard let group = groups.first(where: { $0.id == id }) else { return nil }
+      let members = accounts.ordered
+        .filter { $0.groupId == group.id }
+        .sorted(by: { $0.position < $1.position })
+      let memberStatuses = members.compactMap { syncStatuses[$0.id] }
+      return AccountViewContext(
+        kind: .group,
+        displayName: group.name,
+        displayInstrument: group.instrument,
+        bucket: group.bucket,
+        accountIds: members.map(\.id),
+        syncStatus: AggregatedSyncStatus.aggregate(memberStatuses)
+      )
+    case .earmark, .recentlyAdded, .allTransactions, .upcomingTransactions,
+         .categories, .reports, .analysis:
+      return nil
+    }
+  }
+}
+```
+
+Tests cover:
+- Account selection → 1-element `accountIds`, kind `.account`.
+- Group selection → N-element `accountIds` ordered by member position.
+- Group selection with 0 members (transient state during creation) → context with empty `accountIds` (the view renders a "no members" state — Phase 4's "1-member groups allowed" rule prevents this in normal use).
+- Unknown id returns nil.
+- Earmark selection returns nil (earmarks have their own detail view; out of scope here).
+
+---
+
+## Task 3: Refactor the detail view to bind to `AccountViewContext`
+
+**Files:**
+- Modify: `Features/Investments/Views/InvestmentAccountView.swift` (and any sibling files for current accounts)
+- Modify: `Features/Accounts/Views/StandardAccountView.swift`
+- Modify: the parent view that selects detail view by type (search for where these are constructed)
+- Tests: existing detail-view tests (if any) — verify still pass; add coverage if not present
+
+Strategy: introduce the context binding at the parent view (the one that picks `InvestmentAccountView` vs `StandardAccountView` by `Account.bucket`). For the group case, route to the same view that currently handles `investmentAccounts` (since both real user groups are investment-bucket; current-bucket groups are supported by the model but rare in practice).
+
+The detail view's `var body` currently reads `account.name`, `account.instrument`, etc. Replace with `viewContext.displayName`, `viewContext.displayInstrument`, etc. The header, chart, and positions table become context-driven.
+
+For the positions table and transactions list, the query shape already takes a set (or trivially converts):
+
+```swift
+// Old:
+let positions = accountStore.positions(for: account.id)
+// New:
+let positions = accountStore.positions(for: viewContext.accountIds)
+```
+
+Verify each downstream query supports the set shape. If a query is hard-coded for a single id, refactor it to take `Set<UUID>` (or `[UUID]`).
+
+**No Add Transaction button changes in this PR — Phase 6 covers the "defaults to first account in context" behaviour. For this PR, the New Transaction button defaults to `accountIds.first` (so it works for groups; for single-account it's still the account).**
+
+**No description-rendering changes** — TransactionRowView still receives `viewingAccountId: UUID?` from the detail view; for a group context, pass `nil` (the rows render with the no-context description style). Phase 6 generalises this with a per-row computation.
+
+---
+
+## Task 4: Wire `SidebarView` to construct the context on selection
+
+**Files:**
+- Modify: `Features/Navigation/SidebarView.swift`
+- Modify: the parent / NavigationStack / split-view container that holds the detail view
+
+Currently `SidebarView` binds `selection: Binding<SidebarSelection?>` to the parent. Add a sibling derived value:
+
+```swift
+var detailContext: AccountViewContext? {
+  guard let selection else { return nil }
+  return AccountViewContextBuilder.build(
+    for: selection,
+    accounts: accountStore.accounts,
+    groups: groupStore.groups,
+    syncStatuses: accountStore.syncStatuses)
+}
+```
+
+…and pass `detailContext` into the detail view. If the parent constructs the detail view via a `NavigationDestination` modifier, the destination closure becomes:
+
+```swift
+.navigationDestination(for: SidebarSelection.self) { selection in
+  if let context = AccountViewContextBuilder.build(for: selection, ...) {
+    AccountDetailView(context: context)   // unified entry point
+  } else {
+    // Earmark / Reports / etc. — existing routes
+  }
+}
+```
+
+Introduce a new umbrella `AccountDetailView` if neither `InvestmentAccountView` nor `StandardAccountView` reads from the context naturally — its only job is to switch on `context.bucket` and route to the right sub-view. Bucket = `.investments` → InvestmentAccountView; bucket = `.current` → StandardAccountView.
+
+---
+
+## Task 5: Aggregated balance + conversion-failure UX in the header
+
+**Files:**
+- Modify: detail-view header (wherever the balance card lives — search for `convertedCurrentTotal` / `convertedInvestmentTotal` usage near the header)
+- Modify: `AccountStore` to expose a per-context balance: `func aggregateBalance(for accountIds: [UUID]) -> InstrumentAmount?`
+
+Per `[[feedback_conversion_failure_ux]]`: if any member's conversion failed, the aggregate is marked **unavailable** (nil), never partial-summed. The header renders an "unavailable" badge in that case. Clicking the badge opens a popover listing which members failed (Phase 4-style affordance; can be a simple alert in this PR if popovers feel heavy).
+
+Tests:
+- 3 members all converted → sum.
+- 3 members, 1 conversion failed → nil (badge).
+- 1-member context, account converted → its converted balance.
+- 1-member context, account's conversion failed → nil.
+
+---
+
+## Task 6: Wire `aggregateBalance` into `AccountGroupSidebarRow`
+
+**Files:**
+- Modify: `Features/Navigation/SidebarView.swift` (the `groupRow` builder added by Phase 4)
+- Modify: `Features/Accounts/Views/AccountGroupSidebarRow.swift` (the row created in Phase 4 — wire its `aggregateBalance` parameter)
+
+Phase 4 left `aggregateBalance: nil` (placeholder ProgressView). Replace with:
+
+```swift
+let memberIds = members.map(\.id)
+let balance = accountStore.aggregateBalance(for: memberIds)
+AccountGroupSidebarRow(group: group, ..., aggregateBalance: balance, ...)
+```
+
+Conversion-failure UX in the sidebar: if `aggregateBalance` is nil, the row shows a small badge / dimmed amount slot — same treatment used by single-account rows when their conversion fails.
+
+---
+
+## Task 7: Final verify + open PR
+
+- [ ] `just test` (existing detail-view tests + new context / aggregation tests).
+- [ ] Manual verification: select an account → unchanged rendering; select a group → composite rendering with summed positions, merged transactions, group name in header.
+- [ ] `just format-check`; push; PR; auto-merge.
+
+---
+
+## Acceptance criteria for Phase 5
+
+- `AccountViewContext` value type exists with `accountIds: [UUID]`, `displayName`, `displayInstrument`, `bucket`, `syncStatus`.
+- `AggregatedSyncStatus` aggregates per-member statuses; 1-element input collapses to original.
+- `AccountViewContextBuilder.build(for:...)` resolves `SidebarSelection → AccountViewContext?`.
+- Detail view binds to context (header, chart, positions, transactions all read from context).
+- Group selection renders composite detail view via the same view code as a single-account selection.
+- Aggregate balance respects conversion-failure UX (unavailable, never partial-sum).
+- `AccountGroupSidebarRow` shows the aggregate balance via the same store path.
+- Per-account sync controls (retry, last-sync) are gated to single-account contexts.
+- New Transaction button on a group context defaults to first member in `accountIds`.
+- Full `just test`; `just format-check`.
+
+---
+
+## What's NOT in this phase
+
+- **Phase 6** — `accountContext`-based transaction description rendering (in this phase, group view passes `viewingAccountId: nil` and uses today's no-context style).
+- **Phase 8** — `isExpandedInSidebar` persistence (still in-memory).
+- Per-account sync-status surfacing on the composite header (an inline list of failed members in the badge popover) — basic "1 member failed" + alert is the v1 surface; the rich popover can be a follow-up if user testing shows the alert isn't enough.

--- a/plans/2026-05-26-account-groups-phase-6-description-rendering-plan.md
+++ b/plans/2026-05-26-account-groups-phase-6-description-rendering-plan.md
@@ -1,0 +1,246 @@
+# Account Groups — Phase 6 Implementation Plan: Description rendering
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+> **Initial-version plan.** Written before Phase 5 lands. The exact `TransactionRowView` / description-rendering call signatures may have moved during Phase 5's refactor. The rule this plan establishes is stable; the call-site wiring is the part to recheck.
+
+**Goal:** Replace the existing `viewingAccountId: UUID?` perspective hint in transaction rendering with a per-row `accountContext: UUID?` computed from the selected view's `accountIds` set. Result: when a group is selected, transactions touching exactly one member render from that member's perspective ("Transfer from external_account"); transactions touching multiple members render in the no-context style ("Transfer from member_A to member_B"). Same code path serves single-account, group, and all-accounts views.
+
+**Architecture:** The transaction-description function (currently keyed on `viewingAccountId`) generalises to take `accountContext: UUID?`. The view derives the context per row: `let inScope = tx.legs.map(\.accountId).filter { accountIds.contains($0) }; let accountContext = inScope.count == 1 ? inScope.first : nil`. No new types; the existing function gains the new semantics, callers thread `accountIds` instead of a single id.
+
+**Tech Stack:** SwiftUI, Swift Testing.
+
+**Spec:** `/Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/account-groups-design/plans/2026-05-26-account-groups-design.md` — see "Description rendering & internal transfers".
+
+**Phase ordering:** Depends on **Phase 5** (`AccountViewContext.accountIds`). Independent of Phase 7 / 8.
+
+---
+
+## Worktree setup
+
+- [ ] Base off whichever of Phase 5 has merged (or `origin/main` if it has). Worktree at `.worktrees/transaction-description-context`. Generate.
+
+---
+
+## Task 1: Locate the existing description-rendering path
+
+**No files modified yet — investigation step.**
+
+```bash
+grep -rn "viewingAccountId" /Users/aj/Documents/code/moolah-project/moolah-native/Features/Transactions \
+  /Users/aj/Documents/code/moolah-project/moolah-native/Domain 2>/dev/null
+```
+
+Map out:
+1. The function or computed property that produces the description string (likely on `Transaction` or a free function in a `+Description.swift` file, or inline in `TransactionRowView`).
+2. Every caller — `TransactionRowView` is the main one; check whether the `RecentlyAddedView`, transaction-detail panel, and exports also use it.
+3. The shape of the perspective hint today (a single `UUID?` per the existing `viewingAccountId` parameter on `TransactionRowView`).
+
+Write a one-page note (in the agent's scratch) of the mapping. The next tasks edit each site.
+
+---
+
+## Task 2: Lock in current behaviour with tests
+
+**Files:**
+- Create or modify: `MoolahTests/Domain/TransactionDescriptionTests.swift` (or sibling) — pin the existing renderings before refactoring
+
+For each existing perspective behaviour, write a regression test using a small synthetic transaction. The goal: the refactor must not change description text for any case other than the new "group view with multi-member transaction" case.
+
+Cases to cover:
+- Single-leg expense, account = X, perspective = X → existing description text.
+- Two-leg transfer between X and Y, perspective = X → "Transfer to Y".
+- Two-leg transfer between X and Y, perspective = Y → "Transfer from X".
+- Two-leg transfer between X and Y, no perspective → "Transfer from X to Y" (no-context style).
+- Three-leg trade — verify both perspective-set and no-perspective renderings.
+
+These tests will continue to pass through the refactor — Phase 6 doesn't change semantics for single-account / all-accounts views, only adds the new group-view behaviour.
+
+```bash
+just test TransactionDescriptionTests
+```
+
+Expected: all green against existing implementation.
+
+---
+
+## Task 3: Generalise the description function signature
+
+**Files:**
+- Modify: wherever the description function lives (Task 1's investigation).
+
+Rename / add an overload. The new signature:
+
+```swift
+/// Per-row description string. `accountContext` is the perspective
+/// from which the description is phrased — typically the single
+/// in-scope account for the current view, or nil when the view spans
+/// multiple in-scope accounts (e.g. the all-accounts list, or a group
+/// view where this row touches more than one member).
+func transactionDescription(
+  _ tx: Transaction,
+  accountContext: UUID?,
+  accounts: Accounts,
+  categories: Categories,
+  // …whatever other dependencies the current function takes
+) -> String
+```
+
+The semantics:
+- `accountContext == nil` → use the no-context style ("Transfer from X to Y").
+- `accountContext == some` → use the perspective style ("Transfer to Y" / "Transfer from X").
+
+The body of the function shouldn't change much — it already had a `viewingAccountId: UUID?` path. Rename internally; preserve existing branches.
+
+If the existing function is named `transactionDescription` and has a `viewingAccountId` parameter, just rename the parameter to `accountContext` and update all callers.
+
+---
+
+## Task 4: Replace `viewingAccountId` callers with per-row context derivation
+
+**Files:**
+- Modify: `Features/Transactions/Views/TransactionRowView.swift` (and `+Preview.swift` if it constructs sample data with the old name)
+- Modify: the transaction list view in the detail view (search for `TransactionRowView(`)
+
+`TransactionRowView` today takes `viewingAccountId: UUID?` as a property. Update the property name:
+
+```swift
+struct TransactionRowView: View {
+  // …
+  /// The perspective from which this row's description is rendered.
+  /// Derived per-row by the parent from the view's `accountIds`:
+  /// nil when the transaction touches multiple in-scope accounts
+  /// (no-context style), or the single in-scope account id otherwise.
+  var accountContext: UUID?
+  // …
+}
+```
+
+In the parent (transaction list within the detail view), derive the per-row context from `AccountViewContext.accountIds`:
+
+```swift
+let inScopeIds: Set<UUID> = Set(viewContext.accountIds)
+ForEach(transactions) { tx in
+  let inScope = tx.legs.lazy.map(\.accountId).filter { inScopeIds.contains($0) }
+  let context: UUID? = (inScope.count == 1) ? inScope.first : nil
+  TransactionRowView(
+    transaction: tx,
+    accountContext: context,
+    // …other params
+  )
+}
+```
+
+For the all-accounts list (no detail-view context), `accountIds` is effectively "all" — multi-leg transactions will have `count > 1` → context = nil → same no-context rendering as today.
+
+For the single-account detail view, `accountIds = [account.id]` → inScope = `[account.id]` (assuming the row is shown because it touches the account) → context = the account → same perspective rendering as today.
+
+For the group detail view, the new behaviour kicks in: rows touching exactly one member render from that member's perspective; rows touching multiple members render no-context.
+
+---
+
+## Task 5: Verify against the regression tests + add group-context cases
+
+**Files:**
+- Modify: `MoolahTests/Domain/TransactionDescriptionTests.swift`
+
+Existing regression tests should still pass (no semantic change for single-account / all-accounts). Add new cases:
+
+```swift
+@Test
+func groupViewSingleInScopeLegRendersFromMemberPerspective() {
+  let memberA = Account(...)
+  let external = Account(...)
+  let tx = makeTransfer(from: memberA, to: external, amount: ...)
+
+  // Group context contains memberA + memberB; transaction touches only memberA.
+  let memberIds: Set<UUID> = [memberA.id, memberB.id]
+  let inScope = tx.legs.map(\.accountId).filter { memberIds.contains($0) }
+  let context: UUID? = inScope.count == 1 ? inScope.first : nil
+
+  #expect(context == memberA.id)
+  let desc = transactionDescription(tx, accountContext: context, accounts: ..., categories: ...)
+  #expect(desc == "Transfer to external_account_name")
+}
+
+@Test
+func groupViewMultipleInScopeLegsRendersNoContext() {
+  let memberA = Account(...)
+  let memberB = Account(...)
+  let tx = makeTransfer(from: memberA, to: memberB, amount: ...)   // intra-group bridge
+
+  let memberIds: Set<UUID> = [memberA.id, memberB.id]
+  let inScope = tx.legs.map(\.accountId).filter { memberIds.contains($0) }
+  let context: UUID? = inScope.count == 1 ? inScope.first : nil
+
+  #expect(context == nil)
+  let desc = transactionDescription(tx, accountContext: context, accounts: ..., categories: ...)
+  #expect(desc == "Transfer from memberA_name to memberB_name")
+}
+
+@Test
+func allAccountsViewMultiLegTransactionAlwaysNoContext() {
+  let a = Account(...)
+  let b = Account(...)
+  let tx = makeTransfer(from: a, to: b, amount: ...)
+
+  // All-accounts view: inScopeIds = all accounts (effectively unconstrained).
+  let inScope = tx.legs.map(\.accountId)   // both legs in scope
+  let context: UUID? = inScope.count == 1 ? inScope.first : nil
+
+  #expect(context == nil)
+  // Matches today's all-accounts list rendering — pinning here.
+  let desc = transactionDescription(tx, accountContext: context, accounts: ..., categories: ...)
+  #expect(desc == "Transfer from a_name to b_name")
+}
+```
+
+Run:
+
+```bash
+just test TransactionDescriptionTests
+```
+
+---
+
+## Task 6: Internal-transfer visibility (no filter)
+
+**No new code** — just confirm the spec's "internal transfers are shown" rule (no filter UI, no toggle):
+
+- Select a group in the sidebar.
+- Verify that bridge transactions between two members appear in the list.
+- Verify they render in the no-context style ("Transfer from memberA to memberB").
+- Verify their gas-cost legs also render (no filtering).
+
+If the existing transaction-list view filters by `viewingAccountId` (only showing transactions that touch the selected account), update it for group contexts: a transaction qualifies if it touches *any* `accountId` in `viewContext.accountIds`. This is a query change — likely a small change to the existing transaction-fetch logic in the detail view's transaction list.
+
+---
+
+## Task 7: Manual exercise + open PR
+
+Verify in the running app:
+1. Select an account → unchanged description text for every transaction.
+2. Select a group → transactions touching one member read from that member's perspective; cross-member bridges show "Transfer from … to …".
+3. Select "All Transactions" → unchanged.
+
+`just test`; `just format-check`; push; PR; auto-merge.
+
+---
+
+## Acceptance criteria for Phase 6
+
+- Description rendering function takes `accountContext: UUID?`.
+- `TransactionRowView` exposes `accountContext: UUID?` (renamed from `viewingAccountId`).
+- Parent views derive `accountContext` per row from `AccountViewContext.accountIds` (single in-scope leg → that account; multiple → nil).
+- Regression tests cover single-account, all-accounts, and group views.
+- Group-view bridge transactions render in no-context style + show gas-cost legs.
+- Transaction-list query filters by membership in `accountIds` set rather than equality with a single account id.
+- Full `just test` passes; `just format-check` clean.
+
+---
+
+## What's NOT in this phase
+
+- An "Internal Transfers" filter toggle — user explicitly chose to show them always.
+- Inline summary chips ("3 internal transfers" headers) — out of scope.
+- Cross-currency description nuances beyond what already exists — Phase 6 only changes perspective, not formatting.

--- a/plans/2026-05-26-account-groups-phase-8-expand-state-persistence-plan.md
+++ b/plans/2026-05-26-account-groups-phase-8-expand-state-persistence-plan.md
@@ -1,0 +1,319 @@
+# Account Groups — Phase 8 Implementation Plan: Sidebar expand-state persistence
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+> **Initial-version plan.** Smallest of the remaining phases. Touches one small new GRDB table and one swap in the sidebar's `expandedGroupIds` source-of-truth.
+
+**Goal:** Persist each group's `isExpandedInSidebar` state per profile, so a user's "I always have Personal Crypto expanded" preference survives app launches. The state stays **local-only** — never synced via CloudKit (intentional per spec; expand/collapse is per-device UX state, not data).
+
+**Architecture:** New `account_group_ui` GRDB table on the per-profile `data.sqlite` (same DB the rest of the per-profile records live on). The table is `STRICT`, has a single `group_id BLOB PRIMARY KEY` and `is_expanded INTEGER NOT NULL DEFAULT 0` column, and is excluded from CKSyncEngine wiring (not registered in `RecordTypeRegistry`). A small `GroupUIStateRepository` reads / writes; `SidebarView`'s in-memory `Set<UUID>` from Phase 4 is replaced by a `Binding` driven by the repo.
+
+The table is the project's first **truly local-only persisted** state (per-device sync state from `wallet_sync_state` is similar but is conceptually different — it's protocol-level checkpointing, not UI preferences). The pattern this phase establishes is reusable for future local-only UI state.
+
+**Tech Stack:** GRDB, Swift Testing.
+
+**Spec:** `/Users/aj/Documents/code/moolah-project/moolah-native/.worktrees/account-groups-design/plans/2026-05-26-account-groups-design.md` — see "Local-only state".
+
+**Phase ordering:** Depends on **Phase 3** (`account_group` table must exist for the FK ON DELETE cascade) AND **Phase 4** (the in-memory `expandedGroupIds` set is what this phase replaces). Independent of Phases 5 / 6 / 7 — can run in parallel with any of them once Phases 3 + 4 land.
+
+---
+
+## Worktree setup
+
+- [ ] Worktree off whichever of Phase 3 / Phase 4 merges later (or `origin/main`). Path: `.worktrees/group-ui-state-persistence`. Generate Xcode project.
+
+---
+
+## Task 1: GRDB migration — `account_group_ui` table
+
+**Files:**
+- Create: `Backends/GRDB/ProfileSchema+AccountGroupUIState.swift`
+- Modify: `Backends/GRDB/ProfileSchema.swift` (register the migration)
+- Tests: `MoolahTests/Backends/GRDB/AccountGroupUIStateMigrationTests.swift`
+
+- [ ] **Step 1: Write the migration body**
+
+```swift
+// Backends/GRDB/ProfileSchema+AccountGroupUIState.swift
+
+import Foundation
+import GRDB
+
+extension ProfileSchema {
+  /// v15 migration. Adds the per-profile local-only `account_group_ui`
+  /// table for sidebar expand / collapse state. Intentionally **not**
+  /// synced via CloudKit — expand state is per-device UX preference,
+  /// not data.
+  ///
+  /// `ON DELETE CASCADE` on `group_id` so the row is reaped automatically
+  /// when the underlying group is deleted (locally or via incoming
+  /// CKSyncEngine delete). This is the one FK in the account-groups
+  /// schema; safe because both tables live in the same DB and FK
+  /// enforcement is on (no sync-ordering hazard — the parent row was
+  /// created first and any cascade fires within the same transaction
+  /// as the parent delete).
+  static func addAccountGroupUIState(_ database: Database) throws {
+    try database.execute(
+      sql: """
+        CREATE TABLE account_group_ui (
+            group_id     BLOB    NOT NULL PRIMARY KEY
+                         REFERENCES account_group(id) ON DELETE CASCADE,
+            is_expanded  INTEGER NOT NULL DEFAULT 0
+        ) STRICT;
+        """)
+  }
+}
+```
+
+Wait — Phase 3 explicitly chose **no FK** for `account.group_id` because of sync-ordering. The same concern doesn't apply here: `account_group_ui` is local-only (never receives writes from sync), and its `group_id` references the locally-persisted `account_group.id`. The parent row is guaranteed to exist when a UI-state row is written, because the UI-state write happens after the user has interacted with a group that is on-screen, which means it has been observed locally.
+
+Confirm this reasoning at execution time; if you find a path where UI-state could be written before the group exists (e.g. background restore from a backup), drop the FK and rely on a periodic cleanup task instead.
+
+- [ ] **Step 2: Register the migration**
+
+In `Backends/GRDB/ProfileSchema.swift`:
+1. Bump `static let version = 14` → `static let version = 15`.
+2. Append the doc-comment history entry.
+3. Register the migration after the v14 entry:
+
+```swift
+    migrator.registerMigration(
+      "v15_account_group_ui_state", migrate: addAccountGroupUIState)
+```
+
+- [ ] **Step 3: Migration smoke test**
+
+```swift
+@Suite("v15_account_group_ui_state migration")
+struct AccountGroupUIStateMigrationTests {
+  @Test
+  func createsTableAndCascadeFK() throws {
+    let queue = try DatabaseQueue()
+    try ProfileSchema.migrator.migrate(queue)
+
+    try queue.read { db in
+      let cols = try Row.fetchAll(db, sql: "PRAGMA table_info(account_group_ui)")
+        .map { $0["name"] as String }
+      #expect(cols == ["group_id", "is_expanded"])
+
+      let fks = try Row.fetchAll(db, sql: "PRAGMA foreign_key_list(account_group_ui)")
+      #expect(fks.count == 1)
+      let onDelete = fks.first?["on_delete"] as? String
+      #expect(onDelete == "CASCADE")
+    }
+  }
+
+  @Test
+  func cascadeDeletesUIStateWhenGroupDeleted() throws {
+    let queue = try DatabaseQueue()
+    try ProfileSchema.migrator.migrate(queue)
+
+    let groupId = UUID()
+    try queue.write { db in
+      try db.execute(
+        sql: """
+          INSERT INTO account_group (id, record_name, name, bucket, instrument_id, position)
+          VALUES (?, ?, 'G', 'investments', 'AUD', 0)
+          """,
+        arguments: [groupId.data, "AccountGroupRecord|\(groupId.uuidString)"])
+      try db.execute(
+        sql: "INSERT INTO account_group_ui (group_id, is_expanded) VALUES (?, 1)",
+        arguments: [groupId.data])
+    }
+
+    try queue.write { db in
+      try db.execute(sql: "DELETE FROM account_group WHERE id = ?", arguments: [groupId.data])
+    }
+
+    try queue.read { db in
+      let count = try Int.fetchOne(
+        db, sql: "SELECT COUNT(*) FROM account_group_ui WHERE group_id = ?",
+        arguments: [groupId.data])
+      #expect(count == 0)
+    }
+  }
+}
+```
+
+(`UUID.data` — verify this helper exists or use whatever the project uses to bind a UUID to a BLOB column. Search for `id.data` / `uuid.data` callers in existing GRDB code.)
+
+---
+
+## Task 2: `GroupUIStateRepository`
+
+**Files:**
+- Create: `Domain/Repositories/GroupUIStateRepository.swift` (protocol)
+- Create: `Backends/GRDB/Repositories/GRDBGroupUIStateRepository.swift` (impl)
+- Modify: `Domain/Repositories/BackendProvider.swift` (add `groupUIState`)
+- Modify: every `BackendProvider` conformer
+- Tests: `MoolahTests/Domain/GroupUIStateRepositoryContractTests.swift`
+
+The protocol:
+
+```swift
+protocol GroupUIStateRepository: Sendable {
+  /// Returns true if the group is currently expanded in the sidebar.
+  /// Returns `false` when no row exists (default collapsed).
+  func isExpanded(groupId: UUID) async throws -> Bool
+
+  /// Persists the expand state for a single group.
+  func setExpanded(_ expanded: Bool, for groupId: UUID) async throws
+
+  /// Fetches all expanded group ids (everything not in the set is
+  /// collapsed). Useful for seeding the sidebar in one query.
+  func expandedGroupIds() async throws -> Set<UUID>
+
+  /// Hot stream of expanded-id sets. Emits an initial snapshot and
+  /// again on every persisted change. Used by `SidebarView` to drive
+  /// the per-group binding.
+  func observeExpandedGroupIds() -> AsyncThrowingStream<Set<UUID>, any Error>
+}
+```
+
+GRDB implementation:
+
+```swift
+struct GRDBGroupUIStateRepository: GroupUIStateRepository {
+  let database: DatabaseWriter
+
+  func isExpanded(groupId: UUID) async throws -> Bool {
+    try await database.read { db in
+      let row = try Row.fetchOne(
+        db, sql: "SELECT is_expanded FROM account_group_ui WHERE group_id = ?",
+        arguments: [groupId.data])
+      return (row?["is_expanded"] as? Int ?? 0) != 0
+    }
+  }
+
+  func setExpanded(_ expanded: Bool, for groupId: UUID) async throws {
+    try await database.write { db in
+      // UPSERT on the primary key.
+      try db.execute(
+        sql: """
+          INSERT INTO account_group_ui (group_id, is_expanded) VALUES (?, ?)
+          ON CONFLICT(group_id) DO UPDATE SET is_expanded = excluded.is_expanded
+          """,
+        arguments: [groupId.data, expanded ? 1 : 0])
+    }
+  }
+
+  func expandedGroupIds() async throws -> Set<UUID> {
+    try await database.read { db in
+      let rows = try Row.fetchAll(
+        db, sql: "SELECT group_id FROM account_group_ui WHERE is_expanded = 1")
+      return Set(rows.compactMap { ($0["group_id"] as? Data).flatMap { UUID(data: $0) } })
+    }
+  }
+
+  func observeExpandedGroupIds() -> AsyncThrowingStream<Set<UUID>, any Error> {
+    let observation = ValueObservation.tracking { db in
+      try Row.fetchAll(
+        db, sql: "SELECT group_id FROM account_group_ui WHERE is_expanded = 1"
+      )
+      .compactMap { ($0["group_id"] as? Data).flatMap { UUID(data: $0) } }
+    }
+    return AsyncThrowingStream { continuation in
+      let cancellable = observation.start(in: database) { error in
+        continuation.finish(throwing: error)
+      } onChange: { ids in
+        continuation.yield(Set(ids))
+      }
+      continuation.onTermination = { _ in cancellable.cancel() }
+    }
+  }
+}
+```
+
+Contract tests cover:
+- Default `false` for unknown group.
+- Set → read returns true; unset → read returns false.
+- `expandedGroupIds()` returns the set of true rows.
+- `observeExpandedGroupIds()` emits on changes.
+- Cascade delete (covered by the migration test) — repo's `isExpanded` returns false after parent group is deleted.
+
+Wire `groupUIState` into `BackendProvider`:
+
+```swift
+var groupUIState: any GroupUIStateRepository { get }
+```
+
+…and into every conformer (`CloudKitBackend`, `TestBackend`, `PreviewBackend`) — same shape as Phase 3 Task 8.
+
+---
+
+## Task 3: `GroupUIStateStore`
+
+**Files:**
+- Create: `Features/Accounts/GroupUIStateStore.swift`
+- Tests: `MoolahTests/Features/GroupUIStateStoreTests.swift`
+
+A small `@Observable @MainActor` store that subscribes to `repository.observeExpandedGroupIds()` and exposes:
+- `var expandedGroupIds: Set<UUID> = []`
+- `func toggle(_ groupId: UUID) async`
+- `func setExpanded(_ expanded: Bool, for groupId: UUID) async`
+
+The toggle method writes to the repo; the reactive observation fires back and updates `expandedGroupIds`. Same pattern as `EarmarkStore.update` / `AccountStore.update` — pass-through with reactive observation.
+
+---
+
+## Task 4: Wire `GroupUIStateStore` into `SidebarView`
+
+**Files:**
+- Modify: `Features/Navigation/SidebarView.swift` (replace Phase 4's `@State private var expandedGroupIds: Set<UUID> = []`)
+
+Replace the in-memory state with:
+
+```swift
+@Environment(GroupUIStateStore.self) private var groupUIStateStore
+```
+
+…and the per-group binding in `groupRow`:
+
+```swift
+let expandBinding = Binding<Bool>(
+  get: { groupUIStateStore.expandedGroupIds.contains(group.id) },
+  set: { isExpanded in
+    Task { await groupUIStateStore.setExpanded(isExpanded, for: group.id) }
+  }
+)
+```
+
+The reactive observation closes the loop: setExpanded → repo write → observation emits new set → `expandedGroupIds` updates → binding's `get` returns the new value → SwiftUI re-renders.
+
+Inject `GroupUIStateStore` wherever the other stores are injected (search for `.environment(EarmarkStore`).
+
+---
+
+## Task 5: Manual verification
+
+- Open the app; expand a group; quit + relaunch → still expanded.
+- Expand on Device A; do NOT expect to see it expanded on Device B (the table is local-only). Confirm in the manual cross-device step.
+- Delete a group whose UI-state row was 1 → migration test already covers the cascade; verify in the running app that no orphan row warning appears in logs.
+
+---
+
+## Task 6: Final verify + open PR
+
+- [ ] `just test`; `just format-check`.
+- [ ] Push; `gh pr create`; `land-pr.sh`.
+
+---
+
+## Acceptance criteria for Phase 8
+
+- `account_group_ui` table exists after v15 migration; FK with `ON DELETE CASCADE` to `account_group(id)`.
+- `GroupUIStateRepository` protocol + GRDB impl + wired into every `BackendProvider` conformer.
+- `GroupUIStateStore` reactive store exposes `expandedGroupIds: Set<UUID>` and `setExpanded(_:for:)`.
+- `SidebarView` drives expand bindings from the store (Phase 4's in-memory state removed).
+- Expand state survives app relaunch.
+- Cascade delete reaps UI-state row when parent group is deleted.
+- Local-only — no CloudKit wiring; `account_group_ui` is NOT in `RecordTypeRegistry.allTypes`.
+- Full `just test` passes; `just format-check` clean.
+
+---
+
+## What's NOT in this phase
+
+- Cross-device sync of expand state (intentional — would be a different feature, not part of Account Groups).
+- A "Reset all expand state" UI affordance (out of scope; user can drop the local DB if they want).
+- Persistence of the bucket-section expand state (already handled by SwiftUI's `Section`; doesn't need our table).


### PR DESCRIPTION
## Summary

Initial-version implementation plans for the remaining Account Groups phases:

- **Phase 4** (`...phase-4-sidebar-ux-plan.md`) — 9 tasks. Sidebar group rows + drop semantics (middle-50% vs edge-25%) + creation flows (drag-onto-account + right-click "Group ▸" submenu). New \`AccountGroupStore\`, group-aware sidebar ordering, \`AccountGroupSidebarRow\`. Largest UI shift. Depends on Phases 2 + 3.

- **Phase 5** (\`...phase-5-account-view-context-plan.md\`) — 7 tasks. \`AccountViewContext\` value type abstracts \"selected account vs selected group\"; single detail view binds to it. \`AggregatedSyncStatus\` collapses per-member states (1-element input collapses to original). Aggregated balance respects \`feedback_conversion_failure_ux\`. Depends on Phases 3 + 4.

- **Phase 6** (\`...phase-6-description-rendering-plan.md\`) — 7 tasks. Generalise transaction-description function to take \`accountContext: UUID?\`; views derive it per row from \`accountIds\`. Internal transfers shown (no filter). Regression tests lock in single-account and all-accounts behaviour. Depends on Phase 5.

- **Phase 8** (\`...phase-8-expand-state-persistence-plan.md\`) — 6 tasks. Local-only GRDB v15 \`account_group_ui\` table + repo + reactive store; replaces Phase 4's in-memory \`Set<UUID>\`. Local-only (no CloudKit). Depends on Phases 3 + 4; can land in parallel with Phases 5 / 6 / 7.

## Phase dependency graph

\`\`\`
Phase 1 (bucket) ──┐
                   ├── Phase 3 (model + schema) ──┬── Phase 4 (sidebar UX) ──┬── Phase 5 (view context) ──── Phase 6 (descriptions)
Phase 2 (rename) ──┘                              │                          ├── Phase 8 (expand persist)
                                                  └── Phase 7 (sync wiring)
\`\`\`

Maximum parallel window after Phase 3 lands: Phases **4, 7** can run in parallel. After Phase 4 lands: Phases **5, 7, 8** can run in parallel.

## Style note

All four plans are explicitly tagged as **initial-version** — code paths and line numbers should be reconciled with main at execution time, since this is a long feature and main will have moved. The architectural decisions (entity shapes, drop policies, conversion-failure UX, context-derivation rule, local-only table) are stable.

## Scope

Docs only.

## Test plan

- [x] Each plan self-reviewed for spec coverage, placeholder absence, and dependency consistency
- [ ] N/A — no executable code