### PR TITLE
fix(import-ext): sign embedded action extension with its own match profile

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -77,6 +77,11 @@ platform :ios do
     )
 
     bake_profile("IOS_PROVISIONING_PROFILE", ENV["sigh_rocks.moolah.app_appstore_profile-name"])
+    # The embedded action extension is a separate signing target with its
+    # own App Store profile — bake its name into the env var that
+    # MoolahImportExtension_iOS.Release reads. Both vars are set before this
+    # `just generate` runs, so both specifiers land in one regeneration.
+    bake_profile("IOS_EXT_PROVISIONING_PROFILE", ENV["sigh_rocks.moolah.app.importextension_appstore_profile-name"])
 
     build_app(
       scheme: "Moolah-iOS",
@@ -113,6 +118,11 @@ platform :ios do
     # project.yml's hard-coded "1") is the persistent source of truth for
     # the next build number.
     bake_profile("IOS_PROVISIONING_PROFILE", ENV["sigh_rocks.moolah.app_appstore_profile-name"])
+    # The embedded action extension is a separate signing target with its
+    # own App Store profile — bake its name into the env var that
+    # MoolahImportExtension_iOS.Release reads. Both vars are set before this
+    # `just generate` runs, so both specifiers land in one regeneration.
+    bake_profile("IOS_EXT_PROVISIONING_PROFILE", ENV["sigh_rocks.moolah.app.importextension_appstore_profile-name"])
 
     increment_build_number(
       build_number: latest_testflight_build_number(api_key: api_key) + 1
@@ -240,6 +250,11 @@ platform :mac do
     # iOS appstore uses `sigh_<bundle>_appstore_profile-name` (no platform suffix)
     # because iOS is fastlane's default platform.
     bake_profile("MAC_PROVISIONING_PROFILE", ENV["sigh_rocks.moolah.app_developer_id_macos_profile-name"])
+    # The embedded action extension is a separate signing target with its
+    # own Developer ID profile — bake its name into the env var that
+    # MoolahImportExtension_macOS.Release reads. Both vars are set before
+    # this `just generate` runs, so both specifiers land in one regeneration.
+    bake_profile("MAC_EXT_PROVISIONING_PROFILE", ENV["sigh_rocks.moolah.app.importextension_developer_id_macos_profile-name"])
 
     # Same ordering rule as the iOS `beta` lane (see comment there): anything that
     # mutates the pbxproj must come AFTER the last `just generate` (the one inside

--- a/project.yml
+++ b/project.yml
@@ -238,6 +238,18 @@ targets:
           # produces an .appex but it has no App Group and the share
           # sheet entry never appears.
           CODE_SIGN_ENTITLEMENTS: MoolahImportExtension_iOS/Entitlements.entitlements
+          # Manual distribution signing, scoped to this target — mirrors
+          # Moolah_iOS.configs.Release. The embedded .appex has its own
+          # bundle id (rocks.moolah.app.importextension), which the parent
+          # app's App Store profile does not cover, so it needs a separate
+          # profile specifier. PROVISIONING_PROFILE_SPECIFIER is
+          # xcodegen-substituted from $IOS_EXT_PROVISIONING_PROFILE, which
+          # the iOS fastlane lanes set from `match`'s output before
+          # re-running `just generate`. An unset env var is harmless: local
+          # Debug builds ignore this Release block.
+          CODE_SIGN_STYLE: Manual
+          CODE_SIGN_IDENTITY: Apple Distribution
+          PROVISIONING_PROFILE_SPECIFIER: ${IOS_EXT_PROVISIONING_PROFILE}
 
   MoolahImportExtension_macOS:
     type: app-extension
@@ -272,6 +284,17 @@ targets:
           # `Moolah_macOS.Release` setting above; without it the embedded
           # extension binary fails App Store validation.
           ENABLE_HARDENED_RUNTIME: YES
+          # Manual Developer ID signing, scoped to this target — mirrors
+          # Moolah_macOS.configs.Release. The embedded .appex needs its own
+          # Developer ID profile (its bundle id differs from the parent
+          # app's). PROVISIONING_PROFILE_SPECIFIER is xcodegen-substituted
+          # from $MAC_EXT_PROVISIONING_PROFILE, which the mac `zip` lane
+          # sets from `match`'s output before re-running `just generate`.
+          # An unset env var is harmless: local Debug builds ignore this
+          # Release block.
+          CODE_SIGN_STYLE: Manual
+          CODE_SIGN_IDENTITY: Developer ID Application
+          PROVISIONING_PROFILE_SPECIFIER: ${MAC_EXT_PROVISIONING_PROFILE}
 
   MoolahTests_iOS:
     type: bundle.unit-test


### PR DESCRIPTION
## Why

The **v1.1.0-rc.23** release archive failed at the iOS App Store build step:

```
error: No profiles for 'rocks.moolah.app.importextension' were found:
Xcode couldn't find any iOS App Development provisioning profiles matching
'rocks.moolah.app.importextension'. Automatic signing is disabled and unable
to generate a profile. (in target 'MoolahImportExtension_iOS')
```

rc.23 was the **first RC to bundle the action extension**, so this gap had never been hit before. The extension targets' `Release` configs set only `CODE_SIGN_ENTITLEMENTS`, leaving signing on **automatic** — which fails in CI (no `-allowProvisioningUpdates`) because the parent app's profile doesn't cover the extension's distinct bundle id `rocks.moolah.app.importextension`.

`match` already fetches both an App Store and a Developer ID profile for the extension (the `certificates` / `force_certificates` lanes already list both identifiers) — the profile names simply weren't wired into the build.

## What

- **project.yml** — give both extension targets manual distribution signing mirroring the parent app: `CODE_SIGN_STYLE: Manual`, `CODE_SIGN_IDENTITY`, and a `PROVISIONING_PROFILE_SPECIFIER` from a per-extension env var (`${IOS_EXT_PROVISIONING_PROFILE}` / `${MAC_EXT_PROVISIONING_PROFILE}`).
- **Fastfile** — bake the extension's `match` profile name into those env vars in the iOS `validate` + `beta` lanes and the mac `zip` lane, next to the existing parent-app bake. Both vars are set before the final `just generate`, so one regeneration substitutes both.

Unset env vars stay literal (`${…}`) and are ignored by local Debug builds — identical to how the parent app's specifiers already behave.

## Validation

- `just generate` — clean; generated pbxproj carries `PROVISIONING_PROFILE_SPECIFIER` on both extension `Release` configs, symmetric with the parent app.
- `ruby -c fastlane/Fastfile` — Syntax OK.
- `just format-check` — clean.
- The signing path itself can only be exercised by the release archive (needs `match` secrets) — that's the next RC.

## Follow-up

Once this merges, a fresh **rc.24** will be cut. The CloudKit Production schema deploy for rc.23 already succeeded, so rc.24's preflight will skip the schema gate. rc.23's pre-release will be marked obsolete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)