### PR TITLE
Companion graphs for insights

### DIFF
--- a/App/UITestSeedInsightOverrides.swift
+++ b/App/UITestSeedInsightOverrides.swift
@@ -100,7 +100,8 @@ enum UITestSeedInsightOverrides {
           surprise: 0.8,
           monetaryImpact: InstrumentAmount(quantity: -2499, instrument: .AUD),
           references: InsightReferences(
-            accountIds: [UITestFixtures.TradeBaseline.checkingAccountId])),
+            accountIds: [UITestFixtures.TradeBaseline.checkingAccountId]),
+          chart: largeTxnChart(anchoredAt: now)),
         score: 4.2),
       ScoredInsight(
         insight: Insight(
@@ -124,5 +125,28 @@ enum UITestSeedInsightOverrides {
           surprise: 0.3),
         score: 2.0),
     ]
+  }
+
+  /// A deterministic six-month bar chart attached to the `largeTxnId` fixture
+  /// insight so the `.insightsForYouBaseline` seed yields exactly one charted
+  /// row (the inline chart Button + the zoom-to-detail sheet). All points are
+  /// derived from the fixed `anchoredAt` date — no `Date()` — so the failure
+  /// artefacts stay diffable. The last month spikes to the anomaly value to
+  /// mirror what `CategoryAnomalyInsight` would produce; the highlight marks it.
+  private static func largeTxnChart(anchoredAt anchor: Date) -> InsightChart {
+    let monthlySpend: [Double] = [110, 95, 130, 105, 120, 2499]
+    let monthSeconds = 86_400.0 * 30
+    let points = monthlySpend.enumerated().map { offset, value in
+      InsightChart.Point(
+        date: anchor.addingTimeInterval(Double(offset) * monthSeconds), value: value)
+    }
+    return InsightChart(
+      kind: .bar,
+      unit: .currency(.AUD),
+      series: [
+        InsightChart.Series(id: "spend", label: "Spending", role: .primary, points: points)
+      ],
+      highlight: points.last,
+      xAxis: .monthly)
   }
 }

--- a/Domain/Insights/Detectors/CashFlowForecastInsights.swift
+++ b/Domain/Insights/Detectors/CashFlowForecastInsights.swift
@@ -63,7 +63,9 @@ enum CashFlowForecastInsights {
         facts: facts,
         references: InsightReferences(
           accountIds: culprit?.accountId.map { [$0] } ?? [],
-          instrumentIds: [context.reportingCurrency.id]))
+          instrumentIds: [context.reportingCurrency.id]),
+        chart: InsightChartBuilders.balanceForecast(
+          dailyBalances, reportingCurrency: context.reportingCurrency, highlight: trough.date))
     ]
   }
 
@@ -111,7 +113,9 @@ enum CashFlowForecastInsights {
         facts: [
           InsightFact("Projected balance", rounded)
         ],
-        references: InsightReferences(instrumentIds: [context.reportingCurrency.id]))
+        references: InsightReferences(instrumentIds: [context.reportingCurrency.id]),
+        chart: InsightChartBuilders.balanceForecast(
+          dailyBalances, reportingCurrency: context.reportingCurrency, highlight: monthEndDay.date))
     ]
   }
 

--- a/Domain/Insights/Detectors/CategoryAnomalyInsight.swift
+++ b/Domain/Insights/Detectors/CategoryAnomalyInsight.swift
@@ -99,7 +99,11 @@ enum CategoryAnomalyInsight {
       ],
       references: InsightReferences(
         categoryIds: resolved.map { [$0.id] } ?? [],
-        instrumentIds: [context.reportingCurrency.id]))
+        instrumentIds: [context.reportingCurrency.id]),
+      chart: InsightChartBuilders.categorySpend(
+        points: points,
+        reportingCurrency: context.reportingCurrency,
+        highlightMonth: latest.month))
   }
 
   private static func percent(_ fraction: Double) -> String {

--- a/Domain/Insights/Detectors/CategoryTrendInsight.swift
+++ b/Domain/Insights/Detectors/CategoryTrendInsight.swift
@@ -92,6 +92,10 @@ enum CategoryTrendInsight {
       ],
       references: InsightReferences(
         categoryIds: resolved.map { [$0.id] } ?? [],
-        instrumentIds: [context.reportingCurrency.id]))
+        instrumentIds: [context.reportingCurrency.id]),
+      chart: InsightChartBuilders.categorySpend(
+        points: points,
+        reportingCurrency: context.reportingCurrency,
+        highlightMonth: latest.month))
   }
 }

--- a/Domain/Insights/Detectors/EarmarkBudgetInsights.swift
+++ b/Domain/Insights/Detectors/EarmarkBudgetInsights.swift
@@ -19,12 +19,22 @@ enum EarmarkBudgetInsights {
         let projection = project(spent: spent, budget: budget, window: window, context: context)
       else { continue }
 
+      let remaining = projection.budgetMagnitude - projection.spentMagnitude
+      let chart = InsightChartBuilders.earmarkBurndown(
+        budget: projection.budgetMagnitude,
+        current: InsightChart.Point(date: context.now, value: remaining),
+        projectedRemaining: projection.budgetMagnitude - projection.projected,
+        window: DateInterval(start: window.start, end: window.end),
+        reportingCurrency: context.reportingCurrency)
+
       if projection.fraction > 1 + overspendTolerance {
         insights.append(
-          overspend(earmark, budget: budget, projection: projection, context: context))
+          overspend(earmark, budget: budget, projection: projection, context: context, chart: chart)
+        )
       } else if projection.fraction < 1 - underspendTolerance, projection.elapsedFraction >= 0.5 {
         insights.append(
-          underspend(earmark, budget: budget, projection: projection, context: context))
+          underspend(
+            earmark, budget: budget, projection: projection, context: context, chart: chart))
       }
     }
     return insights
@@ -77,7 +87,8 @@ enum EarmarkBudgetInsights {
     _ earmark: EarmarkSnapshot,
     budget: InstrumentAmount,
     projection: Projection,
-    context: InsightContext
+    context: InsightContext,
+    chart: InsightChart?
   ) -> Insight {
     let overBy = Decimal(projection.projected - projection.budgetMagnitude)
     return Insight(
@@ -90,14 +101,16 @@ enum EarmarkBudgetInsights {
       surprise: min(projection.fraction - 1, 1),
       monetaryImpact: InstrumentAmount(quantity: -overBy, instrument: context.reportingCurrency),
       facts: projectionFacts(budget: budget, projection: projection, context: context),
-      references: InsightReferences(earmarkIds: [earmark.id]))
+      references: InsightReferences(earmarkIds: [earmark.id]),
+      chart: chart)
   }
 
   private static func underspend(
     _ earmark: EarmarkSnapshot,
     budget: InstrumentAmount,
     projection: Projection,
-    context: InsightContext
+    context: InsightContext,
+    chart: InsightChart?
   ) -> Insight {
     let roomToSpare = Decimal(projection.budgetMagnitude - projection.projected)
     return Insight(
@@ -111,7 +124,8 @@ enum EarmarkBudgetInsights {
       monetaryImpact: InstrumentAmount(
         quantity: roomToSpare, instrument: context.reportingCurrency),
       facts: projectionFacts(budget: budget, projection: projection, context: context),
-      references: InsightReferences(earmarkIds: [earmark.id]))
+      references: InsightReferences(earmarkIds: [earmark.id]),
+      chart: chart)
   }
 
   private static func projectionFacts(

--- a/Domain/Insights/Detectors/NetWorthInsights.swift
+++ b/Domain/Insights/Detectors/NetWorthInsights.swift
@@ -38,7 +38,9 @@ enum NetWorthInsights {
           InsightFact("Milestone", context.formatted(crossed)),
           InsightFact("Was", context.formatted(baseline)),
         ],
-        references: InsightReferences(instrumentIds: [context.reportingCurrency.id]))
+        references: InsightReferences(instrumentIds: [context.reportingCurrency.id]),
+        chart: InsightChartBuilders.netWorthTrend(
+          dailyBalances, reportingCurrency: context.reportingCurrency))
     ]
   }
 

--- a/Domain/Insights/Detectors/SavingsRateInsight.swift
+++ b/Domain/Insights/Detectors/SavingsRateInsight.swift
@@ -10,13 +10,14 @@ enum SavingsRateInsight {
     minimumMonths: Int = 4
   ) -> [Insight] {
     let complete = InsightAggregates.completeMonths(monthly, context: context)
-    let rates: [Double] = complete.compactMap { month in
+    let points: [InsightChart.Point] = complete.compactMap { month in
       let income = Double(
         truncating: InsightAggregates.incomeMagnitude(month.totalIncome) as NSDecimalNumber)
       guard income > 0 else { return nil }
       let net = Double(truncating: month.totalProfit.quantity as NSDecimalNumber)
-      return net / income
+      return InsightChart.Point(date: month.end, value: net / income)
     }
+    let rates = points.map(\.value)
     guard rates.count >= minimumMonths, let result = MannKendall.test(rates),
       result.statistic != 0
     else { return [] }
@@ -44,7 +45,8 @@ enum SavingsRateInsight {
           InsightFact(
             "Trend p-value", result.pValue.formatted(.number.precision(.fractionLength(3)))),
         ],
-        references: InsightReferences(instrumentIds: [context.reportingCurrency.id]))
+        references: InsightReferences(instrumentIds: [context.reportingCurrency.id]),
+        chart: InsightChartBuilders.savingsRate(points: points))
     ]
   }
 

--- a/Domain/Insights/Insight.swift
+++ b/Domain/Insights/Insight.swift
@@ -41,6 +41,11 @@ struct Insight: Sendable, Identifiable, Hashable {
   /// Deep-link handles for the UI.
   let references: InsightReferences
 
+  /// An optional companion graph visualising the detected behaviour. `nil`
+  /// when the detector has no chart for this kind or the data is too sparse;
+  /// such insights fall back to a graph-less row.
+  let chart: InsightChart?
+
   init(
     id: String,
     kind: InsightKind,
@@ -51,7 +56,8 @@ struct Insight: Sendable, Identifiable, Hashable {
     surprise: Double,
     monetaryImpact: InstrumentAmount? = nil,
     facts: [InsightFact] = [],
-    references: InsightReferences = InsightReferences()
+    references: InsightReferences = InsightReferences(),
+    chart: InsightChart? = nil
   ) {
     self.id = id
     self.kind = kind
@@ -63,6 +69,7 @@ struct Insight: Sendable, Identifiable, Hashable {
     self.monetaryImpact = monetaryImpact
     self.facts = facts
     self.references = references
+    self.chart = chart
   }
 }
 

--- a/Domain/Insights/InsightChart.swift
+++ b/Domain/Insights/InsightChart.swift
@@ -10,7 +10,6 @@ struct InsightChart: Sendable, Hashable {
   enum Kind: Sendable, Hashable {
     case line
     case bar
-    case area
   }
 
   /// The unit of the y values, driving axis/label formatting. `currency`

--- a/Domain/Insights/InsightChart.swift
+++ b/Domain/Insights/InsightChart.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+/// A companion graph a detector attaches to an `Insight` to visualise the
+/// behaviour it detected. Pure data: the detector computes it (off the main
+/// actor, alongside the `Insight`) and the view renders it — no charting
+/// logic lives in views, mirroring how `InsightFact` is the single source of
+/// truth for any rendered number.
+struct InsightChart: Sendable, Hashable {
+  /// How the primary series is drawn.
+  enum Kind: Sendable, Hashable {
+    case line
+    case bar
+    case area
+  }
+
+  /// The unit of the y values, driving axis/label formatting. `currency`
+  /// carries the reporting instrument so the view can format without a
+  /// global currency.
+  enum Unit: Sendable, Hashable {
+    case currency(Instrument)
+    case percent
+    case count
+  }
+
+  /// The role a series plays, driving its visual treatment.
+  enum SeriesRole: Sendable, Hashable {
+    /// The actual measured series (solid, tinted).
+    case primary
+    /// A forward projection (dashed, lighter).
+    case projected
+    /// A reference line such as a budget or best-fit (grey, dashed).
+    case baseline
+  }
+
+  /// X-axis tick granularity.
+  enum XAxisStyle: Sendable, Hashable {
+    case monthly
+    case daily
+  }
+
+  /// A single (date, value) sample. `value` is in the chart's `unit`
+  /// (reporting-currency amount, a 0...1 fraction for `percent`, or a count).
+  struct Point: Sendable, Hashable {
+    let date: Date
+    let value: Double
+  }
+
+  struct Series: Sendable, Hashable, Identifiable {
+    let id: String
+    let label: String
+    let role: SeriesRole
+    let points: [Point]
+  }
+
+  let kind: Kind
+  let unit: Unit
+  let series: [Series]
+  /// The point/period to mark (the anomaly, trough, or latest reading).
+  let highlight: Point?
+  let xAxis: XAxisStyle
+}

--- a/Domain/Insights/InsightChart.swift
+++ b/Domain/Insights/InsightChart.swift
@@ -45,6 +45,8 @@ struct InsightChart: Sendable, Hashable {
     let value: Double
   }
 
+  /// A named sequence of `Point`s with a visual role. `id` is a stable
+  /// detector-assigned key for SwiftUI diffing.
   struct Series: Sendable, Hashable, Identifiable {
     let id: String
     let label: String

--- a/Domain/Insights/InsightChartBuilders.swift
+++ b/Domain/Insights/InsightChartBuilders.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// Pure functions that turn detector-side aggregates into an `InsightChart`.
+/// Each returns `nil` when the data is too sparse to chart meaningfully (fewer
+/// than two points), so the insight falls back to a graph-less row.
+enum InsightChartBuilders {
+  /// Minimum points before a series is worth drawing.
+  private static let minimumPoints = 2
+
+  /// A category's monthly spend (positive magnitudes), as a bar chart with the
+  /// anomalous / latest financial month highlighted.
+  static func categorySpend(
+    points: [MonthlySpendPoint],
+    reportingCurrency: Instrument,
+    highlightMonth: String
+  ) -> InsightChart? {
+    guard points.count >= minimumPoints else { return nil }
+    let ordered = points.sorted { $0.date < $1.date }
+    let chartPoints = ordered.map { InsightChart.Point(date: $0.date, value: $0.magnitude) }
+    let highlight = ordered.first { $0.month == highlightMonth }
+      .map { InsightChart.Point(date: $0.date, value: $0.magnitude) }
+    return InsightChart(
+      kind: .bar,
+      unit: .currency(reportingCurrency),
+      series: [
+        InsightChart.Series(
+          id: "spend", label: "Spend", role: .primary, points: chartPoints)
+      ],
+      highlight: highlight,
+      xAxis: .monthly)
+  }
+}

--- a/Domain/Insights/InsightChartBuilders.swift
+++ b/Domain/Insights/InsightChartBuilders.swift
@@ -131,4 +131,48 @@ enum InsightChartBuilders {
       highlight: highlight,
       xAxis: .monthly)
   }
+
+  /// A projected budget burndown (remaining budget over the window). Earmark
+  /// snapshots carry no spend history, so this shows the ideal-burndown
+  /// baseline, the current remaining, and a dashed projection to the window
+  /// end — never faked historical data. `current` anchors both the primary
+  /// and projected series at today; `projectedRemaining` is
+  /// `budget - projectedSpend` and may go negative.
+  static func earmarkBurndown(
+    budget: Double,
+    current: InsightChart.Point,
+    projectedRemaining: Double,
+    window: DateInterval,
+    reportingCurrency: Instrument
+  ) -> InsightChart? {
+    guard budget > 0, window.start < window.end else { return nil }
+    return InsightChart(
+      kind: .line,
+      unit: .currency(reportingCurrency),
+      series: [
+        InsightChart.Series(
+          id: "ideal",
+          label: "Budget",
+          role: .baseline,
+          points: [
+            InsightChart.Point(date: window.start, value: budget),
+            InsightChart.Point(date: window.end, value: 0),
+          ]),
+        InsightChart.Series(
+          id: "actual",
+          label: "Remaining",
+          role: .primary,
+          points: [current]),
+        InsightChart.Series(
+          id: "projected",
+          label: "Projected",
+          role: .projected,
+          points: [
+            current,
+            InsightChart.Point(date: window.end, value: projectedRemaining),
+          ]),
+      ],
+      highlight: current,
+      xAxis: .daily)
+  }
 }

--- a/Domain/Insights/InsightChartBuilders.swift
+++ b/Domain/Insights/InsightChartBuilders.swift
@@ -7,6 +7,63 @@ enum InsightChartBuilders {
   /// Minimum points before a series is worth drawing.
   private static let minimumPoints = 2
 
+  /// Daily current-funds balance: the actual tail solid, the forecast tail
+  /// dashed, with `highlight` marking the trough or projected month-end day.
+  /// The two tails are joined at the boundary so the projection continues the
+  /// actual line rather than starting from zero.
+  static func balanceForecast(
+    _ balances: [DailyBalance],
+    reportingCurrency: Instrument,
+    highlight: Date?
+  ) -> InsightChart? {
+    let ordered = balances.sorted { $0.date < $1.date }
+    guard ordered.count >= minimumPoints else { return nil }
+
+    let actual = ordered.filter { !$0.isForecast }
+    let forecast = ordered.filter(\.isForecast)
+    var series: [InsightChart.Series] = []
+    if !actual.isEmpty {
+      let actualPoints = actual.map {
+        InsightChart.Point(date: $0.date, value: $0.balance.doubleValue)
+      }
+      series.append(
+        InsightChart.Series(
+          id: "actual",
+          label: "Balance",
+          role: .primary,
+          points: actualPoints))
+    }
+    if !forecast.isEmpty {
+      // Prepend the last actual point so the dashed projection visually
+      // continues from the solid line.
+      let bridge =
+        actual.last.map {
+          [InsightChart.Point(date: $0.date, value: $0.balance.doubleValue)]
+        } ?? []
+      let forecastPoints = forecast.map {
+        InsightChart.Point(date: $0.date, value: $0.balance.doubleValue)
+      }
+      series.append(
+        InsightChart.Series(
+          id: "projected",
+          label: "Projected",
+          role: .projected,
+          points: bridge + forecastPoints))
+    }
+    guard !series.isEmpty else { return nil }
+
+    let highlightPoint = highlight.flatMap { date in
+      ordered.first { $0.date == date }
+        .map { InsightChart.Point(date: $0.date, value: $0.balance.doubleValue) }
+    }
+    return InsightChart(
+      kind: .line,
+      unit: .currency(reportingCurrency),
+      series: series,
+      highlight: highlightPoint,
+      xAxis: .daily)
+  }
+
   /// A category's monthly spend (positive magnitudes), as a bar chart with the
   /// anomalous / latest financial month highlighted.
   static func categorySpend(

--- a/Domain/Insights/InsightChartBuilders.swift
+++ b/Domain/Insights/InsightChartBuilders.swift
@@ -7,6 +7,10 @@ enum InsightChartBuilders {
   /// Minimum points before a series is worth drawing.
   private static let minimumPoints = 2
 
+  private static func point(from balance: DailyBalance) -> InsightChart.Point {
+    InsightChart.Point(date: balance.date, value: balance.balance.doubleValue)
+  }
+
   /// Daily current-funds balance: the actual tail solid, the forecast tail
   /// dashed, with `highlight` marking the trough or projected month-end day.
   /// The two tails are joined at the boundary so the projection continues the
@@ -23,38 +27,28 @@ enum InsightChartBuilders {
     let forecast = ordered.filter(\.isForecast)
     var series: [InsightChart.Series] = []
     if !actual.isEmpty {
-      let actualPoints = actual.map {
-        InsightChart.Point(date: $0.date, value: $0.balance.doubleValue)
-      }
       series.append(
         InsightChart.Series(
           id: "actual",
           label: "Balance",
           role: .primary,
-          points: actualPoints))
+          points: actual.map(point(from:))))
     }
     if !forecast.isEmpty {
       // Prepend the last actual point so the dashed projection visually
       // continues from the solid line.
-      let bridge =
-        actual.last.map {
-          [InsightChart.Point(date: $0.date, value: $0.balance.doubleValue)]
-        } ?? []
-      let forecastPoints = forecast.map {
-        InsightChart.Point(date: $0.date, value: $0.balance.doubleValue)
-      }
+      let bridge = actual.last.map { [point(from: $0)] } ?? []
       series.append(
         InsightChart.Series(
           id: "projected",
           label: "Projected",
           role: .projected,
-          points: bridge + forecastPoints))
+          points: bridge + forecast.map(point(from:))))
     }
     guard !series.isEmpty else { return nil }
 
     let highlightPoint = highlight.flatMap { date in
-      ordered.first { $0.date == date }
-        .map { InsightChart.Point(date: $0.date, value: $0.balance.doubleValue) }
+      ordered.first { $0.date == date }.map(point(from:))
     }
     return InsightChart(
       kind: .line,

--- a/Domain/Insights/InsightChartBuilders.swift
+++ b/Domain/Insights/InsightChartBuilders.swift
@@ -86,7 +86,7 @@ enum InsightChartBuilders {
             InsightChart.Point(date: balance.date, value: fit.doubleValue)
           }))
     }
