### PR TITLE
Insights: companion balance chart for runway & idle-cash

### DIFF
--- a/Domain/Insights/Detectors/LiquidityInsights.swift
+++ b/Domain/Insights/Detectors/LiquidityInsights.swift
@@ -42,7 +42,8 @@ enum LiquidityInsights {
           InsightFact("Monthly burn", context.formatted(burn)),
           InsightFact("Runway", monthsText(months)),
         ],
-        references: InsightReferences(instrumentIds: [context.reportingCurrency.id]))
+        references: InsightReferences(instrumentIds: [context.reportingCurrency.id]),
+        chart: balanceChart(dailyBalances, context: context))
     ]
   }
 
@@ -80,8 +81,24 @@ enum LiquidityInsights {
           InsightFact("Suggested buffer", context.formatted(cushion)),
           InsightFact("Idle excess", context.formatted(excess)),
         ],
-        references: InsightReferences(instrumentIds: [context.reportingCurrency.id]))
+        references: InsightReferences(instrumentIds: [context.reportingCurrency.id]),
+        chart: balanceChart(dailyBalances, context: context))
     ]
+  }
+
+  /// Both liquidity insights tell a story about the same liquid-balance
+  /// series — runway is that line sloping down, idle cash is it sitting high —
+  /// so they share one chart, anchored at the latest actual reading the
+  /// runway/cushion maths is computed from. The fallback to `nil` (sparse
+  /// data) is deliberately silent: a missing companion graph is a smaller row,
+  /// not an error worth surfacing.
+  private static func balanceChart(
+    _ dailyBalances: [DailyBalance], context: InsightContext
+  ) -> InsightChart? {
+    InsightChartBuilders.balanceForecast(
+      dailyBalances,
+      reportingCurrency: context.reportingCurrency,
+      highlight: InsightAggregates.latestActual(dailyBalances)?.date)
   }
 
   private static func monthsText(_ months: Double) -> String {

--- a/MoolahTests/Domain/Insights/FinanceInsightTests.swift
+++ b/MoolahTests/Domain/Insights/FinanceInsightTests.swift
@@ -160,6 +160,47 @@ struct FinanceInsightTests {
       dailyBalances: balances, monthly: monthly, context: context)
     let runway = try #require(insights.first)
     #expect(runway.kind == .runwayEstimate)
+    // A single balance point is too sparse for `balanceForecast`, so this
+    // runway falls back to a graph-less row.
+    #expect(runway.chart == nil)
+  }
+
+  @Test
+  func runwayAttachesBalanceForecastChart() throws {
+    let balances = [
+      InsightTestSupport.balance(offsetDays: 10, total: 12000, forecast: false),
+      InsightTestSupport.balance(offsetDays: 0, total: 10000, forecast: false),
+      InsightTestSupport.balance(offsetDays: -10, total: 8000, forecast: true),
+      InsightTestSupport.balance(offsetDays: -20, total: 6000, forecast: true),
+    ]
+    let monthly = ["202603", "202604", "202605"].map {
+      InsightTestSupport.monthly(month: $0, income: 1000, expense: 3000)
+    }
+    let runway = try #require(
+      LiquidityInsights.runway(dailyBalances: balances, monthly: monthly, context: context).first)
+    let chart = try #require(runway.chart)
+    #expect(chart.unit == .currency(InsightTestSupport.currency))
+    #expect(chart.series.contains { $0.role == .primary })
+    #expect(chart.series.contains { $0.role == .projected })
+    // Highlight marks the latest actual reading ("you are here" = $10,000 now).
+    #expect(chart.highlight?.value == 10000)
+  }
+
+  @Test
+  func idleCashAttachesBalanceForecastChart() throws {
+    let balances = [
+      InsightTestSupport.balance(offsetDays: 10, total: 19000, forecast: false),
+      InsightTestSupport.balance(offsetDays: 0, total: 20000, forecast: false),
+      InsightTestSupport.balance(offsetDays: -10, total: 20500, forecast: true),
+    ]
+    let monthly = ["202603", "202604", "202605"].map {
+      InsightTestSupport.monthly(month: $0, income: 4000, expense: 2000)
+    }
+    let idle = try #require(
+      LiquidityInsights.idleCash(dailyBalances: balances, monthly: monthly, context: context).first)
+    let chart = try #require(idle.chart)
+    #expect(chart.unit == .currency(InsightTestSupport.currency))
+    #expect(chart.highlight?.value == 20000)
   }
 
   @Test

--- a/MoolahTests/Domain/Insights/InsightTestSupport.swift
+++ b/MoolahTests/Domain/Insights/InsightTestSupport.swift
@@ -77,6 +77,24 @@ enum InsightTestSupport {
     InstrumentAmount(quantity: quantity, instrument: currency)
   }
 
+  /// A `DailyBalance` offset from `now`: positive `offsetDays` is in the past,
+  /// negative is the forecast tail in the future. `total` sets both
+  /// current-funds balance and net worth; `forecast` flags a projected day.
+  static func balance(offsetDays days: Int, total: Decimal, forecast: Bool) -> DailyBalance {
+    let value = amount(total)
+    let zero = amount(0)
+    return DailyBalance(
+      date: daysAgo(days),
+      balance: value,
+      earmarked: zero,
+      availableFunds: value,
+      investments: zero,
+      investmentValue: nil,
+      netWorth: value,
+      bestFit: nil,
+      isForecast: forecast)
+  }
+
   // MARK: - Aggregate builders
 
   /// `InsightInput.recentCandidates` slice: legs within `windowDays` of `now`.

