### PR TITLE
Insights: companion monthly-fee chart for fee-spend

### DIFF
--- a/Domain/Insights/Detectors/SavingsOpportunityInsights.swift
+++ b/Domain/Insights/Detectors/SavingsOpportunityInsights.swift
@@ -16,6 +16,7 @@ enum SavingsOpportunityInsights {
   /// is signed (negative for real spend) and never re-negated here.
   static func feeSpend(
     feeCategorySpend: [CategorySpendSummary],
+    expenseBreakdown: [ExpenseBreakdown],
     context: InsightContext
   ) -> [Insight] {
     let fees = feeCategorySpend.filter { isFeeCategory($0.categoryPath) }
@@ -24,7 +25,7 @@ enum SavingsOpportunityInsights {
     guard total.quantity < 0 else { return [] }
     let legCount = fees.reduce(0) { $0 + $1.legCount }
 
-    let categoryIds = Array(Set(fees.compactMap(\.categoryId)))
+    let feeCategoryIds = Set(fees.compactMap(\.categoryId))
     return [
       Insight(
         id:
@@ -45,7 +46,12 @@ enum SavingsOpportunityInsights {
           InsightFact("Transactions", "\(legCount)"),
         ],
         references: InsightReferences(
-          categoryIds: categoryIds, instrumentIds: [context.reportingCurrency.id]))
+          categoryIds: Array(feeCategoryIds), instrumentIds: [context.reportingCurrency.id]),
+        chart: InsightChartBuilders.monthlyCategorySpend(
+          expenseBreakdown: expenseBreakdown,
+          categoryIds: feeCategoryIds,
+          reportingCurrency: context.reportingCurrency,
+          seriesLabel: "Fees"))
     ]
   }
 

--- a/Domain/Insights/InsightChartBuilders.swift
+++ b/Domain/Insights/InsightChartBuilders.swift
@@ -141,6 +141,35 @@ enum InsightChartBuilders {
     return InsightChart.Point(date: date, value: max(-signed, 0))
   }
 
+  /// Combined monthly spend across a set of categories (e.g. every fee-like
+  /// category), as a bar chart with the latest month highlighted. Sums the
+  /// matching `expenseBreakdown` rows per financial month via
+  /// `CategorySpendSeries` (gap-filled, positive magnitudes); `nil` when no
+  /// rows match or fewer than two months remain. The caller names the series
+  /// (`seriesLabel`) — the builder is category-agnostic.
+  static func monthlyCategorySpend(
+    expenseBreakdown: [ExpenseBreakdown],
+    categoryIds: Set<UUID>,
+    reportingCurrency: Instrument,
+    seriesLabel: String
+  ) -> InsightChart? {
+    let rows = expenseBreakdown.filter { row in
+      row.categoryId.map(categoryIds.contains) ?? false
+    }
+    let points = CategorySpendSeries.total(from: rows)
+    guard points.count >= minimumPoints else { return nil }
+    let chartPoints = points.map { InsightChart.Point(date: $0.date, value: $0.magnitude) }
+    return InsightChart(
+      kind: .bar,
+      unit: .currency(reportingCurrency),
+      series: [
+        InsightChart.Series(
+          id: seriesLabel.lowercased(), label: seriesLabel, role: .primary, points: chartPoints)
+      ],
+      highlight: chartPoints.last,
+      xAxis: .monthly)
+  }
+
   /// A category's monthly spend (positive magnitudes), as a bar chart with the
   /// anomalous / latest financial month highlighted.
   static func categorySpend(

--- a/Domain/Insights/InsightEngine.swift
+++ b/Domain/Insights/InsightEngine.swift
@@ -91,7 +91,9 @@ struct InsightEngine: Sendable {
     insights += CategoryAnomalyInsight.detect(
       breakdown: input.expenseBreakdown, categories: input.categories, context: context)
     insights += SavingsOpportunityInsights.feeSpend(
-      feeCategorySpend: input.feeCategorySpend, context: context)
+      feeCategorySpend: input.feeCategorySpend,
+      expenseBreakdown: input.expenseBreakdown,
+      context: context)
     return insights
   }
 

--- a/Domain/Models/ExpenseBreakdown.swift
+++ b/Domain/Models/ExpenseBreakdown.swift
@@ -11,7 +11,9 @@ struct ExpenseBreakdown: Sendable, Codable, Identifiable, Hashable {
   /// Grouped by user's monthEnd preference (e.g., Jan 26 – Feb 25 = "202602")
   let month: String
 
-  /// Total expenses in cents (always positive, sum of transaction amounts)
+  /// Signed sum of the month's expense legs — negative for net spend (a
+  /// net-refund month can be positive), matching the project's sign
+  /// convention. Use `CategorySpendSeries` to derive positive spend magnitudes.
   let totalExpenses: InstrumentAmount
 }
 

--- a/MoolahTests/Domain/Insights/FinanceInsightTests.swift
+++ b/MoolahTests/Domain/Insights/FinanceInsightTests.swift
@@ -219,8 +219,34 @@ struct FinanceInsightTests {
         total: InsightTestSupport.amount(-200), legCount: 1),
     ]
     let insights = SavingsOpportunityInsights.feeSpend(
-      feeCategorySpend: feeCategorySpend, context: context)
+      feeCategorySpend: feeCategorySpend, expenseBreakdown: [], context: context)
     let fees = try #require(insights.first)
     #expect(fees.kind == .feeSpend)
