### PR TITLE
fix(sidebar): replace flaky SwiftUI .contextMenu with AppKit NSMenu

### DIFF
--- a/Features/Navigation/SidebarOutlineView.swift
+++ b/Features/Navigation/SidebarOutlineView.swift
@@ -114,31 +114,85 @@
         return NSTableCellView()
       }
       return NSTableCellView.hosting(
-        accessibilityIdentifier: UITestIdentifiers.Sidebar.account(id)
+        accessibilityIdentifier: UITestIdentifiers.Sidebar.account(id),
+        menu: makeAccountContextMenu(for: account)
       ) {
         AccountSidebarRow(account: account, isSelected: selection == .account(id))
           .environment(accountStore)
-          .contextMenu { accountContextMenu(for: account) }
       }
     }
 
-    // moolah: macOS outline-cell context menu. Mirrors the
-    // `accountContextMenu(for:)` builder in `SidebarView` but pared down
-    // to the items that work in Phase 1 (no inline rename, no group
-    // submenu — both are iOS-only until later phases). "Edit Account…"
-    // is the regression-critical item: UI tests right-click a sidebar
-    // account row and expect to find the menu by its accessibility
-    // identifier (see `EditAccountValuationPickerTests`).
-    @ViewBuilder
-    private func accountContextMenu(for account: Account) -> some View {
-      Button("Edit Account\u{2026}", systemImage: "pencil") {
-        accountToEdit = account
-      }
-      .accessibilityIdentifier(UITestIdentifiers.Sidebar.editAccountContextMenuItem)
-      Button("View Transactions", systemImage: "list.bullet") {
-        selection = .account(account.id)
-      }
+    // moolah: macOS outline-cell context menu, materialised as a real
+    // AppKit `NSMenu` rather than a SwiftUI `.contextMenu`. Phase 1
+    // initially used `.contextMenu` on the hosted SwiftUI row, but the
+    // hosted tree gets rebuilt by `OutlineViewController.updateData`
+    // whenever the data source changes (e.g.
+    // `AccountStore.convertedBalances` emitting between the right-click
+    // and the NSMenu materialising): the menu's host view is replaced
+    // under AppKit's foot and the menu dismisses or never opens. An
+    // AppKit `NSMenu` attached to `NSTableCellView.menu` is owned by
+    // AppKit's menu-tracking session, independent of any SwiftUI
+    // re-render, so the menu stays open across data refreshes.
+    //
+    // Mirrors the `accountContextMenu(for:)` builder in `SidebarView`
+    // but pared down to the items that work in Phase 1 (no inline
+    // rename, no group submenu — both are iOS-only until later
+    // phases). "Edit Account…" is the regression-critical item: UI
+    // tests right-click a sidebar account row and expect to find the
+    // menu by its accessibility identifier (see
+    // `EditAccountValuationPickerTests`).
+    @MainActor
+    private func makeAccountContextMenu(for account: Account) -> NSMenu {
+      let accountId = account.id
+      // Capture the bindings (not `self`) so the closures keep working
+      // even though the surrounding `SidebarOutlineView` struct value
+      // is rebuilt on every SwiftUI body re-render. The bindings stay
+      // pointed at the parent `SidebarView`'s source of truth.
+      //
+      // Capture the `AccountStore` and look up the latest account by
+      // ID at click time. `NSOutlineView`'s update path only rebuilds
+      // cells on identity changes (insert / remove), so a cell — and
+      // therefore its menu — persists across in-place account edits.
+      // Capturing the `Account` value would freeze the menu's "Edit
+      // Account…" action against the stale snapshot it was built with,
+      // re-opening the edit dialog with pre-edit data after a save.
+      let accountToEdit = $accountToEdit
+      let selection = $selection
+      let accountStore = accountStore
+      let actions = CellMenuActions(
+        onEdit: {
+          guard let fresh = accountStore.accounts.by(id: accountId) else { return }
+          accountToEdit.wrappedValue = fresh
+        },
+        onViewTransactions: { selection.wrappedValue = .account(accountId) }
+      )
+      let menu = NSMenu()
+      let editItem = NSMenuItem(
+        title: "Edit Account\u{2026}",
+        action: #selector(CellMenuActions.editAction(_:)),
+        keyEquivalent: "")
+      editItem.target = actions
+      editItem.image = NSImage(systemSymbolName: "pencil", accessibilityDescription: nil)
+      editItem.setAccessibilityIdentifier(UITestIdentifiers.Sidebar.editAccountContextMenuItem)
+      menu.addItem(editItem)
+      let viewItem = NSMenuItem(
+        title: "View Transactions",
+        action: #selector(CellMenuActions.viewTransactionsAction(_:)),
+        keyEquivalent: "")
+      viewItem.target = actions
+      viewItem.image = NSImage(systemSymbolName: "list.bullet", accessibilityDescription: nil)
+      menu.addItem(viewItem)
+      // moolah: NSMenuItem's `target` is `weak`/unowned by default, so the
+      // `CellMenuActions` instance has no owner once this function returns.
+      // Attach it to the menu's lifetime via an associated object — the
+      // association is retained as long as the menu lives, and the menu
+      // lives as long as the cell holds it (`cell.menu = menu`).
+      objc_setAssociatedObject(
+        menu, &Self.cellActionsKey, actions, .OBJC_ASSOCIATION_RETAIN)
+      return menu
     }
+
+    nonisolated(unsafe) private static var cellActionsKey: UInt8 = 0
 
     private func groupCell(id: UUID) -> NSView {
       guard let group = accountGroupStore.by(id: id) else {
@@ -257,6 +311,42 @@
           }
         }
       )
