### PR TITLE
Fix overspend-insight false positives on recurring and one-off payments

### DIFF
--- a/Domain/Insights/Detectors/CategoryAnomalyInsight.swift
+++ b/Domain/Insights/Detectors/CategoryAnomalyInsight.swift
@@ -145,12 +145,12 @@ enum CategoryAnomalyInsight {
   ) -> Bool {
     guard let latest = magnitudes.last, latest > 0 else { return false }
     let latestIndex = magnitudes.count - 1
-    let floor = latest * tolerance
+    let minimumMagnitude = latest * tolerance
     for lag in lags {
       for offset in -1...1 {
         let index = latestIndex - lag + offset
         guard index >= 0, index < latestIndex else { continue }
-        if magnitudes[index] >= floor { return true }
+        if magnitudes[index] >= minimumMagnitude { return true }
       }
     }
     return false

--- a/Domain/Insights/Detectors/CategoryAnomalyInsight.swift
+++ b/Domain/Insights/Detectors/CategoryAnomalyInsight.swift
@@ -54,6 +54,10 @@ enum CategoryAnomalyInsight {
     bounds: Bounds
   ) -> Insight? {
     let magnitudes = points.map(\.magnitude)
+    // Gate A — regularity. An overspend is only meaningful against an established
+    // baseline. A category with spend in <= half its months (median 0) is a lump
+    // (one-off purchase) or a rare periodic payment, not an overspend.
+    guard DescriptiveStatistics.median(magnitudes) > 0 else { return nil }
     let decomposition = SeasonalDecomposition.decompose(magnitudes, period: 12)
     let remainder = decomposition.remainder
     guard let latest = points.last, remainder.count == points.count else { return nil }

--- a/Domain/Insights/Detectors/CategoryAnomalyInsight.swift
+++ b/Domain/Insights/Detectors/CategoryAnomalyInsight.swift
@@ -55,8 +55,9 @@ enum CategoryAnomalyInsight {
   ) -> Insight? {
     let magnitudes = points.map(\.magnitude)
     // Gate A — regularity. An overspend is only meaningful against an established
-    // baseline. A category with spend in <= half its months (median 0) is a lump
-    // (one-off purchase) or a rare periodic payment, not an overspend.
+    // baseline. A category whose median monthly spend is zero — a one-off lump
+    // (house purchase) or a rare periodic payment (annual bill) — has no "usual"
+    // to overspend against, so it is never flagged.
     guard DescriptiveStatistics.median(magnitudes) > 0 else { return nil }
     let decomposition = SeasonalDecomposition.decompose(magnitudes, period: 12)
     let remainder = decomposition.remainder

--- a/Domain/Insights/Detectors/CategoryAnomalyInsight.swift
+++ b/Domain/Insights/Detectors/CategoryAnomalyInsight.swift
@@ -18,12 +18,18 @@ enum CategoryAnomalyInsight {
     context: InsightContext,
     minimumMonths: Int = 6,
     threshold: Double = 3,
-    minimumOverspendFraction: Double = 0.25
+    minimumOverspendFraction: Double = 0.25,
+    recurrenceLags: [Int] = [12, 6, 3],
+    recurrenceTolerance: Double = 0.6
   ) -> [Insight] {
     let series = CategorySpendSeries.build(
       from: breakdown, reportingCurrency: context.reportingCurrency)
 
-    let bounds = Bounds(zScore: threshold, overspendFraction: minimumOverspendFraction)
+    let gates = Gates(
+      zScore: threshold,
+      overspendFraction: minimumOverspendFraction,
+      recurrenceLags: recurrenceLags,
+      recurrenceTolerance: recurrenceTolerance)
     var insights: [Insight] = []
     for (categoryId, points) in series where points.count >= minimumMonths {
       guard
@@ -32,18 +38,24 @@ enum CategoryAnomalyInsight {
           points: points,
           categories: categories,
           context: context,
-          bounds: bounds)
+          gates: gates)
       else { continue }
       insights.append(insight)
     }
     return insights
   }
 
-  /// The two gate values an anomaly must clear, bundled to keep `evaluate`
-  /// within the parameter-count budget.
-  private struct Bounds {
+  /// The gate values an anomaly must clear, bundled to keep `evaluate` within
+  /// the parameter-count budget.
+  private struct Gates {
     let zScore: Double
     let overspendFraction: Double
+    /// Cadence lags (months) checked for a recurring spike: annual, semi-annual,
+    /// quarterly.
+    let recurrenceLags: [Int]
+    /// A prior spike at a cadence lag of at least this fraction of the latest
+    /// spike's magnitude counts as "recurring".
+    let recurrenceTolerance: Double
   }
 
   private static func evaluate(
@@ -51,7 +63,7 @@ enum CategoryAnomalyInsight {
     points: [MonthlySpendPoint],
     categories: Categories,
     context: InsightContext,
-    bounds: Bounds
+    gates: Gates
   ) -> Insight? {
     let magnitudes = points.map(\.magnitude)
     // Gate A — regularity. An overspend is only meaningful against an established
@@ -66,14 +78,24 @@ enum CategoryAnomalyInsight {
     let latestRemainder = remainder[remainder.count - 1]
     let priorRemainders = Array(remainder.dropLast())
     let zScore = DescriptiveStatistics.robustZScore(of: latestRemainder, in: priorRemainders)
-    guard zScore >= bounds.zScore, latestRemainder > 0 else { return nil }
+    guard zScore >= gates.zScore, latestRemainder > 0 else { return nil }
 
     let expected =
       decomposition.trend[remainder.count - 1]
       + decomposition.seasonal[remainder.count - 1]
     guard expected > 0 else { return nil }
     let overspendFraction = latestRemainder / expected
-    guard overspendFraction >= bounds.overspendFraction else { return nil }
+    guard overspendFraction >= gates.overspendFraction else { return nil }
+
+    // Gate B — recurrence. Suppress a spike that recurs at a fixed cadence
+    // (annual/semi-annual/quarterly), tolerating +/-1 month of date drift, so a
+    // predictable periodic bill does not nag every cycle.
+    guard
+      !isRecurringSpike(
+        magnitudes: magnitudes,
+        lags: gates.recurrenceLags,
+        tolerance: gates.recurrenceTolerance)
+    else { return nil }
 
     let resolved =
       categoryId == CategorySpendSeries.uncategorizedKey
@@ -113,6 +135,25 @@ enum CategoryAnomalyInsight {
 
   private static func percent(_ fraction: Double) -> String {
     fraction.formatted(.percent.precision(.fractionLength(0)))
+  }
+
+  /// True when the latest month's spike has a comparable spike (>= `tolerance`
+  /// of its magnitude) at one of the cadence `lags`, allowing +/-1 month of
+  /// date drift across month buckets.
+  private static func isRecurringSpike(
+    magnitudes: [Double], lags: [Int], tolerance: Double
+  ) -> Bool {
+    guard let latest = magnitudes.last, latest > 0 else { return false }
+    let latestIndex = magnitudes.count - 1
+    let floor = latest * tolerance
+    for lag in lags {
+      for offset in -1...1 {
+        let index = latestIndex - lag + offset
+        guard index >= 0, index < latestIndex else { continue }
+        if magnitudes[index] >= floor { return true }
+      }
+    }
+    return false
   }
 
   /// Wide month name pinned to the context calendar's time zone so a

--- a/Features/Analysis/AnalysisStore+DisplayWindow.swift
+++ b/Features/Analysis/AnalysisStore+DisplayWindow.swift
@@ -15,4 +15,62 @@ extension AnalysisStore {
   nonisolated static func effectiveLoadMonths(historyMonths: Int, floorMonths: Int) -> Int {
     historyMonths == 0 ? Int.max : max(historyMonths, floorMonths)
   }
+
+  // MARK: - Display clipping (pure)
+
+  /// First `YYYYMM` bucket visible for a display window, or `nil` for "All".
+  nonisolated static func displayStartMonth(historyMonths: Int, now: Date) -> String? {
+    guard historyMonths > 0,
+      let start = Calendar.current.date(byAdding: .month, value: -historyMonths, to: now)
+    else { return nil }
+    let components = Calendar.current.dateComponents([.year, .month], from: start)
+    return String(format: "%04d%02d", components.year ?? 0, components.month ?? 0)
+  }
+
+  /// Clips breakdown rows to the display window (string compare on `YYYYMM`).
+  nonisolated static func clipBreakdown(
+    _ rows: [ExpenseBreakdown], historyMonths: Int, now: Date
+  ) -> [ExpenseBreakdown] {
+    guard let startMonth = displayStartMonth(historyMonths: historyMonths, now: now)
+    else { return rows }
+    return rows.filter { $0.month >= startMonth }
+  }
+
+  /// Clips income/expense rows to the display window (string compare on `YYYYMM`).
+  nonisolated static func clipIncomeExpense(
+    _ rows: [MonthlyIncomeExpense], historyMonths: Int, now: Date
+  ) -> [MonthlyIncomeExpense] {
+    guard let startMonth = displayStartMonth(historyMonths: historyMonths, now: now)
+    else { return rows }
+    return rows.filter { $0.month >= startMonth }
+  }
+
+  /// Clips daily balances to the display window. Forecast rows (future-dated)
+  /// are always kept so the net-worth chart still draws its forecast tail.
+  nonisolated static func clipBalances(
+    _ balances: [DailyBalance], historyMonths: Int, now: Date
+  ) -> [DailyBalance] {
+    guard historyMonths > 0,
+      let start = Calendar.current.date(byAdding: .month, value: -historyMonths, to: now)
+    else { return balances }
+    let startDay = Calendar.current.startOfDay(for: start)
+    return balances.filter { $0.isForecast || $0.date >= startDay }
+  }
+
+  // MARK: - Display projections (consumed by AnalysisView)
+
+  /// Daily balances clipped to the current display window.
+  var displayedDailyBalances: [DailyBalance] {
+    Self.clipBalances(dailyBalances, historyMonths: historyMonths, now: Date())
+  }
+
+  /// Expense breakdown clipped to the current display window.
+  var displayedExpenseBreakdown: [ExpenseBreakdown] {
+    Self.clipBreakdown(expenseBreakdown, historyMonths: historyMonths, now: Date())
+  }
+
+  /// Income/expense rows clipped to the current display window.
+  var displayedIncomeAndExpense: [MonthlyIncomeExpense] {
+    Self.clipIncomeExpense(incomeAndExpense, historyMonths: historyMonths, now: Date())
+  }
 }

--- a/Features/Analysis/AnalysisStore+DisplayWindow.swift
+++ b/Features/Analysis/AnalysisStore+DisplayWindow.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+// MARK: - Load window + display clipping
+
+extension AnalysisStore {
+  /// Minimum history (months) loaded for the insight engine, regardless of the
+  /// Analysis screen's display filter. Three years gives the category-anomaly
+  /// detector enough same-month samples to recognise an annual pattern instead
+  /// of mis-flagging it as an overspend. A *minimum*, never a cap.
+  nonisolated static let insightHistoryFloorMonths = 36
+
+  /// The effective load window in months: the larger of the user's display
+  /// filter and the insight floor. `historyMonths == 0` ("All") loads
+  /// everything, represented as `Int.max`.
+  nonisolated static func effectiveLoadMonths(historyMonths: Int, floorMonths: Int) -> Int {
+    historyMonths == 0 ? Int.max : max(historyMonths, floorMonths)
+  }
+}

--- a/Features/Analysis/AnalysisStore+DisplayWindow.swift
+++ b/Features/Analysis/AnalysisStore+DisplayWindow.swift
@@ -36,7 +36,8 @@ extension AnalysisStore {
     return rows.filter { $0.month >= startMonth }
   }
 
-  /// Clips income/expense rows to the display window (string compare on `YYYYMM`).
+  /// Clips income/expense rows to the display window (string compare on `YYYYMM`,
+  /// mirrors `clipBreakdown`).
   nonisolated static func clipIncomeExpense(
     _ rows: [MonthlyIncomeExpense], historyMonths: Int, now: Date
   ) -> [MonthlyIncomeExpense] {
@@ -47,6 +48,12 @@ extension AnalysisStore {
 
   /// Clips daily balances to the display window. Forecast rows (future-dated)
   /// are always kept so the net-worth chart still draws its forecast tail.
+  ///
+  /// Deliberate asymmetry with `clipBreakdown` / `clipIncomeExpense`: those clip
+  /// on a whole-month `YYYYMM` boundary, whereas balances clip on the exact day.
+  /// At a window edge the dense daily chart starts mid-month while the monthly
+  /// aggregates show the whole boundary month — acceptable, since the two
+  /// surfaces have different visual granularity.
   nonisolated static func clipBalances(
     _ balances: [DailyBalance], historyMonths: Int, now: Date
   ) -> [DailyBalance] {

--- a/Features/Analysis/AnalysisStore.swift
+++ b/Features/Analysis/AnalysisStore.swift
@@ -87,17 +87,22 @@ final class AnalysisStore {
     // Load the larger of the user's display window and the insight floor.
     let requestedLoadMonths = Self.effectiveLoadMonths(
       historyMonths: historyMonths, floorMonths: Self.insightHistoryFloorMonths)
+    // Capture the forecast window before any suspension so the cache stamp agrees
+    // with the data we actually fetch, even if the user changes it mid-load.
+    let requestedForecastMonths = forecastMonths
 
     // Refetch only when the request reaches further back than the cache, the
     // forecast window changed, or nothing is loaded yet. Narrowing the display
     // filter needs no fetch — `displayed*` re-clips the cached data.
     let needsLoad =
       !hasCachedData
-      || forecastMonths != cachedForecastMonths
+      || requestedForecastMonths != cachedForecastMonths
       || requestedLoadMonths > (cachedLoadMonths ?? 0)
     guard needsLoad else { return }
 
     isLoading = true
+    defer { isLoading = false }
+
     let growing = requestedLoadMonths > (cachedLoadMonths ?? 0)
     if growing {
       // Dropping stale narrower data so the spinner shows while we widen.
@@ -108,10 +113,8 @@ final class AnalysisStore {
 
     do {
       let after: Date? =
-        historyMonths == 0
-        ? nil
-        : afterDate(monthsAgo: max(historyMonths, Self.insightHistoryFloorMonths))
-      let forecastUntil = forecastDate(monthsAhead: forecastMonths)
+        historyMonths == 0 ? nil : afterDate(monthsAgo: requestedLoadMonths)
+      let forecastUntil = forecastDate(monthsAhead: requestedForecastMonths)
 
       let data = try await repository.loadAll(
         historyAfter: after,
@@ -126,24 +129,16 @@ final class AnalysisStore {
       incomeAndExpense = data.incomeAndExpense.sorted { $0.month > $1.month }
 
       cachedLoadMonths = requestedLoadMonths
-      cachedForecastMonths = forecastMonths
+      cachedForecastMonths = requestedForecastMonths
       lastLoadedAt = Date()
     } catch is CancellationError {
-      // View teardown / supersession — `AnalysisView`'s `.task` modifier
-      // is routinely cancelled during cold-launch state restoration and
-      // when navigating between sidebar items. The repository awaits
-      // rethrow `CancellationError` per their documented contract;
-      // surfacing it would render "Swift.CancellationError error 1" in
-      // the view, which sticks because the store outlives the view.
-      // A re-mount issues its own `loadAll()`.
-      isLoading = false
+      // View teardown / supersession — see AnalysisView's `.task`. A re-mount
+      // issues its own `loadAll()`. `defer` resets `isLoading`.
       return
     } catch {
       logger.error("Failed to load analysis data: \(error)")
       self.error = error
     }
-
-    isLoading = false
   }
 
   /// Reloads analysis data only if it has been at least `minimumInterval` seconds since

--- a/Features/Analysis/AnalysisStore.swift
+++ b/Features/Analysis/AnalysisStore.swift
@@ -201,7 +201,7 @@ final class AnalysisStore {
 
   /// Transforms expense breakdown into chart-ready data grouped by root-level category and month.
   func categoriesOverTime(categories: Categories) -> [CategoryOverTimeEntry] {
-    Self.buildCategoriesOverTime(from: expenseBreakdown, categories: categories)
+    Self.buildCategoriesOverTime(from: displayedExpenseBreakdown, categories: categories)
   }
 
   /// Pure function for testability: transforms expense breakdown into chart-ready grouped data.

--- a/Features/Analysis/AnalysisStore.swift
+++ b/Features/Analysis/AnalysisStore.swift
@@ -14,11 +14,15 @@ final class AnalysisStore {
   private(set) var isLoading = false
   private(set) var error: Error?
 
-  /// Cached analysis parameters — detect if cache is still valid for current filters
-  private var cachedHistoryMonths: Int?
+  /// The effective *load* window (months) of the currently cached data —
+  /// `max(historyMonths, insightHistoryFloorMonths)`, or `Int.max` for "All".
+  /// Keyed on the load window (not the display filter) so narrowing the UI
+  /// window re-clips from cache instead of refetching; only a request that
+  /// reaches further back than the cache triggers a new load.
+  private var cachedLoadMonths: Int?
   private var cachedForecastMonths: Int?
   private var hasCachedData: Bool {
-    cachedHistoryMonths != nil && !dailyBalances.isEmpty
+    cachedLoadMonths != nil && !dailyBalances.isEmpty
   }
 
   /// Timestamp of the last successful `loadAll()`. Used by `refreshIfStale` to
@@ -80,23 +84,33 @@ final class AnalysisStore {
     monthEnd = Calendar.current.component(.day, from: Date())
     error = nil
 
-    // If filters changed, clear cache — stale data with wrong filters is confusing
-    let filtersChanged =
-      historyMonths != cachedHistoryMonths
-      || forecastMonths != cachedForecastMonths
+    // Load the larger of the user's display window and the insight floor.
+    let requestedLoadMonths = Self.effectiveLoadMonths(
+      historyMonths: historyMonths, floorMonths: Self.insightHistoryFloorMonths)
 
-    // Show loading only if we have no cached data or filters changed
-    if !hasCachedData || filtersChanged {
-      isLoading = true
-      if filtersChanged {
-        dailyBalances = []
-        expenseBreakdown = []
-        incomeAndExpense = []
-      }
+    // Refetch only when the request reaches further back than the cache, the
+    // forecast window changed, or nothing is loaded yet. Narrowing the display
+    // filter needs no fetch — `displayed*` re-clips the cached data.
+    let needsLoad =
+      !hasCachedData
+      || forecastMonths != cachedForecastMonths
+      || requestedLoadMonths > (cachedLoadMonths ?? 0)
+    guard needsLoad else { return }
+
+    isLoading = true
+    let growing = requestedLoadMonths > (cachedLoadMonths ?? 0)
+    if growing {
+      // Dropping stale narrower data so the spinner shows while we widen.
+      dailyBalances = []
+      expenseBreakdown = []
+      incomeAndExpense = []
     }
 
     do {
-      let after = afterDate(monthsAgo: historyMonths)
+      let after: Date? =
+        historyMonths == 0
+        ? nil
+        : afterDate(monthsAgo: max(historyMonths, Self.insightHistoryFloorMonths))
       let forecastUntil = forecastDate(monthsAhead: forecastMonths)
 
       let data = try await repository.loadAll(
@@ -111,7 +125,7 @@ final class AnalysisStore {
       expenseBreakdown = data.expenseBreakdown
       incomeAndExpense = data.incomeAndExpense.sorted { $0.month > $1.month }
 
-      cachedHistoryMonths = historyMonths
+      cachedLoadMonths = requestedLoadMonths
       cachedForecastMonths = forecastMonths
       lastLoadedAt = Date()
     } catch is CancellationError {

--- a/Features/Analysis/Views/AnalysisView.swift
+++ b/Features/Analysis/Views/AnalysisView.swift
@@ -144,10 +144,10 @@ struct AnalysisView: View {
           onDismiss: { item in Task { await insightStore.dismiss(item.scored) } },
           onNavigate: onNavigate)
       }
-      NetWorthGraphCard(balances: store.dailyBalances)
+      NetWorthGraphCard(balances: store.displayedDailyBalances)
       upcomingAndIncomeExpense(store: store)
       ExpenseBreakdownCard(
-        breakdown: store.expenseBreakdown,
+        breakdown: store.displayedExpenseBreakdown,
         categories: categoryStore.categories
       )
       CategoriesOverTimeCard(
@@ -170,7 +170,7 @@ struct AnalysisView: View {
           transactionStore: transactionStore,
           selectedTransaction: $selectedUpcomingTransaction
         )
-        IncomeExpenseTableCard(data: store.incomeAndExpense)
+        IncomeExpenseTableCard(data: store.displayedIncomeAndExpense)
       }
     #else
       UpcomingTransactionsCard(
@@ -180,7 +180,7 @@ struct AnalysisView: View {
         transactionStore: transactionStore,
         selectedTransaction: $selectedUpcomingTransaction
       )
-      IncomeExpenseTableCard(data: store.incomeAndExpense)
+      IncomeExpenseTableCard(data: store.displayedIncomeAndExpense)
     #endif
   }
 }

--- a/Features/Analysis/Views/AnalysisView.swift
+++ b/Features/Analysis/Views/AnalysisView.swift
@@ -19,6 +19,7 @@ struct AnalysisView: View {
 
   var body: some View {
     ScrollView {
+      // Load-state check on the full array — not a display-window question.
       if store.isLoading && store.dailyBalances.isEmpty {
         ProgressView("Loading analysis...")
           .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -153,6 +154,8 @@ struct AnalysisView: View {
       CategoriesOverTimeCard(
         entries: store.categoriesOverTime(categories: categoryStore.categories),
         categories: categoryStore.categories,
+        // Instrument is uniform across the profile; read the full (unclipped) array so
+        // a narrow display window with no rows in range doesn't fall back to .AUD.
         instrument: store.dailyBalances.first?.balance.instrument ?? .AUD,
         showActualValues: $store.showActualValues
       )

--- a/MoolahTests/Domain/Insights/SpendAndTrendInsightTests.swift
+++ b/MoolahTests/Domain/Insights/SpendAndTrendInsightTests.swift
@@ -202,21 +202,35 @@ struct SpendAndTrendInsightTests {
 
   @Test
   func categoryAnomalySuppressesQuarterlyRecurrence() {
-    // A regular ~$100/month category with a $600 spike every 3 months. The
-    // latest spike matches the lag-3 occurrence, so it is a predictable bill.
-    let utilities = Category(name: "Water")
+    // A regular ~$100/month category with a $600 spike one quarter (3 months)
+    // before the latest spike. The lag-3 arm of the recurrence guard suppresses
+    // it — and only lag-3: excluding 3 from the cadence set lets the very same
+    // spike fire, which also confirms the spike is a genuine z-outlier reaching
+    // Gate B (not quietly passing the z-gate).
+    let water = Category(name: "Water")
     var magnitudes = Array(repeating: Decimal(100), count: 12)
-    for index in [2, 5, 8, 11] { magnitudes[index] = 600 }
+    magnitudes[8] = 600  // one quarter before the latest spike
+    magnitudes[11] = 600  // latest spike
     let months = [
       "202507", "202508", "202509", "202510", "202511", "202512",
       "202601", "202602", "202603", "202604", "202605", "202606",
     ]
     let breakdown = zip(months, magnitudes).map { month, magnitude in
-      InsightTestSupport.breakdownRow(magnitude, categoryId: utilities.id, month: month)
+      InsightTestSupport.breakdownRow(magnitude, categoryId: water.id, month: month)
     }
-    let insights = CategoryAnomalyInsight.detect(
-      breakdown: breakdown, categories: Categories(from: [utilities]), context: context)
-    #expect(!insights.contains { $0.kind == .categorySpendingAnomaly })
+    let categories = Categories(from: [water])
+    // Suppressed with the default cadence set (which includes the quarterly lag).
+    #expect(
+      !CategoryAnomalyInsight.detect(
+        breakdown: breakdown, categories: categories, context: context
+      ).contains { $0.kind == .categorySpendingAnomaly })
+    // Excluding the quarterly lag lets the same spike through — proving it is the
+    // lag-3 arm doing the suppression, not lag-6/12.
+    #expect(
+      CategoryAnomalyInsight.detect(
+        breakdown: breakdown, categories: categories, context: context,
+        recurrenceLags: [12, 6]
+      ).contains { $0.kind == .categorySpendingAnomaly })
   }
 
   @Test

--- a/MoolahTests/Domain/Insights/SpendAndTrendInsightTests.swift
+++ b/MoolahTests/Domain/Insights/SpendAndTrendInsightTests.swift
@@ -168,6 +168,9 @@ struct SpendAndTrendInsightTests {
     // The reported bug: an $80k annual superannuation payment, identical to last
     // year's, in an otherwise-empty category. Median is 0 → not an overspend.
     let superannuation = Category(name: "Superannuation")
+    // The two rows gap-fill (CategorySpendSeries) into a 13-month series — 11
+    // interior zeros — so it clears `minimumMonths` and reaches Gate A, where
+    // the zero median suppresses it.
     let breakdown = [
       InsightTestSupport.breakdownRow(80_000, categoryId: superannuation.id, month: "202506"),
       InsightTestSupport.breakdownRow(80_000, categoryId: superannuation.id, month: "202606"),

--- a/MoolahTests/Domain/Insights/SpendAndTrendInsightTests.swift
+++ b/MoolahTests/Domain/Insights/SpendAndTrendInsightTests.swift
@@ -148,6 +148,36 @@ struct SpendAndTrendInsightTests {
   }
 
   @Test
+  func categoryAnomalySuppressesOneOffLump() {
+    // A category with a thin trickle then a huge one-off (house deposit). The
+    // series is long enough to clear `minimumMonths`, but its median is 0, so
+    // there is no regular baseline to "overspend" against.
+    let home = Category(name: "Home")
+    let magnitudes: [Decimal] = [100, 0, 0, 0, 0, 500_000]
+    let months = ["202501", "202502", "202503", "202504", "202505", "202506"]
+    let breakdown = zip(months, magnitudes).map { month, magnitude in
+      InsightTestSupport.breakdownRow(magnitude, categoryId: home.id, month: month)
+    }
+    let insights = CategoryAnomalyInsight.detect(
+      breakdown: breakdown, categories: Categories(from: [home]), context: context)
+    #expect(!insights.contains { $0.kind == .categorySpendingAnomaly })
+  }
+
+  @Test
+  func categoryAnomalySuppressesAnnualRecurringPayment() {
+    // The reported bug: an $80k annual superannuation payment, identical to last
+    // year's, in an otherwise-empty category. Median is 0 → not an overspend.
+    let superannuation = Category(name: "Superannuation")
+    let breakdown = [
+      InsightTestSupport.breakdownRow(80_000, categoryId: superannuation.id, month: "202506"),
+      InsightTestSupport.breakdownRow(80_000, categoryId: superannuation.id, month: "202606"),
+    ]
+    let insights = CategoryAnomalyInsight.detect(
+      breakdown: breakdown, categories: Categories(from: [superannuation]), context: context)
+    #expect(!insights.contains { $0.kind == .categorySpendingAnomaly })
+  }
+
+  @Test
   func categoryTrendAttachesChart() throws {
     let dining = Category(name: "Dining")
     let magnitudes: [Decimal] = [100, 140, 180, 220, 260, 300]

--- a/MoolahTests/Domain/Insights/SpendAndTrendInsightTests.swift
+++ b/MoolahTests/Domain/Insights/SpendAndTrendInsightTests.swift
@@ -181,6 +181,45 @@ struct SpendAndTrendInsightTests {
   }
 
   @Test
+  func categoryAnomalySuppressesDriftedRecurrence() {
+    // A regular ~$100/month category (passes Gate A) with a $600 spike that
+    // recurred ~12 months earlier, drifted by one month (June yr1 -> July yr2).
+    let utilities = Category(name: "Utilities")
+    var magnitudes = Array(repeating: Decimal(100), count: 14)
+    magnitudes[0] = 600  // 202506 (June, prior year)
+    magnitudes[13] = 600  // 202607 (July, this year) — the latest spike
+    let months = [
+      "202506", "202507", "202508", "202509", "202510", "202511", "202512",
+      "202601", "202602", "202603", "202604", "202605", "202606", "202607",
+    ]
+    let breakdown = zip(months, magnitudes).map { month, magnitude in
+      InsightTestSupport.breakdownRow(magnitude, categoryId: utilities.id, month: month)
+    }
+    let insights = CategoryAnomalyInsight.detect(
+      breakdown: breakdown, categories: Categories(from: [utilities]), context: context)
+    #expect(!insights.contains { $0.kind == .categorySpendingAnomaly })
+  }
+
+  @Test
+  func categoryAnomalySuppressesQuarterlyRecurrence() {
+    // A regular ~$100/month category with a $600 spike every 3 months. The
+    // latest spike matches the lag-3 occurrence, so it is a predictable bill.
+    let utilities = Category(name: "Water")
+    var magnitudes = Array(repeating: Decimal(100), count: 12)
+    for index in [2, 5, 8, 11] { magnitudes[index] = 600 }
+    let months = [
+      "202507", "202508", "202509", "202510", "202511", "202512",
+      "202601", "202602", "202603", "202604", "202605", "202606",
+    ]
+    let breakdown = zip(months, magnitudes).map { month, magnitude in
+      InsightTestSupport.breakdownRow(magnitude, categoryId: utilities.id, month: month)
+    }
+    let insights = CategoryAnomalyInsight.detect(
+      breakdown: breakdown, categories: Categories(from: [utilities]), context: context)
+    #expect(!insights.contains { $0.kind == .categorySpendingAnomaly })
+  }
+
+  @Test
   func categoryTrendAttachesChart() throws {
     let dining = Category(name: "Dining")
     let magnitudes: [Decimal] = [100, 140, 180, 220, 260, 300]

--- a/MoolahTests/Features/AnalysisStoreDisplayWindowTests.swift
+++ b/MoolahTests/Features/AnalysisStoreDisplayWindowTests.swift
@@ -66,6 +66,23 @@ struct AnalysisStoreClipTests {
     #expect(AnalysisStore.clipBreakdown(rows, historyMonths: 0, now: now).count == 2)
   }
 
+  @Test("income/expense clips to the display window")
+  func clipsIncomeExpense() {
+    let rows = ["202506", "202606"].map {
+      InsightTestSupport.monthly(month: $0, income: 0, expense: 0)
+    }
+    let clipped = AnalysisStore.clipIncomeExpense(rows, historyMonths: 3, now: now)
+    #expect(clipped.map(\.month) == ["202606"])
+  }
+
+  @Test("income/expense All (0) returns everything")
+  func clipsIncomeExpenseAll() {
+    let rows = ["202506", "202606"].map {
+      InsightTestSupport.monthly(month: $0, income: 0, expense: 0)
+    }
+    #expect(AnalysisStore.clipIncomeExpense(rows, historyMonths: 0, now: now).count == 2)
+  }
+
   @Test("balances clip by date but always keep forecast rows")
   func clipsBalancesKeepingForecast() {
     let old = DailyBalance(
@@ -90,6 +107,17 @@ struct AnalysisStoreClipTests {
     #expect(clipped.contains { $0.balance.quantity == 2 })
     #expect(clipped.contains { $0.balance.quantity == 3 })
     #expect(!clipped.contains { $0.balance.quantity == 1 })
+  }
+
+  @Test("balances All (0) returns everything including old rows")
+  func clipsBalancesAll() {
+    let old = DailyBalance(
+      date: cal(monthsFromNow: -40),
+      balance: InstrumentAmount(quantity: 1, instrument: .defaultTestInstrument))
+    let recent = DailyBalance(
+      date: cal(monthsFromNow: -1),
+      balance: InstrumentAmount(quantity: 2, instrument: .defaultTestInstrument))
+    #expect(AnalysisStore.clipBalances([old, recent], historyMonths: 0, now: now).count == 2)
   }
 }
 
@@ -145,5 +173,28 @@ struct AnalysisStoreCacheGateTests {
     await store.loadAll()
     #expect(await repo.lastAfter == nil)
     #expect(await repo.loadCount == 1)
+  }
+
+  @Test("displayed projection clips the loaded data by historyMonths, not forecastMonths")
+  func displayedProjectionUsesHistoryMonths() async throws {
+    // Year-2000 and year-2999 rows so the clip outcome is independent of wall-clock.
+    let repo = RecordingAnalysisRepository(breakdown: [
+      ExpenseBreakdown(
+        categoryId: UUID(), month: "200001",
+        totalExpenses: InstrumentAmount(quantity: -100, instrument: .defaultTestInstrument)),
+      ExpenseBreakdown(
+        categoryId: UUID(), month: "299912",
+        totalExpenses: InstrumentAmount(quantity: -100, instrument: .defaultTestInstrument)),
+    ])
+    let store = AnalysisStore(repository: repo, defaults: try makeDefaults())
+    store.historyMonths = 0  // All
+    await store.loadAll()
+    // All keeps both rows — if `displayed*` wrongly used forecastMonths (1) it would
+    // drop the year-2000 row.
+    #expect(store.displayedExpenseBreakdown.count == 2)
+    // Narrowing re-clips from the cached data with no reload — the year-2000 row drops.
+    store.historyMonths = 12
+    #expect(store.displayedExpenseBreakdown.map(\.month) == ["299912"])
+    #expect(await repo.loadCount == 1)  // no refetch on narrowing
   }
 }

--- a/MoolahTests/Features/AnalysisStoreDisplayWindowTests.swift
+++ b/MoolahTests/Features/AnalysisStoreDisplayWindowTests.swift
@@ -9,18 +9,79 @@ struct AnalysisStoreDisplayWindowTests {
   @Test("a narrow display filter still loads the insight floor")
   func narrowFilterLoadsFloor() {
     #expect(
-      AnalysisStore.effectiveLoadMonths(historyMonths: 3, floorMonths: 36) == 36)
+      AnalysisStore.effectiveLoadMonths(
+        historyMonths: 3, floorMonths: AnalysisStore.insightHistoryFloorMonths)
+        == AnalysisStore.insightHistoryFloorMonths)
   }
 
   @Test("a wide display filter loads the wider window, not the floor")
   func wideFilterLoadsRequested() {
     #expect(
-      AnalysisStore.effectiveLoadMonths(historyMonths: 60, floorMonths: 36) == 60)
+      AnalysisStore.effectiveLoadMonths(
+        historyMonths: 60, floorMonths: AnalysisStore.insightHistoryFloorMonths)
+        == 60)
   }
 
   @Test("All (0) loads everything")
   func allLoadsEverything() {
     #expect(
-      AnalysisStore.effectiveLoadMonths(historyMonths: 0, floorMonths: 36) == Int.max)
+      AnalysisStore.effectiveLoadMonths(
+        historyMonths: 0, floorMonths: AnalysisStore.insightHistoryFloorMonths)
+        == Int.max)
+  }
+}
+
+@Suite("AnalysisStore — load cache gate")
+@MainActor
+struct AnalysisStoreCacheGateTests {
+  private func makeDefaults() throws -> UserDefaults {
+    let suiteName = "com.moolah.test.\(UUID().uuidString)"
+    let defaults = try #require(UserDefaults(suiteName: suiteName))
+    defaults.removePersistentDomain(forName: suiteName)
+    return defaults
+  }
+
+  @Test("narrowing the display filter does not refetch")
+  func narrowingDoesNotRefetch() async throws {
+    let repo = RecordingAnalysisRepository()
+    let store = AnalysisStore(repository: repo, defaults: try makeDefaults())
+    store.historyMonths = 12
+    await store.loadAll()
+    store.historyMonths = 3
+    await store.loadAll()
+    #expect(await repo.loadCount == 1)
+  }
+
+  @Test("widening beyond the cache refetches")
+  func wideningRefetches() async throws {
+    let repo = RecordingAnalysisRepository()
+    let store = AnalysisStore(repository: repo, defaults: try makeDefaults())
+    store.historyMonths = 12
+    await store.loadAll()
+    store.historyMonths = 60
+    await store.loadAll()
+    #expect(await repo.loadCount == 2)
+  }
+
+  @Test("a forecast-window change refetches")
+  func forecastChangeRefetches() async throws {
+    let repo = RecordingAnalysisRepository()
+    let store = AnalysisStore(repository: repo, defaults: try makeDefaults())
+    store.historyMonths = 12
+    store.forecastMonths = 1
+    await store.loadAll()
+    store.forecastMonths = 3
+    await store.loadAll()
+    #expect(await repo.loadCount == 2)
+  }
+
+  @Test("All passes a nil history window to the repository")
+  func allRequestsNilWindow() async throws {
+    let repo = RecordingAnalysisRepository()
+    let store = AnalysisStore(repository: repo, defaults: try makeDefaults())
+    store.historyMonths = 0
+    await store.loadAll()
+    #expect(await repo.lastAfter == nil)
+    #expect(await repo.loadCount == 1)
   }
 }

--- a/MoolahTests/Features/AnalysisStoreDisplayWindowTests.swift
+++ b/MoolahTests/Features/AnalysisStoreDisplayWindowTests.swift
@@ -1,0 +1,26 @@
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("AnalysisStore — effective load window")
+struct AnalysisStoreDisplayWindowTests {
+
+  @Test("a narrow display filter still loads the insight floor")
+  func narrowFilterLoadsFloor() {
+    #expect(
+      AnalysisStore.effectiveLoadMonths(historyMonths: 3, floorMonths: 36) == 36)
+  }
+
+  @Test("a wide display filter loads the wider window, not the floor")
+  func wideFilterLoadsRequested() {
+    #expect(
+      AnalysisStore.effectiveLoadMonths(historyMonths: 60, floorMonths: 36) == 60)
+  }
+
+  @Test("All (0) loads everything")
+  func allLoadsEverything() {
+    #expect(
+      AnalysisStore.effectiveLoadMonths(historyMonths: 0, floorMonths: 36) == Int.max)
+  }
+}

--- a/MoolahTests/Features/AnalysisStoreDisplayWindowTests.swift
+++ b/MoolahTests/Features/AnalysisStoreDisplayWindowTests.swift
@@ -31,6 +31,68 @@ struct AnalysisStoreDisplayWindowTests {
   }
 }
 
+@Suite("AnalysisStore — display clipping")
+struct AnalysisStoreClipTests {
+  // 2026-06-15 anchor so month maths is deterministic.
+  private let now = {
+    var components = DateComponents()
+    components.year = 2026
+    components.month = 6
+    components.day = 15
+    return Calendar.current.date(from: components) ?? Date()
+  }()
+
+  private func breakdown(_ month: String) -> ExpenseBreakdown {
+    ExpenseBreakdown(
+      categoryId: UUID(), month: month,
+      totalExpenses: InstrumentAmount(quantity: -100, instrument: .defaultTestInstrument))
+  }
+
+  private func cal(monthsFromNow: Int) -> Date {
+    Calendar.current.date(byAdding: .month, value: monthsFromNow, to: now) ?? now
+  }
+
+  @Test("breakdown clips to the display window, keeping recent months")
+  func clipsBreakdown() {
+    let rows = ["202506", "202507", "202601", "202606"].map(breakdown)
+    // 3-month display window from 2026-06 keeps 202603..202606 → only 202606.
+    let clipped = AnalysisStore.clipBreakdown(rows, historyMonths: 3, now: now)
+    #expect(clipped.map(\.month) == ["202606"])
+  }
+
+  @Test("breakdown All (0) returns everything")
+  func clipsBreakdownAll() {
+    let rows = ["202506", "202606"].map(breakdown)
+    #expect(AnalysisStore.clipBreakdown(rows, historyMonths: 0, now: now).count == 2)
+  }
+
+  @Test("balances clip by date but always keep forecast rows")
+  func clipsBalancesKeepingForecast() {
+    let old = DailyBalance(
+      date: cal(monthsFromNow: -10),
+      balance: InstrumentAmount(quantity: 1, instrument: .defaultTestInstrument))
+    let recent = DailyBalance(
+      date: cal(monthsFromNow: -1),
+      balance: InstrumentAmount(quantity: 2, instrument: .defaultTestInstrument))
+    let forecast = DailyBalance(
+      date: cal(monthsFromNow: 2),
+      balance: InstrumentAmount(quantity: 3, instrument: .defaultTestInstrument),
+      earmarked: .zero(instrument: .defaultTestInstrument),
+      availableFunds: InstrumentAmount(quantity: 3, instrument: .defaultTestInstrument),
+      investments: .zero(instrument: .defaultTestInstrument),
+      investmentValue: nil,
+      netWorth: InstrumentAmount(quantity: 3, instrument: .defaultTestInstrument),
+      bestFit: nil,
+      isForecast: true)
+    let clipped = AnalysisStore.clipBalances(
+      [old, recent, forecast], historyMonths: 3, now: now)
+    // `old` (10 months back) drops; `recent` stays; `forecast` always stays.
+    #expect(clipped.contains { $0.balance.quantity == 2 })
+    #expect(clipped.contains { $0.balance.quantity == 3 })
+    #expect(!clipped.contains { $0.balance.quantity == 1 })
+  }
+}
+
 @Suite("AnalysisStore — load cache gate")
 @MainActor
 struct AnalysisStoreCacheGateTests {

--- a/MoolahTests/Support/RecordingAnalysisRepository.swift
+++ b/MoolahTests/Support/RecordingAnalysisRepository.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+@testable import Moolah
+
+/// Test double for `AnalysisRepository` that records how `AnalysisStore` drives
+/// it — the number of loads and the most recent `after` window — and returns a
+/// single non-empty daily balance so `hasCachedData` flips true after a load.
+/// Verifies `loadAll`'s cache gate (narrowing must not refetch; widening or a
+/// forecast change must).
+actor RecordingAnalysisRepository: AnalysisRepository {
+  private(set) var loadCount = 0
+  private(set) var lastAfter: Date?
+
+  func fetchDailyBalances(after: Date?, forecastUntil: Date?) async throws -> [DailyBalance] {
+    loadCount += 1
+    lastAfter = after
+    return [
+      DailyBalance(
+        date: Date(),
+        balance: InstrumentAmount(quantity: 100, instrument: .defaultTestInstrument))
+    ]
+  }
+
+  func fetchExpenseBreakdown(monthEnd: Int, after: Date?) async throws -> [ExpenseBreakdown] { [] }
+
+  func fetchIncomeAndExpense(
+    monthEnd: Int, after: Date?
+  ) async throws -> [MonthlyIncomeExpense] { [] }
+
+  func fetchCategoryBalances(
+    dateRange: ClosedRange<Date>,
+    transactionType: TransactionType,
+    filters: TransactionFilter?,
+    targetInstrument: Instrument
+  ) async throws -> [UUID: InstrumentAmount] { [:] }
+}

--- a/MoolahTests/Support/RecordingAnalysisRepository.swift
+++ b/MoolahTests/Support/RecordingAnalysisRepository.swift
@@ -10,6 +10,11 @@ import Foundation
 actor RecordingAnalysisRepository: AnalysisRepository {
   private(set) var loadCount = 0
   private(set) var lastAfter: Date?
+  private let breakdown: [ExpenseBreakdown]
+
+  init(breakdown: [ExpenseBreakdown] = []) {
+    self.breakdown = breakdown
+  }
 
   func fetchDailyBalances(after: Date?, forecastUntil: Date?) async throws -> [DailyBalance] {
     loadCount += 1
@@ -21,7 +26,9 @@ actor RecordingAnalysisRepository: AnalysisRepository {
     ]
   }
 
-  func fetchExpenseBreakdown(monthEnd: Int, after: Date?) async throws -> [ExpenseBreakdown] { [] }
+  func fetchExpenseBreakdown(
+    monthEnd: Int, after: Date?
+  ) async throws -> [ExpenseBreakdown] { breakdown }
 
   func fetchIncomeAndExpense(
     monthEnd: Int, after: Date?

--- a/plans/2026-06-05-overspend-insight-false-positives-design.md
+++ b/plans/2026-06-05-overspend-insight-false-positives-design.md
@@ -1,0 +1,205 @@
+# Overspend Insight — Eliminating False Positives
+
+**Date:** 2026-06-05
+**Status:** Design (pre-implementation)
+**Area:** `Domain/Insights/Detectors/CategoryAnomalyInsight.swift`, `Features/Analysis/AnalysisStore.swift`
+
+## Problem
+
+The "For You" overspend insight raises false positives. In the Large Test
+Profile it reports *"You've overspent by 600% on superannuation this month"*
+for an **annual** $80,000 payment that follows the exact same pattern as the
+prior year. The card shows:
+
+- Category: Superannuation
+- This month: −$80,000.00
+- Expected: −$11,428.57
+- Over by: 600%
+
+`$11,428.57 ≈ $80,000 / 7` — the detector saw a short, mostly-zero series (one
+$80k spike and ~6 zero months), so its "expected" collapsed to the flat mean
+and the single payment read as a 600% overspend.
+
+A second class of false positive is a **one-off lump** — e.g. a house
+purchase. Spending a lot on a house once is not an "overspend"; there is no
+*usual* spend in that category to overspend against.
+
+## Root Cause (two compounding causes)
+
+The card is produced by `CategoryAnomalyInsight.detect`, which builds a
+per-category gap-filled monthly spend series, runs a seasonal-trend
+decomposition (`SeasonalDecomposition.decompose(_, period: 12)`), and flags the
+latest month when its decomposition *remainder* is a robust-z outlier
+(`z ≥ 3`) and `remainder / expected ≥ 0.25`.
+
+**Cause 1 — the data window is coupled to an unrelated UI filter.** The
+detector consumes `sources.analysis.expenseBreakdown` — whatever the **Analysis
+screen** last loaded. That window is `AnalysisStore.historyMonths`, a
+*user-facing display filter* that **defaults to 12 months** and is persisted per
+profile (`UserDefaults` key `analysisHistoryMonths`). So the insight's history
+is whatever the user last set the Analysis chart to. A 12-month window cannot
+contain two annual occurrences with any margin, and the seasonal term needs
+**≥2 full periods (24 months)** to estimate an annual cycle at all.
+
+**Cause 2 — the algorithm can't recognise a recurring or lump spike from few
+occurrences.** The robust z-score uses median + MAD, which is *resistant* to one
+or two prior spikes — so even with a wider window, a single prior $80k payment
+12 months ago does **not** tame the z-score. The STL `seasonal` term only
+absorbs the spike once there are ~2–3 occurrences in the *same* month bucket,
+and ±1-month date drift (a payment that posts in June one year and early July
+the next) defeats it entirely. And nothing in the detector distinguishes a
+*one-off lump* in an otherwise-empty category from a genuine overspend on a
+regular habit.
+
+## Goals
+
+1. Stop annual / periodic recurring payments misfiring as overspend.
+2. Stop one-off lumps (house, car) misfiring as overspend.
+3. Keep firing for genuine overspends on categories the user spends in
+   regularly (e.g. a real dining blowout).
+4. Reuse the existing single analysis data load; do not introduce an
+   independent insight fetch.
+5. Never let the insight's wider load *cap* a larger window the Analysis UI
+   asks for (5 years / All).
+
+## Non-Goals
+
+- Coupling the detector to scheduled / recurring transaction templates. The
+  fix works purely from the monthly spend series. (Considered and explicitly
+  out of scope.)
+- Changing the budget-based `EarmarkBudgetInsights` overspend path.
+
+## Design
+
+### Part 1 — AnalysisStore loads wide, windows down for the UI
+
+The fetch stops being driven solely by the display filter. `AnalysisStore`
+becomes the single owner of a dataset sized for insights; the Analysis UI takes
+a *window* into it.
+
+- **Insight history floor:** a constant, **36 months** (3 years) — enough for
+  three same-month samples so the seasonal estimate is robust and so the lag
+  guard always has prior cadence to compare against.
+
+- **Effective load window = max(user window, floor):**
+
+  ```
+  floorDate = now − 36 months
+  effectiveAfter =
+      nil                            if historyMonths == 0 ("All")  // load everything
+      earlierOf(floorDate, userDate) otherwise                      // the larger window
+  ```
+
+  | User display filter | Loaded            | UI shows | Insights see |
+  | ------------------- | ----------------- | -------- | ------------ |
+  | 3 months            | 36 months (floor) | 3 months | 36 months    |
+  | 5 years (60 mo)     | 60 months (user)  | 5 years  | 5 years      |
+  | All                 | everything        | All      | everything   |
+
+  The floor is a **minimum**, never a **cap**: when the user asks for more than
+  the floor, the larger window is loaded and *both* the UI and insights get it.
+
+- **AnalysisStore holds the full loaded data as the source of truth.** The
+  loaded `dailyBalances` / `expenseBreakdown` / `incomeAndExpense` always span
+  ≥ 36 months (or more).
+
+- **Insights read the full loaded data** via the existing `sources.analysis.*`
+  path (`InsightStore.makeSnapshot`). No new fetch, no new dependency. The
+  display-filter coupling disappears because the loaded data is now always
+  ≥ the floor.
+
+- **The Analysis UI takes a smaller window when it needs one.** Cards render
+  display-clipped projections honouring `historyMonths`
+  (`clip = min(loaded span, historyMonths)`; All / ≥ loaded span = no-op).
+  Because we always load ≥ the user's window, the clip only ever *narrows*; it
+  never has to fabricate or truncate what the user actually asked for.
+
+- **Cache invalidation keys on the effective *load* window**
+  (`max(historyMonths, floor)`, All = ∞). Narrowing the display filter
+  re-clips instantly from cache; only widening *beyond* the cached load
+  triggers a refetch.
+
+**Verification point during implementation:** confirm `AnalysisStore.loadAll`
+is reached on the paths that feed the For You surface (insights ride
+AnalysisStore's `loadAll` / `refreshIfStale`), so the floor takes effect even
+if the user never opens the Analysis tab.
+
+### Part 2 — What actually counts as an overspend (detector hardening)
+
+A candidate spike must clear **both** gates, in this order (cheapest first):
+
+**Gate A — regularity (primary).** An overspend is only meaningful relative to
+an established habit. Require **non-trivial spend in more than half the months
+of the series** — equivalently `median(monthly magnitudes) > 0`. This kills the
+reported false positives:
+
+- **House purchase** — 1 non-zero month → median 0 → suppressed. Not an
+  overspend, just a purchase.
+- **Annual superannuation** — ~3 non-zero months across 36 → median 0 →
+  suppressed.
+- **Dining** (a real habit) — spend most months → median > 0 → eligible.
+
+This matches the insight's purpose: *"you spent more than usual on X"* only
+means something where there is a *usual*.
+
+**Gate B — recurrence / lag guard.** *Within* a regular category, suppress
+spikes that recur at a fixed cadence so a known periodic bill does not nag every
+cycle. For each lag `L ∈ {12, 6, 3}` months, inspect the neighbourhood
+`latestIndex − L ± 1` (the ±1 absorbs date drift across month buckets); if any
+point there has magnitude `≥ recurrenceTolerance × latest.magnitude`
+(default **0.6**), treat the spike as recurring → suppress. Example: a quarterly
+water bill on top of a monthly utilities habit — regular category (passes A),
+but the lag-3 match suppresses the predictable spike.
+
+The existing STL seasonal-absorption and robust-z / overspend-fraction gates
+stay. Order: **Gate A → z-score & overspend-fraction → Gate B**.
+
+**Dropped:** a hard "≥24 months before trusting the seasonal term" gate that an
+earlier draft proposed. It would wrongly suppress a *genuine* spike in a real
+but young category (e.g. 8 months of dining then a real blowout), and Gates A+B
+already cover the false positives it was aimed at.
+
+### Tunables (defaulted parameters on `detect`, pinned by tests)
+
+| Name                  | Default | Meaning                                            |
+| --------------------- | ------- | -------------------------------------------------- |
+| insight history floor | 36 mo   | minimum AnalysisStore load for insights            |
+| `minimumMonths`       | 6       | existing — minimum series length to evaluate       |
+| `threshold` (z)       | 3       | existing — robust-z outlier bar                    |
+| `minimumOverspendFraction` | 0.25 | existing — remainder/expected lower bound        |
+| regularity gate       | median > 0 | > half the months have non-trivial spend        |
+| lag set               | {12, 6, 3} | cadences checked for recurrence                 |
+| `recurrenceTolerance` | 0.6     | prior-spike magnitude ratio that counts as recurring |
+
+## Testing (TDD — tests before implementation)
+
+New / updated tests in `MoolahTests/Domain/Insights/SpendAndTrendInsightTests`,
+using existing `InsightTestSupport.breakdownRow` fixtures:
+
+- **One-off lump suppressed** (house case): single large spike, empty otherwise
+  → no insight.
+- **Annual recurrence suppressed** (reported bug): two $80k spikes 12 months
+  apart, zero otherwise → no insight (Gate A; Gate B as backstop).
+- **Date-drift recurrence suppressed:** comparable spikes in June yr1 / July
+  yr2 within a *regular* category → no insight.
+- **Quarterly recurrence suppressed:** regular category + comparable lag-3
+  spike → no insight.
+- **Genuine spike still fires:** dining 100 → … → 400, all months non-zero →
+  insight emitted (existing `categoryAnomalyFlagsSpike` stays green).
+- **Window decoupling / floor:** AnalysisStore loads ≥ 36 months and clips for
+  the Analysis UI; the insight input sees the full series regardless of
+  `historyMonths`. A larger UI request (60 mo / All) is loaded in full and not
+  capped to the floor.
+
+## Risks / Trade-offs
+
+- **Stricter regularity bar** means genuinely irregular categories never produce
+  an overspend insight. This is intended: a one-off is not an overspend.
+- **Wider default load** (36 mo vs prior 12 mo display default) increases the
+  analysis fetch. The data is pre-aggregated per category/month with a covering
+  index (`leg_analysis_by_type_category`) and daily balances are O(days); the
+  net-worth graph already loads multi-year data, so the cost is low.
+- **Lag guard false-negative:** a genuine overspend that happens to resemble a
+  spike exactly 3/6/12 months earlier (within 0.6×) is suppressed. Acceptable
+  given the user's priority is eliminating false positives, and Gate A already
+  restricts this to regular categories.

--- a/plans/2026-06-05-overspend-insight-false-positives-plan.md
+++ b/plans/2026-06-05-overspend-insight-false-positives-plan.md
@@ -1,0 +1,739 @@
+# Overspend Insight False-Positive Fix — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop the "For You" overspend insight from firing on annual/periodic recurring payments and one-off lumps, while still flagging genuine overspends on regular-spend categories.
+
+**Architecture:** Two independent changes. (1) `CategoryAnomalyInsight` gains two gates — a **regularity gate** (only flag categories with an established monthly baseline, `median > 0`) and a **recurrence/lag guard** (suppress spikes that recur at a fixed cadence, ±1-month drift tolerant). (2) `AnalysisStore` loads a **36-month insight floor** (or more if the UI asks for more — never a cap) as the single source of truth, and the Analysis UI renders **display-clipped projections** of it; the insight engine reads the full loaded data through the existing `sources.analysis.*` path with no new fetch.
+
+**Tech Stack:** Swift 6, SwiftUI, Swift Testing (`@Suite`/`@Test`), GRDB (unchanged — the `:after` filter already exists), `just` build/test tooling.
+
+**Reference spec:** `plans/2026-06-05-overspend-insight-false-positives-design.md`
+
+---
+
+## File Structure
+
+**Modified:**
+- `Domain/Insights/Detectors/CategoryAnomalyInsight.swift` — add Gate A (regularity) and Gate B (recurrence/lag); replace internal `Bounds` with `Gates` carrying the recurrence config.
+- `Features/Analysis/AnalysisStore.swift` — 36-month load floor; cache keyed on the effective *load* window (refetch only when the request grows).
+- `Features/Analysis/Views/AnalysisView.swift` — route the cards to the display-clipped projections.
+
+**Created:**
+- `Features/Analysis/AnalysisStore+DisplayWindow.swift` — pure clip helpers + `displayed*` computed projections (keeps `AnalysisStore.swift` under the 400-line `file_length` warning).
+- `MoolahTests/Features/AnalysisStoreDisplayWindowTests.swift` — pure-function tests for the load-window math and the clip helpers.
+
+**Tests extended:**
+- `MoolahTests/Domain/Insights/SpendAndTrendInsightTests.swift` — new suppression/firing cases.
+
+**Unchanged (verified, not edited):**
+- `Features/Insights/InsightStore+Snapshot.swift` — `makeSnapshot()` keeps reading `sources.analysis.expenseBreakdown` (now the full ≥36-month series). No new dependency, no new fetch.
+- `Backends/GRDB/Repositories/GRDBAnalysisRepository+ExpenseBreakdown.swift` — already supports `:after`.
+
+---
+
+## Task 1: Gate A — regularity gate in `CategoryAnomalyInsight`
+
+An overspend is only meaningful relative to a regular baseline. A category whose median monthly spend is zero (spend in ≤ half its months) is a lump (one-off purchase) or a rare periodic payment — not an overspend.
+
+**Files:**
+- Modify: `Domain/Insights/Detectors/CategoryAnomalyInsight.swift`
+- Test: `MoolahTests/Domain/Insights/SpendAndTrendInsightTests.swift`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add these three `@Test` methods inside `struct SpendAndTrendInsightTests` in `MoolahTests/Domain/Insights/SpendAndTrendInsightTests.swift`:
+
+```swift
+@Test
+func categoryAnomalySuppressesOneOffLump() {
+  // A category with a thin trickle then a huge one-off (house deposit). The
+  // series is long enough to clear `minimumMonths`, but its median is 0, so
+  // there is no regular baseline to "overspend" against.
+  let home = Category(name: "Home")
+  let magnitudes: [Decimal] = [100, 0, 0, 0, 0, 500_000]
+  let months = ["202501", "202502", "202503", "202504", "202505", "202506"]
+  let breakdown = zip(months, magnitudes).map { month, magnitude in
+    InsightTestSupport.breakdownRow(magnitude, categoryId: home.id, month: month)
+  }
+  let insights = CategoryAnomalyInsight.detect(
+    breakdown: breakdown, categories: Categories(from: [home]), context: context)
+  #expect(!insights.contains { $0.kind == .categorySpendingAnomaly })
+}
+
+@Test
+func categoryAnomalySuppressesAnnualRecurringPayment() {
+  // The reported bug: an $80k annual superannuation payment, identical to last
+  // year's, in an otherwise-empty category. Median is 0 → not an overspend.
+  let superannuation = Category(name: "Superannuation")
+  let breakdown = [
+    InsightTestSupport.breakdownRow(80_000, categoryId: superannuation.id, month: "202506"),
+    InsightTestSupport.breakdownRow(80_000, categoryId: superannuation.id, month: "202606"),
+  ]
+  let insights = CategoryAnomalyInsight.detect(
+    breakdown: breakdown, categories: Categories(from: [superannuation]), context: context)
+  #expect(!insights.contains { $0.kind == .categorySpendingAnomaly })
+}
+```
+
+(The existing `categoryAnomalyFlagsSpike` — dining spends every month, median ≈ 101 — is the "still fires" guard; do not modify it.)
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `just test-mac SpendAndTrendInsightTests 2>&1 | tee .agent-tmp/t1.txt`
+Expected: `categoryAnomalySuppressesOneOffLump` and `categoryAnomalySuppressesAnnualRecurringPayment` FAIL (an anomaly is currently emitted). `categoryAnomalyFlagsSpike` PASSES.
+
+- [ ] **Step 3: Implement Gate A**
+
+In `Domain/Insights/Detectors/CategoryAnomalyInsight.swift`, in `evaluate(...)`, insert the regularity gate as the **first** statement after `let magnitudes = points.map(\.magnitude)` (before the `SeasonalDecomposition.decompose` call):
+
+```swift
+let magnitudes = points.map(\.magnitude)
+// Gate A — regularity. An overspend is only meaningful against an established
+// baseline. A category with spend in <= half its months (median 0) is a lump
+// (one-off purchase) or a rare periodic payment, not an overspend.
+guard DescriptiveStatistics.median(magnitudes) > 0 else { return nil }
+let decomposition = SeasonalDecomposition.decompose(magnitudes, period: 12)
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `just test-mac SpendAndTrendInsightTests 2>&1 | tee .agent-tmp/t1.txt`
+Expected: all of `categoryAnomalySuppressesOneOffLump`, `categoryAnomalySuppressesAnnualRecurringPayment`, `categoryAnomalyFlagsSpike`, `categoryAnomalyAttachesHighlightedChart` PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C "$PWD" add Domain/Insights/Detectors/CategoryAnomalyInsight.swift MoolahTests/Domain/Insights/SpendAndTrendInsightTests.swift
+git -C "$PWD" commit -m "Insight: suppress overspend on categories without a regular baseline (Gate A)"
+```
+
+---
+
+## Task 2: Gate B — recurrence/lag guard in `CategoryAnomalyInsight`
+
+Within a *regular* category, suppress a spike that recurs at a fixed cadence (annual/semi-annual/quarterly), tolerating ±1 month of date drift, so a known periodic bill does not nag every cycle.
+
+**Files:**
+- Modify: `Domain/Insights/Detectors/CategoryAnomalyInsight.swift`
+- Test: `MoolahTests/Domain/Insights/SpendAndTrendInsightTests.swift`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add these two `@Test` methods to `SpendAndTrendInsightTests`:
+
+```swift
+@Test
+func categoryAnomalySuppressesDriftedRecurrence() {
+  // A regular ~$100/month category (passes Gate A) with a $600 spike that
+  // recurred ~12 months earlier, drifted by one month (June yr1 -> July yr2).
+  let utilities = Category(name: "Utilities")
+  var magnitudes = Array(repeating: Decimal(100), count: 14)
+  magnitudes[0] = 600  // 202506 (June, prior year)
+  magnitudes[13] = 600  // 202607 (July, this year) — the latest spike
+  let months = [
+    "202506", "202507", "202508", "202509", "202510", "202511", "202512",
+    "202601", "202602", "202603", "202604", "202605", "202606", "202607",
+  ]
+  let breakdown = zip(months, magnitudes).map { month, magnitude in
+    InsightTestSupport.breakdownRow(magnitude, categoryId: utilities.id, month: month)
+  }
+  let insights = CategoryAnomalyInsight.detect(
+    breakdown: breakdown, categories: Categories(from: [utilities]), context: context)
+  #expect(!insights.contains { $0.kind == .categorySpendingAnomaly })
+}
+
+@Test
+func categoryAnomalySuppressesQuarterlyRecurrence() {
+  // A regular ~$100/month category with a $600 spike every 3 months. The
+  // latest spike matches the lag-3 occurrence, so it is a predictable bill.
+  let utilities = Category(name: "Water")
+  var magnitudes = Array(repeating: Decimal(100), count: 12)
+  for index in [2, 5, 8, 11] { magnitudes[index] = 600 }
+  let months = [
+    "202507", "202508", "202509", "202510", "202511", "202512",
+    "202601", "202602", "202603", "202604", "202605", "202606",
+  ]
+  let breakdown = zip(months, magnitudes).map { month, magnitude in
+    InsightTestSupport.breakdownRow(magnitude, categoryId: utilities.id, month: month)
+  }
+  let insights = CategoryAnomalyInsight.detect(
+    breakdown: breakdown, categories: Categories(from: [utilities]), context: context)
+  #expect(!insights.contains { $0.kind == .categorySpendingAnomaly })
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `just test-mac SpendAndTrendInsightTests 2>&1 | tee .agent-tmp/t2.txt`
+Expected: `categoryAnomalySuppressesDriftedRecurrence` and `categoryAnomalySuppressesQuarterlyRecurrence` FAIL (the spike is currently flagged). `categoryAnomalyFlagsSpike` still PASSES (its spike has no comparable lag-3/6/12 occurrence).
+
+- [ ] **Step 3: Replace `Bounds` with `Gates` and thread the recurrence config**
+
+In `Domain/Insights/Detectors/CategoryAnomalyInsight.swift`:
+
+Add two defaulted parameters to `detect` (they do not count toward `function_parameter_count` because `ignores_default_parameters` is on):
+
+```swift
+static func detect(
+  breakdown: [ExpenseBreakdown],
+  categories: Categories,
+  context: InsightContext,
+  minimumMonths: Int = 6,
+  threshold: Double = 3,
+  minimumOverspendFraction: Double = 0.25,
+  recurrenceLags: [Int] = [12, 6, 3],
+  recurrenceTolerance: Double = 0.6
+) -> [Insight] {
+  let series = CategorySpendSeries.build(
+    from: breakdown, reportingCurrency: context.reportingCurrency)
+
+  let gates = Gates(
+    zScore: threshold,
+    overspendFraction: minimumOverspendFraction,
+    recurrenceLags: recurrenceLags,
+    recurrenceTolerance: recurrenceTolerance)
+  var insights: [Insight] = []
+  for (categoryId, points) in series where points.count >= minimumMonths {
+    guard
+      let insight = evaluate(
+        categoryId: categoryId,
+        points: points,
+        categories: categories,
+        context: context,
+        gates: gates)
+    else { continue }
+    insights.append(insight)
+  }
+  return insights
+}
+```
+
+Replace the `Bounds` struct with `Gates`:
+
+```swift
+/// The gate values an anomaly must clear, bundled to keep `evaluate` within
+/// the parameter-count budget.
+private struct Gates {
+  let zScore: Double
+  let overspendFraction: Double
+  /// Cadence lags (months) checked for a recurring spike: annual, semi-annual,
+  /// quarterly.
+  let recurrenceLags: [Int]
+  /// A prior spike at a cadence lag of at least this fraction of the latest
+  /// spike's magnitude counts as "recurring".
+  let recurrenceTolerance: Double
+}
+```
+
+Update `evaluate`'s signature and the two gate references, and add the Gate B check immediately before the `let resolved = ...` line that begins building the `Insight`:
+
+```swift
+private static func evaluate(
+  categoryId: UUID,
+  points: [MonthlySpendPoint],
+  categories: Categories,
+  context: InsightContext,
+  gates: Gates
+) -> Insight? {
+  let magnitudes = points.map(\.magnitude)
+  // Gate A — regularity (see Task 1).
+  guard DescriptiveStatistics.median(magnitudes) > 0 else { return nil }
+  let decomposition = SeasonalDecomposition.decompose(magnitudes, period: 12)
+  let remainder = decomposition.remainder
+  guard let latest = points.last, remainder.count == points.count else { return nil }
+
+  let latestRemainder = remainder[remainder.count - 1]
+  let priorRemainders = Array(remainder.dropLast())
+  let zScore = DescriptiveStatistics.robustZScore(of: latestRemainder, in: priorRemainders)
+  guard zScore >= gates.zScore, latestRemainder > 0 else { return nil }
+
+  let expected =
+    decomposition.trend[remainder.count - 1]
+    + decomposition.seasonal[remainder.count - 1]
+  guard expected > 0 else { return nil }
+  let overspendFraction = latestRemainder / expected
+  guard overspendFraction >= gates.overspendFraction else { return nil }
+
+  // Gate B — recurrence. Suppress a spike that recurs at a fixed cadence
+  // (annual/semi-annual/quarterly), tolerating +/-1 month of date drift, so a
+  // predictable periodic bill does not nag every cycle.
+  guard
+    !isRecurringSpike(
+      magnitudes: magnitudes, lags: gates.recurrenceLags,
+      tolerance: gates.recurrenceTolerance)
+  else { return nil }
+
+  let resolved =
+    categoryId == CategorySpendSeries.uncategorizedKey
+    ? nil : categories.by(id: categoryId)
+  // ... unchanged Insight construction ...
+}
+```
+
+Add the `isRecurringSpike` helper (place it next to `percent(_:)`):
+
+```swift
+/// True when the latest month's spike has a comparable spike (>= `tolerance`
+/// of its magnitude) at one of the cadence `lags`, allowing +/-1 month of
+/// date drift across month buckets.
+private static func isRecurringSpike(
+  magnitudes: [Double], lags: [Int], tolerance: Double
+) -> Bool {
+  guard let latest = magnitudes.last, latest > 0 else { return false }
+  let latestIndex = magnitudes.count - 1
+  let floor = latest * tolerance
+  for lag in lags {
+    for offset in -1...1 {
+      let index = latestIndex - lag + offset
+      guard index >= 0, index < latestIndex else { continue }
+      if magnitudes[index] >= floor { return true }
+    }
+  }
+  return false
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `just test-mac SpendAndTrendInsightTests 2>&1 | tee .agent-tmp/t2.txt`
+Expected: all `SpendAndTrendInsightTests` PASS — the two new recurrence tests, plus the Task 1 suppression tests, plus `categoryAnomalyFlagsSpike` and `categoryAnomalyAttachesHighlightedChart`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C "$PWD" add Domain/Insights/Detectors/CategoryAnomalyInsight.swift MoolahTests/Domain/Insights/SpendAndTrendInsightTests.swift
+git -C "$PWD" commit -m "Insight: suppress cadenced recurring spikes in overspend detector (Gate B)"
+```
+
+---
+
+## Task 3: `AnalysisStore` — 36-month insight load floor
+
+Load at least 36 months for the insight engine, regardless of the Analysis display filter; never cap a larger UI request; refetch only when the request reaches further back than the cache.
+
+**Files:**
+- Modify: `Features/Analysis/AnalysisStore.swift`
+- Create: `Features/Analysis/AnalysisStore+DisplayWindow.swift` (the pure `effectiveLoadMonths` helper lands here; clip helpers are added in Task 4)
+- Test: `MoolahTests/Features/AnalysisStoreDisplayWindowTests.swift`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `MoolahTests/Features/AnalysisStoreDisplayWindowTests.swift`:
+
+```swift
+import Foundation
+import Testing
+
+@testable import Moolah
+
+@Suite("AnalysisStore — effective load window")
+struct AnalysisStoreLoadWindowTests {
+
+  @Test("a narrow display filter still loads the insight floor")
+  func narrowFilterLoadsFloor() {
+    #expect(
+      AnalysisStore.effectiveLoadMonths(historyMonths: 3, floorMonths: 36) == 36)
+  }
+
+  @Test("a wide display filter loads the wider window, not the floor")
+  func wideFilterLoadsRequested() {
+    #expect(
+      AnalysisStore.effectiveLoadMonths(historyMonths: 60, floorMonths: 36) == 60)
+  }
+
+  @Test("All (0) loads everything")
+  func allLoadsEverything() {
+    #expect(
+      AnalysisStore.effectiveLoadMonths(historyMonths: 0, floorMonths: 36) == Int.max)
+  }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `just test-mac AnalysisStoreLoadWindowTests 2>&1 | tee .agent-tmp/t3.txt`
+Expected: FAIL to build — `effectiveLoadMonths` does not exist yet.
+
+- [ ] **Step 3: Add the floor constant and the pure window helper**
+
+Create `Features/Analysis/AnalysisStore+DisplayWindow.swift`:
+
+```swift
+import Foundation
+
+// MARK: - Load window + display clipping
+
+extension AnalysisStore {
+  /// Minimum history (months) loaded for the insight engine, regardless of the
+  /// Analysis screen's display filter. Three years gives the category-anomaly
+  /// detector enough same-month samples to recognise an annual pattern instead
+  /// of mis-flagging it as an overspend. A *minimum*, never a cap.
+  static let insightHistoryFloorMonths = 36
+
+  /// The effective load window in months: the larger of the user's display
+  /// filter and the insight floor. `historyMonths == 0` ("All") loads
+  /// everything, represented as `Int.max`.
+  static func effectiveLoadMonths(historyMonths: Int, floorMonths: Int) -> Int {
+    historyMonths == 0 ? Int.max : max(historyMonths, floorMonths)
+  }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `just test-mac AnalysisStoreLoadWindowTests 2>&1 | tee .agent-tmp/t3.txt`
+Expected: all three PASS.
+
+- [ ] **Step 5: Wire the floor into `loadAll` and re-key the cache**
+
+In `Features/Analysis/AnalysisStore.swift`, replace the cache fields (currently `cachedHistoryMonths` / `hasCachedData` around lines 17–22):
+
+```swift
+/// The effective *load* window (months) of the currently cached data —
+/// `max(historyMonths, insightHistoryFloorMonths)`, or `Int.max` for "All".
+/// Keyed on the load window (not the display filter) so narrowing the UI
+/// window re-clips from cache instead of refetching; only a request that
+/// reaches further back than the cache triggers a new load.
+private var cachedLoadMonths: Int?
+private var cachedForecastMonths: Int?
+private var hasCachedData: Bool {
+  cachedLoadMonths != nil && !dailyBalances.isEmpty
+}
+```
+
+Replace the body of `loadAll()` (the cache/fetch section, currently lines 79–133) with:
+
+```swift
+func loadAll() async {
+  monthEnd = Calendar.current.component(.day, from: Date())
+  error = nil
+
+  // Load the larger of the user's display window and the insight floor.
+  let requestedLoadMonths = Self.effectiveLoadMonths(
+    historyMonths: historyMonths, floorMonths: Self.insightHistoryFloorMonths)
+
+  // Refetch only when the request reaches further back than the cache, the
+  // forecast window changed, or nothing is loaded yet. Narrowing the display
+  // filter needs no fetch — `displayed*` re-clips the cached data.
+  let needsLoad =
+    !hasCachedData
+    || forecastMonths != cachedForecastMonths
+    || requestedLoadMonths > (cachedLoadMonths ?? 0)
+  guard needsLoad else { return }
+
+  isLoading = true
+  let growing = requestedLoadMonths > (cachedLoadMonths ?? 0)
+  if growing {
+    // Dropping stale narrower data so the spinner shows while we widen.
+    dailyBalances = []
+    expenseBreakdown = []
+    incomeAndExpense = []
+  }
+
+  do {
+    let after: Date? =
+      historyMonths == 0
+      ? nil
+      : afterDate(monthsAgo: max(historyMonths, Self.insightHistoryFloorMonths))
+    let forecastUntil = forecastDate(monthsAhead: forecastMonths)
+
+    let data = try await repository.loadAll(
+      historyAfter: after,
+      forecastUntil: forecastUntil,
+      monthEnd: monthEnd
+    )
+
+    dailyBalances = Self.extrapolateBalances(
+      data.dailyBalances, today: Date(), forecastUntil: forecastUntil
+    )
+    expenseBreakdown = data.expenseBreakdown
+    incomeAndExpense = data.incomeAndExpense.sorted { $0.month > $1.month }
+
+    cachedLoadMonths = requestedLoadMonths
+    cachedForecastMonths = forecastMonths
+    lastLoadedAt = Date()
+  } catch is CancellationError {
+    // View teardown / supersession — see AnalysisView's `.task`. A re-mount
+    // issues its own `loadAll()`.
+    isLoading = false
+    return
+  } catch {
+    logger.error("Failed to load analysis data: \(error)")
+    self.error = error
+  }
+
+  isLoading = false
+}
+```
+
+- [ ] **Step 6: Build and run the AnalysisStore suite**
+
+Run: `just build-mac 2>&1 | tee .agent-tmp/t3-build.txt`
+Expected: builds with no warnings (project treats warnings as errors).
+
+Run: `just test-mac AnalysisStoreLoadWindowTests AnalysisStoreRefreshIfStaleTests AnalysisStoreFilterPersistenceTests 2>&1 | tee .agent-tmp/t3.txt`
+Expected: all PASS (the refresh/persistence suites are unaffected — they don't assert refetch-on-filter-change).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git -C "$PWD" add Features/Analysis/AnalysisStore.swift Features/Analysis/AnalysisStore+DisplayWindow.swift MoolahTests/Features/AnalysisStoreDisplayWindowTests.swift
+git -C "$PWD" commit -m "Analysis: load a 36-month insight floor, refetch only when the window grows"
+```
+
+---
+
+## Task 4: `AnalysisStore` — display-window clipping for the UI
+
+The store now holds the full ≥36-month data. The Analysis UI takes a smaller window into it via clipped projections; insights keep reading the full arrays.
+
+**Files:**
+- Modify: `Features/Analysis/AnalysisStore+DisplayWindow.swift` (add clip helpers + `displayed*` projections)
+- Modify: `Features/Analysis/AnalysisStore.swift` (`categoriesOverTime` builds from the clipped breakdown)
+- Modify: `Features/Analysis/Views/AnalysisView.swift` (cards read `displayed*`)
+- Test: `MoolahTests/Features/AnalysisStoreDisplayWindowTests.swift`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add a second suite to `MoolahTests/Features/AnalysisStoreDisplayWindowTests.swift`:
+
+```swift
+@Suite("AnalysisStore — display clipping")
+struct AnalysisStoreClipTests {
+  // 2026-06-15 anchor so month maths is deterministic.
+  private let now = {
+    var c = DateComponents()
+    c.year = 2026; c.month = 6; c.day = 15
+    return Calendar.current.date(from: c) ?? Date()
+  }()
+
+  private func breakdown(_ month: String) -> ExpenseBreakdown {
+    ExpenseBreakdown(
+      categoryId: UUID(), month: month,
+      totalExpenses: InstrumentAmount(quantity: -100, instrument: .defaultTestInstrument))
+  }
+
+  @Test("breakdown clips to the display window, keeping recent months")
+  func clipsBreakdown() {
+    let rows = ["202506", "202507", "202601", "202606"].map(breakdown)
+    // 3-month display window from 2026-06 keeps 202603..202606 → only 202606.
+    let clipped = AnalysisStore.clipBreakdown(rows, historyMonths: 3, now: now)
+    #expect(clipped.map(\.month) == ["202606"])
+  }
+
+  @Test("breakdown All (0) returns everything")
+  func clipsBreakdownAll() {
+    let rows = ["202506", "202606"].map(breakdown)
+    #expect(AnalysisStore.clipBreakdown(rows, historyMonths: 0, now: now).count == 2)
+  }
+
+  @Test("balances clip by date but always keep forecast rows")
+  func clipsBalancesKeepingForecast() {
+    let old = DailyBalance(
+      date: cal(monthsFromNow: -10),
+      balance: InstrumentAmount(quantity: 1, instrument: .defaultTestInstrument))
+    let recent = DailyBalance(
+      date: cal(monthsFromNow: -1),
+      balance: InstrumentAmount(quantity: 2, instrument: .defaultTestInstrument))
+    let forecast = DailyBalance(
+      date: cal(monthsFromNow: 2),
+      balance: InstrumentAmount(quantity: 3, instrument: .defaultTestInstrument),
+      earmarked: .zero(instrument: .defaultTestInstrument),
+      availableFunds: InstrumentAmount(quantity: 3, instrument: .defaultTestInstrument),
+      investments: .zero(instrument: .defaultTestInstrument),
+      investmentValue: nil,
+      netWorth: InstrumentAmount(quantity: 3, instrument: .defaultTestInstrument),
+      bestFit: nil,
+      isForecast: true)
+    let clipped = AnalysisStore.clipBalances(
+      [old, recent, forecast], historyMonths: 3, now: now)
+    // `old` (10 months back) drops; `recent` stays; `forecast` always stays.
+    #expect(clipped.contains { $0.balance.quantity == 2 })
+    #expect(clipped.contains { $0.balance.quantity == 3 })
+    #expect(!clipped.contains { $0.balance.quantity == 1 })
+  }
+
+  private func cal(monthsFromNow: Int) -> Date {
+    Calendar.current.date(byAdding: .month, value: monthsFromNow, to: now) ?? now
+  }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `just test-mac AnalysisStoreClipTests 2>&1 | tee .agent-tmp/t4.txt`
+Expected: FAIL to build — `clipBreakdown` / `clipBalances` do not exist yet.
+
+- [ ] **Step 3: Add the clip helpers and `displayed*` projections**
+
+Append to `extension AnalysisStore` in `Features/Analysis/AnalysisStore+DisplayWindow.swift`:
+
+```swift
+// MARK: - Display clipping (pure)
+
+/// First `YYYYMM` bucket visible for a display window, or `nil` for "All".
+static func displayStartMonth(historyMonths: Int, now: Date) -> String? {
+  guard historyMonths > 0,
+    let start = Calendar.current.date(byAdding: .month, value: -historyMonths, to: now)
+  else { return nil }
+  let components = Calendar.current.dateComponents([.year, .month], from: start)
+  return String(format: "%04d%02d", components.year ?? 0, components.month ?? 0)
+}
+
+/// Clips breakdown rows to the display window (string compare on `YYYYMM`).
+static func clipBreakdown(
+  _ rows: [ExpenseBreakdown], historyMonths: Int, now: Date
+) -> [ExpenseBreakdown] {
+  guard let startMonth = displayStartMonth(historyMonths: historyMonths, now: now)
+  else { return rows }
+  return rows.filter { $0.month >= startMonth }
+}
+
+/// Clips income/expense rows to the display window (string compare on `YYYYMM`).
+static func clipIncomeExpense(
+  _ rows: [MonthlyIncomeExpense], historyMonths: Int, now: Date
+) -> [MonthlyIncomeExpense] {
+  guard let startMonth = displayStartMonth(historyMonths: historyMonths, now: now)
+  else { return rows }
+  return rows.filter { $0.month >= startMonth }
+}
+
+/// Clips daily balances to the display window. Forecast rows (future-dated)
+/// are always kept so the net-worth chart still draws its forecast tail.
+static func clipBalances(
+  _ balances: [DailyBalance], historyMonths: Int, now: Date
+) -> [DailyBalance] {
+  guard historyMonths > 0,
+    let start = Calendar.current.date(byAdding: .month, value: -historyMonths, to: now)
+  else { return balances }
+  let startDay = Calendar.current.startOfDay(for: start)
+  return balances.filter { $0.isForecast || $0.date >= startDay }
+}
+
+// MARK: - Display projections (consumed by AnalysisView)
+
+/// Daily balances clipped to the current display window.
+var displayedDailyBalances: [DailyBalance] {
+  Self.clipBalances(dailyBalances, historyMonths: historyMonths, now: Date())
+}
+
+/// Expense breakdown clipped to the current display window.
+var displayedExpenseBreakdown: [ExpenseBreakdown] {
+  Self.clipBreakdown(expenseBreakdown, historyMonths: historyMonths, now: Date())
+}
+
+/// Income/expense rows clipped to the current display window.
+var displayedIncomeAndExpense: [MonthlyIncomeExpense] {
+  Self.clipIncomeExpense(incomeAndExpense, historyMonths: historyMonths, now: Date())
+}
+```
+
+- [ ] **Step 4: Point `categoriesOverTime` at the clipped breakdown**
+
+In `Features/Analysis/AnalysisStore.swift`, change the instance method `categoriesOverTime(categories:)` (currently line ~194) to build from the clipped projection:
+
+```swift
+func categoriesOverTime(categories: Categories) -> [CategoryOverTimeEntry] {
+  Self.buildCategoriesOverTime(from: displayedExpenseBreakdown, categories: categories)
+}
+```
+
+- [ ] **Step 5: Route the Analysis cards to the clipped projections**
+
+In `Features/Analysis/Views/AnalysisView.swift`, update the card inputs:
+- `NetWorthGraphCard(balances: store.dailyBalances)` → `NetWorthGraphCard(balances: store.displayedDailyBalances)`
+- the `ExpenseBreakdownCard` input `breakdown: store.expenseBreakdown` → `breakdown: store.displayedExpenseBreakdown`
+- both `IncomeExpenseTableCard(data: store.incomeAndExpense)` call sites → `IncomeExpenseTableCard(data: store.displayedIncomeAndExpense)`
+
+Leave the instrument derivation `store.dailyBalances.first?.balance.instrument ?? .AUD` and the `store.isLoading && store.dailyBalances.isEmpty` loading check reading the full `dailyBalances` (the instrument is uniform across the series, and "empty" must reflect the real load state).
+
+- [ ] **Step 6: Build and run the clip + insight suites**
+
+Run: `just build-mac 2>&1 | tee .agent-tmp/t4-build.txt`
+Expected: builds with no warnings.
+
+Run: `just test-mac AnalysisStoreClipTests AnalysisStoreLoadWindowTests 2>&1 | tee .agent-tmp/t4.txt`
+Expected: all PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git -C "$PWD" add Features/Analysis/AnalysisStore+DisplayWindow.swift Features/Analysis/AnalysisStore.swift Features/Analysis/Views/AnalysisView.swift MoolahTests/Features/AnalysisStoreDisplayWindowTests.swift
+git -C "$PWD" commit -m "Analysis: render display-clipped projections; insights read the full series"
+```
+
+---
+
+## Task 5: Verify the insight path sees the full series (no code change expected)
+
+Confirm `InsightStore.makeSnapshot()` still reads the full loaded data and that no other consumer was accidentally narrowed.
+
+**Files:**
+- Inspect only: `Features/Insights/InsightStore+Snapshot.swift`, all readers of `expenseBreakdown` / `dailyBalances` / `incomeAndExpense`.
+
+- [ ] **Step 1: Confirm `makeSnapshot` reads the full arrays**
+
+Run: `grep -n "sources.analysis" Features/Insights/InsightStore+Snapshot.swift`
+Expected: `expenseBreakdown: sources.analysis.expenseBreakdown`, `dailyBalances: sources.analysis.dailyBalances`, `monthly: sources.analysis.incomeAndExpense` — i.e. the full (un-clipped) properties. No change needed.
+
+- [ ] **Step 2: Confirm no other consumer should have been clipped**
+
+Run: `grep -rn "\.expenseBreakdown\|\.dailyBalances\|\.incomeAndExpense" Features --include="*.swift" | grep -v "displayed\|AnalysisStore.swift\|InsightStore+Snapshot.swift\|AnalysisStore+DisplayWindow.swift"`
+Expected: only `AnalysisView.swift`'s deliberately-full reads (instrument derivation, loading check). If any *other* Analysis card reads a full array where it should show the user's window, switch it to the matching `displayed*` projection and note it in the commit. Insight/reporting reads of the full arrays are correct as-is.
+
+- [ ] **Step 3: Commit only if a consumer was re-routed**
+
+```bash
+git -C "$PWD" add -A && git -C "$PWD" commit -m "Analysis: route remaining display consumer to clipped projection"
+```
+
+(Skip this commit if Step 2 found nothing to change.)
+
+---
+
+## Task 6: Full verification, formatting, and review
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Format**
+
+Run: `just format`
+Then: `just format-check`
+Expected: `format-check` exits 0 (no diff, no SwiftLint violation). Fix any reported violation by editing the code (split/rename) — never by adding a baseline or `swiftlint:disable`.
+
+- [ ] **Step 2: Full test suite (both platforms)**
+
+Run: `mkdir -p .agent-tmp && just test 2>&1 | tee .agent-tmp/full-test.txt`
+Then: `grep -i 'failed\|error:' .agent-tmp/full-test.txt`
+Expected: no failures. Pay attention to `SpendAndTrendInsightTests`, `AnalysisStoreDisplayWindowTests`, and the existing `AnalysisStore*` suites.
+
+- [ ] **Step 3: Compiler warnings**
+
+Run: `just build-mac 2>&1 | tee .agent-tmp/warn.txt` and check for `warning:` in user code.
+Expected: none (warnings-as-errors would already have failed the build).
+
+- [ ] **Step 4: Agent reviews**
+
+Dispatch the project review agents on the diff:
+- `code-review` — `CategoryAnomalyInsight.swift`, `AnalysisStore.swift`, `AnalysisStore+DisplayWindow.swift` (naming, thin-view discipline, type choice).
+- `concurrency-review` — `AnalysisStore` changes (main-actor isolation, the `loadAll` guard/early-return, cache fields).
+- `ui-review` — `AnalysisView.swift` (the clipped projections feeding the cards).
+
+Apply all Critical/Important/Minor findings (per project policy: pre-existing-in-another-file is not a skip reason; ask before deferring).
+
+- [ ] **Step 5: Manual end-to-end check (Large Test Profile)**
+
+Using the `automate-app` / `run-mac-app-with-logs` skill, launch with the Large Test Profile and open the For You surface. Confirm the *"You've overspent by 600% on superannuation"* card is gone, and that a genuinely irregular-but-regular category spike (if present) still surfaces. Set the Analysis screen to 3 months, then 5 years, then All, and confirm the net-worth/category/income cards re-window without a reload stutter and the 5-year/All views are not capped to 36 months.
+
+- [ ] **Step 6: Finish the branch**
+
+Use `superpowers:finishing-a-development-branch` to push and open the PR, then land it per the project's `landing-prs` skill. PR body should reference the design + plan docs and the reported false-positive.
+
+---
+
+## Self-Review (completed during planning)
+
+- **Spec coverage:** Gate A regularity → Task 1; Gate B recurrence/lag → Task 2; load floor + max-not-cap + cache-on-load-window → Task 3; load-wide/window-for-UI → Task 4; insights read full via existing path → Task 5; tests for every gate + window/clip → Tasks 1,2,3,4; format/build/review → Task 6. All spec sections mapped.
+- **Type consistency:** `Gates` (not `Bounds`) is used in both `detect` and `evaluate`; `effectiveLoadMonths`, `clipBreakdown`, `clipBalances`, `clipIncomeExpense`, `displayStartMonth`, `displayed{DailyBalances,ExpenseBreakdown,IncomeAndExpense}`, `insightHistoryFloorMonths`, `cachedLoadMonths` are named identically at definition and call sites.
+- **No placeholders:** every code step contains complete, compiling code and exact `just` commands with expected output.


### PR DESCRIPTION
## Problem

The "For You" overspend insight raised false positives. In the Large Test Profile it reported *"You've overspent by 600% on superannuation this month"* for an **$80,000 annual** payment that followed the exact same pattern as the prior year. One-off lumps (e.g. a house purchase) would mis-fire the same way — spending a lot on a house once is not an "overspend".

## Root cause (two compounding causes)

1. **The detector's history window was coupled to an unrelated UI filter.** `CategoryAnomalyInsight` consumed whatever the **Analysis screen** last loaded — `AnalysisStore.historyMonths`, a user-facing display filter that **defaults to 12 months**. A 12-month window can't hold two annual occurrences, and the `period: 12` seasonal model needs ≥2 full periods to recognise an annual cycle. (The card's `Expected = $11,428.57 ≈ $80,000 / 7` confirms it saw a short, mostly-zero series.)
2. **The algorithm couldn't recognise a recurring or one-off spike.** The robust z-score (median + MAD) is *resistant* to one or two prior spikes, so even with more history a single prior $80k payment didn't tame it; and nothing distinguished a one-off lump from a genuine overspend on a regular habit.

## What changed

**Detector (`CategoryAnomalyInsight`)** — two gates compose with the existing z-score / overspend-fraction / seasonal-decomposition gates:
- **Gate A — regularity:** only flag categories with an established baseline (`median(monthly magnitudes) > 0`). Kills one-off lumps *and* rare recurring lumps (annual super) — there is no "usual" to overspend against.
- **Gate B — recurrence/lag guard:** within a regular category, suppress a spike that recurs at a fixed cadence (lags `{12, 6, 3}` months, ±1-month drift, `0.6` magnitude tolerance) so a predictable periodic bill doesn't nag every cycle.

**Data window (`AnalysisStore`)** — decouples the insight's history from the display filter without a second DB load:
- Loads a **36-month insight floor** as the single source of truth — a *minimum*, never a *cap*: a larger UI request (5 years / All) still loads the larger window.
- The cache is re-keyed on the effective **load** window, so narrowing the display filter re-clips from cache (no refetch); only a request reaching further back refetches.
- The Analysis UI renders **`displayed*` clipped projections** honouring `historyMonths`; the insight engine reads the **full** arrays through the existing `InsightStore.makeSnapshot()` path (unchanged — no new fetch, no new dependency).

GRDB needed no change (the `:after` filter already existed).

## Test plan

- [x] `SpendAndTrendInsightTests`: annual recurrence suppressed, one-off lump suppressed, ±1-month-drift recurrence suppressed, quarterly recurrence suppressed (with a negative control proving it's specifically the lag-3 arm and that the spike is a genuine z-outlier reaching Gate B), genuine dining spike **still fires**.
- [x] `AnalysisStoreDisplayWindowTests` / `AnalysisStoreCacheGateTests`: floor loaded; narrowing doesn't refetch; widening past the cache refetches; forecast change refetches; All passes `historyAfter: nil`; `displayed*` clips by `historyMonths` (not `forecastMonths`).
- [x] Full suite green both platforms (iOS 3706 / macOS 3809), 0 warnings, `format-check` clean.
- [x] Reviews applied: code-review, concurrency-review (forecast-capture-before-await), ui-review, and a final holistic pass (Ready to ship).
- [ ] Manual: open the Large Test Profile → For You and confirm the superannuation card is gone; toggle the Analysis history filter (3mo / 5yr / All) and confirm the cards re-window without a reload stutter and 5yr/All aren't capped to 36 months.

## Follow-up (not in this PR)

`InsightStore` also refreshes on the instrument-registry change tick, independent of `AnalysisView`. If that fires before the Analysis screen has ever loaded in a session, the detector runs against an unloaded/empty `AnalysisStore` — benign and self-correcting (it under-produces rather than over-fires), and pre-dates this branch. Worth a tracking issue.

Design: `plans/2026-06-05-overspend-insight-false-positives-design.md` · Plan: `plans/2026-06-05-overspend-insight-false-positives-plan.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)