### PR TITLE
fix(import-ext): make Safari action extension actually activate

### DIFF
--- a/MoolahImportExtension_iOS/Generated/Info.plist
+++ b/MoolahImportExtension_iOS/Generated/Info.plist
@@ -25,12 +25,10 @@
     <key>NSExtensionAttributes</key>
     <dict>
       <key>NSExtensionActivationRule</key>
-      <string>SUBQUERY(extensionItems, $item,
-  SUBQUERY($item.attachments, $att,
-    ANY $att.registeredTypeIdentifiers UTI-CONFORMS-TO "public.url"
-    AND ((($att.URL.host == "macquarie.com.au" OR $att.URL.host ENDSWITH ".macquarie.com.au") AND $att.URL.path BEGINSWITH "/io") OR (($att.URL.host == "hsbc.com.au" OR $att.URL.host ENDSWITH ".hsbc.com.au") AND $att.URL.path BEGINSWITH "/gpib") OR (($att.URL.host == "commbank.com.au" OR $att.URL.host ENDSWITH ".commbank.com.au") AND $att.URL.path BEGINSWITH "/retail/netbank") OR (($att.URL.host == "americanexpress.com" OR $att.URL.host ENDSWITH ".americanexpress.com") AND $att.URL.path BEGINSWITH "/dashboard") OR (($att.URL.host == "americanexpress.com" OR $att.URL.host ENDSWITH ".americanexpress.com") AND $att.URL.path BEGINSWITH "/activity"))
-  ).@count > 0
-).@count > 0</string>
+      <dict>
+        <key>NSExtensionActivationSupportsWebPageWithMaxCount</key>
+        <integer>1</integer>
+      </dict>
       <key>NSExtensionJavaScriptPreprocessingFile</key>
       <string>extension-entry.bundle</string>
     </dict>

--- a/MoolahImportExtension_macOS/Generated/Info.plist
+++ b/MoolahImportExtension_macOS/Generated/Info.plist
@@ -25,12 +25,10 @@
     <key>NSExtensionAttributes</key>
     <dict>
       <key>NSExtensionActivationRule</key>
-      <string>SUBQUERY(extensionItems, $item,
-  SUBQUERY($item.attachments, $att,
-    ANY $att.registeredTypeIdentifiers UTI-CONFORMS-TO "public.url"
-    AND ((($att.URL.host == "macquarie.com.au" OR $att.URL.host ENDSWITH ".macquarie.com.au") AND $att.URL.path BEGINSWITH "/io") OR (($att.URL.host == "hsbc.com.au" OR $att.URL.host ENDSWITH ".hsbc.com.au") AND $att.URL.path BEGINSWITH "/gpib") OR (($att.URL.host == "commbank.com.au" OR $att.URL.host ENDSWITH ".commbank.com.au") AND $att.URL.path BEGINSWITH "/retail/netbank") OR (($att.URL.host == "americanexpress.com" OR $att.URL.host ENDSWITH ".americanexpress.com") AND $att.URL.path BEGINSWITH "/dashboard") OR (($att.URL.host == "americanexpress.com" OR $att.URL.host ENDSWITH ".americanexpress.com") AND $att.URL.path BEGINSWITH "/activity"))
-  ).@count > 0
-).@count > 0</string>
+      <dict>
+        <key>NSExtensionActivationSupportsWebPageWithMaxCount</key>
+        <integer>1</integer>
+      </dict>
       <key>NSExtensionJavaScriptPreprocessingFile</key>
       <string>extension-entry.bundle</string>
     </dict>

--- a/justfile
+++ b/justfile
@@ -132,6 +132,14 @@ build-mac: generate
         # and need a provisioning profile registered for the extension's
         # bundle id (rocks.moolah.app.importextension).
         args+=(CODE_SIGNING_ALLOWED=NO ENABLE_HARDENED_RUNTIME=NO)
+    else
+        # Let Xcode contact the developer portal to mint / refresh
+        # provisioning profiles on demand. Required the first time
+        # `ENABLE_ENTITLEMENTS=1` injects the extension's App Group
+        # entitlement and no profile yet exists for
+        # rocks.moolah.app.importextension; without the flag,
+        # Automatic signing fails with "no profiles found".
+        args+=(-allowProvisioningUpdates)
     fi
     xcodebuild build "${args[@]}"
 
