### PR TITLE
fix(keychain): add keychain-access-groups entitlement for macOS iCloud Keychain

### DIFF
--- a/Features/Settings/CryptoSettingsView.swift
+++ b/Features/Settings/CryptoSettingsView.swift
@@ -88,10 +88,17 @@ struct CryptoSettingsView: View {
         alchemyStatusBadge
       }
     } footer: {
-      Text(
-        "Required to auto-import on-chain transactions for crypto wallet accounts. "
-          + "A free Alchemy key is sufficient for personal use."
-      )
+      VStack(alignment: .leading, spacing: 6) {
+        if let error = store.error {
+          Text(error)
+            .foregroundStyle(.red)
+            .textSelection(.enabled)
+        }
+        Text(
+          "Required to auto-import on-chain transactions for crypto wallet accounts. "
+            + "A free Alchemy key is sufficient for personal use."
+        )
+      }
     }
   }
 

--- a/Features/Settings/CryptoTokenStore.swift
+++ b/Features/Settings/CryptoTokenStore.swift
@@ -321,7 +321,10 @@ final class CryptoTokenStore {
   func saveApiKey(_ key: String) {
     do {
       try apiKeyStore.saveString(key)
+      self.error = nil
     } catch {
+      logger.error(
+        "CoinGecko API key save failed: \(error.localizedDescription, privacy: .public)")
       self.error = "Failed to save API key: \(error.localizedDescription)"
     }
   }
@@ -335,9 +338,10 @@ final class CryptoTokenStore {
   // The Alchemy key drives the wallet auto-import.
   // `ProfileSession.resolveAlchemyApiKey()` reads from the same
   // `(service, account)` keychain entry, so a write here is picked up
-  // by the next sync cycle without further plumbing. Privacy: never
-  // logged. Failures surface via the store's `error` string only —
-  // the underlying `OSStatus` never appears in `os.Logger`.
+  // by the next sync cycle without further plumbing. The key value
+  // itself is never logged; failure paths log only the wrapping
+  // `error.localizedDescription` (which carries the underlying
+  // `OSStatus` via `KeychainError`).
 
   /// `true` when an Alchemy API key is configured in the synced
   /// Keychain. Read on every UI render to drive the status badge —
@@ -357,7 +361,10 @@ final class CryptoTokenStore {
   func saveAlchemyApiKey(_ key: String) {
     do {
       try alchemyKeyStore.saveString(key)
+      self.error = nil
     } catch {
+      logger.error(
+        "Alchemy API key save failed: \(error.localizedDescription, privacy: .public)")
       self.error = "Failed to save Alchemy API key: \(error.localizedDescription)"
     }
   }

--- a/Shared/KeychainStore.swift
+++ b/Shared/KeychainStore.swift
@@ -1,10 +1,33 @@
 import Foundation
+import OSLog
 import Security
 
-enum KeychainError: Error {
+enum KeychainError: LocalizedError {
   case saveFailed(OSStatus)
   case readFailed(OSStatus)
+
+  /// Human-readable description that includes the underlying `OSStatus`
+  /// and Apple's localised string for it. The raw status code surfaces
+  /// even when `SecCopyErrorMessageString` returns nil (some codes have
+  /// no human string on macOS).
+  var errorDescription: String? {
+    switch self {
+    case .saveFailed(let status):
+      return "Keychain save failed (OSStatus \(status): \(Self.message(for: status)))"
+    case .readFailed(let status):
+      return "Keychain read failed (OSStatus \(status): \(Self.message(for: status)))"
+    }
+  }
+
+  private static func message(for status: OSStatus) -> String {
+    if let message = SecCopyErrorMessageString(status, nil) {
+      return message as String
+    }
+    return "no description"
+  }
 }
+
+private let keychainLogger = Logger(subsystem: "com.moolah.app", category: "KeychainStore")
 
 /// Generic Keychain wrapper supporting Data and String values, with optional iCloud sync.
 ///
@@ -24,13 +47,28 @@ struct KeychainStore: Sendable {
 
   func saveData(_ data: Data) throws {
     let query = baseQuery()
-    SecItemDelete(query as CFDictionary)
+    let deleteStatus = SecItemDelete(query as CFDictionary)
+    keychainLogger.info(
+      """
+      saveData: service=\(self.service, privacy: .public) \
+      account=\(self.account, privacy: .public) \
+      synchronizable=\(self.synchronizable, privacy: .public) \
+      deleteStatus=\(deleteStatus, privacy: .public)
+      """
+    )
 
     var addQuery = query
     addQuery[kSecValueData as String] = data
     addQuery[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlock
 
     let status = SecItemAdd(addQuery as CFDictionary, nil)
+    keychainLogger.info(
+      """
+      saveData: service=\(self.service, privacy: .public) \
+      account=\(self.account, privacy: .public) \
+      addStatus=\(status, privacy: .public)
+      """
+    )
     guard status == errSecSuccess else {
       throw KeychainError.saveFailed(status)
     }
@@ -43,6 +81,14 @@ struct KeychainStore: Sendable {
 
     var result: AnyObject?
     let status = SecItemCopyMatching(query as CFDictionary, &result)
+    keychainLogger.info(
+      """
+      restoreData: service=\(self.service, privacy: .public) \
+      account=\(self.account, privacy: .public) \
+      synchronizable=\(self.synchronizable, privacy: .public) \
+      copyStatus=\(status, privacy: .public)
+      """
+    )
 
     switch status {
     case errSecSuccess:

--- a/fastlane/Moolah-mac.entitlements
+++ b/fastlane/Moolah-mac.entitlements
@@ -21,5 +21,10 @@
   <true/>
   <key>com.apple.security.application-groups</key>
   <array><string>group.rocks.moolah.shared</string></array>
+  <!-- Required on macOS for SecItem* with kSecAttrSynchronizable=true.
+       See scripts/inject-entitlements.sh for the equivalent block on
+       Debug builds and the rationale. -->
+  <key>keychain-access-groups</key>
+  <array><string>$(AppIdentifierPrefix)rocks.moolah.app</string></array>
 </dict>
 </plist>

--- a/fastlane/Moolah.entitlements
+++ b/fastlane/Moolah.entitlements
@@ -14,5 +14,10 @@
   <true/>
   <key>com.apple.security.application-groups</key>
   <array><string>group.rocks.moolah.shared</string></array>
+  <!-- Required on macOS for SecItem* with kSecAttrSynchronizable=true.
+       See scripts/inject-entitlements.sh for the equivalent block on
+       Debug builds and the rationale. -->
+  <key>keychain-access-groups</key>
+  <array><string>$(AppIdentifierPrefix)rocks.moolah.app</string></array>
 </dict>
 </plist>

--- a/scripts/inject-entitlements.sh
+++ b/scripts/inject-entitlements.sh
@@ -60,6 +60,19 @@ cat > "$ENTITLEMENTS_FILE" <<'PLIST'
     <array>
         <string>group.rocks.moolah.shared</string>
     </array>
+    <key>keychain-access-groups</key>
+    <array>
+        <!--
+          Required on macOS for SecItemAdd / SecItemCopyMatching with
+          kSecAttrSynchronizable=true (iCloud Keychain). iOS derives a
+          default access group from the bundle id; macOS does not.
+          $(AppIdentifierPrefix) is expanded by codesign from the
+          signing identity / provisioning profile. Without this entry,
+          every keychain op on a synchronizable item fails with
+          errSecMissingEntitlement (-34018).
+        -->
+        <string>$(AppIdentifierPrefix)rocks.moolah.app</string>
+    </array>
 </dict>
 </plist>
 PLIST


### PR DESCRIPTION
## Summary

Restore iCloud-Keychain API-key storage on macOS — every `SecItem*` against a `kSecAttrSynchronizable=true` row was being rejected by the OS with `errSecMissingEntitlement` (-34018), so the Alchemy + CoinGecko keys looked "lost" and new saves silently dropped.

Root cause: iOS auto-derives a default `keychain-access-groups` from the bundle id; macOS does not. Without an explicit `keychain-access-groups` entitlement, sandboxed sync writes / reads fail pre-storage. The repo's entitlement files had CloudKit, App Sandbox, and the App Group, but not this one.

- Adds `\$(AppIdentifierPrefix)rocks.moolah.app` to `scripts/inject-entitlements.sh` (Debug `.build/Moolah.entitlements`), `fastlane/Moolah.entitlements` (Release iOS), and `fastlane/Moolah-mac.entitlements` (Release macOS).
- Bundles the diagnostic plumbing that was needed to find this — silent save failures were a real product gap regardless: `KeychainError: LocalizedError` carrying the OSStatus + `SecCopyErrorMessageString`; `os.Logger` events for `saveData` / `restoreData`; write-side `logger.error` in `CryptoTokenStore`; Alchemy section footer surfaces `store.error` with `.textSelection(.enabled)`.

Existing previously-saved keys recover automatically — they were orphaned by the missing entitlement, not deleted.

Verified locally: pre-fix logs showed `restoreData … copyStatus=-34018` for both `alchemy` and `coingecko` accounts; post-fix, `alchemy` reads `copyStatus=0` (Configured badge returns without re-entering the key), `coingecko` reads `-25300` (errSecItemNotFound — never configured).

## Test plan

- [x] Reproduced -34018 from the worktree build, then rebuilt with the entitlement and confirmed `copyStatus=0` for an existing key.
- [x] UI: Crypto Settings shows "Configured" badge again with no re-entry needed.
- [x] UI: Save-failure path renders selectable red error text in the section footer.
- [ ] Verify Release-signed build (next TestFlight / `fastlane mac_dmg` lane) is accepted by the provisioning profile — if Apple's portal requires manual "Keychain Sharing" capability on the App ID, the fastlane lane will surface that and we'll add the capability via the portal.
- [ ] On iOS, confirm reads still succeed (entitlement was previously implicit; making it explicit should be a no-op).

🤖 Generated with [Claude Code](https://claude.com/claude-code)