### PR TITLE
test(automation): surface emission timeouts (drop try? on waitForEmission)

### DIFF
--- a/MoolahTests/Automation/AddInvestmentValueIntentPolicyTests.swift
+++ b/MoolahTests/Automation/AddInvestmentValueIntentPolicyTests.swift
@@ -28,7 +28,7 @@ struct AddInvestmentValueIntentPolicyTests {
       Issue.record("expected .ready")
       throw OpenSessionFailed()
     }
-    try? await session.accountStore.waitForFirstEmission()
+    try await session.accountStore.waitForFirstEmission()
     let service = AutomationService(sessionManager: sessionManager)
     return (service, session)
   }
@@ -43,7 +43,7 @@ struct AddInvestmentValueIntentPolicyTests {
     let saved = try await session.accountStore.create(
       Account(name: "Brokerage", type: .investment, instrument: session.profile.instrument))
     #expect(saved.valuationMode == .calculatedFromTrades)
-    try? await session.accountStore.waitForNextEmission(
+    try await session.accountStore.waitForNextEmission(
       matching: { $0.accounts.contains { $0.name == "Brokerage" } },
       description: "new account observable"
     )

--- a/MoolahTests/Automation/AutomationServiceAccountTests.swift
+++ b/MoolahTests/Automation/AutomationServiceAccountTests.swift
@@ -25,7 +25,7 @@ struct AutomationServiceAccountTests {
     // AccountStore is reactive — wait for the first emission so any
     // pre-seeded accounts are visible. For a fresh test session there
     // are none, but the wait keeps the public API consistent.
-    try? await session.accountStore.waitForFirstEmission()
+    try await session.accountStore.waitForFirstEmission()
     let service = AutomationService(sessionManager: sessionManager)
     return (service, session)
   }
@@ -46,7 +46,7 @@ struct AutomationServiceAccountTests {
 
     // AccountStore is reactive — the new account is observable via
     // `accounts` once `observeAll()` delivers the post-write snapshot.
-    try? await session.accountStore.waitForNextEmission(
+    try await session.accountStore.waitForNextEmission(
       matching: { $0.accounts.count == 1 },
       description: "new account observable"
     )
@@ -65,7 +65,7 @@ struct AutomationServiceAccountTests {
       type: .bank
     )
 
-    try? await session.accountStore.waitForNextEmission(
+    try await session.accountStore.waitForNextEmission(
       matching: { $0.accounts.contains { $0.name == "My Savings" } },
       description: "new account observable"
     )
@@ -92,7 +92,7 @@ struct AutomationServiceAccountTests {
       type: .bank
     )
 
-    try? await session.accountStore.waitForNextEmission(
+    try await session.accountStore.waitForNextEmission(
       matching: { $0.accounts.by(id: created.id) != nil },
       description: "new account observable"
     )
@@ -118,7 +118,7 @@ struct AutomationServiceAccountTests {
 
     // Wait for the reactive observation to deliver the position
     // computed from the opening-balance transaction.
-    try? await session.accountStore.waitForNextEmission(
+    try await session.accountStore.waitForNextEmission(
       matching: { !($0.positions(for: bankAccount.id).isEmpty) },
       description: "opening balance position observable"
     )
@@ -136,7 +136,7 @@ struct AutomationServiceAccountTests {
       type: .bank
     )
 
-    try? await session.accountStore.waitForNextEmission(
+    try await session.accountStore.waitForNextEmission(
       matching: { $0.accounts.by(id: created.id) != nil },
       description: "new account observable"
     )
@@ -159,7 +159,7 @@ struct AutomationServiceAccountTests {
       type: .bank
     )
 
-    try? await session.accountStore.waitForNextEmission(
+    try await session.accountStore.waitForNextEmission(
       matching: { $0.accounts.by(id: created.id) != nil },
       description: "new account observable"
     )
@@ -169,7 +169,7 @@ struct AutomationServiceAccountTests {
     // `AccountRepository.delete` is a soft delete (flips `isHidden`).
     // Under the reactive observation contract, the row stays in GRDB
     // (and therefore in `accounts`) but with `isHidden == true`.
-    try? await session.accountStore.waitForNextEmission(
+    try await session.accountStore.waitForNextEmission(
       matching: { $0.accounts.by(id: created.id)?.isHidden == true },
       description: "account hidden observable"
     )

--- a/MoolahTests/Automation/AutomationServiceCategoryTests.swift
+++ b/MoolahTests/Automation/AutomationServiceCategoryTests.swift
@@ -24,7 +24,7 @@ struct AutomationServiceCategoryTests {
     }
     // CategoryStore is reactive — wait for the first emission so any
     // pre-seeded rows are visible.
-    try? await session.categoryStore.waitForFirstEmission()
+    try await session.categoryStore.waitForFirstEmission()
     let service = AutomationService(sessionManager: sessionManager)
     return (service, session)
   }
@@ -44,7 +44,7 @@ struct AutomationServiceCategoryTests {
 
     // CategoryStore is reactive — the new category is observable via
     // `categories` once `observeAll()` delivers the post-write snapshot.
-    try? await session.categoryStore.waitForNextEmission(
+    try await session.categoryStore.waitForNextEmission(
       matching: { $0.categories.roots.count == 1 },
       description: "new category observable"
     )
@@ -64,7 +64,7 @@ struct AutomationServiceCategoryTests {
       parentName: nil
     )
 
-    try? await session.categoryStore.waitForNextEmission(
+    try await session.categoryStore.waitForNextEmission(
       matching: { $0.categories.roots.contains { $0.name == "Transport" } },
       description: "new category observable"
     )
@@ -95,7 +95,7 @@ struct AutomationServiceCategoryTests {
     // The subsequent createCategory call resolves "Food" against the
     // store's `categories` cache — wait for the first create to land
     // there before issuing the second.
-    try? await session.categoryStore.waitForNextEmission(
+    try await session.categoryStore.waitForNextEmission(
       matching: { $0.categories.roots.contains { $0.name == "Food" } },
       description: "parent category observable"
     )

--- a/MoolahTests/Automation/AutomationServiceEarmarkTests.swift
+++ b/MoolahTests/Automation/AutomationServiceEarmarkTests.swift
@@ -24,7 +24,7 @@ struct AutomationServiceEarmarkTests {
     }
     // EarmarkStore is reactive — wait for the first emission so any
     // pre-seeded earmarks are visible.
-    try? await session.earmarkStore.waitForFirstEmission()
+    try await session.earmarkStore.waitForFirstEmission()
     let service = AutomationService(sessionManager: sessionManager)
     return (service, session)
   }
@@ -44,7 +44,7 @@ struct AutomationServiceEarmarkTests {
 
     // EarmarkStore is reactive — the new earmark is observable via
     // observeAll() shortly after the GRDB write commits, not synchronously.
-    try? await session.earmarkStore.waitForNextEmission(
+    try await session.earmarkStore.waitForNextEmission(
       matching: { $0.earmarks.contains { $0.name == "Holiday Fund" } },
       description: "new earmark observable"
     )
@@ -63,7 +63,7 @@ struct AutomationServiceEarmarkTests {
       name: "Emergency Fund"
     )
 
-    try? await session.earmarkStore.waitForNextEmission(
+    try await session.earmarkStore.waitForNextEmission(
       matching: { $0.earmarks.contains { $0.name == "Emergency Fund" } },
       description: "new earmark observable"
     )

--- a/MoolahTests/Automation/AutomationServiceExportImportTests.swift
+++ b/MoolahTests/Automation/AutomationServiceExportImportTests.swift
@@ -51,7 +51,7 @@
         Issue.record("expected .ready")
         return
       }
-      try? await session.accountStore.waitForFirstEmission()
+      try await session.accountStore.waitForFirstEmission()
 
       _ = try await harness.service.createAccount(
         profileIdentifier: "Test Profile",
@@ -102,7 +102,7 @@
         Issue.record("expected .ready")
         return
       }
-      try? await sourceSession.accountStore.waitForFirstEmission()
+      try await sourceSession.accountStore.waitForFirstEmission()
       _ = try await harness.service.createAccount(
         profileIdentifier: "Source Profile",
         name: "Savings",
@@ -132,7 +132,7 @@
         Issue.record("expected .ready")
         return
       }
-      try? await importedSession.accountStore.waitForNextEmission(
+      try await importedSession.accountStore.waitForNextEmission(
         matching: { $0.accounts.contains { $0.name == "Savings" } },
         description: "imported account observable"
       )

--- a/MoolahTests/Automation/AutomationServiceTransactionTests.swift
+++ b/MoolahTests/Automation/AutomationServiceTransactionTests.swift
@@ -24,9 +24,9 @@ struct AutomationServiceTransactionTests {
     }
     // AccountStore, EarmarkStore, and CategoryStore are all reactive
     // — wait for the first emission so any pre-seeded rows are visible.
-    try? await session.accountStore.waitForFirstEmission()
-    try? await session.earmarkStore.waitForFirstEmission()
-    try? await session.categoryStore.waitForFirstEmission()
+    try await session.accountStore.waitForFirstEmission()
+    try await session.earmarkStore.waitForFirstEmission()
+    try await session.categoryStore.waitForFirstEmission()
     let service = AutomationService(sessionManager: sessionManager)
     return (service, session)
   }
@@ -41,7 +41,7 @@ struct AutomationServiceTransactionTests {
       name: "Checking",
       type: .bank
     )
-    try? await session.accountStore.waitForNextEmission(
+    try await session.accountStore.waitForNextEmission(
       matching: { $0.accounts.contains { $0.name == "Checking" } },
       description: "new account observable"
     )
@@ -77,7 +77,7 @@ struct AutomationServiceTransactionTests {
       name: "Checking",
       type: .bank
     )
-    try? await session.accountStore.waitForNextEmission(
+    try await session.accountStore.waitForNextEmission(
       matching: { $0.accounts.contains { $0.name == "Checking" } },
       description: "new account observable"
     )
@@ -110,7 +110,7 @@ struct AutomationServiceTransactionTests {
       name: "Checking",
       type: .bank
     )
-    try? await session.accountStore.waitForNextEmission(
+    try await session.accountStore.waitForNextEmission(
       matching: { $0.accounts.contains { $0.name == "Checking" } },
       description: "new account observable"
     )

--- a/MoolahTests/Features/Crypto/CryptoAccountCreationStoreTests.swift
+++ b/MoolahTests/Features/Crypto/CryptoAccountCreationStoreTests.swift
@@ -307,7 +307,7 @@ struct CryptoAccountCreationStoreTests {
     // exists but was never handed to the logic, so the alchemy stub
     // saw no activity). AccountStore is reactive — wait for the
     // observation to deliver the new account before reading.
-    try? await fixture.accountStore.waitForNextEmission(
+    try await fixture.accountStore.waitForNextEmission(
       matching: { $0.accounts.count == 1 },
       description: "new account observable"
     )

--- a/MoolahTests/Features/TransactionStoreAccountBalanceTests.swift
+++ b/MoolahTests/Features/TransactionStoreAccountBalanceTests.swift
@@ -14,7 +14,7 @@ struct TransactionStoreAccountBalanceTests {
   func testCreateUpdatesAccountBalance() async throws {
     let account = TransactionStoreTestSupport.acct(id: accountId, name: "Bank", balance: 1000)
     let (backend, database) = try TestBackend.create()
-    let stores = await TransactionStoreTestSupport.makeStores(
+    let stores = try await TransactionStoreTestSupport.makeStores(
       backend: backend, database: database, accounts: [account])
     let store = stores.transactions
     let accountStore = stores.accounts
@@ -61,7 +61,7 @@ struct TransactionStoreAccountBalanceTests {
     )
     let (backend, database) = try TestBackend.create()
     TestBackend.seed(transactions: [transaction], in: database)
-    let stores = await TransactionStoreTestSupport.makeStores(
+    let stores = try await TransactionStoreTestSupport.makeStores(
       backend: backend, database: database, accounts: [account])
     let store = stores.transactions
     let accountStore = stores.accounts
@@ -107,7 +107,7 @@ struct TransactionStoreAccountBalanceTests {
     )
     let (backend, database) = try TestBackend.create()
     TestBackend.seed(transactions: [transaction], in: database)
-    let stores = await TransactionStoreTestSupport.makeStores(
+    let stores = try await TransactionStoreTestSupport.makeStores(
       backend: backend, database: database, accounts: [account])
     let store = stores.transactions
     let accountStore = stores.accounts

--- a/MoolahTests/Features/TransactionStoreEarmarkTests.swift
+++ b/MoolahTests/Features/TransactionStoreEarmarkTests.swift
@@ -18,7 +18,7 @@ struct TransactionStoreEarmarkTests {
       id: earmarkId, name: "Holiday",
       instrument: .defaultTestInstrument)
     let (backend, database) = try TestBackend.create()
-    let stores = await TransactionStoreTestSupport.makeStores(
+    let stores = try await TransactionStoreTestSupport.makeStores(
       backend: backend, database: database, accounts: [account], earmarks: [earmark])
     let store = stores.transactions
     let earmarkStore = stores.earmarks
@@ -79,7 +79,7 @@ struct TransactionStoreEarmarkTests {
     )
     let (backend, database) = try TestBackend.create()
     TestBackend.seed(transactions: [transaction], in: database)
-    let stores = await TransactionStoreTestSupport.makeStores(
+    let stores = try await TransactionStoreTestSupport.makeStores(
       backend: backend, database: database, accounts: [account],
       earmarks: [earmark1, earmark2])
     let store = stores.transactions
@@ -130,7 +130,7 @@ struct TransactionStoreEarmarkTests {
     )
     let (backend, database) = try TestBackend.create()
     TestBackend.seed(transactions: [transaction], in: database)
-    let stores = await TransactionStoreTestSupport.makeStores(
+    let stores = try await TransactionStoreTestSupport.makeStores(
       backend: backend, database: database, accounts: [account])
     let store = stores.transactions
     let accountStore = stores.accounts
@@ -176,7 +176,7 @@ struct TransactionStoreEarmarkTests {
     )
     let (backend, database) = try TestBackend.create()
     TestBackend.seed(transactions: [scheduled], in: database)
-    let stores = await TransactionStoreTestSupport.makeStores(
+    let stores = try await TransactionStoreTestSupport.makeStores(
       backend: backend, database: database, accounts: [account])
     let store = stores.transactions
     let accountStore = stores.accounts
@@ -212,7 +212,7 @@ struct TransactionStoreEarmarkTests {
     )
     let (backend, database) = try TestBackend.create()
     TestBackend.seed(transactions: [scheduled], in: database)
-    let stores = await TransactionStoreTestSupport.makeStores(
+    let stores = try await TransactionStoreTestSupport.makeStores(
       backend: backend, database: database, accounts: [account])
     let store = stores.transactions
     let accountStore = stores.accounts

--- a/MoolahTests/Features/TransactionStoreTransferTests.swift
+++ b/MoolahTests/Features/TransactionStoreTransferTests.swift
@@ -26,7 +26,7 @@ struct TransactionStoreTransferTests {
     )
     let (backend, database) = try TestBackend.create()
     TestBackend.seed(transactions: [transaction], in: database)
-    let stores = await TransactionStoreTestSupport.makeStores(
+    let stores = try await TransactionStoreTestSupport.makeStores(
       backend: backend, database: database, accounts: [checking, savings])
     let (store, accountStore) = (stores.transactions, stores.accounts)
     await store.load(filter: TransactionFilter(accountId: accountId))
@@ -135,7 +135,7 @@ struct TransactionStoreTransferTests {
     )
     let (backend, database) = try TestBackend.create()
     TestBackend.seed(transactions: [transfer], in: database)
-    let stores = await TransactionStoreTestSupport.makeStores(
+    let stores = try await TransactionStoreTestSupport.makeStores(
       backend: backend, database: database, accounts: [checking, savings, investment])
     return ThreeAccountTransferSeed(stores: stores, transfer: transfer)
   }

--- a/MoolahTests/Support/TransactionStoreTestSupport.swift
+++ b/MoolahTests/Support/TransactionStoreTestSupport.swift
@@ -68,7 +68,7 @@ enum TransactionStoreTestSupport {
     database: any DatabaseWriter,
     accounts: [SeededAccount] = [],
     earmarks: [Earmark] = []
-  ) async -> Stores {
+  ) async throws -> Stores {
     if !accounts.isEmpty {
       let tuples = accounts.map { ($0.account, $0.openingBalance) }
       TestBackend.seed(accounts: tuples, in: database)
@@ -91,19 +91,19 @@ enum TransactionStoreTestSupport {
     // TransactionStore code path that depends on them being visible
     // runs. Without seeded entries the first emission is enough.
     if accounts.isEmpty {
-      try? await accountStore.waitForFirstEmission()
+      try await accountStore.waitForFirstEmission()
     } else {
       let expectedCount = accounts.count
-      try? await accountStore.waitForNextEmission(
+      try await accountStore.waitForNextEmission(
         matching: { $0.accounts.count == expectedCount },
         description: "seeded accounts observable"
       )
     }
     if earmarks.isEmpty {
-      try? await earmarkStore.waitForFirstEmission()
+      try await earmarkStore.waitForFirstEmission()
     } else {
       let expectedCount = earmarks.count
-      try? await earmarkStore.waitForNextEmission(
+      try await earmarkStore.waitForNextEmission(
         matching: { $0.earmarks.count == expectedCount },
         description: "seeded earmarks observable"
       )


### PR DESCRIPTION
## Summary

- `try? await waitForFirstEmission()` / `waitForNextEmission(...)` was silently swallowing `StoreEmissionTimeoutError`. When a CI emission was slow, the next call ran against a stale store snapshot and threw a misleading downstream error (e.g. `.accountNotFound(…)`).
- Drops `try?` → `try` across every emission-wait site in MoolahTests so timeouts now propagate with their original `"Timed out waiting for <Store> emission matching <predicate>"` message.
- Also widens `TransactionStoreTestSupport.makeStores` to `async throws` and updates its three callers.

Fixes #1002

## Test plan

- [x] `just build-mac`
- [x] `just test-mac` over all affected suites — 41 tests, 0 failures
- [x] `just format-check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)