@@ -151,6 +159,9 @@ run-mac *args: generate
     build=(-scheme Moolah-macOS -destination 'platform=macOS' -derivedDataPath .build)
     if [ -z "${DEVELOPMENT_TEAM:-}" ]; then
         build+=(CODE_SIGN_IDENTITY="-" ENABLE_HARDENED_RUNTIME=NO)
+    else
+        # See `build-mac` for the rationale on -allowProvisioningUpdates.
+        build+=(-allowProvisioningUpdates)
     fi
     xcodebuild build "${build[@]}"
     if [ -n "{{args}}" ]; then

--- a/project.yml
+++ b/project.yml
@@ -227,14 +227,16 @@ targets:
         SKIP_INSTALL: YES
       configs:
         Release:
-          # Entitlements are Release-only — Debug builds the extension
-          # without the App Group capability so local builds don't need
-          # a Mac App Development provisioning profile (mirrors the main
-          # app target's pattern, see Moolah_macOS.configs.Release).
-          # Local Debug runs of the extension can't access the App Group
-          # inbox; rely on TestFlight builds for end-to-end testing of
-          # the import flow, or extend scripts/inject-entitlements.sh
-          # to inject extension entitlements at local build time.
+          # Plain `just generate` leaves Debug entitlement-free so local
+          # builds don't need a Mac App Development provisioning profile
+          # (mirrors the main app target's pattern, see
+          # Moolah_macOS.configs.Release). `ENABLE_ENTITLEMENTS=1 just
+          # generate` opts in: scripts/inject-entitlements.sh injects a
+          # Debug: block that points at this same entitlements file, so
+          # the .appex is signed with the App Group and macOS pluginkit
+          # registers it. Without that flag, the Debug build still
+          # produces an .appex but it has no App Group and the share
+          # sheet entry never appears.
           CODE_SIGN_ENTITLEMENTS: MoolahImportExtension_iOS/Entitlements.entitlements
 
   MoolahImportExtension_macOS:

--- a/scripts/inject-entitlements.sh
+++ b/scripts/inject-entitlements.sh
@@ -1,15 +1,22 @@
 #!/usr/bin/env bash
 # Prepares the build tree for local CloudKit development.
 #
-# 1. Writes .build/Moolah.entitlements with the full sandbox + CloudKit keys.
-#    The icloud-container-identifiers list contains ONLY the test container —
-#    a locally-signed binary cannot claim the production container. See
-#    issue #495.
+# 1. Writes .build/Moolah.entitlements with the full sandbox + CloudKit keys
+#    (host app). The icloud-container-identifiers list contains ONLY the test
+#    container — a locally-signed binary cannot claim the production container.
+#    See issue #495.
 # 2. Produces project-entitlements.yml — a copy of project.yml that augments
-#    each app target's existing Debug block with CODE_SIGN_ENTITLEMENTS
-#    pointing at .build/Moolah.entitlements and the CLOUDKIT_ENABLED
-#    compilation condition. (project.yml already carries a Debug block for
-#    CLOUDKIT_ENVIRONMENT.)
+#    each Debug build with CODE_SIGN_ENTITLEMENTS:
+#      - Host apps (Moolah_iOS/_macOS): point at .build/Moolah.entitlements
+#        and add the CLOUDKIT_ENABLED compilation condition. (project.yml
+#        already carries a Debug block for CLOUDKIT_ENVIRONMENT.)
+#      - Share extensions (MoolahImportExtension_iOS/_macOS): point at the
+#        target's own Entitlements.entitlements (sandbox + App Group only).
+#        Without this, the Debug-built .appex has no App Group entitlement,
+#        macOS's pluginkit refuses to register it, and the share-sheet item
+#        never appears. The extension entitlement doesn't declare iCloud or
+#        change any storage path — host-app iCloud container and the
+#        on-disk DB location are unaffected.
 #
 # Only Debug is touched: the only locally-signed CloudKit-enabled build is
 # `just build-mac` / `just run-mac` (Debug). Release builds are produced by
@@ -85,24 +92,23 @@ with open("project.yml") as f:
 
 entitlements_path = os.environ["ENTITLEMENTS_FILE"]
 
