### PR TITLE
fix(tests): widen emission-wait timeout for earmark conversion tests

### DIFF
--- a/MoolahTests/Features/EarmarkStorePartialConversionTests.swift
+++ b/MoolahTests/Features/EarmarkStorePartialConversionTests.swift
@@ -7,6 +7,19 @@ import Testing
 @MainActor
 struct EarmarkStorePartialConversionTests {
 
+  /// Timeout for the first-emission convergence waits in this suite.
+  ///
+  /// Deliberately more generous than the helper's 2s default: unlike the
+  /// other store tests (which drive emissions via an explicit action such
+  /// as `applyDelta`), these waits race the store's init-spawned
+  /// observation task through a GRDB `observeAll()` emission *and* N async
+  /// per-earmark conversion calls. On a loaded CI runner that first
+  /// emission can land just past 2s — a timing artefact, not a regression
+  /// (see issue #1025). `waitForNextEmission` polls the predicate every
+  /// 20ms, so the fast path still returns the instant state settles; the
+  /// larger cap only buys headroom for a slow runner.
+  private static let convergenceTimeout: Duration = .seconds(10)
+
   /// When one earmark's positions can't be converted to its own instrument,
   /// other earmarks whose conversions succeed still appear in
   /// `convertedBalances`. The aggregate `convertedTotalBalance` stays nil
@@ -63,7 +76,8 @@ struct EarmarkStorePartialConversionTests {
     // balance is populated is sufficient to assert convergence.
     try await store.waitForNextEmission(
       matching: { $0.convertedBalance(for: healthyEarmark.id)?.quantity == 300 },
-      description: "healthy earmark balance settled"
+      description: "healthy earmark balance settled",
+      timeout: Self.convergenceTimeout
     )
 
     #expect(store.convertedBalance(for: healthyEarmark.id)?.quantity == 300)
@@ -115,7 +129,8 @@ struct EarmarkStorePartialConversionTests {
     // background.
     try await store.waitForNextEmission(
       matching: { $0.convertedBalance(for: audEarmark.id)?.quantity == 400 },
-      description: "AUD earmark balance settled"
+      description: "AUD earmark balance settled",
+      timeout: Self.convergenceTimeout
     )
 
     // Aggregate cannot be computed (EUR → AUD fails). Per-earmark balances


### PR DESCRIPTION
## Summary

Fixes #1025 — the flaky `conversionFailuresAreRetriedAfterDelay()` emission-wait timeout.

The two tests in `EarmarkStorePartialConversionTests` await the `EarmarkStore`'s **first** convergence emission. That emission races the init-spawned observation task through a GRDB `observeAll()` emission **plus** N async per-earmark conversion calls. Unlike the other store tests — which drive emissions via an explicit action such as `applyDelta` and so have a synchronous trigger — these have no such trigger, so on a loaded CI runner the first emission can land just past the helper's 2s default. The wait then throws `StoreEmissionTimeoutError` *before the retry path under test is even reached* — a timing artefact, not a product regression.

## Fix

Give both first-emission waits in this suite a generous 10s timeout via a shared `convergenceTimeout` constant (matching the existing `.seconds(10)` precedent in `ProfileSessionPragmaOptimizeTests`).

`waitForNextEmission` already polls the predicate every 20ms (the silent-success hardening from #981), so:
- **Fast path is unchanged** — the test still resolves the instant state settles (~40ms locally).
- The larger cap **only buys headroom** for a slow runner; it never slows the common case.

No product code changes — test-only.

## Test plan

- [x] `just test-mac EarmarkStorePartialConversionTests` — both tests pass (`conversionFailuresAreRetriedAfterDelay` in 0.043s, sibling in 0.036s).
- [x] `just format-check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)