### PR TITLE
Insights: companion spend chart for month-over-month delta

### DIFF
--- a/Domain/Insights/Detectors/PeriodComparisonInsights.swift
+++ b/Domain/Insights/Detectors/PeriodComparisonInsights.swift
@@ -20,8 +20,7 @@ enum PeriodComparisonInsights {
 
     var insights: [Insight] = []
     if let monthOverMonth = compare(
-      latest: complete[complete.count - 1],
-      baseline: complete[complete.count - 2],
+      completeMonths: complete,
       label: "last month",
       context: context,
       threshold: threshold)
@@ -31,22 +30,29 @@ enum PeriodComparisonInsights {
     return insights
   }
 
-  /// Compare two months' total spend magnitude and emit a delta insight when
-  /// the change clears `threshold`. Spend magnitude is `-(totalExpense)`
-  /// because expense aggregates are stored negative.
+  /// Compare the latest two complete months' total spend magnitude and emit a
+  /// delta insight when the change clears `threshold`. Spend magnitude is
+  /// `-(totalExpense)` because expense aggregates are stored negative.
+  /// `completeMonths` (ascending, ≥2) is both the comparison source — its last
+  /// two entries — and the full series the companion bar chart plots, with the
+  /// latest month highlighted.
   private static func compare(
-    latest: MonthlyIncomeExpense,
-    baseline: MonthlyIncomeExpense,
+    completeMonths: [MonthlyIncomeExpense],
     label: String,
     context: InsightContext,
     threshold: Double
   ) -> Insight? {
+    // Defensive: the caller already enforces ≥2 complete months; kept so this
+    // private helper is sound on its own.
+    guard completeMonths.count >= 2 else { return nil }
+    let latest = completeMonths[completeMonths.count - 1]
+    let baseline = completeMonths[completeMonths.count - 2]
     let latestSpend = magnitude(latest.totalExpense)
     let baselineSpend = magnitude(baseline.totalExpense)
     guard baselineSpend > 0 else { return nil }
     let fraction = (latestSpend - baselineSpend) / baselineSpend
-    let magnitude = abs(fraction)
-    guard magnitude >= threshold else { return nil }
+    let changeMagnitude = abs(fraction)
+    guard changeMagnitude >= threshold else { return nil }
 
     let increased = fraction > 0
     let deltaAmount = Decimal(-(latestSpend - baselineSpend))
@@ -55,20 +61,24 @@ enum PeriodComparisonInsights {
       id: "\(InsightKind.monthOverMonthDelta.rawValue):\(latest.month)",
       kind: .monthOverMonthDelta,
       title: increased
-        ? "Spending up \(percent(magnitude)) vs \(label)"
-        : "Spending down \(percent(magnitude)) vs \(label)",
+        ? "Spending up \(percent(changeMagnitude)) vs \(label)"
+        : "Spending down \(percent(changeMagnitude)) vs \(label)",
       date: monthDate,
       framing: increased ? .negative : .positive,
       actionability: .informational,
-      surprise: min(magnitude, 1),
+      surprise: min(changeMagnitude, 1),
       monetaryImpact: InstrumentAmount(
         quantity: deltaAmount, instrument: context.reportingCurrency),
       facts: [
         InsightFact("This period", context.formatted(Decimal(-latestSpend))),
         InsightFact("Comparison", context.formatted(Decimal(-baselineSpend))),
-        InsightFact("Change", "\(increased ? "+" : "−")\(percent(magnitude))"),
+        InsightFact("Change", "\(increased ? "+" : "−")\(percent(changeMagnitude))"),
       ],
-      references: InsightReferences(instrumentIds: [context.reportingCurrency.id]))
+      references: InsightReferences(instrumentIds: [context.reportingCurrency.id]),
+      chart: InsightChartBuilders.monthlySpend(
+        monthly: completeMonths,
+        reportingCurrency: context.reportingCurrency,
+        highlightMonth: latest.month))
   }
 
   private static func magnitude(_ amount: InstrumentAmount) -> Double {

--- a/Domain/Insights/InsightChartBuilders.swift
+++ b/Domain/Insights/InsightChartBuilders.swift
@@ -109,6 +109,38 @@ enum InsightChartBuilders {
       xAxis: .monthly)
   }
 
