### PR TITLE
test(earmarks): de-flake converted-balance tests — wait on the converted value

### DIFF
--- a/MoolahTests/Features/EarmarkStoreConvertedBalanceTests.swift
+++ b/MoolahTests/Features/EarmarkStoreConvertedBalanceTests.swift
@@ -38,8 +38,8 @@ struct EarmarkStoreConvertedBalanceTests {
       targetInstrument: .defaultTestInstrument)
 
     try await store.waitForNextEmission(
-      matching: { !$0.earmarks.ordered.isEmpty },
-      description: "seeded earmarks observed"
+      matching: { $0.convertedTotalBalance?.quantity == 500 },
+      description: "converted total balance computed"
     )
 
     #expect(store.convertedTotalBalance?.quantity == 500)
@@ -72,8 +72,8 @@ struct EarmarkStoreConvertedBalanceTests {
       targetInstrument: .defaultTestInstrument)
 
     try await store.waitForNextEmission(
-      matching: { !$0.earmarks.ordered.isEmpty },
-      description: "seeded earmarks observed"
+      matching: { $0.convertedTotalBalance?.quantity == 500 },
+      description: "converted balances computed"
     )
 
     // Individual balances should reflect true values
@@ -138,8 +138,8 @@ struct EarmarkStoreConvertedBalanceTests {
       targetInstrument: .defaultTestInstrument)
 
     try await store.waitForNextEmission(
-      matching: { !$0.earmarks.ordered.isEmpty },
-      description: "seeded earmarks observed"
+      matching: { $0.convertedBalance(for: earmarkId)?.quantity == 500 },
+      description: "converted balance computed"
     )
 
     #expect(store.convertedBalance(for: earmarkId)?.quantity == 500)


### PR DESCRIPTION
Three tests in `EarmarkStoreConvertedBalanceTests` waited for the earmarks emission (`!earmarks.ordered.isEmpty`) and then read `convertedBalance` / `convertedTotalBalance` — values a **separate async conversion pass populates *after* that emission**. Intermittently the read raced ahead of the conversion and saw `nil`, failing in CI (`convertedBalance → nil`) and ejecting PRs from the merge queue.

Fix: wait on the converted value itself, mirroring the already-reliable tests in the same file:
- `testConvertedTotalBalancePopulatedAfterLoad`
- `testConvertedTotalBalanceExcludesNegativeEarmarks`
- `testConvertedBalancePerEarmarkPopulatedAfterLoad`

**Test-only — no production change.** Surfaced as the failing check on #1062 (which doesn't touch any earmark/conversion code). Class passes 3/3 locally; previously intermittent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)