### PR TITLE
feat(sidebar): macOS NSOutlineView rewrite — Phase 1 (skeleton + selection)

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -19,6 +19,10 @@ excluded:
   # the main app's lint contract.
   - tools/CKDBSchemaGen
   - tools/HelpGen
+  # Third-party vendored source (MIT). Style is upstream's, not ours;
+  # local modifications are flagged with `// moolah:` comments.
+  # See Vendored/OutlineView/NOTICE.md.
+  - Vendored
 
 disabled_rules:
   # swift-format territory — do not enable these.

--- a/Features/Accounts/Views/AccountGroupSidebarRow.swift
+++ b/Features/Accounts/Views/AccountGroupSidebarRow.swift
@@ -26,10 +26,17 @@ struct AccountGroupSidebarRow: View {
   /// Inline-rename plumbing — same shape as account / earmark rows.
   var isEditing: Binding<Bool>?
   var onRename: ((String) -> Void)?
+  /// When `false`, the manual chevron-toggle button is suppressed. Used
+  /// by the macOS outline path where `NSOutlineView` provides its own
+  /// disclosure triangle and a second SwiftUI chevron would be
+  /// redundant. iOS and the default macOS `List` path keep `true`.
+  var showChevron: Bool = true
 
   var body: some View {
     HStack(spacing: 4) {
-      disclosureChevron
+      if showChevron {
+        disclosureChevron
+      }
       SidebarRowView(
         icon: "folder.fill",
         name: group.name,
@@ -109,6 +116,30 @@ struct AccountGroupSidebarRow: View {
       isSelected: false,
       isExpanded: $expanded,
       aggregateBalance: nil
+    )
+    .tag("group")
+  }
+  .listStyle(.sidebar)
+  .frame(width: 260)
+}
+
+#Preview("Group row — no chevron") {
+  // Exercises the macOS outline path where `NSOutlineView` provides
+  // its own disclosure triangle and the row suppresses the manual
+  // chevron button. The row should render flush with no extra leading
+  // spacing where the chevron would have been.
+  @Previewable @State var expanded = true
+  return List(selection: .constant(Optional("group"))) {
+    AccountGroupSidebarRow(
+      group: AccountGroup(
+        name: "Trust Fund Crypto",
+        bucket: .investments,
+        instrument: .AUD,
+        position: 0),
+      isSelected: false,
+      isExpanded: $expanded,
+      aggregateBalance: InstrumentAmount(quantity: 42180, instrument: .AUD),
+      showChevron: false
     )
     .tag("group")
   }

--- a/Features/Navigation/SidebarOutlineItem.swift
+++ b/Features/Navigation/SidebarOutlineItem.swift
@@ -1,11 +1,13 @@
 import Foundation
 
-/// One node in the macOS sidebar outline. The two top-level entries are
-/// the bucket section headers ("Current Accounts", "Investments"); their
-/// children are bucket entries (standalone accounts + groups intermixed
-/// by `position`, exactly as produced by
-/// `Accounts.groupAwareSidebar(...)`). A group's `children` are its
-/// member accounts (sorted by member `position`); an account's
+/// One node in the macOS sidebar outline. Each `SidebarOutlineView`
+/// instance renders the contents of a single `AccountBucket` (Current
+/// or Investments) — section chrome ("Current Accounts" /
+/// "Investments") is supplied by the surrounding SwiftUI `Section`,
+/// not as items in the tree. Root-level items are therefore the
+/// bucket's standalone accounts + groups intermixed by `position`,
+/// matching `Accounts.groupAwareSidebar(...)`. A group's `children`
+/// are its member accounts (sorted by member `position`); an account's
 /// `children` is always `nil`.
 ///
 /// `Identifiable` is required by the vendored `OutlineView` package;
@@ -14,8 +16,6 @@ import Foundation
 /// identifier).
 struct SidebarOutlineItem: Identifiable, Hashable, Sendable {
   enum Kind: Hashable, Sendable {
-    case currentAccountsHeader
-    case investmentsHeader
     case account(UUID)
     case group(UUID)
   }
@@ -41,29 +41,27 @@ struct SidebarOutlineItem: Identifiable, Hashable, Sendable {
 
   func hash(into hasher: inout Hasher) { hasher.combine(kind) }
 
-  /// Derives the outline tree from the same source-of-truth helper the
-  /// SwiftUI sidebar uses (`Accounts.groupAwareSidebar`). Hidden /
-  /// excluded handling rides along — callers don't pass `excluding` /
-  /// `alwaysInclude` here; the helper is invoked with defaults because
-  /// the sidebar never wants to hide its own rows.
+  // MARK: - Tree construction
+
+  /// Builds a flat outline tree for one bucket. Root-level items are
+  /// the bucket's standalone accounts + groups intermixed by
+  /// `position`, exactly as produced by
+  /// `Accounts.groupAwareSidebar(...)`. **No section-header items** —
+  /// those are now supplied by the surrounding SwiftUI `Section`
+  /// chrome inside `SidebarView+Sections.swift`.
   static func tree(
     accounts: Accounts,
-    groups: [AccountGroup]
+    groups: [AccountGroup],
+    bucket: AccountBucket
   ) -> [SidebarOutlineItem] {
     let grouped = accounts.groupAwareSidebar(groups: groups)
-    return [
-      section(.currentAccountsHeader, entries: grouped.current),
-      section(.investmentsHeader, entries: grouped.investments),
-    ]
-  }
-
-  private static func section(
-    _ kind: Kind, entries: [SidebarBucketEntry]
-  ) -> SidebarOutlineItem {
-    SidebarOutlineItem(
-      kind: kind,
-      children: entries.map(item(from:))
-    )
+    let entries: [SidebarBucketEntry] = {
+      switch bucket {
+      case .current: return grouped.current
+      case .investments: return grouped.investments
+      }
+    }()
+    return entries.map(item(from:))
   }
 
   private static func item(from entry: SidebarBucketEntry) -> SidebarOutlineItem {

--- a/Features/Navigation/SidebarOutlineItem.swift
+++ b/Features/Navigation/SidebarOutlineItem.swift
@@ -1,0 +1,80 @@
+import Foundation
+
+/// One node in the macOS sidebar outline. The two top-level entries are
+/// the bucket section headers ("Current Accounts", "Investments"); their
+/// children are bucket entries (standalone accounts + groups intermixed
+/// by `position`, exactly as produced by
+/// `Accounts.groupAwareSidebar(...)`). A group's `children` are its
+/// member accounts (sorted by member `position`); an account's
+/// `children` is always `nil`.
+///
+/// `Identifiable` is required by the vendored `OutlineView` package;
+/// `Hashable` is required so SwiftUI's `Binding<SidebarOutlineItem?>`
+/// selection can deduplicate. Equality is by `id` (the kind's stable
+/// identifier).
+struct SidebarOutlineItem: Identifiable, Hashable, Sendable {
+  enum Kind: Hashable, Sendable {
+    case currentAccountsHeader
+    case investmentsHeader
+    case account(UUID)
+    case group(UUID)
+  }
+
+  let kind: Kind
+  // `nil` means "this item is a leaf — never show a disclosure
+  // triangle". `[]` (empty array) means "this item is expandable but
+  // currently has no children — render an expandable triangle".
+  // The vendored `OutlineView` keys `NSOutlineView.isItemExpandable`
+  // off `children != nil`, so swapping to a non-optional empty
+  // collection here would force every account row to render a useless
+  // disclosure triangle. The SwiftLint `discouraged_optional_collection`
+  // rule is silenced for that reason; replacing the optional with an
+  // empty array would break the AppKit contract.
+  // swiftlint:disable:next discouraged_optional_collection
+  let children: [SidebarOutlineItem]?
+
+  var id: Kind { kind }
+
+  static func == (lhs: SidebarOutlineItem, rhs: SidebarOutlineItem) -> Bool {
+    lhs.kind == rhs.kind
+  }
+
+  func hash(into hasher: inout Hasher) { hasher.combine(kind) }
+
+  /// Derives the outline tree from the same source-of-truth helper the
+  /// SwiftUI sidebar uses (`Accounts.groupAwareSidebar`). Hidden /
+  /// excluded handling rides along — callers don't pass `excluding` /
+  /// `alwaysInclude` here; the helper is invoked with defaults because
+  /// the sidebar never wants to hide its own rows.
+  static func tree(
+    accounts: Accounts,
+    groups: [AccountGroup]
+  ) -> [SidebarOutlineItem] {
+    let grouped = accounts.groupAwareSidebar(groups: groups)
+    return [
+      section(.currentAccountsHeader, entries: grouped.current),
+      section(.investmentsHeader, entries: grouped.investments),
+    ]
+  }
+
+  private static func section(
+    _ kind: Kind, entries: [SidebarBucketEntry]
+  ) -> SidebarOutlineItem {
+    SidebarOutlineItem(
+      kind: kind,
+      children: entries.map(item(from:))
+    )
+  }
+
+  private static func item(from entry: SidebarBucketEntry) -> SidebarOutlineItem {
+    switch entry {
+    case .account(let account):
+      return SidebarOutlineItem(kind: .account(account.id), children: nil)
+    case let .group(group, members):
+      return SidebarOutlineItem(
+        kind: .group(group.id),
+        children: members.map { SidebarOutlineItem(kind: .account($0.id), children: nil) }
+      )
+    }
+  }
+}

--- a/Features/Navigation/SidebarOutlineView.swift
+++ b/Features/Navigation/SidebarOutlineView.swift
@@ -20,6 +20,14 @@
     @Environment(AccountGroupStore.self) private var accountGroupStore
     @Environment(GroupUIStateStore.self) private var groupUIStateStore
     @Binding var selection: SidebarSelection?
+    // moolah: account-edit binding owned by the parent `SidebarView`.
+    // Right-clicking a row in the NSOutlineView invokes "Edit Account…"
+    // which assigns to this binding; `SidebarSharedModifiers` then
+    // presents the edit sheet. Threading the binding (rather than
+    // hosting state inside `SidebarOutlineView`) keeps a single source
+    // of truth across the outline + SwiftUI-list halves of the
+    // sidebar so the SwiftUI sheet driver remains the parent.
+    @Binding var accountToEdit: Account?
 
     var body: some View {
       OutlineView(
@@ -86,6 +94,25 @@
       ) {
         AccountSidebarRow(account: account, isSelected: selection == .account(id))
           .environment(accountStore)
+          .contextMenu { accountContextMenu(for: account) }
+      }
+    }
+
+    // moolah: macOS outline-cell context menu. Mirrors the
+    // `accountContextMenu(for:)` builder in `SidebarView` but pared down
+    // to the items that work in Phase 1 (no inline rename, no group
+    // submenu — both are iOS-only until later phases). "Edit Account…"
+    // is the regression-critical item: UI tests right-click a sidebar
+    // account row and expect to find the menu by its accessibility
+    // identifier (see `EditAccountValuationPickerTests`).
+    @ViewBuilder
+    private func accountContextMenu(for account: Account) -> some View {
+      Button("Edit Account\u{2026}", systemImage: "pencil") {
+        accountToEdit = account
+      }
+      .accessibilityIdentifier(UITestIdentifiers.Sidebar.editAccountContextMenuItem)
+      Button("View Transactions", systemImage: "list.bullet") {
+        selection = .account(account.id)
       }
     }
 

--- a/Features/Navigation/SidebarOutlineView.swift
+++ b/Features/Navigation/SidebarOutlineView.swift
@@ -74,24 +74,32 @@
 
     private func accountCell(id: UUID) -> NSView {
       guard let account = accountStore.accounts.by(id: id) else {
+        // Defensive: an account row exists in the outline tree but its
+        // record disappeared from the store between tree-build and
+        // cell-build (e.g. mid-deletion). An empty cell renders blank
+        // for one frame; the next data update drops the row entirely.
+        assertionFailure("SidebarOutlineView: account \(id) missing from store")
         return NSTableCellView()
       }
       return NSTableCellView.hosting(
         accessibilityIdentifier: UITestIdentifiers.Sidebar.account(id)
       ) {
-        AccountSidebarRow(account: account)
+        AccountSidebarRow(account: account, isSelected: selection == .account(id))
           .environment(accountStore)
       }
     }
 
     private func groupCell(id: UUID) -> NSView {
       guard let group = accountGroupStore.by(id: id) else {
+        // Defensive: same rationale as `accountCell`.
+        assertionFailure("SidebarOutlineView: group \(id) missing from store")
         return NSTableCellView()
       }
       let memberIds = accountStore.accounts.ordered
         .filter { $0.groupId == id }
         .sorted { $0.position < $1.position }
         .map(\.id)
+      let isSelected = selection == .group(id)
       return NSTableCellView.hosting(
         accessibilityIdentifier: UITestIdentifiers.Sidebar.group(id)
       ) {
@@ -101,6 +109,7 @@
         ) { balance in
           AccountGroupSidebarRow(
             group: group,
+            isSelected: isSelected,
             // `NSOutlineView` draws the disclosure triangle for us; the
             // row's own chevron is suppressed via `showChevron: false`.
             // The expand state itself rides through
@@ -142,6 +151,16 @@
     /// re-emits the authoritative `expandedGroupIds`, which re-renders
     /// the outline against the new set — the store stays the source of
     /// truth, the binding is purely a translation layer.
+    ///
+    /// `setExpanded(_:for:)` is `async` (not `async throws`) and catches
+    /// its own repository errors into `GroupUIStateStore.error`; the
+    /// fire-and-forget `Task` is safe here — no error-swallowing rule is
+    /// violated because the callee, not the callsite, owns recovery.
+    /// `@MainActor`-bound because the returned `Binding`'s `get` reads
+    /// `groupStore.expandedGroupIds` synchronously and the setter
+    /// dispatches into `groupStore.setExpanded(_:for:)`. Both touch
+    /// `@MainActor`-isolated store state, so the surrounding context
+    /// must already be on the main actor when the binding is built.
     @MainActor
     static func expansionBinding(
       groupStore: GroupUIStateStore

--- a/Features/Navigation/SidebarOutlineView.swift
+++ b/Features/Navigation/SidebarOutlineView.swift
@@ -1,0 +1,149 @@
+#if os(macOS)
+  import AppKit
+  import SwiftUI
+
+  /// macOS-only outline-rendered top section of the sidebar: Current
+  /// Accounts + Investments. Wraps `NSOutlineView` via the vendored
+  /// `OutlineView` package (`Vendored/OutlineView/`). Selection rides
+  /// through a shared `Binding<SidebarSelection?>` with the sibling
+  /// SwiftUI `List` below (earmarks / totals / nav) — clicking in either
+  /// surface updates the same binding.
+  ///
+  /// Phase 1 scope: render items, support row selection, render section
+  /// headers as source-list group rows. **No expansion-state persistence
+  /// here** (Task 3). **No drag-and-drop** (Phase 2). **No inline rename**
+  /// (Phase 3) — rename remains via the "Edit Account…" context menu
+  /// item which opens the full edit sheet.
+  struct SidebarOutlineView: View {
+    @Environment(AccountStore.self) private var accountStore
+    @Environment(AccountGroupStore.self) private var accountGroupStore
+    @Binding var selection: SidebarSelection?
+
+    var body: some View {
+      OutlineView(
+        SidebarOutlineItem.tree(
+          accounts: accountStore.accounts,
+          groups: accountGroupStore.groups),
+        children: \.children,
+        selection: outlineSelectionBinding,
+        content: cellView(for:)
+      )
+      .outlineViewStyle(.sourceList)
+      .outlineViewIsGroupItem { item in
+        switch item.kind {
+        case .currentAccountsHeader, .investmentsHeader: return true
+        case .account, .group: return false
+        }
+      }
+    }
+
+    // MARK: - Cell rendering
+
+    @MainActor
+    private func cellView(for item: SidebarOutlineItem) -> NSView {
+      switch item.kind {
+      case .currentAccountsHeader: return headerCell("Current Accounts")
+      case .investmentsHeader: return headerCell("Investments")
+      case .account(let id): return accountCell(id: id)
+      case .group(let id): return groupCell(id: id)
+      }
+    }
+
+    /// Source-list group-row cell. `NSOutlineView` styles the cell with
+    /// the capitalised, secondary-text-colour treatment when
+    /// `outlineView(_:isGroupItem:)` returns `true` — we just supply the
+    /// text. The explicit title keeps VoiceOver pronunciation
+    /// predictable (NSOutlineView's automatic uppercasing is a render
+    /// transform, not the underlying accessibility string).
+    private func headerCell(_ title: String) -> NSView {
+      let cell = NSTableCellView()
+      let field = NSTextField(labelWithString: title)
+      field.translatesAutoresizingMaskIntoConstraints = false
+      cell.addSubview(field)
+      cell.textField = field
+      NSLayoutConstraint.activate([
+        field.leadingAnchor.constraint(equalTo: cell.leadingAnchor),
+        field.trailingAnchor.constraint(equalTo: cell.trailingAnchor),
+        field.centerYAnchor.constraint(equalTo: cell.centerYAnchor),
+      ])
+      return cell
+    }
+
+    private func accountCell(id: UUID) -> NSView {
+      guard let account = accountStore.accounts.by(id: id) else {
+        return NSTableCellView()
+      }
+      return NSTableCellView.hosting(
+        accessibilityIdentifier: UITestIdentifiers.Sidebar.account(id)
+      ) {
+        AccountSidebarRow(account: account)
+          .environment(accountStore)
+      }
+    }
+
+    private func groupCell(id: UUID) -> NSView {
+      guard let group = accountGroupStore.by(id: id) else {
+        return NSTableCellView()
+      }
+      let memberIds = accountStore.accounts.ordered
+        .filter { $0.groupId == id }
+        .sorted { $0.position < $1.position }
+        .map(\.id)
+      return NSTableCellView.hosting(
+        accessibilityIdentifier: UITestIdentifiers.Sidebar.group(id)
+      ) {
+        GroupAggregateBalanceLoader(
+          memberIds: memberIds,
+          targetInstrument: group.instrument
+        ) { balance in
+          AccountGroupSidebarRow(
+            group: group,
+            // Task 2: no expansion state binding yet. The chevron is
+            // suppressed because `NSOutlineView` draws its own
+            // disclosure triangle; the row still needs *some* binding,
+            // so we hand it a constant `false`. Task 3 replaces the
+            // chevron-control story end-to-end with the persisted
+            // expand-state binding.
+            isExpanded: .constant(false),
+            aggregateBalance: balance,
+            showChevron: false
+          )
+        }
+        .environment(accountStore)
+      }
+    }
+
+    // MARK: - Selection mapping
+
+    /// Maps between the outline's `SidebarOutlineItem?` selection and
+    /// the app's `SidebarSelection?`. Section-header rows are
+    /// non-selectable (the `outlineViewIsGroupItem` hook disables
+    /// selection on them via the vendored delegate); they never reach
+    /// the setter. Earmark / navigation selections that come from the
+    /// sibling SwiftUI `List` map to `nil` on the outline side so the
+    /// outline does not highlight a stale row.
+    private var outlineSelectionBinding: Binding<SidebarOutlineItem?> {
+      Binding(
+        get: {
+          switch selection {
+          case .account(let id):
+            return SidebarOutlineItem(kind: .account(id), children: nil)
+          case .group(let id):
+            return SidebarOutlineItem(kind: .group(id), children: [])
+          case .none, .earmark, .recentlyAdded, .allTransactions,
+            .upcomingTransactions, .categories, .reports, .analysis:
+            return nil
+          }
+        },
+        set: { newItem in
+          switch newItem?.kind {
+          case .account(let id): selection = .account(id)
+          case .group(let id): selection = .group(id)
+          case .currentAccountsHeader, .investmentsHeader, .none:
+            break
+          }
+        }
+      )
+    }
+  }
+#endif

--- a/Features/Navigation/SidebarOutlineView.swift
+++ b/Features/Navigation/SidebarOutlineView.swift
@@ -10,13 +10,15 @@
   /// surface updates the same binding.
   ///
   /// Phase 1 scope: render items, support row selection, render section
-  /// headers as source-list group rows. **No expansion-state persistence
-  /// here** (Task 3). **No drag-and-drop** (Phase 2). **No inline rename**
-  /// (Phase 3) — rename remains via the "Edit Account…" context menu
-  /// item which opens the full edit sheet.
+  /// headers as source-list group rows, and persist per-group expand
+  /// state through `GroupUIStateStore` (see
+  /// `expansionBinding(groupStore:)`). **No drag-and-drop** (Phase 2).
+  /// **No inline rename** (Phase 3) — rename remains via the
+  /// "Edit Account…" context menu item which opens the full edit sheet.
   struct SidebarOutlineView: View {
     @Environment(AccountStore.self) private var accountStore
     @Environment(AccountGroupStore.self) private var accountGroupStore
+    @Environment(GroupUIStateStore.self) private var groupUIStateStore
     @Binding var selection: SidebarSelection?
 
     var body: some View {
@@ -35,6 +37,7 @@
         case .account, .group: return false
         }
       }
+      .outlineViewExpandedItems(Self.expansionBinding(groupStore: groupUIStateStore))
     }
 
     // MARK: - Cell rendering
@@ -98,12 +101,14 @@
         ) { balance in
           AccountGroupSidebarRow(
             group: group,
-            // Task 2: no expansion state binding yet. The chevron is
-            // suppressed because `NSOutlineView` draws its own
-            // disclosure triangle; the row still needs *some* binding,
-            // so we hand it a constant `false`. Task 3 replaces the
-            // chevron-control story end-to-end with the persisted
-            // expand-state binding.
+            // `NSOutlineView` draws the disclosure triangle for us; the
+            // row's own chevron is suppressed via `showChevron: false`.
+            // The expand state itself rides through
+            // `.outlineViewExpandedItems` → `expansionBinding` →
+            // `GroupUIStateStore`, so the `isExpanded` binding on the
+            // SwiftUI row is unused in the outline path. A constant
+            // `false` keeps the row API happy without giving it write
+            // authority — it would race the persisted store.
             isExpanded: .constant(false),
             aggregateBalance: balance,
             showChevron: false
@@ -111,6 +116,62 @@
         }
         .environment(accountStore)
       }
+    }
+
+    // MARK: - Expansion mapping
+
+    /// Builds the two-way binding between
+    /// `Set<SidebarOutlineItem.Kind>` (which the vendored `OutlineView`
+    /// uses to drive per-row expand state) and
+    /// `GroupUIStateStore.expandedGroupIds`.
+    ///
+    /// Section-header items (`.currentAccountsHeader` /
+    /// `.investmentsHeader`) are unconditionally reported as expanded —
+    /// the user can't permanently collapse "Current Accounts" or
+    /// "Investments" away. The setter ignores any add / remove of
+    /// header kinds; only `.group(id)` transitions reach the store.
+    ///
+    /// Account-row kinds (`.account(id)`) are leaves with no children,
+    /// so they never appear in the bound set. The setter tolerates
+    /// them defensively but treats them as no-ops.
+    ///
+    /// Each group transition is dispatched as a `Task` calling
+    /// `setExpanded(_:for:)`. `GroupUIStateStore` is `@MainActor`-bound;
+    /// the inherited MainActor context keeps the persistence write off
+    /// the binding's synchronous setter path. The observation stream
+    /// re-emits the authoritative `expandedGroupIds`, which re-renders
+    /// the outline against the new set — the store stays the source of
+    /// truth, the binding is purely a translation layer.
+    @MainActor
+    static func expansionBinding(
+      groupStore: GroupUIStateStore
+    ) -> Binding<Set<SidebarOutlineItem.Kind>> {
+      Binding(
+        get: {
+          var set: Set<SidebarOutlineItem.Kind> = [
+            .currentAccountsHeader,
+            .investmentsHeader,
+          ]
+          for groupId in groupStore.expandedGroupIds {
+            set.insert(.group(groupId))
+          }
+          return set
+        },
+        set: { newValue in
+          let newGroupExpansion: Set<UUID> = Set(
+            newValue.compactMap { kind -> UUID? in
+              if case .group(let id) = kind { return id }
+              return nil
+            })
+          let old = groupStore.expandedGroupIds
+          for groupId in newGroupExpansion.subtracting(old) {
+            Task { await groupStore.setExpanded(true, for: groupId) }
+          }
+          for groupId in old.subtracting(newGroupExpansion) {
+            Task { await groupStore.setExpanded(false, for: groupId) }
+          }
+        }
+      )
     }
 
     // MARK: - Selection mapping

--- a/Features/Navigation/SidebarOutlineView.swift
+++ b/Features/Navigation/SidebarOutlineView.swift
@@ -52,7 +52,11 @@
         selection: outlineSelectionBinding,
         content: cellView(for:)
       )
-      .outlineViewStyle(.sourceList)
+      // Deliberately NOT `.outlineViewStyle(.sourceList)` — the source-list
+      // style paints its own grey background that doubles up against the
+      // host SwiftUI Section's `.listStyle(.sidebar)` chrome. The plain
+      // (`.automatic`) style with cleared background lets the SwiftUI
+      // sidebar material show through cleanly.
       .outlineViewExpandedItems(Self.expansionBinding(groupStore: groupUIStateStore))
       // `NSViewControllerRepresentable` does not surface an
       // intrinsic content size to SwiftUI's `List` layout — without
@@ -82,11 +86,13 @@
     }
 
     /// Per-row height used by both the height computation above and
-    /// (implicitly) `NSOutlineView`'s automatic row sizing. Sourced
-    /// from the source-list style's default row metric — picking the
-    /// same number here keeps the bound height in sync with the
-    /// actual cells the outline lays out.
-    private static let rowHeight: CGFloat = 24
+    /// (implicitly) `NSOutlineView`'s automatic row sizing. Matches
+    /// SwiftUI `List(.sidebar)` row chrome (icon + label + balance with
+    /// 4pt vertical padding either side via
+    /// `NSTableCellView.hosting`); picking the same number here keeps
+    /// the bound `.frame(height:)` in sync with the actual cells the
+    /// outline lays out, so the parent `List` row doesn't crop or pad.
+    private static let rowHeight: CGFloat = 28
 
     // MARK: - Cell rendering
 

--- a/Features/Navigation/SidebarOutlineView.swift
+++ b/Features/Navigation/SidebarOutlineView.swift
@@ -2,24 +2,36 @@
   import AppKit
   import SwiftUI
 
-  /// macOS-only outline-rendered top section of the sidebar: Current
-  /// Accounts + Investments. Wraps `NSOutlineView` via the vendored
-  /// `OutlineView` package (`Vendored/OutlineView/`). Selection rides
-  /// through a shared `Binding<SidebarSelection?>` with the sibling
-  /// SwiftUI `List` below (earmarks / totals / nav) — clicking in either
-  /// surface updates the same binding.
+  /// macOS-only outline view rendering one bucket of the sidebar
+  /// (Current Accounts **or** Investments — never both). Wraps
+  /// `NSOutlineView` via the vendored `OutlineView` package
+  /// (`Vendored/OutlineView/`). Section chrome ("Current Accounts" /
+  /// "Investments") is supplied by the surrounding SwiftUI `Section`
+  /// in `SidebarView+Sections.swift`; this view renders only the
+  /// bucket's accounts and groups as a flat root with members nested
+  /// under their group.
   ///
-  /// Phase 1 scope: render items, support row selection, render section
-  /// headers as source-list group rows, and persist per-group expand
-  /// state through `GroupUIStateStore` (see
+  /// Selection rides through a shared `Binding<SidebarSelection?>`
+  /// with the host `List(selection:)` (earmarks / totals / nav) —
+  /// clicking in either surface updates the same binding.
+  ///
+  /// Phase 1 scope: render items, support row selection, and persist
+  /// per-group expand state through `GroupUIStateStore` (see
   /// `expansionBinding(groupStore:)`). **No drag-and-drop** (Phase 2).
   /// **No inline rename** (Phase 3) — rename remains via the
-  /// "Edit Account…" context menu item which opens the full edit sheet.
+  /// "Edit Account…" context menu item which opens the full edit
+  /// sheet.
   struct SidebarOutlineView: View {
     @Environment(AccountStore.self) private var accountStore
     @Environment(AccountGroupStore.self) private var accountGroupStore
     @Environment(GroupUIStateStore.self) private var groupUIStateStore
     @Binding var selection: SidebarSelection?
+    /// Which bucket this outline instance renders. The parent
+    /// `SidebarView` instantiates one `SidebarOutlineView` per bucket
+    /// so the two bucket headers can be flat SwiftUI sections with
+    /// Earmarks interleaved between them — the previous
+    /// single-outline layout couldn't express that ordering.
+    let bucket: AccountBucket
     // moolah: account-edit binding owned by the parent `SidebarView`.
     // Right-clicking a row in the NSOutlineView invokes "Edit Account…"
     // which assigns to this binding; `SidebarSharedModifiers` then
@@ -30,54 +42,60 @@
     @Binding var accountToEdit: Account?
 
     var body: some View {
+      let items = SidebarOutlineItem.tree(
+        accounts: accountStore.accounts,
+        groups: accountGroupStore.groups,
+        bucket: bucket)
       OutlineView(
-        SidebarOutlineItem.tree(
-          accounts: accountStore.accounts,
-          groups: accountGroupStore.groups),
+        items,
         children: \.children,
         selection: outlineSelectionBinding,
         content: cellView(for:)
       )
       .outlineViewStyle(.sourceList)
-      .outlineViewIsGroupItem { item in
-        switch item.kind {
-        case .currentAccountsHeader, .investmentsHeader: return true
-        case .account, .group: return false
+      .outlineViewExpandedItems(Self.expansionBinding(groupStore: groupUIStateStore))
+      // `NSViewControllerRepresentable` does not surface an
+      // intrinsic content size to SwiftUI's `List` layout — without
+      // a frame the row collapses to zero height. Compute the
+      // height from the visible row count: each root item is one
+      // row; an expanded group contributes its members on top.
+      .frame(height: computedHeight(for: items))
+    }
+
+    /// Height contributed by this outline inside its host `List`
+    /// row. Each visible row uses `Self.rowHeight`; expanded groups
+    /// add their member rows. Collapsed groups contribute only their
+    /// own row.
+    private func computedHeight(for items: [SidebarOutlineItem]) -> CGFloat {
+      let expanded = groupUIStateStore.expandedGroupIds
+      var visibleRows = 0
+      for item in items {
+        visibleRows += 1
+        if case .group(let id) = item.kind,
+          expanded.contains(id),
+          let children = item.children
+        {
+          visibleRows += children.count
         }
       }
-      .outlineViewExpandedItems(Self.expansionBinding(groupStore: groupUIStateStore))
+      return CGFloat(visibleRows) * Self.rowHeight
     }
+
+    /// Per-row height used by both the height computation above and
+    /// (implicitly) `NSOutlineView`'s automatic row sizing. Sourced
+    /// from the source-list style's default row metric — picking the
+    /// same number here keeps the bound height in sync with the
+    /// actual cells the outline lays out.
+    private static let rowHeight: CGFloat = 24
 
     // MARK: - Cell rendering
 
     @MainActor
     private func cellView(for item: SidebarOutlineItem) -> NSView {
       switch item.kind {
-      case .currentAccountsHeader: return headerCell("Current Accounts")
-      case .investmentsHeader: return headerCell("Investments")
       case .account(let id): return accountCell(id: id)
       case .group(let id): return groupCell(id: id)
       }
-    }
-
-    /// Source-list group-row cell. `NSOutlineView` styles the cell with
-    /// the capitalised, secondary-text-colour treatment when
-    /// `outlineView(_:isGroupItem:)` returns `true` — we just supply the
-    /// text. The explicit title keeps VoiceOver pronunciation
-    /// predictable (NSOutlineView's automatic uppercasing is a render
-    /// transform, not the underlying accessibility string).
-    private func headerCell(_ title: String) -> NSView {
-      let cell = NSTableCellView()
-      let field = NSTextField(labelWithString: title)
-      field.translatesAutoresizingMaskIntoConstraints = false
-      cell.addSubview(field)
-      cell.textField = field
-      NSLayoutConstraint.activate([
-        field.leadingAnchor.constraint(equalTo: cell.leadingAnchor),
-        field.trailingAnchor.constraint(equalTo: cell.trailingAnchor),
-        field.centerYAnchor.constraint(equalTo: cell.centerYAnchor),
-      ])
-      return cell
     }
 
     private func accountCell(id: UUID) -> NSView {
@@ -161,15 +179,10 @@
     /// uses to drive per-row expand state) and
     /// `GroupUIStateStore.expandedGroupIds`.
     ///
-    /// Section-header items (`.currentAccountsHeader` /
-    /// `.investmentsHeader`) are unconditionally reported as expanded —
-    /// the user can't permanently collapse "Current Accounts" or
-    /// "Investments" away. The setter ignores any add / remove of
-    /// header kinds; only `.group(id)` transitions reach the store.
-    ///
-    /// Account-row kinds (`.account(id)`) are leaves with no children,
-    /// so they never appear in the bound set. The setter tolerates
-    /// them defensively but treats them as no-ops.
+    /// Only `.group(id)` kinds are tracked — account rows are leaves
+    /// and never appear in the bound set. Section headers no longer
+    /// exist in the tree (they're SwiftUI sections now), so there's
+    /// nothing to anchor open.
     ///
     /// Each group transition is dispatched as a `Task` calling
     /// `setExpanded(_:for:)`. `GroupUIStateStore` is `@MainActor`-bound;
@@ -193,16 +206,7 @@
       groupStore: GroupUIStateStore
     ) -> Binding<Set<SidebarOutlineItem.Kind>> {
       Binding(
-        get: {
-          var set: Set<SidebarOutlineItem.Kind> = [
-            .currentAccountsHeader,
-            .investmentsHeader,
-          ]
-          for groupId in groupStore.expandedGroupIds {
-            set.insert(.group(groupId))
-          }
-          return set
-        },
+        get: { Set(groupStore.expandedGroupIds.map { .group($0) }) },
         set: { newValue in
           let newGroupExpansion: Set<UUID> = Set(
             newValue.compactMap { kind -> UUID? in
@@ -223,12 +227,9 @@
     // MARK: - Selection mapping
 
     /// Maps between the outline's `SidebarOutlineItem?` selection and
-    /// the app's `SidebarSelection?`. Section-header rows are
-    /// non-selectable (the `outlineViewIsGroupItem` hook disables
-    /// selection on them via the vendored delegate); they never reach
-    /// the setter. Earmark / navigation selections that come from the
-    /// sibling SwiftUI `List` map to `nil` on the outline side so the
-    /// outline does not highlight a stale row.
+    /// the app's `SidebarSelection?`. Earmark / navigation selections
+    /// that come from the sibling SwiftUI `List` map to `nil` on the
+    /// outline side so the outline does not highlight a stale row.
     private var outlineSelectionBinding: Binding<SidebarOutlineItem?> {
       Binding(
         get: {
@@ -246,8 +247,7 @@
           switch newItem?.kind {
           case .account(let id): selection = .account(id)
           case .group(let id): selection = .group(id)
-          case .currentAccountsHeader, .investmentsHeader, .none:
-            break
+          case .none: break
           }
         }
       )

--- a/Features/Navigation/SidebarSharedModifiers.swift
+++ b/Features/Navigation/SidebarSharedModifiers.swift
@@ -1,0 +1,199 @@
+// Cross-platform modifier stack shared between the macOS and iOS
+// sidebar bodies. Lives in its own file so neither `SidebarView.swift`
+// nor `SidebarView+Sections.swift` carries the full modifier chain
+// twice. The modifier is `fileprivate` to the sidebar feature — it is
+// not intended for use elsewhere.
+
+import SwiftUI
+
+/// Cross-platform modifier stack for `SidebarView`. Wraps the chain
+/// once so the macOS and iOS bodies don't each carry a copy. State and
+/// store handles are passed in explicitly because some of
+/// `SidebarView`'s properties are `private` and cannot be reached from
+/// a sibling type by inspecting the view value.
+struct SidebarSharedModifiers: ViewModifier {
+  let session: ProfileSession
+  let accountStore: AccountStore
+  let earmarkStore: EarmarkStore
+  let transactionStore: TransactionStore
+  @Binding var showHidden: Bool
+  @Binding var showSpam: Bool
+  @Binding var selection: SidebarSelection?
+  let selectedAccountBinding: Binding<Account?>
+  @Binding var showCreateEarmarkSheet: Bool
+  @Binding var showCreateAccountSheet: Bool
+  @Binding var accountToEdit: Account?
+  let onRequestAccountEdit: (Notification) -> Void
+
+  func body(content: Content) -> some View {
+    content
+      .navigationTitle("")
+      .modifier(sceneValues)
+      .modifier(storeBridges)
+      .refreshable {
+        // Both AccountStore and EarmarkStore are reactive (subscribe via
+        // observeAll() in init), so pull-to-refresh has nothing
+        // imperative left to nudge here. Pull is still wired so the
+        // system gesture resolves with the standard animation.
+      }
+      .safeAreaInset(edge: .bottom, spacing: 0) {
+        SyncProgressFooter()
+      }
+      #if os(macOS)
+        .toolbar { toolbarContent }
+      #endif
+      .modifier(sheets)
+      .onReceive(
+        NotificationCenter.default.publisher(for: .requestAccountEdit),
+        perform: onRequestAccountEdit
+      )
+  }
+
+  /// Focused-scene-value bindings: surfaced as keypath-bound focus
+  /// values so menu-bar commands (`MoolahDomainCommands`) can pick up
+  /// the current sidebar context.
+  private var sceneValues: some ViewModifier {
+    SidebarSceneValuesModifier(
+      showHidden: $showHidden,
+      showSpam: $showSpam,
+      selection: $selection,
+      selectedAccountBinding: selectedAccountBinding,
+      showCreateEarmarkSheet: $showCreateEarmarkSheet,
+      showCreateAccountSheet: $showCreateAccountSheet)
+  }
+
+  /// Store-bridging modifiers: propagate `@AppStorage` flags into the
+  /// account / earmark / transaction stores on first appearance and on
+  /// change.
+  private var storeBridges: some ViewModifier {
+    SidebarStoreBridgesModifier(
+      accountStore: accountStore,
+      earmarkStore: earmarkStore,
+      transactionStore: transactionStore,
+      showHidden: showHidden,
+      showSpam: showSpam)
+  }
+
+  /// The three sheets driven by sidebar state: create earmark, create
+  /// account, edit account.
+  private var sheets: some ViewModifier {
+    SidebarSheetsModifier(
+      session: session,
+      accountStore: accountStore,
+      earmarkStore: earmarkStore,
+      showCreateEarmarkSheet: $showCreateEarmarkSheet,
+      showCreateAccountSheet: $showCreateAccountSheet,
+      accountToEdit: $accountToEdit)
+  }
+
+  #if os(macOS)
+    @ToolbarContentBuilder private var toolbarContent: some ToolbarContent {
+      ToolbarItem(placement: .primaryAction) {
+        Button {
+          showCreateAccountSheet = true
+        } label: {
+          Label("New Account", systemImage: "plus")
+        }
+        .help("Create new account")
+        .accessibilityIdentifier(UITestIdentifiers.Sidebar.newAccountButton)
+      }
+      ToolbarItem(placement: .primaryAction) {
+        Button {
+          showCreateEarmarkSheet = true
+        } label: {
+          Label("New Earmark", systemImage: "bookmark.fill")
+        }
+        .help("Create new earmark")
+        .accessibilityIdentifier(UITestIdentifiers.Sidebar.newEarmarkButton)
+      }
+    }
+  #endif
+}
+
+/// Carries the focused-scene-value bindings out of the main shared
+/// modifier so the latter stays inside SwiftLint's body-length budget.
+private struct SidebarSceneValuesModifier: ViewModifier {
+  @Binding var showHidden: Bool
+  @Binding var showSpam: Bool
+  @Binding var selection: SidebarSelection?
+  let selectedAccountBinding: Binding<Account?>
+  @Binding var showCreateEarmarkSheet: Bool
+  @Binding var showCreateAccountSheet: Bool
+
+  func body(content: Content) -> some View {
+    content
+      .focusedSceneValue(\.showHiddenAccounts, $showHidden)
+      .focusedSceneValue(\.showSpamTransactions, $showSpam)
+      .focusedSceneValue(\.sidebarSelection, $selection)
+      .focusedSceneValue(\.selectedAccount, selectedAccountBinding)
+      .focusedSceneValue(\.newEarmarkAction) {
+        showCreateEarmarkSheet = true
+      }
+      .focusedSceneValue(\.newAccountAction) {
+        showCreateAccountSheet = true
+      }
+  }
+}
+
+/// Bridges the `@AppStorage` hidden / spam flags through to the
+/// account, earmark, and transaction stores on appearance and on
+/// change.
+private struct SidebarStoreBridgesModifier: ViewModifier {
+  let accountStore: AccountStore
+  let earmarkStore: EarmarkStore
+  let transactionStore: TransactionStore
+  let showHidden: Bool
+  let showSpam: Bool
+
+  func body(content: Content) -> some View {
+    content
+      .onChange(of: showHidden) { _, newValue in
+        accountStore.showHidden = newValue
+        earmarkStore.showHidden = newValue
+      }
+      .onChange(of: showSpam) { _, newValue in
+        transactionStore.showSpam = newValue
+      }
+      .onAppear {
+        accountStore.showHidden = showHidden
+        earmarkStore.showHidden = showHidden
+        transactionStore.showSpam = showSpam
+      }
+  }
+}
+
+/// The three sidebar-owned sheets: create earmark, create account,
+/// edit account.
+private struct SidebarSheetsModifier: ViewModifier {
+  let session: ProfileSession
+  let accountStore: AccountStore
+  let earmarkStore: EarmarkStore
+  @Binding var showCreateEarmarkSheet: Bool
+  @Binding var showCreateAccountSheet: Bool
+  @Binding var accountToEdit: Account?
+
+  func body(content: Content) -> some View {
+    content
+      .sheet(isPresented: $showCreateEarmarkSheet) {
+        CreateEarmarkSheet(
+          instrument: session.profile.instrument,
+          onCreate: { newEarmark in
+            Task {
+              _ = await earmarkStore.create(newEarmark)
+              showCreateEarmarkSheet = false
+            }
+          }
+        )
+      }
+      .sheet(isPresented: $showCreateAccountSheet) {
+        CreateAccountView(
+          instrument: session.profile.instrument,
+          accountStore: accountStore,
+          cryptoSyncStore: session.cryptoSyncStore)
+      }
+      .sheet(item: $accountToEdit) { account in
+        EditAccountView(
+          account: account, accountStore: accountStore)
+      }
+  }
+}

--- a/Features/Navigation/SidebarView+Groups.swift
+++ b/Features/Navigation/SidebarView+Groups.swift
@@ -6,262 +6,264 @@
 import SwiftUI
 import UniformTypeIdentifiers
 
-extension SidebarView {
+#if os(iOS)
+  extension SidebarView {
 
-  // MARK: - Row builders
+    // MARK: - Row builders
 
-  /// Renders a single group entry: the disclosure-aware group row +
-  /// member rows when expanded. Group selection routes through
-  /// `SidebarSelection.group(id)`; Phase 5 will give that a real
-  /// detail surface, Phase 4 lands on a placeholder.
-  @ViewBuilder
-  func groupSidebarEntry(_ group: AccountGroup, members: [Account]) -> some View {
-    groupRowLink(group)
-    if expandBinding(for: group.id).wrappedValue {
-      ForEach(members) { member in
-        memberRowLink(member)
+    /// Renders a single group entry: the disclosure-aware group row +
+    /// member rows when expanded. Group selection routes through
+    /// `SidebarSelection.group(id)`; Phase 5 will give that a real
+    /// detail surface, Phase 4 lands on a placeholder.
+    @ViewBuilder
+    func groupSidebarEntry(_ group: AccountGroup, members: [Account]) -> some View {
+      groupRowLink(group)
+      if expandBinding(for: group.id).wrappedValue {
+        ForEach(members) { member in
+          memberRowLink(member)
+        }
       }
     }
-  }
 
-  /// The clickable group row + its drop / context-menu modifiers. Drop
-  /// onto a group row adds an account to that group (cross-bucket
-  /// rejected); group-onto-group drop is rejected (no nesting).
-  ///
-  /// The aggregate balance is computed by `GroupAggregateBalanceLoader`
-  /// — a thin wrapper that owns the `@State InstrumentAmount?` and
-  /// recomputes via `AccountStore.aggregateBalance(for:in:)` whenever
-  /// the member set changes. Per
-  /// `feedback_conversion_failure_ux.md`, a conversion failure on any
-  /// member surfaces as `nil` (badge / spinner), never a partial sum.
-  @ViewBuilder
-  func groupRowLink(_ group: AccountGroup) -> some View {
-    let memberIds = accountStore.accounts.ordered
-      .filter { $0.groupId == group.id }
-      .sorted(by: { $0.position < $1.position })
-      .map(\.id)
-    NavigationLink(value: SidebarSelection.group(group.id)) {
-      GroupAggregateBalanceLoader(
-        memberIds: memberIds,
-        targetInstrument: group.instrument
-      ) { balance in
-        AccountGroupSidebarRow(
-          group: group,
-          isSelected: selection == .group(group.id),
-          isExpanded: expandBinding(for: group.id),
-          aggregateBalance: balance,
-          isEditing: renameBinding(for: group.id),
-          onRename: renameAction(for: group)
+    /// The clickable group row + its drop / context-menu modifiers. Drop
+    /// onto a group row adds an account to that group (cross-bucket
+    /// rejected); group-onto-group drop is rejected (no nesting).
+    ///
+    /// The aggregate balance is computed by `GroupAggregateBalanceLoader`
+    /// — a thin wrapper that owns the `@State InstrumentAmount?` and
+    /// recomputes via `AccountStore.aggregateBalance(for:in:)` whenever
+    /// the member set changes. Per
+    /// `feedback_conversion_failure_ux.md`, a conversion failure on any
+    /// member surfaces as `nil` (badge / spinner), never a partial sum.
+    @ViewBuilder
+    func groupRowLink(_ group: AccountGroup) -> some View {
+      let memberIds = accountStore.accounts.ordered
+        .filter { $0.groupId == group.id }
+        .sorted(by: { $0.position < $1.position })
+        .map(\.id)
+      NavigationLink(value: SidebarSelection.group(group.id)) {
+        GroupAggregateBalanceLoader(
+          memberIds: memberIds,
+          targetInstrument: group.instrument
+        ) { balance in
+          AccountGroupSidebarRow(
+            group: group,
+            isSelected: selection == .group(group.id),
+            isExpanded: expandBinding(for: group.id),
+            aggregateBalance: balance,
+            isEditing: renameBinding(for: group.id),
+            onRename: renameAction(for: group)
+          )
+        }
+      }
+      .accessibilityIdentifier(UITestIdentifiers.Sidebar.group(group.id))
+      .draggable(DraggableSidebarItem(kind: .group, id: group.id))
+      .dropDestination(for: DraggableSidebarItem.self) { items, _ in
+        guard let item = items.first else { return false }
+        Task { await handleDrop(item, ontoGroup: group) }
+        return true
+      }
+      .contextMenu { groupContextMenu(for: group) }
+    }
+
+    /// A member row: same `AccountSidebarRow` shape as standalone, but
+    /// rendered with the `isMember` style hint so the secondary line
+    /// (chain / address / exchange provider) surfaces. The drag source
+    /// is a `.account` `DraggableSidebarItem`; dropping onto another
+    /// account/group works as it does for standalone accounts.
+    @ViewBuilder
+    func memberRowLink(_ account: Account) -> some View {
+      NavigationLink(value: SidebarSelection.account(account.id)) {
+        AccountSidebarRow(
+          account: account,
+          isSelected: selection == .account(account.id),
+          isMember: true,
+          isEditing: renameBinding(for: account.id),
+          onRename: renameAction(for: account)
+        )
+        .padding(.leading, 16)
+      }
+      .accessibilityIdentifier(UITestIdentifiers.Sidebar.account(account.id))
+      .draggable(DraggableSidebarItem(kind: .account, id: account.id))
+      .dropDestination(for: DraggableSidebarItem.self) { items, _ in
+        guard let item = items.first else { return false }
+        Task { await handleDrop(item, ontoAccount: account) }
+        return true
+      }
+      .contextMenu { accountContextMenu(for: account) }
+    }
+
+    /// Standalone account row, wired with drag / drop / group context
+    /// menu. Used by both the Current and Investments sections in place
+    /// of the previous inline row construction so the drop / drag
+    /// modifiers stay consistent across bucket sections.
+    @ViewBuilder
+    func standaloneAccountRowLink(_ account: Account) -> some View {
+      NavigationLink(value: SidebarSelection.account(account.id)) {
+        AccountSidebarRow(
+          account: account,
+          isSelected: selection == .account(account.id),
+          isEditing: renameBinding(for: account.id),
+          onRename: renameAction(for: account)
         )
       }
+      .dropDestination(for: URL.self) { urls, _ in
+        Task { await ingestDroppedURLs(urls, forcedAccountId: account.id) }
+        return !urls.isEmpty
+      }
+      .draggable(DraggableSidebarItem(kind: .account, id: account.id))
+      .dropDestination(for: DraggableSidebarItem.self) { items, _ in
+        guard let item = items.first else { return false }
+        Task { await handleDrop(item, ontoAccount: account) }
+        return true
+      }
+      .accessibilityIdentifier(UITestIdentifiers.Sidebar.account(account.id))
+      .contextMenu { accountContextMenu(for: account) }
     }
-    .accessibilityIdentifier(UITestIdentifiers.Sidebar.group(group.id))
-    .draggable(DraggableSidebarItem(kind: .group, id: group.id))
-    .dropDestination(for: DraggableSidebarItem.self) { items, _ in
-      guard let item = items.first else { return false }
-      Task { await handleDrop(item, ontoGroup: group) }
-      return true
-    }
-    .contextMenu { groupContextMenu(for: group) }
-  }
 
-  /// A member row: same `AccountSidebarRow` shape as standalone, but
-  /// rendered with the `isMember` style hint so the secondary line
-  /// (chain / address / exchange provider) surfaces. The drag source
-  /// is a `.account` `DraggableSidebarItem`; dropping onto another
-  /// account/group works as it does for standalone accounts.
-  @ViewBuilder
-  func memberRowLink(_ account: Account) -> some View {
-    NavigationLink(value: SidebarSelection.account(account.id)) {
-      AccountSidebarRow(
-        account: account,
-        isSelected: selection == .account(account.id),
-        isMember: true,
-        isEditing: renameBinding(for: account.id),
-        onRename: renameAction(for: account)
-      )
-      .padding(.leading, 16)
-    }
-    .accessibilityIdentifier(UITestIdentifiers.Sidebar.account(account.id))
-    .draggable(DraggableSidebarItem(kind: .account, id: account.id))
-    .dropDestination(for: DraggableSidebarItem.self) { items, _ in
-      guard let item = items.first else { return false }
-      Task { await handleDrop(item, ontoAccount: account) }
-      return true
-    }
-    .contextMenu { accountContextMenu(for: account) }
-  }
+    // MARK: - Expand state
 
-  /// Standalone account row, wired with drag / drop / group context
-  /// menu. Used by both the Current and Investments sections in place
-  /// of the previous inline row construction so the drop / drag
-  /// modifiers stay consistent across bucket sections.
-  @ViewBuilder
-  func standaloneAccountRowLink(_ account: Account) -> some View {
-    NavigationLink(value: SidebarSelection.account(account.id)) {
-      AccountSidebarRow(
-        account: account,
-        isSelected: selection == .account(account.id),
-        isEditing: renameBinding(for: account.id),
-        onRename: renameAction(for: account)
+    /// Returns a two-way binding to the expand state of `groupId`.
+    /// Reads from `groupUIStateStore.expandedGroupIds` (driven by the
+    /// reactive observation of the local-only `account_group_ui` table)
+    /// and writes through `setExpanded(_:for:)` so the change is
+    /// persisted per profile and survives app relaunch.
+    ///
+    /// The store closes the loop: setExpanded → repo write → observation
+    /// emits → `expandedGroupIds` updates → the binding's `get` returns
+    /// the new value → SwiftUI re-renders.
+    func expandBinding(for groupId: UUID) -> Binding<Bool> {
+      Binding(
+        get: { groupUIStateStore.expandedGroupIds.contains(groupId) },
+        set: { newValue in
+          Task { await groupUIStateStore.setExpanded(newValue, for: groupId) }
+        }
       )
     }
-    .dropDestination(for: URL.self) { urls, _ in
-      Task { await ingestDroppedURLs(urls, forcedAccountId: account.id) }
-      return !urls.isEmpty
-    }
-    .draggable(DraggableSidebarItem(kind: .account, id: account.id))
-    .dropDestination(for: DraggableSidebarItem.self) { items, _ in
-      guard let item = items.first else { return false }
-      Task { await handleDrop(item, ontoAccount: account) }
-      return true
-    }
-    .accessibilityIdentifier(UITestIdentifiers.Sidebar.account(account.id))
-    .contextMenu { accountContextMenu(for: account) }
-  }
 
-  // MARK: - Expand state
+    // MARK: - Context menus
 
-  /// Returns a two-way binding to the expand state of `groupId`.
-  /// Reads from `groupUIStateStore.expandedGroupIds` (driven by the
-  /// reactive observation of the local-only `account_group_ui` table)
-  /// and writes through `setExpanded(_:for:)` so the change is
-  /// persisted per profile and survives app relaunch.
-  ///
-  /// The store closes the loop: setExpanded → repo write → observation
-  /// emits → `expandedGroupIds` updates → the binding's `get` returns
-  /// the new value → SwiftUI re-renders.
-  func expandBinding(for groupId: UUID) -> Binding<Bool> {
-    Binding(
-      get: { groupUIStateStore.expandedGroupIds.contains(groupId) },
-      set: { newValue in
-        Task { await groupUIStateStore.setExpanded(newValue, for: groupId) }
+    /// Right-click menu for a group row. Phase 4 only exposes Rename;
+    /// the spec explicitly excludes Hide and Delete for groups (membership
+    /// is the unit of group lifecycle: remove the last member to delete
+    /// the group).
+    @ViewBuilder
+    func groupContextMenu(for group: AccountGroup) -> some View {
+      Button("Rename", systemImage: "character.cursor.ibeam") {
+        editingRowId = group.id
       }
-    )
-  }
-
-  // MARK: - Context menus
-
-  /// Right-click menu for a group row. Phase 4 only exposes Rename;
-  /// the spec explicitly excludes Hide and Delete for groups (membership
-  /// is the unit of group lifecycle: remove the last member to delete
-  /// the group).
-  @ViewBuilder
-  func groupContextMenu(for group: AccountGroup) -> some View {
-    Button("Rename", systemImage: "character.cursor.ibeam") {
-      editingRowId = group.id
+      .accessibilityIdentifier(UITestIdentifiers.Sidebar.renameContextMenuItem)
     }
-    .accessibilityIdentifier(UITestIdentifiers.Sidebar.renameContextMenuItem)
-  }
 
-  /// "Group ▸" submenu inside an account's right-click menu. Lists the
-  /// other groups in the account's bucket, then a "New Group…" entry,
-  /// then a "Remove from Group" entry if the account is currently in a
-  /// group. Same-bucket constraint is enforced by filtering the move
-  /// list to `bucket == account.bucket`.
-  @ViewBuilder
-  func accountGroupSubmenu(for account: Account) -> some View {
-    let groupsInBucket = accountGroupStore.groups
-      .filter { $0.bucket == account.bucket && $0.id != account.groupId }
-    Menu {
-      ForEach(groupsInBucket) { group in
-        Button(group.name) {
-          Task {
-            try? await accountGroupStore.addAccount(
-              account, to: group, accountStore: accountStore)
+    /// "Group ▸" submenu inside an account's right-click menu. Lists the
+    /// other groups in the account's bucket, then a "New Group…" entry,
+    /// then a "Remove from Group" entry if the account is currently in a
+    /// group. Same-bucket constraint is enforced by filtering the move
+    /// list to `bucket == account.bucket`.
+    @ViewBuilder
+    func accountGroupSubmenu(for account: Account) -> some View {
+      let groupsInBucket = accountGroupStore.groups
+        .filter { $0.bucket == account.bucket && $0.id != account.groupId }
+      Menu {
+        ForEach(groupsInBucket) { group in
+          Button(group.name) {
+            Task {
+              try? await accountGroupStore.addAccount(
+                account, to: group, accountStore: accountStore)
+            }
           }
         }
-      }
-      if !groupsInBucket.isEmpty { Divider() }
-      Button("New Group\u{2026}") {
-        Task { await createGroupFromAccount(account) }
-      }
-      if account.groupId != nil {
-        Divider()
-        Button("Remove from Group") {
-          Task {
-            try? await accountGroupStore.removeAccount(
-              account, accountStore: accountStore)
+        if !groupsInBucket.isEmpty { Divider() }
+        Button("New Group\u{2026}") {
+          Task { await createGroupFromAccount(account) }
+        }
+        if account.groupId != nil {
+          Divider()
+          Button("Remove from Group") {
+            Task {
+              try? await accountGroupStore.removeAccount(
+                account, accountStore: accountStore)
+            }
           }
         }
+      } label: {
+        Label("Group", systemImage: "folder")
       }
-    } label: {
-      Label("Group", systemImage: "folder")
+      .accessibilityIdentifier(UITestIdentifiers.Sidebar.groupSubmenu)
     }
-    .accessibilityIdentifier(UITestIdentifiers.Sidebar.groupSubmenu)
-  }
 
-  // MARK: - Drop handling
+    // MARK: - Drop handling
 
-  /// Policy gate for a drop targeting an account row. Same-bucket only;
-  /// group-onto-account is rejected; account-onto-account in the same
-  /// bucket creates a new 2-member group (or moves the dragged account
-  /// into the target's existing group when the target is itself a
-  /// member).
-  func handleDrop(
-    _ item: DraggableSidebarItem,
-    ontoAccount target: Account
-  ) async {
-    guard item.kind == .account else { return }  // group-onto-account = no-op
-    guard let source = accountStore.accounts.by(id: item.id) else { return }
-    guard source.id != target.id else { return }  // self-drop
-    guard source.bucket == target.bucket else { return }  // cross-bucket rejected
+    /// Policy gate for a drop targeting an account row. Same-bucket only;
+    /// group-onto-account is rejected; account-onto-account in the same
+    /// bucket creates a new 2-member group (or moves the dragged account
+    /// into the target's existing group when the target is itself a
+    /// member).
+    func handleDrop(
+      _ item: DraggableSidebarItem,
+      ontoAccount target: Account
+    ) async {
+      guard item.kind == .account else { return }  // group-onto-account = no-op
+      guard let source = accountStore.accounts.by(id: item.id) else { return }
+      guard source.id != target.id else { return }  // self-drop
+      guard source.bucket == target.bucket else { return }  // cross-bucket rejected
 
-    if let targetGroupId = target.groupId {
-      // Target is already a member: add source to the same group.
-      guard let group = accountGroupStore.by(id: targetGroupId) else { return }
+      if let targetGroupId = target.groupId {
+        // Target is already a member: add source to the same group.
+        guard let group = accountGroupStore.by(id: targetGroupId) else { return }
+        try? await accountGroupStore.addAccount(
+          source, to: group, accountStore: accountStore)
+        return
+      }
+
+      // Both standalone: create a 2-member group and put it in rename mode.
+      do {
+        let created = try await accountGroupStore.createGroup(
+          joining: target,
+          and: source,
+          name: "New Group",
+          accountStore: accountStore
+        )
+        editingRowId = created.id
+        await groupUIStateStore.setExpanded(true, for: created.id)
+      } catch {
+        // Error already surfaced on the store; no extra UI hop needed.
+      }
+    }
+
+    /// Policy gate for a drop targeting a group row. Adds the dragged
+    /// account to the group; rejects group-onto-group (no nesting) and
+    /// cross-bucket.
+    func handleDrop(
+      _ item: DraggableSidebarItem,
+      ontoGroup target: AccountGroup
+    ) async {
+      guard item.kind == .account else { return }  // group-onto-group rejected
+      guard let source = accountStore.accounts.by(id: item.id) else { return }
+      guard source.bucket == target.bucket else { return }
+      if source.groupId == target.id { return }  // already in this group
+
       try? await accountGroupStore.addAccount(
-        source, to: group, accountStore: accountStore)
-      return
+        source, to: target, accountStore: accountStore)
     }
 
-    // Both standalone: create a 2-member group and put it in rename mode.
-    do {
-      let created = try await accountGroupStore.createGroup(
-        joining: target,
-        and: source,
-        name: "New Group",
-        accountStore: accountStore
-      )
-      editingRowId = created.id
-      await groupUIStateStore.setExpanded(true, for: created.id)
-    } catch {
-      // Error already surfaced on the store; no extra UI hop needed.
+    // MARK: - Creation flows
+
+    /// Right-click → New Group… → creates a single-member group from the
+    /// source account and immediately enters inline rename mode so the
+    /// user can overwrite the default "New Group" placeholder.
+    func createGroupFromAccount(_ account: Account) async {
+      do {
+        let created = try await accountGroupStore.createGroup(
+          from: account, name: "New Group", accountStore: accountStore)
+        editingRowId = created.id
+        await groupUIStateStore.setExpanded(true, for: created.id)
+      } catch {
+        // Error surfaces on `accountGroupStore.error`; no extra UI hop.
+      }
     }
   }
-
-  /// Policy gate for a drop targeting a group row. Adds the dragged
-  /// account to the group; rejects group-onto-group (no nesting) and
-  /// cross-bucket.
-  func handleDrop(
-    _ item: DraggableSidebarItem,
-    ontoGroup target: AccountGroup
-  ) async {
-    guard item.kind == .account else { return }  // group-onto-group rejected
-    guard let source = accountStore.accounts.by(id: item.id) else { return }
-    guard source.bucket == target.bucket else { return }
-    if source.groupId == target.id { return }  // already in this group
-
-    try? await accountGroupStore.addAccount(
-      source, to: target, accountStore: accountStore)
-  }
-
-  // MARK: - Creation flows
-
-  /// Right-click → New Group… → creates a single-member group from the
-  /// source account and immediately enters inline rename mode so the
-  /// user can overwrite the default "New Group" placeholder.
-  func createGroupFromAccount(_ account: Account) async {
-    do {
-      let created = try await accountGroupStore.createGroup(
-        from: account, name: "New Group", accountStore: accountStore)
-      editingRowId = created.id
-      await groupUIStateStore.setExpanded(true, for: created.id)
-    } catch {
-      // Error surfaces on `accountGroupStore.error`; no extra UI hop.
-    }
-  }
-}
+#endif
 
 // MARK: - Transferable wrapper
 

--- a/Features/Navigation/SidebarView+Previews.swift
+++ b/Features/Navigation/SidebarView+Previews.swift
@@ -120,6 +120,74 @@ private func seedSidebarGroupPreview(
   }
 }
 
+#if os(macOS)
+  /// Seeding helper for the macOS outline preview. Mirrors
+  /// `seedSidebarGroupPreview` above but adds a standalone bank account
+  /// so the preview exercises both the standalone-account and group
+  /// rendering paths in `SidebarOutlineView`. Extracted from the inline
+  /// `.task { }` closure to satisfy SwiftLint's closure_body_length
+  /// rule.
+  @MainActor
+  private func seedOutlinePreview(
+    backend: any BackendProvider,
+    accountStore: AccountStore,
+    accountGroupStore: AccountGroupStore
+  ) async {
+    _ = try? await backend.accounts.create(
+      Account(name: "Bank", type: .bank, instrument: .AUD),
+      openingBalance: InstrumentAmount(quantity: 1000, instrument: .AUD))
+    let walletAAccount = Account(
+      name: "ETH/OP wallet",
+      type: .crypto,
+      instrument: .AUD,
+      walletAddress: "0x7a3f1b5c9d2e8f4a1b6c3d5e7f9a0b2c4d6e8f0a",
+      chainId: 1)
+    let walletBAccount = Account(
+      name: "Polygon wallet",
+      type: .crypto,
+      instrument: .AUD,
+      walletAddress: "0x7a3f1b5c9d2e8f4a1b6c3d5e7f9a0b2c4d6e8f0a",
+      chainId: 137)
+    guard
+      let walletA = try? await backend.accounts.create(
+        walletAAccount,
+        openingBalance: InstrumentAmount(quantity: 5210, instrument: .AUD)),
+      let walletB = try? await backend.accounts.create(
+        walletBAccount,
+        openingBalance: InstrumentAmount(quantity: 410, instrument: .AUD))
+    else { return }
+    _ = try? await accountGroupStore.createGroup(
+      joining: walletA,
+      and: walletB,
+      name: "Trust Fund Crypto",
+      accountStore: accountStore
+    )
+  }
+
+  #Preview("macOS outline — Phase 1 skeleton") {
+    // Drives the new `SidebarOutlineView` directly (no NavigationSplitView,
+    // no surrounding List): Task 4 wires it into the SwiftUI sidebar, this
+    // preview just renders the outline in isolation so the cell layout +
+    // selection wiring can be eyeballed.
+    let backend = PreviewBackend.create()
+    let accountStore = AccountStore(
+      repository: backend.accounts,
+      conversionService: backend.conversionService,
+      targetInstrument: .AUD)
+    let accountGroupStore = AccountGroupStore(repository: backend.accountGroups)
+    return SidebarOutlineView(selection: .constant(nil))
+      .environment(accountStore)
+      .environment(accountGroupStore)
+      .frame(width: 260, height: 480)
+      .task {
+        await seedOutlinePreview(
+          backend: backend,
+          accountStore: accountStore,
+          accountGroupStore: accountGroupStore)
+      }
+  }
+#endif
+
 #Preview("Empty earmarks") {
   let backend = PreviewBackend.create()
   let accountStore = AccountStore(

--- a/Features/Navigation/SidebarView+Previews.swift
+++ b/Features/Navigation/SidebarView+Previews.swift
@@ -176,7 +176,7 @@ private func seedSidebarGroupPreview(
       targetInstrument: .AUD)
     let accountGroupStore = AccountGroupStore(repository: backend.accountGroups)
     let groupUIStateStore = GroupUIStateStore(repository: backend.groupUIState)
-    return SidebarOutlineView(selection: .constant(nil))
+    return SidebarOutlineView(selection: .constant(nil), accountToEdit: .constant(nil))
       .environment(accountStore)
       .environment(accountGroupStore)
       .environment(groupUIStateStore)

--- a/Features/Navigation/SidebarView+Previews.swift
+++ b/Features/Navigation/SidebarView+Previews.swift
@@ -4,6 +4,60 @@
 
 import SwiftUI
 
+/// Builds an in-memory `SyncCoordinator` for `#Preview` use. `SidebarView`
+/// composes `SyncProgressFooter`, which reads
+/// `@Environment(SyncCoordinator.self)`; without the injection SwiftUI
+/// traps inside `EnvironmentBox.update` during initial layout.
+@MainActor
+private func previewSyncCoordinator() -> SyncCoordinator {
+  // swiftlint:disable:next force_try
+  let manager = try! ProfileContainerManager.forTesting()
+  return SyncCoordinator(containerManager: manager)
+}
+
+/// Builds an `AccountStore` against `backend` configured for previews.
+@MainActor
+private func previewAccountStore(_ backend: CloudKitBackend) -> AccountStore {
+  AccountStore(
+    repository: backend.accounts,
+    conversionService: backend.conversionService,
+    targetInstrument: .AUD)
+}
+
+/// Builds an `EarmarkStore` against `backend` configured for previews.
+@MainActor
+private func previewEarmarkStore(_ backend: CloudKitBackend) -> EarmarkStore {
+  EarmarkStore(
+    repository: backend.earmarks,
+    conversionService: backend.conversionService,
+    targetInstrument: .AUD)
+}
+
+/// Wraps `content` in the eight environment values `SidebarView` and
+/// its sub-views read (`AccountStore`, `EarmarkStore`,
+/// `AccountGroupStore`, `GroupUIStateStore`, `ProfileSession`,
+/// `TransactionStore`, `ImportStore`, `SyncCoordinator`). Extracted so
+/// each `#Preview` block fits SwiftLint's 30-line closure budget.
+@MainActor
+@ViewBuilder
+private func sidebarPreviewEnvironment<Content: View>(
+  backend: CloudKitBackend,
+  session: ProfileSession,
+  accountStore: AccountStore,
+  accountGroupStore: AccountGroupStore,
+  @ViewBuilder content: () -> Content
+) -> some View {
+  content()
+    .environment(accountStore)
+    .environment(previewEarmarkStore(backend))
+    .environment(accountGroupStore)
+    .environment(GroupUIStateStore(repository: backend.groupUIState))
+    .environment(session)
+    .environment(session.transactionStore)
+    .environment(session.importStore)
+    .environment(previewSyncCoordinator())
+}
+
 @MainActor
 private func seedSidebarPreview(backend: any BackendProvider) async {
   // Both `accountStore` and `earmarkStore` are reactive — they load
@@ -20,31 +74,23 @@ private func seedSidebarPreview(backend: any BackendProvider) async {
 
 #Preview {
   let backend = PreviewBackend.create()
-  let accountStore = AccountStore(
-    repository: backend.accounts,
-    conversionService: backend.conversionService,
-    targetInstrument: .AUD)
-  let earmarkStore = EarmarkStore(
-    repository: backend.earmarks,
-    conversionService: backend.conversionService,
-    targetInstrument: .AUD)
+  let accountStore = previewAccountStore(backend)
   let accountGroupStore = AccountGroupStore(repository: backend.accountGroups)
-  let groupUIStateStore = GroupUIStateStore(repository: backend.groupUIState)
   // In-memory preview session can't fail in practice: opens an ephemeral
   // GRDB queue with no disk access. A trap here is acceptable in #Preview.
   // swiftlint:disable:next force_try
   let session = try! ProfileSession.preview()
 
   return NavigationSplitView {
-    SidebarView(selection: .constant(nil))
-      .environment(accountStore)
-      .environment(earmarkStore)
-      .environment(accountGroupStore)
-      .environment(groupUIStateStore)
-      .environment(session)
-      .task {
-        await seedSidebarPreview(backend: backend)
-      }
+    sidebarPreviewEnvironment(
+      backend: backend,
+      session: session,
+      accountStore: accountStore,
+      accountGroupStore: accountGroupStore
+    ) {
+      SidebarView(selection: .constant(nil))
+        .task { await seedSidebarPreview(backend: backend) }
+    }
   } detail: {
     Text("Detail")
   }
@@ -56,9 +102,15 @@ private func seedSidebarGroupPreview(
   accountStore: AccountStore,
   accountGroupStore: AccountGroupStore
 ) async {
-  // Seed two crypto wallets, then create a group joining them. The
-  // preview renders the group as a single row with the two members
-  // tucked underneath when the user expands it.
+  // Seed a standalone bank account (so the Current Accounts section
+  // isn't empty in the preview), then two crypto wallets joined into a
+  // group. The preview renders the group as a single row with the two
+  // members tucked underneath when the user expands it.
+  _ = try? await backend.accounts.create(
+    Account(name: "Bank", type: .bank, instrument: .AUD),
+    openingBalance: InstrumentAmount(quantity: 1000, instrument: .AUD))
+  _ = try? await backend.earmarks.create(
+    Earmark(name: "Holiday Fund", instrument: .AUD))
   let walletAAccount = Account(
     name: "ETH/OP wallet",
     type: .crypto,
@@ -89,32 +141,26 @@ private func seedSidebarGroupPreview(
 
 #Preview("With a group") {
   let backend = PreviewBackend.create()
-  let accountStore = AccountStore(
-    repository: backend.accounts,
-    conversionService: backend.conversionService,
-    targetInstrument: .AUD)
-  let earmarkStore = EarmarkStore(
-    repository: backend.earmarks,
-    conversionService: backend.conversionService,
-    targetInstrument: .AUD)
+  let accountStore = previewAccountStore(backend)
   let accountGroupStore = AccountGroupStore(repository: backend.accountGroups)
-  let groupUIStateStore = GroupUIStateStore(repository: backend.groupUIState)
   // swiftlint:disable:next force_try
   let session = try! ProfileSession.preview()
 
   return NavigationSplitView {
-    SidebarView(selection: .constant(nil))
-      .environment(accountStore)
-      .environment(earmarkStore)
-      .environment(accountGroupStore)
-      .environment(groupUIStateStore)
-      .environment(session)
-      .task {
-        await seedSidebarGroupPreview(
-          backend: backend,
-          accountStore: accountStore,
-          accountGroupStore: accountGroupStore)
-      }
+    sidebarPreviewEnvironment(
+      backend: backend,
+      session: session,
+      accountStore: accountStore,
+      accountGroupStore: accountGroupStore
+    ) {
+      SidebarView(selection: .constant(nil))
+        .task {
+          await seedSidebarGroupPreview(
+            backend: backend,
+            accountStore: accountStore,
+            accountGroupStore: accountGroupStore)
+        }
+    }
   } detail: {
     Text("Detail")
   }
@@ -171,10 +217,7 @@ private func seedSidebarGroupPreview(
     // eyeballed. The full `SidebarView` preview above exercises both
     // buckets in their natural section context.
     let backend = PreviewBackend.create()
-    let accountStore = AccountStore(
-      repository: backend.accounts,
-      conversionService: backend.conversionService,
-      targetInstrument: .AUD)
+    let accountStore = previewAccountStore(backend)
     let accountGroupStore = AccountGroupStore(repository: backend.accountGroups)
     let groupUIStateStore = GroupUIStateStore(repository: backend.groupUIState)
     return SidebarOutlineView(
@@ -195,37 +238,28 @@ private func seedSidebarGroupPreview(
 
 #Preview("Empty earmarks") {
   let backend = PreviewBackend.create()
-  let accountStore = AccountStore(
-    repository: backend.accounts,
-    conversionService: backend.conversionService,
-    targetInstrument: .AUD)
-  let earmarkStore = EarmarkStore(
-    repository: backend.earmarks,
-    conversionService: backend.conversionService,
-    targetInstrument: .AUD)
+  let accountStore = previewAccountStore(backend)
   let accountGroupStore = AccountGroupStore(repository: backend.accountGroups)
-  let groupUIStateStore = GroupUIStateStore(repository: backend.groupUIState)
   // In-memory preview session can't fail in practice: opens an ephemeral
   // GRDB queue with no disk access. A trap here is acceptable in #Preview.
   // swiftlint:disable:next force_try
   let session = try! ProfileSession.preview()
 
   return NavigationSplitView {
-    SidebarView(selection: .constant(nil))
-      .environment(accountStore)
-      .environment(earmarkStore)
-      .environment(accountGroupStore)
-      .environment(groupUIStateStore)
-      .environment(session)
-      .task {
-        // Seed only an account — no earmarks. Validates that the
-        // Earmarks section header (and its iOS "+" button) renders in
-        // the empty-state, and that the macOS toolbar shows both the
-        // "New Account" and "New Earmark" buttons.
-        _ = try? await backend.accounts.create(
-          Account(name: "Bank", type: .bank, instrument: .AUD),
-          openingBalance: InstrumentAmount(quantity: 1000, instrument: .AUD))
-      }
+    sidebarPreviewEnvironment(
+      backend: backend,
+      session: session,
+      accountStore: accountStore,
+      accountGroupStore: accountGroupStore
+    ) {
+      SidebarView(selection: .constant(nil))
+        .task {
+          // Seed only an account — no earmarks.
+          _ = try? await backend.accounts.create(
+            Account(name: "Bank", type: .bank, instrument: .AUD),
+            openingBalance: InstrumentAmount(quantity: 1000, instrument: .AUD))
+        }
+    }
   } detail: {
     Text("Detail")
   }

--- a/Features/Navigation/SidebarView+Previews.swift
+++ b/Features/Navigation/SidebarView+Previews.swift
@@ -175,9 +175,11 @@ private func seedSidebarGroupPreview(
       conversionService: backend.conversionService,
       targetInstrument: .AUD)
     let accountGroupStore = AccountGroupStore(repository: backend.accountGroups)
+    let groupUIStateStore = GroupUIStateStore(repository: backend.groupUIState)
     return SidebarOutlineView(selection: .constant(nil))
       .environment(accountStore)
       .environment(accountGroupStore)
+      .environment(groupUIStateStore)
       .frame(width: 260, height: 480)
       .task {
         await seedOutlinePreview(

--- a/Features/Navigation/SidebarView+Previews.swift
+++ b/Features/Navigation/SidebarView+Previews.swift
@@ -166,9 +166,10 @@ private func seedSidebarGroupPreview(
 
   #Preview("macOS outline — Phase 1 skeleton") {
     // Drives the new `SidebarOutlineView` directly (no NavigationSplitView,
-    // no surrounding List): Task 4 wires it into the SwiftUI sidebar, this
-    // preview just renders the outline in isolation so the cell layout +
-    // selection wiring can be eyeballed.
+    // no surrounding List): this preview renders the Investments bucket
+    // outline in isolation so the cell layout + selection wiring can be
+    // eyeballed. The full `SidebarView` preview above exercises both
+    // buckets in their natural section context.
     let backend = PreviewBackend.create()
     let accountStore = AccountStore(
       repository: backend.accounts,
@@ -176,17 +177,19 @@ private func seedSidebarGroupPreview(
       targetInstrument: .AUD)
     let accountGroupStore = AccountGroupStore(repository: backend.accountGroups)
     let groupUIStateStore = GroupUIStateStore(repository: backend.groupUIState)
-    return SidebarOutlineView(selection: .constant(nil), accountToEdit: .constant(nil))
-      .environment(accountStore)
-      .environment(accountGroupStore)
-      .environment(groupUIStateStore)
-      .frame(width: 260, height: 480)
-      .task {
-        await seedOutlinePreview(
-          backend: backend,
-          accountStore: accountStore,
-          accountGroupStore: accountGroupStore)
-      }
+    return SidebarOutlineView(
+      selection: .constant(nil), bucket: .investments, accountToEdit: .constant(nil)
+    )
+    .environment(accountStore)
+    .environment(accountGroupStore)
+    .environment(groupUIStateStore)
+    .frame(width: 260, height: 480)
+    .task {
+      await seedOutlinePreview(
+        backend: backend,
+        accountStore: accountStore,
+        accountGroupStore: accountGroupStore)
+    }
   }
 #endif
 

--- a/Features/Navigation/SidebarView+Sections.swift
+++ b/Features/Navigation/SidebarView+Sections.swift
@@ -12,10 +12,25 @@ extension SidebarView {
     accountToEdit = account
   }
 
-  #if os(iOS)
-    /// Current-bucket section — iOS only. macOS renders Current
-    /// Accounts via `SidebarOutlineView` (NSOutlineView), so this
-    /// SwiftUI builder is unreferenced on macOS and gated out.
+  #if os(macOS)
+    /// Current-bucket section — macOS variant. The section header is
+    /// a flat SwiftUI label (non-collapsible); the body embeds
+    /// `SidebarOutlineView` for the `.current` bucket so the
+    /// `NSOutlineView` only renders that bucket's contents. The
+    /// bucket total row stays inside this section so it scrolls with
+    /// the section content.
+    var currentAccountsSection: some View {
+      Section {
+        SidebarOutlineView(
+          selection: $selection, bucket: .current, accountToEdit: $accountToEdit)
+        totalRow(label: "Current Total", value: accountStore.convertedCurrentTotal)
+      } header: {
+        sectionHeader(title: "Current Accounts", addAction: addAccountAction)
+      }
+    }
+  #else
+    /// Current-bucket section — iOS variant. Single SwiftUI list with
+    /// inline rows; macOS has its own outline-backed version above.
     var currentAccountsSection: some View {
       let groupAware = accountStore.accounts.groupAwareSidebar(
         groups: accountGroupStore.groups,
@@ -55,10 +70,20 @@ extension SidebarView {
     }
   }
 
-  #if os(iOS)
-    /// Investments-bucket section — iOS only. macOS renders Investments
-    /// via `SidebarOutlineView` (NSOutlineView), so this SwiftUI
-    /// builder is unreferenced on macOS and gated out.
+  #if os(macOS)
+    /// Investments-bucket section — macOS variant. Mirrors
+    /// `currentAccountsSection` above: flat section label, outline
+    /// body, total row inside the section.
+    var investmentsSection: some View {
+      Section("Investments") {
+        SidebarOutlineView(
+          selection: $selection, bucket: .investments, accountToEdit: $accountToEdit)
+        totalRow(label: "Investment Total", value: accountStore.convertedInvestmentTotal)
+      }
+    }
+  #else
+    /// Investments-bucket section — iOS variant. Same SwiftUI rendering
+    /// pattern as `currentAccountsSection`.
     var investmentsSection: some View {
       let groupAware = accountStore.accounts.groupAwareSidebar(
         groups: accountGroupStore.groups,

--- a/Features/Navigation/SidebarView+Sections.swift
+++ b/Features/Navigation/SidebarView+Sections.swift
@@ -12,21 +12,26 @@ extension SidebarView {
     accountToEdit = account
   }
 
-  var currentAccountsSection: some View {
-    let groupAware = accountStore.accounts.groupAwareSidebar(
-      groups: accountGroupStore.groups,
-      excluding: nil,
-      alwaysInclude: nil
-    )
-    return Section {
-      ForEach(groupAware.current, id: \.bucketEntryId) { entry in
-        bucketEntryView(entry)
+  #if os(iOS)
+    /// Current-bucket section — iOS only. macOS renders Current
+    /// Accounts via `SidebarOutlineView` (NSOutlineView), so this
+    /// SwiftUI builder is unreferenced on macOS and gated out.
+    var currentAccountsSection: some View {
+      let groupAware = accountStore.accounts.groupAwareSidebar(
+        groups: accountGroupStore.groups,
+        excluding: nil,
+        alwaysInclude: nil
+      )
+      return Section {
+        ForEach(groupAware.current, id: \.bucketEntryId) { entry in
+          bucketEntryView(entry)
+        }
+        totalRow(label: "Current Total", value: accountStore.convertedCurrentTotal)
+      } header: {
+        sectionHeader(title: "Current Accounts", addAction: addAccountAction)
       }
-      totalRow(label: "Current Total", value: accountStore.convertedCurrentTotal)
-    } header: {
-      sectionHeader(title: "Current Accounts", addAction: addAccountAction)
     }
-  }
+  #endif
 
   var earmarksSection: some View {
     Section {
@@ -50,33 +55,40 @@ extension SidebarView {
     }
   }
 
-  var investmentsSection: some View {
-    let groupAware = accountStore.accounts.groupAwareSidebar(
-      groups: accountGroupStore.groups,
-      excluding: nil,
-      alwaysInclude: nil
-    )
-    return Section("Investments") {
-      ForEach(groupAware.investments, id: \.bucketEntryId) { entry in
-        bucketEntryView(entry)
+  #if os(iOS)
+    /// Investments-bucket section — iOS only. macOS renders Investments
+    /// via `SidebarOutlineView` (NSOutlineView), so this SwiftUI
+    /// builder is unreferenced on macOS and gated out.
+    var investmentsSection: some View {
+      let groupAware = accountStore.accounts.groupAwareSidebar(
+        groups: accountGroupStore.groups,
+        excluding: nil,
+        alwaysInclude: nil
+      )
+      return Section("Investments") {
+        ForEach(groupAware.investments, id: \.bucketEntryId) { entry in
+          bucketEntryView(entry)
+        }
+        totalRow(label: "Investment Total", value: accountStore.convertedInvestmentTotal)
       }
-      totalRow(label: "Investment Total", value: accountStore.convertedInvestmentTotal)
     }
-  }
 
-  /// Renders a single bucket entry — standalone account or group with
-  /// its members. The switch lives in this helper rather than inline so
-  /// each `Section`'s `ForEach` body stays within SwiftLint's
-  /// `closure_body_length` budget.
-  @ViewBuilder
-  func bucketEntryView(_ entry: SidebarBucketEntry) -> some View {
-    switch entry {
-    case .account(let account):
-      standaloneAccountRowLink(account)
-    case let .group(group, members):
-      groupSidebarEntry(group, members: members)
+    /// Renders a single bucket entry — standalone account or group with
+    /// its members. The switch lives in this helper rather than inline
+    /// so each `Section`'s `ForEach` body stays within SwiftLint's
+    /// `closure_body_length` budget. iOS-only since both call sites
+    /// (`currentAccountsSection` and `investmentsSection`) are
+    /// iOS-only.
+    @ViewBuilder
+    func bucketEntryView(_ entry: SidebarBucketEntry) -> some View {
+      switch entry {
+      case .account(let account):
+        standaloneAccountRowLink(account)
+      case let .group(group, members):
+        groupSidebarEntry(group, members: members)
+      }
     }
-  }
+  #endif
 
   @ViewBuilder var totalsSection: some View {
     Section {

--- a/Features/Navigation/SidebarView.swift
+++ b/Features/Navigation/SidebarView.swift
@@ -92,19 +92,15 @@ struct SidebarView: View {
   }
 
   #if os(macOS)
-    /// macOS body: the new `SidebarOutlineView` (NSOutlineView-backed)
-    /// renders Current Accounts + Investments at the top, and the
-    /// SwiftUI `List` below it carries Earmarks, Totals, and the
-    /// navigation rows. Selection rides through a shared
-    /// `Binding<SidebarSelection?>` so clicks in either surface update
-    /// the same source of truth.
-    ///
-    /// The two panes scroll **independently** — the VStack does not
-    /// share a single scroll container between them. That matches
-    /// macOS Finder's source-list-plus-fixed-list layout (where the
-    /// "Favorites" outline and the "iCloud / Locations / Tags" list
-    /// each manage their own clipping). Future Phase work may revisit
-    /// this if user feedback prefers a unified scroll.
+    /// macOS body: a single `List(selection:)` with the same 5-section
+    /// structure as iOS — Current Accounts, Earmarks, Investments,
+    /// Totals, Navigation. Within Current Accounts and Investments,
+    /// `SidebarOutlineView` embeds an `NSOutlineView` so the
+    /// account/group rows render with native source-list chrome
+    /// (disclosure triangles, selection highlight) while the section
+    /// headers themselves remain flat, non-collapsible SwiftUI
+    /// `Section` chrome. See `SidebarView+Sections.swift` for the
+    /// per-bucket builders.
     ///
     /// Phase 1 deliberately omits the iOS-only modifiers:
     /// - `.onKeyPress(.return)` for inline rename — not wired on macOS
@@ -112,15 +108,14 @@ struct SidebarView: View {
     /// - `.environment(\.editMode, $editMode)` — iOS list reorder mode
     ///   only.
     var macSidebarBody: some View {
-      VStack(spacing: 0) {
-        SidebarOutlineView(selection: $selection, accountToEdit: $accountToEdit)
-        List(selection: $selection) {
-          earmarksSection
-          totalsSection
-          navigationSection
-        }
-        .listStyle(.sidebar)
+      List(selection: $selection) {
+        currentAccountsSection
+        earmarksSection
+        investmentsSection
+        totalsSection
+        navigationSection
       }
+      .listStyle(.sidebar)
       .modifier(sharedBodyModifiers)
     }
   #endif

--- a/Features/Navigation/SidebarView.swift
+++ b/Features/Navigation/SidebarView.swift
@@ -84,19 +84,63 @@ struct SidebarView: View {
   // MARK: - Body
 
   var body: some View {
-    List(selection: $selection) {
-      currentAccountsSection
-      earmarksSection
-      investmentsSection
-      totalsSection
-      navigationSection
+    #if os(macOS)
+      macSidebarBody
+    #else
+      iosSidebarBody
+    #endif
+  }
+
+  #if os(macOS)
+    /// macOS body: the new `SidebarOutlineView` (NSOutlineView-backed)
+    /// renders Current Accounts + Investments at the top, and the
+    /// SwiftUI `List` below it carries Earmarks, Totals, and the
+    /// navigation rows. Selection rides through a shared
+    /// `Binding<SidebarSelection?>` so clicks in either surface update
+    /// the same source of truth.
+    ///
+    /// Phase 1 deliberately omits the iOS-only modifiers:
+    /// - `.onKeyPress(.return)` for inline rename — not wired on macOS
+    ///   until Phase 3 ships AppKit-cell inline editing.
+    /// - `.environment(\.editMode, $editMode)` — iOS list reorder mode
+    ///   only.
+    var macSidebarBody: some View {
+      VStack(spacing: 0) {
+        SidebarOutlineView(selection: $selection)
+        List(selection: $selection) {
+          earmarksSection
+          totalsSection
+          navigationSection
+        }
+        .listStyle(.sidebar)
+      }
+      .modifier(sharedBodyModifiers)
     }
-    .listStyle(.sidebar)
-    .onKeyPress(.return) {
-      // Only respond to Return when the selection points at a row
-      // that supports inline rename. Other selections (analysis /
-      // reports / etc.) pass through unhandled so any default Return
-      // behaviour is preserved.
+  #endif
+
+  #if os(iOS)
+    /// iOS body: preserves the existing single-`List` layout with all
+    /// five sections (Current Accounts, Earmarks, Investments, Totals,
+    /// Navigation). Phase 1 leaves this path completely unchanged.
+    var iosSidebarBody: some View {
+      List(selection: $selection) {
+        currentAccountsSection
+        earmarksSection
+        investmentsSection
+        totalsSection
+        navigationSection
+      }
+      .listStyle(.sidebar)
+      .onKeyPress(.return, action: handleReturnKey)
+      .environment(\.editMode, $editMode)
+      .modifier(sharedBodyModifiers)
+    }
+
+    /// `.onKeyPress(.return)` handler for the iOS body. Only responds
+    /// when the selection points at a row that supports inline rename —
+    /// other selections (analysis / reports / etc.) pass through
+    /// unhandled so any default Return behaviour is preserved.
+    private func handleReturnKey() -> KeyPress.Result {
       switch selection {
       case .account(let id):
         guard accountStore.accounts.by(id: id) != nil else { return .ignored }
@@ -115,87 +159,32 @@ struct SidebarView: View {
         return .ignored
       }
     }
-    .navigationTitle("")
-    .focusedSceneValue(\.showHiddenAccounts, $showHidden)
-    .focusedSceneValue(\.showSpamTransactions, $showSpam)
-    .focusedSceneValue(\.sidebarSelection, $selection)
-    .focusedSceneValue(\.selectedAccount, selectedAccountBinding)
-    .onChange(of: showHidden) { _, newValue in
-      accountStore.showHidden = newValue
-      earmarkStore.showHidden = newValue
-    }
-    .onChange(of: showSpam) { _, newValue in
-      transactionStore.showSpam = newValue
-    }
-    .onAppear {
-      accountStore.showHidden = showHidden
-      earmarkStore.showHidden = showHidden
-      transactionStore.showSpam = showSpam
-    }
-    #if os(iOS)
-      .environment(\.editMode, $editMode)
-    #endif
-    .refreshable {
-      // Both AccountStore and EarmarkStore are reactive (subscribe via
-      // observeAll() in init), so pull-to-refresh has nothing imperative
-      // left to nudge here. Pull is still wired so the system gesture
-      // resolves with the standard animation.
-    }
-    .safeAreaInset(edge: .bottom, spacing: 0) {
-      SyncProgressFooter()
-    }
-    #if os(macOS)
-      .toolbar {
-        ToolbarItem(placement: .primaryAction) {
-          Button {
-            showCreateAccountSheet = true
-          } label: {
-            Label("New Account", systemImage: "plus")
-          }
-          .help("Create new account")
-          .accessibilityIdentifier(UITestIdentifiers.Sidebar.newAccountButton)
-        }
-        ToolbarItem(placement: .primaryAction) {
-          Button {
-            showCreateEarmarkSheet = true
-          } label: {
-            Label("New Earmark", systemImage: "bookmark.fill")
-          }
-          .help("Create new earmark")
-          .accessibilityIdentifier(UITestIdentifiers.Sidebar.newEarmarkButton)
-        }
-      }
-    #endif
-    .focusedSceneValue(\.newEarmarkAction) {
-      showCreateEarmarkSheet = true
-    }
-    .focusedSceneValue(\.newAccountAction) {
-      showCreateAccountSheet = true
-    }
-    .sheet(isPresented: $showCreateEarmarkSheet) {
-      CreateEarmarkSheet(
-        instrument: session.profile.instrument,
-        onCreate: { newEarmark in
-          Task {
-            _ = await earmarkStore.create(newEarmark)
-            showCreateEarmarkSheet = false
-          }
-        }
-      )
-    }
-    .sheet(isPresented: $showCreateAccountSheet) {
-      CreateAccountView(
-        instrument: session.profile.instrument,
-        accountStore: accountStore,
-        cryptoSyncStore: session.cryptoSyncStore)
-    }
-    .sheet(item: $accountToEdit) { account in
-      EditAccountView(
-        account: account, accountStore: accountStore)
-    }
-    .onReceive(
-      NotificationCenter.default.publisher(for: .requestAccountEdit),
-      perform: handleAccountEditRequest
+  #endif
+
+  /// Bundles the cross-platform modifier stack: navigation title,
+  /// focused-scene values, store-driven `onChange` / `onAppear` hooks,
+  /// the macOS toolbar, the sync-progress footer, and the three sheets
+  /// (create earmark / create account / edit account). Built as a
+  /// concrete value here so both the macOS and iOS bodies pick it up
+  /// via `.modifier(...)` without duplicating the chain. The modifier
+  /// itself lives in `SidebarSharedModifiers.swift`.
+  ///
+  /// Platform-only modifiers (`.onKeyPress`, `.environment(editMode)`)
+  /// live on the platform-specific bodies above so they don't leak.
+  private var sharedBodyModifiers: SidebarSharedModifiers {
+    SidebarSharedModifiers(
+      session: session,
+      accountStore: accountStore,
+      earmarkStore: earmarkStore,
+      transactionStore: transactionStore,
+      showHidden: $showHidden,
+      showSpam: $showSpam,
+      selection: $selection,
+      selectedAccountBinding: selectedAccountBinding,
+      showCreateEarmarkSheet: $showCreateEarmarkSheet,
+      showCreateAccountSheet: $showCreateAccountSheet,
+      accountToEdit: $accountToEdit,
+      onRequestAccountEdit: handleAccountEditRequest
     )
   }
 
@@ -238,11 +227,19 @@ extension SidebarView {
 
   @ViewBuilder
   func accountContextMenu(for account: Account) -> some View {
-    Button("Rename", systemImage: "character.cursor.ibeam") {
-      editingRowId = account.id
-    }
-    .accessibilityIdentifier(UITestIdentifiers.Sidebar.renameContextMenuItem)
-    accountGroupSubmenu(for: account)
+    #if os(iOS)
+      // Inline rename and the Group ▸ submenu are iOS-only until
+      // Phase 3 ships AppKit-cell editing and Phase 2 wires
+      // drag-and-drop / group membership on the macOS outline. macOS
+      // users currently reach grouping via drag-and-drop on the
+      // SwiftUI surface (not yet on the outline) and account renaming
+      // via the "Edit Account…" item below.
+      Button("Rename", systemImage: "character.cursor.ibeam") {
+        editingRowId = account.id
+      }
+      .accessibilityIdentifier(UITestIdentifiers.Sidebar.renameContextMenuItem)
+      accountGroupSubmenu(for: account)
+    #endif
     Button("Edit Account\u{2026}", systemImage: "pencil") {
       accountToEdit = account
     }

--- a/Features/Navigation/SidebarView.swift
+++ b/Features/Navigation/SidebarView.swift
@@ -99,6 +99,13 @@ struct SidebarView: View {
     /// `Binding<SidebarSelection?>` so clicks in either surface update
     /// the same source of truth.
     ///
+    /// The two panes scroll **independently** — the VStack does not
+    /// share a single scroll container between them. That matches
+    /// macOS Finder's source-list-plus-fixed-list layout (where the
+    /// "Favorites" outline and the "iCloud / Locations / Tags" list
+    /// each manage their own clipping). Future Phase work may revisit
+    /// this if user feedback prefers a unified scroll.
+    ///
     /// Phase 1 deliberately omits the iOS-only modifiers:
     /// - `.onKeyPress(.return)` for inline rename — not wired on macOS
     ///   until Phase 3 ships AppKit-cell inline editing.

--- a/Features/Navigation/SidebarView.swift
+++ b/Features/Navigation/SidebarView.swift
@@ -113,7 +113,7 @@ struct SidebarView: View {
     ///   only.
     var macSidebarBody: some View {
       VStack(spacing: 0) {
-        SidebarOutlineView(selection: $selection)
+        SidebarOutlineView(selection: $selection, accountToEdit: $accountToEdit)
         List(selection: $selection) {
           earmarksSection
           totalsSection

--- a/MoolahTests/Navigation/SidebarOutlineItemTests.swift
+++ b/MoolahTests/Navigation/SidebarOutlineItemTests.swift
@@ -5,8 +5,8 @@ import Testing
 
 @Suite("SidebarOutlineItem tree")
 struct SidebarOutlineItemTests {
-  @Test("Current bucket enumeration: standalone, group, standalone in position order")
-  func currentBucketHeaderEnumerationContainsStandaloneThenGroups() throws {
+  @Test("Current bucket: standalone, group, standalone in position order")
+  func currentBucketEnumerationContainsStandaloneThenGroups() throws {
     let bankA = Account(
       id: UUID(), name: "A", type: .bank, instrument: .AUD,
       positions: [], position: 0, isHidden: false)
@@ -23,42 +23,38 @@ struct SidebarOutlineItemTests {
 
     let items = SidebarOutlineItem.tree(
       accounts: Accounts(from: [bankA, bankB, member]),
-      groups: [group]
+      groups: [group],
+      bucket: .current
     )
 
-    // Two section headers at root: Current Accounts, Investments.
-    #expect(items.count == 2)
-    let currentHeader = try #require(items.first)
-    #expect(currentHeader.kind == .currentAccountsHeader)
-    // Children: bankA (pos 0), group G (pos 1), bankB (pos 2).
-    let children = try #require(currentHeader.children)
-    #expect(children.count == 3)
-    #expect(children[0].kind == .account(bankA.id))
-    #expect(children[1].kind == .group(group.id))
-    #expect(children[2].kind == .account(bankB.id))
-    // Group members appear under the group node.
-    let groupChildren = try #require(children[1].children)
+    // Three root items: bankA (pos 0), group G (pos 1), bankB (pos 2).
+    #expect(items.count == 3)
+    #expect(items[0].kind == .account(bankA.id))
+    #expect(items[1].kind == .group(group.id))
+    #expect(items[2].kind == .account(bankB.id))
+    // Group members appear as children of the group node.
+    let groupChildren = try #require(items[1].children)
     #expect(groupChildren.count == 1)
     #expect(groupChildren[0].kind == .account(member.id))
   }
 
-  @Test("Investments header renders even when empty")
-  func investmentsHeaderRendersEvenWhenEmpty() {
-    // Empty investments section still produces the section header
-    // so the user sees "Investments" with a zero-member section.
+  @Test("Investments bucket is empty when no investment accounts exist")
+  func investmentsBucketIsEmptyWhenNoInvestmentAccounts() {
+    // The section header used to live in the tree; now it's supplied
+    // by the surrounding SwiftUI `Section`, so a bucket with no
+    // entries produces an empty array (the section still renders).
     let bank = Account(
       id: UUID(), name: "A", type: .bank, instrument: .AUD,
       positions: [], position: 0, isHidden: false)
     let items = SidebarOutlineItem.tree(
-      accounts: Accounts(from: [bank]), groups: []
+      accounts: Accounts(from: [bank]), groups: [],
+      bucket: .investments
     )
-    #expect(items.count == 2)
-    #expect(items[1].kind == .investmentsHeader)
-    #expect(items[1].children?.isEmpty == true)
+    #expect(items.isEmpty)
   }
 
   @Test("Dangling groupId renders the member as standalone in its bucket")
-  func danglingGroupIdRendersMemberAsStandalone() throws {
+  func danglingGroupIdRendersMemberAsStandaloneInTargetBucket() throws {
     // Sync can deliver an Account ahead of its AccountGroup. The
     // ordering helper folds those into the standalone list — this
     // test asserts SidebarOutlineItem inherits that contract.
@@ -68,10 +64,10 @@ struct SidebarOutlineItemTests {
       positions: [], position: 0, isHidden: false,
       groupId: ghostGroupId)
     let items = SidebarOutlineItem.tree(
-      accounts: Accounts(from: [stranded]), groups: []
+      accounts: Accounts(from: [stranded]), groups: [],
+      bucket: .current
     )
-    let current = try #require(items.first?.children)
-    #expect(current.count == 1)
-    #expect(current[0].kind == .account(stranded.id))
+    #expect(items.count == 1)
+    #expect(items[0].kind == .account(stranded.id))
   }
 }

--- a/MoolahTests/Navigation/SidebarOutlineItemTests.swift
+++ b/MoolahTests/Navigation/SidebarOutlineItemTests.swift
@@ -1,0 +1,77 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("SidebarOutlineItem tree")
+struct SidebarOutlineItemTests {
+  @Test("Current bucket enumeration: standalone, group, standalone in position order")
+  func currentBucketHeaderEnumerationContainsStandaloneThenGroups() throws {
+    let bankA = Account(
+      id: UUID(), name: "A", type: .bank, instrument: .AUD,
+      positions: [], position: 0, isHidden: false)
+    let bankB = Account(
+      id: UUID(), name: "B", type: .bank, instrument: .AUD,
+      positions: [], position: 2, isHidden: false)
+    let group = AccountGroup(
+      name: "G", bucket: .current,
+      instrument: .AUD, position: 1)
+    let member = Account(
+      id: UUID(), name: "M", type: .bank, instrument: .AUD,
+      positions: [], position: 0, isHidden: false,
+      groupId: group.id)
+
+    let items = SidebarOutlineItem.tree(
+      accounts: Accounts(from: [bankA, bankB, member]),
+      groups: [group]
+    )
+
+    // Two section headers at root: Current Accounts, Investments.
+    #expect(items.count == 2)
+    let currentHeader = try #require(items.first)
+    #expect(currentHeader.kind == .currentAccountsHeader)
+    // Children: bankA (pos 0), group G (pos 1), bankB (pos 2).
+    let children = try #require(currentHeader.children)
+    #expect(children.count == 3)
+    #expect(children[0].kind == .account(bankA.id))
+    #expect(children[1].kind == .group(group.id))
+    #expect(children[2].kind == .account(bankB.id))
+    // Group members appear under the group node.
+    let groupChildren = try #require(children[1].children)
+    #expect(groupChildren.count == 1)
+    #expect(groupChildren[0].kind == .account(member.id))
+  }
+
+  @Test("Investments header renders even when empty")
+  func investmentsHeaderRendersEvenWhenEmpty() {
+    // Empty investments section still produces the section header
+    // so the user sees "Investments" with a zero-member section.
+    let bank = Account(
+      id: UUID(), name: "A", type: .bank, instrument: .AUD,
+      positions: [], position: 0, isHidden: false)
+    let items = SidebarOutlineItem.tree(
+      accounts: Accounts(from: [bank]), groups: []
+    )
+    #expect(items.count == 2)
+    #expect(items[1].kind == .investmentsHeader)
+    #expect(items[1].children?.isEmpty == true)
+  }
+
+  @Test("Dangling groupId renders the member as standalone in its bucket")
+  func danglingGroupIdRendersMemberAsStandalone() throws {
+    // Sync can deliver an Account ahead of its AccountGroup. The
+    // ordering helper folds those into the standalone list — this
+    // test asserts SidebarOutlineItem inherits that contract.
+    let ghostGroupId = UUID()
+    let stranded = Account(
+      id: UUID(), name: "S", type: .bank, instrument: .AUD,
+      positions: [], position: 0, isHidden: false,
+      groupId: ghostGroupId)
+    let items = SidebarOutlineItem.tree(
+      accounts: Accounts(from: [stranded]), groups: []
+    )
+    let current = try #require(items.first?.children)
+    #expect(current.count == 1)
+    #expect(current[0].kind == .account(stranded.id))
+  }
+}

--- a/MoolahTests/Navigation/SidebarOutlineViewTests.swift
+++ b/MoolahTests/Navigation/SidebarOutlineViewTests.swift
@@ -1,0 +1,106 @@
+#if os(macOS)
+  import Foundation
+  import Testing
+
+  @testable import Moolah
+
+  /// Exercises the static `SidebarOutlineView.expansionBinding(groupStore:)`
+  /// translation between the vendored OutlineView's
+  /// `Set<SidebarOutlineItem.Kind>` and `GroupUIStateStore.expandedGroupIds`.
+  ///
+  /// The binding is a pure function over the store, so the tests construct
+  /// a real `GroupUIStateStore` against an in-memory `TestBackend` — the
+  /// same pattern `MoolahTests/Features/GroupUIStateStoreTests.swift` uses
+  /// — and assert against the live emission stream rather than mocking.
+  @Suite("SidebarOutlineView.expansionBinding")
+  @MainActor
+  struct SidebarOutlineViewTests {
+    @Test("Getter reports section headers and currently-expanded groups")
+    func expansionBindingReportsSectionHeadersAndCurrentlyExpandedGroups() async throws {
+      let (backend, _) = try TestBackend.create()
+      let store = GroupUIStateStore(repository: backend.groupUIState)
+      try await store.waitForFirstEmission()
+
+      let group = try await backend.accountGroups.create(
+        AccountGroup(
+          name: "G", bucket: .investments, instrument: .defaultTestInstrument))
+      await store.setExpanded(true, for: group.id)
+      try await store.waitForNextEmission(
+        matching: { $0.expandedGroupIds.contains(group.id) },
+        description: "expanded observed")
+
+      let binding = SidebarOutlineView.expansionBinding(groupStore: store)
+      let expanded = binding.wrappedValue
+      #expect(expanded.contains(.currentAccountsHeader))
+      #expect(expanded.contains(.investmentsHeader))
+      #expect(expanded.contains(.group(group.id)))
+    }
+
+    @Test("Setter writes a newly-inserted group through to the store")
+    func expansionBindingExpandsGroupOnInsert() async throws {
+      let (backend, _) = try TestBackend.create()
+      let store = GroupUIStateStore(repository: backend.groupUIState)
+      try await store.waitForFirstEmission()
+
+      let group = try await backend.accountGroups.create(
+        AccountGroup(
+          name: "G", bucket: .investments, instrument: .defaultTestInstrument))
+
+      let binding = SidebarOutlineView.expansionBinding(groupStore: store)
+      binding.wrappedValue = [
+        .currentAccountsHeader, .investmentsHeader, .group(group.id),
+      ]
+
+      // The setter dispatches `setExpanded(true:)` asynchronously; wait
+      // for the observation stream to reflect the persisted state.
+      try await store.waitForNextEmission(
+        matching: { $0.expandedGroupIds.contains(group.id) },
+        description: "expanded observed")
+      #expect(store.expandedGroupIds.contains(group.id))
+    }
+
+    @Test("Setter writes a removed group through to the store")
+    func expansionBindingCollapsesGroupOnRemove() async throws {
+      let (backend, _) = try TestBackend.create()
+      let store = GroupUIStateStore(repository: backend.groupUIState)
+      try await store.waitForFirstEmission()
+
+      let group = try await backend.accountGroups.create(
+        AccountGroup(
+          name: "G", bucket: .investments, instrument: .defaultTestInstrument))
+      await store.setExpanded(true, for: group.id)
+      try await store.waitForNextEmission(
+        matching: { $0.expandedGroupIds.contains(group.id) },
+        description: "expanded observed")
+
+      let binding = SidebarOutlineView.expansionBinding(groupStore: store)
+      #expect(binding.wrappedValue.contains(.group(group.id)))
+
+      binding.wrappedValue = [.currentAccountsHeader, .investmentsHeader]
+
+      try await store.waitForNextEmission(
+        matching: { !$0.expandedGroupIds.contains(group.id) },
+        description: "collapsed observed")
+      #expect(!store.expandedGroupIds.contains(group.id))
+    }
+
+    @Test("Setter ignores removal of section headers; getter still reports them")
+    func expansionBindingIgnoresRemovalOfSectionHeaders() async throws {
+      let (backend, _) = try TestBackend.create()
+      let store = GroupUIStateStore(repository: backend.groupUIState)
+      try await store.waitForFirstEmission()
+
+      let binding = SidebarOutlineView.expansionBinding(groupStore: store)
+
+      // Try to remove everything — including the section headers.
+      binding.wrappedValue = []
+
+      // The store stays empty (no group writes were dispatched), and
+      // the next getter re-injects the section headers.
+      #expect(store.expandedGroupIds.isEmpty)
+      let after = binding.wrappedValue
+      #expect(after.contains(.currentAccountsHeader))
+      #expect(after.contains(.investmentsHeader))
+    }
+  }
+#endif

--- a/MoolahTests/Navigation/SidebarOutlineViewTests.swift
+++ b/MoolahTests/Navigation/SidebarOutlineViewTests.swift
@@ -15,8 +15,8 @@
   @Suite("SidebarOutlineView.expansionBinding")
   @MainActor
   struct SidebarOutlineViewTests {
-    @Test("Getter reports section headers and currently-expanded groups")
-    func expansionBindingReportsSectionHeadersAndCurrentlyExpandedGroups() async throws {
+    @Test("Getter reports currently-expanded groups")
+    func expansionBindingReportsCurrentlyExpandedGroups() async throws {
       let (backend, _) = try TestBackend.create()
       let store = GroupUIStateStore(repository: backend.groupUIState)
       try await store.waitForFirstEmission()
@@ -31,9 +31,10 @@
 
       let binding = SidebarOutlineView.expansionBinding(groupStore: store)
       let expanded = binding.wrappedValue
-      #expect(expanded.contains(.currentAccountsHeader))
-      #expect(expanded.contains(.investmentsHeader))
-      #expect(expanded.contains(.group(group.id)))
+      // Only `.group(id)` kinds are tracked now — section headers
+      // moved out of the tree into SwiftUI sections, so they no
+      // longer appear in the bound set.
+      #expect(expanded == [.group(group.id)])
     }
 
     @Test("Setter writes a newly-inserted group through to the store")
@@ -47,9 +48,7 @@
           name: "G", bucket: .investments, instrument: .defaultTestInstrument))
 
       let binding = SidebarOutlineView.expansionBinding(groupStore: store)
-      binding.wrappedValue = [
-        .currentAccountsHeader, .investmentsHeader, .group(group.id),
-      ]
+      binding.wrappedValue = [.group(group.id)]
 
       // The setter dispatches `setExpanded(true:)` asynchronously; wait
       // for the observation stream to reflect the persisted state.
@@ -76,31 +75,12 @@
       let binding = SidebarOutlineView.expansionBinding(groupStore: store)
       #expect(binding.wrappedValue.contains(.group(group.id)))
 
-      binding.wrappedValue = [.currentAccountsHeader, .investmentsHeader]
+      binding.wrappedValue = []
 
       try await store.waitForNextEmission(
         matching: { !$0.expandedGroupIds.contains(group.id) },
         description: "collapsed observed")
       #expect(!store.expandedGroupIds.contains(group.id))
-    }
-
-    @Test("Setter ignores removal of section headers; getter still reports them")
-    func expansionBindingIgnoresRemovalOfSectionHeaders() async throws {
-      let (backend, _) = try TestBackend.create()
-      let store = GroupUIStateStore(repository: backend.groupUIState)
-      try await store.waitForFirstEmission()
-
-      let binding = SidebarOutlineView.expansionBinding(groupStore: store)
-
-      // Try to remove everything — including the section headers.
-      binding.wrappedValue = []
-
-      // The store stays empty (no group writes were dispatched), and
-      // the next getter re-injects the section headers.
-      #expect(store.expandedGroupIds.isEmpty)
-      let after = binding.wrappedValue
-      #expect(after.contains(.currentAccountsHeader))
-      #expect(after.contains(.investmentsHeader))
     }
   }
 #endif

--- a/Vendored/OutlineView/AdjustableSeparatorRowView.swift
+++ b/Vendored/OutlineView/AdjustableSeparatorRowView.swift
@@ -1,0 +1,84 @@
+import AppKit
+import ObjectiveC
+
+/// An NSTableRowView with an adjustable separator line.
+@available(macOS 11.0, *)
+final class AdjustableSeparatorRowView: NSTableRowView {
+  var separatorInsets: NSEdgeInsets?
+
+  public override init(frame frameRect: NSRect) {
+    Self.setupSwizzling
+    super.init(frame: frameRect)
+  }
+
+  required init?(coder: NSCoder) {
+    Self.setupSwizzling
+    super.init(coder: coder)
+  }
+
+  /// Our implementation of the private `_separatorRect` method.
+  /// Computes the frame of the `_separatorView`.
+  @objc
+  func separatorRect() -> CGRect {
+    // Make sure we only override the behavior for this class.
+    guard type(of: self) == AdjustableSeparatorRowView.self else {
+      return Self.originalSeparatorRect?(self) ?? .zero
+    }
+
+    // Only override the default behavior if the
+    // separator insets are not available.
+    guard let separatorInsets = separatorInsets else {
+      // Get the frame from the original method.
+      return Self.originalSeparatorRect?(self) ?? .zero
+    }
+
+    guard self.numberOfColumns > 0,
+      let viewRect = (self.view(atColumn: 0) as? NSView)?.frame
+    else { return .zero }
+
+    // One point thick separator of the width of the first (and only) column.
+    let separatorRect = NSRect(
+      x: viewRect.origin.x,
+      y: max(0, viewRect.height - 1),
+      width: viewRect.width,
+      height: 1)
+
+    // Inset the separator frame by the separatorInsets.
+    return CGRect(
+      x: separatorRect.origin.x + separatorInsets.left,
+      y: separatorRect.origin.y + separatorInsets.top,
+      width: separatorRect.width - separatorInsets.left - separatorInsets.right,
+      height: separatorRect.height - separatorInsets.top - separatorInsets.bottom)
+  }
+
+  /// Stores the original implementation of `_separatorRect` if successfully swizzled.
+  static var originalSeparatorRect: ((NSTableRowView) -> CGRect)?
+
+  /// Swizzle the private `_separatorRect` defined on NSTableRowView.
+  /// Should be executed early in the life-cycle of `AdjustableSeparatorRowView`.
+  static let setupSwizzling: Void = {
+    // Selector for _separatorRect.
+    let privateSeparatorRectSelector = Selector(unmangle("^rdo`q`snqQdbs"))
+    guard
+      let originalMethod = class_getInstanceMethod(
+        AdjustableSeparatorRowView.self,
+        privateSeparatorRectSelector),
+      let newMethod = class_getInstanceMethod(
+        AdjustableSeparatorRowView.self,
+        #selector(separatorRect))
+    else { return }
+
+    // Replace the original implementation with our implementation.
+    let originalImplementation = method_setImplementation(
+      originalMethod,
+      method_getImplementation(newMethod))
+
+    // Store the original implementation for later use.
+    originalSeparatorRect = { instance in
+      let privateSeparatorRect = unsafeBitCast(
+        originalImplementation,
+        to: (@convention(c) (Any?, Selector?) -> CGRect).self)
+      return privateSeparatorRect(instance, privateSeparatorRectSelector)
+    }
+  }()
+}

--- a/Vendored/OutlineView/Extensions/NSTableCellView+OutlineView.swift
+++ b/Vendored/OutlineView/Extensions/NSTableCellView+OutlineView.swift
@@ -12,15 +12,31 @@ extension NSTableCellView {
   /// emphasised state via `@Environment(\.backgroundStyle)` from inside
   /// the wrapped view tree.
   ///
-  /// `accessibilityIdentifier` is forwarded onto the cell so XCUITest
-  /// resolves the row via the same identifier the SwiftUI sidebar uses
-  /// today.
+  /// `accessibilityIdentifier` is applied to the wrapped SwiftUI
+  /// content via `.accessibilityIdentifier(_:)` so XCUITest resolves the
+  /// row via the same identifier the SwiftUI sidebar uses today.
+  ///
+  /// moolah: `cell.setAccessibilityIdentifier(_:)` alone is not enough
+  /// here — `NSTableCellView` is not itself an accessibility element by
+  /// default, so XCUITest's tree exposes its child `NSHostingView` (and
+  /// the SwiftUI elements beneath it) instead. Calling
+  /// `setAccessibilityIdentifier` on the cell silently has no effect on
+  /// the element the test harness sees. Wrapping the SwiftUI content in
+  /// `.accessibilityIdentifier(_:)` puts the identifier on the leaf
+  /// element XCUITest actually resolves, matching how every other
+  /// sidebar row attaches its identifier (`SidebarView+Groups.swift`,
+  /// `SidebarView+Sections.swift`). The cell-side call is preserved
+  /// belt-and-braces in case future AppKit changes expose it.
   static func hosting<Content: View>(
     accessibilityIdentifier: String? = nil,
     @ViewBuilder content: () -> Content
   ) -> NSTableCellView {
     let cell = NSTableCellView()
-    let host = NSHostingView(rootView: content())
+    let host = NSHostingView(
+      rootView: cellRootView(
+        content: content(),
+        accessibilityIdentifier: accessibilityIdentifier
+      ))
     host.translatesAutoresizingMaskIntoConstraints = false
     cell.addSubview(host)
     NSLayoutConstraint.activate([
@@ -33,5 +49,21 @@ extension NSTableCellView {
       cell.setAccessibilityIdentifier(accessibilityIdentifier)
     }
     return cell
+  }
+
+  // moolah: small wrapper so the identifier is only attached when
+  // the caller supplies one — applying `.accessibilityIdentifier("")`
+  // would clobber any identifier the wrapped SwiftUI content sets on
+  // its own subtree.
+  @ViewBuilder
+  private static func cellRootView<Content: View>(
+    content: Content,
+    accessibilityIdentifier: String?
+  ) -> some View {
+    if let accessibilityIdentifier {
+      content.accessibilityIdentifier(accessibilityIdentifier)
+    } else {
+      content
+    }
   }
 }

--- a/Vendored/OutlineView/Extensions/NSTableCellView+OutlineView.swift
+++ b/Vendored/OutlineView/Extensions/NSTableCellView+OutlineView.swift
@@ -39,11 +39,16 @@ extension NSTableCellView {
       ))
     host.translatesAutoresizingMaskIntoConstraints = false
     cell.addSubview(host)
+    // moolah: padding mirrors what SwiftUI `List(.sidebar)` rows apply
+    // around their hosted content — without it, NSHostingView's
+    // fittingSize collapses to the bare HStack content height (~16pt)
+    // and the outline rows pack visibly tighter than the surrounding
+    // SwiftUI sections.
     NSLayoutConstraint.activate([
       host.leadingAnchor.constraint(equalTo: cell.leadingAnchor),
       host.trailingAnchor.constraint(equalTo: cell.trailingAnchor),
-      host.topAnchor.constraint(equalTo: cell.topAnchor),
-      host.bottomAnchor.constraint(equalTo: cell.bottomAnchor),
+      host.topAnchor.constraint(equalTo: cell.topAnchor, constant: 4),
+      host.bottomAnchor.constraint(equalTo: cell.bottomAnchor, constant: -4),
     ])
     if let accessibilityIdentifier {
       cell.setAccessibilityIdentifier(accessibilityIdentifier)

--- a/Vendored/OutlineView/Extensions/NSTableCellView+OutlineView.swift
+++ b/Vendored/OutlineView/Extensions/NSTableCellView+OutlineView.swift
@@ -1,0 +1,37 @@
+import AppKit
+import SwiftUI
+
+extension NSTableCellView {
+  /// Builds an `NSTableCellView` whose only subview is an
+  /// `NSHostingView` rendering `swiftUIContent`. Per the upstream
+  /// `OutlineView` README, `NSTableCellView` is the preferred cell base
+  /// class because `NSTableRowView` cascades the right `backgroundStyle`
+  /// (`.emphasized` vs `.normal`) into the cell's text field on
+  /// selection — direct `NSHostingView` rows lose that treatment. The
+  /// hosting view's SwiftUI content can still pick up the selected /
+  /// emphasised state via `@Environment(\.backgroundStyle)` from inside
+  /// the wrapped view tree.
+  ///
+  /// `accessibilityIdentifier` is forwarded onto the cell so XCUITest
+  /// resolves the row via the same identifier the SwiftUI sidebar uses
+  /// today.
+  static func hosting<Content: View>(
+    accessibilityIdentifier: String? = nil,
+    @ViewBuilder content: () -> Content
+  ) -> NSTableCellView {
+    let cell = NSTableCellView()
+    let host = NSHostingView(rootView: content())
+    host.translatesAutoresizingMaskIntoConstraints = false
+    cell.addSubview(host)
+    NSLayoutConstraint.activate([
+      host.leadingAnchor.constraint(equalTo: cell.leadingAnchor),
+      host.trailingAnchor.constraint(equalTo: cell.trailingAnchor),
+      host.topAnchor.constraint(equalTo: cell.topAnchor),
+      host.bottomAnchor.constraint(equalTo: cell.bottomAnchor),
+    ])
+    if let accessibilityIdentifier {
+      cell.setAccessibilityIdentifier(accessibilityIdentifier)
+    }
+    return cell
+  }
+}

--- a/Vendored/OutlineView/Extensions/OutlineView+ExpansionBinding.swift
+++ b/Vendored/OutlineView/Extensions/OutlineView+ExpansionBinding.swift
@@ -1,0 +1,31 @@
+// MARK: - expandedItems
+//
+// Documented here for discoverability; the implementation lives in
+// `OutlineView.swift` (modifier + state), `OutlineViewController.swift`
+// (the `applyExpandedItems` reconciliation + `setExpansionChanged`
+// callback installer) and `OutlineViewDelegate.swift` (the
+// `outlineViewItemDidExpand` / `outlineViewItemDidCollapse` dispatch
+// that drives the callback). Search for `// moolah:` comments to find
+// the call sites.
+//
+// `outlineViewExpandedItems(_:)` binds the open / closed state of every
+// expandable row to a `Set<Element.ID>` the caller owns. The
+// `OutlineViewController` reconciles `NSOutlineView`'s current state
+// against the bound set on every SwiftUI `update` pass, and writes
+// element IDs into / out of the set when the user toggles a disclosure
+// triangle.
+//
+// During reconciliation the callback is temporarily suppressed so the
+// programmatic expand / collapse calls do not feed back into the
+// binding that triggered them.
+//
+// Usage:
+//
+// ```swift
+// @State private var expandedItemIDs: Set<Item.ID> = []
+//
+// OutlineView(items, children: \.children, selection: $selection) { item in
+//     buildCell(for: item)
+// }
+// .outlineViewExpandedItems($expandedItemIDs)
+// ```

--- a/Vendored/OutlineView/Extensions/OutlineView+IsGroupItem.swift
+++ b/Vendored/OutlineView/Extensions/OutlineView+IsGroupItem.swift
@@ -1,0 +1,23 @@
+// MARK: - isGroupItem
+//
+// Documented here for discoverability; the implementation lives in
+// `OutlineView.swift` (modifier + state), `OutlineViewController.swift`
+// (plumbing) and `OutlineViewDelegate.swift` (the
+// `outlineView(_:isGroupItem:)` and `outlineView(_:shouldSelectItem:)`
+// dispatch). Search for `// moolah:` comments to find the call sites.
+//
+// Returning `true` from this closure for a given item makes
+// `NSOutlineView` render that row with the source-list group-header
+// chrome (capitalised label, secondary text colour, no disclosure
+// triangle for the header itself, item is not selectable). This is the
+// `isGroupItem` data-source contract that the upstream package
+// hard-codes (by omission) to `false`.
+//
+// Usage:
+//
+// ```swift
+// OutlineView(items, children: \.children, selection: $selection) { item in
+//     buildCell(for: item)
+// }
+// .outlineViewIsGroupItem { $0.isGroup }
+// ```

--- a/Vendored/OutlineView/LICENSE.txt
+++ b/Vendored/OutlineView/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 Samar Sunkaria
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Vendored/OutlineView/NOTICE.md
+++ b/Vendored/OutlineView/NOTICE.md
@@ -1,0 +1,27 @@
+# OutlineView (vendored)
+
+This directory contains a vendored copy of
+[Sameesunkaria/OutlineView](https://github.com/Sameesunkaria/OutlineView)
+at tag `2.0.0`, licensed MIT (see `LICENSE.txt`).
+
+We vendored rather than depended via SPM because the upstream's public
+API surface didn't expose three hooks we needed:
+
+- `isGroupItem` closure on the cell builder, for native source-list
+  group-header rows.
+- `expandedItems` binding on the initialiser, for two-way expansion
+  state with our own persistence store (`GroupUIStateStore`).
+- An `NSTableCellView` factory helper (per the upstream README's
+  recommendation that `NSTableCellView` is the preferred cell base
+  class for selected-row text-colour treatment).
+
+Our additions live in `Extensions/` so the verbatim upstream source
+stays diffable against upstream. Where we had to modify upstream source
+directly (e.g., `OutlineView.swift` to thread the new modifier
+parameters through to the controller, `OutlineViewController.swift` to
+react to the new bindings, and `OutlineViewDelegate.swift` to dispatch
+the group-row + expansion delegate methods), each modification is
+marked with `// moolah:` comments.
+
+If a future upstream release adds these features, we should evaluate
+returning to the SPM dependency.

--- a/Vendored/OutlineView/NSEdgeInsets+Equatable.swift
+++ b/Vendored/OutlineView/NSEdgeInsets+Equatable.swift
@@ -1,0 +1,10 @@
+import AppKit
+
+// moolah: marked `@retroactive` — Swift 6.x requires explicit
+// acknowledgement when extending an imported type to conform to an
+// imported protocol the owning module has not declared.
+extension NSEdgeInsets: @retroactive Equatable {
+  public static func == (lhs: NSEdgeInsets, rhs: NSEdgeInsets) -> Bool {
+    NSEdgeInsetsEqual(lhs, rhs)
+  }
+}

--- a/Vendored/OutlineView/NSEdgeInsets+Zero.swift
+++ b/Vendored/OutlineView/NSEdgeInsets+Zero.swift
@@ -1,0 +1,7 @@
+import AppKit
+
+extension NSEdgeInsets {
+  static var zero: NSEdgeInsets {
+    NSEdgeInsetsZero
+  }
+}

--- a/Vendored/OutlineView/Notifications.swift
+++ b/Vendored/OutlineView/Notifications.swift
@@ -1,0 +1,26 @@
+import AppKit
+
+extension NSOutlineView {
+
+  /// Converts a notification from any of `NSOutlineView`'s item notifiers
+  /// into a tuple of the `NSOutlineView` and the item that was notified about.
+  ///
+  /// Notifications this works for:
+  /// - `itemDidCollapseNotification`
+  /// - `itemDidExpandNotification`
+  /// - `itemWillCollapseNotification`
+  /// - `itemWillExpandNotification`
+  ///
+  /// If the Notification is in an incorrect format for any of the above notifications,
+  /// this function returns `nil`.
+  static func expansionNotificationInfo(_ note: Notification) -> (
+    outlineView: NSOutlineView, object: Any
+  )? {
+    guard let outlineView = note.object as? NSOutlineView,
+      let object = note.userInfo?["NSObject"]
+    else { return nil }
+
+    return (outlineView, object)
+  }
+
+}

--- a/Vendored/OutlineView/OutlineView.swift
+++ b/Vendored/OutlineView/OutlineView.swift
@@ -1,0 +1,585 @@
+import Cocoa
+import SwiftUI
+
+enum ChildSource<Data: Sequence> {
+  case keyPath(KeyPath<Data.Element, Data?>)
+  case provider((Data.Element) -> Data?)
+
+  func children(for element: Data.Element) -> Data? {
+    switch self {
+    case .keyPath(let keyPath):
+      return element[keyPath: keyPath]
+    case .provider(let provider):
+      return provider(element)
+    }
+  }
+}
+
+@available(macOS 10.15, *)
+public struct OutlineView<Data: Sequence, Drop: DropReceiver>: NSViewControllerRepresentable
+where Drop.DataElement == Data.Element {
+  public typealias NSViewControllerType = OutlineViewController<Data, Drop>
+
+  let data: Data
+  let childSource: ChildSource<Data>
+  @Binding var selection: Data.Element?
+  var content: (Data.Element) -> NSView
+  var separatorInsets: ((Data.Element) -> NSEdgeInsets)?
+
+  /// Outline view style is unavailable on macOS 10.15 and below.
+  /// Stored as `Any` to make the property available on all platforms.
+  private var _styleStorage: Any?
+
+  @available(macOS 11.0, *)
+  var style: NSOutlineView.Style {
+    get {
+      _styleStorage
+        .flatMap { $0 as? NSOutlineView.Style }
+        ?? .automatic
+    }
+    set { _styleStorage = newValue }
+  }
+
+  var indentation: CGFloat = 13.0
+  var separatorVisibility: SeparatorVisibility
+  var separatorColor: NSColor = .separatorColor
+
+  var dragDataSource: DragSourceWriter<Data.Element>?
+  var dropReceiver: Drop? = nil
+  var acceptedDropTypes: [NSPasteboard.PasteboardType]? = nil
+
+  // moolah: optional source-list group-row hook. Set via the
+  // `outlineViewIsGroupItem(_:)` modifier — kept out of the public
+  // initialisers (there are eight of them) to avoid an init
+  // explosion.
+  var isGroupItem: ((Data.Element) -> Bool)?
+
+  // moolah: optional two-way expansion-state binding. Set via the
+  // `outlineViewExpandedItems(_:)` modifier. The controller
+  // reconciles `NSOutlineView`'s expand state against this set on
+  // each `updateNSViewController` and writes back into it when the
+  // user toggles a disclosure triangle.
+  var expandedItems: Binding<Set<Data.Element.ID>>?
+
+  // MARK: NSViewControllerRepresentable
+
+  public func makeNSViewController(context: Context) -> OutlineViewController<Data, Drop> {
+    let controller = OutlineViewController<Data, Drop>(
+      data: data,
+      childrenSource: childSource,
+      content: content,
+      selectionChanged: { selection = $0 },
+      separatorInsets: separatorInsets)
+    controller.setIndentation(to: indentation)
+    if #available(macOS 11.0, *) {
+      controller.setStyle(to: style)
+    }
+    return controller
+  }
+
+  public func updateNSViewController(
+    _ outlineController: OutlineViewController<Data, Drop>,
+    context: Context
+  ) {
+    outlineController.updateData(newValue: data)
+    outlineController.changeSelectedItem(to: selection)
+    outlineController.setRowSeparator(visibility: separatorVisibility)
+    outlineController.setRowSeparator(color: separatorColor)
+    outlineController.setDragSourceWriter(dragDataSource)
+    outlineController.setDropReceiver(dropReceiver)
+    outlineController.setAcceptedDragTypes(acceptedDropTypes)
+    // moolah: thread the group-row + expansion hooks through to
+    // the controller. Install the expansion callback before
+    // reconciling expand state — the controller suppresses the
+    // callback internally during reconciliation so writes do not
+    // feed back into the binding that triggered them.
+    outlineController.setIsGroupItem(isGroupItem)
+    if let expandedItems {
+      outlineController.setExpansionChanged { element, isExpanded in
+        var updated = expandedItems.wrappedValue
+        if isExpanded {
+          updated.insert(element.id)
+        } else {
+          updated.remove(element.id)
+        }
+        if updated != expandedItems.wrappedValue {
+          expandedItems.wrappedValue = updated
+        }
+      }
+      outlineController.applyExpandedItems(expandedItems.wrappedValue)
+    } else {
+      outlineController.setExpansionChanged(nil)
+    }
+  }
+}
+
+// MARK: - Modifiers
+
+@available(macOS 10.15, *)
+extension OutlineView {
+  /// Sets the style for the `OutlineView`.
+  @available(macOS 11.0, *)
+  public func outlineViewStyle(_ style: NSOutlineView.Style) -> Self {
+    var mutableSelf = self
+    mutableSelf.style = style
+    return mutableSelf
+  }
+
+  /// Sets the width of the indentation per level for the `OutlineView`.
+  public func outlineViewIndentation(_ width: CGFloat) -> Self {
+    var mutableSelf = self
+    mutableSelf.indentation = width
+    return mutableSelf
+  }
+
+  /// Sets the visibility of the separator between rows of the `OutlineView`.
+  public func rowSeparator(_ visibility: SeparatorVisibility) -> Self {
+    var mutableSelf = self
+    mutableSelf.separatorVisibility = visibility
+    return mutableSelf
+  }
+
+  /// Sets the color of the separator between rows of this `OutlineView`.
+  /// The default color for the separator is `NSColor.separatorColor`.
+  public func rowSeparatorColor(_ color: NSColor) -> Self {
+    var mutableSelf = self
+    mutableSelf.separatorColor = color
+    return mutableSelf
+  }
+
+  /// Adds a drop receiver to the `OutlineView`, allowing it to react to drag
+  /// and drop operations.
+  ///
+  /// - Parameters
+  ///   - acceptedTypes: An array of `PasteboardType`s that the `DropReceiver` is able to read.
+  ///   - receiver: A delegate conforming to `DropReceiver` that handles receiving a
+  ///     drag-and-drop operation onto the `OutlineView`.
+  public func onDrop(of acceptedTypes: [NSPasteboard.PasteboardType], receiver: Drop) -> Self {
+    var mutableSelf = self
+    mutableSelf.acceptedDropTypes = acceptedTypes
+    mutableSelf.dropReceiver = receiver
+    return mutableSelf
+  }
+
+  /// Enables dragging of rows from the `OutlineView` by setting the `DragSourceWriter`
+  /// of the `OutlineView`.
+  ///
+  /// The simplest way to create the data for the pasteboard item is to initialize
+  /// the `NSPasteboardItem` and then calling `setData(_:forType:)` or other types
+  /// of `set` functions.
+  ///
+  /// - Parameter writer: A closure that takes the `Data.Element` from a given row of
+  /// the `OutlineView`, and returns an optional `NSPasteboardItem` with data about the
+  /// item to be dragged. If `nil` is returned, that row can not be dragged.
+  public func dragDataSource(_ writer: @escaping DragSourceWriter<Data.Element>) -> Self {
+    var mutableSelf = self
+    mutableSelf.dragDataSource = writer
+    return mutableSelf
+  }
+
+  // moolah: declares which rows render as source-list group headers
+  // (no disclosure on the row, secondary-text-coloured capitalised
+  // label, not selectable). See
+  // `Extensions/OutlineView+IsGroupItem.swift` for the rationale.
+  /// Returning `true` for a given element makes `NSOutlineView`
+  /// render that row with source-list group-header chrome and
+  /// suppresses selection on the row.
+  public func outlineViewIsGroupItem(_ isGroupItem: @escaping (Data.Element) -> Bool) -> Self {
+    var mutableSelf = self
+    mutableSelf.isGroupItem = isGroupItem
+    return mutableSelf
+  }
+
+  // moolah: two-way expansion-state binding. See
+  // `Extensions/OutlineView+ExpansionBinding.swift` for the
+  // rationale.
+  /// Binds the expansion state of expandable rows to a
+  /// `Set<Element.ID>` owned by the caller. On every render, the
+  /// `NSOutlineView` is reconciled against the set (items in the
+  /// set are expanded; items not in the set are collapsed); when
+  /// the user toggles a disclosure triangle, the set is updated to
+  /// match.
+  public func outlineViewExpandedItems(_ expandedItems: Binding<Set<Data.Element.ID>>) -> Self {
+    var mutableSelf = self
+    mutableSelf.expandedItems = expandedItems
+    return mutableSelf
+  }
+}
+
+// MARK: - Initializers for macOS 10.15 and higher.
+
+@available(macOS 10.15, *)
+extension OutlineView {
+  /// Creates an `OutlineView` from a collection of root data elements and
+  /// a key path to its children.
+  ///
+  /// This initializer creates an instance that uniquely identifies views
+  /// across updates based on the identity of the underlying data element.
+  ///
+  /// All generated rows begin in the collapsed state.
+  ///
+  /// Make sure that the identifier of a data element only changes if you
+  /// mean to replace that element with a new element, one with a new
+  /// identity. If the ID of an element changes, then the content view
+  /// generated from that element will lose any current state and animations.
+  ///
+  /// - NOTE: All elements in data should be uniquely identified. Data with
+  /// elements that have a repeated identity are not supported.
+  ///
+  /// - Parameters:
+  ///   - data: A collection of tree-structured, identified data.
+  ///   - children: A key path to a property whose non-`nil` value gives the
+  ///     children of `data`. A non-`nil` but empty value denotes an element
+  ///     capable of having children that's currently childless, such as an
+  ///     empty directory in a file system. On the other hand, if the property
+  ///     at the key path is `nil`, then the outline view treats `data` as a
+  ///     leaf in the tree, like a regular file in a file system.
+  ///   - selection: A binding to a selected value.
+  ///   - content: A closure that produces an `NSView` based on an
+  ///     element in `data`. An `NSTableCellView` subclass is preferred.
+  ///     The `NSView` should return the correct `fittingSize`
+  ///     as it is used to determine the height of the cell.
+  public init(
+    _ data: Data,
+    children: KeyPath<Data.Element, Data?>,
+    selection: Binding<Data.Element?>,
+    content: @escaping (Data.Element) -> NSView
+  ) {
+    self.data = data
+    self.childSource = .keyPath(children)
+    self._selection = selection
+    self.separatorVisibility = .hidden
+    self.content = content
+  }
+
+  /// Creates an `OutlineView` from a collection of root data elements and
+  /// a closure that provides children to each element.
+  ///
+  /// This initializer creates an instance that uniquely identifies views
+  /// across updates based on the identity of the underlying data element.
+  ///
+  /// All generated rows begin in the collapsed state.
+  ///
+  /// Make sure that the identifier of a data element only changes if you
+  /// mean to replace that element with a new element, one with a new
+  /// identity. If the ID of an element changes, then the content view
+  /// generated from that element will lose any current state and animations.
+  ///
+  /// - NOTE: All elements in data should be uniquely identified. Data with
+  /// elements that have a repeated identity are not supported.
+  ///
+  /// - Parameters:
+  ///   - data: A collection of tree-structured, identified data.
+  ///   - selection: A binding to a selected value.
+  ///   - children: A closure whose non-`nil` return value gives the
+  ///     children of `data`. A non-`nil` but empty value denotes an element
+  ///     capable of having children that's currently childless, such as an
+  ///     empty directory in a file system. On the other hand, if the value
+  ///     from the closure is `nil`, then the outline view treats `data` as a
+  ///     leaf in the tree, like a regular file in a file system.
+  ///   - content: A closure that produces an `NSView` based on an
+  ///     element in `data`. An `NSTableCellView` subclass is preferred.
+  ///     The `NSView` should return the correct `fittingSize`
+  ///     as it is used to determine the height of the cell.
+  public init(
+    _ data: Data,
+    selection: Binding<Data.Element?>,
+    children: @escaping (Data.Element) -> Data?,
+    content: @escaping (Data.Element) -> NSView
+  ) {
+    self.data = data
+    self._selection = selection
+    self.childSource = .provider(children)
+    self.separatorVisibility = .hidden
+    self.content = content
+  }
+}
+
+// MARK: Initializers for macOS 10.15 and higher with NoDropReceiver.
+
+@available(macOS 10.15, *)
+extension OutlineView where Drop == NoDropReceiver<Data.Element> {
+  /// Creates an `OutlineView` from a collection of root data elements and
+  /// a key path to its children.
+  ///
+  /// This initializer creates an instance that uniquely identifies views
+  /// across updates based on the identity of the underlying data element.
+  ///
+  /// All generated rows begin in the collapsed state.
+  ///
+  /// Make sure that the identifier of a data element only changes if you
+  /// mean to replace that element with a new element, one with a new
+  /// identity. If the ID of an element changes, then the content view
+  /// generated from that element will lose any current state and animations.
+  ///
+  /// - NOTE: All elements in data should be uniquely identified. Data with
+  /// elements that have a repeated identity are not supported.
+  ///
+  /// - Parameters:
+  ///   - data: A collection of tree-structured, identified data.
+  ///   - children: A key path to a property whose non-`nil` value gives the
+  ///     children of `data`. A non-`nil` but empty value denotes an element
+  ///     capable of having children that's currently childless, such as an
+  ///     empty directory in a file system. On the other hand, if the property
+  ///     at the key path is `nil`, then the outline view treats `data` as a
+  ///     leaf in the tree, like a regular file in a file system.
+  ///   - selection: A binding to a selected value.
+  ///   - content: A closure that produces an `NSView` based on an
+  ///     element in `data`. An `NSTableCellView` subclass is preferred.
+  ///     The `NSView` should return the correct `fittingSize`
+  ///     as it is used to determine the height of the cell.
+  public init(
+    _ data: Data,
+    children: KeyPath<Data.Element, Data?>,
+    selection: Binding<Data.Element?>,
+    content: @escaping (Data.Element) -> NSView
+  ) {
+    self.data = data
+    self.childSource = .keyPath(children)
+    self._selection = selection
+    self.separatorVisibility = .hidden
+    self.content = content
+  }
+
+  /// Creates an `OutlineView` from a collection of root data elements and
+  /// a closure that provides children to each element.
+  ///
+  /// This initializer creates an instance that uniquely identifies views
+  /// across updates based on the identity of the underlying data element.
+  ///
+  /// All generated rows begin in the collapsed state.
+  ///
+  /// Make sure that the identifier of a data element only changes if you
+  /// mean to replace that element with a new element, one with a new
+  /// identity. If the ID of an element changes, then the content view
+  /// generated from that element will lose any current state and animations.
+  ///
+  /// - NOTE: All elements in data should be uniquely identified. Data with
+  /// elements that have a repeated identity are not supported.
+  ///
+  /// - Parameters:
+  ///   - data: A collection of tree-structured, identified data.
+  ///   - selection: A binding to a selected value.
+  ///   - children: A closure whose non-`nil` return value gives the
+  ///     children of `data`. A non-`nil` but empty value denotes an element
+  ///     capable of having children that's currently childless, such as an
+  ///     empty directory in a file system. On the other hand, if the value
+  ///     from the closure is `nil`, then the outline view treats `data` as a
+  ///     leaf in the tree, like a regular file in a file system.
+  ///   - content: A closure that produces an `NSView` based on an
+  ///     element in `data`. An `NSTableCellView` subclass is preferred.
+  ///     The `NSView` should return the correct `fittingSize`
+  ///     as it is used to determine the height of the cell.
+  public init(
+    _ data: Data,
+    selection: Binding<Data.Element?>,
+    children: @escaping (Data.Element) -> Data?,
+    content: @escaping (Data.Element) -> NSView
+  ) {
+    self.data = data
+    self._selection = selection
+    self.childSource = .provider(children)
+    self.separatorVisibility = .hidden
+    self.content = content
+  }
+}
+
+// MARK: Initializers for macOS 11 and higher.
+
+@available(macOS 11.0, *)
+extension OutlineView {
+  /// Creates an `OutlineView` from a collection of root data elements and
+  /// a key path to its children.
+  ///
+  /// This initializer creates an instance that uniquely identifies views
+  /// across updates based on the identity of the underlying data element.
+  ///
+  /// All generated rows begin in the collapsed state.
+  ///
+  /// Make sure that the identifier of a data element only changes if you
+  /// mean to replace that element with a new element, one with a new
+  /// identity. If the ID of an element changes, then the content view
+  /// generated from that element will lose any current state and animations.
+  ///
+  /// - NOTE: All elements in data should be uniquely identified. Data with
+  /// elements that have a repeated identity are not supported.
+  ///
+  /// - Parameters:
+  ///   - data: A collection of tree-structured, identified data.
+  ///   - children: A key path to a property whose non-`nil` value gives the
+  ///     children of `data`. A non-`nil` but empty value denotes an element
+  ///     capable of having children that's currently childless, such as an
+  ///     empty directory in a file system. On the other hand, if the property
+  ///     at the key path is `nil`, then the outline view treats `data` as a
+  ///     leaf in the tree, like a regular file in a file system.
+  ///   - selection: A binding to a selected value.
+  ///   - separatorInsets: An optional closure that produces row separator lines
+  ///     with the given insets for each item in the outline view. If this closure
+  ///     is not provided (the default), separators are hidden.
+  ///   - content: A closure that produces an `NSView` based on an
+  ///     element in `data`. An `NSTableCellView` subclass is preferred.
+  ///     The `NSView` should return the correct `fittingSize`
+  ///     as it is used to determine the height of the cell.
+  @available(macOS 11.0, *)
+  public init(
+    _ data: Data,
+    children: KeyPath<Data.Element, Data?>,
+    selection: Binding<Data.Element?>,
+    separatorInsets: ((Data.Element) -> NSEdgeInsets)? = nil,
+    content: @escaping (Data.Element) -> NSView
+  ) {
+    self.data = data
+    self.childSource = .keyPath(children)
+    self._selection = selection
+    self.separatorInsets = separatorInsets
+    self.separatorVisibility = separatorInsets == nil ? .hidden : .visible
+    self.content = content
+  }
+
+  /// Creates an `OutlineView` from a collection of root data elements and
+  /// a closure that provides children to each element.
+  ///
+  /// This initializer creates an instance that uniquely identifies views
+  /// across updates based on the identity of the underlying data element.
+  ///
+  /// All generated rows begin in the collapsed state.
+  ///
+  /// Make sure that the identifier of a data element only changes if you
+  /// mean to replace that element with a new element, one with a new
+  /// identity. If the ID of an element changes, then the content view
+  /// generated from that element will lose any current state and animations.
+  ///
+  /// - NOTE: All elements in data should be uniquely identified. Data with
+  /// elements that have a repeated identity are not supported.
+  ///
+  /// - Parameters:
+  ///   - data: A collection of tree-structured, identified data.
+  ///   - selection: A binding to a selected value.
+  ///   - children: A closure whose non-`nil` return value gives the
+  ///     children of `data`. A non-`nil` but empty value denotes an element
+  ///     capable of having children that's currently childless, such as an
+  ///     empty directory in a file system. On the other hand, if the value
+  ///     from the closure is `nil`, then the outline view treats `data` as a
+  ///     leaf in the tree, like a regular file in a file system.
+  ///   - separatorInsets: An optional closure that produces row separator lines
+  ///     with the given insets for each item in the outline view. If this closure
+  ///     is not provided (the default), separators are hidden.
+  ///   - content: A closure that produces an `NSView` based on an
+  ///     element in `data`. An `NSTableCellView` subclass is preferred.
+  ///     The `NSView` should return the correct `fittingSize`
+  ///     as it is used to determine the height of the cell.
+  @available(macOS 11.0, *)
+  public init(
+    _ data: Data,
+    selection: Binding<Data.Element?>,
+    children: @escaping (Data.Element) -> Data?,
+    separatorInsets: ((Data.Element) -> NSEdgeInsets)? = nil,
+    content: @escaping (Data.Element) -> NSView
+  ) {
+    self.data = data
+    self._selection = selection
+    self.childSource = .provider(children)
+    self.separatorInsets = separatorInsets
+    self.separatorVisibility = separatorInsets == nil ? .hidden : .visible
+    self.content = content
+  }
+}
+
+// MARK: Initializers for macOS 11 and higher with NoDropReceiver.
+
+@available(macOS 11.0, *)
+extension OutlineView where Drop == NoDropReceiver<Data.Element> {
+  /// Creates an `OutlineView` from a collection of root data elements and
+  /// a key path to its children.
+  ///
+  /// This initializer creates an instance that uniquely identifies views
+  /// across updates based on the identity of the underlying data element.
+  ///
+  /// All generated rows begin in the collapsed state.
+  ///
+  /// Make sure that the identifier of a data element only changes if you
+  /// mean to replace that element with a new element, one with a new
+  /// identity. If the ID of an element changes, then the content view
+  /// generated from that element will lose any current state and animations.
+  ///
+  /// - NOTE: All elements in data should be uniquely identified. Data with
+  /// elements that have a repeated identity are not supported.
+  ///
+  /// - Parameters:
+  ///   - data: A collection of tree-structured, identified data.
+  ///   - children: A key path to a property whose non-`nil` value gives the
+  ///     children of `data`. A non-`nil` but empty value denotes an element
+  ///     capable of having children that's currently childless, such as an
+  ///     empty directory in a file system. On the other hand, if the property
+  ///     at the key path is `nil`, then the outline view treats `data` as a
+  ///     leaf in the tree, like a regular file in a file system.
+  ///   - selection: A binding to a selected value.
+  ///   - separatorInsets: An optional closure that produces row separator lines
+  ///     with the given insets for each item in the outline view. If this closure
+  ///     is not provided (the default), separators are hidden.
+  ///   - content: A closure that produces an `NSView` based on an
+  ///     element in `data`. An `NSTableCellView` subclass is preferred.
+  ///     The `NSView` should return the correct `fittingSize`
+  ///     as it is used to determine the height of the cell.
+  public init(
+    _ data: Data,
+    children: KeyPath<Data.Element, Data?>,
+    selection: Binding<Data.Element?>,
+    separatorInsets: ((Data.Element) -> NSEdgeInsets)? = nil,
+    content: @escaping (Data.Element) -> NSView
+  ) {
+    self.data = data
+    self.childSource = .keyPath(children)
+    self._selection = selection
+    self.separatorInsets = separatorInsets
+    self.separatorVisibility = separatorInsets == nil ? .hidden : .visible
+    self.content = content
+  }
+
+  /// Creates an `OutlineView` from a collection of root data elements and
+  /// a closure that provides children to each element.
+  ///
+  /// This initializer creates an instance that uniquely identifies views
+  /// across updates based on the identity of the underlying data element.
+  ///
+  /// All generated rows begin in the collapsed state.
+  ///
+  /// Make sure that the identifier of a data element only changes if you
+  /// mean to replace that element with a new element, one with a new
+  /// identity. If the ID of an element changes, then the content view
+  /// generated from that element will lose any current state and animations.
+  ///
+  /// - NOTE: All elements in data should be uniquely identified. Data with
+  /// elements that have a repeated identity are not supported.
+  ///
+  /// - Parameters:
+  ///   - data: A collection of tree-structured, identified data.
+  ///   - selection: A binding to a selected value.
+  ///   - children: A closure whose non-`nil` return value gives the
+  ///     children of `data`. A non-`nil` but empty value denotes an element
+  ///     capable of having children that's currently childless, such as an
+  ///     empty directory in a file system. On the other hand, if the value
+  ///     from the closure is `nil`, then the outline view treats `data` as a
+  ///     leaf in the tree, like a regular file in a file system.
+  ///   - separatorInsets: An optional closure that produces row separator lines
+  ///     with the given insets for each item in the outline view. If this closure
+  ///     is not provided (the default), separators are hidden.
+  ///   - content: A closure that produces an `NSView` based on an
+  ///     element in `data`. An `NSTableCellView` subclass is preferred.
+  ///     The `NSView` should return the correct `fittingSize`
+  ///     as it is used to determine the height of the cell.
+  public init(
+    _ data: Data,
+    selection: Binding<Data.Element?>,
+    children: @escaping (Data.Element) -> Data?,
+    separatorInsets: ((Data.Element) -> NSEdgeInsets)? = nil,
+    content: @escaping (Data.Element) -> NSView
+  ) {
+    self.data = data
+    self._selection = selection
+    self.childSource = .provider(children)
+    self.separatorInsets = separatorInsets
+    self.separatorVisibility = separatorInsets == nil ? .hidden : .visible
+    self.content = content
+  }
+}

--- a/Vendored/OutlineView/OutlineViewController.swift
+++ b/Vendored/OutlineView/OutlineViewController.swift
@@ -27,6 +27,13 @@ where Drop.DataElement == Data.Element {
     scrollView.hasVerticalScroller = true
     scrollView.hasHorizontalRuler = true
     scrollView.drawsBackground = false
+    // moolah: clear the scroll view + outline view backgrounds so the
+    // host SwiftUI sidebar material (vibrancy) shows through. Default
+    // AppKit chrome paints `controlBackgroundColor` here, which
+    // appears as an opaque off-colour band against a `.listStyle(.sidebar)`
+    // List that hosts this view.
+    scrollView.backgroundColor = .clear
+    outlineView.backgroundColor = .clear
 
     outlineView.autoresizesOutlineColumn = false
     outlineView.headerView = nil

--- a/Vendored/OutlineView/OutlineViewController.swift
+++ b/Vendored/OutlineView/OutlineViewController.swift
@@ -1,0 +1,204 @@
+import Cocoa
+
+@available(macOS 10.15, *)
+public class OutlineViewController<Data: Sequence, Drop: DropReceiver>: NSViewController
+where Drop.DataElement == Data.Element {
+  // moolah: raised from `internal` to `public` so callers in the
+  // hosting module (Moolah_macOS) can drive expand / collapse and
+  // read the underlying view for accessibility identifiers. Required
+  // for restoring expansion state from GroupUIStateStore.
+  public let outlineView = NSOutlineView()
+  let scrollView = NSScrollView(frame: NSRect(x: 0, y: 0, width: 400, height: 400))
+
+  let dataSource: OutlineViewDataSource<Data, Drop>
+  let delegate: OutlineViewDelegate<Data>
+  let updater = OutlineViewUpdater<Data>()
+
+  let childrenSource: ChildSource<Data>
+
+  init(
+    data: Data,
+    childrenSource: ChildSource<Data>,
+    content: @escaping (Data.Element) -> NSView,
+    selectionChanged: @escaping (Data.Element?) -> Void,
+    separatorInsets: ((Data.Element) -> NSEdgeInsets)?
+  ) {
+    scrollView.documentView = outlineView
+    scrollView.hasVerticalScroller = true
+    scrollView.hasHorizontalRuler = true
+    scrollView.drawsBackground = false
+
+    outlineView.autoresizesOutlineColumn = false
+    outlineView.headerView = nil
+    outlineView.usesAutomaticRowHeights = true
+    outlineView.columnAutoresizingStyle = .uniformColumnAutoresizingStyle
+
+    let onlyColumn = NSTableColumn()
+    onlyColumn.resizingMask = .autoresizingMask
+    outlineView.addTableColumn(onlyColumn)
+
+    dataSource = OutlineViewDataSource(
+      items: data.map { OutlineViewItem(value: $0, children: childrenSource) },
+      childSource: childrenSource
+    )
+    delegate = OutlineViewDelegate(
+      content: content,
+      selectionChanged: selectionChanged,
+      separatorInsets: separatorInsets)
+    outlineView.dataSource = dataSource
+    outlineView.delegate = delegate
+
+    self.childrenSource = childrenSource
+
+    super.init(nibName: nil, bundle: nil)
+
+    view.addSubview(scrollView)
+    scrollView.translatesAutoresizingMaskIntoConstraints = false
+    NSLayoutConstraint.activate([
+      scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+      scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+      scrollView.topAnchor.constraint(equalTo: view.topAnchor),
+      scrollView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+    ])
+  }
+
+  required init?(coder: NSCoder) {
+    return nil
+  }
+
+  public override func loadView() {
+    view = NSView()
+  }
+
+  public override func viewWillAppear() {
+    // Size the column to take the full width. This combined with
+    // the uniform column autoresizing style allows the column to
+    // adjust its width with a change in width of the outline view.
+    outlineView.sizeLastColumnToFit()
+    super.viewWillAppear()
+  }
+}
+
+// MARK: - Performing updates
+@available(macOS 10.15, *)
+extension OutlineViewController {
+  func updateData(newValue: Data) {
+    let newState = newValue.map { OutlineViewItem(value: $0, children: childrenSource) }
+
+    outlineView.beginUpdates()
+
+    dataSource.items = newState
+    updater.performUpdates(
+      outlineView: outlineView,
+      oldStateTree: dataSource.treeMap,
+      newState: newState,
+      parent: nil)
+
+    outlineView.endUpdates()
+
+    // After updates, dataSource must rebuild its idTree for future updates
+    dataSource.rebuildIDTree(rootItems: newState, outlineView: outlineView)
+  }
+
+  func changeSelectedItem(to item: Data.Element?) {
+    delegate.changeSelectedItem(
+      to: item.map { OutlineViewItem(value: $0, children: childrenSource) },
+      in: outlineView)
+  }
+
+  @available(macOS 11.0, *)
+  func setStyle(to style: NSOutlineView.Style) {
+    outlineView.style = style
+  }
+
+  func setIndentation(to width: CGFloat) {
+    outlineView.indentationPerLevel = width
+  }
+
+  func setRowSeparator(visibility: SeparatorVisibility) {
+    switch visibility {
+    case .hidden:
+      outlineView.gridStyleMask = []
+    case .visible:
+      outlineView.gridStyleMask = .solidHorizontalGridLineMask
+    }
+  }
+
+  func setRowSeparator(color: NSColor) {
+    guard color != outlineView.gridColor else {
+      return
+    }
+
+    outlineView.gridColor = color
+    outlineView.reloadData()
+  }
+
+  func setDragSourceWriter(_ writer: DragSourceWriter<Data.Element>?) {
+    dataSource.dragWriter = writer
+  }
+
+  func setDropReceiver(_ receiver: Drop?) {
+    dataSource.dropReceiver = receiver
+  }
+
+  func setAcceptedDragTypes(_ acceptedTypes: [NSPasteboard.PasteboardType]?) {
+    outlineView.unregisterDraggedTypes()
+    if let acceptedTypes,
+      !acceptedTypes.isEmpty
+    {
+      outlineView.registerForDraggedTypes(acceptedTypes)
+    }
+  }
+
+  // moolah: install the caller's `isGroupItem` closure on the
+  // delegate. Called from `OutlineView.updateNSViewController` so the
+  // closure can capture fresh state on each SwiftUI update.
+  func setIsGroupItem(_ isGroupItem: ((Data.Element) -> Bool)?) {
+    delegate.isGroupItem = isGroupItem
+  }
+
+  // moolah: install the caller's expansion-change callback. Called
+  // by `OutlineView.updateNSViewController` to feed expand /
+  // collapse events back into the bound `Set<Element.ID>`.
+  func setExpansionChanged(_ handler: ((Data.Element, Bool) -> Void)?) {
+    delegate.expansionChanged = handler
+  }
+
+  // moolah: reconcile the NSOutlineView's current expansion state
+  // with `expandedIDs`. Items in the set but not currently expanded
+  // get expanded; items currently expanded but not in the set get
+  // collapsed. We suppress the expansion callback during this
+  // reconciliation so the caller's binding does not feed back into
+  // itself.
+  func applyExpandedItems(_ expandedIDs: Set<Data.Element.ID>) {
+    // Snapshot then nil-out the callback so notifications fired
+    // during expand / collapse do not write back into the binding
+    // that triggered this call. Restored at exit.
+    let saved = delegate.expansionChanged
+    delegate.expansionChanged = nil
+    defer { delegate.expansionChanged = saved }
+
+    for item in dataSource.items {
+      applyExpansion(item: item, expandedIDs: expandedIDs)
+    }
+  }
+
+  private func applyExpansion(
+    item: OutlineViewItem<Data>,
+    expandedIDs: Set<Data.Element.ID>
+  ) {
+    let shouldExpand = expandedIDs.contains(item.id)
+    let isExpanded = outlineView.isItemExpanded(item)
+    if shouldExpand, !isExpanded {
+      outlineView.expandItem(item)
+    } else if !shouldExpand, isExpanded {
+      outlineView.collapseItem(item)
+    }
+    // Recurse into children so nested groups are reconciled too.
+    if let children = item.children {
+      for child in children {
+        applyExpansion(item: child, expandedIDs: expandedIDs)
+      }
+    }
+  }
+}

--- a/Vendored/OutlineView/OutlineViewController.swift
+++ b/Vendored/OutlineView/OutlineViewController.swift
@@ -33,8 +33,34 @@ where Drop.DataElement == Data.Element {
     // appears as an opaque off-colour band against a `.listStyle(.sidebar)`
     // List that hosts this view.
     scrollView.backgroundColor = .clear
+    // moolah: NSScrollView delegates its contentView (an `NSClipView`)
+    // to paint the visible region's backdrop; its `drawsBackground`
+    // defaults to `true` and paints `controlBackgroundColor`, which is
+    // the actual source of the opaque grey "band" the user sees around
+    // the outline rows when this view is embedded inside a SwiftUI
+    // `List(.sidebar)`. Clearing it lets the host sidebar material
+    // (vibrancy) show through the entire outline region — not just the
+    // outline view itself.
+    scrollView.contentView.drawsBackground = false
+    if let clipView = scrollView.contentView as NSClipView? {
+      clipView.backgroundColor = .clear
+    }
     outlineView.backgroundColor = .clear
-
+    // moolah: belt-and-braces — disable AppKit's default row-stripe
+    // and grid chrome that would paint over the host SwiftUI sidebar
+    // material. `selectionHighlightStyle = .regular` is the modern
+    // replacement for the deprecated `.sourceList` style; combined
+    // with `usesAlternatingRowBackgroundColors = false` and an empty
+    // gridStyleMask, no per-row backdrop is painted unless a row is
+    // actually selected.
+    outlineView.selectionHighlightStyle = .regular
+    outlineView.usesAlternatingRowBackgroundColors = false
+    outlineView.gridStyleMask = []
+    // moolah: tighten the per-row internal spacing — SwiftUI's
+    // `List(.sidebar)` rows have ~28pt heights with tight intercell
+    // spacing. Default `(3, 2)` adds a visible gap between rows that
+    // doesn't match the host List.
+    outlineView.intercellSpacing = NSSize(width: 0, height: 0)
     outlineView.autoresizesOutlineColumn = false
     outlineView.headerView = nil
     outlineView.usesAutomaticRowHeights = true

--- a/Vendored/OutlineView/OutlineViewDataSource.swift
+++ b/Vendored/OutlineView/OutlineViewDataSource.swift
@@ -1,0 +1,209 @@
+import Cocoa
+import Combine
+
+// moolah: marked `@MainActor` — every NSOutlineView API called from
+// inside is main-actor-isolated under macOS 26 / Swift 6 strict
+// concurrency. Upstream relied on Swift 5's looser checking; we
+// build with `SWIFT_VERSION: 6.0`.
+@available(macOS 10.15, *)
+@MainActor
+class OutlineViewDataSource<Data: Sequence, Drop: DropReceiver>: NSObject, NSOutlineViewDataSource
+where Drop.DataElement == Data.Element {
+  var items: [OutlineViewItem<Data>]
+  var dropReceiver: Drop?
+  var dragWriter: DragSourceWriter<Data.Element>?
+  let childrenSource: ChildSource<Data>
+
+  var treeMap: TreeMap<Data.Element.ID>
+
+  private var willExpandToken: AnyCancellable?
+  private var didCollapseToken: AnyCancellable?
+
+  init(items: [OutlineViewItem<Data>], childSource: ChildSource<Data>) {
+    self.items = items
+    self.childrenSource = childSource
+
+    treeMap = TreeMap()
+    for item in items {
+      treeMap.addItem(item.value.id, isLeaf: item.children == nil, intoItem: nil, atIndex: nil)
+    }
+
+    super.init()
+
+    // Listen for expand/collapse notifications in order to keep TreeMap up to date
+    willExpandToken = NotificationCenter.default.publisher(
+      for: NSOutlineView.itemWillExpandNotification
+    )
+    .compactMap { NSOutlineView.expansionNotificationInfo($0) }
+    .sink { [weak self] in
+      self?.receiveItemWillExpandNotification(
+        outlineView: $0.outlineView, objectToExpand: $0.object)
+    }
+    didCollapseToken = NotificationCenter.default.publisher(
+      for: NSOutlineView.itemDidCollapseNotification
+    )
+    .compactMap { NSOutlineView.expansionNotificationInfo($0) }
+    .sink { [weak self] in
+      self?.receiveItemDidCollapseNotification(
+        outlineView: $0.outlineView, collapsedObject: $0.object)
+    }
+  }
+
+  func rebuildIDTree(rootItems: [OutlineViewItem<Data>], outlineView: NSOutlineView) {
+    treeMap = TreeMap(rootItems: rootItems, itemIsExpanded: { outlineView.isItemExpanded($0) })
+  }
+
+  private func typedItem(_ item: Any) -> OutlineViewItem<Data> {
+    item as! OutlineViewItem<Data>
+  }
+
+  // MARK: - Basic Data Source
+
+  func outlineView(
+    _ outlineView: NSOutlineView,
+    numberOfChildrenOfItem item: Any?
+  ) -> Int {
+    if let item = item.map(typedItem) {
+      return item.children?.count ?? 0
+    } else {
+      return items.count
+    }
+  }
+
+  func outlineView(
+    _ outlineView: NSOutlineView,
+    isItemExpandable item: Any
+  ) -> Bool {
+    typedItem(item).children != nil
+  }
+
+  func outlineView(
+    _ outlineView: NSOutlineView,
+    child index: Int,
+    ofItem item: Any?
+  ) -> Any {
+    if let item = item.map(typedItem) {
+      // Should only be called if item has children.
+      return item.children.unsafelyUnwrapped[index]
+    } else {
+      return items[index]
+    }
+  }
+
+  // MARK: - Drag & Drop
+
+  func outlineView(
+    _ outlineView: NSOutlineView,
+    pasteboardWriterForItem item: Any
+  ) -> NSPasteboardWriting? {
+    guard let writer = dragWriter,
+      let writeData = writer(typedItem(item).value)
+    else { return nil }
+
+    return writeData
+  }
+
+  func outlineView(
+    _ outlineView: NSOutlineView,
+    validateDrop info: NSDraggingInfo,
+    proposedItem item: Any?,
+    proposedChildIndex index: Int
+  ) -> NSDragOperation {
+    guard
+      let dropTarget = dropTargetData(
+        in: outlineView, dragInfo: info, item: item, childIndex: index),
+      let validationResult = dropReceiver?.validateDrop(target: dropTarget)
+    else { return [] }
+
+    switch validationResult {
+    case .copy:
+      return .copy
+    case .move:
+      return .move
+    case .deny:
+      return []
+    case let .copyRedirect(item, childIndex):
+      let redirectTarget = item.map { OutlineViewItem<Data>(value: $0, children: childrenSource) }
+      outlineView.setDropItem(
+        redirectTarget, dropChildIndex: childIndex ?? NSOutlineViewDropOnItemIndex)
+      return .copy
+    case let .moveRedirect(item, childIndex):
+      let redirectTarget = item.map { OutlineViewItem<Data>(value: $0, children: childrenSource) }
+      outlineView.setDropItem(
+        redirectTarget, dropChildIndex: childIndex ?? NSOutlineViewDropOnItemIndex)
+      return .move
+    }
+  }
+
+  func outlineView(
+    _ outlineView: NSOutlineView,
+    acceptDrop info: NSDraggingInfo,
+    item: Any?,
+    childIndex index: Int
+  ) -> Bool {
+    guard
+      let dropTarget = dropTargetData(
+        in: outlineView, dragInfo: info, item: item, childIndex: index),
+      // Perform `acceptDrop(target:)` to get result of drop
+      let dropIsSuccessful = dropReceiver?.acceptDrop(target: dropTarget)
+    else { return false }
+
+    return dropIsSuccessful
+  }
+}
+
+// MARK: - Helper Functions
+
+@available(macOS 10.15, *)
+extension OutlineViewDataSource {
+  fileprivate func receiveItemWillExpandNotification(
+    outlineView: NSOutlineView, objectToExpand: Any
+  ) {
+    guard let outlineDataSource = outlineView.dataSource,
+      outlineDataSource.isEqual(self)
+    else { return }
+
+    let typedObjToExpand = typedItem(objectToExpand)
+    if let childIDs = typedObjToExpand.children?.map({ ($0.id, $0.children == nil) }) {
+      treeMap.expandItem(typedObjToExpand.value.id, children: childIDs)
+    }
+  }
+
+  fileprivate func receiveItemDidCollapseNotification(
+    outlineView: NSOutlineView, collapsedObject: Any
+  ) {
+    guard let outlineDataSource = outlineView.dataSource,
+      outlineDataSource.isEqual(self)
+    else { return }
+
+    let typedObjThatCollapsed = typedItem(collapsedObject)
+    treeMap.collapseItem(typedObjThatCollapsed.value.id)
+  }
+
+  fileprivate func dropTargetData(
+    in outlineView: NSOutlineView,
+    dragInfo: NSDraggingInfo,
+    item: Any?,
+    childIndex: Int
+  ) -> DropTarget<Data.Element>? {
+    guard let pasteboardItems = dragInfo.draggingPasteboard.pasteboardItems,
+      !pasteboardItems.isEmpty,
+      let dropReceiver
+    else { return nil }
+
+    let decodedItems = pasteboardItems.compactMap {
+      dropReceiver.readPasteboard(item: $0)
+    }
+
+    let dropTarget = DropTarget<Data.Element>(
+      items: decodedItems,
+      intoElement: item.map(typedItem)?.value,
+      childIndex: childIndex == NSOutlineViewDropOnItemIndex ? nil : childIndex,
+      isItemExpanded: { item in
+        let typed = OutlineViewItem<Data>(value: item, children: self.childrenSource)
+        return outlineView.isItemExpanded(typed)
+      }
+    )
+    return dropTarget
+  }
+}

--- a/Vendored/OutlineView/OutlineViewDelegate.swift
+++ b/Vendored/OutlineView/OutlineViewDelegate.swift
@@ -1,0 +1,180 @@
+import Cocoa
+
+// moolah: marked `@MainActor` — see OutlineViewDataSource for
+// rationale (Swift 6 / macOS 26 strict concurrency).
+@available(macOS 10.15, *)
+@MainActor
+class OutlineViewDelegate<Data: Sequence>: NSObject, NSOutlineViewDelegate
+where Data.Element: Identifiable {
+  let content: (Data.Element) -> NSView
+  let selectionChanged: (Data.Element?) -> Void
+  let separatorInsets: ((Data.Element) -> NSEdgeInsets)?
+  var selectedItem: OutlineViewItem<Data>?
+  // moolah: optional closure that asks the caller whether a given
+  // element should render with NSOutlineView's source-list group-row
+  // chrome. Defaults to nil (treat no rows as group rows), preserving
+  // upstream behaviour.
+  var isGroupItem: ((Data.Element) -> Bool)?
+  // moolah: optional callback invoked after a row's expansion state
+  // changes (expand or collapse). Used to write back into a caller's
+  // `expandedItems` binding so the state can be persisted.
+  var expansionChanged: ((Data.Element, Bool) -> Void)?
+
+  func typedItem(_ item: Any) -> OutlineViewItem<Data> {
+    item as! OutlineViewItem<Data>
+  }
+
+  init(
+    content: @escaping (Data.Element) -> NSView,
+    selectionChanged: @escaping (Data.Element?) -> Void,
+    separatorInsets: ((Data.Element) -> NSEdgeInsets)?
+  ) {
+    self.content = content
+    self.selectionChanged = selectionChanged
+    self.separatorInsets = separatorInsets
+  }
+
+  func outlineView(
+    _ outlineView: NSOutlineView,
+    viewFor tableColumn: NSTableColumn?,
+    item: Any
+  ) -> NSView? {
+    content(typedItem(item).value)
+  }
+
+  func outlineView(
+    _ outlineView: NSOutlineView,
+    rowViewForItem item: Any
+  ) -> NSTableRowView? {
+    if #available(macOS 11.0, *) {
+      // Release any unused row views.
+      releaseUnusedRowViews(from: outlineView)
+      let rowView = AdjustableSeparatorRowView(frame: .zero)
+      rowView.separatorInsets = separatorInsets?(typedItem(item).value)
+      return rowView
+    } else {
+      return nil
+    }
+  }
+
+  // There seems to be a memory leak on macOS 11 where row views returned
+  // from `rowViewForItem` are never freed. This hack patches the leak.
+  func releaseUnusedRowViews(from outlineView: NSOutlineView) {
+    guard #available(macOS 11.0, *) else { return }
+
+    // Equivalent to _rowData._rowViewPurgatory
+    let purgatoryPath = unmangle("^qnvC`s`-^qnvUhdvOtqf`snqx")
+    if let rowViewPurgatory = outlineView.value(forKeyPath: purgatoryPath) as? NSMutableSet {
+      rowViewPurgatory
+        .compactMap { $0 as? AdjustableSeparatorRowView }
+        .forEach {
+          $0.removeFromSuperview()
+          rowViewPurgatory.remove($0)
+        }
+    }
+  }
+
+  func outlineView(
+    _ outlineView: NSOutlineView,
+    heightOfRowByItem item: Any
+  ) -> CGFloat {
+    // It appears that for outline views with automatic row heights, the
+    // initial height of the row still needs to be provided. Not providing
+    // a height for each cell would lead to the outline view defaulting to the
+    // `outlineView.rowHeight` when inserted. The cell may resize to the correct
+    // height if the outline view is reloaded.
+
+    // I am not able to find a better way to compute the final width of the cell
+    // other than hard-coding some of the constants.
+    let columnHorizontalInset: CGFloat
+    if #available(macOS 11.0, *) {
+      if outlineView.effectiveStyle == .plain {
+        columnHorizontalInset = 18
+      } else {
+        columnHorizontalInset = 9
+      }
+    } else {
+      columnHorizontalInset = 9
+    }
+
+    let column = outlineView.tableColumns.first.unsafelyUnwrapped
+    let indentInset = CGFloat(outlineView.level(forItem: item)) * outlineView.indentationPerLevel
+
+    let width = column.width - indentInset - columnHorizontalInset
+
+    // The view is provided by the user. And the width info is not provided
+    // separately. It does not seem efficient to create a new cell to find
+    // out the width of a cell. In practice I have not experienced any issues
+    // with a moderate number of cells.
+    let view = content(typedItem(item).value)
+    view.widthAnchor.constraint(equalToConstant: width).isActive = true
+    return view.fittingSize.height
+  }
+
+  // moolah: source-list group-row chrome (capitalised label,
+  // secondary text colour, no disclosure on the row itself). Returns
+  // false by default so existing callers see no change.
+  func outlineView(_ outlineView: NSOutlineView, isGroupItem item: Any) -> Bool {
+    isGroupItem?(typedItem(item).value) ?? false
+  }
+
+  // moolah: group rows must not be selectable (matches Finder /
+  // Mail.app sidebar behaviour and Apple HIG).
+  func outlineView(_ outlineView: NSOutlineView, shouldSelectItem item: Any) -> Bool {
+    !(isGroupItem?(typedItem(item).value) ?? false)
+  }
+
+  func outlineViewItemDidExpand(_ notification: Notification) {
+    let outlineView = notification.object as! NSOutlineView
+    if outlineView.selectedRow == -1 {
+      selectRow(for: selectedItem, in: outlineView)
+    }
+    // moolah: notify the caller's expansion-state binding.
+    if let info = NSOutlineView.expansionNotificationInfo(notification) {
+      let element = typedItem(info.object).value
+      expansionChanged?(element, true)
+    }
+  }
+
+  // moolah: mirror of `outlineViewItemDidExpand` for collapse so the
+  // caller's binding stays in sync on both transitions.
+  func outlineViewItemDidCollapse(_ notification: Notification) {
+    if let info = NSOutlineView.expansionNotificationInfo(notification) {
+      let element = typedItem(info.object).value
+      expansionChanged?(element, false)
+    }
+  }
+
+  func outlineViewSelectionDidChange(_ notification: Notification) {
+    let outlineView = notification.object as! NSOutlineView
+    if outlineView.selectedRow != -1 {
+      let newSelection = outlineView.item(atRow: outlineView.selectedRow).map(typedItem)
+      if selectedItem?.id != newSelection?.id {
+        selectedItem = newSelection
+        selectionChanged(selectedItem?.value)
+      }
+    }
+  }
+
+  func selectRow(
+    for item: OutlineViewItem<Data>?,
+    in outlineView: NSOutlineView
+  ) {
+    // Returns -1 if row is not found.
+    let index = outlineView.row(forItem: selectedItem)
+    if index != -1 {
+      outlineView.selectRowIndexes(IndexSet([index]), byExtendingSelection: false)
+    } else {
+      outlineView.deselectAll(nil)
+    }
+  }
+
+  func changeSelectedItem(
+    to item: OutlineViewItem<Data>?,
+    in outlineView: NSOutlineView
+  ) {
+    guard selectedItem?.id != item?.id else { return }
+    selectedItem = item
+    selectRow(for: selectedItem, in: outlineView)
+  }
+}

--- a/Vendored/OutlineView/OutlineViewDelegate.swift
+++ b/Vendored/OutlineView/OutlineViewDelegate.swift
@@ -74,42 +74,27 @@ where Data.Element: Identifiable {
     }
   }
 
-  func outlineView(
-    _ outlineView: NSOutlineView,
-    heightOfRowByItem item: Any
-  ) -> CGFloat {
-    // It appears that for outline views with automatic row heights, the
-    // initial height of the row still needs to be provided. Not providing
-    // a height for each cell would lead to the outline view defaulting to the
-    // `outlineView.rowHeight` when inserted. The cell may resize to the correct
-    // height if the outline view is reloaded.
-
-    // I am not able to find a better way to compute the final width of the cell
-    // other than hard-coding some of the constants.
-    let columnHorizontalInset: CGFloat
-    if #available(macOS 11.0, *) {
-      if outlineView.effectiveStyle == .plain {
-        columnHorizontalInset = 18
-      } else {
-        columnHorizontalInset = 9
-      }
-    } else {
-      columnHorizontalInset = 9
-    }
-
-    let column = outlineView.tableColumns.first.unsafelyUnwrapped
-    let indentInset = CGFloat(outlineView.level(forItem: item)) * outlineView.indentationPerLevel
-
-    let width = column.width - indentInset - columnHorizontalInset
-
-    // The view is provided by the user. And the width info is not provided
-    // separately. It does not seem efficient to create a new cell to find
-    // out the width of a cell. In practice I have not experienced any issues
-    // with a moderate number of cells.
-    let view = content(typedItem(item).value)
-    view.widthAnchor.constraint(equalToConstant: width).isActive = true
-    return view.fittingSize.height
-  }
+  // moolah: removed upstream's custom `heightOfRowByItem:` implementation.
+  //
+  // Upstream allocated a *fresh* `NSHostingView`-bearing cell on every
+  // height query just to read its `fittingSize.height`. Under XCUITest,
+  // AppKit's accessibility instrumentation forces a full-tree row-height
+  // scan inside `NSOutlineView.endUpdates`, calling this delegate method
+  // for rows that the in-flight diff has already removed from the data
+  // source. The freshly built `NSHostingView` then tried to resolve the
+  // SwiftUI environment chain (e.g. `@Environment(AccountStore.self)` on
+  // `AccountSidebarRow`) against an item whose backing record has been
+  // dropped — the resulting use-after-free dispatched through a freed
+  // pointer and crashed inside `_safeSendDelegateHeightOfRow:`. Manual
+  // (non-XCUITest) launches survived because AppKit only queries heights
+  // for visible rows there, not the full tree.
+  //
+  // `OutlineViewController` configures `outlineView.usesAutomaticRowHeights
+  // = true`, so AppKit derives the row height from each cell view's
+  // intrinsic content size on first display. Not implementing the
+  // delegate optional means AppKit falls back to that automatic path
+  // entirely — heights resolve once the cell is realised, which is the
+  // semantics we actually want for SwiftUI-hosted rows.
 
   // moolah: source-list group-row chrome (capitalised label,
   // secondary text colour, no disclosure on the row itself). Returns

--- a/Vendored/OutlineView/OutlineViewDragAndDrop.swift
+++ b/Vendored/OutlineView/OutlineViewDragAndDrop.swift
@@ -1,0 +1,137 @@
+import AppKit
+
+/// A protocol for use with `OutlineView`, implemented by a delegate to interact
+/// with drop operations in an `OutlineView`.
+@available(macOS 10.15, *)
+public protocol DropReceiver {
+  associatedtype DataElement: Identifiable
+
+  /// Converts a `NSPasteboardItem` received by a drag-and-drop operation to the data
+  /// element of an `OutlineView`.
+  ///
+  /// - Parameter item: The pasteboard item that is being dragged into the OutlineView
+  ///
+  /// - Returns: `nil` if the pasteboard item is not readable by this receiver, or
+  ///   a tuple with the decoded item and its associated PasteboardType, which must
+  ///   be included in `acceptedTypes`.
+  func readPasteboard(item: NSPasteboardItem) -> DraggedItem<DataElement>?
+
+  /// Defines the behavior of the `OutlineView` and the drag cursor when an item is
+  /// being dragged. Called continuously as a dragged item is moved over the `OutlineView`.
+  ///
+  /// - Parameter target: A `DropTarget` describing where the dragged item
+  ///   is currently positioned.
+  ///
+  /// - Returns: A case of `ValidationResult`, which will either highlight the area
+  ///   of the `OutlineView` where the item will be dropped, or some other behavior.
+  ///   See `ValidationResult` for possible return values.
+  func validateDrop(target: DropTarget<DataElement>) -> ValidationResult<DataElement>
+
+  /// Handles updating the data source once an item is dropped into the `OutlineView`.
+  /// Called once after the drop completes and `validateDrop(target:)` returns a case
+  /// other than `deny`.
+  ///
+  /// - Parameter target: A `DropTarget` with instances of the dropped items and
+  ///   information about their position.
+  ///
+  /// - Returns: a boolean indicating that the drop was successful.
+  func acceptDrop(target: DropTarget<DataElement>) -> Bool
+}
+
+@available(macOS 10.15, *)
+public enum NoDropReceiver<Element: Identifiable>: DropReceiver {
+  public typealias DataElement = Element
+
+  public func readPasteboard(item: NSPasteboardItem) -> DraggedItem<Element>? {
+    fatalError()
+  }
+
+  public func validateDrop(target: DropTarget<Element>) -> ValidationResult<Element> {
+    fatalError()
+  }
+
+  public func acceptDrop(target: DropTarget<Element>) -> Bool {
+    fatalError()
+  }
+}
+
+public typealias DragSourceWriter<D> = (D) -> NSPasteboardItem?
+public typealias DraggedItem<D> = (item: D, type: NSPasteboard.PasteboardType)
+
+/// An struct describing what items are being dragged into an `OutlineView`, and
+/// where in the data heirarchy they are being dropped.
+@available(macOS 10.15, *)
+public struct DropTarget<D> {
+  /// A non-empty array of `DraggedItem` tuples, each with the item
+  /// that is being dragged, and the `NSPasteboard.PasteboardType` that
+  /// generated the item from the dragging pasteboard.
+  public var items: [DraggedItem<D>]
+
+  /// The `OutlineView` data element into which the target is dropping
+  /// items.
+  ///
+  /// If `nil`, the items are intended to be dropped into the root of
+  /// the data hierarchy. Otherwise, they are to be dropped into the given
+  /// item's children array.
+  public var intoElement: D?
+
+  /// The index of the children array that the dragged items are to be
+  /// dropped.
+  ///
+  /// If `nil`, assume that the items will be dropped at the default
+  /// location for the children of `intoElement` (i.e. at the end,
+  /// or into a default sorting order). Otherwise, the items should be
+  /// inserted at the given index within the children.
+  public var childIndex: Int?
+
+  /// A closure that can be called to determine if the `OutlineView`'s
+  /// representation of a given item is expanded. This may be used in
+  /// `DropReceiver` functions that take a `DropTarget` as a parameter,
+  /// in case the expanded state of the item affects the outcome of the
+  /// function.
+  public var isItemExpanded: ((D) -> Bool)
+}
+
+/// An enum describing the behavior of a dragged item as it moves over
+/// the `OutlineView`.
+public enum ValidationResult<D> {
+  /// Indicates that the dragged item will be copied to the indicated
+  /// location. The given location will be highlighted, and the cursor
+  /// will show a "+" icon.
+  case copy
+
+  /// Indicates that the dragged item will be moved to the indicated
+  /// location. The given location will be highlighted.
+  case move
+
+  /// Indicates that the dragged item will not be moved. No location
+  /// will be highlighted.
+  case deny
+
+  /// Indicates that the dragged item will be copied to a different
+  /// location than it is currently hovering over. The cursor will
+  /// show a "+" icon, and the highlighted location will be determined
+  /// by `item` and `childIndex`.
+  ///
+  /// - Parameters:
+  ///   - item: The item that the dragged item will be added into as a child.
+  ///     If no item is given, the dragged item will be added to the root of
+  ///     the data structure.
+  ///   - childIndex: The index of the child array of `item` where the dragged
+  ///     item will be dropped. A nil value will cause `item` to be highlighted,
+  ///     while a non-nil value will cause a space between rows to be highlighted.
+  case copyRedirect(item: D?, childIndex: Int?)
+
+  /// Indicates that the dragged item will be moved to a different
+  /// location than it is currently hovering over. The highlighted location
+  /// will be determined by the bound values in this enum.
+  ///
+  /// - Parameters:
+  ///   - item: The item that the dragged item will be added into as a child.
+  ///     If no item is given, the dragged item will be added to the root of
+  ///     the data structure.
+  ///   - childIndex: The index of the child array of `item` where the dragged
+  ///     item will be dropped. A nil value will cause `item` to be highlighted,
+  ///     while a non-nil value will cause a space between rows to be highlighted.
+  case moveRedirect(item: D?, childIndex: Int?)
+}

--- a/Vendored/OutlineView/OutlineViewItem.swift
+++ b/Vendored/OutlineView/OutlineViewItem.swift
@@ -1,0 +1,46 @@
+/// A wrapper for holding the outline view data items. This wrapper exposes the `id` of the
+/// wrapped value for its conformance to `Equatable` and `Hashable`. `NSOutlineView`
+/// requires that Swift value types be "equal" to correctly find the stored item internally.
+/// `OutlineView` chooses to use the `Identifiable` protocol for identifying items,
+/// necessitating the use of a wrapper.
+///
+/// Reference: AppKit Release Notes for macOS 10.14 - API Changes - `NSOutlineView`
+/// https://developer.apple.com/documentation/macos-release-notes/appkit-release-notes-for-macos-10_14
+@available(macOS 10.15, *)
+struct OutlineViewItem<Data: Sequence>: Equatable, Hashable, Identifiable
+where Data.Element: Identifiable {
+  var childSource: ChildSource<Data>
+  var value: Data.Element
+
+  var children: [OutlineViewItem]? {
+    childSource.children(for: value)?.map { OutlineViewItem(value: $0, children: childSource) }
+  }
+
+  init(value: Data.Element, children: KeyPath<Data.Element, Data?>) {
+    self.init(value: value, children: .keyPath(children))
+  }
+
+  init(value: Data.Element, children: @escaping (Data.Element) -> Data?) {
+    self.init(value: value, children: .provider(children))
+  }
+
+  init(value: Data.Element, children: ChildSource<Data>) {
+    self.value = value
+    self.childSource = children
+  }
+
+  var id: Data.Element.ID {
+    value.id
+  }
+
+  static func == (
+    lhs: OutlineViewItem<Data>,
+    rhs: OutlineViewItem<Data>
+  ) -> Bool {
+    lhs.value.id == rhs.value.id
+  }
+
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(value.id)
+  }
+}

--- a/Vendored/OutlineView/OutlineViewUpdater.swift
+++ b/Vendored/OutlineView/OutlineViewUpdater.swift
@@ -1,0 +1,96 @@
+import Cocoa
+
+@available(macOS 10.15, *)
+struct OutlineViewUpdater<Data: Sequence>
+where Data.Element: Identifiable {
+  /// variable for testing purposes. When set to false (the default),
+  /// `performUpdates` will escape its recursion for objects that are not
+  /// expanded in the outlineView.
+  var assumeOutlineIsExpanded = false
+
+  /// Perform updates on the outline view based on the change in state.
+  /// - NOTE: Calls to this method must be surrounded by
+  ///  `NSOutlineView.beginUpdates` and `NSOutlineView.endUpdates`.
+  ///  `OutlineViewDataSource.items` should be updated to the new state before calling this method.
+  // moolah: pinned to the main actor — NSOutlineView mutating APIs
+  // are `@MainActor` under Swift 6 / macOS 26.
+  @MainActor
+  func performUpdates(
+    outlineView: NSOutlineView,
+    oldStateTree: TreeMap<Data.Element.ID>?,
+    newState: [OutlineViewItem<Data>]?,
+    parent: OutlineViewItem<Data>?
+  ) {
+    // Get states to compare: oldIDs and newIDs, as related to the given parent object
+    let oldIDs: [Data.Element.ID]?
+    if let oldStateTree {
+      if let parent {
+        oldIDs = oldStateTree.currentChildrenOfItem(parent.id)
+      } else {
+        oldIDs = oldStateTree.rootData
+      }
+    } else {
+      oldIDs = nil
+    }
+
+    let newNonOptionalState = newState ?? []
+
+    guard oldIDs != nil || newState != nil else {
+      // Early exit. No state to compare.
+      return
+    }
+
+    let oldNonOptionalIDs = oldIDs ?? []
+    let newIDs = newNonOptionalState.map { $0.id }
+    let diff = newIDs.difference(from: oldNonOptionalIDs)
+
+    if !diff.isEmpty || oldIDs != newIDs {
+      // Parent needs to be updated as the children have changed.
+      // Children are not reloaded to allow animation.
+      outlineView.reloadItem(parent, reloadChildren: false)
+    }
+
+    guard assumeOutlineIsExpanded || outlineView.isItemExpanded(parent) else {
+      // Another early exit. If item isn't expanded, no need to compare its children.
+      // They'll be updated when the item is later expanded.
+      return
+    }
+
+    var oldUnchangedElements =
+      newNonOptionalState
+      .filter { oldNonOptionalIDs.contains($0.id) }
+      .reduce(into: [:], { $0[$1.id] = $1 })
+
+    for change in diff {
+      switch change {
+      case .insert(let offset, _, _):
+        outlineView.insertItems(
+          at: IndexSet([offset]),
+          inParent: parent,
+          withAnimation: .effectFade)
+
+      case .remove(let offset, let element, _):
+        oldUnchangedElements[element] = nil
+        outlineView.removeItems(
+          at: IndexSet([offset]),
+          inParent: parent,
+          withAnimation: .effectFade)
+      }
+    }
+
+    let newStateDict = newNonOptionalState.dictionaryFromIdentity()
+
+    oldUnchangedElements
+      .keys
+      .map { newStateDict[$0].unsafelyUnwrapped }
+      .map { (outlineView, oldStateTree, $0.children, $0) }
+      .forEach(performUpdates)
+  }
+}
+
+@available(macOS 10.15, *)
+extension Sequence where Element: Identifiable {
+  fileprivate func dictionaryFromIdentity() -> [Element.ID: Element] {
+    Dictionary(map { ($0.id, $0) }, uniquingKeysWith: { _, latest in latest })
+  }
+}

--- a/Vendored/OutlineView/StringMangling.swift
+++ b/Vendored/OutlineView/StringMangling.swift
@@ -1,0 +1,11 @@
+/// Mangle a string by offsetting the numeric value of each character by `-1`.
+/// Useful for computing a mangled version of the objc private API strings to evade static detection of private API use.
+func mangle(_ string: String) -> String {
+  String(string.utf16.map { $0 - 1 }.compactMap(UnicodeScalar.init).map(Character.init))
+}
+
+/// Unmangle a string by offsetting the numeric value of each character by `+1`.
+/// Useful for unmangling a mangled version of the objc private API strings to evade static detection of private API use.
+func unmangle(_ string: String) -> String {
+  String(string.utf16.map { $0 + 1 }.compactMap(UnicodeScalar.init).map(Character.init))
+}

--- a/Vendored/OutlineView/TreeMap.swift
+++ b/Vendored/OutlineView/TreeMap.swift
@@ -1,0 +1,255 @@
+/// An object representing the state of an OutlineView in which the content
+/// of the OutlineView is Identifiable. The TreeMap should be able to stay
+/// in sync with the OutlineView by reacting to data updates in the OutlineView.
+@available(macOS 10.15, *)
+class TreeMap<D: Hashable> {
+  struct Node: Equatable {
+    enum State: Equatable {
+      case leaf
+      case collapsed
+      case expanded(children: [D])
+    }
+
+    var parentID: D?
+    var state: State
+
+    init(parentID: D?, isLeaf: Bool) {
+      self.parentID = parentID
+      self.state = isLeaf ? .leaf : .collapsed
+    }
+  }
+
+  // moolah: removed space between `private` and `(set)` —
+  // Swift 6.x rejects `private (set)` with a space as
+  // "extraneous whitespace between attribute name and '('".
+  private(set) var rootData: [D] = []
+  private var directory: [D: Node] = [:]
+
+  var allItemIds: Set<D> {
+    Set(directory.keys)
+  }
+
+  init() {}
+
+  init<Data: Sequence>(
+    rootItems: [OutlineViewItem<Data>],
+    itemIsExpanded: ((OutlineViewItem<Data>) -> Bool)
+  ) where Data.Element: Identifiable, Data.Element.ID == D {
+    // Add root items first
+    for item in rootItems {
+      addItem(item.value.id, isLeaf: item.children == nil, intoItem: nil, atIndex: nil)
+    }
+
+    // Loop through all items, adding their children if they're expanded
+    var checkingItems: [(parentID: D?, item: OutlineViewItem<Data>)] = rootItems.map { (nil, $0) }
+    while let nextItem = checkingItems.popLast()?.item {
+      if itemIsExpanded(nextItem),
+        let children = nextItem.children
+      {
+        let expandingChildren = children.map { ($0.id, $0.children == nil) }
+        expandItem(nextItem.id, children: expandingChildren)
+        checkingItems.append(contentsOf: children.map({ (nextItem.id, $0) }))
+      }
+    }
+  }
+
+  /// Adds an item to the TreeMap
+  ///
+  /// - Parameters:
+  ///   - item: The ID of the item to add.
+  ///   - isLeaf: True if this item can have no children.
+  ///   - intoItem: The parent ID to insert this item into. If
+  ///   intoItem is nil, the new item is inserted at the root level.
+  ///   - atIndex: The index among other parent's children at which to
+  ///   insert this item. If no index is given, the item is added to the
+  ///   end of the array of children for the parent (or root if no
+  ///   parent is given).
+  func addItem(_ item: D, isLeaf: Bool, intoItem: D?, atIndex: Int?) {
+    // Add to parent or root
+    if let intoItem,
+      var fullIntoItem = directory[intoItem],
+      case var .expanded(intoChildren) = fullIntoItem.state
+    {
+      // Add to children of selected item
+      if let atIndex {
+        // insert at index
+        intoChildren.insert(item, at: atIndex)
+      } else if atIndex == nil {
+        // append to end
+        intoChildren.append(item)
+      }
+
+      fullIntoItem.state = .expanded(children: intoChildren)
+      directory[intoItem] = fullIntoItem
+    } else {
+      // Add to root data
+      if let atIndex {
+        // insert at index
+        rootData.insert(item, at: atIndex)
+      } else {
+        // append to end
+        rootData.append(item)
+      }
+    }
+
+    // create new node
+    let newNode = Node(parentID: intoItem, isLeaf: isLeaf)
+    directory[item] = newNode
+  }
+
+  /// Marks the item with the given ID as expanded by adding its
+  /// children to the TreeMap
+  ///
+  /// - Parameters:
+  ///   - item: the ID of the item to mark as expanded.
+  ///   - children: An array of objects representing the expanded
+  ///   item's children. Each child must have an ID and a boolean
+  ///   indicating whether it is a leaf or internal node of the tree.
+  func expandItem(_ item: D, children: [(id: D, isLeaf: Bool)]) {
+    guard case .collapsed = directory[item]?.state
+    else { return }
+
+    directory[item]?.state = .expanded(children: children.map(\.id))
+    for child in children {
+      directory[child.id] = Node(parentID: item, isLeaf: child.isLeaf)
+    }
+  }
+
+  /// Marks the item with the given ID as collapsed/unexpanded by
+  /// removing its children from the TreeMap
+  ///
+  /// - Parameters:
+  ///   - item: The ID of the item to mark as collapsed.
+  func collapseItem(_ item: D) {
+    guard case let .expanded(existingChildIDs) = directory[item]?.state
+    else { return }
+    directory[item]?.state = .collapsed
+    for childID in existingChildIDs {
+      directory[childID] = nil
+    }
+  }
+
+  /// Deletes an item from the TreeMap, along with all its children.
+  ///
+  /// - Parameter item: The ID of the item to remove.
+  func removeItem(_ item: D) {
+    // Remove all children from tree
+    if case let .expanded(childIDs) = directory[item]?.state {
+      childIDs.forEach { removeItem($0) }
+    }
+
+    // remove from parent
+    if let parentID = directory[item]?.parentID,
+      case var .expanded(siblingIDs) = directory[parentID]?.state,
+      let childIdx = siblingIDs.firstIndex(of: item)
+    {
+      siblingIDs.remove(at: childIdx)
+      directory[parentID]?.state = .expanded(children: siblingIDs)
+    }
+
+    // remove from root
+    if let rootIdx = rootData.firstIndex(of: item) {
+      rootData.remove(at: rootIdx)
+    }
+
+    // remove from directory
+    directory[item] = nil
+  }
+
+  /// Gets the IDs of the children of the selected item if it is expanded.
+  ///
+  /// - Parameter item: the item to check for children.
+  /// - Returns: An array of IDs of children if the item if it happens to
+  /// be an internal node and is currently expanded.
+  func currentChildrenOfItem(_ item: D) -> [D]? {
+    switch directory[item]?.state {
+    case let .expanded(children):
+      return children
+    default:
+      return nil
+    }
+  }
+
+  /// Tests whether the selected item is a leaf or an internal node that can expand.
+  ///
+  /// - Parameter item: the ID of the item to test
+  /// - Returns: A boolean indicating whether the item can be expanded.
+  func isItemExpandable(_ item: D) -> Bool {
+    switch directory[item]?.state {
+    case .none, .leaf:
+      return false
+    default:
+      return true
+    }
+  }
+
+  /// Tests whether the selected item is an expanded internal node.
+  ///
+  /// - Parameter item: The ID of the item to test.
+  /// - Returns: A boolean indicating whether the item is currently expanded.
+  func isItemExpanded(_ item: D) -> Bool {
+    switch directory[item]?.state {
+    case .expanded(_):
+      return true
+    default:
+      return false
+    }
+  }
+
+  /// Finds the full parentage of the selected item all the way from the root
+  /// of the TreeMap
+  ///
+  /// - Parameter item: the ID of the item to search.
+  /// - Returns: nil if the item doesn't exist in the TreeMap, otherwise an array
+  /// of IDs to follow from the root of the TreeMap to get to the selected item,
+  /// ending with the ID of the selected item.
+  func lineageOfItem(_ item: D) -> [D]? {
+    guard let node = directory[item] else { return nil }
+
+    var result = [item]
+    var parent = node.parentID
+    while let nonNilParent = parent {
+      result.insert(nonNilParent, at: 0)
+      parent = directory[nonNilParent]?.parentID
+    }
+    return result
+  }
+}
+
+@available(macOS 10.15, *)
+extension TreeMap: CustomStringConvertible {
+  var description: String {
+    var strings: [String] = []
+
+    for rootItem in rootData {
+      strings.append(contentsOf: descriptionStrings(for: rootItem))
+    }
+
+    return strings.joined(separator: "\n")
+  }
+
+  private func descriptionStrings(for item: D) -> [String] {
+    guard let depth = lineageOfItem(item)?.count
+    else {
+      assertionFailure("Cannot call `descriptionStrings(for:)` on item not in the TreeMap")
+      return []
+    }
+    let selfDescription = "\(String(repeating: "- ", count: depth))\(item)"
+    var res: [String] = [selfDescription]
+    if case let .expanded(childIDs) = directory[item]?.state {
+      childIDs.forEach { res.append(contentsOf: descriptionStrings(for: $0)) }
+    }
+    return res
+  }
+}
+
+// moolah: removed redundant `extension TreeMap.Node: Equatable {}` —
+// Swift 6.x synthesises Equatable from the `struct Node: Equatable`
+// declaration above and rejects the duplicate conformance.
+
+@available(macOS 10.15, *)
+extension TreeMap: Equatable {
+  static func == (lhs: TreeMap<D>, rhs: TreeMap<D>) -> Bool {
+    lhs.directory == rhs.directory && lhs.rootData == rhs.rootData
+  }
+}

--- a/Vendored/OutlineView/Visibility.swift
+++ b/Vendored/OutlineView/Visibility.swift
@@ -1,0 +1,7 @@
+/// The visibility of a row separator.
+public enum SeparatorVisibility: CaseIterable, Equatable, Hashable {
+  /// The separator may be hidden.
+  case hidden
+  /// The separator may be visible.
+  case visible
+}

--- a/justfile
+++ b/justfile
@@ -11,13 +11,24 @@ default:
 # Run swift-format style lint (prints warnings; does not exit non-zero for
 # pre-existing advisory violations). Use `format-check` in CI and pre-commit
 # to enforce actual formatting.
+#
+# `Vendored/` is excluded — third-party MIT source we copied verbatim
+# (with marked local extensions). See Vendored/OutlineView/NOTICE.md.
 lint:
-    swift-format lint -r . --configuration .swift-format
+    #!/usr/bin/env bash
+    set -euo pipefail
+    git ls-files '*.swift' ':!:Vendored/**' \
+        | xargs swift-format lint --configuration .swift-format
 
 # Apply swift-format formatting in place, then run SwiftLint autocorrect.
 # Run this before committing; CI rejects unformatted files or new lint warnings.
+#
+# `Vendored/` is excluded — see the comment on `lint`.
 format:
-    swift-format format -i -r . --configuration .swift-format
+    #!/usr/bin/env bash
+    set -euo pipefail
+    git ls-files '*.swift' ':!:Vendored/**' \
+        | xargs swift-format format -i --configuration .swift-format
     swiftlint lint --fix --quiet
 
 # Back-compat alias for `format`.
@@ -27,6 +38,8 @@ lint-fix: format
 # Non-destructive: does not modify any files. Exits non-zero on any diff.
 # Used by CI; run locally before committing if you want to preview failures
 # without applying changes.
+#
+# `Vendored/` is excluded — see the comment on `lint`.
 format-check:
     #!/usr/bin/env bash
     set -euo pipefail
@@ -38,7 +51,7 @@ format-check:
                 "$file" <(swift-format format --configuration .swift-format "$file") || true
             fail=1
         fi
-    done < <(git ls-files '*.swift')
+    done < <(git ls-files '*.swift' ':!:Vendored/**')
     if [ "$fail" -ne 0 ]; then
         echo
         echo "One or more files are not formatted correctly."

--- a/plans/2026-05-27-sidebar-nsoutlineview-phase-1-plan.md
+++ b/plans/2026-05-27-sidebar-nsoutlineview-phase-1-plan.md
@@ -1,0 +1,875 @@
+# Sidebar `NSOutlineView` Phase 1 — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. Per project memory (`feedback_subagent_driven.md`), do not ask whether to use it — that is the default.
+
+**Final plan file:** This document will be copied verbatim to `plans/2026-05-27-sidebar-nsoutlineview-phase-1-plan.md` (a project plan, checked in) once approved. The harness-allocated path is the plan-mode draft.
+
+**Closes:** GitHub issue [#991](https://github.com/moolah-rocks/moolah-native/issues/991) — sidebar drag-and-drop broken. Phase 1 does not yet ship the drag-fix; Phase 2 does. We close #991 from Phase 2's PR.
+
+---
+
+## Context
+
+`SidebarView` is a SwiftUI `List(selection:)` with `.listStyle(.sidebar)`. On macOS 26 / Tahoe, SwiftUI `List` cannot deliver the Mail.app sidebar UX we want: `.onMove` and per-row `.dropDestination(for:)` are mutually exclusive, and without `.onMove`, `.draggable` is inert in a sidebar-style list. This is a public SwiftUI limitation confirmed by Apple DTS ([forums thread 763013](https://developer.apple.com/forums/thread/763013)) and reproduced empirically across three implementation attempts (2026-05-27 session). Mail and Finder both achieve the UX by wrapping `NSOutlineView`, whose `validateDrop(proposedChildIndex:)` API natively distinguishes drop-between (insertion line) from drop-onto (full-row highlight).
+
+The full architecture and rationale live in `plans/2026-05-27-sidebar-nsoutlineview-rewrite-design.md`. That design phases the rewrite into 5 steps preceded by a spike. **This plan covers the spike + Phase 1 only:** wrap `NSOutlineView` via the [Sameesunkaria/OutlineView](https://github.com/Sameesunkaria/OutlineView) MIT package, render the Current Accounts + Investments sections through it on macOS, and wire selection back to `SidebarSelection`. No drag-and-drop yet (Phase 2). No inline rename yet (Phase 3). iOS sidebar is untouched.
+
+After Phase 1, the macOS sidebar is functionally regressed: drag-and-drop is still broken (same as today's bug), inline rename is unavailable on the new outline rows, and the context-menu "Rename" item is hidden on macOS until Phase 3 ships. **All other functionality — selection, group expand/collapse via chevron, balance display, "Not set" indicator, navigation to detail surfaces, accessibility identifiers, VoiceOver labels — must work end-to-end at the close of Phase 1.** Users on macOS will continue to use the right-click "Edit Account…" sheet for renames and the "Group ▸" submenu for group membership in the Phase 1 window.
+
+---
+
+## Architecture
+
+Add `Sameesunkaria/OutlineView` (~1500 LOC, MIT) as a Swift Package dependency. Introduce a macOS-only `SidebarOutlineView` SwiftUI view that wraps the package's `OutlineView<Item>`. The `SidebarView` body splits on `#if os(macOS)` — macOS gets `VStack { SidebarOutlineView + List(earmarks/totals/nav) }`, iOS keeps the existing `List` with all sections inline. Cells use `NSHostingView` to wrap the existing SwiftUI `SidebarRowView` / `AccountGroupSidebarRow` — preserves all rich content (icon, balance, "Not set", spinner) without a parallel AppKit reimplementation. Expansion state is bound to the existing `GroupUIStateStore`. The existing `Accounts.groupAwareSidebar(...)` helper continues to produce the `[SidebarBucketEntry]` array; a thin `SidebarOutlineItem` adapter wraps it for the package's `Identifiable` requirement.
+
+The spike validates three package-API unknowns before the rest of the plan commits to code: (a) does the package's `Package.swift` declare macOS 14+ in a way that compiles cleanly against our macOS 26 deployment target; (b) does `NSHostingView`-wrapped SwiftUI cells receive the correct `backgroundProminence` for the selection-colour override in `SidebarRowView`; (c) what is the package's exact mechanism for binding expansion state and marking source-list section headers.
+
+---
+
+## Tech stack
+
+- Swift 6, SwiftUI on macOS 26 (deployment target).
+- `Sameesunkaria/OutlineView` Swift package (latest tagged release; pinned via `exactVersion` like `GRDB`).
+- AppKit `NSOutlineView` (indirectly, via the package).
+- Existing `AccountStore`, `AccountGroupStore`, `GroupUIStateStore` — no new mutations introduced.
+- Tests: Swift Testing for unit / store tests; XCUITest for the macOS UI smoke.
+
+---
+
+## File structure
+
+**Create:**
+
+- `Features/Navigation/SidebarOutlineItem.swift` — `Sendable, Hashable, Identifiable` adapter that wraps a `SidebarBucketEntry` (`.account` / `.group`) plus the two section headers. Exposes `children: [SidebarOutlineItem]?` for the package; section headers carry their bucket label, group items carry their members.
+- `Features/Navigation/SidebarOutlineView.swift` — macOS-only `View` that owns the `OutlineView<SidebarOutlineItem>` construction, binds selection to `SidebarSelection?`, binds expansion state to `GroupUIStateStore`, and produces `NSHostingView`-wrapped cells. Lives in its own file so the macOS-only `#if` blocks don't bloat `SidebarView.swift`.
+- `MoolahTests/Navigation/SidebarOutlineItemTests.swift` — Swift Testing suite for the `SidebarOutlineItem` derivation (bucket → header → entries → group members), including the dangling-groupId case (member of an unknown group renders as standalone), preserved from `Accounts+SidebarOrdering.swift`.
+
+**Modify:**
+
+- `project.yml` — add the `OutlineView` package under `packages:` (next to `GRDB`), and list it under each target's `dependencies` (`Moolah_iOS` excluded — the iOS target does not link the package; macOS app + macOS UI tests link it). Run `just generate` after editing.
+- `Features/Navigation/SidebarView.swift` — split `body` on `#if os(macOS)` / `#if os(iOS)`. macOS body is `VStack(spacing: 0) { SidebarOutlineView(...); List { earmarksSection; totalsSection; navigationSection } }`. iOS body is the existing single `List`. Move the `currentAccountsSection` / `investmentsSection` reference out of the iOS-shared section list. The Return-key handler (`.onKeyPress(.return)`) loses its account/group case on macOS (no inline rename yet) — guard it `#if os(iOS)` so iOS rename still works. The context-menu `accountContextMenu` "Rename" item is gated `#if os(iOS)` for the same reason.
+- `Features/Navigation/SidebarView+Sections.swift` — `currentAccountsSection` and `investmentsSection` stay (they're still referenced from the iOS body), but each is wrapped `#if os(iOS)`. `earmarksSection`, `totalsSection`, `navigationSection`, the row builders, `bucketEntryView` stay cross-platform — earmarks/totals/nav are shared. `bucketEntryView` becomes iOS-only since it's only called from the iOS sections; mark it `#if os(iOS)`.
+- `Features/Navigation/SidebarView+Groups.swift` — drop / drag modifiers on `groupRowLink` / `memberRowLink` / `standaloneAccountRowLink` stay (iOS-only consumers) — wrap the file content (excluding the `DraggableSidebarItem` struct and the `UTType.moolahSidebarItem` extension, which remain shared for Phase 2 use) in `#if os(iOS)`. `expandBinding(for:)` is shared; lift it to the parent file or leave it shared with no `#if`.
+- `Features/Navigation/SidebarView+Previews.swift` — add a third `#Preview` titled `"macOS outline (Phase 1)"` that exercises `SidebarOutlineView` directly with the existing seeded `PreviewBackend`. Existing two previews remain — they validate the iOS body via SwiftUI `List`.
+- `MoolahUITests_macOS/Helpers/Screens/SidebarScreen.swift` — `switchToAccount(_:)` and the named-row helpers still use `app.element(for: UITestIdentifiers.Sidebar.account(id))` — accessibility identifiers ride along on the `NSHostingView`-wrapped SwiftUI cells, so no driver change should be needed for selection. Verify in Phase 1 acceptance and update only if the resolver returns a different element type.
+
+**Untouched (no edits, only referenced):**
+
+- `Domain/Models/Accounts+SidebarOrdering.swift` — `groupAwareSidebar(...)` is the source of truth for entry ordering. `SidebarOutlineItem` consumes its output; no new ordering logic.
+- `Features/Accounts/AccountStore.swift`, `AccountGroupStore.swift`, `GroupUIStateStore.swift` — no API surface changes. Phase 2 will add a `move`/`reorder` API; Phase 1 doesn't need it.
+- `Features/Accounts/Views/AccountSidebarRow.swift`, `AccountGroupSidebarRow.swift` — embedded via `NSHostingView` unchanged. The existing `#Preview` blocks continue to drive design iteration on the cells.
+- `UITestSupport/UITestIdentifiers+Sidebar.swift` — identifier strings unchanged.
+
+---
+
+## Spike (~2 hours, validates the rest of the plan)
+
+The spike is a single throw-away commit at the head of the branch. If any of its three checkpoints fail, **stop and surface to the user** before continuing — the rest of the plan may need redesign.
+
+### Task 0: Spike — validate package, cells, expansion
+
+**Files:**
+- Modify: `project.yml`
+- Modify (temporary, reverted at end of spike): `Features/Navigation/SidebarView+Previews.swift`
+
+- [ ] **Step 1: Add the package**
+
+  Edit `project.yml` under `packages:`:
+
+  ```yaml
+  OutlineView:
+    url: https://github.com/Sameesunkaria/OutlineView
+    # Pinned exactly — same convention as GRDB above.
+    exactVersion: 2.0.0
+  ```
+
+  Add `- package: OutlineView` to the `dependencies:` list under `Moolah_macOS` and `MoolahUITests_macOS`. Do **not** add it to `Moolah_iOS`, `MoolahTests_iOS`, or any benchmark target.
+
+  Then regenerate:
+
+  ```bash
+  just generate
+  ```
+
+  Expected: `xcodegen` produces `Moolah.xcodeproj` without error; `Package.resolved` (gitignored — not tracked) records `OutlineView 2.0.0`.
+
+- [ ] **Step 2: Build macOS to confirm the package compiles**
+
+  ```bash
+  just build-mac 2>&1 | tee .agent-tmp/spike-build.txt
+  ```
+
+  Expected: clean build. If the package's `Package.swift` rejects macOS 26 (e.g. lists only `.macOS(.v10_15)`), record the actual error in `.agent-tmp/spike-build.txt`, surface it to the user, and stop. Mitigations the user may approve: vendor the package, fork it, or drop to a lower SDK floor by adjusting the wrapper.
+
+- [ ] **Step 3: Add a hello-world preview**
+
+  Append a `#Preview("Spike — OutlineView hello world")` block in `SidebarView+Previews.swift` that constructs the package's `OutlineView` against two hardcoded `SpikeItem` instances (one parent, one child). Use `NSHostingView` to wrap a `Text("…")` cell — the goal is to prove `NSHostingView`-cell rendering plus expansion works. Sketch (signatures to be confirmed against the package README):
+
+  ```swift
+  private struct SpikeItem: Identifiable, Hashable {
+    let id: UUID = UUID()
+    let title: String
+    let children: [SpikeItem]?
+  }
+
+  #Preview("Spike — OutlineView hello world") {
+    @Previewable @State var selection: SpikeItem? = nil
+    return OutlineView(
+      [
+        SpikeItem(title: "Parent", children: [
+          SpikeItem(title: "Child A", children: nil),
+          SpikeItem(title: "Child B", children: nil),
+        ])
+      ],
+      selection: $selection,
+      children: \.children
+    ) { item in
+      NSHostingView(rootView: Text(item.title))
+    }
+    .outlineViewStyle(.sourceList)
+    .frame(width: 260, height: 300)
+  }
+  ```
+
+- [ ] **Step 4: Render and inspect via `RenderPreview`**
+
+  Open `Moolah.xcodeproj` in the worktree (per CLAUDE.md's preview note), then render the spike preview via `mcp__xcode__RenderPreview`. Confirm three things, recording each in `.agent-tmp/spike-checks.md`:
+
+  1. The two children are visible under "Parent" after clicking the disclosure chevron. Expansion via the package works.
+  2. Clicking a row updates the bound `selection` (the row highlights blue). Selection-via-`@Binding` works.
+  3. The cells render the text with the system selected-row foreground colour when selected (no manual override). If the text colour stays black on the blue highlight, `NSHostingView`-wrapped SwiftUI cells lose the system foreground treatment — record this finding, and bring it to the user as a fork in the road (option A: hand-build an `NSTableCellView` subclass with `NSTextField`/`NSImageView`; option B: detect selection in the SwiftUI cell via the bound `selection` and recolor manually, which `SidebarRowView` partially does already).
+
+- [ ] **Step 5: Decide on group / section header mechanism**
+
+  Search the package source (`.build/checkouts/OutlineView/Sources/`) for `isGroupItem` or any modifier that marks a row as a source-list group header. Record in `.agent-tmp/spike-checks.md` whether it is exposed (option A: a `.markRowGroup` modifier or analogous; option B: the package treats root-level items as group headers when they have children; option C: not exposed — we'd need a small fork to plumb `outlineView(_:isGroupItem:)` through). Surface option C to the user if that's the answer.
+
+- [ ] **Step 6: Revert the spike**
+
+  Remove the `SpikeItem` struct and the spike `#Preview`. Keep the `project.yml` package addition. Commit:
+
+  ```bash
+  git -C . add project.yml Moolah.xcodeproj
+  git -C . commit -m "deps: add Sameesunkaria/OutlineView (spike-verified, macOS-only)"
+  ```
+
+  > **Note:** `Moolah.xcodeproj` is gitignored — do not stage it. The package addition is captured by `project.yml` alone. If `Package.resolved` lives anywhere tracked, stage that instead.
+
+- [ ] **Step 7: format-check, then push the spike commit**
+
+  ```bash
+  just format-check 2>&1 | tee .agent-tmp/spike-format.txt
+  ```
+
+  Expected: zero violations. If anything is reported, follow `feedback_swiftlint_fix_not_baseline.md` — fix the violation in code, never bump a baseline.
+
+  Don't push yet — the spike is a single commit at the head of the branch; the PR opens at the end of Phase 1.
+
+---
+
+## Phase 1 — `SidebarOutlineView` skeleton + selection
+
+### Task 1: `SidebarOutlineItem` model
+
+**Files:**
+- Create: `Features/Navigation/SidebarOutlineItem.swift`
+- Create: `MoolahTests/Navigation/SidebarOutlineItemTests.swift`
+
+- [ ] **Step 1: Write the failing tests**
+
+  Create `MoolahTests/Navigation/SidebarOutlineItemTests.swift`. Use Swift Testing per project convention. Cover:
+
+  ```swift
+  import Foundation
+  import Testing
+
+  @testable import Moolah
+
+  @Suite struct SidebarOutlineItemTests {
+    @Test func currentBucketHeaderEnumerationContainsStandaloneThenGroups() {
+      let bankA = Account(name: "A", type: .bank, instrument: .defaultTestCurrency, position: 0)
+      let bankB = Account(name: "B", type: .bank, instrument: .defaultTestCurrency, position: 2)
+      let group = AccountGroup(
+        name: "G", bucket: .current,
+        instrument: .defaultTestCurrency, position: 1)
+      let member = Account(
+        name: "M", type: .bank, instrument: .defaultTestCurrency,
+        position: 0, groupId: group.id)
+
+      let items = SidebarOutlineItem.tree(
+        accounts: Accounts(from: [bankA, bankB, member]),
+        groups: [group]
+      )
+
+      // Two section headers at root: Current Accounts, Investments.
+      #expect(items.count == 2)
+      let currentHeader = try #require(items.first)
+      #expect(currentHeader.kind == .currentAccountsHeader)
+      // Children: bankA (pos 0), group G (pos 1), bankB (pos 2).
+      let children = try #require(currentHeader.children)
+      #expect(children.count == 3)
+      #expect(children[0].kind == .account(bankA.id))
+      #expect(children[1].kind == .group(group.id))
+      #expect(children[2].kind == .account(bankB.id))
+      // Group members appear under the group node.
+      let groupChildren = try #require(children[1].children)
+      #expect(groupChildren.count == 1)
+      #expect(groupChildren[0].kind == .account(member.id))
+    }
+
+    @Test func investmentsHeaderRendersEvenWhenEmpty() {
+      // Empty investments section still produces the section header
+      // so the user sees "Investments" with a zero-member section.
+      let bank = Account(name: "A", type: .bank, instrument: .defaultTestCurrency)
+      let items = SidebarOutlineItem.tree(
+        accounts: Accounts(from: [bank]), groups: []
+      )
+      #expect(items.count == 2)
+      #expect(items[1].kind == .investmentsHeader)
+      #expect(items[1].children?.isEmpty == true)
+    }
+
+    @Test func danglingGroupIdRendersMemberAsStandalone() {
+      // Sync can deliver an Account ahead of its AccountGroup. The
+      // ordering helper folds those into the standalone list — this
+      // test asserts SidebarOutlineItem inherits that contract.
+      let ghostGroupId = UUID()
+      let stranded = Account(
+        name: "S", type: .bank, instrument: .defaultTestCurrency,
+        groupId: ghostGroupId)
+      let items = SidebarOutlineItem.tree(
+        accounts: Accounts(from: [stranded]), groups: []
+      )
+      let current = try #require(items.first?.children)
+      #expect(current.count == 1)
+      #expect(current[0].kind == .account(stranded.id))
+    }
+  }
+  ```
+
+- [ ] **Step 2: Run the tests to confirm they fail**
+
+  ```bash
+  just test SidebarOutlineItemTests 2>&1 | tee .agent-tmp/test-outline-item.txt
+  ```
+
+  Expected: compile error (`Cannot find 'SidebarOutlineItem' in scope`).
+
+- [ ] **Step 3: Implement `SidebarOutlineItem`**
+
+  Create `Features/Navigation/SidebarOutlineItem.swift`:
+
+  ```swift
+  import Foundation
+
+  /// One node in the macOS sidebar outline. The two top-level entries are
+  /// the bucket section headers ("Current Accounts", "Investments"); their
+  /// children are bucket entries (standalone accounts + groups intermixed
+  /// by `position`, exactly as produced by
+  /// `Accounts.groupAwareSidebar(...)`). A group's `children` are its
+  /// member accounts (sorted by member `position`); an account's
+  /// `children` is always `nil`.
+  ///
+  /// `Identifiable` is required by the `OutlineView` package; `Hashable`
+  /// is required so SwiftUI's `Binding<SidebarOutlineItem?>` selection
+  /// can deduplicate. Equality is by `id` (the kind's stable identifier).
+  struct SidebarOutlineItem: Identifiable, Hashable, Sendable {
+    enum Kind: Hashable, Sendable {
+      case currentAccountsHeader
+      case investmentsHeader
+      case account(UUID)
+      case group(UUID)
+    }
+
+    let kind: Kind
+    let children: [SidebarOutlineItem]?
+
+    var id: Kind { kind }
+
+    static func == (lhs: SidebarOutlineItem, rhs: SidebarOutlineItem) -> Bool {
+      lhs.kind == rhs.kind
+    }
+
+    func hash(into hasher: inout Hasher) { hasher.combine(kind) }
+
+    /// Derives the outline tree from the same source-of-truth helper the
+    /// SwiftUI sidebar uses (`Accounts.groupAwareSidebar`). Hidden /
+    /// excluded handling rides along — callers don't pass `excluding`
+    /// / `alwaysInclude` here; the helper is invoked with defaults
+    /// because the sidebar never wants to hide its own rows.
+    static func tree(
+      accounts: Accounts,
+      groups: [AccountGroup]
+    ) -> [SidebarOutlineItem] {
+      let grouped = accounts.groupAwareSidebar(groups: groups)
+      return [
+        section(.currentAccountsHeader, entries: grouped.current),
+        section(.investmentsHeader, entries: grouped.investments),
+      ]
+    }
+
+    private static func section(
+      _ kind: Kind, entries: [SidebarBucketEntry]
+    ) -> SidebarOutlineItem {
+      SidebarOutlineItem(
+        kind: kind,
+        children: entries.map(item(from:))
+      )
+    }
+
+    private static func item(from entry: SidebarBucketEntry) -> SidebarOutlineItem {
+      switch entry {
+      case .account(let account):
+        return SidebarOutlineItem(kind: .account(account.id), children: nil)
+      case .group(let group, let members):
+        return SidebarOutlineItem(
+          kind: .group(group.id),
+          children: members.map { SidebarOutlineItem(kind: .account($0.id), children: nil) }
+        )
+      }
+    }
+  }
+  ```
+
+- [ ] **Step 4: Re-run the tests to confirm they pass**
+
+  ```bash
+  just test SidebarOutlineItemTests 2>&1 | tee .agent-tmp/test-outline-item.txt
+  ```
+
+  Expected: 3/3 pass.
+
+- [ ] **Step 5: format-check + commit**
+
+  ```bash
+  just format-check
+  git -C . add Features/Navigation/SidebarOutlineItem.swift MoolahTests/Navigation/SidebarOutlineItemTests.swift
+  git -C . commit -m "feat(sidebar): SidebarOutlineItem tree adapter for macOS outline"
+  ```
+
+  Expected: format-check passes; commit lands.
+
+### Task 2: `SidebarOutlineView` skeleton — sections render, no selection yet
+
+**Files:**
+- Create: `Features/Navigation/SidebarOutlineView.swift`
+
+- [ ] **Step 1: Implement the skeleton**
+
+  Create `Features/Navigation/SidebarOutlineView.swift` — note this file is macOS-only so wrap the whole file in `#if os(macOS)` (do not split via `#if` *inside* the file — it's simpler to read this way):
+
+  ```swift
+  #if os(macOS)
+    import AppKit
+    import OutlineView
+    import SwiftUI
+
+    /// macOS-only outline-rendered top section of the sidebar (Current
+    /// Accounts + Investments). Wraps `NSOutlineView` via the
+    /// `Sameesunkaria/OutlineView` Swift package. Selection rides through
+    /// a shared `Binding<SidebarSelection?>` with the sibling SwiftUI
+    /// list below (earmarks / totals / nav) — clicking in either surface
+    /// updates the same binding.
+    ///
+    /// Phase 1 scope: render the items, support row selection, support
+    /// chevron-driven group expand / collapse bound to
+    /// `GroupUIStateStore`. No drag-and-drop yet (Phase 2). No inline
+    /// rename (Phase 3) — rename is via the `Edit Account…` context menu
+    /// item which opens the full edit sheet.
+    struct SidebarOutlineView: View {
+      @Environment(AccountStore.self) private var accountStore
+      @Environment(AccountGroupStore.self) private var accountGroupStore
+      @Environment(GroupUIStateStore.self) private var groupUIStateStore
+      @Binding var selection: SidebarSelection?
+
+      var body: some View {
+        OutlineView(
+          SidebarOutlineItem.tree(
+            accounts: accountStore.accounts,
+            groups: accountGroupStore.groups),
+          selection: outlineSelectionBinding,
+          children: \.children
+        ) { item in
+          cellView(for: item)
+        }
+        .outlineViewStyle(.sourceList)
+      }
+
+      // MARK: - Cell rendering
+
+      /// Returns an `NSView` for the row. Section headers and group rows
+      /// use bespoke text cells; account and group rows wrap the
+      /// existing SwiftUI cells in `NSHostingView` so the rich content
+      /// (icon, balance, "Not set", spinner, color overrides) carries
+      /// over without reimplementation.
+      private func cellView(for item: SidebarOutlineItem) -> NSView {
+        switch item.kind {
+        case .currentAccountsHeader: return headerCell("Current Accounts")
+        case .investmentsHeader: return headerCell("Investments")
+        case .account(let id): return accountCell(id: id)
+        case .group(let id): return groupCell(id: id)
+        }
+      }
+
+      private func headerCell(_ title: String) -> NSView {
+        let field = NSTextField(labelWithString: title)
+        field.font = NSFont.preferredFont(forTextStyle: .subheadline)
+        field.textColor = .secondaryLabelColor
+        return field
+      }
+
+      private func accountCell(id: UUID) -> NSView {
+        guard let account = accountStore.accounts.by(id: id) else {
+          return NSView()
+        }
+        let host = NSHostingView(
+          rootView: AccountSidebarRow(account: account)
+            .environment(accountStore)
+        )
+        host.setAccessibilityIdentifier(UITestIdentifiers.Sidebar.account(id))
+        return host
+      }
+
+      private func groupCell(id: UUID) -> NSView {
+        guard let group = accountGroupStore.by(id: id) else { return NSView() }
+        let isExpanded = groupUIStateStore.expandedGroupIds.contains(id)
+        let memberIds = accountStore.accounts.ordered
+          .filter { $0.groupId == id }
+          .sorted { $0.position < $1.position }
+          .map(\.id)
+        let host = NSHostingView(
+          rootView: GroupAggregateBalanceLoader(
+            memberIds: memberIds,
+            targetInstrument: group.instrument
+          ) { balance in
+            AccountGroupSidebarRow(
+              group: group,
+              isExpanded: .constant(isExpanded),
+              aggregateBalance: balance)
+          }
+          .environment(accountStore)
+        )
+        host.setAccessibilityIdentifier(UITestIdentifiers.Sidebar.group(id))
+        return host
+      }
+
+      // MARK: - Selection binding
+
+      /// Maps between the outline's `SidebarOutlineItem?` selection and
+      /// the app's `SidebarSelection?`. Section-header rows are
+      /// non-selectable (mapped to `nil`); account / group rows map to
+      /// `.account(id)` / `.group(id)`.
+      private var outlineSelectionBinding: Binding<SidebarOutlineItem?> {
+        Binding(
+          get: {
+            switch selection {
+            case .account(let id):
+              return SidebarOutlineItem(kind: .account(id), children: nil)
+            case .group(let id):
+              return SidebarOutlineItem(kind: .group(id), children: [])
+            case .none, .earmark, .recentlyAdded, .allTransactions,
+              .upcomingTransactions, .categories, .reports, .analysis:
+              return nil
+            }
+          },
+          set: { newItem in
+            switch newItem?.kind {
+            case .account(let id): selection = .account(id)
+            case .group(let id): selection = .group(id)
+            case .currentAccountsHeader, .investmentsHeader, .none:
+              // Header rows are not selectable; clicking one is a no-op
+              // (we deliberately don't clear the existing selection
+              // because the user may be re-selecting their place after
+              // a header click).
+              break
+            }
+          }
+        )
+      }
+    }
+  #endif
+  ```
+
+  **Open questions that the spike will have answered before this task runs:**
+
+  - The `OutlineView` initialiser's exact label set may differ from `OutlineView(_, selection:, children:, content:)`. If so, adjust the call site to match. Do not invent missing parameters.
+  - `outlineViewStyle(.sourceList)` may be the API for source-list styling, but the actual modifier name should be confirmed against the package source.
+  - If section headers cannot be marked as group headers (Spike Step 5 reports option C), this skeleton renders them as bold first-row text without source-list section styling. That is an acceptable Phase 1 shipping state — note the gap in the PR description and open a follow-up.
+
+- [ ] **Step 2: Build to confirm the skeleton compiles**
+
+  ```bash
+  just build-mac 2>&1 | tee .agent-tmp/build-outline-skel.txt
+  ```
+
+  Expected: clean build. Fix compile errors against the actual package API.
+
+- [ ] **Step 3: Render preview**
+
+  Open `Moolah.xcodeproj` in the worktree, then render the existing `"With a group"` preview through `mcp__xcode__RenderPreview` — but the preview still routes to the SwiftUI `List` body for now (we haven't wired `SidebarOutlineView` into `SidebarView` yet — that's Task 4). Add a new `#Preview("macOS outline — Phase 1 skeleton")` block in `SidebarView+Previews.swift` that hosts only `SidebarOutlineView` with the same seed:
+
+  ```swift
+  #Preview("macOS outline — Phase 1 skeleton") {
+    let backend = PreviewBackend.create()
+    let accountStore = AccountStore(
+      repository: backend.accounts,
+      conversionService: backend.conversionService,
+      targetInstrument: .AUD)
+    let accountGroupStore = AccountGroupStore(repository: backend.accountGroups)
+    let groupUIStateStore = GroupUIStateStore(repository: backend.groupUIState)
+    return SidebarOutlineView(selection: .constant(nil))
+      .environment(accountStore)
+      .environment(accountGroupStore)
+      .environment(groupUIStateStore)
+      .frame(width: 260, height: 480)
+      .task {
+        await seedSidebarGroupPreview(
+          backend: backend,
+          accountStore: accountStore,
+          accountGroupStore: accountGroupStore)
+      }
+  }
+  ```
+
+  Confirm the seeded "Trust Fund Crypto" group renders with its two member rows. Confirm the section headers render.
+
+- [ ] **Step 4: format-check + commit**
+
+  ```bash
+  just format-check
+  git -C . add Features/Navigation/SidebarOutlineView.swift Features/Navigation/SidebarView+Previews.swift
+  git -C . commit -m "feat(sidebar): SidebarOutlineView skeleton (macOS, no selection wiring yet)"
+  ```
+
+### Task 3: Wire group expansion to `GroupUIStateStore`
+
+**Files:**
+- Modify: `Features/Navigation/SidebarOutlineView.swift`
+
+- [ ] **Step 1: Inspect the OutlineView package for the expansion API**
+
+  Read `.build/checkouts/OutlineView/Sources/OutlineView/OutlineView.swift` (path may differ — locate via `find`). The package exposes one of:
+
+  - A `.expansion(_:)` modifier taking a `Binding<Set<Item.ID>>`.
+  - An initialiser overload accepting an `expansion:` binding.
+  - No bindable expansion API — the user expands/collapses, the package owns the state, no external persistence.
+
+  Record which one it offers in `.agent-tmp/outline-expansion.md`. Branch on this:
+
+  - **Bindable:** wire it through to `GroupUIStateStore.expandedGroupIds` (a `Set<UUID>` — but the package wants `Set<Item.ID>` where `Item.ID == SidebarOutlineItem.Kind`, so map between them).
+  - **Non-bindable:** keep our existing `GroupUIStateStore` flow alive by subscribing to the package's `onItemExpansionChange` callback (if any), or accept that Phase 1 doesn't restore expand state across sessions on macOS and note it as a Phase 2 follow-up.
+
+  **Stop and surface to the user if the package offers no expansion observation at all** — that is the kind of design-tradeoff the spike was meant to surface but only the source-read can confirm.
+
+- [ ] **Step 2: Write the expansion test**
+
+  Add to `SidebarOutlineItemTests.swift` if the implementation lives there, or to a new `SidebarOutlineViewTests.swift` if the binding helpers live on the view. Test sketch (adjust shape based on Step 1's branch):
+
+  ```swift
+  @Test func expansionBindingReadsAndWritesGroupUIStateStore() async {
+    let store = await GroupUIStateStore.previewEmpty()
+    let g = UUID()
+    let binding = SidebarOutlineView.expansionBinding(
+      groupStore: store,
+      knownGroupIds: [g])
+    #expect(binding.wrappedValue.isEmpty)
+    binding.wrappedValue = [.group(g)]
+    // Yield for the async write.
+    try? await Task.sleep(for: .milliseconds(50))
+    #expect(await store.expandedGroupIds.contains(g))
+  }
+  ```
+
+  (The exact shape depends on whether the helper is a top-level static, a method, or computed property. Pick the one that compiles cleanly with the chosen package API. If the existing test target lacks `GroupUIStateStore.previewEmpty()`, use the production initialiser against an in-memory repository as the other store tests do — search `MoolahTests` for an example, e.g. `GroupUIStateStoreTests.swift`.)
+
+- [ ] **Step 3: Implement the binding (or, if non-bindable, the callback)**
+
+  Wire the package's expansion API to `GroupUIStateStore.setExpanded(_:for:)`. The existing `expandBinding(for:)` helper in `SidebarView+Groups.swift` is a near-exact reference — port its logic. Note the package likely speaks in terms of `Set<Item.ID>` (here `Set<SidebarOutlineItem.Kind>`), not `Set<UUID>`, so map between them in the binding.
+
+- [ ] **Step 4: Re-render the preview and toggle the chevron**
+
+  Render the `"macOS outline — Phase 1 skeleton"` preview. Toggle the group's chevron. The expanded children must appear / disappear. Across a second render, the expand state should still be in memory (the in-process store survives). Cross-session persistence is exercised via the live app, not preview — schedule a manual run via `just run-mac` later in this phase.
+
+- [ ] **Step 5: format-check + commit**
+
+  ```bash
+  just format-check
+  git -C . add Features/Navigation/SidebarOutlineView.swift MoolahTests/Navigation/
+  git -C . commit -m "feat(sidebar): bind outline expansion to GroupUIStateStore"
+  ```
+
+### Task 4: Wire `SidebarOutlineView` into `SidebarView` on macOS
+
+**Files:**
+- Modify: `Features/Navigation/SidebarView.swift`
+- Modify: `Features/Navigation/SidebarView+Sections.swift`
+- Modify: `Features/Navigation/SidebarView+Groups.swift`
+
+- [ ] **Step 1: Split `body` on `#if os(macOS)` / `#if os(iOS)`**
+
+  In `SidebarView.swift`, replace the `var body` contents with:
+
+  ```swift
+  var body: some View {
+    #if os(macOS)
+      macSidebarBody
+    #else
+      iosSidebarBody
+    #endif
+  }
+  ```
+
+  Move the existing `List(selection:)` block into a new `iosSidebarBody: some View` computed property (gated `#if os(iOS)`). Carry over the `.onKeyPress(.return)`, `.navigationTitle`, `focusedSceneValue` modifiers, the `.onChange`, `.onAppear`, the `.sheet` and `.toolbar` modifiers, exactly as they are — they are platform-aware already.
+
+  Add a new `macSidebarBody: some View` (gated `#if os(macOS)`):
+
+  ```swift
+  #if os(macOS)
+    @ViewBuilder
+    private var macSidebarBody: some View {
+      VStack(spacing: 0) {
+        SidebarOutlineView(selection: $selection)
+        List(selection: $selection) {
+          earmarksSection
+          totalsSection
+          navigationSection
+        }
+        .listStyle(.sidebar)
+      }
+      .navigationTitle("")
+      .focusedSceneValue(\.showHiddenAccounts, $showHidden)
+      .focusedSceneValue(\.showSpamTransactions, $showSpam)
+      .focusedSceneValue(\.sidebarSelection, $selection)
+      .focusedSceneValue(\.selectedAccount, selectedAccountBinding)
+      .onChange(of: showHidden) { _, newValue in
+        accountStore.showHidden = newValue
+        earmarkStore.showHidden = newValue
+      }
+      .onChange(of: showSpam) { _, newValue in
+        transactionStore.showSpam = newValue
+      }
+      .onAppear {
+        accountStore.showHidden = showHidden
+        earmarkStore.showHidden = showHidden
+        transactionStore.showSpam = showSpam
+      }
+      .safeAreaInset(edge: .bottom, spacing: 0) {
+        SyncProgressFooter()
+      }
+      .toolbar {
+        ToolbarItem(placement: .primaryAction) {
+          Button { showCreateAccountSheet = true } label: {
+            Label("New Account", systemImage: "plus")
+          }
+          .help("Create new account")
+          .accessibilityIdentifier(UITestIdentifiers.Sidebar.newAccountButton)
+        }
+        ToolbarItem(placement: .primaryAction) {
+          Button { showCreateEarmarkSheet = true } label: {
+            Label("New Earmark", systemImage: "bookmark.fill")
+          }
+          .help("Create new earmark")
+          .accessibilityIdentifier(UITestIdentifiers.Sidebar.newEarmarkButton)
+        }
+      }
+      .focusedSceneValue(\.newEarmarkAction) {
+        showCreateEarmarkSheet = true
+      }
+      .focusedSceneValue(\.newAccountAction) {
+        showCreateAccountSheet = true
+      }
+      .sheet(isPresented: $showCreateEarmarkSheet) {
+        CreateEarmarkSheet(
+          instrument: session.profile.instrument,
+          onCreate: { newEarmark in
+            Task {
+              _ = await earmarkStore.create(newEarmark)
+              showCreateEarmarkSheet = false
+            }
+          }
+        )
+      }
+      .sheet(isPresented: $showCreateAccountSheet) {
+        CreateAccountView(
+          instrument: session.profile.instrument,
+          accountStore: accountStore,
+          cryptoSyncStore: session.cryptoSyncStore)
+      }
+      .sheet(item: $accountToEdit) { account in
+        EditAccountView(account: account, accountStore: accountStore)
+      }
+      .onReceive(
+        NotificationCenter.default.publisher(for: .requestAccountEdit),
+        perform: handleAccountEditRequest
+      )
+    }
+  #endif
+  ```
+
+  DRY this body against `iosSidebarBody` — the modifier set diverges only in: the body content (outline + small list vs single list), the absence of `.onKeyPress(.return)` and the iOS edit-mode environment. If `closure_body_length` or `function_body_length` SwiftLint thresholds trip, split into smaller helpers (e.g. `macSidebarSheets`, `macSidebarFocusedScenes`) — follow `feedback_swiftlint_fix_not_baseline.md` and never bump a baseline.
+
+- [ ] **Step 2: Gate iOS-only section / group code with `#if os(iOS)`**
+
+  In `SidebarView+Sections.swift`, wrap `currentAccountsSection`, `investmentsSection`, `bucketEntryView`, and the `handleAccountEditRequest` helper (which is only called from the iOS sheet wiring on iOS now) under `#if os(iOS)` blocks. `handleAccountEditRequest` is also called from macOS, so re-confirm by reading the call sites — if macOS uses it, lift it out of the `#if`.
+
+  In `SidebarView+Groups.swift`, wrap the entire file's view extension body in `#if os(iOS)` **except** `DraggableSidebarItem`, `UTType.moolahSidebarItem`, and `expandBinding(for:)` — keep those shared (Phase 2 will need them on macOS too, and the iOS path still uses them now). The drop / drag handlers (`handleDrop(_:ontoAccount:)`, `handleDrop(_:ontoGroup:)`) stay shared as well because Phase 2 will reuse them from `SidebarOutlineView`'s `DropReceiver`.
+
+- [ ] **Step 3: Gate the `.onKeyPress(.return)` rename trigger to iOS-only**
+
+  In `SidebarView.swift`'s `iosSidebarBody`, keep `.onKeyPress(.return)` as-is. The macOS body has no Return-to-rename until Phase 3 — Return on a selected outline row falls through to system default behaviour.
+
+- [ ] **Step 4: Build**
+
+  ```bash
+  just build-mac 2>&1 | tee .agent-tmp/build-wired.txt
+  just build-ios 2>&1 | tee .agent-tmp/build-ios.txt
+  ```
+
+  Expected: both clean. iOS must build because we did not break its code path.
+
+- [ ] **Step 5: Render & manually run macOS**
+
+  Render `"With a group"` and `"Empty earmarks"` previews — they should now show the outline-rendered accounts on top + the SwiftUI earmarks/totals/nav below.
+
+  Then:
+
+  ```bash
+  just run-mac
+  ```
+
+  Click around. Verify:
+  - Selecting an account opens its transaction detail (selection binding works).
+  - Selecting a group opens the group detail.
+  - Selecting Earmarks / Recently Added / All Transactions / Analysis / Reports / Categories / Upcoming all work (the SwiftUI `List` selection is shared with the outline's selection).
+  - Toggling a group's chevron expands / collapses; quitting + relaunching restores the expand state (proves `GroupUIStateStore` round-trip).
+  - The toolbar "+ Account" / "+ Earmark" buttons still open their sheets.
+  - "Edit Account…" from the account row's context menu still opens the edit sheet.
+
+  Per `feedback_iterate_via_preview.md`, iterate visual tweaks via `#Preview` rather than relaunching for every change.
+
+- [ ] **Step 6: format-check + commit**
+
+  ```bash
+  just format-check
+  git -C . add Features/Navigation/
+  git -C . commit -m "feat(sidebar): macOS SidebarView body splits on #if; outline + earmarks/nav"
+  ```
+
+### Task 5: Tests — full unit suite + UI smoke
+
+**Files:**
+- Modify (already exists): `MoolahTests/Navigation/SidebarOutlineItemTests.swift` (Task 1)
+- Modify (created in Task 3 or new): `MoolahTests/Navigation/SidebarOutlineViewTests.swift`
+
+- [ ] **Step 1: Run the full macOS unit / UI test suite**
+
+  Before running, kill any wedged test hosts per `reference_macos_test_runner_hang.md`:
+
+  ```bash
+  pkill -f Moolah 2>/dev/null || true
+  ```
+
+  Then:
+
+  ```bash
+  just test 2>&1 | tee .agent-tmp/test-full.txt
+  grep -i 'failed\|error:' .agent-tmp/test-full.txt
+  ```
+
+  Expected: zero failures. If `MoolahUITests_macOS/Helpers/Screens/SidebarScreen.swift`'s `switchToAccount` or `switchToNamed` fails (because the resolver finds an `NSHostingView` instead of a SwiftUI element), update the driver per `guides/UI_TEST_GUIDE.md` — the identifier itself is unchanged.
+
+  If the UI host is wedged after multiple retries (`feedback_pr_ci_gate_when_ui_host_blocked.md`), surface the failure to the user, push the branch, and gate Phase 1 merge on CI's UI Test job rather than on local UI tests. Confirm with the user before doing so.
+
+- [ ] **Step 2: Code review for guide compliance**
+
+  Run the project's review agents in parallel against the working tree:
+
+  ```bash
+  # via the Agent tool, in parallel:
+  # @code-review @concurrency-review @ui-review @ui-test-review
+  ```
+
+  Address every finding per `feedback_apply_all_review_findings.md`. Critical / Important / Minor all get fixed in this PR unless deferred with the user's explicit sign-off.
+
+- [ ] **Step 3: Commit any review-driven fixes**
+
+  ```bash
+  just format-check
+  git -C . status
+  # iff changes:
+  git -C . add -A
+  git -C . commit -m "polish(sidebar): apply code-review findings"
+  ```
+
+### Task 6: PR
+
+**Files:** none (git only).
+
+- [ ] **Step 1: Push the branch**
+
+  Per CLAUDE.md's "Stacked-PR worktrees" section, use the explicit refspec form:
+
+  ```bash
+  git -C . push origin fix-sidebar-drag-drop:fix-sidebar-drag-drop
+  ```
+
+  (If the branch was created off a non-main base, also confirm with `git -C . branch -vv` that no unintended upstream tracking was set.)
+
+- [ ] **Step 2: Open the PR**
+
+  Title: `feat(sidebar): macOS NSOutlineView rewrite — Phase 1 (skeleton + selection)`. Body covers: link to design doc, link to issue #991, what Phase 1 ships, what's deferred to Phase 2 / 3, any spike findings worth surfacing (e.g. if option C from Spike Step 5 was taken, mention the open follow-up).
+
+  ```bash
+  gh pr create \
+    --base main \
+    --title "feat(sidebar): macOS NSOutlineView rewrite — Phase 1 (skeleton + selection)" \
+    --body "$(cat <<'EOF'
+## Summary
+
+Phase 1 of the NSOutlineView sidebar rewrite (design: `plans/2026-05-27-sidebar-nsoutlineview-rewrite-design.md`, executed against `plans/2026-05-27-sidebar-nsoutlineview-phase-1-plan.md`). Adds the `Sameesunkaria/OutlineView` Swift package and replaces the macOS `Current Accounts` / `Investments` sections with an `NSOutlineView`-backed view. Selection is wired back to `SidebarSelection`. iOS sidebar is untouched.
+
+This does **not** yet fix issue #991 — drag-and-drop arrives in Phase 2. Inline rename arrives in Phase 3.
+
+## Test plan
+
+- [ ] `just build-mac` + `just build-ios` are clean.
+- [ ] `just test` passes (unit + UI).
+- [ ] `just format-check` passes.
+- [ ] Manual run-through on macOS: select accounts / groups / named views (Analysis, Reports, Categories, Upcoming, Recently Added, All Transactions, Earmarks); expand/collapse a group; relaunch and confirm expand state persists; right-click → Edit Account opens the sheet.
+- [ ] Review agents (`@code-review`, `@concurrency-review`, `@ui-review`, `@ui-test-review`) report no Critical/Important findings.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+  ```
+
+- [ ] **Step 3: Enable auto-merge**
+
+  Per `feedback_prs_to_merge_queue.md` and the `landing-prs` skill:
+
+  ```bash
+  gh pr merge --auto --rebase
+  ```
+
+  Use the `monitoring-pr-status` skill in a background task to be notified on merge / CI failure / stalled automerge. Do not poll.
+
+---
+
+## Verification (end-to-end)
+
+After Task 6 closes, Phase 1 is **done** if all of these hold against the working tree:
+
+1. `just build-mac` and `just build-ios` build clean.
+2. `just test` passes — including `SidebarOutlineItemTests`, any `SidebarOutlineViewTests`, and the existing `SidebarScreen`-driven UI tests.
+3. `just format-check` reports zero violations and zero new `swiftlint:disable` / baseline entries.
+4. Manual run-through on macOS confirms: account selection, group selection (placeholder detail surface is fine — Phase 5 wires it), navigation to all named views, group expand/collapse with persistence, toolbar add-account / add-earmark, context-menu Edit Account…, "+ Group" creation via context menu (the right-click "Group ▸" submenu is the workaround for #991 until Phase 2 ships).
+5. The four review agents (`@code-review`, `@concurrency-review`, `@ui-review`, `@ui-test-review`) report no unresolved Critical or Important findings.
+6. The PR description names what is intentionally deferred to Phase 2 / 3 so the reader does not expect drag-and-drop or inline rename to work.
+
+---
+
+## Deferred to Phase 2 / 3 / 4 / 5 (out of scope here)
+
+- **Phase 2 — drag-and-drop.** `dragDataSource` + `DropReceiver` on `SidebarOutlineView`. Wire `validateDrop` to dispatch to existing `accountStore.reorderAccounts` / `accountGroupStore.moveGroup` / `accountGroupStore.addAccount` / `createGroup(joining:and:)`. Closes issue #991.
+- **Phase 3 — inline rename.** `NSTextField`-based rename (or `NSHostingView`-wrapped `InlineRenameField` from `AccountSidebarRow.swift`) triggered by double-click and Return. Restores the iOS-side `.onKeyPress(.return)` parity on macOS.
+- **Phase 4 — context menu, keyboard navigation, accessibility audit.** Per-cell `NSMenu`, arrow keys, VoiceOver pass.
+- **Phase 5 — UI test refit.** Rewrite drag-related UI tests if the Phase 2 wiring needs anything beyond identifier-based row resolution.

--- a/project.yml
+++ b/project.yml
@@ -74,6 +74,10 @@ packages:
     # Package.resolved isn't tracked; pinning here is the substitute.
     # Bump deliberately when we want to take a new release.
     exactVersion: 7.10.0
+  OutlineView:
+    url: https://github.com/Sameesunkaria/OutlineView
+    # Pinned exactly — same convention as GRDB above.
+    exactVersion: 2.0.0
 
 targets:
   Moolah_iOS:
@@ -155,6 +159,7 @@ targets:
     dependencies:
       - sdk: AppIntents.framework
       - package: GRDB
+      - package: OutlineView
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: rocks.moolah.app
@@ -255,6 +260,7 @@ targets:
         TEST_TARGET_NAME: Moolah_macOS
     dependencies:
       - target: Moolah_macOS
+      - package: OutlineView
 
 schemes:
   Moolah:

--- a/project.yml
+++ b/project.yml
@@ -74,10 +74,6 @@ packages:
     # Package.resolved isn't tracked; pinning here is the substitute.
     # Bump deliberately when we want to take a new release.
     exactVersion: 7.10.0
-  OutlineView:
-    url: https://github.com/Sameesunkaria/OutlineView
-    # Pinned exactly — same convention as GRDB above.
-    exactVersion: 2.0.0
 
 targets:
   Moolah_iOS:
@@ -152,6 +148,11 @@ targets:
       - path: Shared
       - path: Automation
       - path: UITestSupport
+      # Vendored fork of Sameesunkaria/OutlineView with three local
+      # extensions (isGroupItem, expandedItems binding, NSTableCellView
+      # hosting helper). macOS-only — iOS does not have NSOutlineView.
+      # See Vendored/OutlineView/NOTICE.md for the rationale.
+      - path: Vendored/OutlineView
     preBuildScripts:
       - script: "${SRCROOT}/scripts/check-release-build-number.sh"
         name: Verify Release build number
@@ -159,7 +160,6 @@ targets:
     dependencies:
       - sdk: AppIntents.framework
       - package: GRDB
-      - package: OutlineView
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: rocks.moolah.app
@@ -260,7 +260,6 @@ targets:
         TEST_TARGET_NAME: Moolah_macOS
     dependencies:
       - target: Moolah_macOS
-      - package: OutlineView
 
 schemes:
   Moolah:


### PR DESCRIPTION
## Summary

Phase 1 of the `NSOutlineView` sidebar rewrite (design: [`plans/2026-05-27-sidebar-nsoutlineview-rewrite-design.md`](https://github.com/moolah-rocks/moolah-native/blob/fix-sidebar-drag-drop-phase-1/plans/2026-05-27-sidebar-nsoutlineview-rewrite-design.md), plan: [`plans/2026-05-27-sidebar-nsoutlineview-phase-1-plan.md`](https://github.com/moolah-rocks/moolah-native/blob/fix-sidebar-drag-drop-phase-1/plans/2026-05-27-sidebar-nsoutlineview-phase-1-plan.md)). Vendors the `Sameesunkaria/OutlineView` MIT package under `Vendored/OutlineView/` with three macOS-only hooks added (`outlineViewIsGroupItem`, `outlineViewExpandedItems`, `NSTableCellView.hosting(...)`), introduces `SidebarOutlineItem` + `SidebarOutlineView`, and wires two per-bucket outline instances into `SidebarView`'s macOS body — Current Accounts and Investments are now `NSOutlineView`-backed; Earmarks/Totals/Navigation remain SwiftUI. iOS path is untouched.

This **does not yet fix** issue [#991](https://github.com/moolah-rocks/moolah-native/issues/991) — drag-and-drop arrives in Phase 2. Inline rename arrives in Phase 3.

Visual layout matches iOS exactly: Current Accounts → Earmarks → Investments → Totals → Navigation, with flat non-collapsible `Section` headers (not `isGroupItem` toggles) and translucent sidebar material throughout. Verified via Xcode `#Preview` render side-by-side against `AccountSidebarRow`.

## Deferred

- **Phase 2**: drag-and-drop (closes #991), `DropReceiver` + `dragDataSource` on `SidebarOutlineView`.
- **Phase 3**: inline rename. macOS users continue to use Edit Account… from the context menu meanwhile.
- **Phase 4**: full context-menu parity (group submenu), keyboard nav audit, VoiceOver pass.
- **Phase 5**: UI test refit if Phase 2 drag wiring needs anything beyond identifier-based row resolution.

## Test plan

- [x] `just build-mac` + `just build-ios` clean.
- [x] `just test` passes (3406 tests / 590 suites).
- [x] `just test-ui` passes locally — XCUITest-attached macOS launch crash (`OutlineViewController.updateData` → `NSTableRowHeightData` row-height query) fixed by removing the `heightOfRowByItem` speculative cell-build path; `usesAutomaticRowHeights` does the work safely.
- [x] `just format-check` clean. Zero SwiftLint baseline reintroduction.
- [x] Manual run-through on macOS: select accounts / groups / named views; expand/collapse a group; relaunch and confirm expand state persists via `GroupUIStateStore`; right-click → Edit Account opens the sheet.
- [x] Code-review agents (`@code-review`, `@concurrency-review`, `@ui-review`, `@ui-test-review`) report no unresolved Critical/Important findings.

## Notes

- `Vendored/OutlineView/` is the verbatim upstream source (MIT, see `LICENSE.txt`) with `// moolah:` markers on every local modification — diffable against upstream tag `2.0.0`. Excluded from SwiftLint + swift-format.
- Three modifier additions on the vendored package: `.outlineViewIsGroupItem(_:)`, `.outlineViewExpandedItems(_:)`, and the `NSTableCellView.hosting(accessibilityIdentifier:content:)` cell-builder helper. See `Vendored/OutlineView/NOTICE.md`.
- macOS sidebar visual chrome (background, row padding, intercell spacing) tuned to match `.listStyle(.sidebar)` rows — `NSScrollView.contentView.drawsBackground = false`, `selectionHighlightStyle = .regular`, `usesAlternatingRowBackgroundColors = false`, `intercellSpacing = .zero`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)