+  /// Total spend magnitude per financial month, as a bar chart with
+  /// `highlightMonth` (the latest complete month a month-over-month delta
+  /// compares) marked. Spend is the positive magnitude of `totalExpense`; a
+  /// net-refund month (positive total) clamps to a zero bar rather than
+  /// plotting a negative spend, matching `CategorySpendSeries`.
+  static func monthlySpend(
+    monthly: [MonthlyIncomeExpense],
+    reportingCurrency: Instrument,
+    highlightMonth: String
+  ) -> InsightChart? {
+    let ordered = monthly.sorted { $0.month < $1.month }
+    guard ordered.count >= minimumPoints else { return nil }
+
+    return InsightChart(
+      kind: .bar,
+      unit: .currency(reportingCurrency),
+      series: [
+        InsightChart.Series(
+          id: "spend", label: "Spend", role: .primary, points: ordered.map(point(from:)))
+      ],
+      highlight: ordered.first { $0.month == highlightMonth }.map(point(from:)),
+      xAxis: .monthly)
+  }
+
+  private static func point(from month: MonthlyIncomeExpense) -> InsightChart.Point {
+    let signed = Double(truncating: month.totalExpense.quantity as NSDecimalNumber)
+    // monthDate returns nil only for a malformed YYYYMM key; month.end is a safe
+    // fallback since both dates fall within the same calendar month.
+    let date = CategorySpendSeries.monthDate(month.month) ?? month.end
+    return InsightChart.Point(date: date, value: max(-signed, 0))
+  }
+
   /// A category's monthly spend (positive magnitudes), as a bar chart with the
   /// anomalous / latest financial month highlighted.
   static func categorySpend(

--- a/MoolahTests/Domain/Insights/InsightChartBuildersTests.swift
+++ b/MoolahTests/Domain/Insights/InsightChartBuildersTests.swift
@@ -86,6 +86,52 @@ struct InsightChartBuildersTests {
         points: points, reportingCurrency: currency, highlightMonth: "202606") == nil)
   }
 
