### PR TITLE
fix(profile-window): enforce one window per profile at startup

### DIFF
--- a/App/ProfileWindowLocator.swift
+++ b/App/ProfileWindowLocator.swift
@@ -49,13 +49,25 @@
 
     /// `true` when any window in `windows` is tagged with a per-profile
     /// identifier (i.e. some profile is presented in a
-    /// `ProfileWindowView`). Used by
-    /// `ProfileWindowView.nilBindingIsRedundant` so a state-restored
-    /// nil-binding window can dismiss itself instead of lingering on a
-    /// Welcome screen beside an already-presented profile.
+    /// `ProfileWindowView`).
     @MainActor
     static func anyProfileWindowPresent(in windows: [NSWindow]) -> Bool {
+      anyOtherProfileWindowPresent(excluding: nil, in: windows)
+    }
+
+    /// `true` when any window in `windows` other than `currentWindow`
+    /// is tagged with a per-profile identifier. Used by
+    /// `ProfileWindowView.nilBindingIsRedundant` so a state-restored
+    /// nil-binding window can dismiss itself instead of lingering on a
+    /// Welcome screen beside an already-presented profile — without
+    /// counting itself as a sibling once `tagHostingWindow` has
+    /// stamped its own identifier.
+    @MainActor
+    static func anyOtherProfileWindowPresent(
+      excluding currentWindow: NSWindow?, in windows: [NSWindow]
+    ) -> Bool {
       windows.contains { window in
+        guard window !== currentWindow else { return false }
         guard let raw = window.identifier?.rawValue else { return false }
         return raw.hasPrefix(identifierPrefix)
       }

--- a/App/ProfileWindowLocator.swift
+++ b/App/ProfileWindowLocator.swift
@@ -1,6 +1,7 @@
 #if os(macOS)
   import AppKit
   import Foundation
+  import SwiftUI
 
   /// Finds and activates the existing window for a profile without going
   /// through the `moolah://` URL scheme — used by AppleScript and App Intents
@@ -11,10 +12,15 @@
   /// `ProfileWindowView` via `WindowAccessor`.
   enum ProfileWindowLocator {
 
+    /// Common prefix on every per-profile window identifier — exposed so
+    /// `anyProfileWindowPresent(in:)` can detect "any profile window is
+    /// on screen" without enumerating profile IDs.
+    static let identifierPrefix = "moolah.profile."
+
     /// Stable per-profile identifier; matches the one `ProfileWindowView`
     /// writes to `NSWindow.identifier`.
     static func identifier(for profileID: UUID) -> NSUserInterfaceItemIdentifier {
-      NSUserInterfaceItemIdentifier("moolah.profile.\(profileID.uuidString)")
+      NSUserInterfaceItemIdentifier("\(identifierPrefix)\(profileID.uuidString)")
     }
 
     /// Returns the first window in `windows` whose identifier matches the
@@ -24,6 +30,35 @@
     static func existingWindow(for profileID: UUID, in windows: [NSWindow]) -> NSWindow? {
       let target = identifier(for: profileID)
       return windows.first { $0.identifier == target }
+    }
+
+    /// Returns a window in `windows` tagged for `profileID` that is not
+    /// `currentWindow` — i.e. a duplicate. Used by
+    /// `ProfileWindowView.tagHostingWindow` to detect and close
+    /// duplicates. Returning a value means the caller should close
+    /// `currentWindow` and focus the returned window.
+    @MainActor
+    static func duplicateWindow(
+      for profileID: UUID,
+      currentWindow: NSWindow,
+      in windows: [NSWindow]
+    ) -> NSWindow? {
+      let target = identifier(for: profileID)
+      return windows.first { $0 !== currentWindow && $0.identifier == target }
+    }
+
+    /// `true` when any window in `windows` is tagged with a per-profile
+    /// identifier (i.e. some profile is presented in a
+    /// `ProfileWindowView`). Used by
+    /// `ProfileWindowView.nilBindingIsRedundant` so a state-restored
+    /// nil-binding window can dismiss itself instead of lingering on a
+    /// Welcome screen beside an already-presented profile.
+    @MainActor
+    static func anyProfileWindowPresent(in windows: [NSWindow]) -> Bool {
+      windows.contains { window in
+        guard let raw = window.identifier?.rawValue else { return false }
+        return raw.hasPrefix(identifierPrefix)
+      }
     }
 
     /// Brings the worktree's existing window for the profile to the front.
@@ -39,6 +74,25 @@
       NSApp.activate(ignoringOtherApps: true)
       window.makeKeyAndOrderFront(nil)
       return true
+    }
+
+    /// Focuses the existing window for the profile if one is on screen,
+    /// otherwise calls `openWindow(value:)` to create a new one. Every
+    /// in-app caller that opens a profile window goes through this helper
+    /// so we never request a second window for a profile that is already
+    /// presented — the one-window-per-profile invariant.
+    ///
+    /// Defence in depth alongside the duplicate-window guard in
+    /// `ProfileWindowView.tagHostingWindow`: that guard will close any
+    /// duplicate that does slip through (e.g. SwiftUI state restoration
+    /// of a stale window from a prior version), but routing every caller
+    /// here avoids the user-visible flash of a duplicate appearing and
+    /// then closing itself.
+    @MainActor
+    static func openOrActivate(_ profileID: UUID, openWindow: OpenWindowAction) {
+      if !activateExistingWindow(for: profileID) {
+        openWindow(value: profileID)
+      }
     }
   }
 #endif

