### PR TITLE
feat(transactions): per-row accountContext for group description rendering

### DIFF
--- a/Domain/Models/Transaction+Display.swift
+++ b/Domain/Models/Transaction+Display.swift
@@ -4,22 +4,33 @@ import Foundation
 
 extension Transaction {
   /// Builds a display label for the transaction, handling transfers, earmarks, and payees.
+  ///
+  /// `accountContext` is the perspective from which the description is phrased.
+  /// Callers derive it per-row from the selected view's `accountIds`: exactly one
+  /// in-scope leg → that leg's account id; otherwise → nil. The semantics:
+  /// - `accountContext == nil` → no-context style ("Transfer from A to B"),
+  ///   used by scheduled / all-accounts views and by group views where the
+  ///   transaction touches multiple in-scope members.
+  /// - `accountContext == some` → perspective style ("Transfer to/from <other>"),
+  ///   used by single-account views and by group views where the transaction
+  ///   touches exactly one member.
+  ///
   /// - Parameters:
-  ///   - viewingAccountId: The account the user is viewing from (nil for scheduled/unfiltered views).
+  ///   - accountContext: The account perspective to phrase from (nil = no-context).
   ///   - accounts: Account lookup collection.
   ///   - earmarks: Earmark lookup collection.
   /// - Returns: A human-readable label for the transaction.
   func displayPayee(
-    viewingAccountId: UUID?, accounts: Accounts, earmarks: Earmarks
+    accountContext: UUID?, accounts: Accounts, earmarks: Earmarks
   ) -> String {
     if isTransfer {
-      if isSimple, let viewingAccountId,
-        let otherLeg = legs.first(where: { $0.accountId != viewingAccountId })
+      if isSimple, let accountContext,
+        let otherLeg = legs.first(where: { $0.accountId != accountContext })
       {
         // Account-scoped view: show direction relative to the viewer
         let otherAccountName =
           otherLeg.accountId.flatMap { accounts.by(id: $0) }?.name ?? "Unknown Account"
-        let viewingLeg = legs.first(where: { $0.accountId == viewingAccountId })
+        let viewingLeg = legs.first(where: { $0.accountId == accountContext })
         let isOutgoing = (viewingLeg?.quantity ?? 0) < 0
         let transferLabel =
           isOutgoing

--- a/Features/Analysis/Views/UpcomingTransactionsCard.swift
+++ b/Features/Analysis/Views/UpcomingTransactionsCard.swift
@@ -230,7 +230,7 @@ private struct SimpleTransactionRow: View {
 
   private var displayPayee: String {
     let label = transaction.displayPayee(
-      viewingAccountId: nil, accounts: accounts, earmarks: earmarks)
+      accountContext: nil, accounts: accounts, earmarks: earmarks)
     return label.isEmpty ? "Unknown" : label
   }
 }

--- a/Features/Transactions/Views/TransactionListCSVImportAddons.swift
+++ b/Features/Transactions/Views/TransactionListCSVImportAddons.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+
+/// Groups the CSV-import-specific modifiers (create-rule sheet + drop
+/// target) so the main `body` chain stays within the Swift type
+/// checker's complexity budget on the long `.onReceive` / `.sheet`
+/// chain.
+struct TransactionListCSVImportAddons: ViewModifier {
+  @Binding var createRuleFromTransaction: Transaction?
+  let corpusProvider: () -> [String]
+  let forcedAccountId: UUID?
+  let ingestDroppedURLs: (_ urls: [URL], _ forcedAccountId: UUID) async -> Void
+
+  func body(content: Content) -> some View {
+    content
+      .sheet(item: $createRuleFromTransaction) { transaction in
+        CreateRuleFromTransactionSheet(
+          transaction: transaction,
+          corpus: corpusProvider())
+      }
+      .dropDestination(for: URL.self) { urls, _ in
+        guard let accountId = forcedAccountId else { return false }
+        Task { await ingestDroppedURLs(urls, accountId) }
+        return !urls.isEmpty
+      }
+  }
+}

--- a/Features/Transactions/Views/TransactionListView+List.swift
+++ b/Features/Transactions/Views/TransactionListView+List.swift
@@ -239,6 +239,27 @@ extension TransactionListView {
     return transactionStore.currentTargetInstrument
   }
 
+  /// Per-row description perspective. When the filter scopes to one or more
+  /// accounts, returns the single in-scope account id iff the transaction
+  /// touches exactly one of them; otherwise nil for the no-context style.
+  /// When the filter has no account scope (all-accounts / scheduled), treats
+  /// every leg's account as in scope so single-account transactions still
+  /// resolve to that account and multi-account ones fall back to no-context.
+  private func accountContext(for transaction: Transaction) -> UUID? {
+    let inScopeAccountIds: [UUID]
+    if filter.hasAccountFilter {
+      var scope: Set<UUID> = filter.accountIds
+      if let id = filter.accountId { scope.insert(id) }
+      inScopeAccountIds = transaction.legs
+        .compactMap(\.accountId)
+        .filter { scope.contains($0) }
+    } else {
+      inScopeAccountIds = transaction.legs.compactMap(\.accountId)
+    }
+    let uniqueAccounts = Set(inScopeAccountIds)
+    return uniqueAccounts.count == 1 ? uniqueAccounts.first : nil
+  }
+
   @ViewBuilder
   private func transactionRow(for entry: TransactionWithBalance) -> some View {
     let scheduled = scheduledRowConfig(for: entry)
@@ -246,7 +267,8 @@ extension TransactionListView {
       transaction: entry.transaction, accounts: accounts,
       categories: categories, earmarks: earmarks, displayAmounts: entry.displayAmounts,
       balance: entry.balance, scopeReferenceInstrument: scopeReferenceInstrument,
-      hideEarmark: filter.earmarkId != nil, viewingAccountId: filter.accountId,
+      hideEarmark: filter.earmarkId != nil,
+      accountContext: accountContext(for: entry.transaction),
       isOverdue: scheduled?.isOverdue ?? false,
       isDueToday: scheduled?.isDueToday ?? false,
       onPay: scheduled?.onPay,
@@ -365,29 +387,4 @@ private struct ScheduledRowConfig {
   let isDueToday: Bool
   let pendingPayId: Transaction.ID?
   let onPay: () -> Void
-}
-
-/// Groups the CSV-import-specific modifiers (create-rule sheet + drop
-/// target) so the main `body` chain stays within the Swift type
-/// checker's complexity budget on the long `.onReceive` / `.sheet`
-/// chain.
-struct TransactionListCSVImportAddons: ViewModifier {
-  @Binding var createRuleFromTransaction: Transaction?
-  let corpusProvider: () -> [String]
-  let forcedAccountId: UUID?
-  let ingestDroppedURLs: (_ urls: [URL], _ forcedAccountId: UUID) async -> Void
-
-  func body(content: Content) -> some View {
-    content
-      .sheet(item: $createRuleFromTransaction) { transaction in
-        CreateRuleFromTransactionSheet(
-          transaction: transaction,
-          corpus: corpusProvider())
-      }
-      .dropDestination(for: URL.self) { urls, _ in
-        guard let accountId = forcedAccountId else { return false }
-        Task { await ingestDroppedURLs(urls, accountId) }
-        return !urls.isEmpty
-      }
-  }
 }

--- a/Features/Transactions/Views/TransactionRowView+Preview.swift
+++ b/Features/Transactions/Views/TransactionRowView+Preview.swift
@@ -41,7 +41,7 @@ private struct PreviewRowSpec {
   let legs: [TransactionLeg]
   let displayAmounts: [InstrumentAmount]
   let balance: Decimal
-  var viewingAccountId: UUID?
+  var accountContext: UUID?
 }
 
 @MainActor
@@ -53,7 +53,7 @@ private func previewRow(
   displayAmounts: [InstrumentAmount],
   balance: Decimal,
   scopeReferenceInstrument: Instrument = .AUD,
-  viewingAccountId: UUID? = nil,
+  accountContext: UUID? = nil,
   date: Date = Date(),
   recurPeriod: RecurPeriod? = nil,
   recurEvery: Int? = nil,
@@ -72,7 +72,7 @@ private func previewRow(
     displayAmounts: displayAmounts,
     balance: InstrumentAmount(quantity: balance, instrument: .AUD),
     scopeReferenceInstrument: scopeReferenceInstrument,
-    viewingAccountId: viewingAccountId,
+    accountContext: accountContext,
     isOverdue: isOverdue,
     isDueToday: isDueToday,
     onPay: onPay,
@@ -112,7 +112,7 @@ private func simplePreviewSpecs(data: PreviewData) -> [PreviewRowSpec] {
           accountId: data.savingsId, instrument: .AUD, quantity: 1000, type: .transfer),
       ],
       displayAmounts: [InstrumentAmount(quantity: -1000, instrument: .AUD)],
-      balance: -2449.77, viewingAccountId: data.sourceId),
+      balance: -2449.77, accountContext: data.sourceId),
     PreviewRowSpec(
       payee: "Rent Split",
       legs: [
@@ -122,7 +122,7 @@ private func simplePreviewSpecs(data: PreviewData) -> [PreviewRowSpec] {
           accountId: data.savingsId, instrument: .AUD, quantity: 500, type: .transfer),
       ],
       displayAmounts: [InstrumentAmount(quantity: -500, instrument: .AUD)],
-      balance: -1449.77, viewingAccountId: data.sourceId),
+      balance: -1449.77, accountContext: data.sourceId),
   ]
 }
 
@@ -143,7 +143,7 @@ private func tradePreviewSpecs(data: PreviewData) -> [PreviewRowSpec] {
         InstrumentAmount(quantity: 950, instrument: .AUD),
         InstrumentAmount(quantity: -50, instrument: .AUD),
       ],
-      balance: -2499.77, viewingAccountId: data.sourceId),
+      balance: -2499.77, accountContext: data.sourceId),
     PreviewRowSpec(
       payee: "",
       legs: [
@@ -156,7 +156,7 @@ private func tradePreviewSpecs(data: PreviewData) -> [PreviewRowSpec] {
         InstrumentAmount(quantity: -100, instrument: .AUD),
         InstrumentAmount(quantity: 1_000_000, instrument: data.scam),
       ],
-      balance: -1_549.77, viewingAccountId: data.sourceId),
+      balance: -1_549.77, accountContext: data.sourceId),
   ]
 }
 