+  @Test
+  func monthlySpendChartHighlightsTheGivenMonth() throws {
+    let monthly = [
+      InsightTestSupport.monthly(month: "202604", income: 5000, expense: 2000),
+      InsightTestSupport.monthly(month: "202605", income: 5000, expense: 2200),
+      InsightTestSupport.monthly(month: "202606", income: 5000, expense: 3500),
+    ]
+    let chart = try #require(
+      InsightChartBuilders.monthlySpend(
+        monthly: monthly, reportingCurrency: currency, highlightMonth: "202606"))
+
+    #expect(chart.kind == .bar)
+    #expect(chart.unit == .currency(currency))
+    #expect(chart.xAxis == .monthly)
+    #expect(chart.series.count == 1)
+    #expect(chart.series.first?.id == "spend")
+    #expect(chart.series.first?.points.count == 3)
+    // Positive spend magnitudes, ascending by month.
+    #expect(chart.series.first?.points.first?.value == 2000)
+    #expect(chart.highlight?.value == 3500)
+    #expect(chart.highlight?.date == InsightTestSupport.date(2026, 6, 1))
+  }
+
+  /// A net-refund month (positive `totalExpense`) clamps to a zero bar rather
+  /// than plotting a negative spend.
+  @Test
+  func monthlySpendChartClampsRefundMonthToZero() throws {
+    let monthly = [
+      InsightTestSupport.monthly(month: "202604", income: 5000, expense: 2000),
+      InsightTestSupport.monthly(month: "202605", income: 5000, expense: -300),
+    ]
+    let chart = try #require(
+      InsightChartBuilders.monthlySpend(
+        monthly: monthly, reportingCurrency: currency, highlightMonth: "202605"))
+    #expect(chart.series.first?.points.last?.value == 0)
+    #expect(chart.highlight?.value == 0)
+  }
+
+  @Test
+  func monthlySpendChartIsNilBelowTwoMonths() {
+    let monthly = [InsightTestSupport.monthly(month: "202606", income: 5000, expense: 3500)]
+    #expect(
+      InsightChartBuilders.monthlySpend(
+        monthly: monthly, reportingCurrency: currency, highlightMonth: "202606") == nil)
+  }
+
   private func balance(
     _ day: Int, total: Decimal, forecast: Bool, netWorth: Decimal? = nil
   ) -> DailyBalance {

--- a/MoolahTests/Domain/Insights/SpendAndTrendInsightTests.swift
+++ b/MoolahTests/Domain/Insights/SpendAndTrendInsightTests.swift
@@ -102,6 +102,26 @@ struct SpendAndTrendInsightTests {
   }
 
   @Test
+  func monthOverMonthAttachesSpendChart() throws {
+    let monthly = [
+      InsightTestSupport.monthly(month: "202603", income: 5000, expense: 1800),
+      InsightTestSupport.monthly(month: "202604", income: 5000, expense: 2000),
+      InsightTestSupport.monthly(month: "202605", income: 5000, expense: 2600),
+    ]
+    let insights = PeriodComparisonInsights.detect(monthly: monthly, context: context)
+    let delta = try #require(insights.first { $0.kind == .monthOverMonthDelta })
+    let chart = try #require(delta.chart)
+    #expect(chart.kind == .bar)
+    #expect(chart.unit == .currency(InsightTestSupport.currency))
+    #expect(chart.xAxis == .monthly)
+    // The chart spans every complete month, not just the two compared.
+    #expect(chart.series.first?.points.count == 3)
+    // Highlight marks the latest complete month (202605 = $2,600 spend).
+    #expect(chart.highlight?.value == 2600)
+    #expect(chart.highlight?.date == InsightTestSupport.date(2026, 5, 1))
+  }
+
+  @Test
   func monthOverMonthExcludesInProgressMonth() {
     // Only the current (in-progress) bucket plus one complete month — not
     // enough complete months to compare.


### PR DESCRIPTION
Extends the insight companion-graphs feature (framework [#1053](https://github.com/moolah-rocks/moolah-native/pull/1053)) to the **period-comparison** family — PR 2 of 4 covering the remaining chartable insight kinds (follows [#1054](https://github.com/moolah-rocks/moolah-native/pull/1054)).

## What

- New pure builder `InsightChartBuilders.monthlySpend(monthly:reportingCurrency:highlightMonth:)` — a bar series of total spend magnitude per complete financial month.
- Attached to the `monthOverMonthDelta` insight. The chart spans **every** complete month, not just the two compared, and highlights the latest.
- Spend is the positive magnitude of `totalExpense`; a net-refund month (positive total) clamps to a zero bar, matching `CategorySpendSeries`. No `abs()`, sign preserved. No new aggregation — the detector already holds the monthly series.

## Refactor

- The private `compare` helper now derives latest/baseline from the complete-months series it's passed, dropping its parameter count from 6 to 4 (SwiftLint `function_parameter_count`). Behaviour-preserving.
- Renamed a local `magnitude` that shadowed the `magnitude(_:)` helper.

## Tests

- Builder unit tests: latest-month highlight, refund-month clamp-to-zero, sparse `nil`.
- Detector-level test asserts the chart attaches with the bar / `.currency` unit and latest-complete-month highlight.

`just build-mac` / `test-mac` / `format-check` green. `@code-review` + `@concurrency-review` run clean (all findings applied).

🤖 Generated with [Claude Code](https://claude.com/claude-code)