### PR TITLE
Make date-dependent price/breakdown tests timezone-deterministic

### DIFF
--- a/MoolahTests/Domain/DomainModelsTests.swift
+++ b/MoolahTests/Domain/DomainModelsTests.swift
@@ -113,7 +113,12 @@ struct DomainModelsTests {
 
     let monthDate = try #require(breakdown.monthDate)
 
-    let calendar = Calendar.current
+    // `monthDate` parses the YYYYMM label in UTC (a financial-month label
+    // must map to the same instant on every host), so read the components
+    // back through a UTC calendar — `Calendar.current` would shift the
+    // midnight-UTC instant into the prior month in any UTC-negative zone.
+    var calendar = Calendar(identifier: .gregorian)
+    calendar.timeZone = try #require(TimeZone(identifier: "UTC"))
     let components = calendar.dateComponents([.year, .month], from: monthDate)
     #expect(components.year == 2026)
     #expect(components.month == 4)

--- a/MoolahTests/Shared/CryptoPriceServiceFallbackTests.swift
+++ b/MoolahTests/Shared/CryptoPriceServiceFallbackTests.swift
@@ -34,11 +34,15 @@ struct CryptoPriceServiceFallbackTests {
   ) throws -> CryptoPriceService {
     let database = try ProfileIndexDatabase.openInMemory()
     let client = FixedCryptoPriceClient(prices: ["1:native": tokenPrices], shouldFail: false)
+    // Pin to UTC so the cap's "yesterday" boundary is computed against the
+    // same calendar the `YYYY-MM-DD` fixtures use, regardless of host zone.
+    let utc = try #require(TimeZone(identifier: "UTC"))
     return CryptoPriceService(
       clients: [client],
       database: database,
       resolutionClient: nil,
-      now: now)
+      now: now,
+      timeZone: utc)
   }
 
   /// `exact` returns that day's price; an in-range gap (a date with no row,

--- a/MoolahTests/Shared/ExchangeRateServiceFallbackTests.swift
+++ b/MoolahTests/Shared/ExchangeRateServiceFallbackTests.swift
@@ -16,8 +16,11 @@ struct ExchangeRateServiceFallbackTests {
   ) throws -> ExchangeRateService {
     let client = FixedRateClient(rates: rates)
     let database = try ProfileIndexDatabase.openInMemory()
+    // Pin to UTC so the cap's "yesterday" boundary is computed against the
+    // same calendar the `YYYY-MM-DD` fixtures use, regardless of host zone.
+    let utc = try #require(TimeZone(identifier: "UTC"))
     return ExchangeRateService(
-      client: client, database: database, now: { self.date("2024-02-01") })
+      client: client, database: database, now: { self.date("2024-02-01") }, timeZone: utc)
   }
 
   private func date(_ string: String) -> Date {
@@ -70,8 +73,9 @@ struct ExchangeRateServiceFallbackTests {
         "2024-01-17": ["AUD": dec("1.52")],
       ]))
     let database = try ProfileIndexDatabase.openInMemory()
+    let utc = try #require(TimeZone(identifier: "UTC"))
     let service = ExchangeRateService(
-      client: client, database: database, now: { self.date("2024-02-01") })
+      client: client, database: database, now: { self.date("2024-02-01") }, timeZone: utc)
 
     // Prime so the cached range brackets the hole: 2024-01-15 (cold
     // surrounding fetch) then 2024-01-17 (forward extension). 2024-01-16

--- a/MoolahTests/Shared/StockPriceServiceFallbackTests.swift
+++ b/MoolahTests/Shared/StockPriceServiceFallbackTests.swift
@@ -37,10 +37,14 @@ struct StockPriceServiceFallbackTests {
     let client = FixedStockPriceClient(
       responses: ["BHP.AX": StockPriceResponse(instrument: .AUD, prices: prices)]
     )
+    // Pin to UTC so the cap's "yesterday" boundary is computed against the
+    // same calendar the `YYYY-MM-DD` fixtures use, regardless of host zone.
+    let utc = try #require(TimeZone(identifier: "UTC"))
     return StockPriceService(
       client: client,
       database: database,
-      now: { Self.parse("2024-02-01") }
+      now: { Self.parse("2024-02-01") },
+      timeZone: utc
     )
   }
 

--- a/MoolahTests/Shared/StockPriceServiceTests.swift
+++ b/MoolahTests/Shared/StockPriceServiceTests.swift
@@ -15,7 +15,11 @@ struct StockPriceServiceTests {
   ) throws -> StockPriceService {
     let client = FixedStockPriceClient(responses: responses, shouldFail: shouldFail)
     let resolved = try database ?? ProfileIndexDatabase.openInMemory()
-    return StockPriceService(client: client, database: resolved, now: now)
+    // Pin to UTC so the `YYYY-MM-DD` labels in the fixtures below match the
+    // cap's "yesterday" output regardless of the host machine's local zone.
+    // (Mirrors `CryptoPriceServiceCapTests` / `ExchangeRateServiceCapTests`.)
+    let utc = try #require(TimeZone(identifier: "UTC"))
+    return StockPriceService(client: client, database: resolved, now: now, timeZone: utc)
   }
 
   private func date(_ string: String) -> Date {


### PR DESCRIPTION
## Problem

Five tests failed on any UTC-negative host (and were flaky depending on the runner's timezone):

- `DomainModelsTests` — "ExpenseBreakdown monthDate parses YYYYMM format"
- `StockPriceServiceTests` — `todayRequestRoutesToYesterday`, `todayHitsCacheWithoutNetworkFetch`, `forwardExtensionOverwritesStaleLatest`, `rangeEndingTodayCarriesForwardYesterday`

Per the directive: timezone-sensitivity in a test is a bug. The fixes make the tests deterministic in **any** zone rather than pinning them to the current machine.

## Root causes

1. **`StockPriceServiceTests` did not pin `timeZone`.** The service's `cappedToYesterday` helper computes "yesterday" in `TimeZone.current` unless an explicit zone is injected (this is documented in `Shared/PriceCacheCap.swift`). A frozen `now` at `2026-04-12 00:00 UTC` resolves to `2026-04-11` in UTC-negative zones, so "today" requests routed to the wrong cached close (38.25 vs 38.60) and tripped `.noPriceAvailable`. The sibling harnesses `CryptoPriceServiceCapTests` and `ExchangeRateServiceCapTests` already pin `timeZone: utc`; this just brings the stock-price harness in line.

2. **`DomainModelsTests` read `ExpenseBreakdown.monthDate` through `Calendar.current`.** Production parses the `YYYYMM` label in **UTC** (a financial-month label must map to the same instant on every host — correct, unchanged), so the midnight-UTC instant shifted into the prior month (April → March) in UTC-negative zones. The test now reads components through a UTC calendar.

## Fix-all-instances

Also pinned UTC in the `StockPriceService` / `ExchangeRateService` / `CryptoPriceService` *fallback*-test harnesses. Their queried dates currently sit below the cap boundary so they were not yet flaky, but the unpinned `timeZone` is the same latent root cause — pinning is the correct, consistent seam.

Production code is unchanged; this is a test-only fix.

## Verification

All affected tests pass under:

- `TZ=Pacific/Kiritimati` (UTC+14) ✅
- `TZ=Pacific/Pago_Pago` (UTC-11) ✅
- `TZ=America/New_York` ✅
- default zone ✅

Full `just test-mac` green: **3773 tests passed**. `just format-check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)