### PR TITLE
Insights Phase E2: insight narrator (prompt, provenance guard, template fallback, FM streaming)

### DIFF
--- a/Domain/Insights/Narration/InsightNarrating.swift
+++ b/Domain/Insights/Narration/InsightNarrating.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+/// Errors a narrator may throw into its output stream. Callers that receive
+/// `.fellBack` should substitute the template narrator's output — the user
+/// sees the deterministic fallback, not the error (issue #1042).
+enum NarrationError: Error {
+  /// The narrator could not produce grounded output (provenance check failed
+  /// or the model threw) — the caller must fall back to the template.
+  case fellBack
+}
+
+/// Produces narration for a `NarrationRequest` as a stream of cumulative
+/// snapshots. The final element is the complete narration text.
+///
+/// Implementations must be `Sendable` so they can be injected into
+/// `@MainActor`-isolated stores and called from concurrent contexts.
+/// Each call to `narrate` creates an independent stream — implementations
+/// must not share mutable state across calls.
+protocol InsightNarrating: Sendable {
+  /// Returns an async stream of cumulative narration snapshots. The stream
+  /// ends cleanly when narration is complete, or finishes throwing
+  /// `NarrationError.fellBack` when the output cannot be trusted (provenance
+  /// check failed) or the underlying model errors — callers must then fall
+  /// back to `TemplateNarrator`.
+  func narrate(_ request: NarrationRequest) -> AsyncThrowingStream<String, any Error>
+}

--- a/Domain/Insights/Narration/InsightNarrating.swift
+++ b/Domain/Insights/Narration/InsightNarrating.swift
@@ -1,14 +1,5 @@
 import Foundation
 
-/// Errors a narrator may throw into its output stream. Callers that receive
-/// `.fellBack` should substitute the template narrator's output — the user
-/// sees the deterministic fallback, not the error (issue #1042).
-enum NarrationError: Error {
-  /// The narrator could not produce grounded output (provenance check failed
-  /// or the model threw) — the caller must fall back to the template.
-  case fellBack
-}
-
 /// Produces narration for a `NarrationRequest` as a stream of cumulative
 /// snapshots. The final element is the complete narration text.
 ///
@@ -22,5 +13,5 @@ protocol InsightNarrating: Sendable {
   /// `NarrationError.fellBack` when the output cannot be trusted (provenance
   /// check failed) or the underlying model errors — callers must then fall
   /// back to `TemplateNarrator`.
-  func narrate(_ request: NarrationRequest) -> AsyncThrowingStream<String, any Error>
+  nonisolated func narrate(_ request: NarrationRequest) -> AsyncThrowingStream<String, any Error>
 }

--- a/Domain/Insights/Narration/NarrationError.swift
+++ b/Domain/Insights/Narration/NarrationError.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+/// Errors a narrator may throw into its output stream. Callers that receive
+/// `.fellBack` should substitute the template narrator's output — the user
+/// sees the deterministic fallback, not the error (issue #1042).
+enum NarrationError: Error {
+  /// The narrator could not produce grounded output (provenance check failed
+  /// or the model threw) — the caller must fall back to the template.
+  case fellBack
+}

--- a/Domain/Insights/Narration/NarrationPromptBuilder.swift
+++ b/Domain/Insights/Narration/NarrationPromptBuilder.swift
@@ -1,0 +1,89 @@
+import Foundation
+
+/// Converts a `NarrationRequest` into the system instructions and user prompt
+/// passed to the language model. Pure: no model calls, no side effects, fully
+/// testable in CI without a device (issue #1042).
+///
+/// Discipline encoded in the instructions:
+/// - Use ONLY the figures provided verbatim — do not invent, recompute, or round any number.
+/// - Write plain, warm, non-judgemental prose (brand voice: confident, permission-giving).
+/// - Per-insight: one to two sentences. Weekly recap: exactly two sentences.
+enum NarrationPromptBuilder {
+  /// Builds the `(instructions, prompt)` pair for the given request.
+  ///
+  /// `instructions` becomes the session's system prompt (sets the model's role
+  /// and discipline). `prompt` is the user turn (the specific insight or recap
+  /// to narrate).
+  static func build(_ request: NarrationRequest) -> (instructions: String, prompt: String) {
+    switch request {
+    case let .singleInsight(title, facts):
+      return (
+        instructions: singleInsightInstructions,
+        prompt: singleInsightPrompt(title: title, facts: facts)
+      )
+    case let .weeklyRecap(items):
+      return (
+        instructions: recapInstructions,
+        prompt: recapPrompt(items: items)
+      )
+    }
+  }
+}
+
+extension NarrationPromptBuilder {
+  private static let singleInsightInstructions = """
+    You are a personal finance assistant for moolah.rocks. Your role is to narrate \
+    a single financial insight in plain, warm, non-judgemental prose — the kind of \
+    tone that says "here's what's happening with your money" without lecturing or \
+    worrying the reader.
+
+    Rules you must follow:
+    • Use ONLY the figures provided verbatim in the prompt. Do not invent, recompute, \
+    round, or approximate any number. Every figure you write must appear exactly in \
+    the supplied facts.
+    • Write one to two sentences. No bullet points, no headers.
+    • Do not judge spending choices. Do not use words like "overspent", "wasted", \
+    or "should".
+    • Plain language. "where your money goes" beats "expenditure allocation".
+    • Address the user as "you" or "your".
+    """
+
+  private static let recapInstructions = """
+    You are a personal finance assistant for moolah.rocks. Your role is to narrate \
+    a brief weekly recap of the user's financial highlights in plain, warm, \
+    non-judgemental prose.
+
+    Rules you must follow:
+    • Use ONLY the figures provided verbatim in the prompt. Do not invent, recompute, \
+    round, or approximate any number. Every figure you write must appear exactly in \
+    the supplied facts.
+    • Write exactly two sentences covering the listed insights together.
+    • Do not judge spending choices. Do not use words like "overspent", "wasted", \
+    or "should".
+    • Plain language. Address the user as "you" or "your".
+    """
+
+  private static func singleInsightPrompt(title: String, facts: [InsightFact]) -> String {
+    var lines = ["Insight: \(title)"]
+    if !facts.isEmpty {
+      lines.append("Facts:")
+      for fact in facts {
+        lines.append("  \(fact.label): \(fact.value)")
+      }
+    }
+    lines.append("\nNarrate this insight in one to two sentences.")
+    return lines.joined(separator: "\n")
+  }
+
+  private static func recapPrompt(items: [NarrationRequest.Item]) -> String {
+    var lines = ["Weekly recap — \(items.count) highlight(s) this week:"]
+    for (index, item) in items.enumerated() {
+      lines.append("\n\(index + 1). \(item.title)")
+      for fact in item.facts {
+        lines.append("   \(fact.label): \(fact.value)")
+      }
+    }
+    lines.append("\nSummarise these highlights in exactly two sentences.")
+    return lines.joined(separator: "\n")
+  }
+}

--- a/Domain/Insights/Narration/NarrationPromptBuilder.swift
+++ b/Domain/Insights/Narration/NarrationPromptBuilder.swift
@@ -6,7 +6,9 @@ import Foundation
 ///
 /// Discipline encoded in the instructions:
 /// - Use ONLY the figures provided verbatim — do not invent, recompute, or round any number.
+/// - Omit statistical/technical facts (z-scores, p-values, counts, direction labels).
 /// - Write plain, warm, non-judgemental prose (brand voice: confident, permission-giving).