+# Host app targets already carry a Debug: block (CLOUDKIT_ENVIRONMENT).
+# Insert CODE_SIGN_ENTITLEMENTS + the CLOUDKIT_ENABLED compilation
+# condition at the top of it. Inserting a second Debug: sibling would
+# make xcodegen's YAML loader keep only the last occurrence and silently
+# drop these keys.
 for target in ("Moolah_iOS", "Moolah_macOS"):
     target_header = f"  {target}:\n    type: application\n"
     target_start = content.find(target_header)
     if target_start == -1:
         raise SystemExit(f"inject-entitlements: could not find target {target}")
 
-    configs_marker = "      configs:\n"
-    configs_pos = content.find(configs_marker, target_start)
+    configs_pos = content.find("      configs:\n", target_start)
     if configs_pos == -1:
         raise SystemExit(
             f"inject-entitlements: could not find configs: block for {target}"
         )
 
-    # Insert CODE_SIGN_ENTITLEMENTS and the CLOUDKIT_ENABLED compilation
-    # condition at the top of the existing Debug: block. project.yml already
-    # carries a Debug: block (for CLOUDKIT_ENVIRONMENT: Development);
-    # inserting a second Debug: sibling would make xcodegen's YAML loader
-    # keep only the last occurrence and silently drop these keys.
     debug_header = "        Debug:\n"
     debug_pos = content.find(debug_header, configs_pos)
     if debug_pos == -1:
@@ -116,11 +122,38 @@ for target in ("Moolah_iOS", "Moolah_macOS"):
     )
     content = content[:debug_insert_at] + debug_injection + content[debug_insert_at:]
 
-# Sanity check — both app targets now carry a Debug-scoped entitlement block.
+# Share-extension targets have no Debug: block in project.yml — their
+# entitlement is Release-only there. Insert a fresh Debug: block at the
+# top of `configs:` that points at the target's own entitlements file
+# (sandbox + group.rocks.moolah.shared). Without an App Group at signing
+# time the Debug .appex won't be registered by macOS pluginkit. The
+# entitlement does not include iCloud or any storage-path override, so
+# the host app's iCloud container and on-disk DB location are unchanged.
+for target in ("MoolahImportExtension_iOS", "MoolahImportExtension_macOS"):
+    target_header = f"  {target}:\n    type: app-extension\n"
+    target_start = content.find(target_header)
+    if target_start == -1:
+        raise SystemExit(f"inject-entitlements: could not find target {target}")
+
+    configs_marker = "      configs:\n"
+    configs_pos = content.find(configs_marker, target_start)
+    if configs_pos == -1:
+        raise SystemExit(
+            f"inject-entitlements: could not find configs: block for {target}"
+        )
+
+    insert_at = configs_pos + len(configs_marker)
+    debug_block = (
+        "        Debug:\n"
+        f"          CODE_SIGN_ENTITLEMENTS: {target}/Entitlements.entitlements\n"
+    )
+    content = content[:insert_at] + debug_block + content[insert_at:]
+
+# Sanity check — all four targets now carry a Debug-scoped entitlement block.
 debug_marker = "        Debug:\n          CODE_SIGN_ENTITLEMENTS:"
-if content.count(debug_marker) != 2:
+if content.count(debug_marker) != 4:
     raise SystemExit(
-        "inject-entitlements: expected 2 Debug entitlement blocks, "
+        "inject-entitlements: expected 4 Debug entitlement blocks, "
         f"found {content.count(debug_marker)}"
     )
 

