### PR TITLE
feat(sidebar): inline rename for accounts and earmarks

### DIFF
--- a/Features/Accounts/AccountStore+Mutations.swift
+++ b/Features/Accounts/AccountStore+Mutations.swift
@@ -57,6 +57,21 @@ extension AccountStore {
     }
   }
 
+  /// Convenience rename. Trims whitespace; treats empty / whitespace-only
+  /// input as a revert (no write, returns the current account unchanged).
+  /// Same-name input is also a no-op. The reactive observation delivers
+  /// the renamed account; `surfaceError` handling is delegated to
+  /// `update(_:)`.
+  @discardableResult
+  func rename(id: UUID, to newName: String) async throws -> Account? {
+    let trimmed = newName.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard let account = accounts.by(id: id) else { return nil }
+    guard !trimmed.isEmpty, trimmed != account.name else { return account }
+    var updated = account
+    updated.name = trimmed
+    return try await update(updated)
+  }
+
   /// Persists a new ordering. Each underlying `update` is awaited
   /// sequentially; the first error is captured and surfaced. The
   /// reactive observation delivers the authoritative ordering once the

--- a/Features/Accounts/AccountStore+Mutations.swift
+++ b/Features/Accounts/AccountStore+Mutations.swift
@@ -57,11 +57,12 @@ extension AccountStore {
     }
   }
 
-  /// Convenience rename. Trims whitespace; treats empty / whitespace-only
-  /// input as a revert (no write, returns the current account unchanged).
-  /// Same-name input is also a no-op. The reactive observation delivers
-  /// the renamed account; `surfaceError` handling is delegated to
-  /// `update(_:)`.
+  /// Convenience rename for the inline-rename UI flow. Trims whitespace;
+  /// treats empty / whitespace-only input as a no-op (no write; returns the
+  /// current account unchanged). Same-name input is also a no-op. Guards the
+  /// call site so a cleared or unchanged field does not issue a repository
+  /// write. Errors propagate through `update(_:)`, which captures them on
+  /// `self.error` and rethrows.
   @discardableResult
   func rename(id: UUID, to newName: String) async throws -> Account? {
     let trimmed = newName.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Features/Accounts/Views/AccountSidebarRow.swift
+++ b/Features/Accounts/Views/AccountSidebarRow.swift
@@ -126,7 +126,12 @@ struct SidebarRowView: View {
         },
         onCancel: { isEditing.wrappedValue = false }
       )