--- a/App/ProfileWindowView.swift
+++ b/App/ProfileWindowView.swift
@@ -17,6 +17,14 @@
 
     @State private var sessionResult: SessionOpenResult?
 
+    /// The `NSWindow` this view is hosted in, captured by `tagHostingWindow`
+    /// via `WindowAccessor`. Used by `resolvedProfile` and
+    /// `nilBindingIsRedundant` to exclude self when scanning `NSApp.windows`
+    /// for sibling profile windows — without this, once `tagHostingWindow`
+    /// stamps our identifier the checks would find *us*, decide we're a
+    /// duplicate of ourselves, and dismiss the live window.
+    @State private var hostingWindow: NSWindow?
+
     /// Resolve the profile to display: the window's profileID if it matches a
     /// known profile, otherwise the active profile, otherwise the single
     /// profile when exactly one exists.
@@ -38,7 +46,8 @@
       }
       let fallback = fallbackProfile()
       if let fallback,
-        ProfileWindowLocator.existingWindow(for: fallback.id, in: NSApp.windows) != nil
+        let owner = ProfileWindowLocator.existingWindow(for: fallback.id, in: NSApp.windows),
+        owner !== hostingWindow
       {
         return nil
       }
@@ -61,10 +70,13 @@
     /// classic duplicate-after-state-restoration shape. Drives `dismiss()`
     /// in the WelcomeView branch of `body` so the redundant window goes
     /// away instead of lingering on a Welcome screen beside the real one.