+    }
+  }
+
+  /// Target/action sink for the per-cell AppKit context menu.
+  ///
+  /// `NSMenuItem.action` is a selector dispatched against
+  /// `NSMenuItem.target`, so we can't pass a SwiftUI closure directly.
+  /// Each cell gets its own `CellMenuActions` capturing closures bound
+  /// to that cell's account; the actions instance is kept alive for the
+  /// menu's lifetime via `objc_setAssociatedObject` on the `NSMenu`
+  /// (see `SidebarOutlineView.makeAccountContextMenu(for:)`).
+  ///
+  /// `@MainActor` because the captured closures mutate
+  /// `SidebarOutlineView`'s SwiftUI bindings (`accountToEdit`,
+  /// `selection`), which are read/written on the main actor.
+  @MainActor
+  private final class CellMenuActions: NSObject {
+    private let onEdit: () -> Void
+    private let onViewTransactions: () -> Void
+
+    init(
+      onEdit: @escaping () -> Void,
+      onViewTransactions: @escaping () -> Void
+    ) {
+      self.onEdit = onEdit
+      self.onViewTransactions = onViewTransactions
+    }
+
+    @objc
+    func editAction(_ sender: Any?) {
+      onEdit()
+    }
+
+    @objc
+    func viewTransactionsAction(_ sender: Any?) {
+      onViewTransactions()
     }
   }
 #endif

