### PR TITLE
Insights Phase A: SQL-summary InsightDataSource

### DIFF
--- a/Backends/CloudKit/CloudKitBackend.swift
+++ b/Backends/CloudKit/CloudKitBackend.swift
@@ -10,6 +10,7 @@ final class CloudKitBackend: BackendProvider, @unchecked Sendable {
   let transferSuggestions: any TransferSuggestionRepository
   let earmarks: any EarmarkRepository
   let analysis: any AnalysisRepository
+  let insightDataSource: any InsightDataSource
   let investments: any InvestmentRepository
   let conversionService: any InstrumentConversionService
   let csvImportProfiles: any CSVImportProfileRepository
@@ -136,6 +137,7 @@ final class CloudKitBackend: BackendProvider, @unchecked Sendable {
     self.transferSuggestions = repos.transferSuggestions
     self.earmarks = repos.earmarks
     self.analysis = repos.analysis
+    self.insightDataSource = repos.insightDataSource
     self.investments = repos.investments
     self.csvImportProfiles = repos.csvImportProfiles
     self.importRules = repos.importRules
@@ -158,6 +160,7 @@ final class CloudKitBackend: BackendProvider, @unchecked Sendable {
     let investments: GRDBInvestmentRepository
     let transactionLegs: GRDBTransactionLegRepository
     let analysis: GRDBAnalysisRepository
+    let insightDataSource: GRDBInsightDataSource
     let csvImportProfiles: GRDBCSVImportProfileRepository
     let importRules: GRDBImportRuleRepository
   }
@@ -208,6 +211,7 @@ final class CloudKitBackend: BackendProvider, @unchecked Sendable {
         onRecordChanged: hooks.onTransactionLegChanged,
         onRecordDeleted: hooks.onTransactionLegDeleted),
       analysis: resolving.analysis,
+      insightDataSource: resolving.insightDataSource,
       csvImportProfiles: GRDBCSVImportProfileRepository(
         database: database,
         onRecordChanged: hooks.onCSVImportProfileChanged,
@@ -229,6 +233,7 @@ final class CloudKitBackend: BackendProvider, @unchecked Sendable {
     let earmarks: GRDBEarmarkRepository
     let investments: GRDBInvestmentRepository
     let analysis: GRDBAnalysisRepository
+    let insightDataSource: GRDBInsightDataSource
   }
 
   /// The read-side instrument resolver and the write-side registrar,
@@ -277,6 +282,11 @@ final class CloudKitBackend: BackendProvider, @unchecked Sendable {
         onRecordChanged: hooks.onInvestmentChanged,
         onRecordDeleted: hooks.onInvestmentDeleted),
       analysis: GRDBAnalysisRepository(
+        database: database,
+        instrument: instrument,
+        conversionService: conversionService,
+        instrumentResolver: resolver),
+      insightDataSource: GRDBInsightDataSource(
         database: database,
         instrument: instrument,
         conversionService: conversionService,

--- a/Backends/GRDB/Repositories/GRDBInsightDataSource+CategorySpend.swift
+++ b/Backends/GRDB/Repositories/GRDBInsightDataSource+CategorySpend.swift
@@ -1,0 +1,156 @@
+import Foundation
+import GRDB
+
+/// Windowed per-category / per-account spend sums and the per-category MAD
+/// baseline samples. Pure SQL `GROUP BY` aggregations (and one capped
+/// projection) mirroring `GRDBAnalysisRepository+ExpenseBreakdown` — the
+/// summed rows convert on their own `(day, instrument)` bucket.
+extension GRDBInsightDataSource {
+  /// One `(day, key, instrument)` bucket of summed expense quantity, where
+  /// `key` is the category id (category spend) or account id (account
+  /// spend).
+  struct SpendBucketRow: Sendable {
+    let day: String
+    let key: UUID?
+    let instrumentId: String
+    let qty: Int64
+    let legCount: Int
+  }
+
+  func categorySpend(
+    windowDays: Int,
+    categories: Categories,
+    context: InsightContext
+  ) async throws -> [CategorySpendSummary] {
+    let after = cutoff(windowDays: windowDays, context: context)
+    let instruments = try await resolveInstruments()
+    let rows = try await profileDatabase.read { database in
+      // The two spend aggregations differ only in their grouping column;
+      // each is its own string-literal SQL (no column-name splicing) so no
+      // dynamic SQL is composed — see `guides/DATABASE_CODE_GUIDE.md` §4.
+      let sqlRows = try Row.fetchAll(
+        database,
+        sql: """
+          SELECT DATE(t.date)      AS day,
+                 leg.category_id   AS dim,
+                 leg.instrument_id AS instrument_id,
+                 SUM(leg.quantity) AS qty,
+                 COUNT(*)          AS n
+          FROM transaction_leg leg
+          JOIN "transaction"    t ON leg.transaction_id = t.id
+          WHERE t.recur_period IS NULL
+            AND leg.type = 'expense'
+            AND leg.category_id IS NOT NULL
+            AND (:after IS NULL OR t.date >= :after)
+          GROUP BY day, dim, instrument_id
+          ORDER BY day ASC
+          """,
+        arguments: ["after": after])
+      return sqlRows.compactMap(Self.decodeSpendBucket(_:))
+    }
+    let folded = try await foldSpendBuckets(rows, instruments: instruments, context: context)
+    return
+      folded
+      .map { key, value in
+        let path = key.flatMap { categories.by(id: $0) }.map { categories.path(for: $0) }
+        return CategorySpendSummary(
+          categoryId: key, categoryPath: path, total: value.total, legCount: value.count)
+      }
+      .sorted { lhs, rhs in lhs.total.quantity < rhs.total.quantity }
+  }
+
+  func accountSpend(
+    windowDays: Int,
+    context: InsightContext
+  ) async throws -> [AccountSpendSummary] {
+    let after = cutoff(windowDays: windowDays, context: context)
+    let instruments = try await resolveInstruments()
+    let rows = try await profileDatabase.read { database in
+      let sqlRows = try Row.fetchAll(
+        database,
+        sql: """
+          SELECT DATE(t.date)      AS day,
+                 leg.account_id    AS dim,
+                 leg.instrument_id AS instrument_id,
+                 SUM(leg.quantity) AS qty,
+                 COUNT(*)          AS n
+          FROM transaction_leg leg
+          JOIN "transaction"    t ON leg.transaction_id = t.id
+          WHERE t.recur_period IS NULL
+            AND leg.type = 'expense'
+            AND leg.account_id IS NOT NULL
+            AND (:after IS NULL OR t.date >= :after)
+          GROUP BY day, dim, instrument_id
+          ORDER BY day ASC
+          """,
+        arguments: ["after": after])
+      return sqlRows.compactMap(Self.decodeSpendBucket(_:))
+    }
+    let folded = try await foldSpendBuckets(rows, instruments: instruments, context: context)
+    return
+      folded
+      .map { key, value in
+        AccountSpendSummary(accountId: key, total: value.total, legCount: value.count)
+      }
+      .sorted { lhs, rhs in lhs.total.quantity < rhs.total.quantity }
+  }
+
+  /// Decode one `(day, dim, instrument, qty, n)` aggregation row shared by
+  /// the category and account spend queries (their `dim` is `category_id`
+  /// / `account_id` respectively). The shapes are plan-pinned in
+  /// `InsightDataSourcePlanPinningTests` against the
+  /// `leg_analysis_by_type_category` / `leg_analysis_by_type_account`
+  /// covering composites.
+  private static func decodeSpendBucket(_ row: Row) -> SpendBucketRow? {
+    guard let day: String = row["day"],
+      let instrumentId: String = row["instrument_id"]
+    else { return nil }
+    return SpendBucketRow(
+      day: day,
+      key: row["dim"],
+      instrumentId: instrumentId,
+      qty: row["qty"] ?? 0,
+      legCount: row["n"] ?? 0)
+  }
+
+  /// Convert each bucket on its own day and accumulate per key. A bucket
+  /// whose conversion fails is skipped (Rule 11) and logged.
+  private func foldSpendBuckets(
+    _ rows: [SpendBucketRow],
+    instruments: [String: Instrument],
+    context: InsightContext
+  ) async throws -> [UUID?: (total: InstrumentAmount, count: Int)] {
+    var totals: [UUID?: InstrumentAmount] = [:]
+    var counts: [UUID?: Int] = [:]
+    let zero = context.zero
+    for row in rows {
+      guard let day = GRDBAnalysisRepository.parseDayString(row.day) else {
+        log.error("spendBuckets: unparseable day '\(row.day, privacy: .public)'")
+        continue
+      }
+      let source = instrument(forId: row.instrumentId, in: instruments)
+      do {
+        let amount = try await GRDBAnalysisRepository.convertedQuantity(
+          storageValue: row.qty,
+          instrument: source,
+          to: profileInstrument,
+          on: day,
+          conversionService: converter)
+        totals[row.key] = (totals[row.key] ?? zero) + amount
+        counts[row.key, default: 0] += row.legCount
+      } catch let cancel as CancellationError {
+        throw cancel
+      } catch {
+        log.warning(
+          """
+          spendBuckets: skipping day=\(row.day, privacy: .public) \
+          instrument=\(row.instrumentId, privacy: .public) — conversion failed: \
+          \(error.localizedDescription, privacy: .public)
+          """)
+      }
+    }
+    return totals.reduce(into: [:]) { result, entry in
+      result[entry.key] = (entry.value, counts[entry.key] ?? 0)
+    }
+  }
+}

--- a/Backends/GRDB/Repositories/GRDBInsightDataSource+Payees.swift
+++ b/Backends/GRDB/Repositories/GRDBInsightDataSource+Payees.swift
@@ -1,0 +1,100 @@
+import Foundation
+
+/// Per-normalized-payee cadence summaries over the bounded cadence window.
+///
+/// Reuses the recent-candidate projection (the accepted ~13-month bounded
+/// window of projected columns) and folds it by `(normalizedPayee,
+/// direction)` in Swift — payee normalisation (`PayeeNormalizer`) can't run
+/// in SQL, so the clustering happens here. Memory stays `O(payees +
+/// windowed occurrences)`.
+extension GRDBInsightDataSource {
+  func payeeSummaries(
+    windowDays: Int,
+    context: InsightContext
+  ) async throws -> [PayeeSummary] {
+    try await payeeSummariesWithDrops(windowDays: windowDays, context: context).payees
+  }
+
+  /// Drop-aware variant used by `assemble`: also reports the legs dropped
+  /// for a failed conversion (Rule 11).
+  func payeeSummariesWithDrops(
+    windowDays: Int,
+    context: InsightContext
+  ) async throws -> (payees: [PayeeSummary], dropped: Int) {
+    // Project the cadence window through the same converter as the recent
+    // candidates; categories are irrelevant to a payee summary, so pass an
+    // empty lookup (the projected `categoryPath` goes unused here).
+    let projected = try await recentCandidatesWithDrops(
+      windowDays: windowDays, categories: Categories(from: []), context: context)
+    return (foldPayees(projected.items, context: context), projected.dropped)
+  }
+
+  /// Group projected legs by `(normalizedPayee, isExpense)` into cadence
+  /// summaries, ascending by date. Legs with no payee can't cluster and are
+  /// skipped.
+  private func foldPayees(
+    _ transactions: [InsightTransaction],
+    context: InsightContext
+  ) -> [PayeeSummary] {
+    struct Key: Hashable {
+      let payee: String
+      let isExpense: Bool
+    }
+    var groups: [Key: [InsightTransaction]] = [:]
+    for transaction in transactions where !transaction.normalizedPayee.isEmpty {
+      let key = Key(payee: transaction.normalizedPayee, isExpense: transaction.isExpense)
+      groups[key, default: []].append(transaction)
+    }
+    return
+      groups
+      .map { key, legs in
+        payeeSummary(payee: key.payee, isExpense: key.isExpense, legs: legs, context: context)
+      }
+      .sorted { $0.normalizedPayee < $1.normalizedPayee }
+  }
+
+  /// Build one `PayeeSummary` from a payee's projected legs.
+  private func payeeSummary(
+    payee: String,
+    isExpense: Bool,
+    legs: [InsightTransaction],
+    context: InsightContext
+  ) -> PayeeSummary {
+    let ascending = legs.sorted { $0.date < $1.date }
+    let currency = context.reportingCurrency
+    var total = context.zero
+    var occurrences: [PayeeOccurrence] = []
+    occurrences.reserveCapacity(ascending.count)
+    for leg in ascending {
+      let amount = InstrumentAmount(quantity: leg.amount, instrument: currency)
+      total += amount
+      occurrences.append(
+        PayeeOccurrence(
+          date: leg.date,
+          amount: amount,
+          categoryId: leg.categoryId,
+          accountId: leg.accountId))
+    }
+    return PayeeSummary(
+      normalizedPayee: payee,
+      displayPayee: Self.representativePayee(in: ascending, fallback: payee),
+      isExpense: isExpense,
+      occurrenceCount: ascending.count,
+      firstSeen: ascending.first?.date ?? context.now,
+      lastSeen: ascending.last?.date ?? context.now,
+      windowedTotal: total,
+      occurrences: occurrences)
+  }
+
+  /// The most frequent raw payee spelling in the group, for narration;
+  /// falls back to the normalized key when no raw payee is present.
+  private static func representativePayee(
+    in legs: [InsightTransaction], fallback: String
+  ) -> String {
+    var counts: [String: Int] = [:]
+    for case let raw? in legs.map(\.rawPayee) where !raw.isEmpty {
+      counts[raw, default: 0] += 1
+    }
+    return counts.max { $0.value < $1.value }?.key ?? fallback
+  }
+}

--- a/Backends/GRDB/Repositories/GRDBInsightDataSource+RecentCandidates.swift
+++ b/Backends/GRDB/Repositories/GRDBInsightDataSource+RecentCandidates.swift
@@ -1,0 +1,173 @@
+import Foundation
+import GRDB
+
+/// The bounded recent-candidate projection (the only place insights
+/// materialise individual rows for display) and the `assemble` bundler.
+///
+/// The window is small by construction (`recentCandidateDays`, ~30 days),
+/// so this is `O(window)` regardless of total history. These are the rows
+/// the detectors that must cite a specific `transactionId` read.
+extension GRDBInsightDataSource {
+  /// One projected income / expense leg in the recent window.
+  struct CandidateRow: Sendable {
+    let transactionId: UUID
+    let date: Date
+    let day: String
+    let payee: String?
+    let qty: Int64
+    let categoryId: UUID?
+    let accountId: UUID?
+    let instrumentId: String
+    let type: String
+  }
+
+  func recentCandidates(
+    windowDays: Int,
+    categories: Categories,
+    context: InsightContext
+  ) async throws -> [InsightTransaction] {
+    try await recentCandidatesWithDrops(
+      windowDays: windowDays, categories: categories, context: context
+    ).items
+  }
+
+  /// Drop-aware variant: also reports how many legs were dropped because
+  /// their conversion failed, so `assemble` can surface a "data
+  /// incomplete" signal.
+  func recentCandidatesWithDrops(
+    windowDays: Int,
+    categories: Categories,
+    context: InsightContext
+  ) async throws -> (items: [InsightTransaction], dropped: Int) {
+    let after = cutoff(windowDays: windowDays, context: context)
+    let instruments = try await resolveInstruments()
+    let rows = try await profileDatabase.read { database -> [CandidateRow] in
+      let sql = """
+        SELECT t.id              AS txn_id,
+               t.date            AS txn_date,
+               DATE(t.date)      AS day,
+               t.payee           AS payee,
+               leg.quantity      AS quantity,
+               leg.category_id   AS category_id,
+               leg.account_id    AS account_id,
+               leg.instrument_id AS instrument_id,
+               leg.type          AS type
+        FROM transaction_leg leg
+        JOIN "transaction"    t ON leg.transaction_id = t.id
+        WHERE t.recur_period IS NULL
+          AND leg.type IN ('income', 'expense')
+          AND (:after IS NULL OR t.date >= :after)
+        ORDER BY t.date DESC
+        """
+      let arguments: StatementArguments = ["after": after]
+      return try Row.fetchAll(database, sql: sql, arguments: arguments)
+        .compactMap(Self.decodeCandidateRow(_:))
+    }
+    return try await projectCandidates(rows, instruments: instruments, categories: categories)
+  }
+
+  private static func decodeCandidateRow(_ row: Row) -> CandidateRow? {
+    guard let transactionId: UUID = row["txn_id"],
+      let date: Date = row["txn_date"],
+      let day: String = row["day"],
+      let instrumentId: String = row["instrument_id"],
+      let type: String = row["type"]
+    else { return nil }
+    return CandidateRow(
+      transactionId: transactionId,
+      date: date,
+      day: day,
+      payee: row["payee"],
+      qty: row["quantity"] ?? 0,
+      categoryId: row["category_id"],
+      accountId: row["account_id"],
+      instrumentId: instrumentId,
+      type: type)
+  }
+
+  /// Convert each projected leg on its own day into an `InsightTransaction`
+  /// in the reporting currency. A leg whose conversion fails is dropped
+  /// (Rule 11) and counted — never guessed; the sign is preserved.
+  private func projectCandidates(
+    _ rows: [CandidateRow],
+    instruments: [String: Instrument],
+    categories: Categories
+  ) async throws -> (items: [InsightTransaction], dropped: Int) {
+    var items: [InsightTransaction] = []
+    var dropped = 0
+    for row in rows {
+      guard let day = GRDBAnalysisRepository.parseDayString(row.day),
+        let type = TransactionType(rawValue: row.type)
+      else {
+        log.error("recentCandidates: unparseable row day='\(row.day, privacy: .public)'")
+        continue
+      }
+      let source = instrument(forId: row.instrumentId, in: instruments)
+      let amount: InstrumentAmount
+      do {
+        amount = try await GRDBAnalysisRepository.convertedQuantity(
+          storageValue: row.qty,
+          instrument: source,
+          to: profileInstrument,
+          on: day,
+          conversionService: converter)
+      } catch let cancel as CancellationError {
+        throw cancel
+      } catch {
+        dropped += 1
+        log.warning(
+          """
+          recentCandidates: dropping leg txn=\(row.transactionId, privacy: .public) \
+          instrument=\(row.instrumentId, privacy: .public) — conversion failed: \
+          \(error.localizedDescription, privacy: .public)
+          """)
+        continue
+      }
+      let path = row.categoryId
+        .flatMap { categories.by(id: $0) }
+        .map { categories.path(for: $0) }
+      items.append(
+        InsightTransaction(
+          id: row.transactionId,
+          date: row.date,
+          rawPayee: row.payee,
+          normalizedPayee: PayeeNormalizer.normalize(row.payee),
+          amount: amount.quantity,
+          categoryId: row.categoryId,
+          categoryPath: path,
+          type: type,
+          accountId: row.accountId))
+    }
+    return (items, dropped)
+  }
+
+  // MARK: - assemble
+
+  func assemble(
+    window: InsightDataWindow,
+    categories: Categories,
+    context: InsightContext
+  ) async throws -> InsightDataSummary {
+    let daily = try await dailyTotals(context: context)
+    let categorySpendSummaries = try await categorySpend(
+      windowDays: window.categorySpendDays, categories: categories, context: context)
+    let accountSpendSummaries = try await accountSpend(
+      windowDays: window.accountSpendDays, context: context)
+    let payeeResult = try await payeeSummariesWithDrops(
+      windowDays: window.payeeCadenceDays, context: context)
+    let samples = try await categorySamples(
+      windowDays: window.sampleDays,
+      maxPerCategory: window.maxSamplesPerCategory,
+      context: context)
+    let candidates = try await recentCandidatesWithDrops(
+      windowDays: window.recentCandidateDays, categories: categories, context: context)
+    return InsightDataSummary(
+      dailyTotals: daily,
+      categorySpend: categorySpendSummaries,
+      accountSpend: accountSpendSummaries,
+      payees: payeeResult.payees,
+      categorySamples: samples,
+      recentCandidates: candidates.items,
+      droppedLegCount: payeeResult.dropped + candidates.dropped)
+  }
+}

--- a/Backends/GRDB/Repositories/GRDBInsightDataSource+Samples.swift
+++ b/Backends/GRDB/Repositories/GRDBInsightDataSource+Samples.swift
@@ -1,0 +1,110 @@
+import Foundation
+import GRDB
+
+/// Per-category recent expense-magnitude samples — the baseline
+/// distribution the large-transaction MAD detector scores a recent
+/// candidate against. A SQLite window function caps the projection at
+/// `maxPerCategory` rows per category, so memory stays
+/// `O(categories × cap)` rather than scaling with the window's leg count.
+extension GRDBInsightDataSource {
+  /// One sampled expense leg: the day it posted, its instrument, and the
+  /// raw signed quantity (converted in Swift).
+  struct SampleRow: Sendable {
+    let categoryId: UUID?
+    let day: String
+    let instrumentId: String
+    let qty: Int64
+  }
+
+  func categorySamples(
+    windowDays: Int,
+    maxPerCategory: Int,
+    context: InsightContext
+  ) async throws -> [CategorySpendSamples] {
+    let after = cutoff(windowDays: windowDays, context: context)
+    let instruments = try await resolveInstruments()
+    let cap = max(1, maxPerCategory)
+    let rows = try await profileDatabase.read { database -> [SampleRow] in
+      // `:after` / `:cap` are bound parameters; the SQL is a compile-time
+      // string literal — safe per `guides/DATABASE_CODE_GUIDE.md` §4. The
+      // `ROW_NUMBER()` window caps each category's sample set in SQL.
+      let sql = """
+        SELECT category_id, day, instrument_id, quantity
+        FROM (
+          SELECT leg.category_id    AS category_id,
+                 DATE(t.date)       AS day,
+                 leg.instrument_id  AS instrument_id,
+                 leg.quantity       AS quantity,
+                 ROW_NUMBER() OVER (
+                   PARTITION BY leg.category_id
+                   ORDER BY t.date DESC, leg.transaction_id DESC
+                 ) AS rn
+          FROM transaction_leg leg
+          JOIN "transaction"    t ON leg.transaction_id = t.id
+          WHERE t.recur_period IS NULL
+            AND leg.type = 'expense'
+            AND leg.category_id IS NOT NULL
+            AND (:after IS NULL OR t.date >= :after)
+        )
+        WHERE rn <= :cap
+        ORDER BY category_id ASC, rn ASC
+        """
+      let arguments: StatementArguments = ["after": after, "cap": cap]
+      return try Row.fetchAll(database, sql: sql, arguments: arguments)
+        .compactMap(Self.decodeSampleRow(_:))
+    }
+    return try await foldSamples(rows, instruments: instruments, context: context)
+  }
+
+  private static func decodeSampleRow(_ row: Row) -> SampleRow? {
+    guard let day: String = row["day"],
+      let instrumentId: String = row["instrument_id"]
+    else { return nil }
+    return SampleRow(
+      categoryId: row["category_id"],
+      day: day,
+      instrumentId: instrumentId,
+      qty: row["quantity"] ?? 0)
+  }
+
+  /// Convert each sampled leg on its own day and group the positive spend
+  /// magnitudes per category, preserving the SQL's most-recent-first order.
+  /// A leg whose conversion fails is dropped from the baseline and logged
+  /// (Rule 11) — a thinner sample, never a guessed one.
+  private func foldSamples(
+    _ rows: [SampleRow],
+    instruments: [String: Instrument],
+    context: InsightContext
+  ) async throws -> [CategorySpendSamples] {
+    var magnitudes: [UUID?: [Decimal]] = [:]
+    var order: [UUID?] = []
+    for row in rows {
+      guard let day = GRDBAnalysisRepository.parseDayString(row.day) else {
+        log.error("categorySamples: unparseable day '\(row.day, privacy: .public)'")
+        continue
+      }
+      let source = instrument(forId: row.instrumentId, in: instruments)
+      do {
+        let amount = try await GRDBAnalysisRepository.convertedQuantity(
+          storageValue: row.qty,
+          instrument: source,
+          to: profileInstrument,
+          on: day,
+          conversionService: converter)
+        let magnitude = amount.quantity < 0 ? -amount.quantity : 0
+        if magnitudes[row.categoryId] == nil { order.append(row.categoryId) }
+        magnitudes[row.categoryId, default: []].append(magnitude)
+      } catch let cancel as CancellationError {
+        throw cancel
+      } catch {
+        log.warning(
+          """
+          categorySamples: dropping sample day=\(row.day, privacy: .public) \
+          instrument=\(row.instrumentId, privacy: .public) — conversion failed: \
+          \(error.localizedDescription, privacy: .public)
+          """)
+      }
+    }
+    return order.map { CategorySpendSamples(categoryId: $0, magnitudes: magnitudes[$0] ?? []) }
+  }
+}

--- a/Backends/GRDB/Repositories/GRDBInsightDataSource.swift
+++ b/Backends/GRDB/Repositories/GRDBInsightDataSource.swift
@@ -1,0 +1,181 @@
+import Foundation
+import GRDB
+import OSLog
+
+/// GRDB-backed `InsightDataSource`. Produces the pre-aggregated insight
+/// summaries + a bounded recent-candidate window directly from
+/// `data.sqlite`, never materialising the full transaction history.
+///
+/// Each method drives a SQL `GROUP BY` (or a bounded, capped projection)
+/// and converts the summed / projected rows to the profile instrument on
+/// each row's own `(day, instrument)` bucket — reusing
+/// `GRDBAnalysisRepository.convertedQuantity` / `.parseDayString` so the
+/// per-day rate-cache equivalence required by
+/// `guides/INSTRUMENT_CONVERSION_GUIDE.md` Rule 5 is preserved and a
+/// single-currency profile pays ~nothing.
+///
+/// **Concurrency.** `final class` + `@unchecked Sendable`, mirroring
+/// `GRDBAnalysisRepository`: all stored properties are `let`, `database`
+/// and `conversionService` are `Sendable`, and `logger` is a `Sendable`
+/// value type. Nothing mutates post-init.
+final class GRDBInsightDataSource: InsightDataSource, @unchecked Sendable {
+  // Cross-extension internals. Sibling files reach these `internal`
+  // members rather than the `private` storage:
+  //   `+CategorySpend.swift` — categorySpend / accountSpend / categorySamples
+  //   `+Payees.swift`        — payeeSummaries + the normalize-and-fold
+  //   `+RecentCandidates.swift` — recentCandidates + assemble
+  // The day-parse and `(qty, instrument) → InstrumentAmount` conversion
+  // helpers are shared from `GRDBAnalysisRepository` (same module).
+  private let database: any DatabaseWriter
+  private let instrument: Instrument
+  private let conversionService: any InstrumentConversionService
+  /// Resolves the canonical instrument lookup table. Fetched once per
+  /// method *before* the per-profile read snapshot opens — the registry
+  /// lives on a separate database, so it cannot be joined into the
+  /// snapshot. Mirrors `GRDBAnalysisRepository`.
+  private let instrumentResolver: any InstrumentMapResolving
+  private let logger = Logger(
+    subsystem: "com.moolah.app", category: "GRDBInsightDataSource")
+
+  init(
+    database: any DatabaseWriter,
+    instrument: Instrument,
+    conversionService: any InstrumentConversionService,
+    instrumentResolver: any InstrumentMapResolving
+  ) {
+    self.database = database
+    self.instrument = instrument
+    self.conversionService = conversionService
+    self.instrumentResolver = instrumentResolver
+  }
+
+  // MARK: - Shared access for sibling extensions
+
+  /// The profile (reporting) instrument every summary is reduced to.
+  var profileInstrument: Instrument { instrument }
+
+  /// The conversion service, exposed for the projecting sibling methods.
+  var converter: any InstrumentConversionService { conversionService }
+
+  /// The shared diagnostics logger, exposed for sibling methods.
+  var log: Logger { logger }
+
+  /// Resolve the instrument lookup table outside any read snapshot.
+  func resolveInstruments() async throws -> [String: Instrument] {
+    try await instrumentResolver.instrumentMap()
+  }
+
+  /// The per-profile database, exposed so sibling extensions can open a
+  /// read snapshot without reaching into `private` storage.
+  var profileDatabase: any DatabaseWriter { database }
+
+  /// The inclusive lower bound for a trailing window of `windowDays`,
+  /// computed from the injected `context.now` so summaries stay
+  /// deterministic in tests.
+  func cutoff(windowDays: Int, context: InsightContext) -> Date? {
+    context.calendar.date(byAdding: .day, value: -windowDays, to: context.now)
+  }
+
+  /// Resolve a SQL `instrument_id` to an `Instrument`, falling back to a
+  /// fiat registration for ids absent from the canonical map — the same
+  /// fallback `GRDBAnalysisRepository` uses.
+  func instrument(
+    forId id: String, in map: [String: Instrument]
+  ) -> Instrument {
+    map[id] ?? Instrument.fiat(code: id)
+  }
+
+  // MARK: - dailyTotals
+
+  /// One `(day, instrument)` bucket of summed income / expense quantities.
+  struct DailyTotalsRow: Sendable {
+    let day: String
+    let instrumentId: String
+    let incomeQty: Int64
+    let expenseQty: Int64
+  }
+
+  func dailyTotals(context: InsightContext) async throws -> [DailySpendSummary] {
+    let instruments = try await resolveInstruments()
+    let rows = try await profileDatabase.read { database -> [DailyTotalsRow] in
+      let sql = """
+        SELECT DATE(t.date)      AS day,
+               leg.instrument_id AS instrument_id,
+               SUM(CASE WHEN leg.type = 'income'  THEN leg.quantity ELSE 0 END) AS income_qty,
+               SUM(CASE WHEN leg.type = 'expense' THEN leg.quantity ELSE 0 END) AS expense_qty
+        FROM transaction_leg leg
+        JOIN "transaction"    t ON leg.transaction_id = t.id
+        WHERE t.recur_period IS NULL
+          AND leg.type IN ('income', 'expense')
+        GROUP BY day, leg.instrument_id
+        ORDER BY day ASC
+        """
+      return try Row.fetchAll(database, sql: sql).compactMap { row in
+        guard let day: String = row["day"],
+          let instrumentId: String = row["instrument_id"]
+        else { return nil }
+        return DailyTotalsRow(
+          day: day,
+          instrumentId: instrumentId,
+          incomeQty: row["income_qty"] ?? 0,
+          expenseQty: row["expense_qty"] ?? 0)
+      }
+    }
+    return try await foldDailyTotals(rows, instruments: instruments, context: context)
+  }
+
+  /// Convert each `(day, instrument)` bucket on its own day and fold into
+  /// one `DailySpendSummary` per calendar day. A bucket whose conversion
+  /// fails is skipped (Rule 11) and logged; sibling days still render.
+  private func foldDailyTotals(
+    _ rows: [DailyTotalsRow],
+    instruments: [String: Instrument],
+    context: InsightContext
+  ) async throws -> [DailySpendSummary] {
+    var income: [Date: InstrumentAmount] = [:]
+    var expense: [Date: InstrumentAmount] = [:]
+    let zero = context.zero
+    for row in rows {
+      guard let day = GRDBAnalysisRepository.parseDayString(row.day) else {
+        logger.error("dailyTotals: unparseable day '\(row.day, privacy: .public)'")
+        continue
+      }
+      let source = instrument(forId: row.instrumentId, in: instruments)
+      do {
+        let incomeAmount = try await GRDBAnalysisRepository.convertedQuantity(
+          storageValue: row.incomeQty,
+          instrument: source,
+          to: instrument,
+          on: day,
+          conversionService: conversionService)
+        let expenseAmount = try await GRDBAnalysisRepository.convertedQuantity(
+          storageValue: row.expenseQty,
+          instrument: source,
+          to: instrument,
+          on: day,
+          conversionService: conversionService)
+        income[day] = (income[day] ?? zero) + incomeAmount
+        expense[day] = (expense[day] ?? zero) + expenseAmount
+      } catch let cancel as CancellationError {
+        throw cancel
+      } catch {
+        logger.warning(
+          """
+          dailyTotals: skipping day=\(row.day, privacy: .public) \
+          instrument=\(row.instrumentId, privacy: .public) — conversion failed: \
+          \(error.localizedDescription, privacy: .public)
+          """)
+      }
+    }
+    let days = Set(income.keys).union(expense.keys)
+    return
+      days
+      .map { day in
+        DailySpendSummary(
+          day: day,
+          expense: expense[day] ?? zero,
+          income: income[day] ?? zero)
+      }
+      .sorted { $0.day < $1.day }
+  }
+}

--- a/Domain/Insights/InsightDataSummary.swift
+++ b/Domain/Insights/InsightDataSummary.swift
@@ -1,0 +1,148 @@
+import Foundation
+
+/// Pre-aggregated, currency-normalised summaries plus a bounded
+/// recent-candidate row window assembled by an `InsightDataSource`.
+///
+/// This is the SQL-backed alternative to loading the entire transaction
+/// history into memory and converting every leg on each refresh. Every
+/// field is `O(payees + categories + days + recent window)` — independent
+/// of the *total* transaction count, so a profile with ten years of data
+/// pays the same as one with one. See
+/// `plans/2026-06-01-insights-integration-plan.md` §"Phase A".
+///
+/// Every monetary value is already reduced to `context.reportingCurrency`
+/// via a per-`(day, instrument)` conversion (mirroring
+/// `GRDBAnalysisRepository`); a leg whose conversion fails is dropped and
+/// counted in `droppedLegCount` rather than guessed
+/// (`guides/INSTRUMENT_CONVERSION_GUIDE.md` Rule 11).
+struct InsightDataSummary: Sendable {
+  /// Per-UTC-calendar-day income / expense totals over all history. Drives
+  /// the unusual-day and weekend-skew detectors. `O(active days)`.
+  let dailyTotals: [DailySpendSummary]
+
+  /// Per-category expense totals over a trailing window. Drives fee-spend
+  /// and unbudgeted-category. `O(categories)`.
+  let categorySpend: [CategorySpendSummary]
+
+  /// Per-account expense totals over a trailing window. Drives
+  /// group-spend-concentration once mapped through the membership map.
+  /// `O(accounts)`.
+  let accountSpend: [AccountSpendSummary]
+
+  /// Per-normalized-payee cadence and totals over the bounded cadence
+  /// window. Drives new-merchant, lapsed-merchant, and subscription
+  /// detection. `O(payees + windowed occurrences)`.
+  let payees: [PayeeSummary]
+
+  /// Per-category recent expense-magnitude samples for the
+  /// large-transaction MAD baseline. `O(categories × cap)`.
+  let categorySamples: [CategorySpendSamples]
+
+  /// Bounded recent-candidate window of projected legs, for detectors that
+  /// must cite a specific `transactionId` (large-tx, windfall,
+  /// new-merchant). `O(recent window)`.
+  let recentCandidates: [InsightTransaction]
+
+  /// Count of legs dropped because their currency conversion failed
+  /// (Rule 11). A future "data incomplete" signal — never silently guessed.
+  let droppedLegCount: Int
+
+  init(
+    dailyTotals: [DailySpendSummary] = [],
+    categorySpend: [CategorySpendSummary] = [],
+    accountSpend: [AccountSpendSummary] = [],
+    payees: [PayeeSummary] = [],
+    categorySamples: [CategorySpendSamples] = [],
+    recentCandidates: [InsightTransaction] = [],
+    droppedLegCount: Int = 0
+  ) {
+    self.dailyTotals = dailyTotals
+    self.categorySpend = categorySpend
+    self.accountSpend = accountSpend
+    self.payees = payees
+    self.categorySamples = categorySamples
+    self.recentCandidates = recentCandidates
+    self.droppedLegCount = droppedLegCount
+  }
+}
+
+/// Income and expense totals for one UTC calendar day, reporting currency.
+///
+/// `expense` is the signed sum of the day's expense legs (negative for net
+/// spend, but a net-refund day can be positive); `income` is the signed
+/// sum of income legs. Detectors read `spendMagnitude` / `incomeMagnitude`
+/// rather than `abs()`-ing, preserving the sign convention.
+struct DailySpendSummary: Sendable, Hashable {
+  let day: Date
+  let expense: InstrumentAmount
+  let income: InstrumentAmount
+
+  /// Positive magnitude of money that left the account on this day, or `0`
+  /// for a net-refund day.
+  var spendMagnitude: Decimal {
+    expense.quantity < 0 ? -expense.quantity : 0
+  }
+
+  /// Positive magnitude of money received on this day, or `0`.
+  var incomeMagnitude: Decimal {
+    income.quantity > 0 ? income.quantity : 0
+  }
+}
+
+/// Trailing-window expense total for one category, reporting currency.
+struct CategorySpendSummary: Sendable, Hashable {
+  let categoryId: UUID?
+  let categoryPath: String?
+  /// Signed expense total over the window (negative for net spend).
+  let total: InstrumentAmount
+  /// Number of expense legs contributing to `total`.
+  let legCount: Int
+}
+
+/// Trailing-window expense total for one account, reporting currency.
+struct AccountSpendSummary: Sendable, Hashable {
+  let accountId: UUID?
+  /// Signed expense total over the window (negative for net spend).
+  let total: InstrumentAmount
+  let legCount: Int
+}
+
+/// A bounded sample of recent expense magnitudes for one category, the
+/// baseline distribution the large-transaction MAD detector scores against.
+struct CategorySpendSamples: Sendable, Hashable {
+  let categoryId: UUID?
+  /// Positive spend magnitudes in the reporting currency, most-recent
+  /// first, capped per category.
+  let magnitudes: [Decimal]
+}
+
+/// Cadence and totals for one normalized payee within the bounded cadence
+/// window, the workhorse input for the merchant and subscription detectors.
+struct PayeeSummary: Sendable, Hashable {
+  let normalizedPayee: String
+  /// A representative raw payee for narration (the most frequent raw
+  /// spelling that normalized to `normalizedPayee`).
+  let displayPayee: String
+  /// `true` for an expense payee, `false` for an income stream. A payee
+  /// that appears on both sides yields two summaries.
+  let isExpense: Bool
+  /// Occurrence count within the cadence window.
+  let occurrenceCount: Int
+  /// First / last occurrence date within the cadence window.
+  let firstSeen: Date
+  let lastSeen: Date
+  /// Signed total over the cadence window, reporting currency.
+  let windowedTotal: InstrumentAmount
+  /// Projected occurrences within the cadence window, ascending by date —
+  /// the per-occurrence detail cadence and amount-variability analysis read.
+  let occurrences: [PayeeOccurrence]
+}
+
+/// One projected occurrence of a payee, reporting currency.
+struct PayeeOccurrence: Sendable, Hashable {
+  let date: Date
+  /// Signed amount, reporting currency (income positive, expense negative).
+  let amount: InstrumentAmount
+  let categoryId: UUID?
+  let accountId: UUID?
+}

--- a/Domain/Repositories/BackendProvider.swift
+++ b/Domain/Repositories/BackendProvider.swift
@@ -11,6 +11,10 @@ protocol BackendProvider: Sendable {
   var transferSuggestions: any TransferSuggestionRepository { get }
   var earmarks: any EarmarkRepository { get }
   var analysis: any AnalysisRepository { get }
+  /// SQL-backed assembler of the pre-aggregated insight summaries + bounded
+  /// recent-candidate window the deterministic `InsightEngine` consumes.
+  /// Built from the same per-profile database as `analysis`.
+  var insightDataSource: any InsightDataSource { get }
   var investments: any InvestmentRepository { get }
   var conversionService: any InstrumentConversionService { get }
   var csvImportProfiles: any CSVImportProfileRepository { get }

--- a/Domain/Repositories/InsightDataSource.swift
+++ b/Domain/Repositories/InsightDataSource.swift
@@ -1,0 +1,103 @@
+import Foundation
+
+/// Window sizes (in days) and sample caps the insight summaries are
+/// assembled with. Defaults mirror the thresholds the deterministic
+/// detectors use so `assemble(window:categories:context:)` produces a
+/// summary every raw-row detector can read.
+struct InsightDataWindow: Sendable {
+  /// Recent-candidate projection window — the detectors that cite a
+  /// specific `transactionId` (large-tx, windfall, new-merchant) look back
+  /// at most this far.
+  var recentCandidateDays: Int
+  /// Per-category spend-sum window (fee-spend looks back a year).
+  var categorySpendDays: Int
+  /// Per-account spend-sum window (group concentration is a recent skew).
+  var accountSpendDays: Int
+  /// Per-payee cadence window — ~13 months so an annual subscription still
+  /// shows two occurrences.
+  var payeeCadenceDays: Int
+  /// MAD-baseline sample window and per-category cap.
+  var sampleDays: Int
+  var maxSamplesPerCategory: Int
+
+  init(
+    recentCandidateDays: Int = 30,
+    categorySpendDays: Int = 365,
+    accountSpendDays: Int = 30,
+    payeeCadenceDays: Int = 395,
+    sampleDays: Int = 365,
+    maxSamplesPerCategory: Int = 200
+  ) {
+    self.recentCandidateDays = recentCandidateDays
+    self.categorySpendDays = categorySpendDays
+    self.accountSpendDays = accountSpendDays
+    self.payeeCadenceDays = payeeCadenceDays
+    self.sampleDays = sampleDays
+    self.maxSamplesPerCategory = maxSamplesPerCategory
+  }
+}
+
+/// Produces the pre-aggregated `InsightDataSummary` an `InsightEngine`
+/// needs without ever materialising the full transaction history.
+///
+/// Every method drives a SQL aggregation (or a bounded projection) and
+/// converts the result to `context.reportingCurrency` on each row's own
+/// `(day, instrument)` bucket — the same shape as `AnalysisRepository`.
+/// Memory stays `O(payees + categories + days + window)`, independent of
+/// total transaction count. See
+/// `plans/2026-06-01-insights-integration-plan.md` §"Phase A".
+///
+/// A leg whose conversion fails is dropped, never guessed
+/// (`guides/INSTRUMENT_CONVERSION_GUIDE.md` Rule 11); the projection
+/// methods surface the count through `InsightDataSummary.droppedLegCount`.
+protocol InsightDataSource: Sendable {
+  /// Per-UTC-day income / expense totals over all history. `O(active days)`.
+  func dailyTotals(context: InsightContext) async throws -> [DailySpendSummary]
+
+  /// Per-category expense totals over the trailing `windowDays`.
+  /// `O(categories)`.
+  func categorySpend(
+    windowDays: Int,
+    categories: Categories,
+    context: InsightContext
+  ) async throws -> [CategorySpendSummary]
+
+  /// Per-account expense totals over the trailing `windowDays`.
+  /// `O(accounts)`.
+  func accountSpend(
+    windowDays: Int,
+    context: InsightContext
+  ) async throws -> [AccountSpendSummary]
+
+  /// Per-normalized-payee cadence + totals over the trailing `windowDays`.
+  /// `O(payees + windowed occurrences)`.
+  func payeeSummaries(
+    windowDays: Int,
+    context: InsightContext
+  ) async throws -> [PayeeSummary]
+
+  /// Per-category recent expense-magnitude samples (most-recent first,
+  /// capped at `maxPerCategory`) for the MAD baseline.
+  /// `O(categories × cap)`.
+  func categorySamples(
+    windowDays: Int,
+    maxPerCategory: Int,
+    context: InsightContext
+  ) async throws -> [CategorySpendSamples]
+
+  /// Bounded recent-candidate window of projected legs over the trailing
+  /// `windowDays`, already in the reporting currency. `O(window)`.
+  func recentCandidates(
+    windowDays: Int,
+    categories: Categories,
+    context: InsightContext
+  ) async throws -> [InsightTransaction]
+
+  /// Assemble every summary into one `InsightDataSummary` with the given
+  /// window configuration.
+  func assemble(
+    window: InsightDataWindow,
+    categories: Categories,
+    context: InsightContext
+  ) async throws -> InsightDataSummary
+}

--- a/MoolahTests/Backends/GRDB/GRDBInsightDataSourceScalingTests.swift
+++ b/MoolahTests/Backends/GRDB/GRDBInsightDataSourceScalingTests.swift
@@ -1,0 +1,71 @@
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+/// Pins the central promise of the SQL-backed `InsightDataSource`: summary
+/// size scales with the number of distinct dimensions (days, payees,
+/// categories) and the bounded windows — **never** with the total
+/// transaction count. A profile with years of data must pay no more than a
+/// small one. Exit criterion of issue #1031.
+@Suite("GRDBInsightDataSource scaling")
+struct GRDBInsightDataSourceScalingTests {
+  private let aud = Instrument.defaultTestInstrument
+
+  private var utcCalendar: Calendar {
+    var calendar = Calendar(identifier: .gregorian)
+    calendar.timeZone = TimeZone(identifier: "UTC") ?? calendar.timeZone
+    return calendar
+  }
+
+  @Test("summaries stay bounded as the transaction count grows")
+  func summariesDoNotScaleWithTransactionCount() async throws {
+    let backend = try CloudKitAnalysisTestBackend()
+    let calendar = utcCalendar
+    let now = try AnalysisTestHelpers.utcDate(year: 2026, month: 6, day: 30)
+    let context = InsightContext(now: now, reportingCurrency: aud)
+    let dining = Category(name: "Dining")
+
+    // 40 distinct days × 6 legs/day = 240 transactions, one payee, one
+    // category — deliberately many rows over few dimensions.
+    let days = 40
+    let perDay = 6
+    for dayOffset in 0..<days {
+      let date = try #require(calendar.date(byAdding: .day, value: -dayOffset, to: now))
+      for _ in 0..<perDay {
+        _ = try await backend.transactions.create(
+          Transaction(
+            date: date, payee: "Netflix",
+            legs: [
+              TransactionLeg(
+                accountId: nil, instrument: aud, quantity: -15, type: .expense,
+                categoryId: dining.id)
+            ]))
+      }
+    }
+    let total = days * perDay
+
+    let dailyTotals = try await backend.insightDataSource.dailyTotals(context: context)
+    let payees = try await backend.insightDataSource.payeeSummaries(
+      windowDays: 395, context: context)
+    let samples = try await backend.insightDataSource.categorySamples(
+      windowDays: 365, maxPerCategory: 100, context: context)
+    let recent = try await backend.insightDataSource.recentCandidates(
+      windowDays: 30, categories: Categories(from: [dining]), context: context)
+
+    // O(days), not O(transactions).
+    #expect(dailyTotals.count == days)
+    // O(payees) — one normalized payee regardless of the 240 legs.
+    #expect(payees.count == 1)
+    // O(cap) — the MAD baseline never materialises more than the cap.
+    let diningSamples = try #require(samples.first { $0.categoryId == dining.id })
+    #expect(diningSamples.magnitudes.count == 100)
+    #expect(diningSamples.magnitudes.count < total)
+    // O(window) — the recent projection covers only the trailing window,
+    // never the full history.
+    let cutoff = try #require(calendar.date(byAdding: .day, value: -30, to: now))
+    #expect(recent.count < total)
+    #expect(recent.allSatisfy { $0.date >= cutoff })
+  }
+}

--- a/MoolahTests/Backends/GRDB/GRDBInsightDataSourceTests.swift
+++ b/MoolahTests/Backends/GRDB/GRDBInsightDataSourceTests.swift
@@ -1,0 +1,245 @@
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+/// Contract tests for `GRDBInsightDataSource` against a seeded
+/// `TestBackend` (a real `CloudKitBackend` on an in-memory GRDB queue).
+///
+/// These pin the summaries the SQL aggregations produce — per-day totals,
+/// per-category / per-account windowed sums, per-payee cadence, MAD-baseline
+/// samples, and the bounded recent-candidate window — plus the Rule 11
+/// conversion-drop path. Scaling (memory independence) lives in
+/// `GRDBInsightDataSourceScalingTests`; query-plan pinning in
+/// `InsightDataSourcePlanPinningTests`.
+@Suite("GRDBInsightDataSource summaries")
+struct GRDBInsightDataSourceTests {
+  private let aud = Instrument.defaultTestInstrument
+
+  private func context(now: Date) -> InsightContext {
+    InsightContext(now: now, reportingCurrency: aud)
+  }
+
+  /// Build an account-less expense (negative) or income (positive) leg —
+  /// account-less legs still count toward the insight summaries, matching
+  /// `InsightTransaction.records`.
+  private func leg(
+    _ quantity: Decimal,
+    type: TransactionType,
+    instrument: Instrument,
+    accountId: UUID? = nil,
+    categoryId: UUID? = nil
+  ) -> TransactionLeg {
+    TransactionLeg(
+      accountId: accountId, instrument: instrument, quantity: quantity,
+      type: type, categoryId: categoryId)
+  }
+
+  // MARK: - dailyTotals
+
+  @Test("dailyTotals sums income and expense per UTC day")
+  func dailyTotalsPerDay() async throws {
+    let backend = try CloudKitAnalysisTestBackend()
+    let dayOne = try AnalysisTestHelpers.utcDate(year: 2026, month: 6, day: 10)
+    let dayTwo = try AnalysisTestHelpers.utcDate(year: 2026, month: 6, day: 11)
+    _ = try await backend.transactions.create(
+      Transaction(date: dayOne, payee: "A", legs: [leg(-50, type: .expense, instrument: aud)]))
+    _ = try await backend.transactions.create(
+      Transaction(date: dayOne, payee: "B", legs: [leg(120, type: .income, instrument: aud)]))
+    _ = try await backend.transactions.create(
+      Transaction(date: dayTwo, payee: "C", legs: [leg(-30, type: .expense, instrument: aud)]))
+
+    let totals = try await backend.insightDataSource.dailyTotals(
+      context: context(now: try AnalysisTestHelpers.utcDate(year: 2026, month: 6, day: 15)))
+
+    #expect(totals.count == 2)
+    let first = try #require(totals.first)
+    #expect(first.spendMagnitude == 50)
+    #expect(first.incomeMagnitude == 120)
+    let second = try #require(totals.last)
+    #expect(second.spendMagnitude == 30)
+    #expect(second.incomeMagnitude == 0)
+  }
+
+  @Test("dailyTotals converts each day's foreign legs at that day's rate")
+  func dailyTotalsConvertsPerDay() async throws {
+    let dayOne = try AnalysisTestHelpers.utcDate(year: 2026, month: 6, day: 10)
+    let dayTwo = try AnalysisTestHelpers.utcDate(year: 2026, month: 6, day: 11)
+    let conversion = DateBasedFixedConversionService(
+      rates: [
+        try AnalysisTestHelpers.utcDate(year: 2026, month: 6, day: 10, hour: 0): ["USD": 1.5],
+        try AnalysisTestHelpers.utcDate(year: 2026, month: 6, day: 11, hour: 0): ["USD": 2.0],
+      ])
+    let backend = try CloudKitAnalysisTestBackend(conversionService: conversion)
+    let usd = Instrument.fiat(code: "USD")
+    _ = try await backend.transactions.create(
+      Transaction(date: dayOne, payee: "A", legs: [leg(-100, type: .expense, instrument: usd)]))
+    _ = try await backend.transactions.create(
+      Transaction(date: dayTwo, payee: "B", legs: [leg(-100, type: .expense, instrument: usd)]))
+
+    let totals = try await backend.insightDataSource.dailyTotals(
+      context: context(now: try AnalysisTestHelpers.utcDate(year: 2026, month: 6, day: 15)))
+
+    #expect(try #require(totals.first).spendMagnitude == 150)
+    #expect(try #require(totals.last).spendMagnitude == 200)
+  }
+
+  // MARK: - categorySpend / accountSpend
+
+  @Test("categorySpend sums expenses per category inside the window")
+  func categorySpendWindowed() async throws {
+    let backend = try CloudKitAnalysisTestBackend()
+    let now = try AnalysisTestHelpers.utcDate(year: 2026, month: 6, day: 15)
+    let groceries = Category(name: "Groceries")
+    let inWindow = try AnalysisTestHelpers.utcDate(year: 2026, month: 6, day: 1)
+    let outWindow = try AnalysisTestHelpers.utcDate(year: 2026, month: 1, day: 1)
+    _ = try await backend.transactions.create(
+      Transaction(
+        date: inWindow, payee: "Shop",
+        legs: [leg(-40, type: .expense, instrument: aud, categoryId: groceries.id)]))
+    _ = try await backend.transactions.create(
+      Transaction(
+        date: outWindow, payee: "Shop",
+        legs: [leg(-999, type: .expense, instrument: aud, categoryId: groceries.id)]))
+
+    let spend = try await backend.insightDataSource.categorySpend(
+      windowDays: 30, categories: Categories(from: [groceries]), context: context(now: now))
+
+    #expect(spend.count == 1)
+    let entry = try #require(spend.first)
+    #expect(entry.categoryId == groceries.id)
+    #expect(entry.categoryPath == "Groceries")
+    #expect(entry.total.quantity == -40)
+    #expect(entry.legCount == 1)
+  }
+
+  @Test("accountSpend sums expenses per account inside the window")
+  func accountSpendWindowed() async throws {
+    let backend = try CloudKitAnalysisTestBackend()
+    let now = try AnalysisTestHelpers.utcDate(year: 2026, month: 6, day: 15)
+    let account = Account(id: UUID(), name: "Checking", type: .bank, instrument: aud)
+    _ = try await backend.accounts.create(account)
+    let day = try AnalysisTestHelpers.utcDate(year: 2026, month: 6, day: 2)
+    _ = try await backend.transactions.create(
+      Transaction(
+        date: day, payee: "Shop",
+        legs: [leg(-25, type: .expense, instrument: aud, accountId: account.id)]))
+
+    let spend = try await backend.insightDataSource.accountSpend(
+      windowDays: 30, context: context(now: now))
+
+    let entry = try #require(spend.first { $0.accountId == account.id })
+    #expect(entry.total.quantity == -25)
+    #expect(entry.legCount == 1)
+  }
+
+  // MARK: - payeeSummaries
+
+  @Test("payeeSummaries clusters by normalized payee with cadence detail")
+  func payeeSummariesCadence() async throws {
+    let backend = try CloudKitAnalysisTestBackend()
+    let now = try AnalysisTestHelpers.utcDate(year: 2026, month: 6, day: 15)
+    let first = try AnalysisTestHelpers.utcDate(year: 2026, month: 4, day: 10)
+    let second = try AnalysisTestHelpers.utcDate(year: 2026, month: 5, day: 10)
+    let third = try AnalysisTestHelpers.utcDate(year: 2026, month: 6, day: 10)
+    for date in [first, second, third] {
+      _ = try await backend.transactions.create(
+        Transaction(date: date, payee: "Netflix", legs: [leg(-15, type: .expense, instrument: aud)])
+      )
+    }
+
+    let payees = try await backend.insightDataSource.payeeSummaries(
+      windowDays: 395, context: context(now: now))
+
+    let netflix = try #require(payees.first { $0.normalizedPayee.contains("netflix") })
+    #expect(netflix.isExpense)
+    #expect(netflix.occurrenceCount == 3)
+    #expect(netflix.firstSeen == first)
+    #expect(netflix.lastSeen == third)
+    #expect(netflix.windowedTotal.quantity == -45)
+    #expect(netflix.occurrences.map(\.date) == [first, second, third])
+    #expect(netflix.displayPayee == "Netflix")
+  }
+
+  // MARK: - categorySamples
+
+  @Test("categorySamples returns recent magnitudes most-recent first")
+  func categorySamplesOrder() async throws {
+    let backend = try CloudKitAnalysisTestBackend()
+    let now = try AnalysisTestHelpers.utcDate(year: 2026, month: 6, day: 15)
+    let dining = Category(name: "Dining")
+    let older = try AnalysisTestHelpers.utcDate(year: 2026, month: 6, day: 1)
+    let newer = try AnalysisTestHelpers.utcDate(year: 2026, month: 6, day: 12)
+    _ = try await backend.transactions.create(
+      Transaction(
+        date: older, payee: "Cafe",
+        legs: [leg(-10, type: .expense, instrument: aud, categoryId: dining.id)]))
+    _ = try await backend.transactions.create(
+      Transaction(
+        date: newer, payee: "Cafe",
+        legs: [leg(-99, type: .expense, instrument: aud, categoryId: dining.id)]))
+
+    let samples = try await backend.insightDataSource.categorySamples(
+      windowDays: 365, maxPerCategory: 50, context: context(now: now))
+
+    let entry = try #require(samples.first { $0.categoryId == dining.id })
+    #expect(entry.magnitudes == [99, 10])
+  }
+
+  // MARK: - recentCandidates
+
+  @Test("recentCandidates projects only legs inside the window, signs preserved")
+  func recentCandidatesWindow() async throws {
+    let backend = try CloudKitAnalysisTestBackend()
+    let now = try AnalysisTestHelpers.utcDate(year: 2026, month: 6, day: 15)
+    let dining = Category(name: "Dining")
+    let recent = try AnalysisTestHelpers.utcDate(year: 2026, month: 6, day: 10)
+    let stale = try AnalysisTestHelpers.utcDate(year: 2026, month: 1, day: 1)
+    _ = try await backend.transactions.create(
+      Transaction(
+        date: recent, payee: "Cafe",
+        legs: [leg(-12, type: .expense, instrument: aud, categoryId: dining.id)]))
+    _ = try await backend.transactions.create(
+      Transaction(date: stale, payee: "Old", legs: [leg(-12, type: .expense, instrument: aud)]))
+
+    let candidates = try await backend.insightDataSource.recentCandidates(
+      windowDays: 30, categories: Categories(from: [dining]), context: context(now: now))
+
+    #expect(candidates.count == 1)
+    let candidate = try #require(candidates.first)
+    #expect(candidate.date == recent)
+    #expect(candidate.amount == -12)
+    #expect(candidate.spendMagnitude == 12)
+    #expect(candidate.type == .expense)
+    #expect(candidate.categoryPath == "Dining")
+    #expect(candidate.normalizedPayee.contains("cafe"))
+  }
+
+  // MARK: - Rule 11 conversion failure
+
+  @Test("a leg whose conversion fails is dropped and counted, siblings survive")
+  func conversionFailureDropsLeg() async throws {
+    let failDay = try AnalysisTestHelpers.utcDate(year: 2026, month: 6, day: 10, hour: 0)
+    let conversion = DateFailingConversionService(rates: [:], failingDates: [failDay])
+    let backend = try CloudKitAnalysisTestBackend(conversionService: conversion)
+    let now = try AnalysisTestHelpers.utcDate(year: 2026, month: 6, day: 15)
+    let usd = Instrument.fiat(code: "USD")
+    let day = try AnalysisTestHelpers.utcDate(year: 2026, month: 6, day: 10, hour: 12)
+    _ = try await backend.transactions.create(
+      Transaction(date: day, payee: "Foreign", legs: [leg(-100, type: .expense, instrument: usd)]))
+    _ = try await backend.transactions.create(
+      Transaction(date: day, payee: "Local", legs: [leg(-20, type: .expense, instrument: aud)]))
+
+    let candidates = try await backend.insightDataSource.recentCandidates(
+      windowDays: 30, categories: Categories(from: []), context: context(now: now))
+    let summary = try await backend.insightDataSource.assemble(
+      window: InsightDataWindow(), categories: Categories(from: []), context: context(now: now))
+
+    // The AUD leg (same instrument, never converted) survives; the USD leg
+    // is dropped rather than guessed, and surfaces in the drop count.
+    #expect(candidates.count == 1)
+    #expect(candidates.first?.amount == -20)
+    #expect(summary.droppedLegCount > 0)
+  }
+}

--- a/MoolahTests/Backends/GRDB/InsightDataSourcePlanPinningTests.swift
+++ b/MoolahTests/Backends/GRDB/InsightDataSourcePlanPinningTests.swift
@@ -1,0 +1,157 @@
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+/// `EXPLAIN QUERY PLAN`-pinning for the `GRDBInsightDataSource`
+/// aggregations. Same methodology as `AnalysisAggregationPlanPinningTests`
+/// (see its header): the perf-critical signal is the bare-SCAN rejection
+/// (`planHasFullTableScanOf`) plus the leg-side index assertion. Temp
+/// B-tree GROUP / ORDER lines are accepted because every aggregation groups
+/// by the derived `day = DATE(t.date)` expression.
+@Suite("InsightDataSource plan-pinning")
+struct InsightDataSourcePlanPinningTests {
+  private func makeDatabase() throws -> DatabaseQueue {
+    try PlanPinningTestHelpers.makeDatabase()
+  }
+
+  private func planDetail(
+    _ database: DatabaseQueue, query: String, arguments: StatementArguments = []
+  ) throws -> String {
+    try PlanPinningTestHelpers.planDetail(database, query: query, arguments: arguments)
+  }
+
+  @Test("dailyTotals groups by (day, instrument) off a leg index, no scan")
+  func dailyTotalsAvoidsScan() throws {
+    let database = try makeDatabase()
+    let detail = try planDetail(
+      database,
+      query: """
+        SELECT DATE(t.date)      AS day,
+               leg.instrument_id AS instrument_id,
+               SUM(CASE WHEN leg.type = 'income'  THEN leg.quantity ELSE 0 END) AS income_qty,
+               SUM(CASE WHEN leg.type = 'expense' THEN leg.quantity ELSE 0 END) AS expense_qty
+        FROM transaction_leg leg
+        JOIN "transaction"    t ON leg.transaction_id = t.id
+        WHERE t.recur_period IS NULL
+          AND leg.type IN ('income', 'expense')
+        GROUP BY day, leg.instrument_id
+        ORDER BY day ASC
+        """)
+    // dailyTotals is an all-history aggregation with no selective leg-side
+    // equality, so the planner may legitimately drive from either side; the
+    // perf-critical signal (per `PlanPinningTestHelpers`) is that the leg
+    // table is never bare-scanned.
+    #expect(!PlanPinningTestHelpers.planHasFullTableScanOf(detail, alias: "leg"))
+  }
+
+  @Test("categorySpend uses the leg_analysis_by_type_category index, no scan")
+  func categorySpendUsesCategoryIndex() throws {
+    let database = try makeDatabase()
+    let detail = try planDetail(
+      database,
+      query: """
+        SELECT DATE(t.date)      AS day,
+               leg.category_id   AS dim,
+               leg.instrument_id AS instrument_id,
+               SUM(leg.quantity) AS qty,
+               COUNT(*)          AS n
+        FROM transaction_leg leg
+        JOIN "transaction"    t ON leg.transaction_id = t.id
+        WHERE t.recur_period IS NULL
+          AND leg.type = 'expense'
+          AND leg.category_id IS NOT NULL
+          AND (? IS NULL OR t.date >= ?)
+        GROUP BY day, dim, instrument_id
+        ORDER BY day ASC
+        """,
+      arguments: [Date?.none, Date?.none])
+    #expect(detail.contains("leg_analysis_by_type_category"))
+    #expect(!PlanPinningTestHelpers.planHasFullTableScanOf(detail, alias: "leg"))
+  }
+
+  @Test("accountSpend uses the leg_analysis_by_type_account index, no scan")
+  func accountSpendUsesAccountIndex() throws {
+    let database = try makeDatabase()
+    let detail = try planDetail(
+      database,
+      query: """
+        SELECT DATE(t.date)      AS day,
+               leg.account_id    AS dim,
+               leg.instrument_id AS instrument_id,
+               SUM(leg.quantity) AS qty,
+               COUNT(*)          AS n
+        FROM transaction_leg leg
+        JOIN "transaction"    t ON leg.transaction_id = t.id
+        WHERE t.recur_period IS NULL
+          AND leg.type = 'expense'
+          AND leg.account_id IS NOT NULL
+          AND (? IS NULL OR t.date >= ?)
+        GROUP BY day, dim, instrument_id
+        ORDER BY day ASC
+        """,
+      arguments: [Date?.none, Date?.none])
+    let usesLegIndex =
+      detail.contains("leg_analysis_by_type_account")
+      || detail.contains("leg_by_account")
+    #expect(usesLegIndex)
+    #expect(!PlanPinningTestHelpers.planHasFullTableScanOf(detail, alias: "leg"))
+  }
+
+  @Test("categorySamples window-function projection avoids a leg table scan")
+  func categorySamplesAvoidsScan() throws {
+    let database = try makeDatabase()
+    let detail = try planDetail(
+      database,
+      query: """
+        SELECT category_id, day, instrument_id, quantity
+        FROM (
+          SELECT leg.category_id    AS category_id,
+                 DATE(t.date)       AS day,
+                 leg.instrument_id  AS instrument_id,
+                 leg.quantity       AS quantity,
+                 ROW_NUMBER() OVER (
+                   PARTITION BY leg.category_id
+                   ORDER BY t.date DESC, leg.transaction_id DESC
+                 ) AS rn
+          FROM transaction_leg leg
+          JOIN "transaction"    t ON leg.transaction_id = t.id
+          WHERE t.recur_period IS NULL
+            AND leg.type = 'expense'
+            AND leg.category_id IS NOT NULL
+            AND (? IS NULL OR t.date >= ?)
+        )
+        WHERE rn <= ?
+        ORDER BY category_id ASC, rn ASC
+        """,
+      arguments: [Date?.none, Date?.none, 200])
+    #expect(!PlanPinningTestHelpers.planHasFullTableScanOf(detail, alias: "leg"))
+  }
+
+  @Test("recentCandidates projection avoids a leg table scan")
+  func recentCandidatesAvoidsScan() throws {
+    let database = try makeDatabase()
+    let detail = try planDetail(
+      database,
+      query: """
+        SELECT t.id              AS txn_id,
+               t.date            AS txn_date,
+               DATE(t.date)      AS day,
+               t.payee           AS payee,
+               leg.quantity      AS quantity,
+               leg.category_id   AS category_id,
+               leg.account_id    AS account_id,
+               leg.instrument_id AS instrument_id,
+               leg.type          AS type
+        FROM transaction_leg leg
+        JOIN "transaction"    t ON leg.transaction_id = t.id
+        WHERE t.recur_period IS NULL
+          AND leg.type IN ('income', 'expense')
+          AND (? IS NULL OR t.date >= ?)
+        ORDER BY t.date DESC
+        """,
+      arguments: [Date?.none, Date?.none])
+    #expect(!PlanPinningTestHelpers.planHasFullTableScanOf(detail, alias: "leg"))
+  }
+}

--- a/MoolahTests/Features/AuthStoreTests.swift
+++ b/MoolahTests/Features/AuthStoreTests.swift
@@ -121,6 +121,7 @@ private struct TestAuthBackend: BackendProvider {
   let transferSuggestions: any TransferSuggestionRepository
   let earmarks: any EarmarkRepository
   let analysis: any AnalysisRepository
+  let insightDataSource: any InsightDataSource
   let investments: any InvestmentRepository
   let conversionService: any InstrumentConversionService
   let csvImportProfiles: any CSVImportProfileRepository
@@ -138,6 +139,7 @@ private struct TestAuthBackend: BackendProvider {
     self.transferSuggestions = backend.transferSuggestions
     self.earmarks = backend.earmarks
     self.analysis = backend.analysis
+    self.insightDataSource = backend.insightDataSource
     self.investments = backend.investments
     self.conversionService = backend.conversionService
     self.csvImportProfiles = backend.csvImportProfiles

--- a/MoolahTests/Support/CloudKitAnalysisTestBackend.swift
+++ b/MoolahTests/Support/CloudKitAnalysisTestBackend.swift
@@ -18,6 +18,7 @@ struct CloudKitAnalysisTestBackend: BackendProvider, @unchecked Sendable {
   let transferSuggestions: any TransferSuggestionRepository
   let earmarks: any EarmarkRepository
   let analysis: any AnalysisRepository
+  let insightDataSource: any InsightDataSource
   let investments: any InvestmentRepository
   let conversionService: any InstrumentConversionService
   let csvImportProfiles: any CSVImportProfileRepository
@@ -79,6 +80,7 @@ struct CloudKitAnalysisTestBackend: BackendProvider, @unchecked Sendable {
     self.transferSuggestions = backend.transferSuggestions
     self.earmarks = backend.earmarks
     self.analysis = backend.analysis
+    self.insightDataSource = backend.insightDataSource
     self.investments = backend.investments
     self.conversionService = backend.conversionService
     self.csvImportProfiles = backend.csvImportProfiles


### PR DESCRIPTION
Implements #1031 (Insights Phase A) following the revised plan in #1036:
assemble the deterministic engine's input from **pre-aggregated SQL
summaries + a small bounded recent-candidate window**, instead of loading
every transaction into memory and converting every leg on each refresh
(the O(all history) shape the plan rejects).

## What's here

`InsightDataSource` (`Domain/Repositories`) + `GRDBInsightDataSource`
(`Backends/GRDB`) produce the five summaries the issue specifies:

- **per-UTC-day income/expense totals** (`GROUP BY DATE`) — unusual-day, weekend-skew
- **per-category / per-account windowed expense sums** — fee, unbudgeted, group-concentration
- **per-normalized-payee cadence** over a ~13-month window — subscription, lapsed-merchant, new-merchant
- **per-category MAD-baseline samples**, capped per category via `ROW_NUMBER`
- **a bounded recent-candidate window** of projected legs for the detectors that must cite a specific `transactionId`
- a **dropped-leg count** (Rule 11 "data incomplete" signal)

Every monetary value converts on its own `(day, instrument)` bucket,
reusing `GRDBAnalysisRepository.convertedQuantity` / `parseDayString`, so
single-currency profiles pay ~nothing and per-day rate-cache equivalence
holds. Memory is `O(payees + categories + days + window)` — independent of
total transaction count. A leg whose conversion fails is dropped and
counted, never guessed; the sign is preserved throughout.

Wired through `BackendProvider` (`CloudKitBackend` + the two test
conformers).

## Tests

- Contract correctness against a seeded `TestBackend` (each summary).
- Per-day conversion (date-sensitive rates).
- Rule 11 drop path (foreign leg dropped + counted, AUD sibling survives).
- **Scaling test**: summaries stay bounded (O(days/payees/cap/window)) as
  the transaction count grows — the exit-criterion memory promise.
- `EXPLAIN QUERY PLAN` pins for each SQL shape.

## Exit criteria (#1031)

- [x] `InsightDataSource` produces correct summaries + a bounded recent window from a seeded `TestBackend`
- [x] memory does not scale with total transaction count (scaling test)
- [x] conversion-failure path covered (Rule 11 — drop the leg, preserve sign, count it)
- [x] query plans pinned per `DATABASE_CODE_GUIDE`

## Scope / follow-ups

- Detector + `InsightEngine` rewiring to **consume** these summaries is
  deferred to **Phase B** (the store), where the consumption lives — doing
  it here would create dead code.
- The plan doc edit is left to #1036, which owns it.

## Verification

Format/lint/typecheck were run locally against the CI-pinned toolchain
(Swift 6.2 / swift-format 602 / SwiftLint 0.63.3): domain layer
type-checks clean, `swift-format` byte-parity passes, `swiftlint --strict`
reports 0 violations. The GRDB compile + test execution and the EXPLAIN
pins require the macOS SDK, so CI closes that loop.

Part of #1030.

https://claude.ai/code/session_01PPhtHKPNQ9pfRNBw1Z3zwC

---
_Generated by [Claude Code](https://claude.ai/code/session_01PPhtHKPNQ9pfRNBw1Z3zwC)_