+    /// Excludes `hostingWindow` so a window that has tagged itself does
+    /// not count itself as a sibling.
     private var nilBindingIsRedundant: Bool {
       profileID == nil
         && !profileStore.profiles.isEmpty
-        && ProfileWindowLocator.anyProfileWindowPresent(in: NSApp.windows)
+        && ProfileWindowLocator.anyOtherProfileWindowPresent(
+          excluding: hostingWindow, in: NSApp.windows)
     }
 
     var body: some View {
@@ -194,6 +206,14 @@
     @ViewBuilder private var tagHostingWindow: some View {
       if let profile = resolvedProfile {
         WindowAccessor { window in
+          // Capture the hosting window so `resolvedProfile` and
+          // `nilBindingIsRedundant` can exclude self when scanning
+          // siblings. Without this they would later find this window's
+          // own identifier and dismiss the live window as a "duplicate
+          // of itself."
+          if hostingWindow !== window {
+            hostingWindow = window
+          }
           let identifier = ProfileWindowLocator.identifier(for: profile.id)
           // Load-bearing duplicate-window guard. Catches every dup
           // regardless of how it was created: SwiftUI scene-state

--- a/App/ProfileWindowView.swift
+++ b/App/ProfileWindowView.swift
@@ -18,22 +18,53 @@
     @State private var sessionResult: SessionOpenResult?
 
     /// Resolve the profile to display: the window's profileID if it matches a
-    /// known profile, otherwise the active profile. Falls back to the single
-    /// profile only when exactly one exists — with 2+ profiles and nothing
-    /// selected, `WelcomeView` shows its picker (state 5) instead of
-    /// silently opening one of them.
+    /// known profile, otherwise the active profile, otherwise the single
+    /// profile when exactly one exists.
+    ///
+    /// The two fallback branches (`activeProfileID`, `profiles.count == 1`)
+    /// only fire when this window has no value binding — i.e. a nil-binding
+    /// window restored from prior SwiftUI scene state, or one opened
+    /// without a value. If another NSWindow is already tagged with the
+    /// candidate profile's identifier, the fallback returns `nil` so the
+    /// nil-binding window doesn't shadow its sibling. The body's WelcomeView
+    /// branch then dismisses the redundant window via `nilBindingIsRedundant`.
+    /// Without this guard the same profile would render in two windows
+    /// after every launch.
     private var resolvedProfile: Profile? {
       if let profileID,
         let profile = profileStore.profiles.first(where: { $0.id == profileID })
       {
         return profile
       }
+      let fallback = fallbackProfile()
+      if let fallback,
+        ProfileWindowLocator.existingWindow(for: fallback.id, in: NSApp.windows) != nil
+      {
+        return nil
+      }
+      return fallback
+    }
+
+    /// Pure fallback resolution split out so `resolvedProfile` applies
+    /// the duplicate-window guard uniformly to both branches.
+    private func fallbackProfile() -> Profile? {
       if let activeID = profileStore.activeProfileID,
         let profile = profileStore.profiles.first(where: { $0.id == activeID })
       {
         return profile
       }
       return profileStore.profiles.count == 1 ? profileStore.profiles.first : nil
+    }
+
+    /// `true` when this nil-binding window has no profile to show *and*
+    /// another window already presents a profile-bound view — the
+    /// classic duplicate-after-state-restoration shape. Drives `dismiss()`
+    /// in the WelcomeView branch of `body` so the redundant window goes
+    /// away instead of lingering on a Welcome screen beside the real one.
+    private var nilBindingIsRedundant: Bool {
+      profileID == nil
+        && !profileStore.profiles.isEmpty
+        && ProfileWindowLocator.anyProfileWindowPresent(in: NSApp.windows)
     }
 
     var body: some View {
@@ -51,16 +82,34 @@
               )
               dismiss()
             }
+        } else if nilBindingIsRedundant {
+          // State restoration brought back a nil-binding window beside a
+          // value-bound one for the same profile (the "two windows for
+          // one profile" shape). Drop the redundant window — the user
+          // keeps the explicit profile-bound window.
+          Color.clear
+            .onAppear {
+              logger.info(
+                "Dismissing redundant nil-binding window — profile-bound window already on screen"
+              )
+              dismiss()
+            }
         } else {
           // No specific profile requested AND no active profile. Covers
           // both the empty first-run case (`!hasProfiles` → hero state 1)
           // and the multi-profile-no-selection case (2+ profiles, none
           // picked → picker state 5). `WelcomeView`'s state machine
           // picks the right branch.
+          //
+          // On first-profile creation, dismiss *this* nil-binding window
+          // after opening the profile-bound one. Otherwise the original
+          // Welcome window stays on screen and `resolvedProfile` falls
+          // back to the new single profile, producing the duplicate.
           WelcomeView()
             .onChange(of: profileStore.profiles) { _, newProfiles in
               if newProfiles.count == 1, let first = newProfiles.first {
-                openWindow(value: first.id)
+                ProfileWindowLocator.openOrActivate(first.id, openWindow: openWindow)
+                dismiss()
               }
             }
         }
@@ -139,13 +188,35 @@
     /// Stamps the hosting `NSWindow.identifier` with a per-profile identifier
     /// so `ProfileWindowLocator` can find and focus the window when
     /// AppleScript or an App Intent opens a profile that is already on
-    /// screen. Also maximises the window and opts out of per-window state
-    /// restoration under UI testing — see the inline comment for the
-    /// motivating layout race.
+    /// screen. Also enforces the one-window-per-profile invariant by
+    /// closing this window when another window is already tagged for the
+    /// resolved profile, and maximises the window under UI testing.
     @ViewBuilder private var tagHostingWindow: some View {
       if let profile = resolvedProfile {
         WindowAccessor { window in
-          window.identifier = ProfileWindowLocator.identifier(for: profile.id)
+          let identifier = ProfileWindowLocator.identifier(for: profile.id)
+          // Load-bearing duplicate-window guard. Catches every dup
+          // regardless of how it was created: SwiftUI scene-state
+          // restoration of a stale window from a prior version, a
+          // racing `openWindow(value:)` that slipped past
+          // `ProfileWindowLocator.openOrActivate`, even Cmd-N if AppKit
+          // ever auto-opens a nil-bound window. The losing window
+          // closes via the next runloop turn — closing from inside
+          // `viewDidMoveToWindow` would tear down our own host view
+          // mid-callback.
+          if let existing = ProfileWindowLocator.duplicateWindow(
+            for: profile.id, currentWindow: window, in: NSApp.windows)
+          {
+            logger.warning(
+              "Closing duplicate window for profileID=\(profile.id, privacy: .public)"
+            )
+            existing.makeKeyAndOrderFront(nil)
+            Task { @MainActor in
+              window.close()
+            }
+            return
+          }
+          window.identifier = identifier
           // CI runs on a 1024×768 macos-26 display. The Brokerage-view
           // inspector then renders ~217pt tall — not enough to fit the
           // trade-mode form, so `Received` falls below the visible scroll

--- a/Features/Export/ExportImportButtons.swift
+++ b/Features/Export/ExportImportButtons.swift
@@ -78,7 +78,7 @@
           containerManager: containerManager,
           syncCoordinator: syncCoordinator
         )
-        openWindow(value: newProfileId)
+        ProfileWindowLocator.openOrActivate(newProfileId, openWindow: openWindow)
       } catch {
         await present(NSAlert(error: error))
       }

--- a/Features/Profiles/ProfileCommands.swift
+++ b/Features/Profiles/ProfileCommands.swift
@@ -47,7 +47,7 @@
       Menu("Open Profile") {
         ForEach(profileStore.profiles) { profile in
           Button(profile.label) {
-            openWindow(value: profile.id)
+            ProfileWindowLocator.openOrActivate(profile.id, openWindow: openWindow)
           }
         }
 

--- a/Features/Profiles/Views/ProfileFormView.swift
+++ b/Features/Profiles/Views/ProfileFormView.swift
@@ -89,7 +89,7 @@ struct ProfileFormView: View {
 
     if await profileStore.validateAndAddProfile(profile) {
       #if os(macOS)
-        openWindow(value: profile.id)
+        ProfileWindowLocator.openOrActivate(profile.id, openWindow: openWindow)
       #else
         profileStore.setActiveProfile(profile.id)
       #endif

--- a/MoolahTests/Automation/ProfileWindowLocatorTests.swift
+++ b/MoolahTests/Automation/ProfileWindowLocatorTests.swift
@@ -158,5 +158,39 @@
       settings.identifier = NSUserInterfaceItemIdentifier("settings")
       #expect(ProfileWindowLocator.anyProfileWindowPresent(in: [about, settings]) == false)
     }
+
+    // MARK: - anyOtherProfileWindowPresent
+
+    @Test("anyOtherProfileWindowPresent excludes the supplied window")
+    func presenceExcludesSelf() {
+      let mine = NSWindow()
+      mine.identifier = ProfileWindowLocator.identifier(for: UUID())
+      #expect(
+        ProfileWindowLocator.anyOtherProfileWindowPresent(
+          excluding: mine, in: [mine]) == false
+      )
+    }
+
+    @Test("anyOtherProfileWindowPresent finds a sibling profile window")
+    func presenceFindsSibling() {
+      let mine = NSWindow()
+      mine.identifier = ProfileWindowLocator.identifier(for: UUID())
+      let sibling = NSWindow()
+      sibling.identifier = ProfileWindowLocator.identifier(for: UUID())
+      #expect(
+        ProfileWindowLocator.anyOtherProfileWindowPresent(
+          excluding: mine, in: [mine, sibling]) == true
+      )
+    }
+
+    @Test("anyOtherProfileWindowPresent with no exclusion matches anyProfileWindowPresent")
+    func presenceWithoutExclusionParity() {
+      let tagged = NSWindow()
+      tagged.identifier = ProfileWindowLocator.identifier(for: UUID())
+      #expect(
+        ProfileWindowLocator.anyOtherProfileWindowPresent(excluding: nil, in: [tagged])
+          == ProfileWindowLocator.anyProfileWindowPresent(in: [tagged])
+      )
+    }
   }
 #endif

--- a/MoolahTests/Automation/ProfileWindowLocatorTests.swift
+++ b/MoolahTests/Automation/ProfileWindowLocatorTests.swift
@@ -67,5 +67,96 @@
       let found = ProfileWindowLocator.existingWindow(for: profileID, in: [untagged, tagged])
       #expect(found === tagged)
     }
