### PR TITLE
fix(transactions): autofill pins stable leg ids so saves don't churn

### DIFF
--- a/MoolahTests/Features/TransactionAutofillPersistenceTests.swift
+++ b/MoolahTests/Features/TransactionAutofillPersistenceTests.swift
@@ -1,0 +1,79 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+/// End-to-end regression cover for payee-autocomplete autofill: the draft
+/// must carry stable leg ids so repeated debounced saves upsert the same
+/// rows instead of churning a fresh leg id each time.
+@Suite("Payee autofill persists a stable single leg")
+@MainActor
+struct TransactionAutofillPersistenceTests {
+
+  /// Reload a single transaction by id via `fetchAll`, since
+  /// `TransactionRepository` exposes only filter/pagination fetches.
+  private func reload(
+    _ repo: any TransactionRepository, id: UUID
+  ) async throws -> Transaction? {
+    let all = try await repo.fetchAll(filter: TransactionFilter())
+    return all.first(where: { $0.id == id })
+  }
+
+  @Test("autofill then repeated edits keep the placeholder's single leg id stable")
+  func autofillThenEditsKeepsSingleStableLeg() async throws {
+    // End-to-end repro of #872's residual: a new transaction opens from a
+    // persisted placeholder, the user picks a payee (autofill copies a past
+    // transaction's leg), then edits the amount. Every debounced save must
+    // upsert the *same* leg row. Before the fix, autofill cleared the leg
+    // id, so each save minted a fresh UUID — orphaning the placeholder leg
+    // and emitting a leg-swap that shows up as a duplicate during sync
+    // apply. GRDB deletes the orphan locally, so the tell-tale here is the
+    // leg *id* drifting away from the placeholder's, not the leg count.
+    let (backend, _) = try TestBackend.create()
+    let accountId = UUID()
+    _ = try await backend.accounts.create(
+      Account(
+        id: accountId, name: "Cash", type: .bank,
+        instrument: Instrument.defaultTestInstrument, positions: []))
+
+    // A past "Coffee" transaction to autofill from.
+    _ = try await backend.transactions.create(
+      Transaction(
+        date: Date(timeIntervalSince1970: 0), payee: "Coffee",
+        legs: [
+          TransactionLeg(
+            accountId: accountId, instrument: Instrument.defaultTestInstrument,
+            quantity: -25, type: .expense)
+        ]))
+
+    // The placeholder a new transaction opens from (persisted up front).
+    let placeholder = try await backend.transactions.create(
+      Transaction(
+        date: Date(), payee: "",
+        legs: [
+          TransactionLeg(
+            accountId: accountId, instrument: Instrument.defaultTestInstrument,
+            quantity: 0, type: .expense)
+        ]))
+    let placeholderLegId = placeholder.legs[0].id
+
+    // User picks "Coffee" from autocomplete → autofill.
+    var draft = TransactionDraft(from: placeholder)
+    let match = try #require(
+      await backend.transactions.fetchAll(filter: TransactionFilter(payee: "Coffee")).first)
+    draft.applyAutofill(
+      from: match, categories: Categories(from: []), accounts: Accounts(from: []))
+
+    // First debounced save.
+    _ = try await backend.transactions.update(
+      try #require(draft.toTransaction(id: placeholder.id)))
+
+    // User edits the amount → second debounced save.
+    draft.setAmount("30")
+    _ = try await backend.transactions.update(
+      try #require(draft.toTransaction(id: placeholder.id)))
+
+    let reloaded = try #require(try await reload(backend.transactions, id: placeholder.id))
+    #expect(reloaded.legs.map(\.id) == [placeholderLegId])
+  }
+}

--- a/MoolahTests/Shared/TransactionDraftLegIdTests.swift
+++ b/MoolahTests/Shared/TransactionDraftLegIdTests.swift
@@ -50,8 +50,8 @@ struct TransactionDraftLegIdTests {
     #expect(rebuilt.legs[1].id != leg.id)
   }
 
-  @Test("applyAutofill clears legId so saving does not collide with the source's leg rows")
-  func applyAutofillClearsLegIds() throws {
+  @Test("applyAutofill never carries the source's leg ids, so saving can't steal its rows")
+  func applyAutofillDoesNotReuseSourceLegIds() throws {
     let sourceLeg = TransactionLeg(
       accountId: UUID(),
       instrument: Instrument.defaultTestInstrument,
@@ -62,19 +62,126 @@ struct TransactionDraftLegIdTests {
       payee: "Coffee",
       legs: [sourceLeg])
 
-    // A fresh draft is a brand-new transaction in progress.
+    // A draft with no prior persistence has legId == nil, exercising the
+    // fresh-id fallback in autofill. In production a new transaction always
+    // opens from a persisted placeholder that already carries a non-nil
+    // legId (covered by `applyAutofillReusesOwnLegId`); this is the
+    // defensive case.
     var draft = TransactionDraft(accountId: nil, instrument: Instrument.defaultTestInstrument)
 
     draft.applyAutofill(
       from: source, categories: Categories(from: []), accounts: Accounts(from: []))
 
-    // The carried leg's content matches `source` but its id is regenerated
-    // at save time so it does not collide with `source.legs[0].id` in
-    // GRDB's primary key.
-    #expect(draft.legDrafts.allSatisfy { $0.legId == nil })
+    // The carried leg's content matches `source` but it gets an id of its
+    // own — never the source's — so the GRDB upsert can't collide with or
+    // steal `source.legs[0]`.
+    let carriedIds = Set(draft.legDrafts.compactMap(\.legId))
+    #expect(!carriedIds.contains(sourceLeg.id))
 
-    let savedNewId = UUID()
-    let saved = try #require(draft.toTransaction(id: savedNewId))
+    let saved = try #require(draft.toTransaction(id: UUID()))
     #expect(saved.legs.first?.id != sourceLeg.id)
+  }
+
+  @Test("applyAutofill reuses the draft's own leg id so repeated saves don't churn")
+  func applyAutofillReusesOwnLegId() throws {
+    // A new transaction always opens from a placeholder that was persisted
+    // up front, so its single leg already owns a stable id. Autofill must
+    // reuse that id rather than mint a fresh one on every debounced save —
+    // leg-id churn is what surfaces as a duplicate leg during sync apply
+    // (#872, https://github.com/moolah-rocks/moolah-native/issues/872).
+    let placeholderLeg = TransactionLeg(
+      accountId: UUID(),
+      instrument: Instrument.defaultTestInstrument,
+      quantity: .zero, type: .expense)
+    let placeholder = Transaction(date: Date(), payee: "", legs: [placeholderLeg])
+    var draft = TransactionDraft(from: placeholder)
+
+    let sourceLeg = TransactionLeg(
+      accountId: UUID(),
+      instrument: Instrument.defaultTestInstrument,
+      quantity: Decimal(-25), type: .expense,
+      categoryId: UUID())
+    let source = Transaction(
+      date: Date(timeIntervalSince1970: 0), payee: "Coffee", legs: [sourceLeg])
+
+    draft.applyAutofill(
+      from: source, categories: Categories(from: []), accounts: Accounts(from: []))
+
+    // Reuses this transaction's own leg id — not the source's.
+    #expect(draft.legDrafts.map(\.legId) == [placeholderLeg.id])
+    #expect(placeholderLeg.id != sourceLeg.id)
+
+    // So saving twice yields the same leg id: no per-keystroke leg swap.
+    let first = try #require(draft.toTransaction(id: placeholder.id))
+    let second = try #require(draft.toTransaction(id: placeholder.id))
+    #expect(first.legs.map(\.id) == [placeholderLeg.id])
+    #expect(second.legs.map(\.id) == first.legs.map(\.id))
+  }
+
+  @Test("applyAutofill gives extra legs from a multi-leg source stable ids")
+  func applyAutofillStabilisesExtraLegIds() throws {
+    let placeholderLeg = TransactionLeg(
+      accountId: UUID(),
+      instrument: Instrument.defaultTestInstrument,
+      quantity: .zero, type: .expense)
+    let placeholder = Transaction(date: Date(), payee: "", legs: [placeholderLeg])
+    var draft = TransactionDraft(from: placeholder)
+
+    let legA = TransactionLeg(
+      accountId: UUID(), instrument: Instrument.defaultTestInstrument,
+      quantity: Decimal(-25), type: .transfer)
+    let legB = TransactionLeg(
+      accountId: UUID(), instrument: Instrument.defaultTestInstrument,
+      quantity: Decimal(25), type: .transfer)
+    let source = Transaction(
+      date: Date(timeIntervalSince1970: 0), payee: "Rent", legs: [legA, legB])
+
+    draft.applyAutofill(
+      from: source, categories: Categories(from: []), accounts: Accounts(from: []))
+
+    // Every carried leg has a stable, non-nil id of its own …
+    #expect(draft.legDrafts.allSatisfy { $0.legId != nil })
+    // … the first reusing the placeholder's id, none reusing the source's.
+    #expect(draft.legDrafts.first?.legId == placeholderLeg.id)
+    let carriedIds = Set(draft.legDrafts.compactMap(\.legId))
+    #expect(carriedIds.isDisjoint(with: [legA.id, legB.id]))
+
+    // Saving twice is idempotent — identical leg ids, no churn.
+    let first = try #require(draft.toTransaction(id: placeholder.id))
+    let second = try #require(draft.toTransaction(id: placeholder.id))
+    #expect(first.legs.map(\.id) == second.legs.map(\.id))
+  }
+
+  @Test("changing the payee re-runs autofill and keeps the same stable leg id")
+  func applyAutofillTwiceKeepsSameLegId() throws {
+    // The user can pick one payee, then change their mind and pick another.
+    // The second autofill reads the already-stable id the first one pinned,
+    // so the leg id never drifts — no churn across repeated autofills.
+    let placeholderLeg = TransactionLeg(
+      accountId: UUID(),
+      instrument: Instrument.defaultTestInstrument,
+      quantity: .zero, type: .expense)
+    let placeholder = Transaction(date: Date(), payee: "", legs: [placeholderLeg])
+    var draft = TransactionDraft(from: placeholder)
+
+    let coffee = Transaction(
+      date: Date(timeIntervalSince1970: 0), payee: "Coffee",
+      legs: [
+        TransactionLeg(
+          accountId: UUID(), instrument: Instrument.defaultTestInstrument,
+          quantity: Decimal(-25), type: .expense)
+      ])
+    draft.applyAutofill(from: coffee, categories: Categories(from: []))
+    #expect(draft.legDrafts.map(\.legId) == [placeholderLeg.id])
+
+    let lunch = Transaction(
+      date: Date(timeIntervalSince1970: 0), payee: "Lunch",
+      legs: [
+        TransactionLeg(
+          accountId: UUID(), instrument: Instrument.defaultTestInstrument,
+          quantity: Decimal(-15), type: .expense)
+      ])
+    draft.applyAutofill(from: lunch, categories: Categories(from: []))
+    #expect(draft.legDrafts.map(\.legId) == [placeholderLeg.id])
   }
 }

--- a/Shared/Models/TransactionDraft+Autofill.swift
+++ b/Shared/Models/TransactionDraft+Autofill.swift
@@ -32,12 +32,20 @@ extension TransactionDraft {
       }
     }
 
-    // Autofill copies content from a different transaction; legs save
-    // into *this* transaction so they need new ids — preserving the
-    // source's leg ids would PK-collide on the GRDB upsert against the
-    // source's own row. `clearingLegId()` owns the rebuild so a future
-    // `LegDraft` field addition can't silently drop its value here.
-    newDraft.legDrafts = newDraft.legDrafts.map { $0.clearingLegId() }
+    // Autofill copies content from a *different* transaction, but the legs
+    // save into *this* one. Each carried leg therefore takes a stable id of
+    // this transaction's own — never the source's, which would PK-collide
+    // with (and steal) the source's rows on the GRDB upsert. Ids come from
+    // this draft's existing legs, matched positionally: a new transaction
+    // always opens from a persisted placeholder that already owns one, so
+    // every debounced save upserts the same row rather than inserting a new
+    // one. Any extra leg a multi-leg source brings in gets a fresh id minted
+    // once here, so it too stays stable across saves (#872).
+    let ownLegIds = self.legDrafts.map(\.legId)
+    newDraft.legDrafts = newDraft.legDrafts.enumerated().map { index, leg in
+      let stableId = (index < ownLegIds.count ? ownLegIds[index] : nil) ?? UUID()
+      return leg.withLegId(stableId)
+    }
 
     // Preserve the viewed account. Skip custom mode: a complex match has no
     // single "viewed" leg, and adopting its structure means the user is

--- a/Shared/Models/TransactionDraft.swift
+++ b/Shared/Models/TransactionDraft.swift
@@ -96,14 +96,15 @@ struct TransactionDraft: Sendable, Equatable {
       accountId == nil && earmarkId != nil
     }
 
-    /// Returns a copy of this leg draft with `legId` cleared. Used by
-    /// `applyAutofill` to detach legs carried in from another
-    /// transaction so they save into a new `transaction_leg.id` and do
-    /// not PK-collide with the source. `legId` is `let`, so a new
-    /// value must be returned.
-    func clearingLegId() -> LegDraft {
+    /// Returns a copy of this leg draft carrying `legId` as its identity.
+    /// `legId` is `let`, so a new value must be returned. The id is required
+    /// (not optional) so a carried-in leg always saves into a concrete
+    /// `transaction_leg` row: autofill uses this to pin each leg to a stable
+    /// id, so repeated saves upsert the same row instead of churning a fresh
+    /// leg id each time.
+    func withLegId(_ legId: UUID) -> LegDraft {
       LegDraft(
-        legId: nil,
+        legId: legId,
         type: type,
         accountId: accountId,
         amountText: amountText,


### PR DESCRIPTION
## Problem

Using payee autocomplete to autofill a new transaction could surface a **duplicated leg** — the residual of #872 ("Transient duplicate legs visible during iCloud sync apply").

`TransactionDraft.applyAutofill` deliberately cleared every carried leg's `legId` to nil (to avoid PK-colliding with the source transaction's rows). But a new transaction's `@State` draft is never rebuilt after a save, so `legId` stayed nil and **every debounced save minted a fresh leg UUID** — a delete-old + insert-new "leg swap" on each keystroke.

A normal new transaction doesn't churn, because it opens from a persisted placeholder whose leg id survives in the draft. Autofill was special only because it threw that id away.

#872 made the remote sync *apply* atomic, hiding the common batched case. The underlying leg-id churn remained, so un-coalesced echoes / multi-device sync still showed the duplicate — the "still some cases" the user reported.

## Fix

Give each carried leg a **stable id of this transaction's own** instead of clearing to nil:

- Reuse the draft's existing leg ids positionally (a new transaction always opens from a persisted placeholder that already owns one).
- Mint a fresh id **once** for any extra leg a multi-leg source brings in, so it too stays stable across saves.

Repeated saves now upsert the *same* row. The source's leg ids are never reused, so there's no PK collision with / theft of the source's rows.

`LegDraft.clearingLegId()` is generalised to `withLegId(_:)` — the single mutation point for the `let legId`.

## Tests

- `TransactionDraftLegIdTests`: reuse-own-id, multi-leg stable ids, no-source-id-reuse, and re-autofill stability (changing the payee twice).
- `TransactionAutofillPersistenceTests` (new): end-to-end repro through `TestBackend` — create placeholder → autofill → edit amount → save twice → leg id stays the placeholder's. This fails on the pre-fix code (leg id drifts) and would have caught the original bug.

Verified the new tests RED on the pre-fix code, GREEN after. Full `just test-mac` green except the ~5 pre-existing timezone-flaky tests (unrelated; being fixed separately). `just format-check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)