### PR TITLE
feat(sidebar): persist account-group expand state per profile

### DIFF
--- a/App/ProfileSession+SyncCleanup.swift
+++ b/App/ProfileSession+SyncCleanup.swift
@@ -40,6 +40,7 @@ extension ProfileSession {
     accountStore.stopObserving()
     earmarkStore.stopObserving()
     accountGroupStore?.stopObserving()
+    groupUIStateStore?.stopObserving()
     categoryStore.stopObserving()
     importRuleStore.stopObserving()
     transactionStore.stopObserving()

--- a/App/ProfileSession.swift
+++ b/App/ProfileSession.swift
@@ -34,6 +34,10 @@ final class ProfileSession: Identifiable {
   /// consumers can force-unwrap if needed; the type stays optional to
   /// satisfy SwiftLint's `implicitly_unwrapped_optional` rule.
   private(set) var accountGroupStore: AccountGroupStore?
+  /// Sidebar expand / collapse state for `AccountGroup` rows.
+  /// Local-only (per-device). Same `finishInit`-assigned pattern as
+  /// `accountGroupStore`; functionally `let` from the consumer.
+  private(set) var groupUIStateStore: GroupUIStateStore?
   let analysisStore: AnalysisStore
   let investmentStore: InvestmentStore
   let reportingStore: ReportingStore
@@ -227,6 +231,7 @@ final class ProfileSession: Identifiable {
     // `function_body_length` budget — same pattern as `cryptoSyncStore`
     // / `cryptoTokenDiscovery` below.
     self.accountGroupStore = AccountGroupStore(repository: backend.accountGroups)
+    self.groupUIStateStore = GroupUIStateStore(repository: backend.groupUIState)
     let cryptoWiring = Self.makeCryptoSyncWiring(
       backend: backend,
       registry: instrumentRegistry,

--- a/App/SessionRootView.swift
+++ b/App/SessionRootView.swift
@@ -15,6 +15,7 @@ struct SessionRootView: View {
       .environment(session.categoryStore)
       .environment(session.earmarkStore)
       .environment(session.accountGroupStore)
+      .environment(session.groupUIStateStore)
       .environment(session.analysisStore)
       .environment(session.investmentStore)
       .environment(session.reportingStore)

--- a/Backends/CloudKit/CloudKitBackend.swift
+++ b/Backends/CloudKit/CloudKitBackend.swift
@@ -16,6 +16,7 @@ final class CloudKitBackend: BackendProvider, @unchecked Sendable {
   let importRules: any ImportRuleRepository
   let instrumentRegistry: any InstrumentRegistryRepository
   let walletSyncState: any WalletSyncStateRepository
+  let groupUIState: any GroupUIStateRepository
 
   /// `BackendProvider` change-notification seam: the shared
   /// `GRDBInstrumentRegistryRepository` exposed as the narrow
@@ -141,6 +142,7 @@ final class CloudKitBackend: BackendProvider, @unchecked Sendable {
     self.instrumentRegistry = instrumentRegistry
     self.conversionService = conversionService
     self.walletSyncState = GRDBWalletSyncStateRepository(database: database)
+    self.groupUIState = GRDBGroupUIStateRepository(database: database)
   }
 
   /// Bundle of GRDB repositories produced by `makeRepositories`. Keeps

--- a/Backends/GRDB/ProfileSchema+AccountGroupUIState.swift
+++ b/Backends/GRDB/ProfileSchema+AccountGroupUIState.swift
@@ -1,0 +1,36 @@
+import Foundation
+import GRDB
+
+extension ProfileSchema {
+  /// v15 migration. Adds the per-profile local-only `account_group_ui`
+  /// table that backs sidebar expand / collapse state. Intentionally
+  /// **not** synced via CloudKit — expand state is per-device UX
+  /// preference, not data (see the Account Groups design,
+  /// "Local-only state").
+  ///
+  /// `ON DELETE CASCADE` on `group_id` reaps the row automatically when
+  /// the underlying group is deleted (locally or via incoming
+  /// CKSyncEngine delete). The FK is safe here because both tables live
+  /// in the same DB and the table is never written from the sync apply
+  /// path — a UI-state row is only created in response to user
+  /// interaction with a group that is already on-screen, so the parent
+  /// row is guaranteed to exist at write time. This is the one FK in the
+  /// account-groups schema; `account.group_id` (v14) deliberately has no
+  /// FK because sync delivery order can place an Account ahead of its
+  /// AccountGroup.
+  ///
+  /// `STRICT` per `guides/DATABASE_SCHEMA_GUIDE.md`. Rowid table — no
+  /// `WITHOUT ROWID` because the rest of the per-profile DB uses rowid
+  /// tables and the row count for this table is bounded by the number of
+  /// groups (always small), so there is no storage win to chase.
+  static func addAccountGroupUIState(_ database: Database) throws {
+    try database.execute(
+      sql: """
+        CREATE TABLE account_group_ui (
+            group_id     BLOB    NOT NULL PRIMARY KEY
+                         REFERENCES account_group(id) ON DELETE CASCADE,
+            is_expanded  INTEGER NOT NULL DEFAULT 0
+        ) STRICT;
+        """)
+  }
+}

--- a/Backends/GRDB/ProfileSchema.swift
+++ b/Backends/GRDB/ProfileSchema.swift
@@ -73,6 +73,12 @@ import GRDB
 /// deliver an Account ahead of its AccountGroup, so the lookup layer
 /// resolves unknown ids to nil instead of relying on the database).
 /// See `ProfileSchema+AccountGroups.swift`.
+/// `v15_account_group_ui_state` — adds the local-only `account_group_ui`
+/// table for sidebar expand / collapse state. NOT synced via CloudKit
+/// (per-device UX preference, not data). FK with `ON DELETE CASCADE`
+/// against `account_group(id)` reaps rows automatically when their
+/// parent group is deleted. See
+/// `ProfileSchema+AccountGroupUIState.swift`.
 ///
 /// **Retention policy for the cache tables.** The six rate-cache
 /// tables are kept forever — needed for historic-conversion
@@ -93,7 +99,7 @@ enum ProfileSchema {
   /// Bumped each time a migration is added. Surfaced for open-time
   /// integrity checks; not used by `DatabaseMigrator` (which keys on
   /// the stable string IDs of registered migrations).
-  static let version = 14
+  static let version = 15
 
   static var migrator: DatabaseMigrator {
     var migrator = DatabaseMigrator()
@@ -129,6 +135,8 @@ enum ProfileSchema {
       "v13_transfer_suggestion_record", migrate: addTransferSuggestion)
     migrator.registerMigration(
       "v14_account_groups", migrate: addAccountGroups)
+    migrator.registerMigration(
+      "v15_account_group_ui_state", migrate: addAccountGroupUIState)
 
     return migrator
   }

--- a/Backends/GRDB/Repositories/GRDBGroupUIStateRepository.swift
+++ b/Backends/GRDB/Repositories/GRDBGroupUIStateRepository.swift
@@ -1,0 +1,82 @@
+// Backends/GRDB/Repositories/GRDBGroupUIStateRepository.swift
+
+import Foundation
+import GRDB
+
+/// GRDB-backed implementation of `GroupUIStateRepository`. Stores the
+/// per-device sidebar expand / collapse state for `AccountGroup` rows in
+/// the local `account_group_ui` table (v15 migration). NOT synced via
+/// CKSyncEngine.
+///
+/// Implemented as a `Sendable` struct (not a `final class` with
+/// `@unchecked Sendable`) per CONCURRENCY_GUIDE §2: the only stored
+/// properties are `let database: any DatabaseWriter` and a shared
+/// `ObservationErrorChannel` (an `actor`, implicitly `Sendable`). No
+/// mutable state, no observation fan-out — none of the genuine reasons
+/// that force `@unchecked` in the synced repositories.
+///
+/// Same lifetime model as `GRDBWalletSyncStateRepository`: built once
+/// per `CloudKitBackend` from the same `DatabaseWriter` that every other
+/// per-profile repo uses, so all writes route through the queue's
+/// serial executor and observations share the same change-notification
+/// surface as the rest of the per-profile graph.
+struct GRDBGroupUIStateRepository: GroupUIStateRepository, Sendable {
+  private let database: any DatabaseWriter
+  private let errorChannel = ObservationErrorChannel()
+
+  init(database: any DatabaseWriter) {
+    self.database = database
+  }
+
+  func isExpanded(groupId: UUID) async throws -> Bool {
+    try await database.read { database in
+      try Bool.fetchOne(
+        database,
+        sql: "SELECT is_expanded FROM account_group_ui WHERE group_id = ?",
+        arguments: [groupId]) ?? false
+    }
+  }
+
+  func setExpanded(_ expanded: Bool, for groupId: UUID) async throws {
+    try await database.write { database in
+      try database.execute(
+        sql: """
+          INSERT INTO account_group_ui (group_id, is_expanded) VALUES (?, ?)
+          ON CONFLICT(group_id) DO UPDATE SET is_expanded = excluded.is_expanded
+          """,
+        arguments: [groupId, expanded])
+    }
+  }
+
+  func expandedGroupIds() async throws -> Set<UUID> {
+    try await database.read { database in
+      let ids = try UUID.fetchAll(
+        database,
+        sql: "SELECT group_id FROM account_group_ui WHERE is_expanded = 1")
+      return Set(ids)
+    }
+  }
+
+  /// Streams the set of expanded group ids. Emits an initial snapshot
+  /// and again on every change to the `account_group_ui` table. The
+  /// table has no sync-bookkeeping columns (it's local-only), so the
+  /// full-table tracking region is fine — no `observableRegion`
+  /// allowlist is needed.
+  func observeExpandedGroupIds() -> AsyncStream<Set<UUID>> {
+    ValueObservation
+      .tracking { database in
+        let ids = try UUID.fetchAll(
+          database,
+          sql: "SELECT group_id FROM account_group_ui WHERE is_expanded = 1")
+        return Set(ids)
+      }
+      .toRetryingAsyncStream(
+        in: database,
+        errorChannel: errorChannel,
+        repoMethod: "GRDBGroupUIStateRepository.observeExpandedGroupIds")
+  }
+
+  func observeErrors() -> AsyncStream<any Error> {
+    errorChannel.stream
+  }
+}

--- a/Domain/Repositories/BackendProvider.swift
+++ b/Domain/Repositories/BackendProvider.swift
@@ -19,6 +19,10 @@ protocol BackendProvider: Sendable {
   /// (not synced via CKSyncEngine — see `WalletSyncStateRepository`
   /// doc-comment).
   var walletSyncState: any WalletSyncStateRepository { get }
+  /// Per-device sidebar expand / collapse state for `AccountGroup` rows.
+  /// Local-only (not synced via CKSyncEngine — expand state is per-device
+  /// UX preference, not data). See `GroupUIStateRepository` doc-comment.
+  var groupUIState: any GroupUIStateRepository { get }
 
   /// Narrow change-notification seam over the backend's shared
   /// instrument registry, or `nil` for backends that have no shared

--- a/Domain/Repositories/GroupUIStateRepository.swift
+++ b/Domain/Repositories/GroupUIStateRepository.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+/// Per-profile local-only persistence for sidebar UI state on
+/// `AccountGroup` rows.
+///
+/// The only state stored today is each group's `isExpandedInSidebar`
+/// preference. The repository is intentionally narrow — it owns one
+/// `Bool` per group id, nothing more. Group lifecycle (`create` /
+/// `delete`) is the `AccountGroupRepository`'s responsibility; the
+/// underlying GRDB FK with `ON DELETE CASCADE` reaps stale UI-state
+/// rows automatically when a group is deleted, so this repo never has
+/// to mirror group deletes.
+///
+/// Why a separate repository (rather than a field on `AccountGroup`):
+/// expand state is **per-device**, never synced via CloudKit. Putting
+/// it on the domain type would either force every sync record to carry
+/// a field that shouldn't sync, or require model-level branching at
+/// every write site. A dedicated repo keeps the sync surface clean and
+/// the storage local.
+///
+/// Convention: methods return the **default** (`false` / empty set)
+/// when no row exists. Callers never have to handle a "row missing"
+/// case — groups are simply collapsed by default.
+protocol GroupUIStateRepository: Sendable {
+  /// Returns `true` if the group is currently expanded in the sidebar.
+  /// Returns `false` when no row exists — groups default to collapsed.
+  func isExpanded(groupId: UUID) async throws -> Bool
+
+  /// Persists the expand state for a single group. Upserts on the
+  /// primary key so repeated calls are idempotent.
+  func setExpanded(_ expanded: Bool, for groupId: UUID) async throws
+
+  /// Fetches the set of expanded group ids in one query. Anything not
+  /// in the set is collapsed. Used to seed the sidebar binding at
+  /// launch.
+  func expandedGroupIds() async throws -> Set<UUID>
+
+  /// Hot stream of expanded-id snapshots. Emits an initial snapshot and
+  /// again on every persisted change to the `account_group_ui` table.
+  /// Errors are surfaced out-of-band on `observeErrors()` — the value
+  /// stream itself is non-throwing.
+  func observeExpandedGroupIds() -> AsyncStream<Set<UUID>>
+
+  /// Companion error stream. A healthy observation stays quiet here for
+  /// its lifetime; a programmer-bug or non-recoverable I/O error from
+  /// the underlying observation is yielded once and the stream
+  /// completes.
+  func observeErrors() -> AsyncStream<any Error>
+}

--- a/Features/Accounts/GroupUIStateStore.swift
+++ b/Features/Accounts/GroupUIStateStore.swift
@@ -1,0 +1,128 @@
+import Foundation
+import OSLog
+import Observation
+
+/// Reactive store for sidebar expand / collapse state on `AccountGroup`
+/// rows. Local-only (per-device) — never synced via CloudKit.
+///
+/// Mirrors `AccountGroupStore`: subscribes to
+/// `repository.observeExpandedGroupIds()` in `init`, exposes a
+/// `@MainActor` snapshot (`expandedGroupIds`), and surfaces errors
+/// out-of-band on `error`. The toggle / setExpanded methods are
+/// pass-through to the repository; the reactive observation delivers
+/// the authoritative state. This is the same shape as `EarmarkStore`'s
+/// observation-driven update path.
+@Observable
+@MainActor
+final class GroupUIStateStore {
+  private(set) var expandedGroupIds: Set<UUID> = []
+  private(set) var error: Error?
+
+  private let repository: any GroupUIStateRepository
+  private let logger = Logger(subsystem: "com.moolah.app", category: "GroupUIStateStore")
+
+  /// The observation task driving `expandedGroupIds` from
+  /// `repository.observeExpandedGroupIds()`. Spawned from `init`; torn
+  /// down by `stopObserving()` (called from
+  /// `ProfileSession.cleanupSync`) or `deinit` as a safety net.
+  private var observationTask: Task<Void, Never>?
+
+  /// Test-only emission tick stream. Yields `()` after every state
+  /// assignment in `apply(ids:)`. Tests use the
+  /// `TestableStoreObservation` helpers in
+  /// `MoolahTests/Support/TestableStoreObservation.swift` to await
+  /// emissions deterministically. `internal` access is intentional;
+  /// `@testable import Moolah` exposes it to the test target.
+  let testObservationTickStream: AsyncStream<Void>
+  private let testObservationTickContinuation: AsyncStream<Void>.Continuation
+
+  init(repository: any GroupUIStateRepository) {
+    self.repository = repository
+    let pair = AsyncStream<Void>.makeStream()
+    self.testObservationTickStream = pair.stream
+    self.testObservationTickContinuation = pair.continuation
+    // Strong `self` capture is intentional: the store is `@MainActor`,
+    // the task already holds an implicit strong reference, and
+    // `stopObserving()` is the sole lifetime gate. Same pattern as
+    // `AccountGroupStore.init`.
+    observationTask = Task { await self.observe() }
+  }
+
+  deinit {
+    // Safety net for the case where `cleanupSync` is missed. Swift 6
+    // makes `deinit` nonisolated; reading `@MainActor`-isolated state
+    // requires `MainActor.assumeIsolated`.
+    MainActor.assumeIsolated {
+      observationTask?.cancel()
+      testObservationTickContinuation.finish()
+    }
+  }
+
+  /// Subscribes to `repository.observeExpandedGroupIds()` and forwards
+  /// every emission to `apply(ids:)`. Errors are surfaced out-of-band
+  /// via `repository.observeErrors()`.
+  private func observe() async {
+    let idsStream = repository.observeExpandedGroupIds()
+    let errorsStream = repository.observeErrors()
+    await withTaskGroup(of: Void.self) { group in
+      group.addTask { [self] in
+        for await fresh in idsStream {
+          await self.apply(ids: fresh)
+        }
+      }
+      group.addTask { [self] in
+        for await error in errorsStream {
+          await self.surface(error: error)
+        }
+      }
+    }
+  }
+
+  /// Applies a fresh snapshot from `observeExpandedGroupIds()`. Yields
+  /// the test tick so deterministic emission-aware tests can await
+  /// observed state.
+  private func apply(ids fresh: Set<UUID>) async {
+    self.expandedGroupIds = fresh
+    testObservationTickContinuation.yield(())
+  }
+
+  private func surface(error: any Error) {
+    logger.error("GroupUIStateStore observation error: \(error.localizedDescription)")
+    self.error = error
+  }
+
+  /// Tears down the observation task. Idempotent.
+  func stopObserving() {
+    observationTask?.cancel()
+  }
+
+  /// Test-only. Awaits the observation task chain to fully terminate
+  /// after `stopObserving()`, then nils the reference.
+  func awaitObservationTermination() async {
+    await observationTask?.value
+    observationTask = nil
+  }
+
+  // MARK: - Mutations
+
+  /// Persists the expand state for a single group. Pass-through to the
+  /// repository; the observation stream delivers the authoritative
+  /// `expandedGroupIds` update.
+  func setExpanded(_ expanded: Bool, for groupId: UUID) async {
+    do {
+      try await repository.setExpanded(expanded, for: groupId)
+    } catch {
+      logger.error("setExpanded failed: \(error.localizedDescription)")
+      self.error = error
+    }
+  }
+
+  /// Convenience: flips the current expand state for `groupId`. Reads
+  /// the local snapshot to decide the target value, then routes through
+  /// `setExpanded(_:for:)`. Race-tolerant: the observation stream
+  /// re-syncs the snapshot whether or not the toggle wrote.
+  func toggle(_ groupId: UUID) async {
+    let target = !expandedGroupIds.contains(groupId)
+    await setExpanded(target, for: groupId)
+  }
+}

--- a/Features/Navigation/SidebarView+Groups.swift
+++ b/Features/Navigation/SidebarView+Groups.swift
@@ -106,19 +106,20 @@ extension SidebarView {
 
   // MARK: - Expand state
 
-  /// Returns a two-way binding to the expand state of `groupId`. The
-  /// binding is backed by `expandedGroupIds` (in-memory only this
-  /// phase; Phase 8 persists). Setting `true` inserts; `false`
-  /// removes — straightforward Set membership.
+  /// Returns a two-way binding to the expand state of `groupId`.
+  /// Reads from `groupUIStateStore.expandedGroupIds` (driven by the
+  /// reactive observation of the local-only `account_group_ui` table)
+  /// and writes through `setExpanded(_:for:)` so the change is
+  /// persisted per profile and survives app relaunch.
+  ///
+  /// The store closes the loop: setExpanded → repo write → observation
+  /// emits → `expandedGroupIds` updates → the binding's `get` returns
+  /// the new value → SwiftUI re-renders.
   func expandBinding(for groupId: UUID) -> Binding<Bool> {
     Binding(
-      get: { expandedGroupIds.contains(groupId) },
+      get: { groupUIStateStore.expandedGroupIds.contains(groupId) },
       set: { newValue in
-        if newValue {
-          expandedGroupIds.insert(groupId)
-        } else {
-          expandedGroupIds.remove(groupId)
-        }
+        Task { await groupUIStateStore.setExpanded(newValue, for: groupId) }
       }
     )
   }
@@ -207,7 +208,7 @@ extension SidebarView {
         accountStore: accountStore
       )
       editingRowId = created.id
-      expandedGroupIds.insert(created.id)
+      await groupUIStateStore.setExpanded(true, for: created.id)
     } catch {
       // Error already surfaced on the store; no extra UI hop needed.
     }
@@ -239,7 +240,7 @@ extension SidebarView {
       let created = try await accountGroupStore.createGroup(
         from: account, name: "New Group", accountStore: accountStore)
       editingRowId = created.id
-      expandedGroupIds.insert(created.id)
+      await groupUIStateStore.setExpanded(true, for: created.id)
     } catch {
       // Error surfaces on `accountGroupStore.error`; no extra UI hop.
     }

--- a/Features/Navigation/SidebarView+Previews.swift
+++ b/Features/Navigation/SidebarView+Previews.swift
@@ -29,6 +29,7 @@ private func seedSidebarPreview(backend: any BackendProvider) async {
     conversionService: backend.conversionService,
     targetInstrument: .AUD)
   let accountGroupStore = AccountGroupStore(repository: backend.accountGroups)
+  let groupUIStateStore = GroupUIStateStore(repository: backend.groupUIState)
   // In-memory preview session can't fail in practice: opens an ephemeral
   // GRDB queue with no disk access. A trap here is acceptable in #Preview.
   // swiftlint:disable:next force_try
@@ -39,6 +40,7 @@ private func seedSidebarPreview(backend: any BackendProvider) async {
       .environment(accountStore)
       .environment(earmarkStore)
       .environment(accountGroupStore)
+      .environment(groupUIStateStore)
       .environment(session)
       .task {
         await seedSidebarPreview(backend: backend)
@@ -96,6 +98,7 @@ private func seedSidebarGroupPreview(
     conversionService: backend.conversionService,
     targetInstrument: .AUD)
   let accountGroupStore = AccountGroupStore(repository: backend.accountGroups)
+  let groupUIStateStore = GroupUIStateStore(repository: backend.groupUIState)
   // swiftlint:disable:next force_try
   let session = try! ProfileSession.preview()
 
@@ -104,6 +107,7 @@ private func seedSidebarGroupPreview(
       .environment(accountStore)
       .environment(earmarkStore)
       .environment(accountGroupStore)
+      .environment(groupUIStateStore)
       .environment(session)
       .task {
         await seedSidebarGroupPreview(
@@ -127,6 +131,7 @@ private func seedSidebarGroupPreview(
     conversionService: backend.conversionService,
     targetInstrument: .AUD)
   let accountGroupStore = AccountGroupStore(repository: backend.accountGroups)
+  let groupUIStateStore = GroupUIStateStore(repository: backend.groupUIState)
   // In-memory preview session can't fail in practice: opens an ephemeral
   // GRDB queue with no disk access. A trap here is acceptable in #Preview.
   // swiftlint:disable:next force_try
@@ -137,6 +142,7 @@ private func seedSidebarGroupPreview(
       .environment(accountStore)
       .environment(earmarkStore)
       .environment(accountGroupStore)
+      .environment(groupUIStateStore)
       .environment(session)
       .task {
         // Seed only an account — no earmarks. Validates that the

--- a/Features/Navigation/SidebarView.swift
+++ b/Features/Navigation/SidebarView.swift
@@ -29,6 +29,11 @@ struct SidebarView: View {
   // Internal access required by `SidebarView+Sections.swift` extension;
   // cannot be `private` across file boundaries.
   @Environment(AccountGroupStore.self) var accountGroupStore
+  // Sidebar expand / collapse state for `AccountGroup` rows. Persisted
+  // per profile in the local-only `account_group_ui` GRDB table —
+  // never synced via CloudKit. Internal access for the
+  // `SidebarView+Groups.swift` extension.
+  @Environment(GroupUIStateStore.self) var groupUIStateStore
   @Environment(ProfileSession.self) private var session
   // Internal access required by `SidebarView+Sections.swift` extension;
   // cannot be `private` across file boundaries.
@@ -53,15 +58,6 @@ struct SidebarView: View {
   // Internal access required by `SidebarView+Sections.swift` extension;
   // cannot be `private` across file boundaries.
   @State var editingRowId: UUID?
-  // In-memory expand state for account-group rows. Phase 8 will persist
-  // this in a local-only GRDB sidecar (`local_account_group_ui`); for
-  // Phase 4 the state lives only for the lifetime of the sidebar view
-  // instance, so collapse / expand is lost on app relaunch. The Phase 8
-  // migration will swap the storage without changing the
-  // `expandedGroupIds.contains/insert/remove` API used downstream.
-  // Internal access required by `SidebarView+Sections.swift` extension;
-  // cannot be `private` across file boundaries.
-  @State var expandedGroupIds: Set<UUID> = []
   // Internal access required by `SidebarView+Sections.swift` extension;
   // cannot be `private` across file boundaries.
   @AppStorage("showHiddenAccounts") var showHidden = false

--- a/MoolahTests/Backends/GRDB/AccountGroupUIStateMigrationTests.swift
+++ b/MoolahTests/Backends/GRDB/AccountGroupUIStateMigrationTests.swift
@@ -1,0 +1,110 @@
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+@Suite("v15_account_group_ui_state migration")
+struct AccountGroupUIStateMigrationTests {
+  @Test("creates account_group_ui table with expected columns")
+  func createsTableWithExpectedColumns() throws {
+    let queue = try DatabaseQueue()
+    try ProfileSchema.migrator.migrate(queue)
+
+    try queue.read { database in
+      let columns = try database.columns(in: "account_group_ui")
+      let names = columns.map(\.name)
+      #expect(names == ["group_id", "is_expanded"])
+    }
+  }
+
+  @Test("group_id is the primary key")
+  func groupIdIsPrimaryKey() throws {
+    let queue = try DatabaseQueue()
+    try ProfileSchema.migrator.migrate(queue)
+
+    try queue.read { database in
+      let columns = try database.columns(in: "account_group_ui")
+      let primary = columns.first { $0.primaryKeyIndex > 0 }
+      #expect(primary?.name == "group_id")
+    }
+  }
+
+  @Test("FK to account_group with ON DELETE CASCADE")
+  func foreignKeyCascadesOnDelete() throws {
+    let queue = try DatabaseQueue()
+    try ProfileSchema.migrator.migrate(queue)
+
+    try queue.read { database in
+      let rows = try Row.fetchAll(
+        database, sql: "PRAGMA foreign_key_list(account_group_ui)")
+      #expect(rows.count == 1)
+      let foreignKey = try #require(rows.first)
+      #expect(foreignKey["table"] as? String == "account_group")
+      #expect(foreignKey["from"] as? String == "group_id")
+      #expect(foreignKey["to"] as? String == "id")
+      #expect(foreignKey["on_delete"] as? String == "CASCADE")
+    }
+  }
+
+  @Test("deleting parent group cascades to account_group_ui row")
+  func cascadeDeletesUIStateWhenGroupDeleted() throws {
+    let queue = try DatabaseQueue()
+    try ProfileSchema.migrator.migrate(queue)
+
+    let groupId = UUID()
+    try queue.write { database in
+      try database.execute(
+        sql: """
+          INSERT INTO account_group
+            (id, record_name, name, bucket, instrument_id, position)
+          VALUES (?, ?, 'G', 'investments', 'AUD', 0)
+          """,
+        arguments: [groupId, "AccountGroupRecord|\(groupId.uuidString)"])
+      try database.execute(
+        sql: "INSERT INTO account_group_ui (group_id, is_expanded) VALUES (?, 1)",
+        arguments: [groupId])
+    }
+
+    try queue.write { database in
+      try database.execute(
+        sql: "DELETE FROM account_group WHERE id = ?", arguments: [groupId])
+    }
+
+    let remaining = try queue.read { database in
+      try Int.fetchOne(
+        database,
+        sql: "SELECT COUNT(*) FROM account_group_ui WHERE group_id = ?",
+        arguments: [groupId]) ?? 0
+    }
+    #expect(remaining == 0)
+  }
+
+  @Test("INSERT omitting is_expanded receives DEFAULT 0")
+  func defaultIsExpandedIsZero() throws {
+    let queue = try DatabaseQueue()
+    try ProfileSchema.migrator.migrate(queue)
+
+    let groupId = UUID()
+    try queue.write { database in
+      try database.execute(
+        sql: """
+          INSERT INTO account_group
+            (id, record_name, name, bucket, instrument_id, position)
+          VALUES (?, ?, 'G', 'investments', 'AUD', 0)
+          """,
+        arguments: [groupId, "AccountGroupRecord|\(groupId.uuidString)"])
+      try database.execute(
+        sql: "INSERT INTO account_group_ui (group_id) VALUES (?)",
+        arguments: [groupId])
+    }
+
+    let expanded = try queue.read { database in
+      try Int.fetchOne(
+        database,
+        sql: "SELECT is_expanded FROM account_group_ui WHERE group_id = ?",
+        arguments: [groupId])
+    }
+    #expect(expanded == 0)
+  }
+}

--- a/MoolahTests/Backends/GRDB/ProfileSchemaV10DropLegacyTests.swift
+++ b/MoolahTests/Backends/GRDB/ProfileSchemaV10DropLegacyTests.swift
@@ -71,6 +71,9 @@ struct ProfileSchemaV10DropLegacyTests {
     "transfer_suggestion",
     // v14 account groups (synced; back-reference column added on `account`)
     "account_group",
+    // v15 sidebar expand / collapse state (local-only; cascades from
+    // `account_group` on delete)
+    "account_group_ui",
     "grdb_migrations",
   ]
 

--- a/MoolahTests/Domain/GroupUIStateRepositoryContractTests.swift
+++ b/MoolahTests/Domain/GroupUIStateRepositoryContractTests.swift
@@ -1,0 +1,129 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("GroupUIStateRepository contract")
+struct GroupUIStateRepositoryContractTests {
+  @Test("unknown group defaults to collapsed")
+  func defaultIsCollapsed() async throws {
+    let (backend, _) = try TestBackend.create()
+    let expanded = try await backend.groupUIState.isExpanded(groupId: UUID())
+    #expect(expanded == false)
+  }
+
+  @Test("set then read returns true")
+  func setThenReadTrue() async throws {
+    let (backend, _) = try TestBackend.create()
+    let group = try await backend.accountGroups.create(
+      AccountGroup(
+        name: "Trust Fund Crypto", bucket: .investments,
+        instrument: .defaultTestInstrument))
+    try await backend.groupUIState.setExpanded(true, for: group.id)
+    let expanded = try await backend.groupUIState.isExpanded(groupId: group.id)
+    #expect(expanded == true)
+  }
+
+  @Test("set false then read returns false")
+  func setFalseThenReadFalse() async throws {
+    let (backend, _) = try TestBackend.create()
+    let group = try await backend.accountGroups.create(
+      AccountGroup(
+        name: "Personal Crypto", bucket: .investments,
+        instrument: .defaultTestInstrument))
+    try await backend.groupUIState.setExpanded(true, for: group.id)
+    try await backend.groupUIState.setExpanded(false, for: group.id)
+    let expanded = try await backend.groupUIState.isExpanded(groupId: group.id)
+    #expect(expanded == false)
+  }
+
+  @Test("repeated set is idempotent (upsert)")
+  func setIsIdempotent() async throws {
+    let (backend, _) = try TestBackend.create()
+    let group = try await backend.accountGroups.create(
+      AccountGroup(
+        name: "Stocks", bucket: .investments,
+        instrument: .defaultTestInstrument))
+    try await backend.groupUIState.setExpanded(true, for: group.id)
+    try await backend.groupUIState.setExpanded(true, for: group.id)
+    let expanded = try await backend.groupUIState.isExpanded(groupId: group.id)
+    #expect(expanded == true)
+  }
+
+  @Test("expandedGroupIds returns only expanded entries")
+  func expandedGroupIdsReturnsOnlyExpanded() async throws {
+    let (backend, _) = try TestBackend.create()
+    let groupA = try await backend.accountGroups.create(
+      AccountGroup(
+        name: "A", bucket: .investments,
+        instrument: .defaultTestInstrument, position: 0))
+    let groupB = try await backend.accountGroups.create(
+      AccountGroup(
+        name: "B", bucket: .investments,
+        instrument: .defaultTestInstrument, position: 1))
+    let groupC = try await backend.accountGroups.create(
+      AccountGroup(
+        name: "C", bucket: .investments,
+        instrument: .defaultTestInstrument, position: 2))
+
+    try await backend.groupUIState.setExpanded(true, for: groupA.id)
+    try await backend.groupUIState.setExpanded(false, for: groupB.id)
+    try await backend.groupUIState.setExpanded(true, for: groupC.id)
+
+    let expanded = try await backend.groupUIState.expandedGroupIds()
+    #expect(expanded == [groupA.id, groupC.id])
+  }
+
+  @Test("expandedGroupIds is empty when nothing has been set")
+  func expandedGroupIdsEmpty() async throws {
+    let (backend, _) = try TestBackend.create()
+    let expanded = try await backend.groupUIState.expandedGroupIds()
+    #expect(expanded.isEmpty)
+  }
+
+  @Test("deleting a group cascades the UI-state row away")
+  func cascadeReapsUIStateRow() async throws {
+    let (backend, _) = try TestBackend.create()
+    let group = try await backend.accountGroups.create(
+      AccountGroup(
+        name: "Doomed", bucket: .investments,
+        instrument: .defaultTestInstrument))
+    try await backend.groupUIState.setExpanded(true, for: group.id)
+    try await backend.accountGroups.delete(id: group.id)
+    let expanded = try await backend.groupUIState.isExpanded(groupId: group.id)
+    #expect(expanded == false)
+    let allExpanded = try await backend.groupUIState.expandedGroupIds()
+    #expect(allExpanded.contains(group.id) == false)
+  }
+
+  @Test("observeExpandedGroupIds emits initial snapshot")
+  func observeInitialSnapshot() async throws {
+    let (backend, _) = try TestBackend.create()
+    let group = try await backend.accountGroups.create(
+      AccountGroup(
+        name: "Seeded", bucket: .investments,
+        instrument: .defaultTestInstrument))
+    try await backend.groupUIState.setExpanded(true, for: group.id)
+
+    var iterator = backend.groupUIState.observeExpandedGroupIds().makeAsyncIterator()
+    let initial = await iterator.next()
+    #expect(initial == [group.id])
+  }
+
+  @Test("observeExpandedGroupIds emits on set")
+  func observeEmitsOnSet() async throws {
+    let (backend, _) = try TestBackend.create()
+    let group = try await backend.accountGroups.create(
+      AccountGroup(
+        name: "Watched", bucket: .investments,
+        instrument: .defaultTestInstrument))
+
+    var iterator = backend.groupUIState.observeExpandedGroupIds().makeAsyncIterator()
+    let initial = await iterator.next()
+    #expect(initial?.isEmpty == true)
+
+    try await backend.groupUIState.setExpanded(true, for: group.id)
+    let afterSet = await iterator.next()
+    #expect(afterSet == [group.id])
+  }
+}

--- a/MoolahTests/Features/AuthStoreTests.swift
+++ b/MoolahTests/Features/AuthStoreTests.swift
@@ -126,6 +126,7 @@ private struct TestAuthBackend: BackendProvider {
   let csvImportProfiles: any CSVImportProfileRepository
   let importRules: any ImportRuleRepository
   let walletSyncState: any WalletSyncStateRepository
+  let groupUIState: any GroupUIStateRepository
 
   init(auth: any AuthProvider) throws {
     let (backend, _) = try TestBackend.create()
@@ -142,6 +143,7 @@ private struct TestAuthBackend: BackendProvider {
     self.csvImportProfiles = backend.csvImportProfiles
     self.importRules = backend.importRules
     self.walletSyncState = backend.walletSyncState
+    self.groupUIState = backend.groupUIState
   }
 }
 

--- a/MoolahTests/Features/GroupUIStateStoreTests.swift
+++ b/MoolahTests/Features/GroupUIStateStoreTests.swift
@@ -1,0 +1,128 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("GroupUIStateStore — load, observe, toggle")
+@MainActor
+struct GroupUIStateStoreTests {
+  @Test("initial emission is empty")
+  func initialEmissionEmpty() async throws {
+    let (backend, _) = try TestBackend.create()
+    let store = GroupUIStateStore(repository: backend.groupUIState)
+    try await store.waitForFirstEmission()
+    #expect(store.expandedGroupIds.isEmpty)
+  }
+
+  @Test("setExpanded(true) is reflected via the observation stream")
+  func setExpandedTrueObserved() async throws {
+    let (backend, _) = try TestBackend.create()
+    let store = GroupUIStateStore(repository: backend.groupUIState)
+    try await store.waitForFirstEmission()
+
+    let group = try await backend.accountGroups.create(
+      AccountGroup(
+        name: "G", bucket: .investments, instrument: .defaultTestInstrument))
+
+    await store.setExpanded(true, for: group.id)
+    try await store.waitForNextEmission(
+      matching: { $0.expandedGroupIds.contains(group.id) },
+      description: "expanded observed")
+
+    #expect(store.expandedGroupIds == [group.id])
+    #expect(store.error == nil)
+  }
+
+  @Test("setExpanded(false) removes from the snapshot")
+  func setExpandedFalseObserved() async throws {
+    let (backend, _) = try TestBackend.create()
+    let store = GroupUIStateStore(repository: backend.groupUIState)
+    try await store.waitForFirstEmission()
+
+    let group = try await backend.accountGroups.create(
+      AccountGroup(
+        name: "G", bucket: .investments, instrument: .defaultTestInstrument))
+
+    await store.setExpanded(true, for: group.id)
+    try await store.waitForNextEmission(
+      matching: { $0.expandedGroupIds.contains(group.id) },
+      description: "expanded observed")
+
+    await store.setExpanded(false, for: group.id)
+    try await store.waitForNextEmission(
+      matching: { $0.expandedGroupIds.isEmpty },
+      description: "collapsed observed")
+
+    #expect(store.expandedGroupIds.isEmpty)
+  }
+
+  @Test("toggle flips the expand state")
+  func toggleFlipsState() async throws {
+    let (backend, _) = try TestBackend.create()
+    let store = GroupUIStateStore(repository: backend.groupUIState)
+    try await store.waitForFirstEmission()
+
+    let group = try await backend.accountGroups.create(
+      AccountGroup(
+        name: "G", bucket: .investments, instrument: .defaultTestInstrument))
+
+    await store.toggle(group.id)
+    try await store.waitForNextEmission(
+      matching: { $0.expandedGroupIds.contains(group.id) },
+      description: "toggle to expanded")
+    #expect(store.expandedGroupIds == [group.id])
+
+    await store.toggle(group.id)
+    try await store.waitForNextEmission(
+      matching: { $0.expandedGroupIds.isEmpty },
+      description: "toggle to collapsed")
+    #expect(store.expandedGroupIds.isEmpty)
+  }
+
+  @Test("multiple expanded groups all appear in the snapshot")
+  func multipleExpandedGroups() async throws {
+    let (backend, _) = try TestBackend.create()
+    let store = GroupUIStateStore(repository: backend.groupUIState)
+    try await store.waitForFirstEmission()
+
+    let groupA = try await backend.accountGroups.create(
+      AccountGroup(
+        name: "A", bucket: .investments,
+        instrument: .defaultTestInstrument, position: 0))
+    let groupB = try await backend.accountGroups.create(
+      AccountGroup(
+        name: "B", bucket: .investments,
+        instrument: .defaultTestInstrument, position: 1))
+
+    await store.setExpanded(true, for: groupA.id)
+    await store.setExpanded(true, for: groupB.id)
+    try await store.waitForNextEmission(
+      matching: { $0.expandedGroupIds.count == 2 },
+      description: "both observed")
+
+    #expect(store.expandedGroupIds == [groupA.id, groupB.id])
+  }
+
+  @Test("deleting a group reaps its expand state through the cascade")
+  func deletedGroupReapedFromStore() async throws {
+    let (backend, _) = try TestBackend.create()
+    let store = GroupUIStateStore(repository: backend.groupUIState)
+    try await store.waitForFirstEmission()
+
+    let group = try await backend.accountGroups.create(
+      AccountGroup(
+        name: "Doomed", bucket: .investments,
+        instrument: .defaultTestInstrument))
+    await store.setExpanded(true, for: group.id)
+    try await store.waitForNextEmission(
+      matching: { $0.expandedGroupIds.contains(group.id) },
+      description: "expanded observed")
+
+    try await backend.accountGroups.delete(id: group.id)
+    try await store.waitForNextEmission(
+      matching: { $0.expandedGroupIds.isEmpty },
+      description: "cascade observed")
+
+    #expect(store.expandedGroupIds.isEmpty)
+  }
+}

--- a/MoolahTests/Support/CloudKitAnalysisTestBackend.swift
+++ b/MoolahTests/Support/CloudKitAnalysisTestBackend.swift
@@ -23,6 +23,7 @@ struct CloudKitAnalysisTestBackend: BackendProvider, @unchecked Sendable {
   let csvImportProfiles: any CSVImportProfileRepository
   let importRules: any ImportRuleRepository
   let walletSyncState: any WalletSyncStateRepository
+  let groupUIState: any GroupUIStateRepository
 
   /// The GRDB queue backing every repository — exposed so tests can seed
   /// rows alongside the standard repository APIs.
@@ -80,6 +81,7 @@ struct CloudKitAnalysisTestBackend: BackendProvider, @unchecked Sendable {
     self.csvImportProfiles = backend.csvImportProfiles
     self.importRules = backend.importRules
     self.walletSyncState = backend.walletSyncState
+    self.groupUIState = backend.groupUIState
   }
 }
 

--- a/MoolahTests/Support/TestableStoreObservation.swift
+++ b/MoolahTests/Support/TestableStoreObservation.swift
@@ -195,6 +195,13 @@ extension AccountGroupStore: TestableStoreObservation {
   var snapshot: AccountGroupStore { self }
 }
 
+extension GroupUIStateStore: TestableStoreObservation {
+  var observationTicks: AsyncStream<Void> { testObservationTickStream }
+  /// Tests assert directly against published `@Observable` state; the
+  /// snapshot is the store itself.
+  var snapshot: GroupUIStateStore { self }
+}
+
 extension EarmarkStore: TestableStoreObservation {
   var observationTicks: AsyncStream<Void> { testObservationTickStream }
   /// Tests assert directly against published `@Observable` state; the


### PR DESCRIPTION
## Summary

Phase 8 of the Account Groups feature: each group's `isExpandedInSidebar` preference now survives app launches. Per-profile, local-only — never synced via CloudKit (intentional; expand state is per-device UX preference, not data).

- **v15 GRDB migration** — adds the local-only `account_group_ui` table on the per-profile `data.sqlite`. STRICT, single `group_id BLOB PRIMARY KEY` + `is_expanded INTEGER NOT NULL DEFAULT 0`. FK with `ON DELETE CASCADE` against `account_group(id)` reaps the row automatically when the parent group is deleted. Safe because the table is never written from the sync apply path.
- **`GroupUIStateRepository` protocol + `GRDBGroupUIStateRepository`** — narrow surface: `isExpanded` / `setExpanded` / `expandedGroupIds()` / `observeExpandedGroupIds()` + `observeErrors()`. Wired into every `BackendProvider` conformer.
- **`GroupUIStateStore`** — `@MainActor` / `@Observable` reactive store mirroring `AccountGroupStore`. Subscribes in `init`, exposes `expandedGroupIds: Set<UUID>`, routes mutations through the repo. Constructed in `ProfileSession.finishInit`, injected via `SessionRootView`.
- **`SidebarView`** — Phase 4's `@State expandedGroupIds: Set<UUID>` is replaced by an environment-store-backed binding. The two creation flows in `SidebarView+Groups.swift` that previously inserted into the in-memory set now call `store.setExpanded(true, ...)` so the persisted state matches the visible state.

Stacked on #986 (sidebar-groups / Phase 4). Base will retarget to `main` once #986 merges.

## Test plan

- [x] `just format-check`
- [x] `just test-mac` — 3325 tests pass, including new v15 migration tests, `GroupUIStateRepository` contract tests, and `GroupUIStateStore` store tests
- [x] `just test` — 3292 iOS + 3325 macOS tests pass
- [x] Golden-schema test updated to include `account_group_ui`
- [ ] Manual: open the app, expand a group, quit + relaunch → group stays expanded (covered by the contract tests at the DB layer; recommend a quick smoke pre-merge)
- [ ] Manual: delete a group whose UI-state row was 1 → no orphan-row warning in logs (covered by the migration cascade test + contract test)

## What's NOT in this phase

- Cross-device sync of expand state (intentional — would be a different feature)
- A "Reset all expand state" UI affordance (out of scope; users can drop the local DB)
- Persistence of the bucket-section expand state (handled by SwiftUI's `Section`)