### PR TITLE
Personalized insights: core deterministic detector layer

### DIFF
--- a/.claude/skills/developing-on-linux/SKILL.md
+++ b/.claude/skills/developing-on-linux/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: developing-on-linux
+description: Use when working on this repo from a Linux box (e.g. Claude Code on the web, a Linux container, CI debugging) where Xcode and the macOS `just` toolchain are unavailable. Covers installing a Swift toolchain plus version-matched `swift-format` and `swiftlint`, then running format / lint / typecheck locally so you don't burn a 25-minute macOS CI round-trip to discover a formatting or compile error. Use whenever `swift`, `swift-format`, or `swiftlint` is "command not found", or a task says to fix `format-check` / lint / build issues but `just` can't run.
+---
+
+# Developing on Linux
+
+The project builds and tests on **macOS only** (`just build-mac`, `just test`, and CI all run `xcodebuild` on `macos-26`). On a Linux host none of that runs. But the two gates that catch the most mistakes — `just format-check` (swift-format byte-parity + `swiftlint --strict`) and basic Swift type-checking — **can** be reproduced on Linux if you install the matching tools. Doing so turns a ~25-minute "push → wait for CI → read failure" loop into a local seconds-long loop.
+
+## The one rule: match CI's pinned versions
+
+CI installs exact tool versions (`scripts/install-ci-tools.sh`, `PINNED_TOOLS`). `format-check` does a **byte-for-byte** `cmp` against `swift-format` output, so a different `swift-format` version will reformat differently and fail CI even when your code is fine. Always read the current pins first:
+
+```bash
+grep -A4 'PINNED_TOOLS=' scripts/install-ci-tools.sh
+# e.g. swiftlint|0.63.3|...   swift-format|602.0.0|...   xcodegen|2.45.4|...
+```
+
+`swift-format` versioning maps to the Swift release: **`602.0.0` ⇔ Swift 6.2**. The toolchain-bundled `swift-format` is built from the same source tag as the standalone Homebrew bottle, so the Swift 6.2 Linux toolchain's `swift-format` produces output identical to CI's `602.0.0`. (It self-reports as `6.2.0` — same thing.) If the pin moves to `6xx.y.z`, install the matching Swift `6.x` toolchain.
+
+## Setup (Ubuntu x86_64)
+
+Took ~2–3 min on a fresh container; the toolchain tarball is ~1 GB.
+
+```bash
+# 1. Swift toolchain (provides swiftc, swift-format, and libsourcekitdInProc.so).
+#    Pick the URL matching your distro from https://www.swift.org/install/linux/
+cd /tmp
+curl -sSL -o swift.tar.gz \
+  https://download.swift.org/swift-6.2-release/ubuntu2404/swift-6.2-RELEASE/swift-6.2-RELEASE-ubuntu24.04.tar.gz
+mkdir -p swift-toolchain && tar xzf swift.tar.gz -C swift-toolchain
+TC="/tmp/swift-toolchain/$(ls /tmp/swift-toolchain)/usr"
+
+# 2. SwiftLint Linux binary at the PINNED version (realm/SwiftLint ships
+#    swiftlint_linux_amd64.zip in its GitHub releases).
+curl -sSL -o swiftlint.zip \
+  https://github.com/realm/SwiftLint/releases/download/0.63.3/swiftlint_linux_amd64.zip
+mkdir -p swiftlint-bin && (cd swiftlint-bin && unzip -o ../swiftlint.zip)
+chmod +x swiftlint-bin/swiftlint
+
+# 3. Persist an env file you can `source` in later Bash calls (shell state
+#    does NOT persist between Bash tool calls — re-source it each time, or
+#    inline the exports).
+cat > /tmp/swiftenv.sh <<EOF
+export PATH="$TC/bin:/tmp/swiftlint-bin:\$PATH"
+export LD_LIBRARY_PATH="$TC/lib:\${LD_LIBRARY_PATH:-}"
+EOF
+
+source /tmp/swiftenv.sh
+swift-format --version    # expect 6.2.0  (== CI's 602.0.0)
+swiftlint version         # expect 0.63.3
+```
+
+**`swiftlint` needs the toolchain's `libsourcekitdInProc.so`.** Without it you get `Fatal error: Loading libsourcekitdInProc.so failed`. Setting `LD_LIBRARY_PATH` to the toolchain's `usr/lib` (as above) fixes it — this is why you install the full toolchain even though you "only" want the linter.
+
+## Running the gates locally
+
+Reproduce `just format-check` exactly (format byte-parity, then strict lint):
+
+```bash
+source /tmp/swiftenv.sh
+files=$(git ls-files '*.swift' ':!:Vendored/**')   # or scope to your changed files
+
+# (a) apply formatting in place — equivalent to `just format`'s swift-format step
+swift-format format -i --configuration .swift-format $files
+
+# (b) byte-parity check — what CI's format-check actually asserts
+for f in $files; do
+  cmp -s "$f" <(swift-format format --configuration .swift-format "$f") \
+    || echo "NOT FORMATTED: $f"
+done
+
+# (c) strict lint — respects nested configs (e.g. MoolahTests/.swiftlint.yml)
+swiftlint lint --strict --no-cache $changed_dirs
+```
+
+Scope `swiftlint` to the directories you touched for speed; it reads `.swiftlint.yml` from the repo root and honours nested overrides automatically.
+
+### Lint rules that bite, and how to satisfy them
+
+- **`multiline_parameters` / `multiline_arguments`** — `.swift-format` has `respectsExistingLineBreaks: true`, so it preserves a layout you write. Write wrapped parameter/argument lists **one per line** (matching existing files like `Shared/AccountPerformanceCalculator.swift`) and swift-format keeps them, satisfying the rule. `multiline_arguments` is also blanket-disabled in `MoolahTests/` and may be file-level-disabled on production files per `.swiftlint.yml` — prefer one-per-line over adding a disable.
+- **`function_parameter_count` (>5)** — bundle related args into a small `private struct`.
+- **`unneeded_synthesized_initializer`** — delete a memberwise/`init() {}` that exactly matches what the compiler would synthesize (note: an init that *adds default values* the properties lack is NOT redundant — keep it).
+- **`identifier_name`** — min 3 chars (only `id, x, y, i, j, n, ok, to` are exempt). No `cv`, `mu`, `sd`.
+- For the full policy and the "never reintroduce a baseline / don't `// swiftlint:disable` to dodge debt" rules, load the **`fixing-format-check`** skill.
+
+## Type-checking without Xcode
+
+You can't build the app target on Linux — some files use Darwin-only APIs (`import os`/`OSAllocatedUnfairLock`, `import OSLog`, `import CryptoKit`, `RelativeDateTimeFormatter`, etc.) and there's no iOS/macOS SDK. But you can still catch the bulk of compile errors in a **layer you're editing** by assembling a throwaway type-check harness of just the Foundation-only files it depends on:
+
+```bash
+source /tmp/swiftenv.sh
+rm -rf /tmp/tc && mkdir -p /tmp/tc
+cp Domain/Models/*.swift Domain/Models/CSVImport/*.swift Domain/Services/*.swift /tmp/tc/
+cp Shared/FinancialMonth.swift Shared/Array+Uniqued.swift /tmp/tc/
+cp <your-layer>/*.swift /tmp/tc/
+
+# Shim/skip the few Darwin-only stragglers, then iterate:
+#   - replace `import os` and shim OSAllocatedUnfairLock with an NSLock wrapper
+#   - rm files that import OSLog/CryptoKit or use RelativeDateTimeFormatter
+#     IF your layer doesn't depend on them (the compiler tells you what's missing)
+swiftc -typecheck /tmp/tc/*.swift 2>&1 | grep error: | sort -u
+```
+
+Iterate: each error names either a real bug in your code (fix it in the repo) or a missing dependency / Linux-Foundation gap in an unrelated file (add the dep, or drop the file if your layer doesn't use it). Reaching **0 errors** means your layer compiles against the real domain type signatures — it does not guarantee the macOS build, but it eliminates the common mistakes (wrong initializer labels, `Decimal`-vs-`Double` arithmetic, missing members).
+
+For test files: strip `@testable import Moolah` and `import Testing` and fold the support file into the same harness to type-check the test *builders* (the `@Test`/`#expect` macros themselves need the Testing module and won't compile here).
+
+## What still only CI can verify
+
+- The actual `xcodebuild` compile of the whole app + the iOS/macOS-specific code paths.
+- Test **execution** (assertions, async behaviour) and UI tests.
+- `validate-appstore`, `no-swiftdata`, `validate-todos`, schema additivity (these are quick shell/`just` checks; you can run several directly if `just` is present, but they don't need the toolchain above).
+
+So: use the local loop to land format/lint/typecheck clean, then push and let CI close the loop on build + tests. When monitoring that CI run, follow the **`landing-prs`** skill's guidance and `subscribe_pr_activity` rather than polling.

--- a/Domain/Insights/CategorySpendSeries.swift
+++ b/Domain/Insights/CategorySpendSeries.swift
@@ -39,8 +39,9 @@ enum CategorySpendSeries {
   }
 
   /// Sentinel category id used to key uncategorized spend.
-  static let uncategorizedKey = UUID(
-    uuidString: "00000000-0000-0000-0000-0000000000FF") ?? UUID()
+  static let uncategorizedKey =
+    UUID(
+      uuidString: "00000000-0000-0000-0000-0000000000FF") ?? UUID()
 
   private static func series(from rows: [ExpenseBreakdown]) -> [MonthlySpendPoint] {
     var magnitudeByMonth: [String: Double] = [:]

--- a/Domain/Insights/CategorySpendSeries.swift
+++ b/Domain/Insights/CategorySpendSeries.swift
@@ -1,0 +1,92 @@
+import Foundation
+
+/// One month of spend for a category, magnitude expressed as a positive
+/// `Double` (the underlying `ExpenseBreakdown.totalExpenses` is a signed
+/// negative sum; this flips it so larger = more spending).
+struct MonthlySpendPoint: Sendable, Hashable {
+  /// Financial month bucket, `YYYYMM`.
+  let month: String
+  /// First day of the bucket's calendar month (UTC midnight), for recency.
+  let date: Date
+  /// Positive spend magnitude in the reporting currency.
+  let magnitude: Double
+}
+
+/// Builds per-category, gap-filled monthly spend series from the backend's
+/// `ExpenseBreakdown` rows. Detectors need *evenly spaced* series (a month
+/// with no spend is a real zero, not a missing sample), so the gaps between
+/// the first and last observed month are filled with zeros.
+enum CategorySpendSeries {
+  /// Per-category series keyed by `categoryId` (a `nil` category id is
+  /// folded under a synthetic all-zero UUID so it can still be keyed).
+  /// Each series is sorted ascending by month with interior gaps zero-filled.
+  static func build(
+    from breakdown: [ExpenseBreakdown], reportingCurrency: Instrument
+  ) -> [UUID: [MonthlySpendPoint]] {
+    let byCategory = Dictionary(grouping: breakdown) { $0.categoryId ?? Self.uncategorizedKey }
+    var result: [UUID: [MonthlySpendPoint]] = [:]
+    for (categoryId, rows) in byCategory {
+      result[categoryId] = series(from: rows)
+    }
+    return result
+  }
+
+  /// The combined all-category monthly spend series (gap-filled).
+  static func total(
+    from breakdown: [ExpenseBreakdown]
+  ) -> [MonthlySpendPoint] {
+    series(from: breakdown)
+  }
+
+  /// Sentinel category id used to key uncategorized spend.
+  static let uncategorizedKey = UUID(
+    uuidString: "00000000-0000-0000-0000-0000000000FF") ?? UUID()
+
+  private static func series(from rows: [ExpenseBreakdown]) -> [MonthlySpendPoint] {
+    var magnitudeByMonth: [String: Double] = [:]
+    for row in rows {
+      let signed = Double(truncating: row.totalExpenses.quantity as NSDecimalNumber)
+      // Flip the negative expense sum to a positive spend magnitude; a
+      // net-refund month (positive sum) clamps to zero rather than going
+      // negative, which would distort the trend / anomaly maths.
+      magnitudeByMonth[row.month, default: 0] += max(-signed, 0)
+    }
+    guard let first = magnitudeByMonth.keys.min(),
+      let last = magnitudeByMonth.keys.max()
+    else { return [] }
+
+    var points: [MonthlySpendPoint] = []
+    var cursor = first
+    while true {
+      let date = monthDate(cursor) ?? Date.distantPast
+      points.append(
+        MonthlySpendPoint(month: cursor, date: date, magnitude: magnitudeByMonth[cursor] ?? 0))
+      if cursor == last { break }
+      guard let next = nextMonth(cursor) else { break }
+      cursor = next
+    }
+    return points
+  }
+
+  /// `YYYYMM` → first-of-month UTC date.
+  static func monthDate(_ month: String) -> Date? {
+    guard month.count == 6, let year = Int(month.prefix(4)),
+      let monthNumber = Int(month.suffix(2))
+    else { return nil }
+    var components = DateComponents()
+    components.year = year
+    components.month = monthNumber
+    components.day = 1
+    return InsightContext.defaultCalendar.date(from: components)
+  }
+
+  /// Increment a `YYYYMM` bucket by one month, rolling the year over.
+  static func nextMonth(_ month: String) -> String? {
+    guard month.count == 6, let year = Int(month.prefix(4)),
+      let monthNumber = Int(month.suffix(2)), (1...12).contains(monthNumber)
+    else { return nil }
+    let nextYear = monthNumber == 12 ? year + 1 : year
+    let nextMonthNumber = monthNumber == 12 ? 1 : monthNumber + 1
+    return String(format: "%04d%02d", nextYear, nextMonthNumber)
+  }
+}

--- a/Domain/Insights/Detectors/AccountGroupInsights.swift
+++ b/Domain/Insights/Detectors/AccountGroupInsights.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+/// Account-group insights (research follow-up §A-1) — the first detector to
+/// exploit the post-design-doc account-groups feature. Surfaces when one
+/// group accounts for a dominant share of recent spending, so the user sees
+/// where the money actually flows out.
+enum AccountGroupInsights {
+  static func groupSpendConcentration(
+    _ input: InsightInput,
+    windowDays: Int = 30,
+    minimumShare: Double = 0.6
+  ) -> [Insight] {
+    let context = input.context
+    let groupsById = Dictionary(uniqueKeysWithValues: input.accountGroups.map { ($0.id, $0) })
+    guard groupsById.count >= 2 else { return [] }
+
+    var spendByGroup: [UUID: Double] = [:]
+    var groupedTotal = 0.0
+    for transaction in input.transactions where transaction.isExpense {
+      let age = context.daysSince(transaction.date)
+      guard age >= 0, age <= windowDays,
+        let accountId = transaction.accountId,
+        let groupId = input.accountGroupMembership[accountId]
+      else { continue }
+      let magnitude = Double(truncating: transaction.spendMagnitude as NSDecimalNumber)
+      spendByGroup[groupId, default: 0] += magnitude
+      groupedTotal += magnitude
+    }
+    guard groupedTotal > 0,
+      let top = spendByGroup.max(by: { $0.value < $1.value }),
+      let group = groupsById[top.key]
+    else { return [] }
+
+    let share = top.value / groupedTotal
+    guard share >= minimumShare else { return [] }
+
+    return [
+      Insight(
+        id: "\(InsightKind.groupSpendConcentration.rawValue):\(group.id.uuidString)",
+        kind: .groupSpendConcentration,
+        title: "Most spending runs through \(group.name)",
+        detail:
+          "\(percent(share)) of your spending in the last \(windowDays) days "
+          + "(\(context.formatted(Decimal(-top.value)))) came from accounts in your "
+          + "\(group.name) group.",
+        date: context.now,
+        framing: .neutral,
+        actionability: .informational,
+        surprise: min(share, 1),
+        monetaryImpact: InstrumentAmount(
+          quantity: Decimal(-top.value), instrument: context.reportingCurrency),
+        facts: [
+          InsightFact("Group", group.name),
+          InsightFact("Share of spend", percent(share)),
+          InsightFact("Spent", context.formatted(Decimal(-top.value))),
+        ],
+        references: InsightReferences(
+          groupIds: [group.id], instrumentIds: [context.reportingCurrency.id]))
+    ]
+  }
+
+  private static func percent(_ fraction: Double) -> String {
+    fraction.formatted(.percent.precision(.fractionLength(0)))
+  }
+}

--- a/Domain/Insights/Detectors/BudgetCoverageInsights.swift
+++ b/Domain/Insights/Detectors/BudgetCoverageInsights.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+/// Budget-coverage insight (research follow-up §F-2): the user budgets some
+/// categories but a large spend category has no budget line. Bridges spend
+/// analysis and the earmark-budgeting feature with an actionable nudge.
+enum BudgetCoverageInsights {
+  static func unbudgetedCategory(
+    _ input: InsightInput,
+    windowDays: Int = 90
+  ) -> [Insight] {
+    // Only relevant once the user actually budgets something.
+    guard !input.budgetedCategoryIds.isEmpty else { return [] }
+    let context = input.context
+
+    var spendByCategory: [UUID: Double] = [:]
+    for transaction in input.transactions where transaction.isExpense {
+      let age = context.daysSince(transaction.date)
+      guard age >= 0, age <= windowDays, let categoryId = transaction.categoryId,
+        !input.budgetedCategoryIds.contains(categoryId)
+      else { continue }
+      spendByCategory[categoryId, default: 0] +=
+        Double(truncating: transaction.spendMagnitude as NSDecimalNumber)
+    }
+    guard let top = spendByCategory.max(by: { $0.value < $1.value }), top.value > 0 else {
+      return []
+    }
+    let categoryName =
+      input.categories.by(id: top.key).map { input.categories.path(for: $0) }
+      ?? "A category"
+
+    return [
+      Insight(
+        id: "\(InsightKind.unbudgetedCategory.rawValue):\(top.key.uuidString)",
+        kind: .unbudgetedCategory,
+        title: "\(categoryName) has no budget",
+        detail:
+          "You spent \(context.formatted(Decimal(-top.value))) on \(categoryName) in the last "
+          + "\(windowDays) days, but it isn't in any budget. Adding one would keep it in check.",
+        date: context.now,
+        framing: .neutral,
+        actionability: .review,
+        surprise: 0.4,
+        monetaryImpact: InstrumentAmount(
+          quantity: Decimal(-top.value), instrument: context.reportingCurrency),
+        facts: [
+          InsightFact("Category", categoryName),
+          InsightFact("Spent (\(windowDays)d)", context.formatted(Decimal(-top.value))),
+        ],
+        references: InsightReferences(
+          categoryIds: [top.key], instrumentIds: [context.reportingCurrency.id]))
+    ]
+  }
+}

--- a/Domain/Insights/Detectors/CashFlowForecastInsights.swift
+++ b/Domain/Insights/Detectors/CashFlowForecastInsights.swift
@@ -17,16 +17,23 @@ enum CashFlowForecastInsights {
     buffer: InstrumentAmount? = nil
   ) -> [Insight] {
     let bufferQuantity = buffer?.quantity ?? 0
-    let forecast = dailyBalances
-      .filter { $0.isForecast && context.daysUntil($0.date) >= 0 && context.daysUntil($0.date) <= horizonDays }
+    let forecast =
+      dailyBalances
+      .filter {
+        $0.isForecast && context.daysUntil($0.date) >= 0
+          && context.daysUntil($0.date) <= horizonDays
+      }
       .sorted { $0.date < $1.date }
     guard let trough = forecast.min(by: { $0.balance.quantity < $1.balance.quantity }) else {
       return []
     }
     guard trough.balance.quantity < bufferQuantity else { return [] }
 
-    let culprit = scheduledBills
-      .filter { context.daysUntil($0.date) >= 0 && $0.date <= trough.date && $0.amount.quantity < 0 }
+    let culprit =
+      scheduledBills
+      .filter {
+        context.daysUntil($0.date) >= 0 && $0.date <= trough.date && $0.amount.quantity < 0
+      }
       .min { $0.amount.quantity < $1.amount.quantity }
     let shortfall = bufferQuantity - trough.balance.quantity
     let dateText = trough.date.formatted(.dateTime.month(.abbreviated).day())

--- a/Domain/Insights/Detectors/CashFlowForecastInsights.swift
+++ b/Domain/Insights/Detectors/CashFlowForecastInsights.swift
@@ -1,0 +1,120 @@
+import Foundation
+
+/// Forecast-driven cash-flow insights (design §D): upcoming-bill cash
+/// warning (13) and projected month-end balance (15). Both read the
+/// forecast tail of the daily-balance series that `AnalysisStore` already
+/// projects from scheduled transactions — the insight layer adds no
+/// independent forecasting, it interprets the existing one.
+enum CashFlowForecastInsights {
+  /// Flag when the projected current-funds balance dips below `buffer`
+  /// within the horizon — the user is heading for a shortfall, optionally
+  /// attributable to a known upcoming bill.
+  static func upcomingBillWarning(
+    dailyBalances: [DailyBalance],
+    scheduledBills: [ScheduledBill],
+    context: InsightContext,
+    horizonDays: Int = 35,
+    buffer: InstrumentAmount? = nil
+  ) -> [Insight] {
+    let bufferQuantity = buffer?.quantity ?? 0
+    let forecast = dailyBalances
+      .filter { $0.isForecast && context.daysUntil($0.date) >= 0 && context.daysUntil($0.date) <= horizonDays }
+      .sorted { $0.date < $1.date }
+    guard let trough = forecast.min(by: { $0.balance.quantity < $1.balance.quantity }) else {
+      return []
+    }
+    guard trough.balance.quantity < bufferQuantity else { return [] }
+
+    let culprit = scheduledBills
+      .filter { context.daysUntil($0.date) >= 0 && $0.date <= trough.date && $0.amount.quantity < 0 }
+      .min { $0.amount.quantity < $1.amount.quantity }
+    let shortfall = bufferQuantity - trough.balance.quantity
+    let dateText = trough.date.formatted(.dateTime.month(.abbreviated).day())
+
+    var facts: [InsightFact] = [
+      InsightFact("Lowest projected", context.formatted(trough.balance)),
+      InsightFact("On", dateText),
+    ]
+    if buffer != nil {
+      facts.append(InsightFact("Buffer", context.formatted(bufferQuantity)))
+    }
+    if let culprit, let payee = culprit.payee {
+      facts.append(InsightFact("Upcoming bill", "\(payee) \(context.formatted(culprit.amount))"))
+    }
+
+    return [
+      Insight(
+        id: "\(InsightKind.upcomingBillWarning.rawValue):\(trough.date.timeIntervalSince1970)",
+        kind: .upcomingBillWarning,
+        title: "Low balance coming up",
+        detail:
+          "Your balance is projected to fall to \(context.formatted(trough.balance)) "
+          + "around \(dateText)\(culprit?.payee.map { ", after \($0)" } ?? "").",
+        date: context.now,
+        framing: .negative,
+        actionability: .act,
+        surprise: 0.8,
+        monetaryImpact: InstrumentAmount(
+          quantity: -shortfall, instrument: context.reportingCurrency),
+        facts: facts,
+        references: InsightReferences(
+          accountIds: culprit?.accountId.map { [$0] } ?? [],
+          instrumentIds: [context.reportingCurrency.id]))
+    ]
+  }
+
+  /// Projected end-of-current-financial-month balance with a confidence
+  /// band from recent daily-change volatility (design §D-15). Informational
+  /// and positive-leaning — a forward-looking "here's where you'll land".
+  static func projectedMonthEnd(
+    dailyBalances: [DailyBalance],
+    context: InsightContext
+  ) -> [Insight] {
+    let forecast = dailyBalances.filter(\.isForecast).sorted { $0.date < $1.date }
+    guard !forecast.isEmpty else { return [] }
+    let currentBucket = FinancialMonth.key(
+      for: context.now, monthEnd: context.financialMonthEnd)
+    let withinMonth = forecast.filter {
+      FinancialMonth.key(for: $0.date, monthEnd: context.financialMonthEnd) == currentBucket
+    }
+    guard let monthEndDay = withinMonth.last ?? forecast.first else { return [] }
+
+    let band = confidenceBand(dailyBalances: dailyBalances)
+    let projected = monthEndDay.balance.quantity
+    return [
+      Insight(
+        id: "\(InsightKind.projectedMonthEndBalance.rawValue):\(currentBucket)",
+        kind: .projectedMonthEndBalance,
+        title: "On track to end the month around \(context.formatted(projected))",
+        detail:
+          "Based on your scheduled activity, you're projected to finish the month "
+          + "with about \(context.formatted(projected)) in available funds (±\(context.formatted(band))).",
+        date: monthEndDay.date,
+        framing: projected >= 0 ? .positive : .negative,
+        actionability: .informational,
+        surprise: 0.2,
+        monetaryImpact: InstrumentAmount(
+          quantity: projected, instrument: context.reportingCurrency),
+        facts: [
+          InsightFact("Projected balance", context.formatted(projected)),
+          InsightFact("Confidence band", "±\(context.formatted(band))"),
+        ],
+        references: InsightReferences(instrumentIds: [context.reportingCurrency.id]))
+    ]
+  }
+
+  /// Standard deviation of day-over-day balance changes in the historical
+  /// tail, used as a ± band. Falls back to zero when too little history.
+  private static func confidenceBand(dailyBalances: [DailyBalance]) -> Decimal {
+    let actual = dailyBalances.filter { !$0.isForecast }.sorted { $0.date < $1.date }
+    guard actual.count >= 3 else { return 0 }
+    var deltas: [Double] = []
+    for index in 1..<actual.count {
+      let change = actual[index].balance.quantity - actual[index - 1].balance.quantity
+      deltas.append(Double(truncating: change as NSDecimalNumber))
+    }
+    let deviation = DescriptiveStatistics.standardDeviation(deltas)
+    // Roughly two weeks of accumulated daily noise as the band.
+    return Decimal(deviation * 14.0.squareRoot())
+  }
+}

--- a/Domain/Insights/Detectors/CategoryAnomalyInsight.swift
+++ b/Domain/Insights/Detectors/CategoryAnomalyInsight.swift
@@ -1,0 +1,95 @@
+import Foundation
+
+/// Category spending anomaly (design §B-6): the latest month's spend for a
+/// category is a robust-z outlier on the remainder of a seasonal-trend
+/// decomposition ("dining up 40% this month"). Decomposing first means a
+/// recurring seasonal bump (December gifts, summer travel) is absorbed into
+/// the seasonal term instead of mis-firing as an anomaly.
+///
+/// Only *over*-spend is flagged (positive remainder). The most recent
+/// financial month may be incomplete, which can only depress spend, so
+/// restricting to over-spend sidesteps partial-month false positives;
+/// under-spend reaches the user through the positive-framed budget and MoM
+/// detectors instead.
+enum CategoryAnomalyInsight {
+  static func detect(
+    breakdown: [ExpenseBreakdown],
+    categories: Categories,
+    context: InsightContext,
+    minimumMonths: Int = 6,
+    threshold: Double = 3,
+    minimumOverspendFraction: Double = 0.25
+  ) -> [Insight] {
+    let series = CategorySpendSeries.build(
+      from: breakdown, reportingCurrency: context.reportingCurrency)
+
+    var insights: [Insight] = []
+    for (categoryId, points) in series where points.count >= minimumMonths {
+      guard let insight = evaluate(
+        categoryId: categoryId, points: points, categories: categories,
+        context: context, threshold: threshold,
+        minimumOverspendFraction: minimumOverspendFraction)
+      else { continue }
+      insights.append(insight)
+    }
+    return insights
+  }
+
+  private static func evaluate(
+    categoryId: UUID,
+    points: [MonthlySpendPoint],
+    categories: Categories,
+    context: InsightContext,
+    threshold: Double,
+    minimumOverspendFraction: Double
+  ) -> Insight? {
+    let magnitudes = points.map(\.magnitude)
+    let decomposition = SeasonalDecomposition.decompose(magnitudes, period: 12)
+    let remainder = decomposition.remainder
+    guard let latest = points.last, remainder.count == points.count else { return nil }
+
+    let latestRemainder = remainder[remainder.count - 1]
+    let priorRemainders = Array(remainder.dropLast())
+    let zScore = DescriptiveStatistics.robustZScore(of: latestRemainder, in: priorRemainders)
+    guard zScore >= threshold, latestRemainder > 0 else { return nil }
+
+    let expected = decomposition.trend[remainder.count - 1]
+      + decomposition.seasonal[remainder.count - 1]
+    guard expected > 0 else { return nil }
+    let overspendFraction = latestRemainder / expected
+    guard overspendFraction >= minimumOverspendFraction else { return nil }
+
+    let resolved = categoryId == CategorySpendSeries.uncategorizedKey
+      ? nil : categories.by(id: categoryId)
+    let categoryName = resolved.map { categories.path(for: $0) } ?? "Uncategorized"
+
+    return Insight(
+      id: "\(InsightKind.categorySpendingAnomaly.rawValue):\(categoryId.uuidString):\(latest.month)",
+      kind: .categorySpendingAnomaly,
+      title: "\(categoryName) up this month",
+      detail:
+        "\(categoryName) spend of \(context.formatted(Decimal(-latest.magnitude))) is "
+        + "\(percent(overspendFraction)) above the \(context.formatted(Decimal(-expected))) "
+        + "you'd typically expect this month.",
+      date: latest.date,
+      framing: .negative,
+      actionability: .review,
+      surprise: NormalDistribution.surprise(fromZScore: zScore),
+      monetaryImpact: InstrumentAmount(
+        quantity: Decimal(-latestRemainder), instrument: context.reportingCurrency),
+      facts: [
+        InsightFact("Category", categoryName),
+        InsightFact("This month", context.formatted(Decimal(-latest.magnitude))),
+        InsightFact("Expected", context.formatted(Decimal(-expected))),
+        InsightFact("Over by", percent(overspendFraction)),
+        InsightFact("Robust z-score", zScore.formatted(.number.precision(.fractionLength(1)))),
+      ],
+      references: InsightReferences(
+        categoryIds: resolved.map { [$0.id] } ?? [],
+        instrumentIds: [context.reportingCurrency.id]))
+  }
+
+  private static func percent(_ fraction: Double) -> String {
+    fraction.formatted(.percent.precision(.fractionLength(0)))
+  }
+}

--- a/Domain/Insights/Detectors/CategoryAnomalyInsight.swift
+++ b/Domain/Insights/Detectors/CategoryAnomalyInsight.swift
@@ -23,16 +23,27 @@ enum CategoryAnomalyInsight {
     let series = CategorySpendSeries.build(
       from: breakdown, reportingCurrency: context.reportingCurrency)
 
+    let bounds = Bounds(zScore: threshold, overspendFraction: minimumOverspendFraction)
     var insights: [Insight] = []
     for (categoryId, points) in series where points.count >= minimumMonths {
-      guard let insight = evaluate(
-        categoryId: categoryId, points: points, categories: categories,
-        context: context, threshold: threshold,
-        minimumOverspendFraction: minimumOverspendFraction)
+      guard
+        let insight = evaluate(
+          categoryId: categoryId,
+          points: points,
+          categories: categories,
+          context: context,
+          bounds: bounds)
       else { continue }
       insights.append(insight)
     }
     return insights
+  }
+
+  /// The two gate values an anomaly must clear, bundled to keep `evaluate`
+  /// within the parameter-count budget.
+  private struct Bounds {
+    let zScore: Double
+    let overspendFraction: Double
   }
 
   private static func evaluate(
@@ -40,8 +51,7 @@ enum CategoryAnomalyInsight {
     points: [MonthlySpendPoint],
     categories: Categories,
     context: InsightContext,
-    threshold: Double,
-    minimumOverspendFraction: Double
+    bounds: Bounds
   ) -> Insight? {
     let magnitudes = points.map(\.magnitude)
     let decomposition = SeasonalDecomposition.decompose(magnitudes, period: 12)
@@ -51,20 +61,23 @@ enum CategoryAnomalyInsight {
     let latestRemainder = remainder[remainder.count - 1]
     let priorRemainders = Array(remainder.dropLast())
     let zScore = DescriptiveStatistics.robustZScore(of: latestRemainder, in: priorRemainders)
-    guard zScore >= threshold, latestRemainder > 0 else { return nil }
+    guard zScore >= bounds.zScore, latestRemainder > 0 else { return nil }
 
-    let expected = decomposition.trend[remainder.count - 1]
+    let expected =
+      decomposition.trend[remainder.count - 1]
       + decomposition.seasonal[remainder.count - 1]
     guard expected > 0 else { return nil }
     let overspendFraction = latestRemainder / expected
-    guard overspendFraction >= minimumOverspendFraction else { return nil }
+    guard overspendFraction >= bounds.overspendFraction else { return nil }
 
-    let resolved = categoryId == CategorySpendSeries.uncategorizedKey
+    let resolved =
+      categoryId == CategorySpendSeries.uncategorizedKey
       ? nil : categories.by(id: categoryId)
     let categoryName = resolved.map { categories.path(for: $0) } ?? "Uncategorized"
 
     return Insight(
-      id: "\(InsightKind.categorySpendingAnomaly.rawValue):\(categoryId.uuidString):\(latest.month)",
+      id:
+        "\(InsightKind.categorySpendingAnomaly.rawValue):\(categoryId.uuidString):\(latest.month)",
       kind: .categorySpendingAnomaly,
       title: "\(categoryName) up this month",
       detail:

--- a/Domain/Insights/Detectors/CategoryMixShiftInsight.swift
+++ b/Domain/Insights/Detectors/CategoryMixShiftInsight.swift
@@ -35,7 +35,8 @@ enum CategoryMixShiftInsight {
       }
     }
 
-    return shifts
+    return
+      shifts
       .sorted { abs($0.shift) > abs($1.shift) }
       .prefix(maximumResults)
       .map { makeInsight($0, recentMonth: recentMonth, categories: categories, context: context) }
@@ -74,7 +75,8 @@ enum CategoryMixShiftInsight {
     categories: Categories,
     context: InsightContext
   ) -> Insight {
-    let resolved = shift.categoryId == CategorySpendSeries.uncategorizedKey
+    let resolved =
+      shift.categoryId == CategorySpendSeries.uncategorizedKey
       ? nil : categories.by(id: shift.categoryId)
     let categoryName = resolved.map { categories.path(for: $0) } ?? "Uncategorized"
     let grew = shift.shift > 0

--- a/Domain/Insights/Detectors/CategoryMixShiftInsight.swift
+++ b/Domain/Insights/Detectors/CategoryMixShiftInsight.swift
@@ -1,0 +1,110 @@
+import Foundation
+
+/// Category-mix shift (design §C-12): a category whose share of total spend
+/// moved by more than `minimumShiftPoints` percentage points between the
+/// most recent complete month and the month before. Surfaces only the
+/// largest shifts to avoid flooding (a mix shift is informational, not
+/// actionable).
+enum CategoryMixShiftInsight {
+  static func detect(
+    breakdown: [ExpenseBreakdown],
+    categories: Categories,
+    context: InsightContext,
+    minimumShiftPoints: Double = 0.08,
+    maximumResults: Int = 2
+  ) -> [Insight] {
+    let currentBucket = FinancialMonth.key(
+      for: context.now, monthEnd: context.financialMonthEnd)
+    let completeMonths = Set(breakdown.map(\.month)).filter { $0 < currentBucket }.sorted()
+    guard completeMonths.count >= 2 else { return [] }
+    let recentMonth = completeMonths[completeMonths.count - 1]
+    let priorMonth = completeMonths[completeMonths.count - 2]
+
+    let recent = shares(in: breakdown, month: recentMonth)
+    let prior = shares(in: breakdown, month: priorMonth)
+    guard recent.total > 0, prior.total > 0 else { return [] }
+
+    let categoryIds = Set(recent.byCategory.keys).union(prior.byCategory.keys)
+    var shifts: [Shift] = []
+    for categoryId in categoryIds {
+      let recentShare = recent.byCategory[categoryId] ?? 0
+      let priorShare = prior.byCategory[categoryId] ?? 0
+      let shift = recentShare - priorShare
+      if abs(shift) >= minimumShiftPoints {
+        shifts.append(Shift(categoryId: categoryId, shift: shift, recentShare: recentShare))
+      }
+    }
+
+    return shifts
+      .sorted { abs($0.shift) > abs($1.shift) }
+      .prefix(maximumResults)
+      .map { makeInsight($0, recentMonth: recentMonth, categories: categories, context: context) }
+  }
+
+  /// One category's share movement between the two compared months.
+  private struct Shift {
+    let categoryId: UUID
+    let shift: Double
+    let recentShare: Double
+  }
+
+  private struct ShareBreakdown {
+    let total: Double
+    let byCategory: [UUID: Double]
+  }
+
+  private static func shares(in breakdown: [ExpenseBreakdown], month: String) -> ShareBreakdown {
+    var magnitudes: [UUID: Double] = [:]
+    var total = 0.0
+    for row in breakdown where row.month == month {
+      let signed = Double(truncating: row.totalExpenses.quantity as NSDecimalNumber)
+      let magnitude = max(-signed, 0)
+      let key = row.categoryId ?? CategorySpendSeries.uncategorizedKey
+      magnitudes[key, default: 0] += magnitude
+      total += magnitude
+    }
+    guard total > 0 else { return ShareBreakdown(total: 0, byCategory: [:]) }
+    let shares = magnitudes.mapValues { $0 / total }
+    return ShareBreakdown(total: total, byCategory: shares)
+  }
+
+  private static func makeInsight(
+    _ shift: Shift,
+    recentMonth: String,
+    categories: Categories,
+    context: InsightContext
+  ) -> Insight {
+    let resolved = shift.categoryId == CategorySpendSeries.uncategorizedKey
+      ? nil : categories.by(id: shift.categoryId)
+    let categoryName = resolved.map { categories.path(for: $0) } ?? "Uncategorized"
+    let grew = shift.shift > 0
+    let monthDate = CategorySpendSeries.monthDate(recentMonth) ?? context.now
+    return Insight(
+      id: "\(InsightKind.categoryMixShift.rawValue):\(shift.categoryId.uuidString):\(recentMonth)",
+      kind: .categoryMixShift,
+      title: "\(categoryName) is a \(grew ? "bigger" : "smaller") slice",
+      detail:
+        "\(categoryName) is now \(percent(shift.recentShare)) of your spending, "
+        + "\(grew ? "up" : "down") \(points(abs(shift.shift))) from the month before.",
+      date: monthDate,
+      framing: .neutral,
+      actionability: .informational,
+      surprise: min(abs(shift.shift) * 3, 1),
+      monetaryImpact: nil,
+      facts: [
+        InsightFact("Category", categoryName),
+        InsightFact("Current share", percent(shift.recentShare)),
+        InsightFact("Change", "\(grew ? "+" : "−")\(points(abs(shift.shift)))"),
+      ],
+      references: InsightReferences(
+        categoryIds: resolved.map { [$0.id] } ?? []))
+  }
+
+  private static func percent(_ fraction: Double) -> String {
+    fraction.formatted(.percent.precision(.fractionLength(0)))
+  }
+
+  private static func points(_ fraction: Double) -> String {
+    "\((fraction * 100).formatted(.number.precision(.fractionLength(0)))) pts"
+  }
+}

--- a/Domain/Insights/Detectors/CategoryTrendInsight.swift
+++ b/Domain/Insights/Detectors/CategoryTrendInsight.swift
@@ -1,0 +1,94 @@
+import Foundation
+
+/// Monotonic category trend (design §C-10): a category whose monthly spend
+/// is rising (or falling) over the trailing window, established by the
+/// Mann-Kendall test with a Sen's-slope magnitude.
+///
+/// Benjamini-Hochberg FDR control is applied across the whole family of
+/// per-category tests before anything is surfaced — without it, testing
+/// dozens of categories manufactures spurious "trends" and spams the user.
+/// A falling-spend trend is framed positively; a rising one negatively.
+enum CategoryTrendInsight {
+  static func detect(
+    breakdown: [ExpenseBreakdown],
+    categories: Categories,
+    context: InsightContext,
+    windowMonths: Int = 12,
+    minimumMonths: Int = 4,
+    fdr: Double = 0.1,
+    minimumRelativeChange: Double = 0.2
+  ) -> [Insight] {
+    let series = CategorySpendSeries.build(
+      from: breakdown, reportingCurrency: context.reportingCurrency)
+
+    var results: [UUID: (result: MannKendallResult, points: [MonthlySpendPoint])] = [:]
+    var hypotheses: [PValue<UUID>] = []
+    for (categoryId, allPoints) in series {
+      let points = Array(allPoints.suffix(windowMonths))
+      guard points.count >= minimumMonths else { continue }
+      let magnitudes = points.map(\.magnitude)
+      guard let result = MannKendall.test(magnitudes) else { continue }
+
+      let mean = DescriptiveStatistics.mean(magnitudes)
+      guard mean > 0 else { continue }
+      let cumulativeChange = abs(result.sensSlope) * Double(points.count - 1)
+      guard cumulativeChange >= minimumRelativeChange * mean else { continue }
+
+      results[categoryId] = (result, points)
+      hypotheses.append(PValue(tag: categoryId, pValue: result.pValue))
+    }
+
+    let significant = BenjaminiHochberg.significant(hypotheses, fdr: fdr)
+    return significant.compactMap { hypothesis in
+      guard let entry = results[hypothesis.tag] else { return nil }
+      return makeInsight(
+        categoryId: hypothesis.tag, result: entry.result, points: entry.points,
+        categories: categories, context: context)
+    }
+  }
+
+  private static func makeInsight(
+    categoryId: UUID,
+    result: MannKendallResult,
+    points: [MonthlySpendPoint],
+    categories: Categories,
+    context: InsightContext
+  ) -> Insight? {
+    guard result.statistic != 0, let latest = points.last else { return nil }
+    let months = points.count
+    let totalChange = result.sensSlope * Double(months - 1)
+    let resolved = categoryId == CategorySpendSeries.uncategorizedKey
+      ? nil : categories.by(id: categoryId)
+    let categoryName = resolved.map { categories.path(for: $0) } ?? "Uncategorized"
+    let rising = result.isIncreasing
+    let kind: InsightKind = rising ? .categoryTrendRising : .categoryTrendFalling
+    let perMonth = context.formatted(Decimal(-abs(result.sensSlope)))
+    let direction = rising ? "rising" : "easing"
+
+    return Insight(
+      id: "\(kind.rawValue):\(categoryId.uuidString)",
+      kind: kind,
+      title: "\(categoryName) spend \(direction)",
+      detail:
+        "\(categoryName) has been \(direction) for about \(months) months — "
+        + "roughly \(perMonth)/month, \(rising ? "up" : "down") "
+        + "\(context.formatted(Decimal(-abs(totalChange)))) over the period.",
+      date: latest.date,
+      framing: rising ? .negative : .positive,
+      actionability: .review,
+      surprise: NormalDistribution.surprise(fromZScore: result.zScore),
+      monetaryImpact: InstrumentAmount(
+        quantity: Decimal(rising ? -abs(totalChange) : abs(totalChange)),
+        instrument: context.reportingCurrency),
+      facts: [
+        InsightFact("Category", categoryName),
+        InsightFact("Direction", rising ? "Rising" : "Falling"),
+        InsightFact("Per month", perMonth),
+        InsightFact("Over \(months) months", context.formatted(Decimal(-abs(totalChange)))),
+        InsightFact("Trend p-value", result.pValue.formatted(.number.precision(.fractionLength(3)))),
+      ],
+      references: InsightReferences(
+        categoryIds: resolved.map { [$0.id] } ?? [],
+        instrumentIds: [context.reportingCurrency.id]))
+  }
+}

--- a/Domain/Insights/Detectors/CategoryTrendInsight.swift
+++ b/Domain/Insights/Detectors/CategoryTrendInsight.swift
@@ -42,8 +42,11 @@ enum CategoryTrendInsight {
     return significant.compactMap { hypothesis in
       guard let entry = results[hypothesis.tag] else { return nil }
       return makeInsight(
-        categoryId: hypothesis.tag, result: entry.result, points: entry.points,
-        categories: categories, context: context)
+        categoryId: hypothesis.tag,
+        result: entry.result,
+        points: entry.points,
+        categories: categories,
+        context: context)
     }
   }
 
@@ -57,7 +60,8 @@ enum CategoryTrendInsight {
     guard result.statistic != 0, let latest = points.last else { return nil }
     let months = points.count
     let totalChange = result.sensSlope * Double(months - 1)
-    let resolved = categoryId == CategorySpendSeries.uncategorizedKey
+    let resolved =
+      categoryId == CategorySpendSeries.uncategorizedKey
       ? nil : categories.by(id: categoryId)
     let categoryName = resolved.map { categories.path(for: $0) } ?? "Uncategorized"
     let rising = result.isIncreasing
@@ -85,7 +89,8 @@ enum CategoryTrendInsight {
         InsightFact("Direction", rising ? "Rising" : "Falling"),
         InsightFact("Per month", perMonth),
         InsightFact("Over \(months) months", context.formatted(Decimal(-abs(totalChange)))),
-        InsightFact("Trend p-value", result.pValue.formatted(.number.precision(.fractionLength(3)))),
+        InsightFact(
+          "Trend p-value", result.pValue.formatted(.number.precision(.fractionLength(3)))),
       ],
       references: InsightReferences(
         categoryIds: resolved.map { [$0.id] } ?? [],

--- a/Domain/Insights/Detectors/DataQualityInsights.swift
+++ b/Domain/Insights/Detectors/DataQualityInsights.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+/// Data-quality insights (research follow-up §B-1, §C-1). These don't quantify
+/// money — they protect the inputs every *other* detector relies on. A large
+/// uncategorized backlog blinds the category detectors; unmerged transfers
+/// double-count as phantom income + expense and distort spend, savings-rate,
+/// and trend figures.
+enum DataQualityInsights {
+  /// Nudge to categorize a backlog of imported transactions (C-1).
+  static func uncategorizedBacklog(
+    _ input: InsightInput, minimumCount: Int = 10
+  ) -> [Insight] {
+    let count = input.uncategorizedTransactionCount
+    guard count >= minimumCount else { return [] }
+    let context = input.context
+    return [
+      Insight(
+        id: "\(InsightKind.uncategorizedBacklog.rawValue):\(monthKey(context))",
+        kind: .uncategorizedBacklog,
+        title: "\(count) transactions need a category",
+        detail:
+          "Categorizing your \(count) uncategorized transactions will sharpen your "
+          + "spending breakdowns and the insights built on them.",
+        date: context.now,
+        framing: .neutral,
+        actionability: .review,
+        surprise: min(Double(count) / 100, 0.6),
+        monetaryImpact: nil,
+        facts: [InsightFact("Uncategorized", "\(count)")],
+        references: InsightReferences())
+    ]
+  }
+
+  /// Flag a backlog of unmerged transfer suggestions (B-1).
+  static func unreconciledTransfers(
+    _ input: InsightInput, minimumCount: Int = 3
+  ) -> [Insight] {
+    let count = input.pendingTransferCount
+    guard count >= minimumCount else { return [] }
+    let context = input.context
+    let agedText =
+      input.oldestPendingTransferDate.map { date -> String in
+        let days = context.daysSince(date)
+        return days > 0 ? " The oldest has been waiting \(days) days." : ""
+      } ?? ""
+    return [
+      Insight(
+        id: "\(InsightKind.unreconciledTransfers.rawValue):\(monthKey(context))",
+        kind: .unreconciledTransfers,
+        title: "\(count) transfers waiting to be merged",
+        detail:
+          "You have \(count) likely transfers between your own accounts that aren't "
+          + "merged yet — until they are, they inflate your income and spending."
+          + agedText,
+        date: context.now,
+        framing: .neutral,
+        actionability: .act,
+        surprise: min(Double(count) / 20, 0.6),
+        monetaryImpact: nil,
+        facts: [InsightFact("Pending transfers", "\(count)")],
+        references: InsightReferences())
+    ]
+  }
+
+  private static func monthKey(_ context: InsightContext) -> String {
+    FinancialMonth.key(for: context.now, monthEnd: context.financialMonthEnd)
+  }
+}

--- a/Domain/Insights/Detectors/EarmarkBudgetInsights.swift
+++ b/Domain/Insights/Detectors/EarmarkBudgetInsights.swift
@@ -20,9 +20,11 @@ enum EarmarkBudgetInsights {
       else { continue }
 
       if projection.fraction > 1 + overspendTolerance {
-        insights.append(overspend(earmark, budget: budget, projection: projection, context: context))
+        insights.append(
+          overspend(earmark, budget: budget, projection: projection, context: context))
       } else if projection.fraction < 1 - underspendTolerance, projection.elapsedFraction >= 0.5 {
-        insights.append(underspend(earmark, budget: budget, projection: projection, context: context))
+        insights.append(
+          underspend(earmark, budget: budget, projection: projection, context: context))
       }
     }
     return insights
@@ -48,7 +50,8 @@ enum EarmarkBudgetInsights {
     spent: InstrumentAmount, budget: InstrumentAmount, window: Window, context: InsightContext
   ) -> Projection? {
     let calendar = context.calendar
-    let totalDays = max(calendar.dateComponents([.day], from: window.start, to: window.end).day ?? 0, 1)
+    let totalDays = max(
+      calendar.dateComponents([.day], from: window.start, to: window.end).day ?? 0, 1)
     let elapsedRaw = calendar.dateComponents([.day], from: window.start, to: context.now).day ?? 0
     let elapsedDays = min(max(elapsedRaw, 0), totalDays)
     guard elapsedDays > 0, elapsedDays < totalDays else { return nil }
@@ -61,14 +64,19 @@ enum EarmarkBudgetInsights {
     guard budgetMagnitude > 0 else { return nil }
     let projected = spentMagnitude / elapsedFraction
     return Projection(
-      spentMagnitude: spentMagnitude, projected: projected, budgetMagnitude: budgetMagnitude,
-      fraction: projected / budgetMagnitude, elapsedFraction: elapsedFraction)
+      spentMagnitude: spentMagnitude,
+      projected: projected,
+      budgetMagnitude: budgetMagnitude,
+      fraction: projected / budgetMagnitude,
+      elapsedFraction: elapsedFraction)
   }
 
   // MARK: - Insight construction
 
   private static func overspend(
-    _ earmark: EarmarkSnapshot, budget: InstrumentAmount, projection: Projection,
+    _ earmark: EarmarkSnapshot,
+    budget: InstrumentAmount,
+    projection: Projection,
     context: InsightContext
   ) -> Insight {
     let overBy = Decimal(projection.projected - projection.budgetMagnitude)
@@ -90,7 +98,9 @@ enum EarmarkBudgetInsights {
   }
 
   private static func underspend(
-    _ earmark: EarmarkSnapshot, budget: InstrumentAmount, projection: Projection,
+    _ earmark: EarmarkSnapshot,
+    budget: InstrumentAmount,
+    projection: Projection,
     context: InsightContext
   ) -> Insight {
     let roomToSpare = Decimal(projection.budgetMagnitude - projection.projected)
@@ -105,7 +115,8 @@ enum EarmarkBudgetInsights {
       framing: .positive,
       actionability: .informational,
       surprise: min(1 - projection.fraction, 1),
-      monetaryImpact: InstrumentAmount(quantity: roomToSpare, instrument: context.reportingCurrency),
+      monetaryImpact: InstrumentAmount(
+        quantity: roomToSpare, instrument: context.reportingCurrency),
       facts: projectionFacts(budget: budget, projection: projection, context: context),
       references: InsightReferences(earmarkIds: [earmark.id]))
   }
@@ -117,7 +128,9 @@ enum EarmarkBudgetInsights {
       InsightFact("Budget", context.formatted(budget)),
       InsightFact("Spent so far", context.formatted(Decimal(projection.spentMagnitude))),
       InsightFact("Projected", context.formatted(Decimal(projection.projected))),
-      InsightFact("Window elapsed", projection.elapsedFraction.formatted(.percent.precision(.fractionLength(0)))),
+      InsightFact(
+        "Window elapsed",
+        projection.elapsedFraction.formatted(.percent.precision(.fractionLength(0)))),
     ]
   }
 

--- a/Domain/Insights/Detectors/EarmarkBudgetInsights.swift
+++ b/Domain/Insights/Detectors/EarmarkBudgetInsights.swift
@@ -1,0 +1,143 @@
+import Foundation
+
+/// Earmark (budget) performance insights (design §E): burndown projection
+/// (18) and the positive-framed under-spend counterpart (19). Both
+/// linearly extrapolate spend across the budget window — the under-spend
+/// branch is what keeps the feature from reading as a scold.
+enum EarmarkBudgetInsights {
+  static func detect(
+    earmarks: [EarmarkSnapshot],
+    context: InsightContext,
+    overspendTolerance: Double = 0.05,
+    underspendTolerance: Double = 0.1
+  ) -> [Insight] {
+    var insights: [Insight] = []
+    for earmark in earmarks where !earmark.isHidden {
+      guard let budget = earmark.budget, budget.quantity > 0,
+        let spent = earmark.spent,
+        let window = window(for: earmark, context: context),
+        let projection = project(spent: spent, budget: budget, window: window, context: context)
+      else { continue }
+
+      if projection.fraction > 1 + overspendTolerance {
+        insights.append(overspend(earmark, budget: budget, projection: projection, context: context))
+      } else if projection.fraction < 1 - underspendTolerance, projection.elapsedFraction >= 0.5 {
+        insights.append(underspend(earmark, budget: budget, projection: projection, context: context))
+      }
+    }
+    return insights
+  }
+
+  // MARK: - Projection
+
+  private struct Window {
+    let start: Date
+    let end: Date
+  }
+
+  /// Linear burndown projection of a budget window.
+  private struct Projection {
+    let spentMagnitude: Double
+    let projected: Double
+    let budgetMagnitude: Double
+    let fraction: Double
+    let elapsedFraction: Double
+  }
+
+  private static func project(
+    spent: InstrumentAmount, budget: InstrumentAmount, window: Window, context: InsightContext
+  ) -> Projection? {
+    let calendar = context.calendar
+    let totalDays = max(calendar.dateComponents([.day], from: window.start, to: window.end).day ?? 0, 1)
+    let elapsedRaw = calendar.dateComponents([.day], from: window.start, to: context.now).day ?? 0
+    let elapsedDays = min(max(elapsedRaw, 0), totalDays)
+    guard elapsedDays > 0, elapsedDays < totalDays else { return nil }
+
+    let elapsedFraction = Double(elapsedDays) / Double(totalDays)
+    // `EarmarkSnapshot.spent` is already a positive magnitude; clamp a stray
+    // negative to zero rather than re-flipping it.
+    let spentMagnitude = max(toDouble(spent.quantity), 0)
+    let budgetMagnitude = toDouble(budget.quantity)
+    guard budgetMagnitude > 0 else { return nil }
+    let projected = spentMagnitude / elapsedFraction
+    return Projection(
+      spentMagnitude: spentMagnitude, projected: projected, budgetMagnitude: budgetMagnitude,
+      fraction: projected / budgetMagnitude, elapsedFraction: elapsedFraction)
+  }
+
+  // MARK: - Insight construction
+
+  private static func overspend(
+    _ earmark: EarmarkSnapshot, budget: InstrumentAmount, projection: Projection,
+    context: InsightContext
+  ) -> Insight {
+    let overBy = Decimal(projection.projected - projection.budgetMagnitude)
+    return Insight(
+      id: "\(InsightKind.earmarkBurndownProjection.rawValue):\(earmark.id.uuidString)",
+      kind: .earmarkBurndownProjection,
+      title: "\(earmark.name) heading over budget",
+      detail:
+        "At your current pace you'll spend about \(context.formatted(Decimal(projection.projected))) "
+        + "against the \(context.formatted(budget)) \(earmark.name) budget — over by "
+        + "\(context.formatted(overBy)).",
+      date: context.now,
+      framing: .negative,
+      actionability: .act,
+      surprise: min(projection.fraction - 1, 1),
+      monetaryImpact: InstrumentAmount(quantity: -overBy, instrument: context.reportingCurrency),
+      facts: projectionFacts(budget: budget, projection: projection, context: context),
+      references: InsightReferences(earmarkIds: [earmark.id]))
+  }
+
+  private static func underspend(
+    _ earmark: EarmarkSnapshot, budget: InstrumentAmount, projection: Projection,
+    context: InsightContext
+  ) -> Insight {
+    let roomToSpare = Decimal(projection.budgetMagnitude - projection.projected)
+    return Insight(
+      id: "\(InsightKind.earmarkUnderspend.rawValue):\(earmark.id.uuidString)",
+      kind: .earmarkUnderspend,
+      title: "Room to spare in \(earmark.name)",
+      detail:
+        "You're on track to come in about \(context.formatted(roomToSpare)) under your "
+        + "\(context.formatted(budget)) \(earmark.name) budget. Nicely paced.",
+      date: context.now,
+      framing: .positive,
+      actionability: .informational,
+      surprise: min(1 - projection.fraction, 1),
+      monetaryImpact: InstrumentAmount(quantity: roomToSpare, instrument: context.reportingCurrency),
+      facts: projectionFacts(budget: budget, projection: projection, context: context),
+      references: InsightReferences(earmarkIds: [earmark.id]))
+  }
+
+  private static func projectionFacts(
+    budget: InstrumentAmount, projection: Projection, context: InsightContext
+  ) -> [InsightFact] {
+    [
+      InsightFact("Budget", context.formatted(budget)),
+      InsightFact("Spent so far", context.formatted(Decimal(projection.spentMagnitude))),
+      InsightFact("Projected", context.formatted(Decimal(projection.projected))),
+      InsightFact("Window elapsed", projection.elapsedFraction.formatted(.percent.precision(.fractionLength(0)))),
+    ]
+  }
+
+  /// Budget window: the explicit savings window when set, otherwise the
+  /// current calendar month (a pragmatic default for monthly budgets that
+  /// don't carry an explicit window — documented simplification).
+  private static func window(for earmark: EarmarkSnapshot, context: InsightContext) -> Window? {
+    if let start = earmark.savingsStartDate, let end = earmark.savingsEndDate, start < end {
+      return Window(start: start, end: end)
+    }
+    let calendar = context.calendar
+    let components = calendar.dateComponents([.year, .month], from: context.now)
+    guard let start = calendar.date(from: components),
+      let range = calendar.range(of: .day, in: .month, for: context.now),
+      let end = calendar.date(byAdding: .day, value: range.count, to: start)
+    else { return nil }
+    return Window(start: start, end: end)
+  }
+
+  private static func toDouble(_ value: Decimal) -> Double {
+    Double(truncating: value as NSDecimalNumber)
+  }
+}

--- a/Domain/Insights/Detectors/IncomeExtraInsights.swift
+++ b/Domain/Insights/Detectors/IncomeExtraInsights.swift
@@ -1,0 +1,114 @@
+import Foundation
+
+/// Income extensions (research follow-up §E-2, §E-3): a one-off windfall and
+/// a sustained pay-rate change. Both mirror existing expense techniques onto
+/// the income side, which the original catalog only ever analysed for spend.
+enum IncomeExtraInsights {
+  /// Windfall / one-off income alert (E-3): an income deposit that is a
+  /// robust-z outlier above the user's typical inflow. Positive framing —
+  /// the income-side counterpart of the large-transaction anomaly.
+  static func windfall(
+    transactions: [InsightTransaction],
+    context: InsightContext,
+    windowDays: Int = 30,
+    threshold: Double = 3.5
+  ) -> [Insight] {
+    let income = transactions.filter(\.isIncome)
+    guard income.count >= 6 else { return [] }
+    let magnitudes = income.map { Double(truncating: $0.incomeMagnitude as NSDecimalNumber) }
+
+    var best: InsightTransaction?
+    var bestScore = threshold
+    for transaction in income {
+      let age = context.daysSince(transaction.date)
+      guard age >= 0, age <= windowDays else { continue }
+      let value = Double(truncating: transaction.incomeMagnitude as NSDecimalNumber)
+      let zScore = DescriptiveStatistics.robustZScore(of: value, in: magnitudes)
+      if zScore >= bestScore {
+        bestScore = zScore
+        best = transaction
+      }
+    }
+    guard let windfall = best else { return [] }
+
+    let typical = DescriptiveStatistics.median(magnitudes)
+    return [
+      Insight(
+        id: "\(InsightKind.windfallIncome.rawValue):\(windfall.id.uuidString)",
+        kind: .windfallIncome,
+        title: "Larger-than-usual deposit",
+        detail:
+          "\(context.formatted(windfall.amount)) from \(payee(windfall)) is well above your "
+          + "typical income of \(context.formatted(Decimal(typical))) — a bonus or one-off?",
+        date: windfall.date,
+        framing: .positive,
+        actionability: .informational,
+        surprise: NormalDistribution.surprise(fromZScore: bestScore),
+        monetaryImpact: windfall.amountInReportingCurrency(context),
+        facts: [
+          InsightFact("Source", payee(windfall)),
+          InsightFact("Amount", context.formatted(windfall.amount)),
+          InsightFact("Typical income", context.formatted(Decimal(typical))),
+        ],
+        references: InsightReferences(
+          accountIds: windfall.accountId.map { [$0] } ?? [],
+          transactionIds: [windfall.id]))
+    ]
+  }
+
+  /// Pay-rate change (E-2): the latest recurring-income amount differs from
+  /// the stream's prior median by more than `threshold`. A rise is framed
+  /// positively (pay rise), a fall negatively (pay cut).
+  static func payRateChange(
+    incomeStreams: [DetectedSubscription],
+    context: InsightContext,
+    threshold: Double = 0.05
+  ) -> [Insight] {
+    guard
+      let stream = incomeStreams.max(by: { $0.monthlyCostMagnitude < $1.monthlyCostMagnitude }),
+      stream.amounts.count >= 3
+    else { return [] }
+    let priorMedian = DescriptiveStatistics.median(stream.amounts.dropLast().map(magnitude))
+    let latest = magnitude(stream.latestAmount)
+    guard priorMedian > 0 else { return [] }
+    let change = (latest - priorMedian) / priorMedian
+    guard abs(change) > threshold else { return [] }
+
+    let increased = change > 0
+    return [
+      Insight(
+        id: "\(InsightKind.payRateChange.rawValue):\(stream.id)",
+        kind: .payRateChange,
+        title: increased ? "Your pay went up" : "Your pay dropped",
+        detail:
+          "Your \(stream.displayPayee) income changed by \(percent(abs(change))) — now about "
+          + "\(context.formatted(stream.latestAmount)) versus a usual "
+          + "\(context.formatted(Decimal(priorMedian))).",
+        date: stream.lastDate,
+        framing: increased ? .positive : .negative,
+        actionability: .informational,
+        surprise: min(abs(change) * 2, 1),
+        monetaryImpact: InstrumentAmount(
+          quantity: Decimal(latest - priorMedian), instrument: context.reportingCurrency),
+        facts: [
+          InsightFact("Source", stream.displayPayee),
+          InsightFact("New amount", context.formatted(stream.latestAmount)),
+          InsightFact("Previous", context.formatted(Decimal(priorMedian))),
+          InsightFact("Change", "\(increased ? "+" : "−")\(percent(abs(change)))"),
+        ],
+        references: InsightReferences(accountIds: stream.accountId.map { [$0] } ?? []))
+    ]
+  }
+
+  private static func magnitude(_ value: Decimal) -> Double {
+    Double(truncating: (value < 0 ? -value : value) as NSDecimalNumber)
+  }
+
+  private static func payee(_ transaction: InsightTransaction) -> String {
+    transaction.rawPayee ?? "an unknown source"
+  }
+
+  private static func percent(_ fraction: Double) -> String {
+    fraction.formatted(.percent.precision(.fractionLength(0)))
+  }
+}

--- a/Domain/Insights/Detectors/IncomeInsights.swift
+++ b/Domain/Insights/Detectors/IncomeInsights.swift
@@ -64,7 +64,9 @@ enum IncomeInsights {
     _ stream: DetectedSubscription, context: InsightContext
   ) -> Insight? {
     guard stream.amounts.count >= 3 else { return nil }
-    let magnitudes = stream.amounts.map { Double(truncating: ($0 < 0 ? -$0 : $0) as NSDecimalNumber) }
+    let magnitudes = stream.amounts.map {
+      Double(truncating: ($0 < 0 ? -$0 : $0) as NSDecimalNumber)
+    }
     guard let variation = DescriptiveStatistics.coefficientOfVariation(magnitudes) else {
       return nil
     }
@@ -89,7 +91,8 @@ enum IncomeInsights {
       monetaryImpact: nil,
       facts: [
         InsightFact("Source", stream.displayPayee),
-        InsightFact("Stability", "\((score * 100).formatted(.number.precision(.fractionLength(0))))/100"),
+        InsightFact(
+          "Stability", "\((score * 100).formatted(.number.precision(.fractionLength(0))))/100"),
         InsightFact("Variation", percent(variation)),
       ],
       references: InsightReferences(

--- a/Domain/Insights/Detectors/IncomeInsights.swift
+++ b/Domain/Insights/Detectors/IncomeInsights.swift
@@ -1,0 +1,133 @@
+import Foundation
+
+/// Income-analysis insights (design §H), built on the same subscription
+/// clustering applied to positive-amount streams: paycheck timing (14),
+/// income stability score (29), and missing-paycheck alert (30).
+///
+/// The caller passes the already-detected income streams
+/// (`SubscriptionDetector.detect(incomeStreams: true)`) so the clustering
+/// runs once and is shared with any other income consumer.
+enum IncomeInsights {
+  static func detect(
+    incomeStreams: [DetectedSubscription],
+    context: InsightContext,
+    missedGraceDays: Int = 3
+  ) -> [Insight] {
+    guard let primary = incomeStreams.max(by: { $0.monthlyCostMagnitude < $1.monthlyCostMagnitude })
+    else { return [] }
+
+    var insights: [Insight] = []
+    if let missing = missingPaycheck(primary, context: context, grace: missedGraceDays) {
+      insights.append(missing)
+    } else if let timing = paycheckTiming(primary, context: context) {
+      insights.append(timing)
+    }
+    if let stability = stabilityScore(primary, context: context) {
+      insights.append(stability)
+    }
+    return insights
+  }
+
+  /// Project the next paycheck date and amount (14).
+  private static func paycheckTiming(
+    _ stream: DetectedSubscription, context: InsightContext
+  ) -> Insight? {
+    guard let next = stream.nextExpectedDate(calendar: context.calendar),
+      context.daysUntil(next) >= 0
+    else { return nil }
+    let dateText = next.formatted(.dateTime.month(.abbreviated).day())
+    return Insight(
+      id: "\(InsightKind.paycheckTimingPattern.rawValue):\(stream.id)",
+      kind: .paycheckTimingPattern,
+      title: "Next pay around \(dateText)",
+      detail:
+        "Your \(stream.period.displayName) income from \(stream.displayPayee) "
+        + "(about \(context.formatted(stream.medianAmount))) is next expected around \(dateText).",
+      date: context.now,
+      framing: .neutral,
+      actionability: .informational,
+      surprise: 0.15,
+      monetaryImpact: InstrumentAmount(
+        quantity: stream.medianAmount, instrument: context.reportingCurrency),
+      facts: [
+        InsightFact("Source", stream.displayPayee),
+        InsightFact("Typical amount", context.formatted(stream.medianAmount)),
+        InsightFact("Cadence", stream.period.displayName),
+        InsightFact("Next expected", dateText),
+      ],
+      references: InsightReferences(
+        accountIds: stream.accountId.map { [$0] } ?? []))
+  }
+
+  /// Income stability score (29): lower amount variation → higher score.
+  private static func stabilityScore(
+    _ stream: DetectedSubscription, context: InsightContext
+  ) -> Insight? {
+    guard stream.amounts.count >= 3 else { return nil }
+    let magnitudes = stream.amounts.map { Double(truncating: ($0 < 0 ? -$0 : $0) as NSDecimalNumber) }
+    guard let variation = DescriptiveStatistics.coefficientOfVariation(magnitudes) else {
+      return nil
+    }
+    let score = max(0, min(1, 1 - variation))
+    let descriptor: String
+    switch score {
+    case 0.85...: descriptor = "very steady"
+    case 0.6..<0.85: descriptor = "fairly steady"
+    default: descriptor = "variable"
+    }
+    return Insight(
+      id: "\(InsightKind.incomeStabilityScore.rawValue):\(stream.id)",
+      kind: .incomeStabilityScore,
+      title: "Your income is \(descriptor)",
+      detail:
+        "Your \(stream.displayPayee) income varies by about \(percent(variation)) "
+        + "pay to pay — \(descriptor).",
+      date: context.now,
+      framing: score >= 0.6 ? .positive : .neutral,
+      actionability: .informational,
+      surprise: 0.2,
+      monetaryImpact: nil,
+      facts: [
+        InsightFact("Source", stream.displayPayee),
+        InsightFact("Stability", "\((score * 100).formatted(.number.precision(.fractionLength(0))))/100"),
+        InsightFact("Variation", percent(variation)),
+      ],
+      references: InsightReferences(
+        accountIds: stream.accountId.map { [$0] } ?? []))
+  }
+
+  /// Missing-paycheck alert (30): expected pay overdue past the grace window.
+  private static func missingPaycheck(
+    _ stream: DetectedSubscription, context: InsightContext, grace: Int
+  ) -> Insight? {
+    guard let next = stream.nextExpectedDate(calendar: context.calendar) else { return nil }
+    let overdue = context.daysSince(next)
+    guard overdue > grace else { return nil }
+    let expectedText = next.formatted(.dateTime.month(.abbreviated).day())
+    return Insight(
+      id: "\(InsightKind.missingPaycheckAlert.rawValue):\(stream.id)",
+      kind: .missingPaycheckAlert,
+      title: "Expected pay hasn't arrived",
+      detail:
+        "Your \(stream.displayPayee) income (about \(context.formatted(stream.medianAmount))) "
+        + "was expected around \(expectedText) but hasn't shown up in \(overdue) days.",
+      date: context.now,
+      framing: .negative,
+      actionability: .act,
+      surprise: 0.65,
+      monetaryImpact: InstrumentAmount(
+        quantity: stream.medianAmount, instrument: context.reportingCurrency),
+      facts: [
+        InsightFact("Source", stream.displayPayee),
+        InsightFact("Expected", expectedText),
+        InsightFact("Days overdue", "\(overdue)"),
+        InsightFact("Typical amount", context.formatted(stream.medianAmount)),
+      ],
+      references: InsightReferences(
+        accountIds: stream.accountId.map { [$0] } ?? []))
+  }
+
+  private static func percent(_ fraction: Double) -> String {
+    max(fraction, 0).formatted(.percent.precision(.fractionLength(0)))
+  }
+}

--- a/Domain/Insights/Detectors/InvestmentInsights.swift
+++ b/Domain/Insights/Detectors/InvestmentInsights.swift
@@ -49,7 +49,8 @@ enum InvestmentInsights {
       framing: .neutral,
       actionability: .review,
       surprise: min(toDouble(share), 1),
-      monetaryImpact: InstrumentAmount(quantity: top.currentValue, instrument: context.reportingCurrency),
+      monetaryImpact: InstrumentAmount(
+        quantity: top.currentValue, instrument: context.reportingCurrency),
       facts: [
         InsightFact("Holding", top.instrument.displayLabel),
         InsightFact("Value", context.formatted(top.currentValue)),
@@ -62,7 +63,8 @@ enum InvestmentInsights {
   private static func performers(
     _ profitLoss: [InstrumentProfitLoss], minimumReturn: Decimal, context: InsightContext
   ) -> [Insight] {
-    let ranked = profitLoss
+    let ranked =
+      profitLoss
       .filter { $0.totalInvested > 0 && $0.currentValue > 0 }
       .sorted { $0.returnPercentage > $1.returnPercentage }
     guard ranked.count >= 2 else { return [] }
@@ -95,7 +97,8 @@ enum InvestmentInsights {
       framing: isTop ? .positive : .negative,
       actionability: isTop ? .informational : .review,
       surprise: min(toDouble(abs(position.returnPercentage)) / 100, 1),
-      monetaryImpact: InstrumentAmount(quantity: position.totalGain, instrument: context.reportingCurrency),
+      monetaryImpact: InstrumentAmount(
+        quantity: position.totalGain, instrument: context.reportingCurrency),
       facts: [
         InsightFact("Holding", label),
         InsightFact("Return", returnText),
@@ -122,7 +125,8 @@ enum InvestmentInsights {
     let offset = min(realized, -unrealizedLoss)
     let names = lossPositions.map(\.instrument.displayLabel).sorted().joined(separator: ", ")
     return Insight(
-      id: "\(InsightKind.capitalGainsHarvest.rawValue):\(context.calendar.component(.year, from: context.now))",
+      id:
+        "\(InsightKind.capitalGainsHarvest.rawValue):\(context.calendar.component(.year, from: context.now))",
       kind: .capitalGainsHarvest,
       title: "Possible tax-loss offset",
       detail:

--- a/Domain/Insights/Detectors/InvestmentInsights.swift
+++ b/Domain/Insights/Detectors/InvestmentInsights.swift
@@ -1,0 +1,157 @@
+import Foundation
+
+/// Investment insights (design §G): concentration risk (25), top / bottom
+/// performer (26), and a deliberately conservative capital-gains
+/// tax-harvest prompt (27). All operate on the per-instrument P&L that
+/// `ReportingStore` already computes; amounts are in the reporting currency.
+enum InvestmentInsights {
+  static func detect(
+    profitLoss: [InstrumentProfitLoss],
+    capitalGains: [CapitalGainEvent],
+    context: InsightContext,
+    concentrationThreshold: Decimal = 0.4,
+    minimumReturnFraction: Decimal = 0.1
+  ) -> [Insight] {
+    var insights: [Insight] = []
+    if let concentration = concentrationRisk(
+      profitLoss, threshold: concentrationThreshold, context: context)
+    {
+      insights.append(concentration)
+    }
+    insights.append(
+      contentsOf: performers(profitLoss, minimumReturn: minimumReturnFraction, context: context))
+    if let harvest = taxHarvest(profitLoss, capitalGains: capitalGains, context: context) {
+      insights.append(harvest)
+    }
+    return insights
+  }
+
+  /// Single instrument exceeding `threshold` of total investable value (25).
+  private static func concentrationRisk(
+    _ profitLoss: [InstrumentProfitLoss], threshold: Decimal, context: InsightContext
+  ) -> Insight? {
+    let positive = profitLoss.filter { $0.currentValue > 0 }
+    let total = positive.reduce(Decimal(0)) { $0 + $1.currentValue }
+    guard total > 0, positive.count >= 2,
+      let top = positive.max(by: { $0.currentValue < $1.currentValue })
+    else { return nil }
+    let share = top.currentValue / total
+    guard share > threshold else { return nil }
+
+    return Insight(
+      id: "\(InsightKind.investmentConcentrationRisk.rawValue):\(top.instrument.id)",
+      kind: .investmentConcentrationRisk,
+      title: "\(top.instrument.displayLabel) is a big slice",
+      detail:
+        "\(top.instrument.displayLabel) makes up \(percent(share)) of your investments — "
+        + "a concentrated position worth keeping an eye on.",
+      date: context.now,
+      framing: .neutral,
+      actionability: .review,
+      surprise: min(toDouble(share), 1),
+      monetaryImpact: InstrumentAmount(quantity: top.currentValue, instrument: context.reportingCurrency),
+      facts: [
+        InsightFact("Holding", top.instrument.displayLabel),
+        InsightFact("Value", context.formatted(top.currentValue)),
+        InsightFact("Share of portfolio", percent(share)),
+      ],
+      references: InsightReferences(instrumentIds: [top.instrument.id]))
+  }
+
+  /// Best and worst unrealised performers over the holding period (26).
+  private static func performers(
+    _ profitLoss: [InstrumentProfitLoss], minimumReturn: Decimal, context: InsightContext
+  ) -> [Insight] {
+    let ranked = profitLoss
+      .filter { $0.totalInvested > 0 && $0.currentValue > 0 }
+      .sorted { $0.returnPercentage > $1.returnPercentage }
+    guard ranked.count >= 2 else { return [] }
+    var insights: [Insight] = []
+
+    let minimumPercentage = minimumReturn * Decimal(100)
+    if let top = ranked.first, top.returnPercentage >= minimumPercentage {
+      insights.append(performerInsight(top, isTop: true, context: context))
+    }
+    if let bottom = ranked.last, bottom.returnPercentage <= -minimumPercentage {
+      insights.append(performerInsight(bottom, isTop: false, context: context))
+    }
+    return insights
+  }
+
+  private static func performerInsight(
+    _ position: InstrumentProfitLoss, isTop: Bool, context: InsightContext
+  ) -> Insight {
+    let kind: InsightKind = isTop ? .topPerformer : .bottomPerformer
+    let label = position.instrument.displayLabel
+    let returnText = percentFromPercentage(position.returnPercentage)
+    return Insight(
+      id: "\(kind.rawValue):\(position.instrument.id)",
+      kind: kind,
+      title: isTop ? "\(label) is your top performer" : "\(label) is lagging",
+      detail:
+        "\(label) is \(isTop ? "up" : "down") \(returnText) on your investment "
+        + "(\(context.formatted(position.totalGain))).",
+      date: context.now,
+      framing: isTop ? .positive : .negative,
+      actionability: isTop ? .informational : .review,
+      surprise: min(toDouble(abs(position.returnPercentage)) / 100, 1),
+      monetaryImpact: InstrumentAmount(quantity: position.totalGain, instrument: context.reportingCurrency),
+      facts: [
+        InsightFact("Holding", label),
+        InsightFact("Return", returnText),
+        InsightFact("Gain/loss", context.formatted(position.totalGain)),
+        InsightFact("Invested", context.formatted(position.totalInvested)),
+      ],
+      references: InsightReferences(instrumentIds: [position.instrument.id]))
+  }
+
+  /// Conservative tax-loss-harvest prompt (27): when realised gains are
+  /// positive for the period and unrealised losses exist, note that the
+  /// losses could offset the gains. Framed as a prompt to review, never as
+  /// tax advice — cross-jurisdiction correctness is out of scope (design
+  /// §G-27 "effectively a compliance product").
+  private static func taxHarvest(
+    _ profitLoss: [InstrumentProfitLoss], capitalGains: [CapitalGainEvent], context: InsightContext
+  ) -> Insight? {
+    let realized = capitalGains.reduce(Decimal(0)) { $0 + $1.gain }
+    guard realized > 0 else { return nil }
+    let lossPositions = profitLoss.filter { $0.unrealizedGain < 0 }
+    let unrealizedLoss = lossPositions.reduce(Decimal(0)) { $0 + $1.unrealizedGain }
+    guard unrealizedLoss < 0, !lossPositions.isEmpty else { return nil }
+
+    let offset = min(realized, -unrealizedLoss)
+    let names = lossPositions.map(\.instrument.displayLabel).sorted().joined(separator: ", ")
+    return Insight(
+      id: "\(InsightKind.capitalGainsHarvest.rawValue):\(context.calendar.component(.year, from: context.now))",
+      kind: .capitalGainsHarvest,
+      title: "Possible tax-loss offset",
+      detail:
+        "You've realised \(context.formatted(realized)) in gains this period and hold "
+        + "unrealised losses (\(names)). Realising some could offset up to "
+        + "\(context.formatted(offset)) — worth reviewing with your tax situation.",
+      date: context.now,
+      framing: .neutral,
+      actionability: .review,
+      surprise: 0.4,
+      monetaryImpact: InstrumentAmount(quantity: offset, instrument: context.reportingCurrency),
+      facts: [
+        InsightFact("Realised gains", context.formatted(realized)),
+        InsightFact("Unrealised losses", context.formatted(unrealizedLoss)),
+        InsightFact("Potential offset", context.formatted(offset)),
+        InsightFact("Loss positions", names),
+      ],
+      references: InsightReferences(instrumentIds: lossPositions.map(\.instrument.id)))
+  }
+
+  private static func toDouble(_ value: Decimal) -> Double {
+    Double(truncating: value as NSDecimalNumber)
+  }
+
+  private static func percent(_ fraction: Decimal) -> String {
+    toDouble(fraction).formatted(.percent.precision(.fractionLength(0)))
+  }
+
+  private static func percentFromPercentage(_ percentage: Decimal) -> String {
+    (toDouble(percentage) / 100).formatted(.percent.precision(.fractionLength(1)))
+  }
+}

--- a/Domain/Insights/Detectors/LargeTransactionInsight.swift
+++ b/Domain/Insights/Detectors/LargeTransactionInsight.swift
@@ -1,0 +1,87 @@
+import Foundation
+
+/// Large-transaction anomaly (design §B-7): a recent expense whose magnitude
+/// is a robust-z (MAD-z) outlier within its own category. MAD-z is used
+/// instead of a raw z-score because spending distributions are heavy-tailed
+/// and a single prior outlier would inflate a classic standard deviation.
+///
+/// Sparse categories (too few samples for a stable per-category scale) fall
+/// back to the global spend distribution — a pragmatic stand-in for the
+/// design's "Bayesian shrinkage toward a global prior".
+enum LargeTransactionInsight {
+  static func detect(
+    transactions: [InsightTransaction],
+    categories: Categories,
+    context: InsightContext,
+    windowDays: Int = 30,
+    threshold: Double = 3.5,
+    minimumCategorySamples: Int = 6
+  ) -> [Insight] {
+    let expenses = transactions.filter(\.isExpense)
+    guard expenses.count >= minimumCategorySamples else { return [] }
+
+    let globalMagnitudes = expenses.map(spendMagnitude)
+    let byCategory = Dictionary(grouping: expenses) { $0.categoryId }
+
+    var insights: [Insight] = []
+    for transaction in expenses {
+      guard context.daysSince(transaction.date) <= windowDays,
+        context.daysSince(transaction.date) >= 0
+      else { continue }
+
+      let categoryPeers = byCategory[transaction.categoryId] ?? []
+      let population =
+        categoryPeers.count >= minimumCategorySamples
+        ? categoryPeers.map(spendMagnitude)
+        : globalMagnitudes
+      let value = spendMagnitude(transaction)
+      let zScore = DescriptiveStatistics.robustZScore(of: value, in: population)
+      guard zScore >= threshold, value > 0 else { continue }
+
+      let typical = DescriptiveStatistics.median(population)
+      let categoryName = transaction.categoryPath ?? "Uncategorized"
+      insights.append(
+        Insight(
+          id: "\(InsightKind.largeTransactionAnomaly.rawValue):\(transaction.id.uuidString)",
+          kind: .largeTransactionAnomaly,
+          title: "Unusually large \(categoryName) charge",
+          detail:
+            "\(payeeName(transaction)) for \(context.formatted(transaction.amount)) is "
+            + "well above your typical \(categoryName) spend of "
+            + "\(context.formatted(Decimal(-typical))).",
+          date: transaction.date,
+          framing: .negative,
+          actionability: .review,
+          surprise: NormalDistribution.surprise(fromZScore: zScore),
+          monetaryImpact: transaction.amountInReportingCurrency(context),
+          facts: [
+            InsightFact("Merchant", payeeName(transaction)),
+            InsightFact("Amount", context.formatted(transaction.amount)),
+            InsightFact("Category", categoryName),
+            InsightFact("Typical for category", context.formatted(Decimal(-typical))),
+            InsightFact("Robust z-score", zScore.formatted(.number.precision(.fractionLength(1)))),
+          ],
+          references: InsightReferences(
+            accountIds: transaction.accountId.map { [$0] } ?? [],
+            categoryIds: transaction.categoryId.map { [$0] } ?? [],
+            transactionIds: [transaction.id])))
+    }
+    return insights
+  }
+
+  private static func spendMagnitude(_ transaction: InsightTransaction) -> Double {
+    Double(truncating: transaction.spendMagnitude as NSDecimalNumber)
+  }
+
+  private static func payeeName(_ transaction: InsightTransaction) -> String {
+    transaction.rawPayee ?? "A transaction"
+  }
+}
+
+extension InsightTransaction {
+  /// This record's signed amount as an `InstrumentAmount` in the reporting
+  /// currency — a convenience for detectors building `monetaryImpact`.
+  func amountInReportingCurrency(_ context: InsightContext) -> InstrumentAmount {
+    InstrumentAmount(quantity: amount, instrument: context.reportingCurrency)
+  }
+}

--- a/Domain/Insights/Detectors/LiquidityInsights.swift
+++ b/Domain/Insights/Detectors/LiquidityInsights.swift
@@ -1,0 +1,103 @@
+import Foundation
+
+/// Liquidity insights (design §D-17, §F-21): cash runway and idle-cash
+/// alert. Both compare the user's current liquid balance against their
+/// recent monthly burn / spend.
+enum LiquidityInsights {
+  /// Runway estimate (17): at the current net burn rate, how long liquid
+  /// cash lasts. Only meaningful when the user is net-negative; a surplus
+  /// month yields no runway insight (the savings-rate / projection
+  /// detectors cover the healthy case).
+  static func runway(
+    dailyBalances: [DailyBalance],
+    monthly: [MonthlyIncomeExpense],
+    context: InsightContext,
+    warnBelowMonths: Double = 6
+  ) -> [Insight] {
+    guard let liquid = InsightAggregates.latestActual(dailyBalances)?.balance,
+      liquid.quantity > 0,
+      let net = InsightAggregates.averageMonthlyNet(monthly, context: context),
+      net < 0
+    else { return [] }
+
+    let burn = -net
+    let burnDouble = Double(truncating: burn as NSDecimalNumber)
+    guard burnDouble > 0 else { return [] }
+    let months = Double(truncating: liquid.quantity as NSDecimalNumber) / burnDouble
+    let short = months <= warnBelowMonths
+
+    return [
+      Insight(
+        id: "\(InsightKind.runwayEstimate.rawValue):\(monthKey(context))",
+        kind: .runwayEstimate,
+        title: short ? "About \(monthsText(months)) of runway" : "\(monthsText(months)) of runway",
+        detail:
+          "You're spending about \(context.formatted(burn))/month more than you earn. "
+          + "At that rate your \(context.formatted(liquid)) covers roughly \(monthsText(months)).",
+        date: context.now,
+        framing: short ? .negative : .neutral,
+        actionability: short ? .act : .review,
+        surprise: short ? 0.7 : 0.35,
+        monetaryImpact: InstrumentAmount(quantity: -burn, instrument: context.reportingCurrency),
+        facts: [
+          InsightFact("Liquid cash", context.formatted(liquid)),
+          InsightFact("Monthly burn", context.formatted(burn)),
+          InsightFact("Runway", monthsText(months)),
+        ],
+        references: InsightReferences(instrumentIds: [context.reportingCurrency.id]))
+    ]
+  }
+
+  /// Idle-cash alert (21): liquid balance persistently far above the
+  /// 30-day outflow — money that could be earning more elsewhere. Excess is
+  /// `liquid − multiple × monthly spend`.
+  static func idleCash(
+    dailyBalances: [DailyBalance],
+    monthly: [MonthlyIncomeExpense],
+    context: InsightContext,
+    multiple: Decimal = 3
+  ) -> [Insight] {
+    guard let liquid = InsightAggregates.latestActual(dailyBalances)?.balance,
+      liquid.quantity > 0,
+      let spend = InsightAggregates.averageMonthlySpend(monthly, context: context),
+      spend > 0
+    else { return [] }
+
+    let cushion = spend * multiple
+    guard liquid.quantity > cushion else { return [] }
+    let excess = liquid.quantity - cushion
+
+    return [
+      Insight(
+        id: "\(InsightKind.idleCashAlert.rawValue):\(monthKey(context))",
+        kind: .idleCashAlert,
+        title: "Spare cash sitting idle",
+        detail:
+          "You're holding \(context.formatted(liquid)) — about "
+          + "\(context.formatted(excess)) more than the "
+          + "\(context.formatted(cushion)) buffer your spending needs. It could be working harder.",
+        date: context.now,
+        framing: .neutral,
+        actionability: .act,
+        surprise: 0.45,
+        monetaryImpact: InstrumentAmount(quantity: excess, instrument: context.reportingCurrency),
+        facts: [
+          InsightFact("Liquid cash", context.formatted(liquid)),
+          InsightFact("Suggested buffer", context.formatted(cushion)),
+          InsightFact("Idle excess", context.formatted(excess)),
+        ],
+        references: InsightReferences(instrumentIds: [context.reportingCurrency.id]))
+    ]
+  }
+
+  private static func monthsText(_ months: Double) -> String {
+    if months >= 24 {
+      return "\((months / 12).formatted(.number.precision(.fractionLength(1)))) years"
+    }
+    return "\(months.formatted(.number.precision(.fractionLength(0)))) months"
+  }
+
+  private static func monthKey(_ context: InsightContext) -> String {
+    FinancialMonth.key(for: context.now, monthEnd: context.financialMonthEnd)
+  }
+}

--- a/Domain/Insights/Detectors/NetWorthInsights.swift
+++ b/Domain/Insights/Detectors/NetWorthInsights.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+/// Net-worth milestone (design §G-24): net worth crossing a round-number
+/// threshold since the comparison point. Positive-framed by design — one of
+/// the guaranteed feel-good insights.
+enum NetWorthInsights {
+  static func detect(
+    dailyBalances: [DailyBalance],
+    context: InsightContext,
+    lookbackDays: Int = 35
+  ) -> [Insight] {
+    let actual = dailyBalances.filter { !$0.isForecast }.sorted { $0.date < $1.date }
+    guard let latest = actual.last else { return [] }
+    let current = latest.netWorth.quantity
+
+    let baseline = actual.last { context.daysSince($0.date) >= lookbackDays }?.netWorth.quantity
+      ?? actual.first?.netWorth.quantity
+    guard let baseline, current > baseline, current > 0 else { return [] }
+
+    let step = milestoneStep(for: current)
+    guard step > 0 else { return [] }
+    let crossed = highestMultiple(of: step, atOrBelow: current)
+    guard crossed > baseline, crossed > 0 else { return [] }
+
+    return [
+      Insight(
+        id: "\(InsightKind.netWorthMilestone.rawValue):\(decimalKey(crossed))",
+        kind: .netWorthMilestone,
+        title: "Net worth passed \(context.formatted(crossed))",
+        detail:
+          "Your net worth has crossed \(context.formatted(crossed)) — now about "
+          + "\(context.formatted(current)). Nice milestone.",
+        date: latest.date,
+        framing: .positive,
+        actionability: .informational,
+        surprise: 0.5,
+        monetaryImpact: latest.netWorth,
+        facts: [
+          InsightFact("Net worth", context.formatted(current)),
+          InsightFact("Milestone", context.formatted(crossed)),
+          InsightFact("Was", context.formatted(baseline)),
+        ],
+        references: InsightReferences(instrumentIds: [context.reportingCurrency.id]))
+    ]
+  }
+
+  /// Milestone granularity scales with magnitude so a $5k net worth gets
+  /// $1k steps and a $5M net worth gets $100k steps.
+  private static func milestoneStep(for value: Decimal) -> Decimal {
+    let magnitude = Double(truncating: value as NSDecimalNumber)
+    switch magnitude {
+    case ..<10_000: return 1_000
+    case ..<100_000: return 10_000
+    case ..<1_000_000: return 25_000
+    default: return 100_000
+    }
+  }
+
+  private static func highestMultiple(of step: Decimal, atOrBelow value: Decimal) -> Decimal {
+    guard step > 0 else { return 0 }
+    let quotient = (value / step) as NSDecimalNumber
+    let floored = floor(quotient.doubleValue)
+    return step * Decimal(floored)
+  }
+
+  private static func decimalKey(_ value: Decimal) -> String {
+    "\(NSDecimalNumber(decimal: value).int64Value)"
+  }
+}

--- a/Domain/Insights/Detectors/NetWorthInsights.swift
+++ b/Domain/Insights/Detectors/NetWorthInsights.swift
@@ -13,7 +13,8 @@ enum NetWorthInsights {
     guard let latest = actual.last else { return [] }
     let current = latest.netWorth.quantity
 
-    let baseline = actual.last { context.daysSince($0.date) >= lookbackDays }?.netWorth.quantity
+    let baseline =
+      actual.last { context.daysSince($0.date) >= lookbackDays }?.netWorth.quantity
       ?? actual.first?.netWorth.quantity
     guard let baseline, current > baseline, current > 0 else { return [] }
 

--- a/Domain/Insights/Detectors/NewMerchantInsight.swift
+++ b/Domain/Insights/Detectors/NewMerchantInsight.swift
@@ -1,0 +1,71 @@
+import Foundation
+
+/// New-merchant alert (design §B-8): a payee seen for the first time in the
+/// recent window whose charge lands in the top decile of all historical
+/// spend. Novelty × magnitude — a first-time small charge isn't worth a
+/// notification, a first-time large one is.
+enum NewMerchantInsight {
+  static func detect(
+    transactions: [InsightTransaction],
+    context: InsightContext,
+    windowDays: Int = 7,
+    magnitudePercentile: Double = 0.9
+  ) -> [Insight] {
+    let expenses = transactions.filter(\.isExpense)
+    guard expenses.count >= 10 else { return [] }
+
+    let magnitudes = expenses.map { Double(truncating: $0.spendMagnitude as NSDecimalNumber) }
+    let topDecile = DescriptiveStatistics.percentile(magnitudes, magnitudePercentile)
+
+    // Payees seen before the window opened.
+    var historicalPayees: Set<String> = []
+    for transaction in expenses where context.daysSince(transaction.date) > windowDays {
+      if !transaction.normalizedPayee.isEmpty {
+        historicalPayees.insert(transaction.normalizedPayee)
+      }
+    }
+
+    var seenThisWindow: Set<String> = []
+    var insights: [Insight] = []
+    for transaction in expenses.sorted(by: { $0.date > $1.date }) {
+      let age = context.daysSince(transaction.date)
+      guard age >= 0, age <= windowDays else { continue }
+      let key = transaction.normalizedPayee
+      guard !key.isEmpty, !historicalPayees.contains(key),
+        !seenThisWindow.contains(key)
+      else { continue }
+      seenThisWindow.insert(key)
+
+      let value = Double(truncating: transaction.spendMagnitude as NSDecimalNumber)
+      guard value >= topDecile, value > 0 else { continue }
+
+      insights.append(
+        Insight(
+          id: "\(InsightKind.newMerchantAlert.rawValue):\(key)",
+          kind: .newMerchantAlert,
+          title: "First charge from \(payeeName(transaction))",
+          detail:
+            "\(context.formatted(transaction.amount)) at \(payeeName(transaction)) — a "
+            + "merchant you haven't paid before, and a sizable one.",
+          date: transaction.date,
+          framing: .neutral,
+          actionability: .review,
+          surprise: 0.5,
+          monetaryImpact: transaction.amountInReportingCurrency(context),
+          facts: [
+            InsightFact("Merchant", payeeName(transaction)),
+            InsightFact("Amount", context.formatted(transaction.amount)),
+            InsightFact("Top-decile threshold", context.formatted(Decimal(-topDecile))),
+          ],
+          references: InsightReferences(
+            accountIds: transaction.accountId.map { [$0] } ?? [],
+            categoryIds: transaction.categoryId.map { [$0] } ?? [],
+            transactionIds: [transaction.id])))
+    }
+    return insights
+  }
+
+  private static func payeeName(_ transaction: InsightTransaction) -> String {
+    transaction.rawPayee ?? "a new merchant"
+  }
+}

--- a/Domain/Insights/Detectors/PeriodComparisonInsights.swift
+++ b/Domain/Insights/Detectors/PeriodComparisonInsights.swift
@@ -12,7 +12,8 @@ enum PeriodComparisonInsights {
   ) -> [Insight] {
     let currentBucket = FinancialMonth.key(
       for: context.now, monthEnd: context.financialMonthEnd)
-    let complete = monthly
+    let complete =
+      monthly
       .filter { $0.month < currentBucket }
       .sorted { $0.month < $1.month }
     guard complete.count >= 2 else { return [] }
@@ -21,7 +22,9 @@ enum PeriodComparisonInsights {
     if let monthOverMonth = compare(
       latest: complete[complete.count - 1],
       baseline: complete[complete.count - 2],
-      kind: .monthOverMonthDelta, label: "last month", context: context, threshold: threshold)
+      label: "last month",
+      context: context,
+      threshold: threshold)
     {
       insights.append(monthOverMonth)
     }
@@ -34,7 +37,6 @@ enum PeriodComparisonInsights {
   private static func compare(
     latest: MonthlyIncomeExpense,
     baseline: MonthlyIncomeExpense,
-    kind: InsightKind,
     label: String,
     context: InsightContext,
     threshold: Double
@@ -49,8 +51,8 @@ enum PeriodComparisonInsights {
     let deltaAmount = Decimal(-(latestSpend - baselineSpend))
     let monthDate = CategorySpendSeries.monthDate(latest.month) ?? latest.end
     return Insight(
-      id: "\(kind.rawValue):\(latest.month)",
-      kind: kind,
+      id: "\(InsightKind.monthOverMonthDelta.rawValue):\(latest.month)",
+      kind: .monthOverMonthDelta,
       title: increased ? "Spending up vs \(label)" : "Spending down vs \(label)",
       detail:
         "You spent \(context.formatted(Decimal(-latestSpend))) — "

--- a/Domain/Insights/Detectors/PeriodComparisonInsights.swift
+++ b/Domain/Insights/Detectors/PeriodComparisonInsights.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+/// Month-over-month and year-over-year deltas (design §C-11) on overall
+/// spend. Operates on the pre-bucketed `MonthlyIncomeExpense` aggregates and
+/// only on *complete* financial months — the in-progress current bucket is
+/// excluded so a half-finished month never reads as a spending drop.
+enum PeriodComparisonInsights {
+  static func detect(
+    monthly: [MonthlyIncomeExpense],
+    context: InsightContext,
+    threshold: Double = 0.15
+  ) -> [Insight] {
+    let currentBucket = FinancialMonth.key(
+      for: context.now, monthEnd: context.financialMonthEnd)
+    let complete = monthly
+      .filter { $0.month < currentBucket }
+      .sorted { $0.month < $1.month }
+    guard complete.count >= 2 else { return [] }
+
+    var insights: [Insight] = []
+    if let monthOverMonth = compare(
+      latest: complete[complete.count - 1],
+      baseline: complete[complete.count - 2],
+      kind: .monthOverMonthDelta, label: "last month", context: context, threshold: threshold)
+    {
+      insights.append(monthOverMonth)
+    }
+    return insights
+  }
+
+  /// Compare two months' total spend magnitude and emit a delta insight when
+  /// the change clears `threshold`. Spend magnitude is `-(totalExpense)`
+  /// because expense aggregates are stored negative.
+  private static func compare(
+    latest: MonthlyIncomeExpense,
+    baseline: MonthlyIncomeExpense,
+    kind: InsightKind,
+    label: String,
+    context: InsightContext,
+    threshold: Double
+  ) -> Insight? {
+    let latestSpend = magnitude(latest.totalExpense)
+    let baselineSpend = magnitude(baseline.totalExpense)
+    guard baselineSpend > 0 else { return nil }
+    let fraction = (latestSpend - baselineSpend) / baselineSpend
+    guard abs(fraction) >= threshold else { return nil }
+
+    let increased = fraction > 0
+    let deltaAmount = Decimal(-(latestSpend - baselineSpend))
+    let monthDate = CategorySpendSeries.monthDate(latest.month) ?? latest.end
+    return Insight(
+      id: "\(kind.rawValue):\(latest.month)",
+      kind: kind,
+      title: increased ? "Spending up vs \(label)" : "Spending down vs \(label)",
+      detail:
+        "You spent \(context.formatted(Decimal(-latestSpend))) — "
+        + "\(percent(abs(fraction))) \(increased ? "more" : "less") than \(label) "
+        + "(\(context.formatted(Decimal(-baselineSpend)))).",
+      date: monthDate,
+      framing: increased ? .negative : .positive,
+      actionability: .informational,
+      surprise: min(abs(fraction), 1),
+      monetaryImpact: InstrumentAmount(
+        quantity: deltaAmount, instrument: context.reportingCurrency),
+      facts: [
+        InsightFact("This period", context.formatted(Decimal(-latestSpend))),
+        InsightFact("Comparison", context.formatted(Decimal(-baselineSpend))),
+        InsightFact("Change", "\(increased ? "+" : "−")\(percent(abs(fraction)))"),
+      ],
+      references: InsightReferences(instrumentIds: [context.reportingCurrency.id]))
+  }
+
+  private static func magnitude(_ amount: InstrumentAmount) -> Double {
+    let value = Double(truncating: amount.quantity as NSDecimalNumber)
+    return value < 0 ? -value : 0
+  }
+
+  private static func percent(_ fraction: Double) -> String {
+    fraction.formatted(.percent.precision(.fractionLength(0)))
+  }
+}

--- a/Domain/Insights/Detectors/SavingsGoalInsight.swift
+++ b/Domain/Insights/Detectors/SavingsGoalInsight.swift
@@ -18,7 +18,9 @@ enum SavingsGoalInsight {
   }
 
   private static func evaluate(
-    earmark: EarmarkSnapshot, goal: InstrumentAmount, saved: InstrumentAmount,
+    earmark: EarmarkSnapshot,
+    goal: InstrumentAmount,
+    saved: InstrumentAmount,
     context: InsightContext
   ) -> Insight? {
     if saved.quantity >= goal.quantity {
@@ -29,13 +31,15 @@ enum SavingsGoalInsight {
     else {
       return progressOnly(earmark, goal: goal, saved: saved, progress: progress, context: context)
     }
-    return eta(earmark, goal: goal, saved: saved, progress: progress, date: etaDate, context: context)
+    return eta(earmark, goal: goal, saved: saved, date: etaDate, context: context)
   }
 
   /// Project the completion date from the contribution rate since the goal
   /// started. `nil` when there's no start date or no positive accrual.
   private static func projectedCompletion(
-    _ earmark: EarmarkSnapshot, goal: InstrumentAmount, saved: InstrumentAmount,
+    _ earmark: EarmarkSnapshot,
+    goal: InstrumentAmount,
+    saved: InstrumentAmount,
     context: InsightContext
   ) -> Date? {
     guard let start = earmark.savingsStartDate else { return nil }
@@ -51,7 +55,9 @@ enum SavingsGoalInsight {
   // MARK: - Insight construction
 
   private static func reached(
-    _ earmark: EarmarkSnapshot, goal: InstrumentAmount, saved: InstrumentAmount,
+    _ earmark: EarmarkSnapshot,
+    goal: InstrumentAmount,
+    saved: InstrumentAmount,
     context: InsightContext
   ) -> Insight {
     Insight(
@@ -72,9 +78,13 @@ enum SavingsGoalInsight {
   }
 
   private static func eta(
-    _ earmark: EarmarkSnapshot, goal: InstrumentAmount, saved: InstrumentAmount,
-    progress: Double, date: Date, context: InsightContext
+    _ earmark: EarmarkSnapshot,
+    goal: InstrumentAmount,
+    saved: InstrumentAmount,
+    date: Date,
+    context: InsightContext
   ) -> Insight {
+    let progress = ratio(saved.quantity, goal.quantity)
     let etaText = date.formatted(.dateTime.month(.abbreviated).year())
     return Insight(
       id: "\(InsightKind.savingsGoalETA.rawValue):eta:\(earmark.id.uuidString)",
@@ -98,8 +108,11 @@ enum SavingsGoalInsight {
   }
 
   private static func progressOnly(
-    _ earmark: EarmarkSnapshot, goal: InstrumentAmount, saved: InstrumentAmount,
-    progress: Double, context: InsightContext
+    _ earmark: EarmarkSnapshot,
+    goal: InstrumentAmount,
+    saved: InstrumentAmount,
+    progress: Double,
+    context: InsightContext
   ) -> Insight? {
     // Only celebrate meaningful progress; an untouched goal isn't news.
     guard progress >= 0.5 else { return nil }

--- a/Domain/Insights/Detectors/SavingsGoalInsight.swift
+++ b/Domain/Insights/Detectors/SavingsGoalInsight.swift
@@ -1,0 +1,138 @@
+import Foundation
+
+/// Savings-goal ETA (design §E-20): at the current contribution rate, when
+/// will the goal be reached. A reached goal is the positive-framed
+/// celebration; an in-progress goal projects a target date from the saved
+/// amount accrued since the goal's start.
+enum SavingsGoalInsight {
+  static func detect(
+    earmarks: [EarmarkSnapshot],
+    context: InsightContext
+  ) -> [Insight] {
+    earmarks.compactMap { earmark in
+      guard !earmark.isHidden, let goal = earmark.savingsGoal, goal.quantity > 0,
+        let saved = earmark.saved
+      else { return nil }
+      return evaluate(earmark: earmark, goal: goal, saved: saved, context: context)
+    }
+  }
+
+  private static func evaluate(
+    earmark: EarmarkSnapshot, goal: InstrumentAmount, saved: InstrumentAmount,
+    context: InsightContext
+  ) -> Insight? {
+    if saved.quantity >= goal.quantity {
+      return reached(earmark, goal: goal, saved: saved, context: context)
+    }
+    let progress = ratio(saved.quantity, goal.quantity)
+    guard let etaDate = projectedCompletion(earmark, goal: goal, saved: saved, context: context)
+    else {
+      return progressOnly(earmark, goal: goal, saved: saved, progress: progress, context: context)
+    }
+    return eta(earmark, goal: goal, saved: saved, progress: progress, date: etaDate, context: context)
+  }
+
+  /// Project the completion date from the contribution rate since the goal
+  /// started. `nil` when there's no start date or no positive accrual.
+  private static func projectedCompletion(
+    _ earmark: EarmarkSnapshot, goal: InstrumentAmount, saved: InstrumentAmount,
+    context: InsightContext
+  ) -> Date? {
+    guard let start = earmark.savingsStartDate else { return nil }
+    let elapsedDays = context.calendar.dateComponents([.day], from: start, to: context.now).day ?? 0
+    guard elapsedDays > 0 else { return nil }
+    let ratePerDay = toDouble(saved.quantity) / Double(elapsedDays)
+    guard ratePerDay > 0 else { return nil }
+    let remaining = toDouble(goal.quantity - saved.quantity)
+    let daysToGoal = Int((remaining / ratePerDay).rounded())
+    return context.calendar.date(byAdding: .day, value: daysToGoal, to: context.now)
+  }
+
+  // MARK: - Insight construction
+
+  private static func reached(
+    _ earmark: EarmarkSnapshot, goal: InstrumentAmount, saved: InstrumentAmount,
+    context: InsightContext
+  ) -> Insight {
+    Insight(
+      id: "\(InsightKind.savingsGoalETA.rawValue):reached:\(earmark.id.uuidString)",
+      kind: .savingsGoalETA,
+      title: "\(earmark.name) goal reached 🎉",
+      detail: "You've hit your \(context.formatted(goal)) \(earmark.name) goal. Well done.",
+      date: context.now,
+      framing: .positive,
+      actionability: .informational,
+      surprise: 0.5,
+      monetaryImpact: goal,
+      facts: [
+        InsightFact("Goal", context.formatted(goal)),
+        InsightFact("Saved", context.formatted(saved)),
+      ],
+      references: InsightReferences(earmarkIds: [earmark.id]))
+  }
+
+  private static func eta(
+    _ earmark: EarmarkSnapshot, goal: InstrumentAmount, saved: InstrumentAmount,
+    progress: Double, date: Date, context: InsightContext
+  ) -> Insight {
+    let etaText = date.formatted(.dateTime.month(.abbreviated).year())
+    return Insight(
+      id: "\(InsightKind.savingsGoalETA.rawValue):eta:\(earmark.id.uuidString)",
+      kind: .savingsGoalETA,
+      title: "\(earmark.name): on track for \(etaText)",
+      detail:
+        "You've saved \(context.formatted(saved)) of \(context.formatted(goal)) "
+        + "(\(percent(progress))). At your current pace you'll get there around \(etaText).",
+      date: context.now,
+      framing: .positive,
+      actionability: .informational,
+      surprise: 0.3,
+      monetaryImpact: saved,
+      facts: [
+        InsightFact("Goal", context.formatted(goal)),
+        InsightFact("Saved", context.formatted(saved)),
+        InsightFact("Progress", percent(progress)),
+        InsightFact("Projected completion", etaText),
+      ],
+      references: InsightReferences(earmarkIds: [earmark.id]))
+  }
+
+  private static func progressOnly(
+    _ earmark: EarmarkSnapshot, goal: InstrumentAmount, saved: InstrumentAmount,
+    progress: Double, context: InsightContext
+  ) -> Insight? {
+    // Only celebrate meaningful progress; an untouched goal isn't news.
+    guard progress >= 0.5 else { return nil }
+    return Insight(
+      id: "\(InsightKind.savingsGoalETA.rawValue):progress:\(earmark.id.uuidString)",
+      kind: .savingsGoalETA,
+      title: "\(earmark.name) is \(percent(progress)) of the way there",
+      detail:
+        "You've saved \(context.formatted(saved)) toward your "
+        + "\(context.formatted(goal)) \(earmark.name) goal.",
+      date: context.now,
+      framing: .positive,
+      actionability: .informational,
+      surprise: 0.25,
+      monetaryImpact: saved,
+      facts: [
+        InsightFact("Goal", context.formatted(goal)),
+        InsightFact("Saved", context.formatted(saved)),
+        InsightFact("Progress", percent(progress)),
+      ],
+      references: InsightReferences(earmarkIds: [earmark.id]))
+  }
+
+  private static func ratio(_ numerator: Decimal, _ denominator: Decimal) -> Double {
+    guard denominator != 0 else { return 0 }
+    return toDouble(numerator) / toDouble(denominator)
+  }
+
+  private static func toDouble(_ value: Decimal) -> Double {
+    Double(truncating: value as NSDecimalNumber)
+  }
+
+  private static func percent(_ fraction: Double) -> String {
+    min(max(fraction, 0), 1).formatted(.percent.precision(.fractionLength(0)))
+  }
+}

--- a/Domain/Insights/Detectors/SavingsOpportunityInsights.swift
+++ b/Domain/Insights/Detectors/SavingsOpportunityInsights.swift
@@ -30,7 +30,8 @@ enum SavingsOpportunityInsights {
     let categoryIds = Array(Set(fees.compactMap(\.categoryId)))
     return [
       Insight(
-        id: "\(InsightKind.feeSpend.rawValue):\(FinancialMonth.key(for: context.now, monthEnd: context.financialMonthEnd))",
+        id:
+          "\(InsightKind.feeSpend.rawValue):\(FinancialMonth.key(for: context.now, monthEnd: context.financialMonthEnd))",
         kind: .feeSpend,
         title: "You paid \(context.formatted(Decimal(-toDouble(total)))) in fees",
         detail:
@@ -66,7 +67,8 @@ enum SavingsOpportunityInsights {
 
     return [
       Insight(
-        id: "\(InsightKind.subscriptionOverspend.rawValue):\(FinancialMonth.key(for: context.now, monthEnd: context.financialMonthEnd))",
+        id:
+          "\(InsightKind.subscriptionOverspend.rawValue):\(FinancialMonth.key(for: context.now, monthEnd: context.financialMonthEnd))",
         kind: .subscriptionOverspend,
         title: "Subscriptions are \(percent(share)) of income",
         detail:
@@ -77,7 +79,8 @@ enum SavingsOpportunityInsights {
         framing: .negative,
         actionability: .review,
         surprise: min(share, 1),
-        monetaryImpact: InstrumentAmount(quantity: -monthlyTotal, instrument: context.reportingCurrency),
+        monetaryImpact: InstrumentAmount(
+          quantity: -monthlyTotal, instrument: context.reportingCurrency),
         facts: [
           InsightFact("Monthly subscriptions", context.formatted(monthlyTotal)),
           InsightFact("Share of income", percent(share)),

--- a/Domain/Insights/Detectors/SavingsOpportunityInsights.swift
+++ b/Domain/Insights/Detectors/SavingsOpportunityInsights.swift
@@ -1,0 +1,102 @@
+import Foundation
+
+/// Savings-opportunity insights (design §F): fee spend (22) and
+/// subscription overspend (23). Both quantify recurring leakage the user can
+/// act on.
+enum SavingsOpportunityInsights {
+  /// Category-name keywords that flag a leg as a bank/finance fee. Matched
+  /// case-insensitively against the full category path so a nested
+  /// "Banking:Fees" category is caught.
+  private static let feeKeywords = [
+    "fee", "charge", "interest", "atm", "overdraft", "surcharge", "penalty",
+  ]
+
+  /// Total spend in fee-like categories over the trailing year (22).
+  static func feeSpend(
+    transactions: [InsightTransaction],
+    context: InsightContext,
+    lookbackDays: Int = 365
+  ) -> [Insight] {
+    let fees = transactions.filter { transaction in
+      transaction.isExpense
+        && context.daysSince(transaction.date) >= 0
+        && context.daysSince(transaction.date) <= lookbackDays
+        && isFeeCategory(transaction.categoryPath)
+    }
+    guard !fees.isEmpty else { return [] }
+    let total = fees.reduce(Decimal(0)) { $0 + $1.spendMagnitude }
+    guard total > 0 else { return [] }
+
+    let categoryIds = Array(Set(fees.compactMap(\.categoryId)))
+    return [
+      Insight(
+        id: "\(InsightKind.feeSpend.rawValue):\(FinancialMonth.key(for: context.now, monthEnd: context.financialMonthEnd))",
+        kind: .feeSpend,
+        title: "You paid \(context.formatted(Decimal(-toDouble(total)))) in fees",
+        detail:
+          "Over the past year you've paid about \(context.formatted(Decimal(-toDouble(total)))) "
+          + "in fees and charges across \(fees.count) transactions. Many of these are avoidable.",
+        date: context.now,
+        framing: .negative,
+        actionability: .review,
+        surprise: 0.5,
+        monetaryImpact: InstrumentAmount(quantity: -total, instrument: context.reportingCurrency),
+        facts: [
+          InsightFact("Annual fees", context.formatted(Decimal(-toDouble(total)))),
+          InsightFact("Transactions", "\(fees.count)"),
+        ],
+        references: InsightReferences(
+          categoryIds: categoryIds, instrumentIds: [context.reportingCurrency.id]))
+    ]
+  }
+
+  /// Subscriptions as a share of income (23). Flags when the combined
+  /// monthly subscription cost exceeds `threshold` of average monthly income.
+  static func subscriptionOverspend(
+    subscriptions: [DetectedSubscription],
+    averageMonthlyIncome: Decimal?,
+    context: InsightContext,
+    threshold: Double = 0.15
+  ) -> [Insight] {
+    let expenseStreams = subscriptions.filter { !$0.isIncome }
+    guard !expenseStreams.isEmpty, let income = averageMonthlyIncome, income > 0 else { return [] }
+    let monthlyTotal = expenseStreams.reduce(Decimal(0)) { $0 + $1.monthlyCostMagnitude }
+    let share = toDouble(monthlyTotal) / toDouble(income)
+    guard share > threshold else { return [] }
+
+    return [
+      Insight(
+        id: "\(InsightKind.subscriptionOverspend.rawValue):\(FinancialMonth.key(for: context.now, monthEnd: context.financialMonthEnd))",
+        kind: .subscriptionOverspend,
+        title: "Subscriptions are \(percent(share)) of income",
+        detail:
+          "Your \(expenseStreams.count) subscriptions cost about "
+          + "\(context.formatted(monthlyTotal))/month — \(percent(share)) of your income. "
+          + "Trimming a few could free up real cash.",
+        date: context.now,
+        framing: .negative,
+        actionability: .review,
+        surprise: min(share, 1),
+        monetaryImpact: InstrumentAmount(quantity: -monthlyTotal, instrument: context.reportingCurrency),
+        facts: [
+          InsightFact("Monthly subscriptions", context.formatted(monthlyTotal)),
+          InsightFact("Share of income", percent(share)),
+          InsightFact("Active subscriptions", "\(expenseStreams.count)"),
+        ],
+        references: InsightReferences(instrumentIds: [context.reportingCurrency.id]))
+    ]
+  }
+
+  private static func isFeeCategory(_ path: String?) -> Bool {
+    guard let path = path?.lowercased() else { return false }
+    return feeKeywords.contains { path.contains($0) }
+  }
+
+  private static func toDouble(_ value: Decimal) -> Double {
+    Double(truncating: value as NSDecimalNumber)
+  }
+
+  private static func percent(_ fraction: Double) -> String {
+    fraction.formatted(.percent.precision(.fractionLength(0)))
+  }
+}

--- a/Domain/Insights/Detectors/SavingsRateInsight.swift
+++ b/Domain/Insights/Detectors/SavingsRateInsight.swift
@@ -11,7 +11,8 @@ enum SavingsRateInsight {
   ) -> [Insight] {
     let complete = InsightAggregates.completeMonths(monthly, context: context)
     let rates: [Double] = complete.compactMap { month in
-      let income = Double(truncating: InsightAggregates.incomeMagnitude(month.totalIncome) as NSDecimalNumber)
+      let income = Double(
+        truncating: InsightAggregates.incomeMagnitude(month.totalIncome) as NSDecimalNumber)
       guard income > 0 else { return nil }
       let net = Double(truncating: month.totalProfit.quantity as NSDecimalNumber)
       return net / income
@@ -43,7 +44,8 @@ enum SavingsRateInsight {
           InsightFact("Current savings rate", percent(latest)),
           InsightFact("Direction", rising ? "Rising" : "Falling"),
           InsightFact("Months analysed", "\(rates.count)"),
-          InsightFact("Trend p-value", result.pValue.formatted(.number.precision(.fractionLength(3)))),
+          InsightFact(
+            "Trend p-value", result.pValue.formatted(.number.precision(.fractionLength(3)))),
         ],
         references: InsightReferences(instrumentIds: [context.reportingCurrency.id]))
     ]

--- a/Domain/Insights/Detectors/SavingsRateInsight.swift
+++ b/Domain/Insights/Detectors/SavingsRateInsight.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+/// Savings-rate trend (design §D-16): the rolling `(income − expenses) /
+/// income` ratio across complete months, with a Mann-Kendall trend test.
+/// A rising savings rate is framed positively; a falling one negatively.
+enum SavingsRateInsight {
+  static func detect(
+    monthly: [MonthlyIncomeExpense],
+    context: InsightContext,
+    minimumMonths: Int = 4
+  ) -> [Insight] {
+    let complete = InsightAggregates.completeMonths(monthly, context: context)
+    let rates: [Double] = complete.compactMap { month in
+      let income = Double(truncating: InsightAggregates.incomeMagnitude(month.totalIncome) as NSDecimalNumber)
+      guard income > 0 else { return nil }
+      let net = Double(truncating: month.totalProfit.quantity as NSDecimalNumber)
+      return net / income
+    }
+    guard rates.count >= minimumMonths, let result = MannKendall.test(rates),
+      result.statistic != 0
+    else { return [] }
+
+    let latest = rates[rates.count - 1]
+    let rising = result.isIncreasing
+    // Surface only statistically credible trends (loose threshold — single
+    // series, no multiple-comparison family here).
+    guard result.pValue <= 0.1 else { return [] }
+
+    return [
+      Insight(
+        id: "\(InsightKind.savingsRateTrend.rawValue):\(monthKey(context))",
+        kind: .savingsRateTrend,
+        title: rising ? "Your savings rate is climbing" : "Your savings rate is slipping",
+        detail:
+          "Over the last \(rates.count) months your savings rate has been "
+          + "\(rising ? "rising" : "falling") — currently about \(percent(latest)) of income.",
+        date: context.now,
+        framing: rising ? .positive : .negative,
+        actionability: .review,
+        surprise: NormalDistribution.surprise(fromZScore: result.zScore),
+        monetaryImpact: nil,
+        facts: [
+          InsightFact("Current savings rate", percent(latest)),
+          InsightFact("Direction", rising ? "Rising" : "Falling"),
+          InsightFact("Months analysed", "\(rates.count)"),
+          InsightFact("Trend p-value", result.pValue.formatted(.number.precision(.fractionLength(3)))),
+        ],
+        references: InsightReferences(instrumentIds: [context.reportingCurrency.id]))
+    ]
+  }
+
+  private static func percent(_ fraction: Double) -> String {
+    max(fraction, 0).formatted(.percent.precision(.fractionLength(0)))
+  }
+
+  private static func monthKey(_ context: InsightContext) -> String {
+    FinancialMonth.key(for: context.now, monthEnd: context.financialMonthEnd)
+  }
+}

--- a/Domain/Insights/Detectors/SpendHabitInsights.swift
+++ b/Domain/Insights/Detectors/SpendHabitInsights.swift
@@ -1,0 +1,143 @@
+import Foundation
+
+/// Spend-habit insights (research follow-up §F-1, §E-4): a lapsed merchant
+/// you used to pay regularly, and a habitual weekend-vs-weekday spend skew.
+enum SpendHabitInsights {
+  /// Lapsed merchant (F-1): a payee you paid regularly but haven't in a
+  /// while — a broader cancellation signal than the subscription-cadence
+  /// proxy. Surfaces the highest-spend lapsed merchant.
+  static func lapsedMerchant(
+    transactions: [InsightTransaction],
+    context: InsightContext,
+    minimumOccurrences: Int = 4,
+    minimumSilentDays: Int = 90
+  ) -> [Insight] {
+    let groups = Dictionary(grouping: transactions.filter(\.isExpense)) { $0.normalizedPayee }
+    var best: Insight?
+    var bestSpend = 0.0
+    for (payee, records) in groups where !payee.isEmpty && records.count >= minimumOccurrences {
+      let sorted = records.sorted { $0.date < $1.date }
+      guard let last = sorted.last else { continue }
+      let silentDays = context.daysSince(last.date)
+      let medianInterval = medianIntervalDays(of: sorted.map(\.date), calendar: context.calendar)
+      guard medianInterval > 0,
+        Double(silentDays) > max(Double(minimumSilentDays), 3 * medianInterval)
+      else { continue }
+      let totalSpend = sorted.reduce(0.0) {
+        $0 + Double(truncating: $1.spendMagnitude as NSDecimalNumber)
+      }
+      if totalSpend > bestSpend {
+        bestSpend = totalSpend
+        best = makeLapsedInsight(record: last, silentDays: silentDays, context: context)
+      }
+    }
+    return best.map { [$0] } ?? []
+  }
+
+  /// Weekend-vs-weekday spend skew (E-4): the ratio of average daily
+  /// weekend spend to weekday spend, when stable and lopsided.
+  static func weekendSkew(
+    transactions: [InsightTransaction],
+    context: InsightContext,
+    minimumDaysEachSide: Int = 8,
+    minimumRatio: Double = 1.5
+  ) -> [Insight] {
+    var weekendTotals: [Double] = []
+    var weekdayTotals: [Double] = []
+    let byDay = dailyTotals(of: transactions, context: context)
+    for (day, total) in byDay {
+      let weekday = context.calendar.component(.weekday, from: day)
+      if weekday == 1 || weekday == 7 {
+        weekendTotals.append(total)
+      } else {
+        weekdayTotals.append(total)
+      }
+    }
+    guard weekendTotals.count >= minimumDaysEachSide,
+      weekdayTotals.count >= minimumDaysEachSide
+    else { return [] }
+    let weekendMean = DescriptiveStatistics.mean(weekendTotals)
+    let weekdayMean = DescriptiveStatistics.mean(weekdayTotals)
+    guard weekdayMean > 0 else { return [] }
+    let ratio = weekendMean / weekdayMean
+    guard ratio >= minimumRatio else { return [] }
+
+    return [
+      Insight(
+        id: "\(InsightKind.weekendSpendSkew.rawValue):\(monthKey(context))",
+        kind: .weekendSpendSkew,
+        title: "Weekends are your big spend days",
+        detail:
+          "You spend about \(multiple(ratio))× as much per day on weekends "
+          + "(\(context.formatted(Decimal(-weekendMean)))) as on weekdays "
+          + "(\(context.formatted(Decimal(-weekdayMean)))).",
+        date: context.now,
+        framing: .neutral,
+        actionability: .informational,
+        surprise: min((ratio - 1) / 2, 1),
+        monetaryImpact: nil,
+        facts: [
+          InsightFact("Avg weekend day", context.formatted(Decimal(-weekendMean))),
+          InsightFact("Avg weekday", context.formatted(Decimal(-weekdayMean))),
+          InsightFact("Ratio", "\(multiple(ratio))×"),
+        ],
+        references: InsightReferences(instrumentIds: [context.reportingCurrency.id]))
+    ]
+  }
+
+  // MARK: - Helpers
+
+  private static func makeLapsedInsight(
+    record: InsightTransaction, silentDays: Int, context: InsightContext
+  ) -> Insight {
+    let name = record.rawPayee ?? record.normalizedPayee
+    return Insight(
+      id: "\(InsightKind.lapsedMerchant.rawValue):\(record.normalizedPayee)",
+      kind: .lapsedMerchant,
+      title: "You've stopped paying \(name)",
+      detail:
+        "You used to pay \(name) regularly but haven't in \(silentDays) days. "
+        + "If you've moved on, there's nothing to do — otherwise worth a check.",
+      date: record.date,
+      framing: .neutral,
+      actionability: .review,
+      surprise: 0.35,
+      monetaryImpact: nil,
+      facts: [
+        InsightFact("Merchant", name),
+        InsightFact("Days since last", "\(silentDays)"),
+      ],
+      references: InsightReferences(
+        accountIds: record.accountId.map { [$0] } ?? [],
+        categoryIds: record.categoryId.map { [$0] } ?? []))
+  }
+
+  private static func dailyTotals(
+    of transactions: [InsightTransaction], context: InsightContext
+  ) -> [Date: Double] {
+    var totals: [Date: Double] = [:]
+    for transaction in transactions where transaction.isExpense {
+      let day = context.calendar.startOfDay(for: transaction.date)
+      totals[day, default: 0] += Double(truncating: transaction.spendMagnitude as NSDecimalNumber)
+    }
+    return totals
+  }
+
+  private static func medianIntervalDays(of dates: [Date], calendar: Calendar) -> Double {
+    guard dates.count > 1 else { return 0 }
+    var gaps: [Double] = []
+    for index in 1..<dates.count {
+      let days = calendar.dateComponents([.day], from: dates[index - 1], to: dates[index]).day ?? 0
+      gaps.append(Double(days))
+    }
+    return DescriptiveStatistics.median(gaps)
+  }
+
+  private static func multiple(_ ratio: Double) -> String {
+    ratio.formatted(.number.precision(.fractionLength(1)))
+  }
+
+  private static func monthKey(_ context: InsightContext) -> String {
+    FinancialMonth.key(for: context.now, monthEnd: context.financialMonthEnd)
+  }
+}

--- a/Domain/Insights/Detectors/SubscriptionInsights.swift
+++ b/Domain/Insights/Detectors/SubscriptionInsights.swift
@@ -83,7 +83,9 @@ enum SubscriptionInsights {
   /// monthly cost — likely overlapping services (design §A-3). Emits one
   /// insight per category cluster.
   static func duplicates(
-    _ subscriptions: [DetectedSubscription], categories: Categories, context: InsightContext,
+    _ subscriptions: [DetectedSubscription],
+    categories: Categories,
+    context: InsightContext,
     priceProximity: Double = 0.4
   ) -> [Insight] {
     let expenseStreams = subscriptions.filter { !$0.isIncome && $0.categoryId != nil }
@@ -101,7 +103,8 @@ enum SubscriptionInsights {
       guard clustered.count >= 2 else { continue }
       let names = clustered.map(\.displayPayee).sorted()
       let total = clustered.reduce(Decimal(0)) { $0 + $1.monthlyCostMagnitude }
-      let categoryName = categories.by(id: categoryId).map { categories.path(for: $0) } ?? "this category"
+      let categoryName =
+        categories.by(id: categoryId).map { categories.path(for: $0) } ?? "this category"
       insights.append(
         Insight(
           id: "\(InsightKind.duplicateSubscription.rawValue):\(categoryId.uuidString)",

--- a/Domain/Insights/Detectors/SubscriptionInsights.swift
+++ b/Domain/Insights/Detectors/SubscriptionInsights.swift
@@ -1,0 +1,197 @@
+import Foundation
+
+/// Turns detected subscription streams (`SubscriptionDetector`) into the
+/// recurring-management insights: new-recurring (5), price-hike (2),
+/// duplicate (3), and cancellation-candidate (4). Subscription *overspend*
+/// (23) lives in `SavingsOpportunityInsights` because it needs income.
+enum SubscriptionInsights {
+  /// A stream that reached its third occurrence within the last `window`
+  /// days — it just became a confirmed subscription (design §A-5).
+  static func newRecurring(
+    _ subscriptions: [DetectedSubscription], context: InsightContext, windowDays: Int = 7
+  ) -> [Insight] {
+    subscriptions.compactMap { subscription in
+      guard !subscription.isIncome else { return nil }
+      let age = context.daysSince(subscription.maturedDate)
+      guard age >= 0, age <= windowDays else { return nil }
+      let monthly = context.formatted(subscription.monthlyCostMagnitude)
+      return Insight(
+        id: "\(InsightKind.newRecurringDetected.rawValue):\(subscription.id)",
+        kind: .newRecurringDetected,
+        title: "New \(subscription.period.displayName) subscription",
+        detail:
+          "\(subscription.displayPayee) looks like a recurring "
+          + "\(subscription.period.displayName) charge — about \(monthly)/month.",
+        date: subscription.lastDate,
+        framing: .neutral,
+        actionability: .review,
+        surprise: 0.45,
+        monetaryImpact: amount(-subscription.monthlyCostMagnitude, context),
+        facts: [
+          InsightFact("Merchant", subscription.displayPayee),
+          InsightFact("Cadence", subscription.period.displayName),
+          InsightFact("Typical charge", context.formatted(subscription.medianAmount)),
+          InsightFact("Monthly equivalent", monthly),
+          InsightFact("Occurrences", "\(subscription.occurrenceCount)"),
+        ],
+        references: references(for: subscription))
+    }
+  }
+
+  /// Latest charge exceeds the stream's prior median by more than
+  /// `threshold` (design §A-2). Compares against the median of all
+  /// occurrences *before* the latest, so a one-off spike still flags.
+  static func priceHikes(
+    _ subscriptions: [DetectedSubscription], context: InsightContext, threshold: Double = 0.05
+  ) -> [Insight] {
+    subscriptions.compactMap { subscription in
+      guard subscription.amounts.count >= 3, !subscription.isIncome else { return nil }
+      let priorMagnitudes = subscription.amounts.dropLast().map(magnitude)
+      let priorMedian = DescriptiveStatistics.median(priorMagnitudes)
+      let latest = magnitude(subscription.latestAmount)
+      guard priorMedian > 0 else { return nil }
+      let increase = (latest - priorMedian) / priorMedian
+      guard increase > threshold else { return nil }
+
+      let perChargeDelta = Decimal(latest - priorMedian)
+      let monthlyDelta = perChargeDelta * subscription.period.occurrencesPerMonth
+      return Insight(
+        id: "\(InsightKind.subscriptionPriceHike.rawValue):\(subscription.id)",
+        kind: .subscriptionPriceHike,
+        title: "\(subscription.displayPayee) went up",
+        detail:
+          "\(subscription.displayPayee) rose \(percent(increase)) — now "
+          + "\(context.formatted(subscription.latestAmount)) versus a usual "
+          + "\(context.formatted(Decimal(-priorMedian))).",
+        date: subscription.lastDate,
+        framing: .negative,
+        actionability: .review,
+        surprise: min(increase * 2, 1),
+        monetaryImpact: amount(-monthlyDelta, context),
+        facts: [
+          InsightFact("Merchant", subscription.displayPayee),
+          InsightFact("New charge", context.formatted(subscription.latestAmount)),
+          InsightFact("Previous typical", context.formatted(amountDecimal(priorMedian, false))),
+          InsightFact("Increase", percent(increase)),
+          InsightFact("Extra per month", context.formatted(monthlyDelta)),
+        ],
+        references: references(for: subscription))
+    }
+  }
+
+  /// Two or more active expense streams sharing a category with similar
+  /// monthly cost — likely overlapping services (design §A-3). Emits one
+  /// insight per category cluster.
+  static func duplicates(
+    _ subscriptions: [DetectedSubscription], categories: Categories, context: InsightContext,
+    priceProximity: Double = 0.4
+  ) -> [Insight] {
+    let expenseStreams = subscriptions.filter { !$0.isIncome && $0.categoryId != nil }
+    let byCategory = Dictionary(grouping: expenseStreams) { $0.categoryId }
+
+    var insights: [Insight] = []
+    for (categoryId, streams) in byCategory where streams.count >= 2 {
+      guard let categoryId else { continue }
+      let clustered = streams.filter { stream in
+        streams.contains { other in
+          other.id != stream.id
+            && priceWithin(stream, other, proximity: priceProximity)
+        }
+      }
+      guard clustered.count >= 2 else { continue }
+      let names = clustered.map(\.displayPayee).sorted()
+      let total = clustered.reduce(Decimal(0)) { $0 + $1.monthlyCostMagnitude }
+      let categoryName = categories.by(id: categoryId).map { categories.path(for: $0) } ?? "this category"
+      insights.append(
+        Insight(
+          id: "\(InsightKind.duplicateSubscription.rawValue):\(categoryId.uuidString)",
+          kind: .duplicateSubscription,
+          title: "Overlapping \(categoryName) subscriptions",
+          detail:
+            "You have \(clustered.count) similar \(categoryName) subscriptions "
+            + "(\(names.joined(separator: ", "))) costing about \(context.formatted(total))/month.",
+          date: context.now,
+          framing: .negative,
+          actionability: .act,
+          surprise: 0.6,
+          monetaryImpact: amount(-total, context),
+          facts: [
+            InsightFact("Category", categoryName),
+            InsightFact("Services", names.joined(separator: ", ")),
+            InsightFact("Combined monthly", context.formatted(total)),
+          ],
+          references: InsightReferences(
+            categoryIds: [categoryId],
+            instrumentIds: [context.reportingCurrency.id])))
+    }
+    return insights
+  }
+
+  /// Streams whose cadence is lengthening — the late-half median gap is
+  /// markedly longer than the early-half (design §A-4, weak signal, so
+  /// `review` not `act`). Needs at least four occurrences.
+  static func cancellationCandidates(
+    _ subscriptions: [DetectedSubscription], context: InsightContext, slowdown: Double = 1.4
+  ) -> [Insight] {
+    subscriptions.compactMap { subscription in
+      guard !subscription.isIncome, subscription.amounts.count >= 4 else { return nil }
+      let overdueDays = context.daysSince(subscription.lastDate)
+      let expectedGap = subscription.medianIntervalDays
+      guard expectedGap > 0, Double(overdueDays) > expectedGap * slowdown else { return nil }
+      return Insight(
+        id: "\(InsightKind.subscriptionCancellationCandidate.rawValue):\(subscription.id)",
+        kind: .subscriptionCancellationCandidate,
+        title: "Still paying for \(subscription.displayPayee)?",
+        detail:
+          "\(subscription.displayPayee) usually charges every "
+          + "\(Int(expectedGap.rounded())) days but hasn't in \(overdueDays). "
+          + "If you've stopped using it, it may be worth cancelling.",
+        date: subscription.lastDate,
+        framing: .neutral,
+        actionability: .review,
+        surprise: 0.4,
+        monetaryImpact: amount(-subscription.monthlyCostMagnitude, context),
+        facts: [
+          InsightFact("Merchant", subscription.displayPayee),
+          InsightFact("Usual cadence", "every \(Int(expectedGap.rounded())) days"),
+          InsightFact("Days since last", "\(overdueDays)"),
+          InsightFact("Monthly cost", context.formatted(subscription.monthlyCostMagnitude)),
+        ],
+        references: references(for: subscription))
+    }
+  }
+
+  // MARK: - Helpers
+
+  private static func magnitude(_ value: Decimal) -> Double {
+    Double(truncating: (value < 0 ? -value : value) as NSDecimalNumber)
+  }
+
+  private static func amountDecimal(_ positiveMagnitude: Double, _ isIncome: Bool) -> Decimal {
+    Decimal(positiveMagnitude * (isIncome ? 1.0 : -1.0))
+  }
+
+  private static func priceWithin(
+    _ lhs: DetectedSubscription, _ rhs: DetectedSubscription, proximity: Double
+  ) -> Bool {
+    let left = Double(truncating: lhs.monthlyCostMagnitude as NSDecimalNumber)
+    let right = Double(truncating: rhs.monthlyCostMagnitude as NSDecimalNumber)
+    let larger = max(left, right)
+    guard larger > 0 else { return false }
+    return abs(left - right) / larger <= proximity
+  }
+
+  private static func amount(_ quantity: Decimal, _ context: InsightContext) -> InstrumentAmount {
+    InstrumentAmount(quantity: quantity, instrument: context.reportingCurrency)
+  }
+
+  private static func percent(_ fraction: Double) -> String {
+    (fraction).formatted(.percent.precision(.fractionLength(0...1)))
+  }
+
+  private static func references(for subscription: DetectedSubscription) -> InsightReferences {
+    InsightReferences(
+      accountIds: subscription.accountId.map { [$0] } ?? [],
+      categoryIds: subscription.categoryId.map { [$0] } ?? [])
+  }
+}

--- a/Domain/Insights/Detectors/UnusualDayInsight.swift
+++ b/Domain/Insights/Detectors/UnusualDayInsight.swift
@@ -1,0 +1,82 @@
+import Foundation
+
+/// Unusual day-of-week spend (design §B-9): the most recent day whose total
+/// spend is a robust-z outlier against the distribution of same-weekday
+/// daily totals ("you spent 3× your typical Sunday today").
+enum UnusualDayInsight {
+  static func detect(
+    transactions: [InsightTransaction],
+    context: InsightContext,
+    windowDays: Int = 2,
+    threshold: Double = 3,
+    minimumRatio: Double = 2
+  ) -> [Insight] {
+    let expenses = transactions.filter(\.isExpense)
+    guard expenses.count >= 14 else { return [] }
+
+    // Daily spend magnitude per calendar day.
+    var dailyTotals: [Date: Double] = [:]
+    for transaction in expenses {
+      let day = context.calendar.startOfDay(for: transaction.date)
+      dailyTotals[day, default: 0] += Double(truncating: transaction.spendMagnitude as NSDecimalNumber)
+    }
+    guard !dailyTotals.isEmpty else { return [] }
+
+    // Group day totals by weekday.
+    var byWeekday: [Int: [Double]] = [:]
+    for (day, total) in dailyTotals {
+      let weekday = context.calendar.component(.weekday, from: day)
+      byWeekday[weekday, default: []].append(total)
+    }
+
+    // Examine the most recent day(s) in the window.
+    let recentDays = dailyTotals.keys
+      .filter { context.daysSince($0) >= 0 && context.daysSince($0) <= windowDays }
+      .sorted(by: >)
+
+    var insights: [Insight] = []
+    for day in recentDays {
+      let weekday = context.calendar.component(.weekday, from: day)
+      guard let population = byWeekday[weekday], population.count >= 4 else { continue }
+      let total = dailyTotals[day] ?? 0
+      let typical = DescriptiveStatistics.median(population)
+      guard typical > 0 else { continue }
+      let zScore = DescriptiveStatistics.robustZScore(of: total, in: population)
+      let ratio = total / typical
+      guard zScore >= threshold, ratio >= minimumRatio else { continue }
+
+      let weekdayName = weekdayName(weekday, calendar: context.calendar)
+      insights.append(
+        Insight(
+          id: "\(InsightKind.unusualDaySpend.rawValue):\(context.calendar.startOfDay(for: day).timeIntervalSince1970)",
+          kind: .unusualDaySpend,
+          title: "Big spending \(weekdayName)",
+          detail:
+            "You spent \(context.formatted(Decimal(-total))) — about "
+            + "\(ratio.formatted(.number.precision(.fractionLength(1))))× a typical "
+            + "\(weekdayName) (\(context.formatted(Decimal(-typical)))).",
+          date: day,
+          framing: .neutral,
+          actionability: .informational,
+          surprise: NormalDistribution.surprise(fromZScore: zScore),
+          monetaryImpact: InstrumentAmount(
+            quantity: Decimal(-total), instrument: context.reportingCurrency),
+          facts: [
+            InsightFact("Day", weekdayName),
+            InsightFact("Spent", context.formatted(Decimal(-total))),
+            InsightFact("Typical \(weekdayName)", context.formatted(Decimal(-typical))),
+            InsightFact("Multiple", "\(ratio.formatted(.number.precision(.fractionLength(1))))×"),
+          ],
+          references: InsightReferences(instrumentIds: [context.reportingCurrency.id])))
+      break  // Surface only the single most recent unusual day.
+    }
+    return insights
+  }
+
+  private static func weekdayName(_ weekday: Int, calendar: Calendar) -> String {
+    let symbols = calendar.weekdaySymbols
+    let index = weekday - 1
+    guard symbols.indices.contains(index) else { return "day" }
+    return symbols[index]
+  }
+}

--- a/Domain/Insights/Detectors/UnusualDayInsight.swift
+++ b/Domain/Insights/Detectors/UnusualDayInsight.swift
@@ -18,7 +18,8 @@ enum UnusualDayInsight {
     var dailyTotals: [Date: Double] = [:]
     for transaction in expenses {
       let day = context.calendar.startOfDay(for: transaction.date)
-      dailyTotals[day, default: 0] += Double(truncating: transaction.spendMagnitude as NSDecimalNumber)
+      dailyTotals[day, default: 0] += Double(
+        truncating: transaction.spendMagnitude as NSDecimalNumber)
     }
     guard !dailyTotals.isEmpty else { return [] }
 
@@ -34,7 +35,7 @@ enum UnusualDayInsight {
       .filter { context.daysSince($0) >= 0 && context.daysSince($0) <= windowDays }
       .sorted(by: >)
 
-    var insights: [Insight] = []
+    // Surface only the single most recent unusual day.
     for day in recentDays {
       let weekday = context.calendar.component(.weekday, from: day)
       guard let population = byWeekday[weekday], population.count >= 4 else { continue }
@@ -44,33 +45,51 @@ enum UnusualDayInsight {
       let zScore = DescriptiveStatistics.robustZScore(of: total, in: population)
       let ratio = total / typical
       guard zScore >= threshold, ratio >= minimumRatio else { continue }
-
-      let weekdayName = weekdayName(weekday, calendar: context.calendar)
-      insights.append(
-        Insight(
-          id: "\(InsightKind.unusualDaySpend.rawValue):\(context.calendar.startOfDay(for: day).timeIntervalSince1970)",
-          kind: .unusualDaySpend,
-          title: "Big spending \(weekdayName)",
-          detail:
-            "You spent \(context.formatted(Decimal(-total))) — about "
-            + "\(ratio.formatted(.number.precision(.fractionLength(1))))× a typical "
-            + "\(weekdayName) (\(context.formatted(Decimal(-typical)))).",
-          date: day,
-          framing: .neutral,
-          actionability: .informational,
-          surprise: NormalDistribution.surprise(fromZScore: zScore),
-          monetaryImpact: InstrumentAmount(
-            quantity: Decimal(-total), instrument: context.reportingCurrency),
-          facts: [
-            InsightFact("Day", weekdayName),
-            InsightFact("Spent", context.formatted(Decimal(-total))),
-            InsightFact("Typical \(weekdayName)", context.formatted(Decimal(-typical))),
-            InsightFact("Multiple", "\(ratio.formatted(.number.precision(.fractionLength(1))))×"),
-          ],
-          references: InsightReferences(instrumentIds: [context.reportingCurrency.id])))
-      break  // Surface only the single most recent unusual day.
+      let spike = DaySpike(
+        day: day, weekday: weekday, total: total, typical: typical, zScore: zScore)
+      return [makeInsight(spike, context: context)]
     }
-    return insights
+    return []
+  }
+
+  /// One day's outlier spend versus its weekday baseline.
+  private struct DaySpike {
+    let day: Date
+    let weekday: Int
+    let total: Double
+    let typical: Double
+    let zScore: Double
+  }
+
+  private static func makeInsight(_ spike: DaySpike, context: InsightContext) -> Insight {
+    let day = spike.day
+    let total = spike.total
+    let typical = spike.typical
+    let zScore = spike.zScore
+    let weekdayName = weekdayName(spike.weekday, calendar: context.calendar)
+    let ratio = typical > 0 ? total / typical : 0
+    let multiple = ratio.formatted(.number.precision(.fractionLength(1)))
+    let startOfDay = context.calendar.startOfDay(for: day).timeIntervalSince1970
+    return Insight(
+      id: "\(InsightKind.unusualDaySpend.rawValue):\(startOfDay)",
+      kind: .unusualDaySpend,
+      title: "Big spending \(weekdayName)",
+      detail:
+        "You spent \(context.formatted(Decimal(-total))) — about "
+        + "\(multiple)× a typical \(weekdayName) (\(context.formatted(Decimal(-typical)))).",
+      date: day,
+      framing: .neutral,
+      actionability: .informational,
+      surprise: NormalDistribution.surprise(fromZScore: zScore),
+      monetaryImpact: InstrumentAmount(
+        quantity: Decimal(-total), instrument: context.reportingCurrency),
+      facts: [
+        InsightFact("Day", weekdayName),
+        InsightFact("Spent", context.formatted(Decimal(-total))),
+        InsightFact("Typical \(weekdayName)", context.formatted(Decimal(-typical))),
+        InsightFact("Multiple", "\(multiple)×"),
+      ],
+      references: InsightReferences(instrumentIds: [context.reportingCurrency.id]))
   }
 
   private static func weekdayName(_ weekday: Int, calendar: Calendar) -> String {

--- a/Domain/Insights/Insight.swift
+++ b/Domain/Insights/Insight.swift
@@ -117,6 +117,7 @@ struct InsightReferences: Sendable, Hashable {
   var accountIds: [UUID]
   var categoryIds: [UUID]
   var earmarkIds: [UUID]
+  var groupIds: [UUID]
   var instrumentIds: [String]
   var transactionIds: [UUID]
 
@@ -124,12 +125,14 @@ struct InsightReferences: Sendable, Hashable {
     accountIds: [UUID] = [],
     categoryIds: [UUID] = [],
     earmarkIds: [UUID] = [],
+    groupIds: [UUID] = [],
     instrumentIds: [String] = [],
     transactionIds: [UUID] = []
   ) {
     self.accountIds = accountIds
     self.categoryIds = categoryIds
     self.earmarkIds = earmarkIds
+    self.groupIds = groupIds
     self.instrumentIds = instrumentIds
     self.transactionIds = transactionIds
   }

--- a/Domain/Insights/Insight.swift
+++ b/Domain/Insights/Insight.swift
@@ -1,0 +1,136 @@
+import Foundation
+
+/// One detected, narratable observation about the user's finances.
+///
+/// An `Insight` is the unit produced by the deterministic detectors and
+/// consumed by the ranker and the UI. It carries:
+/// - a stable `id` (used to de-duplicate across refreshes and to key the
+///   fatigue table),
+/// - template-string narration (`title` / `detail`) that needs no LLM,
+/// - the structured `facts` a Foundation Models layer would narrate from
+///   *without inventing numbers* (every number the LLM may print is here),
+/// - the ranking signals (`surprise`, `monetaryImpact`, `actionability`,
+///   `framing`, `date`),
+/// - `references` so the UI can deep-link to the underlying account,
+///   category, earmark, instrument, or transaction.
+///
+/// `Insight` is a pure value type — it never reaches into a store or a
+/// backend. Detectors build it; the wiring layer renders it.
+struct Insight: Sendable, Identifiable, Hashable {
+  let id: String
+  let kind: InsightKind
+  let title: String
+  let detail: String
+  let date: Date
+  let framing: InsightFraming
+  let actionability: InsightActionability
+
+  /// Normalised statistical strength in `0...1`. Higher means more
+  /// surprising relative to the detector's own baseline (a normalised
+  /// MAD-z, trend-test z, or burndown overshoot). Drives `w_surprise`.
+  let surprise: Double
+
+  /// Signed dollar impact in the reporting currency, when the insight has
+  /// one. Magnitude (not sign) feeds `w_magnitude`; the sign is preserved
+  /// for display and never `abs()`-ed away (`guides/CODE_GUIDE.md` §16).
+  let monetaryImpact: InstrumentAmount?
+
+  /// Structured evidence. The single source of truth for any number a
+  /// narration layer is allowed to render. Order is presentation order.
+  let facts: [InsightFact]
+
+  /// Deep-link handles for the UI.
+  let references: InsightReferences
+
+  init(
+    id: String,
+    kind: InsightKind,
+    title: String,
+    detail: String,
+    date: Date,
+    framing: InsightFraming,
+    actionability: InsightActionability,
+    surprise: Double,
+    monetaryImpact: InstrumentAmount? = nil,
+    facts: [InsightFact] = [],
+    references: InsightReferences = InsightReferences()
+  ) {
+    self.id = id
+    self.kind = kind
+    self.title = title
+    self.detail = detail
+    self.date = date
+    self.framing = framing
+    self.actionability = actionability
+    self.surprise = surprise
+    self.monetaryImpact = monetaryImpact
+    self.facts = facts
+    self.references = references
+  }
+}
+
+/// Emotional framing of an insight. The ranker uses `.positive` to honour
+/// the design's "guarantee one positive-framed insight per week" rule so
+/// the feature never reads as a scold (`guides`/design §"Ranking & Fatigue").
+enum InsightFraming: String, Sendable, Hashable {
+  case positive
+  case neutral
+  case negative
+}
+
+/// How much the user can *do* about an insight. The single biggest fatigue
+/// lever in the design: non-actionable insights are scored down hard.
+enum InsightActionability: String, Sendable, Hashable {
+  /// A clear next step ("cancel this duplicate", "cover this bill").
+  case act
+  /// Worth a look, no obvious one-tap action ("dining is trending up").
+  case review
+  /// Noted for awareness only ("net worth crossed $100k").
+  case informational
+
+  /// Weight contributed to the ranking score. Matches the design's
+  /// `1 / 0.5 / 0` scale.
+  var weight: Double {
+    switch self {
+    case .act: return 1
+    case .review: return 0.5
+    case .informational: return 0
+    }
+  }
+}
+
+/// A single labelled, pre-formatted fact. Detectors format the value in the
+/// reporting currency / locale so the narration layer never does arithmetic.
+struct InsightFact: Sendable, Hashable {
+  let label: String
+  let value: String
+
+  init(_ label: String, _ value: String) {
+    self.label = label
+    self.value = value
+  }
+}
+
+/// Identifiers an insight relates to, so the UI can navigate to the source.
+/// Every field defaults empty; detectors populate only what applies.
+struct InsightReferences: Sendable, Hashable {
+  var accountIds: [UUID]
+  var categoryIds: [UUID]
+  var earmarkIds: [UUID]
+  var instrumentIds: [String]
+  var transactionIds: [UUID]
+
+  init(
+    accountIds: [UUID] = [],
+    categoryIds: [UUID] = [],
+    earmarkIds: [UUID] = [],
+    instrumentIds: [String] = [],
+    transactionIds: [UUID] = []
+  ) {
+    self.accountIds = accountIds
+    self.categoryIds = categoryIds
+    self.earmarkIds = earmarkIds
+    self.instrumentIds = instrumentIds
+    self.transactionIds = transactionIds
+  }
+}

--- a/Domain/Insights/InsightAggregates.swift
+++ b/Domain/Insights/InsightAggregates.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+/// Shared roll-ups over the monthly aggregates and daily-balance series,
+/// computed once and reused by the cash-flow, savings, and income detectors
+/// so each doesn't re-derive "average monthly spend" from scratch.
+enum InsightAggregates {
+  /// Complete (not in-progress) financial months, ascending by bucket.
+  static func completeMonths(
+    _ monthly: [MonthlyIncomeExpense], context: InsightContext
+  ) -> [MonthlyIncomeExpense] {
+    let currentBucket = FinancialMonth.key(
+      for: context.now, monthEnd: context.financialMonthEnd)
+    return monthly.filter { $0.month < currentBucket }.sorted { $0.month < $1.month }
+  }
+
+  /// Mean spend magnitude (positive) over the trailing `months` complete
+  /// months. `nil` when there's no complete month.
+  static func averageMonthlySpend(
+    _ monthly: [MonthlyIncomeExpense], context: InsightContext, months: Int = 6
+  ) -> Decimal? {
+    let recent = completeMonths(monthly, context: context).suffix(months)
+    guard !recent.isEmpty else { return nil }
+    let total = recent.reduce(Decimal(0)) { $0 + spendMagnitude($1.totalExpense) }
+    return total / Decimal(recent.count)
+  }
+
+  /// Mean income magnitude (positive) over the trailing `months` complete
+  /// months. `nil` when there's no complete month.
+  static func averageMonthlyIncome(
+    _ monthly: [MonthlyIncomeExpense], context: InsightContext, months: Int = 6
+  ) -> Decimal? {
+    let recent = completeMonths(monthly, context: context).suffix(months)
+    guard !recent.isEmpty else { return nil }
+    let total = recent.reduce(Decimal(0)) { $0 + incomeMagnitude($1.totalIncome) }
+    return total / Decimal(recent.count)
+  }
+
+  /// Mean signed net (income + expense; positive = surplus) over the
+  /// trailing `months` complete months. `nil` when there's no complete month.
+  static func averageMonthlyNet(
+    _ monthly: [MonthlyIncomeExpense], context: InsightContext, months: Int = 6
+  ) -> Decimal? {
+    let recent = completeMonths(monthly, context: context).suffix(months)
+    guard !recent.isEmpty else { return nil }
+    let total = recent.reduce(Decimal(0)) { $0 + $1.totalProfit.quantity }
+    return total / Decimal(recent.count)
+  }
+
+  /// Most recent historical (non-forecast) daily balance.
+  static func latestActual(_ balances: [DailyBalance]) -> DailyBalance? {
+    balances.filter { !$0.isForecast }.max { $0.date < $1.date }
+  }
+
+  /// Positive spend magnitude from a signed (negative) expense amount; a
+  /// net-refund period clamps to zero.
+  static func spendMagnitude(_ amount: InstrumentAmount) -> Decimal {
+    amount.quantity < 0 ? -amount.quantity : 0
+  }
+
+  /// Positive income magnitude from a signed income amount.
+  static func incomeMagnitude(_ amount: InstrumentAmount) -> Decimal {
+    amount.quantity > 0 ? amount.quantity : 0
+  }
+}

--- a/Domain/Insights/InsightContext.swift
+++ b/Domain/Insights/InsightContext.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+/// Ambient parameters every detector needs: the reference "now", the
+/// reporting currency all monetary inputs are denominated in, and the
+/// calendar used for day/month bucketing. `now` is injected (never read
+/// from `Date()` inside a detector) so detector tests are deterministic —
+/// see `guides/TEST_GUIDE.md`.
+struct InsightContext: Sendable {
+  let now: Date
+  let reportingCurrency: Instrument
+  let calendar: Calendar
+
+  /// The user's financial-month boundary day (1–31), mirroring
+  /// `AnalysisStore.monthEnd`. Detectors that bucket by financial month
+  /// use it; most rely on the pre-bucketed `MonthlyIncomeExpense` instead.
+  let financialMonthEnd: Int
+
+  init(
+    now: Date,
+    reportingCurrency: Instrument,
+    calendar: Calendar = InsightContext.defaultCalendar,
+    financialMonthEnd: Int = 1
+  ) {
+    self.now = now
+    self.reportingCurrency = reportingCurrency
+    self.calendar = calendar
+    self.financialMonthEnd = financialMonthEnd
+  }
+
+  /// A UTC Gregorian calendar — matches how balances and aggregates are
+  /// bucketed in the backend (`DATE(...)` is UTC midnight).
+  static var defaultCalendar: Calendar {
+    var calendar = Calendar(identifier: .gregorian)
+    calendar.timeZone = TimeZone(identifier: "UTC") ?? calendar.timeZone
+    return calendar
+  }
+
+  /// Zero amount in the reporting currency — a convenience for detectors
+  /// that accumulate sums.
+  var zero: InstrumentAmount { .zero(instrument: reportingCurrency) }
+
+  /// Whole days from `date` to `now`, rounded toward zero. Negative for
+  /// future dates.
+  func daysSince(_ date: Date) -> Int {
+    calendar.dateComponents([.day], from: date, to: now).day ?? 0
+  }
+
+  /// Whole days from `now` to `date`. Negative for past dates.
+  func daysUntil(_ date: Date) -> Int {
+    calendar.dateComponents([.day], from: now, to: date).day ?? 0
+  }
+
+  /// Format a signed reporting-currency quantity for narration.
+  func formatted(_ quantity: Decimal) -> String {
+    InstrumentAmount(quantity: quantity, instrument: reportingCurrency).formatted
+  }
+
+  /// Format an amount for narration. Falls back to the reporting currency
+  /// label when the amount carries a different instrument.
+  func formatted(_ amount: InstrumentAmount) -> String {
+    amount.formatted
+  }
+}

--- a/Domain/Insights/InsightEngine.swift
+++ b/Domain/Insights/InsightEngine.swift
@@ -33,7 +33,9 @@ struct InsightEngine: Sendable {
     insights += cashFlowInsights(input)
     insights += budgetInsights(input)
     insights += investmentInsights(input)
-    insights += IncomeInsights.detect(incomeStreams: incomeStreams, context: context)
+    insights += incomeInsights(input, incomeStreams: incomeStreams)
+    insights += habitInsights(input)
+    insights += structuralInsights(input)
     return insights
   }
 
@@ -125,6 +127,36 @@ struct InsightEngine: Sendable {
     insights += NetWorthInsights.detect(dailyBalances: input.dailyBalances, context: input.context)
     insights += InvestmentInsights.detect(
       profitLoss: input.profitLoss, capitalGains: input.capitalGains, context: input.context)
+    return insights
+  }
+
+  private func incomeInsights(
+    _ input: InsightInput, incomeStreams: [DetectedSubscription]
+  ) -> [Insight] {
+    let context = input.context
+    var insights: [Insight] = []
+    insights += IncomeInsights.detect(incomeStreams: incomeStreams, context: context)
+    insights += IncomeExtraInsights.windfall(transactions: input.transactions, context: context)
+    insights += IncomeExtraInsights.payRateChange(incomeStreams: incomeStreams, context: context)
+    return insights
+  }
+
+  private func habitInsights(_ input: InsightInput) -> [Insight] {
+    let context = input.context
+    var insights: [Insight] = []
+    insights += SpendHabitInsights.lapsedMerchant(
+      transactions: input.transactions, context: context)
+    insights += SpendHabitInsights.weekendSkew(transactions: input.transactions, context: context)
+    return insights
+  }
+
+  /// Account-structure and data-quality insights (post-design-doc features).
+  private func structuralInsights(_ input: InsightInput) -> [Insight] {
+    var insights: [Insight] = []
+    insights += AccountGroupInsights.groupSpendConcentration(input)
+    insights += BudgetCoverageInsights.unbudgetedCategory(input)
+    insights += DataQualityInsights.uncategorizedBacklog(input)
+    insights += DataQualityInsights.unreconciledTransfers(input)
     return insights
   }
 }

--- a/Domain/Insights/InsightEngine.swift
+++ b/Domain/Insights/InsightEngine.swift
@@ -1,0 +1,130 @@
+import Foundation
+
+/// Runs every deterministic detector over an `InsightInput`, collects the
+/// candidates, and ranks them. The single entry point the wiring layer (and
+/// a future "For You" store) calls each surface refresh.
+///
+/// Pure and synchronous — all async currency conversion happens upstream
+/// when `InsightInput` is assembled (see `InsightTransaction` /
+/// `EarmarkSnapshot`). Detection over a few thousand transactions is
+/// microseconds-to-milliseconds; callers still run it off-main and publish
+/// to a `@MainActor` store per `guides/CONCURRENCY_GUIDE.md`.
+struct InsightEngine: Sendable {
+  var ranker: InsightRanker
+
+  init(ranker: InsightRanker = InsightRanker()) {
+    self.ranker = ranker
+  }
+
+  /// All detected candidates, unranked. Useful for category-scoped surfaces
+  /// that filter by `InsightKind.category` themselves, and for tests.
+  func detectAll(_ input: InsightInput) -> [Insight] {
+    let context = input.context
+    let calendar = context.calendar
+    let expenseSubscriptions = SubscriptionDetector.detect(
+      in: input.transactions, incomeStreams: false, calendar: calendar)
+    let incomeStreams = SubscriptionDetector.detect(
+      in: input.transactions, incomeStreams: true, calendar: calendar)
+
+    var insights: [Insight] = []
+    insights += subscriptionInsights(input, subscriptions: expenseSubscriptions)
+    insights += anomalyInsights(input)
+    insights += trendInsights(input)
+    insights += cashFlowInsights(input)
+    insights += budgetInsights(input)
+    insights += investmentInsights(input)
+    insights += IncomeInsights.detect(incomeStreams: incomeStreams, context: context)
+    return insights
+  }
+
+  /// Detect, score, and cap the insights for a surface.
+  func generate(
+    _ input: InsightInput,
+    dismissals: [InsightKind: Int] = [:],
+    interests: InsightRanker.DeclaredInterests = InsightRanker.DeclaredInterests(),
+    displayCap: Int = 5,
+    guaranteePositive: Bool = true
+  ) -> [ScoredInsight] {
+    ranker.rank(
+      detectAll(input),
+      now: input.context.now,
+      dismissals: dismissals,
+      interests: interests,
+      displayCap: displayCap,
+      guaranteePositive: guaranteePositive)
+  }
+
+  // MARK: - Detector groups
+
+  private func subscriptionInsights(
+    _ input: InsightInput, subscriptions: [DetectedSubscription]
+  ) -> [Insight] {
+    let context = input.context
+    let income = InsightAggregates.averageMonthlyIncome(input.monthly, context: context)
+    var insights: [Insight] = []
+    insights += SubscriptionInsights.newRecurring(subscriptions, context: context)
+    insights += SubscriptionInsights.priceHikes(subscriptions, context: context)
+    insights += SubscriptionInsights.duplicates(
+      subscriptions, categories: input.categories, context: context)
+    insights += SubscriptionInsights.cancellationCandidates(subscriptions, context: context)
+    insights += SavingsOpportunityInsights.subscriptionOverspend(
+      subscriptions: subscriptions, averageMonthlyIncome: income, context: context)
+    return insights
+  }
+
+  private func anomalyInsights(_ input: InsightInput) -> [Insight] {
+    let context = input.context
+    var insights: [Insight] = []
+    insights += LargeTransactionInsight.detect(
+      transactions: input.transactions, categories: input.categories, context: context)
+    insights += NewMerchantInsight.detect(transactions: input.transactions, context: context)
+    insights += UnusualDayInsight.detect(transactions: input.transactions, context: context)
+    insights += CategoryAnomalyInsight.detect(
+      breakdown: input.expenseBreakdown, categories: input.categories, context: context)
+    insights += SavingsOpportunityInsights.feeSpend(
+      transactions: input.transactions, context: context)
+    return insights
+  }
+
+  private func trendInsights(_ input: InsightInput) -> [Insight] {
+    let context = input.context
+    var insights: [Insight] = []
+    insights += CategoryTrendInsight.detect(
+      breakdown: input.expenseBreakdown, categories: input.categories, context: context)
+    insights += PeriodComparisonInsights.detect(monthly: input.monthly, context: context)
+    insights += CategoryMixShiftInsight.detect(
+      breakdown: input.expenseBreakdown, categories: input.categories, context: context)
+    return insights
+  }
+
+  private func cashFlowInsights(_ input: InsightInput) -> [Insight] {
+    let context = input.context
+    var insights: [Insight] = []
+    insights += CashFlowForecastInsights.upcomingBillWarning(
+      dailyBalances: input.dailyBalances, scheduledBills: input.scheduledBills, context: context)
+    insights += CashFlowForecastInsights.projectedMonthEnd(
+      dailyBalances: input.dailyBalances, context: context)
+    insights += LiquidityInsights.runway(
+      dailyBalances: input.dailyBalances, monthly: input.monthly, context: context)
+    insights += LiquidityInsights.idleCash(
+      dailyBalances: input.dailyBalances, monthly: input.monthly, context: context)
+    insights += SavingsRateInsight.detect(monthly: input.monthly, context: context)
+    return insights
+  }
+
+  private func budgetInsights(_ input: InsightInput) -> [Insight] {
+    let context = input.context
+    var insights: [Insight] = []
+    insights += EarmarkBudgetInsights.detect(earmarks: input.earmarks, context: context)
+    insights += SavingsGoalInsight.detect(earmarks: input.earmarks, context: context)
+    return insights
+  }
+
+  private func investmentInsights(_ input: InsightInput) -> [Insight] {
+    var insights: [Insight] = []
+    insights += NetWorthInsights.detect(dailyBalances: input.dailyBalances, context: input.context)
+    insights += InvestmentInsights.detect(
+      profitLoss: input.profitLoss, capitalGains: input.capitalGains, context: input.context)
+    return insights
+  }
+}

--- a/Domain/Insights/InsightInput.swift
+++ b/Domain/Insights/InsightInput.swift
@@ -121,12 +121,4 @@ struct ScheduledBill: Sendable, Identifiable, Hashable {
   /// Signed reporting-currency amount — negative for a bill (outflow).
   let amount: InstrumentAmount
   let accountId: UUID?
-
-  init(id: UUID, date: Date, payee: String?, amount: InstrumentAmount, accountId: UUID?) {
-    self.id = id
-    self.date = date
-    self.payee = payee
-    self.amount = amount
-    self.accountId = accountId
-  }
 }

--- a/Domain/Insights/InsightInput.swift
+++ b/Domain/Insights/InsightInput.swift
@@ -87,6 +87,25 @@ struct InsightInput: Sendable {
 
   let categories: Categories
 
+  /// Account groups the user has defined (`AccountGroupStore`), and the
+  /// `accountId → groupId` membership map. Drives group-level insights.
+  let accountGroups: [InsightAccountGroup]
+  let accountGroupMembership: [UUID: UUID]
+
+  /// Category ids that have a budget line item in some earmark
+  /// (`EarmarkStore`). Lets the budget-coverage detector spot a big
+  /// un-budgeted category.
+  let budgetedCategoryIds: Set<UUID>
+
+  /// Count of posted transactions whose every leg is uncategorized
+  /// (`Transaction.needsReview`). Drives the categorize-backlog nudge.
+  let uncategorizedTransactionCount: Int
+
+  /// Count of outstanding transfer suggestions awaiting merge
+  /// (`TransferSuggestionRepository`), with the oldest suggestion's date.
+  let pendingTransferCount: Int
+  let oldestPendingTransferDate: Date?
+
   init(
     context: InsightContext,
     transactions: [InsightTransaction] = [],
@@ -97,7 +116,13 @@ struct InsightInput: Sendable {
     earmarks: [EarmarkSnapshot] = [],
     profitLoss: [InstrumentProfitLoss] = [],
     capitalGains: [CapitalGainEvent] = [],
-    categories: Categories = Categories(from: [])
+    categories: Categories = Categories(from: []),
+    accountGroups: [InsightAccountGroup] = [],
+    accountGroupMembership: [UUID: UUID] = [:],
+    budgetedCategoryIds: Set<UUID> = [],
+    uncategorizedTransactionCount: Int = 0,
+    pendingTransferCount: Int = 0,
+    oldestPendingTransferDate: Date? = nil
   ) {
     self.context = context
     self.transactions = transactions
@@ -109,6 +134,12 @@ struct InsightInput: Sendable {
     self.profitLoss = profitLoss
     self.capitalGains = capitalGains
     self.categories = categories
+    self.accountGroups = accountGroups
+    self.accountGroupMembership = accountGroupMembership
+    self.budgetedCategoryIds = budgetedCategoryIds
+    self.uncategorizedTransactionCount = uncategorizedTransactionCount
+    self.pendingTransferCount = pendingTransferCount
+    self.oldestPendingTransferDate = oldestPendingTransferDate
   }
 }
 
@@ -121,4 +152,12 @@ struct ScheduledBill: Sendable, Identifiable, Hashable {
   /// Signed reporting-currency amount — negative for a bill (outflow).
   let amount: InstrumentAmount
   let accountId: UUID?
+}
+
+/// Minimal projection of an `AccountGroup` for insight narration —
+/// just the id and display name. The wiring layer builds these from
+/// `AccountGroupStore` alongside the `accountId → groupId` membership map.
+struct InsightAccountGroup: Sendable, Identifiable, Hashable {
+  let id: UUID
+  let name: String
 }

--- a/Domain/Insights/InsightInput.swift
+++ b/Domain/Insights/InsightInput.swift
@@ -1,0 +1,132 @@
+import Foundation
+
+/// A point-in-time view of one earmark (budget / savings goal) already
+/// reduced to the reporting currency, ready for the budget detectors.
+///
+/// `EarmarkStore` exposes converted balances as separate dictionaries
+/// (`convertedBalances`, `convertedSavedAmounts`, `convertedSpentAmounts`);
+/// the wiring layer joins them with the `Earmark` model into this snapshot
+/// so detectors stay pure and currency-safe.
+struct EarmarkSnapshot: Sendable, Identifiable, Hashable {
+  let id: UUID
+  let name: String
+  /// Current balance held against the earmark, reporting currency.
+  let balance: InstrumentAmount
+  /// Amount spent from the earmark within its active window, reporting
+  /// currency (positive magnitude). `nil` when unknown.
+  let spent: InstrumentAmount?
+  /// Total budgeted for the window (sum of line items), reporting currency.
+  /// `nil` for a pure savings goal with no spending budget.
+  let budget: InstrumentAmount?
+  let savingsGoal: InstrumentAmount?
+  /// Amount already saved toward `savingsGoal`, reporting currency.
+  let saved: InstrumentAmount?
+  let savingsStartDate: Date?
+  let savingsEndDate: Date?
+  let isHidden: Bool
+
+  init(
+    id: UUID,
+    name: String,
+    balance: InstrumentAmount,
+    spent: InstrumentAmount? = nil,
+    budget: InstrumentAmount? = nil,
+    savingsGoal: InstrumentAmount? = nil,
+    saved: InstrumentAmount? = nil,
+    savingsStartDate: Date? = nil,
+    savingsEndDate: Date? = nil,
+    isHidden: Bool = false
+  ) {
+    self.id = id
+    self.name = name
+    self.balance = balance
+    self.spent = spent
+    self.budget = budget
+    self.savingsGoal = savingsGoal
+    self.saved = saved
+    self.savingsStartDate = savingsStartDate
+    self.savingsEndDate = savingsEndDate
+    self.isHidden = isHidden
+  }
+}
+
+/// The full substrate handed to `InsightEngine`. Every monetary field is
+/// pre-converted to `context.reportingCurrency`; every collection is
+/// optional-by-emptiness (an empty array simply yields no insights from the
+/// detectors that read it). The wiring layer assembles this from the
+/// existing stores once per surface refresh.
+struct InsightInput: Sendable {
+  let context: InsightContext
+
+  /// Posted (non-scheduled) income/expense records, all instruments folded
+  /// into the reporting currency. The workhorse input for spend detectors.
+  let transactions: [InsightTransaction]
+
+  /// Per-financial-month income/expense aggregates (`AnalysisStore`).
+  let monthly: [MonthlyIncomeExpense]
+
+  /// Per-category per-month expense aggregates (`AnalysisStore`).
+  let expenseBreakdown: [ExpenseBreakdown]
+
+  /// Daily balance series including the forecast tail (`AnalysisStore`).
+  let dailyBalances: [DailyBalance]
+
+  /// Future-dated scheduled transactions (bills, recurring income), already
+  /// in the reporting currency. Drives the upcoming-bill warning.
+  let scheduledBills: [ScheduledBill]
+
+  /// Converted earmark snapshots (`EarmarkStore`).
+  let earmarks: [EarmarkSnapshot]
+
+  /// Per-instrument P&L (`ReportingStore`), in the reporting currency.
+  let profitLoss: [InstrumentProfitLoss]
+
+  /// Realised capital-gain events for the current tax context
+  /// (`ReportingStore`). Empty when no investments / not loaded.
+  let capitalGains: [CapitalGainEvent]
+
+  let categories: Categories
+
+  init(
+    context: InsightContext,
+    transactions: [InsightTransaction] = [],
+    monthly: [MonthlyIncomeExpense] = [],
+    expenseBreakdown: [ExpenseBreakdown] = [],
+    dailyBalances: [DailyBalance] = [],
+    scheduledBills: [ScheduledBill] = [],
+    earmarks: [EarmarkSnapshot] = [],
+    profitLoss: [InstrumentProfitLoss] = [],
+    capitalGains: [CapitalGainEvent] = [],
+    categories: Categories = Categories(from: [])
+  ) {
+    self.context = context
+    self.transactions = transactions
+    self.monthly = monthly
+    self.expenseBreakdown = expenseBreakdown
+    self.dailyBalances = dailyBalances
+    self.scheduledBills = scheduledBills
+    self.earmarks = earmarks
+    self.profitLoss = profitLoss
+    self.capitalGains = capitalGains
+    self.categories = categories
+  }
+}
+
+/// A single upcoming scheduled outflow (or inflow) projected from a
+/// recurring transaction, reduced to the reporting currency.
+struct ScheduledBill: Sendable, Identifiable, Hashable {
+  let id: UUID
+  let date: Date
+  let payee: String?
+  /// Signed reporting-currency amount — negative for a bill (outflow).
+  let amount: InstrumentAmount
+  let accountId: UUID?
+
+  init(id: UUID, date: Date, payee: String?, amount: InstrumentAmount, accountId: UUID?) {
+    self.id = id
+    self.date = date
+    self.payee = payee
+    self.amount = amount
+    self.accountId = accountId
+  }
+}

--- a/Domain/Insights/InsightKind.swift
+++ b/Domain/Insights/InsightKind.swift
@@ -54,6 +54,20 @@ enum InsightKind: String, Sendable, Hashable, CaseIterable {
   case paycheckTimingPattern
   case incomeStabilityScore
   case missingPaycheckAlert
+  case windfallIncome
+  case payRateChange
+
+  // K. Account structure (post-design-doc: account groups)
+  case groupSpendConcentration
+
+  // L. Data quality (post-design-doc: import provenance, transfer detection)
+  case uncategorizedBacklog
+  case unreconciledTransfers
+
+  // M. Merchant & budget coverage
+  case lapsedMerchant
+  case weekendSpendSkew
+  case unbudgetedCategory
 }
 
 extension InsightKind {
@@ -61,26 +75,32 @@ extension InsightKind {
   var category: InsightCategory {
     switch self {
     case .newRecurringDetected, .subscriptionPriceHike, .duplicateSubscription,
-      .subscriptionCancellationCandidate, .subscriptionOverspend:
+      .subscriptionCancellationCandidate, .subscriptionOverspend, .lapsedMerchant:
       return .subscriptions
     case .largeTransactionAnomaly, .newMerchantAlert, .unusualDaySpend,
       .categorySpendingAnomaly:
       return .anomalies
     case .categoryTrendRising, .categoryTrendFalling, .monthOverMonthDelta,
-      .categoryMixShift:
+      .categoryMixShift, .weekendSpendSkew:
       return .trends
     case .upcomingBillWarning, .projectedMonthEndBalance, .savingsRateTrend,
       .runwayEstimate:
       return .cashFlow
-    case .earmarkBurndownProjection, .earmarkUnderspend, .savingsGoalETA:
+    case .earmarkBurndownProjection, .earmarkUnderspend, .savingsGoalETA,
+      .unbudgetedCategory:
       return .budgets
     case .idleCashAlert, .feeSpend:
       return .savings
     case .netWorthMilestone, .investmentConcentrationRisk, .topPerformer,
       .bottomPerformer, .capitalGainsHarvest:
       return .investments
-    case .paycheckTimingPattern, .incomeStabilityScore, .missingPaycheckAlert:
+    case .paycheckTimingPattern, .incomeStabilityScore, .missingPaycheckAlert,
+      .windfallIncome, .payRateChange:
       return .income
+    case .groupSpendConcentration:
+      return .accounts
+    case .uncategorizedBacklog, .unreconciledTransfers:
+      return .dataQuality
     }
   }
 }
@@ -97,4 +117,6 @@ enum InsightCategory: String, Sendable, Hashable, CaseIterable {
   case savings
   case investments
   case income
+  case accounts
+  case dataQuality
 }

--- a/Domain/Insights/InsightKind.swift
+++ b/Domain/Insights/InsightKind.swift
@@ -1,0 +1,100 @@
+import Foundation
+
+/// The catalog of personalized-insight types, numbered to match
+/// `plans/2026-04-18-on-device-ai-design.md` §"Insight Catalog". Each
+/// raw value is a stable identifier used to build per-insight ids and to
+/// key the fatigue table — never rename one without a migration plan for
+/// persisted dismissals.
+///
+/// All detection is deterministic (pure Swift); the Foundation Models
+/// layer only narrates. See the design spec §"Where LLM Is Load-Bearing".
+enum InsightKind: String, Sendable, Hashable, CaseIterable {
+  // A. Recurring & Subscription Management
+  case newRecurringDetected
+  case subscriptionPriceHike
+  case duplicateSubscription
+  case subscriptionCancellationCandidate
+  case subscriptionOverspend
+
+  // B. Anomaly / Surprise Spending
+  case largeTransactionAnomaly
+  case newMerchantAlert
+  case unusualDaySpend
+  case categorySpendingAnomaly
+
+  // C. Trends & Period Comparisons
+  case categoryTrendRising
+  case categoryTrendFalling
+  case monthOverMonthDelta
+  case categoryMixShift
+
+  // D. Cash Flow & Forecasting
+  case upcomingBillWarning
+  case projectedMonthEndBalance
+  case savingsRateTrend
+  case runwayEstimate
+
+  // E. Budget Performance (Earmarks)
+  case earmarkBurndownProjection
+  case earmarkUnderspend
+  case savingsGoalETA
+
+  // F. Savings Opportunities
+  case idleCashAlert
+  case feeSpend
+
+  // G. Net Worth & Investments
+  case netWorthMilestone
+  case investmentConcentrationRisk
+  case topPerformer
+  case bottomPerformer
+  case capitalGainsHarvest
+
+  // H. Income Analysis
+  case paycheckTimingPattern
+  case incomeStabilityScore
+  case missingPaycheckAlert
+}
+
+extension InsightKind {
+  /// Broad grouping used by the ranker and by category-scoped surfaces.
+  var category: InsightCategory {
+    switch self {
+    case .newRecurringDetected, .subscriptionPriceHike, .duplicateSubscription,
+      .subscriptionCancellationCandidate, .subscriptionOverspend:
+      return .subscriptions
+    case .largeTransactionAnomaly, .newMerchantAlert, .unusualDaySpend,
+      .categorySpendingAnomaly:
+      return .anomalies
+    case .categoryTrendRising, .categoryTrendFalling, .monthOverMonthDelta,
+      .categoryMixShift:
+      return .trends
+    case .upcomingBillWarning, .projectedMonthEndBalance, .savingsRateTrend,
+      .runwayEstimate:
+      return .cashFlow
+    case .earmarkBurndownProjection, .earmarkUnderspend, .savingsGoalETA:
+      return .budgets
+    case .idleCashAlert, .feeSpend:
+      return .savings
+    case .netWorthMilestone, .investmentConcentrationRisk, .topPerformer,
+      .bottomPerformer, .capitalGainsHarvest:
+      return .investments
+    case .paycheckTimingPattern, .incomeStabilityScore, .missingPaycheckAlert:
+      return .income
+    }
+  }
+}
+
+/// Coarse grouping of insight kinds. Drives surface routing (e.g. only
+/// `cashFlow` insights appear on a per-account view) and the ranker's
+/// per-category display caps.
+enum InsightCategory: String, Sendable, Hashable, CaseIterable {
+  case subscriptions
+  case anomalies
+  case trends
+  case cashFlow
+  case budgets
+  case savings
+  case investments
+  case income
+}

--- a/Domain/Insights/InsightRanker.swift
+++ b/Domain/Insights/InsightRanker.swift
@@ -25,8 +25,6 @@ struct InsightRanker: Sendable {
     var recency: Double = 0.8
     var interest: Double = 0.7
     var fatigue: Double = 1.5
-
-    init() {}
   }
 
   /// Categories / earmarks the user has pinned — boosts their insights.
@@ -63,11 +61,13 @@ struct InsightRanker: Sendable {
     dismissals: [InsightKind: Int] = [:],
     interests: DeclaredInterests = DeclaredInterests()
   ) -> Double {
-    let magnitude = insight.monetaryImpact
+    let magnitude =
+      insight.monetaryImpact
       .map { abs(Double(truncating: $0.quantity as NSDecimalNumber)) } ?? 0
     let magnitudeTerm = log(magnitude + 1)
 
-    let ageDays = max(0, Double(calendar.dateComponents([.day], from: insight.date, to: now).day ?? 0))
+    let ageDays = max(
+      0, Double(calendar.dateComponents([.day], from: insight.date, to: now).day ?? 0))
     let recencyTerm = exp(-ageDays / recencyHalfLife)
 
     let interestTerm = matchesInterest(insight, interests: interests) ? 1.0 : 0.0
@@ -95,8 +95,12 @@ struct InsightRanker: Sendable {
     guaranteePositive: Bool = true
   ) -> [ScoredInsight] {
     let deduped = deduplicate(insights)
-    let scored = deduped
-      .map { ScoredInsight(insight: $0, score: score($0, now: now, dismissals: dismissals, interests: interests)) }
+    let scored =
+      deduped
+      .map {
+        ScoredInsight(
+          insight: $0, score: score($0, now: now, dismissals: dismissals, interests: interests))
+      }
       .sorted { $0.score > $1.score }
 
     guard displayCap > 0 else { return [] }
@@ -121,7 +125,9 @@ struct InsightRanker: Sendable {
     return result
   }
 
-  private func ensurePositive(in top: [ScoredInsight], from scored: [ScoredInsight]) -> [ScoredInsight] {
+  private func ensurePositive(in top: [ScoredInsight], from scored: [ScoredInsight])
+    -> [ScoredInsight]
+  {
     guard !top.contains(where: { $0.insight.framing == .positive }) else { return top }
     guard let bestPositive = scored.first(where: { $0.insight.framing == .positive }),
       !top.contains(where: { $0.id == bestPositive.id }),

--- a/Domain/Insights/InsightRanker.swift
+++ b/Domain/Insights/InsightRanker.swift
@@ -1,0 +1,145 @@
+import Foundation
+
+/// An insight paired with its computed ranking score. Returned by the ranker
+/// so callers can show "why this is here" diagnostics if they want.
+struct ScoredInsight: Sendable, Identifiable, Hashable {
+  let insight: Insight
+  let score: Double
+  var id: String { insight.id }
+}
+
+/// Scores and orders candidate insights, the single most important
+/// anti-fatigue lever in the design (§"Insight Ranking & Fatigue"). Without
+/// a ranker the feature becomes a notification spambot.
+///
+/// `score = w_surprise·surprise + w_action·actionability +
+/// w_magnitude·log(|$|+1) + w_recency·decay + w_interest·interest −
+/// w_fatigue·recentDismissals`.
+struct InsightRanker: Sendable {
+  /// Tunable term weights. Defaults are the design's hand-tuned starting
+  /// point — "revisit once we have dismissal telemetry".
+  struct Weights: Sendable {
+    var surprise: Double = 1.0
+    var action: Double = 1.2
+    var magnitude: Double = 0.5
+    var recency: Double = 0.8
+    var interest: Double = 0.7
+    var fatigue: Double = 1.5
+
+    init() {}
+  }
+
+  /// Categories / earmarks the user has pinned — boosts their insights.
+  struct DeclaredInterests: Sendable {
+    var categoryIds: Set<UUID>
+    var earmarkIds: Set<UUID>
+
+    init(categoryIds: Set<UUID> = [], earmarkIds: Set<UUID> = []) {
+      self.categoryIds = categoryIds
+      self.earmarkIds = earmarkIds
+    }
+  }
+
+  var weights: Weights
+  /// Recency decay time-constant τ (days). Design suggests ≈7.
+  var recencyHalfLife: Double
+  var calendar: Calendar
+
+  init(
+    weights: Weights = Weights(),
+    recencyHalfLife: Double = 7,
+    calendar: Calendar = InsightContext.defaultCalendar
+  ) {
+    self.weights = weights
+    self.recencyHalfLife = recencyHalfLife
+    self.calendar = calendar
+  }
+
+  /// Score one insight. `dismissals` is the count of recent dismissals for
+  /// that insight kind (the fatigue penalty).
+  func score(
+    _ insight: Insight,
+    now: Date,
+    dismissals: [InsightKind: Int] = [:],
+    interests: DeclaredInterests = DeclaredInterests()
+  ) -> Double {
+    let magnitude = insight.monetaryImpact
+      .map { abs(Double(truncating: $0.quantity as NSDecimalNumber)) } ?? 0
+    let magnitudeTerm = log(magnitude + 1)
+
+    let ageDays = max(0, Double(calendar.dateComponents([.day], from: insight.date, to: now).day ?? 0))
+    let recencyTerm = exp(-ageDays / recencyHalfLife)
+
+    let interestTerm = matchesInterest(insight, interests: interests) ? 1.0 : 0.0
+    let fatiguePenalty = Double(dismissals[insight.kind] ?? 0)
+
+    return weights.surprise * clamp(insight.surprise)
+      + weights.action * insight.actionability.weight
+      + weights.magnitude * magnitudeTerm
+      + weights.recency * recencyTerm
+      + weights.interest * interestTerm
+      - weights.fatigue * fatiguePenalty
+  }
+
+  /// Rank candidates: de-duplicate by id, score, sort descending, then apply
+  /// the display cap. When `guaranteePositive` is set and the capped set has
+  /// no positive-framed insight, the lowest-ranked slot is swapped for the
+  /// best available positive one — the design's "guarantee one positive
+  /// insight per week".
+  func rank(
+    _ insights: [Insight],
+    now: Date,
+    dismissals: [InsightKind: Int] = [:],
+    interests: DeclaredInterests = DeclaredInterests(),
+    displayCap: Int = 5,
+    guaranteePositive: Bool = true
+  ) -> [ScoredInsight] {
+    let deduped = deduplicate(insights)
+    let scored = deduped
+      .map { ScoredInsight(insight: $0, score: score($0, now: now, dismissals: dismissals, interests: interests)) }
+      .sorted { $0.score > $1.score }
+
+    guard displayCap > 0 else { return [] }
+    var top = Array(scored.prefix(displayCap))
+    if guaranteePositive {
+      top = ensurePositive(in: top, from: scored)
+    }
+    return top
+  }
+
+  // MARK: - Helpers
+
+  /// Keep the highest-scoring instance of each id. Detectors are designed to
+  /// produce stable ids, but a defensive de-dup avoids double-showing.
+  private func deduplicate(_ insights: [Insight]) -> [Insight] {
+    var seen: Set<String> = []
+    var result: [Insight] = []
+    for insight in insights where !seen.contains(insight.id) {
+      seen.insert(insight.id)
+      result.append(insight)
+    }
+    return result
+  }
+
+  private func ensurePositive(in top: [ScoredInsight], from scored: [ScoredInsight]) -> [ScoredInsight] {
+    guard !top.contains(where: { $0.insight.framing == .positive }) else { return top }
+    guard let bestPositive = scored.first(where: { $0.insight.framing == .positive }),
+      !top.contains(where: { $0.id == bestPositive.id }),
+      !top.isEmpty
+    else { return top }
+    var adjusted = top
+    adjusted[adjusted.count - 1] = bestPositive
+    return adjusted.sorted { $0.score > $1.score }
+  }
+
+  private func matchesInterest(_ insight: Insight, interests: DeclaredInterests) -> Bool {
+    if insight.references.categoryIds.contains(where: interests.categoryIds.contains) {
+      return true
+    }
+    return insight.references.earmarkIds.contains(where: interests.earmarkIds.contains)
+  }
+
+  private func clamp(_ value: Double) -> Double {
+    min(max(value, 0), 1)
+  }
+}

--- a/Domain/Insights/InsightTransaction.swift
+++ b/Domain/Insights/InsightTransaction.swift
@@ -1,0 +1,128 @@
+import Foundation
+
+/// A flattened, currency-normalised view of one income or expense leg,
+/// shaped for the statistical detectors.
+///
+/// Detectors must stay pure and synchronous, but currency conversion is
+/// async (`InstrumentConversionService`). The boundary is drawn here: the
+/// wiring layer converts each leg's amount to the reporting currency once,
+/// up front, and feeds detectors a flat array of `InsightTransaction`
+/// already denominated in a single instrument. Detectors then do
+/// instrument-safe arithmetic without ever touching the conversion service.
+///
+/// **Sign convention** (`guides/CODE_GUIDE.md` §16): `amount` is signed in
+/// the reporting currency — income positive, expense negative, refunds
+/// (positive-valued expense legs) preserved with their real sign. Detectors
+/// must never `abs()` it; they derive spend magnitude explicitly via
+/// `spendMagnitude`.
+struct InsightTransaction: Sendable, Identifiable, Hashable {
+  /// The owning transaction's id (not the leg's) — multiple records can
+  /// share it when a transaction splits across categories.
+  let id: UUID
+  let date: Date
+  let rawPayee: String?
+  /// `rawPayee` run through `PayeeNormalizer` — the clustering key for
+  /// subscription and new-merchant detection. Empty when no payee.
+  let normalizedPayee: String
+  let amount: Decimal
+  let categoryId: UUID?
+  let categoryPath: String?
+  let type: TransactionType
+  let accountId: UUID?
+
+  init(
+    id: UUID,
+    date: Date,
+    rawPayee: String?,
+    normalizedPayee: String,
+    amount: Decimal,
+    categoryId: UUID?,
+    categoryPath: String?,
+    type: TransactionType,
+    accountId: UUID?
+  ) {
+    self.id = id
+    self.date = date
+    self.rawPayee = rawPayee
+    self.normalizedPayee = normalizedPayee
+    self.amount = amount
+    self.categoryId = categoryId
+    self.categoryPath = categoryPath
+    self.type = type
+    self.accountId = accountId
+  }
+
+  /// Positive magnitude of money that left the account for an expense, or
+  /// `0` for a refund / inflow. Spend-oriented detectors aggregate this;
+  /// it deliberately collapses refunds to `0` rather than `abs()`-ing the
+  /// inflow into a spurious outflow.
+  var spendMagnitude: Decimal {
+    amount < 0 ? -amount : 0
+  }
+
+  /// Positive magnitude of money received as income, or `0` for an outflow.
+  var incomeMagnitude: Decimal {
+    amount > 0 ? amount : 0
+  }
+
+  var isExpense: Bool { type == .expense }
+  var isIncome: Bool { type == .income }
+}
+
+extension InsightTransaction {
+  /// Flatten transactions into per-leg income/expense records, converting
+  /// each leg's amount to the reporting currency via `convert`.
+  ///
+  /// Only `.income` and `.expense` legs are emitted — transfers, opening
+  /// balances, and trades are excluded because they don't represent
+  /// discretionary spend or earned income. A leg whose conversion returns
+  /// `nil` (rate unavailable) is dropped rather than guessed, per
+  /// `guides/INSTRUMENT_CONVERSION_GUIDE.md` Rule 11; callers that need a
+  /// "data incomplete" signal should compare counts.
+  ///
+  /// `convert` receives the leg amount and the transaction date and returns
+  /// the equivalent quantity in the reporting currency, or `nil` on failure.
+  static func records(
+    from transactions: [Transaction],
+    categories: Categories,
+    convert: (InstrumentAmount, Date) -> Decimal?
+  ) -> [InsightTransaction] {
+    var records: [InsightTransaction] = []
+    for transaction in transactions {
+      let normalized = PayeeNormalizer.normalize(transaction.payee)
+      for leg in transaction.legs where leg.type == .income || leg.type == .expense {
+        guard let quantity = convert(leg.amount, transaction.date) else { continue }
+        let path = leg.categoryId
+          .flatMap { categories.by(id: $0) }
+          .map { categories.path(for: $0) }
+        records.append(
+          InsightTransaction(
+            id: transaction.id,
+            date: transaction.date,
+            rawPayee: transaction.payee,
+            normalizedPayee: normalized,
+            amount: quantity,
+            categoryId: leg.categoryId,
+            categoryPath: path,
+            type: leg.type,
+            accountId: leg.accountId))
+      }
+    }
+    return records
+  }
+
+  /// Convenience builder for single-currency profiles (or any caller that
+  /// has already pre-converted): keeps only legs already denominated in
+  /// `reportingCurrency` and uses their quantity directly. Mixed-currency
+  /// profiles must use `records(from:categories:convert:)` with a real
+  /// converter.
+  static func sameCurrencyRecords(
+    from transactions: [Transaction],
+    categories: Categories,
+    reportingCurrency: Instrument
+  ) -> [InsightTransaction] {
+    records(from: transactions, categories: categories) { amount, _ in
+      amount.instrument == reportingCurrency ? amount.quantity : nil
+    }
+  }
+}

--- a/Domain/Insights/PayeeNormalizer.swift
+++ b/Domain/Insights/PayeeNormalizer.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+/// Normalises a raw payee string into a stable clustering key for
+/// subscription and new-merchant detection.
+///
+/// The design (`plans/2026-04-18-on-device-ai-design.md` §"Implementation
+/// notes") calls for: lowercase, collapse whitespace, strip trailing
+/// numerics / merchant-id noise. The transforms here are intentionally
+/// conservative — the goal is to fold "STARBUCKS #1234" and "STARBUCKS
+/// #5678  " onto the same key without merging genuinely different
+/// merchants. It does *not* attempt LLM-grade merchant-name cleanup
+/// (that's the cosmetic FM layer in the design).
+enum PayeeNormalizer {
+  /// Tokens that frequently prefix bank-statement descriptors and carry no
+  /// merchant identity. Stripped only when they lead the string.
+  private static let leadingNoise: Set<String> = [
+    "pos", "sq", "tst", "paypal", "pp", "visa", "eftpos", "debit", "purchase",
+    "payment", "card",
+  ]
+
+  /// Normalise an optional payee. Returns `""` for `nil` / blank input so
+  /// callers can cheaply skip un-clusterable rows.
+  static func normalize(_ payee: String?) -> String {
+    guard let payee, !payee.isEmpty else { return "" }
+    var working = payee.lowercased()
+
+    // Replace any run of non-alphanumeric characters with a single space.
+    working = working.replacingOccurrences(
+      of: "[^a-z0-9]+", with: " ", options: .regularExpression)
+
+    var tokens = working.split(separator: " ").map(String.init)
+
+    // Drop a single leading noise token (e.g. "pos starbucks" → "starbucks").
+    if let first = tokens.first, leadingNoise.contains(first) {
+      tokens.removeFirst()
+    }
+
+    // Drop trailing tokens that are purely numeric or look like store /
+    // reference ids (a digit anywhere). "starbucks 1234" → "starbucks".
+    // Keep going while the last token is noise, but never strip the only
+    // remaining alphabetic anchor.
+    while tokens.count > 1, let last = tokens.last, isReferenceToken(last) {
+      tokens.removeLast()
+    }
+
+    return tokens.joined(separator: " ")
+  }
+
+  /// A token that's all digits, or a short alphanumeric mix that contains a
+  /// digit (store numbers, terminal ids, dates). Pure-alpha tokens are kept.
+  private static func isReferenceToken(_ token: String) -> Bool {
+    let hasDigit = token.contains(where: \.isNumber)
+    guard hasDigit else { return false }
+    let allDigits = token.allSatisfy(\.isNumber)
+    return allDigits || token.count <= 6
+  }
+}

--- a/Domain/Insights/Statistics/BenjaminiHochberg.swift
+++ b/Domain/Insights/Statistics/BenjaminiHochberg.swift
@@ -5,11 +5,6 @@ import Foundation
 struct PValue<Tag: Hashable & Sendable>: Sendable, Hashable {
   let tag: Tag
   let pValue: Double
-
-  init(tag: Tag, pValue: Double) {
-    self.tag = tag
-    self.pValue = pValue
-  }
 }
 
 /// Benjamini-Hochberg false-discovery-rate control. The design (§C-10)

--- a/Domain/Insights/Statistics/BenjaminiHochberg.swift
+++ b/Domain/Insights/Statistics/BenjaminiHochberg.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// One hypothesis fed into the Benjamini-Hochberg procedure, tagged so the
+/// caller can recover which item each p-value belonged to.
+struct PValue<Tag: Hashable & Sendable>: Sendable, Hashable {
+  let tag: Tag
+  let pValue: Double
+
+  init(tag: Tag, pValue: Double) {
+    self.tag = tag
+    self.pValue = pValue
+  }
+}
+
+/// Benjamini-Hochberg false-discovery-rate control. The design (§C-10)
+/// requires it before surfacing per-category trend tests: testing 30
+/// categories at α=0.05 yields ~1.5 false positives per refresh with no
+/// correction, which reads as alert spam.
+enum BenjaminiHochberg {
+  /// Return the subset of `hypotheses` whose discoveries survive FDR control
+  /// at level `fdr`. Standard step-up procedure: sort ascending by p-value,
+  /// find the largest rank `k` with `p₍ₖ₎ ≤ (k/m)·fdr`, reject all
+  /// hypotheses with that p-value or smaller.
+  static func significant<Tag>(
+    _ hypotheses: [PValue<Tag>], fdr: Double = 0.05
+  ) -> [PValue<Tag>] {
+    guard !hypotheses.isEmpty else { return [] }
+    let sorted = hypotheses.sorted { $0.pValue < $1.pValue }
+    let total = Double(sorted.count)
+
+    var threshold = -1
+    for (index, hypothesis) in sorted.enumerated() {
+      let rank = Double(index + 1)
+      if hypothesis.pValue <= (rank / total) * fdr {
+        threshold = index
+      }
+    }
+    guard threshold >= 0 else { return [] }
+    return Array(sorted.prefix(threshold + 1))
+  }
+}

--- a/Domain/Insights/Statistics/DescriptiveStatistics.swift
+++ b/Domain/Insights/Statistics/DescriptiveStatistics.swift
@@ -1,0 +1,89 @@
+import Foundation
+
+/// Pure descriptive-statistics helpers shared by the insight detectors.
+///
+/// Everything operates on `[Double]`; callers convert `Decimal` amounts at
+/// the boundary (`Double(truncating:)`) because the robust estimators here
+/// (median, MAD) need ordering and division that `Decimal` makes clumsy and
+/// the inputs are already lossy aggregates. Monetary *results* are converted
+/// back to `Decimal` / `InstrumentAmount` by the detector.
+enum DescriptiveStatistics {
+  /// Arithmetic mean, or `0` for an empty input.
+  static func mean(_ values: [Double]) -> Double {
+    guard !values.isEmpty else { return 0 }
+    return values.reduce(0, +) / Double(values.count)
+  }
+
+  /// Median (lower-of-two-middle averaged). `0` for an empty input.
+  static func median(_ values: [Double]) -> Double {
+    guard !values.isEmpty else { return 0 }
+    let sorted = values.sorted()
+    let count = sorted.count
+    if count.isMultiple(of: 2) {
+      return (sorted[count / 2 - 1] + sorted[count / 2]) / 2
+    }
+    return sorted[count / 2]
+  }
+
+  /// Population standard deviation. `0` for fewer than two values.
+  static func standardDeviation(_ values: [Double]) -> Double {
+    guard values.count > 1 else { return 0 }
+    let average = mean(values)
+    let variance = values.reduce(0) { $0 + ($1 - average) * ($1 - average) }
+      / Double(values.count)
+    return variance.squareRoot()
+  }
+
+  /// Median Absolute Deviation. Robust scale estimate: `median(|xᵢ −
+  /// median(x)|)`. `0` for an empty input.
+  static func medianAbsoluteDeviation(_ values: [Double]) -> Double {
+    guard !values.isEmpty else { return 0 }
+    let center = median(values)
+    let deviations = values.map { abs($0 - center) }
+    return median(deviations)
+  }
+
+  /// Robust z-score of `value` against the distribution `population`, using
+  /// the MAD with the `0.6745` normal-consistency constant
+  /// (`0.6745 · (x − median) / MAD`). Falls back to the classic z-score when
+  /// the MAD is zero but the standard deviation is not (e.g. a tight cluster
+  /// with one outlier where >50% of points are identical). Returns `0` when
+  /// both scale estimates vanish.
+  ///
+  /// Sign is preserved: a value far *below* the centre yields a negative
+  /// score, distinguishing an unusually large refund from an unusually large
+  /// charge.
+  static func robustZScore(of value: Double, in population: [Double]) -> Double {
+    guard population.count > 1 else { return 0 }
+    let center = median(population)
+    let mad = medianAbsoluteDeviation(population)
+    if mad > 0 {
+      return 0.6745 * (value - center) / mad
+    }
+    let deviation = standardDeviation(population)
+    guard deviation > 0 else { return 0 }
+    return (value - mean(population)) / deviation
+  }
+
+  /// The value below which `fraction` (0...1) of the sorted data falls, via
+  /// linear interpolation between order statistics. `0` for an empty input.
+  static func percentile(_ values: [Double], _ fraction: Double) -> Double {
+    guard !values.isEmpty else { return 0 }
+    let sorted = values.sorted()
+    guard sorted.count > 1 else { return sorted[0] }
+    let clamped = min(max(fraction, 0), 1)
+    let position = clamped * Double(sorted.count - 1)
+    let lower = Int(position.rounded(.down))
+    let upper = Int(position.rounded(.up))
+    let weight = position - Double(lower)
+    return sorted[lower] * (1 - weight) + sorted[upper] * weight
+  }
+
+  /// Coefficient of variation: `stddev / |mean|`. `nil` when the mean is
+  /// zero (the ratio is undefined). Used for the income-stability score.
+  static func coefficientOfVariation(_ values: [Double]) -> Double? {
+    let average = mean(values)
+    guard average != 0 else { return nil }
+    return standardDeviation(values) / abs(average)
+  }
+}

--- a/Domain/Insights/Statistics/DescriptiveStatistics.swift
+++ b/Domain/Insights/Statistics/DescriptiveStatistics.swift
@@ -29,7 +29,8 @@ enum DescriptiveStatistics {
   static func standardDeviation(_ values: [Double]) -> Double {
     guard values.count > 1 else { return 0 }
     let average = mean(values)
-    let variance = values.reduce(0) { $0 + ($1 - average) * ($1 - average) }
+    let variance =
+      values.reduce(0) { $0 + ($1 - average) * ($1 - average) }
       / Double(values.count)
     return variance.squareRoot()
   }

--- a/Domain/Insights/Statistics/MannKendall.swift
+++ b/Domain/Insights/Statistics/MannKendall.swift
@@ -1,0 +1,94 @@
+import Foundation
+
+/// Result of a Mann-Kendall monotonic-trend test plus the Sen's-slope point
+/// estimate, over an evenly-spaced time series.
+struct MannKendallResult: Sendable, Hashable {
+  /// The Mann-Kendall S statistic (sum of pairwise sign comparisons).
+  let statistic: Int
+  /// Normal-approximation z (continuity-corrected, tie-adjusted variance).
+  let zScore: Double
+  /// Two-sided p-value from the normal approximation.
+  let pValue: Double
+  /// Sen's slope: median of all pairwise slopes, in series units per step.
+  let sensSlope: Double
+
+  var isIncreasing: Bool { statistic > 0 }
+  var isDecreasing: Bool { statistic < 0 }
+}
+
+/// Non-parametric monotonic-trend detection. Chosen over linear regression
+/// (design §C-10) because it assumes no distribution and tolerates small N.
+///
+/// Apply `BenjaminiHochberg` across the per-category family of tests before
+/// surfacing any result — testing dozens of categories without FDR control
+/// manufactures false trends and floods the user (design §"alert spam").
+enum MannKendall {
+  /// Run the test over `values` in time order (index = time step). Returns
+  /// `nil` for fewer than four points — the normal approximation is
+  /// meaningless below that and the slope is too noisy to act on.
+  static func test(_ values: [Double]) -> MannKendallResult? {
+    let count = values.count
+    guard count >= 4 else { return nil }
+
+    var statistic = 0
+    for i in 0..<(count - 1) {
+      for j in (i + 1)..<count {
+        statistic += signum(values[j] - values[i])
+      }
+    }
+
+    let variance = tieAdjustedVariance(values)
+    let zScore = continuityCorrectedZ(statistic: statistic, variance: variance)
+    let pValue = NormalDistribution.twoSidedPValue(zScore)
+    let slope = sensSlope(values)
+
+    return MannKendallResult(
+      statistic: statistic, zScore: zScore, pValue: pValue, sensSlope: slope)
+  }
+
+  /// Variance of S under H₀, corrected for ties:
+  /// `[n(n−1)(2n+5) − Σ tₚ(tₚ−1)(2tₚ+5)] / 18`.
+  private static func tieAdjustedVariance(_ values: [Double]) -> Double {
+    let count = Double(values.count)
+    let base = count * (count - 1) * (2 * count + 5)
+    var tieCorrection = 0.0
+    let groups = Dictionary(grouping: values, by: { $0 })
+    for group in groups.values where group.count > 1 {
+      let tied = Double(group.count)
+      tieCorrection += tied * (tied - 1) * (2 * tied + 5)
+    }
+    return (base - tieCorrection) / 18
+  }
+
+  /// Continuity-corrected normal statistic. `0` when S is zero or the
+  /// variance collapses (all points tied).
+  private static func continuityCorrectedZ(statistic: Int, variance: Double) -> Double {
+    guard variance > 0 else { return 0 }
+    let deviation = variance.squareRoot()
+    if statistic > 0 {
+      return Double(statistic - 1) / deviation
+    } else if statistic < 0 {
+      return Double(statistic + 1) / deviation
+    }
+    return 0
+  }
+
+  /// Sen's slope: median of `(xⱼ − xᵢ) / (j − i)` over all `i < j`.
+  private static func sensSlope(_ values: [Double]) -> Double {
+    var slopes: [Double] = []
+    let count = values.count
+    slopes.reserveCapacity(count * (count - 1) / 2)
+    for i in 0..<(count - 1) {
+      for j in (i + 1)..<count {
+        slopes.append((values[j] - values[i]) / Double(j - i))
+      }
+    }
+    return DescriptiveStatistics.median(slopes)
+  }
+
+  private static func signum(_ value: Double) -> Int {
+    if value > 0 { return 1 }
+    if value < 0 { return -1 }
+    return 0
+  }
+}

--- a/Domain/Insights/Statistics/NormalDistribution.swift
+++ b/Domain/Insights/Statistics/NormalDistribution.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// Standard-normal helpers used to turn test statistics into p-values and
+/// to squash unbounded z-scores into a `0...1` surprise signal.
+enum NormalDistribution {
+  /// Cumulative distribution function Φ(z) via the C library `erf`.
+  static func cdf(_ value: Double) -> Double {
+    0.5 * (1 + erf(value / 2.0.squareRoot()))
+  }
+
+  /// Two-sided p-value for a standard-normal test statistic.
+  static func twoSidedPValue(_ statistic: Double) -> Double {
+    2 * (1 - cdf(abs(statistic)))
+  }
+
+  /// Map an unbounded statistic onto `0...1` via the half-normal CDF:
+  /// `2·Φ(|z|) − 1`. `0` at `z = 0`, ~`0.95` at `z ≈ 2`, →`1` as `z → ∞`.
+  /// Used to normalise detector strengths into the ranker's `surprise`.
+  static func surprise(fromZScore statistic: Double) -> Double {
+    min(max(2 * cdf(abs(statistic)) - 1, 0), 1)
+  }
+}

--- a/Domain/Insights/Statistics/SeasonalDecomposition.swift
+++ b/Domain/Insights/Statistics/SeasonalDecomposition.swift
@@ -34,7 +34,8 @@ enum SeasonalDecomposition {
     let trend = movingAverageTrend(values, window: max(period, 2))
 
     let useSeasonal = period > 1 && count >= 2 * period
-    let seasonal = useSeasonal
+    let seasonal =
+      useSeasonal
       ? seasonalComponent(values, trend: trend, period: period)
       : [Double](repeating: 0, count: count)
 

--- a/Domain/Insights/Statistics/SeasonalDecomposition.swift
+++ b/Domain/Insights/Statistics/SeasonalDecomposition.swift
@@ -1,0 +1,90 @@
+import Foundation
+
+/// Additive decomposition of an evenly-spaced series into trend, seasonal,
+/// and remainder components: `y = trend + seasonal + remainder`.
+struct SeriesDecomposition: Sendable {
+  let trend: [Double]
+  let seasonal: [Double]
+  let remainder: [Double]
+}
+
+/// A pragmatic, dependency-free stand-in for STL (design §B-6). Full STL is
+/// overkill and numerically unstable for the handful-to-a-few-dozen monthly
+/// points a personal-finance series carries. This computes:
+///
+/// - **trend** — a centred moving average (window = seasonal `period`, edges
+///   clipped to the available span);
+/// - **seasonal** — mean-centred per-phase means of the detrended series,
+///   but only when there are at least two full cycles; otherwise zero;
+/// - **remainder** — what's left, which the anomaly detector scores with a
+///   robust z.
+///
+/// Documented as a deliberate simplification so a future swap to a real STL
+/// implementation is a drop-in for `decompose`.
+enum SeasonalDecomposition {
+  /// Decompose `values` (time order) with the given seasonal `period`
+  /// (e.g. 12 for month-of-year on a monthly series). A `period` ≤ 1 or a
+  /// series shorter than `2·period` skips the seasonal step.
+  static func decompose(_ values: [Double], period: Int) -> SeriesDecomposition {
+    let count = values.count
+    guard count > 0 else {
+      return SeriesDecomposition(trend: [], seasonal: [], remainder: [])
+    }
+
+    let trend = movingAverageTrend(values, window: max(period, 2))
+
+    let useSeasonal = period > 1 && count >= 2 * period
+    let seasonal = useSeasonal
+      ? seasonalComponent(values, trend: trend, period: period)
+      : [Double](repeating: 0, count: count)
+
+    var remainder = [Double](repeating: 0, count: count)
+    for index in 0..<count {
+      remainder[index] = values[index] - trend[index] - seasonal[index]
+    }
+    return SeriesDecomposition(trend: trend, seasonal: seasonal, remainder: remainder)
+  }
+
+  /// Centred moving average. At the edges the window is clipped to whatever
+  /// neighbours exist, so every index gets a defined trend value.
+  private static func movingAverageTrend(_ values: [Double], window: Int) -> [Double] {
+    let count = values.count
+    let half = window / 2
+    var trend = [Double](repeating: 0, count: count)
+    for index in 0..<count {
+      let lower = max(0, index - half)
+      let upper = min(count - 1, index + half)
+      var sum = 0.0
+      for position in lower...upper {
+        sum += values[position]
+      }
+      trend[index] = sum / Double(upper - lower + 1)
+    }
+    return trend
+  }
+
+  /// Mean-centred per-phase seasonal indices, expanded back to a full
+  /// series. Phase = `index % period`.
+  private static func seasonalComponent(
+    _ values: [Double], trend: [Double], period: Int
+  ) -> [Double] {
+    let count = values.count
+    var phaseSums = [Double](repeating: 0, count: period)
+    var phaseCounts = [Int](repeating: 0, count: period)
+    for index in 0..<count {
+      let phase = index % period
+      phaseSums[phase] += values[index] - trend[index]
+      phaseCounts[phase] += 1
+    }
+    var phaseMeans = [Double](repeating: 0, count: period)
+    for phase in 0..<period where phaseCounts[phase] > 0 {
+      phaseMeans[phase] = phaseSums[phase] / Double(phaseCounts[phase])
+    }
+    let overall = DescriptiveStatistics.mean(phaseMeans)
+    var seasonal = [Double](repeating: 0, count: count)
+    for index in 0..<count {
+      seasonal[index] = phaseMeans[index % period] - overall
+    }
+    return seasonal
+  }
+}

--- a/Domain/Insights/Subscriptions/DetectedSubscription.swift
+++ b/Domain/Insights/Subscriptions/DetectedSubscription.swift
@@ -1,0 +1,102 @@
+import Foundation
+
+/// A recurring cadence a subscription stream can settle into. Nominal day
+/// counts match the design's target set `{7, 14, 30, 90, 365}`.
+enum SubscriptionPeriod: String, Sendable, Hashable, CaseIterable {
+  case weekly
+  case fortnightly
+  case monthly
+  case quarterly
+  case annual
+
+  /// Nominal inter-arrival gap in days.
+  var nominalDays: Double {
+    switch self {
+    case .weekly: return 7
+    case .fortnightly: return 14
+    case .monthly: return 30
+    case .quarterly: return 91
+    case .annual: return 365
+    }
+  }
+
+  /// How many of this period fit in a calendar month — the multiplier that
+  /// normalises a per-occurrence price to a monthly cost.
+  var occurrencesPerMonth: Decimal {
+    switch self {
+    case .weekly: return Decimal(52) / Decimal(12)
+    case .fortnightly: return Decimal(26) / Decimal(12)
+    case .monthly: return 1
+    case .quarterly: return Decimal(1) / Decimal(3)
+    case .annual: return Decimal(1) / Decimal(12)
+    }
+  }
+
+  var displayName: String {
+    switch self {
+    case .weekly: return "weekly"
+    case .fortnightly: return "fortnightly"
+    case .monthly: return "monthly"
+    case .quarterly: return "quarterly"
+    case .annual: return "annual"
+    }
+  }
+
+  /// The period whose nominal gap is closest to `intervalDays`, accepted
+  /// only when the relative error is within `tolerance` (default 25%).
+  /// `nil` when the cadence doesn't resemble any subscription rhythm.
+  static func nearest(toIntervalDays intervalDays: Double, tolerance: Double = 0.25)
+    -> SubscriptionPeriod?
+  {
+    var best: SubscriptionPeriod?
+    var bestError = Double.greatestFiniteMagnitude
+    for period in allCases {
+      let error = abs(intervalDays - period.nominalDays) / period.nominalDays
+      if error < bestError {
+        bestError = error
+        best = period
+      }
+    }
+    return bestError <= tolerance ? best : nil
+  }
+}
+
+/// One detected recurring payment (or income) stream. The output of
+/// `SubscriptionDetector` and the input to the subscription, paycheck, and
+/// overspend insight detectors.
+///
+/// `medianAmount` / `latestAmount` are signed in the reporting currency —
+/// negative for an expense stream, positive for income — preserving the
+/// project's sign convention.
+struct DetectedSubscription: Sendable, Identifiable, Hashable {
+  let id: String
+  let normalizedPayee: String
+  let displayPayee: String
+  let categoryId: UUID?
+  let accountId: UUID?
+  let period: SubscriptionPeriod
+  let occurrenceCount: Int
+  let firstDate: Date
+  let lastDate: Date
+  /// Date the stream reached its third occurrence — when it became a
+  /// "confirmed" subscription. Drives the new-recurring insight.
+  let maturedDate: Date
+  let medianIntervalDays: Double
+  let medianAmount: Decimal
+  let latestAmount: Decimal
+  /// Chronological signed amounts, for price-hike comparison and narration.
+  let amounts: [Decimal]
+  let isIncome: Bool
+
+  /// Monthly-equivalent magnitude (always positive), for cost roll-ups.
+  var monthlyCostMagnitude: Decimal {
+    let magnitude = medianAmount < 0 ? -medianAmount : medianAmount
+    return magnitude * period.occurrencesPerMonth
+  }
+
+  /// Projected next occurrence date, `lastDate + median interval`.
+  func nextExpectedDate(calendar: Calendar) -> Date? {
+    calendar.date(
+      byAdding: .day, value: Int(medianIntervalDays.rounded()), to: lastDate)
+  }
+}

--- a/Domain/Insights/Subscriptions/SubscriptionDetector.swift
+++ b/Domain/Insights/Subscriptions/SubscriptionDetector.swift
@@ -22,8 +22,6 @@ enum SubscriptionDetector {
     /// Maximum coefficient of variation of the inter-arrival gaps. Rejects
     /// streams whose timing is too erratic to be a subscription.
     var maximumIntervalVariation: Double = 0.35
-
-    init() {}
   }
 
   /// Detect subscription streams among `transactions`. Pass `incomeStreams:
@@ -44,8 +42,11 @@ enum SubscriptionDetector {
     for (payee, records) in groups where !payee.isEmpty {
       guard
         let subscription = evaluate(
-          payee: payee, records: records, incomeStreams: incomeStreams,
-          parameters: parameters, calendar: calendar)
+          payee: payee,
+          records: records,
+          incomeStreams: incomeStreams,
+          parameters: parameters,
+          calendar: calendar)
       else { continue }
       detected.append(subscription)
     }

--- a/Domain/Insights/Subscriptions/SubscriptionDetector.swift
+++ b/Domain/Insights/Subscriptions/SubscriptionDetector.swift
@@ -1,0 +1,139 @@
+import Foundation
+
+/// Clusters transactions into recurring payment / income streams (design
+/// §A-1). Pure and deterministic: groups by normalised payee + direction,
+/// then within each group inspects the inter-arrival gaps and the amount
+/// stability to decide whether the stream is a subscription.
+///
+/// References: Plaid's recurring-stream approach and BBVA's weighted
+/// DBSCAN, simplified to a histogram-free median-gap test that's adequate
+/// for a single user's sparse history (design §A-1).
+enum SubscriptionDetector {
+  /// Tuning knobs, exposed so tests can tighten / loosen the gates without
+  /// editing the detector.
+  struct Parameters: Sendable {
+    /// Minimum occurrences before a stream is "confirmed".
+    var minimumOccurrences: Int = 3
+    /// Maximum coefficient of variation of the amount magnitudes. The
+    /// design cites 5–10%; 12% absorbs small FX / rounding wobble.
+    var maximumAmountVariation: Double = 0.12
+    /// Relative tolerance when snapping the median gap to a nominal period.
+    var periodTolerance: Double = 0.25
+    /// Maximum coefficient of variation of the inter-arrival gaps. Rejects
+    /// streams whose timing is too erratic to be a subscription.
+    var maximumIntervalVariation: Double = 0.35
+
+    init() {}
+  }
+
+  /// Detect subscription streams among `transactions`. Pass `incomeStreams:
+  /// true` to detect recurring income (paychecks) instead of expenses —
+  /// the same algorithm runs over the opposite sign.
+  static func detect(
+    in transactions: [InsightTransaction],
+    incomeStreams: Bool = false,
+    parameters: Parameters = Parameters(),
+    calendar: Calendar
+  ) -> [DetectedSubscription] {
+    let relevant = transactions.filter {
+      incomeStreams ? $0.isIncome : $0.isExpense
+    }
+    let groups = Dictionary(grouping: relevant) { $0.normalizedPayee }
+
+    var detected: [DetectedSubscription] = []
+    for (payee, records) in groups where !payee.isEmpty {
+      guard
+        let subscription = evaluate(
+          payee: payee, records: records, incomeStreams: incomeStreams,
+          parameters: parameters, calendar: calendar)
+      else { continue }
+      detected.append(subscription)
+    }
+    return detected.sorted { $0.monthlyCostMagnitude > $1.monthlyCostMagnitude }
+  }
+
+  /// Evaluate one payee's records against the cadence + amount gates.
+  private static func evaluate(
+    payee: String,
+    records: [InsightTransaction],
+    incomeStreams: Bool,
+    parameters: Parameters,
+    calendar: Calendar
+  ) -> DetectedSubscription? {
+    let sorted = records.sorted { $0.date < $1.date }
+    guard sorted.count >= parameters.minimumOccurrences else { return nil }
+
+    let intervals = consecutiveDayGaps(of: sorted.map(\.date), calendar: calendar)
+    guard !intervals.isEmpty else { return nil }
+    let medianInterval = DescriptiveStatistics.median(intervals)
+    guard medianInterval > 0 else { return nil }
+
+    if let intervalCV = DescriptiveStatistics.coefficientOfVariation(intervals),
+      intervalCV > parameters.maximumIntervalVariation
+    {
+      return nil
+    }
+
+    guard
+      let period = SubscriptionPeriod.nearest(
+        toIntervalDays: medianInterval, tolerance: parameters.periodTolerance)
+    else { return nil }
+
+    let amounts = sorted.map(\.amount)
+    let magnitudes = amounts.map { Double(truncating: ($0 < 0 ? -$0 : $0) as NSDecimalNumber) }
+    if let amountCV = DescriptiveStatistics.coefficientOfVariation(magnitudes),
+      amountCV > parameters.maximumAmountVariation
+    {
+      return nil
+    }
+
+    let medianMagnitude = DescriptiveStatistics.median(magnitudes)
+    let medianAmount = Decimal(medianMagnitude * (incomeStreams ? 1.0 : -1.0))
+    let maturedIndex = parameters.minimumOccurrences - 1
+    let dominantAccount = mostCommonAccount(in: sorted)
+
+    return DetectedSubscription(
+      id: "\(incomeStreams ? "income" : "expense"):\(payee)",
+      normalizedPayee: payee,
+      displayPayee: sorted.last?.rawPayee ?? payee,
+      categoryId: mostCommonCategory(in: sorted),
+      accountId: dominantAccount,
+      period: period,
+      occurrenceCount: sorted.count,
+      firstDate: sorted.first?.date ?? sorted[0].date,
+      lastDate: sorted.last?.date ?? sorted[0].date,
+      maturedDate: sorted[min(maturedIndex, sorted.count - 1)].date,
+      medianIntervalDays: medianInterval,
+      medianAmount: medianAmount,
+      latestAmount: amounts.last ?? medianAmount,
+      amounts: amounts,
+      isIncome: incomeStreams)
+  }
+
+  private static func consecutiveDayGaps(of dates: [Date], calendar: Calendar) -> [Double] {
+    guard dates.count > 1 else { return [] }
+    var gaps: [Double] = []
+    gaps.reserveCapacity(dates.count - 1)
+    for index in 1..<dates.count {
+      let days = calendar.dateComponents([.day], from: dates[index - 1], to: dates[index]).day ?? 0
+      gaps.append(Double(days))
+    }
+    return gaps
+  }
+
+  private static func mostCommonCategory(in records: [InsightTransaction]) -> UUID? {
+    let categorized = records.compactMap(\.categoryId)
+    guard !categorized.isEmpty else { return nil }
+    return Dictionary(grouping: categorized, by: { $0 })
+      .max { $0.value.count < $1.value.count }?
+      .key
+  }
+
+  private static func mostCommonAccount(in records: [InsightTransaction]) -> UUID? {
+    let accounts = records.compactMap(\.accountId)
+    guard !accounts.isEmpty else { return nil }
+    return Dictionary(grouping: accounts, by: { $0 })
+      .max { $0.value.count < $1.value.count }?
+      .key
+  }
+}

--- a/MoolahTests/Domain/Insights/AdditionalInsightTests.swift
+++ b/MoolahTests/Domain/Insights/AdditionalInsightTests.swift
@@ -1,0 +1,156 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("Additional insights (follow-up ideas)")
+struct AdditionalInsightTests {
+  private let context = InsightTestSupport.context()
+  private let calendar = InsightTestSupport.calendar
+
+  // MARK: - Data quality
+
+  @Test
+  func uncategorizedBacklogNudge() throws {
+    let input = InsightInput(context: context, uncategorizedTransactionCount: 30)
+    let insights = DataQualityInsights.uncategorizedBacklog(input)
+    let nudge = try #require(insights.first)
+    #expect(nudge.kind == .uncategorizedBacklog)
+    #expect(nudge.title.contains("30"))
+  }
+
+  @Test
+  func uncategorizedBacklogQuietBelowThreshold() {
+    let input = InsightInput(context: context, uncategorizedTransactionCount: 3)
+    #expect(DataQualityInsights.uncategorizedBacklog(input).isEmpty)
+  }
+
+  @Test
+  func unreconciledTransfersBacklog() throws {
+    let input = InsightInput(
+      context: context, pendingTransferCount: 5,
+      oldestPendingTransferDate: InsightTestSupport.daysAgo(20))
+    let insight = try #require(DataQualityInsights.unreconciledTransfers(input).first)
+    #expect(insight.kind == .unreconciledTransfers)
+    #expect(insight.actionability == .act)
+  }
+
+  // MARK: - Account groups
+
+  @Test
+  func groupSpendConcentration() throws {
+    let accountA = UUID()
+    let accountB = UUID()
+    let groupA = InsightAccountGroup(id: UUID(), name: "Daily Spending")
+    let groupB = InsightAccountGroup(id: UUID(), name: "Bills")
+    var transactions: [InsightTransaction] = []
+    for index in 0..<8 {
+      transactions.append(
+        InsightTestSupport.expense(100, payee: "Shop", daysAgo: index + 1, accountId: accountA))
+    }
+    transactions.append(
+      InsightTestSupport.expense(50, payee: "Utility", daysAgo: 2, accountId: accountB))
+    let input = InsightInput(
+      context: context,
+      transactions: transactions,
+      accountGroups: [groupA, groupB],
+      accountGroupMembership: [accountA: groupA.id, accountB: groupB.id])
+    let insight = try #require(AccountGroupInsights.groupSpendConcentration(input).first)
+    #expect(insight.kind == .groupSpendConcentration)
+    #expect(insight.references.groupIds == [groupA.id])
+  }
+
+  // MARK: - Income extensions
+
+  @Test
+  func windfallFlagsLargeDeposit() throws {
+    // Slightly varying paychecks (realistic) so the MAD is non-zero.
+    let payAmounts: [Decimal] = [3000, 3050, 2980, 3020, 3000, 2990, 3010, 3030]
+    var transactions: [InsightTransaction] = []
+    for (index, amount) in payAmounts.enumerated() {
+      transactions.append(
+        InsightTestSupport.income(amount, payee: "Payroll", daysAgo: index * 14 + 40))
+    }
+    transactions.append(InsightTestSupport.income(12000, payee: "Bonus", daysAgo: 3))
+    let insight = try #require(
+      IncomeExtraInsights.windfall(transactions: transactions, context: context).first)
+    #expect(insight.kind == .windfallIncome)
+    #expect(insight.framing == .positive)
+  }
+
+  @Test
+  func payRiseDetected() throws {
+    let transactions = [
+      InsightTestSupport.income(3000, payee: "ACME", daysAgo: 42),
+      InsightTestSupport.income(3000, payee: "ACME", daysAgo: 28),
+      InsightTestSupport.income(3000, payee: "ACME", daysAgo: 14),
+      InsightTestSupport.income(3300, payee: "ACME", daysAgo: 0),
+    ]
+    let streams = SubscriptionDetector.detect(
+      in: transactions, incomeStreams: true, calendar: calendar)
+    let insight = try #require(
+      IncomeExtraInsights.payRateChange(incomeStreams: streams, context: context).first)
+    #expect(insight.kind == .payRateChange)
+    #expect(insight.framing == .positive)
+  }
+
+  // MARK: - Spend habits
+
+  @Test
+  func lapsedMerchantSurfacesStoppedRegular() throws {
+    var transactions: [InsightTransaction] = []
+    // Five monthly charges, the most recent 130 days ago (lapsed).
+    for index in 0..<5 {
+      transactions.append(
+        InsightTestSupport.expense(40, payee: "OldGym", daysAgo: 130 + index * 30))
+    }
+    let insight = try #require(
+      SpendHabitInsights.lapsedMerchant(transactions: transactions, context: context).first)
+    #expect(insight.kind == .lapsedMerchant)
+  }
+
+  @Test
+  func weekendSkewDetected() throws {
+    var transactions: [InsightTransaction] = []
+    for daysAgo in 1...42 {
+      let date = InsightTestSupport.daysAgo(daysAgo)
+      let weekday = calendar.component(.weekday, from: date)
+      let magnitude: Decimal = (weekday == 1 || weekday == 7) ? 120 : 20
+      transactions.append(
+        InsightTestSupport.expense(magnitude, payee: "Spend", daysAgo: daysAgo))
+    }
+    let insight = try #require(
+      SpendHabitInsights.weekendSkew(transactions: transactions, context: context).first)
+    #expect(insight.kind == .weekendSpendSkew)
+  }
+
+  // MARK: - Budget coverage
+
+  @Test
+  func unbudgetedCategorySpotlight() throws {
+    let budgeted = UUID()
+    let unbudgeted = UUID()
+    var transactions: [InsightTransaction] = []
+    transactions.append(
+      InsightTestSupport.expense(50, payee: "A", daysAgo: 5, categoryId: budgeted))
+    for index in 0..<5 {
+      transactions.append(
+        InsightTestSupport.expense(200, payee: "B", daysAgo: index + 1, categoryId: unbudgeted))
+    }
+    let input = InsightInput(
+      context: context, transactions: transactions, budgetedCategoryIds: [budgeted])
+    let insight = try #require(BudgetCoverageInsights.unbudgetedCategory(input).first)
+    #expect(insight.kind == .unbudgetedCategory)
+    #expect(insight.references.categoryIds == [unbudgeted])
+  }
+
+  @Test
+  func unbudgetedCategoryQuietWithoutBudgets() {
+    let category = UUID()
+    let transactions = [
+      InsightTestSupport.expense(200, payee: "B", daysAgo: 1, categoryId: category)
+    ]
+    let input = InsightInput(context: context, transactions: transactions)
+    #expect(BudgetCoverageInsights.unbudgetedCategory(input).isEmpty)
+  }
+}

--- a/MoolahTests/Domain/Insights/FinanceInsightTests.swift
+++ b/MoolahTests/Domain/Insights/FinanceInsightTests.swift
@@ -105,7 +105,9 @@ struct FinanceInsightTests {
 
   @Test
   func idleCashAlert() throws {
-    let balances = [DailyBalance(date: InsightTestSupport.now, balance: InsightTestSupport.amount(20000))]
+    let balances = [
+      DailyBalance(date: InsightTestSupport.now, balance: InsightTestSupport.amount(20000))
+    ]
     let monthly = ["202603", "202604", "202605"].map {
       InsightTestSupport.monthly(month: $0, income: 4000, expense: 2000)
     }
@@ -118,7 +120,9 @@ struct FinanceInsightTests {
 
   @Test
   func runwayWarnsWhenBurning() throws {
-    let balances = [DailyBalance(date: InsightTestSupport.now, balance: InsightTestSupport.amount(10000))]
+    let balances = [
+      DailyBalance(date: InsightTestSupport.now, balance: InsightTestSupport.amount(10000))
+    ]
     let monthly = ["202603", "202604", "202605"].map {
       InsightTestSupport.monthly(month: $0, income: 1000, expense: 3000)
     }
@@ -132,7 +136,8 @@ struct FinanceInsightTests {
   func feeSpendSumsAnnualFees() throws {
     let transactions = [
       InsightTestSupport.expense(35, payee: "Bank", daysAgo: 10, categoryPath: "Banking:Fees"),
-      InsightTestSupport.expense(15, payee: "Bank", daysAgo: 100, categoryPath: "Banking:Account Fee"),
+      InsightTestSupport.expense(
+        15, payee: "Bank", daysAgo: 100, categoryPath: "Banking:Account Fee"),
       InsightTestSupport.expense(200, payee: "Rent", daysAgo: 5, categoryPath: "Housing:Rent"),
     ]
     let insights = SavingsOpportunityInsights.feeSpend(transactions: transactions, context: context)

--- a/MoolahTests/Domain/Insights/FinanceInsightTests.swift
+++ b/MoolahTests/Domain/Insights/FinanceInsightTests.swift
@@ -1,0 +1,142 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("Budget, cash-flow & investment insights")
+struct FinanceInsightTests {
+  private let context = InsightTestSupport.context()
+
+  private func profitLoss(
+    _ name: String, invested: Decimal, value: Decimal, unrealized: Decimal
+  ) -> InstrumentProfitLoss {
+    InstrumentProfitLoss(
+      instrument: Instrument.stock(ticker: name, exchange: "NASDAQ", name: name),
+      currentQuantity: 1, totalInvested: invested, currentValue: value,
+      realizedGain: 0, unrealizedGain: unrealized)
+  }
+
+  // MARK: - Earmarks
+
+  @Test
+  func earmarkOverspendProjection() throws {
+    let earmark = EarmarkSnapshot(
+      id: UUID(), name: "Groceries", balance: InsightTestSupport.amount(20),
+      spent: InsightTestSupport.amount(80), budget: InsightTestSupport.amount(100),
+      savingsStartDate: InsightTestSupport.daysAgo(15),
+      savingsEndDate: InsightTestSupport.daysAgo(-15))
+    let insights = EarmarkBudgetInsights.detect(earmarks: [earmark], context: context)
+    let overspend = try #require(insights.first { $0.kind == .earmarkBurndownProjection })
+    #expect(overspend.actionability == .act)
+  }
+
+  @Test
+  func earmarkUnderspendIsPositive() throws {
+    let earmark = EarmarkSnapshot(
+      id: UUID(), name: "Dining", balance: InsightTestSupport.amount(80),
+      spent: InsightTestSupport.amount(20), budget: InsightTestSupport.amount(100),
+      savingsStartDate: InsightTestSupport.daysAgo(60),
+      savingsEndDate: InsightTestSupport.daysAgo(-30))
+    let insights = EarmarkBudgetInsights.detect(earmarks: [earmark], context: context)
+    let underspend = try #require(insights.first { $0.kind == .earmarkUnderspend })
+    #expect(underspend.framing == .positive)
+  }
+
+  @Test
+  func savingsGoalProjectsCompletion() throws {
+    let earmark = EarmarkSnapshot(
+      id: UUID(), name: "Holiday", balance: InsightTestSupport.amount(250),
+      savingsGoal: InsightTestSupport.amount(1000), saved: InsightTestSupport.amount(250),
+      savingsStartDate: InsightTestSupport.daysAgo(100))
+    let insights = SavingsGoalInsight.detect(earmarks: [earmark], context: context)
+    let eta = try #require(insights.first { $0.kind == .savingsGoalETA })
+    #expect(eta.framing == .positive)
+  }
+
+  @Test
+  func savingsGoalReached() throws {
+    let earmark = EarmarkSnapshot(
+      id: UUID(), name: "Emergency", balance: InsightTestSupport.amount(1000),
+      savingsGoal: InsightTestSupport.amount(1000), saved: InsightTestSupport.amount(1000))
+    let insights = SavingsGoalInsight.detect(earmarks: [earmark], context: context)
+    let reached = try #require(insights.first)
+    #expect(reached.framing == .positive)
+    #expect(reached.title.contains("reached"))
+  }
+
+  // MARK: - Net worth & investments
+
+  @Test
+  func netWorthMilestoneCrossing() throws {
+    let balances = [
+      DailyBalance(date: InsightTestSupport.daysAgo(40), balance: InsightTestSupport.amount(9500)),
+      DailyBalance(date: InsightTestSupport.daysAgo(0), balance: InsightTestSupport.amount(10500)),
+    ]
+    let insights = NetWorthInsights.detect(dailyBalances: balances, context: context)
+    let milestone = try #require(insights.first)
+    #expect(milestone.kind == .netWorthMilestone)
+    #expect(milestone.framing == .positive)
+  }
+
+  @Test
+  func concentrationRiskFlagsDominantHolding() throws {
+    let positions = [
+      profitLoss("AAA", invested: 8000, value: 8000, unrealized: 0),
+      profitLoss("BBB", invested: 2000, value: 2000, unrealized: 0),
+    ]
+    let insights = InvestmentInsights.detect(
+      profitLoss: positions, capitalGains: [], context: context)
+    #expect(insights.contains { $0.kind == .investmentConcentrationRisk })
+  }
+
+  @Test
+  func topAndBottomPerformers() {
+    let positions = [
+      profitLoss("WIN", invested: 1000, value: 1300, unrealized: 300),
+      profitLoss("LOSE", invested: 1000, value: 800, unrealized: -200),
+    ]
+    let insights = InvestmentInsights.detect(
+      profitLoss: positions, capitalGains: [], context: context)
+    #expect(insights.contains { $0.kind == .topPerformer })
+    #expect(insights.contains { $0.kind == .bottomPerformer })
+  }
+
+  // MARK: - Liquidity
+
+  @Test
+  func idleCashAlert() throws {
+    let balances = [DailyBalance(date: InsightTestSupport.now, balance: InsightTestSupport.amount(20000))]
+    let monthly = ["202603", "202604", "202605"].map {
+      InsightTestSupport.monthly(month: $0, income: 4000, expense: 2000)
+    }
+    let insights = LiquidityInsights.idleCash(
+      dailyBalances: balances, monthly: monthly, context: context)
+    let idle = try #require(insights.first)
+    #expect(idle.kind == .idleCashAlert)
+    #expect(idle.actionability == .act)
+  }
+
+  @Test
+  func runwayWarnsWhenBurning() throws {
+    let balances = [DailyBalance(date: InsightTestSupport.now, balance: InsightTestSupport.amount(10000))]
+    let monthly = ["202603", "202604", "202605"].map {
+      InsightTestSupport.monthly(month: $0, income: 1000, expense: 3000)
+    }
+    let insights = LiquidityInsights.runway(
+      dailyBalances: balances, monthly: monthly, context: context)
+    let runway = try #require(insights.first)
+    #expect(runway.kind == .runwayEstimate)
+  }
+
+  @Test
+  func feeSpendSumsAnnualFees() throws {
+    let transactions = [
+      InsightTestSupport.expense(35, payee: "Bank", daysAgo: 10, categoryPath: "Banking:Fees"),
+      InsightTestSupport.expense(15, payee: "Bank", daysAgo: 100, categoryPath: "Banking:Account Fee"),
+      InsightTestSupport.expense(200, payee: "Rent", daysAgo: 5, categoryPath: "Housing:Rent"),
+    ]
+    let insights = SavingsOpportunityInsights.feeSpend(transactions: transactions, context: context)
+    let fees = try #require(insights.first)
+    #expect(fees.kind == .feeSpend)
+  }
+}

--- a/MoolahTests/Domain/Insights/IncomeInsightTests.swift
+++ b/MoolahTests/Domain/Insights/IncomeInsightTests.swift
@@ -1,0 +1,51 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("Income insights")
+struct IncomeInsightTests {
+  private let context = InsightTestSupport.context()
+  private let calendar = InsightTestSupport.calendar
+
+  private func streams(_ transactions: [InsightTransaction]) -> [DetectedSubscription] {
+    SubscriptionDetector.detect(in: transactions, incomeStreams: true, calendar: calendar)
+  }
+
+  @Test
+  func projectsNextPaycheck() throws {
+    let transactions = [
+      InsightTestSupport.income(3000, payee: "ACME Payroll", daysAgo: 28),
+      InsightTestSupport.income(3000, payee: "ACME Payroll", daysAgo: 14),
+      InsightTestSupport.income(3000, payee: "ACME Payroll", daysAgo: 0),
+    ]
+    let insights = IncomeInsights.detect(incomeStreams: streams(transactions), context: context)
+    #expect(insights.contains { $0.kind == .paycheckTimingPattern })
+  }
+
+  @Test
+  func flagsMissingPaycheck() throws {
+    let transactions = [
+      InsightTestSupport.income(3000, payee: "ACME Payroll", daysAgo: 48),
+      InsightTestSupport.income(3000, payee: "ACME Payroll", daysAgo: 34),
+      InsightTestSupport.income(3000, payee: "ACME Payroll", daysAgo: 20),
+    ]
+    let insights = IncomeInsights.detect(incomeStreams: streams(transactions), context: context)
+    let missing = try #require(insights.first { $0.kind == .missingPaycheckAlert })
+    #expect(missing.actionability == .act)
+    // When pay is missing, the forward-looking timing insight is suppressed.
+    #expect(!insights.contains { $0.kind == .paycheckTimingPattern })
+  }
+
+  @Test
+  func reportsStableIncome() throws {
+    let transactions = [
+      InsightTestSupport.income(3000, payee: "ACME Payroll", daysAgo: 28),
+      InsightTestSupport.income(3000, payee: "ACME Payroll", daysAgo: 14),
+      InsightTestSupport.income(3000, payee: "ACME Payroll", daysAgo: 0),
+    ]
+    let insights = IncomeInsights.detect(incomeStreams: streams(transactions), context: context)
+    let stability = try #require(insights.first { $0.kind == .incomeStabilityScore })
+    #expect(stability.framing == .positive)
+  }
+}

--- a/MoolahTests/Domain/Insights/InsightEngineTests.swift
+++ b/MoolahTests/Domain/Insights/InsightEngineTests.swift
@@ -1,0 +1,103 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("InsightEngine")
+struct InsightEngineTests {
+  private let context = InsightTestSupport.context()
+  private let currency = InsightTestSupport.currency
+
+  private func sampleInput() -> InsightInput {
+    var transactions: [InsightTransaction] = []
+    // A monthly subscription with a price hike on the latest charge.
+    let netflixAmounts: [Decimal] = [10, 10, 10, 12]
+    for (index, magnitude) in netflixAmounts.enumerated() {
+      transactions.append(
+        InsightTestSupport.expense(magnitude, payee: "Netflix", daysAgo: (3 - index) * 30))
+    }
+    // Recurring fortnightly income.
+    for index in 0..<4 {
+      transactions.append(
+        InsightTestSupport.income(2500, payee: "ACME Payroll", daysAgo: index * 14))
+    }
+
+    let balances = [
+      DailyBalance(date: InsightTestSupport.daysAgo(40), balance: InsightTestSupport.amount(9400)),
+      DailyBalance(date: InsightTestSupport.now, balance: InsightTestSupport.amount(10200)),
+    ]
+    let underspend = EarmarkSnapshot(
+      id: UUID(), name: "Dining", balance: InsightTestSupport.amount(80),
+      spent: InsightTestSupport.amount(20), budget: InsightTestSupport.amount(100),
+      savingsStartDate: InsightTestSupport.daysAgo(60),
+      savingsEndDate: InsightTestSupport.daysAgo(-30))
+    let monthly = ["202603", "202604", "202605"].map {
+      InsightTestSupport.monthly(month: $0, income: 5000, expense: 3000)
+    }
+
+    return InsightInput(
+      context: context,
+      transactions: transactions,
+      monthly: monthly,
+      dailyBalances: balances,
+      earmarks: [underspend],
+      categories: Categories(from: []))
+  }
+
+  @Test
+  func detectAllProducesMultipleKinds() {
+    let insights = InsightEngine().detectAll(sampleInput())
+    let kinds = Set(insights.map(\.kind))
+    #expect(insights.count >= 3)
+    #expect(kinds.contains(.netWorthMilestone))
+    #expect(kinds.contains(.earmarkUnderspend))
+  }
+
+  @Test
+  func generateRespectsCapAndIncludesPositive() {
+    let ranked = InsightEngine().generate(sampleInput(), displayCap: 5)
+    #expect(ranked.count <= 5)
+    #expect(ranked.contains { $0.insight.framing == .positive })
+  }
+
+  @Test
+  func emptyInputProducesNoInsights() {
+    let input = InsightInput(context: context)
+    #expect(InsightEngine().detectAll(input).isEmpty)
+  }
+
+  @Test
+  func recordsBuilderFlattensExpenseLegs() throws {
+    let dining = Category(name: "Dining")
+    let categories = Categories(from: [dining])
+    let transaction = Transaction(
+      date: InsightTestSupport.now,
+      payee: "Cafe",
+      legs: [
+        TransactionLeg(
+          accountId: UUID(), instrument: currency, quantity: -50, type: .expense,
+          categoryId: dining.id)
+      ])
+    let records = InsightTransaction.sameCurrencyRecords(
+      from: [transaction], categories: categories, reportingCurrency: currency)
+    let record = try #require(records.first)
+    #expect(records.count == 1)
+    #expect(record.amount == -50)
+    #expect(record.categoryPath == "Dining")
+    #expect(record.normalizedPayee == "cafe")
+  }
+
+  @Test
+  func recordsBuilderExcludesTransfers() {
+    let transaction = Transaction(
+      date: InsightTestSupport.now,
+      payee: "Move",
+      legs: [
+        TransactionLeg(accountId: UUID(), instrument: currency, quantity: -100, type: .transfer),
+        TransactionLeg(accountId: UUID(), instrument: currency, quantity: 100, type: .transfer),
+      ])
+    let records = InsightTransaction.sameCurrencyRecords(
+      from: [transaction], categories: Categories(from: []), reportingCurrency: currency)
+    #expect(records.isEmpty)
+  }
+}

--- a/MoolahTests/Domain/Insights/InsightRankerTests.swift
+++ b/MoolahTests/Domain/Insights/InsightRankerTests.swift
@@ -1,0 +1,86 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("InsightRanker")
+struct InsightRankerTests {
+  private let now = InsightTestSupport.now
+
+  private func insight(
+    id: String,
+    kind: InsightKind = .largeTransactionAnomaly,
+    framing: InsightFraming = .negative,
+    actionability: InsightActionability = .review,
+    surprise: Double = 0.5,
+    impact: Decimal? = nil,
+    date: Date? = nil
+  ) -> Insight {
+    Insight(
+      id: id, kind: kind, title: id, detail: id, date: date ?? now, framing: framing,
+      actionability: actionability, surprise: surprise,
+      monetaryImpact: impact.map { InsightTestSupport.amount($0) })
+  }
+
+  @Test
+  func higherSignalRanksFirst() {
+    let strong = insight(id: "strong", surprise: 0.95, impact: 5000)
+    let weak = insight(id: "weak", surprise: 0.1, impact: 5)
+    let ranked = InsightRanker().rank([weak, strong], now: now)
+    #expect(ranked.first?.id == "strong")
+  }
+
+  @Test
+  func fatiguePenaltyLowersScore() {
+    let ranker = InsightRanker()
+    let candidate = insight(id: "x", kind: .newMerchantAlert, surprise: 0.6)
+    let base = ranker.score(candidate, now: now)
+    let fatigued = ranker.score(candidate, now: now, dismissals: [.newMerchantAlert: 2])
+    #expect(fatigued < base)
+  }
+
+  @Test
+  func deduplicatesById() {
+    let ranked = InsightRanker().rank(
+      [insight(id: "dup", surprise: 0.2), insight(id: "dup", surprise: 0.9)],
+      now: now, displayCap: 10)
+    #expect(ranked.count == 1)
+  }
+
+  @Test
+  func respectsDisplayCap() {
+    let candidates = (0..<10).map { insight(id: "i\($0)", surprise: Double($0) / 10) }
+    let ranked = InsightRanker().rank(candidates, now: now, displayCap: 3)
+    #expect(ranked.count == 3)
+  }
+
+  @Test
+  func guaranteesOnePositiveInsight() {
+    var candidates = (0..<5).map {
+      insight(id: "neg\($0)", framing: .negative, surprise: 0.9, impact: 9000)
+    }
+    candidates.append(
+      insight(id: "pos", framing: .positive, surprise: 0.1, impact: 1))
+    let ranked = InsightRanker().rank(
+      candidates, now: now, displayCap: 5, guaranteePositive: true)
+    #expect(ranked.count == 5)
+    #expect(ranked.contains { $0.insight.framing == .positive })
+  }
+
+  @Test
+  func declaredInterestBoostsScore() {
+    let categoryId = UUID()
+    let ranker = InsightRanker()
+    let plain = Insight(
+      id: "plain", kind: .categoryTrendRising, title: "", detail: "", date: now,
+      framing: .neutral, actionability: .review, surprise: 0.5)
+    let pinned = Insight(
+      id: "pinned", kind: .categoryTrendRising, title: "", detail: "", date: now,
+      framing: .neutral, actionability: .review, surprise: 0.5,
+      references: InsightReferences(categoryIds: [categoryId]))
+    let interests = InsightRanker.DeclaredInterests(categoryIds: [categoryId])
+    let plainScore = ranker.score(plain, now: now)
+    let pinnedScore = ranker.score(pinned, now: now, interests: interests)
+    #expect(pinnedScore > plainScore)
+  }
+}

--- a/MoolahTests/Domain/Insights/InsightTestSupport.swift
+++ b/MoolahTests/Domain/Insights/InsightTestSupport.swift
@@ -1,0 +1,104 @@
+import Foundation
+
+@testable import Moolah
+
+/// Shared builders for the insight detector tests. Keeps the suites focused
+/// on behaviour rather than fixture plumbing, and pins every date to the
+/// UTC calendar the detectors use so day/month maths is deterministic.
+enum InsightTestSupport {
+  static let currency = Instrument.fiat(code: "USD")
+  static let calendar = InsightContext.defaultCalendar
+
+  /// A fixed "today" the suites anchor to: 2026-06-15.
+  static let now = date(2026, 6, 15)
+
+  static func context(now: Date = now, monthEnd: Int = 31) -> InsightContext {
+    InsightContext(
+      now: now, reportingCurrency: currency, calendar: calendar, financialMonthEnd: monthEnd)
+  }
+
+  static func date(_ year: Int, _ month: Int, _ day: Int) -> Date {
+    var components = DateComponents()
+    components.year = year
+    components.month = month
+    components.day = day
+    return calendar.date(from: components) ?? Date(timeIntervalSince1970: 0)
+  }
+
+  /// `now` minus `days`.
+  static func daysAgo(_ days: Int, from reference: Date = now) -> Date {
+    calendar.date(byAdding: .day, value: -days, to: reference) ?? reference
+  }
+
+  /// An expense `InsightTransaction`. `amount` is the *positive magnitude*;
+  /// it is stored negative to honour the sign convention.
+  static func expense(
+    _ magnitude: Decimal,
+    payee: String,
+    daysAgo days: Int,
+    categoryId: UUID? = nil,
+    categoryPath: String? = nil,
+    accountId: UUID? = nil,
+    id: UUID = UUID()
+  ) -> InsightTransaction {
+    InsightTransaction(
+      id: id,
+      date: daysAgo(days),
+      rawPayee: payee,
+      normalizedPayee: PayeeNormalizer.normalize(payee),
+      amount: -magnitude,
+      categoryId: categoryId,
+      categoryPath: categoryPath,
+      type: .expense,
+      accountId: accountId)
+  }
+
+  /// An income `InsightTransaction`. `amount` is the positive magnitude.
+  static func income(
+    _ magnitude: Decimal,
+    payee: String,
+    daysAgo days: Int,
+    accountId: UUID? = nil,
+    id: UUID = UUID()
+  ) -> InsightTransaction {
+    InsightTransaction(
+      id: id,
+      date: daysAgo(days),
+      rawPayee: payee,
+      normalizedPayee: PayeeNormalizer.normalize(payee),
+      amount: magnitude,
+      categoryId: nil,
+      categoryPath: nil,
+      type: .income,
+      accountId: accountId)
+  }
+
+  static func amount(_ quantity: Decimal) -> InstrumentAmount {
+    InstrumentAmount(quantity: quantity, instrument: currency)
+  }
+
+  /// A negative (expense-shaped) breakdown row.
+  static func breakdownRow(_ magnitude: Decimal, categoryId: UUID?, month: String) -> ExpenseBreakdown {
+    ExpenseBreakdown(categoryId: categoryId, month: month, totalExpenses: amount(-magnitude))
+  }
+
+  /// A monthly income/expense aggregate. `expense` is the positive
+  /// magnitude; stored negative to match the backend's sign.
+  static func monthly(
+    month: String, income incomeMagnitude: Decimal, expense expenseMagnitude: Decimal
+  ) -> MonthlyIncomeExpense {
+    let income = amount(incomeMagnitude)
+    let expense = amount(-expenseMagnitude)
+    let zero = amount(0)
+    return MonthlyIncomeExpense(
+      month: month,
+      start: CategorySpendSeries.monthDate(month) ?? now,
+      end: CategorySpendSeries.monthDate(month) ?? now,
+      income: income,
+      expense: expense,
+      profit: income + expense,
+      earmarkedIncome: zero,
+      earmarkedExpense: zero,
+      earmarkedProfit: zero)
+  }
+}

--- a/MoolahTests/Domain/Insights/InsightTestSupport.swift
+++ b/MoolahTests/Domain/Insights/InsightTestSupport.swift
@@ -78,7 +78,9 @@ enum InsightTestSupport {
   }
 
   /// A negative (expense-shaped) breakdown row.
-  static func breakdownRow(_ magnitude: Decimal, categoryId: UUID?, month: String) -> ExpenseBreakdown {
+  static func breakdownRow(_ magnitude: Decimal, categoryId: UUID?, month: String)
+    -> ExpenseBreakdown
+  {
     ExpenseBreakdown(categoryId: categoryId, month: month, totalExpenses: amount(-magnitude))
   }
 

--- a/MoolahTests/Domain/Insights/SpendAndTrendInsightTests.swift
+++ b/MoolahTests/Domain/Insights/SpendAndTrendInsightTests.swift
@@ -61,7 +61,8 @@ struct SpendAndTrendInsightTests {
     let dining = Category(name: "Dining")
     let months = ["202509", "202510", "202511", "202512", "202601", "202602", "202603", "202604"]
     let breakdown = months.enumerated().map { index, month in
-      InsightTestSupport.breakdownRow(Decimal(100 + index * 30), categoryId: dining.id, month: month)
+      InsightTestSupport.breakdownRow(
+        Decimal(100 + index * 30), categoryId: dining.id, month: month)
     }
     let insights = CategoryTrendInsight.detect(
       breakdown: breakdown, categories: Categories(from: [dining]), context: context)

--- a/MoolahTests/Domain/Insights/SpendAndTrendInsightTests.swift
+++ b/MoolahTests/Domain/Insights/SpendAndTrendInsightTests.swift
@@ -1,0 +1,107 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("Spend & trend insights")
+struct SpendAndTrendInsightTests {
+  private let context = InsightTestSupport.context()
+  private let emptyCategories = Categories(from: [])
+
+  @Test
+  func largeTransactionAnomalyFlagsOutlier() throws {
+    let dining = UUID()
+    var transactions: [InsightTransaction] = []
+    let normals: [Decimal] = [18, 19, 20, 21, 22, 19, 20, 21, 18]
+    for (index, magnitude) in normals.enumerated() {
+      transactions.append(
+        InsightTestSupport.expense(
+          magnitude, payee: "Cafe", daysAgo: index * 4 + 1, categoryId: dining,
+          categoryPath: "Dining"))
+    }
+    transactions.append(
+      InsightTestSupport.expense(
+        200, payee: "Steakhouse", daysAgo: 2, categoryId: dining, categoryPath: "Dining"))
+
+    let insights = LargeTransactionInsight.detect(
+      transactions: transactions, categories: emptyCategories, context: context)
+    let anomaly = try #require(insights.first { $0.kind == .largeTransactionAnomaly })
+    #expect(anomaly.references.transactionIds.count == 1)
+    #expect(anomaly.surprise > 0.9)
+  }
+
+  @Test
+  func newMerchantAlertFiresForLargeFirstCharge() {
+    var transactions: [InsightTransaction] = []
+    for index in 0..<12 {
+      transactions.append(
+        InsightTestSupport.expense(Decimal(20 + index), payee: "Groceries", daysAgo: 20 + index))
+    }
+    transactions.append(
+      InsightTestSupport.expense(300, payee: "Fancy Restaurant", daysAgo: 2))
+
+    let insights = NewMerchantInsight.detect(transactions: transactions, context: context)
+    #expect(insights.contains { $0.kind == .newMerchantAlert })
+  }
+
+  @Test
+  func newMerchantQuietForKnownPayee() {
+    var transactions: [InsightTransaction] = []
+    for index in 0..<12 {
+      transactions.append(
+        InsightTestSupport.expense(50, payee: "Groceries", daysAgo: 20 + index))
+    }
+    transactions.append(InsightTestSupport.expense(300, payee: "Groceries", daysAgo: 1))
+    let insights = NewMerchantInsight.detect(transactions: transactions, context: context)
+    #expect(insights.isEmpty)
+  }
+
+  @Test
+  func categoryTrendDetectsRisingCategory() throws {
+    let dining = Category(name: "Dining")
+    let months = ["202509", "202510", "202511", "202512", "202601", "202602", "202603", "202604"]
+    let breakdown = months.enumerated().map { index, month in
+      InsightTestSupport.breakdownRow(Decimal(100 + index * 30), categoryId: dining.id, month: month)
+    }
+    let insights = CategoryTrendInsight.detect(
+      breakdown: breakdown, categories: Categories(from: [dining]), context: context)
+    let rising = try #require(insights.first { $0.kind == .categoryTrendRising })
+    #expect(rising.framing == .negative)
+  }
+
+  @Test
+  func monthOverMonthSpendIncrease() throws {
+    let monthly = [
+      InsightTestSupport.monthly(month: "202604", income: 5000, expense: 100),
+      InsightTestSupport.monthly(month: "202605", income: 5000, expense: 130),
+    ]
+    let insights = PeriodComparisonInsights.detect(monthly: monthly, context: context)
+    let delta = try #require(insights.first { $0.kind == .monthOverMonthDelta })
+    #expect(delta.framing == .negative)
+  }
+
+  @Test
+  func monthOverMonthExcludesInProgressMonth() {
+    // Only the current (in-progress) bucket plus one complete month — not
+    // enough complete months to compare.
+    let monthly = [
+      InsightTestSupport.monthly(month: "202605", income: 5000, expense: 100),
+      InsightTestSupport.monthly(month: "202606", income: 5000, expense: 5),
+    ]
+    let insights = PeriodComparisonInsights.detect(monthly: monthly, context: context)
+    #expect(insights.isEmpty)
+  }
+
+  @Test
+  func categoryAnomalyFlagsSpike() throws {
+    let dining = Category(name: "Dining")
+    let magnitudes: [Decimal] = [100, 105, 98, 102, 100, 103, 99, 400]
+    let months = ["202511", "202512", "202601", "202602", "202603", "202604", "202605", "202606"]
+    let breakdown = zip(months, magnitudes).map { month, magnitude in
+      InsightTestSupport.breakdownRow(magnitude, categoryId: dining.id, month: month)
+    }
+    let insights = CategoryAnomalyInsight.detect(
+      breakdown: breakdown, categories: Categories(from: [dining]), context: context)
+    #expect(insights.contains { $0.kind == .categorySpendingAnomaly })
+  }
+}

--- a/MoolahTests/Domain/Insights/StatisticsTests.swift
+++ b/MoolahTests/Domain/Insights/StatisticsTests.swift
@@ -1,0 +1,124 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("Insight statistics")
+struct StatisticsTests {
+  @Test
+  func medianHandlesOddAndEven() {
+    #expect(DescriptiveStatistics.median([3, 1, 2]) == 2)
+    #expect(DescriptiveStatistics.median([4, 1, 2, 3]) == 2.5)
+    #expect(DescriptiveStatistics.median([]) == 0)
+  }
+
+  @Test
+  func robustZScoreFlagsOutlierAndPreservesSign() {
+    let population = [10.0, 11, 9, 10, 12, 8, 10, 11]
+    let high = DescriptiveStatistics.robustZScore(of: 40, in: population)
+    let low = DescriptiveStatistics.robustZScore(of: -20, in: population)
+    #expect(high > 3.5)
+    #expect(low < -3.5)
+  }
+
+  @Test
+  func robustZScoreFallsBackToStdDevWhenMadZero() {
+    // >50% identical → MAD is zero; falls back to classic z-score.
+    let population = [5.0, 5, 5, 5, 5, 100]
+    let score = DescriptiveStatistics.robustZScore(of: 100, in: population)
+    #expect(score > 0)
+  }
+
+  @Test
+  func percentileInterpolates() {
+    let values = [0.0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100]
+    #expect(DescriptiveStatistics.percentile(values, 0.9) >= 89)
+    #expect(DescriptiveStatistics.percentile(values, 0) == 0)
+    #expect(DescriptiveStatistics.percentile(values, 1) == 100)
+  }
+
+  @Test
+  func coefficientOfVariation() {
+    #expect(DescriptiveStatistics.coefficientOfVariation([10, 10, 10]) == 0)
+    #expect(DescriptiveStatistics.coefficientOfVariation([0, 0, 0]) == nil)
+    let cv = DescriptiveStatistics.coefficientOfVariation([8, 12, 10, 9, 11])
+    #expect((cv ?? 0) > 0)
+  }
+
+  @Test
+  func mannKendallDetectsIncreasingTrend() throws {
+    let rising = [1.0, 2, 3, 4, 5, 6, 7, 8]
+    let result = try #require(MannKendall.test(rising))
+    #expect(result.isIncreasing)
+    #expect(result.sensSlope == 1)
+    #expect(result.pValue < 0.05)
+  }
+
+  @Test
+  func mannKendallDetectsDecreasingTrend() throws {
+    let falling = [9.0, 7, 6, 5, 4, 2, 1]
+    let result = try #require(MannKendall.test(falling))
+    #expect(result.isDecreasing)
+    #expect(result.sensSlope < 0)
+  }
+
+  @Test
+  func mannKendallFlatSeriesIsNotSignificant() throws {
+    let flat = [5.0, 5, 5, 5, 5, 5]
+    let result = try #require(MannKendall.test(flat))
+    #expect(result.statistic == 0)
+    #expect(result.pValue >= 0.99)
+  }
+
+  @Test
+  func mannKendallRejectsTooFewPoints() {
+    #expect(MannKendall.test([1, 2, 3]) == nil)
+  }
+
+  @Test
+  func benjaminiHochbergControlsDiscoveries() {
+    let hypotheses = [
+      PValue(tag: "a", pValue: 0.001),
+      PValue(tag: "b", pValue: 0.008),
+      PValue(tag: "c", pValue: 0.04),
+      PValue(tag: "d", pValue: 0.6),
+      PValue(tag: "e", pValue: 0.9),
+    ]
+    let significant = BenjaminiHochberg.significant(hypotheses, fdr: 0.05)
+    let tags = Set(significant.map(\.tag))
+    #expect(tags.contains("a"))
+    #expect(!tags.contains("d"))
+    #expect(!tags.contains("e"))
+  }
+
+  @Test
+  func benjaminiHochbergEmptyInput() {
+    #expect(BenjaminiHochberg.significant([PValue<String>]()).isEmpty)
+  }
+
+  @Test
+  func normalSurpriseMonotonic() {
+    #expect(NormalDistribution.surprise(fromZScore: 0) < 0.1)
+    #expect(NormalDistribution.surprise(fromZScore: 2) > 0.9)
+    #expect(NormalDistribution.surprise(fromZScore: 5) <= 1)
+  }
+
+  @Test
+  func seasonalDecompositionRecoversConstantPlusSeason() {
+    // Two years of a clean period-4 seasonal pattern on a flat trend.
+    let pattern = [10.0, 20, 30, 20]
+    let series = pattern + pattern
+    let decomposition = SeasonalDecomposition.decompose(series, period: 4)
+    #expect(decomposition.remainder.count == series.count)
+    // Remainder should be small relative to the seasonal swing.
+    let maxRemainder = decomposition.remainder.map(abs).max() ?? 0
+    #expect(maxRemainder < 5)
+  }
+
+  @Test
+  func seasonalDecompositionSkipsSeasonalForShortSeries() {
+    let series = [1.0, 2, 3]
+    let decomposition = SeasonalDecomposition.decompose(series, period: 12)
+    #expect(decomposition.seasonal.allSatisfy { $0 == 0 })
+  }
+}

--- a/MoolahTests/Domain/Insights/StatisticsTests.swift
+++ b/MoolahTests/Domain/Insights/StatisticsTests.swift
@@ -41,8 +41,8 @@ struct StatisticsTests {
   func coefficientOfVariation() {
     #expect(DescriptiveStatistics.coefficientOfVariation([10, 10, 10]) == 0)
     #expect(DescriptiveStatistics.coefficientOfVariation([0, 0, 0]) == nil)
-    let cv = DescriptiveStatistics.coefficientOfVariation([8, 12, 10, 9, 11])
-    #expect((cv ?? 0) > 0)
+    let variation = DescriptiveStatistics.coefficientOfVariation([8, 12, 10, 9, 11])
+    #expect((variation ?? 0) > 0)
   }
 
   @Test

--- a/MoolahTests/Domain/Insights/SubscriptionDetectorTests.swift
+++ b/MoolahTests/Domain/Insights/SubscriptionDetectorTests.swift
@@ -1,0 +1,100 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("PayeeNormalizer")
+struct PayeeNormalizerTests {
+  @Test
+  func stripsStoreNumbers() {
+    #expect(PayeeNormalizer.normalize("STARBUCKS #1234") == "starbucks")
+    #expect(PayeeNormalizer.normalize("Starbucks 5678") == "starbucks")
+  }
+
+  @Test
+  func dropsLeadingNoiseToken() {
+    #expect(PayeeNormalizer.normalize("POS STARBUCKS 9001") == "starbucks")
+  }
+
+  @Test
+  func variantsFoldTogether() {
+    let left = PayeeNormalizer.normalize("STARBUCKS #1234")
+    let right = PayeeNormalizer.normalize("starbucks  #99")
+    #expect(left == right)
+  }
+
+  @Test
+  func emptyAndNil() {
+    #expect(PayeeNormalizer.normalize(nil).isEmpty)
+    #expect(PayeeNormalizer.normalize("   ").isEmpty)
+  }
+}
+
+@Suite("SubscriptionDetector")
+struct SubscriptionDetectorTests {
+  private let calendar = InsightTestSupport.calendar
+
+  @Test
+  func detectsMonthlyStream() throws {
+    let transactions = [
+      InsightTestSupport.expense(15.99, payee: "Netflix", daysAgo: 90),
+      InsightTestSupport.expense(15.99, payee: "Netflix", daysAgo: 60),
+      InsightTestSupport.expense(15.99, payee: "Netflix", daysAgo: 30),
+      InsightTestSupport.expense(15.99, payee: "Netflix", daysAgo: 0),
+    ]
+    let detected = SubscriptionDetector.detect(in: transactions, calendar: calendar)
+    let netflix = try #require(detected.first { $0.normalizedPayee == "netflix" })
+    #expect(netflix.period == .monthly)
+    #expect(netflix.occurrenceCount == 4)
+    #expect(netflix.medianAmount < 0)
+  }
+
+  @Test
+  func ignoresIrregularSpending() {
+    let transactions = [
+      InsightTestSupport.expense(5, payee: "Corner Cafe", daysAgo: 51),
+      InsightTestSupport.expense(25, payee: "Corner Cafe", daysAgo: 40),
+      InsightTestSupport.expense(8, payee: "Corner Cafe", daysAgo: 9),
+      InsightTestSupport.expense(31, payee: "Corner Cafe", daysAgo: 2),
+    ]
+    let detected = SubscriptionDetector.detect(in: transactions, calendar: calendar)
+    #expect(detected.isEmpty)
+  }
+
+  @Test
+  func detectsWeeklyCadence() throws {
+    let transactions = (0..<5).map { index in
+      InsightTestSupport.expense(12, payee: "Gym", daysAgo: index * 7)
+    }
+    let detected = SubscriptionDetector.detect(in: transactions, calendar: calendar)
+    let gym = try #require(detected.first)
+    #expect(gym.period == .weekly)
+  }
+
+  @Test
+  func detectsIncomeStreamWhenRequested() throws {
+    let transactions = [
+      InsightTestSupport.income(3000, payee: "ACME Payroll", daysAgo: 42),
+      InsightTestSupport.income(3000, payee: "ACME Payroll", daysAgo: 28),
+      InsightTestSupport.income(3000, payee: "ACME Payroll", daysAgo: 14),
+      InsightTestSupport.income(3000, payee: "ACME Payroll", daysAgo: 0),
+    ]
+    let detected = SubscriptionDetector.detect(
+      in: transactions, incomeStreams: true, calendar: calendar)
+    let payroll = try #require(detected.first)
+    #expect(payroll.isIncome)
+    #expect(payroll.period == .fortnightly)
+    #expect(payroll.medianAmount > 0)
+  }
+
+  @Test
+  func expenseDetectionExcludesIncome() {
+    let transactions = [
+      InsightTestSupport.income(3000, payee: "ACME Payroll", daysAgo: 28),
+      InsightTestSupport.income(3000, payee: "ACME Payroll", daysAgo: 14),
+      InsightTestSupport.income(3000, payee: "ACME Payroll", daysAgo: 0),
+    ]
+    let detected = SubscriptionDetector.detect(in: transactions, calendar: calendar)
+    #expect(detected.isEmpty)
+  }
+}

--- a/MoolahTests/Domain/Insights/SubscriptionInsightsTests.swift
+++ b/MoolahTests/Domain/Insights/SubscriptionInsightsTests.swift
@@ -1,0 +1,93 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("Subscription insights")
+struct SubscriptionInsightsTests {
+  private let calendar = InsightTestSupport.calendar
+  private let context = InsightTestSupport.context()
+
+  private func detect(_ transactions: [InsightTransaction]) -> [DetectedSubscription] {
+    SubscriptionDetector.detect(in: transactions, calendar: calendar)
+  }
+
+  @Test
+  func newRecurringFiresForFreshlyMaturedStream() {
+    let transactions = [
+      InsightTestSupport.expense(9.99, payee: "Spotify", daysAgo: 58),
+      InsightTestSupport.expense(9.99, payee: "Spotify", daysAgo: 30),
+      InsightTestSupport.expense(9.99, payee: "Spotify", daysAgo: 3),
+    ]
+    let insights = SubscriptionInsights.newRecurring(detect(transactions), context: context)
+    #expect(insights.contains { $0.kind == .newRecurringDetected })
+  }
+
+  @Test
+  func newRecurringStaysQuietForOldStream() {
+    let transactions = (0..<6).map { index in
+      InsightTestSupport.expense(9.99, payee: "Spotify", daysAgo: index * 30)
+    }
+    let insights = SubscriptionInsights.newRecurring(detect(transactions), context: context)
+    #expect(insights.isEmpty)
+  }
+
+  @Test
+  func priceHikeDetectsIncrease() throws {
+    let transactions = [
+      InsightTestSupport.expense(10, payee: "CloudStore", daysAgo: 90),
+      InsightTestSupport.expense(10, payee: "CloudStore", daysAgo: 60),
+      InsightTestSupport.expense(10, payee: "CloudStore", daysAgo: 30),
+      InsightTestSupport.expense(12, payee: "CloudStore", daysAgo: 0),
+    ]
+    let insights = SubscriptionInsights.priceHikes(detect(transactions), context: context)
+    let hike = try #require(insights.first)
+    #expect(hike.kind == .subscriptionPriceHike)
+    #expect(hike.framing == .negative)
+  }
+
+  @Test
+  func priceHikeQuietWhenStable() {
+    let transactions = (0..<4).map { index in
+      InsightTestSupport.expense(10, payee: "CloudStore", daysAgo: index * 30)
+    }
+    let insights = SubscriptionInsights.priceHikes(detect(transactions), context: context)
+    #expect(insights.isEmpty)
+  }
+
+  @Test
+  func duplicateSubscriptionsInSameCategory() throws {
+    let streaming = Category(name: "Streaming")
+    let categories = Categories(from: [streaming])
+    var transactions: [InsightTransaction] = []
+    for index in 0..<4 {
+      transactions.append(
+        InsightTestSupport.expense(
+          15, payee: "Netflix", daysAgo: index * 30, categoryId: streaming.id,
+          categoryPath: "Streaming"))
+      transactions.append(
+        InsightTestSupport.expense(
+          16, payee: "Disney Plus", daysAgo: index * 30, categoryId: streaming.id,
+          categoryPath: "Streaming"))
+    }
+    let insights = SubscriptionInsights.duplicates(
+      detect(transactions), categories: categories, context: context)
+    let duplicate = try #require(insights.first)
+    #expect(duplicate.kind == .duplicateSubscription)
+    #expect(duplicate.actionability == .act)
+  }
+
+  @Test
+  func subscriptionOverspendFlagsHighShare() {
+    let transactions = (0..<4).flatMap { index in
+      [
+        InsightTestSupport.expense(40, payee: "BigBundle", daysAgo: index * 30),
+        InsightTestSupport.expense(35, payee: "MegaStream", daysAgo: index * 30),
+      ]
+    }
+    let subscriptions = detect(transactions)
+    let insights = SavingsOpportunityInsights.subscriptionOverspend(
+      subscriptions: subscriptions, averageMonthlyIncome: 300, context: context)
+    #expect(insights.contains { $0.kind == .subscriptionOverspend })
+  }
+}

--- a/plans/2026-06-01-insights-additional-ideas.md
+++ b/plans/2026-06-01-insights-additional-ideas.md
@@ -1,0 +1,219 @@
+# New Personalized-Insight Ideas — moolah-native (beyond Insight Catalog items 1–34)
+
+> **Editor's note (added when saving):** this report was produced by a survey
+> agent against the codebase as of 2026-06-01, as the second half of the
+> insights-core task. One correction to its "cross-cutting prerequisite":
+> `InsightReferences` (`Domain/Insights/Insight.swift`) **already** carries
+> `accountIds`, `instrumentIds`, and `transactionIds` in addition to
+> `categoryIds`/`earmarkIds` — only a `groupId` field is genuinely missing
+> for Theme A. The note about needing a parallel transfer-leg / income-stream
+> feed (transfers are intentionally dropped by `InsightTransaction.records`)
+> is accurate. Everything else is reproduced verbatim.
+
+This proposes ~22 new deterministic, pure-Swift insight ideas that exploit data the original on-device-AI design (`plans/2026-04-18-on-device-ai-design.md`) never modeled, plus several it modeled but didn't fully exploit. The richest unmined seams are **post-design-doc features**: account groups/buckets (`Domain/Models/AccountGroup.swift`, `AccountBucket.swift`), import provenance (`Domain/Models/CSVImport/ImportOrigin.swift`), transfer detection (`Transaction+TransferDetection.swift`, `TransferSuggestion.swift`), and per-leg crypto counterparties (`TransactionLeg.counterpartyAddress`). All detection below stays off the LLM hot path, matching the architecture in `Domain/Insights/`. Every monetary idea respects the signed-amount / never-`abs()` / conversion-can-fail rules (`guides/INSTRUMENT_CONVERSION_GUIDE.md`, `guides/CODE_GUIDE.md` §16).
+
+---
+
+## Theme A — Account Groups & Bucket Structure (entirely new substrate)
+
+The grouping feature added `AccountGroup` (id, name, bucket, instrument, position) and `Account.groupId`/`Account.bucket`. None of the 34 catalog items are group- or bucket-aware. These run on `AccountStore` accounts joined to `AccountGroup` records; insights would need `accountId`/`groupId` added to `InsightReferences` (currently only category/earmark ids — `Domain/Insights/Insight.swift:119`).
+
+### A1. Group net-flow concentration
+- **Value:** "82% of your spending this month came from accounts in your *Daily Spending* group."
+- **Detection:** Group `InsightTransaction.spendMagnitude` by `Account.groupId` (map `accountId → groupId`); report any group whose share of total monthly outflow exceeds a threshold, or whose share moved >N pts vs prior month.
+- **Data:** `InsightTransaction.accountId`, `Account.groupId`, `AccountGroup.name`.
+- **Difficulty:** Easy. **AI:** no.
+- **Caveats:** Drop legs whose conversion failed (count mismatch = "data incomplete"); never `abs()` — use `spendMagnitude`/`incomeMagnitude`.
+
+### A2. Bucket balance drift (current vs investments)
+- **Value:** "Your investable assets now exceed your everyday cash for the first time."
+- **Detection:** Sum converted balances per `AccountBucket` (`.current` vs `.investments` via `Account.bucket`), compare the ratio against the trailing series; fire on a crossing.
+- **Data:** `Account.bucket`, account balances (`AccountStore`/daily balances), `AccountBucket.swift`.
+- **Difficulty:** Medium. **AI:** no.
+- **Caveats:** A bucket sum is only emitted if *every* contributing per-instrument conversion succeeded (mirror `HistoricalValueSeries`' all-or-nothing rule).
+
+### A3. Group instrument mismatch / FX exposure
+- **Value:** "Two accounts in your *Europe* group are denominated in USD, not EUR."
+- **Detection:** For each group, compare member `Account.instrument` against `AccountGroup.instrument`; flag groups holding accounts in a different instrument (latent FX exposure the user grouped as one bucket).
+- **Data:** `AccountGroup.instrument`, `Account.instrument`, `Account.groupId`.
+- **Difficulty:** Easy. **AI:** no.
+- **Caveats:** Purely structural, no money math — safe. Treat unknown `groupId` (group record not yet synced) as ungrouped, per the advisory-reference note in `Account.swift:69`.
+
+### A4. Ungrouped-account nudge (organizational, positive-framed)
+- **Value:** "You have 3 accounts not in any group — want to file them?"
+- **Detection:** Count accounts with `groupId == nil` within a bucket that already has groups; surface as a low-surprise organizational insight.
+- **Data:** `Account.groupId`, `AccountGroup` existence per bucket.
+- **Difficulty:** Easy. **AI:** no. Actionability fits the "noted/review" tier; keep surprise low so the ranker doesn't over-promote it.
+
+---
+
+## Theme B — Transfer Detection & Inter-Account Flow (new substrate)
+
+`TransferSuggestion` (content-addressed pairs) and `Transaction.isTransferDetectionEligible` / `isMergedTransfer` are post-design-doc. Catalog item 13 forecasts balances but nothing reasons about *transfer hygiene* or money movement *between* the user's own accounts.
+
+### B1. Unreconciled-transfer backlog
+- **Value:** "You have 5 likely transfers between your accounts waiting to be merged."
+- **Detection:** Count outstanding `TransferSuggestion` records (each is exactly two tx ids, `TransferSuggestion.swift`); summarize total and oldest `suggestedAt`. Optionally rank by the paired amount.
+- **Data:** `TransferSuggestion`, the two referenced `Transaction`s.
+- **Difficulty:** Easy. **AI:** no.
+- **Caveats:** This is data-quality, not spend — `framing: .neutral`, `actionability: .review`. High value because unmerged transfers double-count as fake income+expense and corrupt every *other* spend detector's inputs.
+
+### B2. Phantom-transfer spend contamination warning
+- **Value:** "Some recent transfers between your accounts may be inflating your spending totals."
+- **Detection:** When unmerged `TransferSuggestion` pairs exist whose legs are typed `.expense`/`.income` (not yet `.transfer`), estimate how much they inflate the period's spend/income magnitude vs the merged-away figure. This is a *meaningful extension* of items 11/16 (deltas / savings rate), explaining anomalies they would otherwise report.
+- **Data:** `TransferSuggestion` + the legs' `type`/`amount`, `InsightAggregates`.
+- **Difficulty:** Medium. **AI:** no.
+- **Caveats:** Sign-sensitive — the two sides have opposite signs; do not collapse with `abs()`. Only an explanatory caveat, not a hard number, unless conversions all succeed.
+
+### B3. Recurring inter-account sweep detection
+- **Value:** "You move about $500 to savings around the 1st each month."
+- **Detection:** Run the existing `SubscriptionDetector` cadence clustering (`Domain/Insights/Subscriptions/`) over *merged transfer* transactions (`Transaction.isMergedTransfer` / two `.transfer` legs) keyed by the destination `accountId` instead of payee. Surface the recurring savings/sweep habit positively, and warn when a month is missing (analogous to missing-paycheck #30 but for self-transfers).
+- **Data:** transfer-typed legs, `accountId`, dates; reuse `SubscriptionDetector`.
+- **Difficulty:** Medium. **AI:** no.
+- **Caveats:** Excluded from `InsightTransaction.records(...)` today (it drops transfers — `InsightTransaction.swift:93`), so this needs a parallel transfer-leg feed; don't pollute the spend feed.
+
+---
+
+## Theme C — Import Provenance & Data Quality (new substrate)
+
+`ImportOrigin` carries `parserIdentifier`, `importSessionId`, `bankReference`, `rawDescription`, `rawBalance`, `importedAt` (`Domain/Models/CSVImport/ImportOrigin.swift`); merged transfers carry `MergedImportOrigin`. The catalog has zero data-quality insights, yet bad data silently breaks every statistical detector.
+
+### C1. Uncategorized-backlog nudge
+- **Value:** "42 imported transactions still need a category — categorize them to sharpen your insights."
+- **Detection:** Count transactions where `Transaction.needsReview` is true (`Transaction+TransferDetection.swift:30` — all legs `categoryId == nil`), optionally scoped to recent `importSessionId`. Suppress all category-based insights' confidence when this backlog is large.
+- **Data:** `Transaction.legs[].categoryId`, `ImportOrigin.importSessionId`.
+- **Difficulty:** Easy. **AI:** no.
+- **Caveats:** Pure count; sign-safe. Strong ranker actionability (`.review`).
+
+### C2. Statement-balance reconciliation gap
+- **Value:** "Your latest CommBank import's running balance doesn't match Moolah's — something may be missing."
+- **Detection:** `ImportOrigin.rawBalance` is the bank's stated running balance per row. Compare the last imported row's `rawBalance` against Moolah's computed account balance at that date (`RunningBalanceResult`/daily balances). A divergence beyond rounding means a missing/duplicate transaction.
+- **Data:** `ImportOrigin.rawBalance`, `ImportOrigin.importedAt`, computed running balance.
+- **Difficulty:** Medium. **AI:** no.
+- **Caveats:** Compare within the *same* instrument only (`rawBalance` is in the account's native currency — no conversion, so don't introduce one). Highest-value data-quality insight: catches the failure mode that breaks everything downstream.
+
+### C3. Possible duplicate import
+- **Value:** "These 3 transactions look like duplicates from re-importing the same statement."
+- **Detection:** Within or across `importSessionId`s, group by (`bankReference` when present) or (date + `rawAmount` + normalized `rawDescription`); flag exact collisions that weren't deduped. `bankReference` is the bank's stable id and the strongest key.
+- **Data:** `ImportOrigin.bankReference`, `rawAmount`, `rawDescription`, `importedAt`.
+- **Difficulty:** Medium. **AI:** no.
+- **Caveats:** `rawAmount` is signed — match on signed value, not magnitude, so a refund isn't paired with a charge.
+
+### C4. Stale data-source warning
+- **Value:** "You haven't imported from Macquarie in 38 days — your spending picture may be incomplete."
+- **Detection:** Group `ImportOrigin.importedAt` by `parserIdentifier`; if a previously-regular source has gone quiet beyond its typical cadence, warn. For synced accounts use `WalletSyncState.lastSyncedAt` / `lastError` (`Domain/Models/WalletSyncState.swift`) instead.
+- **Data:** `ImportOrigin.parserIdentifier` + `importedAt`; `WalletSyncState.lastSyncedAt`/`lastError`.
+- **Difficulty:** Easy. **AI:** no.
+- **Caveats:** Don't fire for one-off manual imports; require an established cadence (≥3 sessions).
+
+---
+
+## Theme D — Crypto / Multi-Instrument Nuances (under-exploited substrate)
+
+Items 25–27 cover concentration, performers, and harvest, but operate only on reduced `InstrumentProfitLoss`. The richer crypto substrate — `TransactionLeg.counterpartyAddress`, `Instrument.kind`/`chainId`, `CostBasisLot`, `CapitalGainEvent.holdingDays`, `CryptoPriceCache` staleness — is untouched.
+
+### D1. Gas/network-fee leakage
+- **Value:** "You spent ~$210 in network fees across 30 on-chain transactions this year."
+- **Detection:** Crypto transactions carry cross-instrument `.expense` fee legs (the gas leg — see `Transaction+TransferDetection.swift:16-19`). Sum converted fee-leg magnitudes per chain. This is a crypto-specific extension of fee-spend (#22), which only matches fiat fee *categories*.
+- **Data:** fee legs (`.expense` leg in a different instrument from the value leg), `Instrument.chainId`.
+- **Difficulty:** Medium. **AI:** no.
+- **Caveats:** Fee legs are in the chain's gas token; convert per-date or report in native token if conversion fails (don't drop silently — note incompleteness).
+
+### D2. Recurring crypto counterparty
+- **Value:** "You've sent ETH to the same address 6 times — looks like a recurring payment."
+- **Detection:** Cluster crypto legs by `TransactionLeg.counterpartyAddress` (lowercased on-chain address) with the subscription cadence test. The on-chain analog of payee-based subscription detection (#1), which can't see addresses.
+- **Data:** `TransactionLeg.counterpartyAddress`, dates, quantity.
+- **Difficulty:** Medium. **AI:** no.
+- **Caveats:** Address is `nil` for multi-recipient/self-send/gas legs (`TransactionLeg.swift:11-17`) — skip those rather than bucketing them as one phantom counterparty.
+
+### D3. Asset-class allocation mix (fiat vs equities vs crypto)
+- **Value:** "Crypto is now 35% of your net worth, up from 12% a year ago."
+- **Detection:** Partition holdings by `Instrument.kind` (`.fiatCurrency` / `.stock` / `.cryptoToken`, `Instrument.swift:5`), sum converted value per class, and trend the shares. A meaningful generalization of single-instrument concentration (#25) to *asset class*.
+- **Data:** `Instrument.kind`, position values, `ValuedPosition`.
+- **Difficulty:** Medium. **AI:** no.
+- **Caveats:** All-or-nothing conversion per class; crypto prices are USD-based (`CryptoPriceCache`) so a missing rate to the reporting currency must invalidate the whole class sum.
+
+### D4. Approaching long-term CGT threshold (Australia)
+- **Value:** "Holding BHP 22 more days crosses the 12-month mark for the 50% CGT discount."
+- **Detection:** For each open `CostBasisLot`, compute days since `acquiredDate`; flag lots at 343–365 days (just under the `holdingDays > 365` long-term boundary defined on `CapitalGainEvent.swift:17`). Purely a *timing* prompt, distinct from the loss-offset harvest (#27).
+- **Data:** `CostBasisLot.acquiredDate`/`remainingQuantity`, `CapitalGainEvent.isLongTerm` rule.
+- **Difficulty:** Medium. **AI:** no.
+- **Caveats:** AU-specific; frame as a prompt to review, never tax advice (same discipline as the existing harvest detector). Only for lots with `remainingQuantity > 0`.
+
+### D5. Stale valuation warning
+- **Value:** "Your portfolio value uses prices from 4 days ago — markets have moved."
+- **Detection:** Compare `CryptoPriceCache.latestDate` / `StockPriceCache` against `context.now`; if the freshest cached price predates today beyond a tolerance, caveat all investment insights.
+- **Data:** `CryptoPriceCache.latestDate`, `StockPriceCache`, `TokenPricingStatus`.
+- **Difficulty:** Easy. **AI:** no.
+- **Caveats:** Data-quality framing; gates the *confidence* of D3/#25–27 rather than asserting a dollar figure.
+
+---
+
+## Theme E — Earmarks, Income & Cash Flow Extensions (under-exploited)
+
+### E1. Earmark funding shortfall vs upcoming bills
+- **Value:** "Your *Holiday* earmark is $300 short of the trip you've scheduled."
+- **Detection:** Join `EarmarkSnapshot.balance`/`savingsGoal` against `ScheduledBill`s whose payee/category maps to that earmark; flag when projected need exceeds funded balance before the due date. Combines earmark state (#18–20) with scheduled bills (#13), which the catalog never cross-references.
+- **Data:** `EarmarkSnapshot` (`InsightInput.swift:10`), `ScheduledBill` (`InsightInput.swift:117`).
+- **Difficulty:** Medium. **AI:** no.
+- **Caveats:** Both pre-converted to reporting currency by the wiring layer; if either is `nil` (unknown), skip.
+
+### E2. Pay-rise / pay-cut detection
+- **Value:** "Your paycheck went up about 4% starting in April."
+- **Detection:** On the detected income stream (#14), apply the subscription *price-hike* technique (#2) to flag a sustained step change in the recurring income amount — the income-side mirror the catalog only applies to expenses.
+- **Data:** detected income stream amounts over time (income-typed `InsightTransaction`s).
+- **Difficulty:** Easy (once income detection exists). **AI:** no.
+- **Caveats:** Require persistence across ≥2 occurrences to distinguish a raise from a one-off bonus; bonus = separate positive (see E3).
+
+### E3. Windfall / one-off income alert
+- **Value:** "You received an unusually large deposit of $4,200 — a bonus or refund?"
+- **Detection:** MAD-z (the same robust score used in #7) on income magnitudes against the user's typical inflow; a positive-framed counterpart to the large-*transaction* anomaly, which today focuses on expenses.
+- **Data:** income-typed `InsightTransaction.incomeMagnitude`.
+- **Difficulty:** Easy. **AI:** no.
+- **Caveats:** Use `incomeMagnitude` (already clamps outflows to 0); never `abs()` an expense into fake income.
+
+### E4. Weekend vs weekday spend split
+- **Value:** "You spend 2.4× more on weekends than weekdays."
+- **Detection:** Bucket `spendMagnitude` by weekday/weekend via `context.calendar`; report the ratio when stable. A distinct framing from the day-of-week *spike* in #9 (which finds one-day anomalies, not the habitual split).
+- **Data:** `InsightTransaction.date`, `InsightContext.calendar`.
+- **Difficulty:** Easy. **AI:** no.
+
+### E5. First-of-period burn-rate front-loading
+- **Value:** "You spend 60% of your monthly budget in the first 10 days."
+- **Detection:** Within each financial month (`FinancialMonth.key`, `context.financialMonthEnd`), compute the cumulative-spend curve and flag heavy front-loading — a leading indicator for the end-of-month cash crunch that #13/#15 only catch once the balance is already low.
+- **Data:** `InsightTransaction.date`/`spendMagnitude`, `InsightContext.financialMonthEnd`.
+- **Difficulty:** Medium. **AI:** no.
+
+---
+
+## Theme F — Merchant & Category Behavior (extensions)
+
+### F1. Lapsed-merchant / "you used to spend here"
+- **Value:** "You haven't shopped at Spotify-adjacent merchants in 3 months — did you cancel?"
+- **Detection:** Set difference the *opposite* direction from new-merchant (#8): merchants present in prior history but absent recently, weighted by their former spend. Stronger cancellation signal than the cadence-lengthening proxy in #4.
+- **Data:** `InsightTransaction.normalizedPayee`, dates.
+- **Difficulty:** Easy. **AI:** no. Marked as a meaningful extension of #4/#8.
+
+### F2. Category-budget-less spending spotlight
+- **Value:** "Your biggest spend category, *Dining*, has no budget set."
+- **Detection:** Rank categories by trailing spend; cross-reference against `EarmarkBudgetItem.categoryId` (`Domain/Models/Earmark.swift:3`) to find the largest *un-budgeted* category. Actionable nudge bridging spend analysis and the budgeting feature.
+- **Data:** `InsightTransaction.categoryId`, `EarmarkBudgetItem.categoryId`.
+- **Difficulty:** Easy. **AI:** no.
+
+### F3. Round-number / split-bill recurring pattern
+- **Value:** "A recurring $50.00 round-number expense to *Jane* looks like a shared cost."
+- **Detection:** Within subscription clusters, flag streams whose amount is an exact round number and category is uncategorized/personal — a heuristic for informal recurring reimbursements. Low priority; nice-to-have.
+- **Data:** subscription clusters + `InsightTransaction.amount`.
+- **Difficulty:** Easy. **AI:** no.
+
+---
+
+## Top 5 recommended next (ranked by value ÷ effort)
+
+1. **C1 Uncategorized-backlog nudge** — trivial count, but it both drives action *and* lets the engine down-weight category insights when data is dirty. Highest leverage per line of code. (`Transaction.needsReview`.)
+2. **B1 Unreconciled-transfer backlog** — Easy, and unmerged transfers actively poison spend/income/savings-rate detectors. Protecting the inputs is worth more than another spend metric. (`TransferSuggestion`.)
+3. **C2 Statement-balance reconciliation gap** — uniquely catches missing/duplicate transactions via `ImportOrigin.rawBalance`; no other signal can. Medium effort, high trust payoff.
+4. **A1 Group net-flow concentration** — first insight that makes the new account-groups feature feel intelligent; Easy once `groupId` is threaded into `InsightReferences`.
+5. **D1 Gas-fee leakage** — concrete, surprising dollar figure for crypto users that the fiat-only fee detector (#22) structurally cannot produce. Reuses the existing cross-instrument fee-leg shape.
+
+**Cross-cutting prerequisite:** add a `groupId` to `InsightReferences` (`Domain/Insights/Insight.swift` — `accountIds`/`instrumentIds`/`transactionIds` already exist) and a parallel transfer-leg / income-stream feed alongside `InsightTransaction.records(...)` (which intentionally drops transfers — `Domain/Insights/InsightTransaction.swift`). Themes B and D depend on it.

--- a/plans/2026-06-01-insights-additional-ideas.md
+++ b/plans/2026-06-01-insights-additional-ideas.md
@@ -1,5 +1,19 @@
 # New Personalized-Insight Ideas — moolah-native (beyond Insight Catalog items 1–34)
 
+> **Implementation status (updated):** the following were implemented in
+> `Domain/Insights/` with tests in `MoolahTests/Domain/Insights/AdditionalInsightTests.swift`:
+> **C-1** uncategorized backlog, **B-1** unreconciled transfers
+> (`DataQualityInsights`); **A-1** group spend concentration
+> (`AccountGroupInsights`); **E-3** windfall income, **E-2** pay-rate change
+> (`IncomeExtraInsights`); **F-1** lapsed merchant, **E-4** weekend-spend skew
+> (`SpendHabitInsights`); **F-2** unbudgeted-category spotlight
+> (`BudgetCoverageInsights`). `InsightReferences` gained `groupIds`; `InsightInput`
+> gained the account-group, budgeted-category, and data-quality-count fields these
+> need. The remaining ideas (B-2/B-3 transfer-stream analysis, C-2/C-3/C-4 import
+> reconciliation, D-1…D-5 crypto/multi-instrument, E-1/E-5) are not yet built —
+> several need a parallel transfer-leg / native-instrument feed alongside
+> `InsightTransaction`.
+>
 > **Editor's note (added when saving):** this report was produced by a survey
 > agent against the codebase as of 2026-06-01, as the second half of the
 > insights-core task. One correction to its "cross-cutting prerequisite":

--- a/plans/2026-06-01-insights-core-implementation.md
+++ b/plans/2026-06-01-insights-core-implementation.md
@@ -1,0 +1,114 @@
+# Personalized Insights — Core Detector Implementation
+
+Implements the deterministic detection layer for Use Case 2 (Personalized
+Insights) of `plans/2026-04-18-on-device-ai-design.md`. This is the
+**core logic only** — pure-Swift statistical detectors operating on real
+domain data. It is intentionally **not** wired into the UI; a follow-up
+task picks up this branch and connects it to a surface ("For You" panel,
+per-category/-account views, etc.).
+
+## What landed
+
+All under `Domain/Insights/` (pure domain layer — no SwiftUI, no SwiftData,
+no backend imports), with a test suite under `MoolahTests/Domain/Insights/`.
+
+### Core model
+- `Insight` — the unit produced by detectors: id, kind, template `title`/
+  `detail` narration, `date`, `framing` (positive/neutral/negative),
+  `actionability` (act/review/informational), normalised `surprise`,
+  signed `monetaryImpact`, structured `facts` (the only numbers a future
+  LLM narration layer may print — zero-hallucination contract), and
+  `references` (account/category/earmark/instrument/transaction ids for
+  deep-linking).
+- `InsightKind` — catalog enum, numbered to the design's §"Insight Catalog".
+- `InsightContext` — ambient `now`, reporting currency, calendar,
+  financial-month boundary (all injected for deterministic tests).
+- `InsightInput` — the substrate bundle the engine consumes.
+- `InsightTransaction` / `ScheduledBill` / `EarmarkSnapshot` — the
+  currency-normalised inputs (see "Currency boundary" below).
+
+### Detectors (catalog item → file)
+- **Subscriptions** — `SubscriptionDetector` clusters streams;
+  `SubscriptionInsights` produces new-recurring (5), price-hike (2),
+  duplicate (3), cancellation-candidate (4). Overspend (23) is in
+  `SavingsOpportunityInsights`.
+- **Anomalies** — `LargeTransactionInsight` (7, MAD-z),
+  `NewMerchantInsight` (8), `UnusualDayInsight` (9),
+  `CategoryAnomalyInsight` (6, seasonal-trend decomposition).
+- **Trends** — `CategoryTrendInsight` (10, Mann-Kendall + Sen's slope +
+  Benjamini-Hochberg FDR), `PeriodComparisonInsights` (11, MoM),
+  `CategoryMixShiftInsight` (12).
+- **Cash flow** — `CashFlowForecastInsights` (13 upcoming-bill, 15
+  projected month-end), `LiquidityInsights` (17 runway, 21 idle-cash),
+  `SavingsRateInsight` (16).
+- **Budgets** — `EarmarkBudgetInsights` (18 burndown, 19 under-spend),
+  `SavingsGoalInsight` (20).
+- **Income** — `IncomeInsights` (14 paycheck timing, 29 stability, 30
+  missing paycheck), built on `SubscriptionDetector` over income streams.
+- **Investments / net worth** — `NetWorthInsights` (24),
+  `InvestmentInsights` (25 concentration, 26 top/bottom performer, 27
+  conservative tax-loss-harvest prompt).
+- **Fees** — `SavingsOpportunityInsights.feeSpend` (22).
+
+### Statistics (pure, reusable)
+`DescriptiveStatistics` (median/MAD/robust-z/percentile/CV),
+`MannKendall` (+ Sen's slope), `BenjaminiHochberg`, `SeasonalDecomposition`
+(STL-lite, documented simplification), `NormalDistribution`.
+
+### Ranking & fatigue
+`InsightRanker` implements the design's scoring model
+(`surprise + actionability + log(magnitude) + recency + interest −
+fatigue`), de-dupes by id, applies a display cap, and **guarantees one
+positive-framed insight** per surface when one exists.
+
+### Orchestration
+`InsightEngine.detectAll(_:)` runs every detector;
+`InsightEngine.generate(_:dismissals:interests:displayCap:)` returns ranked
+`ScoredInsight`s.
+
+## Currency boundary (important for wiring)
+
+Detectors are **pure and synchronous**, but `InstrumentConversionService`
+is async. The boundary is drawn at input assembly:
+
+- The wiring layer converts every leg / earmark / bill amount to the
+  reporting currency **once, up front**, and builds `InsightTransaction`,
+  `EarmarkSnapshot`, and `ScheduledBill` already denominated in one
+  instrument.
+- `InsightTransaction.records(from:categories:convert:)` flattens
+  `[Transaction]` using an injected `(InstrumentAmount, Date) -> Decimal?`
+  converter; a leg whose conversion returns `nil` is dropped (Rule 11 — no
+  partial/guessed totals). `sameCurrencyRecords(...)` is the single-currency
+  convenience.
+
+Sign convention is preserved throughout (income +, expense −, refunds kept;
+never `abs()`). Note: the backend's `MonthlyIncomeExpense.expense` and
+`ExpenseBreakdown.totalExpenses` are **negative** sums; detectors flip to a
+positive spend magnitude explicitly where needed.
+
+## How to wire it up (next task)
+
+1. Build an `InsightInput` per surface refresh, off-main, from the existing
+   stores:
+   - `transactions` ← `TransactionRepository.fetchAll` → convert legs →
+     `InsightTransaction.records`.
+   - `monthly` ← `AnalysisStore.incomeAndExpense`;
+     `expenseBreakdown` ← `AnalysisStore.expenseBreakdown`;
+     `dailyBalances` ← `AnalysisStore.dailyBalances`.
+   - `earmarks` ← join `EarmarkStore.earmarks` with its converted-balance /
+     saved / spent dictionaries into `EarmarkSnapshot`.
+   - `profitLoss` / `capitalGains` ← `ReportingStore`.
+   - `scheduledBills` ← project upcoming scheduled transactions.
+   - `categories` ← `CategoryStore.categories`.
+2. Call `InsightEngine().generate(input, …)` and publish the
+   `[ScoredInsight]` from a `@MainActor` store per
+   `guides/CONCURRENCY_GUIDE.md`.
+3. Persist per-kind dismissal counts to feed the ranker's fatigue term.
+
+## Not in scope here
+- UI surfaces, the `@MainActor` insights store, persistence of dismissals.
+- Foundation Models narration / "why?" / conversational assistant
+  (design Phases 3–4). The `facts` array is the seam for that later.
+- `swift-format` / SwiftLint pass — this branch was authored without the
+  Swift toolchain available; run `just format` and `just format-check`
+  before merge.

--- a/plans/2026-06-01-insights-integration-plan.md
+++ b/plans/2026-06-01-insights-integration-plan.md
@@ -1,0 +1,131 @@
+# Personalized Insights — Integration Plan
+
+How to take the merged deterministic insights engine (`Domain/Insights/`, see
+`plans/2026-06-01-insights-core-implementation.md`) from a standalone library
+to a feature users actually see and benefit from.
+
+**Status:** the detection engine, ranker, and ~38 detectors are built, tested,
+and CI-green. Nothing in the app calls them yet — there is no wiring layer, no
+store, and no UI surface. This document sequences that work.
+
+Aligns with the phasing in `plans/2026-04-18-on-device-ai-design.md`
+(§"Implementation Phasing"): Phase 1 is deterministic + a single surface;
+Foundation Models is strictly additive on top.
+
+## Architectural contract (already established)
+
+- `InsightEngine.generate(_:dismissals:interests:displayCap:)` is **pure and
+  synchronous**. All async currency conversion must happen *upstream* when
+  assembling `InsightInput` (`InsightTransaction` / `EarmarkSnapshot` /
+  `ScheduledBill` arrive already in the reporting currency).
+- Sign convention preserved end to end (income +, expense −, refunds kept;
+  never `abs()`); a conversion failure drops that leg rather than guessing
+  (`guides/INSTRUMENT_CONVERSION_GUIDE.md` Rule 11).
+- Each `Insight` carries template `title`/`detail` (works on every device) plus
+  a structured `facts` array that is the zero-hallucination seam for a later
+  Foundation Models narration layer.
+
+---
+
+## Phase A — Input-assembly layer (the async seam) — **critical path**
+
+The one thing the engine can't do itself. New `Features/Insights/` code that,
+given the loaded stores + `BackendProvider`, builds an `InsightInput`:
+
+- `transactions` ← `TransactionRepository.fetchAll` → flatten each leg through
+  `InstrumentConversionService` → `InsightTransaction.records(from:categories:convert:)`.
+  Track the dropped-leg count for a future "data incomplete" signal.
+- `monthly` / `expenseBreakdown` / `dailyBalances` ← `AnalysisStore`.
+- `earmarks` ← join `EarmarkStore.earmarks` with its converted balance / saved /
+  spent dictionaries into `EarmarkSnapshot`; `budgetedCategoryIds` from line items.
+- `profitLoss` / `capitalGains` ← `ReportingStore`.
+- `accountGroups` + `accountGroupMembership` ← `AccountGroupStore` + `AccountStore`.
+- `uncategorizedTransactionCount` ← `Transaction.needsReview` count;
+  `pendingTransferCount` / `oldestPendingTransferDate` ← `TransferSuggestionRepository`.
+
+Runs **off-main** per `guides/CONCURRENCY_GUIDE.md`. Unit-tested against
+`TestBackend` with realistic seeded data — this is where detector thresholds get
+validated beyond the unit fixtures.
+
+**Exit criteria:** `InsightInputBuilder` produces a correct `InsightInput` from a
+seeded `TestBackend`; conversion-failure path covered.
+
+## Phase B — `@MainActor InsightStore`
+
+Mirrors the existing store pattern (`@Observable`, `@Environment(BackendProvider.self)`).
+Publishes `[ScoredInsight]`; `refresh()` builds the input off-main then calls the
+engine; `dismiss(_:)` updates state. Recompute on data-change ticks, not on every
+view appearance.
+
+**Exit criteria:** store tests assert published insights + dismissal behaviour
+against `TestBackend`.
+
+## Phase C — Dashboard "For You" panel (first surface)
+
+The sole surface for v1 (design §"Discoverability"). Renders the top 3–5 ranked
+insights: `title`, expandable `facts`, dismiss affordance, deep-link via
+`references` (account / category / earmark / group ids). Thin view; all logic in
+the store. `@ui-review` + `MoolahUITests_macOS` coverage (the `writing-ui-tests`
+skill). Template narration only — no LLM yet.
+
+**Exit criteria:** insights render on dashboard open, dismiss works, links
+navigate; UI test green.
+
+## Phase D — Persist dismissals + declared interests
+
+The ranker already accepts `dismissals:` / `interests:` but nothing stores them.
+New repository + CloudKit record type (the `modifying-cloudkit-schema` skill) so a
+dismissal syncs across devices. This makes the anti-fatigue design real.
+
+**Exit criteria:** dismissals survive relaunch and sync; fatigue penalty visibly
+reorders insights.
+
+## Phase E — Foundation Models polish (additive, gated)
+
+Narration over the pre-computed `facts` (never invents numbers), behind
+`SystemLanguageModel.default.availability` with template fallback already present.
+Delivers the "why?" explanation and the weekly-recap narrative. Ships nothing to
+ineligible devices beyond what Phase C already shows.
+
+## Phase F — Conversational assistant (design Phase 4)
+
+Tool-calling `LanguageModelSession` over the existing stores as read-only `Tool`
+conformers, with citation chips. Apple-Intelligence devices only. Larger effort;
+own design doc when reached.
+
+## Phase G — Remaining detector ideas
+
+From `plans/2026-06-01-insights-additional-ideas.md` (not yet built): import-balance
+reconciliation (C-2), crypto gas-fee leakage / on-chain counterparty recurrence
+(D-1/D-2), asset-class allocation (D-3). Most need a **parallel feed** alongside
+`InsightTransaction` — transfer-typed legs and native-instrument metadata, since
+`records(...)` deliberately drops transfers and folds away the instrument. Small
+input-model extension, not new infrastructure.
+
+## Phase H — Productionisation
+
+- **Performance**: cache `InsightInput`/results; recompute on change ticks. Add a
+  `MoolahBenchmarks` case (the `write-benchmark` skill) and verify on device.
+- **Tuning**: ranker weights and detector thresholds are hand-set; add a debug
+  surface to eyeball real output and adjust before GA.
+- **Settings + help**: a disable toggle; help content (`@help-review`).
+- **Privacy**: on-device only; no telemetry by default (design §Privacy).
+
+---
+
+## Recommended first PR
+
+Phases **A–C** as a thin vertical slice: builder → `InsightStore` → dashboard
+panel with template narration and in-memory dismissals. That puts real insights in
+front of a user end to end. Persistence (D), LLM polish (E), and the assistant (F)
+layer on top without rework.
+
+## Dependency order
+
+```
+A (input builder) ─┬─> B (store) ──> C (dashboard)  ← first user-visible PR
+                   │                    └─> D (persist dismissals)
+                   └─> G (extra detectors, parallel feed)
+B ──> E (FM narration) ──> F (assistant)
+H (perf / tuning / settings / help) spans C onward
+```


### PR DESCRIPTION
Implements the **core logic** for Use Case 2 (Personalized Insights) of `plans/2026-04-18-on-device-ai-design.md` — pure-Swift statistical detectors over real domain data, with ranking and fatigue control. **Not wired into the UI**; a follow-up task connects `InsightEngine` to a surface (see `plans/2026-06-01-insights-core-implementation.md` for the integration guide and the currency boundary).

## What's here

All under `Domain/Insights/` (pure domain layer — no SwiftUI/SwiftData/backend imports), with a Swift Testing suite under `MoolahTests/Domain/Insights/`.

**Detectors** (catalog item numbers from the design's §"Insight Catalog"):
- Subscriptions — clustering + new-recurring (5), price-hike (2), duplicate (3), cancellation candidate (4), overspend (23)
- Anomalies — large-transaction MAD-z (7), new-merchant (8), unusual day (9), category seasonal anomaly (6)
- Trends — Mann-Kendall + Sen's slope + Benjamini-Hochberg FDR (10), MoM (11), category-mix shift (12)
- Cash flow — upcoming-bill warning (13), projected month-end (15), savings-rate trend (16), runway (17), idle cash (21)
- Budgets — earmark burndown (18), under-spend (19), savings-goal ETA (20)
- Income — paycheck timing (14), stability (29), missing paycheck (30)
- Investments / net worth — net-worth milestone (24), concentration (25), top/bottom performer (26), tax-loss-harvest prompt (27), fee spend (22)

**Statistics** (pure, reusable): robust z / MAD, Mann-Kendall, Benjamini-Hochberg, STL-lite seasonal decomposition, normal CDF.

**Ranking & fatigue**: `InsightRanker` implements the design's scoring model, display cap, and the guaranteed-positive-insight rule. `InsightEngine` orchestrates detection → ranking.

## Design fidelity
- Detection is deterministic per the design's "no LLM on the hot path" rule; each `Insight`'s structured `facts` are the zero-hallucination seam for a later Foundation Models narration layer.
- Sign convention preserved throughout (income +, expense −, refunds kept; never `abs()`); async currency conversion is drawn at the input boundary so detectors stay pure and synchronous.

## Follow-up research
`plans/2026-06-01-insights-additional-ideas.md` surveys ~22 further insight ideas, weighted toward post-design-doc features (account groups, transfer detection, import provenance/data-quality, crypto/multi-instrument). These will be implemented in a follow-up commit on this branch.

## Verification
Authored on Linux without Xcode, but validated with the repo's pinned toolchain (Swift 6.2 / swift-format 602.0.0 / SwiftLint 0.63.3):
- `swiftlint --strict`: 0 violations
- `swift-format` parity: every file byte-identical to formatter output
- The full Domain model set plus the insights layer typecheck cleanly against the real domain signatures.

Closing the loop on actual `xcodebuild` + test execution is what this PR's CI run validates.

https://claude.ai/code/session_013JqvmoEycu1Qkjifran1FW

---
_Generated by [Claude Code](https://claude.ai/code/session_013JqvmoEycu1Qkjifran1FW)_