--- a/tools/PluginManifestGen/Sources/PluginManifestGen/PlistEmitter.swift
+++ b/tools/PluginManifestGen/Sources/PluginManifestGen/PlistEmitter.swift
@@ -5,8 +5,16 @@ public enum PlistEmitter {
   /// extension. The static CFBundle/NSExtension keys live alongside the generated
   /// `NSExtensionActivationRule`, so the file produced here is the extension's
   /// `INFOPLIST_FILE` directly — no merge step is needed.
-  public static func emit(manifests: [Manifest]) -> String {
-    let predicate = activationRule(manifests: manifests)
+  ///
+  /// The activation rule is the dict-form `NSExtensionActivationSupportsWebPageWithMaxCount`
+  /// rather than a `SUBQUERY`-based URL predicate. The URL predicate shape was rejected
+  /// at parse time by Safari (no log line, just silently dropped from activation
+  /// candidates) and the extension never appeared in the share sheet on either
+  /// platform. Per-host filtering happens instead in `extension-entry.js` /
+  /// `MoolahDispatch.run`: an unsupported host short-circuits to
+  /// `{ error: "no-plugin", host }`, which the principal renders as the
+  /// `schemaMismatch` state.
+  public static func emit() -> String {
     return """
       <?xml version="1.0" encoding="UTF-8"?>
       <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -35,7 +43,10 @@ public enum PlistEmitter {
           <key>NSExtensionAttributes</key>
           <dict>
             <key>NSExtensionActivationRule</key>
-            <string>\(predicate)</string>
+            <dict>
+              <key>NSExtensionActivationSupportsWebPageWithMaxCount</key>
+              <integer>1</integer>
+            </dict>
             <key>NSExtensionJavaScriptPreprocessingFile</key>
             <string>extension-entry.bundle</string>
           </dict>
@@ -46,26 +57,6 @@ public enum PlistEmitter {
         </dict>
       </dict>
       </plist>
-      """
-  }
-
-  /// Emits just the `NSExtensionActivationRule` predicate string. Surfaced for
-  /// tests that want to inspect the predicate without parsing the surrounding
-  /// plist.
-  static func activationRule(manifests: [Manifest]) -> String {
-    if manifests.isEmpty {
-      return "FALSEPREDICATE"
-    }
-    let clauses = manifests.map { m in
-      #"(($att.URL.host == "\#(m.host)" OR $att.URL.host ENDSWITH ".\#(m.host)") AND $att.URL.path BEGINSWITH "\#(m.pathPrefix)")"#
-    }.joined(separator: " OR ")
-    return """
-      SUBQUERY(extensionItems, $item,
-        SUBQUERY($item.attachments, $att,
-          ANY $att.registeredTypeIdentifiers UTI-CONFORMS-TO "public.url"
-          AND (\(clauses))
-        ).@count > 0
-      ).@count > 0
       """
   }
 }

--- a/tools/PluginManifestGen/Sources/PluginManifestGen/main.swift
+++ b/tools/PluginManifestGen/Sources/PluginManifestGen/main.swift
@@ -16,7 +16,7 @@ let index = try JSONDecoder().decode(ManifestIndex.self, from: data)
 let swift = try SwiftEmitter.emitStrict(manifests: index.plugins)
 try swift.write(toFile: args[2], atomically: true, encoding: .utf8)
 
-let plist = PlistEmitter.emit(manifests: index.plugins)
+let plist = PlistEmitter.emit()
 try plist.write(toFile: args[3], atomically: true, encoding: .utf8)
 try plist.write(toFile: args[4], atomically: true, encoding: .utf8)
 

--- a/tools/PluginManifestGen/Tests/PluginManifestGenTests/PlistEmitterTests.swift
+++ b/tools/PluginManifestGen/Tests/PluginManifestGenTests/PlistEmitterTests.swift
@@ -5,35 +5,22 @@ import Testing
 @Suite("PlistEmitter")
 struct PlistEmitterTests {
 
-  @Test("empty manifest emits a predicate that never activates")
-  func empty() {
-    let xml = PlistEmitter.emit(manifests: [])
-    #expect(xml.contains("FALSEPREDICATE"))
-  }
-
-  @Test("one manifest emits the dotted-suffix host clause")
-  func oneEntry() {
-    let m = Manifest(
-      host: "chase.com", pathPrefix: "/x", file: "chase.com/parser.js", displayName: "Chase")
-    let xml = PlistEmitter.emit(manifests: [m])
-    #expect(xml.contains(#"$att.URL.host == "chase.com""#))
-    #expect(xml.contains(#"$att.URL.host ENDSWITH ".chase.com""#))
-    #expect(xml.contains(#"$att.URL.path BEGINSWITH "/x""#))
-  }
-
-  @Test("two manifests are OR'd")
-  func twoEntries() {
-    let a = Manifest(host: "a.com", pathPrefix: "/x", file: "a.js", displayName: "A")
-    let b = Manifest(host: "b.com", pathPrefix: "/y", file: "b.js", displayName: "B")
-    let xml = PlistEmitter.emit(manifests: [a, b])
-    #expect(xml.contains("a.com"))
-    #expect(xml.contains("b.com"))
-    #expect(xml.contains(" OR "))
+  @Test("emits the dict-form web-page activation rule")
+  func activationRule() {
+    let xml = PlistEmitter.emit()
+    #expect(xml.contains("<key>NSExtensionActivationRule</key>"))
+    #expect(xml.contains("<key>NSExtensionActivationSupportsWebPageWithMaxCount</key>"))
+    #expect(xml.contains("<integer>1</integer>"))
+    // Per-host filtering moved to MoolahDispatch in extension-entry.js;
+    // the SUBQUERY string-form predicate was silently rejected by the
+    // system's predicate parser.
+    #expect(!xml.contains("SUBQUERY"))
+    #expect(!xml.contains("UTI-CONFORMS-TO"))
   }
 
   @Test("emits the action extension point identifier and principal class")
   func extensionPointAndPrincipal() {
-    let xml = PlistEmitter.emit(manifests: [])
+    let xml = PlistEmitter.emit()
     #expect(xml.contains("<key>NSExtensionPointIdentifier</key>"))
     #expect(xml.contains("<string>com.apple.ui-services</string>"))
     #expect(xml.contains("<key>NSExtensionPrincipalClass</key>"))
@@ -42,7 +29,7 @@ struct PlistEmitterTests {
 
   @Test("emits CFBundle keys with build setting substitutions")
   func cfBundleKeys() {
-    let xml = PlistEmitter.emit(manifests: [])
+    let xml = PlistEmitter.emit()
     #expect(xml.contains("<key>CFBundleIdentifier</key>"))
     #expect(xml.contains("<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>"))
     #expect(xml.contains("<key>CFBundleDisplayName</key>"))
@@ -51,7 +38,7 @@ struct PlistEmitterTests {
 
   @Test("emits the JavaScript preprocessing file key")
   func javaScriptPreprocessingFile() {
-    let xml = PlistEmitter.emit(manifests: [])
+    let xml = PlistEmitter.emit()
     #expect(xml.contains("<key>NSExtensionJavaScriptPreprocessingFile</key>"))
     // Matches the base name of the generated bundle (`extension-entry.bundle.js`).
     #expect(xml.contains("<string>extension-entry.bundle</string>"))


### PR DESCRIPTION
## Summary

The web-import share extension **never appeared in Safari's share sheet** on either platform. The generated `NSExtensionActivationRule` used a `SUBQUERY` URL predicate (matching the five supported bank hosts), and the system's predicate parser **silently rejected it at parse time** — no log line, the extension was simply dropped from the activation candidates.

This PR is the permanent fix (the change set was sitting uncommitted in the working tree after the original author's session ended; validated, regenerated, and landed here).

### Activation rule
- Switch to the dict form `NSExtensionActivationSupportsWebPageWithMaxCount = 1`, which activates on any web page.
- Per-host filtering already lives in `MoolahDispatch` (`extension-entry.js`): an unsupported host short-circuits to `{ error: "no-plugin", host }`, which `ExtensionItemReader` maps to `.schemaMismatch` and the principal renders as the unsupported-site state. **Dropping the host filter from the plist changes nothing about which sites can be imported** — it only fixes the rule being rejected.
- `PlistEmitter.emit()` no longer takes `manifests`; `activationRule(manifests:)` removed and its tests rewritten.
- Both `Generated/Info.plist` files regenerated (iOS + macOS).

### Local Debug usability
- `scripts/inject-entitlements.sh` now injects a Debug `CODE_SIGN_ENTITLEMENTS` block for the two app-extension targets (sandbox + App Group only). Without an App Group at signing time, macOS `pluginkit` refuses to register the `.appex` and the share-sheet item never appears. The extension entitlement declares no iCloud container and no storage-path override, so the host app's iCloud container and on-disk DB are unaffected.
- `justfile`: pass `-allowProvisioningUpdates` to `build-mac` / `run-mac` when `DEVELOPMENT_TEAM` is set, so Xcode can mint the extension's provisioning profile on first entitled build.
- `project.yml`: document the `ENABLE_ENTITLEMENTS=1 just generate` opt-in.

## Validation
- `just generate` is deterministic — regeneration produces zero drift against the committed plists.
- `swift test --package-path tools/PluginManifestGen` — 15/15 pass (incl. new dict-form rule test).
- `just format-check` clean.
- `just build-mac` succeeds (extension target builds with new plists + entitlement plumbing).

## Not covered here (needs a real device)
The one thing that can't be verified in CI: that the new rule actually makes the extension **appear in Safari's share sheet**. Please confirm on a real macOS/iOS Safari once this builds via TestFlight or a local entitled build (`ENABLE_ENTITLEMENTS=1 just run-mac`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)