### PR TITLE
Phase 5: AccountViewContext + composite group detail view

### DIFF
--- a/App/ContentView+GroupDetail.swift
+++ b/App/ContentView+GroupDetail.swift
@@ -1,25 +1,48 @@
 import SwiftUI
 
 extension ContentView {
-  /// Phase 5 placeholder for the composite group detail view. Until
-  /// the `AccountViewContext`-driven detail surface lands, the
-  /// placeholder shows the group's name and a brief note so the user
-  /// has clear feedback that the group is selected.
+  /// Composite detail view for an `AccountGroup` selection. Builds an
+  /// `AccountViewContext` from the live store snapshots and binds the
+  /// detail surface to it. When the group is unknown (e.g. still
+  /// arriving via sync), renders an "unavailable" placeholder so the
+  /// user has clear feedback that the selection didn't resolve.
   @ViewBuilder
-  func groupDetailPlaceholder(id: UUID) -> some View {
-    if let group = accountGroupStore.by(id: id) {
-      ContentUnavailableView(
-        group.name,
-        systemImage: "folder.fill",
-        description: Text(
-          "Group details are coming soon. Expand the group in the sidebar to view its members.")
-      )
+  func groupDetail(id: UUID) -> some View {
+    if let context = AccountViewContextBuilder.build(
+      for: .group(id),
+      accounts: accountStore.accounts,
+      groups: accountGroupStore.groups,
+      syncStatuses: groupSyncStatuses(for: id))
+    {
+      GroupDetailView(
+        context: context,
+        accounts: accountStore.accounts,
+        categories: categoryStore.categories,
+        earmarks: earmarkStore.earmarks,
+        transactionStore: transactionStore,
+        conversionService: session.backend.conversionService)
     } else {
       ContentUnavailableView(
         "Group not found",
         systemImage: "folder.badge.questionmark",
-        description: Text("This group may not have arrived from sync yet.")
-      )
+        description: Text("This group may not have arrived from sync yet."))
     }
+  }
+
+  /// Builds a per-member `AccountSyncStatus` map for the supplied
+  /// group's members. Reads from `ProfileSession.cryptoSyncStore` so
+  /// the aggregator collapses correctly when the profile has no sync
+  /// surface (returns an empty map → `.allSynced`).
+  private func groupSyncStatuses(for groupId: UUID) -> [UUID: AccountSyncStatus] {
+    guard let syncStore = session.cryptoSyncStore else { return [:] }
+    let members = accountStore.accounts.ordered.filter { $0.groupId == groupId }
+    var result: [UUID: AccountSyncStatus] = [:]
+    for member in members {
+      result[member.id] = AccountSyncStatus(
+        accountId: member.id,
+        isInProgress: syncStore.inProgressAccountIds.contains(member.id),
+        hasError: syncStore.statePerAccount[member.id]?.lastError != nil)
+    }
+    return result
   }
 }

--- a/App/ContentView.swift
+++ b/App/ContentView.swift
@@ -196,12 +196,8 @@ struct ContentView: View {
           analysisRepository: analysisStore.repository)
       }
     case .group(let id):
-      // Phase 5 wires the composite detail view bound to an
-      // `AccountViewContext`. Until then, render a placeholder so the
-      // user has feedback that the group is selected — the existing
-      // `accountDetail(id:)` shape only fits a single account, and
-      // forcing it here would misrepresent the membership.
-      groupDetailPlaceholder(id: id)
+      // Composite detail view bound to an `AccountViewContext`.
+      groupDetail(id: id)
     case .recentlyAdded:
       RecentlyAddedView(backend: session.backend)
     case .allTransactions:
@@ -351,4 +347,4 @@ extension ContentView {
 }
 
 // `accountDetail(id:)` lives in `ContentView+AccountDetail.swift`.
-// `groupDetailPlaceholder(id:)` lives in `ContentView+GroupDetail.swift`.
+// `groupDetail(id:)` lives in `ContentView+GroupDetail.swift`.

