### PR TITLE
Fix For You insight panels: graph clipped, headline collapsed

### DIFF
--- a/Features/Insights/Views/ForYouCard.swift
+++ b/Features/Insights/Views/ForYouCard.swift
@@ -50,31 +50,22 @@ private struct InsightRow: View {
   }
 
   var body: some View {
-    // At accessibility type sizes the inline HStack (headline + impact +
-    // controls) collides, so reflow to a VStack: the headline gets its own
-    // line, then a row of impact and the controls. The non-accessibility
-    // layout keeps everything inline.
+    // The panel is a two-column layout: the textual content (headline + impact +
+    // controls) forms a flexible left column that takes all remaining width, and
+    // the companion graph is a fixed-size sibling pinned to the right. Keeping the
+    // graph out of the text's HStack is what stops the fixed-width chart from
+    // overrunning the row and collapsing the headline into a sliver. At
+    // accessibility type sizes the inline graph would crowd the stacked content,
+    // so it drops to the bottom of the left column (full width) instead.
     Group {
       if dynamicTypeSize.isAccessibilitySize {
-        // At accessibility sizes the inline 200pt chart would crowd the
-        // already-stacked content, so the companion graph drops to the bottom
-        // of the vertical stack (full width) rather than sitting inline.
         VStack(alignment: .leading, spacing: 6) {
-          headlineLine
-          HStack(spacing: 8) {
-            impactText
-            Spacer(minLength: 0)
-            showLessButton
-            viewButton
-          }
+          textColumn
           chartButton
         }
       } else {
-        HStack(spacing: 8) {
-          headlineLine
-          impactText
-          showLessButton
-          viewButton
+        HStack(alignment: .center, spacing: 12) {
+          textColumn
           chartButton
         }
       }
@@ -94,16 +85,51 @@ private struct InsightRow: View {
     }
   }
 
-  /// The trailing companion graph: a fixed ~200pt inline chart that zooms to
-  /// the detail sheet when tapped. Only present when the insight carries a
-  /// chart, so graph-less rows render exactly as before.
+  // MARK: - Layout
+
+  /// Claims all the width the companion graph doesn't, so the headline wraps in
+  /// generous space. Without `maxWidth: .infinity` the fixed-width graph would
+  /// push this column down to a sliver — the bug this layout exists to fix.
+  private var textColumn: some View {
+    VStack(alignment: .leading, spacing: 6) {
+      headlineLine
+      impactAndControls
+    }
+    .frame(maxWidth: .infinity, alignment: .leading)
+  }
+
+  /// The impact amount and the controls. They share a single row when there's
+  /// room; in a tight column (narrow window) the controls drop below the amount
+  /// rather than squeezing it — `ViewThatFits` picks the first layout that fits.
+  private var impactAndControls: some View {
+    ViewThatFits(in: .horizontal) {
+      HStack(spacing: 8) {
+        impactText
+        Spacer(minLength: 8)
+        showLessButton
+        viewButton
+      }
+      VStack(alignment: .leading, spacing: 6) {
+        impactText
+        HStack(spacing: 8) {
+          showLessButton
+          viewButton
+          Spacer(minLength: 0)
+        }
+      }
+    }
+  }
+
+  /// The trailing companion graph: a fixed ~200×72 inline sparkline that zooms
+  /// to the detail sheet when tapped. Only present when the insight carries a
+  /// chart, so graph-less rows render as a plain left column with no graph.
   @ViewBuilder private var chartButton: some View {
     if let chart = insight.chart {
       Button {
         isZoomed = true
       } label: {
         InsightChartView(chart: chart, tint: framingColor, style: .inline)
-          .frame(width: horizontalSizeClass == .compact ? 120 : 200, height: 48)
+          .frame(width: horizontalSizeClass == .compact ? 120 : 200, height: 72)
           .contentShape(Rectangle())
       }
       .buttonStyle(.plain)
@@ -134,11 +160,16 @@ private struct InsightRow: View {
     }
   }
 
+  // MARK: - Leaves and styling
+
   @ViewBuilder private var impactText: some View {
     if let impact = insight.monetaryImpact {
       Text(impact.formatted)
         .font(.subheadline)
         .monospacedDigit()
+        // A monetary amount is read as a whole — never break it mid-number.
+        .lineLimit(1)
+        .fixedSize()
         .foregroundStyle(impactColor(impact))
         .accessibilityLabel("Impact: \(impact.formatted)")
     }
@@ -150,6 +181,9 @@ private struct InsightRow: View {
       // control on both platforms — matches the dismiss button's style.
       Button("View") { onNavigate(target) }
         .buttonStyle(.borderless)
+        // Keep the label intact when the impact row is tight — it should wrap to
+        // a new line as a whole control, never break mid-word.
+        .fixedSize()
         #if os(iOS)
           .frame(minHeight: 44)
         #endif
@@ -168,6 +202,9 @@ private struct InsightRow: View {
         .contentShape(Rectangle())
     }
     .buttonStyle(.borderless)
+    // Keep the label intact when the impact row is tight — it should wrap to a
+    // new line as a whole control, never break mid-word ("Sho w less").
+    .fixedSize()
     .foregroundStyle(.secondary)
     #if os(iOS)
       .frame(minHeight: 44)

--- a/Features/Insights/Views/InsightChartView.swift
+++ b/Features/Insights/Views/InsightChartView.swift
@@ -20,7 +20,10 @@ struct InsightChartView: View {
         .chartXAxis(.hidden)
         .chartYAxis(.hidden)
         .chartLegend(.hidden)
-        .frame(height: 48)
+        .frame(height: 72)
+        // Inline sparkline: keep marks inside the declared frame so a mark at the
+        // plot edge can't bleed into the panel's text column beside it.
+        .clipped()
         .allowsHitTesting(false)
         .accessibilityHidden(true)
         .dynamicTypeSize(.medium ... .accessibility1)


### PR DESCRIPTION
## Problem

The "For You" insight graphs render wrong: each insight shows as a cramped single line with a graph clipped to a sliver at the trailing edge and no axis labels.

![reported](N/A)

**Root cause:** the shipped `ForYouCard` crammed the headline, monetary impact, controls, *and* the companion graph into one flat `HStack`. With the headline greedy (`maxWidth: .infinity`) and the graph a fixed 200pt, the fixed items overran the row — the headline collapsed to a vertical sliver and the 200pt graph overflowed the trailing edge, leaving only its rightmost bar visible.

## Fix

Implement the two-column layout the approved design called for (`plans/2026-06-04-insight-companion-graphs-design.md` §UI: *"headline + impact + controls on the left, a small graph (~200×72) on the right"*):

- Extract a flexible `textColumn` (`maxWidth: .infinity`, headline above impact + controls) and keep `chartButton` as a **sibling** in the outer `HStack` (and the accessibility-size `VStack`). The graph no longer participates in the text's `HStack`, so it can't squeeze or overflow it.
- `ViewThatFits` collapses the impact+controls row to two lines in a narrow window instead of squeezing the amount; the monetary amount is locked to one line and control labels stay intact (`.fixedSize()`), so nothing breaks mid-number / mid-word.
- Bump the inline sparkline to ~200×72 (design spec) and `.clipped()` it so an edge mark can't bleed into the text column.

## Verification

- `#Preview` rendered at narrow (420pt) and wide (760pt) widths — graph fully visible, headline wraps naturally, no clipping at either width.
- All 5 ForYou UI tests pass, including `testTappingInlineChartOpensDetailSheet` (the new tap target still opens the detail sheet).
- `just build-mac` and `just format-check` clean.

## Follow-ups (pre-existing, not in this focused fix)

A UI review surfaced several pre-existing items in `InsightChartDetailSheet.swift` (detail-sheet "View" button missing `.buttonStyle(.borderless)`; no `ScrollView` so facts can clip at large Dynamic Type; `minHeight: 420` floor leaves a void for chart-less insights) and the `.orange` negative-framing colour. These are outside the reported bug; flagged for a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)