### PR TITLE
fix: declare com.moolah.sidebar-item exported UTI in Info.plist

### DIFF
--- a/App/Info-iOS.plist
+++ b/App/Info-iOS.plist
@@ -73,5 +73,18 @@
             </array>
         </dict>
     </array>
+    <key>UTExportedTypeDeclarations</key>
+    <array>
+        <dict>
+            <key>UTTypeIdentifier</key>
+            <string>com.moolah.sidebar-item</string>
+            <key>UTTypeDescription</key>
+            <string>Moolah Sidebar Item</string>
+            <key>UTTypeConformsTo</key>
+            <array>
+                <string>public.data</string>
+            </array>
+        </dict>
+    </array>
 </dict>
 </plist>

--- a/App/Info-macOS.plist
+++ b/App/Info-macOS.plist
@@ -59,5 +59,18 @@
             </array>
         </dict>
     </array>
+    <key>UTExportedTypeDeclarations</key>
+    <array>
+        <dict>
+            <key>UTTypeIdentifier</key>
+            <string>com.moolah.sidebar-item</string>
+            <key>UTTypeDescription</key>
+            <string>Moolah Sidebar Item</string>
+            <key>UTTypeConformsTo</key>
+            <array>
+                <string>public.data</string>
+            </array>
+        </dict>
+    </array>
 </dict>
 </plist>


### PR DESCRIPTION
## Problem

The runtime logs (reported on iOS, applies to macOS too) repeatedly emit:

> Type "com.moolah.sidebar-item" was expected to be declared and exported in the Info.plist of Moolah.app, but it was not found.

## Root cause

Sidebar drag-and-drop builds its `Transferable` payload on a bespoke UTI:

```swift
// Features/Navigation/SidebarView+Groups.swift
static var moolahSidebarItem: UTType {
  UTType(exportedAs: "com.moolah.sidebar-item")
}
```

The `UTType(exportedAs:)` API contract requires a matching `UTExportedTypeDeclarations` entry in the app's Info.plist. Neither `App/Info-iOS.plist` nor `App/Info-macOS.plist` declared it, so every type resolution logged the warning. Functionality was unaffected (the type still works as a session-local pasteboard type), but the missing declaration is the documented cause of the log noise.

## Fix

Declare the exported type in both app Info.plists, conforming to `public.data` (matching the Codable JSON `CodableRepresentation`).

## Verification

- `just build-mac` succeeds; Info.plist validation passes.
- The declaration is present in the built bundle.
- After launch, LaunchServices registers the type as `active exported trusted` (conforms to `public.data`, owned by the Moolah bundle) — the registration that was previously missing.
- No `sidebar-item` / "expected to be declared" warning in process logs after the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)