@@ -167,7 +167,7 @@ private func tradePreviewSpecs(data: PreviewData) -> [PreviewRowSpec] {
       previewRow(
         data: data, payee: spec.payee, legs: spec.legs,
         displayAmounts: spec.displayAmounts, balance: spec.balance,
-        viewingAccountId: spec.viewingAccountId)
+        accountContext: spec.accountContext)
     }
   }
   .environment(\.spamInstruments, [data.scam])

--- a/Features/Transactions/Views/TransactionRowView.swift
+++ b/Features/Transactions/Views/TransactionRowView.swift
@@ -9,7 +9,12 @@ struct TransactionRowView: View {
   let balance: InstrumentAmount?
   let scopeReferenceInstrument: Instrument
   var hideEarmark: Bool = false
-  var viewingAccountId: UUID?
+  /// Perspective the row's description / metadata renders from. Derived
+  /// per-row by the parent from the view's `accountIds` set: exactly one
+  /// in-scope leg → that leg's account; otherwise → nil (no-context style).
+  /// nil for scheduled / all-accounts views and for group-view rows that
+  /// touch multiple members.
+  var accountContext: UUID?
 
   /// When true, the payee header shows a red `exclamationmark.triangle.fill`
   /// leading icon and the payee text renders in red. Used by the
@@ -244,7 +249,7 @@ struct TransactionRowView: View {
 
   private var categoryNames: [String] {
     let applicable =
-      viewingAccountId.map { id in
+      accountContext.map { id in
         transaction.legs.filter { $0.accountId == id }
       } ?? transaction.legs
     let uniqueIds = applicable.compactMap(\.categoryId).uniqued()
@@ -253,7 +258,7 @@ struct TransactionRowView: View {
 
   private var earmarkNames: [String] {
     let applicable =
-      viewingAccountId.map { id in
+      accountContext.map { id in
         transaction.legs.filter { $0.accountId == id }
       } ?? transaction.legs
     let uniqueIds = applicable.compactMap(\.earmarkId).uniqued()
@@ -262,7 +267,7 @@ struct TransactionRowView: View {
 
   private var displayPayee: String {
     transaction.displayPayee(
-      viewingAccountId: viewingAccountId, accounts: accounts, earmarks: earmarks)
+      accountContext: accountContext, accounts: accounts, earmarks: earmarks)
   }
 
 }

--- a/MoolahTests/Domain/TransactionDescriptionTests.swift
+++ b/MoolahTests/Domain/TransactionDescriptionTests.swift
@@ -1,0 +1,204 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+/// Pins the existing perspective-driven description renderings before
+/// Phase 6's parameter rename, and adds the new group-view behaviour
+/// (per-row context derived from `AccountViewContext.accountIds`).
+///
+/// The rule under test (spec §"Description rendering & internal
+/// transfers"): a single rendering function takes `accountContext:
+/// UUID?` — non-nil renders from that account's perspective ("Transfer
+/// to/from <other>"); nil renders no-context ("Transfer from <a> to
+/// <b>"). The caller derives the per-row context from the view's
+/// `accountIds` set: exactly one in-scope leg → that leg's account;
+/// otherwise → nil.
+@Suite("TransactionDescription")
+struct TransactionDescriptionTests {
+  // MARK: - Fixtures
+
+  private struct Fixture {
+    let accountA: Account
+    let accountB: Account
+    let accountC: Account
+    let accounts: Accounts
+    let earmarks: Earmarks
+
+    init() {
+      accountA = Account(
+        id: UUID(), name: "Checking", type: .bank, instrument: .AUD)
+      accountB = Account(
+        id: UUID(), name: "Savings", type: .bank, instrument: .AUD)
+      accountC = Account(
+        id: UUID(), name: "Crypto Wallet", type: .crypto, instrument: .AUD)
+      accounts = Accounts(from: [accountA, accountB, accountC])
+      earmarks = Earmarks(from: [])
+    }
+  }
+
+  private func makeTransfer(
+    from source: Account, to destination: Account, payee: String? = nil
+  ) -> Transaction {
+    Transaction(
+      date: Date(),
+      payee: payee,
+      legs: [
+        TransactionLeg(
+          accountId: source.id, instrument: source.instrument,
+          quantity: -100, type: .transfer),
+        TransactionLeg(
+          accountId: destination.id, instrument: destination.instrument,
+          quantity: 100, type: .transfer),
+      ])
+  }
+
+  private func makeExpense(on account: Account, payee: String) -> Transaction {
+    Transaction(
+      date: Date(),
+      payee: payee,
+      legs: [
+        TransactionLeg(
+          accountId: account.id, instrument: account.instrument,
+          quantity: -25, type: .expense)
+      ])
+  }
+
+  // MARK: - Single-leg expenses
+
+  @Test
+  func simpleExpenseRendersPayeeUnchangedAcrossPerspectives() {
+    let fixture = Fixture()
+    let transaction = makeExpense(on: fixture.accountA, payee: "Coffee Shop")
+
+    // Single-account view (perspective set).
+    let withContext = transaction.displayPayee(
+      accountContext: fixture.accountA.id,
+      accounts: fixture.accounts, earmarks: fixture.earmarks)
+    #expect(withContext == "Coffee Shop")
+
+    // No-context view (scheduled / all transactions).
+    let noContext = transaction.displayPayee(
+      accountContext: nil,
+      accounts: fixture.accounts, earmarks: fixture.earmarks)
+    #expect(noContext == "Coffee Shop")
+  }
+
+  // MARK: - Two-leg transfers (perspective set)
+
+  @Test
+  func transferFromPerspectiveOfSourceRendersTransferTo() {
+    let fixture = Fixture()
+    let transaction = makeTransfer(from: fixture.accountA, to: fixture.accountB)
+
+    let description = transaction.displayPayee(
+      accountContext: fixture.accountA.id,
+      accounts: fixture.accounts, earmarks: fixture.earmarks)
+    #expect(description == "Transfer to Savings")
+  }
+
+  @Test
+  func transferFromPerspectiveOfDestinationRendersTransferFrom() {
+    let fixture = Fixture()
+    let transaction = makeTransfer(from: fixture.accountA, to: fixture.accountB)
+
+    let description = transaction.displayPayee(
+      accountContext: fixture.accountB.id,
+      accounts: fixture.accounts, earmarks: fixture.earmarks)
+    #expect(description == "Transfer from Checking")
+  }
+
+  @Test
+  func transferWithPayeeWrapsTransferLabelInParentheses() {
+    let fixture = Fixture()
+    let transaction = makeTransfer(
+      from: fixture.accountA, to: fixture.accountB, payee: "Loan Payment")
+
+    let description = transaction.displayPayee(
+      accountContext: fixture.accountA.id,
+      accounts: fixture.accounts, earmarks: fixture.earmarks)
+    #expect(description == "Loan Payment (Transfer to Savings)")
+  }
+
+  // MARK: - Two-leg transfers (no perspective)
+
+  @Test
+  func transferWithoutPerspectiveRendersFromToBothAccounts() {
+    let fixture = Fixture()
+    let transaction = makeTransfer(from: fixture.accountA, to: fixture.accountB)
+
+    let description = transaction.displayPayee(
+      accountContext: nil,
+      accounts: fixture.accounts, earmarks: fixture.earmarks)
+    #expect(description == "Transfer from Checking to Savings")
+  }
+
+  // MARK: - Group view (single in-scope leg → member perspective)
+
+  @Test
+  func groupViewSingleInScopeLegRendersFromMemberPerspective() {
+    let fixture = Fixture()
+    // Group context = {accountA, accountC}. Transfer touches accountA + accountB,
+    // so exactly one in-scope leg (accountA). Description should phrase from
+    // accountA's perspective.
+    let transaction = makeTransfer(from: fixture.accountA, to: fixture.accountB)
+    let groupMemberIds: Set<UUID> = [fixture.accountA.id, fixture.accountC.id]
+
+    let inScope = transaction.legs
+      .compactMap(\.accountId)
+      .filter { groupMemberIds.contains($0) }
+    let context: UUID? = inScope.count == 1 ? inScope.first : nil
+    #expect(context == fixture.accountA.id)
+
+    let description = transaction.displayPayee(
+      accountContext: context,
+      accounts: fixture.accounts, earmarks: fixture.earmarks)
+    #expect(description == "Transfer to Savings")
+  }
+
+  // MARK: - Group view (multiple in-scope legs → no-context phrasing)
+
+  @Test
+  func groupViewMultipleInScopeLegsRendersNoContext() {
+    let fixture = Fixture()
+    // Group context = {accountA, accountB} — an intra-group transfer.
+    // Both legs are in scope → no single perspective → no-context style.
+    let transaction = makeTransfer(from: fixture.accountA, to: fixture.accountB)
+    let groupMemberIds: Set<UUID> = [fixture.accountA.id, fixture.accountB.id]
+
+    let inScope = transaction.legs
+      .compactMap(\.accountId)
+      .filter { groupMemberIds.contains($0) }
+    let context: UUID? = inScope.count == 1 ? inScope.first : nil
+    #expect(context == nil)
+
+    let description = transaction.displayPayee(
+      accountContext: context,
+      accounts: fixture.accounts, earmarks: fixture.earmarks)
+    #expect(description == "Transfer from Checking to Savings")
+  }
+
+  // MARK: - All-accounts view (multi-leg always no-context)
+
+  @Test
+  func allAccountsViewMultiLegTransactionAlwaysNoContext() {
+    let fixture = Fixture()
+    // All-accounts view: in-scope set contains every account, so both legs
+    // are in scope → context = nil → no-context rendering. Matches today.
+    let transaction = makeTransfer(from: fixture.accountA, to: fixture.accountB)
+    let allIds: Set<UUID> = [
+      fixture.accountA.id, fixture.accountB.id, fixture.accountC.id,
+    ]
+
+    let inScope = transaction.legs
+      .compactMap(\.accountId)
+      .filter { allIds.contains($0) }
+    let context: UUID? = inScope.count == 1 ? inScope.first : nil
+    #expect(context == nil)
+
+    let description = transaction.displayPayee(
+      accountContext: context,
+      accounts: fixture.accounts, earmarks: fixture.earmarks)
+    #expect(description == "Transfer from Checking to Savings")
+  }
+}


### PR DESCRIPTION
## Summary

Phase 6 of the [Account Groups feature](../blob/main/plans/2026-05-26-account-groups-design.md). Generalises the description-rendering perspective from the single-account `viewingAccountId` to a per-row `accountContext: UUID?` derived from the view's account scope. For single-account and all-accounts views the rendered text is unchanged; group views gain the new behaviour where a row touching exactly one member renders from that member's perspective ("Transfer to <external>"), and a bridge between two members renders in no-context style ("Transfer from <A> to <B>").

- `Transaction.displayPayee` parameter renamed `viewingAccountId` → `accountContext` (same body, clarified doc).
- `TransactionRowView.viewingAccountId` → `accountContext`. The list view derives it per row via `accountContext(for:)`, counting distinct in-scope accounts so multi-leg same-account transactions (3-leg trade with fee on the same account, earmark-split bills) preserve today's perspective filtering for categories / earmarks.
- Extracted `TransactionListCSVImportAddons` to its own file to stay under the file-length policy after the new helper landed.

## Stack

Stacked on Phase 5 (#988); base = `account-view-context`. Will auto-retarget to `main` once the parent merges.

## Test plan

- [x] New `TransactionDescriptionTests` suite pins existing single-account, all-accounts and transfer renderings, plus the new group-view cases (single-member-in-scope perspective and intra-group bridge no-context).
- [x] `just test-mac` — 3360 tests pass.
- [x] `just test-ios TransactionDescriptionTests` — 8 tests pass.
- [x] `just format-check` — clean.
- [ ] Manual exercise: select a group → bridge transactions show "Transfer from … to …", external transfers from a single member show "Transfer to/from <external>".

🤖 Generated with [Claude Code](https://claude.com/claude-code)