### PR TITLE
fix(transactions): keep payee focus on ⌘N when inspector already open

### DIFF
--- a/Features/Transactions/Views/TransactionDetailView.swift
+++ b/Features/Transactions/Views/TransactionDetailView.swift
@@ -113,9 +113,25 @@ struct TransactionDetailView: View {
         // focus on the expected field. The list view cooperates by blurring
         // the `.searchable` toolbar field when the inspector opens, so the
         // responder chain's fallback doesn't steal our assignment.
+        //
+        // `defaultFocus` only re-fires when the inspector's focus scope
+        // *appears* — i.e. on a fresh present (opening the inspector from
+        // closed). When the inspector is already open and ⌘N swaps its
+        // content in place (`.id(selected.id)` changes), the scope does not
+        // re-appear, so only the assignment below claims focus — and at the
+        // moment the task first runs AppKit is still resigning the previous
+        // content's first responder, so a single assignment races that
+        // teardown and is dropped. Assign once, then re-assert on the next
+        // runloop turn (after the teardown settles) so focus reliably lands
+        // on the new transaction's field. On a fresh present the first
+        // assignment already wins and the re-assert is a harmless no-op.
         .defaultFocus($focusedField, isSimpleEarmarkOnly ? .amount : .payee)
         .task(id: transaction.id) {
-          focusedField = isSimpleEarmarkOnly ? .amount : .payee
+          let target: TransactionDetailFocus = isSimpleEarmarkOnly ? .amount : .payee
+          focusedField = target
+          await Task.yield()
+          guard !Task.isCancelled else { return }
+          focusedField = target
         }
       #endif
       .onChange(of: draft) { _, _ in debouncedSave() }

--- a/MoolahUITests_macOS/Helpers/Fields/AutocompleteFieldDriver.swift
+++ b/MoolahUITests_macOS/Helpers/Fields/AutocompleteFieldDriver.swift
@@ -22,7 +22,7 @@ struct AutocompleteFieldDriver {
   /// auto-focused by the surrounding view (e.g. `defaultFocus(.payee)`
   /// does not always win the macOS first-responder).
   func tap() {
-    Trace.record(detail: "field=\(fieldIdentifier)")
+    Trace.record(#function, detail: "field=\(fieldIdentifier)")
     let field = app.element(for: fieldIdentifier)
     if !field.waitForExistence(timeout: 3) {
       Trace.recordFailure("field '\(fieldIdentifier)' did not appear for tap")
@@ -180,7 +180,12 @@ struct AutocompleteFieldDriver {
 
   // MARK: - Expectations (read-only)
 
-  /// Asserts the field currently holds keyboard focus.
+  /// Asserts the field currently holds keyboard focus. Polls for up to
+  /// 3 s — SwiftUI propagates `@FocusState` on a later runloop pass than
+  /// the field's value binding, so a field can exist (and even hold its
+  /// new value) a tick before focus lands. A single point-in-time read
+  /// would flake on a CI runner that processes that pass slower than
+  /// local hardware.
   func expectFocused() {
     let field = app.element(for: fieldIdentifier)
     if !field.waitForExistence(timeout: 3) {
@@ -188,11 +193,13 @@ struct AutocompleteFieldDriver {
       XCTFail("Autocomplete field '\(fieldIdentifier)' did not appear within 3s")
       return
     }
-    let hasFocus = (field.value(forKey: "hasKeyboardFocus") as? Bool) ?? false
-    if !hasFocus {
-      Trace.recordFailure("field '\(fieldIdentifier)' is not focused")
-      XCTFail("Autocomplete field '\(fieldIdentifier)' did not have keyboard focus")
+    let deadline = Date().addingTimeInterval(3)
+    while Date() < deadline {
+      if (field.value(forKey: "hasKeyboardFocus") as? Bool) ?? false { return }
+      RunLoop.current.run(until: Date().addingTimeInterval(0.05))
     }
+    Trace.recordFailure("field '\(fieldIdentifier)' is not focused")
+    XCTFail("Autocomplete field '\(fieldIdentifier)' did not have keyboard focus")
   }
 
   /// Asserts the field's current value equals `expected`. Polls for up

--- a/MoolahUITests_macOS/Helpers/Screens/TransactionListScreen.swift
+++ b/MoolahUITests_macOS/Helpers/Screens/TransactionListScreen.swift
@@ -48,6 +48,14 @@ struct TransactionListScreen {
   /// payee field exists in the accessibility tree). The caller is
   /// responsible for focus assertions — this method does not assume the
   /// field has been auto-focused.
+  ///
+  /// **Panel-swap caveat:** when the inspector is already open showing an
+  /// existing transaction, the payee element exists before ⌘N fires, so
+  /// the existence wait below returns immediately and cannot distinguish
+  /// the still-mounted old view from the swapped-in new one. In that case
+  /// the caller must additionally wait on a value change only the new view
+  /// can produce (e.g. `transactionDetail.payee.expectValue("")`) before
+  /// asserting focus. See `testCreatingSecondTransactionFocusesPayee`.
   func createTransaction() {
     Trace.record(#function)
     app.pressKeyboardShortcut("n", modifiers: .command)

--- a/MoolahUITests_macOS/Tests/TransactionDetail/TransactionDetailFocusTests.swift
+++ b/MoolahUITests_macOS/Tests/TransactionDetail/TransactionDetailFocusTests.swift
@@ -23,4 +23,26 @@ final class TransactionDetailFocusTests: MoolahUITestCase {
 
     app.transactionDetail.payee.expectFocused()
   }
+
+  /// ⌘N while the inspector is *already open* (showing an existing
+  /// transaction) must still land first-responder on the new
+  /// transaction's payee field — the inspector content swaps in place
+  /// rather than presenting fresh, and focus must follow.
+  func testCreatingSecondTransactionFocusesPayee() {
+    let app = launch(seed: .tradeBaseline)
+
+    app.sidebar.switchToAccount(.checking)
+    app.transactionList.openTransaction(.bhpPurchase)
+    app.transactionDetail.payee.expectFocused()
+
+    app.transactionList.createTransaction()
+    // The payee element identifier is shared between the two transactions,
+    // so `createTransaction()`'s existence wait can't tell the swapped-in
+    // new view from the still-mounted old one. Wait for the payee value to
+    // clear (the new placeholder has an empty payee) as the swap barrier
+    // before asserting where focus landed.
+    app.transactionDetail.payee.expectValue("")
+
+    app.transactionDetail.payee.expectFocused()
+  }
 }

--- a/MoolahUITests_macOS/Tests/TransactionDetail/TransactionDetailFocusTests.swift
+++ b/MoolahUITests_macOS/Tests/TransactionDetail/TransactionDetailFocusTests.swift
@@ -36,11 +36,10 @@ final class TransactionDetailFocusTests: MoolahUITestCase {
     app.transactionDetail.payee.expectFocused()
 
     app.transactionList.createTransaction()
-    // The payee element identifier is shared between the two transactions,
-    // so `createTransaction()`'s existence wait can't tell the swapped-in
-    // new view from the still-mounted old one. Wait for the payee value to
-    // clear (the new placeholder has an empty payee) as the swap barrier
-    // before asserting where focus landed.
+    // Swap barrier: the new placeholder has an empty payee, so waiting for
+    // the value to clear proves the new view has replaced the old one
+    // before we assert focus (see `createTransaction()`'s panel-swap
+    // caveat — the shared payee identifier defeats its existence wait).
     app.transactionDetail.payee.expectValue("")
 
     app.transactionDetail.payee.expectFocused()


### PR DESCRIPTION
## Problem

With the transaction detail inspector **closed**, ⌘N (New Transaction) correctly moves keyboard focus to the payee field so the user can start typing immediately. But if the inspector is **already open** (showing an existing transaction) and the user presses ⌘N again, focus is lost instead of landing on the new transaction's payee field.

## Root cause

The two cases differ in how the `.inspector` presentation transitions:

- **Inspector closed → ⌘N:** `selectedTransaction` goes `nil → new`, so `.inspector(isPresented:)` transitions `false → true`. This is a *fresh presentation*, and `.defaultFocus($focusedField, .payee)` on `TransactionDetailView` is honoured on first appearance of the focus scope — a reliable belt-and-suspenders alongside the `.task(id:)` programmatic claim.
- **Inspector open → ⌘N:** `selectedTransaction` goes `txA → txB`. The inspector stays presented; only the `.id(selected.id)` content subtree swaps in place. `.defaultFocus` does **not** re-fire (the focus scope was already present), so focus rests entirely on the `.task(id:)` programmatic assignment — which runs while AppKit is still resigning the torn-down field's first responder, races that teardown, and is dropped.

## Fix

In the macOS focus `.task`, assign focus, `await Task.yield()`, then re-assert it — so the claim lands *after* the teardown settles. On a fresh present the first assignment already wins and the re-assert is a harmless no-op, so the closed-inspector path is unchanged.

## Test-reliability hardening (from `@ui-test-review`)

- `AutocompleteFieldDriver.expectFocused()` now **polls** instead of snap-reading `hasKeyboardFocus` — SwiftUI propagates `@FocusState` a runloop pass after the value binding, so a snap-read could flake on slow CI (and is most exposed by the deferred re-assert above). De-flakes the existing focus tests too.
- `AutocompleteFieldDriver.tap()` passes `#function` explicitly to its trace.
- `TransactionListScreen.createTransaction()` documents the panel-swap caveat.

## Validation (before/after, via CI — local UI host was blocked by a Touch ID session)

- **Before** (test only, commit `e16c4d50`): `testCreatingSecondTransactionFocusesPayee` **failed** — *"detail.payee did not have keyboard focus"*; all other UI tests green. ✅ reproduction proven.
- **After** (fix, commit `aaca186a`): UI Test ✅ · Test ✅ · CloudKit schema additivity ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)