+
+    // MARK: - duplicateWindow
+
+    @Test("duplicateWindow returns nil when only currentWindow has the identifier")
+    func noDuplicateWhenOnlyCurrentMatches() {
+      let profileID = UUID()
+      let current = NSWindow()
+      current.identifier = ProfileWindowLocator.identifier(for: profileID)
+      let untagged = NSWindow()
+
+      let dup = ProfileWindowLocator.duplicateWindow(
+        for: profileID, currentWindow: current, in: [current, untagged])
+      #expect(dup == nil)
+    }
+
+    @Test("duplicateWindow finds the sibling window when another matches")
+    func findsSiblingMatch() {
+      let profileID = UUID()
+      let current = NSWindow()
+      let sibling = NSWindow()
+      sibling.identifier = ProfileWindowLocator.identifier(for: profileID)
+
+      let dup = ProfileWindowLocator.duplicateWindow(
+        for: profileID, currentWindow: current, in: [current, sibling])
+      #expect(dup === sibling)
+    }
+
+    @Test("duplicateWindow never returns currentWindow even when tagged")
+    func ignoresSelfMatch() {
+      let profileID = UUID()
+      let current = NSWindow()
+      current.identifier = ProfileWindowLocator.identifier(for: profileID)
+
+      let dup = ProfileWindowLocator.duplicateWindow(
+        for: profileID, currentWindow: current, in: [current])
+      #expect(dup == nil)
+    }
+
+    @Test("duplicateWindow returns nil for an empty windows list")
+    func emptyWindowsReturnsNil() {
+      let current = NSWindow()
+      let dup = ProfileWindowLocator.duplicateWindow(
+        for: UUID(), currentWindow: current, in: [])
+      #expect(dup == nil)
+    }
+
+    @Test("duplicateWindow ignores windows tagged for a different profile")
+    func ignoresDifferentProfile() {
+      let profileA = UUID()
+      let profileB = UUID()
+      let current = NSWindow()
+      let sibling = NSWindow()
+      sibling.identifier = ProfileWindowLocator.identifier(for: profileB)
+
+      let dup = ProfileWindowLocator.duplicateWindow(
+        for: profileA, currentWindow: current, in: [current, sibling])
+      #expect(dup == nil)
+    }
+
+    // MARK: - anyProfileWindowPresent
+
+    @Test("anyProfileWindowPresent is false for an empty windows list")
+    func presenceEmptyList() {
+      #expect(ProfileWindowLocator.anyProfileWindowPresent(in: []) == false)
+    }
+
+    @Test("anyProfileWindowPresent is false for windows with no identifier")
+    func presenceUntaggedOnly() {
+      let first = NSWindow()
+      let second = NSWindow()
+      #expect(ProfileWindowLocator.anyProfileWindowPresent(in: [first, second]) == false)
+    }
+
+    @Test("anyProfileWindowPresent is true when any window is profile-tagged")
+    func presenceWithProfileTagged() {
+      let untagged = NSWindow()
+      let profileWindow = NSWindow()
+      profileWindow.identifier = ProfileWindowLocator.identifier(for: UUID())
+      #expect(
+        ProfileWindowLocator.anyProfileWindowPresent(in: [untagged, profileWindow]) == true
+      )
+    }
+
+    @Test("anyProfileWindowPresent ignores non-profile identifiers")
+    func presenceIgnoresUnrelatedIdentifiers() {
+      let about = NSWindow()
+      about.identifier = NSUserInterfaceItemIdentifier("about")
+      let settings = NSWindow()
+      settings.identifier = NSUserInterfaceItemIdentifier("settings")
+      #expect(ProfileWindowLocator.anyProfileWindowPresent(in: [about, settings]) == false)
+    }
   }
 #endif