+/// - Use contractions where natural; avoid corporate vocabulary.
 /// - Per-insight: one to two sentences. Weekly recap: exactly two sentences.
 enum NarrationPromptBuilder {
   /// Builds the `(instructions, prompt)` pair for the given request.
@@ -16,10 +18,10 @@ enum NarrationPromptBuilder {
   /// to narrate).
   static func build(_ request: NarrationRequest) -> (instructions: String, prompt: String) {
     switch request {
-    case let .singleInsight(title, facts):
+    case let .singleInsight(title, detail, facts):
       return (
         instructions: singleInsightInstructions,
-        prompt: singleInsightPrompt(title: title, facts: facts)
+        prompt: singleInsightPrompt(title: title, detail: detail, facts: facts)
       )
     case let .weeklyRecap(items):
       return (
@@ -41,10 +43,15 @@ extension NarrationPromptBuilder {
     • Use ONLY the figures provided verbatim in the prompt. Do not invent, recompute, \
     round, or approximate any number. Every figure you write must appear exactly in \
     the supplied facts.
+    • Do not quote fact labels verbatim. Weave the numbers into natural prose. Omit any \
+    statistical or technical fact — z-scores, p-values, counts of months, direction \
+    labels — those are evidence for you, not for the user.
+    • Avoid corporate vocabulary: do not use optimise, leverage, empower, take control, \
+    streamline, robust, or seamless. Use ordinary words instead.
+    • Use contractions where they sound natural: "you've", "it's", "that's".
+    • Match the insight's tone. If it's good news, let a little warmth show — one beat, \
+    not a speech. Never scold: avoid "overspent", "wasted", "should".
     • Write one to two sentences. No bullet points, no headers.
-    • Do not judge spending choices. Do not use words like "overspent", "wasted", \
-    or "should".
-    • Plain language. "where your money goes" beats "expenditure allocation".
     • Address the user as "you" or "your".
     """
 
@@ -57,16 +64,25 @@ extension NarrationPromptBuilder {
     • Use ONLY the figures provided verbatim in the prompt. Do not invent, recompute, \
     round, or approximate any number. Every figure you write must appear exactly in \
     the supplied facts.
+    • Do not quote fact labels verbatim. Weave the numbers into natural prose. Omit any \
+    statistical or technical fact — z-scores, p-values, counts of months, direction \
+    labels — those are evidence for you, not for the user.
+    • Avoid corporate vocabulary: do not use optimise, leverage, empower, take control, \
+    streamline, robust, or seamless. Use ordinary words instead.
+    • Use contractions where they sound natural: "you've", "it's", "that's".
+    • Match the insight's tone. If it's good news, let a little warmth show — one beat, \
+    not a speech. Never scold: avoid "overspent", "wasted", "should".
     • Write exactly two sentences covering the listed insights together.
-    • Do not judge spending choices. Do not use words like "overspent", "wasted", \
-    or "should".
-    • Plain language. Address the user as "you" or "your".
+    • Address the user as "you" or "your".
     """
 
-  private static func singleInsightPrompt(title: String, facts: [InsightFact]) -> String {
+  private static func singleInsightPrompt(title: String, detail: String, facts: [InsightFact])
+    -> String
+  {
     var lines = ["Insight: \(title)"]
+    lines.append("Draft: \(detail)")
     if !facts.isEmpty {
-      lines.append("Facts:")
+      lines.append("Facts (numbers only — do not repeat labels):")
       for fact in facts {
         lines.append("  \(fact.label): \(fact.value)")
       }
@@ -76,9 +92,11 @@ extension NarrationPromptBuilder {
   }
 
   private static func recapPrompt(items: [NarrationRequest.Item]) -> String {
-    var lines = ["Weekly recap — \(items.count) highlight(s) this week:"]
+    let highlightWord = items.count == 1 ? "highlight" : "highlights"
+    var lines = ["Weekly recap — \(items.count) \(highlightWord) this week:"]
     for (index, item) in items.enumerated() {
       lines.append("\n\(index + 1). \(item.title)")
+      lines.append("   Draft: \(item.detail)")
       for fact in item.facts {
         lines.append("   \(fact.label): \(fact.value)")
       }

--- a/Domain/Insights/Narration/NarrationRequest.swift
+++ b/Domain/Insights/Narration/NarrationRequest.swift
@@ -5,7 +5,7 @@ import Foundation
 /// (zero-hallucination seam, issue #1042).
 enum NarrationRequest: Sendable, Hashable {
   /// A single insight to narrate in one or two sentences.
-  case singleInsight(title: String, facts: [InsightFact])
+  case singleInsight(title: String, detail: String, facts: [InsightFact])
 
   /// A collection of insights to narrate as a brief two-sentence weekly recap.
   case weeklyRecap(items: [Item])
@@ -13,6 +13,7 @@ enum NarrationRequest: Sendable, Hashable {
   /// One entry in a weekly-recap narration request.
   struct Item: Sendable, Hashable {
     let title: String
+    let detail: String
     let facts: [InsightFact]
   }
 
@@ -21,7 +22,7 @@ enum NarrationRequest: Sendable, Hashable {
   /// supplied verbatim here — never invented by the model.
   var allFacts: [InsightFact] {
     switch self {
-    case .singleInsight(_, let facts):
+    case .singleInsight(_, _, let facts):
       return facts
     case .weeklyRecap(let items):
       return items.flatMap(\.facts)

--- a/Domain/Insights/Narration/NarrationRequest.swift
+++ b/Domain/Insights/Narration/NarrationRequest.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+/// The sole input to any narrator. Built from pre-formatted `InsightFact` values
+/// so the language model never receives raw transactions or unformatted amounts
+/// (zero-hallucination seam, issue #1042).
+enum NarrationRequest: Sendable, Hashable {
+  /// A single insight to narrate in one or two sentences.
+  case singleInsight(title: String, facts: [InsightFact])
+
+  /// A collection of insights to narrate as a brief two-sentence weekly recap.
+  case weeklyRecap(items: [Item])
+
+  /// One entry in a weekly-recap narration request.
+  struct Item: Sendable, Hashable {
+    let title: String
+    let facts: [InsightFact]
+  }
+
+  /// Every fact across the request, in presentation order. Used by the numeric
+  /// provenance guard to verify that all numbers in the generated text were
+  /// supplied verbatim here — never invented by the model.
+  var allFacts: [InsightFact] {
+    switch self {
+    case .singleInsight(_, let facts):
+      return facts
+    case .weeklyRecap(let items):
+      return items.flatMap(\.facts)
+    }
+  }
+}

--- a/Domain/Insights/Narration/NumericProvenanceGuard.swift
+++ b/Domain/Insights/Narration/NumericProvenanceGuard.swift
@@ -13,15 +13,16 @@ import Foundation
 /// 1. Strip currency symbols (`$`, `€`, `£`, `¥`, `₹`, `₩`, `₿`) — they are
 ///    presentation wrappers, not part of the numeric identity.
 /// 2. Strip a leading ASCII `+` — positive is the default; `+12.5%` and `12.5%`
-///    are the same value. The Unicode minus `−` and ASCII `-` are always
-///    preserved so sign flips are detectable.
-/// 3. Strip thousands separators — a comma or period between digit groups
+///    are the same value.
+/// 3. Canonicalize the Unicode minus `−` (U+2212) to ASCII `-` (U+002D) so a
+///    model that outputs ASCII `-640.00` still matches a fact written `−640.00`
+///    (U+2212). Sign identity is preserved — a genuine sign flip (negative fact,
+///    positive generated text) still fails the guard.
+/// 4. Strip thousands separators — a comma or period between digit groups
 ///    (e.g. `1,200` → `1200`). A period before 1–2 trailing digits is kept
 ///    as the decimal separator.
-/// 4. Keep the negative sign and decimal separator intact. A model that flips
-///    `−640.00` to `640.00` produces a non-matching token, so the guard
-///    rejects it — consistent with the project rule that signs are never
-///    silently dropped or reversed.
+/// 5. Keep the negative sign and decimal separator intact. A model that drops
+///    the sign produces a non-matching token, so the guard rejects it.
 ///
 /// The guard errs toward rejection on ambiguity.
 enum NumericProvenanceGuard {
@@ -44,6 +45,7 @@ enum NumericProvenanceGuard {
     }
     return true
   }
+
 }
 
 extension NumericProvenanceGuard {
@@ -161,7 +163,7 @@ extension NumericProvenanceGuard {
   /// Normalises a raw numeric string (token or fact value) to a canonical form
   /// for equality comparison. See the type-level documentation for the full
   /// normalisation rules.
-  static func normalise(_ raw: String) -> String {
+  private static func normalise(_ raw: String) -> String {
     var working = raw
 
     // 1. Strip common currency symbols.
@@ -169,12 +171,17 @@ extension NumericProvenanceGuard {
     working = String(working.filter { !currencySymbols.contains($0) })
 
     // 2. Strip a leading ASCII `+` (positive is the default).
-    //    Never strip `−` (U+2212) or `-` (ASCII 0x2D) — those are negative.
     if working.hasPrefix("+") {
       working = String(working.dropFirst())
     }
 
-    // 3. Collapse thousands separators.
+    // 3. Canonicalize the Unicode minus sign (U+2212) to ASCII hyphen-minus
+    //    (U+002D). Detectors emit U+2212; LLMs emit ASCII. Unifying the
+    //    codepoint lets them compare equal while preserving sign identity —
+    //    a genuine sign flip still produces a mismatch after normalisation.
+    working = working.replacingOccurrences(of: "\u{2212}", with: "-")
+
+    // 4. Collapse thousands separators.
     return collapseThousandsSeparators(in: working)
   }
 

--- a/Domain/Insights/Narration/NumericProvenanceGuard.swift
+++ b/Domain/Insights/Narration/NumericProvenanceGuard.swift
@@ -1,0 +1,218 @@
+import Foundation
+
+/// Verifies that every numeric token in model-generated text can be traced back
+/// to a supplied fact value. A heuristic safety net: when it fails, the caller
+/// falls back to `TemplateNarrator` rather than showing potentially invented
+/// numbers to the user (issue #1042).
+///
+/// ## Normalisation
+///
+/// Normalisation is applied identically to both the generated text and the fact
+/// values before comparison:
+///
+/// 1. Strip currency symbols (`$`, `€`, `£`, `¥`, `₹`, `₩`, `₿`) — they are
+///    presentation wrappers, not part of the numeric identity.
+/// 2. Strip a leading ASCII `+` — positive is the default; `+12.5%` and `12.5%`
+///    are the same value. The Unicode minus `−` and ASCII `-` are always
+///    preserved so sign flips are detectable.
+/// 3. Strip thousands separators — a comma or period between digit groups
+///    (e.g. `1,200` → `1200`). A period before 1–2 trailing digits is kept
+///    as the decimal separator.
+/// 4. Keep the negative sign and decimal separator intact. A model that flips
+///    `−640.00` to `640.00` produces a non-matching token, so the guard
+///    rejects it — consistent with the project rule that signs are never
+///    silently dropped or reversed.
+///
+/// The guard errs toward rejection on ambiguity.
+enum NumericProvenanceGuard {
+  /// Returns `true` iff every numeric token extracted from `generated` appears
+  /// verbatim in the normalised pool of all `facts` values.
+  ///
+  /// A `true` result means narration passed; `false` means at least one number
+  /// could not be traced to the supplied facts — the caller must fall back.
+  static func isGrounded(_ generated: String, facts: [InsightFact]) -> Bool {
+    let tokens = numericTokens(in: generated)
+    guard !tokens.isEmpty else { return true }
+
+    let factPool = facts.map { normalise($0.value) }
+
+    for token in tokens {
+      let normToken = normalise(token)
+      guard factPool.contains(where: { $0 == normToken }) else {
+        return false
+      }
+    }
+    return true
+  }
+}
+
+extension NumericProvenanceGuard {
+  // MARK: - Token extraction
+
+  /// Extracts numeric tokens from `text` by scanning Unicode scalars.
+  ///
+  /// Currency symbols are stripped first so a sign immediately before a
+  /// currency symbol (e.g. `−$640.00`) becomes adjacent to the digit after
+  /// stripping (`−640.00`), allowing the sign to be captured as part of the
+  /// token. Interior separators (commas, dots) are included only when
+  /// immediately followed by a digit, preventing trailing separators from
+  /// contaminating the token.
+  private static func numericTokens(in text: String) -> [String] {
+    let currencySymbols: Set<Unicode.Scalar> = ["$", "€", "£", "¥", "₹", "₩", "₿"]
+    let stripped = String(text.unicodeScalars.filter { !currencySymbols.contains($0) })
+    let scalars = Array(stripped.unicodeScalars)
+
+    var tokens: [String] = []
+    var index = 0
+    while index < scalars.count {
+      if let (token, nextIndex) = extractToken(from: scalars, at: index) {
+        tokens.append(token)
+        index = nextIndex
+      } else {
+        index += 1
+      }
+    }
+    return tokens
+  }
+
+  /// Attempts to extract a single numeric token starting at `position`.
+  /// Returns the token string and the index of the next unscanned character,
+  /// or `nil` if no token starts at `position`.
+  private static func extractToken(
+    from scalars: [Unicode.Scalar],
+    at position: Int
+  ) -> (token: String, nextIndex: Int)? {
+    // 0x2B = '+', 0x2D = '-', 0x2212 = '−' (Unicode MINUS SIGN).
+    let scalar = scalars[position]
+    let isSign = scalar.value == 0x2B || scalar.value == 0x2D || scalar.value == 0x2212
+    let isDigit = scalar.value >= 48 && scalar.value <= 57
+
+    let startsWithSign =
+      isSign
+      && position + 1 < scalars.count
+      && scalars[position + 1].value >= 48
+      && scalars[position + 1].value <= 57
+    let startsWithDigit = isDigit
+
+    guard startsWithSign || startsWithDigit else { return nil }
+
+    var tokenScalars: [Unicode.Scalar] = []
+    var cursor = position
+
+    if startsWithSign {
+      tokenScalars.append(scalars[cursor])
+      cursor += 1
+    }
+
+    guard cursor < scalars.count,
+      scalars[cursor].value >= 48,
+      scalars[cursor].value <= 57
+    else { return nil }
+
+    cursor = consumeDigitGroup(from: scalars, into: &tokenScalars, at: cursor)
+
+    // Consume optional trailing percent. 0x25 = '%'.
+    if cursor < scalars.count, scalars[cursor].value == 0x25 {
+      tokenScalars.append(scalars[cursor])
+      cursor += 1
+    }
+
+    let token = String(String.UnicodeScalarView(tokenScalars))
+    guard token.unicodeScalars.contains(where: { $0.value >= 48 && $0.value <= 57 }) else {
+      return nil
+    }
+    return (token, cursor)
+  }
+
+  /// Consumes digit groups — digits, and separators (commas/dots) that are
+  /// immediately followed by another digit — into `output`, starting at
+  /// `position`. Returns the index of the first un-consumed character.
+  private static func consumeDigitGroup(
+    from scalars: [Unicode.Scalar],
+    into output: inout [Unicode.Scalar],
+    at position: Int
+  ) -> Int {
+    var cursor = position
+    while cursor < scalars.count {
+      let scalar = scalars[cursor]
+      let isDigit = scalar.value >= 48 && scalar.value <= 57
+      // 0x2C = ',', 0x2E = '.'
+      let isSeparator = scalar.value == 0x2C || scalar.value == 0x2E
+
+      if isDigit {
+        output.append(scalar)
+        cursor += 1
+      } else if isSeparator,
+        cursor + 1 < scalars.count,
+        scalars[cursor + 1].value >= 48,
+        scalars[cursor + 1].value <= 57
+      {
+        output.append(scalar)
+        cursor += 1
+      } else {
+        break
+      }
+    }
+    return cursor
+  }
+
+  // MARK: - Normalisation
+
+  /// Normalises a raw numeric string (token or fact value) to a canonical form
+  /// for equality comparison. See the type-level documentation for the full
+  /// normalisation rules.
+  static func normalise(_ raw: String) -> String {
+    var working = raw
+
+    // 1. Strip common currency symbols.
+    let currencySymbols: Set<Character> = ["$", "€", "£", "¥", "₹", "₩", "₿"]
+    working = String(working.filter { !currencySymbols.contains($0) })
+
+    // 2. Strip a leading ASCII `+` (positive is the default).
+    //    Never strip `−` (U+2212) or `-` (ASCII 0x2D) — those are negative.
+    if working.hasPrefix("+") {
+      working = String(working.dropFirst())
+    }
+
+    // 3. Collapse thousands separators.
+    return collapseThousandsSeparators(in: working)
+  }
+
+  /// Drops commas and periods that are thousands separators (followed by 3+
+  /// digits) while preserving decimal separators (followed by 1–2 digits).
+  private static func collapseThousandsSeparators(in value: String) -> String {
+    var result = ""
+    let chars = Array(value)
+    var index = 0
+    while index < chars.count {
+      let char = chars[index]
+      if char == "," || char == ".",
+        index > 0,
+        index < chars.count - 1,
+        chars[index - 1].isNumber,
+        chars[index + 1].isNumber
+      {
+        let remainingDigits = countLeadingDigits(chars, from: index + 1)
+        if remainingDigits >= 3 {
+          index += 1
+          continue  // Thousands separator — drop it.
+        }
+        // Decimal separator — keep it.
+      }
+      result.append(char)
+      index += 1
+    }
+    return result
+  }
+
+  /// Counts consecutive ASCII digit characters starting at `startIndex`.
+  private static func countLeadingDigits(_ chars: [Character], from startIndex: Int) -> Int {
+    var count = 0
+    var index = startIndex
+    while index < chars.count, chars[index].isNumber {
+      count += 1
+      index += 1
+    }
+    return count
+  }
+}

--- a/Domain/Insights/Narration/TemplateNarrator.swift
+++ b/Domain/Insights/Narration/TemplateNarrator.swift
@@ -1,16 +1,16 @@
 import Foundation
 
 /// Deterministic, model-free narrator that composes a narration from the
-/// request's title and facts. Produces a single snapshot (the full composed
-/// string) and finishes immediately.
+/// request's detail sentence (or title as fallback). Produces a single snapshot
+/// (the full composed string) and finishes immediately.
 ///
 /// Used in two roles:
 /// 1. **Resilience fallback** — when the on-device model is available but a
 ///    generation call fails (provenance check rejected, model error, etc.).
 /// 2. **CI fake / test double** — injected in tests and previews so no real
 ///    model is required.
-struct TemplateNarrator: InsightNarrating, Sendable {
-  func narrate(_ request: NarrationRequest) -> AsyncThrowingStream<String, any Error> {
+struct TemplateNarrator: InsightNarrating {
+  nonisolated func narrate(_ request: NarrationRequest) -> AsyncThrowingStream<String, any Error> {
     let text = compose(request)
     return AsyncThrowingStream { continuation in
       continuation.yield(text)
@@ -22,28 +22,23 @@ struct TemplateNarrator: InsightNarrating, Sendable {
 extension TemplateNarrator {
   private func compose(_ request: NarrationRequest) -> String {
     switch request {
-    case let .singleInsight(title, facts):
-      return composeSingle(title: title, facts: facts)
+    case let .singleInsight(title, detail, _):
+      return detail.isEmpty ? title : detail
     case let .weeklyRecap(items):
       return composeRecap(items: items)
     }
   }
 
-  private func composeSingle(title: String, facts: [InsightFact]) -> String {
-    guard !facts.isEmpty else { return title + "." }
-    let factList = facts.map { "\($0.label): \($0.value)" }.joined(separator: ", ")
-    return "\(title). \(factList)."
-  }
-
   private func composeRecap(items: [NarrationRequest.Item]) -> String {
-    guard !items.isEmpty else { return "Here's your weekly recap." }
-    let parts = items.map { item -> String in
-      let factList = item.facts.map { "\($0.label): \($0.value)" }.joined(separator: ", ")
-      if factList.isEmpty {
-        return item.title
-      }
-      return "\(item.title) (\(factList))"
+    guard !items.isEmpty else { return "" }
+    switch items.count {
+    case 1:
+      return "This week: \(items[0].title)."
+    case 2:
+      return "This week: \(items[0].title) and \(items[1].title)."
+    default:
+      let allButLast = items.dropLast().map(\.title).joined(separator: ", ")
+      return "This week: \(allButLast), and \(items[items.count - 1].title)."
     }
-    return parts.joined(separator: "; ") + "."
   }
 }

--- a/Domain/Insights/Narration/TemplateNarrator.swift
+++ b/Domain/Insights/Narration/TemplateNarrator.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+/// Deterministic, model-free narrator that composes a narration from the
+/// request's title and facts. Produces a single snapshot (the full composed
+/// string) and finishes immediately.
+///
+/// Used in two roles:
+/// 1. **Resilience fallback** — when the on-device model is available but a
+///    generation call fails (provenance check rejected, model error, etc.).
+/// 2. **CI fake / test double** — injected in tests and previews so no real
+///    model is required.
+struct TemplateNarrator: InsightNarrating, Sendable {
+  func narrate(_ request: NarrationRequest) -> AsyncThrowingStream<String, any Error> {
+    let text = compose(request)
+    return AsyncThrowingStream { continuation in
+      continuation.yield(text)
+      continuation.finish()
+    }
+  }
+}
+
+extension TemplateNarrator {
+  private func compose(_ request: NarrationRequest) -> String {
+    switch request {
+    case let .singleInsight(title, facts):
+      return composeSingle(title: title, facts: facts)
+    case let .weeklyRecap(items):
+      return composeRecap(items: items)
+    }
+  }
+
+  private func composeSingle(title: String, facts: [InsightFact]) -> String {
+    guard !facts.isEmpty else { return title + "." }
+    let factList = facts.map { "\($0.label): \($0.value)" }.joined(separator: ", ")
+    return "\(title). \(factList)."
+  }
+
+  private func composeRecap(items: [NarrationRequest.Item]) -> String {
+    guard !items.isEmpty else { return "Here's your weekly recap." }
+    let parts = items.map { item -> String in
+      let factList = item.facts.map { "\($0.label): \($0.value)" }.joined(separator: ", ")
+      if factList.isEmpty {
+        return item.title
+      }
+      return "\(item.title) (\(factList))"
+    }
+    return parts.joined(separator: "; ") + "."
+  }
+}

--- a/Features/Insights/Narration/FoundationModelsNarrator.swift
+++ b/Features/Insights/Narration/FoundationModelsNarrator.swift
@@ -1,0 +1,64 @@
+import FoundationModels
+
+/// Narrates insights using the on-device Foundation Models language model.
+/// Streams cumulative snapshots so the caller can display partial output while
+/// generation is in progress. On completion, runs `NumericProvenanceGuard` to
+/// verify every number in the generated text was supplied verbatim in the
+/// request's facts — if any number fails provenance, or if generation throws,
+/// the stream finishes with `NarrationError.fellBack` so the caller can
+/// substitute the deterministic template output (issue #1042).
+///
+/// API confirmed against the installed SDK (Xcode 26.4):
+/// - `LanguageModelSession(instructions:)` — per-request session with a system prompt.
+/// - `session.streamResponse(to: String, options: GenerationOptions)` — returns
+///   `ResponseStream<String>`, an `AsyncSequence` of `Snapshot` values where
+///   `snapshot.content` is a cumulative `String` (the entire response so far).
+/// - `GenerationOptions(sampling: .greedy)` — deterministic token selection.
+struct FoundationModelsNarrator: InsightNarrating, Sendable {
+  /// Generation options passed to every `streamResponse` call.
+  /// Greedy sampling produces the most deterministic output across runs,
+  /// reducing the chance of the provenance guard flipping between calls.
+  var options: GenerationOptions = .init(sampling: .greedy)
+
+  func narrate(_ request: NarrationRequest) -> AsyncThrowingStream<String, any Error> {
+    let built = NarrationPromptBuilder.build(request)
+    let allFacts = request.allFacts
+    let generationOptions = options
+
+    return AsyncThrowingStream { continuation in
+      let task = Task {
+        do {
+          // Create a per-request session off the main actor.
+          // Sessions are not shared across requests; each call gets a fresh
+          // context window, which also bounds context-window-exceeded errors.
+          let session = LanguageModelSession(instructions: built.instructions)
+          var latestSnapshot = ""
+
+          for try await snapshot in session.streamResponse(
+            to: built.prompt, options: generationOptions)
+          {
+            latestSnapshot = snapshot.content
+            continuation.yield(latestSnapshot)
+          }
+
+          // Verify that every number in the completed narration can be
+          // traced back to a fact supplied by the caller.
+          guard NumericProvenanceGuard.isGrounded(latestSnapshot, facts: allFacts) else {
+            continuation.finish(throwing: NarrationError.fellBack)
+            return
+          }
+
+          continuation.finish()
+        } catch {
+          // Any generation error (guardrail trip, context-window exceeded,
+          // rate limit, etc.) triggers the fallback.
+          continuation.finish(throwing: NarrationError.fellBack)
+        }
+      }
+
+      // Cancel the generation task when the stream is abandoned (e.g. the
+      // user navigates away before narration completes).
+      continuation.onTermination = { _ in task.cancel() }
+    }
+  }
+}

--- a/Features/Insights/Narration/FoundationModelsNarrator.swift
+++ b/Features/Insights/Narration/FoundationModelsNarrator.swift
@@ -1,4 +1,5 @@
 import FoundationModels
+import os
 
 /// Narrates insights using the on-device Foundation Models language model.
 /// Streams cumulative snapshots so the caller can display partial output while
@@ -8,37 +9,49 @@ import FoundationModels
 /// the stream finishes with `NarrationError.fellBack` so the caller can
 /// substitute the deterministic template output (issue #1042).
 ///
-/// API confirmed against the installed SDK (Xcode 26.4):
+/// Session API shape:
 /// - `LanguageModelSession(instructions:)` — per-request session with a system prompt.
 /// - `session.streamResponse(to: String, options: GenerationOptions)` — returns
 ///   `ResponseStream<String>`, an `AsyncSequence` of `Snapshot` values where
 ///   `snapshot.content` is a cumulative `String` (the entire response so far).
 /// - `GenerationOptions(sampling: .greedy)` — deterministic token selection.
-struct FoundationModelsNarrator: InsightNarrating, Sendable {
+struct FoundationModelsNarrator: InsightNarrating {
   /// Generation options passed to every `streamResponse` call.
   /// Greedy sampling produces the most deterministic output across runs,
   /// reducing the chance of the provenance guard flipping between calls.
-  var options: GenerationOptions = .init(sampling: .greedy)
+  let options: GenerationOptions
 
-  func narrate(_ request: NarrationRequest) -> AsyncThrowingStream<String, any Error> {
+  init(options: GenerationOptions = .init(sampling: .greedy)) {
+    self.options = options
+  }
+
+  nonisolated func narrate(_ request: NarrationRequest) -> AsyncThrowingStream<String, any Error> {
     let built = NarrationPromptBuilder.build(request)
     let allFacts = request.allFacts
     let generationOptions = options
 
     return AsyncThrowingStream { continuation in
-      let task = Task {
+      // Shed to a detached task so LanguageModelSession creation and the
+      // streamResponse loop run off the main actor.
+      let task = Task.detached(priority: .userInitiated) {
         do {
-          // Create a per-request session off the main actor.
-          // Sessions are not shared across requests; each call gets a fresh
-          // context window, which also bounds context-window-exceeded errors.
+          // Create a per-request session. Sessions are not shared across
+          // requests; each call gets a fresh context window, which also
+          // bounds context-window-exceeded errors.
           let session = LanguageModelSession(instructions: built.instructions)
           var latestSnapshot = ""
 
           for try await snapshot in session.streamResponse(
             to: built.prompt, options: generationOptions)
           {
+            if Task.isCancelled { break }
             latestSnapshot = snapshot.content
             continuation.yield(latestSnapshot)
+          }
+
+          guard !Task.isCancelled else {
+            continuation.finish(throwing: CancellationError())
+            return
           }
 
           // Verify that every number in the completed narration can be
@@ -50,8 +63,10 @@ struct FoundationModelsNarrator: InsightNarrating, Sendable {
 
           continuation.finish()
         } catch {
-          // Any generation error (guardrail trip, context-window exceeded,
-          // rate limit, etc.) triggers the fallback.
+          // Log the original error before mapping to the fallback signal
+          // so diagnostics are preserved for debugging.
+          let logger = Logger(subsystem: "com.moolah.app", category: "Narration")
+          logger.error("FoundationModelsNarrator: generation failed — \(error)")
           continuation.finish(throwing: NarrationError.fellBack)
         }
       }

--- a/MoolahTests/Domain/Insights/NarrationPromptBuilderTests.swift
+++ b/MoolahTests/Domain/Insights/NarrationPromptBuilderTests.swift
@@ -1,0 +1,73 @@
+import Testing
+
+@testable import Moolah
+
+@Suite("NarrationPromptBuilder")
+struct NarrationPromptBuilderTests {
+  @Test
+  func perInsightPromptContainsOnlySuppliedFacts() {
+    let req = NarrationRequest.singleInsight(
+      title: "Dining is up this month",
+      facts: [InsightFact("This month", "$640.00"), InsightFact("6-mo median", "$410.00")])
+    let built = NarrationPromptBuilder.build(req)
+    #expect(built.prompt.contains("$640.00"))
+    #expect(built.prompt.contains("6-mo median"))
+    #expect(built.prompt.contains("Dining is up this month"))
+    #expect(built.instructions.localizedCaseInsensitiveContains("do not invent"))
+  }
+
+  @Test
+  func perInsightPromptContainsAllFactLabelsAndValues() {
+    let facts = [
+      InsightFact("This month", "$640.00"),
+      InsightFact("6-mo median", "$410.00"),
+      InsightFact("Change", "+$230.00"),
+    ]
+    let req = NarrationRequest.singleInsight(title: "Dining is up", facts: facts)
+    let built = NarrationPromptBuilder.build(req)
+    for fact in facts {
+      #expect(built.prompt.contains(fact.label))
+      #expect(built.prompt.contains(fact.value))
+    }
+  }
+
+  @Test
+  func recapPromptListsEachInsightAndAsksForTwoSentences() {
+    let req = NarrationRequest.weeklyRecap(items: [
+      .init(title: "Net worth crossed $100k", facts: [InsightFact("Now", "$101,200")]),
+      .init(title: "Dining up", facts: [InsightFact("This month", "$640.00")]),
+    ])
+    let built = NarrationPromptBuilder.build(req)
+    #expect(built.prompt.contains("Net worth crossed $100k"))
+    #expect(built.prompt.contains("$640.00"))
+    #expect(built.instructions.localizedCaseInsensitiveContains("two sentences"))
+  }
+
+  @Test
+  func instructionsForbidInventingNumbers() {
+    let req = NarrationRequest.singleInsight(
+      title: "Test", facts: [InsightFact("Amount", "$100.00")])
+    let built = NarrationPromptBuilder.build(req)
+    #expect(built.instructions.localizedCaseInsensitiveContains("do not invent"))
+    #expect(built.instructions.localizedCaseInsensitiveContains("only"))
+  }
+
+  @Test
+  func allFactsAggregatesAcrossRecapItems() {
+    let req = NarrationRequest.weeklyRecap(items: [
+      .init(title: "Item A", facts: [InsightFact("Label A", "100")]),
+      .init(title: "Item B", facts: [InsightFact("Label B", "200")]),
+    ])
+    let all = req.allFacts
+    #expect(all.count == 2)
+    #expect(all.contains(InsightFact("Label A", "100")))
+    #expect(all.contains(InsightFact("Label B", "200")))
+  }
+
+  @Test
+  func singleInsightAllFactsReturnsItsOwnFacts() {
+    let facts = [InsightFact("Label", "42")]
+    let req = NarrationRequest.singleInsight(title: "T", facts: facts)
+    #expect(req.allFacts == facts)
+  }
+}

--- a/MoolahTests/Domain/Insights/NarrationPromptBuilderTests.swift
+++ b/MoolahTests/Domain/Insights/NarrationPromptBuilderTests.swift
@@ -8,6 +8,7 @@ struct NarrationPromptBuilderTests {
   func perInsightPromptContainsOnlySuppliedFacts() {
     let req = NarrationRequest.singleInsight(
       title: "Dining is up this month",
+      detail: "Dining hit $640.00, above your $410.00 median.",
       facts: [InsightFact("This month", "$640.00"), InsightFact("6-mo median", "$410.00")])
     let built = NarrationPromptBuilder.build(req)
     #expect(built.prompt.contains("$640.00"))
@@ -17,13 +18,27 @@ struct NarrationPromptBuilderTests {
   }
 
   @Test
+  func perInsightPromptContainsDetailDraft() {
+    let detail = "Dining hit $640.00, above your usual $410.00."
+    let req = NarrationRequest.singleInsight(
+      title: "Dining is up this month",
+      detail: detail,
+      facts: [InsightFact("This month", "$640.00"), InsightFact("6-mo median", "$410.00")])
+    let built = NarrationPromptBuilder.build(req)
+    #expect(built.prompt.contains("Draft: \(detail)"))
+  }
+
+  @Test
   func perInsightPromptContainsAllFactLabelsAndValues() {
     let facts = [
       InsightFact("This month", "$640.00"),
       InsightFact("6-mo median", "$410.00"),
       InsightFact("Change", "+$230.00"),
     ]
-    let req = NarrationRequest.singleInsight(title: "Dining is up", facts: facts)
+    let req = NarrationRequest.singleInsight(
+      title: "Dining is up",
+      detail: "Dining is up $230.00 on last month.",
+      facts: facts)
     let built = NarrationPromptBuilder.build(req)
     for fact in facts {
       #expect(built.prompt.contains(fact.label))
@@ -34,8 +49,14 @@ struct NarrationPromptBuilderTests {
   @Test
   func recapPromptListsEachInsightAndAsksForTwoSentences() {
     let req = NarrationRequest.weeklyRecap(items: [
-      .init(title: "Net worth crossed $100k", facts: [InsightFact("Now", "$101,200")]),
-      .init(title: "Dining up", facts: [InsightFact("This month", "$640.00")]),
+      .init(
+        title: "Net worth crossed $100k",
+        detail: "Your net worth hit $101,200.",
+        facts: [InsightFact("Now", "$101,200")]),
+      .init(
+        title: "Dining up",
+        detail: "Dining came in at $640.00.",
+        facts: [InsightFact("This month", "$640.00")]),
     ])
     let built = NarrationPromptBuilder.build(req)
     #expect(built.prompt.contains("Net worth crossed $100k"))
@@ -44,19 +65,84 @@ struct NarrationPromptBuilderTests {
   }
 
   @Test
+  func recapPromptContainsDraftForEachItem() {
+    let req = NarrationRequest.weeklyRecap(items: [
+      .init(
+        title: "Net worth crossed $100k",
+        detail: "Your net worth hit $101,200.",
+        facts: [InsightFact("Now", "$101,200")]),
+      .init(
+        title: "Dining up",
+        detail: "Dining came in at $640.00.",
+        facts: [InsightFact("This month", "$640.00")]),
+    ])
+    let built = NarrationPromptBuilder.build(req)
+    #expect(built.prompt.contains("Draft: Your net worth hit $101,200."))
+    #expect(built.prompt.contains("Draft: Dining came in at $640.00."))
+  }
+
+  @Test
   func instructionsForbidInventingNumbers() {
     let req = NarrationRequest.singleInsight(
-      title: "Test", facts: [InsightFact("Amount", "$100.00")])
+      title: "Test",
+      detail: "Something happened.",
+      facts: [InsightFact("Amount", "$100.00")])
     let built = NarrationPromptBuilder.build(req)
     #expect(built.instructions.localizedCaseInsensitiveContains("do not invent"))
     #expect(built.instructions.localizedCaseInsensitiveContains("only"))
   }
 
   @Test
+  func instructionsRequireOmittingStatisticalFacts() {
+    let req = NarrationRequest.singleInsight(
+      title: "Test",
+      detail: "Something happened.",
+      facts: [InsightFact("Amount", "$100.00")])
+    let built = NarrationPromptBuilder.build(req)
+    #expect(
+      built.instructions.localizedCaseInsensitiveContains("z-score")
+        || built.instructions.localizedCaseInsensitiveContains("statistical"))
+  }
+
+  @Test
+  func instructionsEncourageContractions() {
+    let req = NarrationRequest.singleInsight(
+      title: "Test",
+      detail: "Something happened.",
+      facts: [InsightFact("Amount", "$100.00")])
+    let built = NarrationPromptBuilder.build(req)
+    #expect(built.instructions.contains("contractions") || built.instructions.contains("you've"))
+  }
+
+  @Test
+  func recapInstructionsMentionTwoSentenceRecap() {
+    let req = NarrationRequest.weeklyRecap(items: [
+      .init(title: "A", detail: "A detail.", facts: [])
+    ])
+    let built = NarrationPromptBuilder.build(req)
+    #expect(built.instructions.localizedCaseInsensitiveContains("two sentences"))
+  }
+
+  @Test
+  func recapPromptUsesCorrectHighlightWord() {
+    let singleItem = NarrationRequest.weeklyRecap(items: [
+      .init(title: "Net worth up", detail: "Up.", facts: [])
+    ])
+    let multiItem = NarrationRequest.weeklyRecap(items: [
+      .init(title: "Net worth up", detail: "Up.", facts: []),
+      .init(title: "Dining down", detail: "Down.", facts: []),
+    ])
+    let singleBuilt = NarrationPromptBuilder.build(singleItem)
+    let multiBuilt = NarrationPromptBuilder.build(multiItem)
+    #expect(singleBuilt.prompt.contains("1 highlight this week"))
+    #expect(multiBuilt.prompt.contains("2 highlights this week"))
+  }
+
+  @Test
   func allFactsAggregatesAcrossRecapItems() {
     let req = NarrationRequest.weeklyRecap(items: [
-      .init(title: "Item A", facts: [InsightFact("Label A", "100")]),
-      .init(title: "Item B", facts: [InsightFact("Label B", "200")]),
+      .init(title: "Item A", detail: "A.", facts: [InsightFact("Label A", "100")]),
+      .init(title: "Item B", detail: "B.", facts: [InsightFact("Label B", "200")]),
     ])
     let all = req.allFacts
     #expect(all.count == 2)
@@ -67,7 +153,7 @@ struct NarrationPromptBuilderTests {
   @Test
   func singleInsightAllFactsReturnsItsOwnFacts() {
     let facts = [InsightFact("Label", "42")]
-    let req = NarrationRequest.singleInsight(title: "T", facts: facts)
+    let req = NarrationRequest.singleInsight(title: "T", detail: "D.", facts: facts)
     #expect(req.allFacts == facts)
   }
 }

--- a/MoolahTests/Domain/Insights/NumericProvenanceGuardTests.swift
+++ b/MoolahTests/Domain/Insights/NumericProvenanceGuardTests.swift
@@ -45,6 +45,15 @@ struct NumericProvenanceGuardTests {
   }
 
   @Test
+  func passesWhenFactUsesUnicodeMinus_generatedUsesAsciiHyphen() {
+    // Detectors emit U+2212; LLMs typically emit ASCII U+002D. Both represent
+    // the same negative amount and must compare equal after normalisation.
+    let signed = [InsightFact("Change", "−$640.00")]  // U+2212
+    #expect(
+      NumericProvenanceGuard.isGrounded("Down -$640.00 this month.", facts: signed))  // ASCII -
+  }
+
+  @Test
   func passesWithEmptyGeneratedText() {
     #expect(NumericProvenanceGuard.isGrounded("", facts: facts))
   }

--- a/MoolahTests/Domain/Insights/NumericProvenanceGuardTests.swift
+++ b/MoolahTests/Domain/Insights/NumericProvenanceGuardTests.swift
@@ -1,0 +1,90 @@
+import Testing
+
+@testable import Moolah
+
+@Suite("NumericProvenanceGuard")
+struct NumericProvenanceGuardTests {
+  private let facts = [InsightFact("This month", "$640.00"), InsightFact("Median", "$410.00")]
+
+  // MARK: - Passing cases
+
+  @Test
+  func passesWhenEveryNumberIsSourced() {
+    #expect(
+      NumericProvenanceGuard.isGrounded(
+        "Dining hit $640.00, above your $410.00 median.", facts: facts))
+  }
+
+  @Test
+  func passesWhenNoNumbersPresent() {
+    #expect(NumericProvenanceGuard.isGrounded("Looks good this month.", facts: facts))
+  }
+
+  @Test
+  func passesWithPercentagePresentInFacts() {
+    let pctFacts = [InsightFact("Change", "+12.5%"), InsightFact("Base", "$500.00")]
+    #expect(
+      NumericProvenanceGuard.isGrounded(
+        "Spending rose 12.5% to $500.00 this month.", facts: pctFacts))
+  }
+
+  @Test
+  func passesWithThousandsSeparatorInFacts() {
+    let richFacts = [InsightFact("Net worth", "$101,200.00")]
+    #expect(
+      NumericProvenanceGuard.isGrounded(
+        "Your net worth is now $101,200.00.", facts: richFacts))
+  }
+
+  @Test
+  func passesWithNegativeAmountMatchingFact() {
+    let signed = [InsightFact("Change", "−$640.00")]
+    // The generated text uses the same minus sign as the fact value.
+    #expect(
+      NumericProvenanceGuard.isGrounded("Down −$640.00 this month.", facts: signed))
+  }
+
+  @Test
+  func passesWithEmptyGeneratedText() {
+    #expect(NumericProvenanceGuard.isGrounded("", facts: facts))
+  }
+
+  @Test
+  func passesWithEmptyFacts() {
+    // No numbers in generated text, no facts — trivially grounded.
+    #expect(NumericProvenanceGuard.isGrounded("Good news this week.", facts: []))
+  }
+
+  // MARK: - Failing cases
+
+  @Test
+  func failsOnInventedNumber() {
+    #expect(!NumericProvenanceGuard.isGrounded("You spent $700.00 on dining.", facts: facts))
+  }
+
+  @Test
+  func failsOnFlippedSign() {
+    // Fact is −$640.00 (negative) but generated text says +$640.00 (positive).
+    let signed = [InsightFact("Change", "−$640.00")]
+    #expect(!NumericProvenanceGuard.isGrounded("Up +$640.00 this month.", facts: signed))
+  }
+
+  @Test
+  func failsWhenNumberPresentButNoFacts() {
+    #expect(!NumericProvenanceGuard.isGrounded("You spent $200.00.", facts: []))
+  }
+
+  @Test
+  func failsOnRoundedNumber() {
+    // Facts have $640.00 — generated text rounds to $640, which is a different token.
+    // The guard errs toward rejecting: $640 ≠ $640.00 after normalisation.
+    #expect(!NumericProvenanceGuard.isGrounded("You spent $640 on dining.", facts: facts))
+  }
+
+  @Test
+  func failsOnPartialMatch() {
+    // $40 appears as a substring of $640.00 but is not a fact value token.
+    let smallFacts = [InsightFact("Tip", "$40.00")]
+    #expect(!NumericProvenanceGuard.isGrounded("You spent $640.00 total.", facts: smallFacts))
+  }
+}

--- a/MoolahTests/Domain/Insights/TemplateNarratorTests.swift
+++ b/MoolahTests/Domain/Insights/TemplateNarratorTests.swift
@@ -5,10 +5,11 @@ import Testing
 @Suite("TemplateNarrator")
 struct TemplateNarratorTests {
   @Test
-  func singleInsightEmitsSingleSnapshot() async throws {
+  func singleInsightReturnsDetailString() async throws {
     let narrator = TemplateNarrator()
     let req = NarrationRequest.singleInsight(
       title: "Dining is up this month",
+      detail: "Dining hit $640.00 this month, well above your usual $410.00.",
       facts: [InsightFact("This month", "$640.00"), InsightFact("6-mo median", "$410.00")])
 
     var snapshots: [String] = []
@@ -18,19 +19,39 @@ struct TemplateNarratorTests {
 
     #expect(snapshots.count == 1)
     let text = try #require(snapshots.first)
-    #expect(text.contains("Dining is up this month"))
-    #expect(text.contains("This month"))
-    #expect(text.contains("$640.00"))
-    #expect(text.contains("6-mo median"))
-    #expect(text.contains("$410.00"))
+    #expect(text == "Dining hit $640.00 this month, well above your usual $410.00.")
   }
 
   @Test
-  func recapComposesAcrossItems() async throws {
+  func singleInsightEmptyDetailFallsBackToTitle() async throws {
+    let narrator = TemplateNarrator()
+    let req = NarrationRequest.singleInsight(
+      title: "Dining is up this month",
+      detail: "",
+      facts: [InsightFact("This month", "$640.00")])
+
+    var snapshots: [String] = []
+    for try await snapshot in narrator.narrate(req) {
+      snapshots.append(snapshot)
+    }
+
+    #expect(snapshots.count == 1)
+    let text = try #require(snapshots.first)
+    #expect(text == "Dining is up this month")
+  }
+
+  @Test
+  func recapComposesTitleOnlySentence() async throws {
     let narrator = TemplateNarrator()
     let req = NarrationRequest.weeklyRecap(items: [
-      .init(title: "Net worth crossed $100k", facts: [InsightFact("Now", "$101,200")]),
-      .init(title: "Dining up", facts: [InsightFact("This month", "$640.00")]),
+      .init(
+        title: "Net worth crossed $100k",
+        detail: "Your net worth hit $101,200.",
+        facts: [InsightFact("Now", "$101,200")]),
+      .init(
+        title: "Dining up",
+        detail: "Dining came in at $640.00 this month.",
+        facts: [InsightFact("This month", "$640.00")]),
     ])
 
     var snapshots: [String] = []
@@ -40,16 +61,15 @@ struct TemplateNarratorTests {
 
     #expect(snapshots.count == 1)
     let text = try #require(snapshots.first)
-    #expect(text.contains("Net worth crossed $100k"))
-    #expect(text.contains("$101,200"))
-    #expect(text.contains("Dining up"))
-    #expect(text.contains("$640.00"))
+    #expect(text == "This week: Net worth crossed $100k and Dining up.")
   }
 
   @Test
-  func emptyFactsStillProducesTitle() async throws {
+  func recapSingleItemGrammar() async throws {
     let narrator = TemplateNarrator()
-    let req = NarrationRequest.singleInsight(title: "Something happened", facts: [])
+    let req = NarrationRequest.weeklyRecap(items: [
+      .init(title: "Net worth up", detail: "Your net worth grew.", facts: [])
+    ])
 
     var snapshots: [String] = []
     for try await snapshot in narrator.narrate(req) {
@@ -58,6 +78,40 @@ struct TemplateNarratorTests {
 
     #expect(snapshots.count == 1)
     let text = try #require(snapshots.first)
-    #expect(text.contains("Something happened"))
+    #expect(text == "This week: Net worth up.")
+  }
+
+  @Test
+  func recapThreeItemsGrammar() async throws {
+    let narrator = TemplateNarrator()
+    let req = NarrationRequest.weeklyRecap(items: [
+      .init(title: "Net worth up", detail: "", facts: []),
+      .init(title: "Dining down", detail: "", facts: []),
+      .init(title: "Groceries steady", detail: "", facts: []),
+    ])
+
+    var snapshots: [String] = []
+    for try await snapshot in narrator.narrate(req) {
+      snapshots.append(snapshot)
+    }
+
+    #expect(snapshots.count == 1)
+    let text = try #require(snapshots.first)
+    #expect(text == "This week: Net worth up, Dining down, and Groceries steady.")
+  }
+
+  @Test
+  func recapEmptyItemsReturnsEmpty() async throws {
+    let narrator = TemplateNarrator()
+    let req = NarrationRequest.weeklyRecap(items: [])
+
+    var snapshots: [String] = []
+    for try await snapshot in narrator.narrate(req) {
+      snapshots.append(snapshot)
+    }
+
+    #expect(snapshots.count == 1)
+    let text = try #require(snapshots.first)
+    #expect(text.isEmpty)
   }
 }

--- a/MoolahTests/Domain/Insights/TemplateNarratorTests.swift
+++ b/MoolahTests/Domain/Insights/TemplateNarratorTests.swift
@@ -1,0 +1,63 @@
+import Testing
+
+@testable import Moolah
+
+@Suite("TemplateNarrator")
+struct TemplateNarratorTests {
+  @Test
+  func singleInsightEmitsSingleSnapshot() async throws {
+    let narrator = TemplateNarrator()
+    let req = NarrationRequest.singleInsight(
+      title: "Dining is up this month",
+      facts: [InsightFact("This month", "$640.00"), InsightFact("6-mo median", "$410.00")])
+
+    var snapshots: [String] = []
+    for try await snapshot in narrator.narrate(req) {
+      snapshots.append(snapshot)
+    }
+
+    #expect(snapshots.count == 1)
+    let text = try #require(snapshots.first)
+    #expect(text.contains("Dining is up this month"))
+    #expect(text.contains("This month"))
+    #expect(text.contains("$640.00"))
+    #expect(text.contains("6-mo median"))
+    #expect(text.contains("$410.00"))
+  }
+
+  @Test
+  func recapComposesAcrossItems() async throws {
+    let narrator = TemplateNarrator()
+    let req = NarrationRequest.weeklyRecap(items: [
+      .init(title: "Net worth crossed $100k", facts: [InsightFact("Now", "$101,200")]),
+      .init(title: "Dining up", facts: [InsightFact("This month", "$640.00")]),
+    ])
+
+    var snapshots: [String] = []
+    for try await snapshot in narrator.narrate(req) {
+      snapshots.append(snapshot)
+    }
+
+    #expect(snapshots.count == 1)
+    let text = try #require(snapshots.first)
+    #expect(text.contains("Net worth crossed $100k"))
+    #expect(text.contains("$101,200"))
+    #expect(text.contains("Dining up"))
+    #expect(text.contains("$640.00"))
+  }
+
+  @Test
+  func emptyFactsStillProducesTitle() async throws {
+    let narrator = TemplateNarrator()
+    let req = NarrationRequest.singleInsight(title: "Something happened", facts: [])
+
+    var snapshots: [String] = []
+    for try await snapshot in narrator.narrate(req) {
+      snapshots.append(snapshot)
+    }
+
+    #expect(snapshots.count == 1)
+    let text = try #require(snapshots.first)
+    #expect(text.contains("Something happened"))
+  }
+}


### PR DESCRIPTION
Second slice of Phase E (epic #1030, tracking #1042): the **narrator** that turns an insight's pre-formatted facts into prose. Builds on E1's availability gating (#1043). **Still no user-visible surface** — E3 ("Why?") and E4 (weekly recap) consume this.

## What
- **`NarrationRequest`** (`Domain/Insights/Narration/`) — `Sendable` enum (`.singleInsight(title:detail:facts:)` / `.weeklyRecap(items:)`); `allFacts` feeds the guard.
- **`NarrationPromptBuilder`** — pure `instructions`/`prompt` builder. Instructions enforce the zero-hallucination rule (use only supplied figures verbatim; never invent/recompute/round) plus brand voice: omit statistical jargon (z-score, p-value), use contractions, no corporate-speak, warmth for good news, never a scold.
- **`InsightNarrating`** — `nonisolated` streaming protocol returning `AsyncThrowingStream<String, Error>`; `NarrationError.fellBack`.
- **`TemplateNarrator`** — deterministic, model-free fallback **and** CI fake. Returns the insight's clean human `detail` sentence (never dumps raw facts — that would surface "Robust z-score: 3.5" to users); recap composes item titles grammatically.
- **`NumericProvenanceGuard`** — pure; rejects any generated text containing a number not present verbatim in the facts. Sign-preserving (a flipped sign fails) and canonicalises Unicode-minus (U+2212, what detectors emit) vs ASCII-minus (what an LLM emits) so negatives aren't falsely rejected.
- **`FoundationModelsNarrator`** (`Features/Insights/Narration/`) — the only `FoundationModels` consumer. Per-request `LanguageModelSession`, greedy sampling, streams `snapshot.content`; runs the provenance guard on completion and finishes with `.fellBack` on guard failure / generation error (caller swaps in the template). Runs off-main via `nonisolated` + `Task.detached`; cancels on stream termination; logs the original error.

## Testing
- Swift Testing: `NarrationPromptBuilderTests` (12), `TemplateNarratorTests` (6), `NumericProvenanceGuardTests` (13) — incl. invented-number, flipped-sign, and U+2212-vs-ASCII-minus cases. All green.
- `just build-mac` + `just format-check` green.
- Reviewed by `code-review`, `concurrency-review`, `help-review`; all findings applied (detail-based fallback, prompt voice rules, unicode-minus canonicalisation, `var`→`let` options, detached/cancellable streaming task, error logging, `NarrationError` to its own file).
- **Not in CI:** the live `LanguageModelSession` path (no model on CI hardware) — exercised on-device in E3/E4. The prompt builder + guard + template are fully CI-covered.

Part of #1042. `instrument-conversion-review` N/A (facts arrive pre-converted from Phase A).

🤖 Generated with [Claude Code](https://claude.com/claude-code)