-    let last = actual[actual.count - 1]
+    guard let last = actual.last else { return nil }
     return InsightChart(
       kind: .line,
       unit: .currency(reportingCurrency),

--- a/Domain/Insights/InsightChartBuilders.swift
+++ b/Domain/Insights/InsightChartBuilders.swift
@@ -95,6 +95,20 @@ enum InsightChartBuilders {
       xAxis: .daily)
   }
 
+  /// Monthly savings rate as a percentage line, highlighting the latest month.
+  static func savingsRate(points: [InsightChart.Point]) -> InsightChart? {
+    guard points.count >= minimumPoints else { return nil }
+    let ordered = points.sorted { $0.date < $1.date }
+    return InsightChart(
+      kind: .line,
+      unit: .percent,
+      series: [
+        InsightChart.Series(id: "rate", label: "Savings rate", role: .primary, points: ordered)
+      ],
+      highlight: ordered.last,
+      xAxis: .monthly)
+  }
+
   /// A category's monthly spend (positive magnitudes), as a bar chart with the
   /// anomalous / latest financial month highlighted.
   static func categorySpend(

--- a/Domain/Insights/InsightChartBuilders.swift
+++ b/Domain/Insights/InsightChartBuilders.swift
@@ -58,6 +58,43 @@ enum InsightChartBuilders {
       xAxis: .daily)
   }
 
+  /// Net worth over time (actual entries only), highlighting the latest
+  /// reading. Adds a grey best-fit baseline when every actual entry carries
+  /// one.
+  static func netWorthTrend(
+    _ balances: [DailyBalance],
+    reportingCurrency: Instrument
+  ) -> InsightChart? {
+    let actual = balances.filter { !$0.isForecast }.sorted { $0.date < $1.date }
+    guard actual.count >= minimumPoints else { return nil }
+
+    var series = [
+      InsightChart.Series(
+        id: "networth",
+        label: "Net worth",
+        role: .primary,
+        points: actual.map { InsightChart.Point(date: $0.date, value: $0.netWorth.doubleValue) })
+    ]
+    let fits = actual.compactMap(\.bestFit)
+    if fits.count == actual.count {
+      series.append(
+        InsightChart.Series(
+          id: "bestfit",
+          label: "Trend",
+          role: .baseline,
+          points: zip(actual, fits).map { balance, fit in
+            InsightChart.Point(date: balance.date, value: fit.doubleValue)
+          }))
+    }
+    let last = actual[actual.count - 1]
+    return InsightChart(
+      kind: .line,
+      unit: .currency(reportingCurrency),
+      series: series,
+      highlight: InsightChart.Point(date: last.date, value: last.netWorth.doubleValue),
+      xAxis: .daily)
+  }
+
   /// A category's monthly spend (positive magnitudes), as a bar chart with the
   /// anomalous / latest financial month highlighted.
   static func categorySpend(

--- a/Features/Insights/Views/ForYouCard.swift
+++ b/Features/Insights/Views/ForYouCard.swift
@@ -41,6 +41,7 @@ private struct InsightRow: View {
   let onNavigate: (SidebarSelection) -> Void
 
   @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+  @Environment(\.horizontalSizeClass) private var horizontalSizeClass
   @State private var isZoomed = false
 
   private var insight: Insight { item.scored.insight }
@@ -102,11 +103,14 @@ private struct InsightRow: View {
         isZoomed = true
       } label: {
         InsightChartView(chart: chart, tint: framingColor, style: .inline)
-          .frame(width: 200)
+          .frame(width: horizontalSizeClass == .compact ? 120 : 200, height: 48)
+          .contentShape(Rectangle())
       }
       .buttonStyle(.plain)
       .accessibilityIdentifier(UITestIdentifiers.ForYou.chart(insight.id))
       .accessibilityLabel("Show \(item.headline) chart")
+      .accessibilityHint("Opens a larger chart view")
+      .help("Show \(item.headline) chart in detail")
     }
   }
 

--- a/Features/Insights/Views/ForYouCard.swift
+++ b/Features/Insights/Views/ForYouCard.swift
@@ -41,6 +41,7 @@ private struct InsightRow: View {
   let onNavigate: (SidebarSelection) -> Void
 
   @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+  @State private var isZoomed = false
 
   private var insight: Insight { item.scored.insight }
   private var target: SidebarSelection? {
@@ -54,6 +55,9 @@ private struct InsightRow: View {
     // layout keeps everything inline.
     Group {
       if dynamicTypeSize.isAccessibilitySize {
+        // At accessibility sizes the inline 200pt chart would crowd the
+        // already-stacked content, so the companion graph drops to the bottom
+        // of the vertical stack (full width) rather than sitting inline.
         VStack(alignment: .leading, spacing: 6) {
           headlineLine
           HStack(spacing: 8) {
@@ -62,6 +66,7 @@ private struct InsightRow: View {
             showLessButton
             viewButton
           }
+          chartButton
         }
       } else {
         HStack(spacing: 8) {
@@ -69,6 +74,7 @@ private struct InsightRow: View {
           impactText
           showLessButton
           viewButton
+          chartButton
         }
       }
     }
@@ -78,6 +84,30 @@ private struct InsightRow: View {
     // VoiceOver elements.
     .accessibilityElement(children: .contain)
     .accessibilityIdentifier(UITestIdentifiers.ForYou.row(insight.id))
+    .sheet(isPresented: $isZoomed) {
+      InsightChartDetailSheet(
+        insight: insight,
+        headline: item.headline,
+        onNavigate: onNavigate,
+        onDismiss: onDismiss)
+    }
+  }
+
+  /// The trailing companion graph: a fixed ~200pt inline chart that zooms to
+  /// the detail sheet when tapped. Only present when the insight carries a
+  /// chart, so graph-less rows render exactly as before.
+  @ViewBuilder private var chartButton: some View {
+    if let chart = insight.chart {
+      Button {
+        isZoomed = true
+      } label: {
+        InsightChartView(chart: chart, tint: framingColor, style: .inline)
+          .frame(width: 200)
+      }
+      .buttonStyle(.plain)
+      .accessibilityIdentifier(UITestIdentifiers.ForYou.chart(insight.id))
+      .accessibilityLabel("Show \(item.headline) chart")
+    }
   }
 
   private var headlineLine: some View {
@@ -196,7 +226,24 @@ private struct InsightRow: View {
               actionability: .review,
               surprise: 0.8,
               monetaryImpact: InstrumentAmount(quantity: -2499, instrument: .AUD),
-              references: InsightReferences(accountIds: [accountId])),
+              references: InsightReferences(accountIds: [accountId]),
+              chart: InsightChart(
+                kind: .bar,
+                unit: .currency(.AUD),
+                series: [
+                  InsightChart.Series(
+                    id: "spend",
+                    label: "Spending",
+                    role: .primary,
+                    points: (0..<6).map { offset in
+                      InsightChart.Point(
+                        date: now.addingTimeInterval(Double(offset) * 86_400 * 30),
+                        value: offset == 5 ? 2499 : Double.random(in: 80...160))
+                    })
+                ],
+                highlight: InsightChart.Point(
+                  date: now.addingTimeInterval(5 * 86_400 * 30), value: 2499),
+                xAxis: .monthly)),
             score: 4.2),
           headline: "You spent $2,499 at the Apple Store, far above your usual $120."),
         ForYouItem(

--- a/Features/Insights/Views/InsightChartDetailSheet.swift
+++ b/Features/Insights/Views/InsightChartDetailSheet.swift
@@ -57,6 +57,7 @@ struct InsightChartDetailSheet: View {
       }
       .buttonStyle(.plain)
       .accessibilityLabel("Close")
+      .help("Close")
     }
   }
 

--- a/Features/Insights/Views/InsightChartDetailSheet.swift
+++ b/Features/Insights/Views/InsightChartDetailSheet.swift
@@ -31,16 +31,23 @@ struct InsightChartDetailSheet: View {
       actions
     }
     .padding(24)
-    .frame(minWidth: 420, minHeight: 420)
+    .dynamicTypeSize(.medium ... .accessibility3)
+    #if os(macOS)
+      .frame(minWidth: 420, minHeight: 420)
+    #endif
+    #if os(iOS)
+      .presentationDetents([.medium, .large])
+    #endif
   }
 
   private var header: some View {
     HStack(alignment: .firstTextBaseline, spacing: 8) {
       Image(systemName: framingIcon)
         .foregroundStyle(framingColor)
-        .accessibilityHidden(true)
+        .accessibilityLabel(framingDescription)
       Text(headline)
         .font(.headline)
+        .accessibilityAddTraits(.isHeader)
       Spacer()
       Button {
         dismiss()
@@ -59,10 +66,13 @@ struct InsightChartDetailSheet: View {
         HStack {
           Text(fact.label).foregroundStyle(.secondary)
           Spacer()
+          // `.monospacedDigit()` aligns numeric fact values (the common case)
+          // and is harmless on the occasional text-only value.
           Text(fact.value).fontWeight(.semibold).monospacedDigit()
         }
         .font(.subheadline)
         .padding(.vertical, 8)
+        .accessibilityElement(children: .combine)
         Divider()
       }
     }
@@ -70,12 +80,17 @@ struct InsightChartDetailSheet: View {
 
   @ViewBuilder private var actions: some View {
     HStack(spacing: 12) {
-      Button(role: .destructive) {
+      Button {
         onDismiss()
         dismiss()
       } label: {
         Label("Show less", systemImage: "hand.thumbsdown")
+          .font(.caption)
       }
+      .buttonStyle(.borderless)
+      .foregroundStyle(.secondary)
+      .help("Show fewer insights like this")
+      .accessibilityLabel("Show fewer insights like this: \(headline)")
       Spacer()
       if let target {
         Button {
@@ -84,7 +99,8 @@ struct InsightChartDetailSheet: View {
         } label: {
           Label("View", systemImage: "arrow.forward")
         }
-        .keyboardShortcut(.defaultAction)
+        .help("View \(headline)")
+        .accessibilityLabel("View \(headline)")
       }
     }
   }
@@ -104,4 +120,73 @@ struct InsightChartDetailSheet: View {
     case .neutral: return "info.circle.fill"
     }
   }
+
+  private var framingDescription: String {
+    switch insight.framing {
+    case .positive: return "Good news"
+    case .negative: return "Heads up"
+    case .neutral: return "Note"
+    }
+  }
 }
+
+#if DEBUG
+  extension Insight {
+    /// A negative-framed insight with a bar chart and three facts, for previews.
+    static var previewDiningAnomaly: Insight {
+      let points = (0..<6).map { offset -> InsightChart.Point in
+        let date = Calendar.current.date(byAdding: .month, value: -5 + offset, to: Date()) ?? Date()
+        return InsightChart.Point(date: date, value: Double(100 + offset * 60))
+      }
+      let chart = InsightChart(
+        kind: .bar,
+        unit: .currency(.AUD),
+        series: [InsightChart.Series(id: "spend", label: "Spend", role: .primary, points: points)],
+        highlight: nil,
+        xAxis: .monthly)
+      return Insight(
+        id: "preview",
+        kind: .categorySpendingAnomaly,
+        title: "Dining up 62%",
+        date: Date(),
+        framing: .negative,
+        actionability: .review,
+        surprise: 0.8,
+        facts: [
+          InsightFact("Category", "Dining"),
+          InsightFact("This month", "$742"),
+          InsightFact("Expected", "$458"),
+        ],
+        chart: chart)
+    }
+
+    /// A positive-framed, chart-less insight with no references (so no "View").
+    static var previewNetWorthMilestone: Insight {
+      Insight(
+        id: "preview2",
+        kind: .netWorthMilestone,
+        title: "Net worth passed $100k",
+        date: Date(),
+        framing: .positive,
+        actionability: .informational,
+        surprise: 0.5,
+        facts: [InsightFact("Net worth", "$101,000")])
+    }
+  }
+
+  #Preview("Negative · chart + facts") {
+    InsightChartDetailSheet(
+      insight: .previewDiningAnomaly,
+      headline: "Dining out is up 62% this month",
+      onNavigate: { _ in },
+      onDismiss: {})
+  }
+
+  #Preview("Positive · no chart, no View button") {
+    InsightChartDetailSheet(
+      insight: .previewNetWorthMilestone,
+      headline: "Net worth crossed $100k",
+      onNavigate: { _ in },
+      onDismiss: {})
+  }
+#endif

--- a/Features/Insights/Views/InsightChartDetailSheet.swift
+++ b/Features/Insights/Views/InsightChartDetailSheet.swift
@@ -1,0 +1,107 @@
+import SwiftUI
+
+/// The zoomed companion-graph view, presented as a centered sheet when the
+/// user taps an insight's inline chart. Reads only what the `Insight` already
+/// carries — no recompute.
+struct InsightChartDetailSheet: View {
+  let insight: Insight
+  let headline: String
+  let onNavigate: (SidebarSelection) -> Void
+  let onDismiss: () -> Void
+
+  @Environment(\.dismiss) private var dismiss
+
+  private var target: SidebarSelection? {
+    InsightNavigationTarget.sidebarSelection(for: insight.references)
+  }
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 16) {
+      header
+      if let chart = insight.chart {
+        InsightChartView(
+          chart: chart, tint: framingColor, style: .expanded, accessibilityLabel: headline
+        )
+        .accessibilityIdentifier(UITestIdentifiers.ForYou.chartDetail)
+      }
+      if !insight.facts.isEmpty {
+        factsList
+      }
+      Spacer(minLength: 0)
+      actions
+    }
+    .padding(24)
+    .frame(minWidth: 420, minHeight: 420)
+  }
+
+  private var header: some View {
+    HStack(alignment: .firstTextBaseline, spacing: 8) {
+      Image(systemName: framingIcon)
+        .foregroundStyle(framingColor)
+        .accessibilityHidden(true)
+      Text(headline)
+        .font(.headline)
+      Spacer()
+      Button {
+        dismiss()
+      } label: {
+        Image(systemName: "xmark.circle.fill")
+          .foregroundStyle(.secondary)
+      }
+      .buttonStyle(.plain)
+      .accessibilityLabel("Close")
+    }
+  }
+
+  private var factsList: some View {
+    VStack(spacing: 0) {
+      ForEach(insight.facts) { fact in
+        HStack {
+          Text(fact.label).foregroundStyle(.secondary)
+          Spacer()
+          Text(fact.value).fontWeight(.semibold).monospacedDigit()
+        }
+        .font(.subheadline)
+        .padding(.vertical, 8)
+        Divider()
+      }
+    }
+  }
+
+  @ViewBuilder private var actions: some View {
+    HStack(spacing: 12) {
+      Button(role: .destructive) {
+        onDismiss()
+        dismiss()
+      } label: {
+        Label("Show less", systemImage: "hand.thumbsdown")
+      }
+      Spacer()
+      if let target {
+        Button {
+          onNavigate(target)
+          dismiss()
+        } label: {
+          Label("View", systemImage: "arrow.forward")
+        }
+        .keyboardShortcut(.defaultAction)
+      }
+    }
+  }
+
+  private var framingColor: Color {
+    switch insight.framing {
+    case .positive: return .green
+    case .negative: return .orange
+    case .neutral: return .secondary
+    }
+  }
+
+  private var framingIcon: String {
+    switch insight.framing {
+    case .positive: return "checkmark.seal.fill"
+    case .negative: return "exclamationmark.triangle.fill"
+    case .neutral: return "info.circle.fill"
+    }
+  }
+}