-    } else if let isEditing, onRename != nil {
+    } else if let isEditing, onRename != nil, isSelected {
+      // Finder pattern: rename gesture only attaches once the row is
+      // selected. Attaching `.onTapGesture(count: 2)` on an unselected
+      // row's Text makes SwiftUI hold the first click waiting for a
+      // second, which prevents the parent NavigationLink from receiving
+      // the click and updating selection.
       Text(name)
         .onTapGesture(count: 2) { isEditing.wrappedValue = true }
     } else {

--- a/Features/Accounts/Views/AccountSidebarRow.swift
+++ b/Features/Accounts/Views/AccountSidebarRow.swift
@@ -167,6 +167,8 @@ struct SidebarRowView: View {
 struct AccountSidebarRow: View {
   let account: Account
   var isSelected: Bool = false
+  var isEditing: Binding<Bool>?
+  var onRename: ((String) -> Void)?
   @Environment(AccountStore.self) private var accountStore
 
   var body: some View {
@@ -175,7 +177,9 @@ struct AccountSidebarRow: View {
       name: account.name,
       amount: accountStore.convertedBalances[account.id],
       isSelected: isSelected,
-      unsetIndicator: accountStore.hasUnrecordedValue(account) ? "Not set" : nil
+      unsetIndicator: accountStore.hasUnrecordedValue(account) ? "Not set" : nil,
+      isEditing: isEditing,
+      onRename: onRename
     )
   }
 }

--- a/Features/Accounts/Views/AccountSidebarRow.swift
+++ b/Features/Accounts/Views/AccountSidebarRow.swift
@@ -10,6 +10,47 @@ import SwiftUI
 /// guides/UI_GUIDE.md §5 "Selected-Row Contrast Override (Exception)"
 /// for the rationale and the rule that this is the only place in the
 /// app where hardcoded RGB values are permitted.
+///
+/// **Inline rename:** when both `isEditing` and `onRename` are provided,
+/// the row supports double-click-to-rename. Callers that do not opt in
+/// still receive a double-click gesture that no-ops, so do not attach a
+/// competing double-click handler to a `SidebarRowView`.
+
+/// TextField used by `SidebarRowView` while a row is in inline-rename
+/// mode. Auto-focuses on appear; commits on Return or focus loss (calls
+/// `onCommit`); cancels on Escape (calls `onCancel`). Separated from
+/// `SidebarRowView` so the focus/selection machinery is testable in
+/// isolation via #Preview.
+private struct InlineRenameField: View {
+  let initialText: String
+  let onCommit: (String) -> Void
+  let onCancel: () -> Void
+
+  @State private var text: String = ""
+  @FocusState private var isFocused: Bool
+
+  var body: some View {
+    TextField("", text: $text)
+      .textFieldStyle(.plain)
+      .focused($isFocused)
+      .onAppear {
+        text = initialText
+        isFocused = true
+      }
+      .onSubmit { onCommit(text) }
+      .onChange(of: isFocused) { _, focused in
+        // Focus loss without an explicit submit = commit (matches
+        // Finder-style rename). Escape will have set onCancel via
+        // .onKeyPress before focus drops.
+        if !focused { onCommit(text) }
+      }
+      .onKeyPress(.escape) {
+        onCancel()
+        return .handled
+      }
+  }
+}
+
 struct SidebarRowView: View {
   let icon: String
   let name: String
@@ -22,6 +63,16 @@ struct SidebarRowView: View {
   /// the user's mental model of the column. See guides/UI_GUIDE.md §"Not set"
   /// and `INSTRUMENT_CONVERSION_GUIDE.md` Rule 11 for the rationale.
   var unsetIndicator: String?
+  /// When non-nil, the row supports inline rename. The caller flips
+  /// `isEditing.wrappedValue` to true (via double-click, context menu,
+  /// or keyboard shortcut). The row renders a `TextField` instead of
+  /// `Text(name)` while editing; on commit (Return / focus loss) it
+  /// calls `onRename` with the entered text (trimmed by the store).
+  /// On Escape, it sets `isEditing` to false without calling `onRename`.
+  /// Caller is responsible for ensuring only one row is editing at a
+  /// time — there is no global coordination inside this view.
+  var isEditing: Binding<Bool>?
+  var onRename: ((String) -> Void)?
 
   @Environment(\.backgroundProminence) private var backgroundProminence
 
@@ -48,7 +99,7 @@ struct SidebarRowView: View {
         .frame(width: UIConstants.IconSize.listIcon, height: UIConstants.IconSize.listIcon)
         .accessibilityHidden(true)
 
-      Text(name)
+      nameContent
 
       Spacer()
 
@@ -56,6 +107,25 @@ struct SidebarRowView: View {
     }
     .accessibilityElement(children: .ignore)
     .accessibilityLabel(accessibilitySummary)
+  }
+
+  @ViewBuilder private var nameContent: some View {
+    if let isEditing, let onRename, isEditing.wrappedValue {
+      InlineRenameField(
+        initialText: name,
+        onCommit: { committed in
+          isEditing.wrappedValue = false
+          onRename(committed)
+        },
+        onCancel: { isEditing.wrappedValue = false }
+      )
+    } else {
+      Text(name)
+        .onTapGesture(count: 2) {
+          guard let isEditing, onRename != nil else { return }
+          isEditing.wrappedValue = true
+        }
+    }
   }
 
   @ViewBuilder private var trailingValue: some View {
@@ -184,4 +254,21 @@ struct AccountSidebarRow: View {
   }
   .listStyle(.sidebar)
   .preferredColorScheme(.dark)
+}
+
+#Preview("Sidebar row — inline rename") {
+  @Previewable @State var isEditing = true
+  return List(selection: .constant(Optional("selected"))) {
+    SidebarRowView(
+      icon: "building.columns",
+      name: "Bank Account",
+      amount: InstrumentAmount(quantity: 1234.56, instrument: .AUD),
+      isSelected: true,
+      isEditing: $isEditing,
+      onRename: { newName in print("Rename to: \(newName)") }
+    )
+    .tag("selected")
+  }
+  .listStyle(.sidebar)
+  .frame(width: 260)
 }

--- a/Features/Accounts/Views/AccountSidebarRow.swift
+++ b/Features/Accounts/Views/AccountSidebarRow.swift
@@ -1,21 +1,5 @@
 import SwiftUI
 
-/// Shared row view for sidebar items (accounts, earmarks) that displays
-/// an icon, name, and balance with selection-aware color coding.
-/// When `isSelected` is true and the selection background is prominent
-/// (focused sidebar), uses hand-tuned bright greens/reds instead of
-/// `.green` / `.red` so the amount stays legible against the saturated
-/// blue selection highlight. System colours `.mint` / `.pink` were tried
-/// and rejected — too desaturated. See
-/// guides/UI_GUIDE.md §5 "Selected-Row Contrast Override (Exception)"
-/// for the rationale and the rule that this is the only place in the
-/// app where hardcoded RGB values are permitted.
-///
-/// **Inline rename:** when both `isEditing` and `onRename` are provided,
-/// the row supports double-click-to-rename. Callers that do not opt in
-/// still receive a double-click gesture that no-ops, so do not attach a
-/// competing double-click handler to a `SidebarRowView`.
-
 /// TextField used by `SidebarRowView` while a row is in inline-rename
 /// mode. Auto-focuses on appear; commits on Return or focus loss (calls
 /// `onCommit`); cancels on Escape (calls `onCancel`). Separated from
@@ -51,6 +35,21 @@ private struct InlineRenameField: View {
   }
 }
 
+/// Shared row view for sidebar items (accounts, earmarks) that displays
+/// an icon, name, and balance with selection-aware color coding.
+/// When `isSelected` is true and the selection background is prominent
+/// (focused sidebar), uses hand-tuned bright greens/reds instead of
+/// `.green` / `.red` so the amount stays legible against the saturated
+/// blue selection highlight. System colours `.mint` / `.pink` were tried
+/// and rejected — too desaturated. See
+/// guides/UI_GUIDE.md §5 "Selected-Row Contrast Override (Exception)"
+/// for the rationale and the rule that this is the only place in the
+/// app where hardcoded RGB values are permitted.
+///
+/// **Inline rename:** when both `isEditing` and `onRename` are provided,
+/// the row supports double-click-to-rename. Callers that do not opt in
+/// still receive a double-click gesture that no-ops, so do not attach a
+/// competing double-click handler to a `SidebarRowView`.
 struct SidebarRowView: View {
   let icon: String
   let name: String

--- a/Features/Accounts/Views/AccountSidebarRow.swift
+++ b/Features/Accounts/Views/AccountSidebarRow.swift
@@ -2,31 +2,40 @@ import SwiftUI
 
 /// TextField used by `SidebarRowView` while a row is in inline-rename
 /// mode. Auto-focuses on appear; commits on Return or focus loss (calls
-/// `onCommit`); cancels on Escape (calls `onCancel`). Separated from
-/// `SidebarRowView` so the focus/selection machinery is testable in
-/// isolation via #Preview.
+/// `onCommit`); cancels on Escape (calls `onCancel`). Extracted into its
+/// own type so the `@FocusState` + `@State` text buffer are scoped to
+/// the editing lifecycle (they reset naturally when the field unmounts)
+/// without leaking into `SidebarRowView`'s state.
 private struct InlineRenameField: View {
   let initialText: String
   let onCommit: (String) -> Void
   let onCancel: () -> Void
 
   @State private var text: String = ""
+  @State private var didCommit = false
   @FocusState private var isFocused: Bool
 
   var body: some View {
-    TextField("", text: $text)
+    TextField("Name", text: $text)
+      .accessibilityLabel("Name")
       .textFieldStyle(.plain)
       .focused($isFocused)
       .onAppear {
         text = initialText
         isFocused = true
       }
-      .onSubmit { onCommit(text) }
+      .onSubmit {
+        didCommit = true
+        onCommit(text)
+      }
       .onChange(of: isFocused) { _, focused in
         // Focus loss without an explicit submit = commit (matches
-        // Finder-style rename). Escape will have set onCancel via
-        // .onKeyPress before focus drops.
-        if !focused { onCommit(text) }
+        // Finder-style rename). The didCommit guard prevents a
+        // double call when Return triggers onSubmit -> drop focus.
+        if !focused {
+          if !didCommit { onCommit(text) }
+          didCommit = false
+        }
       }
       .onKeyPress(.escape) {
         onCancel()
@@ -47,9 +56,8 @@ private struct InlineRenameField: View {
 /// app where hardcoded RGB values are permitted.
 ///
 /// **Inline rename:** when both `isEditing` and `onRename` are provided,
-/// the row supports double-click-to-rename. Callers that do not opt in
-/// still receive a double-click gesture that no-ops, so do not attach a
-/// competing double-click handler to a `SidebarRowView`.
+/// the row supports double-click-to-rename. Without those properties the
+/// row installs no double-click handler.
 struct SidebarRowView: View {
   let icon: String
   let name: String
@@ -118,12 +126,11 @@ struct SidebarRowView: View {
         },
         onCancel: { isEditing.wrappedValue = false }
       )
+    } else if let isEditing, onRename != nil {
+      Text(name)
+        .onTapGesture(count: 2) { isEditing.wrappedValue = true }
     } else {
       Text(name)
-        .onTapGesture(count: 2) {
-          guard let isEditing, onRename != nil else { return }
-          isEditing.wrappedValue = true
-        }
     }
   }
 

--- a/Features/Earmarks/EarmarkStore+Mutations.swift
+++ b/Features/Earmarks/EarmarkStore+Mutations.swift
@@ -44,16 +44,15 @@ extension EarmarkStore {
     }
   }
 
-  /// Guards the inline-rename UI flow so a cleared or unchanged field
-  /// does not issue a repository write. Trims whitespace; treats empty /
-  /// whitespace-only input as a no-op (no write; returns the current
-  /// earmark unchanged). Same-name input is also a no-op. Errors
-  /// propagate through `update(_:)`, which captures them on
-  /// `self.error` and returns `nil`.
+  /// Prevents spurious repository writes when the user clears or leaves
+  /// unchanged the inline-rename field. Whitespace is trimmed before
+  /// comparison; empty/whitespace-only and same-name inputs are treated
+  /// as no-ops and return the current earmark without touching the
+  /// repository. Errors from `update(_:)` surface on `self.error`.
   @discardableResult
   func rename(id: UUID, to newName: String) async -> Earmark? {
     let trimmed = newName.trimmingCharacters(in: .whitespacesAndNewlines)
-    guard let earmark = earmarks.first(where: { $0.id == id }) else { return nil }
+    guard let earmark = earmarks.by(id: id) else { return nil }
     guard !trimmed.isEmpty, trimmed != earmark.name else { return earmark }
     var updated = earmark
     updated.name = trimmed

--- a/Features/Earmarks/EarmarkStore+Mutations.swift
+++ b/Features/Earmarks/EarmarkStore+Mutations.swift
@@ -44,6 +44,22 @@ extension EarmarkStore {
     }
   }
 
+  /// Guards the inline-rename UI flow so a cleared or unchanged field
+  /// does not issue a repository write. Trims whitespace; treats empty /
+  /// whitespace-only input as a no-op (no write; returns the current
+  /// earmark unchanged). Same-name input is also a no-op. Errors
+  /// propagate through `update(_:)`, which captures them on
+  /// `self.error` and returns `nil`.
+  @discardableResult
+  func rename(id: UUID, to newName: String) async -> Earmark? {
+    let trimmed = newName.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard let earmark = earmarks.first(where: { $0.id == id }) else { return nil }
+    guard !trimmed.isEmpty, trimmed != earmark.name else { return earmark }
+    var updated = earmark
+    updated.name = trimmed
+    return await update(updated)
+  }
+
   /// Marks an earmark as hidden so it no longer appears in default
   /// lists. Pass-through to `update(_:)`.
   @discardableResult

--- a/Features/Earmarks/Views/EarmarkRowView.swift
+++ b/Features/Earmarks/Views/EarmarkRowView.swift
@@ -2,6 +2,9 @@ import SwiftUI
 
 struct EarmarkRowView: View {
   let earmark: Earmark
+  var isSelected: Bool = false
+  var isEditing: Binding<Bool>?
+  var onRename: ((String) -> Void)?
   @Environment(EarmarkStore.self) private var earmarkStore
 
   var body: some View {
@@ -9,7 +12,10 @@ struct EarmarkRowView: View {
       icon: "bookmark.fill",
       name: earmark.name,
       amount: earmarkStore.convertedBalance(for: earmark.id)
-        ?? .zero(instrument: earmark.instrument)
+        ?? .zero(instrument: earmark.instrument),
+      isSelected: isSelected,
+      isEditing: isEditing,
+      onRename: onRename
     )
   }
 }

--- a/Features/Navigation/SidebarView+Sections.swift
+++ b/Features/Navigation/SidebarView+Sections.swift
@@ -1,3 +1,5 @@
+// Section builders, helper methods, and actions for `SidebarView`.
+
 // Reason: SwiftUI sidebar layout mixes Section / Label / NavigationLink calls
 // whose argument lists span multiple lines for readability; the rule's
 // first-arg-on-opening-line convention fights the SwiftUI declarative idiom
@@ -24,9 +26,7 @@ extension SidebarView {
             account: account,
             isSelected: selection == .account(account.id),
             isEditing: renameBinding(for: account.id),
-            onRename: { newName in
-              Task { _ = try? await accountStore.rename(id: account.id, to: newName) }
-            }
+            onRename: renameAction(for: account)
           )
         }
         .dropDestination(for: URL.self) { urls, _ in
@@ -72,9 +72,7 @@ extension SidebarView {
             account: account,
             isSelected: selection == .account(account.id),
             isEditing: renameBinding(for: account.id),
-            onRename: { newName in
-              Task { _ = try? await accountStore.rename(id: account.id, to: newName) }
-            }
+            onRename: renameAction(for: account)
           )
         }
         .accessibilityIdentifier(UITestIdentifiers.Sidebar.account(account.id))

--- a/Features/Navigation/SidebarView+Sections.swift
+++ b/Features/Navigation/SidebarView+Sections.swift
@@ -1,0 +1,202 @@
+// Reason: SwiftUI sidebar layout mixes Section / Label / NavigationLink calls
+// whose argument lists span multiple lines for readability; the rule's
+// first-arg-on-opening-line convention fights the SwiftUI declarative idiom
+// without improving clarity.
+// swiftlint:disable multiline_arguments
+
+import SwiftUI
+
+extension SidebarView {
+  // MARK: - Sections
+
+  func handleAccountEditRequest(_ note: Notification) {
+    guard let id = note.object as? UUID,
+      let account = accountStore.accounts.by(id: id)
+    else { return }
+    accountToEdit = account
+  }
+
+  var currentAccountsSection: some View {
+    Section {
+      ForEach(accountStore.currentAccounts) { account in
+        NavigationLink(value: SidebarSelection.account(account.id)) {
+          AccountSidebarRow(
+            account: account,
+            isSelected: selection == .account(account.id),
+            isEditing: renameBinding(for: account.id),
+            onRename: { newName in
+              Task { _ = try? await accountStore.rename(id: account.id, to: newName) }
+            }
+          )
+        }
+        .dropDestination(for: URL.self) { urls, _ in
+          Task { await ingestDroppedURLs(urls, forcedAccountId: account.id) }
+          return !urls.isEmpty
+        }
+        .accessibilityIdentifier(UITestIdentifiers.Sidebar.account(account.id))
+        .contextMenu { accountContextMenu(for: account) }
+      }
+      .onMove { source, destination in
+        Task { await reorderCurrentAccounts(from: source, to: destination) }
+      }
+      totalRow(label: "Current Total", value: accountStore.convertedCurrentTotal)
+    } header: {
+      sectionHeader(title: "Current Accounts", addAction: addAccountAction)
+    }
+  }
+
+  var earmarksSection: some View {
+    Section {
+      ForEach(earmarkStore.visibleEarmarks) { earmark in
+        NavigationLink(value: SidebarSelection.earmark(earmark.id)) {
+          SidebarRowView(
+            icon: "bookmark.fill", name: earmark.name,
+            amount: earmarkStore.convertedBalance(for: earmark.id),
+            isSelected: selection == .earmark(earmark.id))
+        }
+      }
+      .onMove { source, destination in
+        Task { await earmarkStore.reorderEarmarks(from: source, to: destination) }
+      }
+      totalRow(label: "Earmarked Total", value: earmarkStore.convertedTotalBalance)
+    } header: {
+      sectionHeader(title: "Earmarks", addAction: addEarmarkAction)
+    }
+  }
+
+  var investmentsSection: some View {
+    Section("Investments") {
+      ForEach(accountStore.investmentAccounts) { account in
+        NavigationLink(value: SidebarSelection.account(account.id)) {
+          AccountSidebarRow(
+            account: account,
+            isSelected: selection == .account(account.id),
+            isEditing: renameBinding(for: account.id),
+            onRename: { newName in
+              Task { _ = try? await accountStore.rename(id: account.id, to: newName) }
+            }
+          )
+        }
+        .accessibilityIdentifier(UITestIdentifiers.Sidebar.account(account.id))
+        .contextMenu { accountContextMenu(for: account) }
+      }
+      .onMove { source, destination in
+        Task { await reorderInvestmentAccounts(from: source, to: destination) }
+      }
+      totalRow(label: "Investment Total", value: accountStore.convertedInvestmentTotal)
+    }
+  }
+
+  @ViewBuilder var totalsSection: some View {
+    Section {
+      if let currentTotal = accountStore.convertedCurrentTotal,
+        let earmarkedTotal = earmarkStore.convertedTotalBalance,
+        earmarkedTotal.isPositive
+      {
+        LabeledContent("Available Funds") {
+          InstrumentAmountView(amount: currentTotal - earmarkedTotal)
+        }
+        .font(.headline)
+        .accessibilityLabel("Available Funds: \((currentTotal - earmarkedTotal).formatted)")
+      }
+      if let netWorth = accountStore.convertedNetWorth {
+        LabeledContent("Net Worth") {
+          InstrumentAmountView(amount: netWorth)
+        }
+        .font(.headline)
+        .bold()
+        .accessibilityLabel("Net Worth: \(netWorth.formatted)")
+      }
+    }
+  }
+
+  @ViewBuilder var navigationSection: some View {
+    Section {
+      NavigationLink(value: SidebarSelection.analysis) {
+        Label("Analysis", systemImage: "chart.bar.xaxis")
+      }
+      .accessibilityIdentifier(UITestIdentifiers.Sidebar.view("analysis"))
+      NavigationLink(value: SidebarSelection.reports) {
+        Label("Reports", systemImage: "chart.bar.fill")
+      }
+      .accessibilityIdentifier(UITestIdentifiers.Sidebar.view("reports"))
+      NavigationLink(value: SidebarSelection.categories) {
+        Label("Categories", systemImage: "tag")
+      }
+      .accessibilityIdentifier(UITestIdentifiers.Sidebar.view("categories"))
+      NavigationLink(value: SidebarSelection.upcomingTransactions) {
+        Label("Upcoming", systemImage: "calendar")
+      }
+      .accessibilityIdentifier(UITestIdentifiers.Sidebar.view("upcoming"))
+      NavigationLink(value: SidebarSelection.recentlyAdded) {
+        recentlyAddedLabel
+      }
+      .accessibilityIdentifier(UITestIdentifiers.Sidebar.view("recentlyAdded"))
+      NavigationLink(value: SidebarSelection.allTransactions) {
+        Label("All Transactions", systemImage: "list.bullet")
+      }
+      .accessibilityIdentifier(UITestIdentifiers.Sidebar.view("allTransactions"))
+      #if os(iOS)
+        navigationToggles
+      #endif
+    }
+  }
+
+  #if os(iOS)
+    /// iOS-only visibility toggles shown at the bottom of the navigation
+    /// section. Extracted from `navigationSection` to keep its closure
+    /// within SwiftLint's `closure_body_length` budget.
+    @ViewBuilder var navigationToggles: some View {
+      Toggle(isOn: $showHidden) {
+        Label(
+          showHidden ? "Hide Hidden Accounts" : "Show Hidden Accounts",
+          systemImage: showHidden ? "eye" : "eye.slash"
+        )
+      }
+      Toggle(isOn: $showSpam) {
+        Label(
+          showSpam ? "Hide Spam Transactions" : "Show Spam Transactions",
+          systemImage: showSpam ? "eye" : "eye.slash"
+        )
+      }
+    }
+  #endif
+
+  // MARK: - Helpers
+
+  func reorderCurrentAccounts(from source: IndexSet, to destination: Int) async {
+    var accounts = accountStore.currentAccounts
+    accounts.move(fromOffsets: source, toOffset: destination)
+    await accountStore.reorderAccounts(accounts)
+  }
+
+  /// Dropped CSV onto a sidebar account row: force the import onto that
+  /// account, bypassing profile matching. A profile is created on success.
+  func ingestDroppedURLs(_ urls: [URL], forcedAccountId: UUID) async {
+    for url in urls
+    where url.pathExtension.lowercased() == "csv"
+      || url.pathExtension.isEmpty
+    {
+      let didStart = url.startAccessingSecurityScopedResource()
+      defer {
+        if didStart { url.stopAccessingSecurityScopedResource() }
+      }
+      guard let data = try? Data(contentsOf: url) else { continue }
+      _ = await importStore.ingest(
+        data: data,
+        source: .droppedFile(url: url, forcedAccountId: forcedAccountId))
+    }
+  }
+
+  func reorderInvestmentAccounts(from source: IndexSet, to destination: Int) async {
+    var accounts = accountStore.investmentAccounts
+    accounts.move(fromOffsets: source, toOffset: destination)
+    await accountStore.reorderAccounts(
+      accounts, positionOffset: accountStore.currentAccounts.count)
+  }
+
+  // MARK: - Actions
+
+  func addAccountAction() { showCreateAccountSheet = true }
+  func addEarmarkAction() { showCreateEarmarkSheet = true }
+}

--- a/Features/Navigation/SidebarView+Sections.swift
+++ b/Features/Navigation/SidebarView+Sections.swift
@@ -1,11 +1,5 @@
 // Section builders, helper methods, and actions for `SidebarView`.
 
-// Reason: SwiftUI sidebar layout mixes Section / Label / NavigationLink calls
-// whose argument lists span multiple lines for readability; the rule's
-// first-arg-on-opening-line convention fights the SwiftUI declarative idiom
-// without improving clarity.
-// swiftlint:disable multiline_arguments
-
 import SwiftUI
 
 extension SidebarView {
@@ -49,11 +43,14 @@ extension SidebarView {
     Section {
       ForEach(earmarkStore.visibleEarmarks) { earmark in
         NavigationLink(value: SidebarSelection.earmark(earmark.id)) {
-          SidebarRowView(
-            icon: "bookmark.fill", name: earmark.name,
-            amount: earmarkStore.convertedBalance(for: earmark.id),
-            isSelected: selection == .earmark(earmark.id))
+          EarmarkRowView(
+            earmark: earmark,
+            isSelected: selection == .earmark(earmark.id),
+            isEditing: renameBinding(for: earmark.id),
+            onRename: renameAction(for: earmark)
+          )
         }
+        .contextMenu { earmarkContextMenu(for: earmark) }
       }
       .onMove { source, destination in
         Task { await earmarkStore.reorderEarmarks(from: source, to: destination) }

--- a/Features/Navigation/SidebarView.swift
+++ b/Features/Navigation/SidebarView.swift
@@ -78,10 +78,9 @@ struct SidebarView: View {
     .listStyle(.sidebar)
     .onKeyPress(.return) {
       // Only respond to Return when the selection points at a row
-      // that supports inline rename (account or earmark today; group
-      // in Phase 4). Other selections (analysis / reports / etc.)
-      // pass through unhandled so any default Return behaviour is
-      // preserved.
+      // that supports inline rename. Other selections (analysis /
+      // reports / etc.) pass through unhandled so any default Return
+      // behaviour is preserved.
       switch selection {
       case .account(let id):
         guard accountStore.accounts.by(id: id) != nil else { return .ignored }

--- a/Features/Navigation/SidebarView.swift
+++ b/Features/Navigation/SidebarView.swift
@@ -248,4 +248,21 @@ extension SidebarView {
       Task { _ = try? await accountStore.rename(id: account.id, to: newName) }
     }
   }
+
+  /// Returns the `onRename` closure for an earmark row — earmark
+  /// counterpart of `renameAction(for: Account)`. Same intent-shape;
+  /// dispatches `EarmarkStore.rename`.
+  func renameAction(for earmark: Earmark) -> (String) -> Void {
+    { newName in
+      Task { _ = await earmarkStore.rename(id: earmark.id, to: newName) }
+    }
+  }
+
+  @ViewBuilder
+  func earmarkContextMenu(for earmark: Earmark) -> some View {
+    Button("Rename", systemImage: "character.cursor.ibeam") {
+      editingRowId = earmark.id
+    }
+    .accessibilityIdentifier(UITestIdentifiers.Sidebar.renameContextMenuItem)
+  }
 }

--- a/Features/Navigation/SidebarView.swift
+++ b/Features/Navigation/SidebarView.swift
@@ -1,9 +1,3 @@
-// Reason: SwiftUI sidebar layout mixes Section / Label / NavigationLink calls
-// whose argument lists span multiple lines for readability; the rule's
-// first-arg-on-opening-line convention fights the SwiftUI declarative idiom
-// without improving clarity.
-// swiftlint:disable multiline_arguments
-
 import SwiftUI
 
 enum SidebarSelection: Hashable {
@@ -20,17 +14,22 @@ enum SidebarSelection: Hashable {
 struct SidebarView: View {
   // MARK: - Properties
 
-  @Environment(AccountStore.self) private var accountStore
-  @Environment(EarmarkStore.self) private var earmarkStore
+  @Environment(AccountStore.self) var accountStore
+  @Environment(EarmarkStore.self) var earmarkStore
   @Environment(ProfileSession.self) private var session
-  @Environment(ImportStore.self) private var importStore
+  @Environment(ImportStore.self) var importStore
   @Environment(TransactionStore.self) private var transactionStore
   @Binding var selection: SidebarSelection?
-  @State private var showCreateEarmarkSheet = false
-  @State private var showCreateAccountSheet = false
-  @State private var accountToEdit: Account?
-  @AppStorage("showHiddenAccounts") private var showHidden = false
-  @AppStorage("showSpamTransactions") private var showSpam = false
+  @State var showCreateEarmarkSheet = false
+  @State var showCreateAccountSheet = false
+  @State var accountToEdit: Account?
+  /// Identifies the sidebar row currently in inline rename mode, if
+  /// any. Local-only — never persisted, never synced. At most one row
+  /// is in edit mode at a time across the entire sidebar (accounts,
+  /// earmarks, future groups).
+  @State var editingRowId: UUID?
+  @AppStorage("showHiddenAccounts") var showHidden = false
+  @AppStorage("showSpamTransactions") var showSpam = false
 
   #if os(iOS)
     @State private var editMode: EditMode = .inactive
@@ -146,188 +145,9 @@ struct SidebarView: View {
 }
 
 extension SidebarView {
-  // MARK: - Sections
-
-  private func handleAccountEditRequest(_ note: Notification) {
-    guard let id = note.object as? UUID,
-      let account = accountStore.accounts.by(id: id)
-    else { return }
-    accountToEdit = account
-  }
-
-  private var currentAccountsSection: some View {
-    Section {
-      ForEach(accountStore.currentAccounts) { account in
-        NavigationLink(value: SidebarSelection.account(account.id)) {
-          AccountSidebarRow(account: account, isSelected: selection == .account(account.id))
-        }
-        .dropDestination(for: URL.self) { urls, _ in
-          Task { await ingestDroppedURLs(urls, forcedAccountId: account.id) }
-          return !urls.isEmpty
-        }
-        .accessibilityIdentifier(UITestIdentifiers.Sidebar.account(account.id))
-        .contextMenu { accountContextMenu(for: account) }
-      }
-      .onMove { source, destination in
-        Task { await reorderCurrentAccounts(from: source, to: destination) }
-      }
-      totalRow(label: "Current Total", value: accountStore.convertedCurrentTotal)
-    } header: {
-      sectionHeader(title: "Current Accounts", addAction: addAccountAction)
-    }
-  }
-
-  private var earmarksSection: some View {
-    Section {
-      ForEach(earmarkStore.visibleEarmarks) { earmark in
-        NavigationLink(value: SidebarSelection.earmark(earmark.id)) {
-          SidebarRowView(
-            icon: "bookmark.fill", name: earmark.name,
-            amount: earmarkStore.convertedBalance(for: earmark.id),
-            isSelected: selection == .earmark(earmark.id))
-        }
-      }
-      .onMove { source, destination in
-        Task { await earmarkStore.reorderEarmarks(from: source, to: destination) }
-      }
-      totalRow(label: "Earmarked Total", value: earmarkStore.convertedTotalBalance)
-    } header: {
-      sectionHeader(title: "Earmarks", addAction: addEarmarkAction)
-    }
-  }
-
-  private var investmentsSection: some View {
-    Section("Investments") {
-      ForEach(accountStore.investmentAccounts) { account in
-        NavigationLink(value: SidebarSelection.account(account.id)) {
-          AccountSidebarRow(account: account, isSelected: selection == .account(account.id))
-        }
-        .accessibilityIdentifier(UITestIdentifiers.Sidebar.account(account.id))
-        .contextMenu { accountContextMenu(for: account) }
-      }
-      .onMove { source, destination in
-        Task { await reorderInvestmentAccounts(from: source, to: destination) }
-      }
-      totalRow(label: "Investment Total", value: accountStore.convertedInvestmentTotal)
-    }
-  }
-
-  @ViewBuilder private var totalsSection: some View {
-    Section {
-      if let currentTotal = accountStore.convertedCurrentTotal,
-        let earmarkedTotal = earmarkStore.convertedTotalBalance,
-        earmarkedTotal.isPositive
-      {
-        LabeledContent("Available Funds") {
-          InstrumentAmountView(amount: currentTotal - earmarkedTotal)
-        }
-        .font(.headline)
-        .accessibilityLabel("Available Funds: \((currentTotal - earmarkedTotal).formatted)")
-      }
-      if let netWorth = accountStore.convertedNetWorth {
-        LabeledContent("Net Worth") {
-          InstrumentAmountView(amount: netWorth)
-        }
-        .font(.headline)
-        .bold()
-        .accessibilityLabel("Net Worth: \(netWorth.formatted)")
-      }
-    }
-  }
-
-  @ViewBuilder private var navigationSection: some View {
-    Section {
-      NavigationLink(value: SidebarSelection.analysis) {
-        Label("Analysis", systemImage: "chart.bar.xaxis")
-      }
-      .accessibilityIdentifier(UITestIdentifiers.Sidebar.view("analysis"))
-      NavigationLink(value: SidebarSelection.reports) {
-        Label("Reports", systemImage: "chart.bar.fill")
-      }
-      .accessibilityIdentifier(UITestIdentifiers.Sidebar.view("reports"))
-      NavigationLink(value: SidebarSelection.categories) {
-        Label("Categories", systemImage: "tag")
-      }
-      .accessibilityIdentifier(UITestIdentifiers.Sidebar.view("categories"))
-      NavigationLink(value: SidebarSelection.upcomingTransactions) {
-        Label("Upcoming", systemImage: "calendar")
-      }
-      .accessibilityIdentifier(UITestIdentifiers.Sidebar.view("upcoming"))
-      NavigationLink(value: SidebarSelection.recentlyAdded) {
-        recentlyAddedLabel
-      }
-      .accessibilityIdentifier(UITestIdentifiers.Sidebar.view("recentlyAdded"))
-      NavigationLink(value: SidebarSelection.allTransactions) {
-        Label("All Transactions", systemImage: "list.bullet")
-      }
-      .accessibilityIdentifier(UITestIdentifiers.Sidebar.view("allTransactions"))
-      #if os(iOS)
-        navigationToggles
-      #endif
-    }
-  }
-
-  #if os(iOS)
-    /// iOS-only visibility toggles shown at the bottom of the navigation
-    /// section. Extracted from `navigationSection` to keep its closure
-    /// within SwiftLint's `closure_body_length` budget.
-    @ViewBuilder private var navigationToggles: some View {
-      Toggle(isOn: $showHidden) {
-        Label(
-          showHidden ? "Hide Hidden Accounts" : "Show Hidden Accounts",
-          systemImage: showHidden ? "eye" : "eye.slash"
-        )
-      }
-      Toggle(isOn: $showSpam) {
-        Label(
-          showSpam ? "Hide Spam Transactions" : "Show Spam Transactions",
-          systemImage: showSpam ? "eye" : "eye.slash"
-        )
-      }
-    }
-  #endif
-
-  // MARK: - Helpers
-
-  private func reorderCurrentAccounts(from source: IndexSet, to destination: Int) async {
-    var accounts = accountStore.currentAccounts
-    accounts.move(fromOffsets: source, toOffset: destination)
-    await accountStore.reorderAccounts(accounts)
-  }
-
-  /// Dropped CSV onto a sidebar account row: force the import onto that
-  /// account, bypassing profile matching. A profile is created on success.
-  private func ingestDroppedURLs(_ urls: [URL], forcedAccountId: UUID) async {
-    for url in urls
-    where url.pathExtension.lowercased() == "csv"
-      || url.pathExtension.isEmpty
-    {
-      let didStart = url.startAccessingSecurityScopedResource()
-      defer {
-        if didStart { url.stopAccessingSecurityScopedResource() }
-      }
-      guard let data = try? Data(contentsOf: url) else { continue }
-      _ = await importStore.ingest(
-        data: data,
-        source: .droppedFile(url: url, forcedAccountId: forcedAccountId))
-    }
-  }
-
-  private func reorderInvestmentAccounts(from source: IndexSet, to destination: Int) async {
-    var accounts = accountStore.investmentAccounts
-    accounts.move(fromOffsets: source, toOffset: destination)
-    await accountStore.reorderAccounts(
-      accounts, positionOffset: accountStore.currentAccounts.count)
-  }
-
-  // MARK: - Actions
-
-  private func addAccountAction() { showCreateAccountSheet = true }
-  private func addEarmarkAction() { showCreateEarmarkSheet = true }
-
   // MARK: - Row Builders
 
-  private var recentlyAddedLabel: some View {
+  var recentlyAddedLabel: some View {
     HStack {
       Label("Recently Added", systemImage: "tray.full")
       Spacer()
@@ -345,7 +165,7 @@ extension SidebarView {
     }
   }
 
-  private func totalRow(label: String, value: InstrumentAmount?) -> some View {
+  func totalRow(label: String, value: InstrumentAmount?) -> some View {
     LabeledContent(label) {
       if let value {
         InstrumentAmountView(amount: value)
@@ -358,8 +178,22 @@ extension SidebarView {
     .font(.callout)
   }
 
+  /// Returns a binding that reports `true` when this row id is the one
+  /// currently being inline-renamed, and (on `set(true)`) makes it so.
+  /// Centralises the one-at-a-time invariant.
+  func renameBinding(for id: UUID) -> Binding<Bool> {
+    Binding(
+      get: { editingRowId == id },
+      set: { newValue in editingRowId = newValue ? id : nil }
+    )
+  }
+
   @ViewBuilder
-  private func accountContextMenu(for account: Account) -> some View {
+  func accountContextMenu(for account: Account) -> some View {
+    Button("Rename", systemImage: "character.cursor.ibeam") {
+      editingRowId = account.id
+    }
+    .accessibilityIdentifier(UITestIdentifiers.Sidebar.renameContextMenuItem)
     Button("Edit Account\u{2026}", systemImage: "pencil") {
       accountToEdit = account
     }
@@ -370,7 +204,7 @@ extension SidebarView {
   }
 
   @ViewBuilder
-  private func sectionHeader(title: String, addAction: @escaping () -> Void) -> some View {
+  func sectionHeader(title: String, addAction: @escaping () -> Void) -> some View {
     HStack {
       Text(title)
       Spacer()

--- a/Features/Navigation/SidebarView.swift
+++ b/Features/Navigation/SidebarView.swift
@@ -14,21 +14,39 @@ enum SidebarSelection: Hashable {
 struct SidebarView: View {
   // MARK: - Properties
 
+  // Internal access required by `SidebarView+Sections.swift` extension;
+  // cannot be `private` across file boundaries.
   @Environment(AccountStore.self) var accountStore
+  // Internal access required by `SidebarView+Sections.swift` extension;
+  // cannot be `private` across file boundaries.
   @Environment(EarmarkStore.self) var earmarkStore
   @Environment(ProfileSession.self) private var session
+  // Internal access required by `SidebarView+Sections.swift` extension;
+  // cannot be `private` across file boundaries.
   @Environment(ImportStore.self) var importStore
   @Environment(TransactionStore.self) private var transactionStore
+  // Internal access required by `SidebarView+Sections.swift` extension;
+  // cannot be `private` across file boundaries.
   @Binding var selection: SidebarSelection?
+  // Internal access required by `SidebarView+Sections.swift` extension;
+  // cannot be `private` across file boundaries.
   @State var showCreateEarmarkSheet = false
+  // Internal access required by `SidebarView+Sections.swift` extension;
+  // cannot be `private` across file boundaries.
   @State var showCreateAccountSheet = false
+  // Internal access required by `SidebarView+Sections.swift` extension;
+  // cannot be `private` across file boundaries.
   @State var accountToEdit: Account?
   /// Identifies the sidebar row currently in inline rename mode, if
   /// any. Local-only — never persisted, never synced. At most one row
   /// is in edit mode at a time across the entire sidebar (accounts,
   /// earmarks, future groups).
-  @State var editingRowId: UUID?
+  @State private var editingRowId: UUID?
+  // Internal access required by `SidebarView+Sections.swift` extension;
+  // cannot be `private` across file boundaries.
   @AppStorage("showHiddenAccounts") var showHidden = false
+  // Internal access required by `SidebarView+Sections.swift` extension;
+  // cannot be `private` across file boundaries.
   @AppStorage("showSpamTransactions") var showSpam = false
 
   #if os(iOS)
@@ -145,7 +163,8 @@ struct SidebarView: View {
 }
 
 extension SidebarView {
-  // MARK: - Row Builders
+  // MARK: - View Builders
+  // recentlyAddedLabel, totalRow, accountContextMenu, sectionHeader
 
   var recentlyAddedLabel: some View {
     HStack {
@@ -178,16 +197,6 @@ extension SidebarView {
     .font(.callout)
   }
 
-  /// Returns a binding that reports `true` when this row id is the one
-  /// currently being inline-renamed, and (on `set(true)`) makes it so.
-  /// Centralises the one-at-a-time invariant.
-  func renameBinding(for id: UUID) -> Binding<Bool> {
-    Binding(
-      get: { editingRowId == id },
-      set: { newValue in editingRowId = newValue ? id : nil }
-    )
-  }
-
   @ViewBuilder
   func accountContextMenu(for account: Account) -> some View {
     Button("Rename", systemImage: "character.cursor.ibeam") {
@@ -215,6 +224,28 @@ extension SidebarView {
         .buttonStyle(.plain)
         .accessibilityLabel("Add \(title.lowercased())")
       #endif
+    }
+  }
+
+  // MARK: - State Coordination
+  // renameBinding, renameAction
+
+  /// Returns a binding that reports `true` when this row id is the one
+  /// currently being inline-renamed, and (on `set(true)`) makes it so.
+  /// Centralises the one-at-a-time invariant.
+  func renameBinding(for id: UUID) -> Binding<Bool> {
+    Binding(
+      get: { editingRowId == id },
+      set: { newValue in editingRowId = newValue ? id : nil }
+    )
+  }
+
+  /// Returns the `onRename` closure for an account row — single source
+  /// of truth for the inline-rename dispatch shape, used by both the
+  /// Current and Investments sections.
+  func renameAction(for account: Account) -> (String) -> Void {
+    { newName in
+      Task { _ = try? await accountStore.rename(id: account.id, to: newName) }
     }
   }
 }

--- a/Features/Navigation/SidebarView.swift
+++ b/Features/Navigation/SidebarView.swift
@@ -76,6 +76,26 @@ struct SidebarView: View {
       navigationSection
     }
     .listStyle(.sidebar)
+    .onKeyPress(.return) {
+      // Only respond to Return when the selection points at a row
+      // that supports inline rename (account or earmark today; group
+      // in Phase 4). Other selections (analysis / reports / etc.)
+      // pass through unhandled so any default Return behaviour is
+      // preserved.
+      switch selection {
+      case .account(let id):
+        guard accountStore.accounts.by(id: id) != nil else { return .ignored }
+        editingRowId = id
+        return .handled
+      case .earmark(let id):
+        guard earmarkStore.earmarks.by(id: id) != nil else { return .ignored }
+        editingRowId = id
+        return .handled
+      case .none, .recentlyAdded, .allTransactions, .upcomingTransactions,
+        .categories, .reports, .analysis:
+        return .ignored
+      }
+    }
     .navigationTitle("")
     .focusedSceneValue(\.showHiddenAccounts, $showHidden)
     .focusedSceneValue(\.showSpamTransactions, $showSpam)

--- a/MoolahTests/Features/AccountStoreRenameTests.swift
+++ b/MoolahTests/Features/AccountStoreRenameTests.swift
@@ -27,6 +27,9 @@ struct AccountStoreRenameTests {
       matching: { $0.accounts.by(id: original.id)?.name == "New" },
       description: "rename observed"
     )
+    #expect(store.error == nil)
+    let fetched = try await backend.accounts.fetchAll()
+    #expect(fetched.first(where: { $0.id == original.id })?.name == "New")
   }
 
   @Test("rename trims surrounding whitespace before persisting")
@@ -45,9 +48,15 @@ struct AccountStoreRenameTests {
     let result = try await store.rename(id: original.id, to: "  Spaced  ")
 
     #expect(result?.name == "Spaced")
+    try await store.waitForNextEmission(
+      matching: { $0.accounts.by(id: original.id)?.name == "Spaced" },
+      description: "trimmed rename observed"
+    )
+    let fetched = try await backend.accounts.fetchAll()
+    #expect(fetched.first(where: { $0.id == original.id })?.name == "Spaced")
   }
 
-  @Test("rename to empty / whitespace-only string reverts (returns current account)")
+  @Test("rename to empty / whitespace-only string is a no-op (returns current account unchanged)")
   func renameToEmptyReverts() async throws {
     let (backend, database) = try TestBackend.create()
     let original = AccountStoreTestSupport.seedAccount(
@@ -83,6 +92,9 @@ struct AccountStoreRenameTests {
     let result = try await store.rename(id: original.id, to: "Stable")
 
     #expect(result?.name == "Stable")
+    #expect(store.error == nil)
+    let fetched = try await backend.accounts.fetchAll()
+    #expect(fetched.first(where: { $0.id == original.id })?.name == "Stable")
   }
 
   @Test("rename of unknown id returns nil without surfacing an error")

--- a/MoolahTests/Features/AccountStoreRenameTests.swift
+++ b/MoolahTests/Features/AccountStoreRenameTests.swift
@@ -1,0 +1,101 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("AccountStore/rename")
+@MainActor
+struct AccountStoreRenameTests {
+
+  @Test("rename updates the account's name")
+  func renameUpdatesName() async throws {
+    let (backend, database) = try TestBackend.create()
+    let original = AccountStoreTestSupport.seedAccount(
+      name: "Old", type: .bank, balance: 0, in: database)
+    let store = AccountStore(
+      repository: backend.accounts, conversionService: FixedConversionService(),
+      targetInstrument: .defaultTestInstrument)
+    try await store.waitForNextEmission(
+      matching: { $0.accounts.by(id: original.id) != nil },
+      description: "seeded account observed"
+    )
+
+    let result = try await store.rename(id: original.id, to: "New")
+
+    #expect(result?.name == "New")
+    try await store.waitForNextEmission(
+      matching: { $0.accounts.by(id: original.id)?.name == "New" },
+      description: "rename observed"
+    )
+  }
+
+  @Test("rename trims surrounding whitespace before persisting")
+  func renameTrimsWhitespace() async throws {
+    let (backend, database) = try TestBackend.create()
+    let original = AccountStoreTestSupport.seedAccount(
+      name: "Old", type: .bank, balance: 0, in: database)
+    let store = AccountStore(
+      repository: backend.accounts, conversionService: FixedConversionService(),
+      targetInstrument: .defaultTestInstrument)
+    try await store.waitForNextEmission(
+      matching: { $0.accounts.by(id: original.id) != nil },
+      description: "seeded account observed"
+    )
+
+    let result = try await store.rename(id: original.id, to: "  Spaced  ")
+
+    #expect(result?.name == "Spaced")
+  }
+
+  @Test("rename to empty / whitespace-only string reverts (returns current account)")
+  func renameToEmptyReverts() async throws {
+    let (backend, database) = try TestBackend.create()
+    let original = AccountStoreTestSupport.seedAccount(
+      name: "Old", type: .bank, balance: 0, in: database)
+    let store = AccountStore(
+      repository: backend.accounts, conversionService: FixedConversionService(),
+      targetInstrument: .defaultTestInstrument)
+    try await store.waitForNextEmission(
+      matching: { $0.accounts.by(id: original.id) != nil },
+      description: "seeded account observed"
+    )
+
+    let result = try await store.rename(id: original.id, to: "   ")
+
+    // Returns the existing account unchanged; no write happens.
+    #expect(result?.name == "Old")
+    #expect(store.accounts.by(id: original.id)?.name == "Old")
+  }
+
+  @Test("rename to the same name is a no-op (no write, returns current)")
+  func renameToSameNameIsNoOp() async throws {
+    let (backend, database) = try TestBackend.create()
+    let original = AccountStoreTestSupport.seedAccount(
+      name: "Stable", type: .bank, balance: 0, in: database)
+    let store = AccountStore(
+      repository: backend.accounts, conversionService: FixedConversionService(),
+      targetInstrument: .defaultTestInstrument)
+    try await store.waitForNextEmission(
+      matching: { $0.accounts.by(id: original.id) != nil },
+      description: "seeded account observed"
+    )
+
+    let result = try await store.rename(id: original.id, to: "Stable")
+
+    #expect(result?.name == "Stable")
+  }
+
+  @Test("rename of unknown id returns nil without surfacing an error")
+  func renameOfUnknownIdReturnsNil() async throws {
+    let (backend, _) = try TestBackend.create()
+    let store = AccountStore(
+      repository: backend.accounts, conversionService: FixedConversionService(),
+      targetInstrument: .defaultTestInstrument)
+    try await store.waitForFirstEmission()
+
+    let result = try await store.rename(id: UUID(), to: "Whatever")
+
+    #expect(result == nil)
+    #expect(store.error == nil)
+  }
+}

--- a/MoolahTests/Features/EarmarkStoreRenameTests.swift
+++ b/MoolahTests/Features/EarmarkStoreRenameTests.swift
@@ -1,0 +1,115 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("EarmarkStore/rename")
+@MainActor
+struct EarmarkStoreRenameTests {
+
+  @Test("rename updates the earmark's name")
+  func renameUpdatesName() async throws {
+    let (backend, database) = try TestBackend.create()
+    let original = Earmark(name: "Old", instrument: .defaultTestInstrument)
+    TestBackend.seed(earmarks: [original], in: database)
+    let store = EarmarkStore(
+      repository: backend.earmarks, conversionService: FixedConversionService(),
+      targetInstrument: .defaultTestInstrument)
+    try await store.waitForNextEmission(
+      matching: { $0.earmarks.by(id: original.id) != nil },
+      description: "seeded earmark observed"
+    )
+
+    let result = await store.rename(id: original.id, to: "New")
+
+    #expect(result?.name == "New")
+    #expect(store.error == nil)
+    try await store.waitForNextEmission(
+      matching: { $0.earmarks.by(id: original.id)?.name == "New" },
+      description: "rename observed"
+    )
+    let fetched = try await backend.earmarks.fetchAll()
+    #expect(fetched.first(where: { $0.id == original.id })?.name == "New")
+  }
+
+  @Test("rename trims surrounding whitespace before persisting")
+  func renameTrimsWhitespace() async throws {
+    let (backend, database) = try TestBackend.create()
+    let original = Earmark(name: "Old", instrument: .defaultTestInstrument)
+    TestBackend.seed(earmarks: [original], in: database)
+    let store = EarmarkStore(
+      repository: backend.earmarks, conversionService: FixedConversionService(),
+      targetInstrument: .defaultTestInstrument)
+    try await store.waitForNextEmission(
+      matching: { $0.earmarks.by(id: original.id) != nil },
+      description: "seeded earmark observed"
+    )
+
+    let result = await store.rename(id: original.id, to: "  Spaced  ")
+
+    #expect(result?.name == "Spaced")
+    try await store.waitForNextEmission(
+      matching: { $0.earmarks.by(id: original.id)?.name == "Spaced" },
+      description: "trimmed rename observed"
+    )
+    let fetched = try await backend.earmarks.fetchAll()
+    #expect(fetched.first(where: { $0.id == original.id })?.name == "Spaced")
+  }
+
+  @Test("rename to empty / whitespace-only string is a no-op (returns current earmark unchanged)")
+  func renameToEmptyIsNoOp() async throws {
+    let (backend, database) = try TestBackend.create()
+    let original = Earmark(name: "Stable", instrument: .defaultTestInstrument)
+    TestBackend.seed(earmarks: [original], in: database)
+    let store = EarmarkStore(
+      repository: backend.earmarks, conversionService: FixedConversionService(),
+      targetInstrument: .defaultTestInstrument)
+    try await store.waitForNextEmission(
+      matching: { $0.earmarks.by(id: original.id) != nil },
+      description: "seeded earmark observed"
+    )
+
+    let result = await store.rename(id: original.id, to: "   ")
+
+    #expect(result?.name == "Stable")
+    #expect(store.earmarks.by(id: original.id)?.name == "Stable")
+    #expect(store.error == nil)
+    let fetched = try await backend.earmarks.fetchAll()
+    #expect(fetched.first(where: { $0.id == original.id })?.name == "Stable")
+  }
+
+  @Test("rename to the same name is a no-op (no write, returns current)")
+  func renameToSameNameIsNoOp() async throws {
+    let (backend, database) = try TestBackend.create()
+    let original = Earmark(name: "Stable", instrument: .defaultTestInstrument)
+    TestBackend.seed(earmarks: [original], in: database)
+    let store = EarmarkStore(
+      repository: backend.earmarks, conversionService: FixedConversionService(),
+      targetInstrument: .defaultTestInstrument)
+    try await store.waitForNextEmission(
+      matching: { $0.earmarks.by(id: original.id) != nil },
+      description: "seeded earmark observed"
+    )
+
+    let result = await store.rename(id: original.id, to: "Stable")
+
+    #expect(result?.name == "Stable")
+    #expect(store.error == nil)
+    let fetched = try await backend.earmarks.fetchAll()
+    #expect(fetched.first(where: { $0.id == original.id })?.name == "Stable")
+  }
+
+  @Test("rename of unknown id returns nil without surfacing an error")
+  func renameOfUnknownIdReturnsNil() async throws {
+    let (backend, _) = try TestBackend.create()
+    let store = EarmarkStore(
+      repository: backend.earmarks, conversionService: FixedConversionService(),
+      targetInstrument: .defaultTestInstrument)
+    try await store.waitForFirstEmission()
+
+    let result = await store.rename(id: UUID(), to: "Whatever")
+
+    #expect(result == nil)
+    #expect(store.error == nil)
+  }
+}

--- a/MoolahTests/Features/EarmarkStoreRenameTests.swift
+++ b/MoolahTests/Features/EarmarkStoreRenameTests.swift
@@ -3,7 +3,7 @@ import Testing
 
 @testable import Moolah
 
-@Suite("EarmarkStore/rename")
+@Suite("EarmarkStore -- rename")
 @MainActor
 struct EarmarkStoreRenameTests {
 
@@ -48,6 +48,7 @@ struct EarmarkStoreRenameTests {
     let result = await store.rename(id: original.id, to: "  Spaced  ")
 
     #expect(result?.name == "Spaced")
+    #expect(store.error == nil)
     try await store.waitForNextEmission(
       matching: { $0.earmarks.by(id: original.id)?.name == "Spaced" },
       description: "trimmed rename observed"
@@ -94,6 +95,7 @@ struct EarmarkStoreRenameTests {
     let result = await store.rename(id: original.id, to: "Stable")
 
     #expect(result?.name == "Stable")
+    #expect(store.earmarks.by(id: original.id)?.name == "Stable")
     #expect(store.error == nil)
     let fetched = try await backend.earmarks.fetchAll()
     #expect(fetched.first(where: { $0.id == original.id })?.name == "Stable")

--- a/UITestSupport/UITestIdentifiers.swift
+++ b/UITestSupport/UITestIdentifiers.swift
@@ -49,9 +49,10 @@ public enum UITestIdentifiers {
     /// shared label.
     public static let editAccountContextMenuItem = "sidebar.contextMenu.editAccount"
 
-    /// "Rename" item in the sidebar context menu — applies to accounts,
-    /// earmarks, and (Phase 4 onwards) account groups. Triggers inline
-    /// rename mode in the sidebar.
+    /// "Rename" item in the sidebar context menu for account rows.
+    /// Phase 4 will extend this identifier to earmark and account-group
+    /// rows; the identifier is centralised here so the same selector
+    /// works across all three entity types once they are wired.
     public static let renameContextMenuItem = "sidebar.contextMenu.rename"
   }
 

--- a/UITestSupport/UITestIdentifiers.swift
+++ b/UITestSupport/UITestIdentifiers.swift
@@ -48,6 +48,11 @@ public enum UITestIdentifiers {
     /// drivers must resolve via this identifier rather than the
     /// shared label.
     public static let editAccountContextMenuItem = "sidebar.contextMenu.editAccount"
+
+    /// "Rename" item in the sidebar context menu — applies to accounts,
+    /// earmarks, and (Phase 4 onwards) account groups. Triggers inline
+    /// rename mode in the sidebar.
+    public static let renameContextMenuItem = "sidebar.contextMenu.rename"
   }
 
   // MARK: - TransactionList


### PR DESCRIPTION
## Summary

- Add `AccountStore.rename(id:to:)` and `EarmarkStore.rename(id:to:)` — convenience mutations that trim whitespace, no-op empty / unchanged / unknown-id inputs, and delegate persistence to the existing `update(_:)` pass-throughs. Tests verify both the reactive store state and the persisted repository state.
- Extend `SidebarRowView` with optional inline-rename support (`isEditing` binding + `onRename` closure). When the caller opts in, the row swaps the name `Text` for a focused `TextField` (companion `InlineRenameField`) that commits on Return / focus loss and cancels on Escape. The double-click gesture is only installed when rename is opted in, so non-rename callers don't intercept `List.primaryAction`.
- Wire account rows (Current + Investments) and earmark rows to inline rename. New "Rename" context-menu item on both. Centralised `editingRowId` state on `SidebarView` enforces the one-row-at-a-time invariant (kept `private` after a follow-up access-widening audit).
- Return key on a selected account / earmark row enters rename mode (Finder convention). Exhaustive `switch` over `SidebarSelection` forces a future `.group` case to make a decision.

Builds the rename infrastructure that Phase 4's group rows will reuse for free.

## Why

Phase 2 of the Account Groups feature (spec: `.worktrees/account-groups-design/plans/2026-05-26-account-groups-design.md` — currently on a docs PR). The spec calls for a single inline-editing mode in the sidebar across all entity types, so building it now means Phase 4's group rows inherit it, and the existing dialog-only rename UX gets a faster path for accounts and earmarks today.

## Test plan

- [x] Store unit tests in `AccountStoreRenameTests` and `EarmarkStoreRenameTests` cover: happy path, trim, empty-no-op, same-name-no-op, unknown-id-nil. Both store-state and repository-state asserted on the write paths.
- [x] `just test-mac` — 3243 tests in 565 suites, all passing.
- [x] `just test-ios` — 1473 tests in 246 suites, all passing (host-process SIGKILL during simulator teardown is a known CoreSimulator flake; per-test results all green).
- [x] `just format-check` — clean.
- [ ] Manual smoke: right-click → Rename, double-click name, Return on selected row, Escape cancels, Return inside a focused rename field commits via TextField's own `.onSubmit` (parent List's `.onKeyPress(.return)` doesn't intercept first-responder events).

## Out of scope

- No XCUITest coverage for the keyboard/focus interaction (not currently in the harness for SwiftUI focus state). If a regression surfaces, that's the moment to add it.
- The Edit Account / Edit Earmark dialogs are unchanged — they still cover other-field edits.
- No Rename item on the earmark *detail view* yet (only sidebar). Can land as a separate PR.

## Design deviation noted

`RenameSupport` struct: code review suggested grouping `isEditing` + `onRename` into a single struct to type-enforce their coupling. Deferred — the plan's other tasks build against the two-optionals API, and the coupling risk is mitigated by all callers going through the same `renameBinding(for:)` + `renameAction(for:)` helpers. Conditional gesture installation (only when both properties are non-nil) eliminates the practical "one without the other" failure mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)