### PR TITLE
Insights: companion charge-history chart for recurring streams

### DIFF
--- a/Domain/Insights/Detectors/IncomeExtraInsights.swift
+++ b/Domain/Insights/Detectors/IncomeExtraInsights.swift
@@ -89,7 +89,8 @@ enum IncomeExtraInsights {
           InsightFact("Previous", context.formatted(Decimal(priorMedian))),
           InsightFact("Change", "\(increased ? "+" : "−")\(percent(abs(change)))"),
         ],
-        references: InsightReferences(accountIds: stream.accountId.map { [$0] } ?? []))
+        references: InsightReferences(accountIds: stream.accountId.map { [$0] } ?? []),
+        chart: stream.chargeChart(reportingCurrency: context.reportingCurrency))
     ]
   }
 

--- a/Domain/Insights/Detectors/IncomeInsights.swift
+++ b/Domain/Insights/Detectors/IncomeInsights.swift
@@ -53,7 +53,8 @@ enum IncomeInsights {
         InsightFact("Next expected", dateText),
       ],
       references: InsightReferences(
-        accountIds: stream.accountId.map { [$0] } ?? []))
+        accountIds: stream.accountId.map { [$0] } ?? []),
+      chart: stream.chargeChart(reportingCurrency: context.reportingCurrency))
   }
 
   /// Income stability score (29): lower amount variation → higher score.
@@ -90,7 +91,8 @@ enum IncomeInsights {
         InsightFact("Variation", percent(variation)),
       ],
       references: InsightReferences(
-        accountIds: stream.accountId.map { [$0] } ?? []))
+        accountIds: stream.accountId.map { [$0] } ?? []),
+      chart: stream.chargeChart(reportingCurrency: context.reportingCurrency))
   }
 
   /// Missing-paycheck alert (30): expected pay overdue past the grace window.

--- a/Domain/Insights/Detectors/SubscriptionInsights.swift
+++ b/Domain/Insights/Detectors/SubscriptionInsights.swift
@@ -68,7 +68,8 @@ enum SubscriptionInsights {
           InsightFact("Increase", percent(increase)),
           InsightFact("Extra per month", context.formatted(monthlyDelta)),
         ],
-        references: references(for: subscription))
+        references: references(for: subscription),
+        chart: subscription.chargeChart(reportingCurrency: context.reportingCurrency))
     }
   }
 

--- a/Domain/Insights/InsightChartBuilders.swift
+++ b/Domain/Insights/InsightChartBuilders.swift
@@ -95,6 +95,36 @@ enum InsightChartBuilders {
       xAxis: .daily)
   }
 