--- a/Features/Insights/Views/InsightChartView.swift
+++ b/Features/Insights/Views/InsightChartView.swift
@@ -12,6 +12,7 @@ struct InsightChartView: View {
   let chart: InsightChart
   let tint: Color
   var style: Style = .inline
+  var accessibilityLabel: String = ""
 
   var body: some View {
     if style == .inline {
@@ -21,11 +22,17 @@ struct InsightChartView: View {
         .chartLegend(.hidden)
         .frame(height: 48)
         .allowsHitTesting(false)
+        .accessibilityHidden(true)
+        .dynamicTypeSize(.medium ... .accessibility1)
     } else {
       baseChart
         .chartXAxis { xAxisMarks }
         .chartYAxis { yAxisMarks }
-        .frame(height: 240)
+        .frame(minHeight: 200, idealHeight: 240)
+        .accessibilityLabel(
+          accessibilityLabel.isEmpty
+            ? chart.series.map(\.label).joined(separator: ", ")
+            : accessibilityLabel)
     }
   }
 
@@ -41,11 +48,11 @@ struct InsightChartView: View {
           x: .value("Date", highlight.date),
           y: .value("Value", highlight.value)
         )
-        .foregroundStyle(.red)
+        .foregroundStyle(tint)
         .symbolSize(style == .inline ? 18 : 60)
         if style == .expanded {
           RuleMark(x: .value("Date", highlight.date))
-            .foregroundStyle(.red.opacity(0.25))
+            .foregroundStyle(tint.opacity(0.25))
             .lineStyle(StrokeStyle(lineWidth: 1, dash: [3, 3]))
         }
       }
@@ -63,7 +70,7 @@ struct InsightChartView: View {
         y: .value("Value", point.value)
       )
       .foregroundStyle(color(for: series.role).opacity(series.role == .primary ? 1 : 0.5))
-    case .line, .area:
+    case .line:
       LineMark(
         x: .value("Date", point.date),
         y: .value("Value", point.value),
@@ -79,7 +86,7 @@ struct InsightChartView: View {
     switch role {
     case .primary: tint
     case .projected: tint.opacity(0.5)
-    case .baseline: .gray
+    case .baseline: .secondary
     }
   }
 
@@ -92,12 +99,16 @@ struct InsightChartView: View {
   }
 
   @AxisContentBuilder private var xAxisMarks: some AxisContent {
-    AxisMarks(values: .automatic(desiredCount: 5)) { _ in
+    AxisMarks(values: .automatic(desiredCount: 5)) { value in
       AxisGridLine()
       AxisTick()
-      switch chart.xAxis {
-      case .monthly: AxisValueLabel(format: .dateTime.month(.abbreviated))
-      case .daily: AxisValueLabel(format: .dateTime.month(.abbreviated).day())
+      AxisValueLabel {
+        if let date = value.as(Date.self) {
+          switch chart.xAxis {
+          case .monthly: Text(date, format: .dateTime.month(.abbreviated)).monospacedDigit()
+          case .daily: Text(date, format: .dateTime.month(.abbreviated).day()).monospacedDigit()
+          }
+        }
       }
     }
   }
@@ -125,6 +136,10 @@ struct InsightChartView: View {
   }
 }
 
+private func previewMonth(_ offset: Int) -> Date {
+  Calendar.current.date(byAdding: .month, value: -5 + offset, to: Date()) ?? Date()
+}
+
 #Preview("Inline") {
   InsightChartView(
     chart: InsightChart(
@@ -136,19 +151,40 @@ struct InsightChartView: View {
           label: "Spend",
           role: .primary,
           points: (0..<6).map {
-            InsightChart.Point(
-              date: Date(timeIntervalSince1970: 1_700_000_000 + Double($0) * 2_600_000),
-              value: Double(100 + $0 * 40))
+            InsightChart.Point(date: previewMonth($0), value: Double(100 + $0 * 40))
           })
       ],
-      highlight: InsightChart.Point(
-        date: Date(timeIntervalSince1970: 1_700_000_000 + 5 * 2_600_000), value: 300),
+      highlight: InsightChart.Point(date: previewMonth(5), value: 300),
       xAxis: .monthly),
     tint: .orange,
     style: .inline
   )
   .padding()
   .frame(width: 220)
+}
+
+#Preview("Inline · Dark") {
+  InsightChartView(
+    chart: InsightChart(
+      kind: .bar,
+      unit: .currency(.AUD),
+      series: [
+        InsightChart.Series(
+          id: "spend",
+          label: "Spend",
+          role: .primary,
+          points: (0..<6).map {
+            InsightChart.Point(date: previewMonth($0), value: Double(100 + $0 * 40))
+          })
+      ],
+      highlight: InsightChart.Point(date: previewMonth(5), value: 300),
+      xAxis: .monthly),
+    tint: .orange,
+    style: .inline
+  )
+  .padding()
+  .frame(width: 220)
+  .preferredColorScheme(.dark)
 }
 
 #Preview("Expanded") {
@@ -162,9 +198,7 @@ struct InsightChartView: View {
           label: "Savings rate",
           role: .primary,
           points: (0..<6).map {
-            InsightChart.Point(
-              date: Date(timeIntervalSince1970: 1_700_000_000 + Double($0) * 2_600_000),
-              value: 0.1 + Double($0) * 0.02)
+            InsightChart.Point(date: previewMonth($0), value: 0.1 + Double($0) * 0.02)
           })
       ],
       highlight: nil,

--- a/Features/Insights/Views/InsightChartView.swift
+++ b/Features/Insights/Views/InsightChartView.swift
@@ -1,0 +1,177 @@
+import Charts
+import SwiftUI
+
+/// Renders an `InsightChart` at one of two sizes. The detector computed the
+/// data; this view only draws it (thin-view discipline).
+struct InsightChartView: View {
+  enum Style {
+    case inline
+    case expanded
+  }
+
+  let chart: InsightChart
+  let tint: Color
+  var style: Style = .inline
+
+  var body: some View {
+    if style == .inline {
+      baseChart
+        .chartXAxis(.hidden)
+        .chartYAxis(.hidden)
+        .chartLegend(.hidden)
+        .frame(height: 48)
+        .allowsHitTesting(false)
+    } else {
+      baseChart
+        .chartXAxis { xAxisMarks }
+        .chartYAxis { yAxisMarks }
+        .frame(height: 240)
+    }
+  }
+
+  private var baseChart: some View {
+    Chart {
+      ForEach(chart.series) { series in
+        ForEach(series.points, id: \.date) { point in
+          marks(for: point, in: series)
+        }
+      }
+      if let highlight = chart.highlight {
+        PointMark(
+          x: .value("Date", highlight.date),
+          y: .value("Value", highlight.value)
+        )
+        .foregroundStyle(.red)
+        .symbolSize(style == .inline ? 18 : 60)
+        if style == .expanded {
+          RuleMark(x: .value("Date", highlight.date))
+            .foregroundStyle(.red.opacity(0.25))
+            .lineStyle(StrokeStyle(lineWidth: 1, dash: [3, 3]))
+        }
+      }
+    }
+  }
+
+  @ChartContentBuilder
+  private func marks(
+    for point: InsightChart.Point, in series: InsightChart.Series
+  ) -> some ChartContent {
+    switch chart.kind {
+    case .bar:
+      BarMark(
+        x: .value("Date", point.date),
+        y: .value("Value", point.value)
+      )
+      .foregroundStyle(color(for: series.role).opacity(series.role == .primary ? 1 : 0.5))
+    case .line, .area:
+      LineMark(
+        x: .value("Date", point.date),
+        y: .value("Value", point.value),
+        series: .value("Series", series.id)
+      )
+      .foregroundStyle(color(for: series.role))
+      .lineStyle(strokeStyle(for: series.role))
+      .interpolationMethod(.monotone)
+    }
+  }
+
+  private func color(for role: InsightChart.SeriesRole) -> Color {
+    switch role {
+    case .primary: tint
+    case .projected: tint.opacity(0.5)
+    case .baseline: .gray
+    }
+  }
+
+  private func strokeStyle(for role: InsightChart.SeriesRole) -> StrokeStyle {
+    switch role {
+    case .primary: StrokeStyle(lineWidth: 2)
+    case .projected: StrokeStyle(lineWidth: 1.5, dash: [4, 3])
+    case .baseline: StrokeStyle(lineWidth: 1, dash: [2, 3])
+    }
+  }
+
+  @AxisContentBuilder private var xAxisMarks: some AxisContent {
+    AxisMarks(values: .automatic(desiredCount: 5)) { _ in
+      AxisGridLine()
+      AxisTick()
+      switch chart.xAxis {
+      case .monthly: AxisValueLabel(format: .dateTime.month(.abbreviated))
+      case .daily: AxisValueLabel(format: .dateTime.month(.abbreviated).day())
+      }
+    }
+  }
+
+  @AxisContentBuilder private var yAxisMarks: some AxisContent {
+    AxisMarks { value in
+      AxisGridLine()
+      AxisValueLabel {
+        if let raw = value.as(Double.self) {
+          Text(formattedY(raw)).monospacedDigit()
+        }
+      }
+    }
+  }
+
+  private func formattedY(_ raw: Double) -> String {
+    switch chart.unit {
+    case .currency(let instrument):
+      return InstrumentAmount(quantity: Decimal(raw), instrument: instrument).formatNoSymbol
+    case .percent:
+      return raw.formatted(.percent.precision(.fractionLength(0)))
+    case .count:
+      return Int(raw.rounded()).formatted()
+    }
+  }
+}
+
+#Preview("Inline") {
+  InsightChartView(
+    chart: InsightChart(
+      kind: .bar,
+      unit: .currency(.AUD),
+      series: [
+        InsightChart.Series(
+          id: "spend",
+          label: "Spend",
+          role: .primary,
+          points: (0..<6).map {
+            InsightChart.Point(
+              date: Date(timeIntervalSince1970: 1_700_000_000 + Double($0) * 2_600_000),
+              value: Double(100 + $0 * 40))
+          })
+      ],
+      highlight: InsightChart.Point(
+        date: Date(timeIntervalSince1970: 1_700_000_000 + 5 * 2_600_000), value: 300),
+      xAxis: .monthly),
+    tint: .orange,
+    style: .inline
+  )
+  .padding()
+  .frame(width: 220)
+}
+
+#Preview("Expanded") {
+  InsightChartView(
+    chart: InsightChart(
+      kind: .line,
+      unit: .percent,
+      series: [
+        InsightChart.Series(
+          id: "rate",
+          label: "Savings rate",
+          role: .primary,
+          points: (0..<6).map {
+            InsightChart.Point(
+              date: Date(timeIntervalSince1970: 1_700_000_000 + Double($0) * 2_600_000),
+              value: 0.1 + Double($0) * 0.02)
+          })
+      ],
+      highlight: nil,
+      xAxis: .monthly),
+    tint: .green,
+    style: .expanded
+  )
+  .padding()
+  .frame(width: 480)
+}

--- a/Features/Insights/Views/InsightChartView.swift
+++ b/Features/Insights/Views/InsightChartView.swift
@@ -39,7 +39,10 @@ struct InsightChartView: View {
   private var baseChart: some View {
     Chart {
       ForEach(chart.series) { series in
-        ForEach(series.points, id: \.date) { point in
+        // Positional identity: two points in a series can share a date (e.g. a
+        // burndown's current/start landing on the same day), so `\.date` is not
+        // a unique key.
+        ForEach(Array(series.points.enumerated()), id: \.offset) { _, point in
           marks(for: point, in: series)
         }
       }

--- a/MoolahTests/Domain/Insights/CashFlowForecastInsightsTests.swift
+++ b/MoolahTests/Domain/Insights/CashFlowForecastInsightsTests.swift
@@ -64,5 +64,6 @@ struct CashFlowForecastInsightsTests {
     #expect(insight.monetaryImpact == nil)
     #expect(insight.chart != nil)
     #expect(insight.chart?.series.contains { $0.role == .projected } == true)
+    #expect(insight.chart?.series.contains { $0.role == .primary } == true)
   }
 }

--- a/MoolahTests/Domain/Insights/CashFlowForecastInsightsTests.swift
+++ b/MoolahTests/Domain/Insights/CashFlowForecastInsightsTests.swift
@@ -62,5 +62,7 @@ struct CashFlowForecastInsightsTests {
     // No impact badge: the rounded projection lives in the headline, so an
     // exact to-the-cent impact amount would contradict it.
     #expect(insight.monetaryImpact == nil)
+    #expect(insight.chart != nil)
+    #expect(insight.chart?.series.contains { $0.role == .projected } == true)
   }
 }

--- a/MoolahTests/Domain/Insights/FinanceInsightTests.swift
+++ b/MoolahTests/Domain/Insights/FinanceInsightTests.swift
@@ -101,6 +101,35 @@ struct FinanceInsightTests {
     #expect(insights.contains { $0.kind == .bottomPerformer })
   }
 
+  // MARK: - Savings rate
+
+  @Test
+  func savingsRateRisingAttachesPercentChart() throws {
+    // Constant income with month-over-month falling expenses ⇒ a strictly
+    // rising savings rate (0.40 → 0.80) across five complete months.
+    let months = zip(
+      ["202601", "202602", "202603", "202604", "202605"],
+      [Decimal(3000), 2500, 2000, 1500, 1000]
+    ).map { month, expense in
+      InsightTestSupport.monthly(month: month, income: 5000, expense: expense)
+    }
+    let insights = SavingsRateInsight.detect(monthly: months, context: context)
+    let trend = try #require(insights.first { $0.kind == .savingsRateTrend })
+    #expect(trend.framing == .positive)  // rising
+    #expect(trend.chart?.unit == .percent)
+    #expect(trend.chart?.series.first?.id == "rate")
+    #expect(trend.chart?.series.first?.points.isEmpty == false)
+  }
+
+  @Test
+  func savingsRateQuietWhenEveryMonthHasZeroIncome() {
+    // The `income > 0` guard drops every month, leaving no rates to test.
+    let months = ["202601", "202602", "202603", "202604", "202605"].map {
+      InsightTestSupport.monthly(month: $0, income: 0, expense: 1000)
+    }
+    #expect(SavingsRateInsight.detect(monthly: months, context: context).isEmpty)
+  }
+
   // MARK: - Liquidity
 
   @Test

--- a/MoolahTests/Domain/Insights/FinanceInsightTests.swift
+++ b/MoolahTests/Domain/Insights/FinanceInsightTests.swift
@@ -28,6 +28,7 @@ struct FinanceInsightTests {
     let insights = EarmarkBudgetInsights.detect(earmarks: [earmark], context: context)
     let overspend = try #require(insights.first { $0.kind == .earmarkBurndownProjection })
     #expect(overspend.actionability == .act)
+    #expect(overspend.chart?.series.contains { $0.role == .projected } == true)
   }
 
   @Test

--- a/MoolahTests/Domain/Insights/InsightChartBuildersTests.swift
+++ b/MoolahTests/Domain/Insights/InsightChartBuildersTests.swift
@@ -85,4 +85,41 @@ struct InsightChartBuildersTests {
       InsightChartBuilders.categorySpend(
         points: points, reportingCurrency: currency, highlightMonth: "202606") == nil)
   }
+
+  private func balance(
+    _ day: Int, total: Decimal, forecast: Bool
+  ) -> DailyBalance {
+    let amount = InstrumentAmount(quantity: total, instrument: currency)
+    let zero = InstrumentAmount.zero(instrument: currency)
+    return DailyBalance(
+      date: InsightTestSupport.date(2026, 6, day),
+      balance: amount,
+      earmarked: zero,
+      availableFunds: amount,
+      investments: zero,
+      investmentValue: nil,
+      netWorth: amount,
+      bestFit: nil,
+      isForecast: forecast)
+  }
+
+  @Test
+  func balanceForecastSplitsActualAndProjected() throws {
+    let balances = [
+      balance(1, total: 1000, forecast: false),
+      balance(2, total: 900, forecast: false),
+      balance(3, total: 400, forecast: true),
+      balance(4, total: 700, forecast: true),
+    ]
+    let chart = try #require(
+      InsightChartBuilders.balanceForecast(
+        balances, reportingCurrency: currency, highlight: InsightTestSupport.date(2026, 6, 3)))
+
+    #expect(chart.kind == .line)
+    #expect(chart.unit == .currency(currency))
+    #expect(chart.xAxis == .daily)
+    #expect(chart.series.contains { $0.role == .primary })
+    #expect(chart.series.contains { $0.role == .projected })
+    #expect(chart.highlight?.value == 400)
+  }
 }

--- a/MoolahTests/Domain/Insights/InsightChartBuildersTests.swift
+++ b/MoolahTests/Domain/Insights/InsightChartBuildersTests.swift
@@ -1,0 +1,33 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("Insight chart builders")
+struct InsightChartBuildersTests {
+  private let currency = InsightTestSupport.currency
+
+  @Test
+  func insightCarriesAnOptionalChart() {
+    let chart = InsightChart(
+      kind: .line,
+      unit: .percent,
+      series: [
+        InsightChart.Series(
+          id: "rate", label: "Savings rate", role: .primary,
+          points: [
+            InsightChart.Point(date: InsightTestSupport.date(2026, 1, 1), value: 0.1),
+            InsightChart.Point(date: InsightTestSupport.date(2026, 2, 1), value: 0.2),
+          ])
+      ],
+      highlight: InsightChart.Point(date: InsightTestSupport.date(2026, 2, 1), value: 0.2),
+      xAxis: .monthly)
+
+    let insight = Insight(
+      id: "x", kind: .savingsRateTrend, title: "t", date: InsightTestSupport.now,
+      framing: .positive, actionability: .review, surprise: 0.5, chart: chart)
+
+    #expect(insight.chart == chart)
+    #expect(insight.chart?.series.first?.points.count == 2)
+  }
+}

--- a/MoolahTests/Domain/Insights/InsightChartBuildersTests.swift
+++ b/MoolahTests/Domain/Insights/InsightChartBuildersTests.swift
@@ -69,8 +69,11 @@ struct InsightChartBuildersTests {
     #expect(chart.unit == .currency(currency))
     #expect(chart.xAxis == .monthly)
     #expect(chart.series.count == 1)
+    #expect(chart.series.first?.id == "spend")
+    #expect(chart.series.first?.role == .primary)
     #expect(chart.series.first?.points.count == 3)
     #expect(chart.highlight?.value == 400)
+    #expect(chart.highlight?.date == InsightTestSupport.date(2026, 6, 1))
   }
 
   @Test

--- a/MoolahTests/Domain/Insights/InsightChartBuildersTests.swift
+++ b/MoolahTests/Domain/Insights/InsightChartBuildersTests.swift
@@ -53,4 +53,33 @@ struct InsightChartBuildersTests {
       xAxis: .monthly)
     #expect(chart.unit == .currency(currency))
   }
+
+  @Test
+  func categorySpendChartHighlightsTheGivenMonth() throws {
+    let points = [
+      MonthlySpendPoint(month: "202604", date: InsightTestSupport.date(2026, 4, 1), magnitude: 100),
+      MonthlySpendPoint(month: "202605", date: InsightTestSupport.date(2026, 5, 1), magnitude: 110),
+      MonthlySpendPoint(month: "202606", date: InsightTestSupport.date(2026, 6, 1), magnitude: 400),
+    ]
+    let chart = try #require(
+      InsightChartBuilders.categorySpend(
+        points: points, reportingCurrency: currency, highlightMonth: "202606"))
+
+    #expect(chart.kind == .bar)
+    #expect(chart.unit == .currency(currency))
+    #expect(chart.xAxis == .monthly)
+    #expect(chart.series.count == 1)
+    #expect(chart.series.first?.points.count == 3)
+    #expect(chart.highlight?.value == 400)
+  }
+
+  @Test
+  func categorySpendChartIsNilBelowTwoPoints() {
+    let points = [
+      MonthlySpendPoint(month: "202606", date: InsightTestSupport.date(2026, 6, 1), magnitude: 400)
+    ]
+    #expect(
+      InsightChartBuilders.categorySpend(
+        points: points, reportingCurrency: currency, highlightMonth: "202606") == nil)
+  }
 }

--- a/MoolahTests/Domain/Insights/InsightChartBuildersTests.swift
+++ b/MoolahTests/Domain/Insights/InsightChartBuildersTests.swift
@@ -120,6 +120,20 @@ struct InsightChartBuildersTests {
   }
 
   @Test