### PR DESCRIPTION
## Summary

A single profile could end up rendered in two windows at startup. This is a recurring shape: prior fixes (#378, #386) addressed the URL-scheme and AppleScript paths but never closed the gap inside the SwiftUI `WindowGroup(for:)` itself, so the bug kept resurfacing through state restoration and the Welcome → create flow.

## Root cause

Three independent paths conspired:

1. **WelcomeView upgrade** — `App/ProfileWindowView.swift:60-65` called `openWindow(value: first.id)` on first-profile creation without closing the original nil-binding Welcome window. That window's `resolvedProfile` then fell through its `profiles.count == 1` fallback and rendered the same profile.
2. **State restoration** — `WindowGroup(for: Profile.ID.self)` restores all prior windows including nil-binding ones. The `activeProfileID` / `profiles.count == 1` fallbacks in `resolvedProfile` (`App/ProfileWindowView.swift:25-37`) let those nil-binding windows silently adopt whichever profile a sibling window was already showing.
3. **In-app callers** — `ProfileCommands`, `ProfileFormView`, `ExportImportButtons` called `openWindow(value:)` unconditionally, even when a window for that profile was already on screen.

## Fix

Three layers of defence make "two windows for one profile" unrepresentable:

- **Layer 1 — duplicate guard at `WindowAccessor`.** `tagHostingWindow` (`ProfileWindowView.swift`) detects another `NSWindow` already tagged with the resolved profile's identifier, focuses it, and closes this window on the next runloop turn. Catches every duplicate regardless of how it was created — state restoration of a stale window, Cmd-N, future entry points.
- **Layer 2 — `ProfileWindowLocator.openOrActivate`.** New helper that calls `activateExistingWindow` first; all in-app `openWindow(value:)` callers now route through it so a duplicate is never requested in the first place. Avoids the user-visible flash of a duplicate appearing and closing itself.
- **Layer 3 — tightened `resolvedProfile` + redundant-window dismiss.** Fallback branches now skip when another window already owns the candidate profile, and a new `nilBindingIsRedundant` path dismisses any restored nil-binding window that lingered beside a profile-bound one. The WelcomeView upgrade now also dismisses the original window after opening the new profile-bound one, eliminating the original generator.

Two pure helpers (`duplicateWindow(for:currentWindow:in:)` and `anyProfileWindowPresent(in:)`) are added to `ProfileWindowLocator` and exercised by 9 new unit tests.

## Test plan

- [x] `just format-check` — clean (4 pre-existing CI-SwiftLint-version violations from 69f98571 unchanged)
- [x] `just build-mac` — succeeds
- [x] `just test-mac` — full macOS suite green (4129 tests pass, 16 in `ProfileWindowLocatorTests`)
- [ ] Manual: launch the app — observe one window per profile at startup
- [ ] Manual: create a fresh profile from Welcome — observe the Welcome window is replaced by the profile window, not duplicated
- [ ] Manual: invoke File → Open Profile → X while X is already open — observe the existing window is focused, not a duplicate

🤖 Generated with [Claude Code](https://claude.com/claude-code)