+  /// A recurring stream's charge (or income) magnitude over its occurrence
+  /// dates, as a line with the latest occurrence highlighted — the trend a
+  /// price-hike, pay-rate-change, paycheck-timing, or income-stability insight
+  /// is built from. The chart plots positive magnitudes (signed `amounts` are
+  /// negative for an expense stream) so a rising charge reads as a rising line.
+  /// The caller passes `dates` and `amounts` parallel and chronological (the
+  /// detector builds both from one sorted occurrence list); the length guard is
+  /// defensive and returns `nil` rather than mis-pairing if they disagree.
+  static func recurringCharges(
+    dates: [Date],
+    amounts: [Decimal],
+    reportingCurrency: Instrument,
+    isIncome: Bool
+  ) -> InsightChart? {
+    guard dates.count == amounts.count, dates.count >= minimumPoints else { return nil }
+    let points = zip(dates, amounts).map { date, amount -> InsightChart.Point in
+      let signed = Double(truncating: amount as NSDecimalNumber)
+      return InsightChart.Point(date: date, value: max(isIncome ? signed : -signed, 0))
+    }
+    return InsightChart(
+      kind: .line,
+      unit: .currency(reportingCurrency),
+      series: [
+        InsightChart.Series(
+          id: "charges", label: isIncome ? "Income" : "Charge", role: .primary, points: points)
+      ],
+      highlight: points.last,
+      xAxis: .daily)
+  }
+
   /// Monthly savings rate as a percentage line, highlighting the latest month.
   static func savingsRate(points: [InsightChart.Point]) -> InsightChart? {
     guard points.count >= minimumPoints else { return nil }

--- a/Domain/Insights/Subscriptions/DetectedSubscription.swift
+++ b/Domain/Insights/Subscriptions/DetectedSubscription.swift
@@ -84,9 +84,22 @@ struct DetectedSubscription: Sendable, Identifiable, Hashable {
   let medianIntervalDays: Double
   let medianAmount: Decimal
   let latestAmount: Decimal
-  /// Chronological signed amounts, for price-hike comparison and narration.
-  let amounts: [Decimal]
+  /// Chronological charges, each a signed amount paired with the day it landed.
+  /// One array keeps the amount and its date inseparable — a companion chart
+  /// plots each charge at its date, and the detectors read the amounts for
+  /// price-hike / pay-rate comparison.
+  let occurrences: [Occurrence]
   let isIncome: Bool
+
+  /// One charge in a recurring stream: a signed amount and the day it landed.
+  struct Occurrence: Sendable, Hashable {
+    let date: Date
+    /// Signed, reporting currency (income positive, expense negative).
+    let amount: Decimal
+  }
+
+  /// Chronological signed amounts, for price-hike comparison and narration.
+  var amounts: [Decimal] { occurrences.map(\.amount) }
 
   /// Monthly-equivalent magnitude (always positive), for cost roll-ups.
   var monthlyCostMagnitude: Decimal {
@@ -98,5 +111,16 @@ struct DetectedSubscription: Sendable, Identifiable, Hashable {
   func nextExpectedDate(calendar: Calendar) -> Date? {
     calendar.date(
       byAdding: .day, value: Int(medianIntervalDays.rounded()), to: lastDate)
+  }
+
+  /// A companion charge-magnitude chart for this stream, so each detector can
+  /// attach one without re-deriving the stream's sign (`isIncome`) or the
+  /// sparse-data guard. `nil` when too sparse to plot.
+  func chargeChart(reportingCurrency: Instrument) -> InsightChart? {
+    InsightChartBuilders.recurringCharges(
+      dates: occurrences.map(\.date),
+      amounts: occurrences.map(\.amount),
+      reportingCurrency: reportingCurrency,
+      isIncome: isIncome)
   }
 }

--- a/Domain/Insights/Subscriptions/SubscriptionDetector.swift
+++ b/Domain/Insights/Subscriptions/SubscriptionDetector.swift
@@ -108,7 +108,9 @@ enum SubscriptionDetector {
       medianIntervalDays: medianInterval,
       medianAmount: medianAmount,
       latestAmount: amounts.last ?? medianAmount,
-      amounts: amounts,
+      occurrences: occ.map {
+        DetectedSubscription.Occurrence(date: $0.date, amount: $0.amount.quantity)
+      },
       isIncome: incomeStreams)
   }
 

--- a/MoolahTests/Domain/Insights/AdditionalInsightTests.swift
+++ b/MoolahTests/Domain/Insights/AdditionalInsightTests.swift
@@ -89,6 +89,12 @@ struct AdditionalInsightTests {
       IncomeExtraInsights.payRateChange(incomeStreams: streams, context: context).first)
     #expect(insight.kind == .payRateChange)
     #expect(insight.framing == .positive)
+    let chart = try #require(insight.chart)
+    #expect(chart.kind == .line)
+    #expect(chart.unit == .currency(InsightTestSupport.currency))
+    #expect(chart.series.first?.points.count == 4)
+    // The latest (raised) paycheck is highlighted at its positive amount.
+    #expect(chart.highlight?.value == 3300)
   }
 
   // MARK: - Spend habits

--- a/MoolahTests/Domain/Insights/IncomeInsightTests.swift
+++ b/MoolahTests/Domain/Insights/IncomeInsightTests.swift
@@ -49,4 +49,25 @@ struct IncomeInsightTests {
     let stability = try #require(insights.first { $0.kind == .incomeStabilityScore })
     #expect(stability.framing == .positive)
   }
+
+  @Test
+  func paycheckTimingAndStabilityAttachIncomeCharts() throws {
+    let transactions = [
+      InsightTestSupport.income(3000, payee: "ACME Payroll", daysAgo: 28),
+      InsightTestSupport.income(3000, payee: "ACME Payroll", daysAgo: 14),
+      InsightTestSupport.income(3000, payee: "ACME Payroll", daysAgo: 0),
+    ]
+    let insights = IncomeInsights.detect(incomeStreams: streams(transactions), context: context)
+
+    let timing = try #require(insights.first { $0.kind == .paycheckTimingPattern })
+    let timingChart = try #require(timing.chart)
+    #expect(timingChart.kind == .line)
+    #expect(timingChart.unit == .currency(InsightTestSupport.currency))
+    #expect(timingChart.highlight?.value == 3000)
+
+    let stability = try #require(insights.first { $0.kind == .incomeStabilityScore })
+    let stabilityChart = try #require(stability.chart)
+    #expect(stabilityChart.series.first?.points.count == 3)
+    #expect(stabilityChart.highlight?.value == 3000)
+  }
 }