+  func savingsRateChartIsPercentUnit() throws {
+    let points = [
+      InsightChart.Point(date: InsightTestSupport.date(2026, 3, 31), value: 0.10),
+      InsightChart.Point(date: InsightTestSupport.date(2026, 4, 30), value: 0.15),
+      InsightChart.Point(date: InsightTestSupport.date(2026, 5, 31), value: 0.22),
+    ]
+    let chart = try #require(InsightChartBuilders.savingsRate(points: points))
+    #expect(chart.kind == .line)
+    #expect(chart.unit == .percent)
+    #expect(chart.xAxis == .monthly)
+    #expect(chart.highlight?.value == 0.22)
+  }
+
+  @Test
   func balanceForecastSplitsActualAndProjected() throws {
     let balances = [
       balance(1, total: 1000, forecast: false),

--- a/MoolahTests/Domain/Insights/InsightChartBuildersTests.swift
+++ b/MoolahTests/Domain/Insights/InsightChartBuildersTests.swift
@@ -159,4 +159,26 @@ struct InsightChartBuildersTests {
     #expect(projected.points.count == 3)
     #expect(projected.points.first?.value == 900)
   }
+
+  @Test
+  func earmarkBurndownProjectsBeyondBudget() throws {
+    let start = InsightTestSupport.date(2026, 6, 1)
+    let now = InsightTestSupport.date(2026, 6, 15)
+    let end = InsightTestSupport.date(2026, 6, 30)
+    let chart = try #require(
+      InsightChartBuilders.earmarkBurndown(
+        budget: 1000,
+        current: InsightChart.Point(date: now, value: 300),
+        projectedRemaining: -400,
+        window: DateInterval(start: start, end: end),
+        reportingCurrency: currency))
+
+    #expect(chart.kind == .line)
+    #expect(chart.unit == .currency(currency))
+    #expect(chart.series.contains { $0.role == .baseline })
+    #expect(chart.series.contains { $0.role == .primary })
+    #expect(chart.series.contains { $0.role == .projected })
+    let projected = try #require(chart.series.first { $0.role == .projected })
+    #expect(projected.points.last?.value == -400)  // budget(1000) - projected(1400)
+  }
 }

--- a/MoolahTests/Domain/Insights/InsightChartBuildersTests.swift
+++ b/MoolahTests/Domain/Insights/InsightChartBuildersTests.swift
@@ -104,6 +104,21 @@ struct InsightChartBuildersTests {
   }
 
   @Test
+  func netWorthTrendUsesNetWorthValues() throws {
+    let balances = [
+      balance(1, total: 90_000, forecast: false),
+      balance(15, total: 95_000, forecast: false),
+      balance(30, total: 101_000, forecast: false),
+    ]
+    let chart = try #require(
+      InsightChartBuilders.netWorthTrend(balances, reportingCurrency: currency))
+    #expect(chart.kind == .line)
+    #expect(chart.series.first?.role == .primary)
+    #expect(chart.series.first?.points.count == 3)
+    #expect(chart.highlight?.value == 101_000)
+  }
+
+  @Test
   func balanceForecastSplitsActualAndProjected() throws {
     let balances = [
       balance(1, total: 1000, forecast: false),

--- a/MoolahTests/Domain/Insights/InsightChartBuildersTests.swift
+++ b/MoolahTests/Domain/Insights/InsightChartBuildersTests.swift
@@ -180,5 +180,22 @@ struct InsightChartBuildersTests {
     #expect(chart.series.contains { $0.role == .projected })
     let projected = try #require(chart.series.first { $0.role == .projected })
     #expect(projected.points.last?.value == -400)  // budget(1000) - projected(1400)
+    #expect(chart.xAxis == .daily)
+    #expect(chart.highlight?.value == 300)  // current remaining = budget(1000) - spent(700)
+    let baseline = try #require(chart.series.first { $0.role == .baseline })
+    #expect(baseline.points.count == 2)
+    #expect(chart.series.first { $0.role == .primary }?.points.count == 1)
+  }
+
+  @Test
+  func earmarkBurndownIsNilForZeroBudget() {
+    #expect(
+      InsightChartBuilders.earmarkBurndown(
+        budget: 0,
+        current: InsightChart.Point(date: InsightTestSupport.now, value: 0),
+        projectedRemaining: 0,
+        window: DateInterval(
+          start: InsightTestSupport.date(2026, 6, 1), end: InsightTestSupport.date(2026, 6, 30)),
+        reportingCurrency: currency) == nil)
   }
 }

--- a/MoolahTests/Domain/Insights/InsightChartBuildersTests.swift
+++ b/MoolahTests/Domain/Insights/InsightChartBuildersTests.swift
@@ -87,7 +87,7 @@ struct InsightChartBuildersTests {
   }
 
   private func balance(
-    _ day: Int, total: Decimal, forecast: Bool
+    _ day: Int, total: Decimal, forecast: Bool, netWorth: Decimal? = nil
   ) -> DailyBalance {
     let amount = InstrumentAmount(quantity: total, instrument: currency)
     let zero = InstrumentAmount.zero(instrument: currency)
@@ -98,7 +98,7 @@ struct InsightChartBuildersTests {
       availableFunds: amount,
       investments: zero,
       investmentValue: nil,
-      netWorth: amount,
+      netWorth: InstrumentAmount(quantity: netWorth ?? total, instrument: currency),
       bestFit: nil,
       isForecast: forecast)
   }
@@ -108,13 +108,14 @@ struct InsightChartBuildersTests {
     let balances = [
       balance(1, total: 90_000, forecast: false),
       balance(15, total: 95_000, forecast: false),
-      balance(30, total: 101_000, forecast: false),
+      balance(30, total: 91_000, forecast: false, netWorth: 101_000),
     ]
     let chart = try #require(
       InsightChartBuilders.netWorthTrend(balances, reportingCurrency: currency))
     #expect(chart.kind == .line)
     #expect(chart.series.first?.role == .primary)
     #expect(chart.series.first?.points.count == 3)
+    #expect(chart.series.first?.points.last?.value == 101_000)
     #expect(chart.highlight?.value == 101_000)
   }
 

--- a/MoolahTests/Domain/Insights/InsightChartBuildersTests.swift
+++ b/MoolahTests/Domain/Insights/InsightChartBuildersTests.swift
@@ -30,4 +30,27 @@ struct InsightChartBuildersTests {
     #expect(insight.chart == chart)
     #expect(insight.chart?.series.first?.points.count == 2)
   }
+
+  @Test
+  func insightChartDefaultsToNil() {
+    let insight = Insight(
+      id: "y", kind: .savingsRateTrend, title: "t", date: InsightTestSupport.now,
+      framing: .positive, actionability: .review, surprise: 0.5)
+    #expect(insight.chart == nil)
+  }
+
+  @Test
+  func insightChartCarriesCurrencyUnit() {
+    let chart = InsightChart(
+      kind: .bar,
+      unit: .currency(currency),
+      series: [
+        InsightChart.Series(
+          id: "spend", label: "Spend", role: .primary,
+          points: [InsightChart.Point(date: InsightTestSupport.now, value: 12.5)])
+      ],
+      highlight: nil,
+      xAxis: .monthly)
+    #expect(chart.unit == .currency(currency))
+  }
 }

--- a/MoolahTests/Domain/Insights/InsightChartBuildersTests.swift
+++ b/MoolahTests/Domain/Insights/InsightChartBuildersTests.swift
@@ -121,5 +121,12 @@ struct InsightChartBuildersTests {
     #expect(chart.series.contains { $0.role == .primary })
     #expect(chart.series.contains { $0.role == .projected })
     #expect(chart.highlight?.value == 400)
+
+    let actual = try #require(chart.series.first { $0.role == .primary })
+    #expect(actual.points.count == 2)
+    let projected = try #require(chart.series.first { $0.role == .projected })
+    // Bridge: last actual (day 2 = 900) prepended, then day 3 (400), day 4 (700).
+    #expect(projected.points.count == 3)
+    #expect(projected.points.first?.value == 900)
   }
 }

--- a/MoolahTests/Domain/Insights/SpendAndTrendInsightTests.swift
+++ b/MoolahTests/Domain/Insights/SpendAndTrendInsightTests.swift
@@ -161,5 +161,6 @@ struct SpendAndTrendInsightTests {
       insights.first { $0.kind == .categoryTrendRising || $0.kind == .categoryTrendFalling })
     #expect(trend.chart != nil)
     #expect(trend.chart?.kind == .bar)
+    #expect(trend.chart?.highlight?.value == 300)
   }
 }

--- a/MoolahTests/Domain/Insights/SpendAndTrendInsightTests.swift
+++ b/MoolahTests/Domain/Insights/SpendAndTrendInsightTests.swift
@@ -129,4 +129,37 @@ struct SpendAndTrendInsightTests {
     #expect(anomaly.title.contains("June"))
     #expect(!anomaly.title.contains("this month"))
   }
+
+  @Test
+  func categoryAnomalyAttachesHighlightedChart() throws {
+    let dining = Category(name: "Dining")
+    let magnitudes: [Decimal] = [100, 105, 98, 102, 100, 103, 99, 400]
+    let months = ["202511", "202512", "202601", "202602", "202603", "202604", "202605", "202606"]
+    let breakdown = zip(months, magnitudes).map { month, magnitude in
+      InsightTestSupport.breakdownRow(magnitude, categoryId: dining.id, month: month)
+    }
+    let insights = CategoryAnomalyInsight.detect(
+      breakdown: breakdown, categories: Categories(from: [dining]), context: context)
+    let anomaly = try #require(insights.first { $0.kind == .categorySpendingAnomaly })
+    let chart = try #require(anomaly.chart)
+    #expect(chart.kind == .bar)
+    #expect(chart.series.first?.points.count == 8)
+    #expect(chart.highlight?.value == 400)
+  }
+
+  @Test
+  func categoryTrendAttachesChart() throws {
+    let dining = Category(name: "Dining")
+    let magnitudes: [Decimal] = [100, 140, 180, 220, 260, 300]
+    let months = ["202601", "202602", "202603", "202604", "202605", "202606"]
+    let breakdown = zip(months, magnitudes).map { month, magnitude in
+      InsightTestSupport.breakdownRow(magnitude, categoryId: dining.id, month: month)
+    }
+    let insights = CategoryTrendInsight.detect(
+      breakdown: breakdown, categories: Categories(from: [dining]), context: context)
+    let trend = try #require(
+      insights.first { $0.kind == .categoryTrendRising || $0.kind == .categoryTrendFalling })
+    #expect(trend.chart != nil)
+    #expect(trend.chart?.kind == .bar)
+  }
 }

--- a/MoolahUITests_macOS/Helpers/MoolahUITestCase+SeedFixturesText.swift
+++ b/MoolahUITests_macOS/Helpers/MoolahUITestCase+SeedFixturesText.swift
@@ -178,6 +178,9 @@ extension MoolahUITestCase {
         + "\(UITestFixtures.TradeBaseline.checkingAccountId) "
         + "(\(UITestFixtures.TradeBaseline.checkingAccountName)) → has 'View'")
     lines.append("scripted.narration = \(UITestFixtures.InsightsForYou.scriptedNarration)")
+    lines.append(
+      "largeTxn carries a 6-month bar chart (anomaly spike in the final month) "
+        + "→ has an inline chart Button that zooms to the detail sheet")
   }
 
   func appendPendingWebImportFixtures(into lines: inout [String]) {

--- a/MoolahUITests_macOS/Helpers/Screens/ForYouScreen.swift
+++ b/MoolahUITests_macOS/Helpers/Screens/ForYouScreen.swift
@@ -53,6 +53,31 @@ struct ForYouScreen {
     }
   }
 
+  /// Asserts the inline companion-chart Button for the insight row `id` is
+  /// present. Only rows whose insight carries a chart render this control, so
+  /// its presence is the sentinel a subsequent `tapChart(_:)` relies on.
+  func expectChartVisible(_ id: String) {
+    let identifier = UITestIdentifiers.ForYou.chart(id)
+    let chart = app.element(for: identifier)
+    if !chart.waitForExistence(timeout: 5) {
+      Trace.recordFailure("forYou chart button '\(identifier)' did not appear")
+      XCTFail("For You chart button for '\(id)' did not appear within 5s")
+    }
+  }
+
+  /// Asserts the expanded chart in the zoom detail sheet is on screen — the
+  /// post-condition `tapChart(_:)` already waited on, exposed as a standalone
+  /// expectation so a test can name the outcome explicitly.
+  func expectChartDetailVisible() {
+    let detail = app.element(for: UITestIdentifiers.ForYou.chartDetail)
+    if !detail.waitForExistence(timeout: 5) {
+      Trace.recordFailure(
+        "forYou chart detail '\(UITestIdentifiers.ForYou.chartDetail)' "
+          + "did not appear")
+      XCTFail("Insight chart detail sheet did not appear within 5s")
+    }
+  }
+
   // MARK: - Actions
 
   /// Taps the "Show less" control for the insight row `id`, then waits for that
@@ -103,6 +128,31 @@ struct ForYouScreen {
         "forYou row '\(UITestIdentifiers.ForYou.row(id))' still present 5s after tapView "
           + "— navigation may not have fired")
       XCTFail("For You row for '\(id)' did not leave the screen within 5s of tapping View")
+    }
+  }
+
+  /// Taps the inline companion-chart Button for the insight row `id`, then
+  /// waits for the zoom detail sheet's expanded chart to appear. Tapping the
+  /// chart presents `InsightChartDetailSheet`, whose expanded chart carries
+  /// `UITestIdentifiers.ForYou.chartDetail` — its appearance is the
+  /// post-condition this action returns on.
+  func tapChart(_ id: String) {
+    Trace.record(#function, detail: "id=\(id)")
+    let chartIdentifier = UITestIdentifiers.ForYou.chart(id)
+    let chartButton = app.element(for: chartIdentifier)
+    if !chartButton.waitForExistence(timeout: 5) {
+      Trace.recordFailure("forYou chart button '\(chartIdentifier)' did not appear")
+      XCTFail("For You chart button for '\(id)' did not appear within 5s")
+      return
+    }
+    chartButton.click()
+
+    let detail = app.element(for: UITestIdentifiers.ForYou.chartDetail)
+    if !detail.waitForExistence(timeout: 5) {
+      Trace.recordFailure(
+        "forYou chart detail '\(UITestIdentifiers.ForYou.chartDetail)' did not appear "
+          + "5s after tapping the chart — sheet may not have presented")
+      XCTFail("Insight chart detail sheet did not appear within 5s of tapping the chart")
     }
   }
 

--- a/MoolahUITests_macOS/Tests/ForYou/InsightChartUITests.swift
+++ b/MoolahUITests_macOS/Tests/ForYou/InsightChartUITests.swift
@@ -1,0 +1,32 @@
+import XCTest
+
+/// UI coverage for the inline companion chart on a "For You" insight row.
+///
+/// The `.insightsForYouBaseline` seed boots into the Analysis view with three
+/// deterministic fixture insights. Exactly one — `largeTxnId` — carries an
+/// `InsightChart`, so its row renders an inline chart Button
+/// (`UITestIdentifiers.ForYou.chart(_:)`). Tapping it presents
+/// `InsightChartDetailSheet`, whose expanded chart carries
+/// `UITestIdentifiers.ForYou.chartDetail`.
+///
+/// This suite proves the panel wiring on the real event loop: the inline chart
+/// control is present and, when tapped, opens the zoom detail sheet. The
+/// chart-building and detector logic is covered by domain/store tests; this is
+/// the SwiftUI sheet-presentation seam a store test cannot reach.
+@MainActor
+final class InsightChartUITests: MoolahUITestCase {
+  func testTappingInlineChartOpensDetailSheet() {
+    let app = launch(seed: .insightsForYouBaseline)
+    let forYou = app.forYou
+
+    forYou.expectCardVisible()
+    forYou.expectRowVisible(UITestFixtures.InsightsForYou.largeTxnId)
+    // The charted row renders an inline chart Button; the chart-less rows
+    // (priceHike, milestone) do not — so this is a real presence sentinel.
+    forYou.expectChartVisible(UITestFixtures.InsightsForYou.largeTxnId)
+
+    forYou.tapChart(UITestFixtures.InsightsForYou.largeTxnId)
+
+    forYou.expectChartDetailVisible()
+  }
+}

--- a/UITestSupport/UITestIdentifiers+ForYou.swift
+++ b/UITestSupport/UITestIdentifiers+ForYou.swift
@@ -18,5 +18,9 @@ extension UITestIdentifiers {
     /// Identifier on the single headline `Text` view for an insight row (the
     /// resolved AI line, or the detector title fallback).
     public static func headline(_ id: String) -> String { "foryou.headline.\(id)" }
+
+    public static func chart(_ id: String) -> String { "foryou.chart.\(id)" }
+
+    public static let chartDetail = "foryou.chartdetail"
   }
 }

