### PR TITLE
fix(a11y): drop redundant "Amount" label on InstrumentAmountView

### DIFF
--- a/Shared/InstrumentAmountView.swift
+++ b/Shared/InstrumentAmountView.swift
@@ -23,7 +23,7 @@ struct InstrumentAmountView: View {
       .foregroundStyle(effectiveColor)
       .monospacedDigit()
       .font(font)
-      .accessibilityLabel(Text(amount.accessibilityString(isSpam: isSpamInstrument)))
+      .accessibilityValue(amount.accessibilityString(isSpam: isSpamInstrument))
   }
 
   private var text: Text {

--- a/Shared/InstrumentAmountView.swift
+++ b/Shared/InstrumentAmountView.swift
@@ -23,8 +23,7 @@ struct InstrumentAmountView: View {
       .foregroundStyle(effectiveColor)
       .monospacedDigit()
       .font(font)
-      .accessibilityLabel(Text("Amount"))
-      .accessibilityValue(amount.accessibilityString(isSpam: isSpamInstrument))
+      .accessibilityLabel(Text(amount.accessibilityString(isSpam: isSpamInstrument)))
   }
 
   private var text: Text {


### PR DESCRIPTION
## Summary

- `Shared/InstrumentAmountView.swift` hardcoded `.accessibilityLabel("Amount")`, so every row that wraps it in a `LabeledContent` or `.accessibilityElement(children: .combine)` was announced as "Current Total, Amount, $50.00" — the literal "Amount" interjection broke the natural cadence with no extra information.
- Collapse the label/value pair into a single `.accessibilityLabel` carrying the spam-aware formatted string. VoiceOver now reads "Current Total, $50.00" inside combined surfaces and the formatted amount (or "`<magnitude>` spam token") when used standalone.

Fixes #998

## Test plan

- [x] `just format-check`
- [x] `just build-mac`
- [x] `just test-mac` (full suite passes; `InstrumentAmount.accessibilityString` model tests still green)
- [ ] Manual VoiceOver pass on sidebar totals (Current Total / Available Funds / Net Worth) — visual experience is unaffected