### PR TITLE
test(sidebar): de-flake reorderRoot group-ahead-of-standalone

### DIFF
--- a/MoolahTests/Navigation/SidebarDropDispatchReorderTests.swift
+++ b/MoolahTests/Navigation/SidebarDropDispatchReorderTests.swift
@@ -71,14 +71,24 @@ struct SidebarDropDispatchReorderTests {
       accountStore: stores.accountStore,
       accountGroupStore: stores.accountGroupStore)
 
+    // `reorderRoot` writes to BOTH stores: the group's new position on
+    // `accountGroupStore`, and the shifted standalone's position on
+    // `accountStore`. The original waiter parked on `accountGroupStore`
+    // and read `accountStore` inside the predicate — if the watched
+    // store emitted first (still showing the pre-shift state on the
+    // other), the predicate was false, no further emission came on
+    // the watched store, and the waiter timed out (#1000). Wait on
+    // both stores' writes individually, then assert the cross-store
+    // invariant synchronously.
+    try await stores.accountStore.waitForNextEmission(
+      matching: { $0.accounts.by(id: standalone.id)?.position == 1 },
+      description: "standalone shifted to position 1")
     try await stores.accountGroupStore.waitForNextEmission(
-      matching: {
-        let groupPos = $0.by(id: group.id)?.position ?? -1
-        let standalonePos =
-          stores.accountStore.accounts.by(id: standalone.id)?.position ?? -1
-        return groupPos < standalonePos
-      },
-      description: "group now positioned ahead of standalone")
+      matching: { $0.by(id: group.id)?.position == 0 },
+      description: "group landed at position 0")
+    let groupPos = stores.accountGroupStore.by(id: group.id)?.position
+    let standalonePos = stores.accountStore.accounts.by(id: standalone.id)?.position
+    #expect((groupPos ?? -1) < (standalonePos ?? -1))
   }
 
   @Test("reorderRoot clamps insertion index past the end")


### PR DESCRIPTION
## Summary

Closes #1000. The test `reorderRoot moves a group ahead of a standalone account` flaked on [main CI run #26541528524](https://github.com/moolah-rocks/moolah-native/actions/runs/26541528524) and again on PR #997 CI — passed on the first attempt within a single xcodebuild invocation, failed on the in-process retry.

## Root cause

`SidebarDropDispatch.reorderRoot` writes to BOTH `accountGroupStore` (the dragged group's new position) AND `accountStore` (shifted standalone positions). The test parked a waiter on `accountGroupStore` whose predicate read `accountStore`'s state. When the watched store emitted first (with the unwatched store still pre-shift), the predicate evaluated to false; subsequent emissions on the watched store never came, and the waiter timed out.

## Fix

Replace the single-store waiter with two store-specific waiters in sequence, then assert the cross-store invariant synchronously:

\`\`\`swift
try await stores.accountStore.waitForNextEmission(
  matching: { $0.accounts.by(id: standalone.id)?.position == 1 },
  description: "standalone shifted to position 1")
try await stores.accountGroupStore.waitForNextEmission(
  matching: { $0.by(id: group.id)?.position == 0 },
  description: "group landed at position 0")
let groupPos = stores.accountGroupStore.by(id: group.id)?.position
let standalonePos = stores.accountStore.accounts.by(id: standalone.id)?.position
#expect((groupPos ?? -1) < (standalonePos ?? -1))
\`\`\`

## Test plan

- [x] `just format-check` — clean
- [x] Ran the specific test 5 consecutive times locally — 5/5 PASSED.
- [ ] Full \`just test-mac\` pass on CI.

Fixes #1000.