### PR TITLE
Insights Phase B (3/3): InsightStore + ProfileSession wiring

### DIFF
--- a/App/ProfileSession+SyncCleanup.swift
+++ b/App/ProfileSession+SyncCleanup.swift
@@ -41,6 +41,7 @@ extension ProfileSession {
     earmarkStore.stopObserving()
     accountGroupStore?.stopObserving()
     groupUIStateStore?.stopObserving()
+    insightStore?.stopObserving()
     categoryStore.stopObserving()
     importRuleStore.stopObserving()
     transactionStore.stopObserving()

--- a/App/ProfileSession.swift
+++ b/App/ProfileSession.swift
@@ -38,6 +38,11 @@ final class ProfileSession: Identifiable {
   /// Local-only (per-device). Same `finishInit`-assigned pattern as
   /// `accountGroupStore`; functionally `let` from the consumer.
   private(set) var groupUIStateStore: GroupUIStateStore?
+  /// Same `finishInit`-assigned pattern as `accountGroupStore`: `InsightStore`
+  /// depends on `accountGroupStore` (also wired in `finishInit`), so it is
+  /// constructed there rather than in `makeDomainStores`. Functionally `let`
+  /// from the consumer's perspective.
+  private(set) var insightStore: InsightStore?
   let analysisStore: AnalysisStore
   let investmentStore: InvestmentStore
   let reportingStore: ReportingStore
@@ -232,6 +237,21 @@ final class ProfileSession: Identifiable {
     // / `cryptoTokenDiscovery` below.
     self.accountGroupStore = AccountGroupStore(repository: backend.accountGroups)
     self.groupUIStateStore = GroupUIStateStore(repository: backend.groupUIState)
+    // InsightStore is wired here (not in `makeDomainStores`) because it reads
+    // `accountGroupStore`, which is itself constructed in `finishInit` — by
+    // this point every `self.*Store` sibling it bundles already exists.
+    let insightSources = InsightStoreSources(
+      analysis: analysisStore,
+      earmark: earmarkStore,
+      reporting: reportingStore,
+      account: accountStore,
+      accountGroup: accountGroupStore,
+      category: categoryStore)
+    self.insightStore = InsightStore(
+      sources: insightSources,
+      backend: backend,
+      profile: profile,
+      instrumentChanges: backend.instrumentChangeObserver)
     let cryptoWiring = Self.makeCryptoSyncWiring(
       backend: backend,
       registry: instrumentRegistry,

--- a/Features/Insights/InsightStore.swift
+++ b/Features/Insights/InsightStore.swift
@@ -1,0 +1,282 @@
+import Foundation
+import OSLog
+import Observation
+
+/// The sibling feature stores `InsightStore` reads each refresh to gather the
+/// main-actor half of an `InsightInput` (the `InsightInputSnapshot`). Bundled
+/// into a single struct so `InsightStore.init` stays within SwiftLint's
+/// `function_parameter_count` budget (≤5); the bundle itself groups the 6
+/// store references. `@MainActor` because every member is a main-actor store
+/// and the snapshot is gathered on the main actor.
+@MainActor
+struct InsightStoreSources {
+  let analysis: AnalysisStore
+  let earmark: EarmarkStore
+  let reporting: ReportingStore
+  let account: AccountStore
+  /// Optional because `ProfileSession` assigns `accountGroupStore` in
+  /// `finishInit` and degraded (preview) launches may omit it.
+  let accountGroup: AccountGroupStore?
+  let category: CategoryStore
+}
+
+/// Owns the "For You" insight surface state: builds the `InsightInput` off the
+/// main actor, runs the pure `InsightEngine`, and publishes the ranked result.
+///
+/// ## Refresh model
+/// This codebase has **no transaction-data change tick** a store can subscribe
+/// to — the sibling analysis stores (`AnalysisStore`, `ReportingStore`) reload
+/// via view-driven `loadAll()` / `refreshIfStale`. `InsightStore` follows the
+/// same contract: new-transaction recomputation rides the view-driven
+/// `refreshIfStale(minimumInterval:)` the surface calls (not a rebuild on every
+/// appearance). The one tick available is the instrument registry's
+/// `observeChanges()` stream — instrument/currency-metadata edits **do** affect
+/// insight conversions, so those trigger an immediate tick-driven `refresh()`.
+///
+/// Detected insights are cached as `lastInput`, so `dismiss(_:)` re-ranks the
+/// already-built input instantly without rebuilding off the main actor.
+@Observable
+@MainActor
+final class InsightStore {
+
+  // MARK: - State
+
+  private(set) var insights: [ScoredInsight] = []
+  private(set) var isLoading = false
+  private(set) var error: Error?
+
+  /// Timestamp of the last successful `refresh()`. Used by `refreshIfStale`
+  /// to skip a rebuild when data was fetched recently (mirrors
+  /// `AnalysisStore.lastLoadedAt`).
+  private(set) var lastLoadedAt: Date?
+
+  // MARK: - Dependencies
+
+  private let sources: InsightStoreSources
+  private let builder: InsightInputBuilder
+  private let engine: InsightEngine
+  /// The reporting currency every monetary input is reduced to.
+  private let reportingInstrument: Instrument
+
+  /// Narrow seam onto the shared instrument registry's change stream. Nil in
+  /// previews / legacy tests so no live observation runs.
+  private let instrumentChanges: (any InstrumentChangeObserving)?
+
+  private let logger = Logger(subsystem: "com.moolah.app", category: "InsightStore")
+
+  // MARK: - Cached / mutable
+
+  /// In-memory dismissal counts per insight kind. Each `dismiss(_:)` bumps the
+  /// kind's count; the ranker's fatigue penalty downranks it. Not persisted —
+  /// dismissal telemetry is a future PR.
+  private var dismissals: [InsightKind: Int] = [:]
+
+  /// The most recently-built `InsightInput`. Cached so `dismiss(_:)` re-ranks
+  /// without rebuilding off the main actor.
+  private var lastInput: InsightInput?
+
+  /// Observes `instrumentChanges.observeChanges()` and re-refreshes on each
+  /// tick. Spawned from `init` when a registry seam is wired; torn down by
+  /// `stopObserving()` / `deinit`.
+  private var instrumentChangeObservationTask: Task<Void, Never>?
+
+  // MARK: - Lifecycle
+
+  init(
+    sources: InsightStoreSources,
+    backend: any BackendProvider,
+    profile: Profile,
+    instrumentChanges: (any InstrumentChangeObserving)? = nil
+  ) {
+    self.sources = sources
+    self.builder = InsightInputBuilder(backend: backend)
+    self.engine = InsightEngine()
+    self.reportingInstrument = profile.instrument
+    self.instrumentChanges = instrumentChanges
+
+    // Strong `self` capture mirrors `EarmarkStore`: the store is
+    // `@MainActor`, the task already holds an implicit strong reference, and
+    // `stopObserving()` (from `cleanupSync`) is the sole lifetime gate.
+    if let instrumentChanges {
+      let changes = instrumentChanges.observeChanges()
+      instrumentChangeObservationTask = Task { [self] in
+        await self.observeInstrumentRegistryChanges(changes)
+      }
+    }
+  }
+
+  deinit {
+    // Safety net for tear-down paths that miss `cleanupSync`. Swift 6 makes
+    // `deinit` nonisolated; reading `@MainActor` state needs
+    // `MainActor.assumeIsolated`. The store is owned by main-actor code
+    // (`ProfileSession`), so the assumption holds.
+    MainActor.assumeIsolated {
+      instrumentChangeObservationTask?.cancel()
+    }
+  }
+
+  /// Tears down the instrument-change observation task. Idempotent. Called
+  /// from `ProfileSession.cleanupSync(coordinator:)`.
+  func stopObserving() {
+    instrumentChangeObservationTask?.cancel()
+  }
+
+  // MARK: - Refresh
+
+  /// Rebuilds the `InsightInput` off the main actor and republishes the ranked
+  /// insights. Mirrors `AnalysisStore.loadAll()`'s loading / cancellation /
+  /// error handling.
+  func refresh() async {
+    guard !isLoading else { return }
+    let snapshot = makeSnapshot()
+    let context = makeContext()
+    isLoading = true
+    defer { isLoading = false }
+    error = nil
+
+    do {
+      let (input, scored) = try await compute(
+        snapshot: snapshot, context: context, dismissals: dismissals)
+      lastInput = input
+      insights = scored
+      lastLoadedAt = Date()
+    } catch is CancellationError {
+      // Surface refresh superseded / view torn down — never surface; a
+      // re-mount issues its own `refresh()`. Mirrors `AnalysisStore`.
+      return
+    } catch {
+      logger.error("Failed to build insights: \(error)")
+      self.error = error
+    }
+  }
+
+  /// Refreshes only if at least `minimumInterval` seconds have elapsed since
+  /// the last successful `refresh()`. Always refreshes if nothing is loaded
+  /// yet. Mirrors `AnalysisStore.refreshIfStale(minimumInterval:)`.
+  func refreshIfStale(minimumInterval: TimeInterval) async {
+    if let last = lastLoadedAt,
+      Date().timeIntervalSince(last) < minimumInterval
+    {
+      return
+    }
+    await refresh()
+  }
+
+  /// Test hook: rewind `lastLoadedAt` to simulate staleness without waiting
+  /// real time. Mirrors `AnalysisStore.overrideLastLoadedAtForTesting`.
+  func overrideLastLoadedAtForTesting(_ date: Date?) {
+    lastLoadedAt = date
+  }
+
+  // MARK: - Dismissal
+
+  /// Records a dismissal for the insight's kind and re-ranks the cached input
+  /// in place — no rebuild. The ranker's fatigue penalty downranks (and
+  /// eventually drops) the kind as its dismissal count rises.
+  func dismiss(_ insight: ScoredInsight) {
+    dismissals[insight.insight.kind, default: 0] += 1
+    if let lastInput {
+      insights = engine.generate(lastInput, dismissals: dismissals)
+    }
+  }
+
+  // MARK: - Compute (off-main)
+
+  /// Builds the input and runs the engine off the main actor. `nonisolated`
+  /// so the heavy `builder.build` and pure `engine.generate` run off
+  /// `@MainActor`; the caller publishes the result on the main actor.
+  /// `dismissals` is passed in (a `Sendable` snapshot) rather than read off
+  /// `self`, so this stays free of main-actor isolation.
+  nonisolated private func compute(
+    snapshot: InsightInputSnapshot,
+    context: InsightContext,
+    dismissals: [InsightKind: Int]
+  ) async throws -> (InsightInput, [ScoredInsight]) {
+    let input = try await builder.build(snapshot: snapshot, context: context)
+    let scored = engine.generate(input, dismissals: dismissals)
+    return (input, scored)
+  }
+
+  /// Consumes the shared instrument registry's change stream. Each tick
+  /// re-refreshes so conversion-dependent insights re-derive. `Task.isCancelled`
+  /// is re-checked before and after each suspension so a teardown racing a tick
+  /// exits before issuing a rebuild and promptly after a long in-flight refresh.
+  /// Mirrors `EarmarkStore`.
+  private func observeInstrumentRegistryChanges(_ changes: AsyncStream<Void>) async {
+    for await _ in changes {
+      if Task.isCancelled { return }
+      await refresh()
+      if Task.isCancelled { return }
+    }
+  }
+
+}
+
+// MARK: - Snapshot / context assembly (main actor)
+
+extension InsightStore {
+  /// Gathers the main-actor half of `InsightInput` from the sibling stores.
+  private func makeSnapshot() -> InsightInputSnapshot {
+    InsightInputSnapshot(
+      monthly: sources.analysis.incomeAndExpense,
+      expenseBreakdown: sources.analysis.expenseBreakdown,
+      dailyBalances: sources.analysis.dailyBalances,
+      earmarks: makeEarmarkSnapshots(),
+      profitLoss: sources.reporting.profitLoss,
+      capitalGains: sources.reporting.capitalGainsResult?.events ?? [],
+      categories: sources.category.categories,
+      accountGroups: (sources.accountGroup?.groups ?? []).map {
+        InsightAccountGroup(id: $0.id, name: $0.name)
+      },
+      accountGroupMembership: makeAccountGroupMembership())
+  }
+
+  private func makeContext() -> InsightContext {
+    InsightContext(
+      now: Date(),
+      reportingCurrency: reportingInstrument,
+      financialMonthEnd: sources.analysis.monthEnd)
+  }
+
+  /// `accountId → groupId` map for every grouped account.
+  private func makeAccountGroupMembership() -> [UUID: UUID] {
+    var membership: [UUID: UUID] = [:]
+    for account in sources.account.accounts.ordered {
+      if let groupId = account.groupId {
+        membership[account.id] = groupId
+      }
+    }
+    return membership
+  }
+
+  /// Joins each same-reporting-currency `Earmark` with its converted balances
+  /// from `EarmarkStore`.
+  ///
+  /// Foreign-instrument earmarks are intentionally omitted (Rule 11 — never
+  /// mislabel native-instrument amounts as reporting currency): the dicts in
+  /// `EarmarkStore` are in each earmark's **own** instrument, not the reporting
+  /// instrument, so including them would mix instruments and risk a trap. This
+  /// is the deliberate, documented degradation until `EarmarkStore` exposes
+  /// per-earmark reporting-currency totals.
+  ///
+  /// Remaining deliberate degradation:
+  /// - `budget: nil` — the per-earmark budget total is not yet reduced to the
+  ///   reporting currency, so it is omitted rather than guessed.
+  private func makeEarmarkSnapshots() -> [EarmarkSnapshot] {
+    let zero = InstrumentAmount.zero(instrument: reportingInstrument)
+    return sources.earmark.earmarks.compactMap { earmark in
+      guard earmark.instrument == reportingInstrument else { return nil }
+      return EarmarkSnapshot(
+        id: earmark.id,
+        name: earmark.name,
+        balance: sources.earmark.convertedBalances[earmark.id] ?? zero,
+        spent: sources.earmark.convertedSpentAmounts[earmark.id],
+        budget: nil,
+        savingsGoal: earmark.savingsGoal,
+        saved: sources.earmark.convertedSavedAmounts[earmark.id],
+        savingsStartDate: earmark.savingsStartDate,
+        savingsEndDate: earmark.savingsEndDate,
+        isHidden: earmark.isHidden)
+    }
+  }
+}

--- a/MoolahTests/Features/Insights/InsightStoreTests.swift
+++ b/MoolahTests/Features/Insights/InsightStoreTests.swift
@@ -1,0 +1,212 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+/// Tests for `InsightStore`: the off-main build + on-main publish pipeline,
+/// in-place re-rank on `dismiss(_:)`, and `refreshIfStale` staleness gating.
+///
+/// Sibling stores are constructed against a `CloudKitAnalysisTestBackend`
+/// (mirroring `ProfileSession.makeDomainStores`) with `instrumentChanges: nil`
+/// so no live registry observation runs during the test. The seed creates a
+/// backlog of uncategorized posted transactions, which deterministically fires
+/// the `uncategorizedBacklog` data-quality insight regardless of sibling-store
+/// priming.
+@MainActor
+@Suite("InsightStore")
+struct InsightStoreTests {
+  private let aud = Instrument.defaultTestInstrument
+
+  // MARK: - Harness
+
+  private func makeProfile() -> Profile {
+    Profile(label: "Test", currencyCode: "AUD", financialYearStartMonth: 7)
+  }
+
+  private func makeSources(_ backend: CloudKitAnalysisTestBackend) -> InsightStoreSources {
+    InsightStoreSources(
+      analysis: AnalysisStore(repository: backend.analysis),
+      earmark: EarmarkStore(
+        repository: backend.earmarks, conversionService: backend.conversionService,
+        targetInstrument: aud, instrumentChanges: nil),
+      reporting: ReportingStore(
+        transactionRepository: backend.transactions, analysisRepository: backend.analysis,
+        conversionService: backend.conversionService, profileCurrency: aud),
+      account: AccountStore(
+        repository: backend.accounts, conversionService: backend.conversionService,
+        targetInstrument: aud, instrumentChanges: nil),
+      accountGroup: AccountGroupStore(repository: backend.accountGroups),
+      category: CategoryStore(repository: backend.categories))
+  }
+
+  private func makeStore(_ backend: CloudKitAnalysisTestBackend) -> InsightStore {
+    InsightStore(
+      sources: makeSources(backend), backend: backend, profile: makeProfile(),
+      instrumentChanges: nil)
+  }
+
+  /// Seeds `count` posted, fully-uncategorized transactions so the
+  /// `uncategorizedBacklog` insight (threshold 10) fires deterministically.
+  private func seedUncategorizedBacklog(
+    _ backend: CloudKitAnalysisTestBackend, count: Int
+  ) async throws {
+    for index in 0..<count {
+      _ = try await backend.transactions.create(
+        Transaction(
+          date: try AnalysisTestHelpers.utcDate(year: 2026, month: 5, day: 1),
+          payee: "Merchant \(index)",
+          legs: [
+            TransactionLeg(
+              accountId: nil, instrument: aud, quantity: -10, type: .expense, categoryId: nil)
+          ]))
+    }
+  }
+
+  // MARK: - refresh
+
+  @Test("refresh builds and publishes insights")
+  func refreshPublishesInsights() async throws {
+    let backend = try CloudKitAnalysisTestBackend()
+    try await seedUncategorizedBacklog(backend, count: 12)
+    let store = makeStore(backend)
+
+    await store.refresh()
+
+    #expect(!store.insights.isEmpty)
+    #expect(store.error == nil)
+    #expect(store.isLoading == false)
+    #expect(store.lastLoadedAt != nil)
+    #expect(store.insights.contains { $0.insight.kind == .uncategorizedBacklog })
+  }
+
+  // MARK: - dismiss
+
+  @Test("dismiss re-ranks in place without rebuilding and downranks the kind")
+  func dismissDownranksKind() async throws {
+    let backend = try CloudKitAnalysisTestBackend()
+    try await seedUncategorizedBacklog(backend, count: 12)
+    let store = makeStore(backend)
+    await store.refresh()
+
+    let target = try #require(
+      store.insights.first { $0.insight.kind == .uncategorizedBacklog })
+    let loadedAtBeforeDismiss = store.lastLoadedAt
+
+    store.dismiss(target)
+    let afterFirst = try #require(
+      store.insights.first { $0.insight.kind == .uncategorizedBacklog })
+    // Fatigue penalty lowers the score; re-rank happened in place (no rebuild,
+    // so `lastLoadedAt` is untouched).
+    #expect(afterFirst.score < target.score)
+    #expect(store.lastLoadedAt == loadedAtBeforeDismiss)
+
+    store.dismiss(afterFirst)
+    let afterSecond = try #require(
+      store.insights.first { $0.insight.kind == .uncategorizedBacklog })
+    // A second dismiss further suppresses it.
+    #expect(afterSecond.score < afterFirst.score)
+  }
+
+  // MARK: - refreshIfStale
+
+  @Test("refreshIfStale skips a rebuild within the interval")
+  func refreshIfStaleSkipsWithinInterval() async throws {
+    let backend = try CloudKitAnalysisTestBackend()
+    try await seedUncategorizedBacklog(backend, count: 12)
+    let store = makeStore(backend)
+    await store.refresh()
+    let firstLoadedAt = try #require(store.lastLoadedAt)
+
+    // A very large interval means the recent load is still fresh — no rebuild.
+    await store.refreshIfStale(minimumInterval: 10_000)
+
+    #expect(store.lastLoadedAt == firstLoadedAt)
+  }
+
+  @Test("refreshIfStale rebuilds when stale")
+  func refreshIfStaleRebuildsWhenStale() async throws {
+    let backend = try CloudKitAnalysisTestBackend()
+    try await seedUncategorizedBacklog(backend, count: 12)
+    let store = makeStore(backend)
+    await store.refresh()
+    let firstLoadedAt = try #require(store.lastLoadedAt)
+
+    // Rewind the clock so the store considers itself stale.
+    store.overrideLastLoadedAtForTesting(Date(timeIntervalSinceNow: -3600))
+    await store.refreshIfStale(minimumInterval: 60)
+
+    let secondLoadedAt = try #require(store.lastLoadedAt)
+    #expect(secondLoadedAt > firstLoadedAt)
+    #expect(!store.insights.isEmpty)
+  }
+
+  @Test("refreshIfStale always refreshes if nothing has been loaded yet")
+  func refreshIfStaleLoadsWhenNeverRefreshed() async throws {
+    let backend = try CloudKitAnalysisTestBackend()
+    try await seedUncategorizedBacklog(backend, count: 12)
+    let store = makeStore(backend)
+
+    // No prior refresh — `lastLoadedAt` is nil, so a very large interval must
+    // not suppress the load.
+    await store.refreshIfStale(minimumInterval: 10_000)
+
+    #expect(store.lastLoadedAt != nil)
+    #expect(!store.insights.isEmpty)
+  }
+
+  // MARK: - Earmark instrument filtering
+
+  @Test("makeEarmarkSnapshots omits foreign-instrument earmarks")
+  func earmarkSnapshotsOmitsForeignInstrument() async throws {
+    let backend = try CloudKitAnalysisTestBackend()
+
+    // Seed an AUD earmark (reporting instrument) — must appear in snapshot.
+    let audEarmark = Earmark(
+      name: "AUD Savings",
+      instrument: .AUD,
+      savingsGoal: InstrumentAmount(quantity: 1000, instrument: .AUD))
+    _ = try await backend.earmarks.create(audEarmark)
+
+    // Seed a USD earmark (foreign instrument) — must be omitted from snapshot.
+    let usdEarmark = Earmark(
+      name: "USD Travel Fund",
+      instrument: .USD,
+      savingsGoal: InstrumentAmount(quantity: 500, instrument: .USD))
+    _ = try await backend.earmarks.create(usdEarmark)
+
+    let sources = makeSources(backend)
+    // Wait for the reactive EarmarkStore to observe both seeded earmarks before
+    // InsightStore.refresh() reads the snapshot — avoids a race where the
+    // snapshot sees an empty list.
+    try await sources.earmark.waitForNextEmission(
+      matching: {
+        $0.earmarks.by(id: audEarmark.id) != nil
+          && $0.earmarks.by(id: usdEarmark.id) != nil
+      },
+      description: "both earmarks observed")
+
+    // Seed uncategorized transactions so the engine runs and the `refresh()`
+    // pipeline exercises the full path.
+    try await seedUncategorizedBacklog(backend, count: 12)
+
+    let store = InsightStore(
+      sources: sources, backend: backend, profile: makeProfile(),
+      instrumentChanges: nil)
+    await store.refresh()
+
+    // Refresh must succeed without trapping on mismatched instruments.
+    #expect(store.error == nil)
+    #expect(store.isLoading == false)
+    // The uncategorized-backlog insight fires, proving the engine ran against
+    // the AUD earmark only (no USD-instrument trap in the snapshot).
+    #expect(store.insights.contains { $0.insight.kind == .uncategorizedBacklog })
+  }
+
+  // MARK: - Error path
+
+  // FIX 8 (SKIPPED): `InsightInputBuilder.build()` drops failed conversions per
+  // Rule 11 rather than throwing — so a conversion-service failure does not make
+  // `build()` throw or set `store.error`. The error path in `refresh()` is
+  // reached only by unexpected repository/DB failures, which `CloudKitAnalysisTestBackend`
+  // does not expose an injection point for. No fabricated test added here.
+}


### PR DESCRIPTION
## Phase B, PR 3 of 3 — store + wiring

The end-to-end layer: an `@Observable @MainActor InsightStore` that produces ranked insights from the Phase-A/B pipeline and is wired into `ProfileSession`. Completes Phase B (everything except the Phase C dashboard UI). Builds on #1038 + #1039 (both merged).

### What changed
- **`Features/Insights/InsightStore.swift`** (new) — `@Observable @MainActor final class InsightStore` + a `@MainActor struct InsightStoreSources` bundling the 6 sibling stores (keeps `init` ≤5 params).
  - `refresh()` gathers an `InsightInputSnapshot` from the sibling stores on the main actor, then a `nonisolated compute()` runs `InsightInputBuilder.build` + `InsightEngine.generate` **off-main**, publishing `[ScoredInsight]` back on main. `refreshIfStale(minimumInterval:)` mirrors `AnalysisStore` (caches between refreshes — not a rebuild per appearance).
  - `dismiss(_:)` bumps in-memory `dismissals[kind]` and re-ranks from the cached `lastInput` — instant, no rebuild.
  - Subscribes to the instrument-change tick (`observeChanges()`) for an immediate recompute on currency changes; `stopObserving()`/`deinit` teardown mirrors `EarmarkStore` and is wired into `ProfileSession+SyncCleanup`.
- **`App/ProfileSession.swift` / `+SyncCleanup.swift`** — construct `insightStore` in `finishInit` (alongside `accountGroupStore`, which it depends on and which lives outside `makeDomainStores`); cleanup wired.

### Correctness notes
- **Earmark instrument safety:** `EarmarkStore`'s per-earmark `convertedBalances/Saved/Spent` are in each earmark's *own* instrument (not the reporting currency). So `InsightStore` emits `EarmarkSnapshot`s **only** for earmarks whose instrument equals the reporting instrument; foreign-instrument earmarks are dropped rather than mislabelled (Rule 11), pending a future per-earmark reporting-currency exposure from `EarmarkStore`. `budget` is `nil` for now.
- **Change-tick model (honest):** the codebase has no transaction-data change tick — `AnalysisStore`/`ReportingStore` reload view-driven. `InsightStore` recomputes automatically on instrument-change ticks; new-transaction recompute rides the view-driven `refreshIfStale` (same as the analysis stores). The Phase C view must wire `refreshIfStale` on appearance/scene-phase.

### Review & verification
- Ran `@code-review`, `@concurrency-review`, `@instrument-conversion-review`. The **Critical** earmark-instrument mismatch and the concurrency findings (concurrent-load guard, `defer`-reset of `isLoading`, post-refresh cancellation check) are fixed.
- `just format-check` clean; `just build-mac` succeeds; **6 InsightStore tests pass** (refresh/publish, dismiss re-rank, refreshIfStale fresh/stale/never-loaded, foreign-instrument earmark omission).

Refs #1031, #1030