### PR TITLE
Polish insight detail sheet: consistent footer buttons, right-sized height

### DIFF
--- a/Features/Insights/Views/InsightChartDetailSheet.swift
+++ b/Features/Insights/Views/InsightChartDetailSheet.swift
@@ -33,7 +33,13 @@ struct InsightChartDetailSheet: View {
     .padding(24)
     .dynamicTypeSize(.medium ... .accessibility3)
     #if os(macOS)
-      .frame(minWidth: 420, minHeight: 420)
+      // A floor, not a fixed height: the sheet grows to fit its content (so a
+      // tall chart or large Dynamic Type is never clipped — no scroll view
+      // needed). The floor only stops the sheet collapsing into a cramped
+      // panel. A charted insight needs room for the expanded graph; a
+      // chart-less one is just header + facts + actions, so a smaller floor
+      // avoids dead space below short content.
+      .frame(minWidth: 420, minHeight: insight.chart == nil ? 240 : 360)
     #endif
     #if os(iOS)
       .presentationDetents([.medium, .large])
@@ -100,6 +106,9 @@ struct InsightChartDetailSheet: View {
         } label: {
           Label("View", systemImage: "arrow.forward")
         }
+        // Both footer actions share the same borderless, tinted weight as the
+        // "Show less" sibling.
+        .buttonStyle(.borderless)
         .help("View \(headline)")
         .accessibilityLabel("View \(headline)")
       }
@@ -158,6 +167,9 @@ struct InsightChartDetailSheet: View {
           InsightFact("This month", "$742"),
           InsightFact("Expected", "$458"),
         ],
+        // A category-spending insight deep-links to the categories view, so the
+        // footer shows both "Show less" and "View".
+        references: InsightReferences(categoryIds: [UUID()]),
         chart: chart)
     }
 
@@ -173,6 +185,21 @@ struct InsightChartDetailSheet: View {
         surprise: 0.5,
         facts: [InsightFact("Net worth", "$101,000")])
     }
+
+    /// A chart-less insight that *does* deep-link, so the footer shows both
+    /// actions. Short enough to exercise the adaptive `minHeight` floor.
+    static var previewLargeCharge: Insight {
+      Insight(
+        id: "preview3",
+        kind: .largeTransactionAnomaly,
+        title: "Large charge",
+        date: Date(),
+        framing: .negative,
+        actionability: .review,
+        surprise: 0.7,
+        facts: [InsightFact("Amount", "$2,499"), InsightFact("Usual", "$120")],
+        references: InsightReferences(accountIds: [UUID()]))
+    }
   }
 
   #Preview("Negative · chart + facts") {
@@ -180,13 +207,25 @@ struct InsightChartDetailSheet: View {
       insight: .previewDiningAnomaly,
       headline: "Dining out is up 62% this month",
       onNavigate: { _ in },
-      onDismiss: {})
+      onDismiss: {}
+    )
+    // Size the canvas to a representative real-sheet height so the header and
+    // footer aren't clipped (the charted content is taller than the default).
+    .frame(width: 500, height: 560)
   }
 
   #Preview("Positive · no chart, no View button") {
     InsightChartDetailSheet(
       insight: .previewNetWorthMilestone,
       headline: "Net worth crossed $100k",
+      onNavigate: { _ in },
+      onDismiss: {})
+  }
+
+  #Preview("Negative · no chart, both actions") {
+    InsightChartDetailSheet(
+      insight: .previewLargeCharge,
+      headline: "You spent $2,499 at the Apple Store, far above your usual $120.",
       onNavigate: { _ in },
       onDismiss: {})
   }


### PR DESCRIPTION
Follow-up to #1056 — addresses pre-existing rough edges on the zoomed insight detail sheet (`InsightChartDetailSheet.swift`) that a UI review surfaced while reviewing the companion-graph panels.

## Changes

**1. Consistent footer buttons.** The footer "View" button had no `.buttonStyle`, so on macOS it resolved to `.bordered` while its "Show less" sibling was `.borderless` — two equally-weighted secondary actions rendering at different prominence. "View" is now `.borderless` to match.

**2. Right-sized sheet height.** The macOS sheet used a flat `.frame(minHeight: 420)` — the guide's "wizard / multi-step flow" size (UI_GUIDE §6) — which left dead space below short, chart-less insights. The floor is now adaptive: `minHeight: insight.chart == nil ? 240 : 360`.

`minHeight` is only a *floor*: the sheet still grows to fit a tall chart or large Dynamic Type, so nothing is clipped and **no `ScrollView` is needed** — a nested scroll inside the already-scrolling Analysis page would be awkward (per design discussion).

**3. Preview coverage for the "View" button**, which had none — both existing fixtures had no navigation target. Gave the charted fixture a category reference (realistic for a category-spending insight) and added a short chart-less fixture that deep-links, so both footer actions now render in previews.

## Verification

- `#Preview` rendered: charted sheet (header + chart + facts + both footer actions, no clipping) and the chart-less + deep-linked variant — both footer buttons now the same borderless weight.
- `InsightChartUITests` (opens this sheet) passes; `just build-mac` + `just format-check` clean.
- Real-sheet height is a `minHeight` floor reduction, verified by construction — the preview canvas fills its window so it can't visualise actual sheet sizing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)