### PR TITLE
feat(sidebar): account groups UX (Phase 4)

### DIFF
--- a/App/ContentView+AccountDetail.swift
+++ b/App/ContentView+AccountDetail.swift
@@ -1,0 +1,50 @@
+import SwiftUI
+
+// MARK: - Account Detail
+
+extension ContentView {
+  @ViewBuilder
+  func accountDetail(id: UUID) -> some View {
+    if let account = accountStore.accounts.by(id: id) {
+      switch account.type {
+      case .investment:
+        InvestmentAccountView(
+          account: account,
+          accounts: accountStore.accounts,
+          categories: categoryStore.categories,
+          earmarks: earmarkStore.earmarks,
+          investmentStore: investmentStore,
+          transactionStore: transactionStore)
+      case .crypto:
+        CryptoWalletAccountView(
+          account: account,
+          accounts: accountStore.accounts,
+          categories: categoryStore.categories,
+          earmarks: earmarkStore.earmarks,
+          transactionStore: transactionStore,
+          positions: accountStore.positions(for: account.id),
+          conversionService: session.backend.conversionService,
+          session: session)
+      case .exchange:
+        ExchangeAccountView(
+          account: account,
+          accounts: accountStore.accounts,
+          categories: categoryStore.categories,
+          earmarks: earmarkStore.earmarks,
+          transactionStore: transactionStore,
+          positions: accountStore.positions(for: account.id),
+          conversionService: session.backend.conversionService,
+          session: session)
+      default:
+        StandardAccountView(
+          account: account,
+          positions: accountStore.positions(for: account.id),
+          accounts: accountStore.accounts,
+          categories: categoryStore.categories,
+          earmarks: earmarkStore.earmarks,
+          transactionStore: transactionStore,
+          conversionService: session.backend.conversionService)
+      }
+    }
+  }
+}

--- a/App/ContentView+GroupDetail.swift
+++ b/App/ContentView+GroupDetail.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+
+extension ContentView {
+  /// Phase 5 placeholder for the composite group detail view. Until
+  /// the `AccountViewContext`-driven detail surface lands, the
+  /// placeholder shows the group's name and a brief note so the user
+  /// has clear feedback that the group is selected.
+  @ViewBuilder
+  func groupDetailPlaceholder(id: UUID) -> some View {
+    if let group = accountGroupStore.by(id: id) {
+      ContentUnavailableView(
+        group.name,
+        systemImage: "folder.fill",
+        description: Text(
+          "Group details are coming soon. Expand the group in the sidebar to view its members.")
+      )
+    } else {
+      ContentUnavailableView(
+        "Group not found",
+        systemImage: "folder.badge.questionmark",
+        description: Text("This group may not have arrived from sync yet.")
+      )
+    }
+  }
+}

--- a/App/ContentView.swift
+++ b/App/ContentView.swift
@@ -12,14 +12,18 @@ import SwiftUI
 
 /// Placeholder main content shown after sign-in. Replaced step-by-step with real screens.
 struct ContentView: View {
+  // Internal (not private) so the `+AccountDetail` and `+GroupDetail`
+  // extension files can reach the environment stores across the file
+  // split.
   @Environment(AuthStore.self) private var authStore
-  @Environment(ProfileSession.self) private var session
-  @Environment(AccountStore.self) private var accountStore
-  @Environment(TransactionStore.self) private var transactionStore
-  @Environment(CategoryStore.self) private var categoryStore
-  @Environment(EarmarkStore.self) private var earmarkStore
+  @Environment(ProfileSession.self) var session
+  @Environment(AccountStore.self) var accountStore
+  @Environment(TransactionStore.self) var transactionStore
+  @Environment(CategoryStore.self) var categoryStore
+  @Environment(EarmarkStore.self) var earmarkStore
+  @Environment(AccountGroupStore.self) var accountGroupStore
   @Environment(AnalysisStore.self) private var analysisStore
-  @Environment(InvestmentStore.self) private var investmentStore
+  @Environment(InvestmentStore.self) var investmentStore
   @Environment(ReportingStore.self) private var reportingStore
 
   #if os(macOS)
@@ -191,6 +195,13 @@ struct ContentView: View {
           transactionStore: transactionStore,
           analysisRepository: analysisStore.repository)
       }
+    case .group(let id):
+      // Phase 5 wires the composite detail view bound to an
+      // `AccountViewContext`. Until then, render a placeholder so the
+      // user has feedback that the group is selected — the existing
+      // `accountDetail(id:)` shape only fits a single account, and
+      // forcing it here would misrepresent the membership.
+      groupDetailPlaceholder(id: id)
     case .recentlyAdded:
       RecentlyAddedView(backend: session.backend)
     case .allTransactions:
@@ -339,51 +350,5 @@ extension ContentView {
   }
 }
 
-// MARK: - Account Detail
-
-extension ContentView {
-  @ViewBuilder
-  private func accountDetail(id: UUID) -> some View {
-    if let account = accountStore.accounts.by(id: id) {
-      switch account.type {
-      case .investment:
-        InvestmentAccountView(
-          account: account,
-          accounts: accountStore.accounts,
-          categories: categoryStore.categories,
-          earmarks: earmarkStore.earmarks,
-          investmentStore: investmentStore,
-          transactionStore: transactionStore)
-      case .crypto:
-        CryptoWalletAccountView(
-          account: account,
-          accounts: accountStore.accounts,
-          categories: categoryStore.categories,
-          earmarks: earmarkStore.earmarks,
-          transactionStore: transactionStore,
-          positions: accountStore.positions(for: account.id),
-          conversionService: session.backend.conversionService,
-          session: session)
-      case .exchange:
-        ExchangeAccountView(
-          account: account,
-          accounts: accountStore.accounts,
-          categories: categoryStore.categories,
-          earmarks: earmarkStore.earmarks,
-          transactionStore: transactionStore,
-          positions: accountStore.positions(for: account.id),
-          conversionService: session.backend.conversionService,
-          session: session)
-      default:
-        StandardAccountView(
-          account: account,
-          positions: accountStore.positions(for: account.id),
-          accounts: accountStore.accounts,
-          categories: categoryStore.categories,
-          earmarks: earmarkStore.earmarks,
-          transactionStore: transactionStore,
-          conversionService: session.backend.conversionService)
-      }
-    }
-  }
-}
+// `accountDetail(id:)` lives in `ContentView+AccountDetail.swift`.
+// `groupDetailPlaceholder(id:)` lives in `ContentView+GroupDetail.swift`.

