### PR TITLE
Insights Phase B (2/3): InsightInputBuilder + countNeedsReview

### DIFF
--- a/Backends/GRDB/Repositories/GRDBTransactionRepository+CountNeedsReview.swift
+++ b/Backends/GRDB/Repositories/GRDBTransactionRepository+CountNeedsReview.swift
@@ -1,0 +1,31 @@
+import Foundation
+import GRDB
+
+extension GRDBTransactionRepository {
+  /// SQL `COUNT` of posted transactions whose every leg is uncategorised.
+  /// Never materialises transaction rows — uses a correlated `NOT EXISTS`
+  /// subquery so the planner can terminate early per outer row once it
+  /// finds a categorised leg. Drives the categorise-backlog insight nudge.
+  ///
+  /// The query matches rows that are BOTH posted (`recur_period IS NULL`,
+  /// excludes scheduled/recurring templates) AND have every leg uncategorised
+  /// (`legs.allSatisfy { $0.categoryId == nil }`). Note that
+  /// `Transaction.needsReview` itself does not include the posted constraint
+  /// — it applies to any transaction type.
+  func countNeedsReview() async throws -> Int {
+    try await database.read { database in
+      let sql: SQL =
+        """
+        SELECT COUNT(*)
+        FROM "transaction" t
+        WHERE t.recur_period IS NULL
+          AND NOT EXISTS (
+            SELECT 1 FROM transaction_leg leg
+            WHERE leg.transaction_id = t.id
+              AND leg.category_id IS NOT NULL
+          )
+        """
+      return try SQLRequest<Int>(literal: sql).fetchOne(database) ?? 0
+    }
+  }
+}