+    // No breakdown rows supplied, so the companion chart falls back to nil.
+    #expect(fees.chart == nil)
+  }
+
+  @Test
+  func feeSpendAttachesMonthlyChart() throws {
+    let feesId = UUID()
+    let feeCategorySpend = [
+      CategorySpendSummary(
+        categoryId: feesId, categoryPath: "Banking:Fees",
+        total: InsightTestSupport.amount(-50), legCount: 2)
+    ]
+    let breakdown = [
+      InsightTestSupport.breakdownRow(20, categoryId: feesId, month: "202604"),
+      InsightTestSupport.breakdownRow(30, categoryId: feesId, month: "202605"),
+    ]
+    let fees = try #require(
+      SavingsOpportunityInsights.feeSpend(
+        feeCategorySpend: feeCategorySpend, expenseBreakdown: breakdown, context: context
+      ).first)
+    let chart = try #require(fees.chart)
+    #expect(chart.kind == .bar)
+    #expect(chart.unit == .currency(InsightTestSupport.currency))
+    #expect(chart.series.first?.role == .primary)
+    #expect(chart.series.first?.points.count == 2)
+    #expect(chart.highlight?.value == 30)
   }
 }

--- a/MoolahTests/Domain/Insights/MonthlyCategorySpendChartTests.swift
+++ b/MoolahTests/Domain/Insights/MonthlyCategorySpendChartTests.swift
@@ -1,0 +1,57 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("Monthly category-spend chart builder")
+struct MonthlyCategorySpendChartTests {
+  private let currency = InsightTestSupport.currency
+
+  @Test
+  func monthlyCategorySpendSumsFeeCategoriesPerMonth() throws {
+    let feesA = UUID()
+    let feesB = UUID()
+    let rent = UUID()
+    let breakdown = [
+      InsightTestSupport.breakdownRow(20, categoryId: feesA, month: "202604"),
+      InsightTestSupport.breakdownRow(5, categoryId: feesB, month: "202604"),
+      InsightTestSupport.breakdownRow(30, categoryId: feesA, month: "202605"),
+      // Rent is not a fee category and must not contribute.
+      InsightTestSupport.breakdownRow(500, categoryId: rent, month: "202605"),
+    ]
+    let chart = try #require(
+      InsightChartBuilders.monthlyCategorySpend(
+        expenseBreakdown: breakdown, categoryIds: [feesA, feesB], reportingCurrency: currency,
+        seriesLabel: "Fees"))
+
+    #expect(chart.kind == .bar)
+    #expect(chart.unit == .currency(currency))
+    #expect(chart.xAxis == .monthly)
+    #expect(chart.series.first?.id == "fees")
+    #expect(chart.series.first?.label == "Fees")
+    #expect(chart.series.first?.points.count == 2)
+    // April sums both fee categories (20 + 5); May has only feesA (30).
+    #expect(chart.series.first?.points.first?.value == 25)
+    #expect(chart.highlight?.value == 30)
+    #expect(chart.highlight?.date == InsightTestSupport.date(2026, 5, 1))
+  }
+
+  @Test
+  func monthlyCategorySpendIsNilWhenNoFeeRows() {
+    let breakdown = [InsightTestSupport.breakdownRow(500, categoryId: UUID(), month: "202605")]
+    #expect(
+      InsightChartBuilders.monthlyCategorySpend(
+        expenseBreakdown: breakdown, categoryIds: [UUID()], reportingCurrency: currency,
+        seriesLabel: "Fees") == nil)
+  }
+
+  @Test
+  func monthlyCategorySpendIsNilBelowTwoMonths() {
+    let fees = UUID()
+    let breakdown = [InsightTestSupport.breakdownRow(20, categoryId: fees, month: "202605")]
+    #expect(
+      InsightChartBuilders.monthlyCategorySpend(
+        expenseBreakdown: breakdown, categoryIds: [fees], reportingCurrency: currency,
+        seriesLabel: "Fees") == nil)
+  }
+}


### PR DESCRIPTION
Extends the insight companion-graphs feature (framework [#1053](https://github.com/moolah-rocks/moolah-native/pull/1053)) to the **fee-spend** insight — PR 4 of 4 (follows [#1054](https://github.com/moolah-rocks/moolah-native/pull/1054), [#1055](https://github.com/moolah-rocks/moolah-native/pull/1055), [#1060](https://github.com/moolah-rocks/moolah-native/pull/1060)).

## What

`feeSpend` now carries a bar chart of combined monthly spend across the fee categories, latest month highlighted.

- New pure builder `InsightChartBuilders.monthlyCategorySpend(expenseBreakdown:categoryIds:reportingCurrency:seriesLabel:)` — sums the matching categories' monthly spend by reusing `CategorySpendSeries.total` (gap-filled, positive magnitudes via `max(-signed,0)`, no `abs()`); `nil` when no rows match or fewer than two months remain. The series label is caller-supplied so the builder stays category-agnostic.
- Threads `expenseBreakdown` (already in `InsightInput` — **no new aggregation**) into `SavingsOpportunityInsights.feeSpend`, scoped to the fee category ids it already computes. Uncategorized fees stay in the headline total but not the chart; an all-uncategorized case falls back to a graph-less row.

## Also

Corrects the long-stale `ExpenseBreakdown.totalExpenses` docstring, which claimed "always positive" while the GRDB source and every consumer treat it as a signed-negative sum (verified in `GRDBAnalysisRepository+ExpenseBreakdown`).

## Tests

- Builder unit tests: per-month fee sum + latest highlight, no-match `nil`, sparse `nil`.
- Detector-level test asserts the chart attaches with the bar / `.currency` unit, primary role, and latest-month highlight.

`@code-review` + `@concurrency-review` run clean; all findings applied (label parameterised, `Set`/`Array` dedup, docstring fix, role assertion).

> Closes out the remaining-kinds plan. Investment performers were deliberately skipped — no time series in `InsightInput`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)