### PR TITLE
fix(automation): stop resolveAccount flake — guard store race + authoritative reads

### DIFF
--- a/Automation/AppleScript/Commands/DeleteCommand.swift
+++ b/Automation/AppleScript/Commands/DeleteCommand.swift
@@ -84,9 +84,9 @@
     ) async throws {
       let account: Account
       if let name = target.name {
-        account = try service.resolveAccount(named: name, profileIdentifier: profileName)
+        account = try await service.resolveAccount(named: name, profileIdentifier: profileName)
       } else if let objectID = target.id, let uuid = UUID(uuidString: objectID) {
-        account = try service.resolveAccount(id: uuid, profileIdentifier: profileName)
+        account = try await service.resolveAccount(id: uuid, profileIdentifier: profileName)
       } else {
         throw AutomationError.accountNotFound("unknown")
       }

--- a/Automation/AutomationService+Accounts.swift
+++ b/Automation/AutomationService+Accounts.swift
@@ -1,0 +1,129 @@
+import Foundation
+
+// Account operations for `AutomationService`: listing, authoritative
+// resolution (by name / id), net worth, and create / update / delete.
+// All members are `@MainActor` via the containing class.
+extension AutomationService {
+
+  // MARK: - Account Operations
+
+  /// Returns all accounts for the given profile.
+  func listAccounts(profileIdentifier: String) throws -> [Account] {
+    let session = try resolveSession(for: profileIdentifier)
+    return Array(session.accountStore.accounts)
+  }
+
+  /// Resolves an account by name (case-insensitive) within a profile.
+  ///
+  /// Reads the authoritative repository snapshot (`fetchAll()`) rather
+  /// than the reactive `AccountStore.accounts`. Automation is a scripted,
+  /// read-after-write context — a script (or a single intent) creates an
+  /// account and then references it by name in the very next operation.
+  /// The reactive store is only *eventually* consistent with a committed
+  /// write: under load `observeAll()` can deliver the new snapshot after
+  /// the reference reads it, so a reactive-store lookup can throw
+  /// `.accountNotFound` for an account that is already persisted.
+  /// `fetchAll()` reflects the committed write immediately, making
+  /// resolution deterministic.
+  func resolveAccount(named name: String, profileIdentifier: String) async throws -> Account {
+    let accounts = try await fetchAccounts(profileIdentifier: profileIdentifier)
+    return try Self.account(named: name, in: accounts)
+  }
+
+  /// Resolves an account by UUID within a profile. Authoritative read —
+  /// see `resolveAccount(named:profileIdentifier:)` for the rationale.
+  func resolveAccount(id: UUID, profileIdentifier: String) async throws -> Account {
+    let accounts = try await fetchAccounts(profileIdentifier: profileIdentifier)
+    guard let account = accounts.first(where: { $0.id == id }) else {
+      throw AutomationError.accountNotFound(id.uuidString)
+    }
+    return account
+  }
+
+  /// Authoritative account snapshot for a profile, read straight from the
+  /// repository so it reflects every committed write immediately.
+  func fetchAccounts(profileIdentifier: String) async throws -> [Account] {
+    let session = try resolveSession(for: profileIdentifier)
+    return try await session.backend.accounts.fetchAll()
+  }
+
+  /// Case-insensitive name lookup within an already-fetched account list.
+  /// Shared by `resolveAccount(named:)` and `resolveLegs` (which fetches
+  /// the snapshot once and resolves every leg against it).
+  static func account(named name: String, in accounts: [Account]) throws -> Account {
+    let lowered = name.lowercased()
+    guard let account = accounts.first(where: { $0.name.lowercased() == lowered }) else {
+      throw AutomationError.accountNotFound(name)
+    }
+    return account
+  }
+
+  /// Returns the net worth (current + investment totals) for the given profile,
+  /// converted into the profile's instrument.
+  func getNetWorth(profileIdentifier: String) async throws -> InstrumentAmount {
+    let session = try resolveSession(for: profileIdentifier)
+    do {
+      return try await session.accountStore.computeConvertedNetWorth(
+        in: session.profile.instrument)
+    } catch {
+      throw AutomationError.operationFailed(
+        "Failed to compute net worth: \(error.localizedDescription)")
+    }
+  }
+
+  /// Creates a new account in the given profile.
+  func createAccount(
+    profileIdentifier: String,
+    name: String,
+    type: AccountType,
+    isHidden: Bool = false
+  ) async throws -> Account {
+    let session = try resolveSession(for: profileIdentifier)
+    let instrument = session.profile.instrument
+    let account = Account(
+      id: UUID(),
+      name: name,
+      type: type,
+      instrument: instrument,
+      position: session.accountStore.accounts.count,
+      isHidden: isHidden
+    )
+    do {
+      return try await session.accountStore.create(account)
+    } catch {
+      throw AutomationError.operationFailed(
+        "Failed to create account: \(error.localizedDescription)")
+    }
+  }
+
+  /// Updates an existing account's name and/or hidden status.
+  func updateAccount(
+    profileIdentifier: String,
+    accountId: UUID,
+    changes: AccountChanges
+  ) async throws -> Account {
+    let session = try resolveSession(for: profileIdentifier)
+    guard var account = session.accountStore.accounts.by(id: accountId) else {
+      throw AutomationError.accountNotFound(accountId.uuidString)
+    }
+    if let name = changes.name { account.name = name }
+    if case .setTo(let hidden) = changes.hidden { account.isHidden = hidden }
+    do {
+      return try await session.accountStore.update(account)
+    } catch {
+      throw AutomationError.operationFailed(
+        "Failed to update account: \(error.localizedDescription)")
+    }
+  }
+
+  /// Deletes an account by UUID.
+  func deleteAccount(profileIdentifier: String, accountId: UUID) async throws {
+    let session = try resolveSession(for: profileIdentifier)
+    do {
+      try await session.accountStore.delete(id: accountId)
+    } catch {
+      throw AutomationError.operationFailed(
+        "Failed to delete account: \(error.localizedDescription)")
+    }
+  }
+}

--- a/Automation/AutomationService+Earmarks.swift
+++ b/Automation/AutomationService+Earmarks.swift
@@ -173,7 +173,8 @@ extension AutomationService {
     value: Decimal
   ) async throws {
     let session = try resolveSession(for: profileIdentifier)
-    let account = try resolveAccount(named: accountName, profileIdentifier: profileIdentifier)
+    let account = try await resolveAccount(
+      named: accountName, profileIdentifier: profileIdentifier)
 
     guard account.type == .investment else {
       throw AutomationError.invalidParameter(
@@ -188,7 +189,8 @@ extension AutomationService {
   /// Returns positions for a given investment account.
   func getPositions(profileIdentifier: String, accountName: String) async throws -> [Position] {
     let session = try resolveSession(for: profileIdentifier)
-    let account = try resolveAccount(named: accountName, profileIdentifier: profileIdentifier)
+    let account = try await resolveAccount(
+      named: accountName, profileIdentifier: profileIdentifier)
     await session.investmentStore.loadPositions(accountId: account.id)
     return session.investmentStore.positions
   }

--- a/Automation/AutomationService.swift
+++ b/Automation/AutomationService.swift
@@ -48,104 +48,6 @@ final class AutomationService {
     sessionManager.openProfiles.map(\.profile)
   }
 
-  // MARK: - Account Operations
-
-  /// Returns all accounts for the given profile.
-  func listAccounts(profileIdentifier: String) throws -> [Account] {
-    let session = try resolveSession(for: profileIdentifier)
-    return Array(session.accountStore.accounts)
-  }
-
-  /// Resolves an account by name (case-insensitive) within a profile.
-  func resolveAccount(named name: String, profileIdentifier: String) throws -> Account {
-    let session = try resolveSession(for: profileIdentifier)
-    let lowered = name.lowercased()
-    guard
-      let account = session.accountStore.accounts.first(where: { $0.name.lowercased() == lowered })
-    else {
-      throw AutomationError.accountNotFound(name)
-    }
-    return account
-  }
-
-  /// Resolves an account by UUID within a profile.
-  func resolveAccount(id: UUID, profileIdentifier: String) throws -> Account {
-    let session = try resolveSession(for: profileIdentifier)
-    guard let account = session.accountStore.accounts.by(id: id) else {
-      throw AutomationError.accountNotFound(id.uuidString)
-    }
-    return account
-  }
-
-  /// Returns the net worth (current + investment totals) for the given profile,
-  /// converted into the profile's instrument.
-  func getNetWorth(profileIdentifier: String) async throws -> InstrumentAmount {
-    let session = try resolveSession(for: profileIdentifier)
-    do {
-      return try await session.accountStore.computeConvertedNetWorth(
-        in: session.profile.instrument)
-    } catch {
-      throw AutomationError.operationFailed(
-        "Failed to compute net worth: \(error.localizedDescription)")
-    }
-  }
-
-  /// Creates a new account in the given profile.
-  func createAccount(
-    profileIdentifier: String,
-    name: String,
-    type: AccountType,
-    isHidden: Bool = false
-  ) async throws -> Account {
-    let session = try resolveSession(for: profileIdentifier)
-    let instrument = session.profile.instrument
-    let account = Account(
-      id: UUID(),
-      name: name,
-      type: type,
-      instrument: instrument,
-      position: session.accountStore.accounts.count,
-      isHidden: isHidden
-    )
-    do {
-      return try await session.accountStore.create(account)
-    } catch {
-      throw AutomationError.operationFailed(
-        "Failed to create account: \(error.localizedDescription)")
-    }
-  }
-
-  /// Updates an existing account's name and/or hidden status.
-  func updateAccount(
-    profileIdentifier: String,
-    accountId: UUID,
-    changes: AccountChanges
-  ) async throws -> Account {
-    let session = try resolveSession(for: profileIdentifier)
-    guard var account = session.accountStore.accounts.by(id: accountId) else {
-      throw AutomationError.accountNotFound(accountId.uuidString)
-    }
-    if let name = changes.name { account.name = name }
-    if case .setTo(let hidden) = changes.hidden { account.isHidden = hidden }
-    do {
-      return try await session.accountStore.update(account)
-    } catch {
-      throw AutomationError.operationFailed(
-        "Failed to update account: \(error.localizedDescription)")
-    }
-  }
-
-  /// Deletes an account by UUID.
-  func deleteAccount(profileIdentifier: String, accountId: UUID) async throws {
-    let session = try resolveSession(for: profileIdentifier)
-    do {
-      try await session.accountStore.delete(id: accountId)
-    } catch {
-      throw AutomationError.operationFailed(
-        "Failed to delete account: \(error.localizedDescription)")
-    }
-  }
-
   // MARK: - Transaction Operations
 
   /// Describes a single leg of a transaction for creation.
@@ -167,7 +69,7 @@ final class AutomationService {
     let session = try resolveSession(for: profileIdentifier)
     let instrument = session.profile.instrument
 
-    let resolution = try resolveLegs(
+    let resolution = try await resolveLegs(
       legs, profileIdentifier: profileIdentifier, instrument: instrument)
     let finalLegs = normaliseTransferLegs(resolution.legs, accountIds: resolution.accountIds)
 
@@ -189,12 +91,15 @@ final class AutomationService {
 
   private func resolveLegs(
     _ legs: [LegSpec], profileIdentifier: String, instrument: Instrument
-  ) throws -> (legs: [TransactionLeg], accountIds: Set<UUID>) {
+  ) async throws -> (legs: [TransactionLeg], accountIds: Set<UUID>) {
+    // Fetch the authoritative account snapshot once and resolve every leg
+    // against it (see `resolveAccount(named:)` for why this is a
+    // repository read rather than a reactive-store read).
+    let accounts = try await fetchAccounts(profileIdentifier: profileIdentifier)
     var resolvedLegs: [TransactionLeg] = []
     var accountIds = Set<UUID>()
     for spec in legs {
-      let account = try resolveAccount(
-        named: spec.accountName, profileIdentifier: profileIdentifier)
+      let account = try Self.account(named: spec.accountName, in: accounts)
       accountIds.insert(account.id)
 
       let categoryId: UUID? =
@@ -247,7 +152,8 @@ final class AutomationService {
 
     var filter = TransactionFilter()
     if let accountName {
-      let account = try resolveAccount(named: accountName, profileIdentifier: profileIdentifier)
+      let account = try await resolveAccount(
+        named: accountName, profileIdentifier: profileIdentifier)
       filter.accountId = account.id
     }
     filter.scheduled = scheduled

--- a/Features/Accounts/AccountStore+Observation.swift
+++ b/Features/Accounts/AccountStore+Observation.swift
@@ -99,13 +99,18 @@ extension AccountStore {
   /// teardown that races a tick exits before issuing a fetch. The
   /// task's lifetime is gated by `stopObserving()` / `deinit`, matching
   /// `observe()`.
+  ///
+  /// `snapshotGeneration` is captured *before* the `fetchAll()` so the
+  /// apply can be dropped if a fresher authoritative snapshot lands
+  /// while the fetch is in flight — see `applyInstrumentRegistryRefresh`.
   func observeInstrumentRegistryChanges(_ changes: AsyncStream<Void>) async {
     for await _ in changes {
-      if Task.isCancelled { return }
+      guard !Task.isCancelled else { return }
+      let observedGeneration = snapshotGeneration
       do {
         let fresh = try await repository.fetchAll()
-        if Task.isCancelled { return }
-        await applyAccountsSnapshot(fresh)
+        guard !Task.isCancelled else { return }
+        await applyInstrumentRegistryRefresh(fresh, observedGeneration: observedGeneration)
       } catch {
         surfaceObservationError(error)
       }
@@ -115,9 +120,34 @@ extension AccountStore {
   // MARK: - Entry-point shims
 
   /// Per-emission entry point invoked by the `accounts` subscription
-  /// driver above. Internal so the `addTask` body can call into
-  /// MainActor-isolated state across the file split.
-  func applyAccountsSnapshot(_ fresh: [Account]) async {
+  /// driver above. This is the **authoritative** snapshot source: it bumps
+  /// `snapshotGeneration` so a concurrent instrument-registry refetch can
+  /// detect that it raced a fresher snapshot.
+  private func applyAccountsSnapshot(_ fresh: [Account]) async {
+    bumpSnapshotGeneration()
+    await apply(accounts: fresh)
+  }
+
+  /// Applies an instrument-registry-triggered refetch, but only if no
+  /// authoritative `observeAll()` snapshot has landed since the fetch was
+  /// issued. The `fetchAll()` in `observeInstrumentRegistryChanges` runs
+  /// unordered with respect to `observeAll()`; if it read the database
+  /// before a concurrent write committed, its row set is stale. Applying
+  /// it after a fresher authoritative snapshot would clobber `accounts`
+  /// back to a pre-write state. The generation check and the assignment
+  /// inside `apply(accounts:)` run with no intervening suspension on the
+  /// main actor, so an authoritative snapshot cannot interleave between
+  /// the guard and the write — the only harmful ordering (stale refresh
+  /// applied *after* a fresh snapshot) is exactly the case the guard
+  /// drops. A refresh that lands *before* the next authoritative snapshot
+  /// is harmless: the authoritative apply overwrites it.
+  ///
+  /// Internal (not `private`) so the store's sync-refresh tests can drive
+  /// the guard path directly with a captured generation.
+  func applyInstrumentRegistryRefresh(
+    _ fresh: [Account], observedGeneration: UInt64
+  ) async {
+    guard snapshotGeneration == observedGeneration else { return }
     await apply(accounts: fresh)
   }
 

--- a/Features/Accounts/AccountStore.swift
+++ b/Features/Accounts/AccountStore.swift
@@ -68,6 +68,22 @@ final class AccountStore {
   private let instrumentChanges: (any InstrumentChangeObserving)?
   private var instrumentChangeObservationTask: Task<Void, Never>?
 
+  /// Monotonic counter over authoritative `observeAll()` snapshots. The
+  /// instrument-registry refresh path captures it before its `fetchAll()`
+  /// and drops a stale refetch that raced a fresher snapshot — see
+  /// `applyInstrumentRegistryRefresh` for the full rationale. `private(set)`
+  /// (only `bumpSnapshotGeneration()` writes it) + `@ObservationIgnored`
+  /// (a pure guard counter no view reads).
+  @ObservationIgnored private(set) var snapshotGeneration: UInt64 = 0
+
+  /// The single increment path for `snapshotGeneration`. Internal so the
+  /// authoritative apply shim in the sibling `+Observation` file can call
+  /// it; combined with the property's `private(set)`, every other site is
+  /// barred from mutating the guard counter at compile time.
+  func bumpSnapshotGeneration() {
+    snapshotGeneration &+= 1
+  }
+
   /// Background retry loop spawned by `recomputeConvertedTotals()` when
   /// a conversion pass reports any failure. Cancelled when a subsequent
   /// pass succeeds; otherwise continues until success or the store is

--- a/Features/Earmarks/EarmarkStore+Observation.swift
+++ b/Features/Earmarks/EarmarkStore+Observation.swift
@@ -23,7 +23,7 @@ extension EarmarkStore {
     await withTaskGroup(of: Void.self) { group in
       group.addTask { [self] in
         for await fresh in earmarksStream {
-          await self.apply(earmarks: fresh)
+          await self.applyEarmarksSnapshot(fresh)
         }
       }
       group.addTask { [self] in
@@ -54,16 +54,46 @@ extension EarmarkStore {
   /// so a teardown that races a tick exits before issuing a fetch. The
   /// task's lifetime is gated by `stopObserving()` / `deinit`, matching
   /// `observe()`.
+  ///
+  /// `snapshotGeneration` is captured *before* the `fetchAll()` so the
+  /// apply can be dropped if a fresher authoritative snapshot lands
+  /// while the fetch is in flight — see `applyInstrumentRegistryRefresh`.
   func observeInstrumentRegistryChanges(_ changes: AsyncStream<Void>) async {
     for await _ in changes {
-      if Task.isCancelled { return }
+      guard !Task.isCancelled else { return }
+      let observedGeneration = snapshotGeneration
       do {
         let fresh = try await repository.fetchAll()
-        if Task.isCancelled { return }
-        await apply(earmarks: fresh)
+        guard !Task.isCancelled else { return }
+        await applyInstrumentRegistryRefresh(fresh, observedGeneration: observedGeneration)
       } catch {
         surface(error: error)
       }
     }
+  }
+
+  /// **Authoritative** snapshot entry point driven by `observeAll()`. Bumps
+  /// `snapshotGeneration` so a concurrent instrument-registry refetch can
+  /// detect that it raced a fresher snapshot, then applies.
+  private func applyEarmarksSnapshot(_ fresh: [Earmark]) async {
+    bumpSnapshotGeneration()
+    await apply(earmarks: fresh)
+  }
+
+  /// Applies an instrument-registry-triggered refetch, but only if no
+  /// authoritative `observeAll()` snapshot has landed since the fetch was
+  /// issued. The `fetchAll()` runs unordered with respect to
+  /// `observeAll()`; if it read the database before a concurrent write
+  /// committed, its row set is stale and applying it after a fresher
+  /// authoritative snapshot would clobber `earmarks` back to a pre-write
+  /// state. The generation check and the assignment inside
+  /// `apply(earmarks:)` run with no intervening suspension on the main
+  /// actor, so an authoritative snapshot cannot interleave between the
+  /// guard and the write. See `AccountStore`'s twin for the full rationale.
+  func applyInstrumentRegistryRefresh(
+    _ fresh: [Earmark], observedGeneration: UInt64
+  ) async {
+    guard snapshotGeneration == observedGeneration else { return }
+    await apply(earmarks: fresh)
   }
 }

--- a/Features/Earmarks/EarmarkStore.swift
+++ b/Features/Earmarks/EarmarkStore.swift
@@ -5,6 +5,9 @@ import Observation
 @Observable
 @MainActor
 final class EarmarkStore {
+
+  // MARK: - State
+
   private(set) var earmarks = Earmarks(from: [])
   private(set) var error: Error?
 
@@ -58,6 +61,20 @@ final class EarmarkStore {
   /// alongside `observationTask`.
   private var instrumentChangeObservationTask: Task<Void, Never>?
 
+  /// Monotonic counter over authoritative `observeAll()` snapshots. The
+  /// instrument-registry refresh path captures it before its `fetchAll()`
+  /// and drops a stale refetch that raced a fresher snapshot — see
+  /// `applyInstrumentRegistryRefresh` (mirrors `AccountStore`). `private(set)`
+  /// (only `bumpSnapshotGeneration()` writes it) + `@ObservationIgnored`
+  /// (a pure guard counter no view reads).
+  @ObservationIgnored private(set) var snapshotGeneration: UInt64 = 0
+
+  /// The single increment path for `snapshotGeneration` — internal so the
+  /// `+Observation` apply shim can reach it past the property's `private(set)`.
+  func bumpSnapshotGeneration() {
+    snapshotGeneration &+= 1
+  }
+
   /// Background retry loop spawned by `recomputeConvertedTotals()` when
   /// a conversion pass reports any failure. Cancelled when a subsequent
   /// pass succeeds; otherwise continues until success or the store is
@@ -73,6 +90,8 @@ final class EarmarkStore {
   /// `@testable import Moolah` exposes it to the test target.
   let testObservationTickStream: AsyncStream<Void>
   private let testObservationTickContinuation: AsyncStream<Void>.Continuation
+
+  // MARK: - Lifecycle
 
   init(
     repository: EarmarkRepository,
@@ -123,6 +142,8 @@ final class EarmarkStore {
       testObservationTickContinuation.finish()
     }
   }
+
+  // MARK: - Observation & State Updates
 
   /// Applies a fresh earmarks snapshot from `observeAll()`. Wrapped in
   /// the Layer 7 signpost interval so benchmarks and Instruments traces

--- a/MoolahTests/Automation/AutomationServiceAccountTests.swift
+++ b/MoolahTests/Automation/AutomationServiceAccountTests.swift
@@ -58,19 +58,17 @@ struct AutomationServiceAccountTests {
 
   @Test("resolveAccount finds account by name case-insensitively")
   func resolveAccountByNameCaseInsensitive() async throws {
-    let (service, session) = try await makeServiceWithSession()
+    let (service, _) = try await makeServiceWithSession()
     _ = try await service.createAccount(
       profileIdentifier: "Test",
       name: "My Savings",
       type: .bank
     )
 
-    try await session.accountStore.waitForNextEmission(
-      matching: { $0.accounts.contains { $0.name == "My Savings" } },
-      description: "new account observable"
-    )
-
-    let resolved = try service.resolveAccount(named: "my savings", profileIdentifier: "Test")
+    // `resolveAccount` reads the authoritative repository snapshot, so it
+    // sees the committed account without waiting on the reactive store.
+    let resolved = try await service.resolveAccount(
+      named: "my savings", profileIdentifier: "Test")
     #expect(resolved.name == "My Savings")
   }
 
@@ -78,26 +76,22 @@ struct AutomationServiceAccountTests {
   func resolveAccountNotFoundThrows() async throws {
     let (service, _) = try await makeServiceWithSession()
 
-    #expect(throws: AutomationError.self) {
-      try service.resolveAccount(named: "NonExistent", profileIdentifier: "Test")
+    await #expect(throws: AutomationError.self) {
+      try await service.resolveAccount(named: "NonExistent", profileIdentifier: "Test")
     }
   }
 
   @Test("resolveAccount finds account by UUID")
   func resolveAccountByUUID() async throws {
-    let (service, session) = try await makeServiceWithSession()
+    let (service, _) = try await makeServiceWithSession()
     let created = try await service.createAccount(
       profileIdentifier: "Test",
       name: "Checking",
       type: .bank
     )
 
-    try await session.accountStore.waitForNextEmission(
-      matching: { $0.accounts.by(id: created.id) != nil },
-      description: "new account observable"
-    )
-
-    let resolved = try service.resolveAccount(id: created.id, profileIdentifier: "Test")
+    // Authoritative repository read — no need to wait on the reactive store.
+    let resolved = try await service.resolveAccount(id: created.id, profileIdentifier: "Test")
     #expect(resolved.name == "Checking")
   }
 

--- a/MoolahTests/Automation/AutomationServiceTransactionTests.swift
+++ b/MoolahTests/Automation/AutomationServiceTransactionTests.swift
@@ -33,17 +33,15 @@ struct AutomationServiceTransactionTests {
 
   @Test("createTransaction creates a single-leg transaction")
   func createSingleLegTransaction() async throws {
-    let (service, session) = try await makeServiceWithSession()
+    let (service, _) = try await makeServiceWithSession()
 
-    // Create an account first
+    // Create an account first. `createTransaction` resolves the account
+    // from the authoritative repository snapshot, so there's no need to
+    // wait on the reactive `accountStore` before referencing it.
     _ = try await service.createAccount(
       profileIdentifier: "Test",
       name: "Checking",
       type: .bank
-    )
-    try await session.accountStore.waitForNextEmission(
-      matching: { $0.accounts.contains { $0.name == "Checking" } },
-      description: "new account observable"
     )
 
     let transaction = try await service.createTransaction(
@@ -70,16 +68,12 @@ struct AutomationServiceTransactionTests {
 
   @Test("listTransactions returns created transactions")
   func listTransactions() async throws {
-    let (service, session) = try await makeServiceWithSession()
+    let (service, _) = try await makeServiceWithSession()
 
     _ = try await service.createAccount(
       profileIdentifier: "Test",
       name: "Checking",
       type: .bank
-    )
-    try await session.accountStore.waitForNextEmission(
-      matching: { $0.accounts.contains { $0.name == "Checking" } },
-      description: "new account observable"
     )
 
     _ = try await service.createTransaction(
@@ -103,16 +97,12 @@ struct AutomationServiceTransactionTests {
 
   @Test("createTransaction with positive amount creates income")
   func createIncomeTransaction() async throws {
-    let (service, session) = try await makeServiceWithSession()
+    let (service, _) = try await makeServiceWithSession()
 
     _ = try await service.createAccount(
       profileIdentifier: "Test",
       name: "Checking",
       type: .bank
-    )
-    try await session.accountStore.waitForNextEmission(
-      matching: { $0.accounts.contains { $0.name == "Checking" } },
-      description: "new account observable"
     )
 
     let transaction = try await service.createTransaction(

--- a/MoolahTests/Features/Accounts/AccountStoreSyncRefreshTests.swift
+++ b/MoolahTests/Features/Accounts/AccountStoreSyncRefreshTests.swift
@@ -229,6 +229,81 @@ struct AccountStoreSyncRefreshTests {
     )
   }
 
+  @Test("stale instrument-registry refresh does not clobber a fresher accounts snapshot")
+  func staleRegistryRefreshIsDropped() async throws {
+    // Regression for the `AutomationServiceAccountTests` flake: the
+    // instrument-registry refresh path runs `repository.fetchAll()`
+    // unordered with respect to `observeAll()`. A `fetchAll()` that read
+    // the database before a concurrent write committed returns a stale
+    // (here: empty) row set; without the generation guard, applying it
+    // after a fresher authoritative snapshot would clobber `accounts`
+    // back to the pre-write state. The guard must drop the stale apply.
+    let (backend, _) = try TestBackend.create()
+    let store = AccountStore(
+      repository: backend.accounts,
+      conversionService: FixedConversionService(),
+      targetInstrument: .defaultTestInstrument
+    )
+    let first = try await backend.accounts.create(
+      Account(name: "First", type: .bank, instrument: .defaultTestInstrument),
+      openingBalance: nil
+    )
+    try await store.waitForNextEmission(
+      matching: { $0.accounts.by(id: first.id) != nil },
+      description: "first account visible"
+    )
+
+    // The registry path captures the generation BEFORE its fetch.
+    let observedGeneration = store.snapshotGeneration
+
+    // An authoritative `observeAll()` snapshot lands while the (simulated)
+    // stale fetch is still in flight, bumping the generation.
+    let second = try await backend.accounts.create(
+      Account(name: "Second", type: .bank, instrument: .defaultTestInstrument),
+      openingBalance: nil
+    )
+    try await store.waitForNextEmission(
+      matching: { $0.accounts.by(id: second.id) != nil },
+      description: "second account visible"
+    )
+
+    // The stale, empty refetch resolves last. It must be dropped, not
+    // applied — both accounts survive.
+    await store.applyInstrumentRegistryRefresh([], observedGeneration: observedGeneration)
+    #expect(store.accounts.by(id: first.id) != nil)
+    #expect(store.accounts.by(id: second.id) != nil)
+  }
+
+  @Test("up-to-date instrument-registry refresh applies")
+  func currentRegistryRefreshApplies() async throws {
+    // Companion to `staleRegistryRefreshIsDropped`: when no authoritative
+    // snapshot has landed since the fetch was issued, the refresh applies
+    // (this is the live-instrument-metadata refresh the path exists for).
+    let (backend, _) = try TestBackend.create()
+    let store = AccountStore(
+      repository: backend.accounts,
+      conversionService: FixedConversionService(),
+      targetInstrument: .defaultTestInstrument
+    )
+    let account = try await backend.accounts.create(
+      Account(name: "Original", type: .bank, instrument: .defaultTestInstrument),
+      openingBalance: nil
+    )
+    try await store.waitForNextEmission(
+      matching: { $0.accounts.by(id: account.id) != nil },
+      description: "account visible"
+    )
+
+    // Capture the current generation and apply a refresh tagged with it —
+    // simulating a fetch that observed the latest snapshot. A renamed copy
+    // proves the refresh was applied rather than dropped.
+    let observedGeneration = store.snapshotGeneration
+    var renamed = account
+    renamed.name = "Renamed"
+    await store.applyInstrumentRegistryRefresh([renamed], observedGeneration: observedGeneration)
+    #expect(store.accounts.by(id: account.id)?.name == "Renamed")
+  }
+
   @Test("GRDB wipes during sign-out reach the store before stopObserving cancels it")
   func signOutTeardownOrdering() async throws {
     let (backend, database) = try TestBackend.create()


### PR DESCRIPTION
## Problem

`AutomationServiceAccountTests "resolveAccount finds account by UUID"` flaked under full-suite parallel load ([CI run 26993449274](https://github.com/moolah-rocks/moolah-native/actions/runs/26993449274/job/79658221715)), throwing `.accountNotFound` for an account it had just created and *observed*.

## Root cause

`AccountStore` (and `EarmarkStore`) have **two unordered writers** of their published row list:
1. the authoritative `repository.observeAll()` stream, and
2. a registry-change-triggered `repository.fetchAll()` (`observeInstrumentRegistryChanges`).

`ProfileSession.init` seeds crypto presets on a background `Task`, which fires the shared-registry change. That handler's `fetchAll()` can read the DB **before** a just-created account commits (returning an empty row set) and then apply that stale snapshot **after** `observeAll()` already delivered the account — blanking `accounts`. `AutomationService.resolveAccount` reads that clobbered snapshot synchronously and throws.

Reproduced locally under full-suite load (~1 in 3 runs) with temporary instrumentation; confirmed the stale `fetchAll()=0` apply clobbering `prev=1`.

## Fix (two complementary layers)

1. **Store race guard.** `AccountStore`/`EarmarkStore` gain `@ObservationIgnored private(set) var snapshotGeneration`, bumped by the authoritative `observeAll()` apply. The registry-refetch path captures the generation before its `fetchAll()` and drops its apply if a fresher authoritative snapshot landed meanwhile. The guard check and the `accounts =` assignment run with no intervening main-actor suspension, so a stale refetch can never win. This also fixes the real (cosmetic) UI race where the sidebar could momentarily blank right after creating the first account.
2. **Authoritative automation reads.** `AutomationService` account ops move to `AutomationService+Accounts.swift`; `resolveAccount(named:/id:)` is now `async` and reads `backend.accounts.fetchAll()` instead of the eventually-consistent reactive store — automation is a scripted read-after-write context.

## Tests

- New deterministic regression tests in `AccountStoreSyncRefreshTests`: `staleRegistryRefreshIsDropped` (guard drops a stale refetch) and `currentRegistryRefreshApplies` (pass-through when current).
- Validation: 8/8 full-suite runs with zero Automation-suite failures (vs ~1-in-3 before).

## Reviews

`concurrency-review` (atomicity claim verified) and `code-review` agents run; all findings applied. Extending the authoritative-read pattern to `resolveEarmark`/`resolveCategory` (same read-after-write class) is deferred to #1057.

> Note: unrelated pre-existing timezone-seam failures (`DomainModelsTests`, `StockPriceServiceTests`) surface locally in UTC-negative zones but pass on UTC CI — being fixed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)