--- a/MoolahTests/Domain/Insights/RecurringChargesChartTests.swift
+++ b/MoolahTests/Domain/Insights/RecurringChargesChartTests.swift
@@ -1,0 +1,57 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("Recurring-charge chart builder")
+struct RecurringChargesChartTests {
+  private let currency = InsightTestSupport.currency
+
+  @Test
+  func recurringChargesPlotsExpenseMagnitudeAndHighlightsLatest() throws {
+    let dates = [
+      InsightTestSupport.date(2026, 3, 1),
+      InsightTestSupport.date(2026, 4, 1),
+      InsightTestSupport.date(2026, 5, 1),
+    ]
+    // Expense stream: signed negative; the chart plots positive charge magnitude
+    // so a price hike reads as a rising line.
+    let chart = try #require(
+      InsightChartBuilders.recurringCharges(
+        dates: dates, amounts: [-10, -10, -12], reportingCurrency: currency, isIncome: false))
+
+    #expect(chart.kind == .line)
+    #expect(chart.unit == .currency(currency))
+    #expect(chart.xAxis == .daily)
+    #expect(chart.series.first?.id == "charges")
+    #expect(chart.series.first?.points.map(\.value) == [10, 10, 12])
+    #expect(chart.highlight?.value == 12)
+    #expect(chart.highlight?.date == InsightTestSupport.date(2026, 5, 1))
+  }
+
+  @Test
+  func recurringChargesKeepsIncomePositive() throws {
+    let dates = [InsightTestSupport.date(2026, 4, 1), InsightTestSupport.date(2026, 5, 1)]
+    let chart = try #require(
+      InsightChartBuilders.recurringCharges(
+        dates: dates, amounts: [3000, 3300], reportingCurrency: currency, isIncome: true))
+    #expect(chart.series.first?.points.map(\.value) == [3000, 3300])
+    #expect(chart.highlight?.value == 3300)
+  }
+
+  @Test
+  func recurringChargesIsNilBelowTwoPoints() {
+    #expect(
+      InsightChartBuilders.recurringCharges(
+        dates: [InsightTestSupport.now], amounts: [-10], reportingCurrency: currency,
+        isIncome: false) == nil)
+  }
+
+  @Test
+  func recurringChargesIsNilWhenDatesAndAmountsMisalign() {
+    #expect(
+      InsightChartBuilders.recurringCharges(
+        dates: [InsightTestSupport.date(2026, 4, 1), InsightTestSupport.date(2026, 5, 1)],
+        amounts: [-10], reportingCurrency: currency, isIncome: false) == nil)
+  }
+}