--- a/plans/2026-06-05-insight-companion-graphs-remaining-kinds.md
+++ b/plans/2026-06-05-insight-companion-graphs-remaining-kinds.md
@@ -1,0 +1,68 @@
+# Companion graphs for the remaining insight kinds — execution plan
+
+**Date:** 2026-06-05
+**Status:** In progress
+**Builds on:** `plans/2026-06-04-insight-companion-graphs-design.md` (framework
+shipped in PR #1053).
+
+## Goal
+
+Extend the insight companion-graph framework to the remaining `InsightKind`s
+that have a meaningful time series **already present in `InsightInput`**. Follow
+the established pattern exactly:
+
+1. A pure builder in `InsightChartBuilders` returning `InsightChart?` — returns
+   `nil` when data is too sparse (reuse `minimumPoints`); values already in
+   reporting currency; signs preserved (no `abs()`).
+2. Attach it as the trailing `chart:` argument of the detector's `Insight(...)`,
+   using only data already in `InsightInput` (no new aggregation).
+3. A builder unit test (when a new builder is added) + a detector-level test
+   asserting the chart attaches with the right unit/highlight (Swift Testing,
+   `InsightTestSupport`).
+
+Keep detectors pure and views thin. `just build-mac` / `test-mac` /
+`format-check` green; `@code-review` + `@concurrency-review`; ship via PR, one
+family per PR.
+
+## Batches (one PR each)
+
+### PR 1 — Liquidity (`runwayEstimate`, `idleCashAlert`)
+Reuse `InsightChartBuilders.balanceForecast`. Both detectors already hold
+`dailyBalances`; attach the balance + forecast-tail chart, highlighting the
+latest actual balance ("you are here"). No new builder. Detector-level tests
+assert the chart attaches with `.currency` unit and the latest-actual highlight.
+
+### PR 2 — Period comparison (`monthOverMonthDelta`)
+New builder `monthlySpend(monthly:reportingCurrency:highlightMonth:)` — a bar
+series of total spend magnitude per complete financial month, highlighting the
+latest. Attach in `PeriodComparisonInsights`.
+
+### PR 3 — Recurring streams (`subscriptionPriceHike`, `payRateChange`,
+`incomeStabilityScore`, `paycheckTimingPattern`)
+Surface the per-occurrence dates the detector already computes on
+`DetectedSubscription` (parallel to `amounts`). New builder
+`recurringCharges(...)` — a line/bar of signed charge/income magnitude over the
+occurrence dates, highlighting the latest. Attach across `SubscriptionInsights`,
+`IncomeInsights`, and `IncomeExtraInsights`.
+
+### PR 4 — Fee spend (`feeSpend`)
+New builder `monthlyCategorySpend(expenseBreakdown:categoryIds:reportingCurrency:)`
+— a bar series summing the fee categories' monthly spend from `expenseBreakdown`
+(already in `InsightInput`), highlighting the latest month. Thread
+`expenseBreakdown` into `SavingsOpportunityInsights.feeSpend`.
+
+## Explicitly skipped (no sensible time series)
+
+- **Investments** (`topPerformer`, `bottomPerformer`,
+  `investmentConcentrationRisk`, `capitalGainsHarvest`): `InstrumentProfitLoss`
+  in `InsightInput` is a point-in-time snapshot (no per-instrument value
+  history); `capitalGains` is a scatter of discrete sell events. No honest
+  date-keyed series without new aggregation. Decision confirmed with the user
+  2026-06-05.
+- `categoryMixShift`, `weekendSpendSkew`, `unusualDaySpend`,
+  `largeTransactionAnomaly`, `newMerchantAlert`, `uncategorizedBacklog`,
+  `unreconciledTransfers`, `groupSpendConcentration`, `unbudgetedCategory`,
+  `duplicateSubscription`, `subscriptionOverspend`, `windfallIncome`,
+  `missingPaycheckAlert`, `earmarkUnderspend`, `savingsGoalETA` — point events,
+  share-shifts, or single-value comparisons without a meaningful trend in the
+  available data.


### PR DESCRIPTION
Extends the insight companion-graphs feature (framework shipped in [#1053](https://github.com/moolah-rocks/moolah-native/pull/1053)) to the **liquidity** insight family — the first of four follow-up PRs covering the remaining chartable insight kinds.

## What

- `runwayEstimate` and `idleCashAlert` now carry a companion chart: the daily current-funds balance line with its forecast tail, anchored at the latest actual reading ("you are here").
- Both reuse the existing `InsightChartBuilders.balanceForecast` builder — **no new builder, no new aggregation**. They already hold `dailyBalances`; the chart just rides along on the `Insight`.
- Falls back to `nil` (graph-less row) when the balance series is too sparse to plot (`< 2` points).

## Tests

- New shared fixture helper `InsightTestSupport.balance(offsetDays:total:forecast:)`.
- Detector-level tests assert the chart attaches with the `.currency` unit and the latest-actual highlight, and that a single-point series produces no chart.

## Notes

- Pure-detector / thin-view discipline preserved; sign convention untouched (no `abs()`).
- `@code-review` + `@concurrency-review` run clean (all findings applied).
- Also lands `plans/2026-06-05-insight-companion-graphs-remaining-kinds.md` — the execution plan for PRs 2–4 (period comparison, recurring streams, fee spend). Investment performers are deliberately skipped (no time series in `InsightInput`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)