### PR TITLE
fix(sidebar): trailing-align amounts in macOS total rows

### DIFF
--- a/Features/Navigation/AppKitSidebar/Cells/SidebarTotalRowView.swift
+++ b/Features/Navigation/AppKitSidebar/Cells/SidebarTotalRowView.swift
@@ -10,6 +10,11 @@ import SwiftUI
 /// `Features/Navigation/SidebarView+Sections.swift`). `bold` additionally
 /// applies `.bold()` on top of the headline, matching the iOS path's
 /// extra weight on "Net Worth".
+///
+/// Uses an explicit `HStack { … Spacer() … }` rather than
+/// `LabeledContent`: inside the AppKit outline's `NSHostingView` the
+/// `LabeledContent` automatic style does not push the value to the
+/// trailing edge, so the amount renders flush against the label.
 struct SidebarTotalRowView: View {
   let label: String
   let amount: InstrumentAmount?
@@ -17,7 +22,9 @@ struct SidebarTotalRowView: View {
   var bold: Bool = false
 
   var body: some View {
-    LabeledContent(label) {
+    HStack {
+      Text(label)
+      Spacer()
       if let amount {
         InstrumentAmountView(amount: amount)
       } else {
@@ -26,6 +33,7 @@ struct SidebarTotalRowView: View {
     }
     .foregroundStyle(emphasised ? .primary : .secondary)
     .font(font)
+    .accessibilityElement(children: .combine)
   }
 
   private var font: Font {


### PR DESCRIPTION
## Summary
- `SidebarTotalRowView` rendered Current Total / Investment Total / Earmarked Total / Available Funds / Net Worth with the amount packed flush against the label instead of right-aligned.
- Root cause: `LabeledContent` inside the AppKit outline's `NSHostingView` does not push the value to the trailing edge — the SwiftUI list's automatic LabeledContent style isn't applied outside a real `List`.
- Replace with an explicit `HStack { Text(label); Spacer(); valueView }`, matching the pattern `AccountSidebarRow` already uses.
- iOS path (`SidebarView+Sections.swift` → `totalRow(label:value:)` / `totalsSection`) is unchanged — it works fine because it's inside a real SwiftUI `List`.

## Test plan
- [x] `just build-mac` — clean
- [x] `just format-check` — clean
- [ ] Visually confirm trailing-alignment for Current Total / Investment Total / Earmarked Total / Available Funds / Net Worth in the macOS sidebar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)