--- a/Vendored/OutlineView/Extensions/NSTableCellView+OutlineView.swift
+++ b/Vendored/OutlineView/Extensions/NSTableCellView+OutlineView.swift
@@ -27,12 +27,25 @@ extension NSTableCellView {
   /// sidebar row attaches its identifier (`SidebarView+Groups.swift`,
   /// `SidebarView+Sections.swift`). The cell-side call is preserved
   /// belt-and-braces in case future AppKit changes expose it.
+  ///
+  /// moolah: an optional `menu` parameter attaches an AppKit `NSMenu`
+  /// directly to the cell's `menu` property. This is the right-click
+  /// menu for the cell. Using an AppKit menu (rather than a SwiftUI
+  /// `.contextMenu` on the hosted view) is required because the hosted
+  /// SwiftUI tree is rebuilt by the vendored `OutlineView` controller
+  /// whenever the data source changes — if a SwiftUI context menu is
+  /// open while AccountStore re-emits, the menu's host view is replaced
+  /// under AppKit's foot and the menu dismisses or never opens (see
+  /// `EditAccountValuationPickerTests` flake hunt). An AppKit `NSMenu`
+  /// attached to the cell is owned by AppKit's menu-tracking session,
+  /// independent of any SwiftUI re-render.
   static func hosting<Content: View>(
     accessibilityIdentifier: String? = nil,
+    menu: NSMenu? = nil,
     @ViewBuilder content: () -> Content
   ) -> NSTableCellView {
     let cell = NSTableCellView()
-    let host = NSHostingView(
+    let host = MenuForwardingHostingView(
       rootView: cellRootView(
         content: content(),
         accessibilityIdentifier: accessibilityIdentifier
@@ -53,6 +66,7 @@ extension NSTableCellView {
     if let accessibilityIdentifier {
       cell.setAccessibilityIdentifier(accessibilityIdentifier)
     }
+    cell.menu = menu
     return cell
   }
 
@@ -70,5 +84,23 @@ extension NSTableCellView {
     } else {
       content
     }
+  }
+}
+
+// moolah: `NSHostingView` subclass whose `menu(for:)` falls back to its
+// `superview?.menu` if the hosted SwiftUI tree does not return one. The
+// hosted SwiftUI content does not declare a `.contextMenu` (we use an
+// AppKit `NSMenu` on the enclosing `NSTableCellView` to dodge the
+// SwiftUI-rebuild flake — see
+// `NSTableCellView.hosting(accessibilityIdentifier:menu:content:)`),
+// so without this override the right-click event sees no menu on the
+// hit-tested view and AppKit gives up. Forwarding to the cell's menu
+// lets AppKit's responder chain find the menu we attached to the cell.
+private final class MenuForwardingHostingView<Content: View>: NSHostingView<Content> {
+  override func menu(for event: NSEvent) -> NSMenu? {
+    if let inherited = super.menu(for: event) {
+      return inherited
+    }
+    return superview?.menu
   }
 }


### PR DESCRIPTION
## Summary

Fixes the three `EditAccountValuationPickerTests` flakes that surfaced in the merge queue for [#993](https://github.com/moolah-rocks/moolah-native/pull/993):
- `testFlippingValuationModePersists`
- `testRecordedValueLegacyAccountPreselectsRecordedValue`
- `testRecordedValueLegacyAccountShowsValuationPicker`

All three failed with `'Edit Account…' menu item did not appear within 3s of right-click` on the first attempt and passed on XCTest retry.

## Root cause

Phase 1 wrapped the macOS sidebar cells in `NSHostingView` inside `NSTableCellView` and put the context menu on the hosted SwiftUI view via `.contextMenu`. When `AccountStore.convertedBalances` emitted between the right-click and the NSMenu materialising, `SidebarOutlineView.body` re-ran, the vendored `OutlineView`'s controller rebuilt cells, and the hosted SwiftUI tree got replaced under AppKit's foot — the NSMenu was dismissed or never opened.

## Fix

Switch the macOS outline cells to a real AppKit `NSMenu` attached to `NSTableCellView.menu`, with menu items targeted at a per-cell action sink retained via `objc_setAssociatedObject` on the menu. AppKit owns the menu's lifetime so re-renders don't tear it down. Accessibility identifiers are set on the `NSMenuItem` directly.

Two additional issues surfaced during implementation:

1. **NSHostingView consumed right-click events** before they reached the enclosing `NSTableCellView`, so a bare `cell.menu` had no effect. Subclassed `NSHostingView` as `MenuForwardingHostingView` and override `menu(for:)` to fall through to `superview?.menu` when the hosted SwiftUI tree has no menu of its own.
2. **NSOutlineView only rebuilds cells on identity changes** (insert/remove). Capturing the `Account` value in the menu's edit action froze it against the pre-edit snapshot, so re-opening the edit dialog after a save showed pre-edit data. Capture `AccountStore` and look up the latest account by ID at click time instead.

iOS path is unchanged.

## Test plan

- [x] Baseline: reproduced the flake locally with the exact 3 failing tests before fix.
- [x] `just test-ui EditAccountValuationPickerTests` × 3 consecutive runs, all 4 tests pass first try (no retries).
- [x] `just test-ui` full suite passes (no other regressions).
- [x] `just build-mac`, `just build-ios` green.
- [x] `just test` (unit tests) green.
- [x] `just format-check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)