--- a/MoolahTests/Domain/Insights/SubscriptionInsightsTests.swift
+++ b/MoolahTests/Domain/Insights/SubscriptionInsightsTests.swift
@@ -48,6 +48,24 @@ struct SubscriptionInsightsTests {
   }
 
   @Test
+  func priceHikeAttachesChargeChart() throws {
+    let transactions = [
+      InsightTestSupport.expense(10, payee: "CloudStore", daysAgo: 90),
+      InsightTestSupport.expense(10, payee: "CloudStore", daysAgo: 60),
+      InsightTestSupport.expense(10, payee: "CloudStore", daysAgo: 30),
+      InsightTestSupport.expense(12, payee: "CloudStore", daysAgo: 0),
+    ]
+    let hike = try #require(
+      SubscriptionInsights.priceHikes(detect(transactions), context: context).first)
+    let chart = try #require(hike.chart)
+    #expect(chart.kind == .line)
+    #expect(chart.unit == .currency(InsightTestSupport.currency))
+    #expect(chart.series.first?.points.count == 4)
+    // The latest (hiked) charge is highlighted, plotted as a positive magnitude.
+    #expect(chart.highlight?.value == 12)
+  }
+
+  @Test
   func priceHikeQuietWhenStable() {
     let transactions = (0..<4).map { index in
       InsightTestSupport.expense(10, payee: "CloudStore", daysAgo: index * 30)


### PR DESCRIPTION
Extends the insight companion-graphs feature (framework [#1053](https://github.com/moolah-rocks/moolah-native/pull/1053)) to the **recurring-stream** family — PR 3 of 4 (follows [#1054](https://github.com/moolah-rocks/moolah-native/pull/1054), [#1055](https://github.com/moolah-rocks/moolah-native/pull/1055)).

## What

Four insight kinds gain a line chart of the stream's charge (or income) magnitude over its occurrence dates, latest highlighted:

- `subscriptionPriceHike` (`SubscriptionInsights`)
- `payRateChange` (`IncomeExtraInsights`)
- `paycheckTimingPattern` + `incomeStabilityScore` (`IncomeInsights`)

A rising charge reads as a rising line: expense amounts are signed negative and the new builder plots **positive magnitudes** via a sign-aware flip `max(isIncome ? signed : -signed, 0)` — no `abs()`, matching `CategorySpendSeries`.

## How

- New pure builder `InsightChartBuilders.recurringCharges(dates:amounts:reportingCurrency:isIncome:)` — `nil` below two points or on a dates/amounts length mismatch.
- `DetectedSubscription` now stores its charges as `[Occurrence]` (date + signed amount) instead of a bare `[Decimal] amounts`. This **surfaces the occurrence dates the detector already computes** (no new aggregation) and removes the parallel-array invariant the reviewer flagged. `amounts` remains as a computed accessor, so the statistics detectors are untouched.
- A `DetectedSubscription.chargeChart(reportingCurrency:)` model helper centralises the sign and the sparse-guard so each detector attaches the chart in one line.

## Tests

- Builder unit tests: expense magnitude + latest highlight, income positivity, sparse `nil`, misaligned-length `nil`.
- Detector-level tests across all four kinds assert the chart attaches with the line / `.currency` unit and the latest-occurrence highlight.
- `InsightEngineTests` (full pipeline) still green after the `Occurrence` reshape.

## Review notes

`@code-review` + `@concurrency-review` run clean. Applied: the `[Occurrence]` reshape (I3), removed the redundant in-builder sort and documented the chronological contract (I1), and the doc-comment fixes (M1–M3). One Important finding (I2: prefer a new `Decimal.doubleValue` extension over `Double(truncating:)`) was **not** applied — the whole insight layer, including `InstrumentAmount.doubleValue` and the sibling `CategorySpendSeries`, uses `Double(truncating: … as NSDecimalNumber)`; switching only this builder would make it the inconsistent outlier, and a new shared extension is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)