--- a/App/ProfileSession+SyncCleanup.swift
+++ b/App/ProfileSession+SyncCleanup.swift
@@ -39,6 +39,7 @@ extension ProfileSession {
     // per-store sync-refresh test suites.
     accountStore.stopObserving()
     earmarkStore.stopObserving()
+    accountGroupStore?.stopObserving()
     categoryStore.stopObserving()
     importRuleStore.stopObserving()
     transactionStore.stopObserving()

--- a/App/ProfileSession.swift
+++ b/App/ProfileSession.swift
@@ -25,6 +25,15 @@ final class ProfileSession: Identifiable {
   let transactionStore: TransactionStore
   let categoryStore: CategoryStore
   let earmarkStore: EarmarkStore
+  /// `private(set) var` (rather than `let`) so it can be assigned from
+  /// `finishInit()` rather than the main `init` body. Functionally
+  /// `let` from the consumer's perspective — no caller mutates it.
+  /// Pattern mirrors `cryptoSyncStore` / `cryptoTokenDiscovery`.
+  /// The optional is *always* set by the end of init (the
+  /// `finishInit()` tail runs synchronously inside `init`), so
+  /// consumers can force-unwrap if needed; the type stays optional to
+  /// satisfy SwiftLint's `implicitly_unwrapped_optional` rule.
+  private(set) var accountGroupStore: AccountGroupStore?
   let analysisStore: AnalysisStore
   let investmentStore: InvestmentStore
   let reportingStore: ReportingStore
@@ -186,10 +195,9 @@ final class ProfileSession: Identifiable {
     self.analysisStore = stores.analysis
     self.investmentStore = stores.investment
     self.reportingStore = stores.reporting
-
-    // CSV import: ImportStore owns the pipeline orchestration; the staging
-    // store lives per-profile on disk so pending/failed files follow the
-    // profile across app restarts.
+    // CSV import: ImportStore owns the pipeline orchestration; the
+    // staging store lives per-profile on disk so pending/failed files
+    // follow the profile across app restarts.
     let importPipeline = Self.makeImportPipeline(
       backend: backend, profileId: profile.id, logger: logger)
     self.importStore = importPipeline.importStore
@@ -214,6 +222,11 @@ final class ProfileSession: Identifiable {
   /// to `SyncCoordinator` here — apply drives GRDB writes and the
   /// observation streams take it from there.
   private func finishInit() {
+    // AccountGroupStore is constructed here (rather than the main
+    // `init` body) so the init stays within the
+    // `function_body_length` budget — same pattern as `cryptoSyncStore`
+    // / `cryptoTokenDiscovery` below.
+    self.accountGroupStore = AccountGroupStore(repository: backend.accountGroups)
     let cryptoWiring = Self.makeCryptoSyncWiring(
       backend: backend,
       registry: instrumentRegistry,

--- a/App/SessionRootView.swift
+++ b/App/SessionRootView.swift
@@ -14,6 +14,7 @@ struct SessionRootView: View {
       .environment(session.transactionStore)
       .environment(session.categoryStore)
       .environment(session.earmarkStore)
+      .environment(session.accountGroupStore)
       .environment(session.analysisStore)
       .environment(session.investmentStore)
       .environment(session.reportingStore)

--- a/Automation/Navigation/NavigationDestination+Make.swift
+++ b/Automation/Navigation/NavigationDestination+Make.swift
@@ -29,7 +29,8 @@ extension NavigationDestination {
       return .analysis(history: analysis?.history, forecast: analysis?.forecast)
     case .reports:
       return .reports(from: reports?.from, to: reports?.to)
-    case .account, .earmark, .allTransactions, .recentlyAdded, .upcomingTransactions, .categories:
+    case .account, .earmark, .group, .allTransactions, .recentlyAdded, .upcomingTransactions,
+      .categories:
       return sidebar.navigationDestination
     }
   }

--- a/Automation/Navigation/SidebarSelection+NavigationDestination.swift
+++ b/Automation/Navigation/SidebarSelection+NavigationDestination.swift
@@ -14,6 +14,11 @@ extension SidebarSelection {
     switch self {
     case .account(let id): .account(id)
     case .earmark(let id): .earmark(id)
+    // Phase 5 will introduce a dedicated group detail view bound to an
+    // `AccountViewContext`. Until then, group selection routes to the
+    // all-accounts overview so the user isn't dropped into an empty
+    // pane.
+    case .group: .accounts
     case .allTransactions, .recentlyAdded: .accounts
     case .upcomingTransactions: .upcoming
     case .categories: .categories

--- a/Backends/GRDB/Repositories/GRDBAccountRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBAccountRepository.swift
@@ -196,6 +196,7 @@ final class GRDBAccountRepository: AccountRepository, @unchecked Sendable {
       existing.position = account.position
       existing.isHidden = account.isHidden
       existing.valuationMode = account.valuationMode.rawValue
+      existing.groupId = account.groupId
       try existing.update(database)
 
       let positions = try Self.computePositions(

--- a/Domain/Models/Accounts+SidebarOrdering.swift
+++ b/Domain/Models/Accounts+SidebarOrdering.swift
@@ -7,6 +7,16 @@ import Foundation
 enum SidebarBucketEntry: Equatable {
   case account(Account)
   case group(AccountGroup, members: [Account])
+
+  /// Stable identifier suitable for SwiftUI `ForEach` keying. The
+  /// account / group UUID is unique across the entry list because a
+  /// member account doesn't appear as its own top-level entry.
+  var bucketEntryId: UUID {
+    switch self {
+    case .account(let account): return account.id
+    case .group(let group, _): return group.id
+    }
+  }
 }
 
 extension Accounts {

--- a/Domain/Models/Accounts+SidebarOrdering.swift
+++ b/Domain/Models/Accounts+SidebarOrdering.swift
@@ -1,9 +1,26 @@
 import Foundation
 
+/// A single entry in a bucket section: either a standalone account or a
+/// group with its members. Standalone accounts and groups compete in the
+/// same `position` number space within a bucket; the sidebar renders
+/// them intermixed.
+enum SidebarBucketEntry: Equatable {
+  case account(Account)
+  case group(AccountGroup, members: [Account])
+}
+
 extension Accounts {
   struct SidebarGroups: Equatable {
     let current: [Account]
     let investments: [Account]
+  }
+
+  /// Group-aware sidebar grouping. Returns standalone accounts and
+  /// groups intermixed per bucket, sorted by their shared `position`.
+  /// Within a group, members are returned sorted by member `position`.
+  struct GroupAwareSidebarGroups: Equatable {
+    let current: [SidebarBucketEntry]
+    let investments: [SidebarBucketEntry]
   }
 
   /// Accounts grouped and sorted the way the sidebar shows them.
@@ -49,5 +66,92 @@ extension Accounts {
   ) -> [Account] {
     let groups = sidebarGrouped(excluding: excluding, alwaysInclude: alwaysInclude)
     return groups.current + groups.investments
+  }
+
+  /// Returns standalone accounts (`groupId == nil`) and groups intermixed
+  /// per bucket, sorted by their shared `position`. Members of a group
+  /// are returned alongside their group entry, sorted by member
+  /// `position`. Honours the same hidden / exclusion rules as
+  /// `sidebarGrouped(excluding:alwaysInclude:)` — a hidden member is
+  /// excluded from its group's member list (the group still renders).
+  ///
+  /// Tie-break when a standalone account and a group share the same
+  /// `position` value: standalone account renders first, then the
+  /// group. This is a deterministic-ordering choice — sync conflict on
+  /// `position` should resolve to a stable display order.
+  ///
+  /// Cross-bucket invariant: a group with `bucket == .investments` only
+  /// appears in the investments bucket. Hypothetical members with a
+  /// different bucket would not be included — the helper trusts
+  /// `group.bucket` for placement.
+  func groupAwareSidebar(
+    groups: [AccountGroup],
+    excluding: UUID? = nil,
+    alwaysInclude: UUID? = nil
+  ) -> GroupAwareSidebarGroups {
+    let visible = ordered.filter { account in
+      if account.id == excluding { return false }
+      if account.isHidden && account.id != alwaysInclude { return false }
+      return true
+    }
+    return GroupAwareSidebarGroups(
+      current: entries(for: .current, visible: visible, groups: groups),
+      investments: entries(for: .investments, visible: visible, groups: groups)
+    )
+  }
+
+  private func entries(
+    for bucket: AccountBucket,
+    visible: [Account],
+    groups: [AccountGroup]
+  ) -> [SidebarBucketEntry] {
+    let knownGroupIds = Set(groups.map(\.id))
+    // Standalone = no groupId, OR a dangling groupId pointing at an
+    // unknown group (sync delivery can place an Account ahead of its
+    // AccountGroup — see spec §"Sync & schema").
+    let standalone = visible.filter { account in
+      guard account.bucket == bucket else { return false }
+      guard let gid = account.groupId else { return true }
+      return !knownGroupIds.contains(gid)
+    }
+    let bucketGroups = groups.filter { $0.bucket == bucket }
+    let groupEntries: [SidebarBucketEntry] = bucketGroups.map { group in
+      let members =
+        visible
+        .filter { $0.groupId == group.id }
+        .sorted { $0.position < $1.position }
+      return .group(group, members: members)
+    }
+    let standaloneEntries: [SidebarBucketEntry] = standalone.map { .account($0) }
+    return (standaloneEntries + groupEntries).sorted(by: Self.entryOrdering)
+  }
+
+  /// Sort key for intermixed standalone-account / group entries. Standalone
+  /// accounts and groups compete in the same `position` space; equal
+  /// positions tie-break with standalone-account-first so the order is
+  /// deterministic across sync conflicts.
+  private static func entryOrdering(
+    _ lhs: SidebarBucketEntry, _ rhs: SidebarBucketEntry
+  ) -> Bool {
+    let lhsPos = position(of: lhs)
+    let rhsPos = position(of: rhs)
+    if lhsPos != rhsPos { return lhsPos < rhsPos }
+    return tieBreakWeight(lhs) < tieBreakWeight(rhs)
+  }
+
+  private static func position(of entry: SidebarBucketEntry) -> Int {
+    switch entry {
+    case .account(let account): return account.position
+    case .group(let group, _): return group.position
+    }
+  }
+
+  /// 0 = standalone account, 1 = group — sorting account-first when
+  /// positions tie.
+  private static func tieBreakWeight(_ entry: SidebarBucketEntry) -> Int {
+    switch entry {
+    case .account: return 0
+    case .group: return 1
+    }
   }
 }

--- a/Features/Accounts/AccountGroupStore+Mutations.swift
+++ b/Features/Accounts/AccountGroupStore+Mutations.swift
@@ -1,0 +1,222 @@
+import Foundation
+
+// Mutation surface for `AccountGroupStore`.
+//
+// Mutations are pass-through under the reactive design: every method
+// calls the repository, the GRDB write commits, and
+// `repository.observeAll()` delivers the authoritative state via the
+// observation task spawned in `AccountGroupStore.init`. There is no
+// optimistic insert / rollback path — the reactive emission IS the
+// state update.
+//
+// Cross-store coordination (membership) is via the caller passing an
+// `AccountStore` directly. This keeps the dependency direction explicit
+// (groups depend on accounts; accounts don't know about groups) and
+// avoids retain cycles.
+extension AccountGroupStore {
+
+  /// Creates a single-member group from `account`. The new group's
+  /// bucket and instrument are derived from the source account; the
+  /// account's `groupId` is updated to point at the new group and its
+  /// `position` is set to 0 (first member).
+  ///
+  /// The reactive observation streams deliver both writes (group create
+  /// and account update) via their respective stores' `observeAll()`
+  /// subscriptions shortly after the writes commit.
+  @discardableResult
+  func createGroup(
+    from account: Account,
+    name: String,
+    accountStore: AccountStore
+  ) async throws -> AccountGroup {
+    setError(nil)
+    let group = AccountGroup(
+      name: name,
+      bucket: account.bucket,
+      instrument: account.instrument,
+      position: nextGroupPosition(in: account.bucket)
+    )
+    do {
+      let created = try await repository.create(group)
+      var moved = account
+      moved.groupId = created.id
+      moved.position = 0
+      _ = try await accountStore.update(moved)
+      return created
+    } catch {
+      logger.error("Failed to create group: \(error.localizedDescription)")
+      setError(error)
+      throw error
+    }
+  }
+
+  /// Creates a 2-member group joining `accountA` and `accountB`. Both
+  /// accounts' `groupId` is set; member positions are assigned in the
+  /// order of the arguments (A = 0, B = 1).
+  ///
+  /// Precondition: both accounts share the same bucket. Cross-bucket
+  /// grouping is prohibited by the UI; the precondition is a safety
+  /// belt for programmer error.
+  @discardableResult
+  func createGroup(
+    joining accountA: Account,
+    and accountB: Account,
+    name: String,
+    accountStore: AccountStore
+  ) async throws -> AccountGroup {
+    precondition(
+      accountA.bucket == accountB.bucket,
+      "cross-bucket grouping prohibited")
+    setError(nil)
+    let group = AccountGroup(
+      name: name,
+      bucket: accountA.bucket,
+      instrument: accountA.instrument,
+      position: nextGroupPosition(in: accountA.bucket)
+    )
+    do {
+      let created = try await repository.create(group)
+      for (idx, account) in [accountA, accountB].enumerated() {
+        var member = account
+        member.groupId = created.id
+        member.position = idx
+        _ = try await accountStore.update(member)
+      }
+      return created
+    } catch {
+      logger.error("Failed to create group joining two accounts: \(error.localizedDescription)")
+      setError(error)
+      throw error
+    }
+  }
+
+  /// Adds `account` as a member of `group`. The account's `groupId` is
+  /// set and its `position` is appended to the end of the group's
+  /// current member list. Same-bucket constraint is enforced by
+  /// precondition.
+  func addAccount(
+    _ account: Account,
+    to group: AccountGroup,
+    accountStore: AccountStore
+  ) async throws {
+    precondition(
+      account.bucket == group.bucket,
+      "cross-bucket grouping prohibited")
+    setError(nil)
+    do {
+      var member = account
+      member.groupId = group.id
+      member.position = membersCount(of: group.id, in: accountStore)
+      _ = try await accountStore.update(member)
+    } catch {
+      logger.error("Failed to add account to group: \(error.localizedDescription)")
+      setError(error)
+      throw error
+    }
+  }
+
+  /// Removes `account` from its current group (if any). Auto-deletes
+  /// the group if it becomes empty. Clears `Account.groupId` and
+  /// re-positions the account to the end of its bucket's standalone
+  /// list.
+  ///
+  /// No-op when the account already has no group.
+  func removeAccount(
+    _ account: Account,
+    accountStore: AccountStore
+  ) async throws {
+    guard let groupId = account.groupId else { return }
+    setError(nil)
+    do {
+      var standalone = account
+      standalone.groupId = nil
+      standalone.position = nextStandalonePosition(
+        in: account.bucket, accountStore: accountStore)
+      _ = try await accountStore.update(standalone)
+
+      // Auto-delete the group if no other members remain. Check via the
+      // post-update accountStore snapshot — the just-updated account
+      // hasn't observed back yet, so iterate the ordered list filtering
+      // on groupId and the account's id.
+      let stillMembers = accountStore.accounts.ordered.contains { other in
+        other.groupId == groupId && other.id != account.id
+      }
+      if !stillMembers {
+        try await repository.delete(id: groupId)
+      }
+    } catch {
+      logger.error("Failed to remove account from group: \(error.localizedDescription)")
+      setError(error)
+      throw error
+    }
+  }
+
+  /// Trim-and-no-op rename, matching `AccountStore.rename(id:to:)` and
+  /// `EarmarkStore.rename(id:to:)`. Empty / whitespace-only / same-name
+  /// input is a no-op (no write).
+  @discardableResult
+  func rename(id: UUID, to newName: String) async throws -> AccountGroup? {
+    let trimmed = newName.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard let group = by(id: id) else { return nil }
+    guard !trimmed.isEmpty, trimmed != group.name else { return group }
+    setError(nil)
+    do {
+      var updated = group
+      updated.name = trimmed
+      return try await repository.update(updated)
+    } catch {
+      logger.error("Failed to rename group: \(error.localizedDescription)")
+      setError(error)
+      throw error
+    }
+  }
+
+  /// Updates a group's `position`. Used by the sidebar reorder path.
+  /// The reactive observation delivers the updated position.
+  func moveGroup(_ group: AccountGroup, to newPosition: Int) async throws {
+    setError(nil)
+    do {
+      var updated = group
+      updated.position = newPosition
+      _ = try await repository.update(updated)
+    } catch {
+      logger.error("Failed to move group: \(error.localizedDescription)")
+      setError(error)
+      throw error
+    }
+  }
+
+  // MARK: - Helpers
+
+  /// Returns the next free `position` for a new group in `bucket`. The
+  /// new group lands at the end of the bucket's group list (groups and
+  /// standalone accounts compete in the same position space, but a new
+  /// group's position is computed only against existing groups in the
+  /// bucket — the sidebar ordering layer interleaves them).
+  private func nextGroupPosition(in bucket: AccountBucket) -> Int {
+    let inBucket = groups.filter { $0.bucket == bucket }
+    return (inBucket.map(\.position).max() ?? -1) + 1
+  }
+
+  /// Returns the count of members currently associated with `groupId`,
+  /// used as the next member position when appending. Reads from
+  /// `accountStore.accounts.ordered` — the most up-to-date view, even
+  /// before a fresh observation tick.
+  private func membersCount(
+    of groupId: UUID, in accountStore: AccountStore
+  ) -> Int {
+    accountStore.accounts.ordered.filter { $0.groupId == groupId }.count
+  }
+
+  /// Returns the next free `position` for a standalone account in
+  /// `bucket`. Used when a member is removed from a group and becomes
+  /// standalone — it lands at the end of the bucket's flat ordering.
+  private func nextStandalonePosition(
+    in bucket: AccountBucket, accountStore: AccountStore
+  ) -> Int {
+    let inBucket = accountStore.accounts.ordered.filter {
+      $0.bucket == bucket && $0.groupId == nil
+    }
+    return (inBucket.map(\.position).max() ?? -1) + 1
+  }
+}

--- a/Features/Accounts/AccountGroupStore.swift
+++ b/Features/Accounts/AccountGroupStore.swift
@@ -1,0 +1,139 @@
+import Foundation
+import OSLog
+import Observation
+
+/// Reactive store for the `AccountGroup` collection.
+///
+/// Mirrors `EarmarkStore` / `AccountStore`: subscribes to
+/// `repository.observeAll()` in `init`, exposes a `@MainActor` snapshot
+/// (`groups`), and surfaces errors out-of-band on `error`. Mutations
+/// (extension in `AccountGroupStore+Mutations.swift`) are pass-through
+/// to the repository; the reactive observation delivers the
+/// authoritative state.
+///
+/// Group membership lives on `Account.groupId` (back-reference). Methods
+/// that need to mutate membership take an `AccountStore` directly rather
+/// than holding a reference — keeps the dependency direction explicit
+/// and avoids cycles.
+@Observable
+@MainActor
+final class AccountGroupStore {
+  private(set) var groups: [AccountGroup] = []
+  private(set) var error: Error?
+
+  // Internal access (not private) so the `+Mutations` extension file can
+  // reach the repository and the logger across the file split.
+  let repository: any AccountGroupRepository
+  let logger = Logger(subsystem: "com.moolah.app", category: "AccountGroupStore")
+
+  /// The observation task driving `groups` from `repository.observeAll()`.
+  /// Spawned from `init`; torn down by `stopObserving()` (called from
+  /// `ProfileSession.cleanupSync`) or `deinit` as a safety net.
+  private var observationTask: Task<Void, Never>?
+
+  /// Test-only emission tick stream. Yields `()` after every state
+  /// assignment in `apply(groups:)`. Tests use the
+  /// `TestableStoreObservation` helpers in
+  /// `MoolahTests/Support/TestableStoreObservation.swift` to await
+  /// emissions deterministically. `internal` access is intentional;
+  /// `@testable import Moolah` exposes it to the test target.
+  let testObservationTickStream: AsyncStream<Void>
+  private let testObservationTickContinuation: AsyncStream<Void>.Continuation
+
+  init(repository: any AccountGroupRepository) {
+    self.repository = repository
+    let pair = AsyncStream<Void>.makeStream()
+    self.testObservationTickStream = pair.stream
+    self.testObservationTickContinuation = pair.continuation
+
+    // Strong `self` capture is intentional: the store is `@MainActor`,
+    // the task already holds an implicit strong reference, and
+    // `stopObserving()` is the sole lifetime gate. A weak capture would
+    // just add a nil-check hazard without preventing the retain.
+    observationTask = Task { await self.observe() }
+  }
+
+  deinit {
+    // Safety net for the case where `cleanupSync` is missed (e.g. an
+    // early-error tear-down path that drops the ProfileSession without
+    // calling cleanupSync). Swift 6 makes `deinit` nonisolated; reading
+    // `@MainActor`-isolated state requires `MainActor.assumeIsolated`.
+    MainActor.assumeIsolated {
+      observationTask?.cancel()
+      testObservationTickContinuation.finish()
+    }
+  }
+
+  /// Subscribes to `repository.observeAll()` and forwards every
+  /// emission to `apply(groups:)`. Errors are surfaced out-of-band via
+  /// `repository.observeErrors()`. Modelled on `EarmarkStore.observe()`
+  /// — same `TaskGroup` shape kept small here because the group store
+  /// has no companion conversion / rates stream.
+  private func observe() async {
+    let groupsStream = repository.observeAll()
+    let errorsStream = repository.observeErrors()
+    await withTaskGroup(of: Void.self) { group in
+      group.addTask { [self] in
+        for await fresh in groupsStream {
+          await self.apply(groups: fresh)
+        }
+      }
+      group.addTask { [self] in
+        for await error in errorsStream {
+          await self.surface(error: error)
+        }
+      }
+    }
+  }
+
+  /// Applies a fresh snapshot from `observeAll()`. Yields the test tick
+  /// so deterministic emission-aware tests can await observed state.
+  /// Internal (not private) so a hypothetical future `+Observation`
+  /// split mirrors `AccountStore` / `EarmarkStore`.
+  func apply(groups fresh: [AccountGroup]) async {
+    self.groups = fresh
+    testObservationTickContinuation.yield(())
+  }
+
+  /// Surfaces an observation error onto `self.error`. Internal so the
+  /// `+Mutations` extension can route mutation errors here too.
+  func surface(error: any Error) {
+    logger.error("AccountGroupStore observation error: \(error.localizedDescription)")
+    self.error = error
+  }
+
+  /// Module-internal so `+Mutations` can clear / set `error` directly.
+  /// Necessary because `error` is `private(set)`.
+  func setError(_ error: (any Error)?) {
+    self.error = error
+  }
+
+  /// Tears down the observation task. Idempotent.
+  func stopObserving() {
+    observationTask?.cancel()
+  }
+
+  /// Test-only. Awaits the observation task chain to fully terminate
+  /// after `stopObserving()`, then nils the reference.
+  func awaitObservationTermination() async {
+    await observationTask?.value
+    observationTask = nil
+  }
+
+  // MARK: - Lookups
+
+  /// Looks up a group by id. Returns `nil` for unknown ids.
+  func by(id: UUID) -> AccountGroup? {
+    groups.first { $0.id == id }
+  }
+
+  /// Returns the members of `groupId`, sorted by `Account.position`
+  /// ascending. Visibility / hidden filtering is the caller's
+  /// responsibility — the store doesn't track hidden state for
+  /// accounts.
+  func members(of groupId: UUID, in accounts: Accounts) -> [Account] {
+    accounts.ordered
+      .filter { $0.groupId == groupId }
+      .sorted { $0.position < $1.position }
+  }
+}

--- a/Features/Accounts/Views/AccountGroupSidebarRow.swift
+++ b/Features/Accounts/Views/AccountGroupSidebarRow.swift
@@ -1,0 +1,115 @@
+import SwiftUI
+
+/// Sidebar row for an `AccountGroup`. Composes a chevron disclosure
+/// affordance (toggling `isExpanded`) plus the shared `SidebarRowView`
+/// for the icon / name / amount. Aggregated balance is supplied by the
+/// caller — Phase 5 wires that against `AccountGroupStore`; this row
+/// just renders whatever it's given (or shows a spinner if `nil`).
+///
+/// Inline rename, selection styling, and identifier wiring follow the
+/// account-row conventions so context menus / Return-to-rename / the
+/// shared row component continue to work uniformly.
+struct AccountGroupSidebarRow: View {
+  let group: AccountGroup
+  /// `true` when the group row itself is the current selection.
+  var isSelected: Bool = false
+  /// Two-way binding to the in-memory expand state for this group.
+  /// Toggling fires only the chevron; clicking the row label still
+  /// selects the group (the NavigationLink wraps the entire row).
+  @Binding var isExpanded: Bool
+  /// Aggregated balance to render in the row. `nil` shows a spinner —
+  /// Phase 5 will compute this from member positions; for Phase 4 the
+  /// row simply forwards what the caller provides.
+  var aggregateBalance: InstrumentAmount?
+  /// Inline-rename plumbing — same shape as account / earmark rows.
+  var isEditing: Binding<Bool>?
+  var onRename: ((String) -> Void)?
+
+  var body: some View {
+    HStack(spacing: 4) {
+      disclosureChevron
+      SidebarRowView(
+        icon: "folder.fill",
+        name: group.name,
+        amount: aggregateBalance,
+        isSelected: isSelected,
+        isEditing: isEditing,
+        onRename: onRename
+      )
+    }
+  }
+
+  /// Manual chevron toggling expand state. Button styled `.plain` so
+  /// it doesn't visually compete with the row's selection highlight;
+  /// `accessibilityHidden` because expand/collapse is exposed via the
+  /// row's combined VoiceOver label below.
+  private var disclosureChevron: some View {
+    Button {
+      isExpanded.toggle()
+    } label: {
+      Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
+        .font(.system(size: 10, weight: .semibold))
+        .foregroundStyle(.secondary)
+        .frame(width: 12)
+    }
+    .buttonStyle(.plain)
+    .accessibilityHidden(true)
+  }
+}
+
+#Preview("Group row — collapsed") {
+  @Previewable @State var expanded = false
+  return List(selection: .constant(Optional("group"))) {
+    AccountGroupSidebarRow(
+      group: AccountGroup(
+        name: "Trust Fund Crypto",
+        bucket: .investments,
+        instrument: .AUD,
+        position: 0),
+      isSelected: false,
+      isExpanded: $expanded,
+      aggregateBalance: InstrumentAmount(quantity: 42180, instrument: .AUD)
+    )
+    .tag("group")
+  }
+  .listStyle(.sidebar)
+  .frame(width: 260)
+}
+
+#Preview("Group row — expanded + selected") {
+  @Previewable @State var expanded = true
+  return List(selection: .constant(Optional("group"))) {
+    AccountGroupSidebarRow(
+      group: AccountGroup(
+        name: "Personal Crypto",
+        bucket: .investments,
+        instrument: .AUD,
+        position: 1),
+      isSelected: true,
+      isExpanded: $expanded,
+      aggregateBalance: InstrumentAmount(quantity: 8920, instrument: .AUD)
+    )
+    .tag("group")
+  }
+  .listStyle(.sidebar)
+  .frame(width: 260)
+}
+
+#Preview("Group row — balance loading") {
+  @Previewable @State var expanded = false
+  return List(selection: .constant(Optional("group"))) {
+    AccountGroupSidebarRow(
+      group: AccountGroup(
+        name: "Pending",
+        bucket: .investments,
+        instrument: .AUD,
+        position: 0),
+      isSelected: false,
+      isExpanded: $expanded,
+      aggregateBalance: nil
+    )
+    .tag("group")
+  }
+  .listStyle(.sidebar)
+  .frame(width: 260)
+}

--- a/Features/Accounts/Views/AccountSidebarRow.swift
+++ b/Features/Accounts/Views/AccountSidebarRow.swift
@@ -70,6 +70,11 @@ struct SidebarRowView: View {
   /// the user's mental model of the column. See guides/UI_GUIDE.md §"Not set"
   /// and `INSTRUMENT_CONVERSION_GUIDE.md` Rule 11 for the rationale.
   var unsetIndicator: String?
+  /// Optional secondary text rendered below the name, in `.caption` /
+  /// `.secondary`. Used by member rows under a group to surface chain
+  /// / wallet-address / exchange-provider context so the user can pick
+  /// the right member for reconciliation.
+  var secondaryText: String?
   /// When non-nil, the row supports inline rename. The caller flips
   /// `isEditing.wrappedValue` to true (via double-click, context menu,
   /// or keyboard shortcut). The row renders a `TextField` instead of
@@ -117,6 +122,17 @@ struct SidebarRowView: View {
   }
 
   @ViewBuilder private var nameContent: some View {
+    VStack(alignment: .leading, spacing: 1) {
+      nameLabel
+      if let secondaryText, !secondaryText.isEmpty {
+        Text(secondaryText)
+          .font(.caption2)
+          .foregroundStyle(.secondary)
+      }
+    }
+  }
+
+  @ViewBuilder private var nameLabel: some View {
     if let isEditing, let onRename, isEditing.wrappedValue {
       InlineRenameField(
         initialText: name,
@@ -172,6 +188,11 @@ struct SidebarRowView: View {
 struct AccountSidebarRow: View {
   let account: Account
   var isSelected: Bool = false
+  /// When `true`, the row is rendered as a group member: a short
+  /// secondary line (chain / wallet address / exchange provider)
+  /// appears under the name. The indentation itself is supplied by the
+  /// container — this flag toggles only the secondary line.
+  var isMember: Bool = false
   var isEditing: Binding<Bool>?
   var onRename: ((String) -> Void)?
   @Environment(AccountStore.self) private var accountStore
@@ -183,9 +204,37 @@ struct AccountSidebarRow: View {
       amount: accountStore.convertedBalances[account.id],
       isSelected: isSelected,
       unsetIndicator: accountStore.hasUnrecordedValue(account) ? "Not set" : nil,
+      secondaryText: isMember ? memberSecondaryText : nil,
       isEditing: isEditing,
       onRename: onRename
     )
+  }
+
+  /// Truncated wallet address / exchange provider / nothing — what's
+  /// useful as a glance-able subtitle when the account is shown as a
+  /// member under a group row.
+  private var memberSecondaryText: String? {
+    switch account.type {
+    case .crypto:
+      if let address = account.walletAddress, !address.isEmpty {
+        return Self.shortAddress(address)
+      }
+      return nil
+    case .exchange:
+      return account.exchangeProvider?.displayName
+    case .bank, .creditCard, .asset, .investment:
+      return nil
+    }
+  }
+
+  /// Returns a `0xABCD…1234`-style short address. Truncates the middle
+  /// while keeping the `0x` prefix + 4 chars + ellipsis + last 4 chars
+  /// — enough to disambiguate at a glance without taking sidebar width.
+  private static func shortAddress(_ address: String) -> String {
+    guard address.count > 12 else { return address }
+    let prefix = address.prefix(6)
+    let suffix = address.suffix(4)
+    return "\(prefix)…\(suffix)"
   }
 }
 

--- a/Features/Navigation/SidebarView+Groups.swift
+++ b/Features/Navigation/SidebarView+Groups.swift
@@ -1,0 +1,274 @@
+// Group-aware sidebar surface: row builders, context menus, drop
+// handlers, expand-state binding, and creation flows. Lives in its own
+// file to keep `SidebarView.swift` and `SidebarView+Sections.swift`
+// readable as the membership UX is the highest-churn part of Phase 4.
+
+import SwiftUI
+import UniformTypeIdentifiers
+
+extension SidebarView {
+
+  // MARK: - Row builders
+
+  /// Renders a single group entry: the disclosure-aware group row +
+  /// member rows when expanded. Group selection routes through
+  /// `SidebarSelection.group(id)`; Phase 5 will give that a real
+  /// detail surface, Phase 4 lands on a placeholder.
+  @ViewBuilder
+  func groupSidebarEntry(_ group: AccountGroup, members: [Account]) -> some View {
+    groupRowLink(group)
+    if expandBinding(for: group.id).wrappedValue {
+      ForEach(members) { member in
+        memberRowLink(member)
+      }
+    }
+  }
+
+  /// The clickable group row + its drop / context-menu modifiers. Drop
+  /// onto a group row adds an account to that group (cross-bucket
+  /// rejected); group-onto-group drop is rejected (no nesting).
+  @ViewBuilder
+  func groupRowLink(_ group: AccountGroup) -> some View {
+    NavigationLink(value: SidebarSelection.group(group.id)) {
+      AccountGroupSidebarRow(
+        group: group,
+        isSelected: selection == .group(group.id),
+        isExpanded: expandBinding(for: group.id),
+        aggregateBalance: nil,  // Phase 5 wires the aggregate
+        isEditing: renameBinding(for: group.id),
+        onRename: renameAction(for: group)
+      )
+    }
+    .accessibilityIdentifier(UITestIdentifiers.Sidebar.group(group.id))
+    .draggable(DraggableSidebarItem(kind: .group, id: group.id))
+    .dropDestination(for: DraggableSidebarItem.self) { items, _ in
+      guard let item = items.first else { return false }
+      Task { await handleDrop(item, ontoGroup: group) }
+      return true
+    }
+    .contextMenu { groupContextMenu(for: group) }
+  }
+
+  /// A member row: same `AccountSidebarRow` shape as standalone, but
+  /// rendered with the `isMember` style hint so the secondary line
+  /// (chain / address / exchange provider) surfaces. The drag source
+  /// is a `.account` `DraggableSidebarItem`; dropping onto another
+  /// account/group works as it does for standalone accounts.
+  @ViewBuilder
+  func memberRowLink(_ account: Account) -> some View {
+    NavigationLink(value: SidebarSelection.account(account.id)) {
+      AccountSidebarRow(
+        account: account,
+        isSelected: selection == .account(account.id),
+        isMember: true,
+        isEditing: renameBinding(for: account.id),
+        onRename: renameAction(for: account)
+      )
+      .padding(.leading, 16)
+    }
+    .accessibilityIdentifier(UITestIdentifiers.Sidebar.account(account.id))
+    .draggable(DraggableSidebarItem(kind: .account, id: account.id))
+    .dropDestination(for: DraggableSidebarItem.self) { items, _ in
+      guard let item = items.first else { return false }
+      Task { await handleDrop(item, ontoAccount: account) }
+      return true
+    }
+    .contextMenu { accountContextMenu(for: account) }
+  }
+
+  /// Standalone account row, wired with drag / drop / group context
+  /// menu. Used by both the Current and Investments sections in place
+  /// of the previous inline row construction so the drop / drag
+  /// modifiers stay consistent across bucket sections.
+  @ViewBuilder
+  func standaloneAccountRowLink(_ account: Account) -> some View {
+    NavigationLink(value: SidebarSelection.account(account.id)) {
+      AccountSidebarRow(
+        account: account,
+        isSelected: selection == .account(account.id),
+        isEditing: renameBinding(for: account.id),
+        onRename: renameAction(for: account)
+      )
+    }
+    .dropDestination(for: URL.self) { urls, _ in
+      Task { await ingestDroppedURLs(urls, forcedAccountId: account.id) }
+      return !urls.isEmpty
+    }
+    .draggable(DraggableSidebarItem(kind: .account, id: account.id))
+    .dropDestination(for: DraggableSidebarItem.self) { items, _ in
+      guard let item = items.first else { return false }
+      Task { await handleDrop(item, ontoAccount: account) }
+      return true
+    }
+    .accessibilityIdentifier(UITestIdentifiers.Sidebar.account(account.id))
+    .contextMenu { accountContextMenu(for: account) }
+  }
+
+  // MARK: - Expand state
+
+  /// Returns a two-way binding to the expand state of `groupId`. The
+  /// binding is backed by `expandedGroupIds` (in-memory only this
+  /// phase; Phase 8 persists). Setting `true` inserts; `false`
+  /// removes — straightforward Set membership.
+  func expandBinding(for groupId: UUID) -> Binding<Bool> {
+    Binding(
+      get: { expandedGroupIds.contains(groupId) },
+      set: { newValue in
+        if newValue {
+          expandedGroupIds.insert(groupId)
+        } else {
+          expandedGroupIds.remove(groupId)
+        }
+      }
+    )
+  }
+
+  // MARK: - Context menus
+
+  /// Right-click menu for a group row. Phase 4 only exposes Rename;
+  /// the spec explicitly excludes Hide and Delete for groups (membership
+  /// is the unit of group lifecycle: remove the last member to delete
+  /// the group).
+  @ViewBuilder
+  func groupContextMenu(for group: AccountGroup) -> some View {
+    Button("Rename", systemImage: "character.cursor.ibeam") {
+      editingRowId = group.id
+    }
+    .accessibilityIdentifier(UITestIdentifiers.Sidebar.renameContextMenuItem)
+  }
+
+  /// "Group ▸" submenu inside an account's right-click menu. Lists the
+  /// other groups in the account's bucket, then a "New Group…" entry,
+  /// then a "Remove from Group" entry if the account is currently in a
+  /// group. Same-bucket constraint is enforced by filtering the move
+  /// list to `bucket == account.bucket`.
+  @ViewBuilder
+  func accountGroupSubmenu(for account: Account) -> some View {
+    let groupsInBucket = accountGroupStore.groups
+      .filter { $0.bucket == account.bucket && $0.id != account.groupId }
+    Menu {
+      ForEach(groupsInBucket) { group in
+        Button(group.name) {
+          Task {
+            try? await accountGroupStore.addAccount(
+              account, to: group, accountStore: accountStore)
+          }
+        }
+      }
+      if !groupsInBucket.isEmpty { Divider() }
+      Button("New Group\u{2026}") {
+        Task { await createGroupFromAccount(account) }
+      }
+      if account.groupId != nil {
+        Divider()
+        Button("Remove from Group") {
+          Task {
+            try? await accountGroupStore.removeAccount(
+              account, accountStore: accountStore)
+          }
+        }
+      }
+    } label: {
+      Label("Group", systemImage: "folder")
+    }
+    .accessibilityIdentifier(UITestIdentifiers.Sidebar.groupSubmenu)
+  }
+
+  // MARK: - Drop handling
+
+  /// Policy gate for a drop targeting an account row. Same-bucket only;
+  /// group-onto-account is rejected; account-onto-account in the same
+  /// bucket creates a new 2-member group (or moves the dragged account
+  /// into the target's existing group when the target is itself a
+  /// member).
+  func handleDrop(
+    _ item: DraggableSidebarItem,
+    ontoAccount target: Account
+  ) async {
+    guard item.kind == .account else { return }  // group-onto-account = no-op
+    guard let source = accountStore.accounts.by(id: item.id) else { return }
+    guard source.id != target.id else { return }  // self-drop
+    guard source.bucket == target.bucket else { return }  // cross-bucket rejected
+
+    if let targetGroupId = target.groupId {
+      // Target is already a member: add source to the same group.
+      guard let group = accountGroupStore.by(id: targetGroupId) else { return }
+      try? await accountGroupStore.addAccount(
+        source, to: group, accountStore: accountStore)
+      return
+    }
+
+    // Both standalone: create a 2-member group and put it in rename mode.
+    do {
+      let created = try await accountGroupStore.createGroup(
+        joining: target,
+        and: source,
+        name: "New Group",
+        accountStore: accountStore
+      )
+      editingRowId = created.id
+      expandedGroupIds.insert(created.id)
+    } catch {
+      // Error already surfaced on the store; no extra UI hop needed.
+    }
+  }
+
+  /// Policy gate for a drop targeting a group row. Adds the dragged
+  /// account to the group; rejects group-onto-group (no nesting) and
+  /// cross-bucket.
+  func handleDrop(
+    _ item: DraggableSidebarItem,
+    ontoGroup target: AccountGroup
+  ) async {
+    guard item.kind == .account else { return }  // group-onto-group rejected
+    guard let source = accountStore.accounts.by(id: item.id) else { return }
+    guard source.bucket == target.bucket else { return }
+    if source.groupId == target.id { return }  // already in this group
+
+    try? await accountGroupStore.addAccount(
+      source, to: target, accountStore: accountStore)
+  }
+
+  // MARK: - Creation flows
+
+  /// Right-click → New Group… → creates a single-member group from the
+  /// source account and immediately enters inline rename mode so the
+  /// user can overwrite the default "New Group" placeholder.
+  func createGroupFromAccount(_ account: Account) async {
+    do {
+      let created = try await accountGroupStore.createGroup(
+        from: account, name: "New Group", accountStore: accountStore)
+      editingRowId = created.id
+      expandedGroupIds.insert(created.id)
+    } catch {
+      // Error surfaces on `accountGroupStore.error`; no extra UI hop.
+    }
+  }
+}
+
+// MARK: - Transferable wrapper
+
+/// `Codable` payload carrying the kind (account vs group) + the
+/// dragged entity's UUID across SwiftUI's drag-and-drop boundary.
+/// `Transferable` requires the payload itself to be `Codable`; the
+/// `CodableRepresentation` defaults to JSON encoding.
+struct DraggableSidebarItem: Codable, Sendable, Transferable {
+  enum Kind: String, Codable, Sendable { case account, group }
+
+  let kind: Kind
+  let id: UUID
+
+  static var transferRepresentation: some TransferRepresentation {
+    CodableRepresentation(contentType: .moolahSidebarItem)
+  }
+}
+
+extension UTType {
+  /// Bespoke UTType for sidebar drag-and-drop. Exported so SwiftUI's
+  /// drag system can negotiate the type across rows without falling
+  /// back to plain text. The string must stay stable — it's part of the
+  /// pasteboard contract within a single app session.
+  static var moolahSidebarItem: UTType {
+    UTType(exportedAs: "com.moolah.sidebar-item")
+  }
+}

--- a/Features/Navigation/SidebarView+Previews.swift
+++ b/Features/Navigation/SidebarView+Previews.swift
@@ -28,6 +28,7 @@ private func seedSidebarPreview(backend: any BackendProvider) async {
     repository: backend.earmarks,
     conversionService: backend.conversionService,
     targetInstrument: .AUD)
+  let accountGroupStore = AccountGroupStore(repository: backend.accountGroups)
   // In-memory preview session can't fail in practice: opens an ephemeral
   // GRDB queue with no disk access. A trap here is acceptable in #Preview.
   // swiftlint:disable:next force_try
@@ -37,9 +38,78 @@ private func seedSidebarPreview(backend: any BackendProvider) async {
     SidebarView(selection: .constant(nil))
       .environment(accountStore)
       .environment(earmarkStore)
+      .environment(accountGroupStore)
       .environment(session)
       .task {
         await seedSidebarPreview(backend: backend)
+      }
+  } detail: {
+    Text("Detail")
+  }
+}
+
+@MainActor
+private func seedSidebarGroupPreview(
+  backend: any BackendProvider,
+  accountStore: AccountStore,
+  accountGroupStore: AccountGroupStore
+) async {
+  // Seed two crypto wallets, then create a group joining them. The
+  // preview renders the group as a single row with the two members
+  // tucked underneath when the user expands it.
+  let walletAAccount = Account(
+    name: "ETH/OP wallet",
+    type: .crypto,
+    instrument: .AUD,
+    walletAddress: "0x7a3f1b5c9d2e8f4a1b6c3d5e7f9a0b2c4d6e8f0a",
+    chainId: 1)
+  let walletBAccount = Account(
+    name: "Polygon wallet",
+    type: .crypto,
+    instrument: .AUD,
+    walletAddress: "0x7a3f1b5c9d2e8f4a1b6c3d5e7f9a0b2c4d6e8f0a",
+    chainId: 137)
+  guard
+    let walletA = try? await backend.accounts.create(
+      walletAAccount,
+      openingBalance: InstrumentAmount(quantity: 5210, instrument: .AUD)),
+    let walletB = try? await backend.accounts.create(
+      walletBAccount,
+      openingBalance: InstrumentAmount(quantity: 410, instrument: .AUD))
+  else { return }
+  _ = try? await accountGroupStore.createGroup(
+    joining: walletA,
+    and: walletB,
+    name: "Trust Fund Crypto",
+    accountStore: accountStore
+  )
+}
+
+#Preview("With a group") {
+  let backend = PreviewBackend.create()
+  let accountStore = AccountStore(
+    repository: backend.accounts,
+    conversionService: backend.conversionService,
+    targetInstrument: .AUD)
+  let earmarkStore = EarmarkStore(
+    repository: backend.earmarks,
+    conversionService: backend.conversionService,
+    targetInstrument: .AUD)
+  let accountGroupStore = AccountGroupStore(repository: backend.accountGroups)
+  // swiftlint:disable:next force_try
+  let session = try! ProfileSession.preview()
+
+  return NavigationSplitView {
+    SidebarView(selection: .constant(nil))
+      .environment(accountStore)
+      .environment(earmarkStore)
+      .environment(accountGroupStore)
+      .environment(session)
+      .task {
+        await seedSidebarGroupPreview(
+          backend: backend,
+          accountStore: accountStore,
+          accountGroupStore: accountGroupStore)
       }
   } detail: {
     Text("Detail")
@@ -56,6 +126,7 @@ private func seedSidebarPreview(backend: any BackendProvider) async {
     repository: backend.earmarks,
     conversionService: backend.conversionService,
     targetInstrument: .AUD)
+  let accountGroupStore = AccountGroupStore(repository: backend.accountGroups)
   // In-memory preview session can't fail in practice: opens an ephemeral
   // GRDB queue with no disk access. A trap here is acceptable in #Preview.
   // swiftlint:disable:next force_try
@@ -65,6 +136,7 @@ private func seedSidebarPreview(backend: any BackendProvider) async {
     SidebarView(selection: .constant(nil))
       .environment(accountStore)
       .environment(earmarkStore)
+      .environment(accountGroupStore)
       .environment(session)
       .task {
         // Seed only an account — no earmarks. Validates that the

--- a/Features/Navigation/SidebarView+Sections.swift
+++ b/Features/Navigation/SidebarView+Sections.swift
@@ -13,25 +13,14 @@ extension SidebarView {
   }
 
   var currentAccountsSection: some View {
-    Section {
-      ForEach(accountStore.currentAccounts) { account in
-        NavigationLink(value: SidebarSelection.account(account.id)) {
-          AccountSidebarRow(
-            account: account,
-            isSelected: selection == .account(account.id),
-            isEditing: renameBinding(for: account.id),
-            onRename: renameAction(for: account)
-          )
-        }
-        .dropDestination(for: URL.self) { urls, _ in
-          Task { await ingestDroppedURLs(urls, forcedAccountId: account.id) }
-          return !urls.isEmpty
-        }
-        .accessibilityIdentifier(UITestIdentifiers.Sidebar.account(account.id))
-        .contextMenu { accountContextMenu(for: account) }
-      }
-      .onMove { source, destination in
-        Task { await reorderCurrentAccounts(from: source, to: destination) }
+    let groupAware = accountStore.accounts.groupAwareSidebar(
+      groups: accountGroupStore.groups,
+      excluding: nil,
+      alwaysInclude: nil
+    )
+    return Section {
+      ForEach(groupAware.current, id: \.bucketEntryId) { entry in
+        bucketEntryView(entry)
       }
       totalRow(label: "Current Total", value: accountStore.convertedCurrentTotal)
     } header: {
@@ -62,23 +51,30 @@ extension SidebarView {
   }
 
   var investmentsSection: some View {
-    Section("Investments") {
-      ForEach(accountStore.investmentAccounts) { account in
-        NavigationLink(value: SidebarSelection.account(account.id)) {
-          AccountSidebarRow(
-            account: account,
-            isSelected: selection == .account(account.id),
-            isEditing: renameBinding(for: account.id),
-            onRename: renameAction(for: account)
-          )
-        }
-        .accessibilityIdentifier(UITestIdentifiers.Sidebar.account(account.id))
-        .contextMenu { accountContextMenu(for: account) }
-      }
-      .onMove { source, destination in
-        Task { await reorderInvestmentAccounts(from: source, to: destination) }
+    let groupAware = accountStore.accounts.groupAwareSidebar(
+      groups: accountGroupStore.groups,
+      excluding: nil,
+      alwaysInclude: nil
+    )
+    return Section("Investments") {
+      ForEach(groupAware.investments, id: \.bucketEntryId) { entry in
+        bucketEntryView(entry)
       }
       totalRow(label: "Investment Total", value: accountStore.convertedInvestmentTotal)
+    }
+  }
+
+  /// Renders a single bucket entry — standalone account or group with
+  /// its members. The switch lives in this helper rather than inline so
+  /// each `Section`'s `ForEach` body stays within SwiftLint's
+  /// `closure_body_length` budget.
+  @ViewBuilder
+  func bucketEntryView(_ entry: SidebarBucketEntry) -> some View {
+    switch entry {
+    case .account(let account):
+      standaloneAccountRowLink(account)
+    case let .group(group, members):
+      groupSidebarEntry(group, members: members)
     }
   }
 
@@ -159,12 +155,6 @@ extension SidebarView {
 
   // MARK: - Helpers
 
-  func reorderCurrentAccounts(from source: IndexSet, to destination: Int) async {
-    var accounts = accountStore.currentAccounts
-    accounts.move(fromOffsets: source, toOffset: destination)
-    await accountStore.reorderAccounts(accounts)
-  }
-
   /// Dropped CSV onto a sidebar account row: force the import onto that
   /// account, bypassing profile matching. A profile is created on success.
   func ingestDroppedURLs(_ urls: [URL], forcedAccountId: UUID) async {
@@ -181,13 +171,6 @@ extension SidebarView {
         data: data,
         source: .droppedFile(url: url, forcedAccountId: forcedAccountId))
     }
-  }
-
-  func reorderInvestmentAccounts(from source: IndexSet, to destination: Int) async {
-    var accounts = accountStore.investmentAccounts
-    accounts.move(fromOffsets: source, toOffset: destination)
-    await accountStore.reorderAccounts(
-      accounts, positionOffset: accountStore.currentAccounts.count)
   }
 
   // MARK: - Actions

--- a/Features/Navigation/SidebarView.swift
+++ b/Features/Navigation/SidebarView.swift
@@ -3,6 +3,12 @@ import SwiftUI
 enum SidebarSelection: Hashable {
   case account(UUID)
   case earmark(UUID)
+  /// Selection of an `AccountGroup` row. Phase 5 wires the detail view
+  /// that consumes this case; for Phase 4, selecting a group simply
+  /// updates the binding and the detail leaf falls through to a
+  /// placeholder. Carries the group's UUID so a later detail view can
+  /// resolve the group from `AccountGroupStore`.
+  case group(UUID)
   case recentlyAdded
   case allTransactions
   case upcomingTransactions
@@ -20,6 +26,9 @@ struct SidebarView: View {
   // Internal access required by `SidebarView+Sections.swift` extension;
   // cannot be `private` across file boundaries.
   @Environment(EarmarkStore.self) var earmarkStore
+  // Internal access required by `SidebarView+Sections.swift` extension;
+  // cannot be `private` across file boundaries.
+  @Environment(AccountGroupStore.self) var accountGroupStore
   @Environment(ProfileSession.self) private var session
   // Internal access required by `SidebarView+Sections.swift` extension;
   // cannot be `private` across file boundaries.
@@ -37,11 +46,22 @@ struct SidebarView: View {
   // Internal access required by `SidebarView+Sections.swift` extension;
   // cannot be `private` across file boundaries.
   @State var accountToEdit: Account?
-  /// Identifies the sidebar row currently in inline rename mode, if
-  /// any. Local-only — never persisted, never synced. At most one row
-  /// is in edit mode at a time across the entire sidebar (accounts,
-  /// earmarks, future groups).
-  @State private var editingRowId: UUID?
+  // Identifies the sidebar row currently in inline rename mode, if
+  // any. Local-only — never persisted, never synced. At most one row
+  // is in edit mode at a time across the entire sidebar (accounts,
+  // earmarks, future groups).
+  // Internal access required by `SidebarView+Sections.swift` extension;
+  // cannot be `private` across file boundaries.
+  @State var editingRowId: UUID?
+  // In-memory expand state for account-group rows. Phase 8 will persist
+  // this in a local-only GRDB sidecar (`local_account_group_ui`); for
+  // Phase 4 the state lives only for the lifetime of the sidebar view
+  // instance, so collapse / expand is lost on app relaunch. The Phase 8
+  // migration will swap the storage without changing the
+  // `expandedGroupIds.contains/insert/remove` API used downstream.
+  // Internal access required by `SidebarView+Sections.swift` extension;
+  // cannot be `private` across file boundaries.
+  @State var expandedGroupIds: Set<UUID> = []
   // Internal access required by `SidebarView+Sections.swift` extension;
   // cannot be `private` across file boundaries.
   @AppStorage("showHiddenAccounts") var showHidden = false
@@ -88,6 +108,10 @@ struct SidebarView: View {
         return .handled
       case .earmark(let id):
         guard earmarkStore.earmarks.by(id: id) != nil else { return .ignored }
+        editingRowId = id
+        return .handled
+      case .group(let id):
+        guard accountGroupStore.by(id: id) != nil else { return .ignored }
         editingRowId = id
         return .handled
       case .none, .recentlyAdded, .allTransactions, .upcomingTransactions,
@@ -222,6 +246,7 @@ extension SidebarView {
       editingRowId = account.id
     }
     .accessibilityIdentifier(UITestIdentifiers.Sidebar.renameContextMenuItem)
+    accountGroupSubmenu(for: account)
     Button("Edit Account\u{2026}", systemImage: "pencil") {
       accountToEdit = account
     }
@@ -274,6 +299,15 @@ extension SidebarView {
   func renameAction(for earmark: Earmark) -> (String) -> Void {
     { newName in
       Task { _ = await earmarkStore.rename(id: earmark.id, to: newName) }
+    }
+  }
+
+  /// Returns the `onRename` closure for an account-group row. Same
+  /// intent-shape as the account / earmark variants; dispatches
+  /// `AccountGroupStore.rename`.
+  func renameAction(for group: AccountGroup) -> (String) -> Void {
+    { newName in
+      Task { _ = try? await accountGroupStore.rename(id: group.id, to: newName) }
     }
   }
 

--- a/MoolahTests/Automation/SidebarSelectionRouteTests.swift
+++ b/MoolahTests/Automation/SidebarSelectionRouteTests.swift
@@ -18,6 +18,15 @@ struct SidebarSelectionRouteTests {
     #expect(SidebarSelection.earmark(id).navigationDestination == .earmark(id))
   }
 
+  @Test("group selection maps to .accounts (Phase 5 placeholder)")
+  func groupMapsToAccountsPlaceholder() {
+    // Phase 5 will route groups to a dedicated destination; until then,
+    // group selection lands at the all-accounts overview so the user
+    // isn't dropped into an empty pane.
+    let id = UUID()
+    #expect(SidebarSelection.group(id).navigationDestination == .accounts)
+  }
+
   @Test("allTransactions maps to .accounts")
   func allTransactionsMaps() {
     #expect(SidebarSelection.allTransactions.navigationDestination == .accounts)

--- a/MoolahTests/Domain/AccountsSidebarOrderingTests.swift
+++ b/MoolahTests/Domain/AccountsSidebarOrderingTests.swift
@@ -129,4 +129,159 @@ struct AccountsSidebarOrderingTests {
 
     #expect(accounts.sidebarOrdered().map(\.name) == ["Chequing", "Brokerage"])
   }
+
+  // MARK: - groupAwareSidebar(groups:)
+
+  @Test("groupAwareSidebar with no groups returns standalone-only entries")
+  func groupAwareNoGroups() {
+    let chequing = bank("Chequing", position: 0)
+    let brokerage = investment("Brokerage", position: 0)
+    let accounts = Accounts(from: [chequing, brokerage])
+
+    let result = accounts.groupAwareSidebar(groups: [])
+
+    #expect(result.current == [.account(chequing)])
+    #expect(result.investments == [.account(brokerage)])
+  }
+
+  @Test("groupAwareSidebar collects members by groupId and sorts by member position")
+  func groupAwareMembersSorted() {
+    let group = AccountGroup(
+      name: "Crypto", bucket: .investments, instrument: .AUD, position: 0)
+    let memberB = Account(
+      id: UUID(), name: "B", type: .crypto, instrument: .AUD,
+      positions: [], position: 1, isHidden: false,
+      walletAddress: "0x" + String(repeating: "b", count: 40), chainId: 1,
+      groupId: group.id)
+    let memberA = Account(
+      id: UUID(), name: "A", type: .crypto, instrument: .AUD,
+      positions: [], position: 0, isHidden: false,
+      walletAddress: "0x" + String(repeating: "a", count: 40), chainId: 1,
+      groupId: group.id)
+    let accounts = Accounts(from: [memberA, memberB])
+
+    let result = accounts.groupAwareSidebar(groups: [group])
+
+    guard case .group(let observedGroup, let observedMembers) = result.investments.first else {
+      Issue.record("expected single group entry")
+      return
+    }
+    #expect(observedGroup.id == group.id)
+    #expect(observedMembers.map(\.name) == ["A", "B"])
+  }
+
+  @Test("hidden members are excluded from the group's members array")
+  func groupAwareHiddenMemberExcluded() {
+    let group = AccountGroup(
+      name: "Crypto", bucket: .investments, instrument: .AUD, position: 0)
+    let hidden = Account(
+      id: UUID(), name: "Hidden", type: .crypto, instrument: .AUD,
+      positions: [], position: 0, isHidden: true,
+      walletAddress: "0x" + String(repeating: "a", count: 40), chainId: 1,
+      groupId: group.id)
+    let visible = Account(
+      id: UUID(), name: "Visible", type: .crypto, instrument: .AUD,
+      positions: [], position: 1, isHidden: false,
+      walletAddress: "0x" + String(repeating: "b", count: 40), chainId: 1,
+      groupId: group.id)
+    let accounts = Accounts(from: [hidden, visible])
+
+    let result = accounts.groupAwareSidebar(groups: [group])
+
+    guard case .group(_, let members) = result.investments.first else {
+      Issue.record("expected single group entry")
+      return
+    }
+    #expect(members.map(\.name) == ["Visible"])
+  }
+
+  @Test("standalone accounts and groups intermix by position")
+  func groupAwareIntermixedByPosition() {
+    let group = AccountGroup(
+      name: "Crypto", bucket: .investments, instrument: .AUD, position: 1)
+    let standalone0 = investment("ETF-zero", position: 0)
+    let standalone2 = investment("ETF-two", position: 2)
+    let accounts = Accounts(from: [standalone0, standalone2])
+
+    let result = accounts.groupAwareSidebar(groups: [group])
+
+    // standalone(0), group(1), standalone(2)
+    #expect(result.investments.count == 3)
+    if case .account(let account) = result.investments[0] {
+      #expect(account.name == "ETF-zero")
+    } else {
+      Issue.record("expected ETF-zero first")
+    }
+    if case .group(let observed, _) = result.investments[1] {
+      #expect(observed.name == "Crypto")
+    } else {
+      Issue.record("expected Crypto group second")
+    }
+    if case .account(let account) = result.investments[2] {
+      #expect(account.name == "ETF-two")
+    } else {
+      Issue.record("expected ETF-two third")
+    }
+  }
+
+  @Test("equal positions tie-break account-first")
+  func groupAwareTieBreakAccountFirst() {
+    let group = AccountGroup(
+      name: "Crypto", bucket: .investments, instrument: .AUD, position: 0)
+    let standalone = investment("ETF", position: 0)
+    let accounts = Accounts(from: [standalone])
+
+    let result = accounts.groupAwareSidebar(groups: [group])
+
+    // standalone first, group second
+    if case .account(let account) = result.investments[0] {
+      #expect(account.name == "ETF")
+    } else {
+      Issue.record("expected ETF first on tie")
+    }
+    if case .group(let observed, _) = result.investments[1] {
+      #expect(observed.name == "Crypto")
+    } else {
+      Issue.record("expected Crypto group second on tie")
+    }
+  }
+
+  @Test("groups appear only in their declared bucket")
+  func groupAwareCrossBucketIsolation() {
+    let currentGroup = AccountGroup(
+      name: "Joint", bucket: .current, instrument: .AUD, position: 0)
+    let investmentGroup = AccountGroup(
+      name: "Stocks", bucket: .investments, instrument: .AUD, position: 0)
+    let accounts = Accounts(from: [])
+
+    let result = accounts.groupAwareSidebar(groups: [currentGroup, investmentGroup])
+
+    if case .group(let observed, _) = result.current.first {
+      #expect(observed.name == "Joint")
+    } else {
+      Issue.record("expected Joint group in current bucket")
+    }
+    if case .group(let observed, _) = result.investments.first {
+      #expect(observed.name == "Stocks")
+    } else {
+      Issue.record("expected Stocks group in investments bucket")
+    }
+  }
+
+  @Test("account with dangling groupId renders as standalone in its bucket")
+  func groupAwareOrphanedGroupId() {
+    // Sync delivery can place an Account ahead of its AccountGroup
+    // (spec §"Sync & schema"). The unknown id resolves to standalone
+    // until the group arrives — never to "invisible". This matches
+    // the same dangling-reference tolerance the Category lookup uses.
+    let orphan = Account(
+      id: UUID(), name: "Orphan", type: .bank, instrument: .AUD,
+      positions: [], position: 0, isHidden: false,
+      groupId: UUID())  // points at no group
+    let accounts = Accounts(from: [orphan])
+
+    let result = accounts.groupAwareSidebar(groups: [])
+
+    #expect(result.current == [.account(orphan)])
+  }
 }

--- a/MoolahTests/Features/AccountGroupStoreMutationsTests.swift
+++ b/MoolahTests/Features/AccountGroupStoreMutationsTests.swift
@@ -1,0 +1,298 @@
+import Foundation
+// Re-export the import for `GRDB.DatabaseWriter` used as a type in the
+// helper above. The @testable import of Moolah re-exports GRDB types
+// used by the production code, but the test target needs an explicit
+// `import GRDB` for type names that don't appear elsewhere in this
+// suite's signatures.
+import GRDB
+import Testing
+
+@testable import Moolah
+
+@Suite("AccountGroupStore — mutations")
+@MainActor
+struct AccountGroupStoreMutationsTests {
+
+  private func makeStores(
+    seedAccounts: [Account] = [],
+    in database: any GRDB.DatabaseWriter,
+    backend: CloudKitBackend
+  ) async throws -> (AccountStore, AccountGroupStore) {
+    TestBackend.seed(accounts: seedAccounts, in: database)
+    let accountStore = AccountStore(
+      repository: backend.accounts, conversionService: FixedConversionService(),
+      targetInstrument: .defaultTestInstrument)
+    let groupStore = AccountGroupStore(repository: backend.accountGroups)
+    try await groupStore.waitForFirstEmission()
+    // Wait for the initial accounts emission (carries the seeded rows).
+    // Using `waitForNextEmission` rather than `waitForFirstEmission` so
+    // tests that don't seed still see the empty initial tick.
+    try await accountStore.waitForNextEmission(
+      matching: { $0.accounts.ordered.count == seedAccounts.count },
+      description: "accounts seeded observed")
+    return (accountStore, groupStore)
+  }
+
+  @Test("createGroup(from:) creates a 1-member group with the source account")
+  func createGroupFromSingleAccount() async throws {
+    let (backend, database) = try TestBackend.create()
+    let account = Account(
+      id: UUID(), name: "Wallet", type: .crypto, instrument: .AUD,
+      positions: [], position: 0, isHidden: false,
+      walletAddress: "0x" + String(repeating: "a", count: 40), chainId: 1)
+    let (accountStore, groupStore) = try await makeStores(
+      seedAccounts: [account], in: database, backend: backend)
+
+    let group = try await groupStore.createGroup(
+      from: account, name: "New Group", accountStore: accountStore)
+
+    #expect(group.name == "New Group")
+    #expect(group.bucket == .investments)
+    try await accountStore.waitForNextEmission(
+      matching: { $0.accounts.by(id: account.id)?.groupId == group.id },
+      description: "member.groupId set"
+    )
+    let member = try #require(accountStore.accounts.by(id: account.id))
+    #expect(member.groupId == group.id)
+    #expect(member.position == 0)
+  }
+
+  @Test("createGroup(joining:and:) creates a 2-member group")
+  func createGroupFromTwoAccounts() async throws {
+    let (backend, database) = try TestBackend.create()
+    let accountA = Account(
+      id: UUID(), name: "A", type: .crypto, instrument: .AUD,
+      positions: [], position: 0, isHidden: false,
+      walletAddress: "0x" + String(repeating: "a", count: 40), chainId: 1)
+    let accountB = Account(
+      id: UUID(), name: "B", type: .crypto, instrument: .AUD,
+      positions: [], position: 1, isHidden: false,
+      walletAddress: "0x" + String(repeating: "b", count: 40), chainId: 1)
+    let (accountStore, groupStore) = try await makeStores(
+      seedAccounts: [accountA, accountB], in: database, backend: backend)
+
+    let group = try await groupStore.createGroup(
+      joining: accountA, and: accountB, name: "Pair", accountStore: accountStore)
+
+    try await accountStore.waitForNextEmission(
+      matching: {
+        $0.accounts.by(id: accountA.id)?.groupId == group.id
+          && $0.accounts.by(id: accountB.id)?.groupId == group.id
+      },
+      description: "both members in group"
+    )
+    let memberA = try #require(accountStore.accounts.by(id: accountA.id))
+    let memberB = try #require(accountStore.accounts.by(id: accountB.id))
+    #expect(memberA.position == 0)
+    #expect(memberB.position == 1)
+  }
+
+  @Test("addAccount(_:to:) sets groupId and persists order")
+  func addAccountToExistingGroup() async throws {
+    let (backend, database) = try TestBackend.create()
+    let seed = Account(
+      id: UUID(), name: "Seed", type: .crypto, instrument: .AUD,
+      positions: [], position: 0, isHidden: false,
+      walletAddress: "0x" + String(repeating: "a", count: 40), chainId: 1)
+    let target = Account(
+      id: UUID(), name: "Target", type: .crypto, instrument: .AUD,
+      positions: [], position: 1, isHidden: false,
+      walletAddress: "0x" + String(repeating: "b", count: 40), chainId: 1)
+    let (accountStore, groupStore) = try await makeStores(
+      seedAccounts: [seed, target], in: database, backend: backend)
+
+    let group = try await groupStore.createGroup(
+      from: seed, name: "Crypto", accountStore: accountStore)
+    try await accountStore.waitForNextEmission(
+      matching: { $0.accounts.by(id: seed.id)?.groupId == group.id },
+      description: "seed member observed"
+    )
+
+    try await groupStore.addAccount(target, to: group, accountStore: accountStore)
+    try await accountStore.waitForNextEmission(
+      matching: { $0.accounts.by(id: target.id)?.groupId == group.id },
+      description: "target joined"
+    )
+    let added = try #require(accountStore.accounts.by(id: target.id))
+    #expect(added.groupId == group.id)
+    #expect(added.position == 1)
+  }
+
+  @Test("removeAccount clears groupId and auto-deletes single-member group")
+  func removeLastMemberAutoDeletes() async throws {
+    let (backend, database) = try TestBackend.create()
+    let account = Account(
+      id: UUID(), name: "Solo", type: .crypto, instrument: .AUD,
+      positions: [], position: 0, isHidden: false,
+      walletAddress: "0x" + String(repeating: "a", count: 40), chainId: 1)
+    let (accountStore, groupStore) = try await makeStores(
+      seedAccounts: [account], in: database, backend: backend)
+
+    let group = try await groupStore.createGroup(
+      from: account, name: "Solo Group", accountStore: accountStore)
+    try await accountStore.waitForNextEmission(
+      matching: { $0.accounts.by(id: account.id)?.groupId == group.id },
+      description: "member in group"
+    )
+    try await groupStore.waitForNextEmission(
+      matching: { $0.groups.contains { $0.id == group.id } },
+      description: "group observed"
+    )
+
+    // Reload the post-join account so it carries the updated `groupId`.
+    let member = try #require(accountStore.accounts.by(id: account.id))
+    try await groupStore.removeAccount(member, accountStore: accountStore)
+    try await accountStore.waitForNextEmission(
+      matching: { $0.accounts.by(id: account.id)?.groupId == nil },
+      description: "groupId cleared"
+    )
+    try await groupStore.waitForNextEmission(
+      matching: { !$0.groups.contains { $0.id == group.id } },
+      description: "empty group auto-deleted"
+    )
+    #expect(groupStore.by(id: group.id) == nil)
+  }
+
+  @Test("removeAccount leaves group when other members remain")
+  func removeAccountLeavesGroupWhenMembersRemain() async throws {
+    let (backend, database) = try TestBackend.create()
+    let accountA = Account(
+      id: UUID(), name: "A", type: .crypto, instrument: .AUD,
+      positions: [], position: 0, isHidden: false,
+      walletAddress: "0x" + String(repeating: "a", count: 40), chainId: 1)
+    let accountB = Account(
+      id: UUID(), name: "B", type: .crypto, instrument: .AUD,
+      positions: [], position: 1, isHidden: false,
+      walletAddress: "0x" + String(repeating: "b", count: 40), chainId: 1)
+    let (accountStore, groupStore) = try await makeStores(
+      seedAccounts: [accountA, accountB], in: database, backend: backend)
+
+    let group = try await groupStore.createGroup(
+      joining: accountA, and: accountB, name: "Pair", accountStore: accountStore)
+    try await accountStore.waitForNextEmission(
+      matching: {
+        $0.accounts.by(id: accountA.id)?.groupId == group.id
+          && $0.accounts.by(id: accountB.id)?.groupId == group.id
+      },
+      description: "both joined"
+    )
+
+    // Reload the post-join A so it carries the updated `groupId`.
+    let memberA = try #require(accountStore.accounts.by(id: accountA.id))
+    try await groupStore.removeAccount(memberA, accountStore: accountStore)
+    try await accountStore.waitForNextEmission(
+      matching: { $0.accounts.by(id: accountA.id)?.groupId == nil },
+      description: "A removed"
+    )
+    #expect(groupStore.by(id: group.id) != nil)
+    #expect(accountStore.accounts.by(id: accountB.id)?.groupId == group.id)
+  }
+
+  @Test("rename updates a group's name")
+  func renameUpdatesName() async throws {
+    let (backend, _) = try TestBackend.create()
+    let group = try await backend.accountGroups.create(
+      AccountGroup(
+        name: "Old", bucket: .investments,
+        instrument: .defaultTestInstrument))
+    let store = AccountGroupStore(repository: backend.accountGroups)
+    try await store.waitForNextEmission(
+      matching: { $0.by(id: group.id) != nil },
+      description: "group observed"
+    )
+
+    let renamed = try await store.rename(id: group.id, to: "New")
+
+    #expect(renamed?.name == "New")
+    try await store.waitForNextEmission(
+      matching: { $0.by(id: group.id)?.name == "New" },
+      description: "rename observed"
+    )
+    #expect(store.error == nil)
+  }
+
+  @Test("rename trims whitespace before persisting")
+  func renameTrimsWhitespace() async throws {
+    let (backend, _) = try TestBackend.create()
+    let group = try await backend.accountGroups.create(
+      AccountGroup(
+        name: "Old", bucket: .investments,
+        instrument: .defaultTestInstrument))
+    let store = AccountGroupStore(repository: backend.accountGroups)
+    try await store.waitForNextEmission(
+      matching: { $0.by(id: group.id) != nil },
+      description: "group observed"
+    )
+
+    let renamed = try await store.rename(id: group.id, to: "  Spaced  ")
+
+    #expect(renamed?.name == "Spaced")
+  }
+
+  @Test("rename to empty / whitespace-only string is a no-op")
+  func renameToEmptyIsNoOp() async throws {
+    let (backend, _) = try TestBackend.create()
+    let group = try await backend.accountGroups.create(
+      AccountGroup(
+        name: "Stable", bucket: .investments,
+        instrument: .defaultTestInstrument))
+    let store = AccountGroupStore(repository: backend.accountGroups)
+    try await store.waitForNextEmission(
+      matching: { $0.by(id: group.id) != nil },
+      description: "group observed"
+    )
+
+    let result = try await store.rename(id: group.id, to: "   ")
+    #expect(result?.name == "Stable")
+    #expect(store.error == nil)
+  }
+
+  @Test("rename to same name is a no-op")
+  func renameToSameNameIsNoOp() async throws {
+    let (backend, _) = try TestBackend.create()
+    let group = try await backend.accountGroups.create(
+      AccountGroup(
+        name: "Stable", bucket: .investments,
+        instrument: .defaultTestInstrument))
+    let store = AccountGroupStore(repository: backend.accountGroups)
+    try await store.waitForNextEmission(
+      matching: { $0.by(id: group.id) != nil },
+      description: "group observed"
+    )
+
+    let result = try await store.rename(id: group.id, to: "Stable")
+    #expect(result?.name == "Stable")
+    #expect(store.error == nil)
+  }
+
+  @Test("rename of unknown id returns nil without surfacing an error")
+  func renameOfUnknownIdReturnsNil() async throws {
+    let (backend, _) = try TestBackend.create()
+    let store = AccountGroupStore(repository: backend.accountGroups)
+    try await store.waitForFirstEmission()
+
+    let result = try await store.rename(id: UUID(), to: "Whatever")
+    #expect(result == nil)
+    #expect(store.error == nil)
+  }
+
+  @Test("moveGroup updates the group's position")
+  func moveGroupUpdatesPosition() async throws {
+    let (backend, _) = try TestBackend.create()
+    let group = try await backend.accountGroups.create(
+      AccountGroup(
+        name: "G", bucket: .investments,
+        instrument: .defaultTestInstrument, position: 0))
+    let store = AccountGroupStore(repository: backend.accountGroups)
+    try await store.waitForNextEmission(
+      matching: { $0.by(id: group.id) != nil },
+      description: "group observed"
+    )
+
+    try await store.moveGroup(group, to: 5)
+    try await store.waitForNextEmission(
+      matching: { $0.by(id: group.id)?.position == 5 },
+      description: "position updated"
+    )
+  }
+}

--- a/MoolahTests/Features/AccountGroupStoreTests.swift
+++ b/MoolahTests/Features/AccountGroupStoreTests.swift
@@ -1,0 +1,112 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("AccountGroupStore — load & observe")
+@MainActor
+struct AccountGroupStoreTests {
+
+  @Test("initial emission is empty")
+  func initialLoadEmitsEmpty() async throws {
+    let (backend, _) = try TestBackend.create()
+    let store = AccountGroupStore(repository: backend.accountGroups)
+    try await store.waitForFirstEmission()
+
+    #expect(store.groups.isEmpty)
+  }
+
+  @Test("creating a group emits via observation")
+  func createObserved() async throws {
+    let (backend, _) = try TestBackend.create()
+    let store = AccountGroupStore(repository: backend.accountGroups)
+    try await store.waitForFirstEmission()
+
+    _ = try await backend.accountGroups.create(
+      AccountGroup(
+        name: "Trust Fund Crypto", bucket: .investments,
+        instrument: .defaultTestInstrument))
+
+    try await store.waitForNextEmission(
+      matching: { $0.groups.count == 1 },
+      description: "create observed"
+    )
+    #expect(store.groups.first?.name == "Trust Fund Crypto")
+    #expect(store.error == nil)
+  }
+
+  @Test("groups are ordered by position ascending")
+  func groupsAreOrderedByPositionAscending() async throws {
+    let (backend, _) = try TestBackend.create()
+    let store = AccountGroupStore(repository: backend.accountGroups)
+    try await store.waitForFirstEmission()
+
+    _ = try await backend.accountGroups.create(
+      AccountGroup(
+        name: "B", bucket: .investments,
+        instrument: .defaultTestInstrument, position: 2))
+    _ = try await backend.accountGroups.create(
+      AccountGroup(
+        name: "A", bucket: .investments,
+        instrument: .defaultTestInstrument, position: 1))
+
+    try await store.waitForNextEmission(
+      matching: { $0.groups.count == 2 },
+      description: "creates observed"
+    )
+    #expect(store.groups.map(\.name) == ["A", "B"])
+  }
+
+  @Test("by(id:) finds an existing group")
+  func byIdReturnsGroup() async throws {
+    let (backend, _) = try TestBackend.create()
+    let store = AccountGroupStore(repository: backend.accountGroups)
+    try await store.waitForFirstEmission()
+
+    let created = try await backend.accountGroups.create(
+      AccountGroup(
+        name: "G", bucket: .investments,
+        instrument: .defaultTestInstrument))
+
+    try await store.waitForNextEmission(
+      matching: { $0.groups.count == 1 },
+      description: "create observed"
+    )
+
+    #expect(store.by(id: created.id)?.name == "G")
+    #expect(store.by(id: UUID()) == nil)
+  }
+
+  @Test("members(of:) filters accounts by groupId and sorts by position")
+  func membersFilteredAndSorted() async throws {
+    let (backend, database) = try TestBackend.create()
+    let store = AccountGroupStore(repository: backend.accountGroups)
+    try await store.waitForFirstEmission()
+
+    let group = try await backend.accountGroups.create(
+      AccountGroup(
+        name: "G", bucket: .investments,
+        instrument: .defaultTestInstrument))
+
+    let memberB = Account(
+      id: UUID(), name: "B", type: .crypto, instrument: .AUD,
+      positions: [], position: 1, isHidden: false,
+      walletAddress: "0x" + String(repeating: "a", count: 40), chainId: 1,
+      groupId: group.id)
+    let memberA = Account(
+      id: UUID(), name: "A", type: .crypto, instrument: .AUD,
+      positions: [], position: 0, isHidden: false,
+      walletAddress: "0x" + String(repeating: "b", count: 40), chainId: 1,
+      groupId: group.id)
+    let nonMember = Account(
+      id: UUID(), name: "Standalone", type: .bank, instrument: .AUD,
+      positions: [], position: 0, isHidden: false)
+    TestBackend.seed(accounts: [memberA, memberB, nonMember], in: database)
+
+    let accountsList = try await backend.accounts.fetchAll()
+    let accounts = Accounts(from: accountsList)
+
+    let members = store.members(of: group.id, in: accounts)
+    #expect(members.map(\.name) == ["A", "B"])
+  }
+}

--- a/MoolahTests/Support/TestableStoreObservation.swift
+++ b/MoolahTests/Support/TestableStoreObservation.swift
@@ -188,6 +188,13 @@ extension AccountStore: TestableStoreObservation {
   var snapshot: AccountStore { self }
 }
 
+extension AccountGroupStore: TestableStoreObservation {
+  var observationTicks: AsyncStream<Void> { testObservationTickStream }
+  /// Tests assert directly against published `@Observable` state; the
+  /// snapshot is the store itself.
+  var snapshot: AccountGroupStore { self }
+}
+
 extension EarmarkStore: TestableStoreObservation {
   var observationTicks: AsyncStream<Void> { testObservationTickStream }
   /// Tests assert directly against published `@Observable` state; the

--- a/UITestSupport/UITestIdentifiers+Sidebar.swift
+++ b/UITestSupport/UITestIdentifiers+Sidebar.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+extension UITestIdentifiers {
+  // MARK: - Sidebar
+
+  public enum Sidebar {
+    /// Sidebar row for a specific account. `id` is the account's UUID, lowercased.
+    ///
+    /// The same UUID identifier is applied whether the account renders in
+    /// the Current Accounts section or the Investments section — `AccountType`
+    /// today is mutually exclusive across the two sections (bank/cc/asset
+    /// for Current; investment for Investments). If a future account type
+    /// can appear in both sections, switch this to a sectioned namespace
+    /// (`sidebar.account.current.<uuid>` vs `sidebar.account.investment.<uuid>`)
+    /// to avoid duplicates resolving via `firstMatch`.
+    public static func account(_ id: UUID) -> String {
+      "sidebar.account.\(id.uuidString.lowercased())"
+    }
+
+    /// Sidebar row for a named top-level view (e.g. `"upcoming"`, `"analysis"`).
+    public static func view(_ name: String) -> String {
+      "sidebar.view.\(name)"
+    }
+
+    /// "New Account" toolbar button in the sidebar (macOS only).
+    public static let newAccountButton = "sidebar.toolbar.newAccount"
+
+    /// "New Earmark" toolbar button in the sidebar (macOS only). Pinned for
+    /// symmetry with `newAccountButton` so a UI test can drive the
+    /// create-earmark flow from a zero-earmark seed without further view
+    /// changes when one is added.
+    public static let newEarmarkButton = "sidebar.toolbar.newEarmark"
+
+    /// "Edit Account…" item in the sidebar account context menu.
+    /// Distinct from the menu-bar Account → Edit Account command,
+    /// which has the same title but lives in the application menu —
+    /// drivers must resolve via this identifier rather than the
+    /// shared label.
+    public static let editAccountContextMenuItem = "sidebar.contextMenu.editAccount"
+
+    /// "Rename" item in the sidebar context menu for account rows.
+    /// Phase 4 will extend this identifier to earmark and account-group
+    /// rows; the identifier is centralised here so the same selector
+    /// works across all three entity types once they are wired.
+    public static let renameContextMenuItem = "sidebar.contextMenu.rename"
+
+    /// Sidebar row for a specific account group. `id` is the group's
+    /// UUID, lowercased. Distinct namespace from `account(_:)` so a
+    /// driver can disambiguate group-vs-account rows when needed.
+    public static func group(_ id: UUID) -> String {
+      "sidebar.group.\(id.uuidString.lowercased())"
+    }
+
+    /// The "Group" submenu trigger inside the account context menu.
+    /// Submenu items are matched by their visible label (the existing
+    /// group names + the literal "New Group…" / "Remove from Group")
+    /// rather than by identifier so they remain dynamic.
+    public static let groupSubmenu = "sidebar.contextMenu.groupSubmenu"
+  }
+}

--- a/UITestSupport/UITestIdentifiers.swift
+++ b/UITestSupport/UITestIdentifiers.swift
@@ -12,49 +12,8 @@ import Foundation
 /// Identifiers are added incrementally as drivers and tests need them — see
 /// `guides/UI_TEST_GUIDE.md` §4.
 public enum UITestIdentifiers {
-  // MARK: - Sidebar
-
-  public enum Sidebar {
-    /// Sidebar row for a specific account. `id` is the account's UUID, lowercased.
-    ///
-    /// The same UUID identifier is applied whether the account renders in
-    /// the Current Accounts section or the Investments section — `AccountType`
-    /// today is mutually exclusive across the two sections (bank/cc/asset
-    /// for Current; investment for Investments). If a future account type
-    /// can appear in both sections, switch this to a sectioned namespace
-    /// (`sidebar.account.current.<uuid>` vs `sidebar.account.investment.<uuid>`)
-    /// to avoid duplicates resolving via `firstMatch`.
-    public static func account(_ id: UUID) -> String {
-      "sidebar.account.\(id.uuidString.lowercased())"
-    }
-
-    /// Sidebar row for a named top-level view (e.g. `"upcoming"`, `"analysis"`).
-    public static func view(_ name: String) -> String {
-      "sidebar.view.\(name)"
-    }
-
-    /// "New Account" toolbar button in the sidebar (macOS only).
-    public static let newAccountButton = "sidebar.toolbar.newAccount"
-
-    /// "New Earmark" toolbar button in the sidebar (macOS only). Pinned for
-    /// symmetry with `newAccountButton` so a UI test can drive the
-    /// create-earmark flow from a zero-earmark seed without further view
-    /// changes when one is added.
-    public static let newEarmarkButton = "sidebar.toolbar.newEarmark"
-
-    /// "Edit Account…" item in the sidebar account context menu.
-    /// Distinct from the menu-bar Account → Edit Account command,
-    /// which has the same title but lives in the application menu —
-    /// drivers must resolve via this identifier rather than the
-    /// shared label.
-    public static let editAccountContextMenuItem = "sidebar.contextMenu.editAccount"
-
-    /// "Rename" item in the sidebar context menu for account rows.
-    /// Phase 4 will extend this identifier to earmark and account-group
-    /// rows; the identifier is centralised here so the same selector
-    /// works across all three entity types once they are wired.
-    public static let renameContextMenuItem = "sidebar.contextMenu.rename"
-  }
+  // The `Sidebar` namespace lives in
+  // `UITestIdentifiers+Sidebar.swift`.
 
   // MARK: - TransactionList
 


### PR DESCRIPTION
## Summary

Phase 4 of the Account Groups feature: sidebar rendering, membership creation flows, and inline rename for `AccountGroup` rows. Stacks on top of Phase 2 (#983) — this PR's base is `sidebar-inline-rename` so the diff focuses on Phase 4's changes. Phase 3 (#984) has already merged to main, so its content is no longer in this diff.

- New `AccountGroupStore` (parallel to `EarmarkStore` / `AccountStore`) with reactive load + observe and a membership-mutation surface: `createGroup(from:)`, `createGroup(joining:and:)`, `addAccount`, `removeAccount` (with auto-delete-on-empty), `rename`, `moveGroup`.
- `Accounts.groupAwareSidebar(groups:)` returns intermixed `[SidebarBucketEntry]` per bucket (standalone accounts + groups sorted by shared `position`, tie-break account-first).
- New `AccountGroupSidebarRow` + `AccountSidebarRow.isMember` styling hint (chain-short-address / exchange-provider secondary line for members).
- `SidebarSelection.group(UUID)` case; `ContentView` placeholder detail leaf (Phase 5 replaces).
- Drag-and-drop via `.draggable` + `.dropDestination` with a bespoke `DraggableSidebarItem`. Drop-on-account same-bucket → new 2-member group; drop-on-group → add account; cross-bucket / self-drop / group-onto-anything rejected.
- Account context menu gains "Group ▸" submenu; group context menu exposes Rename only (spec excludes Hide / Delete).
- `UITestIdentifiers.Sidebar.group(_:)` + `.groupSubmenu` pinned.
- In-memory `expandedGroupIds` set drives row expand state (Phase 8 persists).
- Drive-by fix: `GRDBAccountRepository.update` now propagates `Account.groupId` — Phase 3 added the column but the update path was silently dropping membership writes. Caught by the new mutation tests.

## What's not in this PR

- Reorder-via-drag inside the integrated bucket (SwiftUI `.dropDestination` doesn't natively distinguish middle-50% from edge-25%; deferred).
- Phase 5 (composite group detail view).
- Phase 6 (description rendering under group view).
- Phase 7 (CloudKit sync wiring for groups).
- Phase 8 (`isExpandedInSidebar` persistence — currently in-memory only).

## Test plan

- [x] `just format-check` — clean.
- [x] `just test` — passes on both iOS Simulator and macOS.
- [x] New store tests cover createGroup (single + paired), addAccount, removeAccount (with auto-delete), rename (trim / no-op / unknown id), moveGroup.
- [x] New `Accounts.groupAwareSidebar` tests cover empty groups, member sort, hidden-member exclusion, intermixed position, tie-break, cross-bucket isolation, dangling `groupId` falls back to standalone.
- [x] `SidebarSelectionRouteTests` covers the new `.group` → `.accounts` placeholder mapping.
- Manual exercise via SwiftUI `#Preview("With a group")` — seeds two crypto wallets and forms a group.

🤖 Generated with [Claude Code](https://claude.com/claude-code)