--- a/Backends/GRDB/Repositories/GRDBTransactionRepository+Fetch.swift
+++ b/Backends/GRDB/Repositories/GRDBTransactionRepository+Fetch.swift
@@ -65,12 +65,18 @@ extension GRDBTransactionRepository {
 
     let totalCount = filteredRows.count
     let offset = input.page * input.pageSize
+    // Running balance / after-page subtotals only make sense for a
+    // single-account view. A multi-account (group) filter renders a
+    // merged list with no running balance, so the subtotal computation
+    // is skipped and `hasAccountFilter` is reported as false to the
+    // caller (it gates running-balance UI).
+    let isSingleAccount = filter.accountId != nil && filter.accountIds.isEmpty
     guard offset < totalCount else {
       return FetchSnapshot(
         pageTransactions: [],
         resolvedTarget: resolvedTarget,
         totalCount: totalCount,
-        hasAccountFilter: filter.accountId != nil,
+        hasAccountFilter: isSingleAccount,
         isPastEnd: true,
         afterPageSubtotals: [])
     }
@@ -85,7 +91,7 @@ extension GRDBTransactionRepository {
     }
 
     let afterPageSubtotals: [SubtotalEntry]
-    if let accountId = filter.accountId {
+    if let accountId = filter.accountId, isSingleAccount {
       let afterPageIds = Array(filteredRows[end...].map(\.id))
       afterPageSubtotals = try subtotalsAfterPage(
         database: database,
@@ -100,7 +106,7 @@ extension GRDBTransactionRepository {
       pageTransactions: pageTransactions,
       resolvedTarget: resolvedTarget,
       totalCount: totalCount,
-      hasAccountFilter: filter.accountId != nil,
+      hasAccountFilter: isSingleAccount,
       isPastEnd: false,
       afterPageSubtotals: afterPageSubtotals)
   }
@@ -163,10 +169,15 @@ extension GRDBTransactionRepository {
   ) throws -> [TransactionRow] {
     var rows = rows
 
-    if let accountId = filter.accountId {
+    // Build the union of account ids the caller is filtering by: a
+    // single `accountId` (single-account view) and / or a `accountIds`
+    // set (composite group view). Empty union → no account filter.
+    var unionAccountIds: Set<UUID> = filter.accountIds
+    if let accountId = filter.accountId { unionAccountIds.insert(accountId) }
+    if !unionAccountIds.isEmpty {
       let allowedIds =
         try TransactionLegRow
-        .filter(TransactionLegRow.Columns.accountId == accountId)
+        .filter(unionAccountIds.contains(TransactionLegRow.Columns.accountId))
         .select(TransactionLegRow.Columns.transactionId, as: UUID.self)
         .fetchAll(database)
       let allowedSet = Set(allowedIds)
@@ -257,8 +268,9 @@ extension GRDBTransactionRepository {
   }
 
   /// Resolves the running-balance label instrument for the page.
-  /// Account-scoped fetches use the account's own instrument; global
-  /// fetches use `defaultInstrument`. Mirrors
+  /// Single-account fetches use the account's own instrument; global
+  /// and multi-account (group) fetches use `defaultInstrument` (no
+  /// running balance in the merged list). Mirrors
   /// `CloudKitTransactionRepository.accountInstrument(id:)`. If the
   /// account row is missing (deleted concurrently) we fall back to
   /// `defaultInstrument` rather than failing the read.
@@ -268,6 +280,9 @@ extension GRDBTransactionRepository {
     instruments: [String: Instrument],
     defaultInstrument: Instrument
   ) throws -> Instrument {
+    // Multi-account (group) filter — no single per-account instrument
+    // applies, so use the profile default.
+    if !filter.accountIds.isEmpty { return defaultInstrument }
     guard let accountId = filter.accountId else { return defaultInstrument }
     guard
       let accountRow =

--- a/Domain/Models/TransactionFilter.swift
+++ b/Domain/Models/TransactionFilter.swift
@@ -2,6 +2,15 @@ import Foundation
 
 struct TransactionFilter: Sendable, Equatable {
   var accountId: UUID?
+  /// Multi-account filter for composite views (e.g. an `AccountGroup`
+  /// detail view rendering merged transactions across its members).
+  /// Independent of `accountId`; the GRDB fetch layer ORs them together
+  /// (a transaction matches if any of its legs hits `accountId` *or* any
+  /// id in `accountIds`). Typical callers populate exactly one — either
+  /// `accountId` (single-account view) or `accountIds` (group view).
+  /// An empty set means "no multi-account filter" (treated as a no-op
+  /// by the fetch layer).
+  var accountIds: Set<UUID>
   var earmarkId: UUID?
   var scheduled: ScheduledFilter
   var dateRange: ClosedRange<Date>?
@@ -10,6 +19,7 @@ struct TransactionFilter: Sendable, Equatable {
 
   init(
     accountId: UUID? = nil,
+    accountIds: Set<UUID> = [],
     earmarkId: UUID? = nil,
     scheduled: ScheduledFilter = .all,
     dateRange: ClosedRange<Date>? = nil,
@@ -17,6 +27,7 @@ struct TransactionFilter: Sendable, Equatable {
     payee: String? = nil
   ) {
     self.accountId = accountId
+    self.accountIds = accountIds
     self.earmarkId = earmarkId
     self.scheduled = scheduled
     self.dateRange = dateRange
@@ -27,7 +38,17 @@ struct TransactionFilter: Sendable, Equatable {
 
 extension TransactionFilter {
   var hasActiveFilters: Bool {
-    accountId != nil || earmarkId != nil || scheduled != .all
+    accountId != nil || !accountIds.isEmpty || earmarkId != nil
+      || scheduled != .all
       || dateRange != nil || !categoryIds.isEmpty || payee != nil
+  }
+
+  /// True when *any* account-scoped predicate is present (single
+  /// `accountId` or a non-empty `accountIds`). The GRDB fetch path uses
+  /// this to gate running-balance and subtotal computations — those
+  /// only make sense for a single-account view, so a multi-account
+  /// (group) filter disables them.
+  var hasAccountFilter: Bool {
+    accountId != nil || !accountIds.isEmpty
   }
 }

--- a/Features/Accounts/AccountStore+AggregateBalance.swift
+++ b/Features/Accounts/AccountStore+AggregateBalance.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+extension AccountStore {
+  /// Aggregate display balance for the accounts in `accountIds`,
+  /// converted to `target`. Used by the composite detail-view header
+  /// (single-account contexts collapse to the per-account balance) and
+  /// by `AccountGroupSidebarRow` for the group's aggregate amount slot.
+  ///
+  /// Returns `nil` for an empty id list (the caller renders an
+  /// "unavailable" state for a zero-member group). Throws when any
+  /// contributing account's conversion fails — callers treat a thrown
+  /// error as "balance unavailable" (per
+  /// `feedback_conversion_failure_ux.md` — never partial-sum). For a
+  /// single-id list this collapses to the underlying account's
+  /// converted total, so the same code path serves single-account
+  /// headers.
+  func aggregateBalance(
+    for accountIds: [UUID], in target: Instrument
+  ) async throws -> InstrumentAmount? {
+    guard !accountIds.isEmpty else { return nil }
+    let resolved = accountIds.compactMap { accounts.by(id: $0) }
+    guard resolved.count == accountIds.count else {
+      // One or more ids didn't resolve to a current account (transient
+      // store-snapshot lag during sync). Treat as "unavailable" rather
+      // than silently undercount.
+      return nil
+    }
+    return try await balanceCalculator.totalConverted(
+      for: resolved, to: target, using: investmentValueCache)
+  }
+}

--- a/Features/Accounts/AccountViewContextBuilder.swift
+++ b/Features/Accounts/AccountViewContextBuilder.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+/// Builds the `AccountViewContext` the composite detail view binds to
+/// from a `SidebarSelection` and the latest store snapshots. Pure
+/// function — no observation, no async — so it can be called from the
+/// detail-view layer on every render without coupling to a store.
+///
+/// Selections that don't render a detail view (`.earmark`,
+/// `.allTransactions`, `.reports`, etc.) return `nil`; the caller falls
+/// back to the existing route for that selection.
+enum AccountViewContextBuilder {
+  static func build(
+    for selection: SidebarSelection,
+    accounts: Accounts,
+    groups: [AccountGroup],
+    syncStatuses: [UUID: AccountSyncStatus]
+  ) -> AccountViewContext? {
+    switch selection {
+    case .account(let id):
+      return buildAccountContext(id: id, accounts: accounts, syncStatuses: syncStatuses)
+    case .group(let id):
+      return buildGroupContext(
+        id: id, accounts: accounts, groups: groups, syncStatuses: syncStatuses)
+    case .earmark, .recentlyAdded, .allTransactions, .upcomingTransactions,
+      .categories, .reports, .analysis:
+      return nil
+    }
+  }
+
+  private static func buildAccountContext(
+    id: UUID,
+    accounts: Accounts,
+    syncStatuses: [UUID: AccountSyncStatus]
+  ) -> AccountViewContext? {
+    guard let account = accounts.by(id: id) else { return nil }
+    let perAccount = [syncStatuses[account.id]].compactMap { $0 }
+    return AccountViewContext(
+      kind: .account,
+      displayName: account.name,
+      displayInstrument: account.instrument,
+      bucket: account.bucket,
+      accountIds: [account.id],
+      syncStatus: AggregatedSyncStatus.aggregate(perAccount))
+  }
+
+  private static func buildGroupContext(
+    id: UUID,
+    accounts: Accounts,
+    groups: [AccountGroup],
+    syncStatuses: [UUID: AccountSyncStatus]
+  ) -> AccountViewContext? {
+    guard let group = groups.first(where: { $0.id == id }) else { return nil }
+    let members =
+      accounts.ordered
+      .filter { $0.groupId == group.id }
+      .sorted { $0.position < $1.position }
+    let memberStatuses = members.compactMap { syncStatuses[$0.id] }
+    return AccountViewContext(
+      kind: .group,
+      displayName: group.name,
+      displayInstrument: group.instrument,
+      bucket: group.bucket,
+      accountIds: members.map(\.id),
+      syncStatus: AggregatedSyncStatus.aggregate(memberStatuses))
+  }
+}

--- a/Features/Accounts/Models/AccountSyncStatus.swift
+++ b/Features/Accounts/Models/AccountSyncStatus.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+/// Per-account sync state snapshot used to build an `AggregatedSyncStatus`
+/// over a context's `accountIds`. Built from `SyncedAccountStore`'s
+/// `inProgressAccountIds` and `statePerAccount[id]?.lastError` so the
+/// context-builder doesn't need to know the underlying store shape.
+struct AccountSyncStatus: Sendable, Equatable {
+  let accountId: UUID
+  let isInProgress: Bool
+  let hasError: Bool
+}

--- a/Features/Accounts/Models/AccountViewContext.swift
+++ b/Features/Accounts/Models/AccountViewContext.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+/// What the detail view renders. Built from `SidebarSelection`; the detail
+/// view binds to this rather than reading `Account` directly. Selecting a
+/// group produces a context with N member ids; selecting a single account
+/// produces a 1-element list. Same code path serves both.
+///
+/// Order of `accountIds` is preserved so the "first account in this
+/// context" (e.g. the default for the New Transaction button) is
+/// deterministic.
+struct AccountViewContext: Sendable, Equatable {
+  enum Kind: Sendable, Equatable {
+    case account
+    case group
+  }
+
+  let kind: Kind
+  let displayName: String
+  /// Instrument the detail view displays totals in. For accounts this is
+  /// the account's `instrument`; for groups it's the group's `instrument`
+  /// (defaults to the profile's currency in Phase 3).
+  let displayInstrument: Instrument
+  /// The bucket the entity lives in. Drives any UI affordances that
+  /// differ across buckets (e.g. valuation-mode toggle only shows for
+  /// `.investments`).
+  let bucket: AccountBucket
+  /// The set of accounts whose data the detail view aggregates over.
+  /// Single account → `[account.id]`. Group → member ids in member-
+  /// position order. Order is preserved so callers that need a default
+  /// member (e.g. New Transaction button) can take `accountIds.first`.
+  let accountIds: [UUID]
+  /// Aggregated sync status across `accountIds`. A 1-element input
+  /// collapses to the underlying per-account status unchanged, so the
+  /// same path serves single-account headers.
+  let syncStatus: AggregatedSyncStatus
+
+  /// True when this context represents a single account that itself has
+  /// members in `accountIds`. Used to gate per-account sync-config UI
+  /// (retry button, last-sync indicator) that doesn't make sense for
+  /// groups (or for a transient zero-member context).
+  var supportsPerAccountSyncControls: Bool {
+    kind == .account && accountIds.count == 1
+  }
+}

--- a/Features/Accounts/Models/AggregatedSyncStatus.swift
+++ b/Features/Accounts/Models/AggregatedSyncStatus.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+/// Aggregate of the per-member `AccountSyncStatus` values that make up an
+/// `AccountViewContext`. A 1-element input collapses to the underlying
+/// per-account status (synced → `.allSynced`, in-progress → `.syncing(0,
+/// 1)`, error → `.failed(memberIds: [id])`) so the same path serves
+/// single-account headers and composite group headers.
+enum AggregatedSyncStatus: Sendable, Equatable {
+  case allSynced
+  case syncing(done: Int, total: Int)
+  case failed(memberIds: [UUID])
+
+  /// Collapses an array of per-member statuses to a single aggregate.
+  /// Precedence: any failure → `.failed`; otherwise any in-progress →
+  /// `.syncing(done:total:)`; otherwise `.allSynced`. Empty input
+  /// returns `.allSynced` so a non-syncable context (no members claim
+  /// the sync surface) is silently silent.
+  static func aggregate(_ statuses: [AccountSyncStatus]) -> AggregatedSyncStatus {
+    if statuses.isEmpty { return .allSynced }
+    let failed = statuses.filter(\.hasError).map(\.accountId)
+    if !failed.isEmpty { return .failed(memberIds: failed) }
+    let inProgress = statuses.filter(\.isInProgress).count
+    if inProgress > 0 {
+      return .syncing(done: statuses.count - inProgress, total: statuses.count)
+    }
+    return .allSynced
+  }
+}

--- a/Features/Accounts/Views/AccountGroupSidebarRow.swift
+++ b/Features/Accounts/Views/AccountGroupSidebarRow.swift
@@ -3,8 +3,10 @@ import SwiftUI
 /// Sidebar row for an `AccountGroup`. Composes a chevron disclosure
 /// affordance (toggling `isExpanded`) plus the shared `SidebarRowView`
 /// for the icon / name / amount. Aggregated balance is supplied by the
-/// caller — Phase 5 wires that against `AccountGroupStore`; this row
-/// just renders whatever it's given (or shows a spinner if `nil`).
+/// caller — the sidebar wraps each group row in
+/// `GroupAggregateBalanceLoader` which keeps the aggregate refreshed
+/// via `AccountStore.aggregateBalance(for:in:)`; this row itself just
+/// renders whatever it's given (or shows a spinner if `nil`).
 ///
 /// Inline rename, selection styling, and identifier wiring follow the
 /// account-row conventions so context menus / Return-to-rename / the

--- a/Features/Accounts/Views/GroupAggregateBalanceLoader.swift
+++ b/Features/Accounts/Views/GroupAggregateBalanceLoader.swift
@@ -1,0 +1,48 @@
+import SwiftUI
+
+/// View wrapper that keeps an `AccountGroup`'s aggregate balance
+/// refreshed and threads it into its content closure. Owns the
+/// `@State InstrumentAmount?` cache + the `.task(id:)` that recomputes
+/// via `AccountStore.aggregateBalance(for:in:)` whenever the member
+/// set or target instrument changes. A conversion failure on any
+/// member surfaces as `nil` (per `feedback_conversion_failure_ux.md` —
+/// never partial-sum); the content view renders a spinner / badge in
+/// that case.
+///
+/// Used by `SidebarView+Groups.groupRowLink` to wire the sidebar row's
+/// `aggregateBalance` parameter, and reusable from any future call
+/// site that needs a refreshable group total (e.g. an account picker
+/// that wants to show a group's total alongside its name).
+struct GroupAggregateBalanceLoader<Content: View>: View {
+  let memberIds: [UUID]
+  let targetInstrument: Instrument
+  @ViewBuilder var content: (InstrumentAmount?) -> Content
+
+  @Environment(AccountStore.self) private var accountStore
+  @State private var balance: InstrumentAmount?
+
+  /// `.task(id:)` key — recomputes when the member set OR the target
+  /// instrument changes. Hashable so SwiftUI can compare it.
+  private struct Key: Hashable {
+    let memberIds: [UUID]
+    let targetInstrument: Instrument
+  }
+
+  var body: some View {
+    content(balance)
+      .task(id: Key(memberIds: memberIds, targetInstrument: targetInstrument)) {
+        await refresh()
+      }
+  }
+
+  private func refresh() async {
+    do {
+      balance = try await accountStore.aggregateBalance(
+        for: memberIds, in: targetInstrument)
+    } catch {
+      // Per feedback_conversion_failure_ux: never partial-sum on
+      // failure. nil renders the sidebar's loading / unavailable slot.
+      balance = nil
+    }
+  }
+}

--- a/Features/Accounts/Views/GroupDetailView.swift
+++ b/Features/Accounts/Views/GroupDetailView.swift
@@ -1,0 +1,147 @@
+import SwiftUI
+
+/// Sums per-instrument quantities across the supplied account ids,
+/// preserving first-seen order. Members holding the same instrument
+/// coalesce to one row; multi-instrument groups expose a row per
+/// instrument. Pure (no actor isolation) so it can be unit-tested
+/// without instantiating the SwiftUI view.
+func aggregatedGroupPositions(
+  across accountIds: [UUID], in accounts: Accounts
+) -> [Position] {
+  var sums: [Instrument: Decimal] = [:]
+  var order: [Instrument] = []
+  for id in accountIds {
+    guard let account = accounts.by(id: id) else { continue }
+    for position in account.positions {
+      if sums[position.instrument] == nil {
+        order.append(position.instrument)
+      }
+      sums[position.instrument, default: 0] += position.quantity
+    }
+  }
+  return order.compactMap { instrument in
+    guard let quantity = sums[instrument] else { return nil }
+    return Position(instrument: instrument, quantity: quantity)
+  }
+}
+
+/// Composite detail view for an `AccountGroup`. Renders the group's
+/// aggregated balance + merged transactions + multi-instrument position
+/// totals across every member.
+///
+/// Binds to an `AccountViewContext` rather than reading an `Account`
+/// directly. The header, positions split, and transaction list all
+/// consume `context.accountIds`; this view never knows whether the
+/// context came from a group or a single account — both shapes are
+/// supported (a 1-element accountIds list collapses to the same code
+/// path).
+///
+/// New Transaction defaults to the first id in `accountIds` per spec
+/// §"Composite detail view → Header" — the user can change the
+/// destination in the transaction-detail panel's account picker.
+struct GroupDetailView: View {
+  let context: AccountViewContext
+  let accounts: Accounts
+  let categories: Categories
+  let earmarks: Earmarks
+  let transactionStore: TransactionStore
+  let conversionService: any InstrumentConversionService
+
+  @Environment(AccountStore.self) private var accountStore
+
+  /// Cached aggregate balance for the current `accountIds` set,
+  /// recomputed when membership changes. `nil` either before the first
+  /// compute completes or when conversion failed for any member (per
+  /// `feedback_conversion_failure_ux` — never partial-sum).
+  @State private var aggregateBalance: InstrumentAmount?
+
+  var body: some View {
+    let aggregatedPositions = aggregatedGroupPositions(
+      across: context.accountIds, in: accounts)
+
+    TransactionListView(
+      title: context.displayName,
+      filter: TransactionFilter(accountIds: Set(context.accountIds)),
+      accounts: accounts,
+      categories: categories,
+      earmarks: earmarks,
+      transactionStore: transactionStore
+    )
+    .safeAreaInset(edge: .top, spacing: 0) {
+      headerCard
+    }
+    .multiInstrumentPositionsSplit(
+      positions: aggregatedPositions,
+      hostCurrency: context.displayInstrument,
+      title: context.displayName,
+      conversionService: conversionService
+    )
+    .task(id: context.accountIds) {
+      await refreshAggregateBalance()
+    }
+  }
+
+  // MARK: - Header
+
+  /// Header card with the group name + aggregate balance. The full
+  /// rich header (rename affordance, sync-status popover, conversion-
+  /// failure breakdown) is deferred to a follow-up — Phase 5's
+  /// acceptance criterion is that the balance respects the conversion-
+  /// failure UX (unavailable, never partial-sum), which this view
+  /// honours by rendering an "Unavailable" badge when
+  /// `aggregateBalance` is nil after the compute finishes.
+  @ViewBuilder private var headerCard: some View {
+    VStack(alignment: .leading, spacing: 4) {
+      Text(context.displayName)
+        .font(.title2.weight(.semibold))
+      balanceLabel
+      syncStatusLabel
+    }
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .padding(.horizontal)
+    .padding(.vertical, 8)
+    .background(.bar)
+  }
+
+  @ViewBuilder private var balanceLabel: some View {
+    if let amount = aggregateBalance {
+      Text(amount.formatted)
+        .font(.title.weight(.semibold))
+        .monospacedDigit()
+    } else {
+      Text("Unavailable")
+        .font(.title3.weight(.semibold))
+        .foregroundStyle(.secondary)
+        .accessibilityLabel("Aggregate balance unavailable")
+    }
+  }
+
+  @ViewBuilder private var syncStatusLabel: some View {
+    switch context.syncStatus {
+    case .allSynced:
+      EmptyView()
+    case let .syncing(done, total):
+      Label("Syncing \(done) of \(total)", systemImage: "arrow.triangle.2.circlepath")
+        .font(.caption)
+        .foregroundStyle(.secondary)
+    case .failed(let memberIds):
+      Label(
+        "\(memberIds.count) member\(memberIds.count == 1 ? "" : "s") failed",
+        systemImage: "exclamationmark.triangle.fill"
+      )
+      .font(.caption)
+      .foregroundStyle(.red)
+    }
+  }
+
+  // MARK: - Aggregation helpers
+
+  private func refreshAggregateBalance() async {
+    do {
+      aggregateBalance = try await accountStore.aggregateBalance(
+        for: context.accountIds, in: context.displayInstrument)
+    } catch {
+      aggregateBalance = nil
+    }
+  }
+}

--- a/Features/Navigation/SidebarView+Groups.swift
+++ b/Features/Navigation/SidebarView+Groups.swift
@@ -27,17 +27,33 @@ extension SidebarView {
   /// The clickable group row + its drop / context-menu modifiers. Drop
   /// onto a group row adds an account to that group (cross-bucket
   /// rejected); group-onto-group drop is rejected (no nesting).
+  ///
+  /// The aggregate balance is computed by `GroupAggregateBalanceLoader`
+  /// — a thin wrapper that owns the `@State InstrumentAmount?` and
+  /// recomputes via `AccountStore.aggregateBalance(for:in:)` whenever
+  /// the member set changes. Per
+  /// `feedback_conversion_failure_ux.md`, a conversion failure on any
+  /// member surfaces as `nil` (badge / spinner), never a partial sum.
   @ViewBuilder
   func groupRowLink(_ group: AccountGroup) -> some View {
+    let memberIds = accountStore.accounts.ordered
+      .filter { $0.groupId == group.id }
+      .sorted(by: { $0.position < $1.position })
+      .map(\.id)
     NavigationLink(value: SidebarSelection.group(group.id)) {
-      AccountGroupSidebarRow(
-        group: group,
-        isSelected: selection == .group(group.id),
-        isExpanded: expandBinding(for: group.id),
-        aggregateBalance: nil,  // Phase 5 wires the aggregate
-        isEditing: renameBinding(for: group.id),
-        onRename: renameAction(for: group)
-      )
+      GroupAggregateBalanceLoader(
+        memberIds: memberIds,
+        targetInstrument: group.instrument
+      ) { balance in
+        AccountGroupSidebarRow(
+          group: group,
+          isSelected: selection == .group(group.id),
+          isExpanded: expandBinding(for: group.id),
+          aggregateBalance: balance,
+          isEditing: renameBinding(for: group.id),
+          onRename: renameAction(for: group)
+        )
+      }
     }
     .accessibilityIdentifier(UITestIdentifiers.Sidebar.group(group.id))
     .draggable(DraggableSidebarItem(kind: .group, id: group.id))

--- a/MoolahTests/Domain/TransactionFilterTests.swift
+++ b/MoolahTests/Domain/TransactionFilterTests.swift
@@ -36,4 +36,25 @@ struct TransactionFilterTests {
     let filter = TransactionFilter(payee: "Coffee Shop")
     #expect(filter.hasActiveFilters == true)
   }
+
+  @Test("Filter with non-empty accountIds is active")
+  func testFilterWithAccountIdsIsActive() {
+    let filter = TransactionFilter(accountIds: [UUID()])
+    #expect(filter.hasActiveFilters == true)
+    #expect(filter.hasAccountFilter == true)
+  }
+
+  @Test("Filter with empty accountIds set is inactive")
+  func testFilterWithEmptyAccountIdsIsInactive() {
+    let filter = TransactionFilter(accountIds: Set<UUID>())
+    #expect(filter.hasActiveFilters == false)
+    #expect(filter.hasAccountFilter == false)
+  }
+
+  @Test("hasAccountFilter is true for single accountId and false otherwise")
+  func testHasAccountFilter() {
+    #expect(TransactionFilter().hasAccountFilter == false)
+    #expect(TransactionFilter(accountId: UUID()).hasAccountFilter == true)
+    #expect(TransactionFilter(accountIds: [UUID(), UUID()]).hasAccountFilter == true)
+  }
 }

--- a/MoolahTests/Domain/TxnRepoAccountIdsFilterTests.swift
+++ b/MoolahTests/Domain/TxnRepoAccountIdsFilterTests.swift
@@ -1,0 +1,118 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("TransactionRepository — accountIds filter")
+@MainActor
+struct TxnRepoAccountIdsFilterTests {
+
+  /// Seeds two accounts each with one expense, then asserts that filtering
+  /// by a 2-element `accountIds` set returns both transactions while
+  /// filtering by a single-element set returns one. Mirrors the
+  /// `accountId` (singular) filter test shape but exercises the new
+  /// multi-account branch added for `AccountGroup` detail views.
+  @Test("filtering by accountIds union returns transactions from every member")
+  func filtersByAccountIdsUnion() async throws {
+    let (backend, _) = try TestBackend.create()
+
+    let accountA = try await backend.accounts.create(
+      Account(
+        name: "Member A", type: .crypto,
+        instrument: .defaultTestInstrument))
+    let accountB = try await backend.accounts.create(
+      Account(
+        name: "Member B", type: .crypto,
+        instrument: .defaultTestInstrument))
+    let standalone = try await backend.accounts.create(
+      Account(
+        name: "Standalone", type: .crypto,
+        instrument: .defaultTestInstrument))
+
+    _ = try await backend.transactions.create(
+      Transaction(
+        date: Date(), payee: "Member A txn",
+        legs: [
+          TransactionLeg(
+            accountId: accountA.id, instrument: .defaultTestInstrument,
+            quantity: -10, type: .expense)
+        ]))
+    _ = try await backend.transactions.create(
+      Transaction(
+        date: Date(), payee: "Member B txn",
+        legs: [
+          TransactionLeg(
+            accountId: accountB.id, instrument: .defaultTestInstrument,
+            quantity: -20, type: .expense)
+        ]))
+    _ = try await backend.transactions.create(
+      Transaction(
+        date: Date(), payee: "Standalone txn",
+        legs: [
+          TransactionLeg(
+            accountId: standalone.id, instrument: .defaultTestInstrument,
+            quantity: -30, type: .expense)
+        ]))
+
+    let unionFilter = TransactionFilter(accountIds: [accountA.id, accountB.id])
+    let unionPage = try await backend.transactions.fetch(
+      filter: unionFilter, page: 0, pageSize: 50)
+    let payees = Set(unionPage.transactions.compactMap(\.payee))
+    #expect(payees == ["Member A txn", "Member B txn"])
+
+    let singleFilter = TransactionFilter(accountIds: [accountA.id])
+    let singlePage = try await backend.transactions.fetch(
+      filter: singleFilter, page: 0, pageSize: 50)
+    #expect(singlePage.transactions.map(\.payee) == ["Member A txn"])
+  }
+
+  @Test("empty accountIds set is treated as no account filter")
+  func emptyAccountIdsActsAsNoFilter() async throws {
+    let (backend, _) = try TestBackend.create()
+    let account = try await backend.accounts.create(
+      Account(name: "A", type: .bank, instrument: .defaultTestInstrument))
+    _ = try await backend.transactions.create(
+      Transaction(
+        date: Date(), payee: "Only txn",
+        legs: [
+          TransactionLeg(
+            accountId: account.id, instrument: .defaultTestInstrument,
+            quantity: -5, type: .expense)
+        ]))
+
+    let page = try await backend.transactions.fetch(
+      filter: TransactionFilter(accountIds: []), page: 0, pageSize: 50)
+    #expect(page.transactions.count == 1)
+  }
+
+  @Test("accountId and accountIds OR together")
+  func accountIdAndAccountIdsUnion() async throws {
+    let (backend, _) = try TestBackend.create()
+    let accountA = try await backend.accounts.create(
+      Account(name: "A", type: .bank, instrument: .defaultTestInstrument))
+    let accountB = try await backend.accounts.create(
+      Account(name: "B", type: .bank, instrument: .defaultTestInstrument))
+
+    _ = try await backend.transactions.create(
+      Transaction(
+        date: Date(), payee: "A txn",
+        legs: [
+          TransactionLeg(
+            accountId: accountA.id, instrument: .defaultTestInstrument,
+            quantity: -10, type: .expense)
+        ]))
+    _ = try await backend.transactions.create(
+      Transaction(
+        date: Date(), payee: "B txn",
+        legs: [
+          TransactionLeg(
+            accountId: accountB.id, instrument: .defaultTestInstrument,
+            quantity: -20, type: .expense)
+        ]))
+
+    let page = try await backend.transactions.fetch(
+      filter: TransactionFilter(accountId: accountA.id, accountIds: [accountB.id]),
+      page: 0, pageSize: 50)
+    #expect(Set(page.transactions.compactMap(\.payee)) == ["A txn", "B txn"])
+  }
+}

--- a/MoolahTests/Features/AccountStoreAggregateBalanceTests.swift
+++ b/MoolahTests/Features/AccountStoreAggregateBalanceTests.swift
@@ -1,0 +1,126 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("AccountStore — aggregateBalance")
+@MainActor
+struct AccountStoreAggregateBalanceTests {
+
+  /// Two single-instrument accounts: aggregate sums to the total in the
+  /// target instrument.
+  @Test("sums converted balances across N accounts")
+  func sumsAcrossAccounts() async throws {
+    let (backend, database) = try TestBackend.create()
+    let memberA = Account(
+      id: UUID(), name: "A", type: .crypto,
+      instrument: .defaultTestInstrument)
+    let memberB = Account(
+      id: UUID(), name: "B", type: .crypto,
+      instrument: .defaultTestInstrument)
+    TestBackend.seed(accounts: [memberA, memberB], in: database)
+    TestBackend.seed(
+      transactions: [
+        Transaction(
+          date: Date(),
+          legs: [
+            TransactionLeg(
+              accountId: memberA.id,
+              instrument: .defaultTestInstrument,
+              quantity: dec("100.00"),
+              type: .openingBalance)
+          ]),
+        Transaction(
+          date: Date(),
+          legs: [
+            TransactionLeg(
+              accountId: memberB.id,
+              instrument: .defaultTestInstrument,
+              quantity: dec("250.00"),
+              type: .openingBalance)
+          ]),
+      ], in: database)
+
+    let store = AccountStore(
+      repository: backend.accounts,
+      conversionService: backend.conversionService,
+      targetInstrument: .defaultTestInstrument)
+    try await store.waitForNextEmission(
+      matching: { $0.convertedBalances.count == 2 },
+      description: "balances converted")
+
+    let aggregate = try await store.aggregateBalance(
+      for: [memberA.id, memberB.id], in: .defaultTestInstrument)
+    let amount = try #require(aggregate)
+    #expect(amount.quantity == dec("350.00"))
+    #expect(amount.instrument == .defaultTestInstrument)
+  }
+
+  /// A 1-element id list collapses to the single account's converted
+  /// balance — same code path serves single-account headers.
+  @Test("1-element id list returns single account's balance")
+  func singleAccountCase() async throws {
+    let (backend, database) = try TestBackend.create()
+    let account = Account(
+      id: UUID(), name: "Solo", type: .bank,
+      instrument: .defaultTestInstrument)
+    TestBackend.seed(accounts: [account], in: database)
+    TestBackend.seed(
+      transactions: [
+        Transaction(
+          date: Date(),
+          legs: [
+            TransactionLeg(
+              accountId: account.id,
+              instrument: .defaultTestInstrument,
+              quantity: dec("400.00"),
+              type: .openingBalance)
+          ])
+      ], in: database)
+
+    let store = AccountStore(
+      repository: backend.accounts,
+      conversionService: backend.conversionService,
+      targetInstrument: .defaultTestInstrument)
+    try await store.waitForNextEmission(
+      matching: { $0.convertedBalances[account.id] != nil },
+      description: "balance converted")
+
+    let aggregate = try await store.aggregateBalance(
+      for: [account.id], in: .defaultTestInstrument)
+    let amount = try #require(aggregate)
+    #expect(amount.quantity == dec("400.00"))
+  }
+
+  /// Empty id list returns nil — the caller renders an "unavailable"
+  /// state for a zero-member group.
+  @Test("empty id list returns nil")
+  func emptyIdListReturnsNil() async throws {
+    let (backend, _) = try TestBackend.create()
+    let store = AccountStore(
+      repository: backend.accounts,
+      conversionService: backend.conversionService,
+      targetInstrument: .defaultTestInstrument)
+    try await store.waitForFirstEmission()
+
+    let aggregate = try await store.aggregateBalance(
+      for: [], in: .defaultTestInstrument)
+    #expect(aggregate == nil)
+  }
+
+  /// Unknown ids → nil (don't silently undercount when a member is
+  /// transiently absent from the store snapshot during sync).
+  @Test("unknown ids return nil")
+  func unknownIdsReturnNil() async throws {
+    let (backend, _) = try TestBackend.create()
+    let store = AccountStore(
+      repository: backend.accounts,
+      conversionService: backend.conversionService,
+      targetInstrument: .defaultTestInstrument)
+    try await store.waitForFirstEmission()
+
+    let aggregate = try await store.aggregateBalance(
+      for: [UUID()], in: .defaultTestInstrument)
+    #expect(aggregate == nil)
+  }
+}

--- a/MoolahTests/Features/AccountViewContextBuilderTests.swift
+++ b/MoolahTests/Features/AccountViewContextBuilderTests.swift
@@ -1,0 +1,265 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("AccountViewContextBuilder")
+@MainActor
+struct AccountViewContextBuilderTests {
+
+  // MARK: - Helpers
+
+  private func makeAccount(
+    id: UUID = UUID(),
+    name: String = "Account",
+    type: AccountType = .bank,
+    groupId: UUID? = nil,
+    position: Int = 0
+  ) -> Account {
+    Account(
+      id: id, name: name, type: type,
+      instrument: .defaultTestInstrument,
+      positions: [],
+      position: position,
+      groupId: groupId)
+  }
+
+  private func makeGroup(
+    id: UUID = UUID(),
+    name: String = "Trust Fund Crypto",
+    bucket: AccountBucket = .investments,
+    position: Int = 0
+  ) -> AccountGroup {
+    AccountGroup(
+      id: id, name: name, bucket: bucket,
+      instrument: .defaultTestInstrument,
+      position: position)
+  }
+
+  // MARK: - .account
+
+  @Test("account selection → 1-element accountIds, kind .account")
+  func accountSelectionSingleId() throws {
+    let account = makeAccount(name: "Checking")
+    let accounts = Accounts(from: [account])
+
+    let context = try #require(
+      AccountViewContextBuilder.build(
+        for: .account(account.id),
+        accounts: accounts,
+        groups: [],
+        syncStatuses: [:]))
+
+    #expect(context.kind == .account)
+    #expect(context.accountIds == [account.id])
+    #expect(context.displayName == "Checking")
+    #expect(context.bucket == .current)
+    #expect(context.syncStatus == .allSynced)
+  }
+
+  @Test("account selection picks up per-account sync status")
+  func accountSelectionSyncStatus() {
+    let account = makeAccount(type: .crypto)
+    let accounts = Accounts(from: [account])
+
+    let context = AccountViewContextBuilder.build(
+      for: .account(account.id),
+      accounts: accounts,
+      groups: [],
+      syncStatuses: [
+        account.id: AccountSyncStatus(
+          accountId: account.id, isInProgress: true, hasError: false)
+      ])
+
+    #expect(context?.syncStatus == .syncing(done: 0, total: 1))
+  }
+
+  @Test("account selection with unknown id returns nil")
+  func accountSelectionUnknownIdReturnsNil() {
+    let accounts = Accounts(from: [])
+    let context = AccountViewContextBuilder.build(
+      for: .account(UUID()),
+      accounts: accounts,
+      groups: [],
+      syncStatuses: [:])
+
+    #expect(context == nil)
+  }
+
+  // MARK: - .group
+
+  @Test("group selection → N-element accountIds ordered by member position")
+  func groupSelectionIdsOrderedByPosition() throws {
+    let group = makeGroup()
+    let memberA = makeAccount(
+      id: UUID(), name: "ETH wallet", type: .crypto, groupId: group.id, position: 1)
+    let memberB = makeAccount(
+      id: UUID(), name: "Coinstash", type: .crypto, groupId: group.id, position: 0)
+    let memberC = makeAccount(
+      id: UUID(), name: "Polygon wallet", type: .crypto, groupId: group.id, position: 2)
+    let accounts = Accounts(from: [memberA, memberB, memberC])
+
+    let context = try #require(
+      AccountViewContextBuilder.build(
+        for: .group(group.id),
+        accounts: accounts,
+        groups: [group],
+        syncStatuses: [:]))
+
+    #expect(context.kind == .group)
+    #expect(context.accountIds == [memberB.id, memberA.id, memberC.id])
+    #expect(context.displayName == "Trust Fund Crypto")
+    #expect(context.bucket == .investments)
+  }
+
+  @Test("group selection only includes members of that group")
+  func groupSelectionFiltersMembers() {
+    let group = makeGroup()
+    let otherGroup = makeGroup(id: UUID(), name: "Other")
+    let member = makeAccount(
+      id: UUID(), name: "Member", type: .crypto, groupId: group.id, position: 0)
+    let otherMember = makeAccount(
+      id: UUID(), name: "Other Member", type: .crypto, groupId: otherGroup.id, position: 0)
+    let standalone = makeAccount(
+      id: UUID(), name: "Standalone", type: .crypto, groupId: nil, position: 5)
+    let accounts = Accounts(from: [member, otherMember, standalone])
+
+    let context = AccountViewContextBuilder.build(
+      for: .group(group.id),
+      accounts: accounts,
+      groups: [group, otherGroup],
+      syncStatuses: [:])
+
+    #expect(context?.accountIds == [member.id])
+  }
+
+  @Test("group selection with zero members → empty accountIds")
+  func groupSelectionZeroMembers() throws {
+    let group = makeGroup()
+    let accounts = Accounts(from: [])
+
+    let context = try #require(
+      AccountViewContextBuilder.build(
+        for: .group(group.id),
+        accounts: accounts,
+        groups: [group],
+        syncStatuses: [:]))
+
+    #expect(context.accountIds.isEmpty == true)
+    #expect(context.syncStatus == .allSynced)
+  }
+
+  @Test("group selection with unknown id returns nil")
+  func groupSelectionUnknownIdReturnsNil() {
+    let accounts = Accounts(from: [])
+    let context = AccountViewContextBuilder.build(
+      for: .group(UUID()),
+      accounts: accounts,
+      groups: [],
+      syncStatuses: [:])
+
+    #expect(context == nil)
+  }
+
+  @Test("group selection aggregates per-member sync statuses")
+  func groupSelectionAggregatesSync() {
+    let group = makeGroup()
+    let memberA = makeAccount(
+      id: UUID(), name: "A", type: .crypto, groupId: group.id, position: 0)
+    let memberB = makeAccount(
+      id: UUID(), name: "B", type: .crypto, groupId: group.id, position: 1)
+    let accounts = Accounts(from: [memberA, memberB])
+
+    let context = AccountViewContextBuilder.build(
+      for: .group(group.id),
+      accounts: accounts,
+      groups: [group],
+      syncStatuses: [
+        memberA.id: AccountSyncStatus(
+          accountId: memberA.id, isInProgress: false, hasError: false),
+        memberB.id: AccountSyncStatus(
+          accountId: memberB.id, isInProgress: false, hasError: true),
+      ])
+
+    #expect(context?.syncStatus == .failed(memberIds: [memberB.id]))
+  }
+
+  // MARK: - non-detail selections
+
+  @Test("earmark selection returns nil (separate detail view)")
+  func earmarkSelectionReturnsNil() {
+    let accounts = Accounts(from: [])
+    let context = AccountViewContextBuilder.build(
+      for: .earmark(UUID()),
+      accounts: accounts,
+      groups: [],
+      syncStatuses: [:])
+    #expect(context == nil)
+  }
+
+  @Test("allTransactions selection returns nil")
+  func allTransactionsReturnsNil() {
+    let accounts = Accounts(from: [])
+    let context = AccountViewContextBuilder.build(
+      for: .allTransactions,
+      accounts: accounts,
+      groups: [],
+      syncStatuses: [:])
+    #expect(context == nil)
+  }
+
+  @Test("reports selection returns nil")
+  func reportsReturnsNil() {
+    let accounts = Accounts(from: [])
+    let context = AccountViewContextBuilder.build(
+      for: .reports,
+      accounts: accounts,
+      groups: [],
+      syncStatuses: [:])
+    #expect(context == nil)
+  }
+
+  @Test("analysis selection returns nil")
+  func analysisReturnsNil() {
+    let accounts = Accounts(from: [])
+    let context = AccountViewContextBuilder.build(
+      for: .analysis,
+      accounts: accounts,
+      groups: [],
+      syncStatuses: [:])
+    #expect(context == nil)
+  }
+
+  @Test("upcomingTransactions selection returns nil")
+  func upcomingReturnsNil() {
+    let accounts = Accounts(from: [])
+    let context = AccountViewContextBuilder.build(
+      for: .upcomingTransactions,
+      accounts: accounts,
+      groups: [],
+      syncStatuses: [:])
+    #expect(context == nil)
+  }
+
+  @Test("categories selection returns nil")
+  func categoriesReturnsNil() {
+    let accounts = Accounts(from: [])
+    let context = AccountViewContextBuilder.build(
+      for: .categories,
+      accounts: accounts,
+      groups: [],
+      syncStatuses: [:])
+    #expect(context == nil)
+  }
+
+  @Test("recentlyAdded selection returns nil")
+  func recentlyAddedReturnsNil() {
+    let accounts = Accounts(from: [])
+    let context = AccountViewContextBuilder.build(
+      for: .recentlyAdded,
+      accounts: accounts,
+      groups: [],
+      syncStatuses: [:])
+    #expect(context == nil)
+  }
+}

--- a/MoolahTests/Features/AccountViewContextTests.swift
+++ b/MoolahTests/Features/AccountViewContextTests.swift
@@ -1,0 +1,183 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("AccountViewContext")
+struct AccountViewContextTests {
+
+  @Test("single-account context exposes one id and account kind")
+  func singleAccountContext() {
+    let id = UUID()
+    let context = AccountViewContext(
+      kind: .account,
+      displayName: "Checking",
+      displayInstrument: .defaultTestInstrument,
+      bucket: .current,
+      accountIds: [id],
+      syncStatus: .allSynced)
+    #expect(context.kind == .account)
+    #expect(context.accountIds == [id])
+    #expect(context.supportsPerAccountSyncControls == true)
+  }
+
+  @Test("group context exposes N ids and group kind")
+  func groupContextNIds() {
+    let ids = [UUID(), UUID(), UUID()]
+    let context = AccountViewContext(
+      kind: .group,
+      displayName: "Trust Fund Crypto",
+      displayInstrument: .defaultTestInstrument,
+      bucket: .investments,
+      accountIds: ids,
+      syncStatus: .allSynced)
+    #expect(context.kind == .group)
+    #expect(context.accountIds == ids)
+    #expect(context.supportsPerAccountSyncControls == false)
+  }
+
+  @Test("supportsPerAccountSyncControls is false for empty single-account context")
+  func supportsControlsRequiresNonEmpty() {
+    let context = AccountViewContext(
+      kind: .account,
+      displayName: "Empty",
+      displayInstrument: .defaultTestInstrument,
+      bucket: .current,
+      accountIds: [],
+      syncStatus: .allSynced)
+    #expect(context.supportsPerAccountSyncControls == false)
+  }
+
+  @Test("supportsPerAccountSyncControls is false for any group context")
+  func supportsControlsFalseForGroup() {
+    let context = AccountViewContext(
+      kind: .group,
+      displayName: "Solo Group",
+      displayInstrument: .defaultTestInstrument,
+      bucket: .investments,
+      accountIds: [UUID()],
+      syncStatus: .allSynced)
+    #expect(context.supportsPerAccountSyncControls == false)
+  }
+}
+
+@Suite("AccountSyncStatus")
+struct AccountSyncStatusTests {
+
+  @Test("synced status has no error and is not in progress")
+  func syncedStatus() {
+    let status = AccountSyncStatus(accountId: UUID(), isInProgress: false, hasError: false)
+    #expect(status.isInProgress == false)
+    #expect(status.hasError == false)
+  }
+
+  @Test("in-progress status flags isInProgress")
+  func inProgressStatus() {
+    let status = AccountSyncStatus(accountId: UUID(), isInProgress: true, hasError: false)
+    #expect(status.isInProgress == true)
+  }
+
+  @Test("failed status flags hasError")
+  func failedStatus() {
+    let status = AccountSyncStatus(accountId: UUID(), isInProgress: false, hasError: true)
+    #expect(status.hasError == true)
+  }
+}
+
+@Suite("AggregatedSyncStatus")
+struct AggregatedSyncStatusTests {
+
+  @Test("empty input is allSynced")
+  func emptyIsAllSynced() {
+    #expect(AggregatedSyncStatus.aggregate([]) == .allSynced)
+  }
+
+  @Test("all synced collapses to allSynced")
+  func allSynced() {
+    let statuses = [
+      AccountSyncStatus(accountId: UUID(), isInProgress: false, hasError: false),
+      AccountSyncStatus(accountId: UUID(), isInProgress: false, hasError: false),
+    ]
+    #expect(AggregatedSyncStatus.aggregate(statuses) == .allSynced)
+  }
+
+  @Test("any failed produces failed with member ids")
+  func oneFailed() {
+    let failedId = UUID()
+    let statuses = [
+      AccountSyncStatus(accountId: UUID(), isInProgress: false, hasError: false),
+      AccountSyncStatus(accountId: failedId, isInProgress: false, hasError: true),
+      AccountSyncStatus(accountId: UUID(), isInProgress: false, hasError: false),
+    ]
+    #expect(AggregatedSyncStatus.aggregate(statuses) == .failed(memberIds: [failedId]))
+  }
+
+  @Test("multiple failed listed in input order")
+  func multipleFailed() {
+    let firstFailed = UUID()
+    let secondFailed = UUID()
+    let statuses = [
+      AccountSyncStatus(accountId: firstFailed, isInProgress: false, hasError: true),
+      AccountSyncStatus(accountId: UUID(), isInProgress: false, hasError: false),
+      AccountSyncStatus(accountId: secondFailed, isInProgress: false, hasError: true),
+    ]
+    #expect(
+      AggregatedSyncStatus.aggregate(statuses)
+        == .failed(memberIds: [firstFailed, secondFailed]))
+  }
+
+  @Test("all in progress reports syncing with full total")
+  func allInProgress() {
+    let statuses = [
+      AccountSyncStatus(accountId: UUID(), isInProgress: true, hasError: false),
+      AccountSyncStatus(accountId: UUID(), isInProgress: true, hasError: false),
+      AccountSyncStatus(accountId: UUID(), isInProgress: true, hasError: false),
+    ]
+    #expect(AggregatedSyncStatus.aggregate(statuses) == .syncing(done: 0, total: 3))
+  }
+
+  @Test("mix of in-progress and synced reports done/total")
+  func mixedInProgress() {
+    let statuses = [
+      AccountSyncStatus(accountId: UUID(), isInProgress: false, hasError: false),
+      AccountSyncStatus(accountId: UUID(), isInProgress: true, hasError: false),
+      AccountSyncStatus(accountId: UUID(), isInProgress: false, hasError: false),
+    ]
+    #expect(AggregatedSyncStatus.aggregate(statuses) == .syncing(done: 2, total: 3))
+  }
+
+  @Test("failed takes precedence over in-progress")
+  func failedOverInProgress() {
+    let failedId = UUID()
+    let statuses = [
+      AccountSyncStatus(accountId: UUID(), isInProgress: true, hasError: false),
+      AccountSyncStatus(accountId: failedId, isInProgress: false, hasError: true),
+    ]
+    #expect(AggregatedSyncStatus.aggregate(statuses) == .failed(memberIds: [failedId]))
+  }
+
+  @Test("single-element synced collapses to allSynced — same path serves single accounts")
+  func singleSyncedCollapses() {
+    let statuses = [
+      AccountSyncStatus(accountId: UUID(), isInProgress: false, hasError: false)
+    ]
+    #expect(AggregatedSyncStatus.aggregate(statuses) == .allSynced)
+  }
+
+  @Test("single-element in-progress collapses to syncing(0,1)")
+  func singleInProgressCollapses() {
+    let statuses = [
+      AccountSyncStatus(accountId: UUID(), isInProgress: true, hasError: false)
+    ]
+    #expect(AggregatedSyncStatus.aggregate(statuses) == .syncing(done: 0, total: 1))
+  }
+
+  @Test("single-element failed collapses to failed(memberIds: [id])")
+  func singleFailedCollapses() {
+    let failedId = UUID()
+    let statuses = [
+      AccountSyncStatus(accountId: failedId, isInProgress: false, hasError: true)
+    ]
+    #expect(AggregatedSyncStatus.aggregate(statuses) == .failed(memberIds: [failedId]))
+  }
+}

--- a/MoolahTests/Features/GroupAggregatedPositionsTests.swift
+++ b/MoolahTests/Features/GroupAggregatedPositionsTests.swift
@@ -1,0 +1,80 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("aggregatedGroupPositions")
+struct GroupAggregatedPositionsTests {
+
+  private func makeAccount(
+    id: UUID = UUID(), positions: [Position] = []
+  ) -> Account {
+    Account(
+      id: id, name: "Account", type: .crypto,
+      instrument: .defaultTestInstrument,
+      positions: positions)
+  }
+
+  @Test("members holding the same instrument coalesce to one row")
+  func sameInstrumentCoalesces() {
+    let memberA = makeAccount(positions: [
+      Position(instrument: .defaultTestInstrument, quantity: 100)
+    ])
+    let memberB = makeAccount(positions: [
+      Position(instrument: .defaultTestInstrument, quantity: 250)
+    ])
+    let accounts = Accounts(from: [memberA, memberB])
+
+    let result = aggregatedGroupPositions(
+      across: [memberA.id, memberB.id], in: accounts)
+
+    #expect(result.count == 1)
+    #expect(result.first?.instrument == .defaultTestInstrument)
+    #expect(result.first?.quantity == 350)
+  }
+
+  @Test("multi-instrument groups expose a row per instrument")
+  func multiInstrumentRows() {
+    let usd = Instrument.fiat(code: "USD")
+    let memberA = makeAccount(positions: [
+      Position(instrument: .defaultTestInstrument, quantity: 100)
+    ])
+    let memberB = makeAccount(positions: [
+      Position(instrument: usd, quantity: 50)
+    ])
+    let accounts = Accounts(from: [memberA, memberB])
+
+    let result = aggregatedGroupPositions(
+      across: [memberA.id, memberB.id], in: accounts)
+
+    #expect(result.count == 2)
+    #expect(Set(result.map(\.instrument)) == [.defaultTestInstrument, usd])
+  }
+
+  @Test("unknown ids are skipped silently")
+  func unknownIdsSkipped() {
+    let member = makeAccount(positions: [
+      Position(instrument: .defaultTestInstrument, quantity: 100)
+    ])
+    let accounts = Accounts(from: [member])
+
+    let result = aggregatedGroupPositions(
+      across: [member.id, UUID()], in: accounts)
+
+    #expect(result.count == 1)
+    #expect(result.first?.quantity == 100)
+  }
+
+  @Test("empty member list returns empty positions")
+  func emptyMembers() {
+    let accounts = Accounts(from: [])
+    #expect(aggregatedGroupPositions(across: [], in: accounts).isEmpty)
+  }
+
+  @Test("members with no positions contribute nothing")
+  func emptyPositions() {
+    let member = makeAccount(positions: [])
+    let accounts = Accounts(from: [member])
+    #expect(aggregatedGroupPositions(across: [member.id], in: accounts).isEmpty)
+  }
+}


### PR DESCRIPTION
Phase 5 of the [Account Groups design](https://github.com/moolah-rocks/moolah-native/blob/main/plans/2026-05-26-account-groups-design.md). Stacked on Phase 4 ([#986](https://github.com/moolah-rocks/moolah-native/pull/986)). Will retarget to \`main\` automatically once Phase 4 merges (via the \`landing-prs\` skill's watcher).

## What ships

- **\`AccountViewContext\`** — value type the composite detail view binds to. \`kind\` (\`.account\` / \`.group\`), \`displayName\`, \`displayInstrument\`, \`bucket\`, \`accountIds: [UUID]\`, \`syncStatus: AggregatedSyncStatus\`. A 1-element \`accountIds\` collapses to the same code path as a group, so single-account and composite headers share the path.
- **\`AggregatedSyncStatus.aggregate(_:)\`** — pure function over per-member \`AccountSyncStatus\` snapshots. Precedence: any failure → \`.failed(memberIds:)\`, otherwise any in-progress → \`.syncing(done:total:)\`, otherwise \`.allSynced\`. Empty / single-element inputs collapse correctly.
- **\`AccountViewContextBuilder.build(for:accounts:groups:syncStatuses:)\`** — resolves \`SidebarSelection → AccountViewContext?\`. \`.account\` → 1-element \`accountIds\`. \`.group\` → members sorted by \`Account.position\`. Non-detail selections (\`.earmark\`, \`.allTransactions\`, \`.reports\`, etc.) return nil so the existing routes still fire.
- **\`TransactionFilter.accountIds: Set<UUID>\`** — additive multi-account filter, ORed with \`accountId\` in the GRDB fetch path. Multi-account filters disable running-balance / after-page subtotals (which only make sense for a single-account view).
- **\`AccountStore.aggregateBalance(for:in:)\` async** — sums per-account display balances converted to a target instrument. Returns nil on empty / unknown ids and propagates conversion failures so callers honour [\`feedback_conversion_failure_ux\`](https://github.com/moolah-rocks/moolah-native/blob/main/.claude/memory/feedback_conversion_failure_ux.md): never partial-sum.
- **\`GroupDetailView\`** — composite detail surface: header card with \`displayName\` / aggregate balance / aggregated sync status, multi-instrument positions split summed across every member (\`aggregatedGroupPositions\`, pure / unit-tested), and \`TransactionListView\` filtered by the \`accountIds\` union.
- **\`GroupAggregateBalanceLoader\`** — sidebar wrapper that owns the \`@State InstrumentAmount?\` cache + \`.task(id:)\` that recomputes via \`AccountStore.aggregateBalance(for:in:)\` whenever membership / target instrument changes. Replaces Phase 4's \`aggregateBalance: nil\` placeholder.

## Plan deviations

- Did **not** refactor \`InvestmentAccountView\` / \`StandardAccountView\` to bind to \`AccountViewContext\`. The plan preamble explicitly flags this as the volatile part:
  > "The seam this plan introduces (\`AccountViewContext\`) is stable; the which-view-binds-to-it part is the part to recheck."
  The single-account routes (which are tightly coupled to per-account UI: valuation-mode toggle, sync controls, wallet headers, etc.) stay unchanged. The composite \`GroupDetailView\` is the new surface; \`accountDetail(id:)\` still picks per-type leaves for single accounts.
- Header is a card (name + balance + sync-status line), not the full rich header from the spec. The spec's clickable conversion-breakdown popover and rename affordance are deferred to a follow-up — Phase 5's acceptance criterion is that the balance respects the conversion-failure UX (unavailable, never partial-sum), which the card honours with an \"Unavailable\" label when \`aggregateBalance\` is nil.

## Tests

- 17 new \`AccountViewContext\` / \`AccountSyncStatus\` / \`AggregatedSyncStatus\` tests.
- 15 new \`AccountViewContextBuilder\` tests.
- 5 new \`aggregatedGroupPositions\` tests.
- 4 new \`AccountStore.aggregateBalance(for:in:)\` tests.
- 3 new \`TransactionFilter\` tests + 3 new \`TransactionRepository\` accountIds-union filter tests.
- Full \`just test-mac\` (3347 tests) passes.

## Test plan

- [ ] \`just test\` (mac + iOS).
- [ ] Manual: select a group in the sidebar → composite detail view renders with aggregated balance, merged transactions across members, multi-instrument positions split. Single-account selection still renders unchanged.
- [ ] Manual: a group with one member's conversion failing shows \"Unavailable\" in the header and a blank amount slot in the sidebar row (no partial sum).