### PR TITLE
feat(sync): AccountGroup CloudKit sync wiring (Phase 7)

### DIFF
--- a/Backends/CloudKit/Sync/CloudKitRecordConvertible.swift
+++ b/Backends/CloudKit/Sync/CloudKitRecordConvertible.swift
@@ -28,6 +28,7 @@ protocol IdentifiableRecord {
 // `InstrumentRow` is string-keyed; no `IdentifiableRecord` conformance.
 extension ProfileRow: IdentifiableRecord {}
 extension AccountRow: IdentifiableRecord {}
+extension AccountGroupRow: IdentifiableRecord {}
 extension TransactionRow: IdentifiableRecord {}
 extension TransactionLegRow: IdentifiableRecord {}
 extension CategoryRow: IdentifiableRecord {}
@@ -54,6 +55,7 @@ extension CSVImportProfileRow: ValueTypeSystemFieldsReadable {}
 extension ImportRuleRow: ValueTypeSystemFieldsReadable {}
 extension InstrumentRow: ValueTypeSystemFieldsReadable {}
 extension AccountRow: ValueTypeSystemFieldsReadable {}
+extension AccountGroupRow: ValueTypeSystemFieldsReadable {}
 extension CategoryRow: ValueTypeSystemFieldsReadable {}
 extension TransferSuggestionRow: ValueTypeSystemFieldsReadable {}
 extension EarmarkRow: ValueTypeSystemFieldsReadable {}
@@ -95,6 +97,7 @@ enum RecordTypeRegistry: Sendable {
     ProfileRow.recordType: ProfileRow.self,
     InstrumentRow.recordType: InstrumentRow.self,
     AccountRow.recordType: AccountRow.self,
+    AccountGroupRow.recordType: AccountGroupRow.self,
     TransactionRow.recordType: TransactionRow.self,
     TransactionLegRow.recordType: TransactionLegRow.self,
     CategoryRow.recordType: CategoryRow.self,

--- a/Backends/CloudKit/Sync/ProfileDataSyncHandler+GRDBDispatch.swift
+++ b/Backends/CloudKit/Sync/ProfileDataSyncHandler+GRDBDispatch.swift
@@ -61,6 +61,10 @@ extension ProfileDataSyncHandler {
       return { handler in
         handler.applyBatchSaveTransferSuggestion(ckRecords:systemFields:in:)
       }
+    case AccountGroupRow.recordType:
+      return { handler in
+        handler.applyBatchSaveAccountGroup(ckRecords:systemFields:in:)
+      }
     default:
       return nil
     }
@@ -145,6 +149,13 @@ extension ProfileDataSyncHandler {
       return { handler, ids, database in
         try handler.writeRemote(site: "applyGRDBBatchDeletion[TransferSuggestion]") {
           try handler.grdbRepositories.transferSuggestions.applyRemoteChangesSync(
+            saved: [], deleted: ids, in: database)
+        }
+      }
+    case AccountGroupRow.recordType:
+      return { handler, ids, database in
+        try handler.writeRemote(site: "applyGRDBBatchDeletion[AccountGroup]") {
+          try handler.grdbRepositories.accountGroups.applyRemoteChangesSync(
             saved: [], deleted: ids, in: database)
         }
       }

--- a/Backends/CloudKit/Sync/ProfileDataSyncHandler+GRDBSaveHelpers.swift
+++ b/Backends/CloudKit/Sync/ProfileDataSyncHandler+GRDBSaveHelpers.swift
@@ -125,6 +125,24 @@ extension ProfileDataSyncHandler {
     }
   }
 
+  nonisolated func applyBatchSaveAccountGroup(
+    ckRecords: [CKRecord], systemFields: [String: Data], in database: Database
+  ) throws {
+    let context = GRDBBatchSaveContext(
+      ckRecords: ckRecords,
+      systemFields: systemFields,
+      site: "applyGRDBBatchSave[AccountGroup]")
+    let rows = mapRows(
+      context: context,
+      fieldValues: AccountGroupRow.fieldValues(from:),
+      idKey: { $0.id.uuidString },
+      stamp: stampSystemFields)
+    try writeRemote(site: context.site) {
+      try grdbRepositories.accountGroups.applyRemoteChangesSync(
+        saved: rows, deleted: [], in: database)
+    }
+  }
+
   nonisolated func applyBatchSaveEarmark(
     ckRecords: [CKRecord], systemFields: [String: Data], in database: Database
   ) throws {

--- a/Backends/CloudKit/Sync/ProfileDataSyncHandler+QueueAndDelete.swift
+++ b/Backends/CloudKit/Sync/ProfileDataSyncHandler+QueueAndDelete.swift
@@ -71,6 +71,7 @@ extension ProfileDataSyncHandler {
     // `SyncCoordinator.queueUnsyncedSharedInstruments`; the per-profile
     // path deliberately does not enumerate them.
     collectCategoryIds(source: source, into: &recordIDs)
+    collectAccountGroupIds(source: source, into: &recordIDs)
     collectAccountIds(source: source, into: &recordIDs)
     collectEarmarkIds(source: source, into: &recordIDs)
     collectEarmarkBudgetItemIds(source: source, into: &recordIDs)
@@ -107,6 +108,19 @@ extension ProfileDataSyncHandler {
       }
     }
     collectAllGRDBUUIDs(ids: ids, recordType: AccountRow.recordType, into: &recordIDs)
+  }
+
+  private func collectAccountGroupIds(
+    source: GRDBIdSource, into recordIDs: inout [CKRecord.ID]
+  ) {
+    let repo = grdbRepositories.accountGroups
+    let ids: () throws -> [UUID] = {
+      switch source {
+      case .all: return try repo.allRowIdsSync()
+      case .unsynced: return try repo.unsyncedRowIdsSync()
+      }
+    }
+    collectAllGRDBUUIDs(ids: ids, recordType: AccountGroupRow.recordType, into: &recordIDs)
   }
 
   private func collectEarmarkIds(
@@ -231,6 +245,10 @@ extension ProfileDataSyncHandler {
       // is no per-profile `instrument` table, so a `deleteAllSync`
       // against it would throw `no such table`.
       (CategoryRow.recordType, { try self.grdbRepositories.categories.deleteAllSync() }),
+      (
+        AccountGroupRow.recordType,
+        { try self.grdbRepositories.accountGroups.deleteAllSync() }
+      ),
       (AccountRow.recordType, { try self.grdbRepositories.accounts.deleteAllSync() }),
       (EarmarkRow.recordType, { try self.grdbRepositories.earmarks.deleteAllSync() }),
       (

--- a/Backends/CloudKit/Sync/ProfileDataSyncHandler+RecordLookup.swift
+++ b/Backends/CloudKit/Sync/ProfileDataSyncHandler+RecordLookup.swift
@@ -99,6 +99,10 @@ extension ProfileDataSyncHandler {
       return fetchTransferSuggestionRow(id: uuid).map { row in
         buildCKRecord(from: row, encodedSystemFields: row.encodedSystemFields)
       }
+    case AccountGroupRow.recordType:
+      return fetchAccountGroupRow(id: uuid).map { row in
+        buildCKRecord(from: row, encodedSystemFields: row.encodedSystemFields)
+      }
     case CSVImportProfileRow.recordType:
       return fetchCSVImportProfileRow(id: uuid).map { row in
         buildCKRecord(from: row, encodedSystemFields: row.encodedSystemFields)
@@ -185,6 +189,13 @@ extension ProfileDataSyncHandler {
         self.mapBuiltRows(
           self.fetchRowsBatch {
             try self.grdbRepositories.transferSuggestions.fetchRowsSync(ids: ids)
+          })
+      }
+    case AccountGroupRow.recordType:
+      return {
+        self.mapBuiltRows(
+          self.fetchRowsBatch {
+            try self.grdbRepositories.accountGroups.fetchRowsSync(ids: ids)
           })
       }
     case CSVImportProfileRow.recordType:
@@ -302,6 +313,10 @@ extension ProfileDataSyncHandler {
 
   private func fetchTransferSuggestionRow(id: UUID) -> TransferSuggestionRow? {
     fetchRowOrLog { try grdbRepositories.transferSuggestions.fetchRowSync(id: id) }
+  }
+
+  private func fetchAccountGroupRow(id: UUID) -> AccountGroupRow? {
+    fetchRowOrLog { try grdbRepositories.accountGroups.fetchRowSync(id: id) }
   }
 
   private func fetchEarmarkRow(id: UUID) -> EarmarkRow? {

--- a/Backends/CloudKit/Sync/ProfileDataSyncHandler+SystemFields.swift
+++ b/Backends/CloudKit/Sync/ProfileDataSyncHandler+SystemFields.swift
@@ -26,6 +26,7 @@ extension ProfileDataSyncHandler {
     [
       (CategoryRow.recordType, grdbRepositories.categories.clearAllSystemFieldsSync),
       (AccountRow.recordType, grdbRepositories.accounts.clearAllSystemFieldsSync),
+      (AccountGroupRow.recordType, grdbRepositories.accountGroups.clearAllSystemFieldsSync),
       (EarmarkRow.recordType, grdbRepositories.earmarks.clearAllSystemFieldsSync),
       (
         EarmarkBudgetItemRow.recordType,
@@ -239,6 +240,8 @@ extension ProfileDataSyncHandler {
       return { try repos.categories.setEncodedSystemFieldsBatchSync($0) }
     case TransferSuggestionRow.recordType:
       return { try repos.transferSuggestions.setEncodedSystemFieldsBatchSync($0) }
+    case AccountGroupRow.recordType:
+      return { try repos.accountGroups.setEncodedSystemFieldsBatchSync($0) }
     default:
       return nil
     }

--- a/Backends/GRDB/Repositories/GRDBAccountGroupRepository+Sync.swift
+++ b/Backends/GRDB/Repositories/GRDBAccountGroupRepository+Sync.swift
@@ -1,0 +1,30 @@
+// Backends/GRDB/Repositories/GRDBAccountGroupRepository+Sync.swift
+
+import Foundation
+import GRDB
+
+extension GRDBAccountGroupRepository {
+  /// Batch counterpart to `setEncodedSystemFieldsSync` — writes every
+  /// update in a single GRDB transaction so `databaseDidCommit` fires
+  /// once rather than once per row. See the doc on
+  /// `GRDBTransactionRepository.setEncodedSystemFieldsBatchSync` for
+  /// the rationale and issue #865 for the follow-up that drops the
+  /// observation-region dependency on this column.
+  func setEncodedSystemFieldsBatchSync(
+    _ updates: [(id: UUID, data: Data?)]
+  ) throws -> Int {
+    guard !updates.isEmpty else { return 0 }
+    return try database.write { database in
+      var updatedCount = 0
+      for (id, data) in updates {
+        updatedCount +=
+          try AccountGroupRow
+          .filter(AccountGroupRow.Columns.id == id)
+          .updateAll(
+            database,
+            [AccountGroupRow.Columns.encodedSystemFields.set(to: data)])
+      }
+      return updatedCount
+    }
+  }
+}

--- a/Backends/GRDB/Sync/AccountGroupRow+CloudKit.swift
+++ b/Backends/GRDB/Sync/AccountGroupRow+CloudKit.swift
@@ -1,0 +1,45 @@
+import CloudKit
+import Foundation
+
+// MARK: - AccountGroupRow + CloudKitRecordConvertible
+//
+// The wire `recordType` ("AccountGroupRecord") is the stable contract
+// for this record, so it stays unchanged regardless of the local Swift
+// type's name.
+
+extension AccountGroupRow: CloudKitRecordConvertible {
+  func toCKRecord(in zoneID: CKRecordZone.ID) -> CKRecord {
+    let recordID = CKRecord.ID(
+      recordType: Self.recordType, uuid: id, zoneID: zoneID)
+    let record = CKRecord(recordType: Self.recordType, recordID: recordID)
+    AccountGroupRecordCloudKitFields(
+      bucket: bucket,
+      instrumentId: instrumentId,
+      name: name,
+      position: Int64(position)
+    ).write(to: record)
+    return record
+  }
+
+  static func fieldValues(from ckRecord: CKRecord) -> AccountGroupRow? {
+    guard let id = ckRecord.recordID.uuid else { return nil }
+    let fields = AccountGroupRecordCloudKitFields(from: ckRecord)
+    return AccountGroupRow(
+      id: id,
+      recordName: ckRecord.recordID.recordName,
+      name: fields.name ?? "",
+      // Unknown / missing bucket falls back to `.current`; the
+      // `DataFormatVersion` gate guards against a future bucket case
+      // reaching an older build. Mirrors `AccountGroupRow.toDomain`.
+      bucket: fields.bucket ?? AccountBucket.current.rawValue,
+      // Missing instrumentId falls back to AUD — consistent with the
+      // AccountRow CloudKit decoder. Production never writes a record
+      // without an instrument.
+      instrumentId: fields.instrumentId ?? "AUD",
+      position: Int(fields.position ?? 0),
+      // Stamped by applyGRDBBatchSave after upsert; never read from the
+      // CKRecord itself.
+      encodedSystemFields: nil
+    )
+  }
+}

--- a/MoolahTests/Backends/GRDB/AccountGroupSyncHelpersTests.swift
+++ b/MoolahTests/Backends/GRDB/AccountGroupSyncHelpersTests.swift
@@ -1,0 +1,254 @@
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+/// Direct tests for the sync helpers on `GRDBAccountGroupRepository` —
+/// the methods the CKSyncEngine apply / upload paths call from a
+/// non-MainActor context. Mirrors the shape of the per-record-type
+/// sync helper tests for `GRDBTransferSuggestionRepository`.
+@Suite("GRDBAccountGroupRepository sync helpers")
+struct AccountGroupSyncHelpersTests {
+
+  // MARK: - applyRemoteChangesSync (saved)
+
+  @Test
+  func applyRemoteChangesSavedUpsertsRow() async throws {
+    let database = try ProfileDatabase.openInMemory()
+    let repo = GRDBAccountGroupRepository(database: database)
+
+    let group = AccountGroup(
+      name: "Cross-device", bucket: .investments, instrument: .defaultTestInstrument)
+    let row = AccountGroupRow(domain: group)
+    try repo.applyRemoteChangesSync(saved: [row], deleted: [])
+
+    let fetched = try await repo.fetchAll()
+    #expect(fetched.contains { $0.id == row.id && $0.name == "Cross-device" })
+  }
+
+  // MARK: - applyRemoteChangesSync (deleted)
+
+  @Test
+  func applyRemoteChangesDeletedRemovesRow() async throws {
+    let database = try ProfileDatabase.openInMemory()
+    let repo = GRDBAccountGroupRepository(database: database)
+
+    let created = try await repo.create(
+      AccountGroup(
+        name: "Ephemeral", bucket: .investments, instrument: .defaultTestInstrument)
+    )
+    try repo.applyRemoteChangesSync(saved: [], deleted: [created.id])
+
+    let fetched = try await repo.fetchAll()
+    #expect(!fetched.contains { $0.id == created.id })
+  }
+
+  // MARK: - In-transaction variant
+
+  @Test
+  func applyRemoteChangesInTransactionVariantSucceeds() async throws {
+    let database = try ProfileDatabase.openInMemory()
+    let repo = GRDBAccountGroupRepository(database: database)
+
+    let row = AccountGroupRow(
+      domain: AccountGroup(
+        name: "Tx", bucket: .investments, instrument: .defaultTestInstrument)
+    )
+    try await database.write { database in
+      try repo.applyRemoteChangesSync(saved: [row], deleted: [], in: database)
+    }
+
+    let fetched = try await repo.fetchAll()
+    #expect(fetched.contains { $0.id == row.id })
+  }
+
+  // MARK: - setEncodedSystemFieldsSync (single)
+
+  @Test
+  func setEncodedSystemFieldsSyncPersistsBlob() async throws {
+    let database = try ProfileDatabase.openInMemory()
+    let repo = GRDBAccountGroupRepository(database: database)
+
+    let created = try await repo.create(
+      AccountGroup(
+        name: "Stamped", bucket: .investments, instrument: .defaultTestInstrument)
+    )
+
+    let payload = Data([0x01, 0x02, 0x03])
+    let updated = try repo.setEncodedSystemFieldsSync(id: created.id, data: payload)
+    #expect(updated == true)
+
+    let row = try await database.read { database in
+      try AccountGroupRow
+        .filter(AccountGroupRow.Columns.id == created.id)
+        .fetchOne(database)
+    }
+    #expect(row?.encodedSystemFields == payload)
+  }
+
+  @Test
+  func setEncodedSystemFieldsSyncReturnsFalseForUnknownId() throws {
+    let database = try ProfileDatabase.openInMemory()
+    let repo = GRDBAccountGroupRepository(database: database)
+
+    let updated = try repo.setEncodedSystemFieldsSync(
+      id: UUID(), data: Data([0xAA]))
+    #expect(updated == false)
+  }
+
+  // MARK: - setEncodedSystemFieldsBatchSync
+
+  @Test
+  func setEncodedSystemFieldsBatchSyncUpdatesEveryRow() async throws {
+    let database = try ProfileDatabase.openInMemory()
+    let repo = GRDBAccountGroupRepository(database: database)
+
+    let first = try await repo.create(
+      AccountGroup(name: "A", bucket: .investments, instrument: .defaultTestInstrument)
+    )
+    let second = try await repo.create(
+      AccountGroup(name: "B", bucket: .current, instrument: .defaultTestInstrument)
+    )
+
+    let payloadA = Data([0x01])
+    let payloadB = Data([0x02])
+    let updatedCount = try repo.setEncodedSystemFieldsBatchSync(
+      [(id: first.id, data: payloadA), (id: second.id, data: payloadB)])
+    #expect(updatedCount == 2)
+
+    let rows = try await database.read { database in
+      try AccountGroupRow.fetchAll(database)
+    }
+    let blobByID = Dictionary(uniqueKeysWithValues: rows.map { ($0.id, $0.encodedSystemFields) })
+    #expect(blobByID[first.id] == payloadA)
+    #expect(blobByID[second.id] == payloadB)
+  }
+
+  @Test
+  func setEncodedSystemFieldsBatchSyncReturnsZeroForEmptyInput() throws {
+    let database = try ProfileDatabase.openInMemory()
+    let repo = GRDBAccountGroupRepository(database: database)
+
+    let updatedCount = try repo.setEncodedSystemFieldsBatchSync([])
+    #expect(updatedCount == 0)
+  }
+
+  // MARK: - clearAllSystemFieldsSync
+
+  @Test
+  func clearAllSystemFieldsSyncNullsEveryBlob() async throws {
+    let database = try ProfileDatabase.openInMemory()
+    let repo = GRDBAccountGroupRepository(database: database)
+
+    let created = try await repo.create(
+      AccountGroup(
+        name: "Cleared", bucket: .investments, instrument: .defaultTestInstrument)
+    )
+    _ = try repo.setEncodedSystemFieldsSync(id: created.id, data: Data([0x99]))
+
+    try repo.clearAllSystemFieldsSync()
+
+    let row = try await database.read { database in
+      try AccountGroupRow
+        .filter(AccountGroupRow.Columns.id == created.id)
+        .fetchOne(database)
+    }
+    #expect(row?.encodedSystemFields == nil)
+  }
+
+  // MARK: - deleteAllSync
+
+  @Test
+  func deleteAllSyncRemovesEveryRow() async throws {
+    let database = try ProfileDatabase.openInMemory()
+    let repo = GRDBAccountGroupRepository(database: database)
+
+    _ = try await repo.create(
+      AccountGroup(name: "A", bucket: .investments, instrument: .defaultTestInstrument)
+    )
+    _ = try await repo.create(
+      AccountGroup(name: "B", bucket: .current, instrument: .defaultTestInstrument)
+    )
+
+    try repo.deleteAllSync()
+
+    let fetched = try await repo.fetchAll()
+    #expect(fetched.isEmpty)
+  }
+
+  // MARK: - allRowIdsSync / unsyncedRowIdsSync
+
+  @Test
+  func allRowIdsSyncReturnsEveryId() async throws {
+    let database = try ProfileDatabase.openInMemory()
+    let repo = GRDBAccountGroupRepository(database: database)
+
+    let first = try await repo.create(
+      AccountGroup(name: "A", bucket: .investments, instrument: .defaultTestInstrument)
+    )
+    let second = try await repo.create(
+      AccountGroup(name: "B", bucket: .current, instrument: .defaultTestInstrument)
+    )
+
+    let ids = Set(try repo.allRowIdsSync())
+    #expect(ids == Set([first.id, second.id]))
+  }
+
+  @Test
+  func unsyncedRowIdsSyncReturnsRowsWithoutSystemFields() async throws {
+    let database = try ProfileDatabase.openInMemory()
+    let repo = GRDBAccountGroupRepository(database: database)
+
+    let unsynced = try await repo.create(
+      AccountGroup(
+        name: "Pending", bucket: .investments, instrument: .defaultTestInstrument)
+    )
+    let synced = try await repo.create(
+      AccountGroup(name: "Synced", bucket: .current, instrument: .defaultTestInstrument)
+    )
+    _ = try repo.setEncodedSystemFieldsSync(id: synced.id, data: Data([0xAB]))
+
+    let ids = try repo.unsyncedRowIdsSync()
+    #expect(ids.contains(unsynced.id))
+    #expect(!ids.contains(synced.id))
+  }
+
+  // MARK: - fetchRowSync / fetchRowsSync
+
+  @Test
+  func fetchRowSyncReturnsRowOrNil() async throws {
+    let database = try ProfileDatabase.openInMemory()
+    let repo = GRDBAccountGroupRepository(database: database)
+
+    let created = try await repo.create(
+      AccountGroup(name: "X", bucket: .investments, instrument: .defaultTestInstrument)
+    )
+
+    let found = try repo.fetchRowSync(id: created.id)
+    #expect(found?.id == created.id)
+
+    let missing = try repo.fetchRowSync(id: UUID())
+    #expect(missing == nil)
+  }
+
+  @Test
+  func fetchRowsSyncReturnsMatchingSubset() async throws {
+    let database = try ProfileDatabase.openInMemory()
+    let repo = GRDBAccountGroupRepository(database: database)
+
+    let first = try await repo.create(
+      AccountGroup(name: "A", bucket: .investments, instrument: .defaultTestInstrument)
+    )
+    let second = try await repo.create(
+      AccountGroup(name: "B", bucket: .current, instrument: .defaultTestInstrument)
+    )
+    _ = try await repo.create(
+      AccountGroup(name: "C", bucket: .investments, instrument: .defaultTestInstrument)
+    )
+
+    let rows = try repo.fetchRowsSync(ids: [first.id, second.id])
+    let ids = Set(rows.map(\.id))
+    #expect(ids == Set([first.id, second.id]))
+  }
+}

--- a/MoolahTests/Sync/AccountGroupRowCKRecordTests.swift
+++ b/MoolahTests/Sync/AccountGroupRowCKRecordTests.swift
@@ -1,0 +1,115 @@
+import CloudKit
+import Foundation
+import Testing
+
+@testable import Moolah
+
+/// CloudKit wire-format round-trip for `AccountGroupRow`. Mirrors the
+/// shape of the per-type cases in `RecordMappingTests`; lives in its own
+/// file because Phase 3 / Phase 7 ship as separate PRs and keeping the
+/// new round-trip in a sibling file avoids edit conflicts on the busy
+/// `RecordMappingTests.swift` file.
+@Suite("AccountGroupRow CKRecord round-trip")
+struct AccountGroupRowCKRecordTests {
+
+  private let zoneID = CKRecordZone.ID(
+    zoneName: "profile-test", ownerName: CKCurrentUserDefaultName)
+
+  @Test
+  func toCKRecordCarriesAllFields() throws {
+    let id = UUID()
+    let row = AccountGroupRow(
+      id: id,
+      recordName: AccountGroupRow.recordName(for: id),
+      name: "Trust Fund Crypto",
+      bucket: AccountBucket.investments.rawValue,
+      instrumentId: "AUD",
+      position: 3,
+      encodedSystemFields: nil)
+
+    let ckRecord = row.toCKRecord(in: zoneID)
+
+    #expect(ckRecord.recordType == "AccountGroupRecord")
+    #expect(
+      ckRecord.recordID.recordName
+        == "\(AccountGroupRow.recordType)|\(row.id.uuidString)")
+    #expect(ckRecord["name"] as? String == "Trust Fund Crypto")
+    #expect(ckRecord["bucket"] as? String == AccountBucket.investments.rawValue)
+    #expect(ckRecord["instrumentId"] as? String == "AUD")
+    #expect((ckRecord["position"] as? Int64) == 3)
+  }
+
+  @Test
+  func fieldValuesReconstructsRowFromCKRecord() throws {
+    let id = UUID()
+    let recordID = CKRecord.ID(
+      recordType: AccountGroupRow.recordType, uuid: id, zoneID: zoneID)
+    let ckRecord = CKRecord(recordType: "AccountGroupRecord", recordID: recordID)
+    ckRecord["name"] = "Personal Crypto" as CKRecordValue
+    ckRecord["bucket"] = AccountBucket.investments.rawValue as CKRecordValue
+    ckRecord["instrumentId"] = "AUD" as CKRecordValue
+    ckRecord["position"] = Int64(0) as CKRecordValue
+
+    let restored = try #require(AccountGroupRow.fieldValues(from: ckRecord))
+    #expect(restored.id == id)
+    #expect(restored.name == "Personal Crypto")
+    #expect(restored.bucket == AccountBucket.investments.rawValue)
+    #expect(restored.instrumentId == "AUD")
+    #expect(restored.position == 0)
+    // Stamped by applyGRDBBatchSave after upsert; never read from the
+    // CKRecord itself.
+    #expect(restored.encodedSystemFields == nil)
+  }
+
+  @Test
+  func fieldValuesReturnsNilForRecordIDWithoutPrefix() {
+    // A bare-UUID recordName (pre-issue-#416) returns nil — `recordID.uuid`
+    // requires the `<TYPE>|<UUID>` prefix.
+    let recordID = CKRecord.ID(recordName: UUID().uuidString, zoneID: zoneID)
+    let ckRecord = CKRecord(recordType: "AccountGroupRecord", recordID: recordID)
+    ckRecord["name"] = "X" as CKRecordValue
+    ckRecord["bucket"] = AccountBucket.current.rawValue as CKRecordValue
+    ckRecord["instrumentId"] = "AUD" as CKRecordValue
+    ckRecord["position"] = Int64(0) as CKRecordValue
+
+    let restored = AccountGroupRow.fieldValues(from: ckRecord)
+    #expect(restored == nil, "Bare-UUID recordName must be rejected — caller logs and skips")
+  }
+
+  @Test
+  func fieldValuesDefaultsBucketWhenMissing() throws {
+    // A CKRecord missing the `bucket` field falls back to `.current` —
+    // matches `AccountGroupRow.toDomain`'s defensive default.
+    let id = UUID()
+    let recordID = CKRecord.ID(
+      recordType: AccountGroupRow.recordType, uuid: id, zoneID: zoneID)
+    let ckRecord = CKRecord(recordType: "AccountGroupRecord", recordID: recordID)
+    ckRecord["name"] = "No Bucket" as CKRecordValue
+    ckRecord["instrumentId"] = "AUD" as CKRecordValue
+    ckRecord["position"] = Int64(0) as CKRecordValue
+
+    let restored = try #require(AccountGroupRow.fieldValues(from: ckRecord))
+    #expect(restored.bucket == AccountBucket.current.rawValue)
+  }
+
+  @Test
+  func fullDomainCKRecordRoundTrip() throws {
+    let original = AccountGroup(
+      id: UUID(),
+      name: "Joint Accounts",
+      bucket: .current,
+      instrument: .defaultTestInstrument,
+      position: 7)
+    let outboundRow = AccountGroupRow(domain: original)
+
+    let ckRecord = outboundRow.toCKRecord(in: zoneID)
+    let inboundRow = try #require(AccountGroupRow.fieldValues(from: ckRecord))
+    let restored = inboundRow.toDomain()
+
+    #expect(restored.id == original.id)
+    #expect(restored.name == original.name)
+    #expect(restored.bucket == original.bucket)
+    #expect(restored.instrument == original.instrument)
+    #expect(restored.position == original.position)
+  }
+}

--- a/MoolahTests/Sync/AccountGroupSyncIntegrationTests.swift
+++ b/MoolahTests/Sync/AccountGroupSyncIntegrationTests.swift
@@ -1,0 +1,107 @@
+@preconcurrency import CloudKit
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+/// End-to-end dispatch test for `AccountGroupRecord`: drives
+/// `ProfileDataSyncHandler.applyRemoteChanges` with a synthetic CKRecord
+/// representing an insert, then a delete, and verifies the local GRDB
+/// state matches at each step. Mirrors `ApplyRemoteChangesOutOfOrderTests`'
+/// harness construction.
+@Suite("AccountGroup sync integration")
+struct AccountGroupSyncIntegrationTests {
+
+  private static let zoneID = CKRecordZone.ID(
+    zoneName: "TestZone", ownerName: CKCurrentUserDefaultName)
+
+  @Test
+  func applyRemoteChangesInsertThenDeleteAccountGroup() async throws {
+    let harness = try await MainActor.run {
+      try ProfileDataSyncHandlerTestSupport.makeHandlerWithDatabase()
+    }
+
+    let groupId = UUID()
+    let recordID = CKRecord.ID(
+      recordType: AccountGroupRow.recordType, uuid: groupId, zoneID: Self.zoneID)
+    let ckRecord = CKRecord(recordType: "AccountGroupRecord", recordID: recordID)
+    ckRecord["name"] = "Trust Fund Crypto" as CKRecordValue
+    ckRecord["bucket"] = AccountBucket.investments.rawValue as CKRecordValue
+    ckRecord["instrumentId"] = "AUD" as CKRecordValue
+    ckRecord["position"] = Int64(0) as CKRecordValue
+
+    // Apply incoming save — must NOT throw, must NOT report .saveFailed.
+    let saveResult = harness.handler.applyRemoteChanges(saved: [ckRecord], deleted: [])
+    if case .saveFailed(let message) = saveResult {
+      Issue.record("Expected success, got .saveFailed(\(message))")
+    }
+
+    var presentCount = try await harness.database.read { database in
+      try Int.fetchOne(
+        database,
+        sql: "SELECT COUNT(*) FROM account_group WHERE id = ?",
+        arguments: [groupId]) ?? -1
+    }
+    #expect(presentCount == 1, "AccountGroup row should land in GRDB after save dispatch")
+
+    let storedName = try await harness.database.read { database in
+      try String.fetchOne(
+        database,
+        sql: "SELECT name FROM account_group WHERE id = ?",
+        arguments: [groupId])
+    }
+    #expect(storedName == "Trust Fund Crypto")
+
+    // Apply incoming delete — must remove the row.
+    let deleteResult = harness.handler.applyRemoteChanges(
+      saved: [], deleted: [(recordID, "AccountGroupRecord")])
+    if case .saveFailed(let message) = deleteResult {
+      Issue.record("Expected success, got .saveFailed(\(message))")
+    }
+
+    presentCount = try await harness.database.read { database in
+      try Int.fetchOne(
+        database,
+        sql: "SELECT COUNT(*) FROM account_group WHERE id = ?",
+        arguments: [groupId]) ?? -1
+    }
+    #expect(presentCount == 0, "AccountGroup row should be removed after delete dispatch")
+  }
+
+  /// A second AccountGroup save targeting the same id (e.g. a remote
+  /// rename) must upsert in place rather than fail on the PK collision.
+  @Test
+  func applyRemoteChangesAccountGroupUpsertReplacesExistingRow() async throws {
+    let harness = try await MainActor.run {
+      try ProfileDataSyncHandlerTestSupport.makeHandlerWithDatabase()
+    }
+
+    let groupId = UUID()
+    let recordID = CKRecord.ID(
+      recordType: AccountGroupRow.recordType, uuid: groupId, zoneID: Self.zoneID)
+
+    let first = CKRecord(recordType: "AccountGroupRecord", recordID: recordID)
+    first["name"] = "Before Rename" as CKRecordValue
+    first["bucket"] = AccountBucket.investments.rawValue as CKRecordValue
+    first["instrumentId"] = "AUD" as CKRecordValue
+    first["position"] = Int64(0) as CKRecordValue
+    _ = harness.handler.applyRemoteChanges(saved: [first], deleted: [])
+
+    let second = CKRecord(recordType: "AccountGroupRecord", recordID: recordID)
+    second["name"] = "After Rename" as CKRecordValue
+    second["bucket"] = AccountBucket.investments.rawValue as CKRecordValue
+    second["instrumentId"] = "AUD" as CKRecordValue
+    second["position"] = Int64(2) as CKRecordValue
+    _ = harness.handler.applyRemoteChanges(saved: [second], deleted: [])
+
+    let row = try await harness.database.read { database in
+      try AccountGroupRow
+        .filter(AccountGroupRow.Columns.id == groupId)
+        .fetchOne(database)
+    }
+    let fetched = try #require(row)
+    #expect(fetched.name == "After Rename")
+    #expect(fetched.position == 2)
+  }
+}


### PR DESCRIPTION
## Summary

Phase 7 of the Account Groups feature. Takes `AccountGroup` from local-only (Phase 3) to fully cross-device synced. Mirrors the `TransferSuggestionRow` dispatch shape used for reference-data records.

- `CloudKitRecordConvertible` conformance on `AccountGroupRow` (`toCKRecord` + `fieldValues`) via the generated `AccountGroupRecordCloudKitFields` writer/reader. `fieldValues` returns `nil` for recordIDs without a parseable UUID so the caller logs and skips.
- `GRDBAccountGroupRepository+Sync.swift` adds `setEncodedSystemFieldsBatchSync` (single-transaction batch counterpart). The remaining sync helpers (`applyRemoteChangesSync`, `setEncodedSystemFieldsSync`, `clearAllSystemFieldsSync`, `deleteAllSync`, `allRowIdsSync`, `unsyncedRowIdsSync`, `fetchRowSync`, `fetchRowsSync`) already live on the repository from Phase 3.
- Registration in `RecordTypeRegistry.allTypes`, `IdentifiableRecord`, and `ValueTypeSystemFieldsReadable`.
- Dispatch wired into all five `ProfileDataSyncHandler` extension files (`+GRDBSaveHelpers`, `+GRDBDispatch`, `+RecordLookup`, `+SystemFields`, `+QueueAndDelete`).
- Unit tests for CKRecord ↔ row round-trip; sync-helper coverage; integration test driving `applyRemoteChanges` end-to-end (insert + delete + upsert-by-id).

## Why

Without this, `AccountGroup` writes from Phase 3's build stay local and never appear on other devices. The CKDB schema for `AccountGroupRecord` is already declared (Phase 3), so this PR just plugs the new record type into the dispatch tables that the sync handler already uses.

## Phase ordering

Depends on **Phase 3** (`AccountGroupRow`, `GRDBAccountGroupRepository`, `Account.groupId` round-trip, CKDB schema — PR [#984](https://github.com/moolah-rocks/moolah-native/pull/984)). Independent of Phases 2 / 4 / 5 / 6 / 8 — UI work can land in parallel.

Stacked on `account-group-model`; will retarget to `main` once #984 lands.

## Manual cross-device verification

Recommended smoke test before flipping the feature on for daily use (does **not** block this PR):

1. Device A: create two groups, assign members.
2. Wait for sync.
3. Device B: confirm both groups appear with the same members.
4. Device A: rename a group + add a member.
5. Device B: confirm changes within a sync cycle.
6. Device A: delete a group.
7. Device B: confirm group disappears and former members render standalone (no FK cascade — `groupId` resolves to nil).

## Test plan

- [x] `just test-mac AccountGroupSyncHelpersTests AccountGroupRowCKRecordTests AccountGroupSyncIntegrationTests` — 20 tests, all pass.
- [x] `just test-mac` — full macOS suite green (3291 tests in 573 suites).
- [x] `just format-check` — clean.
- [ ] Manual cross-device verification (see above).

## Out of scope

- Per-member sync-status aggregation surface on `AccountGroup` (Phase 5 — `AccountViewContext` + detail-view header).
- Local-only `isExpandedInSidebar` persistence (Phase 8).