--- a/plans/2026-06-04-insight-companion-graphs-design.md
+++ b/plans/2026-06-04-insight-companion-graphs-design.md
@@ -1,0 +1,197 @@
+# Companion graphs for insights — design
+
+**Date:** 2026-06-04
+**Status:** Approved (design); pending implementation plan
+
+## Problem
+
+The "For You" insights on the Analysis page render as a short vertical list of
+rows (framing icon + AI headline + monetary impact + controls). A detected
+behaviour — "dining out is up 62% this month" — is stated but not *shown*. The
+user can't see the trend that produced the insight without leaving the page.
+
+We want each insight detector, **wherever the data supports it**, to attach a
+companion graph that visualises the detected behaviour. The Analysis page then
+shows each insight as a panel with the headline and a small graph, and the user
+can click the graph to zoom it into a larger view with axes and detail.
+
+## Goals
+
+- A detector can attach a companion chart to the `Insight` it produces, computed
+  as pure data (no charting logic in views), matching the existing discipline
+  where detectors compute and views render.
+- The Analysis "For You" section renders insights as **full-width panels**:
+  headline + impact + controls on the left, a small graph on the right.
+- Clicking an insight's graph opens a **centered sheet** with the enlarged chart
+  (axes, highlighted anomaly), the insight's structured facts, and its deep-link
+  actions.
+- Ship the framework plus charts for the four highest-value insight families;
+  the rest get charts incrementally later.
+
+## Non-goals (this cut)
+
+- Charts for the remaining ~30 insight kinds.
+- Any new aggregation in `InsightInput` (e.g. earmark spend history,
+  per-subscription charge history). The first cut uses only data already present
+  in `InsightInput`.
+- Changes to insight ranking, AI headline narration, fatigue/"show less", or
+  dismissal behaviour.
+
+## Decisions (from brainstorming)
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Scope | Framework + high-value subset | Proves the pipeline end-to-end without a 43-way slog. |
+| Chart representation | Generic `InsightChart` value type | Keeps detectors pure/testable, crosses actor boundaries cleanly, matches the "facts are the single source of truth" philosophy. |
+| Panel layout | Full-width rows with side graph (option B) | Closest to today's list; preserves existing controls; gives the graph real estate. |
+| Graph-less insights | Stay as today's compact rows | No empty panels; minimal disruption. |
+| Zoom presentation | Centered sheet/dialog | Self-contained, identical on macOS and iOS, reads as a focused "zoom". |
+| First-cut families | Category spending, Cash-flow forecast, Savings & income, Net worth & earmarks | Clearest charts; data already in `InsightInput`. |
+
+## Architecture
+
+### 1. Data model — `InsightChart`
+
+New file `Domain/Insights/InsightChart.swift`. A `Sendable`/`Hashable` value type
+the detector computes and the view renders.
+
+```swift
+struct InsightChart: Sendable, Hashable {
+  enum Kind: Sendable { case line, bar, area }
+  enum Unit: Sendable { case currency(Instrument), percent, count }
+  enum SeriesRole: Sendable { case primary, projected, baseline }
+  enum XAxisStyle: Sendable { case monthly, daily }
+
+  let kind: Kind
+  let unit: Unit
+  let series: [Series]
+  let highlight: Point?        // anomalous point/period to mark
+  let xAxis: XAxisStyle        // drives tick formatting
+
+  struct Series: Sendable, Hashable, Identifiable {
+    let id: String             // series key (e.g. "actual", "projected", category id)
+    let label: String          // legend label
+    let role: SeriesRole       // .projected → dashed; .baseline → reference line
+    let points: [Point]
+  }
+
+  struct Point: Sendable, Hashable {
+    let date: Date
+    let value: Decimal         // in the chart's stated `unit`; reporting currency for `.currency`
+  }
+}
+```
+
+`Insight` (`Domain/Insights/Insight.swift`) gains:
+
+```swift
+let chart: InsightChart?   // default nil; existing detectors unaffected
+```
+
+added to the struct and to the `init` (defaulted `nil`). Because it is pure data
+it travels with the insight across the off-main-actor → main-actor boundary and
+is unit-testable.
+
+**Sign convention:** point values preserve their natural sign; the renderer never
+`abs()`-es. Spend-over-time series carry positive magnitudes because
+`ExpenseBreakdown.totalExpenses` is already a positive magnitude — the detector,
+not the view, decides the values.
+
+**Currency formatting:** `.currency(Instrument)` carries the reporting instrument
+so the view can format axis ticks and the detail facts without a global currency.
+
+### 2. Chart builders — one pure helper per family
+
+Each builder is a pure function that turns the relevant `InsightInput` arrays
+into an `InsightChart`. All required data already exists in `InsightInput`
+(verified). Builders live alongside their detectors (or in a shared
+`InsightChartBuilders` utility if reuse emerges).
+
+- **Category spending** — `categorySpendingAnomaly`, `categoryTrendRising`,
+  `categoryTrendFalling`. Source: `expenseBreakdown` (per-category per-month),
+  reusing the existing `CategorySpendSeries.build`. Chart: bar or line of the
+  category's last ~12 financial months in reporting currency; `highlight` = the
+  anomalous / latest month.
+- **Cash-flow forecast** — `projectedMonthEndBalance`, `upcomingBillWarning`,
+  `runwayEstimate`. Source: `dailyBalances` (`DailyBalance`). Two series:
+  `.primary` = actual (`!isForecast`), `.projected` = forecast tail
+  (`isForecast`, dashed); `highlight` = the dip / threshold point.
+- **Savings & income** — `savingsRateTrend`, `monthOverMonthDelta`,
+  `incomeStabilityScore`. Source: `monthly` (`MonthlyIncomeExpense`). Either a
+  savings-rate-% line (`unit: .percent`) or income-vs-expense bars; `highlight`
+  = latest month.
+- **Net worth & earmarks**:
+  - `netWorthMilestone` — net-worth line from `dailyBalances.netWorth`, optional
+    `.baseline` series from `DailyBalance.bestFit`.
+  - `earmarkBurndownProjection` — `EarmarkSnapshot` carries **point-in-time
+    totals only, no history**, so this is an honest *projected* burndown: a
+    `.baseline` at the full budget, a `.primary` point at the current actual
+    (`budget − spent`), and a `.projected` (dashed) line to the projected final
+    spend at the window end — reusing the linear extrapolation the detector
+    already computes. It is never presented as real historical data.
+
+### 3. UI — layout B
+
+`Features/Insights/Views/`:
+
+- **`ForYouCard`** renders each item as a full-width **panel**: headline +
+  monetary impact + controls (`View` / `Show less`) on the left, a small graph
+  (~200×72) on the right. An item whose `insight.chart == nil` renders as today's
+  compact row. Ranking, headlines, fatigue, and dismissal are unchanged.
+- **`InsightChartView`** (new) — the generic renderer over `InsightChart`, drawn
+  with Swift Charts. Small/inline mode (no axes, sparkline-style) for the panel;
+  full mode (axes, legend, highlighted anomaly) for the detail sheet. Tapping the
+  inline graph opens the detail sheet.
+- **`InsightChartDetailSheet`** (new) — a centered sheet over the dimmed Analysis
+  page: headline, full `InsightChartView`, the insight's existing `facts` listed,
+  and the insight's deep-link actions (`View transactions` / `Show less`). Reads
+  only data already on the `Insight`; no recompute. Dismiss via close button or
+  click-outside.
+
+The inline graph and the detail chart render the **same `InsightChart` model** at
+different sizes — no second data path.
+
+### 4. Data flow
+
+Unchanged from today except the chart rides along:
+
+```
+InsightInputBuilder.build()  (off-main)
+  → InsightEngine.generate()  → detectors now also call their chart builder,
+                                 attaching InsightChart to the Insight
+  → ScoredInsight ranking
+  → InsightStore headline resolution → ForYouItem (carries the Insight, incl. chart)
+  → ForYouCard panel (inline InsightChartView)
+       → tap graph → InsightChartDetailSheet (full InsightChartView + facts + actions)
+```
+
+Charts are computed eagerly inside the pure detectors during `generate()`
+off-main; the arithmetic is cheap over already-aggregated arrays.
+
+### 5. Error / edge handling
+
+- A family whose data is too sparse to chart (e.g. < 2 points) leaves
+  `chart == nil` → the insight falls back to a compact row. No empty graphs.
+- The detail sheet tolerates a single-point or projection-only chart (draws the
+  point + projection without a misleading historical line).
+- Reporting-currency conversion failures are already handled upstream in
+  `InsightInput`; the builders consume only pre-converted values.
+
+## Testing
+
+- **Builder unit tests** (per family): feed known `InsightInput` slices, assert
+  the produced `InsightChart` — series count/roles, point values, `highlight`,
+  `unit`. Pure and fast, no simulator.
+- **Detector tests**: extend existing detector tests for the four families to
+  assert `chart != nil` and that `highlight` matches the detected anomaly/period.
+- **UI test** (`MoolahUITests_macOS`): one flow — an insight panel shows a graph,
+  tapping it opens the detail sheet (gated by an `.accessibilityIdentifier` on
+  the inline graph and the sheet).
+- Follows `guides/TEST_GUIDE.md`, `guides/UI_TEST_GUIDE.md`, and the thin-view
+  discipline (all chart-shaping logic in builders, none in views).
+
+## Rollout
+
+Single feature branch / PR for the framework + four families. Remaining insight
+kinds get charts in follow-up PRs, reusing `InsightChart` and `InsightChartView`
+with no model changes expected.

