### PR TITLE
fix(tests): poll predicate after stream-finish instead of blind sleep

### DIFF
--- a/MoolahTests/Support/TestableStoreObservation.swift
+++ b/MoolahTests/Support/TestableStoreObservation.swift
@@ -95,16 +95,18 @@ extension TestableStoreObservation {
       while await iterator.next() != nil {
         if await evaluate() { return }
       }
-      // Stream finished without a matching tick. The predicate may still
-      // have become true between the last `evaluate()` and now (e.g.
-      // a MainActor hop applied the awaited state between iterations);
-      // re-check once. If it's still false, block long enough that the
-      // timeout-task in `withEmissionTimeout` always wins so the caller
-      // observes a proper `StoreEmissionTimeoutError` rather than a
-      // false-positive completion. 5 minutes matches the fallback in
-      // `waitForFirstEmission`.
-      if await evaluate() { return }
-      try? await Task.sleep(for: .seconds(300))
+      // Stream finished without a matching tick. The store's awaited
+      // state may still be in flight (e.g. a GRDB `ValueObservation`
+      // hasn't fired yet), or the underlying single-consumer
+      // `AsyncStream` may have dropped a tick across multiple iterator
+      // creations within the same test. Fall back to polling the
+      // predicate until the timeout-task in `withEmissionTimeout`
+      // cancels us — that way state arriving after the iterator
+      // misbehaves is still caught instead of falsely timing out.
+      while !Task.isCancelled {
+        if await evaluate() { return }
+        try? await Task.sleep(for: .milliseconds(20))
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Follow-up to #981 / #982. CI on #981 surfaced a real (existing) flake in `InvestmentStoreSyncRefreshTests.remoteInvestmentValueInsertRefreshesStore` ([failing run](https://github.com/moolah-rocks/moolah-native/actions/runs/26468823350/job/77936334528)) — reproducible at ~2-in-10 locally on macOS too.

**Root cause.** GRDB's `ValueObservation` can take more than 2 seconds to fire after `setValue` returns under CI load. And the test-helper's third iterator on the single-consumer `AsyncStream` (`waitForFirstEmission` and `drainPendingEmissions` each created one before) intermittently returns `nil` immediately — officially undefined territory.

#981 correctly stopped the helper silently succeeding in that case, but the 5-minute sleep that followed guaranteed the timeout fired *even when the awaited state arrived moments later*. The previous behaviour was a false positive; this PR converts that false positive into a real pass.

## Fix

Replace the post-iterator sleep in `waitForNextEmission` with a 20 ms predicate poll, gated by `Task.isCancelled`:

```swift
while !Task.isCancelled {
  if await evaluate() { return }
  try? await Task.sleep(for: .milliseconds(20))
}
```

When the `withEmissionTimeout` timeout-task wins, it cancels the body via `group.cancelAll()`; the loop exits and the caller observes a real `StoreEmissionTimeoutError`. When the state arrives during the wait, the next poll catches it and returns success.

## Test plan

- [x] 15/15 `just test-mac InvestmentStoreSyncRefreshTests` runs pass (vs 8/10 before — reproducible flake).
- [x] Full `just test-mac` — 3271 tests in 570 suites pass.
- [x] `just format-check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)