--- a/Domain/Insights/InsightInput.swift
+++ b/Domain/Insights/InsightInput.swift
@@ -129,8 +129,9 @@ struct InsightInput: Sendable {
   /// un-budgeted category.
   let budgetedCategoryIds: Set<UUID>
 
-  /// Count of posted transactions whose every leg is uncategorized
-  /// (`Transaction.needsReview`). Drives the categorize-backlog nudge.
+  /// Count of posted transactions whose every leg is uncategorized (posted
+  /// meaning `recur_period IS NULL`; does not include scheduled templates).
+  /// Drives the categorize-backlog nudge.
   let uncategorizedTransactionCount: Int
 
   /// Count of outstanding transfer suggestions awaiting merge

--- a/Domain/Repositories/InsightDataSource.swift
+++ b/Domain/Repositories/InsightDataSource.swift
@@ -19,6 +19,10 @@ struct InsightDataWindow: Sendable {
   /// MAD-baseline sample window and per-category cap.
   var sampleDays: Int
   var maxSamplesPerCategory: Int
+  /// Per-category unbudgeted-spend window (90 days).
+  var unbudgetedSpendDays: Int
+  /// Cap on the income-magnitude sample list (windfall baseline).
+  var maxIncomeSamples: Int
 
   init(
     recentCandidateDays: Int = 30,
@@ -26,7 +30,9 @@ struct InsightDataWindow: Sendable {
     accountSpendDays: Int = 30,
     payeeCadenceDays: Int = 395,
     sampleDays: Int = 365,
-    maxSamplesPerCategory: Int = 200
+    maxSamplesPerCategory: Int = 200,
+    unbudgetedSpendDays: Int = 90,
+    maxIncomeSamples: Int = 200
   ) {
     self.recentCandidateDays = recentCandidateDays
     self.categorySpendDays = categorySpendDays
@@ -34,6 +40,8 @@ struct InsightDataWindow: Sendable {
     self.payeeCadenceDays = payeeCadenceDays
     self.sampleDays = sampleDays
     self.maxSamplesPerCategory = maxSamplesPerCategory
+    self.unbudgetedSpendDays = unbudgetedSpendDays
+    self.maxIncomeSamples = maxIncomeSamples
   }
 }
 
@@ -44,8 +52,7 @@ struct InsightDataWindow: Sendable {
 /// converts the result to `context.reportingCurrency` on each row's own
 /// `(day, instrument)` bucket — the same shape as `AnalysisRepository`.
 /// Memory stays `O(payees + categories + days + window)`, independent of
-/// total transaction count. See
-/// `plans/2026-06-01-insights-integration-plan.md` §"Phase A".
+/// total transaction count.
 ///
 /// A leg whose conversion fails is dropped, never guessed
 /// (`guides/INSTRUMENT_CONVERSION_GUIDE.md` Rule 11); the projection

--- a/Domain/Repositories/TransactionRepository.swift
+++ b/Domain/Repositories/TransactionRepository.swift
@@ -99,6 +99,10 @@ protocol TransactionRepository: Sendable {
   /// Used only by exchange-import resolution's rare registry-fallback
   /// tie-break; cheap (`SELECT DISTINCT`), not on a hot path.
   func distinctLegInstrumentIds() async throws -> Set<String>
+  /// Count of posted (non-scheduled) transactions whose every leg is
+  /// uncategorised (`Transaction.needsReview`). A SQL `COUNT` — never
+  /// materialises history. Drives the categorise-backlog insight nudge.
+  func countNeedsReview() async throws -> Int
 }
 
 extension TransactionRepository {

--- a/Features/Insights/InsightInputBuilder.swift
+++ b/Features/Insights/InsightInputBuilder.swift
@@ -1,0 +1,136 @@
+import Foundation
+import os
+
+private let logger = Logger(subsystem: "com.moolah.app", category: "InsightInputBuilder")
+
+/// Assembles a fully-populated `InsightInput` off the main actor.
+///
+/// The `@MainActor` store-derived half arrives pre-gathered as an
+/// `InsightInputSnapshot`; the builder performs the async repository and
+/// `InsightDataSource` work itself (off-main) and joins the two. Errors
+/// propagate to the caller, which decides how to degrade — the builder never
+/// swallows a failure. See `guides/CONCURRENCY_GUIDE.md` and
+/// `guides/INSTRUMENT_CONVERSION_GUIDE.md`.
+struct InsightInputBuilder: Sendable {
+  let backend: any BackendProvider
+
+  /// Build the complete `InsightInput` for `context`, joining the
+  /// store-derived `snapshot` with freshly-fetched data-source summaries and
+  /// repository aggregates.
+  ///
+  /// The independent reads run concurrently via `async let` — each is a
+  /// read-only fetch against a concurrency-safe GRDB read snapshot with no
+  /// shared mutable state, so they can overlap and are awaited together.
+  func build(
+    snapshot: InsightInputSnapshot,
+    context: InsightContext,
+    window: InsightDataWindow = InsightDataWindow()
+  ) async throws -> InsightInput {
+    let source = backend.insightDataSource
+    let categories = snapshot.categories
+
+    async let recentCandidates = source.recentCandidates(
+      windowDays: window.recentCandidateDays, categories: categories, context: context)
+    async let dailyTotals = source.dailyTotals(context: context)
+    async let payees = source.payeeSummaries(
+      windowDays: window.payeeCadenceDays, context: context)
+    async let categorySamples = source.categorySamples(
+      windowDays: window.sampleDays,
+      maxPerCategory: window.maxSamplesPerCategory,
+      context: context)
+    async let incomeSamples = source.incomeSamples(
+      windowDays: window.sampleDays, maxCount: window.maxIncomeSamples, context: context)
+    async let feeCategorySpend = source.categorySpend(
+      windowDays: window.categorySpendDays, categories: categories, context: context)
+    async let unbudgetedCategorySpend = source.categorySpend(
+      windowDays: window.unbudgetedSpendDays, categories: categories, context: context)
+    async let accountSpend = source.accountSpend(
+      windowDays: window.accountSpendDays, context: context)
+
+    async let scheduledBills = scheduledBills(context: context)
+    async let budgetedCategoryIds = budgetedCategoryIds()
+    async let uncategorizedTransactionCount = backend.transactions.countNeedsReview()
+    async let pendingTransfers = backend.transferSuggestions.fetchAll()
+
+    let pendingTransfersList = try await pendingTransfers
+    return InsightInput(
+      context: context,
+      recentCandidates: try await recentCandidates,
+      dailyTotals: try await dailyTotals,
+      payees: try await payees,
+      categorySamples: try await categorySamples,
+      incomeSamples: try await incomeSamples,
+      feeCategorySpend: try await feeCategorySpend,
+      unbudgetedCategorySpend: try await unbudgetedCategorySpend,
+      accountSpend: try await accountSpend,
+      monthly: snapshot.monthly,
+      expenseBreakdown: snapshot.expenseBreakdown,
+      dailyBalances: snapshot.dailyBalances,
+      scheduledBills: try await scheduledBills,
+      earmarks: snapshot.earmarks,
+      profitLoss: snapshot.profitLoss,
+      capitalGains: snapshot.capitalGains,
+      categories: categories,
+      accountGroups: snapshot.accountGroups,
+      accountGroupMembership: snapshot.accountGroupMembership,
+      budgetedCategoryIds: try await budgetedCategoryIds,
+      uncategorizedTransactionCount: try await uncategorizedTransactionCount,
+      pendingTransferCount: pendingTransfersList.count,
+      oldestPendingTransferDate: pendingTransfersList.map(\.suggestedAt).min())
+  }
+
+  /// Future-dated scheduled transactions reduced to the reporting currency.
+  ///
+  /// Each scheduled transaction contributes its first income/expense leg,
+  /// converted to `context.reportingCurrency`. A leg whose conversion fails is
+  /// dropped, never guessed (`INSTRUMENT_CONVERSION_GUIDE.md` Rule 11); the
+  /// original sign is preserved (a bill is a negative outflow — never
+  /// `abs()`). Transactions with no income/expense leg are skipped.
+  private func scheduledBills(context: InsightContext) async throws -> [ScheduledBill] {
+    let filter = TransactionFilter(scheduled: .scheduledOnly)
+    let scheduled = try await backend.transactions.fetchAll(filter: filter)
+    let reportingCurrency = context.reportingCurrency
+    let now = context.now  // gate: is this bill in the future, relative to the injected now?
+    let conversionDate = Date()  // convert a future obligation at the CURRENT wall-clock rate (Rule 6)
+
+    var bills: [ScheduledBill] = []
+    for transaction in scheduled {
+      guard transaction.date >= now else { continue }
+      guard let leg = transaction.legs.first(where: { $0.type == .income || $0.type == .expense })
+      else { continue }
+      let amount: InstrumentAmount
+      do {
+        amount = try await backend.conversionService.convertAmount(
+          leg.amount, to: reportingCurrency, on: conversionDate)
+      } catch {
+        // Rule 11: a leg whose conversion fails is dropped, never guessed.
+        logger.error(
+          "Dropping scheduled bill \(transaction.id, privacy: .public): conversion failed: \(error)"
+        )
+        continue
+      }
+      bills.append(
+        ScheduledBill(
+          id: transaction.id,
+          date: transaction.date,
+          payee: transaction.payee,
+          amount: amount,
+          accountId: leg.accountId))
+    }
+    return bills
+  }
+
+  /// The set of category ids that carry a budget line item in some earmark.
+  private func budgetedCategoryIds() async throws -> Set<UUID> {
+    let earmarks = try await backend.earmarks.fetchAll()
+    let perEarmark = try await withThrowingTaskGroup(of: [EarmarkBudgetItem].self) { group in
+      for earmark in earmarks {
+        group.addTask { try await self.backend.earmarks.fetchBudget(earmarkId: earmark.id) }
+      }
+      var collected: [[EarmarkBudgetItem]] = []
+      for try await items in group { collected.append(items) }
+      return collected
+    }
+    return Set(perEarmark.flatMap { $0.map(\.categoryId) })
+  }
+}

--- a/Features/Insights/InsightInputSnapshot.swift
+++ b/Features/Insights/InsightInputSnapshot.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+/// The main-actor-gathered half of `InsightInput`.
+///
+/// `InsightInput` is assembled from two sources: aggregates already computed
+/// by `@MainActor` feature stores (`AnalysisStore`, `EarmarkStore`,
+/// `ReportingStore`, `AccountGroupStore`, `CategoryStore`), and bounded
+/// summaries produced off-main from the SQL-backed `InsightDataSource`. This
+/// struct carries exactly the former — the store-derived fields the builder
+/// passes through unchanged — as a `Sendable` value the caller gathers on the
+/// main actor and hands to `InsightInputBuilder.build(snapshot:context:window:)`,
+/// which joins it with the data-source half off the main actor.
+struct InsightInputSnapshot: Sendable {
+  let monthly: [MonthlyIncomeExpense]
+  let expenseBreakdown: [ExpenseBreakdown]
+  let dailyBalances: [DailyBalance]
+  let earmarks: [EarmarkSnapshot]
+  let profitLoss: [InstrumentProfitLoss]
+  let capitalGains: [CapitalGainEvent]
+  let categories: Categories
+  let accountGroups: [InsightAccountGroup]
+  let accountGroupMembership: [UUID: UUID]
+
+  init(
+    monthly: [MonthlyIncomeExpense] = [],
+    expenseBreakdown: [ExpenseBreakdown] = [],
+    dailyBalances: [DailyBalance] = [],
+    earmarks: [EarmarkSnapshot] = [],
+    profitLoss: [InstrumentProfitLoss] = [],
+    capitalGains: [CapitalGainEvent] = [],
+    categories: Categories = Categories(from: []),
+    accountGroups: [InsightAccountGroup] = [],
+    accountGroupMembership: [UUID: UUID] = [:]
+  ) {
+    self.monthly = monthly
+    self.expenseBreakdown = expenseBreakdown
+    self.dailyBalances = dailyBalances
+    self.earmarks = earmarks
+    self.profitLoss = profitLoss
+    self.capitalGains = capitalGains
+    self.categories = categories
+    self.accountGroups = accountGroups
+    self.accountGroupMembership = accountGroupMembership
+  }
+}

--- a/MoolahTests/Backends/GRDB/CountNeedsReviewPlanPinningTests.swift
+++ b/MoolahTests/Backends/GRDB/CountNeedsReviewPlanPinningTests.swift
@@ -1,0 +1,42 @@
+import Foundation
+import GRDB
+import Testing
+
+@testable import Moolah
+
+/// `EXPLAIN QUERY PLAN`-pinning for `GRDBTransactionRepository.countNeedsReview()`.
+/// Same methodology as `InsightDataSourcePlanPinningTests`: the perf-critical
+/// signal is that the leg side of the correlated `NOT EXISTS` subquery is
+/// index-driven (no bare `SCAN leg`).
+///
+/// The outer `"transaction"` table has no selective partial index for
+/// `recur_period IS NULL` (the `transaction_scheduled` index covers the
+/// complementary `IS NOT NULL` predicate for the rare scheduled rows). An
+/// all-history `COUNT(*)` of posted rows drives from the full transaction
+/// table; that scan is unavoidable and accepted here — the O(n) cost is
+/// bounded to the transaction header rows alone, with no leg
+/// materialisation. The correlated subquery short-circuits on the first
+/// categorised leg, riding `leg_by_transaction` so each probe is O(log n).
+@Suite("countNeedsReview plan-pinning")
+struct CountNeedsReviewPlanPinningTests {
+  private let query = """
+    SELECT COUNT(*)
+    FROM "transaction" t
+    WHERE t.recur_period IS NULL
+      AND NOT EXISTS (
+        SELECT 1 FROM transaction_leg leg
+        WHERE leg.transaction_id = t.id
+          AND leg.category_id IS NOT NULL
+      )
+    """
+
+  @Test("correlated NOT EXISTS probe uses leg_by_transaction — no bare leg scan")
+  func legSideUsesIndex() throws {
+    let database = try PlanPinningTestHelpers.makeDatabase()
+    let detail = try PlanPinningTestHelpers.planDetail(database, query: query)
+    // The correlated subquery drives via leg.transaction_id = t.id.
+    // SQLite resolves this through leg_by_transaction(transaction_id),
+    // so a bare SCAN of the leg alias must not appear.
+    #expect(!PlanPinningTestHelpers.planHasFullTableScanOf(detail, alias: "leg"))
+  }
+}

--- a/MoolahTests/Domain/CountNeedsReviewContractTests.swift
+++ b/MoolahTests/Domain/CountNeedsReviewContractTests.swift
@@ -1,0 +1,151 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+/// Contract tests for `TransactionRepository.countNeedsReview()`.
+///
+/// "Needs review" = a posted (`recur_period IS NULL`) transaction whose
+/// every leg has `categoryId == nil`. This mirrors `Transaction.needsReview`.
+@Suite("TransactionRepository — countNeedsReview")
+struct CountNeedsReviewContractTests {
+  private let accountId = UUID()
+
+  // MARK: - Scenarios
+
+  @Test("posted transaction with all legs uncategorised counts as needs-review")
+  func testAllUncategorisedPostedCounts() async throws {
+    let uncategorised = makePosted(payee: "Uncategorised", categoryId: nil)
+    let repository = try makeContractCloudKitTransactionRepository(
+      initialTransactions: [uncategorised])
+
+    let count = try await repository.countNeedsReview()
+
+    #expect(count == 1)
+  }
+
+  @Test("posted transaction with at least one categorised leg does not count")
+  func testPartiallyCategorisedPostedDoesNotCount() async throws {
+    let categoryId = UUID()
+    let partiallyCategorised = makePostedTwoLeg(
+      payee: "Partial",
+      firstCategoryId: categoryId,
+      secondCategoryId: nil)
+    let repository = try makeContractCloudKitTransactionRepository(
+      initialTransactions: [partiallyCategorised])
+
+    let count = try await repository.countNeedsReview()
+
+    #expect(count == 0)
+  }
+
+  @Test("posted transaction with all legs categorised does not count")
+  func testFullyCategorisedPostedDoesNotCount() async throws {
+    let categoryId = UUID()
+    let fullyCategorised = makePosted(payee: "Categorised", categoryId: categoryId)
+    let repository = try makeContractCloudKitTransactionRepository(
+      initialTransactions: [fullyCategorised])
+
+    let count = try await repository.countNeedsReview()
+
+    #expect(count == 0)
+  }
+
+  @Test("scheduled (recur_period non-null) all-uncategorised transaction does not count")
+  func testScheduledAllUncategorisedDoesNotCount() async throws {
+    let scheduled = makeScheduled(payee: "Scheduled Uncategorised")
+    let repository = try makeContractCloudKitTransactionRepository(
+      initialTransactions: [scheduled])
+
+    let count = try await repository.countNeedsReview()
+
+    #expect(count == 0)
+  }
+
+  @Test("count equals number of posted all-uncategorised transactions across a mixed set")
+  func testCountEqualsExpectedAcrossMixedSet() async throws {
+    let categoryId = UUID()
+    let needsReview1 = makePosted(payee: "Needs Review A", categoryId: nil)
+    let needsReview2 = makePosted(payee: "Needs Review B", categoryId: nil)
+    let categorised = makePosted(payee: "Categorised", categoryId: categoryId)
+    let partial = makePostedTwoLeg(
+      payee: "Partial",
+      firstCategoryId: categoryId,
+      secondCategoryId: nil)
+    let scheduled = makeScheduled(payee: "Scheduled")
+    let repository = try makeContractCloudKitTransactionRepository(
+      initialTransactions: [needsReview1, needsReview2, categorised, partial, scheduled])
+
+    let count = try await repository.countNeedsReview()
+
+    #expect(count == 2)
+  }
+
+  @Test("empty database returns zero")
+  func testEmptyDatabaseReturnsZero() async throws {
+    let repository = try makeContractCloudKitTransactionRepository()
+
+    let count = try await repository.countNeedsReview()
+
+    #expect(count == 0)
+  }
+
+  // MARK: - Fixtures
+
+  private func makePosted(payee: String, categoryId: UUID?) -> Transaction {
+    Transaction(
+      date: Date(timeIntervalSinceReferenceDate: 0),
+      payee: payee,
+      legs: [
+        TransactionLeg(
+          accountId: accountId,
+          instrument: .defaultTestInstrument,
+          quantity: Decimal(-10),
+          type: .expense,
+          categoryId: categoryId)
+      ]
+    )
+  }
+
+  private func makePostedTwoLeg(
+    payee: String,
+    firstCategoryId: UUID?,
+    secondCategoryId: UUID?
+  ) -> Transaction {
+    Transaction(
+      date: Date(timeIntervalSinceReferenceDate: 0),
+      payee: payee,
+      legs: [
+        TransactionLeg(
+          accountId: accountId,
+          instrument: .defaultTestInstrument,
+          quantity: Decimal(-10),
+          type: .expense,
+          categoryId: firstCategoryId),
+        TransactionLeg(
+          accountId: accountId,
+          instrument: .defaultTestInstrument,
+          quantity: Decimal(-5),
+          type: .expense,
+          categoryId: secondCategoryId),
+      ]
+    )
+  }
+
+  private func makeScheduled(payee: String) -> Transaction {
+    Transaction(
+      date: Date(timeIntervalSinceReferenceDate: 0),
+      payee: payee,
+      recurPeriod: .month,
+      recurEvery: 1,
+      legs: [
+        TransactionLeg(
+          accountId: accountId,
+          instrument: .defaultTestInstrument,
+          quantity: Decimal(-10),
+          type: .expense,
+          categoryId: nil)
+      ]
+    )
+  }
+}

--- a/MoolahTests/Features/Insights/InsightInputBuilderExtraTests.swift
+++ b/MoolahTests/Features/Insights/InsightInputBuilderExtraTests.swift
@@ -1,0 +1,105 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+/// Additional tests for `InsightInputBuilder` covering:
+/// - `budgetedCategoryIds` cross-earmark union
+/// - `scheduledBills` conversion date correctness
+@Suite("InsightInputBuilder — budget and conversion")
+struct InsightInputBuilderExtraTests {
+  private let aud = Instrument.defaultTestInstrument
+
+  private func context(now: Date) -> InsightContext {
+    InsightContext(now: now, reportingCurrency: aud)
+  }
+
+  private func leg(
+    _ quantity: Decimal,
+    type: TransactionType,
+    instrument: Instrument
+  ) -> TransactionLeg {
+    TransactionLeg(
+      accountId: nil, instrument: instrument, quantity: quantity,
+      type: type, categoryId: nil)
+  }
+
+  // MARK: - budgetedCategoryIds
+
+  @Test("budgetedCategoryIds unions budget items across multiple earmarks")
+  func budgetedCategoryIdsMultiEarmark() async throws {
+    let backend = try CloudKitAnalysisTestBackend()
+    let now = try AnalysisTestHelpers.utcDate(year: 2026, month: 6, day: 15)
+    let groceries = Category(name: "Groceries")
+    let travel = Category(name: "Travel")
+    // Two separate earmarks, each budgeting a distinct category.
+    let groceriesEarmark = try await backend.earmarks.create(
+      Earmark(name: "Grocery Budget", instrument: aud))
+    let travelEarmark = try await backend.earmarks.create(
+      Earmark(name: "Travel Fund", instrument: aud))
+    try await backend.earmarks.setBudget(
+      earmarkId: groceriesEarmark.id, categoryId: groceries.id,
+      amount: InstrumentAmount(quantity: 300, instrument: aud))
+    try await backend.earmarks.setBudget(
+      earmarkId: travelEarmark.id, categoryId: travel.id,
+      amount: InstrumentAmount(quantity: 500, instrument: aud))
+
+    let input = try await InsightInputBuilder(backend: backend).build(
+      snapshot: InsightInputSnapshot(), context: context(now: now))
+
+    // Both categories must appear — cross-earmark union is required.
+    #expect(input.budgetedCategoryIds.contains(groceries.id))
+    #expect(input.budgetedCategoryIds.contains(travel.id))
+    #expect(input.budgetedCategoryIds.count == 2)
+  }
+
+  // MARK: - scheduledBills conversion date
+
+  @Test("scheduledBills convert at current rate, not future transaction date's rate")
+  func scheduledBillsConversionUsesCurrentRate() async throws {
+    // The conversion service has two rate entries:
+    // - distantPast (effective "today"): 1 USD → 1.5 AUD
+    // - far-future (effective at transaction date): 1 USD → 3.0 AUD
+    //
+    // scheduledBills must use Date() for conversion (Rule 6 — current rate for
+    // a future obligation), so the result should reflect 1.5, not 3.0.
+    // DateBasedFixedConversionService picks the most-recent date <= requested,
+    // so conversion on Date() resolves the distantPast entry (1.5), while
+    // conversion on the future transaction date would resolve the far-future
+    // entry (3.0). The distinction proves the gate uses context.now and the
+    // conversion uses Date().
+    let usd = Instrument.fiat(code: "USD")
+    let now = try AnalysisTestHelpers.utcDate(year: 2026, month: 6, day: 15)
+    let futureTransactionDate = try AnalysisTestHelpers.utcDate(year: 2027, month: 1, day: 1)
+    let pastTransactionDate = try AnalysisTestHelpers.utcDate(year: 2026, month: 6, day: 14)
+    // Rate effective from distantPast (< Date()) = 1.5; far-future = 3.0.
+    let conversionService = DateBasedFixedConversionService(
+      rates: [
+        Date.distantPast: ["USD": 1.5],
+        futureTransactionDate: ["USD": 3.0],
+      ])
+    let backend = try CloudKitAnalysisTestBackend(conversionService: conversionService)
+
+    // Future-dated bill: must appear, converted at current rate (1.5).
+    let futureBill = try await backend.transactions.create(
+      Transaction(
+        date: futureTransactionDate, payee: "Foreign Sub", recurPeriod: .month, recurEvery: 1,
+        legs: [leg(-100, type: .expense, instrument: usd)]))
+    // Past-dated (before context.now): must be excluded by the gate.
+    _ = try await backend.transactions.create(
+      Transaction(
+        date: pastTransactionDate, payee: "Old Bill", recurPeriod: .month, recurEvery: 1,
+        legs: [leg(-50, type: .expense, instrument: usd)]))
+
+    let input = try await InsightInputBuilder(backend: backend).build(
+      snapshot: InsightInputSnapshot(), context: context(now: now))
+
+    // Only the future bill should appear.
+    #expect(input.scheduledBills.count == 1)
+    let bill = try #require(input.scheduledBills.first { $0.id == futureBill.id })
+    // Converted at current rate (1.5): -100 USD → -150 AUD.
+    // If it used the future-date rate (3.0) it would be -300 AUD.
+    #expect(bill.amount.quantity == -150)
+    #expect(bill.amount.instrument == aud)
+  }
+}

--- a/MoolahTests/Features/Insights/InsightInputBuilderTests.swift
+++ b/MoolahTests/Features/Insights/InsightInputBuilderTests.swift
@@ -1,0 +1,289 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+/// Tests for `InsightInputBuilder`, the off-main assembler that joins a
+/// main-actor-gathered `InsightInputSnapshot` with the SQL-backed
+/// `InsightDataSource` summaries and the repository aggregates.
+///
+/// Seeds a real `CloudKitAnalysisTestBackend` (CloudKitBackend on an in-memory
+/// GRDB queue) via the repository APIs so the data source observes real rows.
+@Suite("InsightInputBuilder")
+struct InsightInputBuilderTests {
+  private let aud = Instrument.defaultTestInstrument
+
+  private func context(now: Date) -> InsightContext {
+    InsightContext(now: now, reportingCurrency: aud)
+  }
+
+  private func leg(
+    _ quantity: Decimal,
+    type: TransactionType,
+    instrument: Instrument,
+    accountId: UUID? = nil,
+    categoryId: UUID? = nil
+  ) -> TransactionLeg {
+    TransactionLeg(
+      accountId: accountId, instrument: instrument, quantity: quantity,
+      type: type, categoryId: categoryId)
+  }
+
+  // MARK: - Data-source half
+
+  @Test("recentCandidates include recent legs and exclude stale ones")
+  func recentCandidatesWindow() async throws {
+    let backend = try CloudKitAnalysisTestBackend()
+    let now = try AnalysisTestHelpers.utcDate(year: 2026, month: 6, day: 15)
+    let recent = try AnalysisTestHelpers.utcDate(year: 2026, month: 6, day: 10)
+    let stale = try AnalysisTestHelpers.utcDate(year: 2026, month: 1, day: 1)
+    _ = try await backend.transactions.create(
+      Transaction(date: recent, payee: "Cafe", legs: [leg(-12, type: .expense, instrument: aud)]))
+    _ = try await backend.transactions.create(
+      Transaction(date: stale, payee: "Old", legs: [leg(-99, type: .expense, instrument: aud)]))
+
+    let input = try await InsightInputBuilder(backend: backend).build(
+      snapshot: InsightInputSnapshot(), context: context(now: now))
+
+    #expect(input.recentCandidates.count == 1)
+    #expect(input.recentCandidates.first?.amount == -12)
+  }
+
+  @Test("dailyTotals, payees, categorySamples, incomeSamples populate from seeded rows")
+  func summariesPopulate() async throws {
+    let backend = try CloudKitAnalysisTestBackend()
+    let now = try AnalysisTestHelpers.utcDate(year: 2026, month: 6, day: 15)
+    let dining = Category(name: "Dining")
+    let day = try AnalysisTestHelpers.utcDate(year: 2026, month: 6, day: 10)
+    _ = try await backend.transactions.create(
+      Transaction(
+        date: day, payee: "Cafe",
+        legs: [leg(-40, type: .expense, instrument: aud, categoryId: dining.id)]))
+    _ = try await backend.transactions.create(
+      Transaction(date: day, payee: "Salary", legs: [leg(2000, type: .income, instrument: aud)]))
+
+    let input = try await InsightInputBuilder(backend: backend).build(
+      snapshot: InsightInputSnapshot(categories: Categories(from: [dining])),
+      context: context(now: now))
+
+    #expect(!input.dailyTotals.isEmpty)
+    #expect(input.payees.contains { $0.normalizedPayee.contains("cafe") })
+    #expect(input.categorySamples.contains { $0.categoryId == dining.id })
+    #expect(input.incomeSamples == [2000])
+  }
+
+  @Test("feeCategorySpend (365d) and unbudgetedCategorySpend (90d) reflect their windows")
+  func categorySpendWindows() async throws {
+    let backend = try CloudKitAnalysisTestBackend()
+    let now = try AnalysisTestHelpers.utcDate(year: 2026, month: 6, day: 15)
+    let fees = Category(name: "Fees")
+    let withinBoth = try AnalysisTestHelpers.utcDate(year: 2026, month: 6, day: 1)
+    let only365 = try AnalysisTestHelpers.utcDate(year: 2025, month: 9, day: 1)
+    _ = try await backend.transactions.create(
+      Transaction(
+        date: withinBoth, payee: "Bank",
+        legs: [leg(-10, type: .expense, instrument: aud, categoryId: fees.id)]))
+    _ = try await backend.transactions.create(
+      Transaction(
+        date: only365, payee: "Bank",
+        legs: [leg(-5, type: .expense, instrument: aud, categoryId: fees.id)]))
+
+    let input = try await InsightInputBuilder(backend: backend).build(
+      snapshot: InsightInputSnapshot(categories: Categories(from: [fees])),
+      context: context(now: now))
+
+    let fee365 = try #require(input.feeCategorySpend.first { $0.categoryId == fees.id })
+    #expect(fee365.total.quantity == -15)
+    let fee90 = try #require(input.unbudgetedCategorySpend.first { $0.categoryId == fees.id })
+    #expect(fee90.total.quantity == -10)
+  }
+
+  @Test("accountSpend reflects 30d per-account spend")
+  func accountSpendWindow() async throws {
+    let backend = try CloudKitAnalysisTestBackend()
+    let now = try AnalysisTestHelpers.utcDate(year: 2026, month: 6, day: 15)
+    let account = Account(id: UUID(), name: "Checking", type: .bank, instrument: aud)
+    _ = try await backend.accounts.create(account)
+    let day = try AnalysisTestHelpers.utcDate(year: 2026, month: 6, day: 2)
+    _ = try await backend.transactions.create(
+      Transaction(
+        date: day, payee: "Shop",
+        legs: [leg(-25, type: .expense, instrument: aud, accountId: account.id)]))
+
+    let input = try await InsightInputBuilder(backend: backend).build(
+      snapshot: InsightInputSnapshot(), context: context(now: now))
+
+    let entry = try #require(input.accountSpend.first { $0.accountId == account.id })
+    #expect(entry.total.quantity == -25)
+  }
+
+  // MARK: - scheduledBills
+
+  @Test("scheduledBills reflect future scheduled transactions, sign preserved")
+  func scheduledBillsConverted() async throws {
+    let backend = try CloudKitAnalysisTestBackend()
+    let now = Date()
+    let account = Account(id: UUID(), name: "Checking", type: .bank, instrument: aud)
+    _ = try await backend.accounts.create(account)
+    let future = try AnalysisTestHelpers.addingDaysCurrentCalendar(14, to: now)
+    let pastScheduled = try AnalysisTestHelpers.addingDaysCurrentCalendar(-14, to: now)
+    let futureScheduled = try await backend.transactions.create(
+      Transaction(
+        date: future, payee: "Rent", recurPeriod: .month, recurEvery: 1,
+        legs: [leg(-1500, type: .expense, instrument: aud, accountId: account.id)]))
+    // A past-dated scheduled transaction must be excluded (future-dated only).
+    _ = try await backend.transactions.create(
+      Transaction(
+        date: pastScheduled, payee: "Old Bill", recurPeriod: .month, recurEvery: 1,
+        legs: [leg(-50, type: .expense, instrument: aud, accountId: account.id)]))
+
+    let input = try await InsightInputBuilder(backend: backend).build(
+      snapshot: InsightInputSnapshot(), context: context(now: now))
+
+    let bill = try #require(input.scheduledBills.first { $0.id == futureScheduled.id })
+    #expect(bill.amount.quantity == -1500)
+    #expect(bill.amount.instrument == aud)
+    #expect(bill.payee == "Rent")
+    #expect(bill.accountId == account.id)
+    #expect(input.scheduledBills.count == 1)
+  }
+
+  @Test("scheduledBills drop a leg whose conversion fails")
+  func scheduledBillsDropFailingConversion() async throws {
+    // Fail every conversion off the AUD reporting currency.
+    let conversion = DateFailingConversionService(rates: [:], failingDates: [])
+    let alwaysFail = AlwaysFailingConversionService(inner: conversion)
+    let backend = try CloudKitAnalysisTestBackend(conversionService: alwaysFail)
+    let now = Date()
+    let future = try AnalysisTestHelpers.addingDaysCurrentCalendar(14, to: now)
+    let usd = Instrument.fiat(code: "USD")
+    // Foreign-instrument scheduled bill — conversion fails, must be dropped.
+    _ = try await backend.transactions.create(
+      Transaction(
+        date: future, payee: "Foreign Sub", recurPeriod: .month, recurEvery: 1,
+        legs: [leg(-30, type: .expense, instrument: usd)]))
+    // Same-currency bill — converts trivially, must appear.
+    let localBill = try await backend.transactions.create(
+      Transaction(
+        date: future, payee: "Local Sub", recurPeriod: .month, recurEvery: 1,
+        legs: [leg(-20, type: .expense, instrument: aud)]))
+
+    let input = try await InsightInputBuilder(backend: backend).build(
+      snapshot: InsightInputSnapshot(), context: context(now: now))
+
+    #expect(input.scheduledBills.count == 1)
+    #expect(input.scheduledBills.first?.id == localBill.id)
+    #expect(input.scheduledBills.first?.amount.quantity == -20)
+  }
+
+  // MARK: - repository aggregates
+
+  @Test("uncategorizedTransactionCount matches countNeedsReview")
+  func uncategorizedCount() async throws {
+    let backend = try CloudKitAnalysisTestBackend()
+    let now = try AnalysisTestHelpers.utcDate(year: 2026, month: 6, day: 15)
+    let day = try AnalysisTestHelpers.utcDate(year: 2026, month: 6, day: 10)
+    _ = try await backend.transactions.create(
+      Transaction(date: day, payee: "A", legs: [leg(-10, type: .expense, instrument: aud)]))
+    _ = try await backend.transactions.create(
+      Transaction(date: day, payee: "B", legs: [leg(-20, type: .expense, instrument: aud)]))
+    let categorised = Category(name: "Cat")
+    _ = try await backend.transactions.create(
+      Transaction(
+        date: day, payee: "C",
+        legs: [leg(-30, type: .expense, instrument: aud, categoryId: categorised.id)]))
+
+    let input = try await InsightInputBuilder(backend: backend).build(
+      snapshot: InsightInputSnapshot(), context: context(now: now))
+
+    let expected = try await backend.transactions.countNeedsReview()
+    #expect(input.uncategorizedTransactionCount == expected)
+    #expect(input.uncategorizedTransactionCount == 2)
+  }
+
+  @Test("pendingTransferCount and oldestPendingTransferDate reflect seeded suggestions")
+  func pendingTransfers() async throws {
+    let backend = try CloudKitAnalysisTestBackend()
+    let now = try AnalysisTestHelpers.utcDate(year: 2026, month: 6, day: 15)
+    let older = try AnalysisTestHelpers.utcDate(year: 2026, month: 6, day: 1)
+    let newer = try AnalysisTestHelpers.utcDate(year: 2026, month: 6, day: 10)
+    _ = try await backend.transferSuggestions.create(
+      TransferSuggestion(transactionIds: [UUID(), UUID()], suggestedAt: older))
+    _ = try await backend.transferSuggestions.create(
+      TransferSuggestion(transactionIds: [UUID(), UUID()], suggestedAt: newer))
+
+    let input = try await InsightInputBuilder(backend: backend).build(
+      snapshot: InsightInputSnapshot(), context: context(now: now))
+
+    #expect(input.pendingTransferCount == 2)
+    #expect(input.oldestPendingTransferDate == older)
+  }
+
+  // MARK: - snapshot pass-through
+
+  @Test("snapshot pass-through fields appear unchanged on the result")
+  func snapshotPassThrough() async throws {
+    let backend = try CloudKitAnalysisTestBackend()
+    let now = try AnalysisTestHelpers.utcDate(year: 2026, month: 6, day: 15)
+    let category = Category(name: "Groceries")
+    let categories = Categories(from: [category])
+    let earmark = EarmarkSnapshot(
+      id: UUID(), name: "Holiday", balance: InstrumentAmount(quantity: 500, instrument: aud))
+    let group = InsightAccountGroup(id: UUID(), name: "Everyday")
+    let accountId = UUID()
+    let membership: [UUID: UUID] = [accountId: group.id]
+    let snapshot = InsightInputSnapshot(
+      earmarks: [earmark],
+      categories: categories,
+      accountGroups: [group],
+      accountGroupMembership: membership)
+
+    let input = try await InsightInputBuilder(backend: backend).build(
+      snapshot: snapshot, context: context(now: now))
+
+    #expect(input.earmarks == [earmark])
+    #expect(input.accountGroups == [group])
+    #expect(input.accountGroupMembership == membership)
+    #expect(input.categories.by(id: category.id)?.name == "Groceries")
+    #expect(input.monthly.isEmpty)
+    #expect(input.expenseBreakdown.isEmpty)
+    #expect(input.dailyBalances.isEmpty)
+    #expect(input.profitLoss.isEmpty)
+    #expect(input.capitalGains.isEmpty)
+  }
+}
+
+/// Conversion service that fails every cross-instrument conversion (and
+/// succeeds same-instrument), for exercising the Rule 11 drop path.
+struct AlwaysFailingConversionService: InstrumentConversionService {
+  let inner: DateFailingConversionService
+
+  func convert(
+    _ quantity: Decimal, from: Instrument, to: Instrument, on date: Date
+  ) async throws -> Decimal {
+    if from.id == to.id { return quantity }
+    throw DateFailingConversionError.unavailable(date: date)
+  }
+
+  func convertAmount(
+    _ amount: InstrumentAmount, to instrument: Instrument, on date: Date
+  ) async throws -> InstrumentAmount {
+    if amount.instrument == instrument { return amount }
+    throw DateFailingConversionError.unavailable(date: date)
+  }
+
+  func convertResult(
+    _ amount: InstrumentAmount, to instrument: Instrument, on date: Date
+  ) async throws -> ConversionResult {
+    if amount.instrument == instrument { return .value(amount) }
+    throw DateFailingConversionError.unavailable(date: date)
+  }
+
+  func invalidateCache(for instrument: Instrument) async {
+    await inner.invalidateCache(for: instrument)
+  }
+
+  func observeRates() -> AsyncStream<Void> { inner.observeRates() }
+
+  func observeErrors() -> AsyncStream<any Error> { inner.observeErrors() }
+}

--- a/MoolahTests/Features/TransactionStoreLoadRaceTests.swift
+++ b/MoolahTests/Features/TransactionStoreLoadRaceTests.swift
@@ -254,4 +254,5 @@ actor FirstFetchGatedTransactionRepository: TransactionRepository {
   }
   func legExists(accountId: UUID, externalId: String) async throws -> Bool { false }
   func distinctLegInstrumentIds() async throws -> Set<String> { [] }
+  func countNeedsReview() async throws -> Int { 0 }
 }

--- a/MoolahTests/Shared/CryptoImport/RecordingTransactionRepository.swift
+++ b/MoolahTests/Shared/CryptoImport/RecordingTransactionRepository.swift
@@ -86,4 +86,8 @@ actor RecordingTransactionRepository: TransactionRepository {
   func distinctLegInstrumentIds() async throws -> Set<String> {
     try await wrapped.distinctLegInstrumentIds()
   }
+
+  func countNeedsReview() async throws -> Int {
+    try await wrapped.countNeedsReview()
+  }
 }

--- a/MoolahTests/Support/CancellablePagingTransactionRepository.swift
+++ b/MoolahTests/Support/CancellablePagingTransactionRepository.swift
@@ -81,6 +81,7 @@ actor CancellablePagingTransactionRepository: TransactionRepository {
   }
   func legExists(accountId: UUID, externalId: String) async throws -> Bool { false }
   func distinctLegInstrumentIds() async throws -> Set<String> { [] }
+  func countNeedsReview() async throws -> Int { 0 }
 }
 
 /// A simple one-shot gate that suspends waiters until `open()` is called.

--- a/MoolahTests/Support/TransactionStoreTestSupport.swift
+++ b/MoolahTests/Support/TransactionStoreTestSupport.swift
@@ -214,4 +214,8 @@ struct FailingTransactionRepository: TransactionRepository {
   func distinctLegInstrumentIds() async throws -> Set<String> {
     throw BackendError.networkUnavailable
   }
+
+  func countNeedsReview() async throws -> Int {
+    throw BackendError.networkUnavailable
+  }
 }

--- a/MoolahTests/Support/TransferDetectionFixture.swift
+++ b/MoolahTests/Support/TransferDetectionFixture.swift
@@ -98,6 +98,10 @@ struct ReplaceFailingTransactionRepository: TransactionRepository {
   func distinctLegInstrumentIds() async throws -> Set<String> {
     try await wrapped.distinctLegInstrumentIds()
   }
+
+  func countNeedsReview() async throws -> Int {
+    try await wrapped.countNeedsReview()
+  }
 }
 
 /// Forwards every call to a wrapped repository, but suspends inside
@@ -169,6 +173,10 @@ actor GatedReplaceTransactionRepository: TransactionRepository {
   }
   nonisolated func distinctLegInstrumentIds() async throws -> Set<String> {
     try await wrapped.distinctLegInstrumentIds()
+  }
+
+  nonisolated func countNeedsReview() async throws -> Int {
+    try await wrapped.countNeedsReview()
   }
 }
 
@@ -243,5 +251,9 @@ actor GatedFetchAllTransactionRepository: TransactionRepository {
   }
   nonisolated func distinctLegInstrumentIds() async throws -> Set<String> {
     try await wrapped.distinctLegInstrumentIds()
+  }
+
+  nonisolated func countNeedsReview() async throws -> Int {
+    try await wrapped.countNeedsReview()
   }
 }


### PR DESCRIPTION
## Phase B, PR 2 of 3 — input assembly

Builds the off-main assembler that turns the Phase-A SQL data source + the feature stores into a complete `InsightInput`, plus the SQL `COUNT` the categorize-backlog nudge needs. Stacks on #1038 (Phase B 1/3, merged).

### What changed
- **`Features/Insights/InsightInputSnapshot.swift`** (new) — a `Sendable` value type carrying the `@MainActor`-store-derived `InsightInput` fields (`monthly`, `expenseBreakdown`, `dailyBalances`, `earmarks`, `profitLoss`, `capitalGains`, `categories`, `accountGroups`, membership). Gathered on the main actor by the caller; joined off-main with the data-source half.
- **`Features/Insights/InsightInputBuilder.swift`** (new) — `struct InsightInputBuilder: Sendable`. `build(snapshot:context:window:) async throws -> InsightInput` fans out (concurrently, `async let` + `TaskGroup`) the 8 `InsightDataSource` windows + `scheduledBills` + `budgetedCategoryIds` + `countNeedsReview()` + transfer-suggestions, then assembles. No `Backends/` import; uses only `any BackendProvider` + domain types.
  - **scheduledBills**: gate future-ness on `context.now` (deterministic); convert each future obligation at the **current `Date()` rate** (Rule 6). A leg whose conversion fails is **dropped + logged** (Rule 11); sign preserved (no `abs()`).
  - **budgetedCategoryIds**: concurrent per-earmark budget fan-out.
- **`TransactionRepository.countNeedsReview()`** + GRDB impl (`GRDBTransactionRepository+CountNeedsReview.swift`) — a correlated `NOT EXISTS` `COUNT` of posted (`recur_period IS NULL`) transactions whose every leg is uncategorised. Compile-time literal SQL, plan-pinned (no leg scan), contract-tested. Replaces an O(all-history) `fetchAll` + client count.
- **`InsightDataWindow`** gains `unbudgetedSpendDays` (90) and `maxIncomeSamples` (200).

### Review & verification
- Ran `@code-review`, `@concurrency-review`, `@instrument-conversion-review`, `@database-code-review`. **No Critical findings.** Important findings applied (serial→concurrent budget fetch; `scheduledBills` gate uses `context.now` while conversion uses `Date()`). Minor doc/style fixes applied; added cross-earmark and date-correctness (`DateBasedFixedConversionService`) tests.
- `just format-check` clean; `just build-mac` succeeds; **21 builder + countNeedsReview tests across 5 suites pass**.

Refs #1031, #1030