--- a/plans/2026-06-04-insight-companion-graphs-design.md
+++ b/plans/2026-06-04-insight-companion-graphs-design.md
@@ -77,7 +77,11 @@ struct InsightChart: Sendable, Hashable {
 
   struct Point: Sendable, Hashable {
     let date: Date
-    let value: Decimal         // in the chart's stated `unit`; reporting currency for `.currency`
+    let value: Double          // in the chart's stated `unit`; reporting-currency amount for
+                               // `.currency`, a 0...1 fraction for `.percent`, a tally for `.count`.
+                               // `Double` matches the Swift Charts mark y-value idiom; currency
+                               // labels reconstruct `InstrumentAmount(quantity: Decimal(value), …)`
+                               // exactly as `NetWorthGraphCard` does.
   }
 }
 ```

--- a/plans/2026-06-04-insight-companion-graphs-implementation.md
+++ b/plans/2026-06-04-insight-companion-graphs-implementation.md
@@ -1,0 +1,1666 @@
+# Companion Graphs for Insights — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give each high-value insight detector a companion graph, render "For You" insights as full-width panels with a small side graph, and let the user click the graph to open a centered detail sheet with the enlarged chart, the insight's facts, and its actions.
+
+**Architecture:** A new `Sendable`/`Hashable` `InsightChart` value type is computed by the pure detectors (off the main actor, alongside the `Insight`) and rendered by a single generic `InsightChartView` at two sizes. Detectors call small pure chart builders in `InsightChartBuilders`; the chart rides on `Insight.chart` through the existing `ScoredInsight` → `ForYouItem` pipeline with no new store plumbing. `ForYouCard` gains the panel layout and a `.sheet` that presents `InsightChartDetailSheet`.
+
+**Tech Stack:** Swift 6, SwiftUI, Swift Charts, Swift Testing (`@Test`/`#expect`/`#require`), XCUITest (macOS), `just` build/test/format targets, `xcodegen`.
+
+---
+
+## Conventions for every task
+
+- **Worktree:** all work happens in the worktree at
+  `/Users/aj/Documents/code/moolah-project/moolah-native/.claude/worktrees/insight-companion-graphs`.
+  This plan refers to it as `$WT`. Run every build/test/format command with
+  `just -d "$WT" --justfile "$WT/justfile" <target>` (never `cd && just`).
+- **New `.swift` files must be added to `project.yml` membership only if not
+  auto-globbed.** This project globs sources by directory, so files created under
+  existing globbed directories (`Domain/Insights/`, `Features/Insights/Views/`,
+  `MoolahTests/Domain/Insights/`, `MoolahUITests_macOS/`, `UITestSupport/`) are
+  picked up automatically. After creating any new file, run
+  `just -d "$WT" --justfile "$WT/justfile" generate` once before building so
+  Xcode sees it.
+- **Capture test output:** `mkdir -p "$WT/.agent-tmp"` then pipe to
+  `"$WT/.agent-tmp/<name>.txt"`; delete the temp file when done.
+- **Every task ends green:** the task is not complete until `build-mac`,
+  the named tests, AND `format-check` all pass. `format-check` runs
+  `swiftlint lint --strict` — do not introduce a baseline or a
+  `// swiftlint:disable`; fix the code instead.
+- **TDD:** write the failing test first, watch it fail, implement, watch it pass,
+  commit. Commit messages end with:
+  `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
+- **Sign convention:** never `abs()` away a sign in production code. Chart point
+  values are plain magnitudes ONLY where the source aggregate is already a
+  positive magnitude (`ExpenseBreakdown.totalExpenses`, `EarmarkSnapshot.spent`);
+  everywhere else carry the natural signed value.
+
+---
+
+## File Structure
+
+**Create:**
+- `Domain/Insights/InsightChart.swift` — the `InsightChart` value type (Task 1).
+- `Domain/Insights/InsightChartBuilders.swift` — pure builders that turn detector data into `InsightChart` (Tasks 2, 4, 5, 6).
+- `Features/Insights/Views/InsightChartView.swift` — generic Swift Charts renderer, inline + expanded (Task 8).
+- `Features/Insights/Views/InsightChartDetailSheet.swift` — the zoom sheet (Task 9).
+- `MoolahTests/Domain/Insights/InsightChartBuildersTests.swift` — builder unit tests (Tasks 2, 4, 5, 6).
+- `MoolahUITests_macOS/InsightChartUITests.swift` — panel→sheet UI test (Task 11).
+
+**Modify:**
+- `Domain/Insights/Insight.swift` — add `chart` property + init param (Task 1).
+- `Domain/Insights/Detectors/CategoryAnomalyInsight.swift` — attach chart (Task 3).
+- `Domain/Insights/Detectors/CategoryTrendInsight.swift` — attach chart (Task 3).
+- `Domain/Insights/Detectors/CashFlowForecastInsights.swift` — attach chart (Task 4).
+- `Domain/Insights/Detectors/NetWorthInsights.swift` — attach chart (Task 5).
+- `Domain/Insights/Detectors/SavingsRateInsight.swift` — refactor to dated points + attach chart (Task 6).
+- `Domain/Insights/Detectors/EarmarkBudgetInsights.swift` — attach chart (Task 7).
+- `Features/Insights/Views/ForYouCard.swift` — panel layout + inline chart + zoom (Task 10).
+- `UITestSupport/UITestIdentifiers+ForYou.swift` — chart + sheet identifiers (Task 10).
+- `MoolahTests/Domain/Insights/SpendAndTrendInsightTests.swift` — assert charts on category insights (Task 3).
+- `MoolahTests/Domain/Insights/CashFlowForecastInsightsTests.swift` — assert charts (Tasks 4, 6). *(If a savings-rate test lives elsewhere, add the assertion next to the existing one — confirm by grep.)*
+
+---
+
+## Task 1: `InsightChart` value type + `Insight.chart`
+
+**Files:**
+- Create: `Domain/Insights/InsightChart.swift`
+- Modify: `Domain/Insights/Insight.swift:19-67`
+- Test: `MoolahTests/Domain/Insights/InsightChartBuildersTests.swift`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `MoolahTests/Domain/Insights/InsightChartBuildersTests.swift`:
+
+```swift
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("Insight chart builders")
+struct InsightChartBuildersTests {
+  private let currency = InsightTestSupport.currency
+
+  @Test
+  func insightCarriesAnOptionalChart() {
+    let chart = InsightChart(
+      kind: .line,
+      unit: .percent,
+      series: [
+        InsightChart.Series(
+          id: "rate", label: "Savings rate", role: .primary,
+          points: [
+            InsightChart.Point(date: InsightTestSupport.date(2026, 1, 1), value: 0.1),
+            InsightChart.Point(date: InsightTestSupport.date(2026, 2, 1), value: 0.2),
+          ])
+      ],
+      highlight: InsightChart.Point(date: InsightTestSupport.date(2026, 2, 1), value: 0.2),
+      xAxis: .monthly)
+
+    let insight = Insight(
+      id: "x", kind: .savingsRateTrend, title: "t", date: InsightTestSupport.now,
+      framing: .positive, actionability: .review, surprise: 0.5, chart: chart)
+
+    #expect(insight.chart == chart)
+    #expect(insight.chart?.series.first?.points.count == 2)
+  }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `just -d "$WT" --justfile "$WT/justfile" test-mac InsightChartBuildersTests 2>&1 | tee "$WT/.agent-tmp/t1.txt"`
+Expected: FAIL — `cannot find 'InsightChart' in scope` and extra argument `chart:`.
+
+- [ ] **Step 3: Create the `InsightChart` type**
+
+Create `Domain/Insights/InsightChart.swift`:
+
+```swift
+import Foundation
+
+/// A companion graph a detector attaches to an `Insight` to visualise the
+/// behaviour it detected. Pure data: the detector computes it (off the main
+/// actor, alongside the `Insight`) and the view renders it — no charting
+/// logic lives in views, mirroring how `InsightFact` is the single source of
+/// truth for any rendered number.
+struct InsightChart: Sendable, Hashable {
+  /// How the primary series is drawn.
+  enum Kind: Sendable, Hashable {
+    case line
+    case bar
+    case area
+  }
+
+  /// The unit of the y values, driving axis/label formatting. `currency`
+  /// carries the reporting instrument so the view can format without a
+  /// global currency.
+  enum Unit: Sendable, Hashable {
+    case currency(Instrument)
+    case percent
+    case count
+  }
+
+  /// The role a series plays, driving its visual treatment.
+  enum SeriesRole: Sendable, Hashable {
+    /// The actual measured series (solid, tinted).
+    case primary
+    /// A forward projection (dashed, lighter).
+    case projected
+    /// A reference line such as a budget or best-fit (grey, dashed).
+    case baseline
+  }
+
+  /// X-axis tick granularity.
+  enum XAxisStyle: Sendable, Hashable {
+    case monthly
+    case daily
+  }
+
+  /// A single (date, value) sample. `value` is in the chart's `unit`
+  /// (reporting-currency amount, a 0...1 fraction for `percent`, or a count).
+  struct Point: Sendable, Hashable {
+    let date: Date
+    let value: Double
+  }
+
+  struct Series: Sendable, Hashable, Identifiable {
+    let id: String
+    let label: String
+    let role: SeriesRole
+    let points: [Point]
+  }
+
+  let kind: Kind
+  let unit: Unit
+  let series: [Series]
+  /// The point/period to mark (the anomaly, trough, or latest reading).
+  let highlight: Point?
+  let xAxis: XAxisStyle
+}
+```
+
+- [ ] **Step 4: Add `chart` to `Insight`**
+
+In `Domain/Insights/Insight.swift`, add the stored property after `references` (around line 41) and a defaulted init parameter + assignment. The property:
+
+```swift
+  /// Deep-link handles for the UI.
+  let references: InsightReferences
+
+  /// An optional companion graph visualising the detected behaviour. `nil`
+  /// when the detector has no chart for this kind or the data is too sparse;
+  /// such insights fall back to a graph-less row.
+  let chart: InsightChart?
+```
+
+Add to the `init` signature the new last parameter and assignment:
+
+```swift
+    facts: [InsightFact] = [],
+    references: InsightReferences = InsightReferences(),
+    chart: InsightChart? = nil
+  ) {
+    ...
+    self.references = references
+    self.chart = chart
+  }
+```
+
+- [ ] **Step 5: Generate, then run the test to verify it passes**
+
+Run:
+```
+just -d "$WT" --justfile "$WT/justfile" generate
+just -d "$WT" --justfile "$WT/justfile" test-mac InsightChartBuildersTests 2>&1 | tee "$WT/.agent-tmp/t1.txt"
+```
+Expected: PASS (`insightCarriesAnOptionalChart`). Then
+`just -d "$WT" --justfile "$WT/justfile" format-check` — expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C "$WT" add Domain/Insights/InsightChart.swift Domain/Insights/Insight.swift MoolahTests/Domain/Insights/InsightChartBuildersTests.swift
+git -C "$WT" commit -m "Add InsightChart value type and Insight.chart
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+rm -f "$WT/.agent-tmp/t1.txt"
+```
+
+---
+
+## Task 2: Category-spend chart builder
+
+**Files:**
+- Create: `Domain/Insights/InsightChartBuilders.swift`
+- Test: `MoolahTests/Domain/Insights/InsightChartBuildersTests.swift`
+
+The category builder takes the per-category `[MonthlySpendPoint]` that
+`CategorySpendSeries.build` already produces (positive magnitudes in reporting
+currency) and the financial-month string to highlight.
+
+- [ ] **Step 1: Write the failing test** (add to `InsightChartBuildersTests`)
+
+```swift
+  @Test
+  func categorySpendChartHighlightsTheGivenMonth() throws {
+    let points = [
+      MonthlySpendPoint(month: "202604", date: InsightTestSupport.date(2026, 4, 1), magnitude: 100),
+      MonthlySpendPoint(month: "202605", date: InsightTestSupport.date(2026, 5, 1), magnitude: 110),
+      MonthlySpendPoint(month: "202606", date: InsightTestSupport.date(2026, 6, 1), magnitude: 400),
+    ]
+    let chart = try #require(
+      InsightChartBuilders.categorySpend(
+        points: points, reportingCurrency: currency, highlightMonth: "202606"))
+
+    #expect(chart.kind == .bar)
+    #expect(chart.unit == .currency(currency))
+    #expect(chart.xAxis == .monthly)
+    #expect(chart.series.count == 1)
+    #expect(chart.series.first?.points.count == 3)
+    #expect(chart.highlight?.value == 400)
+  }
+
+  @Test
+  func categorySpendChartIsNilBelowTwoPoints() {
+    let points = [
+      MonthlySpendPoint(month: "202606", date: InsightTestSupport.date(2026, 6, 1), magnitude: 400)
+    ]
+    #expect(
+      InsightChartBuilders.categorySpend(
+        points: points, reportingCurrency: currency, highlightMonth: "202606") == nil)
+  }
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `just -d "$WT" --justfile "$WT/justfile" test-mac InsightChartBuildersTests 2>&1 | tee "$WT/.agent-tmp/t2.txt"`
+Expected: FAIL — `cannot find 'InsightChartBuilders' in scope`.
+
+- [ ] **Step 3: Create the builder**
+
+Create `Domain/Insights/InsightChartBuilders.swift`:
+
+```swift
+import Foundation
+
+/// Pure functions that turn detector-side aggregates into an `InsightChart`.
+/// Each returns `nil` when the data is too sparse to chart meaningfully (fewer
+/// than two points), so the insight falls back to a graph-less row.
+enum InsightChartBuilders {
+  /// Minimum points before a series is worth drawing.
+  private static let minimumPoints = 2
+
+  /// A category's monthly spend (positive magnitudes), as a bar chart with the
+  /// anomalous / latest financial month highlighted.
+  static func categorySpend(
+    points: [MonthlySpendPoint],
+    reportingCurrency: Instrument,
+    highlightMonth: String
+  ) -> InsightChart? {
+    guard points.count >= minimumPoints else { return nil }
+    let ordered = points.sorted { $0.date < $1.date }
+    let chartPoints = ordered.map { InsightChart.Point(date: $0.date, value: $0.magnitude) }
+    let highlight = ordered.first { $0.month == highlightMonth }
+      .map { InsightChart.Point(date: $0.date, value: $0.magnitude) }
+    return InsightChart(
+      kind: .bar,
+      unit: .currency(reportingCurrency),
+      series: [
+        InsightChart.Series(
+          id: "spend", label: "Spend", role: .primary, points: chartPoints)
+      ],
+      highlight: highlight,
+      xAxis: .monthly)
+  }
+}
+```
+
+- [ ] **Step 4: Generate + run to verify it passes**
+
+Run:
+```
+just -d "$WT" --justfile "$WT/justfile" generate
+just -d "$WT" --justfile "$WT/justfile" test-mac InsightChartBuildersTests 2>&1 | tee "$WT/.agent-tmp/t2.txt"
+```
+Expected: PASS (3 tests). Then `format-check` — clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C "$WT" add Domain/Insights/InsightChartBuilders.swift MoolahTests/Domain/Insights/InsightChartBuildersTests.swift
+git -C "$WT" commit -m "Add category-spend insight chart builder
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+rm -f "$WT/.agent-tmp/t2.txt"
+```
+
+---
+
+## Task 3: Wire category anomaly + trend detectors to attach charts
+
+**Files:**
+- Modify: `Domain/Insights/Detectors/CategoryAnomalyInsight.swift:83-102`
+- Modify: `Domain/Insights/Detectors/CategoryTrendInsight.swift:53-96`
+- Test: `MoolahTests/Domain/Insights/SpendAndTrendInsightTests.swift`
+
+Both detectors already build a per-category `[MonthlySpendPoint]` series via
+`CategorySpendSeries.build`. We pass the relevant category's points into the
+builder and attach the result.
+
+- [ ] **Step 1: Write the failing tests** (add to `SpendAndTrendInsightTests`)
+
+```swift
+  @Test
+  func categoryAnomalyAttachesHighlightedChart() throws {
+    let dining = Category(name: "Dining")
+    let magnitudes: [Decimal] = [100, 105, 98, 102, 100, 103, 99, 400]
+    let months = ["202511", "202512", "202601", "202602", "202603", "202604", "202605", "202606"]
+    let breakdown = zip(months, magnitudes).map { month, magnitude in
+      InsightTestSupport.breakdownRow(magnitude, categoryId: dining.id, month: month)
+    }
+    let insights = CategoryAnomalyInsight.detect(
+      breakdown: breakdown, categories: Categories(from: [dining]), context: context)
+    let anomaly = try #require(insights.first { $0.kind == .categorySpendingAnomaly })
+    let chart = try #require(anomaly.chart)
+    #expect(chart.kind == .bar)
+    #expect(chart.series.first?.points.count == 8)
+    #expect(chart.highlight?.value == 400)
+  }
+
+  @Test
+  func categoryTrendAttachesChart() throws {
+    let dining = Category(name: "Dining")
+    let magnitudes: [Decimal] = [100, 140, 180, 220, 260, 300]
+    let months = ["202601", "202602", "202603", "202604", "202605", "202606"]
+    let breakdown = zip(months, magnitudes).map { month, magnitude in
+      InsightTestSupport.breakdownRow(magnitude, categoryId: dining.id, month: month)
+    }
+    let insights = CategoryTrendInsight.detect(
+      breakdown: breakdown, categories: Categories(from: [dining]), context: context)
+    let trend = try #require(
+      insights.first { $0.kind == .categoryTrendRising || $0.kind == .categoryTrendFalling })
+    #expect(trend.chart != nil)
+    #expect(trend.chart?.kind == .bar)
+  }
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `just -d "$WT" --justfile "$WT/justfile" test-mac SpendAndTrendInsightTests 2>&1 | tee "$WT/.agent-tmp/t3.txt"`
+Expected: FAIL — `anomaly.chart` is `nil` (`#require` throws).
+
+- [ ] **Step 3: Attach the chart in `CategoryAnomalyInsight`**
+
+In `CategoryAnomalyInsight.swift`, the per-category evaluation has the category's
+points and `latest` in scope where the `Insight(...)` is built (lines 83-102).
+The category's series is `series[categoryId]` (from the `CategorySpendSeries.build`
+result at the top of `detect`). Add `chart:` as the final argument of the
+`Insight(...)` initialiser:
+
+```swift
+      references: InsightReferences(
+        categoryIds: resolved.map { [$0.id] } ?? [],
+        instrumentIds: [context.reportingCurrency.id]),
+      chart: InsightChartBuilders.categorySpend(
+        points: points, reportingCurrency: context.reportingCurrency,
+        highlightMonth: latest.month))
+```
+
+`points` is the `[MonthlySpendPoint]` for the current category already in scope in
+the evaluation loop (the same array `latest` came from). If the in-scope variable
+has a different name, use it — read lines 28-72 to confirm the local name; it is
+the per-category point array passed to `evaluate`.
+
+- [ ] **Step 4: Attach the chart in `CategoryTrendInsight`**
+
+In `CategoryTrendInsight.swift`, `makeInsight` (lines 53-96) has the category's
+points and `latest` in scope. Add as the final `Insight(...)` argument:
+
+```swift
+      references: InsightReferences(
+        categoryIds: resolved.map { [$0.id] } ?? [],
+        instrumentIds: [context.reportingCurrency.id]),
+      chart: InsightChartBuilders.categorySpend(
+        points: points, reportingCurrency: context.reportingCurrency,
+        highlightMonth: latest.month))
+```
+
+Confirm the per-category point array's local name by reading lines 21-52.
+
+- [ ] **Step 5: Run to verify they pass**
+
+Run:
+```
+just -d "$WT" --justfile "$WT/justfile" build-mac 2>&1 | tee "$WT/.agent-tmp/t3-build.txt"
+just -d "$WT" --justfile "$WT/justfile" test-mac SpendAndTrendInsightTests 2>&1 | tee "$WT/.agent-tmp/t3.txt"
+```
+Expected: build clean (no warnings — `SWIFT_TREAT_WARNINGS_AS_ERRORS`), tests PASS. Then `format-check` — clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C "$WT" add Domain/Insights/Detectors/CategoryAnomalyInsight.swift Domain/Insights/Detectors/CategoryTrendInsight.swift MoolahTests/Domain/Insights/SpendAndTrendInsightTests.swift
+git -C "$WT" commit -m "Attach spend-over-time charts to category insights
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+rm -f "$WT/.agent-tmp/t3.txt" "$WT/.agent-tmp/t3-build.txt"
+```
+
+---
+
+## Task 4: Cash-flow balance-forecast builder + wire the two cash-flow detectors
+
+**Files:**
+- Modify: `Domain/Insights/InsightChartBuilders.swift`
+- Modify: `Domain/Insights/Detectors/CashFlowForecastInsights.swift:52-67, 99-115`
+- Test: `MoolahTests/Domain/Insights/InsightChartBuildersTests.swift`, `MoolahTests/Domain/Insights/CashFlowForecastInsightsTests.swift`
+
+The builder draws the daily-balance series with the actual tail solid
+(`.primary`) and the forecast tail dashed (`.projected`), highlighting a given
+date (the trough or month-end day). It uses `DailyBalance.balance`.
+
+- [ ] **Step 1: Write the failing builder test** (add to `InsightChartBuildersTests`)
+
+Add a local helper at the bottom of the suite (inside the struct):
+
+```swift
+  private func balance(
+    _ day: Int, total: Decimal, forecast: Bool
+  ) -> DailyBalance {
+    let amount = InstrumentAmount(quantity: total, instrument: currency)
+    let zero = InstrumentAmount.zero(instrument: currency)
+    return DailyBalance(
+      date: InsightTestSupport.date(2026, 6, day),
+      balance: amount,
+      earmarked: zero,
+      availableFunds: amount,
+      investments: zero,
+      investmentValue: nil,
+      netWorth: amount,
+      bestFit: nil,
+      isForecast: forecast)
+  }
+```
+
+*(If `DailyBalance` exposes a shorter convenience init, prefer it — read
+`Domain/Models/DailyBalance.swift:37-57`. The full memberwise init above always
+compiles.)*
+
+Then the test:
+
+```swift
+  @Test
+  func balanceForecastSplitsActualAndProjected() throws {
+    let balances = [
+      balance(1, total: 1000, forecast: false),
+      balance(2, total: 900, forecast: false),
+      balance(3, total: 400, forecast: true),
+      balance(4, total: 700, forecast: true),
+    ]
+    let chart = try #require(
+      InsightChartBuilders.balanceForecast(
+        balances, reportingCurrency: currency, highlight: InsightTestSupport.date(2026, 6, 3)))
+
+    #expect(chart.kind == .line)
+    #expect(chart.unit == .currency(currency))
+    #expect(chart.xAxis == .daily)
+    #expect(chart.series.contains { $0.role == .primary })
+    #expect(chart.series.contains { $0.role == .projected })
+    #expect(chart.highlight?.value == 400)
+  }
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `just -d "$WT" --justfile "$WT/justfile" test-mac InsightChartBuildersTests 2>&1 | tee "$WT/.agent-tmp/t4.txt"`
+Expected: FAIL — no `balanceForecast` member.
+
+- [ ] **Step 3: Add the builder** (append inside `enum InsightChartBuilders`)
+
+```swift
+  /// Daily current-funds balance: the actual tail solid, the forecast tail
+  /// dashed, with `highlight` marking the trough or projected month-end day.
+  /// The two tails are joined at the boundary so the projection continues the
+  /// actual line rather than starting from zero.
+  static func balanceForecast(
+    _ balances: [DailyBalance],
+    reportingCurrency: Instrument,
+    highlight: Date?
+  ) -> InsightChart? {
+    let ordered = balances.sorted { $0.date < $1.date }
+    guard ordered.count >= minimumPoints else { return nil }
+
+    let actual = ordered.filter { !$0.isForecast }
+    let forecast = ordered.filter(\.isForecast)
+    var series: [InsightChart.Series] = []
+    if actual.count >= 1 {
+      series.append(
+        InsightChart.Series(
+          id: "actual", label: "Balance", role: .primary,
+          points: actual.map { InsightChart.Point(date: $0.date, value: $0.balance.doubleValue) }))
+    }
+    if !forecast.isEmpty {
+      // Prepend the last actual point so the dashed projection visually
+      // continues from the solid line.
+      let bridge = actual.last.map {
+        [InsightChart.Point(date: $0.date, value: $0.balance.doubleValue)]
+      } ?? []
+      series.append(
+        InsightChart.Series(
+          id: "projected", label: "Projected", role: .projected,
+          points: bridge
+            + forecast.map { InsightChart.Point(date: $0.date, value: $0.balance.doubleValue) }))
+    }
+    guard !series.isEmpty else { return nil }
+
+    let highlightPoint = highlight.flatMap { date in
+      ordered.first { $0.date == date }
+        .map { InsightChart.Point(date: $0.date, value: $0.balance.doubleValue) }
+    }
+    return InsightChart(
+      kind: .line,
+      unit: .currency(reportingCurrency),
+      series: series,
+      highlight: highlightPoint,
+      xAxis: .daily)
+  }
+```
+
+- [ ] **Step 4: Wire `upcomingBillWarning`**
+
+In `CashFlowForecastInsights.swift`, the `Insight(...)` at lines 52-67 has `trough`
+and `dailyBalances` in scope. Add as the final argument:
+
+```swift
+        references: InsightReferences(
+          accountIds: culprit?.accountId.map { [$0] } ?? [],
+          instrumentIds: [context.reportingCurrency.id]),
+        chart: InsightChartBuilders.balanceForecast(
+          dailyBalances, reportingCurrency: context.reportingCurrency, highlight: trough.date))
+```
+
+- [ ] **Step 5: Wire `projectedMonthEnd`**
+
+In the same file, the `Insight(...)` at lines 99-115 has `monthEndDay` and
+`dailyBalances` in scope. Add as the final argument:
+
+```swift
+        references: InsightReferences(instrumentIds: [context.reportingCurrency.id]),
+        chart: InsightChartBuilders.balanceForecast(
+          dailyBalances, reportingCurrency: context.reportingCurrency,
+          highlight: monthEndDay.date))
+```
+
+- [ ] **Step 6: Add a detector-level assertion**
+
+In `MoolahTests/Domain/Insights/CashFlowForecastInsightsTests.swift`, find an
+existing test that produces a `.upcomingBillWarning` or `.projectedMonthEndBalance`
+insight and add, after the `#require` for that insight:
+
+```swift
+    #expect(warning.chart != nil)
+    #expect(warning.chart?.series.contains { $0.role == .projected } == true)
+```
+
+*(Use the existing test's local variable name in place of `warning`. If no such
+test exists, add one mirroring the suite's existing daily-balance fixtures.)*
+
+- [ ] **Step 7: Generate, build, run to verify pass**
+
+Run:
+```
+just -d "$WT" --justfile "$WT/justfile" build-mac 2>&1 | tee "$WT/.agent-tmp/t4-build.txt"
+just -d "$WT" --justfile "$WT/justfile" test-mac InsightChartBuildersTests CashFlowForecastInsightsTests 2>&1 | tee "$WT/.agent-tmp/t4.txt"
+```
+Expected: build clean, tests PASS. Then `format-check` — clean.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git -C "$WT" add Domain/Insights/InsightChartBuilders.swift Domain/Insights/Detectors/CashFlowForecastInsights.swift MoolahTests/Domain/Insights/InsightChartBuildersTests.swift MoolahTests/Domain/Insights/CashFlowForecastInsightsTests.swift
+git -C "$WT" commit -m "Attach balance-forecast charts to cash-flow insights
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+rm -f "$WT/.agent-tmp/t4.txt" "$WT/.agent-tmp/t4-build.txt"
+```
+
+---
+
+## Task 5: Net-worth trend builder + wire `NetWorthInsights`
+
+**Files:**
+- Modify: `Domain/Insights/InsightChartBuilders.swift`
+- Modify: `Domain/Insights/Detectors/NetWorthInsights.swift:26-42`
+- Test: `MoolahTests/Domain/Insights/InsightChartBuildersTests.swift`
+
+Uses `DailyBalance.netWorth` (actual entries only) as a line, plus an optional
+grey `.baseline` from `DailyBalance.bestFit` when present.
+
+- [ ] **Step 1: Write the failing builder test** (add to `InsightChartBuildersTests`)
+
+```swift
+  @Test
+  func netWorthTrendUsesNetWorthValues() throws {
+    let balances = [
+      balance(1, total: 90_000, forecast: false),
+      balance(15, total: 95_000, forecast: false),
+      balance(30, total: 101_000, forecast: false),
+    ]
+    let chart = try #require(
+      InsightChartBuilders.netWorthTrend(balances, reportingCurrency: currency))
+    #expect(chart.kind == .line)
+    #expect(chart.series.first?.role == .primary)
+    #expect(chart.series.first?.points.count == 3)
+    #expect(chart.highlight?.value == 101_000)
+  }
+```
+
+(With the `balance` helper, `netWorth == total`.)
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `just -d "$WT" --justfile "$WT/justfile" test-mac InsightChartBuildersTests 2>&1 | tee "$WT/.agent-tmp/t5.txt"`
+Expected: FAIL — no `netWorthTrend` member.
+
+- [ ] **Step 3: Add the builder** (append inside `enum InsightChartBuilders`)
+
+```swift
+  /// Net worth over time (actual entries only), highlighting the latest
+  /// reading. Adds a grey best-fit baseline when every actual entry carries
+  /// one.
+  static func netWorthTrend(
+    _ balances: [DailyBalance],
+    reportingCurrency: Instrument
+  ) -> InsightChart? {
+    let actual = balances.filter { !$0.isForecast }.sorted { $0.date < $1.date }
+    guard actual.count >= minimumPoints else { return nil }
+
+    var series = [
+      InsightChart.Series(
+        id: "networth", label: "Net worth", role: .primary,
+        points: actual.map { InsightChart.Point(date: $0.date, value: $0.netWorth.doubleValue) })
+    ]
+    let fits = actual.compactMap(\.bestFit)
+    if fits.count == actual.count {
+      series.append(
+        InsightChart.Series(
+          id: "bestfit", label: "Trend", role: .baseline,
+          points: zip(actual, fits).map { balance, fit in
+            InsightChart.Point(date: balance.date, value: fit.doubleValue)
+          }))
+    }
+    let last = actual[actual.count - 1]
+    return InsightChart(
+      kind: .line,
+      unit: .currency(reportingCurrency),
+      series: series,
+      highlight: InsightChart.Point(date: last.date, value: last.netWorth.doubleValue),
+      xAxis: .daily)
+  }
+```
+
+- [ ] **Step 4: Wire `NetWorthInsights`**
+
+In `NetWorthInsights.swift`, `detect` has `dailyBalances` and `latest` in scope.
+Add as the final `Insight(...)` argument (after `references`, lines 26-42):
+
+```swift
+        references: InsightReferences(instrumentIds: [context.reportingCurrency.id]),
+        chart: InsightChartBuilders.netWorthTrend(
+          dailyBalances, reportingCurrency: context.reportingCurrency))
+```
+
+- [ ] **Step 5: Generate, build, run to verify pass**
+
+Run:
+```
+just -d "$WT" --justfile "$WT/justfile" build-mac 2>&1 | tee "$WT/.agent-tmp/t5-build.txt"
+just -d "$WT" --justfile "$WT/justfile" test-mac InsightChartBuildersTests 2>&1 | tee "$WT/.agent-tmp/t5.txt"
+```
+Expected: build clean, tests PASS. Then `format-check` — clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C "$WT" add Domain/Insights/InsightChartBuilders.swift Domain/Insights/Detectors/NetWorthInsights.swift MoolahTests/Domain/Insights/InsightChartBuildersTests.swift
+git -C "$WT" commit -m "Attach net-worth trend chart to net-worth milestone insight
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+rm -f "$WT/.agent-tmp/t5.txt" "$WT/.agent-tmp/t5-build.txt"
+```
+
+---
+
+## Task 6: Savings-rate builder + detector refactor to dated points
+
+**Files:**
+- Modify: `Domain/Insights/InsightChartBuilders.swift`
+- Modify: `Domain/Insights/Detectors/SavingsRateInsight.swift:11-49`
+- Test: `MoolahTests/Domain/Insights/InsightChartBuildersTests.swift`, plus the savings-rate detector test (grep for it — likely in `CashFlowForecastInsightsTests.swift` or `FinanceInsightTests.swift`)
+
+The detector currently throws away dates when it builds `rates: [Double]`. Refactor
+it to build `points: [InsightChart.Point]` (date = `month.end`, value = rate),
+derive `rates` from `points.map(\.value)`, and pass `points` to the builder.
+
+- [ ] **Step 1: Write the failing builder test** (add to `InsightChartBuildersTests`)
+
+```swift
+  @Test
+  func savingsRateChartIsPercentUnit() throws {
+    let points = [
+      InsightChart.Point(date: InsightTestSupport.date(2026, 3, 31), value: 0.10),
+      InsightChart.Point(date: InsightTestSupport.date(2026, 4, 30), value: 0.15),
+      InsightChart.Point(date: InsightTestSupport.date(2026, 5, 31), value: 0.22),
+    ]
+    let chart = try #require(InsightChartBuilders.savingsRate(points: points))
+    #expect(chart.kind == .line)
+    #expect(chart.unit == .percent)
+    #expect(chart.xAxis == .monthly)
+    #expect(chart.highlight?.value == 0.22)
+  }
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `just -d "$WT" --justfile "$WT/justfile" test-mac InsightChartBuildersTests 2>&1 | tee "$WT/.agent-tmp/t6.txt"`
+Expected: FAIL — no `savingsRate` member.
+
+- [ ] **Step 3: Add the builder** (append inside `enum InsightChartBuilders`)
+
+```swift
+  /// Monthly savings rate as a percentage line, highlighting the latest month.
+  static func savingsRate(points: [InsightChart.Point]) -> InsightChart? {
+    guard points.count >= minimumPoints else { return nil }
+    let ordered = points.sorted { $0.date < $1.date }
+    return InsightChart(
+      kind: .line,
+      unit: .percent,
+      series: [
+        InsightChart.Series(id: "rate", label: "Savings rate", role: .primary, points: ordered)
+      ],
+      highlight: ordered.last,
+      xAxis: .monthly)
+  }
+```
+
+- [ ] **Step 4: Refactor `SavingsRateInsight.detect`**
+
+Replace the `rates` computation (lines 11-19) and add the chart. The new body of
+`detect` from the `rates` line through the `Insight` return:
+
+```swift
+    let points: [InsightChart.Point] = complete.compactMap { month in
+      let income = Double(
+        truncating: InsightAggregates.incomeMagnitude(month.totalIncome) as NSDecimalNumber)
+      guard income > 0 else { return nil }
+      let net = Double(truncating: month.totalProfit.quantity as NSDecimalNumber)
+      return InsightChart.Point(date: month.end, value: net / income)
+    }
+    let rates = points.map(\.value)
+    guard rates.count >= minimumMonths, let result = MannKendall.test(rates),
+      result.statistic != 0
+    else { return [] }
+```
+
+Then add the chart as the final `Insight(...)` argument (after `references`):
+
+```swift
+        references: InsightReferences(instrumentIds: [context.reportingCurrency.id]),
+        chart: InsightChartBuilders.savingsRate(points: points))
+```
+
+- [ ] **Step 5: Add a detector-level assertion**
+
+Grep for the savings-rate test:
+`grep -rl "savingsRateTrend\|SavingsRateInsight" "$WT/MoolahTests"`. In the test
+that asserts the climbing/slipping insight, after its `#require`, add:
+
+```swift
+    #expect(trend.chart?.unit == .percent)
+    #expect(trend.chart?.series.first?.points.isEmpty == false)
+```
+
+(Use the existing local variable name in place of `trend`.)
+
+- [ ] **Step 6: Generate, build, run to verify pass**
+
+Run:
+```
+just -d "$WT" --justfile "$WT/justfile" build-mac 2>&1 | tee "$WT/.agent-tmp/t6-build.txt"
+just -d "$WT" --justfile "$WT/justfile" test-mac InsightChartBuildersTests 2>&1 | tee "$WT/.agent-tmp/t6.txt"
+```
+Then run the savings-rate detector test suite by its discovered name. Expected:
+build clean, tests PASS. Then `format-check` — clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git -C "$WT" add Domain/Insights/InsightChartBuilders.swift Domain/Insights/Detectors/SavingsRateInsight.swift MoolahTests/Domain/Insights/
+git -C "$WT" commit -m "Attach savings-rate trend chart; thread dates through detector
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+rm -f "$WT/.agent-tmp/t6.txt" "$WT/.agent-tmp/t6-build.txt"
+```
+
+---
+
+## Task 7: Earmark projected-burndown chart + wire `EarmarkBudgetInsights`
+
+**Files:**
+- Modify: `Domain/Insights/InsightChartBuilders.swift`
+- Modify: `Domain/Insights/Detectors/EarmarkBudgetInsights.swift:14-31, 76-115`
+- Test: `MoolahTests/Domain/Insights/InsightChartBuildersTests.swift` + the earmark detector test (grep)
+
+`EarmarkSnapshot` has no spend history, so this is an honest *projected* burndown
+built from primitives the detector already has: a grey `.baseline` ideal-burndown
+line (budget remaining: full budget at window start → 0 at window end), a
+`.primary` point at the current remaining (`budget − spent`), and a dashed
+`.projected` line from "now" to the projected remaining at window end
+(`budget − projectedSpend`, which can go negative when over budget).
+
+- [ ] **Step 1: Write the failing builder test** (add to `InsightChartBuildersTests`)
+
+```swift
+  @Test
+  func earmarkBurndownProjectsBeyondBudget() throws {
+    let start = InsightTestSupport.date(2026, 6, 1)
+    let now = InsightTestSupport.date(2026, 6, 15)
+    let end = InsightTestSupport.date(2026, 6, 30)
+    let chart = try #require(
+      InsightChartBuilders.earmarkBurndown(
+        budget: 1000, spent: 700, projected: 1400,
+        windowStart: start, now: now, windowEnd: end,
+        reportingCurrency: currency))
+
+    #expect(chart.kind == .line)
+    #expect(chart.unit == .currency(currency))
+    #expect(chart.series.contains { $0.role == .baseline })
+    #expect(chart.series.contains { $0.role == .primary })
+    #expect(chart.series.contains { $0.role == .projected })
+    // budget(1000) - projected(1400) = -400 remaining at window end
+    let projected = try #require(chart.series.first { $0.role == .projected })
+    #expect(projected.points.last?.value == -400)
+  }
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `just -d "$WT" --justfile "$WT/justfile" test-mac InsightChartBuildersTests 2>&1 | tee "$WT/.agent-tmp/t7.txt"`
+Expected: FAIL — no `earmarkBurndown` member.
+
+- [ ] **Step 3: Add the builder** (append inside `enum InsightChartBuilders`)
+
+```swift
+  /// A projected budget burndown (remaining budget over the window). Earmark
+  /// snapshots carry no spend history, so this shows the ideal-burndown
+  /// baseline, the current remaining, and a dashed projection to the window
+  /// end — never faked historical data. `projected` is total projected spend;
+  /// the projected remaining is `budget - projected` and may go negative.
+  static func earmarkBurndown(
+    budget: Double,
+    spent: Double,
+    projected: Double,
+    windowStart: Date,
+    now: Date,
+    windowEnd: Date,
+    reportingCurrency: Instrument
+  ) -> InsightChart? {
+    guard budget > 0, windowStart < windowEnd else { return nil }
+    let currentRemaining = budget - spent
+    let projectedRemaining = budget - projected
+    return InsightChart(
+      kind: .line,
+      unit: .currency(reportingCurrency),
+      series: [
+        InsightChart.Series(
+          id: "ideal", label: "Budget", role: .baseline,
+          points: [
+            InsightChart.Point(date: windowStart, value: budget),
+            InsightChart.Point(date: windowEnd, value: 0),
+          ]),
+        InsightChart.Series(
+          id: "actual", label: "Remaining", role: .primary,
+          points: [InsightChart.Point(date: now, value: currentRemaining)]),
+        InsightChart.Series(
+          id: "projected", label: "Projected", role: .projected,
+          points: [
+            InsightChart.Point(date: now, value: currentRemaining),
+            InsightChart.Point(date: windowEnd, value: projectedRemaining),
+          ]),
+      ],
+      highlight: InsightChart.Point(date: now, value: currentRemaining),
+      xAxis: .daily)
+  }
+```
+
+- [ ] **Step 4: Build the chart in `detect` and pass it to both branches**
+
+`Window` and `Projection` are private to the file, so build the chart inside
+`detect` (where `window` and `projection` are in scope) and thread it through.
+
+In `detect` (lines 14-31), after the `guard let ... projection = ...` and before
+the `if projection.fraction ...`, add:
+
+```swift
+      let chart = InsightChartBuilders.earmarkBurndown(
+        budget: projection.budgetMagnitude,
+        spent: projection.spentMagnitude,
+        projected: projection.projected,
+        windowStart: window.start,
+        now: context.now,
+        windowEnd: window.end,
+        reportingCurrency: context.reportingCurrency)
+```
+
+Then pass `chart: chart` to both calls:
+
+```swift
+      if projection.fraction > 1 + overspendTolerance {
+        insights.append(
+          overspend(earmark, budget: budget, projection: projection, context: context, chart: chart))
+      } else if projection.fraction < 1 - underspendTolerance, projection.elapsedFraction >= 0.5 {
+        insights.append(
+          underspend(earmark, budget: budget, projection: projection, context: context, chart: chart))
+      }
+```
+
+Add the `chart: InsightChart?` parameter to both `overspend` and `underspend`
+signatures and pass it as the final `Insight(...)` argument in each:
+
+```swift
+  private static func overspend(
+    _ earmark: EarmarkSnapshot,
+    budget: InstrumentAmount,
+    projection: Projection,
+    context: InsightContext,
+    chart: InsightChart?
+  ) -> Insight {
+    ...
+      references: InsightReferences(earmarkIds: [earmark.id]),
+      chart: chart)
+  }
+```
+
+…and identically for `underspend` (final arg `chart: chart`).
+
+- [ ] **Step 5: Add a detector-level assertion**
+
+Grep for the earmark detector test:
+`grep -rl "earmarkBurndownProjection\|EarmarkBudgetInsights" "$WT/MoolahTests"`. In
+the over-budget test, after the `#require`, add:
+
+```swift
+    #expect(overBudget.chart?.series.contains { $0.role == .projected } == true)
+```
+
+(Use the existing local variable name in place of `overBudget`.)
+
+- [ ] **Step 6: Generate, build, run to verify pass**
+
+Run:
+```
+just -d "$WT" --justfile "$WT/justfile" build-mac 2>&1 | tee "$WT/.agent-tmp/t7-build.txt"
+just -d "$WT" --justfile "$WT/justfile" test-mac InsightChartBuildersTests 2>&1 | tee "$WT/.agent-tmp/t7.txt"
+```
+Then run the earmark detector suite by its discovered name. Expected: build clean,
+tests PASS. Then `format-check` — clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git -C "$WT" add Domain/Insights/InsightChartBuilders.swift Domain/Insights/Detectors/EarmarkBudgetInsights.swift MoolahTests/Domain/Insights/
+git -C "$WT" commit -m "Attach projected-burndown chart to earmark budget insights
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+rm -f "$WT/.agent-tmp/t7.txt" "$WT/.agent-tmp/t7-build.txt"
+```
+
+---
+
+## Task 8: `InsightChartView` — generic renderer (inline + expanded)
+
+**Files:**
+- Create: `Features/Insights/Views/InsightChartView.swift`
+
+A single view renders any `InsightChart` at two sizes. Inline: a compact
+sparkline, axes hidden, fixed height, non-interactive. Expanded: axes, formatted
+labels, a larger frame. Tint comes from the insight's framing so the graph
+matches the row icon.
+
+This is a view; it is exercised by the Task 11 UI test and a `#Preview`. There is
+no unit test step (SwiftUI views are validated via preview + UI test per the
+project's thin-view discipline).
+
+- [ ] **Step 1: Create the view**
+
+Create `Features/Insights/Views/InsightChartView.swift`:
+
+```swift
+import Charts
+import SwiftUI
+
+/// Renders an `InsightChart` at one of two sizes. The detector computed the
+/// data; this view only draws it (thin-view discipline).
+struct InsightChartView: View {
+  enum Style {
+    case inline
+    case expanded
+  }
+
+  let chart: InsightChart
+  let tint: Color
+  var style: Style = .inline
+
+  var body: some View {
+    if style == .inline {
+      baseChart
+        .chartXAxis(.hidden)
+        .chartYAxis(.hidden)
+        .chartLegend(.hidden)
+        .frame(height: 48)
+        .allowsHitTesting(false)
+    } else {
+      baseChart
+        .chartXAxis { xAxisMarks }
+        .chartYAxis { yAxisMarks }
+        .frame(height: 240)
+    }
+  }
+
+  private var baseChart: some View {
+    Chart {
+      ForEach(chart.series) { series in
+        ForEach(series.points, id: \.date) { point in
+          marks(for: point, in: series)
+        }
+      }
+      if let highlight = chart.highlight {
+        PointMark(
+          x: .value("Date", highlight.date),
+          y: .value("Value", highlight.value)
+        )
+        .foregroundStyle(.red)
+        .symbolSize(style == .inline ? 18 : 60)
+        if style == .expanded {
+          RuleMark(x: .value("Date", highlight.date))
+            .foregroundStyle(.red.opacity(0.25))
+            .lineStyle(StrokeStyle(lineWidth: 1, dash: [3, 3]))
+        }
+      }
+    }
+  }
+
+  @ChartContentBuilder
+  private func marks(
+    for point: InsightChart.Point, in series: InsightChart.Series
+  ) -> some ChartContent {
+    switch chart.kind {
+    case .bar:
+      BarMark(
+        x: .value("Date", point.date),
+        y: .value("Value", point.value)
+      )
+      .foregroundStyle(color(for: series.role).opacity(series.role == .primary ? 1 : 0.5))
+    case .line, .area:
+      LineMark(
+        x: .value("Date", point.date),
+        y: .value("Value", point.value),
+        series: .value("Series", series.id)
+      )
+      .foregroundStyle(color(for: series.role))
+      .lineStyle(strokeStyle(for: series.role))
+      .interpolationMethod(.monotone)
+    }
+  }
+
+  private func color(for role: InsightChart.SeriesRole) -> Color {
+    switch role {
+    case .primary: tint
+    case .projected: tint.opacity(0.5)
+    case .baseline: .gray
+    }
+  }
+
+  private func strokeStyle(for role: InsightChart.SeriesRole) -> StrokeStyle {
+    switch role {
+    case .primary: StrokeStyle(lineWidth: 2)
+    case .projected: StrokeStyle(lineWidth: 1.5, dash: [4, 3])
+    case .baseline: StrokeStyle(lineWidth: 1, dash: [2, 3])
+    }
+  }
+
+  private var instrument: Instrument? {
+    if case .currency(let value) = chart.unit { return value }
+    return nil
+  }
+
+  @AxisContentBuilder
+  private var xAxisMarks: some AxisContent {
+    AxisMarks(values: .automatic(desiredCount: 5)) { _ in
+      AxisGridLine()
+      AxisTick()
+      switch chart.xAxis {
+      case .monthly: AxisValueLabel(format: .dateTime.month(.abbreviated))
+      case .daily: AxisValueLabel(format: .dateTime.month(.abbreviated).day())
+      }
+    }
+  }
+
+  @AxisContentBuilder
+  private var yAxisMarks: some AxisContent {
+    AxisMarks { value in
+      AxisGridLine()
+      AxisValueLabel {
+        if let raw = value.as(Double.self) {
+          Text(formattedY(raw)).monospacedDigit()
+        }
+      }
+    }
+  }
+
+  private func formattedY(_ raw: Double) -> String {
+    switch chart.unit {
+    case .currency(let instrument):
+      return InstrumentAmount(quantity: Decimal(raw), instrument: instrument).formatNoSymbol
+    case .percent:
+      return raw.formatted(.percent.precision(.fractionLength(0)))
+    case .count:
+      return Int(raw.rounded()).formatted()
+    }
+  }
+}
+
+#Preview("Inline") {
+  InsightChartView(
+    chart: InsightChart(
+      kind: .bar,
+      unit: .currency(.AUD),
+      series: [
+        InsightChart.Series(
+          id: "spend", label: "Spend", role: .primary,
+          points: (0..<6).map {
+            InsightChart.Point(
+              date: Date(timeIntervalSince1970: 1_700_000_000 + Double($0) * 2_600_000),
+              value: Double(100 + $0 * 40))
+          })
+      ],
+      highlight: InsightChart.Point(
+        date: Date(timeIntervalSince1970: 1_700_000_000 + 5 * 2_600_000), value: 300),
+      xAxis: .monthly),
+    tint: .orange,
+    style: .inline
+  )
+  .padding()
+  .frame(width: 220)
+}
+
+#Preview("Expanded") {
+  InsightChartView(
+    chart: InsightChart(
+      kind: .line,
+      unit: .percent,
+      series: [
+        InsightChart.Series(
+          id: "rate", label: "Savings rate", role: .primary,
+          points: (0..<6).map {
+            InsightChart.Point(
+              date: Date(timeIntervalSince1970: 1_700_000_000 + Double($0) * 2_600_000),
+              value: 0.1 + Double($0) * 0.02)
+          })
+      ],
+      highlight: nil,
+      xAxis: .monthly),
+    tint: .green,
+    style: .expanded
+  )
+  .padding()
+  .frame(width: 480)
+}
+```
+
+- [ ] **Step 2: Generate + build to verify it compiles**
+
+Run:
+```
+just -d "$WT" --justfile "$WT/justfile" generate
+just -d "$WT" --justfile "$WT/justfile" build-mac 2>&1 | tee "$WT/.agent-tmp/t8-build.txt"
+```
+Expected: build clean (no warnings). If `Instrument.AUD` is unavailable in the
+previews' module scope, it is defined at `Domain/Models/Instrument.swift:91` — it
+is in-module, so it resolves. Then `format-check` — clean.
+
+- [ ] **Step 3: Optionally render the preview**
+
+Per `reviewing-ui-with-preview`, render `InsightChartView` "Inline" and "Expanded"
+with `mcp__xcode__RenderPreview` to eyeball the sparkline and axes. Not required to
+pass, but do it before the UI wiring so the visual is known-good.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C "$WT" add Features/Insights/Views/InsightChartView.swift
+git -C "$WT" commit -m "Add generic InsightChartView (inline + expanded)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+rm -f "$WT/.agent-tmp/t8-build.txt"
+```
+
+---
+
+## Task 9: `InsightChartDetailSheet` — the zoom sheet
+
+**Files:**
+- Create: `Features/Insights/Views/InsightChartDetailSheet.swift`
+
+A centered sheet: framing icon + headline + close, the expanded chart, the
+insight's `facts`, and its actions (`View` when there's a nav target, `Show less`).
+It reads only data already on the `Insight`.
+
+- [ ] **Step 1: Create the sheet**
+
+Create `Features/Insights/Views/InsightChartDetailSheet.swift`:
+
+```swift
+import SwiftUI
+
+/// The zoomed companion-graph view, presented as a centered sheet when the
+/// user taps an insight's inline chart. Reads only what the `Insight` already
+/// carries — no recompute.
+struct InsightChartDetailSheet: View {
+  let insight: Insight
+  let headline: String
+  let onNavigate: (SidebarSelection) -> Void
+  let onDismiss: () -> Void
+
+  @Environment(\.dismiss) private var dismiss
+
+  private var target: SidebarSelection? {
+    InsightNavigationTarget.sidebarSelection(for: insight.references)
+  }
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 16) {
+      header
+      if let chart = insight.chart {
+        InsightChartView(chart: chart, tint: framingColor, style: .expanded)
+          .accessibilityIdentifier(UITestIdentifiers.ForYou.chartDetail)
+      }
+      if !insight.facts.isEmpty {
+        factsList
+      }
+      Spacer(minLength: 0)
+      actions
+    }
+    .padding(24)
+    .frame(minWidth: 420, minHeight: 420)
+  }
+
+  private var header: some View {
+    HStack(alignment: .firstTextBaseline, spacing: 8) {
+      Image(systemName: framingIcon)
+        .foregroundStyle(framingColor)
+        .accessibilityHidden(true)
+      Text(headline)
+        .font(.headline)
+      Spacer()
+      Button {
+        dismiss()
+      } label: {
+        Image(systemName: "xmark.circle.fill")
+          .foregroundStyle(.secondary)
+      }
+      .buttonStyle(.plain)
+      .accessibilityLabel("Close")
+    }
+  }
+
+  private var factsList: some View {
+    VStack(spacing: 0) {
+      ForEach(insight.facts) { fact in
+        HStack {
+          Text(fact.label).foregroundStyle(.secondary)
+          Spacer()
+          Text(fact.value).fontWeight(.semibold).monospacedDigit()
+        }
+        .font(.subheadline)
+        .padding(.vertical, 8)
+        Divider()
+      }
+    }
+  }
+
+  @ViewBuilder private var actions: some View {
+    HStack(spacing: 12) {
+      Button(role: .destructive) {
+        onDismiss()
+        dismiss()
+      } label: {
+        Label("Show less", systemImage: "hand.thumbsdown")
+      }
+      Spacer()
+      if let target {
+        Button {
+          onNavigate(target)
+          dismiss()
+        } label: {
+          Label("View", systemImage: "arrow.forward")
+        }
+        .keyboardShortcut(.defaultAction)
+      }
+    }
+  }
+
+  private var framingColor: Color {
+    switch insight.framing {
+    case .positive: .green
+    case .neutral: .secondary
+    case .negative: .red
+    }
+  }
+
+  private var framingIcon: String {
+    switch insight.framing {
+    case .positive: "checkmark.circle.fill"
+    case .neutral: "info.circle.fill"
+    case .negative: "exclamationmark.triangle.fill"
+    }
+  }
+}
+```
+
+*(`framingColor`/`framingIcon` mirror the existing `InsightRow` switch at
+`ForYouCard.swift:155-177`. If those mappings differ there, match this sheet to
+the row so the icon/colour are consistent.)*
+
+- [ ] **Step 2: Add the `chartDetail` identifier** (so this file compiles)
+
+This depends on `UITestIdentifiers.ForYou.chartDetail`, added in Task 10 Step 1.
+**Do Task 10 Step 1 now** (add the two identifiers), then return here.
+
+- [ ] **Step 3: Generate + build to verify it compiles**
+
+Run:
+```
+just -d "$WT" --justfile "$WT/justfile" generate
+just -d "$WT" --justfile "$WT/justfile" build-mac 2>&1 | tee "$WT/.agent-tmp/t9-build.txt"
+```
+Expected: build clean. Then `format-check` — clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C "$WT" add Features/Insights/Views/InsightChartDetailSheet.swift UITestSupport/UITestIdentifiers+ForYou.swift
+git -C "$WT" commit -m "Add InsightChartDetailSheet zoom view
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+rm -f "$WT/.agent-tmp/t9-build.txt"
+```
+
+---
+
+## Task 10: Panel layout in `ForYouCard` + inline chart + zoom wiring
+
+**Files:**
+- Modify: `UITestSupport/UITestIdentifiers+ForYou.swift:3-22`
+- Modify: `Features/Insights/Views/ForYouCard.swift:38-178`
+
+Convert `InsightRow` to the panel layout (option B): headline + impact + controls
+on the left, the inline chart on the right when present. Tapping the chart opens
+the detail sheet. Insights with `chart == nil` render exactly as today.
+
+- [ ] **Step 1: Add chart + sheet identifiers**
+
+In `UITestSupport/UITestIdentifiers+ForYou.swift`, add to `enum ForYou`:
+
+```swift
+    public static func chart(_ id: String) -> String { "foryou.chart.\(id)" }
+    public static let chartDetail = "foryou.chartdetail"
+```
+
+- [ ] **Step 2: Add the inline chart + zoom to `InsightRow`**
+
+In `ForYouCard.swift`, `InsightRow` already exposes `private var insight: Insight`.
+Add zoom state and a trailing chart to the row body. The existing body reflows an
+`HStack`/`VStack` by accessibility size (lines 50-81); add the inline chart as a
+trailing element of the horizontal layout (only at standard sizes — at
+accessibility sizes it stacks below). Add this `@State` to `InsightRow`:
+
+```swift
+  @State private var isZoomed = false
+```
+
+Add the inline chart view, shown only when the insight has a chart. Insert it as
+the trailing item in the row's primary `HStack` (after the headline/impact/controls
+`VStack`, before the row closes), wrapped in a `Button` so the tap target is
+accessible:
+
+```swift
+      if let chart = insight.chart {
+        Button {
+          isZoomed = true
+        } label: {
+          InsightChartView(chart: chart, tint: framingColor, style: .inline)
+            .frame(width: 200)
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier(UITestIdentifiers.ForYou.chart(insight.id))
+        .accessibilityLabel("Show \(item.headline) chart")
+      }
+```
+
+Attach the sheet to the row's outermost view (the same view that carries
+`.accessibilityIdentifier(UITestIdentifiers.ForYou.row(insight.id))` near line 79):
+
+```swift
+      .sheet(isPresented: $isZoomed) {
+        InsightChartDetailSheet(
+          insight: insight,
+          headline: item.headline,
+          onNavigate: onNavigate,
+          onDismiss: onDismiss)
+      }
+```
+
+`framingColor` is the existing private computed property on `InsightRow`
+(`ForYouCard.swift:155`); reuse it. Do **not** change the graph-less path — when
+`insight.chart == nil` the row renders exactly as before.
+
+- [ ] **Step 3: Generate + build**
+
+Run:
+```
+just -d "$WT" --justfile "$WT/justfile" generate
+just -d "$WT" --justfile "$WT/justfile" build-mac 2>&1 | tee "$WT/.agent-tmp/t10-build.txt"
+```
+Expected: build clean (no warnings). Then `format-check` — clean.
+
+- [ ] **Step 4: Render the preview to confirm the panel layout**
+
+Per `reviewing-ui-with-preview`, render the existing `ForYouCard` `#Preview` (if
+one exists; otherwise add a `#Preview` that builds a `ForYouCard` with one charted
+and one graph-less `ForYouItem`) via `mcp__xcode__RenderPreview`. Confirm the side
+graph appears and graph-less rows are unchanged.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C "$WT" add Features/Insights/Views/ForYouCard.swift UITestSupport/UITestIdentifiers+ForYou.swift
+git -C "$WT" commit -m "Render For You insights as panels with a side graph and zoom
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+rm -f "$WT/.agent-tmp/t10-build.txt"
+```
+
+---
+
+## Task 11: UI test — panel graph opens the detail sheet
+
+**Files:**
+- Create: `MoolahUITests_macOS/InsightChartUITests.swift`
+- Possibly modify: a UI-test seed if no seeded insight produces a chart (read `UITestSupport/UITestSeeds.swift`)
+
+Follow `guides/UI_TEST_GUIDE.md` and the existing For You driver. Tests import only
+`XCTest`; element resolution goes through the screen driver; wait on post-conditions
+(no sleeps). **Before writing, read an existing `MoolahUITests_macOS` test and its
+screen driver to match the driver pattern** (the For You card already has
+identifiers, so there is likely a driver to extend).
+
+- [ ] **Step 1: Confirm a seed produces a charted insight**
+
+Read `UITestSupport/UITestSeeds.swift` and the For You UI test seed. The detail
+sheet only opens for an insight whose `chart != nil`. Identify (or add) a seed whose
+data triggers one of the wired detectors (e.g. a category with a clear spending
+spike across ≥6 months → `categorySpendingAnomaly`, which now carries a chart).
+If an existing "For You" seed already yields a charted insight, reuse it.
+
+- [ ] **Step 2: Write the failing UI test**
+
+Create `MoolahUITests_macOS/InsightChartUITests.swift`, mirroring the existing For
+You UI test's launch + driver usage. Skeleton (adapt identifiers/driver calls to
+the real driver API):
+
+```swift
+import XCTest
+
+final class InsightChartUITests: XCTestCase {
+  func testTappingInsightChartOpensDetailSheet() throws {
+    let app = XCUIApplication()
+    app.launchArguments += ["-uiTestSeed", "<the charted-insight seed name>"]
+    app.launch()
+
+    // Navigate to Analysis where the For You card renders.
+    // (Use the existing driver/navigation helper — match the For You UI test.)
+
+    // The inline chart button carries UITestIdentifiers.ForYou.chart(<id>).
+    let chart = app.buttons.matching(
+      NSPredicate(format: "identifier BEGINSWITH %@", "foryou.chart.")).firstMatch
+    XCTAssertTrue(chart.waitForExistence(timeout: 10))
+    chart.tap()
+
+    // The detail sheet's expanded chart carries chartDetail.
+    let detail = app.otherElements["foryou.chartdetail"]
+      .firstMatch
+    XCTAssertTrue(detail.waitForExistence(timeout: 10))
+  }
+}
+```
+
+Note: a SwiftUI `Chart` may surface as a different element type; resolve via the
+identifier with `.descendants(matching: .any)` if `otherElements` does not match —
+confirm by reading the on-failure UI tree artifact per `guides/UI_TEST_GUIDE.md`.
+
+- [ ] **Step 3: Run to verify it fails (then passes)**
+
+First, ensure no stale runners (per the macOS test-runner hang remedy):
+`pkill -f Moolah` for stale test-host/xctest processes if `just test-mac` hangs
+"before establishing connection".
+
+Run: `just -d "$WT" --justfile "$WT/justfile" test-mac InsightChartUITests 2>&1 | tee "$WT/.agent-tmp/t11.txt"`
+First run (before the seed/identifiers are correct): expected FAIL with a clear
+"element not found"; inspect the captured UI tree. Iterate identifiers/seed until
+it PASSES. If the local UI host is wedged and cannot run, gate on the PR's CI "UI
+Test" job instead (per project guidance) and note it on the PR.
+
+- [ ] **Step 4: `format-check`, then commit**
+
+Run `just -d "$WT" --justfile "$WT/justfile" format-check` — clean.
+
+```bash
+git -C "$WT" add MoolahUITests_macOS/InsightChartUITests.swift UITestSupport/
+git -C "$WT" commit -m "UI test: insight chart panel opens the detail sheet
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+rm -f "$WT/.agent-tmp/t11.txt"
+```
+
+---
+
+## Task 12: Full-suite green + review + PR
+
+**Files:** none (verification + review)
+
+- [ ] **Step 1: Run the full macOS test suite**
+
+Run: `just -d "$WT" --justfile "$WT/justfile" test-mac 2>&1 | tee "$WT/.agent-tmp/full.txt"`
+Then `grep -i 'failed\|error:' "$WT/.agent-tmp/full.txt"`. Expected: no insight or
+chart failures. (The repo's known date-flaky tests were fixed in PR #1051; a clean
+run is expected.)
+
+- [ ] **Step 2: Run iOS build to confirm cross-platform**
+
+Run: `just -d "$WT" --justfile "$WT/justfile" build-ios 2>&1 | tee "$WT/.agent-tmp/ios.txt"`
+Expected: build clean. The sheet and Swift Charts usage are universal.
+
+- [ ] **Step 3: `format-check` on the whole tree**
+
+Run: `just -d "$WT" --justfile "$WT/justfile" format-check`
+Expected: clean (no swift-format diff, no SwiftLint violations).
+
+- [ ] **Step 4: Run the review agents**
+
+Invoke `@code-review` (CODE_GUIDE + architecture/thin-view), `@concurrency-review`
+(the chart is `Sendable` and crosses the off-main boundary), and `@ui-review`
+(the panel + sheet, accessibility, HIG). Apply ALL findings (Critical/Important/
+Minor) per project policy; do not rationalise any away.
+
+- [ ] **Step 5: Push the branch and open the PR**
+
+```bash
+git -C "$WT" push origin worktree-insight-companion-graphs:worktree-insight-companion-graphs
+gh pr create --repo moolah-rocks/moolah-native --base main \
+  --head worktree-insight-companion-graphs \
+  --title "Companion graphs for insights" \
+  --body "$(cat <<'EOF'
+Adds an optional `InsightChart` to `Insight`, computed by the detectors and
+rendered by a generic `InsightChartView`. For You insights now show as
+full-width panels with a side graph; tapping the graph opens a centered detail
+sheet with the enlarged chart, the insight's facts, and its actions.
+
+First cut wires charts for four insight families: category spending
+(anomaly/trend), cash-flow forecast (projected month-end / upcoming bill), net
+worth milestone, savings-rate trend, and earmark projected burndown. Graph-less
+insights are unchanged. Remaining kinds get charts incrementally.
+
+Design + plan: `plans/2026-06-04-insight-companion-graphs-design.md`,
+`plans/2026-06-04-insight-companion-graphs-implementation.md`.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 6: Land via the project's merge flow**
+
+Per the `landing-prs` skill, set the PR to auto-merge (`gh pr merge --auto
+--rebase`) once CI is green. Do not use the user-level merge-queue skill.
+
+---
+
+## Self-Review (completed during planning)
+
+- **Spec coverage:** `InsightChart` model (Task 1) ✓; generic builder approach
+  (Tasks 2,4,5,6,7) ✓; four families wired — category (Task 3), cash-flow (Task 4),
+  savings (Task 6), net-worth + earmark (Tasks 5,7) ✓; panel layout B (Task 10) ✓;
+  centered detail sheet with facts + actions (Task 9) ✓; graph-less fallback (Task
+  10 Step 2) ✓; sparse-data → `nil` (builders' `minimumPoints`) ✓; honest earmark
+  projection, not faked history (Task 7) ✓; testing — builder unit + detector +
+  one UI test (Tasks 2-7, 11) ✓.
+- **Placeholder scan:** the few "confirm the local variable name / driver API /
+  seed name by reading X" notes are directed verification steps with the exact
+  file:line to read and the full surrounding code shown — not hand-waved content.
+- **Type consistency:** `InsightChart`, `InsightChart.Point/Series/Unit/Kind/
+  SeriesRole/XAxisStyle`, `InsightChartBuilders.{categorySpend,balanceForecast,
+  netWorthTrend,savingsRate,earmarkBurndown}`, and `InsightChartView`/
+  `InsightChartDetailSheet` names match across every task. `Insight.chart` is the
+  single new property threaded through all detectors and the view.
+- **Deviation from spec:** `Point.value` is `Double` (not `Decimal`) to match the
+  Swift Charts `LineMark`/`BarMark` y-value idiom and the existing
+  `NetWorthGraphCard`; currency values are reconstructed as
+  `InstrumentAmount(quantity: Decimal(value), instrument:)` for label formatting,
+  exactly as `NetWorthGraphCard` does. Update the design doc's data-model snippet
+  to say `Double` if strict consistency is wanted.


### PR DESCRIPTION
## What

Each high-value insight detector now attaches a **companion graph** that visualises the behaviour it detected, computed as pure data and rendered by a single generic chart view. The "For You" insights on the Analysis page render as **panels** — headline + impact + controls on the left, a small graph on the right — and tapping the graph opens a **centered detail sheet** with the enlarged chart, the insight's facts, and its deep-link actions.

Motivating example: "Dining out is up 62% this month" now shows that category's spend over recent months with the anomalous month highlighted.

## How

- **`InsightChart`** — a new `Sendable`/`Hashable` value type (`Domain/Insights/InsightChart.swift`) added as an optional `chart` on `Insight`. Detectors compute it off the main actor; views only render it (thin-view discipline, mirroring how `InsightFact` is the single source of truth for rendered numbers).
- **`InsightChartBuilders`** — pure, unit-tested builders, one per family.
- **First-cut families wired:** category spending (anomaly + trend), cash-flow forecast (projected month-end + upcoming bill), net-worth milestone, savings-rate trend, and earmark projected-burndown. Graph-less insights are unchanged (compact rows).
- **Honest earmark burndown:** `EarmarkSnapshot` has no spend history, so that chart is a *projected* burndown (ideal baseline + current point + dashed projection), never faked history.
- **`InsightChartView`** (inline + expanded) and **`InsightChartDetailSheet`** (the zoom), with accessibility, framing-tinted highlight, semantic colors, Dynamic Type, and platform-conditional sizing.

## Scope

Framework + the four highest-value families. Remaining ~30 insight kinds get charts incrementally later, reusing `InsightChart`/`InsightChartView` with no model changes expected. No new aggregation was added to `InsightInput` — the first cut uses only data already present.

## Testing

- Builder unit tests + detector-level tests (chart attached, correct highlight, percent unit, filter guards) — Swift Testing.
- One macOS XCUITest: an insight panel shows a graph, tapping it opens the detail sheet (deterministic seed, screen-driver pattern). Local UI-host execution was blocked by a machine LocalAuthentication prompt; **gated on CI's UI Test job**.
- Full macOS unit suite passes; macOS + iOS builds clean; `format-check` clean.

## Reviews applied

Per-view `@ui-review`, `@concurrency-review` (Sendable boundary), `@ui-test-review`, and per-builder `@code-review` — all findings applied.

Design + plan: `plans/2026-06-04-insight-companion-graphs-design.md`, `plans/2026-06-04-insight-companion-graphs-implementation.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)